### PR TITLE
fix(country-intel): silently dismiss unidentified location clicks

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -134,12 +134,8 @@ export class CountryIntelManager implements AppModule {
     const geo = await reverseGeocode(lat, lon);
     if (token !== this.briefRequestToken) return;
     if (!geo) {
-      if (this.ctx.countryBriefPage.showGeoError) {
-        this.ctx.countryBriefPage.showGeoError(() => this.openCountryBrief(lat, lon));
-      } else {
-        this.ctx.countryBriefPage.hide();
-        this.ctx.map?.setRenderPaused(false);
-      }
+      this.ctx.countryBriefPage.hide();
+      this.ctx.map?.setRenderPaused(false);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Removes the error dialog shown when clicking on ocean or areas where geocode cannot identify a country
- Instead of showing "Could not identify a country at this location" with Retry/Close buttons, silently closes the panel and unpauses the map
- No functional loss: clicking unidentified areas simply does nothing now

## Test plan
- [ ] Click on ocean areas on the globe, verify no error dialog appears
- [ ] Click on land areas, verify country brief still opens normally
- [ ] Verify map rendering resumes after clicking unidentified areas