### PR TITLE
fix(webcams): replace stale Jerusalem live cam feed

### DIFF
--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -22,7 +22,7 @@ const WEBCAM_FEEDS: WebcamFeed[] = [
   // Iran Attacks — Tehran, Tel Aviv, Jerusalem
   { id: 'iran-tehran', city: 'Tehran', country: 'Iran', region: 'iran', channelHandle: '@IranHDCams', fallbackVideoId: '-zGuR1qVKrU' },
   { id: 'iran-telaviv', city: 'Tel Aviv', country: 'Israel', region: 'iran', channelHandle: '@IsraelLiveCam', fallbackVideoId: 'gmtlJ_m2r5A' },
-  { id: 'iran-jerusalem', city: 'Jerusalem', country: 'Israel', region: 'iran', channelHandle: '@JerusalemLive', fallbackVideoId: 'JHwwZRH2wz8' },
+  { id: 'iran-jerusalem', city: 'Jerusalem', country: 'Israel', region: 'iran', channelHandle: '@JerusalemLive', fallbackVideoId: 'dpx0xxbPLN8' },
   { id: 'iran-multicam', city: 'Middle East', country: 'Multi', region: 'iran', channelHandle: '@MiddleEastCams', fallbackVideoId: '4E-iFtUM2kk' },
   // Middle East — Jerusalem & Tehran adjacent (conflict hotspots)
   { id: 'jerusalem', city: 'Jerusalem', country: 'Israel', region: 'middle-east', channelHandle: '@TheWesternWall', fallbackVideoId: 'UyduhBUpO7Q' },


### PR DESCRIPTION
## Summary
- Replace unavailable `iran-jerusalem` webcam fallback video ID (`JHwwZRH2wz8` → `dpx0xxbPLN8`)
- The old stream showed "This live stream recording is not available"

## Test plan
- [ ] Open live webcams panel with Iran region filter
- [ ] Verify bottom-left Jerusalem feed loads the new stream