### PR TITLE
chore(sentry): add noise filters for 3 third-party errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -225,6 +225,9 @@ Sentry.init({
     /VConsole is not defined/,
     /exitFullscreen.*Document not active/,
     /Force close delete origin/,
+    /zp_token is not defined/,
+    /literal not terminated before end of script/,
+    /'' is not a valid selector/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary
- Add `ignoreErrors` patterns for 3 unresolved Sentry issues (all third-party noise)
  - `zp_token is not defined` (ad tracker script injection)
  - `literal not terminated before end of script` (Firefox Mobile injected script parse error)
  - `'' is not a valid selector` (DuckDuckGo browser extension bad `querySelectorAll`)
- All 3 issues resolved in Sentry with `inNextRelease: true`

## Test plan
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Confirm no new Sentry events after deploy for these patterns