### PR TITLE
fix: move emrldco script from body to head

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,300;0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
+    <script>window.addEventListener('load',function(){var s=document.createElement('script');s.async=1;s.src='https://emrldco.com/NTA0NDAw.js?t=504400';document.head.appendChild(s);});</script>
   </head>
   <body>
     <div id="app">
@@ -203,6 +204,5 @@
       </div>
     </aside>
     <script type="module" src="/src/main.ts"></script>
-    <script>window.addEventListener('load',function(){var s=document.createElement('script');s.async=1;s.src='https://emrldco.com/NTA0NDAw.js?t=504400';document.head.appendChild(s);});</script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Moves the emrldco analytics script tag from `<body>` to `<head>` as required
- Still lazy-loaded via `window.load` event — no render blocking

## Context
PR #1000 was merged before the follow-up commit that moved the script to `<head>`. This PR applies that fix.