### PR TITLE
Ensure map URLs record empty layer selections

### DIFF
--- a/src/utils/urlState.ts
+++ b/src/utils/urlState.ts
@@ -61,17 +61,24 @@ export function parseMapUrlState(
 
   const layersParam = params.get('layers');
   let layers: MapLayers | undefined;
-  if (layersParam) {
-    const requested = new Set(
-      layersParam
-        .split(',')
-        .map((layer) => layer.trim())
-        .filter(Boolean)
-    );
+  if (layersParam !== null) {
     layers = { ...fallbackLayers };
-    LAYER_KEYS.forEach((key) => {
-      layers![key] = requested.has(key);
-    });
+    const normalizedLayers = layersParam.trim();
+    if (normalizedLayers !== '' && normalizedLayers !== 'none') {
+      const requested = new Set(
+        normalizedLayers
+          .split(',')
+          .map((layer) => layer.trim())
+          .filter(Boolean)
+      );
+      LAYER_KEYS.forEach((key) => {
+        layers![key] = requested.has(key);
+      });
+    } else {
+      LAYER_KEYS.forEach((key) => {
+        layers![key] = false;
+      });
+    }
   }
 
   return {
@@ -107,9 +114,7 @@ export function buildMapUrl(
   params.set('timeRange', state.timeRange);
 
   const activeLayers = LAYER_KEYS.filter((layer) => state.layers[layer]);
-  if (activeLayers.length > 0) {
-    params.set('layers', activeLayers.join(','));
-  }
+  params.set('layers', activeLayers.length > 0 ? activeLayers.join(',') : 'none');
 
   url.search = params.toString();
   return url.toString();


### PR DESCRIPTION
### Motivation
- Map share URLs must unambiguously reflect when every layer is disabled so viewers get the exact layer state.
- Empty or missing `layers` query values were previously ambiguous, so the URL builder and parser need to explicitly encode and interpret that state.

### Description
- `parseMapUrlState` now treats a present `layers` parameter with value `''` or `'none'` as “all off” and sets every key in `LAYER_KEYS` to `false`, while preserving the existing fallback behavior when the parameter is omitted.
- `buildMapUrl` always emits a `layers` query parameter, using `none` when no layers are active and otherwise joining active keys with commas.
- The parser normalizes and trims the `layers` value before splitting to robustly handle whitespace and empty tokens.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6977b8cdf7dc832eae02f128875f8fed)