### PR TITLE
fix: replace hardcoded FIRMS error with localized no-data message

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2116,7 +2116,7 @@ export class DataLoaderManager implements AppModule {
     try {
       const fireResult = await fetchAllFires(1);
       if (fireResult.skipped) {
-        this.ctx.panels['satellite-fires']?.showConfigError('NASA_FIRMS_API_KEY not configured — add in Settings');
+        this.ctx.panels['satellite-fires']?.showConfigError(t('panels.satelliteFires.noData'));
         this.ctx.statusPanel?.updateApi('FIRMS', { status: 'error' });
         return;
       }

--- a/src/services/wildfires/index.ts
+++ b/src/services/wildfires/index.ts
@@ -54,7 +54,7 @@ export async function fetchAllFires(_days?: number): Promise<FetchResult> {
   const detections = response.fireDetections;
 
   if (detections.length === 0) {
-    return { regions: {}, totalCount: 0, skipped: true, reason: 'NASA_FIRMS_API_KEY not configured' };
+    return { regions: {}, totalCount: 0, skipped: true, reason: 'no_data' };
   }
 
   const regions: Record<string, FireDetection[]> = {};


### PR DESCRIPTION
## Summary
- Fires panel showed "NASA_FIRMS_API_KEY not configured — add in Settings" whenever fire detections were empty, which is misleading on production (key IS configured; empty data can be caused by seed cron lag, Redis expiry, or circuit breaker)
- Replaced with localized `t('panels.satelliteFires.noData')` → "No fire data available" (already translated in all 21 locales)

## Changes
- `src/services/wildfires/index.ts` — changed `reason` from API-key-specific string to generic `'no_data'`
- `src/app/data-loader.ts` — replaced hardcoded English string with `t()` call

## Test plan
- [ ] Verify fires panel shows localized message when no data available
- [ ] Switch language and confirm message updates accordingly
- [ ] Verify normal fire data display is unaffected when data exists