### PR TITLE
fix(rate-limit): increase sliding window to 300 req/min

### DIFF
--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -13,7 +13,7 @@ function getRatelimit(): Ratelimit | null {
 
   ratelimit = new Ratelimit({
     redis: new Redis({ url, token }),
-    limiter: Ratelimit.slidingWindow(200, '60 s'),
+    limiter: Ratelimit.slidingWindow(300, '60 s'),
     prefix: 'rl',
     analytics: false,
   });


### PR DESCRIPTION
## Summary
- Increases API rate limit from 200 → 300 requests per 60s sliding window
- App init fires many concurrent `classify-event`, `summarize-article`, and `record-baseline-snapshot` calls that exhaust the current limit

## Test plan
- [ ] Deploy to preview, open app → verify no 429 errors in console during init
- [ ] Confirm rate limiting still works by exceeding 300 req/min from a single IP