### PR TITLE
Add pipeline flow disruption signals

### DIFF
--- a/src/components/SignalModal.ts
+++ b/src/components/SignalModal.ts
@@ -127,6 +127,8 @@ export class SignalModal {
       'velocity_spike': '🔥 Velocity Spike',
       'convergence': '◉ Convergence',
       'triangulation': '△ Triangulation',
+      'flow_drop': '🛢️ Flow Drop',
+      'flow_price_divergence': '📈 Flow/Price Divergence',
     };
 
     const html = this.currentSignals.map(signal => `

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -617,6 +617,14 @@ body {
   border-left-color: #ff6b00;
 }
 
+.signal-item.flow_drop {
+  border-left-color: #6f42c1;
+}
+
+.signal-item.flow_price_divergence {
+  border-left-color: #2ec4b6;
+}
+
 .signal-type {
   font-size: 10px;
   text-transform: uppercase;


### PR DESCRIPTION
### Motivation
- Detect infrastructure-driven supply shocks by surfacing pipeline flow disruptions in the existing correlation/signal system.  
- Expose a clear cause-effect link between pipeline incidents and commodity price moves to complement the existing "silent divergence" and market layers.  
- Use public news velocity and market data (where available) to infer flow drops and silent price/flow divergences with minimal UI changes.  
- Keep false positives down via deduping and simple heuristics tied to source counts and news velocity.

### Description
- Add two new signal types: `flow_drop` and `flow_price_divergence` to `SignalType` and the correlation pipeline.  
- Implement `detectPipelineFlowDrops(events)` plus `includesKeyword` helper and keyword lists (`PIPELINE_KEYWORDS`, `FLOW_DROP_KEYWORDS`) and thresholds (`FLOW_PRICE_THRESHOLD`, `ENERGY_COMMODITY_SYMBOLS`) in `src/services/correlation.ts`.  
- Integrate pipeline flow detection into `analyzeCorrelations` and emit `flow_drop` signals and `flow_price_divergence` when energy commodities move without pipeline flow news.  
- Add UI labels and CSS rules for the new signals in `src/components/SignalModal.ts` and `src/styles/main.css` so they display consistently in the existing signal modal.

### Testing
- Started the dev server with `npm run dev` (Vite) which launched but produced some network proxy errors (`ENETUNREACH`) and an `xdg-open` spawn warning during the run.  
- Ran a headless Playwright script to inject sample `flow_drop` and `flow_price_divergence` items into the modal and capture a screenshot, which completed successfully and produced an artifact.  
- Verified code compiles in the development server startup phase up to the network-dependent feed fetches, but end-to-end data-driven signals were not fully exercised due to feed network errors.  
- Changes were committed as "Add pipeline flow disruption signals".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69616243ea30832eb85706ac89c6faf8)