### PR TITLE
feat(forecast): add report continuity history

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -2496,7 +2496,7 @@ function summarizeWorldStateHistory(priorWorldStates = []) {
     }));
 }
 
-function buildReportContinuity(worldState, priorWorldStates = []) {
+function buildReportContinuity(current, priorWorldStates = []) {
   const history = summarizeWorldStateHistory(priorWorldStates);
 
   const persistentPressures = [];
@@ -2505,7 +2505,7 @@ function buildReportContinuity(worldState, priorWorldStates = []) {
   const repeatedStrengthening = [];
   const matchedLatestPriorIds = new Set();
 
-  for (const cluster of worldState.situationClusters || []) {
+  for (const cluster of current.situationClusters || []) {
     const priorMatches = [];
     for (const state of priorWorldStates.filter(Boolean)) {
       const candidates = Array.isArray(state.situationClusters) ? state.situationClusters : [];
@@ -2551,8 +2551,11 @@ function buildReportContinuity(worldState, priorWorldStates = []) {
       avgProbability: cluster.avgProbability,
     });
 
+    // priorMatches is ordered most-recent-first (mirrors priorWorldStates order from LRANGE)
     const lastMatch = priorMatches[0];
     const earliestMatch = priorMatches[priorMatches.length - 1];
+    // "strengthening" means current is >= both the most-recent and oldest prior snapshots,
+    // catching recoveries (V-shapes) as well as monotonic increases intentionally
     if (
       cluster.avgProbability >= (lastMatch?.avgProbability || 0) &&
       cluster.avgProbability >= (earliestMatch?.avgProbability || 0) &&
@@ -2575,7 +2578,7 @@ function buildReportContinuity(worldState, priorWorldStates = []) {
       id: cluster.id,
       label: cluster.label,
       forecastCount: cluster.forecastCount || 0,
-      avgProbability: +(cluster.avgProbability || 0).toFixed(3),
+      avgProbability: cluster.avgProbability || 0,
     });
   }
 
@@ -3117,6 +3120,8 @@ async function readPreviousForecastWorldState(storageConfig) {
   }
 }
 
+// Returns world states ordered most-recent-first (LPUSH prepends, LRANGE 0 N reads from head).
+// Callers that rely on priorMatches[0] being the most recent must not reorder this array.
 async function readForecastWorldStateHistory(storageConfig, limit = WORLD_STATE_HISTORY_LIMIT) {
   try {
     const { url, token } = getRedisCredentials();
@@ -3150,8 +3155,13 @@ async function writeForecastTraceArtifacts(data, context = {}) {
   const traceCap = getTraceCapLog(predictionCount);
   console.log(`  Trace cap: raw=${traceCap.raw ?? 'default'} resolved=${traceCap.resolved} total=${traceCap.totalForecasts}`);
 
-  const priorWorldState = await readPreviousForecastWorldState(storageConfig);
-  const priorWorldStates = await readForecastWorldStateHistory(storageConfig, WORLD_STATE_HISTORY_LIMIT);
+  // Run both reads in parallel; derive priorWorldState from history head to avoid
+  // a redundant R2 GET (TRACE_RUNS_KEY[0] and TRACE_LATEST_KEY normally point to the same object).
+  const [priorWorldStates, priorWorldStateFallback] = await Promise.all([
+    readForecastWorldStateHistory(storageConfig, WORLD_STATE_HISTORY_LIMIT),
+    readPreviousForecastWorldState(storageConfig),
+  ]);
+  const priorWorldState = priorWorldStates[0] ?? priorWorldStateFallback;
   const artifacts = buildForecastTraceArtifacts({
     ...data,
     priorWorldState,

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -488,4 +488,49 @@ describe('forecast run world state', () => {
     assert.equal(worldState.reportContinuity.fadingPressureCount, 0);
     assert.ok(worldState.reportContinuity.persistentPressureCount >= 1);
   });
+
+  it('marks fading pressures for situations present in prior state but absent from current run', () => {
+    const a = makePrediction('conflict', 'Iran', 'Escalation risk: Iran', 0.74, 0.64, '7d', [
+      { type: 'cii', value: 'Iran CII 79 (high)', weight: 0.4 },
+    ]);
+    buildForecastCase(a);
+
+    const baseState = buildForecastRunWorldState({
+      generatedAt: Date.parse('2026-03-17T10:00:00Z'),
+      predictions: [a],
+    });
+
+    // Inject a synthetic cluster into the prior state that will not be present in the current run
+    const priorState = {
+      ...baseState,
+      generatedAt: Date.parse('2026-03-17T10:00:00Z'),
+      situationClusters: [
+        ...baseState.situationClusters,
+        {
+          id: 'sit-redseafade-test',
+          label: 'Red Sea: Shipping disruption fading',
+          domain: 'supply_chain',
+          regionIds: ['red_sea'],
+          actorIds: [],
+          forecastIds: ['fc-supply_chain-redseafade'],
+          avgProbability: 0.55,
+          forecastCount: 1,
+        },
+      ],
+    };
+
+    const worldState = buildForecastRunWorldState({
+      generatedAt: Date.parse('2026-03-17T11:00:00Z'),
+      predictions: [a],
+      priorWorldState: priorState,
+      priorWorldStates: [priorState],
+    });
+
+    assert.ok(worldState.reportContinuity.fadingPressureCount >= 1);
+    assert.ok(worldState.reportContinuity.fadingPressurePreview.length >= 1);
+    assert.ok(worldState.reportContinuity.fadingPressurePreview.every(
+      (s) => typeof s.avgProbability === 'number' && typeof s.forecastCount === 'number',
+    ));
+    assert.ok(worldState.reportContinuity.persistentPressureCount >= 1);
+  });
 });


### PR DESCRIPTION
## Summary
- add recent world-state history loading from recent trace runs
- add report continuity over recent runs to the forecast world-state artifact
- surface continuity history counts and summaries in the trace summary export

## Notes
- this supersedes #1785 by including the situation-clustering layer plus the new report continuity history slice
- no detector or ranking behavior changes

## Validation
- node --check scripts/seed-forecasts.mjs
- node /Users/eliehabib/Documents/GitHub/worldmonitor/node_modules/tsx/dist/cli.mjs --test tests/forecast-trace-export.test.mjs tests/forecast-detectors.test.mjs

## Biome
- transient worktree biome invocation could not resolve a binary in this environment
- the only prior focused Biome output on this area was the same existing complexity warnings in scripts/seed-forecasts.mjs