### PR TITLE
ci(lint): add markdown lint to pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -22,5 +22,8 @@ done
 echo "Running edge function tests..."
 node --test tests/edge-functions.test.mjs || exit 1
 
+echo "Running markdown lint..."
+npm run lint:md || exit 1
+
 echo "Running version sync check..."
 npm run version:check || exit 1

--- a/pro-test/README.md
+++ b/pro-test/README.md
@@ -12,7 +12,6 @@ View your app in AI Studio: https://ai.studio/apps/ef577c64-7776-42d3-bb38-3f0a6
 
 **Prerequisites:**  Node.js
 
-
 1. Install dependencies:
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key


### PR DESCRIPTION
## Summary
- Add `npm run lint:md` to `.husky/pre-push` so markdown lint errors are caught locally before push
- Fix existing MD012 violation in `pro-test/README.md` (extra blank line)

## Test plan
- [x] `npm run lint:md` passes with 0 errors