### PR TITLE
feat: add Bild RSS feed scoped to German locale

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -141,6 +141,7 @@ const ALLOWED_DOMAINS = [
   'www.euronews.com',
   'www.lemonde.fr',
   'rss.dw.com',
+  'www.bild.de',
   'www.africanews.com',
   // Nigeria
   'www.premiumtimesng.com',

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -469,6 +469,7 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     { name: 'BBC Mundo', url: rss('https://www.bbc.com/mundo/index.xml'), lang: 'es' },
     // German (DE)
     { name: 'Tagesschau', url: rss('https://www.tagesschau.de/xml/rss2/'), lang: 'de' },
+    { name: 'Bild', url: rss('https://www.bild.de/feed/alles.xml'), lang: 'de' },
     { name: 'Der Spiegel', url: rss('https://www.spiegel.de/schlagzeilen/tops/index.rss'), lang: 'de' },
     { name: 'Die Zeit', url: rss('https://newsfeed.zeit.de/index'), lang: 'de' },
     { name: 'DW News', url: { en: rss('https://rss.dw.com/xml/rss-en-all'), de: rss('https://rss.dw.com/xml/rss-de-all'), es: rss('https://rss.dw.com/xml/rss-es-all') } },


### PR DESCRIPTION
## Summary
- Adds `https://www.bild.de/feed/alles.xml` to RSS feeds with `lang: 'de'`
- Adds `www.bild.de` to RSS proxy allowlist

## Test plan
- [ ] Switch locale to German — Bild appears in news feeds
- [ ] Non-German locales do not show Bild