### PR TITLE
Revert "Manage channels search bar"

### DIFF
--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -264,7 +264,6 @@ export class EventHandlerManager implements AppModule {
           (panel as unknown as { refreshChannelsFromStorage: () => void }).refreshChannelsFromStorage();
         }
       }
-
     };
     window.addEventListener('storage', this.boundStorageHandler);
 
@@ -314,7 +313,6 @@ export class EventHandlerManager implements AppModule {
 
     this.setupMapResize();
     this.setupMapPin();
-
 
     this.boundVisibilityHandler = () => {
       document.body?.classList.toggle('animations-paused', document.hidden);
@@ -654,6 +652,15 @@ export class EventHandlerManager implements AppModule {
       },
       isDesktopApp: this.ctx.isDesktopApp,
       statusPanel: this.ctx.statusPanel,
+      isGlobeMode: () => this.ctx.map?.isGlobeMode() ?? false,
+      onMapModeChange: (useGlobe: boolean) => {
+        saveToStorage(STORAGE_KEYS.mapMode, useGlobe ? 'globe' : 'flat');
+        if (useGlobe) {
+          this.ctx.map?.switchToGlobe();
+        } else {
+          this.ctx.map?.switchToFlat();
+        }
+      },
     });
 
     if (this.ctx.statusPanel) {
@@ -947,7 +954,6 @@ export class EventHandlerManager implements AppModule {
 
     this.setupMapFullscreen(mapSection);
   }
-
 
   private setupMapFullscreen(mapSection: HTMLElement): void {
     const btn = document.getElementById('mapFullscreenBtn');

--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -178,10 +178,10 @@ export class CountryBriefPage implements CountryBriefPanel {
     if (signals.travelAdvisories > 0 && signals.travelAdvisoryMaxLevel) {
       const advisoryClass = signals.travelAdvisoryMaxLevel === 'do-not-travel' ? 'conflict'
         : signals.travelAdvisoryMaxLevel === 'reconsider' ? 'outage'
-          : 'military';
+        : 'military';
       const advisoryLabel = signals.travelAdvisoryMaxLevel === 'do-not-travel' ? 'Do Not Travel'
         : signals.travelAdvisoryMaxLevel === 'reconsider' ? 'Reconsider Travel'
-          : 'Exercise Caution';
+        : 'Exercise Caution';
       chips.push(`<span class="signal-chip ${advisoryClass}">\u26A0\uFE0F ${signals.travelAdvisories} Advisory: ${advisoryLabel}</span>`);
     }
     if (signals.orefSirens > 0) chips.push(`<span class="signal-chip conflict">\u{1F6A8} ${signals.orefSirens} Active Sirens</span>`);
@@ -358,7 +358,7 @@ export class CountryBriefPage implements CountryBriefPanel {
         const orig = linkShareBtn!.innerHTML;
         linkShareBtn!.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
         setTimeout(() => { linkShareBtn!.innerHTML = orig; }, 1500);
-      }).catch(() => { });
+      }).catch(() => {});
     });
     this.overlay.querySelector('.cb-share-btn')?.addEventListener('click', () => {
       if (this.onShareStory && this.currentCode && this.currentName) {
@@ -494,8 +494,8 @@ export class CountryBriefPage implements CountryBriefPanel {
       const safeUrl = sanitizeUrl(item.link);
       const threatColor = item.threat?.level === 'critical' ? getCSSColor('--threat-critical')
         : item.threat?.level === 'high' ? getCSSColor('--threat-high')
-          : item.threat?.level === 'medium' ? getCSSColor('--threat-medium')
-            : getCSSColor('--threat-info');
+        : item.threat?.level === 'medium' ? getCSSColor('--threat-medium')
+        : getCSSColor('--threat-info');
       const timeAgo = this.timeAgo(item.pubDate);
       const cardBody = `
         <span class="cb-news-threat" style="background:${threatColor}"></span>
@@ -594,7 +594,7 @@ export class CountryBriefPage implements CountryBriefPanel {
       html = html.replace(/\[(\d{1,2})\]/g, (_match, numStr) => {
         const n = parseInt(numStr, 10);
         if (n >= 1 && n <= headlineCount) {
-          return `<a href="#cb-news-${n}" class="cb-citation" title="${t('countryBrief.sourceRef', { n: String(n) })}">[${n}]</a>`;
+          return `<a href="#cb-news-${n}" class="cb-citation" title="${t('components.countryBrief.sourceRef', { n: String(n) })}">[${n}]</a>`;
         }
         return `[${numStr}]`;
       });

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -144,7 +144,6 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'cgtn-arabic', name: 'CGTN Arabic', handle: '@CGTNArabic' },
   { id: 'kan-11', name: 'Kan 11', handle: '@KAN11NEWS', fallbackVideoId: 'TCnaIE_SAtM' },
   { id: 'asharq-news', name: 'Asharq News', handle: '@asharqnews', fallbackVideoId: 'f6VpkfV7m4Y', useFallbackOnly: true },
-  { id: 'aljazeera-arabic', name: 'AlJazeera Arabic', handle: '@AljazeeraChannel', fallbackVideoId: 'bNyUyrR0PHo', useFallbackOnly: true },
   // Africa
   { id: 'africanews', name: 'Africanews', handle: '@africanews' },
   { id: 'channels-tv', name: 'Channels TV', handle: '@ChannelsTelevision' },
@@ -171,7 +170,7 @@ const _REGION_ENTRIES: { key: string; labelKey: string; channelIds: string[] }[]
   { key: 'eu', labelKey: 'components.liveNews.regionEurope', channelIds: ['sky', 'euronews', 'dw', 'france24', 'bbc-news', 'france24-en', 'welt', 'rtve', 'trt-haber', 'ntv-turkey', 'cnn-turk', 'tv-rain', 'rt', 'tvp-info', 'telewizja-republika', 'tagesschau24', 'euronews-fr', 'france24-fr', 'france-info', 'bfmtv', 'tv5monde-info', 'nrk1', 'aljazeera-balkans'] },
   { key: 'latam', labelKey: 'components.liveNews.regionLatinAmerica', channelIds: ['cnn-brasil', 'jovem-pan', 'record-news', 'band-jornalismo', 'tn-argentina', 'c5n', 'milenio', 'noticias-caracol', 'ntn24', 't13'] },
   { key: 'asia', labelKey: 'components.liveNews.regionAsia', channelIds: ['tbs-news', 'ann-news', 'ntv-news', 'cti-news', 'wion', 'ndtv', 'cna-asia', 'nhk-world', 'arirang-news', 'india-today', 'abp-news'] },
-  { key: 'me', labelKey: 'components.liveNews.regionMiddleEast', channelIds: ['alarabiya', 'aljazeera', 'al-hadath', 'sky-news-arabia', 'trt-world', 'iran-intl', 'cgtn-arabic', 'kan-11', 'asharq-news', 'aljazeera-arabic'] },
+  { key: 'me', labelKey: 'components.liveNews.regionMiddleEast', channelIds: ['alarabiya', 'aljazeera', 'al-hadath', 'sky-news-arabia', 'trt-world', 'iran-intl', 'cgtn-arabic', 'kan-11', 'asharq-news'] },
   { key: 'africa', labelKey: 'components.liveNews.regionAfrica', channelIds: ['africanews', 'channels-tv', 'ktn-news', 'enca', 'sabc-news', 'arise-news'] },
   { key: 'oc', labelKey: 'components.liveNews.regionOceania', channelIds: ['abc-news-au'] },
 ];
@@ -244,7 +243,6 @@ const DIRECT_HLS_MAP: Readonly<Record<string, string>> = {
   'sabc-news': 'https://sabconetanw.cdn.mangomolo.com/news/smil:news.stream.smil/chunklist_b250000_t64MjQwcA==.m3u8',
   'arirang-news': 'https://amdlive-ch01-ctnd-com.akamaized.net/arirang_1ch/smil:arirang_1ch.smil/playlist.m3u8',
   'fox-news': 'https://247preview.foxnews.com/hls/live/2020027/fncv3preview/primary.m3u8',
-  'aljazeera-arabic': 'https://live-hls-web-aja.getaj.net/AJA/index.m3u8',
 };
 
 interface ProxiedHlsEntry { url: string; referer: string; }
@@ -1173,7 +1171,7 @@ export class LiveNewsPanel extends Panel {
         if (wantUnmute && this.nativeVideoElement === video) {
           video.muted = false;
         }
-      }).catch(() => { });
+      }).catch(() => {});
     }
   }
 
@@ -1181,7 +1179,7 @@ export class LiveNewsPanel extends Panel {
     if (!this.nativeVideoElement) return;
     this.nativeVideoElement.muted = this.isMuted;
     if (this.isPlaying) {
-      this.nativeVideoElement.play()?.catch(() => { });
+      this.nativeVideoElement.play()?.catch(() => {});
     } else {
       this.nativeVideoElement.pause();
     }

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -26,6 +26,10 @@ export interface UnifiedSettingsConfig {
   resetLayout: () => void;
   isDesktopApp: boolean;
   statusPanel?: StatusPanel | null;
+  /** True when the 3D globe is currently active */
+  isGlobeMode?: () => boolean;
+  /** Switch between flat-map and 3D-globe */
+  onMapModeChange?: (useGlobe: boolean) => void;
 }
 
 type TabId = 'general' | 'panels' | 'sources' | 'status';
@@ -183,7 +187,10 @@ export class UnifiedSettings {
         return;
       }
 
-      else if (target.id === 'us-cloud') {
+      if (target.id === 'us-globe-mode') {
+        this.config.onMapModeChange?.(target.checked);
+        return;
+      } else if (target.id === 'us-cloud') {
         setAiFlowSetting('cloudLlm', target.checked);
         this.updateAiStatus();
       } else if (target.id === 'us-browser') {
@@ -220,10 +227,6 @@ export class UnifiedSettings {
 
   public refreshPanelToggles(): void {
     if (this.activeTab === 'panels') this.renderPanelsTab();
-  }
-
-  public refreshMapMode(): void {
-    // No-op (reverted)
   }
 
   public getButton(): HTMLButtonElement {
@@ -320,9 +323,25 @@ export class UnifiedSettings {
   private renderGeneralContent(): string {
     const settings = getAiFlowSettings();
     const currentLang = getCurrentLanguage();
+    const globeEnabled = this.config.isGlobeMode?.() ?? false;
+
     let html = '';
+
     // Map section
     html += `<div class="ai-flow-section-label">${t('components.insights.sectionMap')}</div>`;
+
+    // Globe / flat-map mode toggle
+    html += `
+      <div class="ai-flow-toggle-row">
+        <div class="ai-flow-toggle-label-wrap">
+          <div class="ai-flow-toggle-label">3D Globe View</div>
+          <div class="ai-flow-toggle-desc">Switch between flat map and interactive 3D globe (like Sentinel). Zoom, rotate, and explore in three dimensions.</div>
+        </div>
+        <label class="ai-flow-switch">
+          <input type="checkbox" id="us-globe-mode"${globeEnabled ? ' checked' : ''}>
+          <span class="ai-flow-slider"></span>
+        </label>
+      </div>`;
 
     // Globe render quality (pixel ratio)
     const globeScale = getGlobeRenderScale();

--- a/src/live-channels-window.ts
+++ b/src/live-channels-window.ts
@@ -79,9 +79,6 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
 
   let channels = loadChannelsFromStorage();
   let suppressRowClick = false;
-  let searchQuery = '';
-
-
 
   /** Reads current row order from DOM and persists to storage. */
   function applyOrderFromDom(listEl: HTMLElement): void {
@@ -292,32 +289,16 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
     if (!tabBar || !tabContents) return;
 
     const currentIds = new Set(channels.map((c) => c.id));
-    const term = searchQuery.toLowerCase().trim();
 
     // Render tab buttons
     tabBar.innerHTML = '';
     for (const region of filteredRegions) {
-      const regionChannels = region.channelIds
-        .map(id => optionalChannelMap.get(id))
-        .filter((ch): ch is LiveChannel => !!ch);
-
-      const matchingChannels = regionChannels.filter(ch =>
-        !term || ch.name.toLowerCase().includes(term) || ch.handle.toLowerCase().includes(term)
-      );
-
-      const addedCountInRegion = matchingChannels.filter((ch) => currentIds.has(ch.id)).length;
-
+      const addedCount = region.channelIds.filter((id) => currentIds.has(id)).length;
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.className = 'live-news-manage-tab-btn' + (region.key === activeRegionTab ? ' active' : '');
       const label = t(region.labelKey) ?? region.key.toUpperCase();
-
-      if (term) {
-        btn.textContent = `${label} (${matchingChannels.length})`;
-      } else {
-        btn.textContent = addedCountInRegion > 0 ? `${label} (${addedCountInRegion})` : label;
-      }
-
+      btn.textContent = addedCount > 0 ? `${label} (${addedCount})` : label;
       btn.addEventListener('click', () => {
         activeRegionTab = region.key;
         renderAvailableChannels(listEl);
@@ -334,28 +315,14 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
       const grid = document.createElement('div');
       grid.className = 'live-news-manage-card-grid';
 
-      let matchCount = 0;
       for (const chId of region.channelIds) {
         const ch = optionalChannelMap.get(chId);
         if (!ch) continue;
-
-        if (term && !ch.name.toLowerCase().includes(term) && !ch.handle.toLowerCase().includes(term)) {
-          continue;
-        }
-
         const isAdded = currentIds.has(chId);
         grid.appendChild(createCard(ch, isAdded, listEl));
-        matchCount++;
       }
 
-      if (matchCount === 0 && term) {
-        const empty = document.createElement('div');
-        empty.className = 'live-news-manage-empty';
-        empty.textContent = (t('components.liveNews.noResults') ?? 'No channels found matching "{{term}}"').replace('{{term}}', term);
-        panel.appendChild(empty);
-      } else {
-        panel.appendChild(grid);
-      }
+      panel.appendChild(grid);
       tabContents.appendChild(panel);
     }
   }
@@ -420,15 +387,7 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
         </div>
         <div class="live-news-manage-list" id="liveChannelsList"></div>
         <div class="live-news-manage-available-section">
-          <div class="live-news-manage-available-header">
-            <span class="live-news-manage-add-title">${escapeHtml(t('components.liveNews.availableChannels') ?? 'Available channels')}</span>
-            <div class="live-news-manage-search-wrap">
-              <span class="live-news-manage-search-icon">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-              </span>
-              <input type="text" id="liveChannelsSearch" class="live-news-manage-search-input" placeholder="${escapeHtml(t('header.search') ?? 'Search')}..." autocomplete="off" />
-            </div>
-          </div>
+          <span class="live-news-manage-add-title">${escapeHtml(t('components.liveNews.availableChannels') ?? 'Available channels')}</span>
           <div class="live-news-manage-tab-bar" id="liveChannelsTabBar"></div>
           <div class="live-news-manage-tab-contents" id="liveChannelsTabContents"></div>
         </div>
@@ -573,14 +532,4 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
     if (handleInput) handleInput.value = '';
     if (nameInput) nameInput.value = '';
   });
-
-  const searchInput = document.getElementById('liveChannelsSearch') as HTMLInputElement | null;
-  if (searchInput) {
-    searchInput.value = '';
-    searchQuery = '';
-    searchInput.addEventListener('input', (e) => {
-      searchQuery = (e.target as HTMLInputElement).value;
-      renderAvailableChannels(listEl);
-    });
-  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -28,11 +28,6 @@
       "security": "Security",
       "information": "Information"
     },
-    "shareLink": "Share link",
-    "shareStory": "Share story",
-    "printPdf": "Print / PDF",
-    "exportData": "Export data",
-    "sourceRef": "Source [{{n}}]",
     "signals": {
       "protests": "protests",
       "militaryAir": "mil. aircraft",
@@ -85,7 +80,14 @@
     "noSignals": "No recent high-severity signals.",
     "assessmentUnavailable": "Assessment unavailable.",
     "noNews": "No recent country-specific coverage.",
+    "noMarkets": "No active markets for this country.",
     "noIndicators": "No country-specific indicators available.",
+    "components": {
+      "unrest": "Unrest",
+      "conflict": "Conflict",
+      "security": "Security",
+      "information": "Information"
+    },
     "nearbyPorts": "Nearby Ports",
     "detected": "Detected",
     "notDetected": "No",
@@ -137,7 +139,6 @@
     "downloadApp": "Download App",
     "fullscreen": "Fullscreen",
     "pinMap": "Pin map to top",
-    "globeMode": "3D Globe Mode",
     "viewOnGitHub": "View on GitHub",
     "filterSources": "Filter sources...",
     "sourcesEnabled": "{{enabled}}/{{total}} enabled",
@@ -574,54 +575,86 @@
       "fresh": "Fresh",
       "noMarkets": "No prediction markets found",
       "predictionMarkets": "Prediction Markets",
-      "unavailable": "AI brief unavailable — configure GROQ_API_KEY in Settings.",
-      "gpsJammingZones": "GPS Jamming Zones"
+      "unavailable": "AI brief unavailable — configure GROQ_API_KEY in Settings."
     },
-    "timeAgo": {
-      "m": "{{count}}m ago",
-      "h": "{{count}}h ago",
-      "d": "{{count}}d ago"
-    },
-    "infra": {
-      "pipeline": "Pipelines",
-      "cable": "Undersea Cables",
-      "datacenter": "Data Centers",
-      "base": "Military Bases",
-      "nuclear": "Nuclear Facilities",
-      "port": "Ports"
-    },
-    "levels": {
-      "critical": "Critical",
-      "high": "High",
-      "elevated": "Elevated",
-      "moderate": "Moderate",
-      "normal": "Normal",
-      "low": "Low"
-    },
-    "trends": {
-      "rising": "Rising",
-      "falling": "Falling",
-      "stable": "Stable"
-    },
-    "fallback": {
-      "instabilityIndex": "**Instability Index: {{score}}/100** ({{level}}, {{trend}})",
-      "protestsDetected": "{{count}} active protests detected",
-      "aircraftTracked": "{{count}} military aircraft tracked",
-      "vesselsTracked": "{{count}} military vessels tracked",
-      "activeStrikes": "{{count}} active strikes detected",
-      "internetOutages": "{{count}} internet outages",
-      "recentEarthquakes": "{{count}} recent earthquakes",
-      "stockIndex": "Stock index: {{value}}",
-      "recentHeadlines": "**Recent headlines:**"
+    "countryBrief": {
+      "identifying": "Identifying country...",
+      "locating": "Locating region...",
+      "limitedCoverage": "Limited coverage",
+      "instabilityIndex": "Instability Index",
+      "notTracked": "Not tracked — {{country}} is not in the CII tier-1 list",
+      "intelBrief": "Intelligence Brief",
+      "generatingBrief": "Generating intelligence brief...",
+      "topNews": "Top News",
+      "activeSignals": "Active Signals",
+      "timeline": "7-Day Timeline",
+      "predictionMarkets": "Prediction Markets",
+      "loadingMarkets": "Loading prediction markets...",
+      "infrastructure": "Infrastructure Exposure",
+      "briefUnavailable": "AI brief unavailable — configure GROQ_API_KEY in Settings.",
+      "cached": "Cached",
+      "fresh": "Fresh",
+      "noMarkets": "No prediction markets found",
+      "loadingIndex": "Loading index...",
+      "components": {
+        "unrest": "Unrest",
+        "conflict": "Conflict",
+        "security": "Security",
+        "information": "Information"
+      },
+      "signals": {
+        "protests": "protests",
+        "militaryAir": "mil. aircraft",
+        "militarySea": "mil. vessels",
+        "outages": "outages",
+        "earthquakes": "earthquakes",
+        "displaced": "displaced",
+        "climate": "Climate stress",
+        "conflictEvents": "conflict events",
+        "activeStrikes": "active strikes",
+        "aviationDisruptions": "airport disruptions",
+        "gpsJammingZones": "GPS Jamming Zones"
+      },
+      "timeAgo": {
+        "m": "{{count}}m ago",
+        "h": "{{count}}h ago",
+        "d": "{{count}}d ago"
+      },
+      "infra": {
+        "pipeline": "Pipelines",
+        "cable": "Undersea Cables",
+        "datacenter": "Data Centers",
+        "base": "Military Bases",
+        "nuclear": "Nuclear Facilities",
+        "port": "Ports"
+      },
+      "levels": {
+        "critical": "Critical",
+        "high": "High",
+        "elevated": "Elevated",
+        "moderate": "Moderate",
+        "normal": "Normal",
+        "low": "Low"
+      },
+      "trends": {
+        "rising": "Rising",
+        "falling": "Falling",
+        "stable": "Stable"
+      },
+      "fallback": {
+        "instabilityIndex": "**Instability Index: {{score}}/100** ({{level}}, {{trend}})",
+        "protestsDetected": "{{count}} active protests detected",
+        "aircraftTracked": "{{count}} military aircraft tracked",
+        "vesselsTracked": "{{count}} military vessels tracked",
+        "activeStrikes": "{{count}} active strikes detected",
+        "internetOutages": "{{count}} internet outages",
+        "recentEarthquakes": "{{count}} recent earthquakes",
+        "stockIndex": "Stock index: {{value}}",
+        "recentHeadlines": "**Recent headlines:**"
+      }
     }
   },
   "components": {
-    "countryBrief": {
-      "shareLink": "Share link",
-      "shareStory": "Share story",
-      "printPdf": "Print / PDF",
-      "exportData": "Export data"
-    },
     "webcams": {
       "expand": "Expand",
       "paused": "Webcams paused",
@@ -884,6 +917,13 @@
         "israel-gaza-theater": "Israel/Gaza",
         "yemen-redsea-theater": "Yemen/Red Sea"
       }
+    },
+    "countryBrief": {
+      "shareLink": "Share link",
+      "shareStory": "Share story",
+      "printPdf": "Print / PDF",
+      "exportData": "Export data",
+      "sourceRef": "Source [{{n}}]"
     },
     "relatedAssets": {
       "pipeline": "Pipeline",
@@ -1620,8 +1660,7 @@
       "regionOceania": "Oceania",
       "invalidHandle": "Enter a valid YouTube handle (e.g. @ChannelName)",
       "channelNotFound": "YouTube channel not found",
-      "verifying": "Verifying…",
-      "noResults": "No channels found"
+      "verifying": "Verifying…"
     },
     "map": {
       "showMap": "Show Map",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -959,10 +959,7 @@ canvas,
   align-items: center;
   justify-content: center;
   transition: all 0.2s;
-  flex-shrink: 0;
 }
-
-
 
 .map-pin-btn:hover {
   background: var(--surface-hover);
@@ -1930,68 +1927,6 @@ body.panel-resize-active iframe {
   margin-top: 4px;
 }
 
-.live-news-manage-available-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 12px;
-  gap: 16px;
-}
-
-.live-news-manage-available-header .live-news-manage-add-title {
-  margin-bottom: 0;
-}
-
-.live-news-manage-search-wrap {
-  position: relative;
-  flex: 1;
-  max-width: 240px;
-}
-
-.live-news-manage-search-icon {
-  position: absolute;
-  left: 10px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--text-dim);
-  pointer-events: none;
-  display: flex;
-  align-items: center;
-  opacity: 0.6;
-}
-
-.live-news-manage-search-input {
-  width: 100%;
-  padding: 6px 12px 6px 32px;
-  background: var(--darken-heavy);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  color: var(--text);
-  font-size: 13px;
-  outline: none;
-  transition: border-color 0.2s, box-shadow 0.2s;
-}
-
-.live-news-manage-search-input:focus {
-  border-color: var(--text-dim);
-  background: var(--bg);
-}
-
-.live-news-manage-search-input::placeholder {
-  color: var(--text-dim);
-}
-
-.live-news-manage-empty {
-  padding: 30px 10px;
-  text-align: center;
-  color: var(--text-dim);
-  font-size: 14px;
-  background: var(--darken);
-  border: 1px dashed var(--border);
-  border-radius: 6px;
-  margin-top: 4px;
-}
-
 /* Tab bar */
 .live-news-manage-tab-bar {
   display: flex;
@@ -2288,7 +2223,7 @@ body.live-news-fullscreen-active .map-legend {
   display: none !important;
 }
 
-body.live-news-fullscreen-active .panels-grid>*:not(.live-news-fullscreen) {
+body.live-news-fullscreen-active .panels-grid > *:not(.live-news-fullscreen) {
   visibility: hidden !important;
 }
 
@@ -2592,7 +2527,6 @@ body.live-news-fullscreen-active .panels-grid>*:not(.live-news-fullscreen) {
 
 /* Mobile: make toolbars swipeable (horizontal scroll) */
 @media (max-width: 768px) {
-
   /* Live News channels */
   .live-news-switcher {
     flex-wrap: nowrap;
@@ -2645,7 +2579,6 @@ body.live-news-fullscreen-active .panels-grid>*:not(.live-news-fullscreen) {
     flex: 0 0 auto;
   }
 }
-
 /* News Items */
 .item {
   padding: 8px 0;
@@ -12651,15 +12584,8 @@ a.prediction-link:hover {
 }
 
 @keyframes globe-beta-pulse {
-
-  0%,
-  100% {
-    box-shadow: 0 0 6px rgba(0, 229, 255, 0.3), 0 0 20px rgba(0, 229, 255, 0.15), inset 0 0 8px rgba(0, 229, 255, 0.05);
-  }
-
-  50% {
-    box-shadow: 0 0 10px rgba(0, 229, 255, 0.5), 0 0 30px rgba(0, 229, 255, 0.25), inset 0 0 12px rgba(0, 229, 255, 0.1);
-  }
+  0%, 100% { box-shadow: 0 0 6px rgba(0, 229, 255, 0.3), 0 0 20px rgba(0, 229, 255, 0.15), inset 0 0 8px rgba(0, 229, 255, 0.05); }
+  50% { box-shadow: 0 0 10px rgba(0, 229, 255, 0.5), 0 0 30px rgba(0, 229, 255, 0.25), inset 0 0 12px rgba(0, 229, 255, 0.1); }
 }
 
 /* deck.gl Controls */
@@ -16710,18 +16636,7 @@ body.has-breaking-alert .panels-grid {
 }
 
 @keyframes globe-pulse {
-  0% {
-    transform: scale(1);
-    opacity: 0.6;
-  }
-
-  70% {
-    transform: scale(2.5);
-    opacity: 0;
-  }
-
-  100% {
-    transform: scale(2.5);
-    opacity: 0;
-  }
+  0%   { transform: scale(1); opacity: 0.6; }
+  70%  { transform: scale(2.5); opacity: 0; }
+  100% { transform: scale(2.5); opacity: 0; }
 }


### PR DESCRIPTION
Reverts koala73/worldmonitor#969 

A simple thing that snuck in : 
  1. Map resizing fixes (c9af929, 3b0e74c, 8805b0c, d44ab97, 15f922b) — map container resize/observation refactors                                                                
  2. Country navigation (247c65c) — CII panel country clicks opening country briefs
  3. 3D Globe toggle added then removed (2eee68b adds it, c465771f removes it — along with the country brief section)                                                             
  **4. Actual PR purpose (49697a9) — search bar in manage channels + Al Jazeera Arabic**                                                                        
  5. Cleanup (b01f62a) — null-safety, translations