### PR TITLE
test: cover warm-ping Origin header in seed scripts

### DIFF
--- a/tests/seed-warm-ping-origin.test.mjs
+++ b/tests/seed-warm-ping-origin.test.mjs
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+function readScript(relativePath) {
+  return readFileSync(resolve(root, relativePath), 'utf-8');
+}
+
+describe('warm-ping seed scripts', () => {
+  it('sends the app Origin header for infrastructure warm-pings', () => {
+    const src = readScript('scripts/seed-infra.mjs');
+    assert.match(src, /Origin:\s*'https:\/\/worldmonitor\.app'/);
+    assert.match(src, /method:\s*'POST'/);
+  });
+
+  it('sends the app Origin header for military\/maritime warm-pings', () => {
+    const src = readScript('scripts/seed-military-maritime-news.mjs');
+    assert.match(src, /Origin:\s*'https:\/\/worldmonitor\.app'/);
+    assert.match(src, /method:\s*'POST'/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a targeted regression test for the Origin header sent by the infrastructure warm-ping seed script
- add the same regression coverage for the military/maritime warm-ping seed script
- keep scope limited to the last commit's CORS bypass change in the seed scripts

## Validation
- node --test tests/seed-warm-ping-origin.test.mjs
- pre-push checks passed during git push (typecheck, API typecheck, edge checks/tests, markdown lint, MDX lint, version sync)