### PR TITLE
fix(railway): remove custom install step causing ENOENT builds

### DIFF
--- a/railpack.json
+++ b/railpack.json
@@ -1,10 +1,3 @@
 {
-  "$schema": "https://schema.railpack.com",
-  "steps": {
-    "install": {
-      "commands": [
-        { "cmd": "if [ -f package.json ]; then npm install --omit=dev; else echo 'No package.json, skipping install'; fi" }
-      ]
-    }
-  }
+  "$schema": "https://schema.railpack.com"
 }


### PR DESCRIPTION
## Summary
- Custom `steps.install.commands` in `railpack.json` runs **before** source files are copied into the build container ([railpack#211](https://github.com/railwayapp/railpack/issues/211))
- This caused `ENOENT: /app/package.json` on every Railway service (ais-relay, seed-crypto-quotes, etc.)
- Introduced in PR #1288 to work around `@bufbuild/buf` ETXTBSY, then modified in #1290
- Fix: revert to empty `railpack.json` — let Railpack's auto-detected install handle `npm install` with proper file ordering
- If ETXTBSY recurs, use `RAILPACK_INSTALL_COMMAND` env var per-service instead

## Root cause
```
railpack.json steps.install.commands → runs in build layer BEFORE source copy
→ /app/package.json doesn't exist yet → ENOENT → build fails
```

## Test plan
- [ ] Redeploy `ais-relay` — build should succeed, `ws` package installed
- [ ] Redeploy `seed-crypto-quotes` — build should succeed
- [ ] Verify no ETXTBSY regression from `@bufbuild/buf`