### PR TITLE
feat: mobile hamburger menu with slide-out drawer

### DIFF
--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -82,6 +82,7 @@ export class EventHandlerManager implements AppModule {
   private boundMapEndResizeHandler: (() => void) | null = null;
   private boundMapResizeVisChangeHandler: (() => void) | null = null;
   private boundMapFullscreenEscHandler: ((e: KeyboardEvent) => void) | null = null;
+  private boundMobileMenuKeyHandler: ((e: KeyboardEvent) => void) | null = null;
   private idleTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private snapshotIntervalId: ReturnType<typeof setInterval> | null = null;
   private clockIntervalId: ReturnType<typeof setInterval> | null = null;
@@ -223,6 +224,10 @@ export class EventHandlerManager implements AppModule {
       document.removeEventListener('keydown', this.boundMapFullscreenEscHandler);
       this.boundMapFullscreenEscHandler = null;
     }
+    if (this.boundMobileMenuKeyHandler) {
+      document.removeEventListener('keydown', this.boundMobileMenuKeyHandler);
+      this.boundMobileMenuKeyHandler = null;
+    }
     this.ctx.tvMode?.destroy();
     this.ctx.tvMode = null;
     this.ctx.unifiedSettings?.destroy();
@@ -230,10 +235,12 @@ export class EventHandlerManager implements AppModule {
   }
 
   private setupEventListeners(): void {
-    document.getElementById('searchBtn')?.addEventListener('click', () => {
+    const openSearch = () => {
       this.callbacks.updateSearchIndex();
       this.ctx.searchModal?.open();
-    });
+    };
+    document.getElementById('searchBtn')?.addEventListener('click', openSearch);
+    document.getElementById('mobileSearchBtn')?.addEventListener('click', openSearch);
 
     document.getElementById('copyLinkBtn')?.addEventListener('click', async () => {
       const shareUrl = this.getShareUrl();
@@ -338,8 +345,11 @@ export class EventHandlerManager implements AppModule {
     this.boundThemeChangedHandler = () => {
       this.ctx.map?.render();
       this.updateHeaderThemeIcon();
+      this.updateMobileMenuThemeItem();
     };
     window.addEventListener('theme-changed', this.boundThemeChangedHandler);
+
+    this.setupMobileMenu();
 
     if (this.ctx.isDesktopApp) {
       if (this.boundDesktopExternalLinkHandler) {
@@ -369,6 +379,129 @@ export class EventHandlerManager implements AppModule {
       };
       document.addEventListener('click', this.boundDesktopExternalLinkHandler, true);
     }
+  }
+
+  private setupMobileMenu(): void {
+    const hamburger = document.getElementById('hamburgerBtn');
+    const overlay = document.getElementById('mobileMenuOverlay');
+    const menu = document.getElementById('mobileMenu');
+    const closeBtn = document.getElementById('mobileMenuClose');
+    if (!hamburger || !overlay || !menu || !closeBtn) return;
+
+    hamburger.addEventListener('click', () => this.openMobileMenu());
+    overlay.addEventListener('click', () => this.closeMobileMenu());
+    closeBtn.addEventListener('click', () => this.closeMobileMenu());
+
+    const isLocalDev = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+    menu.querySelectorAll<HTMLButtonElement>('.mobile-menu-variant').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const variant = btn.dataset.variant;
+        if (variant && variant !== SITE_VARIANT) {
+          if (this.ctx.isDesktopApp || isLocalDev) {
+            trackVariantSwitch(SITE_VARIANT, variant);
+            localStorage.setItem('worldmonitor-variant', variant);
+            window.location.reload();
+          } else {
+            const hosts: Record<string, string> = {
+              full: 'https://worldmonitor.app',
+              tech: 'https://tech.worldmonitor.app',
+              finance: 'https://finance.worldmonitor.app',
+              happy: 'https://happy.worldmonitor.app',
+            };
+            if (hosts[variant]) window.location.href = hosts[variant];
+          }
+        }
+      });
+    });
+
+    document.getElementById('mobileMenuRegion')?.addEventListener('click', () => {
+      this.closeMobileMenu();
+      this.openRegionSheet();
+    });
+
+    document.getElementById('mobileMenuSettings')?.addEventListener('click', () => {
+      this.closeMobileMenu();
+      this.ctx.unifiedSettings?.open();
+    });
+
+    document.getElementById('mobileMenuTheme')?.addEventListener('click', () => {
+      this.closeMobileMenu();
+      const next = getCurrentTheme() === 'dark' ? 'light' : 'dark';
+      setTheme(next);
+      this.updateHeaderThemeIcon();
+      trackThemeChanged(next);
+    });
+
+    const sheetBackdrop = document.getElementById('regionSheetBackdrop');
+    sheetBackdrop?.addEventListener('click', () => this.closeRegionSheet());
+
+    const sheet = document.getElementById('regionBottomSheet');
+    sheet?.querySelectorAll<HTMLButtonElement>('.region-sheet-option').forEach(opt => {
+      opt.addEventListener('click', () => {
+        const region = opt.dataset.region;
+        if (!region) return;
+        this.ctx.map?.setView(region as MapView);
+        trackMapViewChange(region);
+        const regionSelect = document.getElementById('regionSelect') as HTMLSelectElement;
+        if (regionSelect) regionSelect.value = region;
+        sheet.querySelectorAll('.region-sheet-option').forEach(o => {
+          o.classList.toggle('active', o === opt);
+          const check = o.querySelector('.region-sheet-check');
+          if (check) check.textContent = o === opt ? '✓' : '';
+        });
+        const menuRegionLabel = document.getElementById('mobileMenuRegion')?.querySelector('.mobile-menu-item-label');
+        if (menuRegionLabel) menuRegionLabel.textContent = opt.querySelector('span')?.textContent ?? '';
+        this.closeRegionSheet();
+      });
+    });
+
+    this.boundMobileMenuKeyHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (sheet?.classList.contains('open')) {
+          this.closeRegionSheet();
+        } else if (menu.classList.contains('open')) {
+          this.closeMobileMenu();
+        }
+      }
+    };
+    document.addEventListener('keydown', this.boundMobileMenuKeyHandler);
+  }
+
+  private openMobileMenu(): void {
+    const overlay = document.getElementById('mobileMenuOverlay');
+    const menu = document.getElementById('mobileMenu');
+    if (!overlay || !menu) return;
+    overlay.classList.add('open');
+    requestAnimationFrame(() => menu.classList.add('open'));
+    document.body.style.overflow = 'hidden';
+  }
+
+  private closeMobileMenu(): void {
+    const overlay = document.getElementById('mobileMenuOverlay');
+    const menu = document.getElementById('mobileMenu');
+    if (!overlay || !menu) return;
+    menu.classList.remove('open');
+    overlay.classList.remove('open');
+    const sheetOpen = document.getElementById('regionBottomSheet')?.classList.contains('open');
+    if (!sheetOpen) document.body.style.overflow = '';
+  }
+
+  private openRegionSheet(): void {
+    const backdrop = document.getElementById('regionSheetBackdrop');
+    const sheet = document.getElementById('regionBottomSheet');
+    if (!backdrop || !sheet) return;
+    backdrop.classList.add('open');
+    requestAnimationFrame(() => sheet.classList.add('open'));
+    document.body.style.overflow = 'hidden';
+  }
+
+  private closeRegionSheet(): void {
+    const backdrop = document.getElementById('regionSheetBackdrop');
+    const sheet = document.getElementById('regionBottomSheet');
+    if (!backdrop || !sheet) return;
+    sheet.classList.remove('open');
+    backdrop.classList.remove('open');
+    document.body.style.overflow = '';
   }
 
   private setupIdleDetection(): void {
@@ -565,6 +698,16 @@ export class EventHandlerManager implements AppModule {
     btn.innerHTML = isDark
       ? '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>'
       : '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>';
+  }
+
+  private updateMobileMenuThemeItem(): void {
+    const btn = document.getElementById('mobileMenuTheme');
+    if (!btn) return;
+    const isDark = getCurrentTheme() === 'dark';
+    const icon = btn.querySelector('.mobile-menu-item-icon');
+    const label = btn.querySelector('.mobile-menu-item-label');
+    if (icon) icon.textContent = isDark ? '☀️' : '🌙';
+    if (label) label.textContent = isDark ? 'Light Mode' : 'Dark Mode';
   }
 
   startHeaderClock(): void {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -117,6 +117,9 @@ export class PanelLayoutManager implements AppModule {
     this.ctx.container.innerHTML = `
       <div class="header">
         <div class="header-left">
+          <button class="hamburger-btn" id="hamburgerBtn" aria-label="Menu">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+          </button>
           <div class="variant-switcher">${(() => {
         const local = this.ctx.isDesktopApp || location.hostname === 'localhost' || location.hostname === '127.0.0.1';
         const vHref = (v: string, prod: string) => local || SITE_VARIANT === v ? '#' : prod;
@@ -185,6 +188,9 @@ export class PanelLayoutManager implements AppModule {
               <option value="oceania">${t('components.deckgl.views.oceania')}</option>
             </select>
           </div>
+          <button class="mobile-search-btn" id="mobileSearchBtn" aria-label="${t('header.search')}">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          </button>
         </div>
         <div class="header-right">
           ${this.ctx.isDesktopApp ? '' : `<div class="download-wrapper" id="downloadWrapper">
@@ -205,6 +211,72 @@ export class PanelLayoutManager implements AppModule {
           ${SITE_VARIANT === 'happy' ? `<button class="tv-mode-btn" id="tvModeBtn" title="TV Mode (Shift+T)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>` : ''}
           <span id="unifiedSettingsMount"></span>
         </div>
+      </div>
+      <div class="mobile-menu-overlay" id="mobileMenuOverlay"></div>
+      <nav class="mobile-menu" id="mobileMenu">
+        <div class="mobile-menu-header">
+          <span class="mobile-menu-title">WORLD MONITOR</span>
+          <button class="mobile-menu-close" id="mobileMenuClose" aria-label="Close menu">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
+        </div>
+        <div class="mobile-menu-divider"></div>
+        ${(() => {
+        const variants = [
+          { key: 'full', icon: '🌍', label: t('header.world') },
+          { key: 'tech', icon: '💻', label: t('header.tech') },
+          { key: 'finance', icon: '📈', label: t('header.finance') },
+        ];
+        if (SITE_VARIANT === 'happy') variants.push({ key: 'happy', icon: '☀️', label: 'Good News' });
+        return variants.map(v =>
+          `<button class="mobile-menu-item mobile-menu-variant ${v.key === SITE_VARIANT ? 'active' : ''}" data-variant="${v.key}">
+            <span class="mobile-menu-item-icon">${v.icon}</span>
+            <span class="mobile-menu-item-label">${v.label}</span>
+            ${v.key === SITE_VARIANT ? '<span class="mobile-menu-check">✓</span>' : ''}
+          </button>`
+        ).join('');
+      })()}
+        <div class="mobile-menu-divider"></div>
+        <button class="mobile-menu-item" id="mobileMenuRegion">
+          <span class="mobile-menu-item-icon">🌐</span>
+          <span class="mobile-menu-item-label">${t('components.deckgl.views.global')}</span>
+          <span class="mobile-menu-chevron">▸</span>
+        </button>
+        <div class="mobile-menu-divider"></div>
+        <button class="mobile-menu-item" id="mobileMenuSettings">
+          <span class="mobile-menu-item-icon">⚙️</span>
+          <span class="mobile-menu-item-label">${t('header.settings')}</span>
+        </button>
+        <button class="mobile-menu-item" id="mobileMenuTheme">
+          <span class="mobile-menu-item-icon">${getCurrentTheme() === 'dark' ? '☀️' : '🌙'}</span>
+          <span class="mobile-menu-item-label">${getCurrentTheme() === 'dark' ? 'Light Mode' : 'Dark Mode'}</span>
+        </button>
+        <a class="mobile-menu-item" href="https://x.com/eliehabib" target="_blank" rel="noopener">
+          <span class="mobile-menu-item-icon"><svg class="x-logo" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></span>
+          <span class="mobile-menu-item-label">@eliehabib</span>
+        </a>
+        <div class="mobile-menu-divider"></div>
+        <div class="mobile-menu-version">v${__APP_VERSION__}</div>
+      </nav>
+      <div class="region-sheet-backdrop" id="regionSheetBackdrop"></div>
+      <div class="region-bottom-sheet" id="regionBottomSheet">
+        <div class="region-sheet-header">${t('header.selectRegion')}</div>
+        <div class="region-sheet-divider"></div>
+        ${[
+        { value: 'global', label: t('components.deckgl.views.global') },
+        { value: 'america', label: t('components.deckgl.views.americas') },
+        { value: 'mena', label: t('components.deckgl.views.mena') },
+        { value: 'eu', label: t('components.deckgl.views.europe') },
+        { value: 'asia', label: t('components.deckgl.views.asia') },
+        { value: 'latam', label: t('components.deckgl.views.latam') },
+        { value: 'africa', label: t('components.deckgl.views.africa') },
+        { value: 'oceania', label: t('components.deckgl.views.oceania') },
+      ].map(r =>
+        `<button class="region-sheet-option ${r.value === 'global' ? 'active' : ''}" data-region="${r.value}">
+          <span>${r.label}</span>
+          <span class="region-sheet-check">${r.value === 'global' ? '✓' : ''}</span>
+        </button>`
+      ).join('')}
       </div>
       <div class="main-content">
         <div class="map-section" id="mapSection">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -139,6 +139,7 @@
     "downloadApp": "Download App",
     "fullscreen": "Fullscreen",
     "pinMap": "Pin map to top",
+    "selectRegion": "Select Region",
     "viewOnGitHub": "View on GitHub",
     "filterSources": "Filter sources...",
     "sourcesEnabled": "{{enabled}}/{{total}} enabled",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9444,6 +9444,308 @@ a.prediction-link:hover {
 }
 
 /* ==========================================================================
+   Mobile Hamburger Menu
+   ========================================================================== */
+
+.hamburger-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  padding: 4px;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mobile-search-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 4px;
+  margin-left: auto;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mobile-menu-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 9999;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  -webkit-tap-highlight-color: transparent;
+  display: none;
+}
+
+.mobile-menu-overlay.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.mobile-menu {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 280px;
+  max-width: 80vw;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  z-index: 10000;
+  transform: translateX(-100%);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  display: none;
+}
+
+.mobile-menu.open {
+  transform: translateX(0);
+}
+
+.mobile-menu-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+}
+
+.mobile-menu-title {
+  font-weight: bold;
+  font-size: 14px;
+  letter-spacing: 2px;
+  color: var(--accent);
+}
+
+.mobile-menu-close {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mobile-menu-close:hover {
+  color: var(--text);
+}
+
+.mobile-menu-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
+.mobile-menu-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 14px 20px;
+  gap: 12px;
+  background: none;
+  border: none;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 14px;
+  cursor: pointer;
+  text-decoration: none;
+  min-height: 44px;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s ease;
+}
+
+.mobile-menu-item:hover {
+  background: var(--overlay-subtle);
+}
+
+.mobile-menu-item:active {
+  background: var(--overlay-medium);
+}
+
+.mobile-menu-item-icon {
+  width: 20px;
+  text-align: center;
+  font-size: 16px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mobile-menu-item-label {
+  flex: 1;
+  text-align: left;
+}
+
+.mobile-menu-check {
+  color: var(--green);
+  font-size: 14px;
+}
+
+.mobile-menu-chevron {
+  color: var(--text-dim);
+  font-size: 12px;
+}
+
+.mobile-menu-item.active {
+  color: var(--green);
+  background: rgba(68, 255, 136, 0.06);
+}
+
+.mobile-menu-version {
+  padding: 16px 20px;
+  font-size: 11px;
+  color: var(--text-ghost);
+}
+
+.region-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 10001;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  -webkit-tap-highlight-color: transparent;
+  display: none;
+}
+
+.region-sheet-backdrop.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.region-bottom-sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  max-height: 60vh;
+  background: var(--surface);
+  border-radius: 16px 16px 0 0;
+  z-index: 10002;
+  transform: translateY(100%);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  display: none;
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+
+.region-bottom-sheet.open {
+  transform: translateY(0);
+}
+
+.region-sheet-header {
+  padding: 16px 20px 12px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  text-align: center;
+}
+
+.region-sheet-divider {
+  height: 1px;
+  background: var(--border);
+}
+
+.region-sheet-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 14px 20px;
+  background: none;
+  border: none;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 15px;
+  cursor: pointer;
+  min-height: 44px;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s ease;
+}
+
+.region-sheet-option:hover {
+  background: var(--overlay-subtle);
+}
+
+.region-sheet-option:active {
+  background: var(--overlay-medium);
+}
+
+.region-sheet-option.active {
+  color: var(--green);
+}
+
+.region-sheet-check {
+  color: var(--green);
+  font-size: 16px;
+  min-width: 20px;
+  text-align: right;
+}
+
+@media (max-width: 768px) {
+  .hamburger-btn {
+    display: flex;
+  }
+
+  .mobile-search-btn {
+    display: flex;
+  }
+
+  .mobile-menu-overlay {
+    display: block;
+  }
+
+  .mobile-menu {
+    display: block;
+  }
+
+  .region-sheet-backdrop {
+    display: block;
+  }
+
+  .region-bottom-sheet {
+    display: block;
+  }
+
+  .variant-switcher,
+  .version,
+  .beta-badge,
+  .credit-link,
+  .github-link,
+  .region-selector,
+  .mobile-settings-btn,
+  .header-right {
+    display: none !important;
+  }
+
+  .header {
+    gap: 8px;
+    padding: 8px 12px;
+  }
+
+  .header-left {
+    flex: 1;
+    gap: 8px;
+  }
+
+  .status-indicator span {
+    display: none;
+  }
+}
+
+/* ==========================================================================
    Mobile Touch Optimization
    ========================================================================== */
 
@@ -9687,46 +9989,7 @@ a.prediction-link:hover {
     display: none !important;
   }
 
-  /* Show only X logo on mobile, hide @eliehabib text */
-  .credit-link .credit-text {
-    display: none;
-  }
-
-  .credit-link .x-logo {
-    display: inline-block;
-  }
-
-  /* Hide GitHub icon on mobile, show settings gear instead */
-  .github-link {
-    display: none !important;
-  }
-
-  .header-right .unified-settings-btn {
-    display: none;
-  }
-
-  .header-center .mobile-settings-btn {
-    display: inline-flex;
-  }
-
-  /* Reduce header clutter on mobile */
-  .header-center {
-    gap: 4px;
-  }
-
-  .focus-select {
-    padding: 6px 20px 6px 8px;
-    font-size: 10px;
-    min-height: 32px;
-    min-width: 80px;
-  }
-
   .focus-label {
-    display: none;
-  }
-
-  /* Hide search button keyboard shortcut on mobile */
-  .search-btn kbd {
     display: none;
   }
 
@@ -9772,28 +10035,8 @@ a.prediction-link:hover {
     right: 8px !important;
   }
 
-  /* Stack header on very small screens */
   .header {
-    flex-wrap: wrap;
     padding: 8px;
-  }
-
-  .header-left,
-  .header-center,
-  .header-right {
-    flex-basis: 100%;
-    justify-content: center;
-  }
-
-  .header-center {
-    order: -1;
-    margin-bottom: 8px;
-  }
-
-  /* Hide non-essential header items */
-  .copy-link-btn,
-  .download-wrapper {
-    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace crowded mobile header (≤768px) with clean hamburger-menu pattern: minimal header row showing ☰ | MONITOR | 🟢 | 🔍
- Add slide-out drawer from left with variant switching, region picker, settings, theme toggle, X profile link, and version
- Add region bottom sheet that slides up from bottom with touch-friendly 44px tap targets
- Remove old mobile header rules (stacking, partial hides) in favor of unified hamburger approach

## Changes
- **`panel-layout.ts`** — Added hamburger button, mobile search icon, slide-out menu nav, and region bottom sheet HTML
- **`event-handlers.ts`** — Wired all interactions: open/close with backdrop/Escape, variant switching (local + production), region selection synced with map, settings/theme/search, scroll lock with guard, theme-changed event sync
- **`main.css`** — 300+ lines of mobile menu styles, media query hiding desktop elements, removed 60 lines of conflicting old mobile rules
- **`en.json`** — Added `header.selectRegion` i18n key

## Test plan
- [ ] Chrome DevTools → iPhone 14 Pro (393×852): verify ☰ | MONITOR | 🟢 | 🔍 header
- [ ] Hamburger opens slide-out menu with smooth 0.3s animation
- [ ] Variant switching works (local: reload, prod: redirect)
- [ ] Region bottom sheet opens from menu, selecting region changes map view
- [ ] Settings opens unified settings panel
- [ ] Theme toggle works and icon/label update on external theme changes
- [ ] Backdrop click / ✕ button / Escape all close menu and sheet
- [ ] Body scroll locked when menu/sheet open
- [ ] Desktop (1920×1080): hamburger hidden, all existing header elements work as before