### PR TITLE
fix: open variant nav links in same window instead of new tab

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -116,7 +116,7 @@ export class PanelLayoutManager implements AppModule {
           <div class="variant-switcher">${(() => {
             const local = this.ctx.isDesktopApp || location.hostname === 'localhost' || location.hostname === '127.0.0.1';
             const vHref = (v: string, prod: string) => local || SITE_VARIANT === v ? '#' : prod;
-            const vTarget = (v: string) => !local && SITE_VARIANT !== v ? 'target="_blank" rel="noopener"' : '';
+            const vTarget = (_v: string) => '';
             return `
             <a href="${vHref('full', 'https://worldmonitor.app')}"
                class="variant-option ${SITE_VARIANT === 'full' ? 'active' : ''}"


### PR DESCRIPTION
## Summary
- The WORLD / TECH / FINANCE variant switcher in the header currently opens links with `target="_blank"`, causing a new browser tab/window to open when switching variants
- Since this is a tab-like interface for switching between site variants, navigation should stay in the same window
- Removed the `target="_blank" rel="noopener"` attribute from variant nav links so they navigate in-place

## Test plan
- [ ] Click WORLD / TECH / FINANCE nav links on production — should navigate in the same tab
- [ ] Verify local/desktop app behavior is unchanged (already uses `#` hrefs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)