### PR TITLE
fix: improve API key signup link discoverability in settings

### DIFF
--- a/src/components/RuntimeConfigPanel.ts
+++ b/src/components/RuntimeConfigPanel.ts
@@ -308,9 +308,7 @@ export class RuntimeConfigPanel extends Panel {
     const helpKey = `modals.runtimeConfig.help.${key}`;
     const helpRaw = t(helpKey);
     const helpText = helpRaw !== helpKey ? helpRaw : '';
-    const linkHtml = signupUrl
-      ? ` <a href="#" data-signup-url="${signupUrl}" class="runtime-secret-link" title="Get API key">&#x2197;</a>`
-      : '';
+    const showGetKey = signupUrl && !state.present && !pending;
     const validated = this.validatedKeys.get(key);
     const inputClass = pending ? (validated === false ? 'invalid' : 'valid-staged') : '';
     const checkClass = validated === true ? 'visible' : '';
@@ -337,13 +335,20 @@ export class RuntimeConfigPanel extends Panel {
       `;
     }
 
+    const getKeyHtml = showGetKey
+      ? `<a href="#" data-signup-url="${signupUrl}" class="runtime-secret-link">Get key</a>`
+      : '';
+
     return `
       <div class="runtime-secret-row">
-        <div class="runtime-secret-key"><code>${escapeHtml(key)}</code>${linkHtml}</div>
+        <div class="runtime-secret-key"><code>${escapeHtml(key)}</code></div>
         <span class="runtime-secret-status ${statusClass}">${escapeHtml(status)}</span>
         <span class="runtime-secret-check ${checkClass}">&#x2713;</span>
         ${helpText ? `<div class="runtime-secret-meta">${escapeHtml(helpText)}</div>` : ''}
-        <input type="${PLAINTEXT_KEYS.has(key) ? 'text' : 'password'}" data-secret="${key}" placeholder="${pending ? t('modals.runtimeConfig.placeholder.staged') : t('modals.runtimeConfig.placeholder.setSecret')}" autocomplete="off" ${isDesktopRuntime() ? '' : 'disabled'} class="${inputClass}" ${pending ? `value="${PLAINTEXT_KEYS.has(key) ? escapeHtml(this.pendingSecrets.get(key) || '') : MASKED_SENTINEL}"` : (PLAINTEXT_KEYS.has(key) && state.present ? `value="${escapeHtml(getRuntimeConfigSnapshot().secrets[key]?.value || '')}"` : '')}>
+        <div class="runtime-input-wrapper${showGetKey ? ' has-suffix' : ''}">
+          <input type="${PLAINTEXT_KEYS.has(key) ? 'text' : 'password'}" data-secret="${key}" placeholder="${pending ? t('modals.runtimeConfig.placeholder.staged') : t('modals.runtimeConfig.placeholder.setSecret')}" autocomplete="off" ${isDesktopRuntime() ? '' : 'disabled'} class="${inputClass}" ${pending ? `value="${PLAINTEXT_KEYS.has(key) ? escapeHtml(this.pendingSecrets.get(key) || '') : MASKED_SENTINEL}"` : (PLAINTEXT_KEYS.has(key) && state.present ? `value="${escapeHtml(getRuntimeConfigSnapshot().secrets[key]?.value || '')}"` : '')}>
+          ${getKeyHtml}
+        </div>
         ${hintText ? `<span class="runtime-secret-hint">${escapeHtml(hintText)}</span>` : ''}
       </div>
     `;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -14568,9 +14568,17 @@ body.has-critical-banner .panels-grid {
   color: var(--text-secondary);
 }
 
+.runtime-input-wrapper {
+  grid-area: input;
+  position: relative;
+}
+
+.runtime-input-wrapper.has-suffix input {
+  padding-right: 72px;
+}
+
 .runtime-secret-row input,
 .runtime-secret-row select {
-  grid-area: input;
   width: 100%;
   background: var(--overlay-medium);
   border: 1px solid var(--overlay-medium);
@@ -14578,6 +14586,34 @@ body.has-critical-banner .panels-grid {
   color: var(--accent);
   padding: 6px 8px;
   font-size: 11px;
+}
+
+/* Direct-child inputs/selects (not inside wrapper) still need grid-area */
+.runtime-secret-row > input,
+.runtime-secret-row > select {
+  grid-area: input;
+}
+
+.runtime-secret-link {
+  position: absolute;
+  right: 3px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--accent);
+  background: rgba(96, 165, 250, 0.1);
+  border: 1px solid rgba(96, 165, 250, 0.25);
+  border-radius: 3px;
+  padding: 2px 8px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.runtime-secret-link:hover {
+  background: rgba(96, 165, 250, 0.2);
+  border-color: var(--accent);
 }
 
 .runtime-secret-row input.hidden-input {

--- a/src/styles/settings-window.css
+++ b/src/styles/settings-window.css
@@ -343,7 +343,7 @@
   border-color: var(--settings-red);
 }
 
-/* ── Signup link icon ── */
+/* ── Key name ── */
 .runtime-secret-key {
   display: flex;
   align-items: center;
@@ -351,18 +351,36 @@
   grid-area: key;
 }
 
+/* ── Input wrapper with optional "Get key" suffix ── */
+.settings-runtime-panel .runtime-input-wrapper {
+  grid-area: input;
+  position: relative;
+}
+
+.settings-runtime-panel .runtime-input-wrapper.has-suffix input {
+  padding-right: 80px;
+}
+
 .runtime-secret-link {
-  color: var(--settings-text-secondary);
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--settings-accent);
+  background: rgba(96, 165, 250, 0.1);
+  border: 1px solid rgba(96, 165, 250, 0.25);
+  border-radius: 4px;
+  padding: 4px 10px;
   text-decoration: none;
-  font-size: 13px;
-  line-height: 1;
-  opacity: 0.5;
-  transition: opacity 0.15s, color 0.15s;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
 }
 
 .runtime-secret-link:hover {
-  color: var(--settings-accent);
-  opacity: 1;
+  background: rgba(96, 165, 250, 0.2);
+  border-color: var(--settings-accent);
 }
 
 /* ── Footer ── */


### PR DESCRIPTION
## Summary
- Replaced the barely-visible `↗` arrow (opacity 0.5, 13px) next to API key names with a clear **"Get key"** button inside the input field
- Button only appears when the key is missing — auto-hides once a value is set or staged
- Styled as a subtle blue pill with hover state, matching the existing accent palette

## Changes
- **`RuntimeConfigPanel.ts`** — Wrapped input in `.runtime-input-wrapper`, moved signup link inside as suffix button with conditional rendering
- **`settings-window.css`** — Restyled `.runtime-secret-link` from invisible arrow to input-inset button
- **`main.css`** — Added wrapper + link styles for the main-app panel variant

## Before / After
| Before | After |
|--------|-------|
| `FRED_API_KEY ↗` (tiny, 50% opacity) | `[Set secret________] [Get key]` (clear button inside input) |

## Test plan
- [ ] Open settings window → verify "Get key" buttons appear on missing keys
- [ ] Click "Get key" → opens correct provider URL in browser
- [ ] Enter a key value → "Get key" button disappears after blur
- [ ] Verify OLLAMA_MODEL row (special case) is unaffected
- [ ] Check main-app runtime config panel renders correctly