### PR TITLE
fix(aviation): prevent AviationStack API quota blowout

### DIFF
--- a/api/[domain]/v1/[rpc].ts
+++ b/api/[domain]/v1/[rpc].ts
@@ -88,7 +88,7 @@ const RPC_CACHE_TIER: Record<string, CacheTier> = {
   '/api/conflict/v1/list-iran-events': 'fast',
   '/api/military/v1/get-theater-posture': 'slow',
   '/api/infrastructure/v1/get-temporal-baseline': 'slow',
-  '/api/aviation/v1/list-airport-delays': 'medium',
+  '/api/aviation/v1/list-airport-delays': 'static',
   '/api/market/v1/get-country-stock-index': 'slow',
 
   '/api/wildfire/v1/list-fire-detections': 'static',

--- a/src/App.ts
+++ b/src/App.ts
@@ -518,7 +518,7 @@ export class App {
         { name: 'ais', fn: () => this.dataLoader.loadAisSignals(), intervalMs: REFRESH_INTERVALS.ais, condition: () => this.state.mapLayers.ais },
         { name: 'cables', fn: () => this.dataLoader.loadCableActivity(), intervalMs: 30 * 60 * 1000, condition: () => this.state.mapLayers.cables },
         { name: 'cableHealth', fn: () => this.dataLoader.loadCableHealth(), intervalMs: 5 * 60 * 1000, condition: () => this.state.mapLayers.cables },
-        { name: 'flights', fn: () => this.dataLoader.loadFlightDelays(), intervalMs: 10 * 60 * 1000, condition: () => this.state.mapLayers.flights },
+        { name: 'flights', fn: () => this.dataLoader.loadFlightDelays(), intervalMs: 2 * 60 * 60 * 1000, condition: () => this.state.mapLayers.flights },
         { name: 'cyberThreats', fn: () => {
           this.state.cyberThreatsCache = null;
           return this.dataLoader.loadCyberThreats();

--- a/src/services/aviation/index.ts
+++ b/src/services/aviation/index.ts
@@ -91,7 +91,7 @@ function toDisplayAlert(proto: ProtoAlert): AirportDelayAlert {
 // --- Client + circuit breaker ---
 
 const client = new AviationServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });
-const breaker = createCircuitBreaker<AirportDelayAlert[]>({ name: 'Flight Delays v2', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
+const breaker = createCircuitBreaker<AirportDelayAlert[]>({ name: 'Flight Delays v2', cacheTtlMs: 2 * 60 * 60 * 1000, persistCache: true });
 
 // --- Main fetch (public API) ---
 


### PR DESCRIPTION
## Summary
- **Thundering herd fix**: Replace manual `getCachedJson`/`setCachedJson` with `cachedFetchJson` for intl delays — concurrent cache misses now coalesce into a single fetch instead of each independently firing 93 API calls
- **Redis TTL**: 30min → 2h
- **Frontend polling**: 10min → 2h (was re-fetching 12x more often than needed)
- **Circuit breaker cache**: 5min → 2h
- **CDN edge tier**: `medium` (5min `s-maxage`) → `static` (1h `s-maxage`)
- **Cache key bump**: `intl:v2` → `intl:v3` to force fresh entry

## Root cause
Each cache miss triggered 93 individual AviationStack API calls (one per non-US airport). With 10-min frontend polling, 5-min circuit breaker, 5-min CDN edge cache, and thundering herd vulnerability — multiple concurrent users could fire thousands of calls/day.

## Impact
- **Before**: ~4,500+ API calls/day (single user), thundering herd multiplied by concurrent users
- **After**: ~93 calls per 2h = ~1,116 calls/day max, with CDN + circuit breaker reducing actual hits further

Supersedes #617 (which only bumped Redis TTL).

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Verify aviation data loads on worldmonitor.app after deploy
- [ ] Monitor AviationStack dashboard for reduced API calls