### PR TITLE
fix: resolve z-index conflict between pinned map and panels grid

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -516,6 +516,8 @@ body.animations-paused *::after {
   align-content: start;
   align-items: stretch;
   min-height: 0;
+  position: relative;
+  z-index: 1; /* This ensures panels scroll UNDER the pinned map (z-index: 100) */
 }
 
 .panel {


### PR DESCRIPTION
**Description:** I fixed a visual bug where the cards were overlapping the map when using the "Pin" option. Now the cards slide correctly underneath the map when scrolling.

**Before:** 
<img width="1914" height="947" alt="error" src="https://github.com/user-attachments/assets/add5b838-b15c-46d9-adea-aff063563af4" />

**and After:**
<img width="1919" height="929" alt="Correction" src="https://github.com/user-attachments/assets/421fb4af-1851-4f8e-a422-3d095ddb9c48" />