### PR TITLE
fix(i18n): wrap t() calls in escapeHtml() for XSS safety

### DIFF
--- a/src/components/GoodThingsDigestPanel.ts
+++ b/src/components/GoodThingsDigestPanel.ts
@@ -35,7 +35,7 @@ export class GoodThingsDigestPanel extends Panel {
     const top5 = items.slice(0, 5);
 
     if (top5.length === 0) {
-      this.content.innerHTML = `<p class="digest-placeholder">${t('components.goodThingsDigest.noStories')}</p>`;
+      this.content.innerHTML = `<p class="digest-placeholder">${escapeHtml(t('components.goodThingsDigest.noStories'))}</p>`;
       this.cardElements = [];
       return;
     }
@@ -57,7 +57,7 @@ export class GoodThingsDigestPanel extends Panel {
             ${escapeHtml(item.title)}
           </a>
           <span class="digest-card-source">${escapeHtml(item.source)}</span>
-          <p class="digest-card-summary digest-card-summary--loading">${t('components.goodThingsDigest.summarizing')}</p>
+          <p class="digest-card-summary digest-card-summary--loading">${escapeHtml(t('components.goodThingsDigest.summarizing'))}</p>
         </div>
       `;
       list.appendChild(card);

--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -230,7 +230,7 @@ export class LiveWebcamsPanel extends Panel {
     this.destroyIframes();
 
     if (!this.isVisible || this.isIdle) {
-      this.content.innerHTML = `<div class="webcam-placeholder">${t('components.webcams.paused')}</div>`;
+      this.content.innerHTML = `<div class="webcam-placeholder">${escapeHtml(t('components.webcams.paused'))}</div>`;
       return;
     }
 
@@ -385,7 +385,7 @@ export class LiveWebcamsPanel extends Panel {
       this.idleTimeout = setTimeout(() => {
         this.isIdle = true;
         this.destroyIframes();
-        this.content.innerHTML = `<div class="webcam-placeholder">${t('components.webcams.pausedIdle')}</div>`;
+        this.content.innerHTML = `<div class="webcam-placeholder">${escapeHtml(t('components.webcams.pausedIdle'))}</div>`;
       }, this.IDLE_PAUSE_MS);
     };
 

--- a/src/components/PositiveNewsFeedPanel.ts
+++ b/src/components/PositiveNewsFeedPanel.ts
@@ -106,7 +106,7 @@ export class PositiveNewsFeedPanel extends Panel {
     this.filteredItems = items;
 
     if (items.length === 0) {
-      this.content.innerHTML = `<div class="positive-feed-empty">${t('components.positiveNewsFeed.noStories')}</div>`;
+      this.content.innerHTML = `<div class="positive-feed-empty">${escapeHtml(t('components.positiveNewsFeed.noStories'))}</div>`;
       return;
     }
 

--- a/src/components/ProgressChartsPanel.ts
+++ b/src/components/ProgressChartsPanel.ts
@@ -12,6 +12,7 @@ import * as d3 from 'd3';
 import { type ProgressDataSet, type ProgressDataPoint } from '@/services/progress-data';
 import { getCSSColor } from '@/utils';
 import { replaceChildren } from '@/utils/dom-utils';
+import { escapeHtml } from '@/utils/sanitize';
 import { t } from '@/services/i18n';
 
 const CHART_MARGIN = { top: 8, right: 12, bottom: 24, left: 40 };
@@ -41,7 +42,7 @@ export class ProgressChartsPanel extends Panel {
     // Filter out empty datasets
     const valid = datasets.filter(ds => ds.data.length > 0);
     if (valid.length === 0) {
-      this.content.innerHTML = `<div class="progress-charts-empty" style="padding:16px;color:var(--text-dim);text-align:center;">${t('components.progressCharts.noData')}</div>`;
+      this.content.innerHTML = `<div class="progress-charts-empty" style="padding:16px;color:var(--text-dim);text-align:center;">${escapeHtml(t('components.progressCharts.noData'))}</div>`;
       return;
     }
 


### PR DESCRIPTION
## Summary

- Wrap all 6 `t()` → `innerHTML` calls from #839 in `escapeHtml()` for defense-in-depth
- Matches established codebase pattern (`Map.ts`, `settings-window.ts`, `SearchModal.ts`)
- Add missing `escapeHtml` import to `ProgressChartsPanel.ts`

### Files changed
- `GoodThingsDigestPanel.ts` — 2 calls wrapped
- `LiveWebcamsPanel.ts` — 2 calls wrapped
- `PositiveNewsFeedPanel.ts` — 1 call wrapped
- `ProgressChartsPanel.ts` — 1 call wrapped + import added

## Test plan
- [ ] Verify empty states still render correctly in all 4 panels
- [ ] Confirm no regressions in English or non-English locales