### PR TITLE
fix(runtime): avoid desktop detection on secure localhost web

### DIFF
--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -57,14 +57,6 @@ type RuntimeProbe = {
 
 export function detectDesktopRuntime(probe: RuntimeProbe): boolean {
   const tauriInUserAgent = probe.userAgent.includes('Tauri');
-  const secureLocalhostOrigin = (
-    probe.locationProtocol === 'https:' && (
-      probe.locationHost === 'localhost' ||
-      probe.locationHost.startsWith('localhost:') ||
-      probe.locationHost === '127.0.0.1' ||
-      probe.locationHost.startsWith('127.0.0.1:')
-    )
-  );
 
   // Tauri production windows can expose tauri-like hosts/schemes without
   // always exposing bridge globals at first paint.
@@ -73,8 +65,7 @@ export function detectDesktopRuntime(probe: RuntimeProbe): boolean {
     probe.locationProtocol === 'asset:' ||
     probe.locationHost === 'tauri.localhost' ||
     probe.locationHost.endsWith('.tauri.localhost') ||
-    probe.locationOrigin.startsWith('tauri://') ||
-    secureLocalhostOrigin
+    probe.locationOrigin.startsWith('tauri://')
   );
 
   return probe.hasTauriGlobals || tauriInUserAgent || tauriLikeLocation;


### PR DESCRIPTION
### Motivation
- Prevent browser-hosted instances served from `https://localhost` or `https://127.0.0.1` from being misclassified as the Tauri desktop runtime so web app behavior is unchanged while preserving Tauri-specific behavior.

### Description
- Removed the secure-localhost heuristic from `detectDesktopRuntime` so the function only signals desktop for Tauri-specific indicators (`__TAURI*` globals, UA containing `Tauri`, `tauri:`/`asset:` protocols, `tauri.localhost` hostnames, and `tauri://` origin).
- Change is confined to `src/services/runtime.ts` and prevents web-hosted apps from entering desktop-only code paths such as `getApiBaseUrl()` and other Tauri-scoped behavior.

### Testing
- Ran `npm run typecheck` which failed in this environment due to missing TypeScript lib/type definition files in `node_modules` (e.g. `lib.dom.d.ts` and `vite/client`), so no passing typecheck result could be produced here.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b40535d654832e9dc7b3cd6c45b97c)