### PR TITLE
fix(server): return 405 Method Not Allowed for wrong HTTP method

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -168,6 +168,13 @@ export function createDomainGateway(
       }
     }
     if (!matchedHandler) {
+      const allowed = router.allowedMethods(new URL(request.url).pathname);
+      if (allowed.length > 0) {
+        return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json', Allow: allowed.join(', '), ...corsHeaders },
+        });
+      }
       return new Response(JSON.stringify({ error: 'Not found' }), {
         status: 404,
         headers: { 'Content-Type': 'application/json', ...corsHeaders },

--- a/server/router.ts
+++ b/server/router.ts
@@ -14,6 +14,7 @@ export interface RouteDescriptor {
 
 export interface Router {
   match(req: Request): ((req: Request) => Promise<Response>) | null;
+  allowedMethods(pathname: string): string[];
 }
 
 interface DynamicRoute {
@@ -27,11 +28,11 @@ interface DynamicRoute {
 
 export function createRouter(allRoutes: RouteDescriptor[]): Router {
   const staticTable = new Map<string, (req: Request) => Promise<Response>>();
+  const staticPaths = new Map<string, Set<string>>();
   const dynamicRoutes: DynamicRoute[] = [];
 
   for (const route of allRoutes) {
     if (route.path.includes('{')) {
-      // Dynamic route — parse segments for pattern matching
       const parts = route.path.split('/').filter(Boolean);
       dynamicRoutes.push({
         method: route.method,
@@ -42,24 +43,24 @@ export function createRouter(allRoutes: RouteDescriptor[]): Router {
     } else {
       const key = `${route.method} ${route.path}`;
       staticTable.set(key, route.handler);
+      if (!staticPaths.has(route.path)) staticPaths.set(route.path, new Set());
+      staticPaths.get(route.path)!.add(route.method);
     }
+  }
+
+  function normalizePath(raw: string): string {
+    return raw.length > 1 && raw.endsWith('/') ? raw.slice(0, -1) : raw;
   }
 
   return {
     match(req: Request) {
       const url = new URL(req.url);
-      // Normalize trailing slashes: /api/foo/v1/bar/ -> /api/foo/v1/bar
-      const pathname =
-        url.pathname.length > 1 && url.pathname.endsWith('/')
-          ? url.pathname.slice(0, -1)
-          : url.pathname;
+      const pathname = normalizePath(url.pathname);
 
-      // Fast path: exact match for static routes
       const key = `${req.method} ${pathname}`;
       const staticHandler = staticTable.get(key);
       if (staticHandler) return staticHandler;
 
-      // Slow path: match dynamic routes
       const parts = pathname.split('/').filter(Boolean);
       for (const route of dynamicRoutes) {
         if (route.method !== req.method) continue;
@@ -75,6 +76,33 @@ export function createRouter(allRoutes: RouteDescriptor[]): Router {
       }
 
       return null;
+    },
+
+    allowedMethods(pathname: string): string[] {
+      const normalized = normalizePath(pathname);
+
+      const methods = staticPaths.get(normalized);
+      if (methods) {
+        const result = Array.from(methods);
+        if (result.includes('GET') && !result.includes('HEAD')) result.push('HEAD');
+        return result;
+      }
+
+      const parts = normalized.split('/').filter(Boolean);
+      const found = new Set<string>();
+      for (const route of dynamicRoutes) {
+        if (route.segmentCount !== parts.length) continue;
+        let matched = true;
+        for (let i = 0; i < route.segmentCount; i++) {
+          if (route.segments[i] !== null && route.segments[i] !== parts[i]) {
+            matched = false;
+            break;
+          }
+        }
+        if (matched) found.add(route.method);
+      }
+      if (found.has('GET')) found.add('HEAD');
+      return Array.from(found);
     },
   };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -452,12 +452,19 @@ function sebufApiPlugin(): Plugin {
           // Route matching
           const matchedHandler = router.match(webRequest);
           if (!matchedHandler) {
-            res.statusCode = 404;
-            res.setHeader('Content-Type', 'application/json');
+            const allowed = router.allowedMethods(new URL(webRequest.url).pathname);
+            if (allowed.length > 0) {
+              res.statusCode = 405;
+              res.setHeader('Content-Type', 'application/json');
+              res.setHeader('Allow', allowed.join(', '));
+            } else {
+              res.statusCode = 404;
+              res.setHeader('Content-Type', 'application/json');
+            }
             for (const [key, value] of Object.entries(corsHeaders)) {
               res.setHeader(key, value);
             }
-            res.end(JSON.stringify({ error: 'Not found' }));
+            res.end(JSON.stringify({ error: res.statusCode === 405 ? 'Method not allowed' : 'Not found' }));
             return;
           }
 


### PR DESCRIPTION
## Summary
- Add `allowedMethods(pathname)` to the Router interface
- Gateway now returns 405 with `Allow` header when the path exists but the method doesn't match
- Previously, all unmatched requests returned 404 regardless of whether the path was valid

## Changes
- `server/router.ts` — track path→methods mapping, add `allowedMethods()` method
- `server/gateway.ts` — check `allowedMethods()` before returning 404
- `vite.config.ts` — same 405 logic in dev server plugin

Supersedes #751 (rebased on top of #753's per-domain edge function split).

Addresses #197 (L-2).

## Test plan
- [ ] Send GET to a POST-only endpoint → should receive 405 with `Allow: POST`
- [ ] Send POST to a nonexistent path → should still receive 404
- [ ] OPTIONS preflight still returns 204 (handled before routing)