### PR TITLE
Improve Vite chunk splitting and update documentation metadata

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -7,9 +7,9 @@ AI-powered real-time global intelligence dashboard aggregating news, markets, ge
 ![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=flat&logo=typescript&logoColor=white)
 ![Vite](https://img.shields.io/badge/Vite-646CFF?style=flat&logo=vite&logoColor=white)
 ![D3.js](https://img.shields.io/badge/D3.js-F9A03C?style=flat&logo=d3.js&logoColor=white)
-![Version](https://img.shields.io/badge/version-1.7.0-blue)
+![Version](https://img.shields.io/badge/version-2.1.4-blue)
 
-![World Monitor Dashboard](new-world-monitor.png)
+![World Monitor Dashboard](../new-world-monitor.png)
 
 ## Platform Variants
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -132,9 +132,22 @@ export default defineConfig({
   build: {
     rollupOptions: {
       output: {
-        manualChunks: {
-          'd3': ['d3'],
-          'topojson': ['topojson-client'],
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            if (id.includes('/@xenova/transformers/') || id.includes('/onnxruntime-web/')) {
+              return 'ml';
+            }
+            if (id.includes('/@deck.gl/') || id.includes('/maplibre-gl/') || id.includes('/h3-js/')) {
+              return 'map';
+            }
+            if (id.includes('/d3/')) {
+              return 'd3';
+            }
+            if (id.includes('/topojson-client/')) {
+              return 'topojson';
+            }
+          }
+          return undefined;
         },
       },
     },


### PR DESCRIPTION
### Motivation
- Reduce main bundle pressure by splitting large third-party libraries into logical chunks to improve load/ caching behavior during production builds.
- Keep documentation accurate and ensure assets referenced from `docs/` resolve correctly.

### Description
- Replaced static `manualChunks` object in `vite.config.ts` with a function-based splitter that creates `ml` for ML deps (`@xenova/transformers`, `onnxruntime-web`), `map` for map/visualization deps (`@deck.gl`, `maplibre-gl`, `h3-js`), and preserves dedicated `d3` and `topojson` chunks.
- Updated `docs/DOCUMENTATION.md` to bump the version badge to `2.1.4` and fixed the dashboard image path to `../new-world-monitor.png` so it loads when viewing files from the `docs/` folder.
- Changes applied to `vite.config.ts` and `docs/DOCUMENTATION.md` and committed to the current branch.

### Testing
- Ran `npm run typecheck` and it completed successfully.
- Ran `npm run build` and the production build succeeded; rollup emitted warnings about `eval` in a dependency and some chunks >500 kB but build artifacts were produced.
- Ran `npm run test:e2e:full` which failed in this environment because Playwright browser binaries are not installed (error: `Executable doesn't exist ... chromium_headless_shell`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f0083f99083338bf9ea2ebbefd191)