### PR TITLE
chore: k8s adaptation — add Dockerfile, nginx.conf, entrypoint.sh and…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ src-tauri/sidecar/node/*
 
 # Compiled sebuf gateway bundle (built by scripts/build-sidecar-sebuf.mjs)
 api/[[][[].*.js
+
+# K8s secrets
+k8s/secret.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# =============================================================
+# World Monitor — Full-Stack K8s Image
+# nginx (static SPA) + Node.js sidecar (60+ API handlers)
+# =============================================================
+
+# ── Stage 1: Build ───────────────────────────────────────────
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+COPY . .
+
+# Compile the sebuf RPC gateway → self-contained ESM bundle
+# so the sidecar can load all 17 typed service handlers
+RUN node scripts/build-sidecar-sebuf.mjs
+
+# Build the static frontend (SPA)
+ENV VITE_VARIANT=full
+RUN npx tsc || true
+RUN npx vite build
+
+
+# ── Stage 2: Runtime ─────────────────────────────────────────
+FROM node:22-alpine
+
+RUN apk add --no-cache nginx
+
+WORKDIR /app
+
+# ── Static frontend ──
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# ── API layer (sidecar) ──
+# Legacy Vercel edge functions (rss-proxy, eia, youtube, etc.)
+COPY --from=builder /app/api ./api
+# Sebuf server handlers + router + CORS + error-mapper
+COPY --from=builder /app/server ./server
+# Generated TypeScript server stubs (sebuf protoc output)
+COPY --from=builder /app/src/generated ./src/generated
+# Desktop sidecar entry → runs all 60+ handlers as a Node.js HTTP server
+COPY --from=builder /app/src-tauri/sidecar/local-api-server.mjs ./sidecar/local-api-server.mjs
+# Node modules for handler dependencies
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+# AIS relay (live vessel tracking via AISStream WebSocket)
+COPY --from=builder /app/scripts/ais-relay.cjs ./scripts/ais-relay.cjs
+
+# ── nginx config ──
+COPY nginx.conf /etc/nginx/http.d/worldmonitor.conf
+RUN rm -f /etc/nginx/http.d/default.conf
+
+# ── Entrypoint ──
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8080
+
+CMD ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+# ── AIS Relay (vessel tracking) ──
+if [ -n "$AISSTREAM_API_KEY" ]; then
+  echo "[worldmonitor] Starting AIS relay on port 3004..."
+  node /app/scripts/ais-relay.cjs &
+  AIS_PID=$!
+else
+  echo "[worldmonitor] AISSTREAM_API_KEY not set, skipping AIS relay"
+  AIS_PID=""
+fi
+
+echo "[worldmonitor] Starting API sidecar (Node.js) on port 46123..."
+node /app/sidecar/local-api-server.mjs &
+SIDECAR_PID=$!
+
+# Wait for sidecar to be ready
+for i in $(seq 1 30); do
+  if wget -q -O /dev/null http://127.0.0.1:46123/api/service-status 2>/dev/null; then
+    echo "[worldmonitor] API sidecar ready"
+    break
+  fi
+  if ! kill -0 "$SIDECAR_PID" 2>/dev/null; then
+    echo "[worldmonitor] API sidecar crashed during startup"
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "[worldmonitor] Starting nginx on port 8080..."
+nginx -g 'daemon off;' &
+NGINX_PID=$!
+
+# Trap signals and forward to all processes
+trap 'kill $SIDECAR_PID $NGINX_PID $AIS_PID 2>/dev/null; wait' TERM INT QUIT
+
+# Wait for any process to exit
+wait -n $SIDECAR_PID $NGINX_PID ${AIS_PID:-} 2>/dev/null || true
+echo "[worldmonitor] A process exited, shutting down..."
+kill $SIDECAR_PID $NGINX_PID $AIS_PID 2>/dev/null
+wait

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worldmonitor
+  namespace: worldmonitor
+  labels:
+    app.kubernetes.io/name: worldmonitor
+    app.kubernetes.io/component: fullstack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: worldmonitor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: worldmonitor
+        app.kubernetes.io/component: fullstack
+    spec:
+      containers:
+        - name: worldmonitor
+          image: worldmonitor:fullstack
+          imagePullPolicy: Never
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: worldmonitor-api-keys
+          env:
+            # Sidecar config — no cloud fallback, use local handlers only
+            - name: LOCAL_API_PORT
+              value: "46123"
+            - name: LOCAL_API_CLOUD_FALLBACK
+              value: "false"
+            - name: NODE_ENV
+              value: "production"
+            # AIS relay runs inside the pod on port 3004
+            - name: WS_RELAY_URL
+              value: "http://127.0.0.1:3004"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: 3000m
+              memory: 12Gi
+          securityContext:
+            runAsNonRoot: false
+            readOnlyRootFilesystem: false
+      restartPolicy: Always

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: worldmonitor
+  labels:
+    app.kubernetes.io/name: worldmonitor
+    app.kubernetes.io/part-of: worldmonitor

--- a/k8s/secret.template.yaml
+++ b/k8s/secret.template.yaml
@@ -1,0 +1,90 @@
+# World Monitor — API Keys Secret (TEMPLATE)
+# ─────────────────────────────────────────────────────────
+# Copy this file and fill in your real keys:
+#   cp k8s/secret.template.yaml k8s/secret.yaml
+#
+# Then apply:
+#   kubectl apply -f k8s/secret.yaml
+#
+# After adding/changing keys, restart the pod:
+#   kubectl rollout restart deployment/worldmonitor -n worldmonitor
+# ─────────────────────────────────────────────────────────
+apiVersion: v1
+kind: Secret
+metadata:
+  name: worldmonitor-api-keys
+  namespace: worldmonitor
+  labels:
+    app.kubernetes.io/name: worldmonitor
+type: Opaque
+stringData:
+  # ── AI Summarization ──────────────────────────────────
+  # Groq (primary — 14,400 req/day free tier)
+  # Register: https://console.groq.com/
+  GROQ_API_KEY: ""
+
+  # OpenRouter (fallback — 50 req/day free tier)
+  # Register: https://openrouter.ai/
+  OPENROUTER_API_KEY: ""
+
+  # ── Local AI (no cloud, runs on your hardware) ────────
+  # Point to an Ollama or LM Studio instance on your LAN
+  # OLLAMA_API_URL: "http://192.168.1.x:11434"
+  # OLLAMA_MODEL: "llama3.1:8b"
+
+  # ── Cross-User Cache (Upstash Redis) ──────────────────
+  # Deduplicates AI calls, caches risk scores
+  # Register: https://upstash.com/
+  UPSTASH_REDIS_REST_URL: ""
+  UPSTASH_REDIS_REST_TOKEN: ""
+
+  # ── Market Data ───────────────────────────────────────
+  # Finnhub (stock quotes — free tier)
+  # Register: https://finnhub.io/
+  FINNHUB_API_KEY: ""
+
+  # ── Energy Data ───────────────────────────────────────
+  # U.S. EIA (oil prices, production, inventory)
+  # Register: https://www.eia.gov/opendata/
+  EIA_API_KEY: ""
+
+  # ── Economic Data ─────────────────────────────────────
+  # FRED (Federal Reserve economic data)
+  # Register: https://fred.stlouisfed.org/docs/api/api_key.html
+  FRED_API_KEY: ""
+
+  # ── Aircraft Tracking ────────────────────────────────
+  # Wingbits (aircraft enrichment: owner, operator, type)
+  # Register: https://wingbits.com/
+  WINGBITS_API_KEY: ""
+
+  # ── Conflict & Protest Data ──────────────────────────
+  # ACLED (armed conflict data — free for researchers)
+  # Register: https://acleddata.com/
+  ACLED_ACCESS_TOKEN: ""
+
+  # ── Internet Outages ─────────────────────────────────
+  # Cloudflare Radar (free Cloudflare account)
+  CLOUDFLARE_API_TOKEN: ""
+
+  # ── Satellite Fire Detection ─────────────────────────
+  # NASA FIRMS (VIIRS thermal hotspots)
+  # Register: https://firms.modaps.eosdis.nasa.gov/
+  NASA_FIRMS_API_KEY: ""
+
+  # ── AIS Vessel Tracking ──────────────────────────────
+  # AISStream (live vessel positions)
+  # Register: https://aisstream.io/
+  AISSTREAM_API_KEY: ""
+
+  # ── OpenSky Network ──────────────────────────────────
+  # Military/commercial flight tracking
+  # Register: https://opensky-network.org/
+  OPENSKY_CLIENT_ID: ""
+  OPENSKY_CLIENT_SECRET: ""
+
+  # ── Relay Server ─────────────────────────────────────
+  # If you deploy the Railway relay (scripts/ais-relay.cjs)
+  # for AIS + OpenSky live data, set these URLs:
+  # WS_RELAY_URL: "https://your-relay.railway.app"
+  # VITE_WS_RELAY_URL: "wss://your-relay.railway.app"

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: worldmonitor
+  namespace: worldmonitor
+  labels:
+    app.kubernetes.io/name: worldmonitor
+    app.kubernetes.io/component: frontend
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: worldmonitor
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      nodePort: 30080
+      protocol: TCP

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,75 @@
+server {
+    listen 8080;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # ── AIS relay proxy → ais-relay on port 3004 ──
+    location /ais/ {
+        proxy_pass http://127.0.0.1:3004;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 30s;
+        proxy_send_timeout 10s;
+        proxy_buffering off;
+    }
+
+    # ── API reverse proxy → Node.js sidecar on port 46123 ──
+    location /api/ {
+        proxy_pass http://127.0.0.1:46123;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # Strip Origin header so sidecar CORS checks pass
+        proxy_set_header Origin "";
+        proxy_set_header Referer "";
+        # Timeouts for slow upstream APIs
+        proxy_connect_timeout 15s;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 15s;
+        # Don't buffer — stream responses
+        proxy_buffering off;
+    }
+
+    # Cache static assets aggressively (they have content hashes)
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Cache favicons and images
+    location ~* \.(ico|png|jpg|jpeg|gif|svg|webp)$ {
+        expires 7d;
+        add_header Cache-Control "public";
+    }
+
+    # SPA fallback — serve index.html for all routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Health check endpoint
+    location /healthz {
+        access_log off;
+        return 200 "ok";
+        add_header Content-Type text/plain;
+    }
+}

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -1969,11 +1969,19 @@ export class MapPopup {
     };
     const callsign = escapeHtml(flight.callsign || t('popups.unknown'));
     const aircraftTypeBadge = escapeHtml(flight.aircraftType.toUpperCase());
-    const operatorLabel = escapeHtml(operatorLabels[flight.operator] || flight.operatorCountry || t('popups.unknown'));
+    const operatorLabel = escapeHtml(
+      operatorLabels[flight.operator] ||
+      flight.enriched?.operatorName ||
+      flight.operatorCountry ||
+      t('popups.unknown')
+    );
     const hexCode = escapeHtml(flight.hexCode || '');
     const aircraftType = escapeHtml(typeLabels[flight.aircraftType] || flight.aircraftType);
     const squawk = flight.squawk ? escapeHtml(flight.squawk) : '';
     const note = flight.note ? escapeHtml(flight.note) : '';
+    const model = flight.aircraftModel ? escapeHtml(flight.aircraftModel) : '';
+    const registration = flight.registration ? escapeHtml(flight.registration) : '';
+    const owner = flight.enriched?.owner ? escapeHtml(flight.enriched.owner) : '';
 
     return `
       <div class="popup-header military-flight ${flight.operator}">
@@ -1983,6 +1991,7 @@ export class MapPopup {
       </div>
       <div class="popup-body">
         <div class="popup-subtitle">${operatorLabel}</div>
+        ${model ? `<div class="popup-subtitle" style="opacity:0.7;font-size:0.85em">${model}</div>` : ''}
         <div class="popup-stats">
           <div class="popup-stat">
             <span class="stat-label">${t('popups.militaryFlight.altitude')}</span>
@@ -2004,6 +2013,12 @@ export class MapPopup {
             <span class="stat-label">${t('popups.type')}</span>
             <span class="stat-value">${aircraftType}</span>
           </div>
+          ${registration ? `
+          <div class="popup-stat">
+            <span class="stat-label">REG</span>
+            <span class="stat-value">${registration}</span>
+          </div>
+          ` : ''}
           ${flight.squawk ? `
           <div class="popup-stat">
             <span class="stat-label">${t('popups.militaryFlight.squawk')}</span>
@@ -2011,6 +2026,7 @@ export class MapPopup {
           </div>
           ` : ''}
         </div>
+        ${owner ? `<p class="popup-description">${owner}</p>` : ''}
         ${flight.note ? `<p class="popup-description">${note}</p>` : ''}
         <div class="popup-attribution">${t('popups.militaryFlight.attribution')}</div>
       </div>

--- a/src/config/military.ts
+++ b/src/config/military.ts
@@ -204,11 +204,22 @@ export const MILITARY_AIRCRAFT_TYPES: Record<string, { type: MilitaryAircraftTyp
 
   // Transports
   'C130': { type: 'transport', name: 'C-130 Hercules' },
+  'C30J': { type: 'transport', name: 'C-130J Super Hercules' },
+  'C30H': { type: 'transport', name: 'C-130H Hercules' },
   'C17': { type: 'transport', name: 'C-17 Globemaster III' },
   'C5': { type: 'transport', name: 'C-5 Galaxy' },
+  'C5A': { type: 'transport', name: 'C-5A Galaxy' },
+  'C5B': { type: 'transport', name: 'C-5B Galaxy' },
   'C5M': { type: 'transport', name: 'C-5M Super Galaxy' },
   'C40': { type: 'transport', name: 'C-40 Clipper' },
+  'C40A': { type: 'transport', name: 'C-40A Clipper' },
+  'C40B': { type: 'transport', name: 'C-40B' },
   'C32': { type: 'transport', name: 'C-32 (757)' },
+  'C32A': { type: 'transport', name: 'C-32A' },
+  'C27J': { type: 'transport', name: 'C-27J Spartan' },
+  'C295': { type: 'transport', name: 'C-295' },
+  'C160': { type: 'transport', name: 'C-160 Transall' },
+  'CN35': { type: 'transport', name: 'CN-235' },
   'VC25': { type: 'vip', name: 'VC-25 Air Force One' },
   'A400': { type: 'transport', name: 'A400M Atlas' },
   'IL76': { type: 'transport', name: 'Il-76 Candid' },
@@ -219,6 +230,8 @@ export const MILITARY_AIRCRAFT_TYPES: Record<string, { type: MilitaryAircraftTyp
   // Tankers
   'KC135': { type: 'tanker', name: 'KC-135 Stratotanker' },
   'K35R': { type: 'tanker', name: 'KC-135R Stratotanker' },
+  'K35A': { type: 'tanker', name: 'KC-135A Stratotanker' },
+  'K35E': { type: 'tanker', name: 'KC-135E Stratotanker' },
   'KC10': { type: 'tanker', name: 'KC-10 Extender' },
   'KC46': { type: 'tanker', name: 'KC-46 Pegasus' },
   'A330': { type: 'tanker', name: 'A330 MRTT' },
@@ -227,6 +240,8 @@ export const MILITARY_AIRCRAFT_TYPES: Record<string, { type: MilitaryAircraftTyp
   // AWACS/AEW
   'E3': { type: 'awacs', name: 'E-3 Sentry AWACS' },
   'E3TF': { type: 'awacs', name: 'E-3 Sentry AWACS' },
+  'E3CF': { type: 'awacs', name: 'E-3 Sentry AWACS' },
+  'E3A': { type: 'awacs', name: 'E-3A Sentry AWACS' },
   'E7': { type: 'awacs', name: 'E-7 Wedgetail' },
   'E2': { type: 'awacs', name: 'E-2 Hawkeye' },
   'A50': { type: 'awacs', name: 'A-50 Mainstay' },
@@ -235,12 +250,14 @@ export const MILITARY_AIRCRAFT_TYPES: Record<string, { type: MilitaryAircraftTyp
   // Reconnaissance
   'RC135': { type: 'reconnaissance', name: 'RC-135 Rivet Joint' },
   'R135': { type: 'reconnaissance', name: 'RC-135' },
+  'E6': { type: 'reconnaissance', name: 'E-6B Mercury' },
+  'E6B': { type: 'reconnaissance', name: 'E-6B Mercury' },
+  'WC135': { type: 'reconnaissance', name: 'WC-135 Constant Phoenix' },
+  'OC135': { type: 'reconnaissance', name: 'OC-135 Open Skies' },
   'U2': { type: 'reconnaissance', name: 'U-2 Dragon Lady' },
   'U2S': { type: 'reconnaissance', name: 'U-2S Dragon Lady' },
   'EP3': { type: 'reconnaissance', name: 'EP-3 Aries' },
   'E8': { type: 'reconnaissance', name: 'E-8 JSTARS' },
-  'WC135': { type: 'reconnaissance', name: 'WC-135 Constant Phoenix' },
-  'OC135': { type: 'reconnaissance', name: 'OC-135 Open Skies' },
 
   // Maritime Patrol
   'P8': { type: 'patrol', name: 'P-8 Poseidon' },
@@ -249,8 +266,11 @@ export const MILITARY_AIRCRAFT_TYPES: Record<string, { type: MilitaryAircraftTyp
 
   // Drones/UAV
   'RQ4': { type: 'drone', name: 'RQ-4 Global Hawk' },
+  'RQ4B': { type: 'drone', name: 'RQ-4B Global Hawk' },
   'GLHK': { type: 'drone', name: 'RQ-4 Global Hawk' },
+  'HRON': { type: 'drone', name: 'MQ-4C Triton' },
   'MQ9': { type: 'drone', name: 'MQ-9 Reaper' },
+  'MQ9A': { type: 'drone', name: 'MQ-9A Reaper' },
   'MQ1': { type: 'drone', name: 'MQ-1 Predator' },
   'RQ170': { type: 'drone', name: 'RQ-170 Sentinel' },
   'MQ4C': { type: 'drone', name: 'MQ-4C Triton' },

--- a/src/services/maritime/index.ts
+++ b/src/services/maritime/index.ts
@@ -197,6 +197,12 @@ async function fetchRawRelaySnapshot(includeCandidates: boolean): Promise<unknow
     if (local.ok) return local.json();
   }
 
+  // Same-origin fallback: relay available via nginx /ais/ proxy (K8s deployments)
+  if (isClientRuntime && !RAILWAY_SNAPSHOT_URL && !isLocalhost) {
+    const sameOrigin = await fetch(`/ais/snapshot${query}`, { headers: { Accept: 'application/json' } });
+    if (sameOrigin.ok) return sameOrigin.json();
+  }
+
   throw new Error('AIS raw relay snapshot unavailable');
 }
 


### PR DESCRIPTION
## Summary

This PR adapts the original Vercel-based deployment of WorldMonitor to run in a self-hosted Kubernetes environment.

The app was originally designed to run on Vercel (edge functions for the API, CDN for the static frontend). This adaptation packages everything into a single self-contained Docker image — nginx serves the SPA and proxies API calls to an embedded Node.js sidecar that runs all 60+ API handlers locally, with no cloud dependency.

**Containerization:**
- Multi-stage `Dockerfile` — builds the Vite SPA and compiles the sebuf RPC gateway, then packages nginx + Node.js runtime in a minimal Alpine image
- `nginx.conf` — serves the SPA with aggressive asset caching, proxies `/api/*` to the Node.js sidecar (port 46123) and `/ais/*` to the AIS relay (port 3004)
- `entrypoint.sh` — orchestrates all three processes (nginx, API sidecar, AIS relay) within the pod, with readiness checks and graceful shutdown

**Kubernetes manifests (`k8s/`):**
- `namespace.yaml` — dedicated `worldmonitor` namespace
- `deployment.yaml` — single-replica deployment, resource limits, liveness/readiness probes against `/healthz`
- `service.yaml` — NodePort service on port 30080
- `secret.template.yaml` — template for all required API keys (blank values); `secret.yaml` is gitignored to prevent leaking credentials

**API adjustments:**
- Military flight tracking (`list-military-flights.ts`) — added OpenSky metadata batch enrichment (registration, model, country, operator, confidence) and Redis bbox-quantized caching so the sidecar behaves efficiently under self-hosted conditions
- Theater posture (`get-theater-posture.ts`) — unified OpenSky auth to use shared `openSkyHeaders()` (Bearer token support)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Docker / nginx / Kubernetes manifests

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots

_N/A — infrastructure only_