### PR TITLE
fix(insights): swap OpenRouter model to gemini-2.5-flash

### DIFF
--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -70,7 +70,7 @@ const LLM_PROVIDERS = [
     name: 'openrouter',
     envKey: 'OPENROUTER_API_KEY',
     apiUrl: 'https://openrouter.ai/api/v1/chat/completions',
-    model: 'openai/gpt-oss-safeguard-20b:nitro',
+    model: 'google/gemini-2.5-flash',
     headers: (key) => ({ 'Authorization': `Bearer ${key}`, 'Content-Type': 'application/json', 'HTTP-Referer': 'https://worldmonitor.app', 'X-Title': 'WorldMonitor', 'User-Agent': CHROME_UA }),
     timeout: 20_000,
   },

--- a/server/worldmonitor/news/v1/_shared.ts
+++ b/server/worldmonitor/news/v1/_shared.ts
@@ -170,7 +170,7 @@ export function getProviderCredentials(provider: string): ProviderCredentials | 
     if (!apiKey) return null;
     return {
       apiUrl: 'https://openrouter.ai/api/v1/chat/completions',
-      model: 'openai/gpt-oss-safeguard-20b:nitro',
+      model: 'google/gemini-2.5-flash',
       headers: {
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- Swap OpenRouter model from `openai/gpt-oss-safeguard-20b:nitro` to `google/gemini-2.5-flash`
- Old model was returning empty responses, causing degraded insights (no world brief)
- Updated in both seed script and server-side RPC handler

## Files changed
- `scripts/seed-insights.mjs` — seed cron model config
- `server/worldmonitor/news/v1/_shared.ts` — server-side provider config

## Test plan
- [ ] Verify next seed-insights run generates a brief successfully
- [ ] Check Railway logs for `Brief generated via openrouter` confirmation