### PR TITLE
Align TradePolicyPanel behavior with WTO trade policy plan

### DIFF
--- a/src/components/TradePolicyPanel.ts
+++ b/src/components/TradePolicyPanel.ts
@@ -59,24 +59,20 @@ export class TradePolicyPanel extends Panel {
       return;
     }
 
-    const hasTariffs = this.tariffsData && this.tariffsData.datapoints.length > 0;
-    const hasFlows = this.flowsData && this.flowsData.flows.length > 0;
-    const hasBarriers = this.barriersData && this.barriersData.barriers.length > 0;
-
     const tabsHtml = `
       <div class="economic-tabs">
         <button class="economic-tab ${this.activeTab === 'restrictions' ? 'active' : ''}" data-tab="restrictions">
           ${t('components.tradePolicy.restrictions')}
         </button>
-        ${hasTariffs ? `<button class="economic-tab ${this.activeTab === 'tariffs' ? 'active' : ''}" data-tab="tariffs">
+        <button class="economic-tab ${this.activeTab === 'tariffs' ? 'active' : ''}" data-tab="tariffs">
           ${t('components.tradePolicy.tariffs')}
-        </button>` : ''}
-        ${hasFlows ? `<button class="economic-tab ${this.activeTab === 'flows' ? 'active' : ''}" data-tab="flows">
+        </button>
+        <button class="economic-tab ${this.activeTab === 'flows' ? 'active' : ''}" data-tab="flows">
           ${t('components.tradePolicy.flows')}
-        </button>` : ''}
-        ${hasBarriers ? `<button class="economic-tab ${this.activeTab === 'barriers' ? 'active' : ''}" data-tab="barriers">
+        </button>
+        <button class="economic-tab ${this.activeTab === 'barriers' ? 'active' : ''}" data-tab="barriers">
           ${t('components.tradePolicy.barriers')}
-        </button>` : ''}
+        </button>
       </div>
     `;
 
@@ -230,6 +226,6 @@ export class TradePolicyPanel extends Panel {
         return `<a href="${escapeHtml(url)}" target="_blank" rel="noopener" class="trade-source-link">Source</a>`;
       }
     } catch { /* invalid URL */ }
-    return '';
+    return `<span class="trade-source-link">${escapeHtml(url)}</span>`;
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure the Trade Policy panel matches the implementation plan by keeping all four tabs available regardless of whether their data is present. 
- Preserve source URL information safely by rendering non-`http`/`https` URLs as plain text instead of dropping them.

### Description
- Render all four tabs (Restrictions, Tariffs, Flows, Barriers) unconditionally in `TradePolicyPanel` so users can switch tabs even when datasets are empty. 
- Update `renderSourceUrl()` to return a plain-text `<span>` fallback for non-`http`/`https` or invalid URLs instead of returning an empty string. 
- Remove conditional-tab visibility flags and keep existing event-delegation on `this.content` for robust tab switching after `setContent()`.

### Testing
- Ran `npx tsc --noEmit` and it completed successfully. 
- Ran `npm run build:sidecar-sebuf` and it completed successfully. 
- Attempted `cd proto && buf lint && buf generate` but `buf` is not installed in the environment, so that check could not be executed. 
- Started the dev server and captured a UI snapshot to validate front-end rendering changes (dev server launched and screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699ecd546fac832ebe9e0669818f86a6)