### PR TITLE
fix: add missing country brief i18n keys and export PDF option

### DIFF
--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -263,6 +263,7 @@ export class CountryBriefPage {
               </button>
               <div class="cb-export-menu hidden">
                 <button class="cb-export-option" data-format="image">${t('common.exportImage')}</button>
+                <button class="cb-export-option" data-format="pdf">${t('common.exportPdf')}</button>
                 <button class="cb-export-option" data-format="json">${t('common.exportJson')}</button>
                 <button class="cb-export-option" data-format="csv">${t('common.exportCsv')}</button>
               </div>
@@ -363,6 +364,8 @@ export class CountryBriefPage {
           if (this.onExportImage && this.currentCode && this.currentName) {
             this.onExportImage(this.currentCode, this.currentName);
           }
+        } else if (format === 'pdf') {
+          this.exportPdf();
         } else {
           this.exportBrief(format as 'json' | 'csv');
         }
@@ -618,6 +621,42 @@ export class CountryBriefPage {
     }
     if (format === 'json') exportCountryBriefJSON(data);
     else exportCountryBriefCSV(data);
+  }
+
+  private exportPdf(): void {
+    const content = this.overlay.querySelector('.cb-body');
+    const header = this.overlay.querySelector('.cb-header');
+    if (!content) return;
+
+    const iframe = document.createElement('iframe');
+    iframe.style.cssText = 'position:fixed;left:-9999px;width:0;height:0;border:none';
+    document.body.appendChild(iframe);
+    const doc = iframe.contentDocument || iframe.contentWindow?.document;
+    if (!doc) { document.body.removeChild(iframe); return; }
+
+    const styles = Array.from(document.querySelectorAll('link[rel="stylesheet"], style'))
+      .map(el => el.outerHTML).join('\n');
+
+    doc.open();
+    doc.write(`<!DOCTYPE html><html><head><meta charset="utf-8">${styles}
+      <style>
+        @media print { body { margin: 0; padding: 16px; background: #fff; color: #111; }
+          .cb-grid { display: block !important; }
+          .cb-grid > * { break-inside: avoid; margin-bottom: 16px; }
+          .cb-badge, .cb-trend { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+          canvas { max-width: 100% !important; }
+        }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+        .country-brief-overlay { position: static !important; background: none !important; }
+      </style>
+    </head><body>${header ? header.outerHTML : ''}${content.outerHTML}</body></html>`);
+    doc.close();
+
+    iframe.contentWindow!.onafterprint = () => document.body.removeChild(iframe);
+    setTimeout(() => {
+      iframe.contentWindow!.print();
+      setTimeout(() => { if (iframe.parentNode) document.body.removeChild(iframe); }, 5000);
+    }, 300);
   }
 
   public hide(): void {

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1802,6 +1802,7 @@
     "information": "معلومات",
     "shareStory": "مشاركة القصة",
     "exportImage": "تصدير صورة",
+    "exportPdf": "تصدير PDF",
     "new": "جديد",
     "live": "مباشر",
     "cached": "مخزّن مؤقتاً",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1795,6 +1795,7 @@
     "exportJson": "JSON exportieren",
     "exportData": "Daten exportieren",
     "exportImage": "Bild exportieren",
+    "exportPdf": "PDF exportieren",
     "unrest": "Unruhen",
     "conflict": "Konflikt",
     "security": "Sicherheit",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -50,6 +50,29 @@
       "base": "Στρατιωτικές Βάσεις",
       "nuclear": "Πυρηνικές Εγκαταστάσεις",
       "port": "Λιμάνια"
+    },
+    "levels": {
+      "critical": "Κρίσιμο",
+      "high": "Υψηλό",
+      "elevated": "Αυξημένο",
+      "moderate": "Μέτριο",
+      "normal": "Κανονικό",
+      "low": "Χαμηλό"
+    },
+    "trends": {
+      "rising": "Ανοδικά",
+      "falling": "Πτωτικά",
+      "stable": "Σταθερό"
+    },
+    "fallback": {
+      "instabilityIndex": "**Δείκτης Αστάθειας: {{score}}/100** ({{level}}, {{trend}})",
+      "protestsDetected": "{{count}} ενεργές διαμαρτυρίες ανιχνεύθηκαν",
+      "aircraftTracked": "{{count}} στρατιωτικά αεροσκάφη παρακολουθούνται",
+      "vesselsTracked": "{{count}} στρατιωτικά πλοία παρακολουθούνται",
+      "internetOutages": "{{count}} διακοπές διαδικτύου",
+      "recentEarthquakes": "{{count}} πρόσφατοι σεισμοί",
+      "stockIndex": "Χρηματιστηριακός δείκτης: {{value}}",
+      "recentHeadlines": "**Πρόσφατοι τίτλοι:**"
     }
   },
   "header": {
@@ -1807,6 +1830,7 @@
     "information": "Πληροφορίες",
     "shareStory": "Κοινοποίηση ιστορίας",
     "exportImage": "Εξαγωγή Εικόνας",
+    "exportPdf": "Εξαγωγή PDF",
     "new": "ΝΕΟ",
     "live": "ΖΩΝΤΑΝΑ",
     "cached": "ΑΠΟΘΗΚΕΥΜΕΝΟ",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -50,6 +50,29 @@
       "base": "Military Bases",
       "nuclear": "Nuclear Facilities",
       "port": "Ports"
+    },
+    "levels": {
+      "critical": "Critical",
+      "high": "High",
+      "elevated": "Elevated",
+      "moderate": "Moderate",
+      "normal": "Normal",
+      "low": "Low"
+    },
+    "trends": {
+      "rising": "Rising",
+      "falling": "Falling",
+      "stable": "Stable"
+    },
+    "fallback": {
+      "instabilityIndex": "**Instability Index: {{score}}/100** ({{level}}, {{trend}})",
+      "protestsDetected": "{{count}} active protests detected",
+      "aircraftTracked": "{{count}} military aircraft tracked",
+      "vesselsTracked": "{{count}} military vessels tracked",
+      "internetOutages": "{{count}} internet outages",
+      "recentEarthquakes": "{{count}} recent earthquakes",
+      "stockIndex": "Stock index: {{value}}",
+      "recentHeadlines": "**Recent headlines:**"
     }
   },
   "header": {
@@ -1830,6 +1853,7 @@
     "information": "Information",
     "shareStory": "Share story",
     "exportImage": "Export Image",
+    "exportPdf": "Export PDF",
     "new": "NEW",
     "live": "LIVE",
     "cached": "CACHED",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1795,6 +1795,7 @@
     "exportJson": "Exportar JSON",
     "exportData": "Exportar datos",
     "exportImage": "Exportar imagen",
+    "exportPdf": "Exportar PDF",
     "unrest": "Disturbios",
     "conflict": "Conflicto",
     "security": "Seguridad",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1799,6 +1799,7 @@
     "information": "Information",
     "shareStory": "Partager le sujet",
     "exportImage": "Exporter l'image",
+    "exportPdf": "Exporter PDF",
     "selectAll": "Sélectionner tout",
     "selectNone": "Sélectionnez Aucun",
     "noDataAvailable": "Aucune donnée disponible",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -1795,6 +1795,7 @@
     "exportJson": "Esporta JSON",
     "exportData": "Esporta dati",
     "exportImage": "Esporta immagine",
+    "exportPdf": "Esporta PDF",
     "unrest": "Disordini",
     "conflict": "Conflitto",
     "security": "Sicurezza",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1803,6 +1803,7 @@
     "information": "情報",
     "shareStory": "ストーリーを共有",
     "exportImage": "画像をエクスポート",
+    "exportPdf": "PDFエクスポート",
     "new": "NEW",
     "live": "LIVE",
     "cached": "CACHED",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -1701,6 +1701,7 @@
     "exportJson": "JSON exporteren",
     "exportData": "Gegevens exporteren",
     "exportImage": "Afbeelding exporteren",
+    "exportPdf": "PDF exporteren",
     "unrest": "Onrust",
     "conflict": "Conflict",
     "security": "Veiligheid",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1795,6 +1795,7 @@
     "exportJson": "Eksportuj JSON",
     "exportData": "Eksportuj dane",
     "exportImage": "Eksportuj obraz",
+    "exportPdf": "Eksportuj PDF",
     "unrest": "Niepokoje",
     "conflict": "Konflikt",
     "security": "Bezpieczeństwo",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1701,6 +1701,7 @@
     "exportJson": "Exportar JSON",
     "exportData": "Exportar dados",
     "exportImage": "Exportar imagem",
+    "exportPdf": "Exportar PDF",
     "unrest": "Agitação",
     "conflict": "Conflito",
     "security": "Segurança",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1802,6 +1802,7 @@
     "information": "Информация",
     "shareStory": "Поделиться сюжетом",
     "exportImage": "Экспорт изображения",
+    "exportPdf": "Экспорт PDF",
     "new": "НОВОЕ",
     "live": "ПРЯМОЙ ЭФИР",
     "cached": "КЭШ",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -1701,6 +1701,7 @@
     "exportJson": "Exportera JSON",
     "exportData": "Exportera data",
     "exportImage": "Exportera bild",
+    "exportPdf": "Exportera PDF",
     "unrest": "Oroligheter",
     "conflict": "Konflikt",
     "security": "Säkerhet",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -50,6 +50,29 @@
       "base": "ฐานทัพ",
       "nuclear": "สิ่งอำนวยความสะดวกนิวเคลียร์",
       "port": "ท่าเรือ"
+    },
+    "levels": {
+      "critical": "วิกฤต",
+      "high": "สูง",
+      "elevated": "ยกระดับ",
+      "moderate": "ปานกลาง",
+      "normal": "ปกติ",
+      "low": "ต่ำ"
+    },
+    "trends": {
+      "rising": "เพิ่มขึ้น",
+      "falling": "ลดลง",
+      "stable": "คงที่"
+    },
+    "fallback": {
+      "instabilityIndex": "**ดัชนีความไม่มั่นคง: {{score}}/100** ({{level}}, {{trend}})",
+      "protestsDetected": "ตรวจพบการประท้วงที่ยังดำเนินอยู่ {{count}} รายการ",
+      "aircraftTracked": "ติดตามอากาศยานทหาร {{count}} ลำ",
+      "vesselsTracked": "ติดตามเรือรบ {{count}} ลำ",
+      "internetOutages": "การหยุดชะงักอินเทอร์เน็ต {{count}} รายการ",
+      "recentEarthquakes": "แผ่นดินไหวล่าสุด {{count}} ครั้ง",
+      "stockIndex": "ดัชนีหุ้น: {{value}}",
+      "recentHeadlines": "**พาดหัวข่าวล่าสุด:**"
     }
   },
   "header": {
@@ -1779,6 +1802,7 @@
     "information": "ข้อมูล",
     "shareStory": "แชร์เรื่องราว",
     "exportImage": "ส่งออกรูปภาพ",
+    "exportPdf": "ส่งออก PDF",
     "new": "ใหม่",
     "live": "สด",
     "cached": "แคช",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1802,6 +1802,7 @@
     "information": "Bilgi",
     "shareStory": "Hikayeyi paylas",
     "exportImage": "Gorsel Disari Aktar",
+    "exportPdf": "PDF Dışa Aktar",
     "new": "YENI",
     "live": "CANLI",
     "cached": "ONBELLEK",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -50,6 +50,29 @@
       "base": "Căn cứ Quân sự",
       "nuclear": "Cơ sở Hạt nhân",
       "port": "Cảng biển"
+    },
+    "levels": {
+      "critical": "Nghiêm trọng",
+      "high": "Cao",
+      "elevated": "Nâng cao",
+      "moderate": "Trung bình",
+      "normal": "Bình thường",
+      "low": "Thấp"
+    },
+    "trends": {
+      "rising": "Tăng",
+      "falling": "Giảm",
+      "stable": "Ổn định"
+    },
+    "fallback": {
+      "instabilityIndex": "**Chỉ số Bất ổn: {{score}}/100** ({{level}}, {{trend}})",
+      "protestsDetected": "Phát hiện {{count}} cuộc biểu tình đang diễn ra",
+      "aircraftTracked": "Đang theo dõi {{count}} máy bay quân sự",
+      "vesselsTracked": "Đang theo dõi {{count}} tàu quân sự",
+      "internetOutages": "{{count}} sự cố gián đoạn internet",
+      "recentEarthquakes": "{{count}} trận động đất gần đây",
+      "stockIndex": "Chỉ số chứng khoán: {{value}}",
+      "recentHeadlines": "**Tin tức gần đây:**"
     }
   },
   "header": {
@@ -1779,6 +1802,7 @@
     "information": "Thông tin",
     "shareStory": "Chia sẻ bài viết",
     "exportImage": "Xuất Hình ảnh",
+    "exportPdf": "Xuất PDF",
     "new": "MỚI",
     "live": "TRỰC TIẾP",
     "cached": "ĐÃ LƯU",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1802,6 +1802,7 @@
     "information": "信息",
     "shareStory": "分享报道",
     "exportImage": "导出图片",
+    "exportPdf": "导出 PDF",
     "new": "新",
     "live": "实时",
     "cached": "已缓存",


### PR DESCRIPTION
## Summary
- Add missing i18n keys for country brief page across all locale files
- Add export PDF option to country brief page

## Test plan
- [ ] Open country brief for any country and verify all labels are translated
- [ ] Verify no missing i18n key warnings in console