### PR TITLE
fix: add Greek flag mapping to language selector

### DIFF
--- a/src/components/LanguageSelector.ts
+++ b/src/components/LanguageSelector.ts
@@ -23,6 +23,7 @@ export class LanguageSelector {
             en: 'gb',
             ar: 'sa',
             zh: 'cn',
+            el: 'gr',
             fr: 'fr',
             de: 'de',
             es: 'es',


### PR DESCRIPTION
## Summary
- Add `el: 'gr'` mapping in `LanguageSelector.ts` so Greek language uses the correct country code (`gr`) for flagcdn.com instead of the language code (`el`)

## Test plan
- [ ] Switch language to Greek and verify the flag icon renders correctly