### PR TITLE
ui(investments): card layout with collapsible filters

### DIFF
--- a/src/components/InvestmentsPanel.ts
+++ b/src/components/InvestmentsPanel.ts
@@ -67,6 +67,7 @@ export class InvestmentsPanel extends Panel {
   };
   private sortKey: keyof GulfInvestment = 'assetName';
   private sortAsc = true;
+  private filtersExpanded = false;
   private onInvestmentClick?: (inv: GulfInvestment) => void;
 
   constructor(onInvestmentClick?: (inv: GulfInvestment) => void) {
@@ -109,76 +110,83 @@ export class InvestmentsPanel extends Panel {
   private render(): void {
     const filtered = this.getFiltered();
 
-    // Build unique entity list for dropdown
     const entities = Array.from(new Set(GULF_INVESTMENTS.map(i => i.investingEntity))).sort();
     const sectors = Array.from(new Set(GULF_INVESTMENTS.map(i => i.sector))).sort();
 
-    const sortArrow = (key: keyof GulfInvestment) =>
-      this.sortKey === key ? (this.sortAsc ? ' ↑' : ' ↓') : '';
+    const sortCls = (key: keyof GulfInvestment) =>
+      this.sortKey === key ? 'fdi-sort fdi-sort-active' : 'fdi-sort';
+    const sortLabel = (key: keyof GulfInvestment, label: string) =>
+      this.sortKey === key ? `${label} ${this.sortAsc ? '↑' : '↓'}` : label;
+
+    const hasActiveFilter = this.filters.investingCountry !== 'ALL'
+      || this.filters.sector !== 'ALL'
+      || this.filters.entity !== 'ALL'
+      || this.filters.status !== 'ALL';
 
     const rows = filtered.map(inv => {
       const statusColor = STATUS_COLORS[inv.status] || '#6b7280';
       const flag = FLAG[inv.investingCountry] || '';
-      const sector = getSectorLabel(inv.sector);
+      const sectorLabel = getSectorLabel(inv.sector);
+      const year = inv.yearAnnounced ?? inv.yearOperational ?? '—';
       return `
-        <tr class="fdi-row" data-id="${escapeHtml(inv.id)}" style="cursor:pointer">
-          <td class="fdi-asset">
+        <div class="fdi-row" data-id="${escapeHtml(inv.id)}">
+          <div class="fdi-row-line1">
             <span class="fdi-flag">${flag}</span>
-            <strong>${escapeHtml(inv.assetName)}</strong>
-            <div class="fdi-entity-sub">${escapeHtml(inv.investingEntity)}</div>
-          </td>
-          <td>${escapeHtml(inv.targetCountry)}</td>
-          <td><span class="fdi-sector-badge">${escapeHtml(sector)}</span></td>
-          <td><span class="fdi-status-dot" style="background:${statusColor}"></span>${escapeHtml(inv.status)}</td>
-          <td class="fdi-usd">${escapeHtml(formatUSD(inv.investmentUSD))}</td>
-          <td>${inv.yearAnnounced ?? inv.yearOperational ?? '—'}</td>
-        </tr>`;
+            <span class="fdi-asset-name">${escapeHtml(inv.assetName)}</span>
+            <span class="fdi-entity-sub">${escapeHtml(inv.investingEntity)}</span>
+            <span class="fdi-usd">${escapeHtml(formatUSD(inv.investmentUSD))}</span>
+          </div>
+          <div class="fdi-row-line2">
+            <span class="fdi-country">${escapeHtml(inv.targetCountry)}</span>
+            <span class="fdi-sector-badge">${escapeHtml(sectorLabel)}</span>
+            <span class="fdi-status-label"><span class="fdi-status-dot" style="background:${statusColor}"></span>${escapeHtml(inv.status)}</span>
+            <span class="fdi-year">${year}</span>
+          </div>
+        </div>`;
     }).join('');
 
+    const toggleCls = this.filtersExpanded || hasActiveFilter ? 'fdi-filter-toggle fdi-filters-active' : 'fdi-filter-toggle';
+    const filtersCls = this.filtersExpanded ? 'fdi-filters fdi-filters-open' : 'fdi-filters';
+
+    const sel = (f: string) => this.filters.status === f ? ' selected' : '';
     const html = `
-      <div class="fdi-toolbar">
-        <input
-          class="fdi-search"
-          type="text"
+      <div class="fdi-search-row">
+        <input class="fdi-search" type="text"
           placeholder="${t('components.investments.searchPlaceholder')}"
-          value="${escapeHtml(this.filters.search)}"
-        />
+          value="${escapeHtml(this.filters.search)}"/>
+        <button class="${toggleCls}" data-action="toggle-filters" title="Filters">⚙</button>
+      </div>
+      <div class="${filtersCls}">
         <select class="fdi-filter" data-filter="investingCountry">
           <option value="ALL">🌐 ${t('components.investments.allCountries')}</option>
-          <option value="SA" ${this.filters.investingCountry === 'SA' ? 'selected' : ''}>🇸🇦 ${t('components.investments.saudiArabia')}</option>
-          <option value="UAE" ${this.filters.investingCountry === 'UAE' ? 'selected' : ''}>🇦🇪 ${t('components.investments.uae')}</option>
+          <option value="SA"${this.filters.investingCountry === 'SA' ? ' selected' : ''}>🇸🇦 ${t('components.investments.saudiArabia')}</option>
+          <option value="UAE"${this.filters.investingCountry === 'UAE' ? ' selected' : ''}>🇦🇪 ${t('components.investments.uae')}</option>
         </select>
         <select class="fdi-filter" data-filter="sector">
           <option value="ALL">${t('components.investments.allSectors')}</option>
-          ${sectors.map(s => `<option value="${s}" ${this.filters.sector === s ? 'selected' : ''}>${escapeHtml(getSectorLabel(s as GulfInvestmentSector))}</option>`).join('')}
+          ${sectors.map(s => `<option value="${s}"${this.filters.sector === s ? ' selected' : ''}>${escapeHtml(getSectorLabel(s as GulfInvestmentSector))}</option>`).join('')}
         </select>
         <select class="fdi-filter" data-filter="entity">
           <option value="ALL">${t('components.investments.allEntities')}</option>
-          ${entities.map(e => `<option value="${escapeHtml(e)}" ${this.filters.entity === e ? 'selected' : ''}>${escapeHtml(e)}</option>`).join('')}
+          ${entities.map(e => `<option value="${escapeHtml(e)}"${this.filters.entity === e ? ' selected' : ''}>${escapeHtml(e)}</option>`).join('')}
         </select>
         <select class="fdi-filter" data-filter="status">
           <option value="ALL">${t('components.investments.allStatuses')}</option>
-          <option value="operational" ${this.filters.status === 'operational' ? 'selected' : ''}>${t('components.investments.operational')}</option>
-          <option value="under-construction" ${this.filters.status === 'under-construction' ? 'selected' : ''}>${t('components.investments.underConstruction')}</option>
-          <option value="announced" ${this.filters.status === 'announced' ? 'selected' : ''}>${t('components.investments.announced')}</option>
-          <option value="rumoured" ${this.filters.status === 'rumoured' ? 'selected' : ''}>${t('components.investments.rumoured')}</option>
-          <option value="divested" ${this.filters.status === 'divested' ? 'selected' : ''}>${t('components.investments.divested')}</option>
+          <option value="operational"${sel('operational')}>${t('components.investments.operational')}</option>
+          <option value="under-construction"${sel('under-construction')}>${t('components.investments.underConstruction')}</option>
+          <option value="announced"${sel('announced')}>${t('components.investments.announced')}</option>
+          <option value="rumoured"${sel('rumoured')}>${t('components.investments.rumoured')}</option>
+          <option value="divested"${sel('divested')}>${t('components.investments.divested')}</option>
         </select>
+        <div class="fdi-sort-pills">
+          <button class="${sortCls('assetName')}" data-sort="assetName">${sortLabel('assetName', t('components.investments.asset'))}</button>
+          <button class="${sortCls('investmentUSD')}" data-sort="investmentUSD">${sortLabel('investmentUSD', t('components.investments.investment'))}</button>
+          <button class="${sortCls('targetCountry')}" data-sort="targetCountry">${sortLabel('targetCountry', t('components.investments.country'))}</button>
+          <button class="${sortCls('yearAnnounced')}" data-sort="yearAnnounced">${sortLabel('yearAnnounced', t('components.investments.year'))}</button>
+        </div>
       </div>
-      <div class="fdi-table-wrap">
-        <table class="fdi-table">
-          <thead>
-            <tr>
-              <th class="fdi-sort" data-sort="assetName">${t('components.investments.asset')}${sortArrow('assetName')}</th>
-              <th class="fdi-sort" data-sort="targetCountry">${t('components.investments.country')}${sortArrow('targetCountry')}</th>
-              <th class="fdi-sort" data-sort="sector">${t('components.investments.sector')}${sortArrow('sector')}</th>
-              <th class="fdi-sort" data-sort="status">${t('components.investments.status')}${sortArrow('status')}</th>
-              <th class="fdi-sort" data-sort="investmentUSD">${t('components.investments.investment')}${sortArrow('investmentUSD')}</th>
-              <th class="fdi-sort" data-sort="yearAnnounced">${t('components.investments.year')}${sortArrow('yearAnnounced')}</th>
-            </tr>
-          </thead>
-          <tbody>${rows || `<tr><td colspan="6" class="fdi-empty">${t('components.investments.noMatch')}</td></tr>`}</tbody>
-        </table>
+      <div class="fdi-list">
+        ${rows || `<div class="fdi-empty">${t('components.investments.noMatch')}</div>`}
       </div>`;
 
     this.setContent(html);
@@ -205,9 +213,17 @@ export class InvestmentsPanel extends Panel {
 
     this.content.addEventListener('click', (e) => {
       const target = e.target as HTMLElement;
-      const th = target.closest('.fdi-sort') as HTMLElement | null;
-      if (th) {
-        const key = th.dataset.sort as keyof GulfInvestment;
+
+      const toggleBtn = target.closest('[data-action="toggle-filters"]') as HTMLElement | null;
+      if (toggleBtn) {
+        this.filtersExpanded = !this.filtersExpanded;
+        this.render();
+        return;
+      }
+
+      const sortBtn = target.closest('.fdi-sort') as HTMLElement | null;
+      if (sortBtn) {
+        const key = sortBtn.dataset.sort as keyof GulfInvestment;
         if (this.sortKey === key) {
           this.sortAsc = !this.sortAsc;
         } else {
@@ -217,6 +233,7 @@ export class InvestmentsPanel extends Panel {
         this.render();
         return;
       }
+
       const row = target.closest('.fdi-row') as HTMLElement | null;
       if (row) {
         const inv = GULF_INVESTMENTS.find(i => i.id === row.dataset.id);

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -288,3 +288,63 @@
 .oref-wave-time { font-size: 9px; color: var(--text-muted); }
 .oref-wave-summary { font-size: 10px; color: var(--text-secondary); line-height: 1.3; }
 .oref-recent-badge { font-size: 8px; font-weight: 700; color: var(--semantic-warning, #f59e0b); background: color-mix(in srgb, var(--semantic-warning, #f59e0b) 12%, transparent); padding: 1px 4px; border-radius: 3px; text-transform: uppercase; letter-spacing: 0.5px; }
+
+/* ----------------------------------------------------------
+   GCC Investments Panel (FDI)
+   ---------------------------------------------------------- */
+.fdi-search-row { display: flex; align-items: center; gap: 6px; margin-bottom: 6px; }
+.fdi-search {
+  flex: 1; min-width: 0;
+  background: var(--overlay-subtle); border: 1px solid var(--border); border-radius: 4px;
+  color: var(--text); font-size: 11px; padding: 6px 8px;
+  outline: none; transition: border-color 0.15s;
+}
+.fdi-search::placeholder { color: var(--text-faint); }
+.fdi-search:focus { border-color: var(--accent); }
+.fdi-filter-toggle {
+  flex-shrink: 0; width: 28px; height: 28px;
+  background: var(--overlay-subtle); border: 1px solid var(--border); border-radius: 4px;
+  color: var(--text-dim); font-size: 13px; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: all 0.15s;
+}
+.fdi-filter-toggle:hover { border-color: var(--accent); color: var(--accent); }
+.fdi-filter-toggle.fdi-filters-active { border-color: var(--accent); color: var(--accent); background: color-mix(in srgb, var(--accent) 10%, transparent); }
+.fdi-filters { display: none; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
+.fdi-filters.fdi-filters-open { display: flex; }
+.fdi-filter {
+  background: var(--overlay-subtle); border: 1px solid var(--border); border-radius: 3px;
+  color: var(--text-secondary); font-size: 10px; padding: 3px 6px;
+  outline: none; cursor: pointer; max-width: 140px;
+}
+.fdi-filter:focus { border-color: var(--accent); }
+.fdi-sort-pills { display: flex; gap: 2px; flex-wrap: wrap; margin-top: 4px; width: 100%; }
+.fdi-sort {
+  background: transparent; border: 1px solid var(--border-strong); border-radius: 3px;
+  color: var(--text-dim); font-size: 9px; padding: 2px 7px; cursor: pointer;
+  transition: all 0.15s; white-space: nowrap;
+}
+.fdi-sort:hover { border-color: var(--text-faint); color: var(--text-secondary); }
+.fdi-sort.fdi-sort-active { border-color: var(--accent); color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, transparent); }
+.fdi-list { display: flex; flex-direction: column; }
+.fdi-row {
+  display: flex; flex-wrap: wrap; align-items: baseline;
+  padding: 7px 8px; border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer; transition: background 0.1s; gap: 0 6px;
+}
+.fdi-row:hover { background: var(--surface-hover); }
+.fdi-row-line1 { display: flex; align-items: baseline; width: 100%; min-width: 0; gap: 6px; }
+.fdi-flag { flex-shrink: 0; }
+.fdi-asset-name { font-size: 12px; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; flex: 1; }
+.fdi-entity-sub { font-size: 10px; color: var(--text-muted); flex-shrink: 0; }
+.fdi-usd { font-size: 12px; font-weight: 600; color: var(--accent); font-variant-numeric: tabular-nums; flex-shrink: 0; margin-left: auto; }
+.fdi-row-line2 { display: flex; align-items: center; width: 100%; gap: 6px; padding-left: 22px; margin-top: 1px; }
+.fdi-country { font-size: 10px; color: var(--text-dim); white-space: nowrap; }
+.fdi-sector-badge {
+  font-size: 9px; font-weight: 600; padding: 1px 5px; border-radius: 3px; letter-spacing: 0.3px;
+  background: color-mix(in srgb, var(--accent) 10%, transparent); color: var(--accent);
+}
+.fdi-status-dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; margin-right: 3px; vertical-align: middle; flex-shrink: 0; }
+.fdi-status-label { font-size: 10px; color: var(--text-dim); white-space: nowrap; }
+.fdi-year { font-size: 10px; color: var(--text-muted); font-variant-numeric: tabular-nums; margin-left: auto; }
+.fdi-empty { padding: 20px 8px; text-align: center; color: var(--text-faint); font-size: 11px; }


### PR DESCRIPTION
## Summary
- Replace 6-column table with 2-line card rows: flag + asset name + entity + value on line 1; country + sector badge + status dot + year on line 2
- Move 4 filter dropdowns behind collapsible ⚙ toggle (hidden by default, saves ~40% vertical space)
- Add sort pill buttons (Name, Value, Country, Year) inside filter row
- Add full `.fdi-*` CSS block with dark theme vars, hover states, sector badges, status dots, text ellipsis

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx playwright test e2e/investments-panel.spec.ts` — 2/2 passed
- [ ] Visual check on deployed preview