### PR TITLE
refactor: consolidate duplicated market data lists into shared JSON configs

### DIFF
--- a/scripts/seed-commodity-quotes.mjs
+++ b/scripts/seed-commodity-quotes.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
+import { createRequire } from 'module';
 import { loadEnvFile, CHROME_UA, sleep, runSeed, parseYahooChart, writeExtraKey } from './_seed-utils.mjs';
+
+const require = createRequire(import.meta.url);
+const commodityConfig = require('../shared/commodities.json');
 
 loadEnvFile(import.meta.url);
 
@@ -30,7 +34,7 @@ async function fetchYahooWithRetry(url, label, maxAttempts = 4) {
   return null;
 }
 
-const COMMODITY_SYMBOLS = ['^VIX', 'GC=F', 'CL=F', 'NG=F', 'SI=F', 'HG=F'];
+const COMMODITY_SYMBOLS = commodityConfig.commodities.map(c => c.symbol);
 
 async function fetchCommodityQuotes() {
   const quotes = [];

--- a/scripts/seed-etf-flows.mjs
+++ b/scripts/seed-etf-flows.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
+import { createRequire } from 'module';
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
+const require = createRequire(import.meta.url);
+const etfConfig = require('../shared/etfs.json');
 
 loadEnvFile(import.meta.url);
 
@@ -8,18 +12,7 @@ const CANONICAL_KEY = 'market:etf-flows:v1';
 const CACHE_TTL = 3600;
 const YAHOO_DELAY_MS = 200;
 
-const ETF_LIST = [
-  { ticker: 'IBIT', issuer: 'BlackRock' },
-  { ticker: 'FBTC', issuer: 'Fidelity' },
-  { ticker: 'ARKB', issuer: 'ARK/21Shares' },
-  { ticker: 'BITB', issuer: 'Bitwise' },
-  { ticker: 'GBTC', issuer: 'Grayscale' },
-  { ticker: 'HODL', issuer: 'VanEck' },
-  { ticker: 'BRRR', issuer: 'Valkyrie' },
-  { ticker: 'EZBC', issuer: 'Franklin' },
-  { ticker: 'BTCO', issuer: 'Invesco' },
-  { ticker: 'BTCW', issuer: 'WisdomTree' },
-];
+const ETF_LIST = etfConfig.btcSpot;
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));

--- a/scripts/seed-gulf-quotes.mjs
+++ b/scripts/seed-gulf-quotes.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
+import { createRequire } from 'module';
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
+const require = createRequire(import.meta.url);
+const gulfConfig = require('../shared/gulf.json');
 
 loadEnvFile(import.meta.url);
 
@@ -8,22 +12,7 @@ const CANONICAL_KEY = 'market:gulf-quotes:v1';
 const CACHE_TTL = 3600;
 const YAHOO_DELAY_MS = 200;
 
-const GULF_SYMBOLS = [
-  { symbol: '^TASI.SR', name: 'Tadawul All Share', country: 'Saudi Arabia', flag: '\u{1F1F8}\u{1F1E6}', type: 'index' },
-  { symbol: 'DFMGI.AE', name: 'Dubai Financial Market', country: 'UAE', flag: '\u{1F1E6}\u{1F1EA}', type: 'index' },
-  { symbol: 'UAE', name: 'Abu Dhabi (iShares)', country: 'UAE', flag: '\u{1F1E6}\u{1F1EA}', type: 'index' },
-  { symbol: 'QAT', name: 'Qatar (iShares)', country: 'Qatar', flag: '\u{1F1F6}\u{1F1E6}', type: 'index' },
-  { symbol: 'GULF', name: 'Gulf Dividend (WisdomTree)', country: 'Kuwait', flag: '\u{1F1F0}\u{1F1FC}', type: 'index' },
-  { symbol: '^MSM', name: 'Muscat MSM 30', country: 'Oman', flag: '\u{1F1F4}\u{1F1F2}', type: 'index' },
-  { symbol: 'SARUSD=X', name: 'Saudi Riyal', country: 'Saudi Arabia', flag: '\u{1F1F8}\u{1F1E6}', type: 'currency' },
-  { symbol: 'AEDUSD=X', name: 'UAE Dirham', country: 'UAE', flag: '\u{1F1E6}\u{1F1EA}', type: 'currency' },
-  { symbol: 'QARUSD=X', name: 'Qatari Riyal', country: 'Qatar', flag: '\u{1F1F6}\u{1F1E6}', type: 'currency' },
-  { symbol: 'KWDUSD=X', name: 'Kuwaiti Dinar', country: 'Kuwait', flag: '\u{1F1F0}\u{1F1FC}', type: 'currency' },
-  { symbol: 'BHDUSD=X', name: 'Bahraini Dinar', country: 'Bahrain', flag: '\u{1F1E7}\u{1F1ED}', type: 'currency' },
-  { symbol: 'OMRUSD=X', name: 'Omani Rial', country: 'Oman', flag: '\u{1F1F4}\u{1F1F2}', type: 'currency' },
-  { symbol: 'CL=F', name: 'WTI Crude', country: '', flag: '\u{1F6E2}\u{FE0F}', type: 'oil' },
-  { symbol: 'BZ=F', name: 'Brent Crude', country: '', flag: '\u{1F6E2}\u{FE0F}', type: 'oil' },
-];
+const GULF_SYMBOLS = gulfConfig.symbols;
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));

--- a/scripts/seed-market-quotes.mjs
+++ b/scripts/seed-market-quotes.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
+import { createRequire } from 'module';
 import { loadEnvFile, CHROME_UA, sleep, runSeed, parseYahooChart, writeExtraKey } from './_seed-utils.mjs';
+
+const require = createRequire(import.meta.url);
+const stocksConfig = require('../shared/stocks.json');
 
 loadEnvFile(import.meta.url);
 
@@ -8,14 +12,9 @@ const CANONICAL_KEY = 'market:stocks-bootstrap:v1';
 const CACHE_TTL = 1800;
 const YAHOO_DELAY_MS = 200;
 
-const MARKET_SYMBOLS = [
-  'AAPL', 'AMZN', 'AVGO', 'BAC', 'BRK-B', 'COST', 'GOOGL', 'HD',
-  'JNJ', 'JPM', 'LLY', 'MA', 'META', 'MSFT', 'NFLX', 'NVO', 'NVDA',
-  'ORCL', 'PG', 'TSLA', 'TSM', 'UNH', 'V', 'WMT', 'XOM',
-  '^DJI', '^GSPC', '^IXIC',
-];
+const MARKET_SYMBOLS = stocksConfig.symbols.map(s => s.symbol);
 
-const YAHOO_ONLY = new Set(['^GSPC', '^DJI', '^IXIC']);
+const YAHOO_ONLY = new Set(stocksConfig.yahooOnly);
 
 async function fetchFinnhubQuote(symbol, apiKey) {
   try {

--- a/scripts/seed-stablecoin-markets.mjs
+++ b/scripts/seed-stablecoin-markets.mjs
@@ -1,13 +1,17 @@
 #!/usr/bin/env node
 
+import { createRequire } from 'module';
 import { loadEnvFile, CHROME_UA, runSeed, sleep } from './_seed-utils.mjs';
+
+const require = createRequire(import.meta.url);
+const stablecoinConfig = require('../shared/stablecoins.json');
 
 loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'market:stablecoins:v1';
 const CACHE_TTL = 3600; // 1 hour
 
-const STABLECOIN_IDS = 'tether,usd-coin,dai,first-digital-usd,ethena-usde';
+const STABLECOIN_IDS = stablecoinConfig.ids.join(',');
 
 async function fetchWithRateLimitRetry(url, maxAttempts = 5, headers = { Accept: 'application/json', 'User-Agent': CHROME_UA }) {
   for (let i = 0; i < maxAttempts; i++) {
@@ -27,13 +31,7 @@ async function fetchWithRateLimitRetry(url, maxAttempts = 5, headers = { Accept:
   throw new Error('CoinGecko rate limit exceeded after retries');
 }
 
-const COINPAPRIKA_ID_MAP = {
-  tether: 'usdt-tether',
-  'usd-coin': 'usdc-usd-coin',
-  dai: 'dai-dai',
-  'first-digital-usd': 'fdusd-first-digital-usd',
-  'ethena-usde': 'usde-ethena-usde',
-};
+const COINPAPRIKA_ID_MAP = stablecoinConfig.coinpaprika;
 
 async function fetchFromCoinGecko() {
   const apiKey = process.env.COINGECKO_API_KEY;

--- a/server/worldmonitor/market/v1/_shared.ts
+++ b/server/worldmonitor/market/v1/_shared.ts
@@ -3,6 +3,7 @@
  */
 import { CHROME_UA, yahooGate } from '../../../_shared/constants';
 import cryptoConfig from '../../../../shared/crypto.json';
+import stablecoinConfig from '../../../../shared/stablecoins.json';
 
 // ========================================================================
 // Relay helpers (Railway proxy for Yahoo when Vercel IPs are rate-limited)
@@ -271,11 +272,7 @@ export async function fetchCoinGeckoMarkets(
 // CoinGecko ID → CoinPaprika ID mapping (shared ids + stablecoin-specific)
 const COINPAPRIKA_ID_MAP: Record<string, string> = {
   ...cryptoConfig.coinpaprika,
-  tether: 'usdt-tether',
-  'usd-coin': 'usdc-usd-coin',
-  dai: 'dai-dai',
-  'first-digital-usd': 'fdusd-first-digital-usd',
-  'ethena-usde': 'usde-ethena-usde',
+  ...stablecoinConfig.coinpaprika,
 };
 
 interface CoinPaprikaTicker {

--- a/server/worldmonitor/market/v1/get-sector-summary.ts
+++ b/server/worldmonitor/market/v1/get-sector-summary.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { fetchFinnhubQuote, fetchYahooQuotesBatch } from './_shared';
 import { cachedFetchJson } from '../../../_shared/redis';
+import sectorConfig from '../../../../shared/sectors.json';
 
 const REDIS_CACHE_KEY = 'market:sectors:v1';
 const REDIS_CACHE_TTL = 600; // 10 min — Finnhub rate-limited
@@ -24,7 +25,7 @@ export async function getSectorSummary(
 
   try {
   const result = await cachedFetchJson<GetSectorSummaryResponse>(REDIS_CACHE_KEY, REDIS_CACHE_TTL, async () => {
-    const sectorSymbols = ['XLK', 'XLF', 'XLE', 'XLV', 'XLY', 'XLI', 'XLP', 'XLU', 'XLB', 'XLRE', 'XLC', 'SMH'];
+    const sectorSymbols = sectorConfig.sectors.map(s => s.symbol);
     const sectors: SectorPerformance[] = [];
 
     if (apiKey) {

--- a/server/worldmonitor/market/v1/list-etf-flows.ts
+++ b/server/worldmonitor/market/v1/list-etf-flows.ts
@@ -12,6 +12,7 @@ import type {
 import { UPSTREAM_TIMEOUT_MS, type YahooChartResponse } from './_shared';
 import { CHROME_UA, yahooGate } from '../../../_shared/constants';
 import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
+import etfConfig from '../../../../shared/etfs.json';
 
 // ========================================================================
 // Constants and cache
@@ -20,18 +21,7 @@ import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 const REDIS_CACHE_KEY = 'market:etf-flows:v1';
 const REDIS_CACHE_TTL = 600; // 10 min — daily volume data, slow-moving
 
-const ETF_LIST = [
-  { ticker: 'IBIT', issuer: 'BlackRock' },
-  { ticker: 'FBTC', issuer: 'Fidelity' },
-  { ticker: 'ARKB', issuer: 'ARK/21Shares' },
-  { ticker: 'BITB', issuer: 'Bitwise' },
-  { ticker: 'GBTC', issuer: 'Grayscale' },
-  { ticker: 'HODL', issuer: 'VanEck' },
-  { ticker: 'BRRR', issuer: 'Valkyrie' },
-  { ticker: 'EZBC', issuer: 'Franklin' },
-  { ticker: 'BTCO', issuer: 'Invesco' },
-  { ticker: 'BTCW', issuer: 'WisdomTree' },
-];
+const ETF_LIST = etfConfig.btcSpot;
 
 const SEED_FRESHNESS_MS = 90 * 60_000; // 90 min — Railway seeds every hour
 

--- a/server/worldmonitor/market/v1/list-gulf-quotes.ts
+++ b/server/worldmonitor/market/v1/list-gulf-quotes.ts
@@ -13,6 +13,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { fetchYahooQuotesBatch } from './_shared';
 import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
+import gulfConfig from '../../../../shared/gulf.json';
 
 const REDIS_KEY = 'market:gulf-quotes:v1';
 const REDIS_TTL = 480; // 8 min
@@ -30,25 +31,7 @@ interface GulfSymbolMeta {
   type: 'index' | 'currency' | 'oil';
 }
 
-const GULF_SYMBOLS: GulfSymbolMeta[] = [
-  // Indices — real Yahoo indices where available, iShares ETF proxies otherwise
-  { symbol: '^TASI.SR', name: 'Tadawul All Share', country: 'Saudi Arabia', flag: '🇸🇦', type: 'index' },
-  { symbol: 'DFMGI.AE', name: 'Dubai Financial Market', country: 'UAE', flag: '🇦🇪', type: 'index' },
-  { symbol: 'UAE', name: 'Abu Dhabi (iShares)', country: 'UAE', flag: '🇦🇪', type: 'index' },
-  { symbol: 'QAT', name: 'Qatar (iShares)', country: 'Qatar', flag: '🇶🇦', type: 'index' },
-  { symbol: 'GULF', name: 'Gulf Dividend (WisdomTree)', country: 'Kuwait', flag: '🇰🇼', type: 'index' },
-  { symbol: '^MSM', name: 'Muscat MSM 30', country: 'Oman', flag: '🇴🇲', type: 'index' },
-  // Currencies (6)
-  { symbol: 'SARUSD=X', name: 'Saudi Riyal', country: 'Saudi Arabia', flag: '🇸🇦', type: 'currency' },
-  { symbol: 'AEDUSD=X', name: 'UAE Dirham', country: 'UAE', flag: '🇦🇪', type: 'currency' },
-  { symbol: 'QARUSD=X', name: 'Qatari Riyal', country: 'Qatar', flag: '🇶🇦', type: 'currency' },
-  { symbol: 'KWDUSD=X', name: 'Kuwaiti Dinar', country: 'Kuwait', flag: '🇰🇼', type: 'currency' },
-  { symbol: 'BHDUSD=X', name: 'Bahraini Dinar', country: 'Bahrain', flag: '🇧🇭', type: 'currency' },
-  { symbol: 'OMRUSD=X', name: 'Omani Rial', country: 'Oman', flag: '🇴🇲', type: 'currency' },
-  // Oil benchmarks (2)
-  { symbol: 'CL=F', name: 'WTI Crude', country: '', flag: '🛢️', type: 'oil' },
-  { symbol: 'BZ=F', name: 'Brent Crude', country: '', flag: '🛢️', type: 'oil' },
-];
+const GULF_SYMBOLS: GulfSymbolMeta[] = gulfConfig.symbols as GulfSymbolMeta[];
 
 const ALL_SYMBOLS = GULF_SYMBOLS.map(s => s.symbol);
 const META_MAP = new Map(GULF_SYMBOLS.map(s => [s.symbol, s]));

--- a/server/worldmonitor/market/v1/list-stablecoin-markets.ts
+++ b/server/worldmonitor/market/v1/list-stablecoin-markets.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { parseStringArray, fetchCryptoMarkets } from './_shared';
 import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
+import stablecoinConfig from '../../../../shared/stablecoins.json';
 
 const REDIS_CACHE_KEY = 'market:stablecoins:v1';
 const REDIS_CACHE_TTL = 600; // 10 min — CoinGecko rate-limited
@@ -19,7 +20,7 @@ const REDIS_CACHE_TTL = 600; // 10 min — CoinGecko rate-limited
 // Constants and cache
 // ========================================================================
 
-const DEFAULT_STABLECOIN_IDS = 'tether,usd-coin,dai,first-digital-usd,ethena-usde';
+const DEFAULT_STABLECOIN_IDS = stablecoinConfig.ids.join(',');
 
 let stablecoinCache: ListStablecoinMarketsResponse | null = null;
 let stablecoinCacheTimestamp = 0;

--- a/shared/commodities.json
+++ b/shared/commodities.json
@@ -1,0 +1,10 @@
+{
+  "commodities": [
+    { "symbol": "^VIX", "name": "VIX", "display": "VIX" },
+    { "symbol": "GC=F", "name": "Gold", "display": "GOLD" },
+    { "symbol": "CL=F", "name": "Crude Oil", "display": "OIL" },
+    { "symbol": "NG=F", "name": "Natural Gas", "display": "NATGAS" },
+    { "symbol": "SI=F", "name": "Silver", "display": "SILVER" },
+    { "symbol": "HG=F", "name": "Copper", "display": "COPPER" }
+  ]
+}

--- a/shared/etfs.json
+++ b/shared/etfs.json
@@ -1,0 +1,14 @@
+{
+  "btcSpot": [
+    { "ticker": "IBIT", "issuer": "BlackRock" },
+    { "ticker": "FBTC", "issuer": "Fidelity" },
+    { "ticker": "ARKB", "issuer": "ARK/21Shares" },
+    { "ticker": "BITB", "issuer": "Bitwise" },
+    { "ticker": "GBTC", "issuer": "Grayscale" },
+    { "ticker": "HODL", "issuer": "VanEck" },
+    { "ticker": "BRRR", "issuer": "Valkyrie" },
+    { "ticker": "EZBC", "issuer": "Franklin" },
+    { "ticker": "BTCO", "issuer": "Invesco" },
+    { "ticker": "BTCW", "issuer": "WisdomTree" }
+  ]
+}

--- a/shared/gulf.json
+++ b/shared/gulf.json
@@ -1,0 +1,18 @@
+{
+  "symbols": [
+    { "symbol": "^TASI.SR", "name": "Tadawul All Share", "country": "Saudi Arabia", "flag": "\ud83c\uddf8\ud83c\udde6", "type": "index" },
+    { "symbol": "DFMGI.AE", "name": "Dubai Financial Market", "country": "UAE", "flag": "\ud83c\udde6\ud83c\uddea", "type": "index" },
+    { "symbol": "UAE", "name": "Abu Dhabi (iShares)", "country": "UAE", "flag": "\ud83c\udde6\ud83c\uddea", "type": "index" },
+    { "symbol": "QAT", "name": "Qatar (iShares)", "country": "Qatar", "flag": "\ud83c\uddf6\ud83c\udde6", "type": "index" },
+    { "symbol": "GULF", "name": "Gulf Dividend (WisdomTree)", "country": "Kuwait", "flag": "\ud83c\uddf0\ud83c\uddfc", "type": "index" },
+    { "symbol": "^MSM", "name": "Muscat MSM 30", "country": "Oman", "flag": "\ud83c\uddf4\ud83c\uddf2", "type": "index" },
+    { "symbol": "SARUSD=X", "name": "Saudi Riyal", "country": "Saudi Arabia", "flag": "\ud83c\uddf8\ud83c\udde6", "type": "currency" },
+    { "symbol": "AEDUSD=X", "name": "UAE Dirham", "country": "UAE", "flag": "\ud83c\udde6\ud83c\uddea", "type": "currency" },
+    { "symbol": "QARUSD=X", "name": "Qatari Riyal", "country": "Qatar", "flag": "\ud83c\uddf6\ud83c\udde6", "type": "currency" },
+    { "symbol": "KWDUSD=X", "name": "Kuwaiti Dinar", "country": "Kuwait", "flag": "\ud83c\uddf0\ud83c\uddfc", "type": "currency" },
+    { "symbol": "BHDUSD=X", "name": "Bahraini Dinar", "country": "Bahrain", "flag": "\ud83c\udde7\ud83c\udded", "type": "currency" },
+    { "symbol": "OMRUSD=X", "name": "Omani Rial", "country": "Oman", "flag": "\ud83c\uddf4\ud83c\uddf2", "type": "currency" },
+    { "symbol": "CL=F", "name": "WTI Crude", "country": "", "flag": "\ud83d\udee2\ufe0f", "type": "oil" },
+    { "symbol": "BZ=F", "name": "Brent Crude", "country": "", "flag": "\ud83d\udee2\ufe0f", "type": "oil" }
+  ]
+}

--- a/shared/sectors.json
+++ b/shared/sectors.json
@@ -1,0 +1,16 @@
+{
+  "sectors": [
+    { "symbol": "XLK", "name": "Tech" },
+    { "symbol": "XLF", "name": "Finance" },
+    { "symbol": "XLE", "name": "Energy" },
+    { "symbol": "XLV", "name": "Health" },
+    { "symbol": "XLY", "name": "Consumer" },
+    { "symbol": "XLI", "name": "Industrial" },
+    { "symbol": "XLP", "name": "Staples" },
+    { "symbol": "XLU", "name": "Utilities" },
+    { "symbol": "XLB", "name": "Materials" },
+    { "symbol": "XLRE", "name": "Real Est" },
+    { "symbol": "XLC", "name": "Comms" },
+    { "symbol": "SMH", "name": "Semis" }
+  ]
+}

--- a/shared/stablecoins.json
+++ b/shared/stablecoins.json
@@ -1,0 +1,10 @@
+{
+  "ids": ["tether", "usd-coin", "dai", "first-digital-usd", "ethena-usde"],
+  "coinpaprika": {
+    "tether": "usdt-tether",
+    "usd-coin": "usdc-usd-coin",
+    "dai": "dai-dai",
+    "first-digital-usd": "fdusd-first-digital-usd",
+    "ethena-usde": "usde-ethena-usde"
+  }
+}

--- a/shared/stocks.json
+++ b/shared/stocks.json
@@ -1,0 +1,33 @@
+{
+  "symbols": [
+    { "symbol": "^GSPC", "name": "S&P 500", "display": "SPX" },
+    { "symbol": "^DJI", "name": "Dow Jones", "display": "DOW" },
+    { "symbol": "^IXIC", "name": "NASDAQ", "display": "NDX" },
+    { "symbol": "AAPL", "name": "Apple", "display": "AAPL" },
+    { "symbol": "MSFT", "name": "Microsoft", "display": "MSFT" },
+    { "symbol": "NVDA", "name": "NVIDIA", "display": "NVDA" },
+    { "symbol": "GOOGL", "name": "Alphabet", "display": "GOOGL" },
+    { "symbol": "AMZN", "name": "Amazon", "display": "AMZN" },
+    { "symbol": "META", "name": "Meta", "display": "META" },
+    { "symbol": "BRK-B", "name": "Berkshire", "display": "BRK.B" },
+    { "symbol": "TSM", "name": "TSMC", "display": "TSM" },
+    { "symbol": "LLY", "name": "Eli Lilly", "display": "LLY" },
+    { "symbol": "TSLA", "name": "Tesla", "display": "TSLA" },
+    { "symbol": "AVGO", "name": "Broadcom", "display": "AVGO" },
+    { "symbol": "WMT", "name": "Walmart", "display": "WMT" },
+    { "symbol": "JPM", "name": "JPMorgan", "display": "JPM" },
+    { "symbol": "V", "name": "Visa", "display": "V" },
+    { "symbol": "UNH", "name": "UnitedHealth", "display": "UNH" },
+    { "symbol": "NVO", "name": "Novo Nordisk", "display": "NVO" },
+    { "symbol": "XOM", "name": "Exxon", "display": "XOM" },
+    { "symbol": "MA", "name": "Mastercard", "display": "MA" },
+    { "symbol": "ORCL", "name": "Oracle", "display": "ORCL" },
+    { "symbol": "PG", "name": "P&G", "display": "PG" },
+    { "symbol": "COST", "name": "Costco", "display": "COST" },
+    { "symbol": "JNJ", "name": "J&J", "display": "JNJ" },
+    { "symbol": "HD", "name": "Home Depot", "display": "HD" },
+    { "symbol": "NFLX", "name": "Netflix", "display": "NFLX" },
+    { "symbol": "BAC", "name": "BofA", "display": "BAC" }
+  ],
+  "yahooOnly": ["^GSPC", "^DJI", "^IXIC"]
+}

--- a/src/config/markets.ts
+++ b/src/config/markets.ts
@@ -1,60 +1,14 @@
 import type { Sector, Commodity, MarketSymbol } from '@/types';
 import cryptoConfig from '../../shared/crypto.json';
+import sectorConfig from '../../shared/sectors.json';
+import commodityConfig from '../../shared/commodities.json';
+import stocksConfig from '../../shared/stocks.json';
 
-export const SECTORS: Sector[] = [
-  { symbol: 'XLK', name: 'Tech' },
-  { symbol: 'XLF', name: 'Finance' },
-  { symbol: 'XLE', name: 'Energy' },
-  { symbol: 'XLV', name: 'Health' },
-  { symbol: 'XLY', name: 'Consumer' },
-  { symbol: 'XLI', name: 'Industrial' },
-  { symbol: 'XLP', name: 'Staples' },
-  { symbol: 'XLU', name: 'Utilities' },
-  { symbol: 'XLB', name: 'Materials' },
-  { symbol: 'XLRE', name: 'Real Est' },
-  { symbol: 'XLC', name: 'Comms' },
-  { symbol: 'SMH', name: 'Semis' },
-];
+export const SECTORS: Sector[] = sectorConfig.sectors as Sector[];
 
-export const COMMODITIES: Commodity[] = [
-  { symbol: '^VIX', name: 'VIX', display: 'VIX' },
-  { symbol: 'GC=F', name: 'Gold', display: 'GOLD' },
-  { symbol: 'CL=F', name: 'Crude Oil', display: 'OIL' },
-  { symbol: 'NG=F', name: 'Natural Gas', display: 'NATGAS' },
-  { symbol: 'SI=F', name: 'Silver', display: 'SILVER' },
-  { symbol: 'HG=F', name: 'Copper', display: 'COPPER' },
-];
+export const COMMODITIES: Commodity[] = commodityConfig.commodities as Commodity[];
 
-export const MARKET_SYMBOLS: MarketSymbol[] = [
-  { symbol: '^GSPC', name: 'S&P 500', display: 'SPX' },
-  { symbol: '^DJI', name: 'Dow Jones', display: 'DOW' },
-  { symbol: '^IXIC', name: 'NASDAQ', display: 'NDX' },
-  { symbol: 'AAPL', name: 'Apple', display: 'AAPL' },
-  { symbol: 'MSFT', name: 'Microsoft', display: 'MSFT' },
-  { symbol: 'NVDA', name: 'NVIDIA', display: 'NVDA' },
-  { symbol: 'GOOGL', name: 'Alphabet', display: 'GOOGL' },
-  { symbol: 'AMZN', name: 'Amazon', display: 'AMZN' },
-  { symbol: 'META', name: 'Meta', display: 'META' },
-  { symbol: 'BRK-B', name: 'Berkshire', display: 'BRK.B' },
-  { symbol: 'TSM', name: 'TSMC', display: 'TSM' },
-  { symbol: 'LLY', name: 'Eli Lilly', display: 'LLY' },
-  { symbol: 'TSLA', name: 'Tesla', display: 'TSLA' },
-  { symbol: 'AVGO', name: 'Broadcom', display: 'AVGO' },
-  { symbol: 'WMT', name: 'Walmart', display: 'WMT' },
-  { symbol: 'JPM', name: 'JPMorgan', display: 'JPM' },
-  { symbol: 'V', name: 'Visa', display: 'V' },
-  { symbol: 'UNH', name: 'UnitedHealth', display: 'UNH' },
-  { symbol: 'NVO', name: 'Novo Nordisk', display: 'NVO' },
-  { symbol: 'XOM', name: 'Exxon', display: 'XOM' },
-  { symbol: 'MA', name: 'Mastercard', display: 'MA' },
-  { symbol: 'ORCL', name: 'Oracle', display: 'ORCL' },
-  { symbol: 'PG', name: 'P&G', display: 'PG' },
-  { symbol: 'COST', name: 'Costco', display: 'COST' },
-  { symbol: 'JNJ', name: 'J&J', display: 'JNJ' },
-  { symbol: 'HD', name: 'Home Depot', display: 'HD' },
-  { symbol: 'NFLX', name: 'Netflix', display: 'NFLX' },
-  { symbol: 'BAC', name: 'BofA', display: 'BAC' },
-];
+export const MARKET_SYMBOLS: MarketSymbol[] = stocksConfig.symbols as MarketSymbol[];
 
 export const CRYPTO_IDS = cryptoConfig.ids as readonly string[];
 export const CRYPTO_MAP: Record<string, { name: string; symbol: string }> = cryptoConfig.meta;


### PR DESCRIPTION
## Summary

- Adding a new market item (crypto, ETF, stablecoin, etc.) previously required editing 2–4 files because lists were hardcoded independently in seed scripts, RPC handlers, and frontend config
- Following the proven `shared/crypto.json` pattern, extract **6 new shared JSON configs** so each list has a single source of truth
- All seed scripts, server handlers, and `src/config/markets.ts` now import from `shared/*.json` instead of maintaining independent copies

### New shared configs
| File | Data | Previously duplicated in |
|------|------|------------------------|
| `shared/stablecoins.json` | IDs + CoinPaprika mappings | seed script, RPC handler, `_shared.ts` |
| `shared/etfs.json` | BTC spot ETF tickers + issuers | seed script, RPC handler |
| `shared/gulf.json` | GCC indices, currencies, oil | seed script, RPC handler |
| `shared/sectors.json` | Sector ETF symbols + names | frontend config, RPC handler |
| `shared/commodities.json` | VIX, gold, oil, gas, silver, copper | frontend config, seed script |
| `shared/stocks.json` | Market symbols + yahoo-only set | frontend config, seed script |

### Before → After
- **Before:** Add 1 new ETF → edit `seed-etf-flows.mjs` AND `list-etf-flows.ts` (identical lists)
- **After:** Add 1 new ETF → edit `shared/etfs.json` only

Net: **+144 −134 lines** (6 new JSON files, 11 files simplified)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx tsc --noEmit -p tsconfig.api.json` — clean
- [x] Edge function tests — 60/60 pass
- [x] Markdown lint — 0 errors
- [x] Version sync check — OK
- [x] Grep confirms no remaining hardcoded lists in seed scripts or handlers