### PR TITLE
feat(cii): hook security advisories into CII scoring & country briefs

### DIFF
--- a/src/app/app-context.ts
+++ b/src/app/app-context.ts
@@ -1,6 +1,7 @@
 import type { NewsItem, Monitor, PanelConfig, MapLayers, InternetOutage, SocialUnrestEvent, MilitaryFlight, MilitaryFlightCluster, MilitaryVessel, MilitaryVesselCluster, CyberThreat, USNIFleetReport } from '@/types';
 import type { AirportDelayAlert } from '@/services/aviation';
 import type { IranEvent } from '@/generated/client/worldmonitor/conflict/v1/service_client';
+import type { SecurityAdvisory } from '@/services/security-advisories';
 import type { MapContainer, Panel, NewsPanel, SignalModal, StatusPanel, SearchModal } from '@/components';
 import type { IntelligenceGapBadge } from '@/components';
 import type { MarketData, ClusteredEvent } from '@/types';
@@ -38,6 +39,8 @@ export interface CountryBriefSignals {
   orefSirens: number;
   orefHistory24h: number;
   aviationDisruptions: number;
+  travelAdvisories: number;
+  travelAdvisoryMaxLevel: string | null;
   isTier1: boolean;
 }
 
@@ -50,6 +53,7 @@ export interface IntelligenceCache {
   usniFleet?: USNIFleetReport;
   iranEvents?: IranEvent[];
   orefAlerts?: { alertCount: number; historyCount24h: number };
+  advisories?: SecurityAdvisory[];
 }
 
 export interface AppModule {

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -66,7 +66,7 @@ import { updateAndCheck } from '@/services/temporal-baseline';
 import { fetchAllFires, flattenFires, computeRegionStats, toMapFires } from '@/services/wildfires';
 import { analyzeFlightsForSurge, surgeAlertToSignal, detectForeignMilitaryPresence, foreignPresenceToSignal, type TheaterPostureSummary } from '@/services/military-surge';
 import { fetchCachedTheaterPosture } from '@/services/cached-theater-posture';
-import { ingestProtestsForCII, ingestMilitaryForCII, ingestNewsForCII, ingestOutagesForCII, ingestConflictsForCII, ingestUcdpForCII, ingestHapiForCII, ingestDisplacementForCII, ingestClimateForCII, ingestStrikesForCII, ingestOrefForCII, ingestAviationForCII, isInLearningMode } from '@/services/country-instability';
+import { ingestProtestsForCII, ingestMilitaryForCII, ingestNewsForCII, ingestOutagesForCII, ingestConflictsForCII, ingestUcdpForCII, ingestHapiForCII, ingestDisplacementForCII, ingestClimateForCII, ingestStrikesForCII, ingestOrefForCII, ingestAviationForCII, ingestAdvisoriesForCII, isInLearningMode } from '@/services/country-instability';
 import { dataFreshness, type DataSourceId } from '@/services/data-freshness';
 import { fetchConflictEvents, fetchUcdpClassifications, fetchHapiSummary, fetchUcdpEvents, deduplicateAgainstAcled, fetchIranEvents } from '@/services/conflict';
 import { fetchUnhcrPopulation } from '@/services/displacement';
@@ -1940,6 +1940,8 @@ export class DataLoaderManager implements AppModule {
       const result = await fetchSecurityAdvisories();
       if (result.ok) {
         (this.ctx.panels['security-advisories'] as SecurityAdvisoriesPanel)?.setData(result.advisories);
+        this.ctx.intelligenceCache.advisories = result.advisories;
+        ingestAdvisoriesForCII(result.advisories);
       }
     } catch (error) {
       console.error('[App] Security advisories fetch failed:', error);

--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -182,6 +182,15 @@ export class CountryBriefPage {
     if (signals.climateStress > 0) chips.push(`<span class="signal-chip climate">🌡️ ${t('modals.countryBrief.signals.climate')}</span>`);
     if (signals.conflictEvents > 0) chips.push(`<span class="signal-chip conflict">⚔️ ${signals.conflictEvents} ${t('modals.countryBrief.signals.conflictEvents')}</span>`);
     if (signals.activeStrikes > 0) chips.push(`<span class="signal-chip conflict">\u{1F4A5} ${signals.activeStrikes} ${t('modals.countryBrief.signals.activeStrikes')}</span>`);
+    if (signals.travelAdvisories > 0 && signals.travelAdvisoryMaxLevel) {
+      const advisoryClass = signals.travelAdvisoryMaxLevel === 'do-not-travel' ? 'conflict'
+        : signals.travelAdvisoryMaxLevel === 'reconsider' ? 'outage'
+        : 'military';
+      const advisoryLabel = signals.travelAdvisoryMaxLevel === 'do-not-travel' ? 'Do Not Travel'
+        : signals.travelAdvisoryMaxLevel === 'reconsider' ? 'Reconsider Travel'
+        : 'Exercise Caution';
+      chips.push(`<span class="signal-chip ${advisoryClass}">\u26A0\uFE0F ${signals.travelAdvisories} Advisory: ${advisoryLabel}</span>`);
+    }
     if (signals.orefSirens > 0) chips.push(`<span class="signal-chip conflict">\u{1F6A8} ${signals.orefSirens} Active Sirens</span>`);
     if (signals.aviationDisruptions > 0) chips.push(`<span class="signal-chip outage">\u{1F6AB} ${signals.aviationDisruptions} ${t('modals.countryBrief.signals.aviationDisruptions')}</span>`);
     chips.push(`<span class="signal-chip stock-loading">📈 ${t('modals.countryBrief.loadingIndex')}</span>`);
@@ -613,6 +622,8 @@ export class CountryBriefPage {
         orefSirens: this.currentSignals.orefSirens,
         orefHistory24h: this.currentSignals.orefHistory24h,
         aviationDisruptions: this.currentSignals.aviationDisruptions,
+        travelAdvisories: this.currentSignals.travelAdvisories,
+        travelAdvisoryMaxLevel: this.currentSignals.travelAdvisoryMaxLevel,
       };
     }
     if (this.currentBrief) data.brief = this.currentBrief;

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -75,7 +75,7 @@ export interface CountryBriefExport {
   level?: string;
   trend?: string;
   components?: { unrest: number; conflict: number; security: number; information: number };
-  signals?: Record<string, number>;
+  signals?: Record<string, number | string | null>;
   brief?: string;
   headlines?: Array<{ title: string; source: string; link: string; pubDate?: string }>;
   generatedAt: string;


### PR DESCRIPTION
## Summary

- Travel advisories from US, AU, UK, NZ governments now act as a **floor and boost** on CII scores — a country with "Do Not Travel" from multiple governments can no longer show as "low"
- Advisory signal chips appear in country brief pages with level-appropriate color coding
- Advisory context is passed to AI brief generation for richer narratives

## Scoring Impact

| Level | Boost | Floor | Effect |
|-------|-------|-------|--------|
| Do Not Travel | +15 (+5 if 3+ govts) | 60 | Minimum "elevated" |
| Reconsider | +10 (+3 if 2+ govts) | 50 | Minimum "normal" |
| Caution | +5 | — | Mild bump |

## Changes (7 files, +130/-20)

- **`security-advisories.ts`** — Extract target country from advisory titles via embassy feed tags + country name matching
- **`country-instability.ts`** — `ingestAdvisoriesForCII()`, `getAdvisoryBoost()`, `getAdvisoryFloor()` wired into both `calculateCII()` and `getCountryScore()`
- **`app-context.ts`** — `IntelligenceCache.advisories`, `CountryBriefSignals.travelAdvisories/travelAdvisoryMaxLevel`
- **`data-loader.ts`** — Store advisories in cache + call CII ingest
- **`country-intel.ts`** — Count advisories per country, add to brief context + fallback text
- **`CountryBriefPage.ts`** — Advisory signal chip (red/yellow/blue by level)
- **`export.ts`** — Widen signals type for new string field

## Test plan

- [ ] `npx tsc --noEmit` passes (verified)
- [ ] `npm run build` succeeds (verified)
- [ ] Click a country with known advisories (Syria, Yemen, Iraq) → advisory chip visible in brief
- [ ] CII panel: countries with Do Not Travel show score ≥60
- [ ] Countries with no advisories → no chip, no score impact
- [ ] SecurityAdvisoriesPanel still renders correctly