### PR TITLE
feat(cache): add per-breaker persistent stale ceiling

### DIFF
--- a/src/services/cached-risk-scores.ts
+++ b/src/services/cached-risk-scores.ts
@@ -174,6 +174,7 @@ const breaker = createCircuitBreaker<CachedRiskScores>({
   name: 'Risk Scores',
   cacheTtlMs: 30 * 60 * 1000,
   persistCache: true,
+  persistentStaleCeilingMs: 60 * 60 * 1000, // 1 h — risk scores go stale fast
 });
 
 // Sync prime from localStorage (before async IndexedDB hydration)

--- a/src/utils/circuit-breaker.ts
+++ b/src/utils/circuit-breaker.ts
@@ -28,6 +28,9 @@ export interface CircuitBreakerOptions {
   persistCache?: boolean;
   /** Maximum in-memory cache entries before LRU eviction. Default: 256. */
   maxCacheEntries?: number;
+  /** Maximum age (ms) for persistent cache entries before they are discarded on hydration.
+   *  Overrides the global 24 h default. Useful for data that goes stale faster (e.g. risk scores). */
+  persistentStaleCeilingMs?: number;
 }
 
 const DEFAULT_MAX_FAILURES = 2;
@@ -56,6 +59,7 @@ export class CircuitBreaker<T> {
   private lastDataState: BreakerDataState = { mode: 'unavailable', timestamp: null, offline: false };
   private backgroundRefreshPromises = new Map<string, Promise<void>>();
   private maxCacheEntries: number;
+  private persistentStaleCeilingMs: number;
 
   constructor(options: CircuitBreakerOptions) {
     this.name = options.name;
@@ -66,6 +70,7 @@ export class CircuitBreaker<T> {
       ? false
       : (options.persistCache ?? false);
     this.maxCacheEntries = options.maxCacheEntries ?? DEFAULT_MAX_CACHE_ENTRIES;
+    this.persistentStaleCeilingMs = options.persistentStaleCeilingMs ?? PERSISTENT_STALE_CEILING_MS;
   }
 
   private resolveCacheKey(cacheKey?: string): string {
@@ -143,7 +148,7 @@ export class CircuitBreaker<T> {
         if (entry == null || entry.data === undefined || entry.data === null) return;
 
         const age = Date.now() - entry.updatedAt;
-        if (age > PERSISTENT_STALE_CEILING_MS) return;
+        if (age > this.persistentStaleCeilingMs) return;
 
         // Only hydrate if in-memory cache is empty (don't overwrite live data)
         if (this.getCacheEntry(cacheKey) === null) {


### PR DESCRIPTION
## Summary

Adds an optional `persistentStaleCeilingMs` parameter to `CircuitBreakerOptions` so individual breakers can override the global 24 h `PERSISTENT_STALE_CEILING_MS` constant.

Risk scores breaker now uses a **1 h** ceiling — day-old CII data is unacceptable for a conflict monitoring app.

Closes #1326

## Changes

### `src/utils/circuit-breaker.ts`
- Added `persistentStaleCeilingMs?` to `CircuitBreakerOptions` interface
- Added private instance field + constructor assignment (falls back to global 24 h default)
- Replaced global constant usage with instance field in `hydratePersistentCache()`

### `src/services/cached-risk-scores.ts`
- Risk scores breaker now passes `persistentStaleCeilingMs: 60 * 60 * 1000` (1 h)

## Backward compatible
All existing breakers continue using the 24 h default — only breakers that explicitly set `persistentStaleCeilingMs` are affected.