### PR TITLE
chore(cache): bump all sub-5min cache TTLs and polling intervals

### DIFF
--- a/api/[domain]/v1/[rpc].ts
+++ b/api/[domain]/v1/[rpc].ts
@@ -73,14 +73,14 @@ const TIER_HEADERS: Record<CacheTier, string> = {
 const RPC_CACHE_TIER: Record<string, CacheTier> = {
   '/api/maritime/v1/get-vessel-snapshot': 'no-store',
 
-  '/api/market/v1/list-market-quotes': 'fast',
-  '/api/market/v1/list-crypto-quotes': 'fast',
-  '/api/market/v1/list-commodity-quotes': 'fast',
-  '/api/market/v1/list-stablecoin-markets': 'fast',
-  '/api/market/v1/get-sector-summary': 'fast',
-  '/api/infrastructure/v1/list-service-statuses': 'fast',
-  '/api/seismology/v1/list-earthquakes': 'fast',
-  '/api/infrastructure/v1/list-internet-outages': 'fast',
+  '/api/market/v1/list-market-quotes': 'medium',
+  '/api/market/v1/list-crypto-quotes': 'medium',
+  '/api/market/v1/list-commodity-quotes': 'medium',
+  '/api/market/v1/list-stablecoin-markets': 'medium',
+  '/api/market/v1/get-sector-summary': 'medium',
+  '/api/infrastructure/v1/list-service-statuses': 'slow',
+  '/api/seismology/v1/list-earthquakes': 'slow',
+  '/api/infrastructure/v1/list-internet-outages': 'slow',
 
   '/api/unrest/v1/list-unrest-events': 'slow',
   '/api/cyber/v1/list-cyber-threats': 'slow',

--- a/server/worldmonitor/economic/v1/get-macro-signals.ts
+++ b/server/worldmonitor/economic/v1/get-macro-signals.ts
@@ -22,9 +22,9 @@ import {
 import { cachedFetchJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'economic:macro-signals:v1';
-const REDIS_CACHE_TTL = 300; // 5 min — matches in-memory TTL
+const REDIS_CACHE_TTL = 900; // 15 min — matches in-memory TTL
 
-const MACRO_CACHE_TTL = 300; // 5 minutes in seconds
+const MACRO_CACHE_TTL = 900; // 15 minutes in seconds
 let macroSignalsCached: GetMacroSignalsResponse | null = null;
 let macroSignalsCacheTimestamp = 0;
 

--- a/server/worldmonitor/infrastructure/v1/list-internet-outages.ts
+++ b/server/worldmonitor/infrastructure/v1/list-internet-outages.ts
@@ -13,7 +13,7 @@ import { CHROME_UA } from '../../../_shared/constants';
 import { cachedFetchJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'infra:outages:v1';
-const REDIS_CACHE_TTL = 300; // 5 min — Cloudflare Radar rate-limited
+const REDIS_CACHE_TTL = 1800; // 30 min — Cloudflare Radar rate-limited
 
 // ========================================================================
 // Constants

--- a/server/worldmonitor/infrastructure/v1/list-service-statuses.ts
+++ b/server/worldmonitor/infrastructure/v1/list-service-statuses.ts
@@ -285,7 +285,7 @@ async function checkServiceStatus(service: ServiceDef): Promise<ServiceStatus> {
 // ========================================================================
 
 const INFRA_CACHE_KEY = 'infra:service-statuses:v1';
-const INFRA_CACHE_TTL = 300; // 5 minutes
+const INFRA_CACHE_TTL = 1800; // 30 minutes
 
 export async function listServiceStatuses(
   _ctx: ServerContext,

--- a/server/worldmonitor/maritime/v1/get-vessel-snapshot.ts
+++ b/server/worldmonitor/maritime/v1/get-vessel-snapshot.ts
@@ -52,7 +52,7 @@ const SEVERITY_MAP: Record<string, AisDisruptionSeverity> = {
 };
 
 // In-memory cache (matches old /api/ais-snapshot behavior)
-const SNAPSHOT_CACHE_TTL_MS = 10_000; // 10 seconds -- matches client poll interval
+const SNAPSHOT_CACHE_TTL_MS = 300_000; // 5 min -- matches client poll interval
 let cachedSnapshot: VesselSnapshot | undefined;
 let cacheTimestamp = 0;
 let inFlightRequest: Promise<VesselSnapshot | undefined> | null = null;

--- a/server/worldmonitor/market/v1/get-sector-summary.ts
+++ b/server/worldmonitor/market/v1/get-sector-summary.ts
@@ -15,7 +15,7 @@ import { fetchFinnhubQuote, fetchYahooQuotesBatch } from './_shared';
 import { cachedFetchJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'market:sectors:v1';
-const REDIS_CACHE_TTL = 300; // 5 min — Finnhub rate-limited
+const REDIS_CACHE_TTL = 600; // 10 min — Finnhub rate-limited
 
 export async function getSectorSummary(
   _ctx: ServerContext,

--- a/server/worldmonitor/market/v1/list-commodity-quotes.ts
+++ b/server/worldmonitor/market/v1/list-commodity-quotes.ts
@@ -13,7 +13,7 @@ import { fetchYahooQuotesBatch } from './_shared';
 import { cachedFetchJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'market:commodities:v1';
-const REDIS_CACHE_TTL = 300; // 5 min — commodities move slower than indices
+const REDIS_CACHE_TTL = 600; // 10 min — commodities move slower than indices
 
 function redisCacheKey(symbols: string[]): string {
   return `${REDIS_CACHE_KEY}:${[...symbols].sort().join(',')}`;

--- a/server/worldmonitor/market/v1/list-crypto-quotes.ts
+++ b/server/worldmonitor/market/v1/list-crypto-quotes.ts
@@ -13,7 +13,7 @@ import { CRYPTO_META, fetchCoinGeckoMarkets } from './_shared';
 import { cachedFetchJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'market:crypto:v1';
-const REDIS_CACHE_TTL = 300; // 5 min — CoinGecko rate-limited
+const REDIS_CACHE_TTL = 600; // 10 min — CoinGecko rate-limited
 
 export async function listCryptoQuotes(
   _ctx: ServerContext,

--- a/server/worldmonitor/market/v1/list-market-quotes.ts
+++ b/server/worldmonitor/market/v1/list-market-quotes.ts
@@ -15,10 +15,10 @@ import { YAHOO_ONLY_SYMBOLS, fetchFinnhubQuote, fetchYahooQuotesBatch } from './
 import { cachedFetchJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'market:quotes:v1';
-const REDIS_CACHE_TTL = 120; // 2 min — shared across all Vercel instances
+const REDIS_CACHE_TTL = 480; // 8 min — shared across all Vercel instances
 
 const quotesCache = new Map<string, { data: ListMarketQuotesResponse; timestamp: number }>();
-const QUOTES_CACHE_TTL = 120_000; // 2 minutes (in-memory fallback)
+const QUOTES_CACHE_TTL = 480_000; // 8 minutes (in-memory fallback)
 
 function cacheKey(symbols: string[]): string {
   return [...symbols].sort().join(',');

--- a/server/worldmonitor/market/v1/list-stablecoin-markets.ts
+++ b/server/worldmonitor/market/v1/list-stablecoin-markets.ts
@@ -14,7 +14,7 @@ import { CHROME_UA } from '../../../_shared/constants';
 import { cachedFetchJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'market:stablecoins:v1';
-const REDIS_CACHE_TTL = 300; // 5 min — CoinGecko rate-limited
+const REDIS_CACHE_TTL = 600; // 10 min — CoinGecko rate-limited
 
 // ========================================================================
 // Constants and cache
@@ -24,7 +24,7 @@ const DEFAULT_STABLECOIN_IDS = 'tether,usd-coin,dai,first-digital-usd,ethena-usd
 
 let stablecoinCache: ListStablecoinMarketsResponse | null = null;
 let stablecoinCacheTimestamp = 0;
-const STABLECOIN_CACHE_TTL = 120_000; // 2 minutes
+const STABLECOIN_CACHE_TTL = 480_000; // 8 minutes
 
 // ========================================================================
 // Types

--- a/server/worldmonitor/prediction/v1/list-prediction-markets.ts
+++ b/server/worldmonitor/prediction/v1/list-prediction-markets.ts
@@ -19,7 +19,7 @@ import { CHROME_UA } from '../../../_shared/constants';
 import { cachedFetchJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'prediction:markets:v1';
-const REDIS_CACHE_TTL = 300; // 5 min
+const REDIS_CACHE_TTL = 600; // 10 min
 
 const GAMMA_BASE = 'https://gamma-api.polymarket.com';
 const FETCH_TIMEOUT = 8000;

--- a/server/worldmonitor/seismology/v1/list-earthquakes.ts
+++ b/server/worldmonitor/seismology/v1/list-earthquakes.ts
@@ -18,7 +18,7 @@ import { CHROME_UA } from '../../../_shared/constants';
 const USGS_FEED_URL =
   'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_day.geojson';
 const CACHE_KEY = 'seismology:earthquakes:v1';
-const CACHE_TTL = 300; // 5 minutes
+const CACHE_TTL = 1800; // 30 minutes
 
 export const listEarthquakes: SeismologyServiceHandler['listEarthquakes'] = async (
   _ctx: ServerContext,

--- a/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
+++ b/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
@@ -18,7 +18,7 @@ import { getVesselSnapshot } from '../../maritime/v1/get-vessel-snapshot';
 import { computeDisruptionScore, scoreToStatus, SEVERITY_SCORE } from './_scoring.mjs';
 
 const REDIS_CACHE_KEY = 'supply_chain:chokepoints:v1';
-const REDIS_CACHE_TTL = 300;
+const REDIS_CACHE_TTL = 900; // 15 min
 
 interface ChokepointConfig {
   id: string;

--- a/src/App.ts
+++ b/src/App.ts
@@ -508,7 +508,7 @@ export class App {
         { name: 'markets', fn: () => this.dataLoader.loadMarkets(), intervalMs: REFRESH_INTERVALS.markets },
         { name: 'predictions', fn: () => this.dataLoader.loadPredictions(), intervalMs: REFRESH_INTERVALS.predictions },
         { name: 'pizzint', fn: () => this.dataLoader.loadPizzInt(), intervalMs: 10 * 60 * 1000 },
-        { name: 'natural', fn: () => this.dataLoader.loadNatural(), intervalMs: 5 * 60 * 1000, condition: () => this.state.mapLayers.natural },
+        { name: 'natural', fn: () => this.dataLoader.loadNatural(), intervalMs: 60 * 60 * 1000, condition: () => this.state.mapLayers.natural },
         { name: 'weather', fn: () => this.dataLoader.loadWeatherAlerts(), intervalMs: 10 * 60 * 1000, condition: () => this.state.mapLayers.weather },
         { name: 'fred', fn: () => this.dataLoader.loadFredData(), intervalMs: 30 * 60 * 1000 },
         { name: 'oil', fn: () => this.dataLoader.loadOilAnalytics(), intervalMs: 30 * 60 * 1000 },
@@ -517,7 +517,7 @@ export class App {
         { name: 'firms', fn: () => this.dataLoader.loadFirmsData(), intervalMs: 30 * 60 * 1000 },
         { name: 'ais', fn: () => this.dataLoader.loadAisSignals(), intervalMs: REFRESH_INTERVALS.ais, condition: () => this.state.mapLayers.ais },
         { name: 'cables', fn: () => this.dataLoader.loadCableActivity(), intervalMs: 30 * 60 * 1000, condition: () => this.state.mapLayers.cables },
-        { name: 'cableHealth', fn: () => this.dataLoader.loadCableHealth(), intervalMs: 5 * 60 * 1000, condition: () => this.state.mapLayers.cables },
+        { name: 'cableHealth', fn: () => this.dataLoader.loadCableHealth(), intervalMs: 2 * 60 * 60 * 1000, condition: () => this.state.mapLayers.cables },
         { name: 'flights', fn: () => this.dataLoader.loadFlightDelays(), intervalMs: 2 * 60 * 60 * 1000, condition: () => this.state.mapLayers.flights },
         { name: 'cyberThreats', fn: () => {
           this.state.cyberThreatsCache = null;

--- a/src/components/IntelligenceGapBadge.ts
+++ b/src/components/IntelligenceGapBadge.ts
@@ -9,7 +9,7 @@ import { trackFindingClicked } from '@/services/analytics';
 const LOW_COUNT_THRESHOLD = 3;
 const MAX_VISIBLE_FINDINGS = 10;
 const SORT_TIME_TOLERANCE_MS = 60000;
-const REFRESH_INTERVAL_MS = 60000;
+const REFRESH_INTERVAL_MS = 180000;
 const ALERT_HOURS = 6;
 const STORAGE_KEY = 'worldmonitor-intel-findings';
 const POPUP_STORAGE_KEY = 'wm-alert-popup-enabled';

--- a/src/config/variants/base.ts
+++ b/src/config/variants/base.ts
@@ -9,9 +9,9 @@ export { AI_DATA_CENTERS } from '../ai-datacenters';
 // Refresh intervals - shared across all variants
 export const REFRESH_INTERVALS = {
   feeds: 7 * 60 * 1000,
-  markets: 4 * 60 * 1000,
-  crypto: 4 * 60 * 1000,
-  predictions: 5 * 60 * 1000,
+  markets: 8 * 60 * 1000,
+  crypto: 8 * 60 * 1000,
+  predictions: 10 * 60 * 1000,
   ais: 10 * 60 * 1000,
 };
 

--- a/src/services/earthquakes.ts
+++ b/src/services/earthquakes.ts
@@ -10,7 +10,7 @@ import { getHydratedData } from '@/services/bootstrap';
 export type { Earthquake };
 
 const client = new SeismologyServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });
-const breaker = createCircuitBreaker<ListEarthquakesResponse>({ name: 'Seismology', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
+const breaker = createCircuitBreaker<ListEarthquakesResponse>({ name: 'Seismology', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
 
 const emptyFallback: ListEarthquakesResponse = { earthquakes: [] };
 

--- a/src/services/gdacs.ts
+++ b/src/services/gdacs.ts
@@ -42,7 +42,7 @@ interface GDACSResponse {
 }
 
 const GDACS_API = 'https://www.gdacs.org/gdacsapi/api/events/geteventlist/MAP';
-const breaker = createCircuitBreaker<GDACSEvent[]>({ name: 'GDACS', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
+const breaker = createCircuitBreaker<GDACSEvent[]>({ name: 'GDACS', cacheTtlMs: 10 * 60 * 1000, persistCache: true });
 
 const EVENT_TYPE_NAMES: Record<string, string> = {
   EQ: 'Earthquake',

--- a/src/services/gdelt-intel.ts
+++ b/src/services/gdelt-intel.ts
@@ -125,7 +125,7 @@ export function getIntelTopics(): IntelTopic[] {
 // ---- Sebuf client ----
 
 const client = new IntelligenceServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });
-const gdeltBreaker = createCircuitBreaker<SearchGdeltDocumentsResponse>({ name: 'GDELT Intelligence', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
+const gdeltBreaker = createCircuitBreaker<SearchGdeltDocumentsResponse>({ name: 'GDELT Intelligence', cacheTtlMs: 10 * 60 * 1000, persistCache: true });
 
 const emptyGdeltFallback: SearchGdeltDocumentsResponse = { articles: [], query: '', error: '' };
 

--- a/src/services/infrastructure/index.ts
+++ b/src/services/infrastructure/index.ts
@@ -21,8 +21,8 @@ import { getHydratedData } from '@/services/bootstrap';
 // ---- Client + Circuit Breakers ----
 
 const client = new InfrastructureServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });
-const outageBreaker = createCircuitBreaker<ListInternetOutagesResponse>({ name: 'Internet Outages', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
-const statusBreaker = createCircuitBreaker<ListServiceStatusesResponse>({ name: 'Service Statuses', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
+const outageBreaker = createCircuitBreaker<ListInternetOutagesResponse>({ name: 'Internet Outages', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
+const statusBreaker = createCircuitBreaker<ListServiceStatusesResponse>({ name: 'Service Statuses', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
 
 const emptyOutageFallback: ListInternetOutagesResponse = { outages: [], pagination: undefined };
 const emptyStatusFallback: ListServiceStatusesResponse = { statuses: [] };

--- a/src/services/maritime/index.ts
+++ b/src/services/maritime/index.ts
@@ -12,7 +12,7 @@ import { isFeatureAvailable } from '../runtime-config';
 // ---- Proto fallback (desktop safety when relay URL is unavailable) ----
 
 const client = new MaritimeServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });
-const snapshotBreaker = createCircuitBreaker<GetVesselSnapshotResponse>({ name: 'Maritime Snapshot', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
+const snapshotBreaker = createCircuitBreaker<GetVesselSnapshotResponse>({ name: 'Maritime Snapshot', cacheTtlMs: 10 * 60 * 1000, persistCache: true });
 const emptySnapshotFallback: GetVesselSnapshotResponse = { snapshot: undefined };
 
 const DISRUPTION_TYPE_REVERSE: Record<string, AisDisruptionType> = {
@@ -127,8 +127,8 @@ let latestStatus: SnapshotStatus = {
 
 // ---- Constants ----
 
-const SNAPSHOT_POLL_INTERVAL_MS = 30 * 1000;
-const SNAPSHOT_STALE_MS = 45 * 1000;
+const SNAPSHOT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+const SNAPSHOT_STALE_MS = 6 * 60 * 1000;
 const CALLBACK_RETENTION_MS = 2 * 60 * 60 * 1000; // 2 hours
 const MAX_CALLBACK_TRACKED_VESSELS = 20000;
 

--- a/src/services/military-flights.ts
+++ b/src/services/military-flights.ts
@@ -38,7 +38,7 @@ const breaker = createCircuitBreaker<{ flights: MilitaryFlight[]; clusters: Mili
   name: 'Military Flight Tracking',
   maxFailures: 3,
   cooldownMs: 5 * 60 * 1000, // 5 minute cooldown
-  cacheTtlMs: 5 * 60 * 1000, // 5 minute cache
+  cacheTtlMs: 10 * 60 * 1000,
 });
 
 // OpenSky API returns arrays in this order:

--- a/src/services/military-vessels.ts
+++ b/src/services/military-vessels.ts
@@ -34,7 +34,7 @@ const breaker = createCircuitBreaker<{ vessels: MilitaryVessel[]; clusters: Mili
   name: 'Military Vessel Tracking',
   maxFailures: 3,
   cooldownMs: 5 * 60 * 1000,
-  cacheTtlMs: 5 * 60 * 1000,
+  cacheTtlMs: 10 * 60 * 1000,
 });
 
 // Strategic chokepoints for naval monitoring

--- a/src/services/oref-alerts.ts
+++ b/src/services/oref-alerts.ts
@@ -208,7 +208,7 @@ export function startOrefPolling(): void {
   pollingInterval = setInterval(async () => {
     const data = await fetchOrefAlerts();
     for (const cb of updateCallbacks) cb(data);
-  }, 10_000);
+  }, 120_000);
 }
 
 export function stopOrefPolling(): void {

--- a/src/services/pizzint.ts
+++ b/src/services/pizzint.ts
@@ -19,7 +19,7 @@ const pizzintBreaker = createCircuitBreaker<PizzIntStatus>({
   name: 'PizzINT',
   maxFailures: 3,
   cooldownMs: 5 * 60 * 1000,
-  cacheTtlMs: 2 * 60 * 1000,
+  cacheTtlMs: 30 * 60 * 1000,
   persistCache: true,
 });
 

--- a/src/services/prediction/index.ts
+++ b/src/services/prediction/index.ts
@@ -61,7 +61,7 @@ const DIRECT_RAILWAY_POLY_URL = wsRelayUrl
 const isLocalhostRuntime = typeof window !== 'undefined' && ['localhost', '127.0.0.1'].includes(window.location.hostname);
 const PROXY_STRIP_KEYS = new Set(['end_date_min', 'active', 'archived']);
 
-const breaker = createCircuitBreaker<PredictionMarket[]>({ name: 'Polymarket', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
+const breaker = createCircuitBreaker<PredictionMarket[]>({ name: 'Polymarket', cacheTtlMs: 10 * 60 * 1000, persistCache: true });
 
 // Sebuf client for strategy 4
 const client = new PredictionServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });

--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -26,7 +26,7 @@ export type {
 const client = new SupplyChainServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });
 
 const shippingBreaker = createCircuitBreaker<GetShippingRatesResponse>({ name: 'Shipping Rates', cacheTtlMs: 15 * 60 * 1000, persistCache: true });
-const chokepointBreaker = createCircuitBreaker<GetChokepointStatusResponse>({ name: 'Chokepoint Status', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
+const chokepointBreaker = createCircuitBreaker<GetChokepointStatusResponse>({ name: 'Chokepoint Status', cacheTtlMs: 20 * 60 * 1000, persistCache: true });
 const mineralsBreaker = createCircuitBreaker<GetCriticalMineralsResponse>({ name: 'Critical Minerals', cacheTtlMs: 60 * 60 * 1000, persistCache: true });
 
 const emptyShipping: GetShippingRatesResponse = { indices: [], fetchedAt: '', upstreamUnavailable: false };

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -35,7 +35,7 @@ interface NWSResponse {
 }
 
 const NWS_API = 'https://api.weather.gov/alerts/active';
-const breaker = createCircuitBreaker<WeatherAlert[]>({ name: 'NWS Weather', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
+const breaker = createCircuitBreaker<WeatherAlert[]>({ name: 'NWS Weather', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
 
 export async function fetchWeatherAlerts(): Promise<WeatherAlert[]> {
   return breaker.execute(async () => {

--- a/src/services/wildfires/index.ts
+++ b/src/services/wildfires/index.ts
@@ -40,7 +40,7 @@ export interface MapFire {
 // -- Client --
 
 const client = new WildfireServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });
-const breaker = createCircuitBreaker<ListFireDetectionsResponse>({ name: 'Wildfires', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
+const breaker = createCircuitBreaker<ListFireDetectionsResponse>({ name: 'Wildfires', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
 
 const emptyFallback: ListFireDetectionsResponse = { fireDetections: [] };
 


### PR DESCRIPTION
## Summary
- Audit and raise every cache/poll interval under 5 min across **31 files** to reduce upstream API pressure, Vercel function invocations, and paid API quota usage
- Aligns CDN edge tiers with new server-side TTLs (market RPCs `fast`→`medium`, infra/seismology `fast`→`slow`)

### Frontend Polling
| Service | Before | After |
|---------|--------|-------|
| markets | 4 min | 8 min |
| crypto | 4 min | 8 min |
| predictions | 5 min | 10 min |
| natural | 5 min | 1 hr |
| cableHealth | 5 min | 2 hr |
| oref-alerts | 10s | 2 min |
| maritime snapshot | 30s | 5 min |
| IntelligenceGapBadge | 1 min | 3 min |

### Circuit Breakers (client-side)
| Breaker | Before | After |
|---------|--------|-------|
| PizzINT | 2 min | 30 min |
| Flight Delays | 5 min | 20 min |
| Seismology, Weather, Outages, Statuses, Wildfires | 5 min | 30 min |
| Military Vessels/Flights, GDACS, Maritime, Polymarket, GDELT | 5 min | 10 min |
| Chokepoint Status | 5 min | 20 min |

### Server Redis Cache
| Handler | Before | After |
|---------|--------|-------|
| market-quotes | 2 min | 8 min |
| stablecoins (in-mem/Redis) | 2/5 min | 8/10 min |
| vessel-snapshot | 10s | 5 min |
| earthquakes | 5 min | 30 min |
| sector, predictions, crypto, commodities | 5 min | 10 min |
| outages, service-statuses | 5 min | 30 min |
| macro-signals, chokepoints | 5 min | 15 min |
| aviation sim fallback | 5 min | 15 min |

## Test plan
- [ ] Verify `tsc --noEmit` passes (confirmed pre-push)
- [ ] Spot-check market quotes panel still refreshes correctly
- [ ] Verify earthquake markers appear on map
- [ ] Confirm maritime vessel tracking updates at 5 min interval