### PR TITLE
feat(rss): add Axios as US news source

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -124,6 +124,7 @@ const ALLOWED_DOMAINS = [
   // Additional tech variant domains
   'www.producthunt.com',
   'www.axios.com',
+  'api.axios.com',
   'github.blog',
   'githubnext.com',
   'mshibanami.github.io',

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -32,6 +32,7 @@ export const SOURCE_TIERS: Record<string, number> = {
   'Al Jazeera': 2,
   'Financial Times': 2,
   'Politico': 2,
+  'Axios': 2,
   'EuroNews': 2,
   'France 24': 2,
   'Le Monde': 2,
@@ -320,7 +321,7 @@ export const SOURCE_TYPES: Record<string, SourceType> = {
   'BBC World': 'mainstream', 'BBC Middle East': 'mainstream',
   'Guardian World': 'mainstream', 'Guardian ME': 'mainstream',
   'NPR News': 'mainstream', 'Al Jazeera': 'mainstream',
-  'CNN World': 'mainstream', 'Politico': 'mainstream',
+  'CNN World': 'mainstream', 'Politico': 'mainstream', 'Axios': 'mainstream',
   'EuroNews': 'mainstream', 'France 24': 'mainstream', 'Le Monde': 'mainstream',
   // European Addition
   'El País': 'mainstream', 'El Mundo': 'mainstream', 'BBC Mundo': 'mainstream',
@@ -443,6 +444,7 @@ const FULL_FEEDS: Record<string, Feed[]> = {
   us: [
     { name: 'NPR News', url: rss('https://feeds.npr.org/1001/rss.xml') },
     { name: 'Politico', url: rss('https://news.google.com/rss/search?q=site:politico.com+when:1d&hl=en-US&gl=US&ceid=US:en') },
+    { name: 'Axios', url: rss('https://api.axios.com/feed/') },
   ],
   europe: [
     {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -506,7 +506,7 @@ const RSS_PROXY_ALLOWED_DOMAINS = new Set([
   'rss.politico.com', 'www.anandtech.com', 'www.tomshardware.com', 'www.semianalysis.com',
   'feed.infoq.com', 'thenewstack.io', 'devops.com', 'dev.to', 'lobste.rs', 'changelog.com',
   'seekingalpha.com', 'news.crunchbase.com', 'www.saastr.com', 'feeds.feedburner.com',
-  'www.producthunt.com', 'www.axios.com', 'github.blog', 'githubnext.com',
+  'www.producthunt.com', 'www.axios.com', 'api.axios.com', 'github.blog', 'githubnext.com',
   'mshibanami.github.io', 'www.engadget.com', 'news.mit.edu', 'dev.events',
   'www.ycombinator.com', 'a16z.com', 'review.firstround.com', 'www.sequoiacap.com',
   'www.nfx.com', 'www.aaronsw.com', 'bothsidesofthetable.com', 'www.lennysnewsletter.com',


### PR DESCRIPTION
## Summary
- Add `api.axios.com` to RSS proxy allowlist and CSP connect-src
- Register `https://api.axios.com/feed/` under US news feeds (Tier 2, mainstream)

## Type of change
- [x] New data source / feed

## Affected areas
- [x] News panels / RSS feeds
- [x] Config / Settings

## Checklist
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)