### PR TITLE
fix(ci): deduplicate smoke test artifact name for dual Linux builds

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -333,7 +333,7 @@ jobs:
         if: contains(matrix.platform, 'ubuntu')
         uses: actions/upload-artifact@v4
         with:
-          name: linux-smoke-test-screenshot
+          name: linux-smoke-test-screenshot-${{ matrix.label }}
           path: screenshot.png
           if-no-files-found: warn
 


### PR DESCRIPTION
## Summary
- Both `ubuntu-24.04` (x64) and `ubuntu-24.04-arm` (ARM64) matrix entries run the smoke test and upload a screenshot artifact with the static name `linux-smoke-test-screenshot`
- `upload-artifact@v4` rejects duplicate names with 409 Conflict (v3 merged, v4 errors)
- Fix: append `${{ matrix.label }}` → `linux-smoke-test-screenshot-Linux-x64` / `linux-smoke-test-screenshot-Linux-ARM64`

**CI log proof** from [run 22452393753](https://github.com/koala73/worldmonitor/actions/runs/22452393753): the ARM64 "Upload smoke test screenshot" step fails on the exact artifact name collision.

## Test plan
- [ ] Re-trigger v2.5.14 build (or push a new tag) and verify both Linux builds complete without 409