### PR TITLE
fix(relay): route USNI through residential proxy to bypass Cloudflare 403

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -4389,12 +4389,23 @@ async function seedUsniFleet() {
   console.log('[USNI] Fetching fleet tracker...');
   const t0 = Date.now();
   try {
-    const res = await fetch(USNI_URL, {
-      headers: { 'User-Agent': CHROME_UA, 'Accept': 'application/json' },
-      signal: AbortSignal.timeout(15000),
-    });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const wpData = await res.json();
+    // USNI (WordPress) returns 403 from Railway datacenter IPs via Cloudflare.
+    // Route through the residential proxy when available; fall back to direct for dev.
+    const proxyAuth = process.env.OREF_PROXY_AUTH || OREF_PROXY_AUTH;
+    let wpData;
+    if (proxyAuth) {
+      const proxy = parseProxyUrl(`http://${proxyAuth}`);
+      const result = proxy ? await ytFetchViaProxy(USNI_URL, proxy) : null;
+      if (!result || !result.ok) throw new Error(`proxy HTTP ${result?.status ?? 'unavailable'}`);
+      wpData = JSON.parse(result.body);
+    } else {
+      const res = await fetch(USNI_URL, {
+        headers: { 'User-Agent': CHROME_UA, 'Accept': 'application/json' },
+        signal: AbortSignal.timeout(15000),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      wpData = await res.json();
+    }
     if (!Array.isArray(wpData) || !wpData.length) throw new Error('No fleet tracker articles');
 
     const post = wpData[0];


### PR DESCRIPTION
## Summary
- USNI WordPress API returns 403 from Railway datacenter IPs (Cloudflare blocks cloud/AWS egress)
- Previous fix (naive `fetch()`) worked from dev but failed on Railway
- Reuses existing `ytFetchViaProxy` + `parseProxyUrl` pattern with `OREF_PROXY_AUTH`
- Falls back to direct `fetch()` when proxy not configured (dev/local, no 403 there)

## Root cause chain
1. Original: `curl` + proxy, but `curl` not in Railway container → ENOENT
2. PR #1908: native `fetch()`, no proxy → 403 from Cloudflare on Railway IPs
3. This PR: `ytFetchViaProxy` via `OREF_PROXY_AUTH` → residential IP → 200

## Test plan
- [ ] Deploy relay, check Railway logs for `[USNI] N vessels`
- [ ] Verify `seed-meta:military:usni-fleet` updated in Redis
- [ ] Health check shows usniFleet green