### PR TITLE
fix(sentry): add noise filters and fix beforeSend null-filename leak

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ Sentry.init({
     /Java bridge method invocation error/,
     /Could not compile fragment shader/,
     /can't redefine non-configurable property/,
-    /Can.t find variable: (CONFIG|currentInset|NP)/,
+    /Can.t find variable: (CONFIG|currentInset|NP|webkit)/,
     /invalid origin/,
     /\.data\.split is not a function/,
     /signal is aborted without reason/,
@@ -114,7 +114,15 @@ Sentry.init({
     /AbortError: The user aborted a request/,
     /\w+ is not a function.*\/uv\/service\//,
     /__isInQueue__/,
-    /^(?:LIDNotifyId|onWebViewAppeared|onGetWiFiBSSID) is not defined$/,
+    /^(?:LIDNotify(?:Id)?|onWebViewAppeared|onGetWiFiBSSID) is not defined$/,
+    /signal timed out/,
+    /Se requiere plan premium/,
+    /hybridExecute is not defined/,
+    /reading 'postMessage'/,
+    /NotSupportedError/,
+    /appendChild.*Unexpected token/,
+    /\bmag is not defined\b/,
+    /evaluating '[^']*\.luma/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';
@@ -126,7 +134,7 @@ Sentry.init({
     }
     // Suppress any TypeError that happens entirely within maplibre or deck.gl internals
     if (/^TypeError:/.test(msg) && frames.length > 0) {
-      const nonSentryFrames = frames.filter(f => !/\/sentry-[A-Za-z0-9-]+\.js/.test(f.filename ?? ''));
+      const nonSentryFrames = frames.filter(f => f.filename && f.filename !== '<anonymous>' && !/\/sentry-[A-Za-z0-9-]+\.js/.test(f.filename));
       if (nonSentryFrames.length > 0 && nonSentryFrames.every(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9-]+\.js/.test(f.filename ?? ''))) return null;
     }
     // Suppress errors originating entirely from blob: URLs (browser extensions)


### PR DESCRIPTION
## Summary
- Triaged 14 unresolved Sentry issues — all NOISE, 0 actionable
- Added 8 new `ignoreErrors` patterns for: signal timeout, premium gate (capital-flow.es), OEM WebView bridge injections (hybridExecute, mag, webkit), null postMessage, NotSupportedError, appendChild injection, luma assignment
- Fixed `LIDNotify` regex to also match `LIDNotifyId` variant
- **Key fix**: `beforeSend` was leaking deck.gl TypeErrors (WM-4C: 28 events, 8 users) because frames with `null`/`<anonymous>` filenames weren't stripped — they broke the "all frames in deck-stack" check

## Issues Resolved
| ShortID | Error | Events | Fix |
|---------|-------|--------|-----|
| WM-67, WM-5Z | `t.luma=s` null access | 2 | `ignoreErrors` + `beforeSend` fix |
| WM-66 | `signal timed out` | 1 | `ignoreErrors` |
| WM-65 | IDB connection closing | 1 | Already filtered (capital-flow.es) |
| WM-64 | Premium gate (Spanish) | 2 | `ignoreErrors` |
| WM-63 | `hybridExecute` | 1 | `ignoreErrors` |
| WM-2S | `postMessage` null | 7 | `ignoreErrors` |
| WM-62 | NotSupportedError | 1 | `ignoreErrors` |
| WM-61 | `LIDNotify` | 1 | Regex fix |
| WM-60 | `e.write` undefined | 1 | `beforeSend` fix |
| WM-5Y | appendChild injection | 1 | `ignoreErrors` |
| WM-5X | `mag` undefined (QQ) | 1 | `ignoreErrors` |
| WM-4C | `_drawLayers` null | 28 | `beforeSend` fix |
| WM-5W | `webkit` undefined | 4 | Regex fix |

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 14 issues resolved in Sentry with `inNextRelease: true` — will auto-reopen if patterns miss