### PR TITLE
fix(forecast): honor full trace count in R2 export

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -1717,6 +1717,14 @@ function getTraceMaxForecasts(totalForecasts = 0) {
   return totalForecasts > 0 ? totalForecasts : 50;
 }
 
+function getTraceCapLog(totalForecasts = 0) {
+  return {
+    raw: process.env.FORECAST_TRACE_MAX_FORECASTS || null,
+    resolved: getTraceMaxForecasts(totalForecasts),
+    totalForecasts,
+  };
+}
+
 function applyTraceMeta(pred, patch) {
   pred.traceMeta = {
     ...(pred.traceMeta || {}),
@@ -1838,10 +1846,13 @@ async function writeForecastTracePointer(pointer) {
 async function writeForecastTraceArtifacts(data, context = {}) {
   const storageConfig = resolveR2StorageConfig();
   if (!storageConfig) return null;
+  const predictionCount = Array.isArray(data?.predictions) ? data.predictions.length : 0;
+  const traceCap = getTraceCapLog(predictionCount);
+  console.log(`  Trace cap: raw=${traceCap.raw ?? 'default'} resolved=${traceCap.resolved} total=${traceCap.totalForecasts}`);
 
   const artifacts = buildForecastTraceArtifacts(data, context, {
     basePrefix: storageConfig.basePrefix,
-    maxForecasts: getTraceMaxForecasts(),
+    maxForecasts: getTraceMaxForecasts(predictionCount),
   });
 
   await putR2JsonObject(storageConfig, artifacts.manifestKey, artifacts.manifest, {
@@ -2539,6 +2550,10 @@ async function fetchForecasts() {
   ];
 
   console.log(`  Generated ${predictions.length} predictions`);
+  {
+    const traceCap = getTraceCapLog(predictions.length);
+    console.log(`  Forecast trace config: raw=${traceCap.raw ?? 'default'} resolved=${traceCap.resolved} total=${traceCap.totalForecasts}`);
+  }
 
   attachNewsContext(predictions, inputs.newsInsights, inputs.newsDigest);
   calibrateWithMarkets(predictions, inputs.predictionMarkets);


### PR DESCRIPTION
## Summary
- fix forecast trace export so the default path stores the full forecast set when `FORECAST_TRACE_MAX_FORECASTS` is unset
- add explicit logging of the raw and resolved trace cap in the seed logs

## Why
PR #1673 updated the artifact builder to default to the full forecast set, but `writeForecastTraceArtifacts()` still called `getTraceMaxForecasts()` without the actual prediction count. That meant live runs still fell back to `50` traces when no env var was set.

## Changes
- pass the current prediction count into `getTraceMaxForecasts()` during trace export
- log both the raw env value and the resolved trace cap during forecast generation and trace export

## Validation
- `node /Users/eliehabib/Documents/GitHub/worldmonitor/node_modules/tsx/dist/cli.mjs --test tests/forecast-detectors.test.mjs tests/forecast-trace-export.test.mjs`
