### PR TITLE
feat(live): geo-restricted channel support

### DIFF
--- a/api/geo.js
+++ b/api/geo.js
@@ -1,0 +1,13 @@
+export const config = { runtime: 'edge' };
+
+export default function handler(req) {
+  const country = req.headers.get('x-vercel-ip-country') || 'XX';
+  return new Response(JSON.stringify({ country }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=300',
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -53,6 +53,7 @@ export interface LiveChannel {
   isLive?: boolean;
   hlsUrl?: string; // HLS manifest URL for native <video> playback (desktop)
   useFallbackOnly?: boolean; // Skip auto-detection, always use fallback
+  geoAvailability?: string[]; // ISO 3166-1 alpha-2 codes; undefined = available everywhere
 }
 
 
@@ -99,7 +100,6 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'france24', name: 'France 24', handle: '@FRANCE24', fallbackVideoId: 'u9foWyMSETk' },
   { id: 'bbc-news', name: 'BBC News', handle: '@BBCNews', fallbackVideoId: 'bjgQzJzCZKs' },
   { id: 'france24-en', name: 'France 24 English', handle: '@France24_en', fallbackVideoId: 'Ap-UM1O9RBU' },
-  { id: 'welt', name: 'WELT', handle: '@WELTVideoTV', fallbackVideoId: 'L-TNmYmaAKQ' },
   { id: 'rtve', name: 'RTVE 24H', handle: '@RTVENoticias', fallbackVideoId: '7_srED6k0bE' },
   { id: 'trt-haber', name: 'TRT Haber', handle: '@trthaber', fallbackVideoId: '3XHebGJG0bc' },
   { id: 'ntv-turkey', name: 'NTV', handle: '@NTV', fallbackVideoId: 'pqq5c6k70kk' },
@@ -149,6 +149,7 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'sabc-news', name: 'SABC News', handle: '@SABCDigitalNews' },
   { id: 'arise-news', name: 'Arise News', handle: '@AriseNewsChannel', fallbackVideoId: '4uHZdlX-DT4' },
   // Europe (additional)
+  { id: 'welt', name: 'WELT', handle: '@WELTVideoTV', fallbackVideoId: 'L-TNmYmaAKQ', geoAvailability: ['DE', 'AT', 'CH'] },
   { id: 'tagesschau24', name: 'Tagesschau24', handle: '@tagesschau', fallbackVideoId: 'fC_q9TkO1uU' },
   { id: 'tv5monde-info', name: 'TV5 Monde Info', handle: '@TV5MONDEInfo' },
   { id: 'nrk1', name: 'NRK1', handle: '@nrk' },
@@ -176,6 +177,24 @@ const DEFAULT_LIVE_CHANNELS = SITE_VARIANT === 'tech' ? TECH_LIVE_CHANNELS : SIT
 /** Default channel list for the current variant (for restore in channel management). */
 export function getDefaultLiveChannels(): LiveChannel[] {
   return [...DEFAULT_LIVE_CHANNELS];
+}
+
+/** Returns optional channels filtered by user country. Channels without geoAvailability pass through. */
+export function getFilteredOptionalChannels(userCountry: string | null): LiveChannel[] {
+  if (!userCountry) return OPTIONAL_LIVE_CHANNELS;
+  const uc = userCountry.toUpperCase();
+  return OPTIONAL_LIVE_CHANNELS.filter((c) => !c.geoAvailability || c.geoAvailability.includes(uc));
+}
+
+/** Returns region entries with geo-restricted channel IDs removed for the user's country. */
+export function getFilteredChannelRegions(userCountry: string | null): typeof OPTIONAL_CHANNEL_REGIONS {
+  if (!userCountry) return OPTIONAL_CHANNEL_REGIONS;
+  const filtered = getFilteredOptionalChannels(userCountry);
+  const allowedIds = new Set(filtered.map((c) => c.id));
+  return OPTIONAL_CHANNEL_REGIONS.map((r) => ({
+    ...r,
+    channelIds: r.channelIds.filter((id) => allowedIds.has(id)),
+  }));
 }
 
 export interface StoredLiveChannels {
@@ -819,9 +838,9 @@ export class LiveNewsPanel extends Panel {
 
     requestAnimationFrame(() => overlay.classList.add('active'));
 
-    import('@/live-channels-window').then(({ initLiveChannelsWindow }) => {
-      initLiveChannelsWindow(container);
-    });
+    import('@/live-channels-window').then(async ({ initLiveChannelsWindow }) => {
+      await initLiveChannelsWindow(container);
+    }).catch(console.error);
 
     const close = () => {
       overlay.remove();

--- a/src/live-channels-window.ts
+++ b/src/live-channels-window.ts
@@ -8,12 +8,13 @@ import {
   saveChannelsToStorage,
   BUILTIN_IDS,
   getDefaultLiveChannels,
-  OPTIONAL_LIVE_CHANNELS,
-  OPTIONAL_CHANNEL_REGIONS,
+  getFilteredOptionalChannels,
+  getFilteredChannelRegions,
 } from '@/components/LiveNewsPanel';
 import { t } from '@/services/i18n';
 import { escapeHtml } from '@/utils/sanitize';
 import { isDesktopRuntime, getRemoteApiBaseUrl } from '@/services/runtime';
+import { resolveUserCountryCode } from '@/utils/user-location';
 
 /** Builds a stable custom channel id from a YouTube handle (e.g. @Foo -> custom-foo). */
 function customChannelIdFromHandle(handle: string): string {
@@ -56,19 +57,21 @@ function parseYouTubeInput(raw: string): { handle: string } | { videoId: string 
 }
 
 // Persist active region tab across re-renders
-let activeRegionTab = OPTIONAL_CHANNEL_REGIONS[0]?.key ?? 'na';
-
-// Build a lookup map: channel id → LiveChannel for optional channels
-const optionalChannelMap = new Map<string, LiveChannel>();
-for (const c of OPTIONAL_LIVE_CHANNELS) optionalChannelMap.set(c.id, c);
+let activeRegionTab = 'all';
 
 function channelInitials(name: string): string {
   return name.split(/[\s-]+/).map((w) => w[0] ?? '').join('').slice(0, 2).toUpperCase();
 }
 
-export function initLiveChannelsWindow(containerEl?: HTMLElement): void {
+export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise<void> {
   const appEl = containerEl ?? document.getElementById('app');
   if (!appEl) return;
+
+  const userCountry = await resolveUserCountryCode();
+  const filteredChannels = getFilteredOptionalChannels(userCountry);
+  const filteredRegions = getFilteredChannelRegions(userCountry);
+  const optionalChannelMap = new Map<string, LiveChannel>();
+  for (const c of filteredChannels) optionalChannelMap.set(c.id, c);
 
   if (!containerEl) {
     document.title = `${t('components.liveNews.manage') ?? 'Channel management'} - World Monitor`;
@@ -289,7 +292,7 @@ export function initLiveChannelsWindow(containerEl?: HTMLElement): void {
 
     // Render tab buttons
     tabBar.innerHTML = '';
-    for (const region of OPTIONAL_CHANNEL_REGIONS) {
+    for (const region of filteredRegions) {
       const addedCount = region.channelIds.filter((id) => currentIds.has(id)).length;
       const btn = document.createElement('button');
       btn.type = 'button';
@@ -305,7 +308,7 @@ export function initLiveChannelsWindow(containerEl?: HTMLElement): void {
 
     // Render tab content panels
     tabContents.innerHTML = '';
-    for (const region of OPTIONAL_CHANNEL_REGIONS) {
+    for (const region of filteredRegions) {
       const panel = document.createElement('div');
       panel.className = 'live-news-manage-tab-content' + (region.key === activeRegionTab ? ' active' : '');
 

--- a/src/utils/user-location.ts
+++ b/src/utils/user-location.ts
@@ -1,3 +1,5 @@
+import { isDesktopRuntime } from '@/services/runtime';
+
 type MapView = 'global' | 'america' | 'mena' | 'eu' | 'asia' | 'latam' | 'africa' | 'oceania';
 
 const ASIA_EAST_TIMEZONES = new Set([
@@ -45,6 +47,61 @@ function getGeolocationPosition(timeout: number): Promise<GeolocationPosition> {
       maximumAge: 300_000,
     });
   });
+}
+
+const TIMEZONE_TO_COUNTRY: Record<string, string> = {
+  'Europe/Berlin': 'DE', 'Europe/Vienna': 'AT', 'Europe/Zurich': 'CH',
+  'Europe/London': 'GB', 'Europe/Paris': 'FR', 'Europe/Madrid': 'ES',
+  'Europe/Rome': 'IT', 'Europe/Amsterdam': 'NL', 'Europe/Brussels': 'BE',
+  'Europe/Lisbon': 'PT', 'Europe/Stockholm': 'SE', 'Europe/Oslo': 'NO',
+  'Europe/Copenhagen': 'DK', 'Europe/Helsinki': 'FI', 'Europe/Warsaw': 'PL',
+  'Europe/Prague': 'CZ', 'Europe/Budapest': 'HU', 'Europe/Bucharest': 'RO',
+  'Europe/Athens': 'GR', 'Europe/Dublin': 'IE',
+  'Europe/Istanbul': 'TR', 'Europe/Moscow': 'RU', 'Europe/Kiev': 'UA',
+  'Europe/Kyiv': 'UA', 'Europe/Belgrade': 'RS', 'Europe/Zagreb': 'HR',
+  'Europe/Sofia': 'BG', 'Europe/Bratislava': 'SK', 'Europe/Ljubljana': 'SI',
+  'Europe/Tallinn': 'EE', 'Europe/Riga': 'LV', 'Europe/Vilnius': 'LT',
+  'Europe/Luxembourg': 'LU',
+  'America/New_York': 'US', 'America/Chicago': 'US', 'America/Denver': 'US',
+  'America/Los_Angeles': 'US', 'America/Phoenix': 'US', 'America/Anchorage': 'US',
+  'Pacific/Honolulu': 'US', 'America/Toronto': 'CA', 'America/Vancouver': 'CA',
+  'America/Edmonton': 'CA', 'America/Winnipeg': 'CA', 'America/Halifax': 'CA',
+  'America/Mexico_City': 'MX', 'America/Sao_Paulo': 'BR', 'America/Argentina/Buenos_Aires': 'AR',
+  'America/Bogota': 'CO', 'America/Lima': 'PE', 'America/Santiago': 'CL',
+  'Asia/Tokyo': 'JP', 'Asia/Seoul': 'KR', 'Asia/Shanghai': 'CN',
+  'Asia/Hong_Kong': 'HK', 'Asia/Taipei': 'TW', 'Asia/Singapore': 'SG',
+  'Asia/Kolkata': 'IN', 'Asia/Dubai': 'AE', 'Asia/Riyadh': 'SA',
+  'Asia/Jerusalem': 'IL', 'Asia/Bangkok': 'TH', 'Asia/Jakarta': 'ID',
+  'Asia/Kuala_Lumpur': 'MY', 'Asia/Manila': 'PH', 'Asia/Karachi': 'PK',
+  'Australia/Sydney': 'AU', 'Australia/Melbourne': 'AU', 'Australia/Perth': 'AU',
+  'Pacific/Auckland': 'NZ', 'Africa/Cairo': 'EG', 'Africa/Lagos': 'NG',
+  'Africa/Johannesburg': 'ZA', 'Africa/Nairobi': 'KE', 'Africa/Casablanca': 'MA',
+};
+
+let _countryPromise: Promise<string | null> | undefined;
+
+async function resolveCountryCodeInternal(): Promise<string | null> {
+  if (!isDesktopRuntime()) {
+    try {
+      const res = await fetch('/api/geo', { signal: AbortSignal.timeout(3000) });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.country && data.country !== 'XX') return data.country;
+      }
+    } catch { /* fallback to timezone */ }
+  }
+
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return TIMEZONE_TO_COUNTRY[tz] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveUserCountryCode(): Promise<string | null> {
+  if (!_countryPromise) _countryPromise = resolveCountryCodeInternal();
+  return _countryPromise;
 }
 
 export async function resolveUserRegion(): Promise<MapView> {


### PR DESCRIPTION
## Summary
- Add `geoAvailability?: string[]` field to `LiveChannel` interface for declaring country restrictions (ISO 3166-1 alpha-2)
- Restore WELT channel with `geoAvailability: ['DE', 'AT', 'CH']` (DACH region only)
- Add `/api/geo.js` edge function that returns user country from Vercel's `x-vercel-ip-country` header
- Add `resolveUserCountryCode()` in `user-location.ts` with promise coalescing, desktop-skip optimization, and timezone fallback
- Filter geo-restricted channels from the channel management UI for non-matching users

## Test plan
- [ ] `npm run dev` — open Live News panel, confirm WELT does NOT appear (dev is not in DACH)
- [ ] Manually set timezone to `Europe/Berlin` — confirm WELT appears in EU region tab
- [ ] Channels without `geoAvailability` remain visible to everyone
- [ ] Channel management window also hides geo-restricted channels for non-matching users
- [ ] Desktop (Tauri) skips `/api/geo` fetch and uses timezone fallback directly