### PR TITLE
fix: wire prediction markets bootstrap hydration

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -18,7 +18,7 @@ import {
   getFeedFailures,
   fetchMultipleStocks,
   fetchCrypto,
-  fetchPredictions,
+  fetchPredictions, type PredictionMarket,
   fetchEarthquakes,
   fetchWeatherAlerts,
   fetchFredData,
@@ -1108,6 +1108,19 @@ export class DataLoaderManager implements AppModule {
 
   async loadPredictions(): Promise<void> {
     try {
+      // Try bootstrap hydration first (instant data from seed)
+      const hydrated = getHydratedData('predictions') as { geopolitical?: PredictionMarket[]; tech?: PredictionMarket[] } | undefined;
+      if (hydrated) {
+        const bootstrapMarkets = (SITE_VARIANT === 'tech' ? hydrated.tech : hydrated.geopolitical) ?? [];
+        if (bootstrapMarkets.length > 0) {
+          this.ctx.latestPredictions = bootstrapMarkets;
+          (this.ctx.panels['polymarket'] as PredictionPanel).renderPredictions(bootstrapMarkets);
+          this.ctx.statusPanel?.updateFeed('Polymarket', { status: 'ok', itemCount: bootstrapMarkets.length });
+          dataFreshness.recordUpdate('polymarket', bootstrapMarkets.length);
+          dataFreshness.recordUpdate('predictions', bootstrapMarkets.length);
+        }
+      }
+
       const predictions = await fetchPredictions();
       this.ctx.latestPredictions = predictions;
       (this.ctx.panels['polymarket'] as PredictionPanel).renderPredictions(predictions);


### PR DESCRIPTION
## Summary
- `seed-prediction-markets` cron writes to `prediction:markets-bootstrap:v1` and `api/bootstrap.js` already registers it, but `data-loader.ts` never consumed the hydrated data
- Predictions panel relied solely on live Polymarket Gamma API calls (fragile: JA3 blocking, proxy chain failures)
- Now `loadPredictions()` tries `getHydratedData('predictions')` first for instant rendering, then refreshes with live data

## Test plan
- [ ] Verify predictions panel renders immediately on page load (from bootstrap)
- [ ] Verify live data refresh still works after initial hydration
- [ ] Verify tech variant gets tech markets, full variant gets geopolitical