### PR TITLE
fix(panels): green home row + Tech Readiness on all variants

### DIFF
--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -846,7 +846,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   dataTracking: {
     labelKey: 'header.panelCatDataTracking',
-    panelKeys: ['monitors', 'satellite-fires', 'ucdp-events', 'displacement', 'climate', 'population-exposure', 'security-advisories', 'oref-sirens', 'world-clock'],
+    panelKeys: ['monitors', 'satellite-fires', 'ucdp-events', 'displacement', 'climate', 'population-exposure', 'security-advisories', 'oref-sirens', 'world-clock', 'tech-readiness'],
     variants: ['full'],
   },
 

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -1537,7 +1537,8 @@
 }
 
 .wc-row.wc-home {
-  background: color-mix(in srgb, var(--accent) 5%, transparent);
+  background: color-mix(in srgb, var(--semantic-positive, #44ff88) 8%, transparent);
+  border-left: 2px solid color-mix(in srgb, var(--semantic-positive, #44ff88) 40%, transparent);
 }
 
 .wc-drag-handle {
@@ -1584,7 +1585,7 @@
 .wc-home-tag {
   margin-left: 4px;
   font-size: 11px;
-  color: var(--accent);
+  color: var(--semantic-positive, #44ff88);
 }
 
 .wc-detail {


### PR DESCRIPTION
## Summary
- **World Clock**: home city row now uses green tint (`semantic-positive`) with green left border, matching original design (was using blue `accent`)
- **Tech Readiness Index**: added to `dataTracking` category so it appears on `full` variant too — previously only available under `techAi` category (`tech` variant only)

## Test plan
- [ ] World Clock home city row shows green highlight
- [ ] Tech Readiness panel loads on the full (default) variant
- [ ] Tech Readiness still loads on the tech variant