### PR TITLE
fix: allow http:// origin from tauri.localhost for Windows CORS

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -424,7 +424,7 @@ const SIDECAR_ALLOWED_ORIGINS = [
   /^tauri:\/\/localhost$/,
   /^https?:\/\/localhost(:\d+)?$/,
   /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
-  /^https:\/\/tauri\.localhost(:\d+)?$/,
+  /^https?:\/\/tauri\.localhost(:\d+)?$/,
   /^https:\/\/(.*\.)?worldmonitor\.app$/,
 ];
 


### PR DESCRIPTION
On Windows, Tauri webviews send requests with origin
`http://tauri.localhost` (HTTP), but the CORS allowlist only permitted
`https://tauri.localhost` (HTTPS). This caused every sidecar API
request to be blocked by CORS, making the app non-functional on
Windows with a "sidecar not reachable" error.

Change the regex from `^https:` to `^https?:` so both HTTP and HTTPS
origins from tauri.localhost are accepted.

https://claude.ai/code/session_016XMWtTPfE81bitu3QEoUwy