### PR TITLE
feat(oref): show history waves timeline in sirens panel

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -529,7 +529,8 @@ async function orefBootstrapHistory() {
   const cleaned = stripBom(raw).trim();
   if (!cleaned || cleaned === '[]') return;
 
-  const records = JSON.parse(cleaned);
+  const allRecords = JSON.parse(cleaned);
+  const records = allRecords.slice(-500);
   const waves = new Map();
   for (const r of records) {
     const key = r.alertDate;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1131,6 +1131,7 @@
       "time": "Time",
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
+      "historySummary": "{{count}} alerts in 24h — {{waves}} waves",
       "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     },
     "satelliteFires": {

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -279,5 +279,12 @@
 .oref-alert-title { font-size: 11px; font-weight: 600; color: var(--text-primary); }
 .oref-alert-time { font-size: 9px; color: var(--text-muted); }
 .oref-alert-areas { font-size: 10px; color: var(--text-secondary); line-height: 1.35; }
-.oref-footer { display: flex; align-items: center; justify-content: center; margin-top: 8px; padding-top: 6px; border-top: 1px solid var(--border-subtle); }
-.oref-history { font-size: 9px; color: var(--text-muted); }
+.oref-history-section { margin-top: 8px; padding-top: 6px; border-top: 1px solid var(--border-subtle); }
+.oref-history-title { font-size: 9px; color: var(--text-muted); margin-bottom: 6px; text-align: center; }
+.oref-wave-list { display: flex; flex-direction: column; gap: 3px; max-height: 320px; overflow-y: auto; }
+.oref-wave-row { padding: 5px 8px; border-radius: 4px; border-left: 3px solid var(--border-subtle); background: var(--overlay-subtle); }
+.oref-wave-recent { border-left-color: var(--semantic-warning, #f59e0b); }
+.oref-wave-header { display: flex; align-items: center; gap: 6px; margin-bottom: 2px; }
+.oref-wave-time { font-size: 9px; color: var(--text-muted); }
+.oref-wave-summary { font-size: 10px; color: var(--text-secondary); line-height: 1.3; }
+.oref-recent-badge { font-size: 8px; font-weight: 700; color: var(--semantic-warning, #f59e0b); background: color-mix(in srgb, var(--semantic-warning, #f59e0b) 12%, transparent); padding: 1px 4px; border-radius: 3px; text-transform: uppercase; letter-spacing: 0.5px; }


### PR DESCRIPTION
## Summary
- Display alert history waves in the Israel Sirens panel (most recent 50 waves)
- Last-hour waves get amber highlight + RECENT badge; older waves get muted styling
- Hebrew history alerts translated via existing LLM translation pipeline
- Fix NaN time display ("NaNd") from unparseable OREF date formats
- Cap relay history bootstrap to 500 records; 3-minute fetch TTL prevents over-polling

## Test plan
- [ ] Deploy to Vercel preview and confirm history waves appear below the status banner
- [ ] Verify recent waves (< 1h) show amber border and RECENT badge
- [ ] Confirm alert titles/types are translated to English (not Hebrew)
- [ ] Verify no "NaNd" appears in time fields
- [ ] Check scrollability when many waves are present (max-height 320px)