### PR TITLE
fix(relay): Telegram auto-reconnect on AUTH_KEY_DUPLICATED

### DIFF
--- a/data/telegram-channels.json
+++ b/data/telegram-channels.json
@@ -86,7 +86,7 @@
         "maxMessages": 25
       },
       {
-        "handle": "IranIntl",
+        "handle": "iranintltv",
         "label": "Iran International",
         "topic": "politics",
         "tier": 2,

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -290,6 +290,12 @@ async function pollTelegramOnce() {
       const em = e?.message || String(e);
       telegramState.lastError = `poll ${handle} failed: ${em}`;
       console.warn('[Relay] Telegram poll error:', telegramState.lastError);
+      if (/AUTH_KEY_DUPLICATED/.test(em)) {
+        console.warn('[Relay] Telegram session conflict — destroying client, will reconnect next cycle');
+        try { telegramState.client?.disconnect(); } catch {}
+        telegramState.client = null;
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- **AUTH_KEY_DUPLICATED recovery** — when Telegram returns 406 (session conflict from competing client), disconnect and null the client so next poll cycle reconnects fresh. Self-heals once the competing process dies.
- **Fix IranIntl handle** — `IranIntl` → `iranintltv` (correct Telegram channel, was returning USERNAME_INVALID)

## Root cause

Two processes (Railway + Vercel) were using the same `TELEGRAM_SESSION` simultaneously. Telegram only allows one active connection per session — the second invalidates the first with `AUTH_KEY_DUPLICATED`.

## Action items

- [ ] Set `TELEGRAM_ENABLED=false` on Vercel (only Railway should run Telegram)
- [ ] Restart Railway service after merge for fresh session connect

## Test plan

- [x] `node --check scripts/ais-relay.cjs` — syntax OK
- [ ] Deploy → verify AUTH_KEY_DUPLICATED triggers reconnect instead of spamming
- [ ] Verify `iranintltv` resolves (no more USERNAME_INVALID)