### PR TITLE
feat(orbital): enable satellite imagery panel

### DIFF
--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -45,7 +45,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   layoffs: { name: 'Layoffs Tracker', enabled: true, priority: 2 },
   monitors: { name: 'My Monitors', enabled: true, priority: 2 },
   'satellite-fires': { name: 'Fires', enabled: true, priority: 2 },
-  'satellite-imagery': { name: 'Satellite Imagery', enabled: false, priority: 2 },
+  'satellite-imagery': { name: 'Satellite Imagery', enabled: true, priority: 2 },
   'macro-signals': { name: 'Market Radar', enabled: true, priority: 2 },
   'gulf-economies': { name: 'Gulf Economies', enabled: false, priority: 2 },
   'etf-flows': { name: 'BTC ETF Tracker', enabled: true, priority: 2 },

--- a/src/config/variants/full.ts
+++ b/src/config/variants/full.ts
@@ -48,7 +48,7 @@ export const DEFAULT_PANELS: Record<string, PanelConfig> = {
   'etf-flows': { name: 'BTC ETF Tracker', enabled: true, priority: 2 },
   stablecoins: { name: 'Stablecoins', enabled: true, priority: 2 },
   monitors: { name: 'My Monitors', enabled: true, priority: 2 },
-  'satellite-imagery': { name: 'Satellite Imagery', enabled: false, priority: 2 },
+  'satellite-imagery': { name: 'Satellite Imagery', enabled: true, priority: 2 },
 };
 
 // Map layers for geopolitical view


### PR DESCRIPTION
## Summary
- Enable the satellite imagery panel (`satellite-imagery`) in both `panels.ts` and `variants/full.ts`
- Previously disabled after the merge that combined satellite imagery into the orbital surveillance layer
- Now when toggling orbital surveillance, the imagery panel appears alongside live satellite tracking

## Test plan
- [ ] Toggle orbital surveillance layer on the globe
- [ ] Verify the Satellite Imagery panel appears in the sidebar
- [ ] Confirm imagery scenes load and display in the panel