### PR TITLE
refactor: dedupe economic fetch timeout wiring

### DIFF
--- a/server/worldmonitor/economic/v1/_bis-shared.ts
+++ b/server/worldmonitor/economic/v1/_bis-shared.ts
@@ -5,6 +5,7 @@
 
 import { CHROME_UA } from '../../../_shared/constants';
 import Papa from 'papaparse';
+import { fetchWithTimeout } from './_fetch-with-timeout';
 
 const BIS_BASE = 'https://stats.bis.org/api/v1/data';
 
@@ -30,18 +31,15 @@ export const BIS_COUNTRY_KEYS = Object.keys(BIS_COUNTRIES).join('+');
 export async function fetchBisCSV(dataset: string, key: string, timeout = 12000): Promise<string> {
   const separator = key.includes('?') ? '&' : '?';
   const url = `${BIS_BASE}/${dataset}/${key}${separator}format=csv`;
-  const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
-  try {
-    const res = await fetch(url, {
+  const res = await fetchWithTimeout(
+    url,
+    {
       headers: { 'User-Agent': CHROME_UA, Accept: 'text/csv' },
-      signal: controller.signal,
-    });
-    if (!res.ok) throw new Error(`BIS HTTP ${res.status}`);
-    return await res.text();
-  } finally {
-    clearTimeout(id);
-  }
+    },
+    timeout,
+  );
+  if (!res.ok) throw new Error(`BIS HTTP ${res.status}`);
+  return await res.text();
 }
 
 // Parse BIS CSV using papaparse — robust handling of quoted fields & metadata

--- a/server/worldmonitor/economic/v1/_fetch-with-timeout.ts
+++ b/server/worldmonitor/economic/v1/_fetch-with-timeout.ts
@@ -1,0 +1,13 @@
+/**
+ * Fetch with an AbortController deadline.
+ * Clears the timeout in all cases to avoid timer leaks.
+ */
+export async function fetchWithTimeout(url: string, init: RequestInit = {}, timeout = 8000): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/server/worldmonitor/economic/v1/_shared.ts
+++ b/server/worldmonitor/economic/v1/_shared.ts
@@ -3,6 +3,7 @@
  */
 
 import { CHROME_UA, yahooGate } from '../../../_shared/constants';
+import { fetchWithTimeout } from './_fetch-with-timeout';
 
 /**
  * Fetch JSON from a URL with a configurable timeout.
@@ -10,15 +11,9 @@ import { CHROME_UA, yahooGate } from '../../../_shared/constants';
  */
 export async function fetchJSON(url: string, timeout = 8000): Promise<any> {
   if (url.includes('yahoo.com')) await yahooGate();
-  const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
-  try {
-    const res = await fetch(url, { headers: { 'User-Agent': CHROME_UA }, signal: controller.signal });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    return await res.json();
-  } finally {
-    clearTimeout(id);
-  }
+  const res = await fetchWithTimeout(url, { headers: { 'User-Agent': CHROME_UA } }, timeout);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return await res.json();
 }
 
 /**


### PR DESCRIPTION
Summary
	•	Extract a shared helper in economic/v1/helpers.
	•	Reuse the helper in the affected modules.
	•	Keep behavior unchanged while removing duplicated AbortController timeout wiring.

Validation
	•	Pre-push checks passed:
	•	typecheck
	•	API typecheck
	•	edge checks/tests
	•	markdown lint
	•	MDX lint
	•	version sync