### PR TITLE
fix: remove orphan Financial panel from commodity variant

### DIFF
--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -660,7 +660,6 @@ const COMMODITY_PANELS: Record<string, PanelConfig> = {
   'gulf-economies': { name: 'Gulf & OPEC Economies', enabled: true, priority: 1 },
   'gcc-investments': { name: 'GCC Resource Investments', enabled: true, priority: 2 },
   'airline-intel': { name: 'Airline Intelligence', enabled: true, priority: 2 },
-  finance: { name: 'Financial News', enabled: true, priority: 2 },
   polymarket: { name: 'Commodity Predictions', enabled: true, priority: 2 },
   'world-clock': { name: 'World Clock', enabled: true, priority: 2 },
   monitors: { name: 'My Monitors', enabled: true, priority: 2 },


### PR DESCRIPTION
## Summary
- Removed `finance` key from `COMMODITY_PANELS` in `src/config/panels.ts`
- This panel had no matching feed in `COMMODITY_FEEDS`, causing it to render as "UNAVAILABLE"

## Test plan
- [ ] Load the commodity variant (`?variant=commodity`)
- [ ] Verify the "Financial" panel no longer appears
- [ ] Verify all other commodity panels still render correctly