### PR TITLE
fix(ui): use event delegation to prevent listener accumulation after innerHTML

### DIFF
--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -60,8 +60,6 @@ export class CountryBriefPage implements CountryBriefPanel {
   private onCloseCallback?: () => void;
   private onShareStory?: (code: string, name: string) => void;
   private onExportImage?: (code: string, name: string) => void;
-  private boundExportMenuClose: (() => void) | null = null;
-  private boundCitationClick: ((e: Event) => void) | null = null;
   private abortController: AbortController = new AbortController();
 
   constructor() {
@@ -69,9 +67,96 @@ export class CountryBriefPage implements CountryBriefPanel {
     this.overlay.className = 'country-brief-overlay';
     document.body.appendChild(this.overlay);
 
+    // Single delegated click handler for all interactive elements.
+    // This prevents listener accumulation when show()/showLoading() replace innerHTML.
     this.overlay.addEventListener('click', (e) => {
-      if ((e.target as HTMLElement).classList.contains('country-brief-overlay')) this.hide();
+      const target = e.target as HTMLElement;
+
+      // Click on overlay background to close
+      if (target.classList.contains('country-brief-overlay')) {
+        this.hide();
+        return;
+      }
+
+      // Close button
+      if (target.closest('.cb-close')) {
+        this.hide();
+        return;
+      }
+
+      // Link share button (copy URL to clipboard)
+      const linkShareBtn = target.closest('.cb-link-share-btn') as HTMLButtonElement | null;
+      if (linkShareBtn) {
+        if (!this.currentCode || !this.currentName) return;
+        const url = `${window.location.origin}/?c=${this.currentCode}`;
+        navigator.clipboard.writeText(url).then(() => {
+          const orig = linkShareBtn.innerHTML;
+          linkShareBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+          setTimeout(() => { linkShareBtn.innerHTML = orig; }, 1500);
+        }).catch(() => {});
+        return;
+      }
+
+      // Share button
+      if (target.closest('.cb-share-btn')) {
+        if (this.onShareStory && this.currentCode && this.currentName) {
+          this.onShareStory(this.currentCode, this.currentName);
+        }
+        return;
+      }
+
+      // Print button
+      if (target.closest('.cb-print-btn')) {
+        window.print();
+        return;
+      }
+
+      // Export button (toggle menu)
+      if (target.closest('.cb-export-btn')) {
+        e.stopPropagation();
+        const exportMenu = this.overlay.querySelector('.cb-export-menu');
+        exportMenu?.classList.toggle('hidden');
+        return;
+      }
+
+      // Export option buttons
+      const exportOption = target.closest('.cb-export-option') as HTMLElement | null;
+      if (exportOption) {
+        const format = exportOption.dataset.format;
+        if (format === 'image') {
+          if (this.onExportImage && this.currentCode && this.currentName) {
+            this.onExportImage(this.currentCode, this.currentName);
+          }
+        } else if (format === 'pdf') {
+          this.exportPdf();
+        } else if (format === 'json' || format === 'csv') {
+          this.exportBrief(format);
+        }
+        const exportMenu = this.overlay.querySelector('.cb-export-menu');
+        exportMenu?.classList.add('hidden');
+        return;
+      }
+
+      // Citation links
+      if (target.classList.contains('cb-citation')) {
+        e.preventDefault();
+        const href = target.getAttribute('href');
+        if (href) {
+          const el = this.overlay.querySelector(href);
+          el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          el?.classList.add('cb-news-highlight');
+          setTimeout(() => el?.classList.remove('cb-news-highlight'), 2000);
+        }
+        return;
+      }
+
+      // Clicking anywhere else closes the export menu if open
+      const exportMenu = this.overlay.querySelector('.cb-export-menu');
+      if (exportMenu && !exportMenu.classList.contains('hidden')) {
+        exportMenu.classList.add('hidden');
+      }
     });
+
     document.addEventListener('keydown', (e) => {
       if (e.key === 'Escape' && this.overlay.classList.contains('active')) this.hide();
     });
@@ -221,7 +306,7 @@ export class CountryBriefPage implements CountryBriefPanel {
           </div>
         </div>
       </div>`;
-    this.overlay.querySelector('.cb-close')?.addEventListener('click', () => this.hide());
+    // Close button click is handled via event delegation on the overlay (set up in constructor)
     this.overlay.classList.add('active');
   }
 
@@ -349,68 +434,8 @@ export class CountryBriefPage implements CountryBriefPanel {
         </div>
       </div>`;
 
-    this.overlay.querySelector('.cb-close')?.addEventListener('click', () => this.hide());
-    const linkShareBtn = this.overlay.querySelector('.cb-link-share-btn') as HTMLButtonElement | null;
-    linkShareBtn?.addEventListener('click', () => {
-      if (!this.currentCode || !this.currentName) return;
-      const url = `${window.location.origin}/?c=${this.currentCode}`;
-      navigator.clipboard.writeText(url).then(() => {
-        const orig = linkShareBtn!.innerHTML;
-        linkShareBtn!.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
-        setTimeout(() => { linkShareBtn!.innerHTML = orig; }, 1500);
-      }).catch(() => {});
-    });
-    this.overlay.querySelector('.cb-share-btn')?.addEventListener('click', () => {
-      if (this.onShareStory && this.currentCode && this.currentName) {
-        this.onShareStory(this.currentCode, this.currentName);
-      }
-    });
-    this.overlay.querySelector('.cb-print-btn')?.addEventListener('click', () => {
-      window.print();
-    });
-
-    const exportBtn = this.overlay.querySelector('.cb-export-btn');
-    const exportMenu = this.overlay.querySelector('.cb-export-menu');
-    exportBtn?.addEventListener('click', (e) => {
-      e.stopPropagation();
-      exportMenu?.classList.toggle('hidden');
-    });
-    this.overlay.querySelectorAll('.cb-export-option').forEach(opt => {
-      opt.addEventListener('click', () => {
-        const format = (opt as HTMLElement).dataset.format;
-        if (format === 'image') {
-          if (this.onExportImage && this.currentCode && this.currentName) {
-            this.onExportImage(this.currentCode, this.currentName);
-          }
-        } else if (format === 'pdf') {
-          this.exportPdf();
-        } else {
-          this.exportBrief(format as 'json' | 'csv');
-        }
-        exportMenu?.classList.add('hidden');
-      });
-    });
-    // Remove previous overlay-level listeners to prevent accumulation
-    if (this.boundExportMenuClose) this.overlay.removeEventListener('click', this.boundExportMenuClose);
-    if (this.boundCitationClick) this.overlay.removeEventListener('click', this.boundCitationClick);
-
-    this.boundExportMenuClose = () => exportMenu?.classList.add('hidden');
-    this.overlay.addEventListener('click', this.boundExportMenuClose);
-
-    this.boundCitationClick = (e: Event) => {
-      const target = e.target as HTMLElement;
-      if (target.classList.contains('cb-citation')) {
-        e.preventDefault();
-        const href = target.getAttribute('href');
-        if (href) {
-          const el = this.overlay.querySelector(href);
-          el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-          el?.classList.add('cb-news-highlight');
-          setTimeout(() => el?.classList.remove('cb-news-highlight'), 2000);
-        }
-      }
-    };
-    this.overlay.addEventListener('click', this.boundCitationClick);
+    // All button click handlers (close, share, print, export, citation, link-share) are handled
+    // via event delegation on the overlay (set up in constructor)
 
     this.overlay.classList.add('active');
   }

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -192,9 +192,14 @@ export class MapPopup {
     // Append to body to avoid container overflow clipping
     document.body.appendChild(this.popup);
 
-    // Close button handler
-    this.popup.querySelector('.popup-close')?.addEventListener('click', () => this.hide());
-    this.popup.querySelector('.map-popup-sheet-handle')?.addEventListener('click', () => this.hide());
+    // Close button handler via event delegation on the popup element.
+    // This avoids re-querying and re-attaching listeners after innerHTML.
+    this.popup.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('.popup-close') || target.closest('.map-popup-sheet-handle')) {
+        this.hide();
+      }
+    });
 
     if (this.isMobileSheet) {
       this.popup.addEventListener('touchstart', this.handleSheetTouchStart, { passive: true });

--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -118,6 +118,14 @@ export class NewsPanel extends Panel {
     this.summaryContainer.style.display = 'none';
     this.element.insertBefore(this.summaryContainer, this.content);
 
+    // Event delegation: handle close button clicks inside summaryContainer
+    // regardless of how many times innerHTML is replaced by showSummary()
+    this.summaryContainer.addEventListener('click', (e) => {
+      if ((e.target as HTMLElement).closest('.panel-summary-close')) {
+        this.hideSummary();
+      }
+    });
+
     // Create summarize button
     this.summaryBtn = document.createElement('button');
     this.summaryBtn.className = 'panel-summarize-btn';
@@ -229,7 +237,7 @@ export class NewsPanel extends Panel {
         <button class="panel-summary-close" title="${t('components.newsPanel.close')}" aria-label="${t('components.newsPanel.close')}">×</button>
       </div>
     `;
-    this.summaryContainer.querySelector('.panel-summary-close')?.addEventListener('click', () => this.hideSummary());
+    // Close button click is handled via event delegation on summaryContainer (set up in constructor)
   }
 
   private hideSummary(): void {


### PR DESCRIPTION
## Summary

- **NewsPanel**: Moved `.panel-summary-close` click listener from `showSummary()` (called on every summary display) to a single delegated listener on `summaryContainer` in the constructor. Prevents listener accumulation when `showSummary()` is called repeatedly.
- **MapPopup**: Replaced per-element `querySelector().addEventListener()` calls for `.popup-close` and `.map-popup-sheet-handle` with a single delegated click handler on the popup root element using `closest()`.
- **CountryBriefPage**: Consolidated all button click handlers (close, share, print, export menu, export options, citation links, and export-menu-dismiss) into a single delegated click handler on the overlay, set up once in the constructor. Removed the `boundExportMenuClose` and `boundCitationClick` fields and their manual add/remove lifecycle, which was an incomplete workaround for the same accumulation issue.
- **SignalModal**: Analyzed and confirmed it is already clean — close/dismiss listeners target stable DOM set up once in the constructor, and dynamic content handlers (location-link, suppress-keyword-btn) already use event delegation.

## Problem

Components that set `container.innerHTML = ...` and then call `container.querySelector('.btn')?.addEventListener('click', handler)` will accumulate listeners if that method is called more than once. While old inner elements get replaced by `innerHTML`, the pattern is fragile: overlay-level listeners (like `boundExportMenuClose`) explicitly accumulated on each `show()` call, requiring manual cleanup that was easy to get wrong.

## Approach

Event delegation: attach a single click listener on a stable parent element and use `(e.target as HTMLElement).closest('.selector')` to match child elements. The listener count stays at exactly 1 regardless of how many times `innerHTML` is replaced.

## Test plan

- [ ] Open the news panel, click the summarize button, verify the close button on the summary dismisses it
- [ ] Click summarize again — verify close still works (no double-fire)
- [ ] Click map markers to open MapPopup — verify close button and sheet handle work
- [ ] Open a country brief page — verify close, share, print, export (all formats), and citation links work
- [ ] Open a different country brief without closing the first — verify all buttons still work correctly
- [ ] Verify TypeScript compiles without errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)