### PR TITLE
fix(sentry): triage 41 issues — 2 code fixes + 39 noise filters

### DIFF
--- a/src/components/BreakingNewsBanner.ts
+++ b/src/components/BreakingNewsBanner.ts
@@ -72,7 +72,7 @@ export class BreakingNewsBanner {
     if (!settings.soundEnabled || !this.audio) return;
     if (Date.now() - this.lastSoundMs < SOUND_COOLDOWN_MS) return;
     this.audio.currentTime = 0;
-    this.audio.play().catch(() => {});
+    this.audio.play()?.catch(() => {});
     this.lastSoundMs = Date.now();
   }
 

--- a/src/components/IntelligenceGapBadge.ts
+++ b/src/components/IntelligenceGapBadge.ts
@@ -141,7 +141,7 @@ export class IntelligenceFindingsBadge {
   private playSound(): void {
     if (this.audioEnabled && this.audio) {
       this.audio.currentTime = 0;
-      this.audio.play().catch(() => {});
+      this.audio.play()?.catch(() => {});
     }
   }
 

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -687,7 +687,11 @@ export class LiveNewsPanel extends Panel {
       this.originalNextSibling = this.element.nextSibling;
       document.body.appendChild(this.element);
     } else if (this.originalParent) {
-      this.originalParent.insertBefore(this.element, this.originalNextSibling);
+      if (this.originalNextSibling && this.originalParent.contains(this.originalNextSibling)) {
+        this.originalParent.insertBefore(this.element, this.originalNextSibling);
+      } else {
+        this.originalParent.appendChild(this.element);
+      }
       this.originalParent = null;
       this.originalNextSibling = null;
     }

--- a/src/components/SignalModal.ts
+++ b/src/components/SignalModal.ts
@@ -232,7 +232,7 @@ export class SignalModal {
   public playSound(): void {
     if (this.audioEnabled && this.audio) {
       this.audio.currentTime = 0;
-      this.audio.play().catch(() => {});
+      this.audio.play()?.catch(() => {});
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ Sentry.init({
     /Java bridge method invocation error/,
     /Could not compile fragment shader/,
     /can't redefine non-configurable property/,
-    /Can.t find variable: (CONFIG|currentInset|NP|webkit|EmptyRanges|logMutedMessage|UTItemActionController)/,
+    /Can.t find variable: (CONFIG|currentInset|NP|webkit|EmptyRanges|logMutedMessage|UTItemActionController|DarkReader|Readability|onPageLoaded|Game|frappe|getPercent|ucConfig|\$a)/,
     /invalid origin/,
     /\.data\.split is not a function/,
     /signal is aborted without reason/,
@@ -104,7 +104,7 @@ Sentry.init({
     /shortcut icon/,
     /Attempting to change value of a readonly property/,
     /reading 'nodeType'/,
-    /feature named .pageContext. was not found/,
+    /feature named .\w+. was not found/,
     /a2z\.onStatusUpdate/,
     /Attempting to run\(\), but is already running/,
     /this\.player\.destroy is not a function/,
@@ -144,13 +144,29 @@ Sentry.init({
     /browser\.storage\.local/,
     /The play\(\) request was interrupted/,
     /MutationEvent is not defined/,
+    /Cannot redefine property: userAgent/,
+    /st_framedeep|ucbrowser_script/,
+    /iabjs_unified_bridge/,
+    /DarkReader/,
+    /window\.receiveMessage/,
+    /Cross-origin script load denied/,
+    /orgSetInterval is not a function/,
+    /Blocked a frame with origin.*accessing a cross-origin frame/,
+    /SnapTube/,
+    /sortedTrackListForMenu/,
+    /isWhiteToBlack/,
+    /window\.videoSniffer/,
+    /closeTabMediaModal/,
+    /missing \) after argument list/,
+    /Error invoking postMessage: Java exception/,
+    /IndexSizeError/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';
     if (msg.length <= 3 && /^[a-zA-Z_$]+$/.test(msg)) return null;
     const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
     // Suppress maplibre internal null-access crashes (light, placement) only when stack is in map chunk
-    if (/this\.style\._layers|reading '_layers'|this\.light is null|can't access property "(id|type|setFilter)", \w+ is (null|undefined)|Cannot read properties of null \(reading '(id|type|setFilter|_layers)'\)|null is not an object \(evaluating '\w{1,3}\.(id|style)|^\w{1,2} is null$/.test(msg)) {
+    if (/this\.style\._layers|reading '_layers'|this\.(light|sky) is null|can't access property "(id|type|setFilter)", \w+ is (null|undefined)|Cannot read properties of null \(reading '(id|type|setFilter|_layers)'\)|null is not an object \(evaluating '\w{1,3}\.(id|style)|^\w{1,2} is null$/.test(msg)) {
       if (frames.some(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     }
     // Suppress any TypeError that happens entirely within maplibre or deck.gl internals


### PR DESCRIPTION
## Summary
- **2 actionable bugs fixed** in our code
- **16 new noise filter patterns** added to `ignoreErrors` + `beforeSend`
- **41 Sentry issues resolved** (set to reopen if they recur after deploy)

### Code Fixes
- **LiveNewsPanel.toggleFullscreen**: `insertBefore` crashes when `originalNextSibling` is no longer a child of `originalParent` (panel reordered/removed while fullscreen). Now falls back to `appendChild`.
- **audio.play()?.catch()**: On some browsers `HTMLAudioElement.play()` returns `void` instead of a `Promise`. Added optional chaining in `BreakingNewsBanner`, `SignalModal`, and `IntelligenceGapBadge`.

### Noise Filters Added
- Browser extensions: DarkReader, Readability, videoSniffer, closeTabMediaModal
- In-app browsers: UCBrowser (`ucConfig`, `st_framedeep`), Facebook (`missing )`), SnapTube, DuckDuckGo (`feature named X`)
- Ad tech: `iabjs_unified_bridge`
- WebView injections: `window.receiveMessage`, `orgSetInterval`, `userAgent` redefine
- Cross-origin: `Blocked a frame with origin`, `Cross-origin script load denied`
- Safari/iOS: `IndexSizeError`, `sortedTrackListForMenu`, `isWhiteToBlack`
- maplibre: `this.sky is null` added to `beforeSend` suppression

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Verify no new Sentry issues after deploy
- [ ] Confirm fullscreen toggle works in LiveNewsPanel (enter + exit)
- [ ] Confirm breaking news alert sound plays on supported browsers