### PR TITLE
refactor: dedupe Upstash JSON read helper

### DIFF
--- a/api/_upstash-json.js
+++ b/api/_upstash-json.js
@@ -1,0 +1,20 @@
+export async function readJsonFromUpstash(key, timeoutMs = 3_000) {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!resp.ok) return null;
+
+  const data = await resp.json();
+  if (!data.result) return null;
+
+  try {
+    return JSON.parse(data.result);
+  } catch {
+    return null;
+  }
+}

--- a/api/gpsjam.js
+++ b/api/gpsjam.js
@@ -1,4 +1,5 @@
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { readJsonFromUpstash } from './_upstash-json.js';
 
 export const config = { runtime: 'edge' };
 
@@ -12,34 +13,17 @@ const CACHE_TTL = 300_000;
 let negUntil = 0;
 const NEG_TTL = 60_000;
 
-async function readFromRedis(key) {
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return null;
-
-  const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
-    headers: { Authorization: `Bearer ${token}` },
-    signal: AbortSignal.timeout(3_000),
-  });
-  if (!resp.ok) return null;
-
-  const data = await resp.json();
-  if (!data.result) return null;
-
-  try { return JSON.parse(data.result); } catch { return null; }
-}
-
 async function fetchGpsJamData() {
   const now = Date.now();
   if (cached && now - cachedAt < CACHE_TTL) return cached;
   if (now < negUntil) return null;
 
   let data;
-  try { data = await readFromRedis(REDIS_KEY); } catch { data = null; }
+  try { data = await readJsonFromUpstash(REDIS_KEY); } catch { data = null; }
 
   if (!data) {
     let v1;
-    try { v1 = await readFromRedis(REDIS_KEY_V1); } catch { v1 = null; }
+    try { v1 = await readJsonFromUpstash(REDIS_KEY_V1); } catch { v1 = null; }
     if (v1?.hexes) {
       data = {
         ...v1,

--- a/api/military-flights.js
+++ b/api/military-flights.js
@@ -1,4 +1,5 @@
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { readJsonFromUpstash } from './_upstash-json.js';
 
 export const config = { runtime: 'edge' };
 
@@ -12,33 +13,16 @@ const CACHE_TTL = 120_000;
 let negUntil = 0;
 const NEG_TTL = 30_000;
 
-async function readFromRedis(key) {
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return null;
-
-  const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
-    headers: { Authorization: `Bearer ${token}` },
-    signal: AbortSignal.timeout(3_000),
-  });
-  if (!resp.ok) return null;
-
-  const data = await resp.json();
-  if (!data.result) return null;
-
-  try { return JSON.parse(data.result); } catch { return null; }
-}
-
 async function fetchMilitaryFlightsData() {
   const now = Date.now();
   if (cached && now - cachedAt < CACHE_TTL) return cached;
   if (now < negUntil) return null;
 
   let data;
-  try { data = await readFromRedis(REDIS_KEY); } catch { data = null; }
+  try { data = await readJsonFromUpstash(REDIS_KEY); } catch { data = null; }
 
   if (!data) {
-    try { data = await readFromRedis(STALE_KEY); } catch { data = null; }
+    try { data = await readJsonFromUpstash(STALE_KEY); } catch { data = null; }
   }
 
   if (!data) {

--- a/api/satellites.js
+++ b/api/satellites.js
@@ -1,4 +1,5 @@
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { readJsonFromUpstash } from './_upstash-json.js';
 
 export const config = { runtime: 'edge' };
 
@@ -11,26 +12,12 @@ const CACHE_TTL = 600_000;
 let negUntil = 0;
 const NEG_TTL = 60_000;
 
-async function readFromRedis(key) {
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return null;
-  const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
-    headers: { Authorization: `Bearer ${token}` },
-    signal: AbortSignal.timeout(3_000),
-  });
-  if (!resp.ok) return null;
-  const data = await resp.json();
-  if (!data.result) return null;
-  try { return JSON.parse(data.result); } catch { return null; }
-}
-
 async function fetchSatelliteData() {
   const now = Date.now();
   if (cached && now - cachedAt < CACHE_TTL) return cached;
   if (now < negUntil) return null;
   let data;
-  try { data = await readFromRedis(REDIS_KEY); } catch { data = null; }
+  try { data = await readJsonFromUpstash(REDIS_KEY); } catch { data = null; }
   if (!data) {
     negUntil = now + NEG_TTL;
     return null;


### PR DESCRIPTION
## Summary
- extract duplicated Upstash Redis JSON read logic into shared `readJsonFromUpstash(...)` helper in `api/_upstash-json.js`
- update `api/military-flights.js`, `api/gpsjam.js`, and `api/satellites.js` to reuse the helper
- keep endpoint behavior and cache-control responses unchanged

## Validation
- node --check api/_upstash-json.js
- node --check api/military-flights.js
- node --check api/gpsjam.js
- node --check api/satellites.js

## Note
- regular `git push` pre-push checks currently fail due unrelated existing TS6133 warnings in `server/_shared/redis.ts`
