### PR TITLE
fix(supply-chain): add CorridorRisk diagnostic logging and HTML detection

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3819,8 +3819,9 @@ let corridorRiskSeedInFlight = false;
 let latestCorridorRiskData = null;
 
 async function seedCorridorRisk() {
-  if (corridorRiskSeedInFlight) return;
+  if (corridorRiskSeedInFlight) { console.log('[CorridorRisk] Skipped (already in-flight)'); return; }
   corridorRiskSeedInFlight = true;
+  console.log('[CorridorRisk] Fetching...');
   const t0 = Date.now();
   try {
     const resp = await fetch(CORRIDOR_RISK_BASE_URL, {
@@ -3829,13 +3830,19 @@ async function seedCorridorRisk() {
         'User-Agent': CHROME_UA,
         Referer: 'https://corridorrisk.io/dashboard.html',
       },
-      signal: AbortSignal.timeout(10000),
+      signal: AbortSignal.timeout(15000),
     });
     if (!resp.ok) {
-      console.warn(`[CorridorRisk] HTTP ${resp.status}`);
+      const body = await resp.text().catch(() => '');
+      console.warn(`[CorridorRisk] HTTP ${resp.status} (${resp.headers.get('content-type') || 'unknown'}) — ${body.slice(0, 200)}`);
       return;
     }
-    const corridors = await resp.json();
+    const text = await resp.text();
+    if (text.startsWith('<')) {
+      console.warn(`[CorridorRisk] Got HTML instead of JSON (Cloudflare challenge?) — ${text.slice(0, 150)}`);
+      return;
+    }
+    const corridors = JSON.parse(text);
     if (!Array.isArray(corridors) || !corridors.length) {
       console.warn('[CorridorRisk] No corridors returned — skipping');
       return;

--- a/tests/corridorrisk-upstream.test.mjs
+++ b/tests/corridorrisk-upstream.test.mjs
@@ -46,8 +46,8 @@ describe('CorridorRisk relay seed loop', () => {
     assert.match(relaySrc, /function startCorridorRiskSeedLoop/);
   });
 
-  it('uses 10s timeout', () => {
-    assert.match(relaySrc, /AbortSignal\.timeout\(10000\)/);
+  it('uses 15s timeout', () => {
+    assert.match(relaySrc, /AbortSignal\.timeout\(15000\)/);
   });
 
   it('logs only status code on HTTP error', () => {


### PR DESCRIPTION
## Summary
corridorrisk: EMPTY in health despite relay running new open-beta code. Zero log output from the seed, making it impossible to diagnose.

## Changes
- Log "Fetching..." on every seed attempt
- Log "Skipped (already in-flight)" if guard triggers
- Log HTTP error response body and content-type (catches Cloudflare blocks)
- Detect HTML responses before JSON.parse (Cloudflare challenge pages)
- Increase timeout from 10s to 15s

## Why
After PR #1598 merged, the relay has the correct CorridorRisk code but produces zero corridor-related log output. This makes it impossible to tell if the API is being blocked by Cloudflare, timing out, or returning unexpected data.

## Test plan
- [x] All pre-push hooks pass
- [ ] After merge + relay redeploy: check logs for `[CorridorRisk] Fetching...` and the response