### PR TITLE
Add info tooltips to 10 panels, remove Supply Chain source footer

### DIFF
--- a/src/components/CorrelationPanel.ts
+++ b/src/components/CorrelationPanel.ts
@@ -31,8 +31,8 @@ export class CorrelationPanel extends Panel {
   private boundUpdateHandler: EventListener;
   private hasLiveData = false;
 
-  constructor(id: string, title: string, domain: CorrelationDomain) {
-    super({ id, title, showCount: true });
+  constructor(id: string, title: string, domain: CorrelationDomain, infoTooltip?: string) {
+    super({ id, title, showCount: true, infoTooltip });
     this.domain = domain;
 
     const bootstrap = getCorrelationBootstrap();

--- a/src/components/ETFFlowsPanel.ts
+++ b/src/components/ETFFlowsPanel.ts
@@ -32,7 +32,7 @@ export class ETFFlowsPanel extends Panel {
   private loading = true;
   private error: string | null = null;
   constructor() {
-    super({ id: 'etf-flows', title: t('panels.etfFlows'), showCount: false });
+    super({ id: 'etf-flows', title: t('panels.etfFlows'), showCount: false, infoTooltip: t('components.etfFlows.infoTooltip') });
   }
 
   public async fetchData(): Promise<void> {

--- a/src/components/EconomicCorrelationPanel.ts
+++ b/src/components/EconomicCorrelationPanel.ts
@@ -1,7 +1,8 @@
 import { CorrelationPanel } from './CorrelationPanel';
+import { t } from '@/services/i18n';
 
 export class EconomicCorrelationPanel extends CorrelationPanel {
   constructor() {
-    super('economic-correlation', 'Economic Warfare', 'economic');
+    super('economic-correlation', 'Economic Warfare', 'economic', t('components.economicCorrelation.infoTooltip'));
   }
 }

--- a/src/components/EconomicPanel.ts
+++ b/src/components/EconomicPanel.ts
@@ -20,7 +20,7 @@ export class EconomicPanel extends Panel {
   private activeTab: TabId = 'indicators';
 
   constructor() {
-    super({ id: 'economic', title: t('panels.economic'), defaultRowSpan: 2 });
+    super({ id: 'economic', title: t('panels.economic'), defaultRowSpan: 2, infoTooltip: t('components.economic.infoTooltip') });
     this.content.addEventListener('click', (e) => {
       const tab = (e.target as HTMLElement).closest('.panel-tab') as HTMLElement | null;
       if (tab?.dataset.tab) {

--- a/src/components/EscalationCorrelationPanel.ts
+++ b/src/components/EscalationCorrelationPanel.ts
@@ -1,7 +1,8 @@
 import { CorrelationPanel } from './CorrelationPanel';
+import { t } from '@/services/i18n';
 
 export class EscalationCorrelationPanel extends CorrelationPanel {
   constructor() {
-    super('escalation-correlation', 'Escalation Monitor', 'escalation');
+    super('escalation-correlation', 'Escalation Monitor', 'escalation', t('components.escalationCorrelation.infoTooltip'));
   }
 }

--- a/src/components/MacroSignalsPanel.ts
+++ b/src/components/MacroSignalsPanel.ts
@@ -127,7 +127,7 @@ export class MacroSignalsPanel extends Panel {
   private lastTimestamp = '';
 
   constructor() {
-    super({ id: 'macro-signals', title: t('panels.macroSignals'), showCount: false });
+    super({ id: 'macro-signals', title: t('panels.macroSignals'), showCount: false, infoTooltip: t('components.macroSignals.infoTooltip') });
   }
 
   public async fetchData(): Promise<boolean> {

--- a/src/components/MarketPanel.ts
+++ b/src/components/MarketPanel.ts
@@ -16,7 +16,7 @@ export class MarketPanel extends Panel {
   private overlay: HTMLElement | null = null;
 
   constructor() {
-    super({ id: 'markets', title: t('panels.markets') });
+    super({ id: 'markets', title: t('panels.markets'), infoTooltip: t('components.markets.infoTooltip') });
     this.createSettingsButton();
   }
 
@@ -135,7 +135,7 @@ export class MarketPanel extends Panel {
 
 export class HeatmapPanel extends Panel {
   constructor() {
-    super({ id: 'heatmap', title: t('panels.heatmap') });
+    super({ id: 'heatmap', title: t('panels.heatmap'), infoTooltip: t('components.heatmap.infoTooltip') });
   }
 
   public renderHeatmap(data: Array<{ name: string; change: number | null }>): void {
@@ -166,7 +166,7 @@ export class HeatmapPanel extends Panel {
 
 export class CommoditiesPanel extends Panel {
   constructor() {
-    super({ id: 'commodities', title: t('panels.commodities') });
+    super({ id: 'commodities', title: t('panels.commodities'), infoTooltip: t('components.commodities.infoTooltip') });
   }
 
   public renderCommodities(data: Array<{ display: string; price: number | null; change: number | null; sparkline?: number[] }>): void {

--- a/src/components/SupplyChainPanel.ts
+++ b/src/components/SupplyChainPanel.ts
@@ -22,7 +22,7 @@ export class SupplyChainPanel extends Panel {
   private chartObserver: MutationObserver | null = null;
 
   constructor() {
-    super({ id: 'supply-chain', title: t('panels.supplyChain'), defaultRowSpan: 2 });
+    super({ id: 'supply-chain', title: t('panels.supplyChain'), defaultRowSpan: 2, infoTooltip: t('components.supplyChain.infoTooltip') });
     this.content.addEventListener('click', (e) => {
       const tab = (e.target as HTMLElement).closest('.panel-tab') as HTMLElement | null;
       if (tab) {
@@ -104,9 +104,6 @@ export class SupplyChainPanel extends Panel {
       ${tabsHtml}
       ${unavailableBanner}
       <div class="economic-content">${contentHtml}</div>
-      <div class="economic-footer">
-        <span class="economic-source">${t('components.supplyChain.sources')}</span>
-      </div>
     `);
 
     if (this.activeTab === 'chokepoints' && this.expandedChokepoint) {

--- a/src/components/TradePolicyPanel.ts
+++ b/src/components/TradePolicyPanel.ts
@@ -20,7 +20,7 @@ export class TradePolicyPanel extends Panel {
   private activeTab: TabId = 'restrictions';
 
   constructor() {
-    super({ id: 'trade-policy', title: t('panels.tradePolicy'), defaultRowSpan: 2 });
+    super({ id: 'trade-policy', title: t('panels.tradePolicy'), defaultRowSpan: 2, infoTooltip: t('components.tradePolicy.infoTooltip') });
     this.content.addEventListener('click', (e) => {
       const target = (e.target as HTMLElement).closest('.panel-tab') as HTMLElement | null;
       if (!target) return;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -783,7 +783,8 @@
       "change": "Change",
       "cut": "cut",
       "hike": "hike",
-      "hold": "hold"
+      "hold": "hold",
+      "infoTooltip": "<strong>Economic Indicators</strong> Key macro data from FRED, EIA, and BIS:<ul><li><strong>Indicators</strong>: GDP, unemployment, inflation, interest rates</li><li><strong>Oil</strong>: WTI/Brent prices, inventory, and spreads</li><li><strong>Gov</strong>: Recent US government contract awards</li><li><strong>Central Banks</strong>: Policy rates and exchange rate data</li></ul>"
     },
     "supplyChain": {
       "chokepoints": "Chokepoints",
@@ -806,7 +807,8 @@
       "mineral": "Mineral",
       "topProducers": "Top Producers",
       "risk": "Risk",
-      "sources": "IMF PortWatch / AISStream / CorridorRisk / NGA / USGS"
+      "sources": "IMF PortWatch / AISStream / CorridorRisk / NGA / USGS",
+      "infoTooltip": "<strong>Supply Chain Monitor</strong> Global logistics and resource tracking:<ul><li><strong>Chokepoints</strong>: Maritime transit status, disruption scores, and vessel counts</li><li><strong>Shipping</strong>: Baltic Dry Index and freight rate trends</li><li><strong>Minerals</strong>: Critical mineral concentration risk (HHI) and top producers</li></ul>Click a chokepoint card to expand transit history chart."
     },
     "tradePolicy": {
       "restrictions": "Restrictions",
@@ -826,7 +828,8 @@
       "yoyChange": "YoY Change",
       "highTariff": "High",
       "moderateTariff": "Moderate",
-      "lowTariff": "Low"
+      "lowTariff": "Low",
+      "infoTooltip": "<strong>Trade Policy</strong> WTO trade monitoring:<ul><li><strong>Restrictions</strong>: Active trade measures by country and sector</li><li><strong>Tariffs</strong>: Applied tariff rate trends by year</li><li><strong>Trade Flows</strong>: Export/import volumes with year-over-year changes</li><li><strong>Barriers</strong>: Technical barriers to trade (TBT/SPS notifications)</li></ul>"
     },
     "gdelt": {
       "empty": "No recent articles for this topic"
@@ -1626,7 +1629,8 @@
         "estFlow": "Est. Flow",
         "volume": "Volume",
         "change": "Change"
-      }
+      },
+      "infoTooltip": "<strong>BTC ETF Tracker</strong> Tracks daily estimated fund flows for US spot Bitcoin ETFs:<ul><li>Inflow/outflow direction and magnitude</li><li>Volume and price change per fund</li><li>Net aggregate flow across all tracked ETFs</li></ul>"
     },
     "macroSignals": {
       "overall": "Overall",
@@ -1643,7 +1647,23 @@
         "hashRate": "Hash Rate",
         "momentum": "Momentum",
         "fearGreed": "Fear & Greed"
-      }
+      },
+      "infoTooltip": "<strong>Market Radar</strong> Composite signal dashboard for crypto macro positioning:<ul><li><strong>Liquidity</strong>: Net Fed liquidity proxy</li><li><strong>Flow</strong>: BTC vs QQQ 5-day returns</li><li><strong>Regime</strong>: QQQ vs XLP rotation (risk-on/off)</li><li><strong>BTC Trend</strong>: Price vs SMA50/200, Mayer Multiple</li><li><strong>Hash Rate</strong>: 30-day network hash change</li><li><strong>Fear & Greed</strong>: Market sentiment index</li></ul>Verdict: BUY when majority signals bullish, CASH otherwise."
+    },
+    "escalationCorrelation": {
+      "infoTooltip": "<strong>Escalation Monitor</strong> Detects converging geopolitical signals:<ul><li>Correlates military movements, conflict events, and news spikes</li><li>Scores convergence zones by severity (critical/high/medium/low)</li><li>Tracks escalation or de-escalation trends over time</li></ul>Click a card to zoom to the region on the map."
+    },
+    "economicCorrelation": {
+      "infoTooltip": "<strong>Economic Warfare</strong> Detects converging economic pressure signals:<ul><li>Sanctions, trade restrictions, and currency movements</li><li>Commodity disruptions linked to geopolitical actors</li><li>Cross-domain correlation between economic and security events</li></ul>Click a card to zoom to the affected region."
+    },
+    "markets": {
+      "infoTooltip": "<strong>Markets</strong> Real-time stock indices, equities, and crypto prices. Customize your watchlist with the Watchlist button. Sparklines show recent price trend."
+    },
+    "heatmap": {
+      "infoTooltip": "<strong>Sector Heatmap</strong> S&P 500 sector performance at a glance. Color intensity reflects the magnitude of daily change. Green = gains, Red = losses."
+    },
+    "commodities": {
+      "infoTooltip": "<strong>Commodities</strong> Key commodity prices including gold, silver, oil, natural gas, copper, and agricultural products. Sparklines show recent price trend."
     },
     "panel": {
       "showMethodologyInfo": "Show methodology info",


### PR DESCRIPTION
## Summary
- Add "?" info tooltips to 10 panels that were missing them: Escalation Monitor, Economic Warfare, Economic Indicators, Trade Policy, Supply Chain, Markets, Sector Heatmap, Commodities, Market Radar, BTC ETF Tracker
- Remove the source attribution footer from Supply Chain panel (was showing "IMF PortWatch / AISStream / CorridorRisk / NGA / USGS")
- CorrelationPanel base class now accepts optional `infoTooltip` param, passed through to Panel

## Test plan
- [ ] Verify "?" icon appears on all 10 panels
- [ ] Hover/click tooltip shows methodology explanation
- [ ] Supply Chain panel no longer shows source footer
- [ ] CascadePanel (already had tooltip) still works
- [ ] No TypeScript errors (`tsc --noEmit` passes)