### PR TITLE
fix: auto-reload on SW activation to prevent stale bundle 404s

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -329,6 +329,14 @@ if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) {
 }
 
 if (!('__TAURI_INTERNALS__' in window) && !('__TAURI__' in window) && 'serviceWorker' in navigator) {
+  // Auto-reload when a new SW takes control (fixes stale HTML after deploys)
+  let refreshing = false;
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (refreshing) return;
+    refreshing = true;
+    window.location.reload();
+  });
+
   navigator.serviceWorker.register('/sw.js', { scope: '/' })
     .then((registration) => {
       console.log('[PWA] Service worker registered');
@@ -336,7 +344,6 @@ if (!('__TAURI_INTERNALS__' in window) && !('__TAURI__' in window) && 'serviceWo
         if (!navigator.onLine) return;
         try { await registration.update(); } catch {}
       }, 5 * 60 * 1000);
-      // Expose interval ID for cleanup/debugging
       (window as unknown as Record<string, unknown>).__swUpdateInterval = swUpdateInterval;
     })
     .catch((err) => {


### PR DESCRIPTION
## Summary
After a deploy, users with a cached service worker see 404s on first load because the old SW serves stale HTML referencing old content-hashed bundles. The browser detects the new sw.js and installs it in the background, but the page is already broken.

This adds a `controllerchange` listener that auto-reloads the page when the new SW takes control. Combined with `skipWaiting` + `clientsClaim`, this means: user loads page → old SW serves stale HTML → 404 → new SW installs + activates → `controllerchange` fires → page auto-reloads → new SW serves fresh HTML → works.

## Test plan
- [ ] Deploy, open site with stale SW — should auto-reload within seconds
- [ ] No reload loops (guard with `refreshing` flag)