### PR TITLE
fix: gate SignalModal auto-popup on findings toggle

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -3621,13 +3621,13 @@ export class App {
           if (surgeAlerts.length > 0) {
             const surgeSignals = surgeAlerts.map(surgeAlertToSignal);
             addToSignalHistory(surgeSignals);
-            this.signalModal?.show(surgeSignals);
+            if (this.findingsBadge?.isEnabled()) this.signalModal?.show(surgeSignals);
           }
           const foreignAlerts = detectForeignMilitaryPresence(flightData.flights);
           if (foreignAlerts.length > 0) {
             const foreignSignals = foreignAlerts.map(foreignPresenceToSignal);
             addToSignalHistory(foreignSignals);
-            this.signalModal?.show(foreignSignals);
+            if (this.findingsBadge?.isEnabled()) this.signalModal?.show(foreignSignals);
           }
         }
       } catch (error) {
@@ -3991,13 +3991,13 @@ export class App {
         if (surgeAlerts.length > 0) {
           const surgeSignals = surgeAlerts.map(surgeAlertToSignal);
           addToSignalHistory(surgeSignals);
-          this.signalModal?.show(surgeSignals);
+          if (this.findingsBadge?.isEnabled()) this.signalModal?.show(surgeSignals);
         }
         const foreignAlerts = detectForeignMilitaryPresence(flightData.flights);
         if (foreignAlerts.length > 0) {
           const foreignSignals = foreignAlerts.map(foreignPresenceToSignal);
           addToSignalHistory(foreignSignals);
-          this.signalModal?.show(foreignSignals);
+          if (this.findingsBadge?.isEnabled()) this.signalModal?.show(foreignSignals);
         }
       }
 
@@ -4143,7 +4143,7 @@ export class App {
       const allSignals = [...signals, ...geoSignals, ...keywordSpikeSignals];
       if (allSignals.length > 0) {
         addToSignalHistory(allSignals);
-        this.signalModal?.show(allSignals);
+        if (this.findingsBadge?.isEnabled()) this.signalModal?.show(allSignals);
       }
     } catch (error) {
       console.error('[App] Correlation analysis failed:', error);


### PR DESCRIPTION
## Summary
- PR #97 hid the badge but the `SignalModal` kept auto-opening on new signals — this is what the reporter was still seeing
- Gates all 5 automatic `this.signalModal?.show()` calls behind `this.findingsBadge?.isEnabled()` so disabling Intelligence Findings also suppresses the full-screen popup overlay and sounds
- Signal history is still recorded (`addToSignalHistory`) even when popup is suppressed, so re-enabling the toggle shows them

Closes #89

## Test plan
- [x] Disable Intelligence Findings via PANELS toggle or right-click
- [x] Wait for signal refresh cycle — no full-screen popup should appear
- [x] Re-enable → popups resume on next signal detection
- [x] Build succeeds with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)