### PR TITLE
fix(git): block pushes to merged/closed PR branches

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,15 @@
+# Block pushes to branches whose PR is already merged/closed
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
+if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && command -v gh >/dev/null 2>&1; then
+  PR_STATE=$(gh pr list --head "$BRANCH" --state all --json state --jq '.[0].state' 2>/dev/null)
+  if [ "$PR_STATE" = "MERGED" ] || [ "$PR_STATE" = "CLOSED" ]; then
+    echo "ERROR: PR for branch '$BRANCH' is already $PR_STATE."
+    echo "Create a NEW branch from main instead:"
+    echo "  git checkout main && git pull && git checkout -b fix/your-new-branch"
+    exit 1
+  fi
+fi
+
 echo "Running type check..."
 npm run typecheck || exit 1
 


### PR DESCRIPTION
## Summary
- Adds a guard at the top of `.husky/pre-push` that checks PR state via `gh pr list` before allowing push
- If the branch's PR is already MERGED or CLOSED, the push is blocked with clear instructions to create a new branch
- Prevents orphaned commits (happened on PRs #1169 and #1187)

## Test plan
- [x] Verified hook detects MERGED state on `feat/pro-i18n` branch
- [ ] Test pushing from a branch with no PR (should pass through)
- [ ] Test pushing from a branch with an open PR (should pass through)