### PR TITLE
fix(i18n): rename OREF Sirens panel to Israel Sirens

### DIFF
--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -51,7 +51,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   climate: { name: 'Climate Anomalies', enabled: true, priority: 2 },
   'population-exposure': { name: 'Population Exposure', enabled: true, priority: 2 },
   'security-advisories': { name: 'Security Advisories', enabled: true, priority: 2 },
-  'oref-sirens': { name: 'OREF Sirens', enabled: true, priority: 2 },
+  'oref-sirens': { name: 'Israel Sirens', enabled: true, priority: 2 },
   'telegram-intel': { name: 'Telegram Intel', enabled: true, priority: 2 },
 };
 

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -205,7 +205,7 @@
     "geoHubs": "مراكز جيوسياسية",
     "liveWebcams": "كاميرات مباشرة",
     "securityAdvisories": "تنبيهات أمنية",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "استخبارات Telegram"
   },
   "modals": {
@@ -1329,15 +1329,15 @@
       "infoTooltip": "<strong>تنبيهات أمنية</strong><br>تحذيرات السفر والتنبيهات الأمنية من الوكالات الحكومية."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -205,7 +205,7 @@
     "geoHubs": "Geopolitical Hotspots",
     "liveWebcams": "Live-Webcams",
     "securityAdvisories": "Sicherheitshinweise",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Telegram-Nachrichten"
   },
   "modals": {
@@ -1329,15 +1329,15 @@
       "infoTooltip": "<strong>Sicherheitshinweise</strong><br>Reisewarnungen und Sicherheitshinweise von Regierungsbehörden."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -205,7 +205,7 @@
     "geoHubs": "Γεωπολιτικά Κέντρα",
     "liveWebcams": "Ζωντανές Κάμερες",
     "securityAdvisories": "Προειδοποιήσεις Ασφαλείας",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Πληροφορίες Telegram"
   },
   "modals": {
@@ -1356,15 +1356,15 @@
       "infoTooltip": "<strong>Προειδοποιήσεις Ασφαλείας</strong><br>Ταξιδιωτικές οδηγίες και προειδοποιήσεις ασφαλείας."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -188,7 +188,7 @@
     "climate": "Climate Anomalies",
     "populationExposure": "Population Exposure",
     "securityAdvisories": "Security Advisories",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Telegram Intel",
     "startups": "Startups & VC",
     "vcblogs": "VC Insights & Essays",
@@ -1117,15 +1117,15 @@
       "infoTooltip": "<strong>Security Advisories</strong><br>Travel advisories and security alerts from government foreign affairs agencies:<br><br><strong>Sources:</strong><br>\uD83C\uDDFA\uD83C\uDDF8 US State Dept Travel Advisories<br>\uD83C\uDDE6\uD83C\uDDFA AU DFAT Smartraveller<br>\uD83C\uDDEC\uD83C\uDDE7 UK FCDO Travel Advice<br>\uD83C\uDDF3\uD83C\uDDFF NZ MFAT SafeTravel<br><br><strong>Levels:</strong><br>\uD83D\uDFE5 Do Not Travel<br>\uD83D\uDFE7 Reconsider Travel<br>\uD83D\uDFE8 Exercise Caution<br>\uD83D\uDFE9 Normal Precautions"
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     },
     "satelliteFires": {
       "noData": "No fire data available",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -205,7 +205,7 @@
     "geoHubs": "Geopolitical Hotspots",
     "liveWebcams": "Cámaras en Vivo",
     "securityAdvisories": "Alertas de Seguridad",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Inteligencia Telegram"
   },
   "modals": {
@@ -1329,15 +1329,15 @@
       "infoTooltip": "<strong>Alertas de Seguridad</strong><br>Avisos de viaje y alertas de seguridad de agencias gubernamentales."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -205,7 +205,7 @@
     "geoHubs": "Centres géopolitiques",
     "liveWebcams": "Webcams en Direct",
     "securityAdvisories": "Avis de Sécurité",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Renseignement Telegram"
   },
   "modals": {
@@ -1329,15 +1329,15 @@
       "infoTooltip": "<strong>Avis de Sécurité</strong><br>Avis aux voyageurs et alertes de sécurité des agences gouvernementales."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -205,7 +205,7 @@
     "geoHubs": "Hotspot geopolitici",
     "liveWebcams": "Webcam in Diretta",
     "securityAdvisories": "Avvisi di Sicurezza",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Intelligence Telegram"
   },
   "modals": {
@@ -1329,15 +1329,15 @@
       "infoTooltip": "<strong>Avvisi di Sicurezza</strong><br>Avvisi di viaggio e allerte di sicurezza dalle agenzie governative."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -205,7 +205,7 @@
     "geoHubs": "地政学ハブ",
     "liveWebcams": "ライブカメラ",
     "securityAdvisories": "セキュリティアドバイザリー",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Telegram インテリジェンス"
   },
   "modals": {
@@ -1329,15 +1329,15 @@
       "infoTooltip": "<strong>セキュリティアドバイザリー</strong><br>各国政府の渡航情報と安全警告。"
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -186,7 +186,7 @@
     "climate": "기후 이상",
     "populationExposure": "인구 노출",
     "securityAdvisories": "보안 권고",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Telegram 인텔리전스",
     "startups": "스타트업 & VC",
     "vcblogs": "VC 인사이트 & 에세이",
@@ -1109,15 +1109,15 @@
       "infoTooltip": "<strong>보안 주의보</strong><br>각국 외교부의 여행 주의보 및 보안 경보:<br><br><strong>출처:</strong><br>🇺🇸 미 국무부 여행 주의보<br>🇦🇺 호주 DFAT Smartraveller<br>🇬🇧 영국 FCDO 여행 안내<br>🇳🇿 뉴질랜드 MFAT SafeTravel<br><br><strong>수준:</strong><br>🟥 여행 금지<br>🟧 여행 재고<br>🟨 주의 필요<br>🟩 일반 주의"
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     },
     "satelliteFires": {
       "noData": "화재 데이터 없음",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -64,7 +64,7 @@
     "climate": "Klimaatafwijkingen",
     "liveWebcams": "Live Webcams",
     "securityAdvisories": "Veiligheidsadviezen",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Telegram Inlichtingen"
   },
   "modals": {
@@ -1188,15 +1188,15 @@
       "infoTooltip": "<strong>Veiligheidsadviezen</strong><br>Reisadviezen en veiligheidswaarschuwingen van overheidsinstanties."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -205,7 +205,7 @@
     "geoHubs": "Geopolitical Hotspots",
     "liveWebcams": "Kamery na Żywo",
     "securityAdvisories": "Ostrzeżenia Bezpieczeństwa",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Wywiad Telegram"
   },
   "modals": {
@@ -1329,15 +1329,15 @@
       "infoTooltip": "<strong>Ostrzeżenia Bezpieczeństwa</strong><br>Ostrzeżenia podróżne i alerty bezpieczeństwa z agencji rządowych."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -64,7 +64,7 @@
     "climate": "Anomalias Climáticas",
     "liveWebcams": "Câmeras ao Vivo",
     "securityAdvisories": "Alertas de Segurança",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Inteligência Telegram"
   },
   "modals": {
@@ -1188,15 +1188,15 @@
       "infoTooltip": "<strong>Alertas de Segurança</strong><br>Avisos de viagem e alertas de segurança de agências governamentais."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -205,7 +205,7 @@
     "geoHubs": "Геополитические хабы",
     "liveWebcams": "Веб-камеры",
     "securityAdvisories": "Предупреждения безопасности",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Разведка Telegram"
   },
   "modals": {
@@ -1329,15 +1329,15 @@
       "infoTooltip": "<strong>Предупреждения безопасности</strong><br>Рекомендации по поездкам и предупреждения от государственных ведомств."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -64,7 +64,7 @@
     "climate": "Klimatanomalier",
     "liveWebcams": "Webbkameror",
     "securityAdvisories": "Säkerhetsvarningar",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Telegram Underrättelser"
   },
   "modals": {
@@ -1188,15 +1188,15 @@
       "infoTooltip": "<strong>Säkerhetsvarningar</strong><br>Resevarningar och säkerhetsmeddelanden från myndigheters utrikesdepartement."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -205,7 +205,7 @@
     "geoHubs": "ศูนย์กลางภูมิรัฐศาสตร์",
     "liveWebcams": "เว็บแคมสด",
     "securityAdvisories": "คำเตือนด้านความปลอดภัย",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "ข่าวกรอง Telegram"
   },
   "modals": {
@@ -1329,15 +1329,15 @@
       "infoTooltip": "<strong>คำเตือนด้านความปลอดภัย</strong><br>คำเตือนการเดินทางและความปลอดภัยจากหน่วยงานรัฐบาล."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -205,7 +205,7 @@
     "geoHubs": "Jeopolitik Merkezler",
     "liveWebcams": "Canli Web Kameralari",
     "securityAdvisories": "Güvenlik Uyarıları",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Telegram İstihbarat"
   },
   "modals": {
@@ -1329,15 +1329,15 @@
       "infoTooltip": "<strong>Güvenlik Uyarıları</strong><br>Hükümet kurumlarından seyahat uyarıları ve güvenlik bildirimleri."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -205,7 +205,7 @@
     "geoHubs": "Trung tâm Địa chính trị",
     "liveWebcams": "Webcam Trực tiếp",
     "securityAdvisories": "Cảnh báo An ninh",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Tình báo Telegram"
   },
   "modals": {
@@ -1329,15 +1329,15 @@
       "infoTooltip": "<strong>Cảnh báo An ninh</strong><br>Cảnh báo du lịch và an ninh từ các cơ quan chính phủ."
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -205,7 +205,7 @@
     "geoHubs": "地缘政治枢纽",
     "liveWebcams": "实时摄像头",
     "securityAdvisories": "安全警告",
-    "orefSirens": "OREF Sirens",
+    "orefSirens": "Israel Sirens",
     "telegramIntel": "Telegram 情报"
   },
   "modals": {
@@ -1329,15 +1329,15 @@
       "infoTooltip": "<strong>安全警告</strong><br>来自各国政府的旅行警告和安全提示。"
     },
     "orefSirens": {
-      "checking": "Checking OREF alerts...",
+      "checking": "Checking siren alerts...",
       "noAlerts": "No active sirens — all clear",
-      "notConfigured": "OREF proxy not configured",
+      "notConfigured": "Sirens service not configured",
       "activeSirens": "{{count}} active siren(s)",
       "area": "Area",
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
-      "infoTooltip": "<strong>OREF Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command (oref.org.il).<br><br>Data is polled every 10 seconds via a proxy relay. A pulsing red indicator means active sirens are sounding."
+      "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     }
   },
   "popups": {


### PR DESCRIPTION
## Summary
- Rename panel title from "OREF Sirens" to "Israel Sirens" across all 18 locales and panel config
- Remove internal implementation details from user-facing strings (proxy relay reference, oref.org.il URL)
- Update loading/error/tooltip text to use generic "siren alerts" / "Sirens service" wording

## Changes
| File | What changed |
|------|-------------|
| `src/config/panels.ts` | Panel name: "OREF Sirens" → "Israel Sirens" |
| `src/locales/*.json` (×18) | Panel title, checking msg, notConfigured msg, infoTooltip — all scrubbed of internal refs |

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Verify panel header shows "ISRAEL SIRENS" in the UI
- [ ] Verify info tooltip no longer mentions proxy relay or oref.org.il