### PR TITLE
fix(cyber): suppress MaxListenersExceededWarning in GeoIP hydration

### DIFF
--- a/scripts/seed-cyber-threats.mjs
+++ b/scripts/seed-cyber-threats.mjs
@@ -231,6 +231,9 @@ async function hydrateCoordinates(threats) {
   const capped = unresolvedIps.slice(0, GEO_MAX_UNRESOLVED);
   const resolved = new Map();
   const controller = new AbortController();
+  if (typeof controller.signal.setMaxListeners === 'function') {
+    controller.signal.setMaxListeners(capped.length * 2 + 20);
+  }
   const timeout = setTimeout(() => controller.abort(), GEO_OVERALL_TIMEOUT_MS);
 
   const queue = [...capped];


### PR DESCRIPTION
## Summary
- Add `setMaxListeners` on the shared AbortSignal in cyber threats GeoIP hydration
- Prevents 100+ `MaxListenersExceededWarning` lines flooding Railway logs
- Root cause: 200 IPs × 2 fetch calls per IP all sharing one AbortSignal (default limit: 10)

## Context
Follow-up to #1111. Railway logs showed the warning spam on every seed run.