### PR TITLE
fix(cache): align CDN and client TTLs with freshness thresholds

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -47,13 +47,13 @@ const SLOW_KEYS = new Set([
   'bisPolicy', 'bisExchange', 'bisCredit', 'minerals', 'giving',
   'sectors', 'etfFlows', 'shippingRates', 'wildfires', 'climateAnomalies',
   'cyberThreats', 'techReadiness', 'progressData', 'renewableEnergy',
-  'theaterPosture', 'naturalEvents',
+  'naturalEvents',
   'cryptoQuotes', 'gulfQuotes', 'stablecoinMarkets', 'unrestEvents', 'ucdpEvents',
 ]);
 const FAST_KEYS = new Set([
   'earthquakes', 'outages', 'serviceStatuses', 'macroSignals', 'chokepoints',
   'marketQuotes', 'commodityQuotes', 'positiveGeoEvents', 'riskScores', 'flightDelays','insights', 'predictions',
-  'iranEvents', 'temporalAnomalies', 'weatherAlerts', 'spending',
+  'iranEvents', 'temporalAnomalies', 'weatherAlerts', 'spending', 'theaterPosture',
 ]);
 
 const TIER_CACHE = {

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -46,7 +46,7 @@ export const BOOTSTRAP_TIERS: Record<string, 'slow' | 'fast'> = {
   progressData: 'slow', renewableEnergy: 'slow',
   etfFlows: 'slow', shippingRates: 'slow', wildfires: 'slow',
   climateAnomalies: 'slow', cyberThreats: 'slow', techReadiness: 'slow',
-  theaterPosture: 'slow', naturalEvents: 'slow',
+  theaterPosture: 'fast', naturalEvents: 'slow',
   cryptoQuotes: 'slow', gulfQuotes: 'slow', stablecoinMarkets: 'slow',
   unrestEvents: 'slow', ucdpEvents: 'slow',
   earthquakes: 'fast', outages: 'fast', serviceStatuses: 'fast',

--- a/src/services/cached-risk-scores.ts
+++ b/src/services/cached-risk-scores.ts
@@ -137,7 +137,7 @@ function isValidCiiEntry(e: unknown): e is CachedCIIScore {
 // ---- localStorage persistence (sync prime for getCachedScores) ----
 
 const LS_KEY = 'wm:risk-scores';
-const LS_MAX_STALENESS_MS = 24 * 60 * 60 * 1000;
+const LS_MAX_STALENESS_MS = 60 * 60 * 1000;
 
 function loadFromStorage(): CachedRiskScores | null {
   try {
@@ -170,7 +170,7 @@ function saveToStorage(data: CachedRiskScores): void {
 
 const breaker = createCircuitBreaker<CachedRiskScores>({
   name: 'Risk Scores',
-  cacheTtlMs: 5 * 60 * 1000, // 5 min
+  cacheTtlMs: 30 * 60 * 1000,
   persistCache: true,
 });
 


### PR DESCRIPTION
## Summary
- Move `theaterPosture` from SLOW tier (2h CDN) to FAST tier (20min CDN, 10min after PR #1314) so military posture data stays fresh relative to the 15min client breaker
- Increase risk scores circuit breaker TTL from 5min to 30min to match `health.js` `maxStaleMin`, reducing unnecessary RPC refetches
- Reduce risk scores localStorage staleness from 24h to 1h to prevent UI from showing day-old CII data

## Files changed
- `api/bootstrap.js` — `theaterPosture` SLOW_KEYS → FAST_KEYS
- `server/_shared/cache-keys.ts` — tier map updated to match
- `src/services/cached-risk-scores.ts` — breaker TTL 5min → 30min, LS staleness 24h → 1h

## Intentionally NOT changed
- **Market quotes breakers** (`cacheTtlMs: 0`): shared across different symbol sets, adding TTL would return wrong symbols. Needs per-symbol-set keying first.
- **Weather alerts**: 30min client breaker accepted as-is.
- **Persistent cache ceiling** (24h IndexedDB in `circuit-breaker.ts`): global constant, per-breaker ceiling is a separate task.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `node --test tests/edge-functions.test.mjs` — 100/100 pass
- [x] grep confirms `theaterPosture` in FAST_KEYS and tier map
- [x] grep confirms 30min breaker TTL and 1h LS staleness
- [ ] Post-deploy: verify `bootstrap?tier=fast` response includes `theaterPosture`
- [ ] Rollback trigger: theater posture absent from fast bootstrap, or risk scores show stale panel data