### PR TITLE
Fix: constrain layers menu height in DeckGLMap

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -2164,7 +2164,7 @@ export class DeckGLMap {
         <button class="layer-help-btn" title="Layer Guide">?</button>
         <button class="toggle-collapse">&#9660;</button>
       </div>
-      <div class="toggle-list" style="max-height: 32vh; overflow-y: auto; scrollbar-width: thin;>
+      <div class="toggle-list" style="max-height: 32vh; overflow-y: auto; scrollbar-width: thin;">
         ${layerConfig.map(({ key, label, icon }) => `
           <label class="layer-toggle" data-layer="${key}">
             <input type="checkbox" ${this.state.layers[key as keyof MapLayers] ? 'checked' : ''}>


### PR DESCRIPTION
I noticed a small UI bug where the Layers dropdown menu becomes too tall causing it to underlap the Global Situation and also overlap the time slider header. Also I made the scroll bar a little thinner it looks nice

This PR should fix it .
Fixed UI:
<img width="1892" height="537" alt="Screenshot 2026-02-14 235518" src="https://github.com/user-attachments/assets/01e96b51-13bf-4d8a-89f7-c944ecee6722" />
<img width="1887" height="537" alt="Screenshot 2026-02-14 235529" src="https://github.com/user-attachments/assets/cf605260-d33a-4400-9d26-df80f74193a9" />
