### PR TITLE
fix(relay): install curl in Railway container for OREF polling

### DIFF
--- a/scripts/nixpacks.toml
+++ b/scripts/nixpacks.toml
@@ -1,0 +1,2 @@
+[phases.setup]
+aptPkgs = ["curl"]


### PR DESCRIPTION
`spawnSync curl ENOENT` — Railway's Nixpacks Node.js image doesn't include curl.
OREF polling needs curl to bypass Akamai JA3 TLS fingerprint blocking.

Adds `scripts/nixpacks.toml` with `aptPkgs = ["curl"]`.