### PR TITLE
fix: harden Windows installer update path and map resize behavior

### DIFF
--- a/src-tauri/nsis/installer-hooks.nsh
+++ b/src-tauri/nsis/installer-hooks.nsh
@@ -1,0 +1,16 @@
+; Stop bundled sidecar runtimes before NSIS copies/deletes files.
+; This avoids "Error opening file for writing ... sidecar ... node ... .exe"
+; when an orphaned local API process keeps the runtime locked.
+!macro WM_KILL_BUNDLED_SIDECAR_NODE
+  System::Call 'kernel32::SetEnvironmentVariable(t, t)i("WM_INSTDIR", "$INSTDIR").r0'
+  nsExec::ExecToLog "$SYSDIR\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -Command $\"$$ErrorActionPreference='SilentlyContinue'; $$inst=$$env:WM_INSTDIR; if ($$inst) { $$targets=@((Join-Path $$inst 'resources\sidecar\node\node.exe'),(Join-Path $$inst 'resources\sidecar\node.node.exe'),(Join-Path $$inst 'resources\sidecar\node.exe')); Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -and ($$targets -contains $$_.ExecutablePath) } | ForEach-Object { Stop-Process -Id $$_.ProcessId -Force } }$\""
+  Pop $R0
+!macroend
+
+!macro NSIS_HOOK_PREINSTALL
+  !insertmacro WM_KILL_BUNDLED_SIDECAR_NODE
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  !insertmacro WM_KILL_BUNDLED_SIDECAR_NODE
+!macroend

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -849,9 +849,17 @@ fn resolve_node_binary(app: &AppHandle) -> Option<PathBuf> {
     if !cfg!(debug_assertions) {
         let node_name = if cfg!(windows) { "node.exe" } else { "node" };
         if let Ok(resource_dir) = app.path().resource_dir() {
-            let bundled = resource_dir.join("sidecar").join("node").join(node_name);
-            if bundled.is_file() {
-                return Some(bundled);
+            let mut candidates = vec![resource_dir.join("sidecar").join("node").join(node_name)];
+            if cfg!(windows) {
+                // NSIS resource paths can flatten nested names in some upgrade scenarios.
+                // Keep this fallback so sidecar startup still succeeds if the runtime is
+                // materialized as sidecar\node.node.exe instead of sidecar\node\node.exe.
+                candidates.push(resource_dir.join("sidecar").join("node.node.exe"));
+            }
+            for bundled in candidates {
+                if bundled.is_file() {
+                    return Some(bundled);
+                }
             }
         }
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -61,7 +61,10 @@
     ],
     "windows": {
       "digestAlgorithm": "sha256",
-      "timestampUrl": "https://timestamp.digicert.com"
+      "timestampUrl": "https://timestamp.digicert.com",
+      "nsis": {
+        "installerHooks": "nsis/installer-hooks.nsh"
+      }
     },
     "macOS": {
       "hardenedRuntime": true

--- a/src-tauri/tauri.finance.conf.json
+++ b/src-tauri/tauri.finance.conf.json
@@ -30,7 +30,10 @@
     },
     "windows": {
       "digestAlgorithm": "sha256",
-      "timestampUrl": "https://timestamp.digicert.com"
+      "timestampUrl": "https://timestamp.digicert.com",
+      "nsis": {
+        "installerHooks": "nsis/installer-hooks.nsh"
+      }
     }
   }
 }

--- a/src-tauri/tauri.tech.conf.json
+++ b/src-tauri/tauri.tech.conf.json
@@ -30,7 +30,10 @@
     },
     "windows": {
       "digestAlgorithm": "sha256",
-      "timestampUrl": "https://timestamp.digicert.com"
+      "timestampUrl": "https://timestamp.digicert.com",
+      "nsis": {
+        "installerHooks": "nsis/installer-hooks.nsh"
+      }
     }
   }
 }

--- a/src/app/desktop-updater.ts
+++ b/src/app/desktop-updater.ts
@@ -124,7 +124,7 @@ export class DesktopUpdater implements AppModule {
       .replace('arm64', 'aarch64');
 
     if (normalizedOs === 'windows') {
-      return normalizedArch === 'x86_64' ? 'windows-exe' : null;
+      return normalizedArch === 'x86_64' ? 'windows-msi' : null;
     }
 
     if (normalizedOs === 'macos' || normalizedOs === 'darwin') {

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -471,7 +471,6 @@ export class DeckGLMap {
       renderWorldCopies: false,
       attributionControl: false,
       interactive: true,
-      trackResize: false,
       ...(MAP_INTERACTION_MODE === 'flat'
         ? {
           maxPitch: 0,

--- a/src/components/DownloadBanner.ts
+++ b/src/components/DownloadBanner.ts
@@ -63,7 +63,7 @@ export function allButtons(): DlButton[] {
   return [
     { cls: 'mac', href: '/api/download?platform=macos-arm64', label: `\uF8FF ${t('modals.downloadBanner.macSilicon')}` },
     { cls: 'mac', href: '/api/download?platform=macos-x64', label: `\uF8FF ${t('modals.downloadBanner.macIntel')}` },
-    { cls: 'win', href: '/api/download?platform=windows-exe', label: `\u229E ${t('modals.downloadBanner.windows')}` },
+    { cls: 'win', href: '/api/download?platform=windows-msi', label: `\u229E ${t('modals.downloadBanner.windows')}` },
     { cls: 'linux', href: '/api/download?platform=linux-appimage', label: `\u{1F427} ${t('modals.downloadBanner.linux')} (x64)` },
     { cls: 'linux', href: '/api/download?platform=linux-appimage-arm64', label: `\u{1F427} ${t('modals.downloadBanner.linux')} (ARM64)` },
   ];

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -868,7 +868,6 @@ canvas,
   flex-direction: column;
   flex-shrink: 0;
   position: relative;
-  overflow: hidden;
 }
 
 .map-section.hidden {
@@ -915,6 +914,7 @@ canvas,
 
 .map-section.resizing {
   user-select: none;
+  overflow: hidden;
 }
 
 .map-section.resizing .map-resize-handle::after {
@@ -16005,7 +16005,6 @@ body.has-breaking-alert .panels-grid {
     height: auto;
     min-height: 0;
     max-height: none;
-    overflow: hidden;
   }
 
   .map-section.pinned {


### PR DESCRIPTION
## Summary
- **NSIS installer hooks**: Kill orphaned sidecar node.exe processes before install/uninstall to prevent "file in use" errors on Windows updates
- **Node binary resolution fallback**: Handle NSIS flattened path (`sidecar\node.node.exe`) when upgrade materializes runtime outside expected nested dir
- **Windows installer format**: Switch from `.exe` to `.msi` for download/update paths
- **Map resize fix**: Move `overflow: hidden` from permanent `.map-section` to `.map-section.resizing` only, and re-enable `trackResize` on maplibre for proper resize handling

## Test plan
- [ ] Windows: verify NSIS installer kills sidecar before update, no "file in use" errors
- [ ] Windows: confirm sidecar starts with either `node\node.exe` or `node.node.exe` path
- [ ] Download banner shows `.msi` link for Windows
- [ ] Map resizes correctly when dragging the resize handle
- [ ] Map content not clipped when not actively resizing