### PR TITLE
Add Czech (cs) translation

### DIFF
--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -212,7 +212,11 @@
     "techReadiness": "Index tech. připravenosti",
     "gccInvestments": "Investice GCC",
     "geoHubs": "Geopolitická centra",
-    "liveWebcams": "Živé webkamery"
+    "liveWebcams": "Živé webkamery",
+    "gulfEconomies": "Ekonomiky Perského zálivu",
+    "gulfIndices": "Indexy Perského zálivu",
+    "gulfCurrencies": "Měny Perského zálivu",
+    "gulfOil": "Ropa Perského zálivu"
   },
   "modals": {
     "search": {
@@ -511,7 +515,8 @@
         "europe": "EVROPA",
         "americas": "AMERIKA",
         "asia": "ASIE"
-      }
+      },
+      "expand": "Rozbalit"
     },
     "monitor": {
       "placeholder": "Klíčová slova (oddělená čárkou)",
@@ -991,7 +996,13 @@
       "aiFlowStatusBrowserOnly": "Pouze model v prohlížeči",
       "aiFlowStatusDisabled": "Nejsou povoleni žádní poskytovatelé AI",
       "insightsDisabledTitle": "AI analýza je zakázána",
-      "insightsDisabledHint": "Povolte poskytovatele prostřednictvím ozubeného kola nastavení v záhlaví mapy"
+      "insightsDisabledHint": "Povolte poskytovatele prostřednictvím ozubeného kola nastavení v záhlaví mapy",
+      "sectionPanels": "Panely",
+      "badgeAnimLabel": "Animace odznáčků",
+      "badgeAnimDesc": "Animovat odznáčky aktualizací v záhlaví panelů",
+      "sectionIntelligence": "Zpravodajství",
+      "headlineMemoryLabel": "Paměť titulků",
+      "headlineMemoryDesc": "Zapamatovat si zobrazené titulky pro zvýraznění nových"
     },
     "cascade": {
       "noImpacts": "Nezjištěny žádné dopady na země",
@@ -1274,7 +1285,8 @@
         "minutesAgo": "před {{count}} min",
         "hoursAgo": "před {{count}} h",
         "daysAgo": "před {{count}} d"
-      }
+      },
+      "hideFindings": "Skrýt nálezy"
     },
     "countryTimeline": {
       "now": "nyní",

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -4,7 +4,7 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 // English is always needed as fallback — bundle it eagerly.
 import enTranslation from '../locales/en.json';
 
-const SUPPORTED_LANGUAGES = ['en', 'fr', 'de', 'el', 'es', 'it', 'pl', 'pt', 'nl', 'sv', 'ru', 'ar', 'zh', 'ja', 'ko', 'tr', 'th', 'vi'] as const;
+const SUPPORTED_LANGUAGES = ['en', 'cs', 'fr', 'de', 'el', 'es', 'it', 'pl', 'pt', 'nl', 'sv', 'ru', 'ar', 'zh', 'ja', 'ko', 'tr', 'th', 'vi'] as const;
 type SupportedLanguage = typeof SUPPORTED_LANGUAGES[number];
 type TranslationDictionary = Record<string, unknown>;
 
@@ -125,13 +125,14 @@ export function isRTL(): boolean {
 
 export function getLocale(): string {
   const lang = getCurrentLanguage();
-  const map: Record<string, string> = { en: 'en-US', el: 'el-GR', zh: 'zh-CN', pt: 'pt-BR', ja: 'ja-JP', ko: 'ko-KR', tr: 'tr-TR', th: 'th-TH', vi: 'vi-VN' };
+  const map: Record<string, string> = { en: 'en-US', cs: 'cs-CZ', el: 'el-GR', zh: 'zh-CN', pt: 'pt-BR', ja: 'ja-JP', ko: 'ko-KR', tr: 'tr-TR', th: 'th-TH', vi: 'vi-VN' };
   return map[lang] || lang;
 }
 
 export const LANGUAGES = [
   { code: 'en', label: 'English', flag: '🇬🇧' },
   { code: 'ar', label: 'العربية', flag: '🇸🇦' },
+  { code: 'cs', label: 'Čeština', flag: '🇨🇿' },
   { code: 'zh', label: '中文', flag: '🇨🇳' },
   { code: 'fr', label: 'Français', flag: '🇫🇷' },
   { code: 'de', label: 'Deutsch', flag: '🇩🇪' },


### PR DESCRIPTION
## Summary

Community contribution by [@JRCZE](https://github.com/JRCZE) — full Czech (cs) translation with 2,114 lines covering all existing i18n keys.

**Translation quality**: Spot-checked — 1,660 keys translated. 52 strings identical to English are intentional (proper nouns, brand names, technical terms like "World Monitor", "WhatsApp", "Token", "Ticker", "AI/ML", etc.).

## Integration requirements

This PR only adds the `cs.json` file. To actually enable Czech in the UI, the following code changes are also needed:

1. **`src/services/i18n.ts`** — add `'cs'` to `SUPPORTED_LANGUAGES` array (line 7) and add `{ code: 'cs', label: 'Čeština', flag: '🇨🇿' }` to `LANGUAGES` array (line 132+)
2. **12 missing keys** need backfilling into `cs.json` (keys added after this PR was based on `en.json`):
   - `panels.gulfEconomies`, `panels.gulfIndices`, `panels.gulfCurrencies`, `panels.gulfOil`
   - `components.insights.sectionPanels`, `badgeAnimLabel`, `badgeAnimDesc`, `sectionIntelligence`, `headlineMemoryLabel`, `headlineMemoryDesc`
   - `components.intelligenceFindings.hideFindings`
   - `components.webcams.expand`

## Type of change

- [x] New feature (new locale)

## Affected areas

- [x] Config / Settings (language selector)
- [x] Other: i18n / Localization

## Review notes

- PR is from a fork (`JRCZE/worldmonitor:main` → `koala73/worldmonitor:main`) — contributor pushed to their own `main` branch, not a feature branch
- File only — no code changes to register the language, so merging alone won't enable Czech in the UI
- Based on `en.json` before PR #703, so 12 recently-added keys are missing

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)
- [ ] Czech registered in `SUPPORTED_LANGUAGES` and `LANGUAGES` in `i18n.ts`
- [ ] 12 missing keys backfilled into `cs.json`