### PR TITLE
fix: hide redundant header search icon on mobile

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9901,7 +9901,7 @@ a.prediction-link:hover {
   }
 
   .mobile-search-btn {
-    display: flex;
+    display: none;
   }
 
   .mobile-menu-overlay {


### PR DESCRIPTION
## Summary
- Hide `.mobile-search-btn` on mobile — the FAB (from PR #998) is the sole search entry point
- Removes the confusing duplicate small magnifying glass in the header

## Test plan
- [ ] Mobile: no search icon in header, only blue FAB at bottom-right
- [ ] Desktop: Cmd+K search unchanged