### PR TITLE
fix: add Mexico to COUNTRY_BOUNDS and COUNTRY_ALIASES

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1159,6 +1159,7 @@ export class App {
     GB: { n: 58.7, s: 49.9, e: 1.8, w: -8.2 }, DE: { n: 55.1, s: 47.3, e: 15.0, w: 5.9 },
     FR: { n: 51.1, s: 41.3, e: 9.6, w: -5.1 }, TR: { n: 42.1, s: 36, e: 44.8, w: 26 },
     BR: { n: 5.3, s: -33.8, e: -34.8, w: -73.9 },
+    MX: { n: 32.7, s: 14.5, e: -86.7, w: -118.4 },
   };
 
   private static COUNTRY_ALIASES: Record<string, string[]> = {
@@ -1184,6 +1185,7 @@ export class App {
     GB: ['united kingdom', 'british', 'london', 'uk '],
     BR: ['brazil', 'brazilian', 'brasilia', 'lula', 'bolsonaro'],
     AE: ['united arab emirates', 'uae', 'emirati', 'dubai', 'abu dhabi'],
+    MX: ['mexico', 'mexican', 'cartel', 'sinaloa', 'jalisco', 'cjng', 'tijuana', 'juarez', 'fentanyl', 'sheinbaum', 'sedena', 'narco'],
   };
 
   private static otherCountryTermsCache: Map<string, string[]> = new Map();


### PR DESCRIPTION
## Summary

- Adds Mexico geo-bounds and news aliases that were missed in PR #337
- Without these, the country brief for Mexico can't geo-match protests/conflicts to its territory, and only matches the bare word "mexico" in headlines (missing cartel/narco/fentanyl stories)

## Changes

**`COUNTRY_BOUNDS`**: `MX: { n: 32.7, s: 14.5, e: -86.7, w: -118.4 }`
**`COUNTRY_ALIASES`**: `mexico`, `mexican`, `cartel`, `sinaloa`, `jalisco`, `cjng`, `tijuana`, `juarez`, `fentanyl`, `sheinbaum`, `sedena`, `narco`

## Test plan

- [x] `tsc --noEmit` — zero errors
- [x] `npm run build:full` — passes
- [ ] Open Mexico country brief — should show cartel/narco headlines in Top News section
- [ ] Protests/conflicts in Mexico territory should appear in 7-day timeline