### PR TITLE
fix(ui): cancel pending debounced calls on component destroy

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -190,6 +190,7 @@ export class DataLoaderManager implements AppModule {
   init(): void {}
 
   destroy(): void {
+    this.applyTimeRangeFilterToNewsPanelsDebounced.cancel();
     stopOrefPolling();
   }
 

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -74,7 +74,7 @@ export class EventHandlerManager implements AppModule {
   private snapshotIntervalId: ReturnType<typeof setInterval> | null = null;
   private clockIntervalId: ReturnType<typeof setInterval> | null = null;
   private readonly IDLE_PAUSE_MS = 2 * 60 * 1000;
-  private debouncedUrlSync = debounce(() => {
+  private readonly debouncedUrlSync = debounce(() => {
     const shareUrl = this.getShareUrl();
     if (!shareUrl) return;
     try { history.replaceState(null, '', shareUrl); } catch { }
@@ -133,6 +133,7 @@ export class EventHandlerManager implements AppModule {
   }
 
   destroy(): void {
+    this.debouncedUrlSync.cancel();
     if (this.boundFullscreenHandler) {
       document.removeEventListener('fullscreenchange', this.boundFullscreenHandler);
       this.boundFullscreenHandler = null;

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -76,7 +76,7 @@ export class PanelLayoutManager implements AppModule {
   private callbacks: PanelLayoutCallbacks;
   private panelDragCleanupHandlers: Array<() => void> = [];
   private criticalBannerEl: HTMLElement | null = null;
-  private readonly applyTimeRangeFilterDebounced: () => void;
+  private readonly applyTimeRangeFilterDebounced: (() => void) & { cancel(): void };
 
   constructor(ctx: AppContext, callbacks: PanelLayoutCallbacks) {
     this.ctx = ctx;
@@ -91,6 +91,7 @@ export class PanelLayoutManager implements AppModule {
   }
 
   destroy(): void {
+    this.applyTimeRangeFilterDebounced.cancel();
     this.panelDragCleanupHandlers.forEach((cleanup) => cleanup());
     this.panelDragCleanupHandlers = [];
     if (this.criticalBannerEl) {

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -365,9 +365,9 @@ export class DeckGLMap {
   private lastCableHighlightSignature = '';
   private lastCableHealthSignature = '';
   private lastPipelineHighlightSignature = '';
-  private debouncedRebuildLayers: () => void;
-  private debouncedFetchBases: () => void;
-  private rafUpdateLayers: () => void;
+  private debouncedRebuildLayers: (() => void) & { cancel(): void };
+  private debouncedFetchBases: (() => void) & { cancel(): void };
+  private rafUpdateLayers: (() => void) & { cancel(): void };
   private moveTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
   constructor(container: HTMLElement, initialState: DeckMapState) {
@@ -4569,6 +4569,10 @@ export class DeckGLMap {
   }
 
   public destroy(): void {
+    this.debouncedRebuildLayers.cancel();
+    this.debouncedFetchBases.cancel();
+    this.rafUpdateLayers.cancel();
+
     if (this.moveTimeoutId) {
       clearTimeout(this.moveTimeoutId);
       this.moveTimeoutId = null;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -53,12 +53,14 @@ export function getHeatmapClass(change: number): string {
 export function debounce<T extends (...args: unknown[]) => void>(
   fn: T,
   delay: number
-): (...args: Parameters<T>) => void {
+): ((...args: Parameters<T>) => void) & { cancel(): void } {
   let timeoutId: ReturnType<typeof setTimeout>;
-  return (...args: Parameters<T>) => {
+  const debounced = (...args: Parameters<T>) => {
     clearTimeout(timeoutId);
     timeoutId = setTimeout(() => fn(...args), delay);
   };
+  debounced.cancel = () => { clearTimeout(timeoutId); };
+  return debounced;
 }
 
 export function throttle<T extends (...args: unknown[]) => void>(
@@ -76,15 +78,16 @@ export function throttle<T extends (...args: unknown[]) => void>(
   };
 }
 
-export function rafSchedule<T extends (...args: unknown[]) => void>(fn: T): (...args: Parameters<T>) => void {
+export function rafSchedule<T extends (...args: unknown[]) => void>(fn: T): ((...args: Parameters<T>) => void) & { cancel(): void } {
   // Frame-synchronized scheduling for visual updates; batches repeated calls into one render frame.
   let scheduled = false;
+  let rafId = 0;
   let lastArgs: Parameters<T> | null = null;
-  return (...args: Parameters<T>) => {
+  const wrapped = (...args: Parameters<T>) => {
     lastArgs = args;
     if (!scheduled) {
       scheduled = true;
-      requestAnimationFrame(() => {
+      rafId = requestAnimationFrame(() => {
         scheduled = false;
         if (lastArgs) {
           fn(...lastArgs);
@@ -93,6 +96,12 @@ export function rafSchedule<T extends (...args: unknown[]) => void>(fn: T): (...
       });
     }
   };
+  wrapped.cancel = () => {
+    cancelAnimationFrame(rafId);
+    scheduled = false;
+    lastArgs = null;
+  };
+  return wrapped;
 }
 
 export function loadFromStorage<T>(key: string, defaultValue: T): T {


### PR DESCRIPTION
## Summary

- **Added `.cancel()` method** to the `debounce()` and `rafSchedule()` utilities in `src/utils/index.ts`, allowing pending callbacks to be explicitly cancelled
- **Cancel all pending debounced/rAF callbacks in `destroy()`** across four components to prevent stale DOM access after teardown:
  - `DeckGLMap`: `debouncedRebuildLayers`, `debouncedFetchBases`, `rafUpdateLayers`
  - `PanelLayoutManager`: `applyTimeRangeFilterDebounced`
  - `DataLoaderManager`: `applyTimeRangeFilterToNewsPanelsDebounced`
  - `EventHandlerManager`: `debouncedUrlSync`

### Problem

Debounced functions created in component constructors could fire after the component was destroyed. For example, `DeckGLMap.debouncedRebuildLayers` has a 150ms delay — if `destroy()` is called during that window, the callback runs against a torn-down DOM (`this.maplibreMap` is null, `this.container.innerHTML` is empty), causing errors or silent corruption.

### Fix

Rather than adding `isDestroyed` guards inside each callback, the cleaner approach is to give `debounce()` and `rafSchedule()` a `.cancel()` method (matching the lodash convention) and call it at the top of each `destroy()` method. This:

- Prevents the callback from ever firing, not just short-circuiting inside it
- Requires no new boolean flags on the component
- Is easy to audit — every `debounce()`/`rafSchedule()` call site can be checked for a matching `.cancel()` in `destroy()`

## Test plan

- [ ] Verify `tsc --noEmit` passes (confirmed in pre-push hook)
- [ ] Verify existing tests still pass
- [ ] Manual: rapidly open/close the map component and confirm no console errors from stale callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)