### PR TITLE
chore: bump v2.5.22 & comprehensive README update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "world-monitor",
   "private": true,
-  "version": "2.5.21",
+  "version": "2.5.22",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-monitor"
-version = "2.5.21"
+version = "2.5.22"
 description = "World Monitor desktop application"
 authors = ["World Monitor"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "World Monitor",
   "mainBinaryName": "world-monitor",
-  "version": "2.5.21",
+  "version": "2.5.22",
   "identifier": "app.worldmonitor.desktop",
   "build": {
     "beforeDevCommand": "npm run build:sidecar-sebuf && npm run dev",


### PR DESCRIPTION
## Summary

- Bump version `2.5.21` → `2.5.22` across `package.json`, `Cargo.toml`, and `tauri.conf.json`
- Document 15+ recently shipped features missing from the README (written as native content, not as "changes")
- Add 21 new completed roadmap items
- Update stale references (PostHog → Vercel Analytics, HLS 10 → 18+, locale feeds 7 → 17)

### New README sections
- **AI Deduction & Forecasting** — full "How It Works" with architecture, request pipeline, cross-panel integration
- **Client-Side Headline Memory (RAG)** — ingestion pipeline diagram, search algorithm, opt-in mechanism
- **Server-Side Feed Aggregation** — architecture diagram showing ~95% edge invocation reduction
- Gulf Economies Panel, TV Mode, mobile map touch gestures, fullscreen live video, breaking news click-through, badge animation toggle, cache purge admin endpoint, locale-aware feed boost, OREF Redis persistence + 1,478 Hebrew→English translations, Oceania region tab

### Updated existing sections
- Localization (7 → 17 locale feed sets + locale boost)
- OREF (Redis persistence, Hebrew translations, Unicode sanitization)
- Live News (HLS 10 → 18+, server-side aggregation, fullscreen toggle)
- Tech Stack (PostHog removed, RAG added, counts updated)
- "Why World Monitor" table (RAG + deductions)
- Map (mobile touch, timezone region detection)
- Railway Relay (conditional GET)

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm no broken markdown links or formatting
- [ ] Version 2.5.22 consistent across all 3 files (verified by pre-push hook)