### PR TITLE
fix(pwa): bump SW nuke key to v2 for CF-cached 404 victims

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -331,7 +331,7 @@ if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) {
 if (!('__TAURI_INTERNALS__' in window) && !('__TAURI__' in window) && 'serviceWorker' in navigator) {
   // One-time nuke: clear stale SWs and caches from old deploys, then re-register fresh.
   // Safe to remove after 2026-03-20 when all users have cycled through.
-  const nukeKey = 'wm-sw-nuked-v1';
+  const nukeKey = 'wm-sw-nuked-v2';
   let alreadyNuked = false;
   try { alreadyNuked = !!localStorage.getItem(nukeKey); } catch { /* private browsing */ }
   if (!alreadyNuked) {


### PR DESCRIPTION
## Summary
- Bumps `wm-sw-nuked-v1` → `wm-sw-nuked-v2` in `src/main.ts`
- Users who visited during the deploy transition had v1 key set but their SWs cached CF-served 404 responses (CF was caching 404s with `max-age=31536000, immutable` from Vercel's `/assets/` header rule)
- v2 forces the nuke to fire again now that CF has status-code TTL rule preventing 404 caching

## Root Cause
`vercel.json` sends `Cache-Control: public, max-age=31536000, immutable` for ALL `/assets/` responses **including 404s**. During deploy transitions, old content-hashed URLs return 404 with "cache forever" headers. CF cached these 404s for a year.

## CF Fix (manual)
- Static cache rule now uses Edge TTL by status code: `200-299: 1 month`, `400-499: No cache`
- Purge `/assets/` prefix on all domains after rule change

## Test plan
- [ ] Verify CF status-code TTL rule is active
- [ ] Purge `/assets/` prefix on all 4 domains
- [ ] Deploy this PR
- [ ] Confirm users no longer get stale 404s
- [ ] Remove nuke code after 2026-03-20