### PR TITLE
fix: only show layer warning when adding layers

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -4636,6 +4636,7 @@ export class DeckGLMap {
   }
 
   private layerWarningShown = false;
+  private lastActiveLayerCount = 0;
 
   private enforceLayerLimit(): void {
     const WARN_THRESHOLD = 10;
@@ -4644,7 +4645,9 @@ export class DeckGLMap {
     const activeCount = Array.from(togglesEl.querySelectorAll<HTMLInputElement>('.layer-toggle input'))
       .filter(i => (i.closest('.layer-toggle') as HTMLElement)?.style.display !== 'none')
       .filter(i => i.checked).length;
-    if (activeCount >= WARN_THRESHOLD && !this.layerWarningShown) {
+    const increasing = activeCount > this.lastActiveLayerCount;
+    this.lastActiveLayerCount = activeCount;
+    if (activeCount >= WARN_THRESHOLD && increasing && !this.layerWarningShown) {
       this.layerWarningShown = true;
       showLayerWarning(WARN_THRESHOLD);
     } else if (activeCount < WARN_THRESHOLD) {

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -1568,13 +1568,16 @@ export class GlobeMap {
   }
 
   private layerWarningShown = false;
+  private lastActiveLayerCount = 0;
 
   private enforceLayerLimit(): void {
     if (!this.layerTogglesEl) return;
     const WARN_THRESHOLD = 6;
     const activeCount = Array.from(this.layerTogglesEl.querySelectorAll<HTMLInputElement>('.layer-toggle input'))
       .filter(i => i.checked).length;
-    if (activeCount >= WARN_THRESHOLD && !this.layerWarningShown) {
+    const increasing = activeCount > this.lastActiveLayerCount;
+    this.lastActiveLayerCount = activeCount;
+    if (activeCount >= WARN_THRESHOLD && increasing && !this.layerWarningShown) {
       this.layerWarningShown = true;
       showLayerWarning(WARN_THRESHOLD);
     } else if (activeCount < WARN_THRESHOLD) {


### PR DESCRIPTION
## Summary
- Track `lastActiveLayerCount` in both `DeckGLMap` and `GlobeMap`
- `enforceLayerLimit()` now only shows the performance warning when the user is **adding** layers past the threshold, not when **removing** them
- Fixes the issue where disabling a layer with many active still triggered the warning dialog

## Test plan
- [ ] Enable 10+ layers on flat map → warning appears
- [ ] Disable a layer while 10+ are active → no warning
- [ ] Re-enable to cross threshold again after dismissal reset → warning reappears
- [ ] Same flow on globe view with 6-layer threshold