### PR TITLE
fix: use window.print() for country brief PDF export

### DIFF
--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -624,39 +624,9 @@ export class CountryBriefPage {
   }
 
   private exportPdf(): void {
-    const content = this.overlay.querySelector('.cb-body');
-    const header = this.overlay.querySelector('.cb-header');
-    if (!content) return;
-
-    const iframe = document.createElement('iframe');
-    iframe.style.cssText = 'position:fixed;left:-9999px;width:0;height:0;border:none';
-    document.body.appendChild(iframe);
-    const doc = iframe.contentDocument || iframe.contentWindow?.document;
-    if (!doc) { document.body.removeChild(iframe); return; }
-
-    const styles = Array.from(document.querySelectorAll('link[rel="stylesheet"], style'))
-      .map(el => el.outerHTML).join('\n');
-
-    doc.open();
-    doc.write(`<!DOCTYPE html><html><head><meta charset="utf-8">${styles}
-      <style>
-        @media print { body { margin: 0; padding: 16px; background: #fff; color: #111; }
-          .cb-grid { display: block !important; }
-          .cb-grid > * { break-inside: avoid; margin-bottom: 16px; }
-          .cb-badge, .cb-trend { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
-          canvas { max-width: 100% !important; }
-        }
-        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
-        .country-brief-overlay { position: static !important; background: none !important; }
-      </style>
-    </head><body>${header ? header.outerHTML : ''}${content.outerHTML}</body></html>`);
-    doc.close();
-
-    iframe.contentWindow!.onafterprint = () => document.body.removeChild(iframe);
-    setTimeout(() => {
-      iframe.contentWindow!.print();
-      setTimeout(() => { if (iframe.parentNode) document.body.removeChild(iframe); }, 5000);
-    }, 300);
+    document.body.classList.add('print-country-brief');
+    window.print();
+    document.body.classList.remove('print-country-brief');
   }
 
   public hide(): void {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -14671,6 +14671,11 @@ body.has-critical-banner .panels-grid {
 
 /* Print styles */
 @media print {
+  body {
+    background: #fff !important;
+    color: #111 !important;
+  }
+
   .country-brief-overlay {
     position: static;
     background: none;
@@ -14686,12 +14691,15 @@ body.has-critical-banner .panels-grid {
     box-shadow: none;
     border-radius: 0;
     min-height: auto;
+    background: #fff !important;
+    color: #111 !important;
   }
 
   .cb-header {
     position: static;
-    background: var(--accent);
     border-radius: 0;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
   }
 
   .cb-close,
@@ -14706,8 +14714,32 @@ body.has-critical-banner .panels-grid {
     grid-template-columns: 1fr;
   }
 
+  .cb-grid > * {
+    break-inside: avoid;
+  }
+
   .cb-timeline-section {
     display: none;
+  }
+
+  .cb-body {
+    background: #fff !important;
+    color: #111 !important;
+  }
+
+  .cb-section {
+    background: #f8f8f8 !important;
+    color: #111 !important;
+    border-color: #ddd !important;
+  }
+
+  .cb-section-title {
+    color: #333 !important;
+  }
+
+  .cb-badge, .cb-trend {
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
   }
 
   body>*:not(.country-brief-overlay) {


### PR DESCRIPTION
## Summary
- Replace broken iframe-based PDF export with `window.print()` and enhanced `@media print` CSS
- The iframe approach failed because stylesheets resolved relative to `about:blank` origin and CSS custom variables were not inherited, resulting in blank pages

## Test plan
- [ ] Open country brief page and click "Export PDF"
- [ ] Verify the print dialog opens with properly styled content (white background, dark text)
- [ ] Verify sections have `break-inside: avoid` and badges retain color