### PR TITLE
fix(webcams): use iframe load fallback for blocked detection

### DIFF
--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -314,6 +314,9 @@ export class LiveWebcamsPanel extends Panel {
 
     // YouTube embeds post yt-ready/yt-state (desktop sidecar) or native YT API events (web with enablejsapi=1).
     // If nothing arrives within the timeout, assume blocked/stuck.
+    // Fallback: iframe load event cancels the timeout — Firefox privacy restrictions
+    // can block YouTube JS API postMessage while the video plays fine.
+    iframe.addEventListener('load', () => this.markIframeReady(iframe), { once: true });
     tracker.timeout = setTimeout(() => this.markIframeBlocked(iframe), this.EMBED_READY_TIMEOUT_MS);
   }
 


### PR DESCRIPTION
## Summary
- Fixes false "blocked" overlay appearing on Firefox after ~15 seconds (#1123)
- Firefox privacy restrictions can block YouTube JS API `postMessage` while the video plays fine
- Adds iframe `load` event as fallback readiness signal to cancel the blocked-detection timeout

## Root cause
PR #1107 added web-side blocked embed detection with a 15s timeout waiting for YouTube JS API messages. On Firefox (and browsers with strict third-party storage partitioning), `youtube-nocookie.com` embeds never send `postMessage` events back — the timeout fires and overlays a "blocked" error on top of perfectly working streams.

## Test plan
- [ ] Open worldmonitor.app in Firefox with default privacy settings
- [ ] Verify webcam streams play without showing "blocked" overlay after 15s
- [ ] Verify genuinely blocked streams (e.g., adblocker blocking YouTube) still show the overlay
- [ ] Verify desktop (Tauri) sidecar embeds still work as before

Closes #1123