### PR TITLE
fix(ui): improve error message specificity in NewsPanel and PWA registration

### DIFF
--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -409,8 +409,22 @@ export class InsightsPanel extends Panel {
       this.renderInsights(importantClusters, sentiments, worldBrief);
     } catch (error) {
       console.error('[InsightsPanel] Error:', error);
-      this.setContent('<div class="insights-error">Analysis failed - retrying...</div>');
+      const reason = InsightsPanel.classifyError(error);
+      this.setContent(`<div class="insights-error">Analysis failed (${reason}) - retrying...</div>`);
     }
+  }
+
+  /** Classify an error into a short user-facing category string. */
+  private static classifyError(err: unknown): string {
+    if (err instanceof DOMException && err.name === 'AbortError') return 'request cancelled';
+    if (err instanceof TypeError && /fetch|network/i.test(err.message)) return 'network error';
+    if (err instanceof Error) {
+      const msg = err.message.toLowerCase();
+      if (msg.includes('timeout') || msg.includes('timed out')) return 'timeout';
+      if (msg.includes('rate') || msg.includes('429') || msg.includes('quota')) return 'rate limited';
+      if (msg.includes('5') && msg.includes('00')) return 'server error';
+    }
+    return 'unexpected error';
   }
 
   private renderInsights(

--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -166,11 +166,14 @@ export class NewsPanel extends Panel {
         this.setCachedSummary(cacheKey, result.summary);
         this.showSummary(result.summary);
       } else {
-        this.summaryContainer.innerHTML = '<div class="panel-summary-error">Could not generate summary</div>';
+        this.summaryContainer.innerHTML = '<div class="panel-summary-error">Summary unavailable (no providers responded)</div>';
+        console.warn('[NewsPanel] generateSummary returned null — all providers exhausted');
         setTimeout(() => this.hideSummary(), 3000);
       }
-    } catch {
-      this.summaryContainer.innerHTML = '<div class="panel-summary-error">Summary failed</div>';
+    } catch (err) {
+      const reason = NewsPanel.classifyError(err);
+      this.summaryContainer.innerHTML = `<div class="panel-summary-error">Summary failed (${reason})</div>`;
+      console.warn('[NewsPanel] Summary error:', err);
       setTimeout(() => this.hideSummary(), 3000);
     } finally {
       this.isSummarizing = false;
@@ -228,6 +231,20 @@ export class NewsPanel extends Panel {
     if (!this.summaryContainer) return;
     this.summaryContainer.style.display = 'none';
     this.summaryContainer.innerHTML = '';
+  }
+
+  /** Classify an error into a short user-facing category string. */
+  private static classifyError(err: unknown): string {
+    if (err instanceof DOMException && err.name === 'AbortError') return 'request cancelled';
+    if (err instanceof TypeError && /fetch|network/i.test(err.message)) return 'network error';
+    if (err instanceof Error) {
+      const msg = err.message.toLowerCase();
+      if (msg.includes('timeout') || msg.includes('timed out')) return 'timeout';
+      if (msg.includes('rate') || msg.includes('429') || msg.includes('quota')) return 'rate limited';
+      if (msg.includes('401') || msg.includes('403') || msg.includes('unauthorized')) return 'auth error';
+      if (msg.includes('5') && msg.includes('00')) return 'server error';
+    }
+    return 'unexpected error';
   }
 
   private getHeadlineSignature(): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -284,8 +284,12 @@ if (!('__TAURI_INTERNALS__' in window) && !('__TAURI__' in window) && 'serviceWo
       console.log('[PWA] Service worker registered');
       setInterval(async () => {
         if (!navigator.onLine) return;
-        try { await registration.update(); } catch {}
+        try { await registration.update(); } catch (updateErr) {
+          console.warn('[PWA] Service worker update check failed:', updateErr);
+        }
       }, 60 * 60 * 1000);
     })
-    .catch(() => {});
+    .catch((error) => {
+      console.warn('[PWA] Service worker registration failed:', error);
+    });
 }


### PR DESCRIPTION
## Summary
- **NewsPanel.ts**: Replaced generic `"Could not generate summary"` and `"Summary failed"` with contextual messages that include the error category (e.g. `"Summary failed (timeout)"`, `"Summary unavailable (no providers responded)"`)
- **InsightsPanel.ts**: Replaced generic `"Analysis failed - retrying..."` with categorized error reason (e.g. `"Analysis failed (network error) - retrying..."`)
- **main.ts**: Replaced silent `.catch(() => {})` on service worker registration and the hourly update interval with `console.warn` logging that includes the error object, aiding offline-mode debugging
- Added `classifyError()` static helper to both `NewsPanel` and `InsightsPanel` that maps common error types (timeout, network, rate limit, auth, server error) to concise user-facing labels without exposing internal details

## Details

Error classification categories:
| Error type | User-facing label |
|---|---|
| `AbortError` DOMException | `request cancelled` |
| `TypeError` with fetch/network | `network error` |
| Message contains "timeout" | `timeout` |
| Message contains "429" / "rate" / "quota" | `rate limited` |
| Message contains "401" / "403" / "unauthorized" | `auth error` |
| Message contains 5xx pattern | `server error` |
| Anything else | `unexpected error` |

All developer-facing `console.warn` calls include the full error object for debugging.

## Test plan
- [ ] Trigger summary generation with API providers down — verify message shows "Summary unavailable (no providers responded)" instead of "Could not generate summary"
- [ ] Simulate a network error during summary — verify message shows "Summary failed (network error)"
- [ ] Verify InsightsPanel shows categorized error on analysis failure
- [ ] Disable service worker (e.g. serve without HTTPS) — verify console shows `[PWA] Service worker registration failed:` with error details
- [ ] Verify no regressions in happy-path summarization flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)