### PR TITLE
fix(pwa): stop auto-reload on service worker update

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -266,20 +266,14 @@ if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) {
   });
 }
 
-if (!('__TAURI_INTERNALS__' in window) && !('__TAURI__' in window)) {
-  import('virtual:pwa-register').then(({ registerSW }) => {
-    registerSW({
-      onRegisteredSW(_swUrl, registration) {
-        if (registration) {
-          setInterval(async () => {
-            if (!navigator.onLine) return;
-            try { await registration.update(); } catch {}
-          }, 60 * 60 * 1000);
-        }
-      },
-      onOfflineReady() {
-        console.log('[PWA] App ready for offline use');
-      },
-    });
-  });
+if (!('__TAURI_INTERNALS__' in window) && !('__TAURI__' in window) && 'serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js', { scope: '/' })
+    .then((registration) => {
+      console.log('[PWA] Service worker registered');
+      setInterval(async () => {
+        if (!navigator.onLine) return;
+        try { await registration.update(); } catch {}
+      }, 60 * 60 * 1000);
+    })
+    .catch(() => {});
 }

--- a/src/pwa.d.ts
+++ b/src/pwa.d.ts
@@ -1,8 +1,3 @@
-declare module 'virtual:pwa-register' {
-  export interface RegisterSWOptions {
-    onRegisteredSW?: (swUrl: string, registration: ServiceWorkerRegistration | undefined) => void;
-    onOfflineReady?: () => void;
-    onNeedRefresh?: () => void;
-  }
-  export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void>;
-}
+// virtual:pwa-register types removed — SW is registered manually in main.ts
+// to avoid the autoUpdate controllerchange → reload() cycle.
+export {};


### PR DESCRIPTION
## Summary
- Replace `virtual:pwa-register` with manual `navigator.serviceWorker.register()` to eliminate the forced page reload triggered by the PWA auto-update `controllerchange` listener
- All PWA functionality preserved: precaching, offline support, hourly update checks
- `chunk-reload.ts` guard still handles stale chunk 404s as safety net

## Context
With `registerType: 'autoUpdate'` + `skipWaiting` + `clientsClaim`, every deployment caused a visible full-page reload on first visit — the new SW installs, activates, claims the page, and `virtual:pwa-register`'s `controllerchange` handler calls `window.location.reload()`.

## Test plan
- [ ] Deploy and verify page loads without a second reload
- [ ] Verify PWA install still works (precaching, offline)
- [ ] Verify new deployments serve updated assets on next navigation