### PR TITLE
fix(aviation): remove encodeURIComponent from NOTAM proxy handler

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -5777,7 +5777,7 @@ function handleNotamProxyRequest(req, res) {
     }, notamCache.data);
   }
 
-  const apiUrl = `https://dataservices.icao.int/api/notams-realtime-list?api_key=${ICAO_API_KEY}&format=json&locations=${encodeURIComponent(locations)}`;
+  const apiUrl = `https://dataservices.icao.int/api/notams-realtime-list?api_key=${ICAO_API_KEY}&format=json&locations=${locations}`;
 
   const request = https.get(apiUrl, {
     headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' },


### PR DESCRIPTION
## Summary
- ICAO API expects literal commas in the `locations` query param
- The seed loop was fixed in #1519 but the proxy handler (`/notam` route) still had `encodeURIComponent(locations)` encoding commas as `%2C`
- One-line fix matching the seed loop pattern

## Test plan
- [ ] Verify NOTAM proxy returns data once ICAO API key is renewed