### PR TITLE
fix(sidecar): upstream concurrency limiter, Yahoo rate gate, startup batching

### DIFF
--- a/server/worldmonitor/market/v1/get-country-stock-index.ts
+++ b/server/worldmonitor/market/v1/get-country-stock-index.ts
@@ -9,7 +9,7 @@ import type {
   GetCountryStockIndexResponse,
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { UPSTREAM_TIMEOUT_MS, type YahooChartResponse } from './_shared';
-import { CHROME_UA } from '../../../_shared/constants';
+import { CHROME_UA, yahooGate } from '../../../_shared/constants';
 import { cachedFetchJson } from '../../../_shared/redis';
 
 // ========================================================================
@@ -102,6 +102,7 @@ export async function getCountryStockIndex(
     const encodedSymbol = encodeURIComponent(index.symbol);
     const yahooUrl = `https://query1.finance.yahoo.com/v8/finance/chart/${encodedSymbol}?range=1mo&interval=1d`;
 
+    await yahooGate();
     const res = await fetch(yahooUrl, {
       headers: { 'User-Agent': CHROME_UA },
       signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -59,43 +59,80 @@ function isTransientVerificationError(error) {
   return /timed out|timeout|network|fetch failed|failed to fetch|socket hang up/i.test(error.message);
 }
 
+// Global concurrency limiter for upstream requests.
+let _activeUpstream = 0;
+const _upstreamQueue = [];
+const MAX_CONCURRENT_UPSTREAM = 6;
+function acquireUpstreamSlot() {
+  if (_activeUpstream < MAX_CONCURRENT_UPSTREAM) {
+    _activeUpstream++;
+    return Promise.resolve();
+  }
+  return new Promise(resolve => _upstreamQueue.push(resolve));
+}
+function releaseUpstreamSlot() {
+  if (_upstreamQueue.length > 0) {
+    _upstreamQueue.shift()();
+  } else {
+    _activeUpstream--;
+  }
+}
+
+// Global Yahoo Finance rate gate — shared across ALL handler bundles.
+let _yahooLastReq = 0;
+let _yahooQueue = Promise.resolve();
+function sidecarYahooGate() {
+  _yahooQueue = _yahooQueue.then(async () => {
+    const elapsed = Date.now() - _yahooLastReq;
+    if (elapsed < 600) await new Promise(r => setTimeout(r, 600 - elapsed));
+    _yahooLastReq = Date.now();
+  });
+  return _yahooQueue;
+}
+
 globalThis.fetch = async function ipv4Fetch(input, init) {
   const isRequest = input && typeof input === 'object' && 'url' in input;
   let url;
   try { url = new URL(typeof input === 'string' ? input : input.url); } catch { return _originalFetch(input, init); }
   if (url.protocol !== 'https:' && url.protocol !== 'http:') return _originalFetch(input, init);
-  const mod = url.protocol === 'https:' ? https : http;
-  const method = init?.method || (isRequest ? input.method : 'GET');
-  const body = await resolveRequestBody(input, init, method, isRequest);
-  const headers = {};
-  const rawHeaders = init?.headers || (isRequest ? input.headers : null);
-  if (rawHeaders) {
-    const h = rawHeaders instanceof Headers ? Object.fromEntries(rawHeaders.entries())
-      : Array.isArray(rawHeaders) ? Object.fromEntries(rawHeaders) : rawHeaders;
-    Object.assign(headers, h);
-  }
-  return new Promise((resolve, reject) => {
-    const req = mod.request({ hostname: url.hostname, port: url.port || (url.protocol === 'https:' ? 443 : 80), path: url.pathname + url.search, method, headers, family: 4 }, (res) => {
-      const chunks = [];
-      res.on('data', (c) => chunks.push(c));
-      res.on('end', () => {
-        const buf = Buffer.concat(chunks);
-        const responseHeaders = new Headers();
-        for (const [k, v] of Object.entries(res.headers)) {
-          if (v) responseHeaders.set(k, Array.isArray(v) ? v.join(', ') : v);
-        }
-        try {
-          resolve(buildSafeResponse(res.statusCode, res.statusMessage, responseHeaders, buf));
-        } catch (error) {
-          reject(error);
-        }
+  if (url.hostname.includes('finance.yahoo.com')) await sidecarYahooGate();
+  await acquireUpstreamSlot();
+  try {
+    const mod = url.protocol === 'https:' ? https : http;
+    const method = init?.method || (isRequest ? input.method : 'GET');
+    const body = await resolveRequestBody(input, init, method, isRequest);
+    const headers = {};
+    const rawHeaders = init?.headers || (isRequest ? input.headers : null);
+    if (rawHeaders) {
+      const h = rawHeaders instanceof Headers ? Object.fromEntries(rawHeaders.entries())
+        : Array.isArray(rawHeaders) ? Object.fromEntries(rawHeaders) : rawHeaders;
+      Object.assign(headers, h);
+    }
+    return await new Promise((resolve, reject) => {
+      const req = mod.request({ hostname: url.hostname, port: url.port || (url.protocol === 'https:' ? 443 : 80), path: url.pathname + url.search, method, headers, family: 4 }, (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          const buf = Buffer.concat(chunks);
+          const responseHeaders = new Headers();
+          for (const [k, v] of Object.entries(res.headers)) {
+            if (v) responseHeaders.set(k, Array.isArray(v) ? v.join(', ') : v);
+          }
+          try {
+            resolve(buildSafeResponse(res.statusCode, res.statusMessage, responseHeaders, buf));
+          } catch (error) {
+            reject(error);
+          }
+        });
       });
+      req.on('error', reject);
+      if (init?.signal) { init.signal.addEventListener('abort', () => req.destroy()); }
+      if (body != null) req.write(body);
+      req.end();
     });
-    req.on('error', reject);
-    if (init?.signal) { init.signal.addEventListener('abort', () => req.destroy()); }
-    if (body != null) req.write(body);
-    req.end();
-  });
+  } finally {
+    releaseUpstreamSlot();
+  }
 };
 
 const ALLOWED_ENV_KEYS = new Set([
@@ -452,7 +489,7 @@ async function importHandler(modulePath) {
 
 function resolveConfig(options = {}) {
   const port = Number(options.port ?? process.env.LOCAL_API_PORT ?? 46123);
-  const remoteBase = String(options.remoteBase ?? process.env.LOCAL_API_REMOTE_BASE ?? 'https://worldmonitor.app').replace(/\/$/, '');
+  const remoteBase = String(options.remoteBase ?? process.env.LOCAL_API_REMOTE_BASE ?? 'https://api.worldmonitor.app').replace(/\/$/, '');
   const resourceDir = String(options.resourceDir ?? process.env.LOCAL_API_RESOURCE_DIR ?? process.cwd());
   const apiDir = options.apiDir
     ? String(options.apiDir)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,6 +14,7 @@
     "windows": [
       {
         "title": "World Monitor",
+        "titleBarStyle": "Overlay",
         "width": 1440,
         "height": 900,
         "minWidth": 1200,

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -396,13 +396,21 @@ export class DataLoaderManager implements AppModule {
       tasks.push({ name: 'techReadiness', task: runGuarded('techReadiness', () => (this.ctx.panels['tech-readiness'] as TechReadinessPanel)?.refresh()) });
     }
 
-    const results = await Promise.allSettled(tasks.map(t => t.task));
-
-    results.forEach((result, idx) => {
-      if (result.status === 'rejected') {
-        console.error(`[App] ${tasks[idx]?.name} load failed:`, result.reason);
+    // Stagger startup: run tasks in small batches to avoid hammering upstreams
+    const BATCH_SIZE = 4;
+    const BATCH_DELAY_MS = 300;
+    for (let i = 0; i < tasks.length; i += BATCH_SIZE) {
+      const batch = tasks.slice(i, i + BATCH_SIZE);
+      const results = await Promise.allSettled(batch.map(t => t.task));
+      results.forEach((result, idx) => {
+        if (result.status === 'rejected') {
+          console.error(`[App] ${batch[idx]?.name} load failed:`, result.reason);
+        }
+      });
+      if (i + BATCH_SIZE < tasks.length) {
+        await new Promise(r => setTimeout(r, BATCH_DELAY_MS));
       }
-    });
+    }
 
     this.updateSearchIndex();
   }


### PR DESCRIPTION
## Summary

- **Sidecar concurrency limiter**: max 6 concurrent upstream requests with queuing to prevent socket exhaustion
- **Yahoo Finance rate gate**: 600ms spacing between Yahoo requests in the sidecar fetch patch (shared across all handler bundles)
- **Startup batching**: data-loader runs panel refresh tasks in batches of 4 with 300ms delays instead of all-at-once `Promise.allSettled`
- **get-country-stock-index**: adds `yahooGate()` before Yahoo fetch call
- **Fix**: sidecar default `remoteBase` → `api.worldmonitor.app` (was `worldmonitor.app`)
- **UI**: titleBarStyle Overlay for macOS

## Test plan

- [ ] Desktop app starts without flooding upstreams (check sidecar logs for staggered requests)
- [ ] Yahoo-dependent panels (Market, ETF, etc.) load without 429 errors
- [ ] All panels still load correctly with batched startup
- [ ] macOS title bar renders as overlay style