### PR TITLE
fix(globe): disable CII Instability layer in 3D mode

### DIFF
--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -54,7 +54,7 @@ export const LAYER_REGISTRY: Record<keyof MapLayers, LayerDefinition> = {
   economic:                 def('economic',                 '&#128176;', 'economicCenters',          'Economic Centers'),
   minerals:                 def('minerals',                 '&#128142;', 'criticalMinerals',         'Critical Minerals'),
   gpsJamming:               def('gpsJamming',               '&#128225;', 'gpsJamming',               'GPS Jamming', ['flat', 'globe'], _desktop ? 'locked' : undefined),
-  ciiChoropleth:            def('ciiChoropleth',            '&#127758;', 'ciiChoropleth',            'CII Instability', ['flat', 'globe'], _desktop ? 'enhanced' : undefined),
+  ciiChoropleth:            def('ciiChoropleth',            '&#127758;', 'ciiChoropleth',            'CII Instability', ['flat'], _desktop ? 'enhanced' : undefined),
   dayNight:                 def('dayNight',                 '&#127763;', 'dayNight',                 'Day/Night', ['flat']),
   sanctions:                def('sanctions',                '&#128683;', 'sanctions',                'Sanctions', []),
   startupHubs:              def('startupHubs',              '&#128640;', 'startupHubs',              'Startup Hubs'),


### PR DESCRIPTION
## Summary
- Restrict CII Instability choropleth to flat map only — it currently wraps the entire globe incorrectly in 3D mode
- Can be re-enabled once the globe rendering is fixed

## Test plan
- [ ] Switch to 3D globe mode — verify CII Instability no longer appears in layer picker
- [ ] Switch to flat map mode — verify CII Instability still works normally