### PR TITLE
feat(health): auto seed-meta freshness tracking for all RPC handlers

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -66,6 +66,18 @@ const SEED_META = {
   insights:         { key: 'seed-meta:news:insights',           maxStaleMin: 30 },
   marketQuotes:     { key: 'seed-meta:market:stocks',         maxStaleMin: 30 },
   commodityQuotes:  { key: 'seed-meta:market:commodities',    maxStaleMin: 30 },
+  // RPC-populated keys — auto-tracked by cachedFetchJson seed-meta writes
+  serviceStatuses:  { key: 'seed-meta:infra:service-statuses',    maxStaleMin: 120 },
+  macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 60 },
+  bisPolicy:        { key: 'seed-meta:economic:bis:policy',       maxStaleMin: 1440 },
+  bisExchange:      { key: 'seed-meta:economic:bis:eer',          maxStaleMin: 1440 },
+  bisCredit:        { key: 'seed-meta:economic:bis:credit',       maxStaleMin: 1440 },
+  shippingRates:    { key: 'seed-meta:supply_chain:shipping',     maxStaleMin: 240 },
+  chokepoints:      { key: 'seed-meta:supply_chain:chokepoints',  maxStaleMin: 60 },
+  minerals:         { key: 'seed-meta:supply_chain:minerals',     maxStaleMin: 2880 },
+  giving:           { key: 'seed-meta:giving:summary',            maxStaleMin: 2880 },
+  gpsjam:           { key: 'seed-meta:intelligence:gpsjam',       maxStaleMin: 720 },
+  cableHealth:      { key: 'seed-meta:cable-health',              maxStaleMin: 60 },
 };
 
 // Standalone keys that are populated on-demand by RPC handlers (not seeds).
@@ -206,6 +218,21 @@ export default async function handler(req) {
     const parsed = parseRedisValue(raw);
     const size = dataSize(parsed);
     const isOnDemand = ON_DEMAND_KEYS.has(name);
+    const seedCfg = SEED_META[name];
+
+    // Freshness tracking for standalone keys (same logic as bootstrap keys)
+    let seedAge = null;
+    let seedStale = null;
+    if (seedCfg) {
+      const metaRaw = keyValues.get(seedCfg.key);
+      const meta = parseRedisValue(metaRaw);
+      if (meta?.fetchedAt) {
+        seedAge = Math.round((now - meta.fetchedAt) / 60_000);
+        seedStale = seedAge > seedCfg.maxStaleMin;
+      }
+      // Don't mark stale if no meta yet — seed-meta auto-writes are new,
+      // existing data may not have meta until next refresh cycle.
+    }
 
     let status;
     if (!parsed || raw === NEG_SENTINEL) {
@@ -224,12 +251,18 @@ export default async function handler(req) {
         status = 'EMPTY_DATA';
         critCount++;
       }
+    } else if (seedStale === true) {
+      status = 'STALE_SEED';
+      warnCount++;
     } else {
       status = 'OK';
       okCount++;
     }
 
-    checks[name] = { status, redisKey, records: size };
+    const entry = { status, redisKey, records: size };
+    if (seedAge !== null) entry.seedAgeMin = seedAge;
+    if (seedCfg) entry.maxStaleMin = seedCfg.maxStaleMin;
+    checks[name] = entry;
   }
 
   let overall;

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -59,6 +59,25 @@ export async function setCachedJson(key: string, value: unknown, ttlSeconds: num
 }
 
 const NEG_SENTINEL = '__WM_NEG__';
+const SEED_META_TTL = 604800; // 7 days
+
+/** Estimate record count from an RPC response object for seed-meta tracking. */
+function estimateRecordCount(obj: unknown): number {
+  if (!obj || typeof obj !== 'object') return 0;
+  if (Array.isArray(obj)) return obj.length;
+  // Check common array fields in RPC responses
+  for (const v of Object.values(obj as Record<string, unknown>)) {
+    if (Array.isArray(v)) return v.length;
+  }
+  return Object.keys(obj as Record<string, unknown>).length;
+}
+
+/** Write seed-meta for a cache key (fire-and-forget). */
+function writeSeedMeta(cacheKey: string, recordCount: number): void {
+  const metaKey = `seed-meta:${cacheKey.replace(/[-:]v\d+$/, '')}`;
+  setCachedJson(metaKey, { fetchedAt: Date.now(), recordCount }, SEED_META_TTL)
+    .catch((err: unknown) => console.warn(`[redis] seed-meta write failed for "${metaKey}":`, errMsg(err)));
+}
 
 /**
  * Batch GET using Upstash pipeline API — single HTTP round-trip for N keys.
@@ -128,6 +147,7 @@ export async function cachedFetchJson<T extends object>(
     .then(async (result) => {
       if (result != null) {
         await setCachedJson(key, result, ttlSeconds);
+        writeSeedMeta(key, estimateRecordCount(result));
       } else {
         await setCachedJson(key, NEG_SENTINEL, negativeTtlSeconds);
       }
@@ -174,6 +194,7 @@ export async function cachedFetchJsonWithMeta<T extends object>(
     .then(async (result) => {
       if (result != null) {
         await setCachedJson(key, result, ttlSeconds);
+        writeSeedMeta(key, estimateRecordCount(result));
       } else {
         await setCachedJson(key, NEG_SENTINEL, negativeTtlSeconds);
       }


### PR DESCRIPTION
## Summary
- `cachedFetchJson` now auto-writes `seed-meta:<key>` with `{ fetchedAt, recordCount }` on every fresh fetch — no manual instrumentation needed per handler
- Health endpoint tracks freshness for all 11 standalone RPC-populated keys (BIS, supply chain, service statuses, etc.) with configurable `maxStaleMin` thresholds
- Keys show `STALE_SEED` (WARN) when data exceeds staleness threshold, closing the gap where data existed but was silently stale

## Test plan
- [x] `tsc --noEmit` clean
- [x] 60/60 edge function tests pass
- [ ] Deploy → verify `/api/health` shows `seedAgeMin` and `maxStaleMin` for standalone keys after first RPC refresh cycle
- [ ] Confirm no regressions — bootstrap keys continue to show freshness from seed scripts