### PR TITLE
fix(ui): prevent event listener accumulation in CascadePanel and GeoHubsPanel

### DIFF
--- a/src/components/CascadePanel.ts
+++ b/src/components/CascadePanel.ts
@@ -28,6 +28,7 @@ export class CascadePanel extends Panel {
       trackActivity: true,
       infoTooltip: t('components.cascade.infoTooltip'),
     });
+    this.setupDelegatedListeners();
     this.init();
   }
 
@@ -196,37 +197,42 @@ export class CascadePanel extends Panel {
         ${this.cascadeResult ? this.renderCascadeResult() : `<div class="cascade-hint">${t('components.cascade.selectInfrastructureHint')}</div>`}
       </div>
     `;
-
-    this.attachEventListeners();
   }
 
-  private attachEventListeners(): void {
-    const filterBtns = this.content.querySelectorAll('.cascade-filter-btn');
-    filterBtns.forEach(btn => {
-      btn.addEventListener('click', () => {
-        this.filter = btn.getAttribute('data-filter') as NodeFilter;
+  /**
+   * Attach delegated event listeners once on the container so that
+   * re-renders (which replace innerHTML) never accumulate listeners.
+   */
+  private setupDelegatedListeners(): void {
+    this.content.addEventListener('click', (e: Event) => {
+      const target = e.target as HTMLElement;
+
+      const filterBtn = target.closest<HTMLElement>('.cascade-filter-btn');
+      if (filterBtn) {
+        this.filter = filterBtn.getAttribute('data-filter') as NodeFilter;
         this.selectedNode = null;
         this.cascadeResult = null;
         this.render();
-      });
+        return;
+      }
+
+      if (target.closest('.cascade-analyze-btn')) {
+        this.runAnalysis();
+      }
     });
 
-    const select = this.content.querySelector('.cascade-select') as HTMLSelectElement;
-    if (select) {
-      select.addEventListener('change', () => {
+    this.content.addEventListener('change', (e: Event) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('.cascade-select')) {
+        const select = target as HTMLSelectElement;
         this.selectedNode = select.value || null;
         this.cascadeResult = null;
         if (this.onSelectCallback) {
           this.onSelectCallback(this.selectedNode);
         }
         this.render();
-      });
-    }
-
-    const analyzeBtn = this.content.querySelector('.cascade-analyze-btn');
-    if (analyzeBtn) {
-      analyzeBtn.addEventListener('click', () => this.runAnalysis());
-    }
+      }
+    });
   }
 
   private runAnalysis(): void {

--- a/src/components/GeoHubsPanel.ts
+++ b/src/components/GeoHubsPanel.ts
@@ -43,6 +43,7 @@ export class GeoHubsPanel extends Panel {
         lowColor: getCSSColor('--text-dim'),
       }),
     });
+    this.setupDelegatedListeners();
   }
 
   public setOnHubClick(handler: (hub: GeoHubActivity) => void): void {
@@ -105,19 +106,22 @@ export class GeoHubsPanel extends Panel {
     }).join('');
 
     this.setContent(html);
-    this.bindEvents();
   }
 
-  private bindEvents(): void {
-    const items = this.content.querySelectorAll<HTMLDivElement>('.geo-hub-item');
-    items.forEach((item) => {
-      item.addEventListener('click', () => {
-        const hubId = item.dataset.hubId;
-        const hub = this.activities.find(a => a.hubId === hubId);
-        if (hub && this.onHubClick) {
-          this.onHubClick(hub);
-        }
-      });
+  /**
+   * Attach a single delegated click listener on the container so that
+   * re-renders (which replace innerHTML) never accumulate listeners.
+   */
+  private setupDelegatedListeners(): void {
+    this.content.addEventListener('click', (e: Event) => {
+      const target = e.target as HTMLElement;
+      const item = target.closest<HTMLDivElement>('.geo-hub-item');
+      if (!item) return;
+      const hubId = item.dataset.hubId;
+      const hub = this.activities.find(a => a.hubId === hubId);
+      if (hub && this.onHubClick) {
+        this.onHubClick(hub);
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary

- **CascadePanel**: replaced per-render `attachEventListeners()` (which attached inline arrow listeners to `.cascade-filter-btn`, `.cascade-select`, and `.cascade-analyze-btn` on every `render()` call) with a single `setupDelegatedListeners()` method called once in the constructor. Uses `event.target.closest()` to delegate click and change events from `this.content`.
- **GeoHubsPanel**: replaced per-render `bindEvents()` (which attached inline click listeners to every `.geo-hub-item` on every `render()` call) with a single delegated click listener set up once in the constructor.

## Problem

Both panels re-created DOM elements via `innerHTML` and then called `addEventListener` with new inline arrow functions on every `render()`. Since arrow functions create a new reference each time, old listeners from previous renders could not be matched for removal, causing them to accumulate. In GeoHubsPanel, the additional complication was that `setContent()` is debounced (150ms), so `bindEvents()` could attach listeners to stale DOM elements that would be replaced moments later.

## Approach

Event delegation (Option B): a single listener on the stable container element (`this.content`) routes events to the correct handler using `event.target.closest()`. This listener is attached exactly once in the constructor and naturally survives `innerHTML` replacements, since the container itself is never replaced. No matter how many times `render()` is called, only one listener exists per event type.

## Test plan

- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] Pre-push hooks pass (typecheck, API typecheck, CJS syntax, version sync)
- [ ] Verify CascadePanel filter buttons switch node type correctly
- [ ] Verify CascadePanel select dropdown updates selected node
- [ ] Verify CascadePanel analyze button runs cascade analysis
- [ ] Verify GeoHubsPanel hub items trigger onHubClick callback
- [ ] Verify repeated render() calls do not duplicate event handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)