### PR TITLE
feat(header): add Download App button for web users

### DIFF
--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -188,6 +188,22 @@ export class EventHandlerManager implements AppModule {
       }
     });
 
+    document.getElementById('downloadBtn')?.addEventListener('click', () => {
+      const ua = navigator.userAgent;
+      const platform = (navigator as unknown as { userAgentData?: { platform: string } }).userAgentData?.platform
+        ?? navigator.platform ?? '';
+      const plat = platform.toLowerCase();
+      let url = 'https://worldmonitor.app/api/download?platform=windows-exe';
+      if (plat.includes('mac')) {
+        url = ua.includes('ARM') || ua.includes('Apple M')
+          ? 'https://worldmonitor.app/api/download?platform=macos-arm64'
+          : 'https://worldmonitor.app/api/download?platform=macos-x64';
+      } else if (plat.includes('linux')) {
+        url = 'https://worldmonitor.app/api/download?platform=linux-appimage';
+      }
+      window.open(url, '_blank');
+    });
+
     window.addEventListener('storage', (e) => {
       if (e.key === STORAGE_KEYS.panels && e.newValue) {
         try {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -180,7 +180,10 @@ export class PanelLayoutManager implements AppModule {
           </div>
         </div>
         <div class="header-right">
-          <!-- TODO: Add "Download App" link here for non-desktop users (this.ctx.isDesktopApp === false) -->
+          ${this.ctx.isDesktopApp ? '' : `<button class="download-btn" id="downloadBtn" title="${t('header.downloadApp')}">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            ${t('header.downloadApp')}
+          </button>`}
           <button class="search-btn" id="searchBtn"><kbd>⌘K</kbd> ${t('header.search')}</button>
           ${this.ctx.isDesktopApp ? '' : `<button class="copy-link-btn" id="copyLinkBtn">${t('header.copyLink')}</button>`}
           <button class="theme-toggle-btn" id="headerThemeToggle" title="${t('header.toggleTheme')}">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -87,6 +87,7 @@
     "settings": "SETTINGS",
     "sources": "SOURCES",
     "copyLink": "Copy Link",
+    "downloadApp": "Download App",
     "fullscreen": "Fullscreen",
     "pinMap": "Pin map to top",
     "viewOnGitHub": "View on GitHub",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -719,6 +719,25 @@ canvas,
   border-color: var(--text);
 }
 
+.download-btn {
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.download-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .search-btn kbd {
   background: var(--bg-secondary);
   padding: 2px 5px;
@@ -9293,7 +9312,8 @@ a.prediction-link:hover {
   }
 
   /* Hide non-essential header items */
-  .copy-link-btn {
+  .copy-link-btn,
+  .download-btn {
     display: none;
   }
 }


### PR DESCRIPTION
## Summary
- Adds a "Download App" button in the header for web users (`isDesktopApp === false`)
- Detects platform via `navigator.userAgentData` (modern) with `navigator.platform` fallback (avoids deprecated-only API)
- Routes to correct installer: macOS ARM64/x64, Windows EXE, Linux AppImage
- Hidden on mobile viewports via existing responsive breakpoint

Cleans up the functional part of #707 — stripped alert grouping (broken TS + false merges), font size, popup toggle, GDELT/ACLED links, and keyboard shortcuts i18n (all unrelated to the download button).

## Test plan
- [ ] Verify button appears on web, hidden on desktop app
- [ ] Verify correct download URL for macOS ARM, macOS Intel, Windows, Linux
- [ ] Verify button hidden on mobile viewport
- [ ] `tsc --noEmit` passes

Co-authored-by: AaronCorkyj <AaronCorkyj@users.noreply.github.com>