### PR TITLE
fix(map): raise layer warning threshold to 10 and localize dialog

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -4582,7 +4582,7 @@ export class DeckGLMap {
   private layerWarningShown = false;
 
   private enforceLayerLimit(): void {
-    const WARN_THRESHOLD = 9;
+    const WARN_THRESHOLD = 10;
     const togglesEl = this.container.querySelector('.deckgl-layer-toggles');
     if (!togglesEl) return;
     const activeCount = Array.from(togglesEl.querySelectorAll<HTMLInputElement>('.layer-toggle input'))

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -946,6 +946,10 @@
         "ciiCritical": "حرج (81–100)"
       },
       "layerGuide": "دليل الطبقات",
+      "layerWarningTitle": "ملاحظة حول الأداء",
+      "layerWarningBody": "قد يؤثر تفعيل أكثر من {{threshold}} طبقة على أداء العرض ومعدل الإطارات.",
+      "layerWarningDismiss": "لا تظهر هذا مجددًا",
+      "layerWarningOk": "فهمت",
       "layersTitle": "الطبقات",
       "timeAll": "الكل",
       "views": {

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -973,6 +973,10 @@
         "ciiCritical": "Критичен (81–100)"
       },
       "layerGuide": "Ръководство на слои",
+      "layerWarningTitle": "Бележка за производителността",
+      "layerWarningBody": "Активирането на повече от {{threshold}} слоя може да повлияе на производителността и честотата на кадрите.",
+      "layerWarningDismiss": "Не показвай отново",
+      "layerWarningOk": "Разбрах",
       "layersTitle": "Слои",
       "timeAll": "Всички",
       "views": {

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -963,6 +963,10 @@
         "ciiCritical": "Kritický (81–100)"
       },
       "layerGuide": "Průvodce vrstvami",
+      "layerWarningTitle": "Upozornění na výkon",
+      "layerWarningBody": "Povolení více než {{threshold}} vrstev může ovlivnit výkon vykreslování a snímkovou frekvenci.",
+      "layerWarningDismiss": "Příště nezobrazovat",
+      "layerWarningOk": "Rozumím",
       "layersTitle": "Vrstvy",
       "timeAll": "Vše",
       "views": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -880,6 +880,10 @@
       },
       "layersTitle": "Schichten",
       "layerGuide": "Ebenenführer",
+      "layerWarningTitle": "Leistungshinweis",
+      "layerWarningBody": "Das Aktivieren von mehr als {{threshold}} Ebenen kann die Renderleistung und Bildrate beeinträchtigen.",
+      "layerWarningDismiss": "Nicht mehr anzeigen",
+      "layerWarningOk": "Verstanden",
       "tooltip": {
         "earthquake": "Erdbeben",
         "militaryAircraft": "Militärflugzeuge",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -973,6 +973,10 @@
         "ciiCritical": "Κρίσιμο (81–100)"
       },
       "layerGuide": "Οδηγός Επιπέδων",
+      "layerWarningTitle": "Σημείωση απόδοσης",
+      "layerWarningBody": "Η ενεργοποίηση περισσότερων από {{threshold}} επιπέδων μπορεί να επηρεάσει την απόδοση απεικόνισης και τον ρυθμό καρέ.",
+      "layerWarningDismiss": "Να μην εμφανιστεί ξανά",
+      "layerWarningOk": "Κατάλαβα",
       "layersTitle": "Επίπεδα",
       "timeAll": "Όλα",
       "views": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -974,6 +974,10 @@
         "ciiCritical": "Critical (81–100)"
       },
       "layerGuide": "Layer Guide",
+      "layerWarningTitle": "Performance notice",
+      "layerWarningBody": "Enabling more than {{threshold}} layers may impact rendering performance and frame rate.",
+      "layerWarningDismiss": "Don't show this again",
+      "layerWarningOk": "Got it",
       "layersTitle": "Layers",
       "timeAll": "All",
       "views": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -880,6 +880,10 @@
       },
       "layersTitle": "capas",
       "layerGuide": "Guía de capas",
+      "layerWarningTitle": "Aviso de rendimiento",
+      "layerWarningBody": "Activar más de {{threshold}} capas puede afectar el rendimiento de renderizado y la tasa de fotogramas.",
+      "layerWarningDismiss": "No volver a mostrar",
+      "layerWarningOk": "Entendido",
       "tooltip": {
         "earthquake": "Terremoto",
         "militaryAircraft": "Aviones militares",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -946,6 +946,10 @@
         "ciiCritical": "Critique (81–100)"
       },
       "layerGuide": "Guide des calques",
+      "layerWarningTitle": "Avis de performance",
+      "layerWarningBody": "Activer plus de {{threshold}} couches peut affecter les performances de rendu et la fréquence d'images.",
+      "layerWarningDismiss": "Ne plus afficher",
+      "layerWarningOk": "Compris",
       "layersTitle": "Couches",
       "timeAll": "Tout",
       "views": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -880,6 +880,10 @@
       },
       "layersTitle": "Livelli",
       "layerGuide": "Guida ai livelli",
+      "layerWarningTitle": "Avviso sulle prestazioni",
+      "layerWarningBody": "Attivare più di {{threshold}} livelli può influire sulle prestazioni di rendering e sul frame rate.",
+      "layerWarningDismiss": "Non mostrare più",
+      "layerWarningOk": "Capito",
       "tooltip": {
         "earthquake": "Terremoto",
         "militaryAircraft": "Aerei militari",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -973,6 +973,10 @@
         "ciiCritical": "危機的 (81–100)"
       },
       "layerGuide": "レイヤーガイド",
+      "layerWarningTitle": "パフォーマンスに関するお知らせ",
+      "layerWarningBody": "{{threshold}}個以上のレイヤーを有効にすると、描画パフォーマンスやフレームレートに影響する場合があります。",
+      "layerWarningDismiss": "今後表示しない",
+      "layerWarningOk": "了解",
       "layersTitle": "レイヤー",
       "timeAll": "全期間",
       "views": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -973,6 +973,10 @@
         "ciiCritical": "심각 (81–100)"
       },
       "layerGuide": "레이어 가이드",
+      "layerWarningTitle": "성능 안내",
+      "layerWarningBody": "{{threshold}}개 이상의 레이어를 활성화하면 렌더링 성능과 프레임 속도에 영향을 줄 수 있습니다.",
+      "layerWarningDismiss": "다시 표시하지 않기",
+      "layerWarningOk": "확인",
       "layersTitle": "레이어",
       "timeAll": "전체",
       "views": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -582,6 +582,10 @@
       },
       "layersTitle": "Lagen",
       "layerGuide": "Lagengids",
+      "layerWarningTitle": "Prestatie-opmerking",
+      "layerWarningBody": "Het inschakelen van meer dan {{threshold}} lagen kan de renderprestaties en framesnelheid beïnvloeden.",
+      "layerWarningDismiss": "Niet meer tonen",
+      "layerWarningOk": "Begrepen",
       "tooltip": {
         "earthquake": "Aardbeving",
         "militaryAircraft": "Militaire vliegtuigen",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -863,6 +863,10 @@
       },
       "layersTitle": "Warstwy",
       "layerGuide": "Przewodnik po warstwach",
+      "layerWarningTitle": "Informacja o wydajności",
+      "layerWarningBody": "Włączenie więcej niż {{threshold}} warstw może wpłynąć na wydajność renderowania i liczbę klatek na sekundę.",
+      "layerWarningDismiss": "Nie pokazuj ponownie",
+      "layerWarningOk": "Rozumiem",
       "tooltip": {
         "earthquake": "Trzęsienie ziemi",
         "militaryAircraft": "Samolot wojskowy",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -582,6 +582,10 @@
       },
       "layersTitle": "Camadas",
       "layerGuide": "Guia de camadas",
+      "layerWarningTitle": "Aviso de desempenho",
+      "layerWarningBody": "Ativar mais de {{threshold}} camadas pode afetar o desempenho de renderização e a taxa de quadros.",
+      "layerWarningDismiss": "Não mostrar novamente",
+      "layerWarningOk": "Entendi",
       "tooltip": {
         "earthquake": "Terremoto",
         "militaryAircraft": "Aeronave Militar",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -973,6 +973,10 @@
         "ciiCritical": "Critic (81–100)"
       },
       "layerGuide": "Ghid de straturi",
+      "layerWarningTitle": "Notificare de performanță",
+      "layerWarningBody": "Activarea a mai mult de {{threshold}} straturi poate afecta performanța de randare și rata de cadre.",
+      "layerWarningDismiss": "Nu mai afișa",
+      "layerWarningOk": "Am înțeles",
       "layersTitle": "Straturi",
       "timeAll": "Toate",
       "views": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -973,6 +973,10 @@
         "ciiCritical": "Критический (81–100)"
       },
       "layerGuide": "Справочник слоёв",
+      "layerWarningTitle": "Уведомление о производительности",
+      "layerWarningBody": "Включение более {{threshold}} слоёв может повлиять на производительность отрисовки и частоту кадров.",
+      "layerWarningDismiss": "Больше не показывать",
+      "layerWarningOk": "Понятно",
       "layersTitle": "Слои",
       "timeAll": "Все",
       "views": {

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -582,6 +582,10 @@
       },
       "layersTitle": "Lager",
       "layerGuide": "Lagerguide",
+      "layerWarningTitle": "Prestandameddelande",
+      "layerWarningBody": "Att aktivera fler än {{threshold}} lager kan påverka renderingsprestanda och bildfrekvens.",
+      "layerWarningDismiss": "Visa inte igen",
+      "layerWarningOk": "Uppfattat",
       "tooltip": {
         "earthquake": "Jordbävning",
         "militaryAircraft": "Militära flygplan",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -973,6 +973,10 @@
         "ciiCritical": "วิกฤต (81–100)"
       },
       "layerGuide": "คู่มือเลเยอร์",
+      "layerWarningTitle": "แจ้งเตือนประสิทธิภาพ",
+      "layerWarningBody": "การเปิดใช้งานมากกว่า {{threshold}} เลเยอร์อาจส่งผลต่อประสิทธิภาพการแสดงผลและอัตราเฟรม",
+      "layerWarningDismiss": "ไม่ต้องแสดงอีก",
+      "layerWarningOk": "รับทราบ",
       "layersTitle": "เลเยอร์",
       "timeAll": "ทั้งหมด",
       "views": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -973,6 +973,10 @@
         "ciiCritical": "Kritik (81–100)"
       },
       "layerGuide": "Katman Rehberi",
+      "layerWarningTitle": "Performans bildirimi",
+      "layerWarningBody": "{{threshold}} adetten fazla katmanı etkinleştirmek, işleme performansını ve kare hızını etkileyebilir.",
+      "layerWarningDismiss": "Bir daha gösterme",
+      "layerWarningOk": "Anladım",
       "layersTitle": "Katmanlar",
       "timeAll": "Tumu",
       "views": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -973,6 +973,10 @@
         "ciiCritical": "Nghiêm trọng (81–100)"
       },
       "layerGuide": "Hướng dẫn Lớp",
+      "layerWarningTitle": "Lưu ý về hiệu suất",
+      "layerWarningBody": "Bật hơn {{threshold}} lớp có thể ảnh hưởng đến hiệu suất hiển thị và tốc độ khung hình.",
+      "layerWarningDismiss": "Không hiển thị lại",
+      "layerWarningOk": "Đã hiểu",
       "layersTitle": "Lớp",
       "timeAll": "Tất cả",
       "views": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -973,6 +973,10 @@
         "ciiCritical": "危急 (81–100)"
       },
       "layerGuide": "图层指南",
+      "layerWarningTitle": "性能提示",
+      "layerWarningBody": "启用超过 {{threshold}} 个图层可能会影响渲染性能和帧率。",
+      "layerWarningDismiss": "不再显示",
+      "layerWarningOk": "知道了",
       "layersTitle": "图层",
       "timeAll": "全部",
       "views": {

--- a/src/utils/layer-warning.ts
+++ b/src/utils/layer-warning.ts
@@ -1,3 +1,5 @@
+import { t } from '@/services/i18n';
+
 const DISMISS_KEY = 'wm-layer-warning-dismissed';
 let activeDialog: HTMLElement | null = null;
 
@@ -16,14 +18,14 @@ export function showLayerWarning(threshold: number): void {
         </svg>
       </div>
       <div class="layer-warn-text">
-        <strong>Performance notice</strong>
-        <p>Enabling more than ${threshold} layers may impact rendering performance and frame rate.</p>
+        <strong>${t('components.deckgl.layerWarningTitle')}</strong>
+        <p>${t('components.deckgl.layerWarningBody', { threshold })}</p>
       </div>
       <label class="layer-warn-dismiss">
         <input type="checkbox" />
-        <span>Don't show this again</span>
+        <span>${t('components.deckgl.layerWarningDismiss')}</span>
       </label>
-      <button class="layer-warn-ok">Got it</button>
+      <button class="layer-warn-ok">${t('components.deckgl.layerWarningOk')}</button>
     </div>`;
 
   const close = () => {


### PR DESCRIPTION
## Summary
- Raised `WARN_THRESHOLD` from 9 → 10 in `DeckGLMap.ts` so the performance notice no longer triggers on first load (9 layers enabled by default)
- Localized all 4 hardcoded English strings in the layer warning dialog (`layer-warning.ts`) using `t()` from i18next
- Added translated keys (`layerWarningTitle`, `layerWarningBody`, `layerWarningDismiss`, `layerWarningOk`) to all 21 locale files

## Test plan
- [ ] Open app fresh (no localStorage) — performance warning should NOT appear
- [ ] Enable a 10th layer — warning should appear
- [ ] Check "Don't show again", click "Got it" — warning dismissed permanently
- [ ] Switch language and trigger warning — verify translated strings render