### PR TITLE
fix(ui): replace biased array shuffle with Fisher-Yates algorithm

### DIFF
--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -1,4 +1,5 @@
 import { escapeHtml } from '@/utils/sanitize';
+import { shuffle } from '@/utils';
 import { t } from '@/services/i18n';
 import { trackSearchUsed } from '@/services/analytics';
 import { getAllCommands, type Command } from '@/config/commands';
@@ -389,7 +390,7 @@ export class SearchModal {
       { icon: '\u2699\uFE0F', key: 'commands.tips.settings', exampleKey: 'commands.tips.settingsExample' },
     ];
 
-    const shuffled = tips.sort(() => Math.random() - 0.5).slice(0, this.isMobile ? 2 : 4);
+    const shuffled = shuffle(tips).slice(0, this.isMobile ? 2 : 4);
 
     let html = `<div class="search-section-header">${t('modals.search.empty')}</div>`;
     shuffled.forEach((tip, i) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -163,6 +163,17 @@ export function toUniqueSortedLowercase(items: string[]): string[] {
   return toUniqueSorted(items.map((item) => item.toLowerCase()));
 }
 
+export function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = a[i] as T;
+    a[i] = a[j] as T;
+    a[j] = tmp;
+  }
+  return a;
+}
+
 export { proxyUrl, fetchWithProxy, rssProxyUrl } from './proxy';
 export { exportToJSON, exportToCSV, ExportPanel } from './export';
 export { buildMapUrl, parseMapUrlState } from './urlState';


### PR DESCRIPTION
## Summary

- **Replace biased `array.sort(() => Math.random() - 0.5)` with a proper Fisher-Yates (Knuth) shuffle** in the search modal's tip randomization (`SearchModal.ts` line 301).
- **Add a reusable `shuffle<T>()` utility** to `src/utils/index.ts` that returns a new array without mutating the original.
- **No other instances** of the biased sort pattern were found elsewhere in the codebase.

## Why this matters

Using `sort()` with a random comparator produces statistically biased results. The ECMAScript spec does not define a particular sorting algorithm, so the distribution of permutations depends on the engine's implementation (e.g., V8 uses TimSort). A random comparator violates the requirement that the comparator be consistent and transitive, meaning some orderings appear significantly more often than others.

The [Fisher-Yates shuffle](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle) (also known as the Knuth shuffle) guarantees a uniformly random permutation in O(n) time by iterating backwards through the array and swapping each element with a randomly chosen element from the remaining unprocessed portion.

## Changes

| File | Change |
|------|--------|
| `src/utils/index.ts` | Add generic `shuffle<T>(arr: T[]): T[]` utility function |
| `src/components/SearchModal.ts` | Import `shuffle` from utils; replace `tips.sort(() => Math.random() - 0.5)` with `shuffle(tips)` |

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify search modal empty state still shows 4 randomized tips when opened
- [ ] Confirm tips appear in varying order across multiple opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)