### PR TITLE
fix(pro): add www→non-www 301 redirect to fix Turnstile 403

### DIFF
--- a/pro-test/src/App.tsx
+++ b/pro-test/src/App.tsx
@@ -809,7 +809,7 @@ const Footer = () => (
             {t('nav.joinWaitlist')}
           </button>
         </div>
-        <div className="cf-turnstile mx-auto" data-sitekey={TURNSTILE_SITE_KEY} data-theme="dark" data-size="compact" />
+        <div className="cf-turnstile mx-auto" />
       </form>
       <p className="text-sm text-wm-muted">
         {t('footer.lookingForEnterprise')} <a href="mailto:enterprise@worldmonitor.app" className="text-wm-text underline underline-offset-4 hover:text-wm-green transition-colors">{t('footer.contactUs')}</a>.

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,9 @@
 {
   "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git cat-file -e $VERCEL_GIT_PREVIOUS_SHA 2>/dev/null || exit 1; git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- ':!*.md' ':!.planning' ':!docs/' ':!e2e/' ':!scripts/' ':!.github/'",
   "crons": [],
+  "redirects": [
+    { "source": "/:path(.*)", "has": [{ "type": "host", "value": "www.worldmonitor.app" }], "destination": "https://worldmonitor.app/:path", "permanent": true }
+  ],
   "rewrites": [
     { "source": "/pro", "destination": "/pro/index.html" },
     { "source": "/((?!api|assets|favico|map-styles|data|textures|pro|sw\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|\\.well-known).*)", "destination": "/index.html" }


### PR DESCRIPTION
## Summary
- Adds a 301 redirect from `www.worldmonitor.app/*` to `worldmonitor.app/*` in `vercel.json`
- The Turnstile site key is configured for `worldmonitor.app` only — visitors on `www.` get a valid-looking widget but the challenge silently fails, producing an empty token → 403 from `register-interest`
- Also removes stale `data-sitekey/theme/size` attributes from the footer `.cf-turnstile` div (explicit rendering sets these via `turnstile.render()`)

## Immediate fix (before merge)
Add `www.worldmonitor.app` to your Turnstile widget's allowed hostnames:
**Cloudflare Dashboard → Turnstile → Widget → Settings → Allowed Hostnames**

## Test plan
- [ ] Visit `www.worldmonitor.app/pro` → should 301 redirect to `worldmonitor.app/pro`
- [ ] Submit waitlist form on `worldmonitor.app/pro` → should succeed (no 403)
- [ ] Both hero and footer forms render Turnstile widget and submit successfully