### PR TITLE
feat(country-brief): add native browser share button

### DIFF
--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -256,6 +256,9 @@ export class CountryBriefPage implements CountryBriefPanel {
             ${tierBadge}
           </div>
           <div class="cb-header-right">
+            <button class="cb-link-share-btn" title="${t('components.countryBrief.shareLink')}">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>
+            </button>
             <button class="cb-share-btn" title="${t('components.countryBrief.shareStory')}">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12v7a2 2 0 002 2h12a2 2 0 002-2v-7"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>
             </button>
@@ -347,6 +350,21 @@ export class CountryBriefPage implements CountryBriefPanel {
       </div>`;
 
     this.overlay.querySelector('.cb-close')?.addEventListener('click', () => this.hide());
+    const linkShareBtn = this.overlay.querySelector('.cb-link-share-btn') as HTMLButtonElement | null;
+    linkShareBtn?.addEventListener('click', () => {
+      if (!this.currentCode || !this.currentName) return;
+      const url = `${window.location.origin}/?c=${this.currentCode}`;
+      const title = `${this.currentName} — World Monitor`;
+      if (navigator.share) {
+        navigator.share({ title, url }).catch(() => {});
+      } else {
+        navigator.clipboard.writeText(url).then(() => {
+          const orig = linkShareBtn!.innerHTML;
+          linkShareBtn!.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+          setTimeout(() => { linkShareBtn!.innerHTML = orig; }, 1500);
+        }).catch(() => {});
+      }
+    });
     this.overlay.querySelector('.cb-share-btn')?.addEventListener('click', () => {
       if (this.onShareStory && this.currentCode && this.currentName) {
         this.onShareStory(this.currentCode, this.currentName);

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -533,6 +533,25 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     });
     this.maximizeButton = maxBtn;
 
+    const shareBtn = this.el('button', 'cdp-action-btn cdp-share-btn') as HTMLButtonElement;
+    shareBtn.setAttribute('type', 'button');
+    shareBtn.setAttribute('aria-label', t('components.countryBrief.shareLink'));
+    shareBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12v7a2 2 0 002 2h12a2 2 0 002-2v-7"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>';
+    shareBtn.addEventListener('click', () => {
+      if (!this.currentCode || !this.currentName) return;
+      const url = `${window.location.origin}/?c=${this.currentCode}`;
+      const title = `${this.currentName} — World Monitor`;
+      if (navigator.share) {
+        navigator.share({ title, url }).catch(() => {});
+      } else {
+        navigator.clipboard.writeText(url).then(() => {
+          const orig = shareBtn.innerHTML;
+          shareBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+          setTimeout(() => { shareBtn.innerHTML = orig; }, 1500);
+        }).catch(() => {});
+      }
+    });
+
     const storyButton = this.el('button', 'cdp-action-btn', 'Story') as HTMLButtonElement;
     storyButton.setAttribute('type', 'button');
     storyButton.addEventListener('click', () => {
@@ -548,7 +567,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         this.onExportImage(this.currentCode, this.currentName);
       }
     });
-    right.append(maxBtn, storyButton, exportButton);
+    right.append(shareBtn, maxBtn, storyButton, exportButton);
     header.append(left, right);
 
     const scoreCard = this.el('section', 'cdp-card cdp-score-card');

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -838,6 +838,7 @@
       }
     },
     "countryBrief": {
+      "shareLink": "Share link",
       "shareStory": "Share story",
       "printPdf": "Print / PDF",
       "exportData": "Export data",

--- a/src/styles/country-deep-dive.css
+++ b/src/styles/country-deep-dive.css
@@ -203,6 +203,13 @@
   border-color: var(--text-faint);
 }
 
+.cdp-share-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+}
+
 .cdp-card {
   background: color-mix(in srgb, var(--surface) 70%, transparent);
   border: 1px solid var(--border-subtle);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -15643,6 +15643,7 @@ body.has-breaking-alert .panels-grid {
   color: var(--accent);
 }
 
+.cb-link-share-btn,
 .cb-share-btn,
 .cb-print-btn,
 .cb-export-btn {
@@ -15657,6 +15658,7 @@ body.has-breaking-alert .panels-grid {
   align-items: center;
 }
 
+.cb-link-share-btn:hover,
 .cb-share-btn:hover,
 .cb-print-btn:hover,
 .cb-export-btn:hover {
@@ -16090,6 +16092,7 @@ body.has-breaking-alert .panels-grid {
   }
 
   .cb-close,
+  .cb-link-share-btn,
   .cb-share-btn,
   .cb-print-btn,
   .cb-export-btn,


### PR DESCRIPTION
## Summary
- Add Web Share API button to **CountryDeepDivePanel** (small brief) and **CountryBriefPage** (large brief)
- Falls back to `navigator.clipboard.writeText` with checkmark feedback when Web Share API is unavailable
- Shares the deep link URL (`?c=CODE`) with country name as title
- i18n key added (`components.countryBrief.shareLink`), consistent SVG icons, clipboard `.catch()` for error safety

## Test plan
- [ ] Open any country brief (small slide-in) → share button visible first in header row → click → native share sheet or clipboard copy with checkmark flash
- [ ] Open any country brief (large full-page) → new link icon button visible before Story/Print/Export → click → native share sheet or clipboard copy with checkmark flash
- [ ] Verify `?c=IR` deep link works when pasted in browser
- [ ] Print preview hides the new button (matches existing buttons)