### PR TITLE
fix: add redirect target domains to RSS proxy allowlist

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -249,8 +249,10 @@ const ALLOWED_DOMAINS = [
   'www.optimistdaily.com',
   'www.sunnyskyz.com',
   'www.huffpost.com',
+  'chaski.huffpost.com',
   'www.sciencedaily.com',
   'feeds.nature.com',
+  'www.nature.com',
   'www.livescience.com',
   'www.newscientist.com',
 ];


### PR DESCRIPTION
## Summary
- HuffPost feed (`www.huffpost.com/section/good-news/feed`) redirects to `chaski.huffpost.com` — not in `ALLOWED_DOMAINS`
- Nature feed (`feeds.nature.com/nature/rss/current`) redirects to `www.nature.com` — not in `ALLOWED_DOMAINS`
- When the redirect is rejected, the proxy falls back to the Railway relay which is currently returning "Application not found"
- This is why all RSS-based panels (Good News Feed, Breakthroughs, 5 Good Things) show empty on happy.worldmonitor.app

## Fix
Add `chaski.huffpost.com` and `www.nature.com` to the RSS proxy allowlist so redirects are followed successfully.

## Note
`www.sunnyskyz.com/rss.xml` returns 404 directly (site issue, not us) — that feed may need replacing separately.

## Test plan
- [x] Deploy and verify happy.worldmonitor.app loads Good News Feed panel
- [x] Verify Nature and HuffPost articles appear in feed
- [x] Confirm no regression on other variants' RSS feeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)