### PR TITLE
fix(panels): restore flex layout and wrap for shared tab styles

### DIFF
--- a/src/components/CascadePanel.ts
+++ b/src/components/CascadePanel.ts
@@ -114,7 +114,7 @@ export class CascadePanel extends Panel {
 
     return `
       <div class="cascade-selector">
-        <div class="panel-tabs" role="radiogroup" aria-label="Infrastructure type filter">${filterButtons}</div>
+        <div class="panel-tabs panel-tabs--wrap" role="radiogroup" aria-label="Infrastructure type filter">${filterButtons}</div>
         <select class="cascade-select" ${nodes.length === 0 ? 'disabled' : ''}>
           <option value="">${t('components.cascade.selectPrompt', { type: selectedType })}</option>
           ${nodeOptions}

--- a/src/components/GivingPanel.ts
+++ b/src/components/GivingPanel.ts
@@ -64,7 +64,7 @@ export class GivingPanel extends Panel {
       institutional: t('components.giving.tabs.institutional'),
     };
     const tabsHtml = `
-      <div class="panel-tabs">
+      <div class="panel-tabs panel-tabs--wrap">
         ${tabs.map(tab => `<button class="panel-tab ${this.activeTab === tab ? 'active' : ''}" data-tab="${tab}">${tabLabels[tab]}</button>`).join('')}
       </div>
     `;

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -40,7 +40,15 @@
   display: none;
 }
 
+.panel-tabs--wrap {
+  flex-wrap: wrap;
+  overflow-x: visible;
+}
+
 .panel-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   padding: 6px 10px;
   background: transparent;
   border: none;


### PR DESCRIPTION
## Summary
- Add `display: inline-flex; align-items: center; gap: 4px` to `.panel-tab` — restores GDELT icon+label alignment broken by #1182
- Add `.panel-tabs--wrap` modifier (`flex-wrap: wrap; overflow-x: visible`) for panels that need wrapping instead of hidden-scrollbar overflow
- Apply `panel-tabs--wrap` to GivingPanel and CascadePanel

## Test plan
- [x] `tsc --noEmit` passes
- [x] All pre-push checks pass
- [ ] Visual: GDELT tabs show icon and label side-by-side with spacing
- [ ] Visual: Giving/Cascade tabs wrap to second row on narrow panels