### PR TITLE
chore(telegram): update channel list

### DIFF
--- a/data/telegram-channels.json
+++ b/data/telegram-channels.json
@@ -23,15 +23,6 @@
         "maxMessages": 25
       },
       {
-        "handle": "air_alert_ua",
-        "label": "Повітряна Тривога",
-        "topic": "alerts",
-        "tier": 2,
-        "enabled": true,
-        "region": "ukraine",
-        "maxMessages": 20
-      },
-      {
         "handle": "AuroraIntel",
         "label": "Aurora Intel",
         "topic": "conflict",
@@ -176,15 +167,6 @@
         "maxMessages": 15
       },
       {
-        "handle": "nexta_live",
-        "label": "NEXTA Live",
-        "topic": "breaking",
-        "tier": 3,
-        "enabled": true,
-        "region": "europe",
-        "maxMessages": 15
-      },
-      {
         "handle": "nexta_tv",
         "label": "NEXTA",
         "topic": "politics",
@@ -232,6 +214,15 @@
       {
         "handle": "spectatorindex",
         "label": "The Spectator Index",
+        "topic": "breaking",
+        "tier": 3,
+        "enabled": true,
+        "region": "global",
+        "maxMessages": 15
+      },
+      {
+        "handle": "wfwitness",
+        "label": "Witness",
         "topic": "breaking",
         "tier": 3,
         "enabled": true,


### PR DESCRIPTION
## Summary
- Remove `nexta_live` (NEXTA Live)
- Remove `air_alert_ua` (Ukrainian air alerts)
- Add `wfwitness` (Witness) as breaking/tier 3

## Test plan
- [ ] Deploy relay → Telegram poll picks up 25 channels (was 27)
- [ ] `/telegram/feed` includes wfwitness messages