### PR TITLE
fix(desktop): backoff on errors to stop CPU abuse + shrink settings window

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "world-monitor"
-version = "2.5.19"
+version = "2.5.21"
 dependencies = [
  "getrandom 0.2.17",
  "keyring",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -561,8 +561,8 @@ fn open_settings_window(app: &AppHandle) -> Result<(), String> {
 
     let _settings_window = WebviewWindowBuilder::new(app, "settings", WebviewUrl::App("settings.html".into()))
         .title("World Monitor Settings")
-        .inner_size(980.0, 760.0)
-        .min_inner_size(820.0, 620.0)
+        .inner_size(980.0, 600.0)
+        .min_inner_size(820.0, 480.0)
         .resizable(true)
         .background_color(tauri::webview::Color(26, 28, 30, 255))
         .build()

--- a/src/app/refresh-scheduler.ts
+++ b/src/app/refresh-scheduler.ts
@@ -85,7 +85,7 @@ export class RefreshScheduler implements AppModule {
         }
       } catch (e) {
         console.error(`[App] Refresh ${name} failed:`, e);
-        currentMultiplier = 1;
+        currentMultiplier = Math.min(currentMultiplier * 2, MAX_BACKOFF_MULTIPLIER);
       } finally {
         this.ctx.inFlight.delete(name);
         scheduleNext(computeDelay(intervalMs * currentMultiplier, false));

--- a/src/services/threat-classifier.ts
+++ b/src/services/threat-classifier.ts
@@ -462,9 +462,9 @@ function flushBatch(): void {
           });
           job.resolve(toThreat(resp));
         } catch (err) {
-          if (err instanceof ApiError && (err.statusCode === 429 || err.statusCode >= 500)) {
+          if (err instanceof ApiError && (err.statusCode === 401 || err.statusCode === 429 || err.statusCode >= 500)) {
             batchPaused = true;
-            const delay = err.statusCode === 429 ? 60_000 : 30_000;
+            const delay = err.statusCode === 401 ? 120_000 : err.statusCode === 429 ? 60_000 : 30_000;
             console.warn(`[Classify] ${err.statusCode} — pausing AI classification for ${delay / 1000}s`);
             const remaining = batch.slice(i + 1);
             // Failed job: increment attempts, requeue if under limit


### PR DESCRIPTION
## Summary
- **RefreshScheduler** (line 88): error handler was resetting `currentMultiplier = 1` (fastest), now backs off with `currentMultiplier * 2` — matches the unchanged-data path
- **classify-event batch**: 401 auth failures now pause the batch for 120s instead of silently resolving null and continuing every 2s
- **Fetch patch 401 retry**: after a token-refresh + retry still returns 401, suppress further retries for 60s (prevents doubling every request)
- **Settings window**: 760→600px height, min 620→480px

## Context
Desktop app burns 130% CPU when sidecar auth fails. Log shows 358 401s + 23 503s in 3.5 min — every request doubled by the 401 retry, scheduler polling at max rate because errors reset backoff, classify-event firing every 2s without stopping.

## Test plan
- [ ] Verify web app still refreshes data on normal intervals (RefreshScheduler change only affects error path)
- [ ] Desktop: confirm CPU usage drops significantly when auth is broken
- [ ] Settings window: check all tabs fit without excessive whitespace