### PR TITLE
perf(military): debounce base fetches + static edge cache

### DIFF
--- a/api/[domain]/v1/[rpc].ts
+++ b/api/[domain]/v1/[rpc].ts
@@ -128,7 +128,7 @@ const RPC_CACHE_TIER: Record<string, CacheTier> = {
   '/api/infrastructure/v1/get-cable-health': 'slow',
   '/api/positive-events/v1/list-positive-geo-events': 'slow',
 
-  '/api/military/v1/list-military-bases': 'medium',
+  '/api/military/v1/list-military-bases': 'static',
   '/api/economic/v1/get-macro-signals': 'medium',
   '/api/prediction/v1/list-prediction-markets': 'medium',
   '/api/supply-chain/v1/get-chokepoint-status': 'medium',

--- a/src/services/military-bases.ts
+++ b/src/services/military-bases.ts
@@ -90,7 +90,8 @@ export async function fetchMilitaryBases(
       };
       lastResult = result;
       return result;
-    } catch {
+    } catch (err) {
+      console.error('[bases-svc] error', err);
       return lastResult;
     } finally {
       pendingFetch = null;


### PR DESCRIPTION
## Summary
- Add 300ms debounce on `moveend` to prevent rapid pans flooding the server with redundant RPC calls
- Fix stale-bbox bug: when `pendingFetch` is in-flight and user pans to new viewport, debounce ensures only the final position triggers a fetch
- Upgrade edge cache tier from `medium` (5min s-maxage) to `static` (1hr s-maxage) — military bases are static infrastructure that only changes on manual reseed, now aligned with server-side `cachedFetchJson` TTL (1hr)

## Test plan
- [ ] Pan map rapidly — verify single network request after 300ms settle (no burst of requests)
- [ ] Check response headers: `Cache-Control: public, s-maxage=3600, stale-while-revalidate=300, stale-if-error=7200`
- [ ] Verify bases still load on initial map render (direct fetch on `load` event, not debounced)