### PR TITLE
feat(scoring): replace hardcoded advisory floors with live Redis data

### DIFF
--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -89,7 +89,7 @@ const ZONE_COUNTRY_MAP: Record<string, string[]> = {
   'Latin America': ['VE', 'CU', 'MX', 'BR'],
 };
 
-const ADVISORY_LEVELS: Record<string, 'do-not-travel' | 'reconsider' | 'caution'> = {
+const ADVISORY_LEVELS_FALLBACK: Record<string, 'do-not-travel' | 'reconsider' | 'caution'> = {
   UA: 'do-not-travel', SY: 'do-not-travel', YE: 'do-not-travel', MM: 'do-not-travel',
   IL: 'reconsider', IR: 'reconsider', PK: 'reconsider', VE: 'reconsider', CU: 'reconsider', MX: 'reconsider',
   RU: 'caution', TR: 'caution',
@@ -189,10 +189,11 @@ interface AuxiliarySources {
   gpsHexes: any[];
   iranEvents: any[];
   orefData: { activeAlertCount: number; historyCount24h: number } | null;
+  advisories: { byCountry: Record<string, 'do-not-travel' | 'reconsider' | 'caution'> } | null;
 }
 
 async function fetchAuxiliarySources(): Promise<AuxiliarySources> {
-  const [ucdpRaw, outagesRaw, climateRaw, cyberRaw, firesRaw, gpsRaw, iranRaw, orefRaw] = await Promise.all([
+  const [ucdpRaw, outagesRaw, climateRaw, cyberRaw, firesRaw, gpsRaw, iranRaw, orefRaw, advisoriesRaw] = await Promise.all([
     getCachedJson('conflict:ucdp-events:v1', true).catch(() => null),
     getCachedJson('infra:outages:v1', true).catch(() => null),
     getCachedJson('climate:anomalies:v1', true).catch(() => null),
@@ -201,6 +202,7 @@ async function fetchAuxiliarySources(): Promise<AuxiliarySources> {
     getCachedJson('intelligence:gpsjam:v2', true).catch(() => null),
     getCachedJson('conflict:iran-events:v1', true).catch(() => null),
     getCachedJson('relay:oref:history:v1', true).catch(() => null),
+    getCachedJson('intelligence:advisories:v1', true).catch(() => null),
   ]);
   const arr = (v: any, field?: string, maxLen = 10000) => {
     let a: any[];
@@ -225,6 +227,9 @@ async function fetchAuxiliarySources(): Promise<AuxiliarySources> {
     gpsHexes: arr(gpsRaw, 'hexes'),
     iranEvents: arr(iranRaw, 'events'),
     orefData,
+    advisories: advisoriesRaw && typeof advisoriesRaw === 'object' && (advisoriesRaw as any).byCountry
+      ? { byCountry: (advisoriesRaw as any).byCountry }
+      : null,
   };
 }
 
@@ -235,7 +240,8 @@ export function computeCIIScores(
   const data: Record<string, CountrySignals> = {};
   for (const code of Object.keys(TIER1_COUNTRIES)) {
     data[code] = emptySignals();
-    data[code].advisoryLevel = ADVISORY_LEVELS[code] || null;
+    const liveLevel = aux.advisories?.byCountry?.[code] ?? null;
+    data[code].advisoryLevel = liveLevel || ADVISORY_LEVELS_FALLBACK[code] || null;
   }
 
   // --- ACLED ingestion with fatality split ---
@@ -479,7 +485,7 @@ export async function getRiskScores(
 
   const stale = (await getCachedJson(RISK_STALE_CACHE_KEY)) as GetRiskScoresResponse | null;
   if (stale) return stale;
-  const emptyAux: AuxiliarySources = { ucdpEvents: [], outages: [], climate: [], cyber: [], fires: [], gpsHexes: [], iranEvents: [], orefData: null };
+  const emptyAux: AuxiliarySources = { ucdpEvents: [], outages: [], climate: [], cyber: [], fires: [], gpsHexes: [], iranEvents: [], orefData: null, advisories: null };
   const ciiScores = computeCIIScores([], emptyAux);
   return { ciiScores, strategicRisks: computeStrategicRisks(ciiScores) };
 }


### PR DESCRIPTION
## Summary

- Adds a new seeder (`seed-security-advisories.mjs`) that fetches travel advisory levels from 24 RSS feeds and writes aggregated results to Redis
- Server-side CII scoring now reads live advisory data from Redis, falling back to the original hardcoded map when unavailable
- Countries like Russia that were pinned at `caution` in the hardcoded map now correctly reflect their current State Dept Level 4 (`do-not-travel`) status

## Problem

`get-risk-scores.ts` uses a hardcoded `ADVISORY_LEVELS` map of 12 countries with static travel advisory levels. The frontend fetches live advisory data from RSS feeds. Server scores drift from reality when advisory levels change — for example, Russia's hardcoded `caution` level produces a CII score of ~19, while the live State Dept Level 4 (`do-not-travel`) should produce a floor of 60.

## Seeder: `scripts/seed-security-advisories.mjs`

Mirrors the frontend's `ADVISORY_FEEDS` array (24 feeds):

| Source Type | Feeds | Examples |
|------------|-------|---------|
| Broad | 3 | US State Dept, NZ MFAT, UK FCDO |
| Embassy-specific | 13 | UA, MX, PK, MM, BD, IT, etc. (hardcoded `targetCountry`) |
| Health | 8 | CDC Travel, 5× ECDC, 2× WHO |

**How it works:**
1. Fetches all 24 feeds in parallel with 10s timeout per feed
2. Parses XML via `fast-xml-parser` (RSS 2.0, Atom, RDF)
3. Extracts country code (ISO alpha-2) + advisory level from each item
4. Filters to items published within last 90 days (prevents stale pinning)
5. Aggregates strictest level per country (`do-not-travel` > `reconsider` > `caution`)
6. Filters output to only actionable levels — omits `normal` and `info`
7. Writes to Redis key `intelligence:advisories:v1` (1-hour TTL) via `runSeed()`

**Output shape:**
```json
{
  "byCountry": { "UA": "do-not-travel", "RU": "do-not-travel", "MX": "caution", ... },
  "fetchedAt": 1773527931631,
  "sourceCount": 24,
  "countryCount": 34
}
```

## Server: `get-risk-scores.ts`

Four surgical changes:
1. Rename `ADVISORY_LEVELS` → `ADVISORY_LEVELS_FALLBACK`
2. Add `advisories` field to `AuxiliarySources` interface
3. Add `getCachedJson('intelligence:advisories:v1', true)` to `fetchAuxiliarySources()`
4. Replace hardcoded lookup with live-first, fallback-second:
   ```typescript
   const liveLevel = aux.advisories?.byCountry?.[code] ?? null;
   data[code].advisoryLevel = liveLevel || ADVISORY_LEVELS_FALLBACK[code] || null;
   ```

**Fallback behavior:** When Redis has no advisory data (fresh deploy, seeder hasn't run), the original hardcoded map applies — behavior is identical to current production.

## Impact

| Panel | Effect |
|-------|--------|
| CII (Country Instability) | Scores reflect current real-world advisory levels instead of stale hardcoded values |
| Strategic Risk | Risk assessments cascade from updated CII scores |
| Globe/Map CII choropleth | Country heatmap colors update accordingly |

## Test Plan

- [x] Seeder runs successfully (23/24 feeds, 34 countries with actionable advisories)
- [x] Redis key contains expected `byCountry` map with only `do-not-travel`/`reconsider`/`caution` values
- [x] CII scores reflect live advisory data (RU: 60 with live data vs 19 with hardcoded `caution`)
- [x] Fallback works: deleting Redis key reverts to hardcoded behavior
- [x] TypeScript compiles clean (no errors in `get-risk-scores.ts`)
- [ ] Run seeder via cron on deployment schedule (1-hour interval recommended)

Closes issue #1359.