### PR TITLE
refactor: dedupe query string array parsing

### DIFF
--- a/server/_shared/parse-string-array.ts
+++ b/server/_shared/parse-string-array.ts
@@ -1,0 +1,9 @@
+/**
+ * Defensive parser for repeated-string query params.
+ * Some codegen paths may pass comma-separated strings into string[] fields.
+ */
+export function parseStringArray(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.filter(Boolean);
+  if (typeof raw === 'string' && raw.length > 0) return raw.split(',').filter(Boolean);
+  return [];
+}

--- a/server/worldmonitor/aviation/v1/_shared.ts
+++ b/server/worldmonitor/aviation/v1/_shared.ts
@@ -14,18 +14,7 @@ import {
 } from '../../../../src/config/airports';
 import { CHROME_UA } from '../../../_shared/constants';
 import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
-
-/**
- * Defensive parser for repeated-string query params.
- * The sebuf codegen assigns `params.get("airports")` (a string) to a field
- * typed as `string[]`.  At runtime `req.airports` may therefore be a
- * comma-separated string rather than an actual array.
- */
-export function parseStringArray(raw: unknown): string[] {
-  if (Array.isArray(raw)) return raw.filter(Boolean);
-  if (typeof raw === 'string' && raw.length > 0) return raw.split(',').filter(Boolean);
-  return [];
-}
+export { parseStringArray } from '../../../_shared/parse-string-array';
 
 // ---------- Constants ----------
 
@@ -601,4 +590,3 @@ export function mergeNotamWithExistingAlert(
     updatedAt: Date.now(),
   };
 }
-

--- a/server/worldmonitor/market/v1/_shared.ts
+++ b/server/worldmonitor/market/v1/_shared.ts
@@ -4,6 +4,7 @@
 import { CHROME_UA, yahooGate } from '../../../_shared/constants';
 import cryptoConfig from '../../../../shared/crypto.json';
 import stablecoinConfig from '../../../../shared/stablecoins.json';
+export { parseStringArray } from '../../../_shared/parse-string-array';
 
 // ========================================================================
 // Relay helpers (Railway proxy for Yahoo when Vercel IPs are rate-limited)
@@ -35,18 +36,6 @@ export const UPSTREAM_TIMEOUT_MS = 10_000;
 
 export function sanitizeSymbol(raw: string): string {
   return raw.trim().replace(/\s+/g, '').slice(0, 32).toUpperCase();
-}
-
-/**
- * Defensive parser for repeated-string query params.
- * The sebuf codegen assigns `params.get("symbols")` (a string) to a field
- * typed as `string[]`.  At runtime `req.symbols` may therefore be a
- * comma-separated string rather than an actual array.
- */
-export function parseStringArray(raw: unknown): string[] {
-  if (Array.isArray(raw)) return raw.filter(Boolean);
-  if (typeof raw === 'string' && raw.length > 0) return raw.split(',').filter(Boolean);
-  return [];
 }
 
 export async function fetchYahooQuotesBatch(


### PR DESCRIPTION
## Summary
- extract duplicated repeated-string query param parsing into shared `parseStringArray(...)` helper in `server/_shared/parse-string-array.ts`
- replace duplicate local implementations in `server/worldmonitor/aviation/v1/_shared.ts` and `server/worldmonitor/market/v1/_shared.ts` with re-exports to preserve existing imports
- keep behavior unchanged while reducing maintenance overhead

## Validation
- pre-push checks passed during `git push` (typecheck, API typecheck, edge checks/tests, markdown lint, MDX lint, version sync check)
