### PR TITLE
fix: restore ultrawide panels when the map starts hidden

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -429,6 +429,7 @@ export class PanelLayoutManager implements AppModule {
           if (mainContent) {
             mainContent.classList.toggle('map-hidden', !config.enabled);
           }
+          this.ensureCorrectZones();
         }
         return;
       }


### PR DESCRIPTION
## Summary
- reconcile panel zones after applying the saved map visibility state
- move bottom-zone panels back into the main grid when the map is hidden on ultrawide layouts

Fixes #1218

## Validation
- `git diff --check`
- `npm run typecheck` *(not available in this worktree: local `tsc` dependency is missing on host, so CI should perform the full TypeScript validation)*