### PR TITLE
feat(ai): add MiniMax as LLM summarization provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,15 @@ GROQ_API_KEY=
 # Get yours at: https://openrouter.ai/
 OPENROUTER_API_KEY=
 
+# MiniMax API (OpenAI-compatible, high-speed models)
+# Get yours at: https://platform.minimax.io/user-center/basic-information
+MINIMAX_API_KEY=
+# Optional: override endpoint (default: https://api.minimax.io/v1)
+# For mainland China users: https://api.minimaxi.com/v1
+# MINIMAX_API_URL=https://api.minimaxi.com/v1
+# Optional: override model (default: MiniMax-M2.5)
+# MINIMAX_MODEL=MiniMax-M2.5
+
 
 # ------ Cross-User Cache (Vercel — Upstash Redis) ------
 

--- a/proto/worldmonitor/news/v1/summarize_article.proto
+++ b/proto/worldmonitor/news/v1/summarize_article.proto
@@ -6,7 +6,7 @@ import "buf/validate/validate.proto";
 
 // SummarizeArticleRequest specifies parameters for LLM article summarization.
 message SummarizeArticleRequest {
-  // LLM provider: "ollama", "groq", "openrouter"
+  // LLM provider: "ollama", "groq", "minimax", "openrouter"
   string provider = 1 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.min_len = 1

--- a/server/worldmonitor/news/v1/_shared.ts
+++ b/server/worldmonitor/news/v1/_shared.ts
@@ -180,5 +180,19 @@ export function getProviderCredentials(provider: string): ProviderCredentials | 
     };
   }
 
+  if (provider === 'minimax') {
+    const apiKey = process.env.MINIMAX_API_KEY;
+    if (!apiKey) return null;
+    const baseUrl = process.env.MINIMAX_API_URL || 'https://api.minimax.io/v1';
+    return {
+      apiUrl: new URL('/chat/completions', baseUrl).toString(),
+      model: process.env.MINIMAX_MODEL || 'MiniMax-M2.5',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    };
+  }
+
   return null;
 }

--- a/server/worldmonitor/news/v1/summarize-article.ts
+++ b/server/worldmonitor/news/v1/summarize-article.ts
@@ -51,6 +51,7 @@ export async function summarizeArticle(
     ollama: 'OLLAMA_API_URL not configured',
     groq: 'GROQ_API_KEY not configured',
     openrouter: 'OPENROUTER_API_KEY not configured',
+    minimax: 'MINIMAX_API_KEY not configured',
   };
 
   const credentials = getProviderCredentials(provider);

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -99,7 +99,7 @@ globalThis.fetch = async function ipv4Fetch(input, init) {
 };
 
 const ALLOWED_ENV_KEYS = new Set([
-  'GROQ_API_KEY', 'OPENROUTER_API_KEY', 'FRED_API_KEY', 'EIA_API_KEY',
+  'GROQ_API_KEY', 'OPENROUTER_API_KEY', 'MINIMAX_API_KEY', 'FRED_API_KEY', 'EIA_API_KEY',
   'CLOUDFLARE_API_TOKEN', 'ACLED_ACCESS_TOKEN', 'URLHAUS_AUTH_KEY',
   'OTX_API_KEY', 'ABUSEIPDB_API_KEY', 'WINGBITS_API_KEY', 'WS_RELAY_URL',
   'VITE_OPENSKY_RELAY_URL', 'OPENSKY_CLIENT_ID', 'OPENSKY_CLIENT_SECRET',
@@ -669,6 +669,17 @@ async function validateSecretAgainstProvider(key, rawValue, context = {}) {
       if (isAuthFailure(response.status, text)) return fail('OpenRouter rejected this key');
       if (!response.ok) return fail(`OpenRouter probe failed (${response.status})`);
       return ok('OpenRouter key verified');
+    }
+
+    case 'MINIMAX_API_KEY': {
+      const response = await fetchWithTimeout('https://api.minimax.io/v1/models', {
+        headers: { Authorization: `Bearer ${value}`, 'User-Agent': CHROME_UA },
+      });
+      const text = await response.text();
+      if (isCloudflareChallenge403(response, text)) return ok('MiniMax key stored (Cloudflare blocked verification)');
+      if (isAuthFailure(response.status, text)) return fail('MiniMax rejected this key');
+      if (!response.ok) return fail(`MiniMax probe failed (${response.status})`);
+      return ok('MiniMax key verified');
     }
 
     case 'FRED_API_KEY': {

--- a/src/services/runtime-config.ts
+++ b/src/services/runtime-config.ts
@@ -4,6 +4,7 @@ import { invokeTauri } from './tauri-bridge';
 export type RuntimeSecretKey =
   | 'GROQ_API_KEY'
   | 'OPENROUTER_API_KEY'
+  | 'MINIMAX_API_KEY'
   | 'FRED_API_KEY'
   | 'EIA_API_KEY'
   | 'CLOUDFLARE_API_TOKEN'
@@ -30,6 +31,7 @@ export type RuntimeSecretKey =
 export type RuntimeFeatureId =
   | 'aiGroq'
   | 'aiOpenRouter'
+  | 'aiMiniMax'
   | 'economicFred'
   | 'energyEia'
   | 'internetOutages'
@@ -83,6 +85,7 @@ function getSidecarSecretValidateUrl(): string {
 const defaultToggles: Record<RuntimeFeatureId, boolean> = {
   aiGroq: true,
   aiOpenRouter: true,
+  aiMiniMax: true,
   economicFred: true,
   energyEia: true,
   internetOutages: true,
@@ -124,7 +127,14 @@ export const RUNTIME_FEATURES: RuntimeFeatureDefinition[] = [
     name: 'OpenRouter summarization',
     description: 'Secondary LLM provider for AI summary fallback.',
     requiredSecrets: ['OPENROUTER_API_KEY'],
-    fallback: 'Falls back to local browser model only.',
+    fallback: 'Falls back to MiniMax, then local browser model.',
+  },
+  {
+    id: 'aiMiniMax',
+    name: 'MiniMax summarization',
+    description: 'MiniMax LLM provider for AI summary generation (OpenAI-compatible).',
+    requiredSecrets: ['MINIMAX_API_KEY'],
+    fallback: 'Falls back to OpenRouter, then local browser model.',
   },
   {
     id: 'economicFred',

--- a/src/services/settings-constants.ts
+++ b/src/services/settings-constants.ts
@@ -3,6 +3,7 @@ import type { RuntimeSecretKey, RuntimeFeatureId } from './runtime-config';
 export const SIGNUP_URLS: Partial<Record<RuntimeSecretKey, string>> = {
   GROQ_API_KEY: 'https://console.groq.com/keys',
   OPENROUTER_API_KEY: 'https://openrouter.ai/settings/keys',
+  MINIMAX_API_KEY: 'https://platform.minimax.io/user-center/basic-information',
   FRED_API_KEY: 'https://fred.stlouisfed.org/docs/api/api_key.html',
   EIA_API_KEY: 'https://www.eia.gov/opendata/register.php',
   CLOUDFLARE_API_TOKEN: 'https://dash.cloudflare.com/profile/api-tokens',
@@ -36,6 +37,7 @@ export const MASKED_SENTINEL = '__WM_MASKED__';
 export const HUMAN_LABELS: Record<RuntimeSecretKey, string> = {
   GROQ_API_KEY: 'Groq API Key',
   OPENROUTER_API_KEY: 'OpenRouter API Key',
+  MINIMAX_API_KEY: 'MiniMax API Key',
   FRED_API_KEY: 'FRED API Key',
   EIA_API_KEY: 'EIA API Key',
   CLOUDFLARE_API_TOKEN: 'Cloudflare API Token',
@@ -70,7 +72,7 @@ export const SETTINGS_CATEGORIES: SettingsCategory[] = [
   {
     id: 'ai',
     label: 'AI & Summarization',
-    features: ['aiOllama', 'aiGroq', 'aiOpenRouter'],
+    features: ['aiOllama', 'aiGroq', 'aiMiniMax', 'aiOpenRouter'],
   },
   {
     id: 'economy',

--- a/src/services/summarization.ts
+++ b/src/services/summarization.ts
@@ -17,7 +17,7 @@ import { NewsServiceClient, type SummarizeArticleResponse } from '@/generated/cl
 import { createCircuitBreaker } from '@/utils';
 import { buildSummaryCacheKey } from '@/utils/summary-cache-key';
 
-export type SummarizationProvider = 'ollama' | 'groq' | 'openrouter' | 'browser' | 'cache';
+export type SummarizationProvider = 'ollama' | 'groq' | 'openrouter' | 'minimax' | 'browser' | 'cache';
 
 export interface SummarizationResult {
   summary: string;
@@ -51,6 +51,7 @@ interface ApiProviderDef {
 const API_PROVIDERS: ApiProviderDef[] = [
   { featureId: 'aiOllama',      provider: 'ollama',     label: 'Ollama' },
   { featureId: 'aiGroq',        provider: 'groq',       label: 'Groq AI' },
+  { featureId: 'aiMiniMax',     provider: 'minimax',    label: 'MiniMax' },
   { featureId: 'aiOpenRouter',  provider: 'openrouter', label: 'OpenRouter' },
 ];
 

--- a/tests/minimax-provider.test.mjs
+++ b/tests/minimax-provider.test.mjs
@@ -1,0 +1,198 @@
+/**
+ * Tests for MiniMax LLM provider implementation.
+ *
+ * Verifies:
+ * - Provider credential resolution
+ * - API URL construction
+ * - Model configuration
+ * - Header configuration
+ * - Environment variable handling
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+const readSrc = (relPath) => readFileSync(resolve(root, relPath), 'utf-8');
+
+// ========================================================================
+// Source code verification tests
+// ========================================================================
+
+describe('MiniMax provider: source code verification', () => {
+  const src = readSrc('server/worldmonitor/news/v1/_shared.ts');
+
+  it('includes minimax provider in getProviderCredentials', () => {
+    assert.match(src, /if\s*\(\s*provider\s*===\s*['"]minimax['"]\s*\)/,
+      'Should have minimax provider case in getProviderCredentials');
+  });
+
+  it('reads MINIMAX_API_KEY from environment', () => {
+    assert.match(src, /process\.env\.MINIMAX_API_KEY/,
+      'Should read MINIMAX_API_KEY from environment');
+  });
+
+  it('returns null when MINIMAX_API_KEY is not set', () => {
+    assert.match(src, /const apiKey = process\.env\.MINIMAX_API_KEY;[\s\S]*?if \(!apiKey\) return null;/,
+      'Should return null when API key is not configured');
+  });
+
+  it('supports custom MINIMAX_API_URL', () => {
+    assert.match(src, /process\.env\.MINIMAX_API_URL/,
+      'Should support custom MINIMAX_API_URL');
+  });
+
+  it('uses default API URL when not specified', () => {
+    assert.match(src, /https:\/\/api\.minimax\.io\/v1/,
+      'Should use https://api.minimax.io/v1 as default base URL');
+  });
+
+  it('constructs correct chat completions endpoint', () => {
+    assert.match(src, /\/chat\/completions/,
+      'Should construct /chat/completions endpoint');
+  });
+
+  it('supports custom MINIMAX_MODEL', () => {
+    assert.match(src, /process\.env\.MINIMAX_MODEL/,
+      'Should support custom MINIMAX_MODEL');
+  });
+
+  it('uses MiniMax-M2.5 as default model', () => {
+    assert.match(src, /MiniMax-M2\.5/,
+      'Should use MiniMax-M2.5 as default model');
+  });
+
+  it('sets Authorization header with Bearer token', () => {
+    const minimaxSection = src.match(/if\s*\(\s*provider\s*===\s*['"]minimax['"]\s*\)[\s\S]*?return\s*\{[\s\S]*?\};/);
+    assert.ok(minimaxSection, 'Should have minimax provider section');
+    assert.match(minimaxSection[0], /Authorization.*Bearer.*apiKey/,
+      'Should set Authorization header with Bearer token');
+  });
+
+  it('sets Content-Type header to application/json', () => {
+    const minimaxSection = src.match(/if\s*\(\s*provider\s*===\s*['"]minimax['"]\s*\)[\s\S]*?return\s*\{[\s\S]*?\};/);
+    assert.ok(minimaxSection, 'Should have minimax provider section');
+    assert.match(minimaxSection[0], /Content-Type.*application\/json/,
+      'Should set Content-Type header to application/json');
+  });
+});
+
+// ========================================================================
+// Summarize article handler verification
+// ========================================================================
+
+describe('MiniMax provider: summarize-article handler', () => {
+  const src = readSrc('server/worldmonitor/news/v1/summarize-article.ts');
+
+  it('includes minimax in skipReasons', () => {
+    assert.match(src, /minimax:\s*['"]MINIMAX_API_KEY not configured['"]/,
+      'Should have skip reason for minimax when API key is not configured');
+  });
+});
+
+// ========================================================================
+// Credential resolution logic verification (static analysis)
+// ========================================================================
+
+describe('MiniMax provider: credential resolution logic', () => {
+  const src = readSrc('server/worldmonitor/news/v1/_shared.ts');
+
+  it('returns null when API key is not present (guard clause)', () => {
+    const minimaxBlock = src.match(/if\s*\(\s*provider\s*===\s*['"]minimax['"]\s*\)\s*\{[\s\S]*?return\s*\{[\s\S]*?\};\s*\}/);
+    assert.ok(minimaxBlock, 'Should have minimax provider block');
+    assert.match(minimaxBlock[0], /if\s*\(\s*!apiKey\s*\)\s*return\s*null/,
+      'Should return null when API key is not set');
+  });
+
+  it('constructs API URL using URL constructor', () => {
+    const minimaxBlock = src.match(/if\s*\(\s*provider\s*===\s*['"]minimax['"]\s*\)\s*\{[\s\S]*?return\s*\{[\s\S]*?\};\s*\}/);
+    assert.ok(minimaxBlock, 'Should have minimax provider block');
+    assert.match(minimaxBlock[0], /new URL\(['"]\/chat\/completions['"],\s*baseUrl\)/,
+      'Should use URL constructor to build chat/completions endpoint');
+  });
+
+  it('uses environment variable fallback pattern for base URL', () => {
+    const minimaxBlock = src.match(/if\s*\(\s*provider\s*===\s*['"]minimax['"]\s*\)\s*\{[\s\S]*?return\s*\{[\s\S]*?\};\s*\}/);
+    assert.ok(minimaxBlock, 'Should have minimax provider block');
+    assert.match(minimaxBlock[0], /process\.env\.MINIMAX_API_URL\s*\|\|\s*['"]https:\/\/api\.minimax\.io\/v1['"]/,
+      'Should use env var with default fallback for API URL');
+  });
+
+  it('uses environment variable fallback pattern for model', () => {
+    const minimaxBlock = src.match(/if\s*\(\s*provider\s*===\s*['"]minimax['"]\s*\)\s*\{[\s\S]*?return\s*\{[\s\S]*?\};\s*\}/);
+    assert.ok(minimaxBlock, 'Should have minimax provider block');
+    assert.match(minimaxBlock[0], /process\.env\.MINIMAX_MODEL\s*\|\|\s*['"]MiniMax-M2\.5['"]/,
+      'Should use env var with default fallback for model');
+  });
+
+  it('does not include extraBody property (unlike ollama)', () => {
+    const minimaxBlock = src.match(/if\s*\(\s*provider\s*===\s*['"]minimax['"]\s*\)\s*\{[\s\S]*?return\s*\{[\s\S]*?\};\s*\}/);
+    assert.ok(minimaxBlock, 'Should have minimax provider block');
+    assert.doesNotMatch(minimaxBlock[0], /extraBody/,
+      'Should not have extraBody property (minimax does not need it)');
+  });
+
+  it('uses template literal for Authorization header', () => {
+    const minimaxBlock = src.match(/if\s*\(\s*provider\s*===\s*['"]minimax['"]\s*\)\s*\{[\s\S]*?return\s*\{[\s\S]*?\};\s*\}/);
+    assert.ok(minimaxBlock, 'Should have minimax provider block');
+    assert.match(minimaxBlock[0], /Authorization.*`Bearer \$\{apiKey\}`/,
+      'Should use template literal for Bearer token');
+  });
+});
+
+// ========================================================================
+// Provider comparison tests
+// ========================================================================
+
+describe('MiniMax provider: comparison with other providers', () => {
+  const src = readSrc('server/worldmonitor/news/v1/_shared.ts');
+
+  it('follows same structure as groq provider', () => {
+    const groqMatch = src.match(/if\s*\(\s*provider\s*===\s*['"]groq['"]\s*\)[\s\S]*?return\s*\{[\s\S]*?\};/);
+    const minimaxMatch = src.match(/if\s*\(\s*provider\s*===\s*['"]minimax['"]\s*\)[\s\S]*?return\s*\{[\s\S]*?\};/);
+    
+    assert.ok(groqMatch, 'Should have groq provider');
+    assert.ok(minimaxMatch, 'Should have minimax provider');
+    
+    assert.match(minimaxMatch[0], /apiUrl:/i, 'minimax should have apiUrl like groq');
+    assert.match(minimaxMatch[0], /model:/i, 'minimax should have model like groq');
+    assert.match(minimaxMatch[0], /headers:/i, 'minimax should have headers like groq');
+  });
+
+  it('is listed alongside other cloud providers', () => {
+    const cloudProviders = ['groq', 'openrouter', 'minimax'];
+    for (const provider of cloudProviders) {
+      assert.match(src, new RegExp(`provider\\s*===\\s*['"]${provider}['"]`),
+        `Should have ${provider} as a cloud provider option`);
+    }
+  });
+});
+
+// ========================================================================
+// Settings integration tests
+// ========================================================================
+
+describe('MiniMax provider: settings integration', () => {
+  it('is listed in settings-constants.ts', () => {
+    const settingsSrc = readSrc('src/services/settings-constants.ts');
+    assert.match(settingsSrc, /minimax/i,
+      'Should be referenced in settings-constants.ts');
+  });
+
+  it('is handled in runtime-config.ts', () => {
+    const runtimeSrc = readSrc('src/services/runtime-config.ts');
+    assert.match(runtimeSrc, /minimax/i,
+      'Should be handled in runtime-config.ts');
+  });
+
+  it('is supported in summarization.ts', () => {
+    const summarizationSrc = readSrc('src/services/summarization.ts');
+    assert.match(summarizationSrc, /minimax/i,
+      'Should be supported in summarization.ts');
+  });
+});


### PR DESCRIPTION
Add MiniMax as a new LLM provider for article summarization, providing an additional fallback option alongside Groq and OpenRouter.

Changes:
- Add MINIMAX_API_KEY support with optional URL/model overrides
- Integrate MiniMax provider into summarization fallback chain
- Add API key validation in sidecar server
- Update settings UI to include MiniMax configuration
- Add provider test suite

Made-with: Cursor