### PR TITLE
Revert PR #803: define ServerOptions locally and warn on duplicate routes

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -16,11 +16,7 @@ import { validateApiKey } from '../api/_api-key.js';
 import { mapErrorToResponse } from './error-mapper';
 import { checkRateLimit } from './_shared/rate-limit';
 import { drainResponseHeaders } from './_shared/response-headers';
-/** Defined locally to avoid a fragile cross-domain import from seismology's generated file. */
-export interface ServerOptions {
-  onError?: (error: unknown, req: Request) => Response | Promise<Response>;
-  validateRequest?: (methodName: string, body: unknown) => { field: string; description: string }[] | undefined;
-}
+import type { ServerOptions } from '../src/generated/server/worldmonitor/seismology/v1/service_server';
 
 export const serverOptions: ServerOptions = { onError: mapErrorToResponse };
 

--- a/server/router.ts
+++ b/server/router.ts
@@ -42,9 +42,6 @@ export function createRouter(allRoutes: RouteDescriptor[]): Router {
       });
     } else {
       const key = `${route.method} ${route.path}`;
-      if (staticTable.has(key)) {
-        console.warn(`[router] Duplicate route registered: ${key}`);
-      }
       staticTable.set(key, route.handler);
       if (!staticPaths.has(route.path)) staticPaths.set(route.path, new Set());
       staticPaths.get(route.path)!.add(route.method);


### PR DESCRIPTION
## Summary
- Reverts #803 which was merged by mistake
- Restores the original `ServerOptions` import from seismology generated file
- Removes the duplicate route warning in router.ts

## Test plan
- [x] `tsc --noEmit` passes (verified by pre-push hook)