### PR TITLE
fix: filter deck.gl Uint8Array WebGL pick noise in Sentry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -98,6 +98,7 @@ Sentry.init({
     /Invalid or unexpected token/,
     /evaluating 'elemFound\.value'/,
     /Cannot access '\w+' before initialization/,
+    /^Uint8Array$/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary
- Adds `/^Uint8Array$/` to Sentry `ignoreErrors` to suppress deck.gl `readPixelsToArrayWebGL` crashes
- Both WORLDMONITOR-52 and WORLDMONITOR-53 resolved in Sentry (will auto-reopen if recurring post-deploy)

## Root cause
deck.gl's pick operation (`v0.pickObject` → `readPixelsToArrayWebGL`) throws `Error: Uint8Array` when the WebGL context is stressed or degraded. Observed on Windows Edge 145 — GPU driver reset scenario. Not actionable in our code.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Both Sentry issues marked resolved (inNextRelease)