### PR TITLE
fix(scripts): sync package-lock.json with h3-js

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -8,6 +8,7 @@
       "name": "worldmonitor-railway-relay",
       "version": "1.1.0",
       "dependencies": {
+        "h3-js": "^4.2.1",
         "telegram": "^2.22.2",
         "ws": "^8.18.0"
       },
@@ -261,6 +262,17 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/h3-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-4.4.0.tgz",
+      "integrity": "sha512-DvJh07MhGgY2KcC4OeZc8SSyA+ZXpdvoh6uCzGpoKvWtZxJB+g6VXXC1+eWYkaMIsLz7J/ErhOalHCpcs1KYog==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=3",
+        "yarn": ">=1.3.0"
+      }
     },
     "node_modules/htmlparser2": {
       "version": "6.1.0",


### PR DESCRIPTION
## Summary
- Add h3-js to scripts/package-lock.json (1 file, 12 lines)

Railway `npm ci` needs lock file in sync with package.json.