### PR TITLE
fix(telegram): fix ESM import in session-auth script

### DIFF
--- a/scripts/telegram/session-auth.mjs
+++ b/scripts/telegram/session-auth.mjs
@@ -12,7 +12,7 @@
  */
 
 import { TelegramClient } from 'telegram';
-import { StringSession } from 'telegram/sessions';
+import { StringSession } from 'telegram/sessions/index.js';
 import readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 


### PR DESCRIPTION
## Summary

Same `telegram/sessions` → `telegram/sessions/index.js` ESM fix, applied to `scripts/telegram/session-auth.mjs`.

Without this, the session generation script crashes on Node.js v24+ with `ERR_UNSUPPORTED_DIR_IMPORT`.