### PR TITLE
feat(telegram): add 8 new intel channels

### DIFF
--- a/data/telegram-channels.json
+++ b/data/telegram-channels.json
@@ -237,6 +237,78 @@
         "enabled": true,
         "region": "ukraine",
         "maxMessages": 20
+      },
+      {
+        "handle": "nayaforiraq",
+        "label": "Naya for Iraq",
+        "topic": "politics",
+        "tier": 3,
+        "enabled": true,
+        "region": "middleeast",
+        "maxMessages": 20
+      },
+      {
+        "handle": "yediotnews25",
+        "label": "Yedioth News",
+        "topic": "breaking",
+        "tier": 3,
+        "enabled": true,
+        "region": "middleeast",
+        "maxMessages": 20
+      },
+      {
+        "handle": "DDGeopolitics",
+        "label": "DD Geopolitics",
+        "topic": "geopolitics",
+        "tier": 3,
+        "enabled": true,
+        "region": "global",
+        "maxMessages": 20
+      },
+      {
+        "handle": "FotrosResistancee",
+        "label": "Fotros Resistance",
+        "topic": "conflict",
+        "tier": 3,
+        "enabled": true,
+        "region": "iran",
+        "maxMessages": 20
+      },
+      {
+        "handle": "RezistanceTrench1",
+        "label": "Resistance Trench",
+        "topic": "conflict",
+        "tier": 3,
+        "enabled": true,
+        "region": "middleeast",
+        "maxMessages": 20
+      },
+      {
+        "handle": "geopolitics_prime",
+        "label": "Geopolitics Prime",
+        "topic": "geopolitics",
+        "tier": 3,
+        "enabled": true,
+        "region": "global",
+        "maxMessages": 20
+      },
+      {
+        "handle": "thecradlemedia",
+        "label": "The Cradle",
+        "topic": "middleeast",
+        "tier": 3,
+        "enabled": true,
+        "region": "middleeast",
+        "maxMessages": 20
+      },
+      {
+        "handle": "LebUpdate",
+        "label": "Lebanon Update",
+        "topic": "breaking",
+        "tier": 3,
+        "enabled": true,
+        "region": "middleeast",
+        "maxMessages": 20
       }
     ],
     "tech": [],


### PR DESCRIPTION
## Summary
- Add 8 new Telegram channels to `data/telegram-channels.json` for intel monitoring
- New channels: nayaforiraq, yediotnews25, DDGeopolitics, FotrosResistancee, RezistanceTrench1, geopolitics_prime, thecradlemedia, LebUpdate
- Middle_East_Spectator was already present (skipped)

## Test plan
- [ ] Relay script loads updated channel list without errors
- [ ] New channels appear in Telegram Intel panel
- [ ] Messages from new channels are fetched and displayed