### PR TITLE
fix: respect Browser Local Model toggle

### DIFF
--- a/src/services/sentiment-gate.ts
+++ b/src/services/sentiment-gate.ts
@@ -36,14 +36,8 @@ export async function filterBySentiment(
   } catch { /* ignore localStorage errors */ }
 
   // Graceful degradation: if ML not available, pass all items through
-  try {
-    const ready = await mlWorker.init();
-    if (!ready) {
-      console.log('[SentimentGate] ML worker not available, passing all items through');
-      return items;
-    }
-  } catch {
-    console.log('[SentimentGate] ML worker init failed, passing all items through');
+  if (!mlWorker.isAvailable) {
+    console.log('[SentimentGate] ML worker not available, passing all items through');
     return items;
   }
 


### PR DESCRIPTION
## Summary
- `mlWorker.init()` was called unconditionally in `App.init()`, ignoring the "Browser Local Model" setting. This caused ONNX model downloads, 120s embed timeouts, and `[Clustering] Semantic clustering failed` warnings even with the toggle OFF.
- Gate `mlWorker.init()` on `browserModel` setting (or desktop runtime)
- Subscribe to setting changes so toggling ON/OFF dynamically inits/terminates the worker
- Replace `mlWorker.init()` call in `sentiment-gate.ts` with `isAvailable` check (was bypassing the gate)
- Clean up subscription in `App.destroy()` to prevent HMR listener leaks

## Test plan
- [ ] Set "Browser Local Model" to OFF → no ML warnings in console, no embed timeouts
- [ ] Set "Browser Local Model" to ON → ML worker initializes, semantic clustering works
- [ ] Toggle OFF while running → worker terminates, falls back to Jaccard-only clustering
- [ ] Desktop app → ML worker always initializes regardless of web setting