### PR TITLE
fix: open URLs in browser instead of file dialog on Windows (#741)

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -426,8 +426,8 @@ fn open_in_shell(arg: &str) -> Result<(), String> {
 
     #[cfg(target_os = "windows")]
     let mut command = {
-        let mut cmd = Command::new("explorer");
-        cmd.arg(arg);
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/c", "start", "", arg]);
         cmd
     };
 


### PR DESCRIPTION
## Summary
- Fixed "Open on YouTube" (and all external URL links) opening a file dialog instead of the browser on Windows
- Changed Windows URL opener from `explorer.exe` to `cmd /c start` which properly delegates URLs to the default browser

## Root Cause
`explorer.exe` is a file manager that treats URL arguments as file paths. The `start` command correctly handles URL protocols (https://, etc.) by opening them in the default browser.

## Test Plan
- [ ] Windows: Click "Open on YouTube" on any live webcam -> opens YouTube in default browser
- [ ] Windows: Click any external link (GitHub, credits) -> opens in browser
- [ ] macOS/Linux: No change in behavior (uses `open` / `xdg-open` respectively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)