### PR TITLE
refactor: move shared types from services/config to types layer

### DIFF
--- a/src/config/ports.ts
+++ b/src/config/ports.ts
@@ -1,15 +1,5 @@
-export type PortType = 'container' | 'oil' | 'lng' | 'naval' | 'mixed' | 'bulk';
-
-export interface Port {
-  id: string;
-  name: string;
-  lat: number;
-  lon: number;
-  country: string;
-  type: PortType;
-  rank?: number;
-  note: string;
-}
+export type { PortType, Port } from '@/types';
+import type { Port, PortType } from '@/types';
 
 export const PORTS: Port[] = [
   // Top Container Ports

--- a/src/config/tech-geo.ts
+++ b/src/config/tech-geo.ts
@@ -22,17 +22,8 @@ export interface Accelerator {
   notable?: string[];
 }
 
-export interface TechHQ {
-  id: string;
-  company: string;
-  city: string;
-  country: string;
-  lat: number;
-  lon: number;
-  type: 'faang' | 'unicorn' | 'public';
-  employees?: number;
-  marketCap?: string;
-}
+export type { TechHQ } from '@/types';
+import type { TechHQ } from '@/types';
 
 export interface CloudRegion {
   id: string;

--- a/src/services/positive-classifier.ts
+++ b/src/services/positive-classifier.ts
@@ -1,13 +1,8 @@
 // Positive content classifier for the happy variant
 // Mirrors the pattern in threat-classifier.ts but for positive news categorization
 
-export type HappyContentCategory =
-  | 'science-health'
-  | 'nature-wildlife'
-  | 'humanity-kindness'
-  | 'innovation-tech'
-  | 'climate-wins'
-  | 'culture-community';
+export type { HappyContentCategory } from '@/types';
+import type { HappyContentCategory } from '@/types';
 
 export const HAPPY_CATEGORY_LABELS: Record<HappyContentCategory, string> = {
   'science-health': 'Science & Health',

--- a/src/services/threat-classifier.ts
+++ b/src/services/threat-classifier.ts
@@ -1,16 +1,5 @@
-export type ThreatLevel = 'critical' | 'high' | 'medium' | 'low' | 'info';
-
-export type EventCategory =
-  | 'conflict' | 'protest' | 'disaster' | 'diplomatic' | 'economic'
-  | 'terrorism' | 'cyber' | 'health' | 'environmental' | 'military'
-  | 'crime' | 'infrastructure' | 'tech' | 'general';
-
-export interface ThreatClassification {
-  level: ThreatLevel;
-  category: EventCategory;
-  confidence: number;
-  source: 'keyword' | 'ml' | 'llm';
-}
+export type { ThreatLevel, EventCategory, ThreatClassification } from '@/types';
+import type { ThreatLevel, EventCategory, ThreatClassification } from '@/types';
 
 import { getCSSColor } from '@/utils';
 import { getRpcBaseUrl } from '@/services/rpc-client';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,27 @@ export interface Feed {
   lang?: string;             // ISO 2-letter code for filtering
 }
 
-export type { ThreatClassification, ThreatLevel, EventCategory } from '@/services/threat-classifier';
+export type ThreatLevel = 'critical' | 'high' | 'medium' | 'low' | 'info';
+
+export type EventCategory =
+  | 'conflict' | 'protest' | 'disaster' | 'diplomatic' | 'economic'
+  | 'terrorism' | 'cyber' | 'health' | 'environmental' | 'military'
+  | 'crime' | 'infrastructure' | 'tech' | 'general';
+
+export interface ThreatClassification {
+  level: ThreatLevel;
+  category: EventCategory;
+  confidence: number;
+  source: 'keyword' | 'ml' | 'llm';
+}
+
+export type HappyContentCategory =
+  | 'science-health'
+  | 'nature-wildlife'
+  | 'humanity-kindness'
+  | 'innovation-tech'
+  | 'climate-wins'
+  | 'culture-community';
 
 export interface NewsItem {
   source: string;
@@ -26,14 +46,12 @@ export interface NewsItem {
   isAlert: boolean;
   monitorColor?: string;
   tier?: number;
-  threat?: import('@/services/threat-classifier').ThreatClassification;
+  threat?: ThreatClassification;
   lat?: number;
   lon?: number;
   locationName?: string;
   lang?: string;
-  // Happy variant: positive content category
-  happyCategory?: import('@/services/positive-classifier').HappyContentCategory;
-  // Image URL extracted from RSS media/enclosure tags
+  happyCategory?: HappyContentCategory;
   imageUrl?: string;
 }
 
@@ -62,7 +80,7 @@ export interface ClusteredEvent {
   isAlert: boolean;
   monitorColor?: string;
   velocity?: VelocityMetrics;
-  threat?: import('@/services/threat-classifier').ThreatClassification;
+  threat?: ThreatClassification;
   lat?: number;
   lon?: number;
   lang?: string;
@@ -1070,8 +1088,30 @@ export interface CascadeResult {
   }[];
 }
 
-// Re-export port types
-export type { Port, PortType } from '@/config/ports';
+export interface TechHQ {
+  id: string;
+  company: string;
+  city: string;
+  country: string;
+  lat: number;
+  lon: number;
+  type: 'faang' | 'unicorn' | 'public';
+  employees?: number;
+  marketCap?: string;
+}
+
+export type PortType = 'container' | 'oil' | 'lng' | 'naval' | 'mixed' | 'bulk';
+
+export interface Port {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  country: string;
+  type: PortType;
+  rank?: number;
+  note: string;
+}
 
 // AI Regulation Types
 export type RegulationType = 'comprehensive' | 'sectoral' | 'voluntary' | 'proposed';
@@ -1316,7 +1356,7 @@ export interface MapTechHQCluster {
   lat: number;
   lon: number;
   count: number;
-  items: import('@/config/tech-geo').TechHQ[];
+  items: TechHQ[];
   city: string;
   country: string;
   primaryType: 'faang' | 'unicorn' | 'public';


### PR DESCRIPTION
## Summary
- Move `ThreatClassification`, `ThreatLevel`, `EventCategory`, `HappyContentCategory`, `TechHQ`, `Port`, `PortType` from services/config layer into `src/types/index.ts` (lowest layer)
- Original files re-export from `@/types` for backward compatibility
- Zero inline `import()` types and zero backward `from '@/...'` imports remain in `src/types/index.ts`

## Context
P2 finding from PR #1587 review: `src/types/index.ts` used inline `import('@/services/...')` and `import('@/config/...')` type expressions, violating the `types -> config -> services` architectural boundary. The lint script (`lint-boundaries.mjs`) would catch these once merged, but the types themselves needed to live in the correct layer.

## Test plan
- [x] `tsc --noEmit` and `tsc --noEmit -p tsconfig.api.json` clean
- [x] 104/104 edge function tests pass
- [x] All pre-push hooks pass
- [x] `grep -c "import(" src/types/index.ts` returns 0