### PR TITLE
fix(linux): prevent AppImage black screen on WebKit/GStreamer

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -89,7 +89,13 @@ jobs:
         if: contains(matrix.platform, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good
 
       - name: Install frontend dependencies
         run: npm ci

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1161,9 +1161,15 @@ fn main() {
         }
 
         // WebKit2GTK's bubblewrap sandbox can fail inside an AppImage FUSE
-        // mount, causing blank white screens.  Disable it when running as
+        // mount, causing blank white screens. Disable it when running as
         // AppImage — the AppImage itself already provides isolation.
         if env::var_os("APPIMAGE").is_some() {
+            // WebKitGTK 2.39.3+ deprecated WEBKIT_FORCE_SANDBOX and now expects
+            // WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1 instead.
+            if env::var_os("WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS").is_none() {
+                unsafe { env::set_var("WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS", "1") };
+            }
+            // Keep the legacy var for older WebKitGTK releases that still use it.
             if env::var_os("WEBKIT_FORCE_SANDBOX").is_none() {
                 unsafe { env::set_var("WEBKIT_FORCE_SANDBOX", "0") };
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -65,6 +65,11 @@
     },
     "macOS": {
       "hardenedRuntime": true
+    },
+    "linux": {
+      "appimage": {
+        "bundleMediaFramework": true
+      }
     }
   }
 }

--- a/src-tauri/tauri.finance.conf.json
+++ b/src-tauri/tauri.finance.conf.json
@@ -23,6 +23,11 @@
     "macOS": {
       "hardenedRuntime": true
     },
+    "linux": {
+      "appimage": {
+        "bundleMediaFramework": true
+      }
+    },
     "windows": {
       "digestAlgorithm": "sha256",
       "timestampUrl": "https://timestamp.digicert.com"

--- a/src-tauri/tauri.tech.conf.json
+++ b/src-tauri/tauri.tech.conf.json
@@ -23,6 +23,11 @@
     "macOS": {
       "hardenedRuntime": true
     },
+    "linux": {
+      "appimage": {
+        "bundleMediaFramework": true
+      }
+    },
     "windows": {
       "digestAlgorithm": "sha256",
       "timestampUrl": "https://timestamp.digicert.com"


### PR DESCRIPTION
## Summary
- set `WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1` for AppImage runtime while keeping legacy `WEBKIT_FORCE_SANDBOX=0` fallback for older WebKitGTK
- enable `bundle.linux.appimage.bundleMediaFramework` in all Tauri desktop configs (full/tech/finance)
- install `gstreamer1.0-plugins-base` and `gstreamer1.0-plugins-good` in Linux CI so AppImage media framework bundling has required build-time plugins

## Why
Linux users reported a black screen with runtime messages like `GStreamer element appsink not found` / `autoaudiosink not found`, plus GLib criticals. The sidecar logs were normal, indicating failure in WebKit/GStreamer process init.

## Validation
- `cargo check` (src-tauri) passes
- push hook checks pass (`typecheck`, Vite production build, version sync)

Closes #405
