### PR TITLE
fix: align BIS exchange handler with real+nominal plan

### DIFF
--- a/server/worldmonitor/economic/v1/get-bis-exchange-rates.ts
+++ b/server/worldmonitor/economic/v1/get-bis-exchange-rates.ts
@@ -24,23 +24,37 @@ export async function getBisExchangeRates(
     const cached = (await getCachedJson(REDIS_CACHE_KEY)) as GetBisExchangeRatesResponse | null;
     if (cached?.rates?.length) return cached;
 
-    // Single batched request: R=Real only (nominal is not displayed), B=Broad basket
+    // Single batched request: R=Real, N=Nominal, B=Broad basket
     const threeMonthsAgo = new Date();
     threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
     const startPeriod = `${threeMonthsAgo.getFullYear()}-${String(threeMonthsAgo.getMonth() + 1).padStart(2, '0')}`;
 
-    const csv = await fetchBisCSV('WS_EER', `M.R.B.${BIS_COUNTRY_KEYS}?startPeriod=${startPeriod}&detail=dataonly`);
+    const csv = await fetchBisCSV('WS_EER', `M.R+N.B.${BIS_COUNTRY_KEYS}?startPeriod=${startPeriod}&detail=dataonly`);
     const rows = parseBisCSV(csv);
 
-    // Group by country, take last 2 observations for change calculation
-    const byCountry = new Map<string, Array<{ date: string; value: number }>>();
+    // Group by country + type, take last 2 real obs for change calculation
+    const byCountry = new Map<string, {
+      real: Array<{ date: string; value: number }>;
+      nominal: Array<{ date: string; value: number }>;
+    }>();
     for (const row of rows) {
       const cc = row['REF_AREA'] || row['Reference area'] || '';
       const date = row['TIME_PERIOD'] || row['Time period'] || '';
+      const type =
+        row['EER_TYPE'] ||
+        row['Exchange rate index type'] ||
+        row['Exchange rate type'] ||
+        row['Type'] ||
+        (row['SERIES_KEY']?.split('.')?.[1] ?? row['Series key']?.split('.')?.[1] ?? '');
       const val = parseBisNumber(row['OBS_VALUE'] || row['Observation value']);
-      if (!cc || !date || val === null) continue;
-      if (!byCountry.has(cc)) byCountry.set(cc, []);
-      byCountry.get(cc)!.push({ date, value: val });
+      if (!cc || !date || val === null || !type) continue;
+      if (!byCountry.has(cc)) byCountry.set(cc, { real: [], nominal: [] });
+      const bucket = byCountry.get(cc)!;
+      if (type === 'R') {
+        bucket.real.push({ date, value: val });
+      } else if (type === 'N') {
+        bucket.nominal.push({ date, value: val });
+      }
     }
 
     const rates: BisExchangeRate[] = [];
@@ -48,22 +62,24 @@ export async function getBisExchangeRates(
       const info = BIS_COUNTRIES[cc];
       if (!info) continue;
 
-      obs.sort((a, b) => a.date.localeCompare(b.date));
-      const latest = obs[obs.length - 1];
-      const prev = obs.length >= 2 ? obs[obs.length - 2] : undefined;
+      obs.real.sort((a, b) => a.date.localeCompare(b.date));
+      obs.nominal.sort((a, b) => a.date.localeCompare(b.date));
+      const latestReal = obs.real[obs.real.length - 1];
+      const prevReal = obs.real.length >= 2 ? obs.real[obs.real.length - 2] : undefined;
+      const latestNominal = obs.nominal[obs.nominal.length - 1];
 
-      if (latest) {
-        const realChange = prev
-          ? Math.round(((latest.value - prev.value) / prev.value) * 1000) / 10
+      if (latestReal) {
+        const realChange = prevReal
+          ? Math.round(((latestReal.value - prevReal.value) / prevReal.value) * 1000) / 10
           : 0;
 
         rates.push({
           countryCode: cc,
           countryName: info.name,
-          realEer: Math.round(latest.value * 100) / 100,
-          nominalEer: 0,
+          realEer: Math.round(latestReal.value * 100) / 100,
+          nominalEer: latestNominal ? Math.round(latestNominal.value * 100) / 100 : 0,
           realChange,
-          date: latest.date,
+          date: latestReal.date,
         });
       }
     }


### PR DESCRIPTION
### Motivation

- The `get-bis-exchange-rates` handler was only requesting real EER series and hardcoding `nominalEer = 0`, which diverged from the design and the proto contract that provides both real and nominal EER values.
- The change restores planned behaviour so the service can return both real and nominal indices and compute the real-period change correctly.

### Description

- Update the BIS request key to fetch both real and nominal series by changing the dataset key to `M.R+N.B.${BIS_COUNTRY_KEYS}` and preserving `startPeriod` and `detail=dataonly` parameters.
- Parse the CSV `EER_TYPE` (or fallback to alternate header names / `SERIES_KEY`) to distinguish `R` (real) vs `N` (nominal) rows, and bucket observations per country into `real` and `nominal` arrays.
- Compute `realChange` from the last two real observations and populate `realEer`, and set `nominalEer` from the latest nominal observation when available; retain prior sorting, rounding, caching, and error handling behaviour.
- No other handlers or frontend wiring were modified in this patch; this change only updates `server/worldmonitor/economic/v1/get-bis-exchange-rates.ts`.

### Testing

- Ran `npx tsc --noEmit` which completed successfully.  
- Ran `npm run build:full` which completed successfully and produced a valid bundle.  
- Performed a BIS API smoke attempt with `curl` in this environment which returned HTTP 403 (remote service denied access from this runner), so live CSV data could not be fetched here; compile/build validation succeeded and CSV parsing logic was exercised by static code review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699ecd3acec4832ebacd030a858047ad)