### PR TITLE
Expand map layer URL keys in parsing and serialization

### DIFF
--- a/src/utils/urlState.ts
+++ b/src/utils/urlState.ts
@@ -7,6 +7,7 @@ const LAYER_KEYS: (keyof MapLayers)[] = [
   'cables',
   'pipelines',
   'hotspots',
+  'ais',
   'nuclear',
   'irradiators',
   'sanctions',
@@ -15,8 +16,17 @@ const LAYER_KEYS: (keyof MapLayers)[] = [
   'waterways',
   'outages',
   'datacenters',
+  'protests',
   'flights',
+  'military',
   'natural',
+  'spaceports',
+  'minerals',
+  'startupHubs',
+  'cloudRegions',
+  'accelerators',
+  'techHQs',
+  'techEvents',
 ];
 
 const TIME_RANGES: TimeRange[] = ['1h', '6h', '24h', '48h', '7d', 'all'];


### PR DESCRIPTION
### Motivation
- Ensure share URLs fully capture map layer state by including every key from the `MapLayers` type (geopolitical and tech layers). 
- Keep `parseMapUrlState` and `buildMapUrl` consistent so both parsing and serialization cover the same complete set of layers.

### Description
- Expanded the `LAYER_KEYS` array in `src/utils/urlState.ts` to include `ais`, `protests`, `military`, `spaceports`, `minerals`, `startupHubs`, `cloudRegions`, `accelerators`, `techHQs`, and `techEvents` so it matches `MapLayers`.
- `parseMapUrlState` continues to use `LAYER_KEYS` to populate a `MapLayers` object from the `layers` query param, now covering the full set.
- `buildMapUrl` uses `LAYER_KEYS` to serialize active layers into the `layers` query param, ensuring all layer flags are represented in share URLs.
- Change is contained to `src/utils/urlState.ts` and committed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6977b8c992e0832eb1acc9f4dd730f11)