### PR TITLE
fix(oref): show OREF history count in badge and stop swallowing fetch errors

### DIFF
--- a/src/components/OrefSirensPanel.ts
+++ b/src/components/OrefSirensPanel.ts
@@ -36,7 +36,7 @@ export class OrefSirensPanel extends Panel {
     const prevCount = this.alerts.length;
     this.alerts = data.alerts || [];
     this.historyCount24h = data.historyCount24h || 0;
-    this.setCount(this.alerts.length);
+    this.setCount(this.alerts.length || this.historyCount24h);
 
     if (prevCount === 0 && this.alerts.length > 0) {
       this.setNewBadge(this.alerts.length);
@@ -58,7 +58,7 @@ export class OrefSirensPanel extends Panel {
           this.render();
         }
       })
-      .catch(() => {})
+      .catch((err) => { console.warn('[OrefSirensPanel] History fetch failed:', err); })
       .finally(() => { this.historyFetchInFlight = false; });
   }
 
@@ -90,7 +90,15 @@ export class OrefSirensPanel extends Panel {
   }
 
   private renderHistoryWaves(): string {
-    if (!this.historyWaves.length) return '';
+    if (!this.historyWaves.length) {
+      if (this.historyCount24h > 0) {
+        return `<div class="oref-history-section">
+          <div class="oref-history-title">${t('components.orefSirens.historySummary', { count: String(this.historyCount24h), waves: '...' })}</div>
+          <div class="oref-wave-list" style="opacity:0.5;text-align:center;padding:8px">${t('components.orefSirens.loadingHistory', { defaultValue: 'Loading history...' })}</div>
+        </div>`;
+      }
+      return '';
+    }
 
     const now = Date.now();
     const withTs = this.historyWaves.map(w => ({ wave: w, ts: new Date(w.timestamp).getTime() }));

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1132,6 +1132,7 @@
       "justNow": "just now",
       "historyCount": "{{count}} alerts in last 24h",
       "historySummary": "{{count}} alerts in 24h — {{waves}} waves",
+      "loadingHistory": "Loading history...",
       "infoTooltip": "<strong>Israel Sirens</strong><br>Real-time rocket and missile siren alerts from Israel Home Front Command.<br><br>Data is polled every 10 seconds. A pulsing red indicator means active sirens are sounding."
     },
     "satelliteFires": {

--- a/src/services/oref-alerts.ts
+++ b/src/services/oref-alerts.ts
@@ -179,6 +179,7 @@ export async function fetchOrefHistory(): Promise<OrefHistoryResponse> {
       headers: { Accept: 'application/json' },
     });
     if (!res.ok) {
+      console.warn('[OREF History] HTTP', res.status);
       return { configured: false, history: [], historyCount24h: 0, timestamp: new Date().toISOString(), error: `HTTP ${res.status}` };
     }
     const data: OrefHistoryResponse = await res.json();


### PR DESCRIPTION
## Summary
- Badge count now falls back to `historyCount24h` when no active sirens (was always 0)
- History fetch errors are logged instead of silently swallowed via `.catch(() => {})`
- Shows immediate history summary ("500 alerts in 24h") while full wave data loads

## Context
Railway relay bootstraps 500+ OREF history records, but the panel badge showed `0` and no history section rendered. Root cause: `setCount(this.alerts.length)` only counted active alerts, and `loadHistory()` errors were silently eaten.

## Test plan
- [ ] Verify badge shows `historyCount24h` when no active sirens
- [ ] Check console for `[OrefSirensPanel] History fetch failed` if history endpoint is down
- [ ] Confirm history section shows "Loading history..." placeholder before waves load
- [ ] Confirm full history waves replace placeholder once loaded