### PR TITLE
fix: restrict SW route patterns to same-origin only

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -533,27 +533,32 @@ export default defineConfig({
             },
           },
           {
-            urlPattern: /^https?:\/\/.*\/api\/.*/i,
+            urlPattern: ({ url, sameOrigin }: { url: URL; sameOrigin: boolean }) =>
+              sameOrigin && /^\/api\//.test(url.pathname),
             handler: 'NetworkOnly',
             method: 'GET',
           },
           {
-            urlPattern: /^https?:\/\/.*\/api\/.*/i,
+            urlPattern: ({ url, sameOrigin }: { url: URL; sameOrigin: boolean }) =>
+              sameOrigin && /^\/api\//.test(url.pathname),
             handler: 'NetworkOnly',
             method: 'POST',
           },
           {
-            urlPattern: /^https?:\/\/.*\/ingest\/.*/i,
+            urlPattern: ({ url, sameOrigin }: { url: URL; sameOrigin: boolean }) =>
+              sameOrigin && /^\/ingest\//.test(url.pathname),
             handler: 'NetworkOnly',
             method: 'GET',
           },
           {
-            urlPattern: /^https?:\/\/.*\/ingest\/.*/i,
+            urlPattern: ({ url, sameOrigin }: { url: URL; sameOrigin: boolean }) =>
+              sameOrigin && /^\/ingest\//.test(url.pathname),
             handler: 'NetworkOnly',
             method: 'POST',
           },
           {
-            urlPattern: /^https?:\/\/.*\/rss\/.*/i,
+            urlPattern: ({ url, sameOrigin }: { url: URL; sameOrigin: boolean }) =>
+              sameOrigin && /^\/rss\//.test(url.pathname),
             handler: 'NetworkOnly',
             method: 'GET',
           },


### PR DESCRIPTION
## Summary
- SW `urlPattern` regex `/^https?:\/\/.*\/api\/.*/i` matched ANY URL with `/api/` in the path — including external APIs like NASA EONET (`eonet.gsfc.nasa.gov/api/v3/events`)
- Workbox intercepted these cross-origin requests with `NetworkOnly`, causing `no-response` errors when CORS/network failed
- Changed all `/api/`, `/ingest/`, and `/rss/` SW route patterns to use `sameOrigin` callback check

## Test plan
- [ ] Build produces valid `sw.js` with `sameOrigin` checks (verified locally)
- [ ] EONET requests no longer trigger workbox `no-response` errors
- [ ] Same-origin `/api/`, `/ingest/`, `/rss/` routes still use `NetworkOnly` handler
- [ ] PostHog `/ingest/` POST requests pass through to Vercel rewrites