### PR TITLE
feat(breaking-news): click banner to scroll to source panel

### DIFF
--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -436,6 +436,18 @@ export function isStateAffiliatedSource(sourceName: string): boolean {
   return !!profile?.stateAffiliated;
 }
 
+let _sourcePanelMap: Map<string, string> | null = null;
+export function getSourcePanelId(sourceName: string): string {
+  if (!_sourcePanelMap) {
+    _sourcePanelMap = new Map();
+    for (const [category, feeds] of Object.entries(FEEDS)) {
+      for (const feed of feeds) _sourcePanelMap.set(feed.name, category);
+    }
+    for (const feed of INTEL_SOURCES) _sourcePanelMap.set(feed.name, 'intel');
+  }
+  return _sourcePanelMap.get(sourceName) ?? 'politics';
+}
+
 const FULL_FEEDS: Record<string, Feed[]> = {
   politics: [
     { name: 'BBC World', url: rss('https://feeds.bbci.co.uk/news/world/rss.xml') },


### PR DESCRIPTION
## Summary
- Breaking news alert banners are now clickable — clicking scrolls to the panel containing the story
- Maps alert origins to target panels: `oref_siren` → OREF Sirens panel, `rss_alert` → source feed's panel (e.g., Guardian ME → middleeast)
- Reuses existing `scrollIntoView` + `flash-highlight` animation pattern from `SearchManager`

## Test plan
- [ ] Trigger a breaking news alert (wait for a high/critical story or lower the recency gate temporarily)
- [ ] Click the banner body → should smooth-scroll to the correct news panel and flash-highlight it
- [ ] Click the × dismiss button → should still dismiss (not scroll)
- [ ] Verify cursor shows pointer on hover over the banner