### PR TITLE
fix: supply chain panel — invalid FRED series, per-tab banner, feature gate

### DIFF
--- a/src/components/SupplyChainPanel.ts
+++ b/src/components/SupplyChainPanel.ts
@@ -60,9 +60,10 @@ export class SupplyChainPanel extends Panel {
       </div>
     `;
 
-    const anyUnavailable = [this.shippingData, this.chokepointData, this.mineralsData]
-      .some(d => d?.upstreamUnavailable);
-    const unavailableBanner = anyUnavailable
+    const activeData = this.activeTab === 'chokepoints' ? this.chokepointData
+      : this.activeTab === 'shipping' ? this.shippingData
+      : this.mineralsData;
+    const unavailableBanner = activeData?.upstreamUnavailable
       ? `<div class="economic-warning">${t('components.supplyChain.upstreamUnavailable')}</div>`
       : '';
 

--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -10,7 +10,6 @@ import {
   type ShippingRatePoint,
 } from '@/generated/client/worldmonitor/supply_chain/v1/service_client';
 import { createCircuitBreaker } from '@/utils';
-import { isFeatureAvailable } from '../runtime-config';
 
 export type {
   GetShippingRatesResponse,
@@ -34,7 +33,6 @@ const emptyChokepoints: GetChokepointStatusResponse = { chokepoints: [], fetched
 const emptyMinerals: GetCriticalMineralsResponse = { minerals: [], fetchedAt: '', upstreamUnavailable: false };
 
 export async function fetchShippingRates(): Promise<GetShippingRatesResponse> {
-  if (!isFeatureAvailable('supplyChain')) return emptyShipping;
   try {
     return await shippingBreaker.execute(async () => {
       return client.getShippingRates({});


### PR DESCRIPTION
## Summary

Fixes three bugs in the Supply Chain panel (PR #387):

- **Shipping tab empty**: `BDIY` (Baltic Dry Index) is proprietary Baltic Exchange data — not available on FRED. Replaced with real public FRED series: `PCU483111483111` (Deep Sea Freight PPI) and `TSIFRGHT` (Freight Transportation Index)
- **"Unavailable" banner on all tabs**: The yellow warning checked all three datasets globally. Shipping's failure poisoned Chokepoints and Minerals tabs that had valid data. Now per-tab only
- **Inconsistent feature gate**: `fetchShippingRates()` had `isFeatureAvailable('supplyChain')` gate but Chokepoints/Minerals didn't. Removed — server handler already returns empty when `FRED_API_KEY` is missing

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx tsx --test tests/supply-chain-handlers.test.mjs` — 13/13 pass
- [ ] Deploy to preview — verify Shipping tab shows Deep Sea Freight PPI and Freight Transportation Index data
- [ ] Verify Chokepoints/Minerals tabs no longer show "unavailable" banner