### PR TITLE
fix: add fetch error cause logging to all seed scripts

### DIFF
--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -266,6 +266,6 @@ runSeed('aviation', 'ops-news', OPS_CACHE_KEY, fetchAll, {
   ttlSeconds: OPS_TTL,
   sourceVersion: 'aviationstack-rss',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-bis-data.mjs
+++ b/scripts/seed-bis-data.mjs
@@ -215,6 +215,6 @@ runSeed('economic', 'bis', KEYS.policy, fetchAll, {
   if (seedData.exchange) await writeExtraKey(KEYS.exchange, seedData.exchange, TTL);
   if (seedData.credit) await writeExtraKey(KEYS.credit, seedData.credit, TTL);
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-climate-anomalies.mjs
+++ b/scripts/seed-climate-anomalies.mjs
@@ -123,6 +123,6 @@ runSeed('climate', 'anomalies', CANONICAL_KEY, fetchClimateAnomalies, {
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'open-meteo-archive-30d',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-commodity-quotes.mjs
+++ b/scripts/seed-commodity-quotes.mjs
@@ -92,6 +92,6 @@ runSeed('market', 'commodities', CANONICAL_KEY, fetchAndStash, {
   await writeExtraKey(commodityKey, seedData, CACHE_TTL);
   await writeExtraKey(quotesKey, quotesPayload, CACHE_TTL);
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -279,6 +279,6 @@ runSeed('conflict', 'acled-intel', ACLED_CACHE_KEY, fetchAll, {
   ttlSeconds: ACLED_TTL,
   sourceVersion: 'acled-hapi-pizzint',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-correlation.mjs
+++ b/scripts/seed-correlation.mjs
@@ -788,6 +788,6 @@ runSeed('correlation', 'cards', CANONICAL_KEY, computeCorrelation, {
     transform: (data) => data[ek.key.split(':')[1]],
   })),
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-crypto-quotes.mjs
+++ b/scripts/seed-crypto-quotes.mjs
@@ -120,6 +120,6 @@ runSeed('market', 'crypto', CANONICAL_KEY, fetchCryptoQuotes, {
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'coingecko-markets',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-cyber-threats.mjs
+++ b/scripts/seed-cyber-threats.mjs
@@ -582,6 +582,6 @@ runSeed('cyber', 'threats', CANONICAL_KEY, fetchAllThreats, {
   sourceVersion: 'multi-ioc-v2',
   extraKeys: [{ key: BOOTSTRAP_KEY }],
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-displacement-summary.mjs
+++ b/scripts/seed-displacement-summary.mjs
@@ -230,6 +230,6 @@ runSeed('displacement', 'summary', canonicalKey, fetchDisplacementSummary, {
   ttlSeconds: CACHE_TTL,
   sourceVersion: `unhcr-${currentYear}`,
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-earthquakes.mjs
+++ b/scripts/seed-earthquakes.mjs
@@ -45,6 +45,6 @@ runSeed('seismology', 'earthquakes', CANONICAL_KEY, fetchEarthquakes, {
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'usgs-4.5-day',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-economy.mjs
+++ b/scripts/seed-economy.mjs
@@ -396,6 +396,6 @@ runSeed('economic', 'energy-prices', KEYS.energyPrices, fetchAll, {
   ttlSeconds: ENERGY_TTL,
   sourceVersion: 'eia-fred-macro',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-fire-detections.mjs
+++ b/scripts/seed-fire-detections.mjs
@@ -123,6 +123,6 @@ async function main() {
 }
 
 main().catch(err => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-gdelt-intel.mjs
+++ b/scripts/seed-gdelt-intel.mjs
@@ -109,6 +109,6 @@ runSeed('intelligence', 'gdelt-intel', CANONICAL_KEY, fetchAllTopics, {
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'gdelt-doc-v2',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-gulf-quotes.mjs
+++ b/scripts/seed-gulf-quotes.mjs
@@ -107,6 +107,6 @@ runSeed('market', 'gulf-quotes', CANONICAL_KEY, fetchGulfQuotes, {
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'yahoo-chart',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -328,7 +328,7 @@ runSeed('news', 'insights', CANONICAL_KEY, fetchInsights, {
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'digest-clustering-v1',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   // Exit gracefully for cron — health endpoint flags stale data via seed-meta.
   process.exit(0);
 });

--- a/scripts/seed-iran-events.mjs
+++ b/scripts/seed-iran-events.mjs
@@ -231,6 +231,6 @@ runSeed('conflict', 'iran-events', CANONICAL_KEY, fetchIranEvents, {
   ttlSeconds: 172800,
   sourceVersion: 'liveuamap-manual-v1',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(0);
 });

--- a/scripts/seed-market-quotes.mjs
+++ b/scripts/seed-market-quotes.mjs
@@ -133,6 +133,6 @@ runSeed('market', 'quotes', CANONICAL_KEY, fetchAndStash, {
   const rpcKey = `market:quotes:v1:${[...MARKET_SYMBOLS].sort().join(',')}`;
   await writeExtraKey(rpcKey, seedData, CACHE_TTL);
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-natural-events.mjs
+++ b/scripts/seed-natural-events.mjs
@@ -424,6 +424,6 @@ runSeed('natural', 'events', CANONICAL_KEY, fetchNaturalEvents, {
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'eonet+gdacs+nhc',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-research.mjs
+++ b/scripts/seed-research.mjs
@@ -313,6 +313,6 @@ runSeed('research', 'arxiv-hn-trending', 'research:arxiv:v1:cs.AI::50', fetchAll
   ttlSeconds: ARXIV_TTL,
   sourceVersion: 'arxiv-hn-gitter',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-security-advisories.mjs
+++ b/scripts/seed-security-advisories.mjs
@@ -212,6 +212,6 @@ runSeed('intelligence', 'advisories', CANONICAL_KEY, fetchAll, {
   sourceVersion: 'rss-feeds',
   extraKeys: [{ key: BOOTSTRAP_KEY, transform: (d) => d, ttl: TTL }],
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-stablecoin-markets.mjs
+++ b/scripts/seed-stablecoin-markets.mjs
@@ -138,6 +138,6 @@ runSeed('market', 'stablecoins', CANONICAL_KEY, fetchStablecoinMarkets, {
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'coingecko-stablecoins',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-submarine-cables.mjs
+++ b/scripts/seed-submarine-cables.mjs
@@ -297,6 +297,6 @@ runSeed('infrastructure', 'submarine-cables', CANONICAL_KEY, fetchSubmarineCable
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'telegeography-v3',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -327,6 +327,6 @@ runSeed('supply_chain', 'shipping', KEYS.shipping, fetchAll, {
   ttlSeconds: SHIPPING_TTL,
   sourceVersion: 'fred-wto',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-ucdp-events.mjs
+++ b/scripts/seed-ucdp-events.mjs
@@ -242,7 +242,7 @@ async function main() {
 }
 
 main().catch(err => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   // Exit gracefully for cron — crashing restarts the container unnecessarily.
   // The health endpoint will flag stale data via seed-meta.
   process.exit(0);

--- a/scripts/seed-usa-spending.mjs
+++ b/scripts/seed-usa-spending.mjs
@@ -83,6 +83,6 @@ runSeed('economic', 'spending', CANONICAL_KEY, fetchSpending, {
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'usaspending-v2',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-usni-fleet.mjs
+++ b/scripts/seed-usni-fleet.mjs
@@ -356,6 +356,6 @@ runSeed('military', 'usni-fleet', CANONICAL_KEY, fetchAll, {
   ttlSeconds: TTL,
   sourceVersion: 'usni-wp-json',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });

--- a/scripts/seed-weather-alerts.mjs
+++ b/scripts/seed-weather-alerts.mjs
@@ -69,6 +69,6 @@ runSeed('weather', 'alerts', CANONICAL_KEY, fetchAlerts, {
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'nws-active',
 }).catch((err) => {
-  console.error('FATAL:', err.message || err);
+  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);
 });


### PR DESCRIPTION
The previous fix (#1638) only covered 3 scripts. The 29-script batch fix was pushed to #1641 after it was already merged, so it was orphaned. This covers all 27 remaining scripts.