### PR TITLE
fix(linux): bundle full GStreamer codec suite for YouTube playback

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -100,7 +100,11 @@ jobs:
             librsvg2-dev \
             patchelf \
             gstreamer1.0-plugins-base \
-            gstreamer1.0-plugins-good
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-plugins-ugly \
+            gstreamer1.0-libav \
+            gstreamer1.0-gl
 
       - name: Install frontend dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- AppImage only bundled `gst-plugins-base` and `gst-plugins-good` — missing H.264, AAC, AV1, and GL video sink codecs
- YouTube's MSE player checks `MediaSource.isTypeSupported()` → WebKitGTK delegates to GStreamer → no compatible decoders found → "Your browser can't play this video"
- Add `gst-plugins-bad`, `gst-plugins-ugly`, `gst-libav`, and `gst-gl` to CI install so `bundleMediaFramework: true` includes them in the AppImage

## Test plan
- [ ] Build new AppImage with these packages and verify YouTube plays on fresh Ubuntu 25