### PR TITLE
fix(sentry): filter Android OEM WebView bridge injection errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -114,6 +114,7 @@ Sentry.init({
     /AbortError: The user aborted a request/,
     /\w+ is not a function.*\/uv\/service\//,
     /__isInQueue__/,
+    /^(?:LIDNotifyId|onWebViewAppeared|onGetWiFiBSSID) is not defined$/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary
- Add Sentry `ignoreErrors` pattern for 3 Android OEM WebView native bridge injections (`LIDNotifyId`, `onWebViewAppeared`, `onGetWiFiBSSID`)
- All from Lenovo/Huawei device SDKs injecting JS into Chrome Mobile WebView — no stack frames in our code
- Resolved WORLDMONITOR-5V, WORLDMONITOR-5S, WORLDMONITOR-5T in Sentry (inNextRelease)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 3 Sentry issues marked resolved with `inNextRelease: true`
- [ ] Verify errors no longer appear in Sentry after next deploy