### PR TITLE
fix: replace HTML5 drag API with mouse events for WKWebView

### DIFF
--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -140,7 +140,6 @@ export class Panel {
     this.resizeHandle = document.createElement('div');
     this.resizeHandle.className = 'panel-resize-handle';
     this.resizeHandle.title = t('components.panel.dragToResize');
-    this.resizeHandle.draggable = false; // Prevent parent's drag from capturing
     this.element.appendChild(this.resizeHandle);
     this.setupResizeHandlers();
 
@@ -164,7 +163,6 @@ export class Panel {
       this.startY = e.clientY;
       this.startHeight = this.element.getBoundingClientRect().height;
       this.element.classList.add('resizing');
-      this.element.draggable = false;
       this.resizeHandle?.classList.add('active');
       document.addEventListener('mousemove', onMouseMove);
       document.addEventListener('mouseup', onMouseUp);
@@ -182,7 +180,6 @@ export class Panel {
       if (!this.isResizing) return;
       this.isResizing = false;
       this.element.classList.remove('resizing');
-      this.element.draggable = true;
       this.resizeHandle?.classList.remove('active');
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
@@ -195,16 +192,6 @@ export class Panel {
     };
 
     this.resizeHandle.addEventListener('mousedown', onMouseDown);
-
-    // Prevent panel drag when resizing (capture phase runs before App.ts listener)
-    this.element.addEventListener('dragstart', (e) => {
-      const target = e.target;
-      if (this.isResizing || target === this.resizeHandle || (target instanceof Element && target.closest('.panel-resize-handle'))) {
-        e.preventDefault();
-        e.stopImmediatePropagation();
-        return false;
-      }
-    }, true);
 
     // Mark element as resizing for external listeners
     this.resizeHandle.addEventListener('mousedown', () => {
@@ -226,7 +213,6 @@ export class Panel {
       this.startY = touch.clientY;
       this.startHeight = this.element.getBoundingClientRect().height;
       this.element.classList.add('resizing');
-      this.element.draggable = false;
       this.element.dataset.resizing = 'true';
       this.resizeHandle?.classList.add('active');
     }, { passive: false });
@@ -246,7 +232,6 @@ export class Panel {
       if (!this.isResizing) return;
       this.isResizing = false;
       this.element.classList.remove('resizing');
-      this.element.draggable = true;
       delete this.element.dataset.resizing;
       this.resizeHandle?.classList.remove('active');
       const currentSpan = this.element.classList.contains('span-4') ? 4 :

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1253,7 +1253,7 @@ canvas,
   border-style: dashed;
 }
 
-.live-channel-btn[draggable="true"] {
+.live-channel-btn {
   cursor: grab;
 }
 


### PR DESCRIPTION
## Summary
- WKWebView (Tauri macOS) doesn't support HTML5 Drag and Drop API — `draggable`, `dragstart`, `dragover`, `drop` all silently fail
- Replace with `mousedown`/`mousemove`/`mouseup` + `elementFromPoint()` across all drag systems:
  - Panel grid reorder (App.ts)
  - Live channel tab reorder (LiveNewsPanel.ts)
  - Channel settings row reorder (live-channels-window.ts)
- Uses `requestAnimationFrame` throttle to prevent reflow storms
- Same-row detection (horizontal midpoint) vs cross-row (vertical midpoint) for accurate grid positioning

## Test plan
- [ ] Tauri macOS: drag panels left/right on same row
- [ ] Tauri macOS: drag panels across rows (up/down)
- [ ] Tauri macOS: drag live channel tabs to reorder
- [ ] Tauri macOS: drag channel rows in manage modal
- [ ] Panel resize (bottom handle) still works
- [ ] Web browser: all drag behaviors unchanged
- [ ] Panel order persists after reload