### PR TITLE
fix(railway): force IPv4 DNS ordering for Node 20 on Railway

### DIFF
--- a/scripts/nixpacks.toml
+++ b/scripts/nixpacks.toml
@@ -1,2 +1,5 @@
 [phases.setup]
 aptPkgs = ["curl"]
+
+[variables]
+NODE_OPTIONS = "--dns-result-order=ipv4first"


### PR DESCRIPTION
## Summary

Node 20's `fetch()` (undici) tries IPv6 first. Railway containers don't support IPv6 (network trace shows `IPV6_NDISC` failures on every TCP connection). This caused ALL seed services to crash after redeploying with Node 20.

## Fix

`scripts/nixpacks.toml`:
```toml
[variables]
NODE_OPTIONS = "--dns-result-order=ipv4first"
```

This tells Node 20 to prefer IPv4 DNS results, avoiding the IPv6 routing failure. Keeps Node 20 (needed for `import ... with { type: 'json' }` in seed scripts).

## Test plan
- [x] Pre-push hooks pass
- [ ] After merge: all seed services redeploy and stop crashing