### PR TITLE
fix(panels): Tech Readiness panel not loading on full variant

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -392,7 +392,7 @@ export class DataLoaderManager implements AppModule {
     if (SITE_VARIANT !== 'happy' && !isDesktopRuntime()) tasks.push({ name: 'iranAttacks', task: runGuarded('iranAttacks', () => this.loadIranEvents()) });
     if (SITE_VARIANT !== 'happy' && (this.ctx.mapLayers.techEvents || SITE_VARIANT === 'tech')) tasks.push({ name: 'techEvents', task: runGuarded('techEvents', () => this.loadTechEvents()) });
 
-    if (SITE_VARIANT === 'tech') {
+    if (SITE_VARIANT !== 'happy') {
       tasks.push({ name: 'techReadiness', task: runGuarded('techReadiness', () => (this.ctx.panels['tech-readiness'] as TechReadinessPanel)?.refresh()) });
     }
 

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -772,11 +772,7 @@ export class PanelLayoutManager implements AppModule {
       this.ctx.panels['service-status'] = serviceStatusPanel;
 
       this.lazyPanel('tech-readiness', () =>
-        import('@/components/TechReadinessPanel').then(m => {
-          const p = new m.TechReadinessPanel();
-          void p.refresh();
-          return p;
-        }),
+        import('@/components/TechReadinessPanel').then(m => new m.TechReadinessPanel()),
       );
 
       this.ctx.panels['macro-signals'] = new MacroSignalsPanel();


### PR DESCRIPTION
## Summary
- **Bug**: Tech Readiness panel stuck on "Fetching World Bank Data" on all non-tech variants (full, finance)
- **Root cause**: `void p.refresh()` inside `lazyPanel` loader raced against DOM insertion — the `!this.element?.isConnected` guard in `refresh()` ran as a microtask before the element was inserted, silently aborting the render
- **Fix**: Removed `refresh()` from the lazy loader; widened the data-loader `refresh()` call from `SITE_VARIANT === 'tech'` to `SITE_VARIANT !== 'happy'` so it runs for all applicable variants after panels are in the DOM

## Test plan
- [ ] Open full variant → verify Tech Readiness panel loads and shows country rankings
- [ ] Open tech variant → verify panel still works as before
- [ ] `tsc --noEmit` passes