### PR TITLE
fix: graceful degradation for seed scripts with missing keys

### DIFF
--- a/scripts/seed-climate-anomalies.mjs
+++ b/scripts/seed-climate-anomalies.mjs
@@ -107,7 +107,7 @@ async function fetchClimateAnomalies() {
     if (r.status === 'fulfilled') {
       if (r.value != null) anomalies.push(r.value);
     } else {
-      console.error(`  [CLIMATE] ${r.reason?.message ?? r.reason}`);
+      console.log(`  [CLIMATE] ${r.reason?.message ?? r.reason}`);
     }
   }
 
@@ -115,7 +115,7 @@ async function fetchClimateAnomalies() {
 }
 
 function validate(data) {
-  return Array.isArray(data?.anomalies) && data.anomalies.length >= 1;
+  return Array.isArray(data?.anomalies);
 }
 
 runSeed('climate', 'anomalies', CANONICAL_KEY, fetchClimateAnomalies, {

--- a/scripts/seed-internet-outages.mjs
+++ b/scripts/seed-internet-outages.mjs
@@ -64,7 +64,7 @@ function toEpochMs(value) {
 async function fetchOutages() {
   const token = process.env.CLOUDFLARE_API_TOKEN;
   if (!token) {
-    console.error('CLOUDFLARE_API_TOKEN not set — skipping');
+    console.log('CLOUDFLARE_API_TOKEN not set — skipping');
     process.exit(0);
   }
 

--- a/scripts/seed-natural-events.mjs
+++ b/scripts/seed-natural-events.mjs
@@ -131,8 +131,8 @@ async function fetchNaturalEvents() {
   const eonetEvents = eonetResult.status === 'fulfilled' ? eonetResult.value : [];
   const gdacsEvents = gdacsResult.status === 'fulfilled' ? gdacsResult.value : [];
 
-  if (eonetResult.status === 'rejected') console.error('[EONET]', eonetResult.reason?.message);
-  if (gdacsResult.status === 'rejected') console.error('[GDACS]', gdacsResult.reason?.message);
+  if (eonetResult.status === 'rejected') console.log('[EONET]', eonetResult.reason?.message);
+  if (gdacsResult.status === 'rejected') console.log('[GDACS]', gdacsResult.reason?.message);
 
   const seenLocations = new Set();
   const merged = [];
@@ -157,7 +157,7 @@ async function fetchNaturalEvents() {
 }
 
 function validate(data) {
-  return Array.isArray(data?.events) && data.events.length >= 1;
+  return Array.isArray(data?.events);
 }
 
 runSeed('natural', 'events', CANONICAL_KEY, fetchNaturalEvents, {

--- a/scripts/seed-unrest-events.mjs
+++ b/scripts/seed-unrest-events.mjs
@@ -92,7 +92,7 @@ function sortBySeverityAndRecency(events) {
 async function fetchAcledProtests() {
   const token = process.env.ACLED_ACCESS_TOKEN;
   if (!token) {
-    console.warn('  ACLED_ACCESS_TOKEN not set, skipping ACLED');
+    console.log('  ACLED_ACCESS_TOKEN not set, skipping ACLED');
     return [];
   }
 
@@ -226,8 +226,8 @@ async function fetchUnrestEvents() {
   const acledEvents = results[0].status === 'fulfilled' ? results[0].value : [];
   const gdeltEvents = results[1].status === 'fulfilled' ? results[1].value : [];
 
-  if (results[0].status === 'rejected') console.warn(`  ACLED failed: ${results[0].reason?.message || results[0].reason}`);
-  if (results[1].status === 'rejected') console.warn(`  GDELT failed: ${results[1].reason?.message || results[1].reason}`);
+  if (results[0].status === 'rejected') console.log(`  ACLED failed: ${results[0].reason?.message || results[0].reason}`);
+  if (results[1].status === 'rejected') console.log(`  GDELT failed: ${results[1].reason?.message || results[1].reason}`);
 
   const merged = deduplicateEvents([...acledEvents, ...gdeltEvents]);
   const sorted = sortBySeverityAndRecency(merged);
@@ -238,7 +238,7 @@ async function fetchUnrestEvents() {
 }
 
 function validate(data) {
-  return Array.isArray(data?.events) && data.events.length >= 1;
+  return Array.isArray(data?.events);
 }
 
 runSeed('unrest', 'events', CANONICAL_KEY, fetchUnrestEvents, {


### PR DESCRIPTION
## Summary
- **seed-unrest-events**: Relax validation to allow 0 events (ACLED key missing + GDELT 404 = FATAL crash). `console.warn` → `console.log`
- **seed-natural-events**: Relax validation (EONET + GDACS both down = crash). `console.error` → `console.log`
- **seed-climate-anomalies**: Relax validation. `console.error` → `console.log`
- **seed-internet-outages**: `console.error` → `console.log` for missing Cloudflare key

Railway tags `console.warn`/`console.error` as `severity:error`, making healthy skip-runs look like crashes.

## Context
These fixes were in PR #1036 but got overwritten during the squash merge (other PRs merged between). Re-applying on a clean branch.

## Test plan
- [ ] seed-unrest-events no longer crashes when ACLED_ACCESS_TOKEN is missing
- [ ] Railway logs show `info` severity for skipped sources