### PR TITLE
fix(panels): flush tab margins against panel headers

### DIFF
--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -18,6 +18,24 @@
   -ms-overflow-style: none;
 }
 
+/* When .panel-content contains tabs (at any depth), remove top padding
+   so tabs sit flush against the header — matching panels using insertBefore(). */
+.panel-content:has(.panel-tabs) {
+  padding-top: 0;
+}
+
+/* Bleed tabs full-width: negate .panel-content's 8px horizontal padding.
+   Direct children get simple negative margin. For nested tabs, the
+   wrapper div is also pulled flush. */
+.panel-content > .panel-tabs {
+  margin-left: -8px;
+  margin-right: -8px;
+}
+.panel-content > :first-child:has(.panel-tabs) {
+  margin-left: -8px;
+  margin-right: -8px;
+}
+
 .panel-tabs::-webkit-scrollbar {
   display: none;
 }


### PR DESCRIPTION
## Summary
Follow-up to #1182. Panels rendering tabs via `setContent()` had an 8px gap between the header and tab bar (from `.panel-content` padding), while panels using `insertBefore()` (Telegram, GDELT, Airline) were flush.

## Fix
- `.panel-content:has(.panel-tabs)` — removes top padding when tabs are present
- `.panel-content > .panel-tabs` — negative horizontal margin bleeds tabs full-width
- `.panel-content > :first-child:has(.panel-tabs)` — same for nested wrapper divs

Uses CSS `:has()` (supported in all modern browsers since Dec 2023).

## Test plan
- [x] Build passes
- [x] All pre-push checks pass
- [ ] Visual check: all panels have tabs flush against header with no gap