### PR TITLE
Add Brotli pre-compression for Vite build assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,6 +967,22 @@ Every API edge function includes `Cache-Control` headers that enable Vercel's CD
 
 Static assets use content-hash filenames with 1-year immutable cache headers. The service worker file (`sw.js`) is never cached (`max-age=0, must-revalidate`) to ensure update detection.
 
+### Brotli Pre-Compression (Build-Time)
+
+`vite build` now emits pre-compressed Brotli artifacts (`*.br`) for static assets larger than 1KB (JS, CSS, HTML, SVG, JSON, XML, TXT, WASM). This reduces transfer size by roughly 20–30% vs gzip-only delivery when the edge can serve Brotli directly.
+
+For the Hetzner Nginx origin, enable static compressed file serving so `dist/*.br` files are returned without runtime recompression:
+
+```nginx
+gzip on;
+gzip_static on;
+
+brotli on;
+brotli_static on;
+```
+
+Cloudflare will negotiate Brotli automatically for compatible clients when the origin/edge has Brotli assets available.
+
 ### Railway Relay Compression
 
 All relay server responses pass through `gzipSync` when the client accepts gzip and the payload exceeds 1KB. This applies to OpenSky aircraft JSON, RSS XML feeds, UCDP event data, AIS snapshots, and health checks — reducing wire size by approximately 80%.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,41 @@
 import { defineConfig, type Plugin } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
-import { resolve } from 'path';
+import { resolve, dirname, extname } from 'path';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { brotliCompress } from 'zlib';
+import { promisify } from 'util';
 import pkg from './package.json';
 
 const isE2E = process.env.VITE_E2E === '1';
+
+
+const brotliCompressAsync = promisify(brotliCompress);
+const BROTLI_EXTENSIONS = new Set(['.js', '.mjs', '.css', '.html', '.svg', '.json', '.txt', '.xml', '.wasm']);
+
+function brotliPrecompressPlugin(): Plugin {
+  return {
+    name: 'brotli-precompress',
+    apply: 'build',
+    async writeBundle(outputOptions, bundle) {
+      const outDir = outputOptions.dir;
+      if (!outDir) return;
+
+      await Promise.all(Object.keys(bundle).map(async (fileName) => {
+        const extension = extname(fileName).toLowerCase();
+        if (!BROTLI_EXTENSIONS.has(extension)) return;
+
+        const sourcePath = resolve(outDir, fileName);
+        const compressedPath = `${sourcePath}.br`;
+        const sourceBuffer = await readFile(sourcePath);
+        if (sourceBuffer.length < 1024) return;
+
+        const compressedBuffer = await brotliCompressAsync(sourceBuffer);
+        await mkdir(dirname(compressedPath), { recursive: true });
+        await writeFile(compressedPath, compressedBuffer);
+      }));
+    },
+  };
+}
 
 const VARIANT_META: Record<string, {
   title: string;
@@ -215,6 +247,7 @@ export default defineConfig({
     htmlVariantPlugin(),
     polymarketPlugin(),
     youtubeLivePlugin(),
+    brotliPrecompressPlugin(),
     VitePWA({
       registerType: 'autoUpdate',
       injectRegister: false,


### PR DESCRIPTION
### Motivation
- Reduce client transfer sizes for static assets by emitting pre-compressed Brotli artifacts at build time so edge/origin can serve `.br` directly.
- Avoid dependency on third-party Vite compression packages when npm registry/policy blocks installation by implementing a small, self-contained build plugin.

### Description
- Added an inlined Vite build plugin `brotliPrecompressPlugin()` to `vite.config.ts` that uses Node's `zlib.brotliCompress` to write `.br` files for emitted assets with extensions `(.js,.mjs,.css,.html,.svg,.json,.txt,.xml,.wasm)` larger than `1024` bytes. 
- Registered the plugin in the Vite `plugins` array so Brotli artifacts are generated automatically during `vite build`.
- Documented build-time Brotli pre-compression and recommended Hetzner Nginx settings (`gzip_static on` and `brotli_static on`) and Cloudflare serving behavior in `README.md` under the Bandwidth Optimization section.

### Testing
- Attempted to install `vite-plugin-compression2` and `vite-plugin-compression`, but both `npm install -D` runs failed with a `403 Forbidden` from the registry in this environment. (expected fallback)
- Ran `npm run build` successfully and observed build completion without errors.
- Verified generated Brotli files exist under `dist/` (examples: `dist/index.html.br`, `dist/settings.html.br`, and multiple `dist/assets/*.br`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997827871e483339853aaae2971d2a3)