### PR TITLE
chore: bump v2.5.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "world-monitor",
   "private": true,
-  "version": "2.5.17",
+  "version": "2.5.18",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-monitor"
-version = "2.5.17"
+version = "2.5.18"
 description = "World Monitor desktop application"
 authors = ["World Monitor"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "World Monitor",
   "mainBinaryName": "world-monitor",
-  "version": "2.5.17",
+  "version": "2.5.18",
   "identifier": "app.worldmonitor.desktop",
   "build": {
     "beforeDevCommand": "npm run build:sidecar-sebuf && npm run dev",


### PR DESCRIPTION
## Summary
- Bump version to 2.5.18 across package.json, tauri.conf.json, and Cargo.toml
- Includes GStreamer ABI isolation fix (#444) and VM compositing fix (#441)