### PR TITLE
perf(api): increase CDN cache TTLs to reduce Vercel + Upstash costs

### DIFF
--- a/api/ais-snapshot.js
+++ b/api/ais-snapshot.js
@@ -82,9 +82,9 @@ export default async function handler(req) {
     const headers = {
       'Content-Type': response.headers.get('content-type') || 'application/json',
       'Cache-Control': isSuccess
-        ? 'public, max-age=60, s-maxage=180, stale-while-revalidate=300, stale-if-error=900'
+        ? 'public, max-age=60, s-maxage=300, stale-while-revalidate=600, stale-if-error=900'
         : 'public, max-age=10, s-maxage=30, stale-while-revalidate=120',
-      ...(isSuccess && { 'CDN-Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300, stale-if-error=900' }),
+      ...(isSuccess && { 'CDN-Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600, stale-if-error=900' }),
       ...corsHeaders,
     };
 

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -103,7 +103,7 @@ export default async function handler(req) {
     headers: {
       ...cors,
       'Content-Type': 'application/json',
-      'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30',
+      'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',
     },
   });
 }

--- a/api/download.js
+++ b/api/download.js
@@ -74,7 +74,7 @@ export default async function handler(req) {
       status: 302,
       headers: {
         'Location': asset.browser_download_url,
-        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=60',
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=60, stale-if-error=600',
       },
     });
   } catch {

--- a/api/geo.js
+++ b/api/geo.js
@@ -6,7 +6,7 @@ export default function handler(req) {
     status: 200,
     headers: {
       'Content-Type': 'application/json',
-      'Cache-Control': 'public, max-age=300',
+      'Cache-Control': 'public, max-age=300, s-maxage=3600, stale-if-error=3600',
       'Access-Control-Allow-Origin': '*',
     },
   });

--- a/api/gpsjam.js
+++ b/api/gpsjam.js
@@ -136,7 +136,7 @@ export default async function handler(req) {
       status: 200,
       headers: {
         'Content-Type': 'application/json',
-        'Cache-Control': 's-maxage=3600, stale-while-revalidate=1800',
+        'Cache-Control': 's-maxage=3600, stale-while-revalidate=1800, stale-if-error=3600',
         ...corsHeaders,
       },
     });

--- a/api/opensky.js
+++ b/api/opensky.js
@@ -67,7 +67,7 @@ export default async function handler(req) {
     const body = await response.text();
     const headers = {
       'Content-Type': response.headers.get('content-type') || 'application/json',
-      'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=60',
+      'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=60, stale-if-error=300',
       ...corsHeaders,
     };
     const xCache = response.headers.get('x-cache');

--- a/api/oref-alerts.js
+++ b/api/oref-alerts.js
@@ -64,8 +64,8 @@ export default async function handler(req) {
 
       if (response.ok) {
         const cacheControl = isHistory
-          ? 'public, max-age=30, s-maxage=30, stale-while-revalidate=10'
-          : 'public, max-age=5, s-maxage=5, stale-while-revalidate=3';
+          ? 'public, max-age=60, s-maxage=180, stale-while-revalidate=60, stale-if-error=600'
+          : 'public, max-age=60, s-maxage=180, stale-while-revalidate=60, stale-if-error=600';
         return new Response(await response.text(), {
           status: 200,
           headers: {

--- a/api/telegram-feed.js
+++ b/api/telegram-feed.js
@@ -68,7 +68,7 @@ export default async function handler(req) {
       headers: {
         'Content-Type': res.headers.get('content-type') || 'application/json',
         // Short cache. Telegram is near-real-time.
-        'Cache-Control': 'public, max-age=10',
+        'Cache-Control': 'public, max-age=60, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',
         ...cors,
       },
     });

--- a/api/version.js
+++ b/api/version.js
@@ -32,7 +32,7 @@ export default async function handler() {
       status: 200,
       headers: {
         'Content-Type': 'application/json',
-        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=60',
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=60, stale-if-error=3600',
         'Access-Control-Allow-Origin': '*',
       },
     });


### PR DESCRIPTION
## Summary
- Increase `s-maxage` across 9 edge functions to let CDN absorb more traffic, reducing both Vercel execution costs and Upstash Redis read counts
- Add `stale-if-error` to all endpoints missing it, so upstream failures serve stale CDN data instead of burning Vercel invocations
- Fix two endpoints (`telegram-feed.js`, `geo.js`) that had **no `s-maxage` at all** — every request hit Vercel

## Changes

| File | `s-maxage` | `stale-if-error` |
|---|---|---|
| `bootstrap.js` | 60→600 | added 900 |
| `ais-snapshot.js` | 180→300 | already had 900 |
| `oref-alerts.js` | 5→180 | added 600 |
| `telegram-feed.js` | 0→600 | added 900 |
| `geo.js` | 0→3600 | added 3600 |
| `gpsjam.js` | unchanged | added 3600 |
| `opensky.js` | unchanged | added 300 |
| `version.js` | unchanged | added 3600 |
| `download.js` | unchanged | added 600 |

## Test plan
- [ ] Verify Vercel deployment succeeds
- [ ] Spot-check response headers on `/api/bootstrap`, `/api/telegram-feed`, `/api/geo` to confirm new `Cache-Control` values
- [ ] Monitor Upstash Redis read count over 24h — expect significant drop on bootstrap reads
- [ ] Monitor Vercel function invocation count — expect drop on telegram-feed and geo