### PR TITLE
fix(channels): remove All tab from channel management

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -177,7 +177,6 @@ const _REGION_ENTRIES: { key: string; labelKey: string; channelIds: string[] }[]
   { key: 'oc', labelKey: 'components.liveNews.regionOceania', channelIds: ['abc-news-au'] },
 ];
 export const OPTIONAL_CHANNEL_REGIONS: { key: string; labelKey: string; channelIds: string[] }[] = [
-  { key: 'all', labelKey: 'components.liveNews.regionAll', channelIds: _REGION_ENTRIES.flatMap((r) => r.channelIds) },
   ..._REGION_ENTRIES,
 ];
 

--- a/src/live-channels-window.ts
+++ b/src/live-channels-window.ts
@@ -71,7 +71,7 @@ function isHlsUrl(raw: string): boolean {
 }
 
 // Persist active region tab across re-renders
-let activeRegionTab = 'all';
+let activeRegionTab = 'na';
 
 function channelInitials(name: string): string {
   return name.split(/[\s-]+/).map((w) => w[0] ?? '').join('').slice(0, 2).toUpperCase();


### PR DESCRIPTION
## Summary
- Remove the "All" tab from live channel management — too large with 60+ channels
- Users can search or browse by region instead
- Default tab changed to North America

## Test plan
- [ ] Open channel management → verify "All" tab is gone
- [ ] First visible tab is North America
- [ ] Search still works across all regions