### PR TITLE
add @sentry-internal/browser-utils as explicit dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "world-monitor",
-  "version": "2.5.3",
+  "version": "2.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "world-monitor",
-      "version": "2.5.3",
+      "version": "2.5.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@deck.gl/aggregation-layers": "^9.2.6",
@@ -14,6 +14,7 @@
         "@deck.gl/geo-layers": "^9.2.6",
         "@deck.gl/layers": "^9.2.6",
         "@deck.gl/mapbox": "^9.2.6",
+        "@sentry-internal/browser-utils": "^10.39.0",
         "@sentry/browser": "^10.39.0",
         "@upstash/redis": "^1.36.1",
         "@vercel/analytics": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@deck.gl/geo-layers": "^9.2.6",
     "@deck.gl/layers": "^9.2.6",
     "@deck.gl/mapbox": "^9.2.6",
+    "@sentry-internal/browser-utils": "^10.39.0",
     "@sentry/browser": "^10.39.0",
     "@upstash/redis": "^1.36.1",
     "@vercel/analytics": "^1.6.1",


### PR DESCRIPTION
## Summary

Adds `@sentry-internal/browser-utils@^10.39.0` as an explicit top-level dependency. Previously it was only pulled in as a transitive peer of `@sentry/browser`, making it an implicit requirement. Declaring it directly prevents accidental breakage if the Sentry package tree changes.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: `package.json` dependency declaration

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots

N/A — dependency-only change, no UI impact.