### PR TITLE
fix(feeds): replace 25 dead/stale RSS URLs and add feed validation script

### DIFF
--- a/scripts/validate-rss-feeds.mjs
+++ b/scripts/validate-rss-feeds.mjs
@@ -20,8 +20,8 @@ function extractFeeds() {
 
   // Match rss('url') or railwayRss('url') — capture raw URL
   const rssUrlRe = /(?:rss|railwayRss)\(\s*'([^']+)'\s*\)/g;
-  // Match name: 'X' or name: "X" (Tom's Hardware uses double quotes)
-  const nameRe = /name:\s*(?:'([^']+)'+|"([^"]+)")/;
+  // Match name: 'X' or name: "X" — handles escaped apostrophes (L\'Orient-Le Jour)
+  const nameRe = /name:\s*(?:'((?:[^'\\]|\\.)*)'|"([^"]+)")/;
   // Match lang key like `en: rss(`, `fr: rss(` — find all on a line with positions
   const langKeyAllRe = /(?:^|[\s{,])([a-z]{2}):\s*(?:rss|railwayRss)\(/g;
 


### PR DESCRIPTION
## Summary
- Replaced 25 dead or stale RSS feed URLs with working alternatives
- Added `scripts/validate-rss-feeds.mjs` validation script to detect broken feeds

## Test plan
- [ ] `npm run dev` — verify news panels load without RSS errors
- [ ] `node scripts/validate-rss-feeds.mjs` — all feeds return 200