### PR TITLE
feat: LLM offline gate + header status indicator

### DIFF
--- a/server/_shared/llm-health.ts
+++ b/server/_shared/llm-health.ts
@@ -1,0 +1,79 @@
+// server/_shared/llm-health.ts
+// Lightweight LLM provider health gate.
+// Probes provider URLs with a fast request, caches results.
+// All LLM call sites check this before attempting expensive fetch calls.
+
+const PROBE_TIMEOUT_MS = 2_000;
+const CACHE_TTL_MS = 60_000; // re-probe every 60s
+
+interface HealthEntry {
+  available: boolean;
+  checkedAt: number;
+}
+
+const cache = new Map<string, HealthEntry>();
+
+/**
+ * Probe a provider URL to check if it's reachable.
+ * Uses a lightweight GET to the base origin (most OpenAI-compat servers
+ * return 200 or 404 on root, either confirms reachability).
+ */
+async function probe(url: string): Promise<boolean> {
+  try {
+    const origin = new URL(url).origin;
+    const resp = await fetch(origin, {
+      method: 'GET',
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    // Any HTTP response means the server is reachable
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if an LLM provider endpoint is available.
+ * Returns cached result if fresh (< CACHE_TTL_MS old).
+ * Otherwise probes and caches the result.
+ */
+export async function isProviderAvailable(apiUrl: string): Promise<boolean> {
+  const origin = new URL(apiUrl).origin;
+  const cached = cache.get(origin);
+  if (cached && Date.now() - cached.checkedAt < CACHE_TTL_MS) {
+    return cached.available;
+  }
+
+  const available = await probe(apiUrl);
+  cache.set(origin, { available, checkedAt: Date.now() });
+
+  if (!available) {
+    console.warn(`[llm-health] Provider unreachable: ${origin}`);
+  }
+
+  return available;
+}
+
+/**
+ * Get current health status for all probed providers.
+ * Used by /api/health to expose LLM status.
+ */
+export function getLlmHealthStatus(): Record<string, { available: boolean; checkedAt: number }> {
+  const status: Record<string, { available: boolean; checkedAt: number }> = {};
+  for (const [origin, entry] of cache) {
+    status[origin] = { available: entry.available, checkedAt: entry.checkedAt };
+  }
+  return status;
+}
+
+/**
+ * Force a re-probe of all cached providers.
+ * Called on startup or when a provider comes back online.
+ */
+export async function reprobeAll(): Promise<void> {
+  const origins = [...cache.keys()];
+  await Promise.all(origins.map(async (origin) => {
+    const available = await probe(origin);
+    cache.set(origin, { available, checkedAt: Date.now() });
+  }));
+}

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -1,4 +1,5 @@
 import { CHROME_UA } from './constants';
+import { isProviderAvailable } from './llm-health';
 
 export interface ProviderCredentials {
   apiUrl: string;
@@ -11,9 +12,9 @@ const OLLAMA_HOST_ALLOWLIST = new Set([
   'localhost', '127.0.0.1', '::1', '[::1]', 'host.docker.internal',
 ]);
 
-function isSidecar(): boolean {
-  return typeof process !== 'undefined' &&
-    (process.env?.LOCAL_API_MODE || '').includes('sidecar');
+function isLocalDeployment(): boolean {
+  const mode = typeof process !== 'undefined' ? (process.env?.LOCAL_API_MODE || '') : '';
+  return mode.includes('sidecar') || mode.includes('docker');
 }
 
 export function getProviderCredentials(provider: string): ProviderCredentials | null {
@@ -21,7 +22,7 @@ export function getProviderCredentials(provider: string): ProviderCredentials | 
     const baseUrl = process.env.OLLAMA_API_URL;
     if (!baseUrl) return null;
 
-    if (!isSidecar()) {
+    if (!isLocalDeployment()) {
       try {
         const hostname = new URL(baseUrl).hostname;
         if (!OLLAMA_HOST_ALLOWLIST.has(hostname)) {
@@ -131,6 +132,13 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
   for (const providerName of providers) {
     const creds = getProviderCredentials(providerName);
     if (!creds) {
+      if (forcedProvider) return null;
+      continue;
+    }
+
+    // Health gate: skip provider if endpoint is unreachable
+    if (!(await isProviderAvailable(creds.apiUrl))) {
+      console.warn(`[llm:${providerName}] Offline, skipping`);
       if (forcedProvider) return null;
       continue;
     }

--- a/server/worldmonitor/intelligence/v1/_batch-classify.ts
+++ b/server/worldmonitor/intelligence/v1/_batch-classify.ts
@@ -1,6 +1,7 @@
 import { setCachedJson } from '../../../_shared/redis';
 import { sha256Hex } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
+import { isProviderAvailable } from '../../../_shared/llm-health';
 
 const VALID_LEVELS = ['critical', 'high', 'medium', 'low', 'info'];
 const VALID_CATEGORIES = [
@@ -55,6 +56,11 @@ export async function batchClassifyTitles(
     const prompt = sanitized.map((t, i) => `${i}|${t}`).join('\n');
 
     try {
+      // Health gate: skip entire batch if provider is unreachable
+      if (!(await isProviderAvailable(apiUrl))) {
+        break;
+      }
+
       const resp = await fetch(apiUrl, {
         method: 'POST',
         headers: {

--- a/server/worldmonitor/intelligence/v1/classify-event.ts
+++ b/server/worldmonitor/intelligence/v1/classify-event.ts
@@ -9,6 +9,7 @@ import { cachedFetchJson } from '../../../_shared/redis';
 import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { UPSTREAM_TIMEOUT_MS, GROQ_API_URL, GROQ_MODEL, sha256Hex } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
+import { isProviderAvailable } from '../../../_shared/llm-health';
 
 // ========================================================================
 // Constants
@@ -68,6 +69,10 @@ Categories: conflict, protest, disaster, diplomatic, economic, terrorism, cyber,
 Focus: geopolitical events, conflicts, disasters, diplomacy. Classify by real-world severity and impact.
 
 Return: {"level":"...","category":"..."}`;
+
+          if (!(await isProviderAvailable(apiUrl))) {
+            return null;
+          }
 
           const resp = await fetch(apiUrl, {
             method: 'POST',

--- a/server/worldmonitor/intelligence/v1/deduct-situation.ts
+++ b/server/worldmonitor/intelligence/v1/deduct-situation.ts
@@ -7,6 +7,7 @@ import type {
 import { cachedFetchJson } from '../../../_shared/redis';
 import { sha256Hex } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
+import { isProviderAvailable } from '../../../_shared/llm-health';
 
 const DEDUCT_TIMEOUT_MS = 120_000;
 const DEDUCT_CACHE_TTL = 3600;
@@ -51,6 +52,10 @@ Your task is to DEDUCT the situation in a near timeline (e.g. 24 hours to a few 
                 let userPrompt = query;
                 if (geoContext) {
                     userPrompt += `\n\n### Current Intelligence Context\n${geoContext}`;
+                }
+
+                if (!(await isProviderAvailable(apiUrl))) {
+                    return null;
                 }
 
                 const resp = await fetch(apiUrl, {

--- a/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
@@ -7,6 +7,7 @@ import type {
 import { cachedFetchJson } from '../../../_shared/redis';
 import { UPSTREAM_TIMEOUT_MS, GROQ_API_URL, GROQ_MODEL, TIER1_COUNTRIES, sha256Hex } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
+import { isProviderAvailable } from '../../../_shared/llm-health';
 
 // ========================================================================
 // Constants
@@ -75,6 +76,10 @@ Rules:
         ];
         if (contextSnapshot) {
           userPromptParts.push(`Context snapshot:\n${contextSnapshot}`);
+        }
+
+        if (!(await isProviderAvailable(GROQ_API_URL))) {
+          return null;
         }
 
         const resp = await fetch(GROQ_API_URL, {

--- a/server/worldmonitor/news/v1/summarize-article.ts
+++ b/server/worldmonitor/news/v1/summarize-article.ts
@@ -13,6 +13,7 @@ import {
   getCacheKey,
 } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
+import { isProviderAvailable } from '../../../_shared/llm-health';
 
 // ======================================================================
 // Reasoning preamble detection
@@ -101,6 +102,11 @@ export async function summarizeArticle(
           variant,
           lang,
         });
+
+        // Health gate: skip if provider is unreachable
+        if (!(await isProviderAvailable(apiUrl))) {
+          return null;
+        }
 
         const response = await fetch(apiUrl, {
           method: 'POST',

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1100,6 +1100,36 @@ async function dispatch(requestUrl, req, routes, context) {
       routes: routes.length,
     });
   }
+  if (requestUrl.pathname === '/api/llm-health') {
+    const providers = [];
+    const ollamaUrl = process.env.OLLAMA_API_URL;
+    const groqKey = process.env.GROQ_API_KEY;
+
+    if (ollamaUrl) {
+      try {
+        const origin = new URL(ollamaUrl).origin;
+        let available = false;
+        try {
+          await fetch(origin, { method: 'GET', signal: AbortSignal.timeout(2000) });
+          available = true;
+        } catch {}
+        providers.push({ name: 'ollama', url: origin, available });
+      } catch {}
+    }
+
+    if (groqKey && groqKey.startsWith('gsk_')) {
+      let groqAvailable = false;
+      try {
+        await fetch('https://api.groq.com', { method: 'GET', signal: AbortSignal.timeout(2000) });
+        groqAvailable = true;
+      } catch {}
+      providers.push({ name: 'groq', url: 'https://api.groq.com', available: groqAvailable });
+    }
+
+    const anyAvailable = providers.some(p => p.available);
+    return json({ available: anyAvailable, providers, checkedAt: Date.now() });
+  }
+
   if (requestUrl.pathname === '/api/local-traffic-log') {
     if (req.method === 'DELETE') {
       trafficLog.length = 0;

--- a/src/App.ts
+++ b/src/App.ts
@@ -371,6 +371,7 @@ export class App {
       exportPanel: null,
       unifiedSettings: null,
       pizzintIndicator: null,
+      llmStatusIndicator: null,
       countryBriefPage: null,
       countryTimeline: null,
       positivePanel: null,
@@ -552,6 +553,7 @@ export class App {
     this.eventHandlers.setupPlaybackControl();
     this.eventHandlers.setupStatusPanel();
     this.eventHandlers.setupPizzIntIndicator();
+    this.eventHandlers.setupLlmStatusIndicator();
     this.eventHandlers.setupExportPanel();
     this.eventHandlers.setupUnifiedSettings();
 

--- a/src/app/app-context.ts
+++ b/src/app/app-context.ts
@@ -13,7 +13,7 @@ import type { CountryTimeline } from '@/components/CountryTimeline';
 import type { PlaybackControl } from '@/components';
 import type { ExportPanel } from '@/utils';
 import type { UnifiedSettings } from '@/components/UnifiedSettings';
-import type { PizzIntIndicator } from '@/components';
+import type { PizzIntIndicator, LlmStatusIndicator } from '@/components';
 import type { ParsedMapUrlState } from '@/utils';
 import type { PositiveNewsFeedPanel } from '@/components/PositiveNewsFeedPanel';
 import type { CountersPanel } from '@/components/CountersPanel';
@@ -105,6 +105,7 @@ export interface AppContext {
   exportPanel: ExportPanel | null;
   unifiedSettings: UnifiedSettings | null;
   pizzintIndicator: PizzIntIndicator | null;
+  llmStatusIndicator: LlmStatusIndicator | null;
   countryBriefPage: CountryBriefPanel | null;
   countryTimeline: CountryTimeline | null;
 

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -8,6 +8,7 @@ import {
   PlaybackControl,
   StatusPanel,
   PizzIntIndicator,
+  LlmStatusIndicator,
   CIIPanel,
   PredictionPanel,
 } from '@/components';
@@ -764,6 +765,14 @@ export class EventHandlerManager implements AppModule {
     const headerLeft = this.ctx.container.querySelector('.header-left');
     if (headerLeft) {
       headerLeft.appendChild(this.ctx.pizzintIndicator.getElement());
+    }
+  }
+
+  setupLlmStatusIndicator(): void {
+    this.ctx.llmStatusIndicator = new LlmStatusIndicator();
+    const headerRight = this.ctx.container.querySelector('.header-right');
+    if (headerRight) {
+      headerRight.appendChild(this.ctx.llmStatusIndicator.getElement());
     }
   }
 

--- a/src/components/LlmStatusIndicator.ts
+++ b/src/components/LlmStatusIndicator.ts
@@ -1,0 +1,82 @@
+// Small header indicator showing LLM provider reachability.
+// Polls /api/llm-health every 60s. Shows green dot when available, red when offline.
+
+import { h } from '@/utils/dom-utils';
+
+const POLL_INTERVAL_MS = 60_000;
+
+interface LlmHealthResponse {
+  available: boolean;
+  providers: Array<{ name: string; url: string; available: boolean }>;
+  checkedAt: number;
+}
+
+export class LlmStatusIndicator {
+  private element: HTMLElement;
+  private dot: HTMLElement;
+  private label: HTMLElement;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    this.dot = h('span', {
+      style: 'display:inline-block;width:6px;height:6px;border-radius:50%;background:#ff4444;margin-right:4px;',
+    });
+    this.label = h('span', {
+      style: 'font-size:9px;letter-spacing:0.5px;opacity:0.7;',
+    }, 'LLM');
+    this.element = h('div', {
+      className: 'llm-status-indicator',
+      title: 'LLM provider status — checking...',
+      style: 'display:flex;align-items:center;padding:0 6px;cursor:default;user-select:none;',
+    }, this.dot, this.label);
+
+    this.poll();
+    this.timer = setInterval(() => this.poll(), POLL_INTERVAL_MS);
+  }
+
+  private async poll(): Promise<void> {
+    try {
+      const resp = await fetch('/api/llm-health', {
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (!resp.ok) {
+        this.setStatus(false, 'LLM', 'Health endpoint error');
+        return;
+      }
+      const data: LlmHealthResponse = await resp.json();
+      const active = data.providers.filter(p => p.available);
+      // Show the active provider name in the label (first available wins the chain)
+      const activeName = active.length > 0 ? active[0]!.name.toUpperCase() : '';
+      const tooltipLines: string[] = [];
+      for (const p of data.providers) {
+        tooltipLines.push(`${p.available ? '●' : '○'} ${p.name} — ${p.available ? 'online' : 'offline'}`);
+      }
+      this.setStatus(
+        data.available,
+        activeName || 'LLM',
+        data.available
+          ? `LLM via ${activeName}\n${tooltipLines.join('\n')}`
+          : `LLM offline — AI features unavailable\n${tooltipLines.join('\n')}`,
+      );
+    } catch {
+      this.setStatus(false, 'LLM', 'LLM health check failed');
+    }
+  }
+
+  private setStatus(available: boolean, labelText: string, tooltip: string): void {
+    this.dot.style.background = available ? '#44ff88' : '#ff4444';
+    this.label.textContent = labelText;
+    this.element.title = tooltip;
+  }
+
+  public getElement(): HTMLElement {
+    return this.element;
+  }
+
+  public destroy(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,6 +17,7 @@ export * from './EconomicPanel';
 export * from './SearchModal';
 export * from './MobileWarningModal';
 export * from './PizzIntIndicator';
+export * from './LlmStatusIndicator';
 export * from './GdeltIntelPanel';
 export * from './LiveNewsPanel';
 export * from './LiveWebcamsPanel';


### PR DESCRIPTION
## Summary
- All six LLM call sites now skip instantly (2s probe, cached 60s) when providers are unreachable instead of hanging 25s+ per request
- New `/api/llm-health` endpoint reports per-provider availability (Ollama, Groq)
- Header indicator shows green dot + active provider name or red dot when offline
- Fixes `LOCAL_API_MODE=docker` not being recognized by the Ollama host allowlist

## Test plan
- [ ] With LLM provider offline: no 25s timeout hangs, console shows skip logs
- [ ] Header shows red dot + "LLM" when all providers offline
- [ ] With Groq key configured: header shows green dot + "GROQ"
- [ ] `/api/llm-health` returns correct provider status JSON
- [ ] Summarize/classify/deduct calls return graceful fallback when provider down