### PR TITLE
chore: skip preview deploys for non-PR branches

### DIFF
--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # Vercel Ignored Build Step: exit 0 = skip, exit 1 = build
 # Triggers build when: blog-site/ changes OR non-docs app code changes
+
+# Always build production (main branch)
+[ "$VERCEL_GIT_COMMIT_REF" = "main" ] && exit 1
+
+# Skip preview deploys that aren't tied to a pull request
+[ -z "$VERCEL_GIT_PULL_REQUEST_ID" ] && exit 0
+
 [ -z "$VERCEL_GIT_PREVIOUS_SHA" ] && exit 1
 git cat-file -e "$VERCEL_GIT_PREVIOUS_SHA" 2>/dev/null || exit 1
 git diff --name-only "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- 'blog-site/' | grep -q . && exit 1


### PR DESCRIPTION
## Summary
- Adds `VERCEL_GIT_PULL_REQUEST_ID` check to `scripts/vercel-ignore.sh`
- Branch pushes without an open PR are skipped (exit 0)
- Production (main) always builds regardless
- Eliminates wasted build minutes from 378+ feature branches pushing without PRs

## Context
At $0.126/min (Turbo tier), every unnecessary preview deploy costs real money. Most feature branch pushes don't need preview URLs until a PR is opened. This check prevents those builds entirely.

Also recommend switching Build Machines from **Turbo** ($0.126/min) to **Standard** ($0.014/min) in the dashboard.

## Test plan
- [ ] Push to a branch without a PR open: should skip build
- [ ] Open a PR on that branch, push again: should build
- [ ] Push to main: should always build