### PR TITLE
fix: settings modal renders behind 3D globe

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3220,7 +3220,7 @@ body.live-news-fullscreen-active .panels-grid > *:not(.live-news-fullscreen) {
   display: none;
   justify-content: center;
   align-items: center;
-  z-index: 1000;
+  z-index: 9999;
 }
 
 .signal-modal-overlay.active {
@@ -5704,7 +5704,7 @@ a.prediction-link:hover {
   display: none;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: 9999;
 }
 
 .modal-overlay.active {


### PR DESCRIPTION
## Summary
- Raised `.modal-overlay` and `.signal-modal-overlay` z-index from 1000 to 9999
- The globe's WebGL canvas container (`position: relative`) creates a stacking context that rendered above modals at z-index 1000
- Aligns with other fullscreen overlays (`.live-channels-modal-overlay` already at 9999)

## Test plan
- [ ] Enable 3D Globe View, open Settings — modal should fully cover the globe
- [ ] Open signal modal in globe mode — should also render above globe
- [ ] Verify flat map mode settings still works as before