### PR TITLE
refactor(services): potential memory leak due to unbounded map growth

### DIFF
--- a/src/services/conflict/index.ts
+++ b/src/services/conflict/index.ts
@@ -22,14 +22,23 @@ import { toApiUrl } from '@/services/runtime';
 const client = new ConflictServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
 const acledBreaker = createCircuitBreaker<ListAcledEventsResponse>({ name: 'ACLED Conflicts', cacheTtlMs: 10 * 60 * 1000, persistCache: true });
 const ucdpBreaker = createCircuitBreaker<ListUcdpEventsResponse>({ name: 'UCDP Events', cacheTtlMs: 10 * 60 * 1000, persistCache: true });
+const MAX_HAPI_BREAKERS = 100;
 const hapiBreakers = new Map<string, ReturnType<typeof createCircuitBreaker<GetHumanitarianSummaryResponse>>>();
 function getHapiBreaker(iso2: string) {
   if (!hapiBreakers.has(iso2)) {
+    if (hapiBreakers.size >= MAX_HAPI_BREAKERS) {
+      const oldestKey = hapiBreakers.keys().next().value;
+      if (oldestKey !== undefined) hapiBreakers.delete(oldestKey);
+    }
     hapiBreakers.set(iso2, createCircuitBreaker<GetHumanitarianSummaryResponse>({
       name: `HDX HAPI:${iso2}`,
       cacheTtlMs: 10 * 60 * 1000,
       persistCache: true,
     }));
+  } else {
+    const breaker = hapiBreakers.get(iso2)!;
+    hapiBreakers.delete(iso2);
+    hapiBreakers.set(iso2, breaker);
   }
   return hapiBreakers.get(iso2)!;
 }


### PR DESCRIPTION
Closes #1873

## ✨ Code Quality

### Problem
The `hapiBreakers` Map stores circuit breaker instances keyed by dynamic strings (`iso2`). There is no eviction policy or size limit. If the application runs for a long time and receives many unique keys, this Map will grow indefinitely, causing a memory leak. A similar issue exists in `src/services/economic/index.ts` with `wbBreakers` (though it includes a console warning, it does not prevent the growth).


**Severity**: `medium`
**File**: `src/services/conflict/index.ts`

### Solution
The `hapiBreakers` Map stores circuit breaker instances keyed by dynamic strings (`iso2`). There is no eviction policy or size limit. If the application runs for a long time and receives many unique keys, this Map will grow indefinitely, causing a memory leak. A similar issue exists in `src/services/economic/index.ts` with `wbBreakers` (though it includes a console warning, it does not prevent the growth).


### Changes
- `src/services/conflict/index.ts` (modified)

## Summary



## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other: 

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [ ] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots



---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>
