### PR TITLE
fix(focal-points): attribute theater military activity to target nations

### DIFF
--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -304,6 +304,13 @@ export class InsightsPanel extends Panel {
       let focalSummary: ReturnType<typeof focalPointDetector.analyze>;
 
       if (SITE_VARIANT === 'full') {
+        // Feed theater-level posture into signal aggregator so target nations
+        // (Iran, Taiwan, etc.) get credited for military activity in their theater,
+        // even when aircraft/vessels are physically over neighboring airspace/waters.
+        if (this.lastMilitaryFlights.length > 0) {
+          const postures = getTheaterPostureSummaries(this.lastMilitaryFlights);
+          signalAggregator.ingestTheaterPostures(postures);
+        }
         signalSummary = signalAggregator.getSummary();
         this.lastConvergenceZones = signalSummary.convergenceZones;
         // Run focal point detection (correlates news entities with map signals)

--- a/src/services/signal-aggregator.ts
+++ b/src/services/signal-aggregator.ts
@@ -300,6 +300,53 @@ class SignalAggregator {
     this.pruneOld();
   }
 
+  ingestTheaterPostures(postures: Array<{
+    targetNation: string | null;
+    totalAircraft: number;
+    totalVessels: number;
+    postureLevel: 'normal' | 'elevated' | 'critical';
+    theaterName: string;
+  }>): void {
+    const TARGET_CODES: Record<string, string> = {
+      'Iran': 'IR', 'Taiwan': 'TW', 'North Korea': 'KP',
+      'Gaza': 'PS', 'Yemen': 'YE',
+    };
+
+    for (const p of postures) {
+      if (!p.targetNation || p.postureLevel === 'normal') continue;
+      const code = TARGET_CODES[p.targetNation];
+      if (!code) continue;
+
+      const hasFlight = this.signals.some(s => s.country === code && s.type === 'military_flight');
+      if (!hasFlight && p.totalAircraft > 0) {
+        this.signals.push({
+          type: 'military_flight',
+          country: code,
+          countryName: getCountryName(code),
+          lat: 0,
+          lon: 0,
+          severity: p.postureLevel === 'critical' ? 'high' : 'medium',
+          title: `${p.totalAircraft} military aircraft in ${p.theaterName}`,
+          timestamp: new Date(),
+        });
+      }
+
+      const hasVessel = this.signals.some(s => s.country === code && s.type === 'military_vessel');
+      if (!hasVessel && p.totalVessels > 0) {
+        this.signals.push({
+          type: 'military_vessel',
+          country: code,
+          countryName: getCountryName(code),
+          lat: 0,
+          lon: 0,
+          severity: p.totalVessels >= 5 ? 'high' : 'medium',
+          title: `${p.totalVessels} naval vessels in ${p.theaterName}`,
+          timestamp: new Date(),
+        });
+      }
+    }
+  }
+
   private coordsToCountry(lat: number, lon: number): string {
     const hit = getCountryAtCoordinates(lat, lon);
     return hit?.code ?? 'XX';

--- a/src/services/threat-classifier.ts
+++ b/src/services/threat-classifier.ts
@@ -357,7 +357,7 @@ export function classifyByKeyword(title: string, variant = 'full'): ThreatClassi
   return { level: 'info', category: 'general', confidence: 0.3, source: 'keyword' };
 }
 
-// Batched AI classification — collects headlines then fires parallel sebuf RPCs
+// Batched AI classification — collects headlines then fires parallel classifyEvent RPCs
 import {
   IntelligenceServiceClient,
   ApiError,


### PR DESCRIPTION
## Summary
- Focal Points panel showed Iran as ELEVATED despite active military strikes, while Strategic Posture correctly showed Iran Theater as CRIT
- Root cause: signal aggregator uses point-in-polygon to attribute flights to countries — aircraft over Persian Gulf/Iraq/Saudi got attributed to XX/IQ/SA, not IR
- New `ingestTheaterPostures()` feeds theater-level posture data back into signal aggregator for target nations (Iran, Taiwan, North Korea, Gaza, Yemen)
- Includes double-count guard: skips injection if nation already has that signal type from coordinate-based attribution
- Also fixes stale "sebuf" comment in threat-classifier

## Test plan
- [ ] Verify Iran shows CRITICAL in Focal Points when Iran Theater is CRIT in Strategic Posture
- [ ] Verify no double-counting when flights already geocode to target nation
- [ ] Verify theaters without targetNation (Baltic, Black Sea, E.Med, SCS) are unaffected
- [ ] `tsc --noEmit` passes clean