### PR TITLE
fix(markets): commodities panel showing stocks instead of commodities

### DIFF
--- a/src/utils/circuit-breaker.ts
+++ b/src/utils/circuit-breaker.ts
@@ -215,7 +215,10 @@ export class CircuitBreaker<T> {
     // within the 24h persistent ceiling), return it instantly and refresh in
     // the background. This prevents "Loading..." on every page reload when
     // the persistent cache is older than the TTL.
-    if (this.cache !== null) {
+    // Skip SWR when cacheTtlMs === 0 (caching disabled) — the breaker may be
+    // shared across calls with different request params (e.g. stocks vs commodities),
+    // so returning stale data from a different call is wrong.
+    if (this.cache !== null && this.cacheTtlMs > 0) {
       this.lastDataState = { mode: 'cached', timestamp: this.cache.timestamp, offline };
       // Fire-and-forget background refresh
       fn().then(result => this.recordSuccess(result)).catch(e => {


### PR DESCRIPTION
## Summary

- **Bug**: Commodities panel always displayed stock data (AAPL, MSFT, NVDA…) instead of actual commodities (Gold, Oil, NatGas, Silver, Copper, VIX)
- **Root cause**: Single shared `stockBreaker` circuit breaker (`cacheTtlMs: 0`) used by both `fetchMultipleStocks(MARKET_SYMBOLS)` and `fetchMultipleStocks(COMMODITIES)`. After stocks call succeeds, `breaker.cache` holds stocks data. The stale-while-revalidate (SWR) path checked `this.cache !== null` — true from the stocks call — and returned cached stocks data for the commodities request, firing the real commodities fetch in the background (which nobody sees).
- **Fix**: Skip SWR when `cacheTtlMs === 0`. When caching is explicitly disabled, stale data from a different call should never be served.

## Test plan

- [ ] Verify Commodities panel shows VIX, GOLD, OIL, NATGAS, SILVER, COPPER (not stocks)
- [ ] Verify Markets panel still shows AAPL, MSFT, NVDA etc. correctly
- [ ] Verify Sector Heatmap still renders
- [ ] Check desktop app (Tauri) commodities panel