### PR TITLE
fix: bypass viewport gate on initial panel data load

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -83,7 +83,7 @@ export class App {
     return panelIds.some((panelId) => this.isPanelNearViewport(panelId, marginPx));
   }
 
-  private async primeVisiblePanelData(): Promise<void> {
+  private async primeVisiblePanelData(forceAll = false): Promise<void> {
     const tasks: Promise<unknown>[] = [];
     const primeTask = (key: string, task: () => Promise<unknown>): void => {
       if (this.visiblePanelPrimed.has(key) || this.state.inFlight.has(key)) return;
@@ -99,55 +99,58 @@ export class App {
       tasks.push(wrapped);
     };
 
-    if (this.isPanelNearViewport('service-status')) {
+    const shouldPrime = (id: string): boolean => forceAll || this.isPanelNearViewport(id);
+    const shouldPrimeAny = (ids: string[]): boolean => forceAll || this.isAnyPanelNearViewport(ids);
+
+    if (shouldPrime('service-status')) {
       const panel = this.state.panels['service-status'] as ServiceStatusPanel | undefined;
       if (panel) primeTask('service-status', () => panel.fetchStatus());
     }
-    if (this.isPanelNearViewport('macro-signals')) {
+    if (shouldPrime('macro-signals')) {
       const panel = this.state.panels['macro-signals'] as MacroSignalsPanel | undefined;
       if (panel) primeTask('macro-signals', () => panel.fetchData());
     }
-    if (this.isPanelNearViewport('etf-flows')) {
+    if (shouldPrime('etf-flows')) {
       const panel = this.state.panels['etf-flows'] as ETFFlowsPanel | undefined;
       if (panel) primeTask('etf-flows', () => panel.fetchData());
     }
-    if (this.isPanelNearViewport('stablecoins')) {
+    if (shouldPrime('stablecoins')) {
       const panel = this.state.panels['stablecoins'] as StablecoinPanel | undefined;
       if (panel) primeTask('stablecoins', () => panel.fetchData());
     }
-    if (this.isPanelNearViewport('telegram-intel')) {
+    if (shouldPrime('telegram-intel')) {
       primeTask('telegramIntel', () => this.dataLoader.loadTelegramIntel());
     }
-    if (this.isPanelNearViewport('gulf-economies')) {
+    if (shouldPrime('gulf-economies')) {
       const panel = this.state.panels['gulf-economies'] as GulfEconomiesPanel | undefined;
       if (panel) primeTask('gulf-economies', () => panel.fetchData());
     }
-    if (this.isAnyPanelNearViewport(['markets', 'heatmap', 'commodities', 'crypto'])) {
+    if (shouldPrimeAny(['markets', 'heatmap', 'commodities', 'crypto'])) {
       primeTask('markets', () => this.dataLoader.loadMarkets());
     }
-    if (this.isPanelNearViewport('polymarket')) {
+    if (shouldPrime('polymarket')) {
       primeTask('predictions', () => this.dataLoader.loadPredictions());
     }
-    if (this.isPanelNearViewport('economic')) {
+    if (shouldPrime('economic')) {
       primeTask('fred', () => this.dataLoader.loadFredData());
       primeTask('oil', () => this.dataLoader.loadOilAnalytics());
       primeTask('spending', () => this.dataLoader.loadGovernmentSpending());
       primeTask('bis', () => this.dataLoader.loadBisData());
     }
-    if (this.isPanelNearViewport('trade-policy')) {
+    if (shouldPrime('trade-policy')) {
       primeTask('tradePolicy', () => this.dataLoader.loadTradePolicy());
     }
-    if (this.isPanelNearViewport('supply-chain')) {
+    if (shouldPrime('supply-chain')) {
       primeTask('supplyChain', () => this.dataLoader.loadSupplyChain());
     }
     if (SITE_VARIANT === 'finance' && getSecretState('WORLDMONITOR_API_KEY').present) {
-      if (this.isPanelNearViewport('stock-analysis')) {
+      if (shouldPrime('stock-analysis')) {
         primeTask('stockAnalysis', () => this.dataLoader.loadStockAnalysis());
       }
-      if (this.isPanelNearViewport('stock-backtest')) {
+      if (shouldPrime('stock-backtest')) {
         primeTask('stockBacktest', () => this.dataLoader.loadStockBacktest());
       }
-      if (this.isPanelNearViewport('daily-market-brief')) {
+      if (shouldPrime('daily-market-brief')) {
         primeTask('dailyMarketBrief', () => this.dataLoader.loadDailyMarketBrief());
       }
     }
@@ -581,8 +584,8 @@ export class App {
     // Phase 6: Data loading
     this.dataLoader.syncDataFreshnessWithLayers();
     await preloadCountryGeometry();
-    await this.dataLoader.loadAllData();
-    await this.primeVisiblePanelData();
+    await this.dataLoader.loadAllData(true);
+    await this.primeVisiblePanelData(true);
     window.addEventListener('scroll', this.handleViewportPrime, { passive: true });
     window.addEventListener('resize', this.handleViewportPrime);
 

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -335,7 +335,7 @@ export class DataLoaderManager implements AppModule {
     return panelIds.some((panelId) => this.isPanelNearViewport(panelId, marginPx));
   }
 
-  async loadAllData(): Promise<void> {
+  async loadAllData(forceAll = false): Promise<void> {
     const runGuarded = async (name: string, fn: () => Promise<void>): Promise<void> => {
       if (this.ctx.isDestroyed || this.ctx.inFlight.has(name)) return;
       this.ctx.inFlight.add(name);
@@ -348,26 +348,29 @@ export class DataLoaderManager implements AppModule {
       }
     };
 
+    const shouldLoad = (id: string): boolean => forceAll || this.isPanelNearViewport(id);
+    const shouldLoadAny = (ids: string[]): boolean => forceAll || this.isAnyPanelNearViewport(ids);
+
     const tasks: Array<{ name: string; task: Promise<void> }> = [
       { name: 'news', task: runGuarded('news', () => this.loadNews()) },
     ];
 
     // Happy variant only loads news data -- skip all geopolitical/financial/military data
     if (SITE_VARIANT !== 'happy') {
-      if (this.isAnyPanelNearViewport(['markets', 'heatmap', 'commodities', 'crypto'])) {
+      if (shouldLoadAny(['markets', 'heatmap', 'commodities', 'crypto'])) {
         tasks.push({ name: 'markets', task: runGuarded('markets', () => this.loadMarkets()) });
       }
-      if (SITE_VARIANT === 'finance' && getSecretState('WORLDMONITOR_API_KEY').present && this.isPanelNearViewport('stock-analysis')) {
+      if (SITE_VARIANT === 'finance' && getSecretState('WORLDMONITOR_API_KEY').present && shouldLoad('stock-analysis')) {
         tasks.push({ name: 'stockAnalysis', task: runGuarded('stockAnalysis', () => this.loadStockAnalysis()) });
       }
-      if (SITE_VARIANT === 'finance' && getSecretState('WORLDMONITOR_API_KEY').present && this.isPanelNearViewport('stock-backtest')) {
+      if (SITE_VARIANT === 'finance' && getSecretState('WORLDMONITOR_API_KEY').present && shouldLoad('stock-backtest')) {
         tasks.push({ name: 'stockBacktest', task: runGuarded('stockBacktest', () => this.loadStockBacktest()) });
       }
-      if (this.isPanelNearViewport('polymarket')) {
+      if (shouldLoad('polymarket')) {
         tasks.push({ name: 'predictions', task: runGuarded('predictions', () => this.loadPredictions()) });
       }
       tasks.push({ name: 'pizzint', task: runGuarded('pizzint', () => this.loadPizzInt()) });
-      if (this.isPanelNearViewport('economic')) {
+      if (shouldLoad('economic')) {
         tasks.push({ name: 'fred', task: runGuarded('fred', () => this.loadFredData()) });
         tasks.push({ name: 'oil', task: runGuarded('oil', () => this.loadOilAnalytics()) });
         tasks.push({ name: 'spending', task: runGuarded('spending', () => this.loadGovernmentSpending()) });
@@ -376,10 +379,10 @@ export class DataLoaderManager implements AppModule {
 
       // Trade policy data (FULL and FINANCE only)
       if (SITE_VARIANT === 'full' || SITE_VARIANT === 'finance' || SITE_VARIANT === 'commodity') {
-        if (this.isPanelNearViewport('trade-policy')) {
+        if (shouldLoad('trade-policy')) {
           tasks.push({ name: 'tradePolicy', task: runGuarded('tradePolicy', () => this.loadTradePolicy()) });
         }
-        if (this.isPanelNearViewport('supply-chain')) {
+        if (shouldLoad('supply-chain')) {
           tasks.push({ name: 'supplyChain', task: runGuarded('supplyChain', () => this.loadSupplyChain()) });
         }
       }
@@ -387,19 +390,19 @@ export class DataLoaderManager implements AppModule {
 
     // Progress charts data (happy variant only)
     if (SITE_VARIANT === 'happy') {
-      if (this.isPanelNearViewport('progress')) {
+      if (shouldLoad('progress')) {
         tasks.push({
           name: 'progress',
           task: runGuarded('progress', () => this.loadProgressData()),
         });
       }
-      if (this.isPanelNearViewport('species')) {
+      if (shouldLoad('species')) {
         tasks.push({
           name: 'species',
           task: runGuarded('species', () => this.loadSpeciesData()),
         });
       }
-      if (this.isPanelNearViewport('renewable')) {
+      if (shouldLoad('renewable')) {
         tasks.push({
           name: 'renewable',
           task: runGuarded('renewable', () => this.loadRenewableData()),


### PR DESCRIPTION
## Summary
- Commit d1789541 introduced viewport-gated loading via `isPanelNearViewport()` for both `loadAllData()` and `primeVisiblePanelData()`, but on initial load the viewport check returns false for panels not yet laid out
- Adds `forceAll` parameter to both methods; initial call from `init()` passes `true` to bypass viewport checks
- Subsequent scroll/resize triggers still use viewport gating for lazy loading

## Affected panels
Service Status, Economic Indicators, Market Radar, BTC ETF Tracker, Stablecoins, Gulf Economies, Polymarket, Trade Policy, Supply Chain (and happy-variant panels)

## Test plan
- [ ] Load dashboard, verify all panels populate (no stuck "Loading...")
- [ ] Scroll down to off-screen panels, verify they still lazy-load on scroll
- [ ] Test finance/happy/commodity variants