### PR TITLE
fix(cyber): make GeoIP centroid fallback jitter deterministic

### DIFF
--- a/server/worldmonitor/cyber/v1/_shared.ts
+++ b/server/worldmonitor/cyber/v1/_shared.ts
@@ -193,12 +193,20 @@ const COUNTRY_CENTROIDS: Record<string, [number, number]> = {
   SN:[14.5,-14.5],CM:[7.4,12.4],CI:[7.5,-5.5],TZ:[-6.4,34.9],UG:[1.4,32.3],
 };
 
-function getCountryCentroid(countryCode: string): { lat: number; lon: number } | null {
+function djb2(seed: string): number {
+  let h = 5381;
+  for (let i = 0; i < seed.length; i++) h = ((h << 5) + h + seed.charCodeAt(i)) & 0xffffffff;
+  return h;
+}
+
+function getCountryCentroid(countryCode: string, seed?: string): { lat: number; lon: number } | null {
   if (!countryCode) return null;
   const coords = COUNTRY_CENTROIDS[countryCode.toUpperCase()];
   if (!coords) return null;
-  const jitter = () => (Math.random() - 0.5) * 2;
-  return { lat: coords[0] + jitter(), lon: coords[1] + jitter() };
+  const key = seed || countryCode;
+  const latOffset = (((djb2(key) & 0xffff) / 0xffff) - 0.5) * 2;
+  const lonOffset = (((djb2(key + ':lon') & 0xffff) / 0xffff) - 0.5) * 2;
+  return { lat: coords[0] + latOffset, lon: coords[1] + lonOffset };
 }
 
 // ========================================================================
@@ -370,7 +378,7 @@ export async function hydrateThreatCoordinates(threats: RawThreat[]): Promise<Ra
       return { ...threat, lat: lookup.lat, lon: lookup.lon, country: threat.country || lookup.country };
     }
 
-    const centroid = getCountryCentroid(threat.country);
+    const centroid = getCountryCentroid(threat.country, threat.indicator);
     if (centroid) {
       return { ...threat, lat: centroid.lat, lon: centroid.lon };
     }


### PR DESCRIPTION
## Summary
- Replaces `Math.random()` jitter in `getCountryCentroid()` with a DJB2 hash seeded by the threat's indicator (IP/URL)
- Same threat → same coordinates across requests (no more jumping markers)
- Different threats from the same country → still spread out (no stacking)
- Fixes the design flaw in #458 where jitter was seeded only on country code, collapsing all same-country threats to one point

Closes #203

## What changed
Single file: `server/worldmonitor/cyber/v1/_shared.ts` (+12 −4)

1. Added `djb2()` hash function for deterministic seeding
2. `getCountryCentroid()` now accepts an optional `seed` param (the threat indicator)
3. Call site passes `threat.indicator` as seed

## Credit
Based on the idea from PR #458 by @fuleinist. That PR was a fork dump (225k+ additions) so this is a clean rewrite with the design flaw fixed.

## Test plan
- [ ] Verify cyber threat markers no longer jump positions on page refresh
- [ ] Verify multiple threats from the same country still fan out around the centroid
- [ ] `tsc --noEmit` passes