### PR TITLE
fix(channels): auto-switch to first matching tab when searching

### DIFF
--- a/src/live-channels-window.ts
+++ b/src/live-channels-window.ts
@@ -315,6 +315,26 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
     const currentIds = new Set(channels.map((c) => c.id));
     const term = searchQuery.toLowerCase().trim();
 
+    // Auto-switch to the first tab with matches when searching
+    if (term) {
+      const activeHasMatch = filteredRegions.some(r => {
+        if (r.key !== activeRegionTab) return false;
+        return r.channelIds.some(id => {
+          const ch = optionalChannelMap.get(id);
+          return ch && (ch.name.toLowerCase().includes(term) || ch.handle?.toLowerCase().includes(term));
+        });
+      });
+      if (!activeHasMatch) {
+        const firstMatch = filteredRegions.find(r =>
+          r.channelIds.some(id => {
+            const ch = optionalChannelMap.get(id);
+            return ch && (ch.name.toLowerCase().includes(term) || ch.handle?.toLowerCase().includes(term));
+          }),
+        );
+        if (firstMatch) activeRegionTab = firstMatch.key;
+      }
+    }
+
     // Render tab buttons
     tabBar.innerHTML = '';
     for (const region of filteredRegions) {


### PR DESCRIPTION
## Summary
- When searching for a channel (e.g. "rudaw"), the active tab stayed on its current region (North America) even when it had 0 matches
- User saw "No channels found" while the tab label clearly showed Middle East (1)
- Now auto-switches `activeRegionTab` to the first region with results when the current tab has none
- If the current tab already has matches, it stays put (non-disruptive)

## Test plan
- [ ] Open Manage Channels, stay on North America tab
- [ ] Type "rudaw" in search — should auto-switch to Middle East tab showing Rudaw
- [ ] Clear search, switch to Europe tab, type "bloomberg" — should auto-switch to North America
- [ ] Type "cnn" (matches in multiple tabs) — should stay on current tab if it has a match