### PR TITLE
fix(settings): Unified Settings modal Close button may not work when content re-renders

### DIFF
--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -236,6 +236,14 @@ export class UnifiedSettings {
       this.prefsCleanup = prefs.attach(settingsPanel as HTMLElement);
     }
 
+    const closeBtn = this.overlay.querySelector<HTMLButtonElement>('.unified-settings-close');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        this.close();
+      });
+    }
+
     this.renderPanelCategoryPills();
     this.renderPanelsTab();
     this.renderRegionPills();


### PR DESCRIPTION
## Summary
Attach a direct click listener to the Unified Settings modal Close button after each \ender()\, so the modal always closes regardless of re-renders or child content calling \stopPropagation()\.

## Problem
The close action relied on a single delegated click listener on the overlay. When \ender()\ replaces \overlay.innerHTML\, the Close button is recreated; if any child (e.g. preferences content) stops propagation, the delegated handler never runs and the user cannot close the modal.

## Solution
In \UnifiedSettings.ts\, after each \ender()\, query the new Close button and add a direct \click\ listener that calls \	his.close()\. No extra listener stacking because the button is a new DOM node every time.

## Testing
- Open Unified Settings (gear icon), switch tabs (Settings / Panels / Sources), click Close — modal closes.
- No new lint/type errors.

Made with [Cursor](https://cursor.com)