### PR TITLE
Secure local API sidecar and fix credential injection for desktop runtime

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -245,6 +245,17 @@ async function dispatch(requestUrl, req, routes, context) {
   if (requestUrl.pathname === '/api/service-status') {
     return handleLocalServiceStatus(context);
   }
+
+  // Security: Verify local API token if configured
+  const expectedToken = process.env.LOCAL_API_TOKEN;
+  if (expectedToken) {
+    const authHeader = req.headers.authorization || '';
+    if (authHeader !== `Bearer ${expectedToken}`) {
+      context.logger.warn(`[local-api] unauthorized access attempt to ${requestUrl.pathname}`);
+      return json({ error: 'Unauthorized' }, 401);
+    }
+  }
+
   if (requestUrl.pathname === '/api/local-status') {
     return json({
       success: true,


### PR DESCRIPTION
Monitoring the desktop runtime revealed that features like AI summarization or conflict tracking were inaccessible because the sidecar process wasn't receiving the necessary API keys from the Tauri vault. This PR addresses that issue and also secures the local API server, which was previously listening on a public port without authentication.

Major updates included:
- Updated the Tauri backend to inject all supported secrets from the keyring into the sidecar's environment variables. This enables features like Groq and ACLED to work correctly on the desktop.
- Implemented a token-based authentication mechanism (`LOCAL_API_TOKEN`) for the local API server to prevent unauthorized access from other local processes.
- Patched the frontend's `fetch` implementation to automatically retrieve the token from the backend and authenticate requests to the secured sidecar.

Functionality and security are significantly improved for local intelligence analysis with these changes. For health checks, I've kept the `service-status` endpoint public to maintain compatibility with existing monitoring logic.