### PR TITLE
Add related-asset cards to clusters and map highlighting for infrastructure

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1,4 +1,4 @@
-import type { NewsItem, Monitor, PanelConfig, MapLayers } from '@/types';
+import type { NewsItem, Monitor, PanelConfig, MapLayers, RelatedAsset } from '@/types';
 import {
   FEEDS,
   INTEL_SOURCES,
@@ -503,14 +503,17 @@ export class App {
 
     // Create all panels
     const politicsPanel = new NewsPanel('politics', 'World / Geopolitical');
+    this.attachRelatedAssetHandlers(politicsPanel);
     this.newsPanels['politics'] = politicsPanel;
     this.panels['politics'] = politicsPanel;
 
     const techPanel = new NewsPanel('tech', 'Technology / AI');
+    this.attachRelatedAssetHandlers(techPanel);
     this.newsPanels['tech'] = techPanel;
     this.panels['tech'] = techPanel;
 
     const financePanel = new NewsPanel('finance', 'Financial News');
+    this.attachRelatedAssetHandlers(financePanel);
     this.newsPanels['finance'] = financePanel;
     this.panels['finance'] = financePanel;
 
@@ -535,10 +538,12 @@ export class App {
     this.panels['polymarket'] = predictionPanel;
 
     const govPanel = new NewsPanel('gov', 'Government / Policy');
+    this.attachRelatedAssetHandlers(govPanel);
     this.newsPanels['gov'] = govPanel;
     this.panels['gov'] = govPanel;
 
     const intelPanel = new NewsPanel('intel', 'Intel Feed');
+    this.attachRelatedAssetHandlers(intelPanel);
     this.newsPanels['intel'] = intelPanel;
     this.panels['intel'] = intelPanel;
 
@@ -546,22 +551,27 @@ export class App {
     this.panels['crypto'] = cryptoPanel;
 
     const middleeastPanel = new NewsPanel('middleeast', 'Middle East / MENA');
+    this.attachRelatedAssetHandlers(middleeastPanel);
     this.newsPanels['middleeast'] = middleeastPanel;
     this.panels['middleeast'] = middleeastPanel;
 
     const layoffsPanel = new NewsPanel('layoffs', 'Layoffs Tracker');
+    this.attachRelatedAssetHandlers(layoffsPanel);
     this.newsPanels['layoffs'] = layoffsPanel;
     this.panels['layoffs'] = layoffsPanel;
 
     const congressPanel = new NewsPanel('congress', 'Congress Trades');
+    this.attachRelatedAssetHandlers(congressPanel);
     this.newsPanels['congress'] = congressPanel;
     this.panels['congress'] = congressPanel;
 
     const aiPanel = new NewsPanel('ai', 'AI / ML');
+    this.attachRelatedAssetHandlers(aiPanel);
     this.newsPanels['ai'] = aiPanel;
     this.panels['ai'] = aiPanel;
 
     const thinktanksPanel = new NewsPanel('thinktanks', 'Think Tanks');
+    this.attachRelatedAssetHandlers(thinktanksPanel);
     this.newsPanels['thinktanks'] = thinktanksPanel;
     this.panels['thinktanks'] = thinktanksPanel;
 
@@ -613,6 +623,51 @@ export class App {
       .map((el) => (el as HTMLElement).dataset.panel)
       .filter((key): key is string => !!key);
     localStorage.setItem('panel-order', JSON.stringify(order));
+  }
+
+  private attachRelatedAssetHandlers(panel: NewsPanel): void {
+    panel.setRelatedAssetHandlers({
+      onRelatedAssetClick: (asset) => this.handleRelatedAssetClick(asset),
+      onRelatedAssetsFocus: (assets) => this.map?.highlightAssets(assets),
+      onRelatedAssetsClear: () => this.map?.highlightAssets(null),
+    });
+  }
+
+  private handleRelatedAssetClick(asset: RelatedAsset): void {
+    if (!this.map) return;
+
+    switch (asset.type) {
+      case 'pipeline':
+        this.map.enableLayer('pipelines');
+        this.mapLayers.pipelines = true;
+        saveToStorage(STORAGE_KEYS.mapLayers, this.mapLayers);
+        this.map.triggerPipelineClick(asset.id);
+        break;
+      case 'cable':
+        this.map.enableLayer('cables');
+        this.mapLayers.cables = true;
+        saveToStorage(STORAGE_KEYS.mapLayers, this.mapLayers);
+        this.map.triggerCableClick(asset.id);
+        break;
+      case 'datacenter':
+        this.map.enableLayer('datacenters');
+        this.mapLayers.datacenters = true;
+        saveToStorage(STORAGE_KEYS.mapLayers, this.mapLayers);
+        this.map.triggerDatacenterClick(asset.id);
+        break;
+      case 'base':
+        this.map.enableLayer('bases');
+        this.mapLayers.bases = true;
+        saveToStorage(STORAGE_KEYS.mapLayers, this.mapLayers);
+        this.map.triggerBaseClick(asset.id);
+        break;
+      case 'nuclear':
+        this.map.enableLayer('nuclear');
+        this.mapLayers.nuclear = true;
+        saveToStorage(STORAGE_KEYS.mapLayers, this.mapLayers);
+        this.map.triggerNuclearClick(asset.id);
+        break;
+    }
   }
 
   private makeDraggable(el: HTMLElement, key: string): void {

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -1,7 +1,7 @@
 import * as d3 from 'd3';
 import * as topojson from 'topojson-client';
 import type { Topology, GeometryCollection } from 'topojson-specification';
-import type { MapLayers, Hotspot, NewsItem, Earthquake, InternetOutage } from '@/types';
+import type { MapLayers, Hotspot, NewsItem, Earthquake, InternetOutage, RelatedAsset, AssetType } from '@/types';
 import type { WeatherAlert } from '@/services/weather';
 import { getSeverityColor } from '@/services/weather';
 import {
@@ -67,6 +67,13 @@ export class MapComponent {
   private onHotspotClick?: (hotspot: Hotspot) => void;
   private onTimeRangeChange?: (range: TimeRange) => void;
   private onLayerChange?: (layer: keyof MapLayers, enabled: boolean) => void;
+  private highlightedAssets: Record<AssetType, Set<string>> = {
+    pipeline: new Set(),
+    cable: new Set(),
+    datacenter: new Set(),
+    base: new Set(),
+    nuclear: new Set(),
+  };
 
   constructor(container: HTMLElement, initialState: MapState) {
     this.container = container;
@@ -540,9 +547,10 @@ export class MapComponent {
         .y((d) => projection(d)?.[1] ?? 0)
         .curve(d3.curveCardinal);
 
+      const isHighlighted = this.highlightedAssets.cable.has(cable.id);
       const path = cableGroup
         .append('path')
-        .attr('class', 'cable-path')
+        .attr('class', `cable-path${isHighlighted ? ' asset-highlight asset-highlight-cable' : ''}`)
         .attr('d', lineGenerator(cable.points));
 
       path.append('title').text(cable.name);
@@ -574,9 +582,10 @@ export class MapComponent {
       const opacity = 0.85;
       const dashArray = pipeline.status === 'construction' ? '4,2' : 'none';
 
+      const isHighlighted = this.highlightedAssets.pipeline.has(pipeline.id);
       const path = pipelineGroup
         .append('path')
-        .attr('class', `pipeline-path pipeline-${pipeline.type} pipeline-${pipeline.status}`)
+        .attr('class', `pipeline-path pipeline-${pipeline.type} pipeline-${pipeline.status}${isHighlighted ? ' asset-highlight asset-highlight-pipeline' : ''}`)
         .attr('d', lineGenerator(pipeline.points))
         .attr('fill', 'none')
         .attr('stroke', color)
@@ -702,7 +711,8 @@ export class MapComponent {
         if (!pos) return;
 
         const div = document.createElement('div');
-        div.className = `nuclear-marker ${facility.status}`;
+        const isHighlighted = this.highlightedAssets.nuclear.has(facility.id);
+        div.className = `nuclear-marker ${facility.status}${isHighlighted ? ' asset-highlight asset-highlight-nuclear' : ''}`;
         div.style.left = `${pos[0]}px`;
         div.style.top = `${pos[1]}px`;
         div.title = `${facility.name} (${facility.type})`;
@@ -839,7 +849,8 @@ export class MapComponent {
         if (!pos) return;
 
         const div = document.createElement('div');
-        div.className = `base-marker ${base.type}`;
+        const isHighlighted = this.highlightedAssets.base.has(base.id);
+        div.className = `base-marker ${base.type}${isHighlighted ? ' asset-highlight asset-highlight-base' : ''}`;
         div.style.left = `${pos[0]}px`;
         div.style.top = `${pos[1]}px`;
 
@@ -1024,7 +1035,8 @@ export class MapComponent {
         if (!pos) return;
 
         const div = document.createElement('div');
-        div.className = `datacenter-marker ${dc.status}`;
+        const isHighlighted = this.highlightedAssets.datacenter.has(dc.id);
+        div.className = `datacenter-marker ${dc.status}${isHighlighted ? ' asset-highlight asset-highlight-datacenter' : ''}`;
         div.style.left = `${pos[0]}px`;
         div.style.top = `${pos[1]}px`;
 
@@ -1418,6 +1430,20 @@ export class MapComponent {
       this.onLayerChange?.(layer, true);
       this.render();
     }
+  }
+
+  public highlightAssets(assets: RelatedAsset[] | null): void {
+    (Object.keys(this.highlightedAssets) as AssetType[]).forEach((type) => {
+      this.highlightedAssets[type].clear();
+    });
+
+    if (assets) {
+      assets.forEach((asset) => {
+        this.highlightedAssets[asset.type].add(asset.id);
+      });
+    }
+
+    this.render();
   }
 
   private applyTransform(): void {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -3,6 +3,7 @@ export * from './markets';
 export * from './polymarket';
 export * from './earthquakes';
 export * from './clustering';
+export * from './related-assets';
 export * from './velocity';
 export * from './storage';
 export * from './correlation';

--- a/src/services/related-assets.ts
+++ b/src/services/related-assets.ts
@@ -1,0 +1,166 @@
+import type { ClusteredEvent, RelatedAsset, AssetType, RelatedAssetContext } from '@/types';
+import {
+  INTEL_HOTSPOTS,
+  CONFLICT_ZONES,
+  MILITARY_BASES,
+  UNDERSEA_CABLES,
+  NUCLEAR_FACILITIES,
+  AI_DATA_CENTERS,
+  PIPELINES,
+} from '@/config';
+
+const MAX_DISTANCE_KM = 600;
+const MAX_ASSETS_PER_TYPE = 3;
+
+const ASSET_KEYWORDS: Record<AssetType, string[]> = {
+  pipeline: ['pipeline', 'oil pipeline', 'gas pipeline', 'fuel pipeline', 'pipeline leak', 'pipeline spill'],
+  cable: ['cable', 'undersea cable', 'subsea cable', 'fiber cable', 'fiber optic', 'internet cable'],
+  datacenter: ['datacenter', 'data center', 'server farm', 'colocation', 'hyperscale'],
+  base: ['military base', 'airbase', 'naval base', 'base', 'garrison'],
+  nuclear: ['nuclear', 'reactor', 'uranium', 'enrichment', 'nuclear plant'],
+};
+
+const ASSET_LABELS: Record<AssetType, string> = {
+  pipeline: 'Pipeline',
+  cable: 'Cable',
+  datacenter: 'Datacenter',
+  base: 'Base',
+  nuclear: 'Nuclear',
+};
+
+interface AssetOrigin {
+  lat: number;
+  lon: number;
+  label: string;
+}
+
+function toTitleLower(titles: string[]): string[] {
+  return titles.map(title => title.toLowerCase());
+}
+
+function detectAssetTypes(titles: string[]): AssetType[] {
+  const normalized = toTitleLower(titles);
+  const types = Object.entries(ASSET_KEYWORDS)
+    .filter(([, keywords]) =>
+      normalized.some(title => keywords.some(keyword => title.includes(keyword)))
+    )
+    .map(([type]) => type as AssetType);
+  return types;
+}
+
+function countKeywordMatches(titles: string[], keywords: string[]): number {
+  const normalized = toTitleLower(titles);
+  return keywords.reduce((count, keyword) => {
+    return count + normalized.filter(title => title.includes(keyword)).length;
+  }, 0);
+}
+
+function inferOrigin(titles: string[]): AssetOrigin | null {
+  const hotspotCandidates = INTEL_HOTSPOTS.map((hotspot) => ({
+    label: hotspot.name,
+    lat: hotspot.lat,
+    lon: hotspot.lon,
+    score: countKeywordMatches(titles, hotspot.keywords),
+  })).filter(candidate => candidate.score > 0);
+
+  const conflictCandidates = CONFLICT_ZONES.map((conflict) => ({
+    label: conflict.name,
+    lat: conflict.center[1],
+    lon: conflict.center[0],
+    score: countKeywordMatches(titles, conflict.keywords ?? []),
+  })).filter(candidate => candidate.score > 0);
+
+  const allCandidates = [...hotspotCandidates, ...conflictCandidates];
+  if (allCandidates.length === 0) return null;
+
+  return allCandidates.sort((a, b) => b.score - a.score)[0] ?? null;
+}
+
+function haversineDistanceKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const toRad = (value: number) => (value * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const originLat = toRad(lat1);
+  const destLat = toRad(lat2);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(originLat) * Math.cos(destLat) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return 6371 * c;
+}
+
+function midpoint(points: [number, number][]): { lat: number; lon: number } | null {
+  if (points.length === 0) return null;
+  const mid = points[Math.floor(points.length / 2)] as [number, number];
+  return { lon: mid[0], lat: mid[1] };
+}
+
+function buildAssetIndex(type: AssetType): Array<{ id: string; name: string; lat: number; lon: number } | null> {
+  switch (type) {
+    case 'pipeline':
+      return PIPELINES.map(pipeline => {
+        const mid = midpoint(pipeline.points);
+        if (!mid) return null;
+        return { id: pipeline.id, name: pipeline.name, lat: mid.lat, lon: mid.lon };
+      });
+    case 'cable':
+      return UNDERSEA_CABLES.map(cable => {
+        const mid = midpoint(cable.points);
+        if (!mid) return null;
+        return { id: cable.id, name: cable.name, lat: mid.lat, lon: mid.lon };
+      });
+    case 'datacenter':
+      return AI_DATA_CENTERS.map(dc => ({ id: dc.id, name: dc.name, lat: dc.lat, lon: dc.lon }));
+    case 'base':
+      return MILITARY_BASES.map(base => ({ id: base.id, name: base.name, lat: base.lat, lon: base.lon }));
+    case 'nuclear':
+      return NUCLEAR_FACILITIES.map(site => ({ id: site.id, name: site.name, lat: site.lat, lon: site.lon }));
+    default:
+      return [];
+  }
+}
+
+function findNearbyAssets(origin: AssetOrigin, types: AssetType[]): RelatedAsset[] {
+  const results: RelatedAsset[] = [];
+
+  types.forEach((type) => {
+    const candidates = buildAssetIndex(type)
+      .filter((asset): asset is { id: string; name: string; lat: number; lon: number } => !!asset)
+      .map((asset) => ({
+        ...asset,
+        distanceKm: haversineDistanceKm(origin.lat, origin.lon, asset.lat, asset.lon),
+      }))
+      .filter(asset => asset.distanceKm <= MAX_DISTANCE_KM)
+      .sort((a, b) => a.distanceKm - b.distanceKm)
+      .slice(0, MAX_ASSETS_PER_TYPE);
+
+    candidates.forEach(candidate => {
+      results.push({
+        id: candidate.id,
+        name: candidate.name,
+        type,
+        distanceKm: candidate.distanceKm,
+      });
+    });
+  });
+
+  return results.sort((a, b) => a.distanceKm - b.distanceKm);
+}
+
+export function getClusterAssetContext(cluster: ClusteredEvent): RelatedAssetContext | null {
+  const titles = cluster.allItems.map(item => item.title);
+  const types = detectAssetTypes(titles);
+  if (types.length === 0) return null;
+
+  const origin = inferOrigin(titles);
+  if (!origin) return null;
+
+  const assets = findNearbyAssets(origin, types);
+  return { origin, assets, types };
+}
+
+export function getAssetLabel(type: AssetType): string {
+  return ASSET_LABELS[type];
+}
+
+export { MAX_DISTANCE_KM };

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -456,6 +456,72 @@ body {
   border-left-color: var(--accent);
 }
 
+/* Related assets */
+.related-assets {
+  margin-top: 8px;
+  padding: 8px;
+  border-radius: 8px;
+  background: rgba(7, 22, 17, 0.7);
+  border: 1px solid rgba(0, 255, 170, 0.2);
+}
+
+.related-assets-header {
+  font-size: 9px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.related-assets-range {
+  color: var(--accent);
+}
+
+.related-assets-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.related-asset {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 6px;
+  align-items: center;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: rgba(10, 34, 26, 0.8);
+  border: 1px solid rgba(0, 255, 170, 0.15);
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.related-asset:hover {
+  border-color: rgba(0, 255, 170, 0.5);
+  box-shadow: 0 0 10px rgba(0, 255, 170, 0.2);
+}
+
+.related-asset-type {
+  font-size: 8px;
+  text-transform: uppercase;
+  color: var(--accent);
+  letter-spacing: 0.4px;
+}
+
+.related-asset-name {
+  font-size: 10px;
+  color: var(--text);
+}
+
+.related-asset-distance {
+  font-size: 9px;
+  color: var(--text-dim);
+}
+
 /* Velocity */
 .velocity-badge {
   font-size: 8px;
@@ -1111,6 +1177,51 @@ body.playback-mode .status-dot {
 
 .pipeline-path.pipeline-products:hover {
   filter: drop-shadow(0 0 8px #ffd166) drop-shadow(0 0 15px #ffd166);
+}
+
+/* Related asset highlights */
+.asset-highlight {
+  animation: asset-pulse 1.2s ease-in-out infinite;
+}
+
+.base-marker.asset-highlight,
+.datacenter-marker.asset-highlight,
+.nuclear-marker.asset-highlight {
+  z-index: 30;
+  box-shadow: 0 0 12px rgba(0, 255, 170, 0.6);
+}
+
+.pipeline-path.asset-highlight {
+  stroke-width: 4.5 !important;
+  filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.6));
+  animation: asset-pulse-glow 1.2s ease-in-out infinite;
+}
+
+.cable-path.asset-highlight {
+  stroke-width: 3.5;
+  opacity: 1;
+  filter: drop-shadow(0 0 10px rgba(0, 255, 170, 0.8));
+  animation: asset-pulse-glow 1.2s ease-in-out infinite;
+}
+
+@keyframes asset-pulse {
+  0%, 100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.05);
+    opacity: 0.7;
+  }
+}
+
+@keyframes asset-pulse-glow {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
 }
 
 /* Pipeline popup header colors */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,21 @@ export interface ClusteredEvent {
   velocity?: VelocityMetrics;
 }
 
+export type AssetType = 'pipeline' | 'cable' | 'datacenter' | 'base' | 'nuclear';
+
+export interface RelatedAsset {
+  id: string;
+  name: string;
+  type: AssetType;
+  distanceKm: number;
+}
+
+export interface RelatedAssetContext {
+  origin: { label: string; lat: number; lon: number };
+  types: AssetType[];
+  assets: RelatedAsset[];
+}
+
 export interface Sector {
   symbol: string;
   name: string;


### PR DESCRIPTION
### Motivation

- Improve discovery by surfacing physical/infrastructural context (pipelines, cables, datacenters, bases, nuclear) for clustered headlines.  
- Make clusters feel more investigative by showing nearby assets and allowing the user to jump to them on the map.  
- Reuse existing geo layers to provide immediate OSINT-grade value with low overhead.

### Description

- Add a new related-asset service (`src/services/related-assets.ts`) and types (`RelatedAsset`, `RelatedAssetContext`, `AssetType` in `src/types/index.ts`) that detect asset types from cluster titles, infer an origin, and find nearby assets.  
- Render related-asset cards inside clustered news items (`src/components/NewsPanel.ts`) and wire hover/click handlers to highlight assets on the map and open the corresponding map popups via handlers attached in `src/App.ts`.  
- Extend the map component (`src/components/Map.ts`) with an asset highlight state and `highlightAssets` method to visually pulse/highlight pipelines, cables, datacenters, bases, and nuclear sites, and add UI styles for cards and highlights (`src/styles/main.css`).  
- Export the new service from `src/services/index.ts` and update application wiring to enable/enable layers and trigger map clicks when users interact with related-asset cards.

### Testing

- Started the dev server with `npm run dev` and the Vite server reported ready successfully.  
- Ran an automated Playwright script that loaded the app and saved a screenshot artifact (`artifacts/related-assets.png`) to exercise the UI end-to-end.  
- Vite logged network proxy `ENETUNREACH` warnings while fetching external feeds (unrelated to the new UI features), but the UI loaded and highlights were rendered for the screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69615f82090c832e9f4167874c71100d)