### PR TITLE
feat(breaking-news): active alert banner with audio for critical/high RSS items

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -15,7 +15,8 @@ import { startLearning } from '@/services/country-instability';
 import { dataFreshness } from '@/services/data-freshness';
 import { loadFromStorage, parseMapUrlState, saveToStorage, isMobileDevice } from '@/utils';
 import type { ParsedMapUrlState } from '@/utils';
-import { SignalModal, IntelligenceGapBadge } from '@/components';
+import { SignalModal, IntelligenceGapBadge, BreakingNewsBanner } from '@/components';
+import { initBreakingNewsAlerts, destroyBreakingNewsAlerts } from '@/services/breaking-news-alerts';
 import type { ServiceStatusPanel } from '@/components/ServiceStatusPanel';
 import type { StablecoinPanel } from '@/components/StablecoinPanel';
 import type { ETFFlowsPanel } from '@/components/ETFFlowsPanel';
@@ -227,6 +228,7 @@ export class App {
       statusPanel: null,
       searchModal: null,
       findingsBadge: null,
+      breakingBanner: null,
       playbackControl: null,
       exportPanel: null,
       unifiedSettings: null,
@@ -356,6 +358,11 @@ export class App {
       });
     }
 
+    if (!this.state.isMobile) {
+      initBreakingNewsAlerts();
+      this.state.breakingBanner = new BreakingNewsBanner();
+    }
+
     // Phase 3: UI setup methods
     this.eventHandlers.startHeaderClock();
     this.eventHandlers.setupMobileWarning();
@@ -420,8 +427,10 @@ export class App {
       this.modules[i]!.destroy();
     }
 
-    // Clean up subscriptions, map, and AIS
+    // Clean up subscriptions, map, AIS, and breaking news
     this.unsubAiFlow?.();
+    this.state.breakingBanner?.destroy();
+    destroyBreakingNewsAlerts();
     this.state.map?.destroy();
     disconnectAisStream();
   }

--- a/src/app/app-context.ts
+++ b/src/app/app-context.ts
@@ -21,6 +21,7 @@ import type { GoodThingsDigestPanel } from '@/components/GoodThingsDigestPanel';
 import type { SpeciesComebackPanel } from '@/components/SpeciesComebackPanel';
 import type { RenewableEnergyPanel } from '@/components/RenewableEnergyPanel';
 import type { TvModeController } from '@/services/tv-mode';
+import type { BreakingNewsBanner } from '@/components/BreakingNewsBanner';
 
 export interface CountryBriefSignals {
   protests: number;
@@ -78,6 +79,7 @@ export interface AppContext {
   statusPanel: StatusPanel | null;
   searchModal: SearchModal | null;
   findingsBadge: IntelligenceGapBadge | null;
+  breakingBanner: BreakingNewsBanner | null;
   playbackControl: PlaybackControl | null;
   exportPanel: ExportPanel | null;
   unifiedSettings: UnifiedSettings | null;

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -57,6 +57,7 @@ import {
   fetchChokepointStatus,
   fetchCriticalMinerals,
 } from '@/services';
+import { checkBatchForBreakingAlerts } from '@/services/breaking-news-alerts';
 import { mlWorker } from '@/services/ml-worker';
 import { clusterNewsHybrid } from '@/services/clustering';
 import { ingestProtests, ingestFlights, ingestVessels, ingestEarthquakes, detectGeoConvergence, geoConvergenceToSignal } from '@/services/geo-convergence';
@@ -480,6 +481,7 @@ export class DataLoaderManager implements AppModule {
         onBatch: (partialItems) => {
           scheduleRender(partialItems);
           this.flashMapForNews(partialItems);
+          checkBatchForBreakingAlerts(partialItems);
         },
       });
 
@@ -575,6 +577,7 @@ export class DataLoaderManager implements AppModule {
         const intelResult = await Promise.allSettled([fetchCategoryFeeds(enabledIntelSources)]);
         if (intelResult[0]?.status === 'fulfilled') {
           const intel = intelResult[0].value;
+          checkBatchForBreakingAlerts(intel);
           this.renderNewsForCategory('intel', intel);
           if (intelPanel) {
             try {

--- a/src/components/BreakingNewsBanner.ts
+++ b/src/components/BreakingNewsBanner.ts
@@ -1,0 +1,267 @@
+import type { BreakingAlert } from '@/services/breaking-news-alerts';
+import { getAlertSettings } from '@/services/breaking-news-alerts';
+import { t } from '@/services/i18n';
+
+const MAX_ALERTS = 3;
+const CRITICAL_DISMISS_MS = 60_000;
+const HIGH_DISMISS_MS = 30_000;
+const SOUND_COOLDOWN_MS = 5 * 60 * 1000;
+
+interface ActiveAlert {
+  alert: BreakingAlert;
+  element: HTMLElement;
+  timer: ReturnType<typeof setTimeout> | null;
+  remainingMs: number;
+  timerStartedAt: number;
+}
+
+export class BreakingNewsBanner {
+  private container: HTMLElement;
+  private activeAlerts: ActiveAlert[] = [];
+  private audio: HTMLAudioElement | null = null;
+  private lastSoundMs = 0;
+  private mutationObserver: MutationObserver | null = null;
+  private resizeObserver: ResizeObserver | null = null;
+  private observedPostureBanner: Element | null = null;
+  private boundOnAlert: (e: Event) => void;
+  private boundOnVisibility: () => void;
+  private boundOnResize: () => void;
+  private dismissed = new Map<string, number>();
+
+  constructor() {
+    this.container = document.createElement('div');
+    this.container.className = 'breaking-news-container';
+    document.body.appendChild(this.container);
+
+    this.initAudio();
+    this.updatePosition();
+    this.setupObservers();
+
+    this.boundOnAlert = (e: Event) => this.handleAlert((e as CustomEvent<BreakingAlert>).detail);
+    this.boundOnVisibility = () => this.handleVisibility();
+    this.boundOnResize = () => this.updatePosition();
+
+    document.addEventListener('wm:breaking-news', this.boundOnAlert);
+    document.addEventListener('visibilitychange', this.boundOnVisibility);
+    window.addEventListener('resize', this.boundOnResize);
+
+    this.container.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement;
+      const dismissBtn = target.closest('.breaking-alert-dismiss');
+      if (dismissBtn) {
+        const alertEl = dismissBtn.closest('.breaking-alert');
+        if (alertEl) {
+          const id = alertEl.getAttribute('data-alert-id');
+          if (id) this.dismissAlert(id);
+        }
+      }
+    });
+  }
+
+  private initAudio(): void {
+    this.audio = new Audio('data:audio/wav;base64,UklGRnoGAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQoGAACBhYqFbF1fdJivrJBhNjVgodDbq2EcBj+a2teleQYjfKapmWswEjCJvuPQfSoXZZ+3qqBJESSP0unGaxMJVYiytrFeLhR6p8znrFUXRW+bs7V3Qx1hn8Xjp1cYPnegprhkMCFmoLi1k0sZTYGlqqlUIA==');
+    this.audio.volume = 0.3;
+  }
+
+  private playSound(): void {
+    const settings = getAlertSettings();
+    if (!settings.soundEnabled || !this.audio) return;
+    if (Date.now() - this.lastSoundMs < SOUND_COOLDOWN_MS) return;
+    this.audio.currentTime = 0;
+    this.audio.play().catch(() => {});
+    this.lastSoundMs = Date.now();
+  }
+
+  private setupObservers(): void {
+    this.mutationObserver = new MutationObserver(() => this.updatePosition());
+    this.mutationObserver.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+  }
+
+  private attachResizeObserverIfNeeded(): void {
+    const postureBanner = document.querySelector('.critical-posture-banner');
+    if (!postureBanner) return;
+    if (postureBanner === this.observedPostureBanner) return;
+
+    if (this.resizeObserver) this.resizeObserver.disconnect();
+    this.resizeObserver = new ResizeObserver(() => this.updatePosition());
+    this.resizeObserver.observe(postureBanner);
+    this.observedPostureBanner = postureBanner;
+  }
+
+  private updatePosition(): void {
+    let top = 50;
+    if (document.body.classList.contains('has-critical-banner')) {
+      this.attachResizeObserverIfNeeded();
+      const postureBanner = document.querySelector('.critical-posture-banner');
+      if (postureBanner) {
+        top += postureBanner.getBoundingClientRect().height;
+      }
+    }
+    this.container.style.top = `${top}px`;
+    this.updateOffset();
+  }
+
+  private updateOffset(): void {
+    const height = this.container.offsetHeight;
+    document.documentElement.style.setProperty(
+      '--breaking-alert-offset',
+      height > 0 ? `${height}px` : '0px'
+    );
+    document.body.classList.toggle('has-breaking-alert', this.activeAlerts.length > 0);
+  }
+
+  private isDismissedRecently(id: string): boolean {
+    const ts = this.dismissed.get(id);
+    if (ts === undefined) return false;
+    if (Date.now() - ts >= 30 * 60 * 1000) {
+      this.dismissed.delete(id);
+      return false;
+    }
+    return true;
+  }
+
+  private handleAlert(alert: BreakingAlert): void {
+    if (this.isDismissedRecently(alert.id)) return;
+
+    const existing = this.activeAlerts.find(a => a.alert.id === alert.id);
+    if (existing) return;
+
+    while (this.activeAlerts.length >= MAX_ALERTS) {
+      const oldest = this.activeAlerts.shift();
+      if (oldest) this.removeAlert(oldest);
+    }
+
+    const el = this.createAlertElement(alert);
+    this.container.appendChild(el);
+
+    const dismissMs = alert.threatLevel === 'critical' ? CRITICAL_DISMISS_MS : HIGH_DISMISS_MS;
+    const now = Date.now();
+    const active: ActiveAlert = {
+      alert,
+      element: el,
+      timer: null,
+      remainingMs: dismissMs,
+      timerStartedAt: now,
+    };
+
+    if (!document.hidden) {
+      active.timer = setTimeout(() => this.dismissAlert(alert.id), dismissMs);
+    }
+
+    this.activeAlerts.push(active);
+    this.playSound();
+    this.updateOffset();
+  }
+
+  private createAlertElement(alert: BreakingAlert): HTMLElement {
+    const el = document.createElement('div');
+    el.className = `breaking-alert severity-${alert.threatLevel}`;
+    el.setAttribute('data-alert-id', alert.id);
+
+    const icon = alert.threatLevel === 'critical' ? '🚨' : '⚠️';
+    const levelText = alert.threatLevel === 'critical'
+      ? t('components.breakingNews.critical')
+      : t('components.breakingNews.high');
+    const timeAgo = this.formatTimeAgo(alert.timestamp);
+
+    const iconSpan = document.createElement('span');
+    iconSpan.className = 'breaking-alert-icon';
+    iconSpan.textContent = icon;
+
+    const content = document.createElement('div');
+    content.className = 'breaking-alert-content';
+
+    const levelSpan = document.createElement('span');
+    levelSpan.className = 'breaking-alert-level';
+    levelSpan.textContent = levelText;
+
+    const headlineSpan = document.createElement('span');
+    headlineSpan.className = 'breaking-alert-headline';
+    headlineSpan.textContent = alert.headline;
+
+    const metaSpan = document.createElement('span');
+    metaSpan.className = 'breaking-alert-meta';
+    metaSpan.textContent = `${alert.source} · ${timeAgo}`;
+
+    content.appendChild(levelSpan);
+    content.appendChild(headlineSpan);
+    content.appendChild(metaSpan);
+
+    const dismissBtn = document.createElement('button');
+    dismissBtn.className = 'breaking-alert-dismiss';
+    dismissBtn.textContent = '×';
+    dismissBtn.title = t('components.breakingNews.dismiss');
+
+    el.appendChild(iconSpan);
+    el.appendChild(content);
+    el.appendChild(dismissBtn);
+
+    return el;
+  }
+
+  private formatTimeAgo(date: Date): string {
+    const ms = Date.now() - date.getTime();
+    if (ms < 60_000) return t('components.intelligenceFindings.time.justNow');
+    if (ms < 3_600_000) return t('components.intelligenceFindings.time.minutesAgo', { count: String(Math.floor(ms / 60_000)) });
+    return t('components.intelligenceFindings.time.hoursAgo', { count: String(Math.floor(ms / 3_600_000)) });
+  }
+
+  private dismissAlert(id: string): void {
+    this.dismissed.set(id, Date.now());
+    const idx = this.activeAlerts.findIndex(a => a.alert.id === id);
+    if (idx === -1) return;
+    const active = this.activeAlerts[idx]!;
+    this.removeAlert(active);
+    this.activeAlerts.splice(idx, 1);
+    this.updateOffset();
+  }
+
+  private removeAlert(active: ActiveAlert): void {
+    if (active.timer) clearTimeout(active.timer);
+    active.element.remove();
+  }
+
+  private handleVisibility(): void {
+    const now = Date.now();
+    if (document.hidden) {
+      for (const active of this.activeAlerts) {
+        if (active.timer) {
+          clearTimeout(active.timer);
+          active.timer = null;
+          const elapsed = now - active.timerStartedAt;
+          active.remainingMs = Math.max(0, active.remainingMs - elapsed);
+        }
+      }
+    } else {
+      const expired: string[] = [];
+      for (const active of this.activeAlerts) {
+        if (!active.timer && active.remainingMs > 0) {
+          active.timerStartedAt = now;
+          active.timer = setTimeout(() => this.dismissAlert(active.alert.id), active.remainingMs);
+        } else if (active.remainingMs <= 0) {
+          expired.push(active.alert.id);
+        }
+      }
+      for (const id of expired) this.dismissAlert(id);
+    }
+  }
+
+  public destroy(): void {
+    document.removeEventListener('wm:breaking-news', this.boundOnAlert);
+    document.removeEventListener('visibilitychange', this.boundOnVisibility);
+    window.removeEventListener('resize', this.boundOnResize);
+    this.mutationObserver?.disconnect();
+    this.resizeObserver?.disconnect();
+
+    for (const active of this.activeAlerts) {
+      if (active.timer) clearTimeout(active.timer);
+    }
+    this.activeAlerts = [];
+    this.container.remove();
+    document.body.classList.remove('has-breaking-alert');
+    document.documentElement.style.removeProperty('--breaking-alert-offset');
+  }
+}

--- a/src/components/IntelligenceGapBadge.ts
+++ b/src/components/IntelligenceGapBadge.ts
@@ -1,5 +1,6 @@
 import { getRecentSignals, type CorrelationSignal } from '@/services/correlation';
 import { getRecentAlerts, type UnifiedAlert } from '@/services/cross-module-integration';
+import { getAlertSettings, updateAlertSettings } from '@/services/breaking-news-alerts';
 import { t } from '@/services/i18n';
 import { getSignalContext } from '@/utils/analysis-constants';
 import { escapeHtml } from '@/utils/sanitize';
@@ -78,8 +79,8 @@ export class IntelligenceFindingsBadge {
     this.dropdown.addEventListener('click', (e) => {
       const target = e.target as HTMLElement;
 
-      // Handle popup toggle click
-      if (target.closest('.popup-toggle-row')) {
+      const toggleAttr = target.closest('[data-toggle]')?.getAttribute('data-toggle');
+      if (toggleAttr === 'popup') {
         e.stopPropagation();
         this.popupEnabled = !this.popupEnabled;
         if (this.popupEnabled) {
@@ -87,6 +88,13 @@ export class IntelligenceFindingsBadge {
         } else {
           localStorage.removeItem(POPUP_STORAGE_KEY);
         }
+        this.renderDropdown();
+        return;
+      }
+      if (toggleAttr === 'breaking-alerts') {
+        e.stopPropagation();
+        const settings = getAlertSettings();
+        updateAlertSettings({ enabled: !settings.enabled });
         this.renderDropdown();
         return;
       }
@@ -314,9 +322,15 @@ export class IntelligenceFindingsBadge {
   private renderPopupToggle(): string {
     const label = t('components.intelligenceFindings.popupAlerts');
     const checked = this.popupEnabled;
-    return `<div class="popup-toggle-row">
+    const breakingSettings = getAlertSettings();
+    const breakingLabel = t('components.intelligenceFindings.breakingAlerts');
+    return `<div class="popup-toggle-row" data-toggle="popup">
         <span class="popup-toggle-label">🔔 ${escapeHtml(label)}</span>
         <span class="popup-toggle-switch${checked ? ' on' : ''}"><span class="popup-toggle-knob"></span></span>
+      </div>
+      <div class="popup-toggle-row" data-toggle="breaking-alerts">
+        <span class="popup-toggle-label">🚨 ${escapeHtml(breakingLabel)}</span>
+        <span class="popup-toggle-switch${breakingSettings.enabled ? ' on' : ''}"><span class="popup-toggle-knob"></span></span>
       </div>`;
   }
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -42,3 +42,4 @@ export * from './UnifiedSettings';
 export * from './TradePolicyPanel';
 export * from './SupplyChainPanel';
 export * from './SecurityAdvisoriesPanel';
+export * from './BreakingNewsBanner';

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1204,7 +1204,14 @@
     "runtimeConfig": {
       "getApiKey": "Get API key"
     },
+    "breakingNews": {
+      "critical": "CRITICAL",
+      "high": "HIGH",
+      "dismiss": "Dismiss",
+      "enableNotifications": "Enable desktop notifications"
+    },
     "intelligenceFindings": {
+      "breakingAlerts": "Breaking Alerts",
       "popupAlerts": "Pop up new alerts",
       "badgeTitle": "Intelligence findings",
       "title": "Intelligence Findings",

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -39,3 +39,4 @@ export { generateSummary, translateText } from './summarization';
 export * from './cached-theater-posture';
 export * from './trade';
 export * from './supply-chain';
+export * from './breaking-news-alerts';

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -13367,6 +13367,113 @@ body.has-critical-banner .panels-grid {
   padding-top: 50px;
 }
 
+/* ============ Breaking News Alert Banner ============ */
+
+.breaking-news-container {
+  position: fixed;
+  top: 50px;
+  left: 0;
+  right: 0;
+  z-index: 1001;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  pointer-events: none;
+}
+
+.breaking-alert {
+  pointer-events: auto;
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  animation: banner-slide-in 0.3s ease-out;
+  color: #fff;
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.breaking-alert.severity-critical {
+  background: linear-gradient(90deg, #8B0000, #DC143C);
+  border-bottom: 2px solid var(--semantic-critical);
+}
+
+.breaking-alert.severity-high {
+  background: linear-gradient(90deg, var(--semantic-high, #c2410c), #b45309);
+  border-bottom: 2px solid var(--semantic-high, #c2410c);
+}
+
+.breaking-alert-icon {
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+.breaking-alert-content {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.breaking-alert-level {
+  font-weight: 700;
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  padding: 1px 6px;
+  background: var(--overlay-heavy);
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.breaking-alert.severity-critical .breaking-alert-level {
+  animation: pulse-breaking 0.8s ease-in-out infinite;
+}
+
+.breaking-alert-headline {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.breaking-alert-meta {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.7);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.breaking-alert-dismiss {
+  background: var(--overlay-heavy);
+  border: none;
+  color: white;
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.breaking-alert-dismiss:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+body.has-breaking-alert .panels-grid {
+  margin-top: var(--breaking-alert-offset, 0px);
+  transition: margin-top 0.3s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .breaking-alert {
+    animation: none;
+  }
+  .breaking-alert.severity-critical .breaking-alert-level {
+    animation: none;
+  }
+}
+
 /* ============ Strategic Posture Panel ============ */
 
 .posture-panel {


### PR DESCRIPTION
## Summary
- **New service** `breaking-news-alerts.ts` — filters RSS items with `isAlert=true`, applies recency gate (15min / session start), dedup via hash-based key with 30min per-event cooldown + 60s global cooldown, dispatches `wm:breaking-news` CustomEvent
- **New component** `BreakingNewsBanner.ts` — fixed full-width banner (z-index 1001), max 3 stacked alerts, auto-dismiss (60s critical / 30s high) paused when tab hidden, audio with 5min cooldown, MutationObserver + lazy ResizeObserver for critical posture banner stacking, event delegation for dismiss. All untrusted content uses `textContent` (never innerHTML)
- **Toggle** in Intelligence Findings dropdown via `data-toggle` attribute routing

## Files changed (10)
| File | Change |
|------|--------|
| `src/services/breaking-news-alerts.ts` | NEW — alert controller service |
| `src/components/BreakingNewsBanner.ts` | NEW — banner UI + audio |
| `src/app/data-loader.ts` | +import, +2 onBatch hooks (RSS + intel) |
| `src/App.ts` | +init, +destroy, +state field |
| `src/app/app-context.ts` | +interface field |
| `src/components/IntelligenceGapBadge.ts` | +data-toggle attrs, +breaking alerts toggle |
| `src/styles/main.css` | +107 lines CSS (banner, severity variants, reduced-motion) |
| `src/locales/en.json` | +7 i18n keys |
| `src/components/index.ts` | +1 re-export |
| `src/services/index.ts` | +1 re-export |

## Test plan
- [ ] Open dev tools → dispatch synthetic alert: `document.dispatchEvent(new CustomEvent('wm:breaking-news', { detail: { id: 'test', headline: 'TEST: Major event detected', source: 'Reuters', threatLevel: 'critical', timestamp: new Date(), origin: 'rss_alert' } }))`
- [ ] Verify banner appears with red gradient, sound plays, auto-dismisses after 60s
- [ ] Dispatch same alert twice within 60s → only 1 banner (dedup)
- [ ] Switch away from tab → auto-dismiss pauses; switch back → resumes countdown
- [ ] Verify banner stacks below critical posture banner when both visible
- [ ] Toggle breaking alerts off in Intelligence Findings dropdown → alerts stop
- [ ] Verify localStorage settings persist across refresh
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds