### PR TITLE
fix: resolve bootstrap 401 and 429 rate limiting

### DIFF
--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -22,9 +22,20 @@ function isTrustedBrowserOrigin(origin) {
   return Boolean(origin) && BROWSER_ORIGIN_PATTERNS.some(p => p.test(origin));
 }
 
+function extractOriginFromReferer(referer) {
+  if (!referer) return '';
+  try {
+    return new URL(referer).origin;
+  } catch {
+    return '';
+  }
+}
+
 export function validateApiKey(req) {
   const key = req.headers.get('X-WorldMonitor-Key');
-  const origin = req.headers.get('Origin') || '';
+  // Same-origin browser requests don't send Origin (per CORS spec).
+  // Fall back to Referer to identify trusted same-origin callers.
+  const origin = req.headers.get('Origin') || extractOriginFromReferer(req.headers.get('Referer')) || '';
 
   // Desktop app — always require API key
   if (isDesktopOrigin(origin)) {

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -13,7 +13,7 @@ function getRatelimit(): Ratelimit | null {
 
   ratelimit = new Ratelimit({
     redis: new Redis({ url, token }),
-    limiter: Ratelimit.slidingWindow(60, '60 s'),
+    limiter: Ratelimit.slidingWindow(200, '60 s'),
     prefix: 'rl',
     analytics: false,
   });


### PR DESCRIPTION
## Summary
- **Bootstrap 401**: Same-origin browser requests don't send `Origin` header (CORS spec). `validateApiKey()` now falls back to extracting origin from `Referer` header, correctly identifying trusted same-origin callers.
- **429 rate limiting**: Increased global rate limit from 60 to 200 req/min. Page init fires ~50 requests in <1s, easily exceeding the old limit.

## Files changed
- `api/_api-key.js` — added `extractOriginFromReferer()` fallback
- `server/_shared/rate-limit.ts` — 60 → 200 req/min sliding window

## Test plan
- [ ] `curl -s https://worldmonitor.app/api/bootstrap` no longer returns 401
- [ ] Rapid page refresh doesn't trigger 429 errors in console
- [ ] Desktop app (Tauri) still requires API key (unchanged behavior)
- [ ] Unknown origins without API key still get 401 (unchanged behavior)