### PR TITLE
fix(iran): bypass stale CDN cache for iran-events endpoint

### DIFF
--- a/src/services/conflict/index.ts
+++ b/src/services/conflict/index.ts
@@ -373,9 +373,11 @@ export function groupByType(events: UcdpGeoEvent[]): Record<string, UcdpGeoEvent
 }
 
 export async function fetchIranEvents(): Promise<IranEvent[]> {
-  const resp = await iranBreaker.execute(
-    () => client.listIranEvents({}),
-    emptyIranFallback,
-  );
+  const resp = await iranBreaker.execute(async () => {
+    // Bypass stale CDN cache from pre-Redis deployment (remove once CDN is clean)
+    const r = await globalThis.fetch('/api/conflict/v1/list-iran-events?_v=2');
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return r.json() as Promise<ListIranEventsResponse>;
+  }, emptyIranFallback);
   return resp.events;
 }


### PR DESCRIPTION
## Summary
- Vercel CDN cached empty `{events:[],scrapedAt:0}` from the pre-Redis deployment with `slow` tier (`stale-if-error=1800`)
- Even after PR #518 deployed, some CDN edge nodes keep serving stale data
- Adds `?_v=2` query param to force CDN cache miss on a fresh key
- Temporary fix — can remove once stale entries expire

## Test plan
- [ ] Deploy to production
- [ ] Verify `/api/conflict/v1/list-iran-events?_v=2` returns 93 events
- [ ] Confirm Iran Attacks markers appear on map