### PR TITLE
feat(ui): add live count badge to news and webcam panels

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -364,6 +364,7 @@ export class LiveNewsPanel extends Panel {
 
   constructor() {
     super({ id: 'live-news', title: t('panels.liveNews'), className: 'panel-wide' });
+    this.insertLiveCountBadge(OPTIONAL_LIVE_CHANNELS.length);
     this.youtubeOrigin = LiveNewsPanel.resolveYouTubeOrigin();
     this.playerElementId = `live-news-player-${Date.now()}`;
     this.channels = loadChannelsFromStorage();

--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -100,6 +100,7 @@ export class LiveWebcamsPanel extends Panel {
 
   constructor() {
     super({ id: 'live-webcams', title: t('panels.liveWebcams'), className: 'panel-wide' });
+    this.insertLiveCountBadge(WEBCAM_FEEDS.length);
 
     // Mobile: force single-cam view. 4 iframes at once is a battery + performance disaster.
     if (this.forceSingleView) {

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -632,6 +632,16 @@ export class Panel {
     if (!this.statusBadgeEl) return;
     this.statusBadgeEl.style.display = 'none';
   }
+
+  protected insertLiveCountBadge(count: number): void {
+    const headerLeft = this.header.querySelector('.panel-header-left');
+    if (!headerLeft) return;
+    const badge = document.createElement('span');
+    badge.className = 'panel-live-count';
+    badge.textContent = `${count} live`;
+    headerLeft.appendChild(badge);
+  }
+
   public getElement(): HTMLElement {
     return this.element;
   }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9410,6 +9410,32 @@ a.prediction-link:hover {
   white-space: nowrap;
 }
 
+.panel-live-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--semantic-critical);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.panel-live-count::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--semantic-critical);
+  animation: live-dot-pulse 2s ease-in-out infinite;
+}
+
+@keyframes live-dot-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
 .panel-new-badge.pulse {
   animation: badge-pulse 1.5s ease-in-out infinite;
 }


### PR DESCRIPTION
## Summary
- Adds a pulsing red dot + count badge to Live News and Live Webcams panel headers (e.g. "● 83 LIVE", "● 28 LIVE")
- Communicates total available channels/feeds beyond what's visible on screen
- Inspired by intel cam UI pattern showing depth of content

## Test plan
- [ ] Verify Live News header shows "● 83 LIVE" badge after the title
- [ ] Verify Live Webcams header shows "● 28 LIVE" badge after the title
- [ ] Verify red dot pulses smoothly
- [ ] Check mobile layout doesn't break with the extra badge