### PR TITLE
fix(rate-limit): use cf-connecting-ip for correct per-user rate limiting behind CF proxy

### DIFF
--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -19,11 +19,12 @@ function getRatelimit(): Ratelimit | null {
 }
 
 function getClientIp(request: Request): string {
-  // Vercel injects x-real-ip from the TCP connection — cannot be spoofed by clients.
+  // With Cloudflare proxy → Vercel, x-real-ip is the CF edge IP (shared across users).
+  // cf-connecting-ip is the actual client IP set by Cloudflare — prefer it.
   // x-forwarded-for is client-settable and MUST NOT be trusted for rate limiting.
   return (
-    request.headers.get('x-real-ip') ||
     request.headers.get('cf-connecting-ip') ||
+    request.headers.get('x-real-ip') ||
     request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
     '0.0.0.0'
   );

--- a/src/services/threat-classifier.ts
+++ b/src/services/threat-classifier.ts
@@ -423,10 +423,13 @@ const STAGGER_JITTER_MS = 200;
 const MIN_GAP_MS = 2000;
 const MAX_RETRIES = 2;
 const MAX_QUEUE_LENGTH = 100;
+const BASE_PAUSE_MS = 60_000;
+const MAX_PAUSE_MS = 300_000;
 let batchPaused = false;
 let batchInFlight = false;
 let batchTimer: ReturnType<typeof setTimeout> | null = null;
 let lastRequestAt = 0;
+let consecutive429s = 0;
 const batchQueue: BatchJob[] = [];
 
 async function waitForGap(): Promise<void> {
@@ -460,23 +463,36 @@ function flushBatch(): void {
           const resp = await classifyClient.classifyEvent({
             title: job.title, description: '', source: '', country: '',
           });
+          consecutive429s = 0;
           job.resolve(toThreat(resp));
         } catch (err) {
           if (err instanceof ApiError && (err.statusCode === 401 || err.statusCode === 429 || err.statusCode >= 500)) {
             batchPaused = true;
-            const delay = err.statusCode === 401 ? 120_000 : err.statusCode === 429 ? 60_000 : 30_000;
-            console.warn(`[Classify] ${err.statusCode} — pausing AI classification for ${delay / 1000}s`);
+            let delay: number;
+            if (err.statusCode === 401) {
+              delay = 120_000;
+            } else if (err.statusCode === 429) {
+              consecutive429s++;
+              delay = Math.min(BASE_PAUSE_MS * Math.pow(2, consecutive429s - 1), MAX_PAUSE_MS);
+            } else {
+              delay = 30_000;
+            }
+            console.warn(`[Classify] ${err.statusCode} — pausing AI classification for ${delay / 1000}s (backoff #${consecutive429s})`);
             const remaining = batch.slice(i + 1);
-            // Failed job: increment attempts, requeue if under limit
             if ((job.attempts ?? 0) < MAX_RETRIES) {
               job.attempts = (job.attempts ?? 0) + 1;
               batchQueue.unshift(job);
             } else {
               job.resolve(null);
             }
-            // Remaining jobs never hit the API — requeue without burning attempts
             for (let j = remaining.length - 1; j >= 0; j--) {
               batchQueue.unshift(remaining[j]!);
+            }
+            // On repeated 429s, drop excess queue to avoid hammering on resume
+            if (consecutive429s >= 2 && batchQueue.length > BATCH_SIZE) {
+              const dropped = batchQueue.splice(BATCH_SIZE);
+              for (const d of dropped) d.resolve(null);
+              console.warn(`[Classify] Dropped ${dropped.length} queued items after repeated 429s`);
             }
             batchInFlight = false;
             setTimeout(() => { batchPaused = false; scheduleBatch(); }, delay);


### PR DESCRIPTION
## Summary
- **Root cause**: `getClientIp()` checked `x-real-ip` first, but with Cloudflare proxy → Vercel, that header contains the CF edge server IP (shared across all users behind the same edge node), not the real client IP. All users shared one rate-limit bucket → 429 storms on classify-event.
- **Fix**: Prioritize `cf-connecting-ip` (set by Cloudflare with the actual client IP) over `x-real-ip`
- **Client resilience**: Added exponential backoff on repeated 429s (60s → 120s → 240s → 5min cap) and queue trimming to prevent hammering

## Test plan
- [ ] Deploy and monitor classify-event 429 rate in logs/Sentry
- [ ] Verify rate-limit headers show per-user limits (not shared bucket)
- [ ] Confirm client console no longer shows repeated 429 pauses