### PR TITLE
fix(health): remove stale SEED_META for RPC keys, bump to v2.6.5

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -89,7 +89,7 @@ const SEED_META = {
   marketQuotes:     { key: 'seed-meta:market:stocks',         maxStaleMin: 30 },
   commodityQuotes:  { key: 'seed-meta:market:commodities',    maxStaleMin: 30 },
   // RPC-populated keys — auto-tracked by cachedFetchJson seed-meta writes
-  serviceStatuses:  { key: 'seed-meta:infra:service-statuses',    maxStaleMin: 120 },
+  // serviceStatuses: removed — RPC-populated, no seed-meta after PR #1649
   macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 60 },
   bisPolicy:        { key: 'seed-meta:economic:bis:policy',       maxStaleMin: 2880 },
   bisExchange:      { key: 'seed-meta:economic:bis:eer',          maxStaleMin: 2880 },
@@ -101,7 +101,7 @@ const SEED_META = {
   gpsjam:           { key: 'seed-meta:intelligence:gpsjam',       maxStaleMin: 720 },
   cableHealth:      { key: 'seed-meta:cable-health',              maxStaleMin: 60 },
   positiveGeoEvents:{ key: 'seed-meta:positive-events:geo',       maxStaleMin: 60 },
-  riskScores:       { key: 'seed-meta:risk:scores:sebuf',          maxStaleMin: 30 },
+  // riskScores: removed — RPC-populated, no seed-meta after PR #1649
   iranEvents:       { key: 'seed-meta:conflict:iran-events',      maxStaleMin: 10080 },
   ucdpEvents:       { key: 'seed-meta:conflict:ucdp-events',      maxStaleMin: 420 },
   militaryFlights:  { key: 'seed-meta:military:flights',           maxStaleMin: 15 },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "world-monitor",
   "private": true,
-  "version": "2.6.1",
+  "version": "2.6.5",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-monitor"
-version = "2.6.1"
+version = "2.6.5"
 description = "World Monitor desktop application"
 authors = ["World Monitor"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "World Monitor",
   "mainBinaryName": "world-monitor",
-  "version": "2.6.1",
+  "version": "2.6.5",
   "identifier": "app.worldmonitor.desktop",
   "build": {
     "beforeDevCommand": "npm run build:sidecar-sebuf && node scripts/build-sidecar-handlers.mjs && npm run dev",


### PR DESCRIPTION
## Summary
- Remove SEED_META entries for riskScores and serviceStatuses (RPC-populated, no seed-meta written after PR #1649)
- Bump version to 2.6.5

ON_DEMAND_KEYS only affects EMPTY status, not STALE_SEED. These keys have data but permanently stale seed-meta. Removing their SEED_META entries eliminates the false STALE_SEED warnings.

## Test plan
- [x] All hooks pass, version sync OK
- [ ] After merge: riskScores and serviceStatuses no longer show as problems in health