### PR TITLE
perf: gate PizzINT to full variant only

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -777,7 +777,7 @@ export class App {
           intervalMs: REFRESH_INTERVALS.forecasts,
           condition: () => this.isPanelNearViewport('forecast'),
         },
-        { name: 'pizzint', fn: () => this.dataLoader.loadPizzInt(), intervalMs: 10 * 60 * 1000 },
+        { name: 'pizzint', fn: () => this.dataLoader.loadPizzInt(), intervalMs: 10 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },
         { name: 'natural', fn: () => this.dataLoader.loadNatural(), intervalMs: 60 * 60 * 1000, condition: () => this.state.mapLayers.natural },
         { name: 'weather', fn: () => this.dataLoader.loadWeatherAlerts(), intervalMs: 10 * 60 * 1000, condition: () => this.state.mapLayers.weather },
         { name: 'fred', fn: () => this.dataLoader.loadFredData(), intervalMs: 6 * 60 * 60 * 1000, condition: () => this.isPanelNearViewport('economic') },

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -378,7 +378,7 @@ export class DataLoaderManager implements AppModule {
       if (shouldLoad('forecast')) {
         tasks.push({ name: 'forecasts', task: runGuarded('forecasts', () => this.loadForecasts()) });
       }
-      tasks.push({ name: 'pizzint', task: runGuarded('pizzint', () => this.loadPizzInt()) });
+      if (SITE_VARIANT === 'full') tasks.push({ name: 'pizzint', task: runGuarded('pizzint', () => this.loadPizzInt()) });
       if (shouldLoad('economic')) {
         tasks.push({ name: 'fred', task: runGuarded('fred', () => this.loadFredData()) });
         tasks.push({ name: 'spending', task: runGuarded('spending', () => this.loadGovernmentSpending()) });

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -852,7 +852,7 @@ export class EventHandlerManager implements AppModule {
   }
 
   setupPizzIntIndicator(): void {
-    if (SITE_VARIANT === 'tech' || SITE_VARIANT === 'finance' || SITE_VARIANT === 'happy') return;
+    if (SITE_VARIANT !== 'full') return;
 
     this.ctx.pizzintIndicator = new PizzIntIndicator();
     const headerLeft = this.ctx.container.querySelector('.header-left');


### PR DESCRIPTION
## Summary

- PizzINT was loading on all variants (tech, finance, commodity, happy) even though the indicator widget is never rendered on those variants
- Stops two unnecessary RPC calls (PizzINT status + GDELT tensions) every 10 minutes on non-full sessions
- Three-line change: startup task, scheduler condition, and indicator setup all gated to \`SITE_VARIANT === 'full'\`

## Test plan

- [ ] On `full` variant: PizzINT indicator appears in header and updates normally
- [ ] On `tech` / `finance` variants: no PizzINT indicator, no `/api/intelligence/v1/get-pizzint-status` requests in network tab