### PR TITLE
Fix memory leak: properly clear clock interval on cleanup

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -193,6 +193,7 @@ export class App {
   private readonly isDesktopApp = isDesktopRuntime();
   private readonly UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
   private updateCheckIntervalId: ReturnType<typeof setInterval> | null = null;
+  private clockIntervalId: ReturnType<typeof setInterval> | null = null;
 
   constructor(containerId: string) {
     const el = document.getElementById(containerId);
@@ -612,7 +613,7 @@ export class App {
       el.textContent = new Date().toUTCString().replace('GMT', 'UTC');
     };
     tick();
-    setInterval(tick, 1000);
+    this.clockIntervalId = setInterval(tick, 1000);
   }
 
   private setupMobileWarning(): void {
@@ -1988,6 +1989,11 @@ export class App {
     if (this.updateCheckIntervalId) {
       clearInterval(this.updateCheckIntervalId);
       this.updateCheckIntervalId = null;
+    }
+
+    if (this.clockIntervalId) {
+      clearInterval(this.clockIntervalId);
+      this.clockIntervalId = null;
     }
 
     // Clear all refresh timeouts


### PR DESCRIPTION
## Summary

Fixes a memory leak where the clock update interval was not being cleared when the app is destroyed. The interval ID is now stored and properly cleaned up in the `destroy()` method, matching the pattern already used for the update check interval.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Memory management / cleanup

## Details

The `setupClock()` method was creating a recurring interval every second to update the UTC time display, but the interval ID was not being stored. This meant the interval would continue running even after the app was destroyed, causing a memory leak.

Changes:
- Added `clockIntervalId` property to store the interval reference
- Updated `setupClock()` to assign the interval ID instead of discarding it
- Added cleanup logic in `destroy()` to clear the interval and reset the reference

## Checklist

- [x] TypeScript compiles without errors
- [x] Follows existing cleanup patterns in the codebase

