### PR TITLE
fix(seeds): lazy-load @aws-sdk/client-s3 in R2 storage helper

### DIFF
--- a/scripts/_r2-storage.mjs
+++ b/scripts/_r2-storage.mjs
@@ -1,6 +1,14 @@
 #!/usr/bin/env node
 
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+let _S3Client, _PutObjectCommand;
+async function loadS3SDK() {
+  if (!_S3Client) {
+    const sdk = await import('@aws-sdk/client-s3');
+    _S3Client = sdk.S3Client;
+    _PutObjectCommand = sdk.PutObjectCommand;
+  }
+  return { S3Client: _S3Client, PutObjectCommand: _PutObjectCommand };
+}
 
 function getEnvValue(env, keys) {
   for (const key of keys) {
@@ -61,7 +69,7 @@ function resolveR2StorageConfig(env = process.env, options = {}) {
 
 const CLIENT_CACHE = new Map();
 
-function getR2StorageClient(config) {
+async function getR2StorageClient(config) {
   const cacheKey = JSON.stringify({
     endpoint: config.endpoint,
     region: config.region,
@@ -71,6 +79,7 @@ function getR2StorageClient(config) {
   });
   let client = CLIENT_CACHE.get(cacheKey);
   if (!client) {
+    const { S3Client } = await loadS3SDK();
     client = new S3Client({
       endpoint: config.endpoint,
       region: config.region,
@@ -103,7 +112,8 @@ async function putR2JsonObject(config, key, payload, metadata = {}) {
     return { bucket: config.bucket, key, bytes: Buffer.byteLength(body, 'utf8') };
   }
 
-  const client = getR2StorageClient(config);
+  const { PutObjectCommand } = await loadS3SDK();
+  const client = await getR2StorageClient(config);
   await client.send(new PutObjectCommand({
     Bucket: config.bucket,
     Key: key,


### PR DESCRIPTION
## Summary

- Convert top-level `import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'` to dynamic `await import()` in `_r2-storage.mjs`
- seed-forecasts crashes on Railway startup because the package isn't installed (RAILPACK doesn't install it since `buildCommand: "echo skip"` skips dependency resolution)
- Dynamic import defers the load to when S3 mode is actually used, so the seed runs fine when R2 is not configured (returns `null` config)

## Test plan

- [x] Pre-push hooks pass
- [x] `node -e "import('./scripts/_r2-storage.mjs')..."` loads without `@aws-sdk/client-s3` installed
- [ ] Redeploy seed-forecasts on Railway, verify it no longer crashes