### PR TITLE
fix: support WebKit fullscreen exit on variant switch

### DIFF
--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -665,10 +665,25 @@ export class EventHandlerManager implements AppModule {
     }, 1500);
   }
 
+  private getFullscreenDocument(): Document & {
+    webkitFullscreenElement?: Element | null;
+    webkitExitFullscreen?: () => Promise<void> | void;
+  } {
+    return document as Document & {
+      webkitFullscreenElement?: Element | null;
+      webkitExitFullscreen?: () => Promise<void> | void;
+    };
+  }
+
   private async exitFullscreenForNavigation(): Promise<void> {
-    if (!document.fullscreenElement) return;
+    const fullscreenDocument = this.getFullscreenDocument();
+    if (!fullscreenDocument.fullscreenElement && !fullscreenDocument.webkitFullscreenElement) return;
     try {
-      await document.exitFullscreen?.();
+      if (typeof fullscreenDocument.exitFullscreen === 'function') {
+        await fullscreenDocument.exitFullscreen();
+        return;
+      }
+      await fullscreenDocument.webkitExitFullscreen?.();
     } catch { /* proceed with navigation regardless */ }
   }
 
@@ -690,8 +705,14 @@ export class EventHandlerManager implements AppModule {
   }
 
   toggleFullscreen(): void {
-    if (document.fullscreenElement) {
-      try { void document.exitFullscreen()?.catch(() => { }); } catch { }
+    const fullscreenDocument = this.getFullscreenDocument();
+    if (fullscreenDocument.fullscreenElement || fullscreenDocument.webkitFullscreenElement) {
+      try {
+        const exitResult = typeof fullscreenDocument.exitFullscreen === 'function'
+          ? fullscreenDocument.exitFullscreen()
+          : fullscreenDocument.webkitExitFullscreen?.();
+        void Promise.resolve(exitResult).catch(() => { });
+      } catch { }
     } else {
       const el = document.documentElement as HTMLElement & { webkitRequestFullscreen?: () => void };
       if (el.requestFullscreen) {


### PR DESCRIPTION
## Summary
- support WebKit fullscreen exit when leaving fullscreen for variant navigation
- reuse the same fallback in toggleFullscreen() so enter/exit behavior stays symmetrical
- fix the Safari/WebKit path introduced by the recent fullscreen-before-navigation change

## Verification
- npm run typecheck
- push hook checks passed (typecheck, typecheck:api, edge function checks/tests, markdown lint, version check)
