### PR TITLE
fix: RT channel HLS recovery, test shim, and LiveNOW fallback

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -79,7 +79,7 @@ const TECH_LIVE_CHANNELS: LiveChannel[] = [
 // Optional channels users can add from the "Available Channels" tab UI
 export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   // North America
-  { id: 'livenow-fox', name: 'LiveNOW from FOX', handle: '@LiveNOWfromFOX' },
+  { id: 'livenow-fox', name: 'LiveNOW from FOX', handle: '@LiveNOWfromFOX', fallbackVideoId: 'QaftgYkG-ek' },
   { id: 'fox-news', name: 'Fox News', handle: '@FoxNews', fallbackVideoId: 'QaftgYkG-ek', useFallbackOnly: true },
   { id: 'newsmax', name: 'Newsmax', handle: '@NEWSMAX', fallbackVideoId: 'S-lFBzloL2Y', useFallbackOnly: true },
   { id: 'abc-news', name: 'ABC News', handle: '@ABCNews' },
@@ -95,7 +95,7 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'ntv-turkey', name: 'NTV', handle: '@NTV', fallbackVideoId: 'pqq5c6k70kk' },
   { id: 'cnn-turk', name: 'CNN TURK', handle: '@cnnturk', fallbackVideoId: 'lsY4GFoj_xY' },
   { id: 'tv-rain', name: 'TV Rain', handle: '@tvrain' },
-  { id: 'rt', name: 'RT', handle: '', useFallbackOnly: true },
+  { id: 'rt', name: 'RT', handle: '' },
   { id: 'tvp-info', name: 'TVP Info', handle: '@tvpinfo', fallbackVideoId: '3jKb-uThfrg' },
   { id: 'telewizja-republika', name: 'Telewizja Republika', handle: '@Telewizja_Republika', fallbackVideoId: 'dzntyCTgJMQ' },
   // Latin America & Portuguese

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -644,6 +644,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       './_shared': resolve(root, 'server/worldmonitor/military/v1/_shared.ts'),
       '../../../_shared/constants': resolve(root, 'server/_shared/constants.ts'),
       '../../../_shared/redis': resolve(root, 'server/_shared/redis.ts'),
+      '../../../_shared/response-headers': resolve(root, 'server/_shared/response-headers.ts'),
     });
   }
 


### PR DESCRIPTION
## Summary

- **P1**: Remove `useFallbackOnly` from RT channel — RT is HLS-only (YouTube banned), the flag caused `undefined` videoId when HLS fails, breaking recovery. Now HLS failure gracefully shows offline via `showOfflineMessage()`
- **P2**: Add `response-headers` shim to `redis-caching.test.mjs` import map — `list-military-flights.ts` gained a `markNoCacheResponse` import but the test harness didn't map it, causing `MODULE_NOT_FOUND` and skipping the entire `military flights bbox behavior` suite (5 tests)
- **P3**: Restore `fallbackVideoId` on LiveNOW from FOX — was added in PR #538, then accidentally removed during a channel audit that updated fox-news/newsmax IDs

## Test plan

- [ ] RT channel plays via HLS stream
- [ ] RT shows offline message (not broken embed) if HLS fails
- [ ] `node --test tests/redis-caching.test.mjs` — all 15 tests pass including military flights bbox suite
- [ ] LiveNOW from FOX falls back to YouTube when handle lookup fails