### PR TITLE
fix(economic): WALCL change displayed in millions instead of billions

### DIFF
--- a/src/services/economic/index.ts
+++ b/src/services/economic/index.ts
@@ -131,10 +131,10 @@ export async function fetchFredData(): Promise<FredSeries[]> {
     if (obs.length >= 2) {
       const latest = obs[obs.length - 1]!;
       const previous = obs[obs.length - 2]!;
-      const change = latest.value - previous.value;
+      let change = latest.value - previous.value;
       const changePercent = (change / previous.value) * 100;
       let displayValue = latest.value;
-      if (config.id === 'WALCL') displayValue = latest.value / 1000;
+      if (config.id === 'WALCL') { displayValue = latest.value / 1000; change = change / 1000; }
 
       out.push({
         id: config.id, name: config.name,


### PR DESCRIPTION
## Summary
Fed Total Assets (WALCL) showed +17450$B change instead of +17$B. The display value was correctly divided by 1000 (millions to billions) but the change delta was not.

## Root cause
Line 134-137: `displayValue` gets `/1000` for WALCL but `change` (line 134) stays in raw millions.

## Fix
Divide `change` by 1000 alongside `displayValue` for WALCL.