### PR TITLE
Add WebGL LOD clustering for map layers

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -954,6 +954,14 @@ body.playback-mode .status-dot {
   position: relative;
 }
 
+.map-cluster-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
 #mapOverlays {
   position: absolute;
   top: 0;


### PR DESCRIPTION
### Motivation
- Reduce rendering cost and improve performance when many point markers are visible by using GPU-accelerated rendering and level-of-detail (LOD) clustering. 
- Avoid DOM/HTML overlay churn at low zooms by drawing aggregated markers instead of many individual HTML markers. 
- Provide configurable cluster thresholds per layer so high-density layers are automatically aggregated at lower zooms. 

### Description
- Add a WebGL cluster canvas (`map-cluster-canvas`) layered between the SVG map and HTML overlays and style it to be non-interactive. 
- Implement a lightweight WebGL renderer with simple vertex/fragment shaders, buffer setup, and helpers (`initClusterRenderer`, `compileShader`, `resizeClusterCanvas`, `clearClusterCanvas`). 
- Introduce `CLUSTER_LAYER_CONFIG` and LOD logic to aggregate points into grid clusters, compute cluster sizes/colors, and draw clustered points via `renderClusterLayer`, `buildClusterPoint`, `drawClusterPoints`, and `hexToRgba`. 
- Integrate clustering into the render flow so clustered layers are suppressed in the HTML overlays when LOD clustering is active and gracefully fall back when WebGL is unavailable. 

### Testing
- Started the dev server with `npm run dev` and Vite reported the app as ready (local network URL printed), which succeeded. 
- Captured an automated UI screenshot using Playwright saved to `artifacts/map-cluster.png` to validate the cluster canvas visually. 
- No unit tests were run as part of this change; integration was validated via the dev server + screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69625a5114b8832eaac2d4cd78a5ef07)