### PR TITLE
Format Rust code and fix Windows focus handling

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -883,7 +883,10 @@ fn main() {
                         let _ = w.set_focus();
                     }
                 }
-                // Raise settings window when main window gains focus so it doesn't hide behind
+                // Only macOS needs explicit re-raising to keep settings above the main window.
+                // On Windows, focusing the settings window here can trigger rapid focus churn
+                // between windows and present as a UI hang.
+                #[cfg(target_os = "macos")]
                 RunEvent::WindowEvent {
                     label,
                     event: WindowEvent::Focused(true),


### PR DESCRIPTION
## Summary

This PR applies Rust formatting improvements to `src-tauri/src/main.rs` and fixes a Windows-specific UI issue with the settings window focus behavior.

## Type of change

- [x] Bug fix
- [x] Refactor / code cleanup

## Affected areas

- [x] Desktop app (Tauri)

## Changes

### Code Formatting
- Reorganized imports in alphabetical order for consistency
- Applied line-wrapping and indentation improvements throughout the file to improve readability
- Reformatted multi-line function calls and struct initializations to follow Rust style conventions

### Bug Fix: Windows Focus Handling
- Fixed an issue where the settings window would be raised whenever the main window gained focus, causing rapid focus churn on Windows
- Added platform-specific conditional compilation (`#[cfg(target_os = "macos")]`) to only apply the window-raising behavior on macOS, where it's needed to keep the settings window above the main window
- On Windows, the settings window is no longer forcibly raised, preventing the UI hang caused by focus thrashing between windows

## Checklist

- [x] No API keys or secrets committed
- [x] Rust formatting applied consistently

## Testing

The formatting changes are non-functional. The focus handling fix is platform-specific and isolated to the macOS code path, preventing the Windows focus churn issue without affecting other platforms.

