### PR TITLE
fix(prod): CORS fallback, rate-limit bump, RSS proxy allowlist

### DIFF
--- a/api/_rate-limit.js
+++ b/api/_rate-limit.js
@@ -12,7 +12,7 @@ function getRatelimit() {
 
   ratelimit = new Ratelimit({
     redis: new Redis({ url, token }),
-    limiter: Ratelimit.slidingWindow(300, '60 s'),
+    limiter: Ratelimit.slidingWindow(600, '60 s'),
     prefix: 'rl',
     analytics: false,
   });

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3231,6 +3231,8 @@ const server = http.createServer(async (req, res) => {
         'feeds.capi24.com',  // News24 redirect destination
         'islandtimes.org',
         'www.atlanticcouncil.org',
+        'smartraveller.gov.au',
+        'www.smartraveller.gov.au',
       ];
       const parsed = new URL(feedUrl);
       // Block deprecated/stale feed domains — stale clients still request these
@@ -3320,6 +3322,10 @@ const server = http.createServer(async (req, res) => {
             const redirectUrl = response.headers.location.startsWith('http')
               ? response.headers.location
               : new URL(response.headers.location, url).href;
+            const redirectHost = new URL(redirectUrl).hostname;
+            if (!allowedDomains.includes(redirectHost)) {
+              return sendError(403, 'Redirect to disallowed domain');
+            }
             logThrottled('log', `rss-redirect:${feedUrl}:${redirectUrl}`, `[Relay] Following redirect to: ${redirectUrl}`);
             return fetchWithRedirects(redirectUrl, redirectCount + 1);
           }

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -11,7 +11,7 @@ function getRatelimit(): Ratelimit | null {
 
   ratelimit = new Ratelimit({
     redis: new Redis({ url, token }),
-    limiter: Ratelimit.slidingWindow(300, '60 s'),
+    limiter: Ratelimit.slidingWindow(600, '60 s'),
     prefix: 'rl',
     analytics: false,
   });

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,14 @@
   ],
   "headers": [
     {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET, POST, OPTIONS" },
+        { "key": "Access-Control-Allow-Headers", "value": "Content-Type, Authorization, X-WorldMonitor-Key" }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },


### PR DESCRIPTION
## Summary
- **CORS safety-net**: Add wildcard CORS headers in `vercel.json` for `/api/*` so Vercel infra 500s (which bypass edge function code) still return CORS headers — prevents opaque `TypeError: Failed to fetch` in browser console
- **Rate limit 300→600**: Bump sliding window from 300 to 600 req/60s in both `api/_rate-limit.js` and `server/_shared/rate-limit.ts` to accommodate dashboard init burst (~30-40 parallel requests)
- **RSS proxy**: Add `smartraveller.gov.au` (bare + www) to Railway relay allowlist + add redirect hostname validation to prevent SSRF via open redirects

## Test plan
- [ ] `vercel.json` validates as JSON (verified locally)
- [ ] Both rate-limit files have matching `600` value (verified locally)
- [ ] `smartraveller.gov.au` present in both `api/rss-proxy.js` (existing) and `scripts/ais-relay.cjs` (new)
- [ ] Post-deploy: `curl -sI -H "Origin: https://www.worldmonitor.app" https://api.worldmonitor.app/api/market/v1/list-market-quotes | grep -i access-control` returns dynamic origin
- [ ] Post-deploy: RSS proxy returns non-403 for smartraveller feeds
- [ ] Post-deploy: monitor Sentry for reduced 429 rate