### PR TITLE
fix(cyber): add pagination cursor to list-cyber-threats response

### DIFF
--- a/server/worldmonitor/cyber/v1/list-cyber-threats.ts
+++ b/server/worldmonitor/cyber/v1/list-cyber-threats.ts
@@ -26,20 +26,41 @@ import {
   toProtoCyberThreat,
 } from './_shared';
 
-const REDIS_CACHE_KEY = 'cyber:threats:v1';
+type CachedThreats = Pick<ListCyberThreatsResponse, 'threats'>;
+
+const REDIS_CACHE_KEY = 'cyber:threats:v2';
 const REDIS_CACHE_TTL = 7200; // 2 hr — IOC feeds update at most daily
+const MAX_CACHED_THREATS = 2000; // cap cached set to avoid oversized Redis values
+
+/** Parse a cursor string into a numeric offset. Invalid/negative values reset to page 1. */
+function parseCursor(cursor: string | undefined): number {
+  if (!cursor) return 0;
+  const n = parseInt(cursor, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    console.warn(`[cyber] invalid cursor "${cursor}", resetting to 0`);
+    return 0;
+  }
+  return n;
+}
 
 export async function listCyberThreats(
   _ctx: ServerContext,
   req: ListCyberThreatsRequest,
 ): Promise<ListCyberThreatsResponse> {
+  const empty: ListCyberThreatsResponse = { threats: [], pagination: { nextCursor: '', totalCount: 0 } };
+
   try {
     const now = Date.now();
 
     const pageSize = clampInt(req.pageSize, DEFAULT_LIMIT, 1, MAX_LIMIT);
-    const cacheKey = `${REDIS_CACHE_KEY}:${pageSize}:${req.start || 0}:${req.type || ''}:${req.source || ''}:${req.minSeverity || ''}`;
+    const offset = parseCursor(req.cursor);
 
-    const result = await cachedFetchJson<ListCyberThreatsResponse>(cacheKey, REDIS_CACHE_TTL, async () => {
+    // Cache key excludes pageSize and cursor — cache holds the full filtered result set.
+    // Changing filter params (start, type, source, minSeverity) between pages resets pagination
+    // because the underlying result set changes. Clients must keep filters stable across pages.
+    const cacheKey = `${REDIS_CACHE_KEY}:${req.start || 0}:${req.type || ''}:${req.source || ''}:${req.minSeverity || ''}`;
+
+    const cached = await cachedFetchJson<CachedThreats>(cacheKey, REDIS_CACHE_TTL, async () => {
       // Derive days from timeRange or use default
       let days = DEFAULT_DAYS;
       if (req.start) {
@@ -50,13 +71,13 @@ export async function listCyberThreats(
       }
       const cutoffMs = now - days * 24 * 60 * 60 * 1000;
 
-      // Fetch all sources in parallel
+      // Fetch all sources in parallel — use MAX_LIMIT so the cache covers all pages.
       const [feodo, urlhaus, c2intel, otx, abuseipdb] = await Promise.all([
-        fetchFeodoSource(pageSize, cutoffMs),
-        fetchUrlhausSource(pageSize, cutoffMs),
-        fetchC2IntelSource(pageSize),
-        fetchOtxSource(pageSize, days),
-        fetchAbuseIpDbSource(pageSize),
+        fetchFeodoSource(MAX_LIMIT, cutoffMs),
+        fetchUrlhausSource(MAX_LIMIT, cutoffMs),
+        fetchC2IntelSource(MAX_LIMIT),
+        fetchOtxSource(MAX_LIMIT, days),
+        fetchAbuseIpDbSource(MAX_LIMIT),
       ]);
 
       const anySucceeded = feodo.ok || urlhaus.ok || c2intel.ok || otx.ok || abuseipdb.ok;
@@ -77,7 +98,7 @@ export async function listCyberThreats(
       let results = hydrated
         .filter((t) => t.lat !== null && t.lon !== null && t.lat >= -90 && t.lat <= 90 && t.lon >= -180 && t.lon <= 180);
 
-      // Apply optional filters BEFORE sorting + slicing (C-2 fix)
+      // Apply optional filters BEFORE sorting (C-2 fix)
       if (req.type && req.type !== 'CYBER_THREAT_TYPE_UNSPECIFIED') {
         const filterType = req.type;
         results = results.filter((t) => THREAT_TYPE_MAP[t.type] === filterType);
@@ -91,22 +112,35 @@ export async function listCyberThreats(
         results = results.filter((t) => (SEVERITY_RANK[SEVERITY_MAP[t.severity] || ''] || 0) >= minRank);
       }
 
-      // Sort by severity then recency, then apply page size limit
-      results = results
-        .sort((a, b) => {
-          const bySeverity = (SEVERITY_RANK[SEVERITY_MAP[b.severity] || ''] || 0)
-            - (SEVERITY_RANK[SEVERITY_MAP[a.severity] || ''] || 0);
-          if (bySeverity !== 0) return bySeverity;
-          return (b.lastSeen || b.firstSeen) - (a.lastSeen || a.firstSeen);
-        })
-        .slice(0, pageSize);
+      // Sort by severity then recency — store the full sorted set (no slice).
+      results.sort((a, b) => {
+        const bySeverity = (SEVERITY_RANK[SEVERITY_MAP[b.severity] || ''] || 0)
+          - (SEVERITY_RANK[SEVERITY_MAP[a.severity] || ''] || 0);
+        if (bySeverity !== 0) return bySeverity;
+        return (b.lastSeen || b.firstSeen) - (a.lastSeen || a.firstSeen);
+      });
 
-      const threats = results.map(toProtoCyberThreat);
-      return threats.length > 0 ? { threats, pagination: undefined } : null;
+      const threats = results.slice(0, MAX_CACHED_THREATS).map(toProtoCyberThreat);
+      return threats.length > 0 ? { threats } : null;
     });
 
-    return result || { threats: [], pagination: undefined };
-  } catch {
-    return { threats: [], pagination: undefined };
+    if (!cached) return empty;
+
+    // Apply cursor-based pagination over the cached full result set.
+    const allThreats = cached.threats;
+    if (offset >= allThreats.length) return empty;
+    const page = allThreats.slice(offset, offset + pageSize);
+    const hasMore = offset + pageSize < allThreats.length;
+
+    return {
+      threats: page,
+      pagination: {
+        totalCount: allThreats.length,
+        nextCursor: hasMore ? String(offset + pageSize) : '',
+      },
+    };
+  } catch (err) {
+    console.error('[cyber] listCyberThreats failed', err);
+    return empty;
   }
 }


### PR DESCRIPTION
## Summary

- **Add cursor-based pagination** to `listCyberThreats` — clients can now fetch subsequent pages using the `nextCursor` from the response
- **Return `PaginationResponse`** with `totalCount` (total matching threats) and `nextCursor` (empty string = last page)
- **Cache the full result set** per filter combination so all pages share one cache entry

### Problem

After filtering and slicing to `pageSize`, the handler returned `pagination: undefined`. Clients had no way to know if more results existed or how to fetch the next page. Combined with server-side filtering, this meant only the first N results were ever accessible.

### Fix

The handler now:
1. Fetches from all 5 sources using `MAX_LIMIT` (1000) instead of `pageSize`
2. Caches the **full** filtered + sorted result set (keyed by filter params only, not pageSize/cursor)
3. Parses `req.cursor` as a numeric offset (empty = page 1)
4. Slices `[offset, offset + pageSize]` from the cached set
5. Returns `{ nextCursor: String(offset + pageSize), totalCount }` — empty `nextCursor` means last page

### Example

```
# Page 1 (no cursor)
GET /api/cyber/v1/list-cyber-threats?pageSize=50
→ { threats: [...50], pagination: { totalCount: 237, nextCursor: "50" } }

# Page 2
GET /api/cyber/v1/list-cyber-threats?pageSize=50&cursor=50
→ { threats: [...50], pagination: { totalCount: 237, nextCursor: "100" } }

# Last page
GET /api/cyber/v1/list-cyber-threats?pageSize=50&cursor=200
→ { threats: [...37], pagination: { totalCount: 237, nextCursor: "" } }
```

## Test plan

- [x] `tsc --noEmit` passes
- [x] `tsc --noEmit -p tsconfig.api.json` passes
- [ ] Test with curl: first page returns `nextCursor`, following it returns next page
- [ ] Verify `totalCount` matches actual filtered count
- [ ] Verify empty `nextCursor` on last page
- [ ] Verify filters still work with pagination (type, source, minSeverity)

Closes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)