### PR TITLE
fix(sentry): filter Swedish locale 'avbruten' TypeError

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ Sentry.init({
     /importScripts/,
     /^TypeError: Load failed( \(.*\))?$/,
     /^TypeError: Failed to fetch( \(.*\))?$/,
-    /^TypeError: cancelled$/,
+    /^TypeError: (?:cancelled|avbruten)$/,
     /^TypeError: NetworkError/,
     /runtime\.sendMessage\(\)/,
     /Java object is gone/,


### PR DESCRIPTION
## Summary
- Expanded Sentry `ignoreErrors` pattern to catch `TypeError: avbruten` (Swedish locale equivalent of `TypeError: cancelled` in WebKit)
- Resolved 5 unresolved Sentry issues: 1 noise filter added, 4 already-filtered IDB errors from third-party domain

## Sentry Issues Resolved
| Issue | Category | Action |
|-------|----------|--------|
| WORLDMONITOR-G5 | Noise | Added `avbruten` to cancelled TypeError pattern |
| WORLDMONITOR-G4 | Already filtered | IDB closing error, third-party domain |
| WORLDMONITOR-G3 | Already filtered | IDB closing error, third-party domain |
| WORLDMONITOR-G2 | Already filtered | IDB closing error, third-party domain |
| WORLDMONITOR-G1 | Already filtered | IDB closing error, third-party domain |

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Pre-push hooks pass (104 tests)
- [ ] Deploy and verify WORLDMONITOR-G5 does not recur