### PR TITLE
fix(satellites): remove dead filter patterns with no public TLEs

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1037,32 +1037,26 @@ const SAT_NAME_FILTERS = [
   /^WORLDVIEW/i, /^SKYSAT/i, /^PLEIADES/i, /^KOMPSAT/i,
   /^SAPPHIRE/i, /^PRAETORIAN/i,
   /^SENTINEL/i,
-  /^OFEK/i, /^EROS/i,
-  /^RISAT/i, /^CARTOSAT/i, /^EOS-0[1-9]/i,
-  /^IGS/i,
+  /^CARTOSAT/i,
   /^GOKTURK/i, /^RASAT/i,
-  /^CSO-/i, /^HELIOS/i,
-  /^LACROSSE/i, /^TOPAZ/i, /^USA[ -]?\d/i,
-  /^KONDOR/i, /^PERSONA/i, /^BARS-M/i, /^RESURS-P/i,
-  /^HISEA/i, /^SUPERVIEW/i, /^ZIYUAN/i,
+  /^USA[ -]?\d/i,
+  /^ZIYUAN/i,
 ];
 
 function satClassify(name) {
   const n = name.toUpperCase();
   let type = 'military';
-  if (/COSMO-SKYMED|TERRASAR|PAZ|SAR-LUPE|YAOGAN|RISAT|KONDOR|HISEA|CSO-/i.test(n)) type = 'sar';
-  else if (/WORLDVIEW|SKYSAT|PLEIADES|KOMPSAT|GAOFEN|JILIN|CARTOSAT|EOS-0|EROS|SUPERVIEW|ZIYUAN/i.test(n)) type = 'optical';
-  else if (/SAPPHIRE|PRAETORIAN|LACROSSE|TOPAZ|USA|IGS|OFEK|GOKTURK|PERSONA|BARS-M/i.test(n)) type = 'military';
+  if (/COSMO-SKYMED|TERRASAR|PAZ|SAR-LUPE|YAOGAN/i.test(n)) type = 'sar';
+  else if (/WORLDVIEW|SKYSAT|PLEIADES|KOMPSAT|GAOFEN|JILIN|CARTOSAT|ZIYUAN/i.test(n)) type = 'optical';
+  else if (/SAPPHIRE|PRAETORIAN|USA|GOKTURK/i.test(n)) type = 'military';
 
   let country = 'OTHER';
-  if (/^YAOGAN|^GAOFEN|^JILIN|^HISEA|^SUPERVIEW|^ZIYUAN/i.test(n)) country = 'CN';
-  else if (/^COSMOS|^KONDOR|^PERSONA|^BARS-M|^RESURS-P/i.test(n)) country = 'RU';
-  else if (/^WORLDVIEW|^SAPPHIRE|^PRAETORIAN|^LACROSSE|^TOPAZ|^USA|^SKYSAT/i.test(n)) country = 'US';
-  else if (/^SENTINEL|^COSMO-SKYMED|^TERRASAR|^SAR-LUPE|^PAZ|^PLEIADES|^CSO-|^HELIOS/i.test(n)) country = 'EU';
+  if (/^YAOGAN|^GAOFEN|^JILIN|^ZIYUAN/i.test(n)) country = 'CN';
+  else if (/^COSMOS/i.test(n)) country = 'RU';
+  else if (/^WORLDVIEW|^SAPPHIRE|^PRAETORIAN|^USA|^SKYSAT/i.test(n)) country = 'US';
+  else if (/^SENTINEL|^COSMO-SKYMED|^TERRASAR|^SAR-LUPE|^PAZ|^PLEIADES/i.test(n)) country = 'EU';
   else if (/^KOMPSAT/i.test(n)) country = 'KR';
-  else if (/^OFEK|^EROS/i.test(n)) country = 'IL';
-  else if (/^RISAT|^CARTOSAT|^EOS-0/i.test(n)) country = 'IN';
-  else if (/^IGS/i.test(n)) country = 'JP';
+  else if (/^CARTOSAT/i.test(n)) country = 'IN';
   else if (/^GOKTURK|^RASAT/i.test(n)) country = 'TR';
 
   return { type, country };

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -43,7 +43,7 @@ import type { ClimateAnomaly } from '@/services/climate';
 import type { GpsJamHex } from '@/services/gps-interference';
 import type { SatellitePosition } from '@/services/satellites';
 
-const SAT_COUNTRY_COLORS: Record<string, string> = { CN: '#ff2020', RU: '#ff8800', US: '#4488ff', EU: '#44cc44', KR: '#aa66ff', IL: '#00ccff', IN: '#ff66aa', JP: '#ffcc00', TR: '#ff4466', OTHER: '#ccccff' };
+const SAT_COUNTRY_COLORS: Record<string, string> = { CN: '#ff2020', RU: '#ff8800', US: '#4488ff', EU: '#44cc44', KR: '#aa66ff', IN: '#ff66aa', TR: '#ff4466', OTHER: '#ccccff' };
 
 // ─── Marker discriminated union ─────────────────────────────────────────────
 interface BaseMarker {


### PR DESCRIPTION
## Summary
- Remove 12 satellite name patterns that match zero entries in CelesTrak (OFEK, EROS, IGS, LACROSSE, TOPAZ, KONDOR, PERSONA, BARS-M, RESURS-P, HISEA, SUPERVIEW, CSO-, HELIOS, RISAT, EOS-0x)
- These are classified programs (Israel, Japan, US NRO) or use different catalog names (Russia → COSMOS 2xxx)
- Clean up satClassify() to remove dead classification branches
- Remove unused IL/JP country colors from globe

## Test plan
- [ ] `tsc --noEmit` passes
- [ ] Deploy relay → satellite count stays ~130+ (no regression — only dead patterns removed)
- [ ] `/api/health` satellites status remains OK