### PR TITLE
fix(globe): render conflict zone polygons correctly on 3D globe

### DIFF
--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -1241,11 +1241,9 @@ export class GlobeMap {
             const code = feat.properties?.['ISO3166-1-Alpha-2'] as string | undefined;
             if (!code || !isoCodes.includes(code)) continue;
             const geom = feat.geometry;
+            if (!geom) continue;
             const rings = geom.type === 'Polygon' ? [geom.coordinates] : geom.type === 'MultiPolygon' ? geom.coordinates : [];
             for (const ring of rings) {
-              // Reverse winding on all rings: globe.gl's ConicPolygonGeometry + earcut
-              // renders CCW exterior rings as complement on the sphere.
-              // Reversing to CW makes earcut fill the polygon interior correctly.
               const reversed = ring.map((r: number[][]) => [...r].reverse());
               polys.push({
                 coords: reversed,
@@ -1271,6 +1269,7 @@ export class GlobeMap {
         const entry = code ? this.ciiScoresMap.get(code) : undefined;
         if (!entry || !code) continue;
         const geom = feat.geometry;
+        if (!geom) continue;
         const rings = geom.type === 'Polygon' ? [geom.coordinates] : geom.type === 'MultiPolygon' ? geom.coordinates : [];
         const name = (feat.properties?.name as string) ?? code;
         for (const ring of rings) {


### PR DESCRIPTION
## Summary
- Conflict zone polygons now render as localized red overlays on the 3D globe (Iran, Ukraine, Gaza/Israel, Sudan, Myanmar)
- Previously only tiny 28x28px circle markers were shown at each zone's center point

## Root Cause
globe.gl's `ConicPolygonGeometry` + earcut renders CCW exterior rings as their **complement** on the sphere (filling everything EXCEPT the polygon). The simplified `CONFLICT_ZONES.coords` also lacked sufficient vertices for proper spherical tessellation.

## Changes
- Use real GeoJSON country geometries from `countriesGeoData` instead of simplified `CONFLICT_ZONES.coords` (maps zone IDs → ISO-2 country codes)
- Reverse winding order (CCW → CW) on all polygon rings so earcut fills the polygon interior correctly
- Apply same winding fix to `GEOPOLITICAL_BOUNDARIES` polygons
- Add `polygonGeoJsonGeometry` accessor (required by globe.gl to map custom data → GeoJSON)
- Zones without country mapping (Strait of Hormuz, South Lebanon, Red Sea) use center markers only
- Intensity-based styling: high=red, medium=orange, low=yellow with 3D altitude

## Test plan
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Playwright: Iran polygon renders as red overlay on Iran only (no globe envelope)
- [x] Playwright: Ukraine, Gaza/Israel, Sudan visible as localized polygons
- [x] Globe is clean — no red tint on unrelated areas
- [ ] Verify CII choropleth still renders correctly alongside conflict polygons
- [ ] Verify layer toggle: conflicts=off removes polygons, conflicts=on shows them