### PR TITLE
fix: forecast RPC cache tier + transitSummary test regex

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -121,6 +121,7 @@ const RPC_CACHE_TIER: Record<string, CacheTier> = {
   '/api/military/v1/list-military-bases': 'static',
   '/api/economic/v1/get-macro-signals': 'medium',
   '/api/prediction/v1/list-prediction-markets': 'medium',
+  '/api/forecast/v1/get-forecasts': 'medium',
   '/api/supply-chain/v1/get-chokepoint-status': 'medium',
   '/api/news/v1/list-feed-digest': 'slow',
   '/api/intelligence/v1/classify-event': 'static',

--- a/tests/supply-chain-v2.test.mjs
+++ b/tests/supply-chain-v2.test.mjs
@@ -108,7 +108,7 @@ describe('Generated types include aisDisruptions', () => {
   });
 
   it('client ChokepointInfo has transitSummary field', () => {
-    assert.match(clientSrc, /transitSummary:\s*TransitSummary/);
+    assert.match(clientSrc, /transitSummary\??:\s*TransitSummary/);
   });
 
   it('server has TransitSummary interface', () => {
@@ -120,7 +120,7 @@ describe('Generated types include aisDisruptions', () => {
   });
 
   it('server ChokepointInfo has transitSummary field', () => {
-    assert.match(serverSrc, /transitSummary:\s*TransitSummary/);
+    assert.match(serverSrc, /transitSummary\??:\s*TransitSummary/);
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `/api/forecast/v1/get-forecasts` to `RPC_CACHE_TIER` as `medium` (route-cache-tier test requires every generated GET route has an explicit tier entry)
- Fix `transitSummary` test regex to accept optional field syntax (`?:`) from proto codegen v0.7.0

## Test plan

- [x] `npm run test:data` passes with 0 failures (was 3)