### PR TITLE
refactor: dedupe contact api json responses

### DIFF
--- a/api/contact.js
+++ b/api/contact.js
@@ -95,12 +95,18 @@ function sanitizeForSubject(str, maxLen = 50) {
   return str.replace(/[\r\n\0]/g, '').slice(0, maxLen);
 }
 
+function jsonResponse(body, status, cors) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: cors
+      ? { 'Content-Type': 'application/json', ...cors }
+      : { 'Content-Type': 'application/json' },
+  });
+}
+
 export default async function handler(req) {
   if (isDisallowedOrigin(req)) {
-    return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    return jsonResponse({ error: 'Origin not allowed' }, 403);
   }
 
   const cors = getCorsHeaders(req, 'POST, OPTIONS');
@@ -110,36 +116,24 @@ export default async function handler(req) {
   }
 
   if (req.method !== 'POST') {
-    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
-      status: 405,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
+    return jsonResponse({ error: 'Method not allowed' }, 405, cors);
   }
 
   const ip = getClientIp(req);
 
   if (isRateLimited(ip)) {
-    return new Response(JSON.stringify({ error: 'Too many requests' }), {
-      status: 429,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
+    return jsonResponse({ error: 'Too many requests' }, 429, cors);
   }
 
   let body;
   try {
     body = await req.json();
   } catch {
-    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
+    return jsonResponse({ error: 'Invalid JSON' }, 400, cors);
   }
 
   if (body.website) {
-    return new Response(JSON.stringify({ status: 'sent' }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
+    return jsonResponse({ status: 'sent' }, 200, cors);
   }
 
   const turnstileOk = await verifyTurnstile({
@@ -149,46 +143,28 @@ export default async function handler(req) {
     missingSecretPolicy: 'allow-in-development',
   });
   if (!turnstileOk) {
-    return new Response(JSON.stringify({ error: 'Bot verification failed' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
+    return jsonResponse({ error: 'Bot verification failed' }, 403, cors);
   }
 
   const { email, name, organization, phone, message, source } = body;
 
   if (!email || typeof email !== 'string' || !EMAIL_RE.test(email)) {
-    return new Response(JSON.stringify({ error: 'Invalid email' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
+    return jsonResponse({ error: 'Invalid email' }, 400, cors);
   }
 
   const emailDomain = email.split('@')[1]?.toLowerCase();
   if (emailDomain && FREE_EMAIL_DOMAINS.has(emailDomain)) {
-    return new Response(JSON.stringify({ error: 'Please use your work email address' }), {
-      status: 422,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
+    return jsonResponse({ error: 'Please use your work email address' }, 422, cors);
   }
 
   if (!name || typeof name !== 'string' || name.trim().length === 0) {
-    return new Response(JSON.stringify({ error: 'Name is required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
+    return jsonResponse({ error: 'Name is required' }, 400, cors);
   }
   if (!organization || typeof organization !== 'string' || organization.trim().length === 0) {
-    return new Response(JSON.stringify({ error: 'Company is required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
+    return jsonResponse({ error: 'Company is required' }, 400, cors);
   }
   if (!phone || typeof phone !== 'string' || !PHONE_RE.test(phone.trim())) {
-    return new Response(JSON.stringify({ error: 'Valid phone number is required' }), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
+    return jsonResponse({ error: 'Valid phone number is required' }, 400, cors);
   }
 
   const safeName = name.slice(0, MAX_FIELD);
@@ -199,10 +175,7 @@ export default async function handler(req) {
 
   const convexUrl = process.env.CONVEX_URL;
   if (!convexUrl) {
-    return new Response(JSON.stringify({ error: 'Service unavailable' }), {
-      status: 503,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
+    return jsonResponse({ error: 'Service unavailable' }, 503, cors);
   }
 
   try {
@@ -218,15 +191,9 @@ export default async function handler(req) {
 
     const emailSent = await sendNotificationEmail(safeName, email.trim(), safeOrg, safePhone, safeMsg);
 
-    return new Response(JSON.stringify({ status: 'sent', emailSent }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
+    return jsonResponse({ status: 'sent', emailSent }, 200, cors);
   } catch (err) {
     console.error('[contact] error:', err);
-    return new Response(JSON.stringify({ error: 'Failed to send message' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json', ...cors },
-    });
+    return jsonResponse({ error: 'Failed to send message' }, 500, cors);
   }
 }


### PR DESCRIPTION
## Summary
- add a local jsonResponse(body, status, cors) helper in api/contact.js
- replace repeated JSON response construction branches in the contact handler
- keep response payloads and status codes unchanged while reducing duplication

## Validation
- node --check api/contact.js