### PR TITLE
perf(positive-events): move GDELT fetch to Railway seed

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -23,6 +23,7 @@ const BOOTSTRAP_CACHE_KEYS = {
   wildfires:        'wildfire:fires:v1',
   cyberThreats:     'cyber:threats-bootstrap:v2',
   techReadiness:    'economic:worldbank-techreadiness:v1',
+  positiveGeoEvents: 'positive-events:geo-bootstrap:v1',
 };
 
 const SLOW_KEYS = new Set([
@@ -32,7 +33,7 @@ const SLOW_KEYS = new Set([
 ]);
 const FAST_KEYS = new Set([
   'earthquakes', 'outages', 'serviceStatuses', 'macroSignals', 'chokepoints',
-  'marketQuotes', 'commodityQuotes',
+  'marketQuotes', 'commodityQuotes', 'positiveGeoEvents',
 ]);
 
 const TIER_CACHE = {

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1760,6 +1760,146 @@ async function startCyberThreatsSeedLoop() {
   }, CYBER_SEED_INTERVAL_MS).unref?.();
 }
 
+// ─────────────────────────────────────────────────────────────
+// Positive Events Seed — Railway fetches GDELT GEO API → writes to Redis
+// so Vercel handler serves from cache (avoids 25s edge timeout on slow GDELT)
+// ─────────────────────────────────────────────────────────────
+const POSITIVE_EVENTS_INTERVAL_MS = 900_000; // 15 min
+const POSITIVE_EVENTS_TTL = 2700; // 3× interval
+const POSITIVE_EVENTS_RPC_KEY = 'positive-events:geo:v1';
+const POSITIVE_EVENTS_BOOTSTRAP_KEY = 'positive-events:geo-bootstrap:v1';
+const POSITIVE_EVENTS_MAX = 500;
+
+const POSITIVE_QUERIES = [
+  '(breakthrough OR discovery OR "renewable energy")',
+  '(conservation OR "poverty decline" OR "humanitarian aid")',
+  '("good news" OR volunteer OR donation OR charity)',
+];
+
+// Mirrors CATEGORY_KEYWORDS from src/services/positive-classifier.ts — keep in sync
+const POSITIVE_CATEGORY_KEYWORDS = [
+  ['clinical trial', 'science-health'], ['study finds', 'science-health'],
+  ['researchers', 'science-health'], ['scientists', 'science-health'],
+  ['breakthrough', 'science-health'], ['discovery', 'science-health'],
+  ['cure', 'science-health'], ['vaccine', 'science-health'],
+  ['treatment', 'science-health'], ['medical', 'science-health'],
+  ['endangered species', 'nature-wildlife'], ['conservation', 'nature-wildlife'],
+  ['wildlife', 'nature-wildlife'], ['species', 'nature-wildlife'],
+  ['marine', 'nature-wildlife'], ['forest', 'nature-wildlife'],
+  ['renewable', 'climate-wins'], ['solar', 'climate-wins'],
+  ['wind energy', 'climate-wins'], ['electric vehicle', 'climate-wins'],
+  ['emissions', 'climate-wins'], ['carbon', 'climate-wins'],
+  ['clean energy', 'climate-wins'], ['climate', 'climate-wins'],
+  ['robot', 'innovation-tech'], ['technology', 'innovation-tech'],
+  ['startup', 'innovation-tech'], ['innovation', 'innovation-tech'],
+  ['artificial intelligence', 'innovation-tech'],
+  ['volunteer', 'humanity-kindness'], ['donated', 'humanity-kindness'],
+  ['charity', 'humanity-kindness'], ['rescued', 'humanity-kindness'],
+  ['hero', 'humanity-kindness'], ['kindness', 'humanity-kindness'],
+  [' art ', 'culture-community'], ['music', 'culture-community'],
+  ['festival', 'culture-community'], ['education', 'culture-community'],
+];
+
+function classifyPositiveName(name) {
+  const lower = ` ${name.toLowerCase()} `;
+  for (const [kw, cat] of POSITIVE_CATEGORY_KEYWORDS) {
+    if (lower.includes(kw)) return cat;
+  }
+  return 'humanity-kindness';
+}
+
+function fetchGdeltGeoPositive(query) {
+  return new Promise((resolve) => {
+    const params = new URLSearchParams({ query, format: 'geojson', timespan: '24h', maxrecords: '75' });
+    const req = https.get(`https://api.gdeltproject.org/api/v2/geo/geo?${params}`, {
+      headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+      timeout: 15000,
+    }, (resp) => {
+      if (resp.statusCode !== 200) { resp.resume(); return resolve([]); }
+      let body = '';
+      resp.on('data', (chunk) => { body += chunk; });
+      resp.on('end', () => {
+        try {
+          const data = JSON.parse(body);
+          const features = Array.isArray(data?.features) ? data.features : [];
+          const events = [];
+          const seen = new Set();
+          for (const f of features) {
+            const name = String(f.properties?.name || '').substring(0, 200);
+            if (!name || seen.has(name)) continue;
+            if (name.startsWith('ERROR:') || name.includes('unknown error')) continue;
+            const count = Number(f.properties?.count) || 1;
+            if (count < 3) continue;
+            const coords = f.geometry?.coordinates;
+            if (!Array.isArray(coords) || coords.length < 2) continue;
+            const [lon, lat] = coords;
+            if (!Number.isFinite(lat) || !Number.isFinite(lon) || lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+            seen.add(name);
+            events.push({ latitude: lat, longitude: lon, name, category: classifyPositiveName(name), count, timestamp: Date.now() });
+          }
+          resolve(events);
+        } catch { resolve([]); }
+      });
+    });
+    req.on('error', () => resolve([]));
+    req.on('timeout', () => { req.destroy(); resolve([]); });
+  });
+}
+
+let positiveEventsInFlight = false;
+
+async function seedPositiveEvents() {
+  if (positiveEventsInFlight) return;
+  positiveEventsInFlight = true;
+  const t0 = Date.now();
+  try {
+    const allEvents = [];
+    const seenNames = new Set();
+    let anyQuerySucceeded = false;
+
+    for (let i = 0; i < POSITIVE_QUERIES.length; i++) {
+      if (i > 0) await new Promise((r) => setTimeout(r, 500));
+      try {
+        const events = await fetchGdeltGeoPositive(POSITIVE_QUERIES[i]);
+        anyQuerySucceeded = true;
+        for (const e of events) {
+          if (!seenNames.has(e.name)) {
+            seenNames.add(e.name);
+            allEvents.push(e);
+          }
+        }
+      } catch { /* individual query failure is non-fatal */ }
+    }
+
+    if (!anyQuerySucceeded) {
+      console.warn('[PositiveEvents] All queries failed — preserving last good data');
+      return;
+    }
+
+    const capped = allEvents.slice(0, POSITIVE_EVENTS_MAX);
+    const payload = { events: capped, fetchedAt: Date.now() };
+    const ok1 = await upstashSet(POSITIVE_EVENTS_RPC_KEY, payload, POSITIVE_EVENTS_TTL);
+    const ok2 = await upstashSet(POSITIVE_EVENTS_BOOTSTRAP_KEY, payload, POSITIVE_EVENTS_TTL);
+    console.log(`[PositiveEvents] Seeded ${capped.length} events (redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+  } catch (e) {
+    console.warn('[PositiveEvents] Seed error:', e?.message || e);
+  } finally {
+    positiveEventsInFlight = false;
+  }
+}
+
+async function startPositiveEventsSeedLoop() {
+  if (!UPSTASH_ENABLED) {
+    console.log('[PositiveEvents] Disabled (no Upstash Redis)');
+    return;
+  }
+  console.log(`[PositiveEvents] Seed loop starting (interval ${POSITIVE_EVENTS_INTERVAL_MS / 1000 / 60}min)`);
+  seedPositiveEvents().catch((e) => console.warn('[PositiveEvents] Initial seed error:', e?.message || e));
+  setInterval(() => {
+    seedPositiveEvents().catch((e) => console.warn('[PositiveEvents] Seed error:', e?.message || e));
+  }, POSITIVE_EVENTS_INTERVAL_MS).unref?.();
+}
+
 function gzipSyncBuffer(body) {
   try {
     return zlib.gzipSync(typeof body === 'string' ? Buffer.from(body) : body);
@@ -4586,6 +4726,7 @@ server.listen(PORT, () => {
   startMarketDataSeedLoop();
   startAviationSeedLoop();
   startCyberThreatsSeedLoop();
+  startPositiveEventsSeedLoop();
 });
 
 wss.on('connection', (ws, req) => {

--- a/server/worldmonitor/positive-events/v1/list-positive-geo-events.ts
+++ b/server/worldmonitor/positive-events/v1/list-positive-geo-events.ts
@@ -1,124 +1,31 @@
-/**
- * ListPositiveGeoEvents RPC -- fetches geocoded positive news events
- * from GDELT GEO API using positive topic queries.
- */
-
 import type {
   ServerContext,
   ListPositiveGeoEventsRequest,
   ListPositiveGeoEventsResponse,
   PositiveGeoEvent,
 } from '../../../../src/generated/server/worldmonitor/positive_events/v1/service_server';
+import { getCachedJson } from '../../../_shared/redis';
 
-import { classifyNewsItem } from '../../../../src/services/positive-classifier';
-import { cachedFetchJson } from '../../../_shared/redis';
-import { markNoCacheResponse } from '../../../_shared/response-headers';
+const CACHE_KEY = 'positive-events:geo:v1';
+const MAX_AGE_MS = 25 * 60 * 60 * 1000;
 
-const GDELT_GEO_URL = 'https://api.gdeltproject.org/api/v2/geo/geo';
-
-const REDIS_CACHE_KEY = 'positive-events:geo:v1';
-const REDIS_CACHE_TTL = 900;
-
-// Compound positive queries combining topics from POSITIVE_GDELT_TOPICS pattern
-const POSITIVE_QUERIES = [
-  '(breakthrough OR discovery OR "renewable energy")',
-  '(conservation OR "poverty decline" OR "humanitarian aid")',
-  '("good news" OR volunteer OR donation OR charity)',
-];
-
-async function fetchGdeltGeoPositive(query: string): Promise<PositiveGeoEvent[]> {
-  const params = new URLSearchParams({
-    query,
-    format: 'geojson',
-    timespan: '24h',
-    maxrecords: '75',
-  });
-
-  const response = await fetch(`${GDELT_GEO_URL}?${params}`, {
-    headers: { Accept: 'application/json' },
-    signal: AbortSignal.timeout(10000),
-  });
-
-  if (!response.ok) return [];
-
-  const data = await response.json();
-  const features: unknown[] = data?.features || [];
-  const seenLocations = new Set<string>();
-  const events: PositiveGeoEvent[] = [];
-
-  for (const feature of features as any[]) {
-    const name: string = feature.properties?.name || '';
-    if (!name || seenLocations.has(name)) continue;
-    // GDELT returns error messages as fake features — skip them
-    if (name.startsWith('ERROR:') || name.includes('unknown error')) continue;
-
-    const count: number = feature.properties?.count || 1;
-    if (count < 3) continue; // Noise filter
-
-    const coords = feature.geometry?.coordinates;
-    if (!Array.isArray(coords) || coords.length < 2) continue;
-
-    const [lon, lat] = coords; // GeoJSON order: [lon, lat]
-    if (
-      !Number.isFinite(lat) ||
-      !Number.isFinite(lon) ||
-      lat < -90 ||
-      lat > 90 ||
-      lon < -180 ||
-      lon > 180
-    ) continue;
-
-    seenLocations.add(name);
-
-    const category = classifyNewsItem('GDELT', name);
-
-    events.push({
-      latitude: lat,
-      longitude: lon,
-      name,
-      category,
-      count,
-      timestamp: Date.now(),
-    });
-  }
-
-  return events;
-}
+let fallback: { events: PositiveGeoEvent[]; ts: number } | null = null;
 
 export async function listPositiveGeoEvents(
-  ctx: ServerContext,
+  _ctx: ServerContext,
   _req: ListPositiveGeoEventsRequest,
 ): Promise<ListPositiveGeoEventsResponse> {
   try {
-    const result = await cachedFetchJson<ListPositiveGeoEventsResponse>(REDIS_CACHE_KEY, REDIS_CACHE_TTL, async () => {
-      const allEvents: PositiveGeoEvent[] = [];
-      const seenNames = new Set<string>();
-      let anyQuerySucceeded = false;
+    const raw = await getCachedJson(CACHE_KEY, true) as { events?: PositiveGeoEvent[]; fetchedAt?: number } | null;
+    if (raw?.events?.length && (!raw.fetchedAt || (Date.now() - raw.fetchedAt) < MAX_AGE_MS)) {
+      fallback = { events: raw.events, ts: Date.now() };
+      return { events: raw.events };
+    }
+  } catch { /* fall through */ }
 
-      for (let i = 0; i < POSITIVE_QUERIES.length; i++) {
-        if (i > 0) {
-          await new Promise(r => setTimeout(r, 500));
-        }
-
-        try {
-          const events = await fetchGdeltGeoPositive(POSITIVE_QUERIES[i]!);
-          anyQuerySucceeded = true;
-          for (const event of events) {
-            if (!seenNames.has(event.name)) {
-              seenNames.add(event.name);
-              allEvents.push(event);
-            }
-          }
-        } catch {
-          // Individual query failure is non-fatal
-        }
-      }
-
-      return anyQuerySucceeded ? { events: allEvents } : null;
-    });
-    return result || { events: [] };
-  } catch {
-    markNoCacheResponse(ctx.request);
-    return { events: [] };
+  if (fallback && (Date.now() - fallback.ts) < 12 * 60 * 60 * 1000) {
+    return { events: fallback.events };
   }
+
+  return { events: [] };
 }

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -122,7 +122,8 @@ import { fetchHappinessScores } from '@/services/happiness-data';
 import { fetchRenewableInstallations } from '@/services/renewable-installations';
 import { filterBySentiment } from '@/services/sentiment-gate';
 import { fetchAllPositiveTopicIntelligence } from '@/services/gdelt-intel';
-import { fetchPositiveGeoEvents, geocodePositiveNewsItems } from '@/services/positive-events-geo';
+import { fetchPositiveGeoEvents, geocodePositiveNewsItems, type PositiveGeoEvent } from '@/services/positive-events-geo';
+import type { HappyContentCategory } from '@/services/positive-classifier';
 import { fetchKindnessData } from '@/services/kindness-data';
 import { getPersistentCache, setPersistentCache } from '@/services/persistent-cache';
 import type { ThreatLevel as ClientThreatLevel } from '@/services/threat-classifier';
@@ -2254,7 +2255,17 @@ export class DataLoaderManager implements AppModule {
   }
 
   private async loadPositiveEvents(): Promise<void> {
-    const gdeltEvents = await fetchPositiveGeoEvents();
+    const hydrated = getHydratedData('positiveGeoEvents') as { events?: Array<{ latitude: number; longitude: number; name: string; category: string; count: number; timestamp: number }> } | undefined;
+    let gdeltEvents: PositiveGeoEvent[];
+    if (hydrated?.events?.length) {
+      gdeltEvents = hydrated.events.map(e => ({
+        lat: e.latitude, lon: e.longitude, name: e.name,
+        category: (e.category || 'humanity-kindness') as HappyContentCategory,
+        count: e.count, timestamp: e.timestamp,
+      }));
+    } else {
+      gdeltEvents = await fetchPositiveGeoEvents();
+    }
     const rssEvents = geocodePositiveNewsItems(
       this.ctx.happyAllItems.map(item => ({
         title: item.title,


### PR DESCRIPTION
## Summary
- **Problem**: GDELT GEO API has 99.9% timeout rate on Vercel Edge (746 invocations timing out — 3 sequential calls with 10s timeouts + 500ms delays = ~31s vs 25s edge limit)
- **Fix**: Move GDELT fetching to Railway seed loop (15min interval, no timeout pressure), write to Redis, Vercel serves read-only from cache
- **Bonus**: Bootstrap hydration for instant first render (no RPC needed on page load)

### Architecture change
```
Before: Browser → Vercel Edge → GDELT API (3 calls, times out) → Redis
After:  Railway cron (15min) → GDELT API → Redis
        Browser → Bootstrap/Vercel Edge → Redis (read-only)
```

### Files changed
| File | Change |
|------|--------|
| `scripts/ais-relay.cjs` | New `startPositiveEventsSeedLoop()` — 15min interval, concurrency guard, 3 GDELT queries, inlined classifier, dual Redis key writes |
| `server/.../list-positive-geo-events.ts` | Stripped to cache-read-only (UCDP pattern) — 125→32 lines |
| `api/bootstrap.js` | Register `positiveGeoEvents` in `FAST_KEYS` |
| `src/app/data-loader.ts` | `getHydratedData('positiveGeoEvents')` before RPC fallback |

## Test plan
- [ ] Deploy Railway first → confirm `[PositiveEvents] Seeded N events (redis: OK)` in logs
- [ ] Verify Redis key: `curl api.worldmonitor.app/api/bootstrap?keys=positiveGeoEvents`
- [ ] Deploy Vercel → verify timeout rate drops to ~0%
- [ ] Frontend: positive events render on map (happy variant)