### PR TITLE
chore: bump v2.5.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "world-monitor",
   "private": true,
-  "version": "2.5.13",
+  "version": "2.5.14",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "world-monitor"
-version = "2.5.13"
+version = "2.5.14"
 dependencies = [
  "getrandom 0.2.17",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-monitor"
-version = "2.5.13"
+version = "2.5.14"
 description = "World Monitor desktop application"
 authors = ["World Monitor"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "World Monitor",
   "mainBinaryName": "world-monitor",
-  "version": "2.5.13",
+  "version": "2.5.14",
   "identifier": "app.worldmonitor.desktop",
   "build": {
     "beforeDevCommand": "npm run build:sidecar-sebuf && npm run dev",


### PR DESCRIPTION
## Summary
- Bump version to 2.5.14 across package.json, tauri.conf.json, and Cargo.toml

## Changelog since v2.5.13
- feat: add ARM64 Linux build target and download detection (#427)
- fix(live-channels): tolerate YouTube API failures when adding custom channels (#425)
- fix(linux): append host GStreamer plugins to AppImage search path (#424)
- fix(linux): enable keyring persistence via Secret Service + keyutils (#419)