### PR TITLE
perf(desktop): pause hidden-window render work

### DIFF
--- a/src/app/desktop-updater.ts
+++ b/src/app/desktop-updater.ts
@@ -67,7 +67,9 @@ export class DesktopUpdater implements AppModule {
 
   private async checkForUpdate(): Promise<void> {
     try {
-      const res = await fetch('https://worldmonitor.app/api/version');
+      const res = await fetch('https://worldmonitor.app/api/version', {
+        signal: AbortSignal.timeout(8000),
+      });
       if (!res.ok) {
         this.logUpdaterOutcome('fetch_failed', { status: res.status });
         return;

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -316,6 +316,9 @@ export class EventHandlerManager implements AppModule {
 
     this.boundVisibilityHandler = () => {
       document.body?.classList.toggle('animations-paused', document.hidden);
+      if (this.ctx.isDesktopApp) {
+        this.ctx.map?.setRenderPaused(document.hidden);
+      }
       if (document.hidden) {
         this.callbacks.setHiddenSince(Date.now());
         mlWorker.unloadOptionalModels();

--- a/src/components/CountersPanel.ts
+++ b/src/components/CountersPanel.ts
@@ -5,12 +5,13 @@ import {
   formatCounterValue,
   type CounterMetric,
 } from '@/services/humanity-counters';
+import { isDesktopRuntime } from '@/services/runtime';
 
 /**
  * CountersPanel -- Worldometer-style ticking counters showing positive global metrics.
  *
  * Displays 6 metrics (births, trees, vaccines, graduates, books, renewable MW)
- * with values ticking at 60fps via requestAnimationFrame. Values are calculated
+ * with values ticking via requestAnimationFrame. Values are calculated
  * from absolute time (seconds since midnight UTC * per-second rate) to avoid
  * drift across tabs, throttling, or background suspension.
  *
@@ -19,10 +20,25 @@ import {
 export class CountersPanel extends Panel {
   private animFrameId: number | null = null;
   private valueElements: Map<string, HTMLElement> = new Map();
+  private readonly desktopMode = isDesktopRuntime();
+  private visibilityHandler: (() => void) | null = null;
+  private lastDesktopUpdateAt = 0;
+  private readonly desktopUpdateIntervalMs = 250;
 
   constructor() {
     super({ id: 'counters', title: 'Live Counters', trackActivity: false });
     this.createCounterGrid();
+    if (this.desktopMode) {
+      this.visibilityHandler = () => {
+        if (document.hidden) {
+          this.stopTicking();
+          return;
+        }
+        this.lastDesktopUpdateAt = 0;
+        this.startTicking();
+      };
+      document.addEventListener('visibilitychange', this.visibilityHandler);
+    }
     this.startTicking();
   }
 
@@ -84,19 +100,36 @@ export class CountersPanel extends Panel {
 
   /**
    * Start the requestAnimationFrame animation loop.
-   * Each frame recalculates all counter values from absolute time.
+   * Each tick recalculates all counter values from absolute time.
    */
   public startTicking(): void {
     if (this.animFrameId !== null) return; // Already ticking
+    if (this.desktopMode && document.hidden) return;
     this.animFrameId = requestAnimationFrame(this.tick);
+  }
+
+  private stopTicking(): void {
+    if (this.animFrameId !== null) {
+      cancelAnimationFrame(this.animFrameId);
+      this.animFrameId = null;
+    }
   }
 
   /**
    * Animation tick -- arrow function for correct `this` binding.
-   * Updates all 6 counter values using textContent (not innerHTML)
-   * to avoid layout thrashing at 60fps.
+   * Updates all 6 counter values using textContent (not innerHTML).
+   * Desktop runtime is throttled to reduce background CPU usage.
    */
   private tick = (): void => {
+    if (this.desktopMode) {
+      const now = performance.now();
+      if ((now - this.lastDesktopUpdateAt) < this.desktopUpdateIntervalMs) {
+        this.animFrameId = requestAnimationFrame(this.tick);
+        return;
+      }
+      this.lastDesktopUpdateAt = now;
+    }
+
     for (const metric of COUNTER_METRICS) {
       const el = this.valueElements.get(metric.id);
       if (el) {
@@ -111,9 +144,10 @@ export class CountersPanel extends Panel {
    * Clean up animation frame and call parent destroy.
    */
   public destroy(): void {
-    if (this.animFrameId !== null) {
-      cancelAnimationFrame(this.animFrameId);
-      this.animFrameId = null;
+    this.stopTicking();
+    if (this.visibilityHandler) {
+      document.removeEventListener('visibilitychange', this.visibilityHandler);
+      this.visibilityHandler = null;
     }
     this.valueElements.clear();
     super.destroy();

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -289,10 +289,26 @@ type GlobeMarker =
   | FlightDelayMarker | CableAdvisoryMarker | RepairShipMarker | AisDisruptionMarker
   | NewsLocationMarker | FlashMarker;
 
+interface GlobeControlsLike {
+  autoRotate: boolean;
+  autoRotateSpeed: number;
+  enablePan: boolean;
+  enableZoom: boolean;
+  zoomSpeed: number;
+  minDistance: number;
+  maxDistance: number;
+  enableDamping: boolean;
+}
+
 export class GlobeMap {
   private container: HTMLElement;
   private globe: GlobeInstance | null = null;
   private unsubscribeGlobeQuality: (() => void) | null = null;
+  private controls: GlobeControlsLike | null = null;
+  private renderPaused = false;
+  private pendingFlushWhilePaused = false;
+  private controlsAutoRotateBeforePause: boolean | null = null;
+  private controlsDampingBeforePause: boolean | null = null;
 
   private initialized = false;
   private destroyed = false;
@@ -429,7 +445,8 @@ export class GlobeMap {
       .pathTransitionDuration(0);
 
     // Orbit controls — match Sentinel's settings
-    const controls = globe.controls();
+    const controls = globe.controls() as GlobeControlsLike;
+    this.controls = controls;
     controls.autoRotate = !desktop;
     controls.autoRotateSpeed = 0.3;
     controls.enablePan = false;
@@ -480,13 +497,15 @@ export class GlobeMap {
 
     // Pause auto-rotate on user interaction; resume after 60 s idle (like Sentinel)
     const pauseAutoRotate = () => {
+      if (this.renderPaused) return;
       controls.autoRotate = false;
       if (this.autoRotateTimer) clearTimeout(this.autoRotateTimer);
     };
     const scheduleResumeAutoRotate = () => {
+      if (this.renderPaused) return;
       if (this.autoRotateTimer) clearTimeout(this.autoRotateTimer);
       this.autoRotateTimer = setTimeout(() => {
-        controls.autoRotate = !desktop;
+        if (!this.renderPaused) controls.autoRotate = !desktop;
       }, 60_000);
     };
 
@@ -1054,6 +1073,10 @@ export class GlobeMap {
 
   private flushMarkers(): void {
     if (!this.globe || !this.initialized || this.destroyed) return;
+    if (this.renderPaused) {
+      this.pendingFlushWhilePaused = true;
+      return;
+    }
     if (this.flushTimer) return;
     this.flushTimer = requestAnimationFrame(() => {
       this.flushTimer = null;
@@ -1464,7 +1487,45 @@ export class GlobeMap {
     if (!isResizing) this.resize();
   }
   public setZoom(_z: number): void {}
-  public setRenderPaused(_paused: boolean): void {}
+  public setRenderPaused(paused: boolean): void {
+    if (this.renderPaused === paused) return;
+    this.renderPaused = paused;
+
+    if (paused) {
+      if (this.flushTimer) {
+        cancelAnimationFrame(this.flushTimer);
+        this.flushTimer = null;
+      }
+      this.pendingFlushWhilePaused = true;
+      if (this.autoRotateTimer) {
+        clearTimeout(this.autoRotateTimer);
+        this.autoRotateTimer = null;
+      }
+    }
+
+    if (this.controls) {
+      if (paused) {
+        this.controlsAutoRotateBeforePause = this.controls.autoRotate;
+        this.controlsDampingBeforePause = this.controls.enableDamping;
+        this.controls.autoRotate = false;
+        this.controls.enableDamping = false;
+      } else {
+        if (this.controlsAutoRotateBeforePause !== null) {
+          this.controls.autoRotate = this.controlsAutoRotateBeforePause;
+        }
+        if (this.controlsDampingBeforePause !== null) {
+          this.controls.enableDamping = this.controlsDampingBeforePause;
+        }
+        this.controlsAutoRotateBeforePause = null;
+        this.controlsDampingBeforePause = null;
+      }
+    }
+
+    if (!paused && this.pendingFlushWhilePaused) {
+      this.pendingFlushWhilePaused = false;
+      this.flushMarkers();
+    }
+  }
   public updateHotspotActivity(_news: any[]): void {}
   public updateMilitaryForEscalation(_f: any[], _v: any[]): void {}
   public getHotspotDynamicScore(_id: string) { return undefined; }
@@ -1755,6 +1816,9 @@ export class GlobeMap {
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
     this.hideTooltip();
+    this.controls = null;
+    this.controlsAutoRotateBeforePause = null;
+    this.controlsDampingBeforePause = null;
     this.layerTogglesEl = null;
     if (this.globe) {
       try { this.globe._destructor(); } catch { /* ignore */ }


### PR DESCRIPTION
**Summary**

pause map render loops when desktop window is hidden via setRenderPaused(document.hidden)
- implement GlobeMap.setRenderPaused() to pause/resume flush plus orbit control work
- throttle CountersPanel updates in desktop runtime and stop ticking while hidde
- n- add timeout to desktop updater version check fetch\n\nValidation
- npm run typechec
- npm run typecheck:api