### PR TITLE
fix: YouTube bot-check bypass via authenticated embeds and sign-in flow

### DIFF
--- a/api/youtube/embed.js
+++ b/api/youtube/embed.js
@@ -63,7 +63,7 @@ export default async function handler(request) {
   const origin = sanitizeOrigin(url.searchParams.get('origin'));
   const parentOrigin = sanitizeParentOrigin(url.searchParams.get('parentOrigin'), origin);
 
-  const embedSrc = new URL(`https://www.youtube-nocookie.com/embed/${videoId}`);
+  const embedSrc = new URL(`https://www.youtube.com/embed/${videoId}`);
   embedSrc.searchParams.set('autoplay', autoplay);
   embedSrc.searchParams.set('mute', mute);
   embedSrc.searchParams.set('playsinline', '1');
@@ -115,7 +115,7 @@ export default async function handler(request) {
     function onYouTubeIframeAPIReady(){
       player=new YT.Player('player',{
         videoId:'${videoId}',
-        host:'https://www.youtube-nocookie.com',
+        host:'https://www.youtube.com',
         playerVars:{autoplay:${autoplay},mute:${mute},playsinline:1,rel:0,controls:1,modestbranding:1,enablejsapi:1,origin:${JSON.stringify(origin)},widget_referrer:${JSON.stringify(origin)}},
         events:{
           onReady:function(){

--- a/api/youtube/embed.test.mjs
+++ b/api/youtube/embed.test.mjs
@@ -21,7 +21,7 @@ test('returns embeddable html for valid video id', async () => {
 
   const html = await response.text();
   assert.equal(html.includes("videoId:'iEpJwprxDdk'"), true);
-  assert.equal(html.includes("host:'https://www.youtube-nocookie.com'"), true);
+  assert.equal(html.includes("host:'https://www.youtube.com'"), true);
   assert.equal(html.includes('autoplay:0'), true);
   assert.equal(html.includes('mute:1'), true);
   assert.equal(html.includes('origin:"https://worldmonitor.app"'), true);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4892,6 +4892,7 @@ dependencies = [
 name = "world-monitor"
 version = "2.5.6"
 dependencies = [
+ "getrandom 0.2.17",
  "keyring",
  "reqwest 0.12.28",
  "serde",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,6 +2,6 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capabilities for World Monitor main and settings windows",
-  "windows": ["main", "settings", "live-channels"],
+  "windows": ["main", "settings", "live-channels", "youtube-login"],
   "permissions": ["core:default"]
 }

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -324,9 +324,6 @@ export class DeckGLMap {
     this.state = initialState;
     this.hotspots = [...INTEL_HOTSPOTS];
 
-    this.rebuildTechHQSupercluster();
-    this.rebuildDatacenterSupercluster();
-
     this.debouncedRebuildLayers = debounce(() => {
       if (this.renderPaused || this.webglLost || !this.maplibreMap) return;
       this.maplibreMap.resize();
@@ -351,6 +348,8 @@ export class DeckGLMap {
     this.initMapLibre();
 
     this.maplibreMap?.on('load', () => {
+      this.rebuildTechHQSupercluster();
+      this.rebuildDatacenterSupercluster();
       this.initDeck();
       this.loadCountryBoundaries();
       this.render();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1269,6 +1269,8 @@
       "retry": "Retry",
       "notLive": "{{name}} is not currently live",
       "cannotEmbed": "{{name}} cannot be embedded in this app (YouTube {{code}})",
+      "botCheck": "YouTube is requesting sign-in to play {{name}}",
+      "signInToYouTube": "Sign in to YouTube",
       "openOnYouTube": "Open on YouTube",
       "manage": "Manage channels",
       "addChannel": "Add channel",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1723,6 +1723,20 @@ canvas,
   border-color: var(--text-dim);
 }
 
+.bot-check-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 4px;
+}
+
+.bot-check-actions .bot-check-signin {
+  background: var(--accent, #4a9eff);
+  border-color: var(--accent, #4a9eff);
+  color: #fff;
+}
+
 @keyframes loadingDots {
 
   0%,


### PR DESCRIPTION
## Summary

Fixes #287 — UI freezing and cursor lag during initial load caused by MapLibre WebGL init, YouTube iframe API, and 15-20 concurrent API fetches all competing on the main thread simultaneously.

### Performance
- **Defer YouTube player init** — `LiveNewsPanel` no longer loads the YouTube iframe API during `createPanels()`. Uses `IntersectionObserver` + `requestIdleCallback` gate to wait until the panel is visible AND the browser is idle. Shows a lightweight clickable placeholder until then.
- **Stagger data loads into 3 tiers** — `loadAllData()` now uses lazy task execution:
  - **Tier 1** (news, markets, pizzint, intelligence): fires immediately
  - **Tier 2** (predictions, fred, oil, spending, firms): yields one `requestAnimationFrame` frame first
  - **Tier 3** (natural, weather, ais, cables, flights, cyber, techEvents): fire-and-forget via `requestIdleCallback`
- **Defer supercluster rebuilds** — moved from DeckGLMap constructor into map `load` callback

### Bug Fixes
- **Suppress notification sound when alerts disabled** — `IntelligenceGapBadge.playSound()` now gated on `popupEnabled` toggle
- **Bot-check detection** — detects YouTube "Sign in to confirm you're not a bot" and offers sign-in/retry/open-on-YouTube options
- **Lifecycle safety** — tier-3 deferred callbacks tracked and cancelled on `App.destroy()`
- **Safe DOM construction** — all new UI paths use `createElement`/`textContent` (no innerHTML with user data)

### Version
- Bumped to **2.5.7**

## Test plan

- [ ] Page loads — map renders with all layers
- [ ] Scroll to LiveNewsPanel → YouTube player initializes and starts playing
- [ ] Click placeholder "Load Player" → immediate init
- [ ] Channel switch before auto-init → correct channel loads
- [ ] All data panels populate (news/markets first, then others staggered)
- [ ] Toggle "Pop up new alerts" OFF → no sound on new findings
- [ ] Toggle "Pop up new alerts" ON → sound plays on new findings
- [ ] No new console errors
- [ ] `tsc --noEmit` — zero errors
- [ ] `npm run build:full` — succeeds