### PR TITLE
fix: increase live channels window size to fit channel grid

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "world-monitor"
-version = "2.5.5"
+version = "2.5.6"
 dependencies = [
  "keyring",
  "reqwest 0.12.28",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -573,8 +573,8 @@ fn open_live_channels_window(app: &AppHandle, base_url: Option<String>) -> Resul
 
     let _live_channels_window = WebviewWindowBuilder::new(app, "live-channels", url)
     .title("Channel management - World Monitor")
-    .inner_size(440.0, 560.0)
-    .min_inner_size(360.0, 480.0)
+    .inner_size(680.0, 760.0)
+    .min_inner_size(520.0, 600.0)
     .resizable(true)
     .background_color(tauri::webview::Color(26, 28, 30, 255))
     .build()

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -531,7 +531,7 @@ export class LiveNewsPanel extends Panel {
       }
       const url = new URL(window.location.href);
       url.searchParams.set('live-channels', '1');
-      window.open(url.toString(), 'worldmonitor-live-channels', 'width=440,height=560,scrollbars=yes');
+      window.open(url.toString(), 'worldmonitor-live-channels', 'width=680,height=760,scrollbars=yes');
     });
     toolbar.appendChild(openBtn);
   }


### PR DESCRIPTION
## Summary
- Increase default window size from 440×560 to 680×760 (both Tauri and web popup)
- Increase minimum size from 360×480 to 520×600
- Channel cards, region tabs, and custom channel form were clipped at the old size

## Test plan
- [x] `cargo check` passes
- [x] `tsc --noEmit` passes
- [x] Vite build passes
- [ ] Open channel management on desktop — window fits all content without scrolling