### PR TITLE
fix(threat-classifier): keyword gaps + news-to-conflict bridge

### DIFF
--- a/src/services/clustering.ts
+++ b/src/services/clustering.ts
@@ -130,6 +130,7 @@ function mergeSemanticallySimilarClusters(
       isAlert: allItems.some(i => i.isAlert),
       monitorColor: primary.monitorColor,
       velocity: primary.velocity,
+      threat: primary.threat,
     };
     merged.push(mergedCluster);
   }

--- a/src/services/threat-classifier.ts
+++ b/src/services/threat-classifier.ts
@@ -80,6 +80,9 @@ const CRITICAL_KEYWORDS: KeywordMap = {
   'evacuation order': 'disaster',
   'meltdown': 'disaster',
   'nuclear meltdown': 'disaster',
+  'major combat operations': 'military',
+  'full-scale war': 'conflict',
+  'declared war': 'conflict',
 };
 
 const HIGH_KEYWORDS: KeywordMap = {
@@ -107,6 +110,26 @@ const HIGH_KEYWORDS: KeywordMap = {
   'tsunami': 'disaster',
   'hurricane': 'disaster',
   'typhoon': 'disaster',
+  'strike on': 'conflict',
+  'strikes on': 'conflict',
+  'attack on': 'conflict',
+  'attack against': 'conflict',
+  'attacks on': 'conflict',
+  'launched attack': 'conflict',
+  'military operation': 'military',
+  'military operations': 'military',
+  'combat operations': 'military',
+  'bombardment': 'conflict',
+  'shelling': 'conflict',
+  'air strikes': 'conflict',
+  'retaliatory strike': 'military',
+  'preemptive strike': 'military',
+  'ground offensive': 'military',
+  'military offensive': 'military',
+  'ballistic missile': 'military',
+  'cruise missile': 'military',
+  'air defense intercepted': 'military',
+  'forces struck': 'conflict',
 };
 
 const MEDIUM_KEYWORDS: KeywordMap = {


### PR DESCRIPTION
## Summary
- Add 3 critical + 18 high contextual military/conflict keywords to threat classifier (e.g., `strike on`, `attack against`, `major combat operations`) — fixes headlines like "Israel's strike on Iran" being classified as `info`
- Preserve `threat` property on semantically merged clusters in `clustering.ts`
- Add news-derived conflict floor in CII scoring when ACLED/HAPI report zero signal — bridges the 1-7 day ACLED data lag with real-time breaking news
- Upsert news events by cluster ID to prevent duplicates on re-ingest
- Extract `newsEventIndex` to module-level Map for serialization safety

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds
- [ ] "Israel's strike on Iran" → `classifyByKeyword()` → high (conflict)
- [ ] "major combat operations against Iran" → critical (military)
- [ ] "cyber attack on infrastructure" → still matches `cyber attack` → high (cyber)
- [ ] Iran CII with 4+ diverse conflict clusters → conflict floor ~70
- [ ] Iran CII with <2 clusters or single source → floor stays 0
- [ ] Iran CII with ACLED data present → news floor ignored
- [ ] Semantically merged clusters preserve `threat` property