### PR TITLE
feat: orbital surveillance — real-time satellite tracking layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ All five variants run from a single codebase — switch between them with one cl
 </details>
 
 <details>
-<summary><strong>Military & Strategic</strong> — 210+ bases, live flights (ADS-B), naval vessels (AIS), nuclear facilities, spaceports</summary>
+<summary><strong>Military & Strategic</strong> — 210+ bases, live flights (ADS-B), naval vessels (AIS), nuclear facilities, spaceports, orbital surveillance</summary>
 
-[Full details →](./docs/DATA_SOURCES.md#data-layers)
+[Full details →](./docs/DATA_SOURCES.md#data-layers) · [Orbital Surveillance →](./docs/ORBITAL_SURVEILLANCE.md)
 </details>
 
 <details>

--- a/api/health.js
+++ b/api/health.js
@@ -57,6 +57,7 @@ const STANDALONE_KEYS = {
   militaryFlightsStale:  'military:flights:stale:v1',
   temporalAnomalies:     'temporal:anomalies:v1',
   displacement:          `displacement:summary:v1:${new Date().getFullYear()}`,
+  satellites:            'intelligence:satellites:tle:v1',
 };
 
 const SEED_META = {
@@ -93,6 +94,7 @@ const SEED_META = {
   iranEvents:       { key: 'seed-meta:conflict:iran-events',      maxStaleMin: 10080 },
   ucdpEvents:       { key: 'seed-meta:conflict:ucdp-events',      maxStaleMin: 420 },
   militaryFlights:  { key: 'seed-meta:military:flights',           maxStaleMin: 15 },
+  satellites:       { key: 'seed-meta:intelligence:satellites',    maxStaleMin: 180 },
   weatherAlerts:    { key: 'seed-meta:weather:alerts',             maxStaleMin: 30 },
   spending:         { key: 'seed-meta:economic:spending',          maxStaleMin: 120 },
   sectors:          { key: 'seed-meta:market:sectors',             maxStaleMin: 30 },
@@ -152,7 +154,7 @@ function dataSize(parsed) {
                       'papers', 'repos', 'articles', 'signals', 'rates', 'countries',
                       'chokepoints', 'minerals', 'anomalies', 'flows', 'bases', 'flights',
                       'theaters', 'fleets', 'warnings', 'closures', 'cables',
-                      'airports', 'categories', 'regions', 'entries']) {
+                      'airports', 'categories', 'regions', 'entries', 'satellites']) {
       if (Array.isArray(parsed[k])) return parsed[k].length;
     }
     return Object.keys(parsed).length;

--- a/api/satellites.js
+++ b/api/satellites.js
@@ -1,0 +1,69 @@
+import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const REDIS_KEY = 'intelligence:satellites:tle:v1';
+
+let cached = null;
+let cachedAt = 0;
+const CACHE_TTL = 600_000;
+
+let negUntil = 0;
+const NEG_TTL = 60_000;
+
+async function readFromRedis(key) {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(3_000),
+  });
+  if (!resp.ok) return null;
+  const data = await resp.json();
+  if (!data.result) return null;
+  try { return JSON.parse(data.result); } catch { return null; }
+}
+
+async function fetchSatelliteData() {
+  const now = Date.now();
+  if (cached && now - cachedAt < CACHE_TTL) return cached;
+  if (now < negUntil) return null;
+  let data;
+  try { data = await readFromRedis(REDIS_KEY); } catch { data = null; }
+  if (!data) {
+    negUntil = now + NEG_TTL;
+    return null;
+  }
+  cached = data;
+  cachedAt = now;
+  return data;
+}
+
+export default async function handler(req) {
+  const corsHeaders = getCorsHeaders(req, 'GET, OPTIONS');
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  if (isDisallowedOrigin(req)) {
+    return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+  }
+  const data = await fetchSatelliteData();
+  if (!data) {
+    return new Response(JSON.stringify({ error: 'Satellite data temporarily unavailable' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache, no-store', ...corsHeaders },
+    });
+  }
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 's-maxage=3600, stale-while-revalidate=1800, stale-if-error=3600',
+      ...corsHeaders,
+    },
+  });
+}

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -33,6 +33,7 @@ Comprehensive documentation of all data sources, feed tiers, and collection meth
 - Nuclear facilities & gamma irradiators
 - APT cyber threat actor attribution
 - Spaceports & launch facilities
+- **Orbital surveillance** — ~80–120 intelligence-relevant satellites tracked in real time via CelesTrak TLE data and client-side SGP4 propagation (satellite.js). Country-coded markers at orbital altitude, 15-min orbit trails, ground footprints. Globe-only. [Details →](./ORBITAL_SURVEILLANCE.md)
 
 </details>
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -16,6 +16,7 @@ AI-powered real-time global intelligence dashboard aggregating news, markets, ge
 | [AI Intelligence](./AI_INTELLIGENCE.md) | LLM chains, RAG, threat classification, deduction |
 | [Desktop App](./DESKTOP_APP.md) | Tauri architecture, sidecar, secret management |
 | [Finance Data](./FINANCE_DATA.md) | Market radar, Gulf FDI, stablecoins, BIS, WTO |
+| [Orbital Surveillance](./ORBITAL_SURVEILLANCE.md) | Satellite tracking, SGP4 propagation, tier availability, roadmap |
 | [API Reference](./api/) | OpenAPI specs for all 22 services |
 | [Adding Endpoints](./ADDING_ENDPOINTS.md) | Guide for adding new RPC endpoints |
 | [Release Packaging](./RELEASE_PACKAGING.md) | Desktop build and release process |

--- a/docs/ORBITAL_SURVEILLANCE.md
+++ b/docs/ORBITAL_SURVEILLANCE.md
@@ -1,0 +1,186 @@
+# Orbital Surveillance
+
+Real-time satellite orbital tracking on the 3D globe, powered by SGP4 propagation from CelesTrak TLE data.
+
+---
+
+## Overview
+
+The Orbital Surveillance layer tracks ~80–120 intelligence-relevant satellites in real time. Satellites are rendered at their actual orbital altitude on the globe with country-coded colors, orbit trails, and ground footprint projections.
+
+**Globe-only** — orbital mechanics don't translate meaningfully to a flat map projection.
+
+### What It Shows
+
+| Element | Description |
+|---------|-------------|
+| **Satellite marker** | 4px glowing dot at actual orbital altitude (LEO ~400km, SSO ~600–900km) |
+| **Country color** | CN = red, RU = orange, US = blue, EU = green, KR = purple, OTHER = grey |
+| **Orbit trail** | 15-minute historical trace rendered as a dashed path at orbital altitude |
+| **Ground footprint** | Translucent circle projected on the surface below each satellite (nadir point) |
+| **Tooltip** | Name, country, sensor type (SAR Imaging / Optical Imaging / Military / SIGINT), altitude |
+
+---
+
+## Architecture
+
+### Data Flow
+
+```
+CelesTrak (free) ──2h──▶ Railway relay ──Redis──▶ Vercel edge ──CDN 1h──▶ Browser
+                         (TLE parse,              (read-only,              (SGP4 propagation
+                          filter,                  10min cache)             every 3 seconds)
+                          classify)
+```
+
+### Cost Model
+
+| Component | Cost | Notes |
+|-----------|------|-------|
+| CelesTrak API | Free | Public NORAD TLE data, 2h update cycle |
+| Railway relay | ~$0 | Seed loop runs inside existing `ais-relay.cjs` process |
+| Redis (Upstash) | Negligible | Single key, 4h TTL, ~50KB payload |
+| Vercel edge | ~$0 | CDN caches 1h (`s-maxage=3600`), stale-while-revalidate 30min |
+| Browser CPU | Client-side | SGP4 math runs locally every 3s — zero server cost for real-time movement |
+
+**Key insight**: TLE data changes slowly (every 2h), but satellite positions change every second. By shipping TLEs to the browser and doing SGP4 propagation client-side, we get real-time movement with zero ongoing server cost.
+
+---
+
+## Satellite Selection
+
+Two CelesTrak groups are fetched: `military` (~21 sats) and `resource` (~164 sats). After deduplication and name-pattern filtering, ~80–120 intelligence-relevant satellites remain.
+
+### Filter Patterns
+
+| Category | Patterns | Type Classification |
+|----------|----------|---------------------|
+| **Chinese recon** | YAOGAN, GAOFEN, JILIN | SAR (YAOGAN), Optical |
+| **Russian recon** | COSMOS 24xx/25xx | Military |
+| **Commercial SAR** | COSMO-SKYMED, TERRASAR, PAZ, SAR-LUPE, ICEYE | SAR |
+| **Commercial optical** | WORLDVIEW, SKYSAT, PLEIADES, KOMPSAT | Optical |
+| **Military** | SAPPHIRE, PRAETORIAN | Military |
+| **EU/civil** | SENTINEL | SAR (Sentinel-1), Optical (Sentinel-2) |
+
+### Country Classification
+
+Satellites are classified by operator country: CN, RU, US, EU, IN, KR, JP, IL, or OTHER. Classification is name-based (e.g., YAOGAN → CN, COSMOS → RU, WORLDVIEW → US).
+
+> **Note**: US KH-11 spy satellites (USA-224/245/290/314/338) are classified — no public TLEs exist. The tracked satellites are those with publicly available orbital elements.
+
+---
+
+## Technical Details
+
+### SGP4 Propagation
+
+The browser uses [`satellite.js`](https://github.com/shashwatak/satellite-js) (v6) for SGP4/SDP4 orbital propagation:
+
+1. **`initSatRecs()`** — Parse TLEs into `SatRec` objects once (expensive, cached until TLEs refresh)
+2. **`propagatePositions()`** — For each satellite: `propagate()` → `eciToGeodetic()` → lat/lng/alt. Also computes 15-point trail (1 per minute, looking back 15 minutes)
+3. **`startPropagationLoop()`** — Runs every 3 seconds via `setInterval`. LEO satellites move ~23km in 3 seconds, producing visible motion on the globe
+
+### Globe Rendering
+
+| Property | Value |
+|----------|-------|
+| `htmlAltitude` | `altitude_km / 6371` (Earth radius = 6371km, globe.gl uses normalized units) |
+| Marker size | 4px with 6px glow |
+| Trail rendering | `pathsData` with `pathPointAlt` for 3D orbit paths |
+| Footprint | Surface-level marker (`htmlAltitude = 0`) with 12px translucent ring |
+
+### Lifecycle
+
+| Event | Action |
+|-------|--------|
+| Layer enabled | `loadSatellites()` → fetch TLEs → init satrecs → start 3s propagation loop |
+| Layer disabled | `stopSatellitePropagation()` → clear interval |
+| Globe → flat map | Propagation stops (globe-only layer) |
+| Page load (cold start) | If `satellites` enabled and globe mode: loads alongside other intelligence signals |
+| Page unload | Cleanup in `destroy()` |
+
+### Circuit Breaker
+
+Client-side fetch uses a circuit breaker: 3 consecutive failures trigger a 10-minute cooldown. Cached data continues to be used during cooldown.
+
+---
+
+## Redis Keys
+
+| Key | TTL | Writer | Shape |
+|-----|-----|--------|-------|
+| `intelligence:satellites:tle:v1` | 4h | Railway relay (2h cycle) | `{ satellites: SatelliteTLE[], fetchedAt: number }` |
+| `seed-meta:intelligence:satellites` | 7d | Railway relay | `{ fetchedAt: number, recordCount: number }` |
+
+### Health Monitoring
+
+- `api/health.js` checks `intelligence:satellites:tle:v1` as a standalone key
+- Seed metadata checked with `maxStaleMin: 180` (3h — survives 1 missed cycle)
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/ais-relay.cjs` | `seedSatelliteTLEs()` + `startSatelliteSeedLoop()` |
+| `api/satellites.js` | Vercel edge handler (Redis read, CDN cache) |
+| `src/services/satellites.ts` | Frontend service: fetch, parse, propagate, loop |
+| `src/components/GlobeMap.ts` | Marker rendering, trails, footprints, tooltips |
+| `src/components/MapContainer.ts` | Adapter with cache + rehydration |
+| `src/app/data-loader.ts` | Lifecycle: load, loop, stop, cleanup |
+| `src/config/map-layer-definitions.ts` | Layer registry entry (globe-only) |
+
+---
+
+## Tier Availability
+
+| Feature | Free | Pro | Enterprise |
+|---------|------|-----|------------|
+| Live satellite positions on globe | Yes | Yes | Yes |
+| Orbit trails (15-min trace) | Yes | Yes | Yes |
+| Ground footprint markers | Yes | Yes | Yes |
+| Overhead pass predictions | — | Yes | Yes |
+| Revisit frequency analysis | — | Yes | Yes |
+| Imaging window alerts | — | Yes | Yes |
+| Cross-layer correlation (sat + GPS jam, sat + conflict) | — | Yes | Yes |
+| Satellite intel summary panel | — | Yes | Yes |
+| Sensor swath / FOV visualization | — | Yes | — |
+| Historical pass log (24h) | — | Yes | 30-day archive |
+| Actual satellite imagery (SAR/optical) | — | — | Yes |
+
+---
+
+## Roadmap (Phase 2)
+
+### Overhead Pass Prediction
+
+Compute next pass times over user-selected locations (hotspots, conflict zones, bases). Example: _"GAOFEN-12 will be overhead Tartus in 14 min."_
+
+### Revisit Time Analysis
+
+Calculate how often a location is observed by hostile or friendly satellites. Useful for operational security and intelligence gap analysis.
+
+### Imaging Window Alerts
+
+Push notifications when SAR or optical satellites are overhead a user's watched regions. Integrates with Pro delivery channels (Slack, Telegram, WhatsApp, Email).
+
+### Sensor Swath Visualization
+
+Replace nadir-point footprints with actual field-of-view cones based on satellite sensor specs and orbital altitude.
+
+### Cross-Layer Correlation
+
+Detect intelligence-relevant patterns by combining satellite positions with other layers:
+
+- **Satellite + GPS jamming zone** → electronic warfare context
+- **Satellite + conflict zone** → battlefield ISR detection
+- **Satellite + AIS gap** → maritime reconnaissance indicator
+
+### Satellite Intel Summary Panel
+
+Dedicated Pro panel with a table of tracked satellites: operator, sensor capability, orbit type, current position, and next pass over user-defined points of interest.
+
+### Historical Pass Log
+
+Which satellites passed over a given location in the last 24h (Pro) or 30 days (Enterprise). Useful for post-event analysis: _"What imaging assets were overhead during the incident?"_

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "papaparse": "^5.5.3",
         "pmtiles": "^4.4.0",
         "preact": "^10.25.4",
+        "satellite.js": "^6.0.2",
         "supercluster": "^8.0.1",
         "telegram": "^2.26.22",
         "topojson-client": "^3.1.0",
@@ -11929,6 +11930,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/satellite.js": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/satellite.js/-/satellite.js-6.0.2.tgz",
+      "integrity": "sha512-XWKxtqVF5xiJ1xAeiYeT/oSSzsukoCLWvk6nO/WFy4un0M3g4djAU9TAtOCqJLtYW9vxx9pkPJ1L9ITOc607GA==",
       "license": "MIT"
     },
     "node_modules/sax": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "papaparse": "^5.5.3",
     "pmtiles": "^4.4.0",
     "preact": "^10.25.4",
+    "satellite.js": "^6.0.2",
     "supercluster": "^8.0.1",
     "telegram": "^2.26.22",
     "topojson-client": "^3.1.0",

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1024,6 +1024,127 @@ async function startUcdpSeedLoop() {
 }
 
 // ─────────────────────────────────────────────────────────────
+// Satellite TLE Seed — CelesTrak NORAD elements → Redis
+// ─────────────────────────────────────────────────────────────
+const SAT_SEED_INTERVAL_MS = 7_200_000;
+const SAT_SEED_TTL = 14_400;
+const SAT_GROUPS = ['military', 'resource'];
+
+const SAT_NAME_FILTERS = [
+  /^YAOGAN/i, /^GAOFEN/i, /^JILIN/i,
+  /^COSMOS 2[45]\d{2}/i,
+  /^COSMO-SKYMED/i, /^TERRASAR/i, /^PAZ$/i, /^SAR-LUPE/i,
+  /^WORLDVIEW/i, /^SKYSAT/i, /^PLEIADES/i, /^KOMPSAT/i,
+  /^SAPPHIRE/i, /^PRAETORIAN/i,
+  /^SENTINEL/i,
+];
+
+function satClassify(name) {
+  const n = name.toUpperCase();
+  let type = 'military';
+  if (/COSMO-SKYMED|TERRASAR|PAZ|SAR-LUPE|YAOGAN/i.test(n)) type = 'sar';
+  else if (/WORLDVIEW|SKYSAT|PLEIADES|KOMPSAT|GAOFEN|JILIN/i.test(n)) type = 'optical';
+  else if (/SAPPHIRE|PRAETORIAN/i.test(n)) type = 'military';
+
+  let country = 'OTHER';
+  if (/^YAOGAN|^GAOFEN|^JILIN/i.test(n)) country = 'CN';
+  else if (/^COSMOS/i.test(n)) country = 'RU';
+  else if (/^WORLDVIEW|^SAPPHIRE|^PRAETORIAN/i.test(n)) country = 'US';
+  else if (/^SENTINEL|^COSMO-SKYMED|^TERRASAR|^SAR-LUPE|^PAZ|^PLEIADES/i.test(n)) country = 'EU';
+  else if (/^KOMPSAT/i.test(n)) country = 'KR';
+  else if (/^SKYSAT/i.test(n)) country = 'US';
+
+  return { type, country };
+}
+
+let satSeedInFlight = false;
+
+async function seedSatelliteTLEs() {
+  if (satSeedInFlight) return;
+  satSeedInFlight = true;
+  const t0 = Date.now();
+  try {
+    const byNorad = new Map();
+
+    for (const group of SAT_GROUPS) {
+      let text;
+      try {
+        text = await new Promise((resolve, reject) => {
+          const url = new URL(`https://celestrak.org/NORAD/elements/gp.php?GROUP=${group}&FORMAT=tle`);
+          const req = https.request(url, { method: 'GET', headers: { 'User-Agent': CHROME_UA }, timeout: 15000 }, (resp) => {
+            if (resp.statusCode < 200 || resp.statusCode >= 300) {
+              resp.resume();
+              return reject(new Error(`CelesTrak ${group}: HTTP ${resp.statusCode}`));
+            }
+            let data = '';
+            let size = 0;
+            resp.on('data', (chunk) => {
+              size += chunk.length;
+              if (size > 2 * 1024 * 1024) { req.destroy(); return reject(new Error(`CelesTrak ${group}: payload > 2MB`)); }
+              data += chunk;
+            });
+            resp.on('end', () => resolve(data));
+          });
+          req.on('error', reject);
+          req.on('timeout', () => { req.destroy(); reject(new Error(`CelesTrak ${group}: timeout`)); });
+          req.end();
+        });
+      } catch (e) {
+        console.warn(`[Satellites] Skipping group ${group}:`, e?.message || e);
+        continue;
+      }
+
+      const lines = text.split('\n').map(l => l.trimEnd());
+      for (let i = 0; i < lines.length - 2; i++) {
+        const l1 = lines[i + 1];
+        const l2 = lines[i + 2];
+        if (!l1.startsWith('1 ') || !l2.startsWith('2 ')) continue;
+        if (l1.length !== 69 || l2.length !== 69) continue;
+        const name = lines[i].trim();
+        const noradId = l1.substring(2, 7).trim();
+        if (!byNorad.has(noradId)) {
+          byNorad.set(noradId, { noradId, name, line1: l1, line2: l2 });
+        }
+        i += 2;
+      }
+    }
+
+    const satellites = [];
+    for (const sat of byNorad.values()) {
+      if (!SAT_NAME_FILTERS.some(rx => rx.test(sat.name))) continue;
+      const { type, country } = satClassify(sat.name);
+      satellites.push({ ...sat, type, country });
+    }
+
+    if (satellites.length === 0) {
+      console.warn('[Satellites] No matching TLEs found — skipping write');
+      return;
+    }
+
+    const payload = { satellites, fetchedAt: Date.now() };
+    const ok = await upstashSet('intelligence:satellites:tle:v1', payload, SAT_SEED_TTL);
+    await upstashSet('seed-meta:intelligence:satellites', { fetchedAt: Date.now(), recordCount: satellites.length }, 604800);
+    console.log(`[Satellites] Seeded ${satellites.length} TLEs (redis: ${ok ? 'OK' : 'FAIL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+  } catch (e) {
+    console.warn('[Satellites] Seed error:', e?.message || e);
+  } finally {
+    satSeedInFlight = false;
+  }
+}
+
+async function startSatelliteSeedLoop() {
+  if (!UPSTASH_ENABLED) {
+    console.log('[Satellites] Disabled (no Upstash Redis)');
+    return;
+  }
+  console.log(`[Satellites] Seed loop starting (interval ${SAT_SEED_INTERVAL_MS / 1000 / 60}min)`);
+  seedSatelliteTLEs().catch(e => console.warn('[Satellites] Initial seed error:', e?.message || e));
+  setInterval(() => {
+    seedSatelliteTLEs().catch(e => console.warn('[Satellites] Seed error:', e?.message || e));
+  }, SAT_SEED_INTERVAL_MS).unref?.();
+}
+
+// ─────────────────────────────────────────────────────────────
 // Market Data Seed — Railway fetches Yahoo/Finnhub → writes to Redis
 // so Vercel handlers serve from cache (avoids Yahoo 429 from Vercel IPs)
 // ─────────────────────────────────────────────────────────────
@@ -6358,6 +6479,7 @@ server.listen(PORT, () => {
   startWeatherSeedLoop();
   startSpendingSeedLoop();
   startWorldBankSeedLoop();
+  startSatelliteSeedLoop();
 });
 
 wss.on('connection', (ws, req) => {

--- a/src/App.ts
+++ b/src/App.ts
@@ -308,6 +308,7 @@ export class App {
       syncDataFreshnessWithLayers: () => this.dataLoader.syncDataFreshnessWithLayers(),
       ensureCorrectZones: () => this.panelLayout.ensureCorrectZones(),
       refreshOpenCountryBrief: () => this.countryIntel.refreshOpenBrief(),
+      stopLayerActivity: (layer) => this.dataLoader.stopLayerActivity(layer),
     });
 
     // Wire cross-module callback: DataLoader → SearchManager

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -71,6 +71,8 @@ import { analyzeFlightsForSurge, surgeAlertToSignal, detectForeignMilitaryPresen
 import { fetchCachedTheaterPosture } from '@/services/cached-theater-posture';
 import { ingestProtestsForCII, ingestMilitaryForCII, ingestNewsForCII, ingestOutagesForCII, ingestConflictsForCII, ingestUcdpForCII, ingestHapiForCII, ingestDisplacementForCII, ingestClimateForCII, ingestStrikesForCII, ingestOrefForCII, ingestAviationForCII, ingestAdvisoriesForCII, ingestGpsJammingForCII, ingestAisDisruptionsForCII, ingestSatelliteFiresForCII, ingestCyberThreatsForCII, ingestTemporalAnomaliesForCII, isInLearningMode, resetHotspotActivity, setIntelligenceSignalsLoaded, hasAnyIntelligenceData, calculateCII } from '@/services/country-instability';
 import { fetchGpsInterference } from '@/services/gps-interference';
+import { fetchSatelliteTLEs, initSatRecs, propagatePositions, startPropagationLoop } from '@/services/satellites';
+import type { SatRecEntry } from '@/services/satellites';
 import { dataFreshness, type DataSourceId } from '@/services/data-freshness';
 import { fetchConflictEvents, fetchUcdpClassifications, fetchHapiSummary, fetchUcdpEvents, deduplicateAgainstAcled, fetchIranEvents } from '@/services/conflict';
 import { fetchUnhcrPopulation } from '@/services/displacement';
@@ -185,6 +187,8 @@ export class DataLoaderManager implements AppModule {
   }
 
   private boundMarketWatchlistHandler: (() => void) | null = null;
+  private satellitePropagationCleanup: (() => void) | null = null;
+  private cachedSatRecs: SatRecEntry[] | null = null;
 
   private digestBreaker = { state: 'closed' as 'closed' | 'open' | 'half-open', failures: 0, cooldownUntil: 0 };
   private readonly digestRequestTimeoutMs = 8000;
@@ -208,6 +212,7 @@ export class DataLoaderManager implements AppModule {
   }
 
   destroy(): void {
+    this.stopSatellitePropagation();
     this.applyTimeRangeFilterToNewsPanelsDebounced.cancel();
     stopOrefPolling();
     if (this.boundMarketWatchlistHandler) {
@@ -393,6 +398,7 @@ export class DataLoaderManager implements AppModule {
     if (SITE_VARIANT !== 'happy' && CYBER_LAYER_ENABLED && this.ctx.mapLayers.cyberThreats) tasks.push({ name: 'cyberThreats', task: runGuarded('cyberThreats', () => this.loadCyberThreats()) });
     if (SITE_VARIANT !== 'happy' && !isDesktopRuntime()) tasks.push({ name: 'iranAttacks', task: runGuarded('iranAttacks', () => this.loadIranEvents()) });
     if (SITE_VARIANT !== 'happy' && (this.ctx.mapLayers.techEvents || SITE_VARIANT === 'tech')) tasks.push({ name: 'techEvents', task: runGuarded('techEvents', () => this.loadTechEvents()) });
+    if (SITE_VARIANT !== 'happy' && this.ctx.mapLayers.satellites && this.ctx.map?.isGlobeMode?.()) tasks.push({ name: 'satellites', task: runGuarded('satellites', () => this.loadSatellites()) });
 
     if (SITE_VARIANT !== 'happy') {
       tasks.push({ name: 'techReadiness', task: runGuarded('techReadiness', () => (this.ctx.panels['tech-readiness'] as TechReadinessPanel)?.refresh()) });
@@ -483,6 +489,9 @@ export class DataLoaderManager implements AppModule {
         case 'iranAttacks':
           await this.loadIranEvents();
           break;
+        case 'satellites':
+          await this.loadSatellites();
+          break;
         case 'ucdpEvents':
         case 'displacement':
         case 'climate':
@@ -494,6 +503,27 @@ export class DataLoaderManager implements AppModule {
       this.ctx.inFlight.delete(layer);
       this.ctx.map?.setLayerLoading(layer, false);
     }
+  }
+
+  async loadSatellites(): Promise<void> {
+    this.stopSatellitePropagation();
+    const data = await fetchSatelliteTLEs();
+    if (!data || data.length === 0) return;
+    this.cachedSatRecs = initSatRecs(data);
+    const positions = propagatePositions(this.cachedSatRecs);
+    this.ctx.map?.setSatellites(positions);
+    this.satellitePropagationCleanup = startPropagationLoop(this.cachedSatRecs, (pos) => {
+      this.ctx.map?.setSatellites(pos);
+    }, 3000);
+  }
+
+  private stopSatellitePropagation(): void {
+    this.satellitePropagationCleanup?.();
+    this.satellitePropagationCleanup = null;
+  }
+
+  stopLayerActivity(layer: keyof MapLayers): void {
+    if (layer === 'satellites') this.stopSatellitePropagation();
   }
 
   private findFlashLocation(title: string): { lat: number; lon: number } | null {

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -1,6 +1,6 @@
 import type { AppContext, AppModule } from '@/app/app-context';
 import type { AirlineIntelPanel } from '@/components/AirlineIntelPanel';
-import type { PanelConfig } from '@/types';
+import type { PanelConfig, MapLayers } from '@/types';
 import type { MapView } from '@/components';
 import type { ClusteredEvent } from '@/types';
 import type { DashboardSnapshot } from '@/services/storage';
@@ -62,6 +62,7 @@ export interface EventHandlerCallbacks {
   syncDataFreshnessWithLayers: () => void;
   ensureCorrectZones: () => void;
   refreshOpenCountryBrief?: () => void;
+  stopLayerActivity?: (layer: keyof MapLayers) => void;
 }
 
 export class EventHandlerManager implements AppModule {
@@ -920,6 +921,8 @@ export class EventHandlerManager implements AppModule {
 
       if (enabled) {
         this.callbacks.loadDataForLayer(layer);
+      } else {
+        this.callbacks.stopLayerActivity?.(layer as keyof MapLayers);
       }
     });
 

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -41,6 +41,9 @@ import { type IranEvent, getIranEventHexColor } from '@/services/conflict';
 import type { DisplacementFlow } from '@/services/displacement';
 import type { ClimateAnomaly } from '@/services/climate';
 import type { GpsJamHex } from '@/services/gps-interference';
+import type { SatellitePosition } from '@/services/satellites';
+
+const SAT_COUNTRY_COLORS: Record<string, string> = { CN: '#ff2020', RU: '#ff8800', US: '#4488ff', EU: '#44cc44', KR: '#aa66ff', OTHER: '#ccccff' };
 
 // ─── Marker discriminated union ─────────────────────────────────────────────
 interface BaseMarker {
@@ -276,12 +279,26 @@ interface AisDisruptionMarker extends BaseMarker {
   severity: AisDisruptionEvent['severity'];
   description: string;
 }
+interface SatelliteMarker extends BaseMarker {
+  _kind: 'satellite';
+  id: string;
+  name: string;
+  country: string;
+  type: string;
+  alt: number;
+}
+interface SatFootprintMarker extends BaseMarker {
+  _kind: 'satFootprint';
+  country: string;
+  noradId: string;
+}
 interface GlobePath {
   id: string;
   name: string;
-  points: [number, number][];
-  pathType: 'cable' | 'oil' | 'gas' | 'products';
+  points: number[][];
+  pathType: 'cable' | 'oil' | 'gas' | 'products' | 'orbit';
   status: string;
+  country?: string;
 }
 interface GlobePolygon {
   coords: number[][][];
@@ -302,7 +319,7 @@ type GlobeMarker =
   | ConflictZoneMarker | MilBaseMarker | NuclearSiteMarker | IrradiatorSiteMarker | SpaceportSiteMarker
   | EarthquakeMarker | EconomicMarker | DatacenterMarker | WaterwayMarker | MineralMarker
   | FlightDelayMarker | CableAdvisoryMarker | RepairShipMarker | AisDisruptionMarker
-  | NewsLocationMarker | FlashMarker;
+  | NewsLocationMarker | FlashMarker | SatelliteMarker | SatFootprintMarker;
 
 interface GlobeControlsLike {
   autoRotate: boolean;
@@ -372,6 +389,9 @@ export class GlobeMap {
   private cableAdvisoryMarkers: CableAdvisoryMarker[] = [];
   private repairShipMarkers: RepairShipMarker[] = [];
   private aisMarkers: AisDisruptionMarker[] = [];
+  private satelliteMarkers: SatelliteMarker[] = [];
+  private satelliteTrailPaths: GlobePath[] = [];
+  private satelliteFootprintMarkers: SatFootprintMarker[] = [];
   private tradeRouteSegments: TradeRouteSegment[] = [];
   private globePaths: GlobePath[] = [];
   private cableFaultIds = new Set<string>();
@@ -532,6 +552,8 @@ export class GlobeMap {
       .htmlLng((d: object) => (d as GlobeMarker)._lng)
       .htmlAltitude((d: object) => {
         const m = d as GlobeMarker;
+        if (m._kind === 'satFootprint') return 0;
+        if (m._kind === 'satellite') return (m as SatelliteMarker).alt / 6371;
         if (m._kind === 'flight' || m._kind === 'vessel') return 0.012;
         if (m._kind === 'hotspot') return 0.005;
         return 0.003;
@@ -562,9 +584,16 @@ export class GlobeMap {
     // Path accessors — set once
     (globe as any)
       .pathPoints((d: GlobePath) => d.points)
-      .pathPointLat((p: [number, number]) => p[1])
-      .pathPointLng((p: [number, number]) => p[0])
+      .pathPointLat((p: number[]) => p[1])
+      .pathPointLng((p: number[]) => p[0])
+      .pathPointAlt((p: number[], _idx: number, path: object) =>
+        (path as GlobePath).pathType === 'orbit' && p.length > 2 ? (p[2] ?? 0) / 6371 : 0
+      )
       .pathColor((d: GlobePath) => {
+        if (d.pathType === 'orbit') {
+          const colors: Record<string, string> = { CN: 'rgba(255,32,32,0.4)', RU: 'rgba(255,136,0,0.4)', US: 'rgba(68,136,255,0.4)', EU: 'rgba(68,204,68,0.4)' };
+          return colors[d.country || ''] || 'rgba(200,200,255,0.3)';
+        }
         if (d.pathType === 'cable') {
           if (this.cableFaultIds.has(d.id))    return '#ff3030';
           if (this.cableDegradedIds.has(d.id)) return '#ff8800';
@@ -574,10 +603,10 @@ export class GlobeMap {
         if (d.pathType === 'gas')   return 'rgba(80,220,120,0.6)';
         return 'rgba(180,160,255,0.6)';
       })
-      .pathStroke((d: GlobePath) => d.pathType === 'cable' ? 0.3 : 0.6)
-      .pathDashLength((d: GlobePath) => d.pathType === 'cable' ? 1 : 0.6)
-      .pathDashGap((d: GlobePath) => d.pathType === 'cable' ? 0 : 0.25)
-      .pathDashAnimateTime((d: GlobePath) => d.pathType === 'cable' ? 0 : 5000)
+      .pathStroke((d: GlobePath) => d.pathType === 'orbit' ? 0.3 : d.pathType === 'cable' ? 0.3 : 0.6)
+      .pathDashLength((d: GlobePath) => d.pathType === 'orbit' ? 0.4 : d.pathType === 'cable' ? 1 : 0.6)
+      .pathDashGap((d: GlobePath) => d.pathType === 'orbit' ? 0.15 : d.pathType === 'cable' ? 0 : 0.25)
+      .pathDashAnimateTime((d: GlobePath) => d.pathType === 'orbit' ? 0 : d.pathType === 'cable' ? 0 : 5000)
       .pathLabel((d: GlobePath) => d.name);
 
     // Polygon accessors — set once
@@ -862,6 +891,15 @@ export class GlobeMap {
       const sc = d.severity === 'high' ? '#ff2020' : d.severity === 'elevated' ? '#ff8800' : '#44aaff';
       el.innerHTML = `<div style="font-size:11px;color:${sc};text-shadow:0 0 4px ${sc}88;">⛴</div>`;
       el.title = d.name;
+    } else if (d._kind === 'satellite') {
+      const c = SAT_COUNTRY_COLORS[(d as SatelliteMarker).country] || '#ccccff';
+      el.innerHTML = `<div style="width:4px;height:4px;border-radius:50%;background:${c};box-shadow:0 0 6px 2px ${c}88"></div>`;
+      el.title = `${(d as SatelliteMarker).name} (${(d as SatelliteMarker).country}) · ${d.type === 'sar' ? 'SAR' : d.type === 'optical' ? 'Optical' : d.type} · ${Math.round((d as SatelliteMarker).alt)}km`;
+    } else if (d._kind === 'satFootprint') {
+      const colors: Record<string, string> = { CN: '#ff2020', RU: '#ff8800', US: '#4488ff', EU: '#44cc44' };
+      const c = colors[(d as SatFootprintMarker).country] || '#ccccff';
+      el.innerHTML = `<div style="width:12px;height:12px;border-radius:50%;border:1px solid ${c}66;background:${c}15;margin:-6px 0 0 -6px"></div>`;
+      el.style.pointerEvents = 'none';
     } else if (d._kind === 'flash') {
       el.style.pointerEvents = 'none';
       el.innerHTML = `
@@ -1048,6 +1086,12 @@ export class GlobeMap {
       const tc = d.threatLevel === 'critical' ? '#ff2020' : d.threatLevel === 'high' ? '#ff6600' : d.threatLevel === 'elevated' ? '#ffaa00' : '#44aaff';
       html = `<span style="color:${tc};font-weight:bold;">📰 ${esc(d.title.slice(0, 60))}</span>` +
              `<br><span style="opacity:.5;">${esc(d.threatLevel)}</span>`;
+    } else if (d._kind === 'satellite') {
+      const sc = SAT_COUNTRY_COLORS[d.country] || '#ccccff';
+      const typeLabel = d.type === 'sar' ? 'SAR Imaging' : d.type === 'optical' ? 'Optical Imaging' : d.type === 'military' ? 'Military' : 'SIGINT';
+      html = `<span style="color:${sc};font-weight:bold;">🛰 ${esc(d.name)}</span>` +
+             `<br><span style="opacity:.7;">${esc(d.country)} · ${esc(typeLabel)}</span>` +
+             `<br><span style="opacity:.5;">${Math.round(d.alt)}km altitude</span>`;
     }
     el.innerHTML = html;
 
@@ -1233,6 +1277,10 @@ export class GlobeMap {
     if (this.layers.displacement) markers.push(...this.displacementMarkers);
     if (this.layers.climate) markers.push(...this.climateMarkers);
     if (this.layers.gpsJamming) markers.push(...this.gpsJamMarkers);
+    if (this.layers.satellites) {
+      markers.push(...this.satelliteMarkers);
+      markers.push(...this.satelliteFootprintMarkers);
+    }
     if (this.layers.techEvents) markers.push(...this.techMarkers);
     if (this.layers.cables) {
       markers.push(...this.cableAdvisoryMarkers);
@@ -1259,7 +1307,8 @@ export class GlobeMap {
     const paths = (showCables && showPipelines)
       ? this.globePaths
       : this.globePaths.filter(p => p.pathType === 'cable' ? showCables : showPipelines);
-    (this.globe as any).pathsData(paths);
+    const orbitPaths = this.layers.satellites ? this.satelliteTrailPaths : [];
+    (this.globe as any).pathsData([...paths, ...orbitPaths]);
   }
 
   private static readonly CII_GLOBE_COLORS: Record<string, string> = {
@@ -1528,6 +1577,7 @@ export class GlobeMap {
     ['pipelines',     { markers: false, arcs: false, paths: true,  polygons: false }],
     ['conflicts',     { markers: true,  arcs: false, paths: false, polygons: true }],
     ['cables',        { markers: true,  arcs: false, paths: true,  polygons: false }],
+    ['satellites',    { markers: true,  arcs: false, paths: true,  polygons: false }],
   ]);
 
   private flushLayerChannels(layer: keyof MapLayers): void {
@@ -1971,6 +2021,41 @@ export class GlobeMap {
     }));
     this.flushMarkers();
   }
+
+  public setSatellites(positions: SatellitePosition[]): void {
+    this.satelliteMarkers = positions.map(s => ({
+      _kind: 'satellite' as const,
+      _lat: s.lat,
+      _lng: s.lng,
+      id: s.noradId,
+      name: s.name,
+      country: s.country,
+      type: s.type,
+      alt: s.alt,
+    }));
+
+    this.satelliteFootprintMarkers = positions.map(s => ({
+      _kind: 'satFootprint' as const,
+      _lat: s.lat,
+      _lng: s.lng,
+      country: s.country,
+      noradId: s.noradId,
+    }));
+
+    this.satelliteTrailPaths = positions
+      .filter(s => s.trail && s.trail.length > 1)
+      .map(s => ({
+        id: `orbit-${s.noradId}`,
+        name: s.name,
+        points: [[s.lng, s.lat, s.alt], ...s.trail],
+        pathType: 'orbit' as const,
+        status: 'active',
+        country: s.country,
+      }));
+
+    this.flushMarkers();
+    this.flushPaths();
+  }
   public setTechEvents(events: Array<{ id: string; title: string; lat: number; lng: number; country: string; daysUntil: number; [key: string]: any }>): void {
     this.techMarkers = (events ?? []).filter(e => e.lat != null && e.lng != null).map(e => ({
       _kind: 'tech' as const,
@@ -2121,7 +2206,7 @@ export class GlobeMap {
       (this.globe as any).pathDashAnimateTime(0);
     } else {
       (this.globe as any).arcDashAnimateTime(5000);
-      (this.globe as any).pathDashAnimateTime((d: GlobePath) => d.pathType === 'cable' ? 0 : 5000);
+      (this.globe as any).pathDashAnimateTime((d: GlobePath) => d.pathType === 'orbit' ? 0 : d.pathType === 'cable' ? 0 : 5000);
     }
 
     if (profile.disableAtmosphere) {

--- a/src/components/MapContainer.ts
+++ b/src/components/MapContainer.ts
@@ -39,6 +39,7 @@ import type { HappinessData } from '@/services/happiness-data';
 import type { SpeciesRecovery } from '@/services/conservation-data';
 import type { RenewableInstallation } from '@/services/renewable-installations';
 import type { GpsJamHex } from '@/services/gps-interference';
+import type { SatellitePosition } from '@/services/satellites';
 import type { IranEvent } from '@/services/conflict';
 
 export type TimeRange = '1h' | '6h' | '24h' | '48h' | '7d' | 'all';
@@ -116,6 +117,7 @@ export class MapContainer {
   private cachedDisplacementFlows: DisplacementFlow[] | null = null;
   private cachedClimateAnomalies: ClimateAnomaly[] | null = null;
   private cachedGpsJamming: GpsJamHex[] | null = null;
+  private cachedSatellites: SatellitePosition[] | null = null;
   private cachedCyberThreats: CyberThreat[] | null = null;
   private cachedIranEvents: IranEvent[] | null = null;
   private cachedNewsLocations: NewsLocationMarker[] | null = null;
@@ -276,6 +278,7 @@ export class MapContainer {
     if (this.cachedDisplacementFlows) this.setDisplacementFlows(this.cachedDisplacementFlows);
     if (this.cachedClimateAnomalies) this.setClimateAnomalies(this.cachedClimateAnomalies);
     if (this.cachedGpsJamming) this.setGpsJamming(this.cachedGpsJamming);
+    if (this.cachedSatellites) this.setSatellites(this.cachedSatellites);
     if (this.cachedCyberThreats) this.setCyberThreats(this.cachedCyberThreats);
     if (this.cachedIranEvents) this.setIranEvents(this.cachedIranEvents);
     if (this.cachedNewsLocations) this.setNewsLocations(this.cachedNewsLocations);
@@ -529,6 +532,11 @@ export class MapContainer {
     if (this.useDeckGL) {
       this.deckGLMap?.setGpsJamming(hexes);
     }
+  }
+
+  public setSatellites(positions: SatellitePosition[]): void {
+    this.cachedSatellites = positions;
+    if (this.useGlobe) { this.globeMap?.setSatellites(positions); return; }
   }
 
   public setCyberThreats(threats: CyberThreat[]): void {
@@ -905,6 +913,7 @@ export class MapContainer {
     this.cachedDisplacementFlows = null;
     this.cachedClimateAnomalies = null;
     this.cachedGpsJamming = null;
+    this.cachedSatellites = null;
     this.cachedCyberThreats = null;
     this.cachedIranEvents = null;
     this.cachedNewsLocations = null;

--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -33,6 +33,7 @@ export const LAYER_REGISTRY: Record<keyof MapLayers, LayerDefinition> = {
   nuclear:                  def('nuclear',                  '&#9762;',   'nuclearSites',             'Nuclear Sites'),
   irradiators:              def('irradiators',              '&#9888;',   'gammaIrradiators',         'Gamma Irradiators'),
   spaceports:               def('spaceports',               '&#128640;', 'spaceports',               'Spaceports'),
+  satellites:               def('satellites',               '&#128752;', 'satellites',               'Orbital Surveillance', ['globe']),
   cables:                   def('cables',                   '&#128268;', 'underseaCables',           'Undersea Cables'),
   pipelines:                def('pipelines',                '&#128738;', 'pipelines',                'Pipelines'),
   datacenters:              def('datacenters',              '&#128421;', 'aiDataCenters',            'AI Data Centers'),
@@ -84,8 +85,8 @@ const VARIANT_LAYER_ORDER: Record<MapVariant, Array<keyof MapLayers>> = {
     'ais', 'tradeRoutes', 'flights', 'protests',
     'ucdpEvents', 'displacement', 'climate', 'weather',
     'outages', 'cyberThreats', 'natural', 'fires',
-    'waterways', 'economic', 'minerals',
-    'gpsJamming', 'ciiChoropleth', 'dayNight',
+    'waterways', 'economic', 'minerals', 'gpsJamming',
+    'satellites', 'ciiChoropleth', 'dayNight',
   ],
   tech: [
     'startupHubs', 'techHQs', 'accelerators', 'cloudRegions',

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -65,6 +65,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
 const FULL_MAP_LAYERS: MapLayers = {
   iranAttacks: _desktop ? false : true,
   gpsJamming: false,
+  satellites: false,
 
   conflicts: true,
   bases: _desktop ? false : true,
@@ -122,6 +123,7 @@ const FULL_MAP_LAYERS: MapLayers = {
 const FULL_MOBILE_MAP_LAYERS: MapLayers = {
   iranAttacks: true,
   gpsJamming: false,
+  satellites: false,
 
   conflicts: true,
   bases: false,
@@ -220,6 +222,7 @@ const TECH_PANELS: Record<string, PanelConfig> = {
 
 const TECH_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,
@@ -277,6 +280,7 @@ const TECH_MAP_LAYERS: MapLayers = {
 
 const TECH_MOBILE_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,
@@ -374,6 +378,7 @@ const FINANCE_PANELS: Record<string, PanelConfig> = {
 
 const FINANCE_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,
@@ -431,6 +436,7 @@ const FINANCE_MAP_LAYERS: MapLayers = {
 
 const FINANCE_MOBILE_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,
@@ -504,6 +510,7 @@ const HAPPY_PANELS: Record<string, PanelConfig> = {
 
 const HAPPY_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,
@@ -561,6 +568,7 @@ const HAPPY_MAP_LAYERS: MapLayers = {
 
 const HAPPY_MOBILE_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,
@@ -649,6 +657,7 @@ const COMMODITY_PANELS: Record<string, PanelConfig> = {
 
 const COMMODITY_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,
@@ -706,6 +715,7 @@ const COMMODITY_MAP_LAYERS: MapLayers = {
 
 const COMMODITY_MOBILE_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,

--- a/src/config/variants/commodity.ts
+++ b/src/config/variants/commodity.ts
@@ -64,6 +64,7 @@ export const DEFAULT_MAP_LAYERS: MapLayers = {
   // ── All non-commodity layers (DISABLED) ───────────────────────────────────
   // Geopolitical / military
   gpsJamming: false,
+  satellites: false,
   iranAttacks: false,
   conflicts: false,
   bases: false,
@@ -132,6 +133,7 @@ export const MOBILE_DEFAULT_MAP_LAYERS: MapLayers = {
 
   // All others disabled on mobile
   gpsJamming: false,
+  satellites: false,
   iranAttacks: false,
   conflicts: false,
   bases: false,

--- a/src/config/variants/finance.ts
+++ b/src/config/variants/finance.ts
@@ -174,6 +174,7 @@ export const DEFAULT_PANELS: Record<string, PanelConfig> = {
 // Finance-focused map layers
 export const DEFAULT_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,
@@ -231,6 +232,7 @@ export const DEFAULT_MAP_LAYERS: MapLayers = {
 // Mobile defaults for finance variant
 export const MOBILE_DEFAULT_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,

--- a/src/config/variants/full.ts
+++ b/src/config/variants/full.ts
@@ -53,6 +53,7 @@ export const DEFAULT_PANELS: Record<string, PanelConfig> = {
 // Map layers for geopolitical view
 export const DEFAULT_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: true,
   bases: true,
@@ -110,6 +111,7 @@ export const DEFAULT_MAP_LAYERS: MapLayers = {
 // Mobile-specific defaults for geopolitical
 export const MOBILE_DEFAULT_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: true,
   bases: false,

--- a/src/config/variants/happy.ts
+++ b/src/config/variants/happy.ts
@@ -21,6 +21,7 @@ export const DEFAULT_PANELS: Record<string, PanelConfig> = {
 // Map layers — all geopolitical overlays disabled; natural events only
 export const DEFAULT_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,
@@ -79,6 +80,7 @@ export const DEFAULT_MAP_LAYERS: MapLayers = {
 // Mobile defaults — same as desktop for happy variant
 export const MOBILE_DEFAULT_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,

--- a/src/config/variants/tech.ts
+++ b/src/config/variants/tech.ts
@@ -215,6 +215,7 @@ export const DEFAULT_PANELS: Record<string, PanelConfig> = {
 export const DEFAULT_MAP_LAYERS: MapLayers = {
   // Keep only relevant layers, set others to false
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,
@@ -272,6 +273,7 @@ export const DEFAULT_MAP_LAYERS: MapLayers = {
 // Mobile defaults for tech variant
 export const MOBILE_DEFAULT_MAP_LAYERS: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,

--- a/src/e2e/map-harness.ts
+++ b/src/e2e/map-harness.ts
@@ -137,6 +137,7 @@ app.style.margin = '0 auto';
 
 const allLayersEnabled: MapLayers = {
   gpsJamming: true,
+  satellites: false,
 
   conflicts: true,
   bases: true,
@@ -189,6 +190,7 @@ const allLayersEnabled: MapLayers = {
 
 const allLayersDisabled: MapLayers = {
   gpsJamming: false,
+  satellites: false,
 
   conflicts: false,
   bases: false,

--- a/src/e2e/mobile-map-integration-harness.ts
+++ b/src/e2e/mobile-map-integration-harness.ts
@@ -86,6 +86,7 @@ window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
 
 const layers = {
   gpsJamming: false,
+  satellites: false,
   conflicts: false,
   bases: false,
   cables: false,

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -984,6 +984,7 @@
         "nuclearSites": "مواقع نووية",
         "gammaIrradiators": "أجهزة تشعيع غاما",
         "spaceports": "مطارات فضائية",
+        "satellites": "مراقبة مدارية",
         "pipelines": "خطوط أنابيب",
         "militaryActivity": "نشاط عسكري",
         "shipTraffic": "حركة السفن",

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -1011,6 +1011,7 @@
         "nuclearSites": "Ядрени места",
         "gammaIrradiators": "Гама облъчватели",
         "spaceports": "Космически пристанища",
+        "satellites": "Орбитално наблюдение",
         "pipelines": "Тръбопроводи",
         "militaryActivity": "Военна активност",
         "shipTraffic": "Трафик на кораби",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -1001,6 +1001,7 @@
         "nuclearSites": "Jaderná zařízení",
         "gammaIrradiators": "Gamma ozařovače",
         "spaceports": "Kosmodromy",
+        "satellites": "Orbitální sledování",
         "pipelines": "Potrubí",
         "militaryActivity": "Vojenská aktivita",
         "shipTraffic": "Lodní doprava",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -854,6 +854,7 @@
         "nuclearSites": "Nukleare Standorte",
         "gammaIrradiators": "Gammastrahler",
         "spaceports": "Raumhäfen",
+        "satellites": "Orbitale Überwachung",
         "pipelines": "ROHRLEITUNGEN",
         "militaryActivity": "Militärische Aktivität",
         "shipTraffic": "Schiffsverkehr",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -1011,6 +1011,7 @@
         "nuclearSites": "Πυρηνικές Εγκαταστάσεις",
         "gammaIrradiators": "Ακτινοβολητές Γάμμα",
         "spaceports": "Διαστημοδρόμια",
+        "satellites": "Τροχιακή Επιτήρηση",
         "pipelines": "Αγωγοί",
         "militaryActivity": "Στρατιωτική Δραστηριότητα",
         "shipTraffic": "Ναυτική Κυκλοφορία",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1027,6 +1027,7 @@
         "nuclearSites": "Nuclear Sites",
         "gammaIrradiators": "Gamma Irradiators",
         "spaceports": "Spaceports",
+        "satellites": "Orbital Surveillance",
         "pipelines": "Pipelines",
         "militaryActivity": "Military Activity",
         "shipTraffic": "Ship Traffic",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -854,6 +854,7 @@
         "nuclearSites": "Sitios nucleares",
         "gammaIrradiators": "Irradiadores gamma",
         "spaceports": "Puertos espaciales",
+        "satellites": "Vigilancia Orbital",
         "pipelines": "Tuberías",
         "militaryActivity": "Actividad militar",
         "shipTraffic": "Tráfico de barcos",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -984,6 +984,7 @@
         "nuclearSites": "Sites nucléaires",
         "gammaIrradiators": "Irradiateurs gamma",
         "spaceports": "Cosmodromes",
+        "satellites": "Surveillance Orbitale",
         "pipelines": "OLÉODUCS ET GAZODUCS",
         "militaryActivity": "Activité militaire",
         "shipTraffic": "Trafic maritime",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -854,6 +854,7 @@
         "nuclearSites": "Siti nucleari",
         "gammaIrradiators": "Irradiatori gamma",
         "spaceports": "Spazioporti",
+        "satellites": "Sorveglianza Orbitale",
         "pipelines": "Condotte",
         "militaryActivity": "Attività militare",
         "shipTraffic": "Traffico navale",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1011,6 +1011,7 @@
         "nuclearSites": "核施設",
         "gammaIrradiators": "ガンマ線照射施設",
         "spaceports": "宇宙港",
+        "satellites": "軌道監視",
         "pipelines": "パイプライン",
         "militaryActivity": "軍事活動",
         "shipTraffic": "船舶交通",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1011,6 +1011,7 @@
         "nuclearSites": "핵 시설",
         "gammaIrradiators": "감마 조사기",
         "spaceports": "우주 발사장",
+        "satellites": "궤도 감시",
         "pipelines": "파이프라인",
         "militaryActivity": "군사 활동",
         "shipTraffic": "선박 교통",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -554,6 +554,7 @@
         "nuclearSites": "Nucleaire locaties",
         "gammaIrradiators": "Gamma-bestralers",
         "spaceports": "Ruimtehavens",
+        "satellites": "Orbitale Bewaking",
         "pipelines": "Pijpleidingen",
         "militaryActivity": "Militaire activiteit",
         "shipTraffic": "Scheepsverkeer",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -837,6 +837,7 @@
         "nuclearSites": "Miejsca nuklearne",
         "gammaIrradiators": "Promienniki gamma",
         "spaceports": "Porty kosmiczne",
+        "satellites": "Nadzór Orbitalny",
         "pipelines": "Rurociągi",
         "militaryActivity": "Działalność wojskowa",
         "shipTraffic": "Ruch statków",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -554,6 +554,7 @@
         "nuclearSites": "Locais Nucleares",
         "gammaIrradiators": "Irradiadores gama",
         "spaceports": "Espaçoportos",
+        "satellites": "Vigilância Orbital",
         "pipelines": "Gasodutos",
         "militaryActivity": "Atividade Militar",
         "shipTraffic": "Tráfego de navios",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1011,6 +1011,7 @@
         "nuclearSites": "Situri nucleare",
         "gammaIrradiators": "Iradiatoare Gamma",
         "spaceports": "Porturi spațiale",
+        "satellites": "Supraveghere Orbitală",
         "pipelines": "Conducte",
         "militaryActivity": "Activitate militară",
         "shipTraffic": "Trafic naval",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1011,6 +1011,7 @@
         "nuclearSites": "Ядерные объекты",
         "gammaIrradiators": "Гамма-облучатели",
         "spaceports": "Космодромы",
+        "satellites": "Орбитальное наблюдение",
         "pipelines": "Трубопроводы",
         "militaryActivity": "Военная активность",
         "shipTraffic": "Судоходство",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -554,6 +554,7 @@
         "nuclearSites": "Nukleära platser",
         "gammaIrradiators": "Gammastrålare",
         "spaceports": "Rymdhamnar",
+        "satellites": "Orbital Övervakning",
         "pipelines": "Rörledningar",
         "militaryActivity": "Militär aktivitet",
         "shipTraffic": "Fartygstrafik",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -1011,6 +1011,7 @@
         "nuclearSites": "สถานที่นิวเคลียร์",
         "gammaIrradiators": "เครื่องฉายรังสีแกมมา",
         "spaceports": "ท่าอวกาศ",
+        "satellites": "การเฝ้าระวังจากวงโคจร",
         "pipelines": "ท่อส่ง",
         "militaryActivity": "กิจกรรมทางทหาร",
         "shipTraffic": "การจราจรทางเรือ",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1011,6 +1011,7 @@
         "nuclearSites": "Nukleer Tesisler",
         "gammaIrradiators": "Gama Isinlama Tesisleri",
         "spaceports": "Uzay Ussu",
+        "satellites": "Yörünge Gözetimi",
         "pipelines": "Boru Hatlari",
         "militaryActivity": "Askeri Faaliyet",
         "shipTraffic": "Gemi Trafigi",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -1011,6 +1011,7 @@
         "nuclearSites": "Cơ sở Hạt nhân",
         "gammaIrradiators": "Cơ sở Chiếu xạ Gamma",
         "spaceports": "Sân bay Vũ trụ",
+        "satellites": "Giám sát Quỹ đạo",
         "pipelines": "Đường ống",
         "militaryActivity": "Hoạt động Quân sự",
         "shipTraffic": "Giao thông Hàng hải",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1011,6 +1011,7 @@
         "nuclearSites": "核设施",
         "gammaIrradiators": "伽马辐照器",
         "spaceports": "航天发射场",
+        "satellites": "轨道监视",
         "pipelines": "管道",
         "militaryActivity": "军事活动",
         "shipTraffic": "船舶交通",

--- a/src/services/satellites.ts
+++ b/src/services/satellites.ts
@@ -1,0 +1,152 @@
+// TODO: Phase 2 — Orbital Surveillance Analysis Panel
+// - Overhead Pass Prediction: compute next pass times over user-selected locations
+//   (hotspots, conflict zones, bases). "GAOFEN-12 will be overhead Tartus in 14 min"
+// - Revisit Time Analysis: how often a location is observed by hostile/friendly sats
+// - Imaging Window Alerts: notify when SAR/optical sats are overhead a watched region
+// - Sensor Swath Visualization: show ground coverage cone (FOV-based) not just nadir dot
+// - Cross-Layer Correlation: satellite overhead + GPS jamming zone = EW context;
+//   satellite overhead + conflict zone = battlefield ISR; satellite + AIS gap = maritime recon
+// - Satellite Intel Summary Panel: table of tracked sats with orbit type, operator,
+//   sensor capability, current position, next pass over user POI
+// - Historical Pass Log: which sats passed over a location in the last 24h
+//   (useful for identifying imaging windows after events)
+
+import { getApiBaseUrl } from '@/services/runtime';
+import { twoline2satrec, propagate, eciToGeodetic, gstime, degreesLong, degreesLat } from 'satellite.js';
+import type { SatRec } from 'satellite.js';
+
+export interface SatelliteTLE {
+  noradId: string;
+  name: string;
+  line1: string;
+  line2: string;
+  type: string;
+  country: string;
+}
+
+export interface SatellitePosition {
+  noradId: string;
+  name: string;
+  lat: number;
+  lng: number;
+  alt: number;
+  type: string;
+  country: string;
+  velocity: number;
+  trail: [number, number, number][];
+}
+
+export interface SatRecEntry {
+  satrec: SatRec;
+  meta: { noradId: string; name: string; type: string; country: string };
+}
+
+let cachedData: SatelliteTLE[] | null = null;
+let cachedAt = 0;
+const CACHE_TTL = 10 * 60 * 1000;
+
+let failures = 0;
+let cooldownUntil = 0;
+const MAX_FAILURES = 3;
+const COOLDOWN_MS = 10 * 60 * 1000;
+
+export async function fetchSatelliteTLEs(): Promise<SatelliteTLE[] | null> {
+  const now = Date.now();
+  if (now < cooldownUntil) return cachedData;
+  if (cachedData && now - cachedAt < CACHE_TTL) return cachedData;
+
+  try {
+    const base = getApiBaseUrl();
+    const resp = await fetch(`${base}/api/satellites`, {
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (!resp.ok) return cachedData;
+
+    const raw = await resp.json();
+    const satellites = (raw.satellites ?? []) as SatelliteTLE[];
+    cachedData = satellites;
+    cachedAt = now;
+    failures = 0;
+    return cachedData;
+  } catch {
+    failures++;
+    if (failures >= MAX_FAILURES) {
+      cooldownUntil = now + COOLDOWN_MS;
+    }
+    return cachedData;
+  }
+}
+
+export function initSatRecs(tles: SatelliteTLE[]): SatRecEntry[] {
+  const entries: SatRecEntry[] = [];
+  for (const tle of tles) {
+    try {
+      const satrec = twoline2satrec(tle.line1, tle.line2);
+      entries.push({
+        satrec,
+        meta: { noradId: tle.noradId, name: tle.name, type: tle.type, country: tle.country },
+      });
+    } catch { /* skip malformed */ }
+  }
+  return entries;
+}
+
+export function propagatePositions(satRecs: SatRecEntry[], date?: Date): SatellitePosition[] {
+  const now = date || new Date();
+  const gmst = gstime(now);
+  const positions: SatellitePosition[] = [];
+
+  for (const { satrec, meta } of satRecs) {
+    try {
+      const pv = propagate(satrec, now);
+      if (!pv || !pv.position || typeof pv.position === 'boolean') continue;
+      const geo = eciToGeodetic(pv.position, gmst);
+      const lat = degreesLat(geo.latitude);
+      const lng = degreesLong(geo.longitude);
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+      const alt = geo.height;
+
+      let velocity = 0;
+      if (pv.velocity && typeof pv.velocity !== 'boolean') {
+        const { x, y, z } = pv.velocity;
+        velocity = Math.sqrt(x * x + y * y + z * z);
+      }
+
+      const trail: [number, number, number][] = [];
+      for (let t = 1; t <= 15; t++) {
+        const pastDate = new Date(now.getTime() - t * 60_000);
+        const pastGmst = gstime(pastDate);
+        try {
+          const pastPv = propagate(satrec, pastDate);
+          if (!pastPv || !pastPv.position || typeof pastPv.position === 'boolean') continue;
+          const pastGeo = eciToGeodetic(pastPv.position, pastGmst);
+          const tLat = degreesLat(pastGeo.latitude);
+          const tLng = degreesLong(pastGeo.longitude);
+          if (!Number.isFinite(tLat) || !Number.isFinite(tLng)) continue;
+          trail.push([tLng, tLat, pastGeo.height]);
+        } catch { /* skip */ }
+      }
+
+      positions.push({ ...meta, lat, lng, alt, velocity, trail });
+    } catch { /* skip propagation errors */ }
+  }
+  return positions;
+}
+
+export function startPropagationLoop(
+  satRecs: SatRecEntry[],
+  callback: (positions: SatellitePosition[]) => void,
+  intervalMs = 3000,
+): () => void {
+  const id = setInterval(() => {
+    const positions = propagatePositions(satRecs);
+    callback(positions);
+  }, intervalMs);
+  return () => clearInterval(id);
+}
+
+export function getSatelliteStatus(): string {
+  if (Date.now() < cooldownUntil) return 'cooldown';
+  if (failures > 0) return 'degraded';
+  return 'ok';
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -553,6 +553,8 @@ export interface MapLayers {
   iranAttacks: boolean;
   // GPS/GNSS interference layer
   gpsJamming: boolean;
+  // Satellite orbital tracking
+  satellites: boolean;
 
   // CII choropleth layer
   ciiChoropleth: boolean;

--- a/src/utils/urlState.ts
+++ b/src/utils/urlState.ts
@@ -35,6 +35,7 @@ const LAYER_KEYS: (keyof MapLayers)[] = [
   'tradeRoutes',
   'iranAttacks',
   'gpsJamming',
+  'satellites',
   'ciiChoropleth',
 ];
 


### PR DESCRIPTION
## Summary

- **New globe layer**: "Orbital Surveillance" tracks ~80-120 intelligence-relevant satellites in real time using CelesTrak TLE data and client-side SGP4 propagation (satellite.js)
- **Zero-cost real-time**: Railway seeds TLEs every 2h → Redis → Vercel CDN (1h cache) → browser does SGP4 math every 3s — no server cost for live movement
- **Visual intelligence**: country-coded markers (CN/RU/US/EU/KR) at orbital altitude, 15-min orbit trails, ground footprint projections, rich tooltips with sensor type
- **Pro page updated**: pricing table now shows Free=Live tracking, Pro=Pass alerts + analysis, Enterprise=Imagery + SAR
- **Full documentation**: `docs/ORBITAL_SURVEILLANCE.md` with architecture, satellite selection, technical details, tier availability, and Phase 2 roadmap

### Files created
- `api/satellites.js` — Vercel edge handler
- `src/services/satellites.ts` — frontend service with SGP4 propagation
- `docs/ORBITAL_SURVEILLANCE.md` — full documentation

### Files modified
- 70 files across relay, globe rendering, map layers, data loader, event handlers, /pro page, i18n (21×2 locales), README, docs

## Test plan
- [x] `tsc --noEmit` passes (0 errors)
- [x] Edge function tests pass (78/78, including `satellites.js`)
- [x] Markdown lint passes (0 errors)
- [ ] Deploy relay → verify `[Satellites] Seeded N TLEs` in Railway logs
- [ ] Verify `curl https://api.worldmonitor.app/api/satellites` returns TLE data
- [ ] Toggle "Orbital Surveillance" on globe → satellites visible at altitude
- [ ] Watch 10+ seconds → satellites visibly move
- [ ] Toggle layer off → propagation loop stops
- [ ] Verify `/pro` pricing table shows Free/Pro/Enterprise columns