### PR TITLE
IndexedDB-backed persistent cache + stale-while-revalidate API response caching

### DIFF
--- a/src/services/arxiv.ts
+++ b/src/services/arxiv.ts
@@ -1,5 +1,6 @@
 import { API_URLS } from '@/config';
 import { createCircuitBreaker } from '@/utils';
+import { fetchWithProxy } from '@/utils';
 
 export interface ArxivPaper {
   id: string;
@@ -77,7 +78,7 @@ export async function fetchArxivPapers(
   maxResults: number = 50
 ): Promise<ArxivPaper[]> {
   return breaker.execute(async () => {
-    const response = await fetch(API_URLS.arxiv(category, maxResults));
+    const response = await fetchWithProxy(API_URLS.arxiv(category, maxResults));
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
     const xmlText = await response.text();

--- a/src/services/earthquakes.ts
+++ b/src/services/earthquakes.ts
@@ -2,6 +2,7 @@ import type { Earthquake } from '@/types';
 import { API_URLS } from '@/config';
 import { createCircuitBreaker } from '@/utils';
 import { getPersistentCache, setPersistentCache } from './persistent-cache';
+import { fetchWithProxy } from '@/utils';
 
 interface USGSFeature {
   id: string;
@@ -31,7 +32,7 @@ async function getFallbackEarthquakes(): Promise<Earthquake[]> {
 
 export async function fetchEarthquakes(): Promise<Earthquake[]> {
   const live = await breaker.execute(async () => {
-    const response = await fetch(API_URLS.earthquakes);
+    const response = await fetchWithProxy(API_URLS.earthquakes);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
     const data: USGSResponse = await response.json();

--- a/src/services/github-trending.ts
+++ b/src/services/github-trending.ts
@@ -1,5 +1,6 @@
 import { API_URLS } from '@/config';
 import { createCircuitBreaker } from '@/utils';
+import { fetchWithProxy } from '@/utils';
 
 export interface GitHubRepo {
   author: string;
@@ -25,7 +26,7 @@ export async function fetchGitHubTrending(
   since: string = 'daily'
 ): Promise<GitHubRepo[]> {
   return breaker.execute(async () => {
-    const response = await fetch(API_URLS.githubTrending(language, since));
+    const response = await fetchWithProxy(API_URLS.githubTrending(language, since));
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
     const data = await response.json();

--- a/src/services/hackernews.ts
+++ b/src/services/hackernews.ts
@@ -1,5 +1,6 @@
 import { API_URLS } from '@/config';
 import { createCircuitBreaker } from '@/utils';
+import { fetchWithProxy } from '@/utils';
 
 export interface HackerNewsStory {
   id: number;
@@ -27,7 +28,7 @@ export async function fetchHackerNews(
   limit: number = 30
 ): Promise<HackerNewsStory[]> {
   return breaker.execute(async () => {
-    const response = await fetch(API_URLS.hackernews(type, limit));
+    const response = await fetchWithProxy(API_URLS.hackernews(type, limit));
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
     const data: HNApiResponse = await response.json();

--- a/src/services/persistent-cache.ts
+++ b/src/services/persistent-cache.ts
@@ -8,6 +8,65 @@ type CacheEnvelope<T> = {
 };
 
 const CACHE_PREFIX = 'worldmonitor-persistent-cache:';
+const CACHE_DB_NAME = 'worldmonitor_persistent_cache';
+const CACHE_DB_VERSION = 1;
+const CACHE_STORE = 'entries';
+
+let cacheDbPromise: Promise<IDBDatabase> | null = null;
+
+function isIndexedDbAvailable(): boolean {
+  return typeof window !== 'undefined' && typeof window.indexedDB !== 'undefined';
+}
+
+function getCacheDb(): Promise<IDBDatabase> {
+  if (!isIndexedDbAvailable()) {
+    return Promise.reject(new Error('IndexedDB unavailable'));
+  }
+
+  if (cacheDbPromise) return cacheDbPromise;
+
+  cacheDbPromise = new Promise((resolve, reject) => {
+    const request = indexedDB.open(CACHE_DB_NAME, CACHE_DB_VERSION);
+
+    request.onerror = () => reject(request.error ?? new Error('Failed to open cache IndexedDB'));
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(CACHE_STORE)) {
+        db.createObjectStore(CACHE_STORE, { keyPath: 'key' });
+      }
+    };
+
+    request.onsuccess = () => {
+      const db = request.result;
+      db.onclose = () => { cacheDbPromise = null; };
+      resolve(db);
+    };
+  });
+
+  return cacheDbPromise;
+}
+
+async function getFromIndexedDb<T>(key: string): Promise<CacheEnvelope<T> | null> {
+  const db = await getCacheDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(CACHE_STORE, 'readonly');
+    const store = tx.objectStore(CACHE_STORE);
+    const request = store.get(key);
+    request.onsuccess = () => resolve((request.result as CacheEnvelope<T> | undefined) ?? null);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function setInIndexedDb<T>(payload: CacheEnvelope<T>): Promise<void> {
+  const db = await getCacheDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(CACHE_STORE, 'readwrite');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.objectStore(CACHE_STORE).put(payload);
+  });
+}
 
 export async function getPersistentCache<T>(key: string): Promise<CacheEnvelope<T> | null> {
   if (isDesktopRuntime()) {
@@ -15,7 +74,16 @@ export async function getPersistentCache<T>(key: string): Promise<CacheEnvelope<
       const value = await invokeTauri<CacheEnvelope<T> | null>('read_cache_entry', { key });
       return value ?? null;
     } catch (error) {
-      console.warn('[persistent-cache] Desktop read failed; falling back to localStorage', error);
+      console.warn('[persistent-cache] Desktop read failed; falling back to browser storage', error);
+    }
+  }
+
+  if (isIndexedDbAvailable()) {
+    try {
+      return await getFromIndexedDb<T>(key);
+    } catch (error) {
+      console.warn('[persistent-cache] IndexedDB read failed; falling back to localStorage', error);
+      cacheDbPromise = null;
     }
   }
 
@@ -35,7 +103,17 @@ export async function setPersistentCache<T>(key: string, data: T): Promise<void>
       await invokeTauri<void>('write_cache_entry', { key, value: JSON.stringify(payload) });
       return;
     } catch (error) {
-      console.warn('[persistent-cache] Desktop write failed; falling back to localStorage', error);
+      console.warn('[persistent-cache] Desktop write failed; falling back to browser storage', error);
+    }
+  }
+
+  if (isIndexedDbAvailable()) {
+    try {
+      await setInIndexedDb(payload);
+      return;
+    } catch (error) {
+      console.warn('[persistent-cache] IndexedDB write failed; falling back to localStorage', error);
+      cacheDbPromise = null;
     }
   }
 

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,6 +1,16 @@
 import { isDesktopRuntime, toRuntimeUrl } from '../services/runtime';
+import { getPersistentCache, setPersistentCache } from '../services/persistent-cache';
 
 const isDev = import.meta.env.DEV;
+const RESPONSE_CACHE_PREFIX = 'api-response:';
+
+type CachedResponsePayload = {
+  url: string;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string;
+};
 
 // In production browser deployments, routes are handled by Vercel serverless functions.
 // In local dev, Vite proxy handles these routes.
@@ -17,6 +27,64 @@ export function proxyUrl(localPath: string): string {
   return localPath;
 }
 
+function shouldPersistResponse(url: string): boolean {
+  return typeof url === 'string' && (url.startsWith('/api/') || url.includes('/api/'));
+}
+
+function buildResponseCacheKey(url: string): string {
+  return `${RESPONSE_CACHE_PREFIX}${url}`;
+}
+
+function toCachedPayload(url: string, response: Response, body: string): CachedResponsePayload {
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  return {
+    url,
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+    body,
+  };
+}
+
+function toResponse(payload: CachedResponsePayload): Response {
+  return new Response(payload.body, {
+    status: payload.status,
+    statusText: payload.statusText,
+    headers: payload.headers,
+  });
+}
+
+async function fetchAndPersist(url: string): Promise<Response> {
+  const response = await fetch(proxyUrl(url));
+  if (response.ok && shouldPersistResponse(url)) {
+    try {
+      const body = await response.clone().text();
+      void setPersistentCache(buildResponseCacheKey(url), toCachedPayload(url, response, body));
+    } catch (error) {
+      console.warn('[proxy] Failed to persist API response cache', error);
+    }
+  }
+  return response;
+}
+
 export async function fetchWithProxy(url: string): Promise<Response> {
-  return fetch(proxyUrl(url));
+  if (!shouldPersistResponse(url)) {
+    return fetch(proxyUrl(url));
+  }
+
+  const cacheKey = buildResponseCacheKey(url);
+  const cached = await getPersistentCache<CachedResponsePayload>(cacheKey);
+
+  if (cached?.data) {
+    void fetchAndPersist(url).catch((error) => {
+      console.warn('[proxy] Background refresh failed for cached API response', error);
+    });
+    return toResponse(cached.data);
+  }
+
+  return fetchAndPersist(url);
 }


### PR DESCRIPTION
### Motivation
- Improve repeat-visit performance by persisting API responses and data-source payloads client-side so the dashboard can show cached data immediately while refreshing in the background (PERF-021).
- Provide a robust multi-tier storage strategy: prefer desktop/Tauri storage, then IndexedDB in browser runtime, and fall back to `localStorage` if needed.

### Description
- Upgrade `src/services/persistent-cache.ts` to use an IndexedDB store (`worldmonitor_persistent_cache`) with `getFromIndexedDb`/`setInIndexedDb` while keeping Tauri RPC and `localStorage` fallbacks. 
- Add stale-while-revalidate API response caching to `src/utils/proxy.ts` via `fetchWithProxy`, which returns cached `/api/*` responses immediately and refreshes them in the background (persisted under `api-response:<url>`).
- Route key data-source fetchers through the new proxy cache by switching `fetch` -> `fetchWithProxy` in `src/services/arxiv.ts`, `src/services/hackernews.ts`, `src/services/github-trending.ts`, and `src/services/earthquakes.ts` so they inherit persistent response hydration.
- Preserve existing behaviors and fallbacks (desktop storage first, IndexedDB where available, then `localStorage`) and avoid breaking existing circuit-breaker logic in services.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) and it succeeded.
- Ran `npm run test:data` and the suite executed; most tests passed but one existing `deploy/cache` guardrail subtest failed (pre-existing assertion about a precache glob pattern), which is unrelated to the caching changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997871eb7648333a131f041010684de)