### PR TITLE
ci: add TypeScript type-check on PRs

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,22 @@
+name: Typecheck
+
+on:
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - '.planning/**'
+      - 'docs/**'
+      - 'e2e/**'
+      - 'scripts/**'
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run typecheck


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs `npm run typecheck` (`tsc --noEmit`) on every PR
- Skips markdown, docs, e2e, scripts, and planning files
- Would have caught the #382 regression that broke the Vercel build

## Test plan
- [ ] Workflow triggers on PR with `.ts` changes
- [ ] Workflow skips on markdown-only PRs
- [ ] Type errors block merge (requires branch protection rule to enforce)