### PR TITLE
fix(globe): hide satellite beams when orbital layer toggled off

### DIFF
--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -1788,6 +1788,9 @@ export class GlobeMap {
     if (ch.arcs)     this.flushArcs();
     if (ch.paths)    this.flushPaths();
     if (ch.polygons) this.flushPolygons();
+    if (layer === 'satellites' && this.satBeamGroup) {
+      this.satBeamGroup.visible = !!this.layers.satellites;
+    }
   }
 
   public setLayers(layers: MapLayers): void {


### PR DESCRIPTION
## Summary
- Fixed satellite beam/cone Three.js geometry remaining visible after disabling Orbital Surveillance layer
- Root cause: the globe's internal checkbox handler called `flushLayerChannels()` which flushed markers and paths but never toggled `satBeamGroup.visible`
- Added `satBeamGroup.visible` toggle to `flushLayerChannels()` when the satellites layer changes

## Test plan
- [ ] Enable Orbital Surveillance layer in 3D globe mode
- [ ] Verify satellite beams appear
- [ ] Disable Orbital Surveillance layer
- [ ] Verify all beams/cones disappear immediately