### PR TITLE
fix: share dialog dismissals across subdomains via cookies

### DIFF
--- a/src/app/desktop-updater.ts
+++ b/src/app/desktop-updater.ts
@@ -2,6 +2,7 @@ import type { AppContext, AppModule } from '@/app/app-context';
 import { invokeTauri } from '@/services/tauri-bridge';
 import { trackUpdateShown, trackUpdateClicked, trackUpdateDismissed } from '@/services/analytics';
 import { escapeHtml } from '@/utils/sanitize';
+import { getDismissed, setDismissed } from '@/utils/cross-domain-storage';
 
 interface DesktopRuntimeInfo {
   os: string;
@@ -88,7 +89,7 @@ export class DesktopUpdater implements AppModule {
       }
 
       const dismissKey = `wm-update-dismissed-${remote}`;
-      if (localStorage.getItem(dismissKey)) {
+      if (getDismissed(dismissKey)) {
         this.logUpdaterOutcome('update_available', { current, remote, dismissed: true });
         return;
       }
@@ -185,7 +186,7 @@ export class DesktopUpdater implements AppModule {
     `;
 
     const dismissToast = () => {
-      localStorage.setItem(`wm-update-dismissed-${version}`, '1');
+      setDismissed(`wm-update-dismissed-${version}`);
       toast.classList.remove('visible');
       setTimeout(() => toast.remove(), 300);
     };

--- a/src/components/CommunityWidget.ts
+++ b/src/components/CommunityWidget.ts
@@ -1,10 +1,11 @@
 import { t } from '@/services/i18n';
+import { getDismissed, setDismissed } from '@/utils/cross-domain-storage';
 
 const DISMISSED_KEY = 'wm-community-dismissed';
 const DISCUSSION_URL = 'https://github.com/koala73/worldmonitor/discussions/94';
 
 export function mountCommunityWidget(): void {
-  if (localStorage.getItem(DISMISSED_KEY) === 'true') return;
+  if (getDismissed(DISMISSED_KEY)) return;
   if (document.querySelector('.community-widget')) return;
 
   const widget = document.createElement('div');
@@ -27,7 +28,7 @@ export function mountCommunityWidget(): void {
   widget.querySelector('.cw-close')!.addEventListener('click', dismiss);
 
   widget.querySelector('.cw-dismiss')!.addEventListener('click', () => {
-    localStorage.setItem(DISMISSED_KEY, 'true');
+    setDismissed(DISMISSED_KEY);
     dismiss();
   });
 

--- a/src/components/MobileWarningModal.ts
+++ b/src/components/MobileWarningModal.ts
@@ -1,5 +1,6 @@
 import { t } from '@/services/i18n';
 import { isMobileDevice } from '@/utils';
+import { getDismissed, setDismissed } from '@/utils/cross-domain-storage';
 
 const STORAGE_KEY = 'mobile-warning-dismissed';
 
@@ -54,7 +55,7 @@ export class MobileWarningModal {
   private dismiss(): void {
     const checkbox = this.element.querySelector('#mobileWarningRemember') as HTMLInputElement;
     if (checkbox?.checked) {
-      localStorage.setItem(STORAGE_KEY, 'true');
+      setDismissed(STORAGE_KEY);
     }
     this.hide();
   }
@@ -68,7 +69,7 @@ export class MobileWarningModal {
   }
 
   public static shouldShow(): boolean {
-    if (localStorage.getItem(STORAGE_KEY) === 'true') return false;
+    if (getDismissed(STORAGE_KEY)) return false;
     return isMobileDevice();
   }
 

--- a/src/utils/cross-domain-storage.ts
+++ b/src/utils/cross-domain-storage.ts
@@ -1,0 +1,20 @@
+const COOKIE_DOMAIN = '.worldmonitor.app';
+const MAX_AGE_SECONDS = 365 * 24 * 60 * 60;
+
+function usesCookies(): boolean {
+  return location.hostname.endsWith('worldmonitor.app');
+}
+
+export function getDismissed(key: string): boolean {
+  if (usesCookies()) {
+    return document.cookie.split('; ').some((c) => c === `${key}=1`);
+  }
+  return localStorage.getItem(key) === '1' || localStorage.getItem(key) === 'true';
+}
+
+export function setDismissed(key: string): void {
+  if (usesCookies()) {
+    document.cookie = `${key}=1; domain=${COOKIE_DOMAIN}; path=/; max-age=${MAX_AGE_SECONDS}; SameSite=Lax; Secure`;
+  }
+  localStorage.setItem(key, '1');
+}

--- a/src/utils/layer-warning.ts
+++ b/src/utils/layer-warning.ts
@@ -1,10 +1,11 @@
 import { t } from '@/services/i18n';
+import { getDismissed, setDismissed } from '@/utils/cross-domain-storage';
 
 const DISMISS_KEY = 'wm-layer-warning-dismissed';
 let activeDialog: HTMLElement | null = null;
 
 export function showLayerWarning(threshold: number): void {
-  if (localStorage.getItem(DISMISS_KEY) === '1') return;
+  if (getDismissed(DISMISS_KEY)) return;
   if (activeDialog) return;
   if (window.self !== window.top) return;
   if (new URLSearchParams(window.location.search).get('alert') === 'false') return;
@@ -32,7 +33,7 @@ export function showLayerWarning(threshold: number): void {
 
   const close = () => {
     const cb = overlay.querySelector<HTMLInputElement>('.layer-warn-dismiss input');
-    if (cb?.checked) localStorage.setItem(DISMISS_KEY, '1');
+    if (cb?.checked) setDismissed(DISMISS_KEY);
     overlay.classList.add('layer-warn-out');
     setTimeout(() => { overlay.remove(); activeDialog = null; }, 200);
   };


### PR DESCRIPTION
## Summary
- Dialog "don't show again" preferences used `localStorage`, which is scoped per origin — dismissing on `www.worldmonitor.app` didn't carry over to `finance.worldmonitor.app` or other variants
- Added `cross-domain-storage.ts` utility that writes dismissal flags as cookies with `domain=.worldmonitor.app` (shared across all subdomains), falling back to localStorage for desktop/localhost
- Updated all 4 affected dialogs: MobileWarningModal, LayerWarning, CommunityWidget, DesktopUpdater

## Test plan
- [ ] Dismiss a dialog (e.g. mobile warning or community widget) on `www.worldmonitor.app`
- [ ] Navigate to `finance.worldmonitor.app` — verify the same dialog stays dismissed
- [ ] Verify cookies are set with `domain=.worldmonitor.app` in browser DevTools
- [ ] Verify desktop app still works (falls back to localStorage since hostname isn't `*.worldmonitor.app`)
- [ ] Verify localhost dev still works (same localStorage fallback)