### PR TITLE
fix(ui): unify panel tab styles to underline pattern

### DIFF
--- a/src/components/AirlineIntelPanel.ts
+++ b/src/components/AirlineIntelPanel.ts
@@ -378,10 +378,10 @@ export class AirlineIntelPanel extends Panel {
         const style = document.createElement('style');
         style.id = 'airline-intel-styles';
         style.textContent = `
-      .airline-intel-tabs { display:flex;gap:2px;padding:4px 6px 0;flex-wrap:wrap;border-bottom:1px solid var(--border-color,#333); }
-      .airline-intel-tabs .tab-btn { background:none;border:none;color:var(--text-secondary,#9ca3af);cursor:pointer;font-size:12px;padding:5px 8px;border-radius:4px 4px 0 0;transition:color .15s,background .15s; }
-      .airline-intel-tabs .tab-btn:hover { color:var(--text-primary,#e5e7eb); }
-      .airline-intel-tabs .tab-btn.active { color:var(--accent,#60a5fa);border-bottom:2px solid var(--accent,#60a5fa);background:rgba(96,165,250,.08); }
+      .airline-intel-tabs { display:flex;gap:2px;padding:8px 10px 0;flex-wrap:wrap;border-bottom:1px solid var(--border); }
+      .airline-intel-tabs .tab-btn { background:transparent;border:none;border-bottom:2px solid transparent;color:var(--text-dim,#9ca3af);cursor:pointer;font-size:11px;padding:6px 10px;transition:all .15s ease;white-space:nowrap; }
+      .airline-intel-tabs .tab-btn:hover { color:var(--text); }
+      .airline-intel-tabs .tab-btn.active { color:var(--accent);border-bottom-color:var(--accent); }
       .airline-intel-content { overflow-y:auto;max-height:320px;padding:8px; }
       .ops-grid,.flights-list,.carriers-list,.tracking-list { display:flex;flex-direction:column;gap:4px; }
       .ops-row,.flight-row,.carrier-row,.track-row { display:flex;gap:8px;align-items:center;font-size:12px;padding:4px;border-radius:4px;transition:background .15s; }

--- a/src/styles/happy-theme.css
+++ b/src/styles/happy-theme.css
@@ -323,10 +323,12 @@
 }
 
 /* ==========================================================
-   Happy Tab Styles — Rounded tabs
+   Happy Tab Styles — Rounded boxed tabs (intentionally different)
    ========================================================== */
 [data-variant="happy"] .disp-tab,
 [data-variant="happy"] .ucdp-tab {
+  border: 1px solid var(--border-strong);
+  border-bottom: 1px solid var(--border-strong);
   border-radius: 8px;
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -7688,37 +7688,64 @@ a.prediction-link:hover {
 .economic-tabs {
   display: flex;
   gap: 2px;
-  padding: 6px 8px;
+  padding: 8px 10px 0;
   border-bottom: 1px solid var(--border);
-  background: var(--darken-heavy);
 }
 
 .economic-tab {
-  flex: 1;
-  padding: 4px 8px;
-  font-size: 10px;
-  border: none;
   background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
   color: var(--text-dim);
+  padding: 6px 10px;
+  font-size: 11px;
   cursor: pointer;
-  border-radius: 4px;
-  transition: all 0.15s;
+  transition: all 0.15s ease;
+  white-space: nowrap;
 }
 
 .economic-tab:hover {
-  background: rgba(68, 255, 136, 0.1);
   color: var(--text);
 }
 
 .economic-tab.active {
-  background: rgba(68, 255, 136, 0.2);
-  color: var(--green);
+  color: var(--accent);
+  border-bottom-color: var(--accent);
 }
 
 .economic-content {
   padding: 8px;
   max-height: 300px;
   overflow-y: auto;
+}
+
+/* Regulation Panel Tabs */
+.regulation-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 8px 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.regulation-tabs .tab {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  padding: 6px 10px;
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.regulation-tabs .tab:hover {
+  color: var(--text);
+}
+
+.regulation-tabs .tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
 }
 
 .economic-empty {
@@ -12610,31 +12637,30 @@ a.prediction-link:hover {
 
 .tech-events-tabs {
   display: flex;
-  gap: 4px;
-  padding: 0 2px;
+  gap: 2px;
+  padding: 8px 10px 0;
+  border-bottom: 1px solid var(--border);
 }
 
 .tech-events-tabs .tab {
-  flex: 1;
-  padding: 5px 8px;
   background: transparent;
-  border: 1px solid var(--border);
-  border-radius: 4px;
+  border: none;
+  border-bottom: 2px solid transparent;
   color: var(--text-dim);
-  font-size: 9px;
+  padding: 6px 10px;
+  font-size: 11px;
   cursor: pointer;
   transition: all 0.15s ease;
+  white-space: nowrap;
 }
 
 .tech-events-tabs .tab:hover {
-  background: var(--overlay-light);
   color: var(--text);
 }
 
 .tech-events-tabs .tab.active {
-  background: var(--accent);
-  color: var(--bg);
-  border-color: var(--accent);
+  color: var(--accent);
+  border-bottom-color: var(--accent);
 }
 
 .tech-events-stats {

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -306,29 +306,29 @@
 .disp-tabs {
   display: flex;
   gap: 2px;
-  margin-bottom: 6px;
+  padding: 8px 10px 0;
+  border-bottom: 1px solid var(--border);
 }
 
 .disp-tab {
   background: transparent;
-  border: 1px solid var(--border-strong);
+  border: none;
+  border-bottom: 2px solid transparent;
   color: var(--text-dim);
-  padding: 4px 14px;
+  padding: 6px 10px;
   font-size: 11px;
   cursor: pointer;
-  border-radius: 3px;
-  transition: all 0.15s;
+  transition: all 0.15s ease;
+  white-space: nowrap;
 }
 
 .disp-tab:hover {
-  border-color: var(--text-faint);
-  color: var(--text-secondary);
+  color: var(--text);
 }
 
 .disp-tab-active {
-  background: color-mix(in srgb, var(--threat-critical) 10%, transparent);
-  border-color: var(--threat-critical);
-  color: var(--threat-critical);
+  color: var(--accent);
+  border-bottom-color: var(--accent);
 }
 
 .disp-table {
@@ -419,28 +419,29 @@
 .ucdp-tabs {
   display: flex;
   gap: 2px;
+  padding: 8px 10px 0;
+  border-bottom: 1px solid var(--border);
 }
 
 .ucdp-tab {
   background: transparent;
-  border: 1px solid var(--border-strong);
+  border: none;
+  border-bottom: 2px solid transparent;
   color: var(--text-dim);
-  padding: 4px 10px;
+  padding: 6px 10px;
   font-size: 11px;
   cursor: pointer;
-  border-radius: 3px;
-  transition: all 0.15s;
+  transition: all 0.15s ease;
+  white-space: nowrap;
 }
 
 .ucdp-tab:hover {
-  border-color: var(--text-faint);
-  color: var(--text-secondary);
+  color: var(--text);
 }
 
 .ucdp-tab-active {
-  background: color-mix(in srgb, var(--threat-critical) 10%, transparent);
-  border-color: var(--threat-critical);
-  color: var(--threat-critical);
+  color: var(--accent);
+  border-bottom-color: var(--accent);
 }
 
 .ucdp-tab-count {
@@ -709,30 +710,30 @@
 .giving-tabs {
   display: flex;
   gap: 2px;
-  margin-bottom: 6px;
+  padding: 8px 10px 0;
+  border-bottom: 1px solid var(--border);
   flex-wrap: wrap;
 }
 
 .giving-tab {
   background: transparent;
-  border: 1px solid var(--border-strong);
+  border: none;
+  border-bottom: 2px solid transparent;
   color: var(--text-dim);
-  padding: 4px 10px;
+  padding: 6px 10px;
   font-size: 11px;
   cursor: pointer;
-  border-radius: 3px;
-  transition: all 0.15s;
+  transition: all 0.15s ease;
+  white-space: nowrap;
 }
 
 .giving-tab:hover {
-  border-color: var(--text-faint);
-  color: var(--text-secondary);
+  color: var(--text);
 }
 
 .giving-tab-active {
-  background: color-mix(in srgb, var(--semantic-positive, #44ff88) 10%, transparent);
-  border-color: var(--semantic-positive, #44ff88);
-  color: var(--semantic-positive, #44ff88);
+  color: var(--accent);
+  border-bottom-color: var(--accent);
 }
 
 .giving-table {


### PR DESCRIPTION
## Summary

Standardize all tabbed panels to the Live Intelligence underline tab style (border-bottom accent) for visual consistency across all "serious" variants (full, tech, finance, commodity).

**9 panels unified:**
- AirlineIntelPanel — removed background tint on active tab
- DisplacementPanel — boxed → underline
- UcdpEventsPanel — boxed → underline  
- GivingPanel — boxed → underline
- EconomicPanel — filled bg → underline
- TradePolicyPanel — shares economic-tab (updated)
- SupplyChainPanel — shares economic-tab (updated)
- TechEventsPanel — pill → underline
- RegulationPanel — added missing tab CSS (was unstyled)

Happy variant intentionally preserves its rounded boxed tab style via theme overrides.

## Test plan

- [ ] Verify tab appearance on each panel listed above
- [ ] Verify happy variant still has rounded boxed tabs on displacement/UCDP panels
- [ ] Check tab hover and active states work correctly