### PR TITLE
fix(scripts): resolve shared JSON configs for Railway rootDirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ src-tauri/sidecar/node/*
 api/[[][[].*.js
 .claudedocs/
 
+# Copied shared configs (postinstall copies ../shared/ for Railway)
+scripts/shared/
+
 # Large generated data files (reproduced by scripts/)
 scripts/data/pizzint-processed.json
 scripts/data/osm-military-processed.json

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -7,7 +7,17 @@ import { fileURLToPath } from 'node:url';
 const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 const MAX_PAYLOAD_BYTES = 5 * 1024 * 1024; // 5MB per key
 
+const __seed_dirname = dirname(fileURLToPath(import.meta.url));
+
 export { CHROME_UA };
+
+export function loadSharedConfig(filename) {
+  for (const base of [join(__seed_dirname, '..', 'shared'), join(__seed_dirname, 'shared')]) {
+    const p = join(base, filename);
+    if (existsSync(p)) return JSON.parse(readFileSync(p, 'utf8'));
+  }
+  throw new Error(`Cannot find shared/${filename} — checked ../shared/ and ./shared/`);
+}
 
 export function loadEnvFile(metaUrl) {
   const __dirname = metaUrl ? dirname(fileURLToPath(metaUrl)) : process.cwd();

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -17,7 +17,13 @@ const { readFileSync } = require('fs');
 const crypto = require('crypto');
 const v8 = require('v8');
 const { WebSocketServer, WebSocket } = require('ws');
-const RSS_ALLOWED_DOMAINS = new Set(require('../shared/rss-allowed-domains.cjs'));
+
+function requireShared(name) {
+  const candidates = [path.join(__dirname, '..', 'shared', name), path.join(__dirname, 'shared', name)];
+  for (const p of candidates) { try { return require(p); } catch {} }
+  throw new Error(`Cannot find shared/${name}`);
+}
+const RSS_ALLOWED_DOMAINS = new Set(requireShared('rss-allowed-domains.cjs'));
 
 // Log effective heap limit at startup (verifies NODE_OPTIONS=--max-old-space-size is active)
 const _heapStats = v8.getHeapStatistics();
@@ -1296,7 +1302,7 @@ async function seedEtfFlows() {
 }
 
 // Crypto Quotes — CoinGecko → CoinPaprika fallback
-const _cryptoCfg = require('../shared/crypto.json');
+const _cryptoCfg = requireShared('crypto.json');
 const CRYPTO_IDS = _cryptoCfg.ids;
 const CRYPTO_META = _cryptoCfg.meta;
 const CRYPTO_PAPRIKA_MAP = _cryptoCfg.coinpaprika;

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,6 +5,7 @@
   "main": "ais-relay.cjs",
   "scripts": {
     "start": "node ais-relay.cjs",
+    "postinstall": "mkdir -p shared && cp ../shared/*.json ../shared/*.cjs shared/ 2>/dev/null || true",
     "telegram:session": "node telegram/session-auth.mjs"
   },
   "dependencies": {

--- a/scripts/seed-commodity-quotes.mjs
+++ b/scripts/seed-commodity-quotes.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
-import { createRequire } from 'module';
-import { loadEnvFile, CHROME_UA, sleep, runSeed, parseYahooChart, writeExtraKey } from './_seed-utils.mjs';
+import { loadEnvFile, loadSharedConfig, CHROME_UA, sleep, runSeed, parseYahooChart, writeExtraKey } from './_seed-utils.mjs';
 
-const require = createRequire(import.meta.url);
-const commodityConfig = require('../shared/commodities.json');
+const commodityConfig = loadSharedConfig('commodities.json');
 
 loadEnvFile(import.meta.url);
 

--- a/scripts/seed-crypto-quotes.mjs
+++ b/scripts/seed-crypto-quotes.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
-import { createRequire } from 'module';
-import { loadEnvFile, CHROME_UA, runSeed, sleep } from './_seed-utils.mjs';
+import { loadEnvFile, loadSharedConfig, CHROME_UA, runSeed, sleep } from './_seed-utils.mjs';
 
-const require = createRequire(import.meta.url);
-const cryptoConfig = require('../shared/crypto.json');
+const cryptoConfig = loadSharedConfig('crypto.json');
 
 loadEnvFile(import.meta.url);
 

--- a/scripts/seed-etf-flows.mjs
+++ b/scripts/seed-etf-flows.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
-import { createRequire } from 'module';
-import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+import { loadEnvFile, loadSharedConfig, CHROME_UA, runSeed } from './_seed-utils.mjs';
 
-const require = createRequire(import.meta.url);
-const etfConfig = require('../shared/etfs.json');
+const etfConfig = loadSharedConfig('etfs.json');
 
 loadEnvFile(import.meta.url);
 

--- a/scripts/seed-gulf-quotes.mjs
+++ b/scripts/seed-gulf-quotes.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
-import { createRequire } from 'module';
-import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+import { loadEnvFile, loadSharedConfig, CHROME_UA, runSeed } from './_seed-utils.mjs';
 
-const require = createRequire(import.meta.url);
-const gulfConfig = require('../shared/gulf.json');
+const gulfConfig = loadSharedConfig('gulf.json');
 
 loadEnvFile(import.meta.url);
 

--- a/scripts/seed-market-quotes.mjs
+++ b/scripts/seed-market-quotes.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
-import { createRequire } from 'module';
-import { loadEnvFile, CHROME_UA, sleep, runSeed, parseYahooChart, writeExtraKey } from './_seed-utils.mjs';
+import { loadEnvFile, loadSharedConfig, CHROME_UA, sleep, runSeed, parseYahooChart, writeExtraKey } from './_seed-utils.mjs';
 
-const require = createRequire(import.meta.url);
-const stocksConfig = require('../shared/stocks.json');
+const stocksConfig = loadSharedConfig('stocks.json');
 
 loadEnvFile(import.meta.url);
 

--- a/scripts/seed-stablecoin-markets.mjs
+++ b/scripts/seed-stablecoin-markets.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 
-import { createRequire } from 'module';
-import { loadEnvFile, CHROME_UA, runSeed, sleep } from './_seed-utils.mjs';
+import { loadEnvFile, loadSharedConfig, CHROME_UA, runSeed, sleep } from './_seed-utils.mjs';
 
-const require = createRequire(import.meta.url);
-const stablecoinConfig = require('../shared/stablecoins.json');
+const stablecoinConfig = loadSharedConfig('stablecoins.json');
 
 loadEnvFile(import.meta.url);
 


### PR DESCRIPTION
## Summary
- Railway seed services deploy with `rootDirectory=scripts/`, so `require('../shared/X.json')` resolves to `/shared/` which doesn't exist in the container
- Added `loadSharedConfig()` helper (ESM) and `requireShared()` (CJS) with dual-path fallback: `../shared/` (local dev) → `./shared/` (Railway)
- Added `postinstall` script that copies `../shared/` into `./shared/` during Railway build
- Updated all 6 seed scripts + ais-relay to use the new helpers

## Test plan
- [x] All 6 seed scripts ran successfully locally with `loadSharedConfig`
- [x] `postinstall` is idempotent (tested repeated runs)
- [x] `postinstall` gracefully handles missing `../shared/` (`|| true`)
- [x] No remaining `require('../shared/...')` imports in `scripts/`
- [x] Relay `requireShared` resolves both `rss-allowed-domains.cjs` and `crypto.json`
- [ ] Verify Railway services start without MODULE_NOT_FOUND after deploy

Fixes crash introduced by #1212 (shared JSON consolidation).