### PR TITLE
fix(sentry): clamp latitude in resize handler + noise filter (4 issues)

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -522,7 +522,8 @@ export class DeckGLMap {
       if (Math.abs(delta) > 1e-6) {
         this.correctingCenter = true;
         const c = this.maplibreMap.getCenter();
-        this.maplibreMap.jumpTo({ center: [c.lng, c.lat + delta] });
+        const clampedLat = Math.max(-90, Math.min(90, c.lat + delta));
+        this.maplibreMap.jumpTo({ center: [c.lng, clampedLat] });
         this.correctingCenter = false;
         // Do NOT update savedTopLat — keep the original mousedown position
         // so every frame targets the exact same geographic anchor.

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,6 +166,7 @@ Sentry.init({
     /\$ is not defined/,
     /Qt\(\) is not a function/,
     /out of memory/,
+    /Could not connect to the server/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary
- **WORLDMONITOR-AK** (1 event): `correctingCenter` in `DeckGLMap.ts` could push latitude beyond ±90 via `c.lat + delta` during resize, causing maplibre `Invalid LngLat latitude` crash. Fixed with `Math.max(-90, Math.min(90, ...))` clamp.
- **WORLDMONITOR-AH** (1 event): Added noise filter for mobile "Could not connect to the server" (iPhone, iOS 15, no stack trace).
- **WORLDMONITOR-AG** (18 events): Already filtered by `beforeSend` reading-type guard from PR #965. Resolved in Sentry.
- **WORLDMONITOR-AJ** (1 event): Single Firefox event with minified stack, not reproducible. Resolved in Sentry.

All 4 issues marked resolved with `inNextRelease: true`.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Resize map at extreme latitudes — no LngLat crash
- [ ] Mobile network errors no longer reported to Sentry