### PR TITLE
fix(api): replace debug console.log with console.warn in server handlers

### DIFF
--- a/server/worldmonitor/aviation/v1/_shared.ts
+++ b/server/worldmonitor/aviation/v1/_shared.ts
@@ -215,11 +215,10 @@ export async function fetchAviationStackDelays(
 ): Promise<AviationStackResult> {
   const apiKey = process.env.AVIATIONSTACK_API;
   if (!apiKey) {
-    console.log('[Aviation] No AVIATIONSTACK_API key — skipping');
+    console.warn('[Aviation] No AVIATIONSTACK_API key — skipping');
     return { alerts: [], healthy: false };
   }
 
-  console.log(`[Aviation] Querying ${allAirports.length} airports (concurrency=${BATCH_CONCURRENCY})`);
   const alerts: AirportDelayAlert[] = [];
   let succeeded = 0, failed = 0;
   const deadline = Date.now() + 50_000;
@@ -244,7 +243,7 @@ export async function fetchAviationStackDelays(
   }
 
   const healthy = allAirports.length < 5 || failed <= succeeded;
-  console.log(`[Aviation] Done: ${succeeded} ok, ${failed} failed, ${alerts.length} alerts, healthy=${healthy}`);
+  console.warn(`[Aviation] Done: ${succeeded} ok, ${failed} failed, ${alerts.length} alerts, healthy=${healthy}`);
   if (!healthy) {
     console.warn(`[Aviation] Systemic failure: ${failed}/${failed + succeeded} airports failed`);
   }
@@ -278,11 +277,6 @@ async function fetchSingleAirport(
     }
     const flights = json?.data ?? [];
     const alert = aggregateFlights(airport, flights);
-    if (flights.length > 0) {
-      const cancelled = flights.filter(f => f.flight_status === 'cancelled').length;
-      const delayed = flights.filter(f => f.departure?.delay && f.departure.delay > 0).length;
-      console.log(`[Aviation] ${airport.iata}: ${flights.length} flights, ${cancelled} cancelled, ${delayed} delayed → ${alert ? alert.severity.replace('FLIGHT_DELAY_SEVERITY_', '') : 'normal'}`);
-    }
     return { ok: true, alert };
   } catch (err) {
     console.warn(`[Aviation] ${airport.iata}: fetch error: ${err instanceof Error ? err.message : 'unknown'}`);
@@ -394,7 +388,7 @@ export async function fetchNotamClosures(
   const apiKey = process.env.ICAO_API_KEY;
   const result: NotamClosureResult = { closedIcaoCodes: new Set(), notamsByIcao: new Map() };
   if (!apiKey) {
-    console.log('[Aviation] NOTAM: no ICAO_API_KEY — skipping');
+    console.warn('[Aviation] NOTAM: no ICAO_API_KEY — skipping');
     return result;
   }
 
@@ -410,7 +404,6 @@ export async function fetchNotamClosures(
     if (relayBase) {
       // Route through Railway relay — avoids Vercel edge timeout / CloudFront blocking
       const relayUrl = `${relayBase}/notam?locations=${encodeURIComponent(locations)}`;
-      console.log(`[Aviation] NOTAM: fetching via relay for ${icaoCodes.length} airports`);
       const resp = await fetch(relayUrl, {
         headers: getRelayHeaders(),
         signal: AbortSignal.timeout(30_000),
@@ -423,7 +416,6 @@ export async function fetchNotamClosures(
       if (Array.isArray(data)) notams = data;
     } else {
       // Direct ICAO call (slower from Vercel, may timeout)
-      console.log(`[Aviation] NOTAM: fetching direct for ${icaoCodes.length} airports`);
       const url = `${ICAO_NOTAM_URL}?api_key=${apiKey}&format=json&locations=${locations}`;
       const resp = await fetch(url, {
         headers: { 'User-Agent': CHROME_UA },
@@ -446,8 +438,6 @@ export async function fetchNotamClosures(
     return result;
   }
 
-  console.log(`[Aviation] NOTAM: ${notams.length} raw NOTAMs received`);
-
   for (const n of notams) {
     const icao = n.itema || n.location || '';
     if (!icao || !icaoCodes.includes(icao)) continue;
@@ -467,9 +457,7 @@ export async function fetchNotamClosures(
   }
 
   if (result.closedIcaoCodes.size > 0) {
-    console.log(`[Aviation] NOTAM closures: ${[...result.closedIcaoCodes].join(', ')}`);
-  } else {
-    console.log('[Aviation] NOTAM: no closures found');
+    console.warn(`[Aviation] NOTAM closures: ${[...result.closedIcaoCodes].join(', ')}`);
   }
   return result;
 }

--- a/server/worldmonitor/aviation/v1/list-airport-delays.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-delays.ts
@@ -53,7 +53,6 @@ export async function listAirportDelays(
         })
         .filter((a): a is AirportDelayAlert => a !== null);
       faaFromSeed = true;
-      console.log(`[Aviation] FAA: ${faaAlerts.length} alerts (from seed, age ${Math.round(seedAge / 60000)}m)`);
     }
   } catch {}
   // Live fallback: only reached if seed is missing/stale AND SEED_FALLBACK_FAA is set.
@@ -107,7 +106,6 @@ export async function listAirportDelays(
       }
     );
     faaAlerts = result?.alerts ?? [];
-    console.log(`[Aviation] FAA: ${faaAlerts.length} alerts`);
   } catch (err) {
     console.warn(`[Aviation] FAA fetch failed: ${err instanceof Error ? err.message : 'unknown'}`);
   }
@@ -119,11 +117,9 @@ export async function listAirportDelays(
     const cached = await getCachedJson(INTL_CACHE_KEY) as { alerts: AirportDelayAlert[] } | null;
     if (cached?.alerts) {
       intlAlerts = cached.alerts;
-      console.log(`[Aviation] Intl: ${intlAlerts.length} alerts (from cache)`);
     } else {
       const nonUs = MONITORED_AIRPORTS.filter(a => a.country !== 'USA');
       intlAlerts = nonUs.map(a => generateSimulatedDelay(a)).filter(Boolean) as AirportDelayAlert[];
-      console.log(`[Aviation] Intl: cache miss — ${intlAlerts.length} simulated alerts`);
     }
   } catch (err) {
     console.warn(`[Aviation] Intl fetch failed: ${err instanceof Error ? err.message : 'unknown'}`);
@@ -140,7 +136,6 @@ export async function listAirportDelays(
     if (seedNotam && (notamAge < SEED_FRESHNESS_MS || !process.env.SEED_FALLBACK_NOTAM)) {
       notamResult = seedNotam;
       notamFromSeed = true;
-      console.log(`[Aviation] NOTAM: ${seedNotam.closedIcaos?.length || 0} closures (from seed, age ${Math.round(notamAge / 60000)}m)`);
     }
   } catch {}
   // Same stampede-safe design as FAA above: no live fetch unless SEED_FALLBACK_NOTAM is set.
@@ -175,7 +170,7 @@ export async function listAirportDelays(
         allAlerts.push(buildNotamAlert(airport, reason));
       }
     }
-    console.log(`[Aviation] NOTAM: ${notamResult.closedIcaos.length} closures applied`);
+    console.warn(`[Aviation] NOTAM: ${notamResult.closedIcaos.length} closures applied`);
   }
 
   // 4. Fill in ALL monitored airports with no alerts as "normal operations"
@@ -206,8 +201,6 @@ export async function listAirportDelays(
       });
     }
   }
-
-  console.log(`[Aviation] Total: ${allAlerts.length} alerts (${normalCount} normal) in ${Date.now() - t0}ms`);
 
   // Write bootstrap key for initial page load hydration
   try {

--- a/server/worldmonitor/military/v1/get-usni-fleet-report.ts
+++ b/server/worldmonitor/military/v1/get-usni-fleet-report.ts
@@ -357,7 +357,6 @@ function parseUSNIArticle(
 // ========================================================================
 
 async function fetchUSNIReport(): Promise<USNIFleetReport | null> {
-  console.log('[USNI Fleet] Fetching from WordPress API...');
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 15000);
 
@@ -387,7 +386,7 @@ async function fetchUSNIReport(): Promise<USNIFleetReport | null> {
   if (!htmlContent) return null;
 
   const report = parseUSNIArticle(htmlContent, articleUrl, articleDate, articleTitle);
-  console.log(`[USNI Fleet] Parsed: ${report.vessels.length} vessels, ${report.strikeGroups.length} CSGs, ${report.regions.length} regions`);
+  console.warn(`[USNI Fleet] Parsed: ${report.vessels.length} vessels, ${report.strikeGroups.length} CSGs, ${report.regions.length} regions`);
 
   if (report.parsingWarnings.length > 0) {
     console.warn('[USNI Fleet] Warnings:', report.parsingWarnings.join('; '));
@@ -417,7 +416,6 @@ export async function getUSNIFleetReport(
       USNI_CACHE_KEY, USNI_CACHE_TTL, fetchUSNIReport,
     );
     if (report) {
-      if (source === 'cache') console.log('[USNI Fleet] Cache hit');
       return { report, cached: source === 'cache', stale: false, error: '' };
     }
 
@@ -428,7 +426,7 @@ export async function getUSNIFleetReport(
 
     const stale = (await getCachedJson(USNI_STALE_CACHE_KEY)) as USNIFleetReport | null;
     if (stale) {
-      console.log('[USNI Fleet] Returning stale cached data');
+      console.warn('[USNI Fleet] Returning stale cached data');
       return { report: stale, cached: true, stale: true, error: 'Using cached data' };
     }
 


### PR DESCRIPTION
## Summary
Supersedes #827 by @NewCoder3294 — rebased on current `main` which added seed-based paths with additional `console.log` calls.

All **21** `console.log` calls in `server/worldmonitor/` cleaned up:
- **Upgraded to `console.warn`** (8): missing API keys, stale fallbacks, operational summaries, NOTAM closures detected
- **Removed** (13): debug traces (fetch start, per-airport stats, cache hits, routine totals, "no closures found")
- **Dead code removed**: unused `cancelled`/`delayed` variables in `fetchSingleAirport` after their log was removed

Zero `console.log` remaining in `server/`.

### Files changed (3)
- `server/worldmonitor/aviation/v1/_shared.ts`
- `server/worldmonitor/aviation/v1/list-airport-delays.ts`
- `server/worldmonitor/military/v1/get-usni-fleet-report.ts`

Co-authored-by: Nicolas Dos Santos <NewCoder3294@users.noreply.github.com>

Closes #827

## Test plan
- [x] `tsc --noEmit` passes
- [x] Zero `console.log` in `server/worldmonitor/`
- [ ] Verify aviation and military endpoints still function with expected warn-level output