### PR TITLE
fix(insights): check server insights before empty cluster guard

### DIFF
--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -257,16 +257,16 @@ export class InsightsPanel extends Panel {
     this.updateGeneration++;
     const thisGeneration = this.updateGeneration;
 
-    if (clusters.length === 0) {
-      this.setDataBadge('unavailable');
-      this.setContent(`<div class="insights-empty">${t('components.insights.waitingForData')}</div>`);
-      return;
-    }
-
-    // Try server-side pre-computed insights first (instant)
+    // Try server-side pre-computed insights first (instant, works even without clusters)
     const serverInsights = getServerInsights();
     if (serverInsights) {
       await this.updateFromServer(serverInsights, clusters, thisGeneration);
+      return;
+    }
+
+    if (clusters.length === 0) {
+      this.setDataBadge('unavailable');
+      this.setContent(`<div class="insights-empty">${t('components.insights.waitingForData')}</div>`);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Move `getServerInsights()` check before the `clusters.length === 0` early return in `InsightsPanel.updateInsights()`
- When client-side news clustering fails or is slow, the panel now renders from pre-computed Railway-seeded insights instead of showing "UNAVAILABLE"
- The server insights path (`updateFromServer`) already handles empty clusters gracefully (uses `serverInsights.topStories` for rendering, not client clusters)

## Root cause
The empty cluster guard at line 260 returned early with "Waiting for news data..." before checking `getServerInsights()`. This meant any clustering failure (network hiccup, slow load, worker error) caused the panel to show UNAVAILABLE even though fresh pre-computed insights were available via bootstrap.

## Test plan
- [ ] Verify AI Insights panel shows LIVE badge on worldmonitor.app
- [ ] Simulate clustering failure (e.g., block digest endpoint) and confirm panel still renders server insights
- [ ] 104 tests pass, types clean, 0 lint errors