### PR TITLE
fix(panels): add CSS grid layouts for Airline Intelligence panel

### DIFF
--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -1745,6 +1745,330 @@
 }
 
 /* ----------------------------------------------------------
+   Airline Intelligence Panel
+   ---------------------------------------------------------- */
+.airline-intel-content {
+  font-size: 12px;
+}
+
+/* ---- Ops tab ---- */
+.ops-grid {
+  display: flex;
+  flex-direction: column;
+}
+
+.ops-row {
+  display: grid;
+  grid-template-columns: 42px 1fr auto auto auto;
+  align-items: center;
+  gap: 0 8px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.ops-row:hover {
+  background: var(--surface-hover);
+}
+
+.ops-iata {
+  font-weight: 700;
+  color: var(--text);
+  font-size: 12px;
+}
+
+.ops-name {
+  color: var(--text-secondary);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ops-severity {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.ops-delay {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-dim);
+  text-align: right;
+}
+
+.ops-cancel {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-align: right;
+}
+
+.ops-closed {
+  font-size: 9px;
+  font-weight: 700;
+  color: var(--semantic-critical);
+  grid-column: 3 / -1;
+}
+
+.ops-notam {
+  font-size: 10px;
+  grid-column: 3 / -1;
+}
+
+/* ---- Flights tab ---- */
+.flights-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.flight-row {
+  display: grid;
+  grid-template-columns: 64px 1fr auto auto auto;
+  align-items: center;
+  gap: 0 8px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.flight-row:hover {
+  background: var(--surface-hover);
+}
+
+.flight-num {
+  font-weight: 600;
+  color: var(--text);
+  font-size: 12px;
+}
+
+.flight-route {
+  color: var(--text-secondary);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.flight-time {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-dim);
+}
+
+.flight-delay {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  min-width: 36px;
+}
+
+.flight-status {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  text-align: right;
+  min-width: 56px;
+}
+
+/* ---- Airlines (Carriers) tab ---- */
+.carriers-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.carrier-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: center;
+  gap: 0 10px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.carrier-row:hover {
+  background: var(--surface-hover);
+}
+
+.carrier-name {
+  font-weight: 600;
+  color: var(--text);
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.carrier-flights {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-dim);
+  text-align: right;
+}
+
+.carrier-delay {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  min-width: 72px;
+}
+
+.carrier-cancel {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  text-align: right;
+  min-width: 54px;
+}
+
+/* ---- Tracking tab ---- */
+.tracking-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.track-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: center;
+  gap: 0 10px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.track-row:hover {
+  background: var(--surface-hover);
+}
+
+.track-cs {
+  font-weight: 600;
+  color: var(--text);
+  font-size: 12px;
+}
+
+.track-alt {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-dim);
+  text-align: right;
+}
+
+.track-spd {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-dim);
+  text-align: right;
+}
+
+.track-pos {
+  font-size: 10px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+/* ---- Prices tab ---- */
+.prices-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.price-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto auto auto;
+  align-items: center;
+  gap: 0 8px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.price-row:hover {
+  background: var(--surface-hover);
+}
+
+.price-carrier {
+  font-weight: 600;
+  color: var(--text);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.price-route {
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.price-amount {
+  font-variant-numeric: tabular-nums;
+}
+
+.price-dur {
+  font-size: 11px;
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.price-stops {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-align: right;
+}
+
+.price-input {
+  background: var(--overlay-subtle);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 11px;
+  padding: 5px 6px;
+  outline: none;
+  font-family: inherit;
+  text-transform: uppercase;
+}
+
+.price-input:focus {
+  border-color: var(--accent);
+}
+
+.tp-badge,
+.demo-badge {
+  font-size: 9px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 3px;
+  letter-spacing: 0.3px;
+}
+
+.tp-badge {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--accent);
+}
+
+.demo-badge {
+  background: color-mix(in srgb, var(--semantic-elevated) 12%, transparent);
+  color: var(--semantic-elevated);
+}
+
+/* ---- News tab ---- */
+.news-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.news-link {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.news-link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+/* ----------------------------------------------------------
    Map Bottom Grid (Large Screen Drop Zone)
    ---------------------------------------------------------- */
 .map-bottom-grid {


### PR DESCRIPTION
## Summary
- All 6 Airline Intelligence tabs (Ops, Flights, Airlines, Tracking, Prices, News) had div-based rows with **zero CSS** — every field rendered as a stacked block element instead of a proper table row
- Added CSS grid layouts, hover states, `tabular-nums`, `text-overflow`, and border separators matching the design patterns of well-styled panels (Stablecoins, Fires, UCDP, etc.)

## Test plan
- [ ] Open Airline Intelligence panel → Ops tab: rows should show IATA | name | severity | delay | cancel in a horizontal grid
- [ ] Switch to Flights tab: flight number | route | time | delay | status in columns
- [ ] Switch to Airlines tab: carrier name | flights | delay% | cancel% in columns
- [ ] Switch to Tracking tab: callsign | altitude | speed | position in columns
- [ ] Switch to Prices tab: search form renders, results show carrier | route | price | duration | stops
- [ ] Switch to News tab: links display properly with source/time metadata
- [ ] Hover rows in any tab → subtle highlight