### PR TITLE
fix(map): fix displacement flows and UCDP armed conflict layers

### DIFF
--- a/server/worldmonitor/displacement/v1/get-displacement-summary.ts
+++ b/server/worldmonitor/displacement/v1/get-displacement-summary.ts
@@ -56,7 +56,7 @@ async function fetchUnhcrYearItems(year: number): Promise<UnhcrRawItem[] | null>
 
   for (let page = 1; page <= maxPageGuard; page++) {
     const response = await fetch(
-      `https://api.unhcr.org/population/v1/population/?year=${year}&limit=${limit}&page=${page}`,
+      `https://api.unhcr.org/population/v1/population/?year=${year}&limit=${limit}&page=${page}&coo_all=true&coa_all=true`,
       { headers: { Accept: 'application/json', 'User-Agent': CHROME_UA } },
     );
 

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -1032,7 +1032,8 @@ export class DeckGLMap {
     const filteredMilitaryVessels = mapLayers.military ? this.filterByTime(this.militaryVessels, (vessel) => vessel.lastAisUpdate) : [];
     const filteredMilitaryFlightClusters = mapLayers.military ? this.filterMilitaryFlightClustersByTime(this.militaryFlightClusters) : [];
     const filteredMilitaryVesselClusters = mapLayers.military ? this.filterMilitaryVesselClustersByTime(this.militaryVesselClusters) : [];
-    const filteredUcdpEvents = mapLayers.ucdpEvents ? this.filterByTime(this.ucdpEvents, (event) => event.date_start) : [];
+    // UCDP is a historical dataset (events aged months); time-range filter always zeroes it out
+    const filteredUcdpEvents = mapLayers.ucdpEvents ? this.ucdpEvents : [];
 
     // Day/night overlay (rendered first as background)
     if (mapLayers.dayNight) {


### PR DESCRIPTION
## Root Cause

Two separate bugs causing these layers to render empty even with correct data in Redis.

### Bug 1 — Displacement Flows: UNHCR API missing required params

`get-displacement-summary.ts` fetched:
```
https://api.unhcr.org/population/v1/population/?year=2024&limit=10000&page=1
```
Without `coo_all=true&coa_all=true`, the UNHCR API returns **a single global aggregate row** (`coo_iso: "-"`) instead of per-country corridor data. This produced `topFlows: []` and zero arc layer entries.

With the correct params, the API returns all **6,200 corridors in a single page** (`maxPages: 1`), which is fast and well within Vercel limits.

### Bug 2 — UCDP Events: 7-day time filter on historical dataset

`filteredUcdpEvents` was running through `filterByTime(events, e => e.date_start)`. UCDP data has a 3–6 month publication lag — all 2,000 events in Redis have `dateStart` from Dec 2024/Jan 2025. The default `timeRange: '7d'` silently zeroes out the entire array on every render.

Fix: skip `filterByTime` for UCDP events since it's a historical dataset, not a live feed.

## Testing

- Enable "Displacement Flows" layer → arcs appear between origin/asylum countries
- Enable "UCDP Events" layer → conflict event markers appear globally
- Other time-range-filtered layers (flights, vessels, weather) are unaffected