### PR TITLE
feat: add Polish tv livestreams

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -94,6 +94,8 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'ntv-turkey', name: 'NTV', handle: '@NTV' },
   { id: 'cnn-turk', name: 'CNN TURK', handle: '@cnnturk' },
   { id: 'tv-rain', name: 'TV Rain', handle: '@tvrain' },
+  { id: 'tvp-info', name: 'TVP Info', handle: '@tvpinfo' },
+  { id: 'telewizja-republika', name: 'Telewizja Republika', handle: '@Telewizja_Republika' },
   // Latin America & Portuguese
   { id: 'cnn-brasil', name: 'CNN Brasil', handle: '@CNNbrasil', fallbackVideoId: '1kWRw-DA6Ns' },
   { id: 'jovem-pan', name: 'Jovem Pan News', handle: '@jovempannews' },
@@ -130,7 +132,7 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
 
 export const OPTIONAL_CHANNEL_REGIONS: { key: string; labelKey: string; channelIds: string[] }[] = [
   { key: 'na', labelKey: 'components.liveNews.regionNorthAmerica', channelIds: ['livenow-fox', 'fox-news', 'newsmax', 'abc-news', 'cbs-news', 'nbc-news'] },
-  { key: 'eu', labelKey: 'components.liveNews.regionEurope', channelIds: ['bbc-news', 'france24-en', 'welt', 'rtve', 'trt-haber', 'ntv-turkey', 'cnn-turk', 'tv-rain'] },
+  { key: 'eu', labelKey: 'components.liveNews.regionEurope', channelIds: ['bbc-news', 'france24-en', 'welt', 'rtve', 'trt-haber', 'ntv-turkey', 'cnn-turk', 'tv-rain', 'tvp-info', 'telewizja-republika'] },
   { key: 'latam', labelKey: 'components.liveNews.regionLatinAmerica', channelIds: ['cnn-brasil', 'jovem-pan', 'record-news', 'band-jornalismo', 'tn-argentina', 'c5n', 'milenio', 'noticias-caracol', 'ntn24', 't13'] },
   { key: 'asia', labelKey: 'components.liveNews.regionAsia', channelIds: ['tbs-news', 'ann-news', 'ntv-news', 'cti-news', 'wion', 'vtc-now', 'cna-asia', 'nhk-world'] },
   { key: 'me', labelKey: 'components.liveNews.regionMiddleEast', channelIds: ['al-hadath', 'sky-news-arabia', 'trt-world', 'iran-intl', 'cgtn-arabic'] },


### PR DESCRIPTION
## Summary
- Added two Polish news channels to the live news panel:
  - **TVP Info** (`@tvpinfo`) — Poland's public broadcaster news channel
  - **Telewizja Republika** (`@Telewizja_Republika`) — Polish conservative news channel
- Both channels are included in the Europe (`eu`) region filter

## Changes
- `src/components/LiveNewsPanel.ts` — Added channel entries to `OPTIONAL_LIVE_CHANNELS` and their IDs to the Europe region in `OPTIONAL_CHANNEL_REGIONS`

## Test plan
- [ ] Open the Live News panel and select the Europe region filter
- [ ] Verify TVP Info and Telewizja Republika appear in the channel list
- [ ] Confirm both streams load correctly via their YouTube handles
