### PR TITLE
feat: add MiniMax as a first-class LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ GROQ_API_KEY=
 # Get yours at: https://openrouter.ai/
 OPENROUTER_API_KEY=
 
+# MiniMax API (fallback — OpenAI-compatible, 204K context)
+# Get yours at: https://platform.minimaxi.com/
+MINIMAX_API_KEY=
+
 
 # ------ Cross-User Cache (Vercel — Upstash Redis) ------
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See the **[self-hosting guide](https://docs.worldmonitor.app/getting-started)** 
 |----------|-------------|
 | **Frontend** | Vanilla TypeScript, Vite, globe.gl + Three.js, deck.gl + MapLibre GL |
 | **Desktop** | Tauri 2 (Rust) with Node.js sidecar |
-| **AI/ML** | Ollama / Groq / OpenRouter, Transformers.js (browser-side) |
+| **AI/ML** | Ollama / Groq / OpenRouter / [MiniMax](https://platform.minimaxi.com/), Transformers.js (browser-side) |
 | **API Contracts** | Protocol Buffers (92 protos, 22 services), sebuf HTTP annotations |
 | **Deployment** | Vercel Edge Functions (60+), Railway relay, Tauri, PWA |
 | **Caching** | Redis (Upstash), 3-tier cache, CDN, service worker |

--- a/server/_shared/llm-health.ts
+++ b/server/_shared/llm-health.ts
@@ -102,6 +102,9 @@ export function warmHealthCache(): void {
   if (typeof process !== 'undefined' && process.env?.OPENROUTER_API_KEY) {
     providerUrls.push('https://openrouter.ai/api/v1/chat/completions');
   }
+  if (typeof process !== 'undefined' && process.env?.MINIMAX_API_KEY) {
+    providerUrls.push('https://api.minimax.io/v1/chat/completions');
+  }
 
   for (const url of providerUrls) {
     void isProviderAvailable(url);

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -74,6 +74,19 @@ export function getProviderCredentials(provider: string): ProviderCredentials | 
     };
   }
 
+  if (provider === 'minimax') {
+    const apiKey = process.env.MINIMAX_API_KEY;
+    if (!apiKey) return null;
+    return {
+      apiUrl: 'https://api.minimax.io/v1/chat/completions',
+      model: process.env.MINIMAX_MODEL || 'MiniMax-M2.5',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    };
+  }
+
   // Generic OpenAI-compatible endpoint via LLM_API_URL/LLM_API_KEY/LLM_MODEL
   if (provider === 'generic') {
     const apiUrl = process.env.LLM_API_URL;
@@ -112,7 +125,7 @@ export function stripThinkingTags(text: string): string {
   return s;
 }
 
-const PROVIDER_CHAIN = ['ollama', 'groq', 'openrouter', 'generic'] as const;
+const PROVIDER_CHAIN = ['ollama', 'groq', 'openrouter', 'minimax', 'generic'] as const;
 
 export interface LlmCallOptions {
   messages: Array<{ role: string; content: string }>;


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimaxi.com/) as a first-class LLM provider in the fallback chain, giving users another cloud AI option alongside Ollama, Groq, and OpenRouter.

MiniMax offers an OpenAI-compatible chat completions API with a **204K context window** via the `MiniMax-M2.5` model — well-suited for World Monitor's long-context intelligence summarization tasks.

## Changes

- **`server/_shared/llm.ts`** — New `minimax` provider block in `getProviderCredentials()` using `MINIMAX_API_KEY` env var; added to `PROVIDER_CHAIN` before the generic fallback
- **`server/_shared/llm-health.ts`** — Warm MiniMax endpoint in startup health cache when `MINIMAX_API_KEY` is configured
- **`.env.example`** — Document `MINIMAX_API_KEY` alongside existing AI provider keys
- **`README.md`** — List MiniMax in the AI/ML tech stack table

## Configuration

```bash
# .env.local
MINIMAX_API_KEY=your_key_here
# Optional: override the default model
MINIMAX_MODEL=MiniMax-M2.5
```

## Test Plan

- [x] `npm run typecheck` passes with no errors
- [x] All 1415 existing data tests pass (`npm run test:data`)
- [x] Provider chain fallback logic is unchanged — MiniMax is only used when `MINIMAX_API_KEY` is set
- [x] No breaking changes to existing providers