### PR TITLE
chore: bump v2.5.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "world-monitor",
-  "version": "2.5.8",
+  "version": "2.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "world-monitor",
-      "version": "2.5.8",
+      "version": "2.5.12",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@deck.gl/aggregation-layers": "^9.2.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "world-monitor",
   "private": true,
-  "version": "2.5.11",
+  "version": "2.5.12",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "world-monitor"
-version = "2.5.11"
+version = "2.5.12"
 dependencies = [
  "getrandom 0.2.17",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-monitor"
-version = "2.5.11"
+version = "2.5.12"
 description = "World Monitor desktop application"
 authors = ["World Monitor"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "World Monitor",
   "mainBinaryName": "world-monitor",
-  "version": "2.5.11",
+  "version": "2.5.12",
   "identifier": "app.worldmonitor.desktop",
   "build": {
     "beforeDevCommand": "npm run build:sidecar-sebuf && npm run dev",


### PR DESCRIPTION
## Changelog

- **fix(linux)**: enable keyring persistence via Secret Service + keyutils (#419)
- **fix(ci)**: use weston+XWayland for Linux smoke test (#417)
- **ci**: add standalone Test Linux App workflow (#414)
- **ci**: skip Typecheck and Lint on fork PRs (#415)
- **perf**: optimize Wingbits API usage and reduce unnecessary polling (#416)