### PR TITLE
fix(panels): clear stuck error headers, sanitize error messages, and restore FRED config UX

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1930,7 +1930,7 @@ export class DataLoaderManager implements AppModule {
 
       if (data.length === 0) {
         if (!isFeatureAvailable('economicFred')) {
-          economicPanel?.showError();
+          economicPanel?.showConfigError(t('components.economic.fredKeyMissing'));
           this.ctx.statusPanel?.updateApi('FRED', { status: 'error' });
           return;
         }
@@ -1942,14 +1942,12 @@ export class DataLoaderManager implements AppModule {
           this.ctx.statusPanel?.updateApi('FRED', { status: 'error' });
           return;
         }
-        economicPanel?.setErrorState(false);
         economicPanel?.update(retryData);
         this.ctx.statusPanel?.updateApi('FRED', { status: 'ok' });
         dataFreshness.recordUpdate('economic', retryData.length);
         return;
       }
 
-      economicPanel?.setErrorState(false);
       economicPanel?.update(data);
       this.ctx.statusPanel?.updateApi('FRED', { status: 'ok' });
       dataFreshness.recordUpdate('economic', data.length);
@@ -1960,7 +1958,6 @@ export class DataLoaderManager implements AppModule {
           await new Promise(r => setTimeout(r, 20_000));
           const retryData = await fetchFredData();
           if (retryData.length > 0) {
-            economicPanel?.setErrorState(false);
             economicPanel?.update(retryData);
             this.ctx.statusPanel?.updateApi('FRED', { status: 'ok' });
             dataFreshness.recordUpdate('economic', retryData.length);

--- a/src/components/CIIPanel.ts
+++ b/src/components/CIIPanel.ts
@@ -135,10 +135,12 @@ export class CIIPanel extends Panel {
       this.setCount(withData.length);
 
       if (withData.length === 0) {
+        this.setErrorState(false);
         replaceChildren(this.content, h('div', { className: 'empty-state' }, t('components.cii.noSignals')));
         return;
       }
 
+      this.setErrorState(false);
       const listEl = h('div', { className: 'cii-list' }, ...withData.map(s => this.buildCountry(s)));
       replaceChildren(this.content, listEl);
       this.bindShareButtons();
@@ -154,6 +156,7 @@ export class CIIPanel extends Panel {
     this.scores = scores;
     this.hasCachedRender = true;
     this.setCount(scores.length);
+    this.setErrorState(false);
     const listEl = h('div', { className: 'cii-list' }, ...scores.map(s => this.buildCountry(s)));
     replaceChildren(this.content, listEl);
     this.bindShareButtons();

--- a/src/components/ETFFlowsPanel.ts
+++ b/src/components/ETFFlowsPanel.ts
@@ -68,7 +68,8 @@ export class ETFFlowsPanel extends Panel {
           if (!this.element?.isConnected) return;
           continue;
         }
-        this.error = err instanceof Error ? err.message : 'Failed to fetch';
+        console.warn('[ETFFlows] Fetch error:', err);
+        this.error = null;
       }
     }
     this.loading = false;

--- a/src/components/GdeltIntelPanel.ts
+++ b/src/components/GdeltIntelPanel.ts
@@ -99,6 +99,7 @@ export class GdeltIntelPanel extends Panel {
   }
 
   private renderArticles(articles: GdeltArticle[]): void {
+    this.setErrorState(false);
     if (articles.length === 0) {
       replaceChildren(this.content, h('div', { className: 'empty-state' }, t('components.gdelt.empty')));
       return;

--- a/src/components/MacroSignalsPanel.ts
+++ b/src/components/MacroSignalsPanel.ts
@@ -164,7 +164,8 @@ export class MacroSignalsPanel extends Panel {
           if (!this.element?.isConnected) return false;
           continue;
         }
-        this.error = err instanceof Error ? err.message : 'Failed to fetch';
+        console.warn('[MacroSignals] Fetch error:', err);
+        this.error = null;
       }
     }
     this.loading = false;

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -638,6 +638,7 @@ export class Panel {
 
   public showLoading(message = t('common.loading')): void {
     if (this._locked) return;
+    this.setErrorState(false);
     this.clearRetryCountdown();
     replaceChildren(this.content,
       h('div', { className: 'panel-loading' },
@@ -690,7 +691,7 @@ export class Panel {
     this.retryAttempt = 0;
   }
 
-  public showLocked(_features: string[] = []): void {
+  public showLocked(features: string[] = []): void {
     this._locked = true;
     this.clearRetryCountdown();
 
@@ -707,6 +708,14 @@ export class Panel {
       iconEl,
       h('div', { className: 'panel-locked-desc' }, t('premium.lockedDesc')),
     ];
+
+    if (features.length > 0) {
+      const featureList = h('ul', { className: 'panel-locked-features' });
+      for (const feat of features) {
+        featureList.appendChild(h('li', {}, feat));
+      }
+      lockedChildren.push(featureList);
+    }
 
     const ctaBtn = h('button', { type: 'button', className: 'panel-locked-cta' }, t('premium.joinWaitlist'));
     if (isDesktopRuntime()) {
@@ -812,6 +821,7 @@ export class Panel {
 
   public setContent(html: string): void {
     if (this._locked) return;
+    this.setErrorState(false);
     this.clearRetryCountdown();
     this.retryAttempt = 0;
     if (this.pendingContentHtml === html || this.content.innerHTML === html) {

--- a/src/components/ServiceStatusPanel.ts
+++ b/src/components/ServiceStatusPanel.ts
@@ -63,7 +63,7 @@ export class ServiceStatusPanel extends Panel {
     } catch (err) {
       if (this.isAbortError(err)) return false;
       if (!this.element?.isConnected) return false;
-      this.error = err instanceof Error ? err.message : 'Failed to fetch';
+      this.error = t('common.failedToLoad');
       console.error('[ServiceStatus] Fetch error:', err);
       return true;
     } finally {
@@ -100,6 +100,7 @@ export class ServiceStatusPanel extends Panel {
       return;
     }
 
+    this.setErrorState(false);
     const filtered = this.getFilteredServices();
     const issues = filtered.filter(s => s.status !== 'operational');
 

--- a/src/components/StablecoinPanel.ts
+++ b/src/components/StablecoinPanel.ts
@@ -68,7 +68,8 @@ export class StablecoinPanel extends Panel {
           if (!this.element?.isConnected) return;
           continue;
         }
-        this.error = err instanceof Error ? err.message : 'Failed to fetch';
+        console.warn('[Stablecoin] Fetch error:', err);
+        this.error = null;
       }
     }
     this.loading = false;

--- a/src/components/TechEventsPanel.ts
+++ b/src/components/TechEventsPanel.ts
@@ -60,7 +60,7 @@ export class TechEventsPanel extends Panel {
           if (!this.element?.isConnected) return;
           continue;
         }
-        this.error = err instanceof Error ? err.message : 'Failed to fetch events';
+        this.error = t('common.failedToLoad');
         console.error('[TechEvents] Fetch error:', err);
       }
     }
@@ -84,6 +84,7 @@ export class TechEventsPanel extends Panel {
       return;
     }
 
+    this.setErrorState(false);
     const filteredEvents = this.getFilteredEvents();
     const upcomingConferences = this.events.filter(e => e.type === 'conference' && new Date(e.startDate) >= new Date());
     const mappableCount = upcomingConferences.filter(e => e.coords && !e.coords.virtual).length;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9325,6 +9325,20 @@ a.prediction-link:hover {
   color: var(--text-dim, #888);
 }
 
+.panel-locked-features {
+  list-style: none;
+  padding: 0;
+  margin: 4px 0;
+  font-size: 10px;
+  color: var(--text-dim, #888);
+  text-align: center;
+}
+
+.panel-locked-features li::before {
+  content: "— ";
+  color: #d4a843;
+}
+
 .panel-locked-cta {
   padding: 6px 18px;
   font-size: 11px;


### PR DESCRIPTION
## Summary

- **Error recovery**: Panel headers stay red after transient errors recover. Added `setErrorState(false)` to `Panel.setContent()` and `showLoading()` (covers ~70+ panels), plus explicit calls in 4 panels using `replaceChildren` directly (ServiceStatus, TechEvents, CII, GdeltIntel)
- **Raw error leaks**: 5 panels exposed raw `err.message` to users. Group A (Stablecoin, ETFFlows, MacroSignals) now log + null the error so localized fallback activates. Group B (ServiceStatus, TechEvents) use `t('common.failedToLoad')`
- **FRED config**: Restored actionable `showConfigError()` with Settings button on desktop when FRED API key is missing
- **Premium features**: `showLocked()` now renders the feature list it receives instead of discarding it

## Test plan

- [ ] Disconnect network → wait for error (red header) → reconnect → verify header clears on recovery
- [ ] Test on ServiceStatus, CII, TechEvents, GdeltIntel (replaceChildren panels)
- [ ] Trigger fetch error on Stablecoin/ETF/Macro → verify "No data" shown, not raw error text
- [ ] Desktop: remove FRED key → verify "FRED key missing" with Settings button
- [ ] Check locked panel (e.g. oref-sirens) → verify feature bullets render
- [ ] Toggle dark/light theme with locked panel → verify readability