### PR TITLE
Broaden OpenSky candidate capture and apply post-enrichment military filter

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -642,6 +642,7 @@ export interface MilitaryFlight {
     manufacturer?: string;
     owner?: string;
     operatorName?: string;
+    typeCode?: string;
     builtYear?: string;
     confirmedMilitary?: boolean;
     militaryBranch?: string;


### PR DESCRIPTION
### Motivation
- Allow Wingbits enrichment to evaluate more hotspot-bound candidates so additional signals (type code/owner) can identify military aircraft that initial heuristics miss.
- Keep OpenSky query volume unchanged by bounding candidates to configured hotspots while avoiding overly strict pre-enrichment filtering.
- Persist Wingbits type code so it can be used when applying a stricter military filter after enrichment.

### Description
- Change the OpenSky parsing logic to accept any flight inside hotspot bounds by using `getNearbyHotspot` in `parseOpenSkyResponse` and removed the old pre-enrichment `isMilitaryFlight` gate in `src/services/military-flights.ts`.
- Add a post-enrichment classifier `isConfirmedMilitaryFlight` that combines callsign, hex ranges, Wingbits `confirmedMilitary`, Wingbits `typeCode` (pattern match), and enriched `owner` keywords to decide final military membership in `src/services/military-flights.ts`.
- Implement an explicit two-stage flow in `fetchMilitaryFlights`: collect hotspot candidates via `fetchFromOpenSky`, batch-enrich them with `enrichFlightsWithWingbits`, then apply `isConfirmedMilitaryFlight` to produce the final `flights` set and clusters (documented in a comment block inside the function).
- Persist Wingbits `typecode` into flight enrichment as `enriched.typeCode` and update the type definition in `src/types/index.ts` to expose `typeCode` for downstream use.

### Testing
- No automated tests were executed during this change (none requested); commit contains only code modifications and updated type definitions.
- The patch compiles in-place during development and commit succeeded locally (no test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697849fea1d8832e8e033d40c4dc5d6d)