### PR TITLE
fix(rate-limit): per-endpoint rate limits for summarize endpoints

### DIFF
--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -1,4 +1,4 @@
-import { Ratelimit } from '@upstash/ratelimit';
+import { Ratelimit, type Duration } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 
 let ratelimit: Ratelimit | null = null;
@@ -40,6 +40,78 @@ export async function checkRateLimit(
 
   try {
     const { success, limit, reset } = await rl.limit(ip);
+
+    if (!success) {
+      return new Response(JSON.stringify({ error: 'Too many requests' }), {
+        status: 429,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-RateLimit-Limit': String(limit),
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': String(reset),
+          'Retry-After': String(Math.ceil((reset - Date.now()) / 1000)),
+          ...corsHeaders,
+        },
+      });
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// --- Per-endpoint rate limiting ---
+
+interface EndpointRatePolicy {
+  limit: number;
+  window: Duration;
+}
+
+const ENDPOINT_RATE_POLICIES: Record<string, EndpointRatePolicy> = {
+  '/api/news/v1/summarize-article': { limit: 20, window: '60 s' },
+  '/api/news/v1/summarize-article-cache': { limit: 3000, window: '60 s' },
+};
+
+const endpointLimiters = new Map<string, Ratelimit>();
+
+function getEndpointRatelimit(pathname: string): Ratelimit | null {
+  const policy = ENDPOINT_RATE_POLICIES[pathname];
+  if (!policy) return null;
+
+  const cached = endpointLimiters.get(pathname);
+  if (cached) return cached;
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  const rl = new Ratelimit({
+    redis: new Redis({ url, token }),
+    limiter: Ratelimit.slidingWindow(policy.limit, policy.window),
+    prefix: 'rl:ep',
+    analytics: false,
+  });
+  endpointLimiters.set(pathname, rl);
+  return rl;
+}
+
+export function hasEndpointRatePolicy(pathname: string): boolean {
+  return pathname in ENDPOINT_RATE_POLICIES;
+}
+
+export async function checkEndpointRateLimit(
+  request: Request,
+  pathname: string,
+  corsHeaders: Record<string, string>,
+): Promise<Response | null> {
+  const rl = getEndpointRatelimit(pathname);
+  if (!rl) return null;
+
+  const ip = getClientIp(request);
+
+  try {
+    const { success, limit, reset } = await rl.limit(`${pathname}:${ip}`);
 
     if (!success) {
       return new Response(JSON.stringify({ error: 'Too many requests' }), {

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -14,7 +14,7 @@ import { getCorsHeaders, isDisallowedOrigin } from './cors';
 // @ts-expect-error — JS module, no declaration file
 import { validateApiKey } from '../api/_api-key.js';
 import { mapErrorToResponse } from './error-mapper';
-import { checkRateLimit } from './_shared/rate-limit';
+import { checkRateLimit, checkEndpointRateLimit, hasEndpointRatePolicy } from './_shared/rate-limit';
 import { drainResponseHeaders } from './_shared/response-headers';
 import type { ServerOptions } from '../src/generated/server/worldmonitor/seismology/v1/service_server';
 
@@ -166,9 +166,17 @@ export function createDomainGateway(
       });
     }
 
-    // IP-based rate limiting (60 req/min sliding window)
-    const rateLimitResponse = await checkRateLimit(request, corsHeaders);
-    if (rateLimitResponse) return rateLimitResponse;
+    // IP-based rate limiting — two-phase: endpoint-specific first, then global fallback
+    const rawPathname = new URL(request.url).pathname;
+    const pathname = rawPathname.length > 1 ? rawPathname.replace(/\/+$/, '') : rawPathname;
+
+    const endpointRlResponse = await checkEndpointRateLimit(request, pathname, corsHeaders);
+    if (endpointRlResponse) return endpointRlResponse;
+
+    if (!hasEndpointRatePolicy(pathname)) {
+      const rateLimitResponse = await checkRateLimit(request, corsHeaders);
+      if (rateLimitResponse) return rateLimitResponse;
+    }
 
     // Route matching — if POST doesn't match, convert to GET for stale clients
     let matchedHandler = router.match(request);
@@ -233,7 +241,6 @@ export function createDomainGateway(
         mergedHeaders.set('Cache-Control', 'no-store');
         mergedHeaders.set('X-Cache-Tier', 'no-store');
       } else {
-        const pathname = new URL(request.url).pathname;
         const rpcName = pathname.split('/').pop() ?? '';
         const envOverride = process.env[`CACHE_TIER_OVERRIDE_${rpcName.replace(/-/g, '_').toUpperCase()}`] as CacheTier | undefined;
         const tier = (envOverride && envOverride in TIER_HEADERS ? envOverride : null) ?? RPC_CACHE_TIER[pathname] ?? 'medium';


### PR DESCRIPTION
## Summary

- Cache lookups (`summarize-article-cache`) shared the global 600/60s IP rate limit with expensive LLM calls (`summarize-article`), causing users to burn rate limit budget on cheap Redis reads
- Added `ENDPOINT_RATE_POLICIES` map with per-endpoint Upstash sliding window limiters
- `summarize-article` POST: **20 req/60s** (protects LLM provider quota)
- `summarize-article-cache` GET: **3000 req/60s** (generous for normal browsing)
- Gateway uses two-phase check: endpoint-specific first → global fallback only for unconfigured endpoints
- Path normalization (trailing slash strip) prevents bypass via `/api/news/v1/summarize-article/`

## Test plan

- [ ] `tsc --noEmit` and `tsc --noEmit -p tsconfig.api.json` pass
- [ ] `summarize-article-cache` GET can be called >600 times/min without 429
- [ ] `summarize-article` POST returns 429 after 20 calls/min from same IP
- [ ] Other endpoints (e.g. `list-earthquakes`) still limited at 600/60s
- [ ] 429 responses include `Retry-After` and CORS headers