### PR TITLE
fix(map): show zoom-in hint on layer toggles hidden by zoom threshold

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -3619,6 +3619,18 @@ export class DeckGLMap {
     if (import.meta.env.DEV && elapsed > 16) {
       console.warn(`[DeckGLMap] updateLayers took ${elapsed.toFixed(2)}ms (>16ms budget)`);
     }
+    this.updateZoomHints();
+  }
+
+  private updateZoomHints(): void {
+    const toggleList = this.container.querySelector('.deckgl-layer-toggles .toggle-list');
+    if (!toggleList) return;
+    for (const [key, enabled] of Object.entries(this.state.layers)) {
+      const toggle = toggleList.querySelector(`.layer-toggle[data-layer="${key}"]`) as HTMLElement | null;
+      if (!toggle) continue;
+      const zoomHidden = !!enabled && !this.isLayerVisible(key as keyof MapLayers);
+      toggle.classList.toggle('zoom-hidden', zoomHidden);
+    }
   }
 
   public setView(view: DeckMapView): void {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -12844,6 +12844,20 @@ a.prediction-link:hover {
   background: var(--bg);
 }
 
+.deckgl-layer-toggles .layer-toggle.zoom-hidden .toggle-label {
+  opacity: 0.45;
+}
+
+.deckgl-layer-toggles .layer-toggle.zoom-hidden::after {
+  content: '🔍+';
+  position: absolute;
+  top: -4px;
+  right: 2px;
+  font-size: 7px;
+  opacity: 0.65;
+  pointer-events: none;
+}
+
 .deckgl-layer-toggles .layer-toggle input[type="checkbox"] {
   -webkit-appearance: none;
   appearance: none;


### PR DESCRIPTION
## Root Cause

Layers like **Military Bases** (minZoom:3), **Nuclear Sites** (minZoom:3), **Gamma Irradiators** (minZoom:4), and **Spaceports** (minZoom:3) are gated by `isLayerVisible()` which checks the current map zoom against `LAYER_ZOOM_THRESHOLDS`. At the default **Global** view (zoom 1.5) none of these layers render — but there was zero visual feedback.

This is **not** a regression from any recent PR. The zoom thresholds and global zoom default (1.5) have been stable. The issue is missing UX feedback.

## Fix

- Adds `updateZoomHints()` called at the end of every `updateLayers()` cycle
- Toggles a `.zoom-hidden` CSS class on any enabled toggle whose `minZoom` isn't met yet
- Class dims the toggle label (opacity 0.45) and shows a 🔍+ badge in the corner
- Class removed automatically when user zooms in past the threshold

## Changes

- `src/components/DeckGLMap.ts` — `updateZoomHints()` method + call in `updateLayers()`
- `src/styles/main.css` — `.deckgl-layer-toggles .layer-toggle.zoom-hidden` styles

## Test

1. Load the map at Global view (zoom ~1.5)
2. Enable Military Bases, Nuclear Sites, Gamma Irradiators, or Spaceports
3. Should see 🔍+ badge and dimmed label instead of nothing
4. Zoom in to ≥3 (or ≥4 for irradiators) — badge disappears, data renders