### PR TITLE
fix(feeds): update dead RSS feed URLs

### DIFF
--- a/scripts/shared/rss-allowed-domains.json
+++ b/scripts/shared/rss-allowed-domains.json
@@ -84,6 +84,7 @@
   "dev.events",
   "www.ycombinator.com",
   "a16z.com",
+  "www.a16z.news",
   "review.firstround.com",
   "www.sequoiacap.com",
   "www.nfx.com",

--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -147,8 +147,8 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
     ],
     vcblogs: [
       { name: 'Y Combinator Blog', url: 'https://www.ycombinator.com/blog/rss/' },
-      { name: 'a16z Blog', url: 'https://a16z.com/feed/' },
-      { name: 'First Round Review', url: 'https://review.firstround.com/feed.xml' },
+      { name: 'a16z Blog', url: 'https://www.a16z.news/feed' },
+      { name: 'First Round Review', url: 'https://review.firstround.com/articles/rss' },
       { name: 'Sequoia Blog', url: 'https://www.sequoiacap.com/feed/' },
       { name: 'Stratechery', url: 'https://stratechery.com/feed/' },
     ],

--- a/shared/rss-allowed-domains.json
+++ b/shared/rss-allowed-domains.json
@@ -84,6 +84,7 @@
   "dev.events",
   "www.ycombinator.com",
   "a16z.com",
+  "www.a16z.news",
   "review.firstround.com",
   "www.sequoiacap.com",
   "www.nfx.com",

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -627,7 +627,7 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     { name: 'Atlantic Council', url: railwayRss('https://www.atlanticcouncil.org/feed/') },
     { name: 'Foreign Affairs', url: rss('https://www.foreignaffairs.com/rss.xml') },
     { name: 'CSIS', url: rss('https://news.google.com/rss/search?q=site:csis.org+when:7d&hl=en-US&gl=US&ceid=US:en') },
-    { name: 'RAND', url: rss('https://news.google.com/rss/search?q=site:rand.org+when:7d&hl=en-US&gl=US&ceid=US:en') },
+    { name: 'RAND', url: rss('https://www.rand.org/pubs/articles.xml') },
     { name: 'Brookings', url: rss('https://news.google.com/rss/search?q=site:brookings.edu+when:7d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Carnegie', url: rss('https://news.google.com/rss/search?q=site:carnegieendowment.org+when:7d&hl=en-US&gl=US&ceid=US:en') },
     // New verified think tank feeds
@@ -1241,7 +1241,7 @@ export const INTEL_SOURCES: Feed[] = [
   { name: 'Middle East Institute', url: rss('https://news.google.com/rss/search?q=site:mei.edu+when:7d&hl=en-US&gl=US&ceid=US:en'), type: 'intl' },
 
   // Think Tanks & Research (Tier 3)
-  { name: 'RAND', url: rss('https://news.google.com/rss/search?q=site:rand.org+when:7d&hl=en-US&gl=US&ceid=US:en'), type: 'research' },
+  { name: 'RAND', url: rss('https://www.rand.org/pubs/articles.xml'), type: 'research' },
   { name: 'Brookings', url: rss('https://news.google.com/rss/search?q=site:brookings.edu&hl=en&gl=US&ceid=US:en'), type: 'research' },
   { name: 'Carnegie', url: rss('https://news.google.com/rss/search?q=site:carnegieendowment.org&hl=en&gl=US&ceid=US:en'), type: 'research' },
   { name: 'FAS', url: rss('https://news.google.com/rss/search?q=site:fas.org+nuclear+weapons+security&hl=en&gl=US&ceid=US:en'), type: 'research' },

--- a/src/config/variants/tech.ts
+++ b/src/config/variants/tech.ts
@@ -72,8 +72,8 @@ export const FEEDS: Record<string, Feed[]> = {
   // Accelerator & VC Blogs - Thought leadership
   vcblogs: [
     { name: 'Y Combinator Blog', url: rss('https://www.ycombinator.com/blog/rss/') },
-    { name: 'a16z Blog', url: rss('https://a16z.com/feed/') },
-    { name: 'First Round Review', url: rss('https://review.firstround.com/feed.xml') },
+    { name: 'a16z Blog', url: rss('https://www.a16z.news/feed') },
+    { name: 'First Round Review', url: rss('https://review.firstround.com/articles/rss') },
     { name: 'Sequoia Blog', url: rss('https://www.sequoiacap.com/feed/') },
     { name: 'NFX Essays', url: rss('https://www.nfx.com/feed') },
     { name: 'Paul Graham Essays', url: rss('https://www.aaronsw.com/2002/feeds/pgessays.rss') },


### PR DESCRIPTION
## Summary
- **a16z**: `a16z.com/feed/` -> `www.a16z.news/feed` (old domain dead)
- **First Round Review**: `/feed.xml` -> `/articles/rss` (URL changed)
- **RAND**: Google News proxy -> `rand.org/pubs/articles.xml` (direct feed restored)
- Added `www.a16z.news` to RSS allowed domains

## Files changed
- `server/worldmonitor/news/v1/_feeds.ts` (a16z, First Round)
- `src/config/variants/tech.ts` (a16z, First Round)
- `src/config/feeds.ts` (RAND x2)
- `shared/rss-allowed-domains.json` + `scripts/shared/` copy

## Test plan
- [ ] Verify a16z feed returns articles at new URL
- [ ] Verify First Round feed returns articles at new URL
- [ ] Verify RAND feed returns articles at new URL
- [ ] No relay RSS 404 errors for these feeds after deploy