### PR TITLE
fix(webcams): detect blocked YouTube embeds on web, not just desktop

### DIFF
--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -249,8 +249,7 @@ export class LiveWebcamsPanel extends Panel {
       return `http://localhost:${getLocalApiPort()}/api/youtube-embed?${params.toString()}`;
     }
     const vq = quality !== 'auto' ? `&vq=${quality}` : '';
-    const origin = encodeURIComponent(window.location.origin);
-    return `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&mute=1&controls=0&modestbranding=1&playsinline=1&rel=0&enablejsapi=1&origin=${origin}${vq}`;
+    return `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&mute=1&controls=0&modestbranding=1&playsinline=1&rel=0&enablejsapi=1&origin=${window.location.origin}${vq}`;
   }
 
   private createIframe(feed: WebcamFeed): HTMLIFrameElement {
@@ -374,6 +373,7 @@ export class LiveWebcamsPanel extends Panel {
 
     // YouTube native API (web) posts JSON strings: '{"event":"onReady",...}'
     if (typeof msg === 'string') {
+      if (msg[0] !== '{') return;
       try {
         const parsed = JSON.parse(msg) as { event?: string; info?: { playerState?: number } };
         if (parsed.event === 'onReady' || parsed.event === 'initialDelivery') {


### PR DESCRIPTION
## Summary
Closes the gap where web users behind GFW/corporate firewalls saw broken YouTube iframes with no feedback in the Webcams panel. Desktop already had a 15s watchdog via sidecar `postMessage` — this extends it to web.

### Changes (1 file)
- **`enablejsapi=1`** added to web embed URLs → YouTube sends native postMessage events
- **Removed `isDesktopRuntime()` guard** on the 15s iframe timeout → now applies to all platforms
- **Dual postMessage handling**: YouTube native format (JSON strings like `{"event":"onReady"}`) alongside desktop sidecar format (`{type: "yt-ready"}`)
- On timeout → existing "blocked or failed" overlay with Retry + Open on YouTube

### How it works
1. Iframe created → 15s watchdog timer starts
2. YouTube loads successfully → sends `onReady` or `infoDelivery` postMessage → timer cleared
3. YouTube blocked (GFW/firewall) → no message → timeout fires → blocked overlay shown
4. User clicks Retry → fresh iframe replaces the blocked one

### What was NOT changed
- LiveNewsPanel already has its own error handling via YT IFrame Player API `onError` + bot check timeout
- No new files or services created — reuses existing `WebcamIframeTracker` infrastructure

## Test plan
- [ ] Web: verify webcams load normally (timeout should clear before 15s)
- [ ] Web: simulate block (DevTools → Network → block `youtube-nocookie.com`) → blocked overlay appears after 15s
- [ ] Desktop: verify existing sidecar-based detection still works
- [ ] Retry button works after block detection