### PR TITLE
perf(globe): decouple flush channels + Eco mode workload reduction

### DIFF
--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -21,7 +21,7 @@ import { INTEL_HOTSPOTS, CONFLICT_ZONES, MILITARY_BASES, NUCLEAR_FACILITIES, SPA
 import { PIPELINES } from '@/config/pipelines';
 import { t } from '@/services/i18n';
 import { SITE_VARIANT } from '@/config/variant';
-import { getGlobeRenderScale, resolveGlobePixelRatio, subscribeGlobeRenderScaleChange, type GlobeRenderScale } from '@/services/globe-render-settings';
+import { getGlobeRenderScale, resolveGlobePixelRatio, resolvePerformanceProfile, subscribeGlobeRenderScaleChange, type GlobeRenderScale, type GlobePerformanceProfile } from '@/services/globe-render-settings';
 import { getLayersForVariant, resolveLayerLabel, type MapVariant } from '@/config/map-layer-definitions';
 import { resolveTradeRouteSegments, type TradeRouteSegment } from '@/config/trade-routes';
 import { GAMMA_IRRADIATORS } from '@/config/irradiators';
@@ -325,7 +325,10 @@ export class GlobeMap {
 
   private initialized = false;
   private destroyed = false;
-  private flushTimer: ReturnType<typeof requestAnimationFrame> | null = null;
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private flushMaxTimer: ReturnType<typeof setTimeout> | null = null;
+  private _pulseEnabled = true;
+  private reversedRingCache = new Map<string, number[][][]>();
 
   // Current data
   private hotspots: HotspotMarker[] = [];
@@ -377,9 +380,6 @@ export class GlobeMap {
   // Auto-rotate timer (like Sentinel: resume after 60 s idle)
   private autoRotateTimer: ReturnType<typeof setTimeout> | null = null;
 
-  // ResizeObserver keeps the canvas in sync with the container
-  private resizeObserver: ResizeObserver | null = null;
-
   // Overlay UI elements
   private layerTogglesEl: HTMLElement | null = null;
   private tooltipEl: HTMLElement | null = null;
@@ -427,24 +427,11 @@ export class GlobeMap {
       return;
     }
 
-    const applyRenderQuality = (scale?: GlobeRenderScale, width?: number, height?: number) => {
-      try {
-        const pr = desktop
-          ? Math.min(resolveGlobePixelRatio(scale ?? getGlobeRenderScale()), 1.25)
-          : resolveGlobePixelRatio(scale ?? getGlobeRenderScale());
-        const renderer = globe.renderer();
-        renderer.setPixelRatio(pr);
-        const w = (width ?? this.container.clientWidth) || window.innerWidth;
-        const h = (height ?? this.container.clientHeight) || window.innerHeight;
-        if (w > 0 && h > 0) globe.width(w).height(h);
-      } catch {
-        // best-effort
-      }
-    };
-
-    applyRenderQuality(initialScale);
     this.unsubscribeGlobeQuality?.();
-    this.unsubscribeGlobeQuality = subscribeGlobeRenderScaleChange((scale) => applyRenderQuality(scale));
+    this.unsubscribeGlobeQuality = subscribeGlobeRenderScaleChange((scale) => {
+      this.applyRenderQuality(scale);
+      this.applyPerformanceProfile(resolvePerformanceProfile(scale));
+    });
 
     // Initial sizing: use container dimensions, fall back to window if not yet laid out
     const initW = this.container.clientWidth || window.innerWidth;
@@ -479,16 +466,6 @@ export class GlobeMap {
       (glCanvas as HTMLElement).style.cssText =
         'position:absolute;top:0;left:0;width:100% !important;height:100% !important;';
     }
-
-    // ResizeObserver: whenever the container grows or shrinks (fullscreen toggle,
-    // drag-resize, window resize), update the globe.gl renderer dimensions.
-    this.resizeObserver = new ResizeObserver(() => {
-      if (!this.globe || this.destroyed) return;
-      const w = this.container.clientWidth;
-      const h = this.container.clientHeight;
-      applyRenderQuality(undefined, w, h);
-    });
-    this.resizeObserver.observe(this.container);
 
     // Load specular/water map for ocean shimmer
     setTimeout(async () => {
@@ -545,8 +522,88 @@ export class GlobeMap {
       })
       .htmlElement((d: object) => this.buildMarkerElement(d as GlobeMarker));
 
+    // Arc accessors — set once, only data changes on flush
+
+    (globe as any)
+      .arcStartLat((d: TradeRouteSegment) => d.sourcePosition[1])
+      .arcStartLng((d: TradeRouteSegment) => d.sourcePosition[0])
+      .arcEndLat((d: TradeRouteSegment) => d.targetPosition[1])
+      .arcEndLng((d: TradeRouteSegment) => d.targetPosition[0])
+      .arcColor((d: TradeRouteSegment) => {
+        if (d.status === 'disrupted') return ['rgba(255,32,32,0.1)', 'rgba(255,32,32,0.8)', 'rgba(255,32,32,0.1)'];
+        if (d.status === 'high_risk') return ['rgba(255,180,0,0.1)', 'rgba(255,180,0,0.7)', 'rgba(255,180,0,0.1)'];
+        if (d.category === 'energy')    return ['rgba(255,140,0,0.05)', 'rgba(255,140,0,0.6)', 'rgba(255,140,0,0.05)'];
+        if (d.category === 'container') return ['rgba(68,136,255,0.05)', 'rgba(68,136,255,0.6)', 'rgba(68,136,255,0.05)'];
+        return ['rgba(68,204,136,0.05)', 'rgba(68,204,136,0.6)', 'rgba(68,204,136,0.05)'];
+      })
+      .arcAltitudeAutoScale(0.3)
+      .arcStroke(0.5)
+      .arcDashLength(0.9)
+      .arcDashGap(4)
+      .arcDashAnimateTime(5000)
+      .arcLabel((d: TradeRouteSegment) => `${d.routeName} · ${d.volumeDesc}`);
+
+    // Path accessors — set once
+    (globe as any)
+      .pathPoints((d: GlobePath) => d.points)
+      .pathPointLat((p: [number, number]) => p[1])
+      .pathPointLng((p: [number, number]) => p[0])
+      .pathColor((d: GlobePath) => {
+        if (d.pathType === 'cable') {
+          if (this.cableFaultIds.has(d.id))    return '#ff3030';
+          if (this.cableDegradedIds.has(d.id)) return '#ff8800';
+          return 'rgba(0,200,255,0.65)';
+        }
+        if (d.pathType === 'oil')   return 'rgba(255,140,0,0.6)';
+        if (d.pathType === 'gas')   return 'rgba(80,220,120,0.6)';
+        return 'rgba(180,160,255,0.6)';
+      })
+      .pathStroke((d: GlobePath) => d.pathType === 'cable' ? 0.3 : 0.6)
+      .pathDashLength((d: GlobePath) => d.pathType === 'cable' ? 1 : 0.6)
+      .pathDashGap((d: GlobePath) => d.pathType === 'cable' ? 0 : 0.25)
+      .pathDashAnimateTime((d: GlobePath) => d.pathType === 'cable' ? 0 : 5000)
+      .pathLabel((d: GlobePath) => d.name);
+
+    // Polygon accessors — set once
+    (globe as any)
+      .polygonGeoJsonGeometry((d: GlobePolygon) => ({ type: 'Polygon', coordinates: d.coords }))
+      .polygonCapColor((d: GlobePolygon) => {
+        if (d._kind === 'cii') return GlobeMap.CII_GLOBE_COLORS[d.level!] ?? 'rgba(0,0,0,0)';
+        if (d._kind === 'conflict') return GlobeMap.CONFLICT_CAP[d.intensity!] ?? GlobeMap.CONFLICT_CAP.low;
+        return 'rgba(255,60,60,0.15)';
+      })
+      .polygonSideColor((d: GlobePolygon) => {
+        if (d._kind === 'cii') return 'rgba(0,0,0,0)';
+        if (d._kind === 'conflict') return GlobeMap.CONFLICT_SIDE[d.intensity!] ?? GlobeMap.CONFLICT_SIDE.low;
+        return 'rgba(255,60,60,0.08)';
+      })
+      .polygonStrokeColor((d: GlobePolygon) => {
+        if (d._kind === 'cii') return 'rgba(80,80,80,0.3)';
+        if (d._kind === 'conflict') return GlobeMap.CONFLICT_STROKE[d.intensity!] ?? GlobeMap.CONFLICT_STROKE.low;
+        return '#ff4444';
+      })
+      .polygonAltitude((d: GlobePolygon) => {
+        if (d._kind === 'cii') return 0.002;
+        if (d._kind === 'conflict') return GlobeMap.CONFLICT_ALT[d.intensity!] ?? GlobeMap.CONFLICT_ALT.low;
+        return 0.005;
+      })
+      .polygonLabel((d: GlobePolygon) => {
+        if (d._kind === 'cii') return `<b>${escapeHtml(d.name)}</b><br/>CII: ${d.score}/100 (${escapeHtml(d.level ?? '')})`;
+        if (d._kind === 'conflict') {
+          let label = `<b>${escapeHtml(d.name)}</b>`;
+          if (d.parties?.length) label += `<br/>Parties: ${d.parties.map(p => escapeHtml(p)).join(', ')}`;
+          if (d.casualties) label += `<br/>Casualties: ${escapeHtml(d.casualties)}`;
+          return label;
+        }
+        return escapeHtml(d.name);
+      });
+
     this.globe = globe;
     this.initialized = true;
+
+    // Apply initial render quality + performance profile
+    this.applyRenderQuality(initialScale);
+    this.applyPerformanceProfile(resolvePerformanceProfile(initialScale));
 
     // Add overlay UI (zoom controls + layer panel)
     this.createControls();
@@ -564,18 +621,25 @@ export class GlobeMap {
 
     // Flush any data that arrived before init completed
     this.flushMarkers();
+    this.flushArcs();
+    this.flushPaths();
     this.flushPolygons();
 
     // Load countries GeoJSON for CII choropleth
     getCountriesGeoJson().then(geojson => {
       if (geojson && !this.destroyed) {
         this.countriesGeoData = geojson;
+        this.reversedRingCache.clear();
         this.flushPolygons();
       }
     }).catch(err => { if (import.meta.env.DEV) console.warn('[GlobeMap] Failed to load countries GeoJSON', err); });
   }
 
   // ─── Marker element builder ────────────────────────────────────────────────
+
+  private pulseStyle(duration: string): string {
+    return this._pulseEnabled ? `animation:globe-pulse ${duration} ease-out infinite;` : 'animation:none;';
+  }
 
   private buildMarkerElement(d: GlobeMarker): HTMLElement {
     const el = document.createElement('div');
@@ -594,7 +658,7 @@ export class GlobeMap {
           <div style="
             position:absolute;inset:-4px;border-radius:50%;
             background:rgba(255,50,50,0.2);
-            animation:globe-pulse 2s ease-out infinite;
+            ${this.pulseStyle('2s')}
           "></div>
         </div>`;
       el.title = `${d.location}`;
@@ -651,7 +715,7 @@ export class GlobeMap {
       el.innerHTML = `
         <div style="position:relative;width:9px;height:9px;">
           <div style="position:absolute;inset:0;border-radius:50%;background:${sc};border:1.5px solid rgba(255,255,255,0.5);box-shadow:0 0 5px 2px ${sc}88;"></div>
-          <div style="position:absolute;inset:-4px;border-radius:50%;background:${sc}33;animation:globe-pulse 2s ease-out infinite;"></div>
+          <div style="position:absolute;inset:-4px;border-radius:50%;background:${sc}33;${this.pulseStyle('2s')}"></div>
         </div>`;
       el.title = d.title;
     } else if (d._kind === 'outage') {
@@ -775,7 +839,7 @@ export class GlobeMap {
       el.innerHTML = `
         <div style="position:relative;width:16px;height:16px;">
           <div style="position:absolute;inset:0;border-radius:50%;background:${tc}44;border:1.5px solid ${tc};box-shadow:0 0 5px 2px ${tc}55;"></div>
-          <div style="position:absolute;inset:-5px;border-radius:50%;background:${tc}22;animation:globe-pulse 1.8s ease-out infinite;"></div>
+          <div style="position:absolute;inset:-5px;border-radius:50%;background:${tc}22;${this.pulseStyle('1.8s')}"></div>
         </div>`;
       el.title = d.title;
     } else if (d._kind === 'aisDisruption') {
@@ -789,7 +853,7 @@ export class GlobeMap {
           <div style="position:absolute;width:44px;height:44px;border-radius:50%;
             border:2px solid rgba(255,255,255,0.9);background:rgba(255,255,255,0.2);
             left:-22px;top:-22px;
-            animation:globe-pulse 0.7s ease-out infinite;"></div>
+            ${this.pulseStyle('0.7s')}"></div>
         </div>`;
     }
 
@@ -1062,7 +1126,7 @@ export class GlobeMap {
         if (layer) {
           const checked = (input as HTMLInputElement).checked;
           this.layers[layer] = checked;
-          this.flushMarkers();
+          this.flushLayerChannels(layer);
           this.onLayerChangeCb?.(layer, checked, 'user');
         }
       });
@@ -1091,15 +1155,21 @@ export class GlobeMap {
 
   private flushMarkers(): void {
     if (!this.globe || !this.initialized || this.destroyed) return;
-    if (this.renderPaused) {
-      this.pendingFlushWhilePaused = true;
-      return;
+    if (this.renderPaused) { this.pendingFlushWhilePaused = true; return; }
+
+    if (!this.flushMaxTimer) {
+      this.flushMaxTimer = setTimeout(() => {
+        this.flushMaxTimer = null;
+        if (this.flushTimer) { clearTimeout(this.flushTimer); this.flushTimer = null; }
+        this.flushMarkersImmediate();
+      }, 300);
     }
-    if (this.flushTimer) return;
-    this.flushTimer = requestAnimationFrame(() => {
+    if (this.flushTimer) clearTimeout(this.flushTimer);
+    this.flushTimer = setTimeout(() => {
       this.flushTimer = null;
+      if (this.flushMaxTimer) { clearTimeout(this.flushMaxTimer); this.flushMaxTimer = null; }
       this.flushMarkersImmediate();
-    });
+    }, 100);
   }
 
   private flushMarkersImmediate(): void {
@@ -1146,61 +1216,23 @@ export class GlobeMap {
 
     try {
       this.globe.htmlElementsData(markers);
-      this.flushArcs();
-      this.flushPaths();
-      this.flushPolygons();
     } catch (err) { if (import.meta.env.DEV) console.warn('[GlobeMap] flush error', err); }
   }
 
   private flushArcs(): void {
     if (!this.globe || !this.initialized || this.destroyed) return;
     const segments = this.layers.tradeRoutes ? this.tradeRouteSegments : [];
-    (this.globe as any)
-      .arcsData(segments)
-      .arcStartLat((d: TradeRouteSegment) => d.sourcePosition[1])
-      .arcStartLng((d: TradeRouteSegment) => d.sourcePosition[0])
-      .arcEndLat((d: TradeRouteSegment) => d.targetPosition[1])
-      .arcEndLng((d: TradeRouteSegment) => d.targetPosition[0])
-      .arcColor((d: TradeRouteSegment) => {
-        if (d.status === 'disrupted') return ['rgba(255,32,32,0.1)', 'rgba(255,32,32,0.8)', 'rgba(255,32,32,0.1)'];
-        if (d.status === 'high_risk') return ['rgba(255,180,0,0.1)', 'rgba(255,180,0,0.7)', 'rgba(255,180,0,0.1)'];
-        if (d.category === 'energy')    return ['rgba(255,140,0,0.05)', 'rgba(255,140,0,0.6)', 'rgba(255,140,0,0.05)'];
-        if (d.category === 'container') return ['rgba(68,136,255,0.05)', 'rgba(68,136,255,0.6)', 'rgba(68,136,255,0.05)'];
-        return ['rgba(68,204,136,0.05)', 'rgba(68,204,136,0.6)', 'rgba(68,204,136,0.05)'];
-      })
-      .arcAltitudeAutoScale(0.3)
-      .arcStroke(0.5)
-      .arcDashLength(0.9)
-      .arcDashGap(4)
-      .arcDashAnimateTime(5000)
-      .arcLabel((d: TradeRouteSegment) => `${d.routeName} · ${d.volumeDesc}`);
+    (this.globe as any).arcsData(segments);
   }
 
   private flushPaths(): void {
     if (!this.globe || !this.initialized || this.destroyed) return;
-    const paths: GlobePath[] = [];
-    if (this.layers.cables)    paths.push(...this.globePaths.filter(p => p.pathType === 'cable'));
-    if (this.layers.pipelines) paths.push(...this.globePaths.filter(p => p.pathType !== 'cable'));
-    (this.globe as any)
-      .pathsData(paths)
-      .pathPoints((d: GlobePath) => d.points)
-      .pathPointLat((p: [number, number]) => p[1])
-      .pathPointLng((p: [number, number]) => p[0])
-      .pathColor((d: GlobePath) => {
-        if (d.pathType === 'cable') {
-          if (this.cableFaultIds.has(d.id))    return '#ff3030';
-          if (this.cableDegradedIds.has(d.id)) return '#ff8800';
-          return 'rgba(0,200,255,0.65)';
-        }
-        if (d.pathType === 'oil')   return 'rgba(255,140,0,0.6)';
-        if (d.pathType === 'gas')   return 'rgba(80,220,120,0.6)';
-        return 'rgba(180,160,255,0.6)';
-      })
-      .pathStroke((d: GlobePath) => d.pathType === 'cable' ? 0.3 : 0.6)
-      .pathDashLength((d: GlobePath) => d.pathType === 'cable' ? 1 : 0.6)
-      .pathDashGap((d: GlobePath) => d.pathType === 'cable' ? 0 : 0.25)
-      .pathDashAnimateTime((d: GlobePath) => d.pathType === 'cable' ? 0 : 5000)
-      .pathLabel((d: GlobePath) => d.name);
+    const showCables = this.layers.cables;
+    const showPipelines = this.layers.pipelines;
+    const paths = (showCables && showPipelines)
+      ? this.globePaths
+      : this.globePaths.filter(p => p.pathType === 'cable' ? showCables : showPipelines);
+    (this.globe as any).pathsData(paths);
   }
 
   private static readonly CII_GLOBE_COLORS: Record<string, string> = {
@@ -1210,24 +1242,28 @@ export class GlobeMap {
     high:     'rgba(220, 50, 20, 0.45)',
     critical: 'rgba(140, 10, 0, 0.50)',
   };
+  private static readonly CONFLICT_CAP: Record<string, string> = { high: 'rgba(255,40,40,0.25)', medium: 'rgba(255,120,0,0.20)', low: 'rgba(255,200,0,0.15)' };
+  private static readonly CONFLICT_SIDE: Record<string, string> = { high: 'rgba(255,40,40,0.12)', medium: 'rgba(255,120,0,0.08)', low: 'rgba(255,200,0,0.06)' };
+  private static readonly CONFLICT_STROKE: Record<string, string> = { high: '#ff3030', medium: '#ff8800', low: '#ffcc00' };
+  private static readonly CONFLICT_ALT: Record<string, number> = { high: 0.006, medium: 0.004, low: 0.003 };
 
+  private getReversedRing(zoneId: string, countryIso: string, ringIdx: number, ring: number[][][]): number[][][] {
+    const key = `${zoneId}:${countryIso}:${ringIdx}`;
+    let cached = this.reversedRingCache.get(key);
+    if (!cached) {
+      cached = ring.map((r: number[][]) => [...r].reverse());
+      this.reversedRingCache.set(key, cached);
+    }
+    return cached;
+  }
 
   private flushPolygons(): void {
     if (!this.globe || !this.initialized || this.destroyed) return;
     const polys: GlobePolygon[] = [];
 
-
-
     if (this.layers.conflicts) {
-      // Map conflict zone IDs to ISO-2 country codes for real GeoJSON geometry lookup.
-      // Using actual country geometries from countriesGeoData ensures correct rendering
-      // (same approach as CII choropleth which renders correctly).
       const CONFLICT_ISO: Record<string, string[]> = {
-        iran: ['IR'],
-        ukraine: ['UA'],
-        gaza: ['PS', 'IL'],
-        sudan: ['SD'],
-        myanmar: ['MM'],
+        iran: ['IR'], ukraine: ['UA'], gaza: ['PS', 'IL'], sudan: ['SD'], myanmar: ['MM'],
       };
       for (const z of CONFLICT_ZONES) {
         const isoCodes = CONFLICT_ISO[z.id];
@@ -1238,10 +1274,9 @@ export class GlobeMap {
             const geom = feat.geometry;
             if (!geom) continue;
             const rings = geom.type === 'Polygon' ? [geom.coordinates] : geom.type === 'MultiPolygon' ? geom.coordinates : [];
-            for (const ring of rings) {
-              const reversed = ring.map((r: number[][]) => [...r].reverse());
+            for (let ri = 0; ri < rings.length; ri++) {
               polys.push({
-                coords: reversed,
+                coords: this.getReversedRing(z.id, code, ri, rings[ri] as number[][][]),
                 name: z.name,
                 _kind: 'conflict',
                 intensity: z.intensity ?? 'low',
@@ -1250,10 +1285,6 @@ export class GlobeMap {
               });
             }
           }
-        } else {
-          // Zones without country mapping (Strait of Hormuz, South Lebanon, etc.)
-          // are represented by center markers only — custom simplified polygons
-          // don't render correctly on globe.gl's spherical tessellation.
         }
       }
     }
@@ -1273,44 +1304,7 @@ export class GlobeMap {
       }
     }
 
-    const colors = GlobeMap.CII_GLOBE_COLORS;
-    const conflictCap: Record<string, string> = { high: 'rgba(255,40,40,0.25)', medium: 'rgba(255,120,0,0.20)', low: 'rgba(255,200,0,0.15)' };
-    const conflictSide: Record<string, string> = { high: 'rgba(255,40,40,0.12)', medium: 'rgba(255,120,0,0.08)', low: 'rgba(255,200,0,0.06)' };
-    const conflictStroke: Record<string, string> = { high: '#ff3030', medium: '#ff8800', low: '#ffcc00' };
-    const conflictAlt: Record<string, number> = { high: 0.006, medium: 0.004, low: 0.003 };
-    (this.globe as any)
-      .polygonsData(polys)
-      .polygonGeoJsonGeometry((d: GlobePolygon) => ({ type: 'Polygon', coordinates: d.coords }))
-      .polygonCapColor((d: GlobePolygon) => {
-        if (d._kind === 'cii') return colors[d.level!] ?? 'rgba(0,0,0,0)';
-        if (d._kind === 'conflict') return conflictCap[d.intensity!] ?? conflictCap.low;
-        return 'rgba(255,60,60,0.15)';
-      })
-      .polygonSideColor((d: GlobePolygon) => {
-        if (d._kind === 'cii') return 'rgba(0,0,0,0)';
-        if (d._kind === 'conflict') return conflictSide[d.intensity!] ?? conflictSide.low;
-        return 'rgba(255,60,60,0.08)';
-      })
-      .polygonStrokeColor((d: GlobePolygon) => {
-        if (d._kind === 'cii') return 'rgba(80,80,80,0.3)';
-        if (d._kind === 'conflict') return conflictStroke[d.intensity!] ?? conflictStroke.low;
-        return '#ff4444';
-      })
-      .polygonAltitude((d: GlobePolygon) => {
-        if (d._kind === 'cii') return 0.002;
-        if (d._kind === 'conflict') return conflictAlt[d.intensity!] ?? conflictAlt.low;
-        return 0.005;
-      })
-      .polygonLabel((d: GlobePolygon) => {
-        if (d._kind === 'cii') return `<b>${escapeHtml(d.name)}</b><br/>CII: ${d.score}/100 (${escapeHtml(d.level ?? '')})`;
-        if (d._kind === 'conflict') {
-          let label = `<b>${escapeHtml(d.name)}</b>`;
-          if (d.parties?.length) label += `<br/>Parties: ${d.parties.map(p => escapeHtml(p)).join(', ')}`;
-          if (d.casualties) label += `<br/>Casualties: ${escapeHtml(d.casualties)}`;
-          return label;
-        }
-        return escapeHtml(d.name);
-      });
+    (this.globe as any).polygonsData(polys);
   }
 
   // ─── Public data setters ──────────────────────────────────────────────────
@@ -1501,18 +1495,46 @@ export class GlobeMap {
 
   // ─── Layer control ────────────────────────────────────────────────────────
 
+  private static readonly LAYER_CHANNELS: Map<string, { markers: boolean; arcs: boolean; paths: boolean; polygons: boolean }> = new Map([
+    ['ciiChoropleth', { markers: false, arcs: false, paths: false, polygons: true }],
+    ['tradeRoutes',   { markers: false, arcs: true,  paths: false, polygons: false }],
+    ['pipelines',     { markers: false, arcs: false, paths: true,  polygons: false }],
+    ['conflicts',     { markers: true,  arcs: false, paths: false, polygons: true }],
+    ['cables',        { markers: true,  arcs: false, paths: true,  polygons: false }],
+  ]);
+
+  private flushLayerChannels(layer: keyof MapLayers): void {
+    const ch = GlobeMap.LAYER_CHANNELS.get(layer);
+    if (!ch) { this.flushMarkers(); return; }
+    if (ch.markers)  this.flushMarkers();
+    if (ch.arcs)     this.flushArcs();
+    if (ch.paths)    this.flushPaths();
+    if (ch.polygons) this.flushPolygons();
+  }
+
   public setLayers(layers: MapLayers): void {
-    // dayNight toggle excluded by catalog — harmless if true in memory
+    const prev = this.layers;
     this.layers = { ...layers };
-    this.flushMarkers();
-    this.flushPolygons();
+    let needMarkers = false, needArcs = false, needPaths = false, needPolygons = false;
+    for (const k of Object.keys(layers) as (keyof MapLayers)[]) {
+      if (prev[k] === layers[k]) continue;
+      const ch = GlobeMap.LAYER_CHANNELS.get(k);
+      if (!ch) { needMarkers = true; continue; }
+      if (ch.markers)  needMarkers = true;
+      if (ch.arcs)     needArcs = true;
+      if (ch.paths)    needPaths = true;
+      if (ch.polygons) needPolygons = true;
+    }
+    if (needMarkers)  this.flushMarkers();
+    if (needArcs)     this.flushArcs();
+    if (needPaths)    this.flushPaths();
+    if (needPolygons) this.flushPolygons();
   }
 
   public enableLayer(layer: keyof MapLayers): void {
-    // dayNight toggle excluded by catalog — no guard needed
+    if (this.layers[layer]) return;
     (this.layers as any)[layer] = true;
-    this.flushMarkers();
-    this.flushPolygons();
+    this.flushLayerChannels(layer);
   }
 
   // ─── Camera / navigation ──────────────────────────────────────────────────
@@ -1562,9 +1584,7 @@ export class GlobeMap {
 
   public resize(): void {
     if (!this.globe || this.destroyed) return;
-    const w = this.container.clientWidth;
-    const h = this.container.clientHeight;
-    if (w > 0 && h > 0) this.globe.width(w).height(h);
+    this.applyRenderQuality(undefined, this.container.clientWidth, this.container.clientHeight);
   }
 
   // ─── State API ────────────────────────────────────────────────────────────
@@ -1609,10 +1629,8 @@ export class GlobeMap {
     this.renderPaused = paused;
 
     if (paused) {
-      if (this.flushTimer) {
-        cancelAnimationFrame(this.flushTimer);
-        this.flushTimer = null;
-      }
+      if (this.flushTimer) { clearTimeout(this.flushTimer); this.flushTimer = null; }
+      if (this.flushMaxTimer) { clearTimeout(this.flushMaxTimer); this.flushMaxTimer = null; }
       this.pendingFlushWhilePaused = true;
       if (this.autoRotateTimer) {
         clearTimeout(this.autoRotateTimer);
@@ -1766,6 +1784,7 @@ export class GlobeMap {
     this.cableFaultIds    = new Set((advisories ?? []).filter(a => a.severity === 'fault').map(a => a.cableId));
     this.cableDegradedIds = new Set((advisories ?? []).filter(a => a.severity === 'degraded').map(a => a.cableId));
     this.flushMarkers();
+    this.flushPaths();
   }
   public setCableHealth(_m: any): void {}
   public setProtests(events: SocialUnrestEvent[]): void {
@@ -1922,16 +1941,58 @@ export class GlobeMap {
   public setOnCountry(_cb: any): void {}
   public getHotspotLevel(_id: string) { return 'low'; }
 
+  // ─── Render quality & performance profile ────────────────────────────────
+
+  private applyRenderQuality(scale?: GlobeRenderScale, width?: number, height?: number): void {
+    if (!this.globe) return;
+    try {
+      const desktop = isDesktopRuntime();
+      const pr = desktop
+        ? Math.min(resolveGlobePixelRatio(scale ?? getGlobeRenderScale()), 1.25)
+        : resolveGlobePixelRatio(scale ?? getGlobeRenderScale());
+      const renderer = this.globe.renderer();
+      renderer.setPixelRatio(pr);
+      const w = (width ?? this.container.clientWidth) || window.innerWidth;
+      const h = (height ?? this.container.clientHeight) || window.innerHeight;
+      if (w > 0 && h > 0) this.globe.width(w).height(h);
+    } catch { /* best-effort */ }
+  }
+
+  private applyPerformanceProfile(profile: GlobePerformanceProfile): void {
+    if (!this.globe || !this.initialized || this.destroyed) return;
+
+    const prevPulse = this._pulseEnabled;
+    this._pulseEnabled = !profile.disablePulseAnimations;
+
+    if (profile.disableDashAnimations) {
+      (this.globe as any).arcDashAnimateTime(0);
+      (this.globe as any).pathDashAnimateTime(0);
+    } else {
+      (this.globe as any).arcDashAnimateTime(5000);
+      (this.globe as any).pathDashAnimateTime((d: GlobePath) => d.pathType === 'cable' ? 0 : 5000);
+    }
+
+    if (profile.disableAtmosphere) {
+      this.globe.atmosphereAltitude(0);
+    } else {
+      this.globe.atmosphereAltitude(0.18);
+    }
+
+    if (prevPulse !== this._pulseEnabled) {
+      this.flushMarkers();
+    }
+  }
+
   // ─── Destroy ──────────────────────────────────────────────────────────────
 
   public destroy(): void {
     this.unsubscribeGlobeQuality?.();
     this.unsubscribeGlobeQuality = null;
     this.destroyed = true;
-    if (this.flushTimer) { cancelAnimationFrame(this.flushTimer); this.flushTimer = null; }
+    if (this.flushTimer) { clearTimeout(this.flushTimer); this.flushTimer = null; }
+    if (this.flushMaxTimer) { clearTimeout(this.flushMaxTimer); this.flushMaxTimer = null; }
     if (this.autoRotateTimer) clearTimeout(this.autoRotateTimer);
-    this.resizeObserver?.disconnect();
-    this.resizeObserver = null;
+    this.reversedRingCache.clear();
     this.hideTooltip();
     this.controls = null;
     this.controlsAutoRotateBeforePause = null;

--- a/src/services/globe-render-settings.ts
+++ b/src/services/globe-render-settings.ts
@@ -50,3 +50,18 @@ export function resolveGlobePixelRatio(scale: GlobeRenderScale): number {
   if (!Number.isFinite(num) || num <= 0) return 1;
   return Math.min(3, Math.max(1, num));
 }
+
+export interface GlobePerformanceProfile {
+  disablePulseAnimations: boolean;
+  disableDashAnimations: boolean;
+  disableAtmosphere: boolean;
+}
+
+export function resolvePerformanceProfile(scale: GlobeRenderScale): GlobePerformanceProfile {
+  const isEco = scale === '1';
+  return {
+    disablePulseAnimations: isEco,
+    disableDashAnimations: isEco,
+    disableAtmosphere: isEco,
+  };
+}


### PR DESCRIPTION
## Summary
- **Decouple flush channels**: marker updates no longer rebuild arcs/paths/polygons (and vice versa). Each data setter routes to only the flush channel(s) it affects via a static `LAYER_CHANNELS` map.
- **Set accessors once**: arc, path, and polygon accessor functions are registered once at `initGlobe()`. Flush methods now only call `.arcsData()` / `.pathsData()` / `.polygonsData()` with new data arrays.
- **Hybrid debounce**: 100ms trailing + 300ms maxWait coalesces the ~15 parallel data setters that fire during startup while guaranteeing flush within 300ms.
- **Eco mode actually reduces work**: disables dash animations (`arcDashAnimateTime(0)` stops globe.gl's continuous RAF render loop), pulse CSS animations, and atmosphere shader. Previously Eco only changed pixel ratio.
- **Cache reversed GeoJSON rings**: conflict zone polygon ring reversals are cached (keyed by zone+country+ringIdx) instead of recomputed every `flushPolygons()` call.
- **Remove duplicate ResizeObserver**: MapContainer's observer already handles resize; GlobeMap's redundant observer removed.
- **Static color maps**: conflict color lookups moved to `static readonly` class properties (no per-call allocation).

## Test plan
- [ ] Open globe with 5-6 layers in Eco mode → CPU should drop significantly vs previous
- [ ] Toggle layers on/off → markers/arcs/paths/polygons appear/disappear correctly
- [ ] `setCableActivity()` with faults → cable paths turn red
- [ ] Switch render scale Eco↔Auto while globe active → animations enable/disable immediately
- [ ] Fresh app load → all markers appear within 300ms
- [ ] Click markers → tooltips still work
- [ ] Auto-rotate on web mode still works
- [ ] `tsc --noEmit` passes ✅