### PR TITLE
fix(docker): restore server/ in build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,6 @@ coverage
 .DS_Store
 
 src-tauri
-server
 e2e
 scripts
 docs


### PR DESCRIPTION
## Summary
- Removes `server` from `.dockerignore` to fix Docker build failure

`vite.config.ts` imports from `./server/` at config load time (Vercel dev middleware plugin). Excluding `server/` broke the Docker build with 25 "Could not resolve" errors.

This was introduced by #1309 per a review suggestion that didn't account for the Vite config dependency.

## Test plan
- [ ] Docker build completes: `docker build -t worldmonitor:test .`