### PR TITLE
fix(imagery): fix panel hidden for existing users, remove refetch deadlock

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -160,6 +160,17 @@ export class App {
       }
     }
 
+    // One-time migration: enable satellite imagery panel for existing users
+    const IMAGERY_PANEL_MIGRATION_KEY = 'worldmonitor-imagery-panel-enabled-v1';
+    if (!localStorage.getItem(IMAGERY_PANEL_MIGRATION_KEY)) {
+      if (panelSettings['satellite-imagery'] && !panelSettings['satellite-imagery'].enabled) {
+        panelSettings['satellite-imagery'].enabled = true;
+        saveToStorage(STORAGE_KEYS.panels, panelSettings);
+        console.log('[App] Migration: enabled satellite imagery panel');
+      }
+      localStorage.setItem(IMAGERY_PANEL_MIGRATION_KEY, 'done');
+    }
+
     // One-time migration: clear stale panel ordering and sizing state
     const LAYOUT_RESET_MIGRATION_KEY = 'worldmonitor-layout-reset-v2.5';
     if (!localStorage.getItem(LAYOUT_RESET_MIGRATION_KEY)) {

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -691,7 +691,7 @@ export class DeckGLMap {
       this.debouncedFetchAircraft();
       this.state.zoom = this.maplibreMap?.getZoom() ?? this.state.zoom;
       this.onStateChange?.(this.getState());
-      if (this.state.layers.satellites && this.imageryScenes.length > 0) {
+      if (this.state.layers.satellites) {
         if (this.imagerySearchTimer) clearTimeout(this.imagerySearchTimer);
         this.imagerySearchTimer = setTimeout(() => this.fetchImageryForViewport(), 500);
       }


### PR DESCRIPTION
## Summary
- **Stale localStorage migration**: Existing users had `satellite-imagery: { enabled: false }` cached in localStorage from before PR #1375. The stored value overrides the new default via `{ ...defaultValue, ...parsed }` merge in `loadFromStorage`. Added a one-time migration to flip `enabled: true` for these users.
- **Viewport refetch deadlock**: `DeckGLMap.moveend` handler required `imageryScenes.length > 0` before fetching imagery for the new viewport. This created a bootstrap problem where imagery could never load via viewport changes if the initial fetch returned no results. Removed the guard.

## Root cause
`loadFromStorage()` merges stored settings over defaults (`{ ...default, ...stored }`). When PR #1375 changed the default from `enabled: false` to `enabled: true`, users who already had stored settings kept the old `enabled: false` value.

## Test plan
- [ ] Clear localStorage, reload with satellites layer on: imagery panel should appear
- [ ] With existing localStorage from before this PR: imagery panel should auto-enable via migration
- [ ] Toggle satellites layer, pan the 2D map: imagery should refetch for new viewport
- [ ] Check console for `[App] Migration: enabled satellite imagery panel` on first load