### PR TITLE
feat(map): add per-provider map theme selector

### DIFF
--- a/docs/MAP_ENGINE.md
+++ b/docs/MAP_ENGINE.md
@@ -39,7 +39,21 @@ The flat map supports multiple tile providers, selectable at runtime via **Setti
 3. Set `VITE_PMTILES_URL=https://your-server.example/planet.pmtiles` in `.env.local`
 4. The PMTiles and Auto options will appear in Settings
 
-**Fallback behavior**: When using PMTiles or Auto mode, if tile loading fails (CORS errors, server downtime, 403s), the map automatically falls back to OpenFreeMap after detecting 2+ errors within 10 seconds. A console warning is logged when fallback activates.
+### Map Themes
+
+Each tile provider offers different visual themes, selectable via **Settings → Map Theme**. The theme selection is **per-provider** — switching providers remembers each provider's last-used theme. Map theme is fully independent of the app theme (Auto/Dark/Light); the app theme only affects UI chrome, while the map theme controls basemap appearance.
+
+| Provider | Available Themes | Default |
+|----------|-----------------|---------|
+| **PMTiles** | Black (deepest dark), Dark, Grayscale, Light, White | Black |
+| **OpenFreeMap** | Dark, Positron (light) | Dark |
+| **CARTO** | Dark Matter, Voyager (light), Positron (light) | Dark Matter |
+
+**Sprite mapping**: PMTiles themes `black`, `dark`, and `grayscale` use the `dark` Protomaps sprite sheet; `light` and `white` use the `light` sprite sheet.
+
+**Overlay paint adaptation**: Country highlight/hover paint colors automatically adapt to the selected map theme (not the app theme), using lower opacity on light themes for visibility.
+
+**Fallback behavior**: When using PMTiles or Auto mode, if tile loading fails (CORS errors, server downtime, 403s), the map automatically falls back to OpenFreeMap after detecting 2+ errors within 10 seconds. The fallback respects the current map theme's light/dark nature — a light PMTiles theme falls back to OpenFreeMap Positron, not Dark. A console warning is logged when fallback activates.
 
 **Flat Map (deck.gl + MapLibre GL JS)** — a WebGL-accelerated 2D map with smooth 60fps rendering and thousands of concurrent markers:
 

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -7,7 +7,7 @@ import { MapboxOverlay } from '@deck.gl/mapbox';
 import type { Layer, LayersList, PickingInfo } from '@deck.gl/core';
 import { GeoJsonLayer, ScatterplotLayer, PathLayer, IconLayer, TextLayer, PolygonLayer } from '@deck.gl/layers';
 import maplibregl from 'maplibre-gl';
-import { registerPMTilesProtocol, FALLBACK_DARK_STYLE, FALLBACK_LIGHT_STYLE, getMapProvider, getStyleForProvider } from '@/config/basemap';
+import { registerPMTilesProtocol, FALLBACK_DARK_STYLE, FALLBACK_LIGHT_STYLE, getMapProvider, getMapTheme, getStyleForProvider, isLightMapTheme } from '@/config/basemap';
 import Supercluster from 'supercluster';
 import type {
   MapLayers,
@@ -389,7 +389,8 @@ export class DeckGLMap {
   private debouncedFetchBases: (() => void) & { cancel(): void };
   private debouncedFetchAircraft: (() => void) & { cancel(): void };
   private rafUpdateLayers: (() => void) & { cancel(): void };
-  private handleThemeChange: (e: Event) => void;
+  private handleThemeChange: () => void;
+  private handleMapThemeChange: () => void;
   private moveTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private lastAircraftFetchCenter: [number, number] | null = null;
   private lastAircraftFetchZoom = -1;
@@ -417,14 +418,23 @@ export class DeckGLMap {
     this.setupDOM();
     this.popup = new MapPopup(container);
 
-    this.handleThemeChange = (e: Event) => {
-      const theme = (e as CustomEvent).detail?.theme as 'dark' | 'light';
-      if (theme) {
-        this.switchBasemap(theme);
-        this.render(); // Rebuilds Deck.GL layers with new theme-aware colors
+    this.handleThemeChange = () => {
+      if (isHappyVariant) {
+        this.switchBasemap();
+        return;
       }
+      const provider = getMapProvider();
+      const mapTheme = getMapTheme(provider);
+      const paintTheme = isLightMapTheme(mapTheme) ? 'light' as const : 'dark' as const;
+      this.updateCountryLayerPaint(paintTheme);
+      this.render();
     };
     window.addEventListener('theme-changed', this.handleThemeChange);
+
+    this.handleMapThemeChange = () => {
+      this.switchBasemap();
+    };
+    window.addEventListener('map-theme-changed', this.handleMapThemeChange);
 
     this.initMapLibre();
 
@@ -500,10 +510,10 @@ export class DeckGLMap {
     if (initialProvider === 'pmtiles' || initialProvider === 'auto') registerPMTilesProtocol();
 
     const preset = VIEW_PRESETS[this.state.view];
-    const initialTheme = getCurrentTheme();
+    const initialMapTheme = getMapTheme(initialProvider);
     const primaryStyle = isHappyVariant
-      ? (initialTheme === 'light' ? HAPPY_LIGHT_STYLE : HAPPY_DARK_STYLE)
-      : getStyleForProvider(initialProvider, initialTheme);
+      ? (getCurrentTheme() === 'light' ? HAPPY_LIGHT_STYLE : HAPPY_DARK_STYLE)
+      : getStyleForProvider(initialProvider, initialMapTheme);
     if (!isHappyVariant && typeof primaryStyle === 'string' && !primaryStyle.includes('pmtiles')) {
       this.usedFallbackStyle = true;
       const attr = this.container.querySelector('.map-attribution');
@@ -531,7 +541,7 @@ export class DeckGLMap {
     const recreateWithFallback = () => {
       if (this.usedFallbackStyle) return;
       this.usedFallbackStyle = true;
-      const fallback = initialTheme === 'light' ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE;
+      const fallback = isLightMapTheme(initialMapTheme) ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE;
       console.warn(`[DeckGLMap] Primary basemap failed, recreating with fallback: ${fallback}`);
       const attr = this.container.querySelector('.map-attribution');
       if (attr) attr.innerHTML = '© <a href="https://openfreemap.org" target="_blank" rel="noopener">OpenFreeMap</a> © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a>';
@@ -4872,7 +4882,9 @@ export class DeckGLMap {
         });
 
         if (!this.countryHoverSetup) this.setupCountryHover();
-        this.updateCountryLayerPaint(getCurrentTheme());
+        const paintProvider = getMapProvider();
+        const paintMapTheme = getMapTheme(paintProvider);
+        this.updateCountryLayerPaint(isLightMapTheme(paintMapTheme) ? 'light' : 'dark');
         if (this.highlightedCountryCode) this.highlightCountry(this.highlightedCountryCode);
       })
       .catch((err) => console.warn('[DeckGLMap] Failed to load country boundaries:', err));
@@ -4933,31 +4945,32 @@ export class DeckGLMap {
     } catch { /* layer not ready */ }
   }
 
-  private switchBasemap(theme: 'dark' | 'light'): void {
+  private switchBasemap(): void {
     if (!this.maplibreMap) return;
     const provider = getMapProvider();
+    const mapTheme = getMapTheme(provider);
     const style = isHappyVariant
-      ? (theme === 'light' ? HAPPY_LIGHT_STYLE : HAPPY_DARK_STYLE)
+      ? (getCurrentTheme() === 'light' ? HAPPY_LIGHT_STYLE : HAPPY_DARK_STYLE)
       : (this.usedFallbackStyle && provider === 'auto')
-        ? (theme === 'light' ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE)
-        : getStyleForProvider(provider, theme);
+        ? (isLightMapTheme(mapTheme) ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE)
+        : getStyleForProvider(provider, mapTheme);
     this.maplibreMap.setStyle(style);
     this.countryGeoJsonLoaded = false;
     this.maplibreMap.once('style.load', () => {
       localizeMapLabels(this.maplibreMap);
       this.loadCountryBoundaries();
-      this.updateCountryLayerPaint(theme);
+      const paintTheme = isLightMapTheme(mapTheme) ? 'light' as const : 'dark' as const;
+      this.updateCountryLayerPaint(paintTheme);
       this.render();
     });
   }
 
   public reloadBasemap(): void {
     if (!this.maplibreMap) return;
-    const theme = document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
     const provider = getMapProvider();
     if (provider === 'pmtiles' || provider === 'auto') registerPMTilesProtocol();
     this.usedFallbackStyle = false;
-    this.switchBasemap(theme as 'dark' | 'light');
+    this.switchBasemap();
   }
 
   private updateCountryLayerPaint(theme: 'dark' | 'light'): void {
@@ -4972,6 +4985,7 @@ export class DeckGLMap {
 
   public destroy(): void {
     window.removeEventListener('theme-changed', this.handleThemeChange);
+    window.removeEventListener('map-theme-changed', this.handleMapThemeChange);
     this.debouncedRebuildLayers.cancel();
     this.debouncedFetchBases.cancel();
     this.debouncedFetchAircraft.cancel();

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -3,7 +3,7 @@ import { PANEL_CATEGORY_MAP } from '@/config/panels';
 import { SITE_VARIANT } from '@/config/variant';
 import { LANGUAGES, changeLanguage, getCurrentLanguage, t } from '@/services/i18n';
 import { getAiFlowSettings, setAiFlowSetting, getStreamQuality, setStreamQuality, STREAM_QUALITY_OPTIONS } from '@/services/ai-flow-settings';
-import { getMapProvider, setMapProvider, MAP_PROVIDER_OPTIONS, type MapProvider } from '@/config/basemap';
+import { getMapProvider, setMapProvider, MAP_PROVIDER_OPTIONS, MAP_THEME_OPTIONS, getMapTheme, setMapTheme, type MapProvider } from '@/config/basemap';
 import { getLiveStreamsAlwaysOn, setLiveStreamsAlwaysOn } from '@/services/live-stream-settings';
 import { getGlobeVisualPreset, setGlobeVisualPreset, GLOBE_VISUAL_PRESET_OPTIONS, type GlobeVisualPreset } from '@/services/globe-render-settings';
 import type { StreamQuality } from '@/services/ai-flow-settings';
@@ -217,7 +217,16 @@ export class UnifiedSettings {
       if (target.id === 'us-map-provider') {
         const provider = target.value as MapProvider;
         setMapProvider(provider);
+        this.renderMapThemeDropdown(provider);
         this.config.onMapProviderChange?.(provider);
+        window.dispatchEvent(new CustomEvent('map-theme-changed'));
+        return;
+      }
+
+      if (target.id === 'us-map-theme') {
+        const provider = getMapProvider();
+        setMapTheme(provider, target.value);
+        window.dispatchEvent(new CustomEvent('map-theme-changed'));
         return;
       }
 
@@ -407,6 +416,21 @@ export class UnifiedSettings {
     }
     html += `</select>`;
 
+    // Map theme dropdown
+    const currentMapTheme = getMapTheme(currentProvider);
+    html += `<div class="ai-flow-toggle-row">
+      <div class="ai-flow-toggle-label-wrap">
+        <div class="ai-flow-toggle-label">Map Theme</div>
+        <div class="ai-flow-toggle-desc">Visual style of the map tiles. Options vary by provider.</div>
+      </div>
+    </div>`;
+    html += `<select class="unified-settings-select" id="us-map-theme">`;
+    for (const opt of MAP_THEME_OPTIONS[currentProvider]) {
+      const selected = opt.value === currentMapTheme ? ' selected' : '';
+      html += `<option value="${opt.value}"${selected}>${opt.label}</option>`;
+    }
+    html += `</select>`;
+
     html += this.toggleRowHtml('us-map-flash', t('components.insights.mapFlashLabel'), t('components.insights.mapFlashDesc'), settings.mapNewsFlash);
 
     // Panels section
@@ -510,6 +534,15 @@ export class UnifiedSettings {
     }
 
     return html;
+  }
+
+  private renderMapThemeDropdown(provider: MapProvider): void {
+    const select = this.overlay.querySelector<HTMLSelectElement>('#us-map-theme');
+    if (!select) return;
+    const currentTheme = getMapTheme(provider);
+    select.innerHTML = MAP_THEME_OPTIONS[provider]
+      .map(opt => `<option value="${opt.value}"${opt.value === currentTheme ? ' selected' : ''}>${opt.label}</option>`)
+      .join('');
   }
 
   private toggleRowHtml(id: string, label: string, desc: string, checked: boolean): string {

--- a/src/config/basemap.ts
+++ b/src/config/basemap.ts
@@ -16,13 +16,17 @@ export function registerPMTilesProtocol(): void {
   maplibregl.addProtocol('pmtiles', protocol.tile);
 }
 
-export function buildPMTilesStyle(theme: 'dark' | 'light'): StyleSpecification | null {
+export type PMTilesTheme = 'black' | 'dark' | 'grayscale' | 'light' | 'white';
+export type OpenFreeMapTheme = 'dark' | 'positron';
+export type CartoTheme = 'dark-matter' | 'voyager' | 'positron';
+
+export function buildPMTilesStyle(flavor: PMTilesTheme): StyleSpecification | null {
   if (!hasTilesUrl) return null;
-  const flavor = theme === 'light' ? 'light' : 'dark';
+  const spriteName = ['light', 'white'].includes(flavor) ? 'light' : 'dark';
   return {
     version: 8,
     glyphs: 'https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf',
-    sprite: `https://protomaps.github.io/basemaps-assets/sprites/v4/${flavor}`,
+    sprite: `https://protomaps.github.io/basemaps-assets/sprites/v4/${spriteName}`,
     sources: {
       basemap: {
         type: 'vector',
@@ -40,6 +44,7 @@ export const FALLBACK_LIGHT_STYLE = 'https://tiles.openfreemap.org/styles/positr
 export type MapProvider = 'auto' | 'pmtiles' | 'openfreemap' | 'carto';
 
 const STORAGE_KEY = 'wm-map-provider';
+const THEME_STORAGE_PREFIX = 'wm-map-theme:';
 
 export { hasTilesUrl as hasPMTilesUrl };
 
@@ -53,6 +58,35 @@ export const MAP_PROVIDER_OPTIONS: { value: MapProvider; label: string }[] = (()
   opts.push({ value: 'carto', label: 'CARTO' });
   return opts;
 })();
+
+const PMTILES_THEMES: { value: string; label: string }[] = [
+  { value: 'black', label: 'Black (deepest dark)' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'grayscale', label: 'Grayscale' },
+  { value: 'light', label: 'Light' },
+  { value: 'white', label: 'White' },
+];
+
+export const MAP_THEME_OPTIONS: Record<MapProvider, { value: string; label: string }[]> = {
+  pmtiles: PMTILES_THEMES,
+  auto: PMTILES_THEMES,
+  openfreemap: [
+    { value: 'dark', label: 'Dark' },
+    { value: 'positron', label: 'Positron (light)' },
+  ],
+  carto: [
+    { value: 'dark-matter', label: 'Dark Matter' },
+    { value: 'voyager', label: 'Voyager (light)' },
+    { value: 'positron', label: 'Positron (light)' },
+  ],
+};
+
+const DEFAULT_THEME: Record<MapProvider, string> = {
+  pmtiles: 'black',
+  auto: 'black',
+  openfreemap: 'dark',
+  carto: 'dark-matter',
+};
 
 export function getMapProvider(): MapProvider {
   const stored = localStorage.getItem(STORAGE_KEY) as MapProvider | null;
@@ -69,24 +103,54 @@ export function setMapProvider(provider: MapProvider): void {
   localStorage.setItem(STORAGE_KEY, provider);
 }
 
-const CARTO_DARK = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
-const CARTO_LIGHT = 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json';
+export function getMapTheme(provider: MapProvider): string {
+  const stored = localStorage.getItem(THEME_STORAGE_PREFIX + provider);
+  const options = MAP_THEME_OPTIONS[provider];
+  if (stored && options.some(o => o.value === stored)) return stored;
+  return DEFAULT_THEME[provider];
+}
 
-export function getStyleForProvider(provider: MapProvider, theme: 'dark' | 'light'): StyleSpecification | string {
+export function setMapTheme(provider: MapProvider, theme: string): void {
+  const options = MAP_THEME_OPTIONS[provider];
+  if (!options.some(o => o.value === theme)) return;
+  localStorage.setItem(THEME_STORAGE_PREFIX + provider, theme);
+}
+
+export function isLightMapTheme(mapTheme: string): boolean {
+  return ['light', 'white', 'positron', 'voyager'].includes(mapTheme);
+}
+
+const CARTO_DARK = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
+const CARTO_VOYAGER = 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json';
+const CARTO_POSITRON = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+
+const CARTO_STYLES: Record<string, string> = {
+  'dark-matter': CARTO_DARK,
+  'voyager': CARTO_VOYAGER,
+  'positron': CARTO_POSITRON,
+};
+
+function asPMTilesTheme(mapTheme: string): PMTilesTheme {
+  const valid = PMTILES_THEMES.some(o => o.value === mapTheme);
+  return (valid ? mapTheme : 'black') as PMTilesTheme;
+}
+
+export function getStyleForProvider(provider: MapProvider, mapTheme: string): StyleSpecification | string {
+  const lightFallback = isLightMapTheme(mapTheme);
   switch (provider) {
     case 'pmtiles': {
-      const style = buildPMTilesStyle(theme);
+      const style = buildPMTilesStyle(asPMTilesTheme(mapTheme));
       if (style) return style;
-      return theme === 'light' ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE;
+      return lightFallback ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE;
     }
     case 'openfreemap':
-      return theme === 'light' ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE;
+      return mapTheme === 'positron' ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE;
     case 'carto':
-      return theme === 'light' ? CARTO_LIGHT : CARTO_DARK;
+      return CARTO_STYLES[mapTheme] ?? CARTO_DARK;
     case 'auto':
     default: {
-      const pmtiles = buildPMTilesStyle(theme);
-      return pmtiles ?? (theme === 'light' ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE);
+      const pmtiles = buildPMTilesStyle(asPMTilesTheme(mapTheme));
+      return pmtiles ?? (lightFallback ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE);
     }
   }
 }

--- a/src/utils/settings-persistence.ts
+++ b/src/utils/settings-persistence.ts
@@ -28,6 +28,7 @@ const SETTINGS_KEY_PREFIXES = [
   'wm-breaking-alerts-v1',
   'wm-globe-render-scale',
   'wm-live-streams-always-on',
+  'wm-map-theme:',
   'map-height',
   'map-pinned',
   'mobile-map-collapsed',


### PR DESCRIPTION
## Summary

- Add **Map Theme** dropdown in Settings below Map Tile Provider
- Each provider has different visual themes (PMTiles: 5, OpenFreeMap: 2, CARTO: 3)
- PMTiles default changed from `dark` to `black` (much darker, closer to CARTO dark-matter)
- Theme is per-provider and persisted independently — switching providers remembers each one's last theme
- Map theme is fully independent of app theme (Auto/Dark/Light); app theme only affects UI chrome
- Overlay paint (country highlights) adapts to map theme lightness, not app theme
- Fallback style respects theme lightness (light PMTiles falls back to OpenFreeMap Positron)

## Files Changed

| File | Change |
|------|--------|
| `src/config/basemap.ts` | Theme types, `MAP_THEME_OPTIONS`, `getMapTheme/setMapTheme`, `isLightMapTheme`, validated `asPMTilesTheme`, updated `buildPMTilesStyle` and `getStyleForProvider` |
| `src/components/UnifiedSettings.ts` | Map Theme dropdown, dynamic options per provider, `map-theme-changed` event |
| `src/components/DeckGLMap.ts` | Decouple `theme-changed` (overlay only) from basemap. New `map-theme-changed` listener. Refactored `switchBasemap()` |
| `src/utils/settings-persistence.ts` | `wm-map-theme:` prefix for export/import |
| `docs/MAP_ENGINE.md` | Map Themes documentation section |

## Test plan

- [ ] Settings → Map Theme dropdown appears below Map Tile Provider
- [ ] Switching provider updates theme options dynamically
- [ ] PMTiles "Black" renders very dark (earth `#141414`)
- [ ] PMTiles "Light" / "White" renders light map with light sprites
- [ ] OpenFreeMap "Dark" vs "Positron" both work
- [ ] CARTO "Dark Matter" / "Voyager" / "Positron" all work
- [ ] Theme persists per-provider after reload
- [ ] Provider switch → theme shows that provider's last-used (or default)
- [ ] App theme toggle (Auto/Dark/Light) does NOT change basemap
- [ ] Country hover/highlight opacity adapts to map theme lightness
- [ ] Bad `VITE_PMTILES_URL` with light theme → falls back to OpenFreeMap Positron