### PR TITLE
fix(map): add close button and hover-pause to all marker tooltips

### DIFF
--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -1055,11 +1055,11 @@ export class GlobeMap {
       'color:#d4d4d4',
       'max-width:240px',
       'z-index:1000',
-      'pointer-events:none',
+      'pointer-events:auto',
       'line-height:1.5',
     ].join(';');
 
-    const closeBtn = `<button style="position:absolute;top:4px;right:4px;background:none;border:none;color:#888;cursor:pointer;font-size:14px;line-height:1;padding:2px 4px;pointer-events:auto;" aria-label="Close">\u00D7</button>`;
+    const closeBtn = `<button style="position:absolute;top:4px;right:4px;background:none;border:none;color:#888;cursor:pointer;font-size:14px;line-height:1;padding:2px 4px;" aria-label="Close">\u00D7</button>`;
 
     const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
@@ -1206,7 +1206,7 @@ export class GlobeMap {
       const operatorName = SAT_OPERATOR_NAME[d.country] || getCountryNameByCode(d.country) || d.country;
       const overHit = getCountryAtCoordinates(d._lat, d._lng);
       const overLabel = overHit ? overHit.name : 'Ocean';
-      html = `<div style="min-width:220px;padding-right:16px;">` + closeBtn +
+      html = `<div style="min-width:220px;">` +
         `<span style="color:${sc};font-weight:bold;font-size:12px;">${SAT_TYPE_EMOJI[d.type] || '\u{1F6F0}'} ${esc(d.name)}</span>` +
         `<div style="opacity:.5;font-size:10px;margin:2px 0 6px;">NORAD ${esc(d.id)}</div>` +
         `<div style="display:grid;grid-template-columns:auto 1fr;gap:2px 8px;font-size:11px;">` +
@@ -1222,18 +1222,15 @@ export class GlobeMap {
              `<br><span style="opacity:.7;">${esc(d.datetime)}</span>` +
              `<br><span style="opacity:.5;">Res: ${d.resolutionM}m · ${esc(d.mode)}</span>`;
     }
-    el.innerHTML = html;
-    if (d._kind === 'satellite') {
-      el.style.maxWidth = '300px';
-      el.style.pointerEvents = 'auto';
-      el.querySelector('button')?.addEventListener('click', () => this.hideTooltip());
-      el.addEventListener('mouseenter', () => {
-        if (this.tooltipHideTimer) { clearTimeout(this.tooltipHideTimer); this.tooltipHideTimer = null; }
-      });
-      el.addEventListener('mouseleave', () => {
-        this.tooltipHideTimer = setTimeout(() => this.hideTooltip(), 2000);
-      });
-    }
+    el.innerHTML = `<div style="padding-right:16px;position:relative;">${closeBtn}${html}</div>`;
+    if (d._kind === 'satellite') el.style.maxWidth = '300px';
+    el.querySelector('button')?.addEventListener('click', () => this.hideTooltip());
+    el.addEventListener('mouseenter', () => {
+      if (this.tooltipHideTimer) { clearTimeout(this.tooltipHideTimer); this.tooltipHideTimer = null; }
+    });
+    el.addEventListener('mouseleave', () => {
+      this.tooltipHideTimer = setTimeout(() => this.hideTooltip(), 2000);
+    });
 
     this.container.appendChild(el);
 


### PR DESCRIPTION
## Summary
- Adds a clickable x close button to all marker tooltip popups (conflicts, satellites, earthquakes, flights, etc.)
- Enables pointer events on tooltips so the button is clickable
- Pauses auto-hide timer on hover, resumes 2s after mouse leaves

## Test plan
- [ ] Click any marker on the globe to open its tooltip
- [ ] Verify the x button appears in the top-right corner
- [ ] Click the x button to dismiss the tooltip
- [ ] Hover over the tooltip and confirm it stays open
- [ ] Move mouse away and confirm it auto-hides after ~2s