### PR TITLE
docs: align protobuf domain count in CONTRIBUTING with README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ World Monitor is a real-time OSINT dashboard built with **Vanilla TypeScript** (
 | **TypeScript** | All code — frontend, edge functions, and handlers |
 | **Vite** | Build tool and dev server |
 | **Sebuf** | Proto-first HTTP RPC framework for typed API contracts |
-| **Protobuf / Buf** | Service and message definitions across 17 domains |
+| **Protobuf / Buf** | Service and message definitions across 22 domains |
 | **MapLibre GL** | Base map rendering (tiles, globe mode, camera) |
 | **deck.gl** | WebGL overlay layers (scatterplot, geojson, arcs, heatmaps) |
 | **d3** | Charts, sparklines, and data visualization |


### PR DESCRIPTION
Updates the Architecture Overview table in CONTRIBUTING.md to reflect 22 protobuf domains (consistent with README and the actual `proto/` directory).

- Scope: docs only
- Behavior change: none