### PR TITLE
fix(hydration): guard bootstrap consumers against empty CDN-cached data

### DIFF
--- a/api/telegram-feed.js
+++ b/api/telegram-feed.js
@@ -1,21 +1,76 @@
-import { createRelayHandler } from './_relay.js';
+import { getRelayBaseUrl, getRelayHeaders, fetchWithTimeout } from './_relay.js';
+import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 
 export const config = { runtime: 'edge' };
 
-export default createRelayHandler({
-  buildRelayPath: (_req, url) => {
+export default async function handler(req) {
+  const corsHeaders = getCorsHeaders(req, 'GET, OPTIONS');
+
+  if (isDisallowedOrigin(req)) {
+    return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+  }
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  if (req.method !== 'GET') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+  }
+
+  const relayBaseUrl = getRelayBaseUrl();
+  if (!relayBaseUrl) {
+    return new Response(JSON.stringify({ error: 'WS_RELAY_URL is not configured' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+  }
+
+  try {
+    const url = new URL(req.url);
     const limit = Math.max(1, Math.min(200, parseInt(url.searchParams.get('limit') || '50', 10) || 50));
     const topic = (url.searchParams.get('topic') || '').trim();
     const channel = (url.searchParams.get('channel') || '').trim();
     const params = new URLSearchParams();
     params.set('limit', String(limit));
-    if (topic) params.set('topic', topic);
-    if (channel) params.set('channel', channel);
-    return `/telegram/feed?${params}`;
-  },
-  forwardSearch: false,
-  timeout: 25000,
-  cacheHeaders: () => ({
-    'Cache-Control': 'public, max-age=60, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',
-  }),
-});
+    if (topic) params.set('topic', encodeURIComponent(topic));
+    if (channel) params.set('channel', encodeURIComponent(channel));
+
+    const relayUrl = `${relayBaseUrl}/telegram/feed?${params}`;
+    const response = await fetchWithTimeout(relayUrl, {
+      headers: getRelayHeaders({ Accept: 'application/json' }),
+    }, 15000);
+
+    const body = await response.text();
+
+    let cacheControl = 'public, max-age=30, s-maxage=120, stale-while-revalidate=60, stale-if-error=120';
+    try {
+      const parsed = JSON.parse(body);
+      if (!parsed || parsed.count === 0 || !parsed.items || parsed.items.length === 0) {
+        cacheControl = 'public, max-age=0, s-maxage=15, stale-while-revalidate=10';
+      }
+    } catch {}
+
+    return new Response(body, {
+      status: response.status,
+      headers: {
+        'Content-Type': response.headers.get('content-type') || 'application/json',
+        'Cache-Control': cacheControl,
+        ...corsHeaders,
+      },
+    });
+  } catch (error) {
+    const isTimeout = error?.name === 'AbortError';
+    return new Response(JSON.stringify({
+      error: isTimeout ? 'Relay timeout' : 'Relay request failed',
+      details: error?.message || String(error),
+    }), {
+      status: isTimeout ? 504 : 502,
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store', ...corsHeaders },
+    });
+  }
+}

--- a/src/components/ETFFlowsPanel.ts
+++ b/src/components/ETFFlowsPanel.ts
@@ -39,7 +39,7 @@ export class ETFFlowsPanel extends Panel {
 
   public async fetchData(): Promise<void> {
     const hydrated = getHydratedData('etfFlows') as ETFFlowsResult | undefined;
-    if (hydrated) {
+    if (hydrated?.etfs?.length) {
       this.data = hydrated;
       this.error = null;
       this.loading = false;

--- a/src/components/MacroSignalsPanel.ts
+++ b/src/components/MacroSignalsPanel.ts
@@ -132,7 +132,7 @@ export class MacroSignalsPanel extends Panel {
 
   public async fetchData(): Promise<boolean> {
     const hydrated = getHydratedData('macroSignals') as GetMacroSignalsResponse | undefined;
-    if (hydrated) {
+    if (hydrated?.signals && hydrated.totalCount > 0) {
       this.data = mapProtoToData(hydrated);
       this.lastTimestamp = this.data.timestamp;
       this.error = null;

--- a/src/services/climate/index.ts
+++ b/src/services/climate/index.ts
@@ -35,9 +35,9 @@ const emptyClimateFallback: ListClimateAnomaliesResponse = { anomalies: [] };
 
 export async function fetchClimateAnomalies(): Promise<ClimateFetchResult> {
   const hydrated = getHydratedData('climateAnomalies') as ListClimateAnomaliesResponse | undefined;
-  if (hydrated) {
-    const anomalies = (hydrated.anomalies ?? []).map(toDisplayAnomaly).filter(a => a.severity !== 'normal');
-    return { ok: true, anomalies };
+  if (hydrated && (hydrated.anomalies ?? []).length > 0) {
+    const anomalies = hydrated.anomalies.map(toDisplayAnomaly).filter(a => a.severity !== 'normal');
+    if (anomalies.length > 0) return { ok: true, anomalies };
   }
 
   const response = await breaker.execute(async () => {

--- a/src/services/earthquakes.ts
+++ b/src/services/earthquakes.ts
@@ -16,7 +16,7 @@ const emptyFallback: ListEarthquakesResponse = { earthquakes: [] };
 
 export async function fetchEarthquakes(): Promise<Earthquake[]> {
   const hydrated = getHydratedData('earthquakes') as ListEarthquakesResponse | undefined;
-  if (hydrated) return hydrated.earthquakes ?? [];
+  if (hydrated?.earthquakes?.length) return hydrated.earthquakes;
 
   const response = await breaker.execute(async () => {
     return client.listEarthquakes({ minMagnitude: 0, start: 0, end: 0, pageSize: 0, cursor: '' });

--- a/src/services/economic/index.ts
+++ b/src/services/economic/index.ts
@@ -584,9 +584,9 @@ export async function fetchBisData(): Promise<BisData> {
 
   try {
     const [policy, eer, credit] = await Promise.all([
-      hPolicy ? Promise.resolve(hPolicy) : bisPolicyBreaker.execute(() => client.getBisPolicyRates({}, { signal: AbortSignal.timeout(20_000) }), emptyBisPolicyFallback),
-      hEer ? Promise.resolve(hEer) : bisEerBreaker.execute(() => client.getBisExchangeRates({}, { signal: AbortSignal.timeout(20_000) }), emptyBisEerFallback),
-      hCredit ? Promise.resolve(hCredit) : bisCreditBreaker.execute(() => client.getBisCredit({}, { signal: AbortSignal.timeout(20_000) }), emptyBisCreditFallback),
+      hPolicy?.rates?.length ? Promise.resolve(hPolicy) : bisPolicyBreaker.execute(() => client.getBisPolicyRates({}, { signal: AbortSignal.timeout(20_000) }), emptyBisPolicyFallback),
+      hEer?.rates?.length ? Promise.resolve(hEer) : bisEerBreaker.execute(() => client.getBisExchangeRates({}, { signal: AbortSignal.timeout(20_000) }), emptyBisEerFallback),
+      hCredit?.entries?.length ? Promise.resolve(hCredit) : bisCreditBreaker.execute(() => client.getBisCredit({}, { signal: AbortSignal.timeout(20_000) }), emptyBisCreditFallback),
     ]);
     return {
       policyRates: policy.rates,

--- a/src/services/eonet.ts
+++ b/src/services/eonet.ts
@@ -59,7 +59,7 @@ function toNaturalEvent(e: ListNaturalEventsResponse['events'][number]): Natural
 
 export async function fetchNaturalEvents(_days = 30): Promise<NaturalEvent[]> {
   const hydrated = getHydratedData('naturalEvents') as ListNaturalEventsResponse | undefined;
-  const response = hydrated ?? await breaker.execute(async () => {
+  const response = (hydrated?.events?.length ? hydrated : null) ?? await breaker.execute(async () => {
     return client.listNaturalEvents({ days: 30 });
   }, emptyFallback);
 

--- a/src/services/giving/index.ts
+++ b/src/services/giving/index.ts
@@ -154,7 +154,7 @@ const REFETCH_INTERVAL_MS = 30 * 60 * 1000; // 30 min
 export async function fetchGivingSummary(): Promise<GivingFetchResult> {
   // Check bootstrap hydration first
   const hydrated = getHydratedData('giving') as ProtoResponse | undefined;
-  if (hydrated) {
+  if (hydrated?.summary?.platforms?.length) {
     const data = toDisplaySummary(hydrated);
     cachedData = data;
     cachedAt = Date.now();

--- a/src/services/infrastructure/index.ts
+++ b/src/services/infrastructure/index.ts
@@ -82,7 +82,7 @@ export async function fetchInternetOutages(): Promise<InternetOutage[]> {
   }
 
   const hydrated = getHydratedData('outages') as ListInternetOutagesResponse | undefined;
-  const resp = hydrated ?? await outageBreaker.execute(async () => {
+  const resp = (hydrated?.outages?.length ? hydrated : null) ?? await outageBreaker.execute(async () => {
     return client.listInternetOutages({
       country: '',
       start: 0,
@@ -162,10 +162,9 @@ function computeSummary(services: ServiceStatusResult[]): ServiceStatusSummary {
 }
 
 export async function fetchServiceStatuses(): Promise<ServiceStatusResponse> {
-  const hydrated = getHydratedData('serviceStatuses');
-  if (hydrated) {
-    const raw = hydrated as { statuses?: ProtoServiceStatus[] };
-    const services = (raw.statuses ?? []).map(toServiceResult);
+  const hydrated = getHydratedData('serviceStatuses') as { statuses?: ProtoServiceStatus[] } | undefined;
+  if (hydrated?.statuses?.length) {
+    const services = hydrated.statuses.map(toServiceResult);
     return { success: true, timestamp: new Date().toISOString(), summary: computeSummary(services), services };
   }
 

--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -35,7 +35,7 @@ const emptyMinerals: GetCriticalMineralsResponse = { minerals: [], fetchedAt: ''
 
 export async function fetchShippingRates(): Promise<GetShippingRatesResponse> {
   const hydrated = getHydratedData('shippingRates') as GetShippingRatesResponse | undefined;
-  if (hydrated) return hydrated;
+  if (hydrated?.indices?.length) return hydrated;
 
   try {
     return await shippingBreaker.execute(async () => {
@@ -48,7 +48,7 @@ export async function fetchShippingRates(): Promise<GetShippingRatesResponse> {
 
 export async function fetchChokepointStatus(): Promise<GetChokepointStatusResponse> {
   const hydrated = getHydratedData('chokepoints') as GetChokepointStatusResponse | undefined;
-  if (hydrated) return hydrated;
+  if (hydrated?.chokepoints?.length) return hydrated;
 
   try {
     return await chokepointBreaker.execute(async () => {
@@ -61,7 +61,7 @@ export async function fetchChokepointStatus(): Promise<GetChokepointStatusRespon
 
 export async function fetchCriticalMinerals(): Promise<GetCriticalMineralsResponse> {
   const hydrated = getHydratedData('minerals') as GetCriticalMineralsResponse | undefined;
-  if (hydrated) return hydrated;
+  if (hydrated?.minerals?.length) return hydrated;
 
   try {
     return await mineralsBreaker.execute(async () => {

--- a/src/services/wildfires/index.ts
+++ b/src/services/wildfires/index.ts
@@ -48,7 +48,7 @@ const emptyFallback: ListFireDetectionsResponse = { fireDetections: [] };
 
 export async function fetchAllFires(_days?: number): Promise<FetchResult> {
   const hydrated = getHydratedData('wildfires') as ListFireDetectionsResponse | undefined;
-  const response = hydrated ?? await breaker.execute(async () => {
+  const response = (hydrated?.fireDetections?.length ? hydrated : null) ?? await breaker.execute(async () => {
     return client.listFireDetections({ start: 0, end: 0, pageSize: 0, cursor: '', neLat: 0, neLon: 0, swLat: 0, swLon: 0 });
   }, emptyFallback);
   const detections = response.fireDetections;


### PR DESCRIPTION
## Summary
- Fixed 12 vulnerable `getHydratedData()` consumers that trusted empty CDN-cached bootstrap responses (e.g., `{anomalies:[]}`) as valid, skipping the RPC fallback and showing empty panels
- Rewrote `api/telegram-feed.js` to inspect response body — empty responses get short CDN TTL (15s vs 120s) to prevent prolonged staleness
- Added `encodeURIComponent` on telegram relay query params for defense-in-depth

## Root Cause
When CDN serves stale bootstrap data with empty arrays, `if (hydrated)` is truthy → code skips RPC fallback → panels render with zero items. Affected: climate, earthquakes, EONET, wildfires, giving, supply-chain (3 fns), infrastructure (2 fns), ETF flows, macro signals, economic (3 breakers).

## Files Changed (11)
- `api/telegram-feed.js` — custom handler with body-aware cache TTL
- `src/services/climate/index.ts` — check `anomalies.length`
- `src/services/earthquakes.ts` — check `earthquakes.length`
- `src/services/eonet.ts` — check `events.length`
- `src/services/wildfires/index.ts` — check `fireDetections.length`
- `src/services/giving/index.ts` — check `summary.platforms.length`
- `src/services/supply-chain/index.ts` — check 3 array fields
- `src/services/infrastructure/index.ts` — check `outages.length` + `statuses.length`
- `src/services/economic/index.ts` — check 3 BIS array fields
- `src/components/ETFFlowsPanel.ts` — check `etfs.length`
- `src/components/MacroSignalsPanel.ts` — check `signals && totalCount > 0`

## Test plan
- [x] `tsc --noEmit` passes clean
- [x] Edge function tests pass (57/57)
- [ ] Verify Climate Anomalies panel loads data after deploy
- [ ] Verify Telegram Intel panel loads data after deploy
- [ ] Verify other panels (ETF, Macro Signals, etc.) still load correctly