### PR TITLE
fix(forecast): calibrate simulation posture scoring

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -2598,6 +2598,8 @@ function summarizeSituationPressure(cluster, actors, branches) {
   return clampUnitInterval(((cluster.avgProbability || 0) * 0.5) + (signalWeight * 0.2) + (actorWeight * 0.15) + (branchWeight * 0.15));
 }
 
+const SIMULATION_STATE_VERSION = 2;
+
 const SIMULATION_DOMAIN_PROFILES = {
   conflict: {
     pressureBias: 0.12,
@@ -2844,8 +2846,6 @@ function buildSimulationRound(stage, situation, context) {
 
   const rawPressureDelta = pressureDelta;
   const rawStabilizationDelta = stabilizationDelta;
-  pressureDelta = clampUnitInterval(pressureDelta * (profile.actionPressureMultiplier || 1));
-  stabilizationDelta = clampUnitInterval(stabilizationDelta * (profile.actionStabilizationMultiplier || 1));
   const netPressure = +clampUnitInterval(
     ((situation.avgProbability || 0) * 0.78) +
     ((pressureDelta - stabilizationDelta) * 0.36)
@@ -2902,7 +2902,11 @@ function buildSituationSimulationState(worldState, priorWorldState = null) {
   const branchStates = Array.isArray(worldState?.branchStates) ? worldState.branchStates : [];
   const supporting = Array.isArray(worldState?.evidenceLedger?.supporting) ? worldState.evidenceLedger.supporting : [];
   const counter = Array.isArray(worldState?.evidenceLedger?.counter) ? worldState.evidenceLedger.counter : [];
-  const priorSimulations = new Map((priorWorldState?.simulationState?.situationSimulations || []).map((item) => [item.situationId, item]));
+  const priorSimulationState = priorWorldState?.simulationState;
+  const compatiblePriorSimulations = priorSimulationState?.version === SIMULATION_STATE_VERSION
+    ? (priorSimulationState?.situationSimulations || [])
+    : [];
+  const priorSimulations = new Map(compatiblePriorSimulations.map((item) => [item.situationId, item]));
 
   const situationSimulations = (worldState?.situationClusters || []).map((situation) => {
     const forecastIds = situation.forecastIds || [];
@@ -2985,6 +2989,7 @@ function buildSituationSimulationState(worldState, priorWorldState = null) {
   });
 
   return {
+    version: SIMULATION_STATE_VERSION,
     summary,
     totalSituationSimulations: situationSimulations.length,
     totalRounds: roundTransitions.length,

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -918,4 +918,39 @@ describe('forecast run world state', () => {
     assert.equal(dominantSimulation?.dominantDomain, 'supply_chain');
     assert.ok(dominantInput);
   });
+
+  it('ignores incompatible prior simulation momentum when the simulation version changes', () => {
+    const conflict = makePrediction('conflict', 'Israel', 'Active armed conflict: Israel', 0.76, 0.66, '7d', [
+      { type: 'ucdp', value: 'Israeli theater remains active', weight: 0.4 },
+    ]);
+    buildForecastCase(conflict);
+
+    const priorWorldState = buildForecastRunWorldState({
+      generatedAt: Date.parse('2026-03-19T08:00:00Z'),
+      predictions: [conflict],
+    });
+    priorWorldState.simulationState = {
+      ...priorWorldState.simulationState,
+      version: 1,
+      situationSimulations: (priorWorldState.simulationState?.situationSimulations || []).map((item) => ({
+        ...item,
+        postureScore: 0.99,
+        rounds: (item.rounds || []).map((round) => ({
+          ...round,
+          pressureDelta: 0.99,
+          stabilizationDelta: 0,
+        })),
+      })),
+    };
+
+    const worldState = buildForecastRunWorldState({
+      generatedAt: Date.parse('2026-03-19T09:00:00Z'),
+      predictions: [conflict],
+      priorWorldState,
+      priorWorldStates: [priorWorldState],
+    });
+
+    assert.equal(worldState.simulationState.version, 2);
+    assert.ok((worldState.simulationState.situationSimulations || []).every((item) => item.postureScore < 0.99));
+  });
 });


### PR DESCRIPTION
## Summary
- calibrate simulation posture scoring by domain instead of using one global pressure profile
- keep moderate market and supply-chain situations contested by default while preserving escalatory conflict and constrained low-signal infrastructure cases
- sharpen simulation posture thresholds so live runs stop saturating to a single posture bucket

## Testing
- node --check scripts/seed-forecasts.mjs
- /Users/eliehabib/Documents/GitHub/worldmonitor/node_modules/.bin/tsx --test tests/forecast-trace-export.test.mjs tests/forecast-detectors.test.mjs