### PR TITLE
fix(aviation): don't encodeURIComponent NOTAM locations param

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1870,7 +1870,7 @@ function fetchIcaoNotams() {
   return new Promise((resolve) => {
     if (!ICAO_API_KEY) return resolve([]);
     const locations = NOTAM_MONITORED_ICAO.join(',');
-    const apiUrl = `https://dataservices.icao.int/api/notams-realtime-list?api_key=${ICAO_API_KEY}&format=json&locations=${encodeURIComponent(locations)}`;
+    const apiUrl = `https://dataservices.icao.int/api/notams-realtime-list?api_key=${ICAO_API_KEY}&format=json&locations=${locations}`;
     const req = https.get(apiUrl, {
       headers: { 'User-Agent': CHROME_UA },
       timeout: 30000,


### PR DESCRIPTION
## Summary
- ICAO API returns 403 when commas in the `locations` query param are encoded as `%2C`
- The relay NOTAM seed loop used `encodeURIComponent(locations)` which encoded commas
- The manual seed script (`seed-airport-delays.mjs`) passes literal commas and works fine
- Removes `encodeURIComponent` to match the working pattern

## Evidence
From relay logs after PR #1516 deployed:
```
[NOTAM-Seed] ICAO HTTP 403
[NOTAM-Seed] No NOTAMs received — preserving existing cache
```

## Test plan
- [ ] After deploy, verify relay logs show `[NOTAM-Seed] X raw NOTAMs, Y closures` instead of HTTP 403
- [ ] Verify `api/health` shows `notamClosures: OK`