### PR TITLE
fix(relay): upstreamWs → upstreamSocket in graceful shutdown

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3020,8 +3020,8 @@ async function gracefulShutdown(signal) {
     } catch {}
     telegramState.client = null;
   }
-  if (upstreamWs) {
-    try { upstreamWs.close(); } catch {}
+  if (upstreamSocket) {
+    try { upstreamSocket.close(); } catch {}
   }
   server.close(() => process.exit(0));
   setTimeout(() => process.exit(0), 5000);


### PR DESCRIPTION
ReferenceError crash in gracefulShutdown: referenced `upstreamWs` but the actual variable is `upstreamSocket` (defined at line 2859). Causes SIGTERM handler to crash instead of cleanly shutting down.