### PR TITLE
fix: WTO API rate limit handling and diagnostic logging

### DIFF
--- a/server/worldmonitor/trade/v1/_shared.ts
+++ b/server/worldmonitor/trade/v1/_shared.ts
@@ -51,7 +51,10 @@ export async function wtoFetch(
   params?: Record<string, string>,
 ): Promise<any | null> {
   const apiKey = process.env.WTO_API_KEY;
-  if (!apiKey) return null;
+  if (!apiKey) {
+    console.warn('[WTO] WTO_API_KEY not set in process.env');
+    return null;
+  }
 
   try {
     const url = new URL(`${WTO_API_BASE}${path}`);
@@ -71,9 +74,13 @@ export async function wtoFetch(
 
     // 204 = No Content (valid query, no matching data)
     if (res.status === 204) return { Dataset: [] };
-    if (!res.ok) return null;
+    if (!res.ok) {
+      console.warn(`[WTO] HTTP ${res.status} for ${path}`);
+      return null;
+    }
     return await res.json();
-  } catch {
+  } catch (e) {
+    console.error('[WTO] Fetch error:', e instanceof Error ? e.message : e);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- **Root cause**: WTO Timeseries API free tier has strict per-minute call quota. 6 parallel requests per page load exhausted it instantly → HTTP 403 "Quota Exceeded"
- **Stagger all WTO calls sequentially** — both at data-loader level (4 endpoints) and within handlers (barriers: 2 sub-calls, flows: 2 sub-calls)
- **Incremental panel updates** — each endpoint updates the panel as it resolves, so users see data progressively
- **Fixed "temporarily unavailable" banner** — only shows when ALL sources fail, not on partial failure (e.g., 3/4 succeed)
- **Added diagnostic logging** to `wtoFetch()` — missing key, HTTP errors, and exceptions now log to Vercel function logs
- **Changed default partner** from `156` (China) to `000` (World) for tariffs/flows — more useful default

## Files changed
- `server/worldmonitor/trade/v1/_shared.ts` — diagnostic logging
- `server/worldmonitor/trade/v1/get-trade-barriers.ts` — sequential sub-calls
- `server/worldmonitor/trade/v1/get-trade-flows.ts` — sequential sub-calls
- `src/app/data-loader.ts` — sequential endpoint calls + incremental updates
- `src/components/TradePolicyPanel.ts` — banner logic (allUnavailable vs anyUnavailable)

## Test plan
- [ ] Load worldmonitor.app → Trade Policy panel shows all 4 tabs with data
- [ ] No "temporarily unavailable" banner when partial data loads
- [ ] Vercel logs show no `[WTO] HTTP 403` errors
- [ ] Second page load within 6h serves from Redis cache (no WTO API calls)