### PR TITLE
feat: add Nigeria feeds and Greek locale feeds

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -142,6 +142,16 @@ const ALLOWED_DOMAINS = [
   'www.lemonde.fr',
   'rss.dw.com',
   'www.africanews.com',
+  // Nigeria
+  'www.premiumtimesng.com',
+  'www.vanguardngr.com',
+  'www.channelstv.com',
+  'dailytrust.com',
+  'www.thisdaylive.com',
+  // Greek
+  'www.naftemporiki.gr',
+  'www.in.gr',
+  'www.iefimerida.gr',
   'www.lasillavacia.com',
   'www.channelnewsasia.com',
   'www.thehindu.com',

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -188,6 +188,18 @@ export const SOURCE_TIERS: Record<string, number> = {
   'Disrupt Africa': 3,
   'Wamda (MENA)': 3,
   'Magnitt': 3,
+  // Nigeria
+  'Premium Times': 2,
+  'Vanguard Nigeria': 2,
+  'Channels TV': 2,
+  'Daily Trust': 3,
+  'ThisDay': 2,
+  // Greek
+  'Kathimerini': 2,
+  'Naftemporiki': 2,
+  'in.gr': 3,
+  'iefimerida': 3,
+  'Proto Thema': 3,
 
   // Tier 3 - Think Tanks
   'Brookings Tech': 3,
@@ -490,6 +502,12 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     // Vietnamese (VI)
     { name: 'VnExpress', url: rss('https://vnexpress.net/rss'), lang: 'vi' },
     { name: 'Tuoi Tre News', url: rss('https://news.google.com/rss/search?q=site:tuoitrenews.vn+when:2d&hl=vi&gl=VN&ceid=VN:vi'), lang: 'vi' },
+    // Greek (EL)
+    { name: 'Kathimerini', url: rss('https://news.google.com/rss/search?q=site:kathimerini.gr+when:2d&hl=el&gl=GR&ceid=GR:el'), lang: 'el' },
+    { name: 'Naftemporiki', url: rss('https://www.naftemporiki.gr/feed/'), lang: 'el' },
+    { name: 'in.gr', url: rss('https://www.in.gr/feed/'), lang: 'el' },
+    { name: 'iefimerida', url: rss('https://www.iefimerida.gr/rss.xml'), lang: 'el' },
+    { name: 'Proto Thema', url: rss('https://news.google.com/rss/search?q=site:protothema.gr+when:2d&hl=el&gl=GR&ceid=GR:el'), lang: 'el' },
   ],
   middleeast: [
     { name: 'BBC Middle East', url: rss('https://feeds.bbci.co.uk/news/world/middle_east/rss.xml') },
@@ -587,6 +605,12 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     { name: 'Jeune Afrique', url: rss('https://www.jeuneafrique.com/feed/'), lang: 'fr' },
     { name: 'Africanews', url: { en: rss('https://www.africanews.com/feed/rss'), fr: rss('https://fr.africanews.com/feed/rss') } },
     { name: 'BBC Afrique', url: rss('https://www.bbc.com/afrique/index.xml'), lang: 'fr' },
+    // Nigeria
+    { name: 'Premium Times', url: rss('https://www.premiumtimesng.com/feed') },
+    { name: 'Vanguard Nigeria', url: rss('https://www.vanguardngr.com/feed/') },
+    { name: 'Channels TV', url: rss('https://www.channelstv.com/feed/') },
+    { name: 'Daily Trust', url: rss('https://dailytrust.com/feed/') },
+    { name: 'ThisDay', url: rss('https://www.thisdaylive.com/feed') },
   ],
   latam: [
     { name: 'Latin America', url: rss('https://news.google.com/rss/search?q=(Brazil+OR+Mexico+OR+Argentina+OR+Venezuela+OR+Colombia)+when:2d&hl=en-US&gl=US&ceid=US:en') },


### PR DESCRIPTION
## Summary
- Add 5 Nigeria news sources to Africa section (Premium Times, Vanguard, Channels TV, Daily Trust, ThisDay)
- Add 5 Greek feeds with `lang: 'el'` for locale-aware filtering (Kathimerini, Naftemporiki, in.gr, iefimerida, Proto Thema)
- Add source tiers for all new outlets
- Allowlist 8 new domains in RSS proxy

## Test plan
- [ ] Verify Nigeria feeds load in the Africa panel
- [ ] Switch UI to Greek locale → verify Greek feeds appear in the localized section
- [ ] Confirm RSS proxy accepts requests to new domains