### PR TITLE
fix(webcams): clamp zoom floor so globe renderer loads webcam data

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2069,9 +2069,7 @@ export class DataLoaderManager implements AppModule {
     if (!this.ctx.map) return;
     try {
       const map = this.ctx.map;
-      const zoom = map.getState().zoom ?? 3;
-
-      if (zoom < 2) return;
+      const zoom = Math.max(2, map.getState().zoom ?? 3);
 
       const now = Date.now();
       if (now - this.lastWebcamFetchAt < 1000) return;


### PR DESCRIPTION
## Summary

- Globe renderer (`GlobeMap.getState()`) always returns `zoom: 1` because the 3D globe doesn't map to traditional tile zoom levels
- `loadWebcams()` in `data-loader.ts` had a `if (zoom < 2) return` guard that silently skipped the webcam fetch on globe
- Toggling the webcam layer checkbox on the globe did nothing — no API call, no markers rendered

## Fix

Clamp zoom to `Math.max(2, zoom)` so the fetch always fires regardless of which renderer is active. The server-side clustering handles the actual viewport-appropriate grouping via the bounding box, so the zoom value just needs to be valid.

```diff
- const zoom = map.getState().zoom ?? 3;
- if (zoom < 2) return;
+ const zoom = Math.max(2, map.getState().zoom ?? 3);
```

## Test Plan

- [ ] Open globe (3D) renderer
- [ ] Toggle webcam layer on in layers overlay
- [ ] Verify webcam markers/clusters appear on globe
- [ ] Verify DeckGL (flat) renderer still works with webcam layer
- [ ] Verify zoom/pan on flat renderer still triggers re-fetch at different zoom levels