### PR TITLE
fix(strategic-risk): use server-cached scores when data sources insufficient

### DIFF
--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -126,10 +126,10 @@ export class StrategicRiskPanel extends Panel {
     );
     this.alerts = getRecentAlerts(24);
 
-    // Try to get cached scores during learning mode
+    // Try to get cached scores during learning mode OR when data sources are insufficient
     const { inLearning } = getLearningProgress();
     this.usedCachedScores = false;
-    if (inLearning) {
+    if (inLearning || this.freshnessSummary.overallStatus === 'insufficient') {
       const cached = await fetchCachedRiskScores(this.signal);
       if (!this.element?.isConnected) return false;
       if (cached && cached.strategicRisk) {
@@ -459,7 +459,7 @@ export class StrategicRiskPanel extends Panel {
     // Only show insufficient state if zero sources after 60s (true failure)
     let html: string;
     const uptime = performance.now();
-    if (this.freshnessSummary.overallStatus === 'insufficient' && uptime > 60_000) {
+    if (this.freshnessSummary.overallStatus === 'insufficient' && uptime > 60_000 && !this.usedCachedScores) {
       html = this.renderInsufficientData();
     } else {
       html = this.renderFullData();


### PR DESCRIPTION
## Summary
- Strategic Risk panel showed "Insufficient Data" even when Railway/Vercel had pre-computed 8-source CII scores in Redis
- Root cause: the `overallStatus === 'insufficient'` check only looked at client-side GDELT/RSS freshness, ignoring available server-cached scores
- Now fetches cached server scores when `overallStatus` is `insufficient` (not just during learning mode) and bypasses the insufficient view when those scores are available

## Test plan
- [ ] Load app with GDELT/RSS feeds disabled or slow to connect — panel should show risk gauge from server-cached scores instead of "Insufficient Data"
- [ ] Verify normal flow with GDELT/RSS active still shows "LIVE" badge
- [ ] Verify learning mode still works correctly with cached scores