### PR TITLE
fix(ui): hide zero warnings/disruptions line on chokepoint cards

### DIFF
--- a/src/components/SupplyChainPanel.ts
+++ b/src/components/SupplyChainPanel.ts
@@ -156,7 +156,9 @@ export class SupplyChainPanel extends Panel {
             <span class="trade-status ${statusClass}">${escapeHtml(cp.status)}</span>
           </div>
           <div class="trade-restriction-body">
-            <div class="trade-sector">${cp.activeWarnings} ${t('components.supplyChain.warnings')} · ${aisDisruptions} ${t('components.supplyChain.aisDisruptions')}${cp.directions?.length ? ` · ${escapeHtml(cp.directions.join('/'))}` : ''}</div>
+            ${cp.activeWarnings > 0 || aisDisruptions > 0
+              ? `<div class="trade-sector">${cp.activeWarnings} ${t('components.supplyChain.warnings')} · ${aisDisruptions} ${t('components.supplyChain.aisDisruptions')}${cp.directions?.length ? ` · ${escapeHtml(cp.directions.join('/'))}` : ''}</div>`
+              : cp.directions?.length ? `<div class="trade-sector">${escapeHtml(cp.directions.join('/'))}</div>` : ''}
             ${transitRow}
             ${riskRow}
             <div class="trade-description">${escapeHtml(cp.description)}</div>


### PR DESCRIPTION
## Summary
Hide the "0 warning(s), 0 AIS disruption(s)" line when both are zero. It adds no information and contradicts actual intelligence (e.g. "Traffic down 95%" at Hormuz).

- When warnings or disruptions > 0: show the full line with counts + directions
- When both are 0: show only directions (if present), skip the zero counts

## Test plan
- [x] `tsc --noEmit` clean
- [x] All pre-push hooks pass
- [ ] Verify Hormuz card no longer shows "0 warnings, 0 AIS disruptions"
- [ ] Verify cards WITH active warnings still show the count line