### PR TITLE
fix(seeds): increase forecast TTL from 3600s to 4200s

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -10,7 +10,7 @@ if (_isDirectRun) loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'forecast:predictions:v1';
 const PRIOR_KEY = 'forecast:predictions:prior:v1';
-const TTL_SECONDS = 3600;
+const TTL_SECONDS = 4200; // 70min — covers 1h cron interval + cold start gap
 
 const THEATER_IDS = [
   'iran-theater', 'taiwan-theater', 'baltic-theater',


### PR DESCRIPTION
## Summary
Forecast TTL (3600s/1h) equaled cron interval (1h), leaving zero buffer for container cold starts (~3min). Health saw EMPTY records=0 during the gap. Increased to 4200s (70min).