### PR TITLE
Validate WORLDMONITOR_API_KEY before allowing cloud fallback

### DIFF
--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -222,10 +222,14 @@ export function installRuntimeFetchPatch(): void {
 
     if (allowCloudFallback) {
       try {
-        const { secretsReady } = await import('@/services/runtime-config');
+        const { getSecretState, secretsReady } = await import('@/services/runtime-config');
         await Promise.race([secretsReady, new Promise<void>(r => setTimeout(r, 2000))]);
+        const wmKeyState = getSecretState('WORLDMONITOR_API_KEY');
+        if (!wmKeyState.present || !wmKeyState.valid) {
+          allowCloudFallback = false;
+        }
       } catch {
-        // secrets module failed to load — still allow cloud fallback
+        allowCloudFallback = false;
       }
     }
 


### PR DESCRIPTION
## Summary

Add validation of the `WORLDMONITOR_API_KEY` secret before allowing cloud fallback in the runtime fetch patch. If the API key is missing or invalid, cloud fallback is now disabled. Additionally, if the secrets module fails to load, cloud fallback is disabled rather than silently allowed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other:

## Details

The runtime fetch patch now:
1. Imports `getSecretState` in addition to `secretsReady` from the runtime-config service
2. Checks the state of the `WORLDMONITOR_API_KEY` secret after waiting for secrets to be ready
3. Disables cloud fallback if the API key is not present or invalid
4. Disables cloud fallback if the secrets module fails to load (instead of allowing it)

This ensures that cloud fallback requests are only made when a valid API key is available.

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

https://claude.ai/code/session_014yJsGsxD1sWt6B6PvQXiaA