### PR TITLE
fix(aviation): replace broken lock with direct cache + cancellation tiers

### DIFF
--- a/server/worldmonitor/aviation/v1/_shared.ts
+++ b/server/worldmonitor/aviation/v1/_shared.ts
@@ -298,6 +298,12 @@ function aggregateFlights(
   } else if (cancelledPct >= 50 && total >= MIN_FLIGHTS_FOR_CLOSURE) {
     severity = 'major'; delayType = 'ground_stop';
     reason = `${Math.round(cancelledPct)}% flights cancelled`;
+  } else if (cancelledPct >= 20 && total >= MIN_FLIGHTS_FOR_CLOSURE) {
+    severity = 'moderate'; delayType = 'ground_delay';
+    reason = `${Math.round(cancelledPct)}% flights cancelled`;
+  } else if (cancelledPct >= 10 && total >= MIN_FLIGHTS_FOR_CLOSURE) {
+    severity = 'minor'; delayType = 'general';
+    reason = `${Math.round(cancelledPct)}% flights cancelled`;
   } else if (avgDelay > 0) {
     severity = determineSeverity(avgDelay, delayedPct);
     delayType = avgDelay >= 60 ? 'ground_delay' : 'general';
@@ -366,6 +372,11 @@ export async function fetchNotamClosures(
       });
       if (!resp.ok) {
         console.warn(`[Aviation] NOTAM batch ${i / batchSize + 1}: HTTP ${resp.status}`);
+        continue;
+      }
+      const contentType = resp.headers.get('content-type') || '';
+      if (contentType.includes('text/html')) {
+        console.warn(`[Aviation] NOTAM batch ${i / batchSize + 1}: got HTML instead of JSON (API may be down or key invalid)`);
         continue;
       }
       const notams = await resp.json() as IcaoNotam[];


### PR DESCRIPTION
## Summary
- **Root cause**: Redis SETNX lock waited 3s but AviationStack takes ~25s for 50 airports → every lock-loser fell back to simulation → real API data was never served
- **Fix**: Replace `fetchIntlWithLock`/`tryAcquireLock` with direct `getCachedJson`/`setCachedJson` and conditional TTL (30min real, 5min simulation)
- **Cancellation tiers**: DXB at 32% cancelled was silently dropped (null). Added ≥20% → moderate, ≥10% → minor thresholds
- **NOTAM defense**: ICAO CloudFront returns HTML challenge pages from Vercel IPs — added content-type check before JSON parse

## Verified with live API
```
AUH: 100 flights, 92 cancelled → severe closure ✓
DXB: 100 flights, 32 cancelled → moderate ✓ (was null before)
DOH: 100 flights, 2 cancelled  → no alert ✓ (correct)
NOTAM: returns valid JSON locally, HTML from Vercel IPs (handled gracefully)
```

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Deploy → check Vercel logs for `[Aviation] AviationStack OK:` instead of `falling back to simulation`
- [ ] AUH should show severe closure alert in aviation panel
- [ ] DXB should show moderate delay (32% cancelled) instead of simulated data
- [ ] NOTAM errors should log clean warning, not JSON parse crash

Supersedes #589