### PR TITLE
fix(webcams): replace duplicate feed, rename Iran tab to IRAN ATTACKS

### DIFF
--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -19,10 +19,9 @@ interface WebcamFeed {
 // Verified YouTube live stream IDs — validated Feb 2026 via title cross-check.
 // IDs may rotate; update when stale.
 const WEBCAM_FEEDS: WebcamFeed[] = [
-  // Iran focus — Tehran, Middle East overview, Jerusalem
+  // Iran Attacks — Tehran, Tel Aviv, Jerusalem
   { id: 'iran-tehran', city: 'Tehran', country: 'Iran', region: 'iran', channelHandle: '@IranHDCams', fallbackVideoId: '-zGuR1qVKrU' },
-  { id: 'iran-mideast', city: 'Middle East', country: 'Middle East', region: 'iran', channelHandle: '@MiddleEastLive', fallbackVideoId: '4E-iFtUM2kk' },
-  { id: 'iran-tehran2', city: 'Tehran', country: 'Iran', region: 'iran', channelHandle: '@IranHDCams', fallbackVideoId: '-zGuR1qVKrU' },
+  { id: 'iran-telaviv', city: 'Tel Aviv', country: 'Israel', region: 'iran', channelHandle: '@IsraelLiveCam', fallbackVideoId: '-VLcYT5QBrY' },
   { id: 'iran-jerusalem', city: 'Jerusalem', country: 'Israel', region: 'iran', channelHandle: '@JerusalemLive', fallbackVideoId: 'JHwwZRH2wz8' },
   // Middle East — Jerusalem & Tehran adjacent (conflict hotspots)
   { id: 'jerusalem', city: 'Jerusalem', country: 'Israel', region: 'middle-east', channelHandle: '@TheWesternWall', fallbackVideoId: 'UyduhBUpO7Q' },

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -468,7 +468,7 @@
   "components": {
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "الكل",
         "mideast": "الشرق الأوسط",
         "europe": "أوروبا",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -477,7 +477,7 @@
     },
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "ALLE",
         "mideast": "NAHOST",
         "europe": "EUROPA",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -495,7 +495,7 @@
   "components": {
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "ΟΛΑ",
         "mideast": "Μ. ΑΝΑΤΟΛΗ",
         "europe": "ΕΥΡΩΠΗ",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -503,7 +503,7 @@
   "components": {
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "ALL",
         "mideast": "MIDEAST",
         "europe": "EUROPE",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -477,7 +477,7 @@
     },
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "TODOS",
         "mideast": "MEDIO ORIENTE",
         "europe": "EUROPA",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -477,7 +477,7 @@
     },
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "TOUS",
         "mideast": "MOYEN-ORIENT",
         "europe": "EUROPE",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -477,7 +477,7 @@
     },
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "TUTTE",
         "mideast": "MEDIORIENTE",
         "europe": "EUROPA",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -468,7 +468,7 @@
   "components": {
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "すべて",
         "mideast": "中東",
         "europe": "ヨーロッパ",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -497,7 +497,7 @@
   "components": {
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "전체",
         "mideast": "중동",
         "europe": "유럽",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -336,7 +336,7 @@
     },
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "ALLE",
         "mideast": "MIDDEN-OOSTEN",
         "europe": "EUROPA",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -477,7 +477,7 @@
     },
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "WSZYSTKIE",
         "mideast": "BLISKI WSCHÓD",
         "europe": "EUROPA",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -336,7 +336,7 @@
     },
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "TODAS",
         "mideast": "ORIENTE MÉDIO",
         "europe": "EUROPA",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -477,7 +477,7 @@
     },
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "ВСЕ",
         "mideast": "БЛИЖНИЙ ВОСТОК",
         "europe": "ЕВРОПА",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -336,7 +336,7 @@
     },
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "ALLA",
         "mideast": "MELLANÖSTERN",
         "europe": "EUROPA",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -468,7 +468,7 @@
   "components": {
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "ทั้งหมด",
         "mideast": "ตะวันออกกลาง",
         "europe": "ยุโรป",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -468,7 +468,7 @@
   "components": {
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "TUMU",
         "mideast": "ORTA DOGU",
         "europe": "AVRUPA",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -468,7 +468,7 @@
   "components": {
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "TẤT CẢ",
         "mideast": "TRUNG ĐÔNG",
         "europe": "CHÂU ÂU",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -468,7 +468,7 @@
   "components": {
     "webcams": {
       "regions": {
-        "iran": "IRAN",
+        "iran": "IRAN ATTACKS",
         "all": "全部",
         "mideast": "中东",
         "europe": "欧洲",


### PR DESCRIPTION
## Summary
- Remove duplicate `iran-tehran2` feed (identical channel + video as `iran-tehran`)
- Remove `iran-mideast` feed
- Add Tel Aviv feed (`-VLcYT5QBrY`) to the Iran tab
- Rename tab label from "IRAN" → "IRAN ATTACKS" across all 18 locales

Follows up on #569.

## Test plan
- [ ] Verify Iran Attacks tab shows 3 feeds: Tehran, Tel Aviv, Jerusalem
- [ ] Verify tab label reads "IRAN ATTACKS"