### PR TITLE
fix(ui): guard async operations against stale DOM references

### DIFF
--- a/src/components/DeductionPanel.ts
+++ b/src/components/DeductionPanel.ts
@@ -140,10 +140,12 @@ export class DeductionPanel extends Panel {
                 query,
                 geoContext,
             });
+            if (!this.element?.isConnected) return;
 
             this.resultContainer.className = 'deduction-result';
             if (resp.analysis) {
                 const parsed = await marked.parse(resp.analysis);
+                if (!this.element?.isConnected) return;
                 this.resultContainer.innerHTML = DOMPurify.sanitize(parsed);
 
                 const meta = h('div', { style: 'margin-top: 12px; font-size: 0.75em; color: #888;' },
@@ -154,12 +156,15 @@ export class DeductionPanel extends Panel {
                 this.resultContainer.textContent = 'No analysis available for this query.';
             }
         } catch (err) {
+            if (!this.element?.isConnected) return;
             console.error('[DeductionPanel] Error:', err);
             this.resultContainer.className = 'deduction-result error';
             this.resultContainer.textContent = 'An error occurred while analyzing the situation.';
         } finally {
             this.isSubmitting = false;
-            setTimeout(() => { this.submitBtn.disabled = false; }, COOLDOWN_MS);
+            if (this.element?.isConnected) {
+                setTimeout(() => { this.submitBtn.disabled = false; }, COOLDOWN_MS);
+            }
         }
     }
 }

--- a/src/components/ETFFlowsPanel.ts
+++ b/src/components/ETFFlowsPanel.ts
@@ -51,19 +51,23 @@ export class ETFFlowsPanel extends Panel {
       try {
         const client = new MarketServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });
         this.data = await client.listEtfFlows({});
+        if (!this.element?.isConnected) return;
         this.error = null;
 
         if (this.data && this.data.etfs.length === 0 && !this.data.rateLimited && attempt < 2) {
           this.showRetrying();
           await new Promise(r => setTimeout(r, 20_000));
+          if (!this.element?.isConnected) return;
           continue;
         }
         break;
       } catch (err) {
         if (this.isAbortError(err)) return;
+        if (!this.element?.isConnected) return;
         if (attempt < 2) {
           this.showRetrying();
           await new Promise(r => setTimeout(r, 20_000));
+          if (!this.element?.isConnected) return;
           continue;
         }
         this.error = err instanceof Error ? err.message : 'Failed to fetch';

--- a/src/components/GdeltIntelPanel.ts
+++ b/src/components/GdeltIntelPanel.ts
@@ -70,11 +70,13 @@ export class GdeltIntelPanel extends Panel {
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
         const data = await fetchTopicIntelligence(this.activeTopic);
+        if (!this.element?.isConnected) return;
         this.topicData.set(this.activeTopic.id, data);
 
         if (data.articles.length === 0 && attempt < 2) {
           this.showRetrying();
           await new Promise(r => setTimeout(r, 15_000));
+          if (!this.element?.isConnected) return;
           continue;
         }
 
@@ -83,10 +85,12 @@ export class GdeltIntelPanel extends Panel {
         return;
       } catch (error) {
         if (this.isAbortError(error)) return;
+        if (!this.element?.isConnected) return;
         console.error(`[GdeltIntelPanel] Load error (attempt ${attempt + 1}):`, error);
         if (attempt < 2) {
           this.showRetrying();
           await new Promise(r => setTimeout(r, 15_000));
+          if (!this.element?.isConnected) return;
           continue;
         }
         this.showError(t('common.failedIntelFeed'));

--- a/src/components/GoodThingsDigestPanel.ts
+++ b/src/components/GoodThingsDigestPanel.ts
@@ -67,7 +67,7 @@ export class GoodThingsDigestPanel extends Panel {
     // Summarize in parallel with progressive updates
     const signal = this.summaryAbort.signal;
     await Promise.allSettled(top5.map(async (item, idx) => {
-      if (signal.aborted) return;
+      if (signal.aborted || !this.element?.isConnected) return;
       try {
         // Pass [title, source] as two headlines to satisfy generateSummary's
         // minimum length requirement (headlines.length >= 2).
@@ -76,11 +76,11 @@ export class GoodThingsDigestPanel extends Panel {
           undefined,
           item.locationName,
         );
-        if (signal.aborted) return;
+        if (signal.aborted || !this.element?.isConnected) return;
         const summary = result?.summary ?? item.title.slice(0, 200);
         this.updateCardSummary(idx, summary);
       } catch {
-        if (!signal.aborted) {
+        if (!signal.aborted && this.element?.isConnected) {
           this.updateCardSummary(idx, item.title.slice(0, 200));
         }
       }

--- a/src/components/GulfEconomiesPanel.ts
+++ b/src/components/GulfEconomiesPanel.ts
@@ -42,13 +42,15 @@ export class GulfEconomiesPanel extends Panel {
   public async fetchData(): Promise<void> {
     try {
       const data = await client.listGulfQuotes({});
+      if (!this.element?.isConnected) return;
       this.renderGulf(data);
     } catch (err) {
       if (this.isAbortError(err)) return;
+      if (!this.element?.isConnected) return;
       this.showError(t('common.failedMarketData'));
     }
 
-    if (!this.pollTimer) {
+    if (!this.pollTimer && this.element?.isConnected) {
       this.pollTimer = setInterval(() => void this.fetchData(), 60_000);
     }
   }

--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -690,6 +690,7 @@ export class InsightsPanel extends Panel {
     } catch {
       // Best effort; fallback regeneration still works from memory reset.
     }
+    if (!this.element?.isConnected) return;
 
     if (!isAnyAiProviderEnabled()) {
       this.setDataBadge('unavailable');

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -910,6 +910,7 @@ export class LiveNewsPanel extends Panel {
     });
 
     await this.resolveChannelVideo(channel);
+    if (!this.element?.isConnected) return;
 
     this.channelSwitcher?.querySelectorAll('.live-channel-btn').forEach(btn => {
       const btnEl = btn as HTMLElement;
@@ -1208,6 +1209,7 @@ export class LiveNewsPanel extends Panel {
     const useFallbackVideo = this.activeChannel.useFallbackOnly || this.forceFallbackVideoForNextInit;
     this.forceFallbackVideoForNextInit = false;
     await this.resolveChannelVideo(this.activeChannel, useFallbackVideo);
+    if (!this.element?.isConnected) return;
 
     if (this.getDirectHlsUrl(this.activeChannel.id) || this.getProxiedHlsUrl(this.activeChannel.id)) {
       this.renderNativeHlsPlayer();
@@ -1225,6 +1227,7 @@ export class LiveNewsPanel extends Panel {
     }
 
     await LiveNewsPanel.loadYouTubeApi();
+    if (!this.element?.isConnected) return;
     if (this.player || !this.playerElement || !window.YT?.Player) return;
 
     this.player = new window.YT!.Player(this.playerElement, {

--- a/src/components/MacroSignalsPanel.ts
+++ b/src/components/MacroSignalsPanel.ts
@@ -144,20 +144,24 @@ export class MacroSignalsPanel extends Panel {
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
         const res = await economicClient.getMacroSignals({});
+        if (!this.element?.isConnected) return false;
         this.data = mapProtoToData(res);
         this.error = null;
 
         if (this.data && this.data.unavailable && attempt < 2) {
           this.showRetrying();
           await new Promise(r => setTimeout(r, 20_000));
+          if (!this.element?.isConnected) return false;
           continue;
         }
         break;
       } catch (err) {
         if (this.isAbortError(err)) return false;
+        if (!this.element?.isConnected) return false;
         if (attempt < 2) {
           this.showRetrying();
           await new Promise(r => setTimeout(r, 20_000));
+          if (!this.element?.isConnected) return false;
           continue;
         }
         this.error = err instanceof Error ? err.message : 'Failed to fetch';

--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -158,6 +158,7 @@ export class NewsPanel extends Panel {
 
     try {
       const result = await generateSummary(this.currentHeadlines.slice(0, 8), undefined, this.panelId, currentLang);
+      if (!this.element?.isConnected) return;
       if (this.lastHeadlineSignature !== sigAtStart) {
         this.hideSummary();
         return;
@@ -170,12 +171,15 @@ export class NewsPanel extends Panel {
         setTimeout(() => this.hideSummary(), 3000);
       }
     } catch {
+      if (!this.element?.isConnected) return;
       this.summaryContainer.innerHTML = '<div class="panel-summary-error">Summary failed</div>';
       setTimeout(() => this.hideSummary(), 3000);
     } finally {
       this.isSummarizing = false;
-      this.summaryBtn.innerHTML = '✨';
-      this.summaryBtn.disabled = false;
+      if (this.summaryBtn) {
+        this.summaryBtn.innerHTML = '✨';
+        this.summaryBtn.disabled = false;
+      }
     }
   }
 
@@ -194,6 +198,7 @@ export class NewsPanel extends Panel {
 
     try {
       const translated = await translateText(text, currentLang);
+      if (!this.element?.isConnected) return;
       if (translated) {
         titleEl.textContent = translated;
         titleEl.dataset.original = originalText;
@@ -205,15 +210,18 @@ export class NewsPanel extends Panel {
         // Shake animation or error state could be added here
       }
     } catch (e) {
+      if (!this.element?.isConnected) return;
       console.error('Translation failed', e);
       element.innerHTML = '文';
     } finally {
-      element.style.pointerEvents = 'auto';
+      if (element.isConnected) {
+        element.style.pointerEvents = 'auto';
+      }
     }
   }
 
   private showSummary(summary: string): void {
-    if (!this.summaryContainer) return;
+    if (!this.summaryContainer || !this.element?.isConnected) return;
     this.summaryContainer.style.display = 'block';
     this.summaryContainer.innerHTML = `
       <div class="panel-summary-content">

--- a/src/components/PlaybackControl.ts
+++ b/src/components/PlaybackControl.ts
@@ -71,6 +71,7 @@ export class PlaybackControl {
 
   private async loadTimestamps(): Promise<void> {
     this.timestamps = await getSnapshotTimestamps();
+    if (!this.element?.isConnected) return;
     this.timestamps.sort((a, b) => a - b);
 
     const slider = this.element.querySelector('.playback-slider') as HTMLInputElement;
@@ -97,6 +98,7 @@ export class PlaybackControl {
     this.updateTimeDisplay();
 
     const snapshot = await getSnapshotAt(timestamp);
+    if (!this.element?.isConnected) return;
     this.onSnapshotChange?.(snapshot);
 
     document.body.classList.add('playback-mode');

--- a/src/components/RuntimeConfigPanel.ts
+++ b/src/components/RuntimeConfigPanel.ts
@@ -538,6 +538,8 @@ export class RuntimeConfigPanel extends Panel {
         }
       } catch { /* Ollama endpoint not available, try OpenAI format */ }
 
+      if (!select.isConnected) return;
+
       if (models.length === 0) {
         try {
           const res = await fetch(new URL('/v1/models', ollamaUrl).toString(), {
@@ -549,6 +551,8 @@ export class RuntimeConfigPanel extends Panel {
           }
         } catch { /* OpenAI endpoint also unavailable */ }
       }
+
+      if (!select.isConnected) return;
 
       if (models.length === 0) {
         // No models discovered — show manual text input as fallback

--- a/src/components/ServiceStatusPanel.ts
+++ b/src/components/ServiceStatusPanel.ts
@@ -51,6 +51,7 @@ export class ServiceStatusPanel extends Panel {
   public async fetchStatus(): Promise<boolean> {
     try {
       const data = await fetchServiceStatuses();
+      if (!this.element?.isConnected) return false;
       if (!data.success) throw new Error('Failed to load status');
 
       const fingerprint = data.services.map(s => `${s.name}:${s.status}`).join(',');
@@ -61,12 +62,15 @@ export class ServiceStatusPanel extends Panel {
       return changed;
     } catch (err) {
       if (this.isAbortError(err)) return false;
+      if (!this.element?.isConnected) return false;
       this.error = err instanceof Error ? err.message : 'Failed to fetch';
       console.error('[ServiceStatus] Fetch error:', err);
       return true;
     } finally {
       this.loading = false;
-      this.render();
+      if (this.element?.isConnected) {
+        this.render();
+      }
     }
   }
 

--- a/src/components/StablecoinPanel.ts
+++ b/src/components/StablecoinPanel.ts
@@ -39,19 +39,23 @@ export class StablecoinPanel extends Panel {
       try {
         const client = new MarketServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });
         this.data = await client.listStablecoinMarkets({ coins: [] });
+        if (!this.element?.isConnected) return;
         this.error = null;
 
         if (this.data && this.data.stablecoins.length === 0 && attempt < 2) {
           this.showRetrying();
           await new Promise(r => setTimeout(r, 20_000));
+          if (!this.element?.isConnected) return;
           continue;
         }
         break;
       } catch (err) {
         if (this.isAbortError(err)) return;
+        if (!this.element?.isConnected) return;
         if (attempt < 2) {
           this.showRetrying();
           await new Promise(r => setTimeout(r, 20_000));
+          if (!this.element?.isConnected) return;
           continue;
         }
         this.error = err instanceof Error ? err.message : 'Failed to fetch';

--- a/src/components/StrategicPosturePanel.ts
+++ b/src/components/StrategicPosturePanel.ts
@@ -47,6 +47,7 @@ export class StrategicPosturePanel extends Panel {
     if (!this.isPanelVisible() || this.postures.length === 0) return;
     console.log('[StrategicPosturePanel] Re-augmenting with vessels...');
     await this.augmentWithVessels();
+    if (!this.element?.isConnected) return;
     this.render();
   }
 
@@ -125,6 +126,7 @@ export class StrategicPosturePanel extends Panel {
       // Fetch aircraft data from server
       this.showLoadingStage('aircraft');
       const data = await fetchCachedTheaterPosture(this.signal);
+      if (!this.element?.isConnected) return;
       if (!data || data.postures.length === 0) {
         this.showNoData();
         return;
@@ -141,6 +143,7 @@ export class StrategicPosturePanel extends Panel {
       // Try to augment with vessel data (client-side)
       this.showLoadingStage('vessels');
       await this.augmentWithVessels();
+      if (!this.element?.isConnected) return;
 
       this.showLoadingStage('analysis');
       this.updateBadges();
@@ -275,6 +278,7 @@ export class StrategicPosturePanel extends Panel {
     this.lastTimestamp = data.timestamp;
     this.isStale = data.stale || false;
     this.augmentWithVessels().then(() => {
+      if (!this.element?.isConnected) return;
       this.updateBadges();
       this.render();
     });

--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -131,6 +131,7 @@ export class StrategicRiskPanel extends Panel {
     this.usedCachedScores = false;
     if (inLearning) {
       const cached = await fetchCachedRiskScores(this.signal);
+      if (!this.element?.isConnected) return false;
       if (cached && cached.strategicRisk) {
         this.usedCachedScores = true;
         console.log('[StrategicRiskPanel] Using cached scores from backend');

--- a/src/components/TechEventsPanel.ts
+++ b/src/components/TechEventsPanel.ts
@@ -37,6 +37,7 @@ export class TechEventsPanel extends Panel {
           days: 180,
           limit: 100,
         });
+        if (!this.element?.isConnected) return;
         if (!data.success) throw new Error(data.error || 'Unknown error');
 
         this.events = data.events;
@@ -46,14 +47,17 @@ export class TechEventsPanel extends Panel {
         if (this.events.length === 0 && attempt < 2) {
           this.showRetrying();
           await new Promise(r => setTimeout(r, 15_000));
+          if (!this.element?.isConnected) return;
           continue;
         }
         break;
       } catch (err) {
         if (this.isAbortError(err)) return;
+        if (!this.element?.isConnected) return;
         if (attempt < 2) {
           this.showRetrying();
           await new Promise(r => setTimeout(r, 15_000));
+          if (!this.element?.isConnected) return;
           continue;
         }
         this.error = err instanceof Error ? err.message : 'Failed to fetch events';

--- a/src/components/TechReadinessPanel.ts
+++ b/src/components/TechReadinessPanel.ts
@@ -44,10 +44,12 @@ export class TechReadinessPanel extends Panel {
 
     try {
       this.rankings = await getTechReadinessRankings();
+      if (!this.element?.isConnected) return;
       this.lastFetch = Date.now();
       this.setCount(this.rankings.length);
       this.render();
     } catch (error) {
+      if (!this.element?.isConnected) return;
       console.error('[TechReadinessPanel] Error fetching data:', error);
       this.showError(t('common.failedTechReadiness'));
     } finally {

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -461,6 +461,7 @@ export class UnifiedSettings {
     try {
       if ('storage' in navigator && 'estimate' in navigator.storage) {
         const estimate = await navigator.storage.estimate();
+        if (!container.isConnected) return;
         const used = estimate.usage ? (estimate.usage / 1024 / 1024).toFixed(2) : '0';
         const quota = estimate.quota ? (estimate.quota / 1024 / 1024).toFixed(0) : 'N/A';
         container.innerHTML = `<div class="status-row">
@@ -471,6 +472,7 @@ export class UnifiedSettings {
         container.innerHTML = `<div class="status-row">${t('components.status.storageUnavailable')}</div>`;
       }
     } catch {
+      if (!container.isConnected) return;
       container.innerHTML = `<div class="status-row">${t('components.status.storageUnavailable')}</div>`;
     }
   }


### PR DESCRIPTION
## Summary

- Add `isConnected` guards after every `await` that precedes DOM manipulation across 18 component files
- Prevents errors and memory leaks when a panel is destroyed while an async operation (API call, translation, summary generation) is still in flight
- Uses `this.element?.isConnected` for Panel subclasses and `element.isConnected` for locally-captured DOM references

## Problem

Several components perform async operations but don't verify the component is still mounted before updating the DOM. If a user navigates away or closes a panel during an in-flight request, the callback tries to update elements that no longer exist -- causing runtime errors or orphaned DOM updates.

Race condition pattern:
```typescript
async someMethod() {
  const data = await fetchSomething();  // panel destroyed here
  this.container.innerHTML = data;      // crashes or leaks
}
```

## Guarded locations

| File | Method(s) | Guard placement |
|------|-----------|----------------|
| `NewsPanel.ts` | `handleSummarize()`, `handleTranslate()`, `showSummary()` | After `generateSummary()`, `translateText()`, and at method entry |
| `DeductionPanel.ts` | `handleSubmit()` | After `deductSituation()` and `marked.parse()` |
| `GdeltIntelPanel.ts` | `loadActiveTopic()` | After `fetchTopicIntelligence()` and retry delays |
| `GoodThingsDigestPanel.ts` | `setStories()` | After each `generateSummary()` in parallel batch |
| `GulfEconomiesPanel.ts` | `fetchData()` | After `listGulfQuotes()` |
| `InsightsPanel.ts` | `onAiFlowChanged()` | After `deletePersistentCache()` |
| `LiveNewsPanel.ts` | `switchChannel()`, `initializePlayer()` | After `resolveChannelVideo()` and `loadYouTubeApi()` |
| `MacroSignalsPanel.ts` | `fetchData()` | After `getMacroSignals()` and retry delays |
| `ETFFlowsPanel.ts` | `fetchData()` | After `listEtfFlows()` and retry delays |
| `StablecoinPanel.ts` | `fetchData()` | After `listStablecoinMarkets()` and retry delays |
| `TechEventsPanel.ts` | `fetchEvents()` | After `listTechEvents()` and retry delays |
| `TechReadinessPanel.ts` | `refresh()` | After `getTechReadinessRankings()` |
| `ServiceStatusPanel.ts` | `fetchStatus()` | After `fetchServiceStatuses()`, and conditional `render()` in finally |
| `StrategicRiskPanel.ts` | `refresh()` | After `fetchCachedRiskScores()` |
| `StrategicPosturePanel.ts` | `fetchAndRender()`, `reaugmentVessels()`, `updatePostures()` | After `fetchCachedTheaterPosture()`, `augmentWithVessels()` |
| `PlaybackControl.ts` | `loadTimestamps()`, `loadSnapshot()` | After `getSnapshotTimestamps()`, `getSnapshotAt()` |
| `RuntimeConfigPanel.ts` | `fetchOllamaModels()` | After each `fetch()` call, using `select.isConnected` |
| `UnifiedSettings.ts` | `updateStorageInfo()` | After `navigator.storage.estimate()` |

## Test plan

- [ ] Verify TypeScript compiles cleanly (`tsc --noEmit` passes)
- [ ] Open any panel, trigger an async operation (e.g. summarize), and close the panel before it completes -- no console errors
- [ ] Verify normal panel operation is unaffected (summaries, translations, data fetching all still work)
- [ ] Verify retry loops in data panels (ETF, Macro, Stablecoin, TechEvents) still retry correctly when the panel remains mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)