### PR TITLE
feat: add search bar to manage channels + AlJazeera Arabic

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -144,6 +144,7 @@ export const OPTIONAL_LIVE_CHANNELS: LiveChannel[] = [
   { id: 'cgtn-arabic', name: 'CGTN Arabic', handle: '@CGTNArabic' },
   { id: 'kan-11', name: 'Kan 11', handle: '@KAN11NEWS', fallbackVideoId: 'TCnaIE_SAtM' },
   { id: 'asharq-news', name: 'Asharq News', handle: '@asharqnews', fallbackVideoId: 'f6VpkfV7m4Y', useFallbackOnly: true },
+  { id: 'aljazeera-arabic', name: 'AlJazeera Arabic', handle: '@AljazeeraChannel', fallbackVideoId: 'bNyUyrR0PHo', useFallbackOnly: true },
   // Africa
   { id: 'africanews', name: 'Africanews', handle: '@africanews' },
   { id: 'channels-tv', name: 'Channels TV', handle: '@ChannelsTelevision' },
@@ -170,7 +171,7 @@ const _REGION_ENTRIES: { key: string; labelKey: string; channelIds: string[] }[]
   { key: 'eu', labelKey: 'components.liveNews.regionEurope', channelIds: ['sky', 'euronews', 'dw', 'france24', 'bbc-news', 'france24-en', 'welt', 'rtve', 'trt-haber', 'ntv-turkey', 'cnn-turk', 'tv-rain', 'rt', 'tvp-info', 'telewizja-republika', 'tagesschau24', 'euronews-fr', 'france24-fr', 'france-info', 'bfmtv', 'tv5monde-info', 'nrk1', 'aljazeera-balkans'] },
   { key: 'latam', labelKey: 'components.liveNews.regionLatinAmerica', channelIds: ['cnn-brasil', 'jovem-pan', 'record-news', 'band-jornalismo', 'tn-argentina', 'c5n', 'milenio', 'noticias-caracol', 'ntn24', 't13'] },
   { key: 'asia', labelKey: 'components.liveNews.regionAsia', channelIds: ['tbs-news', 'ann-news', 'ntv-news', 'cti-news', 'wion', 'ndtv', 'cna-asia', 'nhk-world', 'arirang-news', 'india-today', 'abp-news'] },
-  { key: 'me', labelKey: 'components.liveNews.regionMiddleEast', channelIds: ['alarabiya', 'aljazeera', 'al-hadath', 'sky-news-arabia', 'trt-world', 'iran-intl', 'cgtn-arabic', 'kan-11', 'asharq-news'] },
+  { key: 'me', labelKey: 'components.liveNews.regionMiddleEast', channelIds: ['alarabiya', 'aljazeera', 'al-hadath', 'sky-news-arabia', 'trt-world', 'iran-intl', 'cgtn-arabic', 'kan-11', 'asharq-news', 'aljazeera-arabic'] },
   { key: 'africa', labelKey: 'components.liveNews.regionAfrica', channelIds: ['africanews', 'channels-tv', 'ktn-news', 'enca', 'sabc-news', 'arise-news'] },
   { key: 'oc', labelKey: 'components.liveNews.regionOceania', channelIds: ['abc-news-au'] },
 ];
@@ -243,6 +244,7 @@ const DIRECT_HLS_MAP: Readonly<Record<string, string>> = {
   'sabc-news': 'https://sabconetanw.cdn.mangomolo.com/news/smil:news.stream.smil/chunklist_b250000_t64MjQwcA==.m3u8',
   'arirang-news': 'https://amdlive-ch01-ctnd-com.akamaized.net/arirang_1ch/smil:arirang_1ch.smil/playlist.m3u8',
   'fox-news': 'https://247preview.foxnews.com/hls/live/2020027/fncv3preview/primary.m3u8',
+  'aljazeera-arabic': 'https://live-hls-web-aja.getaj.net/AJA/index.m3u8',
 };
 
 interface ProxiedHlsEntry { url: string; referer: string; }

--- a/src/live-channels-window.ts
+++ b/src/live-channels-window.ts
@@ -79,6 +79,7 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
 
   let channels = loadChannelsFromStorage();
   let suppressRowClick = false;
+  let searchQuery = '';
 
   /** Reads current row order from DOM and persists to storage. */
   function applyOrderFromDom(listEl: HTMLElement): void {
@@ -289,16 +290,28 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
     if (!tabBar || !tabContents) return;
 
     const currentIds = new Set(channels.map((c) => c.id));
+    const term = searchQuery.toLowerCase().trim();
 
     // Render tab buttons
     tabBar.innerHTML = '';
     for (const region of filteredRegions) {
-      const addedCount = region.channelIds.filter((id) => currentIds.has(id)).length;
+      const regionChannels = region.channelIds
+        .map(id => optionalChannelMap.get(id))
+        .filter((ch): ch is LiveChannel => !!ch);
+
+      const matchingChannels = term
+        ? regionChannels.filter(ch => ch.name.toLowerCase().includes(term) || ch.handle.toLowerCase().includes(term))
+        : regionChannels;
+
+      const addedCount = matchingChannels.filter(ch => currentIds.has(ch.id)).length;
+
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.className = 'live-news-manage-tab-btn' + (region.key === activeRegionTab ? ' active' : '');
       const label = t(region.labelKey) ?? region.key.toUpperCase();
-      btn.textContent = addedCount > 0 ? `${label} (${addedCount})` : label;
+      btn.textContent = term
+        ? `${label} (${matchingChannels.length})`
+        : addedCount > 0 ? `${label} (${addedCount})` : label;
       btn.addEventListener('click', () => {
         activeRegionTab = region.key;
         renderAvailableChannels(listEl);
@@ -315,14 +328,24 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
       const grid = document.createElement('div');
       grid.className = 'live-news-manage-card-grid';
 
+      let matchCount = 0;
       for (const chId of region.channelIds) {
         const ch = optionalChannelMap.get(chId);
         if (!ch) continue;
+        if (term && !ch.name.toLowerCase().includes(term) && !ch.handle.toLowerCase().includes(term)) continue;
         const isAdded = currentIds.has(chId);
         grid.appendChild(createCard(ch, isAdded, listEl));
+        matchCount++;
       }
 
-      panel.appendChild(grid);
+      if (matchCount === 0 && term) {
+        const empty = document.createElement('div');
+        empty.className = 'live-news-manage-empty';
+        empty.textContent = (t('components.liveNews.noResults') ?? 'No channels found matching "{{term}}"').replace('{{term}}', term);
+        panel.appendChild(empty);
+      } else {
+        panel.appendChild(grid);
+      }
       tabContents.appendChild(panel);
     }
   }
@@ -387,7 +410,15 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
         </div>
         <div class="live-news-manage-list" id="liveChannelsList"></div>
         <div class="live-news-manage-available-section">
-          <span class="live-news-manage-add-title">${escapeHtml(t('components.liveNews.availableChannels') ?? 'Available channels')}</span>
+          <div class="live-news-manage-available-header">
+            <span class="live-news-manage-add-title">${escapeHtml(t('components.liveNews.availableChannels') ?? 'Available channels')}</span>
+            <div class="live-news-manage-search-wrap">
+              <span class="live-news-manage-search-icon">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+              </span>
+              <input type="text" id="liveChannelsSearch" class="live-news-manage-search-input" placeholder="${escapeHtml(t('header.search') ?? 'Search')}..." autocomplete="off" />
+            </div>
+          </div>
           <div class="live-news-manage-tab-bar" id="liveChannelsTabBar"></div>
           <div class="live-news-manage-tab-contents" id="liveChannelsTabContents"></div>
         </div>
@@ -531,5 +562,13 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
     renderList(listEl);
     if (handleInput) handleInput.value = '';
     if (nameInput) nameInput.value = '';
+  });
+
+  let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+  const searchInput = document.getElementById('liveChannelsSearch') as HTMLInputElement | null;
+  searchInput?.addEventListener('input', (e) => {
+    searchQuery = (e.target as HTMLInputElement).value;
+    if (searchDebounce) clearTimeout(searchDebounce);
+    searchDebounce = setTimeout(() => renderAvailableChannels(listEl), 150);
   });
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1649,6 +1649,7 @@
       "confirmTitle": "Confirm",
       "restoreDefaults": "Restore default channels",
       "availableChannels": "Available channels",
+      "noResults": "No channels found matching \"{{term}}\"",
       "customChannel": "Custom channel",
       "regionAll": "All",
       "regionNorthAmerica": "North America",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1927,6 +1927,68 @@ body.panel-resize-active iframe {
   margin-top: 4px;
 }
 
+.live-news-manage-available-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  gap: 16px;
+}
+
+.live-news-manage-available-header .live-news-manage-add-title {
+  margin-bottom: 0;
+}
+
+.live-news-manage-search-wrap {
+  position: relative;
+  flex: 1;
+  max-width: 240px;
+}
+
+.live-news-manage-search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-dim);
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  opacity: 0.6;
+}
+
+.live-news-manage-search-input {
+  width: 100%;
+  padding: 6px 12px 6px 32px;
+  background: var(--darken-heavy);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.live-news-manage-search-input:focus {
+  border-color: var(--text-dim);
+  background: var(--bg);
+}
+
+.live-news-manage-search-input::placeholder {
+  color: var(--text-dim);
+}
+
+.live-news-manage-empty {
+  padding: 30px 10px;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 14px;
+  background: var(--darken);
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  margin-top: 4px;
+}
+
 /* Tab bar */
 .live-news-manage-tab-bar {
   display: flex;


### PR DESCRIPTION
## Summary
- Add real-time search/filter input for available channels in the manage channels window
- Search filters channels by name and handle with 150ms debounce
- Tab counts update to show matching results when searching
- Empty state shown when no channels match the search term
- Add AlJazeera Arabic channel to Middle East region with HLS stream

## Type of change
- [x] New feature

## Affected areas
- [x] Manage Channels
- [x] News panels / RSS feeds

## Checklist
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Test plan
- [ ] Open manage channels window, verify search input appears next to "Available channels" title
- [ ] Type a channel name (e.g., "cnn") and verify channels filter in real-time
- [ ] Verify tab counts update to show number of matching channels per region
- [ ] Search for a non-existent term and verify empty state message appears
- [ ] Clear search and verify all channels reappear
- [ ] Verify AlJazeera Arabic appears in Middle East region tab