### PR TITLE
fix(sentry): guard pauseVideo optional chaining + add 4 noise filters

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -1298,7 +1298,7 @@ export class LiveNewsPanel extends Panel {
       if (isNewVideo) {
         // WKWebView loses user gesture context after await.
         // Pause then play after a delay — mimics the manual workaround.
-        this.player.pauseVideo();
+        this.player.pauseVideo?.();
         setTimeout(() => {
           if (this.player && this.isPlaying) {
             this.player.mute?.();

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ Sentry.init({
     /Java bridge method invocation error/,
     /Could not compile fragment shader/,
     /can't redefine non-configurable property/,
-    /Can.t find variable: (CONFIG|currentInset|NP|webkit)/,
+    /Can.t find variable: (CONFIG|currentInset|NP|webkit|EmptyRanges)/,
     /invalid origin/,
     /\.data\.split is not a function/,
     /signal is aborted without reason/,
@@ -126,6 +126,10 @@ Sentry.init({
     /translateNotifyError/,
     /GM_getValue/,
     /^InvalidStateError:|The object is in an invalid state/,
+    /Could not establish connection\. Receiving end does not exist/,
+    /webkitCurrentPlaybackTargetIsWireless/,
+    /null is not an object \(evaluating '\w+\.theme'\)/,
+    /this\.player\.\w+ is not a function/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary
- Fix `this.player.pauseVideo()` → `this.player.pauseVideo?.()` in LiveNewsPanel (6 Sentry issues, 33 events)
- Add 4 noise filter patterns to `ignoreErrors` in `src/main.ts`
- Broaden existing `Can't find variable` pattern to include `EmptyRanges`

## Sentry issues resolved (12 of 13)
| ID | Category | Action |
|----|----------|--------|
| 6T, 6R, 6J, 6Q, 6P, 6M | **Actionable** | `pauseVideo?.()` optional chaining fix |
| 6K, 6F | **Stale builds** | `/this\.player\.\w+ is not a function/` noise filter |
| 6G | **Noise** | Chrome extension "Could not establish connection" |
| 6S | **Noise** | Safari `webkitCurrentPlaybackTargetIsWireless` |
| 2S | **Noise** | Sentry SDK crash on iOS (`a.theme`) |
| 6H | **Noise** | Broadened `Can't find variable` for `EmptyRanges` |
| 6N | **Skipped** | Too generic (`e.type` minified, no stack trace) |

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 12 issues marked resolved in Sentry with `inNextRelease: true`