### PR TITLE
fix(aviation): add AUH, DOH, IST, ICN to busyAirports simulation

### DIFF
--- a/server/worldmonitor/aviation/v1/_shared.ts
+++ b/server/worldmonitor/aviation/v1/_shared.ts
@@ -426,7 +426,7 @@ export function buildNotamAlert(airport: MonitoredAirport, reason: string): Airp
 export function generateSimulatedDelay(airport: typeof MONITORED_AIRPORTS[number]): AirportDelayAlert | null {
   const hour = new Date().getUTCHours();
   const isRushHour = (hour >= 6 && hour <= 10) || (hour >= 16 && hour <= 20);
-  const busyAirports = ['LHR', 'CDG', 'FRA', 'JFK', 'LAX', 'ORD', 'PEK', 'HND', 'DXB', 'SIN'];
+  const busyAirports = ['LHR', 'CDG', 'FRA', 'JFK', 'LAX', 'ORD', 'PEK', 'HND', 'DXB', 'SIN', 'AUH', 'DOH', 'IST', 'ICN'];
   const isBusy = busyAirports.includes(airport.iata);
   const random = Math.random();
   const delayChance = isRushHour ? 0.35 : 0.15;


### PR DESCRIPTION
## Summary

- Abu Dhabi (AUH), Doha (DOH), Istanbul (IST), and Incheon (ICN) added to `busyAirports` list in simulated delay generation
- These top-20 global hubs were missing the 1.5x delay probability multiplier, causing them to frequently show no data when using the computed simulation fallback (no AviationStack API key)

## Test plan

- [ ] Type check passes
- [ ] After deploy, AUH and DOH should appear in aviation delay data alongside DXB