### PR TITLE
fix: switch basemap fallback from Stadia Maps to OpenFreeMap

### DIFF
--- a/docs/Docs_To_Review/todo.md
+++ b/docs/Docs_To_Review/todo.md
@@ -1000,6 +1000,6 @@ Add scheduled export and a public API endpoint for integration with external too
 ### TODO-131 — Self-Hosted Map Tiles via Protomaps + CloudFront
 
 - **Priority:** 🔴 High | **Effort:** ~2 days
-- Replace CARTO/Stadia third-party basemap tiles with self-hosted Protomaps PMTiles on CloudFront. Eliminates CORS failures, third-party availability issues, and rate limits. CARTO has been intermittently blocking cross-origin requests (no `Access-Control-Allow-Origin` header), causing blank maps until the Stadia fallback kicks in. Self-hosted tiles = zero external dependency for the base map.
+- Replace CARTO/Stadia third-party basemap tiles with self-hosted Protomaps PMTiles on CloudFront. Eliminates CORS failures, third-party availability issues, and rate limits. CARTO has been intermittently blocking cross-origin requests (no `Access-Control-Allow-Origin` header), causing blank maps until the OpenFreeMap fallback kicks in. Self-hosted tiles = zero external dependency for the base map.
 - **Approach:** Download a PMTiles archive (OpenStreetMap-based, ~70GB planet or extract regions), host on S3 + CloudFront CDN, use `pmtiles://` protocol with MapLibre GL JS. Style JSON also self-hosted.
 - **References:** protomaps.com, github.com/protomaps/PMTiles

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -157,8 +157,8 @@ const LIGHT_STYLE = SITE_VARIANT === 'happy'
   ? '/map-styles/happy-light.json'
   : 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json';
 
-const FALLBACK_DARK_STYLE = 'https://tiles.stadiamaps.com/styles/alidade_smooth_dark.json';
-const FALLBACK_LIGHT_STYLE = 'https://tiles.stadiamaps.com/styles/alidade_smooth.json';
+const FALLBACK_DARK_STYLE = 'https://tiles.openfreemap.org/styles/dark';
+const FALLBACK_LIGHT_STYLE = 'https://tiles.openfreemap.org/styles/positron';
 
 // Zoom thresholds for layer visibility and labels (matches old Map.ts)
 // Zoom-dependent layer visibility and labels
@@ -359,6 +359,7 @@ export class DeckGLMap {
   private renderPending = false;
   private webglLost = false;
   private usedFallbackStyle = false;
+  private styleLoadTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
 
   private layerCache: Map<string, Layer> = new Map();
@@ -512,15 +513,21 @@ export class DeckGLMap {
 
     this.maplibreMap.on('error', (e: { error?: Error; message?: string }) => {
       const msg = e.error?.message ?? e.message ?? '';
-      if (msg.includes('Failed to fetch') || msg.includes('AJAXError') || msg.includes('CORS') || msg.includes('NetworkError') || msg.includes('style.json')) {
+      if (msg.includes('Failed to fetch') || msg.includes('AJAXError') || msg.includes('CORS') || msg.includes('NetworkError') || msg.includes('cartocdn.com')) {
         switchToFallback();
       }
     });
 
-    const styleLoadTimeout = setTimeout(() => {
+    this.styleLoadTimeoutId = setTimeout(() => {
+      this.styleLoadTimeoutId = null;
       if (!this.maplibreMap?.isStyleLoaded()) switchToFallback();
     }, 5000);
-    this.maplibreMap.once('style.load', () => clearTimeout(styleLoadTimeout));
+    this.maplibreMap.once('style.load', () => {
+      if (this.styleLoadTimeoutId) {
+        clearTimeout(this.styleLoadTimeoutId);
+        this.styleLoadTimeoutId = null;
+      }
+    });
 
     const canvas = this.maplibreMap.getCanvas();
     canvas.addEventListener('webglcontextlost', (e) => {
@@ -4770,6 +4777,10 @@ export class DeckGLMap {
       this.moveTimeoutId = null;
     }
 
+    if (this.styleLoadTimeoutId) {
+      clearTimeout(this.styleLoadTimeoutId);
+      this.styleLoadTimeoutId = null;
+    }
     this.stopPulseAnimation();
     this.stopDayNightTimer();
     if (this.aircraftFetchTimer) {


### PR DESCRIPTION
## Summary
- Switch fallback basemap from Stadia Maps to **OpenFreeMap** (free, no auth, proper CORS)
- Replace overly broad `style.json` error match with `cartocdn.com`
- Store style load timeout on instance and clear in `destroy()` to prevent stale callbacks
- Update TODO-131 roadmap text

Fixes #1031

## Root cause
PR #1037 added Stadia Maps as fallback, but Stadia tiles return **HTTP 401** without an API key. The `style.json` loads fine, but actual `.pbf` tile requests fail silently — map stays black with data points floating on nothing.

OpenFreeMap serves tiles with no authentication, no rate limits, and `Access-Control-Allow-Origin: *`. Dark style available at `tiles.openfreemap.org/styles/dark`.

## Test plan
- [ ] Deploy preview → verify map loads with OpenFreeMap dark basemap when CARTO is blocked
- [ ] Verify no fallback warnings when CARTO is working normally
- [ ] Verify theme switching respects fallback state
- [ ] Verify 5s timeout triggers fallback if style never loads