### PR TITLE
fix(panels): resolve tech UNAVAILABLE feeds, Yahoo batch early-exit, and sector heatmap gate

### DIFF
--- a/server/worldmonitor/market/v1/_shared.ts
+++ b/server/worldmonitor/market/v1/_shared.ts
@@ -14,16 +14,19 @@ export async function fetchYahooQuotesBatch(
 ): Promise<{ results: Map<string, { price: number; change: number; sparkline: number[] }>; rateLimited: boolean }> {
   const results = new Map<string, { price: number; change: number; sparkline: number[] }>();
   let rateLimitHits = 0;
+  let consecutiveFails = 0;
   for (let i = 0; i < symbols.length; i++) {
     const q = await fetchYahooQuote(symbols[i]!);
     if (q) {
       results.set(symbols[i]!, q);
+      consecutiveFails = 0;
     } else {
       rateLimitHits++;
+      consecutiveFails++;
     }
-    if (rateLimitHits >= 3 && results.size === 0) break;
+    if (consecutiveFails >= 5) break;
   }
-  return { results, rateLimited: rateLimitHits >= 3 && results.size === 0 };
+  return { results, rateLimited: rateLimitHits > symbols.length / 2 };
 }
 
 // Yahoo-only symbols: indices and futures not on Finnhub free tier

--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -113,9 +113,38 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'VentureBeat', url: 'https://venturebeat.com/feed/' },
       { name: 'Crunchbase News', url: 'https://news.crunchbase.com/feed/' },
     ],
+    vcblogs: [
+      { name: 'Y Combinator Blog', url: 'https://www.ycombinator.com/blog/rss/' },
+      { name: 'a16z Blog', url: 'https://a16z.com/feed/' },
+      { name: 'First Round Review', url: 'https://review.firstround.com/feed.xml' },
+      { name: 'Sequoia Blog', url: 'https://www.sequoiacap.com/feed/' },
+      { name: 'Stratechery', url: 'https://stratechery.com/feed/' },
+    ],
+    regionalStartups: [
+      { name: 'EU Startups', url: 'https://www.eu-startups.com/feed/' },
+      { name: 'Tech.eu', url: 'https://tech.eu/feed/' },
+      { name: 'Sifted (Europe)', url: 'https://sifted.eu/feed' },
+      { name: 'Tech in Asia', url: 'https://www.techinasia.com/feed' },
+      { name: 'TechCabal (Africa)', url: 'https://techcabal.com/feed/' },
+      { name: 'Inc42 (India)', url: 'https://inc42.com/feed/' },
+    ],
+    unicorns: [
+      { name: 'Unicorn News', url: gn('("unicorn startup" OR "unicorn valuation" OR "$1 billion valuation") when:7d') },
+      { name: 'Decacorn News', url: gn('("decacorn" OR "$10 billion valuation") startup when:14d') },
+    ],
+    accelerators: [
+      { name: 'YC News', url: 'https://news.ycombinator.com/rss' },
+      { name: 'YC Blog', url: 'https://www.ycombinator.com/blog/rss/' },
+      { name: 'Demo Day News', url: gn('("demo day" OR "YC batch" OR "accelerator batch") startup when:7d') },
+    ],
     security: [
       { name: 'Krebs Security', url: 'https://krebsonsecurity.com/feed/' },
       { name: 'Dark Reading', url: 'https://www.darkreading.com/rss.xml' },
+    ],
+    policy: [
+      { name: 'Politico Tech', url: 'https://rss.politico.com/technology.xml' },
+      { name: 'AI Regulation', url: gn('AI regulation OR "artificial intelligence" law OR policy when:7d') },
+      { name: 'Tech Antitrust', url: gn('tech antitrust OR FTC Google OR FTC Apple OR FTC Amazon when:7d') },
     ],
     github: [
       { name: 'GitHub Blog', url: 'https://github.blog/feed/' },

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -946,36 +946,37 @@ export class DataLoaderManager implements AppModule {
 
       if (stocksResult.rateLimited && stocksResult.data.length === 0) {
         const rlMsg = 'Market data temporarily unavailable (rate limited) — retrying shortly';
-        this.ctx.panels['heatmap']?.showError(rlMsg);
         this.ctx.panels['commodities']?.showError(rlMsg);
       } else if (stocksResult.skipped) {
         this.ctx.statusPanel?.updateApi('Finnhub', { status: 'error' });
         if (stocksResult.data.length === 0) {
           this.ctx.panels['markets']?.showConfigError(finnhubConfigMsg);
         }
-        this.ctx.panels['heatmap']?.showConfigError(finnhubConfigMsg);
       } else {
         this.ctx.statusPanel?.updateApi('Finnhub', { status: 'ok' });
+      }
 
-        const hydratedSectors = getHydratedData('sectors') as GetSectorSummaryResponse | undefined;
-        if (hydratedSectors?.sectors?.length) {
-          const mapped = hydratedSectors.sectors.map((s) => ({ name: s.name, change: s.change }));
-          (this.ctx.panels['heatmap'] as HeatmapPanel).renderHeatmap(mapped);
-        } else {
-          const sectorsResult = await fetchMultipleStocks(
-            SECTORS.map((s) => ({ ...s, display: s.name })),
-            {
-              onBatch: (partialSectors) => {
-                (this.ctx.panels['heatmap'] as HeatmapPanel).renderHeatmap(
-                  partialSectors.map((s) => ({ name: s.name, change: s.change }))
-                );
-              },
-            }
-          );
-          (this.ctx.panels['heatmap'] as HeatmapPanel).renderHeatmap(
-            sectorsResult.data.map((s) => ({ name: s.name, change: s.change }))
-          );
-        }
+      // Sector heatmap: always attempt loading regardless of market rate-limit status
+      const hydratedSectors = getHydratedData('sectors') as GetSectorSummaryResponse | undefined;
+      if (hydratedSectors?.sectors?.length) {
+        const mapped = hydratedSectors.sectors.map((s) => ({ name: s.name, change: s.change }));
+        (this.ctx.panels['heatmap'] as HeatmapPanel).renderHeatmap(mapped);
+      } else if (!stocksResult.skipped) {
+        const sectorsResult = await fetchMultipleStocks(
+          SECTORS.map((s) => ({ ...s, display: s.name })),
+          {
+            onBatch: (partialSectors) => {
+              (this.ctx.panels['heatmap'] as HeatmapPanel).renderHeatmap(
+                partialSectors.map((s) => ({ name: s.name, change: s.change }))
+              );
+            },
+          }
+        );
+        (this.ctx.panels['heatmap'] as HeatmapPanel).renderHeatmap(
+          sectorsResult.data.map((s) => ({ name: s.name, change: s.change }))
+        );
+      } else {
+        this.ctx.panels['heatmap']?.showConfigError(finnhubConfigMsg);
       }
 
       const commoditiesPanel = this.ctx.panels['commodities'] as CommoditiesPanel;


### PR DESCRIPTION
## Summary
- **Tech variant UNAVAILABLE panels**: 5 server-side feed categories (`vcblogs`, `regionalStartups`, `unicorns`, `accelerators`, `policy`) were missing from `_feeds.ts` — the digest endpoint returned empty for these keys while the frontend expected them. Added matching RSS sources.
- **Markets & Commodities empty quotes**: `fetchYahooQuotesBatch()` broke after just 3 total failures when no results accumulated, killing the entire symbol batch on transient Yahoo 429s. Changed to track consecutive failures (break after 5) and reset on any success.
- **Sector Heatmap "Failed to load"**: Sector loading was gated behind market stock rate-limit check — if markets were rate-limited, sector data was never attempted even though `get-sector-summary` had valid data. Decoupled the two so hydrated sectors always load.

## Test plan
- [ ] Verify tech.worldmonitor.app panels (VC Insights, Global Startup News, Unicorn Tracker, Accelerators, AI Policy) load data instead of showing UNAVAILABLE
- [ ] Verify finance.worldmonitor.app Markets panel populates even under partial Yahoo rate limiting
- [ ] Verify finance.worldmonitor.app Sector Heatmap loads independently of market stock status
- [ ] Verify Commodities panel still loads with retry logic