### PR TITLE
ci(hooks): add CJS syntax check to pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,5 +4,10 @@ npm run typecheck || exit 1
 echo "Running API type check..."
 npm run typecheck:api || exit 1
 
+echo "Running CJS syntax check..."
+for f in scripts/*.cjs; do
+  [ -f "$f" ] && node -c "$f" || exit 1
+done
+
 echo "Running version sync check..."
 npm run version:check || exit 1


### PR DESCRIPTION
## Summary
- `tsc --noEmit` skips `.cjs` files entirely — duplicate `const` declarations (like the crash fixed in #766) pass undetected
- Adds `node -c` validation for all `scripts/*.cjs` files to the pre-push hook, catching JS syntax errors before they reach Railway

## Test plan
- [x] `node -c scripts/*.cjs` passes locally
- [x] Pre-push hook runs successfully with the new check