### PR TITLE
fix(ui): hide entire map-section during panel fullscreen (#829, #859)

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2511,6 +2511,7 @@ body.panel-resize-active iframe {
   z-index: 10000 !important;
   border-radius: 0 !important;
   margin: 0 !important;
+  visibility: visible !important;
 }
 
 .live-news-fullscreen .panel-content {
@@ -2527,11 +2528,20 @@ body.live-news-fullscreen-active {
   overflow: hidden;
 }
 
-body.live-news-fullscreen-active .time-slider,
-body.live-news-fullscreen-active .deckgl-layer-toggles,
-body.live-news-fullscreen-active .map-legend,
-body.live-news-fullscreen-active .map-controls,
-body.live-news-fullscreen-active .map-timestamp {
+/* Hide everything behind the fullscreen panel (#829, #859).
+   Previous attempts hid individual overlays (.layer-toggles, .map-legend, etc.)
+   but new elements kept slipping through. Hiding the entire map-section and
+   non-fullscreen panels is comprehensive and future-proof.
+   :not(.live-news-fullscreen) excludes the map-section itself when it is the
+   fullscreen element. For panels inside .map-bottom-grid that go fullscreen,
+   visibility: visible !important on .live-news-fullscreen overrides the
+   inherited hidden state, and position: fixed renders it independently. */
+body.live-news-fullscreen-active .map-section:not(.live-news-fullscreen) {
+  visibility: hidden !important;
+  pointer-events: none !important;
+}
+
+body.live-news-fullscreen-active .panels-grid > *:not(.live-news-fullscreen) {
   visibility: hidden !important;
   pointer-events: none !important;
 }
@@ -2548,17 +2558,7 @@ body.live-news-fullscreen-active #mapSection.live-news-fullscreen .map-container
 }
 
 body.live-news-fullscreen-active .community-widget {
-  display: none;
-}
-
-/* Hide map overlays and sibling panels behind fullscreen panel (#829, #859) */
-body.live-news-fullscreen-active .layer-toggles,
-body.live-news-fullscreen-active .map-legend {
   display: none !important;
-}
-
-body.live-news-fullscreen-active .panels-grid > *:not(.live-news-fullscreen) {
-  visibility: hidden !important;
 }
 
 .live-indicator-btn {


### PR DESCRIPTION
## Summary

- **Replaces fragile element-by-element overlay hiding with a single `.map-section` hide rule** that comprehensively covers the WebGL canvas, all overlays, controls, legend, layer toggles, bottom grid, and resize handle
- Adds `visibility: visible !important` to `.live-news-fullscreen` so fullscreen panels stay visible even when ancestors are hidden
- Uses `:not(.live-news-fullscreen)` guard to prevent map section from hiding itself when it is the fullscreen element
- Consolidates 3 redundant CSS rule blocks into clean, documented rules

## Context

Five previous PRs (#689, #708, #857, #887, #934) attempted to fix these issues by hiding individual overlay elements (`.layer-toggles`, `.map-legend`, `.deckgl-layer-toggles`, `.map-controls`, etc.), but new elements kept slipping through. This fix takes a different approach — hiding the entire `.map-section` container instead of chasing individual children.

## Scenarios verified with screenshots

| Scenario | Result |
|---|---|
| Live News panel fullscreen | Clean — no map overlays or panels visible |
| Live Webcams panel fullscreen | Clean — no map overlays or panels visible |
| Map section fullscreen (edge case) | Correct — map + controls visible, panels hidden |
| Exit fullscreen → normal state | Fully restored |

### Live News fullscreen
<img width="1200" height="834" alt="03-live-news-fullscreen" src="https://github.com/user-attachments/assets/42121add-eac8-4bac-ba6b-8c5c8bea63c3" />

### Live Webcams fullscreen
<img width="1200" height="834" alt="04-live-webcams-fullscreen" src="https://github.com/user-attachments/assets/0cea3196-f0d0-496c-9da4-435882ed6ddb" />

### Map fullscreen
<img width="1200" height="834" alt="05-map-fullscreen" src="https://github.com/user-attachments/assets/139c0c9f-ab92-4b81-890c-280158261a3b" />

## Test plan

- [x] Vite build succeeds
- [x] Pre-push hooks pass (typecheck, edge function tests, markdown lint, version sync)
- [x] Live News fullscreen: no map overlays, legend, layer toggles, or sibling panels visible
- [x] Live Webcams fullscreen: same clean fullscreen behavior
- [x] Map section fullscreen: map + its own controls visible, all panels hidden
- [x] Exiting fullscreen restores normal layout completely
- [ ] Manual test on Chromium, Firefox, Safari
- [ ] Manual test on Tauri desktop app

Closes #829
Closes #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)