### PR TITLE
fix(sw): remove 206 from cacheable statuses for PMTiles

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -656,7 +656,7 @@ export default defineConfig({
             options: {
               cacheName: 'pmtiles-ranges',
               expiration: { maxEntries: 500, maxAgeSeconds: 30 * 24 * 60 * 60 },
-              cacheableResponse: { statuses: [0, 200, 206] },
+              cacheableResponse: { statuses: [0, 200] },
             },
           },
           {


### PR DESCRIPTION
## Summary
- Fixes `TypeError: Failed to execute 'put' on 'Cache': Partial response (status code 206) is unsupported` errors in console
- The Cache API spec forbids storing HTTP 206 (Partial Content) responses
- Workbox's `cacheableResponse` plugin accepted 206 but `Cache.put()` threw at the browser level
- PMTiles Range responses are already cached by the browser HTTP cache and Cloudflare edge — SW caching is unnecessary

## Test plan
- [ ] Open commodity.worldmonitor.app, verify no `Cache.put` 206 errors in console
- [ ] Verify map tiles still load correctly (PMTiles served via Range requests)