### PR TITLE
fix(health): prevent CF caching with private, no-store

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -194,7 +194,8 @@ function dataSize(parsed) {
 export default async function handler(req) {
   const headers = {
     'Content-Type': 'application/json',
-    'Cache-Control': 'no-cache, no-store',
+    'Cache-Control': 'private, no-store, max-age=0',
+    'CDN-Cache-Control': 'no-store',
     'Access-Control-Allow-Origin': '*',
   };
 


### PR DESCRIPTION
## Summary
CF was caching /api/health responses for days despite `no-cache, no-store`. Changed to `private, no-store, max-age=0` + `CDN-Cache-Control: no-store` which CF definitively won't cache.

## Root cause
The CF Cache Rule marks all `/api/` GET requests as "eligible for cache" with "use cache-control header if present." CF interprets `no-cache` as "revalidate before serving" (still caches). `private` tells CF the response is not edge-cacheable at all.