### PR TITLE
fix: respect user preference for Desktop Configuration panel (#884)

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -171,14 +171,14 @@ export class App {
 
     // Desktop key management panel must always remain accessible in Tauri.
     if (isDesktopApp) {
-      const runtimePanel = panelSettings['runtime-config'] ?? {
-        name: 'Desktop Configuration',
-        enabled: true,
-        priority: 2,
-      };
-      runtimePanel.enabled = true;
-      panelSettings['runtime-config'] = runtimePanel;
-      saveToStorage(STORAGE_KEYS.panels, panelSettings);
+      if (!panelSettings['runtime-config']) {
+        panelSettings['runtime-config'] = {
+          name: 'Desktop Configuration',
+          enabled: true,
+          priority: 2,
+        };
+        saveToStorage(STORAGE_KEYS.panels, panelSettings);
+      }
     }
 
     let initialUrlState: ParsedMapUrlState | null = parseMapUrlState(window.location.search, mapLayers);


### PR DESCRIPTION
## Summary
- The Desktop Configuration (`runtime-config`) panel was force-enabled on every app restart, ignoring the user's preference to disable it
- Changed to only create the panel with `enabled: true` on first run; subsequent restarts preserve the user's saved state

## Root Cause
`src/App.ts` unconditionally set `runtimePanel.enabled = true` on every startup for desktop apps, overwriting the user's saved `enabled: false` preference.

## Test Plan
- [ ] Fresh install: Desktop Configuration panel appears enabled (as before)
- [ ] Disable panel → restart app → panel stays disabled
- [ ] Re-enable panel → restart app → panel stays enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)