### PR TITLE
fix(sentry): add noise filters for 4 unresolved issues

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -77,7 +77,7 @@ Sentry.init({
     /setting 'luma'/,
     /ML request .* timed out/,
     /^Element not found$/,
-    /^The operation was aborted\.?\s*$/,
+    /(?:AbortError: )?The operation was aborted\.?\s*$/,
     /Unexpected end of script/,
     /error loading dynamically imported module/,
     /Style is not done loading/,
@@ -111,6 +111,9 @@ Sentry.init({
     /isReCreate is not defined/,
     /reading 'style'.*HTMLImageElement/,
     /can't access property "write", \w+ is undefined/,
+    /AbortError: The user aborted a request/,
+    /\w+ is not a function.*\/uv\/service\//,
+    /__isInQueue__/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary

Add Sentry `ignoreErrors` filters for 4 noise issues (all resolved via API with `inNextRelease: true`):

- **WORLDMONITOR-5R**: UltraViewer service worker injection (`/uv/service/`)
- **WORLDMONITOR-5Q**: Tighten existing AbortError filter to match `AbortError: The operation was aborted`
- **WORLDMONITOR-5P**: `AbortError: The user aborted a request` (normal navigation cancellation)
- **WORLDMONITOR-2S**: Huawei WebView `__isInQueue__` injection (Chrome Mobile WebView on ALN-AL00)

## Test plan

- [ ] Verify `npx tsc --noEmit` passes
- [ ] No existing ignoreErrors patterns broken