### PR TITLE
feat(config): add NSE and BSE (India) market support (#1102)

### DIFF
--- a/src/config/india-markets.ts
+++ b/src/config/india-markets.ts
@@ -1,0 +1,24 @@
+import type { MarketSymbol } from '@/types';
+
+export const INDIA_MARKET_SYMBOLS: MarketSymbol[] = [
+  { symbol: "^NSEI", name: "Nifty 50", display: "NIFTY" },
+  { symbol: "^BSESN", name: "S&P BSE SENSEX", display: "SENSEX" },
+  { symbol: "RELIANCE.NS", name: "Reliance Industries", display: "RELIANCE" },
+  { symbol: "TCS.NS", name: "TCS", display: "TCS" },
+  { symbol: "HDFCBANK.NS", name: "HDFC Bank", display: "HDFCBANK" },
+  { symbol: "ICICIBANK.NS", name: "ICICI Bank", display: "ICICIBANK" },
+  { symbol: "BHARTIARTL.NS", name: "Bharti Airtel", display: "AIRTEL" },
+  { symbol: "INFY.NS", name: "Infosys", display: "INFY" },
+  { symbol: "SBIN.NS", name: "State Bank of India", display: "SBIN" },
+  { symbol: "LICI.NS", name: "LIC", display: "LICI" },
+  { symbol: "ITC.NS", name: "ITC", display: "ITC" },
+  { symbol: "HINDUNILVR.NS", name: "Hindustan Unilever", display: "HUL" },
+  { symbol: "LT.NS", name: "L&T", display: "LT" },
+  { symbol: "BAJFINANCE.NS", name: "Bajaj Finance", display: "BAJFIN" },
+  { symbol: "ADANIENT.NS", name: "Adani Enterprises", display: "ADANI" },
+  { symbol: "SUNPHARMA.NS", name: "Sun Pharma", display: "SUN" },
+  { symbol: "TITAN.NS", name: "Titan Company", display: "TITAN" },
+  { symbol: "M&M.NS", name: "Mahindra & Mahindra", display: "M&M" },
+  { symbol: "TATASTEEL.NS", name: "Tata Steel", display: "STEEL" },
+  { symbol: "KOTAKBANK.NS", name: "Kotak Mahindra", display: "KOTAK" }
+];


### PR DESCRIPTION
This PR adds regional market support for India.

Key changes:
- Created `india-markets.ts` with NSE and BSE configuration.
- Added support for tracking Indian equity indices and major tickers.