### PR TITLE
fix(proto): add missing sebuf.http.query annotations to webcam messages

### DIFF
--- a/proto/worldmonitor/webcam/v1/get_webcam_image.proto
+++ b/proto/worldmonitor/webcam/v1/get_webcam_image.proto
@@ -1,8 +1,11 @@
 syntax = "proto3";
+
 package worldmonitor.webcam.v1;
 
+import "sebuf/http/annotations.proto";
+
 message GetWebcamImageRequest {
-  string webcam_id = 1;
+  string webcam_id = 1 [(sebuf.http.query) = {name: "webcam_id"}];
 }
 
 message GetWebcamImageResponse {

--- a/proto/worldmonitor/webcam/v1/list_webcams.proto
+++ b/proto/worldmonitor/webcam/v1/list_webcams.proto
@@ -1,12 +1,15 @@
 syntax = "proto3";
+
 package worldmonitor.webcam.v1;
 
+import "sebuf/http/annotations.proto";
+
 message ListWebcamsRequest {
-  int32 zoom = 1;
-  double bound_w = 2;
-  double bound_s = 3;
-  double bound_e = 4;
-  double bound_n = 5;
+  int32 zoom = 1 [(sebuf.http.query) = {name: "zoom"}];
+  double bound_w = 2 [(sebuf.http.query) = {name: "bound_w"}];
+  double bound_s = 3 [(sebuf.http.query) = {name: "bound_s"}];
+  double bound_e = 4 [(sebuf.http.query) = {name: "bound_e"}];
+  double bound_n = 5 [(sebuf.http.query) = {name: "bound_n"}];
 }
 
 message WebcamEntry {


### PR DESCRIPTION
## Summary
- Adds `(sebuf.http.query)` annotations to all GET request fields in `list_webcams.proto` (zoom, bound_w/s/e/n) and `get_webcam_image.proto` (webcam_id)
- Adds missing `sebuf/http/annotations.proto` import to both message files
- Fixes `buf generate` failure introduced after #1563 (service-level extensions were fixed but request-level query annotations were missed)

## Test plan
- [ ] `make generate` completes without errors