### PR TITLE
fix: enable pinch-to-zoom on Android for map (#868)

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3393,6 +3393,9 @@ body.playback-mode .status-dot {
   position: relative;
   overflow: hidden;
   background: var(--map-bg);
+  /* Let the map library handle all touch gestures (pinch-zoom, pan)
+     instead of the browser intercepting them on mobile/Android */
+  touch-action: none;
 }
 
 .map-wrapper {
@@ -12414,6 +12417,9 @@ a.prediction-link:hover {
   width: 100%;
   height: 100%;
   overflow: hidden;
+  /* Prevent browser from intercepting touch gestures (pinch-zoom, pan)
+     so MapLibre/deck.gl can handle them directly — fixes Android pinch-zoom */
+  touch-action: none;
 }
 
 #deckgl-basemap {
@@ -12422,6 +12428,9 @@ a.prediction-link:hover {
   left: 0;
   width: 100%;
   height: 100%;
+  /* Let MapLibre handle all touch gestures (pinch-zoom, pan, rotate)
+     instead of the browser intercepting them for page zoom on Android */
+  touch-action: none;
 }
 
 #deckgl-overlay {


### PR DESCRIPTION
## Summary
- Fixed pinch-to-zoom not working on Android devices by adding `touch-action: none` CSS to the map container elements
- Without this property, Android Chrome intercepts pinch/pan gestures for native page zoom before MapLibre/deck.gl can handle them
- Applied to `.map-container` (base map), `.deckgl-map-wrapper`, and `#deckgl-basemap` to cover both the standard and DeckGL map modes

## Test Plan
- [ ] Android: pinch-to-zoom works on the map
- [ ] Android: single-finger pan/drag still works on the map
- [ ] Desktop: mouse scroll zoom still works
- [ ] Desktop: click-and-drag pan still works
- [ ] iOS: pinch-to-zoom still works (if it was working before)

Closes #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)