### PR TITLE
test(circuit-breakers): harden HAPI/GDELT regression tests (P2 fixes)

### DIFF
--- a/tests/hapi-gdelt-circuit-breakers.test.mjs
+++ b/tests/hapi-gdelt-circuit-breakers.test.mjs
@@ -27,6 +27,11 @@ const root = resolve(__dirname, '..');
 
 const readSrc = (relPath) => readFileSync(resolve(root, relPath), 'utf-8');
 
+// Shared URL for dynamic imports in behavioral tests
+const CIRCUIT_BREAKER_URL = pathToFileURL(
+  resolve(root, 'src/utils/circuit-breaker.ts'),
+).href;
+
 // ============================================================
 // 1. Static analysis: conflict/index.ts — per-country HAPI breakers
 // ============================================================
@@ -34,9 +39,9 @@ const readSrc = (relPath) => readFileSync(resolve(root, relPath), 'utf-8');
 describe('conflict/index.ts — per-country HAPI circuit breakers', () => {
   const src = readSrc('src/services/conflict/index.ts');
 
-  // Scoped slices to avoid false positives from comments or unrelated code
-  const breakerSection = src.slice(src.indexOf('hapiBreakers'), src.indexOf('hapiBreakers') + 400);
+  // Scoped function body slice — guard against rename/removal silently broadening scope
   const fnStart = src.indexOf('export async function fetchHapiSummary');
+  assert.ok(fnStart !== -1, 'fetchHapiSummary must exist in conflict/index.ts');
   const fnBody = src.slice(fnStart, src.indexOf('\nexport ', fnStart + 1));
 
   it('does NOT have a single shared hapiBreaker', () => {
@@ -48,9 +53,10 @@ describe('conflict/index.ts — per-country HAPI circuit breakers', () => {
   });
 
   it('has a hapiBreakers Map for per-country instances', () => {
+    // Check src directly — pattern is specific enough to avoid false positives
     assert.match(
-      breakerSection,
-      /new\s+Map/,
+      src,
+      /\bhapiBreakers\s*=\s*new\s+Map/,
       'hapiBreakers Map must exist to store per-country circuit breakers',
     );
   });
@@ -72,8 +78,9 @@ describe('conflict/index.ts — per-country HAPI circuit breakers', () => {
   });
 
   it('per-country breaker names embed iso2', () => {
+    // Check src directly — template literal is specific enough without window slicing
     assert.match(
-      breakerSection,
+      src,
       /name\s*:\s*`HDX HAPI:\$\{iso2\}`/,
       'Breaker name must embed iso2 (e.g. "HDX HAPI:US") for unique IndexedDB persistence per country',
     );
@@ -87,10 +94,13 @@ describe('conflict/index.ts — per-country HAPI circuit breakers', () => {
 describe('gdelt-intel.ts — dedicated circuit breakers per GDELT query type', () => {
   const src = readSrc('src/services/gdelt-intel.ts');
 
-  // Scoped function body slices
+  // Scoped function body slices — guard against rename/removal silently broadening scope
   const posStart = src.indexOf('export async function fetchPositiveGdeltArticles');
+  assert.ok(posStart !== -1, 'fetchPositiveGdeltArticles must exist in gdelt-intel.ts');
   const posBody = src.slice(posStart, src.indexOf('\nexport ', posStart + 1));
+
   const regStart = src.indexOf('export async function fetchGdeltArticles');
+  assert.ok(regStart !== -1, 'fetchGdeltArticles must exist in gdelt-intel.ts');
   const regBody = src.slice(regStart, src.indexOf('\nexport ', regStart + 1));
 
   it('has a dedicated positiveGdeltBreaker separate from gdeltBreaker', () => {
@@ -133,7 +143,7 @@ describe('gdelt-intel.ts — dedicated circuit breakers per GDELT query type', (
       /positiveGdeltBreaker\.execute/,
       'fetchPositiveGdeltArticles must use positiveGdeltBreaker.execute',
     );
-    // word-boundary prevents matching `positiveGdeltBreaker.execute`
+    // \b word-boundary ensures `positiveGdeltBreaker.execute` (uppercase G) is not matched
     assert.doesNotMatch(
       posBody,
       /\bgdeltBreaker\.execute/,
@@ -147,37 +157,34 @@ describe('gdelt-intel.ts — dedicated circuit breakers per GDELT query type', (
 // ============================================================
 
 describe('CircuitBreaker isolation — HAPI per-country independence', () => {
-  const CIRCUIT_BREAKER_URL = pathToFileURL(
-    resolve(root, 'src/utils/circuit-breaker.ts'),
-  ).href;
-
   it('HAPI: failure in one country does not trip another', async () => {
     const { createCircuitBreaker, clearAllCircuitBreakers } = await import(
       `${CIRCUIT_BREAKER_URL}?t=${Date.now()}`
     );
 
     clearAllCircuitBreakers();
+    try {
+      const breakerUS = createCircuitBreaker({ name: 'HDX HAPI:US', cacheTtlMs: 30 * 60 * 1000 });
+      const breakerRU = createCircuitBreaker({ name: 'HDX HAPI:RU', cacheTtlMs: 30 * 60 * 1000 });
 
-    const breakerUS = createCircuitBreaker({ name: 'HDX HAPI:US', cacheTtlMs: 30 * 60 * 1000 });
-    const breakerRU = createCircuitBreaker({ name: 'HDX HAPI:RU', cacheTtlMs: 30 * 60 * 1000 });
+      const fallback = { summary: null };
+      const alwaysFail = () => { throw new Error('HDX HAPI unavailable'); };
 
-    const fallback = { summary: null };
-    const alwaysFail = () => { throw new Error('HDX HAPI unavailable'); };
+      // Default maxFailures is 2 — force breakerUS into cooldown
+      await breakerUS.execute(alwaysFail, fallback); // failure 1
+      await breakerUS.execute(alwaysFail, fallback); // failure 2 → cooldown
+      assert.equal(breakerUS.isOnCooldown(), true, 'breakerUS should be on cooldown after 2 failures');
 
-    // Force breakerUS into cooldown (2 failures = maxFailures)
-    await breakerUS.execute(alwaysFail, fallback); // failure 1
-    await breakerUS.execute(alwaysFail, fallback); // failure 2 → cooldown
-    assert.equal(breakerUS.isOnCooldown(), true, 'breakerUS should be on cooldown after 2 failures');
+      // breakerRU must NOT be affected
+      assert.equal(breakerRU.isOnCooldown(), false, 'breakerRU must not be on cooldown when breakerUS fails');
 
-    // breakerRU must NOT be affected
-    assert.equal(breakerRU.isOnCooldown(), false, 'breakerRU must not be on cooldown when breakerUS fails');
-
-    // breakerRU should still call through successfully
-    const goodData = { summary: { countryCode: 'RU', conflictEvents: 12, displacedPersons: 5000 } };
-    const result = await breakerRU.execute(async () => goodData, fallback);
-    assert.deepEqual(result, goodData, 'breakerRU should return live data unaffected by breakerUS cooldown');
-
-    clearAllCircuitBreakers();
+      // breakerRU should still call through successfully
+      const goodData = { summary: { countryCode: 'RU', conflictEvents: 12, displacedPersons: 5000 } };
+      const result = await breakerRU.execute(async () => goodData, fallback);
+      assert.deepEqual(result, goodData, 'breakerRU should return live data unaffected by breakerUS cooldown');
+    } finally {
+      clearAllCircuitBreakers();
+    }
   });
 
   it('HAPI: different countries cache independently (no cross-country poisoning)', async () => {
@@ -186,65 +193,63 @@ describe('CircuitBreaker isolation — HAPI per-country independence', () => {
     );
 
     clearAllCircuitBreakers();
+    try {
+      const breakerUS = createCircuitBreaker({ name: 'HDX HAPI:US', cacheTtlMs: 30 * 60 * 1000 });
+      const breakerRU = createCircuitBreaker({ name: 'HDX HAPI:RU', cacheTtlMs: 30 * 60 * 1000 });
 
-    const breakerUS = createCircuitBreaker({ name: 'HDX HAPI:US', cacheTtlMs: 30 * 60 * 1000 });
-    const breakerRU = createCircuitBreaker({ name: 'HDX HAPI:RU', cacheTtlMs: 30 * 60 * 1000 });
+      const fallback = { summary: null };
+      const usData = { summary: { countryCode: 'US', conflictEvents: 3, displacedPersons: 100 } };
+      const ruData = { summary: { countryCode: 'RU', conflictEvents: 47, displacedPersons: 120000 } };
 
-    const fallback = { summary: null };
-    const usData = { summary: { countryCode: 'US', conflictEvents: 3, displacedPersons: 100 } };
-    const ruData = { summary: { countryCode: 'RU', conflictEvents: 47, displacedPersons: 120000 } };
+      // Populate both caches with different data
+      await breakerUS.execute(async () => usData, fallback);
+      await breakerRU.execute(async () => ruData, fallback);
 
-    // Populate both caches with different data
-    await breakerUS.execute(async () => usData, fallback);
-    await breakerRU.execute(async () => ruData, fallback);
+      // Each must return its own cached value; pass a fallback fn that would return wrong data
+      const cachedUS = await breakerUS.execute(async () => fallback, fallback);
+      const cachedRU = await breakerRU.execute(async () => fallback, fallback);
 
-    // Each must return its own cached value; pass a fallback fn that would return wrong data
-    const cachedUS = await breakerUS.execute(async () => fallback, fallback);
-    const cachedRU = await breakerRU.execute(async () => fallback, fallback);
-
-    assert.equal(cachedUS.summary?.countryCode, 'US',
-      'breakerUS cache must return US data, not RU data');
-    assert.equal(cachedRU.summary?.countryCode, 'RU',
-      'breakerRU cache must return RU data, not US data');
-    assert.notEqual(cachedUS.summary?.conflictEvents, cachedRU.summary?.conflictEvents,
-      'Cached conflict event counts must be independent per country');
-
-    clearAllCircuitBreakers();
+      assert.equal(cachedUS.summary?.countryCode, 'US',
+        'breakerUS cache must return US data, not RU data');
+      assert.equal(cachedRU.summary?.countryCode, 'RU',
+        'breakerRU cache must return RU data, not US data');
+      assert.notEqual(cachedUS.summary?.conflictEvents, cachedRU.summary?.conflictEvents,
+        'Cached conflict event counts must be independent per country');
+    } finally {
+      clearAllCircuitBreakers();
+    }
   });
 });
 
 describe('CircuitBreaker isolation — GDELT split breaker independence', () => {
-  const CIRCUIT_BREAKER_URL = pathToFileURL(
-    resolve(root, 'src/utils/circuit-breaker.ts'),
-  ).href;
-
   it('GDELT: positive breaker failure does not trip regular breaker', async () => {
     const { createCircuitBreaker, clearAllCircuitBreakers } = await import(
       `${CIRCUIT_BREAKER_URL}?t=${Date.now()}`
     );
 
     clearAllCircuitBreakers();
+    try {
+      const gdelt = createCircuitBreaker({ name: 'GDELT Intelligence', cacheTtlMs: 10 * 60 * 1000 });
+      const positive = createCircuitBreaker({ name: 'GDELT Positive', cacheTtlMs: 10 * 60 * 1000 });
 
-    const gdelt = createCircuitBreaker({ name: 'GDELT Intelligence', cacheTtlMs: 10 * 60 * 1000 });
-    const positive = createCircuitBreaker({ name: 'GDELT Positive', cacheTtlMs: 10 * 60 * 1000 });
+      const fallback = { articles: [], totalArticles: 0 };
+      const alwaysFail = () => { throw new Error('GDELT API unavailable'); };
 
-    const fallback = { articles: [], totalArticles: 0 };
-    const alwaysFail = () => { throw new Error('GDELT API unavailable'); };
+      // Default maxFailures is 2 — force positive breaker into cooldown
+      await positive.execute(alwaysFail, fallback); // failure 1
+      await positive.execute(alwaysFail, fallback); // failure 2 → cooldown
+      assert.equal(positive.isOnCooldown(), true, 'positive breaker should be on cooldown after 2 failures');
 
-    // Force positive breaker into cooldown (2 failures)
-    await positive.execute(alwaysFail, fallback); // failure 1
-    await positive.execute(alwaysFail, fallback); // failure 2 → cooldown
-    assert.equal(positive.isOnCooldown(), true, 'positive breaker should be on cooldown after 2 failures');
+      // gdelt breaker must NOT be affected
+      assert.equal(gdelt.isOnCooldown(), false, 'gdelt breaker must not be on cooldown when positive fails');
 
-    // gdelt breaker must NOT be affected
-    assert.equal(gdelt.isOnCooldown(), false, 'gdelt breaker must not be on cooldown when positive fails');
-
-    // gdelt should still call through successfully
-    const realArticles = { articles: [{ url: 'https://news.example/military', title: 'Conflict update' }], totalArticles: 1 };
-    const result = await gdelt.execute(async () => realArticles, fallback);
-    assert.deepEqual(result, realArticles, 'gdelt breaker should return live data unaffected by positive cooldown');
-
-    clearAllCircuitBreakers();
+      // gdelt should still call through successfully
+      const realArticles = { articles: [{ url: 'https://news.example/military', title: 'Conflict update' }], totalArticles: 1 };
+      const result = await gdelt.execute(async () => realArticles, fallback);
+      assert.deepEqual(result, realArticles, 'gdelt breaker should return live data unaffected by positive cooldown');
+    } finally {
+      clearAllCircuitBreakers();
+    }
   });
 
   it('GDELT: regular and positive breakers cache different data independently', async () => {
@@ -253,36 +258,37 @@ describe('CircuitBreaker isolation — GDELT split breaker independence', () => 
     );
 
     clearAllCircuitBreakers();
+    try {
+      const gdelt = createCircuitBreaker({ name: 'GDELT Intelligence', cacheTtlMs: 10 * 60 * 1000 });
+      const positive = createCircuitBreaker({ name: 'GDELT Positive', cacheTtlMs: 10 * 60 * 1000 });
 
-    const gdelt = createCircuitBreaker({ name: 'GDELT Intelligence', cacheTtlMs: 10 * 60 * 1000 });
-    const positive = createCircuitBreaker({ name: 'GDELT Positive', cacheTtlMs: 10 * 60 * 1000 });
+      const fallback = { articles: [], totalArticles: 0 };
+      const militaryData = { articles: [{ url: 'https://news.example/military', title: 'Military operations' }], totalArticles: 1 };
+      const peaceData    = { articles: [{ url: 'https://good.example/peace', title: 'Peace agreement' }], totalArticles: 1 };
 
-    const fallback = { articles: [], totalArticles: 0 };
-    const militaryData = { articles: [{ url: 'https://news.example/military', title: 'Military operations' }], totalArticles: 1 };
-    const peaceData    = { articles: [{ url: 'https://good.example/peace', title: 'Peace agreement' }], totalArticles: 1 };
+      // Populate both caches with different data
+      await gdelt.execute(async () => militaryData, fallback);
+      await positive.execute(async () => peaceData, fallback);
 
-    // Populate both caches with different data
-    await gdelt.execute(async () => militaryData, fallback);
-    await positive.execute(async () => peaceData, fallback);
+      // Each must return its own cached value; pass fallback fn that would return wrong data
+      const cachedGdelt    = await gdelt.execute(async () => fallback, fallback);
+      const cachedPositive = await positive.execute(async () => fallback, fallback);
 
-    // Each must return its own cached value; pass fallback fn that would return wrong data
-    const cachedGdelt    = await gdelt.execute(async () => fallback, fallback);
-    const cachedPositive = await positive.execute(async () => fallback, fallback);
-
-    assert.ok(
-      cachedGdelt.articles[0]?.url.includes('military'),
-      'gdelt cache must return military article URL, not peace article',
-    );
-    assert.ok(
-      cachedPositive.articles[0]?.url.includes('peace'),
-      'positive cache must return peace article URL, not military article',
-    );
-    assert.notEqual(
-      cachedGdelt.articles[0]?.url,
-      cachedPositive.articles[0]?.url,
-      'Cached article URLs must be distinct per breaker (no cross-contamination)',
-    );
-
-    clearAllCircuitBreakers();
+      assert.ok(
+        cachedGdelt.articles[0]?.url.includes('military'),
+        'gdelt cache must return military article URL, not peace article',
+      );
+      assert.ok(
+        cachedPositive.articles[0]?.url.includes('peace'),
+        'positive cache must return peace article URL, not military article',
+      );
+      assert.notEqual(
+        cachedGdelt.articles[0]?.url,
+        cachedPositive.articles[0]?.url,
+        'Cached article URLs must be distinct per breaker (no cross-contamination)',
+      );
+    } finally {
+      clearAllCircuitBreakers();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #879. The initial regression tests were included in the squash merge, but P2 hardening from a post-merge code review was not.

**Single commit, test file only** (`tests/hapi-gdelt-circuit-breakers.test.mjs`):

- `assert.ok(fnStart/posStart/regStart !== -1, '...')` guards before every `src.slice(idx, ...)` — prevents silent scope expansion to the whole file when a function is renamed/removed
- Replace `src.slice(src.indexOf('hapiBreakers'), idx + 400)` window with direct `src` match on `/\bhapiBreakers\s*=\s*new\s+Map/` — removes fragile layout-dependent 400-char window assumption  
- Lift `CIRCUIT_BREAKER_URL` to module scope — was duplicated in two `describe` blocks
- Wrap all 4 behavioral test bodies in `try/finally` — guarantees `clearAllCircuitBreakers()` runs even when an assertion throws mid-test

## Test plan
- [x] All 13 tests pass: `npm run test:data -- tests/hapi-gdelt-circuit-breakers.test.mjs`
- [x] `npx tsc --noEmit` clean