### PR TITLE
fix(panels): unify tab styles across all panels

### DIFF
--- a/src/components/AirlineIntelPanel.ts
+++ b/src/components/AirlineIntelPanel.ts
@@ -105,10 +105,10 @@ export class AirlineIntelPanel extends Panel {
 
         // Insert tab bar between header and content
         this.tabBar = document.createElement('div');
-        this.tabBar.className = 'airline-intel-tabs';
+        this.tabBar.className = 'panel-tabs';
         TABS.forEach(tab => {
             const btn = document.createElement('button');
-            btn.className = `tab-btn${tab === this.activeTab ? ' active' : ''}`;
+            btn.className = `panel-tab${tab === this.activeTab ? ' active' : ''}`;
             btn.textContent = TAB_LABELS[tab];
             btn.dataset.tab = tab;
             btn.addEventListener('click', () => this.switchTab(tab as Tab));
@@ -159,7 +159,7 @@ export class AirlineIntelPanel extends Panel {
 
     private switchTab(tab: Tab): void {
         this.activeTab = tab;
-        this.tabBar.querySelectorAll('.tab-btn').forEach(b => {
+        this.tabBar.querySelectorAll('.panel-tab').forEach(b => {
             b.classList.toggle('active', (b as HTMLElement).dataset.tab === tab);
         });
         this.renderTab();

--- a/src/components/CascadePanel.ts
+++ b/src/components/CascadePanel.ts
@@ -100,7 +100,7 @@ export class CascadePanel extends Panel {
   private renderSelector(): string {
     const nodes = this.getFilteredNodes();
     const filterButtons = ['cable', 'pipeline', 'port', 'chokepoint'].map((f) =>
-      `<button class="cascade-filter-btn ${this.filter === f ? 'active' : ''}" data-filter="${f}" role="radio" aria-checked="${this.filter === f}" aria-label="${this.getFilterLabel(f as Exclude<NodeFilter, 'all'>)}">
+      `<button class="panel-tab ${this.filter === f ? 'active' : ''}" data-filter="${f}" role="radio" aria-checked="${this.filter === f}" aria-label="${this.getFilterLabel(f as Exclude<NodeFilter, 'all'>)}">
         ${this.getNodeTypeEmoji(f)} ${this.getFilterLabel(f as Exclude<NodeFilter, 'all'>)}
       </button>`
     ).join('');
@@ -114,7 +114,7 @@ export class CascadePanel extends Panel {
 
     return `
       <div class="cascade-selector">
-        <div class="cascade-filters" role="radiogroup" aria-label="Infrastructure type filter">${filterButtons}</div>
+        <div class="panel-tabs" role="radiogroup" aria-label="Infrastructure type filter">${filterButtons}</div>
         <select class="cascade-select" ${nodes.length === 0 ? 'disabled' : ''}>
           <option value="">${t('components.cascade.selectPrompt', { type: selectedType })}</option>
           ${nodeOptions}
@@ -207,7 +207,7 @@ export class CascadePanel extends Panel {
     this.content.addEventListener('click', (e: Event) => {
       const target = e.target as HTMLElement;
 
-      const filterBtn = target.closest<HTMLElement>('.cascade-filter-btn');
+      const filterBtn = target.closest<HTMLElement>('.panel-tab');
       if (filterBtn) {
         this.filter = filterBtn.getAttribute('data-filter') as NodeFilter;
         this.selectedNode = null;

--- a/src/components/DisplacementPanel.ts
+++ b/src/components/DisplacementPanel.ts
@@ -52,9 +52,9 @@ export class DisplacementPanel extends Panel {
     ).join('');
 
     const tabsHtml = `
-      <div class="disp-tabs" role="tablist" aria-label="Displacement data view">
-        <button class="disp-tab ${this.activeTab === 'origins' ? 'disp-tab-active' : ''}" data-tab="origins" role="tab" aria-selected="${this.activeTab === 'origins'}" id="disp-tab-origins" aria-controls="disp-tab-panel">${t('components.displacement.origins')}</button>
-        <button class="disp-tab ${this.activeTab === 'hosts' ? 'disp-tab-active' : ''}" data-tab="hosts" role="tab" aria-selected="${this.activeTab === 'hosts'}" id="disp-tab-hosts" aria-controls="disp-tab-panel">${t('components.displacement.hosts')}</button>
+      <div class="panel-tabs" role="tablist" aria-label="Displacement data view">
+        <button class="panel-tab ${this.activeTab === 'origins' ? 'active' : ''}" data-tab="origins" role="tab" aria-selected="${this.activeTab === 'origins'}" id="disp-tab-origins" aria-controls="disp-tab-panel">${t('components.displacement.origins')}</button>
+        <button class="panel-tab ${this.activeTab === 'hosts' ? 'active' : ''}" data-tab="hosts" role="tab" aria-selected="${this.activeTab === 'hosts'}" id="disp-tab-hosts" aria-controls="disp-tab-panel">${t('components.displacement.hosts')}</button>
       </div>
     `;
 
@@ -121,7 +121,7 @@ export class DisplacementPanel extends Panel {
       </div>
     `);
 
-    this.content.querySelectorAll('.disp-tab').forEach(btn => {
+    this.content.querySelectorAll('.panel-tab').forEach(btn => {
       btn.addEventListener('click', () => {
         this.activeTab = (btn as HTMLElement).dataset.tab as DisplacementTab;
         this.renderContent();

--- a/src/components/EconomicPanel.ts
+++ b/src/components/EconomicPanel.ts
@@ -22,7 +22,7 @@ export class EconomicPanel extends Panel {
   constructor() {
     super({ id: 'economic', title: t('panels.economic') });
     this.content.addEventListener('click', (e) => {
-      const tab = (e.target as HTMLElement).closest('.economic-tab') as HTMLElement | null;
+      const tab = (e.target as HTMLElement).closest('.panel-tab') as HTMLElement | null;
       if (tab?.dataset.tab) {
         this.activeTab = tab.dataset.tab as TabId;
         this.render();
@@ -64,22 +64,22 @@ export class EconomicPanel extends Panel {
 
     // Build tabs HTML
     const tabsHtml = `
-      <div class="economic-tabs">
-        <button class="economic-tab ${this.activeTab === 'indicators' ? 'active' : ''}" data-tab="indicators">
+      <div class="panel-tabs">
+        <button class="panel-tab ${this.activeTab === 'indicators' ? 'active' : ''}" data-tab="indicators">
           📊 ${t('components.economic.indicators')}
         </button>
         ${hasOil ? `
-          <button class="economic-tab ${this.activeTab === 'oil' ? 'active' : ''}" data-tab="oil">
+          <button class="panel-tab ${this.activeTab === 'oil' ? 'active' : ''}" data-tab="oil">
             🛢️ ${t('components.economic.oil')}
           </button>
         ` : ''}
         ${hasSpending ? `
-          <button class="economic-tab ${this.activeTab === 'spending' ? 'active' : ''}" data-tab="spending">
+          <button class="panel-tab ${this.activeTab === 'spending' ? 'active' : ''}" data-tab="spending">
             🏛️ ${t('components.economic.gov')}
           </button>
         ` : ''}
         ${hasBis ? `
-          <button class="economic-tab ${this.activeTab === 'centralBanks' ? 'active' : ''}" data-tab="centralBanks">
+          <button class="panel-tab ${this.activeTab === 'centralBanks' ? 'active' : ''}" data-tab="centralBanks">
             🏦 ${t('components.economic.centralBanks')}
           </button>
         ` : ''}

--- a/src/components/GdeltIntelPanel.ts
+++ b/src/components/GdeltIntelPanel.ts
@@ -30,10 +30,10 @@ export class GdeltIntelPanel extends Panel {
   }
 
   private createTabs(): void {
-    this.tabsEl = h('div', { className: 'gdelt-intel-tabs' },
+    this.tabsEl = h('div', { className: 'panel-tabs' },
       ...getIntelTopics().map(topic =>
         h('button', {
-          className: `gdelt-intel-tab ${topic.id === this.activeTopic.id ? 'active' : ''}`,
+          className: `panel-tab ${topic.id === this.activeTopic.id ? 'active' : ''}`,
           dataset: { topicId: topic.id },
           title: topic.description,
           onClick: () => this.selectTopic(topic),
@@ -52,7 +52,7 @@ export class GdeltIntelPanel extends Panel {
 
     this.activeTopic = topic;
 
-    this.tabsEl?.querySelectorAll('.gdelt-intel-tab').forEach(tab => {
+    this.tabsEl?.querySelectorAll('.panel-tab').forEach(tab => {
       tab.classList.toggle('active', (tab as HTMLElement).dataset.topicId === topic.id);
     });
 

--- a/src/components/GivingPanel.ts
+++ b/src/components/GivingPanel.ts
@@ -64,8 +64,8 @@ export class GivingPanel extends Panel {
       institutional: t('components.giving.tabs.institutional'),
     };
     const tabsHtml = `
-      <div class="giving-tabs">
-        ${tabs.map(tab => `<button class="giving-tab ${this.activeTab === tab ? 'giving-tab-active' : ''}" data-tab="${tab}">${tabLabels[tab]}</button>`).join('')}
+      <div class="panel-tabs">
+        ${tabs.map(tab => `<button class="panel-tab ${this.activeTab === tab ? 'active' : ''}" data-tab="${tab}">${tabLabels[tab]}</button>`).join('')}
       </div>
     `;
 
@@ -96,7 +96,7 @@ export class GivingPanel extends Panel {
     `;
 
     // Attach tab click listeners
-    this.content.querySelectorAll('.giving-tab').forEach(btn => {
+    this.content.querySelectorAll('.panel-tab').forEach(btn => {
       btn.addEventListener('click', () => {
         this.activeTab = (btn as HTMLElement).dataset.tab as GivingTab;
         this.renderContent();

--- a/src/components/RegulationPanel.ts
+++ b/src/components/RegulationPanel.ts
@@ -23,11 +23,11 @@ export class RegulationPanel extends Panel {
       <div class="regulation-panel">
         <div class="regulation-header">
           <h3>${t('components.regulation.dashboard')}</h3>
-          <div class="regulation-tabs">
-            <button class="tab ${this.viewMode === 'timeline' ? 'active' : ''}" data-view="timeline">${t('components.regulation.timeline')}</button>
-            <button class="tab ${this.viewMode === 'deadlines' ? 'active' : ''}" data-view="deadlines">${t('components.regulation.deadlines')}</button>
-            <button class="tab ${this.viewMode === 'regulations' ? 'active' : ''}" data-view="regulations">${t('components.regulation.regulations')}</button>
-            <button class="tab ${this.viewMode === 'countries' ? 'active' : ''}" data-view="countries">${t('components.regulation.countries')}</button>
+          <div class="panel-tabs">
+            <button class="panel-tab ${this.viewMode === 'timeline' ? 'active' : ''}" data-view="timeline">${t('components.regulation.timeline')}</button>
+            <button class="panel-tab ${this.viewMode === 'deadlines' ? 'active' : ''}" data-view="deadlines">${t('components.regulation.deadlines')}</button>
+            <button class="panel-tab ${this.viewMode === 'regulations' ? 'active' : ''}" data-view="regulations">${t('components.regulation.regulations')}</button>
+            <button class="panel-tab ${this.viewMode === 'countries' ? 'active' : ''}" data-view="countries">${t('components.regulation.countries')}</button>
           </div>
         </div>
         <div class="regulation-content">
@@ -37,7 +37,7 @@ export class RegulationPanel extends Panel {
     `;
 
     // Add event listeners for tabs
-    this.content.querySelectorAll('.tab').forEach(tab => {
+    this.content.querySelectorAll('.panel-tab').forEach(tab => {
       tab.addEventListener('click', (e) => {
         const target = e.target as HTMLElement;
         const view = target.dataset.view as typeof this.viewMode;

--- a/src/components/SupplyChainPanel.ts
+++ b/src/components/SupplyChainPanel.ts
@@ -20,7 +20,7 @@ export class SupplyChainPanel extends Panel {
   constructor() {
     super({ id: 'supply-chain', title: t('panels.supplyChain') });
     this.content.addEventListener('click', (e) => {
-      const target = (e.target as HTMLElement).closest('.economic-tab') as HTMLElement | null;
+      const target = (e.target as HTMLElement).closest('.panel-tab') as HTMLElement | null;
       if (!target) return;
       const tabId = target.dataset.tab as TabId;
       if (tabId && tabId !== this.activeTab) {
@@ -47,14 +47,14 @@ export class SupplyChainPanel extends Panel {
 
   private render(): void {
     const tabsHtml = `
-      <div class="economic-tabs">
-        <button class="economic-tab ${this.activeTab === 'chokepoints' ? 'active' : ''}" data-tab="chokepoints">
+      <div class="panel-tabs">
+        <button class="panel-tab ${this.activeTab === 'chokepoints' ? 'active' : ''}" data-tab="chokepoints">
           ${t('components.supplyChain.chokepoints')}
         </button>
-        <button class="economic-tab ${this.activeTab === 'shipping' ? 'active' : ''}" data-tab="shipping">
+        <button class="panel-tab ${this.activeTab === 'shipping' ? 'active' : ''}" data-tab="shipping">
           ${t('components.supplyChain.shipping')}
         </button>
-        <button class="economic-tab ${this.activeTab === 'minerals' ? 'active' : ''}" data-tab="minerals">
+        <button class="panel-tab ${this.activeTab === 'minerals' ? 'active' : ''}" data-tab="minerals">
           ${t('components.supplyChain.minerals')}
         </button>
       </div>

--- a/src/components/TechEventsPanel.ts
+++ b/src/components/TechEventsPanel.ts
@@ -98,10 +98,10 @@ export class TechEventsPanel extends Panel {
 
     replaceChildren(this.content,
       h('div', { className: 'tech-events-panel' },
-        h('div', { className: 'tech-events-tabs' },
+        h('div', { className: 'panel-tabs' },
           ...tabEntries.map(([view, label]) =>
             h('button', {
-              className: `tab ${this.viewMode === view ? 'active' : ''}`,
+              className: `panel-tab ${this.viewMode === view ? 'active' : ''}`,
               dataset: { view },
               onClick: () => { this.viewMode = view; this.render(); },
             }, label),

--- a/src/components/TelegramIntelPanel.ts
+++ b/src/components/TelegramIntelPanel.ts
@@ -28,10 +28,10 @@ export class TelegramIntelPanel extends Panel {
   }
 
   private createTabs(): void {
-    this.tabsEl = h('div', { className: 'telegram-intel-tabs' },
+    this.tabsEl = h('div', { className: 'panel-tabs' },
       ...TELEGRAM_TOPICS.map(topic =>
         h('button', {
-          className: `telegram-intel-tab ${topic.id === this.activeTopic ? 'active' : ''}`,
+          className: `panel-tab ${topic.id === this.activeTopic ? 'active' : ''}`,
           dataset: { topicId: topic.id },
           onClick: () => this.selectTopic(topic.id),
         }, t(topic.labelKey)),
@@ -44,7 +44,7 @@ export class TelegramIntelPanel extends Panel {
     if (topicId === this.activeTopic) return;
     this.activeTopic = topicId;
 
-    this.tabsEl?.querySelectorAll('.telegram-intel-tab').forEach(tab => {
+    this.tabsEl?.querySelectorAll('.panel-tab').forEach(tab => {
       tab.classList.toggle('active', (tab as HTMLElement).dataset.topicId === topicId);
     });
 

--- a/src/components/TradePolicyPanel.ts
+++ b/src/components/TradePolicyPanel.ts
@@ -22,7 +22,7 @@ export class TradePolicyPanel extends Panel {
   constructor() {
     super({ id: 'trade-policy', title: t('panels.tradePolicy') });
     this.content.addEventListener('click', (e) => {
-      const target = (e.target as HTMLElement).closest('.economic-tab') as HTMLElement | null;
+      const target = (e.target as HTMLElement).closest('.panel-tab') as HTMLElement | null;
       if (!target) return;
       const tabId = target.dataset.tab as TabId;
       if (tabId && tabId !== this.activeTab) {
@@ -64,17 +64,17 @@ export class TradePolicyPanel extends Panel {
     const hasBarriers = this.barriersData && this.barriersData.barriers.length > 0;
 
     const tabsHtml = `
-      <div class="economic-tabs">
-        <button class="economic-tab ${this.activeTab === 'restrictions' ? 'active' : ''}" data-tab="restrictions">
+      <div class="panel-tabs">
+        <button class="panel-tab ${this.activeTab === 'restrictions' ? 'active' : ''}" data-tab="restrictions">
           ${t('components.tradePolicy.restrictions')}
         </button>
-        ${hasTariffs ? `<button class="economic-tab ${this.activeTab === 'tariffs' ? 'active' : ''}" data-tab="tariffs">
+        ${hasTariffs ? `<button class="panel-tab ${this.activeTab === 'tariffs' ? 'active' : ''}" data-tab="tariffs">
           ${t('components.tradePolicy.tariffs')}
         </button>` : ''}
-        ${hasFlows ? `<button class="economic-tab ${this.activeTab === 'flows' ? 'active' : ''}" data-tab="flows">
+        ${hasFlows ? `<button class="panel-tab ${this.activeTab === 'flows' ? 'active' : ''}" data-tab="flows">
           ${t('components.tradePolicy.flows')}
         </button>` : ''}
-        ${hasBarriers ? `<button class="economic-tab ${this.activeTab === 'barriers' ? 'active' : ''}" data-tab="barriers">
+        ${hasBarriers ? `<button class="panel-tab ${this.activeTab === 'barriers' ? 'active' : ''}" data-tab="barriers">
           ${t('components.tradePolicy.barriers')}
         </button>` : ''}
       </div>

--- a/src/components/UcdpEventsPanel.ts
+++ b/src/components/UcdpEventsPanel.ts
@@ -53,7 +53,7 @@ export class UcdpEventsPanel extends Panel {
     const totalDeaths = filtered.reduce((sum, e) => sum + e.deaths_best, 0);
 
     const tabsHtml = tabs.map(t =>
-      `<button class="ucdp-tab ${t.key === this.activeTab ? 'ucdp-tab-active' : ''}" data-tab="${t.key}">${t.label} <span class="ucdp-tab-count">${tabCounts[t.key]}</span></button>`
+      `<button class="panel-tab ${t.key === this.activeTab ? 'active' : ''}" data-tab="${t.key}">${t.label} <span class="ucdp-tab-count">${tabCounts[t.key]}</span></button>`
     ).join('');
 
     const displayed = filtered.slice(0, 50);
@@ -100,7 +100,7 @@ export class UcdpEventsPanel extends Panel {
     this.setContent(`
       <div class="ucdp-panel-content">
         <div class="ucdp-header">
-          <div class="ucdp-tabs">${tabsHtml}</div>
+          <div class="panel-tabs">${tabsHtml}</div>
           ${totalDeaths > 0 ? `<span class="ucdp-total-deaths">${t('components.ucdpEvents.deathsCount', { count: totalDeaths.toLocaleString() })}</span>` : ''}
         </div>
         ${bodyHtml}
@@ -108,7 +108,7 @@ export class UcdpEventsPanel extends Panel {
       </div>
     `);
 
-    this.content.querySelectorAll('.ucdp-tab').forEach(btn => {
+    this.content.querySelectorAll('.panel-tab').forEach(btn => {
       btn.addEventListener('click', () => {
         this.activeTab = (btn as HTMLElement).dataset.tab as UcdpEventType;
         this.renderContent();

--- a/src/live-channels-window.ts
+++ b/src/live-channels-window.ts
@@ -330,7 +330,7 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
 
       const btn = document.createElement('button');
       btn.type = 'button';
-      btn.className = 'live-news-manage-tab-btn' + (region.key === activeRegionTab ? ' active' : '');
+      btn.className = 'panel-tab' + (region.key === activeRegionTab ? ' active' : '');
       const label = t(region.labelKey) ?? region.key.toUpperCase();
       btn.textContent = term
         ? `${label} (${matchingChannels.length})`
@@ -442,7 +442,7 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
               <input type="text" id="liveChannelsSearch" class="live-news-manage-search-input" placeholder="${escapeHtml(t('header.search') ?? 'Search')}..." autocomplete="off" />
             </div>
           </div>
-          <div class="live-news-manage-tab-bar" id="liveChannelsTabBar"></div>
+          <div class="panel-tabs" id="liveChannelsTabBar"></div>
           <div class="live-news-manage-tab-contents" id="liveChannelsTabContents"></div>
         </div>
         <div class="live-news-manage-add-section">

--- a/src/styles/happy-theme.css
+++ b/src/styles/happy-theme.css
@@ -325,15 +325,13 @@
 /* ==========================================================
    Happy Tab Styles — Rounded boxed tabs (intentionally different)
    ========================================================== */
-[data-variant="happy"] .disp-tab,
-[data-variant="happy"] .ucdp-tab {
+[data-variant="happy"] .panel-tab {
   border: 1px solid var(--border-strong);
   border-bottom: 1px solid var(--border-strong);
   border-radius: 8px;
 }
 
-[data-variant="happy"] .disp-tab-active,
-[data-variant="happy"] .ucdp-tab-active {
+[data-variant="happy"] .panel-tab.active {
   background: color-mix(in srgb, var(--semantic-high) 12%, transparent);
   border-color: var(--semantic-high);
   color: var(--semantic-high);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2059,42 +2059,7 @@ body.panel-resize-active iframe {
   margin-top: 4px;
 }
 
-/* Tab bar */
-.live-news-manage-tab-bar {
-  display: flex;
-  gap: 0;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: 8px;
-  overflow-x: auto;
-}
-
-.live-news-manage-tab-bar::-webkit-scrollbar {
-  display: none;
-}
-
-.live-news-manage-tab-btn {
-  font-family: inherit;
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.75px;
-  padding: 6px 10px;
-  background: none;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-faint);
-  cursor: pointer;
-  white-space: nowrap;
-  transition: all 0.15s;
-}
-
-.live-news-manage-tab-btn:hover {
-  color: var(--text-dim);
-}
-
-.live-news-manage-tab-btn.active {
-  color: var(--text);
-  border-bottom-color: var(--text);
-}
+/* live-news-manage-tab: now uses shared .panel-tabs / .panel-tab */
 
 /* Tab content panels */
 .live-news-manage-tab-content {
@@ -7792,34 +7757,7 @@ a.prediction-link:hover {
   color: var(--text-dim);
 }
 
-/* Economic Panel Tabs */
-.economic-tabs {
-  display: flex;
-  gap: 2px;
-  padding: 8px 10px 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.economic-tab {
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-dim);
-  padding: 6px 10px;
-  font-size: 11px;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  white-space: nowrap;
-}
-
-.economic-tab:hover {
-  color: var(--text);
-}
-
-.economic-tab.active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-}
+/* economic-tabs: now uses shared .panel-tabs / .panel-tab */
 
 .economic-content {
   padding: 8px;
@@ -7827,34 +7765,7 @@ a.prediction-link:hover {
   overflow-y: auto;
 }
 
-/* Regulation Panel Tabs */
-.regulation-tabs {
-  display: flex;
-  gap: 2px;
-  padding: 8px 10px 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.regulation-tabs .tab {
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-dim);
-  padding: 6px 10px;
-  font-size: 11px;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  white-space: nowrap;
-}
-
-.regulation-tabs .tab:hover {
-  color: var(--text);
-}
-
-.regulation-tabs .tab.active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-}
+/* regulation-tabs: now uses shared .panel-tabs / .panel-tab */
 
 .economic-empty {
   padding: 16px;
@@ -10531,55 +10442,7 @@ a.prediction-link:hover {
    GDELT Intelligence Panel
    ========================================================================== */
 
-.gdelt-intel-tabs {
-  display: flex;
-  gap: 2px;
-  padding: 8px 10px 0;
-  overflow-x: auto;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg);
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-
-.gdelt-intel-tabs::-webkit-scrollbar {
-  display: none;
-}
-
-.gdelt-intel-tab {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 10px;
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-dim);
-  font-size: 11px;
-  font-family: inherit;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.gdelt-intel-tab:hover {
-  color: var(--text);
-  background: var(--overlay-subtle);
-}
-
-.gdelt-intel-tab.active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-}
-
-.gdelt-intel-tab .tab-icon {
-  font-size: 12px;
-}
-
-.gdelt-intel-tab .tab-label {
-  font-weight: 500;
-}
+/* gdelt-intel-tabs: now uses shared .panel-tabs / .panel-tab */
 
 .gdelt-intel-articles {
   display: flex;
@@ -11208,33 +11071,7 @@ a.prediction-link:hover {
   gap: 8px;
 }
 
-.cascade-filters {
-  display: flex;
-  gap: 4px;
-  flex-wrap: wrap;
-}
-
-.cascade-filter-btn {
-  padding: 4px 8px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  color: var(--text-dim);
-  font-size: 11px;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.cascade-filter-btn:hover {
-  background: var(--overlay-medium);
-  color: var(--text);
-}
-
-.cascade-filter-btn.active {
-  background: rgba(68, 255, 136, 0.15);
-  border-color: var(--green);
-  color: var(--green);
-}
+/* cascade-filters: now uses shared .panel-tabs / .panel-tab */
 
 .cascade-select {
   width: 100%;
@@ -12819,33 +12656,7 @@ a.prediction-link:hover {
   color: var(--text-dim);
 }
 
-.tech-events-tabs {
-  display: flex;
-  gap: 2px;
-  padding: 8px 10px 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.tech-events-tabs .tab {
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-dim);
-  padding: 6px 10px;
-  font-size: 11px;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  white-space: nowrap;
-}
-
-.tech-events-tabs .tab:hover {
-  color: var(--text);
-}
-
-.tech-events-tabs .tab.active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-}
+/* tech-events-tabs: now uses shared .panel-tabs / .panel-tab */
 
 .tech-events-stats {
   display: flex;
@@ -17526,45 +17337,7 @@ body.has-breaking-alert .panels-grid {
    Telegram Intel Panel
    ========================================================================== */
 
-.telegram-intel-tabs {
-  display: flex;
-  gap: 2px;
-  padding: 8px 10px 0;
-  overflow-x: auto;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg);
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-
-.telegram-intel-tabs::-webkit-scrollbar {
-  display: none;
-}
-
-.telegram-intel-tab {
-  padding: 6px 10px;
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-dim);
-  font-size: 11px;
-  font-family: inherit;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.telegram-intel-tab:hover {
-  color: var(--text);
-  background: var(--overlay-subtle);
-}
-
-.telegram-intel-tab.active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-  font-weight: 500;
-}
+/* telegram-intel-tabs: now uses shared .panel-tabs / .panel-tab */
 
 .telegram-intel-items {
   display: flex;

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -5,6 +5,61 @@
    ========================================================== */
 
 /* ----------------------------------------------------------
+   Shared Panel Tabs (gold standard: Telegram Intel style)
+   ---------------------------------------------------------- */
+.panel-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 8px 10px 0;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.panel-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.panel-tab {
+  padding: 6px 10px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  font-size: 11px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.panel-tab:hover {
+  color: var(--text);
+  background: var(--overlay-subtle);
+}
+
+.panel-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 500;
+}
+
+.panel-tab .tab-icon {
+  font-size: 12px;
+}
+
+.panel-tab .tab-label {
+  font-weight: 500;
+}
+
+.panel-tab.active .tab-label {
+  font-weight: 600;
+}
+
+/* ----------------------------------------------------------
    Satellite Fires Panel
    ---------------------------------------------------------- */
 .fires-panel-content {
@@ -303,33 +358,7 @@
   color: var(--accent);
 }
 
-.disp-tabs {
-  display: flex;
-  gap: 2px;
-  padding: 8px 10px 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.disp-tab {
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-dim);
-  padding: 6px 10px;
-  font-size: 11px;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  white-space: nowrap;
-}
-
-.disp-tab:hover {
-  color: var(--text);
-}
-
-.disp-tab-active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-}
+/* disp-tabs: now uses shared .panel-tabs / .panel-tab */
 
 .disp-table {
   width: 100%;
@@ -416,33 +445,7 @@
   gap: 4px;
 }
 
-.ucdp-tabs {
-  display: flex;
-  gap: 2px;
-  padding: 8px 10px 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.ucdp-tab {
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-dim);
-  padding: 6px 10px;
-  font-size: 11px;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  white-space: nowrap;
-}
-
-.ucdp-tab:hover {
-  color: var(--text);
-}
-
-.ucdp-tab-active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-}
+/* ucdp-tabs: now uses shared .panel-tabs / .panel-tab */
 
 .ucdp-tab-count {
   font-variant-numeric: tabular-nums;
@@ -707,34 +710,7 @@
   font-size: 22px;
 }
 
-.giving-tabs {
-  display: flex;
-  gap: 2px;
-  padding: 8px 10px 0;
-  border-bottom: 1px solid var(--border);
-  flex-wrap: wrap;
-}
-
-.giving-tab {
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-dim);
-  padding: 6px 10px;
-  font-size: 11px;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  white-space: nowrap;
-}
-
-.giving-tab:hover {
-  color: var(--text);
-}
-
-.giving-tab-active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-}
+/* giving-tabs: now uses shared .panel-tabs / .panel-tab */
 
 .giving-table {
   width: 100%;


### PR DESCRIPTION
## Summary
- Create shared `.panel-tabs` / `.panel-tab` CSS classes (gold standard: Telegram Intel style)
- Migrate 13 panels to use shared tab classes, eliminating 4+ inconsistent tab styles
- Remove ~250 lines of duplicate per-panel tab CSS

## What was wrong
| Panel | Issue |
|-------|-------|
| Airline Intel | **Zero CSS** — tabs were completely unstyled |
| Infrastructure Cascade | Bordered box buttons instead of underline tabs |
| Live Channels | Different font-size (10px), uppercase, `--text` active color, extra `margin-bottom` |
| Others | Minor inconsistencies: missing `font-family: inherit`, `flex-shrink`, hover background, scrollbar hiding |

## Panels migrated
TelegramIntel, GdeltIntel, Economic, TradePolicy, SupplyChain, TechEvents, UCDP, AirlineIntel, Cascade, LiveChannels, Displacement, Giving, Regulation

UnifiedSettings tabs intentionally excluded (modal dialog with equal-width centered layout).

## Test plan
- [x] `tsc --noEmit` passes
- [x] `vite build` succeeds
- [x] All pre-push checks pass (edge functions, markdown lint, version sync)
- [ ] Visual check: verify all panels render tabs with consistent underline style
- [ ] Verify happy theme still overrides tab styles correctly