### PR TITLE
feat(cii): integrate Iran strike events into CII scoring & country brief

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -568,9 +568,10 @@ export class App {
     // Refresh intelligence signals for CII (geopolitical variant only)
     if (SITE_VARIANT === 'full') {
       this.refreshScheduler.scheduleRefresh('intelligence', () => {
-        const { military } = this.state.intelligenceCache;
+        const { military, iranEvents } = this.state.intelligenceCache;
         this.state.intelligenceCache = {};
         if (military) this.state.intelligenceCache.military = military;
+        if (iranEvents) this.state.intelligenceCache.iranEvents = iranEvents;
         return this.dataLoader.loadIntelligenceSignals();
       }, 15 * 60 * 1000);
     }

--- a/src/app/app-context.ts
+++ b/src/app/app-context.ts
@@ -1,4 +1,5 @@
 import type { NewsItem, Monitor, PanelConfig, MapLayers, InternetOutage, SocialUnrestEvent, MilitaryFlight, MilitaryFlightCluster, MilitaryVessel, MilitaryVesselCluster, CyberThreat, USNIFleetReport } from '@/types';
+import type { IranEvent } from '@/generated/client/worldmonitor/conflict/v1/service_client';
 import type { MapContainer, Panel, NewsPanel, SignalModal, StatusPanel, SearchModal } from '@/components';
 import type { IntelligenceGapBadge } from '@/components';
 import type { MarketData, ClusteredEvent } from '@/types';
@@ -32,6 +33,7 @@ export interface CountryBriefSignals {
   displacementOutflow: number;
   climateStress: number;
   conflictEvents: number;
+  activeStrikes: number;
   isTier1: boolean;
 }
 
@@ -41,6 +43,7 @@ export interface IntelligenceCache {
   military?: { flights: MilitaryFlight[]; flightClusters: MilitaryFlightCluster[]; vessels: MilitaryVessel[]; vesselClusters: MilitaryVesselCluster[] };
   earthquakes?: Earthquake[];
   usniFleet?: USNIFleetReport;
+  iranEvents?: IranEvent[];
 }
 
 export interface AppModule {

--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -183,6 +183,7 @@ export class CountryBriefPage {
     }
     if (signals.climateStress > 0) chips.push(`<span class="signal-chip climate">🌡️ ${t('modals.countryBrief.signals.climate')}</span>`);
     if (signals.conflictEvents > 0) chips.push(`<span class="signal-chip conflict">⚔️ ${signals.conflictEvents} ${t('modals.countryBrief.signals.conflictEvents')}</span>`);
+    if (signals.activeStrikes > 0) chips.push(`<span class="signal-chip conflict">\u{1F4A5} ${signals.activeStrikes} ${t('modals.countryBrief.signals.activeStrikes')}</span>`);
     chips.push(`<span class="signal-chip stock-loading">📈 ${t('modals.countryBrief.loadingIndex')}</span>`);
     return chips.join('');
   }
@@ -608,6 +609,7 @@ export class CountryBriefPage {
         displacementOutflow: this.currentSignals.displacementOutflow,
         climateStress: this.currentSignals.climateStress,
         conflictEvents: this.currentSignals.conflictEvents,
+        activeStrikes: this.currentSignals.activeStrikes,
       };
     }
     if (this.currentBrief) data.brief = this.currentBrief;

--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -619,9 +619,10 @@ export class InsightsPanel extends Panel {
   }
 
   private renderFocalPoints(): string {
-    // Only show focal points that have both news AND signals (true correlations)
+    // Show focal points with news+signals correlations, or those with active strikes
     const correlatedFPs = this.lastFocalPoints.filter(
-      fp => fp.newsMentions > 0 && fp.signalCount > 0
+      fp => (fp.newsMentions > 0 && fp.signalCount > 0) ||
+            fp.signalTypes.includes('active_strike')
     ).slice(0, 5);
 
     if (correlatedFPs.length === 0) {
@@ -634,6 +635,7 @@ export class InsightsPanel extends Panel {
       military_vessel: '⚓',
       protest: '📢',
       ais_disruption: '🚢',
+      active_strike: '💥',
     };
 
     const focalPointsHtml = correlatedFPs.map(fp => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,7 +36,8 @@
       "earthquakes": "earthquakes",
       "displaced": "displaced",
       "climate": "Climate stress",
-      "conflictEvents": "conflict events"
+      "conflictEvents": "conflict events",
+      "activeStrikes": "active strikes"
     },
     "timeAgo": {
       "m": "{{count}}m ago",
@@ -72,7 +73,8 @@
       "internetOutages": "{{count}} internet outages",
       "recentEarthquakes": "{{count}} recent earthquakes",
       "stockIndex": "Stock index: {{value}}",
-      "recentHeadlines": "**Recent headlines:**"
+      "recentHeadlines": "**Recent headlines:**",
+      "activeStrikes": "{{count}} active strikes detected"
     }
   },
   "header": {
@@ -453,7 +455,8 @@
         "earthquakes": "earthquakes",
         "displaced": "displaced",
         "climate": "Climate stress",
-        "conflictEvents": "conflict events"
+        "conflictEvents": "conflict events",
+        "activeStrikes": "active strikes"
       },
       "timeAgo": {
         "m": "{{count}}m ago",
@@ -486,6 +489,7 @@
         "protestsDetected": "{{count}} active protests detected",
         "aircraftTracked": "{{count}} military aircraft tracked",
         "vesselsTracked": "{{count}} military vessels tracked",
+        "activeStrikes": "{{count}} active strikes detected",
         "internetOutages": "{{count}} internet outages",
         "recentEarthquakes": "{{count}} recent earthquakes",
         "stockIndex": "Stock index: {{value}}",

--- a/src/services/focal-point-detector.ts
+++ b/src/services/focal-point-detector.ts
@@ -21,6 +21,7 @@ const SIGNAL_TYPE_LABELS: Record<SignalType, string> = {
   ais_disruption: 'shipping disruption',
   satellite_fire: 'satellite fires',
   temporal_anomaly: 'anomaly detection',
+  active_strike: 'active strikes',
 };
 
 const SIGNAL_TYPE_ICONS: Record<SignalType, string> = {
@@ -31,6 +32,7 @@ const SIGNAL_TYPE_ICONS: Record<SignalType, string> = {
   ais_disruption: '🚢',
   satellite_fire: '🔥',
   temporal_anomaly: '📊',
+  active_strike: '💥',
 };
 
 class FocalPointDetector {
@@ -202,7 +204,8 @@ class FocalPointDetector {
     const newsScore = this.calculateNewsScore(mention);
     const signalScore = signals ? this.calculateSignalScore(signals) : 0;
     const correlationBonus = this.calculateCorrelationBonus(mention, signals);
-    const rawScore = newsScore + signalScore + correlationBonus;
+    const conflictScore = signals ? this.calculateConflictScore(signals) : 0;
+    const rawScore = newsScore + signalScore + correlationBonus + conflictScore;
 
     const signalTypes = signals ? Array.from(signals.signalTypes) : [];
     const urgency = this.determineUrgency(rawScore, signalTypes.length);
@@ -246,10 +249,28 @@ class FocalPointDetector {
   }
 
   private calculateSignalScore(signals: CountrySignalCluster): number {
-    const typeBonus = signals.signalTypes.size * 10;
-    const countBonus = Math.min(15, signals.totalCount * 3);
-    const severityBonus = signals.highSeverityCount * 5;
+    const nonStrike = signals.signals.filter(s => s.type !== 'active_strike');
+    const types = new Set(nonStrike.map(s => s.type));
+    const typeBonus = types.size * 10;
+    const countBonus = Math.min(15, nonStrike.length * 3);
+    const severityBonus = nonStrike.filter(s => s.severity === 'high').length * 5;
     return typeBonus + countBonus + severityBonus;
+  }
+
+  private calculateConflictScore(signals: CountrySignalCluster): number {
+    const strikeSignals = signals.signals.filter(s => s.type === 'active_strike');
+    if (strikeSignals.length === 0) return 0;
+
+    let totalCount = 0;
+    let highSevCount = 0;
+    for (const s of strikeSignals) {
+      totalCount += s.strikeCount ?? 0;
+      highSevCount += s.highSeverityStrikeCount ?? 0;
+    }
+
+    const base = Math.min(30, totalCount * 1.5);
+    const severityBonus = Math.min(30, highSevCount * 3);
+    return base + severityBonus;
   }
 
   private calculateCorrelationBonus(
@@ -267,7 +288,8 @@ class FocalPointDetector {
       return (signals.signalTypes.has('military_flight') && /military|troops|forces|army|air force/.test(lower)) ||
              (signals.signalTypes.has('military_vessel') && /navy|naval|ships|fleet|carrier/.test(lower)) ||
              (signals.signalTypes.has('protest') && /protest|demonstrat|unrest|riot/.test(lower)) ||
-             (signals.signalTypes.has('internet_outage') && /internet|blackout|outage|connectivity/.test(lower));
+             (signals.signalTypes.has('internet_outage') && /internet|blackout|outage|connectivity/.test(lower)) ||
+             (signals.signalTypes.has('active_strike') && /strike|attack|bomb|missile|target|hit/.test(lower));
     })) {
       bonus += 5;
     }


### PR DESCRIPTION
## Summary

- Integrates ~100 geolocated Iran strike events into the Country Instability Index (CII) scoring system, country brief panel, and 7-day timeline
- CII conflict score now boosted by strikes with a 7-day freshness window (Iran conflict goes from 70 → ~100)
- Strike chip ("💥 N active strikes") shown in Active Signals section
- Conflict timeline lane populated with strike events (previously "No events in 7 days")
- Intelligence brief fallback text includes strike count
- Structured `strikeCount`/`highSeverityStrikeCount` fields on GeoSignal replace fragile regex parsing
- Bounding-box fallback ensures geo-lookup works even before GeoJSON asset loads

## Files changed

| File | Change |
|------|--------|
| `country-instability.ts` | `strikes[]` on CountryData, `ingestStrikesForCII()`, strike boost in `calcConflictScore()` |
| `signal-aggregator.ts` | `ingestConflictEvents()`, `active_strike` signal type, structured metadata fields |
| `focal-point-detector.ts` | `calculateConflictScore()` using structured fields, strike correlation bonus |
| `app-context.ts` | `iranEvents` on IntelligenceCache, `activeStrikes` on CountryBriefSignals |
| `App.ts` | Preserve `iranEvents` across intelligence refresh |
| `data-loader.ts` | Always load Iran events, ingest into CII, trigger panel refresh |
| `country-intel.ts` | `getCountryStrikes()` helper, strike count in signals/timeline/brief |
| `CountryBriefPage.ts` | Strike chip + export data |
| `InsightsPanel.ts` | Show focal points with active strikes |
| `en.json` | i18n keys for `activeStrikes` |

## Test plan

- [ ] Open Iran country brief → verify Conflict component ≈ 100 (was 70)
- [ ] Verify "💥 N active strikes" chip in Active Signals
- [ ] Verify Conflict timeline lane has events (not "No events in 7 days")
- [ ] Verify Intelligence Brief mentions strikes in fallback mode
- [ ] Open a country with no strikes → verify scores unaffected
- [ ] `npx tsc --noEmit` passes clean