### PR TITLE
refactor(map): unify layer toggle definitions into shared catalog

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -79,6 +79,7 @@ import {
 } from '@/config';
 import type { GulfInvestment } from '@/types';
 import { resolveTradeRouteSegments, TRADE_ROUTES as TRADE_ROUTES_LIST, type TradeRouteSegment } from '@/config/trade-routes';
+import { getLayersForVariant, resolveLayerLabel, type MapVariant } from '@/config/map-layer-definitions';
 import { MapPopup, type PopupType } from './MapPopup';
 import {
   updateHotspotEscalation,
@@ -3270,78 +3271,12 @@ export class DeckGLMap {
     const toggles = document.createElement('div');
     toggles.className = 'layer-toggles deckgl-layer-toggles';
 
-    const layerConfig = SITE_VARIANT === 'tech'
-      ? [
-        { key: 'startupHubs', label: t('components.deckgl.layers.startupHubs'), icon: '&#128640;' },
-        { key: 'techHQs', label: t('components.deckgl.layers.techHQs'), icon: '&#127970;' },
-        { key: 'accelerators', label: t('components.deckgl.layers.accelerators'), icon: '&#9889;' },
-        { key: 'cloudRegions', label: t('components.deckgl.layers.cloudRegions'), icon: '&#9729;' },
-        { key: 'datacenters', label: t('components.deckgl.layers.aiDataCenters'), icon: '&#128421;' },
-        { key: 'cables', label: t('components.deckgl.layers.underseaCables'), icon: '&#128268;' },
-        { key: 'outages', label: t('components.deckgl.layers.internetOutages'), icon: '&#128225;' },
-        { key: 'cyberThreats', label: t('components.deckgl.layers.cyberThreats'), icon: '&#128737;' },
-        { key: 'techEvents', label: t('components.deckgl.layers.techEvents'), icon: '&#128197;' },
-        { key: 'natural', label: t('components.deckgl.layers.naturalEvents'), icon: '&#127755;' },
-        { key: 'fires', label: t('components.deckgl.layers.fires'), icon: '&#128293;' },
-        { key: 'dayNight', label: t('components.deckgl.layers.dayNight'), icon: '&#127763;' },
-      ]
-      : SITE_VARIANT === 'finance'
-        ? [
-          { key: 'stockExchanges', label: t('components.deckgl.layers.stockExchanges'), icon: '&#127963;' },
-          { key: 'financialCenters', label: t('components.deckgl.layers.financialCenters'), icon: '&#128176;' },
-          { key: 'centralBanks', label: t('components.deckgl.layers.centralBanks'), icon: '&#127974;' },
-          { key: 'commodityHubs', label: t('components.deckgl.layers.commodityHubs'), icon: '&#128230;' },
-          { key: 'gulfInvestments', label: t('components.deckgl.layers.gulfInvestments'), icon: '&#127760;' },
-          { key: 'tradeRoutes', label: t('components.deckgl.layers.tradeRoutes'), icon: '&#128674;' },
-          { key: 'cables', label: t('components.deckgl.layers.underseaCables'), icon: '&#128268;' },
-          { key: 'pipelines', label: t('components.deckgl.layers.pipelines'), icon: '&#128738;' },
-          { key: 'outages', label: t('components.deckgl.layers.internetOutages'), icon: '&#128225;' },
-          { key: 'weather', label: t('components.deckgl.layers.weatherAlerts'), icon: '&#9928;' },
-          { key: 'economic', label: t('components.deckgl.layers.economicCenters'), icon: '&#128176;' },
-          { key: 'waterways', label: t('components.deckgl.layers.strategicWaterways'), icon: '&#9875;' },
-          { key: 'natural', label: t('components.deckgl.layers.naturalEvents'), icon: '&#127755;' },
-          { key: 'cyberThreats', label: t('components.deckgl.layers.cyberThreats'), icon: '&#128737;' },
-          { key: 'dayNight', label: t('components.deckgl.layers.dayNight'), icon: '&#127763;' },
-        ]
-        : SITE_VARIANT === 'happy'
-          ? [
-            { key: 'positiveEvents', label: 'Positive Events', icon: '&#127775;' },
-            { key: 'kindness', label: 'Acts of Kindness', icon: '&#128154;' },
-            { key: 'happiness', label: 'World Happiness', icon: '&#128522;' },
-            { key: 'speciesRecovery', label: 'Species Recovery', icon: '&#128062;' },
-            { key: 'renewableInstallations', label: 'Clean Energy', icon: '&#9889;' },
-          ]
-          : [
-            { key: 'iranAttacks', label: t('components.deckgl.layers.iranAttacks'), icon: '&#127919;' },
-            { key: 'hotspots', label: t('components.deckgl.layers.intelHotspots'), icon: '&#127919;' },
-            { key: 'conflicts', label: t('components.deckgl.layers.conflictZones'), icon: '&#9876;' },
-            { key: 'geopoliticalBoundaries', label: t('components.deckgl.layers.geopoliticalBoundaries'), icon: '&#9878;' },
-            { key: 'bases', label: t('components.deckgl.layers.militaryBases'), icon: '&#127963;' },
-            { key: 'nuclear', label: t('components.deckgl.layers.nuclearSites'), icon: '&#9762;' },
-            { key: 'irradiators', label: t('components.deckgl.layers.gammaIrradiators'), icon: '&#9888;' },
-            { key: 'spaceports', label: t('components.deckgl.layers.spaceports'), icon: '&#128640;' },
-            { key: 'cables', label: t('components.deckgl.layers.underseaCables'), icon: '&#128268;' },
-            { key: 'pipelines', label: t('components.deckgl.layers.pipelines'), icon: '&#128738;' },
-            { key: 'datacenters', label: t('components.deckgl.layers.aiDataCenters'), icon: '&#128421;' },
-            { key: 'military', label: t('components.deckgl.layers.militaryActivity'), icon: '&#9992;' },
-            { key: 'ais', label: t('components.deckgl.layers.shipTraffic'), icon: '&#128674;' },
-            { key: 'tradeRoutes', label: t('components.deckgl.layers.tradeRoutes'), icon: '&#9875;' },
-            { key: 'flights', label: t('components.deckgl.layers.flightDelays'), icon: '&#9992;' },
-            { key: 'protests', label: t('components.deckgl.layers.protests'), icon: '&#128226;' },
-            { key: 'ucdpEvents', label: t('components.deckgl.layers.ucdpEvents'), icon: '&#9876;' },
-            { key: 'displacement', label: t('components.deckgl.layers.displacementFlows'), icon: '&#128101;' },
-            { key: 'climate', label: t('components.deckgl.layers.climateAnomalies'), icon: '&#127787;' },
-            { key: 'weather', label: t('components.deckgl.layers.weatherAlerts'), icon: '&#9928;' },
-            { key: 'outages', label: t('components.deckgl.layers.internetOutages'), icon: '&#128225;' },
-            { key: 'cyberThreats', label: t('components.deckgl.layers.cyberThreats'), icon: '&#128737;' },
-            { key: 'natural', label: t('components.deckgl.layers.naturalEvents'), icon: '&#127755;' },
-            { key: 'fires', label: t('components.deckgl.layers.fires'), icon: '&#128293;' },
-            { key: 'waterways', label: t('components.deckgl.layers.strategicWaterways'), icon: '&#9875;' },
-            { key: 'economic', label: t('components.deckgl.layers.economicCenters'), icon: '&#128176;' },
-            { key: 'minerals', label: t('components.deckgl.layers.criticalMinerals'), icon: '&#128142;' },
-            { key: 'gpsJamming', label: t('components.deckgl.layers.gpsJamming'), icon: '&#128225;' },
-            { key: 'dayNight', label: t('components.deckgl.layers.dayNight'), icon: '&#127763;' },
-          ];
+    const layerDefs = getLayersForVariant((SITE_VARIANT || 'full') as MapVariant, 'flat');
+    const layerConfig = layerDefs.map(def => ({
+      key: def.key,
+      label: resolveLayerLabel(def, t),
+      icon: def.icon,
+    }));
 
     toggles.innerHTML = `
       <div class="toggle-header">

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -18,6 +18,9 @@ import Globe from 'globe.gl';
 import type { GlobeInstance, ConfigOptions } from 'globe.gl';
 import { INTEL_HOTSPOTS, CONFLICT_ZONES, GEOPOLITICAL_BOUNDARIES, MILITARY_BASES, NUCLEAR_FACILITIES, SPACEPORTS, ECONOMIC_CENTERS, STRATEGIC_WATERWAYS, CRITICAL_MINERALS, UNDERSEA_CABLES } from '@/config/geo';
 import { PIPELINES } from '@/config/pipelines';
+import { t } from '@/services/i18n';
+import { SITE_VARIANT } from '@/config/variant';
+import { getLayersForVariant, resolveLayerLabel, type MapVariant } from '@/config/map-layer-definitions';
 import { resolveTradeRouteSegments, type TradeRouteSegment } from '@/config/trade-routes';
 import { GAMMA_IRRADIATORS } from '@/config/irradiators';
 import { AI_DATA_CENTERS } from '@/config/ai-datacenters';
@@ -488,9 +491,7 @@ export class GlobeMap {
     // Navigate to initial view
     this.setView(this.currentView);
 
-    // Day/Night is a DeckGL solar-terminator polygon layer — not available on globe
-    this.layers.dayNight = false;
-    this.hideLayerToggle('dayNight');
+    // dayNight toggle excluded by catalog (renderers: ['flat'])
 
     // Flush any data that arrived before init completed
     this.flushMarkers();
@@ -956,39 +957,12 @@ export class GlobeMap {
   }
 
   private createLayerToggles(): void {
-    const layers: Array<{ key: keyof MapLayers; label: string; icon: string }> = [
-      // Conflict & Security
-      { key: 'iranAttacks',  label: 'Iran Attacks',          icon: '&#127919;' },
-      { key: 'hotspots',     label: 'Intel Hotspots',        icon: '&#127919;' },
-      { key: 'conflicts',    label: 'Conflict Zones',         icon: '&#9876;'   },
-      { key: 'bases',        label: 'Military Bases',         icon: '&#127963;' },
-      { key: 'nuclear',      label: 'Nuclear Sites',          icon: '&#9762;'   },
-      { key: 'irradiators',  label: 'Gamma Irradiators',      icon: '&#9888;'   },
-      { key: 'spaceports',   label: 'Spaceports',             icon: '&#128640;' },
-      { key: 'military',     label: 'Military Activity',      icon: '&#9992;'   },
-      { key: 'ais',          label: 'Ship Traffic',           icon: '&#128674;' },
-      { key: 'flights',      label: 'Flight Delays',          icon: '&#9992;'   },
-      { key: 'protests',     label: 'Protests & Unrest',      icon: '&#128226;' },
-      { key: 'ucdpEvents',   label: 'UCDP Events',            icon: '&#9876;'   },
-      { key: 'displacement', label: 'Displacement Flows',     icon: '&#128101;' },
-      // Infrastructure
-      { key: 'cables',       label: 'Undersea Cables',        icon: '&#128268;' },
-      { key: 'pipelines',    label: 'Pipelines',              icon: '&#128738;' },
-      { key: 'datacenters',  label: 'Data Centers',           icon: '&#128421;' },
-      { key: 'tradeRoutes',  label: 'Trade Routes',           icon: '&#9875;'   },
-      { key: 'waterways',    label: 'Strategic Waterways',    icon: '&#9875;'   },
-      { key: 'economic',     label: 'Economic Centers',       icon: '&#128176;' },
-      { key: 'minerals',     label: 'Critical Minerals',      icon: '&#128142;' },
-      // Hazards & Environment
-      { key: 'weather',      label: 'Weather Alerts',         icon: '&#9928;'   },
-      { key: 'natural',      label: 'Natural Events',         icon: '&#127755;' },
-      { key: 'fires',        label: 'Wildfires',              icon: '&#128293;' },
-      { key: 'climate',      label: 'Climate Anomalies',      icon: '&#127787;' },
-      { key: 'outages',      label: 'Internet Outages',       icon: '&#128225;' },
-      { key: 'cyberThreats', label: 'Cyber Threats',          icon: '&#128737;' },
-      { key: 'gpsJamming',   label: 'GPS Jamming',            icon: '&#128225;' },
-      { key: 'dayNight',     label: 'Day / Night',            icon: '&#127763;' },
-    ];
+    const layerDefs = getLayersForVariant((SITE_VARIANT || 'full') as MapVariant, 'globe');
+    const layers = layerDefs.map(def => ({
+      key: def.key,
+      label: resolveLayerLabel(def, t),
+      icon: def.icon,
+    }));
 
     const el = document.createElement('div');
     el.className = 'layer-toggles deckgl-layer-toggles';
@@ -997,7 +971,7 @@ export class GlobeMap {
     el.style.top = '10px';
     el.innerHTML = `
       <div class="toggle-header">
-        <span>LAYERS</span>
+        <span>${t('components.deckgl.layersTitle')}</span>
         <button class="toggle-collapse">&#9660;</button>
       </div>
       <div class="toggle-list" style="max-height:32vh;overflow-y:auto;scrollbar-width:thin;">
@@ -1345,12 +1319,13 @@ export class GlobeMap {
   // ─── Layer control ────────────────────────────────────────────────────────
 
   public setLayers(layers: MapLayers): void {
-    this.layers = { ...layers, dayNight: false }; // dayNight unsupported on globe
+    // dayNight toggle excluded by catalog — harmless if true in memory
+    this.layers = { ...layers };
     this.flushMarkers();
   }
 
   public enableLayer(layer: keyof MapLayers): void {
-    if (layer === 'dayNight') return; // unsupported on globe
+    // dayNight toggle excluded by catalog — no guard needed
     (this.layers as any)[layer] = true;
     this.flushMarkers();
   }

--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -1,0 +1,113 @@
+import type { MapLayers } from '@/types';
+
+export type MapRenderer = 'flat' | 'globe';
+export type MapVariant = 'full' | 'tech' | 'finance' | 'happy';
+
+export interface LayerDefinition {
+  key: keyof MapLayers;
+  icon: string;
+  i18nSuffix: string;
+  fallbackLabel: string;
+  renderers: MapRenderer[];
+}
+
+const def = (
+  key: keyof MapLayers,
+  icon: string,
+  i18nSuffix: string,
+  fallbackLabel: string,
+  renderers: MapRenderer[] = ['flat', 'globe'],
+): LayerDefinition => ({ key, icon, i18nSuffix, fallbackLabel, renderers });
+
+export const LAYER_REGISTRY: Record<keyof MapLayers, LayerDefinition> = {
+  iranAttacks:              def('iranAttacks',              '&#127919;', 'iranAttacks',              'Iran Attacks'),
+  hotspots:                 def('hotspots',                 '&#127919;', 'intelHotspots',            'Intel Hotspots'),
+  conflicts:                def('conflicts',                '&#9876;',   'conflictZones',            'Conflict Zones'),
+  geopoliticalBoundaries:   def('geopoliticalBoundaries',   '&#9878;',   'geopoliticalBoundaries',   'Geopolitical Boundaries'),
+  bases:                    def('bases',                    '&#127963;', 'militaryBases',            'Military Bases'),
+  nuclear:                  def('nuclear',                  '&#9762;',   'nuclearSites',             'Nuclear Sites'),
+  irradiators:              def('irradiators',              '&#9888;',   'gammaIrradiators',         'Gamma Irradiators'),
+  spaceports:               def('spaceports',               '&#128640;', 'spaceports',               'Spaceports'),
+  cables:                   def('cables',                   '&#128268;', 'underseaCables',           'Undersea Cables'),
+  pipelines:                def('pipelines',                '&#128738;', 'pipelines',                'Pipelines'),
+  datacenters:              def('datacenters',              '&#128421;', 'aiDataCenters',            'AI Data Centers'),
+  military:                 def('military',                 '&#9992;',   'militaryActivity',         'Military Activity'),
+  ais:                      def('ais',                      '&#128674;', 'shipTraffic',              'Ship Traffic'),
+  tradeRoutes:              def('tradeRoutes',              '&#9875;',   'tradeRoutes',              'Trade Routes'),
+  flights:                  def('flights',                  '&#9992;',   'flightDelays',             'Flight Delays'),
+  protests:                 def('protests',                 '&#128226;', 'protests',                 'Protests'),
+  ucdpEvents:               def('ucdpEvents',               '&#9876;',   'ucdpEvents',               'Armed Conflict Events'),
+  displacement:             def('displacement',             '&#128101;', 'displacementFlows',        'Displacement Flows'),
+  climate:                  def('climate',                  '&#127787;', 'climateAnomalies',         'Climate Anomalies'),
+  weather:                  def('weather',                  '&#9928;',   'weatherAlerts',            'Weather Alerts'),
+  outages:                  def('outages',                  '&#128225;', 'internetOutages',          'Internet Outages'),
+  cyberThreats:             def('cyberThreats',             '&#128737;', 'cyberThreats',             'Cyber Threats'),
+  natural:                  def('natural',                  '&#127755;', 'naturalEvents',            'Natural Events'),
+  fires:                    def('fires',                    '&#128293;', 'fires',                    'Fires'),
+  waterways:                def('waterways',                '&#9875;',   'strategicWaterways',       'Strategic Waterways'),
+  economic:                 def('economic',                 '&#128176;', 'economicCenters',          'Economic Centers'),
+  minerals:                 def('minerals',                 '&#128142;', 'criticalMinerals',         'Critical Minerals'),
+  gpsJamming:               def('gpsJamming',               '&#128225;', 'gpsJamming',               'GPS Jamming'),
+  dayNight:                 def('dayNight',                 '&#127763;', 'dayNight',                 'Day/Night', ['flat']),
+  sanctions:                def('sanctions',                '&#128683;', 'sanctions',                'Sanctions', []),
+  startupHubs:              def('startupHubs',              '&#128640;', 'startupHubs',              'Startup Hubs'),
+  techHQs:                  def('techHQs',                  '&#127970;', 'techHQs',                  'Tech HQs'),
+  accelerators:             def('accelerators',             '&#9889;',   'accelerators',             'Accelerators'),
+  cloudRegions:             def('cloudRegions',             '&#9729;',   'cloudRegions',             'Cloud Regions'),
+  techEvents:               def('techEvents',               '&#128197;', 'techEvents',               'Tech Events'),
+  stockExchanges:           def('stockExchanges',           '&#127963;', 'stockExchanges',           'Stock Exchanges'),
+  financialCenters:         def('financialCenters',         '&#128176;', 'financialCenters',         'Financial Centers'),
+  centralBanks:             def('centralBanks',             '&#127974;', 'centralBanks',             'Central Banks'),
+  commodityHubs:            def('commodityHubs',            '&#128230;', 'commodityHubs',            'Commodity Hubs'),
+  gulfInvestments:          def('gulfInvestments',          '&#127760;', 'gulfInvestments',          'GCC Investments'),
+  positiveEvents:           def('positiveEvents',           '&#127775;', 'positiveEvents',           'Positive Events'),
+  kindness:                 def('kindness',                 '&#128154;', 'kindness',                 'Acts of Kindness'),
+  happiness:                def('happiness',                '&#128522;', 'happiness',                'World Happiness'),
+  speciesRecovery:          def('speciesRecovery',          '&#128062;', 'speciesRecovery',          'Species Recovery'),
+  renewableInstallations:   def('renewableInstallations',   '&#9889;',   'renewableInstallations',   'Clean Energy'),
+};
+
+const VARIANT_LAYER_ORDER: Record<MapVariant, Array<keyof MapLayers>> = {
+  full: [
+    'iranAttacks', 'hotspots', 'conflicts', 'geopoliticalBoundaries',
+    'bases', 'nuclear', 'irradiators', 'spaceports',
+    'cables', 'pipelines', 'datacenters', 'military',
+    'ais', 'tradeRoutes', 'flights', 'protests',
+    'ucdpEvents', 'displacement', 'climate', 'weather',
+    'outages', 'cyberThreats', 'natural', 'fires',
+    'waterways', 'economic', 'minerals', 'gpsJamming',
+    'dayNight',
+  ],
+  tech: [
+    'startupHubs', 'techHQs', 'accelerators', 'cloudRegions',
+    'datacenters', 'cables', 'outages', 'cyberThreats',
+    'techEvents', 'natural', 'fires', 'dayNight',
+  ],
+  finance: [
+    'stockExchanges', 'financialCenters', 'centralBanks', 'commodityHubs',
+    'gulfInvestments', 'tradeRoutes', 'cables', 'pipelines',
+    'outages', 'weather', 'economic', 'waterways',
+    'natural', 'cyberThreats', 'dayNight',
+  ],
+  happy: [
+    'positiveEvents', 'kindness', 'happiness',
+    'speciesRecovery', 'renewableInstallations',
+  ],
+};
+
+const I18N_PREFIX = 'components.deckgl.layers.';
+
+export function getLayersForVariant(variant: MapVariant, renderer: MapRenderer): LayerDefinition[] {
+  const keys = VARIANT_LAYER_ORDER[variant] ?? VARIANT_LAYER_ORDER.full;
+  return keys
+    .map(k => LAYER_REGISTRY[k])
+    .filter(d => d.renderers.includes(renderer));
+}
+
+export function resolveLayerLabel(def: LayerDefinition, tFn?: (key: string) => string): string {
+  if (tFn) {
+    const translated = tFn(I18N_PREFIX + def.i18nSuffix);
+    if (translated && translated !== I18N_PREFIX + def.i18nSuffix) return translated;
+  }
+  return def.fallbackLabel;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1017,7 +1017,12 @@
         "iranAttacks": "Iran Attacks",
         "gpsJamming": "GPS JAMMING",
         "dayNight": "Day/Night",
-        "geopoliticalBoundaries": "Geopolitical Boundaries"
+        "geopoliticalBoundaries": "Geopolitical Boundaries",
+        "positiveEvents": "Positive Events",
+        "kindness": "Acts of Kindness",
+        "happiness": "World Happiness",
+        "speciesRecovery": "Species Recovery",
+        "renewableInstallations": "Clean Energy"
       },
       "tooltip": {
         "earthquake": "Earthquake",


### PR DESCRIPTION
## Summary
- Creates `src/config/map-layer-definitions.ts` — single source of truth for all 37 map layer toggle definitions, with renderer gating (`flat`/`globe`), variant ordering, and i18n resolution
- Replaces DeckGLMap's 72-line 4-branch if/else and GlobeMap's 28-entry hardcoded array with single catalog calls
- Adds 5 missing happy-variant i18n keys to `en.json`
- Globe now respects `SITE_VARIANT` (tech/finance/happy show variant-relevant layers only)
- Removes 3 redundant `dayNight` guards in GlobeMap (catalog handles exclusion via `renderers: ['flat']`)

Net: **-85 lines** removed from components, one file to edit when adding layers.

## Test plan
- [ ] `npx tsc --noEmit` passes (0 new errors; 3 pre-existing globe.gl/three type errors unchanged)
- [ ] Flat map: toggle panel unchanged for all 4 variants (same layers, order, labels)
- [ ] Globe: toggle panel matches flat per variant (minus `dayNight`)
- [ ] Globe on tech/finance/happy subdomains shows only variant-relevant layers
- [ ] `dayNight` absent from globe toggles, present on flat
- [ ] Toggle check/uncheck propagates to map rendering on both renderers