### PR TITLE
fix: skip LLM health poll on web, add Iran geolocations

### DIFF
--- a/scripts/seed-iran-events.mjs
+++ b/scripts/seed-iran-events.mjs
@@ -145,6 +145,10 @@ const LOCATION_COORDS = {
   'empty quarter': { lat: 22.5200, lon: 54.0000 },
   'ovadia':        { lat: 31.4700, lon: 34.5300 },
   'shin bet':      { lat: 31.7683, lon: 35.2137 },
+  'kharg':         { lat: 29.2635, lon: 50.3273 },
+  'qom':           { lat: 34.6401, lon: 50.8764 },
+  'andisheh':      { lat: 35.7050, lon: 51.0000 },
+  'ankara':        { lat: 39.9334, lon: 32.8597 },
 };
 
 const CATEGORY_MAP = {

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -29,6 +29,7 @@ import {
   INTEL_SOURCES,
 } from '@/config';
 import { VARIANT_META } from '@/config/variant-meta';
+import { isDesktopRuntime } from '@/services/runtime';
 import {
   saveSnapshot,
   initAisStream,
@@ -763,6 +764,7 @@ export class EventHandlerManager implements AppModule {
   }
 
   setupLlmStatusIndicator(): void {
+    if (!isDesktopRuntime()) return;
     this.ctx.llmStatusIndicator = new LlmStatusIndicator();
     const headerRight = this.ctx.container.querySelector('.header-right');
     if (headerRight) {


### PR DESCRIPTION
## Summary
- Gate `LlmStatusIndicator` behind `isDesktopRuntime()` so Vercel web never fires a wasted 404 fetch to `/api/llm-health` (sidecar-only endpoint)
- Add 4 missing locations to Iran events geolocation map: Kharg Island, Qom, Andisheh, Ankara

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 104 edge function tests pass
- [x] Markdown lint clean
- [ ] Verify no `/api/llm-health` 404 in browser console on web
- [ ] Verify LLM indicator still appears in desktop app