### PR TITLE
fix: add drag cleanup handlers and suppress click after drag-drop

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -217,6 +217,7 @@ export class LiveNewsPanel extends Panel {
   private useDesktopEmbedProxy = false;
   private desktopEmbedIframe: HTMLIFrameElement | null = null;
   private desktopEmbedRenderToken = 0;
+  private suppressChannelClick = false;
   private boundMessageHandler!: (e: MessageEvent) => void;
   private muteSyncInterval: ReturnType<typeof setInterval> | null = null;
   private static readonly MUTE_SYNC_POLL_MS = 500;
@@ -465,6 +466,11 @@ export class LiveNewsPanel extends Panel {
     btn.textContent = channel.name;
     btn.style.cursor = 'grab';
     btn.addEventListener('click', (e) => {
+      if (this.suppressChannelClick) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
       e.preventDefault();
       this.switchChannel(channel);
     });
@@ -489,6 +495,7 @@ export class LiveNewsPanel extends Panel {
       if (e.button !== 0) return;
       const btn = (e.target as HTMLElement).closest('.live-channel-btn') as HTMLElement | null;
       if (!btn) return;
+      this.suppressChannelClick = false;
       dragging = btn;
       dragStarted = false;
       startX = e.clientX;
@@ -520,6 +527,10 @@ export class LiveNewsPanel extends Panel {
       if (dragStarted) {
         dragging.classList.remove('live-channel-dragging');
         this.applyChannelOrderFromDom();
+        this.suppressChannelClick = true;
+        setTimeout(() => {
+          this.suppressChannelClick = false;
+        }, 0);
       }
       dragging = null;
       dragStarted = false;

--- a/src/live-channels-window.ts
+++ b/src/live-channels-window.ts
@@ -46,6 +46,7 @@ export function initLiveChannelsWindow(containerEl?: HTMLElement): void {
   }
 
   let channels = loadChannelsFromStorage();
+  let suppressRowClick = false;
 
   /** Reads current row order from DOM and persists to storage. */
   function applyOrderFromDom(listEl: HTMLElement): void {
@@ -99,6 +100,10 @@ export function initLiveChannelsWindow(containerEl?: HTMLElement): void {
       if (dragStarted) {
         dragging.classList.remove('live-news-manage-row-dragging');
         applyOrderFromDom(listEl);
+        suppressRowClick = true;
+        setTimeout(() => {
+          suppressRowClick = false;
+        }, 0);
       }
       dragging = null;
       dragStarted = false;
@@ -118,8 +123,8 @@ export function initLiveChannelsWindow(containerEl?: HTMLElement): void {
       row.appendChild(nameSpan);
 
       row.addEventListener('click', (e) => {
-        // Don't open edit if row was just dragged
-        if (row.classList.contains('live-news-manage-row-dragging')) return;
+        // Suppress click immediately after drag-drop to avoid accidental edit open.
+        if (suppressRowClick || row.classList.contains('live-news-manage-row-dragging')) return;
         if ((e.target as HTMLElement).closest('input, button, textarea, select')) return;
         e.preventDefault();
         showEditForm(row, ch, listEl);


### PR DESCRIPTION
## Summary
Follow-up to #313 (WKWebView drag fix). These changes were pushed after the PR was merged:

- Add `panelDragCleanupHandlers` to properly remove document-level `mousemove`/`mouseup` listeners on `destroy()`
- Add `suppressChannelClick` flag in LiveNewsPanel to prevent accidental channel switch after drag-end
- Add `suppressRowClick` flag in live-channels-window to prevent accidental edit-form open after drag-end

## Test plan
- [ ] Drag channel tabs — no accidental channel switch on drop
- [ ] Drag rows in manage modal — no accidental edit-form open on drop
- [ ] App destroy/cleanup — no leaked document listeners