### PR TITLE
fix(intel): reorder deep dive layout and remove duplicate headlines

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -359,10 +359,6 @@ export class CountryIntelManager implements AppModule {
           if (signals.earthquakes > 0) lines.push(t('countryBrief.fallback.recentEarthquakes', { count: String(signals.earthquakes) }));
           if (signals.orefHistory24h > 0) lines.push(`🚨 Sirens in past 24h: ${signals.orefHistory24h}`);
           if (context.stockIndex) lines.push(t('countryBrief.fallback.stockIndex', { value: context.stockIndex }));
-          if (briefHeadlines.length > 0) {
-            lines.push('', t('countryBrief.fallback.recentHeadlines'));
-            briefHeadlines.slice(0, 5).forEach(h => lines.push(`• ${h}`));
-          }
           if (lines.length > 0) {
             this.ctx.countryBriefPage?.updateBrief({ brief: lines.join('\n'), country, code, fallback: true });
           } else {

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -725,7 +725,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     marketsBody.append(this.makeLoading(t('countryBrief.loadingMarkets')));
     briefBody.append(this.makeLoading(t('countryBrief.generatingBrief')));
 
-    bodyGrid.append(signalsCard, timelineCard, newsCard, militaryCard, infraCard, factsExpanded, economicCard, marketsCard, briefCard);
+    bodyGrid.append(briefCard, factsExpanded, signalsCard, timelineCard, newsCard, militaryCard, infraCard, economicCard, marketsCard);
     shell.append(header, scoreCard, bodyGrid);
     this.content.append(shell);
   }


### PR DESCRIPTION
## Summary
- Move Intelligence Brief and Country Facts to top of expanded panel (after score card) for executive-summary-first layout
- Remove duplicate "Recent headlines" from fallback brief that repeated the Top News section verbatim

## Test plan
- [ ] Open any country brief, maximize it, verify Brief and Facts appear first
- [ ] Trigger fallback brief (no AI key) and confirm no headline bullets at the bottom
- [ ] Compact view unchanged (Facts still hidden via `cdp-expanded-only`)