### PR TITLE
feat(supply-chain): surface CorridorRisk intelligence and routing recommendations

### DIFF
--- a/proto/worldmonitor/supply_chain/v1/supply_chain_data.proto
+++ b/proto/worldmonitor/supply_chain/v1/supply_chain_data.proto
@@ -59,6 +59,8 @@ message TransitSummary {
   string risk_level = 7;
   int32 incident_count_7d = 8;
   double disruption_pct = 9;
+  string risk_summary = 10;
+  string risk_report_action = 11;
 }
 
 message MineralProducer {

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3862,6 +3862,7 @@ async function seedCorridorRisk() {
         disruptionPct: Number(corridor.disruption_pct ?? 0),
         vesselCount: Number(corridor.vessel_count ?? 0),
         riskSummary: String(corridor.risk_summary || '').slice(0, 200),
+        riskReportAction: String((corridor.risk_report?.action) || '').slice(0, 500),
       };
     }
     if (Object.keys(result).length === 0) {
@@ -5085,6 +5086,8 @@ async function seedTransitSummaries() {
       riskLevel: cr?.riskLevel ?? '',
       incidentCount7d: cr?.incidentCount7d ?? 0,
       disruptionPct: cr?.disruptionPct ?? 0,
+      riskSummary: cr?.riskSummary ?? '',
+      riskReportAction: cr?.riskReportAction ?? '',
       anomaly,
     };
   }

--- a/server/worldmonitor/supply-chain/v1/_corridorrisk-upstream.ts
+++ b/server/worldmonitor/supply-chain/v1/_corridorrisk-upstream.ts
@@ -2,6 +2,8 @@ export interface CorridorRiskEntry {
   riskLevel: string;
   incidentCount7d: number;
   disruptionPct: number;
+  riskSummary: string;
+  riskReportAction: string;
 }
 
 export interface CorridorRiskData {

--- a/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
+++ b/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
@@ -77,6 +77,8 @@ interface PreBuiltTransitSummary {
   riskLevel: string;
   incidentCount7d: number;
   disruptionPct: number;
+  riskSummary: string;
+  riskReportAction: string;
   anomaly: { dropPct: number; signal: boolean };
 }
 
@@ -237,7 +239,7 @@ interface ChokepointFetchResult {
   upstreamUnavailable: boolean;
 }
 
-interface CorridorRiskEntry { riskLevel: string; incidentCount7d: number; disruptionPct: number }
+interface CorridorRiskEntry { riskLevel: string; incidentCount7d: number; disruptionPct: number; riskSummary: string; riskReportAction: string }
 interface RelayTransitEntry { tanker: number; cargo: number; other: number; total: number }
 interface RelayTransitPayload { transits: Record<string, RelayTransitEntry>; fetchedAt: number }
 
@@ -270,6 +272,8 @@ function buildFallbackSummaries(
       riskLevel: cr?.riskLevel ?? '',
       incidentCount7d: cr?.incidentCount7d ?? 0,
       disruptionPct: cr?.disruptionPct ?? 0,
+      riskSummary: cr?.riskSummary ?? '',
+      riskReportAction: cr?.riskReportAction ?? '',
       anomaly,
     };
   }
@@ -333,6 +337,9 @@ async function fetchChokepointData(): Promise<ChokepointFetchResult> {
     if (anomaly.signal) {
       descriptions.push(`Traffic down ${anomaly.dropPct}% vs 30-day baseline, vessels may be transiting dark (AIS off)`);
     }
+    if (ts?.riskSummary) {
+      descriptions.push(ts.riskSummary);
+    }
     if (!threatConfigFresh) {
       descriptions.push(THREAT_CONFIG_STALE_NOTE);
     }
@@ -367,7 +374,9 @@ async function fetchChokepointData(): Promise<ChokepointFetchResult> {
         riskLevel: ts.riskLevel,
         incidentCount7d: ts.incidentCount7d,
         disruptionPct: ts.disruptionPct,
-      } : { todayTotal: 0, todayTanker: 0, todayCargo: 0, todayOther: 0, wowChangePct: 0, history: [], riskLevel: '', incidentCount7d: 0, disruptionPct: 0 },
+        riskSummary: ts.riskSummary,
+        riskReportAction: ts.riskReportAction,
+      } : { todayTotal: 0, todayTanker: 0, todayCargo: 0, todayOther: 0, wowChangePct: 0, history: [], riskLevel: '', incidentCount7d: 0, disruptionPct: 0, riskSummary: '', riskReportAction: '' },
     };
   });
 

--- a/src/components/SupplyChainPanel.ts
+++ b/src/components/SupplyChainPanel.ts
@@ -142,9 +142,12 @@ export class SupplyChainPanel extends Panel {
             ? `<div class="trade-sector">${t('components.supplyChain.wowChange')}: ${wowSpan}</div>`
             : '';
         const riskRow = ts?.riskLevel
-          ? `<div class="trade-sector">${t('components.supplyChain.riskLevel')}: ${escapeHtml(ts.riskLevel)} | ${ts.incidentCount7d} incidents (7d)</div>`
+          ? `<div class="trade-sector">${t('components.supplyChain.riskLevel')}: ${escapeHtml(ts.riskLevel)} | ${ts.incidentCount7d} incidents (7d)${ts.riskSummary ? ` | ${escapeHtml(ts.riskSummary)}` : ''}</div>`
           : '';
         const expanded = this.expandedChokepoint === cp.name;
+        const actionRow = expanded && ts?.riskReportAction
+          ? `<div class="trade-sector"><strong>${t('components.supplyChain.routingAction')}:</strong> ${escapeHtml(ts.riskReportAction)}</div>`
+          : '';
         const chartPlaceholder = expanded && ts?.history?.length
           ? `<div data-chart-cp="${escapeHtml(cp.name)}" style="margin-top:8px;min-height:120px"></div>`
           : '';
@@ -161,6 +164,7 @@ export class SupplyChainPanel extends Panel {
             ${riskRow}
             <div class="trade-description">${escapeHtml(cp.description)}</div>
             <div class="trade-affected">${escapeHtml(cp.affectedRoutes.join(', '))}</div>
+            ${actionRow}
             ${chartPlaceholder}
           </div>
         </div>`;

--- a/src/generated/client/worldmonitor/supply_chain/v1/service_client.ts
+++ b/src/generated/client/worldmonitor/supply_chain/v1/service_client.ts
@@ -69,6 +69,8 @@ export interface TransitSummary {
   riskLevel: string;
   incidentCount7d: number;
   disruptionPct: number;
+  riskSummary: string;
+  riskReportAction: string;
 }
 
 export interface TransitDayCount {

--- a/src/generated/server/worldmonitor/supply_chain/v1/service_server.ts
+++ b/src/generated/server/worldmonitor/supply_chain/v1/service_server.ts
@@ -69,6 +69,8 @@ export interface TransitSummary {
   riskLevel: string;
   incidentCount7d: number;
   disruptionPct: number;
+  riskSummary: string;
+  riskReportAction: string;
 }
 
 export interface TransitDayCount {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -804,6 +804,7 @@
       "wowChange": "WoW change",
       "vesselTransits": "Vessel Transits (180d)",
       "riskLevel": "Risk level",
+      "routingAction": "Routing",
       "mineral": "Mineral",
       "topProducers": "Top Producers",
       "risk": "Risk",

--- a/tests/corridorrisk-upstream.test.mjs
+++ b/tests/corridorrisk-upstream.test.mjs
@@ -64,6 +64,10 @@ describe('CorridorRisk relay seed loop', () => {
     assert.match(relaySrc, /risk_summary.*\.slice\(0,\s*200\)/);
   });
 
+  it('stores riskReportAction truncated to 500 chars', () => {
+    assert.match(relaySrc, /risk_report\?\.action.*\.slice\(0,\s*500\)/);
+  });
+
   it('triggers seedTransitSummaries after successful seed', () => {
     assert.match(relaySrc, /seedTransitSummaries\(\).*Post-CorridorRisk/);
   });


### PR DESCRIPTION
## Summary
Surface CorridorRisk API intelligence that was stored but not displayed:
- **risk_summary**: Live intelligence narrative in the description (e.g. "Armed confrontations are active across the Persian Gulf with 52% of events classified as armed clashes")
- **risk_report.action**: Routing recommendation in expanded card view (e.g. "Recommend REROUTING via Cape of Good Hope for all non-essential Gulf cargo")

## Changes
- Proto: add `risk_summary` (field 10) and `risk_report_action` (field 11) to `TransitSummary`
- Relay: extract `risk_report.action` in `seedCorridorRisk`, pass both through `seedTransitSummaries`
- Handler: pass through fields + include `riskSummary` in description text
- UI: risk row includes summary inline, expanded view shows routing action
- i18n: add `routingAction` key
- Test: assert `riskReportAction` storage

## Test plan
- [x] `tsc --noEmit` both configs clean
- [x] 120/120 supply chain tests pass
- [x] 104/104 edge function tests pass
- [ ] After merge: verify Hormuz card shows CorridorRisk intelligence narrative and routing recommendation