### PR TITLE
fix(cors): prevent Cloudflare from caching per-origin ACAO responses

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -73,9 +73,12 @@ const FAST_KEYS = new Set([
   'correlationCards', 'forecasts', 'shippingRates',
 ]);
 
+// No public/s-maxage: CF (in front of api.worldmonitor.app) ignores Vary: Origin and would
+// pin ACAO: worldmonitor.app on cached responses, breaking CORS for preview deployments.
+// Vercel CDN caching is handled by TIER_CDN_CACHE via CDN-Cache-Control below.
 const TIER_CACHE = {
-  slow: 'public, s-maxage=3600, stale-while-revalidate=600, stale-if-error=3600',
-  fast: 'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',
+  slow: 'max-age=300, stale-while-revalidate=600, stale-if-error=3600',
+  fast: 'max-age=60, stale-while-revalidate=120, stale-if-error=900',
 };
 const TIER_CDN_CACHE = {
   slow: 'public, s-maxage=7200, stale-while-revalidate=1800, stale-if-error=7200',

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -26,18 +26,23 @@ export const serverOptions: ServerOptions = { onError: mapErrorToResponse };
 
 type CacheTier = 'fast' | 'medium' | 'slow' | 'slow-browser' | 'static' | 'daily' | 'no-store';
 
+// Browser-only cache: no `public` or `s-maxage` so Cloudflare (which ignores
+// Vary: Origin) does NOT cache these responses. CF sits in front of api.worldmonitor.app
+// and would otherwise pin ACAO: worldmonitor.app on the cached response, breaking CORS
+// for preview deployments. Vercel CDN caching is handled separately by CDN-Cache-Control.
 const TIER_HEADERS: Record<CacheTier, string> = {
-  fast: 'public, s-maxage=300, stale-while-revalidate=60, stale-if-error=600',
-  medium: 'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',
-  slow: 'public, s-maxage=1800, stale-while-revalidate=300, stale-if-error=3600',
-  'slow-browser': 'public, max-age=300, s-maxage=900, stale-while-revalidate=60, stale-if-error=1800',
-  static: 'public, s-maxage=7200, stale-while-revalidate=600, stale-if-error=14400',
-  daily: 'public, s-maxage=86400, stale-while-revalidate=7200, stale-if-error=172800',
+  fast: 'max-age=60, stale-while-revalidate=60, stale-if-error=600',
+  medium: 'max-age=120, stale-while-revalidate=120, stale-if-error=900',
+  slow: 'max-age=300, stale-while-revalidate=300, stale-if-error=3600',
+  'slow-browser': 'max-age=300, stale-while-revalidate=60, stale-if-error=1800',
+  static: 'max-age=600, stale-while-revalidate=600, stale-if-error=14400',
+  daily: 'max-age=3600, stale-while-revalidate=7200, stale-if-error=172800',
   'no-store': 'no-store',
 };
 
-// Cloudflare-specific cache TTLs — more aggressive than s-maxage since CF can
-// revalidate via ETag/If-None-Match without full payload transfer.
+// Vercel CDN-specific cache TTLs — CDN-Cache-Control overrides Cache-Control for
+// Vercel's own edge cache, so Vercel can still cache aggressively (and respects
+// Vary: Origin correctly) while CF sees no public s-maxage and passes through.
 const TIER_CDN_CACHE: Record<CacheTier, string | null> = {
   fast: 'public, s-maxage=600, stale-while-revalidate=300, stale-if-error=1200',
   medium: 'public, s-maxage=1200, stale-while-revalidate=600, stale-if-error=1800',

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -140,9 +140,11 @@ describe('Bootstrap endpoint (api/bootstrap.js)', () => {
   });
 
   it('sets Cache-Control header with s-maxage for both tiers', () => {
-    assert.ok(src.includes('s-maxage=3600'), 'Missing s-maxage=3600 for slow tier');
-    assert.ok(src.includes('s-maxage=600'), 'Missing s-maxage=600 for fast tier');
+    // Cache-Control uses browser-only max-age (no s-maxage) so CF does not cache and
+    // pin a single ACAO origin. Vercel CDN uses CDN-Cache-Control for edge caching.
+    assert.ok(src.includes('max-age='), 'Missing max-age in Cache-Control');
     assert.ok(src.includes('stale-while-revalidate'), 'Missing stale-while-revalidate');
+    assert.ok(src.includes('CDN-Cache-Control'), 'Missing CDN-Cache-Control for Vercel CDN');
   });
 
   it('validates API key for desktop origins', () => {


### PR DESCRIPTION
## Summary

- **Root cause**: Cloudflare (sitting in front of `api.worldmonitor.app`) ignores `Vary: Origin` and pins the first response's `Access-Control-Allow-Origin` header for all subsequent origins. Preview deployments (`worldmonitor-xxx.vercel.app`) were getting `ACAO: https://worldmonitor.app` from CF's cache instead of their own origin, causing CORS to fail.
- **Fix in `server/gateway.ts`**: Remove `public` and `s-maxage` from `TIER_HEADERS` (browser-only cache). CF sees no shared-cache directive and stops caching. Vercel CDN still caches aggressively via `CDN-Cache-Control` (which it prioritizes over `Cache-Control`), and correctly varies by origin.
- **Fix in `api/bootstrap.js`**: Same treatment for bootstrap's inline `TIER_CACHE` values.
- **Update `tests/bootstrap.test.mjs`**: Adjust Cache-Control assertion to match new `max-age`-only strategy and verify `CDN-Cache-Control` is still present.

## Test plan

- [ ] Deploy to Vercel preview and confirm `api.worldmonitor.app` requests (bootstrap, RPCs) succeed without CORS errors
- [ ] Confirm production (`worldmonitor.app`) API calls still work
- [ ] Confirm API responses still have `CDN-Cache-Control` header for Vercel CDN caching