### PR TITLE
fix(aviation): correct cancellation rate calculation and add 12 airports

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1431,13 +1431,16 @@ const AVIATION_SEED_TTL = 14400; // 4h — survives 1 missed cycle
 const AVIATION_REDIS_KEY = 'aviation:delays:intl:v3';
 const AVIATION_BATCH_CONCURRENCY = 10;
 const AVIATION_MIN_FLIGHTS_FOR_CLOSURE = 10;
+const RESOLVED_STATUSES = new Set(['cancelled', 'landed', 'active', 'arrived', 'diverted']);
 
 // Must match src/config/airports.ts AVIATIONSTACK_AIRPORTS — update both when changing
 const AVIATIONSTACK_AIRPORTS = [
-  'YYZ', 'MEX', 'GRU', 'EZE', 'BOG',
+  'YYZ', 'YVR', 'MEX', 'GRU', 'EZE', 'BOG', 'SCL',
   'LHR', 'CDG', 'FRA', 'AMS', 'MAD', 'FCO', 'MUC', 'BCN', 'ZRH', 'IST', 'VIE', 'CPH',
+  'DUB', 'LIS', 'ATH', 'WAW',
   'HND', 'NRT', 'PEK', 'PVG', 'HKG', 'SIN', 'ICN', 'BKK', 'SYD', 'DEL', 'BOM', 'KUL',
-  'DXB', 'DOH', 'AUH', 'RUH', 'CAI', 'TLV',
+  'CAN', 'TPE', 'MNL',
+  'DXB', 'DOH', 'AUH', 'RUH', 'CAI', 'TLV', 'AMM', 'KWI', 'CMN',
   'JNB', 'NBO', 'LOS', 'ADD', 'CPT',
 ];
 
@@ -1483,6 +1486,19 @@ const AIRPORT_META = {
   LOS: { icao: 'DNMM', name: 'Murtala Muhammed International', city: 'Lagos', country: 'Nigeria', lat: 6.5774, lon: 3.3212, region: 'africa' },
   ADD: { icao: 'HAAB', name: 'Bole International', city: 'Addis Ababa', country: 'Ethiopia', lat: 8.9779, lon: 38.7993, region: 'africa' },
   CPT: { icao: 'FACT', name: 'Cape Town International', city: 'Cape Town', country: 'South Africa', lat: -33.9715, lon: 18.6021, region: 'africa' },
+  // Added airports
+  YVR: { icao: 'CYVR', name: 'Vancouver International', city: 'Vancouver', country: 'Canada', lat: 49.1947, lon: -123.1792, region: 'americas' },
+  SCL: { icao: 'SCEL', name: 'Arturo Merino Benítez', city: 'Santiago', country: 'Chile', lat: -33.3930, lon: -70.7858, region: 'americas' },
+  DUB: { icao: 'EIDW', name: 'Dublin Airport', city: 'Dublin', country: 'Ireland', lat: 53.4264, lon: -6.2499, region: 'europe' },
+  LIS: { icao: 'LPPT', name: 'Humberto Delgado Airport', city: 'Lisbon', country: 'Portugal', lat: 38.7756, lon: -9.1354, region: 'europe' },
+  ATH: { icao: 'LGAV', name: 'Athens International', city: 'Athens', country: 'Greece', lat: 37.9364, lon: 23.9445, region: 'europe' },
+  WAW: { icao: 'EPWA', name: 'Warsaw Chopin Airport', city: 'Warsaw', country: 'Poland', lat: 52.1657, lon: 20.9671, region: 'europe' },
+  CAN: { icao: 'ZGGG', name: 'Guangzhou Baiyun International', city: 'Guangzhou', country: 'China', lat: 23.3924, lon: 113.2988, region: 'apac' },
+  TPE: { icao: 'RCTP', name: 'Taiwan Taoyuan International', city: 'Taipei', country: 'Taiwan', lat: 25.0797, lon: 121.2342, region: 'apac' },
+  MNL: { icao: 'RPLL', name: 'Ninoy Aquino International', city: 'Manila', country: 'Philippines', lat: 14.5086, lon: 121.0197, region: 'apac' },
+  AMM: { icao: 'OJAI', name: 'Queen Alia International', city: 'Amman', country: 'Jordan', lat: 31.7226, lon: 35.9932, region: 'mena' },
+  KWI: { icao: 'OKBK', name: 'Kuwait International', city: 'Kuwait City', country: 'Kuwait', lat: 29.2266, lon: 47.9689, region: 'mena' },
+  CMN: { icao: 'GMMN', name: 'Mohammed V International', city: 'Casablanca', country: 'Morocco', lat: 33.3675, lon: -7.5898, region: 'mena' },
 };
 
 const REGION_MAP = {
@@ -1520,7 +1536,8 @@ function aviationDetermineSeverity(avgDelay, delayedPct) {
 
 function fetchAviationStackSingle(apiKey, iata) {
   return new Promise((resolve) => {
-    const url = `https://api.aviationstack.com/v1/flights?access_key=${apiKey}&dep_iata=${iata}&limit=100`;
+    const today = new Date().toISOString().slice(0, 10);
+    const url = `https://api.aviationstack.com/v1/flights?access_key=${apiKey}&dep_iata=${iata}&flight_date=${today}&limit=100`;
     const req = https.get(url, {
       headers: { 'User-Agent': CHROME_UA },
       timeout: 5000,
@@ -1559,8 +1576,9 @@ function aviationAggregateFlights(iata, flights) {
   const meta = AIRPORT_META[iata];
   if (!meta) return null;
 
-  let delayed = 0, cancelled = 0, totalDelay = 0;
+  let delayed = 0, cancelled = 0, totalDelay = 0, resolved = 0;
   for (const f of flights) {
+    if (RESOLVED_STATUSES.has(f.flight_status || '')) resolved++;
     if (f.flight_status === 'cancelled') cancelled++;
     if (f.departure?.delay && f.departure.delay > 0) {
       delayed++;
@@ -1568,7 +1586,7 @@ function aviationAggregateFlights(iata, flights) {
     }
   }
 
-  const total = flights.length;
+  const total = resolved >= AVIATION_MIN_FLIGHTS_FOR_CLOSURE ? resolved : flights.length;
   const cancelledPct = (cancelled / total) * 100;
   const delayedPct = (delayed / total) * 100;
   const avgDelay = delayed > 0 ? Math.round(totalDelay / delayed) : 0;

--- a/server/worldmonitor/aviation/v1/_shared.ts
+++ b/server/worldmonitor/aviation/v1/_shared.ts
@@ -34,6 +34,7 @@ export const ICAO_NOTAM_URL = 'https://dataservices.icao.int/api/notams-realtime
 export const DEFAULT_WATCHED_AIRPORTS = ['IST', 'ESB', 'SAW', 'LHR', 'FRA', 'CDG'];
 const BATCH_CONCURRENCY = 10;
 const MIN_FLIGHTS_FOR_CLOSURE = 10;
+const RESOLVED_STATUSES = new Set(['cancelled', 'landed', 'active', 'arrived', 'diverted']);
 const NOTAM_CLOSURE_QCODES = new Set(['FA', 'AH', 'AL', 'AW', 'AC', 'AM']);
 
 // ---------- XML Parser ----------
@@ -189,6 +190,14 @@ export function toProtoSource(s: string): FlightDelaySource {
 
 // ---------- Severity classification ----------
 
+export function severityFromCancelRate(cancelRate: number): string {
+  if (cancelRate >= 80) return 'severe';
+  if (cancelRate >= 50) return 'major';
+  if (cancelRate >= 20) return 'moderate';
+  if (cancelRate >= 10) return 'minor';
+  return 'normal';
+}
+
 export function determineSeverity(avgDelayMinutes: number, delayedPct?: number): string {
   const t = DELAY_SEVERITY_THRESHOLDS;
   if (avgDelayMinutes >= t.severe.avgDelayMinutes || (delayedPct && delayedPct >= t.severe.delayedPct)) return 'severe';
@@ -202,6 +211,7 @@ export function determineSeverity(avgDelayMinutes: number, delayedPct?: number):
 
 interface AviationStackFlight {
   flight_status?: string;
+  flight_date?: string;
   departure?: { delay?: number };
 }
 
@@ -256,9 +266,11 @@ async function fetchSingleAirport(
   apiKey: string, airport: MonitoredAirport
 ): Promise<FetchResult> {
   try {
+    const today = new Date().toISOString().slice(0, 10);
     const params = new URLSearchParams({
       access_key: apiKey,
       dep_iata: airport.iata,
+      flight_date: today,
       limit: '100',
     });
     const url = `${AVIATIONSTACK_URL}?${params}`;
@@ -289,8 +301,9 @@ function aggregateFlights(
 ): AirportDelayAlert | null {
   if (flights.length === 0) return null;
 
-  let delayed = 0, cancelled = 0, totalDelay = 0;
+  let delayed = 0, cancelled = 0, totalDelay = 0, resolved = 0;
   for (const f of flights) {
+    if (RESOLVED_STATUSES.has(f.flight_status ?? '')) resolved++;
     if (f.flight_status === 'cancelled') cancelled++;
     if (f.departure?.delay && f.departure.delay > 0) {
       delayed++;
@@ -298,7 +311,7 @@ function aggregateFlights(
     }
   }
 
-  const total = flights.length;
+  const total = resolved >= MIN_FLIGHTS_FOR_CLOSURE ? resolved : flights.length;
   const cancelledPct = (cancelled / total) * 100;
   const delayedPct = (delayed / total) * 100;
   const avgDelay = delayed > 0 ? Math.round(totalDelay / delayed) : 0;

--- a/server/worldmonitor/aviation/v1/get-airport-ops-summary.ts
+++ b/server/worldmonitor/aviation/v1/get-airport-ops-summary.ts
@@ -11,6 +11,7 @@ import {
     fetchAviationStackDelays,
     fetchNotamClosures,
     determineSeverity,
+    severityFromCancelRate,
     parseStringArray,
     DEFAULT_WATCHED_AIRPORTS,
 } from './_shared';
@@ -58,7 +59,10 @@ export async function getAirportOpsSummary(
                     const totalFlights = alert?.totalFlights ?? 0;
                     const cancelRate = totalFlights > 0 ? (cancelledFlights / totalFlights) * 100 : 0;
 
-                    const sevStr = isClosed ? 'severe' : determineSeverity(avgDelay, delayPct);
+                    const cancelSev = isClosed ? 'severe' : severityFromCancelRate(cancelRate);
+                    const delaySev = determineSeverity(avgDelay, delayPct);
+                    const sevOrder = ['normal', 'minor', 'moderate', 'major', 'severe'];
+                    const sevStr = sevOrder.indexOf(cancelSev) >= sevOrder.indexOf(delaySev) ? cancelSev : delaySev;
                     const severity = `FLIGHT_DELAY_SEVERITY_${sevStr.toUpperCase()}` as FlightDelaySeverity;
 
                     const notamFlags: string[] = [];

--- a/src/config/airports.ts
+++ b/src/config/airports.ts
@@ -41,6 +41,9 @@ export const MONITORED_AIRPORTS: MonitoredAirport[] = [
   { iata: 'CPH', icao: 'EKCH', name: 'Copenhagen Airport', city: 'Copenhagen', country: 'Denmark', lat: 55.6180, lon: 12.6508, region: 'europe' },
   { iata: 'DUB', icao: 'EIDW', name: 'Dublin Airport', city: 'Dublin', country: 'Ireland', lat: 53.4264, lon: -6.2499, region: 'europe' },
   { iata: 'IST', icao: 'LTFM', name: 'Istanbul Airport', city: 'Istanbul', country: 'Turkey', lat: 41.2753, lon: 28.7519, region: 'europe' },
+  { iata: 'LIS', icao: 'LPPT', name: 'Humberto Delgado Airport', city: 'Lisbon', country: 'Portugal', lat: 38.7756, lon: -9.1354, region: 'europe' },
+  { iata: 'ATH', icao: 'LGAV', name: 'Athens International', city: 'Athens', country: 'Greece', lat: 37.9364, lon: 23.9445, region: 'europe' },
+  { iata: 'WAW', icao: 'EPWA', name: 'Warsaw Chopin Airport', city: 'Warsaw', country: 'Poland', lat: 52.1657, lon: 20.9671, region: 'europe' },
   { iata: 'SVO', icao: 'UUEE', name: 'Sheremetyevo International', city: 'Moscow', country: 'Russia', lat: 55.9736, lon: 37.4125, region: 'europe' },
   { iata: 'ARN', icao: 'ESSA', name: 'Stockholm Arlanda', city: 'Stockholm', country: 'Sweden', lat: 59.6519, lon: 17.9186, region: 'europe' },
   { iata: 'OSL', icao: 'ENGM', name: 'Oslo Gardermoen', city: 'Oslo', country: 'Norway', lat: 60.1939, lon: 11.1004, region: 'europe' },
@@ -51,6 +54,7 @@ export const MONITORED_AIRPORTS: MonitoredAirport[] = [
   { iata: 'NRT', icao: 'RJAA', name: 'Narita International', city: 'Tokyo', country: 'Japan', lat: 35.7720, lon: 140.3929, region: 'apac' },
   { iata: 'PEK', icao: 'ZBAA', name: 'Beijing Capital', city: 'Beijing', country: 'China', lat: 40.0799, lon: 116.6031, region: 'apac' },
   { iata: 'PVG', icao: 'ZSPD', name: 'Shanghai Pudong', city: 'Shanghai', country: 'China', lat: 31.1443, lon: 121.8083, region: 'apac' },
+  { iata: 'CAN', icao: 'ZGGG', name: 'Guangzhou Baiyun International', city: 'Guangzhou', country: 'China', lat: 23.3924, lon: 113.2988, region: 'apac' },
   { iata: 'HKG', icao: 'VHHH', name: 'Hong Kong International', city: 'Hong Kong', country: 'China', lat: 22.3080, lon: 113.9185, region: 'apac' },
   { iata: 'SIN', icao: 'WSSS', name: 'Singapore Changi', city: 'Singapore', country: 'Singapore', lat: 1.3644, lon: 103.9915, region: 'apac' },
   { iata: 'ICN', icao: 'RKSI', name: 'Incheon International', city: 'Seoul', country: 'South Korea', lat: 37.4602, lon: 126.4407, region: 'apac' },
@@ -132,17 +136,19 @@ export const FAA_AIRPORTS = MONITORED_AIRPORTS.filter(
   (a) => a.country === 'USA'
 ).map((a) => a.iata);
 
-// Top 40 international hubs queried via AviationStack (non-US; US uses FAA)
-// All 128 airports remain in MONITORED_AIRPORTS for map display, NOTAMs, and gray dots
+// Top international hubs queried via AviationStack (non-US; US uses FAA)
+// All airports remain in MONITORED_AIRPORTS for map display, NOTAMs, and gray dots
 export const AVIATIONSTACK_AIRPORTS: string[] = [
-  // Americas (5)
-  'YYZ', 'MEX', 'GRU', 'EZE', 'BOG',
-  // Europe (12)
+  // Americas (7)
+  'YYZ', 'YVR', 'MEX', 'GRU', 'EZE', 'BOG', 'SCL',
+  // Europe (16)
   'LHR', 'CDG', 'FRA', 'AMS', 'MAD', 'FCO', 'MUC', 'BCN', 'ZRH', 'IST', 'VIE', 'CPH',
-  // APAC (12)
+  'DUB', 'LIS', 'ATH', 'WAW',
+  // APAC (15)
   'HND', 'NRT', 'PEK', 'PVG', 'HKG', 'SIN', 'ICN', 'BKK', 'SYD', 'DEL', 'BOM', 'KUL',
-  // MENA (6)
-  'DXB', 'DOH', 'AUH', 'RUH', 'CAI', 'TLV',
+  'CAN', 'TPE', 'MNL',
+  // MENA (9)
+  'DXB', 'DOH', 'AUH', 'RUH', 'CAI', 'TLV', 'AMM', 'KWI', 'CMN',
   // Africa (5)
   'JNB', 'NBO', 'LOS', 'ADD', 'CPT',
 ];


### PR DESCRIPTION
## Summary

- **Fix cancellation rate denominator**: Use only resolved flights (landed, active, cancelled, diverted) instead of all flights including scheduled/unknown. DXB was showing 15% cancelled (NORMAL) when the real rate among resolved flights is ~58% (MAJOR).
- **Add `flight_date=today` filter**: Prevents mixing historical/future flights into cancellation stats.
- **Factor cancellation rate into ops summary severity**: Table was ignoring cancellations entirely — only delay minutes affected severity. Now uses `severityFromCancelRate()` shared function.
- **Add 12 major airports**: YVR, SCL, DUB, LIS, ATH, WAW, CAN, TPE, MNL, AMM, KWI, CMN (40→52 AviationStack airports).

## Before / After (DXB example)

| Metric | Before | After |
|--------|--------|-------|
| Sample | 100 flights (all statuses) | 100 flights (resolved only) |
| Denominator | 100 (incl. scheduled/unknown) | ~24 resolved |
| Cancel rate | 15% → NORMAL | ~58% → MAJOR |
| Date filter | None (mixed days) | Today only |

## Test plan

- [x] `tsc --noEmit` passes
- [x] Edge function tests pass (60/60)
- [x] Markdown lint clean
- [ ] Verify DXB shows correct severity on map popup and ops table after deploy
- [ ] Verify new airports (e.g., CAN, ATH) appear in relay seed output