### PR TITLE
fix: align CDN cache TTL with insights freshness threshold

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -62,7 +62,7 @@ const TIER_CACHE = {
 };
 const TIER_CDN_CACHE = {
   slow: 'public, s-maxage=7200, stale-while-revalidate=1800, stale-if-error=7200',
-  fast: 'public, s-maxage=1200, stale-while-revalidate=300, stale-if-error=1800',
+  fast: 'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',
 };
 
 const NEG_SENTINEL = '__WM_NEG__';


### PR DESCRIPTION
## Summary
- Reduces `CDN-Cache-Control` for fast-tier bootstrap from 20min+5min SWR to 10min+2min SWR
- Aligns with `insights-loader.ts` `MAX_AGE_MS` (15min) so CF revalidates before the client rejects server insights as stale

## Problem
CF could serve bootstrap responses up to 25 min old. `insights-loader.ts` rejects insights older than 15 min. This 10-min gap caused frequent fallback to the slow 4-step client-side AI pipeline (LLM call + browser ML), adding unnecessary latency and cost.

## Test plan
- [x] All 100 edge function tests pass
- [ ] After deploy, verify insights panel shows "LIVE" without the 4-step progress bar on web
- [ ] Monitor CF cache hit ratio — slightly lower but within acceptable range