### PR TITLE
fix(techReadiness): use seed data only, never call WB API from frontend

### DIFF
--- a/src/services/economic/index.ts
+++ b/src/services/economic/index.ts
@@ -495,64 +495,25 @@ export async function getTechReadinessRankings(
   const hydrated = getHydratedData('techReadiness') as TechReadinessScore[] | undefined;
   if (hydrated?.length && !countries) return hydrated;
 
-  const [internet, mobile, broadband, rdSpend] = await Promise.all([
-    getIndicatorData('IT.NET.USER.ZS', { countries, years: 5 }),
-    getIndicatorData('IT.CEL.SETS.P2', { countries, years: 5 }),
-    getIndicatorData('IT.NET.BBND.P2', { countries, years: 5 }),
-    getIndicatorData('GB.XPD.RSDV.GD.ZS', { countries, years: 7 }),
-  ]);
-
-  const allCountries = new Set<string>();
-  [internet, mobile, broadband, rdSpend].forEach((data) => {
-    Object.keys(data.latestByCountry).forEach((c) => allCountries.add(c));
-  });
-
-  const normalize = (val: number | undefined, max: number): number | null => {
-    if (val === undefined || val === null) return null;
-    return Math.min(100, (val / max) * 100);
-  };
-
-  const scores: TechReadinessScore[] = [];
-
-  for (const countryCode of allCountries) {
-    const components = {
-      internet: normalize(internet.latestByCountry[countryCode]?.value, 100),
-      mobile: normalize(mobile.latestByCountry[countryCode]?.value, 150),
-      broadband: normalize(broadband.latestByCountry[countryCode]?.value, 50),
-      rdSpend: normalize(rdSpend.latestByCountry[countryCode]?.value, 5),
-    };
-
-    const weights = { internet: 30, mobile: 15, broadband: 20, rdSpend: 35 };
-    let totalWeight = 0;
-    let weightedSum = 0;
-
-    for (const [key, weight] of Object.entries(weights)) {
-      const val = components[key as keyof typeof components];
-      if (val !== null) {
-        weightedSum += val * weight;
-        totalWeight += weight;
+  // Fallback: fetch the pre-computed seed key directly from bootstrap endpoint.
+  // The data is seeded by seed-wb-indicators.mjs — we never call the World Bank
+  // API directly from the frontend (it hangs/fails from Vercel Edge).
+  try {
+    const resp = await fetch('/api/bootstrap?keys=techReadiness', {
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (resp.ok) {
+      const { data } = (await resp.json()) as { data: { techReadiness?: TechReadinessScore[] } };
+      if (data.techReadiness?.length) {
+        const scores = countries
+          ? data.techReadiness.filter(s => countries.includes(s.country))
+          : data.techReadiness;
+        return scores;
       }
     }
+  } catch { /* fall through */ }
 
-    const score = totalWeight > 0 ? weightedSum / totalWeight : 0;
-    const countryName =
-      internet.latestByCountry[countryCode]?.name ||
-      mobile.latestByCountry[countryCode]?.name ||
-      countryCode;
-
-    scores.push({
-      country: countryCode,
-      countryName,
-      score: Math.round(score * 10) / 10,
-      rank: 0,
-      components,
-    });
-  }
-
-  scores.sort((a, b) => b.score - a.score);
-  scores.forEach((s, i) => { s.rank = i + 1; });
-
-  return scores;
+  return [];
 }
 
 export async function getCountryComparison(


### PR DESCRIPTION
## Summary
Tech Readiness panel stuck on "Fetching World Bank Data" forever.

**Root cause**: When bootstrap hydration misses (deployed v2.5.23 has 800ms timeout — too short), the panel falls through to making 4 direct World Bank API calls via Vercel Edge. These calls fail/timeout, `cachedFetchJson` caches a negative sentinel, and the panel hangs indefinitely.

**Fix**: Replace the 4 direct WB API calls with a single fetch of the pre-computed seed key from the bootstrap endpoint (`/api/bootstrap?keys=techReadiness`). Data is seeded by `seed-wb-indicators.mjs` on Railway — the frontend should never call the World Bank API directly.

## Before
```
getTechReadinessRankings()
  → getHydratedData('techReadiness')  // miss (800ms timeout)
  → 4x listWorldBankIndicators RPC    // all fail from Edge
  → negative sentinel cached           // panel stuck forever
```

## After
```
getTechReadinessRankings()
  → getHydratedData('techReadiness')  // miss
  → fetch /api/bootstrap?keys=techReadiness  // single call, reads seed data
  → 255 countries returned             // panel renders
```

## Test plan
- [ ] Deploy and verify Tech Readiness panel loads data
- [ ] Verify no World Bank API calls in browser network tab
- [ ] Clear bootstrap cache → panel should still load via fallback fetch