### PR TITLE
fix(map): use CORS-enabled R2 URL for PMTiles in Tauri desktop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,6 +174,10 @@ VITE_MAP_INTERACTION_MODE=3d
 # Leave empty to use free OpenFreeMap tiles. Set to your own PMTiles URL for self-hosted tiles.
 # See: https://protomaps.com/docs/pmtiles for how to generate PMTiles files.
 VITE_PMTILES_URL=
+# Public CORS-enabled URL for the same PMTiles file (used by Tauri desktop app).
+# If your VITE_PMTILES_URL is behind a reverse proxy without CORS, set this to the
+# direct R2/S3 public URL. The desktop app uses this URL; the web app uses VITE_PMTILES_URL.
+VITE_PMTILES_URL_PUBLIC=
 
 
 # ------ Desktop Cloud Fallback (Vercel) ------

--- a/src/config/basemap.ts
+++ b/src/config/basemap.ts
@@ -3,7 +3,10 @@ import maplibregl from 'maplibre-gl';
 import { layers, namedFlavor } from '@protomaps/basemaps';
 import type { StyleSpecification } from 'maplibre-gl';
 
-const R2_BASE = import.meta.env.VITE_PMTILES_URL ?? '';
+const R2_PROXY = import.meta.env.VITE_PMTILES_URL ?? '';
+const R2_PUBLIC = import.meta.env.VITE_PMTILES_URL_PUBLIC ?? '';
+const isTauri = typeof window !== 'undefined' && '__TAURI__' in window;
+const R2_BASE = isTauri && R2_PUBLIC ? R2_PUBLIC : R2_PROXY;
 
 const hasTilesUrl = !!R2_BASE;
 


### PR DESCRIPTION
## Summary
- PMTiles basemap doesn't render in Tauri desktop — tiles fail silently with no fallback
- **Root cause**: `maps.worldmonitor.app` (CF proxy custom domain) doesn't forward R2 CORS headers. Tauri's origin (`https://tauri.localhost`) gets blocked.
- **Fix**: Detect Tauri via `__TAURI__` and use `VITE_PMTILES_URL_PUBLIC` (direct R2 public URL with CORS) instead of the CF proxy URL
- Web continues using CF proxy URL for edge caching benefits

## Manual step required
Add `https://tauri.localhost` to R2 CORS allowed origins:
```bash
curl -X PUT "https://api.cloudflare.com/client/v4/accounts/0b8b3c0a2a904be8bb12e1a379aebbff/r2/buckets/worldmonitor-maps/cors" \
  -H "Authorization: Bearer $CLOUDFLARE_R2_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"rules":[{"allowed":{"origins":["https://worldmonitor.app","https://tech.worldmonitor.app","https://finance.worldmonitor.app","https://happy.worldmonitor.app","https://commodity.worldmonitor.app","https://tauri.localhost","http://localhost:5173"],"methods":["GET","HEAD"],"headers":["range","if-match","if-none-match"]},"exposed":["content-range","content-length","etag","accept-ranges"],"maxAge":86400}]}'
```

## Test plan
- [ ] Run `CLOUDFLARE_R2_TOKEN=... curl` command above to update R2 CORS
- [ ] Set `VITE_PMTILES_URL_PUBLIC=https://pub-...r2.dev/planet.pmtiles` in `.env`
- [ ] Build Tauri app → PMTiles basemap renders
- [ ] Web app still works with CF proxy URL (no CORS needed, same-origin)
- [ ] Fallback to OpenFreeMap still works if R2 is down