### PR TITLE
refactor: share lowercase dedupe sort helper for aircraft keys

### DIFF
--- a/src/services/military-flights.ts
+++ b/src/services/military-flights.ts
@@ -1,5 +1,5 @@
 import type { MilitaryFlight, MilitaryFlightCluster, MilitaryAircraftType, MilitaryOperator } from '@/types';
-import { createCircuitBreaker } from '@/utils';
+import { createCircuitBreaker, toUniqueSortedLowercase } from '@/utils';
 import {
   identifyByCallsign,
   identifyByAircraftType,
@@ -255,7 +255,7 @@ async function enrichFlightsWithWingbits(flights: MilitaryFlight[]): Promise<Mil
   }
 
   // Use deterministic ordering to improve cache locality across refreshes.
-  const hexCodes = Array.from(new Set(flights.map((f) => f.hexCode.toLowerCase()))).sort();
+  const hexCodes = toUniqueSortedLowercase(flights.map((flight) => flight.hexCode));
 
   // Batch fetch aircraft details
   const detailsMap = await getAircraftDetailsBatch(hexCodes);

--- a/src/services/wingbits.ts
+++ b/src/services/wingbits.ts
@@ -6,7 +6,7 @@
  * instead of the legacy /api/wingbits proxy.
  */
 
-import { createCircuitBreaker } from '@/utils';
+import { createCircuitBreaker, toUniqueSortedLowercase } from '@/utils';
 import { getRpcBaseUrl } from '@/services/rpc-client';
 import { dataFreshness } from './data-freshness';
 import { isFeatureAvailable } from './runtime-config';
@@ -243,7 +243,7 @@ export async function getAircraftDetailsBatch(icao24List: string[]): Promise<Map
   if (!isFeatureAvailable('wingbitsEnrichment')) return new Map();
   const results = new Map<string, WingbitsAircraftDetails>();
   const toFetch: string[] = [];
-  const requestedKeys = Array.from(new Set(icao24List.map((icao24) => icao24.toLowerCase()))).sort();
+  const requestedKeys = toUniqueSortedLowercase(icao24List);
 
   // Check local cache first
   for (const key of requestedKeys) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -172,6 +172,10 @@ export function chunkArray<T>(items: T[], size: number): T[][] {
   return chunks;
 }
 
+export function toUniqueSortedLowercase(values: readonly string[]): string[] {
+  return Array.from(new Set(values.map((value) => value.toLowerCase()))).sort();
+}
+
 export { proxyUrl, fetchWithProxy, rssProxyUrl } from './proxy';
 export { exportToJSON, exportToCSV, ExportPanel } from './export';
 export { buildMapUrl, parseMapUrlState } from './urlState';


### PR DESCRIPTION
## Summary
- add `toUniqueSortedLowercase` utility in `src/utils/index.ts`
- replace duplicated lowercase+dedupe+sort logic in military flights enrichment and Wingbits batch lookup
- keep behavior unchanged while reducing duplication

## Testing
- pre-push checks passed (typecheck, typecheck:api, edge tests, markdown lint, mdx lint, version check)
