### PR TITLE
fix(api): harden cache-control headers for polymarket and rss-proxy

### DIFF
--- a/api/polymarket.js
+++ b/api/polymarket.js
@@ -67,7 +67,7 @@ export default async function handler(req) {
     const body = await response.text();
     const headers = {
       'Content-Type': response.headers.get('content-type') || 'application/json',
-      'Cache-Control': response.headers.get('cache-control') || 'no-cache',
+      'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=60',
       ...corsHeaders,
     };
 

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -422,7 +422,7 @@ export default async function handler(req) {
       status: response.status,
       headers: {
         'Content-Type': response.headers.get('content-type') || 'application/xml',
-        'Cache-Control': response.headers.get('cache-control') || 'public, max-age=600, s-maxage=600, stale-while-revalidate=300',
+        'Cache-Control': 'public, max-age=900, s-maxage=900, stale-while-revalidate=300',
         ...corsHeaders,
       },
     });


### PR DESCRIPTION
## Summary
- **polymarket**: Fixed `s-maxage=120` instead of forwarding upstream cache-control (which could be `no-cache`, defeating CDN caching)
- **rss-proxy**: Bumped `s-maxage` from 600→900 to match `max-age`, with 300s stale-while-revalidate

## Test plan
- [ ] Polymarket panel loads, responses have `s-maxage=120` header
- [ ] RSS feeds load, responses have `s-maxage=900` header