### PR TITLE
perf: faster panel loading — instant flat render, higher concurrency

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -3266,7 +3266,7 @@ export class App {
   private async loadNewsCategory(category: string, feeds: typeof FEEDS.politics): Promise<NewsItem[]> {
     try {
       const panel = this.newsPanels[category];
-      const renderIntervalMs = 250;
+      const renderIntervalMs = 100;
       let lastRenderTime = 0;
       let renderTimeout: ReturnType<typeof setTimeout> | null = null;
       let pendingItems: NewsItem[] | null = null;
@@ -3367,7 +3367,7 @@ export class App {
       .map(([key, feeds]) => ({ key, feeds }));
 
     // Stage category fetches to avoid startup bursts and API pressure in all variants.
-    const maxCategoryConcurrency = SITE_VARIANT === 'finance' ? 3 : SITE_VARIANT === 'tech' ? 4 : 5;
+    const maxCategoryConcurrency = SITE_VARIANT === 'tech' ? 4 : 5;
     const categoryConcurrency = Math.max(1, Math.min(maxCategoryConcurrency, categories.length));
     const categoryResults: PromiseSettledResult<NewsItem[]>[] = [];
     for (let i = 0; i < categories.length; i += categoryConcurrency) {

--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -272,10 +272,12 @@ export class NewsPanel extends Panel {
 
     this.setDataBadge('live');
 
+    // Always show flat items immediately for instant visual feedback,
+    // then upgrade to clustered view in the background when ready.
+    this.renderFlat(items);
+
     if (this.clusteredMode) {
       void this.renderClustersAsync(items);
-    } else {
-      this.renderFlat(items);
     }
   }
 


### PR DESCRIPTION
## Summary

Reduce perceived panel load time with three targeted changes:

- **Instant flat rendering**: Panels now show a flat item list immediately when feed data arrives, then upgrade to the clustered+ML-enriched view in the background (1-3s later). Previously, panels were blank until clustering completed.
- **Higher finance concurrency**: Increase finance variant category concurrency from 3 to 5 (matching the full variant). With 14 categories, this cuts sequential fetch waves from 5 to 3, saving ~10-15s on cold starts. The SWR cache layer means warm-start fetches return cached data instantly anyway.
- **Faster render throttle**: Reduce the batch render debounce from 250ms to 100ms. Virtual scrolling already bounds DOM impact, so the tighter interval gives faster visual feedback as feeds stream in.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] New data source / feed
- [ ] New map layer
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [x] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [x] Config / Settings
- [ ] Other

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [x] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots

N/A — behavioral change (faster content appearance), no visual changes.