### PR TITLE
fix(map): layer toggles unresponsive after idle

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -356,7 +356,7 @@ export class DeckGLMap {
     nuclear: new Set(),
   };
 
-  private renderScheduled = false;
+  private renderRafId: number | null = null;
   private renderPaused = false;
   private renderPending = false;
   private webglLost = false;
@@ -3852,11 +3852,11 @@ export class DeckGLMap {
       this.renderPending = true;
       return;
     }
-    if (this.renderScheduled) return;
-    this.renderScheduled = true;
-
-    requestAnimationFrame(() => {
-      this.renderScheduled = false;
+    if (this.renderRafId !== null) {
+      cancelAnimationFrame(this.renderRafId);
+    }
+    this.renderRafId = requestAnimationFrame(() => {
+      this.renderRafId = null;
       this.updateLayers();
     });
   }
@@ -3865,6 +3865,11 @@ export class DeckGLMap {
     if (this.renderPaused === paused) return;
     this.renderPaused = paused;
     if (paused) {
+      if (this.renderRafId !== null) {
+        cancelAnimationFrame(this.renderRafId);
+        this.renderRafId = null;
+        this.renderPending = true;
+      }
       this.stopPulseAnimation();
       this.stopDayNightTimer();
       return;
@@ -5054,6 +5059,11 @@ export class DeckGLMap {
     this.debouncedFetchBases.cancel();
     this.debouncedFetchAircraft.cancel();
     this.rafUpdateLayers.cancel();
+
+    if (this.renderRafId !== null) {
+      cancelAnimationFrame(this.renderRafId);
+      this.renderRafId = null;
+    }
 
     if (this.moveTimeoutId) {
       clearTimeout(this.moveTimeoutId);


### PR DESCRIPTION
## Summary

- Replace `renderScheduled` boolean with `renderRafId` (rAF ID tracking) in DeckGLMap
- When the browser throttles rAF (background tab, idle power saving, GPU throttling), the boolean stayed `true` indefinitely, silently dropping all `render()` calls — including layer toggle clicks
- Cancel stale frames and schedule fresh ones so the latest state is always rendered
- Cancel pending rAF on pause and destroy to prevent callbacks on stale/torn-down state

## Test plan

- [ ] Open app, wait for idle timer (`[App] User idle` in console), toggle a layer — should respond immediately
- [ ] Switch to another tab, wait 30s+, come back, toggle — should respond immediately
- [ ] Rapid toggle bursts during reactivation — no duplicate renders or visual glitches
- [ ] `npx tsc --noEmit` — no type errors (verified)
- [ ] `grep -rn 'renderScheduled' src/components/DeckGLMap.ts` — zero hits (verified)