### PR TITLE
fix(intel): add console.warn to silent catch blocks for observability

### DIFF
--- a/server/worldmonitor/intelligence/v1/classify-event.ts
+++ b/server/worldmonitor/intelligence/v1/classify-event.ts
@@ -89,7 +89,8 @@ Return: {"level":"...","category":"..."}`;
           let parsed: { level?: string; category?: string };
           try {
             parsed = JSON.parse(raw);
-          } catch {
+          } catch (error) {
+            console.warn('[classify-event] JSON.parse of LLM response failed', error);
             return null;
           }
 
@@ -98,12 +99,14 @@ Return: {"level":"...","category":"..."}`;
           if (!level || !category) return null;
 
           return { level, category, timestamp: Date.now() };
-        } catch {
+        } catch (error) {
+          console.warn('[classify-event] classification fetch failed', error);
           return null;
         }
       },
     );
-  } catch {
+  } catch (error) {
+    console.warn('[classify-event] cached fetch failed', error);
     markNoCacheResponse(ctx.request);
     return { classification: undefined };
   }

--- a/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
@@ -39,7 +39,8 @@ export async function getCountryIntelBrief(
   try {
     const url = new URL(ctx.request.url);
     contextSnapshot = (url.searchParams.get('context') || '').trim().slice(0, 4000);
-  } catch {
+  } catch (error) {
+    console.warn('[get-country-intel-brief] context parse failed', error);
     contextSnapshot = '';
   }
 
@@ -102,11 +103,13 @@ Rules:
           model: GROQ_MODEL,
           generatedAt: Date.now(),
         };
-      } catch {
+      } catch (error) {
+        console.warn('[get-country-intel-brief] GROQ brief generation failed', error);
         return null;
       }
     });
-  } catch {
+  } catch (error) {
+    console.warn('[get-country-intel-brief] cached fetch failed', error);
     return empty;
   }
 

--- a/server/worldmonitor/intelligence/v1/get-pizzint-status.ts
+++ b/server/worldmonitor/intelligence/v1/get-pizzint-status.ts
@@ -111,7 +111,7 @@ export async function getPizzintStatus(
             locations,
           };
         }
-      } catch (_) { /* PizzINT unavailable — continue to GDELT */ }
+      } catch (error) { console.warn('[get-pizzint-status] PizzINT API fetch failed', error); }
 
       // Fetch GDELT tension pairs
       let tensionPairs: GdeltTensionPair[] = [];
@@ -146,14 +146,15 @@ export async function getPizzintStatus(
               };
             });
           }
-        } catch { /* gdelt unavailable */ }
+        } catch (error) { console.warn('[get-pizzint-status] GDELT fetch failed', error); }
       }
 
       // Only cache if PizzINT data was retrieved
       if (!pizzint) return null;
       return { pizzint, tensionPairs };
     });
-  } catch {
+  } catch (error) {
+    console.warn('[get-pizzint-status] cached fetch failed', error);
     return { pizzint: undefined, tensionPairs: [] };
   }
 

--- a/server/worldmonitor/military/v1/list-military-bases.ts
+++ b/server/worldmonitor/military/v1/list-military-bases.ts
@@ -186,7 +186,7 @@ export async function listMilitaryBases(
           const raw = metaMap.get(id);
           if (!raw) continue;
           let meta: Record<string, unknown>;
-          try { meta = JSON.parse(raw); } catch { continue; }
+          try { meta = JSON.parse(raw); } catch (error) { console.warn('[list-military-bases] JSON.parse failed', error); continue; }
 
           const tier = (meta.tier as number) || 2;
           if (zoom < 5 && tier > 1) continue;


### PR DESCRIPTION
## Summary

- Addresses lint issue **L-14**: silent catch blocks in intelligence and military handlers are now observable in production logs
- Added `console.warn` with handler-name prefixes (e.g. `[get-country-intel-brief]`) and the caught error to every previously-empty catch block across 4 files
- No logic changes — only logging additions to existing catch blocks

## Files modified

| File | Catch blocks updated |
|------|---------------------|
| `server/worldmonitor/intelligence/v1/get-country-intel-brief.ts` | 3 (context parse, GROQ fetch, cached fetch) |
| `server/worldmonitor/intelligence/v1/classify-event.ts` | 3 (JSON.parse, classification fetch, cached fetch) |
| `server/worldmonitor/intelligence/v1/get-pizzint-status.ts` | 3 (PizzINT API, GDELT fetch, cached fetch) |
| `server/worldmonitor/military/v1/list-military-bases.ts` | 1 (JSON.parse of base metadata) |

## Test plan

- [ ] Verify type checks pass (`npm run typecheck`) — confirmed passing in pre-push hook
- [ ] Grep for `console.warn` in the 4 files to confirm all silent catches now log
- [ ] Deploy to staging and trigger error paths to verify log output is present and grep-friendly
- [ ] Confirm no behavioral changes — all catch blocks still return the same fallback values

🤖 Generated with [Claude Code](https://claude.com/claude-code)