### PR TITLE
feat: add UTM attribution tags to outbound links

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import * as Sentry from '@sentry/browser';
 import { inject } from '@vercel/analytics';
 import { App } from './App';
+import { installUtmInterceptor } from './utils/utm';
 
 const sentryDsn = import.meta.env.VITE_SENTRY_DSN?.trim();
 
@@ -320,6 +321,7 @@ if (urlParams.get('settings') === '1') {
     }
   );
 } else {
+  installUtmInterceptor();
   const app = new App('app');
   app
     .init()

--- a/src/utils/utm.ts
+++ b/src/utils/utm.ts
@@ -1,0 +1,50 @@
+const UTM_SOURCE = 'worldmonitor';
+const UTM_MEDIUM = 'referral';
+
+function isExternalUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url, window.location.origin);
+    return parsed.origin !== window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+function detectCampaign(anchor: HTMLElement): string {
+  const panel = anchor.closest('[data-panel]');
+  if (panel) return (panel as HTMLElement).dataset.panel || 'unknown';
+
+  const popup = anchor.closest('.maplibregl-popup, .mapboxgl-popup');
+  if (popup) return 'map-popup';
+
+  const modal = anchor.closest('.modal, [role="dialog"]');
+  if (modal) return 'modal';
+
+  return 'general';
+}
+
+function appendUtmParams(url: string, campaign: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.searchParams.has('utm_source')) return url;
+    parsed.searchParams.set('utm_source', UTM_SOURCE);
+    parsed.searchParams.set('utm_medium', UTM_MEDIUM);
+    parsed.searchParams.set('utm_campaign', campaign);
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+export function installUtmInterceptor(): void {
+  document.addEventListener('click', (e) => {
+    const anchor = (e.target as HTMLElement).closest('a[target="_blank"]') as HTMLAnchorElement | null;
+    if (!anchor) return;
+
+    const href = anchor.href;
+    if (!href || !isExternalUrl(href)) return;
+
+    const campaign = detectCampaign(anchor);
+    anchor.href = appendUtmParams(href, campaign);
+  }, true);
+}


### PR DESCRIPTION
## Summary
- Adds global click interceptor that appends `utm_source=worldmonitor&utm_medium=referral&utm_campaign={panel}` to all external links
- Campaign auto-detected from `data-panel` attribute, popup container, modal, or fallback to `general`
- Covers all ~30+ panels, map popups, and modals with zero per-file changes
- Skips same-origin links and links that already have UTM params

## Files changed
- `src/utils/utm.ts` — new utility with `installUtmInterceptor()`
- `src/main.ts` — wires interceptor before app init

## Test plan
- [ ] Click a news article link → verify URL has `?utm_source=worldmonitor&utm_medium=referral&utm_campaign=news`
- [ ] Click a link in map popup → verify `utm_campaign=map-popup`
- [ ] Click a link in a different panel (e.g., predictions) → verify campaign matches panel ID
- [ ] Verify internal links (same origin) are NOT modified