### PR TITLE
fix(sentry): add noise filters for 24 unresolved issues

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -216,6 +216,11 @@ Sentry.init({
     /Attempting to run\(\), but is already running/,
     /Out of range source coordinates for DEM data/,
     /Invalid character: '\\0'/,
+    /Failed to execute 'unobserve' on 'IntersectionObserver'/,
+    /WKErrorDomain/,
+    /Content-Length header of network response exceeds response Body/,
+    /^Uncaught \[object ErrorEvent\]$/,
+    /trsMethod\w+ is not defined/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';
@@ -236,6 +241,10 @@ Sentry.init({
       const hasSourceMapped = nonSentryFrames.some(f => /\.(ts|tsx)$/.test(f.filename ?? '') || /^src\//.test(f.filename ?? ''));
       if (!hasSourceMapped) return null;
     }
+    // Suppress minified Three.js/globe.gl crashes (e.g. "l is undefined" in raycast, "b is undefined" in update/initGlobe)
+    if (/^\w{1,2} is (?:undefined|not an object)$/.test(msg) && frames.length > 0) {
+      if (frames.some(f => /\/(main|index)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? '') && /(raycast|update|initGlobe|traverse|render)/.test(f.function ?? ''))) return null;
+    }
     // Suppress Three.js OrbitControls touch crashes (finger lifted during pinch-zoom)
     if (/undefined is not an object \(evaluating 't\.x'\)|Cannot read properties of undefined \(reading 'x'\)/.test(msg)) {
       const nonSentryFrames = frames.filter(f => f.filename && f.filename !== '<anonymous>' && !/\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename));
@@ -244,10 +253,12 @@ Sentry.init({
     }
     // Suppress deck.gl/maplibre null-access crashes with no usable stack trace (requestAnimationFrame wrapping)
     if (/null is not an object \(evaluating '\w{1,3}\.(id|type|style)'\)/.test(msg) && frames.length === 0) return null;
-    // Suppress TypeErrors from anonymous/injected scripts (no real source files)
-    if (/^TypeError:/.test(msg) && frames.length > 0 && frames.every(f => !f.filename || f.filename === '<anonymous>' || /^blob:/.test(f.filename))) return null;
-    // Suppress parentNode.insertBefore from injected scripts only (iOS WKWebView)
-    if (/parentNode\.insertBefore/.test(msg) && frames.every(f => !f.filename || f.filename === '<anonymous>' || /^blob:/.test(f.filename))) return null;
+    // Suppress TypeErrors from anonymous/injected scripts (no real source files or only inline page URL)
+    if (/^TypeError:/.test(msg) && frames.length > 0 && frames.every(f => !f.filename || f.filename === '<anonymous>' || /^blob:/.test(f.filename) || /^https?:\/\/[^/]+\/?$/.test(f.filename))) return null;
+    // Suppress parentNode.insertBefore from injected/inline scripts (iOS WKWebView, Apple Mail)
+    if (/parentNode\.insertBefore/.test(msg) && frames.every(f => !f.filename || f.filename === '<anonymous>' || /^blob:/.test(f.filename) || /^https?:\/\/[^/]+\/?$/.test(f.filename))) return null;
+    // Suppress Sentry breadcrumb DOM-measuring crashes (element.offsetWidth on detached DOM)
+    if (/evaluating '(?:element|e)\.offset(?:Width|Height)'/.test(msg) && frames.some(f => /\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     // Suppress errors originating entirely from blob: URLs (browser extensions)
     if (frames.length > 0 && frames.every(f => /^blob:/.test(f.filename ?? ''))) return null;
     // Suppress errors originating from UV proxy (Ultraviolet service worker)


### PR DESCRIPTION
## Summary
- Add 5 new `ignoreErrors` patterns: IntersectionObserver unobserve (WebView video injection), WKErrorDomain, Content-Length exceeds Body, ErrorEvent in worker, trsMethod extension injection
- Add `beforeSend` filter for minified Three.js/globe.gl crashes where message is just a single-letter variable name (e.g. "l is undefined") but stack shows `raycast`/`update`/`initGlobe` functions
- Widen anonymous/injected script filters to also match page-root URLs (`https://www.worldmonitor.app/`) used by Apple Mail and iOS WebView
- Add Sentry breadcrumb DOM-measuring crash filter (`offsetWidth` on detached element)
- All 24 issues resolved in Sentry with `inNextRelease: true`

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Pre-push hooks pass (typecheck, edge function tests, markdown lint, version sync)
- [ ] Monitor Sentry after deploy — resolved issues should not reappear