### PR TITLE
fix(health): bump unrestEvents maxStaleMin to 45

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -73,7 +73,7 @@ const SEED_META = {
   wildfires:        { key: 'seed-meta:wildfire:fires',          maxStaleMin: 120 },
   outages:          { key: 'seed-meta:infra:outages',           maxStaleMin: 30 },
   climateAnomalies: { key: 'seed-meta:climate:anomalies',       maxStaleMin: 120 },
-  unrestEvents:     { key: 'seed-meta:unrest:events',           maxStaleMin: 30 },
+  unrestEvents:     { key: 'seed-meta:unrest:events',           maxStaleMin: 45 },
   cyberThreats:     { key: 'seed-meta:cyber:threats',           maxStaleMin: 480 },
   cryptoQuotes:     { key: 'seed-meta:market:crypto',           maxStaleMin: 30 },
   etfFlows:         { key: 'seed-meta:market:etf-flows',        maxStaleMin: 60 },


### PR DESCRIPTION
## Summary
unrestEvents maxStaleMin was 30min but seed runs every ~15min, leaving insufficient buffer for slow runs. Bumped to 45min.

## Other health issues (not fixable here)
- **usniFleet STALE_SEED**: Relay USNI seed loop (6h interval) hasn't run since last relay restart. RPC handler is read-only, warm-ping can't fix this. Transient.
- **cableHealth EMPTY_ON_DEMAND**: NGA returned no cable-related warnings. Empty is valid.
- **temporalAnomalies EMPTY_ON_DEMAND**: On-demand key, only populated after first request. Expected.