### PR TITLE
fix: restore FilterSpecification type on country highlight filters

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -4192,7 +4192,7 @@ export class DeckGLMap {
   public highlightCountry(code: string): void {
     this.highlightedCountryCode = code;
     if (!this.maplibreMap || !this.countryGeoJsonLoaded) return;
-    const filter = ['==', ['get', 'ISO3166-1-Alpha-2'], code];
+    const filter = ['==', ['get', 'ISO3166-1-Alpha-2'], code] as maplibregl.FilterSpecification;
     try {
       this.maplibreMap.setFilter('country-highlight-fill', filter);
       this.maplibreMap.setFilter('country-highlight-border', filter);
@@ -4202,7 +4202,7 @@ export class DeckGLMap {
   public clearCountryHighlight(): void {
     this.highlightedCountryCode = null;
     if (!this.maplibreMap) return;
-    const noMatch = ['==', ['get', 'ISO3166-1-Alpha-2'], ''];
+    const noMatch = ['==', ['get', 'ISO3166-1-Alpha-2'], ''] as maplibregl.FilterSpecification;
     try {
       this.maplibreMap.setFilter('country-highlight-fill', noMatch);
       this.maplibreMap.setFilter('country-highlight-border', noMatch);


### PR DESCRIPTION
## Summary
- PR #382 accidentally removed the `maplibregl.FilterSpecification` type annotation from country highlight filter expressions in `DeckGLMap.ts`
- Without it, TypeScript infers `(string | string[])[]` which doesn't satisfy `setFilter()`'s `FilterSpecification` parameter type
- This broke the Vercel production build (`tsc` exits with 4 errors)

## Root cause
The type annotation was already correct before #382. The PR removed it while claiming to "fix deckgl filter typing."

## Why wasn't this caught?
- `.husky/pre-push` hook is not executable (ignored by git)
- No CI type-check on PRs before merge

## Test plan
- [x] `npx tsc --noEmit` passes locally
- [ ] Vercel build succeeds after merge