### PR TITLE
feat(feeds): add MTV Lebanon News to Middle East

### DIFF
--- a/shared/rss-allowed-domains.json
+++ b/shared/rss-allowed-domains.json
@@ -289,5 +289,6 @@
   "www.mining-technology.com",
   "www.australianmining.com.au",
   "news.goldseek.com",
-  "news.silverseek.com"
+  "news.silverseek.com",
+  "www.youtube.com"
 ]

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -582,6 +582,7 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     { name: 'Asharq Business', url: rss('https://asharqbusiness.com/rss.xml') },
     { name: 'Asharq News', url: rss('https://asharq.com/snapchat/rss.xml'), lang: 'ar' },
     { name: 'Rudaw', url: rss('https://news.google.com/rss/search?q=site:rudaw.net+when:7d&hl=en&gl=US&ceid=US:en') },
+    { name: 'MTV Lebanon', url: rss('https://www.youtube.com/feeds/videos.xml?channel_id=UC9_XmAwE5szLHF76FjMylaw'), lang: 'ar' },
   ],
   tech: [
     { name: 'Hacker News', url: rss('https://hnrss.org/frontpage') },
@@ -1266,7 +1267,7 @@ export const DEFAULT_ENABLED_SOURCES: Record<string, string[]> = {
   politics: ['BBC World', 'Guardian World', 'AP News', 'Reuters World', 'CNN World'],
   us: ['Reuters US', 'NPR News', 'PBS NewsHour', 'ABC News', 'CBS News', 'NBC News', 'Wall Street Journal', 'Politico', 'The Hill'],
   europe: ['France 24', 'EuroNews', 'Le Monde', 'DW News', 'Tagesschau', 'ANSA', 'NOS Nieuws', 'SVT Nyheter'],
-  middleeast: ['BBC Middle East', 'Al Jazeera', 'Al Arabiya', 'Guardian ME', 'BBC Persian', 'Iran International', 'Haaretz', 'Asharq News', 'The National'],
+  middleeast: ['BBC Middle East', 'Al Jazeera', 'Al Arabiya', 'Guardian ME', 'BBC Persian', 'Iran International', 'Haaretz', 'Asharq News', 'The National', 'MTV Lebanon'],
   africa: ['BBC Africa', 'News24', 'Africanews', 'Jeune Afrique', 'Africa News', 'Premium Times', 'Channels TV', 'Sahel Crisis'],
   latam: ['BBC Latin America', 'Reuters LatAm', 'InSight Crime', 'Mexico News Daily', 'Clarín', 'Primicias', 'Infobae Americas', 'El Universo'],
   asia: ['BBC Asia', 'The Diplomat', 'South China Morning Post', 'Reuters Asia', 'Nikkei Asia', 'CNA', 'Asia News', 'The Hindu'],


### PR DESCRIPTION
## Summary
- Add MTV Lebanon News YouTube RSS feed to Middle East region
- Channel: `@MTVLebanonNews` (`UC9_XmAwE5szLHF76FjMylaw`)
- Add `www.youtube.com` to RSS allowed domains
- Add to `topSourcesByRegion.middleeast`

## Test
YouTube Atom feed verified working: returns Arabic-language news video entries.