### PR TITLE
feat(search): add optional 'See all commands' link in Cmd+K modal

### DIFF
--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -94,6 +94,8 @@ export class SearchModal {
   private placeholder: string;
   private activePanelIds: Set<string> = new Set();
   private isMobile: boolean;
+  /** When true, results area shows the full command list (opt-in). Sourced from getAllCommands(); no separate list to maintain. */
+  private showingAllCommands = false;
 
   constructor(container: HTMLElement, options?: SearchModalOptions) {
     this.container = container;
@@ -134,6 +136,7 @@ export class SearchModal {
     this.isMobile = isMobileDevice();
     this.createModal();
     this.input?.focus();
+    this.showingAllCommands = false;
     this.showRecentOrEmpty();
     if (this.isMobile) this.renderChips();
   }
@@ -270,6 +273,7 @@ export class SearchModal {
     const query = this.input?.value.trim().toLowerCase() || '';
 
     if (!query) {
+      this.showingAllCommands = false;
       this.commandResults = [];
       this.showRecentOrEmpty();
       if (this.isMobile) this.renderChips();
@@ -329,6 +333,11 @@ export class SearchModal {
   private showRecentOrEmpty(): void {
     this.results = [];
 
+    if (this.showingAllCommands) {
+      this.renderAllCommandsList();
+      return;
+    }
+
     if (this.recentSearches.length > 0) {
       this.renderRecent();
     } else {
@@ -364,6 +373,8 @@ export class SearchModal {
 
       this.resultsList?.appendChild(item);
     });
+
+    this.appendSeeAllCommandsLink();
   }
 
   private renderEmpty(): void {
@@ -401,6 +412,91 @@ export class SearchModal {
         if (this.input) {
           this.input.value = example;
           this.handleSearch();
+        }
+      });
+    });
+
+    this.appendSeeAllCommandsLink();
+  }
+
+  private appendSeeAllCommandsLink(): void {
+    if (!this.resultsList) return;
+    const link = document.createElement('a');
+    link.href = '#';
+    link.className = 'search-all-commands-link';
+    link.textContent = t('modals.search.seeAllCommands');
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      this.showingAllCommands = true;
+      this.renderAllCommandsList();
+    });
+    const wrap = document.createElement('div');
+    wrap.className = 'search-all-commands-wrap';
+    wrap.appendChild(link);
+    this.resultsList.appendChild(wrap);
+  }
+
+  /** Renders the full command list by category. Commands are sourced from getAllCommands(); no separate list to maintain. */
+  private renderAllCommandsList(): void {
+    if (!this.resultsList) return;
+
+    const allCommands = getAllCommands();
+    const commands = allCommands.filter(cmd => {
+      if (cmd.id.startsWith('panel:') && this.activePanelIds.size > 0) {
+        const panelId = cmd.id.slice(6);
+        if (!this.activePanelIds.has(panelId)) return false;
+      }
+      return true;
+    });
+
+    const categoryOrder: Command['category'][] = ['navigate', 'layers', 'panels', 'view', 'actions', 'country'];
+    const byCategory = new Map<Command['category'], Command[]>();
+    for (const cat of categoryOrder) byCategory.set(cat, []);
+    for (const cmd of commands) {
+      const list = byCategory.get(cmd.category);
+      if (list) list.push(cmd);
+    }
+
+    let html = `
+      <div class="search-section-header search-command-list-back">
+        <a href="#" class="search-all-commands-back">${escapeHtml(t('modals.search.hideCommandList'))}</a>
+      </div>`;
+
+    for (const category of categoryOrder) {
+      const list = byCategory.get(category) || [];
+      if (list.length === 0) continue;
+      const label = resolveCategoryLabel(list[0]);
+      html += `<details class="search-command-category" open>`;
+      html += `<summary class="search-command-category-summary">${escapeHtml(label)}</summary>`;
+      html += `<div class="search-command-category-list">`;
+      for (const cmd of list) {
+        html += `
+          <div class="search-result-item command-item" data-command="${escapeHtml(cmd.id)}">
+            <span class="search-result-icon">${escapeHtml(cmd.icon)}</span>
+            <div class="search-result-content">
+              <div class="search-result-title">${escapeHtml(resolveCommandLabel(cmd))}</div>
+            </div>
+          </div>`;
+      }
+      html += `</div></details>`;
+    }
+
+    this.resultsList.innerHTML = html;
+
+    const backLink = this.resultsList.querySelector('.search-all-commands-back');
+    backLink?.addEventListener('click', (e) => {
+      e.preventDefault();
+      this.showingAllCommands = false;
+      this.showRecentOrEmpty();
+    });
+
+    this.resultsList.querySelectorAll('.search-command-category .command-item').forEach((el) => {
+      el.addEventListener('click', () => {
+        const id = (el as HTMLElement).dataset.command;
+        const command = getAllCommands().find(c => c.id === id);
+        if (command) {
+          this.onCommand?.(command);
+          this.close();
         }
       });
     });

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -377,6 +377,8 @@
       "noResults": "لا توجد نتائج",
       "commands": "أوامر",
       "results": "نتائج",
+      "seeAllCommands": "عرض جميع الأوامر",
+      "hideCommandList": "رجوع",
       "navigate": "تنقّل",
       "select": "اختيار",
       "close": "إغلاق",

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -377,6 +377,8 @@
       "noResults": "Няма резултати",
       "commands": "Команди",
       "results": "Резултати",
+      "seeAllCommands": "Виж всички команди",
+      "hideCommandList": "Назад",
       "navigate": "навигиране",
       "select": "избор",
       "close": "затвори",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -401,7 +401,9 @@
         "accelerator": "Akcelerátor"
       },
       "commands": "Příkazy",
-      "results": "Výsledky"
+      "results": "Výsledky",
+      "seeAllCommands": "Zobrazit všechny příkazy",
+      "hideCommandList": "Zpět"
     },
     "signal": {
       "title": "ZPRAVODAJSKÉ ZJIŠTĚNÍ",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -401,7 +401,9 @@
       "placeholderFinance": "Suchen oder Befehl eingeben...",
       "hintFinance": "Suche • Börsen • Märkte • Ebenen • Navigation • Einstellungen",
       "commands": "Befehle",
-      "results": "Ergebnisse"
+      "results": "Ergebnisse",
+      "seeAllCommands": "Alle Befehle anzeigen",
+      "hideCommandList": "Zurück"
     },
     "signal": {
       "title": "INTELLIGENZFINDEN",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -377,6 +377,8 @@
       "noResults": "Κανένα αποτέλεσμα",
       "commands": "Εντολές",
       "results": "Αποτελέσματα",
+      "seeAllCommands": "Εμφάνιση όλων των εντολών",
+      "hideCommandList": "Πίσω",
       "navigate": "πλοήγηση",
       "select": "επιλογή",
       "close": "κλείσιμο",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -379,6 +379,8 @@
       "noResults": "No results",
       "commands": "Commands",
       "results": "Results",
+      "seeAllCommands": "See all commands",
+      "hideCommandList": "Back",
       "navigate": "navigate",
       "select": "select",
       "close": "close",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -401,7 +401,9 @@
       "placeholderFinance": "Buscar o escribir un comando...",
       "hintFinance": "Búsqueda • Bolsas • Mercados • Capas • Navegación • Ajustes",
       "commands": "Comandos",
-      "results": "Resultados"
+      "results": "Resultados",
+      "seeAllCommands": "Ver todos los comandos",
+      "hideCommandList": "Volver"
     },
     "signal": {
       "title": "ENCUENTRO DE INTELIGENCIA",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -401,7 +401,9 @@
       "placeholderFinance": "Rechercher ou saisir une commande...",
       "hintFinance": "Recherche • Bourses • Marchés • Couches • Navigation • Paramètres",
       "commands": "Commandes",
-      "results": "Résultats"
+      "results": "Résultats",
+      "seeAllCommands": "Voir toutes les commandes",
+      "hideCommandList": "Retour"
     },
     "signal": {
       "title": "DÉCOUVERTE RENSEIGNEMENT",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -401,7 +401,9 @@
       "placeholderFinance": "Cerca o digita un comando...",
       "hintFinance": "Ricerca • Borse • Mercati • Livelli • Navigazione • Impostazioni",
       "commands": "Comandi",
-      "results": "Risultati"
+      "results": "Risultati",
+      "seeAllCommands": "Vedi tutti i comandi",
+      "hideCommandList": "Indietro"
     },
     "signal": {
       "title": "RICERCA DI INTELLIGENZA",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -377,6 +377,8 @@
       "noResults": "結果なし",
       "commands": "コマンド",
       "results": "結果",
+      "seeAllCommands": "コマンド一覧を見る",
+      "hideCommandList": "戻る",
       "navigate": "移動",
       "select": "選択",
       "close": "閉じる",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -377,6 +377,8 @@
       "noResults": "결과 없음",
       "commands": "명령어",
       "results": "결과",
+      "seeAllCommands": "모든 명령 보기",
+      "hideCommandList": "뒤로",
       "navigate": "탐색",
       "select": "선택",
       "close": "닫기",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -205,7 +205,9 @@
       "placeholderFinance": "Zoeken of commando typen...",
       "hintFinance": "Zoeken • Beurzen • Markten • Lagen • Navigatie • Instellingen",
       "commands": "Opdrachten",
-      "results": "Resultaten"
+      "results": "Resultaten",
+      "seeAllCommands": "Alle opdrachten tonen",
+      "hideCommandList": "Terug"
     },
     "signal": {
       "source": "Source",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -401,7 +401,9 @@
       "placeholderFinance": "Szukaj lub wpisz polecenie...",
       "hintFinance": "Szukaj • Giełdy • Rynki • Warstwy • Nawigacja • Ustawienia",
       "commands": "Polecenia",
-      "results": "Wyniki"
+      "results": "Wyniki",
+      "seeAllCommands": "Pokaż wszystkie polecenia",
+      "hideCommandList": "Wstecz"
     },
     "signal": {
       "title": "WYKONANIE INTELIGENCJI",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -205,7 +205,9 @@
       "placeholderFinance": "Pesquisar ou digitar um comando...",
       "hintFinance": "Pesquisa • Bolsas • Mercados • Camadas • Navegação • Configurações",
       "commands": "Comandos",
-      "results": "Resultados"
+      "results": "Resultados",
+      "seeAllCommands": "Ver todos os comandos",
+      "hideCommandList": "Voltar"
     },
     "signal": {
       "source": "Source",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -377,6 +377,8 @@
       "noResults": "Niciun rezultat",
       "commands": "Comenzi",
       "results": "Rezultate",
+      "seeAllCommands": "Vezi toate comenzile",
+      "hideCommandList": "Înapoi",
       "navigate": "navigați",
       "select": "selectați",
       "close": "închide",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -377,6 +377,8 @@
       "noResults": "Ничего не найдено",
       "commands": "Команды",
       "results": "Результаты",
+      "seeAllCommands": "Показать все команды",
+      "hideCommandList": "Назад",
       "navigate": "навигация",
       "select": "выбрать",
       "close": "закрыть",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -205,7 +205,9 @@
       "placeholderFinance": "Sök eller skriv ett kommando...",
       "hintFinance": "Sök • Börser • Marknader • Lager • Navigering • Inställningar",
       "commands": "Kommandon",
-      "results": "Resultat"
+      "results": "Resultat",
+      "seeAllCommands": "Visa alla kommandon",
+      "hideCommandList": "Tillbaka"
     },
     "signal": {
       "source": "Source",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -377,6 +377,8 @@
       "noResults": "ไม่พบผลลัพธ์",
       "commands": "คำสั่ง",
       "results": "ผลลัพธ์",
+      "seeAllCommands": "ดูคำสั่งทั้งหมด",
+      "hideCommandList": "กลับ",
       "navigate": "นำทาง",
       "select": "เลือก",
       "close": "ปิด",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -377,6 +377,8 @@
       "noResults": "Sonuc bulunamadi",
       "commands": "Komutlar",
       "results": "Sonuçlar",
+      "seeAllCommands": "Tüm komutları gör",
+      "hideCommandList": "Geri",
       "navigate": "gezin",
       "select": "sec",
       "close": "kapat",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -377,6 +377,8 @@
       "noResults": "Không có kết quả",
       "commands": "Lệnh",
       "results": "Kết quả",
+      "seeAllCommands": "Xem tất cả lệnh",
+      "hideCommandList": "Quay lại",
       "navigate": "điều hướng",
       "select": "chọn",
       "close": "đóng",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -377,6 +377,8 @@
       "noResults": "无结果",
       "commands": "命令",
       "results": "结果",
+      "seeAllCommands": "查看所有命令",
+      "hideCommandList": "返回",
       "navigate": "导航",
       "select": "选择",
       "close": "关闭",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -8451,6 +8451,70 @@ a.prediction-link:hover {
   margin: 0 2px;
 }
 
+.search-all-commands-wrap {
+  padding: 8px 16px 12px;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.search-all-commands-link {
+  font-size: 11px;
+  color: var(--text-dim);
+  text-decoration: none;
+}
+
+.search-all-commands-link:hover {
+  color: var(--green);
+  text-decoration: underline;
+}
+
+.search-command-list-back {
+  padding: 8px 16px;
+}
+
+.search-all-commands-back {
+  font-size: 11px;
+  color: var(--text-dim);
+  text-decoration: none;
+}
+
+.search-all-commands-back:hover {
+  color: var(--green);
+  text-decoration: underline;
+}
+
+.search-command-category {
+  border-bottom: 1px solid var(--border);
+}
+
+.search-command-category:last-child {
+  border-bottom: none;
+}
+
+.search-command-category-summary {
+  padding: 8px 16px;
+  font-size: 10px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  background: var(--bg);
+  cursor: pointer;
+  list-style: none;
+}
+
+.search-command-category-summary::-webkit-details-marker {
+  display: none;
+}
+
+.search-command-category-list {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.search-command-category-list .command-item {
+  border-left: none;
+}
+
 .search-footer {
   display: flex;
   gap: 16px;


### PR DESCRIPTION
Adds an optional "See all commands" link in the Cmd+K search modal so users can open a full, category-grouped command list without changing the default experience.

**Behaviour**
- When the search box is empty (tips or recent searches shown), a "See all commands" link appears at the bottom.
- Clicking it shows a scrollable list grouped by category (Navigate, Layers, Panels, View, Actions, Country) with collapsible sections. Clicking a command runs it and closes the modal.
- A "Back" link returns to the tips/recent view. Typing in the search box also returns to normal search; the full list is opt-in only.

**Implementation**
- **SearchModal.ts**: New state `showingAllCommands` and `renderAllCommandsList()` that builds the list from existing `getAllCommands()` (no separate command list to maintain). Panel commands are filtered by `activePanelIds` as in the existing search.
- **Locales**: New keys `modals.search.seeAllCommands` and `modals.search.hideCommandList` in all 21 locale files.
- **CSS**: Styles for the link, back button, and category sections (details/summary).

Default UX is unchanged; only users who click "See all commands" see the full list. Ref: #1247, Discussion #719.
