### PR TITLE
fix(seeds): add Origin header to warm-ping scripts

### DIFF
--- a/scripts/seed-infra.mjs
+++ b/scripts/seed-infra.mjs
@@ -28,7 +28,7 @@ async function warmPing(name, path) {
   try {
     const resp = await fetch(`${API_BASE}${path}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_UA, Origin: 'https://worldmonitor.app' },
       body: JSON.stringify({}),
       signal: AbortSignal.timeout(TIMEOUT),
     });

--- a/scripts/seed-military-maritime-news.mjs
+++ b/scripts/seed-military-maritime-news.mjs
@@ -31,7 +31,7 @@ async function warmPing(name, path, body = {}) {
   try {
     const resp = await fetch(`${API_BASE}${path}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
+      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_UA, Origin: 'https://worldmonitor.app' },
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(TIMEOUT),
     });


### PR DESCRIPTION
## Summary
Warm-ping seed scripts (seed-infra, seed-military-maritime) were getting Cloudflare bot challenge HTML instead of JSON responses. Added `Origin: 'https://worldmonitor.app'` header matching the relay's service-statuses warm-ping pattern.

## Health issues fixed
- `usniFleet`: STALE_SEED (warm-ping couldn't refresh)
- `cableHealth`: EMPTY_ON_DEMAND (warm-ping couldn't populate)