### PR TITLE
Expand country instability signals across briefs

### DIFF
--- a/src/app/app-context.ts
+++ b/src/app/app-context.ts
@@ -31,6 +31,14 @@ export interface CountryBriefSignals {
   militaryFlights: number;
   militaryVessels: number;
   outages: number;
+  criticalNews: number;
+  highNews: number;
+  economicStressSignals: number;
+  electionSignals: number;
+  cyberThreats: number;
+  aisDisruptions: number;
+  satelliteFires: number;
+  temporalAnomalies: number;
   earthquakes: number;
   displacementOutflow: number;
   climateStress: number;

--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -172,6 +172,14 @@ export class CountryBriefPage {
     if (signals.militaryFlights > 0) chips.push(`<span class="signal-chip military">✈️ ${signals.militaryFlights} ${t('modals.countryBrief.signals.militaryAir')}</span>`);
     if (signals.militaryVessels > 0) chips.push(`<span class="signal-chip military">⚓ ${signals.militaryVessels} ${t('modals.countryBrief.signals.militarySea')}</span>`);
     if (signals.outages > 0) chips.push(`<span class="signal-chip outage">🌐 ${signals.outages} ${t('modals.countryBrief.signals.outages')}</span>`);
+    if (signals.criticalNews > 0) chips.push(`<span class="signal-chip conflict">🚨 ${signals.criticalNews} critical news</span>`);
+    if (signals.highNews > 0) chips.push(`<span class="signal-chip conflict">⚠️ ${signals.highNews} high-risk news</span>`);
+    if (signals.economicStressSignals > 0) chips.push(`<span class="signal-chip displacement">💹 ${signals.economicStressSignals} economic stress</span>`);
+    if (signals.electionSignals > 0) chips.push(`<span class="signal-chip protest">🗳️ ${signals.electionSignals} election/governance</span>`);
+    if (signals.cyberThreats > 0) chips.push(`<span class="signal-chip military">🛡️ ${signals.cyberThreats} cyber threats</span>`);
+    if (signals.aisDisruptions > 0) chips.push(`<span class="signal-chip outage">🚢 ${signals.aisDisruptions} AIS disruptions</span>`);
+    if (signals.satelliteFires > 0) chips.push(`<span class="signal-chip climate">🔥 ${signals.satelliteFires} satellite fires</span>`);
+    if (signals.temporalAnomalies > 0) chips.push(`<span class="signal-chip protest">📈 ${signals.temporalAnomalies} temporal anomalies</span>`);
     if (signals.earthquakes > 0) chips.push(`<span class="signal-chip quake">🌍 ${signals.earthquakes} ${t('modals.countryBrief.signals.earthquakes')}</span>`);
     if (signals.displacementOutflow > 0) {
       const fmt = signals.displacementOutflow >= 1_000_000
@@ -192,6 +200,7 @@ export class CountryBriefPage {
       chips.push(`<span class="signal-chip ${advisoryClass}">\u26A0\uFE0F ${signals.travelAdvisories} Advisory: ${advisoryLabel}</span>`);
     }
     if (signals.orefSirens > 0) chips.push(`<span class="signal-chip conflict">\u{1F6A8} ${signals.orefSirens} Active Sirens</span>`);
+    if (signals.orefHistory24h > 0) chips.push(`<span class="signal-chip conflict">\u{1F6A8} ${signals.orefHistory24h} OREF alerts (24h)</span>`);
     if (signals.aviationDisruptions > 0) chips.push(`<span class="signal-chip outage">\u{1F6AB} ${signals.aviationDisruptions} ${t('modals.countryBrief.signals.aviationDisruptions')}</span>`);
     if (signals.gpsJammingHexes > 0) chips.push(`<span class="signal-chip outage">\u{1F4E1} ${signals.gpsJammingHexes} ${t('modals.countryBrief.signals.gpsJammingZones')}</span>`);
     chips.push(`<span class="signal-chip stock-loading">📈 ${t('modals.countryBrief.loadingIndex')}</span>`);
@@ -615,6 +624,14 @@ export class CountryBriefPage {
         militaryFlights: this.currentSignals.militaryFlights,
         militaryVessels: this.currentSignals.militaryVessels,
         outages: this.currentSignals.outages,
+        criticalNews: this.currentSignals.criticalNews,
+        highNews: this.currentSignals.highNews,
+        economicStressSignals: this.currentSignals.economicStressSignals,
+        electionSignals: this.currentSignals.electionSignals,
+        cyberThreats: this.currentSignals.cyberThreats,
+        aisDisruptions: this.currentSignals.aisDisruptions,
+        satelliteFires: this.currentSignals.satelliteFires,
+        temporalAnomalies: this.currentSignals.temporalAnomalies,
         earthquakes: this.currentSignals.earthquakes,
         displacementOutflow: this.currentSignals.displacementOutflow,
         climateStress: this.currentSignals.climateStress,

--- a/src/services/cached-risk-scores.ts
+++ b/src/services/cached-risk-scores.ts
@@ -5,7 +5,6 @@
  */
 
 import type { CountryScore, ComponentScores } from './country-instability';
-import { setHasCachedScores } from './country-instability';
 import { getPersistentCache, setPersistentCache } from './persistent-cache';
 import {
   IntelligenceServiceClient,
@@ -188,7 +187,6 @@ export async function fetchCachedRiskScores(signal?: AbortSignal): Promise<Cache
       const data = toRiskScores(resp);
       cachedScores = data;
       lastFetchTime = now;
-      setHasCachedScores(true);
       void setPersistentCache(RISK_CACHE_KEY, data);
       return cachedScores;
     } catch (error) {


### PR DESCRIPTION
Summary
- surface new critical/high news, cyber, AIS, satellite, temporal anomaly, and governance/economic signals in country briefs and fallback messaging
- enrich the country instability data pipeline by ingesting the new signal categories and computing consolidated news signal summaries
- add temporal anomaly propagation so the overview can reflect national/global anomalies alongside the existing CII signals

Testing
- Not run (not requested)