### PR TITLE
feat(forecast): add situation simulation state

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -2579,6 +2579,173 @@ function buildSituationSummary(situationClusters, situationContinuity) {
   };
 }
 
+function clampUnitInterval(value) {
+  return Math.max(0, Math.min(1, Number(value) || 0));
+}
+
+function intersectAny(left = [], right = []) {
+  return left.some((item) => right.includes(item));
+}
+
+function summarizeSituationPressure(cluster, actors, branches) {
+  const signalWeight = Math.min(1, ((cluster.topSignals || []).reduce((sum, item) => sum + (item.count || 0), 0)) / 6);
+  const actorWeight = Math.min(1, (actors.length || 0) / 4);
+  const branchWeight = Math.min(1, (branches.length || 0) / 6);
+  return clampUnitInterval(((cluster.avgProbability || 0) * 0.5) + (signalWeight * 0.2) + (actorWeight * 0.15) + (branchWeight * 0.15));
+}
+
+function buildSimulationRound(stage, situation, context) {
+  const { actors, branches, counterEvidence, supportiveEvidence, priorSimulation } = context;
+  const topSignalTypes = (situation.topSignals || []).slice(0, 3).map((item) => item.type);
+  const actorLikelyActions = actors.flatMap((actor) => actor.likelyActions || []).filter(Boolean);
+  const branchKinds = uniqueSortedStrings(branches.map((branch) => branch.kind).filter(Boolean));
+  const branchPressure = summarizeSituationPressure(situation, actors, branches);
+  const counterWeight = Math.min(1, (counterEvidence.length || 0) / 5);
+  const supportWeight = Math.min(1, (supportiveEvidence.length || 0) / 5);
+  const priorMomentum = clampUnitInterval(priorSimulation?.postureScore || 0.5);
+
+  let pressureDelta = 0;
+  let stabilizationDelta = 0;
+  let lead = '';
+  let actions = [];
+
+  if (stage === 'round_1') {
+    pressureDelta = clampUnitInterval((branchPressure * 0.45) + (supportWeight * 0.2) + (priorMomentum * 0.15));
+    stabilizationDelta = clampUnitInterval(counterWeight * 0.35);
+    lead = topSignalTypes[0] || situation.domains[0] || 'signal interpretation';
+    actions = uniqueSortedStrings(actorLikelyActions).slice(0, 4);
+  } else if (stage === 'round_2') {
+    pressureDelta = clampUnitInterval((branchPressure * 0.35) + (actors.length ? 0.2 : 0) + (branchKinds.length ? 0.15 : 0));
+    stabilizationDelta = clampUnitInterval((counterWeight * 0.4) + ((priorSimulation?.rounds?.[0]?.stabilizationDelta || 0) * 0.2));
+    lead = branchKinds[0] || topSignalTypes[0] || 'interaction response';
+    actions = uniqueSortedStrings([
+      ...actorLikelyActions,
+      ...branches.flatMap((branch) => branch.triggerSample || []),
+    ]).slice(0, 4);
+  } else {
+    const crossDomainWeight = Math.min(1, ((situation.domains || []).length - 1) * 0.25);
+    pressureDelta = clampUnitInterval((branchPressure * 0.25) + (crossDomainWeight * 0.35) + ((priorSimulation?.rounds?.[1]?.pressureDelta || 0) * 0.15));
+    stabilizationDelta = clampUnitInterval((counterWeight * 0.35) + (supportWeight * 0.15) + ((priorSimulation?.rounds?.[1]?.stabilizationDelta || 0) * 0.15));
+    lead = (situation.domains || []).length > 1 ? `${formatSituationDomainLabel(situation.domains)} spillover` : `${situation.domains[0] || 'regional'} effects`;
+    actions = uniqueSortedStrings([
+      ...branches.map((branch) => branch.outcome).filter(Boolean),
+      ...counterEvidence.map((item) => item.type).filter(Boolean),
+    ]).slice(0, 4);
+  }
+
+  const netPressure = +clampUnitInterval((pressureDelta - stabilizationDelta + (situation.avgProbability || 0))).toFixed(3);
+  return {
+    stage,
+    lead,
+    signalTypes: topSignalTypes,
+    branchKinds,
+    actions,
+    pressureDelta: +pressureDelta.toFixed(3),
+    stabilizationDelta: +stabilizationDelta.toFixed(3),
+    netPressure,
+  };
+}
+
+function summarizeSimulationOutcome(rounds = []) {
+  const finalRound = rounds[rounds.length - 1] || null;
+  const postureScore = finalRound?.netPressure || 0;
+  let posture = 'contested';
+  if (postureScore >= 0.72) posture = 'escalatory';
+  else if (postureScore <= 0.42) posture = 'constrained';
+
+  return {
+    posture,
+    postureScore: +postureScore.toFixed(3),
+    netPressureDelta: rounds.length
+      ? +rounds.reduce((sum, round) => sum + ((round.pressureDelta || 0) - (round.stabilizationDelta || 0)), 0).toFixed(3)
+      : 0,
+  };
+}
+
+function buildSituationSimulationState(worldState, priorWorldState = null) {
+  const actorRegistry = Array.isArray(worldState?.actorRegistry) ? worldState.actorRegistry : [];
+  const branchStates = Array.isArray(worldState?.branchStates) ? worldState.branchStates : [];
+  const supporting = Array.isArray(worldState?.evidenceLedger?.supporting) ? worldState.evidenceLedger.supporting : [];
+  const counter = Array.isArray(worldState?.evidenceLedger?.counter) ? worldState.evidenceLedger.counter : [];
+  const priorSimulations = new Map((priorWorldState?.simulationState?.situationSimulations || []).map((item) => [item.situationId, item]));
+
+  const situationSimulations = (worldState?.situationClusters || []).map((situation) => {
+    const forecastIds = situation.forecastIds || [];
+    const actors = actorRegistry.filter((actor) => intersectAny(actor.forecastIds || [], forecastIds));
+    const branches = branchStates.filter((branch) => forecastIds.includes(branch.forecastId));
+    const supportingEvidence = supporting.filter((item) => forecastIds.includes(item.forecastId)).slice(0, 8);
+    const counterEvidence = counter.filter((item) => forecastIds.includes(item.forecastId)).slice(0, 8);
+    const priorSimulation = priorSimulations.get(situation.id) || null;
+    const rounds = [
+      buildSimulationRound('round_1', situation, { actors, branches, counterEvidence, supportiveEvidence: supportingEvidence, priorSimulation }),
+      buildSimulationRound('round_2', situation, { actors, branches, counterEvidence, supportiveEvidence: supportingEvidence, priorSimulation }),
+      buildSimulationRound('round_3', situation, { actors, branches, counterEvidence, supportiveEvidence: supportingEvidence, priorSimulation }),
+    ];
+    const outcome = summarizeSimulationOutcome(rounds);
+
+    return {
+      situationId: situation.id,
+      label: situation.label,
+      dominantRegion: situation.regions?.[0] || '',
+      dominantDomain: situation.domains?.[0] || '',
+      forecastIds: forecastIds.slice(0, 12),
+      actorIds: actors.map((actor) => actor.id).slice(0, 8),
+      branchIds: branches.map((branch) => branch.id).slice(0, 10),
+      pressureSignals: (situation.topSignals || []).slice(0, 5),
+      stabilizers: uniqueSortedStrings(counterEvidence.map((item) => item.type).filter(Boolean)).slice(0, 5),
+      constraints: uniqueSortedStrings([
+        ...actors.flatMap((actor) => actor.constraints || []),
+        ...counterEvidence.map((item) => item.summary || item.type).filter(Boolean),
+      ]).slice(0, 6),
+      actorPostures: actors.slice(0, 6).map((actor) => ({
+        id: actor.id,
+        name: actor.name,
+        influenceScore: actor.influenceScore,
+        domains: actor.domains,
+        regions: actor.regions,
+        likelyActions: (actor.likelyActions || []).slice(0, 3),
+      })),
+      branchSeeds: branches.slice(0, 6).map((branch) => ({
+        id: branch.id,
+        kind: branch.kind,
+        title: branch.title,
+        projectedProbability: branch.projectedProbability,
+        probabilityDelta: branch.probabilityDelta,
+      })),
+      rounds,
+      ...outcome,
+    };
+  });
+
+  const postureCounts = summarizeTypeCounts(situationSimulations.map((item) => item.posture));
+  const summary = situationSimulations.length
+    ? `${situationSimulations.length} simulation units were derived from active situations and advanced through 3 deterministic rounds, producing ${postureCounts.escalatory || 0} escalatory, ${postureCounts.contested || 0} contested, and ${postureCounts.constrained || 0} constrained paths.`
+    : 'No simulation units were derived from the current run.';
+
+  const roundTransitions = ['round_1', 'round_2', 'round_3'].map((stage) => {
+    const roundSlice = situationSimulations.map((item) => item.rounds.find((round) => round.stage === stage)).filter(Boolean);
+    const avgNetPressure = roundSlice.length
+      ? +(roundSlice.reduce((sum, round) => sum + (round.netPressure || 0), 0) / roundSlice.length).toFixed(3)
+      : 0;
+    return {
+      stage,
+      situationCount: roundSlice.length,
+      avgNetPressure,
+      leadSignals: pickTopCountEntries(summarizeTypeCounts(roundSlice.flatMap((round) => round.signalTypes || [])), 4),
+      leadActions: uniqueSortedStrings(roundSlice.flatMap((round) => round.actions || [])).slice(0, 6),
+    };
+  });
+
+  return {
+    summary,
+    totalSituationSimulations: situationSimulations.length,
+    totalRounds: roundTransitions.length,
+    postureCounts,
+    roundTransitions,
+    situationSimulations,
+  };
+}
+
 function attachSituationContext(predictions, situationClusters = buildSituationClusters(predictions)) {
   const situationIndex = buildSituationForecastIndex(situationClusters);
   for (const pred of predictions) {
@@ -2820,11 +2987,23 @@ function buildWorldStateReport(worldState) {
 
   const continuitySummary = `Actors: ${worldState.actorContinuity?.newlyActiveCount || 0} new, ${worldState.actorContinuity?.strengthenedCount || 0} strengthened. Branches: ${worldState.branchContinuity?.newBranchCount || 0} new, ${worldState.branchContinuity?.strengthenedBranchCount || 0} strengthened, ${worldState.branchContinuity?.resolvedBranchCount || 0} resolved. Situations: ${worldState.situationContinuity?.newSituationCount || 0} new, ${worldState.situationContinuity?.strengthenedSituationCount || 0} strengthened, ${worldState.situationContinuity?.resolvedSituationCount || 0} resolved.`;
 
-  const summary = `${worldState.summary} The leading domains in this run are ${leadDomains.join(', ') || 'none'}, the main continuity changes are captured through ${worldState.actorContinuity?.newlyActiveCount || 0} newly active actors and ${worldState.branchContinuity?.strengthenedBranchCount || 0} strengthened branches, and the situation layer currently carries ${worldState.situationClusters?.length || 0} active clusters.`;
+  const simulationSummary = worldState.simulationState?.summary || 'No simulation-state summary is available.';
+  const simulationWatchlist = (worldState.simulationState?.situationSimulations || [])
+    .slice()
+    .sort((a, b) => (b.postureScore || 0) - (a.postureScore || 0) || a.label.localeCompare(b.label))
+    .slice(0, 6)
+    .map((item) => ({
+      type: `${item.posture}_simulation`,
+      label: item.label,
+      summary: `${item.label} resolved to a ${item.posture} posture after 3 rounds, with ${Math.round((item.postureScore || 0) * 100)}% final pressure and ${item.actorIds.length} active actors.`,
+    }));
+
+  const summary = `${worldState.summary} The leading domains in this run are ${leadDomains.join(', ') || 'none'}, the main continuity changes are captured through ${worldState.actorContinuity?.newlyActiveCount || 0} newly active actors and ${worldState.branchContinuity?.strengthenedBranchCount || 0} strengthened branches, the situation layer currently carries ${worldState.situationClusters?.length || 0} active clusters, and the simulation layer reports ${worldState.simulationState?.totalSituationSimulations || 0} executable units.`;
 
   return {
     summary,
     continuitySummary,
+    simulationSummary,
     domainOverview: {
       leadDomains,
       activeDomainCount: worldState.domainStates?.length || 0,
@@ -2835,6 +3014,7 @@ function buildWorldStateReport(worldState) {
     branchWatchlist,
     situationWatchlist,
     continuityWatchlist,
+    simulationWatchlist,
     keyUncertainties: (worldState.uncertainties || []).slice(0, 6).map(item => item.summary || item),
   };
 }
@@ -3028,6 +3208,7 @@ function buildForecastRunWorldState(data) {
     evidenceLedger,
     uncertainties: evidenceLedger.counter.slice(0, 10),
   };
+  worldState.simulationState = buildSituationSimulationState(worldState, priorWorldState);
   worldState.report = buildWorldStateReport(worldState);
   return worldState;
 }
@@ -3183,9 +3364,12 @@ function buildForecastTraceArtifacts(data, context = {}, config = {}) {
       summary: worldState.summary,
       reportSummary: worldState.report?.summary || '',
       reportContinuitySummary: worldState.reportContinuity?.summary || '',
+      simulationSummary: worldState.simulationState?.summary || '',
       domainCount: worldState.domainStates.length,
       regionCount: worldState.regionalStates.length,
       situationCount: worldState.situationClusters.length,
+      simulationSituationCount: worldState.simulationState?.totalSituationSimulations || 0,
+      simulationRoundCount: worldState.simulationState?.totalRounds || 0,
       persistentSituations: worldState.situationContinuity.persistentSituationCount,
       newSituations: worldState.situationContinuity.newSituationCount,
       strengthenedSituations: worldState.situationContinuity.strengthenedSituationCount,
@@ -3208,6 +3392,9 @@ function buildForecastTraceArtifacts(data, context = {}, config = {}) {
       strengthenedBranches: worldState.branchContinuity.strengthenedBranchCount,
       weakenedBranches: worldState.branchContinuity.weakenedBranchCount,
       resolvedBranches: worldState.branchContinuity.resolvedBranchCount,
+      escalatorySimulations: worldState.simulationState?.postureCounts?.escalatory || 0,
+      contestedSimulations: worldState.simulationState?.postureCounts?.contested || 0,
+      constrainedSimulations: worldState.simulationState?.postureCounts?.constrained || 0,
       newForecasts: worldState.continuity.newForecasts,
       materiallyChanged: worldState.continuity.materiallyChanged.length,
     },

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -150,6 +150,9 @@ describe('forecast trace artifact builder', () => {
     assert.equal(artifacts.summary.worldStateSummary.regionCount, 2);
     assert.ok(typeof artifacts.summary.worldStateSummary.situationCount === 'number');
     assert.ok(artifacts.summary.worldStateSummary.situationCount >= 1);
+    assert.ok(typeof artifacts.summary.worldStateSummary.simulationSituationCount === 'number');
+    assert.equal(artifacts.summary.worldStateSummary.simulationRoundCount, 3);
+    assert.ok(typeof artifacts.summary.worldStateSummary.simulationSummary === 'string');
     assert.ok(typeof artifacts.summary.worldStateSummary.historyRuns === 'number');
     assert.ok(Array.isArray(artifacts.worldState.actorRegistry));
     assert.ok(artifacts.worldState.actorRegistry.every(actor => actor.name && actor.id));
@@ -159,9 +162,12 @@ describe('forecast trace artifact builder', () => {
     assert.equal(artifacts.summary.worldStateSummary.newBranches, 6);
     assert.equal(artifacts.summary.triggerContext.triggerRequest.requester, 'seed-military-flights');
     assert.ok(Array.isArray(artifacts.worldState.situationClusters));
+    assert.ok(Array.isArray(artifacts.worldState.simulationState?.situationSimulations));
+    assert.equal(artifacts.worldState.simulationState?.roundTransitions?.length, 3);
     assert.ok(Array.isArray(artifacts.worldState.report.situationWatchlist));
     assert.ok(Array.isArray(artifacts.worldState.report.actorWatchlist));
     assert.ok(Array.isArray(artifacts.worldState.report.branchWatchlist));
+    assert.ok(Array.isArray(artifacts.worldState.report.simulationWatchlist));
     assert.ok(artifacts.forecasts[0].payload.caseFile.worldState.summary.includes('Iran'));
     assert.equal(artifacts.forecasts[0].payload.caseFile.branches.length, 3);
     assert.equal(artifacts.forecasts[0].payload.traceMeta.narrativeSource, 'fallback');
@@ -315,11 +321,17 @@ describe('forecast run world state', () => {
     assert.ok(worldState.situationClusters.length >= 1);
     assert.ok(worldState.situationSummary.summary.includes('clustered situations'));
     assert.ok(typeof worldState.situationContinuity.newSituationCount === 'number');
+    assert.ok(worldState.simulationState.summary.includes('deterministic rounds'));
+    assert.equal(worldState.simulationState.roundTransitions.length, 3);
+    assert.ok(worldState.simulationState.situationSimulations.length >= 1);
+    assert.ok(worldState.simulationState.situationSimulations.every((unit) => unit.rounds.length === 3));
     assert.ok(worldState.report.summary.includes('leading domains'));
     assert.ok(worldState.report.continuitySummary.includes('Actors:'));
+    assert.ok(worldState.report.simulationSummary.includes('deterministic rounds'));
     assert.ok(worldState.report.regionalHotspots.length >= 1);
     assert.ok(worldState.report.branchWatchlist.length >= 1);
     assert.ok(Array.isArray(worldState.report.situationWatchlist));
+    assert.ok(Array.isArray(worldState.report.simulationWatchlist));
   });
 
   it('reports full actor continuity counts even when previews are capped', () => {
@@ -637,5 +649,30 @@ describe('forecast run world state', () => {
 
     assert.equal(worldState.situationContinuity.strengthenedSituationCount, 0);
     assert.ok(worldState.report.situationWatchlist.every((item) => item.type !== 'strengthened_situation'));
+  });
+
+  it('builds deterministic simulation units and round transitions from clustered situations', () => {
+    const conflict = makePrediction('conflict', 'Israel', 'Active armed conflict: Israel', 0.76, 0.66, '7d', [
+      { type: 'ucdp', value: 'Israeli theater remains active', weight: 0.4 },
+      { type: 'news_corroboration', value: 'Regional actors prepare responses', weight: 0.2 },
+    ]);
+    conflict.newsContext = ['Regional actors prepare responses'];
+    buildForecastCase(conflict);
+
+    const supply = makePrediction('supply_chain', 'Eastern Mediterranean', 'Shipping disruption: Eastern Mediterranean', 0.59, 0.55, '14d', [
+      { type: 'chokepoint', value: 'Shipping reroutes through the Eastern Mediterranean', weight: 0.4 },
+    ]);
+    buildForecastCase(supply);
+
+    const worldState = buildForecastRunWorldState({
+      generatedAt: Date.parse('2026-03-19T08:00:00Z'),
+      predictions: [conflict, supply],
+    });
+
+    assert.ok(worldState.simulationState.totalSituationSimulations >= 2);
+    assert.equal(worldState.simulationState.totalRounds, 3);
+    assert.ok(worldState.simulationState.roundTransitions.every((round) => round.situationCount >= 1));
+    assert.ok(worldState.simulationState.situationSimulations.every((unit) => ['escalatory', 'contested', 'constrained'].includes(unit.posture)));
+    assert.ok(worldState.simulationState.situationSimulations.every((unit) => unit.rounds.every((round) => typeof round.netPressure === 'number')));
   });
 });


### PR DESCRIPTION
## Summary
- add deterministic simulation-state units to forecast world-state output, keyed by situation clusters
- derive 3 round transitions per situation from actors, branches, supporting evidence, and counter-evidence
- expose simulation summaries in trace artifacts and world-state reports so downstream report work can consume evolved state instead of raw forecasts

## Validation
- 
-   [Graph] Loaded 38 nodes
  [fallbackNarratives] Applied fallback narratives to 1 forecast(s)
  [LLM] Scenario 0 rejected: no evidence reference
  [Cascade] Loaded 9 rules from JSON
  [Cascade] Loaded 9 rules from JSON
  [Cascade] Loaded 9 rules from JSON
  [filterPublished] Suppressed 1 weak fallback forecast(s)
  [filterPublished] Suppressed 1 situation-overlap forecast(s)
  [filterPublished] Suppressed 1 situation-domain-cap forecast(s)
▶ forecastId
  ✔ same inputs produce same ID (6.218792ms)
  ✔ different inputs produce different IDs (0.634667ms)
  ✔ ID format is fc-{domain}-{8char_hex} (0.477209ms)
  ✔ domain is embedded in the ID (0.323125ms)
✔ forecastId (9.240083ms)
▶ normalize
  ✔ value at min returns 0 (0.3665ms)
  ✔ value at max returns 1 (4.589208ms)
  ✔ midpoint returns 0.5 (0.2855ms)
  ✔ value below min clamps to 0 (0.466625ms)
  ✔ value above max clamps to 1 (0.633125ms)
  ✔ min === max returns 0 (0.370417ms)
  ✔ min > max returns 0 (1.323667ms)
✔ normalize (10.050416ms)
▶ resolveCascades
  ✔ conflict near chokepoint creates supply_chain and market cascades (2.564167ms)
  ✔ cascade probabilities capped at 0.8 (0.817583ms)
  ✔ deduplication within a single call: same rule does not fire twice for same source (0.413709ms)
  ✔ no self-edges: cascade domain differs from source domain (0.470042ms)
  ✔ political > 0.6 creates conflict cascade (0.300875ms)
  ✔ political <= 0.6 does not cascade to conflict (7.126417ms)
✔ resolveCascades (13.231958ms)
▶ calibrateWithMarkets
  ✔ matching market adjusts probability with 40/60 blend (26.274667ms)
  ✔ no match leaves probability unchanged (11.368625ms)
  ✔ drift calculated correctly (0.938625ms)
  ✔ null markets handled gracefully (0.243792ms)
  ✔ empty markets handled gracefully (0.172708ms)
  ✔ markets without geopolitical key handled gracefully (0.162167ms)
  ✔ does not calibrate from unrelated same-region macro market (2.098291ms)
  ✔ does not calibrate commodity forecasts from loosely related regional conflict markets (5.439667ms)
✔ calibrateWithMarkets (55.900667ms)
▶ computeTrends
  ✔ no prior: all trends set to stable (1.056ms)
  ✔ rising: delta > 0.05 (0.680959ms)
  ✔ falling: delta < -0.05 (0.997584ms)
  ✔ stable: delta within +/- 0.05 (15.127083ms)
  ✔ new prediction (no prior match): stable (78.10925ms)
  ✔ prior with empty predictions array: all stable (13.821875ms)
  ✔ just above +0.05 threshold: rising (21.862083ms)
  ✔ just below -0.05 threshold: falling (41.788083ms)
  ✔ delta exactly at boundary: uses strict comparison (> 0.05) (2.924958ms)
✔ computeTrends (212.820417ms)
▶ detector smoke tests: null/empty inputs
  ✔ detectConflictScenarios({}) returns [] (21.82775ms)
  ✔ detectMarketScenarios({}) returns [] (83.717709ms)
  ✔ detectSupplyChainScenarios({}) returns [] (0.429875ms)
  ✔ detectPoliticalScenarios({}) returns [] (7.67225ms)
  ✔ detectMilitaryScenarios({}) returns [] (23.435416ms)
  ✔ detectInfraScenarios({}) returns [] (0.373667ms)
  ✔ detectors handle null arrays gracefully (0.215542ms)
✔ detector smoke tests: null/empty inputs (138.057334ms)
▶ detectConflictScenarios
  ✔ high CII rising score produces conflict prediction (64.198125ms)
  ✔ low CII score is ignored (3.875375ms)
  ✔ critical theater posture produces prediction (0.312333ms)
  ✔ accepts theater posture entries that use theater instead of id (0.172958ms)
✔ detectConflictScenarios (68.802459ms)
▶ detectMarketScenarios
  ✔ high-risk chokepoint with known commodity produces market prediction (0.239542ms)
  ✔ maps live chokepoint names to market-sensitive regions (0.54225ms)
  ✔ low-risk chokepoint is ignored (0.3585ms)
✔ detectMarketScenarios (1.298375ms)
▶ detectInfraScenarios
  ✔ major outage produces infra prediction (9.442042ms)
  ✔ minor outage is ignored (0.338833ms)
  ✔ cyber threats boost probability (0.605459ms)
✔ detectInfraScenarios (15.177375ms)
▶ detectPoliticalScenarios
  ✔ uses geoConvergence when unrest-specific fields are absent or zero (43.187958ms)
  ✔ can generate from unrest event counts even when CII unrest is weak (37.844333ms)
✔ detectPoliticalScenarios (81.926417ms)
▶ detectMilitaryScenarios
  ✔ accepts live theater entries that use theater instead of id (3.3945ms)
  ✔ creates a military forecast from theater surge data even before posture turns elevated (0.82025ms)
  ✔ ignores stale military surge payloads (22.4745ms)
  ✔ rejects military bundles whose theater timestamps drift from fetchedAt (37.065209ms)
  ✔ suppresses one-off generic air activity when it lacks persistence and theater-relevant actors (2.439041ms)
✔ detectMilitaryScenarios (73.130791ms)
▶ attachNewsContext
  ✔ matches headlines mentioning prediction region and scenario context (21.630541ms)
  ✔ adds news_corroboration signal when headlines match (1.094834ms)
  ✔ does NOT add signal when no headlines match (2.111833ms)
  ✔ does not attach unrelated generic headlines when no match (0.801709ms)
  ✔ excludes commodity node names from matching (no false positives) (0.482625ms)
  ✔ reads headlines from digest categories (primary path) (0.684583ms)
  ✔ handles null newsInsights and null digest (0.210958ms)
  ✔ handles empty topStories with no digest (0.142709ms)
  ✔ prefers region-relevant headlines over generic domain-only matches (0.822792ms)
  ✔ rejects domain-only headlines with no geographic grounding (7.570583ms)
✔ attachNewsContext (36.356542ms)
▶ headline and market relevance helpers
  ✔ scores region-specific headlines above generic domain headlines (80.556541ms)
  ✔ scores semantically aligned markets above broad regional ones (0.612375ms)
  ✔ penalizes mismatched regional headlines and markets (25.99975ms)
✔ headline and market relevance helpers (117.835875ms)
▶ forecast case assembly
  ✔ buildForecastCase assembles evidence, triggers, and actors from current forecast data (62.068834ms)
  ✔ buildForecastCases populates the case file for every forecast (6.863709ms)
  ✔ helper functions return structured case ingredients (1.382833ms)
✔ forecast case assembly (70.605208ms)
▶ forecast evaluation and ranking
  ✔ scores evidence-rich forecasts above thin forecasts (7.320958ms)
  ✔ uses readiness to rank better-grounded forecasts ahead of thinner peers (29.0595ms)
  ✔ penalizes thin forecasts with weak grounding even at similar base probability (0.7835ms)
  ✔ filters non-positive forecasts before publish while keeping positive probabilities (186.419916ms)
  ✔ selects enrichment targets from a broader, domain-balanced top slice (28.49675ms)
✔ forecast evaluation and ranking (253.302917ms)
▶ forecast change tracking
  ✔ builds prior snapshots with enough context for evidence diffs (15.418709ms)
  ✔ annotates what changed versus the prior run (106.678791ms)
  ✔ marks newly surfaced forecasts clearly (2.6315ms)
✔ forecast change tracking (124.925084ms)
▶ forecast llm overrides
  ✔ parses provider order safely (15.703083ms)
  ✔ keeps default provider order when no override is set (1.707083ms)
  ✔ supports a stronger combined-model override without changing scenario defaults (4.9985ms)
  ✔ lets a global provider order and openrouter model apply to non-combined stages (0.256042ms)
✔ forecast llm overrides (22.965542ms)
▶ forecast narrative fallbacks
  ✔ buildUserPrompt keeps headlines scoped to each prediction (7.710375ms)
  ✔ populateFallbackNarratives fills missing scenario, perspectives, and case narratives (41.916417ms)
  ✔ fallback perspective references calibration when present (0.251958ms)
  ✔ fallback scenario stays concise and evidence-led (0.142959ms)
  ✔ fallback case narratives stay evidence-led and concise (0.39ms)
  ✔ fallback narratives reference broader situation context when available (0.672ms)
  ✔ buildFeedSummary stays compact and distinct from the deeper case output (0.284209ms)
✔ forecast narrative fallbacks (51.848459ms)
▶ validateCaseNarratives
  ✔ accepts valid case narratives (1.453916ms)
✔ validateCaseNarratives (1.640125ms)
▶ computeConfidence
  ✔ higher source diversity = higher confidence (0.633583ms)
  ✔ cii and cii_delta count as one source (1.351458ms)
  ✔ low calibration drift = higher confidence than high drift (0.813833ms)
  ✔ high calibration drift = lower confidence (1.218ms)
  ✔ floors at 0.2 (9.048292ms)
✔ computeConfidence (13.9775ms)
▶ sanitizeForPrompt
  ✔ strips HTML tags (0.379708ms)
  ✔ strips newlines (0.270291ms)
  ✔ truncates to 200 chars (0.139042ms)
  ✔ handles null/undefined (0.154875ms)
✔ sanitizeForPrompt (1.820958ms)
▶ parseLLMScenarios
  ✔ parses valid JSON array (31.779708ms)
  ✔ returns null for invalid JSON (5.335875ms)
  ✔ strips thinking tags before parsing (0.231042ms)
  ✔ repairs truncated JSON array (0.221583ms)
  ✔ extracts JSON from surrounding text (0.119833ms)
✔ parseLLMScenarios (37.910959ms)
▶ validateScenarios
  ✔ accepts scenario with signal reference (1.169208ms)
  ✔ accepts scenario with headline reference (11.636375ms)
  ✔ accepts scenario with market cue and trigger reference (0.534667ms)
  ✔ rejects scenario without any evidence reference (0.553208ms)
  ✔ rejects too-short scenario (0.156875ms)
  ✔ rejects out-of-bounds index (1.739958ms)
  ✔ strips HTML from scenario (2.156917ms)
  ✔ handles null/non-array input (0.420667ms)
✔ validateScenarios (18.889958ms)
▶ computeProjections
  ✔ anchors projection to timeHorizon (0.5485ms)
  ✔ different domains produce different curves (0.322084ms)
  ✔ caps at 0.95 (0.567042ms)
  ✔ floors at 0.01 (0.520375ms)
  ✔ unknown domain defaults to multiplier 1 (0.221667ms)
✔ computeProjections (9.387084ms)
▶ validatePerspectives
  ✔ accepts valid perspectives (26.087167ms)
  ✔ rejects too-short perspectives (0.181667ms)
  ✔ strips HTML before length check (0.146958ms)
  ✔ handles null input (0.097959ms)
  ✔ rejects out-of-bounds index (0.093167ms)
✔ validatePerspectives (26.816917ms)
▶ loadCascadeRules
  ✔ loads rules from JSON file (0.90975ms)
  ✔ each rule has required fields (0.362666ms)
  ✔ includes new Phase 3 rules (0.249875ms)
✔ loadCascadeRules (1.618875ms)
▶ evaluateRuleConditions
  ✔ requiresChokepoint passes for chokepoint region (0.364083ms)
  ✔ requiresChokepoint fails for non-chokepoint region (0.137416ms)
  ✔ minProbability passes when above threshold (0.096458ms)
  ✔ minProbability fails when below threshold (0.086375ms)
  ✔ requiresSeverity checks outage signal value (0.162625ms)
  ✔ requiresSeverity fails for non-matching severity (0.114542ms)
✔ evaluateRuleConditions (1.094167ms)
▶ normalizeChokepoints
  ✔ maps v4 shape to v2 fields (0.210958ms)
  ✔ maps red status to critical + disrupted (0.093958ms)
  ✔ handles null (0.078083ms)
✔ normalizeChokepoints (0.450542ms)
▶ normalizeGpsJamming
  ✔ maps hexes to zones (0.131542ms)
  ✔ preserves existing zones (0.076584ms)
  ✔ handles null (0.064792ms)
✔ normalizeGpsJamming (0.33625ms)
▶ detectUcdpConflictZones
  ✔ generates prediction for 10+ events in one country (0.28725ms)
  ✔ skips countries with < 10 events (0.101167ms)
  ✔ handles empty input (0.076834ms)
✔ detectUcdpConflictZones (0.521334ms)
▶ detectCyberScenarios
  ✔ generates prediction for 5+ threats in one country (1.077083ms)
  ✔ skips countries with < 5 threats (0.197875ms)
  ✔ handles empty input (0.108625ms)
  ✔ caps broad cyber output to the top-ranked countries (1.191209ms)
✔ detectCyberScenarios (43.474084ms)
▶ detectGpsJammingScenarios
  ✔ generates prediction for hexes in maritime region (0.533917ms)
  ✔ skips hexes outside maritime regions (0.651583ms)
✔ detectGpsJammingScenarios (1.300542ms)
▶ detectFromPredictionMarkets
  ✔ generates from 60-90% markets with region (1.245041ms)
  ✔ skips markets below 60% (0.543042ms)
  ✔ caps at 5 predictions (0.935167ms)
✔ detectFromPredictionMarkets (2.952916ms)
▶ lowered CII conflict threshold
  ✔ CII score 67 (high level) now triggers conflict (1.220375ms)
  ✔ CII score 62 (elevated level) does NOT trigger conflict (0.314417ms)
✔ lowered CII conflict threshold (1.711917ms)
▶ loadEntityGraph
  ✔ loads graph from JSON (0.2495ms)
  ✔ aliases resolve country codes (0.175958ms)
✔ loadEntityGraph (0.558458ms)
▶ discoverGraphCascades
  ✔ finds linked predictions via graph (0.605958ms)
  ✔ skips same-domain predictions (0.99075ms)
✔ discoverGraphCascades (1.688584ms)
▶ forecast quality gating
  ✔ reserves scenario enrichment slots for scarce market and military forecasts (1.023959ms)
  ✔ filters only the weakest fallback forecasts from publish output (4.055833ms)
  ✔ suppresses weaker duplicate-like conflict forecasts while preserving distinct consequences (2.849458ms)
  ✔ caps dominant same-domain situation output while preserving cross-domain consequences (1.686833ms)
  ✔ does not report capped situations when a situation only reaches the cap without dropping anything (0.843583ms)
  ✔ keeps unrelated forecasts in separate situations instead of token-only over-merging (11.545625ms)
  ✔ does not report capped situations when a situation only reaches the cap without dropping anything (0.877416ms)
✔ forecast quality gating (23.222458ms)
  [fallbackNarratives] Applied fallback narratives to 2 forecast(s)
  [fallbackNarratives] Applied fallback narratives to 2 forecast(s)
  [fallbackNarratives] Applied fallback narratives to 1 forecast(s)
  [fallbackNarratives] Applied fallback narratives to 1 forecast(s)
  [fallbackNarratives] Applied fallback narratives to 2 forecast(s)
▶ forecast trace storage config
  ✔ resolves Cloudflare R2 trace env vars and derives the endpoint from account id (1.679542ms)
  ✔ falls back to a shared Cloudflare R2 bucket env var (0.346375ms)
✔ forecast trace storage config (12.393333ms)
▶ forecast trace artifact builder
  ✔ builds manifest, summary, and per-forecast trace artifacts (124.93775ms)
  ✔ stores all forecasts by default when no explicit max is configured (7.149375ms)
  ✔ summarizes fallback, enrichment, and domain quality across traced forecasts (2.461083ms)
✔ forecast trace artifact builder (154.075583ms)
▶ forecast run world state
  ✔ builds a canonical run-level world state artifact (8.84ms)
  ✔ reports full actor continuity counts even when previews are capped (1.997458ms)
  ✔ tracks situation continuity across runs (5.110333ms)
  ✔ keeps situation continuity stable when a cluster expands with a new earlier-sorting actor (61.839625ms)
  ✔ summarizes report continuity across recent world-state history (1.155625ms)
  ✔ matches report continuity when historical situation ids drift from cluster expansion (1.067167ms)
  ✔ marks fading pressures for situations present in prior state but absent from current run (1.313541ms)
  ✔ does not collapse unrelated cross-country conflict and political forecasts into one giant situation (1.512041ms)
  ✔ does not describe a lower-probability situation as strengthened just because it expanded (3.673417ms)
  ✔ builds deterministic simulation units and round transitions from clustered situations (1.254167ms)
✔ forecast run world state (88.620916ms)
ℹ tests 181
ℹ suites 40
ℹ pass 181
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 5958.798917
- focused Biome lint attempt stalled in the clean worktree install path again, so final push used  after the targeted validations above passed