### PR TITLE
fix: reduce dedup coordinate rounding from 0.5° to 0.1° (~10km)

### DIFF
--- a/server/worldmonitor/unrest/v1/_shared.ts
+++ b/server/worldmonitor/unrest/v1/_shared.ts
@@ -73,8 +73,8 @@ export function deduplicateEvents(events: UnrestEvent[]): UnrestEvent[] {
   for (const event of events) {
     const lat = event.location?.latitude ?? 0;
     const lon = event.location?.longitude ?? 0;
-    const latKey = Math.round(lat * 2) / 2;
-    const lonKey = Math.round(lon * 2) / 2;
+    const latKey = Math.round(lat * 10) / 10;
+    const lonKey = Math.round(lon * 10) / 10;
     const dateKey = new Date(event.occurredAt).toISOString().split('T')[0];
     const key = `${latKey}:${lonKey}:${dateKey}`;
 


### PR DESCRIPTION
## Problem

Deduplication in `_shared.ts` rounds coordinates to the nearest 0.5° (~50km). In dense urban areas, distinct protests in adjacent neighborhoods (e.g., Manhattan vs Brooklyn) on the same day get incorrectly merged into a single event.

## Fix

Reduce rounding granularity from 0.5° (`Math.round(x * 2) / 2`) to 0.1° (`Math.round(x * 10) / 10`), giving ~10km resolution. This preserves neighborhood-level distinctions while still deduplicating true duplicates from overlapping sources.

Ref: PR #106 re-review (NEW-11)
Fixes #204