### PR TITLE
fix(api): harden IP extraction, input validation, redirect SSRF check, and origin-pattern parity across edge functions

### DIFF
--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -7,7 +7,7 @@ const DESKTOP_ORIGIN_PATTERNS = [
 
 const BROWSER_ORIGIN_PATTERNS = [
   /^https:\/\/(.*\.)?worldmonitor\.app$/,
-  /^https:\/\/worldmonitor-[a-z0-9-]+\.vercel\.app$/,
+  /^https:\/\/worldmonitor-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,
   ...(process.env.NODE_ENV === 'production' ? [] : [
     /^https?:\/\/localhost(:\d+)?$/,
     /^https?:\/\/127\.0\.0\.1(:\d+)?$/,

--- a/api/register-interest.js
+++ b/api/register-interest.js
@@ -5,6 +5,7 @@ import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MAX_EMAIL_LENGTH = 320;
+const MAX_META_LENGTH = 100;
 
 const rateLimitMap = new Map();
 const RATE_LIMIT = 5;
@@ -42,7 +43,14 @@ export default async function handler(req) {
     });
   }
 
-  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  // x-real-ip is injected by Vercel from the TCP connection and cannot be spoofed by
+  // clients. x-forwarded-for is client-settable and MUST NOT be the primary source for
+  // rate limiting — an attacker can rotate arbitrary values to bypass the limit entirely.
+  const ip =
+    req.headers.get('x-real-ip') ||
+    req.headers.get('cf-connecting-ip') ||
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    'unknown';
   if (isRateLimited(ip)) {
     return new Response(JSON.stringify({ error: 'Too many requests' }), {
       status: 429,
@@ -68,6 +76,17 @@ export default async function handler(req) {
     });
   }
 
+  // Coerce metadata fields to strings and enforce length caps to prevent
+  // non-string values (objects/arrays are truthy and bypass `|| 'unknown'`)
+  // from being forwarded to the database as wrong types, and to prevent
+  // arbitrarily large payloads filling the registrations table.
+  const safeSource = typeof source === 'string'
+    ? source.slice(0, MAX_META_LENGTH)
+    : 'unknown';
+  const safeAppVersion = typeof appVersion === 'string'
+    ? appVersion.slice(0, MAX_META_LENGTH)
+    : 'unknown';
+
   const convexUrl = process.env.CONVEX_URL;
   if (!convexUrl) {
     return new Response(JSON.stringify({ error: 'Registration service unavailable' }), {
@@ -80,8 +99,8 @@ export default async function handler(req) {
     const client = new ConvexHttpClient(convexUrl);
     const result = await client.mutation('registerInterest:register', {
       email,
-      source: source || 'unknown',
-      appVersion: appVersion || 'unknown',
+      source: safeSource,
+      appVersion: safeAppVersion,
     });
     return new Response(JSON.stringify(result), {
       status: 200,

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -120,7 +120,17 @@ export default async function handler(req) {
         const location = response.headers.get('location');
         if (location) {
           const redirectUrl = new URL(location, feedUrl);
-          if (!ALLOWED_DOMAINS.includes(redirectUrl.hostname)) {
+          // Apply the same www-normalization as the initial domain check so that
+          // canonical redirects (e.g. bbc.co.uk → www.bbc.co.uk) are not
+          // incorrectly rejected when only one form is in the allowlist.
+          const rHost = redirectUrl.hostname;
+          const rBare = rHost.replace(/^www\./, '');
+          const rWithWww = rHost.startsWith('www.') ? rHost : `www.${rHost}`;
+          if (
+            !ALLOWED_DOMAINS.includes(rHost) &&
+            !ALLOWED_DOMAINS.includes(rBare) &&
+            !ALLOWED_DOMAINS.includes(rWithWww)
+          ) {
             throw new Error('Redirect to disallowed domain');
           }
           return fetchWithTimeout(redirectUrl.href, {


### PR DESCRIPTION
## Summary

Three independent security and correctness bugs found during a manual audit of the `api/` edge functions. All fixes are contained to three files, add no new dependencies, and pass `npm run typecheck` cleanly.

---

## Bug 1 — Spoofable rate-limit IP in `register-interest.js`

**Root cause:** The email-registration endpoint extracted the client IP using only `X-Forwarded-For`:

```js
const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
```

`X-Forwarded-For` is a client-controlled header. An attacker can rotate it on every request to appear as a different IP each time, completely defeating the 5-registrations-per-hour in-memory rate limit and enabling unlimited spam to the Convex `registrations` table at zero cost. The rest of the codebase already knows this — `server/_shared/rate-limit.ts` carries the explicit comment: *"x-forwarded-for is client-settable and MUST NOT be trusted for rate limiting."* Both `_rate-limit.js` and `server/_shared/rate-limit.ts` follow the safe priority order (`x-real-ip` → `cf-connecting-ip` → `x-forwarded-for` last resort). This endpoint did not.

**Fix:** Align `register-interest.js` with the same header-priority chain used everywhere else in the codebase.

---

## Bug 2 — Untyped / unbounded `source` and `appVersion` in `register-interest.js`

**Root cause:** Both fields are forwarded to the Convex mutation with only `|| 'unknown'` as a guard:

```js
source: source || 'unknown',
appVersion: appVersion || 'unknown',
```

This has two failure modes:

- **Wrong type → 500:** Any JSON non-string value (object, array, number) is truthy, passes the `|| 'unknown'` fallback, and arrives at Convex as the wrong type. Convex's `v.optional(v.string())` validator rejects it and the edge function returns a `500` instead of a `400`.
- **Unbounded payload → DB bloat:** No length cap means a caller can write arbitrarily large strings into the `registrations` table, wasting Convex write capacity.

**Fix:** Add an explicit `typeof x === 'string'` guard (falling back to `'unknown'` for non-strings) and slice both fields to `MAX_META_LENGTH = 100` characters before forwarding to Convex.

---

## Bug 3 — www-normalization gap in the `rss-proxy.js` redirect SSRF check

**Root cause:** The initial URL domain check normalises `www.` prefixes — it tests the hostname, the bare form (without `www.`), and the `www.`-prefixed form. The 301-redirect follow-up check inside `fetchDirect` does not:

```js
if (!ALLOWED_DOMAINS.includes(redirectUrl.hostname)) {
  throw new Error('Redirect to disallowed domain');
}
```

A canonical server-side redirect (e.g. `bbc.co.uk → www.bbc.co.uk`) throws `"Redirect to disallowed domain"` even though one form of that hostname is in `ALLOWED_DOMAINS`, causing silent feed-fetch failures. The inconsistency is also a future maintenance hazard: adding a domain in only one `www.` form would inadvertently break its redirect variant.

**Fix:** Mirror the exact three-way normalization from the initial check in the redirect check.

---

## Bug 4 — Dead-code origin branch in `_api-key.js` (pattern drift from `_cors.js`)

**Root cause:** The two modules use different regexes for Vercel preview deployments:

| File | Pattern |
|---|---|
| `_cors.js` (evaluated first) | `worldmonitor-[a-z0-9-]+-elie-[a-z0-9]+.vercel.app` |
| `_api-key.js` (evaluated second) | `worldmonitor-[a-z0-9-]+.vercel.app` |

Because `_cors.js` runs before `_api-key.js` in every handler, any preview URL matching the broader `_api-key.js` pattern but not the narrower `_cors.js` pattern is already rejected with a `403` before `_api-key.js` is consulted. The broader trusted-browser-origin branch is dead code. More importantly, the divergence is a latent hazard: a future refactor that reorders checks or copies just the `_api-key.js` pattern would inadvertently trust a wider set of Vercel previews than intended.

**Fix:** Align `BROWSER_ORIGIN_PATTERNS` in `_api-key.js` to the identical narrower pattern already enforced by `_cors.js`.

---

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)

## Checklist

- [x] TypeScript compiles without errors (`npm run typecheck`)
- [x] No API keys or secrets committed
- [x] Branch based on latest `main` (rebased after upstream fast-forward to `16661457`)
