### PR TITLE
feat(globe): render Korean DMZ polygon on 3D globe

### DIFF
--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -16,7 +16,7 @@
 
 import Globe from 'globe.gl';
 import type { GlobeInstance, ConfigOptions } from 'globe.gl';
-import { INTEL_HOTSPOTS, CONFLICT_ZONES, MILITARY_BASES, NUCLEAR_FACILITIES, SPACEPORTS, ECONOMIC_CENTERS, STRATEGIC_WATERWAYS, CRITICAL_MINERALS, UNDERSEA_CABLES } from '@/config/geo';
+import { INTEL_HOTSPOTS, CONFLICT_ZONES, GEOPOLITICAL_BOUNDARIES, MILITARY_BASES, NUCLEAR_FACILITIES, SPACEPORTS, ECONOMIC_CENTERS, STRATEGIC_WATERWAYS, CRITICAL_MINERALS, UNDERSEA_CABLES } from '@/config/geo';
 import { PIPELINES } from '@/config/pipelines';
 import { resolveTradeRouteSegments, type TradeRouteSegment } from '@/config/trade-routes';
 import { GAMMA_IRRADIATORS } from '@/config/irradiators';
@@ -1089,6 +1089,7 @@ export class GlobeMap {
     this.globe.htmlElementsData(markers);
     this.flushArcs();
     this.flushPaths();
+    this.flushPolygons();
   }
 
   private flushArcs(): void {
@@ -1140,6 +1141,24 @@ export class GlobeMap {
       .pathDashGap((d: GlobePath) => d.pathType === 'cable' ? 0 : 0.25)
       .pathDashAnimateTime((d: GlobePath) => d.pathType === 'cable' ? 0 : 5000)
       .pathLabel((d: GlobePath) => d.name);
+  }
+
+  private flushPolygons(): void {
+    if (!this.globe || !this.initialized) return;
+    const polys = this.layers.conflicts
+      ? GEOPOLITICAL_BOUNDARIES.map(b => ({
+          coords: [b.coords],
+          name: b.name,
+          boundaryType: b.boundaryType,
+        }))
+      : [];
+    (this.globe as any)
+      .polygonsData(polys)
+      .polygonCapColor(() => 'rgba(255, 60, 60, 0.15)')
+      .polygonSideColor(() => 'rgba(255, 60, 60, 0.08)')
+      .polygonStrokeColor(() => '#ff4444')
+      .polygonAltitude(0.005)
+      .polygonLabel((d: { name: string }) => d.name);
   }
 
   // ─── Public data setters ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Renders `GEOPOLITICAL_BOUNDARIES` (Korean DMZ) as a polygon on the 3D globe using `globe.gl`'s `polygonsData` API
- Shows/hides with the existing **Conflict Zones** layer toggle (no new toggle added)
- Semi-transparent red fill + red stroke, slight altitude for visibility

## Context
PR #912 added the DMZ to the flat (DeckGL) map. This adds parity for the 3D globe view.

## Test plan
- [ ] Enable 3D globe → enable Conflict Zones layer → verify red DMZ polygon visible on Korean peninsula
- [ ] Disable Conflict Zones → verify DMZ polygon disappears
- [ ] Hover DMZ polygon → verify "Korean Demilitarized Zone" label tooltip