### PR TITLE
docs: add dedicated license page with anti-rebranding enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,40 +546,53 @@ If you find World Monitor useful:
 
 ## License
 
-This project is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)** — see [LICENSE](LICENSE) for the full text.
+This project is dual-licensed:
+
+- **AGPL-3.0** for non-commercial, personal, educational, and research use. See [LICENSE](LICENSE) for the full text.
+- **Commercial license** required for any commercial use. Contact the maintainer.
 
 ### What This Means
 
-**You are free to:**
+**You are free to (non-commercial):**
 
-- **Use** — run World Monitor for any purpose, including commercial use
+- **Use** — run World Monitor for personal, educational, or research purposes
 - **Study** — read, audit, and learn from the source code
-- **Modify** — adapt, extend, and build upon the code
-- **Distribute** — share copies with anyone
+- **Modify** — adapt, extend, and build upon the code for non-commercial use
+- **Distribute** — share copies with anyone under AGPL-3.0
 
 **Under these conditions:**
 
 - **Source code disclosure** — if you distribute or modify this software, you **must** make the complete source code available under the same AGPL-3.0 license
-- **Network use is distribution** — if you run a modified version as a network service (SaaS, web app, API), you **must** provide the source code to all users who interact with it over the network. This is the key difference from GPL-3.0 — you cannot run a modified version behind a server without sharing the source
+- **Network use is distribution** — if you run a modified version as a network service (SaaS, web app, API), you **must** provide the source code to all users who interact with it over the network
 - **Same license (copyleft)** — any derivative work must be released under AGPL-3.0. You cannot re-license under a proprietary or more permissive license
 - **Attribution** — you must retain all copyright notices, give appropriate credit to the original author, and clearly indicate any changes you made
-- **State changes** — modified files must carry prominent notices stating that you changed them, with the date of the change
-- **No additional restrictions** — you may not impose any further restrictions on the rights granted by this license (e.g., no DRM, no additional terms)
+- **No rebranding** — forking the code, changing the name/logo, and deploying as your own product is not permitted without a commercial license
+
+**Commercial use is prohibited without a commercial license.** This includes:
+
+- Rebranding, white-labeling, or renaming World Monitor and deploying it as your own product
+- Running World Monitor (or a fork) as a paid service or behind a paywall
+- Embedding World Monitor code, components, or data pipelines into a commercial product
+- Using World Monitor internally at a for-profit company for revenue or competitive advantage
+- Selling data collected or processed through World Monitor
 
 **In plain terms:**
 
 | Use Case | Allowed? | Condition |
 |----------|----------|-----------|
-| Personal / internal use | Yes | No conditions |
-| Self-hosted deployment | Yes | No conditions if unmodified |
-| Forking & modifying | Yes | Must share source under AGPL-3.0 |
-| Commercial use | Yes | Must share source under AGPL-3.0 |
-| Running as a SaaS/web service | Yes | Must share source under AGPL-3.0 |
-| Bundling into a proprietary product | No | AGPL-3.0 copyleft prevents this |
+| Personal / research use | Yes | No conditions |
+| Self-hosted deployment (non-commercial) | Yes | Must retain attribution |
+| Forking and modifying (non-commercial) | Yes | Must share source under AGPL-3.0, retain attribution |
+| Rebranding / renaming as your own product | No | Requires commercial license |
+| Commercial use of any kind | No | Requires commercial license |
+| Running as a SaaS / paid web service | No | Requires commercial license |
+| Bundling into a proprietary product | No | Requires commercial license |
+
+For commercial licensing, contact the maintainer at the [GitHub repository](https://github.com/koala73/worldmonitor).
 
 **No warranty** — the software is provided "as is" without warranty of any kind.
 
-Copyright (C) 2024-2026 Elie Habib. All rights reserved under AGPL-3.0.
+Copyright (C) 2024-2026 Elie Habib. All rights reserved.
 
 ---
 

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -183,48 +183,4 @@ PRs that don't follow the code style or introduce security issues will be asked 
 
 ## License
 
-World Monitor is licensed under the [GNU Affero General Public License v3.0 (AGPL-3.0-only)](https://www.gnu.org/licenses/agpl-3.0.html).
-
-### What AGPL-3.0 means
-
-AGPL is a strong copyleft license designed for network software. It extends the GPL with one additional requirement: if you run a modified version of World Monitor as a publicly accessible service, you must make your source code available to users of that service.
-
-| You can | You must | You cannot |
-|---------|----------|------------|
-| View, study, and learn from the source code | Distribute source code with any binary distribution | Use World Monitor commercially without a commercial license |
-| Modify and create derivative works for personal/research use | License derivative works under AGPL-3.0 | Sublicense under a different license |
-| Run a personal instance for non-commercial use | State changes you made to the code | Hold the author liable |
-| Contribute improvements back to the project | Provide source access to users of any public-facing modified deployment | Use the project's trademarks without permission |
-
-### Commercial use requires a separate license
-
-**Any commercial use of World Monitor requires a commercial license from the maintainer.** This includes but is not limited to:
-
-- Running World Monitor (or a modified version) as a paid product or service
-- Embedding World Monitor code, components, or data pipelines into a commercial product
-- Offering World Monitor's capabilities as part of a consulting, SaaS, or managed service
-- Using World Monitor internally at a for-profit company to generate revenue or competitive advantage
-
-The AGPL-3.0 license governs non-commercial, personal, educational, and research use. If your use case involves any form of commercial activity, contact the maintainer to obtain a commercial license.
-
-### Common scenarios
-
-**Personal use or research**: Free to use, modify, and self-host. No restrictions beyond AGPL compliance.
-
-**Self-hosting for a non-profit or educational institution**: Permitted under AGPL. If you modify the code and make it publicly accessible, you must share your modifications.
-
-**Running a modified public instance (non-commercial)**: You must make your modified source code available to users who interact with your deployment. The simplest way is to publish your fork on GitHub and link to it from your instance.
-
-**Using World Monitor's public API in your own tool**: If your tool calls World Monitor's public API and displays the results, your tool is not a derivative work. No AGPL obligations apply. However, if your tool is commercial, you must comply with the API terms of service.
-
-**Contributing a pull request**: By submitting a PR, you agree that your contribution is licensed under AGPL-3.0, consistent with the rest of the project.
-
-**Commercial use (any of the above in a for-profit context)**: Requires a separate commercial license. Contact the maintainer at the [GitHub repository](https://github.com/koala73/worldmonitor).
-
-### Why AGPL + Commercial License
-
-World Monitor aggregates publicly available intelligence data and makes it accessible to everyone. The dual-license model (AGPL for open use, commercial license for business use) ensures that:
-
-1. **The community benefits**: Individual researchers, journalists, students, and open-source contributors can freely use and improve the platform.
-2. **Commercial use is sustainable**: Companies that derive commercial value from World Monitor contribute back through licensing fees, which fund continued development.
-3. **The project stays open**: AGPL prevents a scenario where a commercial entity takes the open-source code, adds proprietary features, and competes with the project without contributing back.
+By contributing to World Monitor, you agree that your contributions are licensed under AGPL-3.0. See the [License](/license) page for full terms, commercial licensing, and common scenarios.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -109,6 +109,12 @@
               "relay-parameters",
               "data-sources"
             ]
+          },
+          {
+            "group": "Legal",
+            "pages": [
+              "license"
+            ]
           }
         ]
       },

--- a/docs/documentation.mdx
+++ b/docs/documentation.mdx
@@ -21,9 +21,9 @@ The platform is designed for journalists, security analysts, researchers, and an
 - **Want to understand the system?** Read [Architecture](/architecture) for how the pieces fit together
 - **Looking for specific features?** See [Features & Interface](/features) for the full capability list
 - **Interested in the data?** Check [Data Sources](/data-sources) for all 31+ sources and collection methods
-- **Want to contribute?** Read [Contributing](/contributing) for code style, PR process, and license terms
+- **Want to contribute?** Read [Contributing](/contributing) for code style and PR process
 - **Building on the API?** Browse the [API Reference](/api/) for all 24 typed services
 
 ## License
 
-World Monitor is open source under [AGPL-3.0](/contributing#license). Free for personal, educational, and research use. Commercial use requires a [separate license](/contributing#commercial-use-requires-a-separate-license).
+World Monitor is open source under [AGPL-3.0](/license). Free for personal, educational, and research use. Commercial use requires a [separate license](/license#commercial-use-requires-a-separate-license).

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -332,7 +332,7 @@ The system degrades gracefully. Blocked sources are skipped while others continu
 
 ## License
 
-World Monitor is licensed under the [GNU Affero General Public License v3.0 (AGPL-3.0)](https://www.gnu.org/licenses/agpl-3.0.html) for non-commercial use. Commercial use requires a separate license. See the [Contributing guide](/contributing#license) for full details on what this means in practice.
+World Monitor is licensed under the [GNU Affero General Public License v3.0 (AGPL-3.0)](/license) for non-commercial use. Commercial use requires a [separate license](/license#commercial-use-requires-a-separate-license). See the [License](/license) page for full details on what this means in practice.
 
 ## Author
 

--- a/docs/license.mdx
+++ b/docs/license.mdx
@@ -1,0 +1,81 @@
+---
+title: "License"
+description: "World Monitor licensing terms: AGPL-3.0 for open use, commercial license for business use. Rebranding and commercial forks are prohibited without a license."
+---
+
+World Monitor is licensed under the [GNU Affero General Public License v3.0 (AGPL-3.0-only)](https://www.gnu.org/licenses/agpl-3.0.html).
+
+<Warning>
+**Copying, renaming, or rebranding World Monitor for commercial use is illegal without a commercial license.** Changing the name does not change the license. If you fork this project and use it to make money, you are in violation of the AGPL-3.0 and subject to legal action. See [enforcement](#enforcement) below.
+</Warning>
+
+## What AGPL-3.0 means
+
+AGPL is a strong copyleft license designed for network software. It extends the GPL with one additional requirement: if you run a modified version of World Monitor as a publicly accessible service, you must make your source code available to users of that service.
+
+| You can | You must | You cannot |
+|---------|----------|------------|
+| View, study, and learn from the source code | Distribute source code with any binary distribution | Use World Monitor commercially without a commercial license |
+| Modify and create derivative works for personal/research use | License derivative works under AGPL-3.0 | Sublicense under a different license |
+| Run a personal instance for non-commercial use | State changes you made to the code | Remove or obscure the original copyright and license notices |
+| Contribute improvements back to the project | Provide source access to users of any public-facing modified deployment | Rebrand and sell as your own product |
+
+## Rebranding and commercial forks are prohibited
+
+<Warning>
+Forking World Monitor, changing the name, logo, or branding, and deploying it as your own product is **not permitted** under any circumstances without a commercial license. The AGPL-3.0 requires that:
+
+1. **You must retain all original copyright notices** in the source code and UI.
+2. **You must prominently state that your version is a modified fork of World Monitor** and link back to the original project.
+3. **You must publish your complete modified source code** under AGPL-3.0, available to all users of your deployment.
+4. **You cannot use this for commercial purposes** without a separate commercial license from the maintainer.
+
+Renaming the project does not remove these obligations. Removing copyright headers is a separate legal violation.
+</Warning>
+
+## Commercial use requires a separate license
+
+**Any commercial use of World Monitor requires a commercial license from the maintainer.** This includes but is not limited to:
+
+- **Rebranding or white-labeling**: Forking the code, changing the name/logo, and deploying it as your own product or service
+- **Running as a paid product**: Offering World Monitor (or a modified version) behind a paywall, subscription, or any fee
+- **Embedding in commercial products**: Using World Monitor code, components, UI, or data pipelines inside a product you sell
+- **SaaS or consulting**: Offering World Monitor's capabilities as part of a consulting engagement, managed service, or SaaS platform
+- **Internal corporate use**: Using World Monitor inside a for-profit company to generate revenue or competitive advantage
+- **Selling data derived from World Monitor**: Using the platform to collect, process, or resell intelligence data commercially
+
+The AGPL-3.0 license governs non-commercial, personal, educational, and research use only. If your use case involves any form of commercial activity, you must contact the maintainer to obtain a commercial license.
+
+**Contact**: [GitHub repository](https://github.com/koala73/worldmonitor) or email the maintainer directly.
+
+## Enforcement
+
+The maintainer actively monitors for unauthorized commercial use, rebranding, and license violations. If you are found to be in violation:
+
+1. You will receive a formal takedown notice requiring immediate cessation of the infringing activity.
+2. If the violation is not resolved promptly, the maintainer reserves the right to pursue legal remedies, including injunctive relief and damages, under applicable copyright law.
+3. AGPL violations are enforceable under international copyright law (Berne Convention), the DMCA, and equivalent statutes in the EU and other jurisdictions.
+
+If you are aware of an unauthorized commercial fork or rebranded deployment, please report it via [GitHub Issues](https://github.com/koala73/worldmonitor/issues) or contact the maintainer directly.
+
+## Common scenarios
+
+**Personal use or research**: Free to use, modify, and self-host. No restrictions beyond AGPL compliance.
+
+**Self-hosting for a non-profit or educational institution**: Permitted under AGPL. If you modify the code and make it publicly accessible, you must share your modifications.
+
+**Running a modified public instance (non-commercial)**: You must retain all copyright notices, state that it is a fork of World Monitor, and make your modified source code available to users who interact with your deployment.
+
+**Using World Monitor's public API in your own tool**: If your tool calls World Monitor's public API and displays the results, your tool is not a derivative work. No AGPL obligations apply. However, if your tool is commercial, you must comply with the API terms of service.
+
+**Contributing a pull request**: By submitting a PR, you agree that your contribution is licensed under AGPL-3.0, consistent with the rest of the project.
+
+**Commercial use (any of the above in a for-profit context)**: Requires a separate commercial license. Contact the maintainer at the [GitHub repository](https://github.com/koala73/worldmonitor).
+
+## Why AGPL + Commercial License
+
+World Monitor aggregates publicly available intelligence data and makes it accessible to everyone. The dual-license model (AGPL for open use, commercial license for business use) ensures that:
+
+1. **The community benefits**: Individual researchers, journalists, students, and open-source contributors can freely use and improve the platform.
+2. **Commercial use is sustainable**: Companies that derive commercial value from World Monitor contribute back through licensing fees, which fund continued development.
+3. **The project stays open**: AGPL prevents a scenario where a commercial entity takes the open-source code, adds proprietary features, and competes with the project without contributing back.


### PR DESCRIPTION
## Summary
- Create dedicated `docs/license.mdx` page with its own "Legal" nav group, making licensing a first-class citizen instead of buried in contributing
- Add prominent warning callouts about rebranding/renaming being prohibited without a commercial license
- Add enforcement section (takedown notices, legal remedies, DMCA/Berne Convention)
- Expand commercial use restrictions to explicitly cover white-labeling, data reselling, internal corporate use
- Fix README.md license section which previously stated "Commercial use: Yes" under AGPL alone; now correctly reflects the dual-license model (AGPL for non-commercial, commercial license required)
- Update cross-references in documentation.mdx and getting-started.mdx to point to /license

## Test plan
- [x] Markdown lint passes
- [x] MDX lint passes (no bare angle brackets or curly braces)
- [ ] Verify /license page renders correctly on Mintlify
- [ ] Verify all internal links resolve (/license, /license#commercial-use-requires-a-separate-license, /license#enforcement)