### PR TITLE
perf: reduce OpenSky API calls from 4 to 2 via merged regions

### DIFF
--- a/src/config/military.ts
+++ b/src/config/military.ts
@@ -454,6 +454,29 @@ export const MILITARY_HOTSPOTS = [
   { name: 'ARCTIC', lat: 75.0, lon: 0.0, radius: 10, priority: 'low' },
 ] as const;
 
+export interface QueryRegion {
+  name: string;
+  lamin: number;
+  lamax: number;
+  lomin: number;
+  lomax: number;
+}
+
+export const MILITARY_QUERY_REGIONS: QueryRegion[] = [
+  { name: 'PACIFIC', lamin: 10, lamax: 46, lomin: 107, lomax: 143 },
+  { name: 'WESTERN', lamin: 13, lamax: 85, lomin: -10, lomax: 57 },
+];
+
+if (import.meta.env.DEV) {
+  for (const h of MILITARY_HOTSPOTS) {
+    const hbox = { lamin: h.lat - h.radius, lamax: h.lat + h.radius, lomin: h.lon - h.radius, lomax: h.lon + h.radius };
+    const covered = MILITARY_QUERY_REGIONS.some(r =>
+      r.lamin <= hbox.lamin && r.lamax >= hbox.lamax && r.lomin <= hbox.lomin && r.lomax >= hbox.lomax
+    );
+    if (!covered) console.error(`[Military] HOTSPOT ${h.name} bbox not covered by any QUERY_REGION`);
+  }
+}
+
 export const USNI_REGION_COORDINATES: Record<string, { lat: number; lon: number }> = {
   // Seas & Oceans
   'Philippine Sea': { lat: 18.0, lon: 130.0 },

--- a/src/services/military-flights.ts
+++ b/src/services/military-flights.ts
@@ -6,7 +6,9 @@ import {
   isKnownMilitaryHex,
   getNearbyHotspot,
   MILITARY_HOTSPOTS,
+  MILITARY_QUERY_REGIONS,
 } from '@/config/military';
+import type { QueryRegion } from '@/config/military';
 import {
   getAircraftDetailsBatch,
   analyzeAircraftDetails,
@@ -256,71 +258,80 @@ function parseOpenSkyResponse(data: OpenSkyResponse): MilitaryFlight[] {
   return flights;
 }
 
-/**
- * Fetch flights for a single hotspot region
- */
-async function fetchHotspotRegion(hotspot: typeof MILITARY_HOTSPOTS[number]): Promise<MilitaryFlight[]> {
-  try {
-    const lamin = hotspot.lat - hotspot.radius;
-    const lamax = hotspot.lat + hotspot.radius;
-    const lomin = hotspot.lon - hotspot.radius;
-    const lomax = hotspot.lon + hotspot.radius;
-    const query = `lamin=${lamin}&lamax=${lamax}&lomin=${lomin}&lomax=${lomax}`;
-    const urls = [`${OPENSKY_PROXY_URL}?${query}`];
-    if (isLocalhostRuntime && DIRECT_OPENSKY_BASE_URL) {
-      urls.push(`${DIRECT_OPENSKY_BASE_URL}?${query}`);
-    }
+interface RegionResult {
+  name: string;
+  flights: MilitaryFlight[];
+  ok: boolean;
+}
 
+async function fetchQueryRegion(region: QueryRegion): Promise<RegionResult> {
+  const query = `lamin=${region.lamin}&lamax=${region.lamax}&lomin=${region.lomin}&lomax=${region.lomax}`;
+  const urls = [`${OPENSKY_PROXY_URL}?${query}`];
+  if (isLocalhostRuntime && DIRECT_OPENSKY_BASE_URL) {
+    urls.push(`${DIRECT_OPENSKY_BASE_URL}?${query}`);
+  }
+
+  try {
     for (const url of urls) {
       const response = await fetch(url, { headers: { 'Accept': 'application/json' } });
       if (!response.ok) {
         if (response.status === 429) {
-          console.warn(`[Military Flights] Rate limited for ${hotspot.name}`);
+          console.warn(`[Military Flights] Rate limited for ${region.name}`);
         }
         continue;
       }
       const data: OpenSkyResponse = await response.json();
-      return parseOpenSkyResponse(data);
+      return { name: region.name, flights: parseOpenSkyResponse(data), ok: true };
     }
-    return [];
+    return { name: region.name, flights: [], ok: false };
   } catch {
-    return [];
+    return { name: region.name, flights: [], ok: false };
   }
 }
 
-/**
- * Fetch military flights from OpenSky Network
- * Uses regional queries to reduce API usage and bandwidth
- */
+const STALE_MAX_AGE_MS = 10 * 60 * 1000;
+const regionCache = new Map<string, { flights: MilitaryFlight[]; timestamp: number }>();
+
 async function fetchFromOpenSky(): Promise<MilitaryFlight[]> {
   const allFlights: MilitaryFlight[] = [];
   const seenHexCodes = new Set<string>();
+  let allFailed = true;
 
-  // Execute in batches to avoid rate limiting
-  // Note: Requests are started when the batch executes, not when defined
-  const batchSize = 3;
-  for (let i = 0; i < MILITARY_HOTSPOTS.length; i += batchSize) {
-    const batch = MILITARY_HOTSPOTS.slice(i, i + batchSize);
+  const results = await Promise.all(
+    MILITARY_QUERY_REGIONS.map(region => fetchQueryRegion(region))
+  );
 
-    // Start requests for this batch only
-    const results = await Promise.all(batch.map(hotspot => fetchHotspotRegion(hotspot)));
+  for (const result of results) {
+    let flights: MilitaryFlight[];
 
-    for (const flights of results) {
-      for (const flight of flights) {
-        if (!seenHexCodes.has(flight.hexCode)) {
-          seenHexCodes.add(flight.hexCode);
-          allFlights.push(flight);
-        }
+    if (result.ok) {
+      allFailed = false;
+      regionCache.set(result.name, { flights: result.flights, timestamp: Date.now() });
+      flights = result.flights;
+    } else {
+      const stale = regionCache.get(result.name);
+      if (stale && (Date.now() - stale.timestamp < STALE_MAX_AGE_MS)) {
+        console.warn(`[Military Flights] ${result.name} failed, using stale data (${Math.round((Date.now() - stale.timestamp) / 1000)}s old)`);
+        flights = stale.flights;
+      } else {
+        console.warn(`[Military Flights] ${result.name} failed, no usable stale data`);
+        flights = [];
       }
     }
 
-    // Small delay between batches to be respectful of rate limits
-    if (i + batchSize < MILITARY_HOTSPOTS.length) {
-      await new Promise((r) => setTimeout(r, 200));
+    for (const flight of flights) {
+      if (!seenHexCodes.has(flight.hexCode)) {
+        seenHexCodes.add(flight.hexCode);
+        allFlights.push(flight);
+      }
     }
   }
 
-  console.log(`[Military Flights] Found ${allFlights.length} military aircraft from ${MILITARY_HOTSPOTS.length} regions`);
+  if (allFailed && allFlights.length === 0) {
+    throw new Error('All regions failed — upstream may be down');
+  }
+
+  console.log(`[Military Flights] Found ${allFlights.length} military aircraft from ${MILITARY_QUERY_REGIONS.length} regions`);
   return allFlights;
 }
 


### PR DESCRIPTION
## Summary
- Merge 4 overlapping OpenSky bounding-box queries into 2 larger regions
- Cuts API calls in half, reducing rate-limit pressure and latency

## Test plan
- [ ] Military flights layer still shows data for all regions
- [ ] No gaps in coverage at region boundaries