### PR TITLE
fix(health): align shipping maxStaleMin with 6h cron interval

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -91,7 +91,7 @@ const SEED_META = {
   bisPolicy:        { key: 'seed-meta:economic:bis:policy',       maxStaleMin: 2880 },
   bisExchange:      { key: 'seed-meta:economic:bis:eer',          maxStaleMin: 2880 },
   bisCredit:        { key: 'seed-meta:economic:bis:credit',       maxStaleMin: 2880 },
-  shippingRates:    { key: 'seed-meta:supply_chain:shipping',     maxStaleMin: 240 },
+  shippingRates:    { key: 'seed-meta:supply_chain:shipping',     maxStaleMin: 420 },
   chokepoints:      { key: 'seed-meta:supply_chain:chokepoints',  maxStaleMin: 60 },
   minerals:         { key: 'seed-meta:supply_chain:minerals',     maxStaleMin: 10080 },
   giving:           { key: 'seed-meta:giving:summary',            maxStaleMin: 10080 },


### PR DESCRIPTION
## Summary
Shipping seed cron was moved to 6h intervals but health.js maxStaleMin was still 240min (4h), causing STALE alerts for 2h every cycle. Updated to 420min (7h).

## Health vs cron alignment check
| Key | maxStaleMin | Cron interval | Buffer |
|-----|------------|---------------|--------|
| macroSignals | 60min | 15min | 4x |
| shippingRates | **420min** (was 240) | 360min (6h) | 1.2x |
| techEvents | 420min | 60min | 7x |
| serviceStatuses | 120min | 30min | 4x |
| cableHealth | 60min | 30min | 2x |
| gdeltIntel | 120min | 120min (2h) | 1x |