### PR TITLE
feat(live-news): residential proxy + gzip for YouTube detection

### DIFF
--- a/api/youtube/live.js
+++ b/api/youtube/live.js
@@ -1,11 +1,88 @@
 // YouTube Live Stream Detection API
-// Uses YouTube's oembed endpoint to check for live streams
+// Uses residential proxy to bypass YouTube's datacenter IP blocking
 
 import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+import http from 'node:http';
+import https from 'node:https';
+import zlib from 'node:zlib';
 
 export const config = {
-  runtime: 'edge',
+  maxDuration: 15,
 };
+
+const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36';
+
+// Parse proxy URL: http://user:pass@host:port
+function parseProxy(proxyUrl) {
+  if (!proxyUrl) return null;
+  try {
+    const u = new URL(proxyUrl);
+    return {
+      host: u.hostname,
+      port: parseInt(u.port, 10),
+      auth: u.username ? `${decodeURIComponent(u.username)}:${decodeURIComponent(u.password)}` : null,
+    };
+  } catch { return null; }
+}
+
+// Fetch via HTTP CONNECT proxy tunnel
+function fetchViaProxy(targetUrl, proxy) {
+  return new Promise((resolve, reject) => {
+    const target = new URL(targetUrl);
+    const connectOpts = {
+      host: proxy.host,
+      port: proxy.port,
+      method: 'CONNECT',
+      path: `${target.hostname}:443`,
+      headers: {},
+    };
+    if (proxy.auth) {
+      connectOpts.headers['Proxy-Authorization'] = 'Basic ' + Buffer.from(proxy.auth).toString('base64');
+    }
+    const connectReq = http.request(connectOpts);
+    connectReq.on('connect', (_res, socket) => {
+      const req = https.request({
+        hostname: target.hostname,
+        path: target.pathname + target.search,
+        method: 'GET',
+        headers: { 'User-Agent': CHROME_UA, 'Accept-Encoding': 'gzip, deflate' },
+        socket,
+        agent: false,
+      }, (res) => {
+        let stream = res;
+        const encoding = (res.headers['content-encoding'] || '').trim().toLowerCase();
+        if (encoding === 'gzip') stream = res.pipe(zlib.createGunzip());
+        else if (encoding === 'deflate') stream = res.pipe(zlib.createInflate());
+
+        const chunks = [];
+        stream.on('data', (c) => chunks.push(c));
+        stream.on('end', () => {
+          resolve({
+            ok: res.statusCode >= 200 && res.statusCode < 300,
+            status: res.statusCode,
+            text: () => Promise.resolve(Buffer.concat(chunks).toString()),
+            json: () => Promise.resolve(JSON.parse(Buffer.concat(chunks).toString())),
+          });
+        });
+        stream.on('error', reject);
+      });
+      req.on('error', reject);
+      req.end();
+    });
+    connectReq.on('error', reject);
+    connectReq.setTimeout(12000, () => { connectReq.destroy(); reject(new Error('Proxy timeout')); });
+    connectReq.end();
+  });
+}
+
+// Fetch YouTube - uses proxy if configured, otherwise direct fetch
+async function ytFetch(url) {
+  const proxy = parseProxy(process.env.YOUTUBE_PROXY_URL);
+  if (proxy) {
+    return fetchViaProxy(url, proxy);
+  }
+  return globalThis.fetch(url, { headers: { 'User-Agent': CHROME_UA, 'Accept-Encoding': 'gzip, deflate' }, redirect: 'follow' });
+}
 
 export default async function handler(request) {
   const cors = getCorsHeaders(request);
@@ -20,9 +97,8 @@ export default async function handler(request) {
   // Video ID lookup: resolve author name via oembed
   if (videoIdParam && /^[A-Za-z0-9_-]{11}$/.test(videoIdParam)) {
     try {
-      const oembedRes = await fetch(
+      const oembedRes = await ytFetch(
         `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoIdParam}&format=json`,
-        { headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36' } },
       );
       if (oembedRes.ok) {
         const data = await oembedRes.json();
@@ -46,16 +122,10 @@ export default async function handler(request) {
   }
 
   try {
-    // Try to fetch the channel's live page
     const channelHandle = channel.startsWith('@') ? channel : `@${channel}`;
     const liveUrl = `https://www.youtube.com/${channelHandle}/live`;
 
-    const response = await fetch(liveUrl, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
-      },
-      redirect: 'follow',
-    });
+    const response = await ytFetch(liveUrl);
 
     if (!response.ok) {
       return new Response(JSON.stringify({ videoId: null, channelExists: false }), {
@@ -66,10 +136,8 @@ export default async function handler(request) {
 
     const html = await response.text();
 
-    // Channel exists if the page contains canonical channel metadata
     const channelExists = html.includes('"channelId"') || html.includes('og:url');
 
-    // Extract channel name from page metadata (prefer channel name over video title)
     let channelName = null;
     const ownerMatch = html.match(/"ownerChannelName"\s*:\s*"([^"]+)"/);
     if (ownerMatch) {
@@ -79,8 +147,6 @@ export default async function handler(request) {
       if (authorMatch) channelName = authorMatch[1];
     }
 
-    // Scope both fields to the same videoDetails block so we don't
-    // combine a videoId from one object with isLive from another.
     let videoId = null;
     const detailsIdx = html.indexOf('"videoDetails"');
     if (detailsIdx !== -1) {
@@ -92,8 +158,6 @@ export default async function handler(request) {
       }
     }
 
-    // Extract HLS manifest URL for native playback (available for live streams).
-    // The URL is in streamingData and contains a signed googlevideo.com manifest.
     let hlsUrl = null;
     const hlsMatch = html.match(/"hlsManifestUrl"\s*:\s*"([^"]+)"/);
     if (hlsMatch && videoId) {
@@ -103,6 +167,7 @@ export default async function handler(request) {
     return new Response(JSON.stringify({ videoId, isLive: videoId !== null, channelExists, channelName, hlsUrl }), {
       status: 200,
       headers: {
+        ...cors,
         'Content-Type': 'application/json',
         'Cache-Control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=60',
       },
@@ -111,7 +176,7 @@ export default async function handler(request) {
     console.error('YouTube live check error:', error);
     return new Response(JSON.stringify({ videoId: null, error: error.message }), {
       status: 200,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { ...cors, 'Content-Type': 'application/json' },
     });
   }
 }

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -89,7 +89,7 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   // Europe
   { id: 'bbc-news', name: 'BBC News', handle: '@BBCNews', fallbackVideoId: 'bjgQzJzCZKs' },
   { id: 'france24-en', name: 'France 24 English', handle: '@France24_en', fallbackVideoId: 'Ap-UM1O9RBU' },
-  { id: 'welt', name: 'WELT', handle: '@WELTVideoTV' },
+  { id: 'welt', name: 'WELT', handle: '@WELTVideoTV', fallbackVideoId: 'L-TNmYmaAKQ' },
   { id: 'rtve', name: 'RTVE 24H', handle: '@RTVENoticias', fallbackVideoId: '7_srED6k0bE' },
   { id: 'trt-haber', name: 'TRT Haber', handle: '@trthaber', fallbackVideoId: '3XHebGJG0bc' },
   { id: 'ntv-turkey', name: 'NTV', handle: '@NTV', fallbackVideoId: 'pqq5c6k70kk' },
@@ -109,13 +109,13 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'ntn24', name: 'NTN24', handle: '@NTN24' },
   { id: 't13', name: 'T13', handle: '@Teletrece' },
   // Asia
-  { id: 'tbs-news', name: 'TBS NEWS DIG', handle: '@tbsnewsdig', fallbackVideoId: '9tvIxaANcaY' },
+  { id: 'tbs-news', name: 'TBS NEWS DIG', handle: '@tbsnewsdig', fallbackVideoId: 'aUDm173E8k8' },
   { id: 'ann-news', name: 'ANN News', handle: '@ANNnewsCH' },
   { id: 'ntv-news', name: 'NTV News (Japan)', handle: '@ntv_news' },
   { id: 'cti-news', name: 'CTI News (Taiwan)', handle: '@中天新聞CtiNews', fallbackVideoId: 'wUPPkSANpyo', useFallbackOnly: true },
   { id: 'wion', name: 'WION', handle: '@WION' },
   { id: 'vtc-now', name: 'VTC NOW', handle: '@VTCNowOfficial' },
-  { id: 'cna-asia', name: 'CNA (NewsAsia)', handle: '@channelnewsasia' },
+  { id: 'cna-asia', name: 'CNA (NewsAsia)', handle: '@channelnewsasia', fallbackVideoId: 'XWq5kBlakcQ' },
   { id: 'nhk-world', name: 'NHK World Japan', handle: '@NHKWORLDJAPAN' },
   // Middle East
   { id: 'al-hadath', name: 'Al Hadath', handle: '@AlHadath', fallbackVideoId: 'xWXpl7azI8k', useFallbackOnly: true },
@@ -126,7 +126,7 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   // Africa
   { id: 'africanews', name: 'Africanews', handle: '@africanews' },
   { id: 'channels-tv', name: 'Channels TV', handle: '@ChannelsTelevision' },
-  { id: 'ktn-news', name: 'KTN News', handle: '@ktnnews_kenya' },
+  { id: 'ktn-news', name: 'KTN News', handle: '@ktnnews_kenya', fallbackVideoId: 'RmHtsdVb3mo' },
   { id: 'enca', name: 'eNCA', handle: '@eNCA' },
   { id: 'sabc-news', name: 'SABC News', handle: '@SABCDigitalNews' },
 ];


### PR DESCRIPTION
## Summary
- Switch `api/youtube/live.js` from edge runtime to Node.js serverless to enable proxy support
- Add HTTP CONNECT tunnel proxy via `YOUTUBE_PROXY_URL` env var (residential proxy bypasses YouTube's datacenter IP blocking)
- Add `zlib` decompression — YouTube returns empty body without `Accept-Encoding` header; `node:https` doesn't auto-decompress like `fetch`
- Add missing fallback video IDs for WELT, KTN News, CNA NewsAsia; update TBS NEWS DIG

## Context
PR #541 was merged before these commits landed. This PR contains the proxy + gzip changes that were missing.

## Required env var on Vercel
```
YOUTUBE_PROXY_URL=http://mJUHY3QN1MM4WWP0:wifi%3Bus%3B%3B%3B@proxy.froxy.com:9000
```

## Test plan
- [ ] Add `YOUTUBE_PROXY_URL` env var on Vercel
- [ ] Deploy and test `api.worldmonitor.app/api/youtube/live?channel=@BBCNews` returns `videoId` + `isLive: true`
- [ ] Verify channels that previously failed (WELT, KTN, CNA) now auto-detect live streams