### PR TITLE
fix(seeds): allow conflict-intel seed to succeed without ACLED keys

### DIFF
--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -265,7 +265,7 @@ async function fetchAll() {
   if (pizzint.status === 'rejected') console.warn(`  PizzINT failed: ${pizzint.reason?.message || pizzint.reason}`);
   if (gdelt.status === 'rejected') console.warn(`  GDELT failed: ${gdelt.reason?.message || gdelt.reason}`);
 
-  if (!ac && !pi) throw new Error('All conflict/intel fetches failed');
+  if (!ac && !ha && !pi) throw new Error('All conflict/intel fetches failed');
 
   // Write secondary keys BEFORE returning (runSeed calls process.exit after primary write)
   if (ha) { for (const [cc, data] of Object.entries(ha)) await writeExtraKeyWithMeta(`${HAPI_CACHE_KEY_PREFIX}:${cc}`, data, HAPI_TTL, 1); }
@@ -276,7 +276,7 @@ async function fetchAll() {
 }
 
 function validate(data) {
-  return data?.events?.length > 0;
+  return data != null && Array.isArray(data.events);
 }
 
 runSeed('conflict', 'acled-intel', ACLED_CACHE_KEY, fetchAll, {


### PR DESCRIPTION
## Summary

- Accept empty ACLED events array in validation when humanitarian or pizzint data was fetched
- Seed now writes canonical key `conflict:acled:v1:all:0:0` with `{ events: [] }` instead of skipping it entirely
- Humanitarian (20/20 countries) and PizzINT extra keys continue to be written as before
- Error guard includes humanitarian: throws only if all three sources fail

## Test plan

- [x] Pre-push hooks pass (typecheck, edge tests, lint)
- [ ] Redeploy Railway seed-conflict-intel service
- [ ] Verify logs show `=== Done ===` instead of `SKIPPED: validation failed`
- [ ] Verify `/api/health` shows conflict:acled key as populated (even if empty events)