### PR TITLE
fix(insights): graceful exit, LKG fallback, delay after RPC warm

### DIFF
--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -205,9 +205,19 @@ async function fetchInsights() {
   if (!digest) {
     console.log('  Digest not in Redis, warming cache via RPC...');
     await warmDigestCache();
+    // Wait for RPC write to propagate to Redis
+    await new Promise(r => setTimeout(r, 3_000));
     digest = await readDigestFromRedis();
   }
-  if (!digest) throw new Error('No news digest found in Redis');
+  if (!digest) {
+    // LKG fallback: reuse existing insights if digest is unavailable
+    const existing = await readExistingInsights();
+    if (existing?.topStories?.length) {
+      console.log('  Digest unavailable — reusing existing insights (LKG)');
+      return existing;
+    }
+    throw new Error('No news digest found in Redis');
+  }
 
   // Digest shape: { categories: { politics: { items: [...] }, ... }, feedStatuses, generatedAt }
   let items;
@@ -318,5 +328,6 @@ runSeed('news', 'insights', CANONICAL_KEY, fetchInsights, {
   sourceVersion: 'digest-clustering-v1',
 }).catch((err) => {
   console.error('FATAL:', err.message || err);
-  process.exit(1);
+  // Exit gracefully for cron — health endpoint flags stale data via seed-meta.
+  process.exit(0);
 });


### PR DESCRIPTION
## Summary
Fixes three failure modes observed in Railway seed-insights logs:

- **Groq 429 + OpenRouter empty** → already handled (degraded publish + LKG preservation), no change needed
- **Digest key missing from Redis** → warm-via-RPC succeeds (HTTP 200) but data doesn't propagate instantly. Added 3s delay after warm before re-reading. If still missing, fall back to existing insights payload (LKG) instead of crashing
- **`process.exit(1)` on failure** → changed to `exit(0)` so Railway cron doesn't restart the container on transient failures. Health endpoint flags stale data via seed-meta

## Changes
1. Wait 3s after RPC warm before re-reading digest from Redis
2. LKG fallback: reuse existing `news:insights:v1` if digest is unavailable
3. Graceful exit (0) on fatal errors

## Test plan
- [ ] Deploy to Railway and verify seed completes or exits gracefully
- [ ] Simulate missing digest key — should fall back to existing insights
- [ ] Confirm no container restart loops in Railway logs