### PR TITLE
feat(markets): customizable watchlist symbols

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -57,7 +57,7 @@ import {
   fetchChokepointStatus,
   fetchCriticalMinerals,
 } from '@/services';
-import { getMarketWatchlistSymbols } from '@/services/market-watchlist';
+import { getMarketWatchlistEntries } from '@/services/market-watchlist';
 import { checkBatchForBreakingAlerts, dispatchOrefBreakingAlert } from '@/services/breaking-news-alerts';
 import { mlWorker } from '@/services/ml-worker';
 import { clusterNewsHybrid } from '@/services/clustering';
@@ -952,15 +952,16 @@ export class DataLoaderManager implements AppModule {
 
   async loadMarkets(): Promise<void> {
     try {
-      const customSymbols = getMarketWatchlistSymbols();
+      const customEntries = getMarketWatchlistEntries();
       const effectiveSymbols = (() => {
-        if (customSymbols.length === 0) return MARKET_SYMBOLS;
+        if (customEntries.length === 0) return MARKET_SYMBOLS;
         const base = MARKET_SYMBOLS.slice();
         const seen = new Set(base.map((s) => s.symbol));
-        for (const sym of customSymbols) {
+        for (const entry of customEntries) {
+          const sym = entry.symbol;
           if (!sym || seen.has(sym)) continue;
           seen.add(sym);
-          base.push({ symbol: sym, name: sym, display: sym });
+          base.push({ symbol: sym, name: entry.name || sym, display: entry.display || sym });
           if (base.length >= 50) break;
         }
         return base;
@@ -971,7 +972,7 @@ export class DataLoaderManager implements AppModule {
       const hydratedMarkets = getHydratedData('marketQuotes') as ListMarketQuotesResponse | undefined;
       let stocksResult: Awaited<ReturnType<typeof fetchMultipleStocks>>;
 
-      if (customSymbols.length === 0 && hydratedMarkets?.quotes?.length) {
+      if (customEntries.length === 0 && hydratedMarkets?.quotes?.length) {
         const symbolMetaMap = new Map(effectiveSymbols.map((s) => [s.symbol, s]));
         const data = hydratedMarkets.quotes.map((q) => ({
           symbol: q.symbol,

--- a/src/components/MarketPanel.ts
+++ b/src/components/MarketPanel.ts
@@ -4,12 +4,11 @@ import type { MarketData, CryptoData } from '@/types';
 import { formatPrice, formatChange, getChangeClass, getHeatmapClass } from '@/utils';
 import { escapeHtml } from '@/utils/sanitize';
 import { miniSparkline } from '@/utils/sparkline';
-import { MARKET_SYMBOLS } from '@/config';
 import {
-  getMarketWatchlistSymbols,
-  parseMarketSymbolsInput,
+  getMarketWatchlistEntries,
+  parseMarketWatchlistInput,
   resetMarketWatchlist,
-  setMarketWatchlistSymbols,
+  setMarketWatchlistEntries,
 } from '@/services/market-watchlist';
 
 export class MarketPanel extends Panel {
@@ -36,9 +35,10 @@ export class MarketPanel extends Panel {
   private openWatchlistModal(): void {
     if (this.overlay) return;
 
-    const current = getMarketWatchlistSymbols();
-    const defaultText = MARKET_SYMBOLS.map((s) => s.symbol).join(', ');
-    const currentText = current.length ? current.join(', ') : defaultText;
+    const current = getMarketWatchlistEntries();
+    const currentText = current.length
+      ? current.map((e) => (e.name ? `${e.symbol}|${e.name}` : e.symbol)).join('\n')
+      : '';
 
     const overlay = document.createElement('div');
     overlay.className = 'modal-overlay active';
@@ -58,7 +58,8 @@ export class MarketPanel extends Panel {
       </div>
       <div style="padding:14px 16px 16px 16px">
         <div style="color:var(--text-dim);font-size:12px;line-height:1.4;margin-bottom:10px">
-          Add tickers (comma or newline separated). Example: AAPL, MSFT, TSLA, ^GSPC
+          Add extra tickers (comma or newline separated). Friendly labels supported: SYMBOL|Label.
+          Example: TSLA|Tesla, AAPL|Apple, ^GSPC|S&P 500
           <br/>
           Tip: keep it under ~30 unless you enjoy scrolling.
         </div>
@@ -86,14 +87,14 @@ export class MarketPanel extends Panel {
     modal.querySelector<HTMLButtonElement>('#wmMarketCancelBtn')?.addEventListener('click', () => this.closeWatchlistModal());
     modal.querySelector<HTMLButtonElement>('#wmMarketResetBtn')?.addEventListener('click', () => {
       resetMarketWatchlist();
-      if (input) input.value = defaultText;
+      if (input) input.value = ''; // defaults are always included automatically
       this.closeWatchlistModal();
     });
     modal.querySelector<HTMLButtonElement>('#wmMarketSaveBtn')?.addEventListener('click', () => {
       const raw = input?.value || '';
-      const parsed = parseMarketSymbolsInput(raw);
+      const parsed = parseMarketWatchlistInput(raw);
       if (parsed.length === 0) resetMarketWatchlist();
-      else setMarketWatchlistSymbols(parsed);
+      else setMarketWatchlistEntries(parsed);
       this.closeWatchlistModal();
     });
   }

--- a/src/services/market-watchlist.ts
+++ b/src/services/market-watchlist.ts
@@ -1,12 +1,20 @@
 /**
- * User-customizable market watchlist.
+ * User-customizable market watchlist (additive).
  *
- * Stores a list of ticker symbols in localStorage. Used by Market panel
- * to fetch quotes for the user-selected set.
+ * Stores a list of extra tickers the user wants to track beyond the defaults.
+ * Optional friendly label is supported (used as the displayed name).
  */
 
+export interface MarketWatchlistEntry {
+  symbol: string;
+  /** Friendly label shown in the UI (maps to MarketData.name). */
+  name?: string;
+  /** Optional short display code (maps to MarketData.display). Defaults to symbol. */
+  display?: string;
+}
+
 const STORAGE_KEY = 'wm-market-watchlist-v1';
-const EVENT_NAME = 'wm-market-watchlist-changed';
+export const MARKET_WATCHLIST_EVENT = 'wm-market-watchlist-changed';
 
 function safeParseJson<T>(raw: string | null): T | null {
   if (!raw) return null;
@@ -15,17 +23,42 @@ function safeParseJson<T>(raw: string | null): T | null {
 
 function normalizeSymbol(raw: string): string {
   // Allow common finnhub/yahoo formats: ^GSPC, BRK-B, GC=F, BTCUSD, etc.
-  // We only trim whitespace and remove internal spaces.
+  // Only trim whitespace and remove internal spaces.
   return raw.trim().replace(/\s+/g, '');
 }
 
-export function getMarketWatchlistSymbols(): string[] {
+function normalizeName(raw: string | undefined): string | undefined {
+  const v = (raw || '').trim();
+  return v ? v : undefined;
+}
+
+function coerceEntry(v: unknown): MarketWatchlistEntry | null {
+  if (typeof v === 'string') {
+    const sym = normalizeSymbol(v);
+    if (!sym) return null;
+    return { symbol: sym };
+  }
+  if (v && typeof v === 'object') {
+    const obj = v as any;
+    const sym = normalizeSymbol(String(obj.symbol || ''));
+    if (!sym) return null;
+    const name = normalizeName(typeof obj.name === 'string' ? obj.name : undefined);
+    const display = normalizeName(typeof obj.display === 'string' ? obj.display : undefined);
+    return { symbol: sym, ...(name ? { name } : {}), ...(display ? { display } : {}) };
+  }
+  return null;
+}
+
+export function getMarketWatchlistEntries(): MarketWatchlistEntry[] {
   try {
     const parsed = safeParseJson<unknown>(localStorage.getItem(STORAGE_KEY));
     if (Array.isArray(parsed)) {
-      return parsed
-        .map((s) => (typeof s === 'string' ? normalizeSymbol(s) : ''))
-        .filter(Boolean);
+      const entries: MarketWatchlistEntry[] = [];
+      for (const item of parsed) {
+        const e = coerceEntry(item);
+        if (e) entries.push(e);
+      }
+      return entries;
     }
   } catch {
     // ignore
@@ -33,49 +66,72 @@ export function getMarketWatchlistSymbols(): string[] {
   return [];
 }
 
-export function setMarketWatchlistSymbols(symbols: string[]): void {
-  const cleaned = symbols
-    .map(normalizeSymbol)
-    .filter(Boolean);
-
-  // De-dupe but keep order
+export function setMarketWatchlistEntries(entries: MarketWatchlistEntry[]): void {
+  // Clean, de-dupe by symbol but keep order.
   const seen = new Set<string>();
-  const uniq: string[] = [];
-  for (const s of cleaned) {
-    if (seen.has(s)) continue;
-    seen.add(s);
-    uniq.push(s);
-    if (uniq.length >= 50) break;
+  const out: MarketWatchlistEntry[] = [];
+
+  for (const raw of entries || []) {
+    const sym = normalizeSymbol(raw.symbol || '');
+    if (!sym || seen.has(sym)) continue;
+    seen.add(sym);
+
+    const name = normalizeName(raw.name);
+    const display = normalizeName(raw.display);
+
+    out.push({ symbol: sym, ...(name ? { name } : {}), ...(display ? { display } : {}) });
+    if (out.length >= 50) break;
   }
 
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(uniq));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(out));
   } catch {
     // ignore
   }
 
-  window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: { symbols: uniq } }));
+  window.dispatchEvent(new CustomEvent(MARKET_WATCHLIST_EVENT, { detail: { entries: out } }));
 }
 
 export function resetMarketWatchlist(): void {
   try { localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
-  window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: { symbols: [] } }));
+  window.dispatchEvent(new CustomEvent(MARKET_WATCHLIST_EVENT, { detail: { entries: [] } }));
 }
 
-export function subscribeMarketWatchlistChange(cb: (symbols: string[]) => void): () => void {
+export function subscribeMarketWatchlistChange(cb: (entries: MarketWatchlistEntry[]) => void): () => void {
   const handler = (e: Event) => {
-    const detail = (e as CustomEvent).detail as { symbols?: string[] } | undefined;
-    cb(Array.isArray(detail?.symbols) ? detail!.symbols! : getMarketWatchlistSymbols());
+    const detail = (e as CustomEvent).detail as { entries?: unknown } | undefined;
+    if (Array.isArray(detail?.entries)) {
+      const coerced: MarketWatchlistEntry[] = [];
+      for (const it of detail!.entries!) {
+        const ce = coerceEntry(it);
+        if (ce) coerced.push(ce);
+      }
+      cb(coerced);
+      return;
+    }
+    cb(getMarketWatchlistEntries());
   };
-  window.addEventListener(EVENT_NAME, handler);
-  return () => window.removeEventListener(EVENT_NAME, handler);
+  window.addEventListener(MARKET_WATCHLIST_EVENT, handler);
+  return () => window.removeEventListener(MARKET_WATCHLIST_EVENT, handler);
 }
 
-export function parseMarketSymbolsInput(text: string): string[] {
-  // Accept comma, newline, or space separated.
-  return text
+export function parseMarketWatchlistInput(text: string): MarketWatchlistEntry[] {
+  // Accept comma or newline-separated entries.
+  // Friendly label format: SYMBOL|Label (ex: TSLA|Tesla)
+  const rawItems = text
     .split(/[\n,]+/g)
-    .flatMap((chunk) => chunk.split(/\s+/g))
-    .map(normalizeSymbol)
+    .map((s) => s.trim())
     .filter(Boolean);
+
+  const entries: MarketWatchlistEntry[] = [];
+
+  for (const item of rawItems) {
+    const [left, ...rest] = item.split('|');
+    const symbol = normalizeSymbol(left || '');
+    if (!symbol) continue;
+    const name = normalizeName(rest.join('|'));
+    entries.push({ symbol, ...(name ? { name } : {}) });
+  }
+
+  return entries;
 }


### PR DESCRIPTION
Adds a simple user customization flow for the Markets panel so users can track symbols beyond the built-in list.

What:
- Markets panel header gets a **Watchlist** button.
- Modal lets users paste **extra** tickers (comma/newline separated) and Save/Reset.
- **Additive**: defaults remain, watchlist adds extra symbols.
- Friendly labels supported via "SYMBOL|Label" (ex: "TSLA|Tesla").
- Stored per-user in localStorage (wm-market-watchlist-v1).
- DataLoader merges custom entries on top of the built-in MARKET_SYMBOLS and reloads markets immediately on save.

Notes:
- Custom symbols are sent as-is to the market quote RPC (supports ^ indexes, BRK-B, GC=F, etc).
- Hard cap 50 extras to avoid huge payloads / infinite scrolling.
