### PR TITLE
fix(panel): live news fullscreen renders above all UI elements

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -637,10 +637,24 @@ export class LiveNewsPanel extends Panel {
     header?.appendChild(this.fullscreenBtn);
   }
 
+  private originalParent: HTMLElement | null = null;
+  private originalNextSibling: Node | null = null;
+
   private toggleFullscreen(): void {
     this.isFullscreen = !this.isFullscreen;
     this.element.classList.toggle('live-news-fullscreen', this.isFullscreen);
     document.body.classList.toggle('live-news-fullscreen-active', this.isFullscreen);
+
+    if (this.isFullscreen) {
+      this.originalParent = this.element.parentElement;
+      this.originalNextSibling = this.element.nextSibling;
+      document.body.appendChild(this.element);
+    } else if (this.originalParent) {
+      this.originalParent.insertBefore(this.element, this.originalNextSibling);
+      this.originalParent = null;
+      this.originalNextSibling = null;
+    }
+
     if (this.fullscreenBtn) {
       this.fullscreenBtn.title = this.isFullscreen ? 'Exit fullscreen' : 'Fullscreen';
       this.fullscreenBtn.innerHTML = this.isFullscreen

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1917,7 +1917,7 @@ body.panel-resize-active iframe {
   left: 0 !important;
   width: 100vw !important;
   height: 100vh !important;
-  z-index: 9999 !important;
+  z-index: 10000 !important;
   border-radius: 0 !important;
   margin: 0 !important;
 }
@@ -1935,6 +1935,10 @@ body.panel-resize-active iframe {
 
 body.live-news-fullscreen-active {
   overflow: hidden;
+}
+
+body.live-news-fullscreen-active .community-widget {
+  display: none;
 }
 
 .live-indicator-btn {


### PR DESCRIPTION
## Summary
- Move fullscreen live news panel element to `document.body` to escape the `panels-grid` stacking context (`z-index: 1`) that trapped it below sibling elements
- Bump fullscreen z-index from 9999 to 10000
- Hide "Join the Discussion" widget during fullscreen

## Problem
Clicking maximize on the live video news panel caused it to render **under** the map legend, DEFCON badge, time range selector, layers panel, and community discussion widget. Root cause: `panels-grid` has `position: relative; z-index: 1` which creates a stacking context — `position: fixed` children cannot escape it regardless of their own z-index.

## Test plan
- [ ] Click fullscreen on Live News panel — video should cover entire viewport with no UI elements visible on top
- [ ] Press Escape or click minimize — panel returns to its original grid position
- [ ] Verify DEFCON badge, legend, time buttons, layers panel are all hidden behind the fullscreen video
- [ ] Verify "Join the Discussion" widget is hidden during fullscreen