### PR TITLE
refactor(api): extract shared relay helper into _relay.js

### DIFF
--- a/api/_relay.js
+++ b/api/_relay.js
@@ -1,0 +1,120 @@
+import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { validateApiKey } from './_api-key.js';
+import { checkRateLimit } from './_rate-limit.js';
+
+export function getRelayBaseUrl() {
+  const relayUrl = process.env.WS_RELAY_URL;
+  if (!relayUrl) return null;
+  return relayUrl.replace('wss://', 'https://').replace('ws://', 'http://').replace(/\/$/, '');
+}
+
+export function getRelayHeaders(baseHeaders = {}) {
+  const headers = { ...baseHeaders };
+  const relaySecret = process.env.RELAY_SHARED_SECRET || '';
+  if (relaySecret) {
+    const relayHeader = (process.env.RELAY_AUTH_HEADER || 'x-relay-key').toLowerCase();
+    headers[relayHeader] = relaySecret;
+    headers.Authorization = `Bearer ${relaySecret}`;
+  }
+  return headers;
+}
+
+export async function fetchWithTimeout(url, options, timeoutMs = 15000) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function createRelayHandler(cfg) {
+  return async function handler(req) {
+    const corsHeaders = getCorsHeaders(req, 'GET, OPTIONS');
+
+    if (isDisallowedOrigin(req)) {
+      return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
+        status: 403,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders },
+      });
+    }
+
+    if (req.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders });
+    }
+    if (req.method !== 'GET') {
+      return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+        status: 405,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders },
+      });
+    }
+
+    if (cfg.requireApiKey) {
+      const keyCheck = validateApiKey(req);
+      if (keyCheck.required && !keyCheck.valid) {
+        return new Response(JSON.stringify({ error: keyCheck.error }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json', ...corsHeaders },
+        });
+      }
+    }
+
+    if (cfg.requireRateLimit) {
+      const rateLimitResponse = await checkRateLimit(req, corsHeaders);
+      if (rateLimitResponse) return rateLimitResponse;
+    }
+
+    const relayBaseUrl = getRelayBaseUrl();
+    if (!relayBaseUrl) {
+      if (cfg.fallback) return cfg.fallback(req, corsHeaders);
+      return new Response(JSON.stringify({ error: 'WS_RELAY_URL is not configured' }), {
+        status: 503,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders },
+      });
+    }
+
+    try {
+      const requestUrl = new URL(req.url);
+      const path = typeof cfg.buildRelayPath === 'function'
+        ? cfg.buildRelayPath(req, requestUrl)
+        : cfg.relayPath;
+      const search = cfg.forwardSearch !== false ? (requestUrl.search || '') : '';
+      const relayUrl = `${relayBaseUrl}${path}${search}`;
+
+      const reqHeaders = cfg.requestHeaders || { Accept: 'application/json' };
+      const response = await fetchWithTimeout(relayUrl, {
+        headers: getRelayHeaders(reqHeaders),
+      }, cfg.timeout || 15000);
+
+      if (cfg.onlyOk && !response.ok && cfg.fallback) {
+        return cfg.fallback(req, corsHeaders);
+      }
+
+      const extraHeaders = cfg.extraHeaders ? cfg.extraHeaders(response) : {};
+      const body = await response.text();
+      const isSuccess = response.status >= 200 && response.status < 300;
+      const cacheHeaders = cfg.cacheHeaders ? cfg.cacheHeaders(isSuccess) : {};
+
+      return new Response(body, {
+        status: response.status,
+        headers: {
+          'Content-Type': response.headers.get('content-type') || 'application/json',
+          ...cacheHeaders,
+          ...extraHeaders,
+          ...corsHeaders,
+        },
+      });
+    } catch (error) {
+      if (cfg.fallback) return cfg.fallback(req, corsHeaders);
+      const isTimeout = error?.name === 'AbortError';
+      return new Response(JSON.stringify({
+        error: isTimeout ? 'Relay timeout' : 'Relay request failed',
+        details: error?.message || String(error),
+      }), {
+        status: isTimeout ? 504 : 502,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders },
+      });
+    }
+  };
+}

--- a/api/ais-snapshot.js
+++ b/api/ais-snapshot.js
@@ -1,105 +1,16 @@
-import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
-import { validateApiKey } from './_api-key.js';
-import { checkRateLimit } from './_rate-limit.js';
+import { createRelayHandler } from './_relay.js';
 
 export const config = { runtime: 'edge' };
 
-function getRelayBaseUrl() {
-  const relayUrl = process.env.WS_RELAY_URL;
-  if (!relayUrl) return null;
-  return relayUrl.replace('wss://', 'https://').replace('ws://', 'http://').replace(/\/$/, '');
-}
-
-function getRelayHeaders(baseHeaders = {}) {
-  const headers = { ...baseHeaders };
-  const relaySecret = process.env.RELAY_SHARED_SECRET || '';
-  if (relaySecret) {
-    const relayHeader = (process.env.RELAY_AUTH_HEADER || 'x-relay-key').toLowerCase();
-    headers[relayHeader] = relaySecret;
-    headers.Authorization = `Bearer ${relaySecret}`;
-  }
-  return headers;
-}
-
-async function fetchWithTimeout(url, options, timeoutMs = 15000) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(url, { ...options, signal: controller.signal });
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-export default async function handler(req) {
-  const corsHeaders = getCorsHeaders(req, 'GET, OPTIONS');
-
-  if (isDisallowedOrigin(req)) {
-    return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: corsHeaders });
-  }
-  if (req.method !== 'GET') {
-    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
-      status: 405,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-
-  const keyCheck = validateApiKey(req);
-  if (keyCheck.required && !keyCheck.valid) {
-    return new Response(JSON.stringify({ error: keyCheck.error }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-
-  const rateLimitResponse = await checkRateLimit(req, corsHeaders);
-  if (rateLimitResponse) return rateLimitResponse;
-
-  const relayBaseUrl = getRelayBaseUrl();
-  if (!relayBaseUrl) {
-    return new Response(JSON.stringify({ error: 'WS_RELAY_URL is not configured' }), {
-      status: 503,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-
-  try {
-    const requestUrl = new URL(req.url);
-    const relayUrl = `${relayBaseUrl}/ais/snapshot${requestUrl.search || ''}`;
-    const response = await fetchWithTimeout(relayUrl, {
-      headers: getRelayHeaders({ Accept: 'application/json' }),
-    }, 12000);
-
-    const body = await response.text();
-    const isSuccess = response.status >= 200 && response.status < 300;
-    const headers = {
-      'Content-Type': response.headers.get('content-type') || 'application/json',
-      'Cache-Control': isSuccess
-        ? 'public, max-age=60, s-maxage=300, stale-while-revalidate=600, stale-if-error=900'
-        : 'public, max-age=10, s-maxage=30, stale-while-revalidate=120',
-      ...(isSuccess && { 'CDN-Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600, stale-if-error=900' }),
-      ...corsHeaders,
-    };
-
-    return new Response(body, {
-      status: response.status,
-      headers,
-    });
-  } catch (error) {
-    const isTimeout = error?.name === 'AbortError';
-    return new Response(JSON.stringify({
-      error: isTimeout ? 'Relay timeout' : 'Relay request failed',
-      details: error?.message || String(error),
-    }), {
-      status: isTimeout ? 504 : 502,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-}
+export default createRelayHandler({
+  relayPath: '/ais/snapshot',
+  timeout: 12000,
+  requireApiKey: true,
+  requireRateLimit: true,
+  cacheHeaders: (ok) => ({
+    'Cache-Control': ok
+      ? 'public, max-age=60, s-maxage=300, stale-while-revalidate=600, stale-if-error=900'
+      : 'public, max-age=10, s-maxage=30, stale-while-revalidate=120',
+    ...(ok && { 'CDN-Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600, stale-if-error=900' }),
+  }),
+});

--- a/api/opensky.js
+++ b/api/opensky.js
@@ -1,90 +1,15 @@
-import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { createRelayHandler } from './_relay.js';
 
 export const config = { runtime: 'edge' };
 
-function getRelayBaseUrl() {
-  const relayUrl = process.env.WS_RELAY_URL;
-  if (!relayUrl) return null;
-  return relayUrl.replace('wss://', 'https://').replace('ws://', 'http://').replace(/\/$/, '');
-}
-
-function getRelayHeaders(baseHeaders = {}) {
-  const headers = { ...baseHeaders };
-  const relaySecret = process.env.RELAY_SHARED_SECRET || '';
-  if (relaySecret) {
-    const relayHeader = (process.env.RELAY_AUTH_HEADER || 'x-relay-key').toLowerCase();
-    headers[relayHeader] = relaySecret;
-    headers.Authorization = `Bearer ${relaySecret}`;
-  }
-  return headers;
-}
-
-async function fetchWithTimeout(url, options, timeoutMs = 20000) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(url, { ...options, signal: controller.signal });
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-export default async function handler(req) {
-  const corsHeaders = getCorsHeaders(req, 'GET, OPTIONS');
-
-  if (isDisallowedOrigin(req)) {
-    return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: corsHeaders });
-  }
-  if (req.method !== 'GET') {
-    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
-      status: 405,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-
-  const relayBaseUrl = getRelayBaseUrl();
-  if (!relayBaseUrl) {
-    return new Response(JSON.stringify({ error: 'WS_RELAY_URL is not configured' }), {
-      status: 503,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-
-  try {
-    const requestUrl = new URL(req.url);
-    const relayUrl = `${relayBaseUrl}/opensky${requestUrl.search || ''}`;
-    const response = await fetchWithTimeout(relayUrl, {
-      headers: getRelayHeaders({ Accept: 'application/json' }),
-    });
-
-    const body = await response.text();
-    const headers = {
-      'Content-Type': response.headers.get('content-type') || 'application/json',
-      'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=60, stale-if-error=300',
-      ...corsHeaders,
-    };
+export default createRelayHandler({
+  relayPath: '/opensky',
+  timeout: 20000,
+  cacheHeaders: () => ({
+    'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=60, stale-if-error=300',
+  }),
+  extraHeaders: (response) => {
     const xCache = response.headers.get('x-cache');
-    if (xCache) headers['X-Cache'] = xCache;
-
-    return new Response(body, {
-      status: response.status,
-      headers,
-    });
-  } catch (error) {
-    const isTimeout = error?.name === 'AbortError';
-    return new Response(JSON.stringify({
-      error: isTimeout ? 'Relay timeout' : 'Relay request failed',
-      details: error?.message || String(error),
-    }), {
-      status: isTimeout ? 504 : 502,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-}
+    return xCache ? { 'X-Cache': xCache } : {};
+  },
+});

--- a/api/oref-alerts.js
+++ b/api/oref-alerts.js
@@ -1,86 +1,19 @@
-import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { createRelayHandler } from './_relay.js';
 
 export const config = { runtime: 'edge' };
 
-function getRelayBaseUrl() {
-  const relayUrl = process.env.WS_RELAY_URL;
-  if (!relayUrl) return null;
-  return relayUrl.replace('wss://', 'https://').replace('ws://', 'http://').replace(/\/$/, '');
-}
-
-function getRelayHeaders(baseHeaders = {}) {
-  const headers = { ...baseHeaders };
-  const relaySecret = process.env.RELAY_SHARED_SECRET || '';
-  if (relaySecret) {
-    const relayHeader = (process.env.RELAY_AUTH_HEADER || 'x-relay-key').toLowerCase();
-    headers[relayHeader] = relaySecret;
-    headers.Authorization = `Bearer ${relaySecret}`;
-  }
-  return headers;
-}
-
-async function fetchWithTimeout(url, options, timeoutMs = 15000) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(url, { ...options, signal: controller.signal });
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-export default async function handler(req) {
-  const corsHeaders = getCorsHeaders(req, 'GET, OPTIONS');
-
-  if (isDisallowedOrigin(req)) {
-    return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: corsHeaders });
-  }
-  if (req.method !== 'GET') {
-    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
-      status: 405,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-
-  const requestUrl = new URL(req.url);
-  const endpoint = requestUrl.searchParams.get('endpoint');
-  const isHistory = endpoint === 'history';
-
-  const relayBaseUrl = getRelayBaseUrl();
-
-  if (relayBaseUrl) {
-    try {
-      const relayPath = isHistory ? '/oref/history' : '/oref/alerts';
-      const response = await fetchWithTimeout(`${relayBaseUrl}${relayPath}`, {
-        headers: getRelayHeaders({ Accept: 'application/json' }),
-      }, 12000);
-
-      if (response.ok) {
-        const cacheControl = isHistory
-          ? 'public, max-age=60, s-maxage=180, stale-while-revalidate=60, stale-if-error=600'
-          : 'public, max-age=60, s-maxage=180, stale-while-revalidate=60, stale-if-error=600';
-        return new Response(await response.text(), {
-          status: 200,
-          headers: {
-            'Content-Type': 'application/json',
-            'Cache-Control': cacheControl,
-            ...corsHeaders,
-          },
-        });
-      }
-    } catch {
-      // Relay failed
-    }
-  }
-
-  return new Response(JSON.stringify({
+export default createRelayHandler({
+  buildRelayPath: (_req, url) => {
+    const endpoint = url.searchParams.get('endpoint');
+    return endpoint === 'history' ? '/oref/history' : '/oref/alerts';
+  },
+  forwardSearch: false,
+  timeout: 12000,
+  onlyOk: true,
+  cacheHeaders: () => ({
+    'Cache-Control': 'public, max-age=60, s-maxage=180, stale-while-revalidate=60, stale-if-error=600',
+  }),
+  fallback: (_req, corsHeaders) => new Response(JSON.stringify({
     configured: false,
     alerts: [],
     historyCount24h: 0,
@@ -89,5 +22,5 @@ export default async function handler(req) {
   }), {
     status: 503,
     headers: { 'Content-Type': 'application/json', ...corsHeaders },
-  });
-}
+  }),
+});

--- a/api/polymarket.js
+++ b/api/polymarket.js
@@ -1,105 +1,16 @@
-import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
-import { validateApiKey } from './_api-key.js';
-import { checkRateLimit } from './_rate-limit.js';
+import { createRelayHandler } from './_relay.js';
 
 export const config = { runtime: 'edge' };
 
-function getRelayBaseUrl() {
-  const relayUrl = process.env.WS_RELAY_URL;
-  if (!relayUrl) return null;
-  return relayUrl.replace('wss://', 'https://').replace('ws://', 'http://').replace(/\/$/, '');
-}
-
-function getRelayHeaders(baseHeaders = {}) {
-  const headers = { ...baseHeaders };
-  const relaySecret = process.env.RELAY_SHARED_SECRET || '';
-  if (relaySecret) {
-    const relayHeader = (process.env.RELAY_AUTH_HEADER || 'x-relay-key').toLowerCase();
-    headers[relayHeader] = relaySecret;
-    headers.Authorization = `Bearer ${relaySecret}`;
-  }
-  return headers;
-}
-
-async function fetchWithTimeout(url, options, timeoutMs = 15000) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(url, { ...options, signal: controller.signal });
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-export default async function handler(req) {
-  const corsHeaders = getCorsHeaders(req, 'GET, OPTIONS');
-
-  if (isDisallowedOrigin(req)) {
-    return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: corsHeaders });
-  }
-  if (req.method !== 'GET') {
-    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
-      status: 405,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-
-  const keyCheck = validateApiKey(req);
-  if (keyCheck.required && !keyCheck.valid) {
-    return new Response(JSON.stringify({ error: keyCheck.error }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-
-  const rateLimitResponse = await checkRateLimit(req, corsHeaders);
-  if (rateLimitResponse) return rateLimitResponse;
-
-  const relayBaseUrl = getRelayBaseUrl();
-  if (!relayBaseUrl) {
-    return new Response(JSON.stringify({ error: 'WS_RELAY_URL is not configured' }), {
-      status: 503,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-
-  try {
-    const requestUrl = new URL(req.url);
-    const relayUrl = `${relayBaseUrl}/polymarket${requestUrl.search || ''}`;
-    const response = await fetchWithTimeout(relayUrl, {
-      headers: getRelayHeaders({ Accept: 'application/json' }),
-    }, 15000);
-
-    const body = await response.text();
-    const isSuccess = response.status >= 200 && response.status < 300;
-    const headers = {
-      'Content-Type': response.headers.get('content-type') || 'application/json',
-      'Cache-Control': isSuccess
-        ? 'public, max-age=120, s-maxage=300, stale-while-revalidate=900, stale-if-error=1800'
-        : 'public, max-age=10, s-maxage=30, stale-while-revalidate=120',
-      ...(isSuccess && { 'CDN-Cache-Control': 'public, s-maxage=300, stale-while-revalidate=900, stale-if-error=1800' }),
-      ...corsHeaders,
-    };
-
-    return new Response(body, {
-      status: response.status,
-      headers,
-    });
-  } catch (error) {
-    const isTimeout = error?.name === 'AbortError';
-    return new Response(JSON.stringify({
-      error: isTimeout ? 'Relay timeout' : 'Relay request failed',
-      details: error?.message || String(error),
-    }), {
-      status: isTimeout ? 504 : 502,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    });
-  }
-}
+export default createRelayHandler({
+  relayPath: '/polymarket',
+  timeout: 15000,
+  requireApiKey: true,
+  requireRateLimit: true,
+  cacheHeaders: (ok) => ({
+    'Cache-Control': ok
+      ? 'public, max-age=120, s-maxage=300, stale-while-revalidate=900, stale-if-error=1800'
+      : 'public, max-age=10, s-maxage=30, stale-while-revalidate=120',
+    ...(ok && { 'CDN-Cache-Control': 'public, s-maxage=300, stale-while-revalidate=900, stale-if-error=1800' }),
+  }),
+});

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -1,38 +1,9 @@
-// Non-sebuf: returns XML/HTML, stays as standalone Vercel function
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { validateApiKey } from './_api-key.js';
 import { checkRateLimit } from './_rate-limit.js';
+import { getRelayBaseUrl, getRelayHeaders, fetchWithTimeout } from './_relay.js';
 
 export const config = { runtime: 'edge' };
-
-// Fetch with timeout
-async function fetchWithTimeout(url, options, timeoutMs = 15000) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const response = await fetch(url, { ...options, signal: controller.signal });
-    return response;
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-function getRelayBaseUrl() {
-  const relayUrl = process.env.WS_RELAY_URL || '';
-  if (!relayUrl) return '';
-  return relayUrl.replace('wss://', 'https://').replace('ws://', 'http://').replace(/\/$/, '');
-}
-
-function getRelayHeaders(baseHeaders = {}) {
-  const headers = { ...baseHeaders };
-  const relaySecret = process.env.RELAY_SHARED_SECRET || '';
-  if (relaySecret) {
-    const relayHeader = (process.env.RELAY_AUTH_HEADER || 'x-relay-key').toLowerCase();
-    headers[relayHeader] = relaySecret;
-    headers.Authorization = `Bearer ${relaySecret}`;
-  }
-  return headers;
-}
 
 async function fetchViaRailway(feedUrl, timeoutMs) {
   const relayBaseUrl = getRelayBaseUrl();

--- a/api/telegram-feed.js
+++ b/api/telegram-feed.js
@@ -1,85 +1,21 @@
-// Telegram feed proxy (web)
-// Fetches Telegram Early Signals from the Railway relay (stateful MTProto lives there).
-
-import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { createRelayHandler } from './_relay.js';
 
 export const config = { runtime: 'edge' };
 
-async function fetchWithTimeout(url, options, timeoutMs = 25000) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(url, { ...options, signal: controller.signal });
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-export default async function handler(req) {
-  const cors = getCorsHeaders(req, 'GET, OPTIONS');
-
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: cors });
-  }
-
-  if (isDisallowedOrigin(req)) {
-    return new Response(JSON.stringify({ error: 'Origin not allowed' }), { status: 403, headers: cors });
-  }
-
-  let relay = process.env.WS_RELAY_URL;
-  if (!relay) {
-    return new Response(JSON.stringify({ error: 'WS_RELAY_URL not configured' }), {
-      status: 503,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
-  }
-
-  // Guard: WS_RELAY_URL should be HTTP(S) for server-side fetches.
-  // If someone accidentally sets a ws:// or wss:// URL, normalize it.
-  if (relay.startsWith('wss://')) relay = relay.replace('wss://', 'https://');
-  if (relay.startsWith('ws://')) relay = relay.replace('ws://', 'http://');
-
-  const url = new URL(req.url);
-  const limit = Math.max(1, Math.min(200, parseInt(url.searchParams.get('limit') || '50', 10) || 50));
-  const topic = (url.searchParams.get('topic') || '').trim();
-  const channel = (url.searchParams.get('channel') || '').trim();
-
-  const relayUrl = new URL('/telegram/feed', relay);
-  relayUrl.searchParams.set('limit', String(limit));
-  if (topic) relayUrl.searchParams.set('topic', topic);
-  if (channel) relayUrl.searchParams.set('channel', channel);
-
-  const fetchHeaders = { 'Accept': 'application/json' };
-  const relaySecret = process.env.RELAY_SHARED_SECRET || '';
-  if (relaySecret) {
-    const relayHeader = (process.env.RELAY_AUTH_HEADER || 'x-relay-key').toLowerCase();
-    fetchHeaders[relayHeader] = relaySecret;
-    fetchHeaders.Authorization = `Bearer ${relaySecret}`;
-  }
-
-  try {
-    const res = await fetchWithTimeout(relayUrl.toString(), {
-      headers: fetchHeaders,
-    }, 25000);
-
-    const text = await res.text();
-    return new Response(text, {
-      status: res.status,
-      headers: {
-        'Content-Type': res.headers.get('content-type') || 'application/json',
-        // Short cache. Telegram is near-real-time.
-        'Cache-Control': 'public, max-age=60, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',
-        ...cors,
-      },
-    });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    const isAbort = err && (err.name === 'AbortError' || /aborted/i.test(msg));
-    return new Response(JSON.stringify({
-      error: isAbort ? 'Telegram relay request timed out' : 'Telegram relay fetch failed',
-    }), {
-      status: isAbort ? 504 : 502,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
-  }
-}
+export default createRelayHandler({
+  buildRelayPath: (_req, url) => {
+    const limit = Math.max(1, Math.min(200, parseInt(url.searchParams.get('limit') || '50', 10) || 50));
+    const topic = (url.searchParams.get('topic') || '').trim();
+    const channel = (url.searchParams.get('channel') || '').trim();
+    const params = new URLSearchParams();
+    params.set('limit', String(limit));
+    if (topic) params.set('topic', topic);
+    if (channel) params.set('channel', channel);
+    return `/telegram/feed?${params}`;
+  },
+  forwardSearch: false,
+  timeout: 25000,
+  cacheHeaders: () => ({
+    'Cache-Control': 'public, max-age=60, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',
+  }),
+});

--- a/api/youtube/live.js
+++ b/api/youtube/live.js
@@ -2,25 +2,9 @@
 // Proxies to Railway relay which uses residential proxy for YouTube scraping
 
 import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+import { getRelayBaseUrl, getRelayHeaders } from '../_relay.js';
 
 export const config = { runtime: 'edge' };
-
-function getRelayBaseUrl() {
-  const relayUrl = process.env.WS_RELAY_URL;
-  if (!relayUrl) return null;
-  return relayUrl.replace('wss://', 'https://').replace('ws://', 'http://').replace(/\/$/, '');
-}
-
-function getRelayHeaders(baseHeaders = {}) {
-  const headers = { ...baseHeaders };
-  const relaySecret = process.env.RELAY_SHARED_SECRET || '';
-  if (relaySecret) {
-    const relayHeader = (process.env.RELAY_AUTH_HEADER || 'x-relay-key').toLowerCase();
-    headers[relayHeader] = relaySecret;
-    headers.Authorization = `Bearer ${relaySecret}`;
-  }
-  return headers;
-}
 
 export default async function handler(request) {
   const cors = getCorsHeaders(request);

--- a/tests/relay-helper.test.mjs
+++ b/tests/relay-helper.test.mjs
@@ -1,0 +1,369 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+process.env.WS_RELAY_URL = 'wss://relay.example.com';
+process.env.RELAY_SHARED_SECRET = 'test-secret';
+
+const { getRelayBaseUrl, getRelayHeaders, fetchWithTimeout, createRelayHandler } = await import('../api/_relay.js');
+
+function makeRequest(url, opts = {}) {
+  return new Request(url, {
+    method: opts.method || 'GET',
+    headers: new Headers({
+      Origin: 'https://worldmonitor.app',
+      ...opts.headers,
+    }),
+  });
+}
+
+function mockFetch(handler) {
+  globalThis.fetch = handler;
+}
+
+function mockFetchOk(body = '{"ok":true}', headers = {}) {
+  mockFetch(async () => new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  }));
+}
+
+function mockFetchStatus(status, body = '{"error":"upstream"}') {
+  mockFetch(async () => new Response(body, {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  }));
+}
+
+function mockFetchError(message = 'Network error') {
+  mockFetch(async () => { throw new Error(message); });
+}
+
+describe('getRelayBaseUrl', () => {
+  afterEach(restoreEnv);
+
+  it('converts wss:// to https://', () => {
+    process.env.WS_RELAY_URL = 'wss://relay.example.com';
+    assert.equal(getRelayBaseUrl(), 'https://relay.example.com');
+  });
+
+  it('converts ws:// to http://', () => {
+    process.env.WS_RELAY_URL = 'ws://relay.example.com';
+    assert.equal(getRelayBaseUrl(), 'http://relay.example.com');
+  });
+
+  it('strips trailing slash', () => {
+    process.env.WS_RELAY_URL = 'https://relay.example.com/';
+    assert.equal(getRelayBaseUrl(), 'https://relay.example.com');
+  });
+
+  it('returns null when not set', () => {
+    delete process.env.WS_RELAY_URL;
+    assert.equal(getRelayBaseUrl(), null);
+  });
+
+  it('returns null for empty string', () => {
+    process.env.WS_RELAY_URL = '';
+    assert.equal(getRelayBaseUrl(), null);
+  });
+});
+
+describe('getRelayHeaders', () => {
+  afterEach(restoreEnv);
+
+  it('injects relay secret and Authorization', () => {
+    process.env.RELAY_SHARED_SECRET = 'my-secret';
+    delete process.env.RELAY_AUTH_HEADER;
+    const headers = getRelayHeaders({ Accept: 'application/json' });
+    assert.equal(headers.Accept, 'application/json');
+    assert.equal(headers['x-relay-key'], 'my-secret');
+    assert.equal(headers.Authorization, 'Bearer my-secret');
+  });
+
+  it('uses custom auth header name', () => {
+    process.env.RELAY_SHARED_SECRET = 'sec';
+    process.env.RELAY_AUTH_HEADER = 'X-Custom-Key';
+    const headers = getRelayHeaders();
+    assert.equal(headers['x-custom-key'], 'sec');
+    assert.equal(headers.Authorization, 'Bearer sec');
+  });
+
+  it('returns base headers only when no secret', () => {
+    process.env.RELAY_SHARED_SECRET = '';
+    const headers = getRelayHeaders({ Accept: 'text/xml' });
+    assert.equal(headers.Accept, 'text/xml');
+    assert.equal(headers.Authorization, undefined);
+  });
+});
+
+describe('fetchWithTimeout', () => {
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it('returns response on success', async () => {
+    mockFetchOk('{"data":1}');
+    const res = await fetchWithTimeout('https://example.com', {}, 5000);
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), '{"data":1}');
+  });
+
+  it('aborts on timeout', async () => {
+    mockFetch((_url, opts) => new Promise((resolve, reject) => {
+      const timer = setTimeout(resolve, 5000);
+      opts?.signal?.addEventListener('abort', () => {
+        clearTimeout(timer);
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      });
+    }));
+    await assert.rejects(
+      () => fetchWithTimeout('https://example.com', {}, 50),
+      (err) => err.name === 'AbortError',
+    );
+  });
+});
+
+describe('createRelayHandler', () => {
+  beforeEach(() => {
+    process.env.WS_RELAY_URL = 'wss://relay.example.com';
+    process.env.RELAY_SHARED_SECRET = 'test-secret';
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    restoreEnv();
+  });
+
+  it('returns CORS headers on every response', async () => {
+    mockFetchOk();
+    const handler = createRelayHandler({ relayPath: '/test' });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test'));
+    assert.ok(res.headers.get('access-control-allow-origin'));
+    assert.ok(res.headers.get('vary'));
+  });
+
+  it('responds 204 to OPTIONS', async () => {
+    const handler = createRelayHandler({ relayPath: '/test' });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test', { method: 'OPTIONS' }));
+    assert.equal(res.status, 204);
+  });
+
+  it('responds 403 to disallowed origin', async () => {
+    const handler = createRelayHandler({ relayPath: '/test' });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test', {
+      headers: { Origin: 'https://evil.com' },
+    }));
+    assert.equal(res.status, 403);
+    const body = await res.json();
+    assert.equal(body.error, 'Origin not allowed');
+  });
+
+  it('responds 405 to non-GET', async () => {
+    const handler = createRelayHandler({ relayPath: '/test' });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test', { method: 'POST' }));
+    assert.equal(res.status, 405);
+  });
+
+  it('responds 401 when requireApiKey and no valid key', async () => {
+    process.env.WORLDMONITOR_VALID_KEYS = 'real-key-123';
+    const handler = createRelayHandler({ relayPath: '/test', requireApiKey: true });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test', {
+      headers: { Origin: 'https://tauri.localhost', 'X-WorldMonitor-Key': 'wrong-key' },
+    }));
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.equal(body.error, 'Invalid API key');
+  });
+
+  it('allows request when requireApiKey and key is valid', async () => {
+    process.env.WORLDMONITOR_VALID_KEYS = 'real-key-123';
+    mockFetchOk();
+    const handler = createRelayHandler({ relayPath: '/test', requireApiKey: true });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test', {
+      headers: { Origin: 'https://tauri.localhost', 'X-WorldMonitor-Key': 'real-key-123' },
+    }));
+    assert.equal(res.status, 200);
+  });
+
+  it('responds 503 when WS_RELAY_URL not set', async () => {
+    delete process.env.WS_RELAY_URL;
+    const handler = createRelayHandler({ relayPath: '/test' });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test'));
+    assert.equal(res.status, 503);
+    const body = await res.json();
+    assert.equal(body.error, 'WS_RELAY_URL is not configured');
+  });
+
+  it('proxies relay response with correct status and body', async () => {
+    mockFetchOk('{"items":[1,2,3]}');
+    const handler = createRelayHandler({ relayPath: '/data' });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/data'));
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), '{"items":[1,2,3]}');
+  });
+
+  it('forwards search params by default', async () => {
+    let capturedUrl;
+    mockFetch(async (url) => {
+      capturedUrl = url;
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+    const handler = createRelayHandler({ relayPath: '/test' });
+    await handler(makeRequest('https://worldmonitor.app/api/test?foo=bar&baz=1'));
+    assert.ok(capturedUrl.includes('?foo=bar&baz=1'));
+  });
+
+  it('drops search params when forwardSearch is false', async () => {
+    let capturedUrl;
+    mockFetch(async (url) => {
+      capturedUrl = url;
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+    const handler = createRelayHandler({ relayPath: '/test', forwardSearch: false });
+    await handler(makeRequest('https://worldmonitor.app/api/test?foo=bar'));
+    assert.ok(!capturedUrl.includes('?foo=bar'));
+  });
+
+  it('uses buildRelayPath for dynamic paths', async () => {
+    let capturedUrl;
+    mockFetch(async (url) => {
+      capturedUrl = url;
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+    const handler = createRelayHandler({
+      buildRelayPath: (_req, url) => {
+        const ep = url.searchParams.get('endpoint');
+        return ep === 'history' ? '/oref/history' : '/oref/alerts';
+      },
+      forwardSearch: false,
+    });
+    await handler(makeRequest('https://worldmonitor.app/api/oref?endpoint=history'));
+    assert.ok(capturedUrl.endsWith('/oref/history'));
+  });
+
+  it('applies cacheHeaders on success', async () => {
+    mockFetchOk();
+    const handler = createRelayHandler({
+      relayPath: '/test',
+      cacheHeaders: (ok) => ({
+        'Cache-Control': ok ? 'public, max-age=60' : 'max-age=10',
+      }),
+    });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test'));
+    assert.equal(res.headers.get('cache-control'), 'public, max-age=60');
+  });
+
+  it('applies cacheHeaders on error pass-through', async () => {
+    mockFetchStatus(500);
+    const handler = createRelayHandler({
+      relayPath: '/test',
+      cacheHeaders: (ok) => ({
+        'Cache-Control': ok ? 'public, max-age=60' : 'max-age=10',
+      }),
+    });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test'));
+    assert.equal(res.status, 500);
+    assert.equal(res.headers.get('cache-control'), 'max-age=10');
+  });
+
+  it('applies extraHeaders', async () => {
+    mockFetch(async () => new Response('{}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', 'X-Cache': 'HIT' },
+    }));
+    const handler = createRelayHandler({
+      relayPath: '/test',
+      extraHeaders: (response) => {
+        const xc = response.headers.get('x-cache');
+        return xc ? { 'X-Cache': xc } : {};
+      },
+    });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test'));
+    assert.equal(res.headers.get('x-cache'), 'HIT');
+  });
+
+  it('returns 504 on timeout', async () => {
+    mockFetch((_url, opts) => new Promise((resolve, reject) => {
+      const timer = setTimeout(resolve, 5000);
+      opts?.signal?.addEventListener('abort', () => {
+        clearTimeout(timer);
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      });
+    }));
+    const handler = createRelayHandler({ relayPath: '/test', timeout: 50 });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test'));
+    assert.equal(res.status, 504);
+    const body = await res.json();
+    assert.equal(body.error, 'Relay timeout');
+  });
+
+  it('returns 502 on network error', async () => {
+    mockFetchError('Connection refused');
+    const handler = createRelayHandler({ relayPath: '/test' });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test'));
+    assert.equal(res.status, 502);
+    const body = await res.json();
+    assert.equal(body.error, 'Relay request failed');
+    assert.equal(body.details, 'Connection refused');
+  });
+
+  it('calls fallback when relay unavailable', async () => {
+    delete process.env.WS_RELAY_URL;
+    const handler = createRelayHandler({
+      relayPath: '/test',
+      fallback: (_req, cors) => new Response('{"fallback":true}', {
+        status: 503,
+        headers: { 'Content-Type': 'application/json', ...cors },
+      }),
+    });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test'));
+    assert.equal(res.status, 503);
+    const body = await res.json();
+    assert.equal(body.fallback, true);
+  });
+
+  it('calls fallback on network error when fallback set', async () => {
+    mockFetchError('fail');
+    const handler = createRelayHandler({
+      relayPath: '/test',
+      fallback: (_req, cors) => new Response('{"fallback":true}', {
+        status: 503,
+        headers: { 'Content-Type': 'application/json', ...cors },
+      }),
+    });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test'));
+    assert.equal(res.status, 503);
+    const body = await res.json();
+    assert.equal(body.fallback, true);
+  });
+
+  it('calls fallback when onlyOk and non-2xx', async () => {
+    mockFetchStatus(502);
+    const handler = createRelayHandler({
+      relayPath: '/test',
+      onlyOk: true,
+      fallback: (_req, cors) => new Response('{"fallback":true}', {
+        status: 503,
+        headers: { 'Content-Type': 'application/json', ...cors },
+      }),
+    });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test'));
+    assert.equal(res.status, 503);
+    const body = await res.json();
+    assert.equal(body.fallback, true);
+  });
+
+  it('passes through non-2xx when onlyOk is false', async () => {
+    mockFetchStatus(502, '{"upstream":"error"}');
+    const handler = createRelayHandler({ relayPath: '/test' });
+    const res = await handler(makeRequest('https://worldmonitor.app/api/test'));
+    assert.equal(res.status, 502);
+    assert.equal(await res.text(), '{"upstream":"error"}');
+  });
+});


### PR DESCRIPTION
## Summary

- Extract duplicated relay proxy boilerplate from 7 edge functions into a shared `api/_relay.js` helper
- `createRelayHandler(config)` factory reduces simple relay proxies from ~100 lines to ~15-25 lines of config
- `getRelayBaseUrl()`, `getRelayHeaders()`, `fetchWithTimeout()` exported for complex handlers (youtube/live, rss-proxy) that don't fit the factory pattern
- **-501 lines removed, +72 added** across 7 prod files (~32% reduction). Relay utility functions exist in 1 place instead of 7

### Converted endpoints (factory pattern)
| Endpoint | Before | After | Key config |
|----------|--------|-------|------------|
| ais-snapshot | 105 | 16 | auth + rate limit, CDN-Cache-Control |
| polymarket | 105 | 16 | auth + rate limit, CDN-Cache-Control |
| opensky | 90 | 15 | X-Cache passthrough, no auth |
| oref-alerts | 93 | 26 | buildRelayPath, onlyOk + fallback |
| telegram-feed | 85 | 21 | buildRelayPath with param sanitization |

### Refactored (import shared utils only)
| Endpoint | Before | After | Change |
|----------|--------|-------|--------|
| youtube/live | 137 | 121 | Replace local getRelayBaseUrl/getRelayHeaders with imports |
| rss-proxy | 465 | 436 | Replace local getRelayBaseUrl/getRelayHeaders/fetchWithTimeout with imports |

## Test plan

- [x] `node --test tests/relay-helper.test.mjs` — 30/30 pass (unit + behavior tests for all factory options)
- [x] `node --test tests/edge-functions.test.mjs` — 32/32 pass (`_relay.js` excluded by underscore prefix)
- [x] `tsc --noEmit` + `tsc --noEmit -p tsconfig.api.json` — typecheck passes (pre-push hook)
- [x] Parity matrix verified: relay paths, auth, timeouts, cache headers, error codes, fallback behavior all match originals