### PR TITLE
fix(sidecar): resolve ReferenceError for 'addresses' in isSafeUrl proxy

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -173,8 +173,8 @@ async function isSafeUrl(urlString) {
   // DNS resolution check — resolve the hostname and verify all resolved IPs
   // are public. This prevents DNS rebinding attacks where a public domain
   // resolves to a private IP.
+  let addresses = []; // Declared outside the try block to avoid ReferenceError
   try {
-    let addresses = [];
     try {
       const v4 = await dns.resolve4(hostname);
       addresses = addresses.concat(v4);


### PR DESCRIPTION
The `addresses` variable was defined with `let` inside a `try` block, making 
it inaccessible at the final return statement. Moved the declaration outside 
the try block to fix local proxy crashes causing 'No news available' errors.

## Summary

The sidecar's `isSafeUrl()` function threw a fatal `ReferenceError: addresses 
is not defined` on every incoming request because `let addresses = []` was 
scoped inside the `try` block but referenced in the final `return` statement 
outside it. This caused the local API server to crash in a loop, preventing 
any RSS feed from being fetched on the desktop app.

## Type of change

- [x] Bug fix

## Affected areas

- [x] News panels / RSS feeds
- [x] Desktop app (Tauri)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots

The sidecar logs before the fix (looping fatal crash):
`[local-api] fatal ReferenceError: addresses is not defined at isSafeUrl (...local-api-server.mjs:200:43)`

Tested via the **desktop executable** (Windows `.exe`) — the only context 
where the sidecar runs. After the fix, the crash no longer appears in logs 
and external feeds load correctly.
