### PR TITLE
fix(health): aviation seed interval 2h→1h, maxStaleMin 30→90

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -69,7 +69,7 @@ const SEED_META = {
   gulfQuotes:       { key: 'seed-meta:market:gulf-quotes',      maxStaleMin: 30 },
   stablecoinMarkets:{ key: 'seed-meta:market:stablecoins',      maxStaleMin: 60 },
   naturalEvents:    { key: 'seed-meta:natural:events',          maxStaleMin: 120 },
-  flightDelays:     { key: 'seed-meta:aviation:faa',            maxStaleMin: 30 },
+  flightDelays:     { key: 'seed-meta:aviation:faa',            maxStaleMin: 90 },
   predictions:      { key: 'seed-meta:prediction:markets',      maxStaleMin: 15 },
   insights:         { key: 'seed-meta:news:insights',           maxStaleMin: 30 },
   marketQuotes:     { key: 'seed-meta:market:stocks',         maxStaleMin: 30 },

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1444,7 +1444,7 @@ async function startMarketDataSeedLoop() {
 // so Vercel handler serves from cache (avoids 114 API calls per miss)
 // ─────────────────────────────────────────────────────────────
 const AVIATIONSTACK_API_KEY = process.env.AVIATIONSTACK_API || '';
-const AVIATION_SEED_INTERVAL_MS = 2 * 60 * 60 * 1000; // 2h
+const AVIATION_SEED_INTERVAL_MS = 1 * 60 * 60 * 1000; // 1h
 const AVIATION_SEED_TTL = 14400; // 4h — survives 1 missed cycle
 const AVIATION_REDIS_KEY = 'aviation:delays:intl:v3';
 const AVIATION_BATCH_CONCURRENCY = 10;


### PR DESCRIPTION
## Summary
- Aviation seed loop: 2h → 1h interval
- Health maxStaleMin: 30 → 90min (1h + 30min restart buffer)

## Files
- `scripts/ais-relay.cjs` — interval change
- `api/health.js` — threshold change