### PR TITLE
fix: remove smartraveller.gov.au feeds

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -281,7 +281,6 @@ const ALLOWED_DOMAINS = [
   'cointelegraph.com',
   // Security advisories — government travel advisory feeds
   'travel.state.gov',
-  'www.smartraveller.gov.au',
   'www.safetravel.govt.nz',
   // US Embassy security alerts
   'th.usembassy.gov',

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -4353,8 +4353,6 @@ const server = http.createServer(async (req, res) => {
         'feeds.capi24.com',  // News24 redirect destination
         'islandtimes.org',
         'www.atlanticcouncil.org',
-        'smartraveller.gov.au',
-        'www.smartraveller.gov.au',
       ];
       const parsed = new URL(feedUrl);
       // Block deprecated/stale feed domains — stale clients still request these

--- a/src/services/security-advisories.ts
+++ b/src/services/security-advisories.ts
@@ -63,27 +63,6 @@ const ADVISORY_FEEDS: AdvisoryFeed[] = [
     url: 'https://travel.state.gov/_res/rss/TAsTWs.xml',
     parseLevel: parseUsLevel,
   },
-  // Australia (DFAT Smartraveller) — all destinations
-  {
-    name: 'AU Smartraveller',
-    sourceCountry: 'AU',
-    url: 'https://www.smartraveller.gov.au/countries/documents/index.rss',
-    parseLevel: parseAuLevel,
-  },
-  // Australia — Do Not Travel specifically
-  {
-    name: 'AU DNT',
-    sourceCountry: 'AU',
-    url: 'https://www.smartraveller.gov.au/countries/documents/do-not-travel.rss',
-    parseLevel: () => 'do-not-travel',
-  },
-  // Australia — Reconsider
-  {
-    name: 'AU Reconsider',
-    sourceCountry: 'AU',
-    url: 'https://www.smartraveller.gov.au/countries/documents/reconsider-your-need-to-travel.rss',
-    parseLevel: () => 'reconsider',
-  },
   // New Zealand MFAT
   {
     name: 'NZ MFAT',


### PR DESCRIPTION
## Summary
- Remove all AU Smartraveller RSS feed references that were causing persistent 503 errors
- Cleaned from `security-advisories.ts` (3 feed entries), `api/rss-proxy.js` (allowed domain), and `scripts/ais-relay.cjs` (relay allowlist)

## Test plan
- [ ] Verify no console 503 errors for smartraveller URLs on production
- [ ] Confirm other security advisory feeds (US State Dept, NZ MFAT, UK FCDO) still load