### PR TITLE
fix(security): use crypto.randomUUID() instead of Math.random() for ID generation

### DIFF
--- a/src/utils/analysis-constants.ts
+++ b/src/utils/analysis-constants.ts
@@ -213,7 +213,7 @@ export function findRelatedTopics(prediction: string): string[] {
 }
 
 export function generateSignalId(): string {
-  return `sig-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return `sig-${crypto.randomUUID()}`;
 }
 
 export function generateDedupeKey(type: string, identifier: string, value: number): string {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -143,7 +143,7 @@ export function saveToStorage<T>(key: string, value: T): void {
 }
 
 export function generateId(): string {
-  return `id-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  return `id-${crypto.randomUUID()}`;
 }
 
 /** Breakpoint (px): below this width the app uses the simplified mobile layout. Must match CSS @media (max-width: …). */


### PR DESCRIPTION
## Summary

- Replace `Math.random()` with `crypto.randomUUID()` in `generateId()` (`src/utils/index.ts`) and `generateSignalId()` (`src/utils/analysis-constants.ts`)
- `Math.random()` is not cryptographically secure and produces predictable output, making generated IDs potentially guessable
- `crypto.randomUUID()` provides standard UUID v4 strings with cryptographic randomness, available in all modern browsers and Node.js 19+

## Details

The previous implementation used `Math.random().toString(36).slice(...)` combined with `Date.now()` to produce IDs. `Math.random()` uses a PRNG that can be predicted if an attacker observes enough outputs, and `Date.now()` further narrows the search space. `crypto.randomUUID()` uses the operating system's CSPRNG, producing 122 bits of cryptographic randomness per UUID.

Other `Math.random()` usages in the codebase (jitter timing, tip shuffling, simulation data, cache-busting) are not security-sensitive and are left unchanged.

## Test plan

- [ ] Verify `generateId()` returns strings matching `id-<uuid>` format
- [ ] Verify `generateSignalId()` returns strings matching `sig-<uuid>` format
- [ ] Confirm existing functionality that consumes these IDs (signals, dedup keys, etc.) works correctly with the new format
- [ ] TypeScript type checks pass (verified via pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)