### PR TITLE
feat: add MiniMax as LLM provider with M3 default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@
 # Get yours at: https://console.groq.com/
 GROQ_API_KEY=
 
+# MiniMax API (OpenAI-compatible — supports MiniMax-M2.7 and MiniMax-M2.7-highspeed)
+# Get yours at: https://www.minimaxi.com/
+MINIMAX_API_KEY=
+# Optional: override the default model (MiniMax-M2.7)
+# MINIMAX_MODEL=MiniMax-M2.7-highspeed
+
 # OpenRouter API (fallback — 50 req/day on free tier)
 # Get yours at: https://openrouter.ai/
 OPENROUTER_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,10 @@
 # Get yours at: https://console.groq.com/
 GROQ_API_KEY=
 
-# MiniMax API (OpenAI-compatible — supports MiniMax-M2.7 and MiniMax-M2.7-highspeed)
+# MiniMax API (OpenAI-compatible — supports MiniMax-M3, MiniMax-M2.7, and MiniMax-M2.7-highspeed)
 # Get yours at: https://www.minimaxi.com/
 MINIMAX_API_KEY=
-# Optional: override the default model (MiniMax-M2.7)
+# Optional: override the default model (MiniMax-M3)
 # MINIMAX_MODEL=MiniMax-M2.7-highspeed
 
 # OpenRouter API (fallback — 50 req/day on free tier)

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -9,7 +9,7 @@ export interface ProviderCredentials {
   extraBody?: Record<string, unknown>;
 }
 
-export type LlmProviderName = 'ollama' | 'groq' | 'openrouter' | 'generic';
+export type LlmProviderName = 'ollama' | 'groq' | 'minimax' | 'openrouter' | 'generic';
 
 export interface ProviderCredentialOverrides {
   model?: string;
@@ -62,6 +62,19 @@ export function getProviderCredentials(
     return {
       apiUrl: 'https://api.groq.com/openai/v1/chat/completions',
       model: overrides.model || 'llama-3.1-8b-instant',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    };
+  }
+
+  if (provider === 'minimax') {
+    const apiKey = process.env.MINIMAX_API_KEY;
+    if (!apiKey) return null;
+    return {
+      apiUrl: 'https://api.minimax.io/v1/chat/completions',
+      model: overrides.model || process.env.MINIMAX_MODEL || 'MiniMax-M2.7',
       headers: {
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
@@ -123,8 +136,7 @@ export function stripThinkingTags(text: string): string {
   return s;
 }
 
-
-const PROVIDER_CHAIN = ['ollama', 'groq', 'openrouter', 'generic'] as const;
+const PROVIDER_CHAIN = ['ollama', 'groq', 'minimax', 'openrouter', 'generic'] as const;
 const PROVIDER_SET = new Set<string>(PROVIDER_CHAIN);
 
 export interface LlmCallOptions {

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -74,7 +74,7 @@ export function getProviderCredentials(
     if (!apiKey) return null;
     return {
       apiUrl: 'https://api.minimax.io/v1/chat/completions',
-      model: overrides.model || process.env.MINIMAX_MODEL || 'MiniMax-M2.7',
+      model: overrides.model || process.env.MINIMAX_MODEL || 'MiniMax-M3',
       headers: {
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json',

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -7,6 +7,7 @@ const originalFetch = globalThis.fetch;
 const originalGroqApiKey = process.env.GROQ_API_KEY;
 const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
 const originalOllamaApiUrl = process.env.OLLAMA_API_URL;
+const originalMiniMaxApiKey = process.env.MINIMAX_API_KEY;
 const originalLlmApiUrl = process.env.LLM_API_URL;
 const originalLlmApiKey = process.env.LLM_API_KEY;
 
@@ -21,6 +22,10 @@ afterEach(() => {
 
   if (originalOllamaApiUrl === undefined) delete process.env.OLLAMA_API_URL;
   else process.env.OLLAMA_API_URL = originalOllamaApiUrl;
+
+  if (originalMiniMaxApiKey === undefined) delete process.env.MINIMAX_API_KEY;
+  else process.env.MINIMAX_API_KEY = originalMiniMaxApiKey;
+  delete process.env.MINIMAX_MODEL;
 
   if (originalLlmApiUrl === undefined) delete process.env.LLM_API_URL;
   else process.env.LLM_API_URL = originalLlmApiUrl;
@@ -70,6 +75,85 @@ describe('callLlm', () => {
     assert.deepEqual(postUrls.filter(url => url.includes('/chat/completions')), [
       'https://api.groq.com/openai/v1/chat/completions',
     ]);
+  });
+
+  it('uses MiniMax-M2.7 as default when MINIMAX_API_KEY is set', async () => {
+    process.env.MINIMAX_API_KEY = 'mm-test-key';
+    delete process.env.GROQ_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    const postBodies: Array<{ url: string; body: Record<string, unknown> }> = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+      if ((init?.method || 'GET') === 'GET') {
+        return new Response('', { status: 200 });
+      }
+
+      const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>;
+      postBodies.push({ url, body });
+
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'minimax response' } }],
+        usage: { total_tokens: 55 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await callLlm({
+      messages: [{ role: 'user', content: 'Test MiniMax.' }],
+      provider: 'minimax',
+    });
+
+    assert.ok(result);
+    assert.equal(result.provider, 'minimax');
+    assert.equal(result.model, 'MiniMax-M2.7');
+    assert.equal(postBodies.length, 1);
+    assert.equal(postBodies[0]?.url, 'https://api.minimax.io/v1/chat/completions');
+    assert.equal(postBodies[0]?.body.model, 'MiniMax-M2.7');
+  });
+
+  it('supports MiniMax model override via MINIMAX_MODEL env var', async () => {
+    process.env.MINIMAX_API_KEY = 'mm-test-key';
+    process.env.MINIMAX_MODEL = 'MiniMax-M2.7-highspeed';
+    delete process.env.GROQ_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    const postBodies: Array<{ url: string; body: Record<string, unknown> }> = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+      if ((init?.method || 'GET') === 'GET') {
+        return new Response('', { status: 200 });
+      }
+
+      const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>;
+      postBodies.push({ url, body });
+
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'minimax highspeed response' } }],
+        usage: { total_tokens: 30 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await callLlm({
+      messages: [{ role: 'user', content: 'Test MiniMax highspeed.' }],
+      provider: 'minimax',
+    });
+
+    assert.ok(result);
+    assert.equal(result.provider, 'minimax');
+    assert.equal(result.model, 'MiniMax-M2.7-highspeed');
+    assert.equal(postBodies[0]?.body.model, 'MiniMax-M2.7-highspeed');
+
+    delete process.env.MINIMAX_MODEL;
   });
 
   it('supports explicitly bypassing groq with a stronger model override', async () => {

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -77,7 +77,7 @@ describe('callLlm', () => {
     ]);
   });
 
-  it('uses MiniMax-M2.7 as default when MINIMAX_API_KEY is set', async () => {
+  it('uses MiniMax-M3 as default when MINIMAX_API_KEY is set', async () => {
     process.env.MINIMAX_API_KEY = 'mm-test-key';
     delete process.env.GROQ_API_KEY;
     delete process.env.OPENROUTER_API_KEY;
@@ -110,10 +110,10 @@ describe('callLlm', () => {
 
     assert.ok(result);
     assert.equal(result.provider, 'minimax');
-    assert.equal(result.model, 'MiniMax-M2.7');
+    assert.equal(result.model, 'MiniMax-M3');
     assert.equal(postBodies.length, 1);
     assert.equal(postBodies[0]?.url, 'https://api.minimax.io/v1/chat/completions');
-    assert.equal(postBodies[0]?.body.model, 'MiniMax-M2.7');
+    assert.equal(postBodies[0]?.body.model, 'MiniMax-M3');
   });
 
   it('supports MiniMax model override via MINIMAX_MODEL env var', async () => {


### PR DESCRIPTION
## Summary

- Add MiniMax as a first-class LLM provider in the provider chain (between Groq and OpenRouter)
- Default model: **MiniMax-M3** (512K context, up to 128K output, image input support)
- Support MINIMAX_MODEL env var override (e.g. `MiniMax-M2.7` or `MiniMax-M2.7-highspeed` for previous-generation models)
- API endpoint: https://api.minimax.io/v1 (OpenAI-compatible)

## Changes

- **server/_shared/llm.ts**: Add `minimax` provider with API key auth, model env var override (defaulting to `MiniMax-M3`), and provider chain integration
- **.env.example**: Add `MINIMAX_API_KEY` and `MINIMAX_MODEL` configuration docs (notes that M3, M2.7, and M2.7-highspeed are all supported)
- **tests/shared-llm.test.mts**: Add 2 unit tests — one asserting `MiniMax-M3` as the default, one verifying `MINIMAX_MODEL=MiniMax-M2.7-highspeed` override works

## Why MiniMax-M3

`MiniMax-M3` is the latest flagship model with a 512K context window, up to 128K max output, and image input support (OpenAI- and Anthropic-compatible APIs). Previous-generation `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` remain available via `MINIMAX_MODEL` for low-latency / cost-sensitive scenarios.

## Testing

- All 5 unit tests passing (3 existing + 2 new MiniMax tests)
- Default model verified as `MiniMax-M3`
- `MINIMAX_MODEL` override verified with `MiniMax-M2.7-highspeed`