### PR TITLE
fix(aviation): invalidate stale IndexedDB cache + reduce CDN TTL

### DIFF
--- a/api/[domain]/v1/[rpc].ts
+++ b/api/[domain]/v1/[rpc].ts
@@ -88,7 +88,7 @@ const RPC_CACHE_TIER: Record<string, CacheTier> = {
   '/api/conflict/v1/list-iran-events': 'fast',
   '/api/military/v1/get-theater-posture': 'slow',
   '/api/infrastructure/v1/get-temporal-baseline': 'slow',
-  '/api/aviation/v1/list-airport-delays': 'slow',
+  '/api/aviation/v1/list-airport-delays': 'medium',
   '/api/market/v1/get-country-stock-index': 'slow',
 
   '/api/wildfire/v1/list-fire-detections': 'static',

--- a/src/services/aviation/index.ts
+++ b/src/services/aviation/index.ts
@@ -91,7 +91,7 @@ function toDisplayAlert(proto: ProtoAlert): AirportDelayAlert {
 // --- Client + circuit breaker ---
 
 const client = new AviationServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });
-const breaker = createCircuitBreaker<AirportDelayAlert[]>({ name: 'FAA Flight Delays', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
+const breaker = createCircuitBreaker<AirportDelayAlert[]>({ name: 'Flight Delays v2', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
 
 // --- Main fetch (public API) ---
 


### PR DESCRIPTION
## Summary
- Bump circuit breaker cache key from `FAA Flight Delays` → `Flight Delays v2` to force all clients to discard stale IndexedDB entries that predate PR #603 (normal-ops airport fill)
- Downgrade CDN cache tier from `slow` (15 min `s-maxage`) to `medium` (5 min) since airport status changes more frequently

## Root Cause
After PR #603 added "normal operations" entries for all 128 monitored airports, users with existing sessions still saw only airports with active delays (DXB visible, DOH/AUH missing). The client-side circuit breaker persisted old responses in IndexedDB, and clearing localStorage doesn't touch IndexedDB. The stale-while-revalidate pattern returned cached data immediately, making the fix invisible until a double-refresh.

## Test plan
- [ ] Deploy → verify DOH, AUH appear as gray dots on fresh browser session
- [ ] Verify existing sessions show all airports after single page refresh (new breaker key forces fresh fetch)
- [ ] Check `X-Cache-Tier: medium` header on aviation responses (with `?_debug` param)