### PR TITLE
Add power grid stress & blackout alert layer

### DIFF
--- a/src/components/StatusPanel.ts
+++ b/src/components/StatusPanel.ts
@@ -76,7 +76,7 @@ export class StatusPanel {
     const feedNames = [
       'Politics', 'Middleeast', 'Tech', 'Ai', 'Finance',
       'Gov', 'Intel', 'Layoffs', 'Congress', 'Thinktanks',
-      'Polymarket', 'Weather'
+      'Polymarket', 'Weather', 'NetBlocks', 'Grid'
     ];
     feedNames.forEach(name => {
       this.feeds.set(name, { name, lastUpdate: null, status: 'warning', itemCount: 0 });

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -26,6 +26,7 @@ export const DEFAULT_MAP_LAYERS: MapLayers = {
   cables: true,
   pipelines: false,
   hotspots: true,
+  grid: true,
   nuclear: true,
   irradiators: false,
   sanctions: true,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -9,3 +9,4 @@ export * from './correlation';
 export * from './weather';
 export * from './fred';
 export * from './outages';
+export * from './powerGrid';

--- a/src/services/powerGrid.ts
+++ b/src/services/powerGrid.ts
@@ -1,0 +1,76 @@
+import type { PowerGridAlert } from '@/types';
+
+const GRID_ALERT_TEMPLATES: Array<Omit<PowerGridAlert, 'time'> & { timeOffsetMinutes: number }> = [
+  {
+    id: 'ercot-reserve-margin',
+    title: 'ERCOT reserve margin stress',
+    description: 'Operating reserves tightened after a demand surge and generation derates. Operators issued conservation requests.',
+    region: 'Texas, USA',
+    lat: 31.2,
+    lon: -99.4,
+    severity: 'critical',
+    signalType: 'stress',
+    reserveMargin: 2.4,
+    frequencyHz: 59.86,
+    impactRadiusKm: 320,
+    source: 'ERCOT Grid Alert',
+    sourceUrl: 'https://www.ercot.com/gridinfo',
+    timeOffsetMinutes: 95,
+  },
+  {
+    id: 'ng-frequency-deviation',
+    title: 'Frequency deviation event',
+    description: 'Short-duration frequency dip observed during evening ramp with tight reserve margins.',
+    region: 'Great Britain',
+    lat: 52.6,
+    lon: -1.6,
+    severity: 'warning',
+    signalType: 'stress',
+    reserveMargin: 4.9,
+    frequencyHz: 49.62,
+    impactRadiusKm: 260,
+    source: 'National Grid ESO',
+    sourceUrl: 'https://www.nationalgrideso.com/data-portal',
+    timeOffsetMinutes: 180,
+  },
+  {
+    id: 'north-india-outages',
+    title: 'Outage cluster across northern feeders',
+    description: 'Multiple substation trips triggered rolling outages across industrial corridors.',
+    region: 'Northern India',
+    lat: 28.9,
+    lon: 77.1,
+    severity: 'critical',
+    signalType: 'outage',
+    customersAffected: 2400000,
+    outageCount: 19,
+    impactRadiusKm: 220,
+    source: 'Regional outage dashboard',
+    sourceUrl: 'https://poweroutage.in/',
+    timeOffsetMinutes: 70,
+  },
+  {
+    id: 'south-africa-load-shed',
+    title: 'Stage 4 load shedding',
+    description: 'Generation shortfall pushed load shedding to Stage 4 with rotating blackouts.',
+    region: 'South Africa',
+    lat: -28.5,
+    lon: 24.7,
+    severity: 'warning',
+    signalType: 'outage',
+    customersAffected: 1100000,
+    outageCount: 12,
+    impactRadiusKm: 260,
+    source: 'Eskom System Status',
+    sourceUrl: 'https://www.eskom.co.za/dataportal/',
+    timeOffsetMinutes: 210,
+  },
+];
+
+export async function fetchPowerGridAlerts(): Promise<PowerGridAlert[]> {
+  const now = Date.now();
+  return GRID_ALERT_TEMPLATES.map((alert) => ({
+    ...alert,
+    time: new Date(now - alert.timeOffsetMinutes * 60 * 1000),
+  }));
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1176,6 +1176,76 @@ body.playback-mode .status-dot {
   50% { opacity: 0.6; transform: translate(-50%, -50%) scale(calc(var(--marker-scale, 1) * 1.2)); }
 }
 
+/* Power grid alerts */
+.grid-alert {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  transform: translate(-50%, -50%) scale(var(--marker-scale, 1));
+  transform-origin: center;
+  cursor: pointer;
+  z-index: 14;
+}
+
+.grid-alert.watch {
+  --grid-color: #ffb347;
+}
+
+.grid-alert.warning {
+  --grid-color: #ff7a3a;
+}
+
+.grid-alert.critical {
+  --grid-color: #ff2e2e;
+  animation: grid-pulse 1.6s ease-in-out infinite;
+}
+
+.grid-alert.grid-stress {
+  width: var(--grid-size, 160px);
+  height: var(--grid-size, 160px);
+  border-radius: 50%;
+  border: 1px solid var(--grid-color);
+  background: radial-gradient(circle, rgba(255, 125, 0, 0.28) 0%, rgba(255, 80, 0, 0.12) 45%, rgba(255, 20, 0, 0.03) 70%);
+  box-shadow: 0 0 14px var(--grid-color);
+}
+
+.grid-alert.grid-outage {
+  width: calc(var(--grid-size, 120px) * 0.55);
+  height: calc(var(--grid-size, 120px) * 0.55);
+  border-radius: 50%;
+  border: 1px solid var(--grid-color);
+  background: rgba(60, 0, 0, 0.45);
+  box-shadow: 0 0 10px var(--grid-color);
+}
+
+.grid-icon {
+  font-size: 14px;
+  color: var(--grid-color);
+  filter: drop-shadow(0 0 4px var(--grid-color));
+}
+
+.grid-alert.grid-stress .grid-icon {
+  font-size: 16px;
+}
+
+.grid-label {
+  position: absolute;
+  bottom: -10px;
+  font-size: 8px;
+  color: var(--grid-color);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  white-space: nowrap;
+  text-shadow: 0 0 4px var(--bg), 0 0 8px var(--bg);
+}
+
+@keyframes grid-pulse {
+  0%, 100% { opacity: 1; transform: translate(-50%, -50%) scale(var(--marker-scale, 1)); }
+  50% { opacity: 0.65; transform: translate(-50%, -50%) scale(calc(var(--marker-scale, 1) * 1.15)); }
+}
+
 /* Outage popup header */
 .popup-header.outage.total {
   border-bottom-color: #ff2222;
@@ -1187,6 +1257,19 @@ body.playback-mode .status-dot {
 
 .popup-header.outage.partial {
   border-bottom-color: #ffaa00;
+}
+
+/* Grid popup header */
+.popup-header.grid.watch {
+  border-bottom-color: #ffb347;
+}
+
+.popup-header.grid.warning {
+  border-bottom-color: #ff7a3a;
+}
+
+.popup-header.grid.critical {
+  border-bottom-color: #ff2e2e;
 }
 
 /* Conflict zones */
@@ -2294,6 +2377,7 @@ body.playback-mode .status-dot {
 .map-legend-icon.conflict { color: #ff4444; }
 .map-legend-icon.earthquake { color: #ffaa00; }
 .map-legend-icon.apt { color: #ff6600; }
+.map-legend-icon.grid { color: #ff8844; }
 
 .legend-dot {
   width: 8px;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -246,6 +246,7 @@ export interface MapLayers {
   cables: boolean;
   pipelines: boolean;
   hotspots: boolean;
+  grid: boolean;
   nuclear: boolean;
   irradiators: boolean;
   sanctions: boolean;
@@ -289,6 +290,28 @@ export interface InternetOutage {
   cause?: string;
   outageType?: string;
   endDate?: Date;
+}
+
+export type PowerGridSeverity = 'watch' | 'warning' | 'critical';
+export type PowerGridSignal = 'stress' | 'outage';
+
+export interface PowerGridAlert {
+  id: string;
+  title: string;
+  description: string;
+  region: string;
+  lat: number;
+  lon: number;
+  severity: PowerGridSeverity;
+  signalType: PowerGridSignal;
+  reserveMargin?: number;
+  frequencyHz?: number;
+  customersAffected?: number;
+  outageCount?: number;
+  impactRadiusKm?: number;
+  time: Date;
+  source: string;
+  sourceUrl?: string;
 }
 
 export type EconomicCenterType = 'exchange' | 'central-bank' | 'financial-hub';


### PR DESCRIPTION
### Motivation
- Surface electrical grid stress and clustered blackout signals as a first-class operational layer tied to the existing map and hotspot correlation logic.
- Provide both "stress" signals (reserve margin / frequency deviations) and "outage cluster" signals (large customer impacts / multiple substation trips) for situational awareness.
- Reuse the map overlay, legend, and popup UI patterns so grid alerts are togglable and immediately visible alongside weather/infrastructure layers.
- Improve hotspot correlation by boosting matches when blackout-related keywords appear in news items to detect perception/impact signals.

### Description
- Added a mock data service `fetchPowerGridAlerts` in `src/services/powerGrid.ts` and exported it from `src/services/index.ts` to produce sample `PowerGridAlert` items.
- Introduced new types `PowerGridAlert`, `PowerGridSeverity`, and `PowerGridSignal` in `src/types/index.ts` and added a `grid` key to `MapLayers` and `DEFAULT_MAP_LAYERS`.
- Rendered a new `grid` map layer in `src/components/Map.ts` with overlays, click-to-popup behavior (`setPowerGridAlerts` + legend entries), and integrated the layer toggle into the layer controls.
- Implemented a grid popup renderer in `src/components/MapPopup.ts`, CSS styles in `src/styles/main.css`, and wired periodic loading via `loadPowerGridAlerts()` in `src/App.ts` with a `Grid` entry in the `StatusPanel`.
- Enhanced hotspot correlation by adding blackout keyword detection and applying a score boost when blackout-related terms appear in news titles (in `Map.ts`).
- Ensured stored map layer defaults are merged with `DEFAULT_MAP_LAYERS` on startup so the new `grid` layer behaves correctly for existing users.

### Testing
- Started the local dev server with `npm run dev` and confirmed the application served successfully (Vite server ready); this step completed.
- Captured a UI screenshot using Playwright (headless) to verify the new map overlays render; the screenshot artifact was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696161e0c9bc832e9da5d23cd7e79625)