### PR TITLE
feat(header): download dropdown + system status settings tab

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -180,10 +180,13 @@ export class PanelLayoutManager implements AppModule {
           </div>
         </div>
         <div class="header-right">
-          ${this.ctx.isDesktopApp ? '' : `<button class="download-btn" id="downloadBtn" title="${t('header.downloadApp')}">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-            ${t('header.downloadApp')}
-          </button>`}
+          ${this.ctx.isDesktopApp ? '' : `<div class="download-wrapper" id="downloadWrapper">
+            <button class="download-btn" id="downloadBtn" title="${t('header.downloadApp')}">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+              <span id="downloadBtnLabel">${t('header.downloadApp')}</span>
+            </button>
+            <div class="download-dropdown" id="downloadDropdown"></div>
+          </div>`}
           <button class="search-btn" id="searchBtn"><kbd>⌘K</kbd> ${t('header.search')}</button>
           ${this.ctx.isDesktopApp ? '' : `<button class="copy-link-btn" id="copyLinkBtn">${t('header.copyLink')}</button>`}
           <button class="theme-toggle-btn" id="headerThemeToggle" title="${t('header.toggleTheme')}">

--- a/src/components/DownloadBanner.ts
+++ b/src/components/DownloadBanner.ts
@@ -31,9 +31,9 @@ function dismiss(panel: HTMLElement, fromDownload = false): void {
   panel.addEventListener('transitionend', () => panel.remove(), { once: true });
 }
 
-type Platform = 'macos-arm64' | 'macos-x64' | 'macos' | 'windows' | 'linux' | 'linux-x64' | 'linux-arm64' | 'unknown';
+export type Platform = 'macos-arm64' | 'macos-x64' | 'macos' | 'windows' | 'linux' | 'linux-x64' | 'linux-arm64' | 'unknown';
 
-function detectPlatform(): Platform {
+export function detectPlatform(): Platform {
   const ua = navigator.userAgent;
   if (/Windows/i.test(ua)) return 'windows';
   if (/Linux/i.test(ua) && !/Android/i.test(ua)) return 'linux';
@@ -57,9 +57,9 @@ function detectPlatform(): Platform {
   return 'unknown';
 }
 
-interface DlButton { cls: string; href: string; label: string }
+export interface DlButton { cls: string; href: string; label: string }
 
-function allButtons(): DlButton[] {
+export function allButtons(): DlButton[] {
   return [
     { cls: 'mac', href: '/api/download?platform=macos-arm64', label: `\uF8FF ${t('modals.downloadBanner.macSilicon')}` },
     { cls: 'mac', href: '/api/download?platform=macos-x64', label: `\uF8FF ${t('modals.downloadBanner.macIntel')}` },
@@ -69,7 +69,7 @@ function allButtons(): DlButton[] {
   ];
 }
 
-function buttonsForPlatform(p: Platform): DlButton[] {
+export function buttonsForPlatform(p: Platform): DlButton[] {
   const buttons = allButtons();
   switch (p) {
     case 'macos-arm64': return buttons.filter(b => b.href.includes('macos-arm64'));

--- a/src/components/StatusPanel.ts
+++ b/src/components/StatusPanel.ts
@@ -1,9 +1,9 @@
 import { SITE_VARIANT } from '@/config';
-import { h, replaceChildren } from '@/utils/dom-utils';
+import { h } from '@/utils/dom-utils'; // kept for Panel base class compat
 
-type StatusLevel = 'ok' | 'warning' | 'error' | 'disabled';
+export type StatusLevel = 'ok' | 'warning' | 'error' | 'disabled';
 
-interface FeedStatus {
+export interface FeedStatus {
   name: string;
   lastUpdate: Date | null;
   status: StatusLevel;
@@ -11,7 +11,7 @@ interface FeedStatus {
   errorMessage?: string;
 }
 
-interface ApiStatus {
+export interface ApiStatus {
   name: string;
   status: StatusLevel;
   latency?: number;
@@ -46,15 +46,14 @@ import { t } from '../services/i18n';
 import { Panel } from './Panel';
 
 export class StatusPanel extends Panel {
-  private isOpen = false;
   private feeds: Map<string, FeedStatus> = new Map();
   private apis: Map<string, ApiStatus> = new Map();
   private allowedFeeds!: Set<string>;
   private allowedApis!: Set<string>;
+  public onUpdate: (() => void) | null = null;
 
   constructor() {
     super({ id: 'status', title: t('panels.status') });
-    // Title is hidden in CSS, we use custom header
     this.init();
   }
 
@@ -62,89 +61,41 @@ export class StatusPanel extends Panel {
     this.allowedFeeds = SITE_VARIANT === 'tech' ? TECH_FEEDS : WORLD_FEEDS;
     this.allowedApis = SITE_VARIANT === 'tech' ? TECH_APIS : WORLD_APIS;
 
-    const panel = h('div', { className: 'status-panel hidden' },
-      h('div', { className: 'status-panel-header' },
-        h('span', null, t('panels.status')),
-        h('button', {
-          className: 'status-panel-close',
-          onClick: () => { this.isOpen = false; panel.classList.add('hidden'); },
-        }, '×'),
-      ),
-      h('div', { className: 'status-panel-content' },
-        h('div', { className: 'status-section' },
-          h('div', { className: 'status-section-title' }, t('components.status.dataFeeds')),
-          h('div', { className: 'feeds-list' }),
-        ),
-        h('div', { className: 'status-section' },
-          h('div', { className: 'status-section-title' }, t('components.status.apiStatus')),
-          h('div', { className: 'apis-list' }),
-        ),
-        h('div', { className: 'status-section' },
-          h('div', { className: 'status-section-title' }, t('components.status.storage')),
-          h('div', { className: 'storage-info' }),
-        ),
-      ),
-      h('div', { className: 'status-panel-footer' },
-        h('span', { className: 'last-check' }, t('components.status.updatedJustNow')),
-      ),
-    );
-
-    this.element = h('div', { className: 'status-panel-container' },
-      h('button', {
-        className: 'status-panel-toggle',
-        title: t('components.status.systemStatus'),
-        onClick: () => {
-          this.isOpen = !this.isOpen;
-          panel.classList.toggle('hidden', !this.isOpen);
-          if (this.isOpen) this.updateDisplay();
-        },
-      },
-        h('span', { className: 'status-icon' }, '◉'),
-      ),
-      panel,
-    );
-
+    this.element = h('div', { className: 'status-panel-container' });
     this.initDefaultStatuses();
   }
 
   private initDefaultStatuses(): void {
-    // Initialize all allowed feeds/APIs as disabled
-    // They get enabled when App.ts reports data
     this.allowedFeeds.forEach(name => {
       this.feeds.set(name, { name, lastUpdate: null, status: 'disabled', itemCount: 0 });
     });
-
     this.allowedApis.forEach(name => {
       this.apis.set(name, { name, status: 'disabled' });
     });
   }
 
-  public updateFeed(name: string, status: Partial<FeedStatus>): void {
-    // Only track feeds relevant to current variant
-    if (!this.allowedFeeds.has(name)) return;
+  public getFeeds(): Map<string, FeedStatus> { return this.feeds; }
+  public getApis(): Map<string, ApiStatus> { return this.apis; }
 
+  public updateFeed(name: string, status: Partial<FeedStatus>): void {
+    if (!this.allowedFeeds.has(name)) return;
     const existing = this.feeds.get(name) || { name, lastUpdate: null, status: 'ok' as const, itemCount: 0 };
     this.feeds.set(name, { ...existing, ...status, lastUpdate: new Date() });
-    this.updateStatusIcon();
-    if (this.isOpen) this.updateDisplay();
+    this.onUpdate?.();
   }
 
   public updateApi(name: string, status: Partial<ApiStatus>): void {
-    // Only track APIs relevant to current variant
     if (!this.allowedApis.has(name)) return;
-
     const existing = this.apis.get(name) || { name, status: 'ok' as const };
     this.apis.set(name, { ...existing, ...status });
-    this.updateStatusIcon();
-    if (this.isOpen) this.updateDisplay();
+    this.onUpdate?.();
   }
 
   public setFeedDisabled(name: string): void {
     const existing = this.feeds.get(name);
     if (existing) {
       this.feeds.set(name, { ...existing, status: 'disabled', itemCount: 0, lastUpdate: null });
-      this.updateStatusIcon();
-      if (this.isOpen) this.updateDisplay();
+      this.onUpdate?.();
     }
   }
 
@@ -152,87 +103,11 @@ export class StatusPanel extends Panel {
     const existing = this.apis.get(name);
     if (existing) {
       this.apis.set(name, { ...existing, status: 'disabled' });
-      this.updateStatusIcon();
-      if (this.isOpen) this.updateDisplay();
+      this.onUpdate?.();
     }
   }
 
-  private updateStatusIcon(): void {
-    const icon = this.element.querySelector('.status-icon')!;
-    // Only count enabled feeds/APIs (not 'disabled') for status indicator
-    const enabledFeeds = [...this.feeds.values()].filter(f => f.status !== 'disabled');
-    const enabledApis = [...this.apis.values()].filter(a => a.status !== 'disabled');
-
-    const hasError = enabledFeeds.some(f => f.status === 'error') ||
-      enabledApis.some(a => a.status === 'error');
-    const hasWarning = enabledFeeds.some(f => f.status === 'warning') ||
-      enabledApis.some(a => a.status === 'warning');
-
-    icon.className = 'status-icon';
-    if (hasError) {
-      icon.classList.add('error');
-      icon.textContent = '◉';
-    } else if (hasWarning) {
-      icon.classList.add('warning');
-      icon.textContent = '◉';
-    } else {
-      icon.classList.add('ok');
-      icon.textContent = '◉';
-    }
-  }
-
-  private updateDisplay(): void {
-    const feedsList = this.element.querySelector('.feeds-list')!;
-    const apisList = this.element.querySelector('.apis-list')!;
-    const storageInfo = this.element.querySelector('.storage-info')!;
-    const lastCheck = this.element.querySelector('.last-check')!;
-
-    replaceChildren(feedsList,
-      ...[...this.feeds.values()].map(feed =>
-        h('div', { className: 'status-row' },
-          h('span', { className: `status-dot ${feed.status}` }),
-          h('span', { className: 'status-name' }, feed.name),
-          h('span', { className: 'status-detail' }, `${feed.itemCount} items`),
-          h('span', { className: 'status-time' }, feed.lastUpdate ? this.formatTime(feed.lastUpdate) : 'Never'),
-        ),
-      ),
-    );
-
-    replaceChildren(apisList,
-      ...[...this.apis.values()].map(api =>
-        h('div', { className: 'status-row' },
-          h('span', { className: `status-dot ${api.status}` }),
-          h('span', { className: 'status-name' }, api.name),
-          api.latency ? h('span', { className: 'status-detail' }, `${api.latency}ms`) : false,
-        ),
-      ),
-    );
-
-    this.updateStorageInfo(storageInfo);
-    lastCheck.textContent = t('components.status.updatedAt', { time: this.formatTime(new Date()) });
-  }
-
-  private async updateStorageInfo(container: Element): Promise<void> {
-    try {
-      if ('storage' in navigator && 'estimate' in navigator.storage) {
-        const estimate = await navigator.storage.estimate();
-        const used = estimate.usage ? (estimate.usage / 1024 / 1024).toFixed(2) : '0';
-        const quota = estimate.quota ? (estimate.quota / 1024 / 1024).toFixed(0) : 'N/A';
-        replaceChildren(container,
-          h('div', { className: 'status-row' },
-            h('span', { className: 'status-name' }, 'IndexedDB'),
-            h('span', { className: 'status-detail' }, `${used} MB / ${quota} MB`),
-          ),
-        );
-      } else {
-        replaceChildren(container, h('div', { className: 'status-row' }, t('components.status.storageUnavailable')));
-      }
-    } catch {
-      replaceChildren(container, h('div', { className: 'status-row' }, t('components.status.storageUnavailable')));
-    }
-  }
-
-  private formatTime(date: Date): string {
+  public formatTime(date: Date): string {
     const now = Date.now();
     const diff = now - date.getTime();
     if (diff < 60000) return 'just now';

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -86,7 +86,7 @@
     "search": "Search",
     "settings": "SETTINGS",
     "sources": "SOURCES",
-    "copyLink": "Copy Link",
+    "copyLink": "Link",
     "downloadApp": "Download App",
     "fullscreen": "Fullscreen",
     "pinMap": "Pin map to top",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -719,6 +719,10 @@ canvas,
   border-color: var(--text);
 }
 
+.download-wrapper {
+  position: relative;
+}
+
 .download-btn {
   padding: 4px 10px;
   background: transparent;
@@ -736,6 +740,102 @@ canvas,
 .download-btn:hover {
   border-color: var(--accent);
   color: var(--accent);
+}
+
+.download-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  width: 280px;
+  background: var(--border-subtle);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px var(--shadow-color);
+  z-index: 1000;
+  display: none;
+  margin-top: 4px;
+  padding: 10px;
+}
+
+.download-dropdown.open {
+  display: block;
+}
+
+.dl-dd-tagline {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-bottom: 10px;
+  line-height: 1.4;
+}
+
+.dl-dd-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dl-dd-btn {
+  display: block;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  text-decoration: none;
+  text-align: center;
+  transition: opacity 0.15s;
+  color: #e0e0e0;
+}
+
+.dl-dd-btn:hover {
+  opacity: 0.85;
+}
+
+.dl-dd-btn.mac {
+  background: #2d5a2d;
+  border: 1px solid #3a7a3a;
+}
+
+.dl-dd-btn.win {
+  background: #2d4a5a;
+  border: 1px solid #3a6a8a;
+}
+
+.dl-dd-btn.linux {
+  background: #5a4a2d;
+  border: 1px solid #8a7a3a;
+}
+
+.dl-dd-btn.primary {
+  font-weight: 600;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.dl-dd-toggle {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 11px;
+  cursor: pointer;
+  padding: 8px 0 4px;
+  font-family: inherit;
+  text-align: center;
+}
+
+.dl-dd-toggle:hover {
+  text-decoration: underline;
+}
+
+.dl-dd-others {
+  display: none;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.dl-dd-others.show {
+  display: flex;
 }
 
 .search-btn kbd {
@@ -6105,93 +6205,7 @@ a.prediction-link:hover {
 }
 
 /* Status Panel */
-.status-panel-container {
-  position: relative;
-}
-
-.status-panel-toggle {
-  background: transparent;
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  padding: 2px 6px;
-  font-size: 10px;
-  cursor: pointer;
-  border-radius: 3px;
-}
-
-.status-panel-toggle:hover {
-  border-color: var(--text-dim);
-}
-
-.status-icon {
-  font-size: 8px;
-}
-
-.status-icon.ok {
-  color: var(--green);
-}
-
-.status-icon.warning {
-  color: var(--yellow);
-}
-
-.status-icon.error {
-  color: var(--red);
-}
-
-.status-panel {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  margin-top: 8px;
-  width: 280px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  z-index: 1000;
-  box-shadow: 0 4px 20px var(--shadow-color);
-}
-
-.status-panel.hidden {
-  display: none;
-}
-
-.status-panel-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--border);
-  font-size: 11px;
-  font-weight: bold;
-  color: var(--text);
-}
-
-.status-panel-close {
-  background: none;
-  border: none;
-  color: var(--text-dim);
-  font-size: 14px;
-  cursor: pointer;
-}
-
-.status-panel-content {
-  padding: 8px 0;
-  max-height: 300px;
-  overflow-y: auto;
-}
-
-.status-section {
-  padding: 8px 12px;
-}
-
-.status-section-title {
-  font-size: 9px;
-  color: var(--text-dim);
-  text-transform: uppercase;
-  margin-bottom: 6px;
-}
-
+/* Status rows (used in settings status tab) */
 .status-row {
   display: flex;
   align-items: center;
@@ -6242,7 +6256,25 @@ a.prediction-link:hover {
   font-size: 10px;
 }
 
-.status-panel-footer {
+/* Status tab inside Unified Settings */
+.us-status-content {
+  padding: 4px 0;
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.us-status-section {
+  padding: 8px 12px;
+}
+
+.us-status-section-title {
+  font-size: 9px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.us-status-footer {
   padding: 6px 12px;
   border-top: 1px solid var(--border);
   font-size: 9px;
@@ -9313,7 +9345,7 @@ a.prediction-link:hover {
 
   /* Hide non-essential header items */
   .copy-link-btn,
-  .download-btn {
+  .download-wrapper {
     display: none;
   }
 }


### PR DESCRIPTION
## Summary
- **Download button**: shows detected platform (e.g. ` Silicon`, `Windows`), click opens dropdown with primary download highlighted + "Show all platforms" toggle for remaining options
- **System Status**: moved from standalone header dropdown into Settings modal as a new "System Status" tab — removes the toggle button from the header
- **Header**: "Copy Link" shortened to "Link"

## Test plan
- [ ] Download button shows correct platform label on macOS/Windows/Linux
- [ ] Click opens dropdown below button with platform-colored download links
- [ ] "Show all platforms" toggle reveals remaining options
- [ ] Click outside or Esc closes dropdown
- [ ] Settings gear → "System Status" tab shows feeds, APIs, storage info
- [ ] Status tab updates live as data feeds report in
- [ ] Hidden on mobile < 480px
- [ ] `tsc --noEmit` passes