### PR TITLE
fix: make seed-military-bases resilient to missing data file

### DIFF
--- a/scripts/seed-military-bases.mjs
+++ b/scripts/seed-military-bases.mjs
@@ -239,9 +239,19 @@ async function main() {
     process.exit(1);
   }
 
-  const dataPath = join(__dirname, 'data', 'military-bases-final.json');
-  if (!existsSync(dataPath)) {
-    console.error(`Data file not found: ${dataPath}`);
+  const volumePath = '/data/military-bases-final.json';
+  const localPath = join(__dirname, 'data', 'military-bases-final.json');
+  const dataPath = existsSync(volumePath) ? volumePath : existsSync(localPath) ? localPath : null;
+
+  if (!dataPath) {
+    const activeKey = `${prefix}military:bases:active`;
+    const check = await pipelineRequest(redisUrl, redisToken, [['GET', activeKey]]);
+    const existing = check[0]?.result;
+    if (existing) {
+      console.log(`No data file found — Redis already has active version ${existing}, skipping.`);
+      process.exit(0);
+    }
+    console.error(`Data file not found at ${volumePath} or ${localPath}, and no existing data in Redis.`);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- Check Railway volume mount (`/data/`) first, then local `scripts/data/`
- If no file found, check if Redis already has active data → skip gracefully (exit 0)
- Only crash if both file AND Redis data are missing

## Context
The 34MB `military-bases-final.json` is not tracked in git (too large, sensitive). When deployed as a Railway cron, it crashes every tick because the file isn't there. The data uses Redis GEO/HASH keys with **no TTL** — it persists indefinitely. Re-seeding only needed when base data changes.

To use Railway Volume: mount a volume at `/data`, upload the file once. Otherwise, the script gracefully skips if Redis already has the data.

## Test plan
- [ ] Railway cron: no crash when file missing and Redis has data
- [ ] Local run with file at `scripts/data/`: seeds normally
- [ ] Volume mount at `/data/`: reads from volume