### PR TITLE
fix(server): return 405 Method Not Allowed for wrong HTTP method

### DIFF
--- a/api/[domain]/v1/[rpc].ts
+++ b/api/[domain]/v1/[rpc].ts
@@ -221,11 +221,7 @@ export default async function handler(originalRequest: Request): Promise<Respons
     }
   }
   if (!matchedHandler) {
-    const url = new URL(request.url);
-    const pathname = url.pathname.length > 1 && url.pathname.endsWith('/')
-      ? url.pathname.slice(0, -1)
-      : url.pathname;
-    const allowed = router.allowedMethods(pathname);
+    const allowed = router.allowedMethods(new URL(request.url).pathname);
     if (allowed.length > 0) {
       return new Response(JSON.stringify({ error: 'Method not allowed' }), {
         status: 405,

--- a/server/router.ts
+++ b/server/router.ts
@@ -33,7 +33,6 @@ export function createRouter(allRoutes: RouteDescriptor[]): Router {
 
   for (const route of allRoutes) {
     if (route.path.includes('{')) {
-      // Dynamic route — parse segments for pattern matching
       const parts = route.path.split('/').filter(Boolean);
       dynamicRoutes.push({
         method: route.method,
@@ -44,52 +43,55 @@ export function createRouter(allRoutes: RouteDescriptor[]): Router {
     } else {
       const key = `${route.method} ${route.path}`;
       staticTable.set(key, route.handler);
-      const methods = staticPaths.get(route.path) || new Set<string>();
-      methods.add(route.method);
-      staticPaths.set(route.path, methods);
+      if (!staticPaths.has(route.path)) staticPaths.set(route.path, new Set());
+      staticPaths.get(route.path)!.add(route.method);
     }
+  }
+
+  function normalizePath(raw: string): string {
+    return raw.length > 1 && raw.endsWith('/') ? raw.slice(0, -1) : raw;
+  }
+
+  function matchDynamic(parts: string[], method?: string): DynamicRoute | null {
+    for (const route of dynamicRoutes) {
+      if (method && route.method !== method) continue;
+      if (route.segmentCount !== parts.length) continue;
+      let matched = true;
+      for (let i = 0; i < route.segmentCount; i++) {
+        if (route.segments[i] !== null && route.segments[i] !== parts[i]) {
+          matched = false;
+          break;
+        }
+      }
+      if (matched) return route;
+    }
+    return null;
   }
 
   return {
     match(req: Request) {
       const url = new URL(req.url);
-      // Normalize trailing slashes: /api/foo/v1/bar/ -> /api/foo/v1/bar
-      const pathname =
-        url.pathname.length > 1 && url.pathname.endsWith('/')
-          ? url.pathname.slice(0, -1)
-          : url.pathname;
+      const pathname = normalizePath(url.pathname);
 
-      // Fast path: exact match for static routes
       const key = `${req.method} ${pathname}`;
       const staticHandler = staticTable.get(key);
       if (staticHandler) return staticHandler;
 
-      // Slow path: match dynamic routes
       const parts = pathname.split('/').filter(Boolean);
-      for (const route of dynamicRoutes) {
-        if (route.method !== req.method) continue;
-        if (route.segmentCount !== parts.length) continue;
-        let matched = true;
-        for (let i = 0; i < route.segmentCount; i++) {
-          if (route.segments[i] !== null && route.segments[i] !== parts[i]) {
-            matched = false;
-            break;
-          }
-        }
-        if (matched) return route.handler;
-      }
-
-      return null;
+      const route = matchDynamic(parts, req.method);
+      return route ? route.handler : null;
     },
 
     allowedMethods(pathname: string): string[] {
-      const normalized = pathname.length > 1 && pathname.endsWith('/')
-        ? pathname.slice(0, -1)
-        : pathname;
-      const methods = staticPaths.get(normalized);
-      if (methods) return Array.from(methods);
+      const normalized = normalizePath(pathname);
 
-      // Check dynamic routes
+      const methods = staticPaths.get(normalized);
+      if (methods) {
+        const result = Array.from(methods);
+        if (result.includes('GET') && !result.includes('HEAD')) result.push('HEAD');
+        return result;
+      }
+
       const parts = normalized.split('/').filter(Boolean);
       const found = new Set<string>();
       for (const route of dynamicRoutes) {
@@ -103,6 +105,7 @@ export function createRouter(allRoutes: RouteDescriptor[]): Router {
         }
         if (matched) found.add(route.method);
       }
+      if (found.has('GET')) found.add('HEAD');
       return Array.from(found);
     },
   };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -452,12 +452,19 @@ function sebufApiPlugin(): Plugin {
           // Route matching
           const matchedHandler = router.match(webRequest);
           if (!matchedHandler) {
-            res.statusCode = 404;
-            res.setHeader('Content-Type', 'application/json');
+            const allowed = router.allowedMethods(new URL(webRequest.url).pathname);
+            if (allowed.length > 0) {
+              res.statusCode = 405;
+              res.setHeader('Content-Type', 'application/json');
+              res.setHeader('Allow', allowed.join(', '));
+            } else {
+              res.statusCode = 404;
+              res.setHeader('Content-Type', 'application/json');
+            }
             for (const [key, value] of Object.entries(corsHeaders)) {
               res.setHeader(key, value);
             }
-            res.end(JSON.stringify({ error: 'Not found' }));
+            res.end(JSON.stringify({ error: res.statusCode === 405 ? 'Method not allowed' : 'Not found' }));
             return;
           }
 


### PR DESCRIPTION
## Summary
- Add `allowedMethods(pathname)` to the Router interface
- Gateway now returns 405 with `Allow` header when the path exists but the method doesn't match
- Previously, all unmatched requests returned 404 regardless of whether the path was valid

## Changes
- `server/router.ts` — track path→methods mapping, add `allowedMethods()` method
- `api/[domain]/v1/[rpc].ts` — check `allowedMethods()` before returning 404

## Test plan
- [ ] Send GET to a POST-only endpoint → should receive 405 with `Allow: POST`
- [ ] Send POST to a nonexistent path → should still receive 404
- [ ] OPTIONS preflight still returns 204 (handled before routing)

Addresses #197 (L-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)