### PR TITLE
fix(runtime): route all /api/* through CDN edge

### DIFF
--- a/api/geo.js
+++ b/api/geo.js
@@ -1,7 +1,8 @@
 export const config = { runtime: 'edge' };
 
 export default function handler(req) {
-  const country = req.headers.get('x-vercel-ip-country') || 'XX';
+  const cfCountry = req.headers.get('cf-ipcountry');
+  const country = (cfCountry && cfCountry !== 'T1' ? cfCountry : null) || req.headers.get('x-vercel-ip-country') || 'XX';
   return new Response(JSON.stringify({ country }), {
     status: 200,
     headers: {

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -387,12 +387,6 @@ export function installRuntimeFetchPatch(): void {
   (window as unknown as Record<string, unknown>).__wmFetchPatched = true;
 }
 
-const WEB_REDIRECT_PATHS = [
-  /^\/api\/[^/]+\/v1\//,
-  /^\/api\/rss-proxy(?:\?|$)/,
-  /^\/api\/polymarket(?:\?|$)/,
-  /^\/api\/ais-snapshot(?:\?|$)/,
-];
 const ALLOWED_REDIRECT_HOSTS = /^https:\/\/([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*worldmonitor\.app(:\d+)?$/;
 
 function isAllowedRedirectTarget(url: string): boolean {
@@ -415,8 +409,8 @@ export function installWebApiRedirect(): void {
 
   const nativeFetch = window.fetch.bind(window);
   const API_BASE = WS_API_URL;
-  const shouldRedirectPath = (pathWithQuery: string): boolean => WEB_REDIRECT_PATHS.some((pattern) => pattern.test(pathWithQuery));
-  const shouldFallbackToOrigin = (status: number): boolean => status === 404 || status === 405 || status === 501;
+  const shouldRedirectPath = (pathWithQuery: string): boolean => pathWithQuery.startsWith('/api/');
+  const shouldFallbackToOrigin = (status: number): boolean => status === 404 || status === 405 || status === 501 || status === 502 || status === 503;
   const fetchWithRedirectFallback = async (
     redirectedInput: RequestInfo | URL,
     originalInput: RequestInfo | URL,


### PR DESCRIPTION
## Summary
- `installWebApiRedirect()` was active (`VITE_WS_API_URL` already set) but the path allowlist only covered 4 patterns: `/api/*/v1/*`, `/api/rss-proxy`, `/api/polymarket`, `/api/ais-snapshot`
- All other `/api/*` calls (`/api/bootstrap` on every page load, `/api/opensky`, `/api/gpsjam`, `/api/oref-alerts`, `/api/fwdstart`, etc.) bypassed CDN and hit Vercel directly
- Replace allowlist regex array with catch-all `startsWith('/api/')` — all API calls now route through Cloudflare edge
- Add 502/503 to CDN fallback so edge outages gracefully degrade to direct Vercel
- `geo.js`: prefer Cloudflare `cf-ipcountry` header (works through CDN), filter Tor exit nodes (`T1`), fall back to `x-vercel-ip-country`

## Test plan
- [ ] After deploy, open Network tab → confirm `/api/bootstrap` calls go to `api.worldmonitor.app` not `worldmonitor.app`
- [ ] Verify `/api/geo` still returns correct country code through CDN
- [ ] Monitor Vercel usage dashboard for bandwidth/execution drop