### PR TITLE
Remove pro banner and community widget from UI

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -42,7 +42,6 @@ import { PanelLayoutManager } from '@/app/panel-layout';
 import { DataLoaderManager } from '@/app/data-loader';
 import { EventHandlerManager } from '@/app/event-handlers';
 import { resolveUserRegion, resolvePreciseUserCoordinates, type PreciseCoordinates } from '@/utils/user-location';
-import { showProBanner } from '@/components/ProBanner';
 import {
   CorrelationEngine,
   militaryAdapter,
@@ -547,7 +546,6 @@ export class App {
 
     // Phase 1: Layout (creates map + panels — they'll find hydrated data)
     this.panelLayout.init();
-    showProBanner(this.state.container);
 
     const mobileGeoCoords = await geoCoordsPromise;
     if (mobileGeoCoords && this.state.map) {

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -107,7 +107,7 @@ import { classifyWithAI } from '@/services/threat-classifier';
 import { ingestHeadlines } from '@/services/trending-keywords';
 import type { ListFeedDigestResponse } from '@/generated/client/worldmonitor/news/v1/service_client';
 import type { GetSectorSummaryResponse, ListMarketQuotesResponse } from '@/generated/client/worldmonitor/market/v1/service_client';
-import { mountCommunityWidget } from '@/components/CommunityWidget';
+// import { mountCommunityWidget } from '@/components/CommunityWidget';
 import { ResearchServiceClient } from '@/generated/client/worldmonitor/research/v1/service_client';
 import {
   MarketPanel,
@@ -1033,7 +1033,7 @@ export class DataLoaderManager implements AppModule {
 
     this.ctx.allNews = collectedNews;
     this.ctx.initialLoadComplete = true;
-    mountCommunityWidget();
+    // mountCommunityWidget(); // Community widget disabled
 
     this.ctx.map?.updateHotspotActivity(this.ctx.allNews);
 

--- a/src/components/ProBanner.ts
+++ b/src/components/ProBanner.ts
@@ -25,7 +25,10 @@ function dismiss(): void {
 }
 */
 
-export function showProBanner(container: HTMLElement): void {
+/** Pro banner disabled. Remove the early return below to re-enable. */
+export function showProBanner(_container: HTMLElement): void {
+  return; // Banner disabled — remove this line to re-enable
+
   if (bannerEl) return;
   if (window.self !== window.top) return;
 
@@ -47,11 +50,11 @@ export function showProBanner(container: HTMLElement): void {
   });
   */
 
-  const header = container.querySelector('.header');
+  const header = _container.querySelector('.header');
   if (header) {
     header.before(banner);
   } else {
-    container.prepend(banner);
+    _container.prepend(banner);
   }
 
   bannerEl = banner;


### PR DESCRIPTION
Disable the PRO promotional banner and the "Join the Discussion" community widget pill so they no longer render in the app.

Made-with: Cursor

## Summary

<!-- Brief description of what this PR does -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other: <!-- specify -->

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [ ] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots

<!-- If applicable, add screenshots or screen recordings -->
