### PR TITLE
fix(deduction): append panel to DOM after async import resolves

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -549,6 +549,17 @@ export class PanelLayoutManager implements AppModule {
         import('@/components/DeductionPanel').then(({ DeductionPanel }) => {
           const deductionPanel = new DeductionPanel(() => this.ctx.allNews);
           this.ctx.panels['deduction'] = deductionPanel;
+          const el = deductionPanel.getElement();
+          this.makeDraggable(el, 'deduction');
+          const grid = document.getElementById('panelsGrid');
+          if (grid) {
+            const gdeltEl = this.ctx.panels['gdelt-intel']?.getElement();
+            if (gdeltEl?.nextSibling) {
+              grid.insertBefore(el, gdeltEl.nextSibling);
+            } else {
+              grid.appendChild(el);
+            }
+          }
         });
       }
 


### PR DESCRIPTION
## Summary
- DeductionPanel was created via dynamic `import()` but never appended to the panels grid
- The grid rendering loop iterates `DEFAULT_PANELS` keys synchronously, but `'deduction'` is intentionally excluded (desktop-only feature)
- By the time the async import resolved, the grid was already built — the panel existed in memory but was invisible
- Fix: after import resolves, manually insert the panel into the grid (after GDELT Intel) and make it draggable
- Desktop-only gate (`isDesktopApp`) preserved — web users never see this panel

## Test plan
- [ ] Open desktop app → verify "Deduct Situation" panel appears in the sidebar
- [ ] Verify panel is draggable/reorderable like other panels
- [ ] Open web app → verify panel does NOT appear
- [ ] Submit a query in the panel → verify AI analysis returns