### PR TITLE
feat(map): native mobile map experience

### DIFF
--- a/e2e/mobile-map-native.spec.ts
+++ b/e2e/mobile-map-native.spec.ts
@@ -1,0 +1,151 @@
+import { devices, expect, test } from '@playwright/test';
+
+const MOBILE_VIEWPORT = devices['iPhone 14 Pro Max'];
+
+test.describe('Mobile map native experience', () => {
+  const { defaultBrowserType: _bt, ...mobileContext } = MOBILE_VIEWPORT;
+
+  test.describe('timezone-based startup region', () => {
+    test('America/New_York → america view', async ({ browser }) => {
+      const context = await browser.newContext({
+        ...mobileContext,
+        timezoneId: 'America/New_York',
+        locale: 'en-US',
+      });
+      const page = await context.newPage();
+      await page.addInitScript(() => {
+        (window as any).__testResolvedLocation = true;
+      });
+      await page.goto('/');
+      await page.waitForTimeout(3000);
+      const region = await page.evaluate(() => {
+        const select = document.getElementById('regionSelect') as HTMLSelectElement | null;
+        return select?.value ?? null;
+      });
+      expect(region).toBe('america');
+      await context.close();
+    });
+
+    test('Europe/London → eu view', async ({ browser }) => {
+      const context = await browser.newContext({
+        ...mobileContext,
+        timezoneId: 'Europe/London',
+        locale: 'en-GB',
+      });
+      const page = await context.newPage();
+      await page.goto('/');
+      await page.waitForTimeout(3000);
+      const region = await page.evaluate(() => {
+        const select = document.getElementById('regionSelect') as HTMLSelectElement | null;
+        return select?.value ?? null;
+      });
+      expect(region).toBe('eu');
+      await context.close();
+    });
+
+    test('Asia/Tokyo → asia view', async ({ browser }) => {
+      const context = await browser.newContext({
+        ...mobileContext,
+        timezoneId: 'Asia/Tokyo',
+        locale: 'ja-JP',
+      });
+      const page = await context.newPage();
+      await page.goto('/');
+      await page.waitForTimeout(3000);
+      const region = await page.evaluate(() => {
+        const select = document.getElementById('regionSelect') as HTMLSelectElement | null;
+        return select?.value ?? null;
+      });
+      expect(region).toBe('asia');
+      await context.close();
+    });
+  });
+
+  test.describe('URL restore', () => {
+    test.use(mobileContext);
+
+    test('lat/lon override view center', async ({ page }) => {
+      await page.goto('/?view=eu&lat=48.86&lon=2.35&zoom=5');
+      await page.waitForTimeout(3000);
+      const url = page.url();
+      const params = new URL(url).searchParams;
+      const lat = params.get('lat');
+      const lon = params.get('lon');
+      if (lat && lon) {
+        expect(parseFloat(lat)).toBeCloseTo(48.86, 0);
+        expect(parseFloat(lon)).toBeCloseTo(2.35, 0);
+      } else {
+        const region = await page.evaluate(() => {
+          const select = document.getElementById('regionSelect') as HTMLSelectElement | null;
+          return select?.value ?? null;
+        });
+        expect(region).not.toBe('eu');
+      }
+    });
+
+    test('zero-degree coordinates center at equator/prime meridian', async ({ page }) => {
+      await page.goto('/?lat=0&lon=0&zoom=4');
+      await page.waitForTimeout(3000);
+      const url = page.url();
+      const params = new URL(url).searchParams;
+      const lat = params.get('lat');
+      const lon = params.get('lon');
+      expect(lat).not.toBeNull();
+      expect(lon).not.toBeNull();
+      if (lat && lon) {
+        expect(Math.abs(parseFloat(lat))).toBeLessThan(5);
+        expect(Math.abs(parseFloat(lon))).toBeLessThan(5);
+      }
+    });
+  });
+
+  test.describe('touch interactions', () => {
+    test.use(mobileContext);
+
+    test('single-finger pan does not scroll page', async ({ page }) => {
+      await page.goto('/');
+      await page.waitForTimeout(3000);
+      const mapEl = page.locator('#mapContainer');
+      await expect(mapEl).toBeVisible({ timeout: 10000 });
+
+      const scrollBefore = await page.evaluate(() => window.scrollY);
+
+      const box = await mapEl.boundingBox();
+      if (box) {
+        const startX = box.x + box.width / 2;
+        const startY = box.y + box.height / 2;
+        await page.touchscreen.tap(startX, startY);
+        await page.mouse.move(startX, startY);
+        await page.touchscreen.tap(startX, startY + 50);
+      }
+
+      const scrollAfter = await page.evaluate(() => window.scrollY);
+      expect(scrollAfter).toBe(scrollBefore);
+    });
+  });
+
+  test.describe('breakpoint consistency at 768px', () => {
+    test('JS and CSS agree at exactly 768px', async ({ browser }) => {
+      const context = await browser.newContext({
+        viewport: { width: 768, height: 1024 },
+        locale: 'en-US',
+      });
+      const page = await context.newPage();
+      await page.goto('/');
+      await page.waitForTimeout(2000);
+
+      const result = await page.evaluate(() => {
+        const jsMobile = window.innerWidth <= 768;
+        const el = document.createElement('div');
+        el.style.display = 'none';
+        document.body.appendChild(el);
+        const cssMobile = window.matchMedia('(max-width: 768px)').matches;
+        el.remove();
+        return { jsMobile, cssMobile };
+      });
+
+      expect(result.jsMobile).toBe(result.cssMobile);
+      await context.close();
+    });
+  });
+});

--- a/src/App.ts
+++ b/src/App.ts
@@ -37,6 +37,7 @@ import { RefreshScheduler } from '@/app/refresh-scheduler';
 import { PanelLayoutManager } from '@/app/panel-layout';
 import { DataLoaderManager } from '@/app/data-loader';
 import { EventHandlerManager } from '@/app/event-handlers';
+import { resolveUserRegion } from '@/utils/user-location';
 
 const CYBER_LAYER_ENABLED = import.meta.env.VITE_ENABLE_CYBER_LAYER === 'true';
 
@@ -250,6 +251,7 @@ export class App {
       isPlaybackMode: false,
       isIdle: false,
       initialLoadComplete: false,
+      resolvedLocation: 'global',
       initialUrlState,
       PANEL_ORDER_KEY,
       PANEL_SPANS_KEY,
@@ -330,6 +332,9 @@ export class App {
 
     // Hydrate in-memory cache from bootstrap endpoint (before panels construct and fetch)
     await fetchBootstrapData();
+
+    const resolvedRegion = await resolveUserRegion();
+    this.state.resolvedLocation = resolvedRegion;
 
     // Phase 1: Layout (creates map + panels — they'll find hydrated data)
     this.panelLayout.init();

--- a/src/app/app-context.ts
+++ b/src/app/app-context.ts
@@ -122,6 +122,7 @@ export interface AppContext {
   isPlaybackMode: boolean;
   isIdle: boolean;
   initialLoadComplete: boolean;
+  resolvedLocation: 'global' | 'america' | 'mena' | 'eu' | 'asia' | 'latam' | 'africa' | 'oceania';
 
   initialUrlState: ParsedMapUrlState | null;
   readonly PANEL_ORDER_KEY: string;

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -305,7 +305,7 @@ export class PanelLayoutManager implements AppModule {
     this.ctx.map = new MapContainer(mapContainer, {
       zoom: this.ctx.isMobile ? 2.5 : 1.0,
       pan: { x: 0, y: 0 },
-      view: this.ctx.isMobile ? 'mena' : 'global',
+      view: this.ctx.isMobile ? this.ctx.resolvedLocation : 'global',
       layers: this.ctx.mapLayers,
       timeRange: '7d',
     });
@@ -743,13 +743,11 @@ export class PanelLayoutManager implements AppModule {
       this.ctx.map.setLayers(layers);
     }
 
-    if (!view) {
-      if (zoom !== undefined) {
-        this.ctx.map.setZoom(zoom);
-      }
-      if (lat !== undefined && lon !== undefined && zoom !== undefined && zoom > 2) {
-        this.ctx.map.setCenter(lat, lon);
-      }
+    if (lat !== undefined && lon !== undefined) {
+      const effectiveZoom = zoom ?? this.ctx.map.getState().zoom;
+      if (effectiveZoom > 2) this.ctx.map.setCenter(lat, lon, zoom);
+    } else if (!view && zoom !== undefined) {
+      this.ctx.map.setZoom(zoom);
     }
 
     const regionSelect = document.getElementById('regionSelect') as HTMLSelectElement;

--- a/src/components/MapContainer.ts
+++ b/src/components/MapContainer.ts
@@ -80,7 +80,7 @@ export class MapContainer {
     this.isMobile = isMobileDevice();
 
     // Use deck.gl on desktop with WebGL support, SVG on mobile
-    this.useDeckGL = !this.isMobile && this.hasWebGLSupport();
+    this.useDeckGL = this.shouldUseDeckGL();
 
     this.init();
   }
@@ -96,6 +96,14 @@ export class MapContainer {
     } catch {
       return false;
     }
+  }
+
+  private shouldUseDeckGL(): boolean {
+    if (!this.hasWebGLSupport()) return false;
+    if (!this.isMobile) return true;
+    const mem = (navigator as any).deviceMemory;
+    if (mem !== undefined && mem < 3) return false;
+    return true;
   }
 
   private initSvgMap(logMessage: string): void {
@@ -590,10 +598,19 @@ export class MapContainer {
     }
   }
 
-  // Country click + highlight (deck.gl only)
   public onCountryClicked(callback: (country: CountryClickPayload) => void): void {
     if (this.useDeckGL) {
       this.deckGLMap?.setOnCountryClick(callback);
+    } else {
+      this.svgMap?.setOnCountryClick(callback);
+    }
+  }
+
+  public fitCountry(code: string): void {
+    if (this.useDeckGL) {
+      this.deckGLMap?.fitCountry(code);
+    } else {
+      this.svgMap?.fitCountry(code);
     }
   }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -151,7 +151,7 @@ export const MOBILE_BREAKPOINT_PX = 768;
 
 /** True when viewport is below mobile breakpoint. Touch-capable notebooks keep desktop layout. */
 export function isMobileDevice(): boolean {
-  return window.innerWidth < MOBILE_BREAKPOINT_PX;
+  return window.innerWidth <= MOBILE_BREAKPOINT_PX;
 }
 
 export function chunkArray<T>(items: T[], size: number): T[][] {

--- a/src/utils/user-location.ts
+++ b/src/utils/user-location.ts
@@ -1,0 +1,71 @@
+type MapView = 'global' | 'america' | 'mena' | 'eu' | 'asia' | 'latam' | 'africa' | 'oceania';
+
+const ASIA_EAST_TIMEZONES = new Set([
+  'Asia/Tokyo', 'Asia/Seoul', 'Asia/Shanghai', 'Asia/Hong_Kong',
+  'Asia/Taipei', 'Asia/Singapore',
+]);
+
+function timezoneToRegion(tz: string): MapView | null {
+  if (ASIA_EAST_TIMEZONES.has(tz)) return 'asia';
+  const prefix = tz.split('/')[0];
+  switch (prefix) {
+    case 'America':
+    case 'US':
+    case 'Canada':
+      return 'america';
+    case 'Europe':
+      return 'eu';
+    case 'Africa':
+      return 'africa';
+    case 'Asia':
+      return 'mena';
+    case 'Australia':
+    case 'Pacific':
+      return 'oceania';
+    default:
+      return null;
+  }
+}
+
+function coordsToRegion(lat: number, lon: number): MapView {
+  if (lat > 15 && lon > 60 && lon < 150) return 'asia';
+  if (lat > 10 && lat < 45 && lon > 25 && lon < 65) return 'mena';
+  if (lat > -40 && lat < 40 && lon > -25 && lon < 55) return 'africa';
+  if (lat > 35 && lat < 72 && lon > -25 && lon < 45) return 'eu';
+  if (lat > -60 && lat < 15 && lon > -90 && lon < -30) return 'latam';
+  if (lat > 15 && lon > -170 && lon < -50) return 'america';
+  if (lat < 0 && lon > 100) return 'oceania';
+  return 'global';
+}
+
+function getGeolocationPosition(timeout: number): Promise<GeolocationPosition> {
+  return new Promise((resolve, reject) => {
+    navigator.geolocation.getCurrentPosition(resolve, reject, {
+      timeout,
+      maximumAge: 300_000,
+    });
+  });
+}
+
+export async function resolveUserRegion(): Promise<MapView> {
+  let tzRegion: MapView = 'global';
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    tzRegion = timezoneToRegion(tz) ?? 'global';
+  } catch {
+    // Intl unavailable
+  }
+
+  try {
+    if (typeof navigator === 'undefined' || !navigator.permissions) throw 0;
+    const status = await navigator.permissions.query({ name: 'geolocation' as PermissionName });
+    if (status.state === 'granted') {
+      const pos = await getGeolocationPosition(3000);
+      return coordsToRegion(pos.coords.latitude, pos.coords.longitude);
+    }
+  } catch {
+    // permissions.query unsupported or geolocation failed
+  }
+
+  return tzRegion;
+}


### PR DESCRIPTION
## Summary
- **URL restore fix**: lat/lon now override view center when explicitly in URL; handles 0° coordinates correctly
- **Touch scroll fix**: 8px movement threshold before activating drag, `preventDefault()` once active; inertial animation on touchend
- **Location bootstrap**: timezone-first region detection (no permission prompt), geolocation upgrade only if pre-granted
- **DeckGL on mobile**: capability detection replaces blanket mobile block; low-memory guard (deviceMemory < 3GB)
- **DeckGL state sync**: moveend/zoomend handlers now emit state changes for URL sync
- **Breakpoint fix**: JS `<` → `<=` to match CSS `max-width: 768px`
- **SVG country-click**: click handler with CSS transform inversion → D3 projection invert → country detection
- **fitCountry()**: DeckGL uses MapLibre `fitBounds()`, SVG uses projection-based pixel span calculation
- **E2E tests**: timezone startup, URL restore, touch scroll, breakpoint consistency at 768px

## Test plan
- [ ] Open `?view=mena&lat=35&lon=50&zoom=5` — map centers on (35,50) not MENA preset
- [ ] Open `?lat=0&lon=0&zoom=4` — map centers at equator/prime meridian
- [ ] On phone, single-finger drag on map pans without scrolling page
- [ ] Clear URL params on mobile — map starts in user's region (no permission prompt)
- [ ] Open on phone — DeckGL with native pinch/momentum gestures
- [ ] Pan/zoom on mobile DeckGL → URL params update
- [ ] At exactly 768px width — JS and CSS agree on mobile
- [ ] Force SVG mode → tap country → country brief opens
- [ ] `map.fitCountry('IR')` — camera animates to Iran bounds
- [ ] `npx playwright test e2e/mobile-map-native.spec.ts`