### PR TITLE
fix(panels): lazy panel race conditions + server feed gaps

### DIFF
--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -33,12 +33,18 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'EuroNews', url: 'https://www.euronews.com/rss?format=xml' },
       { name: 'Le Monde', url: 'https://www.lemonde.fr/en/rss/une.xml' },
       { name: 'DW News', url: 'https://rss.dw.com/xml/rss-en-all' },
+      { name: 'Tagesschau', url: 'https://www.tagesschau.de/xml/rss2/', lang: 'de' },
+      { name: 'ANSA', url: 'https://www.ansa.it/sito/ansait_rss.xml', lang: 'it' },
+      { name: 'NOS Nieuws', url: 'https://feeds.nos.nl/nosnieuwsalgemeen', lang: 'nl' },
+      { name: 'SVT Nyheter', url: 'https://www.svt.se/nyheter/rss.xml', lang: 'sv' },
     ],
     middleeast: [
       { name: 'BBC Middle East', url: 'https://feeds.bbci.co.uk/news/world/middle_east/rss.xml' },
       { name: 'Al Jazeera', url: 'https://www.aljazeera.com/xml/rss/all.xml' },
       { name: 'Guardian ME', url: 'https://www.theguardian.com/world/middleeast/rss' },
       { name: 'Oman Observer', url: 'https://www.omanobserver.om/rssFeed/1' },
+      { name: 'BBC Persian', url: 'https://feeds.bbci.co.uk/persian/rss.xml', lang: 'fa' },
+      { name: 'The National', url: 'https://www.thenationalnews.com/arc/outboundfeeds/rss/?outputType=xml' },
     ],
     tech: [
       { name: 'Hacker News', url: 'https://hnrss.org/frontpage' },
@@ -68,10 +74,15 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'SEC', url: 'https://www.sec.gov/news/pressreleases.rss' },
       { name: 'UN News', url: 'https://news.un.org/feed/subscribe/en/news/all/rss.xml' },
       { name: 'CISA', url: 'https://www.cisa.gov/cybersecurity-advisories/all.xml' },
+      { name: 'Treasury', url: gn('site:treasury.gov') },
+      { name: 'DOJ', url: gn('site:justice.gov') },
     ],
     africa: [
       { name: 'BBC Africa', url: 'https://feeds.bbci.co.uk/news/world/africa/rss.xml' },
       { name: 'News24', url: 'https://feeds.news24.com/articles/news24/TopStories/rss' },
+      { name: 'Africanews', url: 'https://www.africanews.com/feed/' },
+      { name: 'Jeune Afrique', url: 'https://www.jeuneafrique.com/feed/', lang: 'fr' },
+      { name: 'Premium Times', url: 'https://www.premiumtimesng.com/feed' },
     ],
     latam: [
       { name: 'BBC Latin America', url: 'https://feeds.bbci.co.uk/news/world/latin_america/rss.xml' },
@@ -79,6 +90,8 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'Primicias', url: 'https://www.primicias.ec/feed/', lang: 'es' },
       { name: 'Infobae Americas', url: 'https://www.infobae.com/feeds/rss/', lang: 'es' },
       { name: 'El Universo', url: 'https://www.eluniverso.com/arc/outboundfeeds/rss/category/noticias/?outputType=xml', lang: 'es' },
+      { name: 'Clarín', url: 'https://www.clarin.com/rss/lo-ultimo/', lang: 'es' },
+      { name: 'InSight Crime', url: 'https://insightcrime.org/feed/' },
     ],
     asia: [
       { name: 'BBC Asia', url: 'https://feeds.bbci.co.uk/news/world/asia/rss.xml' },
@@ -86,14 +99,21 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'Nikkei Asia', url: gn('site:asia.nikkei.com when:3d') },
       { name: 'CNA', url: 'https://www.channelnewsasia.com/api/v1/rss-outbound-feed?_format=xml' },
       { name: 'NDTV', url: 'https://feeds.feedburner.com/ndtvnews-top-stories' },
+      { name: 'South China Morning Post', url: gn('site:scmp.com when:2d') },
+      { name: 'The Hindu', url: 'https://www.thehindu.com/feeder/default.rss' },
+      { name: 'Asia News', url: gn('site:asianews.it when:3d') },
     ],
     energy: [
       { name: 'Oil & Gas', url: gn('(oil price OR OPEC OR "natural gas" OR pipeline OR LNG) when:2d') },
+      { name: 'Reuters Energy', url: gn('site:reuters.com energy when:2d') },
+      { name: 'Nuclear Energy', url: gn('("nuclear energy" OR "nuclear power" OR "nuclear reactor") when:3d') },
     ],
     thinktanks: [
       { name: 'Foreign Policy', url: 'https://foreignpolicy.com/feed/' },
       { name: 'Atlantic Council', url: 'https://www.atlanticcouncil.org/feed/' },
       { name: 'Foreign Affairs', url: 'https://www.foreignaffairs.com/rss.xml' },
+      { name: 'War on the Rocks', url: 'https://warontherocks.com/feed/' },
+      { name: 'CSIS', url: 'https://www.csis.org/feed' },
     ],
     crisis: [
       { name: 'CrisisWatch', url: 'https://www.crisisgroup.org/rss' },
@@ -101,7 +121,9 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'WHO', url: 'https://www.who.int/rss-feeds/news-english.xml' },
     ],
     layoffs: [
+      { name: 'Layoffs.fyi', url: gn('tech+company+layoffs+announced') },
       { name: 'TechCrunch Layoffs', url: 'https://techcrunch.com/tag/layoffs/feed/' },
+      { name: 'Layoffs News', url: gn('(layoffs OR "job cuts" OR "workforce reduction") when:3d') },
     ],
   },
 
@@ -167,6 +189,7 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'The New Stack', url: 'https://thenewstack.io/feed/' },
     ],
     layoffs: [
+      { name: 'Layoffs.fyi', url: gn('tech+layoffs+when:7d') },
       { name: 'TechCrunch Layoffs', url: 'https://techcrunch.com/tag/layoffs/feed/' },
     ],
     finance: [

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1,4 +1,5 @@
 import type { AppContext, AppModule } from '@/app/app-context';
+import { enqueuePanelCall } from '@/app/pending-panel-data';
 import type { NewsItem, MapLayers, SocialUnrestEvent } from '@/types';
 import type { MarketData } from '@/types';
 import type { TimeRange } from '@/components';
@@ -103,19 +104,12 @@ import {
   EconomicPanel,
   TechReadinessPanel,
   UcdpEventsPanel,
-  DisplacementPanel,
-  ClimateAnomalyPanel,
-  PopulationExposurePanel,
   TradePolicyPanel,
   SupplyChainPanel,
-  SecurityAdvisoriesPanel,
-  OrefSirensPanel,
-  TelegramIntelPanel,
 } from '@/components';
 import { SatelliteFiresPanel } from '@/components/SatelliteFiresPanel';
 import { classifyNewsItem } from '@/services/positive-classifier';
 import { fetchGivingSummary } from '@/services/giving';
-import { GivingPanel } from '@/components';
 import { fetchProgressData } from '@/services/progress-data';
 import { fetchConservationWins } from '@/services/conservation-data';
 import { fetchRenewableEnergyData, fetchEnergyCapacity } from '@/services/renewable-energy-data';
@@ -177,6 +171,17 @@ export class DataLoaderManager implements AppModule {
   }, 120);
 
   public updateSearchIndex: () => void = () => {};
+
+  private callPanel(key: string, method: string, ...args: unknown[]): void {
+    const panel = this.ctx.panels[key];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const obj = panel as any;
+    if (obj && typeof obj[method] === 'function') {
+      obj[method](...args);
+      return;
+    }
+    enqueuePanelCall(key, method, args);
+  }
 
   private boundMarketWatchlistHandler: (() => void) | null = null;
 
@@ -359,7 +364,7 @@ export class DataLoaderManager implements AppModule {
           return;
         }
         const data = givingResult.data;
-        (this.ctx.panels['giving'] as GivingPanel)?.setData(data);
+        this.callPanel('giving', 'setData', data);
         if (data.platforms.length > 0) dataFreshness.recordUpdate('giving', data.platforms.length);
       }),
     });
@@ -1426,7 +1431,7 @@ export class DataLoaderManager implements AppModule {
           return;
         }
         const data = unhcrResult.data;
-        (this.ctx.panels['displacement'] as DisplacementPanel)?.setData(data);
+        this.callPanel('displacement', 'setData', data);
         ingestDisplacementForCII(data.countries);
         if (this.ctx.mapLayers.displacement && data.topFlows) {
           this.ctx.map?.setDisplacementFlows(data.topFlows);
@@ -1446,7 +1451,7 @@ export class DataLoaderManager implements AppModule {
           return;
         }
         const anomalies = climateResult.anomalies;
-        (this.ctx.panels['climate'] as ClimateAnomalyPanel)?.setAnomalies(anomalies);
+        this.callPanel('climate', 'setAnomalies', anomalies);
         ingestClimateForCII(anomalies);
         if (this.ctx.mapLayers.climate) {
           this.ctx.map?.setClimateAnomalies(anomalies);
@@ -1468,14 +1473,14 @@ export class DataLoaderManager implements AppModule {
     tasks.push((async () => {
       try {
         const data = await fetchOrefAlerts();
-        (this.ctx.panels['oref-sirens'] as OrefSirensPanel)?.setData(data);
+        this.callPanel('oref-sirens', 'setData', data);
         const alertCount = data.alerts?.length ?? 0;
         const historyCount24h = data.historyCount24h ?? 0;
         ingestOrefForCII(alertCount, historyCount24h);
         this.ctx.intelligenceCache.orefAlerts = { alertCount, historyCount24h };
         if (data.alerts?.length) dispatchOrefBreakingAlert(data.alerts);
         onOrefAlertsUpdate((update) => {
-          (this.ctx.panels['oref-sirens'] as OrefSirensPanel)?.setData(update);
+          this.callPanel('oref-sirens', 'setData', update);
           const updAlerts = update.alerts?.length ?? 0;
           const updHistory = update.historyCount24h ?? 0;
           ingestOrefForCII(updAlerts, updHistory);
@@ -1527,10 +1532,10 @@ export class DataLoaderManager implements AppModule {
       ];
       if (events.length > 0) {
         const exposures = await enrichEventsWithExposure(events);
-        (this.ctx.panels['population-exposure'] as PopulationExposurePanel)?.setExposures(exposures);
+        this.callPanel('population-exposure', 'setExposures', exposures);
         if (exposures.length > 0) dataFreshness.recordUpdate('worldpop', exposures.length);
       } else {
-        (this.ctx.panels['population-exposure'] as PopulationExposurePanel)?.setExposures([]);
+        this.callPanel('population-exposure', 'setExposures', []);
       }
     } catch (error) {
       console.error('[Intelligence] Population exposure fetch failed:', error);
@@ -2240,27 +2245,25 @@ export class DataLoaderManager implements AppModule {
       }));
 
       const scienceSources = ['GNN Science', 'ScienceDaily', 'Nature News', 'Live Science', 'New Scientist', 'Singularity Hub', 'Human Progress', 'Greater Good (Berkeley)'];
-      this.ctx.breakthroughsPanel?.setItems(
+      this.callPanel('breakthroughs', 'setItems',
         items.filter(item => scienceSources.includes(item.source) || item.happyCategory === 'science-health')
       );
-      this.ctx.heroPanel?.setHeroStory(
+      this.callPanel('spotlight', 'setHeroStory',
         items.filter(item => item.happyCategory === 'humanity-kindness')
           .sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime())[0]
       );
-      this.ctx.digestPanel?.setStories(
+      this.callPanel('digest', 'setStories',
         [...items].sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime()).slice(0, 5)
       );
-      this.ctx.positivePanel?.renderPositiveNews(items);
+      this.callPanel('positive-feed', 'renderPositiveNews', items);
     } catch (err) {
       console.warn('[App] Happy panel cache hydration failed:', err);
     }
   }
 
   private async loadHappySupplementaryAndRender(): Promise<void> {
-    if (!this.ctx.positivePanel) return;
-
     const curated = [...this.ctx.happyAllItems];
-    this.ctx.positivePanel.renderPositiveNews(curated);
+    this.callPanel('positive-feed', 'renderPositiveNews', curated);
 
     let supplementary: NewsItem[] = [];
     try {
@@ -2285,24 +2288,24 @@ export class DataLoaderManager implements AppModule {
     if (supplementary.length > 0) {
       const merged = [...curated, ...supplementary];
       merged.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
-      this.ctx.positivePanel.renderPositiveNews(merged);
+      this.callPanel('positive-feed', 'renderPositiveNews', merged);
     }
 
     const scienceSources = ['GNN Science', 'ScienceDaily', 'Nature News', 'Live Science', 'New Scientist', 'Singularity Hub', 'Human Progress', 'Greater Good (Berkeley)'];
     const scienceItems = this.ctx.happyAllItems.filter(item =>
       scienceSources.includes(item.source) || item.happyCategory === 'science-health'
     );
-    this.ctx.breakthroughsPanel?.setItems(scienceItems);
+    this.callPanel('breakthroughs', 'setItems', scienceItems);
 
     const heroItem = this.ctx.happyAllItems
       .filter(item => item.happyCategory === 'humanity-kindness')
       .sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime())[0];
-    this.ctx.heroPanel?.setHeroStory(heroItem);
+    this.callPanel('spotlight', 'setHeroStory', heroItem);
 
     const digestItems = [...this.ctx.happyAllItems]
       .sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime())
       .slice(0, 5);
-    this.ctx.digestPanel?.setStories(digestItems);
+    this.callPanel('digest', 'setStories', digestItems);
 
     setPersistentCache(
       DataLoaderManager.HAPPY_ITEMS_CACHE_KEY,
@@ -2349,12 +2352,12 @@ export class DataLoaderManager implements AppModule {
 
   private async loadProgressData(): Promise<void> {
     const datasets = await fetchProgressData();
-    this.ctx.progressPanel?.setData(datasets);
+    this.callPanel('progress', 'setData', datasets);
   }
 
   private async loadSpeciesData(): Promise<void> {
     const species = await fetchConservationWins();
-    this.ctx.speciesPanel?.setData(species);
+    this.callPanel('species', 'setData', species);
     this.ctx.map?.setSpeciesRecoveryZones(species);
     if (SITE_VARIANT === 'happy' && species.length > 0) {
       checkMilestones({
@@ -2366,7 +2369,7 @@ export class DataLoaderManager implements AppModule {
 
   private async loadRenewableData(): Promise<void> {
     const data = await fetchRenewableEnergyData();
-    this.ctx.renewablePanel?.setData(data);
+    this.callPanel('renewable', 'setData', data);
     if (SITE_VARIANT === 'happy' && data?.globalPercentage) {
       checkMilestones({
         renewablePercent: data.globalPercentage,
@@ -2374,7 +2377,7 @@ export class DataLoaderManager implements AppModule {
     }
     try {
       const capacity = await fetchEnergyCapacity();
-      this.ctx.renewablePanel?.setCapacityData(capacity);
+      this.callPanel('renewable', 'setCapacityData', capacity);
     } catch {
       // EIA failure does not break the existing World Bank gauge
     }
@@ -2384,7 +2387,7 @@ export class DataLoaderManager implements AppModule {
     try {
       const result = await fetchSecurityAdvisories();
       if (result.ok) {
-        (this.ctx.panels['security-advisories'] as SecurityAdvisoriesPanel)?.setData(result.advisories);
+        this.callPanel('security-advisories', 'setData', result.advisories);
         this.ctx.intelligenceCache.advisories = result.advisories;
         ingestAdvisoriesForCII(result.advisories);
       }
@@ -2396,7 +2399,7 @@ export class DataLoaderManager implements AppModule {
   async loadTelegramIntel(): Promise<void> {
     try {
       const result = await fetchTelegramFeed();
-      (this.ctx.panels['telegram-intel'] as TelegramIntelPanel)?.setData(result);
+      this.callPanel('telegram-intel', 'setData', result);
     } catch (error) {
       console.error('[App] Telegram intel fetch failed:', error);
     }

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1,4 +1,5 @@
 import type { AppContext, AppModule } from '@/app/app-context';
+import { replayPendingCalls, clearAllPendingCalls } from '@/app/pending-panel-data';
 import type { RelatedAsset } from '@/types';
 import type { TheaterPostureSummary } from '@/services/military-surge';
 import {
@@ -79,6 +80,7 @@ export class PanelLayoutManager implements AppModule {
   }
 
   destroy(): void {
+    clearAllPendingCalls();
     this.applyTimeRangeFilterDebounced.cancel();
     this.panelDragCleanupHandlers.forEach((cleanup) => cleanup());
     this.panelDragCleanupHandlers = [];
@@ -750,7 +752,11 @@ export class PanelLayoutManager implements AppModule {
       this.ctx.panels['service-status'] = serviceStatusPanel;
 
       this.lazyPanel('tech-readiness', () =>
-        import('@/components/TechReadinessPanel').then(m => new m.TechReadinessPanel()),
+        import('@/components/TechReadinessPanel').then(m => {
+          const p = new m.TechReadinessPanel();
+          void p.refresh();
+          return p;
+        }),
       );
 
       this.ctx.panels['macro-signals'] = new MacroSignalsPanel();
@@ -1137,8 +1143,9 @@ export class PanelLayoutManager implements AppModule {
     loader: () => Promise<T>,
     setup?: (panel: T) => void,
   ): void {
-    loader().then((panel) => {
+    loader().then(async (panel) => {
       this.ctx.panels[key] = panel as unknown as import('@/components/Panel').Panel;
+      await replayPendingCalls(key, panel);
       if (setup) setup(panel);
       const el = panel.getElement();
       this.makeDraggable(el, key);

--- a/src/app/pending-panel-data.ts
+++ b/src/app/pending-panel-data.ts
@@ -1,0 +1,30 @@
+const pendingCalls = new Map<string, Map<string, unknown[]>>();
+
+export function enqueuePanelCall(key: string, method: string, args: unknown[]): void {
+  let methods = pendingCalls.get(key);
+  if (!methods) {
+    methods = new Map();
+    pendingCalls.set(key, methods);
+  }
+  methods.set(method, args);
+}
+
+// Race-safe: panels[key] is set BEFORE replay starts (panel-layout.ts line 1147),
+// so any concurrent callPanel() during async replay takes the direct-call path
+// (not the queue). delete() before iteration prevents double-replay.
+export async function replayPendingCalls(key: string, panel: unknown): Promise<void> {
+  const methods = pendingCalls.get(key);
+  if (!methods) return;
+  pendingCalls.delete(key);
+  for (const [method, args] of methods) {
+    const fn = (panel as Record<string, unknown>)[method];
+    if (typeof fn === 'function') {
+      const result = fn.apply(panel, args);
+      if (result instanceof Promise) await result;
+    }
+  }
+}
+
+export function clearAllPendingCalls(): void {
+  pendingCalls.clear();
+}


### PR DESCRIPTION
## Summary

- **Lazy panel data queue**: 12 of 16 lazy-loaded panels silently dropped data when `data-loader.ts` pushed via `?.setData()` before the panel's dynamic import resolved. New `pending-panel-data.ts` queues calls and replays them once the panel initializes. 21 call sites converted.
- **Server feed gaps**: Added 20 missing feeds to server digest (`_feeds.ts` full variant) matching `DEFAULT_ENABLED_SOURCES` — europe +4, asia +3, africa +3, latam +2, middleeast +2, thinktanks +2, energy +2, gov +2.

## Files changed

| File | Change |
|---|---|
| `src/app/pending-panel-data.ts` | **NEW** — last-write-wins queue per panel key + method |
| `src/app/panel-layout.ts` | `replayPendingCalls` in `lazyPanel`, cleanup in `destroy` |
| `src/app/data-loader.ts` | `callPanel()` helper, 21 call sites, happy early-return fix |
| `server/worldmonitor/news/v1/_feeds.ts` | 20 feeds across 8 categories |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — production build succeeds
- [x] All 20 feed names verified against `DEFAULT_ENABLED_SOURCES`
- [x] Pre-push hooks pass (60 tests, edge function checks, version sync)
- [ ] Post-deploy: verify displacement, climate, giving, spotlight panels render on full variant
- [ ] Post-deploy: verify progress, breakthroughs, digest panels render on happy variant
- [ ] Post-deploy: `curl api.worldmonitor.app/.../ListFeedDigest` shows new categories