### PR TITLE
fix(chart): use app design system colors for transit chart

### DIFF
--- a/src/utils/transit-chart.ts
+++ b/src/utils/transit-chart.ts
@@ -82,9 +82,9 @@ export class TransitChart {
   private colors() {
     return {
       text: getCSSColor('--text-dim') || '#888',
-      grid: getCSSColor('--border-subtle') || '#333',
-      tanker: getCSSColor('--accent-primary') || '#4fc3f7',
-      cargo: '#ff9800',
+      grid: getCSSColor('--border') || '#2a2a2a',
+      tanker: getCSSColor('--semantic-info') || '#3b82f6',
+      cargo: getCSSColor('--semantic-high') || '#ff8800',
       bg: 'transparent',
     };
   }
@@ -164,7 +164,7 @@ export class TransitChart {
       ctx.arc(x(data.length - 1), y(last[key]), 3.5, 0, Math.PI * 2);
       ctx.fillStyle = color;
       ctx.fill();
-      ctx.strokeStyle = getCSSColor('--bg-primary') || '#1a1a2e';
+      ctx.strokeStyle = getCSSColor('--panel-bg') || '#141414';
       ctx.lineWidth = 1.5;
       ctx.stroke();
     };


### PR DESCRIPTION
## Summary
Transit chart was using arbitrary colors not from the design system.

- Tanker: `--semantic-info` (#3b82f6) instead of hardcoded #4fc3f7
- Cargo: `--semantic-high` (#ff8800) instead of hardcoded #ff9800
- Grid: `--border` (#2a2a2a) instead of `--border-subtle`
- Endpoint dot stroke: `--panel-bg` (#141414) instead of non-existent `--bg-primary`

All colors now read from CSS variables, adapting to light theme automatically.