### PR TITLE
fix(forecast): wire per-situation simulation into per-forecast worldState

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -1987,7 +1987,25 @@ function buildTraceRunPrefix(runId, generatedAt, basePrefix) {
   return `${basePrefix}/${year}/${month}/${day}/${runId}`;
 }
 
-function buildForecastTraceRecord(pred, rank) {
+function buildForecastTraceRecord(pred, rank, simulationByForecastId = null) {
+  const caseFile = pred.caseFile || null;
+  let worldState = caseFile?.worldState || null;
+  if (worldState && simulationByForecastId) {
+    const sim = simulationByForecastId.get(pred.id);
+    if (sim) {
+      const [r1, r2, r3] = sim.rounds || [];
+      const simulationSummary = `${sim.label} moved through ${r1?.lead || 'initial interpretation'}, ${r2?.lead || 'interaction responses'}, and ${r3?.lead || 'regional effects'} before resolving to a ${describeSimulationPosture(sim.posture)} posture at ${roundPct(sim.postureScore)}.`;
+      worldState = {
+        ...worldState,
+        situationId: sim.situationId,
+        familyId: sim.familyId,
+        familyLabel: sim.familyLabel,
+        simulationSummary,
+        simulationPosture: sim.posture,
+        simulationPostureScore: sim.postureScore,
+      };
+    }
+  }
   return {
     rank,
     id: pred.id,
@@ -2007,7 +2025,7 @@ function buildForecastTraceRecord(pred, rank) {
     signals: pred.signals || [],
     newsContext: pred.newsContext || [],
     perspectives: pred.perspectives || null,
-    caseFile: pred.caseFile || null,
+    caseFile: caseFile ? { ...caseFile, worldState } : null,
     readiness: scoreForecastReadiness(pred),
     analysisPriority: computeAnalysisPriority(pred),
     traceMeta: pred.traceMeta || {
@@ -4055,14 +4073,6 @@ function buildForecastTraceArtifacts(data, context = {}, config = {}) {
   const predictions = Array.isArray(data?.predictions) ? data.predictions : [];
   const fullRunPredictions = Array.isArray(data?.fullRunPredictions) ? data.fullRunPredictions : predictions;
   const maxForecasts = config.maxForecasts || getTraceMaxForecasts(predictions.length);
-  const tracedPredictions = predictions.slice(0, maxForecasts).map((pred, index) => buildForecastTraceRecord(pred, index + 1));
-  const quality = summarizeForecastTraceQuality(
-    predictions,
-    tracedPredictions,
-    data?.enrichmentMeta || null,
-    data?.publishTelemetry || null,
-    fullRunPredictions
-  );
   const worldState = buildForecastRunWorldState({
     generatedAt,
     predictions,
@@ -4072,6 +4082,20 @@ function buildForecastTraceArtifacts(data, context = {}, config = {}) {
     situationFamilies: data?.situationFamilies || undefined,
     publishTelemetry: data?.publishTelemetry || null,
   });
+  const simulationByForecastId = new Map();
+  for (const sim of (worldState.simulationState?.situationSimulations || [])) {
+    for (const forecastId of (sim.forecastIds || [])) {
+      simulationByForecastId.set(forecastId, sim);
+    }
+  }
+  const tracedPredictions = predictions.slice(0, maxForecasts).map((pred, index) => buildForecastTraceRecord(pred, index + 1, simulationByForecastId));
+  const quality = summarizeForecastTraceQuality(
+    predictions,
+    tracedPredictions,
+    data?.enrichmentMeta || null,
+    data?.publishTelemetry || null,
+    fullRunPredictions
+  );
   const candidateWorldState = fullRunPredictions !== predictions || data?.fullRunSituationClusters
     ? buildForecastRunWorldState({
       generatedAt,

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -194,6 +194,15 @@ describe('forecast trace artifact builder', () => {
     assert.ok(artifacts.forecasts[0].payload.caseFile.worldState.summary.includes('Iran'));
     assert.equal(artifacts.forecasts[0].payload.caseFile.branches.length, 3);
     assert.equal(artifacts.forecasts[0].payload.traceMeta.narrativeSource, 'fallback');
+    // simulation linkage: per-forecast worldState must carry simulation fields from the global simulation state
+    const forecastWorldState = artifacts.forecasts[0].payload.caseFile.worldState;
+    const simulations = artifacts.worldState.simulationState?.situationSimulations || [];
+    if (simulations.length > 0) {
+      assert.ok(typeof forecastWorldState.situationId === 'string' && forecastWorldState.situationId.length > 0, 'worldState.situationId should be set from simulation');
+      assert.ok(typeof forecastWorldState.simulationSummary === 'string' && forecastWorldState.simulationSummary.length > 0, 'worldState.simulationSummary should be set from simulation');
+      assert.ok(['escalatory', 'contested', 'constrained'].includes(forecastWorldState.simulationPosture), 'worldState.simulationPosture should be a valid posture');
+      assert.ok(typeof forecastWorldState.simulationPostureScore === 'number', 'worldState.simulationPostureScore should be a number');
+    }
   });
 
   it('stores all forecasts by default when no explicit max is configured', () => {


### PR DESCRIPTION
## Why this PR?

The MiroFish 3-round simulation was being computed globally (`worldState.simulationState.situationSimulations`) but never wired into individual per-forecast `caseFile.worldState` objects written to R2. Consumers reading a trace file had no way to know which situation a forecast belonged to, what its simulation posture was, or get a narrative summary.

## Changes

**`scripts/seed-forecasts.mjs`**
- `buildForecastTraceArtifacts`: moved `worldState` build **before** `tracedPredictions` (previously reversed order made simulation data unavailable during forecast serialization)
- Built a `forecastId → simulation` lookup map from `worldState.simulationState.situationSimulations`
- `buildForecastTraceRecord`: accepts new `simulationByForecastId` map; injects simulation fields into `caseFile.worldState`:
  - `situationId`, `familyId`, `familyLabel`
  - `simulationSummary` (human-readable narrative of the 3 rounds)
  - `simulationPosture` (escalatory / contested / constrained)
  - `simulationPostureScore` (0–1)

**`tests/forecast-trace-export.test.mjs`**
- Added 4 regression assertions verifying simulation fields appear on `caseFile.worldState` when simulations exist

## Test plan
- [ ] `node --test tests/forecast-trace-export.test.mjs` passes (194/194)
- [ ] Live trace: `caseFile.worldState` on forecast objects now carries `situationId`, `simulationSummary`, `simulationPosture`, `simulationPostureScore`