### PR TITLE
fix(globe): correct satellite beam coordinate system to match globe.gl

### DIFF
--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -2094,14 +2094,15 @@ export class GlobeMap {
   }
 
   private static latLngAltToVec3(lat: number, lng: number, alt: number, vec3Ctor: any): any {
-    const R = 1;
-    const r = R + alt / 6371;
+    const GLOBE_R = 100;
+    const r = GLOBE_R * (1 + alt / 6371);
     const phi = (90 - lat) * (Math.PI / 180);
-    const theta = (lng + 180) * (Math.PI / 180);
+    const theta = (90 - lng) * (Math.PI / 180);
+    const sinPhi = Math.sin(phi);
     return new vec3Ctor(
-      -r * Math.sin(phi) * Math.cos(theta),
+      r * sinPhi * Math.cos(theta),
       r * Math.cos(phi),
-      r * Math.sin(phi) * Math.sin(theta),
+      r * sinPhi * Math.sin(theta),
     );
   }
 
@@ -2128,7 +2129,7 @@ export class GlobeMap {
     };
 
     const RAY_COUNT = 8;
-    const GROUND_SPREAD_RAD = 0.018;
+    const GROUND_SPREAD_RAD = 1.8;
 
     const allRayPositions: number[] = [];
     const allRayColors: number[] = [];
@@ -2159,7 +2160,7 @@ export class GlobeMap {
           .copy(groundCenter)
           .addScaledVector(right, Math.cos(angle) * GROUND_SPREAD_RAD)
           .addScaledVector(forward, Math.sin(angle) * GROUND_SPREAD_RAD)
-          .normalize();
+          .normalize().multiplyScalar(100);
         groundPts.push(gp);
         allRayPositions.push(satPos.x, satPos.y, satPos.z, gp.x, gp.y, gp.z);
         allRayColors.push(r, g, b, r, g, b);


### PR DESCRIPTION
## Summary
- Fix satellite beam coordinates: `GLOBE_R = 100` (was 1), `theta = (90 - lng)` (was `lng + 180`)
- Fix ground spread radius from `0.018` to `1.8` and normalize ground points to globe surface (`multiplyScalar(100)`)
- Without this fix, beams were invisible due to coordinate system mismatch with globe.gl internals

## Context
The coordinate fix from PR #1342 was committed after the PR was already merged, so the fix never made it to main.

## Test plan
- [ ] Enable satellites layer on 3D globe
- [ ] Verify beam/ray lines render from satellite positions down to the ground
- [ ] Verify beams are color-coded by satellite country