### PR TITLE
fix(webcams): fix seed script variable collision and API offset limit

### DIFF
--- a/scripts/seed-webcams.mjs
+++ b/scripts/seed-webcams.mjs
@@ -69,6 +69,23 @@ async function fetchRegion(bounds, regionName) {
     });
 
     if (!resp.ok) {
+      if (resp.status === 400 && offset > 0) {
+        console.warn(`  [${regionName}] API limit reached at offset ${offset}, splitting into quadrants...`);
+        const midLat = (S + N) / 2;
+        const midLon = (W + E) / 2;
+        const quadrants = [
+          [[S, W, midLat, midLon], `${regionName} SW`],
+          [[S, midLon, midLat, E], `${regionName} SE`],
+          [[midLat, W, N, midLon], `${regionName} NW`],
+          [[midLat, midLon, N, E], `${regionName} NE`],
+        ];
+        cameras.length = 0;
+        for (const [qBounds, qName] of quadrants) {
+          const qCameras = await fetchRegion(qBounds, qName);
+          cameras.push(...qCameras);
+        }
+        return cameras;
+      }
       console.warn(`  [${regionName}] API error at offset ${offset}: ${resp.status}`);
       break;
     }
@@ -205,8 +222,8 @@ async function main() {
   }
 
   const seedMetaKey = `${PREFIX}seed-meta:webcam:cameras:geo`;
-  const seedMeta = JSON.stringify({ fetchedAt: Date.now(), recordCount: unique.length });
-  await pipelineRequest([['SET', seedMetaKey, seedMeta, 'EX', '604800']]);
+  const seedMetaVal = JSON.stringify({ fetchedAt: Date.now(), recordCount: unique.length });
+  await pipelineRequest([['SET', seedMetaKey, seedMetaVal, 'EX', '604800']]);
 
   console.log(`seed-webcams: done (${unique.length} cameras seeded)`);
 }


### PR DESCRIPTION
## Summary

- Fix `const seedMeta` shadowing the `seedMeta()` function (caused "Cannot access before initialization" crash)
- Auto-split regions into quadrants when Windy API returns 400 at offset limit (~1000), fetching all webcams instead of capping at ~1050

## Test plan

- [ ] Railway seed-webcams builds and runs successfully
- [ ] Total unique webcams > 1050 (quadrant splitting works)
- [ ] seed-meta key written to Redis