### PR TITLE
fix(relay): add error logging to Wingbits flight fetcher

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2855,7 +2855,10 @@ async function fetchTheaterFlightsFromOpenSky() {
 
 async function fetchTheaterFlightsFromWingbits() {
   const apiKey = process.env.WINGBITS_API_KEY;
-  if (!apiKey) return null;
+  if (!apiKey) {
+    console.warn('[Wingbits] WINGBITS_API_KEY not set — skipped');
+    return null;
+  }
   const areas = POSTURE_THEATERS.map((t) => ({
     alias: t.id,
     by: 'box',
@@ -2872,7 +2875,10 @@ async function fetchTheaterFlightsFromWingbits() {
       body: JSON.stringify(areas),
       signal: AbortSignal.timeout(15_000),
     });
-    if (!resp.ok) return null;
+    if (!resp.ok) {
+      console.warn(`[Wingbits] API error: ${resp.status} ${resp.statusText}`);
+      return null;
+    }
     const data = await resp.json();
     const flights = [];
     const seenIds = new Set();
@@ -2897,8 +2903,10 @@ async function fetchTheaterFlightsFromWingbits() {
         });
       }
     }
+    console.log(`[Wingbits] Fetched ${flights.length} military flights from ${data.length} areas`);
     return flights;
-  } catch {
+  } catch (err) {
+    console.warn(`[Wingbits] Fetch failed: ${err?.message || err}`);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Wingbits `fetchTheaterFlightsFromWingbits()` silently returned `null` on missing API key, HTTP errors, and caught exceptions
- Added logging for: missing key, non-OK HTTP status, successful fetch count, and caught errors
- Next deploy will show exactly why Wingbits is returning no flights

## Changes
- Log `WINGBITS_API_KEY not set` if key missing
- Log `API error: {status}` on non-OK response (was silent `return null`)
- Log `Fetched N military flights from M areas` on success
- Log `Fetch failed: {error}` on exception (was bare `catch { return null }`)

## Test plan
- [ ] Deploy to Railway, check logs for `[Wingbits]` entries
- [ ] Identify actual failure reason