### PR TITLE
fix(linux): isolate AppImage GStreamer plugins to prevent ABI mismatch

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1211,35 +1211,22 @@ fn main() {
                 unsafe { env::set_var("GTK_IM_MODULE", "gtk-im-context-simple") };
             }
 
-            // The linuxdeploy GStreamer hook force-overrides GST_PLUGIN_SYSTEM_PATH_1_0
-            // and GST_PLUGIN_PATH_1_0 to only contain bundled plugins.  The AppImage
-            // bundles GStreamer from the CI build system (Ubuntu 24.04, GStreamer 1.24)
-            // but does NOT bundle codec plugins (gst-libav, fakevideosink from
-            // gst-plugins-bad).  On hosts with newer GStreamer (e.g. Arch with 1.28),
-            // the bundled-only path means host plugins are invisible → WebKit can't
-            // play video.  Append host plugin directories as fallback so the system's
-            // codec plugins are discoverable.
-            let host_gst_dirs = [
-                "/usr/lib/x86_64-linux-gnu/gstreamer-1.0",
-                "/usr/lib/gstreamer-1.0",
-                "/usr/lib64/gstreamer-1.0",
-                "/usr/lib/aarch64-linux-gnu/gstreamer-1.0",
-            ];
-            let existing: Vec<String> = host_gst_dirs
-                .iter()
-                .filter(|d| std::path::Path::new(d).is_dir())
-                .map(|d| d.to_string())
-                .collect();
-            if !existing.is_empty() {
-                let suffix = existing.join(":");
-                for var in ["GST_PLUGIN_PATH_1_0", "GST_PLUGIN_SYSTEM_PATH_1_0"] {
-                    let current = env::var(var).unwrap_or_default();
-                    if !current.is_empty() {
-                        unsafe { env::set_var(var, format!("{current}:{suffix}")) };
-                    } else {
-                        unsafe { env::set_var(var, &suffix) };
-                    }
-                }
+            // The linuxdeploy GStreamer hook sets GST_PLUGIN_PATH_1_0 and
+            // GST_PLUGIN_SYSTEM_PATH_1_0 to only contain bundled plugins.
+            // CI installs the full GStreamer codec suite (base, good, bad,
+            // ugly, libav, gl) so bundleMediaFramework=true bundles everything.
+            //
+            // IMPORTANT: Do NOT append host plugin directories — mixing plugins
+            // compiled against a different GStreamer version causes ABI mismatches
+            // (undefined symbol errors like gst_util_floor_log2, mpg123_open_handle64)
+            // and leaves WebKit without usable codecs.  The AppImage must be fully
+            // self-contained for GStreamer.
+            //
+            // If the linuxdeploy hook didn't set the paths (shouldn't happen),
+            // explicitly block host plugin scanning to prevent ABI conflicts.
+            if env::var_os("GST_PLUGIN_SYSTEM_PATH_1_0").is_none() {
+                // Empty string prevents GStreamer from scanning /usr/lib/gstreamer-1.0
+                unsafe { env::set_var("GST_PLUGIN_SYSTEM_PATH_1_0", "") };
             }
         }
     }


### PR DESCRIPTION
## Summary
- Remove host GStreamer plugin directory fallback that caused ABI version mismatches
- Block host plugin scanning with empty `GST_PLUGIN_SYSTEM_PATH_1_0` as safety net
- AppImage is now fully self-contained for GStreamer (CI installs full codec suite since #434)

## Problem
Users on various Linux distros reported GStreamer errors and no YouTube playback:
```
Failed to load plugin '/usr/lib/gstreamer-1.0/libgstcodecparsers-1.0.so.0': undefined symbol: gst_util_floor_log2
GStreamer element vp9parse not found
GStreamer element h264parse not found
GStreamer element opusparse not found
```

Root cause: The AppImage bundles GStreamer 1.24 from CI (Ubuntu 24.04), but the code appended host plugin directories as fallback. Host plugins compiled against a different GStreamer version (older or newer) fail with undefined symbol errors due to ABI mismatch. This left WebKit with zero usable codec plugins.

## Why this is safe now
PR #434 added the full GStreamer codec suite (base, good, bad, ugly, libav, gl) to CI. With `bundleMediaFramework: true`, the AppImage bundles all necessary plugins. No host fallback needed.

## Separate issue: Exec format error (aarch64 on x86_64)
One user also reported `Exec format error` when running an aarch64 AppImage — this is an architecture mismatch (wrong download), not a code bug.

## Test plan
- [ ] Run AppImage on distro with GStreamer 1.22 (Ubuntu 22.04/Debian 12) — no undefined symbol errors
- [ ] Run AppImage on distro with GStreamer 1.28 (Arch) — no ABI conflicts
- [ ] YouTube Live News plays correctly
- [ ] Check stderr for absence of `Failed to load plugin` GStreamer warnings from host paths