### PR TITLE
fix: sync YouTube live panel mute state with native player controls

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -220,7 +220,7 @@ export class LiveNewsPanel extends Panel {
   private desktopEmbedRenderToken = 0;
   private boundMessageHandler!: (e: MessageEvent) => void;
   private muteSyncInterval: ReturnType<typeof setInterval> | null = null;
-  private readonly MUTE_SYNC_POLL_MS = 500;
+  private static readonly MUTE_SYNC_POLL_MS = 500;
 
   constructor() {
     super({ id: 'live-news', title: t('panels.liveNews') });
@@ -346,7 +346,7 @@ export class LiveNewsPanel extends Panel {
 
   private startMuteSyncPolling(): void {
     this.stopMuteSyncPolling();
-    this.muteSyncInterval = setInterval(() => this.syncMuteStateFromPlayer(), this.MUTE_SYNC_POLL_MS);
+    this.muteSyncInterval = setInterval(() => this.syncMuteStateFromPlayer(), LiveNewsPanel.MUTE_SYNC_POLL_MS);
   }
 
   private syncMuteStateFromPlayer(): void {
@@ -931,7 +931,8 @@ export class LiveNewsPanel extends Panel {
   }
 
   public destroy(): void {
-    this.stopMuteSyncPolling();
+    this.destroyPlayer();
+
     if (this.idleTimeout) {
       clearTimeout(this.idleTimeout);
       this.idleTimeout = null;
@@ -943,14 +944,7 @@ export class LiveNewsPanel extends Panel {
       document.removeEventListener(event, this.boundIdleResetHandler);
     });
 
-    if (this.player) {
-      this.player.destroy();
-      this.player = null;
-    }
-    this.desktopEmbedIframe = null;
-    this.isPlayerReady = false;
     this.playerContainer = null;
-    this.playerElement = null;
 
     super.destroy();
   }


### PR DESCRIPTION
## Summary

When muting or unmuting audio from the **YouTube player’s native controls** (inside the embed), the panel’s mute button and icon now stay in sync. Previously, only the panel button updated the player; changes made in the YouTube UI were not reflected in the panel.

Implementation: polling the player’s mute state (native IFrame API) and handling a new `yt-mute-state` postMessage from the desktop embed iframe so both code paths stay aligned.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [x] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other: <!-- specify -->

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [x] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)