### PR TITLE
fix(ui): replace unsafe non-null assertions with proper null guards

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -278,7 +278,7 @@ export class CountryIntelManager implements AppModule {
       } catch { /* server unreachable */ }
 
       if (briefText) {
-        this.ctx.countryBriefPage!.updateBrief({ brief: briefText, country, code });
+        this.ctx.countryBriefPage?.updateBrief({ brief: briefText, country, code });
       } else {
         let fallbackBrief = '';
         const sumModelId = BETA_MODE ? 'summarization-beta' : 'summarization';
@@ -291,7 +291,7 @@ export class CountryIntelManager implements AppModule {
         }
 
         if (fallbackBrief) {
-          this.ctx.countryBriefPage!.updateBrief({ brief: fallbackBrief, country, code, fallback: true });
+          this.ctx.countryBriefPage?.updateBrief({ brief: fallbackBrief, country, code, fallback: true });
         } else {
           const lines: string[] = [];
           if (score) lines.push(t('countryBrief.fallback.instabilityIndex', { score: String(score.score), level: t(`countryBrief.levels.${score.level}`), trend: t(`countryBrief.trends.${score.trend}`) }));
@@ -315,15 +315,15 @@ export class CountryIntelManager implements AppModule {
             briefHeadlines.slice(0, 5).forEach(h => lines.push(`• ${h}`));
           }
           if (lines.length > 0) {
-            this.ctx.countryBriefPage!.updateBrief({ brief: lines.join('\n'), country, code, fallback: true });
+            this.ctx.countryBriefPage?.updateBrief({ brief: lines.join('\n'), country, code, fallback: true });
           } else {
-            this.ctx.countryBriefPage!.updateBrief({ brief: '', country, code, error: 'No AI service available. Configure GROQ_API_KEY in Settings for full briefs.' });
+            this.ctx.countryBriefPage?.updateBrief({ brief: '', country, code, error: 'No AI service available. Configure GROQ_API_KEY in Settings for full briefs.' });
           }
         }
       }
     } catch (err) {
       console.error('[CountryBrief] fetch error:', err);
-      this.ctx.countryBriefPage!.updateBrief({ brief: '', country, code, error: 'Failed to generate brief' });
+      this.ctx.countryBriefPage?.updateBrief({ brief: '', country, code, error: 'Failed to generate brief' });
     }
   }
 

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -369,7 +369,7 @@ export class EventHandlerManager implements AppModule {
       center,
       timeRange: state.timeRange,
       layers: state.layers,
-      country: isCountryVisible ? (briefPage!.getCode() ?? undefined) : undefined,
+      country: isCountryVisible ? (briefPage?.getCode() ?? undefined) : undefined,
       expanded: isCountryVisible && briefPage?.getIsMaximized?.() ? true : undefined,
     });
   }

--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -669,9 +669,13 @@ export class CountryBriefPage implements CountryBriefPanel {
     </head><body>${header ? header.outerHTML : ''}${content.outerHTML}</body></html>`);
     doc.close();
 
-    iframe.contentWindow!.onafterprint = () => document.body.removeChild(iframe);
+    if (iframe.contentWindow) {
+      iframe.contentWindow.onafterprint = () => document.body.removeChild(iframe);
+    }
     setTimeout(() => {
-      iframe.contentWindow!.print();
+      if (iframe.contentWindow) {
+        iframe.contentWindow.print();
+      }
       setTimeout(() => { if (iframe.parentNode) document.body.removeChild(iframe); }, 5000);
     }, 300);
   }

--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -282,7 +282,7 @@ export class SearchModal {
         this.handleSearch();
       });
 
-      this.resultsList!.appendChild(item);
+      this.resultsList?.appendChild(item);
     });
   }
 


### PR DESCRIPTION
## Summary

- **`CountryBriefPage.ts`** (lines 672, 674): Replaced `iframe.contentWindow!` non-null assertions with `if (iframe.contentWindow)` guards — `contentWindow` can be null if the iframe hasn't fully loaded or cross-origin restrictions apply
- **`country-intel.ts`** (lines 281, 294, 318, 320, 326): Replaced `this.ctx.countryBriefPage!.updateBrief(...)` with optional chaining `?.updateBrief(...)` — the brief page could be destroyed during async operations
- **`event-handlers.ts`** (line 372): Replaced `briefPage!.getCode()` with `briefPage?.getCode()` — makes the null safety consistent with the optional chaining already used on line 373
- **`SearchModal.ts`** (line 285): Replaced `this.resultsList!.appendChild(item)` with `this.resultsList?.appendChild(item)` — `resultsList` is a class property that may not be initialized

### Intentionally left unchanged

Non-null assertions that are provably safe via prior guards were not modified:
- `StrategicPosturePanel.ts` — `posture.bounds!` guarded by `if (!posture.bounds) continue` on the preceding line
- `StrategicRiskPanel.ts` — `alert.location!` guarded by truthiness check on `hasLocation`
- `TechEventsPanel.ts` — `event.coords!` guarded by `event.coords &&` conditional
- `LiveNewsPanel.ts` — `this.channelSwitcher!` guarded by early return; `window.YT!` guarded by null check + return
- `RuntimeConfigPanel.ts` — `this.featureFilter!` guarded by ternary truthiness check
- `data-freshness.ts` — `s.lastUpdate!` guarded by `.filter(s => s.lastUpdate)`
- `threat-classifier.ts` — `item.threat!` guarded by `.filter(i => i.threat)`
- `analysis-core.ts` — `market.change!` guarded by threshold check that eliminates undefined
- `analysis-worker.ts` — `this.worker!` guarded by `await this.waitForReady()`
- `storage.ts` — `entry!` inside else branch of null check
- `config/trade-routes.ts` — `validRouteIds!` set on preceding lines if null

## Test plan

- [ ] Verify TypeScript compilation passes with `npx tsc --noEmit` (confirmed locally)
- [ ] Open a country brief and trigger PDF export — should still print correctly
- [ ] Navigate to a country and verify the intel brief loads without errors
- [ ] Use the search modal with recent history items — items should still appear
- [ ] Share a map URL while a country brief is open — URL should include country code

🤖 Generated with [Claude Code](https://claude.com/claude-code)