### PR TITLE
fix(research): add console.warn to silent catch blocks in research/maritime handlers

### DIFF
--- a/server/worldmonitor/maritime/v1/get-vessel-snapshot.ts
+++ b/server/worldmonitor/maritime/v1/get-vessel-snapshot.ts
@@ -135,7 +135,8 @@ async function fetchVesselSnapshotFromRelay(): Promise<VesselSnapshot | undefine
       densityZones,
       disruptions,
     };
-  } catch {
+  } catch (error) {
+    console.warn('[get-vessel-snapshot] failed to fetch snapshot from relay', error);
     return undefined;
   }
 }
@@ -151,7 +152,8 @@ export async function getVesselSnapshot(
   try {
     const snapshot = await fetchVesselSnapshot();
     return { snapshot };
-  } catch {
+  } catch (error) {
+    console.warn('[get-vessel-snapshot] getVesselSnapshot handler failed', error);
     return { snapshot: undefined };
   }
 }

--- a/server/worldmonitor/research/v1/list-arxiv-papers.ts
+++ b/server/worldmonitor/research/v1/list-arxiv-papers.ts
@@ -102,7 +102,8 @@ export async function listArxivPapers(
       },
     );
     return result || { papers: [], pagination: undefined };
-  } catch {
+  } catch (error) {
+    console.warn('[list-arxiv-papers] failed to fetch arXiv papers', error);
     return { papers: [], pagination: undefined };
   }
 }

--- a/server/worldmonitor/research/v1/list-hackernews-items.ts
+++ b/server/worldmonitor/research/v1/list-hackernews-items.ts
@@ -66,7 +66,8 @@ async function fetchHackernewsItems(req: ListHackernewsItemsRequest): Promise<Ha
             by: raw.by || '',
             submittedAt: (raw.time || 0) * 1000, // HN uses Unix seconds, proto uses ms
           };
-        } catch {
+        } catch (error) {
+          console.warn('[list-hackernews-items] failed to fetch item', id, error);
           return null;
         }
       }),
@@ -93,7 +94,8 @@ export async function listHackernewsItems(
       return items.length > 0 ? { items, pagination: undefined } : null;
     });
     return result || { items: [], pagination: undefined };
-  } catch {
+  } catch (error) {
+    console.warn('[list-hackernews-items] failed to fetch HN items', error);
     return { items: [], pagination: undefined };
   }
 }

--- a/server/worldmonitor/research/v1/list-trending-repos.ts
+++ b/server/worldmonitor/research/v1/list-trending-repos.ts
@@ -37,7 +37,8 @@ async function fetchTrendingRepos(req: ListTrendingReposRequest): Promise<Github
 
     if (!response.ok) throw new Error('Primary API failed');
     data = await response.json() as any[];
-  } catch {
+  } catch (error) {
+    console.warn('[list-trending-repos] primary API failed, trying fallback', error);
     // Fallback API
     try {
       const fallbackUrl = `https://gh-trending-api.herokuapp.com/repositories/${language}?since=${period}`;
@@ -48,7 +49,8 @@ async function fetchTrendingRepos(req: ListTrendingReposRequest): Promise<Github
 
       if (!fallbackResponse.ok) return [];
       data = await fallbackResponse.json() as any[];
-    } catch {
+    } catch (error) {
+      console.warn('[list-trending-repos] fallback API also failed', error);
       return [];
     }
   }
@@ -79,7 +81,8 @@ export async function listTrendingRepos(
       return repos.length > 0 ? { repos, pagination: undefined } : null;
     });
     return result || { repos: [], pagination: undefined };
-  } catch {
+  } catch (error) {
+    console.warn('[list-trending-repos] failed to fetch trending repos', error);
     return { repos: [], pagination: undefined };
   }
 }


### PR DESCRIPTION
## Summary

- Adds `console.warn` logging to 8 silent catch blocks across 4 handler files in the research and maritime modules
- Follows the same pattern established in PR #807 (which covered intelligence handlers)
- Each warning includes the handler name in brackets for grep-ability, a brief description of what failed, and the caught error object

### Files modified:
- `server/worldmonitor/research/v1/list-arxiv-papers.ts` — 1 catch block
- `server/worldmonitor/research/v1/list-trending-repos.ts` — 3 catch blocks (primary API, fallback API, handler)
- `server/worldmonitor/research/v1/list-hackernews-items.ts` — 2 catch blocks (per-item fetch, handler)
- `server/worldmonitor/maritime/v1/get-vessel-snapshot.ts` — 2 catch blocks (relay fetch, handler)

No logic changes — only added logging to previously silent catch blocks.

## Test plan

- [ ] Verify TypeScript compilation passes (`npm run typecheck`)
- [ ] Confirm no runtime behavior changes — all catch blocks still return the same fallback values
- [ ] Optionally trigger a failure scenario (e.g., network timeout) and verify the warning appears in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)