### PR TITLE
fix(imagery): outline-only polygons to eliminate blue tint

### DIFF
--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -729,14 +729,14 @@ export class GlobeMap {
       .polygonCapColor((d: GlobePolygon) => {
         if (d._kind === 'cii') return GlobeMap.CII_GLOBE_COLORS[d.level!] ?? 'rgba(0,0,0,0)';
         if (d._kind === 'conflict') return GlobeMap.CONFLICT_CAP[d.intensity!] ?? GlobeMap.CONFLICT_CAP.low;
-        if (d._kind === 'imageryFootprint') return 'rgba(0,180,255,0.08)';
+        if (d._kind === 'imageryFootprint') return 'rgba(0,0,0,0)';
         if (d._kind === 'forecastCone') return 'rgba(255,140,60,0.2)';
         return 'rgba(255,60,60,0.15)';
       })
       .polygonSideColor((d: GlobePolygon) => {
         if (d._kind === 'cii') return 'rgba(0,0,0,0)';
         if (d._kind === 'conflict') return GlobeMap.CONFLICT_SIDE[d.intensity!] ?? GlobeMap.CONFLICT_SIDE.low;
-        if (d._kind === 'imageryFootprint') return 'rgba(0,180,255,0.04)';
+        if (d._kind === 'imageryFootprint') return 'rgba(0,0,0,0)';
         if (d._kind === 'forecastCone') return 'rgba(255,140,60,0.1)';
         return 'rgba(255,60,60,0.08)';
       })


### PR DESCRIPTION
## Summary
- Set imagery footprint polygon cap and side colors to fully transparent (`rgba(0,0,0,0)`)
- Only the stroke outline (`#00b4ff`) remains visible
- With 50+ overlapping polygons, any non-zero alpha accumulates to near-opacity, covering the globe in solid blue

## Before
![blue tint](https://github.com/user-attachments/assets/placeholder)
Globe covered in solid blue when viewing area with satellite imagery

## After
Outline-only footprints, no fill accumulation

## Test plan
- [ ] Toggle orbital surveillance ON in globe mode
- [ ] Verify footprint outlines visible without blue fill
- [ ] Rotate to area with many overlapping scenes, confirm no blue tint
- [ ] Rotate away from imagery area, confirm globe renders clean