### PR TITLE
Offload news clustering to worker and reduce O(n²) comparisons

### DIFF
--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -3,7 +3,7 @@ import { WindowedList } from './VirtualList';
 import type { NewsItem, ClusteredEvent, DeviationLevel, RelatedAsset, RelatedAssetContext } from '@/types';
 import { formatTime } from '@/utils';
 import { escapeHtml, sanitizeUrl } from '@/utils/sanitize';
-import { clusterNews, enrichWithVelocity, getClusterAssetContext, getAssetLabel, MAX_DISTANCE_KM, activityTracker } from '@/services';
+import { analysisWorker, enrichWithVelocity, getClusterAssetContext, getAssetLabel, MAX_DISTANCE_KM, activityTracker } from '@/services';
 
 /** Threshold for enabling virtual scrolling */
 const VIRTUAL_SCROLL_THRESHOLD = 15;
@@ -27,6 +27,7 @@ export class NewsPanel extends Panel {
   private isFirstRender = true;
   private windowedList: WindowedList<PreparedCluster> | null = null;
   private useVirtualScroll = true;
+  private renderRequestId = 0;
 
   constructor(id: string, title: string) {
     super({ id, title, showCount: true, trackActivity: true });
@@ -110,11 +111,24 @@ export class NewsPanel extends Panel {
     }
 
     if (this.clusteredMode) {
-      const clusters = clusterNews(items);
-      const enriched = enrichWithVelocity(clusters);
-      this.renderClusters(enriched);
+      void this.renderClustersAsync(items);
     } else {
       this.renderFlat(items);
+    }
+  }
+
+  private async renderClustersAsync(items: NewsItem[]): Promise<void> {
+    const requestId = ++this.renderRequestId;
+
+    try {
+      const clusters = await analysisWorker.clusterNews(items);
+      if (requestId !== this.renderRequestId) return;
+      const enriched = enrichWithVelocity(clusters);
+      this.renderClusters(enriched);
+    } catch (error) {
+      if (requestId !== this.renderRequestId) return;
+      console.error('[NewsPanel] Failed to cluster news:', error);
+      this.showError('Failed to cluster news');
     }
   }
 


### PR DESCRIPTION
### Motivation
- Clustering was performed on the main UI thread via `clusterNews` in `NewsPanel.renderNews`, which can stall rendering for large inputs. 
- The core clustering used a nested pairwise loop (O(n²) Jaccard comparisons) that becomes expensive for larger news lists.

### Description
- Offload UI clustering to the existing analysis worker by calling `analysisWorker.clusterNews(items)` from `NewsPanel` and render results only after the worker returns, protecting against stale results with a `renderRequestId` guard and error handling (`src/components/NewsPanel.ts`).
- Reduce pairwise comparisons in the clustering core by adding a token inverted-index and candidate set pass so items only compare against others that share tokens, preserving Jaccard-based behaviour while drastically cutting the number of comparisons (`src/services/analysis-core.ts`).
- Keep tokenization and Jaccard similarity logic intact while introducing `tokenList` and `invertedIndex` to build candidate buckets and iterate sorted candidate indices for clustering.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968b4ebae98832e89e61bbb94e51c95)