### PR TITLE
feat: CII Railway seed — pre-compute instability scores from 8 sources

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1762,297 +1762,6 @@ async function startCyberThreatsSeedLoop() {
 }
 
 // ─────────────────────────────────────────────────────────────
-// CII Risk Scores Seed — Railway computes 8-source Country Instability Index
-// Writes to risk:scores:sebuf:v1 (900s) + risk:scores:sebuf:stale:v1 (3600s)
-// ─────────────────────────────────────────────────────────────
-const CII_SEED_INTERVAL_MS = 600_000; // 10 min
-const CII_RPC_KEY = 'risk:scores:sebuf:v1';
-const CII_STALE_KEY = 'risk:scores:sebuf:stale:v1';
-const CII_RPC_TTL = 900;
-const CII_STALE_TTL = 3600;
-const ACLED_ACCESS_TOKEN = process.env.ACLED_ACCESS_TOKEN || '';
-const ACLED_API_URL = 'https://acleddata.com/api/acled/read';
-
-const CII_BASELINE_RISK = {
-  US: 5, RU: 35, CN: 25, UA: 50, IR: 40, IL: 45, TW: 30, KP: 45,
-  SA: 20, TR: 25, PL: 10, DE: 5, FR: 10, GB: 5, IN: 20, PK: 35,
-  SY: 50, YE: 50, MM: 45, VE: 40,
-};
-const CII_EVENT_MULTIPLIER = {
-  US: 0.3, RU: 2.0, CN: 2.5, UA: 0.8, IR: 2.0, IL: 0.7, TW: 1.5, KP: 3.0,
-  SA: 2.0, TR: 1.2, PL: 0.8, DE: 0.5, FR: 0.6, GB: 0.5, IN: 0.8, PK: 1.5,
-  SY: 0.7, YE: 0.7, MM: 1.8, VE: 1.8,
-};
-const CII_TIER1 = {
-  US: 'United States', RU: 'Russia', CN: 'China', UA: 'Ukraine', IR: 'Iran',
-  IL: 'Israel', TW: 'Taiwan', KP: 'North Korea', SA: 'Saudi Arabia', TR: 'Turkey',
-  PL: 'Poland', DE: 'Germany', FR: 'France', GB: 'United Kingdom', IN: 'India',
-  PK: 'Pakistan', SY: 'Syria', YE: 'Yemen', MM: 'Myanmar', VE: 'Venezuela',
-};
-const CII_COUNTRY_KEYWORDS = {
-  US: ['united states', 'usa', 'america'], RU: ['russia', 'moscow'], CN: ['china', 'beijing'],
-  UA: ['ukraine', 'kyiv'], IR: ['iran', 'tehran'], IL: ['israel', 'gaza'],
-  TW: ['taiwan', 'taipei'], KP: ['north korea', 'pyongyang'], SA: ['saudi arabia', 'riyadh'],
-  TR: ['turkey', 'ankara'], PL: ['poland', 'warsaw'], DE: ['germany', 'berlin'],
-  FR: ['france', 'paris'], GB: ['britain', 'uk', 'london'], IN: ['india', 'delhi'],
-  PK: ['pakistan', 'islamabad'], SY: ['syria', 'damascus'], YE: ['yemen', 'sanaa', 'houthi'],
-  MM: ['myanmar', 'burma'], VE: ['venezuela', 'caracas'],
-};
-
-const CII_COUNTRY_BBOX = {
-  US: { minLat: 24.5, maxLat: 49.4, minLon: -125.0, maxLon: -66.9 },
-  RU: { minLat: 41.2, maxLat: 81.9, minLon: 19.6, maxLon: 180.0 },
-  CN: { minLat: 18.2, maxLat: 53.6, minLon: 73.5, maxLon: 135.1 },
-  UA: { minLat: 44.4, maxLat: 52.4, minLon: 22.1, maxLon: 40.2 },
-  IR: { minLat: 25.1, maxLat: 39.8, minLon: 44.0, maxLon: 63.3 },
-  IL: { minLat: 29.5, maxLat: 33.3, minLon: 34.3, maxLon: 35.9 },
-  TW: { minLat: 21.9, maxLat: 25.3, minLon: 120.0, maxLon: 122.0 },
-  KP: { minLat: 37.7, maxLat: 43.0, minLon: 124.3, maxLon: 130.7 },
-  SA: { minLat: 16.4, maxLat: 32.2, minLon: 34.6, maxLon: 55.7 },
-  TR: { minLat: 36.0, maxLat: 42.1, minLon: 26.0, maxLon: 44.8 },
-  PL: { minLat: 49.0, maxLat: 54.8, minLon: 14.1, maxLon: 24.2 },
-  DE: { minLat: 47.3, maxLat: 55.1, minLon: 5.9, maxLon: 15.0 },
-  FR: { minLat: 41.4, maxLat: 51.1, minLon: -5.1, maxLon: 9.6 },
-  GB: { minLat: 49.9, maxLat: 60.9, minLon: -8.2, maxLon: 1.8 },
-  IN: { minLat: 6.7, maxLat: 35.5, minLon: 68.1, maxLon: 97.4 },
-  PK: { minLat: 23.7, maxLat: 37.1, minLon: 60.9, maxLon: 77.8 },
-  SY: { minLat: 32.3, maxLat: 37.3, minLon: 35.7, maxLon: 42.4 },
-  YE: { minLat: 12.1, maxLat: 19.0, minLon: 42.5, maxLon: 54.5 },
-  MM: { minLat: 9.8, maxLat: 28.5, minLon: 92.2, maxLon: 101.2 },
-  VE: { minLat: 0.6, maxLat: 12.2, minLon: -73.4, maxLon: -59.8 },
-};
-
-const CII_ZONE_COUNTRY_MAP = {
-  'North America': ['US'], 'Europe': ['DE', 'FR', 'GB', 'PL', 'TR', 'UA'],
-  'East Asia': ['CN', 'TW', 'KP'], 'South Asia': ['IN', 'PK', 'MM'],
-  'Middle East': ['IR', 'IL', 'SA', 'SY', 'YE'], 'Russia': ['RU'],
-  'Latin America': ['VE'],
-};
-
-function ciiPointInBbox(lat, lon, bbox) {
-  return lat >= bbox.minLat && lat <= bbox.maxLat && lon >= bbox.minLon && lon <= bbox.maxLon;
-}
-
-function ciiNormalizeCountry(text) {
-  const lower = (text || '').toLowerCase();
-  for (const [code, kws] of Object.entries(CII_COUNTRY_KEYWORDS)) {
-    if (kws.some((kw) => lower.includes(kw))) return code;
-  }
-  return null;
-}
-
-function ciiGeoToCountry(lat, lon) {
-  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
-  for (const [code, bbox] of Object.entries(CII_COUNTRY_BBOX)) {
-    if (ciiPointInBbox(lat, lon, bbox)) return code;
-  }
-  return null;
-}
-
-function ciiFetchAcled() {
-  return new Promise((resolve) => {
-    if (!ACLED_ACCESS_TOKEN) return resolve([]);
-    const endDate = new Date().toISOString().split('T')[0];
-    const startDate = new Date(Date.now() - 7 * 86400000).toISOString().split('T')[0];
-    const params = new URLSearchParams({
-      event_type: 'Protests|Riots|Battles|Explosions/Remote violence|Violence against civilians',
-      event_date: `${startDate}|${endDate}`, event_date_where: 'BETWEEN',
-      limit: '1000', _format: 'json',
-    });
-    const fullUrl = `${ACLED_API_URL}?${params}`;
-    const url = new URL(fullUrl);
-    const req = https.request(url, {
-      method: 'GET',
-      headers: { Accept: 'application/json', Authorization: `Bearer ${ACLED_ACCESS_TOKEN}`, 'User-Agent': CHROME_UA },
-      timeout: 15000,
-    }, (resp) => {
-      if (resp.statusCode < 200 || resp.statusCode >= 300) { resp.resume(); return resolve([]); }
-      let data = '';
-      resp.on('data', (chunk) => { data += chunk; });
-      resp.on('end', () => {
-        try { const parsed = JSON.parse(data); resolve(parsed?.data || []); }
-        catch { resolve([]); }
-      });
-    });
-    req.on('error', () => resolve([]));
-    req.on('timeout', () => { req.destroy(); resolve([]); });
-    req.end();
-  });
-}
-
-let ciiSeedInFlight = false;
-
-async function seedCiiScores() {
-  if (ciiSeedInFlight) return;
-  ciiSeedInFlight = true;
-  const t0 = Date.now();
-  try {
-    const [acledRaw, ucdpRaw, outagesRaw, climateRaw, cyberRaw, firesRaw, gpsRaw, iranRaw] = await Promise.all([
-      ciiFetchAcled(),
-      upstashGet('conflict:ucdp-events:v1').catch(() => null),
-      upstashGet('infra:outages:v1').catch(() => null),
-      upstashGet('climate:anomalies:v1').catch(() => null),
-      upstashGet('cyber:threats-bootstrap:v2').catch(() => null),
-      upstashGet('wildfire:fires:v1').catch(() => null),
-      upstashGet('intelligence:gpsjam:v1').catch(() => null),
-      upstashGet('conflict:iran-events:v1').catch(() => null),
-    ]);
-
-    const acledEvents = Array.isArray(acledRaw) ? acledRaw : [];
-    const ucdpEvents = Array.isArray(ucdpRaw?.events) ? ucdpRaw.events : (Array.isArray(ucdpRaw) ? ucdpRaw : []);
-    const outagesList = Array.isArray(outagesRaw?.outages) ? outagesRaw.outages : (Array.isArray(outagesRaw) ? outagesRaw : []);
-    const climateList = Array.isArray(climateRaw?.anomalies) ? climateRaw.anomalies : (Array.isArray(climateRaw) ? climateRaw : []);
-    const cyberThreats = Array.isArray(cyberRaw?.threats) ? cyberRaw.threats : (Array.isArray(cyberRaw) ? cyberRaw : []);
-    const firesList = Array.isArray(firesRaw?.fires) ? firesRaw.fires : (Array.isArray(firesRaw) ? firesRaw : []);
-    const gpsHexes = Array.isArray(gpsRaw?.hexes) ? gpsRaw.hexes : (Array.isArray(gpsRaw) ? gpsRaw : []);
-    const iranEvents = Array.isArray(iranRaw?.events) ? iranRaw.events : (Array.isArray(iranRaw) ? iranRaw : []);
-
-    const countryData = {};
-    for (const code of Object.keys(CII_TIER1)) {
-      countryData[code] = { protests: 0, riots: 0, battles: 0, explosions: 0, civilianViolence: 0, fatalities: 0, iranStrikes: 0, ucdpWar: false, ucdpMinor: false, outageBoost: 0, climateSeverity: 0, cyberCount: 0, fireCount: 0, gpsHexCount: 0 };
-    }
-
-    for (const ev of acledEvents) {
-      const code = ciiNormalizeCountry(ev.country || '');
-      if (!code || !countryData[code]) continue;
-      const type = (ev.event_type || '').toLowerCase();
-      if (type.includes('protest')) countryData[code].protests++;
-      else if (type.includes('riot')) countryData[code].riots++;
-      else if (type.includes('battle')) countryData[code].battles++;
-      else if (type.includes('explosion') || type.includes('remote')) countryData[code].explosions++;
-      else if (type.includes('violence')) countryData[code].civilianViolence++;
-      countryData[code].fatalities += parseInt(ev.fatalities || '0', 10) || 0;
-    }
-
-    for (const ev of ucdpEvents) {
-      const code = ciiNormalizeCountry(ev.country || ev.location || '');
-      if (!code || !countryData[code]) continue;
-      const intensity = parseInt(ev.intensity_level || ev.type_of_violence || '0', 10);
-      if (intensity >= 2) countryData[code].ucdpWar = true;
-      else if (intensity >= 1) countryData[code].ucdpMinor = true;
-    }
-
-    for (const o of outagesList) {
-      const code = (o.countryCode || o.country_code || '').toUpperCase();
-      if (countryData[code]) {
-        const severity = Number(o.severity || o.score || 0);
-        countryData[code].outageBoost = Math.max(countryData[code].outageBoost, Math.min(10, severity * 2));
-      }
-    }
-
-    for (const a of climateList) {
-      const zone = a.zone || a.region || '';
-      const countries = CII_ZONE_COUNTRY_MAP[zone] || [];
-      const severity = Number(a.severity || a.score || 0);
-      for (const code of countries) {
-        if (countryData[code]) countryData[code].climateSeverity = Math.max(countryData[code].climateSeverity, severity);
-      }
-    }
-
-    for (const t of cyberThreats) {
-      const code = (t.country || '').toUpperCase();
-      if (countryData[code]) countryData[code].cyberCount++;
-    }
-
-    for (const f of firesList) {
-      const lat = Number(f.lat || f.latitude);
-      const lon = Number(f.lon || f.longitude);
-      const code = ciiGeoToCountry(lat, lon);
-      if (code && countryData[code]) countryData[code].fireCount++;
-    }
-
-    for (const h of gpsHexes) {
-      const lat = Number(h.lat || h.latitude);
-      const lon = Number(h.lon || h.longitude);
-      const code = ciiGeoToCountry(lat, lon);
-      if (code && countryData[code]) countryData[code].gpsHexCount++;
-    }
-
-    for (const s of iranEvents) {
-      const lat = Number(s.lat || s.latitude);
-      const lon = Number(s.lon || s.longitude);
-      const code = ciiGeoToCountry(lat, lon) || ciiNormalizeCountry(s.title || s.location || '');
-      if (code && countryData[code]) countryData[code].iranStrikes++;
-    }
-
-    const ciiScores = [];
-    for (const [code, _name] of Object.entries(CII_TIER1)) {
-      const d = countryData[code];
-      const baseline = CII_BASELINE_RISK[code] || 20;
-      const multiplier = CII_EVENT_MULTIPLIER[code] || 1.0;
-
-      const unrest = Math.min(100, Math.round((d.protests * multiplier + d.riots * multiplier * 2 + d.outageBoost) * 2));
-      const conflict = Math.min(100, Math.round((d.battles + d.explosions + d.civilianViolence + d.fatalities * 0.5 + d.iranStrikes * 3) * multiplier));
-      const security = Math.min(100, Math.round(d.gpsHexCount * 3 * multiplier));
-      const information = 0;
-
-      const eventScore = unrest * 0.25 + conflict * 0.30 + security * 0.20 + information * 0.25;
-
-      const climateBoost = Math.min(15, d.climateSeverity * 3);
-      const cyberBoost = Math.min(10, Math.floor(d.cyberCount / 5));
-      const fireBoost = Math.min(8, Math.floor(d.fireCount / 10));
-
-      let blended = baseline * 0.4 + eventScore * 0.6 + climateBoost + cyberBoost + fireBoost;
-
-      const floor = d.ucdpWar ? 70 : (d.ucdpMinor ? 50 : 0);
-      const composite = Math.min(100, Math.max(floor, Math.round(blended)));
-
-      ciiScores.push({
-        region: code,
-        staticBaseline: baseline,
-        dynamicScore: composite - baseline,
-        combinedScore: composite,
-        trend: 'TREND_DIRECTION_STABLE',
-        components: { newsActivity: information, ciiContribution: unrest, geoConvergence: conflict, militaryActivity: security },
-        computedAt: Date.now(),
-      });
-    }
-
-    ciiScores.sort((a, b) => b.combinedScore - a.combinedScore);
-
-    const top5 = ciiScores.slice(0, 5);
-    const weights = top5.map((_, i) => 1 - i * 0.15);
-    const totalWeight = weights.reduce((s, w) => s + w, 0);
-    const weightedSum = top5.reduce((s, sc, i) => s + sc.combinedScore * weights[i], 0);
-    const overallScore = Math.min(100, Math.round((weightedSum / totalWeight) * 0.7 + 15));
-    const strategicRisks = [{
-      region: 'global',
-      level: overallScore >= 70 ? 'SEVERITY_LEVEL_HIGH' : (overallScore >= 40 ? 'SEVERITY_LEVEL_MEDIUM' : 'SEVERITY_LEVEL_LOW'),
-      score: overallScore,
-      factors: top5.map((s) => s.region),
-      trend: 'TREND_DIRECTION_STABLE',
-    }];
-
-    const payload = { ciiScores, strategicRisks };
-    const ok1 = await upstashSet(CII_RPC_KEY, payload, CII_RPC_TTL);
-    const ok2 = await upstashSet(CII_STALE_KEY, payload, CII_STALE_TTL);
-
-    const topEntry = ciiScores[0];
-    const srcCount = (acledEvents.length > 0 ? 1 : 0) + (ucdpEvents.length > 0 ? 1 : 0)
-      + (outagesList.length > 0 ? 1 : 0) + (climateList.length > 0 ? 1 : 0)
-      + (cyberThreats.length > 0 ? 1 : 0) + (firesList.length > 0 ? 1 : 0)
-      + (gpsHexes.length > 0 ? 1 : 0) + (iranEvents.length > 0 ? 1 : 0);
-    console.log(`[CII] Seeded ${ciiScores.length} scores (top: ${topEntry?.region}=${topEntry?.combinedScore}, sources: ${srcCount}/8, acled: ${acledEvents.length}, redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
-  } catch (e) {
-    console.error('[CII] Seed error:', e?.message || e);
-  } finally {
-    ciiSeedInFlight = false;
-  }
-}
-
-async function startCiiSeedLoop() {
-  if (!UPSTASH_ENABLED) {
-    console.log('[CII] Disabled (no Upstash Redis)');
-    return;
-  }
-  console.log(`[CII] Seed loop starting (interval ${CII_SEED_INTERVAL_MS / 1000 / 60}min, acled: ${ACLED_ACCESS_TOKEN ? 'yes' : 'no'})`);
-  seedCiiScores().catch((e) => console.warn('[CII] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedCiiScores().catch((e) => console.warn('[CII] Seed error:', e?.message || e));
-  }, CII_SEED_INTERVAL_MS).unref?.();
-}
-
-// ─────────────────────────────────────────────────────────────
 // Positive Events Seed — Railway fetches GDELT GEO API → writes to Redis
 // so Vercel handler serves from cache (avoids 25s edge timeout on slow GDELT)
 // ─────────────────────────────────────────────────────────────
@@ -2190,6 +1899,356 @@ async function startPositiveEventsSeedLoop() {
   setInterval(() => {
     seedPositiveEvents().catch((e) => console.warn('[PositiveEvents] Seed error:', e?.message || e));
   }, POSITIVE_EVENTS_INTERVAL_MS).unref?.();
+}
+
+// ─────────────────────────────────────────────────────────────
+// CII (Country Instability Index) Seed — Railway reads Redis sources
+// + calls ACLED directly, computes enriched CII scores → writes to Redis
+// so bootstrap + RPC handler serve pre-computed scores (instant render)
+// ─────────────────────────────────────────────────────────────
+const CII_SEED_INTERVAL_MS = 600_000; // 10 min
+const CII_SEED_TTL = 900; // 15 min
+const CII_STALE_TTL = 3600; // 1 hour
+const CII_REDIS_KEY = 'risk:scores:sebuf:v1';
+const CII_STALE_KEY = 'risk:scores:sebuf:stale:v1';
+const ACLED_ACCESS_TOKEN = process.env.ACLED_ACCESS_TOKEN || '';
+const ACLED_API_URL = 'https://acleddata.com/api/acled/read';
+
+const CII_BASELINE_RISK = {
+  US: 5, RU: 35, CN: 25, UA: 50, IR: 40, IL: 45, TW: 30, KP: 45,
+  SA: 20, TR: 25, PL: 10, DE: 5, FR: 10, GB: 5, IN: 20, PK: 35,
+  SY: 50, YE: 50, MM: 45, VE: 40,
+};
+const CII_EVENT_MULTIPLIER = {
+  US: 0.3, RU: 2.0, CN: 2.5, UA: 0.8, IR: 2.0, IL: 0.7, TW: 1.5, KP: 3.0,
+  SA: 2.0, TR: 1.2, PL: 0.8, DE: 0.5, FR: 0.6, GB: 0.5, IN: 0.8, PK: 1.5,
+  SY: 0.7, YE: 0.7, MM: 1.8, VE: 1.8,
+};
+const CII_COUNTRY_NAMES = {
+  US: 'United States', RU: 'Russia', CN: 'China', UA: 'Ukraine', IR: 'Iran',
+  IL: 'Israel', TW: 'Taiwan', KP: 'North Korea', SA: 'Saudi Arabia', TR: 'Turkey',
+  PL: 'Poland', DE: 'Germany', FR: 'France', GB: 'United Kingdom', IN: 'India',
+  PK: 'Pakistan', SY: 'Syria', YE: 'Yemen', MM: 'Myanmar', VE: 'Venezuela',
+};
+const CII_COUNTRY_KEYWORDS = {
+  US: ['united states', 'usa', 'america', 'washington', 'biden', 'trump', 'pentagon'],
+  RU: ['russia', 'moscow', 'kremlin', 'putin'],
+  CN: ['china', 'beijing', 'xi jinping', 'prc'],
+  UA: ['ukraine', 'kyiv', 'zelensky', 'donbas'],
+  IR: ['iran', 'tehran', 'khamenei', 'irgc'],
+  IL: ['israel', 'tel aviv', 'netanyahu', 'idf', 'gaza'],
+  TW: ['taiwan', 'taipei'], KP: ['north korea', 'pyongyang', 'kim jong'],
+  SA: ['saudi arabia', 'riyadh'], TR: ['turkey', 'ankara', 'erdogan'],
+  PL: ['poland', 'warsaw'], DE: ['germany', 'berlin'],
+  FR: ['france', 'paris', 'macron'], GB: ['britain', 'uk', 'london'],
+  IN: ['india', 'delhi', 'modi'], PK: ['pakistan', 'islamabad'],
+  SY: ['syria', 'damascus'], YE: ['yemen', 'sanaa', 'houthi'],
+  MM: ['myanmar', 'burma'], VE: ['venezuela', 'caracas', 'maduro'],
+};
+
+const CII_ZONE_COUNTRY_MAP = {
+  'Ukraine': ['UA'], 'Middle East': ['IR', 'IL', 'SA', 'SY', 'YE'],
+  'South Asia': ['PK', 'IN'], 'Myanmar': ['MM'],
+};
+
+const CII_TIER1_BB = {
+  US: { n: 72, s: 18, e: -66, w: -180 }, RU: { n: 82, s: 41, e: 180, w: 27 },
+  CN: { n: 54, s: 18, e: 135, w: 73 }, UA: { n: 52, s: 44, e: 40, w: 22 },
+  IR: { n: 40, s: 25, e: 63, w: 44 }, IL: { n: 33.3, s: 29.5, e: 35.9, w: 34.3 },
+  TW: { n: 25.5, s: 21.5, e: 122, w: 120 }, KP: { n: 43, s: 37.6, e: 131, w: 124 },
+  SA: { n: 32, s: 16, e: 55, w: 35 }, TR: { n: 42, s: 36, e: 45, w: 26 },
+  PL: { n: 55, s: 49, e: 24, w: 14 }, DE: { n: 55, s: 47, e: 15, w: 6 },
+  FR: { n: 51, s: 42, e: 10, w: -5 }, GB: { n: 61, s: 49, e: 2, w: -8 },
+  IN: { n: 36, s: 6, e: 97, w: 68 }, PK: { n: 37, s: 24, e: 77, w: 61 },
+  SY: { n: 37.3, s: 32.3, e: 42.4, w: 35.7 }, YE: { n: 19, s: 12, e: 54.5, w: 42 },
+  MM: { n: 28, s: 10, e: 101, w: 92 }, VE: { n: 12, s: 1, e: -60, w: -73 },
+};
+
+function ciiNormalizeCountry(text) {
+  if (!text) return null;
+  const lower = text.toLowerCase();
+  for (const [code, kws] of Object.entries(CII_COUNTRY_KEYWORDS)) {
+    if (kws.some((kw) => lower.includes(kw))) return code;
+  }
+  return null;
+}
+
+function ciiBoundsLookup(lat, lon) {
+  for (const [code, b] of Object.entries(CII_TIER1_BB)) {
+    if (lat >= b.s && lat <= b.n && lon >= b.w && lon <= b.e) return code;
+  }
+  return null;
+}
+
+function ciiClamp(val, min, max) {
+  const n = Number(val);
+  if (!Number.isFinite(n)) return min;
+  return Math.max(min, Math.min(max, n));
+}
+
+function ciiAcledFetch() {
+  return new Promise((resolve) => {
+    if (!ACLED_ACCESS_TOKEN) return resolve([]);
+    const endDate = new Date().toISOString().split('T')[0];
+    const startDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+    const params = new URLSearchParams({
+      event_type: 'Protests|Riots|Battles|Explosions/Remote violence|Violence against civilians',
+      event_date: `${startDate}|${endDate}`,
+      event_date_where: 'BETWEEN',
+      limit: '2000',
+      _format: 'json',
+    });
+    const url = new URL(`${ACLED_API_URL}?${params}`);
+    const req = https.request(url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${ACLED_ACCESS_TOKEN}`,
+        'User-Agent': 'Mozilla/5.0 (WorldMonitor Railway Seed)',
+      },
+      timeout: 15000,
+    }, (resp) => {
+      if (resp.statusCode < 200 || resp.statusCode >= 300) {
+        resp.resume();
+        return resolve([]);
+      }
+      let raw = '';
+      resp.on('data', (chunk) => { raw += chunk; });
+      resp.on('end', () => {
+        try {
+          const parsed = JSON.parse(raw);
+          resolve(Array.isArray(parsed?.data) ? parsed.data : []);
+        } catch { resolve([]); }
+      });
+    });
+    req.on('error', () => resolve([]));
+    req.on('timeout', () => { req.destroy(); resolve([]); });
+    req.end();
+  });
+}
+
+let ciiSeedInFlight = false;
+
+async function seedCiiScores() {
+  if (ciiSeedInFlight) return;
+  ciiSeedInFlight = true;
+  const t0 = Date.now();
+  try {
+    const [acled, ucdpRaw, outagesRaw, climateRaw, cyberRaw, firesRaw, gpsRaw, iranRaw] = await Promise.all([
+      ciiAcledFetch(),
+      upstashGet('conflict:ucdp-events:v1'),
+      upstashGet('infra:outages:v1'),
+      upstashGet('climate:anomalies:v1'),
+      upstashGet('cyber:threats-bootstrap:v2'),
+      upstashGet('wildfire:fires:v1'),
+      upstashGet('intelligence:gpsjam:v1'),
+      upstashGet('conflict:iran-events:v1'),
+    ]);
+
+    const countryCounts = {};
+    for (const code of Object.keys(CII_BASELINE_RISK)) {
+      countryCounts[code] = { protests: 0, riots: 0, battles: 0, explosions: 0, civilian: 0, fatalities: 0 };
+    }
+
+    if (Array.isArray(acled)) {
+      for (const e of acled) {
+        const code = ciiNormalizeCountry(e.country);
+        if (!code || !countryCounts[code]) continue;
+        const type = (e.event_type || '').toLowerCase();
+        const fat = ciiClamp(e.fatalities, 0, 10000);
+        if (type.includes('protest')) countryCounts[code].protests++;
+        else if (type.includes('riot')) countryCounts[code].riots++;
+        else if (type.includes('battle')) { countryCounts[code].battles++; countryCounts[code].fatalities += fat; }
+        else if (type.includes('explosion') || type.includes('remote')) { countryCounts[code].explosions++; countryCounts[code].fatalities += fat; }
+        else if (type.includes('civilian')) { countryCounts[code].civilian++; countryCounts[code].fatalities += fat; }
+      }
+    }
+
+    const ucdpFloors = {};
+    if (Array.isArray(ucdpRaw?.classifications || ucdpRaw)) {
+      const items = ucdpRaw?.classifications || ucdpRaw;
+      for (const u of items) {
+        const code = u?.countryCode || u?.country_code;
+        if (!code || !countryCounts[code]) continue;
+        const intensity = (u?.intensity || '').toLowerCase();
+        if (intensity === 'war') ucdpFloors[code] = Math.max(ucdpFloors[code] || 0, 70);
+        else if (intensity === 'minor') ucdpFloors[code] = Math.max(ucdpFloors[code] || 0, 50);
+      }
+    }
+
+    const outageBoosts = {};
+    if (Array.isArray(outagesRaw?.outages || outagesRaw)) {
+      const items = outagesRaw?.outages || outagesRaw;
+      for (const o of items) {
+        const code = ciiNormalizeCountry(o?.country) || o?.countryCode;
+        if (!code || !countryCounts[code]) continue;
+        const sev = (o?.severity || '').toLowerCase();
+        const boost = sev === 'total' ? 30 : sev === 'major' ? 15 : 5;
+        outageBoosts[code] = Math.min(50, (outageBoosts[code] || 0) + boost);
+      }
+    }
+
+    const climateBoosts = {};
+    if (Array.isArray(climateRaw?.anomalies || climateRaw)) {
+      const items = climateRaw?.anomalies || climateRaw;
+      for (const a of items) {
+        if ((a?.severity || '') === 'normal') continue;
+        const codes = CII_ZONE_COUNTRY_MAP[a?.zone] || [];
+        const stress = a?.severity === 'extreme' ? 15 : 8;
+        for (const c of codes) {
+          if (countryCounts[c]) climateBoosts[c] = Math.max(climateBoosts[c] || 0, stress);
+        }
+      }
+    }
+
+    const cyberBoosts = {};
+    if (Array.isArray(cyberRaw?.threats || cyberRaw)) {
+      const items = cyberRaw?.threats || cyberRaw;
+      for (const t of items) {
+        const code = t?.country || (Number.isFinite(t?.lat) && Number.isFinite(t?.lon) ? ciiBoundsLookup(t.lat, t.lon) : null);
+        if (!code || !countryCounts[code]) continue;
+        const sev = (t?.severity || '').toLowerCase();
+        const val = sev === 'critical' ? 3 : sev === 'high' ? 1.8 : sev === 'medium' ? 0.9 : 0;
+        cyberBoosts[code] = (cyberBoosts[code] || 0) + val;
+      }
+    }
+    for (const code of Object.keys(cyberBoosts)) cyberBoosts[code] = Math.min(12, cyberBoosts[code]);
+
+    const fireBoosts = {};
+    if (Array.isArray(firesRaw?.fires || firesRaw)) {
+      const items = firesRaw?.fires || firesRaw;
+      for (const f of items) {
+        const code = f?.region || (Number.isFinite(f?.lat) && Number.isFinite(f?.lon) ? ciiBoundsLookup(f.lat, f.lon) : null);
+        if (!code || !countryCounts[code]) continue;
+        const isHigh = (f?.brightness >= 360 || f?.frp >= 50);
+        if (!fireBoosts[code]) fireBoosts[code] = { count: 0, high: 0 };
+        fireBoosts[code].count++;
+        if (isHigh) fireBoosts[code].high++;
+      }
+    }
+    for (const code of Object.keys(fireBoosts)) {
+      const fb = fireBoosts[code];
+      fireBoosts[code] = Math.min(8, fb.high * 1.5 + Math.min(20, fb.count) * 0.25);
+    }
+
+    const gpsBoosts = {};
+    if (Array.isArray(gpsRaw?.hexes || gpsRaw)) {
+      const items = gpsRaw?.hexes || gpsRaw;
+      for (const hex of items) {
+        if (!Number.isFinite(hex?.lat) || !Number.isFinite(hex?.lon)) continue;
+        const code = ciiBoundsLookup(hex.lat, hex.lon);
+        if (!code || !countryCounts[code]) continue;
+        const val = (hex?.level === 'high') ? 5 : 2;
+        gpsBoosts[code] = (gpsBoosts[code] || 0) + val;
+      }
+    }
+    for (const code of Object.keys(gpsBoosts)) gpsBoosts[code] = Math.min(35, gpsBoosts[code]);
+
+    const iranStrikeBoosts = {};
+    if (Array.isArray(iranRaw?.events || iranRaw)) {
+      const items = iranRaw?.events || iranRaw;
+      const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+      for (const e of items) {
+        if (e?.timestamp && e.timestamp < sevenDaysAgo) continue;
+        if (!Number.isFinite(e?.latitude) || !Number.isFinite(e?.longitude)) continue;
+        const code = ciiBoundsLookup(e.latitude, e.longitude);
+        if (!code || !countryCounts[code]) continue;
+        const sevVal = (e?.severity || '').toLowerCase();
+        const boost = (sevVal === 'high' || sevVal === 'critical') ? 8 : 3;
+        iranStrikeBoosts[code] = (iranStrikeBoosts[code] || 0) + boost;
+      }
+    }
+    for (const code of Object.keys(iranStrikeBoosts)) iranStrikeBoosts[code] = Math.min(50, iranStrikeBoosts[code]);
+
+    const ciiScores = [];
+    for (const [code, _name] of Object.entries(CII_COUNTRY_NAMES)) {
+      const baseline = CII_BASELINE_RISK[code] || 20;
+      const mult = CII_EVENT_MULTIPLIER[code] || 1.0;
+      const c = countryCounts[code] || { protests: 0, riots: 0, battles: 0, explosions: 0, civilian: 0, fatalities: 0 };
+
+      const isHighVolume = mult < 0.7;
+      const protestCount = c.protests + c.riots;
+      const adjustedProtests = isHighVolume
+        ? Math.log2(protestCount + 1) * mult * 5
+        : protestCount * mult;
+      const unrest = ciiClamp(adjustedProtests * 8 + (outageBoosts[code] || 0), 0, 100);
+
+      const battleScore = Math.min(50, (c.battles * 3 + c.explosions * 4 + c.civilian * 5) * mult);
+      const fatalityScore = Math.min(40, Math.sqrt(c.fatalities) * 5 * mult);
+      const civilianBoost = c.civilian > 0 ? Math.min(10, c.civilian * 3) : 0;
+      const acledConflict = battleScore + fatalityScore + civilianBoost + (iranStrikeBoosts[code] || 0);
+      const conflict = ciiClamp(Math.max(acledConflict, ucdpFloors[code] || 0), 0, 100);
+
+      const security = ciiClamp(gpsBoosts[code] || 0, 0, 100);
+      const information = 0;
+
+      const eventScore = unrest * 0.25 + conflict * 0.30 + security * 0.20 + information * 0.25;
+      const supplemental = (climateBoosts[code] || 0) + (typeof cyberBoosts[code] === 'number' ? cyberBoosts[code] : 0) + (typeof fireBoosts[code] === 'number' ? fireBoosts[code] : 0);
+      const blended = baseline * 0.4 + eventScore * 0.6 + supplemental;
+      const floor = ucdpFloors[code] || 0;
+      const combinedScore = ciiClamp(Math.round(Math.max(baseline, Math.max(floor, blended))), 0, 100);
+
+      ciiScores.push({
+        region: code,
+        staticBaseline: baseline,
+        dynamicScore: combinedScore - baseline,
+        combinedScore,
+        trend: 'TREND_DIRECTION_STABLE',
+        components: {
+          ciiContribution: Math.round(unrest),
+          geoConvergence: Math.round(conflict),
+          militaryActivity: Math.round(security),
+          newsActivity: Math.round(information),
+        },
+        computedAt: Date.now(),
+      });
+    }
+
+    ciiScores.sort((a, b) => b.combinedScore - a.combinedScore);
+
+    if (!Array.isArray(ciiScores) || ciiScores.length === 0 || ciiScores.some(s => !Number.isFinite(s.combinedScore))) {
+      console.warn('[CII] Invalid payload shape — skipping Redis write');
+      return;
+    }
+
+    const top5 = ciiScores.slice(0, 5);
+    const weights = top5.map((_, i) => 1 - i * 0.15);
+    const totalWeight = weights.reduce((sum, w) => sum + w, 0);
+    const weightedSum = top5.reduce((sum, s, i) => sum + s.combinedScore * weights[i], 0);
+    const overallScore = Math.min(100, Math.round((weightedSum / totalWeight) * 0.7 + 15));
+
+    const strategicRisks = [{
+      region: 'global',
+      level: overallScore >= 70 ? 'SEVERITY_LEVEL_HIGH' : overallScore >= 40 ? 'SEVERITY_LEVEL_MEDIUM' : 'SEVERITY_LEVEL_LOW',
+      score: overallScore,
+      factors: top5.map((s) => s.region),
+      trend: 'TREND_DIRECTION_STABLE',
+    }];
+
+    const payload = { ciiScores, strategicRisks };
+    const ok1 = await upstashSet(CII_REDIS_KEY, payload, CII_SEED_TTL);
+    if (ok1) {
+      await upstashSet(CII_STALE_KEY, payload, CII_STALE_TTL);
+    }
+    const topEntry = ciiScores[0];
+    console.log(`[CII] Seeded ${ciiScores.length} scores (top: ${topEntry?.region}=${topEntry?.combinedScore}, acled:${Array.isArray(acled) ? acled.length : 0} redis:${ok1 ? 'OK' : 'FAIL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+  } catch (e) {
+    console.warn('[CII] Seed error:', e?.message || e);
+  } finally {
+    ciiSeedInFlight = false;
+  }
+}
+
+async function startCiiSeedLoop() {
+  if (!UPSTASH_ENABLED) {
+    console.log('[CII] Disabled (no Upstash Redis)');
+    return;
+  }
+  console.log(`[CII] Seed loop starting (interval ${CII_SEED_INTERVAL_MS / 1000 / 60}min, acled:${ACLED_ACCESS_TOKEN ? 'yes' : 'no'})`);
+  seedCiiScores().catch((e) => console.warn('[CII] Initial seed error:', e?.message || e));
+  setInterval(() => {
+    seedCiiScores().catch((e) => console.warn('[CII] Seed error:', e?.message || e));
+  }, CII_SEED_INTERVAL_MS).unref?.();
 }
 
 function gzipSyncBuffer(body) {


### PR DESCRIPTION
## Summary
- Adds `seedCiiScores()` to `scripts/ais-relay.cjs` that runs every 10 minutes on Railway
- Reads 7 Redis sources (UCDP, outages, climate, cyber, fires, GPS jam, Iran) + calls ACLED API directly
- Computes simplified CII scores for 20 TIER1 countries
- Writes to `risk:scores:sebuf:v1` (TTL 900s) + `risk:scores:sebuf:stale:v1` (TTL 3600s)

Frontend bootstrap hydration (already on main) consumes these scores for instant CII panel render.

## Changes
- **1 file**: `scripts/ais-relay.cjs` (+350 lines)

## Test plan
- [ ] Deploy to Railway, check logs for `[CII] Seeded N scores (top: XX=NN)` every 10 min
- [ ] Verify Redis key `risk:scores:sebuf:v1` has valid JSON with enriched scores
- [ ] Verify `curl 'https://api.worldmonitor.app/api/bootstrap?tier=fast'` includes `riskScores` data
- [ ] CII panel renders instantly on page load (no loading spinner)

## Prerequisite
- `ACLED_ACCESS_TOKEN` must be set in Railway environment variables