### PR TITLE
fix(brief): country brief formatting, duplication, and news cap

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -223,7 +223,7 @@ export class CountryIntelManager implements AppModule {
       if (severityDelta !== 0) return severityDelta;
       return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
     });
-    this.ctx.countryBriefPage.updateNews(filteredNews.slice(0, 15));
+    this.ctx.countryBriefPage.updateNews(filteredNews.slice(0, 10));
 
     this.ctx.countryBriefPage.updateInfrastructure(code);
 

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -260,7 +260,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         if (sb !== sa) return sb - sa;
         return this.toTimestamp(b.pubDate) - this.toTimestamp(a.pubDate);
       })
-      .slice(0, 15);
+      .slice(0, 10);
 
     this.currentHeadlineCount = items.length;
 
@@ -532,8 +532,9 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
       return;
     }
 
-    const summary = this.summarizeBrief(data.brief);
-    const text = this.el('p', 'cdp-assessment-text', summary);
+    const summaryHtml = this.formatBrief(this.summarizeBrief(data.brief), 0);
+    const text = this.el('div', 'cdp-assessment-text cdp-summary-only');
+    text.innerHTML = summaryHtml;
 
     const metaTokens: string[] = [];
     if (data.cached) metaTokens.push('Cached');
@@ -931,7 +932,12 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   }
 
   private summarizeBrief(brief: string): string {
-    const normalized = brief.replace(/\s+/g, ' ').trim();
+    const stripped = brief.replace(/\*\*(.*?)\*\*/g, '$1');
+    const lines = stripped.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+    if (lines.length >= 3) {
+      return lines.slice(0, 3).join('\n');
+    }
+    const normalized = stripped.replace(/\s+/g, ' ').trim();
     const sentences = normalized.split(/(?<=[.!?])\s+/).filter((part) => part.length > 0);
     return sentences.slice(0, 3).join(' ') || normalized;
   }

--- a/src/styles/country-deep-dive.css
+++ b/src/styles/country-deep-dive.css
@@ -51,6 +51,10 @@
   display: block;
 }
 
+.country-deep-dive.maximized .cdp-summary-only {
+  display: none;
+}
+
 .cdp-maximize-btn {
   border: 1px solid var(--border);
   background: var(--surface);


### PR DESCRIPTION
## Summary
- Fix `summarizeBrief()` collapsing multi-line fallback text into an unreadable run-on blob by detecting structured text (≥3 lines) and preserving line breaks
- Strip `**markdown**` markers before summarizing so bold syntax doesn't render as literal asterisks
- Render brief summary with `innerHTML` via `formatBrief()` instead of `textContent` for proper formatting
- Hide summary when panel is maximized (`cdp-summary-only` CSS class) to eliminate content duplication with the expanded full brief
- Cap news section at 10 articles (was 15)

## Test plan
- [ ] Open country brief for a Tier 1 country (e.g. Iran) — verify summary is readable with line breaks
- [ ] Maximize panel — verify brief shows only once (expanded version), no duplicate summary
- [ ] Minimize panel — verify summary reappears properly
- [ ] Verify news section shows max 10 items (5 visible + 5 expanded-only)
- [ ] Test with Groq API key disabled to trigger fallback brief — confirm formatting is clean