### PR TITLE
feat(feeds): add Asharq News & Business to Middle East

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -161,6 +161,8 @@ const ALLOWED_DOMAINS = [
   // Accelerators
   'www.techstars.com',
   // Middle East & Regional News
+  'asharqbusiness.com',
+  'asharq.com',
   'www.omanobserver.om',
   'english.alarabiya.net',
   'www.arabnews.com',

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -128,7 +128,7 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'iran-intl', name: 'Iran International', handle: '@IranIntl' },
   { id: 'cgtn-arabic', name: 'CGTN Arabic', handle: '@CGTNArabic' },
   { id: 'kan-11', name: 'Kan 11', handle: '@KAN11NEWS', fallbackVideoId: 'TCnaIE_SAtM' },
-  { id: 'asharq-news', name: 'Asharq News', handle: '@asharqnews', useFallbackOnly: true },
+  { id: 'asharq-news', name: 'Asharq News', handle: '@asharqnews', fallbackVideoId: 'f6VpkfV7m4Y', useFallbackOnly: true },
   // Africa
   { id: 'africanews', name: 'Africanews', handle: '@africanews' },
   { id: 'channels-tv', name: 'Channels TV', handle: '@ChannelsTelevision' },

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -538,6 +538,8 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     { name: 'Haaretz', url: rss('https://news.google.com/rss/search?q=site:haaretz.com+when:7d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Arab News', url: rss('https://news.google.com/rss/search?q=site:arabnews.com+when:7d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Oman Observer', url: rss('https://www.omanobserver.om/rssFeed/1') },
+    { name: 'Asharq Business', url: rss('https://asharqbusiness.com/rss.xml') },
+    { name: 'Asharq News', url: rss('https://asharq.com/snapchat/rss.xml'), lang: 'ar' },
   ],
   tech: [
     { name: 'Hacker News', url: rss('https://hnrss.org/frontpage') },


### PR DESCRIPTION
## Summary
- Add Asharq News YouTube live channel to Middle East region (with fallback video ID)
- Add Asharq Business RSS feed (`asharqbusiness.com/rss.xml`) to Middle East feeds
- Add Asharq News RSS feed (`asharq.com/snapchat/rss.xml`, Arabic) to Middle East feeds
- Add both domains to RSS proxy allowlist

## Test plan
- [ ] Verify Asharq News appears in Middle East region of Available Channels
- [ ] Verify Asharq Business & Asharq News RSS feeds load in Middle East feed section