### PR TITLE
fix(sentry): filter 'Identifier element already declared' noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -192,7 +192,7 @@ Sentry.init({
     /Can't find variable: caches/,
     /crypto\.randomUUID is not a function/,
     /ucapi is not defined/,
-    /Identifier '(?:script|reportPage)' has already been declared/,
+    /Identifier '(?:script|reportPage|element)' has already been declared/,
     /getAttribute is not a function.*getAttribute\("role"\)/,
     /^TypeError: Internal error$/,
     /SCDynimacBridge/,


### PR DESCRIPTION
## Summary
- Extends existing `ignoreErrors` regex to include `element` alongside `script` and `reportPage`

## Context
WORLDMONITOR-2D: `SyntaxError: Identifier 'element' has already been declared` (78 events, 39 users). Stack trace points to `index.html` line 1, col 1 from Electron 39.7.0 on Linux. This is an injected script collision, not our code.

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Verify error stops appearing in Sentry after deploy