### PR TITLE
fix: resolve Tech/Finance map rendering by adding external tab switcher

### DIFF
--- a/pro-test/src/App.tsx
+++ b/pro-test/src/App.tsx
@@ -408,7 +408,7 @@ const WhyUpgrade = () => {
 };
 
 /* ─── 5. Live Dashboard Embed (current) ─── */
-const LivePreview = () => (
+const LivePreview = () => { const [activeTab, setActiveTab] = useState<'world'|'tech'|'finance'>('world'); const tabSrc = activeTab === 'tech' ? 'https://tech.worldmonitor.app?alert=false' : activeTab === 'finance' ? 'https://finance.worldmonitor.app?alert=false' : 'https://worldmonitor.app?alert=false'; return (
   <section className="px-6 py-16">
     <div className="max-w-6xl mx-auto">
       <div className="relative rounded-lg overflow-hidden border border-wm-border shadow-2xl shadow-wm-green/5">
@@ -428,14 +428,14 @@ const LivePreview = () => (
             {t('livePreview.openFullScreen')} <ExternalLink className="w-3 h-3" aria-hidden="true" />
           </a>
         </div>
-        <div className="relative aspect-[16/9] bg-black">
+        <div className="flex gap-2 mb-2"><button onClick={() => setActiveTab('world')} className={`px-3 py-1 text-xs font-mono rounded border ${activeTab === 'world' ? 'border-wm-green text-wm-green bg-wm-green/10' : 'border-wm-border text-wm-muted hover:border-wm-text'}`}>World</button><button onClick={() => setActiveTab('tech')} className={`px-3 py-1 text-xs font-mono rounded border ${activeTab === 'tech' ? 'border-wm-green text-wm-green bg-wm-green/10' : 'border-wm-border text-wm-muted hover:border-wm-text'}`}>Tech</button><button onClick={() => setActiveTab('finance')} className={`px-3 py-1 text-xs font-mono rounded border ${activeTab === 'finance' ? 'border-wm-green text-wm-green bg-wm-green/10' : 'border-wm-border text-wm-muted hover:border-wm-text'}`}>Finance</button></div><div className="flex gap-2 mb-2"><button onClick={() => setActiveTab('world')} className={`px-3 py-1 text-xs font-mono rounded border ${activeTab === 'world' ? 'border-wm-green text-wm-green bg-wm-green/10' : 'border-wm-border text-wm-muted hover:border-wm-text'}`}>World</button><button onClick={() => setActiveTab('tech')} className={`px-3 py-1 text-xs font-mono rounded border ${activeTab === 'tech' ? 'border-wm-green text-wm-green bg-wm-green/10' : 'border-wm-border text-wm-muted hover:border-wm-text'}`}>Tech</button><button onClick={() => setActiveTab('finance')} className={`px-3 py-1 text-xs font-mono rounded border ${activeTab === 'finance' ? 'border-wm-green text-wm-green bg-wm-green/10' : 'border-wm-border text-wm-muted hover:border-wm-text'}`}>Finance</button></div><div className="relative aspect-[16/9] bg-black">
           <img
             src={dashboardFallback}
             alt="World Monitor Dashboard"
             className="absolute inset-0 w-full h-full object-cover"
           />
           <iframe
-            src="https://worldmonitor.app?alert=false"
+            src={tabSrc}
             title={t('livePreview.iframeTitle')}
             className="relative w-full h-full border-0"
             loading="lazy"
@@ -460,6 +460,7 @@ const LivePreview = () => (
     </div>
   </section>
 );
+                           };
 
 /* ─── 6. Source Marquee (current) ─── */
 const SourceMarquee = () => {


### PR DESCRIPTION
Fixes #1322

## Problem
The Tech and Finance map tabs in the Live Dashboard section were not rendering. When a user clicked the Tech or Finance tab inside the embedded iframe, the iframe attempted to navigate to a different subdomain (tech.worldmonitor.app or finance.worldmonitor.app), which was blocked by the iframe's sandbox restrictions.

## Solution
This PR implements a two-part fix:

1. **Sandbox permissions** (previous commit): Added `allow-popups`, `allow-popups-to-escape-sandbox`, and `allow-top-navigation-by-user-activation` to the iframe sandbox attribute.

2. **External tab switcher** (this commit): Converted `LivePreview` from a static component to a stateful one with external World/Tech/Finance buttons rendered *outside* the iframe. Clicking a tab updates the iframe `src` directly to the appropriate subdomain, bypassing in-frame navigation entirely and making the fix bulletproof.

## Changes
- `pro-test/src/App.tsx`: Refactored `LivePreview` to use `useState`, added tab switcher UI, made iframe `src` dynamic based on active tab.