### PR TITLE
fix(health): treat missing seed-meta as stale, not OK

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -237,9 +237,10 @@ export default async function handler(req) {
       if (meta?.fetchedAt) {
         seedAge = Math.round((now - meta.fetchedAt) / 60_000);
         seedStale = seedAge > seedCfg.maxStaleMin;
+      } else {
+        // No seed-meta → data exists but freshness is unknown → stale
+        seedStale = true;
       }
-      // Don't mark stale if no meta yet — seed-meta auto-writes are new,
-      // existing data may not have meta until next refresh cycle.
     }
 
     // Cascade: if this key is empty but a sibling in the cascade group has data, it's OK.


### PR DESCRIPTION
## Summary
- Removes the grace period that silently treated missing seed-meta as OK
- Standalone RPC keys with data but no `seed-meta` record now show `STALE_SEED` (WARN) instead of false `OK`
- Health now truly reflects the user's requirement: data must be **present AND fresh**

After deploy, these 11 keys will show WARN until their first `cachedFetchJson` cache miss triggers a fresh fetch + seed-meta write. This is correct behavior — it surfaces the freshness blind spot instead of hiding it.

## Test plan
- [x] `node -c api/health.js` — syntax OK
- [x] 60/60 edge function tests pass
- [x] `tsc --noEmit` clean
- [ ] Deploy → verify standalone keys without seed-meta show `STALE_SEED`
- [ ] After cache expiry cycle, verify they flip to `OK` with `seedAgeMin`