### PR TITLE
fix(relay): add Wingbits fallback for military flights seed

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2637,6 +2637,67 @@ const MIL_QUERY_REGIONS = [
   { name: 'WESTERN', lamin: 13, lamax: 85, lomin: -10, lomax: 57 },
 ];
 
+async function fetchMilitaryFlightsFromWingbits() {
+  const apiKey = process.env.WINGBITS_API_KEY;
+  if (!apiKey) return [];
+  const areas = MIL_QUERY_REGIONS.map((r) => ({
+    alias: r.name,
+    by: 'box',
+    la: (r.lamax + r.lamin) / 2,
+    lo: (r.lomax + r.lomin) / 2,
+    w: Math.abs(r.lomax - r.lomin) * 60,
+    h: Math.abs(r.lamax - r.lamin) * 60,
+    unit: 'nm',
+  }));
+  try {
+    const resp = await fetch('https://customer-api.wingbits.com/v1/flights', {
+      method: 'POST',
+      headers: { 'x-api-key': apiKey, Accept: 'application/json', 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
+      body: JSON.stringify(areas),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!resp.ok) {
+      console.warn(`[MilitaryFlights] Wingbits ${resp.status}`);
+      return [];
+    }
+    const data = await resp.json();
+    const seenIds = new Set();
+    const states = [];
+    for (const areaResult of data) {
+      const flightList = Array.isArray(areaResult.flights || areaResult) ? (areaResult.flights || areaResult) : [];
+      for (const f of flightList) {
+        const icao24 = f.h || f.icao24 || f.id;
+        if (!icao24 || seenIds.has(icao24)) continue;
+        seenIds.add(icao24);
+        const callsign = (f.f || f.callsign || f.flight || '').trim();
+        // Convert Wingbits to OpenSky state array format for unified processing
+        states.push([
+          icao24,                                    // [0] icao24
+          callsign,                                  // [1] callsign
+          f.co || f.originCountry || '',             // [2] origin country
+          null,                                      // [3] time_position
+          f.ts ? f.ts / 1000 : Date.now() / 1000,   // [4] last_contact (seconds)
+          f.lo || f.longitude || f.lon || f.lng,     // [5] longitude
+          f.la || f.latitude || f.lat,               // [6] latitude
+          (f.ab || f.altitude || f.alt || 0) * 0.3048, // [7] baro_altitude (Wingbits ft → meters for unified conversion)
+          f.gr || f.onGround || false,               // [8] on_ground
+          (f.gs || f.groundSpeed || f.speed || 0) * 0.514444, // [9] velocity (Wingbits kts → m/s)
+          f.th || f.heading || f.track || 0,         // [10] true_track
+          (f.vr || f.verticalRate || 0) * 0.00508,   // [11] vertical_rate (Wingbits ft/min → m/s)
+          null,                                      // [12] sensors
+          null,                                      // [13] geo_altitude
+          f.sq || f.squawk || null,                  // [14] squawk
+        ]);
+      }
+    }
+    console.log(`[MilitaryFlights] Wingbits returned ${states.length} aircraft`);
+    return states;
+  } catch (e) {
+    console.warn(`[MilitaryFlights] Wingbits failed: ${e?.message || e}`);
+    return [];
+  }
+}
+
 async function seedMilitaryFlights() {
   if (milFlightsSeedRunning) {
     console.log('[MilitaryFlights] Skipping — previous seed still running');
@@ -2687,6 +2748,22 @@ async function seedMilitaryFlights() {
         if (seenIds.has(icao24)) continue;
         seenIds.add(icao24);
         allStates.push(state);
+      }
+    }
+
+    // Wingbits fallback — always try to supplement (merges with OpenSky, dedupes by icao24)
+    if (allStates.length === 0 || process.env.WINGBITS_API_KEY) {
+      try {
+        const wbStates = await fetchMilitaryFlightsFromWingbits();
+        for (const state of wbStates) {
+          const icao24 = state[0];
+          if (seenIds.has(icao24)) continue;
+          seenIds.add(icao24);
+          allStates.push(state);
+        }
+        if (wbStates.length > 0) console.log(`[MilitaryFlights] Merged ${wbStates.length} Wingbits states (total: ${allStates.length})`);
+      } catch (e) {
+        console.warn(`[MilitaryFlights] Wingbits merge error: ${e?.message || e}`);
       }
     }
 


### PR DESCRIPTION
## Summary
- Adds Wingbits as fallback + supplement source for military flights seed
- When OpenSky is blocked (proxy auth timeout + anonymous rate limit), Wingbits provides data
- When both available, Wingbits supplements OpenSky with additional aircraft (deduped by icao24)
- Wingbits data converted to OpenSky state array format for unified processing through existing military detection pipeline

## Data flow
```
seedMilitaryFlights():
  1. OpenSky proxy (auth) → fallback to OpenSky anonymous
  2. Wingbits API (always if WINGBITS_API_KEY set, supplements + fallback)
  3. Merge + dedupe by icao24
  4. Military detection pipeline (hex ranges + callsign patterns)
  5. Redis write
```

## Test plan
- [x] Syntax check passes
- [x] Pre-push hooks pass
- [ ] Deploy to Railway → verify logs show Wingbits merge
- [ ] Verify `api/military-flights` returns flight data