### PR TITLE
fix: gate localhost CORS behind NODE_ENV and deterministic centroid jitter

### DIFF
--- a/api/_cors.js
+++ b/api/_cors.js
@@ -1,8 +1,14 @@
+const isDev = process.env.NODE_ENV !== 'production';
+
 const ALLOWED_ORIGIN_PATTERNS = [
   /^https:\/\/(.*\.)?worldmonitor\.app$/,
   /^https:\/\/worldmonitor-[a-z0-9-]+-elie-habib-projects\.vercel\.app$/,
-  /^https?:\/\/localhost(:\d+)?$/,
-  /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
+  // Plain localhost/127.0.0.1 — dev only
+  ...(isDev ? [
+    /^https?:\/\/localhost(:\d+)?$/,
+    /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
+  ] : []),
+  // Tauri desktop origins — always allowed
   /^https?:\/\/tauri\.localhost(:\d+)?$/,
   /^https?:\/\/[a-z0-9-]+\.tauri\.localhost(:\d+)?$/i,
   /^tauri:\/\/localhost$/,


### PR DESCRIPTION
## Summary
- **#183**: Plain `localhost` and `127.0.0.1` CORS origin patterns are now gated behind `NODE_ENV !== 'production'`. Tauri desktop origins (`tauri.localhost`, `tauri://localhost`, `asset://localhost`) remain always allowed since the desktop app needs them in all environments.
- **#203**: `getCountryCentroid()` replaced `Math.random()` jitter with an FNV-1a hash of the threat's indicator (IP address). Same threat → same coordinates across requests, eliminating the "jumping marker" problem on the map.

## Changes
| File | What changed |
|------|-------------|
| `api/_cors.js` | Wrap `localhost`/`127.0.0.1` patterns in `isDev` conditional; keep Tauri origins unconditional |
| `api/cyber-threats.js` | `getCountryCentroid(code, seed)`: hash-based deterministic jitter; call site passes `threat.indicator` |

## Checklist
- [x] `npx tsc --noEmit` passes
- [x] No new dependencies
- [x] No secrets or API keys
- [x] Edge-runtime compatible (pure JS, no node: imports)
- [x] Backwards-compatible (`getCountryCentroid` seed param defaults to `''`)

Closes #183, closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)