### PR TITLE
perf(ci): skip Vercel deploy when only scripts change on main

### DIFF
--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -2,8 +2,17 @@
 # Vercel Ignored Build Step: exit 0 = skip, exit 1 = build
 # Only build when web-relevant files change. Skip desktop, docs, scripts, CI, etc.
 
-# Always build production (main branch)
-[ "$VERCEL_GIT_COMMIT_REF" = "main" ] && exit 1
+# On main: skip if ONLY scripts/, docs/, .github/, or non-web files changed
+if [ "$VERCEL_GIT_COMMIT_REF" = "main" ] && [ -n "$VERCEL_GIT_PREVIOUS_SHA" ]; then
+  git cat-file -e "$VERCEL_GIT_PREVIOUS_SHA" 2>/dev/null && {
+    WEB_CHANGES=$(git diff --name-only "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- \
+      'src/' 'api/' 'server/' 'shared/' 'public/' 'blog-site/' 'pro-test/' 'proto/' \
+      'package.json' 'package-lock.json' 'vite.config.ts' 'tsconfig.json' \
+      'tsconfig.api.json' 'vercel.json' 'middleware.ts' | head -1)
+    [ -z "$WEB_CHANGES" ] && echo "Skipping: no web-relevant changes on main" && exit 0
+  }
+  exit 1
+fi
 
 # Skip preview deploys that aren't tied to a pull request
 [ -z "$VERCEL_GIT_PULL_REQUEST_ID" ] && exit 0


### PR DESCRIPTION
## Summary
Every merge to main triggered a Vercel build, even for scripts-only changes (seed scripts, relay updates). Now checks if any web-relevant files changed on main too.

## How it works
The existing `vercel-ignore.sh` already skips non-web changes on preview branches. This extends the same logic to main: if only `scripts/`, `docs/`, `.github/`, etc. changed, skip the Vercel build.

Web-relevant paths that trigger a build: `src/`, `api/`, `server/`, `shared/`, `public/`, `blog-site/`, `package.json`, `vite.config.ts`, `vercel.json`, etc.