### PR TITLE
fix: Linux AppImage crashes, RSS proxy 403s, and console noise

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -50,7 +50,7 @@ jobs:
             node_target: 'x86_64-pc-windows-msvc'
             label: 'Windows-x64'
             timeout: 120
-          - platform: 'ubuntu-22.04'
+          - platform: 'ubuntu-24.04'
             args: ''
             node_target: 'x86_64-unknown-linux-gnu'
             label: 'Linux-x64'

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -51,6 +51,7 @@ const ALLOWED_DOMAINS = [
   'feeds.npr.org',
   'news.google.com',
   'www.aljazeera.com',
+  'www.aljazeera.net',
   'rss.cnn.com',
   'hnrss.org',
   'feeds.arstechnica.com',
@@ -169,10 +170,17 @@ const ALLOWED_DOMAINS = [
   // International News Sources
   'www.france24.com',
   'www.euronews.com',
+  'de.euronews.com',
+  'es.euronews.com',
+  'fr.euronews.com',
+  'it.euronews.com',
+  'pt.euronews.com',
+  'ru.euronews.com',
   'www.lemonde.fr',
   'rss.dw.com',
   'www.bild.de',
   'www.africanews.com',
+  'fr.africanews.com',
   // Nigeria
   'www.premiumtimesng.com',
   'www.vanguardngr.com',
@@ -219,6 +227,30 @@ const ALLOWED_DOMAINS = [
   'www.fao.org',
   'worldbank.org',
   'www.imf.org',
+  // International news (various languages)
+  'www.bbc.com',
+  'www.spiegel.de',
+  'www.tagesschau.de',
+  'newsfeed.zeit.de',
+  'feeds.elpais.com',
+  'e00-elmundo.uecdn.es',
+  'www.repubblica.it',
+  'www.ansa.it',
+  'xml2.corriereobjects.it',
+  'feeds.nos.nl',
+  'www.nrc.nl',
+  'www.telegraaf.nl',
+  'www.dn.se',
+  'www.svd.se',
+  'www.svt.se',
+  'www.asahi.com',
+  'www.clarin.com',
+  'oglobo.globo.com',
+  'feeds.folha.uol.com.br',
+  'www.eltiempo.com',
+  'www.eluniversal.com.mx',
+  'www.jeuneafrique.com',
+  'www.lorientlejour.com',
   // Regional locale feeds (tr, pl, ru, th, vi, pt)
   'www.hurriyet.com.tr',
   'tvn24.pl',
@@ -286,8 +318,11 @@ export default async function handler(req) {
   try {
     const parsedUrl = new URL(feedUrl);
 
-    // Security: Check if domain is allowed
-    if (!ALLOWED_DOMAINS.includes(parsedUrl.hostname)) {
+    // Security: Check if domain is allowed (normalize www prefix)
+    const hostname = parsedUrl.hostname;
+    const bare = hostname.replace(/^www\./, '');
+    const withWww = hostname.startsWith('www.') ? hostname : `www.${hostname}`;
+    if (!ALLOWED_DOMAINS.includes(hostname) && !ALLOWED_DOMAINS.includes(bare) && !ALLOWED_DOMAINS.includes(withWww)) {
       return new Response(JSON.stringify({ error: 'Domain not allowed' }), {
         status: 403,
         headers: { 'Content-Type': 'application/json', ...corsHeaders },

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -152,6 +152,7 @@ export async function initAnalytics(): Promise<void> {
 
       posthog.init(POSTHOG_KEY, {
         api_host: POSTHOG_HOST,
+        ui_host: 'https://us.posthog.com',
         persistence: 'localStorage',
         autocapture: false,
         capture_pageview: false, // Manual capture below — auto-capture silently fails with bootstrap + SPA

--- a/src/services/trending-keywords.ts
+++ b/src/services/trending-keywords.ts
@@ -512,7 +512,7 @@ async function handleSpike(spike: TrendingSpike, config: TrendingConfig): Promis
   try {
     const significant = await isSignificantTerm(spike.term, spike.headlines);
     if (!significant) {
-      console.log(`[TrendingKeywords] Suppressed non-entity term: "${spike.term}"`);
+      console.debug(`[TrendingKeywords] Suppressed non-entity term: "${spike.term}"`);
       return;
     }
 


### PR DESCRIPTION
## Summary

- **Linux AppImage** (#370, #257): Upgrade CI to Ubuntu 24.04 (GLib 2.80), add Wayland GDK_BACKEND hint, disable WebKit sandbox in FUSE mount, isolate GTK input-method modules
- **RSS proxy**: Add 32 missing feed domains + normalize www prefix in domain validation
- **Console noise**: Downgrade TrendingKeywords suppression logs to debug, add PostHog `ui_host` for reverse proxy

## Test plan
- [ ] Linux AppImage launches on Wayland-only compositor (niri/river)
- [ ] Linux AppImage renders content (not blank) on Fedora/Ubuntu/Debian
- [ ] RSS feeds from EuroNews language variants, international sources load
- [ ] channelstv.com and vanguardngr.com feeds no longer 403
- [ ] Browser console is cleaner (no TrendingKeywords spam)
- [ ] PostHog events reach ingestion endpoint (no 404s)

Closes #370
Closes #257