### PR TITLE
Fix hotspot overlay positioning during map drag

### DIFF
--- a/src/e2e/map-harness.ts
+++ b/src/e2e/map-harness.ts
@@ -36,6 +36,7 @@ import type {
   MilitaryVessel,
   MilitaryVesselCluster,
   NaturalEvent,
+  NewsItem,
   RepairShip,
   SocialUnrestEvent,
 } from '../types';
@@ -84,6 +85,7 @@ type MapHarness = {
   variant: HarnessVariant;
   seedAllDynamicData: () => void;
   setProtestsScenario: (scenario: Scenario) => void;
+  setHotspotActivityScenario: (scenario: 'none' | 'breaking') => void;
   setZoom: (zoom: number) => void;
   setLayersForSnapshot: (enabledLayers: HarnessLayerKey[]) => void;
   setCamera: (camera: CameraState) => void;
@@ -608,6 +610,22 @@ const buildProtests = (scenario: Scenario): SocialUnrestEvent[] => {
   ];
 };
 
+const buildHotspotActivityNews = (
+  scenario: 'none' | 'breaking'
+): NewsItem[] => {
+  if (scenario === 'none') return [];
+
+  return [
+    {
+      source: 'e2e-harness',
+      title: 'Sahel alert: mali coup activity intensifies',
+      link: 'https://example.com/hotspot-breaking',
+      pubDate: new Date(),
+      isAlert: true,
+    },
+  ];
+};
+
 const seedAllDynamicData = (): void => {
   const earthquakes: Earthquake[] = [
     {
@@ -986,6 +1004,9 @@ window.__mapHarness = {
   seedAllDynamicData,
   setProtestsScenario: (scenario: Scenario): void => {
     map.setProtests(buildProtests(scenario));
+  },
+  setHotspotActivityScenario: (scenario: 'none' | 'breaking'): void => {
+    map.updateHotspotActivity(buildHotspotActivityNews(scenario));
   },
   setZoom: (zoom: number): void => {
     map.setZoom(zoom);


### PR DESCRIPTION
## Summary
Fixes visual lag where high-activity hotspot overlays drift from their geographic positions during map panning operations.

## Problem
HTML overlays for high-activity hotspots (`level=high` or `hasBreaking=true`) were only updating positions on a throttled 100ms delay. During map drag operations, this caused overlays to maintain their screen position while the map moved underneath, resulting in a "drift and snap" effect where markers would float away from their true locations then jump back when the update triggered.

## Solution
- Added `updateHotspotPositions()` method that synchronizes overlay positions with the map viewport in real-time during movement
- Bound method to the map `'move'` event for frame-by-frame position updates during drag operations
- Eliminated the 100ms throttle delay for position calculations during active map movement

## Changes
- **Added** `updateHotspotPositions()` method for real-time overlay position synchronization
- **Added** `'move'` event listener to trigger position updates during map drag/pan
- **Fixed** drifting issue for high-activity and breaking hotspot markers
- **Added** dev mode helper to force 3 random hotspots as `breaking` for easier overlay behavior testing (for some reason they just weren't appearing on localhost)


https://github.com/user-attachments/assets/a1cfe749-69bb-499c-b396-24054e7891ce


https://github.com/user-attachments/assets/59c4265a-0667-4ea9-a657-a4f67f983f1e

