### PR TITLE
fix: RSS redirect crash — stale allowedDomains reference

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -4752,7 +4752,7 @@ const server = http.createServer(async (req, res) => {
               ? response.headers.location
               : new URL(response.headers.location, url).href;
             const redirectHost = new URL(redirectUrl).hostname;
-            if (!allowedDomains.includes(redirectHost)) {
+            if (!RSS_ALLOWED_DOMAINS.has(redirectHost)) {
               return sendError(403, 'Redirect to disallowed domain');
             }
             logThrottled('log', `rss-redirect:${feedUrl}:${redirectUrl}`, `[Relay] Following redirect to: ${redirectUrl}`);


### PR DESCRIPTION
## Summary
- The `RSS_ALLOWED_DOMAINS` refactor missed the redirect handler inside `fetchWithRedirects()` at line 4755
- Every RSS feed that returns a 301/302 redirect hits `ReferenceError: allowedDomains is not defined` and **crashes the entire relay process**
- Relay restarts, runs for ~2min, hits another redirect, crashes again — repeat loop
- Fix: `allowedDomains.includes()` → `RSS_ALLOWED_DOMAINS.has()`

## Impact
- **P0 production crash** — relay is in a crash loop
- All downstream services (AIS, Telegram, RSS, market seed, OpenSky) affected by relay instability

## Test plan
- [x] Verified no other `allowedDomains` references remain in the file
- [x] `tsc --noEmit` passes
- [ ] Deploy to Railway and verify relay stays up without `ReferenceError` in logs