### PR TITLE
fix(seeds): extend existing cache TTL on validation failure

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -305,7 +305,10 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     const publishResult = await atomicPublish(canonicalKey, data, validateFn, ttlSeconds);
     if (publishResult.skipped) {
       const durationMs = Date.now() - startMs;
-      console.log(`  SKIPPED: validation failed (empty data) — preserving existing cache`);
+      const keys = [canonicalKey];
+      if (extraKeys) keys.push(...extraKeys.map(ek => ek.key));
+      await extendExistingTtl(keys, ttlSeconds || 600);
+      console.log(`  SKIPPED: validation failed (empty data) — extended existing cache TTL`);
       console.log(`\n=== Done (${Math.round(durationMs)}ms, no write) ===`);
       await releaseLock(`${domain}:${resource}`, runId);
       process.exit(0);


### PR DESCRIPTION
## Summary
When a seed fetches data but validation rejects it (e.g. FIRMS API timeout returns 0 fires), extend the existing Redis key's TTL instead of letting it expire. Old data survives until the next successful fetch.

## Root cause
Wildfire seed with TTL=2h and cron=2h: one failed FIRMS fetch = key expires before next cycle = health shows EMPTY. The validateFn correctly rejects empty results, but the old valid data was expiring.

## Fix
In `_seed-utils.mjs` `runSeed()`: when `publishResult.skipped` (validation failed), call `extendExistingTtl()` on the canonical key + extra keys. This applies to ALL seeds, not just wildfires.

No TTL changes needed. Fresh data gets normal TTL. Stale data gets its TTL refreshed only when the new fetch fails.

## Test plan
- [x] All hooks pass
- [ ] Next time FIRMS API times out, wildfire data persists instead of going EMPTY