### PR TITLE
fix: seed scripts exit cleanly for Railway cron

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -184,8 +184,39 @@ export async function verifySeedKey(key) {
   return data;
 }
 
+export async function writeExtraKey(key, data, ttl) {
+  const { url, token } = getRedisCredentials();
+  const payload = JSON.stringify(data);
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(['SET', key, payload, 'EX', ttl]),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!resp.ok) console.warn(`  Extra key ${key}: write failed (HTTP ${resp.status})`);
+  else console.log(`  Extra key ${key}: written`);
+}
+
+export function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export function parseYahooChart(data, symbol) {
+  const result = data?.chart?.result?.[0];
+  const meta = result?.meta;
+  if (!meta) return null;
+
+  const price = meta.regularMarketPrice;
+  const prevClose = meta.chartPreviousClose || meta.previousClose || price;
+  const change = prevClose ? ((price - prevClose) / prevClose) * 100 : 0;
+  const closes = result.indicators?.quote?.[0]?.close;
+  const sparkline = Array.isArray(closes) ? closes.filter((v) => v != null) : [];
+
+  return { symbol, name: symbol, display: symbol, price, change: +change.toFixed(2), sparkline };
+}
+
 export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}) {
-  const { validateFn, ttlSeconds, lockTtlMs = 120_000 } = opts;
+  const { validateFn, ttlSeconds, lockTtlMs = 120_000, extraKeys } = opts;
   const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const startMs = Date.now();
 
@@ -197,7 +228,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
   const locked = await acquireLock(`${domain}:${resource}`, runId, lockTtlMs);
   if (!locked) {
     console.log('  SKIPPED: another seed run in progress');
-    return { skipped: true };
+    process.exit(0);
   }
 
   try {
@@ -205,7 +236,15 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     const { payloadBytes } = await atomicPublish(canonicalKey, data, validateFn, ttlSeconds);
     const recordCount = Array.isArray(data) ? data.length
       : (data?.events?.length ?? data?.earthquakes?.length ?? data?.outages?.length
-        ?? data?.fireDetections?.length ?? data?.anomalies?.length ?? data?.threats?.length ?? 0);
+        ?? data?.fireDetections?.length ?? data?.anomalies?.length ?? data?.threats?.length
+        ?? data?.quotes?.length ?? data?.stablecoins?.length ?? 0);
+
+    // Write extra keys (e.g., bootstrap hydration keys)
+    if (extraKeys) {
+      for (const ek of extraKeys) {
+        await writeExtraKey(ek.key, ek.transform ? ek.transform(data) : data, ek.ttl || ttlSeconds);
+      }
+    }
 
     const meta = await writeFreshnessMetadata(domain, resource, recordCount, opts.sourceVersion);
 
@@ -221,8 +260,10 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     }
 
     console.log(`\n=== Done (${Math.round(durationMs)}ms) ===`);
-    return { success: true, recordCount, durationMs, meta };
-  } finally {
     await releaseLock(`${domain}:${resource}`, runId);
+    process.exit(0);
+  } catch (err) {
+    await releaseLock(`${domain}:${resource}`, runId);
+    throw err;
   }
 }


### PR DESCRIPTION
## Summary
- Add `process.exit(0)` to `runSeed()` success and lock-skip paths so Railway marks cron jobs as "Ready" instead of "Last run failed"
- Fix `recordCount` reporting for crypto (`.quotes`) and stablecoin (`.stablecoins`) domains — was reporting 0 due to missing destructuring
- Add shared utilities (`writeExtraKey`, `sleep`, `parseYahooChart`) to `_seed-utils.mjs` for upcoming market/commodity seed scripts
- Add `extraKeys` option to `runSeed()` for writing bootstrap hydration keys alongside canonical keys

## Root cause
Railway cron containers mark jobs "failed" when the Node.js process doesn't exit with code 0 promptly. Seed scripts relied on natural event loop drain after `runSeed()` resolved, but `fetch` (undici) keeps connection pool handles alive, preventing clean exit. Self-contained scripts (wb-indicators, iran-events, etc.) that don't use `_seed-utils.mjs` weren't affected because their simpler fetch patterns drained faster.

## Test plan
- [x] `tsc --noEmit` clean
- [x] 57/57 edge function tests pass
- [x] Local test: `seed-crypto-quotes.mjs` exits with code 0, `recordCount=4`
- [x] Local test: lock-skip scenario exits with code 0
- [ ] After merge: verify Railway cron status changes from "failed" to "Ready" within 1-2 cron cycles