### PR TITLE
fix: show specific error messages for waitlist registration (#673)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -483,6 +483,9 @@
           "success": "You're on the list! We'll notify you first.",
           "alreadyRegistered": "You're already on the waitlist.",
           "error": "Registration failed. Please try again.",
+          "errorRateLimit": "Too many attempts. Please try again in an hour.",
+          "errorServiceUnavailable": "Registration service is temporarily unavailable.",
+          "errorNetwork": "Network error. Check your connection and try again.",
           "invalidEmail": "Please enter a valid email address."
         },
         "byokTitle": "Or bring your own keys",

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -300,12 +300,18 @@ function initOverviewListeners(area: HTMLElement): void {
           ? t('modals.settingsWindow.worldMonitor.register.alreadyRegistered')
           : t('modals.settingsWindow.worldMonitor.register.success');
         regStatus.className = 'wm-reg-status ok';
+      } else if (res.status === 429) {
+        regStatus.textContent = t('modals.settingsWindow.worldMonitor.register.errorRateLimit');
+        regStatus.className = 'wm-reg-status error';
+      } else if (res.status === 503) {
+        regStatus.textContent = t('modals.settingsWindow.worldMonitor.register.errorServiceUnavailable');
+        regStatus.className = 'wm-reg-status error';
       } else {
         regStatus.textContent = data.error || t('modals.settingsWindow.worldMonitor.register.error');
         regStatus.className = 'wm-reg-status error';
       }
     } catch {
-      regStatus.textContent = t('modals.settingsWindow.worldMonitor.register.error');
+      regStatus.textContent = t('modals.settingsWindow.worldMonitor.register.errorNetwork');
       regStatus.className = 'wm-reg-status error';
     } finally {
       btn.disabled = false;


### PR DESCRIPTION
## Summary
- Improved error handling for the "Reserve Your Spot" waitlist registration
- Users now see specific messages instead of generic "Registration failed" for:
  - Rate limiting (429) -> "Too many attempts. Please try again in an hour."
  - Service unavailable (503) -> "Registration service is temporarily unavailable."
  - Network errors (fetch failure) -> "Network error. Check your connection and try again."
- Added i18n keys (`errorRateLimit`, `errorServiceUnavailable`, `errorNetwork`) in `en.json`
- Other locales fall back to English via i18next `fallbackLng: 'en'`

## Test plan
- [ ] Register with new email -> success message
- [ ] Register with same email again -> "already registered" message
- [ ] Simulate rate limiting (6+ requests in 1 hour) -> "Too many attempts" message
- [ ] Simulate service unavailable (503) -> "Registration service is temporarily unavailable"
- [ ] Disconnect network, then register -> "Network error" message
- [ ] TypeScript type check passes (`npx tsc --noEmit`)

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)