### PR TITLE
feat: persist OREF history to Redis + retry bootstrap

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -659,6 +659,7 @@ async function orefBootstrapHistoryFromUpstream() {
     .filter(h => new Date(h.timestamp).getTime() > cutoff24h)
     .reduce((sum, h) => sum + h.alerts.reduce((s, a) => s + (Array.isArray(a.data) ? a.data.length : 1), 0), 0);
   orefState.bootstrapSource = 'upstream';
+  if (history.length > 0) orefState._persistVersion++;
   console.log(`[Relay] OREF history bootstrap: ${totalAlertRecords} records across ${history.length} waves`);
 }
 


### PR DESCRIPTION
## Summary

- **Redis persistence**: OREF alert history is now persisted to Upstash Redis after each poll mutation, surviving container restarts
- **Redis-first bootstrap**: On startup, loads history from Redis instantly instead of waiting for upstream curl (~20s)
- **Upstream retry**: If no Redis data, retries upstream with exponential backoff (3 attempts, ~70s budget) instead of single fire-and-forget call
- **Stale data handling**: Redis data >7d is purged on load; if all entries are stale, falls through to upstream retry

### Failure matrix

| Upstream | Redis | Result |
|----------|-------|--------|
| UP | UP | Redis first (instant), poll refreshes + persists |
| UP | DOWN | Bootstrap from upstream, persist fails silently |
| DOWN | UP | Bootstrap from Redis cache |
| DOWN | DOWN | 3 retries then empty history |

### Implementation details

- `upstashGet`/`upstashSet` inline helpers using `https.request` (HTTPS-only, 5s timeout, never-throw, HTTP status validation)
- Version-based dedup prevents redundant Redis writes when history hasn't changed
- Concurrent persist guard prevents overlapping writes
- 200-wave hard cap keeps payload well under Upstash 1MB limit
- 7d TTL matches the existing 7-day history purge window
- Preserves `totalHistoryCount` and `historyWaves` from main
- `/health` endpoint now exposes `oref.redisEnabled` and `oref.bootstrapSource`

### Env vars needed on Railway

- `UPSTASH_REDIS_REST_URL` (same as Vercel)
- `UPSTASH_REDIS_REST_TOKEN` (same as Vercel)

## Test plan

- [ ] Deploy to Railway with `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN`
- [ ] Check logs for `OREF history loaded from Redis` or `bootstrap succeeded on attempt N`
- [ ] Hit `/health` — verify `oref.redisEnabled: true`, `oref.bootstrapSource`
- [ ] Force container restart — history loads from Redis instantly
- [ ] Check `/oref/history` returns populated data after restart
- [ ] Test: malformed Redis payload → fallback to upstream retry
- [ ] Test: restart after >7d downtime → stale entries dropped, falls through to upstream

Supersedes #670 (had merge conflicts from worktree base commits).