### PR TITLE
Refactor WTO trade data caching with unified cachedFetchJson helper

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -482,6 +482,11 @@ export class App {
       ]);
     }
 
+    // WTO trade policy data — annual data, poll every 10 min to avoid hammering upstream
+    if (SITE_VARIANT === 'full' || SITE_VARIANT === 'finance') {
+      this.refreshScheduler.scheduleRefresh('tradePolicy', () => this.dataLoader.loadTradePolicy(), 10 * 60 * 1000);
+    }
+
     // Refresh intelligence signals for CII (geopolitical variant only)
     if (SITE_VARIANT === 'full') {
       this.refreshScheduler.scheduleRefresh('intelligence', () => {


### PR DESCRIPTION
## Summary

Consolidates repetitive caching logic across four WTO trade data endpoints by replacing manual `getCachedJson`/`setCachedJson` calls with a unified `cachedFetchJson` helper. This reduces code duplication, improves consistency, and simplifies error handling. Also adds a scheduled refresh task for trade policy data to avoid hammering upstream WTO APIs.

## Type of change

- [x] Refactor / code cleanup
- [x] New feature (scheduled refresh for trade policy data)

## Affected areas

- [x] API endpoints (`/api/*`)

## Details

**Caching refactor:**
- Replaced manual cache get/set pattern in 4 files with `cachedFetchJson<T>()` helper
- Simplified error handling: fetch failures now consistently return empty results with `upstreamUnavailable: true`
- Removed conditional cache writes (only cached if data non-empty) — now handled by helper
- Updated cache TTL comments to clarify WTO data is annual and rarely changes

**Scheduled refresh:**
- Added 10-minute polling interval for trade policy data in `App.ts`
- Applies to 'full' and 'finance' site variants
- Reduces risk of upstream API rate limiting during peak usage

## Checklist

- [x] TypeScript compiles without errors
- [x] No API keys or secrets committed
- [x] Refactoring maintains existing behavior (cache fallback, error handling)

