### PR TITLE
fix(alerts): remove SESSION_START gate blocking breaking news banner

### DIFF
--- a/src/services/breaking-news-alerts.ts
+++ b/src/services/breaking-news-alerts.ts
@@ -22,7 +22,6 @@ const SETTINGS_KEY = 'wm-breaking-alerts-v1';
 const RECENCY_GATE_MS = 15 * 60 * 1000;
 const PER_EVENT_COOLDOWN_MS = 30 * 60 * 1000;
 const GLOBAL_COOLDOWN_MS = 60 * 1000;
-const SESSION_START = Date.now();
 
 const DEFAULT_SETTINGS: AlertSettings = {
   enabled: true,
@@ -87,9 +86,7 @@ export function updateAlertSettings(partial: Partial<AlertSettings>): void {
 }
 
 function isRecent(pubDate: Date): boolean {
-  const now = Date.now();
-  const recencyCutoff = Math.max(now - RECENCY_GATE_MS, SESSION_START);
-  return pubDate.getTime() >= recencyCutoff;
+  return pubDate.getTime() >= (Date.now() - RECENCY_GATE_MS);
 }
 
 function pruneDedupeMap(): void {


### PR DESCRIPTION
## Summary
- Removed `SESSION_START` gate from `isRecent()` in breaking news alerts
- Items published before page load were **permanently blocked** from triggering the banner — `SESSION_START` blocked them in the first 15 min, then the 15-min recency window blocked them after
- Now uses only the 15-minute recency window; spam prevention intact via per-event dedup (30 min), global cooldown (60s), and source tier filter

## Test plan
- [ ] Load page during active breaking event (CRITICAL/HIGH headlines visible)
- [ ] Verify breaking news banner appears within seconds of page load
- [ ] Refresh page — banner should reappear for still-active breaking news
- [ ] After dismissing, same headline should not re-fire for 30 minutes
- [ ] Two alerts within 60 seconds — only first should fire (global cooldown)