### PR TITLE
feat: mobile bottom sheet search with trigger bar

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -260,7 +260,6 @@ export class App {
       playbackControl: null,
       exportPanel: null,
       unifiedSettings: null,
-      mobileWarningModal: null,
       pizzintIndicator: null,
       countryBriefPage: null,
       countryTimeline: null,
@@ -433,7 +432,6 @@ export class App {
 
     // Phase 3: UI setup methods
     this.eventHandlers.startHeaderClock();
-    this.eventHandlers.setupMobileWarning();
     this.eventHandlers.setupPlaybackControl();
     this.eventHandlers.setupStatusPanel();
     this.eventHandlers.setupPizzIntIndicator();

--- a/src/app/app-context.ts
+++ b/src/app/app-context.ts
@@ -13,7 +13,7 @@ import type { CountryTimeline } from '@/components/CountryTimeline';
 import type { PlaybackControl } from '@/components';
 import type { ExportPanel } from '@/utils';
 import type { UnifiedSettings } from '@/components/UnifiedSettings';
-import type { MobileWarningModal, PizzIntIndicator } from '@/components';
+import type { PizzIntIndicator } from '@/components';
 import type { ParsedMapUrlState } from '@/utils';
 import type { PositiveNewsFeedPanel } from '@/components/PositiveNewsFeedPanel';
 import type { CountersPanel } from '@/components/CountersPanel';
@@ -102,7 +102,6 @@ export interface AppContext {
   playbackControl: PlaybackControl | null;
   exportPanel: ExportPanel | null;
   unifiedSettings: UnifiedSettings | null;
-  mobileWarningModal: MobileWarningModal | null;
   pizzintIndicator: PizzIntIndicator | null;
   countryBriefPage: CountryBriefPanel | null;
   countryTimeline: CountryTimeline | null;

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -6,7 +6,6 @@ import type { DashboardSnapshot } from '@/services/storage';
 import {
   PlaybackControl,
   StatusPanel,
-  MobileWarningModal,
   PizzIntIndicator,
   CIIPanel,
   PredictionPanel,
@@ -241,6 +240,11 @@ export class EventHandlerManager implements AppModule {
     };
     document.getElementById('searchBtn')?.addEventListener('click', openSearch);
     document.getElementById('mobileSearchBtn')?.addEventListener('click', openSearch);
+
+    document.getElementById('searchMobileTrigger')?.addEventListener('click', () => {
+      this.callbacks.updateSearchIndex();
+      this.ctx.searchModal?.open();
+    });
 
     document.getElementById('copyLinkBtn')?.addEventListener('click', async () => {
       const shareUrl = this.getShareUrl();
@@ -718,13 +722,6 @@ export class EventHandlerManager implements AppModule {
     };
     tick();
     this.clockIntervalId = setInterval(tick, 1000);
-  }
-
-  setupMobileWarning(): void {
-    if (MobileWarningModal.shouldShow()) {
-      this.ctx.mobileWarningModal = new MobileWarningModal();
-      this.ctx.mobileWarningModal.show();
-    }
   }
 
   setupStatusPanel(): void {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -161,7 +161,7 @@ export class PanelLayoutManager implements AppModule {
               <span class="variant-label">Good News</span>
             </a>` : ''}`;
       })()}</div>
-          <span class="logo">MONITOR</span><span class="version">v${__APP_VERSION__}</span>${BETA_MODE ? '<span class="beta-badge">BETA</span>' : ''}
+          <span class="logo">MONITOR</span><span class="logo-mobile">World Monitor</span><span class="version">v${__APP_VERSION__}</span>${BETA_MODE ? '<span class="beta-badge">BETA</span>' : ''}
           <a href="https://x.com/eliehabib" target="_blank" rel="noopener" class="credit-link">
             <svg class="x-logo" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
             <span class="credit-text">@eliehabib</span>
@@ -302,6 +302,10 @@ export class PanelLayoutManager implements AppModule {
           <div class="map-bottom-grid" id="mapBottomGrid"></div>
         </div>
         <div class="panels-grid" id="panelsGrid"></div>
+        <div class="search-mobile-trigger" id="searchMobileTrigger">
+          <span>\u{1F50D}</span>
+          <span>${t('modals.search.placeholder')}</span>
+        </div>
       </div>
     `;
 

--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -2,6 +2,7 @@ import { escapeHtml } from '@/utils/sanitize';
 import { t } from '@/services/i18n';
 import { trackSearchUsed } from '@/services/analytics';
 import { getAllCommands, type Command } from '@/config/commands';
+import { isMobileDevice } from '@/utils';
 
 interface CommandResult {
   command: Command;
@@ -80,6 +81,8 @@ export class SearchModal {
   private overlay: HTMLElement | null = null;
   private input: HTMLInputElement | null = null;
   private resultsList: HTMLElement | null = null;
+  private chipsContainer: HTMLElement | null = null;
+  private closeTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private sources: SearchableSource[] = [];
   private results: SearchResult[] = [];
   private commandResults: CommandResult[] = [];
@@ -89,10 +92,12 @@ export class SearchModal {
   private onCommand?: (command: Command) => void;
   private placeholder: string;
   private activePanelIds: Set<string> = new Set();
+  private isMobile: boolean;
 
   constructor(container: HTMLElement, options?: SearchModalOptions) {
     this.container = container;
     this.placeholder = options?.placeholder || t('modals.search.placeholder');
+    this.isMobile = isMobileDevice();
     this.loadRecentSearches();
   }
 
@@ -118,21 +123,41 @@ export class SearchModal {
   }
 
   public open(): void {
+    if (this.closeTimeoutId) {
+      clearTimeout(this.closeTimeoutId);
+      this.closeTimeoutId = null;
+      this.overlay?.remove();
+      this.overlay = null;
+    }
     if (this.overlay) return;
+    this.isMobile = isMobileDevice();
     this.createModal();
     this.input?.focus();
     this.showRecentOrEmpty();
+    if (this.isMobile) this.renderChips();
   }
 
   public close(): void {
     if (this.overlay) {
-      this.overlay.remove();
-      this.overlay = null;
-      this.input = null;
-      this.resultsList = null;
-      this.results = [];
-      this.commandResults = [];
-      this.selectedIndex = 0;
+      this.overlay.classList.remove('open');
+      const remove = () => {
+        this.overlay?.remove();
+        this.overlay = null;
+        this.input = null;
+        this.resultsList = null;
+        this.chipsContainer = null;
+        this.results = [];
+        this.commandResults = [];
+        this.selectedIndex = 0;
+      };
+      if (this.isMobile) {
+        this.closeTimeoutId = setTimeout(() => {
+          this.closeTimeoutId = null;
+          remove();
+        }, 300);
+      } else {
+        remove();
+      }
     }
   }
 
@@ -142,34 +167,62 @@ export class SearchModal {
 
   private createModal(): void {
     this.overlay = document.createElement('div');
-    this.overlay.className = 'search-overlay';
-    this.overlay.innerHTML = `
-      <div class="search-modal">
-        <div class="search-header">
-          <span class="search-icon">⌘</span>
-          <input type="text" class="search-input" placeholder="${this.placeholder}" autofocus />
-          <kbd class="search-kbd">ESC</kbd>
-        </div>
-        <div class="search-results"></div>
-        <div class="search-footer">
-          <span><kbd>↑↓</kbd> ${t('modals.search.navigate')}</span>
-          <span><kbd>↵</kbd> ${t('modals.search.select')}</span>
-          <span><kbd>esc</kbd> ${t('modals.search.close')}</span>
-        </div>
-      </div>
-    `;
 
-    this.overlay.addEventListener('click', (e) => {
-      if (e.target === this.overlay) this.close();
-    });
+    if (this.isMobile) {
+      this.overlay.className = 'search-overlay search-mobile';
+      this.overlay.innerHTML = `
+        <div class="search-sheet">
+          <div class="search-sheet-handle"></div>
+          <div class="search-sheet-header">
+            <span class="search-sheet-icon">\u{1F50D}</span>
+            <input type="text" class="search-input" placeholder="${this.placeholder}" autofocus />
+            <button class="search-sheet-cancel">${t('modals.search.close')}</button>
+          </div>
+          <div class="search-sheet-chips"></div>
+          <div class="search-results"></div>
+        </div>
+      `;
+
+      this.overlay.addEventListener('click', (e) => {
+        if (e.target === this.overlay) this.close();
+      });
+
+      this.overlay.querySelector('.search-sheet-cancel')?.addEventListener('click', () => this.close());
+
+      this.chipsContainer = this.overlay.querySelector('.search-sheet-chips');
+
+      this.container.appendChild(this.overlay);
+      requestAnimationFrame(() => this.overlay?.classList.add('open'));
+    } else {
+      this.overlay.className = 'search-overlay';
+      this.overlay.innerHTML = `
+        <div class="search-modal">
+          <div class="search-header">
+            <span class="search-icon">\u2318</span>
+            <input type="text" class="search-input" placeholder="${this.placeholder}" autofocus />
+            <kbd class="search-kbd">ESC</kbd>
+          </div>
+          <div class="search-results"></div>
+          <div class="search-footer">
+            <span><kbd>\u2191\u2193</kbd> ${t('modals.search.navigate')}</span>
+            <span><kbd>\u21B5</kbd> ${t('modals.search.select')}</span>
+            <span><kbd>esc</kbd> ${t('modals.search.close')}</span>
+          </div>
+        </div>
+      `;
+
+      this.overlay.addEventListener('click', (e) => {
+        if (e.target === this.overlay) this.close();
+      });
+
+      this.container.appendChild(this.overlay);
+    }
 
     this.input = this.overlay.querySelector('.search-input');
     this.resultsList = this.overlay.querySelector('.search-results');
 
     this.input?.addEventListener('input', () => this.handleSearch());
     this.input?.addEventListener('keydown', (e) => this.handleKeydown(e));
-
-    this.container.appendChild(this.overlay);
   }
 
   private matchCommands(query: string): CommandResult[] {
@@ -204,6 +257,7 @@ export class SearchModal {
     if (!query) {
       this.commandResults = [];
       this.showRecentOrEmpty();
+      if (this.isMobile) this.renderChips();
       return;
     }
 
@@ -253,6 +307,7 @@ export class SearchModal {
     trackSearchUsed(query.length, this.results.length + this.commandResults.length);
     this.selectedIndex = 0;
     this.renderResults();
+    if (this.isMobile) this.renderChips(query);
   }
 
   private showRecentOrEmpty(): void {
@@ -419,6 +474,40 @@ export class SearchModal {
       el.addEventListener('click', () => {
         const index = parseInt((el as HTMLElement).dataset.index || '0');
         this.selectResult(index);
+      });
+    });
+  }
+
+  private renderChips(query?: string): void {
+    if (!this.chipsContainer) return;
+    if (query && query.length >= 3) {
+      this.chipsContainer.innerHTML = '';
+      return;
+    }
+
+    const chips: { label: string; value: string }[] = [];
+    const commands = getAllCommands();
+    const navCmds = commands.filter(c => c.id.startsWith('country:'));
+    for (const cmd of navCmds.slice(0, 6)) {
+      chips.push({ label: cmd.label, value: cmd.label.toLowerCase() });
+    }
+    const actionCmds = commands.filter(c => c.category === 'actions' || c.category === 'view');
+    for (const cmd of actionCmds.slice(0, 4)) {
+      const label = resolveCommandLabel(cmd);
+      chips.push({ label, value: label.toLowerCase() });
+    }
+
+    this.chipsContainer.innerHTML = chips.map(c =>
+      `<button class="search-chip" data-value="${escapeHtml(c.value)}">${escapeHtml(c.label)}</button>`
+    ).join('');
+
+    this.chipsContainer.querySelectorAll('.search-chip').forEach(el => {
+      el.addEventListener('click', () => {
+        const val = (el as HTMLElement).dataset.value || '';
+        if (this.input) {
+          this.input.value = val;
+          this.handleSearch();
+        }
       });
     });
   }

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -425,6 +425,13 @@ export class UnifiedSettings {
     }
     html += `</select>`;
 
+    // Community section
+    html += `<div class="ai-flow-section-label">${t('components.community.sectionLabel')}</div>`;
+    html += `<a href="https://github.com/koala73/worldmonitor/discussions/94" target="_blank" rel="noopener" class="us-discussion-link">
+      <span class="us-discussion-dot"></span>
+      <span>${t('components.community.joinDiscussion')}</span>
+    </a>`;
+
     // AI status footer (web-only)
     if (!this.config.isDesktopApp) {
       html += `<div class="ai-flow-popup-footer"><span class="ai-flow-status-dot" id="usStatusDot"></span><span class="ai-flow-status-text" id="usStatusText"></span></div>`;

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -855,7 +855,8 @@
     "community": {
       "joinDiscussion": "انضم إلى النقاش",
       "openDiscussion": "فتح النقاش",
-      "dontShowAgain": "عدم العرض مجدداً"
+      "dontShowAgain": "عدم العرض مجدداً",
+      "sectionLabel": "المجتمع"
     },
     "threatLabels": {
       "critical": "حرج",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -936,7 +936,8 @@
     "community": {
       "joinDiscussion": "Join the Discussion",
       "openDiscussion": "Open Discussion",
-      "dontShowAgain": "Don't show again"
+      "dontShowAgain": "Don't show again",
+      "sectionLabel": "Community"
     },
     "threatLabels": {
       "critical": "CRIT",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -372,6 +372,14 @@ canvas,
   color: var(--accent);
 }
 
+.logo-mobile {
+  display: none;
+  font-weight: bold;
+  font-size: 14px;
+  letter-spacing: 2px;
+  color: var(--accent);
+}
+
 .version {
   font-size: 9px;
   color: var(--muted);
@@ -8207,6 +8215,153 @@ a.prediction-link:hover {
   margin-right: 4px;
 }
 
+/* Mobile search trigger bar — hidden on desktop */
+.search-mobile-trigger {
+  display: none;
+}
+
+/* Mobile bottom sheet search */
+.search-overlay.search-mobile {
+  align-items: flex-end;
+  padding-top: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.search-overlay.search-mobile .search-sheet {
+  width: 100%;
+  max-height: 75vh;
+  background: var(--surface);
+  border-radius: 16px 16px 0 0;
+  display: flex;
+  flex-direction: column;
+  transform: translateY(100%);
+  transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.search-overlay.search-mobile.open .search-sheet {
+  transform: translateY(0);
+}
+
+.search-sheet-handle {
+  width: 36px;
+  height: 4px;
+  background: var(--text-dim);
+  opacity: 0.4;
+  border-radius: 2px;
+  margin: 8px auto;
+}
+
+.search-sheet-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px 12px;
+}
+
+.search-sheet-icon {
+  font-size: 16px;
+}
+
+.search-sheet-header .search-input {
+  flex: 1;
+  font-size: 15px;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-family: inherit;
+  outline: none;
+}
+
+.search-sheet-cancel {
+  background: none;
+  border: none;
+  color: var(--accent, #4488ff);
+  font-size: 14px;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 4px 8px;
+  white-space: nowrap;
+}
+
+.search-sheet-chips {
+  display: flex;
+  gap: 6px;
+  padding: 0 16px 10px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.search-sheet-chips::-webkit-scrollbar {
+  display: none;
+}
+
+.search-chip {
+  flex-shrink: 0;
+  padding: 6px 14px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.search-chip:active {
+  background: var(--border);
+}
+
+@media (max-width: 768px) {
+  .search-mobile-trigger {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    position: fixed;
+    bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+    left: 16px;
+    right: 16px;
+    padding: 12px 18px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 28px;
+    box-shadow: 0 4px 20px var(--shadow-color);
+    color: var(--text-dim);
+    font-size: 14px;
+    cursor: pointer;
+    z-index: 500;
+  }
+
+  .search-mobile-trigger:active {
+    background: var(--bg);
+  }
+
+  .search-btn {
+    display: none !important;
+  }
+
+  .search-overlay.search-mobile .search-results {
+    max-height: calc(75vh - 120px);
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .search-overlay.search-mobile .search-result-item {
+    min-height: 48px;
+    padding: 12px 16px;
+  }
+
+  .search-overlay.search-mobile .search-result-title {
+    font-size: 14px;
+  }
+
+  .search-overlay.search-mobile .search-section-header {
+    font-size: 11px;
+    padding: 10px 16px;
+  }
+}
+
 /* Flight Delay Markers */
 .flight-delay-marker {
   position: absolute;
@@ -9838,6 +9993,7 @@ a.prediction-link:hover {
     flex-direction: column;
     gap: 8px;
     padding: 8px;
+    padding-bottom: 72px;
   }
 
   body {
@@ -9986,6 +10142,30 @@ a.prediction-link:hover {
   .pizzint-indicator,
   .focus-label,
   .focus-select {
+    display: none !important;
+  }
+
+  /* Mobile: show "World Monitor" instead of "MONITOR" */
+  .logo {
+    display: none;
+  }
+
+  .logo-mobile {
+    display: inline;
+  }
+
+  /* Mobile: hide "Global Situation" panel title */
+  .map-section .panel-title {
+    display: none;
+  }
+
+  /* Mobile: hide the UTC clock */
+  .header-clock {
+    display: none !important;
+  }
+
+  /* Mobile: hide community discussion widget (accessible via settings) */
+  .community-widget {
     display: none !important;
   }
 
@@ -14216,6 +14396,35 @@ a.prediction-link:hover {
 .ai-flow-cta-link:hover {
   color: #93c5fd;
   text-decoration: underline;
+}
+
+/* Discussion link in settings */
+.us-discussion-link {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: var(--overlay-subtle);
+  border: 1px solid var(--border);
+  color: var(--text);
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 500;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.us-discussion-link:hover {
+  border-color: hsl(229, 48%, 55%);
+  background: rgba(99, 120, 198, 0.1);
+}
+
+.us-discussion-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: hsl(229, 48%, 55%);
+  flex-shrink: 0;
 }
 
 /* Footer status */


### PR DESCRIPTION
## Summary
- Replace desktop-only Cmd+K search modal with a native bottom sheet on mobile (<768px)
- Add fixed pill-shaped trigger bar at screen bottom that opens the search sheet
- Suggestion chips for quick access to countries/commands, hidden when query >= 3 chars
- 48px touch targets, slide-up animation with cubic-bezier easing, Cancel + backdrop dismiss
- Remove deprecated `MobileWarningModal` (replaced by this native search experience)
- Add community discussion link in unified settings panel
- Improve mobile header: show "World Monitor" logo, hide UTC clock and panel title

## Test plan
- [ ] Desktop: Cmd+K still opens centered modal (unchanged behavior)
- [ ] Mobile (resize to <768px): Trigger bar visible at bottom, tapping opens bottom sheet
- [ ] Typing shows results with 48px rows, chips disappear at 3+ chars
- [ ] Cancel button and backdrop tap both dismiss the sheet with slide-down animation
- [ ] Rapid close→open (tap Cancel then immediately tap trigger) works without delay
- [ ] Last panel in grid is not obscured by the trigger bar (72px bottom padding)
- [ ] `npx tsc --noEmit` passes clean