### PR TITLE
feat: seed-first pattern for 15 RPC handlers + Railway seed scripts

### DIFF
--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -1,0 +1,115 @@
+import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { validateApiKey } from './_api-key.js';
+
+export const config = { runtime: 'edge' };
+
+const SEED_DOMAINS = {
+  // Phase 1 — Snapshot endpoints
+  'seismology:earthquakes':   { key: 'seed-meta:seismology:earthquakes',   intervalMin: 15 },
+  'wildfire:fires':           { key: 'seed-meta:wildfire:fires',           intervalMin: 30 },
+  'infra:outages':            { key: 'seed-meta:infra:outages',            intervalMin: 15 },
+  'climate:anomalies':        { key: 'seed-meta:climate:anomalies',        intervalMin: 60 },
+  // Phase 2 — Parameterized endpoints
+  'unrest:events':            { key: 'seed-meta:unrest:events',            intervalMin: 15 },
+  'cyber:threats':            { key: 'seed-meta:cyber:threats',            intervalMin: 120 },
+  // market:quotes and market:commodities seeded by ais-relay (separate monitoring)
+  'market:crypto':            { key: 'seed-meta:market:crypto',            intervalMin: 10 },
+  'market:etf-flows':         { key: 'seed-meta:market:etf-flows',         intervalMin: 30 },
+  'market:gulf-quotes':       { key: 'seed-meta:market:gulf-quotes',       intervalMin: 15 },
+  'market:stablecoins':       { key: 'seed-meta:market:stablecoins',       intervalMin: 30 },
+  // Phase 3 — Hybrid endpoints
+  'natural:events':           { key: 'seed-meta:natural:events',           intervalMin: 30 },
+  'displacement:summary':     { key: 'seed-meta:displacement:summary',     intervalMin: 360 },
+};
+
+async function getMetaBatch(keys) {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return new Map();
+
+  const pipeline = keys.map((k) => ['GET', k]);
+  const resp = await fetch(`${url}/pipeline`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(pipeline),
+    signal: AbortSignal.timeout(3000),
+  });
+  if (!resp.ok) return new Map();
+
+  const data = await resp.json();
+  const result = new Map();
+  for (let i = 0; i < keys.length; i++) {
+    const raw = data[i]?.result;
+    if (raw) {
+      try { result.set(keys[i], JSON.parse(raw)); } catch { /* skip */ }
+    }
+  }
+  return result;
+}
+
+export default async function handler(req) {
+  if (isDisallowedOrigin(req))
+    return new Response('Forbidden', { status: 403 });
+
+  const cors = getCorsHeaders(req);
+  if (req.method === 'OPTIONS')
+    return new Response(null, { status: 204, headers: cors });
+
+  const apiKeyResult = validateApiKey(req);
+  if (apiKeyResult.required && !apiKeyResult.valid)
+    return new Response(JSON.stringify({ error: apiKeyResult.error }), {
+      status: 401, headers: { ...cors, 'Content-Type': 'application/json' },
+    });
+
+  const now = Date.now();
+  const entries = Object.entries(SEED_DOMAINS);
+  const metaKeys = entries.map(([, v]) => v.key);
+
+  let metaMap;
+  try {
+    metaMap = await getMetaBatch(metaKeys);
+  } catch {
+    return new Response(JSON.stringify({ error: 'Redis unavailable' }), {
+      status: 503, headers: { ...cors, 'Content-Type': 'application/json' },
+    });
+  }
+
+  const seeds = {};
+  let staleCount = 0;
+  let missingCount = 0;
+
+  for (const [domain, cfg] of entries) {
+    const meta = metaMap.get(cfg.key);
+    const maxStalenessMs = cfg.intervalMin * 2 * 60 * 1000;
+
+    if (!meta) {
+      seeds[domain] = { status: 'missing', fetchedAt: null, recordCount: null, stale: true };
+      missingCount++;
+      continue;
+    }
+
+    const ageMs = now - (meta.fetchedAt || 0);
+    const stale = ageMs > maxStalenessMs;
+    if (stale) staleCount++;
+
+    seeds[domain] = {
+      status: stale ? 'stale' : 'ok',
+      fetchedAt: meta.fetchedAt,
+      recordCount: meta.recordCount ?? null,
+      sourceVersion: meta.sourceVersion || null,
+      ageMinutes: Math.round(ageMs / 60000),
+      stale,
+    };
+  }
+
+  const overall = missingCount > 0 ? 'degraded' : staleCount > 0 ? 'warning' : 'healthy';
+
+  return new Response(JSON.stringify({ overall, seeds, checkedAt: now }), {
+    status: 200,
+    headers: {
+      ...cors,
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-cache',
+    },
+  });
+}

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+const MAX_PAYLOAD_BYTES = 5 * 1024 * 1024; // 5MB per key
+
+export { CHROME_UA };
+
+export function loadEnvFile(metaUrl) {
+  const __dirname = metaUrl ? dirname(fileURLToPath(metaUrl)) : process.cwd();
+  const candidates = [
+    join(__dirname, '..', '.env.local'),
+    join(__dirname, '..', '..', '.env.local'),
+  ];
+  if (process.env.HOME) {
+    candidates.push(join(process.env.HOME, 'Documents/GitHub/worldmonitor', '.env.local'));
+  }
+  for (const envPath of candidates) {
+    if (!existsSync(envPath)) continue;
+    const lines = readFileSync(envPath, 'utf8').split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eqIdx = trimmed.indexOf('=');
+      if (eqIdx === -1) continue;
+      const key = trimmed.slice(0, eqIdx).trim();
+      let val = trimmed.slice(eqIdx + 1).trim();
+      if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+        val = val.slice(1, -1);
+      }
+      if (!process.env[key]) process.env[key] = val;
+    }
+    return;
+  }
+}
+
+export function maskToken(token) {
+  if (!token || token.length < 8) return '***';
+  return token.slice(0, 4) + '***' + token.slice(-4);
+}
+
+export function getRedisCredentials() {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    console.error('Missing UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN');
+    process.exit(1);
+  }
+  return { url, token };
+}
+
+async function redisCommand(url, token, command) {
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(command),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    throw new Error(`Redis command failed: HTTP ${resp.status} — ${text.slice(0, 200)}`);
+  }
+  return resp.json();
+}
+
+async function redisGet(url, token, key) {
+  const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!resp.ok) return null;
+  const data = await resp.json();
+  return data.result ? JSON.parse(data.result) : null;
+}
+
+async function redisSet(url, token, key, value, ttlSeconds) {
+  const payload = JSON.stringify(value);
+  const cmd = ttlSeconds
+    ? ['SET', key, payload, 'EX', ttlSeconds]
+    : ['SET', key, payload];
+  return redisCommand(url, token, cmd);
+}
+
+async function redisDel(url, token, key) {
+  return redisCommand(url, token, ['DEL', key]);
+}
+
+export async function acquireLock(domain, runId, ttlMs) {
+  const { url, token } = getRedisCredentials();
+  const lockKey = `seed-lock:${domain}`;
+  const result = await redisCommand(url, token, ['SET', lockKey, runId, 'NX', 'PX', ttlMs]);
+  return result?.result === 'OK';
+}
+
+export async function releaseLock(domain, runId) {
+  const { url, token } = getRedisCredentials();
+  const lockKey = `seed-lock:${domain}`;
+  const script = `if redis.call("get",KEYS[1]) == ARGV[1] then return redis.call("del",KEYS[1]) else return 0 end`;
+  try {
+    await redisCommand(url, token, ['EVAL', script, 1, lockKey, runId]);
+  } catch {
+    // Best-effort release; lock will expire via TTL
+  }
+}
+
+export async function atomicPublish(canonicalKey, data, validateFn, ttlSeconds) {
+  const { url, token } = getRedisCredentials();
+  const runId = String(Date.now());
+  const stagingKey = `${canonicalKey}:staging:${runId}`;
+
+  const payload = JSON.stringify(data);
+  const payloadBytes = Buffer.byteLength(payload, 'utf8');
+  if (payloadBytes > MAX_PAYLOAD_BYTES) {
+    throw new Error(`Payload too large: ${(payloadBytes / 1024 / 1024).toFixed(1)}MB > 5MB limit`);
+  }
+
+  if (validateFn) {
+    const valid = validateFn(data);
+    if (!valid) throw new Error('Validation failed for seed data');
+  }
+
+  // Write to staging key
+  await redisSet(url, token, stagingKey, data, 300); // 5 min staging TTL
+
+  // Overwrite canonical key
+  if (ttlSeconds) {
+    await redisCommand(url, token, ['SET', canonicalKey, payload, 'EX', ttlSeconds]);
+  } else {
+    await redisCommand(url, token, ['SET', canonicalKey, payload]);
+  }
+
+  // Cleanup staging
+  await redisDel(url, token, stagingKey).catch(() => {});
+
+  return { payloadBytes, recordCount: Array.isArray(data) ? data.length : null };
+}
+
+export async function writeFreshnessMetadata(domain, resource, count, source) {
+  const { url, token } = getRedisCredentials();
+  const metaKey = `seed-meta:${domain}:${resource}`;
+  const meta = {
+    fetchedAt: Date.now(),
+    recordCount: count,
+    sourceVersion: source || '',
+  };
+  await redisSet(url, token, metaKey, meta, 86400 * 7); // 7 day TTL on metadata
+  return meta;
+}
+
+export async function withRetry(fn, maxRetries = 3, delayMs = 1000) {
+  let lastErr;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt < maxRetries) {
+        const wait = delayMs * Math.pow(2, attempt);
+        console.warn(`  Retry ${attempt + 1}/${maxRetries} in ${wait}ms: ${err.message || err}`);
+        await new Promise(r => setTimeout(r, wait));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+export function logSeedResult(domain, count, durationMs, extra = {}) {
+  console.log(JSON.stringify({
+    event: 'seed_complete',
+    domain,
+    recordCount: count,
+    durationMs: Math.round(durationMs),
+    timestamp: new Date().toISOString(),
+    ...extra,
+  }));
+}
+
+export async function verifySeedKey(key) {
+  const { url, token } = getRedisCredentials();
+  const data = await redisGet(url, token, key);
+  return data;
+}
+
+export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}) {
+  const { validateFn, ttlSeconds, lockTtlMs = 120_000 } = opts;
+  const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const startMs = Date.now();
+
+  console.log(`=== ${domain}:${resource} Seed ===`);
+  console.log(`  Run ID:  ${runId}`);
+  console.log(`  Key:     ${canonicalKey}`);
+
+  // Acquire lock
+  const locked = await acquireLock(`${domain}:${resource}`, runId, lockTtlMs);
+  if (!locked) {
+    console.log('  SKIPPED: another seed run in progress');
+    return { skipped: true };
+  }
+
+  try {
+    const data = await withRetry(fetchFn);
+    const { payloadBytes } = await atomicPublish(canonicalKey, data, validateFn, ttlSeconds);
+    const recordCount = Array.isArray(data) ? data.length
+      : (data?.events?.length ?? data?.earthquakes?.length ?? data?.outages?.length
+        ?? data?.fireDetections?.length ?? data?.anomalies?.length ?? data?.threats?.length ?? 0);
+
+    const meta = await writeFreshnessMetadata(domain, resource, recordCount, opts.sourceVersion);
+
+    const durationMs = Date.now() - startMs;
+    logSeedResult(domain, recordCount, durationMs, { payloadBytes });
+
+    // Verify
+    const verified = await verifySeedKey(canonicalKey);
+    if (verified) {
+      console.log(`  Verified: data present in Redis`);
+    } else {
+      console.warn('  WARNING: verification read returned null');
+    }
+
+    console.log(`\n=== Done (${Math.round(durationMs)}ms) ===`);
+    return { success: true, recordCount, durationMs, meta };
+  } finally {
+    await releaseLock(`${domain}:${resource}`, runId);
+  }
+}

--- a/scripts/seed-climate-anomalies.mjs
+++ b/scripts/seed-climate-anomalies.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY = 'climate:anomalies:v1';
+const CACHE_TTL = 10800; // 3h
+
+const ZONES = [
+  { name: 'Ukraine', lat: 48.4, lon: 31.2 },
+  { name: 'Middle East', lat: 33.0, lon: 44.0 },
+  { name: 'Sahel', lat: 14.0, lon: 0.0 },
+  { name: 'Horn of Africa', lat: 8.0, lon: 42.0 },
+  { name: 'South Asia', lat: 25.0, lon: 78.0 },
+  { name: 'California', lat: 36.8, lon: -119.4 },
+  { name: 'Amazon', lat: -3.4, lon: -60.0 },
+  { name: 'Australia', lat: -25.0, lon: 134.0 },
+  { name: 'Mediterranean', lat: 38.0, lon: 20.0 },
+  { name: 'Taiwan Strait', lat: 24.0, lon: 120.0 },
+  { name: 'Myanmar', lat: 19.8, lon: 96.7 },
+  { name: 'Central Africa', lat: 4.0, lon: 22.0 },
+  { name: 'Southern Africa', lat: -25.0, lon: 28.0 },
+  { name: 'Central Asia', lat: 42.0, lon: 65.0 },
+  { name: 'Caribbean', lat: 19.0, lon: -72.0 },
+];
+
+function avg(arr) {
+  return arr.length ? arr.reduce((s, v) => s + v, 0) / arr.length : 0;
+}
+
+function classifySeverity(tempDelta, precipDelta) {
+  const absTemp = Math.abs(tempDelta);
+  const absPrecip = Math.abs(precipDelta);
+  if (absTemp >= 5 || absPrecip >= 80) return 'ANOMALY_SEVERITY_EXTREME';
+  if (absTemp >= 3 || absPrecip >= 40) return 'ANOMALY_SEVERITY_MODERATE';
+  return 'ANOMALY_SEVERITY_NORMAL';
+}
+
+function classifyType(tempDelta, precipDelta) {
+  const absTemp = Math.abs(tempDelta);
+  const absPrecip = Math.abs(precipDelta);
+  if (absTemp >= absPrecip / 20) {
+    if (tempDelta > 0 && precipDelta < -20) return 'ANOMALY_TYPE_MIXED';
+    if (tempDelta > 3) return 'ANOMALY_TYPE_WARM';
+    if (tempDelta < -3) return 'ANOMALY_TYPE_COLD';
+  }
+  if (precipDelta > 40) return 'ANOMALY_TYPE_WET';
+  if (precipDelta < -40) return 'ANOMALY_TYPE_DRY';
+  if (tempDelta > 0) return 'ANOMALY_TYPE_WARM';
+  return 'ANOMALY_TYPE_COLD';
+}
+
+async function fetchZone(zone, startDate, endDate) {
+  const url = `https://archive-api.open-meteo.com/v1/archive?latitude=${zone.lat}&longitude=${zone.lon}&start_date=${startDate}&end_date=${endDate}&daily=temperature_2m_mean,precipitation_sum&timezone=UTC`;
+
+  const resp = await fetch(url, {
+    headers: { 'User-Agent': CHROME_UA },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!resp.ok) throw new Error(`Open-Meteo ${resp.status} for ${zone.name}`);
+
+  const data = await resp.json();
+
+  const rawTemps = data.daily?.temperature_2m_mean ?? [];
+  const rawPrecips = data.daily?.precipitation_sum ?? [];
+  const temps = [];
+  const precips = [];
+  for (let i = 0; i < rawTemps.length; i++) {
+    if (rawTemps[i] != null && rawPrecips[i] != null) {
+      temps.push(rawTemps[i]);
+      precips.push(rawPrecips[i]);
+    }
+  }
+
+  if (temps.length < 14) return null;
+
+  const recentTemps = temps.slice(-7);
+  const baselineTemps = temps.slice(0, -7);
+  const recentPrecips = precips.slice(-7);
+  const baselinePrecips = precips.slice(0, -7);
+
+  const tempDelta = Math.round((avg(recentTemps) - avg(baselineTemps)) * 10) / 10;
+  const precipDelta = Math.round((avg(recentPrecips) - avg(baselinePrecips)) * 10) / 10;
+
+  return {
+    zone: zone.name,
+    location: { latitude: zone.lat, longitude: zone.lon },
+    tempDelta,
+    precipDelta,
+    severity: classifySeverity(tempDelta, precipDelta),
+    type: classifyType(tempDelta, precipDelta),
+    period: `${startDate} to ${endDate}`,
+  };
+}
+
+async function fetchClimateAnomalies() {
+  const endDate = new Date().toISOString().slice(0, 10);
+  const startDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+  const results = await Promise.allSettled(
+    ZONES.map((zone) => fetchZone(zone, startDate, endDate)),
+  );
+
+  const anomalies = [];
+  for (const r of results) {
+    if (r.status === 'fulfilled') {
+      if (r.value != null) anomalies.push(r.value);
+    } else {
+      console.error(`  [CLIMATE] ${r.reason?.message ?? r.reason}`);
+    }
+  }
+
+  return { anomalies, pagination: undefined };
+}
+
+function validate(data) {
+  return Array.isArray(data?.anomalies) && data.anomalies.length >= 1;
+}
+
+runSeed('climate', 'anomalies', CANONICAL_KEY, fetchClimateAnomalies, {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: 'open-meteo-archive-30d',
+}).catch((err) => {
+  console.error('FATAL:', err.message || err);
+  process.exit(1);
+});

--- a/scripts/seed-crypto-quotes.mjs
+++ b/scripts/seed-crypto-quotes.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY = 'market:crypto:v1';
+const CACHE_TTL = 3600; // 1 hour
+
+const CRYPTO_IDS = ['bitcoin', 'ethereum', 'solana', 'ripple'];
+const CRYPTO_META = {
+  bitcoin: { name: 'Bitcoin', symbol: 'BTC' },
+  ethereum: { name: 'Ethereum', symbol: 'ETH' },
+  solana: { name: 'Solana', symbol: 'SOL' },
+  ripple: { name: 'XRP', symbol: 'XRP' },
+};
+
+async function fetchCryptoQuotes() {
+  const ids = CRYPTO_IDS.join(',');
+  const url = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=${ids}&order=market_cap_desc&sparkline=true&price_change_percentage=24h`;
+  const resp = await fetch(url, {
+    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) throw new Error(`CoinGecko HTTP ${resp.status}`);
+
+  const data = await resp.json();
+  if (!Array.isArray(data) || data.length === 0) {
+    throw new Error('CoinGecko returned no data');
+  }
+
+  const byId = new Map(data.map((c) => [c.id, c]));
+  const quotes = [];
+
+  for (const id of CRYPTO_IDS) {
+    const coin = byId.get(id);
+    if (!coin) continue;
+    const meta = CRYPTO_META[id];
+    const prices = coin.sparkline_in_7d?.price;
+    const sparkline = prices && prices.length > 24 ? prices.slice(-48) : (prices || []);
+
+    quotes.push({
+      name: meta?.name || id,
+      symbol: meta?.symbol || id.toUpperCase(),
+      price: coin.current_price ?? 0,
+      change: coin.price_change_percentage_24h ?? 0,
+      sparkline,
+    });
+  }
+
+  if (quotes.every((q) => q.price === 0)) {
+    throw new Error('CoinGecko returned all-zero prices');
+  }
+
+  return { quotes };
+}
+
+function validate(data) {
+  return (
+    Array.isArray(data?.quotes) &&
+    data.quotes.length >= 1 &&
+    data.quotes.some((q) => q.price > 0)
+  );
+}
+
+runSeed('market', 'crypto', CANONICAL_KEY, fetchCryptoQuotes, {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: 'coingecko-markets',
+}).catch((err) => {
+  console.error('FATAL:', err.message || err);
+  process.exit(1);
+});

--- a/scripts/seed-cyber-threats.mjs
+++ b/scripts/seed-cyber-threats.mjs
@@ -1,0 +1,578 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY = 'cyber:threats:v2';
+const BOOTSTRAP_KEY = 'cyber:threats-bootstrap:v2';
+const CACHE_TTL = 7200; // 2 hours
+
+const FEODO_URL = 'https://feodotracker.abuse.ch/downloads/ipblocklist.json';
+const URLHAUS_RECENT_URL = (limit) => `https://urlhaus-api.abuse.ch/v1/urls/recent/limit/${limit}/`;
+const C2INTEL_URL = 'https://raw.githubusercontent.com/drb-ra/C2IntelFeeds/master/feeds/IPC2s-30day.csv';
+const OTX_INDICATORS_URL = 'https://otx.alienvault.com/api/v1/indicators/export?type=IPv4&modified_since=';
+const ABUSEIPDB_BLACKLIST_URL = 'https://api.abuseipdb.com/api/v2/blacklist';
+
+const UPSTREAM_TIMEOUT_MS = 10_000;
+const MAX_LIMIT = 1000;
+const DEFAULT_DAYS = 14;
+const MAX_CACHED_THREATS = 2000;
+const GEO_MAX_UNRESOLVED = 200;
+const GEO_CONCURRENCY = 12;
+const GEO_OVERALL_TIMEOUT_MS = 15_000;
+const GEO_PER_IP_TIMEOUT_MS = 2000;
+
+const THREAT_TYPE_MAP = {
+  c2_server: 'CYBER_THREAT_TYPE_C2_SERVER',
+  malware_host: 'CYBER_THREAT_TYPE_MALWARE_HOST',
+  phishing: 'CYBER_THREAT_TYPE_PHISHING',
+  malicious_url: 'CYBER_THREAT_TYPE_MALICIOUS_URL',
+};
+
+const SOURCE_MAP = {
+  feodo: 'CYBER_THREAT_SOURCE_FEODO',
+  urlhaus: 'CYBER_THREAT_SOURCE_URLHAUS',
+  c2intel: 'CYBER_THREAT_SOURCE_C2INTEL',
+  otx: 'CYBER_THREAT_SOURCE_OTX',
+  abuseipdb: 'CYBER_THREAT_SOURCE_ABUSEIPDB',
+};
+
+const INDICATOR_TYPE_MAP = {
+  ip: 'CYBER_THREAT_INDICATOR_TYPE_IP',
+  domain: 'CYBER_THREAT_INDICATOR_TYPE_DOMAIN',
+  url: 'CYBER_THREAT_INDICATOR_TYPE_URL',
+};
+
+const SEVERITY_MAP = {
+  low: 'CRITICALITY_LEVEL_LOW',
+  medium: 'CRITICALITY_LEVEL_MEDIUM',
+  high: 'CRITICALITY_LEVEL_HIGH',
+  critical: 'CRITICALITY_LEVEL_CRITICAL',
+};
+
+const SEVERITY_RANK = {
+  CRITICALITY_LEVEL_CRITICAL: 4,
+  CRITICALITY_LEVEL_HIGH: 3,
+  CRITICALITY_LEVEL_MEDIUM: 2,
+  CRITICALITY_LEVEL_LOW: 1,
+  CRITICALITY_LEVEL_UNSPECIFIED: 0,
+};
+
+const COUNTRY_CENTROIDS = {
+  US:[39.8,-98.6],CA:[56.1,-106.3],MX:[23.6,-102.6],BR:[-14.2,-51.9],AR:[-38.4,-63.6],
+  GB:[55.4,-3.4],DE:[51.2,10.5],FR:[46.2,2.2],IT:[41.9,12.6],ES:[40.5,-3.7],
+  NL:[52.1,5.3],BE:[50.5,4.5],SE:[60.1,18.6],NO:[60.5,8.5],FI:[61.9,25.7],
+  DK:[56.3,9.5],PL:[51.9,19.1],CZ:[49.8,15.5],AT:[47.5,14.6],CH:[46.8,8.2],
+  PT:[39.4,-8.2],IE:[53.1,-8.2],RO:[45.9,25.0],HU:[47.2,19.5],BG:[42.7,25.5],
+  HR:[45.1,15.2],SK:[48.7,19.7],UA:[48.4,31.2],RU:[61.5,105.3],BY:[53.7,28.0],
+  TR:[39.0,35.2],GR:[39.1,21.8],RS:[44.0,21.0],CN:[35.9,104.2],JP:[36.2,138.3],
+  KR:[35.9,127.8],IN:[20.6,79.0],PK:[30.4,69.3],BD:[23.7,90.4],ID:[-0.8,113.9],
+  TH:[15.9,101.0],VN:[14.1,108.3],PH:[12.9,121.8],MY:[4.2,101.9],SG:[1.4,103.8],
+  TW:[23.7,121.0],HK:[22.4,114.1],AU:[-25.3,133.8],NZ:[-40.9,174.9],
+  ZA:[-30.6,22.9],NG:[9.1,8.7],EG:[26.8,30.8],KE:[-0.02,37.9],ET:[9.1,40.5],
+  MA:[31.8,-7.1],DZ:[28.0,1.7],TN:[33.9,9.5],GH:[7.9,-1.0],
+  SA:[23.9,45.1],AE:[23.4,53.8],IL:[31.0,34.9],IR:[32.4,53.7],IQ:[33.2,43.7],
+  KW:[29.3,47.5],QA:[25.4,51.2],BH:[26.0,50.6],JO:[30.6,36.2],LB:[33.9,35.9],
+  CL:[-35.7,-71.5],CO:[4.6,-74.3],PE:[-9.2,-75.0],VE:[6.4,-66.6],
+  KZ:[48.0,68.0],UZ:[41.4,64.6],GE:[42.3,43.4],AZ:[40.1,47.6],AM:[40.1,45.0],
+  LT:[55.2,23.9],LV:[56.9,24.1],EE:[58.6,25.0],
+  HN:[15.2,-86.2],GT:[15.8,-90.2],PA:[8.5,-80.8],CR:[9.7,-84.0],
+  SN:[14.5,-14.5],CM:[7.4,12.4],CI:[7.5,-5.5],TZ:[-6.4,34.9],UG:[1.4,32.3],
+};
+
+// ========================================================================
+// Helpers
+// ========================================================================
+
+function clean(value, maxLen = 120) {
+  if (typeof value !== 'string') return '';
+  return value.trim().replace(/\s+/g, ' ').slice(0, maxLen);
+}
+
+function toNum(value) {
+  const n = typeof value === 'number' ? value : parseFloat(String(value ?? ''));
+  return Number.isFinite(n) ? n : null;
+}
+
+function validCoords(lat, lon) {
+  return lat !== null && lon !== null && lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
+}
+
+function isIPv4(v) {
+  if (!/^(\d{1,3}\.){3}\d{1,3}$/.test(v)) return false;
+  return v.split('.').map(Number).every((n) => Number.isInteger(n) && n >= 0 && n <= 255);
+}
+
+function isIPv6(v) { return /^[0-9a-f:]+$/i.test(v) && v.includes(':'); }
+
+function isIp(v) {
+  const c = clean(v, 80).toLowerCase();
+  return c && (isIPv4(c) || isIPv6(c));
+}
+
+function normCountry(v) {
+  const r = clean(String(v ?? ''), 64);
+  if (!r) return '';
+  return /^[a-z]{2}$/i.test(r) ? r.toUpperCase() : r;
+}
+
+function toEpochMs(v) {
+  if (!v) return 0;
+  const raw = clean(String(v), 80);
+  if (!raw) return 0;
+  const d = new Date(raw);
+  if (!isNaN(d.getTime())) return d.getTime();
+  const norm = raw.replace(' UTC', 'Z').replace(' GMT', 'Z').replace(' +00:00', 'Z').replace(' ', 'T');
+  const d2 = new Date(norm);
+  return isNaN(d2.getTime()) ? 0 : d2.getTime();
+}
+
+function normTags(input, max = 8) {
+  const tags = Array.isArray(input) ? input : typeof input === 'string' ? input.split(/[;,|]/g) : [];
+  const out = [];
+  const seen = new Set();
+  for (const t of tags) {
+    const c = clean(String(t ?? ''), 40).toLowerCase();
+    if (!c || seen.has(c)) continue;
+    seen.add(c);
+    out.push(c);
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+function djb2(s) {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff;
+  return h;
+}
+
+function countryCentroid(cc, seed) {
+  if (!cc) return null;
+  const coords = COUNTRY_CENTROIDS[cc.toUpperCase()];
+  if (!coords) return null;
+  const k = seed || cc;
+  const latOff = (((djb2(k) & 0xffff) / 0xffff) - 0.5) * 2;
+  const lonOff = (((djb2(k + ':lon') & 0xffff) / 0xffff) - 0.5) * 2;
+  return { lat: coords[0] + latOff, lon: coords[1] + lonOff };
+}
+
+function sanitize(t) {
+  const indicator = clean(t.indicator, 255);
+  if (!indicator) return null;
+  if ((t.indicatorType || 'ip') === 'ip' && !isIp(indicator)) return null;
+  return {
+    id: clean(t.id, 255) || `${t.source || 'feodo'}:${t.indicatorType || 'ip'}:${indicator}`,
+    type: t.type || 'malicious_url',
+    source: t.source || 'feodo',
+    indicator,
+    indicatorType: t.indicatorType || 'ip',
+    lat: t.lat ?? null,
+    lon: t.lon ?? null,
+    country: t.country || '',
+    severity: t.severity || 'medium',
+    malwareFamily: clean(t.malwareFamily, 80),
+    tags: t.tags || [],
+    firstSeen: t.firstSeen || 0,
+    lastSeen: t.lastSeen || 0,
+  };
+}
+
+// ========================================================================
+// GeoIP hydration
+// ========================================================================
+
+async function fetchGeoIp(ip, signal) {
+  try {
+    const resp = await fetch(`https://ipinfo.io/${encodeURIComponent(ip)}/json`, {
+      headers: { 'User-Agent': CHROME_UA },
+      signal: signal || AbortSignal.timeout(GEO_PER_IP_TIMEOUT_MS),
+    });
+    if (resp.ok) {
+      const d = await resp.json();
+      const parts = (d.loc || '').split(',');
+      const lat = toNum(parts[0]);
+      const lon = toNum(parts[1]);
+      if (validCoords(lat, lon)) return { lat, lon, country: normCountry(d.country) };
+    }
+  } catch { /* fall through */ }
+  if (signal?.aborted) return null;
+  try {
+    const resp = await fetch(`https://freeipapi.com/api/json/${encodeURIComponent(ip)}`, {
+      headers: { 'User-Agent': CHROME_UA },
+      signal: signal || AbortSignal.timeout(GEO_PER_IP_TIMEOUT_MS),
+    });
+    if (!resp.ok) return null;
+    const d = await resp.json();
+    const lat = toNum(d.latitude);
+    const lon = toNum(d.longitude);
+    if (!validCoords(lat, lon)) return null;
+    return { lat, lon, country: normCountry(d.countryCode || d.countryName) };
+  } catch { return null; }
+}
+
+async function hydrateCoordinates(threats) {
+  const unresolvedIps = [];
+  const seen = new Set();
+  for (const t of threats) {
+    if (validCoords(t.lat, t.lon)) continue;
+    if (t.indicatorType !== 'ip') continue;
+    const ip = clean(t.indicator, 80).toLowerCase();
+    if (!isIp(ip) || seen.has(ip)) continue;
+    seen.add(ip);
+    unresolvedIps.push(ip);
+  }
+
+  const capped = unresolvedIps.slice(0, GEO_MAX_UNRESOLVED);
+  const resolved = new Map();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), GEO_OVERALL_TIMEOUT_MS);
+
+  const queue = [...capped];
+  const workerCount = Math.min(GEO_CONCURRENCY, queue.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (queue.length > 0 && !controller.signal.aborted) {
+      const ip = queue.shift();
+      if (!ip) continue;
+      const geo = await fetchGeoIp(ip, controller.signal);
+      if (geo) resolved.set(ip, geo);
+    }
+  });
+
+  try { await Promise.all(workers); } catch { /* aborted */ }
+  clearTimeout(timeout);
+
+  console.log(`  GeoIP: resolved ${resolved.size}/${capped.length} IPs`);
+
+  return threats.map((t) => {
+    if (validCoords(t.lat, t.lon)) return t;
+    if (t.indicatorType !== 'ip') return t;
+    const lookup = resolved.get(clean(t.indicator, 80).toLowerCase());
+    if (lookup) return { ...t, lat: lookup.lat, lon: lookup.lon, country: t.country || lookup.country };
+    const cent = countryCentroid(t.country, t.indicator);
+    if (cent) return { ...t, lat: cent.lat, lon: cent.lon };
+    return t;
+  });
+}
+
+// ========================================================================
+// Source fetchers
+// ========================================================================
+
+async function fetchFeodo(cutoffMs) {
+  try {
+    const resp = await fetch(FEODO_URL, {
+      headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+    if (!resp.ok) return { ok: false, threats: [] };
+    const payload = await resp.json();
+    const records = Array.isArray(payload) ? payload : (Array.isArray(payload?.data) ? payload.data : []);
+    const threats = [];
+    for (const r of records) {
+      const ip = clean(r?.ip_address || r?.dst_ip || r?.ip || r?.ioc || r?.host, 80).toLowerCase();
+      if (!isIp(ip)) continue;
+      const status = clean(r?.status || r?.c2_status || '', 30).toLowerCase();
+      if (status && status !== 'online' && status !== 'offline') continue;
+      const firstSeen = toEpochMs(r?.first_seen || r?.first_seen_utc || r?.dateadded);
+      const lastSeen = toEpochMs(r?.last_online || r?.last_seen || r?.last_seen_utc || r?.first_seen || r?.first_seen_utc);
+      if ((lastSeen || firstSeen) && (lastSeen || firstSeen) < cutoffMs) continue;
+      const mf = clean(r?.malware || r?.malware_family || r?.family, 80);
+      const sev = status === 'online' && /emotet|qakbot|trickbot|dridex|ransom/i.test(mf) ? 'critical'
+        : status === 'online' ? 'high' : 'medium';
+      const t = sanitize({
+        id: `feodo:${ip}`, type: 'c2_server', source: 'feodo', indicator: ip, indicatorType: 'ip',
+        lat: toNum(r?.latitude ?? r?.lat), lon: toNum(r?.longitude ?? r?.lon),
+        country: normCountry(r?.country || r?.country_code), severity: sev, malwareFamily: mf,
+        tags: normTags(['botnet', 'c2', ...(normTags(r?.tags))]), firstSeen, lastSeen,
+      });
+      if (t) threats.push(t);
+      if (threats.length >= MAX_LIMIT) break;
+    }
+    console.log(`  Feodo: ${threats.length} threats`);
+    return { ok: true, threats };
+  } catch (e) {
+    console.warn(`  Feodo: failed — ${e.message}`);
+    return { ok: false, threats: [] };
+  }
+}
+
+async function fetchUrlhaus(cutoffMs) {
+  const authKey = clean(process.env.URLHAUS_AUTH_KEY || '', 200);
+  if (!authKey) { console.log('  URLhaus: skipped (no URLHAUS_AUTH_KEY)'); return { ok: false, threats: [] }; }
+  try {
+    const resp = await fetch(URLHAUS_RECENT_URL(MAX_LIMIT), {
+      method: 'GET',
+      headers: { Accept: 'application/json', 'Auth-Key': authKey, 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+    if (!resp.ok) return { ok: false, threats: [] };
+    const payload = await resp.json();
+    const rows = Array.isArray(payload?.urls) ? payload.urls : (Array.isArray(payload?.data) ? payload.data : []);
+    const threats = [];
+    for (const r of rows) {
+      const rawUrl = clean(r?.url || r?.ioc || '', 1024);
+      const status = clean(r?.url_status || r?.status || '', 30).toLowerCase();
+      if (status && status !== 'online') continue;
+      const tags = normTags(r?.tags);
+      let hostname = '';
+      if (rawUrl) { try { hostname = clean(new URL(rawUrl).hostname, 255).toLowerCase(); } catch {} }
+      const recordIp = clean(r?.host || r?.ip_address || r?.ip, 80).toLowerCase();
+      const ipCand = isIp(recordIp) ? recordIp : (isIp(hostname) ? hostname : '');
+      const indType = ipCand ? 'ip' : (hostname ? 'domain' : 'url');
+      const indicator = ipCand || hostname || rawUrl;
+      if (!indicator) continue;
+      const firstSeen = toEpochMs(r?.dateadded || r?.firstseen || r?.first_seen);
+      const lastSeen = toEpochMs(r?.last_online || r?.last_seen || r?.dateadded);
+      if ((lastSeen || firstSeen) && (lastSeen || firstSeen) < cutoffMs) continue;
+      const threat = clean(r?.threat || r?.threat_type || '', 40).toLowerCase();
+      const allTags = tags.join(' ');
+      const type = threat.includes('phish') || allTags.includes('phish') ? 'phishing'
+        : threat.includes('malware') || threat.includes('payload') || allTags.includes('malware') ? 'malware_host'
+        : 'malicious_url';
+      const sev = type === 'phishing' ? 'medium'
+        : tags.includes('ransomware') || tags.includes('botnet') ? 'critical'
+        : type === 'malware_host' ? 'high' : 'medium';
+      const t = sanitize({
+        id: `urlhaus:${indType}:${indicator}`, type, source: 'urlhaus', indicator, indicatorType: indType,
+        lat: toNum(r?.latitude ?? r?.lat), lon: toNum(r?.longitude ?? r?.lon),
+        country: normCountry(r?.country || r?.country_code), severity: sev,
+        malwareFamily: clean(r?.threat, 80), tags, firstSeen, lastSeen,
+      });
+      if (t) threats.push(t);
+      if (threats.length >= MAX_LIMIT) break;
+    }
+    console.log(`  URLhaus: ${threats.length} threats`);
+    return { ok: true, threats };
+  } catch (e) {
+    console.warn(`  URLhaus: failed — ${e.message}`);
+    return { ok: false, threats: [] };
+  }
+}
+
+async function fetchC2Intel() {
+  try {
+    const resp = await fetch(C2INTEL_URL, {
+      headers: { Accept: 'text/plain', 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+    if (!resp.ok) return { ok: false, threats: [] };
+    const text = await resp.text();
+    const threats = [];
+    for (const line of text.split('\n')) {
+      if (!line || line.startsWith('#')) continue;
+      const ci = line.indexOf(',');
+      if (ci < 0) continue;
+      const ip = clean(line.slice(0, ci), 80).toLowerCase();
+      if (!isIp(ip)) continue;
+      const desc = clean(line.slice(ci + 1), 200);
+      const mf = desc.replace(/^Possible\s+/i, '').replace(/\s+C2\s+IP$/i, '').trim() || 'Unknown';
+      const tags = ['c2'];
+      const dl = desc.toLowerCase();
+      if (dl.includes('cobaltstrike') || dl.includes('cobalt strike')) tags.push('cobaltstrike');
+      if (dl.includes('metasploit')) tags.push('metasploit');
+      if (dl.includes('sliver')) tags.push('sliver');
+      if (dl.includes('brute ratel') || dl.includes('bruteratel')) tags.push('bruteratel');
+      const sev = /cobaltstrike|cobalt.strike|brute.?ratel/i.test(desc) ? 'high' : 'medium';
+      const t = sanitize({
+        id: `c2intel:${ip}`, type: 'c2_server', source: 'c2intel', indicator: ip, indicatorType: 'ip',
+        lat: null, lon: null, country: '', severity: sev, malwareFamily: mf, tags: normTags(tags),
+        firstSeen: 0, lastSeen: 0,
+      });
+      if (t) threats.push(t);
+      if (threats.length >= MAX_LIMIT) break;
+    }
+    console.log(`  C2Intel: ${threats.length} threats`);
+    return { ok: true, threats };
+  } catch (e) {
+    console.warn(`  C2Intel: failed — ${e.message}`);
+    return { ok: false, threats: [] };
+  }
+}
+
+async function fetchOtx(days) {
+  const apiKey = clean(process.env.OTX_API_KEY || '', 200);
+  if (!apiKey) { console.log('  OTX: skipped (no OTX_API_KEY)'); return { ok: false, threats: [] }; }
+  try {
+    const since = new Date(Date.now() - days * 86400000).toISOString().slice(0, 10);
+    const resp = await fetch(`${OTX_INDICATORS_URL}${encodeURIComponent(since)}`, {
+      headers: { Accept: 'application/json', 'X-OTX-API-KEY': apiKey, 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+    if (!resp.ok) return { ok: false, threats: [] };
+    const payload = await resp.json();
+    const results = Array.isArray(payload?.results) ? payload.results : (Array.isArray(payload) ? payload : []);
+    const threats = [];
+    for (const r of results) {
+      const ip = clean(r?.indicator || r?.ip || '', 80).toLowerCase();
+      if (!isIp(ip)) continue;
+      const tags = normTags(r?.tags || []);
+      const sev = tags.some((t) => /ransomware|apt|c2|botnet/.test(t)) ? 'high' : 'medium';
+      const type = tags.some((t) => /c2|botnet/.test(t)) ? 'c2_server' : 'malware_host';
+      const title = clean(r?.title || r?.description || '', 200);
+      const t = sanitize({
+        id: `otx:${ip}`, type, source: 'otx', indicator: ip, indicatorType: 'ip',
+        lat: null, lon: null, country: '', severity: sev, malwareFamily: title, tags,
+        firstSeen: toEpochMs(r?.created), lastSeen: toEpochMs(r?.modified || r?.created),
+      });
+      if (t) threats.push(t);
+      if (threats.length >= MAX_LIMIT) break;
+    }
+    console.log(`  OTX: ${threats.length} threats`);
+    return { ok: true, threats };
+  } catch (e) {
+    console.warn(`  OTX: failed — ${e.message}`);
+    return { ok: false, threats: [] };
+  }
+}
+
+async function fetchAbuseIpDb() {
+  const apiKey = clean(process.env.ABUSEIPDB_API_KEY || '', 200);
+  if (!apiKey) { console.log('  AbuseIPDB: skipped (no ABUSEIPDB_API_KEY)'); return { ok: false, threats: [] }; }
+  try {
+    const url = `${ABUSEIPDB_BLACKLIST_URL}?confidenceMinimum=90&limit=${Math.min(MAX_LIMIT, 500)}`;
+    const resp = await fetch(url, {
+      headers: { Accept: 'application/json', Key: apiKey, 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+    if (!resp.ok) return { ok: false, threats: [] };
+    const payload = await resp.json();
+    const records = Array.isArray(payload?.data) ? payload.data : [];
+    const threats = [];
+    for (const r of records) {
+      const ip = clean(r?.ipAddress || r?.ip || '', 80).toLowerCase();
+      if (!isIp(ip)) continue;
+      const score = toNum(r?.abuseConfidenceScore) ?? 0;
+      const sev = score >= 95 ? 'critical' : (score >= 80 ? 'high' : 'medium');
+      const t = sanitize({
+        id: `abuseipdb:${ip}`, type: 'malware_host', source: 'abuseipdb', indicator: ip, indicatorType: 'ip',
+        lat: toNum(r?.latitude ?? r?.lat), lon: toNum(r?.longitude ?? r?.lon),
+        country: normCountry(r?.countryCode || r?.country), severity: sev, malwareFamily: '',
+        tags: normTags([`score:${score}`]), firstSeen: 0, lastSeen: toEpochMs(r?.lastReportedAt),
+      });
+      if (t) threats.push(t);
+      if (threats.length >= MAX_LIMIT) break;
+    }
+    console.log(`  AbuseIPDB: ${threats.length} threats`);
+    return { ok: true, threats };
+  } catch (e) {
+    console.warn(`  AbuseIPDB: failed — ${e.message}`);
+    return { ok: false, threats: [] };
+  }
+}
+
+// ========================================================================
+// Dedup + proto mapping
+// ========================================================================
+
+function dedupeThreats(threats) {
+  const map = new Map();
+  for (const t of threats) {
+    const key = `${t.source}:${t.indicatorType}:${t.indicator}`;
+    const existing = map.get(key);
+    if (!existing) { map.set(key, t); continue; }
+    const eSeen = existing.lastSeen || existing.firstSeen;
+    const cSeen = t.lastSeen || t.firstSeen;
+    if (cSeen >= eSeen) {
+      map.set(key, { ...existing, ...t, tags: normTags([...existing.tags, ...t.tags]) });
+    }
+  }
+  return Array.from(map.values());
+}
+
+function toProto(raw) {
+  return {
+    id: raw.id,
+    type: THREAT_TYPE_MAP[raw.type] || 'CYBER_THREAT_TYPE_UNSPECIFIED',
+    source: SOURCE_MAP[raw.source] || 'CYBER_THREAT_SOURCE_UNSPECIFIED',
+    indicator: raw.indicator,
+    indicatorType: INDICATOR_TYPE_MAP[raw.indicatorType] || 'CYBER_THREAT_INDICATOR_TYPE_UNSPECIFIED',
+    location: validCoords(raw.lat, raw.lon) ? { latitude: raw.lat, longitude: raw.lon } : undefined,
+    country: raw.country,
+    severity: SEVERITY_MAP[raw.severity] || 'CRITICALITY_LEVEL_UNSPECIFIED',
+    malwareFamily: raw.malwareFamily,
+    tags: raw.tags,
+    firstSeenAt: raw.firstSeen,
+    lastSeenAt: raw.lastSeen,
+  };
+}
+
+// ========================================================================
+// Main fetch function
+// ========================================================================
+
+async function fetchAllThreats() {
+  const now = Date.now();
+  const cutoffMs = now - DEFAULT_DAYS * 86400000;
+
+  const [feodo, urlhaus, c2intel, otx, abuseipdb] = await Promise.all([
+    fetchFeodo(cutoffMs),
+    fetchUrlhaus(cutoffMs),
+    fetchC2Intel(),
+    fetchOtx(DEFAULT_DAYS),
+    fetchAbuseIpDb(),
+  ]);
+
+  const anyOk = feodo.ok || urlhaus.ok || c2intel.ok || otx.ok || abuseipdb.ok;
+  if (!anyOk) throw new Error('All 5 IOC sources failed');
+
+  const combined = dedupeThreats([
+    ...feodo.threats, ...urlhaus.threats, ...c2intel.threats, ...otx.threats, ...abuseipdb.threats,
+  ]);
+
+  console.log(`  Combined (deduped): ${combined.length}`);
+
+  const hydrated = await hydrateCoordinates(combined);
+
+  let results = hydrated.filter((t) =>
+    t.lat !== null && t.lon !== null && t.lat >= -90 && t.lat <= 90 && t.lon >= -180 && t.lon <= 180
+  );
+
+  results.sort((a, b) => {
+    const bySev = (SEVERITY_RANK[SEVERITY_MAP[b.severity] || ''] || 0) - (SEVERITY_RANK[SEVERITY_MAP[a.severity] || ''] || 0);
+    if (bySev !== 0) return bySev;
+    return (b.lastSeen || b.firstSeen) - (a.lastSeen || a.firstSeen);
+  });
+
+  const threats = results.slice(0, MAX_CACHED_THREATS).map(toProto);
+  console.log(`  Final threats (with coords): ${threats.length}`);
+
+  return { threats };
+}
+
+function validate(data) {
+  return Array.isArray(data?.threats) && data.threats.length >= 1;
+}
+
+import { atomicPublish } from './_seed-utils.mjs';
+
+let cachedResult = null;
+
+async function fetchOnce() {
+  if (cachedResult) return cachedResult;
+  cachedResult = await fetchAllThreats();
+  return cachedResult;
+}
+
+async function run() {
+  const result = await runSeed('cyber', 'threats', CANONICAL_KEY, fetchOnce, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: 'multi-ioc-v2',
+  });
+
+  if (result?.success && cachedResult) {
+    try {
+      await atomicPublish(BOOTSTRAP_KEY, cachedResult, validate, CACHE_TTL);
+      console.log(`  Bootstrap key written: ${BOOTSTRAP_KEY}`);
+    } catch (e) {
+      console.warn(`  Bootstrap write failed (non-fatal): ${e.message}`);
+    }
+  }
+}
+
+run().catch((err) => {
+  console.error('FATAL:', err.message || err);
+  process.exit(1);
+});

--- a/scripts/seed-displacement-summary.mjs
+++ b/scripts/seed-displacement-summary.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY_PREFIX = 'displacement:summary:v1';
+const CACHE_TTL = 86400; // 24 hours — UNHCR data is annual
+
+const COUNTRY_CENTROIDS = {
+  AFG: [33.9, 67.7], SYR: [35.0, 38.0], UKR: [48.4, 31.2], SDN: [15.5, 32.5],
+  SSD: [6.9, 31.3], SOM: [5.2, 46.2], COD: [-4.0, 21.8], MMR: [19.8, 96.7],
+  YEM: [15.6, 48.5], ETH: [9.1, 40.5], VEN: [6.4, -66.6], IRQ: [33.2, 43.7],
+  COL: [4.6, -74.1], NGA: [9.1, 7.5], PSE: [31.9, 35.2], TUR: [39.9, 32.9],
+  DEU: [51.2, 10.4], PAK: [30.4, 69.3], UGA: [1.4, 32.3], BGD: [23.7, 90.4],
+  KEN: [0.0, 38.0], TCD: [15.5, 19.0], JOR: [31.0, 36.0], LBN: [33.9, 35.5],
+  EGY: [26.8, 30.8], IRN: [32.4, 53.7], TZA: [-6.4, 34.9], RWA: [-1.9, 29.9],
+  CMR: [7.4, 12.4], MLI: [17.6, -4.0], BFA: [12.3, -1.6], NER: [17.6, 8.1],
+  CAF: [6.6, 20.9], MOZ: [-18.7, 35.5], USA: [37.1, -95.7], FRA: [46.2, 2.2],
+  GBR: [55.4, -3.4], IND: [20.6, 79.0], CHN: [35.9, 104.2], RUS: [61.5, 105.3],
+};
+
+function getCoordinates(code) {
+  const centroid = COUNTRY_CENTROIDS[code];
+  if (!centroid) return undefined;
+  return { latitude: centroid[0], longitude: centroid[1] };
+}
+
+async function fetchUnhcrYearItems(year) {
+  const limit = 10000;
+  const maxPageGuard = 25;
+  const items = [];
+
+  for (let page = 1; page <= maxPageGuard; page++) {
+    const resp = await fetch(
+      `https://api.unhcr.org/population/v1/population/?year=${year}&limit=${limit}&page=${page}&coo_all=true&coa_all=true`,
+      {
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': CHROME_UA,
+        },
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+
+    if (!resp.ok) return null;
+
+    const data = await resp.json();
+    const pageItems = Array.isArray(data.items) ? data.items : [];
+    if (pageItems.length === 0) break;
+    items.push(...pageItems);
+
+    const maxPages = Number(data.maxPages);
+    if (Number.isFinite(maxPages) && maxPages > 0) {
+      if (page >= maxPages) break;
+      continue;
+    }
+
+    if (pageItems.length < limit) break;
+  }
+
+  return items;
+}
+
+async function fetchDisplacementSummary() {
+  const currentYear = new Date().getFullYear();
+  let rawItems = [];
+  let dataYearUsed = currentYear;
+
+  for (let y = currentYear; y >= currentYear - 2; y--) {
+    const items = await fetchUnhcrYearItems(y);
+    if (!items) continue;
+    if (items.length > 0) {
+      rawItems = items;
+      dataYearUsed = y;
+      break;
+    }
+  }
+
+  if (rawItems.length === 0) throw new Error('No UNHCR data available for current or past 2 years');
+
+  const byOrigin = {};
+  const byAsylum = {};
+  const flowMap = {};
+  let totalRefugees = 0;
+  let totalAsylumSeekers = 0;
+  let totalIdps = 0;
+  let totalStateless = 0;
+
+  for (const item of rawItems) {
+    const originCode = item.coo_iso || '';
+    const asylumCode = item.coa_iso || '';
+    const refugees = Number(item.refugees) || 0;
+    const asylumSeekers = Number(item.asylum_seekers) || 0;
+    const idps = Number(item.idps) || 0;
+    const stateless = Number(item.stateless) || 0;
+
+    totalRefugees += refugees;
+    totalAsylumSeekers += asylumSeekers;
+    totalIdps += idps;
+    totalStateless += stateless;
+
+    if (originCode) {
+      if (!byOrigin[originCode]) {
+        byOrigin[originCode] = { name: item.coo_name || originCode, refugees: 0, asylumSeekers: 0, idps: 0, stateless: 0 };
+      }
+      byOrigin[originCode].refugees += refugees;
+      byOrigin[originCode].asylumSeekers += asylumSeekers;
+      byOrigin[originCode].idps += idps;
+      byOrigin[originCode].stateless += stateless;
+    }
+
+    if (asylumCode) {
+      if (!byAsylum[asylumCode]) {
+        byAsylum[asylumCode] = { name: item.coa_name || asylumCode, refugees: 0, asylumSeekers: 0 };
+      }
+      byAsylum[asylumCode].refugees += refugees;
+      byAsylum[asylumCode].asylumSeekers += asylumSeekers;
+    }
+
+    if (originCode && asylumCode && refugees > 0) {
+      const flowKey = `${originCode}->${asylumCode}`;
+      if (!flowMap[flowKey]) {
+        flowMap[flowKey] = { originCode, originName: item.coo_name || originCode, asylumCode, asylumName: item.coa_name || asylumCode, refugees: 0 };
+      }
+      flowMap[flowKey].refugees += refugees;
+    }
+  }
+
+  const countries = {};
+
+  for (const [code, data] of Object.entries(byOrigin)) {
+    countries[code] = {
+      code,
+      name: data.name,
+      refugees: data.refugees,
+      asylumSeekers: data.asylumSeekers,
+      idps: data.idps,
+      stateless: data.stateless,
+      totalDisplaced: data.refugees + data.asylumSeekers + data.idps + data.stateless,
+      hostRefugees: 0,
+      hostAsylumSeekers: 0,
+      hostTotal: 0,
+    };
+  }
+
+  for (const [code, data] of Object.entries(byAsylum)) {
+    const hostRefugees = data.refugees;
+    const hostAsylumSeekers = data.asylumSeekers;
+    const hostTotal = hostRefugees + hostAsylumSeekers;
+
+    if (!countries[code]) {
+      countries[code] = {
+        code,
+        name: data.name,
+        refugees: 0,
+        asylumSeekers: 0,
+        idps: 0,
+        stateless: 0,
+        totalDisplaced: 0,
+        hostRefugees,
+        hostAsylumSeekers,
+        hostTotal,
+      };
+    } else {
+      countries[code].hostRefugees = hostRefugees;
+      countries[code].hostAsylumSeekers = hostAsylumSeekers;
+      countries[code].hostTotal = hostTotal;
+    }
+  }
+
+  const sortedCountries = Object.values(countries)
+    .sort((a, b) => Math.max(b.totalDisplaced, b.hostTotal) - Math.max(a.totalDisplaced, a.hostTotal))
+    .map((d) => ({
+      code: d.code,
+      name: d.name,
+      refugees: d.refugees,
+      asylumSeekers: d.asylumSeekers,
+      idps: d.idps,
+      stateless: d.stateless,
+      totalDisplaced: d.totalDisplaced,
+      hostRefugees: d.hostRefugees,
+      hostAsylumSeekers: d.hostAsylumSeekers,
+      hostTotal: d.hostTotal,
+      location: getCoordinates(d.code),
+    }));
+
+  const topFlows = Object.values(flowMap)
+    .sort((a, b) => b.refugees - a.refugees)
+    .map((f) => ({
+      originCode: f.originCode,
+      originName: f.originName,
+      asylumCode: f.asylumCode,
+      asylumName: f.asylumName,
+      refugees: f.refugees,
+      originLocation: getCoordinates(f.originCode),
+      asylumLocation: getCoordinates(f.asylumCode),
+    }));
+
+  return {
+    summary: {
+      year: dataYearUsed,
+      globalTotals: {
+        refugees: totalRefugees,
+        asylumSeekers: totalAsylumSeekers,
+        idps: totalIdps,
+        stateless: totalStateless,
+        total: totalRefugees + totalAsylumSeekers + totalIdps + totalStateless,
+      },
+      countries: sortedCountries,
+      topFlows,
+    },
+  };
+}
+
+function validate(data) {
+  return (
+    data?.summary &&
+    typeof data.summary.year === 'number' &&
+    Array.isArray(data.summary.countries) &&
+    data.summary.countries.length >= 1
+  );
+}
+
+const currentYear = new Date().getFullYear();
+const canonicalKey = `${CANONICAL_KEY_PREFIX}:${currentYear}`;
+
+runSeed('displacement', 'summary', canonicalKey, fetchDisplacementSummary, {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: `unhcr-${currentYear}`,
+}).catch((err) => {
+  console.error('FATAL:', err.message || err);
+  process.exit(1);
+});

--- a/scripts/seed-earthquakes.mjs
+++ b/scripts/seed-earthquakes.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const USGS_FEED_URL = 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_day.geojson';
+const CANONICAL_KEY = 'seismology:earthquakes:v1';
+const CACHE_TTL = 3600; // 1 hour
+
+async function fetchEarthquakes() {
+  const resp = await fetch(USGS_FEED_URL, {
+    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) throw new Error(`USGS API error: ${resp.status}`);
+
+  const geojson = await resp.json();
+  const features = geojson.features || [];
+
+  const earthquakes = features
+    .filter((f) => f?.properties && f?.geometry?.coordinates)
+    .map((f) => ({
+      id: String(f.id || ''),
+      place: String(f.properties?.place || ''),
+      magnitude: f.properties?.mag ?? 0,
+      depthKm: f.geometry?.coordinates?.[2] ?? 0,
+      location: {
+        latitude: f.geometry?.coordinates?.[1] ?? 0,
+        longitude: f.geometry?.coordinates?.[0] ?? 0,
+      },
+      occurredAt: f.properties?.time ?? 0,
+      sourceUrl: String(f.properties?.url || ''),
+    }));
+
+  return { earthquakes };
+}
+
+function validate(data) {
+  return Array.isArray(data?.earthquakes) && data.earthquakes.length >= 1;
+}
+
+runSeed('seismology', 'earthquakes', CANONICAL_KEY, fetchEarthquakes, {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: 'usgs-4.5-day',
+}).catch((err) => {
+  console.error('FATAL:', err.message || err);
+  process.exit(1);
+});

--- a/scripts/seed-etf-flows.mjs
+++ b/scripts/seed-etf-flows.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY = 'market:etf-flows:v1';
+const CACHE_TTL = 3600;
+const YAHOO_DELAY_MS = 200;
+
+const ETF_LIST = [
+  { ticker: 'IBIT', issuer: 'BlackRock' },
+  { ticker: 'FBTC', issuer: 'Fidelity' },
+  { ticker: 'ARKB', issuer: 'ARK/21Shares' },
+  { ticker: 'BITB', issuer: 'Bitwise' },
+  { ticker: 'GBTC', issuer: 'Grayscale' },
+  { ticker: 'HODL', issuer: 'VanEck' },
+  { ticker: 'BRRR', issuer: 'Valkyrie' },
+  { ticker: 'EZBC', issuer: 'Franklin' },
+  { ticker: 'BTCO', issuer: 'Invesco' },
+  { ticker: 'BTCW', issuer: 'WisdomTree' },
+];
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function parseEtfChartData(chart, ticker, issuer) {
+  const result = chart?.chart?.result?.[0];
+  if (!result) return null;
+
+  const quote = result.indicators?.quote?.[0];
+  const closes = quote?.close || [];
+  const volumes = quote?.volume || [];
+
+  const validCloses = closes.filter((p) => p != null);
+  const validVolumes = volumes.filter((v) => v != null);
+
+  if (validCloses.length < 2) return null;
+
+  const latestPrice = validCloses[validCloses.length - 1];
+  const prevPrice = validCloses[validCloses.length - 2];
+  const priceChange = prevPrice ? ((latestPrice - prevPrice) / prevPrice) * 100 : 0;
+
+  const latestVolume = validVolumes.length > 0 ? validVolumes[validVolumes.length - 1] : 0;
+  const avgVolume =
+    validVolumes.length > 1
+      ? validVolumes.slice(0, -1).reduce((a, b) => a + b, 0) / (validVolumes.length - 1)
+      : latestVolume;
+
+  const volumeRatio = avgVolume > 0 ? latestVolume / avgVolume : 1;
+  const direction = priceChange > 0.1 ? 'inflow' : priceChange < -0.1 ? 'outflow' : 'neutral';
+  const estFlowMagnitude = latestVolume * latestPrice * (priceChange > 0 ? 1 : -1) * 0.1;
+
+  return {
+    ticker,
+    issuer,
+    price: +latestPrice.toFixed(2),
+    priceChange: +priceChange.toFixed(2),
+    volume: latestVolume,
+    avgVolume: Math.round(avgVolume),
+    volumeRatio: +volumeRatio.toFixed(2),
+    direction,
+    estFlow: Math.round(estFlowMagnitude),
+  };
+}
+
+async function fetchEtfFlows() {
+  const etfs = [];
+  let misses = 0;
+
+  for (let i = 0; i < ETF_LIST.length; i++) {
+    const { ticker, issuer } = ETF_LIST[i];
+    if (i > 0) await sleep(YAHOO_DELAY_MS);
+
+    try {
+      const url = `https://query1.finance.yahoo.com/v8/finance/chart/${ticker}?range=5d&interval=1d`;
+      const resp = await fetch(url, {
+        headers: { 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!resp.ok) {
+        console.warn(`  [Yahoo] ${ticker} HTTP ${resp.status}`);
+        misses++;
+        continue;
+      }
+      const chart = await resp.json();
+      const parsed = parseEtfChartData(chart, ticker, issuer);
+      if (parsed) {
+        etfs.push(parsed);
+        console.log(`  ${ticker}: $${parsed.price} (${parsed.direction})`);
+      } else {
+        misses++;
+      }
+    } catch (err) {
+      console.warn(`  [Yahoo] ${ticker} error: ${err.message}`);
+      misses++;
+    }
+
+    if (misses >= 3 && etfs.length === 0) break;
+  }
+
+  if (etfs.length === 0) {
+    throw new Error(`All ETF fetches failed (${misses} misses)`);
+  }
+
+  const totalVolume = etfs.reduce((sum, e) => sum + e.volume, 0);
+  const totalEstFlow = etfs.reduce((sum, e) => sum + e.estFlow, 0);
+  const inflowCount = etfs.filter((e) => e.direction === 'inflow').length;
+  const outflowCount = etfs.filter((e) => e.direction === 'outflow').length;
+
+  etfs.sort((a, b) => b.volume - a.volume);
+
+  return {
+    timestamp: new Date().toISOString(),
+    summary: {
+      etfCount: etfs.length,
+      totalVolume,
+      totalEstFlow,
+      netDirection: totalEstFlow > 0 ? 'NET INFLOW' : totalEstFlow < 0 ? 'NET OUTFLOW' : 'NEUTRAL',
+      inflowCount,
+      outflowCount,
+    },
+    etfs,
+    rateLimited: false,
+  };
+}
+
+function validate(data) {
+  return Array.isArray(data?.etfs) && data.etfs.length >= 1;
+}
+
+runSeed('market', 'etf-flows', CANONICAL_KEY, fetchEtfFlows, {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: 'yahoo-chart-5d',
+}).catch((err) => {
+  console.error('FATAL:', err.message || err);
+  process.exit(1);
+});

--- a/scripts/seed-fire-detections.mjs
+++ b/scripts/seed-fire-detections.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, maskToken, runSeed, CHROME_UA } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY = 'wildfire:fires:v1';
+const FIRMS_SOURCE = 'VIIRS_SNPP_NRT';
+
+const MONITORED_REGIONS = {
+  'Ukraine': '22,44,40,53',
+  'Russia': '20,50,180,82',
+  'Iran': '44,25,63,40',
+  'Israel/Gaza': '34,29,36,34',
+  'Syria': '35,32,42,37',
+  'Taiwan': '119,21,123,26',
+  'North Korea': '124,37,131,43',
+  'Saudi Arabia': '34,16,56,32',
+  'Turkey': '26,36,45,42',
+};
+
+function mapConfidence(c) {
+  switch ((c || '').toLowerCase()) {
+    case 'h': return 'FIRE_CONFIDENCE_HIGH';
+    case 'n': return 'FIRE_CONFIDENCE_NOMINAL';
+    case 'l': return 'FIRE_CONFIDENCE_LOW';
+    default: return 'FIRE_CONFIDENCE_UNSPECIFIED';
+  }
+}
+
+function parseCSV(csv) {
+  const lines = csv.trim().split('\n');
+  if (lines.length < 2) return [];
+  const headers = lines[0].split(',').map(h => h.trim());
+  const results = [];
+  for (let i = 1; i < lines.length; i++) {
+    const vals = lines[i].split(',').map(v => v.trim());
+    if (vals.length < headers.length) continue;
+    const row = {};
+    headers.forEach((h, idx) => { row[h] = vals[idx]; });
+    results.push(row);
+  }
+  return results;
+}
+
+function parseDetectedAt(acqDate, acqTime) {
+  const padded = (acqTime || '').padStart(4, '0');
+  const hours = padded.slice(0, 2);
+  const minutes = padded.slice(2);
+  return new Date(`${acqDate}T${hours}:${minutes}:00Z`).getTime();
+}
+
+async function fetchAllRegions(apiKey) {
+  const entries = Object.entries(MONITORED_REGIONS);
+  const results = await Promise.allSettled(
+    entries.map(async ([regionName, bbox]) => {
+      const url = `https://firms.modaps.eosdis.nasa.gov/api/area/csv/${apiKey}/${FIRMS_SOURCE}/${bbox}/1`;
+      const res = await fetch(url, {
+        headers: { Accept: 'text/csv', 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!res.ok) throw new Error(`FIRMS ${res.status} for ${regionName}`);
+      const csv = await res.text();
+      const rows = parseCSV(csv);
+      return { regionName, rows };
+    }),
+  );
+
+  const fireDetections = [];
+  let fulfilled = 0;
+  let failed = 0;
+
+  for (const r of results) {
+    if (r.status === 'fulfilled') {
+      fulfilled++;
+      const { regionName, rows } = r.value;
+      for (const row of rows) {
+        const detectedAt = parseDetectedAt(row.acq_date || '', row.acq_time || '');
+        fireDetections.push({
+          id: `${row.latitude ?? ''}-${row.longitude ?? ''}-${row.acq_date ?? ''}-${row.acq_time ?? ''}`,
+          location: {
+            latitude: parseFloat(row.latitude ?? '0') || 0,
+            longitude: parseFloat(row.longitude ?? '0') || 0,
+          },
+          brightness: parseFloat(row.bright_ti4 ?? '0') || 0,
+          frp: parseFloat(row.frp ?? '0') || 0,
+          confidence: mapConfidence(row.confidence || ''),
+          satellite: row.satellite || '',
+          detectedAt,
+          region: regionName,
+          dayNight: row.daynight || '',
+        });
+      }
+    } else {
+      failed++;
+      console.error(`  [FIRMS] ${r.reason?.message || r.reason}`);
+    }
+  }
+
+  console.log(`  Regions: ${fulfilled} ok, ${failed} failed | Detections: ${fireDetections.length}`);
+  return { fireDetections, pagination: undefined };
+}
+
+async function main() {
+  const apiKey = process.env.NASA_FIRMS_API_KEY || process.env.FIRMS_API_KEY || '';
+  if (!apiKey) {
+    console.log('NASA_FIRMS_API_KEY not set — skipping fire detections seed');
+    process.exit(0);
+  }
+
+  console.log(`  FIRMS key: ${maskToken(apiKey)}`);
+
+  await runSeed('wildfire', 'fires', CANONICAL_KEY, () => fetchAllRegions(apiKey), {
+    validateFn: (data) => Array.isArray(data?.fireDetections) && data.fireDetections.length > 0,
+    ttlSeconds: 7200,
+    sourceVersion: FIRMS_SOURCE,
+  });
+}
+
+main().catch(err => {
+  console.error('FATAL:', err.message || err);
+  process.exit(1);
+});

--- a/scripts/seed-gulf-quotes.mjs
+++ b/scripts/seed-gulf-quotes.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY = 'market:gulf-quotes:v1';
+const CACHE_TTL = 3600;
+const YAHOO_DELAY_MS = 200;
+
+const GULF_SYMBOLS = [
+  { symbol: '^TASI.SR', name: 'Tadawul All Share', country: 'Saudi Arabia', flag: '\u{1F1F8}\u{1F1E6}', type: 'index' },
+  { symbol: 'DFMGI.AE', name: 'Dubai Financial Market', country: 'UAE', flag: '\u{1F1E6}\u{1F1EA}', type: 'index' },
+  { symbol: 'UAE', name: 'Abu Dhabi (iShares)', country: 'UAE', flag: '\u{1F1E6}\u{1F1EA}', type: 'index' },
+  { symbol: 'QAT', name: 'Qatar (iShares)', country: 'Qatar', flag: '\u{1F1F6}\u{1F1E6}', type: 'index' },
+  { symbol: 'GULF', name: 'Gulf Dividend (WisdomTree)', country: 'Kuwait', flag: '\u{1F1F0}\u{1F1FC}', type: 'index' },
+  { symbol: '^MSM', name: 'Muscat MSM 30', country: 'Oman', flag: '\u{1F1F4}\u{1F1F2}', type: 'index' },
+  { symbol: 'SARUSD=X', name: 'Saudi Riyal', country: 'Saudi Arabia', flag: '\u{1F1F8}\u{1F1E6}', type: 'currency' },
+  { symbol: 'AEDUSD=X', name: 'UAE Dirham', country: 'UAE', flag: '\u{1F1E6}\u{1F1EA}', type: 'currency' },
+  { symbol: 'QARUSD=X', name: 'Qatari Riyal', country: 'Qatar', flag: '\u{1F1F6}\u{1F1E6}', type: 'currency' },
+  { symbol: 'KWDUSD=X', name: 'Kuwaiti Dinar', country: 'Kuwait', flag: '\u{1F1F0}\u{1F1FC}', type: 'currency' },
+  { symbol: 'BHDUSD=X', name: 'Bahraini Dinar', country: 'Bahrain', flag: '\u{1F1E7}\u{1F1ED}', type: 'currency' },
+  { symbol: 'OMRUSD=X', name: 'Omani Rial', country: 'Oman', flag: '\u{1F1F4}\u{1F1F2}', type: 'currency' },
+  { symbol: 'CL=F', name: 'WTI Crude', country: '', flag: '\u{1F6E2}\u{FE0F}', type: 'oil' },
+  { symbol: 'BZ=F', name: 'Brent Crude', country: '', flag: '\u{1F6E2}\u{FE0F}', type: 'oil' },
+];
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function parseYahooChart(data, meta) {
+  const result = data?.chart?.result?.[0];
+  const chartMeta = result?.meta;
+  if (!chartMeta) return null;
+
+  const price = chartMeta.regularMarketPrice;
+  const prevClose = chartMeta.chartPreviousClose || chartMeta.previousClose || price;
+  const change = ((price - prevClose) / prevClose) * 100;
+
+  const closes = result.indicators?.quote?.[0]?.close;
+  const sparkline = (closes || []).filter((v) => v != null);
+
+  return {
+    symbol: meta.symbol,
+    name: meta.name,
+    country: meta.country,
+    flag: meta.flag,
+    type: meta.type,
+    price,
+    change: +change.toFixed(2),
+    sparkline,
+  };
+}
+
+async function fetchGulfQuotes() {
+  const quotes = [];
+  let misses = 0;
+
+  for (let i = 0; i < GULF_SYMBOLS.length; i++) {
+    const meta = GULF_SYMBOLS[i];
+    if (i > 0) await sleep(YAHOO_DELAY_MS);
+
+    try {
+      const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(meta.symbol)}`;
+      const resp = await fetch(url, {
+        headers: { 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!resp.ok) {
+        console.warn(`  [Yahoo] ${meta.symbol} HTTP ${resp.status}`);
+        misses++;
+        continue;
+      }
+      const chart = await resp.json();
+      const parsed = parseYahooChart(chart, meta);
+      if (parsed) {
+        quotes.push(parsed);
+        console.log(`  ${meta.symbol}: $${parsed.price} (${parsed.change > 0 ? '+' : ''}${parsed.change}%)`);
+      } else {
+        misses++;
+      }
+    } catch (err) {
+      console.warn(`  [Yahoo] ${meta.symbol} error: ${err.message}`);
+      misses++;
+    }
+  }
+
+  if (quotes.length === 0) {
+    throw new Error(`All Gulf quote fetches failed (${misses} misses)`);
+  }
+
+  return { quotes, rateLimited: false };
+}
+
+function validate(data) {
+  return Array.isArray(data?.quotes) && data.quotes.length >= 1;
+}
+
+runSeed('market', 'gulf-quotes', CANONICAL_KEY, fetchGulfQuotes, {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: 'yahoo-chart',
+}).catch((err) => {
+  console.error('FATAL:', err.message || err);
+  process.exit(1);
+});

--- a/scripts/seed-internet-outages.mjs
+++ b/scripts/seed-internet-outages.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CF_RADAR_URL = 'https://api.cloudflare.com/client/v4/radar/annotations/outages';
+const CANONICAL_KEY = 'infra:outages:v1';
+const CACHE_TTL = 1800; // 30 min
+
+const COUNTRY_COORDS = {
+  AF:[33.94,67.71],AL:[41.15,20.17],DZ:[28.03,1.66],AO:[-11.20,17.87],
+  AR:[-38.42,-63.62],AM:[40.07,45.04],AU:[-25.27,133.78],AT:[47.52,14.55],
+  AZ:[40.14,47.58],BH:[26.07,50.56],BD:[23.69,90.36],BY:[53.71,27.95],
+  BE:[50.50,4.47],BJ:[9.31,2.32],BO:[-16.29,-63.59],BA:[43.92,17.68],
+  BW:[-22.33,24.68],BR:[-14.24,-51.93],BG:[42.73,25.49],BF:[12.24,-1.56],
+  BI:[-3.37,29.92],KH:[12.57,104.99],CM:[7.37,12.35],CA:[56.13,-106.35],
+  CF:[6.61,20.94],TD:[15.45,18.73],CL:[-35.68,-71.54],CN:[35.86,104.20],
+  CO:[4.57,-74.30],CG:[-0.23,15.83],CD:[-4.04,21.76],CR:[9.75,-83.75],
+  HR:[45.10,15.20],CU:[21.52,-77.78],CY:[35.13,33.43],CZ:[49.82,15.47],
+  DK:[56.26,9.50],DJ:[11.83,42.59],EC:[-1.83,-78.18],EG:[26.82,30.80],
+  SV:[13.79,-88.90],ER:[15.18,39.78],EE:[58.60,25.01],ET:[9.15,40.49],
+  FI:[61.92,25.75],FR:[46.23,2.21],GA:[-0.80,11.61],GM:[13.44,-15.31],
+  GE:[42.32,43.36],DE:[51.17,10.45],GH:[7.95,-1.02],GR:[39.07,21.82],
+  GT:[15.78,-90.23],GN:[9.95,-9.70],HT:[18.97,-72.29],HN:[15.20,-86.24],
+  HK:[22.32,114.17],HU:[47.16,19.50],IN:[20.59,78.96],ID:[-0.79,113.92],
+  IR:[32.43,53.69],IQ:[33.22,43.68],IE:[53.14,-7.69],IL:[31.05,34.85],
+  IT:[41.87,12.57],CI:[7.54,-5.55],JP:[36.20,138.25],JO:[30.59,36.24],
+  KZ:[48.02,66.92],KE:[-0.02,37.91],KW:[29.31,47.48],KG:[41.20,74.77],
+  LA:[19.86,102.50],LV:[56.88,24.60],LB:[33.85,35.86],LY:[26.34,17.23],
+  LT:[55.17,23.88],LU:[49.82,6.13],MG:[-18.77,46.87],MW:[-13.25,34.30],
+  MY:[4.21,101.98],ML:[17.57,-4.00],MR:[21.01,-10.94],MX:[23.63,-102.55],
+  MD:[47.41,28.37],MN:[46.86,103.85],MA:[31.79,-7.09],MZ:[-18.67,35.53],
+  MM:[21.92,95.96],NA:[-22.96,18.49],NP:[28.39,84.12],NL:[52.13,5.29],
+  NZ:[-40.90,174.89],NI:[12.87,-85.21],NE:[17.61,8.08],NG:[9.08,8.68],
+  KP:[40.34,127.51],NO:[60.47,8.47],OM:[21.47,55.98],PK:[30.38,69.35],
+  PS:[31.95,35.23],PA:[8.54,-80.78],PG:[-6.32,143.96],PY:[-23.44,-58.44],
+  PE:[-9.19,-75.02],PH:[12.88,121.77],PL:[51.92,19.15],PT:[39.40,-8.22],
+  QA:[25.35,51.18],RO:[45.94,24.97],RU:[61.52,105.32],RW:[-1.94,29.87],
+  SA:[23.89,45.08],SN:[14.50,-14.45],RS:[44.02,21.01],SL:[8.46,-11.78],
+  SG:[1.35,103.82],SK:[48.67,19.70],SI:[46.15,14.99],SO:[5.15,46.20],
+  ZA:[-30.56,22.94],KR:[35.91,127.77],SS:[6.88,31.31],ES:[40.46,-3.75],
+  LK:[7.87,80.77],SD:[12.86,30.22],SE:[60.13,18.64],CH:[46.82,8.23],
+  SY:[34.80,38.997],TW:[23.70,120.96],TJ:[38.86,71.28],TZ:[-6.37,34.89],
+  TH:[15.87,100.99],TG:[8.62,0.82],TT:[10.69,-61.22],TN:[33.89,9.54],
+  TR:[38.96,35.24],TM:[38.97,59.56],UG:[1.37,32.29],UA:[48.38,31.17],
+  AE:[23.42,53.85],GB:[55.38,-3.44],US:[37.09,-95.71],UY:[-32.52,-55.77],
+  UZ:[41.38,64.59],VE:[6.42,-66.59],VN:[14.06,108.28],YE:[15.55,48.52],
+  ZM:[-13.13,27.85],ZW:[-19.02,29.15],
+};
+
+function mapOutageSeverity(outageType) {
+  if (outageType === 'NATIONWIDE') return 'OUTAGE_SEVERITY_TOTAL';
+  if (outageType === 'REGIONAL') return 'OUTAGE_SEVERITY_MAJOR';
+  return 'OUTAGE_SEVERITY_PARTIAL';
+}
+
+function toEpochMs(value) {
+  if (!value) return 0;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? 0 : d.getTime();
+}
+
+async function fetchOutages() {
+  const token = process.env.CLOUDFLARE_API_TOKEN;
+  if (!token) {
+    console.error('CLOUDFLARE_API_TOKEN not set — skipping');
+    process.exit(0);
+  }
+
+  const resp = await fetch(`${CF_RADAR_URL}?dateRange=7d&limit=50`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'User-Agent': CHROME_UA,
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) throw new Error(`Cloudflare Radar API error: ${resp.status}`);
+
+  const data = await resp.json();
+  if (data.configured === false || !data.success || data.errors?.length) {
+    throw new Error(`Cloudflare Radar error: ${JSON.stringify(data.errors || [])}`);
+  }
+
+  const outages = [];
+  for (const raw of data.result?.annotations || []) {
+    if (!raw.locations?.length) continue;
+    const countryCode = raw.locations[0];
+    if (!countryCode) continue;
+
+    const coords = COUNTRY_COORDS[countryCode];
+    if (!coords) continue;
+
+    const countryName = raw.locationsDetails?.[0]?.name ?? countryCode;
+
+    const categories = ['Cloudflare Radar'];
+    if (raw.outage?.outageCause) categories.push(raw.outage.outageCause.replace(/_/g, ' '));
+    if (raw.outage?.outageType) categories.push(raw.outage.outageType);
+    for (const asn of raw.asnsDetails?.slice(0, 2) || []) {
+      if (asn.name) categories.push(asn.name);
+    }
+
+    outages.push({
+      id: `cf-${raw.id}`,
+      title: raw.scope ? `${raw.scope} outage in ${countryName}` : `Internet disruption in ${countryName}`,
+      link: raw.linkedUrl || 'https://radar.cloudflare.com/outage-center',
+      description: raw.description,
+      detectedAt: toEpochMs(raw.startDate),
+      country: countryName,
+      region: '',
+      location: { latitude: coords[0], longitude: coords[1] },
+      severity: mapOutageSeverity(raw.outage?.outageType),
+      categories,
+      cause: raw.outage?.outageCause || '',
+      outageType: raw.outage?.outageType || '',
+      endedAt: toEpochMs(raw.endDate),
+    });
+  }
+
+  return { outages, pagination: undefined };
+}
+
+function validate(data) {
+  return data && Array.isArray(data.outages);
+}
+
+runSeed('infra', 'outages', CANONICAL_KEY, fetchOutages, {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: 'cloudflare-radar-7d',
+}).catch((err) => {
+  console.error('FATAL:', err.message || err);
+  process.exit(1);
+});

--- a/scripts/seed-natural-events.mjs
+++ b/scripts/seed-natural-events.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const EONET_API_URL = 'https://eonet.gsfc.nasa.gov/api/v3/events';
+const GDACS_API = 'https://www.gdacs.org/gdacsapi/api/events/geteventlist/MAP';
+const CANONICAL_KEY = 'natural:events:v1';
+const CACHE_TTL = 3600; // 1 hour
+
+const DAYS = 30;
+const WILDFIRE_MAX_AGE_MS = 48 * 60 * 60 * 1000;
+
+const GDACS_TO_CATEGORY = {
+  EQ: 'earthquakes',
+  FL: 'floods',
+  TC: 'severeStorms',
+  VO: 'volcanoes',
+  WF: 'wildfires',
+  DR: 'drought',
+};
+
+const EVENT_TYPE_NAMES = {
+  EQ: 'Earthquake',
+  FL: 'Flood',
+  TC: 'Tropical Cyclone',
+  VO: 'Volcano',
+  WF: 'Wildfire',
+  DR: 'Drought',
+};
+
+async function fetchEonet(days) {
+  const url = `${EONET_API_URL}?status=open&days=${days}`;
+  const res = await fetch(url, {
+    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) throw new Error(`EONET ${res.status}`);
+
+  const data = await res.json();
+  const events = [];
+  const now = Date.now();
+
+  for (const event of data.events || []) {
+    const category = event.categories?.[0];
+    if (!category) continue;
+    if (category.id === 'earthquakes') continue;
+
+    const latestGeo = event.geometry?.[event.geometry.length - 1];
+    if (!latestGeo || latestGeo.type !== 'Point') continue;
+
+    const eventDate = new Date(latestGeo.date);
+    const [lon, lat] = latestGeo.coordinates;
+
+    if (category.id === 'wildfires' && now - eventDate.getTime() > WILDFIRE_MAX_AGE_MS) continue;
+
+    const source = event.sources?.[0];
+    events.push({
+      id: event.id || '',
+      title: event.title || '',
+      description: event.description || '',
+      category: category.id || '',
+      categoryTitle: category.title || '',
+      lat,
+      lon,
+      date: eventDate.getTime(),
+      magnitude: latestGeo.magnitudeValue ?? 0,
+      magnitudeUnit: latestGeo.magnitudeUnit || '',
+      sourceUrl: source?.url || '',
+      sourceName: source?.id || '',
+      closed: event.closed !== null,
+    });
+  }
+
+  return events;
+}
+
+async function fetchGdacs() {
+  const res = await fetch(GDACS_API, {
+    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) throw new Error(`GDACS ${res.status}`);
+
+  const data = await res.json();
+  const features = data.features || [];
+  const seen = new Set();
+  const events = [];
+
+  for (const f of features) {
+    if (!f.geometry || f.geometry.type !== 'Point') continue;
+    const props = f.properties;
+    const key = `${props.eventtype}-${props.eventid}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    if (props.alertlevel === 'Green') continue;
+
+    const category = GDACS_TO_CATEGORY[props.eventtype] || 'manmade';
+    const alertPrefix = props.alertlevel === 'Red' ? '\u{1F534} ' : props.alertlevel === 'Orange' ? '\u{1F7E0} ' : '';
+    const description = props.description || EVENT_TYPE_NAMES[props.eventtype] || props.eventtype;
+    const severity = props.severitydata?.severitytext || '';
+
+    events.push({
+      id: `gdacs-${props.eventtype}-${props.eventid}`,
+      title: `${alertPrefix}${props.name || ''}`,
+      description: `${description}${severity ? ` - ${severity}` : ''}`,
+      category,
+      categoryTitle: description,
+      lat: f.geometry.coordinates[1] ?? 0,
+      lon: f.geometry.coordinates[0] ?? 0,
+      date: new Date(props.fromdate || 0).getTime(),
+      magnitude: 0,
+      magnitudeUnit: '',
+      sourceUrl: props.url?.report || '',
+      sourceName: 'GDACS',
+      closed: false,
+    });
+  }
+
+  return events.slice(0, 100);
+}
+
+async function fetchNaturalEvents() {
+  const [eonetResult, gdacsResult] = await Promise.allSettled([
+    fetchEonet(DAYS),
+    fetchGdacs(),
+  ]);
+
+  const eonetEvents = eonetResult.status === 'fulfilled' ? eonetResult.value : [];
+  const gdacsEvents = gdacsResult.status === 'fulfilled' ? gdacsResult.value : [];
+
+  if (eonetResult.status === 'rejected') console.error('[EONET]', eonetResult.reason?.message);
+  if (gdacsResult.status === 'rejected') console.error('[GDACS]', gdacsResult.reason?.message);
+
+  const seenLocations = new Set();
+  const merged = [];
+
+  for (const event of gdacsEvents) {
+    const k = `${event.lat.toFixed(1)}-${event.lon.toFixed(1)}-${event.category}`;
+    if (!seenLocations.has(k)) {
+      seenLocations.add(k);
+      merged.push(event);
+    }
+  }
+  for (const event of eonetEvents) {
+    const k = `${event.lat.toFixed(1)}-${event.lon.toFixed(1)}-${event.category}`;
+    if (!seenLocations.has(k)) {
+      seenLocations.add(k);
+      merged.push(event);
+    }
+  }
+
+  if (merged.length === 0) return null;
+  return { events: merged };
+}
+
+function validate(data) {
+  return Array.isArray(data?.events) && data.events.length >= 1;
+}
+
+runSeed('natural', 'events', CANONICAL_KEY, fetchNaturalEvents, {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: 'eonet+gdacs',
+}).catch((err) => {
+  console.error('FATAL:', err.message || err);
+  process.exit(1);
+});

--- a/scripts/seed-stablecoin-markets.mjs
+++ b/scripts/seed-stablecoin-markets.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY = 'market:stablecoins:v1';
+const CACHE_TTL = 3600; // 1 hour
+
+const STABLECOIN_IDS = 'tether,usd-coin,dai,first-digital-usd,ethena-usde';
+
+async function fetchStablecoinMarkets() {
+  const url = `https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=${STABLECOIN_IDS}&order=market_cap_desc&sparkline=false&price_change_percentage=7d`;
+  const resp = await fetch(url, {
+    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) throw new Error(`CoinGecko HTTP ${resp.status}`);
+
+  const data = await resp.json();
+  if (!Array.isArray(data) || data.length === 0) {
+    throw new Error('CoinGecko returned no stablecoin data');
+  }
+
+  const stablecoins = data.map((coin) => {
+    const price = coin.current_price || 0;
+    const deviation = Math.abs(price - 1.0);
+    let pegStatus;
+    if (deviation <= 0.005) pegStatus = 'ON PEG';
+    else if (deviation <= 0.01) pegStatus = 'SLIGHT DEPEG';
+    else pegStatus = 'DEPEGGED';
+
+    return {
+      id: coin.id,
+      symbol: (coin.symbol || '').toUpperCase(),
+      name: coin.name,
+      price,
+      deviation: +(deviation * 100).toFixed(3),
+      pegStatus,
+      marketCap: coin.market_cap || 0,
+      volume24h: coin.total_volume || 0,
+      change24h: coin.price_change_percentage_24h || 0,
+      change7d: coin.price_change_percentage_7d_in_currency || 0,
+      image: coin.image || '',
+    };
+  });
+
+  const totalMarketCap = stablecoins.reduce((sum, c) => sum + c.marketCap, 0);
+  const totalVolume24h = stablecoins.reduce((sum, c) => sum + c.volume24h, 0);
+  const depeggedCount = stablecoins.filter((c) => c.pegStatus === 'DEPEGGED').length;
+
+  return {
+    timestamp: new Date().toISOString(),
+    summary: {
+      totalMarketCap,
+      totalVolume24h,
+      coinCount: stablecoins.length,
+      depeggedCount,
+      healthStatus: depeggedCount === 0 ? 'HEALTHY' : depeggedCount === 1 ? 'CAUTION' : 'WARNING',
+    },
+    stablecoins,
+  };
+}
+
+function validate(data) {
+  return (
+    Array.isArray(data?.stablecoins) &&
+    data.stablecoins.length >= 1 &&
+    data.summary?.coinCount > 0
+  );
+}
+
+runSeed('market', 'stablecoins', CANONICAL_KEY, fetchStablecoinMarkets, {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: 'coingecko-stablecoins',
+}).catch((err) => {
+  console.error('FATAL:', err.message || err);
+  process.exit(1);
+});

--- a/scripts/seed-unrest-events.mjs
+++ b/scripts/seed-unrest-events.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const GDELT_GEO_URL = 'https://api.gdeltproject.org/api/v2/geo/geo';
+const ACLED_API_URL = 'https://acleddata.com/api/acled/read';
+const CANONICAL_KEY = 'unrest:events:v1';
+const CACHE_TTL = 3600;
+
+// ---------- ACLED Event Type Mapping (from _shared.ts) ----------
+
+function mapAcledEventType(eventType, subEventType) {
+  const lower = (eventType + ' ' + subEventType).toLowerCase();
+  if (lower.includes('riot') || lower.includes('mob violence')) return 'UNREST_EVENT_TYPE_RIOT';
+  if (lower.includes('strike')) return 'UNREST_EVENT_TYPE_STRIKE';
+  if (lower.includes('demonstration')) return 'UNREST_EVENT_TYPE_DEMONSTRATION';
+  if (lower.includes('protest')) return 'UNREST_EVENT_TYPE_PROTEST';
+  return 'UNREST_EVENT_TYPE_CIVIL_UNREST';
+}
+
+// ---------- Severity Classification (from _shared.ts) ----------
+
+function classifySeverity(fatalities, eventType) {
+  if (fatalities > 0 || eventType.toLowerCase().includes('riot')) return 'SEVERITY_LEVEL_HIGH';
+  if (eventType.toLowerCase().includes('protest')) return 'SEVERITY_LEVEL_MEDIUM';
+  return 'SEVERITY_LEVEL_LOW';
+}
+
+function classifyGdeltSeverity(count, name) {
+  const lowerName = name.toLowerCase();
+  if (count > 100 || lowerName.includes('riot') || lowerName.includes('clash')) return 'SEVERITY_LEVEL_HIGH';
+  if (count < 25) return 'SEVERITY_LEVEL_LOW';
+  return 'SEVERITY_LEVEL_MEDIUM';
+}
+
+function classifyGdeltEventType(name) {
+  const lowerName = name.toLowerCase();
+  if (lowerName.includes('riot')) return 'UNREST_EVENT_TYPE_RIOT';
+  if (lowerName.includes('strike')) return 'UNREST_EVENT_TYPE_STRIKE';
+  if (lowerName.includes('demonstration')) return 'UNREST_EVENT_TYPE_DEMONSTRATION';
+  return 'UNREST_EVENT_TYPE_PROTEST';
+}
+
+// ---------- Deduplication (from _shared.ts) ----------
+
+function deduplicateEvents(events) {
+  const unique = new Map();
+  for (const event of events) {
+    const lat = event.location?.latitude ?? 0;
+    const lon = event.location?.longitude ?? 0;
+    const latKey = Math.round(lat * 10) / 10;
+    const lonKey = Math.round(lon * 10) / 10;
+    const dateKey = new Date(event.occurredAt).toISOString().split('T')[0];
+    const key = `${latKey}:${lonKey}:${dateKey}`;
+
+    const existing = unique.get(key);
+    if (!existing) {
+      unique.set(key, event);
+    } else if (event.sourceType === 'UNREST_SOURCE_TYPE_ACLED' && existing.sourceType !== 'UNREST_SOURCE_TYPE_ACLED') {
+      event.sources = [...new Set([...event.sources, ...existing.sources])];
+      unique.set(key, event);
+    } else if (existing.sourceType === 'UNREST_SOURCE_TYPE_ACLED') {
+      existing.sources = [...new Set([...existing.sources, ...event.sources])];
+    } else {
+      existing.sources = [...new Set([...existing.sources, ...event.sources])];
+      if (existing.sources.length >= 2) existing.confidence = 'CONFIDENCE_LEVEL_HIGH';
+    }
+  }
+  return Array.from(unique.values());
+}
+
+// ---------- Sort (from _shared.ts) ----------
+
+function sortBySeverityAndRecency(events) {
+  const severityOrder = {
+    SEVERITY_LEVEL_HIGH: 0,
+    SEVERITY_LEVEL_MEDIUM: 1,
+    SEVERITY_LEVEL_LOW: 2,
+    SEVERITY_LEVEL_UNSPECIFIED: 3,
+  };
+  return events.sort((a, b) => {
+    const sevDiff = (severityOrder[a.severity] ?? 3) - (severityOrder[b.severity] ?? 3);
+    if (sevDiff !== 0) return sevDiff;
+    return b.occurredAt - a.occurredAt;
+  });
+}
+
+// ---------- ACLED Fetch ----------
+
+async function fetchAcledProtests() {
+  const token = process.env.ACLED_ACCESS_TOKEN;
+  if (!token) {
+    console.warn('  ACLED_ACCESS_TOKEN not set, skipping ACLED');
+    return [];
+  }
+
+  const now = Date.now();
+  const startDate = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+  const endDate = new Date(now).toISOString().split('T')[0];
+
+  const params = new URLSearchParams({
+    event_type: 'Protests',
+    event_date: `${startDate}|${endDate}`,
+    event_date_where: 'BETWEEN',
+    limit: '500',
+    _format: 'json',
+  });
+
+  const resp = await fetch(`${ACLED_API_URL}?${params}`, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+      'User-Agent': CHROME_UA,
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!resp.ok) throw new Error(`ACLED API error: ${resp.status}`);
+  const data = await resp.json();
+  if (data.message || data.error) throw new Error(data.message || data.error || 'ACLED API error');
+
+  const rawEvents = data.data || [];
+  console.log(`  ACLED: ${rawEvents.length} raw events`);
+
+  return rawEvents
+    .filter((e) => {
+      const lat = parseFloat(e.latitude || '');
+      const lon = parseFloat(e.longitude || '');
+      return Number.isFinite(lat) && Number.isFinite(lon) && lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
+    })
+    .map((e) => {
+      const fatalities = parseInt(e.fatalities || '', 10) || 0;
+      return {
+        id: `acled-${e.event_id_cnty}`,
+        title: e.notes?.slice(0, 200) || `${e.sub_event_type} in ${e.location}`,
+        summary: typeof e.notes === 'string' ? e.notes.substring(0, 500) : '',
+        eventType: mapAcledEventType(e.event_type || '', e.sub_event_type || ''),
+        city: e.location || '',
+        country: e.country || '',
+        region: e.admin1 || '',
+        location: {
+          latitude: parseFloat(e.latitude || '0'),
+          longitude: parseFloat(e.longitude || '0'),
+        },
+        occurredAt: new Date(e.event_date || '').getTime(),
+        severity: classifySeverity(fatalities, e.event_type || ''),
+        fatalities,
+        sources: [e.source].filter(Boolean),
+        sourceType: 'UNREST_SOURCE_TYPE_ACLED',
+        tags: e.tags?.split(';').map((t) => t.trim()).filter(Boolean) ?? [],
+        actors: [e.actor1, e.actor2].filter(Boolean),
+        confidence: 'CONFIDENCE_LEVEL_HIGH',
+      };
+    });
+}
+
+// ---------- GDELT Fetch ----------
+
+async function fetchGdeltEvents() {
+  const params = new URLSearchParams({
+    query: 'protest',
+    format: 'geojson',
+    maxrecords: '250',
+    timespan: '7d',
+  });
+
+  const resp = await fetch(`${GDELT_GEO_URL}?${params}`, {
+    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!resp.ok) throw new Error(`GDELT API error: ${resp.status}`);
+
+  const data = await resp.json();
+  const features = data?.features || [];
+  const seenLocations = new Set();
+  const events = [];
+
+  for (const feature of features) {
+    const name = feature.properties?.name || '';
+    if (!name || seenLocations.has(name)) continue;
+
+    const count = feature.properties?.count || 1;
+    if (count < 5) continue;
+
+    const coords = feature.geometry?.coordinates;
+    if (!Array.isArray(coords) || coords.length < 2) continue;
+
+    const [lon, lat] = coords;
+    if (!Number.isFinite(lat) || !Number.isFinite(lon) || lat < -90 || lat > 90 || lon < -180 || lon > 180) continue;
+
+    seenLocations.add(name);
+    const country = name.split(',').pop()?.trim() || name;
+
+    events.push({
+      id: `gdelt-${lat.toFixed(2)}-${lon.toFixed(2)}-${Date.now()}`,
+      title: `${name} (${count} reports)`,
+      summary: '',
+      eventType: classifyGdeltEventType(name),
+      city: name.split(',')[0]?.trim() || '',
+      country,
+      region: '',
+      location: { latitude: lat, longitude: lon },
+      occurredAt: Date.now(),
+      severity: classifyGdeltSeverity(count, name),
+      fatalities: 0,
+      sources: ['GDELT'],
+      sourceType: 'UNREST_SOURCE_TYPE_GDELT',
+      tags: [],
+      actors: [],
+      confidence: count > 20 ? 'CONFIDENCE_LEVEL_HIGH' : 'CONFIDENCE_LEVEL_MEDIUM',
+    });
+  }
+
+  console.log(`  GDELT: ${events.length} events`);
+  return events;
+}
+
+// ---------- Main Fetch ----------
+
+async function fetchUnrestEvents() {
+  const results = await Promise.allSettled([fetchAcledProtests(), fetchGdeltEvents()]);
+
+  const acledEvents = results[0].status === 'fulfilled' ? results[0].value : [];
+  const gdeltEvents = results[1].status === 'fulfilled' ? results[1].value : [];
+
+  if (results[0].status === 'rejected') console.warn(`  ACLED failed: ${results[0].reason?.message || results[0].reason}`);
+  if (results[1].status === 'rejected') console.warn(`  GDELT failed: ${results[1].reason?.message || results[1].reason}`);
+
+  const merged = deduplicateEvents([...acledEvents, ...gdeltEvents]);
+  const sorted = sortBySeverityAndRecency(merged);
+
+  console.log(`  Merged: ${acledEvents.length} ACLED + ${gdeltEvents.length} GDELT = ${sorted.length} deduplicated`);
+
+  return { events: sorted, clusters: [], pagination: undefined };
+}
+
+function validate(data) {
+  return Array.isArray(data?.events) && data.events.length >= 1;
+}
+
+runSeed('unrest', 'events', CANONICAL_KEY, fetchUnrestEvents, {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: 'acled+gdelt',
+}).catch((err) => {
+  console.error('FATAL:', err.message || err);
+  process.exit(1);
+});

--- a/scripts/validate-seed-migration.mjs
+++ b/scripts/validate-seed-migration.mjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+
+/**
+ * Post-deploy validation for seed migration.
+ *
+ * Usage:
+ *   node scripts/validate-seed-migration.mjs [--base-url URL]
+ *
+ * Requires: Referer header from trusted origin OR X-WorldMonitor-Key header.
+ * Uses api.worldmonitor.app by default.
+ */
+
+const BASE_URL = process.argv.includes('--base-url')
+  ? process.argv[process.argv.indexOf('--base-url') + 1]
+  : 'https://api.worldmonitor.app';
+
+const ORIGIN = 'https://worldmonitor.app';
+
+// ========================================================================
+// Test definitions — one per migrated handler
+// ========================================================================
+
+const TESTS = [
+  // Phase 1 — Snapshot endpoints
+  {
+    name: 'Earthquakes',
+    endpoint: '/api/seismology/v1/list-earthquakes',
+    validate: (d) => Array.isArray(d.earthquakes) && d.earthquakes.length > 0,
+    minRecords: 1,
+    field: 'earthquakes',
+  },
+  {
+    name: 'Fire Detections',
+    endpoint: '/api/wildfire/v1/list-fire-detections',
+    validate: (d) => Array.isArray(d.fireDetections),
+    minRecords: 0,
+    field: 'fireDetections',
+  },
+  {
+    name: 'Internet Outages',
+    endpoint: '/api/infrastructure/v1/list-internet-outages',
+    validate: (d) => Array.isArray(d.outages),
+    minRecords: 0,
+    field: 'outages',
+  },
+  {
+    name: 'Climate Anomalies',
+    endpoint: '/api/climate/v1/list-climate-anomalies',
+    validate: (d) => Array.isArray(d.anomalies) && d.anomalies.length > 0,
+    minRecords: 1,
+    field: 'anomalies',
+  },
+
+  // Phase 2 — Parameterized endpoints
+  {
+    name: 'Unrest Events',
+    endpoint: '/api/unrest/v1/list-unrest-events',
+    validate: (d) => Array.isArray(d.events),
+    minRecords: 0,
+    field: 'events',
+  },
+  {
+    name: 'Cyber Threats',
+    endpoint: '/api/cyber/v1/list-cyber-threats',
+    validate: (d) => Array.isArray(d.threats),
+    minRecords: 0,
+    field: 'threats',
+  },
+  {
+    name: 'Market Quotes',
+    endpoint: '/api/market/v1/list-market-quotes?symbols=AAPL,MSFT',
+    validate: (d) => Array.isArray(d.quotes) && d.quotes.length > 0,
+    minRecords: 1,
+    field: 'quotes',
+  },
+  {
+    name: 'Commodity Quotes',
+    endpoint: '/api/market/v1/list-commodity-quotes?symbols=GC%3DF,CL%3DF',
+    validate: (d) => Array.isArray(d.quotes) && d.quotes.length > 0,
+    minRecords: 1,
+    field: 'quotes',
+  },
+  {
+    name: 'Crypto Quotes',
+    endpoint: '/api/market/v1/list-crypto-quotes',
+    validate: (d) => Array.isArray(d.quotes),
+    minRecords: 0,
+    field: 'quotes',
+  },
+  {
+    name: 'ETF Flows',
+    endpoint: '/api/market/v1/list-etf-flows',
+    validate: (d) => Array.isArray(d.etfs),
+    minRecords: 0,
+    field: 'etfs',
+  },
+  {
+    name: 'Gulf Quotes',
+    endpoint: '/api/market/v1/list-gulf-quotes',
+    validate: (d) => Array.isArray(d.quotes),
+    minRecords: 0,
+    field: 'quotes',
+  },
+  {
+    name: 'Stablecoin Markets',
+    endpoint: '/api/market/v1/list-stablecoin-markets',
+    validate: (d) => Array.isArray(d.stablecoins),
+    minRecords: 0,
+    field: 'stablecoins',
+  },
+
+  // Phase 3 — Hybrid endpoints
+  {
+    name: 'Natural Events',
+    endpoint: '/api/natural/v1/list-natural-events',
+    validate: (d) => Array.isArray(d.events),
+    minRecords: 0,
+    field: 'events',
+  },
+  {
+    name: 'Displacement Summary',
+    endpoint: '/api/displacement/v1/get-displacement-summary',
+    validate: (d) => d.summary && typeof d.summary.year === 'number',
+    minRecords: null,
+    field: null,
+  },
+];
+
+// ========================================================================
+// Seed Health check
+// ========================================================================
+
+const API_KEY = process.env.WORLDMONITOR_KEY || '';
+
+const SEED_HEALTH_TEST = {
+  name: 'Seed Health',
+  endpoint: '/api/seed-health',
+  validate: (d) => d.overall && d.seeds && typeof d.checkedAt === 'number',
+};
+
+// ========================================================================
+// Runner
+// ========================================================================
+
+const PASS = '\x1b[32m✓\x1b[0m';
+const FAIL = '\x1b[31m✗\x1b[0m';
+const WARN = '\x1b[33m⚠\x1b[0m';
+const BOLD = '\x1b[1m';
+const RESET = '\x1b[0m';
+
+async function fetchEndpoint(endpoint) {
+  const url = `${BASE_URL}${endpoint}`;
+  const resp = await fetch(url, {
+    headers: {
+      Accept: 'application/json',
+      Origin: ORIGIN,
+      Referer: `${ORIGIN}/`,
+      'User-Agent': 'validate-seed-migration/1.0',
+      ...(API_KEY ? { 'X-WorldMonitor-Key': API_KEY } : {}),
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+  return { status: resp.status, data: resp.ok ? await resp.json() : null };
+}
+
+async function runTest(test) {
+  const t0 = Date.now();
+  try {
+    const { status, data } = await fetchEndpoint(test.endpoint);
+    const elapsed = Date.now() - t0;
+
+    if (status !== 200) {
+      return { name: test.name, pass: false, reason: `HTTP ${status}`, elapsed };
+    }
+
+    if (!data) {
+      return { name: test.name, pass: false, reason: 'Empty response body', elapsed };
+    }
+
+    if (!test.validate(data)) {
+      return { name: test.name, pass: false, reason: 'Validation failed — unexpected shape', elapsed, data };
+    }
+
+    const count = test.field ? (data[test.field]?.length ?? 0) : null;
+    const belowMin = test.minRecords != null && count != null && count < test.minRecords;
+
+    return {
+      name: test.name,
+      pass: !belowMin,
+      warn: belowMin,
+      reason: belowMin ? `Only ${count} records (expected >= ${test.minRecords})` : null,
+      count,
+      elapsed,
+    };
+  } catch (err) {
+    return { name: test.name, pass: false, reason: err.message, elapsed: Date.now() - t0 };
+  }
+}
+
+async function runSeedHealth() {
+  try {
+    const { status, data } = await fetchEndpoint(SEED_HEALTH_TEST.endpoint);
+    if (status !== 200 || !data) {
+      return { pass: false, reason: `HTTP ${status}`, seeds: null };
+    }
+    return { pass: true, overall: data.overall, seeds: data.seeds };
+  } catch (err) {
+    return { pass: false, reason: err.message, seeds: null };
+  }
+}
+
+// ========================================================================
+// Main
+// ========================================================================
+
+async function main() {
+  console.log(`\n${BOLD}=== Seed Migration Validation ===${RESET}`);
+  console.log(`Base URL: ${BASE_URL}\n`);
+
+  // 1. Seed Health
+  console.log(`${BOLD}--- Seed Health ---${RESET}`);
+  const health = await runSeedHealth();
+  if (health.pass && health.seeds) {
+    const icon = health.overall === 'healthy' ? PASS
+      : health.overall === 'warning' ? WARN : FAIL;
+    console.log(`  ${icon} Overall: ${health.overall}`);
+    for (const [domain, info] of Object.entries(health.seeds)) {
+      const dIcon = info.status === 'ok' ? PASS
+        : info.status === 'stale' ? WARN : FAIL;
+      const age = info.ageMinutes != null ? ` (${info.ageMinutes}m ago)` : '';
+      const count = info.recordCount != null ? `, ${info.recordCount} records` : '';
+      console.log(`    ${dIcon} ${domain}: ${info.status}${age}${count}`);
+    }
+  } else {
+    console.log(`  ${FAIL} Seed health check failed: ${health.reason}`);
+  }
+
+  // 2. RPC Endpoints
+  console.log(`\n${BOLD}--- RPC Endpoints (${TESTS.length} handlers) ---${RESET}`);
+  const results = [];
+  for (const test of TESTS) {
+    const result = await runTest(test);
+    results.push(result);
+    const icon = result.pass ? PASS : result.warn ? WARN : FAIL;
+    const countStr = result.count != null ? ` [${result.count} records]` : '';
+    const timeStr = ` (${result.elapsed}ms)`;
+    const reasonStr = result.reason ? ` — ${result.reason}` : '';
+    console.log(`  ${icon} ${result.name}${countStr}${timeStr}${reasonStr}`);
+  }
+
+  // 3. Summary
+  const passed = results.filter((r) => r.pass).length;
+  const failed = results.filter((r) => !r.pass).length;
+  const total = results.length;
+
+  console.log(`\n${BOLD}--- Summary ---${RESET}`);
+  console.log(`  ${passed}/${total} passed, ${failed} failed`);
+
+  if (failed > 0) {
+    console.log(`\n  ${FAIL} Failed endpoints:`);
+    for (const r of results.filter((r) => !r.pass)) {
+      console.log(`    - ${r.name}: ${r.reason}`);
+    }
+  }
+
+  // 4. Cross-validation: compare seed health vs RPC data
+  if (health.seeds) {
+    console.log(`\n${BOLD}--- Cross-Validation ---${RESET}`);
+    const seedDomainToTest = {
+      'seismology:earthquakes': 'Earthquakes',
+      'wildfire:fires': 'Fire Detections',
+      'infra:outages': 'Internet Outages',
+      'climate:anomalies': 'Climate Anomalies',
+      'unrest:events': 'Unrest Events',
+      'cyber:threats': 'Cyber Threats',
+      'market:crypto': 'Crypto Quotes',
+      'market:etf-flows': 'ETF Flows',
+      'market:gulf-quotes': 'Gulf Quotes',
+      'market:stablecoins': 'Stablecoin Markets',
+      'natural:events': 'Natural Events',
+      'displacement:summary': 'Displacement Summary',
+    };
+
+    for (const [domain, testName] of Object.entries(seedDomainToTest)) {
+      const seedInfo = health.seeds[domain];
+      const rpcResult = results.find((r) => r.name === testName);
+      if (!seedInfo || !rpcResult) continue;
+
+      if (seedInfo.status === 'ok' && rpcResult.pass) {
+        console.log(`  ${PASS} ${domain}: seed fresh + RPC returns data`);
+      } else if (seedInfo.status === 'ok' && !rpcResult.pass) {
+        console.log(`  ${FAIL} ${domain}: seed fresh but RPC failed (${rpcResult.reason})`);
+      } else if (seedInfo.status !== 'ok' && rpcResult.pass) {
+        console.log(`  ${WARN} ${domain}: seed ${seedInfo.status} but RPC still returns data (fallback working)`);
+      } else {
+        console.log(`  ${FAIL} ${domain}: seed ${seedInfo.status} AND RPC failed`);
+      }
+    }
+  }
+
+  console.log('');
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('Validation script crashed:', err);
+  process.exit(2);
+});

--- a/server/worldmonitor/climate/v1/list-climate-anomalies.ts
+++ b/server/worldmonitor/climate/v1/list-climate-anomalies.ts
@@ -18,10 +18,11 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/climate/v1/service_server';
 
 import { CHROME_UA } from '../../../_shared/constants';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'climate:anomalies:v1';
 const REDIS_CACHE_TTL = 10800; // 3h — Open-Meteo Archive uses ERA5 reanalysis with 2-7 day lag
+const SEED_FRESHNESS_MS = 150 * 60 * 1000; // 2.5 hours
 
 /** The 15 monitored zones matching the legacy api/climate-anomalies.js list. */
 const ZONES: { name: string; lat: number; lon: number }[] = [
@@ -135,10 +136,37 @@ async function fetchZone(
   };
 }
 
+type AnomalyCache = { anomalies: ClimateAnomaly[]; pagination: undefined };
+
+async function trySeededData(): Promise<AnomalyCache | null> {
+  try {
+    const [seedData, seedMeta] = await Promise.all([
+      getCachedJson(REDIS_CACHE_KEY, true) as Promise<AnomalyCache | null>,
+      getCachedJson('seed-meta:climate:anomalies', true) as Promise<{ fetchedAt?: number } | null>,
+    ]);
+
+    if (!seedData?.anomalies?.length) return null;
+
+    const fetchedAt = seedMeta?.fetchedAt ?? 0;
+    const isFresh = Date.now() - fetchedAt < SEED_FRESHNESS_MS;
+
+    if (isFresh) return seedData;
+
+    if (!process.env.SEED_FALLBACK_CLIMATE) return seedData;
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export const listClimateAnomalies: ClimateServiceHandler['listClimateAnomalies'] = async (
   _ctx: ServerContext,
   _req: ListClimateAnomaliesRequest,
 ): Promise<ListClimateAnomaliesResponse> => {
+  const seeded = await trySeededData();
+  if (seeded) return { anomalies: seeded.anomalies, pagination: undefined };
+
   let result: ListClimateAnomaliesResponse | null = null;
   try {
     result = await cachedFetchJson<ListClimateAnomaliesResponse>(

--- a/server/worldmonitor/cyber/v1/list-cyber-threats.ts
+++ b/server/worldmonitor/cyber/v1/list-cyber-threats.ts
@@ -4,7 +4,7 @@ import type {
   ListCyberThreatsResponse,
 } from '../../../../src/generated/server/worldmonitor/cyber/v1/service_server';
 
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 import {
   DEFAULT_LIMIT,
@@ -30,9 +30,9 @@ type CachedThreats = Pick<ListCyberThreatsResponse, 'threats'>;
 
 const REDIS_CACHE_KEY = 'cyber:threats:v2';
 const REDIS_CACHE_TTL = 7200; // 2 hr — IOC feeds update at most daily
-const MAX_CACHED_THREATS = 2000; // cap cached set to avoid oversized Redis values
+const MAX_CACHED_THREATS = 2000;
+const SEED_FRESHNESS_MS = 150 * 60 * 1000; // 2.5 hours
 
-/** Parse a cursor string into a numeric offset. Invalid/negative values reset to page 1. */
 function parseCursor(cursor: string | undefined): number {
   if (!cursor) return 0;
   const n = parseInt(cursor, 10);
@@ -41,6 +41,50 @@ function parseCursor(cursor: string | undefined): number {
     return 0;
   }
   return n;
+}
+
+function filterSeededThreats(
+  threats: ListCyberThreatsResponse['threats'],
+  req: ListCyberThreatsRequest,
+): ListCyberThreatsResponse['threats'] {
+  let results = threats;
+  if (req.type && req.type !== 'CYBER_THREAT_TYPE_UNSPECIFIED') {
+    results = results.filter((t) => t.type === req.type);
+  }
+  if (req.source && req.source !== 'CYBER_THREAT_SOURCE_UNSPECIFIED') {
+    results = results.filter((t) => t.source === req.source);
+  }
+  if (req.minSeverity && req.minSeverity !== 'CRITICALITY_LEVEL_UNSPECIFIED') {
+    const minRank = SEVERITY_RANK[req.minSeverity] || 0;
+    results = results.filter((t) => (SEVERITY_RANK[t.severity || ''] || 0) >= minRank);
+  }
+  return results;
+}
+
+async function trySeededData(req: ListCyberThreatsRequest): Promise<CachedThreats | null> {
+  try {
+    const [seedData, seedMeta] = await Promise.all([
+      getCachedJson(REDIS_CACHE_KEY, true) as Promise<CachedThreats | null>,
+      getCachedJson('seed-meta:cyber:threats', true) as Promise<{ fetchedAt?: number } | null>,
+    ]);
+
+    if (!seedData?.threats?.length) return null;
+
+    const fetchedAt = seedMeta?.fetchedAt ?? 0;
+    const isFresh = Date.now() - fetchedAt < SEED_FRESHNESS_MS;
+
+    if (isFresh) {
+      return { threats: filterSeededThreats(seedData.threats, req) };
+    }
+
+    if (!process.env.SEED_FALLBACK_CYBER) {
+      return { threats: filterSeededThreats(seedData.threats, req) };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 export async function listCyberThreats(
@@ -55,13 +99,21 @@ export async function listCyberThreats(
     const pageSize = clampInt(req.pageSize, DEFAULT_LIMIT, 1, MAX_LIMIT);
     const offset = parseCursor(req.cursor);
 
-    // Cache key excludes pageSize and cursor — cache holds the full filtered result set.
-    // Changing filter params (start, type, source, minSeverity) between pages resets pagination
-    // because the underlying result set changes. Clients must keep filters stable across pages.
+    const seeded = await trySeededData(req);
+    if (seeded) {
+      const allThreats = seeded.threats;
+      if (offset >= allThreats.length) return empty;
+      const page = allThreats.slice(offset, offset + pageSize);
+      const hasMore = offset + pageSize < allThreats.length;
+      return {
+        threats: page,
+        pagination: { totalCount: allThreats.length, nextCursor: hasMore ? String(offset + pageSize) : '' },
+      };
+    }
+
     const cacheKey = `${REDIS_CACHE_KEY}:${req.start || 0}:${req.type || ''}:${req.source || ''}:${req.minSeverity || ''}`;
 
     const cached = await cachedFetchJson<CachedThreats>(cacheKey, REDIS_CACHE_TTL, async () => {
-      // Derive days from timeRange or use default
       let days = DEFAULT_DAYS;
       if (req.start) {
         days = clampInt(
@@ -71,7 +123,6 @@ export async function listCyberThreats(
       }
       const cutoffMs = now - days * 24 * 60 * 60 * 1000;
 
-      // Fetch all sources in parallel — use MAX_LIMIT so the cache covers all pages.
       const [feodo, urlhaus, c2intel, otx, abuseipdb] = await Promise.all([
         fetchFeodoSource(MAX_LIMIT, cutoffMs),
         fetchUrlhausSource(MAX_LIMIT, cutoffMs),
@@ -83,7 +134,6 @@ export async function listCyberThreats(
       const anySucceeded = feodo.ok || urlhaus.ok || c2intel.ok || otx.ok || abuseipdb.ok;
       if (!anySucceeded) return null;
 
-      // Merge, deduplicate, hydrate coordinates
       const combined = dedupeThreats([
         ...feodo.threats,
         ...urlhaus.threats,
@@ -94,11 +144,9 @@ export async function listCyberThreats(
 
       const hydrated = await hydrateThreatCoordinates(combined);
 
-      // Filter to only threats with valid coordinates
       let results = hydrated
         .filter((t) => t.lat !== null && t.lon !== null && t.lat >= -90 && t.lat <= 90 && t.lon >= -180 && t.lon <= 180);
 
-      // Apply optional filters BEFORE sorting (C-2 fix)
       if (req.type && req.type !== 'CYBER_THREAT_TYPE_UNSPECIFIED') {
         const filterType = req.type;
         results = results.filter((t) => THREAT_TYPE_MAP[t.type] === filterType);
@@ -112,7 +160,6 @@ export async function listCyberThreats(
         results = results.filter((t) => (SEVERITY_RANK[SEVERITY_MAP[t.severity] || ''] || 0) >= minRank);
       }
 
-      // Sort by severity then recency — store the full sorted set (no slice).
       results.sort((a, b) => {
         const bySeverity = (SEVERITY_RANK[SEVERITY_MAP[b.severity] || ''] || 0)
           - (SEVERITY_RANK[SEVERITY_MAP[a.severity] || ''] || 0);
@@ -126,7 +173,6 @@ export async function listCyberThreats(
 
     if (!cached) return empty;
 
-    // Apply cursor-based pagination over the cached full result set.
     const allThreats = cached.threats;
     if (offset >= allThreats.length) return empty;
     const page = allThreats.slice(offset, offset + pageSize);

--- a/server/worldmonitor/displacement/v1/get-displacement-summary.ts
+++ b/server/worldmonitor/displacement/v1/get-displacement-summary.ts
@@ -13,10 +13,11 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/displacement/v1/service_server';
 
 import { CHROME_UA } from '../../../_shared/constants';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'displacement:summary:v1';
 const REDIS_CACHE_TTL = 43200; // 12 hr — annual UNHCR data, very slow-moving
+const SEED_FRESHNESS_MS = 7 * 60 * 60 * 1000; // 7 hours — seed runs every 6hr
 
 // ---------- Country centroids (ISO3 -> [lat, lon]) ----------
 
@@ -123,6 +124,36 @@ interface MergedCountry {
   hostTotal: number;
 }
 
+// ---------- Seed-first helpers ----------
+
+async function trySeededData(req: GetDisplacementSummaryRequest): Promise<GetDisplacementSummaryResponse | null> {
+  try {
+    const year = req.year > 0 ? req.year : new Date().getFullYear();
+    const seedKey = `${REDIS_CACHE_KEY}:${year}`;
+    const [seedData, seedMeta] = await Promise.all([
+      getCachedJson(seedKey, true) as Promise<GetDisplacementSummaryResponse | null>,
+      getCachedJson('seed-meta:displacement:summary', true) as Promise<{ fetchedAt?: number } | null>,
+    ]);
+
+    if (!seedData?.summary) return null;
+
+    const fetchedAt = seedMeta?.fetchedAt ?? 0;
+    const isFresh = Date.now() - fetchedAt < SEED_FRESHNESS_MS;
+
+    if (isFresh || !process.env.SEED_FALLBACK_DISPLACEMENT) {
+      const summary = { ...seedData.summary };
+      if (req.countryLimit > 0) summary.countries = summary.countries.slice(0, req.countryLimit);
+      const flowLimit = req.flowLimit > 0 ? req.flowLimit : 50;
+      summary.topFlows = summary.topFlows.slice(0, flowLimit);
+      return { summary };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 // ---------- RPC handler ----------
 
 export async function getDisplacementSummary(
@@ -139,6 +170,9 @@ export async function getDisplacementSummary(
   };
 
   try {
+    const seeded = await trySeededData(req);
+    if (seeded) return seeded;
+
     // Redis shared cache (keyed by year)
     const year = req.year > 0 ? req.year : new Date().getFullYear();
     const cacheKey = `${REDIS_CACHE_KEY}:${year}`;

--- a/server/worldmonitor/infrastructure/v1/list-internet-outages.ts
+++ b/server/worldmonitor/infrastructure/v1/list-internet-outages.ts
@@ -8,12 +8,12 @@ import type {
 
 import { UPSTREAM_TIMEOUT_MS } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'infra:outages:v1';
 const REDIS_CACHE_TTL = 1800; // 30 min — Cloudflare Radar rate-limited
-
-let fallbackOutagesCache: { data: ListInternetOutagesResponse; ts: number } | null = null;
+const SEED_FRESHNESS_KEY = 'seed-meta:infra:outages';
+const SEED_MAX_AGE_MS = 45 * 60 * 1000; // 45 min
 
 // ========================================================================
 // Constants
@@ -137,6 +137,21 @@ export async function listInternetOutages(
   req: ListInternetOutagesRequest,
 ): Promise<ListInternetOutagesResponse> {
   try {
+    const [seedData, seedMeta] = await Promise.all([
+      getCachedJson(REDIS_CACHE_KEY, true) as Promise<ListInternetOutagesResponse | null>,
+      getCachedJson(SEED_FRESHNESS_KEY, true) as Promise<{ fetchedAt?: number } | null>,
+    ]);
+    if (seedData?.outages) {
+      const isFresh = (seedMeta?.fetchedAt ?? 0) > 0 && (Date.now() - seedMeta!.fetchedAt!) < SEED_MAX_AGE_MS;
+      if (isFresh || !process.env.SEED_FALLBACK_OUTAGES) {
+        return { outages: filterOutages(seedData.outages, req), pagination: undefined };
+      }
+    }
+  } catch {
+    // Fall through to live fetch
+  }
+
+  try {
     const result = await cachedFetchJson<ListInternetOutagesResponse>(REDIS_CACHE_KEY, REDIS_CACHE_TTL, async () => {
       const token = process.env.CLOUDFLARE_API_TOKEN;
       if (!token) return null;
@@ -192,11 +207,8 @@ export async function listInternetOutages(
       return outages.length > 0 ? { outages, pagination: undefined } : null;
     });
 
-    if (result) fallbackOutagesCache = { data: result, ts: Date.now() };
-    const effective = result || fallbackOutagesCache?.data;
-    return { outages: filterOutages(effective?.outages || [], req), pagination: undefined };
+    return { outages: filterOutages(result?.outages || [], req), pagination: undefined };
   } catch {
-    const stale = fallbackOutagesCache?.data?.outages || [];
-    return { outages: filterOutages(stale, req), pagination: undefined };
+    return { outages: [], pagination: undefined };
   }
 }

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -8,8 +8,13 @@ import type {
   SeverityLevel,
 } from '../../../../src/generated/server/worldmonitor/intelligence/v1/service_server';
 
-import { getCachedJson } from '../../../_shared/redis';
+import { getCachedJson, setCachedJson, cachedFetchJson } from '../../../_shared/redis';
 import { TIER1_COUNTRIES } from './_shared';
+import { fetchAcledCached } from '../../../_shared/acled';
+
+// ========================================================================
+// Country risk baselines and multipliers
+// ========================================================================
 
 const BASELINE_RISK: Record<string, number> = {
   US: 5, RU: 35, CN: 25, UA: 50, IR: 40, IL: 45, TW: 30, KP: 45,
@@ -17,20 +22,265 @@ const BASELINE_RISK: Record<string, number> = {
   SY: 50, YE: 50, MM: 45, VE: 40,
 };
 
-function computeBaselineScores(): CiiScore[] {
+const EVENT_MULTIPLIER: Record<string, number> = {
+  US: 0.3, RU: 2.0, CN: 2.5, UA: 0.8, IR: 2.0, IL: 0.7, TW: 1.5, KP: 3.0,
+  SA: 2.0, TR: 1.2, PL: 0.8, DE: 0.5, FR: 0.6, GB: 0.5, IN: 0.8, PK: 1.5,
+  SY: 0.7, YE: 0.7, MM: 1.8, VE: 1.8,
+};
+
+const COUNTRY_KEYWORDS: Record<string, string[]> = {
+  US: ['united states', 'usa', 'america', 'washington', 'biden', 'trump', 'pentagon'],
+  RU: ['russia', 'moscow', 'kremlin', 'putin'],
+  CN: ['china', 'beijing', 'xi jinping', 'prc'],
+  UA: ['ukraine', 'kyiv', 'zelensky', 'donbas'],
+  IR: ['iran', 'tehran', 'khamenei', 'irgc'],
+  IL: ['israel', 'tel aviv', 'netanyahu', 'idf', 'gaza'],
+  TW: ['taiwan', 'taipei'],
+  KP: ['north korea', 'pyongyang', 'kim jong'],
+  SA: ['saudi arabia', 'riyadh'],
+  TR: ['turkey', 'ankara', 'erdogan'],
+  PL: ['poland', 'warsaw'],
+  DE: ['germany', 'berlin'],
+  FR: ['france', 'paris', 'macron'],
+  GB: ['britain', 'uk', 'london'],
+  IN: ['india', 'delhi', 'modi'],
+  PK: ['pakistan', 'islamabad'],
+  SY: ['syria', 'damascus'],
+  YE: ['yemen', 'sanaa', 'houthi'],
+  MM: ['myanmar', 'burma'],
+  VE: ['venezuela', 'caracas', 'maduro'],
+};
+
+const COUNTRY_BBOX: Record<string, { minLat: number; maxLat: number; minLon: number; maxLon: number }> = {
+  US: { minLat: 24.5, maxLat: 49.4, minLon: -125.0, maxLon: -66.9 },
+  RU: { minLat: 41.2, maxLat: 81.9, minLon: 19.6, maxLon: 180.0 },
+  CN: { minLat: 18.2, maxLat: 53.6, minLon: 73.5, maxLon: 135.1 },
+  UA: { minLat: 44.4, maxLat: 52.4, minLon: 22.1, maxLon: 40.2 },
+  IR: { minLat: 25.1, maxLat: 39.8, minLon: 44.0, maxLon: 63.3 },
+  IL: { minLat: 29.5, maxLat: 33.3, minLon: 34.3, maxLon: 35.9 },
+  TW: { minLat: 21.9, maxLat: 25.3, minLon: 120.0, maxLon: 122.0 },
+  KP: { minLat: 37.7, maxLat: 43.0, minLon: 124.3, maxLon: 130.7 },
+  SA: { minLat: 16.4, maxLat: 32.2, minLon: 34.6, maxLon: 55.7 },
+  TR: { minLat: 36.0, maxLat: 42.1, minLon: 26.0, maxLon: 44.8 },
+  PL: { minLat: 49.0, maxLat: 54.8, minLon: 14.1, maxLon: 24.2 },
+  DE: { minLat: 47.3, maxLat: 55.1, minLon: 5.9, maxLon: 15.0 },
+  FR: { minLat: 41.4, maxLat: 51.1, minLon: -5.1, maxLon: 9.6 },
+  GB: { minLat: 49.9, maxLat: 60.9, minLon: -8.2, maxLon: 1.8 },
+  IN: { minLat: 6.7, maxLat: 35.5, minLon: 68.1, maxLon: 97.4 },
+  PK: { minLat: 23.7, maxLat: 37.1, minLon: 60.9, maxLon: 77.8 },
+  SY: { minLat: 32.3, maxLat: 37.3, minLon: 35.7, maxLon: 42.4 },
+  YE: { minLat: 12.1, maxLat: 19.0, minLon: 42.5, maxLon: 54.5 },
+  MM: { minLat: 9.8, maxLat: 28.5, minLon: 92.2, maxLon: 101.2 },
+  VE: { minLat: 0.6, maxLat: 12.2, minLon: -73.4, maxLon: -59.8 },
+};
+
+const ZONE_COUNTRY_MAP: Record<string, string[]> = {
+  'North America': ['US'], 'Europe': ['DE', 'FR', 'GB', 'PL', 'TR', 'UA'],
+  'East Asia': ['CN', 'TW', 'KP'], 'South Asia': ['IN', 'PK', 'MM'],
+  'Middle East': ['IR', 'IL', 'SA', 'SY', 'YE'], 'Russia': ['RU'],
+  'Latin America': ['VE'],
+};
+
+// ========================================================================
+// Internal helpers
+// ========================================================================
+
+function normalizeCountryName(text: string): string | null {
+  const lower = text.toLowerCase();
+  for (const [code, keywords] of Object.entries(COUNTRY_KEYWORDS)) {
+    if (keywords.some((kw) => lower.includes(kw))) return code;
+  }
+  return null;
+}
+
+function geoToCountry(lat: number, lon: number): string | null {
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+  for (const [code, bbox] of Object.entries(COUNTRY_BBOX)) {
+    if (lat >= bbox.minLat && lat <= bbox.maxLat && lon >= bbox.minLon && lon <= bbox.maxLon) return code;
+  }
+  return null;
+}
+
+interface CountrySignals {
+  protests: number;
+  riots: number;
+  battles: number;
+  explosions: number;
+  civilianViolence: number;
+  fatalities: number;
+  ucdpWar: boolean;
+  ucdpMinor: boolean;
+  outageBoost: number;
+  climateSeverity: number;
+  cyberCount: number;
+  fireCount: number;
+  gpsHexCount: number;
+  iranStrikes: number;
+}
+
+function emptySignals(): CountrySignals {
+  return { protests: 0, riots: 0, battles: 0, explosions: 0, civilianViolence: 0, fatalities: 0, ucdpWar: false, ucdpMinor: false, outageBoost: 0, climateSeverity: 0, cyberCount: 0, fireCount: 0, gpsHexCount: 0, iranStrikes: 0 };
+}
+
+async function fetchACLEDEvents(): Promise<Array<{ country: string; event_type: string; fatalities: number }>> {
+  const endDate = new Date().toISOString().split('T')[0]!;
+  const startDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]!;
+  const raw = await fetchAcledCached({
+    eventTypes: 'Protests|Riots|Battles|Explosions/Remote violence|Violence against civilians',
+    startDate,
+    endDate,
+    limit: 1000,
+  });
+  return raw.map((e) => ({
+    country: e.country || '',
+    event_type: e.event_type || '',
+    fatalities: parseInt(e.fatalities || '0', 10) || 0,
+  }));
+}
+
+async function fetchAuxiliarySources(): Promise<{
+  ucdpEvents: any[];
+  outages: any[];
+  climate: any[];
+  cyber: any[];
+  fires: any[];
+  gpsHexes: any[];
+  iranEvents: any[];
+}> {
+  const [ucdpRaw, outagesRaw, climateRaw, cyberRaw, firesRaw, gpsRaw, iranRaw] = await Promise.all([
+    getCachedJson('conflict:ucdp-events:v1', true).catch(() => null),
+    getCachedJson('infra:outages:v1', true).catch(() => null),
+    getCachedJson('climate:anomalies:v1', true).catch(() => null),
+    getCachedJson('cyber:threats-bootstrap:v2', true).catch(() => null),
+    getCachedJson('wildfire:fires:v1', true).catch(() => null),
+    getCachedJson('intelligence:gpsjam:v1', true).catch(() => null),
+    getCachedJson('conflict:iran-events:v1', true).catch(() => null),
+  ]);
+  const arr = (v: any, field?: string) => {
+    if (field && v && Array.isArray(v[field])) return v[field];
+    return Array.isArray(v) ? v : [];
+  };
+  return {
+    ucdpEvents: arr(ucdpRaw, 'events'),
+    outages: arr(outagesRaw, 'outages'),
+    climate: arr(climateRaw, 'anomalies'),
+    cyber: arr(cyberRaw, 'threats'),
+    fires: arr(firesRaw, 'fireDetections') || arr(firesRaw, 'fires'),
+    gpsHexes: arr(gpsRaw, 'hexes'),
+    iranEvents: arr(iranRaw, 'events'),
+  };
+}
+
+function computeCIIScores(
+  acled: Array<{ country: string; event_type: string; fatalities: number }>,
+  aux: Awaited<ReturnType<typeof fetchAuxiliarySources>>,
+): CiiScore[] {
+  const data: Record<string, CountrySignals> = {};
+  for (const code of Object.keys(TIER1_COUNTRIES)) {
+    data[code] = emptySignals();
+  }
+
+  for (const ev of acled) {
+    const code = normalizeCountryName(ev.country);
+    if (!code || !data[code]) continue;
+    const type = ev.event_type.toLowerCase();
+    if (type.includes('protest')) data[code].protests++;
+    else if (type.includes('riot')) data[code].riots++;
+    else if (type.includes('battle')) data[code].battles++;
+    else if (type.includes('explosion') || type.includes('remote')) data[code].explosions++;
+    else if (type.includes('violence')) data[code].civilianViolence++;
+    data[code].fatalities += ev.fatalities;
+  }
+
+  for (const ev of aux.ucdpEvents) {
+    const code = normalizeCountryName(ev.country || ev.location || '');
+    if (!code || !data[code]) continue;
+    const intensity = parseInt(ev.intensity_level || ev.type_of_violence || '0', 10);
+    if (intensity >= 2) data[code].ucdpWar = true;
+    else if (intensity >= 1) data[code].ucdpMinor = true;
+  }
+
+  for (const o of aux.outages) {
+    const code = (o.countryCode || o.country_code || '').toUpperCase();
+    if (data[code]) {
+      const severity = Number(o.severity || o.score || 0);
+      data[code].outageBoost = Math.max(data[code].outageBoost, Math.min(10, severity * 2));
+    }
+  }
+
+  for (const a of aux.climate) {
+    const zone = a.zone || a.region || '';
+    const countries = ZONE_COUNTRY_MAP[zone] || [];
+    const severity = Number(a.severity || a.score || 0);
+    for (const code of countries) {
+      if (data[code]) data[code].climateSeverity = Math.max(data[code].climateSeverity, severity);
+    }
+  }
+
+  for (const t of aux.cyber) {
+    const code = (t.country || '').toUpperCase();
+    if (data[code]) data[code].cyberCount++;
+  }
+
+  for (const f of aux.fires) {
+    const lat = Number(f.lat || f.latitude || f.location?.latitude);
+    const lon = Number(f.lon || f.longitude || f.location?.longitude);
+    const code = geoToCountry(lat, lon);
+    if (code && data[code]) data[code].fireCount++;
+  }
+
+  for (const h of aux.gpsHexes) {
+    const lat = Number(h.lat || h.latitude);
+    const lon = Number(h.lon || h.longitude);
+    const code = geoToCountry(lat, lon);
+    if (code && data[code]) data[code].gpsHexCount++;
+  }
+
+  for (const s of aux.iranEvents) {
+    const lat = Number(s.lat || s.latitude);
+    const lon = Number(s.lon || s.longitude);
+    const code = geoToCountry(lat, lon) || normalizeCountryName(s.title || s.location || '');
+    if (code && data[code]) data[code].iranStrikes++;
+  }
+
   const scores: CiiScore[] = [];
-  for (const [code] of Object.entries(TIER1_COUNTRIES)) {
+  for (const code of Object.keys(TIER1_COUNTRIES)) {
+    const d = data[code]!;
     const baseline = BASELINE_RISK[code] || 20;
+    const multiplier = EVENT_MULTIPLIER[code] || 1.0;
+
+    const unrest = Math.min(100, Math.round((d.protests * multiplier + d.riots * multiplier * 2 + d.outageBoost) * 2));
+    const conflict = Math.min(100, Math.round((d.battles + d.explosions + d.civilianViolence + d.fatalities * 0.5 + d.iranStrikes * 3) * multiplier));
+    const security = Math.min(100, Math.round(d.gpsHexCount * 3 * multiplier));
+    const information = 0;
+
+    const eventScore = unrest * 0.25 + conflict * 0.30 + security * 0.20 + information * 0.25;
+
+    const climateBoost = Math.min(15, d.climateSeverity * 3);
+    const cyberBoost = Math.min(10, Math.floor(d.cyberCount / 5));
+    const fireBoost = Math.min(8, Math.floor(d.fireCount / 10));
+
+    const blended = baseline * 0.4 + eventScore * 0.6 + climateBoost + cyberBoost + fireBoost;
+
+    const floor = d.ucdpWar ? 70 : (d.ucdpMinor ? 50 : 0);
+    const composite = Math.min(100, Math.max(floor, Math.round(blended)));
+
     scores.push({
       region: code,
       staticBaseline: baseline,
-      dynamicScore: 0,
-      combinedScore: baseline,
+      dynamicScore: composite - baseline,
+      combinedScore: composite,
       trend: 'TREND_DIRECTION_STABLE' as TrendDirection,
-      components: { newsActivity: 0, ciiContribution: 0, geoConvergence: 0, militaryActivity: 0 },
+      components: {
+        newsActivity: information,
+        ciiContribution: unrest,
+        geoConvergence: conflict,
+        militaryActivity: security,
+      },
       computedAt: Date.now(),
     });
   }
+
   scores.sort((a, b) => b.combinedScore - a.combinedScore);
   return scores;
 }
@@ -57,32 +307,44 @@ function computeStrategicRisks(ciiScores: CiiScore[]): StrategicRisk[] {
   ];
 }
 
+// ========================================================================
+// Cache keys
+// ========================================================================
+
 const RISK_CACHE_KEY = 'risk:scores:sebuf:v1';
 const RISK_STALE_CACHE_KEY = 'risk:scores:sebuf:stale:v1';
+const RISK_CACHE_TTL = 600;
+const RISK_STALE_TTL = 3600;
 
-function isValidResponse(data: unknown): data is GetRiskScoresResponse {
-  if (!data || typeof data !== 'object') return false;
-  const d = data as Record<string, unknown>;
-  if (!Array.isArray(d.ciiScores) || d.ciiScores.length === 0) return false;
-  for (const s of d.ciiScores) {
-    if (!s || typeof s !== 'object') return false;
-    const sc = s as Record<string, unknown>;
-    if (typeof sc.region !== 'string' || !Number.isFinite(sc.combinedScore)) return false;
-    if ((sc.combinedScore as number) < 0 || (sc.combinedScore as number) > 100) return false;
-  }
-  return true;
-}
+// ========================================================================
+// RPC handler
+// ========================================================================
 
 export async function getRiskScores(
   _ctx: ServerContext,
   _req: GetRiskScoresRequest,
 ): Promise<GetRiskScoresResponse> {
-  const cached = await getCachedJson(RISK_CACHE_KEY);
-  if (isValidResponse(cached)) return cached;
+  try {
+    const result = await cachedFetchJson<GetRiskScoresResponse>(
+      RISK_CACHE_KEY,
+      RISK_CACHE_TTL,
+      async () => {
+        const [acled, aux] = await Promise.all([
+          fetchACLEDEvents(),
+          fetchAuxiliarySources(),
+        ]);
+        const ciiScores = computeCIIScores(acled, aux);
+        const strategicRisks = computeStrategicRisks(ciiScores);
+        const r: GetRiskScoresResponse = { ciiScores, strategicRisks };
+        await setCachedJson(RISK_STALE_CACHE_KEY, r, RISK_STALE_TTL).catch(() => {});
+        return r;
+      },
+    );
+    if (result) return result;
+  } catch { /* upstream failed — fall through to stale */ }
 
-  const stale = await getCachedJson(RISK_STALE_CACHE_KEY);
-  if (isValidResponse(stale)) return stale;
-
-  const ciiScores = computeBaselineScores();
+  const stale = (await getCachedJson(RISK_STALE_CACHE_KEY)) as GetRiskScoresResponse | null;
+  if (stale) return stale;
+  const ciiScores = computeCIIScores([], { ucdpEvents: [], outages: [], climate: [], cyber: [], fires: [], gpsHexes: [], iranEvents: [] });
   return { ciiScores, strategicRisks: computeStrategicRisks(ciiScores) };
 }

--- a/server/worldmonitor/market/v1/list-commodity-quotes.ts
+++ b/server/worldmonitor/market/v1/list-commodity-quotes.ts
@@ -10,7 +10,7 @@ import type {
   CommodityQuote,
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { fetchYahooQuotesBatch, parseStringArray } from './_shared';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'market:commodities:v1';
 const REDIS_CACHE_TTL = 600; // 10 min — commodities move slower than indices
@@ -27,6 +27,18 @@ export async function listCommodityQuotes(
 ): Promise<ListCommodityQuotesResponse> {
   const symbols = parseStringArray(req.symbols);
   if (!symbols.length) return { quotes: [] };
+
+  // Layer 0: bootstrap/seed data (written by Railway ais-relay)
+  try {
+    const bootstrap = await getCachedJson('market:commodities-bootstrap:v1', true) as ListCommodityQuotesResponse | null;
+    if (bootstrap?.quotes?.length) {
+      const symbolSet = new Set(symbols);
+      const filtered = bootstrap.quotes.filter((q: CommodityQuote) => symbolSet.has(q.symbol));
+      if (filtered.length > 0) {
+        return { quotes: filtered };
+      }
+    }
+  } catch {}
 
   const redisKey = redisCacheKey(symbols);
 

--- a/server/worldmonitor/market/v1/list-crypto-quotes.ts
+++ b/server/worldmonitor/market/v1/list-crypto-quotes.ts
@@ -10,12 +10,41 @@ import type {
   CryptoQuote,
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { CRYPTO_META, fetchCoinGeckoMarkets, parseStringArray } from './_shared';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'market:crypto:v1';
 const REDIS_CACHE_TTL = 600; // 10 min — CoinGecko rate-limited
 
+const SEED_FRESHNESS_MS = 45 * 60 * 1000; // 45 minutes
+
 const fallbackCryptoCache = new Map<string, { data: ListCryptoQuotesResponse; ts: number }>();
+
+const SYMBOL_TO_ID = new Map(Object.entries(CRYPTO_META).map(([id, m]) => [m.symbol, id]));
+
+async function trySeededCrypto(ids: string[]): Promise<ListCryptoQuotesResponse | null> {
+  try {
+    const [seedData, seedMeta] = await Promise.all([
+      getCachedJson(REDIS_CACHE_KEY, true) as Promise<{ quotes: CryptoQuote[] } | null>,
+      getCachedJson('seed-meta:market:crypto', true) as Promise<{ fetchedAt?: number } | null>,
+    ]);
+
+    if (!seedData?.quotes?.length) return null;
+
+    const fetchedAt = seedMeta?.fetchedAt ?? 0;
+    const isFresh = Date.now() - fetchedAt < SEED_FRESHNESS_MS;
+
+    const allIds = new Set(ids);
+    const filtered = allIds.size === 0
+      ? seedData.quotes
+      : seedData.quotes.filter((q) => allIds.has(SYMBOL_TO_ID.get(q.symbol) ?? ''));
+
+    if (filtered.length === 0) return null;
+    if (isFresh || !process.env.SEED_FALLBACK_CRYPTO) return { quotes: filtered };
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 export async function listCryptoQuotes(
   _ctx: ServerContext,
@@ -23,6 +52,10 @@ export async function listCryptoQuotes(
 ): Promise<ListCryptoQuotesResponse> {
   const parsedIds = parseStringArray(req.ids);
   const ids = parsedIds.length > 0 ? parsedIds : Object.keys(CRYPTO_META);
+
+  // Try Railway-seeded data first
+  const seeded = await trySeededCrypto(ids);
+  if (seeded) return seeded;
 
   const cacheKey = `${REDIS_CACHE_KEY}:${[...ids].sort().join(',')}`;
 

--- a/server/worldmonitor/market/v1/list-etf-flows.ts
+++ b/server/worldmonitor/market/v1/list-etf-flows.ts
@@ -11,7 +11,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { UPSTREAM_TIMEOUT_MS, type YahooChartResponse } from './_shared';
 import { CHROME_UA, yahooGate } from '../../../_shared/constants';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 // ========================================================================
 // Constants and cache
@@ -32,6 +32,8 @@ const ETF_LIST = [
   { ticker: 'BTCO', issuer: 'Invesco' },
   { ticker: 'BTCW', issuer: 'WisdomTree' },
 ];
+
+const SEED_FRESHNESS_MS = 90 * 60_000; // 90 min — Railway seeds every hour
 
 let etfCache: ListEtfFlowsResponse | null = null;
 let etfCacheTimestamp = 0;
@@ -113,6 +115,22 @@ export async function listEtfFlows(
   if (etfCache && now - etfCacheTimestamp < ETF_CACHE_TTL) {
     return etfCache;
   }
+
+  try {
+    const [seedData, seedMeta] = await Promise.all([
+      getCachedJson(REDIS_CACHE_KEY, true) as Promise<ListEtfFlowsResponse | null>,
+      getCachedJson('seed-meta:market:etf-flows', true) as Promise<{ fetchedAt?: number } | null>,
+    ]);
+    if (seedData?.etfs?.length) {
+      const fetchedAt = seedMeta?.fetchedAt ?? 0;
+      const isFresh = now - fetchedAt < SEED_FRESHNESS_MS;
+      if (isFresh || !process.env.SEED_FALLBACK_ETF) {
+        etfCache = seedData;
+        etfCacheTimestamp = now;
+        return seedData;
+      }
+    }
+  } catch { /* fall through to live fetch */ }
 
   try {
   const result = await cachedFetchJson<ListEtfFlowsResponse>(REDIS_CACHE_KEY, REDIS_CACHE_TTL, async () => {

--- a/server/worldmonitor/market/v1/list-gulf-quotes.ts
+++ b/server/worldmonitor/market/v1/list-gulf-quotes.ts
@@ -12,10 +12,12 @@ import type {
   GulfQuote,
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { fetchYahooQuotesBatch } from './_shared';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 const REDIS_KEY = 'market:gulf-quotes:v1';
 const REDIS_TTL = 480; // 8 min
+
+const SEED_FRESHNESS_MS = 90 * 60_000; // 90 min — Railway seeds every hour
 
 let memCache: { data: ListGulfQuotesResponse; ts: number } | null = null;
 const MEM_TTL = 480_000;
@@ -60,6 +62,21 @@ export async function listGulfQuotes(
   if (memCache && now - memCache.ts < MEM_TTL) {
     return memCache.data;
   }
+
+  try {
+    const [seedData, seedMeta] = await Promise.all([
+      getCachedJson(REDIS_KEY, true) as Promise<ListGulfQuotesResponse | null>,
+      getCachedJson('seed-meta:market:gulf-quotes', true) as Promise<{ fetchedAt?: number } | null>,
+    ]);
+    if (seedData?.quotes?.length) {
+      const fetchedAt = seedMeta?.fetchedAt ?? 0;
+      const isFresh = now - fetchedAt < SEED_FRESHNESS_MS;
+      if (isFresh || !process.env.SEED_FALLBACK_GULF) {
+        memCache = { data: seedData, ts: now };
+        return seedData;
+      }
+    }
+  } catch { /* fall through to live fetch */ }
 
   try {
     const result = await cachedFetchJson<ListGulfQuotesResponse>(REDIS_KEY, REDIS_TTL, async () => {

--- a/server/worldmonitor/market/v1/list-market-quotes.ts
+++ b/server/worldmonitor/market/v1/list-market-quotes.ts
@@ -9,7 +9,7 @@ import type {
   MarketQuote,
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { YAHOO_ONLY_SYMBOLS, fetchFinnhubQuote, fetchYahooQuotesBatch, parseStringArray } from './_shared';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'market:quotes:v1';
 const REDIS_CACHE_TTL = 480; // 8 min — shared across all Vercel instances
@@ -32,6 +32,20 @@ export async function listMarketQuotes(
   const now = Date.now();
   const parsedSymbols = parseStringArray(req.symbols);
   const key = cacheKey(parsedSymbols);
+
+  // Layer 0: bootstrap/seed data (written by Railway ais-relay)
+  try {
+    const bootstrap = await getCachedJson('market:stocks-bootstrap:v1', true) as ListMarketQuotesResponse | null;
+    if (bootstrap?.quotes?.length) {
+      const symbolSet = new Set(parsedSymbols);
+      const filtered = bootstrap.quotes.filter((q: MarketQuote) => symbolSet.has(q.symbol));
+      if (filtered.length > 0) {
+        const resp: ListMarketQuotesResponse = { quotes: filtered, finnhubSkipped: false, skipReason: '', rateLimited: false };
+        quotesCache.set(key, { data: resp, timestamp: now });
+        return resp;
+      }
+    }
+  } catch {}
 
   // Layer 1: in-memory cache (same instance)
   const memCached = quotesCache.get(key);

--- a/server/worldmonitor/market/v1/list-stablecoin-markets.ts
+++ b/server/worldmonitor/market/v1/list-stablecoin-markets.ts
@@ -11,7 +11,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { UPSTREAM_TIMEOUT_MS, parseStringArray } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'market:stablecoins:v1';
 const REDIS_CACHE_TTL = 600; // 10 min — CoinGecko rate-limited
@@ -25,6 +25,7 @@ const DEFAULT_STABLECOIN_IDS = 'tether,usd-coin,dai,first-digital-usd,ethena-usd
 let stablecoinCache: ListStablecoinMarketsResponse | null = null;
 let stablecoinCacheTimestamp = 0;
 const STABLECOIN_CACHE_TTL = 480_000; // 8 minutes
+const SEED_FRESHNESS_MS = 45 * 60 * 1000; // 45 minutes
 
 // ========================================================================
 // Types
@@ -46,6 +47,26 @@ interface CoinGeckoStablecoinItem {
 // Handler
 // ========================================================================
 
+async function trySeededStablecoins(): Promise<ListStablecoinMarketsResponse | null> {
+  try {
+    const [seedData, seedMeta] = await Promise.all([
+      getCachedJson(REDIS_CACHE_KEY, true) as Promise<ListStablecoinMarketsResponse | null>,
+      getCachedJson('seed-meta:market:stablecoins', true) as Promise<{ fetchedAt?: number } | null>,
+    ]);
+
+    if (!seedData?.stablecoins?.length) return null;
+
+    const fetchedAt = seedMeta?.fetchedAt ?? 0;
+    const isFresh = Date.now() - fetchedAt < SEED_FRESHNESS_MS;
+
+    if (isFresh) return seedData;
+    if (!process.env.SEED_FALLBACK_STABLECOINS) return seedData;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export async function listStablecoinMarkets(
   _ctx: ServerContext,
   req: ListStablecoinMarketsRequest,
@@ -53,6 +74,14 @@ export async function listStablecoinMarkets(
   const now = Date.now();
   if (stablecoinCache && now - stablecoinCacheTimestamp < STABLECOIN_CACHE_TTL) {
     return stablecoinCache;
+  }
+
+  // Try Railway-seeded data first
+  const seeded = await trySeededStablecoins();
+  if (seeded) {
+    stablecoinCache = seeded;
+    stablecoinCacheTimestamp = now;
+    return seeded;
   }
 
   const parsedCoins = parseStringArray(req.coins);

--- a/server/worldmonitor/natural/v1/list-natural-events.ts
+++ b/server/worldmonitor/natural/v1/list-natural-events.ts
@@ -7,10 +7,11 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/natural/v1/service_server';
 
 import { CHROME_UA } from '../../../_shared/constants';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'natural:events:v1';
 const REDIS_CACHE_TTL = 1800; // 30 min
+const SEED_FRESHNESS_MS = 45 * 60 * 1000; // 45 minutes
 
 const EONET_API_URL = 'https://eonet.gsfc.nasa.gov/api/v3/events';
 const GDACS_API = 'https://www.gdacs.org/gdacsapi/api/events/geteventlist/MAP';
@@ -128,12 +129,41 @@ async function fetchGdacs(): Promise<NaturalEvent[]> {
   return events.slice(0, 100);
 }
 
+type NaturalEventsCache = { events: ListNaturalEventsResponse['events'] };
+
+async function trySeededData(): Promise<NaturalEventsCache | null> {
+  try {
+    const [seedData, seedMeta] = await Promise.all([
+      getCachedJson(REDIS_CACHE_KEY, true) as Promise<NaturalEventsCache | null>,
+      getCachedJson('seed-meta:natural:events', true) as Promise<{ fetchedAt?: number } | null>,
+    ]);
+
+    if (!seedData?.events?.length) return null;
+
+    const fetchedAt = seedMeta?.fetchedAt ?? 0;
+    const isFresh = Date.now() - fetchedAt < SEED_FRESHNESS_MS;
+
+    if (isFresh) return seedData;
+
+    if (!process.env.SEED_FALLBACK_NATURAL) return seedData;
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export const listNaturalEvents: NaturalServiceHandler['listNaturalEvents'] = async (
   _ctx: ServerContext,
   _req: ListNaturalEventsRequest,
 ): Promise<ListNaturalEventsResponse> => {
 
   try {
+    const seeded = await trySeededData();
+    if (seeded) {
+      return { events: seeded.events };
+    }
+
     const result = await cachedFetchJson<ListNaturalEventsResponse>(
       REDIS_CACHE_KEY,
       REDIS_CACHE_TTL,

--- a/server/worldmonitor/seismology/v1/list-earthquakes.ts
+++ b/server/worldmonitor/seismology/v1/list-earthquakes.ts
@@ -1,8 +1,8 @@
 /**
  * ListEarthquakes RPC -- proxies the USGS earthquake GeoJSON API.
  *
- * Fetches M4.5+ earthquakes from the last 24 hours and transforms the USGS
- * GeoJSON features into proto-shaped Earthquake objects.
+ * Prefers Railway-seeded Redis data when fresh; falls back to direct
+ * USGS fetch via cachedFetchJson.
  */
 
 import type {
@@ -12,13 +12,38 @@ import type {
   ListEarthquakesResponse,
 } from '../../../../src/generated/server/worldmonitor/seismology/v1/service_server';
 
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 import { CHROME_UA } from '../../../_shared/constants';
 
 const USGS_FEED_URL =
   'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_day.geojson';
 const CACHE_KEY = 'seismology:earthquakes:v1';
 const CACHE_TTL = 1800; // 30 minutes
+const SEED_FRESHNESS_MS = 45 * 60 * 1000; // 45 minutes
+
+type EarthquakeCache = { earthquakes: ListEarthquakesResponse['earthquakes'] };
+
+async function trySeededData(): Promise<EarthquakeCache | null> {
+  try {
+    const [seedData, seedMeta] = await Promise.all([
+      getCachedJson(CACHE_KEY, true) as Promise<EarthquakeCache | null>,
+      getCachedJson('seed-meta:seismology:earthquakes', true) as Promise<{ fetchedAt?: number } | null>,
+    ]);
+
+    if (!seedData?.earthquakes?.length) return null;
+
+    const fetchedAt = seedMeta?.fetchedAt ?? 0;
+    const isFresh = Date.now() - fetchedAt < SEED_FRESHNESS_MS;
+
+    if (isFresh) return seedData;
+
+    if (!process.env.SEED_FALLBACK_EARTHQUAKES) return seedData;
+
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 export const listEarthquakes: SeismologyServiceHandler['listEarthquakes'] = async (
   _ctx: ServerContext,
@@ -27,41 +52,45 @@ export const listEarthquakes: SeismologyServiceHandler['listEarthquakes'] = asyn
   const pageSize = req.pageSize || 500;
 
   try {
-  // Cache stores full set, slice on read — avoids polluting cache with partial results
-  const cached = await cachedFetchJson<{ earthquakes: ListEarthquakesResponse['earthquakes'] }>(CACHE_KEY, CACHE_TTL, async () => {
-    const response = await fetch(USGS_FEED_URL, {
-      headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-      signal: AbortSignal.timeout(10_000),
-    });
-
-    if (!response.ok) {
-      throw new Error(`USGS API error: ${response.status}`);
+    const seeded = await trySeededData();
+    if (seeded) {
+      const earthquakes = seeded.earthquakes || [];
+      return { earthquakes: earthquakes.slice(0, pageSize), pagination: undefined };
     }
 
-    const geojson: any = await response.json();
-    const features: any[] = geojson.features || [];
+    const cached = await cachedFetchJson<EarthquakeCache>(CACHE_KEY, CACHE_TTL, async () => {
+      const response = await fetch(USGS_FEED_URL, {
+        headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(10_000),
+      });
 
-    // Null-safe property access
-    const earthquakes = features
-      .filter((f: any) => f?.properties && f?.geometry?.coordinates)
-      .map((f: any) => ({
-        id: (f.id as string) || '',
-        place: (f.properties?.place as string) || '',
-        magnitude: (f.properties?.mag as number) ?? 0,
-        depthKm: (f.geometry?.coordinates?.[2] as number) ?? 0,
-        location: {
-          latitude: (f.geometry?.coordinates?.[1] as number) ?? 0,
-          longitude: (f.geometry?.coordinates?.[0] as number) ?? 0,
-        },
-        occurredAt: f.properties?.time ?? 0,
-        sourceUrl: (f.properties?.url as string) || '',
-      }));
+      if (!response.ok) {
+        throw new Error(`USGS API error: ${response.status}`);
+      }
 
-    return earthquakes.length > 0 ? { earthquakes } : null;
-  });
+      const geojson: any = await response.json();
+      const features: any[] = geojson.features || [];
 
-  const earthquakes = cached?.earthquakes || [];
-  return { earthquakes: earthquakes.slice(0, pageSize), pagination: undefined };
+      const earthquakes = features
+        .filter((f: any) => f?.properties && f?.geometry?.coordinates)
+        .map((f: any) => ({
+          id: (f.id as string) || '',
+          place: (f.properties?.place as string) || '',
+          magnitude: (f.properties?.mag as number) ?? 0,
+          depthKm: (f.geometry?.coordinates?.[2] as number) ?? 0,
+          location: {
+            latitude: (f.geometry?.coordinates?.[1] as number) ?? 0,
+            longitude: (f.geometry?.coordinates?.[0] as number) ?? 0,
+          },
+          occurredAt: f.properties?.time ?? 0,
+          sourceUrl: (f.properties?.url as string) || '',
+        }));
+
+      return earthquakes.length > 0 ? { earthquakes } : null;
+    });
+
+    const earthquakes = cached?.earthquakes || [];
+    return { earthquakes: earthquakes.slice(0, pageSize), pagination: undefined };
   } catch {
     return { earthquakes: [], pagination: undefined };
   }

--- a/server/worldmonitor/unrest/v1/list-unrest-events.ts
+++ b/server/worldmonitor/unrest/v1/list-unrest-events.ts
@@ -22,11 +22,14 @@ import {
   sortBySeverityAndRecency,
 } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 import { fetchAcledCached } from '../../../_shared/acled';
 
 const REDIS_CACHE_KEY = 'unrest:events:v1';
 const REDIS_CACHE_TTL = 900; // 15 min — ACLED + GDELT merge
+const SEED_KEY = 'unrest:events:v1';
+const SEED_META_KEY = 'seed-meta:unrest:events';
+const SEED_FRESHNESS_MS = 45 * 60 * 1000; // 45 min
 
 // ---------- ACLED Fetch (ported from api/acled.js + src/services/protests.ts) ----------
 
@@ -157,11 +160,48 @@ async function fetchGdeltEvents(): Promise<UnrestEvent[]> {
 
 // ---------- RPC Implementation ----------
 
+function filterSeedEvents(
+  events: UnrestEvent[],
+  req: ListUnrestEventsRequest,
+): UnrestEvent[] {
+  let filtered = events;
+  if (req.country) {
+    const country = req.country.toLowerCase();
+    filtered = filtered.filter(
+      (e) => e.country.toLowerCase() === country || e.country.toLowerCase().includes(country),
+    );
+  }
+  if (req.start > 0) {
+    filtered = filtered.filter((e) => e.occurredAt >= req.start);
+  }
+  if (req.end > 0) {
+    filtered = filtered.filter((e) => e.occurredAt <= req.end);
+  }
+  return filtered;
+}
+
 export async function listUnrestEvents(
   _ctx: ServerContext,
   req: ListUnrestEventsRequest,
 ): Promise<ListUnrestEventsResponse> {
   try {
+    // Try seed data first
+    try {
+      const [seedData, seedMeta] = await Promise.all([
+        getCachedJson(SEED_KEY, true) as Promise<ListUnrestEventsResponse | null>,
+        getCachedJson(SEED_META_KEY, true) as Promise<{ fetchedAt?: number } | null>,
+      ]);
+      if (seedData?.events?.length) {
+        const isFresh = (seedMeta?.fetchedAt ?? 0) > 0 && (Date.now() - seedMeta!.fetchedAt!) < SEED_FRESHNESS_MS;
+        if (isFresh || !process.env.SEED_FALLBACK_UNREST) {
+          const filtered = filterSeedEvents(seedData.events, req);
+          const sorted = sortBySeverityAndRecency(filtered);
+          return { events: sorted, clusters: [], pagination: undefined };
+        }
+      }
+    } catch {}
+
+    // Fallback: live fetch with caching
     const startBucket = req.start > 0 ? new Date(req.start).toISOString().slice(0, 10) : 'default';
     const endBucket = req.end > 0 ? new Date(req.end).toISOString().slice(0, 10) : 'default';
     const cacheKey = `${REDIS_CACHE_KEY}:${req.country || 'all'}:${startBucket}:${endBucket}`;

--- a/server/worldmonitor/wildfire/v1/list-fire-detections.ts
+++ b/server/worldmonitor/wildfire/v1/list-fire-detections.ts
@@ -15,10 +15,11 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/wildfire/v1/service_server';
 
 import { CHROME_UA } from '../../../_shared/constants';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 const REDIS_CACHE_KEY = 'wildfire:fires:v1';
 const REDIS_CACHE_TTL = 3600; // 1h — NASA FIRMS VIIRS NRT updates every ~3 hours
+const SEED_FRESHNESS_MS = 90 * 60 * 1000; // 90 minutes
 
 const FIRMS_SOURCE = 'VIIRS_SNPP_NRT';
 
@@ -86,6 +87,19 @@ export const listFireDetections: WildfireServiceHandler['listFireDetections'] = 
   _ctx: ServerContext,
   _req: ListFireDetectionsRequest,
 ): Promise<ListFireDetectionsResponse> => {
+  try {
+    const [seedData, seedMeta] = await Promise.all([
+      getCachedJson(REDIS_CACHE_KEY, true) as Promise<ListFireDetectionsResponse | null>,
+      getCachedJson('seed-meta:wildfire:fires', true) as Promise<{ fetchedAt?: number } | null>,
+    ]);
+    if (seedData?.fireDetections?.length) {
+      const isFresh = (seedMeta?.fetchedAt ?? 0) > 0 && (Date.now() - seedMeta!.fetchedAt!) < SEED_FRESHNESS_MS;
+      if (isFresh || !process.env.SEED_FALLBACK_WILDFIRES) {
+        return seedData;
+      }
+    }
+  } catch { /* fall through to live fetch */ }
+
   const apiKey =
     process.env.NASA_FIRMS_API_KEY || process.env.FIRMS_API_KEY || '';
 


### PR DESCRIPTION
## Summary

- **15 RPC handlers** updated with seed-first pattern: try Redis seed data → check freshness → return stale if no `SEED_FALLBACK_*` env → fallback to live fetch via `cachedFetchJson`
- **13 new seed scripts** (`scripts/seed-*.mjs`) for Railway cron, using shared `_seed-utils.mjs` framework (atomic publish, distributed locks, retry, freshness metadata)
- **`api/seed-health.js`** monitoring endpoint (tracks 12 seed domains with expected intervals)
- **`scripts/validate-seed-migration.mjs`** post-deploy validation (tests 14 RPC endpoints + cross-validates seed health)
- **Restored multi-source CII** in `get-risk-scores.ts` — reads 8 sources (ACLED, UCDP, outages, climate, cyber, fires, GPS jamming, Iran events) from existing Redis seed keys
- **Code review fixes**: removed orphaned bootstrap tier, collapsed duplicate displacement logic, pre-built crypto symbol reverse map, removed redundant climate try-catch

### Handlers migrated
| Handler | Seed Schedule | Redis Key |
|---------|--------------|-----------|
| list-earthquakes | 15 min | `seismology:earthquakes:v1` |
| list-fire-detections | 30 min | `wildfire:fires:v1` |
| list-internet-outages | 15 min | `infra:outages:v1` |
| list-climate-anomalies | 60 min | `climate:anomalies:v1` |
| list-unrest-events | 15 min | `unrest:events:v1` |
| list-cyber-threats | 2 hr | `cyber:threats:v2` |
| list-crypto-quotes | 10 min | `market:crypto:v1` |
| list-etf-flows | 30 min | `market:etf-flows:v1` |
| list-gulf-quotes | 15 min | `market:gulf-quotes:v1` |
| list-stablecoin-markets | 30 min | `market:stablecoins:v1` |
| list-natural-events | 30 min | `natural:events:v1` |
| get-displacement-summary | 6 hr | `displacement:summary:v1` |
| get-risk-scores | 10 min | `risk:scores:sebuf:v1` |

### Rollback
Each handler has a `SEED_FALLBACK_<DOMAIN>=true` env var. Without it, stale seed data is returned (better than nothing). With it enabled, stale seed falls through to live `cachedFetchJson` fetch.

## Test plan
- [x] `tsc --noEmit` passes (clean)
- [x] 34/34 edge function tests pass
- [x] `scripts/validate-seed-migration.mjs` — 14/14 endpoints pass against production
- [ ] After deploy: run `node scripts/validate-seed-migration.mjs` to verify seed-health endpoint
- [ ] Configure Railway cron schedules for each seed script
- [ ] Monitor `api/seed-health` for freshness after seeds run