### PR TITLE
fix(relay): replace nixpacks.toml with railpack.json for curl

### DIFF
--- a/railpack.json
+++ b/railpack.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.railpack.com",
+  "deploy": {
+    "aptPackages": ["curl"]
+  }
+}

--- a/scripts/nixpacks.toml
+++ b/scripts/nixpacks.toml
@@ -1,2 +1,0 @@
-[phases.setup]
-aptPkgs = ["curl"]


### PR DESCRIPTION
## Summary
- Remove `scripts/nixpacks.toml` (silently skipped by Railpack builder)
- Add `railpack.json` at repo root with `deploy.aptPackages: ["curl"]`

## Problem
Railway build log showed:
```
skipping 'nixpacks.toml' at 'scripts/nixpacks.toml' as it is not rooted at a valid path
```
Railway uses Railpack (not Nixpacks). The `nixpacks.toml` was ignored entirely, so `curl` was never installed — OREF polling fails with `spawnSync curl ENOENT`.

## Fix
Railpack uses `railpack.json` ([docs](https://railpack.com/config/file/)) with `deploy.aptPackages` for runtime system packages.

## Test plan
- [ ] Merge and check Railway build log for `install apt packages: curl`
- [ ] Verify OREF poll no longer shows `ENOENT`