### PR TITLE
feat(live-news): improve Manage Channels UX

### DIFF
--- a/src/components/IntelligenceGapBadge.ts
+++ b/src/components/IntelligenceGapBadge.ts
@@ -507,13 +507,20 @@ export class IntelligenceFindingsBadge {
       </div>
     `;
 
-    // Add click handlers
-    overlay.querySelector('.findings-modal-close')?.addEventListener('click', () => overlay.remove());
+    const closeOverlay = () => {
+      overlay.remove();
+      document.removeEventListener('keydown', onEsc);
+    };
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeOverlay();
+    };
+    overlay.querySelector('.findings-modal-close')?.addEventListener('click', closeOverlay);
     overlay.addEventListener('click', (e) => {
       if ((e.target as HTMLElement).classList.contains('findings-modal-overlay')) {
-        overlay.remove();
+        closeOverlay();
       }
     });
+    document.addEventListener('keydown', onEsc);
 
     // Handle clicking individual items
     overlay.querySelectorAll('.findings-modal-item').forEach(item => {
@@ -525,10 +532,10 @@ export class IntelligenceFindingsBadge {
         trackFindingClicked(finding.id, finding.source, finding.type, finding.priority);
         if (finding.source === 'signal' && this.onSignalClick) {
           this.onSignalClick(finding.original as CorrelationSignal);
-          overlay.remove();
+          closeOverlay();
         } else if (finding.source === 'alert' && this.onAlertClick) {
           this.onAlertClick(finding.original as UnifiedAlert);
-          overlay.remove();
+          closeOverlay();
         }
       });
     });

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -64,7 +64,7 @@ const FULL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'dw', name: 'DW', handle: '@DWNews', fallbackVideoId: 'LuKwFajn37U' },
   { id: 'cnbc', name: 'CNBC', handle: '@CNBC', fallbackVideoId: '9NyxcX3rhQs' },
   { id: 'cnn', name: 'CNN', handle: '@CNN', fallbackVideoId: 'w_Ma8oQLmSM' },
-  { id: 'france24', name: 'France24', handle: '@France24_en', fallbackVideoId: 'Ap-UM1O9RBU' },
+  { id: 'france24', name: 'France 24', handle: '@FRANCE24', fallbackVideoId: 'u9foWyMSETk' },
   { id: 'alarabiya', name: 'AlArabiya', handle: '@AlArabiya', fallbackVideoId: 'n7eQejkXbnM', useFallbackOnly: true },
   { id: 'aljazeera', name: 'AlJazeera', handle: '@AlJazeeraEnglish', fallbackVideoId: 'gCNeDWCI0vo', useFallbackOnly: true },
 ];
@@ -78,8 +78,12 @@ const TECH_LIVE_CHANNELS: LiveChannel[] = [
 ];
 
 // Optional channels users can add from the "Available Channels" tab UI
+// Includes default channels so they appear in the grid for toggle on/off
 export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
-  // North America
+  // North America (defaults first)
+  { id: 'bloomberg', name: 'Bloomberg', handle: '@markets', fallbackVideoId: 'iEpJwprxDdk' },
+  { id: 'cnbc', name: 'CNBC', handle: '@CNBC', fallbackVideoId: '9NyxcX3rhQs' },
+  { id: 'yahoo', name: 'Yahoo Finance', handle: '@YahooFinance', fallbackVideoId: 'KQp-e_XQnDE' },
   { id: 'cnn', name: 'CNN', handle: '@CNN', fallbackVideoId: 'w_Ma8oQLmSM' },
   { id: 'fox-news', name: 'Fox News', handle: '@FoxNews', fallbackVideoId: 'QaftgYkG-ek' },
   { id: 'newsmax', name: 'Newsmax', handle: '@NEWSMAX', fallbackVideoId: 'S-lFBzloL2Y', useFallbackOnly: true },
@@ -87,7 +91,12 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'cbs-news', name: 'CBS News', handle: '@CBSNews', fallbackVideoId: 'R9L8sDK8iEc' },
   { id: 'nbc-news', name: 'NBC News', handle: '@NBCNews', fallbackVideoId: 'yMr0neQhu6c' },
   { id: 'cbc-news', name: 'CBC News', handle: '@CBCNews', fallbackVideoId: 'jxP_h3V-Dv8' },
-  // Europe
+  { id: 'nasa', name: 'Sen Space Live', handle: '@NASA', fallbackVideoId: 'aB1yRz0HhdY', useFallbackOnly: true },
+  // Europe (defaults first)
+  { id: 'sky', name: 'SkyNews', handle: '@SkyNews', fallbackVideoId: 'uvviIF4725I' },
+  { id: 'euronews', name: 'Euronews', handle: '@euronews', fallbackVideoId: 'pykpO5kQJ98' },
+  { id: 'dw', name: 'DW', handle: '@DWNews', fallbackVideoId: 'LuKwFajn37U' },
+  { id: 'france24', name: 'France 24', handle: '@FRANCE24', fallbackVideoId: 'u9foWyMSETk' },
   { id: 'bbc-news', name: 'BBC News', handle: '@BBCNews', fallbackVideoId: 'bjgQzJzCZKs' },
   { id: 'france24-en', name: 'France 24 English', handle: '@France24_en', fallbackVideoId: 'Ap-UM1O9RBU' },
   { id: 'welt', name: 'WELT', handle: '@WELTVideoTV', fallbackVideoId: 'L-TNmYmaAKQ' },
@@ -122,7 +131,9 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'arirang-news', name: 'Arirang News', handle: '@ArirangCoKrArirangNEWS' },
   { id: 'india-today', name: 'India Today', handle: '@indiatoday', fallbackVideoId: 'sYZtOFzM78M' },
   { id: 'abp-news', name: 'ABP News', handle: '@ABPNews' },
-  // Middle East
+  // Middle East (defaults first)
+  { id: 'alarabiya', name: 'AlArabiya', handle: '@AlArabiya', fallbackVideoId: 'n7eQejkXbnM', useFallbackOnly: true },
+  { id: 'aljazeera', name: 'AlJazeera', handle: '@AlJazeeraEnglish', fallbackVideoId: 'gCNeDWCI0vo', useFallbackOnly: true },
   { id: 'al-hadath', name: 'Al Hadath', handle: '@AlHadath', fallbackVideoId: 'xWXpl7azI8k', useFallbackOnly: true },
   { id: 'sky-news-arabia', name: 'Sky News Arabia', handle: '@skynewsarabia', fallbackVideoId: 'U--OjmpjF5o' },
   { id: 'trt-world', name: 'TRT World', handle: '@TRTWorld', fallbackVideoId: 'ABfFhWzWs0s' },
@@ -146,14 +157,18 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'abc-news-au', name: 'ABC News Australia', handle: '@abcnewsaustralia', fallbackVideoId: 'vOTiJkg1voo' },
 ];
 
-export const OPTIONAL_CHANNEL_REGIONS: { key: string; labelKey: string; channelIds: string[] }[] = [
-  { key: 'na', labelKey: 'components.liveNews.regionNorthAmerica', channelIds: ['cnn', 'fox-news', 'newsmax', 'abc-news', 'cbs-news', 'nbc-news', 'cbc-news'] },
-  { key: 'eu', labelKey: 'components.liveNews.regionEurope', channelIds: ['bbc-news', 'france24-en', 'welt', 'rtve', 'trt-haber', 'ntv-turkey', 'cnn-turk', 'tv-rain', 'rt', 'tvp-info', 'telewizja-republika', 'tagesschau24', 'tv5monde-info', 'nrk1', 'aljazeera-balkans'] },
+const _REGION_ENTRIES: { key: string; labelKey: string; channelIds: string[] }[] = [
+  { key: 'na', labelKey: 'components.liveNews.regionNorthAmerica', channelIds: ['bloomberg', 'cnbc', 'yahoo', 'cnn', 'fox-news', 'newsmax', 'abc-news', 'cbs-news', 'nbc-news', 'cbc-news', 'nasa'] },
+  { key: 'eu', labelKey: 'components.liveNews.regionEurope', channelIds: ['sky', 'euronews', 'dw', 'france24', 'bbc-news', 'france24-en', 'welt', 'rtve', 'trt-haber', 'ntv-turkey', 'cnn-turk', 'tv-rain', 'rt', 'tvp-info', 'telewizja-republika', 'tagesschau24', 'tv5monde-info', 'nrk1', 'aljazeera-balkans'] },
   { key: 'latam', labelKey: 'components.liveNews.regionLatinAmerica', channelIds: ['cnn-brasil', 'jovem-pan', 'record-news', 'band-jornalismo', 'tn-argentina', 'c5n', 'milenio', 'noticias-caracol', 'ntn24', 't13'] },
   { key: 'asia', labelKey: 'components.liveNews.regionAsia', channelIds: ['tbs-news', 'ann-news', 'ntv-news', 'cti-news', 'wion', 'ndtv', 'cna-asia', 'nhk-world', 'arirang-news', 'india-today', 'abp-news'] },
-  { key: 'me', labelKey: 'components.liveNews.regionMiddleEast', channelIds: ['al-hadath', 'sky-news-arabia', 'trt-world', 'iran-intl', 'cgtn-arabic', 'kan-11', 'asharq-news'] },
+  { key: 'me', labelKey: 'components.liveNews.regionMiddleEast', channelIds: ['alarabiya', 'aljazeera', 'al-hadath', 'sky-news-arabia', 'trt-world', 'iran-intl', 'cgtn-arabic', 'kan-11', 'asharq-news'] },
   { key: 'africa', labelKey: 'components.liveNews.regionAfrica', channelIds: ['africanews', 'channels-tv', 'ktn-news', 'enca', 'sabc-news', 'arise-news'] },
   { key: 'oc', labelKey: 'components.liveNews.regionOceania', channelIds: ['abc-news-au'] },
+];
+export const OPTIONAL_CHANNEL_REGIONS: { key: string; labelKey: string; channelIds: string[] }[] = [
+  { key: 'all', labelKey: 'components.liveNews.regionAll', channelIds: _REGION_ENTRIES.flatMap((r) => r.channelIds) },
+  ..._REGION_ENTRIES,
 ];
 
 const DEFAULT_LIVE_CHANNELS = SITE_VARIANT === 'tech' ? TECH_LIVE_CHANNELS : SITE_VARIANT === 'happy' ? [] : FULL_LIVE_CHANNELS;
@@ -810,12 +825,17 @@ export class LiveNewsPanel extends Panel {
 
     const close = () => {
       overlay.remove();
+      document.removeEventListener('keydown', onKey);
       this.refreshChannelsFromStorage();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
     };
     closeBtn.addEventListener('click', close);
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) close();
     });
+    document.addEventListener('keydown', onKey);
   }
 
   private refreshChannelSwitcher(): void {

--- a/src/components/SignalModal.ts
+++ b/src/components/SignalModal.ts
@@ -12,6 +12,7 @@ export class SignalModal {
   private audioEnabled = true;
   private audio: HTMLAudioElement | null = null;
   private onLocationClick?: (lat: number, lon: number) => void;
+  private escHandler = (e: KeyboardEvent) => { if (e.key === 'Escape') this.hide(); };
 
   constructor() {
     this.element = document.createElement('div');
@@ -99,6 +100,10 @@ export class SignalModal {
     this.onLocationClick = handler;
   }
 
+  private activateEsc(): void {
+    document.addEventListener('keydown', this.escHandler);
+  }
+
   public show(signals: CorrelationSignal[]): void {
     if (signals.length === 0) return;
     if (document.fullscreenElement) return;
@@ -106,6 +111,7 @@ export class SignalModal {
     this.currentSignals = [...signals, ...this.currentSignals].slice(0, 50);
     this.renderSignals();
     this.element.classList.add('active');
+    this.activateEsc();
     this.playSound();
   }
 
@@ -113,6 +119,7 @@ export class SignalModal {
     this.currentSignals = [signal];
     this.renderSignals();
     this.element.classList.add('active');
+    this.activateEsc();
   }
 
   public showAlert(alert: UnifiedAlert): void {
@@ -219,6 +226,7 @@ export class SignalModal {
     `;
 
     this.element.classList.add('active');
+    this.activateEsc();
   }
 
   public playSound(): void {
@@ -230,6 +238,7 @@ export class SignalModal {
 
   public hide(): void {
     this.element.classList.remove('active');
+    document.removeEventListener('keydown', this.escHandler);
   }
 
   private renderSignals(): void {

--- a/src/components/StoryModal.ts
+++ b/src/components/StoryModal.ts
@@ -8,6 +8,10 @@ let currentDataUrl: string | null = null;
 let currentBlob: Blob | null = null;
 let currentData: StoryData | null = null;
 
+function storyEscHandler(e: KeyboardEvent): void {
+  if (e.key === 'Escape') closeStoryModal();
+}
+
 export function openStoryModal(data: StoryData): void {
   closeStoryModal();
   currentData = data;
@@ -53,6 +57,7 @@ export function openStoryModal(data: StoryData): void {
   modalEl.addEventListener('click', (e) => {
     if (e.target === modalEl) closeStoryModal();
   });
+  document.addEventListener('keydown', storyEscHandler);
   modalEl.querySelector('.story-close-x')?.addEventListener('click', closeStoryModal);
   modalEl.querySelector('.story-save')?.addEventListener('click', downloadStory);
   modalEl.querySelector('.story-whatsapp')?.addEventListener('click', () => currentData && shareWhatsApp(currentData));
@@ -104,6 +109,7 @@ export function closeStoryModal(): void {
     currentDataUrl = null;
     currentBlob = null;
     currentData = null;
+    document.removeEventListener('keydown', storyEscHandler);
   }
 }
 

--- a/src/live-channels-window.ts
+++ b/src/live-channels-window.ts
@@ -142,6 +142,7 @@ export function initLiveChannelsWindow(containerEl?: HTMLElement): void {
   function renderList(listEl: HTMLElement): void {
     listEl.innerHTML = '';
     for (const ch of channels) {
+      const isCustom = !BUILTIN_IDS.has(ch.id);
       const row = document.createElement('div');
       row.className = 'live-news-manage-row';
       row.dataset.channelId = ch.id;
@@ -151,13 +152,25 @@ export function initLiveChannelsWindow(containerEl?: HTMLElement): void {
       nameSpan.textContent = ch.name ?? '';
       row.appendChild(nameSpan);
 
-      row.addEventListener('click', (e) => {
-        // Suppress click immediately after drag-drop to avoid accidental edit open.
-        if (suppressRowClick || row.classList.contains('live-news-manage-row-dragging')) return;
-        if ((e.target as HTMLElement).closest('input, button, textarea, select')) return;
-        e.preventDefault();
-        showEditForm(row, ch, listEl);
+      const removeX = document.createElement('span');
+      removeX.className = 'live-news-manage-row-remove-x';
+      removeX.textContent = '✕';
+      removeX.addEventListener('click', (e) => {
+        e.stopPropagation();
+        channels = channels.filter((c) => c.id !== ch.id);
+        saveChannelsToStorage(channels);
+        renderList(listEl);
       });
+      row.appendChild(removeX);
+
+      if (isCustom) {
+        row.addEventListener('click', (e) => {
+          if (suppressRowClick || row.classList.contains('live-news-manage-row-dragging')) return;
+          if ((e.target as HTMLElement).closest('input, button, textarea, select, .live-news-manage-row-remove-x')) return;
+          e.preventDefault();
+          showEditForm(row, ch, listEl);
+        });
+      }
 
       listEl.appendChild(row);
     }
@@ -338,14 +351,23 @@ export function initLiveChannelsWindow(containerEl?: HTMLElement): void {
     card.appendChild(info);
     card.appendChild(action);
 
-    if (!isAdded) {
-      card.addEventListener('click', () => {
+    card.addEventListener('mouseenter', () => {
+      if (card.classList.contains('added')) action.textContent = '✕';
+    });
+    card.addEventListener('mouseleave', () => {
+      if (card.classList.contains('added')) action.textContent = '✓';
+    });
+
+    card.addEventListener('click', () => {
+      if (isAdded) {
+        channels = channels.filter((c) => c.id !== ch.id);
+      } else {
         if (channels.some((c) => c.id === ch.id)) return;
         channels.push({ ...ch });
-        saveChannelsToStorage(channels);
-        renderList(listEl);
-      });
-    }
+      }
+      saveChannelsToStorage(channels);
+      renderList(listEl);
+    });
     return card;
   }
 

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1403,6 +1403,7 @@
       "restoreDefaults": "استعادة القنوات الافتراضية",
       "availableChannels": "القنوات المتاحة",
       "customChannel": "قناة مخصصة",
+      "regionAll": "الكل",
       "regionNorthAmerica": "أمريكا الشمالية",
       "regionEurope": "أوروبا",
       "regionLatinAmerica": "أمريكا اللاتينية",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -1490,6 +1490,7 @@
       "restoreDefaults": "Obnovit výchozí kanály",
       "availableChannels": "Dostupné kanály",
       "customChannel": "Vlastní kanál",
+      "regionAll": "Vše",
       "regionNorthAmerica": "Severní Amerika",
       "regionEurope": "Evropa",
       "regionLatinAmerica": "Latinská Amerika",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1455,6 +1455,7 @@
       "restoreDefaults": "Standardkanäle wiederherstellen",
       "availableChannels": "Verfügbare Kanäle",
       "customChannel": "Benutzerdefinierter Kanal",
+      "regionAll": "Alle",
       "regionNorthAmerica": "Nordamerika",
       "regionEurope": "Europa",
       "regionLatinAmerica": "Lateinamerika",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -1390,6 +1390,7 @@
       "openOnYouTube": "Άνοιγμα στο YouTube",
       "availableChannels": "Διαθέσιμα κανάλια",
       "customChannel": "Προσαρμοσμένο κανάλι",
+      "regionAll": "Όλα",
       "regionNorthAmerica": "Βόρεια Αμερική",
       "regionEurope": "Ευρώπη",
       "regionLatinAmerica": "Λατινική Αμερική",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1491,6 +1491,7 @@
       "restoreDefaults": "Restore default channels",
       "availableChannels": "Available channels",
       "customChannel": "Custom channel",
+      "regionAll": "All",
       "regionNorthAmerica": "North America",
       "regionEurope": "Europe",
       "regionLatinAmerica": "Latin America",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1455,6 +1455,7 @@
       "restoreDefaults": "Restaurar canales predeterminados",
       "availableChannels": "Canales disponibles",
       "customChannel": "Canal personalizado",
+      "regionAll": "Todos",
       "regionNorthAmerica": "Norteamérica",
       "regionEurope": "Europa",
       "regionLatinAmerica": "Latinoamérica",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1403,6 +1403,7 @@
       "restoreDefaults": "Restaurer les chaînes par défaut",
       "availableChannels": "Chaînes disponibles",
       "customChannel": "Chaîne personnalisée",
+      "regionAll": "Tous",
       "regionNorthAmerica": "Amérique du Nord",
       "regionEurope": "Europe",
       "regionLatinAmerica": "Amérique latine",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -1455,6 +1455,7 @@
       "restoreDefaults": "Ripristina canali predefiniti",
       "availableChannels": "Canali disponibili",
       "customChannel": "Canale personalizzato",
+      "regionAll": "Tutti",
       "regionNorthAmerica": "Nord America",
       "regionEurope": "Europa",
       "regionLatinAmerica": "America Latina",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1403,6 +1403,7 @@
       "restoreDefaults": "デフォルトのチャンネルを復元",
       "availableChannels": "利用可能なチャンネル",
       "customChannel": "カスタムチャンネル",
+      "regionAll": "すべて",
       "regionNorthAmerica": "北米",
       "regionEurope": "ヨーロッパ",
       "regionLatinAmerica": "中南米",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1490,6 +1490,7 @@
       "restoreDefaults": "기본 채널 복원",
       "availableChannels": "사용 가능한 채널",
       "customChannel": "사용자 지정 채널",
+      "regionAll": "전체",
       "regionNorthAmerica": "북미",
       "regionEurope": "유럽",
       "regionLatinAmerica": "중남미",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -1258,6 +1258,7 @@
       "restoreDefaults": "Standaardkanalen herstellen",
       "availableChannels": "Beschikbare kanalen",
       "customChannel": "Aangepast kanaal",
+      "regionAll": "Alle",
       "regionNorthAmerica": "Noord-Amerika",
       "regionEurope": "Europa",
       "regionLatinAmerica": "Latijns-Amerika",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1403,6 +1403,7 @@
       "restoreDefaults": "Przywróć domyślne kanały",
       "availableChannels": "Dostępne kanały",
       "customChannel": "Kanał niestandardowy",
+      "regionAll": "Wszystkie",
       "regionNorthAmerica": "Ameryka Północna",
       "regionEurope": "Europa",
       "regionLatinAmerica": "Ameryka Łacińska",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1258,6 +1258,7 @@
       "restoreDefaults": "Restaurar canais padrão",
       "availableChannels": "Canais disponíveis",
       "customChannel": "Canal personalizado",
+      "regionAll": "Todos",
       "regionNorthAmerica": "América do Norte",
       "regionEurope": "Europa",
       "regionLatinAmerica": "América Latina",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1403,6 +1403,7 @@
       "restoreDefaults": "Восстановить каналы по умолчанию",
       "availableChannels": "Доступные каналы",
       "customChannel": "Пользовательский канал",
+      "regionAll": "Все",
       "regionNorthAmerica": "Северная Америка",
       "regionEurope": "Европа",
       "regionLatinAmerica": "Латинская Америка",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -1258,6 +1258,7 @@
       "restoreDefaults": "Återställ standardkanaler",
       "availableChannels": "Tillgängliga kanaler",
       "customChannel": "Anpassad kanal",
+      "regionAll": "Alla",
       "regionNorthAmerica": "Nordamerika",
       "regionEurope": "Europa",
       "regionLatinAmerica": "Latinamerika",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -1403,6 +1403,7 @@
       "restoreDefaults": "คืนค่าช่องเริ่มต้น",
       "availableChannels": "ช่องที่พร้อมใช้งาน",
       "customChannel": "ช่องกำหนดเอง",
+      "regionAll": "ทั้งหมด",
       "regionNorthAmerica": "อเมริกาเหนือ",
       "regionEurope": "ยุโรป",
       "regionLatinAmerica": "ละตินอเมริกา",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1403,6 +1403,7 @@
       "restoreDefaults": "Varsayılan kanalları geri yükle",
       "availableChannels": "Mevcut kanallar",
       "customChannel": "Özel kanal",
+      "regionAll": "Tümü",
       "regionNorthAmerica": "Kuzey Amerika",
       "regionEurope": "Avrupa",
       "regionLatinAmerica": "Latin Amerika",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -1403,6 +1403,7 @@
       "restoreDefaults": "Khôi phục kênh mặc định",
       "availableChannels": "Kênh có sẵn",
       "customChannel": "Kênh tùy chỉnh",
+      "regionAll": "Tất cả",
       "regionNorthAmerica": "Bắc Mỹ",
       "regionEurope": "Châu Âu",
       "regionLatinAmerica": "Mỹ Latinh",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1403,6 +1403,7 @@
       "restoreDefaults": "恢复默认频道",
       "availableChannels": "可用频道",
       "customChannel": "自定义频道",
+      "regionAll": "全部",
       "regionNorthAmerica": "北美",
       "regionEurope": "欧洲",
       "regionLatinAmerica": "拉丁美洲",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1433,7 +1433,7 @@ body.panel-resize-active iframe {
 .live-news-toolbar {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 4px;
   padding: 6px 8px;
   background: var(--darken-heavy);
@@ -1519,6 +1519,7 @@ body.panel-resize-active iframe {
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  align-self: flex-start;
 }
 .live-news-settings-btn:hover {
   border-color: var(--text-dim);
@@ -1589,6 +1590,21 @@ body.panel-resize-active iframe {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.live-news-manage-row-remove-x {
+  display: none;
+  font-size: 10px;
+  color: var(--text-faint);
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  transition: color 0.15s;
+}
+.live-news-manage-row:hover .live-news-manage-row-remove-x {
+  display: inline;
+}
+.live-news-manage-row-remove-x:hover {
+  color: var(--red);
 }
 .live-news-manage-edit {
   padding: 4px 8px;
@@ -1715,7 +1731,7 @@ body.panel-resize-active iframe {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px;
+  padding: 8px 14px;
   border-bottom: 1px solid var(--border);
   background: var(--darken-heavy);
   flex-shrink: 0;
@@ -1728,10 +1744,10 @@ body.panel-resize-active iframe {
   border-radius: 4px;
 }
 .live-channels-window-toolbar {
-  margin-bottom: 12px;
+  margin-bottom: 4px;
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
 }
 .live-news-manage-restore-defaults {
@@ -1749,18 +1765,18 @@ body.panel-resize-active iframe {
   border-color: var(--text-dim);
 }
 .live-channels-window-title {
-  font-size: 16px;
+  font-size: 14px;
   font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 1px;
 }
 .live-channels-window-content {
-  padding: 16px;
+  padding: 10px 14px;
   flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 8px;
 }
 .live-channels-window-shell .live-news-manage-list {
   min-height: 0;
@@ -1822,8 +1838,8 @@ body.panel-resize-active iframe {
 /* Available channels section */
 .live-news-manage-available-section {
   border-top: 1px solid var(--border);
-  padding-top: 16px;
-  margin-top: 16px;
+  padding-top: 8px;
+  margin-top: 4px;
 }
 
 /* Tab bar */
@@ -1831,7 +1847,7 @@ body.panel-resize-active iframe {
   display: flex;
   gap: 0;
   border-bottom: 1px solid var(--border);
-  margin-bottom: 12px;
+  margin-bottom: 8px;
   overflow-x: auto;
 }
 .live-news-manage-tab-bar::-webkit-scrollbar { display: none; }
@@ -1840,7 +1856,7 @@ body.panel-resize-active iframe {
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.75px;
-  padding: 8px 12px;
+  padding: 6px 10px;
   background: none;
   border: none;
   border-bottom: 2px solid transparent;
@@ -1884,7 +1900,14 @@ body.panel-resize-active iframe {
 .live-news-manage-card.added {
   border-color: rgba(68, 255, 136, 0.3);
   background: rgba(68, 255, 136, 0.05);
-  cursor: default;
+  cursor: pointer;
+}
+.live-news-manage-card.added:hover {
+  border-color: rgba(255, 80, 80, 0.5);
+  background: rgba(255, 80, 80, 0.08);
+}
+.live-news-manage-card:active {
+  transform: scale(0.97);
 }
 
 /* Card icon (initials) */
@@ -1936,6 +1959,7 @@ body.panel-resize-active iframe {
 }
 .live-news-manage-card:hover .live-news-manage-card-action { color: var(--green); }
 .live-news-manage-card.added .live-news-manage-card-action { color: var(--green); }
+.live-news-manage-card.added:hover .live-news-manage-card-action { color: var(--red); }
 
 /* Tab count badge */
 .live-news-manage-tab-count {


### PR DESCRIPTION
## Summary

- Make the Available Channels grid the primary toggle mechanism (add + remove) instead of requiring pill → edit form → REMOVE
- Add all 10 default channels (Bloomberg, SkyNews, DW, CNBC, France24, AlArabiya, AlJazeera, Yahoo, NASA) to the grid so they're visible and toggleable
- Add "All" region tab (default) showing every channel across all regions
- Top pills now have × close button on hover for quick removal; click-to-edit reserved for custom channels only
- Fix France24 default to use French channel (`@FRANCE24`)
- Tighten header/content whitespace, align settings gear to top of pill row
- Add ESC dismiss to all 4 modals (channels, story, signal, findings)
- i18n: `regionAll` key added to all 19 locale files

## Test plan

- [ ] Open Manage Channels → "All" tab is default, shows every channel
- [ ] Default channels (Bloomberg, SkyNews, etc.) appear with ✓ in grid
- [ ] Click ✓ card → removes channel (pill disappears, card shows +)
- [ ] Click + card → adds channel (pill appears, card shows ✓)
- [ ] Hover ✓ card → shows ✕ with red tint
- [ ] Top pills show × on hover → click removes channel
- [ ] Custom channels still open edit form on pill click
- [ ] Drag-to-reorder still works on top pills
- [ ] ESC closes the channel management modal
- [ ] ESC closes story, signal, and findings modals
- [ ] Region tabs show correct counts
- [ ] `npx tsc --noEmit` passes