### PR TITLE
fix: remove emrldco analytics and improve basemap fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https: http://localhost:5173 ws: wss: blob: data:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'sha256-LnMFPWZxTgVOr2VYwIh9mhQ3l/l3+a3SfNOLERnuHfY=' 'sha256-+SFBjfmi2XfnyAT3POBxf6JIKYDcNXtllPclOcaNBI0=' 'sha256-AhZAmdCW6h8iXMyBcvIrqN71FGNk4lwLD+lPxx43hxg=' 'sha256-PnEBZii+iFaNE2EyXaJhRq34g6bdjRJxpLfJALdXYt8=' 'sha256-cVhuR63Moy56DV5yG0caJCEyCugMTbYclkvkK6fSwXY=' 'wasm-unsafe-eval' https://www.youtube.com https://static.cloudflareinsights.com https://vercel.live https://emrldco.com; worker-src 'self' blob:; font-src 'self' data: https:; media-src 'self' data: blob: https: http://127.0.0.1:* http://localhost:*; frame-src 'self' http://127.0.0.1:* http://localhost:* https://worldmonitor.app https://tech.worldmonitor.app https://happy.worldmonitor.app https://www.youtube.com https://www.youtube-nocookie.com;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https: http://localhost:5173 ws: wss: blob: data:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'sha256-LnMFPWZxTgVOr2VYwIh9mhQ3l/l3+a3SfNOLERnuHfY=' 'sha256-+SFBjfmi2XfnyAT3POBxf6JIKYDcNXtllPclOcaNBI0=' 'sha256-AhZAmdCW6h8iXMyBcvIrqN71FGNk4lwLD+lPxx43hxg=' 'sha256-PnEBZii+iFaNE2EyXaJhRq34g6bdjRJxpLfJALdXYt8=' 'sha256-cVhuR63Moy56DV5yG0caJCEyCugMTbYclkvkK6fSwXY=' 'wasm-unsafe-eval' https://www.youtube.com https://static.cloudflareinsights.com https://vercel.live; worker-src 'self' blob:; font-src 'self' data: https:; media-src 'self' data: blob: https: http://127.0.0.1:* http://localhost:*; frame-src 'self' http://127.0.0.1:* http://localhost:* https://worldmonitor.app https://tech.worldmonitor.app https://happy.worldmonitor.app https://www.youtube.com https://www.youtube-nocookie.com;" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
 
     <!-- Primary Meta Tags -->
@@ -161,7 +161,6 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Tajawal:wght@200;300;400;500;700;800;900&display=swap" rel="stylesheet">
-    <script>window.addEventListener('load',function(){var s=document.createElement('script');s.async=1;s.src='https://emrldco.com/NTA0NDAw.js?t=504400';document.head.appendChild(s);});</script>
   </head>
   <body>
     <div id="app">

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https: http://localhost:5173 http://127.0.0.1:* ws: wss: blob: data:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval' https://www.youtube.com https://emrldco.com; worker-src 'self' blob:; font-src 'self' data: https:; media-src 'self' data: blob: https: http://127.0.0.1:* http://localhost:*; frame-src 'self' http://127.0.0.1:* http://localhost:* https://worldmonitor.app https://tech.worldmonitor.app https://www.youtube.com https://www.youtube-nocookie.com;"
+      "csp": "default-src 'self'; connect-src 'self' https: http://localhost:5173 http://127.0.0.1:* ws: wss: blob: data:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval' https://www.youtube.com; worker-src 'self' blob:; font-src 'self' data: https:; media-src 'self' data: blob: https: http://127.0.0.1:* http://localhost:*; frame-src 'self' http://127.0.0.1:* http://localhost:* https://worldmonitor.app https://tech.worldmonitor.app https://www.youtube.com https://www.youtube-nocookie.com;"
     }
   },
   "bundle": {

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -486,9 +486,6 @@ export class DeckGLMap {
   }
 
   private initMapLibre(): void {
-    // Load the RTL text plugin for correct Arabic/Hebrew glyph joining.
-    // Self-hosted in public/ to avoid CSP issues with external CDN scripts.
-    // Lazy-loaded — only fetched when a RTL text-field is actually rendered.
     if (maplibregl.getRTLTextPluginStatus() === 'unavailable') {
       maplibregl.setRTLTextPlugin(
         '/mapbox-gl-rtl-text.min.js',
@@ -498,10 +495,11 @@ export class DeckGLMap {
 
     const preset = VIEW_PRESETS[this.state.view];
     const initialTheme = getCurrentTheme();
+    const primaryStyle = initialTheme === 'light' ? LIGHT_STYLE : DARK_STYLE;
 
     this.maplibreMap = new maplibregl.Map({
       container: 'deckgl-basemap',
-      style: initialTheme === 'light' ? LIGHT_STYLE : DARK_STYLE,
+      style: primaryStyle,
       center: [preset.longitude, preset.latitude],
       zoom: preset.zoom,
       renderWorldCopies: false,
@@ -517,26 +515,57 @@ export class DeckGLMap {
         : {}),
     });
 
-    const switchToFallback = () => {
+    const recreateWithFallback = () => {
       if (this.usedFallbackStyle) return;
       this.usedFallbackStyle = true;
       const fallback = initialTheme === 'light' ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE;
-      console.warn(`[DeckGLMap] Primary basemap failed, switching to fallback: ${fallback}`);
-      this.maplibreMap?.setStyle(fallback);
+      console.warn(`[DeckGLMap] Primary basemap failed, recreating with fallback: ${fallback}`);
+      this.maplibreMap?.remove();
+      this.maplibreMap = new maplibregl.Map({
+        container: 'deckgl-basemap',
+        style: fallback,
+        center: [preset.longitude, preset.latitude],
+        zoom: preset.zoom,
+        renderWorldCopies: false,
+        attributionControl: false,
+        interactive: true,
+        ...(MAP_INTERACTION_MODE === 'flat'
+          ? {
+            maxPitch: 0,
+            pitchWithRotate: false,
+            dragRotate: false,
+            touchPitch: false,
+          }
+          : {}),
+      });
+      this.maplibreMap.on('load', () => {
+        localizeMapLabels(this.maplibreMap);
+        this.rebuildTechHQSupercluster();
+        this.rebuildDatacenterSupercluster();
+        this.initDeck();
+        this.loadCountryBoundaries();
+        this.fetchServerBases();
+        this.render();
+      });
     };
+
+    let styleLoaded = false;
 
     this.maplibreMap.on('error', (e: { error?: Error; message?: string }) => {
       const msg = e.error?.message ?? e.message ?? '';
-      if (msg.includes('Failed to fetch') || msg.includes('AJAXError') || msg.includes('CORS') || msg.includes('NetworkError') || msg.includes('cartocdn.com')) {
-        switchToFallback();
+      if (msg.includes('Failed to fetch') || msg.includes('AJAXError') || msg.includes('CORS') || msg.includes('NetworkError') || msg.includes('cartocdn.com') || msg.includes('403') || msg.includes('Forbidden')) {
+        if (!styleLoaded) {
+          recreateWithFallback();
+        }
       }
     });
 
     this.styleLoadTimeoutId = setTimeout(() => {
       this.styleLoadTimeoutId = null;
-      if (!this.maplibreMap?.isStyleLoaded()) switchToFallback();
+      if (!this.maplibreMap?.isStyleLoaded()) recreateWithFallback();
     }, 5000);
     this.maplibreMap.once('style.load', () => {
+      styleLoaded = true;
       if (this.styleLoadTimeoutId) {
         clearTimeout(this.styleLoadTimeoutId);
         this.styleLoadTimeoutId = null;


### PR DESCRIPTION
## Summary
- **Remove emrldco.com analytics** — script loader and CSP entries stripped from `index.html`, `vercel.json`, and `tauri.conf.json`
- **Fix basemap fallback reliability** — when Carto returns 403 (intermittent), the old `setStyle()` approach left MapLibre in a broken state where the map never rendered. Now we `remove()` the failed map and create a fresh one with the OpenFreeMap fallback URL
- **Broader error detection** — added `403`/`Forbidden` to the error pattern matching
- **Scoped fallback** — only recreate the map for pre-style-load errors; post-load tile errors are ignored (single tile failure ≠ basemap failure)

## Context
A user reported a blank map + console errors. Root cause: Carto style.json returned 403 intermittently, and `setStyle()` on a map whose initial style never loaded doesn't reliably recover MapLibre's rendering pipeline.

## Test plan
- [ ] Verify map loads normally (Carto working → no change in behavior)
- [ ] Simulate Carto failure (block `basemaps.cartocdn.com` in DevTools Network) → map should recreate with OpenFreeMap within 5s
- [ ] Verify no `emrldco.com` script or CSP references remain
- [ ] Theme toggle (dark↔light) still works after fallback