### PR TITLE
Service Worker Excludes ML WASM but Still Caches 60+ MB ML JS Chunk

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -245,7 +245,7 @@ export default defineConfig({
 
       workbox: {
         globPatterns: ['**/*.{js,css,ico,png,svg,woff2}', 'index.html'],
-        globIgnores: ['**/ml-*.js', '**/onnx*.wasm'],
+        globIgnores: ['**/ml*.js', '**/onnx*.wasm'],
         navigateFallback: '/index.html',
         navigateFallbackDenylist: [/^\/api\//, /^\/settings/],
         skipWaiting: true,


### PR DESCRIPTION
globIgnores` excludes `**/onnx*.wasm` but the `ml` chunk (Xenova Transformers JS code) is still matched by `**/*.{js,…}` and will be precached by Workbox.
This inflates the initial service worker cache by ~60 MB, wasting bandwidth for users who never use browser ML.