### PR TITLE
fix(desktop): route waitlist signup through sidecar

### DIFF
--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -25,7 +25,7 @@ import {
   type RuntimeFeatureId,
   type RuntimeSecretKey,
 } from '@/services/runtime-config';
-import { getApiBaseUrl, getRemoteApiBaseUrl, isDesktopRuntime, resolveLocalApiPort, startSmartPollLoop, type SmartPollLoopHandle } from '@/services/runtime';
+import { getApiBaseUrl, isDesktopRuntime, resolveLocalApiPort, startSmartPollLoop, type SmartPollLoopHandle } from '@/services/runtime';
 import { tryInvokeTauri, invokeTauri } from '@/services/tauri-bridge';
 import { escapeHtml } from '@/utils/sanitize';
 import { initI18n, t } from '@/services/i18n';
@@ -287,8 +287,7 @@ function initOverviewListeners(area: HTMLElement): void {
     btn.textContent = t('modals.settingsWindow.worldMonitor.register.submitting');
 
     try {
-      const base = isDesktopRuntime() ? getRemoteApiBaseUrl() : '';
-      const res = await fetch(`${base}/api/register-interest`, {
+      const res = await diagFetch('/api/register-interest', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, source: 'desktop-settings' }),


### PR DESCRIPTION
## Summary
- Settings window waitlist registration bypassed the sidecar, calling the cloud API directly via `getRemoteApiBaseUrl()` — inconsistent with every other API call in `settings-main.ts`
- Switch to `diagFetch()` which routes through the sidecar (with auth token), where the existing `register-interest` handler proxies to cloud via `tryCloudFallback()`
- Removes unused `getRemoteApiBaseUrl` import

Supersedes #954 which used a relative path but missed that the settings window lacks `installRuntimeFetchPatch()`.

## Type of change
- [x] Bug fix

## Affected areas
- [x] Desktop app (Tauri)
- [x] Config / Settings

## Test plan
- [ ] Desktop: open settings → enter email → verify registration succeeds (sidecar logs show cloud fallback)
- [ ] Web: verify registration still works with relative path via `diagFetch`