### PR TITLE
fix(sentry): guard YT player methods + filter GM/InvalidState noise

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -1279,9 +1279,13 @@ export class LiveNewsPanel extends Panel {
         return;
       }
       if (this.isPlaying) {
-        this.player.loadVideoById(videoId);
+        if (typeof this.player.loadVideoById === 'function') {
+          this.player.loadVideoById(videoId);
+        }
       } else {
-        this.player.cueVideoById(videoId);
+        if (typeof this.player.cueVideoById === 'function') {
+          this.player.cueVideoById(videoId);
+        }
       }
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,6 +124,8 @@ Sentry.init({
     /\bmag is not defined\b/,
     /evaluating '[^']*\.luma/,
     /translateNotifyError/,
+    /GM_getValue/,
+    /^InvalidStateError:|The object is in an invalid state/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary
- Guard `loadVideoById`/`cueVideoById` with `typeof` check in LiveNewsPanel — race condition where YT.Player object exists but methods aren't available before `onReady` fires
- Add `ignoreErrors` for `GM_getValue` (Greasemonkey browser extension) and `InvalidStateError` (IndexedDB/DOM state errors from browser internals)
- Resolves Sentry issues WM-6D, WM-6A, WM-6B, WM-6E, WM-6C

## Test plan
- [ ] Verify live news panel YouTube playback still works
- [ ] Verify no new Sentry errors after deploy