### PR TITLE
fix: correct Vietnam flag country code in language selector

### DIFF
--- a/src/components/LanguageSelector.ts
+++ b/src/components/LanguageSelector.ts
@@ -33,7 +33,9 @@ export class LanguageSelector {
             sv: 'se',
             ru: 'ru',
             ja: 'jp',
-            tr: 'tr'
+            tr: 'tr',
+            vi: 'vn',
+            th: 'th'
         };
         const countryCode = map[langCode] || langCode;
         return `https://flagcdn.com/24x18/${countryCode}.png`;


### PR DESCRIPTION
## Summary
- Fix Vietnam flag showing wrong image — `vi` is not a valid ISO country code, changed to `vn`
- Add explicit `th` mapping for Thailand (was working by coincidence via fallback)

## Test plan
- [ ] Open language selector dropdown → Vietnam shows correct red flag with yellow star
- [ ] Thailand flag unchanged