### PR TITLE
fix(insights): clear stale state on server fallback path

### DIFF
--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -287,6 +287,12 @@ export class InsightsPanel extends Panel {
     const totalSteps = 2;
 
     try {
+      // Clear stale ML-detected stories when clusters are empty (e.g. clustering
+      // failed) so unrelated missed stories don't render next to server insights
+      if (clusters.length === 0) {
+        this.lastMissedStories = [];
+      }
+
       // Step 1: Signal aggregation (client-side, depends on real-time map data)
       this.setProgress(1, totalSteps, 'Loading server insights...');
 
@@ -842,13 +848,9 @@ export class InsightsPanel extends Panel {
       return;
     }
 
-    if (this.lastClusters.length > 0) {
-      void this.updateInsights(this.lastClusters);
-      return;
-    }
-
-    this.setDataBadge('unavailable');
-    this.setContent(`<div class="insights-empty">${t('components.insights.waitingForData')}</div>`);
+    // Re-run full updateInsights which checks server insights first,
+    // then falls back to client-side clustering
+    void this.updateInsights(this.lastClusters);
   }
 
   public override destroy(): void {


### PR DESCRIPTION
## Summary
Follow-up to PR #1574 addressing two review findings:

- **P2-1**: `onAiFlowChanged()` checked `lastClusters.length > 0` before re-rendering, dropping to "waiting" state on AI flow toggle instead of trying server insights. Now delegates to `updateInsights()` which checks the server path first.
- **P2-2**: `renderServerInsights()` rendered `lastMissedStories` from a previous clustering run. With the empty-cluster fallback from #1574, stale ML-detected stories could appear next to unrelated server stories. Now clears `lastMissedStories` when entering server path with empty clusters.

## Test plan
- [ ] Toggle AI flow settings (e.g., disable/re-enable cloud LLM) while server insights are active: panel should re-render server insights, not show "waiting"
- [ ] Simulate clustering failure after a successful run: stale "ML DETECTED" section should not appear alongside server stories
- [ ] 104 tests pass, types clean, 0 lint errors