### PR TITLE
fix desktop custom youtube channels

### DIFF
--- a/api/youtube/live.js
+++ b/api/youtube/live.js
@@ -49,15 +49,6 @@ export default async function handler(request) {
     } catch { /* relay unavailable — fall through to direct fetch */ }
   }
 
-  // If running in the desktop sidecar without a relay, return 502 so local-api-server falls back to the cloud API.
-  // Direct scraping from the sidecar fails because YouTube blocks the datacenter/Node.js fetch fingerprint.
-  if (process.env.LOCAL_API_MODE === 'desktop-sidecar') {
-    return new Response(JSON.stringify({ error: 'Relay unavailable, falling back' }), {
-      status: 502,
-      headers: { ...cors, 'Content-Type': 'application/json' },
-    });
-  }
-
   // Fallback: direct fetch (works for oembed, limited for live detection from datacenter IPs)
   if (videoIdParam && /^[A-Za-z0-9_-]{11}$/.test(videoIdParam)) {
     try {

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1127,6 +1127,15 @@ async function dispatch(requestUrl, req, routes, context) {
     }
   }
 
+  // YouTube live detection — requires residential proxy (Railway relay).
+  // Direct fetch from sidecar fails (YouTube blocks datacenter IPs).
+  // Always proxy to cloud, bypassing the cloudFallback flag.
+  if (requestUrl.pathname === '/api/youtube/live') {
+    const cloudResponse = await tryCloudFallback(requestUrl, req, context, 'youtube-live needs relay');
+    if (cloudResponse) return cloudResponse;
+    return json({ error: 'YouTube live detection unavailable' }, 503);
+  }
+
   // RSS proxy — fetch public feeds with SSRF protection
   if (requestUrl.pathname === '/api/rss-proxy') {
     const feedUrl = requestUrl.searchParams.get('url');


### PR DESCRIPTION
force 502 for sidecar so cloud fallback works
fixes #903

## summary
fixes desktop app failing to add custom youtube channels by forcing sidecar to fallback to cloud proxy.

## type of change
- [x] bug fix
- [ ] new feature
- [ ] new data source / feed
- [ ] new map layer
- [ ] refactor / code cleanup
- [ ] documentation
- [ ] ci / build / infrastructure

## affected areas
- [ ] map / globe
- [ ] news panels / rss feeds
- [ ] ai insights / world brief
- [ ] market radar / crypto
- [x] desktop app (tauri)
- [x] api endpoints (`/api/*`)
- [ ] config / settings
- [ ] other: 

## checklist
- [x] tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] new rss feed domains added to [api/rss-proxy.js](cci:7://file:///home/dharun/Desktop/worldmonitor/api/rss-proxy.js:0:0-0:0) allowlist (if adding feeds)
- [x] no api keys or secrets committed
- [x] typescript compiles without errors (`npm run typecheck`)
