### PR TITLE
fix: allow iframe embedding from dashboard.dhahugannew.org

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,11 +9,10 @@
       "source": "/(.*)",
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; connect-src 'self' https: http://localhost:5173 ws: wss: blob: data:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.youtube.com https://static.cloudflareinsights.com https://vercel.live https://us-assets.i.posthog.com; worker-src 'self' blob:; font-src 'self' data: https:; media-src 'self' data: blob: https:; frame-src 'self' https://worldmonitor.app https://tech.worldmonitor.app https://happy.worldmonitor.app https://www.youtube.com https://www.youtube-nocookie.com; frame-ancestors 'self'; base-uri 'self'; object-src 'none'; form-action 'self'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; connect-src 'self' https: http://localhost:5173 ws: wss: blob: data:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://www.youtube.com https://static.cloudflareinsights.com https://vercel.live https://us-assets.i.posthog.com; worker-src 'self' blob:; font-src 'self' data: https:; media-src 'self' data: blob: https:; frame-src 'self' https://worldmonitor.app https://tech.worldmonitor.app https://happy.worldmonitor.app https://www.youtube.com https://www.youtube-nocookie.com; frame-ancestors 'self' https://dashboard.dhahugannew.org https://*.dhahugannew.org; base-uri 'self'; object-src 'none'; form-action 'self'" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Removed `X-Frame-Options: SAMEORIGIN` header — `ALLOW-FROM` is deprecated and unsupported by Chrome/Firefox, so this header can only block, never selectively allow cross-origin framing
- Updated CSP `frame-ancestors` from `'self'` to `'self' https://dashboard.dhahugannew.org https://*.dhahugannew.org`

## Problem
The Hive Dashboard at `dashboard.dhahugannew.org` embeds World Monitor in its News tab via iframe. The browser blocks this with "refused to connect" because both `X-Frame-Options: SAMEORIGIN` and CSP `frame-ancestors 'self'` reject cross-origin framing.

## Test plan
- [ ] After Vercel deploy, verify worldmonitor.app loads in iframe from dashboard.dhahugannew.org
- [ ] Verify direct access to worldmonitor.app still works
- [ ] Verify other origins still cannot iframe worldmonitor.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)