### PR TITLE
fix(globe): satellite beams stay visible when Orbital Surveillance layer toggled off

### DIFF
--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -2201,6 +2201,7 @@ export class GlobeMap {
       this.satBeamGroup.add(new THREE.Mesh(coneGeo, coneMat));
     }
 
+    this.satBeamGroup.visible = !!this.layers.satellites;
     scene.add(this.satBeamGroup);
   }
 


### PR DESCRIPTION
## Summary

- Satellite beams (THREE.js LineSegments/Mesh) remained visible when toggling the Orbital Surveillance layer off because `rebuildSatBeams()` always added the beam group with default visibility (`true`), ignoring the current layer state.

## Root cause

`rebuildSatBeams()` is called on every periodic satellite position update via `setSatellites()`. It removes the old beam group from the scene, creates a new one, and adds it back. The new group defaults to `visible: true`, overriding the `visible = false` set by `setLayers()` when the toggle was turned off.

## Fix

Set `this.satBeamGroup.visible = !!this.layers.satellites` before adding the group to the scene, so it respects the current layer toggle state.

## Test plan

- [ ] Toggle Orbital Surveillance ON, verify beams and dots appear
- [ ] Toggle OFF, verify both beams AND dots disappear
- [ ] Wait for a satellite position update cycle, verify beams stay hidden while layer is off
- [ ] Toggle back ON, verify beams reappear