### PR TITLE
feat: add JSON export and import for settings persistence

### DIFF
--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -10,7 +10,7 @@ import { escapeHtml } from '@/utils/sanitize';
 import { trackLanguageChange } from '@/services/analytics';
 import type { PanelConfig } from '@/types';
 import type { StatusPanel } from './StatusPanel';
-import { exportSettings, importSettings } from '@/utils/settings-persistence';
+import { exportSettings, importSettings, type ImportResult } from '@/utils/settings-persistence';
 
 const GEAR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`;
 
@@ -148,7 +148,12 @@ export class UnifiedSettings {
       }
 
       if (target.closest('#usExportBtn')) {
-        exportSettings();
+        try {
+          exportSettings();
+          this.showDataMgmtToast(t('components.settings.exportSuccess'), true);
+        } catch {
+          this.showDataMgmtToast(t('components.settings.exportFailed'), false);
+        }
         return;
       }
 
@@ -179,9 +184,10 @@ export class UnifiedSettings {
       if (target.id === 'usImportInput') {
         const file = target.files?.[0];
         if (!file) return;
-        importSettings(file).catch(err => {
-          console.error('Failed to import settings', err);
-          alert('Failed to import settings: Invalid file format');
+        importSettings(file).then((result: ImportResult) => {
+          this.showDataMgmtToast(t('components.settings.importSuccess', { count: String(result.keysImported) }), true);
+        }).catch(() => {
+          this.showDataMgmtToast(t('components.settings.importFailed'), false);
         });
         target.value = '';
         return;
@@ -449,13 +455,14 @@ export class UnifiedSettings {
     html += `</select>`;
 
     // Data Management section
-    html += `<div class="ai-flow-section-label">${t('settings.dataManagementLabel')}</div>`;
+    html += `<div class="ai-flow-section-label">${t('components.settings.dataManagementLabel')}</div>`;
     html += `
-      <div style="display: flex; gap: 10px; padding: 0 16px 16px;">
-        <button type="button" class="settings-btn settings-btn-secondary" id="usExportBtn" style="flex: 1;">📥 ${t('settings.exportSettings')}</button>
-        <button type="button" class="settings-btn settings-btn-secondary" id="usImportBtn" style="flex: 1;">📤 ${t('settings.importSettings')}</button>
-        <input type="file" id="usImportInput" accept=".json" style="display: none;" />
+      <div class="us-data-mgmt">
+        <button type="button" class="settings-btn settings-btn-secondary" id="usExportBtn">${t('components.settings.exportSettings')}</button>
+        <button type="button" class="settings-btn settings-btn-secondary" id="usImportBtn">${t('components.settings.importSettings')}</button>
+        <input type="file" id="usImportInput" accept=".json" class="us-hidden-input" />
       </div>
+      <div class="us-data-mgmt-toast" id="usDataMgmtToast"></div>
     `;
     // Community section
     html += `<div class="ai-flow-section-label">${t('components.community.sectionLabel')}</div>`;
@@ -507,6 +514,19 @@ export class UnifiedSettings {
       dot.classList.add('disabled');
       text.textContent = t('components.insights.aiFlowStatusDisabled');
     }
+  }
+
+  private showDataMgmtToast(msg: string, success: boolean): void {
+    const toast = this.overlay.querySelector('#usDataMgmtToast');
+    if (!toast) return;
+    toast.className = `us-data-mgmt-toast ${success ? 'ok' : 'error'}`;
+    toast.innerHTML = success
+      ? `${escapeHtml(msg)} <a href="#" class="us-toast-reload">${t('components.settings.reloadNow')}</a>`
+      : escapeHtml(msg);
+    toast.querySelector('.us-toast-reload')?.addEventListener('click', (e) => {
+      e.preventDefault();
+      window.location.reload();
+    });
   }
 
   public refreshStatusTab(): void {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -80,7 +80,14 @@
     "noSignals": "No recent high-severity signals.",
     "assessmentUnavailable": "Assessment unavailable.",
     "noNews": "No recent country-specific coverage.",
+    "noMarkets": "No active markets for this country.",
     "noIndicators": "No country-specific indicators available.",
+    "components": {
+      "unrest": "Unrest",
+      "conflict": "Conflict",
+      "security": "Security",
+      "information": "Information"
+    },
     "nearbyPorts": "Nearby Ports",
     "detected": "Detected",
     "notDetected": "No",
@@ -1194,7 +1201,12 @@
     "settings": {
       "dataManagementLabel": "Data Management",
       "exportSettings": "Export Settings",
-      "importSettings": "Import Settings"
+      "importSettings": "Import Settings",
+      "exportSuccess": "Settings exported successfully",
+      "exportFailed": "Failed to export settings",
+      "importSuccess": "Imported {{count}} settings",
+      "importFailed": "Failed to import settings",
+      "reloadNow": "Reload now"
     },
     "cascade": {
       "noImpacts": "No country impacts detected",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1032,6 +1032,16 @@
       "streamAlwaysOnLabel": "Garder les flux en direct actifs",
       "streamAlwaysOnDesc": "Empêche la mise en pause automatique de Live Cams et Live News lorsque vous êtes inactif. Recommandé pour un second écran / usage wallboard. Désactivez (Éco) pour économiser CPU/bande passante."
     },
+    "settings": {
+      "dataManagementLabel": "Gestion des données",
+      "exportSettings": "Exporter les paramètres",
+      "importSettings": "Importer les paramètres",
+      "exportSuccess": "Paramètres exportés avec succès",
+      "exportFailed": "Échec de l'exportation des paramètres",
+      "importSuccess": "{{count}} paramètres importés",
+      "importFailed": "Échec de l'importation des paramètres",
+      "reloadNow": "Recharger maintenant"
+    },
     "cascade": {
       "noImpacts": "Aucun impact pays détecté",
       "filters": {
@@ -2116,11 +2126,6 @@
         "description": "Opérations navales, points d'étranglement maritimes, voies maritimes"
       }
     }
-  },
-  "settings": {
-    "dataManagementLabel": "Gestion des données",
-    "exportSettings": "Exporter les paramètres",
-    "importSettings": "Importer des paramètres"
   },
   "common": {
     "loading": "Chargement...",

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -1,7 +1,7 @@
 import './styles/main.css';
 import './styles/settings-window.css';
 import { SettingsManager } from '@/services/settings-manager';
-import { exportSettings, importSettings } from '@/utils/settings-persistence';
+import { exportSettings, importSettings, type ImportResult } from '@/utils/settings-persistence';
 import {
   SETTINGS_CATEGORIES,
   HUMAN_LABELS,
@@ -218,10 +218,10 @@ function renderOverview(area: HTMLElement): void {
       <div class="settings-ov-cats">${catCards}</div>
       <div class="settings-ov-actions">
         <button type="button" class="settings-btn settings-btn-secondary" id="exportSettingsBtn">
-          📥 ${t('settings.exportSettings')}
+          ${t('components.settings.exportSettings')}
         </button>
         <button type="button" class="settings-btn settings-btn-secondary" id="importSettingsBtn">
-          📤 ${t('settings.importSettings')}
+          ${t('components.settings.importSettings')}
         </button>
         <input type="file" id="importSettingsInput" accept=".json" style="display: none;" />
       </div>
@@ -281,28 +281,23 @@ function initOverviewListeners(area: HTMLElement): void {
     const file = (e.target as HTMLInputElement).files?.[0];
     if (!file) return;
     try {
-      await importSettings(file);
+      const result: ImportResult = await importSettings(file);
+      setActionStatus(t('components.settings.importSuccess', { count: String(result.keysImported) }), 'ok');
     } catch (err: unknown) {
-      let statusMessage = 'Failed to import settings.';
-
-      // Handle common browser storage / quota / security issues explicitly
       if (err instanceof DOMException) {
         if (err.name === 'QuotaExceededError' || err.name === 'NS_ERROR_DOM_QUOTA_REACHED') {
-          statusMessage = 'Failed to import settings: Browser storage limit has been reached.';
+          setActionStatus(t('components.settings.importFailed') + ': storage limit reached', 'error');
         } else if (err.name === 'SecurityError') {
-          statusMessage = 'Failed to import settings: Access to browser storage is blocked by your settings or extensions.';
+          setActionStatus(t('components.settings.importFailed') + ': storage blocked', 'error');
         } else {
-          statusMessage = `Failed to import settings: ${err.message || err.name}.`;
+          setActionStatus(`${t('components.settings.importFailed')}: ${err.message || err.name}`, 'error');
         }
       } else if (err instanceof Error && err.message) {
-        statusMessage = `Failed to import settings: ${err.message}`;
+        setActionStatus(`${t('components.settings.importFailed')}: ${err.message}`, 'error');
       } else {
-        statusMessage = 'Failed to import settings due to an unknown error.';
+        setActionStatus(t('components.settings.importFailed'), 'error');
       }
-
-      setActionStatus(statusMessage, 'error');
     }
-    // reset input
     importInput.value = '';
   });
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -14450,6 +14450,45 @@ a.prediction-link:hover {
   flex-shrink: 0;
 }
 
+/* Data management buttons in settings */
+.us-data-mgmt {
+  display: flex;
+  gap: 10px;
+  padding: 0 16px 12px;
+}
+
+.us-data-mgmt .settings-btn {
+  flex: 1;
+}
+
+.us-hidden-input {
+  display: none;
+}
+
+.us-data-mgmt-toast {
+  padding: 0 16px;
+  font-size: 12px;
+  min-height: 0;
+  transition: opacity 0.2s;
+}
+
+.us-data-mgmt-toast:empty {
+  display: none;
+}
+
+.us-data-mgmt-toast.ok {
+  color: #34d399;
+}
+
+.us-data-mgmt-toast.error {
+  color: #f87171;
+}
+
+.us-toast-reload {
+  color: #60a5fa;
+  margin-left: 6px;
+}
+
 /* Footer status */
 .ai-flow-popup-footer {
   display: flex;

--- a/src/styles/settings-window.css
+++ b/src/styles/settings-window.css
@@ -1094,3 +1094,14 @@ tr.diag-err td { color: var(--settings-red); }
     flex-wrap: wrap;
   }
 }
+
+/* Data management in overview */
+.settings-ov-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.settings-ov-actions .settings-btn {
+  flex: 1;
+}

--- a/src/utils/settings-persistence.ts
+++ b/src/utils/settings-persistence.ts
@@ -1,7 +1,3 @@
-/**
- * Utility for exporting and importing World Monitor dashboard settings.
- */
-
 export interface ExportedSettings {
   version: number;
   timestamp: string;
@@ -9,85 +5,72 @@ export interface ExportedSettings {
   data: Record<string, string>;
 }
 
-// 5MB limit for imported settings JSON
+export interface ImportResult {
+  success: boolean;
+  keysImported: number;
+  error?: string;
+}
+
 const MAX_IMPORT_SIZE_BYTES = 5 * 1024 * 1024;
 
-/**
- * Validates if a localStorage key is safe to export/import.
- * Excludes transient caches and sensitive secrets (API keys, tokens).
- */
-function isKeySafeToExport(key: string): boolean {
-  // Ignore massive internal caches or transient states to avoid bloated JSON
-  if (
-    key.startsWith('wm-cache-') ||
-    key.includes('vesselPosture') ||
-    key.includes('wm-secrets-updated') ||
-    key.includes('wm-waitlist-registered') ||
-    key.includes('wm-debug-log') ||
-    key.includes('wm-settings-open')
-  ) {
-    return false;
-  }
+const SETTINGS_KEY_PREFIXES = [
+  'worldmonitor-panels',
+  'worldmonitor-monitors',
+  'worldmonitor-layers',
+  'worldmonitor-disabled-feeds',
+  'worldmonitor-live-channels',
+  'worldmonitor-map-mode',
+  'worldmonitor-variant',
+  'worldmonitor-theme',
+  'worldmonitor-panel-spans',
+  'worldmonitor-panel-order',
+  'worldmonitor-runtime-feature-toggles',
+  'wm-breaking-alerts-v1',
+  'wm-globe-render-scale',
+  'wm-live-streams-always-on',
+  'map-height',
+  'map-pinned',
+  'mobile-map-collapsed',
+  'positive-threshold',
+];
 
-  // Strictly exclude potential secrets: API keys, tokens, passwords.
-  if (/secret|token|key|password|auth/i.test(key)) {
-    return false;
-  }
-
-  return true;
+function isSettingsKey(key: string): boolean {
+  return SETTINGS_KEY_PREFIXES.some(prefix => key.startsWith(prefix));
 }
 
 export function exportSettings(): void {
-  try {
-    const data: Record<string, string> = {};
+  const data: Record<string, string> = {};
 
-    for (let i = 0; i < localStorage.length; i++) {
-      const key = localStorage.key(i);
-      if (!key) continue;
-
-      if (!isKeySafeToExport(key)) {
-        continue;
-      }
-
-      const value = localStorage.getItem(key);
-      if (value !== null) {
-        data[key] = value;
-      }
-    }
-
-    const exportData: ExportedSettings = {
-      version: 1,
-      timestamp: new Date().toISOString(),
-      variant: localStorage.getItem('worldmonitor-variant') || 'full',
-      data,
-    };
-
-    const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    const timestampStr = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-    a.download = `worldmonitor-settings-${timestampStr}.json`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-  } catch (err) {
-    // Surface a meaningful error when localStorage (or related browser APIs) are unavailable
-    console.error('Failed to export World Monitor settings: localStorage may be unavailable or blocked.', err);
-    if (typeof window !== 'undefined' && typeof window.alert === 'function') {
-      window.alert(
-        'Failed to export settings because browser storage is unavailable. ' +
-        'Please check your browser privacy settings and try again.'
-      );
-    }
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (!key || !isSettingsKey(key)) continue;
+    const value = localStorage.getItem(key);
+    if (value !== null) data[key] = value;
   }
+
+  const exportData: ExportedSettings = {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    variant: localStorage.getItem('worldmonitor-variant') || 'full',
+    data,
+  };
+
+  const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  a.download = `worldmonitor-settings-${ts}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }
 
-export function importSettings(file: File): Promise<void> {
+export function importSettings(file: File): Promise<ImportResult> {
   return new Promise((resolve, reject) => {
     if (file.size > MAX_IMPORT_SIZE_BYTES) {
-      reject(new Error(`File is too large. Maximum size is 5MB.`));
+      reject(new Error('File is too large. Maximum size is 5MB.'));
       return;
     }
 
@@ -98,37 +81,24 @@ export function importSettings(file: File): Promise<void> {
         const result = e.target?.result as string;
         const parsed = JSON.parse(result) as ExportedSettings;
 
-        if (!parsed || !parsed.data || typeof parsed.data !== 'object') {
-          throw new Error('Invalid format: parsed data is missing or not an object.');
+        if (!parsed || typeof parsed.data !== 'object' || Array.isArray(parsed.data)) {
+          throw new Error('Invalid format: expected an object with a data property.');
         }
 
-        // Ask for user confirmation before overwriting localStorage
-        const confirmMsg = parsed.variant
-          ? `Replace current settings with the imported ${parsed.variant} settings bundle?`
-          : 'Replace current settings with the imported configuration?';
-
-        if (!window.confirm(confirmMsg)) {
-          resolve(); // user cancelled
-          return;
+        if (parsed.version !== 1) {
+          throw new Error(`Unsupported settings version: ${parsed.version}`);
         }
 
-        // Apply settings
         let keysImported = 0;
         for (const [key, value] of Object.entries(parsed.data)) {
-          // Re-apply the EXACT same safety filter as export
-          if (isKeySafeToExport(key) && typeof value === 'string') {
+          if (isSettingsKey(key) && typeof value === 'string') {
             localStorage.setItem(key, value);
             keysImported++;
           }
         }
 
-        if (window.confirm(`Successfully imported ${keysImported} settings. Reload now to apply changes?`)) {
-          window.location.reload();
-        }
-
-        resolve();
+        resolve({ success: true, keysImported });
       } catch (err) {
-        console.error('Failed to parse imported settings:', err);
         reject(err);
       }
     };


### PR DESCRIPTION
## Summary

This PR introduces a JSON-based export and import system to allow users to back up and restore their dashboard configuration, preventing settings loss upon page refreshes or when switching devices.

Key Changes:

New Persistence Module: Added 

src/utils/settings-persistence.ts
 which iterates through localStorage to capture all active configurations (panel order, widget sizes, custom monitors, theme, and API keys) while excluding large internal caches.
Settings UI Integration: Added "Export Settings" and "Import Settings" buttons under the General > Data Management section in the 

UnifiedSettings
 component.
Standalone Support: Integrated the same functionality into the desktop/standalone settings viewer (

src/settings-main.ts
).
Safety Features: Added basic validation for the imported JSON and an automatic page reload to ensure settings are applied immediately after import.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [x] Config / Settings
- [ ] Other: <!-- specify -->

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [x] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots

<img width="554" height="84" alt="SCR-20260302-rmja" src="https://github.com/user-attachments/assets/91906465-4844-4b03-a6e5-a12dca2c2d4f" />


