### PR TITLE
perf(web): lazy-load DeductionPanel to exclude dompurify from web bundle

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -43,7 +43,6 @@ import { PositiveNewsFeedPanel } from '@/components/PositiveNewsFeedPanel';
 import { CountersPanel } from '@/components/CountersPanel';
 import { ProgressChartsPanel } from '@/components/ProgressChartsPanel';
 import { BreakthroughsTickerPanel } from '@/components/BreakthroughsTickerPanel';
-import { DeductionPanel } from '@/components/DeductionPanel';
 import { HeroSpotlightPanel } from '@/components/HeroSpotlightPanel';
 import { GoodThingsDigestPanel } from '@/components/GoodThingsDigestPanel';
 import { SpeciesComebackPanel } from '@/components/SpeciesComebackPanel';
@@ -502,8 +501,10 @@ export class PanelLayoutManager implements AppModule {
       this.ctx.panels['gdelt-intel'] = gdeltIntelPanel;
 
       if (this.ctx.isDesktopApp) {
-        const deductionPanel = new DeductionPanel(() => this.ctx.allNews);
-        this.ctx.panels['deduction'] = deductionPanel;
+        import('@/components/DeductionPanel').then(({ DeductionPanel }) => {
+          const deductionPanel = new DeductionPanel(() => this.ctx.allNews);
+          this.ctx.panels['deduction'] = deductionPanel;
+        });
       }
 
       const ciiPanel = new CIIPanel();


### PR DESCRIPTION
## Summary
- DeductionPanel is desktop-only (`isDesktopApp` guard) but was statically imported, pulling `dompurify` + `marked` into the web bundle unnecessarily
- Converted to dynamic `import()` so Vite code-splits them into a separate chunk only loaded on desktop

## Test plan
- [ ] Web build: verify `dompurify` is not in the main JS bundle
- [ ] Desktop app: verify DeductionPanel still loads and renders LLM analysis