### PR TITLE
fix: economic panel wrong values and unresponsive tabs

### DIFF
--- a/src/components/EconomicPanel.ts
+++ b/src/components/EconomicPanel.ts
@@ -21,6 +21,13 @@ export class EconomicPanel extends Panel {
 
   constructor() {
     super({ id: 'economic', title: t('panels.economic') });
+    this.content.addEventListener('click', (e) => {
+      const tab = (e.target as HTMLElement).closest('.economic-tab') as HTMLElement | null;
+      if (tab?.dataset.tab) {
+        this.activeTab = tab.dataset.tab as TabId;
+        this.render();
+      }
+    });
   }
 
   public update(data: FredSeries[]): void {
@@ -110,16 +117,6 @@ export class EconomicPanel extends Panel {
       </div>
     `);
 
-    // Bind tab click events
-    this.content.querySelectorAll('.economic-tab').forEach(tab => {
-      tab.addEventListener('click', (e) => {
-        const tabId = (e.target as HTMLElement).dataset.tab as TabId;
-        if (tabId) {
-          this.activeTab = tabId;
-          this.render();
-        }
-      });
-    });
   }
 
   private getSourceLabel(): string {


### PR DESCRIPTION
## Summary
- **Wrong values**: All 7 FRED indicators displayed the same value (~326.59%) because a single shared `fredBreaker` circuit breaker cached whichever series completed last and returned it for all subsequent calls. Replaced with per-series circuit breakers keyed by series ID.
- **Tabs not clickable**: Tab click listeners were bound to DOM elements after `setContent()`, which is debounced at 150ms. When the debounce fired and replaced innerHTML, all listeners were destroyed. Fixed with event delegation on the stable `this.content` element (set once in constructor).

## Test plan
- [ ] Verify each FRED indicator (WALCL, FEDFUNDS, T10Y2Y, UNRATE, CPI, DGS10, VIX) shows distinct, realistic values
- [ ] Click Oil, Gov, Central Banks tabs — verify they switch content
- [ ] Click back to Indicators tab — verify it returns to FRED data
- [ ] Wait 15+ minutes and confirm values refresh independently per series