### PR TITLE
fix(sentry): fix Safari TypeError filtering and add noise patterns

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -221,6 +221,10 @@ Sentry.init({
     /Content-Length header of network response exceeds response Body/,
     /^Uncaught \[object ErrorEvent\]$/,
     /trsMethod\w+ is not defined/,
+    /checkLogin is not a function/,
+    /VConsole is not defined/,
+    /exitFullscreen.*Document not active/,
+    /Force close delete origin/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';
@@ -231,7 +235,8 @@ Sentry.init({
       if (frames.some(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     }
     // Suppress any TypeError that happens entirely within maplibre or deck.gl internals
-    if (/^TypeError:/.test(msg) && frames.length > 0) {
+    const excType = event.exception?.values?.[0]?.type ?? '';
+    if ((excType === 'TypeError' || /^TypeError:/.test(msg)) && frames.length > 0) {
       const nonSentryFrames = frames.filter(f => f.filename && f.filename !== '<anonymous>' && !/\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename));
       if (nonSentryFrames.length > 0 && nonSentryFrames.every(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     }
@@ -253,8 +258,10 @@ Sentry.init({
     }
     // Suppress deck.gl/maplibre null-access crashes with no usable stack trace (requestAnimationFrame wrapping)
     if (/null is not an object \(evaluating '\w{1,3}\.(id|type|style)'\)/.test(msg) && frames.length === 0) return null;
+    // Suppress Safari sortedTrackListForMenu native crash (value is generic "Type error", function name in stack)
+    if (excType === 'TypeError' && frames.some(f => /sortedTrackListForMenu/.test(f.function ?? ''))) return null;
     // Suppress TypeErrors from anonymous/injected scripts (no real source files or only inline page URL)
-    if (/^TypeError:/.test(msg) && frames.length > 0 && frames.every(f => !f.filename || f.filename === '<anonymous>' || /^blob:/.test(f.filename) || /^https?:\/\/[^/]+\/?$/.test(f.filename))) return null;
+    if ((excType === 'TypeError' || /^TypeError:/.test(msg)) && frames.length > 0 && frames.every(f => !f.filename || f.filename === '<anonymous>' || /^blob:/.test(f.filename) || /^https?:\/\/[^/]+\/?$/.test(f.filename))) return null;
     // Suppress parentNode.insertBefore from injected/inline scripts (iOS WKWebView, Apple Mail)
     if (/parentNode\.insertBefore/.test(msg) && frames.every(f => !f.filename || f.filename === '<anonymous>' || /^blob:/.test(f.filename) || /^https?:\/\/[^/]+\/?$/.test(f.filename))) return null;
     // Suppress Sentry breadcrumb DOM-measuring crashes (element.offsetWidth on detached DOM)


### PR DESCRIPTION
## Summary
- Fix `beforeSend` TypeError filter to also check `event.exception.values[0].type` field (Safari reports type separately from value, so `/^TypeError:/.test(msg)` never matched)
- Add stack-based `sortedTrackListForMenu` suppression (Safari native crash sends generic "Type error" as value)
- Add 4 new `ignoreErrors` patterns: `checkLogin` injection, `VConsole` injection, `exitFullscreen` on inactive document, IndexedDB force close

Resolves 9 unresolved Sentry issues (all noise/third-party), all marked resolved with `inNextRelease`.

## Test plan
- [x] `tsc --noEmit` passes
- [x] All pre-push checks pass (104 tests, 0 failures)
- [ ] Monitor Sentry after deploy for regressions