### PR TITLE
fix(forecast): keep forecast execution in one runtime

### DIFF
--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -2,11 +2,10 @@
 
 import { loadEnvFile, CHROME_UA, getRedisCredentials, acquireLockSafely, releaseLock, withRetry, writeFreshnessMetadata, logSeedResult, verifySeedKey, extendExistingTtl } from './_seed-utils.mjs';
 import { summarizeMilitaryTheaters, buildMilitarySurges, appendMilitaryHistory } from './_military-surges.mjs';
-import { spawn } from 'node:child_process';
 import http from 'node:http';
 import https from 'node:https';
 import tls from 'node:tls';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pathToFileURL } from 'node:url';
 
 loadEnvFile(import.meta.url);
 
@@ -1257,22 +1256,7 @@ async function requestForecastRefreshIfEnabled(runId, assessedAt, source) {
   };
   await redisSet(url, token, FORECAST_REFRESH_REQUEST_KEY, request, FORECAST_REFRESH_REQUEST_TTL);
   console.log('  Forecast refresh requested after military publish');
-
-  const scriptPath = fileURLToPath(new URL('./seed-forecasts.mjs', import.meta.url));
-  console.log('  Triggering forecast reseed after military publish...');
-
-  await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [scriptPath], {
-      stdio: 'inherit',
-      env: process.env,
-    });
-
-    child.once('error', reject);
-    child.once('exit', (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`forecast reseed exited with code ${code}`));
-    });
-  });
+  console.log('  Forecast execution is delegated to the forecast service runtime');
 }
 
 // ── Main ───────────────────────────────────────────────────
@@ -1428,7 +1412,7 @@ async function main() {
     try {
       await requestForecastRefreshIfEnabled(runId, assessedAt, source);
     } catch (err) {
-      console.warn(`  Forecast reseed failed after military publish: ${err.message || err}`);
+      console.warn(`  Forecast refresh request failed after military publish: ${err.message || err}`);
     }
 
     const durationMs = Date.now() - startMs;


### PR DESCRIPTION
## Summary
- stop  from directly executing 
- keep the military-side forecast refresh request so the forecast service can remain the single forecast runtime
- update the military log/error wording to reflect request-based handoff instead of local reseeding

## Validation
- 
- Checked 1 file in 47ms. No fixes applied.