### PR TITLE
Optimize map rendering layers

### DIFF
--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -636,7 +636,6 @@ export class MapComponent {
 
     // Setup projection
     const projection = this.getProjection(width, height);
-    const path = d3.geoPath().projection(projection);
 
     this.updateCountryFills();
 


### PR DESCRIPTION
### Motivation
- Reduce expensive full-SVG rebuilds performed on every `render()` by caching static geometry and only updating dynamic overlays.
- Avoid repeated `topojson.feature` conversion on each render by extracting features once on map data load.
- Make sanctions and other style changes apply without reconstructing the entire base map to improve redraw performance.

### Description
- Cache TopoJSON-derived features during `loadMapData()` by calling `topojson.feature` once and storing results in `this.countryFeatures`.
- Split the SVG into persistent groups: `this.baseLayerGroup` for static base elements and `this.dynamicLayerGroup` (with `overlaysSvgGroup`) for per-render dynamic content, and only rebuild the base when size changes or on initial load.
- Refactor `renderGrid`, `renderGraticule`, and `renderCountries` to accept a target group, and update layer renderers to append into `this.dynamicLayerGroup` instead of the root SVG.
- Replace the old `renderSanctions` approach with `updateCountryFills()` to toggle country fills based on `this.state.layers.sanctions` without rebuilding base geometry.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968b5e5cf90832e9bf07c04558c9f1a)