### PR TITLE
fix(footer): unify links, logos, and layout across all pages

### DIFF
--- a/blog-site/src/styles/global.css
+++ b/blog-site/src/styles/global.css
@@ -199,14 +199,10 @@ img { max-width: 100%; height: auto; border-radius: var(--radius); }
 .site-footer .footer-links a:hover { color: var(--wm-text); }
 
 .site-footer .footer-copy {
-  width: 100%;
-  text-align: center;
-  margin-top: 1.5rem;
-  padding-top: 1.5rem;
-  border-top: 1px solid var(--wm-border);
   color: var(--wm-muted);
-  font-size: 0.75rem;
+  font-size: 0.625rem;
   font-family: var(--font-mono);
+  opacity: 0.6;
 }
 
 /* ─── Blog Listing ─── */

--- a/pro-test/src/App.tsx
+++ b/pro-test/src/App.tsx
@@ -924,11 +924,15 @@ const Footer = () => (
 
     <div className="flex flex-col md:flex-row items-center justify-between max-w-7xl mx-auto pt-8 border-t border-wm-border/50 text-xs text-wm-muted font-mono">
       <div className="flex items-center gap-3 mb-4 md:mb-0">
-        <Logo />
-        <span className="text-[9px] uppercase tracking-[2px] opacity-60">by Someone.ceo</span>
+        <img src="/favico/favicon-32x32.png" alt="" width="28" height="28" className="rounded-full" />
+        <div className="flex flex-col">
+          <span className="font-display font-bold text-sm leading-none tracking-tight text-wm-text">WORLD MONITOR</span>
+          <span className="text-[9px] uppercase tracking-[2px] opacity-60 mt-0.5">by Someone.ceo</span>
+        </div>
       </div>
       <div className="flex items-center gap-6">
         <a href="/" className="hover:text-wm-text transition-colors">Dashboard</a>
+        <a href="/pro" className="hover:text-wm-text transition-colors">Pro</a>
         <a href="/blog/" className="hover:text-wm-text transition-colors">Blog</a>
         <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">GitHub</a>
         <a href="https://github.com/koala73/worldmonitor/discussions" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">Discussions</a>
@@ -1119,12 +1123,15 @@ const EnterprisePage = () => (
     <footer className="border-t border-wm-border bg-[#020202] py-8 px-6 text-center">
       <div className="flex flex-col md:flex-row items-center justify-between max-w-7xl mx-auto text-xs text-wm-muted font-mono">
         <div className="flex items-center gap-3 mb-4 md:mb-0">
-          <Logo />
-          <span className="text-[9px] uppercase tracking-[2px] opacity-60">by Someone.ceo</span>
+          <img src="/favico/favicon-32x32.png" alt="" width="28" height="28" className="rounded-full" />
+          <div className="flex flex-col">
+            <span className="font-display font-bold text-sm leading-none tracking-tight text-wm-text">WORLD MONITOR</span>
+            <span className="text-[9px] uppercase tracking-[2px] opacity-60 mt-0.5">by Someone.ceo</span>
+          </div>
         </div>
         <div className="flex items-center gap-6">
           <a href="/" className="hover:text-wm-text transition-colors">Dashboard</a>
-          <a href="#" onClick={(e) => { e.preventDefault(); window.location.hash = ''; }} className="hover:text-wm-text transition-colors">{t('nav.pro')}</a>
+          <a href="/pro" className="hover:text-wm-text transition-colors">Pro</a>
           <a href="/blog/" className="hover:text-wm-text transition-colors">Blog</a>
           <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">GitHub</a>
           <a href="https://github.com/koala73/worldmonitor/discussions" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">Discussions</a>

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -322,6 +322,7 @@ export class PanelLayoutManager implements AppModule {
           </div>
         </div>
         <nav>
+          <a href="/">Dashboard</a>
           <a href="/pro">Pro</a>
           <a href="/blog/">Blog</a>
           <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noopener">GitHub</a>


### PR DESCRIPTION
## Summary
- Standardized all 4 footers (Dashboard, Pro main, Pro Enterprise, Blog) to have identical links: Dashboard, Pro, Blog, GitHub, Discussions, X
- Replaced SVG `<Logo>` component in Pro footers with `favicon-32x32.png` to match Dashboard and Blog
- Made Blog footer copyright display inline instead of a separate bordered row

## Test plan
- [ ] Verify Dashboard footer shows all 6 links with favicon logo
- [ ] Verify Pro landing page footer shows all 6 links with favicon logo
- [ ] Verify Pro Enterprise page footer shows all 6 links with favicon logo
- [ ] Verify Blog footer shows all 6 links with copyright inline (no separate row)