### PR TITLE
feat: add developer beta mode for T5-small evaluation

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -12,6 +12,7 @@ import {
   STORAGE_KEYS,
   SITE_VARIANT,
 } from '@/config';
+import { BETA_MODE } from '@/config/beta';
 import { fetchCategoryFeeds, fetchMultipleStocks, fetchCrypto, fetchPredictions, fetchEarthquakes, fetchWeatherAlerts, fetchFredData, fetchInternetOutages, isOutagesConfigured, fetchAisSignals, initAisStream, getAisStatus, disconnectAisStream, isAisConfigured, fetchCableActivity, fetchProtestEvents, getProtestStatus, fetchFlightDelays, fetchMilitaryFlights, fetchMilitaryVessels, initMilitaryVesselStream, isMilitaryVesselTrackingConfigured, initDB, updateBaseline, calculateDeviation, addToSignalHistory, saveSnapshot, cleanOldSnapshots, analysisWorker, fetchPizzIntStatus, fetchGdeltTensions, fetchNaturalEvents, fetchRecentAwards, fetchOilAnalytics, fetchCyberThreats, drainTrendingSignals } from '@/services';
 import { fetchCountryMarkets } from '@/services/polymarket';
 import { mlWorker } from '@/services/ml-worker';
@@ -1699,7 +1700,7 @@ export class App {
               <span class="variant-label">${t('header.finance')}</span>
             </a>
           </div>
-          <span class="logo">MONITOR</span><span class="version">v${__APP_VERSION__}</span>
+          <span class="logo">MONITOR</span><span class="version">v${__APP_VERSION__}</span>${BETA_MODE ? '<span class="beta-badge">BETA</span>' : ''}
           <a href="https://x.com/eliehabib" target="_blank" rel="noopener" class="credit-link">
             <svg class="x-logo" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
             <span class="credit-text">@eliehabib</span>

--- a/src/config/beta.ts
+++ b/src/config/beta.ts
@@ -1,0 +1,2 @@
+export const BETA_MODE = typeof window !== 'undefined'
+  && localStorage.getItem('worldmonitor-beta-mode') === 'true';

--- a/src/config/ml-config.ts
+++ b/src/config/ml-config.ts
@@ -42,6 +42,15 @@ export const MODEL_CONFIGS: ModelConfig[] = [
     task: 'text2text-generation',
   },
   {
+    id: 'summarization-beta',
+    name: 'Flan-T5-small',
+    hfModel: 'Xenova/flan-t5-small',
+    size: 60_000_000,
+    priority: 3,
+    required: false,
+    task: 'text2text-generation',
+  },
+  {
     id: 'ner',
     name: 'BERT-NER',
     hfModel: 'Xenova/bert-base-NER',

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,6 +104,20 @@ app
   count: getCellCount,
 };
 
+// Beta mode toggle: type `beta=true` / `beta=false` in console
+Object.defineProperty(window, 'beta', {
+  get() {
+    const on = localStorage.getItem('worldmonitor-beta-mode') === 'true';
+    console.log(`[Beta] ${on ? 'ON' : 'OFF'}`);
+    return on;
+  },
+  set(v: boolean) {
+    if (v) localStorage.setItem('worldmonitor-beta-mode', 'true');
+    else localStorage.removeItem('worldmonitor-beta-mode');
+    location.reload();
+  },
+});
+
 if (!('__TAURI_INTERNALS__' in window) && !('__TAURI__' in window)) {
   import('virtual:pwa-register').then(({ registerSW }) => {
     registerSW({

--- a/src/services/ml-worker.ts
+++ b/src/services/ml-worker.ts
@@ -267,9 +267,9 @@ class MLWorkerManager {
   /**
    * Generate summaries for texts
    */
-  async summarize(texts: string[]): Promise<string[]> {
+  async summarize(texts: string[], modelId?: string): Promise<string[]> {
     if (!this.isReady) throw new Error('ML Worker not ready');
-    return this.request<string[]>('summarize', { texts });
+    return this.request<string[]>('summarize', { texts, ...(modelId && { modelId }) });
   }
 
   /**

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -392,6 +392,20 @@ canvas,
   opacity: 1;
 }
 
+.beta-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
+  padding: 1px 7px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: #0a0a0a;
+  background: #f59e0b;
+  border-radius: 8px;
+  vertical-align: middle;
+}
+
 @keyframes update-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.6; }

--- a/src/workers/ml.worker.ts
+++ b/src/workers/ml.worker.ts
@@ -38,6 +38,7 @@ interface SummarizeMessage {
   type: 'summarize';
   id: string;
   texts: string[];
+  modelId?: string;
 }
 
 interface SentimentMessage {
@@ -145,9 +146,9 @@ async function embedTexts(texts: string[]): Promise<number[][]> {
   return results;
 }
 
-async function summarizeTexts(texts: string[]): Promise<string[]> {
-  await loadModel('summarization');
-  const pipe = loadedPipelines.get('summarization')!;
+async function summarizeTexts(texts: string[], modelId = 'summarization'): Promise<string[]> {
+  await loadModel(modelId);
+  const pipe = loadedPipelines.get(modelId)!;
 
   const results: string[] = [];
   for (const text of texts) {
@@ -310,7 +311,7 @@ self.onmessage = async (event: MessageEvent<MLWorkerMessage>) => {
       }
 
       case 'summarize': {
-        const summaries = await summarizeTexts(message.texts);
+        const summaries = await summarizeTexts(message.texts, message.modelId);
         self.postMessage({
           type: 'summarize-result',
           id: message.id,


### PR DESCRIPTION
Console-activated (beta=true) mode that swaps browser summarization to Flan-T5-small (60MB) as first provider with comparison logging against Groq. Persists via localStorage, shows amber BETA badge in header.

## Summary

<!-- Brief description of what this PR does -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other: <!-- specify -->

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [ ] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots

<!-- If applicable, add screenshots or screen recordings -->
