### PR TITLE
feat(ui): move layout tabs & widget picker to drop zone

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -182,9 +182,7 @@ export class PanelLayoutManager implements AppModule {
             </select>
           </div>
         </div>
-        <div class="layout-tabs-mount" id="layoutTabsMount"></div>
         <div class="header-right">
-          <span id="widgetPickerMount"></span>
           ${this.ctx.isDesktopApp ? '' : `<div class="download-wrapper" id="downloadWrapper">
             <button class="download-btn" id="downloadBtn" title="${t('header.downloadApp')}">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
@@ -225,7 +223,13 @@ export class PanelLayoutManager implements AppModule {
           <div class="map-container" id="mapContainer"></div>
           ${SITE_VARIANT === 'happy' ? '<button class="tv-exit-btn" id="tvExitBtn">Exit TV Mode</button>' : ''}
           <div class="map-resize-handle" id="mapResizeHandle"></div>
-          <div class="map-bottom-grid" id="mapBottomGrid"></div>
+          <div class="map-bottom-grid" id="mapBottomGrid">
+            <div class="drop-zone-controls" id="dropZoneControls">
+              <div id="layoutTabsMount"></div>
+              <span id="widgetPickerMount"></span>
+            </div>
+            <div class="drop-zone-label">Drop panels here to move them below the map</div>
+          </div>
         </div>
         <div class="panels-grid" id="panelsGrid"></div>
       </div>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -625,12 +625,40 @@ canvas,
   gap: 12px;
 }
 
-/* Layout tabs */
+/* Drop zone controls (layout tabs + widget picker) */
+.drop-zone-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+}
+
+.drop-zone-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 8px;
+  padding: 40px 12px;
+  border: 1.5px dashed var(--text-dim);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  opacity: 1;
+  pointer-events: none;
+}
+
+.map-bottom-grid:has(.panel) > .drop-zone-label {
+  display: none;
+}
+
 .layout-tabs {
   display: flex;
   align-items: center;
   gap: 2px;
-  margin: 0 12px;
+  margin: 0;
   flex-shrink: 1;
   overflow-x: auto;
 }
@@ -682,7 +710,7 @@ canvas,
 }
 
 @media (max-width: 900px) {
-  .layout-tabs {
+  .drop-zone-controls {
     display: none;
   }
 }
@@ -1141,6 +1169,26 @@ canvas,
 .map-section.resizing .map-resize-handle::after {
   background: var(--green);
   opacity: 1;
+}
+
+.map-bottom-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: auto 1fr;
+  grid-auto-rows: minmax(200px, 380px);
+  gap: 4px;
+  padding: 4px;
+  min-height: 28px;
+}
+
+.map-bottom-grid > .drop-zone-controls {
+  grid-column: 1 / -1;
+  grid-row: 1;
+}
+
+.map-bottom-grid > .drop-zone-label {
+  grid-column: 1 / -1;
+  grid-row: 2;
 }
 
 .map-section.pinned {
@@ -16533,7 +16581,7 @@ body.has-breaking-alert .panels-grid {
     transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1) !important;
   }
 
-  .map-bottom-grid:empty {
+  .map-bottom-grid:not(:has(.panel)) {
     border-top: none;
     padding: 0;
   }


### PR DESCRIPTION
## Summary
- Move layout tabs (Intelligence, Markets, News, Minimal) and widget picker (+) button from the header into the map bottom drop zone
- Add dashed-border drop zone with centered "DROP PANELS HERE TO MOVE THEM BELOW THE MAP" label
- Panels dropped into the zone use a 2-column grid layout
- Label auto-hides when panels are present
- Header is now cleaner, matching production

## Files changed
- `src/app/panel-layout.ts` — moved mount points from header to drop zone
- `src/styles/main.css` — drop zone controls styling, grid layout, dashed border label

## Test plan
- [ ] Layout tabs and + button appear at top of drop zone below the map
- [ ] Header no longer contains layout tabs or widget picker
- [ ] Clicking layout tabs still switches presets
- [ ] Widget picker (+) still opens popover
- [ ] Drag-and-drop panels into the zone works, panels show in 2-column grid
- [ ] Drop zone label hides when panels are present
- [ ] Responsive: controls hidden on mobile (< 900px)
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)