### PR TITLE
ci: add typecheck step before desktop build to fail fast

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -28,7 +28,27 @@ env:
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    name: TypeScript type check
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: TypeScript type check
+        run: npx tsc --noEmit
+
   build-tauri:
+    needs: typecheck
     permissions:
       contents: write
     strategy:


### PR DESCRIPTION
## Summary
- Adds a new `typecheck` job to the desktop build workflow that runs `tsc --noEmit` before any platform builds begin
- The `build-tauri` matrix jobs now depend on this typecheck job via `needs: typecheck`, so all 5 platform builds are gated behind the type check passing
- The typecheck job runs on `ubuntu-latest` with a 5-minute timeout, keeping it lightweight and fast

## Motivation
The desktop build workflow runs a 30+ minute Tauri build across 5 platforms (2 macOS, 1 Windows, 2 Linux). If there is a TypeScript type error, developers currently have to wait for the full build to fail before discovering it. By adding a quick typecheck step that runs first, type errors are caught in under 2 minutes instead of 30+, saving significant CI time and developer frustration.

## Test plan
- [ ] Verify the workflow YAML is valid (no syntax errors)
- [ ] Confirm typecheck job runs before build-tauri jobs in the workflow graph
- [ ] Confirm that a type error would cause the typecheck job to fail and skip all build-tauri jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)