### PR TITLE
fix(bootstrap): harden hydration cache + polling review fixes

### DIFF
--- a/src/app/refresh-scheduler.ts
+++ b/src/app/refresh-scheduler.ts
@@ -44,6 +44,7 @@ export class RefreshScheduler implements AppModule {
     const HIDDEN_REFRESH_MULTIPLIER = 10;
     const JITTER_FRACTION = 0.1;
     const MIN_REFRESH_MS = 1000;
+    // Max effective interval: intervalMs * 4 (backoff) * 10 (hidden) = 40x base
     const MAX_BACKOFF_MULTIPLIER = 4;
 
     let currentMultiplier = 1;

--- a/src/components/IntelligenceGapBadge.ts
+++ b/src/components/IntelligenceGapBadge.ts
@@ -37,7 +37,14 @@ export class IntelligenceFindingsBadge {
   private onAlertClick: ((alert: UnifiedAlert) => void) | null = null;
   private findings: UnifiedFinding[] = [];
   private boundCloseDropdown = () => this.closeDropdown();
-  private boundUpdate = () => this.update();
+  private pendingUpdateFrame = 0;
+  private boundUpdate = () => {
+    if (this.pendingUpdateFrame) return;
+    this.pendingUpdateFrame = requestAnimationFrame(() => {
+      this.pendingUpdateFrame = 0;
+      this.update();
+    });
+  };
   private audio: HTMLAudioElement | null = null;
   private audioEnabled = true;
   private enabled: boolean;
@@ -518,6 +525,9 @@ export class IntelligenceFindingsBadge {
   public destroy(): void {
     if (this.refreshInterval) {
       clearInterval(this.refreshInterval);
+    }
+    if (this.pendingUpdateFrame) {
+      cancelAnimationFrame(this.pendingUpdateFrame);
     }
     document.removeEventListener('wm:intelligence-updated', this.boundUpdate);
     document.removeEventListener('click', this.boundCloseDropdown);

--- a/src/components/ServiceStatusPanel.ts
+++ b/src/components/ServiceStatusPanel.ts
@@ -53,9 +53,9 @@ export class ServiceStatusPanel extends Panel {
       const data = await fetchServiceStatuses();
       if (!data.success) throw new Error('Failed to load status');
 
-      const json = JSON.stringify(data.services);
-      const changed = json !== this.lastServicesJson;
-      this.lastServicesJson = json;
+      const fingerprint = data.services.map(s => `${s.name}:${s.status}`).join(',');
+      const changed = fingerprint !== this.lastServicesJson;
+      this.lastServicesJson = fingerprint;
       this.services = data.services;
       this.error = null;
       return changed;

--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -89,7 +89,8 @@ export class StrategicRiskPanel extends Panel {
 
     this.render();
 
-    const fp = `${this.overview?.compositeScore}|${this.overview?.trend}|${this.alerts.length}`;
+    const alertIds = this.alerts.map(a => a.id).sort().join(',');
+    const fp = `${this.overview?.compositeScore}|${this.overview?.trend}|${alertIds}`;
     const changed = fp !== this.lastRiskFingerprint;
     this.lastRiskFingerprint = fp;
     return changed;

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -14,7 +14,9 @@ export async function fetchBootstrapData(): Promise<void> {
     if (!resp.ok) return;
     const { data } = (await resp.json()) as { data: Record<string, unknown> };
     for (const [k, v] of Object.entries(data)) {
-      hydrationCache.set(k, v);
+      if (v !== null && v !== undefined) {
+        hydrationCache.set(k, v);
+      }
     }
   } catch {
     // silent — panels fall through to individual calls


### PR DESCRIPTION
## Summary

Follow-up fixes from code review of #495 (`perf: bootstrap endpoint + polling optimization`):

- **P1: Null hydration leak** — `fetchBootstrapData()` now filters `null`/`undefined` values before storing in hydration cache. Consumers use truthiness checks which caught this, but `!== undefined` checks would misinterpret null as valid data.
- **P2: Event handler debounce** — `IntelligenceGapBadge` now coalesces rapid `wm:intelligence-updated` events via `requestAnimationFrame` instead of running full render pipeline per event.
- **P2: Lossy risk fingerprint** — `StrategicRiskPanel` now includes sorted alert IDs in its change fingerprint, detecting content changes even when alert count stays the same.
- **P2: Cheaper change detection** — `ServiceStatusPanel` uses `name:status` string instead of `JSON.stringify(services)` for backoff change detection.
- **P3: Max interval documentation** — Comment in `RefreshScheduler` documenting the 40x max effective interval (4x backoff × 10x hidden tab).

## Test plan

- [x] `tsc --noEmit` passes
- [x] `tsc --noEmit -p tsconfig.api.json` passes
- [x] `node --test tests/bootstrap.test.mjs` — 28/28 pass
- [x] `node --test tests/edge-functions.test.mjs` — 24/24 pass