### PR TITLE
Extract layer-to-source mapping to config constant

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -11,6 +11,7 @@ import {
   MOBILE_DEFAULT_MAP_LAYERS,
   STORAGE_KEYS,
   SITE_VARIANT,
+  LAYER_TO_SOURCE,
 } from '@/config';
 import { BETA_MODE } from '@/config/beta';
 import { fetchCategoryFeeds, getFeedFailures, fetchMultipleStocks, fetchCrypto, fetchPredictions, fetchEarthquakes, fetchWeatherAlerts, fetchFredData, fetchInternetOutages, isOutagesConfigured, fetchAisSignals, initAisStream, getAisStatus, disconnectAisStream, isAisConfigured, fetchCableActivity, fetchProtestEvents, getProtestStatus, fetchFlightDelays, fetchMilitaryFlights, fetchMilitaryVessels, initMilitaryVesselStream, isMilitaryVesselTrackingConfigured, initDB, updateBaseline, calculateDeviation, addToSignalHistory, saveSnapshot, cleanOldSnapshots, analysisWorker, fetchPizzIntStatus, fetchGdeltTensions, fetchNaturalEvents, fetchRecentAwards, fetchOilAnalytics, fetchCyberThreats, drainTrendingSignals } from '@/services';
@@ -694,21 +695,7 @@ export class App {
   }
 
   private syncDataFreshnessWithLayers(): void {
-    // Map layer toggles to data source IDs
-    const layerToSource: Partial<Record<keyof MapLayers, DataSourceId[]>> = {
-      military: ['opensky', 'wingbits'],
-      ais: ['ais'],
-      natural: ['usgs'],
-      weather: ['weather'],
-      outages: ['outages'],
-      cyberThreats: ['cyber_threats'],
-      protests: ['acled'],
-      ucdpEvents: ['ucdp_events'],
-      displacement: ['unhcr'],
-      climate: ['climate'],
-    };
-
-    for (const [layer, sourceIds] of Object.entries(layerToSource)) {
+    for (const [layer, sourceIds] of Object.entries(LAYER_TO_SOURCE)) {
       const enabled = this.mapLayers[layer as keyof MapLayers] ?? false;
       for (const sourceId of sourceIds) {
         dataFreshness.setEnabled(sourceId as DataSourceId, enabled);
@@ -732,19 +719,7 @@ export class App {
       saveToStorage(STORAGE_KEYS.mapLayers, this.mapLayers);
 
       // Sync data freshness tracker
-      const layerToSource: Partial<Record<keyof MapLayers, DataSourceId[]>> = {
-        military: ['opensky', 'wingbits'],
-        ais: ['ais'],
-        natural: ['usgs'],
-        weather: ['weather'],
-        outages: ['outages'],
-        cyberThreats: ['cyber_threats'],
-        protests: ['acled'],
-        ucdpEvents: ['ucdp_events'],
-        displacement: ['unhcr'],
-        climate: ['climate'],
-      };
-      const sourceIds = layerToSource[layer];
+      const sourceIds = LAYER_TO_SOURCE[layer];
       if (sourceIds) {
         for (const sourceId of sourceIds) {
           dataFreshness.setEnabled(sourceId, enabled);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -41,6 +41,7 @@ export {
   DEFAULT_PANELS,
   DEFAULT_MAP_LAYERS,
   MOBILE_DEFAULT_MAP_LAYERS,
+  LAYER_TO_SOURCE,
 } from './panels';
 
 // ============================================

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -1,4 +1,5 @@
 import type { PanelConfig, MapLayers } from '@/types';
+import type { DataSourceId } from '@/services/data-freshness';
 import { SITE_VARIANT } from './variant';
 
 // ============================================
@@ -373,6 +374,24 @@ const FINANCE_MOBILE_MAP_LAYERS: MapLayers = {
 export const DEFAULT_PANELS = SITE_VARIANT === 'tech' ? TECH_PANELS : SITE_VARIANT === 'finance' ? FINANCE_PANELS : FULL_PANELS;
 export const DEFAULT_MAP_LAYERS = SITE_VARIANT === 'tech' ? TECH_MAP_LAYERS : SITE_VARIANT === 'finance' ? FINANCE_MAP_LAYERS : FULL_MAP_LAYERS;
 export const MOBILE_DEFAULT_MAP_LAYERS = SITE_VARIANT === 'tech' ? TECH_MOBILE_MAP_LAYERS : SITE_VARIANT === 'finance' ? FINANCE_MOBILE_MAP_LAYERS : FULL_MOBILE_MAP_LAYERS;
+
+/**
+ * Maps map-layer toggle keys to their corresponding data-freshness source IDs.
+ * Used by both syncDataFreshnessWithLayers() and setupMapLayerHandlers() in App.ts
+ * so the mapping is defined once and stays in sync.
+ */
+export const LAYER_TO_SOURCE: Partial<Record<keyof MapLayers, DataSourceId[]>> = {
+  military: ['opensky', 'wingbits'],
+  ais: ['ais'],
+  natural: ['usgs'],
+  weather: ['weather'],
+  outages: ['outages'],
+  cyberThreats: ['cyber_threats'],
+  protests: ['acled'],
+  ucdpEvents: ['ucdp_events'],
+  displacement: ['unhcr'],
+  climate: ['climate'],
+};
 
 // Monitor palette — fixed category colors persisted to localStorage (not theme-dependent)
 export const MONITOR_COLORS = [


### PR DESCRIPTION
## Summary

Refactors the `layerToSource` mapping from a locally-defined object in `App.ts` into a reusable constant `LAYER_TO_SOURCE` in the config module. This eliminates code duplication where the same mapping was defined twice in `syncDataFreshnessWithLayers()` and `setupMapLayerHandlers()` methods.

## Type of change

- [x] Refactor / code cleanup

## Affected areas

- [x] Config / Settings

## Details

The `layerToSource` mapping, which associates map layer toggles with their corresponding data-freshness source IDs, was previously duplicated in two locations within `App.ts`. This change:

1. Defines the mapping once in `src/config/panels.ts` as `LAYER_TO_SOURCE`
2. Exports it from `src/config/index.ts`
3. Replaces both inline definitions in `App.ts` with references to the constant
4. Adds proper TypeScript typing and documentation

This ensures the mapping stays in sync across all usages and makes it easier to maintain in the future.

## Checklist

- [x] Refactor maintains existing functionality
- [x] TypeScript compiles without errors
- [x] No API keys or secrets involved

https://claude.ai/code/session_014jutAseJaTSjM2mYWqCzfU