### PR TITLE
feat(aviation): add Dubai and Riyadh to default watchlist

### DIFF
--- a/src/services/aviation/watchlist.ts
+++ b/src/services/aviation/watchlist.ts
@@ -12,7 +12,7 @@ export interface AviationWatchlist {
 }
 
 const DEFAULT_WATCHLIST: AviationWatchlist = {
-  airports: ['IST', 'ESB', 'SAW', 'LHR', 'FRA', 'CDG'],
+  airports: ['IST', 'ESB', 'SAW', 'LHR', 'FRA', 'CDG', 'DXB', 'RUH'],
   airlines: ['TK'],
   routes: ['IST-LHR', 'IST-FRA'],
 };


### PR DESCRIPTION
## Summary
- Add DXB (Dubai International) and RUH (King Khalid International, Riyadh) to the default aviation watchlist airports
- LHR was already included

## Test plan
- [ ] Open Airline Intelligence panel → Ops tab shows DXB and RUH
- [ ] Clear localStorage `aviation:watchlist:v1` to verify defaults apply