### PR TITLE
fix: add CARTO and OpenStreetMap attribution to map

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -376,6 +376,12 @@ export class DeckGLMap {
     mapContainer.style.cssText = 'position: absolute; top: 0; left: 0; width: 100%; height: 100%;';
     wrapper.appendChild(mapContainer);
 
+    // Map attribution (CARTO basemap + OpenStreetMap data)
+    const attribution = document.createElement('div');
+    attribution.className = 'map-attribution';
+    attribution.innerHTML = '© <a href="https://carto.com/attributions" target="_blank" rel="noopener">CARTO</a> © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a>';
+    wrapper.appendChild(attribution);
+
     this.container.appendChild(wrapper);
   }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -11925,6 +11925,27 @@ a.prediction-link:hover {
   display: none;
 }
 
+/* Map tile attribution */
+.map-attribution {
+  position: absolute;
+  bottom: 2px;
+  right: 4px;
+  font-size: 9px;
+  color: var(--text-dim);
+  opacity: 0.6;
+  z-index: 10;
+  pointer-events: auto;
+}
+
+.map-attribution a {
+  color: var(--text-dim);
+  text-decoration: none;
+}
+
+.map-attribution a:hover {
+  text-decoration: underline;
+}
+
 /* deck.gl mode indicator */
 .map-container.deckgl-mode::after {
   content: 'WebGL';


### PR DESCRIPTION
## Summary
- Adds small attribution text at bottom-left of the map: `© CARTO © OpenStreetMap`
- Links to CARTO attributions page and OSM copyright page
- Styled to be unobtrusive (9px, dimmed, `opacity: 0.6`)
- TomTom is **not** used — reporter was mistaken about that

## Context
Issue #321 correctly identified that `attributionControl: false` was set on MapLibre, hiding required attribution for CARTO basemap tiles and OpenStreetMap data.

Closes #321

## Test plan
- [ ] Attribution visible at bottom-left of map in dark and light themes
- [ ] Links open correct pages in new tab
- [ ] Text doesn't overlap map controls or legend