### PR TITLE
refactor: dedupe company enrichment headers and iso date formatting

### DIFF
--- a/api/enrichment/company.js
+++ b/api/enrichment/company.js
@@ -17,11 +17,12 @@ export const config = { runtime: 'edge' };
 
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
 const CACHE_TTL_SECONDS = 3600;
+const GITHUB_API_HEADERS = Object.freeze({ Accept: 'application/vnd.github.v3+json', 'User-Agent': UA });
 
 async function fetchGitHubOrg(name) {
   try {
     const res = await fetch(`https://api.github.com/orgs/${encodeURIComponent(name)}`, {
-      headers: { 'Accept': 'application/vnd.github.v3+json', 'User-Agent': UA },
+      headers: GITHUB_API_HEADERS,
       signal: AbortSignal.timeout(5000),
     });
     if (!res.ok) return null;
@@ -46,7 +47,7 @@ async function fetchGitHubTechStack(orgName) {
     const res = await fetch(
       `https://api.github.com/orgs/${encodeURIComponent(orgName)}/repos?sort=stars&per_page=10`,
       {
-        headers: { 'Accept': 'application/vnd.github.v3+json', 'User-Agent': UA },
+        headers: GITHUB_API_HEADERS,
         signal: AbortSignal.timeout(5000),
       },
     );
@@ -126,13 +127,17 @@ function inferFromDomain(domain) {
 }
 
 function getTodayISO() {
-  return new Date().toISOString().split('T')[0];
+  return toISODate(new Date());
 }
 
 function getDateMonthsAgo(months) {
   const d = new Date();
   d.setMonth(d.getMonth() - months);
-  return d.toISOString().split('T')[0];
+  return toISODate(d);
+}
+
+function toISODate(date) {
+  return date.toISOString().split('T')[0];
 }
 
 export default async function handler(req) {


### PR DESCRIPTION
## Summary
- extract shared GitHub API headers constant in the company enrichment edge function
- reuse shared header object in both GitHub org and repo fetch paths
- extract shared ISO date formatter helper and reuse in getTodayISO and getDateMonthsAgo

## Validation
- node --check api/enrichment/company.js
- pre-push hook checks passed during git push (typecheck, API typecheck, edge checks/tests, markdown lint, MDX lint, version sync)