### PR TITLE
fix(scoring): CII scoring followups from #1351 review

### DIFF
--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -52,7 +52,7 @@ const COUNTRY_KEYWORDS: Record<string, string[]> = {
   CU: ['cuba', 'havana', 'diaz-canel'],
   MX: ['mexico', 'mexican', 'sheinbaum', 'cartel', 'sinaloa'],
   BR: ['brazil', 'brasilia', 'lula'],
-  AE: ['uae', 'emirates', 'dubai', 'abu dhabi'],
+  AE: ['uae', 'emirates', 'dubai', 'abu dhabi', 'united arab emirates'],
 };
 
 const COUNTRY_BBOX: Record<string, { minLat: number; maxLat: number; minLon: number; maxLon: number }> = {
@@ -107,10 +107,14 @@ function normalizeCountryName(text: string): string | null {
   return null;
 }
 
+const BBOX_BY_AREA = Object.entries(COUNTRY_BBOX)
+  .map(([code, b]) => ({ code, ...b, area: (b.maxLat - b.minLat) * (b.maxLon - b.minLon) }))
+  .sort((a, b) => a.area - b.area);
+
 function geoToCountry(lat: number, lon: number): string | null {
   if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
-  for (const [code, bbox] of Object.entries(COUNTRY_BBOX)) {
-    if (lat >= bbox.minLat && lat <= bbox.maxLat && lon >= bbox.minLon && lon <= bbox.maxLon) return code;
+  for (const b of BBOX_BY_AREA) {
+    if (lat >= b.minLat && lat <= b.maxLat && lon >= b.minLon && lon <= b.maxLon) return b.code;
   }
   return null;
 }
@@ -275,7 +279,7 @@ export function computeCIIScores(
     const sev = String(o.severity || '').toUpperCase();
     if (sev.includes('TOTAL') || sev === 'NATIONWIDE') data[code].outageTotalCount++;
     else if (sev.includes('MAJOR') || sev === 'REGIONAL') data[code].outageMajorCount++;
-    else data[code].outagePartialCount++;
+    else if (sev.includes('PARTIAL') || sev.includes('LOCAL') || sev.includes('MINOR')) data[code].outagePartialCount++;
   }
 
   // --- Climate ---

--- a/src/services/cached-risk-scores.ts
+++ b/src/services/cached-risk-scores.ts
@@ -54,6 +54,7 @@ const TIER1_NAMES: Record<string, string> = {
   IL: 'Israel', TW: 'Taiwan', KP: 'North Korea', SA: 'Saudi Arabia', TR: 'Turkey',
   PL: 'Poland', DE: 'Germany', FR: 'France', GB: 'United Kingdom', IN: 'India',
   PK: 'Pakistan', SY: 'Syria', YE: 'Yemen', MM: 'Myanmar', VE: 'Venezuela',
+  CU: 'Cuba', MX: 'Mexico', BR: 'Brazil', AE: 'United Arab Emirates',
 };
 
 const TREND_REVERSE: Record<string, 'rising' | 'stable' | 'falling'> = {

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -153,6 +153,16 @@ describe('CII scoring', () => {
     }
   });
 
+  it('UAE geo events attributed to AE not SA despite bbox overlap', () => {
+    const aux = emptyAux();
+    aux.gpsHexes = [{ lat: 25.2, lon: 55.3, level: 'high' }];
+    const scores = computeCIIScores([], aux);
+    const ae = scoreFor(scores, 'AE')!;
+    const sa = scoreFor(scores, 'SA')!;
+    assert.ok(ae.components!.militaryActivity > 0, 'AE should get the Dubai GPS hex');
+    assert.equal(sa.components!.militaryActivity, 0, 'SA should not get the Dubai GPS hex');
+  });
+
   it('empty data returns baseline-derived scores with floors', () => {
     const scores = computeCIIScores([], emptyAux());
     const us = scoreFor(scores, 'US')!;


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #1351 (data-driven CII scoring) identified during Codex review and manual testing:

- **Bbox area-sorted matching**: Dubai coords (25.2, 55.3) fall inside both SA and AE bboxes. Sort by area (smallest first) so AE matches before SA.
- **Explicit outage severity**: Remove catch-all `else` that counted unknown/unrecognized severity strings as partial outages, inflating scores.
- **AE keyword normalization**: Add `'united arab emirates'` to AE keywords so ACLED/UCDP events using the formal name get attributed correctly.
- **Client TIER1_NAMES**: Add CU, MX, BR, AE entries so the frontend adapter displays proper country names instead of raw ISO codes.
- **UAE geo attribution test**: Verifies bbox overlap resolution works correctly.

Closes orphaned commits from #1351 post-merge.
Related: #1359 (advisory floors follow-up)

## Test plan

- [x] All 15 CII scoring tests pass (including new UAE geo attribution test)
- [x] `tsc --noEmit` clean
- [x] Pre-push hooks pass (edge functions, markdown lint, version sync)