### PR TITLE
Fix live video stopping on tab switch

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -129,17 +129,19 @@ export class LiveNewsPanel extends Panel {
   }
 
   private setupIdleDetection(): void {
-    // Pause when tab becomes hidden
+    // Suspend idle timer when hidden, resume when visible
     this.boundVisibilityHandler = () => {
       if (document.hidden) {
-        this.pauseForIdle();
+        // Suspend idle timer so background playback isn't killed
+        if (this.idleTimeout) clearTimeout(this.idleTimeout);
       } else {
         this.resumeFromIdle();
+        this.boundIdleResetHandler();
       }
     };
     document.addEventListener('visibilitychange', this.boundVisibilityHandler);
 
-    // Track user activity to detect idle
+    // Track user activity to detect idle (pauses after 5 min inactivity)
     this.boundIdleResetHandler = () => {
       if (this.idleTimeout) clearTimeout(this.idleTimeout);
       this.idleTimeout = setTimeout(() => this.pauseForIdle(), this.IDLE_PAUSE_MS);


### PR DESCRIPTION
## Summary
- Stop destroying the YouTube player when the tab becomes hidden — audio/video now continues in background tabs
- Suspend the 5-minute idle timer while the tab is hidden so it doesn't silently kill background playback
- Idle timer resumes when the user returns to the tab

## Test plan
- [ ] Open the live news panel and start a stream
- [ ] Switch to another browser tab — verify audio continues playing
- [ ] Minimize the browser window — verify audio continues
- [ ] Return to the tab after >5 minutes — verify stream is still playing
- [ ] Leave the tab visible but don't interact for 5 minutes — verify idle pause still triggers