### PR TITLE
fix: remove unused variable in llm-health probe

### DIFF
--- a/server/_shared/llm-health.ts
+++ b/server/_shared/llm-health.ts
@@ -22,11 +22,10 @@ const inFlight = new Map<string, Promise<boolean>>();
 async function probe(url: string): Promise<boolean> {
   try {
     const origin = new URL(url).origin;
-    const resp = await fetch(origin, {
+    await fetch(origin, {
       method: 'GET',
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     });
-    // Any HTTP response means the server is reachable
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- Remove unused `resp` variable in `server/_shared/llm-health.ts` probe function
- The fetch result was assigned but never read (TS6133)

## Test plan
- [x] `tsc --noEmit` passes