### PR TITLE
fix(seed): SyntaxError from mixing || and ?? operators

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -254,9 +254,12 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
       process.exit(0);
     }
     const { payloadBytes } = publishResult;
-    const topicArticleCount = data?.topics?.reduce?.((n, t) => n + (t?.articles?.length || t?.events?.length || 0), 0);
+    const topicArticleCount = Array.isArray(data?.topics)
+      ? data.topics.reduce((n, t) => n + (t?.articles?.length || t?.events?.length || 0), 0)
+      : undefined;
     const recordCount = Array.isArray(data) ? data.length
-      : (topicArticleCount || data?.events?.length ?? data?.earthquakes?.length ?? data?.outages?.length
+      : (topicArticleCount
+        ?? data?.events?.length ?? data?.earthquakes?.length ?? data?.outages?.length
         ?? data?.fireDetections?.length ?? data?.anomalies?.length ?? data?.threats?.length
         ?? data?.quotes?.length ?? data?.stablecoins?.length
         ?? data?.cables?.length ?? 0);


### PR DESCRIPTION
## Summary
- Fixes `SyntaxError: Unexpected token '??'` crashing ALL Railway seed scripts since #1556 merged
- Cannot mix `||` and `??` in the same expression without explicit grouping
- Refactored to use `??` throughout with `Array.isArray` guard for topic payloads

## Urgency
**P0 hotfix**: every seed cron on Railway is broken right now. Merge ASAP.

## Test plan
- `node -c scripts/_seed-utils.mjs` passes (no syntax error)
- CI: 104 tests pass, typecheck clean