### PR TITLE
fix(supply-chain): force rebuild to deploy freight indices UI

### DIFF
--- a/src/components/SupplyChainPanel.ts
+++ b/src/components/SupplyChainPanel.ts
@@ -258,7 +258,6 @@ export class SupplyChainPanel extends Panel {
   private renderFredIndices(): string {
     if (isDesktopRuntime() && !isFeatureAvailable('supplyChain')) return '';
     if (!this.shippingData?.indices?.length) return '';
-
     const container = new Set(['SCFI', 'CCFI']);
     const bulk = new Set(['BDI', 'BCI', 'BPI', 'BSI', 'BHSI']);
 


### PR DESCRIPTION
## Summary
- Vercel build cache served stale bundle missing PR #1666 frontend changes
- SCFI, CCFI, BDI grouping in SupplyChainPanel never appeared in production despite code being on main
- Trivial whitespace change to `src/components/SupplyChainPanel.ts` to invalidate Vite cache

## Context
- API confirmed returning all 9 indices (verified via curl)
- Incognito browser still shows only 2 Economic Indicators (no Container Rates or Bulk Shipping sections)
- Deployed bundle (`main-v-TSTaMA.js`) has zero occurrences of `SCFI` or `containerRates`

## Test plan
- [x] `tsc --noEmit` passes
- [x] Pre-push hooks pass
- [ ] After merge, verify bundle contains `SCFI`, `containerRates`, `bulkShipping`
- [ ] Verify Shipping Rates tab shows 3 sections