### PR TITLE
Fix refresh scheduler parity after controller extraction

### DIFF
--- a/src/controllers/deep-link-handler.ts
+++ b/src/controllers/deep-link-handler.ts
@@ -1,0 +1,55 @@
+import { dataFreshness } from '@/services/data-freshness';
+
+interface DeepLinkHandlerDeps {
+  getLatestClustersCount: () => number;
+  consumePendingCountry: () => string | null;
+  openCountryStory: (code: string, name: string) => void;
+  openCountryBriefByCode: (code: string, name: string) => void;
+  resolveCountryName: (code: string) => string;
+}
+
+export class DeepLinkHandler {
+  constructor(private readonly deps: DeepLinkHandlerDeps) {}
+
+  public handle(): void {
+    const url = new URL(window.location.href);
+
+    if (url.pathname === '/story' || url.searchParams.has('c')) {
+      const countryCode = url.searchParams.get('c');
+      if (countryCode) {
+        const countryNames: Record<string, string> = {
+          UA: 'Ukraine', RU: 'Russia', CN: 'China', US: 'United States',
+          IR: 'Iran', IL: 'Israel', TW: 'Taiwan', KP: 'North Korea',
+          SA: 'Saudi Arabia', TR: 'Turkey', PL: 'Poland', DE: 'Germany',
+          FR: 'France', GB: 'United Kingdom', IN: 'India', PK: 'Pakistan',
+          SY: 'Syria', YE: 'Yemen', MM: 'Myanmar', VE: 'Venezuela',
+        };
+        const countryName = countryNames[countryCode.toUpperCase()] || countryCode;
+
+        const checkAndOpen = () => {
+          if (dataFreshness.hasSufficientData() && this.deps.getLatestClustersCount() > 0) {
+            this.deps.openCountryStory(countryCode.toUpperCase(), countryName);
+          } else {
+            setTimeout(checkAndOpen, 500);
+          }
+        };
+        setTimeout(checkAndOpen, 2000);
+        history.replaceState(null, '', '/');
+        return;
+      }
+    }
+
+    const deepLinkCountry = this.deps.consumePendingCountry();
+    if (deepLinkCountry) {
+      const cName = this.deps.resolveCountryName(deepLinkCountry);
+      const checkAndOpenBrief = () => {
+        if (dataFreshness.hasSufficientData()) {
+          this.deps.openCountryBriefByCode(deepLinkCountry, cName);
+        } else {
+          setTimeout(checkAndOpenBrief, 500);
+        }
+      };
+      setTimeout(checkAndOpenBrief, 2000);
+    }
+  }
+}

--- a/src/controllers/desktop-updater.ts
+++ b/src/controllers/desktop-updater.ts
@@ -1,0 +1,164 @@
+import { invokeTauri } from '@/services/tauri-bridge';
+
+export type UpdaterOutcome = 'no_update' | 'update_available' | 'open_failed' | 'fetch_failed';
+type DesktopBuildVariant = 'full' | 'tech' | 'finance';
+
+interface DesktopRuntimeInfo {
+  os: string;
+  arch: string;
+}
+
+interface DesktopUpdaterDeps {
+  container: HTMLElement;
+  isDesktopApp: boolean;
+  isDestroyed: () => boolean;
+  getBuildVariant: () => DesktopBuildVariant;
+  updateIntervalMs: number;
+}
+
+export class DesktopUpdater {
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private readonly deps: DesktopUpdaterDeps) {}
+
+  public setup(): void {
+    if (!this.deps.isDesktopApp || this.deps.isDestroyed()) return;
+
+    setTimeout(() => {
+      if (this.deps.isDestroyed()) return;
+      void this.checkForUpdate();
+    }, 5000);
+
+    if (this.intervalId) clearInterval(this.intervalId);
+    this.intervalId = setInterval(() => {
+      if (this.deps.isDestroyed()) return;
+      void this.checkForUpdate();
+    }, this.deps.updateIntervalMs);
+  }
+
+  public teardown(): void {
+    if (!this.intervalId) return;
+    clearInterval(this.intervalId);
+    this.intervalId = null;
+  }
+
+  private logOutcome(outcome: UpdaterOutcome, context: Record<string, unknown> = {}): void {
+    const logger = outcome === 'open_failed' || outcome === 'fetch_failed' ? console.warn : console.info;
+    logger('[updater]', outcome, context);
+  }
+
+  private async checkForUpdate(): Promise<void> {
+    try {
+      const res = await fetch('https://worldmonitor.app/api/version');
+      if (!res.ok) {
+        this.logOutcome('fetch_failed', { status: res.status });
+        return;
+      }
+      const data = await res.json();
+      const remote = data.version as string;
+      if (!remote) {
+        this.logOutcome('fetch_failed', { reason: 'missing_remote_version' });
+        return;
+      }
+
+      const current = __APP_VERSION__;
+      if (!this.isNewerVersion(remote, current)) {
+        this.logOutcome('no_update', { current, remote });
+        return;
+      }
+
+      const dismissKey = `wm-update-dismissed-${remote}`;
+      if (localStorage.getItem(dismissKey)) {
+        this.logOutcome('update_available', { current, remote, dismissed: true });
+        return;
+      }
+
+      const releaseUrl = typeof data.url === 'string' && data.url
+        ? data.url
+        : 'https://github.com/koala73/worldmonitor/releases/latest';
+      this.logOutcome('update_available', { current, remote, dismissed: false });
+      await this.showUpdateBadge(remote, releaseUrl);
+    } catch (error) {
+      this.logOutcome('fetch_failed', { error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+
+  private isNewerVersion(remote: string, current: string): boolean {
+    const r = remote.split('.').map(Number);
+    const c = current.split('.').map(Number);
+    for (let i = 0; i < Math.max(r.length, c.length); i++) {
+      const rv = r[i] ?? 0;
+      const cv = c[i] ?? 0;
+      if (rv > cv) return true;
+      if (rv < cv) return false;
+    }
+    return false;
+  }
+
+  private mapDesktopDownloadPlatform(os: string, arch: string): string | null {
+    const normalizedOs = os.toLowerCase();
+    const normalizedArch = arch.toLowerCase().replace('amd64', 'x86_64').replace('x64', 'x86_64').replace('arm64', 'aarch64');
+    if (normalizedOs === 'windows') return normalizedArch === 'x86_64' ? 'windows-exe' : null;
+    if (normalizedOs === 'macos' || normalizedOs === 'darwin') {
+      if (normalizedArch === 'aarch64') return 'macos-arm64';
+      if (normalizedArch === 'x86_64') return 'macos-x64';
+      return null;
+    }
+    return null;
+  }
+
+  private async resolveUpdateDownloadUrl(releaseUrl: string): Promise<string> {
+    try {
+      const runtimeInfo = await invokeTauri<DesktopRuntimeInfo>('get_desktop_runtime_info');
+      const platform = this.mapDesktopDownloadPlatform(runtimeInfo.os, runtimeInfo.arch);
+      if (platform) {
+        const variant = this.deps.getBuildVariant();
+        return `https://worldmonitor.app/api/download?platform=${platform}&variant=${variant}`;
+      }
+    } catch {
+      // noop fallback
+    }
+    return releaseUrl;
+  }
+
+  private async showUpdateBadge(version: string, releaseUrl: string): Promise<void> {
+    const versionSpan = this.deps.container.querySelector('.version');
+    if (!versionSpan) return;
+    const existingBadge = this.deps.container.querySelector<HTMLElement>('.update-badge');
+    if (existingBadge?.dataset.version === version) return;
+    existingBadge?.remove();
+
+    const url = await this.resolveUpdateDownloadUrl(releaseUrl);
+    const badge = document.createElement('a');
+    badge.className = 'update-badge';
+    badge.dataset.version = version;
+    badge.href = url;
+    badge.target = this.deps.isDesktopApp ? '_self' : '_blank';
+    badge.rel = 'noopener';
+    badge.textContent = `UPDATE v${version}`;
+    badge.addEventListener('click', (e) => {
+      e.preventDefault();
+      if (this.deps.isDesktopApp) {
+        void invokeTauri<void>('open_url', { url }).catch((error) => {
+          this.logOutcome('open_failed', { url, error: error instanceof Error ? error.message : String(error) });
+          window.open(url, '_blank', 'noopener');
+        });
+        return;
+      }
+      window.open(url, '_blank', 'noopener');
+    });
+
+    const dismiss = document.createElement('span');
+    dismiss.className = 'update-badge-dismiss';
+    dismiss.textContent = '\u00d7';
+    dismiss.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      localStorage.setItem(`wm-update-dismissed-${version}`, '1');
+      badge.remove();
+    });
+
+    badge.appendChild(dismiss);
+    versionSpan.insertAdjacentElement('afterend', badge);
+  }
+}

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,0 +1,3 @@
+export { DeepLinkHandler } from './deep-link-handler';
+export { DesktopUpdater } from './desktop-updater';
+export { RefreshScheduler } from './refresh-scheduler';

--- a/src/controllers/refresh-scheduler.ts
+++ b/src/controllers/refresh-scheduler.ts
@@ -1,0 +1,95 @@
+import type { MapLayers } from '@/types';
+import { REFRESH_INTERVALS, SITE_VARIANT } from '@/config';
+
+interface RefreshSchedulerDeps {
+  isDestroyed: () => boolean;
+  mapLayers: () => MapLayers;
+  isInFlight: (name: string) => boolean;
+  markInFlight: (name: string) => void;
+  clearInFlight: (name: string) => void;
+  shouldRefreshCyberThreats: () => boolean;
+  loadNews: () => Promise<void>;
+  loadMarkets: () => Promise<void>;
+  loadPredictions: () => Promise<void>;
+  loadPizzInt: () => Promise<void>;
+  loadNatural: () => Promise<void>;
+  loadWeatherAlerts: () => Promise<void>;
+  loadFredData: () => Promise<void>;
+  loadOilAnalytics: () => Promise<void>;
+  loadGovernmentSpending: () => Promise<void>;
+  refreshIntelligence: () => Promise<void>;
+  loadFirmsData: () => Promise<void>;
+  loadAisSignals: () => Promise<void>;
+  loadCableActivity: () => Promise<void>;
+  loadFlightDelays: () => Promise<void>;
+  loadCyberThreats: () => Promise<void>;
+}
+
+export class RefreshScheduler {
+  private readonly timeoutIds = new Map<string, ReturnType<typeof setTimeout>>();
+
+  constructor(private readonly deps: RefreshSchedulerDeps) {}
+
+  public teardown(): void {
+    for (const timeoutId of this.timeoutIds.values()) clearTimeout(timeoutId);
+    this.timeoutIds.clear();
+  }
+
+  public setupIntervals(): void {
+    this.scheduleRefresh('news', () => this.deps.loadNews(), REFRESH_INTERVALS.feeds);
+    this.scheduleRefresh('markets', () => this.deps.loadMarkets(), REFRESH_INTERVALS.markets);
+    this.scheduleRefresh('predictions', () => this.deps.loadPredictions(), REFRESH_INTERVALS.predictions);
+    this.scheduleRefresh('pizzint', () => this.deps.loadPizzInt(), 10 * 60 * 1000);
+
+    this.scheduleRefresh('natural', () => this.deps.loadNatural(), 5 * 60 * 1000, () => this.deps.mapLayers().natural);
+    this.scheduleRefresh('weather', () => this.deps.loadWeatherAlerts(), 10 * 60 * 1000, () => this.deps.mapLayers().weather);
+    this.scheduleRefresh('fred', () => this.deps.loadFredData(), 30 * 60 * 1000);
+    this.scheduleRefresh('oil', () => this.deps.loadOilAnalytics(), 30 * 60 * 1000);
+    this.scheduleRefresh('spending', () => this.deps.loadGovernmentSpending(), 60 * 60 * 1000);
+
+    if (SITE_VARIANT === 'full') {
+      this.scheduleRefresh('intelligence', () => this.deps.refreshIntelligence(), 5 * 60 * 1000);
+    }
+
+    this.scheduleRefresh('firms', () => this.deps.loadFirmsData(), 30 * 60 * 1000);
+    this.scheduleRefresh('ais', () => this.deps.loadAisSignals(), REFRESH_INTERVALS.ais, () => this.deps.mapLayers().ais);
+    this.scheduleRefresh('cables', () => this.deps.loadCableActivity(), 30 * 60 * 1000, () => this.deps.mapLayers().cables);
+    this.scheduleRefresh('flights', () => this.deps.loadFlightDelays(), 10 * 60 * 1000, () => this.deps.mapLayers().flights);
+    this.scheduleRefresh('cyberThreats', () => this.deps.loadCyberThreats(), 10 * 60 * 1000, () => this.deps.shouldRefreshCyberThreats() && this.deps.mapLayers().cyberThreats);
+  }
+
+  private scheduleRefresh(name: string, fn: () => Promise<void>, intervalMs: number, condition?: () => boolean): void {
+    const HIDDEN_REFRESH_MULTIPLIER = 4;
+    const JITTER_FRACTION = 0.1;
+    const MIN_REFRESH_MS = 1000;
+    const computeDelay = (baseMs: number, isHidden: boolean) => {
+      const adjusted = baseMs * (isHidden ? HIDDEN_REFRESH_MULTIPLIER : 1);
+      const jitterRange = adjusted * JITTER_FRACTION;
+      const jittered = adjusted + (Math.random() * 2 - 1) * jitterRange;
+      return Math.max(MIN_REFRESH_MS, Math.round(jittered));
+    };
+    const scheduleNext = (delay: number) => {
+      if (this.deps.isDestroyed()) return;
+      const timeoutId = setTimeout(run, delay);
+      this.timeoutIds.set(name, timeoutId);
+    };
+    const run = async () => {
+      if (this.deps.isDestroyed()) return;
+      const isHidden = document.visibilityState === 'hidden';
+      if (isHidden) return scheduleNext(computeDelay(intervalMs, true));
+      if (condition && !condition()) return scheduleNext(computeDelay(intervalMs, false));
+      if (this.deps.isInFlight(name)) return scheduleNext(computeDelay(intervalMs, false));
+
+      this.deps.markInFlight(name);
+      try {
+        await fn();
+      } catch (e) {
+        console.error(`[App] Refresh ${name} failed:`, e);
+      } finally {
+        this.deps.clearInFlight(name);
+        scheduleNext(computeDelay(intervalMs, false));
+      }
+    };
+    scheduleNext(computeDelay(intervalMs, document.visibilityState === 'hidden'));
+  }
+}


### PR DESCRIPTION
### Motivation
- The prior refactor moved refresh orchestration into `RefreshScheduler` but accidentally detached deduplication from the app-wide in-flight guard, risking overlapping fetches. 
- Cyber-threat refresh gating was also changed unintentionally and needed to match the original feature-flag behavior.
- Move lifecycle and updater responsibilities into controllers while preserving previous runtime semantics and teardown behavior.

### Description
- Updated `RefreshScheduler` to accept `isInFlight`, `markInFlight`, and `clearInFlight` callbacks and to use them for refresh deduplication instead of an internal set. 
- Added a `shouldRefreshCyberThreats` dependency to `RefreshScheduler` and used it in the cyber refresh scheduling condition to preserve feature-flag gating. 
- Wired the new scheduler dependencies from `App` when instantiating `RefreshScheduler`, and restored the scheduler teardown via `refreshScheduler.teardown()`. 
- Kept the controller extraction (added `DeepLinkHandler`, `DesktopUpdater`, and `RefreshScheduler` in `src/controllers/`) and wired `DeepLinkHandler.handle()` and `DesktopUpdater.setup()/teardown()` from `App`.

### Testing
- Ran `npm run typecheck` (which runs `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69977fb8398083338bf602abc118ea4a)