### PR TITLE
fix: add Greek flag mapping to language selector

### DIFF
--- a/src/components/LanguageSelector.ts
+++ b/src/components/LanguageSelector.ts
@@ -23,6 +23,7 @@ export class LanguageSelector {
             en: 'gb',
             ar: 'sa',
             zh: 'cn',
+            el: 'gr',
             fr: 'fr',
             de: 'de',
             es: 'es',


### PR DESCRIPTION
## Summary
- Add missing `el: 'gr'` mapping in `LanguageSelector.ts` so the Greek flag renders correctly
- The fallback was sending `el` (language code) to flagcdn, which needs `gr` (country code)

## Test plan
- [ ] Open language selector dropdown — Greek option shows 🇬🇷 flag instead of broken image