### PR TITLE
fix(health): explicit seed-meta for chokepoints, move RPC keys to ON_DEMAND

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -135,6 +135,7 @@ const ON_DEMAND_KEYS = new Set([
   'macroSignals', 'shippingRates', 'chokepoints', 'minerals', 'giving',
   'cyberThreatsRpc', 'militaryBases', 'temporalAnomalies', 'displacement',
   'corridorrisk', // intermediate key; data flows through transit-summaries:v1
+  'riskScores', 'serviceStatuses', // RPC-populated; no seed-meta after PR #1649 removed it from cachedFetchJson
 ]);
 
 // Keys where 0 records is a valid healthy state (e.g. no airports closed).

--- a/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
+++ b/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
@@ -12,7 +12,7 @@ import type {
   AisDisruption,
 } from '../../../../src/generated/server/worldmonitor/maritime/v1/service_server';
 
-import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson, setCachedJson } from '../../../_shared/redis';
 import { listNavigationalWarnings } from '../../maritime/v1/list-navigational-warnings';
 import { getVesselSnapshot } from '../../maritime/v1/get-vessel-snapshot';
 import type { PortWatchData } from './_portwatch-upstream';
@@ -388,7 +388,9 @@ export async function getChokepointStatus(
       async () => {
         const { chokepoints, upstreamUnavailable } = await fetchChokepointData();
         if (upstreamUnavailable) return null;
-        return { chokepoints, fetchedAt: new Date().toISOString(), upstreamUnavailable };
+        const response = { chokepoints, fetchedAt: new Date().toISOString(), upstreamUnavailable };
+        setCachedJson('seed-meta:supply_chain:chokepoints', { fetchedAt: Date.now(), recordCount: chokepoints.length }, 604800).catch(() => {});
+        return response;
       },
     );
 


### PR DESCRIPTION
## Summary
- Chokepoints handler writes seed-meta explicitly on fresh fetch
- Move riskScores and serviceStatuses to ON_DEMAND_KEYS (WARN not CRIT)
- cableHealth already in ON_DEMAND_KEYS

## Context
PR #1649 removed writeSeedMeta from cachedFetchJson (by design: seed-meta should reflect actual seed freshness, not cache hits). This left RPC-populated keys with permanently stale seed-meta. Fix: chokepoints gets explicit write, others move to ON_DEMAND classification.

## Test plan
- [x] All hooks pass
- [ ] After merge: chokepoints shows OK with fresh seedAgeMin
- [ ] riskScores and serviceStatuses show WARN (on-demand) not STALE_SEED