### PR TITLE
fix(map): guard MapLibre against missing container + remove link icon

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -532,8 +532,11 @@ export class DeckGLMap {
       if (attr) attr.innerHTML = '© <a href="https://openfreemap.org" target="_blank" rel="noopener">OpenFreeMap</a> © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a>';
     }
 
+    const basemapEl = document.getElementById('deckgl-basemap');
+    if (!basemapEl) return;
+
     this.maplibreMap = new maplibregl.Map({
-      container: 'deckgl-basemap',
+      container: basemapEl,
       style: primaryStyle,
       center: [preset.longitude, preset.latitude],
       zoom: preset.zoom,
@@ -558,8 +561,10 @@ export class DeckGLMap {
       const attr = this.container.querySelector('.map-attribution');
       if (attr) attr.innerHTML = '© <a href="https://openfreemap.org" target="_blank" rel="noopener">OpenFreeMap</a> © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a>';
       this.maplibreMap?.remove();
+      const fallbackEl = document.getElementById('deckgl-basemap');
+      if (!fallbackEl) return;
       this.maplibreMap = new maplibregl.Map({
-        container: 'deckgl-basemap',
+        container: fallbackEl,
         style: fallback,
         center: [preset.longitude, preset.latitude],
         zoom: preset.zoom,

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -747,7 +747,7 @@ export class LiveNewsPanel extends Panel {
   }
 
   private getChannelDisplayName(channel: LiveChannel): string {
-    return channel.hlsUrl && !channel.handle ? `${channel.name} 🔗` : channel.name;
+    return channel.name;
   }
 
   /** Creates a single channel tab button with click and drag handlers. */


### PR DESCRIPTION
## Summary

- Guard both `new maplibregl.Map()` calls in DeckGLMap against missing `#deckgl-basemap` element. Prevents crash when `destroy()` is called while MapLibre init or fallback recreation is still pending (Sentry WORLDMONITOR-FM).
- Remove link emoji from HLS-only channel tabs in LiveNewsPanel. All tabs now show just the channel name.

## Test plan

- [ ] Load the map, switch views rapidly, verify no "Container not found" errors
- [ ] Open Live News panel, verify no link icons on any channel tab (including RUDAW)