### PR TITLE
fix(security): escape external data in innerHTML to prevent XSS

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -3,6 +3,7 @@ import { fetchLiveVideoInfo } from '@/services/live-news';
 import { isDesktopRuntime, getRemoteApiBaseUrl, getApiBaseUrl, getLocalApiPort } from '@/services/runtime';
 import { t } from '../services/i18n';
 import { loadFromStorage, saveToStorage } from '@/utils';
+import { escapeHtml, sanitizeUrl } from '@/utils/sanitize';
 import { STORAGE_KEYS, SITE_VARIANT } from '@/config';
 import { getStreamQuality } from '@/services/ai-flow-settings';
 
@@ -945,10 +946,11 @@ export class LiveNewsPanel extends Panel {
 
   private showOfflineMessage(channel: LiveChannel): void {
     this.destroyPlayer();
+    const safeName = escapeHtml(channel.name);
     this.content.innerHTML = `
       <div class="live-offline">
         <div class="offline-icon">📺</div>
-        <div class="offline-text">${t('components.liveNews.notLive', { name: channel.name })}</div>
+        <div class="offline-text">${t('components.liveNews.notLive', { name: safeName })}</div>
         <button class="offline-retry" onclick="this.closest('.panel').querySelector('.live-channel-btn.active')?.click()">${t('common.retry')}</button>
       </div>
     `;
@@ -958,13 +960,14 @@ export class LiveNewsPanel extends Panel {
     this.destroyPlayer();
     const watchUrl = channel.videoId
       ? `https://www.youtube.com/watch?v=${encodeURIComponent(channel.videoId)}`
-      : `https://www.youtube.com/${channel.handle}`;
+      : `https://www.youtube.com/${encodeURIComponent(channel.handle)}`;
+    const safeName = escapeHtml(channel.name);
 
     this.content.innerHTML = `
       <div class="live-offline">
         <div class="offline-icon">!</div>
-        <div class="offline-text">${t('components.liveNews.cannotEmbed', { name: channel.name, code: String(errorCode) })}</div>
-        <a class="offline-retry" href="${watchUrl}" target="_blank" rel="noopener noreferrer">${t('components.liveNews.openOnYouTube')}</a>
+        <div class="offline-text">${t('components.liveNews.cannotEmbed', { name: safeName, code: String(errorCode) })}</div>
+        <a class="offline-retry" href="${sanitizeUrl(watchUrl)}" target="_blank" rel="noopener noreferrer">${t('components.liveNews.openOnYouTube')}</a>
       </div>
     `;
   }

--- a/src/components/SignalModal.ts
+++ b/src/components/SignalModal.ts
@@ -192,7 +192,7 @@ export class SignalModal {
       detailsHtml += `
         <div class="signal-context-item">
           <span class="context-label">${t('modals.signal.source')}</span>
-          <span class="context-value">${escapeHtml(cascade.sourceName)} (${cascade.sourceType})</span>
+          <span class="context-value">${escapeHtml(cascade.sourceName)} (${escapeHtml(cascade.sourceType)})</span>
         </div>
         <div class="signal-context-item">
           <span class="context-label">${t('modals.signal.countriesAffected')}</span>
@@ -295,7 +295,7 @@ export class SignalModal {
           ${locationData.lat && locationData.lon ? `
             <div class="signal-location">
               <button class="location-link" data-lat="${locationData.lat}" data-lon="${locationData.lon}">
-                📍 ${t('modals.signal.viewOnMap')}: ${locationData.regionName || `${locationData.lat.toFixed(2)}°, ${locationData.lon.toFixed(2)}°`}
+                📍 ${t('modals.signal.viewOnMap')}: ${locationData.regionName ? escapeHtml(locationData.regionName) : `${locationData.lat.toFixed(2)}°, ${locationData.lon.toFixed(2)}°`}
               </button>
             </div>
           ` : ''}


### PR DESCRIPTION
## Summary

- **LiveNewsPanel**: `channel.name` from user-created custom channels was interpolated into `innerHTML` via `i18next.t()` without escaping (i18n config has `escapeValue: false`). Also `channel.handle` was used directly in a YouTube URL path without encoding, and the resulting URL was not sanitized before use in an `href` attribute.
- **SignalModal**: `regionName` from correlation signal data and `cascade.sourceType` (both typed as plain `string`) were interpolated into `innerHTML` without `escapeHtml()`.

These are all cases where external data (custom channel names stored in localStorage, signal data from the correlation engine, cascade analysis results) flows into `innerHTML` without HTML escaping, creating potential XSS vectors.

## Changes

| File | Fix |
|------|-----|
| `src/components/LiveNewsPanel.ts` | Import `escapeHtml`/`sanitizeUrl`; escape `channel.name` before passing to `t()`; `encodeURIComponent` the `channel.handle` in URL path; `sanitizeUrl()` the YouTube watch URL in href |
| `src/components/SignalModal.ts` | Wrap `regionName` and `cascade.sourceType` with `escapeHtml()` |

## Context

The project already has a well-used `escapeHtml` utility in `src/utils/sanitize.ts` and most components apply it correctly. The i18next configuration explicitly sets `escapeValue: false`, meaning any values interpolated via `t('key', { name: value })` are passed through as-is -- callers must escape before passing to `t()` when the result ends up in `innerHTML`.

## Test plan

- [ ] Verify custom live channels with special characters in name (`<b>test</b>`) display the literal text, not bold HTML
- [ ] Verify offline/embed-error messages render correctly for built-in channels
- [ ] Verify signal modal displays location region names correctly
- [ ] Verify TypeScript compilation passes (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)