### PR TITLE
fix(sentry): filter Three.js WebGL and third-party noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -161,6 +161,11 @@ Sentry.init({
     /Error invoking postMessage: Java exception/,
     /IndexSizeError/,
     /Cannot add property \w+, object is not extensible/,
+    /Failed to construct 'Worker'.*cannot be accessed from origin/,
+    /undefined is not an object \(evaluating '(?:this\.)?media(?:Controller)?\.(?:duration|videoTracks|readyState|audioTracks|media)/,
+    /\$ is not defined/,
+    /Qt\(\) is not a function/,
+    /out of memory/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';
@@ -174,6 +179,12 @@ Sentry.init({
     if (/^TypeError:/.test(msg) && frames.length > 0) {
       const nonSentryFrames = frames.filter(f => f.filename && f.filename !== '<anonymous>' && !/\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename));
       if (nonSentryFrames.length > 0 && nonSentryFrames.every(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
+    }
+    // Suppress Three.js/globe.gl TypeError crashes in main bundle (reading 'type' on undefined during WebGL traversal)
+    if (/reading 'type'|can't access property "type",? \w+ is undefined/.test(msg)) {
+      const nonSentryFrames = frames.filter(f => f.filename && f.filename !== '<anonymous>' && !/\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename));
+      const hasSourceMapped = nonSentryFrames.some(f => /\.(ts|tsx)$/.test(f.filename ?? '') || /^src\//.test(f.filename ?? ''));
+      if (!hasSourceMapped) return null;
     }
     // Suppress deck.gl/maplibre null-access crashes with no usable stack trace (requestAnimationFrame wrapping)
     if (/null is not an object \(evaluating '\w{1,3}\.(id|type|style)'\)/.test(msg) && frames.length === 0) return null;


### PR DESCRIPTION
## Summary
- Add `beforeSend` guard for Three.js `reading 'type'` TypeError crashes (1582 events across 22 issues) — suppresses when all stack frames are in minified bundles with no source-mapped `.ts` files
- Add 5 `ignoreErrors` patterns: cross-origin Worker construction, iOS media element crashes (`media.duration`/`videoTracks`/`readyState`), jQuery extensions (`$ is not defined`), injected scripts (`Qt()`), and OOM edge cases
- All 33 unresolved Sentry issues resolved with `inNextRelease: true` (auto-reopen if recur)

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 33 issues marked resolved via Sentry API (HTTP 200)
- [ ] Verify Sentry dashboard shows 0 unresolved issues after deploy
- [ ] Monitor for regressions — `inNextRelease` will auto-reopen if errors recur