### PR TITLE
refactor(server): consolidate declare const process into shared env.d.ts

### DIFF
--- a/server/_shared/acled.ts
+++ b/server/_shared/acled.ts
@@ -5,9 +5,6 @@
  * acled-events) with overlapping queries. This shared layer ensures
  * identical queries hit Redis instead of making redundant upstream calls.
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import { CHROME_UA } from './constants';
 import { cachedFetchJson } from './redis';
 

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -1,8 +1,5 @@
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
-
-declare const process: { env: Record<string, string | undefined> };
-
 let ratelimit: Ratelimit | null = null;
 
 function getRatelimit(): Ratelimit | null {

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 const REDIS_OP_TIMEOUT_MS = 1_500;
 const REDIS_PIPELINE_TIMEOUT_MS = 5_000;

--- a/server/cors.ts
+++ b/server/cors.ts
@@ -4,9 +4,6 @@
  * Identical ALLOWED_ORIGIN_PATTERNS and logic, with methods set
  * to 'GET, POST, OPTIONS' (sebuf routes support GET and POST).
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 const PRODUCTION_PATTERNS: RegExp[] = [
   /^https:\/\/(.*\.)?worldmonitor\.app$/,
   /^https:\/\/worldmonitor-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -1,0 +1,2 @@
+/** Ambient declaration for process.env — shared by all server-side modules. */
+declare const process: { env: Record<string, string | undefined> };

--- a/server/worldmonitor/cyber/v1/_shared.ts
+++ b/server/worldmonitor/cyber/v1/_shared.ts
@@ -13,9 +13,6 @@
  * No caching in handler (client-side polling manages refresh intervals).
  * GeoIP hydration uses in-memory cache for resolved IPs within a process lifetime.
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import type {
   CyberThreat,
   CyberThreatType,
@@ -777,4 +774,3 @@ export function toProtoCyberThreat(raw: RawThreat): CyberThreat {
     lastSeenAt: raw.lastSeen,
   };
 }
-

--- a/server/worldmonitor/cyber/v1/list-cyber-threats.ts
+++ b/server/worldmonitor/cyber/v1/list-cyber-threats.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   ServerContext,

--- a/server/worldmonitor/economic/v1/get-energy-capacity.ts
+++ b/server/worldmonitor/economic/v1/get-energy-capacity.ts
@@ -2,9 +2,6 @@
  * RPC: getEnergyCapacity -- EIA Open Data API v2
  * Installed generation capacity data (solar, wind, coal) aggregated to US national totals.
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import type {
   ServerContext,
   GetEnergyCapacityRequest,

--- a/server/worldmonitor/economic/v1/get-energy-prices.ts
+++ b/server/worldmonitor/economic/v1/get-energy-prices.ts
@@ -2,9 +2,6 @@
  * RPC: getEnergyPrices -- EIA Open Data API v2
  * Energy commodity price data (WTI, Brent, etc.)
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import type {
   ServerContext,
   GetEnergyPricesRequest,

--- a/server/worldmonitor/economic/v1/get-fred-series.ts
+++ b/server/worldmonitor/economic/v1/get-fred-series.ts
@@ -2,9 +2,6 @@
  * RPC: getFredSeries -- Federal Reserve Economic Data (FRED) time series
  * Port from api/fred-data.js
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import type {
   ServerContext,
   GetFredSeriesRequest,

--- a/server/worldmonitor/infrastructure/v1/_shared.ts
+++ b/server/worldmonitor/infrastructure/v1/_shared.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 // ========================================================================
 // Constants

--- a/server/worldmonitor/infrastructure/v1/list-internet-outages.ts
+++ b/server/worldmonitor/infrastructure/v1/list-internet-outages.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   ServerContext,

--- a/server/worldmonitor/intelligence/v1/classify-event.ts
+++ b/server/worldmonitor/intelligence/v1/classify-event.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   ServerContext,

--- a/server/worldmonitor/intelligence/v1/deduct-situation.ts
+++ b/server/worldmonitor/intelligence/v1/deduct-situation.ts
@@ -1,5 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
-
 import type {
     ServerContext,
     DeductSituationRequest,

--- a/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   ServerContext,

--- a/server/worldmonitor/maritime/v1/get-vessel-snapshot.ts
+++ b/server/worldmonitor/maritime/v1/get-vessel-snapshot.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   ServerContext,

--- a/server/worldmonitor/market/v1/_shared.ts
+++ b/server/worldmonitor/market/v1/_shared.ts
@@ -1,9 +1,6 @@
 /**
  * Shared helpers, types, and constants for the market service handler RPCs.
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import { CHROME_UA, yahooGate } from '../../../_shared/constants';
 
 // ========================================================================

--- a/server/worldmonitor/market/v1/get-sector-summary.ts
+++ b/server/worldmonitor/market/v1/get-sector-summary.ts
@@ -2,9 +2,6 @@
  * RPC: GetSectorSummary
  * Fetches sector ETF performance from Finnhub.
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import type {
   ServerContext,
   GetSectorSummaryRequest,

--- a/server/worldmonitor/market/v1/list-market-quotes.ts
+++ b/server/worldmonitor/market/v1/list-market-quotes.ts
@@ -2,9 +2,6 @@
  * RPC: ListMarketQuotes
  * Fetches stock/index quotes from Finnhub (stocks) and Yahoo Finance (indices/futures).
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import type {
   ServerContext,
   ListMarketQuotesRequest,

--- a/server/worldmonitor/military/v1/_shared.ts
+++ b/server/worldmonitor/military/v1/_shared.ts
@@ -1,10 +1,7 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   AircraftDetails,
 } from '../../../../src/generated/server/worldmonitor/military/v1/service_server';
-
-
 
 // ========================================================================
 // Military identification
@@ -147,4 +144,3 @@ export function mapWingbitsDetails(icao24: string, data: Record<string, unknown>
     categoryDescription: String(data.categoryDescription ?? ''),
   };
 }
-

--- a/server/worldmonitor/military/v1/get-aircraft-details-batch.ts
+++ b/server/worldmonitor/military/v1/get-aircraft-details-batch.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   ServerContext,

--- a/server/worldmonitor/military/v1/get-aircraft-details.ts
+++ b/server/worldmonitor/military/v1/get-aircraft-details.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   ServerContext,

--- a/server/worldmonitor/military/v1/get-theater-posture.ts
+++ b/server/worldmonitor/military/v1/get-theater-posture.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   ServerContext,

--- a/server/worldmonitor/military/v1/get-wingbits-status.ts
+++ b/server/worldmonitor/military/v1/get-wingbits-status.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   ServerContext,

--- a/server/worldmonitor/military/v1/list-military-bases.ts
+++ b/server/worldmonitor/military/v1/list-military-bases.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   ServerContext,

--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   ServerContext,

--- a/server/worldmonitor/news/v1/_shared.ts
+++ b/server/worldmonitor/news/v1/_shared.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 // ========================================================================
 // Constants

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -10,9 +10,6 @@ import { cachedFetchJson } from '../../../_shared/redis';
 import { CHROME_UA } from '../../../_shared/constants';
 import { VARIANT_FEEDS, INTEL_SOURCES, type ServerFeed } from './_feeds';
 import { classifyByKeyword, type ThreatLevel } from './_classifier';
-
-declare const process: { env: Record<string, string | undefined> };
-
 const VALID_VARIANTS = new Set(['full', 'tech', 'finance', 'happy']);
 const fallbackDigestCache = new Map<string, { data: ListFeedDigestResponse; ts: number }>();
 const ITEMS_PER_FEED = 5;

--- a/server/worldmonitor/supply-chain/v1/get-shipping-rates.ts
+++ b/server/worldmonitor/supply-chain/v1/get-shipping-rates.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   ServerContext,

--- a/server/worldmonitor/trade/v1/_shared.ts
+++ b/server/worldmonitor/trade/v1/_shared.ts
@@ -2,9 +2,6 @@
  * Shared helpers for the trade domain RPCs.
  * WTO Timeseries API integration.
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import { CHROME_UA } from '../../../_shared/constants';
 
 /** WTO Timeseries API base URL. */

--- a/server/worldmonitor/trade/v1/get-tariff-trends.ts
+++ b/server/worldmonitor/trade/v1/get-tariff-trends.ts
@@ -5,9 +5,6 @@
  * NOTE: Tariff indicators (TP_A_*) do NOT have a partner dimension.
  * The `partnerCountry` request field is accepted but not sent to the API.
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import type {
   ServerContext,
   GetTariffTrendsRequest,

--- a/server/worldmonitor/trade/v1/get-trade-barriers.ts
+++ b/server/worldmonitor/trade/v1/get-trade-barriers.ts
@@ -7,9 +7,6 @@
  * NOTE: The WTO ePing API (SPS/TBT notifications) is a separate subscription product.
  * This handler uses Timeseries API tariff data to surface sector-level trade barriers.
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import type {
   ServerContext,
   GetTradeBarriersRequest,

--- a/server/worldmonitor/trade/v1/get-trade-flows.ts
+++ b/server/worldmonitor/trade/v1/get-trade-flows.ts
@@ -5,9 +5,6 @@
  * NOTE: The WTO API does NOT support comma-separated indicator codes.
  * Exports and imports must be fetched in separate requests.
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import type {
   ServerContext,
   GetTradeFlowsRequest,

--- a/server/worldmonitor/trade/v1/get-trade-restrictions.ts
+++ b/server/worldmonitor/trade/v1/get-trade-restrictions.ts
@@ -7,9 +7,6 @@
  * NOTE: The WTO Quantitative Restrictions (QR) API is a separate subscription product.
  * This handler uses the Timeseries API tariff data as an available proxy for trade barriers.
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import type {
   ServerContext,
   GetTradeRestrictionsRequest,

--- a/server/worldmonitor/unrest/v1/_shared.ts
+++ b/server/worldmonitor/unrest/v1/_shared.ts
@@ -1,4 +1,3 @@
-declare const process: { env: Record<string, string | undefined> };
 
 import type {
   UnrestEvent,
@@ -122,4 +121,3 @@ export function sortBySeverityAndRecency(events: UnrestEvent[]): UnrestEvent[] {
     return b.occurredAt - a.occurredAt;
   });
 }
-

--- a/server/worldmonitor/wildfire/v1/list-fire-detections.ts
+++ b/server/worldmonitor/wildfire/v1/list-fire-detections.ts
@@ -6,9 +6,6 @@
  *
  * Gracefully degrades to empty results when NASA_FIRMS_API_KEY is not set.
  */
-
-declare const process: { env: Record<string, string | undefined> };
-
 import type {
   WildfireServiceHandler,
   ServerContext,


### PR DESCRIPTION
## Summary
- Create `server/env.d.ts` with the shared `declare const process` ambient declaration
- Remove the duplicated declaration from 35 server files
- `tsconfig.api.json` already includes `server/` so the `.d.ts` is automatically picked up

Rebased version of #752 by @NewCoder3294 onto current `main` (resolves merge conflict in `server/_shared/redis.ts` from #749).

Addresses #197 (L-15).

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.api.json` passes
- [x] Grep confirms only `server/env.d.ts` contains `declare const process`