### PR TITLE
fix: rate-guard AbuseIPDB calls to stay under 100/day limit

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -5378,7 +5378,8 @@ server.listen(PORT, () => {
   startUcdpSeedLoop();
   startMarketDataSeedLoop();
   startAviationSeedLoop();
-  startCyberThreatsSeedLoop();
+  // Cyber seed disabled — standalone cron seed-cyber-threats.mjs handles this
+  // (avoids burning 12 extra AbuseIPDB calls/day from duplicate relay loop)
   startCiiSeedLoop();
   startPositiveEventsSeedLoop();
   startGpsJamSeedLoop();

--- a/scripts/seed-cyber-threats.mjs
+++ b/scripts/seed-cyber-threats.mjs
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, verifySeedKey, writeExtraKey } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
+const ABUSEIPDB_RATE_KEY = 'rate:abuseipdb:last-call';
+const ABUSEIPDB_CACHE_KEY = 'cache:abuseipdb:threats';
+const ABUSEIPDB_MIN_INTERVAL_MS = 2 * 60 * 60 * 1000; // 2h — keeps daily calls under 100/day limit
+
 const CANONICAL_KEY = 'cyber:threats:v2';
 const BOOTSTRAP_KEY = 'cyber:threats-bootstrap:v2';
-const CACHE_TTL = 7200; // 2 hours
+const CACHE_TTL = 10800; // 3h — survives 1 missed 2h cron cycle
 
 const FEODO_URL = 'https://feodotracker.abuse.ch/downloads/ipblocklist.json';
 const URLHAUS_RECENT_URL = (limit) => `https://urlhaus-api.abuse.ch/v1/urls/recent/limit/${limit}/`;
@@ -430,6 +434,21 @@ async function fetchOtx(days) {
 async function fetchAbuseIpDb() {
   const apiKey = clean(process.env.ABUSEIPDB_API_KEY || '', 200);
   if (!apiKey) { console.log('  AbuseIPDB: skipped (no ABUSEIPDB_API_KEY)'); return { ok: false, threats: [] }; }
+
+  try {
+    const lastCall = await verifySeedKey(ABUSEIPDB_RATE_KEY);
+    const lastTs = lastCall?.calledAt || 0;
+    if (Date.now() - lastTs < ABUSEIPDB_MIN_INTERVAL_MS) {
+      const cached = await verifySeedKey(ABUSEIPDB_CACHE_KEY);
+      if (Array.isArray(cached) && cached.length > 0) {
+        console.log(`  AbuseIPDB: ${cached.length} threats (cached, called ${Math.round((Date.now() - lastTs) / 60000)}m ago)`);
+        return { ok: true, threats: cached };
+      }
+      console.log('  AbuseIPDB: skipped (rate limit, no cache)');
+      return { ok: false, threats: [] };
+    }
+  } catch { /* proceed if rate check fails */ }
+
   try {
     const url = `${ABUSEIPDB_BLACKLIST_URL}?confidenceMinimum=90&limit=${Math.min(MAX_LIMIT, 500)}`;
     const resp = await fetch(url, {
@@ -455,6 +474,8 @@ async function fetchAbuseIpDb() {
       if (threats.length >= MAX_LIMIT) break;
     }
     console.log(`  AbuseIPDB: ${threats.length} threats`);
+    await writeExtraKey(ABUSEIPDB_CACHE_KEY, threats, 86400).catch(() => {});
+    await writeExtraKey(ABUSEIPDB_RATE_KEY, { calledAt: Date.now() }, 86400).catch(() => {});
     return { ok: true, threats };
   } catch (e) {
     console.warn(`  AbuseIPDB: failed — ${e.message}`);


### PR DESCRIPTION
## Summary
- **Rate-guard AbuseIPDB** in `seed-cyber-threats.mjs`: checks `rate:abuseipdb:last-call` Redis key before calling API. Only calls every 2h, caches threats in `cache:abuseipdb:threats` between calls.
- **Disable duplicate cyber seed loop** in `ais-relay.cjs` — standalone cron already handles this, relay was burning 12 extra AbuseIPDB calls/day.
- **Increase seed TTL** from 2h to 3h to survive 1 missed cron cycle (prevents Vercel handler fallthrough during TTL expiry gap).

## Root cause
AbuseIPDB allows 100 calls/day. The cyber seed cron runs every 2h with a 2h TTL — when the key expires between cron runs, the Vercel handler falls through to live API fetches, consuming quota rapidly. Combined with the duplicate relay loop, daily calls exceeded the limit.

## Also done (not in this PR)
- Deployed `seed-airport-delays` as a Railway cron service (was the only missing seed script)

## Test plan
- [ ] Verify seed-cyber-threats cron still runs and writes to `cyber:threats:v2`
- [ ] Verify AbuseIPDB calls stay under 100/day (monitor via AbuseIPDB dashboard)
- [ ] Verify `seed-airport-delays` cron runs on Railway (check logs)