### PR TITLE
fix: one-time SW nuke on first visit after deploy

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -329,24 +329,40 @@ if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) {
 }
 
 if (!('__TAURI_INTERNALS__' in window) && !('__TAURI__' in window) && 'serviceWorker' in navigator) {
-  // Auto-reload when a new SW takes control (fixes stale HTML after deploys)
-  let refreshing = false;
-  navigator.serviceWorker.addEventListener('controllerchange', () => {
-    if (refreshing) return;
-    refreshing = true;
-    window.location.reload();
-  });
-
-  navigator.serviceWorker.register('/sw.js', { scope: '/' })
-    .then((registration) => {
-      console.log('[PWA] Service worker registered');
-      const swUpdateInterval = setInterval(async () => {
-        if (!navigator.onLine) return;
-        try { await registration.update(); } catch {}
-      }, 5 * 60 * 1000);
-      (window as unknown as Record<string, unknown>).__swUpdateInterval = swUpdateInterval;
-    })
-    .catch((err) => {
-      console.warn('[PWA] Service worker registration failed:', err);
+  // One-time nuke: clear stale SWs and caches from old deploys, then re-register fresh.
+  // Safe to remove after 2026-03-20 when all users have cycled through.
+  const nukeKey = 'wm-sw-nuked-v1';
+  let alreadyNuked = false;
+  try { alreadyNuked = !!localStorage.getItem(nukeKey); } catch { /* private browsing */ }
+  if (!alreadyNuked) {
+    try { localStorage.setItem(nukeKey, '1'); } catch { /* best effort */ }
+    navigator.serviceWorker.getRegistrations().then(async (regs) => {
+      await Promise.all(regs.map(r => r.unregister()));
+      const keys = await caches.keys();
+      await Promise.all(keys.map(k => caches.delete(k)));
+      console.log('[PWA] Nuked stale service workers and caches');
+      window.location.reload();
     });
+  } else {
+    // Auto-reload when a new SW takes control (fixes stale HTML after deploys)
+    let refreshing = false;
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      if (refreshing) return;
+      refreshing = true;
+      window.location.reload();
+    });
+
+    navigator.serviceWorker.register('/sw.js', { scope: '/' })
+      .then((registration) => {
+        console.log('[PWA] Service worker registered');
+        const swUpdateInterval = setInterval(async () => {
+          if (!navigator.onLine) return;
+          try { await registration.update(); } catch {}
+        }, 5 * 60 * 1000);
+        (window as unknown as Record<string, unknown>).__swUpdateInterval = swUpdateInterval;
+      })
+      .catch((err) => {
+        console.warn('[PWA] Service worker registration failed:', err);
+      });
+  }
 }


### PR DESCRIPTION
## HOTFIX — deploy ASAP

Users with stale service workers get 404s on every page load. This adds a one-time nuke in `main.ts` that unregisters all SWs, clears all caches, and reloads on first visit. Guarded by `localStorage` so it fires only once per browser.

This commit was pushed to PR #1073 after it was already merged, so it never got deployed.