### PR TITLE
fix: sentry triage + SW POST method for PostHog ingest

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -2838,11 +2838,11 @@ export class App {
 
   private toggleFullscreen(): void {
     if (document.fullscreenElement) {
-      void document.exitFullscreen().catch(() => {});
+      try { void document.exitFullscreen()?.catch(() => {}); } catch {}
     } else {
       const el = document.documentElement as HTMLElement & { webkitRequestFullscreen?: () => void };
       if (el.requestFullscreen) {
-        void el.requestFullscreen().catch(() => {});
+        try { void el.requestFullscreen()?.catch(() => {}); } catch {}
       } else if (el.webkitRequestFullscreen) {
         try { el.webkitRequestFullscreen(); } catch {}
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,7 @@ Sentry.init({
     /requestFullscreen/,
     /webkitEnterFullscreen/,
     /vc_text_indicators_context/,
-    /Program failed to link: null/,
+    /Program failed to link/,
     /too much recursion/,
     /zaloJSV2/,
     /Java bridge method invocation error/,
@@ -61,6 +61,7 @@ Sentry.init({
     /Unexpected end of input/,
     /window\.android\.\w+ is not a function/,
     /Attempted to assign to readonly property/,
+    /Cannot assign to read only property/,
     /FetchEvent\.respondWith/,
     /e\.toLowerCase is not a function/,
     /\.trim is not a function/,
@@ -81,6 +82,11 @@ Sentry.init({
     /Style is not done loading/,
     /Event `CustomEvent`.*captured as promise rejection/,
     /getProgramInfoLog/,
+    /__firefox__/,
+    /ifameElement\.contentDocument/,
+    /Invalid video id/,
+    /Fetch is aborted/,
+    /Stylesheet append timeout/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -535,14 +535,27 @@ export default defineConfig({
           {
             urlPattern: /^https?:\/\/.*\/api\/.*/i,
             handler: 'NetworkOnly',
+            method: 'GET',
+          },
+          {
+            urlPattern: /^https?:\/\/.*\/api\/.*/i,
+            handler: 'NetworkOnly',
+            method: 'POST',
           },
           {
             urlPattern: /^https?:\/\/.*\/ingest\/.*/i,
             handler: 'NetworkOnly',
+            method: 'GET',
+          },
+          {
+            urlPattern: /^https?:\/\/.*\/ingest\/.*/i,
+            handler: 'NetworkOnly',
+            method: 'POST',
           },
           {
             urlPattern: /^https?:\/\/.*\/rss\/.*/i,
             handler: 'NetworkOnly',
+            method: 'GET',
           },
           {
             urlPattern: /^https:\/\/api\.maptiler\.com\//,


### PR DESCRIPTION
## Summary
- **PostHog /ingest 404 fix**: Workbox `registerRoute` defaults to `GET` only. PostHog sends analytics via `POST` to `/ingest/e/`. Added duplicate POST routes for `/api/` and `/ingest/` patterns.
- **Sentry triage**: Fixed fullscreen crash (optional chaining on `exitFullscreen()?.catch()`), added 6 noise filters, widened 1 existing filter. All 9 issues resolved in Sentry.

## Root Cause
The previous SW fix (PR #244) added `/ingest/` to `NetworkOnly` routes but Workbox only matches GET by default. POST requests from PostHog fell through to the precache handler → 404.

## Test plan
- [ ] Deploy → open worldmonitor.app in incognito → no PostHog 404 errors in console
- [ ] Verify `/ingest/e/` POST requests pass through SW to Vercel rewrite
- [ ] Existing API calls still work (GET routes unchanged)