### PR TITLE
fix(ui): clean up window event listeners and ResizeObserver in destroy()

### DIFF
--- a/src/components/CountryTimeline.ts
+++ b/src/components/CountryTimeline.ts
@@ -36,6 +36,7 @@ export class CountryTimeline {
   private tooltip: HTMLDivElement | null = null;
   private resizeObserver: ResizeObserver | null = null;
   private currentEvents: TimelineEvent[] = [];
+  private handleThemeChange: () => void;
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -45,7 +46,7 @@ export class CountryTimeline {
     });
     this.resizeObserver.observe(this.container);
 
-    window.addEventListener('theme-changed', () => {
+    this.handleThemeChange = () => {
       // Re-create tooltip with new theme colors
       if (this.tooltip) {
         this.tooltip.remove();
@@ -54,7 +55,8 @@ export class CountryTimeline {
       this.createTooltip();
       // Re-render chart with new colors
       if (this.currentEvents.length > 0) this.render(this.currentEvents);
-    });
+    };
+    window.addEventListener('theme-changed', this.handleThemeChange);
   }
 
   private createTooltip(): void {
@@ -268,6 +270,7 @@ export class CountryTimeline {
   }
 
   destroy(): void {
+    window.removeEventListener('theme-changed', this.handleThemeChange);
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
       this.resizeObserver = null;

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -389,6 +389,7 @@ export class DeckGLMap {
   private debouncedFetchBases: (() => void) & { cancel(): void };
   private debouncedFetchAircraft: (() => void) & { cancel(): void };
   private rafUpdateLayers: (() => void) & { cancel(): void };
+  private handleThemeChange: (e: Event) => void;
   private moveTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private lastAircraftFetchCenter: [number, number] | null = null;
   private lastAircraftFetchZoom = -1;
@@ -414,13 +415,14 @@ export class DeckGLMap {
     this.setupDOM();
     this.popup = new MapPopup(container);
 
-    window.addEventListener('theme-changed', (e: Event) => {
+    this.handleThemeChange = (e: Event) => {
       const theme = (e as CustomEvent).detail?.theme as 'dark' | 'light';
       if (theme) {
         this.switchBasemap(theme);
         this.render(); // Rebuilds Deck.GL layers with new theme-aware colors
       }
-    });
+    };
+    window.addEventListener('theme-changed', this.handleThemeChange);
 
     this.initMapLibre();
 
@@ -4780,6 +4782,7 @@ export class DeckGLMap {
   }
 
   public destroy(): void {
+    window.removeEventListener('theme-changed', this.handleThemeChange);
     this.debouncedRebuildLayers.cancel();
     this.debouncedFetchBases.cancel();
     this.debouncedFetchAircraft.cancel();

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -159,6 +159,8 @@ export class MapComponent {
     nuclear: new Set(),
   };
   private boundVisibilityHandler!: () => void;
+  private handleThemeChange: () => void;
+  private resizeObserver: ResizeObserver | null = null;
   private renderScheduled = false;
   private lastRenderTime = 0;
   private readonly MIN_RENDER_INTERVAL_MS = 100;
@@ -211,16 +213,17 @@ export class MapComponent {
     this.loadMapData();
     this.setupResizeObserver();
 
-    window.addEventListener('theme-changed', () => {
+    this.handleThemeChange = () => {
       this.baseRendered = false;
       this.render();
-    });
+    };
+    window.addEventListener('theme-changed', this.handleThemeChange);
   }
 
   private setupResizeObserver(): void {
     let lastWidth = 0;
     let lastHeight = 0;
-    const resizeObserver = new ResizeObserver((entries) => {
+    this.resizeObserver = new ResizeObserver((entries) => {
       if (this.isResizing) return;
       for (const entry of entries) {
         const { width, height } = entry.contentRect;
@@ -231,7 +234,7 @@ export class MapComponent {
         }
       }
     });
-    resizeObserver.observe(this.container);
+    this.resizeObserver.observe(this.container);
 
     // Re-render when page becomes visible again (after browser throttling)
     this.boundVisibilityHandler = () => {
@@ -255,7 +258,12 @@ export class MapComponent {
   }
 
   public destroy(): void {
+    window.removeEventListener('theme-changed', this.handleThemeChange);
     document.removeEventListener('visibilitychange', this.boundVisibilityHandler);
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    }
     if (this.healthCheckLoop) {
       this.healthCheckLoop.stop();
       this.healthCheckLoop = null;


### PR DESCRIPTION
## Summary

Multiple components add window-level event listeners using anonymous callbacks, making them impossible to remove when `destroy()` is called. This causes memory leaks as listeners accumulate across component mount/unmount cycles (e.g., when switching views or panels).

**The pattern fixed in each component:**
- Anonymous callback passed to `addEventListener` → stored as a named class property
- `destroy()` now calls `removeEventListener` with the same function reference

### Components fixed

- **CountryTimeline.ts** — `theme-changed` listener was never removed in `destroy()`. Stored handler as `this.handleThemeChange`, added `removeEventListener` call in `destroy()`.
- **DeckGLMap.ts** — `theme-changed` listener was never removed in `destroy()`. Same fix pattern.
- **Map.ts** — Two leaks fixed:
  1. `theme-changed` listener was never removed in `destroy()`. Same fix pattern.
  2. `ResizeObserver` was created as a local variable inside `setupResizeObserver()`, so it could never be disconnected. Promoted to `this.resizeObserver` class property and added `disconnect()` call in `destroy()`.

**Note:** `BreakingNewsBanner.ts` was also audited but already correctly stores all handler references and removes them in its `destroy()` method — no changes needed.

## Test plan

- [ ] Verify TypeScript compiles cleanly (`tsc --noEmit` — confirmed passing in CI pre-push hook)
- [ ] Mount and destroy CountryTimeline, DeckGLMap, and Map components repeatedly; confirm no accumulating `theme-changed` listeners via DevTools Event Listeners panel
- [ ] Toggle theme after component destruction; confirm no errors from stale listeners
- [ ] Resize browser window after Map component destruction; confirm no errors from stale ResizeObserver

🤖 Generated with [Claude Code](https://claude.com/claude-code)