### PR TITLE
hotfix: remove www→non-www redirect causing infinite loop

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,6 @@
 {
   "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git cat-file -e $VERCEL_GIT_PREVIOUS_SHA 2>/dev/null || exit 1; git diff --quiet $VERCEL_GIT_PREVIOUS_SHA HEAD -- ':!*.md' ':!.planning' ':!docs/' ':!e2e/' ':!scripts/' ':!.github/'",
   "crons": [],
-  "redirects": [
-    { "source": "/:path(.*)", "has": [{ "type": "host", "value": "www.worldmonitor.app" }], "destination": "https://worldmonitor.app/:path", "permanent": true }
-  ],
   "rewrites": [
     { "source": "/pro", "destination": "/pro/index.html" },
     { "source": "/((?!api|assets|favico|map-styles|data|textures|pro|sw\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|\\.well-known).*)", "destination": "/index.html" }


### PR DESCRIPTION
## URGENT — Site is down due to redirect loop

PR #1198 added a `www.worldmonitor.app` → `worldmonitor.app` redirect in `vercel.json`, but Vercel project settings already redirect `worldmonitor.app` → `www.worldmonitor.app` (307). The result is an infinite redirect loop.

This PR removes the conflicting redirect from `vercel.json`.

## Turnstile 403 fix (separate action)
Add `www.worldmonitor.app` to the Turnstile widget's allowed hostnames:
**Cloudflare Dashboard → Turnstile → Widget → Settings → Allowed Hostnames**

## Test plan
- [ ] `worldmonitor.app` loads without redirect loop
- [ ] `www.worldmonitor.app` loads normally
- [ ] `/pro` waitlist page accessible