### PR TITLE
fix(i18n): correct indentation for geocode error keys in nl/pt/sv

### DIFF
--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -304,9 +304,9 @@
     "countryIntel": {
       "identifying": "Land identificeren...",
       "locating": "Regio lokaliseren...",
-    "geocodeFailed": "Kan geen land identificeren op deze locatie",
-    "retryBtn": "Opnieuw proberen",
-    "closeBtn": "Sluiten",
+      "geocodeFailed": "Kan geen land identificeren op deze locatie",
+      "retryBtn": "Opnieuw proberen",
+      "closeBtn": "Sluiten",
       "instabilityIndex": "Instabiliteitsindex",
       "protests": "protesten",
       "militaryAircraft": "miljoen vliegtuigen",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -304,9 +304,9 @@
     "countryIntel": {
       "identifying": "Identificando país...",
       "locating": "Localizando região...",
-    "geocodeFailed": "Não foi possível identificar um país nesta localização",
-    "retryBtn": "Tentar novamente",
-    "closeBtn": "Fechar",
+      "geocodeFailed": "Não foi possível identificar um país nesta localização",
+      "retryBtn": "Tentar novamente",
+      "closeBtn": "Fechar",
       "instabilityIndex": "Índice de Instabilidade",
       "protests": "protestos",
       "militaryAircraft": "mil. aeronave",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -304,9 +304,9 @@
     "countryIntel": {
       "identifying": "Identifierar land...",
       "locating": "Hittar region...",
-    "geocodeFailed": "Kunde inte identifiera ett land på denna plats",
-    "retryBtn": "Försök igen",
-    "closeBtn": "Stäng",
+      "geocodeFailed": "Kunde inte identifiera ett land på denna plats",
+      "retryBtn": "Försök igen",
+      "closeBtn": "Stäng",
       "instabilityIndex": "Instabilitetsindex",
       "protests": "protester",
       "militaryAircraft": "mil. flygplan",


### PR DESCRIPTION
## Summary
Follow-up to #1134 — fixes wrong JSON nesting for `geocodeFailed`, `retryBtn`, and `closeBtn` in nl.json, pt.json, and sv.json.

These keys were inserted as siblings of `countryIntel` (4-space indent) instead of children (6-space indent), breaking i18n lookups for Dutch, Portuguese, and Swedish users.

## Test plan
- [ ] Verify `node -e "JSON.parse(require('fs').readFileSync('src/locales/nl.json'))"` passes
- [ ] Switch language to NL/PT/SV → trigger geocode error → verify translated strings appear