### PR TITLE
Add `/api/aggregate` serverless endpoint for batched startup calls

### DIFF
--- a/api/aggregate.js
+++ b/api/aggregate.js
@@ -1,0 +1,157 @@
+import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const DEFAULT_ENDPOINT_ALIASES = ['news', 'markets', 'cii', 'conflicts', 'fires', 'signals'];
+
+const ENDPOINT_MAP = {
+  news: '/api/hackernews',
+  markets: '/api/stock-index?code=SPY',
+  cii: '/api/risk-scores',
+  conflicts: '/api/acled-conflict',
+  fires: '/api/firms-fires?days=3',
+  signals: '/api/macro-signals',
+};
+
+const MAX_ENDPOINTS = 20;
+
+function resolveEndpointTarget(entry) {
+  const trimmed = entry.trim();
+  if (!trimmed) return null;
+
+  if (ENDPOINT_MAP[trimmed]) {
+    return { key: trimmed, path: ENDPOINT_MAP[trimmed] };
+  }
+
+  if (trimmed.startsWith('/api/')) {
+    const [pathOnly] = trimmed.split('#', 1);
+    return { key: trimmed, path: pathOnly };
+  }
+
+  return null;
+}
+
+async function fetchEndpoint(baseUrl, target) {
+  const startedAt = Date.now();
+  try {
+    const response = await fetch(new URL(target.path, baseUrl), {
+      headers: {
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(12000),
+    });
+
+    const durationMs = Date.now() - startedAt;
+    const contentType = response.headers.get('content-type') || '';
+    const isJson = contentType.includes('application/json');
+
+    if (!response.ok) {
+      const errorText = isJson
+        ? JSON.stringify(await response.json().catch(() => ({ error: `HTTP ${response.status}` })))
+        : await response.text();
+      return {
+        ok: false,
+        status: response.status,
+        durationMs,
+        error: errorText.slice(0, 300),
+      };
+    }
+
+    const data = isJson ? await response.json() : await response.text();
+    return {
+      ok: true,
+      status: response.status,
+      durationMs,
+      data,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 500,
+      durationMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : 'Unknown fetch error',
+    };
+  }
+}
+
+export default async function handler(req) {
+  const cors = getCorsHeaders(req);
+
+  if (isDisallowedOrigin(req)) {
+    return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: cors });
+  }
+
+  if (req.method !== 'GET') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+
+  const url = new URL(req.url);
+  const rawEndpoints = url.searchParams.get('endpoints');
+  const endpointNames = (rawEndpoints ? rawEndpoints.split(',') : DEFAULT_ENDPOINT_ALIASES)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  if (endpointNames.length === 0) {
+    return new Response(JSON.stringify({ error: 'No endpoints requested' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+
+  if (endpointNames.length > MAX_ENDPOINTS) {
+    return new Response(JSON.stringify({ error: `Too many endpoints requested (max ${MAX_ENDPOINTS})` }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+
+  const targets = endpointNames.map(resolveEndpointTarget);
+  const invalidEndpoints = endpointNames.filter((_, idx) => !targets[idx]);
+
+  if (invalidEndpoints.length > 0) {
+    return new Response(JSON.stringify({
+      error: 'One or more endpoint entries are invalid',
+      invalidEndpoints,
+      allowedAliases: Object.keys(ENDPOINT_MAP),
+    }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+
+  const baseUrl = `${url.protocol}//${url.host}`;
+  const validTargets = targets;
+
+  const results = await Promise.all(
+    validTargets.map((target) => fetchEndpoint(baseUrl, target))
+  );
+
+  const payload = {};
+  validTargets.forEach((target, index) => {
+    payload[target.key] = results[index];
+  });
+
+  return new Response(JSON.stringify({
+    requested: endpointNames,
+    completed: results.filter((result) => result.ok).length,
+    failed: results.filter((result) => !result.ok).length,
+    payload,
+  }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=30, s-maxage=30, stale-while-revalidate=30',
+      ...cors,
+    },
+  });
+}

--- a/api/aggregate.test.mjs
+++ b/api/aggregate.test.mjs
@@ -1,0 +1,76 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import handler from './aggregate.js';
+
+function makeRequest(query = '', options = {}) {
+  const headers = new Headers(options.headers || {});
+  return new Request(`https://worldmonitor.app/api/aggregate${query}`, {
+    method: options.method || 'GET',
+    headers,
+  });
+}
+
+test('returns default aggregate payload with aliased endpoints', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    const path = new URL(url).pathname;
+    return new Response(JSON.stringify({ source: path }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+
+  try {
+    const response = await handler(makeRequest());
+    assert.equal(response.status, 200);
+    const body = await response.json();
+
+    assert.equal(body.completed, 6);
+    assert.equal(body.failed, 0);
+    assert.equal(body.payload.news.ok, true);
+    assert.equal(body.payload.signals.data.source, '/api/macro-signals');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('supports explicit endpoints list and tracks failed endpoint calls', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    const pathname = new URL(url).pathname;
+    if (pathname === '/api/risk-scores') {
+      return new Response(JSON.stringify({ error: 'upstream unavailable' }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ pathname }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+
+  try {
+    const response = await handler(makeRequest('?endpoints=cii,signals'));
+    assert.equal(response.status, 200);
+    const body = await response.json();
+
+    assert.equal(body.completed, 1);
+    assert.equal(body.failed, 1);
+    assert.equal(body.payload.cii.ok, false);
+    assert.equal(body.payload.signals.ok, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('rejects invalid endpoint aliases', async () => {
+  const response = await handler(makeRequest('?endpoints=signals,badalias'));
+  assert.equal(response.status, 400);
+
+  const body = await response.json();
+  assert.deepEqual(body.invalidEndpoints, ['badalias']);
+});


### PR DESCRIPTION
### Motivation
- The app issues many small HTTP requests on startup; batching them reduces client-side round-trips and speeds initialization. 
- Provide a single server-side endpoint that fans out to multiple internal APIs and returns a consolidated response so clients can request one payload instead of ~30 separate calls. 
- Ensure the aggregate call is safe and resilient to partial upstream failures while preserving per-endpoint status for graceful degradation. 

### Description
- Added a new edge function at `api/aggregate.js` that accepts `?endpoints=` (comma-separated aliases or `/api/...` paths) and fans out parallel requests to each target, returning a merged JSON payload with per-endpoint metadata. 
- Added built-in aliases mapping (`news`, `markets`, `cii`, `conflicts`, `fires`, `signals`) to internal routes, plus validation, an endpoint count limit (`MAX_ENDPOINTS`), and input error reporting. 
- Implemented per-endpoint fetch semantics with a 12s timeout, JSON/text detection, duration tracking, isolated error reporting (`ok`, `status`, `durationMs`, `data`/`error`), and short edge cache headers. 
- Enforced CORS/origin rules using existing `getCorsHeaders`/`isDisallowedOrigin` utilities and added `api/aggregate.test.mjs` covering default alias bundle, mixed success/failure, and invalid endpoint validation. 

### Testing
- Ran the automated test suite `node --test api/aggregate.test.mjs`, which executed 3 tests covering default aliases, mixed success/failure aggregation, and invalid alias rejection, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997870b69048333b14b627d426cd540)