### PR TITLE
feat: animate panel count badge on new data arrival

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6382,7 +6382,6 @@
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
       "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@epic-web/invariant": "^1.0.0",
         "cross-spawn": "^7.0.6"

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -661,7 +661,13 @@ export class Panel {
 
   public setCount(count: number): void {
     if (this.countEl) {
+      const prev = parseInt(this.countEl.textContent ?? '0', 10);
       this.countEl.textContent = count.toString();
+      if (count > prev) {
+        this.countEl.classList.remove('bump');
+        void this.countEl.offsetWidth; // force reflow to restart animation
+        this.countEl.classList.add('bump');
+      }
     }
   }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1061,6 +1061,17 @@ body.panel-resize-active iframe {
   background: var(--border);
   padding: 2px 6px;
   border-radius: 2px;
+  transition: color 0.3s ease, background 0.3s ease;
+}
+
+.panel-count.bump {
+  animation: count-bump 0.5s ease-out;
+}
+
+@keyframes count-bump {
+  0%   { transform: scale(1);    background: var(--border); color: var(--text-dim); }
+  40%  { transform: scale(1.3);  background: var(--accent); color: var(--bg); }
+  100% { transform: scale(1);    background: var(--border); color: var(--text-dim); }
 }
 
 


### PR DESCRIPTION
## Summary

Adds a brief pulse animation to the panel count badge whenever new data arrives. When setCount() is called with a higher value than the current count, the badge scales up to 1.3× and flashes the accent color for 0.5s before returning to its default style. The animation is triggered automatically for all panels that use showCount: true and no per-panel changes required.

Implements TODO-034.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [x] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other: <!-- specify -->

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots
https://github.com/user-attachments/assets/2eb8c0f6-29a3-42d9-9dc1-f589f8d0a49d


