### PR TITLE
perf(cache): bump CDN cache TTLs for oref-alerts and youtube/live

### DIFF
--- a/api/oref-alerts.js
+++ b/api/oref-alerts.js
@@ -11,7 +11,7 @@ export default createRelayHandler({
   timeout: 12000,
   onlyOk: true,
   cacheHeaders: () => ({
-    'Cache-Control': 'public, max-age=60, s-maxage=180, stale-while-revalidate=60, stale-if-error=600',
+    'Cache-Control': 'public, max-age=60, s-maxage=300, stale-while-revalidate=120, stale-if-error=900',
   }),
   fallback: (_req, corsHeaders) => new Response(JSON.stringify({
     configured: false,

--- a/api/youtube/live.js
+++ b/api/youtube/live.js
@@ -36,7 +36,7 @@ export default async function handler(request) {
       const relayRes = await fetch(`${relayBase}/youtube-live?${qs}`, { headers: relayHeaders });
       if (relayRes.ok) {
         const data = await relayRes.json();
-        const cacheTime = videoIdParam ? 3600 : 300;
+        const cacheTime = videoIdParam ? 3600 : 600;
         return new Response(JSON.stringify(data), {
           status: 200,
           headers: {
@@ -111,7 +111,7 @@ export default async function handler(request) {
 
     return new Response(JSON.stringify({ videoId, isLive: videoId !== null, channelExists, channelName, hlsUrl }), {
       status: 200,
-      headers: { ...cors, 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=300, s-maxage=300, stale-while-revalidate=60' },
+      headers: { ...cors, 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=300, s-maxage=600, stale-while-revalidate=120' },
     });
   } catch {
     return new Response(JSON.stringify({ videoId: null, error: 'Failed to fetch channel data' }), {


### PR DESCRIPTION
## Summary
- **oref-alerts**: `s-maxage` 180s → 300s (5 min), `stale-while-revalidate` 60s → 120s
- **youtube/live**: channel-based `s-maxage` 300s → 600s (10 min) for both relay and direct scrape paths

Part of a broader Vercel cost review. Also configured Cloudflare Cache Rules (Edge TTL → respect origin `Cache-Control`) on both `api.worldmonitor.app` and `proxy.worldmonitor.com` to ensure CF actually caches JSON API responses.

## Test plan
- [ ] Verify oref-alerts response includes `s-maxage=300`
- [ ] Verify youtube/live channel query response includes `s-maxage=600`
- [ ] Monitor Vercel function invocations over 24h post-deploy + CF Edge TTL change