### PR TITLE
fix(oref): grab newest history records and preserve bootstrap data

### DIFF
--- a/src/components/OrefSirensPanel.ts
+++ b/src/components/OrefSirensPanel.ts
@@ -11,6 +11,7 @@ const HISTORY_TTL = 3 * 60 * 1000;
 export class OrefSirensPanel extends Panel {
   private alerts: OrefAlert[] = [];
   private historyCount24h = 0;
+  private totalHistoryCount = 0;
   private historyWaves: OrefHistoryEntry[] = [];
   private historyFetchInFlight = false;
   private historyLastFetchAt = 0;
@@ -36,7 +37,8 @@ export class OrefSirensPanel extends Panel {
     const prevCount = this.alerts.length;
     this.alerts = data.alerts || [];
     this.historyCount24h = data.historyCount24h || 0;
-    this.setCount(this.alerts.length || this.historyCount24h);
+    this.totalHistoryCount = data.totalHistoryCount || 0;
+    this.setCount(this.alerts.length || this.historyCount24h || this.totalHistoryCount);
 
     if (prevCount === 0 && this.alerts.length > 0) {
       this.setNewBadge(this.alerts.length);

--- a/src/services/oref-alerts.ts
+++ b/src/services/oref-alerts.ts
@@ -14,6 +14,7 @@ export interface OrefAlertsResponse {
   configured: boolean;
   alerts: OrefAlert[];
   historyCount24h: number;
+  totalHistoryCount?: number;
   timestamp: string;
   error?: string;
 }


### PR DESCRIPTION
## Summary
- **Root cause**: OREF `AlertsHistory.json` returns records newest-first, but `.slice(-500)` took the oldest 500 — all outside the 24h window. The poll loop then purged them all, leaving `historyCount24h = 0` and an empty history panel.
- Bootstrap history now kept for 7 days instead of being purged at 24h
- New `totalHistoryCount` field exposed in relay API for badge fallback

## Changes
- `scripts/ais-relay.cjs`: Fix `.slice(-500)` → `.slice(0, 500)`, extend purge to 7d, add `totalHistoryCount`
- `src/components/OrefSirensPanel.ts`: Badge falls back to `totalHistoryCount`
- `src/services/oref-alerts.ts`: Add `totalHistoryCount` to interface

## Test plan
- [ ] Deploy relay to Railway first, verify `/health` shows `totalHistoryCount > 0` and `historyWaves > 0`
- [ ] Deploy frontend to Vercel, verify badge shows non-zero count
- [ ] Confirm history panel renders wave data