### PR TITLE
fix: detect Linux Node runtime target from host arch in desktop packaging

### DIFF
--- a/scripts/desktop-package.mjs
+++ b/scripts/desktop-package.mjs
@@ -71,7 +71,11 @@ if (variant === 'tech') {
 const resolveNodeTarget = () => {
   if (env.NODE_TARGET) return env.NODE_TARGET;
   if (os === 'windows') return 'x86_64-pc-windows-msvc';
-  if (os === 'linux') return 'x86_64-unknown-linux-gnu';
+  if (os === 'linux') {
+    if (process.arch === 'arm64') return 'aarch64-unknown-linux-gnu';
+    if (process.arch === 'x64') return 'x86_64-unknown-linux-gnu';
+    return '';
+  }
   if (os === 'macos') {
     if (process.arch === 'arm64') return 'aarch64-apple-darwin';
     if (process.arch === 'x64') return 'x86_64-apple-darwin';


### PR DESCRIPTION
## Summary
- fix Linux desktop-package Node target inference to use host architecture
- select aarch64-unknown-linux-gnu on ARM64 hosts and x86_64-unknown-linux-gnu on x64 hosts
- keep explicit NODE_TARGET override behavior unchanged

## Why
Packaging on ARM Linux previously defaulted to x64 Node sidecar, which can break sidecar startup at runtime.

## Validation
- node --check scripts/desktop-package.mjs
- pre-push checks passed:
  - npm run typecheck
  - npm run typecheck:api
  - npm run version:check
