### PR TITLE
Add live protest feed ingestion and map integration

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,6 +5,7 @@ export * from './panels';
 export * from './irradiators';
 export * from './pipelines';
 export * from './ai-datacenters';
+export * from './protests';
 
 export const API_URLS = {
   yahooFinance: (symbol: string) =>

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -26,6 +26,7 @@ export const DEFAULT_MAP_LAYERS: MapLayers = {
   cables: true,
   pipelines: false,
   hotspots: true,
+  protests: true,
   nuclear: true,
   irradiators: false,
   sanctions: true,

--- a/src/config/protests.ts
+++ b/src/config/protests.ts
@@ -1,0 +1,103 @@
+import type { Feed } from '@/types';
+
+export interface ProtestLocation {
+  id: string;
+  city?: string;
+  country: string;
+  lat: number;
+  lon: number;
+  keywords: string[];
+  relatedHotspots?: string[];
+}
+
+export const PROTEST_FEEDS: Feed[] = [
+  { name: 'Reuters Protest', url: '/rss/googlenews/rss/search?q=site:reuters.com+protest+OR+demonstration+OR+strike&hl=en-US&gl=US&ceid=US:en' },
+  { name: 'AP Protest', url: '/rss/googlenews/rss/search?q=site:apnews.com+protest+OR+demonstration+OR+strike&hl=en-US&gl=US&ceid=US:en' },
+  { name: 'Al Jazeera Protest', url: '/rss/googlenews/rss/search?q=site:aljazeera.com+protest+OR+demonstration+OR+strike&hl=en-US&gl=US&ceid=US:en' },
+  { name: 'Guardian Protest', url: '/rss/googlenews/rss/search?q=site:theguardian.com+protest+OR+demonstration+OR+strike&hl=en-US&gl=US&ceid=US:en' },
+  { name: 'BBC Protest', url: '/rss/googlenews/rss/search?q=site:bbc.com+protest+OR+demonstration+OR+strike&hl=en-US&gl=US&ceid=US:en' },
+];
+
+export const PROTEST_LOCATIONS: ProtestLocation[] = [
+  {
+    id: 'paris',
+    city: 'Paris',
+    country: 'France',
+    lat: 48.8566,
+    lon: 2.3522,
+    keywords: ['paris', 'france', 'french'],
+    relatedHotspots: ['brussels', 'london'],
+  },
+  {
+    id: 'buenos-aires',
+    city: 'Buenos Aires',
+    country: 'Argentina',
+    lat: -34.6037,
+    lon: -58.3816,
+    keywords: ['buenos aires', 'argentina', 'argentine'],
+    relatedHotspots: ['caracas'],
+  },
+  {
+    id: 'nairobi',
+    city: 'Nairobi',
+    country: 'Kenya',
+    lat: -1.2864,
+    lon: 36.8172,
+    keywords: ['nairobi', 'kenya', 'kenyan'],
+    relatedHotspots: ['cairo'],
+  },
+  {
+    id: 'manila',
+    city: 'Manila',
+    country: 'Philippines',
+    lat: 14.5995,
+    lon: 120.9842,
+    keywords: ['manila', 'philippines', 'filipino'],
+    relatedHotspots: ['taipei', 'beijing'],
+  },
+  {
+    id: 'jakarta',
+    city: 'Jakarta',
+    country: 'Indonesia',
+    lat: -6.2088,
+    lon: 106.8456,
+    keywords: ['jakarta', 'indonesia', 'indonesian'],
+    relatedHotspots: ['beijing'],
+  },
+  {
+    id: 'lagos',
+    city: 'Lagos',
+    country: 'Nigeria',
+    lat: 6.5244,
+    lon: 3.3792,
+    keywords: ['lagos', 'nigeria', 'nigerian'],
+    relatedHotspots: ['cairo'],
+  },
+  {
+    id: 'kyiv',
+    city: 'Kyiv',
+    country: 'Ukraine',
+    lat: 50.4501,
+    lon: 30.5234,
+    keywords: ['kyiv', 'kiev', 'ukraine', 'ukrainian'],
+    relatedHotspots: ['kyiv'],
+  },
+  {
+    id: 'tehran',
+    city: 'Tehran',
+    country: 'Iran',
+    lat: 35.6892,
+    lon: 51.389,
+    keywords: ['tehran', 'iran', 'iranian'],
+    relatedHotspots: ['tehran'],
+  },
+  {
+    id: 'caracas',
+    city: 'Caracas',
+    country: 'Venezuela',
+    lat: 10.4806,
+    lon: -66.9036,
+    keywords: ['caracas', 'venezuela', 'venezuelan'],
+    relatedHotspots: ['caracas'],
+  },
+];

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -9,3 +9,4 @@ export * from './correlation';
 export * from './weather';
 export * from './fred';
 export * from './outages';
+export * from './protests';

--- a/src/services/protests.ts
+++ b/src/services/protests.ts
@@ -1,0 +1,72 @@
+import type { SocialUnrestEvent, ProtestSeverity } from '@/types';
+import { PROTEST_FEEDS, PROTEST_LOCATIONS } from '@/config';
+import { fetchCategoryFeeds } from './rss';
+import { generateId } from '@/utils';
+
+const SEVERITY_KEYWORDS: Record<ProtestSeverity, string[]> = {
+  high: ['clash', 'riot', 'violence', 'deadly', 'shooting', 'arson', 'killed', 'looting'],
+  medium: ['strike', 'march', 'blockade', 'shutdown', 'rally', 'protest'],
+  low: ['demonstration', 'sit-in', 'petition', 'walkout'],
+};
+
+const TAG_KEYWORDS: Record<string, string[]> = {
+  labor: ['strike', 'union', 'walkout', 'wage'],
+  fuel: ['fuel', 'gas', 'petrol', 'diesel'],
+  transport: ['transport', 'metro', 'rail', 'bus', 'airport', 'port'],
+  politics: ['election', 'opposition', 'government', 'parliament'],
+  inflation: ['inflation', 'cost of living', 'prices'],
+  education: ['student', 'tuition', 'campus'],
+  security: ['police', 'security forces', 'military'],
+};
+
+function pickSeverity(title: string): ProtestSeverity {
+  const lower = title.toLowerCase();
+  if (SEVERITY_KEYWORDS.high.some((kw) => lower.includes(kw))) return 'high';
+  if (SEVERITY_KEYWORDS.medium.some((kw) => lower.includes(kw))) return 'medium';
+  return 'low';
+}
+
+function extractTags(title: string): string[] {
+  const lower = title.toLowerCase();
+  return Object.entries(TAG_KEYWORDS)
+    .filter(([, keywords]) => keywords.some((kw) => lower.includes(kw)))
+    .map(([tag]) => tag);
+}
+
+function matchLocation(title: string) {
+  const lower = title.toLowerCase();
+  return PROTEST_LOCATIONS.find((location) =>
+    location.keywords.some((kw) => lower.includes(kw.toLowerCase()))
+  );
+}
+
+export async function fetchProtestEvents(): Promise<SocialUnrestEvent[]> {
+  const items = await fetchCategoryFeeds(PROTEST_FEEDS);
+  const events: SocialUnrestEvent[] = [];
+  const seen = new Set<string>();
+
+  for (const item of items) {
+    const location = matchLocation(item.title);
+    if (!location) continue;
+
+    const key = `${location.id}:${item.title.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    events.push({
+      id: generateId(),
+      title: item.title,
+      city: location.city,
+      country: location.country,
+      lat: location.lat,
+      lon: location.lon,
+      time: item.pubDate,
+      severity: pickSeverity(item.title),
+      sources: [item.source],
+      tags: extractTags(item.title),
+      relatedHotspots: location.relatedHotspots,
+    });
+  }
+
+  return events;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1176,6 +1176,58 @@ body.playback-mode .status-dot {
   50% { opacity: 0.6; transform: translate(-50%, -50%) scale(calc(var(--marker-scale, 1) * 1.2)); }
 }
 
+/* Protest markers */
+.protest-marker {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transform: translate(-50%, -50%) scale(var(--marker-scale, 1));
+  transform-origin: center;
+  cursor: pointer;
+  z-index: 14;
+}
+
+.protest-marker.low {
+  --protest-color: #7bdff2;
+}
+
+.protest-marker.medium {
+  --protest-color: #ffd166;
+}
+
+.protest-marker.high {
+  --protest-color: #ef476f;
+}
+
+.protest-icon {
+  font-size: 16px;
+  filter: drop-shadow(0 0 4px var(--protest-color, #7bdff2));
+}
+
+.protest-label {
+  font-size: 8px;
+  color: var(--protest-color, #7bdff2);
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 2px;
+  text-shadow: 0 0 4px var(--bg), 0 0 8px var(--bg);
+}
+
+.protest-cluster {
+  position: absolute;
+  top: -12px;
+  right: -10px;
+  background: var(--protest-color, #7bdff2);
+  color: var(--bg);
+  font-size: 9px;
+  font-weight: bold;
+  padding: 2px 5px;
+  border-radius: 10px;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
+}
+
 /* Outage popup header */
 .popup-header.outage.total {
   border-bottom-color: #ff2222;
@@ -1976,6 +2028,14 @@ body.playback-mode .status-dot {
   color: #ff8c00;
 }
 
+.popup-header.protest {
+  border-bottom-color: #ef476f;
+}
+
+.popup-header.protest .popup-title {
+  color: #ef476f;
+}
+
 .popup-title.magnitude {
   font-size: 28px;
 }
@@ -2293,6 +2353,7 @@ body.playback-mode .status-dot {
 .map-legend-icon.cable { color: #00ffaa; }
 .map-legend-icon.conflict { color: #ff4444; }
 .map-legend-icon.earthquake { color: #ffaa00; }
+.map-legend-icon.protest { color: #ef476f; }
 .map-legend-icon.apt { color: #ff6600; }
 
 .legend-dot {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -246,6 +246,7 @@ export interface MapLayers {
   cables: boolean;
   pipelines: boolean;
   hotspots: boolean;
+  protests: boolean;
   nuclear: boolean;
   irradiators: boolean;
   sanctions: boolean;
@@ -256,6 +257,25 @@ export interface MapLayers {
   waterways: boolean;
   outages: boolean;
   datacenters: boolean;
+}
+
+export type ProtestSeverity = 'low' | 'medium' | 'high';
+
+export interface SocialUnrestEvent {
+  id: string;
+  title: string;
+  summary?: string;
+  city?: string;
+  country: string;
+  lat: number;
+  lon: number;
+  time: Date;
+  severity: ProtestSeverity;
+  sources: string[];
+  tags?: string[];
+  relatedHotspots?: string[];
+  clusterSize?: number;
+  clusterWindowHours?: number;
 }
 
 export interface AIDataCenter {


### PR DESCRIPTION
### Motivation

- Replace the previous static, hardcoded protest dataset with live RSS ingestion to surface timely social unrest signals.
- Geolocate protest mentions via keyword-to-location mapping so events can be shown on the map and correlated with hotspots.
- Surface protest activity in the UI and have protests influence hotspot scoring to reflect on-the-ground risk.

### Description

- Added `src/config/protests.ts` which defines `PROTEST_FEEDS` and `PROTEST_LOCATIONS` for feed sources and location keyword mapping. 
- Implemented live ingestion in `src/services/protests.ts` with `fetchProtestEvents()` that matches titles to locations, extracts tags, and derives `severity`; exported via `src/services/index.ts`.
- Wired ingestion into the app in `src/App.ts` (added `fetchProtestEvents`, `loadProtests`, merged stored `DEFAULT_MAP_LAYERS`) and added status updates to the `StatusPanel`.
- Integrated protests into the map: updated `src/components/Map.ts` to compute clusters (`calculateProtestClusters`), render `protest-marker`s, compute distances (`getDistanceKm`), expose `setProtests`, and factor protests into `updateHotspotActivity`; added popup rendering in `src/components/MapPopup.ts`, type definitions in `src/types/index.ts`, and styles in `src/styles/main.css`.

### Testing

- No automated unit or integration tests were run for this change.
- No automated E2E or CI checks were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6961621f041c832eb66d25207b9ceba1)