### PR TITLE
fix: rate-limit UX, auth retry, verbose persistence

### DIFF
--- a/server/worldmonitor/market/v1/get-sector-summary.ts
+++ b/server/worldmonitor/market/v1/get-sector-summary.ts
@@ -41,7 +41,7 @@ export async function getSectorSummary(
     if (sectors.length === 0) {
       const batch = await fetchYahooQuotesBatch(sectorSymbols);
       for (const s of sectorSymbols) {
-        const yahoo = batch.get(s);
+        const yahoo = batch.results.get(s);
         if (yahoo) sectors.push({ symbol: s, name: s, change: yahoo.change });
       }
     }

--- a/server/worldmonitor/market/v1/list-commodity-quotes.ts
+++ b/server/worldmonitor/market/v1/list-commodity-quotes.ts
@@ -33,7 +33,7 @@ export async function listCommodityQuotes(
     const batch = await fetchYahooQuotesBatch(symbols);
     const quotes: CommodityQuote[] = [];
     for (const s of symbols) {
-      const yahoo = batch.get(s);
+      const yahoo = batch.results.get(s);
       if (yahoo) {
         quotes.push({ symbol: s, name: s, display: s, price: yahoo.price, change: yahoo.change, sparkline: yahoo.sparkline });
       }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "world-monitor"
-version = "2.5.8"
+version = "2.5.9"
 dependencies = [
  "getrandom 0.2.17",
  "keyring",

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -396,8 +396,8 @@ const trafficLog = [];
 let verboseMode = false;
 let _verboseStatePath = null;
 
-function loadVerboseState(resourceDir) {
-  _verboseStatePath = path.join(resourceDir, 'verbose-mode.json');
+function loadVerboseState(dataDir) {
+  _verboseStatePath = path.join(dataDir, 'verbose-mode.json');
   try {
     const data = JSON.parse(readFileSync(_verboseStatePath, 'utf-8'));
     verboseMode = !!data.verboseMode;
@@ -459,6 +459,7 @@ function resolveConfig(options = {}) {
       path.join(resourceDir, 'api'),
       path.join(resourceDir, '_up_', 'api'),
     ].find((candidate) => existsSync(candidate)) ?? path.join(resourceDir, 'api');
+  const dataDir = String(options.dataDir ?? process.env.LOCAL_API_DATA_DIR ?? resourceDir);
   const mode = String(options.mode ?? process.env.LOCAL_API_MODE ?? 'desktop-sidecar');
   const cloudFallback = String(options.cloudFallback ?? process.env.LOCAL_API_CLOUD_FALLBACK ?? '') === 'true';
   const logger = options.logger ?? console;
@@ -467,6 +468,7 @@ function resolveConfig(options = {}) {
     port,
     remoteBase,
     resourceDir,
+    dataDir,
     apiDir,
     mode,
     cloudFallback,
@@ -1152,7 +1154,7 @@ async function dispatch(requestUrl, req, routes, context) {
 
 export async function createLocalApiServer(options = {}) {
   const context = resolveConfig(options);
-  loadVerboseState(context.resourceDir);
+  loadVerboseState(context.dataDir);
   const routes = await buildRouteTable(context.apiDir);
 
   const server = createServer(async (req, res) => {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -984,10 +984,14 @@ fn start_local_api(app: &AppHandle) -> Result<(), String> {
         "INFO",
         &format!("node args: script={script_for_node} resource_dir={resource_for_node}"),
     );
+    let data_dir = logs_dir_path(app)
+        .map(|p| sanitize_path_for_node(&p))
+        .unwrap_or_else(|_| resource_for_node.clone());
     cmd.arg(&script_for_node)
         .env("LOCAL_API_PORT", DEFAULT_LOCAL_API_PORT.to_string())
         .env("LOCAL_API_PORT_FILE", &port_file)
         .env("LOCAL_API_RESOURCE_DIR", &resource_for_node)
+        .env("LOCAL_API_DATA_DIR", &data_dir)
         .env("LOCAL_API_MODE", "tauri-sidecar")
         .env("LOCAL_API_TOKEN", &local_api_token)
         .stdout(Stdio::from(log_file))

--- a/src/components/ETFFlowsPanel.ts
+++ b/src/components/ETFFlowsPanel.ts
@@ -53,7 +53,7 @@ export class ETFFlowsPanel extends Panel {
         this.data = await client.listEtfFlows({});
         this.error = null;
 
-        if (this.data && this.data.etfs.length === 0 && attempt < 2) {
+        if (this.data && this.data.etfs.length === 0 && !this.data.rateLimited && attempt < 2) {
           this.showRetrying();
           await new Promise(r => setTimeout(r, 20_000));
           continue;
@@ -86,7 +86,8 @@ export class ETFFlowsPanel extends Panel {
 
     const d = this.data;
     if (!d.etfs.length) {
-      this.setContent(`<div class="panel-loading-text">${t('components.etfFlows.unavailable')}</div>`);
+      const msg = d.rateLimited ? t('components.etfFlows.rateLimited') : t('components.etfFlows.unavailable');
+      this.setContent(`<div class="panel-loading-text">${msg}</div>`);
       return;
     }
 

--- a/src/components/MarketPanel.ts
+++ b/src/components/MarketPanel.ts
@@ -25,9 +25,9 @@ export class MarketPanel extends Panel {
     super({ id: 'markets', title: t('panels.markets') });
   }
 
-  public renderMarkets(data: MarketData[]): void {
+  public renderMarkets(data: MarketData[], rateLimited?: boolean): void {
     if (data.length === 0) {
-      this.showError(t('common.failedMarketData'));
+      this.showError(rateLimited ? t('common.rateLimitedMarket') : t('common.failedMarketData'));
       return;
     }
 

--- a/src/generated/client/worldmonitor/market/v1/service_client.ts
+++ b/src/generated/client/worldmonitor/market/v1/service_client.ts
@@ -9,6 +9,7 @@ export interface ListMarketQuotesResponse {
   quotes: MarketQuote[];
   finnhubSkipped: boolean;
   skipReason: string;
+  rateLimited?: boolean;
 }
 
 export interface MarketQuote {
@@ -106,6 +107,7 @@ export interface ListEtfFlowsResponse {
   timestamp: string;
   summary?: EtfFlowsSummary;
   etfs: EtfFlow[];
+  rateLimited?: boolean;
 }
 
 export interface EtfFlowsSummary {

--- a/src/generated/server/worldmonitor/market/v1/service_server.ts
+++ b/src/generated/server/worldmonitor/market/v1/service_server.ts
@@ -9,6 +9,7 @@ export interface ListMarketQuotesResponse {
   quotes: MarketQuote[];
   finnhubSkipped: boolean;
   skipReason: string;
+  rateLimited?: boolean;
 }
 
 export interface MarketQuote {
@@ -106,6 +107,7 @@ export interface ListEtfFlowsResponse {
   timestamp: string;
   summary?: EtfFlowsSummary;
   etfs: EtfFlow[];
+  rateLimited?: boolean;
 }
 
 export interface EtfFlowsSummary {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1265,6 +1265,7 @@
     },
     "etfFlows": {
       "unavailable": "ETF data temporarily unavailable",
+      "rateLimited": "ETF data temporarily unavailable (rate limited) — retrying shortly",
       "netFlow": "Net Flow",
       "estFlow": "Est. Flow",
       "totalVol": "Total Vol",
@@ -1989,6 +1990,7 @@
     "failedSectorData": "Failed to load sector data",
     "failedCommodities": "Failed to load commodities",
     "failedCryptoData": "Failed to load crypto data",
+    "rateLimitedMarket": "Market data temporarily unavailable (rate limited) — retrying shortly",
     "failedClusterNews": "Failed to cluster news",
     "noNewsAvailable": "No news available",
     "noActiveTechHubs": "No active tech hubs",

--- a/src/services/market/index.ts
+++ b/src/services/market/index.ts
@@ -55,6 +55,7 @@ export interface MarketFetchResult {
   data: MarketData[];
   skipped?: boolean;
   reason?: string;
+  rateLimited?: boolean;
 }
 
 // ========================================================================
@@ -99,6 +100,7 @@ export async function fetchMultipleStocks(
     data,
     skipped: resp.finnhubSkipped || undefined,
     reason: resp.skipReason || undefined,
+    rateLimited: resp.rateLimited || undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- Show rate-limited message instead of generic "Failed to load" on Markets, ETF, Commodities, and Sector panels when Yahoo Finance returns 429
- `fetchYahooQuotesBatch` returns `rateLimited` flag with early-exit after 3 consecutive misses
- ETF panel skips retry loop when rate-limited, shows specific i18n message
- Fallback Finnhub symbols through Yahoo when API key is missing
- 401-retry in runtime fetch patch for stale sidecar token after restart
- `diagFetch` auth helper for settings window diagnostic endpoints
- Verbose toggle writes to writable `dataDir` instead of read-only app bundle

## Test plan
- [ ] Launch app without Finnhub key — markets should load via Yahoo fallback
- [ ] When Yahoo rate-limits (429), panels show "rate limited — retrying shortly" not "Failed to load"
- [ ] ETF panel shows rate-limit message and does not retry 3x when rate-limited
- [ ] Toggle verbose logging in settings — persists across app restart
- [ ] Settings diagnostics (traffic log, verbose toggle) work with auth token
- [ ] Sidecar token refresh works after sidecar restart (no persistent 401s)