### PR TITLE
refactor: dynamically load environment variables within Vite config a…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2696,6 +2696,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2712,6 +2713,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2728,6 +2730,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2744,6 +2747,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2760,6 +2764,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2776,6 +2781,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2792,6 +2798,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2808,6 +2815,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -4809,6 +4817,17 @@
         "commander": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nuxt/cli/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@nuxt/devalue": {


### PR DESCRIPTION
## Summary

Refactors `vite.config.ts` to explicitly load environment variables during development using Vite's `loadEnv` utility. This ensures that variables defined in `.env` and `.env.local` are available to the dev server configuration, plugins, and proxy rewrites.

Previously, environment-dependent constants were evaluated before Vite injected variables into `process.env`, causing `.env.local` overrides to be ignored when running `npm run dev`. As a result, API proxies (such as the FRED data proxy) and variant configuration could fail locally.

The configuration now uses the function-based `defineConfig` pattern to load environment variables before computing configuration values.

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

---

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [x] Config / Settings
- [ ] Other:

---

## Details

### Problem

`vite.config.ts` previously used a static `defineConfig` object. This caused environment-dependent values such as:

- `FRED_API_KEY`
- `VITE_VARIANT`
- `isE2E`
- `activeVariant`

to be evaluated at module load time before environment variables from `.env` and `.env.local` were loaded.

As a result:

- `.env.local` overrides were ignored during `npm run dev`
- API proxies relying on `process.env` (such as the FRED proxy rewrite) could fail
- Variant selection did not always reflect local configuration

### Solution

The configuration was refactored to use the function-based `defineConfig` signature.

Key changes:

- **Explicit env loading**
  - Uses `loadEnv(mode, process.cwd(), '')` to load variables from `.env`, `.env.local`, and related files.

- **Inject env into `process.env`**
  - Uses `Object.assign(process.env, env)` so dev server plugins and proxy rewrites relying on `process.env` can access the variables.

- **Delayed evaluation**
  - Environment-dependent constants are now calculated inside the config function so they reflect the correct values.

- **Plugin decoupling**
  - `htmlVariantPlugin` was refactored to accept configuration values via parameters rather than relying on global state.

---

## Impact & Scope

**Local Development**
- Fixes broken API keys in dev server proxy rewrites.
- Ensures `.env.local` overrides work correctly.

**Variant Selection**
- `VITE_VARIANT` is now correctly respected during development.

**Production / CI**
- No impact. Production environments already provide environment variables through system configuration.

**Client Code**
- No changes required. Frontend code using `import.meta.env` continues to work as before.

---

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [x] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

---

## Screenshots

N/A