### PR TITLE
fix(docs): add required theme field to Mintlify docs.json

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -10,126 +10,194 @@
   "colors": {
     "primary": "#3b82f6",
     "light": "#60a5fa",
-    "dark": "#2563eb",
-    "background": {
-      "dark": "#0a0a1a"
+    "dark": "#2563eb"
+  },
+  "navbar": {
+    "links": [
+      {
+        "label": "Live App",
+        "href": "https://worldmonitor.app"
+      }
+    ],
+    "primary": {
+      "type": "button",
+      "label": "GitHub",
+      "href": "https://github.com/koala73/worldmonitor"
     }
   },
-  "topbarLinks": [
-    {
-      "name": "Live App",
-      "url": "https://worldmonitor.app"
-    }
-  ],
-  "topbarCtaButton": {
-    "name": "GitHub",
-    "url": "https://github.com/koala73/worldmonitor"
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "Documentation",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "DOCUMENTATION",
+              "ARCHITECTURE"
+            ]
+          },
+          {
+            "group": "Core Systems",
+            "pages": [
+              "DATA_SOURCES",
+              "ALGORITHMS",
+              "MAP_ENGINE",
+              "AI_INTELLIGENCE",
+              "MAPS_AND_GEOCODING"
+            ]
+          },
+          {
+            "group": "Finance",
+            "pages": [
+              "FINANCE_DATA",
+              "PREMIUM_FINANCE",
+              "PREMIUM_FINANCE_SEARCH"
+            ]
+          },
+          {
+            "group": "Infrastructure",
+            "pages": [
+              "DESKTOP_APP",
+              "ORBITAL_SURVEILLANCE",
+              "CORS",
+              "HEALTH_ENDPOINTS",
+              "RELAY_PARAMETERS"
+            ]
+          },
+          {
+            "group": "Contributing",
+            "pages": [
+              "ADDING_ENDPOINTS",
+              "API_KEY_DEPLOYMENT",
+              "RELEASE_PACKAGING"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "API Reference",
+        "groups": [
+          {
+            "group": "Geopolitical",
+            "pages": [
+              {
+                "group": "Conflicts",
+                "openapi": "api/ConflictService.openapi.yaml"
+              },
+              {
+                "group": "Military",
+                "openapi": "api/MilitaryService.openapi.yaml"
+              },
+              {
+                "group": "Unrest",
+                "openapi": "api/UnrestService.openapi.yaml"
+              },
+              {
+                "group": "Intelligence",
+                "openapi": "api/IntelligenceService.openapi.yaml"
+              },
+              {
+                "group": "Displacement",
+                "openapi": "api/DisplacementService.openapi.yaml"
+              },
+              {
+                "group": "Cyber",
+                "openapi": "api/CyberService.openapi.yaml"
+              }
+            ]
+          },
+          {
+            "group": "Natural Events",
+            "pages": [
+              {
+                "group": "Natural Disasters",
+                "openapi": "api/NaturalService.openapi.yaml"
+              },
+              {
+                "group": "Seismology",
+                "openapi": "api/SeismologyService.openapi.yaml"
+              },
+              {
+                "group": "Climate",
+                "openapi": "api/ClimateService.openapi.yaml"
+              },
+              {
+                "group": "Wildfires",
+                "openapi": "api/WildfireService.openapi.yaml"
+              }
+            ]
+          },
+          {
+            "group": "Economy & Markets",
+            "pages": [
+              {
+                "group": "Economic",
+                "openapi": "api/EconomicService.openapi.yaml"
+              },
+              {
+                "group": "Markets",
+                "openapi": "api/MarketService.openapi.yaml"
+              },
+              {
+                "group": "Trade",
+                "openapi": "api/TradeService.openapi.yaml"
+              },
+              {
+                "group": "Supply Chain",
+                "openapi": "api/SupplyChainService.openapi.yaml"
+              },
+              {
+                "group": "Predictions",
+                "openapi": "api/PredictionService.openapi.yaml"
+              }
+            ]
+          },
+          {
+            "group": "Infrastructure & Transport",
+            "pages": [
+              {
+                "group": "Aviation",
+                "openapi": "api/AviationService.openapi.yaml"
+              },
+              {
+                "group": "Maritime",
+                "openapi": "api/MaritimeService.openapi.yaml"
+              },
+              {
+                "group": "Infrastructure",
+                "openapi": "api/InfrastructureService.openapi.yaml"
+              }
+            ]
+          },
+          {
+            "group": "Other",
+            "pages": [
+              {
+                "group": "News",
+                "openapi": "api/NewsService.openapi.yaml"
+              },
+              {
+                "group": "Research",
+                "openapi": "api/ResearchService.openapi.yaml"
+              },
+              {
+                "group": "Positive Events",
+                "openapi": "api/PositiveEventsService.openapi.yaml"
+              },
+              {
+                "group": "Giving",
+                "openapi": "api/GivingService.openapi.yaml"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
-  "anchors": [
-    {
-      "name": "API Reference",
-      "icon": "code",
-      "url": "api-reference"
+  "footer": {
+    "socials": {
+      "github": "https://github.com/koala73/worldmonitor"
     }
-  ],
-  "navigation": [
-    {
-      "group": "Getting Started",
-      "pages": [
-        "DOCUMENTATION",
-        "ARCHITECTURE"
-      ]
-    },
-    {
-      "group": "Core Systems",
-      "pages": [
-        "DATA_SOURCES",
-        "ALGORITHMS",
-        "MAP_ENGINE",
-        "AI_INTELLIGENCE",
-        "MAPS_AND_GEOCODING"
-      ]
-    },
-    {
-      "group": "Finance",
-      "pages": [
-        "FINANCE_DATA",
-        "PREMIUM_FINANCE",
-        "PREMIUM_FINANCE_SEARCH"
-      ]
-    },
-    {
-      "group": "Infrastructure",
-      "pages": [
-        "DESKTOP_APP",
-        "ORBITAL_SURVEILLANCE",
-        "CORS",
-        "HEALTH_ENDPOINTS",
-        "RELAY_PARAMETERS"
-      ]
-    },
-    {
-      "group": "Contributing",
-      "pages": [
-        "ADDING_ENDPOINTS",
-        "API_KEY_DEPLOYMENT",
-        "RELEASE_PACKAGING"
-      ]
-    },
-    {
-      "group": "API Reference",
-      "pages": [
-        {
-          "group": "Geopolitical",
-          "openapi": [
-            "api/ConflictService.openapi.yaml",
-            "api/MilitaryService.openapi.yaml",
-            "api/UnrestService.openapi.yaml",
-            "api/IntelligenceService.openapi.yaml",
-            "api/DisplacementService.openapi.yaml",
-            "api/CyberService.openapi.yaml"
-          ]
-        },
-        {
-          "group": "Natural Events",
-          "openapi": [
-            "api/NaturalService.openapi.yaml",
-            "api/SeismologyService.openapi.yaml",
-            "api/ClimateService.openapi.yaml",
-            "api/WildfireService.openapi.yaml"
-          ]
-        },
-        {
-          "group": "Economy & Markets",
-          "openapi": [
-            "api/EconomicService.openapi.yaml",
-            "api/MarketService.openapi.yaml",
-            "api/TradeService.openapi.yaml",
-            "api/SupplyChainService.openapi.yaml",
-            "api/PredictionService.openapi.yaml"
-          ]
-        },
-        {
-          "group": "Infrastructure & Transport",
-          "openapi": [
-            "api/AviationService.openapi.yaml",
-            "api/MaritimeService.openapi.yaml",
-            "api/InfrastructureService.openapi.yaml"
-          ]
-        },
-        {
-          "group": "Other",
-          "openapi": [
-            "api/NewsService.openapi.yaml",
-            "api/ResearchService.openapi.yaml",
-            "api/PositiveEventsService.openapi.yaml",
-            "api/GivingService.openapi.yaml"
-          ]
-        }
-      ]
-    }
-  ],
-  "footerSocials": {
-    "github": "https://github.com/koala73/worldmonitor"
   }
 }


### PR DESCRIPTION
## Summary
- Adds the required `"theme": "mint"` field to `docs/docs.json`
- Mintlify v2 requires a theme discriminator; without it, deployment fails with "Invalid discriminator value" error

## Test plan
- [ ] Mintlify deployment succeeds after merge