### PR TITLE
chore: remove unused WORLDPOP_API_KEY from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,8 +105,7 @@ VITE_WS_RELAY_URL=
 # UCDP (Uppsala Conflict Data Program) — public API, no auth
 # UNHCR (UN Refugee Agency) — public API, no auth (CC BY 4.0)
 # Open-Meteo — public API, no auth (processes Copernicus ERA5)
-# WorldPop — public API, optional key for higher rate limits
-# WORLDPOP_API_KEY=
+# WorldPop — public API, no auth needed
 
 
 # ------ Site Configuration ------


### PR DESCRIPTION
## Summary
- Removes `WORLDPOP_API_KEY` from `.env.example` — no code references it, WorldPop API is public/no-auth

## Test plan
- [ ] Verify no code imports or references `WORLDPOP_API_KEY`