### PR TITLE
fix: raise layers panel above attribution badge

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3782,7 +3782,7 @@ body.playback-mode .status-dot {
 
 .layer-toggles:not(.deckgl-layer-toggles) {
   position: absolute;
-  bottom: 10px;
+  bottom: 36px;
   left: 10px;
   display: flex;
   gap: 4px;
@@ -13253,7 +13253,7 @@ a.prediction-link:hover {
 /* deck.gl Layer Toggles */
 .deckgl-layer-toggles {
   position: absolute;
-  bottom: 10px;
+  bottom: 36px;
   left: 10px;
   z-index: 100;
   background: var(--bg);


### PR DESCRIPTION
## Summary
- Raise `.deckgl-layer-toggles` and `.layer-toggles` from `bottom: 10px` → `bottom: 36px`
- Attribution badge sits directly below the layers panel without overlap

## Test plan
- [ ] 3D globe — layers panel above attribution badge
- [ ] 2D map — layers panel raised, attribution visible below it