### PR TITLE
fix(telegram): add missing relay auth headers to feed proxy

### DIFF
--- a/api/telegram-feed.js
+++ b/api/telegram-feed.js
@@ -49,9 +49,17 @@ export default async function handler(req) {
   if (topic) relayUrl.searchParams.set('topic', topic);
   if (channel) relayUrl.searchParams.set('channel', channel);
 
+  const fetchHeaders = { 'Accept': 'application/json' };
+  const relaySecret = process.env.RELAY_SHARED_SECRET || '';
+  if (relaySecret) {
+    const relayHeader = (process.env.RELAY_AUTH_HEADER || 'x-relay-key').toLowerCase();
+    fetchHeaders[relayHeader] = relaySecret;
+    fetchHeaders.Authorization = `Bearer ${relaySecret}`;
+  }
+
   try {
     const res = await fetchWithTimeout(relayUrl.toString(), {
-      headers: { 'Accept': 'application/json' },
+      headers: fetchHeaders,
     }, 25000);
 
     const text = await res.text();


### PR DESCRIPTION
## Summary
- `api/telegram-feed.js` was the only edge function proxying to Railway without `RELAY_SHARED_SECRET` auth headers
- Relay returns 401 for all non-public routes → panel always got error → "No messages available"
- Added the same auth pattern used by all other relay proxies (`oref-alerts.js`, `rss-proxy.js`, `opensky.js`, etc.)

## Test plan
- [ ] Deploy to Vercel → hit `/api/telegram-feed` → returns items array with data
- [ ] Telegram Intel panel shows messages instead of "No messages available"