### PR TITLE
feat: replace hard layer limit with performance warning dialog

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -51,6 +51,7 @@ import { escapeHtml } from '@/utils/sanitize';
 import { tokenizeForMatch, matchKeyword, matchesAnyKeyword, findMatchingKeywords } from '@/utils/keyword-match';
 import { t } from '@/services/i18n';
 import { debounce, rafSchedule, getCurrentTheme } from '@/utils/index';
+import { showLayerWarning } from '@/utils/layer-warning';
 import { localizeMapLabels } from '@/utils/map-locale';
 import {
   INTEL_HOTSPOTS,
@@ -4446,34 +4447,21 @@ export class DeckGLMap {
     setGeoAlertGetter(getAlertsNearLocation);
   }
 
+  private layerWarningShown = false;
+
   private enforceLayerLimit(): void {
-    const MAX_FLAT_LAYERS = 9;
+    const WARN_THRESHOLD = 9;
     const togglesEl = this.container.querySelector('.deckgl-layer-toggles');
     if (!togglesEl) return;
-    const allToggles = Array.from(togglesEl.querySelectorAll<HTMLInputElement>('.layer-toggle input'))
-      .filter(i => (i.closest('.layer-toggle') as HTMLElement)?.style.display !== 'none');
-    const checked = allToggles.filter(i => i.checked);
-    if (checked.length > MAX_FLAT_LAYERS) {
-      const excess = checked.slice(MAX_FLAT_LAYERS);
-      for (const inp of excess) {
-        inp.checked = false;
-        const layer = inp.closest('.layer-toggle')?.getAttribute('data-layer') as keyof MapLayers | null;
-        if (layer) {
-          this.state.layers[layer] = false;
-        }
-      }
-      this.render();
+    const activeCount = Array.from(togglesEl.querySelectorAll<HTMLInputElement>('.layer-toggle input'))
+      .filter(i => (i.closest('.layer-toggle') as HTMLElement)?.style.display !== 'none')
+      .filter(i => i.checked).length;
+    if (activeCount >= WARN_THRESHOLD && !this.layerWarningShown) {
+      this.layerWarningShown = true;
+      showLayerWarning(WARN_THRESHOLD);
+    } else if (activeCount < WARN_THRESHOLD) {
+      this.layerWarningShown = false;
     }
-    const activeCount = allToggles.filter(i => i.checked).length;
-    allToggles.forEach(i => {
-      if (!i.checked) {
-        i.disabled = activeCount >= MAX_FLAT_LAYERS;
-        i.closest('.layer-toggle')?.classList.toggle('limit-reached', activeCount >= MAX_FLAT_LAYERS);
-      } else {
-        i.disabled = false;
-        i.closest('.layer-toggle')?.classList.remove('limit-reached');
-      }
-    });
   }
 
   // UI visibility methods

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -28,6 +28,7 @@ import { GAMMA_IRRADIATORS } from '@/config/irradiators';
 import { AI_DATA_CENTERS } from '@/config/ai-datacenters';
 import { getCountryBbox, getCountriesGeoJson } from '@/services/country-geometry';
 import { escapeHtml } from '@/utils/sanitize';
+import { showLayerWarning } from '@/utils/layer-warning';
 import type { FeatureCollection, Geometry } from 'geojson';
 import type { MapLayers, Hotspot, MilitaryFlight, MilitaryVessel, NaturalEvent, InternetOutage, CyberThreat, SocialUnrestEvent, UcdpGeoEvent, MilitaryBase, GammaIrradiator, Spaceport, EconomicCenter, StrategicWaterway, CriticalMineralProject, AIDataCenter, UnderseaCable, Pipeline, CableAdvisory, RepairShip, AisDisruptionEvent, AisDensityZone, AisDisruptionType } from '@/types';
 import type { Earthquake } from '@/services/earthquakes';
@@ -1625,32 +1626,19 @@ export class GlobeMap {
     this.enforceLayerLimit();
   }
 
+  private layerWarningShown = false;
+
   private enforceLayerLimit(): void {
     if (!this.layerTogglesEl) return;
-    const MAX_GLOBE_LAYERS = 6;
-    const allToggles = Array.from(this.layerTogglesEl.querySelectorAll<HTMLInputElement>('.layer-toggle input'));
-    const checked = allToggles.filter(i => i.checked);
-    if (checked.length > MAX_GLOBE_LAYERS) {
-      const excess = checked.slice(MAX_GLOBE_LAYERS);
-      for (const inp of excess) {
-        inp.checked = false;
-        const layer = inp.closest('.layer-toggle')?.getAttribute('data-layer') as keyof MapLayers | null;
-        if (layer) {
-          this.layers[layer] = false;
-          this.flushLayerChannels(layer);
-        }
-      }
+    const WARN_THRESHOLD = 6;
+    const activeCount = Array.from(this.layerTogglesEl.querySelectorAll<HTMLInputElement>('.layer-toggle input'))
+      .filter(i => i.checked).length;
+    if (activeCount >= WARN_THRESHOLD && !this.layerWarningShown) {
+      this.layerWarningShown = true;
+      showLayerWarning(WARN_THRESHOLD);
+    } else if (activeCount < WARN_THRESHOLD) {
+      this.layerWarningShown = false;
     }
-    const activeCount = allToggles.filter(i => i.checked).length;
-    allToggles.forEach(i => {
-      if (!i.checked) {
-        i.disabled = activeCount >= MAX_GLOBE_LAYERS;
-        i.closest('.layer-toggle')?.classList.toggle('limit-reached', activeCount >= MAX_GLOBE_LAYERS);
-      } else {
-        i.disabled = false;
-        i.closest('.layer-toggle')?.classList.remove('limit-reached');
-      }
-    });
   }
 
   // ─── Camera / navigation ──────────────────────────────────────────────────

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -13406,14 +13406,109 @@ a.prediction-link:hover {
   border-color: rgba(68, 255, 136, 0.2);
 }
 
-.deckgl-layer-toggles .layer-toggle.limit-reached {
-  opacity: 0.35;
-  pointer-events: none;
+/* Layer performance warning dialog */
+.layer-warn-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0);
+  backdrop-filter: blur(0);
+  transition: background 0.2s, backdrop-filter 0.2s;
 }
 
-.layer-toggles:not(.deckgl-layer-toggles) .layer-toggle.limit-reached {
-  opacity: 0.35;
-  pointer-events: none;
+.layer-warn-overlay.layer-warn-in {
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+.layer-warn-overlay.layer-warn-out {
+  background: rgba(0, 0, 0, 0);
+  backdrop-filter: blur(0);
+}
+
+.layer-warn-dialog {
+  background: var(--bg, #0a0e14);
+  border: 1px solid rgba(255, 170, 0, 0.3);
+  border-radius: 8px;
+  padding: 24px;
+  max-width: 340px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  text-align: center;
+  box-shadow: 0 0 30px rgba(255, 170, 0, 0.1), 0 8px 32px rgba(0, 0, 0, 0.6);
+  transform: scale(0.95);
+  opacity: 0;
+  transition: transform 0.2s, opacity 0.2s;
+}
+
+.layer-warn-in .layer-warn-dialog {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.layer-warn-out .layer-warn-dialog {
+  transform: scale(0.95);
+  opacity: 0;
+}
+
+.layer-warn-icon {
+  color: #ffaa00;
+  line-height: 1;
+}
+
+.layer-warn-text strong {
+  display: block;
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 13px;
+  letter-spacing: 0.5px;
+  color: #ffaa00;
+  margin-bottom: 6px;
+}
+
+.layer-warn-text p {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-dim, #8899aa);
+  line-height: 1.5;
+}
+
+.layer-warn-dismiss {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-dim, #8899aa);
+  cursor: pointer;
+  user-select: none;
+}
+
+.layer-warn-dismiss input {
+  accent-color: #ffaa00;
+  cursor: pointer;
+}
+
+.layer-warn-ok {
+  padding: 6px 28px;
+  background: rgba(255, 170, 0, 0.12);
+  border: 1px solid rgba(255, 170, 0, 0.4);
+  border-radius: 4px;
+  color: #ffaa00;
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  cursor: pointer;
+  transition: background 0.15s, box-shadow 0.15s;
+}
+
+.layer-warn-ok:hover {
+  background: rgba(255, 170, 0, 0.2);
+  box-shadow: 0 0 12px rgba(255, 170, 0, 0.2);
 }
 
 /* deck.gl Legend - horizontal bar at bottom center */

--- a/src/utils/layer-warning.ts
+++ b/src/utils/layer-warning.ts
@@ -1,0 +1,42 @@
+const DISMISS_KEY = 'wm-layer-warning-dismissed';
+let activeDialog: HTMLElement | null = null;
+
+export function showLayerWarning(threshold: number): void {
+  if (localStorage.getItem(DISMISS_KEY) === '1') return;
+  if (activeDialog) return;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'layer-warn-overlay';
+  overlay.innerHTML = `
+    <div class="layer-warn-dialog">
+      <div class="layer-warn-icon">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+          <line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
+        </svg>
+      </div>
+      <div class="layer-warn-text">
+        <strong>Performance notice</strong>
+        <p>Enabling more than ${threshold} layers may impact rendering performance and frame rate.</p>
+      </div>
+      <label class="layer-warn-dismiss">
+        <input type="checkbox" />
+        <span>Don't show this again</span>
+      </label>
+      <button class="layer-warn-ok">Got it</button>
+    </div>`;
+
+  const close = () => {
+    const cb = overlay.querySelector<HTMLInputElement>('.layer-warn-dismiss input');
+    if (cb?.checked) localStorage.setItem(DISMISS_KEY, '1');
+    overlay.classList.add('layer-warn-out');
+    setTimeout(() => { overlay.remove(); activeDialog = null; }, 200);
+  };
+
+  overlay.querySelector('.layer-warn-ok')!.addEventListener('click', close);
+  overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+
+  document.body.appendChild(overlay);
+  activeDialog = overlay;
+  requestAnimationFrame(() => overlay.classList.add('layer-warn-in'));
+}


### PR DESCRIPTION
## Summary
Replaces the hard layer limit (disable checkboxes after 9 in 2D / 6 in 3D) with a non-blocking warning dialog.

- Amber-themed minimalistic dialog with warning icon
- Shows once when crossing the threshold (9 layers in 2D, 6 in 3D)
- "Don't show this again" checkbox persisted via localStorage
- Click backdrop or "Got it" to dismiss
- Smooth fade-in/out with backdrop blur
- All layers remain fully toggleable — user decides

## Test plan
- [ ] 2D: enable 9+ layers — warning dialog appears
- [ ] Dismiss dialog — layers stay enabled, no disable
- [ ] Check "Don't show again" + dismiss — dialog never shows again
- [ ] 3D globe: enable 6+ layers — same warning behavior
- [ ] Clear `wm-layer-warning-dismissed` from localStorage — dialog reappears