### PR TITLE
Add Mexico to geopolitical instability tracking and port data

### DIFF
--- a/src/config/countries.ts
+++ b/src/config/countries.ts
@@ -26,4 +26,5 @@ export const TIER1_COUNTRIES: Record<string, string> = {
   VE: 'Venezuela',
   BR: 'Brazil',
   AE: 'United Arab Emirates',
+  MX: 'Mexico',
 };

--- a/src/config/ports.ts
+++ b/src/config/ports.ts
@@ -80,6 +80,11 @@ export const PORTS: Port[] = [
   { id: 'nhava_sheva', name: 'Nhava Sheva (JNPT)', lat: 18.95, lon: 72.95, country: 'India', type: 'container', note: "India's busiest container port. Mumbai gateway. 6M+ TEU." },
   { id: 'chennai', name: 'Port of Chennai', lat: 13.10, lon: 80.29, country: 'India', type: 'container', note: "India's 2nd largest. Auto industry. Bay of Bengal." },
   { id: 'mundra', name: 'Mundra Port', lat: 22.73, lon: 69.72, country: 'India', type: 'mixed', note: "India's largest private port. Adani Group." },
+
+  // Mexico
+  { id: 'manzanillo', name: 'Port of Manzanillo', lat: 19.05, lon: -104.32, country: 'Mexico', type: 'container', note: "Mexico's busiest port. Pacific gateway. USMCA trade corridor. 3M+ TEU." },
+  { id: 'lazaro_cardenas', name: 'Lazaro Cardenas', lat: 17.94, lon: -102.18, country: 'Mexico', type: 'mixed', note: "Mexico's 2nd largest. Pacific deep-water. Asia-Mexico trade. Auto/steel exports." },
+  { id: 'veracruz', name: 'Port of Veracruz', lat: 19.20, lon: -96.13, country: 'Mexico', type: 'mixed', note: "Mexico's oldest and largest Gulf port. Auto imports. US-Mexico trade." },
 ];
 
 export function getPortsByType(type: PortType): Port[] {

--- a/src/services/country-instability.ts
+++ b/src/services/country-instability.ts
@@ -115,6 +115,7 @@ const COUNTRY_KEYWORDS: Record<string, string[]> = {
   VE: ['venezuela', 'caracas', 'maduro'],
   BR: ['brazil', 'brasilia', 'lula', 'bolsonaro'],
   AE: ['uae', 'emirates', 'dubai', 'abu dhabi'],
+  MX: ['mexico', 'mexican', 'amlo', 'sheinbaum', 'cartel', 'sinaloa', 'jalisco', 'cjng', 'tijuana', 'juarez', 'sedena'],
 };
 
 // Geopolitical baseline risk scores (0-50)
@@ -142,6 +143,7 @@ const BASELINE_RISK: Record<string, number> = {
   VE: 40,   // Economic collapse, authoritarian
   BR: 15,   // Large democracy, social tensions, Amazon deforestation
   AE: 10,   // Stable, regional hub, low internal unrest
+  MX: 35,   // Cartel warfare, state fragility, fentanyl crisis, US border tensions
 };
 
 // Event significance multipliers
@@ -170,6 +172,7 @@ const EVENT_MULTIPLIER: Record<string, number> = {
   VE: 1.8,  // Suppressed
   BR: 0.6,  // Large democracy, many events
   AE: 1.5,  // Events rare, significant when occur
+  MX: 1.0,  // Mixed: some events well-reported, cartel zones under-reported
 };
 
 const countryDataMap = new Map<string, CountryData>();
@@ -248,6 +251,7 @@ const ISO3_TO_ISO2: Record<string, string> = {
   COL: 'CO', NGA: 'NG', PSE: 'PS', TUR: 'TR', PAK: 'PK', IRN: 'IR',
   IND: 'IN', CHN: 'CN', RUS: 'RU', ISR: 'IL', SAU: 'SA', USA: 'US',
   TWN: 'TW', PRK: 'KP', POL: 'PL', DEU: 'DE', FRA: 'FR', GBR: 'GB',
+  MEX: 'MX',
 };
 
 const COUNTRY_NAME_TO_ISO: Record<string, string> = {
@@ -256,7 +260,7 @@ const COUNTRY_NAME_TO_ISO: Record<string, string> = {
   'Yemen': 'YE', 'Ethiopia': 'ET', 'Venezuela': 'VE', 'Iraq': 'IQ',
   'Colombia': 'CO', 'Nigeria': 'NG', 'Palestine': 'PS', 'Turkey': 'TR',
   'Pakistan': 'PK', 'Iran': 'IR', 'India': 'IN', 'China': 'CN',
-  'Russia': 'RU', 'Israel': 'IL', 'Saudi Arabia': 'SA',
+  'Russia': 'RU', 'Israel': 'IL', 'Saudi Arabia': 'SA', 'Mexico': 'MX',
 };
 
 export function ingestDisplacementForCII(countries: CountryDisplacement[]): void {
@@ -312,6 +316,7 @@ const COUNTRY_BOUNDS: Record<string, [number, number, number, number]> = {
   IN: [6, 36, 68, 97],       // India
   CN: [18, 54, 73, 135],     // China
   RU: [41, 82, 19, 180],     // Russia (simplified)
+  MX: [14, 33, -118, -86],   // Mexico
 };
 const LOCATION_COUNTRY_CANDIDATES = Object.keys(TIER1_COUNTRIES);
 
@@ -342,6 +347,7 @@ const HOTSPOT_COUNTRY_MAP: Record<string, string> = {
   telaviv: 'IL', pyongyang: 'KP', riyadh: 'SA', ankara: 'TR', damascus: 'SY',
   sanaa: 'YE', caracas: 'VE', dc: 'US', london: 'GB', brussels: 'FR',
   baghdad: 'IR', beirut: 'IR', doha: 'SA', abudhabi: 'SA',
+  mexico: 'MX',
 };
 
 const hotspotActivityMap = new Map<string, number>();

--- a/src/services/infrastructure-cascade.ts
+++ b/src/services/infrastructure-cascade.ts
@@ -214,7 +214,7 @@ function normalizeCountryCode(country: string): string {
     'Yemen': 'YE', 'Panama': 'PA', 'Spain': 'ES', 'Pakistan': 'PK',
     'Sri Lanka': 'LK', 'Japan': 'JP', 'UK': 'GB', 'France': 'FR',
     'Brazil': 'BR', 'India': 'IN', 'Singapore': 'SG', 'Germany': 'DE',
-    'UAE': 'AE',
+    'UAE': 'AE', 'Mexico': 'MX',
   };
   return mappings[country] || country;
 }


### PR DESCRIPTION
## Summary

Adds Mexico as a Tier 1 country to the geopolitical instability monitoring system and includes major Mexican ports in the infrastructure database. Mexico is configured with appropriate risk baseline (35), event multiplier (1.0), and relevant keywords for cartel activity and political figures.

## Type of change

- [x] New feature
- [x] New data source / feed

## Affected areas

- [x] Map / Globe
- [x] Config / Settings
- [x] API endpoints (`/api/*`)

## Changes

### Geopolitical Instability Service
- Added Mexico (MX) to `COUNTRY_KEYWORDS` with terms covering political leadership (AMLO, Sheinbaum) and cartel-related activity (Sinaloa, CJNG, Tijuana, Juarez, Sedena)
- Set baseline risk score of 35 for Mexico (reflecting cartel warfare, state fragility, and fentanyl crisis)
- Configured event multiplier of 1.0 (mixed reporting: some events well-documented, cartel zones under-reported)
- Added Mexico to ISO3-to-ISO2 mapping and country name mappings
- Added geographic bounds for Mexico bounding box detection
- Added 'mexico' to hotspot country map

### Port Infrastructure
- Added three major Mexican ports to the ports database:
  - **Manzanillo**: Mexico's busiest port, Pacific gateway, 3M+ TEU capacity
  - **Lazaro Cardenas**: 2nd largest, deep-water Pacific port for Asia-Mexico trade
  - **Veracruz**: Largest Gulf port, primary US-Mexico trade gateway

### Infrastructure Cascade Service
- Updated country code normalization to include Mexico mapping

## Checklist

- [x] TypeScript compiles without errors
- [x] No API keys or secrets committed
- [x] Configuration changes follow existing patterns

https://claude.ai/code/session_01SvianZPVThu1SigAVNTLcT