### PR TITLE
chore: expand curated Telegram channels list (global/ME/Iran/cyber)

### DIFF
--- a/data/telegram-channels.json
+++ b/data/telegram-channels.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-02-23T12:19:41Z",
+  "updatedAt": "2026-02-23T18:37:10Z",
   "note": "Product-managed curated list. Not user-configurable.",
   "channels": {
     "full": [
@@ -14,17 +14,35 @@
         "maxMessages": 20
       },
       {
-        "handle": "BNONews",
-        "label": "BNO News",
-        "topic": "breaking",
+        "handle": "abualiexpress",
+        "label": "Abu Ali Express",
+        "topic": "middleeast",
         "tier": 2,
         "enabled": true,
-        "region": "global",
+        "region": "middleeast",
         "maxMessages": 25
       },
       {
-        "handle": "LiveUAMap",
-        "label": "LiveUAMap",
+        "handle": "air_alert_ua",
+        "label": "Повітряна Тривога",
+        "topic": "alerts",
+        "tier": 2,
+        "enabled": true,
+        "region": "ukraine",
+        "maxMessages": 20
+      },
+      {
+        "handle": "AuroraIntel",
+        "label": "Aurora Intel",
+        "topic": "conflict",
+        "tier": 2,
+        "enabled": true,
+        "region": "global",
+        "maxMessages": 20
+      },
+      {
+        "handle": "BNONews",
+        "label": "BNO News",
         "topic": "breaking",
         "tier": 2,
         "enabled": true,
@@ -41,8 +59,17 @@
         "maxMessages": 30
       },
       {
-        "handle": "OSINTdefender",
-        "label": "OSINTdefender",
+        "handle": "DeepStateUA",
+        "label": "DeepState",
+        "topic": "conflict",
+        "tier": 2,
+        "enabled": true,
+        "region": "ukraine",
+        "maxMessages": 20
+      },
+      {
+        "handle": "DefenderDome",
+        "label": "The Defender Dome",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
@@ -50,39 +77,21 @@
         "maxMessages": 25
       },
       {
-        "handle": "AuroraIntel",
-        "label": "Aurora Intel",
-        "topic": "conflict",
+        "handle": "englishabuali",
+        "label": "Abu Ali Express EN",
+        "topic": "middleeast",
         "tier": 2,
         "enabled": true,
-        "region": "global",
-        "maxMessages": 20
+        "region": "middleeast",
+        "maxMessages": 25
       },
       {
-        "handle": "GeopoliticalCenter",
-        "label": "GeopoliticalCenter",
-        "topic": "geopolitics",
-        "tier": 3,
-        "enabled": true,
-        "region": "global",
-        "maxMessages": 20
-      },
-      {
-        "handle": "Osintlatestnews",
-        "label": "OSIntOps News",
-        "topic": "osint",
-        "tier": 3,
-        "enabled": true,
-        "region": "global",
-        "maxMessages": 20
-      },
-      {
-        "handle": "air_alert_ua",
-        "label": "Повітряна Тривога",
-        "topic": "alerts",
+        "handle": "IranIntl",
+        "label": "Iran International",
+        "topic": "politics",
         "tier": 2,
         "enabled": true,
-        "region": "ukraine",
+        "region": "iran",
         "maxMessages": 20
       },
       {
@@ -95,21 +104,30 @@
         "maxMessages": 20
       },
       {
-        "handle": "war_monitor",
-        "label": "monitor",
-        "topic": "alerts",
-        "tier": 3,
+        "handle": "LiveUAMap",
+        "label": "LiveUAMap",
+        "topic": "breaking",
+        "tier": 2,
         "enabled": true,
-        "region": "ukraine",
-        "maxMessages": 20
+        "region": "global",
+        "maxMessages": 25
       },
       {
-        "handle": "DeepStateUA",
-        "label": "DeepState",
+        "handle": "OSINTdefender",
+        "label": "OSINTdefender",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
-        "region": "ukraine",
+        "region": "global",
+        "maxMessages": 25
+      },
+      {
+        "handle": "OsintUpdates",
+        "label": "Osint Updates",
+        "topic": "breaking",
+        "tier": 2,
+        "enabled": true,
+        "region": "global",
         "maxMessages": 20
       },
       {
@@ -120,6 +138,42 @@
         "enabled": true,
         "region": "global",
         "maxMessages": 10
+      },
+      {
+        "handle": "CyberDetective",
+        "label": "CyberDetective",
+        "topic": "cyber",
+        "tier": 3,
+        "enabled": true,
+        "region": "global",
+        "maxMessages": 15
+      },
+      {
+        "handle": "GeopoliticalCenter",
+        "label": "GeopoliticalCenter",
+        "topic": "geopolitics",
+        "tier": 3,
+        "enabled": true,
+        "region": "global",
+        "maxMessages": 20
+      },
+      {
+        "handle": "Middle_East_Spectator",
+        "label": "Middle East Spectator",
+        "topic": "middleeast",
+        "tier": 3,
+        "enabled": true,
+        "region": "middleeast",
+        "maxMessages": 20
+      },
+      {
+        "handle": "MiddleEastNow_Breaking",
+        "label": "Middle East Now Breaking",
+        "topic": "middleeast",
+        "tier": 3,
+        "enabled": true,
+        "region": "middleeast",
+        "maxMessages": 15
       },
       {
         "handle": "nexta_live",
@@ -138,6 +192,60 @@
         "enabled": true,
         "region": "europe",
         "maxMessages": 15
+      },
+      {
+        "handle": "OSINTIndustries",
+        "label": "OSINT Industries",
+        "topic": "osint",
+        "tier": 3,
+        "enabled": true,
+        "region": "global",
+        "maxMessages": 15
+      },
+      {
+        "handle": "Osintlatestnews",
+        "label": "OSIntOps News",
+        "topic": "osint",
+        "tier": 3,
+        "enabled": true,
+        "region": "global",
+        "maxMessages": 20
+      },
+      {
+        "handle": "osintlive",
+        "label": "OSINT Live",
+        "topic": "osint",
+        "tier": 3,
+        "enabled": true,
+        "region": "global",
+        "maxMessages": 15
+      },
+      {
+        "handle": "OsintTv",
+        "label": "OsintTV",
+        "topic": "geopolitics",
+        "tier": 3,
+        "enabled": true,
+        "region": "global",
+        "maxMessages": 15
+      },
+      {
+        "handle": "spectatorindex",
+        "label": "The Spectator Index",
+        "topic": "breaking",
+        "tier": 3,
+        "enabled": true,
+        "region": "global",
+        "maxMessages": 15
+      },
+      {
+        "handle": "war_monitor",
+        "label": "monitor",
+        "topic": "alerts",
+        "tier": 3,
+        "enabled": true,
+        "region": "ukraine",
+        "maxMessages": 20
       }
     ],
     "tech": [],


### PR DESCRIPTION
This PR is now a data-only update after rebase.

## What changed
- Updates `data/telegram-channels.json` (curated product-managed list).
- Expands `channels.full` from 15 to 27 channels (+12, none removed).
- Adds broader coverage across global, Middle East, Iran, and cyber/OSINT sources.
- Updates `updatedAt` metadata.

## Added handles
`abualiexpress`, `DefenderDome`, `englishabuali`, `IranIntl`, `OsintUpdates`, `CyberDetective`, `Middle_East_Spectator`, `MiddleEastNow_Breaking`, `OSINTIndustries`, `osintlive`, `OsintTv`, `spectatorindex`

## What did not change
Telegram runtime support was already merged into `main` earlier.
This PR does **not** change Telegram ingestion code paths (`api/telegram-feed.js`, `scripts/ais-relay.cjs`, `scripts/telegram/session-auth.mjs`).
