### PR TITLE
fix: remove smartraveller.gov.au from RSS allowed domains

### DIFF
--- a/api/_rss-allowed-domains.js
+++ b/api/_rss-allowed-domains.js
@@ -221,8 +221,6 @@ export default [
   "www.coindesk.com",
   "cointelegraph.com",
   "travel.state.gov",
-  "smartraveller.gov.au",
-  "www.smartraveller.gov.au",
   "www.safetravel.govt.nz",
   "th.usembassy.gov",
   "ae.usembassy.gov",

--- a/scripts/shared/rss-allowed-domains.json
+++ b/scripts/shared/rss-allowed-domains.json
@@ -218,8 +218,6 @@
   "www.coindesk.com",
   "cointelegraph.com",
   "travel.state.gov",
-  "smartraveller.gov.au",
-  "www.smartraveller.gov.au",
   "www.safetravel.govt.nz",
   "th.usembassy.gov",
   "ae.usembassy.gov",

--- a/shared/rss-allowed-domains.json
+++ b/shared/rss-allowed-domains.json
@@ -218,8 +218,6 @@
   "www.coindesk.com",
   "cointelegraph.com",
   "travel.state.gov",
-  "smartraveller.gov.au",
-  "www.smartraveller.gov.au",
   "www.safetravel.govt.nz",
   "th.usembassy.gov",
   "ae.usembassy.gov",


### PR DESCRIPTION
## Summary
- Remove `smartraveller.gov.au` and `www.smartraveller.gov.au` from all three RSS allowed-domains files
- Domain causes persistent relay timeouts (`[Relay] RSS timeout for https://www.smartraveller.gov.au/*`)

## Changed files
- `shared/rss-allowed-domains.json`
- `scripts/shared/rss-allowed-domains.json`
- `api/_rss-allowed-domains.js`

## Test plan
- [x] Pre-push checks pass (typecheck, edge functions, shared sync, markdown lint)
- [ ] Verify relay logs no longer show smartraveller timeout entries after deploy