### PR TITLE
refactor(services): unsafe non-null assertion

### DIFF
--- a/src/services/giving/index.ts
+++ b/src/services/giving/index.ts
@@ -66,8 +66,20 @@ export interface GivingFetchResult {
 
 // ─── Proto -> display mapping ───
 
+const emptyResult: GivingSummary = {
+  generatedAt: new Date().toISOString(),
+  activityIndex: 0,
+  trend: 'stable',
+  estimatedDailyFlowUsd: 0,
+  platforms: [],
+  categories: [],
+  crypto: { dailyInflowUsd: 0, trackedWallets: 0, transactions24h: 0, topReceivers: [], pctOfTotal: 0 },
+  institutional: { oecdOdaAnnualUsdBn: 0, oecdDataYear: 0, cafWorldGivingIndex: 0, cafDataYear: 0, candidGrantsTracked: 0, dataLag: 'Unknown' },
+};
+
 function toDisplaySummary(proto: ProtoResponse): GivingSummary {
-  const s = proto.summary!;
+  if (!proto.summary) return emptyResult;
+  const s = proto.summary;
   return {
     generatedAt: s.generatedAt,
     activityIndex: s.activityIndex,
@@ -126,17 +138,6 @@ function toDisplayInstitutional(proto?: ProtoInstitutional): InstitutionalGiving
 // ─── Client + circuit breaker + caching ───
 
 const client = new GivingServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
-
-const emptyResult: GivingSummary = {
-  generatedAt: new Date().toISOString(),
-  activityIndex: 0,
-  trend: 'stable',
-  estimatedDailyFlowUsd: 0,
-  platforms: [],
-  categories: [],
-  crypto: { dailyInflowUsd: 0, trackedWallets: 0, transactions24h: 0, topReceivers: [], pctOfTotal: 0 },
-  institutional: { oecdOdaAnnualUsdBn: 0, oecdDataYear: 0, cafWorldGivingIndex: 0, cafDataYear: 0, candidGrantsTracked: 0, dataLag: 'Unknown' },
-};
 
 const breaker = createCircuitBreaker<GivingSummary>({
   name: 'Global Giving',


### PR DESCRIPTION
Closes #1871

## ✨ Code Quality

### Problem
The `toDisplaySummary` function uses a non-null assertion (`proto.summary!`) to access the summary object. If the gRPC/protobuf response omits the `summary` field (which is common if the field is empty, uninitialized, or an error occurred upstream), this will throw a runtime `TypeError` and crash the execution context.


**Severity**: `high`
**File**: `src/services/giving/index.ts`

### Solution
The `toDisplaySummary` function uses a non-null assertion (`proto.summary!`) to access the summary object. If the gRPC/protobuf response omits the `summary` field (which is common if the field is empty, uninitialized, or an error occurred upstream), this will throw a runtime `TypeError` and crash the execution context.


### Changes
- `src/services/giving/index.ts` (modified)

## Summary



## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other: 

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [ ] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots



---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>
