### PR TITLE
fix(iran): bust CDN cache for Gulf-geocoded events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ CLAUDE.md
 skills/
 ideas/
 docs/internal/
+internal/
 test-results/
 src-tauri/sidecar/node/*
 !src-tauri/sidecar/node/.gitkeep

--- a/src/services/conflict/index.ts
+++ b/src/services/conflict/index.ts
@@ -375,7 +375,7 @@ export function groupByType(events: UcdpGeoEvent[]): Record<string, UcdpGeoEvent
 export async function fetchIranEvents(): Promise<IranEvent[]> {
   const resp = await iranBreaker.execute(async () => {
     // Bypass stale CDN cache from pre-Redis deployment (remove once CDN is clean)
-    const r = await globalThis.fetch('/api/conflict/v1/list-iran-events?_v=2');
+    const r = await globalThis.fetch('/api/conflict/v1/list-iran-events?_v=3');
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     return r.json() as Promise<ListIranEventsResponse>;
   }, emptyIranFallback);


### PR DESCRIPTION
## Summary
- Bump Iran events cache-bust param from `?_v=2` to `?_v=3` so CDN serves fresh 100-event data with Gulf state coordinates (UAE, Bahrain, Qatar, Kuwait)
- Add `internal/` to `.gitignore` for private tooling scripts

## Context
After pushing updated geocoded events to Redis (100 events including Gulf states), the CDN edge cache continued serving the stale 93-event response. The `?_v=3` creates a new cache key that bypasses the stale CDN entry.

## Test plan
- [ ] After deploy, verify `/api/conflict/v1/list-iran-events?_v=3` returns 100 events
- [ ] Verify Gulf markers (UAE, Bahrain, Qatar, Kuwait) appear on map