### PR TITLE
fix: gateway cache tier headers overridden by Vercel default

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -210,7 +210,7 @@ export function createDomainGateway(
       }
     }
 
-    if (response.status === 200 && request.method === 'GET' && !mergedHeaders.has('Cache-Control')) {
+    if (response.status === 200 && request.method === 'GET') {
       if (mergedHeaders.get('X-No-Cache')) {
         mergedHeaders.set('Cache-Control', 'no-store');
         mergedHeaders.set('X-Cache-Tier', 'no-store');


### PR DESCRIPTION
## Summary
- Remove `!mergedHeaders.has('Cache-Control')` guard from gateway cache tier logic
- Vercel edge runtime adds a default `Cache-Control: public` to responses, which prevented the gateway from applying proper `s-maxage` tier headers
- Without `s-maxage`, Cloudflare has no TTL guidance — some endpoints cached inconsistently

## Before
All endpoints got `Cache-Control: public` (no `s-maxage`). Cloudflare used its own heuristic for TTL.

## After  
Endpoints get their configured tier headers:
- `fast`: `s-maxage=120, stale-while-revalidate=30, stale-if-error=300`
- `medium`: `s-maxage=300, stale-while-revalidate=60, stale-if-error=600`
- `slow`: `s-maxage=900, stale-while-revalidate=120, stale-if-error=1800`

## Test plan
- [x] `tsc --noEmit` clean
- [x] 57/57 edge function tests pass
- [ ] After deploy: verify `Cache-Control` header includes `s-maxage` on API responses