### PR TITLE
fix(railway): remove railpack.json to restore Nixpacks builds

### DIFF
--- a/railpack.json
+++ b/railpack.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://schema.railpack.com"
-}


### PR DESCRIPTION
## Summary
- Removes `railpack.json` from repo root — this file forces Railway to use Railpack builder for ALL services, overriding per-service builder settings
- Railpack's runtime container doesn't include `scripts/` directory, causing `Cannot find module '/app/scripts/ais-relay.cjs'` at startup
- **Emergency fix**: ais-relay and other Railway services are down

## Root cause
`railpack.json` at repo root → Railway auto-detects and uses Railpack → runtime image missing scripts → all Node.js services crash

## Test plan
- [ ] Railway services rebuild with Nixpacks after merge
- [ ] ais-relay starts successfully