### PR TITLE
fix(insights): strip OREF translation labels from World Brief

### DIFF
--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -4,6 +4,7 @@ import { generateSummary, type SummarizeOptions } from '@/services/summarization
 import { parallelAnalysis, type AnalyzedHeadline } from '@/services/parallel-analysis';
 import { signalAggregator, type RegionalConvergence } from '@/services/signal-aggregator';
 import { focalPointDetector } from '@/services/focal-point-detector';
+import { stripOrefLabels } from '@/services/oref-alerts';
 import { ingestNewsForCII } from '@/services/country-instability';
 import { getTheaterPostureSummaries } from '@/services/military-surge';
 import { isMobileDevice } from '@/utils';
@@ -349,7 +350,8 @@ export class InsightsPanel extends Panel {
       }
 
       // Cap titles sent to AI at 5 to reduce entity conflation in small models
-      const titles = importantClusters.slice(0, 5).map(c => c.primaryTitle);
+      // Strip OREF translation labels (ALERT[id]:, AREAS[id]:) that may leak into cluster titles
+      const titles = importantClusters.slice(0, 5).map(c => stripOrefLabels(c.primaryTitle));
 
       // Step 2: Analyze sentiment (browser-based, fast)
       this.setProgress(2, totalSteps, t('components.insights.analyzingSentiment'));

--- a/src/services/oref-alerts.ts
+++ b/src/services/oref-alerts.ts
@@ -114,6 +114,14 @@ function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+const OREF_LABEL_RE = /(?:ALERT|AREAS|DESC)\[[^\]]*\]:\s*/g;
+
+function stripOrefLabels(text: string): string {
+  return text.replace(OREF_LABEL_RE, '').trim();
+}
+
+export { stripOrefLabels };
+
 function buildTranslationPrompt(alerts: OrefAlert[]): string {
   const lines: string[] = [];
   for (const a of alerts) {
@@ -144,9 +152,9 @@ function parseTranslationResponse(raw: string, alerts: OrefAlert[]): void {
     }
     if (title === null && areas === null && desc === null) continue;
     const entry = {
-      title: title && !hasHebrew(title) ? title : staticTranslate(alert.title),
-      data: areas && !areas.some(hasHebrew) ? areas : alert.data.map(d => locationTranslator ? locationTranslator(staticTranslate(d)) : staticTranslate(d)),
-      desc: desc && !hasHebrew(desc) ? desc : staticTranslate(alert.desc),
+      title: stripOrefLabels(title && !hasHebrew(title) ? title : staticTranslate(alert.title)),
+      data: (areas && !areas.some(hasHebrew) ? areas : alert.data.map(d => locationTranslator ? locationTranslator(staticTranslate(d)) : staticTranslate(d))).map(stripOrefLabels),
+      desc: stripOrefLabels(desc && !hasHebrew(desc) ? desc : staticTranslate(alert.desc)),
     };
     translationCache.set(alert.id, entry);
   }


### PR DESCRIPTION
## Summary
- OREF alert translation uses `ALERT[id]:`/`AREAS[id]:`/`DESC[id]:` labels to structure the LLM translation prompt. These labels were leaking into the World Brief, appearing verbatim in the AI summary.
- Adds `stripOrefLabels()` regex sanitizer that removes these label patterns from text.
- Applied in two layers: inside `parseTranslationResponse` (defense-in-depth) and on cluster titles before they reach `generateSummary()`.

## Test plan
- [ ] Trigger an OREF siren alert (or use test data) and verify the World Brief no longer shows `ALERT[...]:`/`AREAS[...]:` bracket text
- [ ] Verify OREF Sirens panel still displays translated alert titles and locations correctly
- [ ] Verify `tsc --noEmit` passes (confirmed locally)