### PR TITLE
PERF-010: Debounce Panel.setContent to reduce re-renders

### DIFF
--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -63,6 +63,9 @@ export class Panel {
   private onTouchMove: ((e: TouchEvent) => void) | null = null;
   private onTouchEnd: (() => void) | null = null;
   private onDocMouseUp: (() => void) | null = null;
+  private readonly contentDebounceMs = 150;
+  private pendingContentHtml: string | null = null;
+  private contentDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(options: PanelOptions) {
     this.panelId = options.id;
@@ -286,7 +289,7 @@ export class Panel {
   }
 
   public showLoading(message = t('common.loading')): void {
-    this.content.innerHTML = `
+    this.setContentImmediate(`
       <div class="panel-loading">
         <div class="panel-loading-radar">
           <div class="panel-radar-sweep"></div>
@@ -294,18 +297,18 @@ export class Panel {
         </div>
         <div class="panel-loading-text">${escapeHtml(message)}</div>
       </div>
-    `;
+    `);
   }
 
   public showError(message = t('common.failedToLoad')): void {
-    this.content.innerHTML = `<div class="error-message">${escapeHtml(message)}</div>`;
+    this.setContentImmediate(`<div class="error-message">${escapeHtml(message)}</div>`);
   }
 
   public showConfigError(message: string): void {
     const settingsBtn = isDesktopRuntime()
       ? '<button type="button" class="config-error-settings-btn">Open Settings</button>'
       : '';
-    this.content.innerHTML = `<div class="config-error-message">${escapeHtml(message)}${settingsBtn}</div>`;
+    this.setContentImmediate(`<div class="config-error-message">${escapeHtml(message)}${settingsBtn}</div>`);
     if (isDesktopRuntime()) {
       this.content.querySelector('.config-error-settings-btn')?.addEventListener('click', () => {
         void invokeTauri<void>('open_settings_window_command').catch(() => { });
@@ -329,7 +332,32 @@ export class Panel {
   }
 
   public setContent(html: string): void {
-    this.content.innerHTML = html;
+    if (this.pendingContentHtml === html || this.content.innerHTML === html) {
+      return;
+    }
+
+    this.pendingContentHtml = html;
+    if (this.contentDebounceTimer) {
+      clearTimeout(this.contentDebounceTimer);
+    }
+
+    this.contentDebounceTimer = setTimeout(() => {
+      if (this.pendingContentHtml !== null) {
+        this.setContentImmediate(this.pendingContentHtml);
+      }
+    }, this.contentDebounceMs);
+  }
+
+  private setContentImmediate(html: string): void {
+    if (this.contentDebounceTimer) {
+      clearTimeout(this.contentDebounceTimer);
+      this.contentDebounceTimer = null;
+    }
+
+    this.pendingContentHtml = null;
+    if (this.content.innerHTML !== html) {
+      this.content.innerHTML = html;
+    }
   }
 
   public show(): void {
@@ -399,6 +427,12 @@ export class Panel {
    * Clean up event listeners and resources
    */
   public destroy(): void {
+    if (this.contentDebounceTimer) {
+      clearTimeout(this.contentDebounceTimer);
+      this.contentDebounceTimer = null;
+    }
+    this.pendingContentHtml = null;
+
     if (this.tooltipCloseHandler) {
       document.removeEventListener('click', this.tooltipCloseHandler);
       this.tooltipCloseHandler = null;


### PR DESCRIPTION
### Motivation
- Panels can receive multiple content updates in quick succession, causing many DOM writes and janky re-renders during data bursts.  
- Pairing a debounce with the existing DOM diffing/RAF throttling reduces unnecessary work and smooths the UI.

### Description
- Added a 150ms debounce to `Panel.setContent()` and new private fields (`contentDebounceMs`, `pendingContentHtml`, `contentDebounceTimer`) to buffer rapid updates and apply only the latest payload.  
- `setContent()` now skips no-op updates when the pending or current HTML already matches and resets the timer on rapid calls.  
- Introduced `setContentImmediate()` and switched `showLoading()`, `showError()`, and `showConfigError()` to use it so immediate UI states are not overwritten by stale debounced writes.  
- Extended `destroy()` to clear any pending debounce timers and pending content to avoid delayed updates after teardown.

### Testing
- Ran `npm run typecheck` (i.e. `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699782a113a88333ab664a828cb00b02)