### PR TITLE
fix(conflict): bump iran events cache-bust to v7

### DIFF
--- a/src/services/conflict/index.ts
+++ b/src/services/conflict/index.ts
@@ -375,7 +375,7 @@ export function groupByType(events: UcdpGeoEvent[]): Record<string, UcdpGeoEvent
 export async function fetchIranEvents(): Promise<IranEvent[]> {
   const resp = await iranBreaker.execute(async () => {
     // Bypass stale CDN cache from pre-Redis deployment (remove once CDN is clean)
-    const r = await globalThis.fetch('/api/conflict/v1/list-iran-events?_v=6');
+    const r = await globalThis.fetch('/api/conflict/v1/list-iran-events?_v=7');
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     return r.json() as Promise<ListIranEventsResponse>;
   }, emptyIranFallback);


### PR DESCRIPTION
## Summary
- Bump `?_v=6` → `?_v=7` to bust stale CDN cache after fresh Redis seed (100 events, 2 Mar 2026)

## Test plan
- [ ] Iran Attacks layer shows updated events on map