### PR TITLE
feat: expand live channels with HLS support and Oceania region

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -117,28 +117,41 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'wion', name: 'WION', handle: '@WION' },
   { id: 'ndtv', name: 'NDTV 24x7', handle: '@NDTV' },
   { id: 'cna-asia', name: 'CNA (NewsAsia)', handle: '@channelnewsasia', fallbackVideoId: 'XWq5kBlakcQ' },
-  { id: 'nhk-world', name: 'NHK World Japan', handle: '@NHKWORLDJAPAN' },
+  { id: 'nhk-world', name: 'NHK World Japan', handle: '@NHKWORLDJAPAN', fallbackVideoId: 'f0lYfG_vY_U' },
+  { id: 'arirang-news', name: 'Arirang News', handle: '@ArirangCoKrArirangNEWS' },
+  { id: 'india-today', name: 'India Today', handle: '@indiatoday', fallbackVideoId: 'sYZtOFzM78M' },
+  { id: 'abp-news', name: 'ABP News', handle: '@ABPNews' },
   // Middle East
   { id: 'al-hadath', name: 'Al Hadath', handle: '@AlHadath', fallbackVideoId: 'xWXpl7azI8k', useFallbackOnly: true },
   { id: 'sky-news-arabia', name: 'Sky News Arabia', handle: '@skynewsarabia', fallbackVideoId: 'U--OjmpjF5o' },
   { id: 'trt-world', name: 'TRT World', handle: '@TRTWorld', fallbackVideoId: 'ABfFhWzWs0s' },
   { id: 'iran-intl', name: 'Iran International', handle: '@IranIntl' },
   { id: 'cgtn-arabic', name: 'CGTN Arabic', handle: '@CGTNArabic' },
+  { id: 'kan-11', name: 'Kan 11', handle: '@KAN11NEWS', fallbackVideoId: 'TCnaIE_SAtM' },
   // Africa
   { id: 'africanews', name: 'Africanews', handle: '@africanews' },
   { id: 'channels-tv', name: 'Channels TV', handle: '@ChannelsTelevision' },
   { id: 'ktn-news', name: 'KTN News', handle: '@ktnnews_kenya', fallbackVideoId: 'RmHtsdVb3mo' },
   { id: 'enca', name: 'eNCA', handle: '@encanews' },
   { id: 'sabc-news', name: 'SABC News', handle: '@SABCDigitalNews' },
+  { id: 'arise-news', name: 'Arise News', handle: '@AriseNewsChannel', fallbackVideoId: '4uHZdlX-DT4' },
+  // Europe (additional)
+  { id: 'tagesschau24', name: 'Tagesschau24', handle: '@tagesschau', fallbackVideoId: 'fC_q9TkO1uU' },
+  { id: 'tv5monde-info', name: 'TV5 Monde Info', handle: '@TV5MONDEInfo' },
+  { id: 'nrk1', name: 'NRK1', handle: '@nrk' },
+  { id: 'aljazeera-balkans', name: 'Al Jazeera Balkans', handle: '@AlJazeeraBalkans' },
+  // Oceania
+  { id: 'abc-news-au', name: 'ABC News Australia', handle: '@abcnewsaustralia', fallbackVideoId: 'vOTiJkg1voo' },
 ];
 
 export const OPTIONAL_CHANNEL_REGIONS: { key: string; labelKey: string; channelIds: string[] }[] = [
   { key: 'na', labelKey: 'components.liveNews.regionNorthAmerica', channelIds: ['livenow-fox', 'fox-news', 'newsmax', 'abc-news', 'cbs-news', 'nbc-news', 'cbc-news'] },
-  { key: 'eu', labelKey: 'components.liveNews.regionEurope', channelIds: ['bbc-news', 'france24-en', 'welt', 'rtve', 'trt-haber', 'ntv-turkey', 'cnn-turk', 'tv-rain', 'rt', 'tvp-info', 'telewizja-republika'] },
+  { key: 'eu', labelKey: 'components.liveNews.regionEurope', channelIds: ['bbc-news', 'france24-en', 'welt', 'rtve', 'trt-haber', 'ntv-turkey', 'cnn-turk', 'tv-rain', 'rt', 'tvp-info', 'telewizja-republika', 'tagesschau24', 'tv5monde-info', 'nrk1', 'aljazeera-balkans'] },
   { key: 'latam', labelKey: 'components.liveNews.regionLatinAmerica', channelIds: ['cnn-brasil', 'jovem-pan', 'record-news', 'band-jornalismo', 'tn-argentina', 'c5n', 'milenio', 'noticias-caracol', 'ntn24', 't13'] },
-  { key: 'asia', labelKey: 'components.liveNews.regionAsia', channelIds: ['tbs-news', 'ann-news', 'ntv-news', 'cti-news', 'wion', 'ndtv', 'cna-asia', 'nhk-world'] },
-  { key: 'me', labelKey: 'components.liveNews.regionMiddleEast', channelIds: ['al-hadath', 'sky-news-arabia', 'trt-world', 'iran-intl', 'cgtn-arabic'] },
-  { key: 'africa', labelKey: 'components.liveNews.regionAfrica', channelIds: ['africanews', 'channels-tv', 'ktn-news', 'enca', 'sabc-news'] },
+  { key: 'asia', labelKey: 'components.liveNews.regionAsia', channelIds: ['tbs-news', 'ann-news', 'ntv-news', 'cti-news', 'wion', 'ndtv', 'cna-asia', 'nhk-world', 'arirang-news', 'india-today', 'abp-news'] },
+  { key: 'me', labelKey: 'components.liveNews.regionMiddleEast', channelIds: ['al-hadath', 'sky-news-arabia', 'trt-world', 'iran-intl', 'cgtn-arabic', 'kan-11'] },
+  { key: 'africa', labelKey: 'components.liveNews.regionAfrica', channelIds: ['africanews', 'channels-tv', 'ktn-news', 'enca', 'sabc-news', 'arise-news'] },
+  { key: 'oc', labelKey: 'components.liveNews.regionOceania', channelIds: ['abc-news-au'] },
 ];
 
 const DEFAULT_LIVE_CHANNELS = SITE_VARIANT === 'tech' ? TECH_LIVE_CHANNELS : SITE_VARIANT === 'happy' ? [] : FULL_LIVE_CHANNELS;
@@ -171,6 +184,21 @@ const DIRECT_HLS_MAP: Readonly<Record<string, string>> = {
   'sky-news-arabia': 'https://live-stream.skynewsarabia.com/c-horizontal-channel/horizontal-stream/index.m3u8',
   'al-hadath': 'https://av.alarabiya.net/alarabiapublish/alhadath.smil/playlist.m3u8',
   'rt': 'https://rt-glb.rttv.com/dvr/rtnews/playlist.m3u8',
+  'abc-news-au': 'https://abc-iview-mediapackagestreams-2.akamaized.net/out/v1/6e1cc6d25ec0480ea099a5399d73bc4b/index.m3u8',
+  'bbc-news': 'https://vs-hls-push-uk.live.fastly.md.bbci.co.uk/x=4/i=urn:bbc:pips:service:bbc_news_channel_hd/iptv_hd_abr_v1.m3u8',
+  'tagesschau24': 'https://tagesschau.akamaized.net/hls/live/2020115/tagesschau/tagesschau_1/master.m3u8',
+  'india-today': 'https://indiatodaylive.akamaized.net/hls/live/2014320/indiatoday/indiatodaylive/playlist.m3u8',
+  'kan-11': 'https://kan11.media.kan.org.il/hls/live/2024514/2024514/master.m3u8',
+  'tv5monde-info': 'https://ott.tv5monde.com/Content/HLS/Live/channel(info)/index.m3u8',
+  'arise-news': 'https://liveedge-arisenews.visioncdn.com/live-hls/arisenews/arisenews/arisenews_web/master.m3u8',
+  'nhk-world': 'https://nhkwlive-ojp.akamaized.net/hls/live/2003459/nhkwlive-ojp-en/index_4M.m3u8',
+  'cbc-news': 'https://cbcnewshd-f.akamaihd.net/i/cbcnews_1@8981/index_2500_av-p.m3u8',
+  'record-news': 'https://stream.ads.ottera.tv/playlist.m3u8?network_id=2116',
+  'abp-news': 'https://abplivetv.pc.cdn.bitgravity.com/httppush/abp_livetv/abp_abpnews/master.m3u8',
+  'nrk1': 'https://nrk-nrk1.akamaized.net/21/0/hls/nrk_1/playlist.m3u8',
+  'aljazeera-balkans': 'https://live-hls-web-ajb.getaj.net/AJB/index.m3u8',
+  'sabc-news': 'https://sabconetanw.cdn.mangomolo.com/news/smil:news.stream.smil/chunklist_b250000_t64MjQwcA==.m3u8',
+  'arirang-news': 'https://amdlive-ch01-ctnd-com.akamaized.net/arirang_1ch/smil:arirang_1ch.smil/playlist.m3u8',
 };
 
 if (import.meta.env.DEV) {

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1308,7 +1308,8 @@
       "regionLatinAmerica": "أمريكا اللاتينية",
       "regionAsia": "آسيا",
       "regionMiddleEast": "الشرق الأوسط",
-      "regionAfrica": "أفريقيا"
+      "regionAfrica": "أفريقيا",
+      "regionOceania": "أوقيانوسيا"
     },
     "securityAdvisories": {
       "loading": "جاري جلب التحذيرات الأمنية...",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1308,7 +1308,8 @@
       "regionLatinAmerica": "Lateinamerika",
       "regionAsia": "Asien",
       "regionMiddleEast": "Naher Osten",
-      "regionAfrica": "Afrika"
+      "regionAfrica": "Afrika",
+      "regionOceania": "Ozeanien"
     },
     "securityAdvisories": {
       "loading": "Reisehinweise werden geladen...",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -1335,7 +1335,8 @@
       "regionLatinAmerica": "Λατινική Αμερική",
       "regionAsia": "Ασία",
       "regionMiddleEast": "Μέση Ανατολή",
-      "regionAfrica": "Αφρική"
+      "regionAfrica": "Αφρική",
+      "regionOceania": "Ωκεανία"
     },
     "securityAdvisories": {
       "loading": "Φόρτωση ταξιδιωτικών οδηγιών...",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1450,6 +1450,7 @@
       "regionAsia": "Asia",
       "regionMiddleEast": "Middle East",
       "regionAfrica": "Africa",
+      "regionOceania": "Oceania",
       "invalidHandle": "Enter a valid YouTube handle (e.g. @ChannelName)",
       "channelNotFound": "YouTube channel not found",
       "verifying": "Verifying…"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1308,7 +1308,8 @@
       "regionLatinAmerica": "Latinoamérica",
       "regionAsia": "Asia",
       "regionMiddleEast": "Oriente Medio",
-      "regionAfrica": "África"
+      "regionAfrica": "África",
+      "regionOceania": "Oceanía"
     },
     "securityAdvisories": {
       "loading": "Cargando alertas de viaje...",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1308,7 +1308,8 @@
       "regionLatinAmerica": "Amérique latine",
       "regionAsia": "Asie",
       "regionMiddleEast": "Moyen-Orient",
-      "regionAfrica": "Afrique"
+      "regionAfrica": "Afrique",
+      "regionOceania": "Océanie"
     },
     "securityAdvisories": {
       "loading": "Chargement des avis de voyage...",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -1308,7 +1308,8 @@
       "regionLatinAmerica": "America Latina",
       "regionAsia": "Asia",
       "regionMiddleEast": "Medio Oriente",
-      "regionAfrica": "Africa"
+      "regionAfrica": "Africa",
+      "regionOceania": "Oceania"
     },
     "securityAdvisories": {
       "loading": "Caricamento avvisi di viaggio...",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1308,7 +1308,8 @@
       "regionLatinAmerica": "中南米",
       "regionAsia": "アジア",
       "regionMiddleEast": "中東",
-      "regionAfrica": "アフリカ"
+      "regionAfrica": "アフリカ",
+      "regionOceania": "オセアニア"
     },
     "securityAdvisories": {
       "loading": "渡航情報を取得中...",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1431,7 +1431,7 @@
       "regionAsia": "아시아",
       "regionMiddleEast": "중동",
       "regionAfrica": "아프리카",
-      "invalidHandle": "유효한 YouTube 핸들을 입력하세요 (예: @ChannelName)",
+      "regionOceania": "오세아니아",      "invalidHandle": "유효한 YouTube 핸들을 입력하세요 (예: @ChannelName)",
       "channelNotFound": "YouTube 채널을 찾을 수 없습니다",
       "verifying": "확인 중…"
     }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -1166,7 +1166,8 @@
       "regionLatinAmerica": "Latijns-Amerika",
       "regionAsia": "Azië",
       "regionMiddleEast": "Midden-Oosten",
-      "regionAfrica": "Afrika"
+      "regionAfrica": "Afrika",
+      "regionOceania": "Oceanië"
     },
     "securityAdvisories": {
       "loading": "Reisadviezen laden...",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1308,7 +1308,8 @@
       "regionLatinAmerica": "Ameryka Łacińska",
       "regionAsia": "Azja",
       "regionMiddleEast": "Bliski Wschód",
-      "regionAfrica": "Afryka"
+      "regionAfrica": "Afryka",
+      "regionOceania": "Oceania"
     },
     "securityAdvisories": {
       "loading": "Ładowanie ostrzeżeń podróżnych...",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1166,7 +1166,8 @@
       "regionLatinAmerica": "América Latina",
       "regionAsia": "Ásia",
       "regionMiddleEast": "Oriente Médio",
-      "regionAfrica": "África"
+      "regionAfrica": "África",
+      "regionOceania": "Oceania"
     },
     "securityAdvisories": {
       "loading": "Carregando alertas de viagem...",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1308,7 +1308,8 @@
       "regionLatinAmerica": "Латинская Америка",
       "regionAsia": "Азия",
       "regionMiddleEast": "Ближний Восток",
-      "regionAfrica": "Африка"
+      "regionAfrica": "Африка",
+      "regionOceania": "Океания"
     },
     "securityAdvisories": {
       "loading": "Загрузка предупреждений...",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -1166,7 +1166,8 @@
       "regionLatinAmerica": "Latinamerika",
       "regionAsia": "Asien",
       "regionMiddleEast": "Mellanöstern",
-      "regionAfrica": "Afrika"
+      "regionAfrica": "Afrika",
+      "regionOceania": "Oceanien"
     },
     "securityAdvisories": {
       "loading": "Hämtar resevarningar...",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -1308,7 +1308,8 @@
       "regionLatinAmerica": "ละตินอเมริกา",
       "regionAsia": "เอเชีย",
       "regionMiddleEast": "ตะวันออกกลาง",
-      "regionAfrica": "แอฟริกา"
+      "regionAfrica": "แอฟริกา",
+      "regionOceania": "โอเชียเนีย"
     },
     "securityAdvisories": {
       "loading": "กำลังโหลดคำเตือนการเดินทาง...",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1308,7 +1308,8 @@
       "regionLatinAmerica": "Latin Amerika",
       "regionAsia": "Asya",
       "regionMiddleEast": "Orta Doğu",
-      "regionAfrica": "Afrika"
+      "regionAfrica": "Afrika",
+      "regionOceania": "Okyanusya"
     },
     "securityAdvisories": {
       "loading": "Seyahat uyarıları yükleniyor...",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -1308,7 +1308,8 @@
       "regionLatinAmerica": "Mỹ Latinh",
       "regionAsia": "Châu Á",
       "regionMiddleEast": "Trung Đông",
-      "regionAfrica": "Châu Phi"
+      "regionAfrica": "Châu Phi",
+      "regionOceania": "Châu Đại Dương"
     },
     "securityAdvisories": {
       "loading": "Đang tải cảnh báo du lịch...",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1308,7 +1308,8 @@
       "regionLatinAmerica": "拉丁美洲",
       "regionAsia": "亚洲",
       "regionMiddleEast": "中东",
-      "regionAfrica": "非洲"
+      "regionAfrica": "非洲",
+      "regionOceania": "大洋洲"
     },
     "securityAdvisories": {
       "loading": "正在加载旅行警告...",


### PR DESCRIPTION
## Summary
- Add 10 new live news channels across 5 regions + new Oceania region (ABC News Australia)
- Add 15 HLS direct stream URLs for desktop native playback
- Add verified YouTube fallback IDs for abc-news-au, arise-news, nhk-world
- Add `regionOceania` translations to all 18 locale files
- Remove n1-bih channel (HLS URL contained embedded credentials)
- Properly integrate aljazeera-balkans (was orphaned HLS entry, now has channel definition + Europe region)

## New channels
| Region | Channels |
|--------|----------|
| Europe | Tagesschau24, TV5 Monde Info, NRK1, Al Jazeera Balkans |
| Asia | Arirang News, India Today, ABP News |
| Middle East | Kan 11 |
| Africa | Arise News |
| Oceania (new) | ABC News Australia |

## Test plan
- [ ] Verify new channels appear in correct region tabs
- [ ] Test HLS playback on desktop (Tauri) for new streams
- [ ] Verify YouTube fallback works for abc-news-au, arise-news
- [ ] Confirm Oceania region tab renders with correct locale label
- [ ] Spot-check locale translations in non-English languages