### PR TITLE
fix(cyber): seed cyber threats on Railway + fix Cloudflare 500 errors

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -21,11 +21,13 @@ const BOOTSTRAP_CACHE_KEYS = {
   giving:           'giving:summary:v1',
   climateAnomalies: 'climate:anomalies:v1',
   wildfires:        'wildfire:fires:v1',
+  cyberThreats:     'cyber:threats-bootstrap:v2',
 };
 
 const SLOW_KEYS = new Set([
   'bisPolicy', 'bisExchange', 'bisCredit', 'minerals', 'giving',
   'sectors', 'etfFlows', 'shippingRates', 'wildfires', 'climateAnomalies',
+  'cyberThreats',
 ]);
 const FAST_KEYS = new Set([
   'earthquakes', 'outages', 'serviceStatuses', 'macroSignals', 'chokepoints',

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1347,6 +1347,339 @@ async function startAviationSeedLoop() {
   }, AVIATION_SEED_INTERVAL_MS).unref?.();
 }
 
+// ─────────────────────────────────────────────────────────────
+// Cyber Threat Intelligence Seed — Railway fetches IOC feeds → writes to Redis
+// so Vercel handler (list-cyber-threats) serves from cache instead of live fetches
+// ─────────────────────────────────────────────────────────────
+const URLHAUS_AUTH_KEY = process.env.URLHAUS_AUTH_KEY || '';
+const OTX_API_KEY = process.env.OTX_API_KEY || '';
+const ABUSEIPDB_API_KEY = process.env.ABUSEIPDB_API_KEY || '';
+const CYBER_SEED_INTERVAL_MS = 2 * 60 * 60 * 1000; // 2h — matches IOC feed update cadence
+const CYBER_SEED_TTL = 10800; // 3h — survives 1 missed cycle
+const CYBER_RPC_KEY = 'cyber:threats:v2:0:::'; // matches handler default cache key
+const CYBER_BOOTSTRAP_KEY = 'cyber:threats-bootstrap:v2';
+const CYBER_MAX_CACHED = 2000;
+const CYBER_GEO_MAX = 200;
+const CYBER_GEO_CONCURRENCY = 12;
+const CYBER_GEO_TIMEOUT_MS = 20_000;
+const CYBER_SOURCE_TIMEOUT_MS = 15_000; // longer than Vercel edge budget — OK on Railway
+
+const CYBER_COUNTRY_CENTROIDS = {
+  US:[39.8,-98.6],CA:[56.1,-106.3],MX:[23.6,-102.6],BR:[-14.2,-51.9],AR:[-38.4,-63.6],
+  GB:[55.4,-3.4],DE:[51.2,10.5],FR:[46.2,2.2],IT:[41.9,12.6],ES:[40.5,-3.7],
+  NL:[52.1,5.3],BE:[50.5,4.5],SE:[60.1,18.6],NO:[60.5,8.5],FI:[61.9,25.7],
+  DK:[56.3,9.5],PL:[51.9,19.1],CZ:[49.8,15.5],AT:[47.5,14.6],CH:[46.8,8.2],
+  PT:[39.4,-8.2],IE:[53.1,-8.2],RO:[45.9,25.0],HU:[47.2,19.5],BG:[42.7,25.5],
+  HR:[45.1,15.2],SK:[48.7,19.7],UA:[48.4,31.2],RU:[61.5,105.3],BY:[53.7,28.0],
+  TR:[39.0,35.2],GR:[39.1,21.8],RS:[44.0,21.0],CN:[35.9,104.2],JP:[36.2,138.3],
+  KR:[35.9,127.8],IN:[20.6,79.0],PK:[30.4,69.3],BD:[23.7,90.4],ID:[-0.8,113.9],
+  TH:[15.9,101.0],VN:[14.1,108.3],PH:[12.9,121.8],MY:[4.2,101.9],SG:[1.4,103.8],
+  TW:[23.7,121.0],HK:[22.4,114.1],AU:[-25.3,133.8],NZ:[-40.9,174.9],
+  ZA:[-30.6,22.9],NG:[9.1,8.7],EG:[26.8,30.8],KE:[-0.02,37.9],ET:[9.1,40.5],
+  MA:[31.8,-7.1],DZ:[28.0,1.7],TN:[33.9,9.5],GH:[7.9,-1.0],
+  SA:[23.9,45.1],AE:[23.4,53.8],IL:[31.0,34.9],IR:[32.4,53.7],IQ:[33.2,43.7],
+  KW:[29.3,47.5],QA:[25.4,51.2],BH:[26.0,50.6],JO:[30.6,36.2],LB:[33.9,35.9],
+  CL:[-35.7,-71.5],CO:[4.6,-74.3],PE:[-9.2,-75.0],VE:[6.4,-66.6],
+  KZ:[48.0,68.0],UZ:[41.4,64.6],GE:[42.3,43.4],AZ:[40.1,47.6],AM:[40.1,45.0],
+  LT:[55.2,23.9],LV:[56.9,24.1],EE:[58.6,25.0],
+  HN:[15.2,-86.2],GT:[15.8,-90.2],PA:[8.5,-80.8],CR:[9.7,-84.0],
+  SN:[14.5,-14.5],CM:[7.4,12.4],CI:[7.5,-5.5],TZ:[-6.4,34.9],UG:[1.4,32.3],
+};
+
+const CYBER_THREAT_TYPE_MAP = { c2_server:'CYBER_THREAT_TYPE_C2_SERVER', malware_host:'CYBER_THREAT_TYPE_MALWARE_HOST', phishing:'CYBER_THREAT_TYPE_PHISHING', malicious_url:'CYBER_THREAT_TYPE_MALICIOUS_URL' };
+const CYBER_SOURCE_MAP = { feodo:'CYBER_THREAT_SOURCE_FEODO', urlhaus:'CYBER_THREAT_SOURCE_URLHAUS', c2intel:'CYBER_THREAT_SOURCE_C2INTEL', otx:'CYBER_THREAT_SOURCE_OTX', abuseipdb:'CYBER_THREAT_SOURCE_ABUSEIPDB' };
+const CYBER_INDICATOR_MAP = { ip:'CYBER_THREAT_INDICATOR_TYPE_IP', domain:'CYBER_THREAT_INDICATOR_TYPE_DOMAIN', url:'CYBER_THREAT_INDICATOR_TYPE_URL' };
+const CYBER_SEVERITY_MAP = { low:'CRITICALITY_LEVEL_LOW', medium:'CRITICALITY_LEVEL_MEDIUM', high:'CRITICALITY_LEVEL_HIGH', critical:'CRITICALITY_LEVEL_CRITICAL' };
+const CYBER_SEVERITY_RANK = { CRITICALITY_LEVEL_CRITICAL:4, CRITICALITY_LEVEL_HIGH:3, CRITICALITY_LEVEL_MEDIUM:2, CRITICALITY_LEVEL_LOW:1, CRITICALITY_LEVEL_UNSPECIFIED:0 };
+
+function cyberClean(v, max) { if (typeof v !== 'string') return ''; return v.trim().replace(/\s+/g, ' ').slice(0, max || 120); }
+function cyberToNum(v) { const n = typeof v === 'number' ? v : parseFloat(String(v ?? '')); return Number.isFinite(n) ? n : null; }
+function cyberValidCoords(lat, lon) { return lat !== null && lon !== null && lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180; }
+function cyberIsIPv4(v) { if (!/^(\d{1,3}\.){3}\d{1,3}$/.test(v)) return false; return v.split('.').map(Number).every((n) => Number.isInteger(n) && n >= 0 && n <= 255); }
+function cyberIsIPv6(v) { return /^[0-9a-f:]+$/i.test(v) && v.includes(':'); }
+function cyberIsIp(v) { return cyberIsIPv4(v) || cyberIsIPv6(v); }
+function cyberNormCountry(v) { const r = cyberClean(String(v ?? ''), 64); if (!r) return ''; if (/^[a-z]{2}$/i.test(r)) return r.toUpperCase(); return r; }
+function cyberToMs(v) {
+  if (!v) return 0;
+  const raw = cyberClean(String(v), 80); if (!raw) return 0;
+  const d1 = new Date(raw); if (!isNaN(d1.getTime())) return d1.getTime();
+  const d2 = new Date(raw.replace(' UTC', 'Z').replace(' GMT', 'Z').replace(' ', 'T'));
+  return isNaN(d2.getTime()) ? 0 : d2.getTime();
+}
+function cyberNormTags(input, max) {
+  const tags = Array.isArray(input) ? input : typeof input === 'string' ? input.split(/[;,|]/g) : [];
+  const out = []; const seen = new Set();
+  for (const t of tags) { const c = cyberClean(String(t ?? ''), 40).toLowerCase(); if (!c || seen.has(c)) continue; seen.add(c); out.push(c); if (out.length >= (max || 8)) break; }
+  return out;
+}
+function cyberDjb2(s) { let h = 5381; for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff; return h; }
+function cyberCentroid(cc, seed) {
+  const c = CYBER_COUNTRY_CENTROIDS[cc ? cc.toUpperCase() : '']; if (!c) return null;
+  const k = seed || cc;
+  return { lat: c[0] + (((cyberDjb2(k) & 0xffff) / 0xffff) - 0.5) * 2, lon: c[1] + (((cyberDjb2(k + ':lon') & 0xffff) / 0xffff) - 0.5) * 2 };
+}
+function cyberSanitize(t) {
+  const ind = cyberClean(t.indicator, 255); if (!ind) return null;
+  if ((t.indicatorType || 'ip') === 'ip' && !cyberIsIp(ind)) return null;
+  return { id: cyberClean(t.id, 255) || `${t.source||'feodo'}:${t.indicatorType||'ip'}:${ind}`, type: t.type||'malicious_url', source: t.source||'feodo', indicator: ind, indicatorType: t.indicatorType||'ip', lat: t.lat??null, lon: t.lon??null, country: t.country||'', severity: t.severity||'medium', malwareFamily: cyberClean(t.malwareFamily, 80), tags: t.tags||[], firstSeen: t.firstSeen||0, lastSeen: t.lastSeen||0 };
+}
+function cyberDedupe(threats) {
+  const map = new Map();
+  for (const t of threats) {
+    const key = `${t.source}:${t.indicatorType}:${t.indicator}`;
+    const ex = map.get(key);
+    if (!ex) { map.set(key, t); continue; }
+    if ((t.lastSeen || t.firstSeen) >= (ex.lastSeen || ex.firstSeen)) map.set(key, { ...ex, ...t, tags: cyberNormTags([...ex.tags, ...t.tags]) });
+  }
+  return Array.from(map.values());
+}
+function cyberToProto(t) {
+  return { id: t.id, type: CYBER_THREAT_TYPE_MAP[t.type]||'CYBER_THREAT_TYPE_UNSPECIFIED', source: CYBER_SOURCE_MAP[t.source]||'CYBER_THREAT_SOURCE_UNSPECIFIED', indicator: t.indicator, indicatorType: CYBER_INDICATOR_MAP[t.indicatorType]||'CYBER_THREAT_INDICATOR_TYPE_UNSPECIFIED', location: cyberValidCoords(t.lat, t.lon) ? { latitude: t.lat, longitude: t.lon } : undefined, country: t.country, severity: CYBER_SEVERITY_MAP[t.severity]||'CRITICALITY_LEVEL_UNSPECIFIED', malwareFamily: t.malwareFamily, tags: t.tags, firstSeenAt: t.firstSeen, lastSeenAt: t.lastSeen };
+}
+
+function cyberHttpGetJson(url, reqHeaders, timeoutMs) {
+  return new Promise((resolve) => {
+    const req = https.get(url, { headers: { 'User-Agent': CHROME_UA, ...reqHeaders }, timeout: timeoutMs || 10000 }, (resp) => {
+      if (resp.statusCode < 200 || resp.statusCode >= 300) { resp.resume(); return resolve(null); }
+      const chunks = [];
+      resp.on('data', (c) => chunks.push(c));
+      resp.on('end', () => { try { resolve(JSON.parse(Buffer.concat(chunks).toString())); } catch { resolve(null); } });
+    });
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => { req.destroy(); resolve(null); });
+  });
+}
+function cyberHttpGetText(url, reqHeaders, timeoutMs) {
+  return new Promise((resolve) => {
+    const req = https.get(url, { headers: { 'User-Agent': CHROME_UA, ...reqHeaders }, timeout: timeoutMs || 10000 }, (resp) => {
+      if (resp.statusCode < 200 || resp.statusCode >= 300) { resp.resume(); return resolve(null); }
+      const chunks = [];
+      resp.on('data', (c) => chunks.push(c));
+      resp.on('end', () => resolve(Buffer.concat(chunks).toString()));
+    });
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => { req.destroy(); resolve(null); });
+  });
+}
+
+const CYBER_GEO_CACHE_MAX = 2048;
+const cyberGeoCache = new Map();
+function cyberGeoCacheSet(ip, geo) {
+  if (cyberGeoCache.size >= CYBER_GEO_CACHE_MAX) {
+    cyberGeoCache.delete(cyberGeoCache.keys().next().value);
+  }
+  cyberGeoCache.set(ip, geo);
+}
+async function cyberGeoLookup(ip) {
+  if (cyberGeoCache.has(ip)) return cyberGeoCache.get(ip);
+  const d1 = await cyberHttpGetJson(`https://ipinfo.io/${encodeURIComponent(ip)}/json`, {}, 3000);
+  if (d1?.loc) {
+    const [latS, lonS] = d1.loc.split(',');
+    const lat = parseFloat(latS), lon = parseFloat(lonS);
+    if (cyberValidCoords(lat, lon)) { const r = { lat, lon, country: String(d1.country||'').slice(0,2).toUpperCase() }; cyberGeoCacheSet(ip, r); return r; }
+  }
+  const d2 = await cyberHttpGetJson(`https://freeipapi.com/api/json/${encodeURIComponent(ip)}`, {}, 3000);
+  if (d2) {
+    const lat = parseFloat(d2.latitude), lon = parseFloat(d2.longitude);
+    if (cyberValidCoords(lat, lon)) { const r = { lat, lon, country: String(d2.countryCode||d2.countryName||'').slice(0,2).toUpperCase() }; cyberGeoCacheSet(ip, r); return r; }
+  }
+  return null;
+}
+async function cyberHydrateGeo(threats) {
+  const needsGeo = []; const seen = new Set();
+  for (const t of threats) {
+    if (cyberValidCoords(t.lat, t.lon) || t.indicatorType !== 'ip') continue;
+    const ip = t.indicator.toLowerCase();
+    if (!cyberIsIp(ip) || seen.has(ip)) continue;
+    seen.add(ip); needsGeo.push(ip);
+  }
+  if (needsGeo.length === 0) return threats;
+  const queue = [...needsGeo.slice(0, CYBER_GEO_MAX)];
+  const resolved = new Map();
+  let timedOut = false;
+  // timedOut flag stops workers from dequeuing new IPs; in-flight requests may still
+  // complete up to ~3s after the flag fires (per-request timeout). Acceptable overshoot.
+  const timeoutId = setTimeout(() => { timedOut = true; }, CYBER_GEO_TIMEOUT_MS);
+  const workers = Array.from({ length: Math.min(CYBER_GEO_CONCURRENCY, queue.length) }, async () => {
+    while (queue.length > 0 && !timedOut) {
+      const ip = queue.shift(); if (!ip) break;
+      const geo = await cyberGeoLookup(ip);
+      if (geo) resolved.set(ip, geo);
+    }
+  });
+  try { await Promise.all(workers); } catch { /* ignore */ }
+  clearTimeout(timeoutId);
+  return threats.map((t) => {
+    if (cyberValidCoords(t.lat, t.lon)) return t;
+    if (t.indicatorType !== 'ip') return t;
+    const geo = resolved.get(t.indicator.toLowerCase());
+    if (geo) return { ...t, lat: geo.lat, lon: geo.lon, country: t.country || geo.country };
+    const cen = cyberCentroid(t.country, t.indicator);
+    return cen ? { ...t, lat: cen.lat, lon: cen.lon } : t;
+  });
+}
+
+async function cyberFetchFeodo(limit, cutoffMs) {
+  try {
+    const payload = await cyberHttpGetJson('https://feodotracker.abuse.ch/downloads/ipblocklist.json', { Accept: 'application/json' }, CYBER_SOURCE_TIMEOUT_MS);
+    if (!payload) return [];
+    const records = Array.isArray(payload) ? payload : (Array.isArray(payload?.data) ? payload.data : []);
+    const out = [];
+    for (const r of records) {
+      const ip = cyberClean(r?.ip_address || r?.dst_ip || r?.ip || r?.ioc || r?.host, 80).toLowerCase();
+      if (!cyberIsIp(ip)) continue;
+      const status = cyberClean(r?.status || r?.c2_status || '', 30).toLowerCase();
+      if (status && status !== 'online' && status !== 'offline') continue;
+      const firstSeen = cyberToMs(r?.first_seen || r?.first_seen_utc || r?.dateadded);
+      const lastSeen = cyberToMs(r?.last_online || r?.last_seen || r?.last_seen_utc || r?.first_seen || r?.first_seen_utc);
+      if ((lastSeen || firstSeen) && (lastSeen || firstSeen) < cutoffMs) continue;
+      const malwareFamily = cyberClean(r?.malware || r?.malware_family || r?.family, 80);
+      const sev = status === 'online' ? (/emotet|qakbot|trickbot|dridex|ransom/i.test(malwareFamily) ? 'critical' : 'high') : 'medium';
+      const t = cyberSanitize({ id: `feodo:${ip}`, type: 'c2_server', source: 'feodo', indicator: ip, indicatorType: 'ip', lat: cyberToNum(r?.latitude ?? r?.lat), lon: cyberToNum(r?.longitude ?? r?.lon), country: cyberNormCountry(r?.country || r?.country_code), severity: sev, malwareFamily, tags: cyberNormTags(['botnet', 'c2', ...(r?.tags||[])]), firstSeen, lastSeen });
+      if (t) { out.push(t); if (out.length >= limit) break; }
+    }
+    return out;
+  } catch { return []; }
+}
+async function cyberFetchUrlhaus(limit, cutoffMs) {
+  if (!URLHAUS_AUTH_KEY) return [];
+  try {
+    const payload = await cyberHttpGetJson(`https://urlhaus-api.abuse.ch/v1/urls/recent/limit/${limit}/`, { Accept: 'application/json', 'Auth-Key': URLHAUS_AUTH_KEY }, CYBER_SOURCE_TIMEOUT_MS);
+    if (!payload) return [];
+    const rows = Array.isArray(payload?.urls) ? payload.urls : (Array.isArray(payload?.data) ? payload.data : []);
+    const out = [];
+    for (const r of rows) {
+      const rawUrl = cyberClean(r?.url || r?.ioc || '', 1024);
+      const status = cyberClean(r?.url_status || r?.status || '', 30).toLowerCase();
+      if (status && status !== 'online') continue;
+      const tags = cyberNormTags(r?.tags);
+      let hostname = ''; try { hostname = new URL(rawUrl).hostname.toLowerCase(); } catch {}
+      const recordIp = cyberClean(r?.host || r?.ip_address || r?.ip, 80).toLowerCase();
+      const ipCandidate = cyberIsIp(recordIp) ? recordIp : (cyberIsIp(hostname) ? hostname : '');
+      const indType = ipCandidate ? 'ip' : (hostname ? 'domain' : 'url');
+      const indicator = ipCandidate || hostname || rawUrl; if (!indicator) continue;
+      const firstSeen = cyberToMs(r?.dateadded || r?.firstseen || r?.first_seen);
+      const lastSeen = cyberToMs(r?.last_online || r?.last_seen || r?.dateadded);
+      if ((lastSeen || firstSeen) && (lastSeen || firstSeen) < cutoffMs) continue;
+      const threat = cyberClean(r?.threat || r?.threat_type || '', 40).toLowerCase();
+      const allTags = tags.join(' ');
+      const type = (threat.includes('phish') || allTags.includes('phish')) ? 'phishing' : (threat.includes('malware') || threat.includes('payload') || allTags.includes('malware')) ? 'malware_host' : 'malicious_url';
+      const sev = type === 'phishing' ? 'medium' : (tags.includes('ransomware') || tags.includes('botnet')) ? 'critical' : 'high';
+      const t = cyberSanitize({ id: `urlhaus:${indType}:${indicator}`, type, source: 'urlhaus', indicator, indicatorType: indType, lat: cyberToNum(r?.latitude ?? r?.lat), lon: cyberToNum(r?.longitude ?? r?.lon), country: cyberNormCountry(r?.country || r?.country_code), severity: sev, malwareFamily: cyberClean(r?.threat, 80), tags, firstSeen, lastSeen });
+      if (t) { out.push(t); if (out.length >= limit) break; }
+    }
+    return out;
+  } catch { return []; }
+}
+async function cyberFetchC2Intel(limit) {
+  try {
+    const text = await cyberHttpGetText('https://raw.githubusercontent.com/drb-ra/C2IntelFeeds/master/feeds/IPC2s-30day.csv', { Accept: 'text/plain' }, CYBER_SOURCE_TIMEOUT_MS);
+    if (!text) return [];
+    const out = [];
+    for (const line of text.split('\n')) {
+      if (!line || line.startsWith('#')) continue;
+      const ci = line.indexOf(','); if (ci < 0) continue;
+      const ip = cyberClean(line.slice(0, ci), 80).toLowerCase(); if (!cyberIsIp(ip)) continue;
+      const desc = cyberClean(line.slice(ci + 1), 200);
+      const malwareFamily = desc.replace(/^Possible\s+/i, '').replace(/\s+C2\s+IP$/i, '').trim() || 'Unknown';
+      const tags = ['c2']; const descLow = desc.toLowerCase();
+      if (descLow.includes('cobaltstrike') || descLow.includes('cobalt strike')) tags.push('cobaltstrike');
+      if (descLow.includes('metasploit')) tags.push('metasploit');
+      if (descLow.includes('sliver')) tags.push('sliver');
+      if (descLow.includes('brute ratel') || descLow.includes('bruteratel')) tags.push('bruteratel');
+      const t = cyberSanitize({ id: `c2intel:${ip}`, type: 'c2_server', source: 'c2intel', indicator: ip, indicatorType: 'ip', lat: null, lon: null, country: '', severity: /cobaltstrike|cobalt.strike|brute.?ratel/i.test(desc) ? 'high' : 'medium', malwareFamily, tags: cyberNormTags(tags), firstSeen: 0, lastSeen: 0 });
+      if (t) { out.push(t); if (out.length >= limit) break; }
+    }
+    return out;
+  } catch { return []; }
+}
+async function cyberFetchOtx(limit, days) {
+  if (!OTX_API_KEY) return [];
+  try {
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const payload = await cyberHttpGetJson(`https://otx.alienvault.com/api/v1/indicators/export?type=IPv4&modified_since=${encodeURIComponent(since)}`, { Accept: 'application/json', 'X-OTX-API-KEY': OTX_API_KEY }, CYBER_SOURCE_TIMEOUT_MS);
+    if (!payload) return [];
+    const results = Array.isArray(payload?.results) ? payload.results : (Array.isArray(payload) ? payload : []);
+    const out = [];
+    for (const r of results) {
+      const ip = cyberClean(r?.indicator || r?.ip || '', 80).toLowerCase(); if (!cyberIsIp(ip)) continue;
+      const tags = cyberNormTags(r?.tags || []);
+      const t = cyberSanitize({ id: `otx:${ip}`, type: tags.some((tt) => /c2|botnet/.test(tt)) ? 'c2_server' : 'malware_host', source: 'otx', indicator: ip, indicatorType: 'ip', lat: null, lon: null, country: '', severity: tags.some((tt) => /ransomware|apt|c2|botnet/.test(tt)) ? 'high' : 'medium', malwareFamily: cyberClean(r?.title || r?.description || '', 200), tags, firstSeen: cyberToMs(r?.created), lastSeen: cyberToMs(r?.modified || r?.created) });
+      if (t) { out.push(t); if (out.length >= limit) break; }
+    }
+    return out;
+  } catch { return []; }
+}
+async function cyberFetchAbuseIpDb(limit) {
+  if (!ABUSEIPDB_API_KEY) return [];
+  try {
+    const payload = await cyberHttpGetJson(`https://api.abuseipdb.com/api/v2/blacklist?confidenceMinimum=90&limit=${Math.min(limit, 500)}`, { Accept: 'application/json', Key: ABUSEIPDB_API_KEY }, CYBER_SOURCE_TIMEOUT_MS);
+    if (!payload) return [];
+    const records = Array.isArray(payload?.data) ? payload.data : [];
+    const out = [];
+    for (const r of records) {
+      const ip = cyberClean(r?.ipAddress || r?.ip || '', 80).toLowerCase(); if (!cyberIsIp(ip)) continue;
+      const score = cyberToNum(r?.abuseConfidenceScore) ?? 0;
+      const t = cyberSanitize({ id: `abuseipdb:${ip}`, type: 'malware_host', source: 'abuseipdb', indicator: ip, indicatorType: 'ip', lat: cyberToNum(r?.latitude ?? r?.lat), lon: cyberToNum(r?.longitude ?? r?.lon), country: cyberNormCountry(r?.countryCode || r?.country), severity: score >= 95 ? 'critical' : (score >= 80 ? 'high' : 'medium'), malwareFamily: '', tags: cyberNormTags([`score:${score}`]), firstSeen: 0, lastSeen: cyberToMs(r?.lastReportedAt) });
+      if (t) { out.push(t); if (out.length >= limit) break; }
+    }
+    return out;
+  } catch { return []; }
+}
+
+async function seedCyberThreats() {
+  const t0 = Date.now();
+  const days = 14;
+  const cutoffMs = Date.now() - days * 24 * 60 * 60 * 1000;
+  const MAX_LIMIT = 1000;
+
+  const [feodo, urlhaus, c2intel, otx, abuseipdb] = await Promise.all([
+    cyberFetchFeodo(MAX_LIMIT, cutoffMs),
+    cyberFetchUrlhaus(MAX_LIMIT, cutoffMs),
+    cyberFetchC2Intel(MAX_LIMIT),
+    cyberFetchOtx(MAX_LIMIT, days),
+    cyberFetchAbuseIpDb(MAX_LIMIT),
+  ]);
+
+  if (feodo.length + urlhaus.length + c2intel.length + otx.length + abuseipdb.length === 0) {
+    console.warn('[Cyber] All sources returned 0 threats — skipping Redis write');
+    return 0;
+  }
+
+  const combined = cyberDedupe([...feodo, ...urlhaus, ...c2intel, ...otx, ...abuseipdb]);
+  const hydrated = await cyberHydrateGeo(combined);
+  const filtered = hydrated.filter((t) => cyberValidCoords(t.lat, t.lon));
+
+  filtered.sort((a, b) => {
+    const bySev = (CYBER_SEVERITY_RANK[CYBER_SEVERITY_MAP[b.severity]||'']||0) - (CYBER_SEVERITY_RANK[CYBER_SEVERITY_MAP[a.severity]||'']||0);
+    return bySev !== 0 ? bySev : (b.lastSeen || b.firstSeen) - (a.lastSeen || a.firstSeen);
+  });
+
+  const threats = filtered.slice(0, CYBER_MAX_CACHED).map(cyberToProto);
+  if (threats.length === 0) {
+    console.warn('[Cyber] No threats with valid coordinates — skipping Redis write');
+    return 0;
+  }
+
+  const payload = { threats };
+  const ok1 = await upstashSet(CYBER_RPC_KEY, payload, CYBER_SEED_TTL);
+  const ok2 = await upstashSet(CYBER_BOOTSTRAP_KEY, payload, CYBER_SEED_TTL);
+  console.log(`[Cyber] Seeded ${threats.length} threats (feodo:${feodo.length} urlhaus:${urlhaus.length} c2intel:${c2intel.length} otx:${otx.length} abuseipdb:${abuseipdb.length} redis:${ok1 && ok2 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+  return threats.length;
+}
+
+async function startCyberThreatsSeedLoop() {
+  if (!UPSTASH_ENABLED) {
+    console.log('[Cyber] Disabled (no Upstash Redis)');
+    return;
+  }
+  console.log(`[Cyber] Seed loop starting (interval ${CYBER_SEED_INTERVAL_MS / 1000 / 60 / 60}h, urlhaus:${URLHAUS_AUTH_KEY ? 'yes' : 'no'} otx:${OTX_API_KEY ? 'yes' : 'no'} abuseipdb:${ABUSEIPDB_API_KEY ? 'yes' : 'no'})`);
+  seedCyberThreats().catch((e) => console.warn('[Cyber] Initial seed error:', e?.message || e));
+  setInterval(() => {
+    seedCyberThreats().catch((e) => console.warn('[Cyber] Seed error:', e?.message || e));
+  }, CYBER_SEED_INTERVAL_MS).unref?.();
+}
+
 function gzipSyncBuffer(body) {
   try {
     return zlib.gzipSync(typeof body === 'string' ? Buffer.from(body) : body);
@@ -4172,6 +4505,7 @@ server.listen(PORT, () => {
   startUcdpSeedLoop();
   startMarketDataSeedLoop();
   startAviationSeedLoop();
+  startCyberThreatsSeedLoop();
 });
 
 wss.on('connection', (ws, req) => {

--- a/server/error-mapper.ts
+++ b/server/error-mapper.ts
@@ -57,6 +57,14 @@ export function mapErrorToResponse(error: unknown, _req: Request): Response {
     });
   }
 
+  // JSON parse errors from req.json() on malformed/empty POST body → 400 not 500
+  if (error instanceof SyntaxError) {
+    return new Response(JSON.stringify({ message: 'Invalid request body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
   // Network/fetch errors: upstream is unreachable (M-5 fix: runtime-agnostic detection)
   if (isNetworkError(error)) {
     console.error('[error-mapper] Network error (502):', (error as Error).message);

--- a/server/worldmonitor/cyber/v1/_shared.ts
+++ b/server/worldmonitor/cyber/v1/_shared.ts
@@ -38,10 +38,10 @@ const C2INTEL_URL = 'https://raw.githubusercontent.com/drb-ra/C2IntelFeeds/maste
 const OTX_INDICATORS_URL = 'https://otx.alienvault.com/api/v1/indicators/export?type=IPv4&modified_since=';
 const ABUSEIPDB_BLACKLIST_URL = 'https://api.abuseipdb.com/api/v2/blacklist';
 
-const UPSTREAM_TIMEOUT_MS = 8000;
-const GEO_MAX_UNRESOLVED = 250;
-const GEO_CONCURRENCY = 16;
-const GEO_OVERALL_TIMEOUT_MS = 15_000;
+const UPSTREAM_TIMEOUT_MS = 7000;
+const GEO_MAX_UNRESOLVED = 200;
+const GEO_CONCURRENCY = 12;
+const GEO_OVERALL_TIMEOUT_MS = 12_000;
 const GEO_PER_IP_TIMEOUT_MS = 1500;
 const GEO_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 

--- a/server/worldmonitor/intelligence/v1/_shared.ts
+++ b/server/worldmonitor/intelligence/v1/_shared.ts
@@ -6,7 +6,7 @@
 // Constants
 // ========================================================================
 
-export const UPSTREAM_TIMEOUT_MS = 30_000;
+export const UPSTREAM_TIMEOUT_MS = 25_000;
 export const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
 export const GROQ_MODEL = 'llama-3.1-8b-instant';
 

--- a/server/worldmonitor/news/v1/summarize-article.ts
+++ b/server/worldmonitor/news/v1/summarize-article.ts
@@ -116,7 +116,7 @@ export async function summarizeArticle(
             top_p: 0.9,
             ...extraBody,
           }),
-          signal: AbortSignal.timeout(30_000),
+          signal: AbortSignal.timeout(25_000),
         });
 
         if (!response.ok) {


### PR DESCRIPTION
## Summary

- **Railway seeding for cyber threats**: Add a full `seedCyberThreats()` loop to `scripts/ais-relay.cjs` that fetches from 5 IOC sources (Feodo, URLhaus, C2IntelFeeds, AlienVault OTX, AbuseIPDB), hydrates GeoIP coordinates, deduplicates, and writes to Redis every 2h. Vercel's `list-cyber-threats` handler now reads from cache instead of live-fetching during every request.
- **Bootstrap hydration**: Register `cyberThreats: 'cyber:threats-bootstrap:v2'` in `api/bootstrap.js` so the frontend receives cyber threat data on initial page load.
- **Cloudflare 500 fixes**: Map `SyntaxError` → HTTP 400 in `error-mapper.ts` (malformed POST body); reduce LLM/upstream timeouts from 30s → 25s so edge functions don't hit the wall-clock budget.

## Changes

| File | Change |
|---|---|
| `scripts/ais-relay.cjs` | +334 lines: cyber seed loop (5 sources, GeoIP hydration, FIFO-capped 2048-entry cache, dual Redis write) |
| `api/bootstrap.js` | Register `cyberThreats` key + add to `SLOW_KEYS` |
| `server/error-mapper.ts` | `SyntaxError` → 400 handler for malformed POST bodies |
| `server/worldmonitor/cyber/v1/_shared.ts` | Reduce timeouts/concurrency to fit 30s edge budget |
| `server/worldmonitor/intelligence/v1/_shared.ts` | `UPSTREAM_TIMEOUT_MS` 30s → 25s |
| `server/worldmonitor/news/v1/summarize-article.ts` | `AbortSignal.timeout` 30s → 25s |

## Test plan

- [ ] Deploy Railway: verify `[Cyber] Seeded N threats` log appears within ~30s of startup
- [ ] `curl https://api.worldmonitor.app/api/cyber/v1/list-cyber-threats` — should return `source: cache` with threat data
- [ ] `curl https://api.worldmonitor.app/api/bootstrap?tier=slow` — should include `cyberThreats` key in response
- [ ] POST malformed JSON to a Vercel handler — verify 400 response (not 500)
- [ ] Monitor Cloudflare: 500s on `/api/news/v1/summarize-article` and `/api/intelligence/v1/classify-event` should decrease