### PR TITLE
fix(polymarket): add queue backpressure and response limit slicing

### DIFF
--- a/src/services/prediction/index.ts
+++ b/src/services/prediction/index.ts
@@ -59,6 +59,7 @@ const DIRECT_RAILWAY_POLY_URL = wsRelayUrl
   ? wsRelayUrl.replace('wss://', 'https://').replace('ws://', 'http://').replace(/\/$/, '') + '/polymarket'
   : '';
 const isLocalhostRuntime = typeof window !== 'undefined' && ['localhost', '127.0.0.1'].includes(window.location.hostname);
+const PROXY_STRIP_KEYS = new Set(['end_date_min', 'active', 'archived']);
 
 const breaker = createCircuitBreaker<PredictionMarket[]>({ name: 'Polymarket', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
 
@@ -122,9 +123,6 @@ async function polyFetch(endpoint: 'events' | 'markets', params: Record<string, 
     } catch { /* Tauri command failed, fall through to proxy */ }
   }
 
-  // Proxy params — strip fields the relay ignores (end_date_min, active, archived)
-  // to keep the URL deterministic for CDN caching.
-  const PROXY_STRIP_KEYS = new Set(['end_date_min', 'active', 'archived']);
   const proxyParams: Record<string, string> = { endpoint };
   for (const [k, v] of Object.entries(params)) {
     if (PROXY_STRIP_KEYS.has(k)) continue;


### PR DESCRIPTION
## Summary
Follow-up to #592 (code review fixes that landed after the PR was merged).

- **Queue backpressure**: `POLYMARKET_MAX_QUEUED=20` cap prevents unbounded queue growth under sustained load — excess requests get negative-cached instead of queuing indefinitely
- **Response limit slicing**: `requestedLimit` was declared but never used — callers requesting `limit=20` were getting full 50-item upstream payloads. Now `sliceToLimit()` trims responses to the requested size
- **Module-level constant**: Hoisted `PROXY_STRIP_KEYS` Set from per-call allocation to module level in `prediction/index.ts`

## Test plan
- [ ] Verify Polymarket data loads correctly on dashboard
- [ ] Check Railway logs show no queue-related errors under normal load
- [ ] Confirm callers requesting limit=20 receive at most 20 items