### PR TITLE
fix(ui): add span-2 to content-heavy panels truncated at 380px

### DIFF
--- a/src/components/CIIPanel.ts
+++ b/src/components/CIIPanel.ts
@@ -18,8 +18,8 @@ export class CIIPanel extends Panel {
       id: 'cii',
       title: t('panels.cii'),
       infoTooltip: t('components.cii.infoTooltip'),
+      defaultRowSpan: 2,
     });
-    this.element.classList.add('span-2');
     this.showLoading(t('common.loading'));
   }
 

--- a/src/components/DisplacementPanel.ts
+++ b/src/components/DisplacementPanel.ts
@@ -18,8 +18,8 @@ export class DisplacementPanel extends Panel {
       showCount: true,
       trackActivity: true,
       infoTooltip: t('components.displacement.infoTooltip'),
+      defaultRowSpan: 2,
     });
-    this.element.classList.add('span-2');
     this.showLoading(t('common.loadingDisplacement'));
 
     this.content.addEventListener('click', (e) => {

--- a/src/components/EconomicPanel.ts
+++ b/src/components/EconomicPanel.ts
@@ -20,8 +20,7 @@ export class EconomicPanel extends Panel {
   private activeTab: TabId = 'indicators';
 
   constructor() {
-    super({ id: 'economic', title: t('panels.economic') });
-    this.element.classList.add('span-2');
+    super({ id: 'economic', title: t('panels.economic'), defaultRowSpan: 2 });
     this.content.addEventListener('click', (e) => {
       const tab = (e.target as HTMLElement).closest('.panel-tab') as HTMLElement | null;
       if (tab?.dataset.tab) {

--- a/src/components/GdeltIntelPanel.ts
+++ b/src/components/GdeltIntelPanel.ts
@@ -24,8 +24,8 @@ export class GdeltIntelPanel extends Panel {
       showCount: true,
       trackActivity: true,
       infoTooltip: t('components.gdeltIntel.infoTooltip'),
+      defaultRowSpan: 2,
     });
-    this.element.classList.add('span-2');
     this.createTabs();
     this.loadActiveTopic();
   }

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -15,6 +15,7 @@ export interface PanelOptions {
   infoTooltip?: string;
   premium?: 'locked' | 'enhanced';
   closable?: boolean;
+  defaultRowSpan?: number;
 }
 
 const PANEL_SPANS_KEY = 'worldmonitor-panel-spans';
@@ -299,10 +300,15 @@ export class Panel {
     this.element.appendChild(this.colResizeHandle);
     this.setupColResizeHandlers();
 
-    // Restore saved span
+    // Apply default row span (before restore, so saved preferences win)
+    if (options.defaultRowSpan && options.defaultRowSpan > 1) {
+      this.element.classList.add(`span-${options.defaultRowSpan}`);
+    }
+
+    // Restore saved span (overrides default)
     const savedSpans = loadPanelSpans();
     const savedSpan = savedSpans[this.panelId];
-    if (savedSpan && savedSpan > 1) {
+    if (savedSpan !== undefined) {
       setSpanClass(this.element, savedSpan);
     }
 

--- a/src/components/SecurityAdvisoriesPanel.ts
+++ b/src/components/SecurityAdvisoriesPanel.ts
@@ -18,8 +18,8 @@ export class SecurityAdvisoriesPanel extends Panel {
       showCount: true,
       trackActivity: true,
       infoTooltip: t('components.securityAdvisories.infoTooltip'),
+      defaultRowSpan: 2,
     });
-    this.element.classList.add('span-2');
     this.showLoading(t('components.securityAdvisories.loading'));
 
     this.content.addEventListener('click', (e) => {

--- a/src/components/StrategicPosturePanel.ts
+++ b/src/components/StrategicPosturePanel.ts
@@ -24,8 +24,8 @@ export class StrategicPosturePanel extends Panel {
       showCount: false,
       trackActivity: true,
       infoTooltip: t('components.strategicPosture.infoTooltip'),
+      defaultRowSpan: 2,
     });
-    this.element.classList.add('span-2');
     this.init();
   }
 

--- a/src/components/SupplyChainPanel.ts
+++ b/src/components/SupplyChainPanel.ts
@@ -22,8 +22,7 @@ export class SupplyChainPanel extends Panel {
   private chartObserver: MutationObserver | null = null;
 
   constructor() {
-    super({ id: 'supply-chain', title: t('panels.supplyChain') });
-    this.element.classList.add('span-2');
+    super({ id: 'supply-chain', title: t('panels.supplyChain'), defaultRowSpan: 2 });
     this.content.addEventListener('click', (e) => {
       const tab = (e.target as HTMLElement).closest('.panel-tab') as HTMLElement | null;
       if (tab) {

--- a/src/components/TelegramIntelPanel.ts
+++ b/src/components/TelegramIntelPanel.ts
@@ -24,8 +24,8 @@ export class TelegramIntelPanel extends Panel {
       showCount: true,
       trackActivity: true,
       infoTooltip: t('components.telegramIntel.infoTooltip'),
+      defaultRowSpan: 2,
     });
-    this.element.classList.add('span-2');
     this.createTabs();
     this.showLoading(t('components.telegramIntel.loading'));
   }

--- a/src/components/TradePolicyPanel.ts
+++ b/src/components/TradePolicyPanel.ts
@@ -20,8 +20,7 @@ export class TradePolicyPanel extends Panel {
   private activeTab: TabId = 'restrictions';
 
   constructor() {
-    super({ id: 'trade-policy', title: t('panels.tradePolicy') });
-    this.element.classList.add('span-2');
+    super({ id: 'trade-policy', title: t('panels.tradePolicy'), defaultRowSpan: 2 });
     this.content.addEventListener('click', (e) => {
       const target = (e.target as HTMLElement).closest('.panel-tab') as HTMLElement | null;
       if (!target) return;

--- a/src/components/UcdpEventsPanel.ts
+++ b/src/components/UcdpEventsPanel.ts
@@ -15,8 +15,8 @@ export class UcdpEventsPanel extends Panel {
       showCount: true,
       trackActivity: true,
       infoTooltip: t('components.ucdpEvents.infoTooltip'),
+      defaultRowSpan: 2,
     });
-    this.element.classList.add('span-2');
     this.showLoading(t('common.loadingUcdpEvents'));
 
     this.content.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- Content-heavy panels were capped at 380px by `grid-auto-rows: minmax(200px, 380px)`, making content invisible without scrolling
- Added `span-2` (2 grid rows, ~760px) to 10 panels that have tabs + dense list/card/table content

## Panels updated
| Panel | Why it needs more height |
|-------|------------------------|
| SupplyChainPanel | 3 tabs + 10+ chokepoint cards with charts |
| TelegramIntelPanel | Topic tabs + message list with media |
| EconomicPanel | 4 tabs (Indicators, Oil, Spending, Central Banks) |
| TradePolicyPanel | 4 tabs (Restrictions, Tariffs, Flows, Barriers) |
| GdeltIntelPanel | Topic tabs + article list |
| SecurityAdvisoriesPanel | Filter buttons + advisory cards |
| CIIPanel | Country instability list with scores |
| UcdpEventsPanel | Tabs + conflict event cards |
| DisplacementPanel | Tabs + displacement data cards |
| StrategicPosturePanel | Theater cards with posture data |

## Panels intentionally NOT changed
- **NewsPanel**: Uses virtual scrolling (windowed list), designed to scroll within panel
- **MarketPanel, ETFFlows, Stablecoin**: Compact row layouts, fit in 380px
- **CountersPanel, WorldClock, Monitor**: Simple/small content

## Test plan
- [ ] Verify all 10 panels display full content without needing to scroll within the panel
- [ ] Check grid layout doesn't break on ultrawide (1600px+) or mobile
- [ ] Panels still resizable via drag handle