### PR TITLE
fix(i18n): add 12 missing translation keys across all 18 locales

### DIFF
--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -212,7 +212,11 @@
     "orefSirens": "Israel Sirens",
     "telegramIntel": "استخبارات Telegram",
     "giving": "العطاء العالمي",
-    "supplyChain": "سلسلة الإمداد"
+    "supplyChain": "سلسلة الإمداد",
+    "gulfEconomies": "اقتصادات الخليج",
+    "gulfIndices": "مؤشرات الخليج",
+    "gulfCurrencies": "عملات الخليج",
+    "gulfOil": "نفط الخليج"
   },
   "modals": {
     "search": {
@@ -511,7 +515,8 @@
         "europe": "أوروبا",
         "americas": "الأمريكتان",
         "asia": "آسيا"
-      }
+      },
+      "expand": "توسيع"
     },
     "monitor": {
       "placeholder": "كلمات مفتاحية (مفصولة بفواصل)",
@@ -975,7 +980,13 @@
       "insightsDisabledHint": "Enable providers via the settings gear in the map header",
       "sectionStreaming": "البث المباشر",
       "streamQualityDesc": "تعيين جودة البث لجميع القنوات المباشرة (الجودة المنخفضة توفر عرض النطاق)",
-      "streamQualityLabel": "جودة الفيديو"
+      "streamQualityLabel": "جودة الفيديو",
+      "sectionPanels": "اللوحات",
+      "badgeAnimLabel": "حركة الشارات",
+      "badgeAnimDesc": "تحريك شارات التحديث في رؤوس اللوحات",
+      "sectionIntelligence": "الاستخبارات",
+      "headlineMemoryLabel": "ذاكرة العناوين",
+      "headlineMemoryDesc": "تذكر العناوين المشاهدة لتمييز الجديدة"
     },
     "cascade": {
       "noImpacts": "لم يتم رصد تأثيرات على الدول",
@@ -1189,7 +1200,8 @@
         "daysAgo": "{{count}}ي مضت"
       },
       "breakingAlerts": "تنبيهات عاجلة",
-      "popupAlerts": "إظهار التنبيهات الجديدة"
+      "popupAlerts": "إظهار التنبيهات الجديدة",
+      "hideFindings": "إخفاء النتائج"
     },
     "countryTimeline": {
       "now": "الآن",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -212,7 +212,11 @@
     "liveWebcams": "Live-Webcams",
     "securityAdvisories": "Sicherheitshinweise",
     "orefSirens": "Israel Sirens",
-    "telegramIntel": "Telegram-Nachrichten"
+    "telegramIntel": "Telegram-Nachrichten",
+    "gulfEconomies": "Golf-Ökonomien",
+    "gulfIndices": "Golf-Indizes",
+    "gulfCurrencies": "Golf-Währungen",
+    "gulfOil": "Golf-Öl"
   },
   "modals": {
     "search": {
@@ -520,7 +524,8 @@
         "europe": "EUROPA",
         "americas": "AMERIKA",
         "asia": "ASIEN"
-      }
+      },
+      "expand": "Erweitern"
     },
     "regulation": {
       "timeline": "Zeitleiste",
@@ -1077,7 +1082,8 @@
         "minutesAgo": "Vor {{count}}m",
         "hoursAgo": "Vor {{count}}h",
         "daysAgo": "Vor {{count}}d"
-      }
+      },
+      "hideFindings": "Erkenntnisse ausblenden"
     },
     "satelliteFires": {
       "noData": "Keine Branddaten verfügbar",
@@ -1293,7 +1299,13 @@
       "aiFlowStatusBrowserOnly": "Nur Browser-Modell",
       "aiFlowStatusDisabled": "Keine KI-Anbieter aktiviert",
       "insightsDisabledTitle": "KI-Analyse ist deaktiviert",
-      "insightsDisabledHint": "Enable providers via the settings gear in the map header"
+      "insightsDisabledHint": "Enable providers via the settings gear in the map header",
+      "sectionPanels": "Panels",
+      "badgeAnimLabel": "Badge-Animationen",
+      "badgeAnimDesc": "Update-Badges in Panel-Kopfzeilen animieren",
+      "sectionIntelligence": "Intelligence",
+      "headlineMemoryLabel": "Schlagzeilen-Speicher",
+      "headlineMemoryDesc": "Gesehene Schlagzeilen merken, um neue hervorzuheben"
     },
     "export": {
       "exportData": "Daten exportieren"

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -212,7 +212,11 @@
     "orefSirens": "Israel Sirens",
     "telegramIntel": "Πληροφορίες Telegram",
     "supplyChain": "Εφοδιαστική Αλυσίδα",
-    "giving": "Παγκόσμιες Δωρεές"
+    "giving": "Παγκόσμιες Δωρεές",
+    "gulfEconomies": "Οικονομίες Κόλπου",
+    "gulfIndices": "Δείκτες Κόλπου",
+    "gulfCurrencies": "Νομίσματα Κόλπου",
+    "gulfOil": "Πετρέλαιο Κόλπου"
   },
   "modals": {
     "search": {
@@ -511,7 +515,8 @@
         "europe": "ΕΥΡΩΠΗ",
         "americas": "ΑΜΕΡΙΚΗ",
         "asia": "ΑΣΙΑ"
-      }
+      },
+      "expand": "Ανάπτυξη"
     },
     "monitor": {
       "placeholder": "Λέξεις-κλειδιά (διαχωρισμένες με κόμμα)",
@@ -975,7 +980,13 @@
       "insightsDisabledHint": "Ενεργοποιήστε παρόχους μέσω του γραναζιού ρυθμίσεων στην κεφαλίδα του χάρτη",
       "sectionStreaming": "Streaming",
       "streamQualityLabel": "Ποιότητα Βίντεο",
-      "streamQualityDesc": "Ρύθμιση ποιότητας για όλες τις ζωντανές ροές (χαμηλότερη εξοικονομεί εύρος ζώνης)"
+      "streamQualityDesc": "Ρύθμιση ποιότητας για όλες τις ζωντανές ροές (χαμηλότερη εξοικονομεί εύρος ζώνης)",
+      "sectionPanels": "Πάνελ",
+      "badgeAnimLabel": "Κινούμενα σήματα",
+      "badgeAnimDesc": "Κίνηση σημάτων ενημέρωσης στις κεφαλίδες πάνελ",
+      "sectionIntelligence": "Πληροφορίες",
+      "headlineMemoryLabel": "Μνήμη τίτλων",
+      "headlineMemoryDesc": "Αποθήκευση τίτλων που είδατε για επισήμανση νέων"
     },
     "cascade": {
       "noImpacts": "Δεν ανιχνεύθηκαν επιπτώσεις σε χώρες",
@@ -1189,7 +1200,8 @@
         "hoursAgo": "{{count}}ω πριν",
         "daysAgo": "{{count}}μ πριν"
       },
-      "breakingAlerts": "Έκτακτες Ειδοποιήσεις"
+      "breakingAlerts": "Έκτακτες Ειδοποιήσεις",
+      "hideFindings": "Απόκρυψη ευρημάτων"
     },
     "countryTimeline": {
       "now": "τώρα",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -212,7 +212,11 @@
     "techReadiness": "Tech Readiness Index",
     "gccInvestments": "GCC Investments",
     "geoHubs": "Geopolitical Hubs",
-    "liveWebcams": "Live Webcams"
+    "liveWebcams": "Live Webcams",
+    "gulfEconomies": "Gulf Economies",
+    "gulfIndices": "Gulf Indices",
+    "gulfCurrencies": "Gulf Currencies",
+    "gulfOil": "Gulf Oil"
   },
   "modals": {
     "search": {
@@ -504,6 +508,7 @@
   },
   "components": {
     "webcams": {
+      "expand": "Expand",
       "regions": {
         "iran": "IRAN ATTACKS",
         "all": "ALL",
@@ -991,7 +996,13 @@
       "aiFlowStatusBrowserOnly": "Browser model only",
       "aiFlowStatusDisabled": "No AI providers enabled",
       "insightsDisabledTitle": "AI analysis is disabled",
-      "insightsDisabledHint": "Enable providers via the settings gear in the map header"
+      "insightsDisabledHint": "Enable providers via the settings gear in the map header",
+    "sectionPanels": "Panels",
+    "badgeAnimLabel": "Badge Animations",
+    "badgeAnimDesc": "Animate update badges on panel headers",
+    "sectionIntelligence": "Intelligence",
+    "headlineMemoryLabel": "Headline Memory",
+    "headlineMemoryDesc": "Remember seen headlines to highlight new stories"
     },
     "cascade": {
       "noImpacts": "No country impacts detected",
@@ -1253,6 +1264,7 @@
       "detected": "{{count}} DETECTED",
       "critical": "{{count}} CRITICAL",
       "highPriority": "{{count}} HIGH PRIORITY",
+      "hideFindings": "Hide Findings",
       "more": "+{{count}} more findings",
       "all": "All Intelligence Findings ({{count}})",
       "priority": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -212,7 +212,11 @@
     "liveWebcams": "Cámaras en Vivo",
     "securityAdvisories": "Alertas de Seguridad",
     "orefSirens": "Israel Sirens",
-    "telegramIntel": "Inteligencia Telegram"
+    "telegramIntel": "Inteligencia Telegram",
+    "gulfEconomies": "Economías del Golfo",
+    "gulfIndices": "Índices del Golfo",
+    "gulfCurrencies": "Monedas del Golfo",
+    "gulfOil": "Petróleo del Golfo"
   },
   "modals": {
     "search": {
@@ -520,7 +524,8 @@
         "europe": "EUROPA",
         "americas": "AMÉRICAS",
         "asia": "ASIA"
-      }
+      },
+      "expand": "Expandir"
     },
     "regulation": {
       "timeline": "Línea de tiempo",
@@ -1077,7 +1082,8 @@
         "minutesAgo": "Hace {{count}}m",
         "hoursAgo": "Hace {{count}}h",
         "daysAgo": "Hace {{count}}d"
-      }
+      },
+      "hideFindings": "Ocultar hallazgos"
     },
     "satelliteFires": {
       "noData": "No hay datos de incendios disponibles",
@@ -1293,7 +1299,13 @@
       "aiFlowStatusBrowserOnly": "Solo modelo del navegador",
       "aiFlowStatusDisabled": "Ningún proveedor de IA habilitado",
       "insightsDisabledTitle": "El análisis de IA está desactivado",
-      "insightsDisabledHint": "Enable providers via the settings gear in the map header"
+      "insightsDisabledHint": "Enable providers via the settings gear in the map header",
+      "sectionPanels": "Paneles",
+      "badgeAnimLabel": "Animaciones de insignias",
+      "badgeAnimDesc": "Animar insignias de actualización en encabezados de paneles",
+      "sectionIntelligence": "Inteligencia",
+      "headlineMemoryLabel": "Memoria de titulares",
+      "headlineMemoryDesc": "Recordar titulares vistos para resaltar nuevos"
     },
     "export": {
       "exportData": "Exportar datos"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -212,7 +212,11 @@
     "orefSirens": "Israel Sirens",
     "telegramIntel": "Renseignement Telegram",
     "giving": "Dons mondiaux",
-    "supplyChain": "Chaîne d'approvisionnement"
+    "supplyChain": "Chaîne d'approvisionnement",
+    "gulfEconomies": "Économies du Golfe",
+    "gulfIndices": "Indices du Golfe",
+    "gulfCurrencies": "Devises du Golfe",
+    "gulfOil": "Pétrole du Golfe"
   },
   "modals": {
     "search": {
@@ -520,7 +524,8 @@
         "europe": "EUROPE",
         "americas": "AMÉRIQUES",
         "asia": "ASIE"
-      }
+      },
+      "expand": "Agrandir"
     },
     "regulation": {
       "timeline": "Chronologie",
@@ -975,7 +980,13 @@
       "insightsDisabledHint": "Enable providers via the settings gear in the map header",
       "sectionStreaming": "Diffusion",
       "streamQualityDesc": "Définir la qualité de tous les flux en direct (une qualité moindre économise la bande passante)",
-      "streamQualityLabel": "Qualité vidéo"
+      "streamQualityLabel": "Qualité vidéo",
+      "sectionPanels": "Panneaux",
+      "badgeAnimLabel": "Animations des badges",
+      "badgeAnimDesc": "Animer les badges de mise à jour dans les en-têtes de panneau",
+      "sectionIntelligence": "Renseignement",
+      "headlineMemoryLabel": "Mémoire des titres",
+      "headlineMemoryDesc": "Mémoriser les titres vus pour mettre en évidence les nouveaux"
     },
     "cascade": {
       "noImpacts": "Aucun impact pays détecté",
@@ -1223,7 +1234,8 @@
         "daysAgo": "il y a {{count}} j"
       },
       "breakingAlerts": "Alertes urgentes",
-      "popupAlerts": "Afficher les nouvelles alertes"
+      "popupAlerts": "Afficher les nouvelles alertes",
+      "hideFindings": "Masquer les résultats"
     },
     "countryTimeline": {
       "now": "maintenant",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -212,7 +212,11 @@
     "liveWebcams": "Webcam in Diretta",
     "securityAdvisories": "Avvisi di Sicurezza",
     "orefSirens": "Israel Sirens",
-    "telegramIntel": "Intelligence Telegram"
+    "telegramIntel": "Intelligence Telegram",
+    "gulfEconomies": "Economie del Golfo",
+    "gulfIndices": "Indici del Golfo",
+    "gulfCurrencies": "Valute del Golfo",
+    "gulfOil": "Petrolio del Golfo"
   },
   "modals": {
     "search": {
@@ -520,7 +524,8 @@
         "europe": "EUROPA",
         "americas": "AMERICHE",
         "asia": "ASIA"
-      }
+      },
+      "expand": "Espandi"
     },
     "regulation": {
       "timeline": "Cronologia",
@@ -1077,7 +1082,8 @@
         "minutesAgo": "{{count}} min fa",
         "hoursAgo": "{{count}} h fa",
         "daysAgo": "{{count}} g fa"
-      }
+      },
+      "hideFindings": "Nascondi risultati"
     },
     "satelliteFires": {
       "noData": "Nessun dato sugli incendi disponibile",
@@ -1293,7 +1299,13 @@
       "aiFlowStatusBrowserOnly": "Solo modello browser",
       "aiFlowStatusDisabled": "Nessun fornitore IA abilitato",
       "insightsDisabledTitle": "L'analisi IA è disattivata",
-      "insightsDisabledHint": "Enable providers via the settings gear in the map header"
+      "insightsDisabledHint": "Enable providers via the settings gear in the map header",
+      "sectionPanels": "Pannelli",
+      "badgeAnimLabel": "Animazioni badge",
+      "badgeAnimDesc": "Animare i badge di aggiornamento nelle intestazioni dei pannelli",
+      "sectionIntelligence": "Intelligence",
+      "headlineMemoryLabel": "Memoria titoli",
+      "headlineMemoryDesc": "Ricordare i titoli visti per evidenziare quelli nuovi"
     },
     "etfFlows": {
       "unavailable": "Dati ETF temporaneamente non disponibili",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -212,7 +212,11 @@
     "orefSirens": "Israel Sirens",
     "telegramIntel": "Telegram インテリジェンス",
     "giving": "グローバル寄付",
-    "supplyChain": "サプライチェーン"
+    "supplyChain": "サプライチェーン",
+    "gulfEconomies": "湾岸経済",
+    "gulfIndices": "湾岸指数",
+    "gulfCurrencies": "湾岸通貨",
+    "gulfOil": "湾岸石油"
   },
   "modals": {
     "search": {
@@ -511,7 +515,8 @@
         "europe": "ヨーロッパ",
         "americas": "アメリカ",
         "asia": "アジア"
-      }
+      },
+      "expand": "拡大"
     },
     "monitor": {
       "placeholder": "キーワード（カンマ区切り）",
@@ -975,7 +980,13 @@
       "insightsDisabledHint": "Enable providers via the settings gear in the map header",
       "sectionStreaming": "ストリーミング",
       "streamQualityDesc": "すべてのライブストリームの画質を設定（低画質は帯域幅を節約）",
-      "streamQualityLabel": "動画画質"
+      "streamQualityLabel": "動画画質",
+      "sectionPanels": "パネル",
+      "badgeAnimLabel": "バッジアニメーション",
+      "badgeAnimDesc": "パネルヘッダーの更新バッジをアニメーション表示",
+      "sectionIntelligence": "インテリジェンス",
+      "headlineMemoryLabel": "ヘッドラインメモリ",
+      "headlineMemoryDesc": "閲覧済みの見出しを記憶して新着を強調"
     },
     "cascade": {
       "noImpacts": "国への影響未検出",
@@ -1189,7 +1200,8 @@
         "daysAgo": "{{count}}日前"
       },
       "breakingAlerts": "速報アラート",
-      "popupAlerts": "新しいアラートをポップアップ表示"
+      "popupAlerts": "新しいアラートをポップアップ表示",
+      "hideFindings": "検出結果を非表示"
     },
     "countryTimeline": {
       "now": "現在",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -212,7 +212,11 @@
     "techReadiness": "기술 준비 지수",
     "gccInvestments": "GCC 투자",
     "geoHubs": "지정학 허브",
-    "liveWebcams": "실시간 웹캠"
+    "liveWebcams": "실시간 웹캠",
+    "gulfEconomies": "걸프 경제",
+    "gulfIndices": "걸프 지수",
+    "gulfCurrencies": "걸프 통화",
+    "gulfOil": "걸프 석유"
   },
   "modals": {
     "search": {
@@ -511,7 +515,8 @@
         "europe": "유럽",
         "americas": "미주",
         "asia": "아시아"
-      }
+      },
+      "expand": "확장"
     },
     "monitor": {
       "placeholder": "키워드 (쉼표로 구분)",
@@ -991,7 +996,13 @@
       "aiFlowStatusBrowserOnly": "브라우저 모델만 사용",
       "aiFlowStatusDisabled": "AI 제공자 비활성화됨",
       "insightsDisabledTitle": "AI 분석이 비활성화되었습니다",
-      "insightsDisabledHint": "지도 헤더의 설정 기어를 통해 제공자를 활성화하세요"
+      "insightsDisabledHint": "지도 헤더의 설정 기어를 통해 제공자를 활성화하세요",
+      "sectionPanels": "패널",
+      "badgeAnimLabel": "배지 애니메이션",
+      "badgeAnimDesc": "패널 헤더의 업데이트 배지 애니메이션",
+      "sectionIntelligence": "인텔리전스",
+      "headlineMemoryLabel": "헤드라인 메모리",
+      "headlineMemoryDesc": "본 헤드라인을 기억하여 새 기사 강조"
     },
     "cascade": {
       "noImpacts": "국가 영향 감지되지 않음",
@@ -1274,7 +1285,8 @@
         "minutesAgo": "{{count}}m 전",
         "hoursAgo": "{{count}}h 전",
         "daysAgo": "{{count}}d 전"
-      }
+      },
+      "hideFindings": "결과 숨기기"
     },
     "countryTimeline": {
       "now": "현재",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -67,7 +67,11 @@
     "orefSirens": "Israel Sirens",
     "telegramIntel": "Telegram Inlichtingen",
     "giving": "Mondiale donaties",
-    "supplyChain": "Toeleveringsketen"
+    "supplyChain": "Toeleveringsketen",
+    "gulfEconomies": "Golfeconomieën",
+    "gulfIndices": "Golfindices",
+    "gulfCurrencies": "Golfvaluta",
+    "gulfOil": "Golfolie"
   },
   "modals": {
     "search": {
@@ -375,7 +379,8 @@
         "europe": "EUROPA",
         "americas": "AMERIKA",
         "asia": "AZIË"
-      }
+      },
+      "expand": "Uitvouwen"
     },
     "playback": {
       "live": "Live",
@@ -810,7 +815,8 @@
         "daysAgo": "{{count}}d geleden"
       },
       "breakingAlerts": "Urgente meldingen",
-      "popupAlerts": "Nieuwe meldingen weergeven"
+      "popupAlerts": "Nieuwe meldingen weergeven",
+      "hideFindings": "Bevindingen verbergen"
     },
     "economic": {
       "noIndicatorData": "Nog geen indicatorgegevens - FRED wordt mogelijk geladen",
@@ -1043,7 +1049,13 @@
       "insightsDisabledHint": "Enable providers via the settings gear in the map header",
       "sectionStreaming": "Streaming",
       "streamQualityDesc": "Kwaliteit instellen voor alle livestreams (lager bespaart bandbreedte)",
-      "streamQualityLabel": "Videokwaliteit"
+      "streamQualityLabel": "Videokwaliteit",
+      "sectionPanels": "Panelen",
+      "badgeAnimLabel": "Badge-animaties",
+      "badgeAnimDesc": "Update-badges in paneelkoppen animeren",
+      "sectionIntelligence": "Inlichtingen",
+      "headlineMemoryLabel": "Koptekstgeheugen",
+      "headlineMemoryDesc": "Gezien koppen onthouden om nieuwe te markeren"
     },
     "techHubs": {
       "infoTooltip": "<strong>Tech Hub-activiteit</strong><br>Toont tech-hubs met de meeste nieuwsactiviteit.<br><br><em>Activiteitsniveaus:</em><br>• <span style=\"color: {{highColor}}\">Hoog</span> — Breaking news of 50+ score<br>• <span style=\"color: {{elevatedColor}}\">Verhoogd</span> — Score 20-49<br>• <span style=\"color: {{lowColor}}\">Laag</span> — Score lager dan 20<br><br>Klik op een hub om naar de locatie ervan te zoomen.",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -212,7 +212,11 @@
     "orefSirens": "Israel Sirens",
     "telegramIntel": "Wywiad Telegram",
     "giving": "Globalna Dobroczynność",
-    "supplyChain": "Łańcuch Dostaw"
+    "supplyChain": "Łańcuch Dostaw",
+    "gulfEconomies": "Gospodarka Zatoki",
+    "gulfIndices": "Indeksy Zatoki",
+    "gulfCurrencies": "Waluty Zatoki",
+    "gulfOil": "Ropa Zatoki"
   },
   "modals": {
     "search": {
@@ -520,7 +524,8 @@
         "europe": "EUROPA",
         "americas": "AMERYKI",
         "asia": "AZJA"
-      }
+      },
+      "expand": "Rozwiń"
     },
     "regulation": {
       "timeline": "Oś czasu",
@@ -1055,7 +1060,8 @@
         "daysAgo": "{{count}}d temu"
       },
       "breakingAlerts": "Pilne alerty",
-      "popupAlerts": "Wyświetlaj nowe alerty w okienku"
+      "popupAlerts": "Wyświetlaj nowe alerty w okienku",
+      "hideFindings": "Ukryj wyniki"
     },
     "satelliteFires": {
       "noData": "Brak danych o pożarach",
@@ -1243,7 +1249,13 @@
       "insightsDisabledHint": "Enable providers via the settings gear in the map header",
       "sectionStreaming": "Streaming",
       "streamQualityDesc": "Ustaw jakość dla wszystkich transmisji na żywo (niższa oszczędza przepustowość)",
-      "streamQualityLabel": "Jakość wideo"
+      "streamQualityLabel": "Jakość wideo",
+      "sectionPanels": "Panele",
+      "badgeAnimLabel": "Animacje odznak",
+      "badgeAnimDesc": "Animuj odznaki aktualizacji w nagłówkach paneli",
+      "sectionIntelligence": "Wywiad",
+      "headlineMemoryLabel": "Pamięć nagłówków",
+      "headlineMemoryDesc": "Zapamiętuj widziane nagłówki, aby wyróżnić nowe"
     },
     "etfFlows": {
       "unavailable": "Dane ETF tymczasowo niedostępne",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -67,7 +67,11 @@
     "orefSirens": "Israel Sirens",
     "telegramIntel": "Inteligência Telegram",
     "giving": "Doações Globais",
-    "supplyChain": "Cadeia de Suprimentos"
+    "supplyChain": "Cadeia de Suprimentos",
+    "gulfEconomies": "Economias do Golfo",
+    "gulfIndices": "Índices do Golfo",
+    "gulfCurrencies": "Moedas do Golfo",
+    "gulfOil": "Petróleo do Golfo"
   },
   "modals": {
     "search": {
@@ -375,7 +379,8 @@
         "europe": "EUROPA",
         "americas": "AMÉRICAS",
         "asia": "ÁSIA"
-      }
+      },
+      "expand": "Expandir"
     },
     "playback": {
       "live": "Live",
@@ -810,7 +815,8 @@
         "daysAgo": "{{count}}d atrás"
       },
       "breakingAlerts": "Alertas urgentes",
-      "popupAlerts": "Exibir novos alertas"
+      "popupAlerts": "Exibir novos alertas",
+      "hideFindings": "Ocultar descobertas"
     },
     "economic": {
       "noIndicatorData": "Ainda não há dados do indicador - FRED pode estar carregando",
@@ -1043,7 +1049,13 @@
       "insightsDisabledHint": "Enable providers via the settings gear in the map header",
       "sectionStreaming": "Transmissão",
       "streamQualityDesc": "Definir qualidade para todas as transmissões ao vivo (menor economiza largura de banda)",
-      "streamQualityLabel": "Qualidade de vídeo"
+      "streamQualityLabel": "Qualidade de vídeo",
+      "sectionPanels": "Painéis",
+      "badgeAnimLabel": "Animações de emblemas",
+      "badgeAnimDesc": "Animar emblemas de atualização nos cabeçalhos dos painéis",
+      "sectionIntelligence": "Inteligência",
+      "headlineMemoryLabel": "Memória de manchetes",
+      "headlineMemoryDesc": "Lembrar manchetes vistas para destacar novas"
     },
     "techHubs": {
       "infoTooltip": "<strong>Atividade do Tech Hub</strong><br>Mostra os hubs de tecnologia com mais atividade de notícias.<br><br><em>Níveis de atividade:</em><br>• <span style=\"color: {{highColor}}\">Alto</span> — Notícias de última hora ou pontuação acima de 50<br>• <span style=\"color: {{elevatedColor}}\">Elevado</span> — Pontuação 20-49<br>• <span style=\"color: {{lowColor}}\">Baixo</span> — Pontuação abaixo de 20<br><br>Clique em um hub para ampliar sua localização.",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -212,7 +212,11 @@
     "orefSirens": "Israel Sirens",
     "telegramIntel": "Разведка Telegram",
     "giving": "Глобальная благотворительность",
-    "supplyChain": "Цепочка поставок"
+    "supplyChain": "Цепочка поставок",
+    "gulfEconomies": "Экономика Залива",
+    "gulfIndices": "Индексы Залива",
+    "gulfCurrencies": "Валюты Залива",
+    "gulfOil": "Нефть Залива"
   },
   "modals": {
     "search": {
@@ -520,7 +524,8 @@
         "europe": "ЕВРОПА",
         "americas": "АМЕРИКА",
         "asia": "АЗИЯ"
-      }
+      },
+      "expand": "Развернуть"
     },
     "regulation": {
       "timeline": "Хронология",
@@ -975,7 +980,13 @@
       "insightsDisabledHint": "Enable providers via the settings gear in the map header",
       "sectionStreaming": "Трансляции",
       "streamQualityDesc": "Установить качество для всех прямых трансляций (низкое экономит трафик)",
-      "streamQualityLabel": "Качество видео"
+      "streamQualityLabel": "Качество видео",
+      "sectionPanels": "Панели",
+      "badgeAnimLabel": "Анимация значков",
+      "badgeAnimDesc": "Анимировать значки обновлений в заголовках панелей",
+      "sectionIntelligence": "Разведка",
+      "headlineMemoryLabel": "Память заголовков",
+      "headlineMemoryDesc": "Запоминать просмотренные заголовки для выделения новых"
     },
     "cascade": {
       "noImpacts": "Воздействие на страны не обнаружено",
@@ -1223,7 +1234,8 @@
         "daysAgo": "{{count}}д назад"
       },
       "breakingAlerts": "Срочные оповещения",
-      "popupAlerts": "Всплывающие новые оповещения"
+      "popupAlerts": "Всплывающие новые оповещения",
+      "hideFindings": "Скрыть результаты"
     },
     "countryTimeline": {
       "now": "сейчас",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -67,7 +67,11 @@
     "orefSirens": "Israel Sirens",
     "telegramIntel": "Telegram Underrättelser",
     "giving": "Global Givmildhet",
-    "supplyChain": "Försörjningskedja"
+    "supplyChain": "Försörjningskedja",
+    "gulfEconomies": "Gulfekonomierna",
+    "gulfIndices": "Gulfindex",
+    "gulfCurrencies": "Gulfvalutor",
+    "gulfOil": "Gulfolja"
   },
   "modals": {
     "search": {
@@ -375,7 +379,8 @@
         "europe": "EUROPA",
         "americas": "AMERIKA",
         "asia": "ASIEN"
-      }
+      },
+      "expand": "Expandera"
     },
     "playback": {
       "live": "LIVE",
@@ -810,7 +815,8 @@
         "daysAgo": "{{count}}d sedan"
       },
       "breakingAlerts": "Akuta larm",
-      "popupAlerts": "Visa nya larm i popup"
+      "popupAlerts": "Visa nya larm i popup",
+      "hideFindings": "Dölj fynd"
     },
     "economic": {
       "noIndicatorData": "Inga indikatordata ännu - FRED kanske laddar",
@@ -1043,7 +1049,13 @@
       "insightsDisabledHint": "Enable providers via the settings gear in the map header",
       "sectionStreaming": "Strömning",
       "streamQualityDesc": "Ställ in kvalitet för alla liveströmmar (lägre sparar bandbredd)",
-      "streamQualityLabel": "Videokvalitet"
+      "streamQualityLabel": "Videokvalitet",
+      "sectionPanels": "Paneler",
+      "badgeAnimLabel": "Emblemanimationer",
+      "badgeAnimDesc": "Animera uppdateringsemblem i panelrubriker",
+      "sectionIntelligence": "Underrättelser",
+      "headlineMemoryLabel": "Rubrikminne",
+      "headlineMemoryDesc": "Kom ihåg sedda rubriker för att markera nya"
     },
     "techHubs": {
       "infoTooltip": "<strong>Teknisk hubbaktivitet</strong><br>Visar tekniska nav med mest nyhetsaktivitet.<br><br><em>Aktivitetsnivåer:</em><br>• <span style=\"color: {{highColor}}\">Hög</span> — Nyheter från 50+ PH_• 50+ stil: {{elevatedColor}}\">Höjd</span> — Poäng 20-49<br>• <span style=\"color: {{lowColor}}\">Låg</span> — Poäng under 20<br><br>Klicka på ett nav för att zooma till dess plats.",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -212,7 +212,11 @@
     "orefSirens": "Israel Sirens",
     "telegramIntel": "ข่าวกรอง Telegram",
     "giving": "การบริจาคทั่วโลก",
-    "supplyChain": "ห่วงโซ่อุปทาน"
+    "supplyChain": "ห่วงโซ่อุปทาน",
+    "gulfEconomies": "เศรษฐกิจอ่าว",
+    "gulfIndices": "ดัชนีอ่าว",
+    "gulfCurrencies": "สกุลเงินอ่าว",
+    "gulfOil": "น้ำมันอ่าว"
   },
   "modals": {
     "search": {
@@ -511,7 +515,8 @@
         "europe": "ยุโรป",
         "americas": "อเมริกา",
         "asia": "เอเชีย"
-      }
+      },
+      "expand": "ขยาย"
     },
     "monitor": {
       "placeholder": "คำสำคัญ (คั่นด้วยจุลภาค)",
@@ -975,7 +980,13 @@
       "insightsDisabledHint": "Enable providers via the settings gear in the map header",
       "sectionStreaming": "การสตรีม",
       "streamQualityDesc": "ตั้งค่าคุณภาพสำหรับสตรีมสดทั้งหมด (ต่ำกว่าประหยัดแบนด์วิดท์)",
-      "streamQualityLabel": "คุณภาพวิดีโอ"
+      "streamQualityLabel": "คุณภาพวิดีโอ",
+      "sectionPanels": "แผงควบคุม",
+      "badgeAnimLabel": "แอนิเมชันป้าย",
+      "badgeAnimDesc": "แสดงแอนิเมชันป้ายอัปเดตบนส่วนหัวของแผง",
+      "sectionIntelligence": "ข่าวกรอง",
+      "headlineMemoryLabel": "หน่วยความจำพาดหัว",
+      "headlineMemoryDesc": "จดจำพาดหัวที่เคยดูเพื่อเน้นข่าวใหม่"
     },
     "cascade": {
       "noImpacts": "ไม่พบผลกระทบต่อประเทศ",
@@ -1189,7 +1200,8 @@
         "daysAgo": "{{count}}ว. ที่แล้ว"
       },
       "breakingAlerts": "การแจ้งเตือนด่วน",
-      "popupAlerts": "แสดงการแจ้งเตือนใหม่แบบป๊อปอัป"
+      "popupAlerts": "แสดงการแจ้งเตือนใหม่แบบป๊อปอัป",
+      "hideFindings": "ซ่อนผลการค้นหา"
     },
     "countryTimeline": {
       "now": "ตอนนี้",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -212,7 +212,11 @@
     "orefSirens": "Israel Sirens",
     "telegramIntel": "Telegram İstihbarat",
     "giving": "Küresel Bağış",
-    "supplyChain": "Tedarik Zinciri"
+    "supplyChain": "Tedarik Zinciri",
+    "gulfEconomies": "Körfez Ekonomileri",
+    "gulfIndices": "Körfez Endeksleri",
+    "gulfCurrencies": "Körfez Para Birimleri",
+    "gulfOil": "Körfez Petrolü"
   },
   "modals": {
     "search": {
@@ -511,7 +515,8 @@
         "europe": "AVRUPA",
         "americas": "AMERIKA",
         "asia": "ASYA"
-      }
+      },
+      "expand": "Genişlet"
     },
     "monitor": {
       "placeholder": "Anahtar kelimeler (virgul ile ayirin)",
@@ -975,7 +980,13 @@
       "insightsDisabledHint": "Enable providers via the settings gear in the map header",
       "sectionStreaming": "Canlı Yayın",
       "streamQualityDesc": "Tüm canlı yayınlar için kaliteyi ayarlayın (düşük kalite bant genişliği tasarrufu sağlar)",
-      "streamQualityLabel": "Video Kalitesi"
+      "streamQualityLabel": "Video Kalitesi",
+      "sectionPanels": "Paneller",
+      "badgeAnimLabel": "Rozet animasyonları",
+      "badgeAnimDesc": "Panel başlıklarındaki güncelleme rozetlerini canlandır",
+      "sectionIntelligence": "İstihbarat",
+      "headlineMemoryLabel": "Başlık hafızası",
+      "headlineMemoryDesc": "Yenileri vurgulamak için görülen başlıkları hatırla"
     },
     "cascade": {
       "noImpacts": "Ulke etkisi tespit edilmedi",
@@ -1189,7 +1200,8 @@
         "daysAgo": "{{count}}g once"
       },
       "breakingAlerts": "Son Dakika Uyarıları",
-      "popupAlerts": "Yeni uyarıları açılır pencerede göster"
+      "popupAlerts": "Yeni uyarıları açılır pencerede göster",
+      "hideFindings": "Bulguları gizle"
     },
     "countryTimeline": {
       "now": "simdi",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -212,7 +212,11 @@
     "orefSirens": "Israel Sirens",
     "telegramIntel": "Tình báo Telegram",
     "giving": "Từ thiện Toàn cầu",
-    "supplyChain": "Chuỗi Cung ứng"
+    "supplyChain": "Chuỗi Cung ứng",
+    "gulfEconomies": "Kinh tế vùng Vịnh",
+    "gulfIndices": "Chỉ số vùng Vịnh",
+    "gulfCurrencies": "Tiền tệ vùng Vịnh",
+    "gulfOil": "Dầu vùng Vịnh"
   },
   "modals": {
     "search": {
@@ -511,7 +515,8 @@
         "europe": "CHÂU ÂU",
         "americas": "CHÂU MỸ",
         "asia": "CHÂU Á"
-      }
+      },
+      "expand": "Mở rộng"
     },
     "monitor": {
       "placeholder": "Từ khóa (phân cách bằng dấu phẩy)",
@@ -975,7 +980,13 @@
       "insightsDisabledHint": "Enable providers via the settings gear in the map header",
       "sectionStreaming": "Phát trực tiếp",
       "streamQualityDesc": "Đặt chất lượng cho tất cả luồng phát trực tiếp (thấp hơn tiết kiệm băng thông)",
-      "streamQualityLabel": "Chất lượng Video"
+      "streamQualityLabel": "Chất lượng Video",
+      "sectionPanels": "Bảng điều khiển",
+      "badgeAnimLabel": "Hoạt ảnh huy hiệu",
+      "badgeAnimDesc": "Hoạt ảnh huy hiệu cập nhật trên tiêu đề bảng",
+      "sectionIntelligence": "Tình báo",
+      "headlineMemoryLabel": "Bộ nhớ tiêu đề",
+      "headlineMemoryDesc": "Ghi nhớ tiêu đề đã xem để làm nổi bật tin mới"
     },
     "cascade": {
       "noImpacts": "Không phát hiện tác động quốc gia",
@@ -1189,7 +1200,8 @@
         "daysAgo": "{{count}}ng trước"
       },
       "breakingAlerts": "Cảnh báo Khẩn cấp",
-      "popupAlerts": "Hiển thị cảnh báo mới dạng popup"
+      "popupAlerts": "Hiển thị cảnh báo mới dạng popup",
+      "hideFindings": "Ẩn phát hiện"
     },
     "countryTimeline": {
       "now": "hiện tại",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -212,7 +212,11 @@
     "orefSirens": "Israel Sirens",
     "telegramIntel": "Telegram 情报",
     "giving": "全球捐赠",
-    "supplyChain": "供应链"
+    "supplyChain": "供应链",
+    "gulfEconomies": "海湾经济",
+    "gulfIndices": "海湾指数",
+    "gulfCurrencies": "海湾货币",
+    "gulfOil": "海湾石油"
   },
   "modals": {
     "search": {
@@ -511,7 +515,8 @@
         "europe": "欧洲",
         "americas": "美洲",
         "asia": "亚洲"
-      }
+      },
+      "expand": "展开"
     },
     "monitor": {
       "placeholder": "关键词（逗号分隔）",
@@ -975,7 +980,13 @@
       "insightsDisabledHint": "Enable providers via the settings gear in the map header",
       "sectionStreaming": "直播",
       "streamQualityDesc": "设置所有直播流的画质（低画质可节省带宽）",
-      "streamQualityLabel": "视频画质"
+      "streamQualityLabel": "视频画质",
+      "sectionPanels": "面板",
+      "badgeAnimLabel": "徽章动画",
+      "badgeAnimDesc": "在面板标题中显示更新徽章动画",
+      "sectionIntelligence": "情报",
+      "headlineMemoryLabel": "标题记忆",
+      "headlineMemoryDesc": "记住已阅标题以突出显示新内容"
     },
     "cascade": {
       "noImpacts": "未检测到国家影响",
@@ -1189,7 +1200,8 @@
         "daysAgo": "{{count}}天前"
       },
       "breakingAlerts": "突发警报",
-      "popupAlerts": "弹出新警报"
+      "popupAlerts": "弹出新警报",
+      "hideFindings": "隐藏发现"
     },
     "countryTimeline": {
       "now": "现在",


### PR DESCRIPTION
## Summary
- Settings panel displayed raw i18n keys (`components.insights.badgeAnimLabel`, `sectionPanels`, etc.) instead of translated text
- Audited all `t('...')` calls across the codebase against `en.json` — found **12 missing keys** total
- Added translations for all 12 keys across all 18 locale files

## Missing keys fixed
| Key | Component |
|-----|-----------|
| `components.insights.sectionPanels` | UnifiedSettings section header |
| `components.insights.badgeAnimLabel` | UnifiedSettings toggle |
| `components.insights.badgeAnimDesc` | UnifiedSettings toggle |
| `components.insights.sectionIntelligence` | UnifiedSettings section header |
| `components.insights.headlineMemoryLabel` | UnifiedSettings toggle |
| `components.insights.headlineMemoryDesc` | UnifiedSettings toggle |
| `panels.gulfEconomies` | GulfEconomiesPanel title |
| `panels.gulfIndices` | GulfEconomiesPanel section |
| `panels.gulfCurrencies` | GulfEconomiesPanel section |
| `panels.gulfOil` | GulfEconomiesPanel section |
| `components.intelligenceFindings.hideFindings` | IntelligenceGapBadge context menu |
| `components.webcams.expand` | LiveWebcamsPanel tooltip |

## Test plan
- [ ] Open Settings panel → verify "Panels" section shows localized text
- [ ] Switch language → verify badge/headline memory labels translate
- [ ] Open Gulf Economies panel → verify title and section headings
- [ ] Right-click intelligence badge → verify "Hide Findings" label