### PR TITLE
feat: add Ransomware.live RSS feed to cyber/security sources

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -105,6 +105,7 @@ const ALLOWED_DOMAINS = [
   'www.techmeme.com',
   'www.darkreading.com',
   'www.schneier.com',
+  'www.ransomware.live',
   'rss.politico.com',
   'www.anandtech.com',
   'www.tomshardware.com',

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -89,6 +89,7 @@ export const SOURCE_TIERS: Record<string, number> = {
   'The Diplomat': 3,
   'Bellingcat': 3,
   'Krebs Security': 3,
+  'Ransomware.live': 3,
   'Federal Reserve': 3,
   'SEC': 3,
   'MIT Tech Review': 3,
@@ -1100,6 +1101,7 @@ export const INTEL_SOURCES: Feed[] = [
   // OSINT & Monitoring (Tier 2)
   { name: 'Bellingcat', url: rss('https://www.bellingcat.com/feed/'), type: 'osint' },
   { name: 'Krebs Security', url: rss('https://krebsonsecurity.com/feed/'), type: 'cyber' },
+  { name: 'Ransomware.live', url: rss('https://www.ransomware.live/rss.xml'), type: 'cyber' },
 
   // Economic & Food Security (Tier 2)
   { name: 'FAO News', url: rss('https://www.fao.org/feeds/fao-newsroom-rss'), type: 'economic' },

--- a/src/config/variants/tech.ts
+++ b/src/config/variants/tech.ts
@@ -104,6 +104,7 @@ export const FEEDS: Record<string, Feed[]> = {
     { name: 'Schneier', url: rss('https://www.schneier.com/feed/') },
     { name: 'CISA Advisories', url: 'https://rss.worldmonitor.app/api/rss-proxy?url=' + encodeURIComponent('https://www.cisa.gov/cybersecurity-advisories/all.xml') },
     { name: 'Cyber Incidents', url: rss('https://news.google.com/rss/search?q=cyber+attack+OR+data+breach+OR+ransomware+OR+hacking+when:3d&hl=en-US&gl=US&ceid=US:en') },
+    { name: 'Ransomware.live', url: rss('https://www.ransomware.live/rss.xml') },
   ],
 
   // Policy & Regulation


### PR DESCRIPTION
## Summary
- Add [ransomware.live/rss.xml](https://www.ransomware.live/rss.xml) to the **tech variant** `security` feed group
- Add to **main variant** global feeds as `type: 'cyber'` (ready for when cyber panel is enabled)
- Add `www.ransomware.live` to RSS proxy `ALLOWED_DOMAINS`
- Set source tier to 3 (specialty)

## Test plan
- [ ] Tech variant loads Ransomware.live feed in security section
- [ ] RSS proxy does not 403 on `www.ransomware.live`
- [ ] Main variant includes feed when `cyberThreats` panel is enabled