### PR TITLE
style: align footer links order across all properties

### DIFF
--- a/blog-site/src/layouts/Base.astro
+++ b/blog-site/src/layouts/Base.astro
@@ -113,10 +113,10 @@ const keywordTags = keywords ? keywords.split(',').map(k => k.trim()).slice(0, 6
           <a href="https://www.worldmonitor.app" target="_blank" rel="noopener noreferrer">Dashboard</a>
           <a href="https://www.worldmonitor.app/pro" target="_blank" rel="noopener noreferrer">Pro</a>
           <a href="https://www.worldmonitor.app/docs" target="_blank" rel="noopener noreferrer">Docs</a>
+          <a href="https://status.worldmonitor.app/" target="_blank" rel="noopener noreferrer">Status</a>
           <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noopener noreferrer">GitHub</a>
           <a href="https://github.com/koala73/worldmonitor/discussions" target="_blank" rel="noopener noreferrer">Discussions</a>
           <a href="https://x.com/worldmonitorai" target="_blank" rel="noopener noreferrer">X</a>
-          <a href="https://status.worldmonitor.app/" target="_blank" rel="noopener noreferrer">Status</a>
         </div>
         <div class="footer-copy">
           &copy; {new Date().getFullYear()} World Monitor

--- a/pro-test/src/App.tsx
+++ b/pro-test/src/App.tsx
@@ -933,10 +933,11 @@ const Footer = () => (
       <div className="flex items-center gap-6">
         <a href="/" className="hover:text-wm-text transition-colors">Dashboard</a>
         <a href="https://www.worldmonitor.app/blog/" className="hover:text-wm-text transition-colors">Blog</a>
+        <a href="https://www.worldmonitor.app/docs" className="hover:text-wm-text transition-colors">Docs</a>
+        <a href="https://status.worldmonitor.app/" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">Status</a>
         <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">GitHub</a>
         <a href="https://github.com/koala73/worldmonitor/discussions" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">Discussions</a>
         <a href="https://x.com/worldmonitorai" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">X</a>
-        <a href="https://status.worldmonitor.app/" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">Status</a>
       </div>
       <span className="text-[10px] opacity-40 mt-4 md:mt-0">&copy; {new Date().getFullYear()} WorldMonitor</span>
     </div>
@@ -1133,10 +1134,10 @@ const EnterprisePage = () => (
           <a href="/" className="hover:text-wm-text transition-colors">Dashboard</a>
           <a href="https://www.worldmonitor.app/blog/" className="hover:text-wm-text transition-colors">Blog</a>
           <a href="https://www.worldmonitor.app/docs" className="hover:text-wm-text transition-colors">Docs</a>
+          <a href="https://status.worldmonitor.app/" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">Status</a>
           <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">GitHub</a>
           <a href="https://github.com/koala73/worldmonitor/discussions" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">Discussions</a>
           <a href="https://x.com/worldmonitorai" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">X</a>
-          <a href="https://status.worldmonitor.app/" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">Status</a>
         </div>
         <span className="text-[10px] opacity-40 mt-4 md:mt-0">&copy; {new Date().getFullYear()} WorldMonitor</span>
       </div>

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -325,10 +325,10 @@ export class PanelLayoutManager implements AppModule {
           <a href="${this.ctx.isDesktopApp ? 'https://worldmonitor.app/pro' : 'https://www.worldmonitor.app/pro'}" target="_blank" rel="noopener">Pro</a>
           <a href="${this.ctx.isDesktopApp ? 'https://worldmonitor.app/blog/' : 'https://www.worldmonitor.app/blog/'}" target="_blank" rel="noopener">Blog</a>
           <a href="${this.ctx.isDesktopApp ? 'https://worldmonitor.app/docs' : 'https://www.worldmonitor.app/docs'}" target="_blank" rel="noopener">Docs</a>
+          <a href="https://status.worldmonitor.app/" target="_blank" rel="noopener">Status</a>
           <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noopener">GitHub</a>
           <a href="https://github.com/koala73/worldmonitor/discussions" target="_blank" rel="noopener">Discussions</a>
           <a href="https://x.com/worldmonitorai" target="_blank" rel="noopener">X</a>
-          <a href="https://status.worldmonitor.app/" target="_blank" rel="noopener">Status</a>
         </nav>
         <span class="site-footer-copy">&copy; ${new Date().getFullYear()} World Monitor</span>
       </footer>


### PR DESCRIPTION
## Summary
Standardize footer link order across all 4 properties. Each page omits its own self-link.

**Canonical order:** Dashboard, Pro, Blog, Docs, Status, GitHub, Discussions, X

| Page | Links |
|---|---|
| Dashboard | Pro, Blog, Docs, Status, GitHub, Discussions, X |
| Blog | Dashboard, Pro, Docs, Status, GitHub, Discussions, X |
| Pro (main) | Dashboard, Blog, Docs, Status, GitHub, Discussions, X |
| Pro (enterprise) | Dashboard, Blog, Docs, Status, GitHub, Discussions, X |

**Fixes:**
- Pro main footer was missing "Docs" link
- "Status" was at end instead of after "Docs" (before community links)

## Test plan
- [ ] Verify footer link order matches table above on each property