### PR TITLE
fix: keep flat news on cluster failure and fix deckgl filter typing

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -4192,7 +4192,7 @@ export class DeckGLMap {
   public highlightCountry(code: string): void {
     this.highlightedCountryCode = code;
     if (!this.maplibreMap || !this.countryGeoJsonLoaded) return;
-    const filter: maplibregl.FilterSpecification = ['==', ['get', 'ISO3166-1-Alpha-2'], code];
+    const filter = ['==', ['get', 'ISO3166-1-Alpha-2'], code];
     try {
       this.maplibreMap.setFilter('country-highlight-fill', filter);
       this.maplibreMap.setFilter('country-highlight-border', filter);
@@ -4202,7 +4202,7 @@ export class DeckGLMap {
   public clearCountryHighlight(): void {
     this.highlightedCountryCode = null;
     if (!this.maplibreMap) return;
-    const noMatch: maplibregl.FilterSpecification = ['==', ['get', 'ISO3166-1-Alpha-2'], ''];
+    const noMatch = ['==', ['get', 'ISO3166-1-Alpha-2'], ''];
     try {
       this.maplibreMap.setFilter('country-highlight-fill', noMatch);
       this.maplibreMap.setFilter('country-highlight-border', noMatch);

--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -300,13 +300,17 @@ export class NewsPanel extends Panel {
       this.renderClusters(enriched);
     } catch (error) {
       if (requestId !== this.renderRequestId) return;
-      console.error('[NewsPanel] Failed to cluster news:', error);
-      this.showError(t('common.failedClusterNews'));
+      // Keep already-rendered flat list visible when clustering fails.
+      console.warn('[NewsPanel] Failed to cluster news, keeping flat list:', error);
     }
   }
 
   private renderFlat(items: NewsItem[]): void {
     this.setCount(items.length);
+    this.currentHeadlines = items
+      .slice(0, 5)
+      .map(item => item.title)
+      .filter((title): title is string => typeof title === 'string' && title.trim().length > 0);
 
     const html = items
       .map(


### PR DESCRIPTION
## Summary

This PR fixes two regressions:

1. News panel clustering fallback UX:
- Keep the already-rendered flat news list visible when async clustering fails (instead of replacing content with “Failed to cluster news”).
- Update `currentHeadlines` from flat items so the summarize button cannot use stale cluster headlines from a previous render.

2. DeckGL map build/type issue:
- Remove invalid `maplibregl.FilterSpecification` annotations in country highlight filters, which were causing TypeScript build errors with current maplibre typings.

Validation run locally:
- `npm run typecheck`
- `npm run test:data`
- `npm run test:sidecar`
- `npm run build`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [x] Map / Globe
- [x] News panels / RSS feeds
- [x] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other:

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [x] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots
<img width="1512" height="982" alt="Screenshot 2026-02-25 at 11 09 12 PM" src="https://github.com/user-attachments/assets/e493b462-b4da-4fe6-b42f-38cfc13a6567" />
