### PR TITLE
fix(relay): use execFileSync for OREF curl to avoid shell injection

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -361,12 +361,15 @@ function stripBom(text) {
 function orefCurlFetch(proxyAuth, url) {
   // Use curl via child_process — Node.js TLS fingerprint (JA3) gets blocked by Akamai,
   // but curl's fingerprint passes. curl is available on Railway (Linux) and macOS.
-  const { execSync } = require('child_process');
+  // execFileSync avoids shell interpolation — safe with special chars in proxy credentials.
+  const { execFileSync } = require('child_process');
   const proxyUrl = `http://${proxyAuth}`;
-  const result = execSync(
-    `curl -s -x "${proxyUrl}" --max-time 15 -H "Accept: application/json" -H "Referer: https://www.oref.org.il/" "${url}"`,
-    { encoding: 'utf8', timeout: 20000 }
-  );
+  const result = execFileSync('curl', [
+    '-s', '-x', proxyUrl, '--max-time', '15',
+    '-H', 'Accept: application/json',
+    '-H', 'Referer: https://www.oref.org.il/',
+    url,
+  ], { encoding: 'utf8', timeout: 20000 });
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Switch `orefCurlFetch` from `execSync` (shell interpolation) to `execFileSync` (direct exec)
- Proxy credentials with special characters (semicolons in password) were passed into a shell command via template literal — semicolons are shell command separators
- `execFileSync` passes args directly to the process without shell parsing, making it safe for any credential characters

## Test plan
- [ ] Deploy relay to Railway with `OREF_PROXY_AUTH` containing semicolons in password
- [ ] Verify OREF polling works (`/oref/alerts` returns data)
- [ ] Check relay logs for no curl errors