### PR TITLE
fix(cache): add no-cache header for /pro exact path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -44,7 +44,13 @@
       ]
     },
     {
-      "source": "/pro/(.*)",
+      "source": "/pro/:path*",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/pro",
       "headers": [
         { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
       ]


### PR DESCRIPTION
## Summary
- `/pro/(.*)` header rule only matches subpaths like `/pro/assets/...`, not `/pro` itself
- Cloudflare cached the `/pro` HTML page, serving stale bundles after deploys (old `index--Jy-bdnT.js` instead of new `index-OBYEb4DO.js`)
- Added explicit `/pro` header rule with `no-cache, no-store`

## Test plan
- [ ] After merge + CF cache purge, `/pro` should serve fresh HTML with new bundle hash
- [ ] Verify `Cache-Control: no-cache, no-store, must-revalidate` on `/pro` response