### PR TITLE
feat(cmdk): disambiguate Map vs Panel commands + split country map/brief

### DIFF
--- a/src/app/search-manager.ts
+++ b/src/app/search-manager.ts
@@ -9,6 +9,7 @@ import { SITE_VARIANT, STORAGE_KEYS } from '@/config';
 import { LAYER_PRESETS, LAYER_KEY_MAP } from '@/config/commands';
 import { calculateCII, TIER1_COUNTRIES } from '@/services/country-instability';
 import { CURATED_COUNTRIES } from '@/config/countries';
+import { getCountryBbox } from '@/services/country-geometry';
 import { INTEL_HOTSPOTS, CONFLICT_ZONES, MILITARY_BASES, UNDERSEA_CABLES, NUCLEAR_FACILITIES } from '@/config/geo';
 import { PIPELINES } from '@/config/pipelines';
 import { AI_DATA_CENTERS } from '@/config/ai-datacenters';
@@ -477,6 +478,20 @@ export class SearchManager implements AppModule {
           || action;
         trackCountrySelected(action, name, 'command');
         this.callbacks.openCountryBriefByCode(action, name);
+        break;
+      }
+
+      case 'country-map': {
+        const bbox = getCountryBbox(action);
+        if (bbox) {
+          const [minLon, minLat, maxLon, maxLat] = bbox;
+          const lat = (minLat + maxLat) / 2;
+          const lon = (minLon + maxLon) / 2;
+          const span = Math.max(maxLat - minLat, maxLon - minLon);
+          const zoom = span > 40 ? 3 : span > 15 ? 4 : span > 5 ? 5 : 6;
+          this.ctx.map?.setView('global');
+          setTimeout(() => { this.ctx.map?.setCenter(lat, lon, zoom); }, 300);
+        }
         break;
       }
     }

--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -8,6 +8,46 @@ interface CommandResult {
   score: number;
 }
 
+const CATEGORY_KEYS: Record<string, string> = {
+  navigate: 'commands.categories.navigate',
+  layers: 'commands.categories.layers',
+  panels: 'commands.categories.panels',
+  view: 'commands.categories.view',
+  actions: 'commands.categories.actions',
+  country: 'commands.categories.country',
+};
+
+function kebabToCamel(s: string): string {
+  return s.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+function resolveCommandLabel(cmd: Command): string {
+  const colonIdx = cmd.id.indexOf(':');
+  if (colonIdx === -1) return cmd.label;
+  const prefix = cmd.id.slice(0, colonIdx);
+  const action = cmd.id.slice(colonIdx + 1);
+
+  switch (prefix) {
+    case 'nav':
+      return `${t('commands.prefixes.map')}: ${t('commands.regions.' + action, { defaultValue: cmd.label })}`;
+    case 'country-map':
+      return `${t('commands.prefixes.map')}: ${cmd.label}`;
+    case 'panel': {
+      const panelName = t('panels.' + kebabToCamel(action), { defaultValue: cmd.label });
+      return `${t('commands.prefixes.panel')}: ${panelName}`;
+    }
+    case 'country':
+      return `${t('commands.prefixes.brief')}: ${cmd.label}`;
+    default:
+      return cmd.label;
+  }
+}
+
+function resolveCategoryLabel(cmd: Command): string {
+  const key = CATEGORY_KEYS[cmd.category];
+  return key ? t(key, { defaultValue: cmd.category }) : cmd.category;
+}
+
 export type SearchResultType = 'country' | 'news' | 'hotspot' | 'market' | 'prediction' | 'conflict' | 'base' | 'pipeline' | 'cable' | 'datacenter' | 'earthquake' | 'outage' | 'nuclear' | 'irradiator' | 'techcompany' | 'ailab' | 'startup' | 'techevent' | 'techhq' | 'accelerator' | 'exchange' | 'financialcenter' | 'centralbank' | 'commodityhub';
 
 export interface SearchResult {
@@ -318,9 +358,9 @@ export class SearchModal {
           <div class="search-result-item command-item ${globalIndex === this.selectedIndex ? 'selected' : ''}" data-index="${globalIndex}" data-command="${command.id}">
             <span class="search-result-icon">${command.icon}</span>
             <div class="search-result-content">
-              <div class="search-result-title">${escapeHtml(command.label)}</div>
+              <div class="search-result-title">${escapeHtml(resolveCommandLabel(command))}</div>
             </div>
-            <span class="search-result-type">${escapeHtml(command.category)}</span>
+            <span class="search-result-type">${escapeHtml(resolveCategoryLabel(command))}</span>
           </div>`;
         globalIndex++;
       }

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -25,14 +25,14 @@ export const LAYER_KEY_MAP: Record<string, keyof MapLayers> = {
 
 export const COMMANDS: Command[] = [
   // Navigation (region switching)
-  { id: 'nav:global', keywords: ['global', 'world', 'reset', 'home'], label: 'Go to Global view', icon: '\u{1F30D}', category: 'navigate' },
-  { id: 'nav:mena', keywords: ['mena', 'middle east', 'mideast'], label: 'Go to Middle East & North Africa', icon: '\u{1F54C}', category: 'navigate' },
-  { id: 'nav:eu', keywords: ['europe', 'eu'], label: 'Go to Europe', icon: '\u{1F3F0}', category: 'navigate' },
-  { id: 'nav:asia', keywords: ['asia', 'pacific'], label: 'Go to Asia-Pacific', icon: '\u{1F3EF}', category: 'navigate' },
-  { id: 'nav:america', keywords: ['america', 'americas', 'us', 'usa'], label: 'Go to Americas', icon: '\u{1F5FD}', category: 'navigate' },
-  { id: 'nav:africa', keywords: ['africa'], label: 'Go to Africa', icon: '\u{1F30D}', category: 'navigate' },
-  { id: 'nav:latam', keywords: ['latam', 'latin america', 'south america'], label: 'Go to Latin America', icon: '\u{1F30E}', category: 'navigate' },
-  { id: 'nav:oceania', keywords: ['oceania', 'australia', 'pacific islands'], label: 'Go to Oceania', icon: '\u{1F30F}', category: 'navigate' },
+  { id: 'nav:global', keywords: ['global', 'world', 'reset', 'home'], label: 'Map: Global view', icon: '\u{1F30D}', category: 'navigate' },
+  { id: 'nav:mena', keywords: ['mena', 'middle east', 'mideast'], label: 'Map: Middle East & North Africa', icon: '\u{1F54C}', category: 'navigate' },
+  { id: 'nav:eu', keywords: ['europe', 'eu'], label: 'Map: Europe', icon: '\u{1F3F0}', category: 'navigate' },
+  { id: 'nav:asia', keywords: ['asia', 'pacific'], label: 'Map: Asia-Pacific', icon: '\u{1F3EF}', category: 'navigate' },
+  { id: 'nav:america', keywords: ['america', 'americas', 'us', 'usa'], label: 'Map: Americas', icon: '\u{1F5FD}', category: 'navigate' },
+  { id: 'nav:africa', keywords: ['africa'], label: 'Map: Africa', icon: '\u{1F30D}', category: 'navigate' },
+  { id: 'nav:latam', keywords: ['latam', 'latin america', 'south america'], label: 'Map: Latin America', icon: '\u{1F30E}', category: 'navigate' },
+  { id: 'nav:oceania', keywords: ['oceania', 'australia', 'pacific islands'], label: 'Map: Oceania', icon: '\u{1F30F}', category: 'navigate' },
 
   // Layer presets (toggle groups)
   { id: 'layers:military', keywords: ['military', 'military layers', 'show military'], label: 'Show military layers', icon: '\u{1F396}\uFE0F', category: 'layers' },
@@ -62,38 +62,38 @@ export const COMMANDS: Command[] = [
   { id: 'layer:tradeRoutes', keywords: ['trade routes', 'shipping lanes', 'trade'], label: 'Toggle trade routes', icon: '\u{1F6A2}', category: 'layers' },
 
   // Panel navigation (matching actual DEFAULT_PANELS keys)
-  { id: 'panel:live-news', keywords: ['news', 'live news', 'headlines'], label: 'Jump to Live News', icon: '\u{1F4F0}', category: 'panels' },
-  { id: 'panel:intel', keywords: ['intel', 'intel feed'], label: 'Jump to Intel Feed', icon: '\u{1F50E}', category: 'panels' },
-  { id: 'panel:gdelt-intel', keywords: ['gdelt', 'intelligence feed'], label: 'Jump to Live Intelligence', icon: '\u{1F50D}', category: 'panels' },
-  { id: 'panel:deduction', keywords: ['deduction', 'future', 'what if'], label: 'Jump to Deduct Situation', icon: '\u{1F9E0}', category: 'panels' },
-  { id: 'panel:cii', keywords: ['cii', 'instability', 'country risk'], label: 'Jump to Country Instability', icon: '\u{1F3AF}', category: 'panels' },
-  { id: 'panel:cascade', keywords: ['cascade', 'infrastructure cascade'], label: 'Jump to Infrastructure Cascade', icon: '\u{1F517}', category: 'panels' },
-  { id: 'panel:strategic-risk', keywords: ['risk', 'strategic risk', 'threat level'], label: 'Jump to Strategic Risk', icon: '\u26A0\uFE0F', category: 'panels' },
-  { id: 'panel:politics', keywords: ['world news', 'politics', 'geopolitics'], label: 'Jump to World News', icon: '\u{1F30D}', category: 'panels' },
-  { id: 'panel:us', keywords: ['united states', 'us news', 'america news'], label: 'Jump to United States', icon: '\u{1F1FA}\u{1F1F8}', category: 'panels' },
-  { id: 'panel:europe', keywords: ['europe news', 'eu news'], label: 'Jump to Europe', icon: '\u{1F1EA}\u{1F1FA}', category: 'panels' },
-  { id: 'panel:middleeast', keywords: ['middle east news', 'mideast news'], label: 'Jump to Middle East', icon: '\u{1F54C}', category: 'panels' },
-  { id: 'panel:africa', keywords: ['africa news'], label: 'Jump to Africa', icon: '\u{1F30D}', category: 'panels' },
-  { id: 'panel:latam', keywords: ['latin america news', 'latam news'], label: 'Jump to Latin America', icon: '\u{1F30E}', category: 'panels' },
-  { id: 'panel:asia', keywords: ['asia news', 'asia-pacific news'], label: 'Jump to Asia-Pacific', icon: '\u{1F30F}', category: 'panels' },
-  { id: 'panel:energy', keywords: ['energy', 'resources', 'oil news'], label: 'Jump to Energy & Resources', icon: '\u26A1', category: 'panels' },
-  { id: 'panel:gov', keywords: ['government', 'gov'], label: 'Jump to Government', icon: '\u{1F3DB}\uFE0F', category: 'panels' },
-  { id: 'panel:thinktanks', keywords: ['think tanks', 'thinktanks', 'analysis'], label: 'Jump to Think Tanks', icon: '\u{1F9E0}', category: 'panels' },
-  { id: 'panel:polymarket', keywords: ['predictions', 'polymarket', 'forecasts'], label: 'Jump to Predictions', icon: '\u{1F52E}', category: 'panels' },
-  { id: 'panel:commodities', keywords: ['commodities', 'gold', 'silver'], label: 'Jump to Commodities', icon: '\u{1F4E6}', category: 'panels' },
-  { id: 'panel:markets', keywords: ['markets', 'stocks', 'indices'], label: 'Jump to Markets', icon: '\u{1F4C8}', category: 'panels' },
-  { id: 'panel:economic', keywords: ['economic', 'economy', 'fred'], label: 'Jump to Economic Indicators', icon: '\u{1F4CA}', category: 'panels' },
-  { id: 'panel:trade-policy', keywords: ['trade', 'tariffs', 'wto', 'trade policy', 'sanctions', 'restrictions'], label: 'Jump to Trade Policy', icon: '\u{1F4CA}', category: 'panels' },
-  { id: 'panel:supply-chain', keywords: ['supply chain', 'shipping', 'chokepoint', 'minerals', 'freight', 'logistics'], label: 'Jump to Supply Chain', icon: '\u{1F6A2}', category: 'panels' },
-  { id: 'panel:finance', keywords: ['financial', 'finance news'], label: 'Jump to Financial', icon: '\u{1F4B5}', category: 'panels' },
-  { id: 'panel:tech', keywords: ['technology', 'tech news'], label: 'Jump to Technology', icon: '\u{1F4BB}', category: 'panels' },
-  { id: 'panel:crypto', keywords: ['crypto', 'bitcoin', 'ethereum'], label: 'Jump to Crypto', icon: '\u20BF', category: 'panels' },
-  { id: 'panel:heatmap', keywords: ['heatmap', 'sector heatmap'], label: 'Jump to Sector Heatmap', icon: '\u{1F5FA}\uFE0F', category: 'panels' },
-  { id: 'panel:ai', keywords: ['ai', 'ml', 'artificial intelligence'], label: 'Jump to AI/ML', icon: '\u{1F916}', category: 'panels' },
-  { id: 'panel:macro-signals', keywords: ['macro', 'macro signals', 'liquidity'], label: 'Jump to Market Radar', icon: '\u{1F4C9}', category: 'panels' },
-  { id: 'panel:etf-flows', keywords: ['etf', 'etf flows', 'fund flows'], label: 'Jump to BTC ETF Tracker', icon: '\u{1F4B9}', category: 'panels' },
-  { id: 'panel:stablecoins', keywords: ['stablecoins', 'usdt', 'usdc'], label: 'Jump to Stablecoins', icon: '\u{1FA99}', category: 'panels' },
-  { id: 'panel:monitors', keywords: ['monitors', 'my monitors', 'watchlist'], label: 'Jump to My Monitors', icon: '\u{1F4CB}', category: 'panels' },
+  { id: 'panel:live-news', keywords: ['news', 'live news', 'headlines'], label: 'Panel: Live News', icon: '\u{1F4F0}', category: 'panels' },
+  { id: 'panel:intel', keywords: ['intel', 'intel feed'], label: 'Panel: Intel Feed', icon: '\u{1F50E}', category: 'panels' },
+  { id: 'panel:gdelt-intel', keywords: ['gdelt', 'intelligence feed'], label: 'Panel: Live Intelligence', icon: '\u{1F50D}', category: 'panels' },
+  { id: 'panel:deduction', keywords: ['deduction', 'future', 'what if'], label: 'Panel: Deduct Situation', icon: '\u{1F9E0}', category: 'panels' },
+  { id: 'panel:cii', keywords: ['cii', 'instability', 'country risk'], label: 'Panel: Country Instability', icon: '\u{1F3AF}', category: 'panels' },
+  { id: 'panel:cascade', keywords: ['cascade', 'infrastructure cascade'], label: 'Panel: Infrastructure Cascade', icon: '\u{1F517}', category: 'panels' },
+  { id: 'panel:strategic-risk', keywords: ['risk', 'strategic risk', 'threat level'], label: 'Panel: Strategic Risk', icon: '\u26A0\uFE0F', category: 'panels' },
+  { id: 'panel:politics', keywords: ['world news', 'politics', 'geopolitics'], label: 'Panel: World News', icon: '\u{1F30D}', category: 'panels' },
+  { id: 'panel:us', keywords: ['united states', 'us news', 'america news'], label: 'Panel: United States', icon: '\u{1F1FA}\u{1F1F8}', category: 'panels' },
+  { id: 'panel:europe', keywords: ['europe news', 'eu news'], label: 'Panel: Europe', icon: '\u{1F1EA}\u{1F1FA}', category: 'panels' },
+  { id: 'panel:middleeast', keywords: ['middle east news', 'mideast news'], label: 'Panel: Middle East', icon: '\u{1F54C}', category: 'panels' },
+  { id: 'panel:africa', keywords: ['africa news'], label: 'Panel: Africa', icon: '\u{1F30D}', category: 'panels' },
+  { id: 'panel:latam', keywords: ['latin america news', 'latam news'], label: 'Panel: Latin America', icon: '\u{1F30E}', category: 'panels' },
+  { id: 'panel:asia', keywords: ['asia news', 'asia-pacific news'], label: 'Panel: Asia-Pacific', icon: '\u{1F30F}', category: 'panels' },
+  { id: 'panel:energy', keywords: ['energy', 'resources', 'oil news'], label: 'Panel: Energy & Resources', icon: '\u26A1', category: 'panels' },
+  { id: 'panel:gov', keywords: ['government', 'gov'], label: 'Panel: Government', icon: '\u{1F3DB}\uFE0F', category: 'panels' },
+  { id: 'panel:thinktanks', keywords: ['think tanks', 'thinktanks', 'analysis'], label: 'Panel: Think Tanks', icon: '\u{1F9E0}', category: 'panels' },
+  { id: 'panel:polymarket', keywords: ['predictions', 'polymarket', 'forecasts'], label: 'Panel: Predictions', icon: '\u{1F52E}', category: 'panels' },
+  { id: 'panel:commodities', keywords: ['commodities', 'gold', 'silver'], label: 'Panel: Commodities', icon: '\u{1F4E6}', category: 'panels' },
+  { id: 'panel:markets', keywords: ['markets', 'stocks', 'indices'], label: 'Panel: Markets', icon: '\u{1F4C8}', category: 'panels' },
+  { id: 'panel:economic', keywords: ['economic', 'economy', 'fred'], label: 'Panel: Economic Indicators', icon: '\u{1F4CA}', category: 'panels' },
+  { id: 'panel:trade-policy', keywords: ['trade', 'tariffs', 'wto', 'trade policy', 'sanctions', 'restrictions'], label: 'Panel: Trade Policy', icon: '\u{1F4CA}', category: 'panels' },
+  { id: 'panel:supply-chain', keywords: ['supply chain', 'shipping', 'chokepoint', 'minerals', 'freight', 'logistics'], label: 'Panel: Supply Chain', icon: '\u{1F6A2}', category: 'panels' },
+  { id: 'panel:finance', keywords: ['financial', 'finance news'], label: 'Panel: Financial', icon: '\u{1F4B5}', category: 'panels' },
+  { id: 'panel:tech', keywords: ['technology', 'tech news'], label: 'Panel: Technology', icon: '\u{1F4BB}', category: 'panels' },
+  { id: 'panel:crypto', keywords: ['crypto', 'bitcoin', 'ethereum'], label: 'Panel: Crypto', icon: '\u20BF', category: 'panels' },
+  { id: 'panel:heatmap', keywords: ['heatmap', 'sector heatmap'], label: 'Panel: Sector Heatmap', icon: '\u{1F5FA}\uFE0F', category: 'panels' },
+  { id: 'panel:ai', keywords: ['ai', 'ml', 'artificial intelligence'], label: 'Panel: AI/ML', icon: '\u{1F916}', category: 'panels' },
+  { id: 'panel:macro-signals', keywords: ['macro', 'macro signals', 'liquidity'], label: 'Panel: Market Radar', icon: '\u{1F4C9}', category: 'panels' },
+  { id: 'panel:etf-flows', keywords: ['etf', 'etf flows', 'fund flows'], label: 'Panel: BTC ETF Tracker', icon: '\u{1F4B9}', category: 'panels' },
+  { id: 'panel:stablecoins', keywords: ['stablecoins', 'usdt', 'usdc'], label: 'Panel: Stablecoins', icon: '\u{1FA99}', category: 'panels' },
+  { id: 'panel:monitors', keywords: ['monitors', 'my monitors', 'watchlist'], label: 'Panel: My Monitors', icon: '\u{1F4CB}', category: 'panels' },
 
   // View / settings
   { id: 'view:dark', keywords: ['dark', 'dark mode', 'night'], label: 'Switch to dark mode', icon: '\u{1F319}', category: 'view' },
@@ -133,19 +133,28 @@ const ISO_CODES = [
 
 const displayNames = new Intl.DisplayNames(['en'], { type: 'region' });
 
-const COUNTRY_COMMANDS: Command[] = ISO_CODES.map(code => {
+const COUNTRY_COMMANDS: Command[] = ISO_CODES.flatMap(code => {
   const curated = CURATED_COUNTRIES[code];
   const name = curated?.name || displayNames.of(code) || code;
   const keywords = curated
     ? [name.toLowerCase(), ...curated.searchAliases]
     : [name.toLowerCase()];
-  return {
-    id: `country:${code}`,
-    keywords,
-    label: `Open ${name} brief`,
-    icon: toFlagEmoji(code),
-    category: 'country' as const,
-  };
+  return [
+    {
+      id: `country-map:${code}`,
+      keywords: [...keywords, 'map'],
+      label: name,
+      icon: toFlagEmoji(code),
+      category: 'navigate' as const,
+    },
+    {
+      id: `country:${code}`,
+      keywords: [...keywords, 'brief'],
+      label: name,
+      icon: toFlagEmoji(code),
+      category: 'country' as const,
+    },
+  ];
 });
 
 COMMANDS.push(...COUNTRY_COMMANDS);

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -183,6 +183,7 @@
     "macroSignals": "رادار السوق",
     "etfFlows": "متتبع BTC ETF",
     "stablecoins": "العملات المستقرة",
+    "deduction": "استنتاج الوضع",
     "ucdpEvents": "أحداث نزاع UCDP",
     "displacement": "نزوح UNHCR",
     "climate": "شذوذات مناخية",
@@ -217,6 +218,31 @@
     "gulfIndices": "مؤشرات الخليج",
     "gulfCurrencies": "عملات الخليج",
     "gulfOil": "نفط الخليج"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "خريطة",
+      "panel": "لوحة",
+      "brief": "موجز"
+    },
+    "categories": {
+      "navigate": "تنقل",
+      "layers": "طبقات",
+      "panels": "لوحات",
+      "view": "عرض",
+      "actions": "إجراءات",
+      "country": "دولة"
+    },
+    "regions": {
+      "global": "عرض عالمي",
+      "mena": "الشرق الأوسط وشمال أفريقيا",
+      "eu": "أوروبا",
+      "asia": "آسيا والمحيط الهادئ",
+      "america": "الأمريكتان",
+      "africa": "أفريقيا",
+      "latam": "أمريكا اللاتينية",
+      "oceania": "أوقيانوسيا"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -184,6 +184,7 @@
     "macroSignals": "Tržní radar",
     "etfFlows": "Sledování BTC ETF",
     "stablecoins": "Stablecoiny",
+    "deduction": "Dedukce situace",
     "ucdpEvents": "UCDP Konflikty",
     "giving": "Globální dárcovství",
     "displacement": "UNHCR Vysídlení",
@@ -217,6 +218,31 @@
     "gulfIndices": "Indexy Perského zálivu",
     "gulfCurrencies": "Měny Perského zálivu",
     "gulfOil": "Ropa Perského zálivu"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Mapa",
+      "panel": "Panel",
+      "brief": "Shrnutí"
+    },
+    "categories": {
+      "navigate": "Navigace",
+      "layers": "Vrstvy",
+      "panels": "Panely",
+      "view": "Zobrazení",
+      "actions": "Akce",
+      "country": "Země"
+    },
+    "regions": {
+      "global": "Globální pohled",
+      "mena": "Blízký východ a severní Afrika",
+      "eu": "Evropa",
+      "asia": "Asie a Tichomoří",
+      "america": "Amerika",
+      "africa": "Afrika",
+      "latam": "Latinská Amerika",
+      "oceania": "Oceánie"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -182,6 +182,7 @@
     "macroSignals": "Markt-Radar",
     "etfFlows": "BTC ETF-Tracker",
     "stablecoins": "Stablecoins",
+    "deduction": "Lagebeurteilung",
     "ucdpEvents": "UCDP Konfliktereignisse",
     "giving": "Globale Spenden",
     "supplyChain": "Lieferkette",
@@ -217,6 +218,31 @@
     "gulfIndices": "Golf-Indizes",
     "gulfCurrencies": "Golf-Währungen",
     "gulfOil": "Golf-Öl"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Karte",
+      "panel": "Panel",
+      "brief": "Kurzübersicht"
+    },
+    "categories": {
+      "navigate": "Navigieren",
+      "layers": "Ebenen",
+      "panels": "Panels",
+      "view": "Ansicht",
+      "actions": "Aktionen",
+      "country": "Land"
+    },
+    "regions": {
+      "global": "Globale Ansicht",
+      "mena": "Naher Osten & Nordafrika",
+      "eu": "Europa",
+      "asia": "Asien-Pazifik",
+      "america": "Amerika",
+      "africa": "Afrika",
+      "latam": "Lateinamerika",
+      "oceania": "Ozeanien"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -183,6 +183,7 @@
     "macroSignals": "Ραντάρ Αγορών",
     "etfFlows": "BTC ETF Tracker",
     "stablecoins": "Stablecoins",
+    "deduction": "Εκτίμηση κατάστασης",
     "ucdpEvents": "Συγκρούσεις UCDP",
     "displacement": "Εκτοπισμοί UNHCR",
     "climate": "Κλιματικές Ανωμαλίες",
@@ -217,6 +218,31 @@
     "gulfIndices": "Δείκτες Κόλπου",
     "gulfCurrencies": "Νομίσματα Κόλπου",
     "gulfOil": "Πετρέλαιο Κόλπου"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Χάρτης",
+      "panel": "Πάνελ",
+      "brief": "Σύνοψη"
+    },
+    "categories": {
+      "navigate": "Πλοήγηση",
+      "layers": "Επίπεδα",
+      "panels": "Πάνελ",
+      "view": "Προβολή",
+      "actions": "Ενέργειες",
+      "country": "Χώρα"
+    },
+    "regions": {
+      "global": "Παγκόσμια προβολή",
+      "mena": "Μέση Ανατολή & Βόρεια Αφρική",
+      "eu": "Ευρώπη",
+      "asia": "Ασία-Ειρηνικός",
+      "america": "Αμερική",
+      "africa": "Αφρική",
+      "latam": "Λατινική Αμερική",
+      "oceania": "Ωκεανία"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -185,6 +185,7 @@
     "macroSignals": "Market Radar",
     "etfFlows": "BTC ETF Tracker",
     "stablecoins": "Stablecoins",
+    "deduction": "Deduct Situation",
     "ucdpEvents": "UCDP Conflict Events",
     "giving": "Global Giving",
     "displacement": "UNHCR Displacement",
@@ -218,6 +219,31 @@
     "gulfIndices": "Gulf Indices",
     "gulfCurrencies": "Gulf Currencies",
     "gulfOil": "Gulf Oil"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Map",
+      "panel": "Panel",
+      "brief": "Brief"
+    },
+    "categories": {
+      "navigate": "Navigate",
+      "layers": "Layers",
+      "panels": "Panels",
+      "view": "View",
+      "actions": "Actions",
+      "country": "Country"
+    },
+    "regions": {
+      "global": "Global view",
+      "mena": "Middle East & North Africa",
+      "eu": "Europe",
+      "asia": "Asia-Pacific",
+      "america": "Americas",
+      "africa": "Africa",
+      "latam": "Latin America",
+      "oceania": "Oceania"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -182,6 +182,7 @@
     "macroSignals": "Radar de mercado",
     "etfFlows": "Rastreador de ETF BTC",
     "stablecoins": "Monedas estables",
+    "deduction": "Deducir situación",
     "ucdpEvents": "Eventos de conflicto UCDP",
     "giving": "Donaciones Globales",
     "supplyChain": "Cadena de Suministro",
@@ -217,6 +218,31 @@
     "gulfIndices": "Índices del Golfo",
     "gulfCurrencies": "Monedas del Golfo",
     "gulfOil": "Petróleo del Golfo"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Mapa",
+      "panel": "Panel",
+      "brief": "Resumen"
+    },
+    "categories": {
+      "navigate": "Navegar",
+      "layers": "Capas",
+      "panels": "Paneles",
+      "view": "Vista",
+      "actions": "Acciones",
+      "country": "País"
+    },
+    "regions": {
+      "global": "Vista global",
+      "mena": "Oriente Medio y Norte de África",
+      "eu": "Europa",
+      "asia": "Asia-Pacífico",
+      "america": "Américas",
+      "africa": "África",
+      "latam": "América Latina",
+      "oceania": "Oceanía"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -182,6 +182,7 @@
     "macroSignals": "Radar de marché",
     "etfFlows": "Suivi ETF BTC",
     "stablecoins": "Stablecoins",
+    "deduction": "Déduire la situation",
     "ucdpEvents": "Conflits UCDP",
     "displacement": "Déplacements HCR",
     "climate": "Anomalies climatiques",
@@ -217,6 +218,31 @@
     "gulfIndices": "Indices du Golfe",
     "gulfCurrencies": "Devises du Golfe",
     "gulfOil": "Pétrole du Golfe"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Carte",
+      "panel": "Panneau",
+      "brief": "Dossier"
+    },
+    "categories": {
+      "navigate": "Naviguer",
+      "layers": "Couches",
+      "panels": "Panneaux",
+      "view": "Vue",
+      "actions": "Actions",
+      "country": "Pays"
+    },
+    "regions": {
+      "global": "Vue mondiale",
+      "mena": "Moyen-Orient et Afrique du Nord",
+      "eu": "Europe",
+      "asia": "Asie-Pacifique",
+      "america": "Amériques",
+      "africa": "Afrique",
+      "latam": "Amérique latine",
+      "oceania": "Océanie"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -182,6 +182,7 @@
     "macroSignals": "Radar di mercato",
     "etfFlows": "Tracciamento ETF BTC",
     "stablecoins": "Stablecoin",
+    "deduction": "Dedurre situazione",
     "ucdpEvents": "Eventi di conflitto UCDP",
     "giving": "Donazioni Globali",
     "supplyChain": "Catena di Approvvigionamento",
@@ -217,6 +218,31 @@
     "gulfIndices": "Indici del Golfo",
     "gulfCurrencies": "Valute del Golfo",
     "gulfOil": "Petrolio del Golfo"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Mappa",
+      "panel": "Pannello",
+      "brief": "Riepilogo"
+    },
+    "categories": {
+      "navigate": "Naviga",
+      "layers": "Livelli",
+      "panels": "Pannelli",
+      "view": "Vista",
+      "actions": "Azioni",
+      "country": "Paese"
+    },
+    "regions": {
+      "global": "Vista globale",
+      "mena": "Medio Oriente e Nord Africa",
+      "eu": "Europa",
+      "asia": "Asia-Pacifico",
+      "america": "Americhe",
+      "africa": "Africa",
+      "latam": "America Latina",
+      "oceania": "Oceania"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -183,6 +183,7 @@
     "macroSignals": "マーケットレーダー",
     "etfFlows": "BTC ETFトラッカー",
     "stablecoins": "ステーブルコイン",
+    "deduction": "状況推定",
     "ucdpEvents": "UCDP紛争イベント",
     "displacement": "UNHCR避難民",
     "climate": "気候異常",
@@ -217,6 +218,31 @@
     "gulfIndices": "湾岸指数",
     "gulfCurrencies": "湾岸通貨",
     "gulfOil": "湾岸石油"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "マップ",
+      "panel": "パネル",
+      "brief": "概要"
+    },
+    "categories": {
+      "navigate": "ナビゲート",
+      "layers": "レイヤー",
+      "panels": "パネル",
+      "view": "ビュー",
+      "actions": "アクション",
+      "country": "国"
+    },
+    "regions": {
+      "global": "グローバルビュー",
+      "mena": "中東・北アフリカ",
+      "eu": "ヨーロッパ",
+      "asia": "アジア太平洋",
+      "america": "アメリカ大陸",
+      "africa": "アフリカ",
+      "latam": "ラテンアメリカ",
+      "oceania": "オセアニア"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -184,6 +184,7 @@
     "macroSignals": "시장 레이더",
     "etfFlows": "BTC ETF 추적",
     "stablecoins": "스테이블코인",
+    "deduction": "상황 추론",
     "ucdpEvents": "UCDP 분쟁 사건",
     "giving": "글로벌 기부",
     "displacement": "UNHCR 실향민",
@@ -217,6 +218,31 @@
     "gulfIndices": "걸프 지수",
     "gulfCurrencies": "걸프 통화",
     "gulfOil": "걸프 석유"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "지도",
+      "panel": "패널",
+      "brief": "요약"
+    },
+    "categories": {
+      "navigate": "탐색",
+      "layers": "레이어",
+      "panels": "패널",
+      "view": "보기",
+      "actions": "작업",
+      "country": "국가"
+    },
+    "regions": {
+      "global": "글로벌 보기",
+      "mena": "중동 및 북아프리카",
+      "eu": "유럽",
+      "asia": "아시아태평양",
+      "america": "아메리카",
+      "africa": "아프리카",
+      "latam": "라틴 아메리카",
+      "oceania": "오세아니아"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -48,6 +48,7 @@
     "regulation": "Dashboard voor AI-regulering",
     "serviceStatus": "Servicestatus",
     "stablecoins": "Stabiele munten",
+    "deduction": "Situatie afleiden",
     "events": "Technische evenementen",
     "techHubs": "Hottech-hubs",
     "techReadiness": "Tech Readiness-index",
@@ -72,6 +73,31 @@
     "gulfIndices": "Golfindices",
     "gulfCurrencies": "Golfvaluta",
     "gulfOil": "Golfolie"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Kaart",
+      "panel": "Paneel",
+      "brief": "Samenvatting"
+    },
+    "categories": {
+      "navigate": "Navigeren",
+      "layers": "Lagen",
+      "panels": "Panelen",
+      "view": "Weergave",
+      "actions": "Acties",
+      "country": "Land"
+    },
+    "regions": {
+      "global": "Globaal overzicht",
+      "mena": "Midden-Oosten & Noord-Afrika",
+      "eu": "Europa",
+      "asia": "Azië-Pacific",
+      "america": "Amerika",
+      "africa": "Afrika",
+      "latam": "Latijns-Amerika",
+      "oceania": "Oceanië"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -182,6 +182,7 @@
     "macroSignals": "Radar rynkowy",
     "etfFlows": "Śledzenie ETF BTC",
     "stablecoins": "Stablecoiny",
+    "deduction": "Dedukcja sytuacji",
     "ucdpEvents": "Wydarzenia konfliktowe UCDP",
     "displacement": "Przesiedlenia UNHCR",
     "climate": "Anomalie klimatyczne",
@@ -217,6 +218,31 @@
     "gulfIndices": "Indeksy Zatoki",
     "gulfCurrencies": "Waluty Zatoki",
     "gulfOil": "Ropa Zatoki"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Mapa",
+      "panel": "Panel",
+      "brief": "Podsumowanie"
+    },
+    "categories": {
+      "navigate": "Nawigacja",
+      "layers": "Warstwy",
+      "panels": "Panele",
+      "view": "Widok",
+      "actions": "Akcje",
+      "country": "Kraj"
+    },
+    "regions": {
+      "global": "Widok globalny",
+      "mena": "Bliski Wschód i Afryka Północna",
+      "eu": "Europa",
+      "asia": "Azja i Pacyfik",
+      "america": "Ameryka",
+      "africa": "Afryka",
+      "latam": "Ameryka Łacińska",
+      "oceania": "Oceania"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -48,6 +48,7 @@
     "regulation": "Painel de regulamentação de IA",
     "serviceStatus": "Status do serviço",
     "stablecoins": "Moedas estáveis",
+    "deduction": "Deduzir situação",
     "events": "Eventos tecnológicos",
     "techHubs": "Centros de tecnologia importantes",
     "techReadiness": "Índice de prontidão tecnológica",
@@ -72,6 +73,31 @@
     "gulfIndices": "Índices do Golfo",
     "gulfCurrencies": "Moedas do Golfo",
     "gulfOil": "Petróleo do Golfo"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Mapa",
+      "panel": "Painel",
+      "brief": "Resumo"
+    },
+    "categories": {
+      "navigate": "Navegar",
+      "layers": "Camadas",
+      "panels": "Painéis",
+      "view": "Vista",
+      "actions": "Ações",
+      "country": "País"
+    },
+    "regions": {
+      "global": "Vista global",
+      "mena": "Médio Oriente e Norte de África",
+      "eu": "Europa",
+      "asia": "Ásia-Pacífico",
+      "america": "Américas",
+      "africa": "África",
+      "latam": "América Latina",
+      "oceania": "Oceânia"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -183,6 +183,7 @@
     "macroSignals": "Рыночный радар",
     "etfFlows": "Трекер BTC ETF",
     "stablecoins": "Стейблкоины",
+    "deduction": "Оценка ситуации",
     "ucdpEvents": "Конфликтные события UCDP",
     "displacement": "Перемещение населения UNHCR",
     "climate": "Климатические аномалии",
@@ -217,6 +218,31 @@
     "gulfIndices": "Индексы Залива",
     "gulfCurrencies": "Валюты Залива",
     "gulfOil": "Нефть Залива"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Карта",
+      "panel": "Панель",
+      "brief": "Сводка"
+    },
+    "categories": {
+      "navigate": "Навигация",
+      "layers": "Слои",
+      "panels": "Панели",
+      "view": "Вид",
+      "actions": "Действия",
+      "country": "Страна"
+    },
+    "regions": {
+      "global": "Глобальный обзор",
+      "mena": "Ближний Восток и Северная Африка",
+      "eu": "Европа",
+      "asia": "Азиатско-Тихоокеанский регион",
+      "america": "Америка",
+      "africa": "Африка",
+      "latam": "Латинская Америка",
+      "oceania": "Океания"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -48,6 +48,7 @@
     "regulation": "AI-regleringspanel",
     "serviceStatus": "Servicestatus",
     "stablecoins": "Stablecoins",
+    "deduction": "Bedöm situation",
     "events": "Tekniska evenemang",
     "techHubs": "Teknikhubbar",
     "techReadiness": "Teknikberedskapsindex",
@@ -72,6 +73,31 @@
     "gulfIndices": "Gulfindex",
     "gulfCurrencies": "Gulfvalutor",
     "gulfOil": "Gulfolja"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Karta",
+      "panel": "Panel",
+      "brief": "Sammanfattning"
+    },
+    "categories": {
+      "navigate": "Navigera",
+      "layers": "Lager",
+      "panels": "Paneler",
+      "view": "Vy",
+      "actions": "Åtgärder",
+      "country": "Land"
+    },
+    "regions": {
+      "global": "Global vy",
+      "mena": "Mellanöstern & Nordafrika",
+      "eu": "Europa",
+      "asia": "Asien-Stillahavsområdet",
+      "america": "Amerika",
+      "africa": "Afrika",
+      "latam": "Latinamerika",
+      "oceania": "Oceanien"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -183,6 +183,7 @@
     "macroSignals": "เรดาร์ตลาด",
     "etfFlows": "ตัวติดตาม BTC ETF",
     "stablecoins": "เหรียญ Stablecoin",
+    "deduction": "วิเคราะห์สถานการณ์",
     "ucdpEvents": "เหตุการณ์ความขัดแย้ง UCDP",
     "displacement": "การพลัดถิ่น UNHCR",
     "climate": "ความผิดปกติของสภาพภูมิอากาศ",
@@ -217,6 +218,31 @@
     "gulfIndices": "ดัชนีอ่าว",
     "gulfCurrencies": "สกุลเงินอ่าว",
     "gulfOil": "น้ำมันอ่าว"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "แผนที่",
+      "panel": "แผง",
+      "brief": "สรุป"
+    },
+    "categories": {
+      "navigate": "นำทาง",
+      "layers": "เลเยอร์",
+      "panels": "แผง",
+      "view": "มุมมอง",
+      "actions": "การดำเนินการ",
+      "country": "ประเทศ"
+    },
+    "regions": {
+      "global": "มุมมองทั่วโลก",
+      "mena": "ตะวันออกกลางและแอฟริกาเหนือ",
+      "eu": "ยุโรป",
+      "asia": "เอเชียแปซิฟิก",
+      "america": "อเมริกา",
+      "africa": "แอฟริกา",
+      "latam": "ละตินอเมริกา",
+      "oceania": "โอเชียเนีย"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -183,6 +183,7 @@
     "macroSignals": "Piyasa Radari",
     "etfFlows": "BTC ETF Takibi",
     "stablecoins": "Stablecoin'ler",
+    "deduction": "Durum çıkarımı",
     "ucdpEvents": "UCDP Catisma Olaylari",
     "displacement": "UNHCR Yerinden Edilme",
     "climate": "Iklim Anomalileri",
@@ -217,6 +218,31 @@
     "gulfIndices": "Körfez Endeksleri",
     "gulfCurrencies": "Körfez Para Birimleri",
     "gulfOil": "Körfez Petrolü"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Harita",
+      "panel": "Panel",
+      "brief": "Özet"
+    },
+    "categories": {
+      "navigate": "Gezinme",
+      "layers": "Katmanlar",
+      "panels": "Paneller",
+      "view": "Görünüm",
+      "actions": "Eylemler",
+      "country": "Ülke"
+    },
+    "regions": {
+      "global": "Küresel görünüm",
+      "mena": "Orta Doğu ve Kuzey Afrika",
+      "eu": "Avrupa",
+      "asia": "Asya-Pasifik",
+      "america": "Amerika",
+      "africa": "Afrika",
+      "latam": "Latin Amerika",
+      "oceania": "Okyanusya"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -183,6 +183,7 @@
     "macroSignals": "Radar Thị trường",
     "etfFlows": "Theo dõi BTC ETF",
     "stablecoins": "Stablecoin",
+    "deduction": "Suy luận tình huống",
     "ucdpEvents": "Sự kiện Xung đột UCDP",
     "displacement": "Di dời UNHCR",
     "climate": "Bất thường Khí hậu",
@@ -217,6 +218,31 @@
     "gulfIndices": "Chỉ số vùng Vịnh",
     "gulfCurrencies": "Tiền tệ vùng Vịnh",
     "gulfOil": "Dầu vùng Vịnh"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "Bản đồ",
+      "panel": "Bảng",
+      "brief": "Tóm tắt"
+    },
+    "categories": {
+      "navigate": "Điều hướng",
+      "layers": "Lớp",
+      "panels": "Bảng",
+      "view": "Xem",
+      "actions": "Hành động",
+      "country": "Quốc gia"
+    },
+    "regions": {
+      "global": "Toàn cầu",
+      "mena": "Trung Đông & Bắc Phi",
+      "eu": "Châu Âu",
+      "asia": "Châu Á - Thái Bình Dương",
+      "america": "Châu Mỹ",
+      "africa": "Châu Phi",
+      "latam": "Mỹ Latinh",
+      "oceania": "Châu Đại Dương"
+    }
   },
   "modals": {
     "search": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -183,6 +183,7 @@
     "macroSignals": "市场雷达",
     "etfFlows": "BTC ETF追踪",
     "stablecoins": "稳定币",
+    "deduction": "推断局势",
     "ucdpEvents": "UCDP冲突事件",
     "displacement": "UNHCR流离失所",
     "climate": "气候异常",
@@ -217,6 +218,31 @@
     "gulfIndices": "海湾指数",
     "gulfCurrencies": "海湾货币",
     "gulfOil": "海湾石油"
+  },
+  "commands": {
+    "prefixes": {
+      "map": "地图",
+      "panel": "面板",
+      "brief": "简报"
+    },
+    "categories": {
+      "navigate": "导航",
+      "layers": "图层",
+      "panels": "面板",
+      "view": "视图",
+      "actions": "操作",
+      "country": "国家"
+    },
+    "regions": {
+      "global": "全球视图",
+      "mena": "中东和北非",
+      "eu": "欧洲",
+      "asia": "亚太地区",
+      "america": "美洲",
+      "africa": "非洲",
+      "latam": "拉丁美洲",
+      "oceania": "大洋洲"
+    }
   },
   "modals": {
     "search": {


### PR DESCRIPTION
## Summary
- **Map vs Panel clarity**: "Go to Europe" → `Map: Europe`, "Jump to Europe" → `Panel: Europe` — now immediately clear which one navigates the map vs scrolls to a news panel
- **Country commands split**: Each country now has TWO commands:
  - `Map: France` — flies the map to the country (uses bbox center + zoom)
  - `Brief: France` — opens the country intelligence brief
- **Full i18n**: Labels composed at render time via `t()`, reusing existing `panels.*` keys. New `commands.prefixes`, `commands.categories`, `commands.regions` keys added to all 19 locale files
- **Category badges localized**: "NAVIGATE", "PANELS", etc. now translated

## Test plan
- [ ] Open CMD+K, type "europe" — should see "Map: Europe" (NAVIGATE) and "Panel: Europe" (PANELS) as distinct commands
- [ ] Type a country name (e.g., "france") — should see both "Map: France" and "Brief: France"
- [ ] Select "Map: France" → map flies to France
- [ ] Select "Brief: France" → country brief page opens
- [ ] Switch language in settings → prefixes (Map/Panel/Brief) and categories should be translated
- [ ] Layer commands still work (unchanged labels)
- [ ] View/time commands still work