### PR TITLE
feat(gateway): complete edge cache tier coverage + degraded-response policy

### DIFF
--- a/server/_shared/response-headers.ts
+++ b/server/_shared/response-headers.ts
@@ -1,0 +1,28 @@
+/**
+ * Side-channel for handlers to attach response headers without modifying codegen.
+ *
+ * Handlers set headers via setResponseHeader(ctx.request, key, value).
+ * The gateway reads and applies them after the handler returns.
+ * WeakMap ensures automatic cleanup when the Request is GC'd.
+ */
+
+const channel = new WeakMap<Request, Record<string, string>>();
+
+export function setResponseHeader(req: Request, key: string, value: string): void {
+  let headers = channel.get(req);
+  if (!headers) {
+    headers = {};
+    channel.set(req, headers);
+  }
+  headers[key] = value;
+}
+
+export function markNoCacheResponse(req: Request): void {
+  setResponseHeader(req, 'X-No-Cache', '1');
+}
+
+export function drainResponseHeaders(req: Request): Record<string, string> | undefined {
+  const headers = channel.get(req);
+  if (headers) channel.delete(req);
+  return headers;
+}

--- a/server/worldmonitor/positive-events/v1/list-positive-geo-events.ts
+++ b/server/worldmonitor/positive-events/v1/list-positive-geo-events.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/positive_events/v1/service_server';
 
 import { classifyNewsItem } from '../../../../src/services/positive-classifier';
+import { markNoCacheResponse } from '../../../_shared/response-headers';
 
 const GDELT_GEO_URL = 'https://api.gdeltproject.org/api/v2/geo/geo';
 
@@ -81,21 +82,22 @@ async function fetchGdeltGeoPositive(query: string): Promise<PositiveGeoEvent[]>
 }
 
 export async function listPositiveGeoEvents(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   _req: ListPositiveGeoEventsRequest,
 ): Promise<ListPositiveGeoEventsResponse> {
   try {
     const allEvents: PositiveGeoEvent[] = [];
     const seenNames = new Set<string>();
+    let anyQuerySucceeded = false;
 
     for (let i = 0; i < POSITIVE_QUERIES.length; i++) {
       if (i > 0) {
-        // Rate-limit delay between queries
         await new Promise(r => setTimeout(r, 500));
       }
 
       try {
         const events = await fetchGdeltGeoPositive(POSITIVE_QUERIES[i]);
+        anyQuerySucceeded = true;
         for (const event of events) {
           if (!seenNames.has(event.name)) {
             seenNames.add(event.name);
@@ -107,8 +109,10 @@ export async function listPositiveGeoEvents(
       }
     }
 
+    if (!anyQuerySucceeded) markNoCacheResponse(ctx.request);
     return { events: allEvents };
   } catch {
+    markNoCacheResponse(ctx.request);
     return { events: [] };
   }
 }

--- a/src/services/positive-events-geo.ts
+++ b/src/services/positive-events-geo.ts
@@ -19,7 +19,7 @@ export interface PositiveGeoEvent {
 }
 
 const client = new PositiveEventsServiceClient('', {
-  fetch: fetch.bind(globalThis),
+  fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args),
 });
 
 const breaker = createCircuitBreaker<PositiveGeoEvent[]>({

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -373,10 +373,24 @@ export function installRuntimeFetchPatch(): void {
 }
 
 const WEB_RPC_PATTERN = /^\/api\/[^/]+\/v1\//;
+const ALLOWED_REDIRECT_HOSTS = /^https:\/\/([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*worldmonitor\.app(:\d+)?$/;
+
+function isAllowedRedirectTarget(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return ALLOWED_REDIRECT_HOSTS.test(parsed.origin) || parsed.hostname === 'localhost';
+  } catch {
+    return false;
+  }
+}
 
 export function installWebApiRedirect(): void {
   if (isDesktopRuntime() || typeof window === 'undefined') return;
   if (!WS_API_URL) return;
+  if (!isAllowedRedirectTarget(WS_API_URL)) {
+    console.warn('[runtime] VITE_WS_API_URL blocked — not in hostname allowlist:', WS_API_URL);
+    return;
+  }
   if ((window as unknown as Record<string, unknown>).__wmWebRedirectPatched) return;
 
   const nativeFetch = window.fetch.bind(window);

--- a/tests/route-cache-tier.test.mjs
+++ b/tests/route-cache-tier.test.mjs
@@ -1,0 +1,81 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+function extractGetRoutes() {
+  const generatedDir = join(root, 'src', 'generated', 'server', 'worldmonitor');
+  const routes = [];
+
+  function walk(dir) {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        walk(full);
+      } else if (entry === 'service_server.ts') {
+        const src = readFileSync(full, 'utf-8');
+        const re = /method:\s*"GET",[\s\S]*?path:\s*"([^"]+)"/g;
+        let m;
+        while ((m = re.exec(src)) !== null) {
+          routes.push(m[1]);
+        }
+      }
+    }
+  }
+
+  walk(generatedDir);
+  return routes.sort();
+}
+
+function extractCacheTierKeys() {
+  const gatewayPath = join(root, 'api', '[domain]', 'v1', '[rpc].ts');
+  const src = readFileSync(gatewayPath, 'utf-8');
+  const re = /'\/(api\/[^']+)':\s*'(fast|medium|slow|static|no-store)'/g;
+  const entries = {};
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    entries['/' + m[1]] = m[2];
+  }
+  return entries;
+}
+
+describe('RPC_CACHE_TIER route parity', () => {
+  const getRoutes = extractGetRoutes();
+  const tierMap = extractCacheTierKeys();
+  const tierKeys = Object.keys(tierMap);
+
+  it('finds at least 50 GET routes in generated server files', () => {
+    assert.ok(getRoutes.length >= 50, `Expected ≥50 GET routes, found ${getRoutes.length}`);
+  });
+
+  it('every generated GET route has an explicit cache tier entry', () => {
+    const missing = getRoutes.filter((r) => !(r in tierMap));
+    assert.deepStrictEqual(
+      missing,
+      [],
+      `Missing RPC_CACHE_TIER entries for:\n  ${missing.join('\n  ')}\n\nAdd explicit tier entries in api/[domain]/v1/[rpc].ts`,
+    );
+  });
+
+  it('every cache tier key maps to a real generated route', () => {
+    const stale = tierKeys.filter((k) => !getRoutes.includes(k));
+    assert.deepStrictEqual(
+      stale,
+      [],
+      `Stale RPC_CACHE_TIER entries (no matching generated route):\n  ${stale.join('\n  ')}`,
+    );
+  });
+
+  it('no route uses the implicit default tier', () => {
+    const gatewaySrc = readFileSync(join(root, 'api', '[domain]', 'v1', '[rpc].ts'), 'utf-8');
+    assert.match(
+      gatewaySrc,
+      /RPC_CACHE_TIER\[pathname\]\s*\?\?\s*'medium'/,
+      'Gateway still has medium default fallback — ensure all routes are explicit',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add 11 missing GET routes to `RPC_CACHE_TIER` map (8 slow, 3 medium) — eliminates silent default-tier fallback for all endpoints
- Add response-headers side-channel (`WeakMap<Request>`) so handlers can signal `X-No-Cache` without codegen changes; wire into `list-military-flights` and `list-positive-geo-events` to prevent caching empty 200s on upstream failure
- Add env-controlled per-endpoint tier override (`CACHE_TIER_OVERRIDE_*`) for incident response rollback
- Add `VITE_WS_API_URL` hostname allowlist (`*.worldmonitor.app` + `localhost`) — fail-closed validation before patching fetch
- Fix `fetch.bind(globalThis)` → deferred lambda in `positive-events-geo.ts` (last remaining pre-patch capture)
- Add CI test asserting every generated GET route has an explicit cache tier entry

## Context
Follows up on Codex review findings from the Vercel Cost Optimization initiative (PRs #466–#481). Addresses P1 items 1–3 and P2 item 6 from the review.

## Test plan
- [x] `node --test tests/route-cache-tier.test.mjs` — 4/4 pass (parity, staleness, threshold, default-tier assertion)
- [x] `tsc --noEmit` — clean
- [x] Existing tests (`server-handlers`, `deploy-config`) — 24/24 pass, no regressions
- [ ] Verify `x-vercel-cache: HIT` ratio improves for the 11 newly-tiered routes after deploy
- [ ] Test `CACHE_TIER_OVERRIDE_LIST_MILITARY_FLIGHTS=no-store` env var override in preview deploy