### PR TITLE
feat(forecast): add branch continuity to world state

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -2119,6 +2119,122 @@ function buildActorContinuitySummary(currentActors, priorWorldState = null) {
   };
 }
 
+function buildForecastBranchStates(predictions) {
+  const branches = [];
+
+  for (const pred of predictions) {
+    const branchList = pred.caseFile?.branches || buildForecastBranches(pred, {
+      actors: pred.caseFile?.actors || buildForecastActors(pred),
+      triggers: pred.caseFile?.triggers || buildCaseTriggers(pred),
+      counterEvidence: pred.caseFile?.counterEvidence || buildCounterEvidence(pred),
+      worldState: pred.caseFile?.worldState || buildForecastWorldState(pred),
+    });
+
+    for (const branch of branchList) {
+      branches.push({
+        id: `${pred.id}:${branch.kind}`,
+        forecastId: pred.id,
+        forecastTitle: pred.title,
+        kind: branch.kind,
+        title: branch.title,
+        domain: pred.domain,
+        region: pred.region,
+        projectedProbability: +(branch.projectedProbability || 0).toFixed(3),
+        baselineProbability: +(pred.probability || 0).toFixed(3),
+        probabilityDelta: +((branch.projectedProbability || 0) - (pred.probability || 0)).toFixed(3),
+        summary: branch.summary,
+        outcome: branch.outcome,
+        roundCount: Array.isArray(branch.rounds) ? branch.rounds.length : 0,
+        actorIds: (pred.caseFile?.actors || []).map(actor => actor.id).slice(0, 6),
+        triggerSample: (pred.caseFile?.triggers || []).slice(0, 3),
+        evidenceSample: (pred.caseFile?.supportingEvidence || []).slice(0, 2).map(item => item.summary),
+        counterEvidenceSample: (pred.caseFile?.counterEvidence || []).slice(0, 2).map(item => item.summary),
+      });
+    }
+  }
+
+  return branches
+    .sort((a, b) => b.projectedProbability - a.projectedProbability || a.id.localeCompare(b.id));
+}
+
+function buildBranchContinuitySummary(currentBranchStates, priorWorldState = null) {
+  const priorBranchStates = Array.isArray(priorWorldState?.branchStates) ? priorWorldState.branchStates : [];
+  const priorById = new Map(priorBranchStates.map(branch => [branch.id, branch]));
+  const currentById = new Map(currentBranchStates.map(branch => [branch.id, branch]));
+
+  const newBranches = [];
+  const strengthened = [];
+  const weakened = [];
+  const stable = [];
+
+  for (const branch of currentBranchStates) {
+    const prev = priorById.get(branch.id);
+    if (!prev) {
+      newBranches.push({
+        id: branch.id,
+        forecastId: branch.forecastId,
+        kind: branch.kind,
+        title: branch.title,
+        projectedProbability: branch.projectedProbability,
+      });
+      continue;
+    }
+
+    const delta = +((branch.projectedProbability || 0) - (prev.projectedProbability || 0)).toFixed(3);
+    const actorDelta = branch.actorIds.filter(id => !(prev.actorIds || []).includes(id));
+    const triggerDelta = branch.triggerSample.filter(item => !(prev.triggerSample || []).includes(item));
+
+    const record = {
+      id: branch.id,
+      forecastId: branch.forecastId,
+      kind: branch.kind,
+      title: branch.title,
+      projectedProbability: branch.projectedProbability,
+      priorProjectedProbability: +(prev.projectedProbability || 0).toFixed(3),
+      probabilityDelta: delta,
+      newActorIds: actorDelta.slice(0, 4),
+      newTriggers: triggerDelta.slice(0, 3),
+    };
+
+    if (delta >= 0.05 || actorDelta.length > 0 || triggerDelta.length > 0) {
+      strengthened.push(record);
+    } else if (delta <= -0.05) {
+      weakened.push(record);
+    } else {
+      stable.push(record);
+    }
+  }
+
+  const resolved = priorBranchStates
+    .filter(branch => !currentById.has(branch.id))
+    .map(branch => ({
+      id: branch.id,
+      forecastId: branch.forecastId,
+      kind: branch.kind,
+      title: branch.title,
+      projectedProbability: +(branch.projectedProbability || 0).toFixed(3),
+    }));
+
+  return {
+    priorBranchCount: priorBranchStates.length,
+    currentBranchCount: currentBranchStates.length,
+    persistentBranchCount: currentBranchStates.filter(branch => priorById.has(branch.id)).length,
+    newBranchCount: newBranches.length,
+    strengthenedBranchCount: strengthened.length,
+    weakenedBranchCount: weakened.length,
+    stableBranchCount: stable.length,
+    resolvedBranchCount: resolved.length,
+    newBranchPreview: newBranches.slice(0, 8),
+    strengthenedBranchPreview: strengthened
+      .sort((a, b) => b.probabilityDelta - a.probabilityDelta || a.id.localeCompare(b.id))
+      .slice(0, 8),
+    weakenedBranchPreview: weakened
+      .sort((a, b) => a.probabilityDelta - b.probabilityDelta || a.id.localeCompare(b.id))
+      .slice(0, 8),
+    resolvedBranchPreview: resolved.slice(0, 8),
+  };
+}
+
 function buildForecastDomainStates(predictions) {
   const states = new Map();
 
@@ -2277,10 +2393,12 @@ function buildForecastRunWorldState(data) {
   const regionalStates = buildForecastRegionalStates(predictions);
   const actorRegistry = buildForecastRunActorRegistry(predictions);
   const actorContinuity = buildActorContinuitySummary(actorRegistry, priorWorldState);
+  const branchStates = buildForecastBranchStates(predictions);
+  const branchContinuity = buildBranchContinuitySummary(branchStates, priorWorldState);
   const continuity = buildForecastRunContinuity(predictions);
   const evidenceLedger = buildForecastEvidenceLedger(predictions);
   const activeDomains = domainStates.filter((item) => item.forecastCount > 0).map((item) => item.domain);
-  const summary = `${predictions.length} active forecasts are spanning ${activeDomains.length} domains and ${regionalStates.length} key regions in this run, with ${continuity.newForecasts} new forecasts, ${continuity.materiallyChanged.length} materially changed paths, and ${actorContinuity.newlyActiveCount} newly active actors.`;
+  const summary = `${predictions.length} active forecasts are spanning ${activeDomains.length} domains and ${regionalStates.length} key regions in this run, with ${continuity.newForecasts} new forecasts, ${continuity.materiallyChanged.length} materially changed paths, ${actorContinuity.newlyActiveCount} newly active actors, and ${branchContinuity.strengthenedBranchCount} strengthened branches.`;
 
   return {
     version: 1,
@@ -2291,6 +2409,8 @@ function buildForecastRunWorldState(data) {
     regionalStates,
     actorRegistry,
     actorContinuity,
+    branchStates,
+    branchContinuity,
     continuity,
     evidenceLedger,
     uncertainties: evidenceLedger.counter.slice(0, 10),
@@ -2448,6 +2568,12 @@ function buildForecastTraceArtifacts(data, context = {}, config = {}) {
       strengthenedActors: worldState.actorContinuity.strengthenedCount,
       weakenedActors: worldState.actorContinuity.weakenedCount,
       noLongerActiveActors: worldState.actorContinuity.noLongerActiveCount,
+      branchCount: worldState.branchStates.length,
+      persistentBranches: worldState.branchContinuity.persistentBranchCount,
+      newBranches: worldState.branchContinuity.newBranchCount,
+      strengthenedBranches: worldState.branchContinuity.strengthenedBranchCount,
+      weakenedBranches: worldState.branchContinuity.weakenedBranchCount,
+      resolvedBranches: worldState.branchContinuity.resolvedBranchCount,
       newForecasts: worldState.continuity.newForecasts,
       materiallyChanged: worldState.continuity.materiallyChanged.length,
     },

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -118,6 +118,8 @@ describe('forecast trace artifact builder', () => {
     assert.ok(artifacts.worldState.actorRegistry.every(actor => actor.name && actor.id));
     assert.equal(artifacts.summary.worldStateSummary.persistentActorCount, 0);
     assert.ok(typeof artifacts.summary.worldStateSummary.newlyActiveActors === 'number');
+    assert.equal(artifacts.summary.worldStateSummary.branchCount, 6);
+    assert.equal(artifacts.summary.worldStateSummary.newBranches, 6);
     assert.ok(artifacts.forecasts[0].payload.caseFile.worldState.summary.includes('Iran'));
     assert.equal(artifacts.forecasts[0].payload.caseFile.branches.length, 3);
     assert.equal(artifacts.forecasts[0].payload.traceMeta.narrativeSource, 'fallback');
@@ -227,12 +229,33 @@ describe('forecast run world state', () => {
             regions: ['Middle East'],
           },
         ],
+        branchStates: [
+          {
+            id: `${a.id}:base`,
+            forecastId: a.id,
+            kind: 'base',
+            title: 'Base Branch',
+            projectedProbability: 0.62,
+            actorIds: ['Regional command authority:state'],
+            triggerSample: ['Old trigger'],
+          },
+          {
+            id: `${a.id}:contrarian`,
+            forecastId: a.id,
+            kind: 'contrarian',
+            title: 'Contrarian Branch',
+            projectedProbability: 0.55,
+            actorIds: ['Regional command authority:state'],
+            triggerSample: [],
+          },
+        ],
       },
     });
 
     assert.equal(worldState.version, 1);
     assert.equal(worldState.domainStates.length, 2);
     assert.ok(worldState.actorRegistry.length > 0);
+    assert.equal(worldState.branchStates.length, 6);
     assert.equal(worldState.continuity.risingForecasts, 1);
     assert.ok(worldState.summary.includes('2 active forecasts'));
     assert.ok(worldState.evidenceLedger.supporting.length > 0);
@@ -240,6 +263,10 @@ describe('forecast run world state', () => {
     assert.ok(worldState.actorContinuity.newlyActiveCount >= 1);
     assert.ok(worldState.actorContinuity.newlyActivePreview.length >= 1);
     assert.ok(worldState.actorContinuity.noLongerActivePreview.some(actor => actor.id === 'legacy:state'));
+    assert.ok(worldState.branchContinuity.persistentBranchCount >= 2);
+    assert.ok(worldState.branchContinuity.newBranchCount >= 1);
+    assert.ok(worldState.branchContinuity.strengthenedBranchCount >= 1);
+    assert.ok(worldState.branchContinuity.resolvedBranchCount >= 0);
   });
 
   it('reports full actor continuity counts even when previews are capped', () => {


### PR DESCRIPTION
## Summary
- add branch states to the run-level forecast world state using stable `forecastId:kind` ids
- compare current branch states to the prior world state to compute branch continuity across runs
- expose branch continuity counts in the world-state summary and extend trace tests

## Validation
- `node --check scripts/seed-forecasts.mjs`
- `node /Users/eliehabib/Documents/GitHub/worldmonitor/node_modules/tsx/dist/cli.mjs --test tests/forecast-trace-export.test.mjs tests/forecast-detectors.test.mjs`
- `npm exec --yes @biomejs/biome@2.4.7 -- lint scripts/seed-forecasts.mjs tests/forecast-trace-export.test.mjs`

## Notes
- This PR is stacked on top of `feat/forecast-world-state`, which already carries the merged actor continuity slice from `#1774`.
- Biome still reports the existing complexity warnings in `detectMilitaryScenarios` and `enrichScenariosWithLLM`; no new blocking lint issues were introduced in this slice.
