### PR TITLE
feat(feeds): add configurable custom RSS feeds

### DIFF
--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -23,10 +23,10 @@ import {
   STORAGE_KEYS,
   SITE_VARIANT,
   LAYER_TO_SOURCE,
-  FEEDS,
   INTEL_SOURCES,
   DEFAULT_PANELS,
 } from '@/config';
+import { getMergedFeeds } from '@/services/custom-feeds';
 import {
   saveSnapshot,
   initAisStream,
@@ -736,7 +736,7 @@ export class EventHandlerManager implements AppModule {
 
   getAllSourceNames(): string[] {
     const sources = new Set<string>();
-    Object.values(FEEDS).forEach(feeds => {
+    Object.values(getMergedFeeds()).forEach(feeds => {
       if (feeds) feeds.forEach(f => sources.add(f.name));
     });
     INTEL_SOURCES.forEach(f => sources.add(f.name));

--- a/src/config/variants/base.ts
+++ b/src/config/variants/base.ts
@@ -35,6 +35,7 @@ export const STORAGE_KEYS = {
   monitors: 'worldmonitor-monitors',
   mapLayers: 'worldmonitor-layers',
   disabledFeeds: 'worldmonitor-disabled-feeds',
+  customFeeds: 'worldmonitor-custom-feeds',
   liveChannels: 'worldmonitor-live-channels',
 } as const;
 

--- a/src/services/custom-feeds.ts
+++ b/src/services/custom-feeds.ts
@@ -1,0 +1,150 @@
+import type { Feed } from '@/types';
+import { FEEDS } from '@/config/feeds';
+import { STORAGE_KEYS } from '@/config/variants/base';
+
+export interface CustomFeedEntry {
+  id: string;
+  name: string;
+  url: string;
+  category: string;
+}
+
+const MAX_CUSTOM_FEEDS = 20;
+
+export function loadCustomFeeds(): CustomFeedEntry[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.customFeeds);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed as CustomFeedEntry[];
+  } catch {
+    return [];
+  }
+}
+
+export function saveCustomFeeds(feeds: CustomFeedEntry[]): void {
+  localStorage.setItem(STORAGE_KEYS.customFeeds, JSON.stringify(feeds));
+}
+
+export function addCustomFeed(entry: Omit<CustomFeedEntry, 'id'>): CustomFeedEntry {
+  const feeds = loadCustomFeeds();
+
+  if (feeds.length >= MAX_CUSTOM_FEEDS) {
+    throw new Error(`Maximum of ${MAX_CUSTOM_FEEDS} custom feeds reached`);
+  }
+
+  // Check duplicate URL among custom feeds
+  if (feeds.some(f => f.url === entry.url)) {
+    throw new Error('This feed URL already exists');
+  }
+
+  // Check duplicate URL among built-in feeds
+  for (const feedList of Object.values(FEEDS)) {
+    if (!feedList) continue;
+    for (const f of feedList) {
+      const builtinUrl = typeof f.url === 'string' ? f.url : Object.values(f.url)[0];
+      if (builtinUrl?.includes(encodeURIComponent(entry.url)) || builtinUrl === entry.url) {
+        throw new Error('This feed URL is already a built-in source');
+      }
+    }
+  }
+
+  // Auto-append " (Custom)" if name matches a built-in feed
+  let name = entry.name;
+  const allBuiltinNames = new Set<string>();
+  for (const feedList of Object.values(FEEDS)) {
+    if (feedList) feedList.forEach(f => allBuiltinNames.add(f.name));
+  }
+  if (allBuiltinNames.has(name)) {
+    name = `${name} (Custom)`;
+  }
+
+  const newEntry: CustomFeedEntry = {
+    id: `custom-${Date.now()}`,
+    name,
+    url: entry.url,
+    category: entry.category,
+  };
+
+  feeds.push(newEntry);
+  saveCustomFeeds(feeds);
+  return newEntry;
+}
+
+export function removeCustomFeed(id: string): void {
+  const feeds = loadCustomFeeds();
+  const entry = feeds.find(f => f.id === id);
+  if (!entry) return;
+
+  // Clean name from disabled sources
+  const disabledRaw = localStorage.getItem(STORAGE_KEYS.disabledFeeds);
+  if (disabledRaw) {
+    try {
+      const disabled: string[] = JSON.parse(disabledRaw);
+      const cleaned = disabled.filter(s => s !== entry.name);
+      localStorage.setItem(STORAGE_KEYS.disabledFeeds, JSON.stringify(cleaned));
+    } catch { /* ignore */ }
+  }
+
+  saveCustomFeeds(feeds.filter(f => f.id !== id));
+}
+
+export function getMergedFeeds(): Record<string, Feed[]> {
+  const merged: Record<string, Feed[]> = {};
+  for (const [key, feeds] of Object.entries(FEEDS)) {
+    merged[key] = feeds ? [...feeds] : [];
+  }
+
+  const custom = loadCustomFeeds();
+  for (const entry of custom) {
+    const proxyUrl = `/api/rss-proxy?url=${encodeURIComponent(entry.url)}`;
+    const feed: Feed = { name: entry.name, url: proxyUrl };
+
+    const existing = merged[entry.category];
+    if (existing) {
+      existing.push(feed);
+    } else {
+      merged[entry.category] = [feed];
+    }
+  }
+
+  return merged;
+}
+
+export function getCustomFeedNames(): Set<string> {
+  return new Set(loadCustomFeeds().map(f => f.name));
+}
+
+export async function validateRssUrl(url: string): Promise<{ valid: boolean; title?: string; error?: string }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const proxyUrl = `/api/rss-proxy?url=${encodeURIComponent(url)}`;
+    const res = await fetch(proxyUrl, { signal: controller.signal });
+
+    if (!res.ok) {
+      return { valid: false, error: `HTTP ${res.status}` };
+    }
+
+    const text = await res.text();
+
+    if (!text.includes('<rss') && !text.includes('<feed') && !text.includes('<channel')) {
+      return { valid: false, error: 'Not a valid RSS/Atom feed' };
+    }
+
+    // Extract title
+    const titleMatch = text.match(/<title[^>]*>(?:<!\[CDATA\[)?(.*?)(?:\]\]>)?<\/title>/);
+    const title = titleMatch?.[1]?.trim() || '';
+
+    return { valid: true, title };
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      return { valid: false, error: 'Request timed out' };
+    }
+    return { valid: false, error: 'Failed to fetch feed' };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -5485,6 +5485,163 @@ a.prediction-link:hover {
   }
 }
 
+/* Custom Feeds */
+.custom-feeds-section {
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+}
+
+.custom-feeds-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.custom-feeds-title {
+  font-size: 10px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.custom-feed-add-btn {
+  padding: 4px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.custom-feed-add-btn:hover {
+  border-color: var(--text-dim);
+}
+
+.custom-feed-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.custom-feed-form.hidden {
+  display: none;
+}
+
+.custom-feed-form input,
+.custom-feed-form select {
+  padding: 6px 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 10px;
+}
+
+.custom-feed-url {
+  flex: 1 1 100%;
+}
+
+.custom-feed-name {
+  flex: 1 1 40%;
+}
+
+.custom-feed-category {
+  flex: 0 0 auto;
+}
+
+.custom-feed-form input:focus,
+.custom-feed-form select:focus {
+  outline: none;
+  border-color: var(--text-dim);
+}
+
+.custom-feed-validate-btn,
+.custom-feed-submit-btn {
+  padding: 6px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.custom-feed-validate-btn:hover,
+.custom-feed-submit-btn:hover:not(:disabled) {
+  border-color: var(--text-dim);
+}
+
+.custom-feed-submit-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.custom-feed-status {
+  flex: 1 1 100%;
+  font-size: 10px;
+}
+
+.custom-feed-ok {
+  color: var(--green);
+}
+
+.custom-feed-error {
+  color: var(--red, #ff4444);
+}
+
+.custom-feed-loading {
+  color: var(--text-dim);
+}
+
+.custom-feed-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.custom-feed-list-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  font-size: 10px;
+}
+
+.custom-feed-list-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.custom-feed-remove {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 10px;
+}
+
+.custom-feed-remove:hover {
+  color: var(--red, #ff4444);
+}
+
+.custom-feed-badge {
+  font-size: 9px;
+  padding: 1px 5px;
+  background: var(--accent, var(--text-dim));
+  color: var(--bg);
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
 /* Map Popups */
 .map-popup {
   position: fixed;


### PR DESCRIPTION
## Summary

- Add ability to add/remove custom RSS feeds at runtime via Settings → Sources tab
- Custom feeds are validated against the RSS proxy, persisted to localStorage, and merged with built-in feeds on each data refresh cycle
- Supports up to 20 custom feeds with duplicate URL detection, name collision handling, and "Custom" badge in the source grid

Closes #649

## Changes

| File | Change |
|------|--------|
| `src/services/custom-feeds.ts` | **New** — storage, merge, validation logic |
| `src/config/variants/base.ts` | Add `customFeeds` storage key |
| `src/app/data-loader.ts` | Use `getMergedFeeds()` instead of `FEEDS` |
| `src/app/event-handlers.ts` | Use `getMergedFeeds()` in `getAllSourceNames()` |
| `src/components/UnifiedSettings.ts` | Custom feed UI section in Sources tab |
| `src/styles/main.css` | Styles for add-feed form, list, and badges |

## Test plan

- [ ] `npm run typecheck` passes
- [ ] Add feed: paste RSS URL → Validate → auto-fill name → select category → Add → appears in list + source grid with "Custom" badge
- [ ] Remove feed: click ✕ → removed from list + grid
- [ ] Persistence: add feed, reload → still in list
- [ ] Toggle: disable custom feed in source grid → not fetched on next refresh
- [ ] Validation errors: invalid URL → error message; non-RSS URL → "Not a valid RSS feed"
- [ ] Duplicate detection: same URL → error; same name as built-in → auto-appends "(Custom)"
- [ ] Max limit: 20 feeds → shows error on 21st

🤖 Generated with [Claude Code](https://claude.ai/code)