### PR TITLE
feat(pro): disable banner dismiss during launch promotion

### DIFF
--- a/src/components/ProBanner.ts
+++ b/src/components/ProBanner.ts
@@ -1,7 +1,8 @@
+let bannerEl: HTMLElement | null = null;
+
+/* TODO: re-enable dismiss after pro launch promotion period
 const DISMISS_KEY = 'wm-pro-banner-dismissed';
 const DISMISS_MS = 7 * 24 * 60 * 60 * 1000;
-
-let bannerEl: HTMLElement | null = null;
 
 function isDismissed(): boolean {
   const ts = localStorage.getItem(DISMISS_KEY);
@@ -13,8 +14,18 @@ function isDismissed(): boolean {
   return true;
 }
 
+function dismiss(): void {
+  if (!bannerEl) return;
+  bannerEl.classList.add('pro-banner-out');
+  setTimeout(() => {
+    bannerEl?.remove();
+    bannerEl = null;
+  }, 300);
+  localStorage.setItem(DISMISS_KEY, String(Date.now()));
+}
+*/
+
 export function showProBanner(container: HTMLElement): void {
-  if (isDismissed()) return;
   if (bannerEl) return;
   if (window.self !== window.top) return;
 
@@ -26,13 +37,15 @@ export function showProBanner(container: HTMLElement): void {
       <strong>Pro is coming</strong> — More Signal, Less Noise. More AI Briefings. A Geopolitical &amp; Equity Researcher just for you.
     </span>
     <a class="pro-banner-cta" href="/pro">Reserve your spot →</a>
-    <button class="pro-banner-close" aria-label="Dismiss">×</button>
   `;
 
+  /* TODO: re-enable close button after pro launch promotion period
+  banner.innerHTML += `<button class="pro-banner-close" aria-label="Dismiss">×</button>`;
   banner.querySelector('.pro-banner-close')!.addEventListener('click', (e) => {
     e.preventDefault();
     dismiss();
   });
+  */
 
   const header = container.querySelector('.header');
   if (header) {
@@ -43,16 +56,6 @@ export function showProBanner(container: HTMLElement): void {
 
   bannerEl = banner;
   requestAnimationFrame(() => banner.classList.add('pro-banner-in'));
-}
-
-function dismiss(): void {
-  if (!bannerEl) return;
-  bannerEl.classList.add('pro-banner-out');
-  setTimeout(() => {
-    bannerEl?.remove();
-    bannerEl = null;
-  }, 300);
-  localStorage.setItem(DISMISS_KEY, String(Date.now()));
 }
 
 export function hideProBanner(): void {


### PR DESCRIPTION
## Summary
- Temporarily hides the close button on the Pro banner so users cannot dismiss it
- Skips the `isDismissed()` localStorage check so the banner always renders
- All dismiss logic preserved in block comments for easy re-enablement

## Test plan
- [ ] Verify Pro banner appears on page load
- [ ] Verify no close button is visible
- [ ] Verify previously-dismissed users still see the banner