### PR TITLE
fix(sidecar): preserve request body on cloud fallback

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -223,10 +223,18 @@ async function buildRouteTable(root) {
   return files;
 }
 
+const REQUEST_BODY_CACHE = Symbol('requestBodyCache');
+
 async function readBody(req) {
+  if (Object.prototype.hasOwnProperty.call(req, REQUEST_BODY_CACHE)) {
+    return req[REQUEST_BODY_CACHE];
+  }
+
   const chunks = [];
   for await (const chunk of req) chunks.push(chunk);
-  return chunks.length ? Buffer.concat(chunks) : undefined;
+  const body = chunks.length ? Buffer.concat(chunks) : undefined;
+  req[REQUEST_BODY_CACHE] = body;
+  return body;
 }
 
 function toHeaders(nodeHeaders, options = {}) {


### PR DESCRIPTION
## Summary
- fix a sidecar fallback bug where non-GET request bodies could be dropped when local handlers return non-OK responses and cloud fallback is used
- preserve request-body semantics by buffering inbound body once and reusing it for both local dispatch and fallback proxying
- add regression coverage for POST payload preservation through local non-OK -> cloud fallback path

## Problem
In `src-tauri/sidecar/local-api-server.mjs`, the inbound Node request stream was consumed for local handler dispatch and then read again inside cloud fallback. For POST/PUT/PATCH this second read was empty, so fallback requests could reach cloud with no body.

## Fix
- add a per-request cache (`REQUEST_BODY_CACHE`) in `readBody(req)`
- return the cached buffer on subsequent reads instead of consuming the stream again
- keep behavior unchanged for requests without a body

## Regression Test
Added:
- `preserves POST body when cloud fallback is triggered after local non-OK response`

This test verifies that when a local handler reads request body and returns 500, the cloud fallback still receives the original POST JSON payload.

## Validation
- `npm run typecheck`
- `npm run test:sidecar`
- `npm run test:data`
- `npm run build`
