### PR TITLE
fix(country-brief): copy link to clipboard and fix ?c= deep link

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -48,6 +48,7 @@ export class App {
   private state: AppContext;
   private pendingDeepLinkCountry: string | null = null;
   private pendingDeepLinkExpanded = false;
+  private pendingDeepLinkStoryCode: string | null = null;
 
   private panelLayout: PanelLayoutManager;
   private dataLoader: DataLoaderManager;
@@ -431,10 +432,12 @@ export class App {
 
     // Phase 5: Event listeners + URL sync
     this.eventHandlers.init();
-    // Capture ?country= and ?expanded= BEFORE URL sync overwrites them
+    // Capture deep link params BEFORE URL sync overwrites them
     const initState = parseMapUrlState(window.location.search, this.state.mapLayers);
     this.pendingDeepLinkCountry = initState.country ?? null;
     this.pendingDeepLinkExpanded = initState.expanded === true;
+    const earlyParams = new URLSearchParams(window.location.search);
+    this.pendingDeepLinkStoryCode = earlyParams.get('c') ?? null;
     this.eventHandlers.setupUrlStateSync();
 
     this.state.countryBriefPage?.onStateChange?.(() => {
@@ -498,17 +501,22 @@ export class App {
     const DEEP_LINK_RETRY_INTERVAL_MS = 500;
     const DEEP_LINK_INITIAL_DELAY_MS = 2000;
 
-    // Check for story deep link: /story?c=UA&t=ciianalysis
-    if (url.pathname === '/story' || url.searchParams.has('c')) {
-      const countryCode = url.searchParams.get('c');
+    // Check for country brief deep link: ?c=IR (captured early before URL sync)
+    const storyCode = this.pendingDeepLinkStoryCode ?? url.searchParams.get('c');
+    this.pendingDeepLinkStoryCode = null;
+    if (url.pathname === '/story' || storyCode) {
+      const countryCode = storyCode;
       if (countryCode) {
-        trackDeeplinkOpened('story', countryCode);
+        trackDeeplinkOpened('country', countryCode);
         const countryName = getCountryNameByCode(countryCode.toUpperCase()) || countryCode;
 
         let attempts = 0;
         const checkAndOpen = () => {
-          if (dataFreshness.hasSufficientData() && this.state.latestClusters.length > 0) {
-            this.countryIntel.openCountryStory(countryCode.toUpperCase(), countryName);
+          if (dataFreshness.hasSufficientData()) {
+            this.countryIntel.openCountryBriefByCode(countryCode.toUpperCase(), countryName, {
+              maximize: true,
+            });
+            this.eventHandlers.syncUrlState();
             return;
           }
           attempts += 1;
@@ -521,7 +529,6 @@ export class App {
         };
         setTimeout(checkAndOpen, DEEP_LINK_INITIAL_DELAY_MS);
 
-        history.replaceState(null, '', '/');
         return;
       }
     }

--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -354,16 +354,11 @@ export class CountryBriefPage implements CountryBriefPanel {
     linkShareBtn?.addEventListener('click', () => {
       if (!this.currentCode || !this.currentName) return;
       const url = `${window.location.origin}/?c=${this.currentCode}`;
-      const title = `${this.currentName} — World Monitor`;
-      if (navigator.share) {
-        navigator.share({ title, url }).catch(() => {});
-      } else {
-        navigator.clipboard.writeText(url).then(() => {
-          const orig = linkShareBtn!.innerHTML;
-          linkShareBtn!.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
-          setTimeout(() => { linkShareBtn!.innerHTML = orig; }, 1500);
-        }).catch(() => {});
-      }
+      navigator.clipboard.writeText(url).then(() => {
+        const orig = linkShareBtn!.innerHTML;
+        linkShareBtn!.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+        setTimeout(() => { linkShareBtn!.innerHTML = orig; }, 1500);
+      }).catch(() => {});
     });
     this.overlay.querySelector('.cb-share-btn')?.addEventListener('click', () => {
       if (this.onShareStory && this.currentCode && this.currentName) {

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -540,16 +540,11 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     shareBtn.addEventListener('click', () => {
       if (!this.currentCode || !this.currentName) return;
       const url = `${window.location.origin}/?c=${this.currentCode}`;
-      const title = `${this.currentName} — World Monitor`;
-      if (navigator.share) {
-        navigator.share({ title, url }).catch(() => {});
-      } else {
-        navigator.clipboard.writeText(url).then(() => {
-          const orig = shareBtn.innerHTML;
-          shareBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
-          setTimeout(() => { shareBtn.innerHTML = orig; }, 1500);
-        }).catch(() => {});
-      }
+      navigator.clipboard.writeText(url).then(() => {
+        const orig = shareBtn.innerHTML;
+        shareBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+        setTimeout(() => { shareBtn.innerHTML = orig; }, 1500);
+      }).catch(() => {});
     });
 
     const storyButton = this.el('button', 'cdp-action-btn', 'Story') as HTMLButtonElement;


### PR DESCRIPTION
## Summary
- **Copy button**: Always copies URL to clipboard with checkmark feedback, instead of opening the native share dialog (`navigator.share`) on desktop Chrome/Edge
- **Deep link `?c=IR`**: Fixed race condition where `setupUrlStateSync()` replaced the URL before `handleDeepLinks()` could read the `?c=` param — now captured early before URL sync runs
- **Brief page**: `?c=IR` now opens the full country brief page (maximized) instead of the story modal

## Root cause
`setupUrlStateSync()` runs in Phase 5 and immediately calls `debouncedUrlSync()`, which replaces the URL with map state params. `handleDeepLinks()` runs later in Phase 8 and reads `window.location.href` — by then `?c=IR` is already gone.

## Test plan
- [ ] Click the link/share button on a country brief → URL copied to clipboard (no share dialog)
- [ ] Visit `worldmonitor.app/?c=IR` → Iran country brief page opens after data loads
- [ ] Visit `worldmonitor.app/?c=UA` → Ukraine country brief page opens
- [ ] Visit `worldmonitor.app/?country=IR&expanded=1` → Still works as before