### PR TITLE
fix(iran): bump CDN cache-bust to v4 for fresh event data

### DIFF
--- a/src/services/conflict/index.ts
+++ b/src/services/conflict/index.ts
@@ -375,7 +375,7 @@ export function groupByType(events: UcdpGeoEvent[]): Record<string, UcdpGeoEvent
 export async function fetchIranEvents(): Promise<IranEvent[]> {
   const resp = await iranBreaker.execute(async () => {
     // Bypass stale CDN cache from pre-Redis deployment (remove once CDN is clean)
-    const r = await globalThis.fetch('/api/conflict/v1/list-iran-events?_v=3');
+    const r = await globalThis.fetch('/api/conflict/v1/list-iran-events?_v=4');
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     return r.json() as Promise<ListIranEventsResponse>;
   }, emptyIranFallback);


### PR DESCRIPTION
## Summary
- Bump `?_v=3` to `?_v=4` to serve 100 fresh events from Redis
- Events cover active Iran-Israel-US conflict theater including Gulf states

## Locations covered
Abu Dhabi (3), Israel (12), UAE (6), Qatar (5), Doha (2), Kuwait (2), Bahrain (4), Jordan (4), Erbil (4), Dubai (3), Syria (3), Tehran (2), Shiraz (2), Jerusalem (2), + 20 more locations