### PR TITLE
ci: skip Typecheck and Lint on fork PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   markdown:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   typecheck:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds `if` condition to Typecheck and Lint jobs to skip fork PRs
- Only PRs from branches within the repo trigger CI

## Why
External contributor PRs (e.g. from `Jacob-Strokus:main`) were triggering CI runs unnecessarily.