### PR TITLE
fix(security): harden cache keys against injection and hash collision

### DIFF
--- a/server/_shared/hash.ts
+++ b/server/_shared/hash.ts
@@ -1,14 +1,11 @@
 /**
- * FNV-1a 52-bit hash — stronger than Java hashCode (32-bit) or DJB2 (32-bit).
+ * FNV-1a 52-bit hash — fast, non-cryptographic.
  *
- * Uses 52 bits (JS safe integer range) to greatly reduce collision probability
- * compared to 32-bit hashes. At 77k keys, 32-bit has ~50% collision chance
- * (birthday problem); 52-bit has ~0.00007% chance at 77k keys.
- *
- * Unified implementation replacing two separate hashString functions (H-7 fix).
+ * WARNING: Do NOT use for cache keys derived from attacker-controlled input.
+ * Use sha256Hex() instead for any server-side cache key with user input.
+ * Retained for client-side non-security contexts (e.g. vector-db dedup).
  */
 export function hashString(input: string): string {
-  // FNV-1a parameters adapted for 52-bit output (within JS safe integer range)
   let h = 0xcbf29ce484222325n;
   const FNV_PRIME = 0x100000001b3n;
   const MASK_52 = (1n << 52n) - 1n;
@@ -19,4 +16,18 @@ export function hashString(input: string): string {
   }
 
   return Number(h).toString(36);
+}
+
+/**
+ * SHA-256 hex digest via Web Crypto (available in Edge/Vercel/Node 18+).
+ * Use for all server-side cache keys derived from user-controlled input.
+ */
+export async function sha256Hex(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(input),
+  );
+  return Array.from(new Uint8Array(buf))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
 }

--- a/server/worldmonitor/intelligence/v1/_shared.ts
+++ b/server/worldmonitor/intelligence/v1/_shared.ts
@@ -25,4 +25,4 @@ export const TIER1_COUNTRIES: Record<string, string> = {
 // Helpers
 // ========================================================================
 
-export { hashString } from '../../../_shared/hash';
+export { hashString, sha256Hex } from '../../../_shared/hash';

--- a/server/worldmonitor/intelligence/v1/classify-event.ts
+++ b/server/worldmonitor/intelligence/v1/classify-event.ts
@@ -7,7 +7,7 @@ import type {
 
 import { cachedFetchJson } from '../../../_shared/redis';
 import { markNoCacheResponse } from '../../../_shared/response-headers';
-import { UPSTREAM_TIMEOUT_MS, GROQ_API_URL, GROQ_MODEL, hashString } from './_shared';
+import { UPSTREAM_TIMEOUT_MS, GROQ_API_URL, GROQ_MODEL, sha256Hex } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
 
 // ========================================================================
@@ -48,7 +48,7 @@ export async function classifyEvent(
   const title = typeof req.title === 'string' ? req.title.slice(0, MAX_TITLE_LEN) : '';
   if (!title) { markNoCacheResponse(ctx.request); return { classification: undefined }; }
 
-  const cacheKey = `classify:sebuf:v1:${hashString(title.toLowerCase())}`;
+  const cacheKey = `classify:sebuf:v1:${(await sha256Hex(title.toLowerCase())).slice(0, 16)}`;
 
   let cached: { level: string; category: string; timestamp: number } | null = null;
   try {

--- a/server/worldmonitor/intelligence/v1/deduct-situation.ts
+++ b/server/worldmonitor/intelligence/v1/deduct-situation.ts
@@ -5,7 +5,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/intelligence/v1/service_server';
 
 import { cachedFetchJson } from '../../../_shared/redis';
-import { hashString } from './_shared';
+import { sha256Hex } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
 
 const DEDUCT_TIMEOUT_MS = 120_000;
@@ -33,7 +33,7 @@ export async function deductSituation(
 
     if (!query) return { analysis: '', model: '', provider: 'skipped' };
 
-    const cacheKey = `deduct:situation:v1:${hashString(query.toLowerCase() + '|' + geoContext.toLowerCase())}`;
+    const cacheKey = `deduct:situation:v1:${(await sha256Hex(query.toLowerCase() + '|' + geoContext.toLowerCase())).slice(0, 16)}`;
 
     const cached = await cachedFetchJson<{ analysis: string; model: string; provider: string }>(
         cacheKey,

--- a/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
@@ -5,7 +5,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/intelligence/v1/service_server';
 
 import { cachedFetchJson } from '../../../_shared/redis';
-import { UPSTREAM_TIMEOUT_MS, GROQ_API_URL, GROQ_MODEL, TIER1_COUNTRIES, hashString } from './_shared';
+import { UPSTREAM_TIMEOUT_MS, GROQ_API_URL, GROQ_MODEL, TIER1_COUNTRIES, sha256Hex } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
 
 // ========================================================================
@@ -45,7 +45,7 @@ export async function getCountryIntelBrief(
     contextSnapshot = '';
   }
 
-  const contextHash = contextSnapshot ? hashString(contextSnapshot) : 'base';
+  const contextHash = contextSnapshot ? (await sha256Hex(contextSnapshot)).slice(0, 16) : 'base';
   const cacheKey = `ci-sebuf:v2:${req.countryCode}:${lang}:${contextHash}`;
   const countryName = TIER1_COUNTRIES[req.countryCode] || req.countryCode;
   const dateStr = new Date().toISOString().split('T')[0];

--- a/server/worldmonitor/intelligence/v1/search-gdelt-documents.ts
+++ b/server/worldmonitor/intelligence/v1/search-gdelt-documents.ts
@@ -8,6 +8,7 @@ import type {
 import { UPSTREAM_TIMEOUT_MS } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
 import { cachedFetchJson } from '../../../_shared/redis';
+import { sha256Hex } from '../../../_shared/hash';
 
 const REDIS_CACHE_KEY = 'intel:gdelt-docs:v1';
 const REDIS_CACHE_TTL = 600; // 10 min
@@ -28,9 +29,13 @@ export async function searchGdeltDocuments(
   _ctx: ServerContext,
   req: SearchGdeltDocumentsRequest,
 ): Promise<SearchGdeltDocumentsResponse> {
+  const MAX_QUERY_LEN = 500;
   let query = req.query;
   if (!query || query.length < 2) {
     return { articles: [], query: query || '', error: 'Query parameter required (min 2 characters)' };
+  }
+  if (query.length > MAX_QUERY_LEN) {
+    return { articles: [], query, error: 'Query too long' };
   }
 
   // Append tone filter to query if provided (e.g., "tone>5" for positive articles)
@@ -45,7 +50,8 @@ export async function searchGdeltDocuments(
   const timespan = req.timespan || '72h';
 
   try {
-    const cacheKey = `${REDIS_CACHE_KEY}:${query}:${timespan}:${maxRecords}`;
+    const keyHash = await sha256Hex(`${query}|${timespan}|${maxRecords}`);
+    const cacheKey = `${REDIS_CACHE_KEY}:${keyHash}`;
     const result = await cachedFetchJson<SearchGdeltDocumentsResponse>(
       cacheKey,
       REDIS_CACHE_TTL,

--- a/src/utils/summary-cache-key.ts
+++ b/src/utils/summary-cache-key.ts
@@ -26,7 +26,7 @@ export function buildSummaryCacheKey(
 ): string {
   const canon = canonicalizeSummaryInputs(headlines, geoContext);
   const sorted = canon.headlines.slice(0, MAX_HEADLINES_FOR_KEY).sort().join('|');
-  const geoHash = canon.geoContext ? ':g' + hashString(canon.geoContext).slice(0, 6) : '';
+  const geoHash = canon.geoContext ? ':g' + hashString(canon.geoContext) : '';
   const hash = hashString(`${mode}:${sorted}`);
   const normalizedVariant = typeof variant === 'string' && variant ? variant.toLowerCase() : 'full';
   const normalizedLang = typeof lang === 'string' && lang ? lang.toLowerCase() : 'en';


### PR DESCRIPTION
## Summary

Addresses security advisory WM-2026-001 / WM-2026-002 (reported via responsible disclosure by Cody Richard).

- **CVE-1**: `search-gdelt-documents.ts` — raw user query was interpolated directly into Redis cache key with no hashing and no length limit. Fixed with 500-char upper bound + SHA-256 hash.
- **CVE-2**: `get-country-intel-brief.ts` — attacker-controlled `?context=` URL param was hashed with FNV-1a (52-bit, non-cryptographic). Replaced with `sha256Hex()` (truncated to 16 hex chars = 64 bits).
- **BONUS**: `summary-cache-key.ts` — `.slice(0, 6)` truncation collapsed geoHash space from 2^52 to ~2.18B values. Removed truncation.
- **Hardened**: `classify-event.ts` and `deduct-situation.ts` — same `hashString()` → `sha256Hex()` migration for consistency.

New `sha256Hex()` utility added to `server/_shared/hash.ts` using `crypto.subtle.digest('SHA-256')` (available on Edge/Vercel/Node 18+).

**Note**: Existing Redis cache keys will naturally expire (10min–24hr TTLs). No migration needed — the key format change just means a one-time cache miss for each entry.

## Test plan

- [x] `tsc --noEmit` passes (both main and API configs)
- [x] All 60 edge function tests pass
- [ ] Verify GDELT search still returns results after deploy
- [ ] Verify country intel brief generates and caches correctly
- [ ] Verify event classification caching works