### PR TITLE
fix(analytics): use greedy regex in PostHog ingest rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git cat-file -e $VERCEL_GIT_PREVIOUS_SHA 2>/dev/null || exit 1; git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- ':!*.md' ':!.planning' ':!docs/' ':!e2e/' ':!scripts/' ':!.github/'",
   "rewrites": [
-    { "source": "/ingest/static/:path*", "destination": "https://us-assets.i.posthog.com/static/:path*" },
-    { "source": "/ingest/:path*", "destination": "https://us.i.posthog.com/:path*" }
+    { "source": "/ingest/static/:path(.*)", "destination": "https://us-assets.i.posthog.com/static/:path" },
+    { "source": "/ingest/:path(.*)", "destination": "https://us.i.posthog.com/:path" }
   ],
   "headers": [
     {


### PR DESCRIPTION
## Summary
- Fix PostHog `/ingest/*` 404 errors by switching Vercel rewrite patterns from `:path*` to `:path(.*)`
- Vercel's `:path*` wildcard silently fails on trailing slashes that PostHog SDK appends (e.g. `/ingest/s/?compression=...`)
- Known Vercel issue: PostHog/posthog#17596

## Test plan
- [ ] Deploy to preview, confirm PostHog events reach `us.i.posthog.com` (no 404s in browser console)
- [ ] Verify `/ingest/static/*` assets still load (PostHog JS bundle)
- [ ] Check PostHog dashboard for incoming events after deploy