### PR TITLE
feat: Cloudflare edge caching infrastructure for api.worldmonitor.app

### DIFF
--- a/api/[domain]/v1/[rpc].ts
+++ b/api/[domain]/v1/[rpc].ts
@@ -142,6 +142,18 @@ export default async function handler(request: Request): Promise<Response> {
     mergedHeaders.set(key, value);
   }
 
+  if (response.status === 200 && request.method === 'GET' && !mergedHeaders.has('Cache-Control')) {
+    const url = new URL(request.url);
+    const noStoreEndpoints = new Set([
+      '/api/maritime/v1/get-vessel-snapshot',
+    ]);
+    if (noStoreEndpoints.has(url.pathname)) {
+      mergedHeaders.set('Cache-Control', 'no-store');
+    } else {
+      mergedHeaders.set('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=60');
+    }
+  }
+
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/middleware.ts
+++ b/middleware.ts
@@ -20,8 +20,13 @@ const SOCIAL_IMAGE_UA =
   /Slack-ImgProxy|Slackbot|twitterbot|facebookexternalhit|linkedinbot|telegrambot|whatsapp|discordbot|redditbot/i;
 
 export default function middleware(request: Request) {
-  const ua = request.headers.get('user-agent') ?? '';
   const url = new URL(request.url);
+
+  if (url.hostname === 'api.worldmonitor.app') {
+    return;
+  }
+
+  const ua = request.headers.get('user-agent') ?? '';
   const path = url.pathname;
 
   // Allow social preview/image bots on OG image assets (bypasses Vercel Attack Challenge)

--- a/server/cors.ts
+++ b/server/cors.ts
@@ -1,8 +1,8 @@
 /**
  * CORS header generation -- TypeScript port of api/_cors.js.
  *
- * Identical ALLOWED_ORIGIN_PATTERNS and logic, with methods hardcoded
- * to 'POST, OPTIONS' (all sebuf routes are POST).
+ * Identical ALLOWED_ORIGIN_PATTERNS and logic, with methods set
+ * to 'GET, POST, OPTIONS' (sebuf routes support GET and POST).
  */
 
 declare const process: { env: Record<string, string | undefined> };
@@ -35,7 +35,7 @@ export function getCorsHeaders(req: Request): Record<string, string> {
   const allowOrigin = isAllowedOrigin(origin) ? origin : 'https://worldmonitor.app';
   return {
     'Access-Control-Allow-Origin': allowOrigin,
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key',
     'Access-Control-Max-Age': '86400',
     'Vary': 'Origin',

--- a/src/main.ts
+++ b/src/main.ts
@@ -142,7 +142,7 @@ window.addEventListener('unhandledrejection', (e) => {
 
 import { debugInjectTestEvents, debugGetCells, getCellCount } from '@/services/geo-convergence';
 import { initMetaTags } from '@/services/meta-tags';
-import { installRuntimeFetchPatch } from '@/services/runtime';
+import { installRuntimeFetchPatch, installWebApiRedirect } from '@/services/runtime';
 import { loadDesktopSecrets } from '@/services/runtime-config';
 import { initAnalytics, trackApiKeysSnapshot } from '@/services/analytics';
 import { applyStoredTheme } from '@/utils/theme-manager';
@@ -163,6 +163,8 @@ initMetaTags();
 
 // In desktop mode, route /api/* calls to the local Tauri sidecar backend.
 installRuntimeFetchPatch();
+// In web production, route RPC calls through api.worldmonitor.app (Cloudflare edge).
+installWebApiRedirect();
 loadDesktopSecrets().then(async () => {
   await initAnalytics();
   trackApiKeysSnapshot();


### PR DESCRIPTION
## Summary
- **Web fetch interceptor** (`installWebApiRedirect`) routes RPC traffic through `api.worldmonitor.app` on production web, enabling CF edge caching
- **Cache-Control headers** added to GET 200 responses (`s-maxage=300, stale-while-revalidate=60`), with `no-store` override for real-time endpoints (vessel snapshot)
- **CORS updated** to allow `GET, POST, OPTIONS` methods (needed for POST→GET migration in #468)
- **Bot middleware** skips `api.worldmonitor.app` by hostname check (non-spoofable, CF handles bot protection)
- **Desktop cloud fallback** routes through `api.worldmonitor.app` for edge caching benefit

### Files changed
| File | Change |
|------|--------|
| `src/services/runtime.ts` | New `installWebApiRedirect()`, `DEFAULT_REMOTE_HOSTS` → api subdomain, `APP_HOSTS` updated |
| `src/main.ts` | Call `installWebApiRedirect()` after desktop fetch patch |
| `api/[domain]/v1/[rpc].ts` | Default `Cache-Control` on GET 200, `no-store` for real-time endpoints |
| `server/cors.ts` | GET added to allowed methods |
| `middleware.ts` | Skip bot check for API subdomain by hostname |

### Depends on
- #468 (POST→GET endpoint conversion)

## Test plan
- [x] `tsc --noEmit` passes
- [x] Vite production build passes
- [ ] Web: RPC requests on `worldmonitor.app` route to `api.worldmonitor.app`
- [ ] Web: Preview deploys keep relative `/api/` paths
- [ ] Desktop: Cloud fallback uses `api.worldmonitor.app`
- [ ] `curl -v` GET endpoint returns `Cache-Control: public, s-maxage=300`
- [ ] `curl -v` vessel snapshot returns `Cache-Control: no-store`
- [ ] POST endpoints have no `Cache-Control` header
- [ ] CORS preflight returns `GET, POST, OPTIONS`