### PR TITLE
fix(linux): detect NVIDIA GPU and work around EGL_BAD_ALLOC on Wayland

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "world-monitor",
   "private": true,
-  "version": "2.5.18",
+  "version": "2.5.19",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {
@@ -28,6 +28,7 @@
     "test:e2e:runtime": "VITE_VARIANT=full playwright test e2e/runtime-fetch.spec.ts",
     "test:e2e": "npm run test:e2e:runtime && npm run test:e2e:full && npm run test:e2e:tech && npm run test:e2e:finance",
     "test:data": "node --test tests/*.test.mjs",
+    "test:feeds": "node scripts/validate-rss-feeds.mjs",
     "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs api/_cors.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs",
     "test:e2e:visual:full": "VITE_VARIANT=full playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual:tech": "VITE_VARIANT=tech playwright test -g \"matches golden screenshots per layer and zoom\"",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "world-monitor"
-version = "2.5.15"
+version = "2.5.19"
 dependencies = [
  "getrandom 0.2.17",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-monitor"
-version = "2.5.18"
+version = "2.5.19"
 description = "World Monitor desktop application"
 authors = ["World Monitor"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "World Monitor",
   "mainBinaryName": "world-monitor",
-  "version": "2.5.18",
+  "version": "2.5.19",
   "identifier": "app.worldmonitor.desktop",
   "build": {
     "beforeDevCommand": "npm run build:sidecar-sebuf && npm run dev",


### PR DESCRIPTION
## Summary
- Detect NVIDIA proprietary drivers via `/proc/driver/nvidia` at startup
- Set `__NV_DISABLE_EXPLICIT_SYNC=1` to prevent Wayland explicit sync flickering/crashes
- Force `GDK_BACKEND=x11` on NVIDIA + Wayland to avoid surfaceless EGL failures (user can override with `GDK_BACKEND=wayland`)
- Bump version to 2.5.19

## Context
Linux users with NVIDIA proprietary drivers on Wayland report:
```
Could not create surfaceless EGL display: EGL_BAD_ALLOC. Aborting...
```

WebKitGTK's web process calls `eglGetPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA, ...)` which fails with NVIDIA's EGL implementation and triggers `abort()`. The existing `WEBKIT_DISABLE_DMABUF_RENDERER=1` only controls buffer sharing, not EGL initialization itself.

Same issue reported across Tauri ecosystem: tauri-apps/tauri#9394, gitbutlerapp/gitbutler#5282, spacedriveapp/spacedrive#2541.

## Test plan
- [ ] Verify build compiles on Linux (`cargo check`)
- [ ] Test on NVIDIA + Wayland: app should launch without EGL_BAD_ALLOC
- [ ] Test on NVIDIA + X11: no change in behavior
- [ ] Test on AMD/Intel: NVIDIA block skipped (no `/proc/driver/nvidia`)
- [ ] Verify `GDK_BACKEND=wayland` override works for NVIDIA users who want native Wayland