### PR TITLE
feat(settings): add AVIATIONSTACK_API to desktop settings

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -27,7 +27,7 @@ const MENU_HELP_GITHUB_ID: &str = "help.github";
 #[cfg(feature = "devtools")]
 const MENU_HELP_DEVTOOLS_ID: &str = "help.devtools";
 const TRUSTED_WINDOWS: [&str; 3] = ["main", "settings", "live-channels"];
-const SUPPORTED_SECRET_KEYS: [&str; 22] = [
+const SUPPORTED_SECRET_KEYS: [&str; 23] = [
     "GROQ_API_KEY",
     "OPENROUTER_API_KEY",
     "FRED_API_KEY",
@@ -50,6 +50,7 @@ const SUPPORTED_SECRET_KEYS: [&str; 22] = [
     "OLLAMA_MODEL",
     "WORLDMONITOR_API_KEY",
     "WTO_API_KEY",
+    "AVIATIONSTACK_API",
 ];
 
 #[derive(Default)]

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -54,6 +54,7 @@ const SECRET_ANALYTICS_NAMES: Record<RuntimeSecretKey, string> = {
   OLLAMA_MODEL: 'ollama_model',
   WORLDMONITOR_API_KEY: 'worldmonitor',
   WTO_API_KEY: 'wto',
+  AVIATIONSTACK_API: 'aviationstack',
 };
 
 // ── Typed event schemas (allowlisted properties per event) ──

--- a/src/services/runtime-config.ts
+++ b/src/services/runtime-config.ts
@@ -23,7 +23,8 @@ export type RuntimeSecretKey =
   | 'OLLAMA_API_URL'
   | 'OLLAMA_MODEL'
   | 'WORLDMONITOR_API_KEY'
-  | 'WTO_API_KEY';
+  | 'WTO_API_KEY'
+  | 'AVIATIONSTACK_API';
 
 export type RuntimeFeatureId =
   | 'aiGroq'
@@ -42,7 +43,8 @@ export type RuntimeFeatureId =
   | 'nasaFirms'
   | 'aiOllama'
   | 'wtoTrade'
-  | 'supplyChain';
+  | 'supplyChain'
+  | 'aviationStack';
 
 export interface RuntimeFeatureDefinition {
   id: RuntimeFeatureId;
@@ -89,6 +91,7 @@ const defaultToggles: Record<RuntimeFeatureId, boolean> = {
   aiOllama: true,
   wtoTrade: true,
   supplyChain: true,
+  aviationStack: true,
 };
 
 export const RUNTIME_FEATURES: RuntimeFeatureDefinition[] = [
@@ -212,6 +215,13 @@ export const RUNTIME_FEATURES: RuntimeFeatureDefinition[] = [
     description: 'Shipping rates via FRED Baltic Dry Index. Chokepoints and minerals use public data.',
     requiredSecrets: ['FRED_API_KEY'],
     fallback: 'Chokepoints and minerals always available; shipping requires FRED key.',
+  },
+  {
+    id: 'aviationStack',
+    name: 'AviationStack flight delays',
+    description: 'Real-time international airport delay data from AviationStack API.',
+    requiredSecrets: ['AVIATIONSTACK_API'],
+    fallback: 'Non-US airports use simulated delay data.',
   },
 ];
 

--- a/src/services/settings-constants.ts
+++ b/src/services/settings-constants.ts
@@ -20,6 +20,7 @@ export const SIGNUP_URLS: Partial<Record<RuntimeSecretKey, string>> = {
   OLLAMA_API_URL: 'https://ollama.com/download',
   OLLAMA_MODEL: 'https://ollama.com/library',
   WTO_API_KEY: 'https://apiportal.wto.org/',
+  AVIATIONSTACK_API: 'https://aviationstack.com/signup/free',
 };
 
 export const PLAINTEXT_KEYS = new Set<RuntimeSecretKey>([
@@ -54,6 +55,7 @@ export const HUMAN_LABELS: Record<RuntimeSecretKey, string> = {
   OLLAMA_MODEL: 'Ollama Model',
   WORLDMONITOR_API_KEY: 'World Monitor License Key',
   WTO_API_KEY: 'WTO API Key',
+  AVIATIONSTACK_API: 'AviationStack API Key',
 };
 
 export interface SettingsCategory {
@@ -86,6 +88,6 @@ export const SETTINGS_CATEGORIES: SettingsCategory[] = [
   {
     id: 'tracking',
     label: 'Tracking & Sensing',
-    features: ['aisRelay', 'openskyRelay', 'wingbitsEnrichment', 'nasaFirms'],
+    features: ['aisRelay', 'openskyRelay', 'wingbitsEnrichment', 'nasaFirms', 'aviationStack'],
   },
 ];


### PR DESCRIPTION
## Summary
- Adds `AVIATIONSTACK_API` key to the desktop settings page so users can configure it via the UI
- Adds the key to Tauri keychain support (`SUPPORTED_SECRET_KEYS`), runtime config (type + feature toggle), settings UI (signup URL + label + category), and analytics tracking

## Changes
- `src-tauri/src/main.rs` — add to `SUPPORTED_SECRET_KEYS` array (22→23)
- `src/services/runtime-config.ts` — add `AVIATIONSTACK_API` to `RuntimeSecretKey`, `aviationStack` feature with fallback message
- `src/services/settings-constants.ts` — add signup URL + human label + tracking category entry
- `src/services/analytics.ts` — add analytics name mapping

## Context
Follow-up to #552 which integrated AviationStack API for non-US airport delays. Without this change, users cannot configure the API key through the desktop settings UI.

## Test plan
- [ ] Desktop app: Settings → Tracking & Sensing → AviationStack API Key field visible
- [ ] Key saves to keychain and persists across restart
- [ ] Without key: fallback message shown, simulated data used
- [ ] With key: real AviationStack data fetched for non-US airports