### PR TITLE
fix(api): add AbortSignal.timeout to unprotected fetch calls

### DIFF
--- a/server/worldmonitor/displacement/v1/get-displacement-summary.ts
+++ b/server/worldmonitor/displacement/v1/get-displacement-summary.ts
@@ -57,7 +57,7 @@ async function fetchUnhcrYearItems(year: number): Promise<UnhcrRawItem[] | null>
   for (let page = 1; page <= maxPageGuard; page++) {
     const response = await fetch(
       `https://api.unhcr.org/population/v1/population/?year=${year}&limit=${limit}&page=${page}`,
-      { headers: { Accept: 'application/json', 'User-Agent': CHROME_UA } },
+      { headers: { Accept: 'application/json', 'User-Agent': CHROME_UA }, signal: AbortSignal.timeout(15_000) },
     );
 
     if (!response.ok) return null;

--- a/server/worldmonitor/research/v1/list-tech-events.ts
+++ b/server/worldmonitor/research/v1/list-tech-events.ts
@@ -261,9 +261,11 @@ async function fetchTechEvents(req: ListTechEventsRequest): Promise<ListTechEven
   const [icsResponse, rssResponse] = await Promise.allSettled([
     fetch(ICS_URL, {
       headers: { 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(15_000),
     }),
     fetch(DEV_EVENTS_RSS, {
       headers: { 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(15_000),
     }),
   ]);
 


### PR DESCRIPTION
## Summary
- Add `AbortSignal.timeout(15_000)` to the two unprotected `fetch()` calls in `server/worldmonitor/research/v1/list-tech-events.ts` (ICS and RSS background fetches)
- Add `AbortSignal.timeout(15_000)` to the unprotected `fetch()` call in `server/worldmonitor/displacement/v1/get-displacement-summary.ts` (UNHCR Population API)
- These were the only `fetch()` calls in `server/worldmonitor/` without a `signal` option; all other fetches already had timeout protection

## Files modified
| File | Timeout | Rationale |
|------|---------|-----------|
| `server/worldmonitor/research/v1/list-tech-events.ts` | `15_000` (15s) | ICS calendar + RSS feed — heavy payloads |
| `server/worldmonitor/displacement/v1/get-displacement-summary.ts` | `15_000` (15s) | UNHCR JSON API — large paginated dataset |

## Test plan
- [ ] Verify `list-tech-events` still returns results when ICS/RSS sources are reachable
- [ ] Verify `list-tech-events` gracefully handles timeout (Promise.allSettled already handles rejection)
- [ ] Verify `get-displacement-summary` still returns UNHCR data normally
- [ ] Verify `get-displacement-summary` returns `null` on timeout (existing `try`/response check handles it)
- [ ] Run `npm run typecheck` — confirmed passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)