### PR TITLE
feat: add Mexico and LatAm security feeds

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -200,6 +200,12 @@ const ALLOWED_DOMAINS = [
   'www.abc.net.au',
   'islandtimes.org',
   'www.brasilparalelo.com.br',
+  // Mexico & LatAm Security
+  'mexiconewsdaily.com',
+  'animalpolitico.com',
+  'www.proceso.com.mx',
+  'www.milenio.com',
+  'insightcrime.org',
   // Additional
   'news.ycombinator.com',
   // Finance variant

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -620,6 +620,16 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     { name: 'El Tiempo', url: rss('https://www.eltiempo.com/rss/mundo_latinoamerica.xml'), lang: 'es' },
     { name: 'El Universal', url: rss('https://www.eluniversal.com.mx/rss.xml'), lang: 'es' },
     { name: 'La Silla Vacía', url: rss('https://www.lasillavacia.com/rss') },
+    // Mexico
+    { name: 'Mexico News Daily', url: rss('https://mexiconewsdaily.com/feed/') },
+    { name: 'Animal Político', url: rss('https://animalpolitico.com/feed/'), lang: 'es' },
+    { name: 'Proceso', url: rss('https://www.proceso.com.mx/feed/'), lang: 'es' },
+    { name: 'Milenio', url: rss('https://www.milenio.com/rss'), lang: 'es' },
+    { name: 'Mexico Security', url: rss('https://news.google.com/rss/search?q=(Mexico+cartel+OR+Mexico+violence+OR+Mexico+troops+OR+narco+Mexico)+when:2d&hl=en-US&gl=US&ceid=US:en') },
+    { name: 'AP Mexico', url: rss('https://news.google.com/rss/search?q=site:apnews.com+Mexico+when:3d&hl=en-US&gl=US&ceid=US:en') },
+    // LatAm Security
+    { name: 'InSight Crime', url: rss('https://insightcrime.org/feed/') },
+    { name: 'France 24 LatAm', url: rss('https://www.france24.com/en/americas/rss') },
   ],
   asia: [
     { name: 'Asia News', url: rss('https://news.google.com/rss/search?q=(China+OR+Japan+OR+Korea+OR+India+OR+ASEAN)+when:2d&hl=en-US&gl=US&ceid=US:en') },


### PR DESCRIPTION
## Summary
- Mexico had only **1 dedicated source** (El Universal) despite significant cartel/security events
- Added **8 new feeds** to the `latam` region for better instability coverage:
  - **Mexico News Daily** — English-language Mexico daily
  - **Animal Político** — Top Mexican investigative journalism (es)
  - **Proceso** — Mexico's leading investigative magazine (es)
  - **Milenio** — Major Mexican newspaper with strong security coverage (es)
  - **Mexico Security** — Targeted Google News query for cartel/violence/troops events
  - **AP Mexico** — Wire service Mexico coverage via Google News
  - **InSight Crime** — Organized crime tracker across Latin America
  - **France 24 LatAm** — France 24's Americas bureau (already in RSS allowlist)
- Added 5 new domains to RSS proxy allowlist

## Test plan
- [ ] Verify latam panel loads new feeds without errors
- [ ] Confirm Mexico security events surface in clustering
- [ ] Check RSS proxy doesn't block any of the new domains