### PR TITLE
fix: remove overly broad CORS origin regex

### DIFF
--- a/api/_cors.js
+++ b/api/_cors.js
@@ -1,7 +1,6 @@
 const ALLOWED_ORIGIN_PATTERNS = [
   /^https:\/\/(.*\.)?worldmonitor\.app$/,
   /^https:\/\/worldmonitor-[a-z0-9-]+-elie-habib-projects\.vercel\.app$/,
-  /^https:\/\/worldmonitor-[a-z0-9-]+\.vercel\.app$/,
   /^https?:\/\/localhost(:\d+)?$/,
   /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
   /^https:\/\/tauri\.localhost(:\d+)?$/,


### PR DESCRIPTION
## Summary
- Removes `/worldmonitor.*\.vercel\.app/` CORS pattern from `api/_cors.js` and `api/rss-proxy.js`
- This pattern matched **any** Vercel deployment starting with "worldmonitor", allowing unauthorized origins to bypass CORS and consume server-side API keys (Finnhub, FRED, ACLED, Wingbits, Cloudflare)
- The owner-scoped pattern (`*-elie-habib-projects.vercel.app`) on the preceding line already covers all legitimate preview deployments

## Test plan
- [ ] Verify production site (`worldmonitor.app`) still works
- [ ] Verify Vercel preview deployments still pass CORS checks
- [ ] Verify `localhost` dev server still works
- [ ] Confirm an arbitrary `worldmonitor-test.vercel.app` origin is now rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)