### PR TITLE
fix(live-news): add HLS fallbacks for 8 channels, fix custom HLS-only channel validation

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -961,7 +961,7 @@ export class LiveNewsPanel extends Panel {
   private async resolveChannelVideo(channel: LiveChannel, forceFallback = false): Promise<void> {
     const useFallbackVideo = channel.useFallbackOnly || forceFallback;
 
-    if (this.getDirectHlsUrl(channel.id) || this.getProxiedHlsUrl(channel.id)) {
+    if (this.getDirectHlsUrl(channel.id) || this.getProxiedHlsUrl(channel.id) || channel.hlsUrl) {
       channel.videoId = channel.fallbackVideoId;
       channel.isLive = true;
       return;
@@ -970,7 +970,6 @@ export class LiveNewsPanel extends Panel {
     if (useFallbackVideo) {
       channel.videoId = channel.fallbackVideoId;
       channel.isLive = false;
-      channel.hlsUrl = undefined;
       return;
     }
 
@@ -1012,7 +1011,7 @@ export class LiveNewsPanel extends Panel {
       }
     });
 
-    if (this.getDirectHlsUrl(channel.id) || this.getProxiedHlsUrl(channel.id)) {
+    if (this.getDirectHlsUrl(channel.id) || this.getProxiedHlsUrl(channel.id) || channel.hlsUrl) {
       this.renderNativeHlsPlayer();
       return;
     }
@@ -1169,7 +1168,7 @@ export class LiveNewsPanel extends Panel {
   }
 
   private renderNativeHlsPlayer(): void {
-    const hlsUrl = this.getDirectHlsUrl(this.activeChannel.id) || this.getProxiedHlsUrl(this.activeChannel.id);
+    const hlsUrl = this.getDirectHlsUrl(this.activeChannel.id) || this.getProxiedHlsUrl(this.activeChannel.id) || this.activeChannel.hlsUrl;
     if (!hlsUrl || !(hlsUrl.startsWith('https://') || hlsUrl.startsWith('http://127.0.0.1'))) return;
 
     this.destroyPlayer();
@@ -1311,7 +1310,7 @@ export class LiveNewsPanel extends Panel {
     await this.resolveChannelVideo(this.activeChannel, useFallbackVideo);
     if (!this.element?.isConnected) return;
 
-    if (this.getDirectHlsUrl(this.activeChannel.id) || this.getProxiedHlsUrl(this.activeChannel.id)) {
+    if (this.getDirectHlsUrl(this.activeChannel.id) || this.getProxiedHlsUrl(this.activeChannel.id) || this.activeChannel.hlsUrl) {
       this.renderNativeHlsPlayer();
       return;
     }


### PR DESCRIPTION
## Why this PR?

HLS-only custom channels (no YouTube handle) were silently dropped from user channel lists because the filter required `c.handle`. Desktop users who added a custom stream with only an `hlsUrl` would see it disappear on reload.

Additionally, 8 channels (RT, Record News, Arirang News, ABP News, SABC News, TV5 Monde Info, NRK1, Al Jazeera Balkans) had no HLS fallback, so desktop playback would fail when YouTube detection returned nothing.

## Changes

- **Validation fix**: `if (c.id && c.handle)` → `if (c.id && (c.handle || c.hlsUrl))` — HLS-only custom channels are now retained
- **HLS fallbacks**: Added `hlsUrl` for 8 channels so desktop video works independently of YouTube availability

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass
- [x] `node --test tests/live-news-hls.test.mjs` — 46/46 pass
- [x] `npm run version:check` — pass
- [x] `npm run lint:md` — pass

---

Closes #1391
Co-authored-by: lspassos1 <lspassos1@users.noreply.github.com>