### PR TITLE
perf(proxy): increase AIS snapshot edge TTL from 2s to 10s

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2078,7 +2078,7 @@ const server = http.createServer(async (req, res) => {
       sendPreGzipped(req, res, 200, {
         'Content-Type': 'application/json',
         'Cache-Control': 'public, max-age=2',
-        'CDN-Cache-Control': 'public, max-age=2',
+        'CDN-Cache-Control': 'public, max-age=10',
       }, json, gz);
     } else {
       // Cold start fallback
@@ -2086,7 +2086,7 @@ const server = http.createServer(async (req, res) => {
       sendCompressed(req, res, 200, {
         'Content-Type': 'application/json',
         'Cache-Control': 'public, max-age=2',
-        'CDN-Cache-Control': 'public, max-age=2',
+        'CDN-Cache-Control': 'public, max-age=10',
       }, JSON.stringify(payload));
     }
   } else if (pathname === '/opensky-reset') {


### PR DESCRIPTION
## Summary

- Increase `CDN-Cache-Control` for `/ais/snapshot` from `max-age=2` to `max-age=10` (browser TTL unchanged at 2s)

## Why

`/ais/snapshot` is 60% of proxy traffic (20k requests/30min). With per-PoP Cloudflare caching, a 2s edge TTL expires before the next request from the same PoP arrives — resulting in near-zero cache hits (34 HITs out of 33.5k total requests).

10s allows same-PoP dedup while keeping browser-side data fresh at 2s.

## Test plan

- [ ] Deploy and monitor Cloudflare cache status for `/ais/snapshot`
- [ ] Verify `cf-cache-status: HIT` rate increases for AIS requests
- [ ] Confirm vessel position freshness is acceptable with 10s edge staleness