### PR TITLE
fix(pro): reset Turnstile on enterprise form error + retry on hashchange

### DIFF
--- a/pro-test/src/App.tsx
+++ b/pro-test/src/App.tsx
@@ -1002,6 +1002,10 @@ const EnterprisePage = () => (
             } catch {
               btn.textContent = t('enterpriseShowcase.contactFailed');
               btn.disabled = false;
+              if (turnstileWidget?.dataset.widgetId && window.turnstile) {
+                window.turnstile.reset(turnstileWidget.dataset.widgetId);
+                delete turnstileWidget.dataset.token;
+              }
               setTimeout(() => { btn.textContent = origText; }, 4000);
             }
           }}>

--- a/pro-test/src/main.tsx
+++ b/pro-test/src/main.tsx
@@ -32,7 +32,13 @@ initI18n().then(() => {
   }
 
   // Re-render Turnstile widgets when navigating between pages (hash routing).
+  // Retry a few times since React needs to mount the new page's .cf-turnstile divs.
   window.addEventListener('hashchange', () => {
-    setTimeout(() => initWidgets(), 100);
+    let tries = 0;
+    const poll = () => {
+      if (initWidgets() || ++tries >= 10) return;
+      setTimeout(poll, 200);
+    };
+    setTimeout(poll, 100);
   });
 });


### PR DESCRIPTION
## Summary
Two bugs found during fresh-eyes review:

1. **Enterprise form doesn't reset Turnstile on error** — after a failed submit, the token is consumed. Retries send a stale token → permanent 403. Now matches waitlist form behavior (reset widget + clear token on catch).

2. **Hashchange handler only tries once** — navigating to `#enterprise` before Turnstile loads means the enterprise form's widget never renders. Now retries up to 10 times (2s total), matching startup behavior.

## Test plan
- [ ] Submit enterprise form with invalid data → form recovers, Turnstile resets, retry works
- [ ] Navigate directly to `#enterprise` on slow connection → Turnstile widget appears
- [ ] Navigate home → enterprise → home → enterprise → widgets render each time