### PR TITLE
feat: add mobile search FAB for always-visible search access

### DIFF
--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -240,6 +240,7 @@ export class EventHandlerManager implements AppModule {
     };
     document.getElementById('searchBtn')?.addEventListener('click', openSearch);
     document.getElementById('mobileSearchBtn')?.addEventListener('click', openSearch);
+    document.getElementById('searchMobileFab')?.addEventListener('click', openSearch);
 
     document.getElementById('copyLinkBtn')?.addEventListener('click', async () => {
       const shareUrl = this.getShareUrl();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -302,6 +302,7 @@ export class PanelLayoutManager implements AppModule {
           <div class="map-bottom-grid" id="mapBottomGrid"></div>
         </div>
         <div class="panels-grid" id="panelsGrid"></div>
+        <button class="search-mobile-fab" id="searchMobileFab" aria-label="Search">\u{1F50D}</button>
       </div>
     `;
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -8248,6 +8248,38 @@ a.prediction-link:hover {
   margin-right: 4px;
 }
 
+/* Mobile search FAB — always visible floating button */
+.search-mobile-fab {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .search-mobile-fab {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+    right: 16px;
+    width: 56px;
+    height: 56px;
+    background: var(--accent, #4488ff);
+    border: none;
+    border-radius: 50%;
+    box-shadow: 0 4px 20px rgba(68, 136, 255, 0.4), 0 2px 8px rgba(0, 0, 0, 0.3);
+    color: #fff;
+    font-size: 22px;
+    cursor: pointer;
+    z-index: 500;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .search-mobile-fab:active {
+    transform: scale(0.9);
+    opacity: 0.85;
+  }
+}
+
 /* Mobile bottom sheet search */
 .search-overlay.search-mobile {
   align-items: flex-end;
@@ -8365,6 +8397,14 @@ a.prediction-link:hover {
   .search-overlay.search-mobile .search-section-header {
     font-size: 11px;
     padding: 10px 16px;
+  }
+
+  .search-overlay.search-mobile .search-result-subtitle {
+    display: none;
+  }
+
+  .search-overlay.search-mobile .search-result-type {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add 56px accent-blue floating action button (bottom-right corner) for mobile search
- Always visible regardless of scroll position or horizontal overflow
- Hide subtitles and type badges on mobile search results for cleaner look
- Complements the header search icon — users can search from anywhere on the page

## Context
Follow-up to PR #988. The header search icon is easy to miss (small, clipped by horizontal overflow, requires scrolling to top). The FAB provides a persistent, highly visible search entry point.

## Test plan
- [ ] Mobile: blue circular 🔍 button visible at bottom-right at all scroll positions
- [ ] Tap FAB → bottom sheet opens
- [ ] Desktop: FAB hidden, Cmd+K modal unchanged
- [ ] Search results show only icon + title on mobile (no subtitle/type badge)