### PR TITLE
fix(panels): preserve panel order across refresh

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -62,6 +62,7 @@ export class PanelLayoutManager implements AppModule {
   private ctx: AppContext;
   private callbacks: PanelLayoutCallbacks;
   private panelDragCleanupHandlers: Array<() => void> = [];
+  private resolvedPanelOrder: string[] = [];
   private criticalBannerEl: HTMLElement | null = null;
   private aviationCommandBar: AviationCommandBar | null = null;
   private readonly applyTimeRangeFilterDebounced: (() => void) & { cancel(): void };
@@ -857,12 +858,22 @@ export class PanelLayoutManager implements AppModule {
     const savedBottomOrder = this.getSavedBottomPanelOrder();
     const isUltraWide = window.innerWidth >= 1600;
 
+    const hasSavedOrder = savedOrder.length > 0 || savedBottomOrder.length > 0;
     let panelOrder = defaultOrder;
-    if (savedOrder.length > 0 || savedBottomOrder.length > 0) {
+    let bottomPanelOrder: string[] = [];
+
+    if (hasSavedOrder) {
       const allSaved = [...savedOrder, ...savedBottomOrder];
       const missing = defaultOrder.filter(k => !allSaved.includes(k));
       const valid = savedOrder.filter(k => defaultOrder.includes(k));
-      const validBottom = isUltraWide ? savedBottomOrder.filter(k => defaultOrder.includes(k)) : [];
+      const validBottom = savedBottomOrder.filter(k => defaultOrder.includes(k));
+
+      // On non-ultrawide, merge bottom panels back into sidebar at end
+      if (!isUltraWide) {
+        valid.push(...validBottom);
+      } else {
+        bottomPanelOrder = validBottom;
+      }
 
       const monitorsIdx = valid.indexOf('monitors');
       if (monitorsIdx !== -1) valid.splice(monitorsIdx, 1);
@@ -874,8 +885,8 @@ export class PanelLayoutManager implements AppModule {
       }
       panelOrder = valid;
 
-      // Handle bottom panels
-      validBottom.forEach(key => {
+      // Handle bottom panels (ultrawide only)
+      bottomPanelOrder.forEach(key => {
         const panel = this.ctx.panels[key];
         if (panel) {
           const el = panel.getElement();
@@ -885,30 +896,36 @@ export class PanelLayoutManager implements AppModule {
       });
     }
 
-    if (SITE_VARIANT !== 'happy') {
-      const liveNewsIdx = panelOrder.indexOf('live-news');
-      if (liveNewsIdx > 0) {
-        panelOrder.splice(liveNewsIdx, 1);
-        panelOrder.unshift('live-news');
+    // Only force panel positions when using default order (no user customization)
+    if (!hasSavedOrder) {
+      if (SITE_VARIANT !== 'happy') {
+        const liveNewsIdx = panelOrder.indexOf('live-news');
+        if (liveNewsIdx > 0) {
+          panelOrder.splice(liveNewsIdx, 1);
+          panelOrder.unshift('live-news');
+        }
+
+        const webcamsIdx = panelOrder.indexOf('live-webcams');
+        if (webcamsIdx !== -1 && webcamsIdx !== panelOrder.indexOf('live-news') + 1) {
+          panelOrder.splice(webcamsIdx, 1);
+          const afterNews = panelOrder.indexOf('live-news') + 1;
+          panelOrder.splice(afterNews, 0, 'live-webcams');
+        }
       }
 
-      const webcamsIdx = panelOrder.indexOf('live-webcams');
-      if (webcamsIdx !== -1 && webcamsIdx !== panelOrder.indexOf('live-news') + 1) {
-        panelOrder.splice(webcamsIdx, 1);
-        const afterNews = panelOrder.indexOf('live-news') + 1;
-        panelOrder.splice(afterNews, 0, 'live-webcams');
+      if (this.ctx.isDesktopApp) {
+        const runtimeIdx = panelOrder.indexOf('runtime-config');
+        if (runtimeIdx > 1) {
+          panelOrder.splice(runtimeIdx, 1);
+          panelOrder.splice(1, 0, 'runtime-config');
+        } else if (runtimeIdx === -1) {
+          panelOrder.splice(1, 0, 'runtime-config');
+        }
       }
     }
 
-    if (this.ctx.isDesktopApp) {
-      const runtimeIdx = panelOrder.indexOf('runtime-config');
-      if (runtimeIdx > 1) {
-        panelOrder.splice(runtimeIdx, 1);
-        panelOrder.splice(1, 0, 'runtime-config');
-      } else if (runtimeIdx === -1) {
-        panelOrder.splice(1, 0, 'runtime-config');
-      }
-    }
+    // Store resolved order so lazy panels can insert at correct position
+    this.resolvedPanelOrder = [...panelOrder, ...bottomPanelOrder];
 
     panelOrder.forEach((key: string) => {
       const panel = this.ctx.panels[key];
@@ -1151,8 +1168,35 @@ export class PanelLayoutManager implements AppModule {
       if (setup) setup(panel);
       const el = panel.getElement();
       this.makeDraggable(el, key);
+
+      // Check if this panel belongs in the bottom grid (ultrawide only)
+      const bottomGrid = document.getElementById('mapBottomGrid');
+      const savedBottom = this.getSavedBottomPanelOrder();
+      if (bottomGrid && window.innerWidth >= 1600 && savedBottom.includes(key)) {
+        bottomGrid.appendChild(el);
+        return;
+      }
+
+      // Insert at saved position in sidebar grid instead of always appending
       const grid = document.getElementById('panelsGrid');
-      if (grid) grid.appendChild(el);
+      if (!grid) return;
+      const savedIdx = this.resolvedPanelOrder.indexOf(key);
+      if (savedIdx === -1) {
+        grid.appendChild(el);
+        return;
+      }
+
+      // Find the first panel in resolvedPanelOrder AFTER this one that is already in the grid
+      let inserted = false;
+      for (let i = savedIdx + 1; i < this.resolvedPanelOrder.length; i++) {
+        const nextEl = grid.querySelector(`[data-panel="${this.resolvedPanelOrder[i]}"]`);
+        if (nextEl) {
+          grid.insertBefore(el, nextEl);
+          inserted = true;
+          break;
+        }
+      }
+      if (!inserted) grid.appendChild(el);
     }).catch((err) => {
       console.error(`[panel] failed to lazy-load "${key}"`, err);
     });


### PR DESCRIPTION
## Summary
Fixes #1108 — panels shifting positions (e.g., bottom-left → bottom-right) on page reload.

Three bugs found and fixed in `panel-layout.ts`:

- **Bottom-grid panels orphaned on non-ultrawide**: Panels dragged to the bottom grid were saved separately but silently dropped on refresh at <1600px width. Now merged back into sidebar order.
- **Forced reordering stomped saved order**: `live-news`, `live-webcams`, and `runtime-config` were force-repositioned on every load, shifting all other panels by ±1 slot (left↔right column flip in 2-col grid). Now only applies to default order — user-customized layouts are respected exactly.
- **Lazy-loaded panels ignored saved order**: `telegram-intel`, `displacement`, `climate`, and other async panels always appended to grid end on resolve. Now insert at their saved position using `resolvedPanelOrder` with sibling lookup.

## Test plan
- [ ] Arrange panels in custom order → refresh → order preserved exactly
- [ ] Drag telegram-intel to a specific position → refresh → stays in that position
- [ ] On ultrawide (≥1600px): drag panel to bottom grid → refresh → stays in bottom grid
- [ ] On ultrawide: drag panel to bottom grid → resize to <1600px → panel moves to sidebar end
- [ ] First-time user (clear localStorage) → default order with live-news at top
- [ ] New panel added to defaults → appears at correct position without breaking saved order