### PR TITLE
fix(ui): store and clear setInterval/setTimeout IDs to prevent memory leaks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -282,10 +282,14 @@ if (!('__TAURI_INTERNALS__' in window) && !('__TAURI__' in window) && 'serviceWo
   navigator.serviceWorker.register('/sw.js', { scope: '/' })
     .then((registration) => {
       console.log('[PWA] Service worker registered');
-      setInterval(async () => {
+      const swUpdateInterval = setInterval(async () => {
         if (!navigator.onLine) return;
         try { await registration.update(); } catch {}
       }, 60 * 60 * 1000);
+      // Expose interval ID for cleanup/debugging
+      (window as unknown as Record<string, unknown>).__swUpdateInterval = swUpdateInterval;
     })
-    .catch(() => {});
+    .catch((err) => {
+      console.warn('[PWA] Service worker registration failed:', err);
+    });
 }

--- a/src/services/military-flights.ts
+++ b/src/services/military-flights.ts
@@ -32,6 +32,7 @@ let flightCache: { data: MilitaryFlight[]; timestamp: number } | null = null;
 const flightHistory = new Map<string, { positions: [number, number][]; lastUpdate: number }>();
 const HISTORY_MAX_POINTS = 20;
 const HISTORY_CLEANUP_INTERVAL = 5 * 60 * 1000; // 5 minutes
+let historyCleanupIntervalId: ReturnType<typeof setInterval> | null = null;
 
 // Circuit breaker for API calls
 const breaker = createCircuitBreaker<{ flights: MilitaryFlight[]; clusters: MilitaryFlightCluster[] }>({
@@ -497,7 +498,15 @@ function cleanupFlightHistory(): void {
 
 // Set up periodic cleanup
 if (typeof window !== 'undefined') {
-  setInterval(cleanupFlightHistory, HISTORY_CLEANUP_INTERVAL);
+  historyCleanupIntervalId = setInterval(cleanupFlightHistory, HISTORY_CLEANUP_INTERVAL);
+}
+
+/** Stop the periodic flight-history cleanup (for teardown / testing). */
+export function stopFlightHistoryCleanup(): void {
+  if (historyCleanupIntervalId) {
+    clearInterval(historyCleanupIntervalId);
+    historyCleanupIntervalId = null;
+  }
 }
 
 /**

--- a/src/services/military-vessels.ts
+++ b/src/services/military-vessels.ts
@@ -28,6 +28,7 @@ const VESSEL_STALE_TIME = 60 * 60 * 1000; // 1 hour - consider vessel stale
 // Tracking state
 let isTracking = false;
 let messageCount = 0;
+let historyCleanupIntervalId: ReturnType<typeof setInterval> | null = null;
 
 // Circuit breaker
 const breaker = createCircuitBreaker<{ vessels: MilitaryVessel[]; clusters: MilitaryVesselCluster[] }>({
@@ -489,7 +490,15 @@ function clusterVessels(vessels: MilitaryVessel[]): MilitaryVesselCluster[] {
 
 // Initialize cleanup interval
 if (typeof window !== 'undefined') {
-  setInterval(cleanup, HISTORY_CLEANUP_INTERVAL);
+  historyCleanupIntervalId = setInterval(cleanup, HISTORY_CLEANUP_INTERVAL);
+}
+
+/** Stop the periodic history cleanup (for teardown / testing). */
+export function stopVesselHistoryCleanup(): void {
+  if (historyCleanupIntervalId) {
+    clearInterval(historyCleanupIntervalId);
+    historyCleanupIntervalId = null;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`src/main.ts`**: The `setInterval` for hourly SW update checks was never stored, leaking the interval ID. Now stored and exposed on `window.__swUpdateInterval` for cleanup/debugging. Also changed the `.catch(() => {})` on SW registration to log the error with `console.warn`.
- **`src/services/military-vessels.ts`**: The module-level `setInterval(cleanup, ...)` for vessel history cleanup had no stored ID and no way to clear it. Now stored in a module variable with an exported `stopVesselHistoryCleanup()` function for teardown/testing.
- **`src/services/military-flights.ts`**: Same issue as vessels -- `setInterval(cleanupFlightHistory, ...)` was never stored. Now stored with an exported `stopFlightHistoryCleanup()` function.

### Interval audit across `src/`

| File | Interval | Had cleanup? | Status |
|------|----------|-------------|--------|
| `src/main.ts` | SW update check (hourly) | No | **Fixed** -- stored + exposed on window |
| `src/services/military-vessels.ts` | History cleanup (10 min) | No | **Fixed** -- stored + exported stop fn |
| `src/services/military-flights.ts` | History cleanup (5 min) | No | **Fixed** -- stored + exported stop fn |
| `src/components/IntelligenceGapBadge.ts` | `refreshInterval` (3 min) | Yes (`destroy()` + `setEnabled(false)`) | OK |
| `src/components/IntelligenceGapBadge.ts` | `pendingUpdateFrame` (rAF) | Yes (`destroy()`) | OK |
| `src/components/SecurityAdvisoriesPanel.ts` | `refreshInterval` | Yes (`destroy()`) | OK |
| `src/components/Map.ts` | `healthCheckIntervalId` | Yes (`destroy()`) | OK |
| `src/components/DeckGLMap.ts` | `newsPulseIntervalId`, `dayNightIntervalId` | Yes (`destroy()`) | OK |
| `src/components/WorldClockPanel.ts` | `tickInterval` | Yes (`destroy()`) | OK |
| `src/components/GulfEconomiesPanel.ts` | `pollTimer` | Yes (`destroy()`) | OK |
| `src/components/LiveNewsPanel.ts` | `muteSyncInterval` | Yes (`destroy()`) | OK |
| `src/components/StrategicPosturePanel.ts` | `loadingElapsedInterval` | Yes (`destroy()`) | OK |
| `src/services/tv-mode.ts` | `intervalId` | Yes (`stop()`) | OK |
| `src/services/oref-alerts.ts` | `pollingInterval` | Yes (`stopOrefPolling()`) | OK |
| `src/services/maritime/index.ts` | `pollInterval` | Yes (`stopMaritimePolling()`) | OK |
| `src/app/desktop-updater.ts` | `updateCheckIntervalId` | Yes (`destroy()`) | OK |
| `src/app/event-handlers.ts` | `snapshotIntervalId`, `clockIntervalId` | Yes (`destroy()`) | OK |
| `src/settings-main.ts` | `refreshInterval` (traffic log) | Yes (cleanup on close) | OK |

## Test plan

- [ ] Verify the app loads without TypeScript errors (pre-push hook passes `tsc --noEmit`)
- [ ] Confirm service worker registers and hourly update check fires
- [ ] Confirm `window.__swUpdateInterval` is set after SW registration
- [ ] Confirm failed SW registration logs a warning instead of silently failing
- [ ] Verify military vessel/flight modules still run their cleanup intervals

🤖 Generated with [Claude Code](https://claude.com/claude-code)