### PR TITLE
Update infrastructure-cascade.ts

### DIFF
--- a/src/services/infrastructure-cascade.ts
+++ b/src/services/infrastructure-cascade.ts
@@ -576,7 +576,16 @@ function getCapacityForCountry(sourceId: string, countryCode: string): number {
     const countryData = cable?.countriesServed?.find(cs => cs.country === countryCode);
     return countryData?.capacityShare || 0;
   }
-  return 0.1;
+  const graph = buildDependencyGraph();
+  const countryId = `country:${countryCode}`;
+  const outgoing = graph.outgoing.get(sourceId) || [];
+  const direct = outgoing.filter(e => e.to === countryId);
+
+  if (direct.length > 0) {
+    const effective = direct.map(e => e.strength * (1 - (e.redundancy || 0)));
+    return Math.max(...effective);
+  }
+  return 0;
 }
 
 function findRedundancies(sourceId: string): CascadeResult['redundancies'] {


### PR DESCRIPTION
FIX: Previously, non-cable sources always returned 0.1 (10%), which made pipelines/chokepoints/ports always show 10% on the site. Now uses the hardcoded strength/redundancy values already encoded, or falls back to 0.

## Summary

Fixes the % Capacity effect calculated and displayed on infra cascade feature. Before, it correctly calculated the effect for purposes of color/display order, but showed wrong % capacity effect.

## Type of change

Changed the value returned by infra cascade for non-cable infra.
 
## Affected areas

Only the % capacity value in infra cascade is affected.

## Checklist

Didn't test in dev environment, only changed the # returned.
