### PR TITLE
chore: gitignore military bases rebuild script and partial data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ scripts/data/pizzint-processed.json
 scripts/data/osm-military-processed.json
 scripts/data/military-bases-final.json
 scripts/data/dedup-dropped-pairs.json
+scripts/data/pizzint-partial.json
 scripts/data/gpsjam-latest.json
 scripts/data/mirta-raw.geojson
 scripts/data/osm-military-raw.json
@@ -44,3 +45,6 @@ scripts/data/osm-military-raw.json
 # Iran events seed script + data (sensitive, not for public repo)
 scripts/seed-iran-events.mjs
 scripts/data/iran-events-latest.json
+
+# Military bases rebuild script (references external Supabase URLs)
+scripts/rebuild-military-bases.mjs


### PR DESCRIPTION
## Summary
- Adds `scripts/rebuild-military-bases.mjs` to `.gitignore` (references external Supabase URLs — should not be public)
- Adds `scripts/data/pizzint-partial.json` to `.gitignore` (checkpoint file from pipeline runs)

## Context
The rebuild script orchestrates the full military bases pipeline (Pizzint + OSM + MIRTA + curated → 125K merged bases → Redis seed). It auto-extracts a Supabase anon key from an external frontend, so it stays local-only.

## Test plan
- [x] `git status` clean
- [x] All pre-push checks pass (tsc, edge function tests, version sync)