### PR TITLE
fix(aviation): increase cache TTL to 2h to reduce API quota

### DIFF
--- a/server/worldmonitor/aviation/v1/list-airport-delays.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-delays.ts
@@ -27,7 +27,7 @@ import { cachedFetchJson, getCachedJson, setCachedJson } from '../../../_shared/
 const FAA_CACHE_KEY = 'aviation:delays:faa:v1';
 const INTL_CACHE_KEY = 'aviation:delays:intl:v2';
 const NOTAM_CACHE_KEY = 'aviation:notam:closures:v1';
-const CACHE_TTL = 1800;      // 30 min for FAA, intl (real), and NOTAM
+const CACHE_TTL = 7200;      // 2h for FAA, intl (real), and NOTAM
 const SIM_CACHE_TTL = 300;   // 5 min for simulation fallback — retry sooner
 
 export async function listAirportDelays(


### PR DESCRIPTION
## Summary
- Increase `CACHE_TTL` from 1800s (30min) to 7200s (2h) for FAA, AviationStack (intl), and NOTAM caches
- Reduces AviationStack API calls by ~4x to prevent quota overage
- Simulation fallback TTL unchanged at 5min

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Verify on Vercel that aviation data still loads (cached for 2h between refreshes)