### PR TITLE
fix(country-brief): deep link blocked by loadAllData() never resolving

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -12,7 +12,6 @@ import { initDB, cleanOldSnapshots, isAisConfigured, initAisStream, isOutagesCon
 import { mlWorker } from '@/services/ml-worker';
 import { getAiFlowSettings, subscribeAiFlowChange, isHeadlineMemoryEnabled } from '@/services/ai-flow-settings';
 import { startLearning } from '@/services/country-instability';
-import { dataFreshness } from '@/services/data-freshness';
 import { loadFromStorage, parseMapUrlState, saveToStorage, isMobileDevice } from '@/utils';
 import type { ParsedMapUrlState } from '@/utils';
 import { SignalModal, IntelligenceGapBadge, BreakingNewsBanner } from '@/components';
@@ -444,6 +443,10 @@ export class App {
       this.eventHandlers.syncUrlState();
     });
 
+    // Start deep link handling early — its retry loop polls hasSufficientData()
+    // independently, so it must not be gated behind loadAllData() which can hang.
+    this.handleDeepLinks();
+
     // Phase 6: Data loading
     this.dataLoader.syncDataFreshnessWithLayers();
     await preloadCountryGeometry();
@@ -467,8 +470,7 @@ export class App {
     this.eventHandlers.setupSnapshotSaving();
     cleanOldSnapshots().catch((e) => console.warn('[Storage] Snapshot cleanup failed:', e));
 
-    // Phase 8: Deep links + update checks
-    this.handleDeepLinks();
+    // Phase 8: Update checks
     this.desktopUpdater.init();
 
     // Analytics
@@ -497,9 +499,7 @@ export class App {
 
   private handleDeepLinks(): void {
     const url = new URL(window.location.href);
-    const MAX_DEEP_LINK_RETRIES = 60;
-    const DEEP_LINK_RETRY_INTERVAL_MS = 500;
-    const DEEP_LINK_INITIAL_DELAY_MS = 2000;
+    const DEEP_LINK_INITIAL_DELAY_MS = 1500;
 
     // Check for country brief deep link: ?c=IR (captured early before URL sync)
     const storyCode = this.pendingDeepLinkStoryCode ?? url.searchParams.get('c');
@@ -509,26 +509,12 @@ export class App {
       if (countryCode) {
         trackDeeplinkOpened('country', countryCode);
         const countryName = getCountryNameByCode(countryCode.toUpperCase()) || countryCode;
-
-        let attempts = 0;
-        const checkAndOpen = () => {
-          if (dataFreshness.hasSufficientData()) {
-            this.countryIntel.openCountryBriefByCode(countryCode.toUpperCase(), countryName, {
-              maximize: true,
-            });
-            this.eventHandlers.syncUrlState();
-            return;
-          }
-          attempts += 1;
-          if (attempts >= MAX_DEEP_LINK_RETRIES) {
-            this.eventHandlers.showToast('Data not available');
-            return;
-          } else {
-            setTimeout(checkAndOpen, DEEP_LINK_RETRY_INTERVAL_MS);
-          }
-        };
-        setTimeout(checkAndOpen, DEEP_LINK_INITIAL_DELAY_MS);
-
+        setTimeout(() => {
+          this.countryIntel.openCountryBriefByCode(countryCode.toUpperCase(), countryName, {
+            maximize: true,
+          });
+          this.eventHandlers.syncUrlState();
+        }, DEEP_LINK_INITIAL_DELAY_MS);
         return;
       }
     }
@@ -541,24 +527,12 @@ export class App {
     if (deepLinkCountry) {
       trackDeeplinkOpened('country', deepLinkCountry);
       const cName = CountryIntelManager.resolveCountryName(deepLinkCountry);
-      let attempts = 0;
-      const checkAndOpenBrief = () => {
-        if (dataFreshness.hasSufficientData()) {
-          this.countryIntel.openCountryBriefByCode(deepLinkCountry, cName, {
-            maximize: deepLinkExpanded,
-          });
-          this.eventHandlers.syncUrlState();
-          return;
-        }
-        attempts += 1;
-        if (attempts >= MAX_DEEP_LINK_RETRIES) {
-          this.eventHandlers.showToast('Data not available');
-          return;
-        } else {
-          setTimeout(checkAndOpenBrief, DEEP_LINK_RETRY_INTERVAL_MS);
-        }
-      };
-      setTimeout(checkAndOpenBrief, DEEP_LINK_INITIAL_DELAY_MS);
+      setTimeout(() => {
+        this.countryIntel.openCountryBriefByCode(deepLinkCountry, cName, {
+          maximize: deepLinkExpanded,
+        });
+        this.eventHandlers.syncUrlState();
+      }, DEEP_LINK_INITIAL_DELAY_MS);
     }
   }
 


### PR DESCRIPTION
## Summary

- `handleDeepLinks()` was called in Phase 8 **after** `await loadAllData()`, which hangs indefinitely when data sources fail/timeout — deep links never execute
- Moved `handleDeepLinks()` to run **before** `loadAllData()` — its 1.5s `setTimeout` lets the UI initialize while data loads in parallel
- Removed `hasSufficientData()` gate that required BOTH `gdelt` AND `rss` to be active — `openCountryBriefByCode()` fetches its own data independently

## Root cause

The `?c=IR` deep link flow was:
1. Phase 5: capture `?c=` param ✅
2. Phase 6: `await loadAllData()` — **hangs when APIs fail** ❌
3. Phase 8: `handleDeepLinks()` — **never reached**

Even when `loadAllData()` eventually resolved, the retry loop inside `handleDeepLinks()` required `hasSufficientData()` (both gdelt + rss active), adding another failure mode.

## Test plan

- [x] Navigate to `/?c=IR` — Iran brief opens maximized within ~2s
- [x] Navigate to `/?country=UA&expanded=1` — Ukraine brief opens maximized
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Verified with Playwright: `.country-deep-dive.active.maximized` present, URL updates to `&country=IR&expanded=1`