### PR TITLE
fix(relay): stop Polymarket cache stampede from concurrent limit + CDN bypass

### DIFF
--- a/src/services/prediction/index.ts
+++ b/src/services/prediction/index.ts
@@ -122,9 +122,12 @@ async function polyFetch(endpoint: 'events' | 'markets', params: Record<string, 
     } catch { /* Tauri command failed, fall through to proxy */ }
   }
 
-  // Proxy params (expects 'tag' not 'tag_slug' for Vercel handler)
+  // Proxy params — strip fields the relay ignores (end_date_min, active, archived)
+  // to keep the URL deterministic for CDN caching.
+  const PROXY_STRIP_KEYS = new Set(['end_date_min', 'active', 'archived']);
   const proxyParams: Record<string, string> = { endpoint };
   for (const [k, v] of Object.entries(params)) {
+    if (PROXY_STRIP_KEYS.has(k)) continue;
     proxyParams[k === 'tag_slug' ? 'tag' : k] = v;
   }
   const proxyQs = new URLSearchParams(proxyParams).toString();


### PR DESCRIPTION
## Summary
- **Concurrent limit was poisoning cache**: 11 Polymarket tags fire via `Promise.all` but `MAX_CONCURRENT=3` — the other 8 tags were silently rejected with negative cache (`[]` for 5 min). Those tags could never get positive cache because they were always re-throttled. Replaced reject-with-negative-cache with a proper async queue that waits for a slot.
- **Cache key fragmentation**: `fetchPredictions` (limit=20) and `fetchCountryMarkets` (limit=30) created separate cache entries for the same tag. Normalized to canonical `limit=50` upstream so all callers share one cache entry per tag.
- **CDN bypass**: `end_date_min: new Date().toISOString()` in every proxy URL made each request a unique CDN key, preventing Vercel edge caching entirely. Stripped `end_date_min`, `active`, `archived` from proxy params (relay already ignores them).

**Expected result**: After deploy, you should see 11 MISS entries on startup (cold cache), then all HITs for 10 minutes. No more continuous MISS every 5 seconds.

## Test plan
- [ ] Deploy and check Railway logs — should see initial burst of MISS, then silence (all HITs)
- [ ] Verify Polymarket panel still shows data on frontend
- [ ] Check `/status` endpoint — `polymarket` cache size should stabilize (~15 entries, not growing)
- [ ] Multiple browser tabs loading simultaneously should not cause repeated MISSes