### PR TITLE
fix(security-advisories): route feeds through RSS proxy, fix ECDC URL, add News24 domain

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -166,6 +166,7 @@ const ALLOWED_DOMAINS = [
   'kyivindependent.com',
   'www.themoscowtimes.com',
   'feeds.24.com',
+  'feeds.news24.com',  // News24 main feed domain
   'feeds.capi24.com',  // News24 redirect destination
   // International News Sources
   'www.france24.com',

--- a/src/services/security-advisories.ts
+++ b/src/services/security-advisories.ts
@@ -1,6 +1,12 @@
+import { isDesktopRuntime } from '@/services/runtime';
 import { proxyUrl } from '@/utils';
 import { getPersistentCache, setPersistentCache } from './persistent-cache';
 import { dataFreshness } from './data-freshness';
+
+function advisoryFeedUrl(feedUrl: string): string {
+  if (isDesktopRuntime()) return proxyUrl(feedUrl);
+  return `/api/rss-proxy?url=${encodeURIComponent(feedUrl)}`;
+}
 
 export interface SecurityAdvisory {
   title: string;
@@ -108,7 +114,7 @@ const ADVISORY_FEEDS: AdvisoryFeed[] = [
   { name: 'ECDC Epidemiological Updates', sourceCountry: 'EU', url: 'https://www.ecdc.europa.eu/en/taxonomy/term/1310/feed' },
   { name: 'ECDC Threats Report', sourceCountry: 'EU', url: 'https://www.ecdc.europa.eu/en/taxonomy/term/1505/feed' },
   { name: 'ECDC Risk Assessments', sourceCountry: 'EU', url: 'https://www.ecdc.europa.eu/en/taxonomy/term/1295/feed' },
-  { name: 'ECDC Avian Influenza', sourceCountry: 'EU', url: 'https://www.ecdc.europa.eu/en/taxonomy/term/323//feed' },
+  { name: 'ECDC Avian Influenza', sourceCountry: 'EU', url: 'https://www.ecdc.europa.eu/en/taxonomy/term/323/feed' },
   { name: 'ECDC Publications', sourceCountry: 'EU', url: 'https://www.ecdc.europa.eu/en/taxonomy/term/1244/feed' },
   { name: 'WHO News', sourceCountry: 'INT', url: 'https://www.who.int/rss-feeds/news-english.xml' },
   { name: 'WHO Africa Emergencies', sourceCountry: 'INT', url: 'https://www.afro.who.int/rss/emergencies.xml' },
@@ -185,7 +191,7 @@ export async function fetchSecurityAdvisories(
   const feedResults = await Promise.allSettled(
     ADVISORY_FEEDS.map(async (feed) => {
       try {
-        const response = await fetch(proxyUrl(feed.url), {
+        const response = await fetch(advisoryFeedUrl(feed.url), {
           headers: { Accept: 'application/rss+xml, application/xml, text/xml, */*' },
           ...(signal ? { signal } : {}),
         });


### PR DESCRIPTION
## Summary
- **Security Advisories panel was completely broken on web** — all 21 feeds (US State Dept, AU Smartraveller, NZ MFAT, UK FCDO, 13 US Embassies, CDC, 5 ECDC, 2 WHO) were fetched directly from the browser instead of through `/api/rss-proxy`, hitting CORS blocks on every single one
- Fix double slash in ECDC Avian Influenza feed URL (`323//feed` → `323/feed`)
- Add `feeds.news24.com` to RSS proxy allowlist (was returning 403 — domain missing from ALLOWED_DOMAINS)

## Root cause
`security-advisories.ts` used `proxyUrl(feed.url)` which returns the raw URL for web deployments. Regular RSS feeds use `/api/rss-proxy?url=...` pattern. Advisory feeds need the same treatment.

## Changes
- `src/services/security-advisories.ts`: New `advisoryFeedUrl()` helper that routes through `/api/rss-proxy` on web, keeps `proxyUrl()` for desktop (Tauri sidecar handles CORS natively)
- `api/rss-proxy.js`: Add `feeds.news24.com` to ALLOWED_DOMAINS

## Test plan
- [ ] Verify Security Advisories panel loads data on worldmonitor.app (was empty before)
- [ ] Verify no CORS errors in browser console for advisory feeds
- [ ] Verify News24 feed loads without 403
- [ ] Verify desktop app still works (uses proxyUrl path)