### PR TITLE
fix(aviation): always show all monitored airports on flight delays map

### DIFF
--- a/server/worldmonitor/aviation/v1/list-airport-delays.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-delays.ts
@@ -159,12 +159,13 @@ export async function listAirportDelays(
     }
   }
 
-  // 4. Fill in MENA airports with no alerts as "normal operations"
+  // 4. Fill in ALL monitored airports with no alerts as "normal operations"
   //    so they always appear on the map (gray dots)
   const alertedIatas = new Set(allAlerts.map(a => a.iata));
-  const menaAirports = MONITORED_AIRPORTS.filter(a => a.region === 'mena');
-  for (const airport of menaAirports) {
+  let normalCount = 0;
+  for (const airport of MONITORED_AIRPORTS) {
     if (!alertedIatas.has(airport.iata)) {
+      normalCount++;
       allAlerts.push({
         id: `status-${airport.iata}`,
         iata: airport.iata,
@@ -187,8 +188,7 @@ export async function listAirportDelays(
     }
   }
 
-  const menaNormal = menaAirports.filter(a => !alertedIatas.has(a.iata)).length;
-  console.log(`[Aviation] Total: ${allAlerts.length} alerts (${menaNormal} MENA normal) in ${Date.now() - t0}ms`);
+  console.log(`[Aviation] Total: ${allAlerts.length} alerts (${normalCount} normal) in ${Date.now() - t0}ms`);
   return { alerts: allAlerts };
 }
 


### PR DESCRIPTION
## Summary
- All 128 monitored airports only appeared on the flight delays map when they had active delays or NOTAM closures
- Airports operating normally (no delays) were completely invisible — user reported only seeing 2 airports in entire GCC region
- After collecting all real alerts (FAA + AviationStack + NOTAM), fills in remaining airports with `severity: normal` / `reason: "Normal operations"` entries
- Frontend already renders normal severity as gray dots (8000m radius) — no frontend changes needed
- Applies globally to all regions: Americas, Europe, APAC, MENA, Africa

## Test plan
- [ ] Toggle flight delays layer → all ~128 monitored airports should appear
- [ ] GCC airports (DXB, DOH, AUH, RUH, JED, KWI, BAH, MCT) always visible
- [ ] European/Asian/African airports also always visible
- [ ] Airports with real delays still show correct severity colors
- [ ] NOTAM closures still override normal status