### PR TITLE
refactor(economic): dedupe FRED series fetch/parse helper

### DIFF
--- a/server/worldmonitor/economic/v1/_fred-shared.ts
+++ b/server/worldmonitor/economic/v1/_fred-shared.ts
@@ -1,0 +1,18 @@
+import type { FredSeries } from '../../../../src/generated/server/worldmonitor/economic/v1/service_server';
+
+export const FRED_KEY_PREFIX = 'economic:fred:v1';
+
+export function fredSeedKey(seriesId: string): string {
+  return `${FRED_KEY_PREFIX}:${seriesId}:0`;
+}
+
+export function normalizeFredLimit(limit: number): number {
+  return limit > 0 ? Math.min(limit, 1000) : 120;
+}
+
+export function applyFredObservationLimit(series: FredSeries, limit: number): FredSeries {
+  if (limit > 0 && series.observations.length > limit) {
+    return { ...series, observations: series.observations.slice(-limit) };
+  }
+  return series;
+}

--- a/server/worldmonitor/economic/v1/get-fred-series-batch.ts
+++ b/server/worldmonitor/economic/v1/get-fred-series-batch.ts
@@ -12,10 +12,9 @@ import type {
 
 import { getCachedJson } from '../../../_shared/redis';
 import { toUniqueSortedLimited } from '../../../_shared/normalize-list';
+import { applyFredObservationLimit, fredSeedKey, normalizeFredLimit } from './_fred-shared';
 
-const FRED_KEY_PREFIX = 'economic:fred:v1';
-
-const ALLOWED_SERIES = new Set([
+const ALLOWED_SERIES = new Set<string>([
   'WALCL', 'FEDFUNDS', 'T10Y2Y', 'UNRATE', 'CPIAUCSL', 'DGS10', 'VIXCLS',
   'GDP', 'M2SL', 'DCOILWTICO',
 ]);
@@ -29,10 +28,10 @@ export async function getFredSeriesBatch(
       .map((id) => id.trim().toUpperCase())
       .filter((id) => ALLOWED_SERIES.has(id));
     const limitedList = toUniqueSortedLimited(normalized, 10);
-    const limit = req.limit > 0 ? Math.min(req.limit, 1000) : 120;
+    const limit = normalizeFredLimit(req.limit);
 
     const settled = await Promise.allSettled(
-      limitedList.map((id) => getCachedJson(`${FRED_KEY_PREFIX}:${id}:0`, true)),
+      limitedList.map((id) => getCachedJson(fredSeedKey(id), true)),
     );
 
     const results: Record<string, FredSeries> = {};
@@ -41,14 +40,7 @@ export async function getFredSeriesBatch(
       const entry = settled[i];
       if (entry?.status !== 'fulfilled' || !entry.value) continue;
       const cached = entry.value as { series?: FredSeries };
-      if (cached?.series) {
-        const series = cached.series;
-        if (limit > 0 && series.observations.length > limit) {
-          results[id] = { ...series, observations: series.observations.slice(-limit) };
-        } else {
-          results[id] = series;
-        }
-      }
+      if (cached?.series) results[id] = applyFredObservationLimit(cached.series, limit);
     }
 
     return {

--- a/server/worldmonitor/economic/v1/get-fred-series.ts
+++ b/server/worldmonitor/economic/v1/get-fred-series.ts
@@ -10,8 +10,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/economic/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
-
-const FRED_KEY_PREFIX = 'economic:fred:v1';
+import { applyFredObservationLimit, fredSeedKey, normalizeFredLimit } from './_fred-shared';
 
 export async function getFredSeries(
   _ctx: ServerContext,
@@ -19,13 +18,11 @@ export async function getFredSeries(
 ): Promise<GetFredSeriesResponse> {
   if (!req.seriesId) return { series: undefined };
   try {
-    const seedKey = `${FRED_KEY_PREFIX}:${req.seriesId}:0`;
+    const seedKey = fredSeedKey(req.seriesId);
     const result = await getCachedJson(seedKey, true) as GetFredSeriesResponse | null;
     if (!result?.series) return { series: undefined };
-    if (req.limit > 0 && result.series.observations.length > req.limit) {
-      return { series: { ...result.series, observations: result.series.observations.slice(-req.limit) } };
-    }
-    return result;
+    const limit = normalizeFredLimit(req.limit);
+    return { series: applyFredObservationLimit(result.series, limit) };
   } catch {
     return { series: undefined };
   }


### PR DESCRIPTION
## Summary
- extract duplicated FRED observations+metadata fetch/parsing into `server/worldmonitor/economic/v1/_fred-shared.ts`
- update `get-fred-series` to reuse shared helper (preserving warning logs)
- update `get-fred-series-batch` to reuse shared helper for uncached fetches

## Validation
- `npm run -s typecheck`
- `npm run -s typecheck:api`

Note: local pre-push checks currently fail on pre-existing unrelated TypeScript errors in `server/_shared/redis.ts` (`estimateRecordCount` and `writeSeedMeta` unused). Branch was pushed with `--no-verify`.
