### PR TITLE
Fix webcam service proto: use correct sebuf.http extensions

### DIFF
--- a/proto/worldmonitor/webcam/v1/service.proto
+++ b/proto/worldmonitor/webcam/v1/service.proto
@@ -1,14 +1,18 @@
 syntax = "proto3";
+
 package worldmonitor.webcam.v1;
 
+import "sebuf/http/annotations.proto";
 import "worldmonitor/webcam/v1/list_webcams.proto";
 import "worldmonitor/webcam/v1/get_webcam_image.proto";
 
 service WebcamService {
+  option (sebuf.http.service_config) = {base_path: "/api/webcam/v1"};
+
   rpc ListWebcams(ListWebcamsRequest) returns (ListWebcamsResponse) {
-    option (sebuf.http.rule) = { get: "/api/webcam/v1/list-webcams" };
+    option (sebuf.http.config) = {path: "/list-webcams", method: HTTP_METHOD_GET};
   }
   rpc GetWebcamImage(GetWebcamImageRequest) returns (GetWebcamImageResponse) {
-    option (sebuf.http.rule) = { get: "/api/webcam/v1/get-webcam-image" };
+    option (sebuf.http.config) = {path: "/get-webcam-image", method: HTTP_METHOD_GET};
   }
 }


### PR DESCRIPTION
The webcam service.proto was using a non-existent `sebuf.http.rule`
extension. Replaced with the correct `sebuf.http.service_config` and
`sebuf.http.config` extensions, and added the missing import for
sebuf/http/annotations.proto, matching the pattern used by all other
services.

https://claude.ai/code/session_016kehDa7PHG56XsgiGWo9GE