### PR TITLE
feat(conflict): enhance Iran events popup with severity and related events

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -3008,6 +3008,17 @@ export class DeckGLMap {
       if (fullConflict) data = fullConflict;
     }
 
+    // Enrich iran events with related events from same location
+    if (popupType === 'iranEvent' && data.locationName) {
+      const clickedId = data.id;
+      const normalizedLoc = data.locationName.trim().toLowerCase();
+      const related = this.iranEvents
+        .filter(e => e.id !== clickedId && e.locationName && e.locationName.trim().toLowerCase() === normalizedLoc)
+        .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))
+        .slice(0, 5);
+      data = { ...data, relatedEvents: related };
+    }
+
     // Get click coordinates relative to container
     const x = info.x ?? 0;
     const y = info.y ?? 0;

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1755,6 +1755,9 @@
     "commodityHub": {
       "commodities": "السلع"
     },
+    "iranEvent": {
+      "relatedEvents": "أحداث ذات صلة"
+    },
     "hotspotSubtexts": {
       "conflict_zone": "منطقة نزاع",
       "dprk_watch": "مراقبة كوريا الشمالية",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1862,6 +1862,9 @@
     "commodityHub": {
       "commodities": "COMMODITIES"
     },
+    "iranEvent": {
+      "relatedEvents": "Related Events"
+    },
     "hotspotSubtexts": {
       "conflict_zone": "Conflict Zone",
       "dprk_watch": "DPRK Watch",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1755,6 +1755,9 @@
     "commodityHub": {
       "commodities": "PRODUITS"
     },
+    "iranEvent": {
+      "relatedEvents": "Événements liés"
+    },
     "hotspotSubtexts": {
       "conflict_zone": "Zone de conflit",
       "dprk_watch": "Montre RPDC",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -5514,6 +5514,22 @@ a.prediction-link:hover {
   z-index: -1;
 }
 
+.popup-header.iranEvent {
+  background: rgba(255, 68, 68, 0.1);
+}
+
+.popup-header.iranEvent.high {
+  border-left: 3px solid #ff3232;
+}
+
+.popup-header.iranEvent.medium {
+  border-left: 3px solid #ffa500;
+}
+
+.popup-header.iranEvent.low {
+  border-left: 3px solid #cccc00;
+}
+
 .popup-header.conflict {
   background: rgba(255, 68, 68, 0.1);
 }


### PR DESCRIPTION
## Summary
- Rewrites the Iran events popup to follow the established popup pattern (conflict/protest) with severity-colored header, badge, close button, and structured stat rows
- Displays severity badge (HIGH/MEDIUM/LOW) using existing CSS classes instead of inline styles
- Shows up to 5 related events from the same location (normalized `locationName` matching)
- Adds `IranEventPopupData` to the `PopupData` union type, removing the unsafe `as unknown as` double cast
- Adds `iranEvent` header CSS with severity-specific `border-left` colors
- Adds i18n keys (`popups.iranEvent.relatedEvents`) for en, ar, fr

## Test plan
- [ ] Click an Iran event dot → severity badge shows HIGH/MEDIUM/LOW with correct color
- [ ] "Related Events" section shows same-location events; hidden when none exist
- [ ] Close button dismisses popup
- [ ] Source link opens in new tab with `rel="noopener noreferrer nofollow"`
- [ ] Unknown severity value falls back to `low` styling
- [ ] Missing `locationName` → no related events shown
- [ ] Missing `timestamp` → no crash, time row hidden
- [ ] `npm run typecheck` passes clean