### PR TITLE
fix(map): remove duplicate day/night layer and add UNHCR fetch timeout

### DIFF
--- a/server/worldmonitor/displacement/v1/get-displacement-summary.ts
+++ b/server/worldmonitor/displacement/v1/get-displacement-summary.ts
@@ -57,7 +57,7 @@ async function fetchUnhcrYearItems(year: number): Promise<UnhcrRawItem[] | null>
   for (let page = 1; page <= maxPageGuard; page++) {
     const response = await fetch(
       `https://api.unhcr.org/population/v1/population/?year=${year}&limit=${limit}&page=${page}&coo_all=true&coa_all=true`,
-      { headers: { Accept: 'application/json', 'User-Agent': CHROME_UA } },
+      { headers: { Accept: 'application/json', 'User-Agent': CHROME_UA }, signal: AbortSignal.timeout(10_000) },
     );
 
     if (!response.ok) return null;

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -1044,15 +1044,6 @@ export class DeckGLMap {
       this.layerCache.delete('day-night-layer');
     }
 
-    // Day/night overlay (rendered first as background)
-    if (mapLayers.dayNight) {
-      if (!this.dayNightIntervalId) this.startDayNightTimer();
-      layers.push(this.createDayNightLayer());
-    } else {
-      if (this.dayNightIntervalId) this.stopDayNightTimer();
-      this.layerCache.delete('day-night-layer');
-    }
-
     // Undersea cables layer
     if (mapLayers.cables) {
       layers.push(this.createCablesLayer());


### PR DESCRIPTION
## Summary

- **P1**: Remove duplicate `if (mapLayers.dayNight)` block in `DeckGLMap.ts:buildLayers()` — the identical block was being pushed twice into `layers[]`, causing two `day-night-layer` PolygonLayer instances per render cycle. DeckGL deduplicates by `id` so the visual was fine, but it wasted a full layer computation and ran timer/cache logic twice.
- **P2**: Add `signal: AbortSignal.timeout(10_000)` to the UNHCR Population API `fetch()` in `get-displacement-summary.ts` — without this, a slow upstream response could hold an Edge Function open until Vercel's 30 s hard timeout, blocking the cache fill for all concurrent callers.

## Test plan
- [ ] Day/night overlay toggle works correctly (single layer rendered)
- [ ] Displacement flows still load and render arcs on the map
- [ ] UNHCR fetch aborts within 10 s on an unresponsive upstream