### PR TITLE
fix(relay): fix telegram ESM import path and broaden latch regex

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -230,7 +230,7 @@ async function initTelegramClientIfNeeded() {
 
   try {
     const { TelegramClient } = await import('telegram');
-    const { StringSession } = await import('telegram/sessions');
+    const { StringSession } = await import('telegram/sessions/index.js');
 
     const client = new TelegramClient(new StringSession(sessionStr), apiId, apiHash, {
       connectionRetries: 3,
@@ -242,7 +242,7 @@ async function initTelegramClientIfNeeded() {
     console.log('[Relay] Telegram client connected');
     return true;
   } catch (e) {
-    if (e?.code === 'ERR_MODULE_NOT_FOUND' || /Cannot find package/.test(e?.message)) {
+    if (e?.code === 'ERR_MODULE_NOT_FOUND' || /Cannot find package|Directory import/.test(e?.message)) {
       telegramImportFailed = true;
       telegramState.lastError = 'telegram package not installed';
       console.warn('[Relay] Telegram package not installed — disabling permanently for this session');


### PR DESCRIPTION
## Summary

- `import('telegram/sessions')` → `import('telegram/sessions/index.js')` — Node.js ESM resolution rejects bare directory imports in CJS context
- Broaden permanent-disable latch to catch "Directory import" errors (not just "Cannot find package")

Found via Railway deploy logs showing: `Directory import '/app/node_modules/telegram/sessions' is not supported resolving ES modules`

## Test plan

- [x] `node --check scripts/ais-relay.cjs` — syntax OK
- [x] `node -e "import('telegram/sessions/index.js')"` — resolves
- [ ] Deploy to Railway → no telegram import errors in logs