### PR TITLE
feat: add Island Times (Palau) RSS feed

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -198,6 +198,7 @@ const ALLOWED_DOMAINS = [
   'www.bangkokpost.com',
   'vnexpress.net',
   'www.abc.net.au',
+  'islandtimes.org',
   'www.brasilparalelo.com.br',
   // Additional
   'news.ycombinator.com',

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -642,6 +642,8 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     // Australia
     { name: 'ABC News Australia', url: rss('https://www.abc.net.au/news/feed/2942460/rss.xml') },
     { name: 'Guardian Australia', url: rss('https://www.theguardian.com/australia-news/rss') },
+    // Pacific Islands
+    { name: 'Island Times (Palau)', url: rss('https://islandtimes.org/feed/') },
   ],
   energy: [
     { name: 'Oil & Gas', url: rss('https://news.google.com/rss/search?q=(oil+price+OR+OPEC+OR+"natural+gas"+OR+pipeline+OR+LNG)+when:2d&hl=en-US&gl=US&ceid=US:en') },


### PR DESCRIPTION
## Summary
- Adds [Island Times](https://islandtimes.org/) (Palau) RSS feed to the `asia` region for Pacific Islands coverage
- Allowlists `islandtimes.org` in the RSS proxy

## Test plan
- [ ] Verify feed loads via `/api/rss-proxy?url=https://islandtimes.org/feed/`
- [ ] Confirm articles appear in Asia panel