### PR TITLE
fix: keep Settings visible on scaled desktop widths

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -727,6 +727,14 @@ canvas,
   color: var(--text);
 }
 
+/* Medium-width desktop: keep header utility actions reachable when OS scaling
+   reduces the effective viewport width (e.g. 1920px @ 150% = ~1280px CSS). */
+@media (max-width: 1360px) {
+  .credit-link {
+    display: none;
+  }
+}
+
 .search-btn {
   padding: 4px 10px;
   background: transparent;


### PR DESCRIPTION
## Summary
- hide the low-priority X credit link at medium desktop widths
- preserve access to the header action cluster, including the Settings gear
- document the Windows display-scaling case that collapses a 1920px screen to ~1280 CSS px

## Validation
- reproduced the header overflow in Chrome at 1280px-equivalent width before the fix
- `git diff --check`

Fixes #906.