### PR TITLE
feat(feeds): add major US news sources to United States tab

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -322,6 +322,14 @@ const ALLOWED_DOMAINS = [
   'www.nature.com',
   'www.livescience.com',
   'www.newscientist.com',
+  // US broadcast & print news
+  'www.pbs.org',
+  'feeds.abcnews.com',
+  'feeds.nbcnews.com',
+  'www.cbsnews.com',
+  'moxie.foxnews.com',
+  'feeds.content.dowjones.io',
+  'thehill.com',
 ];
 
 export default async function handler(req) {

--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -17,8 +17,15 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'CNN World', url: gn('site:cnn.com world news when:1d') },
     ],
     us: [
+      { name: 'Reuters US', url: gn('site:reuters.com US') },
       { name: 'NPR News', url: 'https://feeds.npr.org/1001/rss.xml' },
-      { name: 'Politico', url: gn('site:politico.com when:1d') },
+      { name: 'PBS NewsHour', url: 'https://www.pbs.org/newshour/feeds/rss/headlines' },
+      { name: 'ABC News', url: 'https://feeds.abcnews.com/abcnews/topstories' },
+      { name: 'CBS News', url: 'https://www.cbsnews.com/latest/rss/main' },
+      { name: 'NBC News', url: 'https://feeds.nbcnews.com/nbcnews/public/news' },
+      { name: 'Wall Street Journal', url: 'https://feeds.content.dowjones.io/public/rss/RSSUSnews' },
+      { name: 'Politico', url: 'https://rss.politico.com/politics-news.xml' },
+      { name: 'The Hill', url: 'https://thehill.com/news/feed' },
       { name: 'Axios', url: 'https://api.axios.com/feed/' },
     ],
     europe: [

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -63,6 +63,10 @@ export const SOURCE_TIERS: Record<string, number> = {
   'Fox News': 2,
   'NBC News': 2,
   'CBS News': 2,
+  'ABC News': 2,
+  'PBS NewsHour': 2,
+  'Wall Street Journal': 1,
+  'The Hill': 3,
   'The National': 2,
   'Yonhap News': 2,
   'Chosun Ilbo': 2,
@@ -464,13 +468,17 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     { name: 'CNN World', url: rss('https://news.google.com/rss/search?q=site:cnn.com+world+news+when:1d&hl=en-US&gl=US&ceid=US:en') },
   ],
   us: [
+    { name: 'Reuters US', url: rss('https://news.google.com/rss/search?q=site:reuters.com+US&hl=en-US&gl=US&ceid=US:en') },
     { name: 'NPR News', url: rss('https://feeds.npr.org/1001/rss.xml') },
-    { name: 'Politico', url: rss('https://news.google.com/rss/search?q=site:politico.com+when:1d&hl=en-US&gl=US&ceid=US:en') },
+    { name: 'PBS NewsHour', url: rss('https://www.pbs.org/newshour/feeds/rss/headlines') },
+    { name: 'ABC News', url: rss('https://feeds.abcnews.com/abcnews/topstories') },
+    { name: 'CBS News', url: rss('https://www.cbsnews.com/latest/rss/main') },
+    { name: 'NBC News', url: rss('https://feeds.nbcnews.com/nbcnews/public/news') },
+    { name: 'Wall Street Journal', url: rss('https://feeds.content.dowjones.io/public/rss/RSSUSnews') },
+    { name: 'Politico', url: rss('https://rss.politico.com/politics-news.xml') },
+    { name: 'The Hill', url: rss('https://thehill.com/news/feed') },
     { name: 'Axios', url: rss('https://api.axios.com/feed/') },
     { name: 'Fox News', url: rss('https://moxie.foxnews.com/google-publisher/us.xml') },
-    { name: 'NBC News', url: rss('http://feeds.nbcnews.com/feeds/topstories') },
-    { name: 'CBS News', url: rss('http://www.cbsnews.com/latest/rss/main') },
-    { name: 'Reuters US', url: rss('http://feeds.reuters.com/Reuters/domesticNews') },
   ],
   europe: [
     {
@@ -1151,7 +1159,7 @@ export const INTEL_SOURCES: Feed[] = [
 // Default-enabled sources per panel (Tier 1+2 priority, ≥8 per panel)
 export const DEFAULT_ENABLED_SOURCES: Record<string, string[]> = {
   politics: ['BBC World', 'Guardian World', 'AP News', 'Reuters World', 'CNN World'],
-  us: ['NPR News', 'Politico', 'Axios', 'Fox News', 'NBC News', 'CBS News', 'Reuters US'],
+  us: ['Reuters US', 'NPR News', 'PBS NewsHour', 'ABC News', 'CBS News', 'NBC News', 'Wall Street Journal', 'Politico', 'The Hill'],
   europe: ['France 24', 'EuroNews', 'Le Monde', 'DW News', 'Tagesschau', 'ANSA', 'NOS Nieuws', 'SVT Nyheter'],
   middleeast: ['BBC Middle East', 'Al Jazeera', 'Al Arabiya', 'Guardian ME', 'BBC Persian', 'Iran International', 'Haaretz', 'Asharq News', 'The National'],
   africa: ['BBC Africa', 'News24', 'Africanews', 'Jeune Afrique', 'Africa News', 'Premium Times', 'Channels TV', 'Sahel Crisis'],


### PR DESCRIPTION
## Summary
- Add **PBS NewsHour**, **ABC News**, **Wall Street Journal**, **The Hill** to the `us` feed group (UNITED STATES tab)
- Fix dead/broken URLs: Reuters US (`feeds.reuters.com` shut down 2020 → Google News), NBC News (http→https + correct endpoint), CBS News (http→https), Politico (Google News → official `rss.politico.com`)
- Whitelist 7 previously-missing domains in `rss-proxy.js` `ALLOWED_DOMAINS` (`www.pbs.org`, `feeds.abcnews.com`, `feeds.nbcnews.com`, `www.cbsnews.com`, `moxie.foxnews.com`, `feeds.content.dowjones.io`, `thehill.com`)
- Add `SOURCE_TIERS` entries: ABC News (2), PBS NewsHour (2), Wall Street Journal (1), The Hill (3)
- Update `DEFAULT_ENABLED_SOURCES.us` to reflect new lineup

## Test plan
- [ ] Open UNITED STATES tab in source filter — verify PBS NewsHour, ABC News, WSJ, The Hill appear
- [ ] Verify Reuters US, NBC News, CBS News, Politico feeds load without 403 errors
- [ ] Verify AP News remains in WORLDWIDE tab only (not duplicated in US)