### PR TITLE
fix(health): resolve bisCredit empty data and theater posture warnings

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -71,11 +71,19 @@ const SEED_META = {
 // Standalone keys that are populated on-demand by RPC handlers (not seeds).
 // Empty = WARN not CRIT since they only exist after first request.
 const ON_DEMAND_KEYS = new Set([
-  'theaterPostureLive', 'theaterPostureBackup', 'riskScoresLive',
+  'riskScoresLive',
   'usniFleet', 'usniFleetStale', 'positiveEventsLive', 'cableHealth',
-  'theaterPosture', 'bisPolicy', 'bisExchange', 'bisCredit',
+  'bisPolicy', 'bisExchange', 'bisCredit',
   'serviceStatuses', 'macroSignals', 'shippingRates', 'chokepoints', 'minerals', 'giving',
 ]);
+
+// Cascade groups: if any key in the group has data, all empty siblings are OK.
+// Theater posture uses live → stale → backup fallback chain.
+const CASCADE_GROUPS = {
+  theaterPosture:       ['theaterPosture', 'theaterPostureLive', 'theaterPostureBackup'],
+  theaterPostureLive:   ['theaterPosture', 'theaterPostureLive', 'theaterPostureBackup'],
+  theaterPostureBackup: ['theaterPosture', 'theaterPostureLive', 'theaterPostureBackup'],
+};
 
 const NEG_SENTINEL = '__WM_NEG__';
 
@@ -108,7 +116,7 @@ function dataSize(parsed) {
                       'papers', 'repos', 'articles', 'signals', 'rates', 'countries',
                       'chokepoints', 'minerals', 'anomalies', 'flows', 'bases',
                       'theaters', 'fleets', 'warnings', 'closures', 'cables',
-                      'airports', 'categories', 'regions']) {
+                      'airports', 'categories', 'regions', 'entries']) {
       if (Array.isArray(parsed[k])) return parsed[k].length;
     }
     return Object.keys(parsed).length;
@@ -207,9 +215,29 @@ export default async function handler(req) {
     const size = dataSize(parsed);
     const isOnDemand = ON_DEMAND_KEYS.has(name);
 
+    // Cascade: if this key is empty but a sibling in the cascade group has data, it's OK.
+    const cascadeSiblings = CASCADE_GROUPS[name];
+    let cascadeCovered = false;
+    if (cascadeSiblings && (!parsed || size === 0)) {
+      for (const sibling of cascadeSiblings) {
+        if (sibling === name) continue;
+        const sibKey = STANDALONE_KEYS[sibling];
+        if (!sibKey) continue;
+        const sibRaw = keyValues.get(sibKey);
+        const sibParsed = parseRedisValue(sibRaw);
+        if (sibParsed && dataSize(sibParsed) > 0) {
+          cascadeCovered = true;
+          break;
+        }
+      }
+    }
+
     let status;
     if (!parsed || raw === NEG_SENTINEL) {
-      if (isOnDemand) {
+      if (cascadeCovered) {
+        status = 'OK_CASCADE';
+        okCount++;
+      } else if (isOnDemand) {
         status = 'EMPTY_ON_DEMAND';
         warnCount++;
       } else {
@@ -217,7 +245,10 @@ export default async function handler(req) {
         critCount++;
       }
     } else if (size === 0) {
-      if (isOnDemand) {
+      if (cascadeCovered) {
+        status = 'OK_CASCADE';
+        okCount++;
+      } else if (isOnDemand) {
         status = 'EMPTY_ON_DEMAND';
         warnCount++;
       } else {

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2119,6 +2119,48 @@ async function startPositiveEventsSeedLoop() {
 }
 
 // ─────────────────────────────────────────────────────────────
+// Theater Posture Seed — warm-pings Vercel RPC every 10 min
+// so the strategic posture panel always has data in Redis.
+// ─────────────────────────────────────────────────────────────
+const THEATER_POSTURE_SEED_INTERVAL_MS = 600_000; // 10 min
+const THEATER_POSTURE_RPC_URL = 'https://worldmonitor.app/api/military/v1/get-theater-posture';
+
+async function seedTheaterPosture() {
+  try {
+    const resp = await fetch(THEATER_POSTURE_RPC_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': CHROME_UA,
+        Origin: 'https://worldmonitor.app',
+      },
+      body: '{}',
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!resp.ok) {
+      console.warn(`[TheaterPosture] Seed ping failed: HTTP ${resp.status}`);
+      return;
+    }
+    const data = await resp.json();
+    const theaters = data?.theaters?.length || 0;
+    console.log(`[TheaterPosture] Seed ping OK — ${theaters} theaters`);
+  } catch (e) {
+    console.warn('[TheaterPosture] Seed ping error:', e?.message || e);
+  }
+}
+
+function startTheaterPostureSeedLoop() {
+  console.log(`[TheaterPosture] Seed loop starting (interval ${THEATER_POSTURE_SEED_INTERVAL_MS / 1000 / 60}min)`);
+  // Delay initial seed 30s to let the relay start up first (it proxies OpenSky)
+  setTimeout(() => {
+    seedTheaterPosture().catch((e) => console.warn('[TheaterPosture] Initial seed error:', e?.message || e));
+    setInterval(() => {
+      seedTheaterPosture().catch((e) => console.warn('[TheaterPosture] Seed error:', e?.message || e));
+    }, THEATER_POSTURE_SEED_INTERVAL_MS).unref?.();
+  }, 30_000);
+}
+
+// ─────────────────────────────────────────────────────────────
 // GPS/GNSS Jamming Seed — fetches from gpsjam.org, seeds Redis
 // Data updates once per day; we poll every 6 hours.
 // ─────────────────────────────────────────────────────────────
@@ -5442,6 +5484,7 @@ server.listen(PORT, () => {
   // (avoids burning 12 extra AbuseIPDB calls/day from duplicate relay loop)
   startCiiSeedLoop();
   startPositiveEventsSeedLoop();
+  startTheaterPostureSeedLoop();
   startGpsJamSeedLoop();
 });
 

--- a/server/worldmonitor/economic/v1/get-bis-credit.ts
+++ b/server/worldmonitor/economic/v1/get-bis-credit.ts
@@ -33,7 +33,7 @@ export async function getBisCredit(
       // Group by country, take last 2 observations
       const byCountry = new Map<string, Array<{ date: string; value: number }>>();
       for (const row of rows) {
-        const cc = row['REF_AREA'] || row['Reference area'] || '';
+        const cc = row['REF_AREA'] || row['BORROWERS_CTY'] || row['Reference area'] || '';
         const date = row['TIME_PERIOD'] || row['Time period'] || '';
         const val = parseBisNumber(row['OBS_VALUE'] || row['Observation value']);
         if (!cc || !date || val === null) continue;


### PR DESCRIPTION
## Summary
- **bisCredit always empty**: BIS WS_TC dataset uses `BORROWERS_CTY` column, not `REF_AREA` (which policy/exchange use). Was silently matching 0 rows → `null` → empty Redis key. Added `BORROWERS_CTY` fallback.
- **theaterPosture/theaterPostureLive false WARN**: Removed from `ON_DEMAND_KEYS`. Added `CASCADE_GROUPS` — if backup key (7-day TTL, 9 records) has data, empty live/stale siblings show `OK_CASCADE` instead of WARN.
- **Theater posture seed loop**: 10-min warm-ping from ais-relay calls the Vercel RPC endpoint to keep Redis populated. 30s startup delay so OpenSky proxy is ready.
- **dataSize `entries`**: Added `entries` to known array keys for bisCredit `{ entries: [...] }` response shape.

## Test plan
- [ ] After deploy, health endpoint should show 0 WARN for theaterPosture/theaterPostureLive (OK_CASCADE)
- [ ] After Railway redeploy, bisCredit should populate within 12h (BIS cache TTL)
- [ ] Theater posture seed loop logs `[TheaterPosture] Seed ping OK` every 10min in Railway logs