### PR TITLE
fix(footer): align all footers, make dashboard footer visible

### DIFF
--- a/blog-site/src/layouts/Base.astro
+++ b/blog-site/src/layouts/Base.astro
@@ -111,12 +111,13 @@ const keywordTags = keywords ? keywords.split(',').map(k => k.trim()).slice(0, 6
         <div class="footer-links">
           <a href="https://worldmonitor.app" target="_blank" rel="noopener noreferrer">Dashboard</a>
           <a href="https://worldmonitor.app/pro" target="_blank" rel="noopener noreferrer">Pro</a>
-          <a href="https://x.com/worldmonitorai" target="_blank" rel="noopener noreferrer">X</a>
+          <a href="/blog/">Blog</a>
           <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noopener noreferrer">GitHub</a>
           <a href="https://github.com/koala73/worldmonitor/discussions" target="_blank" rel="noopener noreferrer">Discussions</a>
+          <a href="https://x.com/worldmonitorai" target="_blank" rel="noopener noreferrer">X</a>
         </div>
         <div class="footer-copy">
-          &copy; {new Date().getFullYear()} WorldMonitor. Free, open-source global intelligence.
+          &copy; {new Date().getFullYear()} WorldMonitor
         </div>
       </div>
     </footer>

--- a/pro-test/src/App.tsx
+++ b/pro-test/src/App.tsx
@@ -923,15 +923,18 @@ const Footer = () => (
     </div>
 
     <div className="flex flex-col md:flex-row items-center justify-between max-w-7xl mx-auto pt-8 border-t border-wm-border/50 text-xs text-wm-muted font-mono">
-      <div className="flex items-center gap-4 mb-4 md:mb-0">
+      <div className="flex items-center gap-3 mb-4 md:mb-0">
         <Logo />
+        <span className="text-[9px] uppercase tracking-[2px] opacity-60">by Someone.ceo</span>
       </div>
-      <div className="flex gap-6">
-        <a href="/blog/" aria-label="WorldMonitor Blog" className="hover:text-wm-text transition-colors">Blog</a>
-        <a href="https://x.com/worldmonitorai" target="_blank" rel="noreferrer" aria-label="Follow World Monitor on X" className="hover:text-wm-text transition-colors">X</a>
-        <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noreferrer" aria-label="World Monitor on GitHub" className="hover:text-wm-text transition-colors">GitHub</a>
-        <a href="https://github.com/koala73/worldmonitor/discussions" target="_blank" rel="noreferrer" aria-label="World Monitor Discussions" className="hover:text-wm-text transition-colors">Discussions</a>
+      <div className="flex items-center gap-6">
+        <a href="/" className="hover:text-wm-text transition-colors">Dashboard</a>
+        <a href="/blog/" className="hover:text-wm-text transition-colors">Blog</a>
+        <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">GitHub</a>
+        <a href="https://github.com/koala73/worldmonitor/discussions" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">Discussions</a>
+        <a href="https://x.com/worldmonitorai" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">X</a>
       </div>
+      <span className="text-[10px] opacity-40 mt-4 md:mt-0">&copy; {new Date().getFullYear()} WorldMonitor</span>
     </div>
   </footer>
 );
@@ -1115,16 +1118,19 @@ const EnterprisePage = () => (
     {/* Footer */}
     <footer className="border-t border-wm-border bg-[#020202] py-8 px-6 text-center">
       <div className="flex flex-col md:flex-row items-center justify-between max-w-7xl mx-auto text-xs text-wm-muted font-mono">
-        <div className="flex items-center gap-4 mb-4 md:mb-0">
+        <div className="flex items-center gap-3 mb-4 md:mb-0">
           <Logo />
+          <span className="text-[9px] uppercase tracking-[2px] opacity-60">by Someone.ceo</span>
         </div>
-        <div className="flex gap-6">
+        <div className="flex items-center gap-6">
+          <a href="/" className="hover:text-wm-text transition-colors">Dashboard</a>
           <a href="#" onClick={(e) => { e.preventDefault(); window.location.hash = ''; }} className="hover:text-wm-text transition-colors">{t('nav.pro')}</a>
           <a href="/blog/" className="hover:text-wm-text transition-colors">Blog</a>
-          <a href="https://x.com/worldmonitorai" target="_blank" rel="noreferrer" aria-label="Follow World Monitor on X" className="hover:text-wm-text transition-colors">X</a>
           <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">GitHub</a>
           <a href="https://github.com/koala73/worldmonitor/discussions" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">Discussions</a>
+          <a href="https://x.com/worldmonitorai" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">X</a>
         </div>
+        <span className="text-[10px] opacity-40 mt-4 md:mt-0">&copy; {new Date().getFullYear()} WorldMonitor</span>
       </div>
     </footer>
   </div>

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -311,24 +311,25 @@ export class PanelLayoutManager implements AppModule {
           <div class="map-bottom-grid" id="mapBottomGrid"></div>
         </div>
         <div class="panels-grid" id="panelsGrid"></div>
-        <footer class="site-footer">
-          <div class="site-footer-brand">
-            <img src="/favico/favicon-32x32.png" alt="" width="28" height="28" class="site-footer-icon" />
-            <div class="site-footer-brand-text">
-              <span class="site-footer-name">WORLD MONITOR</span>
-              <span class="site-footer-sub">by Someone.ceo</span>
-            </div>
-          </div>
-          <nav>
-            <a href="/pro">Pro</a>
-            <a href="/blog/">Blog</a>
-            <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noopener">GitHub</a>
-            <a href="https://github.com/koala73/worldmonitor/discussions" target="_blank" rel="noopener">Discussions</a>
-            <a href="https://x.com/worldmonitorai" target="_blank" rel="noopener">X</a>
-          </nav>
-        </footer>
         <button class="search-mobile-fab" id="searchMobileFab" aria-label="Search">\u{1F50D}</button>
       </div>
+      <footer class="site-footer">
+        <div class="site-footer-brand">
+          <img src="/favico/favicon-32x32.png" alt="" width="28" height="28" class="site-footer-icon" />
+          <div class="site-footer-brand-text">
+            <span class="site-footer-name">WORLD MONITOR</span>
+            <span class="site-footer-sub">by Someone.ceo</span>
+          </div>
+        </div>
+        <nav>
+          <a href="/pro">Pro</a>
+          <a href="/blog/">Blog</a>
+          <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://github.com/koala73/worldmonitor/discussions" target="_blank" rel="noopener">Discussions</a>
+          <a href="https://x.com/worldmonitorai" target="_blank" rel="noopener">X</a>
+        </nav>
+        <span class="site-footer-copy">&copy; ${new Date().getFullYear()} WorldMonitor</span>
+      </footer>
     `;
 
     this.createPanels();

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1059,12 +1059,12 @@ canvas,
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 20px;
+  padding: 12px 20px;
   font-size: 11px;
   color: var(--text-dim);
   border-top: 1px solid var(--border);
-  grid-column: 1 / -1;
   flex-shrink: 0;
+  background: var(--surface);
 }
 .site-footer-brand {
   display: flex;
@@ -1107,13 +1107,19 @@ canvas,
 .site-footer a:hover {
   color: var(--accent);
 }
+.site-footer-copy {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  color: var(--text-dim);
+  opacity: 0.6;
+}
 
 @media (max-width: 768px) {
   .site-footer {
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
     text-align: center;
-    padding: 16px;
+    padding: 12px 16px;
   }
   .site-footer nav {
     flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Moved dashboard footer outside `.main-content` so it's always visible (was buried inside scrollable container, unreachable behind panels)
- Unified link order across all 4 footers: Pro, Blog, GitHub, Discussions, X (context-aware additions like Dashboard on blog/pro pages)
- Added "by Someone.ceo" branding to Pro page footers (was missing)
- Added copyright line to all footers (only blog had it)
- Standardized footer styling (background, padding)

## Test plan
- [ ] Verify dashboard footer is visible at the bottom of the page
- [ ] Verify blog footer shows aligned links in correct order
- [ ] Verify Pro main page footer shows branding + all links + copyright
- [ ] Verify Pro enterprise page footer matches
- [ ] Check mobile responsive layout on all footers