### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug Report
+description: Report a bug in World Monitor
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the sections below so we can reproduce and fix it.
+
+  - type: dropdown
+    id: variant
+    attributes:
+      label: Variant
+      description: Which variant are you using?
+      options:
+        - worldmonitor.app (Full / Geopolitical)
+        - tech.worldmonitor.app (Tech / Startup)
+        - Desktop app (Windows)
+        - Desktop app (macOS)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of the app is affected?
+      options:
+        - Map / Globe
+        - News panels / RSS feeds
+        - AI Insights / World Brief
+        - Market Radar / Crypto
+        - Service Status
+        - Trending Keywords
+        - Country Brief pages
+        - Live video streams
+        - Desktop app (Tauri)
+        - Settings / API keys
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: A clear description of what the bug is.
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / Console errors
+      description: If applicable, add screenshots or paste browser console errors.
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser & OS
+      description: e.g. Chrome 120 on Windows 11, Safari 17 on macOS Sonoma
+      placeholder: Chrome 120 on Windows 11

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/koala73/worldmonitor/blob/main/docs/DOCUMENTATION.md
+    about: Read the full documentation before opening an issue
+  - name: Discussions
+    url: https://github.com/koala73/worldmonitor/discussions
+    about: Ask questions and share ideas in Discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for World Monitor? We'd love to hear it!
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Feature area
+      description: Which area does this feature relate to?
+      options:
+        - Map / Globe / Data layers
+        - News panels / RSS feeds
+        - AI / Intelligence analysis
+        - Market data / Crypto
+        - Desktop app
+        - UI / UX
+        - API / Backend
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the feature you'd like.
+      placeholder: I'd like to see...
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem it solves
+      description: What problem does this feature address? What's the use case?
+      placeholder: This would help with...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any alternative solutions or workarounds?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any mockups, screenshots, links, or references that help illustrate the idea.

--- a/.github/ISSUE_TEMPLATE/new_data_source.yml
+++ b/.github/ISSUE_TEMPLATE/new_data_source.yml
@@ -1,0 +1,68 @@
+name: New Data Source
+description: Suggest a new RSS feed, API, or map layer
+labels: ["data-source"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        World Monitor aggregates 100+ feeds and data layers. Suggest a new one!
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Source type
+      description: What kind of data source is this?
+      options:
+        - RSS / News feed
+        - API integration
+        - Map layer (geospatial data)
+        - Live video stream
+        - Status page
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: variant
+    attributes:
+      label: Target variant
+      description: Which variant should this appear in?
+      options:
+        - Full (Geopolitical)
+        - Tech (Startup)
+        - Both
+    validations:
+      required: true
+
+  - type: input
+    id: source-name
+    attributes:
+      label: Source name
+      description: Name of the source or organization.
+      placeholder: e.g. RAND Corporation, CoinDesk, USGS
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: Feed / API URL
+      description: Direct URL to the RSS feed, API endpoint, or data source.
+      placeholder: https://example.com/rss
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Why add this source?
+      description: What value does this source bring? What does it cover that existing sources don't?
+      placeholder: This source provides coverage of...
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional notes
+      description: Any details about rate limits, authentication requirements, data format, or category placement.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] New data source / feed
+- [ ] New map layer
+- [ ] Refactor / code cleanup
+- [ ] Documentation
+- [ ] CI / Build / Infrastructure
+
+## Affected areas
+
+- [ ] Map / Globe
+- [ ] News panels / RSS feeds
+- [ ] AI Insights / World Brief
+- [ ] Market Radar / Crypto
+- [ ] Desktop app (Tauri)
+- [ ] API endpoints (`/api/*`)
+- [ ] Config / Settings
+- [ ] Other: <!-- specify -->
+
+## Checklist
+
+- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
+- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
+- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
+- [ ] No API keys or secrets committed
+- [ ] TypeScript compiles without errors (`npm run typecheck`)
+
+## Screenshots
+
+<!-- If applicable, add screenshots or screen recordings -->


### PR DESCRIPTION
## Summary

- Adds structured GitHub issue templates (bug report, feature request, new data source)
- Adds a PR template with checklist tailored to WorldMonitor workflows
- Disables blank issues and links to docs/discussions

## Templates

| Template | Purpose |
|----------|---------|
| **Bug Report** | Variant selector, affected area dropdown, repro steps, browser/OS info |
| **Feature Request** | Feature area dropdown, problem description, alternatives |
| **New Data Source** | Source type, target variant, feed URL, justification |
| **PR Template** | Change type checkboxes, affected areas, RSS allowlist reminder |
| **config.yml** | Disables blank issues, links to docs and discussions |

## Test plan

- [x] Open "New Issue" on the repo and verify all 3 templates appear
- [x] Verify blank issues are disabled
- [x] Open a new PR and verify the PR template auto-populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)