### PR TITLE
fix(live-news): replace 7 stale YouTube fallback video IDs

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -80,7 +80,7 @@ const TECH_LIVE_CHANNELS: LiveChannel[] = [
 export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   // North America
   { id: 'livenow-fox', name: 'LiveNOW from FOX', handle: '@LiveNOWfromFOX' },
-  { id: 'fox-news', name: 'Fox News', handle: '@FoxNews', fallbackVideoId: 'QaftgYkG-ek', useFallbackOnly: true },
+  { id: 'fox-news', name: 'Fox News', handle: '@FoxNews', fallbackVideoId: 'ZvdiJUYGBis', useFallbackOnly: true },
   { id: 'newsmax', name: 'Newsmax', handle: '@NEWSMAX', fallbackVideoId: 'cZikyozILOY', useFallbackOnly: true },
   { id: 'abc-news', name: 'ABC News', handle: '@ABCNews' },
   { id: 'cbs-news', name: 'CBS News', handle: '@CBSNews', fallbackVideoId: 'pBk4NYhWNMM' },
@@ -90,7 +90,7 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'bbc-news', name: 'BBC News', handle: '@BBCNews' },
   { id: 'france24-en', name: 'France 24 English', handle: '@FRANCE24English' },
   { id: 'welt', name: 'WELT', handle: '@WELTNachrichtensender' },
-  { id: 'rtve', name: 'RTVE 24H', handle: '@RTVENoticias', fallbackVideoId: '7_srED6k0bE' },
+  { id: 'rtve', name: 'RTVE 24H', handle: '@RTVENoticias', fallbackVideoId: '-7GEFgUKilA' },
   { id: 'trt-haber', name: 'TRT Haber', handle: '@trthaber' },
   { id: 'ntv-turkey', name: 'NTV', handle: '@NTV' },
   { id: 'cnn-turk', name: 'CNN TURK', handle: '@cnnturk' },
@@ -98,18 +98,18 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'tvp-info', name: 'TVP Info', handle: '@tvpinfo' },
   { id: 'telewizja-republika', name: 'Telewizja Republika', handle: '@Telewizja_Republika' },
   // Latin America & Portuguese
-  { id: 'cnn-brasil', name: 'CNN Brasil', handle: '@CNNbrasil', fallbackVideoId: '1kWRw-DA6Ns' },
+  { id: 'cnn-brasil', name: 'CNN Brasil', handle: '@CNNbrasil', fallbackVideoId: '6ZkOlaGfxq4' },
   { id: 'jovem-pan', name: 'Jovem Pan News', handle: '@jovempannews' },
   { id: 'record-news', name: 'Record News', handle: '@recordnewsoficial' },
   { id: 'band-jornalismo', name: 'Band Jornalismo', handle: '@BandJornalismo' },
   { id: 'tn-argentina', name: 'TN (Todo Noticias)', handle: '@todonoticias', fallbackVideoId: 'cb12KmMMDJA' },
-  { id: 'c5n', name: 'C5N', handle: '@c5n', fallbackVideoId: 'NdQSOItOQ5Y' },
+  { id: 'c5n', name: 'C5N', handle: '@c5n', fallbackVideoId: 'SF06Qy1Ct6Y' },
   { id: 'milenio', name: 'MILENIO', handle: '@MILENIO' },
   { id: 'noticias-caracol', name: 'Noticias Caracol', handle: '@NoticiasCaracol' },
   { id: 'ntn24', name: 'NTN24', handle: '@NTN24' },
   { id: 't13', name: 'T13', handle: '@T13' },
   // Asia
-  { id: 'tbs-news', name: 'TBS NEWS DIG', handle: '@tbsnewsdig', fallbackVideoId: 'ohI356mwBp8' },
+  { id: 'tbs-news', name: 'TBS NEWS DIG', handle: '@tbsnewsdig', fallbackVideoId: 'Anr15FA9OCI' },
   { id: 'ann-news', name: 'ANN News', handle: '@ANNnewsCH' },
   { id: 'ntv-news', name: 'NTV News (Japan)', handle: '@ntv_news' },
   { id: 'cti-news', name: 'CTI News (Taiwan)', handle: '@CtiTv', fallbackVideoId: 'wUPPkSANpyo', useFallbackOnly: true },
@@ -119,8 +119,8 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'nhk-world', name: 'NHK World Japan', handle: '@NHKWORLDJAPAN' },
   // Middle East
   { id: 'al-hadath', name: 'Al Hadath', handle: '@AlHadath', fallbackVideoId: 'xWXpl7azI8k', useFallbackOnly: true },
-  { id: 'sky-news-arabia', name: 'Sky News Arabia', handle: '@skynewsarabia', fallbackVideoId: 'MN50dHFHMKE' },
-  { id: 'trt-world', name: 'TRT World', handle: '@TRTWorld', fallbackVideoId: 'CV5Fooi8WDI' },
+  { id: 'sky-news-arabia', name: 'Sky News Arabia', handle: '@skynewsarabia', fallbackVideoId: 'U--OjmpjF5o' },
+  { id: 'trt-world', name: 'TRT World', handle: '@TRTWorld', fallbackVideoId: 'ABfFhWzWs0s' },
   { id: 'iran-intl', name: 'Iran International', handle: '@IranIntl' },
   { id: 'cgtn-arabic', name: 'CGTN Arabic', handle: '@CGTNArabic' },
   // Africa


### PR DESCRIPTION
## Summary
- Validated all 23 YouTube `fallbackVideoId` values via oEmbed API and all 9 `DIRECT_HLS_MAP` URLs
- Replaced 7 broken/stale video IDs (5 newly found + 2 from earlier)

### Broken IDs found
| Channel | Old ID | Issue | New ID |
|---------|--------|-------|--------|
| Fox News | `QaftgYkG-ek` | 403 | `ZvdiJUYGBis` |
| Sky News Arabia | `MN50dHFHMKE` | 403 (error 150) | `U--OjmpjF5o` |
| RTVE 24H | `7_srED6k0bE` | 403 | `-7GEFgUKilA` |
| CNN Brasil | `1kWRw-DA6Ns` | 403 | `6ZkOlaGfxq4` |
| C5N | `NdQSOItOQ5Y` | 403 | `SF06Qy1Ct6Y` |
| TBS NEWS DIG | `ohI356mwBp8` | 403 | `Anr15FA9OCI` |
| TRT World | `CV5Fooi8WDI` | 404 | `ABfFhWzWs0s` |

### Validated OK
- **16 YouTube IDs**: All returned 200 from oEmbed
- **9 HLS URLs**: All returned 200 (sky, euronews, dw, france24, alarabiya, cbs-news, trt-world, sky-news-arabia, al-hadath)

## Test plan
- [ ] Open app → add RTVE, CNN Brasil, C5N, TBS NEWS DIG, TRT World channels
- [ ] Verify each shows YouTube player (not error 150)
- [ ] Verify Fox News and Sky News Arabia still work
- [ ] Verify HLS channels load native video on desktop