### PR TITLE
fix(economic): guard all BIS and spending array access with optional chaining

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1999,8 +1999,8 @@ export class DataLoaderManager implements AppModule {
     try {
       const data = await fetchRecentAwards({ daysBack: 7, limit: 15 });
       economicPanel?.updateSpending(data);
-      this.ctx.statusPanel?.updateApi('USASpending', { status: data.awards.length > 0 ? 'ok' : 'error' });
-      if (data.awards.length > 0) {
+      this.ctx.statusPanel?.updateApi('USASpending', { status: data.awards?.length > 0 ? 'ok' : 'error' });
+      if (data.awards?.length > 0) {
         dataFreshness.recordUpdate('spending', data.awards.length);
       } else {
         dataFreshness.recordError('spending', 'No awards returned');
@@ -2017,10 +2017,10 @@ export class DataLoaderManager implements AppModule {
     try {
       const data = await fetchBisData();
       economicPanel?.updateBis(data);
-      const hasData = data.policyRates.length > 0;
+      const hasData = data.policyRates?.length > 0;
       this.ctx.statusPanel?.updateApi('BIS', { status: hasData ? 'ok' : 'error' });
       if (hasData) {
-        dataFreshness.recordUpdate('bis', data.policyRates.length);
+        dataFreshness.recordUpdate('bis', data.policyRates!.length);
       }
     } catch (e) {
       console.error('[App] BIS data failed:', e);

--- a/src/components/EconomicPanel.ts
+++ b/src/components/EconomicPanel.ts
@@ -59,8 +59,8 @@ export class EconomicPanel extends Panel {
 
   private render(): void {
     const hasOil = this.oilData && (this.oilData.wtiPrice || this.oilData.brentPrice);
-    const hasSpending = this.spendingData && this.spendingData.awards.length > 0;
-    const hasBis = this.bisData && this.bisData.policyRates.length > 0;
+    const hasSpending = this.spendingData && this.spendingData.awards?.length > 0;
+    const hasBis = this.bisData && this.bisData.policyRates?.length > 0;
 
     // Build tabs HTML
     const tabsHtml = `
@@ -206,7 +206,7 @@ export class EconomicPanel extends Panel {
   }
 
   private renderSpending(): string {
-    if (!this.spendingData || this.spendingData.awards.length === 0) {
+    if (!this.spendingData || !this.spendingData.awards?.length) {
       return `<div class="economic-empty">${t('components.economic.noSpending')}</div>`;
     }
 
@@ -236,7 +236,7 @@ export class EconomicPanel extends Panel {
   }
 
   private renderCentralBanks(): string {
-    if (!this.bisData || this.bisData.policyRates.length === 0) {
+    if (!this.bisData || !this.bisData.policyRates?.length) {
       return `<div class="economic-empty">${t('components.economic.noBisData')}</div>`;
     }
 
@@ -274,7 +274,7 @@ export class EconomicPanel extends Panel {
 
     // Exchange Rates
     let eerHtml = '';
-    if (this.bisData.exchangeRates.length > 0) {
+    if (this.bisData.exchangeRates?.length > 0) {
       eerHtml = `
         <div class="bis-section">
           <div class="bis-section-title">${t('components.economic.realEer')}</div>
@@ -302,7 +302,7 @@ export class EconomicPanel extends Panel {
 
     // Credit-to-GDP
     let creditHtml = '';
-    if (this.bisData.creditToGdp.length > 0) {
+    if (this.bisData.creditToGdp?.length > 0) {
       const sortedCredit = [...this.bisData.creditToGdp].sort((a, b) => b.creditGdpRatio - a.creditGdpRatio);
       creditHtml = `
         <div class="bis-section">

--- a/src/services/economic/index.ts
+++ b/src/services/economic/index.ts
@@ -558,9 +558,9 @@ export async function fetchBisData(): Promise<BisData> {
       hCredit?.entries?.length ? Promise.resolve(hCredit) : bisCreditBreaker.execute(() => client.getBisCredit({}, { signal: AbortSignal.timeout(20_000) }), emptyBisCreditFallback),
     ]);
     return {
-      policyRates: policy.rates,
-      exchangeRates: eer.rates,
-      creditToGdp: credit.entries,
+      policyRates: policy.rates ?? [],
+      exchangeRates: eer.rates ?? [],
+      creditToGdp: credit.entries ?? [],
       fetchedAt: new Date(),
     };
   } catch {


### PR DESCRIPTION
## Summary
- Fixes `TypeError: Cannot read properties of undefined (reading 'length')` for BIS and government spending data in `EconomicPanel`
- Previous fix (#1162) missed several `.length` access points where arrays can be `undefined` from hydrated bootstrap data
- Adds `?? []` defaults at source (`fetchBisData`) and `?.length` guards at all consumer sites

## Changes
- `src/services/economic/index.ts` — default `policy.rates`, `eer.rates`, `credit.entries` to `[]` via `??`
- `src/components/EconomicPanel.ts` — optional chaining on all array `.length` checks in `render()`, `renderSpending()`, `renderCentralBanks()`
- `src/app/data-loader.ts` — optional chaining on `data.awards?.length` and `data.policyRates?.length`

## Test plan
- [x] `tsc --noEmit` passes
- [x] All pre-push checks pass (60/60 tests, lint, edge function checks)
- [ ] Verify BIS and spending tabs load without console errors in production