### PR TITLE
fix(cii): add Cuba to risk scoring pipeline

### DIFF
--- a/server/worldmonitor/intelligence/v1/_shared.ts
+++ b/server/worldmonitor/intelligence/v1/_shared.ts
@@ -19,6 +19,7 @@ export const TIER1_COUNTRIES: Record<string, string> = {
   IL: 'Israel', TW: 'Taiwan', KP: 'North Korea', SA: 'Saudi Arabia', TR: 'Turkey',
   PL: 'Poland', DE: 'Germany', FR: 'France', GB: 'United Kingdom', IN: 'India',
   PK: 'Pakistan', SY: 'Syria', YE: 'Yemen', MM: 'Myanmar', VE: 'Venezuela',
+  CU: 'Cuba',
 };
 
 // ========================================================================

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -19,13 +19,13 @@ import { fetchAcledCached } from '../../../_shared/acled';
 const BASELINE_RISK: Record<string, number> = {
   US: 5, RU: 35, CN: 25, UA: 50, IR: 40, IL: 45, TW: 30, KP: 45,
   SA: 20, TR: 25, PL: 10, DE: 5, FR: 10, GB: 5, IN: 20, PK: 35,
-  SY: 50, YE: 50, MM: 45, VE: 40,
+  SY: 50, YE: 50, MM: 45, VE: 40, CU: 45,
 };
 
 const EVENT_MULTIPLIER: Record<string, number> = {
   US: 0.3, RU: 2.0, CN: 2.5, UA: 0.8, IR: 2.0, IL: 0.7, TW: 1.5, KP: 3.0,
   SA: 2.0, TR: 1.2, PL: 0.8, DE: 0.5, FR: 0.6, GB: 0.5, IN: 0.8, PK: 1.5,
-  SY: 0.7, YE: 0.7, MM: 1.8, VE: 1.8,
+  SY: 0.7, YE: 0.7, MM: 1.8, VE: 1.8, CU: 2.0,
 };
 
 const COUNTRY_KEYWORDS: Record<string, string[]> = {
@@ -49,6 +49,7 @@ const COUNTRY_KEYWORDS: Record<string, string[]> = {
   YE: ['yemen', 'sanaa', 'houthi'],
   MM: ['myanmar', 'burma'],
   VE: ['venezuela', 'caracas', 'maduro'],
+  CU: ['cuba', 'havana', 'diaz-canel'],
 };
 
 const COUNTRY_BBOX: Record<string, { minLat: number; maxLat: number; minLon: number; maxLon: number }> = {
@@ -72,13 +73,14 @@ const COUNTRY_BBOX: Record<string, { minLat: number; maxLat: number; minLon: num
   YE: { minLat: 12.1, maxLat: 19.0, minLon: 42.5, maxLon: 54.5 },
   MM: { minLat: 9.8, maxLat: 28.5, minLon: 92.2, maxLon: 101.2 },
   VE: { minLat: 0.6, maxLat: 12.2, minLon: -73.4, maxLon: -59.8 },
+  CU: { minLat: 19.8, maxLat: 23.3, minLon: -85.0, maxLon: -74.1 },
 };
 
 const ZONE_COUNTRY_MAP: Record<string, string[]> = {
   'North America': ['US'], 'Europe': ['DE', 'FR', 'GB', 'PL', 'TR', 'UA'],
   'East Asia': ['CN', 'TW', 'KP'], 'South Asia': ['IN', 'PK', 'MM'],
   'Middle East': ['IR', 'IL', 'SA', 'SY', 'YE'], 'Russia': ['RU'],
-  'Latin America': ['VE'],
+  'Latin America': ['VE', 'CU'],
 };
 
 // ========================================================================

--- a/src/config/countries.ts
+++ b/src/config/countries.ts
@@ -217,6 +217,13 @@ export const CURATED_COUNTRIES: Record<string, CuratedCountryConfig> = {
     baselineRisk: 15,
     eventMultiplier: 1.0,
   },
+  CU: {
+    name: 'Cuba',
+    scoringKeywords: ['cuba', 'cuban', 'havana', 'diaz-canel'],
+    searchAliases: ['cuba', 'cuban', 'havana', 'diaz-canel', 'canel'],
+    baselineRisk: 45,
+    eventMultiplier: 2.0,
+  },
 };
 
 export const TIER1_COUNTRIES: Record<string, string> = {
@@ -243,6 +250,7 @@ export const TIER1_COUNTRIES: Record<string, string> = {
   BR: 'Brazil',
   AE: 'United Arab Emirates',
   MX: 'Mexico',
+  CU: 'Cuba',
 };
 
 export const DEFAULT_BASELINE_RISK = 15;
@@ -253,7 +261,7 @@ export const HOTSPOT_COUNTRY_MAP: Record<string, string | string[]> = {
   telaviv: 'IL', pyongyang: 'KP', sanaa: 'YE', riyadh: 'SA', ankara: 'TR',
   damascus: 'SY', caracas: 'VE', dc: 'US', london: 'GB',
   brussels: 'BE', baghdad: 'IQ', beirut: 'LB', doha: 'QA', abudhabi: 'AE',
-  mexico: 'MX', nuuk: 'GL', sahel: ['ML', 'NE', 'BF'], haiti: 'HT',
+  mexico: 'MX', havana: 'CU', nuuk: 'GL', sahel: ['ML', 'NE', 'BF'], haiti: 'HT',
   horn_africa: ['ET', 'SO', 'SD'], silicon_valley: 'US', wall_street: 'US',
   houston: 'US', cairo: 'EG',
 };


### PR DESCRIPTION
## Summary
- Cuba is experiencing a severe humanitarian crisis (grid collapse, 20h+ daily blackouts, pot-banging protests across Havana, UN "collapse" warning) but was completely invisible on WorldMonitor
- Root cause: Cuba (CU) was absent from `TIER1_COUNTRIES`, `CURATED_COUNTRIES`, and all server-side scoring configs
- Added Cuba with baseline risk **45** and event multiplier **2.0** (comparable to Myanmar/Venezuela)

## Changes
- `server/.../intelligence/v1/_shared.ts`: Added `CU: 'Cuba'` to `TIER1_COUNTRIES`
- `server/.../intelligence/v1/get-risk-scores.ts`: Added Cuba to `BASELINE_RISK` (45), `EVENT_MULTIPLIER` (2.0), `COUNTRY_KEYWORDS`, `COUNTRY_BBOX`, and `ZONE_COUNTRY_MAP` (Latin America)
- `src/config/countries.ts`: Added Cuba to `CURATED_COUNTRIES` (with scoring keywords, search aliases), `TIER1_COUNTRIES`, and `HOTSPOT_COUNTRY_MAP`

## Context
As of March 2026, Cuba faces:
- Near-total electric grid collapse (deficit ~2,000 MW, blackouts 20+ hours/day)
- Active protests (pot-banging demonstrations across Havana, March 7-8)
- GDP down 4% in 2025, average salary ~$13/month
- UN warning of humanitarian "collapse" if oil shipments don't arrive
- US seized Venezuelan oil tankers bound for Cuba

## Test plan
- [ ] Deploy to staging, verify Cuba appears in CII panel
- [ ] Verify ACLED protest/unrest events for Cuba are aggregated into score
- [ ] Verify Cuba risk score reflects current crisis (~45+ baseline before events)
- [ ] `npx tsc --noEmit` passes
- [ ] `npx tsc --noEmit -p tsconfig.api.json` passes