### PR TITLE
fix(live-news): use correct relay auth header for YouTube proxy

### DIFF
--- a/api/youtube/live.js
+++ b/api/youtube/live.js
@@ -8,7 +8,7 @@ export const config = {
 };
 
 const RELAY_URL = process.env.VITE_WS_API_URL || '';
-const RELAY_AUTH = process.env.RELAY_AUTH_TOKEN || '';
+const RELAY_AUTH = process.env.RELAY_SHARED_SECRET || '';
 
 export default async function handler(request) {
   const cors = getCorsHeaders(request);
@@ -37,7 +37,7 @@ export default async function handler(request) {
   if (RELAY_URL) {
     try {
       const relayHeaders = { 'User-Agent': 'WorldMonitor-Edge/1.0' };
-      if (RELAY_AUTH) relayHeaders['X-Relay-Auth'] = RELAY_AUTH;
+      if (RELAY_AUTH) relayHeaders['x-relay-key'] = RELAY_AUTH;
       const relayRes = await fetch(`${RELAY_URL}/youtube-live?${qs}`, { headers: relayHeaders });
       if (relayRes.ok) {
         const data = await relayRes.json();


### PR DESCRIPTION
## Summary
- Fix auth header mismatch between Vercel edge function and Railway relay for YouTube live detection
- Edge function was sending `X-Relay-Auth` header with `RELAY_AUTH_TOKEN` env var
- Railway relay expects `x-relay-key` header validated against `RELAY_SHARED_SECRET`
- This caused all relay requests to fail auth, falling back to direct YouTube scrape (which fails from datacenter IPs)

## Verified
- All 7 previously-failing channels confirmed working via Railway proxy: `@AlArabiya`, `@WELTVideoTV`, `@NTV`, `@todonoticias`, `@ktnnews_kenya`, `@tbsnewsdig`, `@channelnewsasia`
- `RELAY_SHARED_SECRET` already exists on both Railway and Vercel (shared env vars)

## Test plan
- [ ] Merge and deploy to Vercel
- [ ] Verify `https://worldmonitor.app/api/youtube/live?channel=@BBCNews` returns live data via relay (not fallback)
- [ ] Check all Live News panel channels load correctly