### PR TITLE
fix: preserve successful empty WTO responses in coalesced trade endpoints

### DIFF
--- a/server/worldmonitor/trade/v1/get-tariff-trends.ts
+++ b/server/worldmonitor/trade/v1/get-tariff-trends.ts
@@ -97,7 +97,7 @@ export async function getTariffTrends(
       REDIS_CACHE_TTL,
       async () => {
         const { datapoints, ok } = await fetchTariffTrends(reporter, partner, productSector, years);
-        if (!ok || datapoints.length === 0) return null;
+        if (!ok) return null;
         return { datapoints, fetchedAt: new Date().toISOString(), upstreamUnavailable: false };
       },
     );

--- a/server/worldmonitor/trade/v1/get-trade-barriers.ts
+++ b/server/worldmonitor/trade/v1/get-trade-barriers.ts
@@ -163,7 +163,7 @@ export async function getTradeBarriers(
       REDIS_CACHE_TTL,
       async () => {
         const { barriers, ok } = await fetchBarriers(countries, limit);
-        if (!ok || barriers.length === 0) return null;
+        if (!ok) return null;
         return { barriers, fetchedAt: new Date().toISOString(), upstreamUnavailable: false };
       },
     );

--- a/server/worldmonitor/trade/v1/get-trade-flows.ts
+++ b/server/worldmonitor/trade/v1/get-trade-flows.ts
@@ -160,7 +160,7 @@ export async function getTradeFlows(
       REDIS_CACHE_TTL,
       async () => {
         const { flows, ok } = await fetchTradeFlows(reporter, partner, years);
-        if (!ok || flows.length === 0) return null;
+        if (!ok) return null;
         return { flows, fetchedAt: new Date().toISOString(), upstreamUnavailable: false };
       },
     );

--- a/server/worldmonitor/trade/v1/get-trade-restrictions.ts
+++ b/server/worldmonitor/trade/v1/get-trade-restrictions.ts
@@ -112,7 +112,7 @@ export async function getTradeRestrictions(
       REDIS_CACHE_TTL,
       async () => {
         const { restrictions, ok } = await fetchRestrictions([], limit);
-        if (!ok || restrictions.length === 0) return null;
+        if (!ok) return null;
         return { restrictions, fetchedAt: new Date().toISOString(), upstreamUnavailable: false };
       },
     );


### PR DESCRIPTION
### Motivation
- Prevent the WTO trade endpoints from misreporting successful-but-empty upstream responses as outages and from repeatedly missing cache opportunities.
- Reduce redundant upstream calls by coalescing concurrent cache misses into a single request and ensure trade policy is refreshed periodically rather than only at startup.

### Description
- Switched the four WTO trade handlers to use `cachedFetchJson` which coalesces concurrent cache misses and writes to Redis on success. 
- Added a 10-minute refresh schedule for `tradePolicy` in `src/App.ts` so WTO trade policy data is polled periodically (FULL/FINANCE variants). 
- Fixed a regression in `server/worldmonitor/trade/v1/get-tariff-trends.ts`, `get-trade-barriers.ts`, `get-trade-flows.ts`, and `get-trade-restrictions.ts` so the fetcher only returns `null` to `cachedFetchJson` when the upstream call actually failed (`ok === false`), thereby allowing valid empty result arrays to be cached and reported with `upstreamUnavailable: false`.
- Updated cache TTL comments and preserved existing TTL behavior (`REDIS_CACHE_TTL = 21600`) for WTO endpoints.

### Testing
- Ran type checking with `npm run -s typecheck` which completed successfully.
