### PR TITLE
fix: restore Linux AppImage updater routing and fallback status

### DIFF
--- a/api/download.js
+++ b/api/download.js
@@ -12,23 +12,28 @@ const PLATFORM_PATTERNS = {
   'linux-appimage': (name) => name.endsWith('_amd64.AppImage'),
 };
 
-const VARIANT_PREFIXES = {
-  full: ['world-monitor'],
-  world: ['world-monitor'],
-  tech: ['tech-monitor'],
-  finance: ['finance-monitor'],
+const VARIANT_IDENTIFIERS = {
+  full: ['worldmonitor'],
+  world: ['worldmonitor'],
+  tech: ['techmonitor'],
+  finance: ['financemonitor'],
 };
 
+function canonicalAssetName(name) {
+  return String(name || '').toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
 function findAssetForVariant(assets, variant, platformMatcher) {
-  const prefixes = VARIANT_PREFIXES[variant] ?? null;
-  if (!prefixes) return null;
+  const identifiers = VARIANT_IDENTIFIERS[variant] ?? null;
+  if (!identifiers) return null;
 
   return assets.find((asset) => {
-    const assetName = String(asset?.name || '').toLowerCase();
-    const hasVariantPrefix = prefixes.some((prefix) =>
-      assetName.startsWith(`${prefix.toLowerCase()}_`) || assetName.startsWith(`${prefix.toLowerCase()}-`)
+    const assetName = String(asset?.name || '');
+    const normalizedAssetName = canonicalAssetName(assetName);
+    const hasVariantIdentifier = identifiers.some((identifier) =>
+      normalizedAssetName.includes(identifier)
     );
-    return hasVariantPrefix && platformMatcher(String(asset?.name || ''));
+    return hasVariantIdentifier && platformMatcher(assetName);
   }) ?? null;
 }
 

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1245,6 +1245,7 @@ export async function createLocalApiServer(options = {}) {
 
       const address = server.address();
       const boundPort = typeof address === 'object' && address?.port ? address.port : context.port;
+      context.port = boundPort;
 
       const portFile = process.env.LOCAL_API_PORT_FILE;
       if (portFile) {

--- a/src/app/desktop-updater.ts
+++ b/src/app/desktop-updater.ts
@@ -133,6 +133,10 @@ export class DesktopUpdater implements AppModule {
       return null;
     }
 
+    if (normalizedOs === 'linux') {
+      return normalizedArch === 'x86_64' ? 'linux-appimage' : null;
+    }
+
     return null;
   }
 

--- a/tests/download-handler.test.mjs
+++ b/tests/download-handler.test.mjs
@@ -1,0 +1,82 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import handler from '../api/download.js';
+
+const RELEASES_PAGE = 'https://github.com/koala73/worldmonitor/releases/latest';
+
+function makeGitHubReleaseResponse(assets) {
+  return new Response(JSON.stringify({ assets }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+test('matches full variant for dotted World.Monitor AppImage asset names', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => makeGitHubReleaseResponse([
+    {
+      name: 'World.Monitor_2.5.7_amd64.AppImage',
+      browser_download_url: 'https://downloads.example/World.Monitor_2.5.7_amd64.AppImage',
+    },
+  ]);
+
+  try {
+    const response = await handler(
+      new Request('https://worldmonitor.app/api/download?platform=linux-appimage&variant=full')
+    );
+    assert.equal(response.status, 302);
+    assert.equal(
+      response.headers.get('location'),
+      'https://downloads.example/World.Monitor_2.5.7_amd64.AppImage'
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('matches tech variant for dashed Tech-Monitor AppImage asset names', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => makeGitHubReleaseResponse([
+    {
+      name: 'Tech-Monitor_2.5.7_amd64.AppImage',
+      browser_download_url: 'https://downloads.example/Tech-Monitor_2.5.7_amd64.AppImage',
+    },
+    {
+      name: 'World.Monitor_2.5.7_amd64.AppImage',
+      browser_download_url: 'https://downloads.example/World.Monitor_2.5.7_amd64.AppImage',
+    },
+  ]);
+
+  try {
+    const response = await handler(
+      new Request('https://worldmonitor.app/api/download?platform=linux-appimage&variant=tech')
+    );
+    assert.equal(response.status, 302);
+    assert.equal(
+      response.headers.get('location'),
+      'https://downloads.example/Tech-Monitor_2.5.7_amd64.AppImage'
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('falls back to release page when requested variant has no matching asset', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => makeGitHubReleaseResponse([
+    {
+      name: 'World.Monitor_2.5.7_amd64.AppImage',
+      browser_download_url: 'https://downloads.example/World.Monitor_2.5.7_amd64.AppImage',
+    },
+  ]);
+
+  try {
+    const response = await handler(
+      new Request('https://worldmonitor.app/api/download?platform=linux-appimage&variant=finance')
+    );
+    assert.equal(response.status, 302);
+    assert.equal(response.headers.get('location'), RELEASES_PAGE);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
- ## Fixes
- Map Linux desktop runtime to `linux-appimage` in updater URL resolution
- make `/api/download` variant matching robust across asset naming formats (dot/dash/underscore)
- update sidecar context port after EADDRINUSE fallback bind so status endpoints report the true port
- add regression tests for download variant matching and fallback port reporting\

- ## Validation
- node --test tests/download-handler.test.mjs\n- node --test src-tauri/sidecar/local-api-server.test.mjs\n- pre-push checks (typecheck + full build + version check)