### PR TITLE
feat: consolidate 4 Vercel deployments into 1 via runtime variant detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
 
 
     <!-- Theme: apply stored preference before first paint to prevent FOUC -->
-    <script>(function(){try{var t=localStorage.getItem('worldmonitor-theme');var v=localStorage.getItem('worldmonitor-variant');if(!v){var h=location.hostname;if(h.startsWith('happy.'))v='happy';else if(h.startsWith('tech.'))v='tech';else if(h.startsWith('finance.'))v='finance';}if(v)document.documentElement.dataset.variant=v;if(t==='dark'||t==='light'){document.documentElement.dataset.theme=t;}else if(v==='happy'){document.documentElement.dataset.theme='light';}}catch(e){}document.documentElement.classList.add('no-transition');})()</script>
+    <script>(function(){try{var h=location.hostname;var v;if(h.startsWith('happy.'))v='happy';else if(h.startsWith('tech.'))v='tech';else if(h.startsWith('finance.'))v='finance';if(!v&&(h==='localhost'||h==='127.0.0.1'||'__TAURI_INTERNALS__' in window))v=localStorage.getItem('worldmonitor-variant');if(v)document.documentElement.dataset.variant=v;else document.documentElement.removeAttribute('data-variant');var t=localStorage.getItem('worldmonitor-theme');if(t==='dark'||t==='light'){document.documentElement.dataset.theme=t;}else if(v==='happy'){document.documentElement.dataset.theme='light';}}catch(e){}document.documentElement.classList.add('no-transition');})()</script>
 
     <!-- Critical CSS: inline skeleton visible before JS boots -->
     <style>

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,3 @@
-/**
- * Vercel Edge Middleware — blocks bot/crawler traffic from API routes.
- * Runs on /api/* paths only (configured via matcher below).
- * Social preview bots are allowed on /api/story and /api/og-story.
- */
-
 const BOT_UA =
   /bot|crawl|spider|slurp|archiver|wget|curl\/|python-requests|scrapy|httpclient|go-http|java\/|libwww|perl|ruby|php\/|ahrefsbot|semrushbot|mj12bot|dotbot|baiduspider|yandexbot|sogou|bytespider|petalbot|gptbot|claudebot|ccbot/i;
 
@@ -12,20 +6,93 @@ const SOCIAL_PREVIEW_UA =
 
 const SOCIAL_PREVIEW_PATHS = new Set(['/api/story', '/api/og-story']);
 
-// Public endpoints that should never be bot-blocked (version check, etc.)
 const PUBLIC_API_PATHS = new Set(['/api/version']);
 
-// Slack uses Slack-ImgProxy to fetch OG images — distinct from Slackbot
 const SOCIAL_IMAGE_UA =
   /Slack-ImgProxy|Slackbot|twitterbot|facebookexternalhit|linkedinbot|telegrambot|whatsapp|discordbot|redditbot/i;
 
+const VARIANT_HOST_MAP: Record<string, string> = {
+  'tech.worldmonitor.app': 'tech',
+  'finance.worldmonitor.app': 'finance',
+  'happy.worldmonitor.app': 'happy',
+};
+
+// Source of truth: src/config/variant-meta.ts — keep in sync when variant metadata changes.
+const VARIANT_OG: Record<string, { title: string; description: string; image: string; url: string }> = {
+  tech: {
+    title: 'Tech Monitor - Real-Time AI & Tech Industry Dashboard',
+    description: 'Real-time AI and tech industry dashboard tracking tech giants, AI labs, startup ecosystems, funding rounds, and tech events worldwide.',
+    image: 'https://tech.worldmonitor.app/favico/tech/og-image.png',
+    url: 'https://tech.worldmonitor.app/',
+  },
+  finance: {
+    title: 'Finance Monitor - Real-Time Markets & Trading Dashboard',
+    description: 'Real-time finance and trading dashboard tracking global markets, stock exchanges, central banks, commodities, forex, crypto, and economic indicators worldwide.',
+    image: 'https://finance.worldmonitor.app/favico/finance/og-image.png',
+    url: 'https://finance.worldmonitor.app/',
+  },
+  happy: {
+    title: 'Happy Monitor - Good News & Global Progress',
+    description: 'Curated positive news, progress data, and uplifting stories from around the world.',
+    image: 'https://happy.worldmonitor.app/favico/happy/og-image.png',
+    url: 'https://happy.worldmonitor.app/',
+  },
+};
+
+const ALLOWED_HOSTS = new Set([
+  'worldmonitor.app',
+  ...Object.keys(VARIANT_HOST_MAP),
+]);
+const VERCEL_PREVIEW_RE = /^[a-z0-9-]+-[a-z0-9]{8,}\.vercel\.app$/;
+
+function normalizeHost(raw: string): string {
+  return raw.toLowerCase().replace(/:\d+$/, '');
+}
+
+function isAllowedHost(host: string): boolean {
+  return ALLOWED_HOSTS.has(host) || VERCEL_PREVIEW_RE.test(host);
+}
+
 export default function middleware(request: Request) {
   const url = new URL(request.url);
-
   const ua = request.headers.get('user-agent') ?? '';
   const path = url.pathname;
+  const host = normalizeHost(request.headers.get('host') ?? url.hostname);
 
-  // Allow social preview/image bots on OG image assets (bypasses Vercel Attack Challenge)
+  // Social bot OG response for variant subdomain root pages
+  if (path === '/' && SOCIAL_PREVIEW_UA.test(ua)) {
+    const variant = VARIANT_HOST_MAP[host];
+    if (variant && isAllowedHost(host)) {
+      const og = VARIANT_OG[variant];
+      const html = `<!DOCTYPE html><html><head>
+<meta property="og:type" content="website"/>
+<meta property="og:title" content="${og.title}"/>
+<meta property="og:description" content="${og.description}"/>
+<meta property="og:image" content="${og.image}"/>
+<meta property="og:url" content="${og.url}"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:title" content="${og.title}"/>
+<meta name="twitter:description" content="${og.description}"/>
+<meta name="twitter:image" content="${og.image}"/>
+<title>${og.title}</title>
+</head><body></body></html>`;
+      return new Response(html, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+          'Cache-Control': 'no-store',
+          'Vary': 'User-Agent, Host',
+        },
+      });
+    }
+  }
+
+  // Only apply bot filtering to /api/* and /favico/* paths
+  if (!path.startsWith('/api/') && !path.startsWith('/favico/')) {
+    return;
+  }
+
+  // Allow social preview/image bots on OG image assets
   if (path.startsWith('/favico/') || path.endsWith('.png')) {
     if (SOCIAL_IMAGE_UA.test(ua)) {
       return;
@@ -60,5 +127,5 @@ export default function middleware(request: Request) {
 }
 
 export const config = {
-  matcher: ['/api/:path*', '/favico/:path*'],
+  matcher: ['/', '/api/:path*', '/favico/:path*'],
 };

--- a/src/config/variant-meta.ts
+++ b/src/config/variant-meta.ts
@@ -1,0 +1,107 @@
+export interface VariantMeta {
+  title: string;
+  description: string;
+  keywords: string;
+  url: string;
+  siteName: string;
+  shortName: string;
+  subject: string;
+  classification: string;
+  categories: string[];
+  features: string[];
+}
+
+export const VARIANT_META: { full: VariantMeta; [k: string]: VariantMeta } = {
+  full: {
+    title: 'World Monitor - Real-Time Global Intelligence Dashboard',
+    description: 'Real-time global intelligence dashboard with live news, markets, military tracking, infrastructure monitoring, and geopolitical data. OSINT in one view.',
+    keywords: 'global intelligence, geopolitical dashboard, world news, market data, military bases, nuclear facilities, undersea cables, conflict zones, real-time monitoring, situation awareness, OSINT, flight tracking, AIS ships, earthquake monitor, protest tracker, power outages, oil prices, government spending, polymarket predictions',
+    url: 'https://worldmonitor.app/',
+    siteName: 'World Monitor',
+    shortName: 'WorldMonitor',
+    subject: 'Real-Time Global Intelligence and Situation Awareness',
+    classification: 'Intelligence Dashboard, OSINT Tool, News Aggregator',
+    categories: ['news', 'productivity'],
+    features: [
+      'Real-time news aggregation',
+      'Stock market tracking',
+      'Military flight monitoring',
+      'Ship AIS tracking',
+      'Earthquake alerts',
+      'Protest tracking',
+      'Power outage monitoring',
+      'Oil price analytics',
+      'Government spending data',
+      'Prediction markets',
+      'Infrastructure monitoring',
+      'Geopolitical intelligence',
+    ],
+  },
+  tech: {
+    title: 'Tech Monitor - Real-Time AI & Tech Industry Dashboard',
+    description: 'Real-time AI and tech industry dashboard tracking tech giants, AI labs, startup ecosystems, funding rounds, and tech events worldwide.',
+    keywords: 'tech dashboard, AI industry, startup ecosystem, tech companies, AI labs, venture capital, tech events, tech conferences, cloud infrastructure, datacenters, tech layoffs, funding rounds, unicorns, FAANG, tech HQ, accelerators, Y Combinator, tech news',
+    url: 'https://tech.worldmonitor.app/',
+    siteName: 'Tech Monitor',
+    shortName: 'TechMonitor',
+    subject: 'AI, Tech Industry, and Startup Ecosystem Intelligence',
+    classification: 'Tech Dashboard, AI Tracker, Startup Intelligence',
+    categories: ['news', 'business'],
+    features: [
+      'Tech news aggregation',
+      'AI lab tracking',
+      'Startup ecosystem mapping',
+      'Tech HQ locations',
+      'Conference & event calendar',
+      'Cloud infrastructure monitoring',
+      'Datacenter mapping',
+      'Tech layoff tracking',
+      'Funding round analytics',
+      'Tech stock tracking',
+      'Service status monitoring',
+    ],
+  },
+  happy: {
+    title: 'Happy Monitor - Good News & Global Progress',
+    description: 'Curated positive news, progress data, and uplifting stories from around the world.',
+    keywords: 'good news, positive news, global progress, happy news, uplifting stories, human achievement, science breakthroughs, conservation wins',
+    url: 'https://happy.worldmonitor.app/',
+    siteName: 'Happy Monitor',
+    shortName: 'HappyMonitor',
+    subject: 'Good News, Global Progress, and Human Achievement',
+    classification: 'Positive News Dashboard, Progress Tracker',
+    categories: ['news', 'lifestyle'],
+    features: [
+      'Curated positive news',
+      'Global progress tracking',
+      'Live humanity counters',
+      'Science breakthrough feed',
+      'Conservation tracker',
+      'Renewable energy dashboard',
+    ],
+  },
+  finance: {
+    title: 'Finance Monitor - Real-Time Markets & Trading Dashboard',
+    description: 'Real-time finance and trading dashboard tracking global markets, stock exchanges, central banks, commodities, forex, crypto, and economic indicators worldwide.',
+    keywords: 'finance dashboard, trading dashboard, stock market, forex, commodities, central banks, crypto, economic indicators, market news, financial centers, stock exchanges, bonds, derivatives, fintech, hedge funds, IPO tracker, market analysis',
+    url: 'https://finance.worldmonitor.app/',
+    siteName: 'Finance Monitor',
+    shortName: 'FinanceMonitor',
+    subject: 'Global Markets, Trading, and Financial Intelligence',
+    classification: 'Finance Dashboard, Market Tracker, Trading Intelligence',
+    categories: ['finance', 'news'],
+    features: [
+      'Real-time market data',
+      'Stock exchange mapping',
+      'Central bank monitoring',
+      'Commodity price tracking',
+      'Forex & currency news',
+      'Crypto & digital assets',
+      'Economic indicator alerts',
+      'IPO & earnings tracking',
+      'Financial center mapping',
+      'Sector heatmap',
+      'Market radar signals',
+    ],
+  },
+};

--- a/src/config/variant.ts
+++ b/src/config/variant.ts
@@ -1,19 +1,23 @@
 export const SITE_VARIANT: string = (() => {
-  const env = import.meta.env.VITE_VARIANT || 'full';
-  // Desktop app: always respect localStorage so variant switcher works
-  // (desktop builds may inherit VITE_VARIANT from .env.local).
-  if (typeof window !== 'undefined') {
-    const isTauri = '__TAURI_INTERNALS__' in window || '__TAURI__' in window;
-    if (isTauri) {
-      const stored = localStorage.getItem('worldmonitor-variant');
-      if (stored === 'tech' || stored === 'full' || stored === 'finance' || stored === 'happy') return stored;
-    }
-  }
-  // Web deployments: build-time variant (non-full) takes priority — each deployment is variant-specific.
-  if (env !== 'full') return env;
-  if (typeof window !== 'undefined') {
+  if (typeof window === 'undefined') return import.meta.env.VITE_VARIANT || 'full';
+
+  const isTauri = '__TAURI_INTERNALS__' in window || '__TAURI__' in window;
+  if (isTauri) {
     const stored = localStorage.getItem('worldmonitor-variant');
     if (stored === 'tech' || stored === 'full' || stored === 'finance' || stored === 'happy') return stored;
+    return import.meta.env.VITE_VARIANT || 'full';
   }
-  return env;
+
+  const h = location.hostname;
+  if (h.startsWith('tech.')) return 'tech';
+  if (h.startsWith('finance.')) return 'finance';
+  if (h.startsWith('happy.')) return 'happy';
+
+  if (h === 'localhost' || h === '127.0.0.1') {
+    const stored = localStorage.getItem('worldmonitor-variant');
+    if (stored === 'tech' || stored === 'full' || stored === 'finance' || stored === 'happy') return stored;
+    return import.meta.env.VITE_VARIANT || 'full';
+  }
+
+  return 'full';
 })();

--- a/src/main.ts
+++ b/src/main.ts
@@ -201,10 +201,16 @@ loadDesktopSecrets().catch(() => {});
 // Apply stored theme preference before app initialization (safety net for inline script)
 applyStoredTheme();
 
-// Set data-variant on <html> so CSS theme overrides activate (inline script handles hostname/localStorage,
-// this catches the VITE_VARIANT env var path used during local dev and Vercel deployments)
+// Set data-variant on <html> so CSS theme overrides activate
 if (SITE_VARIANT && SITE_VARIANT !== 'full') {
   document.documentElement.dataset.variant = SITE_VARIANT;
+
+  // Swap favicons to variant-specific versions before browser finishes fetching defaults
+  document.querySelectorAll<HTMLLinkElement>('link[rel="icon"], link[rel="apple-touch-icon"]').forEach(link => {
+    link.href = link.href
+      .replace(/\/favico\/favicon/g, `/favico/${SITE_VARIANT}/favicon`)
+      .replace(/\/favico\/apple-touch-icon/g, `/favico/${SITE_VARIANT}/apple-touch-icon`);
+  });
 }
 
 // Remove no-transition class after first paint to enable smooth theme transitions

--- a/src/services/meta-tags.ts
+++ b/src/services/meta-tags.ts
@@ -1,5 +1,5 @@
-// Dynamic Meta Tags Service for World Monitor
-// Updates OG tags and Twitter Cards for shared stories
+import { SITE_VARIANT } from '@/config/variant';
+import { VARIANT_META } from '@/config/variant-meta';
 
 interface StoryMeta {
   countryCode: string;
@@ -10,58 +10,52 @@ interface StoryMeta {
   type: 'ciianalysis' | 'crisisalert' | 'dailybrief' | 'marketfocus';
 }
 
-const BASE_URL = 'https://worldmonitor.app';
-const DEFAULT_IMAGE = 'https://worldmonitor.app/favico/og-image.png';
+const variantMeta = VARIANT_META[SITE_VARIANT] ?? VARIANT_META.full;
+const BASE_URL = variantMeta.url.replace(/\/$/, '');
+const DEFAULT_IMAGE = `${BASE_URL}/favico/${SITE_VARIANT === 'full' ? '' : SITE_VARIANT + '/'}og-image.png`;
 
 export function updateMetaTagsForStory(meta: StoryMeta): void {
   const { countryCode, countryName, ciiScore, ciiLevel, trend, type } = meta;
-  
-  // Generate dynamic content
-  const title = `${countryName} Intelligence Brief | World Monitor`;
+
+  const title = `${countryName} Intelligence Brief | ${variantMeta.siteName}`;
   const description = generateDescription(ciiScore, ciiLevel, trend, type, countryName);
   const storyUrl = `${BASE_URL}/api/story?c=${countryCode}&t=${type}`;
   let imageUrl = `${BASE_URL}/api/og-story?c=${countryCode}&t=${type}`;
   if (ciiScore !== undefined) imageUrl += `&s=${ciiScore}`;
   if (ciiLevel) imageUrl += `&l=${ciiLevel}`;
-  
-  // Update standard meta tags
+
   setMetaTag('title', title);
   setMetaTag('description', description);
   setCanonicalLink(storyUrl);
-  
-  // Update Open Graph
+
   setMetaTag('og:title', title);
   setMetaTag('og:description', description);
   setMetaTag('og:url', storyUrl);
   setMetaTag('og:image', imageUrl);
-  
-  // Update Twitter Cards
+
   setMetaTag('twitter:title', title);
   setMetaTag('twitter:description', description);
   setMetaTag('twitter:url', storyUrl);
   setMetaTag('twitter:image', imageUrl);
-  
-  // Store in session for og-image API
+
   sessionStorage.setItem('storyMeta', JSON.stringify(meta));
-  
 }
 
 export function resetMetaTags(): void {
-  const defaultTitle = 'World Monitor - Global Situation with AI Insights';
-  const defaultDesc = 'AI-powered real-time global intelligence dashboard with live news, markets, military tracking, and geopolitical data.';
-  
-  setMetaTag('title', defaultTitle);
-  setMetaTag('description', defaultDesc);
-  setCanonicalLink(BASE_URL);
-  setMetaTag('og:title', defaultTitle);
-  setMetaTag('og:description', defaultDesc);
-  setMetaTag('og:url', BASE_URL);
+  document.title = variantMeta.title;
+
+  setMetaTag('title', variantMeta.title);
+  setMetaTag('description', variantMeta.description);
+  setCanonicalLink(BASE_URL + '/');
+  setMetaTag('og:title', variantMeta.title);
+  setMetaTag('og:description', variantMeta.description);
+  setMetaTag('og:url', BASE_URL + '/');
   setMetaTag('og:image', DEFAULT_IMAGE);
-  setMetaTag('twitter:title', defaultTitle);
-  setMetaTag('twitter:description', defaultDesc);
-  setMetaTag('twitter:url', BASE_URL);
+  setMetaTag('twitter:title', variantMeta.title);
+  setMetaTag('twitter:description', variantMeta.description);
+  setMetaTag('twitter:url', BASE_URL + '/');
   setMetaTag('twitter:image', DEFAULT_IMAGE);
-  
+
   sessionStorage.removeItem('storyMeta');
 }
 
@@ -73,36 +67,34 @@ function generateDescription(
   countryName?: string
 ): string {
   const parts: string[] = [];
-  
+
   if (score !== undefined && level) {
     parts.push(`${countryName} has an instability score of ${score}/100 (${level})`);
   }
-  
+
   if (trend) {
     const trendText = trend === 'rising' ? 'trending upward' : trend === 'falling' ? 'trending downward' : 'stable';
     parts.push(`Risk is ${trendText}`);
   }
-  
+
   const typeDescriptions: Record<string, string> = {
     ciianalysis: 'Full intelligence analysis with military posture and prediction markets',
     crisisalert: 'Crisis-focused briefing with convergence alerts',
     dailybrief: 'AI-synthesized daily briefing of top stories',
     marketfocus: 'Prediction market probabilities and market-moving events',
   };
-  
+
   if (type && typeDescriptions[type]) {
     parts.push(typeDescriptions[type]);
   }
-  
-  return `World Monitor ${parts.join('. ')}. Free, open-source geopolitical intelligence.`;
+
+  return `${variantMeta.siteName} ${parts.join('. ')}. Free, open-source geopolitical intelligence.`;
 }
 
 function setMetaTag(property: string, content: string): void {
-  // Remove existing tag
   const existing = document.querySelector(`meta[property="${property}"], meta[name="${property}"]`);
   if (existing) existing.remove();
-  
-  // Create new tag
+
   const meta = document.createElement('meta');
   if (property.startsWith('og:') || property.startsWith('twitter:')) {
     meta.setAttribute('property', property);
@@ -123,7 +115,6 @@ function setCanonicalLink(href: string): void {
   link.setAttribute('href', href);
 }
 
-// Parse URL params for story pages
 export function parseStoryParams(url: URL): StoryMeta | null {
   const countryCode = url.searchParams.get('c');
   const type = url.searchParams.get('t') || 'ciianalysis';
@@ -134,8 +125,7 @@ export function parseStoryParams(url: URL): StoryMeta | null {
   const safeType: StoryMeta['type'] = validTypes.includes(type as StoryMeta['type'])
     ? (type as StoryMeta['type'])
     : 'ciianalysis';
-  
-  // Get country name from mapping (would normally come from data)
+
   const countryNames: Record<string, string> = {
     UA: 'Ukraine', RU: 'Russia', CN: 'China', US: 'United States',
     IR: 'Iran', IL: 'Israel', TW: 'Taiwan', KP: 'North Korea',
@@ -143,7 +133,7 @@ export function parseStoryParams(url: URL): StoryMeta | null {
     FR: 'France', GB: 'United Kingdom', IN: 'India', PK: 'Pakistan',
     SY: 'Syria', YE: 'Yemen', MM: 'Myanmar', VE: 'Venezuela',
   };
-  
+
   return {
     countryCode: countryCode.toUpperCase(),
     countryName: countryNames[countryCode.toUpperCase()] || countryCode.toUpperCase(),
@@ -151,10 +141,9 @@ export function parseStoryParams(url: URL): StoryMeta | null {
   };
 }
 
-// Initialize on page load
 export function initMetaTags(): void {
   const url = new URL(window.location.href);
-  
+
   if (url.pathname === '/story' || url.searchParams.has('c')) {
     const params = parseStoryParams(url);
     if (params) {

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -1,3 +1,5 @@
+import { SITE_VARIANT } from '@/config/variant';
+
 const WS_API_URL = import.meta.env.VITE_WS_API_URL || '';
 const KEYED_CLOUD_API_PATTERN = /^\/api\/(?:[^/]+\/v1\/|bootstrap(?:\?|$)|rss-proxy(?:\?|$)|polymarket(?:\?|$)|ais-snapshot(?:\?|$))/;
 
@@ -113,8 +115,7 @@ export function getRemoteApiBaseUrl(): string {
     return normalizeBaseUrl(configuredRemoteBase);
   }
 
-  const variant = import.meta.env.VITE_VARIANT || 'full';
-  const fromHosts = DEFAULT_REMOTE_HOSTS[variant] ?? DEFAULT_REMOTE_HOSTS.full ?? '';
+  const fromHosts = DEFAULT_REMOTE_HOSTS[SITE_VARIANT] ?? DEFAULT_REMOTE_HOSTS.full ?? '';
   if (fromHosts) return fromHosts;
 
   // Desktop builds may not set VITE_WS_API_URL; default to production.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { mkdir, readFile, writeFile } from 'fs/promises';
 import { brotliCompress } from 'zlib';
 import { promisify } from 'util';
 import pkg from './package.json';
+import { VARIANT_META } from './src/config/variant-meta';
 
 const isE2E = process.env.VITE_E2E === '1';
 const isDesktopBuild = process.env.VITE_DESKTOP_RUNTIME === '1';
@@ -36,112 +37,6 @@ function brotliPrecompressPlugin(): Plugin {
     },
   };
 }
-
-const VARIANT_META: Record<string, {
-  title: string;
-  description: string;
-  keywords: string;
-  url: string;
-  siteName: string;
-  shortName: string;
-  subject: string;
-  classification: string;
-  categories: string[];
-  features: string[];
-}> = {
-  full: {
-    title: 'World Monitor - Real-Time Global Intelligence Dashboard',
-    description: 'Real-time global intelligence dashboard with live news, markets, military tracking, infrastructure monitoring, and geopolitical data. OSINT in one view.',
-    keywords: 'global intelligence, geopolitical dashboard, world news, market data, military bases, nuclear facilities, undersea cables, conflict zones, real-time monitoring, situation awareness, OSINT, flight tracking, AIS ships, earthquake monitor, protest tracker, power outages, oil prices, government spending, polymarket predictions',
-    url: 'https://worldmonitor.app/',
-    siteName: 'World Monitor',
-    shortName: 'WorldMonitor',
-    subject: 'Real-Time Global Intelligence and Situation Awareness',
-    classification: 'Intelligence Dashboard, OSINT Tool, News Aggregator',
-    categories: ['news', 'productivity'],
-    features: [
-      'Real-time news aggregation',
-      'Stock market tracking',
-      'Military flight monitoring',
-      'Ship AIS tracking',
-      'Earthquake alerts',
-      'Protest tracking',
-      'Power outage monitoring',
-      'Oil price analytics',
-      'Government spending data',
-      'Prediction markets',
-      'Infrastructure monitoring',
-      'Geopolitical intelligence',
-    ],
-  },
-  tech: {
-    title: 'Tech Monitor - Real-Time AI & Tech Industry Dashboard',
-    description: 'Real-time AI and tech industry dashboard tracking tech giants, AI labs, startup ecosystems, funding rounds, and tech events worldwide.',
-    keywords: 'tech dashboard, AI industry, startup ecosystem, tech companies, AI labs, venture capital, tech events, tech conferences, cloud infrastructure, datacenters, tech layoffs, funding rounds, unicorns, FAANG, tech HQ, accelerators, Y Combinator, tech news',
-    url: 'https://tech.worldmonitor.app/',
-    siteName: 'Tech Monitor',
-    shortName: 'TechMonitor',
-    subject: 'AI, Tech Industry, and Startup Ecosystem Intelligence',
-    classification: 'Tech Dashboard, AI Tracker, Startup Intelligence',
-    categories: ['news', 'business'],
-    features: [
-      'Tech news aggregation',
-      'AI lab tracking',
-      'Startup ecosystem mapping',
-      'Tech HQ locations',
-      'Conference & event calendar',
-      'Cloud infrastructure monitoring',
-      'Datacenter mapping',
-      'Tech layoff tracking',
-      'Funding round analytics',
-      'Tech stock tracking',
-      'Service status monitoring',
-    ],
-  },
-  happy: {
-    title: 'Happy Monitor - Good News & Global Progress',
-    description: 'Curated positive news, progress data, and uplifting stories from around the world.',
-    keywords: 'good news, positive news, global progress, happy news, uplifting stories, human achievement, science breakthroughs, conservation wins',
-    url: 'https://happy.worldmonitor.app/',
-    siteName: 'Happy Monitor',
-    shortName: 'HappyMonitor',
-    subject: 'Good News, Global Progress, and Human Achievement',
-    classification: 'Positive News Dashboard, Progress Tracker',
-    categories: ['news', 'lifestyle'],
-    features: [
-      'Curated positive news',
-      'Global progress tracking',
-      'Live humanity counters',
-      'Science breakthrough feed',
-      'Conservation tracker',
-      'Renewable energy dashboard',
-    ],
-  },
-  finance: {
-    title: 'Finance Monitor - Real-Time Markets & Trading Dashboard',
-    description: 'Real-time finance and trading dashboard tracking global markets, stock exchanges, central banks, commodities, forex, crypto, and economic indicators worldwide.',
-    keywords: 'finance dashboard, trading dashboard, stock market, forex, commodities, central banks, crypto, economic indicators, market news, financial centers, stock exchanges, bonds, derivatives, fintech, hedge funds, IPO tracker, market analysis',
-    url: 'https://finance.worldmonitor.app/',
-    siteName: 'Finance Monitor',
-    shortName: 'FinanceMonitor',
-    subject: 'Global Markets, Trading, and Financial Intelligence',
-    classification: 'Finance Dashboard, Market Tracker, Trading Intelligence',
-    categories: ['finance', 'news'],
-    features: [
-      'Real-time market data',
-      'Stock exchange mapping',
-      'Central bank monitoring',
-      'Commodity price tracking',
-      'Forex & currency news',
-      'Crypto & digital assets',
-      'Economic indicator alerts',
-      'IPO & earnings tracking',
-      'Financial center mapping',
-      'Sector heatmap',
-      'Market radar signals',
-    ],
-  },
-};
 
 const activeVariant = process.env.VITE_VARIANT || 'full';
 const activeMeta = VARIANT_META[activeVariant] || VARIANT_META.full;
@@ -180,8 +75,8 @@ function htmlVariantPlugin(): Plugin {
         );
       }
 
-      // Inject build-time variant into the inline script so data-variant is set before CSS loads.
-      // Force the variant (don't let stale localStorage override the build-time setting).
+      // Desktop builds: inject build-time variant into the inline script so data-variant is set
+      // before CSS loads. Web builds always use 'full' — runtime hostname detection handles variants.
       if (activeVariant !== 'full') {
         result = result.replace(
           /if\(v\)document\.documentElement\.dataset\.variant=v;/,
@@ -203,7 +98,8 @@ function htmlVariantPlugin(): Plugin {
           );
       }
 
-      // Favicon variant paths — replace /favico/ paths with variant-specific subdirectory
+      // Desktop builds: replace favicon paths with variant-specific subdirectory.
+      // Web builds use 'full' favicons in HTML; runtime JS swaps them per hostname.
       if (activeVariant !== 'full') {
         result = result
           .replace(/\/favico\/favicon/g, `/favico/${activeVariant}/favicon`)


### PR DESCRIPTION
## Summary

- Replace build-time `VITE_VARIANT` env var with runtime hostname detection for web deployments
- A single `npm run build` now serves all 4 variants (`full`, `tech`, `finance`, `happy`) via subdomain routing
- Eliminates 3 redundant Vercel projects and their build minutes
- Desktop builds and localhost dev remain fully compatible with `VITE_VARIANT`

## Changes

| File | Change |
|------|--------|
| `src/config/variant-meta.ts` (new) | Extracted `VARIANT_META` from vite.config.ts — shared build-time + runtime |
| `src/config/variant.ts` | Hostname detection for web, localStorage/env fallback on localhost/Tauri |
| `index.html` | Pre-paint script checks hostname first, localStorage only on localhost/Tauri |
| `vite.config.ts` | Imports from `variant-meta.ts`, kept desktop variant blocks |
| `src/services/meta-tags.ts` | `resetMetaTags()` uses variant-aware title/description/URL/image |
| `middleware.ts` | Social bot OG response for variant subdomain `/`, host whitelist |
| `src/main.ts` | Favicon swap to `/favico/{variant}/` for non-full variants |
| `src/services/runtime.ts` | `getRemoteApiBaseUrl()` uses `SITE_VARIANT` import |

## Post-Deploy (Manual)

1. Add `tech.`, `finance.`, `happy.` subdomains to the single Vercel project
2. Disable the 3 variant Vercel projects (72h rollback window, then delete)
3. Unset `VITE_VARIANT` env var (defaults to `full`)

## Test plan

- [x] `tsc --noEmit` passes
- [x] `npm run build` succeeds (single output, no `VITE_VARIANT` needed)
- [x] Edge function tests pass (30/30)
- [ ] `VITE_VARIANT=tech npm run dev` → localhost shows tech variant
- [ ] Vercel preview deploy → all 4 subdomains serve correct variant
- [ ] `curl -A "Twitterbot" -H "Host: tech.worldmonitor.app"` → variant-specific OG tags
- [ ] Desktop build (`npm run desktop:build:tech`) still works