### PR TITLE
fix(health): close corridorrisk health monitoring gap

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -134,6 +134,7 @@ const ON_DEMAND_KEYS = new Set([
   'bisPolicy', 'bisExchange', 'bisCredit',
   'macroSignals', 'shippingRates', 'chokepoints', 'minerals', 'giving',
   'cyberThreatsRpc', 'militaryBases', 'temporalAnomalies', 'displacement',
+  'corridorrisk', // intermediate key; data flows through transit-summaries:v1
 ]);
 
 // Keys where 0 records is a valid healthy state (e.g. no airports closed).

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3846,7 +3846,7 @@ async function startPortWatchSeedLoop() {
 
 const CORRIDOR_RISK_BASE_URL = 'https://corridorrisk.io/api/corridors';
 const CORRIDOR_RISK_REDIS_KEY = 'supply_chain:corridorrisk:v1';
-const CORRIDOR_RISK_TTL = 7200;
+const CORRIDOR_RISK_TTL = 14400; // 4h (seed runs hourly, gives 3 retries before expiry)
 const CORRIDOR_RISK_SEED_INTERVAL_MS = 60 * 60 * 1000;
 // API name -> canonical chokepoint ID (partial substring match)
 const CORRIDOR_RISK_NAME_MAP = [


### PR DESCRIPTION
## Summary
- Increase `CORRIDOR_RISK_TTL` from 2h to 4h (gives 3 hourly seed retries before expiry)
- Add `corridorrisk` to `ON_DEMAND_KEYS` (WARN not CRIT when empty)

## Context
Health reports `corridorrisk: EMPTY` even though CorridorRisk data flows correctly through `transit-summaries:v1` to the panel. The raw `corridorrisk:v1` key is an intermediate artifact with a 2h TTL that expires between hourly seed cycles. The actual data path is: relay seeds corridorrisk -> builds transit summaries -> Vercel reads transit summaries.

## Test plan
- [x] All hooks pass
- [ ] After merge: health should show corridorrisk as WARN (on-demand) not EMPTY (critical)