### PR TITLE
Fix type error: remove invalid 'satelliteImagery' from LAYER_SYNONYMS

### DIFF
--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -160,7 +160,7 @@ export const LAYER_SYNONYMS: Record<string, Array<keyof MapLayers>> = {
   missile: ['iranAttacks', 'military'],
   nuke: ['nuclear'],
   radiation: ['nuclear', 'irradiators'],
-  space: ['spaceports', 'satellites', 'satelliteImagery'],
+  space: ['spaceports', 'satellites'],
   orbit: ['satellites'],
   internet: ['outages', 'cables', 'cyberThreats'],
   cyber: ['cyberThreats', 'outages'],


### PR DESCRIPTION
The 'satelliteImagery' layer was removed from MapLayers but still
referenced in LAYER_SYNONYMS, causing a TS2322 type error.

https://claude.ai/code/session_01DSiTeEn5zde1ViMFyTLu1Z