### PR TITLE
fix(linux): sanitize env for xdg-open in AppImage

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -434,6 +434,8 @@ fn open_in_shell(arg: &str) -> Result<(), String> {
     let mut command = {
         let mut cmd = Command::new("xdg-open");
         cmd.arg(arg);
+        cmd.env_remove("LD_LIBRARY_PATH");
+        cmd.env_remove("LD_PRELOAD");
         cmd
     };
 


### PR DESCRIPTION
## Summary
Fixes Linux AppImage external link failures on some distros (e.g. Arch). When spawning `xdg-open`, the AppImage runtime can leak `LD_LIBRARY_PATH` / `LD_PRELOAD` into the child process, causing `/bin/sh` to fail with a symbol lookup error (`rl_print_keybinding`). This change removes those environment variables for the `xdg-open` child process so system tools use host libraries correctly. Fixes #628.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas
- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [x] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other: <!-- specify -->

## Checklist
- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots
N/A – backend-only fix affecting Linux AppImage runtime behavior.
