### PR TITLE
fix(server): add logging for network errors in error mapper

### DIFF
--- a/server/error-mapper.ts
+++ b/server/error-mapper.ts
@@ -59,6 +59,7 @@ export function mapErrorToResponse(error: unknown, _req: Request): Response {
 
   // Network/fetch errors: upstream is unreachable (M-5 fix: runtime-agnostic detection)
   if (isNetworkError(error)) {
+    console.error('[error-mapper] Network error (502):', (error as Error).message);
     return new Response(JSON.stringify({ message: 'Upstream unavailable' }), {
       status: 502,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Add `console.error` logging for 502 network errors in the error mapper
- Previously, upstream unavailability was silently converted to a 502 response with no server-side trace

## Test plan
- [ ] Verify Vercel logs show `[error-mapper] Network error (502):` when upstream is unreachable
- [ ] Confirm 502 response body is unchanged (`{ "message": "Upstream unavailable" }`)

Addresses #197 (L-6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)