### PR TITLE
fix(sidecar): preserve Request body semantics in ipv4 shim

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -34,13 +34,9 @@ async function resolveRequestBody(input, init, method, isRequest) {
   }
 
   if (isRequest && input?.body) {
-    try {
-      const clone = typeof input.clone === 'function' ? input.clone() : input;
-      const buffer = await clone.arrayBuffer();
-      return normalizeRequestBody(buffer);
-    } catch {
-      return null;
-    }
+    const clone = typeof input.clone === 'function' ? input.clone() : input;
+    const buffer = await clone.arrayBuffer();
+    return normalizeRequestBody(buffer);
   }
 
   return null;

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -325,6 +325,60 @@ test('preserves Request body when handler uses fetch(Request)', async () => {
   }
 });
 
+test('returns local handler error when fetch(Request) uses a consumed body', async () => {
+  let upstreamHits = 0;
+
+  const upstream = createServer((req, res) => {
+    upstreamHits += 1;
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  const upstreamPort = await listen(upstream);
+  process.env.WM_TEST_UPSTREAM = `http://127.0.0.1:${upstreamPort}`;
+
+  const localApi = await setupApiDir({
+    'request-consumed.js': `
+      export default async function handler() {
+        const request = new Request(\`\${process.env.WM_TEST_UPSTREAM}/echo\`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ secret: 'used-body' }),
+        });
+        await request.text();
+        await fetch(request);
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+    `,
+  });
+
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() {}, warn() {}, error() {} },
+  });
+  const { port } = await app.start();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/request-consumed`);
+    assert.equal(response.status, 502);
+    const body = await response.json();
+    assert.equal(body.error, 'Local handler error');
+    assert.equal(typeof body.reason, 'string');
+    assert.equal(body.reason.length > 0, true);
+    assert.equal(upstreamHits, 0);
+  } finally {
+    delete process.env.WM_TEST_UPSTREAM;
+    await app.close();
+    await localApi.cleanup();
+    await new Promise((resolve, reject) => {
+      upstream.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
 test('strips browser origin headers when proxying to cloud fallback (cloudFallback enabled)', async () => {
   const remote = await setupRemoteServer();
   const localApi = await setupApiDir({});


### PR DESCRIPTION
## Summary
- preserve request body forwarding when the local handler calls `fetch(request)` without an explicit `init.body`
- preserve native semantics for consumed/disturbed request bodies by throwing instead of silently sending an empty body
- add sidecar regression coverage for both behaviors

## Changes
- update `src-tauri/sidecar/local-api-server.mjs`
  - support forwarding body from `Request` when `init.body` is absent
  - stop swallowing `clone()/arrayBuffer()` errors in `resolveRequestBody(...)`
- add tests in `src-tauri/sidecar/local-api-server.test.mjs`
  - `preserves Request body when handler uses fetch(Request)`
  - `returns local handler error when fetch(Request) uses a consumed body`

## Validation
- `npm run typecheck`
- `npm run test:sidecar`
- `npm run test:data`
- `npm run build`
