### PR TITLE
fix(docs): escape angle brackets for MDX compatibility

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -57,7 +57,7 @@ Several non-obvious algorithmic choices are worth explaining:
 
 **H3 hexagonal grid for GPS jamming** — Hexagonal grids (H3 resolution 4, ~22km edge length) are used instead of rectangular lat/lon cells because hexagons have uniform adjacency (6 neighbors vs. 4/8 for squares), equal area at any latitude, and no meridian convergence distortion. This matters for interference zone detection where spatial uniformity affects clustering accuracy.
 
-**Cosine-latitude-corrected distance** — Cable health matching and several proximity calculations use equirectangular approximation with `cos(lat)` longitude correction instead of full Haversine. At the distances involved (50–600km), the error is <0.5% while being ~10x faster — important when computing distances against 500+ infrastructure assets per event.
+**Cosine-latitude-corrected distance** — Cable health matching and several proximity calculations use equirectangular approximation with `cos(lat)` longitude correction instead of full Haversine. At the distances involved (50–600km), the error is &lt;0.5% while being ~10x faster — important when computing distances against 500+ infrastructure assets per event.
 
 **Negative caching** — When an upstream API returns an error, the system caches the failure state for a defined period (5 minutes for UCDP, 30 seconds for Polymarket queue rejections) rather than retrying immediately. This prevents thundering-herd effects where hundreds of concurrent users all hammer a downed API, and it provides clear signal to the intelligence gap tracker that a source is unavailable.
 
@@ -330,7 +330,7 @@ WebGPU (fastest)  →  WebGL (fast)  →  WASM + SIMD (baseline)
 2. **WebGL** — fallback when WebGPU is unavailable. Uses the existing GPU via WebGL compute shaders. Available in all modern browsers
 3. **WASM + SIMD** — CPU-only fallback. `SharedArrayBuffer` and WASM SIMD availability are probed. SIMD provides ~2–4x speedup over plain WASM for vector operations
 
-A `deviceMemory` API guard excludes the ML pipeline entirely on low-memory devices (mobile phones with <4GB RAM), preventing out-of-memory crashes from loading 384-dimensional float32 embedding models alongside the map renderer and live video streams.
+A `deviceMemory` API guard excludes the ML pipeline entirely on low-memory devices (mobile phones with &lt;4GB RAM), preventing out-of-memory crashes from loading 384-dimensional float32 embedding models alongside the map renderer and live video streams.
 
 ---
 

--- a/docs/data-sources.mdx
+++ b/docs/data-sources.mdx
@@ -367,7 +367,7 @@ Feeds also carry a **propaganda risk rating** and **state affiliation flag**. St
 
 ### Data Freshness & Intelligence Gaps
 
-A singleton tracker monitors 31 data sources (GDELT, GDELT Doc, RSS, AIS, OpenSky, Wingbits, USGS, weather, outages, ACLED, ACLED conflict, Polymarket, predictions, PizzINT, economic, oil, spending, NASA FIRMS, cyber threats, UCDP, UCDP events, HAPI, UNHCR, climate, WorldPop, giving, BIS, WTO trade, supply chain, security advisories, GPS jamming) with status categorization: fresh (<15 min), stale (2h), very_stale (6h), no_data, error, disabled. Two sources (GDELT, RSS) are flagged as `requiredForRisk` — their absence directly impacts CII scoring quality. The tracker explicitly reports **intelligence gaps** — what analysts can't see — preventing false confidence when critical data sources are down or degraded.
+A singleton tracker monitors 31 data sources (GDELT, GDELT Doc, RSS, AIS, OpenSky, Wingbits, USGS, weather, outages, ACLED, ACLED conflict, Polymarket, predictions, PizzINT, economic, oil, spending, NASA FIRMS, cyber threats, UCDP, UCDP events, HAPI, UNHCR, climate, WorldPop, giving, BIS, WTO trade, supply chain, security advisories, GPS jamming) with status categorization: fresh (&lt;15 min), stale (2h), very_stale (6h), no_data, error, disabled. Two sources (GDELT, RSS) are flagged as `requiredForRisk` — their absence directly impacts CII scoring quality. The tracker explicitly reports **intelligence gaps** — what analysts can't see — preventing false confidence when critical data sources are down or degraded.
 
 ---
 
@@ -379,7 +379,7 @@ Polymarket geopolitical markets are queried using tag-based filters (Ukraine, Ir
 
 **4-tier fetch strategy** — prediction markets use a cascading fetch chain to maximize data availability:
 
-1. **Bootstrap hydration** — zero-network, page-load-embedded data from the Redis-cached `predictions` key. If fresh (<20 min), the panel renders instantly without any API call
+1. **Bootstrap hydration** — zero-network, page-load-embedded data from the Redis-cached `predictions` key. If fresh (&lt;20 min), the panel renders instantly without any API call
 2. **Sebuf RPC** — `POST /api/prediction/v1/list-prediction-markets` queries Redis for the seed-script-maintained cache. Single request, sub-100ms cold start
 3. **Browser-direct Polymarket** — the browser fetches Polymarket's Gamma API directly, bypassing JA3 fingerprinting (browser TLS passes Cloudflare)
 4. **Sidecar native TLS** — on Tauri desktop, Rust's `reqwest` TLS fingerprint differs from Node.js, providing another bypass vector

--- a/docs/documentation.mdx
+++ b/docs/documentation.mdx
@@ -724,7 +724,7 @@ similarity(A, B) = |A ∩ B| / |A ∪ B|
 
 - Headlines are lowercased and split on word boundaries
 - Stop words removed: "the", "a", "an", "in", "on", "at", "to", "for", "of", "and", "or"
-- Short tokens (<3 characters) filtered out
+- Short tokens (&lt;3 characters) filtered out
 - Result cached per headline for performance
 
 **Inverted Index Optimization**:
@@ -748,7 +748,7 @@ Each news cluster tracks publication velocity:
 
 - **Sources per hour** = article count / time span
 - **Trend** = rising/stable/falling based on first-half vs second-half publication rate
-- **Levels**: Normal (<3/hr), Elevated (3-6/hr), Spike (>6/hr)
+- **Levels**: Normal (&lt;3/hr), Elevated (3-6/hr), Spike (>6/hr)
 
 ### Sentiment Detection
 
@@ -839,7 +839,7 @@ The system counts matching news articles in the current feed, applies velocity a
 
 | Level | Criteria | Visual |
 |-------|----------|--------|
-| **Low** | <3 matches, normal velocity | Gray marker |
+| **Low** | &lt;3 matches, normal velocity | Gray marker |
 | **Elevated** | 3-6 matches OR elevated velocity | Yellow pulse |
 | **High** | >6 matches OR spike velocity | Red pulse |
 
@@ -1072,7 +1072,7 @@ Beyond the base component scores, several contextual factors can boost a country
 
 - Information ≥70: +5 points
 - Information ≥50: +3 points
-- Information <50: +0 points
+- Information &lt;50: +0 points
 
 **Focal Point Boost Tiers**:
 
@@ -1398,7 +1398,7 @@ Aggregate activity maps to a 5-level readiness scale:
 | **DEFCON 2** | ≥75% | FAST PACE | High activity; significant event underway |
 | **DEFCON 3** | ≥50% | ROUND HOUSE | Elevated; above-normal operations |
 | **DEFCON 4** | ≥25% | DOUBLE TAKE | Increased vigilance |
-| **DEFCON 5** | <25% | FADE OUT | Normal peacetime operations |
+| **DEFCON 5** | &lt;25% | FADE OUT | Normal peacetime operations |
 
 ### GDELT Tension Pairs
 
@@ -2231,12 +2231,12 @@ Each data source has calibrated freshness expectations:
 
 | Source | Expected Interval | "Fresh" Threshold |
 |--------|------------------|-------------------|
-| News feeds | 5 minutes | <10 minutes |
-| Stock quotes | 1 minute | <5 minutes |
-| Earthquakes | 5 minutes | <15 minutes |
-| Weather | 10 minutes | <30 minutes |
-| Flight delays | 10 minutes | <20 minutes |
-| AIS vessels | Real-time | <1 minute |
+| News feeds | 5 minutes | &lt;10 minutes |
+| Stock quotes | 1 minute | &lt;5 minutes |
+| Earthquakes | 5 minutes | &lt;15 minutes |
+| Weather | 10 minutes | &lt;30 minutes |
+| Flight delays | 10 minutes | &lt;20 minutes |
+| AIS vessels | Real-time | &lt;1 minute |
 
 ### Visual Indicators
 


### PR DESCRIPTION
## Summary
- Escapes `<digit` patterns in `architecture.mdx`, `data-sources.mdx`, and `documentation.mdx` with `&lt;`
- MDX interprets bare `<0`, `<3`, `<4` etc. as JSX tags, causing parse failures on Mintlify deploy

## Test plan
- [ ] Mintlify deploy shows no parse errors for these 3 files