### PR TITLE
fix(map): align Iran event severity/category with seed values

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -39,7 +39,7 @@ import type {
 import { fetchMilitaryBases, type MilitaryBaseCluster as ServerBaseCluster } from '@/services/military-bases';
 import type { AirportDelayAlert, PositionSample } from '@/services/aviation';
 import { fetchAircraftPositions } from '@/services/aviation';
-import type { IranEvent } from '@/services/conflict';
+import { type IranEvent, getIranEventColor, getIranEventRadius } from '@/services/conflict';
 import type { GpsJamHex } from '@/services/gps-interference';
 import type { DisplacementFlow } from '@/services/displacement';
 import type { Earthquake } from '@/services/earthquakes';
@@ -1863,12 +1863,8 @@ export class DeckGLMap {
       id: 'iran-events-layer',
       data: this.iranEvents,
       getPosition: (d: IranEvent) => [d.longitude, d.latitude],
-      getRadius: (d: IranEvent) => (d.severity === 'high' || d.severity === 'critical') ? 20000 : d.severity === 'medium' ? 15000 : 10000,
-      getFillColor: (d: IranEvent) => {
-        if (d.severity === 'critical' || d.category === 'military') return [255, 50, 50, 220] as [number, number, number, number];
-        if (d.category === 'politics' || d.category === 'diplomacy') return [255, 165, 0, 200] as [number, number, number, number];
-        return [255, 255, 0, 180] as [number, number, number, number];
-      },
+      getRadius: (d: IranEvent) => getIranEventRadius(d.severity),
+      getFillColor: (d: IranEvent) => getIranEventColor(d),
       radiusMinPixels: 4,
       radiusMaxPixels: 16,
       pickable: true,

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -37,7 +37,7 @@ import type { AirportDelayAlert } from '@/services/aviation';
 import type { MapContainerState, MapView, TimeRange } from './MapContainer';
 import type { CountryClickPayload } from './DeckGLMap';
 import type { WeatherAlert } from '@/services/weather';
-import type { IranEvent } from '@/services/conflict';
+import { type IranEvent, getIranEventHexColor } from '@/services/conflict';
 import type { DisplacementFlow } from '@/services/displacement';
 import type { ClimateAnomaly } from '@/services/climate';
 import type { GpsJamHex } from '@/services/gps-interference';
@@ -727,7 +727,7 @@ export class GlobeMap {
       el.innerHTML = `<div style="font-size:11px;">${icon}</div>`;
       el.title = d.title;
     } else if (d._kind === 'iran') {
-      const sc = (d.severity === 'high' || d.severity === 'critical') ? '#ff3030' : d.severity === 'medium' ? '#ff8800' : '#ffcc00';
+      const sc = getIranEventHexColor(d);
       el.innerHTML = `
         <div style="position:relative;width:9px;height:9px;">
           <div style="position:absolute;inset:0;border-radius:50%;background:${sc};border:1.5px solid rgba(255,255,255,0.5);box-shadow:0 0 5px 2px ${sc}88;"></div>
@@ -935,7 +935,7 @@ export class GlobeMap {
       html = `<span style="font-weight:bold;">${esc(d.title.slice(0, 60))}</span>` +
              `<br><span style="opacity:.7;">${esc(d.category)}</span>`;
     } else if (d._kind === 'iran') {
-      const sc = (d.severity === 'high' || d.severity === 'critical') ? '#ff3030' : d.severity === 'medium' ? '#ff8800' : '#ffcc00';
+      const sc = getIranEventHexColor(d);
       html = `<span style="color:${sc};font-weight:bold;">🎯 ${esc(d.title.slice(0, 60))}</span>` +
              `<br><span style="opacity:.7;">${esc(d.category)}${d.location ? ' · ' + esc(d.location) : ''}</span>`;
     } else if (d._kind === 'outage') {
@@ -1901,7 +1901,7 @@ export class GlobeMap {
       id: e.id,
       title: e.title ?? '',
       category: e.category ?? '',
-      severity: e.severity ?? 'medium',
+      severity: e.severity ?? 'moderate',
       location: e.locationName ?? '',
     }));
     this.flushMarkers();

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -7,7 +7,7 @@ import type { Feature, Geometry } from 'geojson';
 import type { MapLayers, Hotspot, NewsItem, InternetOutage, RelatedAsset, AssetType, AisDisruptionEvent, AisDensityZone, CableAdvisory, RepairShip, SocialUnrestEvent, MilitaryFlight, MilitaryVessel, MilitaryFlightCluster, MilitaryVesselCluster, NaturalEvent, CyberThreat, CableHealthRecord } from '@/types';
 import type { AirportDelayAlert, PositionSample } from '@/services/aviation';
 import type { Earthquake } from '@/services/earthquakes';
-import type { IranEvent } from '@/services/conflict';
+import { type IranEvent, getIranEventCssColor, getIranEventSize } from '@/services/conflict';
 import type { TechHubActivity } from '@/services/tech-activity';
 import type { GeoHubActivity } from '@/services/geo-activity';
 import { getNaturalEventIcon } from '@/services/eonet';
@@ -1490,10 +1490,8 @@ export class MapComponent {
         const pos = projection([ev.longitude, ev.latitude]);
         if (!pos || !Number.isFinite(pos[0]) || !Number.isFinite(pos[1])) return;
 
-        const size = (ev.severity === 'high' || ev.severity === 'critical') ? 14 : ev.severity === 'medium' ? 11 : 8;
-        const color = ev.category === 'military' ? 'rgba(255,50,50,0.85)'
-          : (ev.category === 'politics' || ev.category === 'diplomacy') ? 'rgba(255,165,0,0.8)'
-            : 'rgba(255,255,0,0.7)';
+        const size = getIranEventSize(ev.severity);
+        const color = getIranEventCssColor(ev);
 
         const div = document.createElement('div');
         div.className = 'iran-event-marker';

--- a/src/services/conflict/index.ts
+++ b/src/services/conflict/index.ts
@@ -410,6 +410,50 @@ export function groupByType(events: UcdpGeoEvent[]): Record<string, UcdpGeoEvent
   };
 }
 
+const IRAN_RED_CATEGORIES = new Set(['military', 'airstrike', 'defense']);
+const IRAN_ORANGE_CATEGORIES = new Set(['political', 'international']);
+
+type IranColorTier = 'red' | 'orange' | 'yellow';
+
+function iranColorTier(ev: Pick<IranEvent, 'severity' | 'category'>): IranColorTier {
+  if (ev.severity === 'critical' || IRAN_RED_CATEGORIES.has(ev.category)) return 'red';
+  if (IRAN_ORANGE_CATEGORIES.has(ev.category)) return 'orange';
+  return 'yellow';
+}
+
+const IRAN_RGBA: Record<IranColorTier, [number, number, number, number]> = {
+  red: [255, 50, 50, 220], orange: [255, 165, 0, 200], yellow: [255, 255, 0, 180],
+};
+const IRAN_CSS: Record<IranColorTier, string> = {
+  red: 'rgba(255,50,50,0.85)', orange: 'rgba(255,165,0,0.8)', yellow: 'rgba(255,255,0,0.7)',
+};
+
+export function getIranEventColor(ev: Pick<IranEvent, 'severity' | 'category'>): [number, number, number, number] {
+  return IRAN_RGBA[iranColorTier(ev)];
+}
+
+export function getIranEventCssColor(ev: Pick<IranEvent, 'severity' | 'category'>): string {
+  return IRAN_CSS[iranColorTier(ev)];
+}
+
+export function getIranEventHexColor(ev: Pick<IranEvent, 'severity'>): string {
+  if (ev.severity === 'high' || ev.severity === 'critical') return '#ff3030';
+  if (ev.severity === 'elevated') return '#ff8800';
+  return '#ffcc00';
+}
+
+export function getIranEventRadius(severity: string): number {
+  if (severity === 'high' || severity === 'critical') return 20000;
+  if (severity === 'elevated') return 15000;
+  return 10000;
+}
+
+export function getIranEventSize(severity: string): number {
+  if (severity === 'high' || severity === 'critical') return 14;
+  if (severity === 'elevated') return 11;
+  return 8;
+}
+
 export async function fetchIranEvents(): Promise<IranEvent[]> {
   const hydrated = getHydratedData('iranEvents') as ListIranEventsResponse | undefined;
   if (hydrated?.events?.length) return hydrated.events;


### PR DESCRIPTION
## Summary

- **Bug fix**: Map renderers checked for severity `medium` and categories `politics`/`diplomacy`, but the seed produces `elevated`/`moderate` and `political`/`international` — causing wrong sizes and colors
- **Refactor**: Extract shared Iran event color/size helpers into `src/services/conflict/index.ts`, eliminating duplicated logic across 3 map renderers (DeckGL, SVG, Globe)
- **Fix**: GlobeMap default severity fallback from `'medium'` to `'moderate'`

## What was wrong

| Field | Seed produces | Renderers checked | Result |
|-------|--------------|-------------------|--------|
| severity | `elevated`, `moderate` | `medium` | All fell to smallest size (dead code) |
| category | `political`, `international` | `politics`, `diplomacy` | Wrong color (yellow instead of orange) |
| category | `airstrike`, `defense` | (not checked) | Yellow instead of red |

## Test plan

- [x] `tsc --noEmit` passes
- [x] All pre-push checks pass (edge function tests, markdown lint, version sync)
- [ ] Visual check: Iran events render with correct severity-based sizes and category-based colors on DeckGL, SVG, and Globe views