### PR TITLE
fix(bootstrap): increase timeout and isolate tier abort controllers

### DIFF
--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -26,14 +26,20 @@ async function fetchTier(tier: string, signal: AbortSignal): Promise<void> {
 }
 
 export async function fetchBootstrapData(): Promise<void> {
-  const ctrl = new AbortController();
-  const timeout = setTimeout(() => ctrl.abort(), 800);
+  // Each tier gets its own abort controller so a slow response in one
+  // doesn't kill the other. Timeouts are generous — bootstrap data is
+  // critical for instant panel rendering.
+  const fastCtrl = new AbortController();
+  const slowCtrl = new AbortController();
+  const fastTimeout = setTimeout(() => fastCtrl.abort(), 3_000);
+  const slowTimeout = setTimeout(() => slowCtrl.abort(), 5_000);
   try {
     await Promise.all([
-      fetchTier('slow', ctrl.signal),
-      fetchTier('fast', ctrl.signal),
+      fetchTier('slow', slowCtrl.signal),
+      fetchTier('fast', fastCtrl.signal),
     ]);
   } finally {
-    clearTimeout(timeout);
+    clearTimeout(fastTimeout);
+    clearTimeout(slowTimeout);
   }
 }


### PR DESCRIPTION
## Summary
- **Root cause**: The 800ms shared abort timeout for both bootstrap tiers was too aggressive. The fast tier alone takes ~650ms on some connections, aborting both tiers and leaving panels like Tech Readiness and Financial without hydrated data.
- **Fix**: Each tier now gets its own AbortController (fast: 3s, slow: 5s). A slow response in one tier no longer kills the other.
- Without bootstrap hydration, Tech Readiness falls back to 4 World Bank API calls (slow/unreliable), and Financial NewsPanel waits for RSS proxy (also slow on first load).

## Test plan
- [x] `tsc --noEmit` clean
- [x] 60/60 edge function tests pass
- [ ] Deploy → verify Tech Readiness and Financial panels render on first load
- [ ] Test from throttled network (3G) — panels should still hydrate