### PR TITLE
fix: use viewport width only for mobile detection (fixes touch notebo…

### DIFF
--- a/src/components/MobileWarningModal.ts
+++ b/src/components/MobileWarningModal.ts
@@ -1,4 +1,5 @@
 import { t } from '@/services/i18n';
+import { isMobileDevice } from '@/utils';
 
 const STORAGE_KEY = 'mobile-warning-dismissed';
 
@@ -61,16 +62,8 @@ export class MobileWarningModal {
   }
 
   public static shouldShow(): boolean {
-    // Check if already dismissed permanently
-    if (localStorage.getItem(STORAGE_KEY) === 'true') {
-      return false;
-    }
-
-    // Check if mobile device (screen width < 768px or touch-primary device)
-    const isMobileWidth = window.innerWidth < 768;
-    const isTouchDevice = window.matchMedia('(pointer: coarse)').matches;
-
-    return isMobileWidth || isTouchDevice;
+    if (localStorage.getItem(STORAGE_KEY) === 'true') return false;
+    return isMobileDevice();
   }
 
   public getElement(): HTMLElement {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -6837,8 +6837,8 @@ a.prediction-link:hover {
    Mobile Touch Optimization
    ========================================================================== */
 
-/* Touch device detection - applies to both small screens and touch devices */
-@media (pointer: coarse), (max-width: 768px) {
+/* Narrow viewport only - touch-capable desktops (e.g. touch notebooks) keep desktop layout. Keep 768 in sync with MOBILE_BREAKPOINT_PX in src/utils/index.ts */
+@media (max-width: 768px) {
   /* Expand touch targets for all map markers using ::before pseudo-element */
   /* This creates an invisible touch area around small markers */
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -113,10 +113,15 @@ export function generateId(): string {
   return `id-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
+/** Breakpoint (px): below this width the app uses the simplified mobile layout. Must match CSS @media (max-width: …). */
+export const MOBILE_BREAKPOINT_PX = 768;
+
+/**
+ * モバイル表示とするか。画面幅のみで判定（タッチ端末は含めない）。
+ * タッチパネル付きノートPCではデスクトップレイアウトになる。
+ */
 export function isMobileDevice(): boolean {
-  const isMobileWidth = window.innerWidth < 768;
-  const isTouchDevice = window.matchMedia('(pointer: coarse)').matches;
-  return isMobileWidth || isTouchDevice;
+  return window.innerWidth < MOBILE_BREAKPOINT_PX;
 }
 
 export function chunkArray<T>(items: T[], size: number): T[][] {


### PR DESCRIPTION
…oks)

- Remove (pointer: coarse) from mobile detection so touch-capable desktops (e.g. ROG Flow X13) get desktop layout instead of mobile
- Define MOBILE_BREAKPOINT_PX (768) in utils and use in isMobileDevice(); CSS @media (max-width: 768px) kept in sync
- MobileWarningModal uses isMobileDevice() for consistent behavior

Ref: https://github.com/koala73/worldmonitor/discussions/94

## Summary

<!-- Brief description of what this PR does -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [x] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other: <!-- specify -->

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [ ] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots

<!-- If applicable, add screenshots or screen recordings -->
