### PR TITLE
fix: InsightsPanel exits loading state on finance/tech variants

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -932,10 +932,8 @@ export class DataLoaderManager implements AppModule {
         ? await clusterNewsHybrid(this.ctx.allNews)
         : await analysisWorker.clusterNews(this.ctx.allNews);
 
-      if (this.ctx.latestClusters.length > 0) {
-        const insightsPanel = this.ctx.panels['insights'] as InsightsPanel | undefined;
-        insightsPanel?.updateInsights(this.ctx.latestClusters);
-      }
+      const insightsPanel = this.ctx.panels['insights'] as InsightsPanel | undefined;
+      insightsPanel?.updateInsights(this.ctx.latestClusters);
 
       const geoLocated = this.ctx.latestClusters
         .filter((c): c is typeof c & { lat: number; lon: number } => c.lat != null && c.lon != null)
@@ -951,6 +949,8 @@ export class DataLoaderManager implements AppModule {
       }
     } catch (error) {
       console.error('[App] Clustering failed, clusters unchanged:', error);
+      const insightsPanel = this.ctx.panels['insights'] as InsightsPanel | undefined;
+      insightsPanel?.updateInsights([]);
     }
 
     // Happy variant: run multi-stage positive news pipeline + map layers


### PR DESCRIPTION
## Summary
- InsightsPanel on `finance.worldmonitor.app` and `tech.worldmonitor.app` stayed spinning indefinitely
- Root cause: `updateInsights()` was only called when `latestClusters.length > 0` — these variants often produce zero clusters, so the panel never transitioned out of `showLoading()`
- Removed the length guard so `updateInsights` always fires (it already handles empty arrays gracefully)
- Added `updateInsights([])` in the clustering catch block so errors also clear the spinner

## Test plan
- [ ] Verify `finance.worldmonitor.app` InsightsPanel shows content or "waiting for data" instead of spinning
- [ ] Verify `tech.worldmonitor.app` InsightsPanel behaves the same
- [ ] Verify `www.worldmonitor.app` InsightsPanel still works normally
- [ ] Verify no TypeScript errors (`npx tsc --noEmit` passes)