### PR TITLE
fix: gracefully skip seed write when validation fails (empty data)

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -119,7 +119,9 @@ export async function atomicPublish(canonicalKey, data, validateFn, ttlSeconds) 
 
   if (validateFn) {
     const valid = validateFn(data);
-    if (!valid) throw new Error('Validation failed for seed data');
+    if (!valid) {
+      return { payloadBytes: 0, skipped: true };
+    }
   }
 
   // Write to staging key
@@ -233,7 +235,15 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
 
   try {
     const data = await withRetry(fetchFn);
-    const { payloadBytes } = await atomicPublish(canonicalKey, data, validateFn, ttlSeconds);
+    const publishResult = await atomicPublish(canonicalKey, data, validateFn, ttlSeconds);
+    if (publishResult.skipped) {
+      const durationMs = Date.now() - startMs;
+      console.log(`  SKIPPED: validation failed (empty data) — preserving existing cache`);
+      console.log(`\n=== Done (${Math.round(durationMs)}ms, no write) ===`);
+      await releaseLock(`${domain}:${resource}`, runId);
+      process.exit(0);
+    }
+    const { payloadBytes } = publishResult;
     const recordCount = Array.isArray(data) ? data.length
       : (data?.events?.length ?? data?.earthquakes?.length ?? data?.outages?.length
         ?? data?.fireDetections?.length ?? data?.anomalies?.length ?? data?.threats?.length


### PR DESCRIPTION
## Summary
- At midnight UTC, FIRMS API returns 0 fire detections due to date rollover
- Previously, `atomicPublish` threw a FATAL error when `validateFn` rejected empty data, crashing the seed with exit code 1
- Now it exits cleanly (code 0), preserving existing cached data in Redis

## Changes
- `atomicPublish()` returns `{ skipped: true }` instead of throwing when validation fails
- `runSeed()` handles the skip gracefully — logs a warning and exits 0
- Applies to all seeds using `validateFn`, not just fire detections

## Test plan
- [ ] Verify fire detections seed runs successfully during normal hours
- [ ] Verify seed exits 0 (not 1) when FIRMS returns empty data at midnight UTC
- [ ] Verify existing Redis cache is preserved when skip occurs