### PR TITLE
fix(live-news): destroy player before offline/error message (fixes #347)

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -736,6 +736,7 @@ export class LiveNewsPanel extends Panel {
   }
 
   private showOfflineMessage(channel: LiveChannel): void {
+    this.destroyPlayer();
     this.content.innerHTML = `
       <div class="live-offline">
         <div class="offline-icon">📺</div>
@@ -746,6 +747,7 @@ export class LiveNewsPanel extends Panel {
   }
 
   private showEmbedError(channel: LiveChannel, errorCode: number): void {
+    this.destroyPlayer();
     const watchUrl = channel.videoId
       ? `https://www.youtube.com/watch?v=${encodeURIComponent(channel.videoId)}`
       : `https://www.youtube.com/${channel.handle}`;


### PR DESCRIPTION
## Summary
- `showOfflineMessage()` and `showEmbedError()` replaced `this.content.innerHTML` without calling `destroyPlayer()`, leaving `this.player` set
- On next channel switch, `initializePlayer()` bailed early → black screen
- Added `this.destroyPlayer()` at the top of both methods — it's idempotent so the `onError` path won't double-destroy

Closes #347

Co-authored-by: N Cho-chin (Niboshi-Wasabi) — original diagnosis in #388

## Test plan
- [ ] Add an offline channel → switch to it → switch back to a live channel → stream loads (was black)
- [ ] Trigger embed error (e.g. region-blocked video) → switch to a live channel → stream loads