### PR TITLE
fix(docs): remove invalid colors.anchors from Mintlify config

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -12,8 +12,7 @@
   "colors": {
     "primary": "#4ade80",
     "light": "#4ade80",
-    "dark": "#22c55e",
-    "anchors": "#4ade80"
+    "dark": "#22c55e"
   },
   "navbar": {
     "links": [


### PR DESCRIPTION
## Summary
- Removes `colors.anchors` key that was added in #1463
- Mintlify v2 schema rejects it as unrecognized, blocking deployment validation

## Test plan
- [ ] Mintlify validation passes (no `Unrecognized key` error)