### PR TITLE
feat: universal country detection — CII scoring for all countries

### DIFF
--- a/src/config/countries.ts
+++ b/src/config/countries.ts
@@ -1,7 +1,223 @@
-/**
- * Tier 1 Countries - Core geopolitical focus
- * Separated to avoid circular dependencies between services
- */
+export interface CuratedCountryConfig {
+  name: string;
+  scoringKeywords: string[];
+  searchAliases: string[];
+  baselineRisk: number;
+  eventMultiplier: number;
+}
+
+export const CURATED_COUNTRIES: Record<string, CuratedCountryConfig> = {
+  US: {
+    name: 'United States',
+    scoringKeywords: ['united states', 'usa', 'america', 'washington', 'biden', 'trump', 'pentagon'],
+    searchAliases: ['united states', 'american', 'washington', 'pentagon', 'white house', 'usa', 'america', 'biden', 'trump'],
+    baselineRisk: 5,
+    eventMultiplier: 0.3,
+  },
+  RU: {
+    name: 'Russia',
+    scoringKeywords: ['russia', 'moscow', 'kremlin', 'putin'],
+    searchAliases: ['russia', 'russian', 'moscow', 'kremlin', 'putin', 'ukraine war'],
+    baselineRisk: 35,
+    eventMultiplier: 2.0,
+  },
+  CN: {
+    name: 'China',
+    scoringKeywords: ['china', 'beijing', 'xi jinping', 'prc'],
+    searchAliases: ['china', 'chinese', 'beijing', 'taiwan strait', 'south china sea', 'xi jinping'],
+    baselineRisk: 25,
+    eventMultiplier: 2.5,
+  },
+  UA: {
+    name: 'Ukraine',
+    scoringKeywords: ['ukraine', 'kyiv', 'zelensky', 'donbas'],
+    searchAliases: ['ukraine', 'ukrainian', 'kyiv', 'zelensky', 'zelenskyy'],
+    baselineRisk: 50,
+    eventMultiplier: 0.8,
+  },
+  IR: {
+    name: 'Iran',
+    scoringKeywords: ['iran', 'tehran', 'khamenei', 'irgc'],
+    searchAliases: ['iran', 'iranian', 'tehran', 'persian', 'irgc', 'khamenei'],
+    baselineRisk: 40,
+    eventMultiplier: 2.0,
+  },
+  IL: {
+    name: 'Israel',
+    scoringKeywords: ['israel', 'tel aviv', 'netanyahu', 'idf', 'gaza'],
+    searchAliases: ['israel', 'israeli', 'gaza', 'hamas', 'hezbollah', 'netanyahu', 'idf', 'west bank', 'tel aviv', 'jerusalem'],
+    baselineRisk: 45,
+    eventMultiplier: 0.7,
+  },
+  TW: {
+    name: 'Taiwan',
+    scoringKeywords: ['taiwan', 'taipei'],
+    searchAliases: ['taiwan', 'taiwanese', 'taipei'],
+    baselineRisk: 30,
+    eventMultiplier: 1.5,
+  },
+  KP: {
+    name: 'North Korea',
+    scoringKeywords: ['north korea', 'pyongyang', 'kim jong'],
+    searchAliases: ['north korea', 'pyongyang', 'kim jong'],
+    baselineRisk: 45,
+    eventMultiplier: 3.0,
+  },
+  SA: {
+    name: 'Saudi Arabia',
+    scoringKeywords: ['saudi arabia', 'riyadh', 'mbs'],
+    searchAliases: ['saudi', 'riyadh', 'mbs'],
+    baselineRisk: 20,
+    eventMultiplier: 2.0,
+  },
+  TR: {
+    name: 'Turkey',
+    scoringKeywords: ['turkey', 'ankara', 'erdogan'],
+    searchAliases: ['turkey', 'turkish', 'ankara', 'erdogan', 'türkiye'],
+    baselineRisk: 25,
+    eventMultiplier: 1.2,
+  },
+  PL: {
+    name: 'Poland',
+    scoringKeywords: ['poland', 'warsaw'],
+    searchAliases: ['poland', 'polish', 'warsaw'],
+    baselineRisk: 10,
+    eventMultiplier: 0.8,
+  },
+  DE: {
+    name: 'Germany',
+    scoringKeywords: ['germany', 'berlin'],
+    searchAliases: ['germany', 'german', 'berlin'],
+    baselineRisk: 5,
+    eventMultiplier: 0.5,
+  },
+  FR: {
+    name: 'France',
+    scoringKeywords: ['france', 'paris', 'macron'],
+    searchAliases: ['france', 'french', 'paris', 'macron'],
+    baselineRisk: 10,
+    eventMultiplier: 0.6,
+  },
+  GB: {
+    name: 'United Kingdom',
+    scoringKeywords: ['britain', 'uk', 'london', 'starmer'],
+    searchAliases: ['united kingdom', 'british', 'london', 'uk '],
+    baselineRisk: 5,
+    eventMultiplier: 0.5,
+  },
+  IN: {
+    name: 'India',
+    scoringKeywords: ['india', 'delhi', 'modi'],
+    searchAliases: ['india', 'indian', 'new delhi', 'modi'],
+    baselineRisk: 20,
+    eventMultiplier: 0.8,
+  },
+  PK: {
+    name: 'Pakistan',
+    scoringKeywords: ['pakistan', 'islamabad'],
+    searchAliases: ['pakistan', 'pakistani', 'islamabad'],
+    baselineRisk: 35,
+    eventMultiplier: 1.5,
+  },
+  SY: {
+    name: 'Syria',
+    scoringKeywords: ['syria', 'damascus', 'assad'],
+    searchAliases: ['syria', 'syrian', 'damascus', 'assad'],
+    baselineRisk: 50,
+    eventMultiplier: 0.7,
+  },
+  YE: {
+    name: 'Yemen',
+    scoringKeywords: ['yemen', 'sanaa', 'houthi'],
+    searchAliases: ['yemen', 'houthi', 'sanaa'],
+    baselineRisk: 50,
+    eventMultiplier: 0.7,
+  },
+  MM: {
+    name: 'Myanmar',
+    scoringKeywords: ['myanmar', 'burma', 'rangoon'],
+    searchAliases: ['myanmar', 'burmese', 'burma', 'rangoon'],
+    baselineRisk: 45,
+    eventMultiplier: 1.8,
+  },
+  VE: {
+    name: 'Venezuela',
+    scoringKeywords: ['venezuela', 'caracas', 'maduro'],
+    searchAliases: ['venezuela', 'venezuelan', 'caracas', 'maduro'],
+    baselineRisk: 40,
+    eventMultiplier: 1.8,
+  },
+  BR: {
+    name: 'Brazil',
+    scoringKeywords: ['brazil', 'brasilia', 'lula', 'bolsonaro'],
+    searchAliases: ['brazil', 'brazilian', 'brasilia', 'lula', 'bolsonaro'],
+    baselineRisk: 15,
+    eventMultiplier: 0.6,
+  },
+  AE: {
+    name: 'United Arab Emirates',
+    scoringKeywords: ['uae', 'emirates', 'dubai', 'abu dhabi'],
+    searchAliases: ['united arab emirates', 'uae', 'emirati', 'dubai', 'abu dhabi'],
+    baselineRisk: 10,
+    eventMultiplier: 1.5,
+  },
+  MX: {
+    name: 'Mexico',
+    scoringKeywords: ['mexico', 'mexican', 'amlo', 'sheinbaum', 'cartel', 'sinaloa', 'jalisco', 'cjng', 'tijuana', 'juarez', 'sedena'],
+    searchAliases: ['mexico', 'mexican', 'amlo', 'sheinbaum', 'cartel', 'sinaloa', 'jalisco', 'cjng', 'tijuana', 'juarez', 'sedena', 'fentanyl', 'narco'],
+    baselineRisk: 35,
+    eventMultiplier: 1.0,
+  },
+  KR: {
+    name: 'South Korea',
+    scoringKeywords: ['south korea', 'seoul'],
+    searchAliases: ['south korea', 'seoul'],
+    baselineRisk: 15,
+    eventMultiplier: 1.0,
+  },
+  IQ: {
+    name: 'Iraq',
+    scoringKeywords: ['iraq', 'iraqi', 'baghdad'],
+    searchAliases: ['iraq', 'iraqi', 'baghdad'],
+    baselineRisk: 35,
+    eventMultiplier: 1.0,
+  },
+  AF: {
+    name: 'Afghanistan',
+    scoringKeywords: ['afghanistan', 'afghan', 'kabul', 'taliban'],
+    searchAliases: ['afghanistan', 'afghan', 'kabul', 'taliban'],
+    baselineRisk: 15,
+    eventMultiplier: 1.0,
+  },
+  LB: {
+    name: 'Lebanon',
+    scoringKeywords: ['lebanon', 'lebanese', 'beirut'],
+    searchAliases: ['lebanon', 'lebanese', 'beirut'],
+    baselineRisk: 15,
+    eventMultiplier: 1.0,
+  },
+  EG: {
+    name: 'Egypt',
+    scoringKeywords: ['egypt', 'egyptian', 'cairo', 'suez'],
+    searchAliases: ['egypt', 'egyptian', 'cairo', 'suez'],
+    baselineRisk: 15,
+    eventMultiplier: 1.0,
+  },
+  JP: {
+    name: 'Japan',
+    scoringKeywords: ['japan', 'japanese', 'tokyo'],
+    searchAliases: ['japan', 'japanese', 'tokyo'],
+    baselineRisk: 15,
+    eventMultiplier: 1.0,
+  },
+  QA: {
+    name: 'Qatar',
+    scoringKeywords: ['qatar', 'qatari', 'doha'],
+    searchAliases: ['qatar', 'qatari', 'doha'],
+    baselineRisk: 15,
+    eventMultiplier: 1.0,
+  },
+};
 
 export const TIER1_COUNTRIES: Record<string, string> = {
   US: 'United States',
@@ -28,3 +244,22 @@ export const TIER1_COUNTRIES: Record<string, string> = {
   AE: 'United Arab Emirates',
   MX: 'Mexico',
 };
+
+export const DEFAULT_BASELINE_RISK = 15;
+export const DEFAULT_EVENT_MULTIPLIER = 1.0;
+
+export const HOTSPOT_COUNTRY_MAP: Record<string, string | string[]> = {
+  tehran: 'IR', moscow: 'RU', beijing: 'CN', kyiv: 'UA', taipei: 'TW',
+  telaviv: 'IL', pyongyang: 'KP', sanaa: 'YE', riyadh: 'SA', ankara: 'TR',
+  damascus: 'SY', caracas: 'VE', dc: 'US', london: 'GB',
+  brussels: 'BE', baghdad: 'IQ', beirut: 'LB', doha: 'QA', abudhabi: 'AE',
+  mexico: 'MX', nuuk: 'GL', sahel: ['ML', 'NE', 'BF'], haiti: 'HT',
+  horn_africa: ['ET', 'SO', 'SD'], silicon_valley: 'US', wall_street: 'US',
+  houston: 'US', cairo: 'EG',
+};
+
+export function getHotspotCountries(hotspotId: string): string[] {
+  const val = HOTSPOT_COUNTRY_MAP[hotspotId];
+  if (!val) return [];
+  return Array.isArray(val) ? val : [val];
+}

--- a/src/services/conflict/index.ts
+++ b/src/services/conflict/index.ts
@@ -124,14 +124,10 @@ function toUcdpGeoEvent(proto: ProtoUcdpEvent): UcdpGeoEvent {
 
 // ---- Adapter 3: Proto HumanitarianCountrySummary -> legacy HapiConflictSummary ----
 
-const ISO3_TO_ISO2: Record<string, string> = {
-  USA: 'US', RUS: 'RU', CHN: 'CN', UKR: 'UA', IRN: 'IR',
-  ISR: 'IL', TWN: 'TW', PRK: 'KP', SAU: 'SA', TUR: 'TR',
-  POL: 'PL', DEU: 'DE', FRA: 'FR', GBR: 'GB', IND: 'IN',
-  PAK: 'PK', SYR: 'SY', YEM: 'YE', MMR: 'MM', VEN: 'VE',
-};
-
-const ISO2_TO_ISO2_KEYS = Object.values(ISO3_TO_ISO2);
+const HAPI_COUNTRY_CODES = [
+  'US', 'RU', 'CN', 'UA', 'IR', 'IL', 'TW', 'KP', 'SA', 'TR',
+  'PL', 'DE', 'FR', 'GB', 'IN', 'PK', 'SY', 'YE', 'MM', 'VE',
+];
 
 function toHapiSummary(proto: ProtoHumanSummary): HapiConflictSummary {
   // Proto fields now accurately represent HAPI conflict event data (MEDIUM-1 fix)
@@ -271,7 +267,7 @@ export async function fetchUcdpClassifications(): Promise<Map<string, UcdpConfli
 
 export async function fetchHapiSummary(): Promise<Map<string, HapiConflictSummary>> {
   const results = await Promise.allSettled(
-    ISO2_TO_ISO2_KEYS.map(async (iso2) => {
+    HAPI_COUNTRY_CODES.map(async (iso2) => {
       const resp = await hapiBreaker.execute(async () => {
         return client.getHumanitarianSummary({ countryCode: iso2 });
       }, emptyHapiFallback);

--- a/src/services/country-geometry.ts
+++ b/src/services/country-geometry.ts
@@ -14,17 +14,33 @@ interface CountryHit {
 
 const COUNTRY_GEOJSON_URL = '/data/countries.geojson';
 
+const POLITICAL_OVERRIDES: Record<string, string> = { 'CN-TW': 'TW' };
+
+const NAME_ALIASES: Record<string, string> = {
+  'dr congo': 'CD', 'democratic republic of the congo': 'CD',
+  'czech republic': 'CZ', 'ivory coast': 'CI', "cote d'ivoire": 'CI',
+  'uae': 'AE', 'uk': 'GB', 'usa': 'US',
+  'south korea': 'KR', 'north korea': 'KP',
+  'republic of the congo': 'CG', 'east timor': 'TL',
+  'cape verde': 'CV', 'swaziland': 'SZ', 'burma': 'MM',
+};
+
 let loadPromise: Promise<void> | null = null;
 let loadedGeoJson: FeatureCollection<Geometry> | null = null;
 const countryIndex = new Map<string, IndexedCountryGeometry>();
 let countryList: IndexedCountryGeometry[] = [];
+const iso3ToIso2 = new Map<string, string>();
+const nameToIso2 = new Map<string, string>();
+const codeToName = new Map<string, string>();
+let sortedCountryNames: Array<{ name: string; code: string; regex: RegExp }> = [];
 
 function normalizeCode(properties: GeoJsonProperties | null | undefined): string | null {
   if (!properties) return null;
   const rawCode = properties['ISO3166-1-Alpha-2'] ?? properties.ISO_A2 ?? properties.iso_a2;
   if (typeof rawCode !== 'string') return null;
-  const code = rawCode.trim().toUpperCase();
-  return /^[A-Z]{2}$/.test(code) ? code : null;
+  const trimmed = rawCode.trim().toUpperCase();
+  const overridden = POLITICAL_OVERRIDES[trimmed] ?? trimmed;
+  return /^[A-Z]{2}$/.test(overridden) ? overridden : null;
 }
 
 function normalizeName(properties: GeoJsonProperties | null | undefined): string | null {
@@ -135,6 +151,21 @@ function pointInCountryGeometry(country: IndexedCountryGeometry, lon: number, la
   return false;
 }
 
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildCountryNameMatchers(): void {
+  sortedCountryNames = [...nameToIso2.entries()]
+    .filter(([name]) => name.length >= 4)
+    .sort((a, b) => b[0].length - a[0].length)
+    .map(([name, code]) => ({
+      name,
+      code,
+      regex: new RegExp(`\\b${escapeRegex(name)}\\b`, 'i'),
+    }));
+}
+
 async function ensureLoaded(): Promise<void> {
   if (loadedGeoJson || loadPromise) {
     await loadPromise;
@@ -158,11 +189,21 @@ async function ensureLoaded(): Promise<void> {
       loadedGeoJson = data;
       countryIndex.clear();
       countryList = [];
+      iso3ToIso2.clear();
+      nameToIso2.clear();
+      codeToName.clear();
 
       for (const feature of data.features) {
         const code = normalizeCode(feature.properties);
         const name = normalizeName(feature.properties);
         if (!code || !name) continue;
+
+        const iso3 = feature.properties?.['ISO3166-1-Alpha-3'];
+        if (typeof iso3 === 'string' && /^[A-Z]{3}$/i.test(iso3.trim())) {
+          iso3ToIso2.set(iso3.trim().toUpperCase(), code);
+        }
+        nameToIso2.set(name.toLowerCase(), code);
+        if (!codeToName.has(code)) codeToName.set(code, name);
 
         const polygons = normalizeGeometry(feature.geometry);
         const bbox = computeBbox(polygons);
@@ -172,6 +213,14 @@ async function ensureLoaded(): Promise<void> {
         countryIndex.set(code, indexed);
         countryList.push(indexed);
       }
+
+      for (const [alias, code] of Object.entries(NAME_ALIASES)) {
+        if (!nameToIso2.has(alias)) {
+          nameToIso2.set(alias, code);
+        }
+      }
+
+      buildCountryNameMatchers();
     } catch (err) {
       console.warn('[country-geometry] Failed to load countries.geojson:', err);
     }
@@ -190,12 +239,10 @@ export async function getCountriesGeoJson(): Promise<FeatureCollection<Geometry>
 }
 
 export function hasCountryGeometry(code: string): boolean {
-  // Synchronous API: caller should preload via preloadCountryGeometry().
   return countryIndex.has(code.toUpperCase());
 }
 
 export function getCountryAtCoordinates(lat: number, lon: number, candidateCodes?: string[]): CountryHit | null {
-  // Synchronous API: return null until geometry is preloaded.
   if (!loadedGeoJson) return null;
   const candidates = Array.isArray(candidateCodes) && candidateCodes.length > 0
     ? candidateCodes
@@ -212,9 +259,45 @@ export function getCountryAtCoordinates(lat: number, lon: number, candidateCodes
 }
 
 export function isCoordinateInCountry(lat: number, lon: number, code: string): boolean | null {
-  // Synchronous API: return null until geometry is preloaded.
   if (!loadedGeoJson) return null;
   const country = countryIndex.get(code.toUpperCase());
   if (!country) return null;
   return pointInCountryGeometry(country, lon, lat);
+}
+
+export function getCountryNameByCode(code: string): string | null {
+  const upper = code.toUpperCase();
+  const entry = countryIndex.get(upper);
+  if (entry) return entry.name;
+  return codeToName.get(upper) ?? null;
+}
+
+export function iso3ToIso2Code(iso3: string): string | null {
+  return iso3ToIso2.get(iso3.trim().toUpperCase()) ?? null;
+}
+
+export function nameToCountryCode(text: string): string | null {
+  const normalized = text.toLowerCase().trim();
+  return nameToIso2.get(normalized) ?? null;
+}
+
+export function matchCountryNamesInText(text: string): string[] {
+  const matched: string[] = [];
+  let remaining = text.toLowerCase();
+  for (const { code, regex } of sortedCountryNames) {
+    if (regex.test(remaining)) {
+      matched.push(code);
+      remaining = remaining.replace(regex, '');
+    }
+  }
+  return matched;
+}
+
+export function getAllCountryCodes(): string[] {
+  return [...countryIndex.keys()];
+}
+
+export function getCountryBbox(code: string): [number, number, number, number] | null {
+  const entry = countryIndex.get(code.toUpperCase());
+  return entry?.bbox ?? null;
 }

--- a/src/services/country-instability.ts
+++ b/src/services/country-instability.ts
@@ -1,11 +1,11 @@
 import type { SocialUnrestEvent, MilitaryFlight, MilitaryVessel, ClusteredEvent, InternetOutage } from '@/types';
 import { INTEL_HOTSPOTS, CONFLICT_ZONES, STRATEGIC_WATERWAYS } from '@/config/geo';
-import { TIER1_COUNTRIES } from '@/config/countries';
+import { CURATED_COUNTRIES, DEFAULT_BASELINE_RISK, DEFAULT_EVENT_MULTIPLIER, getHotspotCountries } from '@/config/countries';
 import { focalPointDetector } from './focal-point-detector';
 import type { ConflictEvent, UcdpConflictStatus, HapiConflictSummary } from './conflict';
 import type { CountryDisplacement } from '@/services/displacement';
 import type { ClimateAnomaly } from '@/services/climate';
-import { getCountryAtCoordinates } from './country-geometry';
+import { getCountryAtCoordinates, iso3ToIso2Code, nameToCountryCode, getCountryNameByCode, matchCountryNamesInText } from './country-geometry';
 
 export interface CountryScore {
   code: string;
@@ -38,11 +38,9 @@ interface CountryData {
   climateStress: number;
 }
 
-// Re-export for backwards compatibility
 export { TIER1_COUNTRIES } from '@/config/countries';
 
-// Learning Mode - warmup period for reliable data (bypassed when cached scores exist)
-const LEARNING_DURATION_MS = 15 * 60 * 1000; // 15 minutes
+const LEARNING_DURATION_MS = 15 * 60 * 1000;
 let learningStartTime: number | null = null;
 let isLearningComplete = false;
 let hasCachedScoresAvailable = false;
@@ -50,7 +48,7 @@ let hasCachedScoresAvailable = false;
 export function setHasCachedScores(hasScores: boolean): void {
   hasCachedScoresAvailable = hasScores;
   if (hasScores) {
-    isLearningComplete = true; // Skip learning when cached scores available
+    isLearningComplete = true;
   }
 }
 
@@ -61,7 +59,7 @@ export function startLearning(): void {
 }
 
 export function isInLearningMode(): boolean {
-  if (hasCachedScoresAvailable) return false; // Bypass if backend has cached scores
+  if (hasCachedScoresAvailable) return false;
   if (isLearningComplete) return false;
   if (learningStartTime === null) return true;
 
@@ -92,88 +90,28 @@ export function getLearningProgress(): { inLearning: boolean; remainingMinutes: 
   };
 }
 
-const COUNTRY_KEYWORDS: Record<string, string[]> = {
-  US: ['united states', 'usa', 'america', 'washington', 'biden', 'trump', 'pentagon'],
-  RU: ['russia', 'moscow', 'kremlin', 'putin'],
-  CN: ['china', 'beijing', 'xi jinping', 'prc'],
-  UA: ['ukraine', 'kyiv', 'zelensky', 'donbas'],
-  IR: ['iran', 'tehran', 'khamenei', 'irgc'],
-  IL: ['israel', 'tel aviv', 'netanyahu', 'idf', 'gaza'],
-  TW: ['taiwan', 'taipei'],
-  KP: ['north korea', 'pyongyang', 'kim jong'],
-  SA: ['saudi arabia', 'riyadh', 'mbs'],
-  TR: ['turkey', 'ankara', 'erdogan'],
-  PL: ['poland', 'warsaw'],
-  DE: ['germany', 'berlin'],
-  FR: ['france', 'paris', 'macron'],
-  GB: ['britain', 'uk', 'london', 'starmer'],
-  IN: ['india', 'delhi', 'modi'],
-  PK: ['pakistan', 'islamabad'],
-  SY: ['syria', 'damascus', 'assad'],
-  YE: ['yemen', 'sanaa', 'houthi'],
-  MM: ['myanmar', 'burma', 'rangoon'],
-  VE: ['venezuela', 'caracas', 'maduro'],
-  BR: ['brazil', 'brasilia', 'lula', 'bolsonaro'],
-  AE: ['uae', 'emirates', 'dubai', 'abu dhabi'],
-  MX: ['mexico', 'mexican', 'amlo', 'sheinbaum', 'cartel', 'sinaloa', 'jalisco', 'cjng', 'tijuana', 'juarez', 'sedena'],
-};
+let processedCount = 0;
+let unmappedCount = 0;
 
-// Geopolitical baseline risk scores (0-50)
-// Reflects inherent instability regardless of current events
-const BASELINE_RISK: Record<string, number> = {
-  US: 5,    // Stable democracy, high media coverage inflates event counts
-  RU: 35,   // Authoritarian, active in Ukraine conflict
-  CN: 25,   // Authoritarian, Taiwan tensions, internal repression
-  UA: 50,   // Active war zone
-  IR: 40,   // Authoritarian, regional tensions, under-reported
-  IL: 45,   // Active conflict with Gaza/Lebanon
-  TW: 30,   // China tensions, invasion risk
-  KP: 45,   // Rogue state, nuclear threat, near-zero reporting
-  SA: 20,   // Regional tensions but relatively stable
-  TR: 25,   // Regional involvement, internal tensions
-  PL: 10,   // NATO frontline but stable
-  DE: 5,    // Stable democracy
-  FR: 10,   // Social tensions but stable
-  GB: 5,    // Stable democracy
-  IN: 20,   // Regional tensions, internal issues
-  PK: 35,   // Nuclear state, instability, terrorism
-  SY: 50,   // Active civil war
-  YE: 50,   // Active civil war
-  MM: 45,   // Military coup, civil conflict
-  VE: 40,   // Economic collapse, authoritarian
-  BR: 15,   // Large democracy, social tensions, Amazon deforestation
-  AE: 10,   // Stable, regional hub, low internal unrest
-  MX: 35,   // Cartel warfare, state fragility, fentanyl crisis, US border tensions
-};
+export function getIngestStats(): { processed: number; unmapped: number; rate: number } {
+  const rate = processedCount > 0 ? unmappedCount / processedCount : 0;
+  return { processed: processedCount, unmapped: unmappedCount, rate };
+}
 
-// Event significance multipliers
-// Higher = each event is more significant (authoritarian states where events are suppressed)
-// Lower = events are common/expected (open democracies with high media coverage)
-const EVENT_MULTIPLIER: Record<string, number> = {
-  US: 0.3,  // Many protests normal, over-reported
-  RU: 2.0,  // Protests rare and significant
-  CN: 2.5,  // Any protest is major (heavily suppressed)
-  UA: 0.8,  // War context, events expected
-  IR: 2.0,  // Protests suppressed, significant when occur
-  IL: 0.7,  // Frequent conflict, well-documented
-  TW: 1.5,  // Events significant
-  KP: 3.0,  // Almost no reporting, any event = major
-  SA: 2.0,  // Suppressed
-  TR: 1.2,  // Some suppression
-  PL: 0.8,  // Open democracy
-  DE: 0.5,  // Protests normal
-  FR: 0.6,  // Protests common
-  GB: 0.5,  // Open democracy
-  IN: 0.8,  // Large democracy, many events
-  PK: 1.5,  // Some suppression
-  SY: 0.7,  // War zone, events expected
-  YE: 0.7,  // War zone, events expected
-  MM: 1.8,  // Military suppression
-  VE: 1.8,  // Suppressed
-  BR: 0.6,  // Large democracy, many events
-  AE: 1.5,  // Events rare, significant when occur
-  MX: 1.0,  // Mixed — some events well-reported, cartel zones under-reported
-};
+export function resetIngestStats(): void {
+  processedCount = 0;
+  unmappedCount = 0;
+}
+
+function ensureISO2(code: string): string | null {
+  const upper = code.trim().toUpperCase();
+  if (/^[A-Z]{2}$/.test(upper)) return upper;
+  const iso2 = iso3ToIso2Code(upper);
+  if (iso2) return iso2;
+  const fromName = nameToCountryCode(code);
+  if (fromName) return fromName;
+  return null;
+}
 
 const countryDataMap = new Map<string, CountryData>();
 const previousScores = new Map<string, number>();
@@ -195,24 +133,21 @@ export function getPreviousScores(): Map<string, number> {
   return previousScores;
 }
 
-export { COUNTRY_BOUNDS };
 export type { CountryData };
 
 function normalizeCountryName(name: string): string | null {
   const lower = name.toLowerCase();
-  for (const [code, keywords] of Object.entries(COUNTRY_KEYWORDS)) {
-    if (keywords.some(kw => lower.includes(kw))) return code;
+  for (const [code, cfg] of Object.entries(CURATED_COUNTRIES)) {
+    if (cfg.scoringKeywords.some(kw => lower.includes(kw))) return code;
   }
-  for (const [code, countryName] of Object.entries(TIER1_COUNTRIES)) {
-    if (lower.includes(countryName.toLowerCase())) return code;
-  }
-  return null;
+  return nameToCountryCode(lower);
 }
 
 export function ingestProtestsForCII(events: SocialUnrestEvent[]): void {
   for (const e of events) {
+    processedCount++;
     const code = normalizeCountryName(e.country);
-    if (!code || !TIER1_COUNTRIES[code]) continue;
+    if (!code) { unmappedCount++; continue; }
     if (!countryDataMap.has(code)) countryDataMap.set(code, initCountryData());
     countryDataMap.get(code)!.protests.push(e);
     trackHotspotActivity(e.lat, e.lon, e.severity === 'high' ? 2 : 1);
@@ -221,8 +156,9 @@ export function ingestProtestsForCII(events: SocialUnrestEvent[]): void {
 
 export function ingestConflictsForCII(events: ConflictEvent[]): void {
   for (const e of events) {
+    processedCount++;
     const code = normalizeCountryName(e.country);
-    if (!code || !TIER1_COUNTRIES[code]) continue;
+    if (!code) { unmappedCount++; continue; }
     if (!countryDataMap.has(code)) countryDataMap.set(code, initCountryData());
     countryDataMap.get(code)!.conflicts.push(e);
     trackHotspotActivity(e.lat, e.lon, e.fatalities > 0 ? 3 : 2);
@@ -231,38 +167,23 @@ export function ingestConflictsForCII(events: ConflictEvent[]): void {
 
 export function ingestUcdpForCII(classifications: Map<string, UcdpConflictStatus>): void {
   for (const [code, status] of classifications) {
-    if (!TIER1_COUNTRIES[code]) continue;
-    if (!countryDataMap.has(code)) countryDataMap.set(code, initCountryData());
-    countryDataMap.get(code)!.ucdpStatus = status;
+    processedCount++;
+    const iso2 = ensureISO2(code);
+    if (!iso2) { unmappedCount++; continue; }
+    if (!countryDataMap.has(iso2)) countryDataMap.set(iso2, initCountryData());
+    countryDataMap.get(iso2)!.ucdpStatus = status;
   }
 }
 
 export function ingestHapiForCII(summaries: Map<string, HapiConflictSummary>): void {
   for (const [code, summary] of summaries) {
-    if (!TIER1_COUNTRIES[code]) continue;
-    if (!countryDataMap.has(code)) countryDataMap.set(code, initCountryData());
-    countryDataMap.get(code)!.hapiSummary = summary;
+    processedCount++;
+    const iso2 = ensureISO2(code);
+    if (!iso2) { unmappedCount++; continue; }
+    if (!countryDataMap.has(iso2)) countryDataMap.set(iso2, initCountryData());
+    countryDataMap.get(iso2)!.hapiSummary = summary;
   }
 }
-
-const ISO3_TO_ISO2: Record<string, string> = {
-  AFG: 'AF', SYR: 'SY', UKR: 'UA', SDN: 'SD', SSD: 'SS', SOM: 'SO',
-  COD: 'CD', MMR: 'MM', YEM: 'YE', ETH: 'ET', VEN: 'VE', IRQ: 'IQ',
-  COL: 'CO', NGA: 'NG', PSE: 'PS', TUR: 'TR', PAK: 'PK', IRN: 'IR',
-  IND: 'IN', CHN: 'CN', RUS: 'RU', ISR: 'IL', SAU: 'SA', USA: 'US',
-  TWN: 'TW', PRK: 'KP', POL: 'PL', DEU: 'DE', FRA: 'FR', GBR: 'GB',
-  MEX: 'MX',
-};
-
-const COUNTRY_NAME_TO_ISO: Record<string, string> = {
-  'Afghanistan': 'AF', 'Syria': 'SY', 'Ukraine': 'UA', 'Sudan': 'SD',
-  'South Sudan': 'SS', 'Somalia': 'SO', 'DR Congo': 'CD', 'Myanmar': 'MM',
-  'Yemen': 'YE', 'Ethiopia': 'ET', 'Venezuela': 'VE', 'Iraq': 'IQ',
-  'Colombia': 'CO', 'Nigeria': 'NG', 'Palestine': 'PS', 'Turkey': 'TR',
-  'Pakistan': 'PK', 'Iran': 'IR', 'India': 'IN', 'China': 'CN',
-  'Russia': 'RU', 'Israel': 'IL', 'Saudi Arabia': 'SA',
-  'Mexico': 'MX',
-};
 
 export function ingestDisplacementForCII(countries: CountryDisplacement[]): void {
   for (const data of countryDataMap.values()) {
@@ -270,10 +191,17 @@ export function ingestDisplacementForCII(countries: CountryDisplacement[]): void
   }
 
   for (const c of countries) {
-    const code = c.code?.length === 3
-      ? ISO3_TO_ISO2[c.code] || c.code.substring(0, 2)
-      : COUNTRY_NAME_TO_ISO[c.name] || c.code;
-    if (!code || !TIER1_COUNTRIES[code]) continue;
+    processedCount++;
+    let code: string | null = null;
+    if (c.code?.length === 3) {
+      code = iso3ToIso2Code(c.code);
+    } else if (c.code?.length === 2) {
+      code = c.code.toUpperCase();
+    }
+    if (!code) {
+      code = nameToCountryCode(c.name);
+    }
+    if (!code) { unmappedCount++; continue; }
     if (!countryDataMap.has(code)) countryDataMap.set(code, initCountryData());
     const outflow = c.refugees + c.asylumSeekers;
     countryDataMap.get(code)!.displacementOutflow = outflow;
@@ -294,7 +222,6 @@ export function ingestClimateForCII(anomalies: ClimateAnomaly[]): void {
     if (a.severity === 'normal') continue;
     const codes = ZONE_COUNTRY_MAP[a.zone] || [];
     for (const code of codes) {
-      if (!TIER1_COUNTRIES[code]) continue;
       if (!countryDataMap.has(code)) countryDataMap.set(code, initCountryData());
       const stress = a.severity === 'extreme' ? 15 : 8;
       countryDataMap.get(code)!.climateStress = Math.max(countryDataMap.get(code)!.climateStress, stress);
@@ -302,37 +229,9 @@ export function ingestClimateForCII(anomalies: ClimateAnomaly[]): void {
   }
 }
 
-// Country bounding boxes for location-based attribution [minLat, maxLat, minLon, maxLon]
-const COUNTRY_BOUNDS: Record<string, [number, number, number, number]> = {
-  IR: [25, 40, 44, 63],      // Iran
-  IL: [29, 34, 34, 36],      // Israel
-  UA: [44, 53, 22, 40],      // Ukraine
-  TW: [21, 26, 119, 122],    // Taiwan
-  KP: [37, 43, 124, 131],    // North Korea
-  SY: [32, 37, 35, 42],      // Syria
-  YE: [12, 19, 42, 54],      // Yemen
-  SA: [16, 32, 34, 56],      // Saudi Arabia
-  TR: [36, 42, 26, 45],      // Turkey
-  PK: [23, 37, 60, 77],      // Pakistan
-  IN: [6, 36, 68, 97],       // India
-  CN: [18, 54, 73, 135],     // China
-  RU: [41, 82, 19, 180],     // Russia (simplified)
-  MX: [14, 33, -118, -86],   // Mexico
-};
-const LOCATION_COUNTRY_CANDIDATES = Object.keys(TIER1_COUNTRIES);
-
 function getCountryFromLocation(lat: number, lon: number): string | null {
-  const precise = getCountryAtCoordinates(lat, lon, LOCATION_COUNTRY_CANDIDATES);
-  if (precise && TIER1_COUNTRIES[precise.code]) {
-    return precise.code;
-  }
-
-  for (const [code, [minLat, maxLat, minLon, maxLon]] of Object.entries(COUNTRY_BOUNDS)) {
-    if (lat >= minLat && lat <= maxLat && lon >= minLon && lon <= maxLon) {
-      return code;
-    }
-  }
-  return null;
+  const precise = getCountryAtCoordinates(lat, lon);
+  return precise?.code ?? null;
 }
 
 function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
@@ -343,22 +242,14 @@ function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): nu
   return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 }
 
-const HOTSPOT_COUNTRY_MAP: Record<string, string> = {
-  tehran: 'IR', moscow: 'RU', beijing: 'CN', kyiv: 'UA', taipei: 'TW',
-  telaviv: 'IL', pyongyang: 'KP', riyadh: 'SA', ankara: 'TR', damascus: 'SY',
-  sanaa: 'YE', caracas: 'VE', dc: 'US', london: 'GB', brussels: 'FR',
-  baghdad: 'IR', beirut: 'IR', doha: 'SA', abudhabi: 'SA',
-  mexico: 'MX',
-};
-
 const hotspotActivityMap = new Map<string, number>();
 
 function trackHotspotActivity(lat: number, lon: number, weight: number = 1): void {
   for (const hotspot of INTEL_HOTSPOTS) {
     const dist = haversineKm(lat, lon, hotspot.lat, hotspot.lon);
     if (dist < 150) {
-      const countryCode = HOTSPOT_COUNTRY_MAP[hotspot.id];
-      if (countryCode && TIER1_COUNTRIES[countryCode]) {
+      const countryCodes = getHotspotCountries(hotspot.id);
+      for (const countryCode of countryCodes) {
         const current = hotspotActivityMap.get(countryCode) || 0;
         hotspotActivityMap.set(countryCode, current + weight);
       }
@@ -373,10 +264,8 @@ function trackHotspotActivity(lat: number, lon: number, weight: number = 1): voi
       };
       const countries = zoneCountries[zone.id] || [];
       for (const code of countries) {
-        if (TIER1_COUNTRIES[code]) {
-          const current = hotspotActivityMap.get(code) || 0;
-          hotspotActivityMap.set(code, current + weight * 2);
-        }
+        const current = hotspotActivityMap.get(code) || 0;
+        hotspotActivityMap.set(code, current + weight * 2);
       }
     }
   }
@@ -389,10 +278,8 @@ function trackHotspotActivity(lat: number, lon: number, weight: number = 1): voi
       };
       const countries = waterwayCountries[waterway.id] || [];
       for (const code of countries) {
-        if (TIER1_COUNTRIES[code]) {
-          const current = hotspotActivityMap.get(code) || 0;
-          hotspotActivityMap.set(code, current + weight * 1.5);
-        }
+        const current = hotspotActivityMap.get(code) || 0;
+        hotspotActivityMap.set(code, current + weight * 1.5);
       }
     }
   }
@@ -400,24 +287,24 @@ function trackHotspotActivity(lat: number, lon: number, weight: number = 1): voi
 
 function getHotspotBoost(countryCode: string): number {
   const activity = hotspotActivityMap.get(countryCode) || 0;
-  return Math.min(10, activity * 1.5);  // Reduced from 30 max to 10 max
+  return Math.min(10, activity * 1.5);
 }
 
 export function ingestMilitaryForCII(flights: MilitaryFlight[], vessels: MilitaryVessel[]): void {
-  // Track foreign military activity per country
   const foreignMilitaryByCountry = new Map<string, { flights: number; vessels: number }>();
 
   for (const f of flights) {
-    // 1. Credit operator country (their own military activity)
+    processedCount++;
     const operatorCode = normalizeCountryName(f.operatorCountry);
-    if (operatorCode && TIER1_COUNTRIES[operatorCode]) {
+    if (operatorCode) {
       if (!countryDataMap.has(operatorCode)) countryDataMap.set(operatorCode, initCountryData());
       countryDataMap.get(operatorCode)!.militaryFlights.push(f);
+    } else {
+      unmappedCount++;
     }
 
-    // 2. Credit LOCATION country if different (foreign military over their territory = threat)
     const locationCode = getCountryFromLocation(f.lat, f.lon);
-    if (locationCode && TIER1_COUNTRIES[locationCode] && locationCode !== operatorCode) {
+    if (locationCode && locationCode !== operatorCode) {
       if (!foreignMilitaryByCountry.has(locationCode)) {
         foreignMilitaryByCountry.set(locationCode, { flights: 0, vessels: 0 });
       }
@@ -427,16 +314,17 @@ export function ingestMilitaryForCII(flights: MilitaryFlight[], vessels: Militar
   }
 
   for (const v of vessels) {
-    // 1. Credit operator country
+    processedCount++;
     const operatorCode = normalizeCountryName(v.operatorCountry);
-    if (operatorCode && TIER1_COUNTRIES[operatorCode]) {
+    if (operatorCode) {
       if (!countryDataMap.has(operatorCode)) countryDataMap.set(operatorCode, initCountryData());
       countryDataMap.get(operatorCode)!.militaryVessels.push(v);
+    } else {
+      unmappedCount++;
     }
 
-    // 2. Credit LOCATION country if different (foreign naval presence = threat)
     const locationCode = getCountryFromLocation(v.lat, v.lon);
-    if (locationCode && TIER1_COUNTRIES[locationCode] && locationCode !== operatorCode) {
+    if (locationCode && locationCode !== operatorCode) {
       if (!foreignMilitaryByCountry.has(locationCode)) {
         foreignMilitaryByCountry.set(locationCode, { flights: 0, vessels: 0 });
       }
@@ -445,12 +333,9 @@ export function ingestMilitaryForCII(flights: MilitaryFlight[], vessels: Militar
     trackHotspotActivity(v.lat, v.lon, 2);
   }
 
-  // Store foreign military counts for security calculation
   for (const [code, counts] of foreignMilitaryByCountry) {
     if (!countryDataMap.has(code)) countryDataMap.set(code, initCountryData());
     const data = countryDataMap.get(code)!;
-    // Add synthetic entries to represent foreign military presence
-    // Each foreign flight/vessel counts MORE than own military (it's a threat)
     for (let i = 0; i < counts.flights * 2; i++) {
       data.militaryFlights.push({} as MilitaryFlight);
     }
@@ -463,20 +348,30 @@ export function ingestMilitaryForCII(flights: MilitaryFlight[], vessels: Militar
 export function ingestNewsForCII(events: ClusteredEvent[]): void {
   for (const e of events) {
     const title = e.primaryTitle.toLowerCase();
-    for (const [code] of Object.entries(TIER1_COUNTRIES)) {
-      const keywords = COUNTRY_KEYWORDS[code] || [];
-      if (keywords.some(kw => title.includes(kw))) {
-        if (!countryDataMap.has(code)) countryDataMap.set(code, initCountryData());
-        countryDataMap.get(code)!.newsEvents.push(e);
+    const matched = new Set<string>();
+
+    for (const [code, cfg] of Object.entries(CURATED_COUNTRIES)) {
+      if (cfg.scoringKeywords.some(kw => title.includes(kw))) {
+        matched.add(code);
       }
+    }
+
+    for (const code of matchCountryNamesInText(title)) {
+      matched.add(code);
+    }
+
+    for (const code of matched) {
+      if (!countryDataMap.has(code)) countryDataMap.set(code, initCountryData());
+      countryDataMap.get(code)!.newsEvents.push(e);
     }
   }
 }
 
 export function ingestOutagesForCII(outages: InternetOutage[]): void {
   for (const o of outages) {
+    processedCount++;
     const code = normalizeCountryName(o.country);
-    if (!code || !TIER1_COUNTRIES[code]) continue;
+    if (!code) { unmappedCount++; continue; }
     if (!countryDataMap.has(code)) countryDataMap.set(code, initCountryData());
     countryDataMap.get(code)!.outages.push(o);
   }
@@ -484,7 +379,7 @@ export function ingestOutagesForCII(outages: InternetOutage[]): void {
 
 function calcUnrestScore(data: CountryData, countryCode: string): number {
   const protestCount = data.protests.length;
-  const multiplier = EVENT_MULTIPLIER[countryCode] ?? 1.0;
+  const multiplier = CURATED_COUNTRIES[countryCode]?.eventMultiplier ?? DEFAULT_EVENT_MULTIPLIER;
 
   let baseScore = 0;
   let fatalityBoost = 0;
@@ -494,31 +389,23 @@ function calcUnrestScore(data: CountryData, countryCode: string): number {
     const fatalities = data.protests.reduce((sum, p) => sum + (p.fatalities || 0), 0);
     const highSeverity = data.protests.filter(p => p.severity === 'high').length;
 
-    // For democracies with frequent protests (low multiplier), use log scaling
-    // This prevents routine protests from triggering instability alerts
     const isHighVolume = multiplier < 0.7;
     const adjustedCount = isHighVolume
-      ? Math.log2(protestCount + 1) * multiplier * 5  // Log scale for democracies
+      ? Math.log2(protestCount + 1) * multiplier * 5
       : protestCount * multiplier;
 
     baseScore = Math.min(50, adjustedCount * 8);
 
-    // Fatalities and high severity always matter, but scaled by multiplier
     fatalityBoost = Math.min(30, fatalities * 5 * multiplier);
     severityBoost = Math.min(20, highSeverity * 10 * multiplier);
   }
 
-  // Internet outages are a MAJOR signal of instability
-  // Governments cut internet during crackdowns, conflicts, coups
   let outageBoost = 0;
   if (data.outages.length > 0) {
     const totalOutages = data.outages.filter(o => o.severity === 'total').length;
     const majorOutages = data.outages.filter(o => o.severity === 'major').length;
     const partialOutages = data.outages.filter(o => o.severity === 'partial').length;
 
-    // Total blackout = major red flag (30 points)
-    // Major outage = significant (15 points)
-    // Partial = moderate (5 points)
     outageBoost = Math.min(50, totalOutages * 30 + majorOutages * 15 + partialOutages * 5);
   }
 
@@ -527,7 +414,7 @@ function calcUnrestScore(data: CountryData, countryCode: string): number {
 
 function calcConflictScore(data: CountryData, countryCode: string): number {
   const events = data.conflicts;
-  const multiplier = EVENT_MULTIPLIER[countryCode] ?? 1.0;
+  const multiplier = CURATED_COUNTRIES[countryCode]?.eventMultiplier ?? DEFAULT_EVENT_MULTIPLIER;
 
   if (events.length === 0 && !data.hapiSummary) return 0;
 
@@ -540,9 +427,6 @@ function calcConflictScore(data: CountryData, countryCode: string): number {
   const fatalityScore = Math.min(40, Math.sqrt(totalFatalities) * 5 * multiplier);
   const civilianBoost = civilianCount > 0 ? Math.min(10, civilianCount * 3) : 0;
 
-  // HAPI fallback: if no ACLED conflict events but HAPI shows political violence
-  // Note: eventsCivilianTargeting is folded into eventsPoliticalViolence (HAPI doesn't
-  // split them), so we use a blended weight of 3 to avoid underweighting civilian targeting.
   let hapiFallback = 0;
   if (events.length === 0 && data.hapiSummary) {
     const h = data.hapiSummary;
@@ -574,26 +458,22 @@ function calcInformationScore(data: CountryData, countryCode: string): number {
   const count = data.newsEvents.length;
   if (count === 0) return 0;
 
-  const multiplier = EVENT_MULTIPLIER[countryCode] ?? 1.0;
+  const multiplier = CURATED_COUNTRIES[countryCode]?.eventMultiplier ?? DEFAULT_EVENT_MULTIPLIER;
   const velocitySum = data.newsEvents.reduce((sum, e) => sum + (e.velocity?.sourcesPerHour || 0), 0);
   const avgVelocity = velocitySum / count;
 
-  // For high-volume countries (US, UK, DE, FR), use logarithmic scaling
-  // This prevents routine news volume from triggering instability
   const isHighVolume = multiplier < 0.7;
   const adjustedCount = isHighVolume
-    ? Math.log2(count + 1) * multiplier * 3  // Log scale for media-saturated countries
+    ? Math.log2(count + 1) * multiplier * 3
     : count * multiplier;
 
   const baseScore = Math.min(40, adjustedCount * 5);
 
-  // Velocity only matters if it's actually high (breaking news style)
   const velocityThreshold = isHighVolume ? 5 : 2;
   const velocityBoost = avgVelocity > velocityThreshold
     ? Math.min(40, (avgVelocity - velocityThreshold) * 10 * multiplier)
     : 0;
 
-  // Alert boost also scaled by multiplier
   const alertBoost = data.newsEvents.some(e => e.isAlert) ? 20 * multiplier : 0;
 
   return Math.min(100, baseScore + velocityBoost + alertBoost);
@@ -620,9 +500,15 @@ export function calculateCII(): CountryScore[] {
   const scores: CountryScore[] = [];
   const focalUrgencies = focalPointDetector.getCountryUrgencyMap();
 
-  for (const [code, name] of Object.entries(TIER1_COUNTRIES)) {
+  const countryCodes = new Set<string>([
+    ...countryDataMap.keys(),
+    ...Object.keys(CURATED_COUNTRIES),
+  ]);
+
+  for (const code of countryCodes) {
+    const name = CURATED_COUNTRIES[code]?.name || getCountryNameByCode(code) || code;
     const data = countryDataMap.get(code) || initCountryData();
-    const baselineRisk = BASELINE_RISK[code] ?? 20;
+    const baselineRisk = CURATED_COUNTRIES[code]?.baselineRisk ?? DEFAULT_BASELINE_RISK;
 
     const components: ComponentScores = {
       unrest: Math.round(calcUnrestScore(data, code)),
@@ -631,7 +517,6 @@ export function calculateCII(): CountryScore[] {
       information: Math.round(calcInformationScore(data, code)),
     };
 
-    // Weighted components: conflict gets highest weight (armed conflict is strongest signal)
     const eventScore = components.unrest * 0.25 + components.conflict * 0.30 + components.security * 0.20 + components.information * 0.25;
 
     const hotspotBoost = getHotspotBoost(code);
@@ -650,8 +535,6 @@ export function calculateCII(): CountryScore[] {
 
     const blendedScore = baselineRisk * 0.4 + eventScore * 0.6 + hotspotBoost + newsUrgencyBoost + focalBoost + displacementBoost + climateBoost;
 
-    // UCDP-derived conflict floor replaces hardcoded floors
-    // war (1000+ deaths/yr) → 70, minor (25-999) → 50, none → 0
     const floor = getUcdpFloor(data);
     const score = Math.round(Math.min(100, Math.max(floor, blendedScore)));
 
@@ -682,7 +565,7 @@ export function getCountryScore(code: string): number | null {
   const data = countryDataMap.get(code);
   if (!data) return null;
 
-  const baselineRisk = BASELINE_RISK[code] ?? 20;
+  const baselineRisk = CURATED_COUNTRIES[code]?.baselineRisk ?? DEFAULT_BASELINE_RISK;
   const components: ComponentScores = {
     unrest: calcUnrestScore(data, code),
     conflict: calcConflictScore(data, code),

--- a/src/services/cross-module-integration.ts
+++ b/src/services/cross-module-integration.ts
@@ -1,7 +1,8 @@
 import { getLocationName, type GeoConvergenceAlert } from './geo-convergence';
 import type { CountryScore } from './country-instability';
 import type { CascadeResult, CascadeImpactLevel } from '@/types';
-import { calculateCII, TIER1_COUNTRIES, isInLearningMode } from './country-instability';
+import { calculateCII, isInLearningMode } from './country-instability';
+import { getCountryNameByCode } from './country-geometry';
 import { t } from '@/services/i18n';
 
 export type AlertPriority = 'critical' | 'high' | 'medium' | 'low';
@@ -233,7 +234,7 @@ function getHigherPriority(a: AlertPriority, b: AlertPriority): AlertPriority {
 }
 
 function getCountryDisplayName(code: string): string {
-  return TIER1_COUNTRIES[code] || code;
+  return getCountryNameByCode(code) || code;
 }
 
 function generateCompositeTitle(a: UnifiedAlert, b: UnifiedAlert): string {
@@ -347,7 +348,7 @@ function getCountriesNearLocation(lat: number, lon: number): string[] {
     countries.push(...regionCountries.americas);
   }
 
-  return countries.filter(c => TIER1_COUNTRIES[c]);
+  return countries;
 }
 
 export function checkCIIChanges(): UnifiedAlert[] {

--- a/src/services/hotspot-escalation.ts
+++ b/src/services/hotspot-escalation.ts
@@ -1,5 +1,6 @@
 import type { Hotspot, EscalationTrend, MilitaryFlight, MilitaryVessel } from '@/types';
 import { INTEL_HOTSPOTS } from '@/config/geo';
+import { getHotspotCountries } from '@/config/countries';
 
 export interface DynamicEscalationScore {
   hotspotId: string;
@@ -27,31 +28,6 @@ interface EscalationInputs {
   flightsNearby: number;
   vesselsNearby: number;
 }
-
-const HOTSPOT_COUNTRY_MAP: Record<string, string | string[] | null> = {
-  tehran: 'IR',
-  moscow: 'RU',
-  beijing: 'CN',
-  kyiv: 'UA',
-  taipei: 'TW',
-  telaviv: 'IL',
-  pyongyang: 'KP',
-  sanaa: 'YE',
-  sahel: ['ML', 'NE', 'BF'],
-  haiti: 'HT',
-  horn_africa: ['ET', 'SO', 'SD'],
-  silicon_valley: 'US',
-  wall_street: 'US',
-  houston: 'US',
-  dc: 'US',
-  cairo: 'EG',
-  doha: 'QA',
-  beirut: 'LB',
-  riyadh: 'SA',
-  ankara: 'TR',
-  damascus: 'SY',
-  caracas: 'VE',
-};
 
 const COMPONENT_WEIGHTS = {
   news: 0.35,
@@ -84,15 +60,11 @@ function getStaticBaseline(hotspot: Hotspot): number {
 function getCIIForHotspot(hotspotId: string): number | null {
   if (!ciiGetter) return null;
 
-  const mapping = HOTSPOT_COUNTRY_MAP[hotspotId];
-  if (!mapping) return null;
+  const countryCodes = getHotspotCountries(hotspotId);
+  if (countryCodes.length === 0) return null;
 
-  if (Array.isArray(mapping)) {
-    const scores = mapping.map(code => ciiGetter!(code)).filter((s): s is number => s !== null);
-    return scores.length > 0 ? Math.max(...scores) : null;
-  }
-
-  return ciiGetter(mapping);
+  const scores = countryCodes.map(code => ciiGetter!(code)).filter((s): s is number => s !== null);
+  return scores.length > 0 ? Math.max(...scores) : null;
 }
 
 function getGeoAlertForHotspot(hotspot: Hotspot): { score: number; types: number } | null {

--- a/src/services/signal-aggregator.ts
+++ b/src/services/signal-aggregator.ts
@@ -11,7 +11,7 @@ import type {
   SocialUnrestEvent,
   AisDisruptionEvent,
 } from '@/types';
-import { TIER1_COUNTRIES } from '@/config/countries';
+import { getCountryAtCoordinates, getCountryNameByCode, nameToCountryCode } from './country-geometry';
 
 export type SignalType =
   | 'internet_outage'
@@ -87,23 +87,13 @@ const REGION_DEFINITIONS: Record<string, { countries: string[]; name: string }> 
   },
 };
 
-const COUNTRY_TO_CODE: Record<string, string> = {
-  'Iran': 'IR', 'Israel': 'IL', 'Saudi Arabia': 'SA', 'United Arab Emirates': 'AE',
-  'Iraq': 'IQ', 'Syria': 'SY', 'Yemen': 'YE', 'Jordan': 'JO', 'Lebanon': 'LB',
-  'China': 'CN', 'Taiwan': 'TW', 'Japan': 'JP', 'South Korea': 'KR', 'North Korea': 'KP',
-  'India': 'IN', 'Pakistan': 'PK', 'Bangladesh': 'BD', 'Afghanistan': 'AF',
-  'Ukraine': 'UA', 'Russia': 'RU', 'Belarus': 'BY', 'Poland': 'PL',
-  'Egypt': 'EG', 'Libya': 'LY', 'Sudan': 'SD', 'South Sudan': 'SS',
-  'United States': 'US', 'United Kingdom': 'GB', 'Germany': 'DE', 'France': 'FR',
-};
-
 function normalizeCountryCode(country: string): string {
   if (country.length === 2) return country.toUpperCase();
-  return COUNTRY_TO_CODE[country] || country.slice(0, 2).toUpperCase();
+  return nameToCountryCode(country) || country.slice(0, 2).toUpperCase();
 }
 
 function getCountryName(code: string): string {
-  return TIER1_COUNTRIES[code] || code;
+  return getCountryNameByCode(code) || code;
 }
 
 class SignalAggregator {
@@ -311,16 +301,8 @@ class SignalAggregator {
   }
 
   private coordsToCountry(lat: number, lon: number): string {
-    if (lat >= 25 && lat <= 40 && lon >= 44 && lon <= 63) return 'IR';
-    if (lat >= 29 && lat <= 33 && lon >= 34 && lon <= 36) return 'IL';
-    if (lat >= 15 && lat <= 32 && lon >= 34 && lon <= 55) return 'SA';
-    if (lat >= 20 && lat <= 55 && lon >= 73 && lon <= 135) return 'CN';
-    if (lat >= 22 && lat <= 25 && lon >= 120 && lon <= 122) return 'TW';
-    if (lat >= 8 && lat <= 37 && lon >= 68 && lon <= 97) return 'IN';
-    if (lat >= 44 && lat <= 52 && lon >= 22 && lon <= 40) return 'UA';
-    if (lat >= 50 && lat <= 82 && lon >= 20 && lon <= 180) return 'RU';
-    if (lat >= 22 && lat <= 32 && lon >= 25 && lon <= 35) return 'EG';
-    return 'XX';
+    const hit = getCountryAtCoordinates(lat, lon);
+    return hit?.code ?? 'XX';
   }
 
   private pruneOld(): void {

--- a/src/services/story-data.ts
+++ b/src/services/story-data.ts
@@ -1,29 +1,7 @@
 import { calculateCII, type CountryScore } from './country-instability';
 import type { ClusteredEvent } from '@/types';
 import type { ThreatLevel } from './threat-classifier';
-
-const COUNTRY_KEYWORDS: Record<string, string[]> = {
-  US: ['united states', 'usa', 'america', 'washington', 'biden', 'trump', 'pentagon'],
-  RU: ['russia', 'moscow', 'kremlin', 'putin'],
-  CN: ['china', 'beijing', 'xi jinping', 'prc'],
-  UA: ['ukraine', 'kyiv', 'zelensky', 'donbas'],
-  IR: ['iran', 'tehran', 'khamenei', 'irgc'],
-  IL: ['israel', 'tel aviv', 'netanyahu', 'idf', 'gaza'],
-  TW: ['taiwan', 'taipei'],
-  KP: ['north korea', 'pyongyang', 'kim jong'],
-  SA: ['saudi arabia', 'riyadh', 'mbs'],
-  TR: ['turkey', 'ankara', 'erdogan'],
-  PL: ['poland', 'warsaw'],
-  DE: ['germany', 'berlin'],
-  FR: ['france', 'paris', 'macron'],
-  GB: ['britain', 'uk', 'london', 'starmer'],
-  IN: ['india', 'delhi', 'modi'],
-  PK: ['pakistan', 'islamabad'],
-  SY: ['syria', 'damascus', 'assad'],
-  YE: ['yemen', 'sanaa', 'houthi'],
-  MM: ['myanmar', 'burma', 'rangoon'],
-  VE: ['venezuela', 'caracas', 'maduro'],
-};
+import { CURATED_COUNTRIES } from '@/config/countries';
 
 export interface StoryData {
   countryCode: string;
@@ -85,7 +63,7 @@ export function collectStoryData(
   const scores = calculateCII();
   const countryScore = scores.find(s => s.code === countryCode) || null;
 
-  const keywords = COUNTRY_KEYWORDS[countryCode] || [countryName.toLowerCase()];
+  const keywords = CURATED_COUNTRIES[countryCode]?.scoringKeywords || [countryName.toLowerCase()];
   const countryNews = allNews.filter(e => {
     const lower = e.primaryTitle.toLowerCase();
     return keywords.some(kw => lower.includes(kw));


### PR DESCRIPTION
## Summary

- **Removes all TIER1 gates** from 9 ingest functions so any country with data gets a CII score (previously silently discarded for non-TIER1 countries)
- **Creates single source of truth** for country metadata in `src/config/countries.ts` — replaces 13+ hardcoded maps across 8 files with centralized `CURATED_COUNTRIES` (30 entries with expert-tuned params) and GeoJSON-backed universal registry (~240 countries)
- **Fixes 5 bugs** in `HOTSPOT_COUNTRY_MAP`: brussels→BE (was FR), baghdad→IQ (was IR), beirut→LB (was IR), doha→QA (was SA), abudhabi→AE (was SA), adds nuuk→GL

### Key changes

| File | Change |
|------|--------|
| `src/config/countries.ts` | `CURATED_COUNTRIES` with separate `scoringKeywords`/`searchAliases`, canonical `HOTSPOT_COUNTRY_MAP`, `getHotspotCountries()` helper |
| `src/services/country-geometry.ts` | ISO3→ISO2, name→ISO2 indexes, Taiwan `CN-TW`→`TW` override, word-boundary country name matchers |
| `src/services/country-instability.ts` | Removed 9 TIER1 gates, deleted 7 hardcoded maps, `ensureISO2()` normalizer, observability counters |
| `src/App.ts` | Removed `COUNTRY_BOUNDS` + `COUNTRY_ALIASES`, migrated all consumers to centralized config |
| 5 other consumer files | Replaced local hardcoded maps with centralized imports |

### Design decisions

- **TIER1 (23 countries) unchanged** — keeps exact same hand-tuned baseline risk and event multipliers
- **CURATED_COUNTRIES (30 entries)** is a superset including non-TIER1 countries from old `COUNTRY_ALIASES` (KR, IQ, AF, LB, EG, JP, QA)
- **Non-curated countries** get `DEFAULT_BASELINE_RISK=15` and `DEFAULT_EVENT_MULTIPLIER=1.0`
- **HAPI fetch scope kept conservative** — don't expand to 240 countries to avoid API spam
- **Longest-first word-boundary regex** prevents "Guinea" matching inside "Papua New Guinea"

## Test plan

- [ ] `tsc --noEmit` passes (verified)
- [ ] `build:full` passes (verified)
- [ ] Click Egypt/Colombia on map → country brief opens with CII score
- [ ] Click Taiwan → resolves as `TW` (not `CN-TW`)
- [ ] Search "Egypt" → appears in search results
- [ ] All 23 TIER1 countries retain exact same scores
- [ ] Hotspot escalation scores still compute (no broken hotspot→country mappings)