### PR TITLE
fix(server): define ServerOptions locally and warn on duplicate routes

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -16,7 +16,11 @@ import { validateApiKey } from '../api/_api-key.js';
 import { mapErrorToResponse } from './error-mapper';
 import { checkRateLimit } from './_shared/rate-limit';
 import { drainResponseHeaders } from './_shared/response-headers';
-import type { ServerOptions } from '../src/generated/server/worldmonitor/seismology/v1/service_server';
+/** Defined locally to avoid a fragile cross-domain import from seismology's generated file. */
+export interface ServerOptions {
+  onError?: (error: unknown, req: Request) => Response | Promise<Response>;
+  validateRequest?: (methodName: string, body: unknown) => { field: string; description: string }[] | undefined;
+}
 
 export const serverOptions: ServerOptions = { onError: mapErrorToResponse };
 

--- a/server/router.ts
+++ b/server/router.ts
@@ -42,6 +42,9 @@ export function createRouter(allRoutes: RouteDescriptor[]): Router {
       });
     } else {
       const key = `${route.method} ${route.path}`;
+      if (staticTable.has(key)) {
+        console.warn(`[router] Duplicate route registered: ${key}`);
+      }
       staticTable.set(key, route.handler);
       if (!staticPaths.has(route.path)) staticPaths.set(route.path, new Set());
       staticPaths.get(route.path)!.add(route.method);


### PR DESCRIPTION
## Summary
- Define `ServerOptions` interface directly in `gateway.ts` instead of importing it from seismology's generated file. This eliminates a fragile cross-domain dependency where changes to the seismology service could break the gateway.
- Add a `console.warn` in `router.ts` when a duplicate static route is registered. Previously, duplicates were silently overwritten, making route conflicts invisible during development.

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx tsc --noEmit -p tsconfig.api.json` passes with no errors
- [x] Pre-push hooks (typecheck, CJS syntax check, version sync) all pass

Addresses #197 (L-1, L-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)