### PR TITLE
fix: generalize Vercel preview origin regex + bases cache key

### DIFF
--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -7,7 +7,7 @@ const DESKTOP_ORIGIN_PATTERNS = [
 
 const BROWSER_ORIGIN_PATTERNS = [
   /^https:\/\/(.*\.)?worldmonitor\.app$/,
-  /^https:\/\/worldmonitor-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,
+  /^https:\/\/worldmonitor-[a-z0-9-]+\.vercel\.app$/,
   ...(process.env.NODE_ENV === 'production' ? [] : [
     /^https?:\/\/localhost(:\d+)?$/,
     /^https?:\/\/127\.0\.0\.1(:\d+)?$/,

--- a/src/services/military-bases.ts
+++ b/src/services/military-bases.ts
@@ -13,8 +13,7 @@ interface CachedResult {
   clusters: MilitaryBaseCluster[];
   totalInView: number;
   truncated: boolean;
-  bbox: string;
-  zoom: number;
+  cacheKey: string;
 }
 
 const quantize = (v: number, step: number) => Math.round(v / step) * step;
@@ -62,8 +61,9 @@ export async function fetchMilitaryBases(
 ): Promise<CachedResult | null> {
   const qBbox = quantizeBbox(swLat, swLon, neLat, neLon, zoom);
   const floorZoom = Math.floor(zoom);
+  const cacheKey = `${qBbox}:${floorZoom}:${filters?.type || ''}:${filters?.kind || ''}:${filters?.country || ''}`;
 
-  if (lastResult && lastResult.bbox === qBbox && lastResult.zoom === floorZoom) {
+  if (lastResult && lastResult.cacheKey === cacheKey) {
     return lastResult;
   }
 
@@ -85,8 +85,7 @@ export async function fetchMilitaryBases(
         clusters: resp.clusters,
         totalInView: resp.totalInView,
         truncated: resp.truncated,
-        bbox: qBbox,
-        zoom: floorZoom,
+        cacheKey,
       };
       lastResult = result;
       return result;


### PR DESCRIPTION
## Summary
- **`api/_api-key.js`**: Vercel preview URL pattern was user-specific (`-elie-`), rejecting other collaborators' preview deployments. Generalized to `worldmonitor-[a-z0-9-]+\.vercel\.app`.
- **`src/services/military-bases.ts`**: Client-side cache key only checked bbox/zoom, ignoring type/kind/country filters. Switching filters without panning returned stale results. Unified bbox, zoom, and filters into a single `cacheKey` string.

## Test plan
- [x] `tsc --noEmit` passes
- [x] 24/24 edge function tests pass
- [ ] Verify Vercel preview deployments from non-elie accounts can access API without key
- [ ] Verify map base filtering doesn't serve stale results when switching filter type