### PR TITLE
fix(market): add bootstrap hydration for markets & commodities panels

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -7,6 +7,8 @@ const BOOTSTRAP_CACHE_KEYS = {
   earthquakes:      'seismology:earthquakes:v1',
   outages:          'infra:outages:v1',
   serviceStatuses:  'infra:service-statuses:v1',
+  marketQuotes:     'market:stocks-bootstrap:v1',
+  commodityQuotes:  'market:commodities-bootstrap:v1',
   sectors:          'market:sectors:v1',
   etfFlows:         'market:etf-flows:v1',
   macroSignals:     'economic:macro-signals:v1',
@@ -27,6 +29,7 @@ const SLOW_KEYS = new Set([
 ]);
 const FAST_KEYS = new Set([
   'earthquakes', 'outages', 'serviceStatuses', 'macroSignals', 'chokepoints',
+  'marketQuotes', 'commodityQuotes',
 ]);
 
 const TIER_CACHE = {

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1004,7 +1004,9 @@ async function seedMarketQuotes() {
   const payload = { quotes, finnhubSkipped: skipped, skipReason: skipped ? 'FINNHUB_API_KEY not configured' : '', rateLimited: false };
   const redisKey = `market:quotes:v1:${[...MARKET_SYMBOLS].sort().join(',')}`;
   const ok = await upstashSet(redisKey, payload, MARKET_SEED_TTL);
-  console.log(`[Market] Seeded ${quotes.length}/${MARKET_SYMBOLS.length} quotes (redis: ${ok ? 'OK' : 'FAIL'})`);
+  // Bootstrap-friendly fixed key — frontend hydrates from /api/bootstrap without RPC
+  const ok2 = await upstashSet('market:stocks-bootstrap:v1', payload, MARKET_SEED_TTL);
+  console.log(`[Market] Seeded ${quotes.length}/${MARKET_SYMBOLS.length} quotes (redis: ${ok && ok2 ? 'OK' : 'PARTIAL'})`);
   return quotes.length;
 }
 
@@ -1029,7 +1031,9 @@ async function seedCommodityQuotes() {
   const quotesKey = `market:quotes:v1:${[...COMMODITY_SYMBOLS].sort().join(',')}`;
   const quotesPayload = { quotes, finnhubSkipped: false, skipReason: '', rateLimited: false };
   const ok2 = await upstashSet(quotesKey, quotesPayload, MARKET_SEED_TTL);
-  console.log(`[Market] Seeded ${quotes.length}/${COMMODITY_SYMBOLS.length} commodities (redis: ${ok && ok2 ? 'OK' : 'PARTIAL'})`);
+  // Bootstrap-friendly fixed key — frontend hydrates from /api/bootstrap without RPC
+  const ok3 = await upstashSet('market:commodities-bootstrap:v1', quotesPayload, MARKET_SEED_TTL);
+  console.log(`[Market] Seeded ${quotes.length}/${COMMODITY_SYMBOLS.length} commodities (redis: ${ok && ok2 && ok3 ? 'OK' : 'PARTIAL'})`);
   return quotes.length;
 }
 

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -85,7 +85,7 @@ import { canQueueAiClassification, AI_CLASSIFY_MAX_PER_FEED } from '@/services/a
 import { classifyWithAI } from '@/services/threat-classifier';
 import { ingestHeadlines } from '@/services/trending-keywords';
 import type { ListFeedDigestResponse } from '@/generated/client/worldmonitor/news/v1/service_client';
-import type { GetSectorSummaryResponse } from '@/generated/client/worldmonitor/market/v1/service_client';
+import type { GetSectorSummaryResponse, ListMarketQuotesResponse } from '@/generated/client/worldmonitor/market/v1/service_client';
 import { mountCommunityWidget } from '@/components/CommunityWidget';
 import { ResearchServiceClient } from '@/generated/client/worldmonitor/research/v1/service_client';
 import {
@@ -934,16 +934,35 @@ export class DataLoaderManager implements AppModule {
 
   async loadMarkets(): Promise<void> {
     try {
-      const stocksResult = await fetchMultipleStocks(MARKET_SYMBOLS, {
-        onBatch: (partialStocks) => {
-          this.ctx.latestMarkets = partialStocks;
-          (this.ctx.panels['markets'] as MarketPanel).renderMarkets(partialStocks);
-        },
-      });
+      // Hydrate markets from bootstrap (same pattern as sectors) — instant data on page load
+      const hydratedMarkets = getHydratedData('marketQuotes') as ListMarketQuotesResponse | undefined;
+      let stocksResult: Awaited<ReturnType<typeof fetchMultipleStocks>>;
+
+      if (hydratedMarkets?.quotes?.length) {
+        const symbolMetaMap = new Map(MARKET_SYMBOLS.map((s) => [s.symbol, s]));
+        const data = hydratedMarkets.quotes.map((q) => ({
+          symbol: q.symbol,
+          name: symbolMetaMap.get(q.symbol)?.name || q.name,
+          display: symbolMetaMap.get(q.symbol)?.display || q.display || q.symbol,
+          price: q.price != null ? q.price : null,
+          change: q.change ?? null,
+          sparkline: q.sparkline?.length > 0 ? q.sparkline : undefined,
+        }));
+        this.ctx.latestMarkets = data;
+        (this.ctx.panels['markets'] as MarketPanel).renderMarkets(data);
+        stocksResult = { data, skipped: hydratedMarkets.finnhubSkipped || undefined, rateLimited: hydratedMarkets.rateLimited || undefined };
+      } else {
+        stocksResult = await fetchMultipleStocks(MARKET_SYMBOLS, {
+          onBatch: (partialStocks) => {
+            this.ctx.latestMarkets = partialStocks;
+            (this.ctx.panels['markets'] as MarketPanel).renderMarkets(partialStocks);
+          },
+        });
+        this.ctx.latestMarkets = stocksResult.data;
+        (this.ctx.panels['markets'] as MarketPanel).renderMarkets(stocksResult.data, stocksResult.rateLimited);
+      }
 
       const finnhubConfigMsg = 'FINNHUB_API_KEY not configured — add in Settings';
-      this.ctx.latestMarkets = stocksResult.data;
-      (this.ctx.panels['markets'] as MarketPanel).renderMarkets(stocksResult.data, stocksResult.rateLimited);
 
       if (stocksResult.rateLimited && stocksResult.data.length === 0) {
         const rlMsg = 'Market data temporarily unavailable (rate limited) — retrying shortly';
@@ -983,7 +1002,27 @@ export class DataLoaderManager implements AppModule {
       const commoditiesPanel = this.ctx.panels['commodities'] as CommoditiesPanel;
       const mapCommodity = (c: MarketData) => ({ display: c.display, price: c.price, change: c.change, sparkline: c.sparkline });
 
+      // Hydrate commodities from bootstrap (same pattern as sectors/markets)
+      const hydratedCommodities = getHydratedData('commodityQuotes') as ListMarketQuotesResponse | undefined;
       let commoditiesLoaded = stocksResult.rateLimited && stocksResult.data.length === 0;
+
+      if (!commoditiesLoaded && hydratedCommodities?.quotes?.length) {
+        const symbolMetaMap = new Map(COMMODITIES.map((s) => [s.symbol, s]));
+        const data = hydratedCommodities.quotes.map((q) => ({
+          symbol: q.symbol,
+          name: symbolMetaMap.get(q.symbol)?.name || q.name,
+          display: symbolMetaMap.get(q.symbol)?.display || q.display || q.symbol,
+          price: q.price != null ? q.price : null,
+          change: q.change ?? null,
+          sparkline: q.sparkline?.length > 0 ? q.sparkline : undefined,
+        }));
+        const mapped = data.map(mapCommodity);
+        if (mapped.some(d => d.price !== null)) {
+          commoditiesPanel.renderCommodities(mapped);
+          commoditiesLoaded = true;
+        }
+      }
+
       for (let attempt = 0; attempt < 3 && !commoditiesLoaded; attempt++) {
         if (attempt > 0) {
           commoditiesPanel.showRetrying();
@@ -991,6 +1030,7 @@ export class DataLoaderManager implements AppModule {
         }
         const commoditiesResult = await fetchMultipleStocks(COMMODITIES, {
           onBatch: (partial) => commoditiesPanel.renderCommodities(partial.map(mapCommodity)),
+          useCommodityBreaker: true,
         });
         const mapped = commoditiesResult.data.map(mapCommodity);
         if (mapped.some(d => d.price !== null)) {

--- a/src/services/market/index.ts
+++ b/src/services/market/index.ts
@@ -19,6 +19,7 @@ import { createCircuitBreaker } from '@/utils';
 
 const client = new MarketServiceClient('', { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) });
 const stockBreaker = createCircuitBreaker<ListMarketQuotesResponse>({ name: 'Market Quotes', cacheTtlMs: 0 });
+const commodityBreaker = createCircuitBreaker<ListMarketQuotesResponse>({ name: 'Commodity Quotes', cacheTtlMs: 0 });
 const cryptoBreaker = createCircuitBreaker<ListCryptoQuotesResponse>({ name: 'Crypto Quotes' });
 
 const emptyStockFallback: ListMarketQuotesResponse = { quotes: [], finnhubSkipped: false, skipReason: '', rateLimited: false };
@@ -70,14 +71,14 @@ function symbolSetKey(symbols: string[]): string {
 
 export async function fetchMultipleStocks(
   symbols: Array<{ symbol: string; name: string; display: string }>,
-  options: { onBatch?: (results: MarketData[]) => void } = {},
+  options: { onBatch?: (results: MarketData[]) => void; useCommodityBreaker?: boolean } = {},
 ): Promise<MarketFetchResult> {
-  // All symbols go through listMarketQuotes (handler handles Yahoo vs Finnhub routing internally)
   const allSymbolStrings = symbols.map((s) => s.symbol);
   const setKey = symbolSetKey(allSymbolStrings);
   const symbolMetaMap = new Map(symbols.map((s) => [s.symbol, s]));
 
-  const resp = await stockBreaker.execute(async () => {
+  const breaker = options.useCommodityBreaker ? commodityBreaker : stockBreaker;
+  const resp = await breaker.execute(async () => {
     return client.listMarketQuotes({ symbols: allSymbolStrings });
   }, emptyStockFallback);
 


### PR DESCRIPTION
## Summary
- Markets and commodities panels showed "Failed to load" while sectors worked — root cause: sectors used bootstrap hydration but markets/commodities relied entirely on the `listMarketQuotes` RPC
- Railway seed now writes bootstrap-friendly fixed Redis keys (`market:stocks-bootstrap:v1`, `market:commodities-bootstrap:v1`) alongside the existing dynamic keys
- `api/bootstrap.js` registers both new keys in `BOOTSTRAP_CACHE_KEYS` and `FAST_KEYS` so they're delivered on page load
- `data-loader.ts` hydrates markets and commodities from bootstrap (same consume-once pattern as sectors), falling back to RPC if bootstrap data is missing
- Split the shared circuit breaker into separate `stockBreaker` and `commodityBreaker` — previously 2 transient failures across both calls triggered a 5-minute cooldown killing all retries

## Test plan
- [ ] Deploy to preview, verify Markets panel shows stock data on page load
- [ ] Verify Commodities panel shows prices (VIX, Gold, etc.)
- [ ] Verify Sector Heatmap still works (regression check)
- [ ] Check `/api/bootstrap?tier=fast` returns `marketQuotes` and `commodityQuotes` keys with data
- [ ] Verify Railway logs show successful bootstrap key writes