### PR TITLE
fix(sentry): guard setView against invalid preset + filter translateNotifyError

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -3511,8 +3511,9 @@ export class DeckGLMap {
   }
 
   public setView(view: DeckMapView): void {
-    this.state.view = view;
     const preset = VIEW_PRESETS[view];
+    if (!preset) return;
+    this.state.view = view;
 
     if (this.maplibreMap) {
       this.maplibreMap.flyTo({

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,6 +123,7 @@ Sentry.init({
     /appendChild.*Unexpected token/,
     /\bmag is not defined\b/,
     /evaluating '[^']*\.luma/,
+    /translateNotifyError/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary
- **WM-68 (ACTIONABLE)**: `DeckGLMap.setView()` crashed with `TypeError: Cannot read properties of undefined (reading 'longitude')` when the view select had an invalid value. Added null guard on `VIEW_PRESETS[view]`.
- **WM-69 (NOISE)**: Google Translate widget injection (`translateNotifyError`). Added `ignoreErrors` filter.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Both issues resolved in Sentry with `inNextRelease: true`