### PR TITLE
fix: panels pushed right when map disabled after reload (#1086)

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -410,6 +410,10 @@ export class PanelLayoutManager implements AppModule {
         const mapSection = document.getElementById('mapSection');
         if (mapSection) {
           mapSection.classList.toggle('hidden', !config.enabled);
+          const mainContent = document.querySelector('.main-content');
+          if (mainContent) {
+            mainContent.classList.toggle('map-hidden', !config.enabled);
+          }
         }
         return;
       }


### PR DESCRIPTION
## Summary
Fixes #1086 — when "Global Situation" module is disabled and the page reloads, panels get pushed right as if the map column still exists.

**Root cause:** `panel-layout.ts:applyPanelSettings()` (called on initial load) hid `mapSection` but did NOT add `map-hidden` to `.main-content`. The CSS rule `.main-content.map-hidden` switches the grid from 2-column to 1-column. Without it, the grid reserves space for the invisible map.

The runtime toggle in `event-handlers.ts` already had this logic — it was just missing from the initial-load path.

## Test plan
- [ ] Disable "Global Situation" in Settings → Panels
- [ ] Refresh the page
- [ ] Verify panels use full width (no empty space on left)
- [ ] Re-enable map — verify it reappears correctly