### PR TITLE
fix: correct trade policy panel data display

### DIFF
--- a/src/components/TradePolicyPanel.ts
+++ b/src/components/TradePolicyPanel.ts
@@ -113,8 +113,8 @@ export class TradePolicyPanel extends Panel {
 
     return `<div class="trade-restrictions-list">
       ${this.restrictionsData.restrictions.map(r => {
-        const statusClass = r.status === 'IN_FORCE' ? 'status-active' : r.status === 'TERMINATED' ? 'status-terminated' : 'status-notified';
-        const statusLabel = r.status === 'IN_FORCE' ? t('components.tradePolicy.inForce') : r.status === 'TERMINATED' ? t('components.tradePolicy.terminated') : t('components.tradePolicy.notified');
+        const statusClass = r.status === 'high' ? 'status-active' : r.status === 'moderate' ? 'status-notified' : 'status-terminated';
+        const statusLabel = r.status === 'high' ? t('components.tradePolicy.highTariff') : r.status === 'moderate' ? t('components.tradePolicy.moderateTariff') : t('components.tradePolicy.lowTariff');
         const sourceLink = this.renderSourceUrl(r.sourceUrl);
         return `<div class="trade-restriction-card">
           <div class="trade-restriction-header">
@@ -145,7 +145,6 @@ export class TradePolicyPanel extends Panel {
       `<tr>
         <td>${d.year}</td>
         <td>${d.tariffRate.toFixed(1)}%</td>
-        <td>${d.boundRate.toFixed(1)}%</td>
         <td>${escapeHtml(d.productSector || '—')}</td>
       </tr>`
     ).join('');
@@ -156,7 +155,6 @@ export class TradePolicyPanel extends Panel {
           <tr>
             <th>Year</th>
             <th>${t('components.tradePolicy.appliedRate')}</th>
-            <th>${t('components.tradePolicy.boundRate')}</th>
             <th>Sector</th>
           </tr>
         </thead>

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -553,9 +553,9 @@
       "exports": "الصادرات",
       "imports": "الواردات",
       "yoyChange": "التغير السنوي",
-      "inForce": "ساري المفعول",
-      "notified": "تم الإخطار",
-      "terminated": "منتهي"
+      "highTariff": "مرتفع",
+      "moderateTariff": "متوسط",
+      "lowTariff": "منخفض"
     },
     "gdelt": {
       "empty": "لا توجد مقالات حديثة لهذا الموضوع"

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -553,9 +553,9 @@
       "exports": "Exporte",
       "imports": "Importe",
       "yoyChange": "Veränderung zum Vorjahr",
-      "inForce": "In Kraft",
-      "notified": "Notifiziert",
-      "terminated": "Beendet"
+      "highTariff": "Hoch",
+      "moderateTariff": "Mittel",
+      "lowTariff": "Niedrig"
     },
     "gdelt": {
       "empty": "Keine aktuellen Artikel zu diesem Thema"

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -581,9 +581,9 @@
       "exports": "Εξαγωγές",
       "imports": "Εισαγωγές",
       "yoyChange": "Ετήσια Μεταβολή",
-      "inForce": "Σε Ισχύ",
-      "notified": "Κοινοποιημένο",
-      "terminated": "Τερματισμένο"
+      "highTariff": "Υψηλό",
+      "moderateTariff": "Μέτριο",
+      "lowTariff": "Χαμηλό"
     },
     "gdelt": {
       "empty": "Δεν υπάρχουν πρόσφατα άρθρα για αυτό το θέμα"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -582,9 +582,9 @@
       "exports": "Exports",
       "imports": "Imports",
       "yoyChange": "YoY Change",
-      "inForce": "In Force",
-      "notified": "Notified",
-      "terminated": "Terminated"
+      "highTariff": "High",
+      "moderateTariff": "Moderate",
+      "lowTariff": "Low"
     },
     "gdelt": {
       "empty": "No recent articles for this topic"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -553,9 +553,9 @@
       "exports": "Exportaciones",
       "imports": "Importaciones",
       "yoyChange": "Cambio Interanual",
-      "inForce": "En Vigor",
-      "notified": "Notificado",
-      "terminated": "Terminado"
+      "highTariff": "Alto",
+      "moderateTariff": "Moderado",
+      "lowTariff": "Bajo"
     },
     "gdelt": {
       "empty": "No hay artículos recientes para este tema."

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -553,9 +553,9 @@
       "exports": "Exportations",
       "imports": "Importations",
       "yoyChange": "Variation annuelle",
-      "inForce": "En vigueur",
-      "notified": "Notifié",
-      "terminated": "Terminé"
+      "highTariff": "Élevé",
+      "moderateTariff": "Modéré",
+      "lowTariff": "Faible"
     },
     "gdelt": {
       "empty": "Aucun article récent pour ce sujet"

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -553,9 +553,9 @@
       "exports": "Esportazioni",
       "imports": "Importazioni",
       "yoyChange": "Variazione Annua",
-      "inForce": "In Vigore",
-      "notified": "Notificato",
-      "terminated": "Terminato"
+      "highTariff": "Alto",
+      "moderateTariff": "Moderato",
+      "lowTariff": "Basso"
     },
     "gdelt": {
       "empty": "Nessun articolo recente per questo argomento"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -553,9 +553,9 @@
       "exports": "輸出",
       "imports": "輸入",
       "yoyChange": "前年比",
-      "inForce": "発効中",
-      "notified": "通報済み",
-      "terminated": "終了"
+      "highTariff": "高い",
+      "moderateTariff": "中程度",
+      "lowTariff": "低い"
     },
     "gdelt": {
       "empty": "このトピックの最新記事なし"

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -797,9 +797,9 @@
       "exports": "Export",
       "imports": "Import",
       "yoyChange": "Verandering op Jaarbasis",
-      "inForce": "Van Kracht",
-      "notified": "Gemeld",
-      "terminated": "Beëindigd"
+      "highTariff": "Hoog",
+      "moderateTariff": "Gemiddeld",
+      "lowTariff": "Laag"
     },
     "satelliteFires": {
       "region": "Regio",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -553,9 +553,9 @@
       "exports": "Eksport",
       "imports": "Import",
       "yoyChange": "Zmiana Roczna",
-      "inForce": "Obowiązuje",
-      "notified": "Zgłoszone",
-      "terminated": "Zakończone"
+      "highTariff": "Wysokie",
+      "moderateTariff": "Umiarkowane",
+      "lowTariff": "Niskie"
     },
     "gdelt": {
       "empty": "Brak najnowszych artykułów na ten temat"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -797,9 +797,9 @@
       "exports": "Exportações",
       "imports": "Importações",
       "yoyChange": "Variação Anual",
-      "inForce": "Em Vigor",
-      "notified": "Notificado",
-      "terminated": "Encerrado"
+      "highTariff": "Alto",
+      "moderateTariff": "Moderado",
+      "lowTariff": "Baixo"
     },
     "satelliteFires": {
       "region": "Região",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -553,9 +553,9 @@
       "exports": "Экспорт",
       "imports": "Импорт",
       "yoyChange": "Изменение за год",
-      "inForce": "Действует",
-      "notified": "Уведомлено",
-      "terminated": "Прекращено"
+      "highTariff": "Высокий",
+      "moderateTariff": "Умеренный",
+      "lowTariff": "Низкий"
     },
     "gdelt": {
       "empty": "Нет свежих статей по этой теме"

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -797,9 +797,9 @@
       "exports": "Export",
       "imports": "Import",
       "yoyChange": "Förändring på Årsbasis",
-      "inForce": "I Kraft",
-      "notified": "Anmäld",
-      "terminated": "Avslutad"
+      "highTariff": "Hög",
+      "moderateTariff": "Måttlig",
+      "lowTariff": "Låg"
     },
     "satelliteFires": {
       "region": "Område",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -553,9 +553,9 @@
       "exports": "การส่งออก",
       "imports": "การนำเข้า",
       "yoyChange": "เปลี่ยนแปลงรายปี",
-      "inForce": "มีผลบังคับใช้",
-      "notified": "แจ้งแล้ว",
-      "terminated": "สิ้นสุด"
+      "highTariff": "สูง",
+      "moderateTariff": "ปานกลาง",
+      "lowTariff": "ต่ำ"
     },
     "gdelt": {
       "empty": "ไม่มีบทความล่าสุดสำหรับหัวข้อนี้"

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -553,9 +553,9 @@
       "exports": "İhracat",
       "imports": "İthalat",
       "yoyChange": "Yıllık Değişim",
-      "inForce": "Yürürlükte",
-      "notified": "Bildirildi",
-      "terminated": "Sonlandırıldı"
+      "highTariff": "Yüksek",
+      "moderateTariff": "Orta",
+      "lowTariff": "Düşük"
     },
     "gdelt": {
       "empty": "Bu konu icin son makale yok"

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -553,9 +553,9 @@
       "exports": "Xuất khẩu",
       "imports": "Nhập khẩu",
       "yoyChange": "Thay đổi theo Năm",
-      "inForce": "Có hiệu lực",
-      "notified": "Đã thông báo",
-      "terminated": "Đã chấm dứt"
+      "highTariff": "Cao",
+      "moderateTariff": "Trung bình",
+      "lowTariff": "Thấp"
     },
     "gdelt": {
       "empty": "Không có bài viết gần đây cho chủ đề này"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -553,9 +553,9 @@
       "exports": "出口",
       "imports": "进口",
       "yoyChange": "同比变化",
-      "inForce": "生效中",
-      "notified": "已通报",
-      "terminated": "已终止"
+      "highTariff": "高",
+      "moderateTariff": "中等",
+      "lowTariff": "低"
     },
     "gdelt": {
       "empty": "该主题暂无近期文章"


### PR DESCRIPTION
## Summary
- Remove "Bound Rate" column from tariffs table — WTO `TP_B_0090` bound rate indicator returns no data on our subscription tier (column always showed 0.0%)
- Fix restrictions status labels: backend returns `high/moderate/low` but panel expected `IN_FORCE/TERMINATED` — CSS classes and labels now match actual values
- Update all 17 locale files with translated tariff level labels (High/Moderate/Low)

## Test plan
- [ ] Verify Restrictions tab shows correct color-coded High/Moderate/Low badges
- [ ] Verify Tariffs tab shows 3-column table (Year, Applied Rate, Sector) without Bound Rate
- [ ] Verify Trade Flows and Barriers tabs still render correctly