### PR TITLE
fix(pwa): disable default navigate fallback to keep HTML network-first

### DIFF
--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -35,6 +35,11 @@ describe('deploy/cache configuration guardrails', () => {
     assert.doesNotMatch(viteConfigSource, /globPatterns:\s*\['\*\*\/\*\.\{js,css,html/);
   });
 
+  it('explicitly disables navigateFallback when HTML is not precached', () => {
+    assert.match(viteConfigSource, /navigateFallback:\s*null/);
+    assert.doesNotMatch(viteConfigSource, /navigateFallbackDenylist:\s*\[/);
+  });
+
   it('uses network-first runtime caching for navigation requests', () => {
     assert.match(viteConfigSource, /request\.mode === 'navigate'/);
     assert.match(viteConfigSource, /handler:\s*'NetworkFirst'/);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -246,8 +246,7 @@ export default defineConfig({
       workbox: {
         globPatterns: ['**/*.{js,css,ico,png,svg,woff2}'],
         globIgnores: ['**/ml-*.js', '**/onnx*.wasm'],
-        navigateFallback: '/index.html',
-        navigateFallbackDenylist: [/^\/api\//, /^\/settings/],
+        navigateFallback: null,
         skipWaiting: true,
         clientsClaim: true,
         cleanupOutdatedCaches: true,


### PR DESCRIPTION
## Summary
- keep PWA precache HTML-free by using:
  - `globPatterns: ['**/*.{js,css,ico,png,svg,woff2}']`
- explicitly disable vite-plugin-pwa’s default navigation fallback:
  - `navigateFallback: null`
- remove `navigateFallbackDenylist` because no fallback route is registered
- add deploy guardrail test asserting fallback is explicitly disabled

## Why
`vite-plugin-pwa` (`generateSW`) defaults `workbox.navigateFallback` to `index.html`.
Without an explicit override, generated `sw.js` injects `NavigationRoute(createHandlerBoundToURL("index.html"))`, which conflicts with network-first HTML strategy and can fail at runtime when `index.html` is not in the precache manifest.

## Validation
- `npm run typecheck`
- `npm run test:data`
- `npm run test:sidecar`
- `npm run test:e2e:runtime`
- `npm run build`
- verified generated `dist/sw.js` has:
  - no `NavigationRoute(createHandlerBoundToURL("index.html"))`
  - no `index.html` precache entry

## Current PR Check Status
The only failing PR checks are Vercel deployment checks requiring org-level authorization for this forked PR.
