### PR TITLE
fix(railway): omit dev deps to fix ETXTBSY build failure

### DIFF
--- a/railpack.json
+++ b/railpack.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://schema.railpack.com",
-  "deploy": {
-    "aptPackages": ["curl"]
+  "steps": {
+    "install": {
+      "commands": [
+        { "cmd": "npm ci --omit=dev" }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Override Railpack install step to use `npm ci --omit=dev`, preventing `@bufbuild/buf` postinstall from racing with binary extraction (`ETXTBSY`)
- Remove unused `curl` apt dependency (replaced by native Node.js HTTP in #1287)
- Eliminates 16 `EBADENGINE` warnings (packages requiring Node >=20 are all devDependencies)

## Test plan
- [ ] Redeploy `seed-crypto-quotes` on Railway and verify build succeeds
- [ ] Verify crypto quotes are seeded to Redis after deploy