### PR TITLE
fix(sentry): null guards + noise filters + beforeSend regex fix

### DIFF
--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -251,7 +251,7 @@ export class EventHandlerManager implements AppModule {
     this.setupMapPin();
 
     this.boundVisibilityHandler = () => {
-      document.body.classList.toggle('animations-paused', document.hidden);
+      document.body?.classList.toggle('animations-paused', document.hidden);
       if (document.hidden) {
         this.callbacks.setHiddenSince(Date.now());
         mlWorker.unloadOptionalModels();
@@ -299,7 +299,7 @@ export class EventHandlerManager implements AppModule {
     this.boundIdleResetHandler = () => {
       if (this.ctx.isIdle) {
         this.ctx.isIdle = false;
-        document.body.classList.remove('animations-paused');
+        document.body?.classList.remove('animations-paused');
       }
       this.resetIdleTimer();
     };
@@ -318,7 +318,7 @@ export class EventHandlerManager implements AppModule {
     this.idleTimeoutId = setTimeout(() => {
       if (!document.hidden) {
         this.ctx.isIdle = true;
-        document.body.classList.add('animations-paused');
+        document.body?.classList.add('animations-paused');
         console.log('[App] User idle - pausing animations to save resources');
       }
     }, this.IDLE_PAUSE_MS);

--- a/src/components/BreakingNewsBanner.ts
+++ b/src/components/BreakingNewsBanner.ts
@@ -93,7 +93,7 @@ export class BreakingNewsBanner {
 
   private updatePosition(): void {
     let top = 50;
-    if (document.body.classList.contains('has-critical-banner')) {
+    if (document.body?.classList.contains('has-critical-banner')) {
       this.attachResizeObserverIfNeeded();
       const postureBanner = document.querySelector('.critical-posture-banner');
       if (postureBanner) {
@@ -110,7 +110,7 @@ export class BreakingNewsBanner {
       '--breaking-alert-offset',
       height > 0 ? `${height}px` : '0px'
     );
-    document.body.classList.toggle('has-breaking-alert', this.activeAlerts.length > 0);
+    document.body?.classList.toggle('has-breaking-alert', this.activeAlerts.length > 0);
   }
 
   private isDismissedRecently(id: string): boolean {

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -456,11 +456,11 @@ export class Panel {
     this.onTouchCancel = this.onTouchEnd;
 
     this.onDocMouseUp = () => {
-      if (this.element.dataset.resizing) {
+      if (this.element?.dataset.resizing) {
         delete this.element.dataset.resizing;
       }
       if (!this.isResizing && !this.isColResizing) {
-        document.body.classList.remove('panel-resize-active');
+        document.body?.classList.remove('panel-resize-active');
       }
     };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,6 +130,13 @@ Sentry.init({
     /webkitCurrentPlaybackTargetIsWireless/,
     /null is not an object \(evaluating '\w+\.theme'\)/,
     /this\.player\.\w+ is not a function/,
+    /videoTrack\.configuration/,
+    /evaluating 'v\.setProps'/,
+    /button\[aria-label/,
+    /The fetching process for the media resource was aborted/,
+    /Invalid regular expression: missing/,
+    /WeixinJSBridge/,
+    /evaluating 'e\.type'/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';
@@ -137,12 +144,12 @@ Sentry.init({
     const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
     // Suppress maplibre internal null-access crashes (light, placement) only when stack is in map chunk
     if (/this\.style\._layers|reading '_layers'|this\.light is null|can't access property "(id|type|setFilter)", \w+ is (null|undefined)|Cannot read properties of null \(reading '(id|type|setFilter|_layers)'\)|null is not an object \(evaluating '\w{1,3}\.(id|style)|^\w{1,2} is null$/.test(msg)) {
-      if (frames.some(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9-]+\.js/.test(f.filename ?? ''))) return null;
+      if (frames.some(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     }
     // Suppress any TypeError that happens entirely within maplibre or deck.gl internals
     if (/^TypeError:/.test(msg) && frames.length > 0) {
-      const nonSentryFrames = frames.filter(f => f.filename && f.filename !== '<anonymous>' && !/\/sentry-[A-Za-z0-9-]+\.js/.test(f.filename));
-      if (nonSentryFrames.length > 0 && nonSentryFrames.every(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9-]+\.js/.test(f.filename ?? ''))) return null;
+      const nonSentryFrames = frames.filter(f => f.filename && f.filename !== '<anonymous>' && !/\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename));
+      if (nonSentryFrames.length > 0 && nonSentryFrames.every(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     }
     // Suppress errors originating entirely from blob: URLs (browser extensions)
     if (frames.length > 0 && frames.every(f => /^blob:/.test(f.filename ?? ''))) return null;


### PR DESCRIPTION
## Summary
- **Null guards** on `document.body?.classList` in 3 event handlers (visibilitychange, resize, mouseup) that crash during page teardown — fixes WORLDMONITOR-40, 6Y, 6Z
- **7 new `ignoreErrors` patterns** for third-party noise: Safari `videoTrack.configuration`, deck.gl `setProps`, Facebook/WeChat in-app browser injections, media abort, regex injection
- **Fixed `beforeSend` chunk-hash regex** — added underscore to character class (`[A-Za-z0-9-]` → `[A-Za-z0-9_-]`) so Vite hashes like `BPZ27_H4` match, properly suppressing deck.gl internal crashes (WORLDMONITOR-71, 6V, 6W)

All 12 unresolved Sentry issues resolved (`inNextRelease: true`).

## Test plan
- [ ] `npx tsc --noEmit` passes (only pre-existing posthog-js stub missing)
- [ ] Verify no regressions on visibility/resize/mouseup handlers
- [ ] Confirm new ignoreErrors patterns don't suppress real bugs (all are specific to third-party error messages)