### PR TITLE
fix(health): bump theaterPosture maxStaleMin 30→60

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -108,7 +108,7 @@ const SEED_META = {
   renewableEnergy:  { key: 'seed-meta:economic:worldbank-renewable:v1',    maxStaleMin: 10080 },
   intlDelays:       { key: 'seed-meta:aviation:intl',           maxStaleMin: 90 },
   faaDelays:        { key: 'seed-meta:aviation:faa',            maxStaleMin: 60 },
-  theaterPosture:   { key: 'seed-meta:theater-posture',         maxStaleMin: 30 },
+  theaterPosture:   { key: 'seed-meta:theater-posture',         maxStaleMin: 60 },
 };
 
 // Standalone keys that are populated on-demand by RPC handlers (not seeds).


### PR DESCRIPTION
## Summary
- Increases `theaterPosture` staleness threshold from 30 to 60 minutes
- The 10-min seed interval with occasional slow OpenSky API responses was triggering false STALE_SEED warnings
- UptimeRobot alerts were firing on benign delays, causing alert fatigue

## Test plan
- [ ] Deploy and monitor UptimeRobot for 24h, confirm no more false theaterPosture STALE_SEED alerts
- [ ] Verify `/api/health` returns OK status under normal conditions