### PR TITLE
fix(aviation): route NOTAM through Railway relay to fix timeout

### DIFF
--- a/server/worldmonitor/aviation/v1/list-airport-delays.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-delays.ts
@@ -94,6 +94,9 @@ export async function listAirportDelays(
     const cached = await getCachedJson(INTL_CACHE_KEY);
     if (cached && typeof cached === 'object' && 'alerts' in (cached as Record<string, unknown>)) {
       intlAlerts = (cached as { alerts: AirportDelayAlert[] }).alerts;
+      const simCount = intlAlerts.filter(a => a.id.startsWith('sim-')).length;
+      const realCount = intlAlerts.length - simCount;
+      console.log(`[Aviation] Intl cache HIT: ${intlAlerts.length} alerts (${realCount} real, ${simCount} simulated)`);
     } else {
       const nonUs = MONITORED_AIRPORTS.filter(a => a.country !== 'USA');
       const apiKey = process.env.AVIATIONSTACK_API;


### PR DESCRIPTION
## Summary
- ICAO NOTAM API times out from Vercel edge (>10s) — confirmed in logs: `NOTAM batch 1: The operation was aborted due to timeout`
- Added `/notam` proxy endpoint to Railway relay (25s timeout, 30min local cache)
- `fetchNotamClosures` now routes through relay when `WS_RELAY_URL` is set, falls back to direct call (20s timeout)
- Added logging to distinguish real AviationStack alerts vs simulation in cache hits

## Deployment steps
1. Merge this PR
2. **Add `ICAO_API_KEY` env var to Railway relay** (same value as Vercel)
3. Railway redeploys automatically
4. Check relay logs for `[Relay] NOTAM:` entries

## Also check
- Is `AVIATIONSTACK_API` env var set on Vercel? If not, all intl alerts are simulation (random)
- After this fix, NOTAM will catch real closures for MENA airports even without AviationStack

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `node -c scripts/ais-relay.cjs` passes
- [ ] Deploy → check Vercel logs for `NOTAM: fetching via relay`
- [ ] Check Railway relay logs for `[Relay] NOTAM:` 
- [ ] MENA airports with active NOTAMs should show closure alerts