### PR TITLE
fix(relay): block rsshub.app requests with 410 Gone

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -86,7 +86,6 @@ const ALLOWED_DOMAINS = [
   'openai.com',
   'www.reutersagency.com',
   'feeds.reuters.com',
-  'rsshub.app',
   'asia.nikkei.com',
   'www.cfr.org',
   'www.csis.org',
@@ -345,6 +344,15 @@ export default async function handler(req) {
 
   try {
     const parsedUrl = new URL(feedUrl);
+
+    // Block deprecated feed domains (stale clients still request these)
+    const BLOCKED_DOMAINS = ['rsshub.app'];
+    if (BLOCKED_DOMAINS.includes(parsedUrl.hostname)) {
+      return new Response(JSON.stringify({ error: 'Feed deprecated' }), {
+        status: 410,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders },
+      });
+    }
 
     // Security: Check if domain is allowed (normalize www prefix)
     const hostname = parsedUrl.hostname;

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2308,10 +2308,14 @@ const server = http.createServer(async (req, res) => {
         'feeds.capi24.com',  // News24 redirect destination
         'islandtimes.org',
         'www.atlanticcouncil.org',
-        // RSSHub (NHK, MIIT, MOFCOM)
-        'rsshub.app',
       ];
       const parsed = new URL(feedUrl);
+      // Block deprecated/stale feed domains — stale clients still request these
+      const blockedDomains = ['rsshub.app'];
+      if (blockedDomains.includes(parsed.hostname)) {
+        res.writeHead(410, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'Feed deprecated' }));
+      }
       if (!allowedDomains.includes(parsed.hostname)) {
         res.writeHead(403, { 'Content-Type': 'application/json' });
         return res.end(JSON.stringify({ error: 'Domain not allowed on Railway proxy' }));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -497,7 +497,7 @@ const RSS_PROXY_ALLOWED_DOMAINS = new Set([
   'www.fema.gov', 'www.dhs.gov', 'www.thedrive.com', 'krebsonsecurity.com',
   'finance.yahoo.com', 'thediplomat.com', 'venturebeat.com', 'foreignpolicy.com',
   'www.ft.com', 'openai.com', 'www.reutersagency.com', 'feeds.reuters.com',
-  'rsshub.app', 'asia.nikkei.com', 'www.cfr.org', 'www.csis.org', 'www.politico.com',
+  'asia.nikkei.com', 'www.cfr.org', 'www.csis.org', 'www.politico.com',
   'www.brookings.edu', 'layoffs.fyi', 'www.defensenews.com', 'www.militarytimes.com',
   'taskandpurpose.com', 'news.usni.org', 'www.oryxspioenkop.com', 'www.gov.uk',
   'www.foreignaffairs.com', 'www.atlanticcouncil.org',
@@ -966,12 +966,6 @@ export default defineConfig({
         target: 'https://feeds.npr.org',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/rss\/npr/, ''),
-      },
-      // RSS Feeds - AP News
-      '/rss/apnews': {
-        target: 'https://rsshub.app/apnews',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/rss\/apnews/, ''),
       },
       // RSS Feeds - Al Jazeera
       '/rss/aljazeera': {


### PR DESCRIPTION
## Summary

- Stale PWA clients still request rsshub.app feeds (NHK, MOFCOM, MIIT) that were migrated to Google News RSS
- Relay was forwarding these to rsshub.app upstream → 403
- Added explicit blocklist returning **410 Gone** before the allowlist check in both relay and edge proxy
- Removed rsshub.app from all allowlists and the dead vite dev proxy

## Test plan

- [ ] Relay logs show `410` instead of `RSS upstream 403` for rsshub.app requests
- [ ] No upstream requests to rsshub.app
- [ ] Other RSS feeds unaffected