### PR TITLE
fix(predictions): extend Redis TTL to 3h (6x gold standard)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -90,7 +90,7 @@ const SEED_META = {
   naturalEvents:    { key: 'seed-meta:natural:events',          maxStaleMin: 120 },
   flightDelays:     { key: 'seed-meta:aviation:faa',            maxStaleMin: 60 },
   notamClosures:    { key: 'seed-meta:aviation:notam',          maxStaleMin: 90 },
-  predictions:      { key: 'seed-meta:prediction:markets',      maxStaleMin: 30 },
+  predictions:      { key: 'seed-meta:prediction:markets',      maxStaleMin: 90 },
   insights:         { key: 'seed-meta:news:insights',           maxStaleMin: 30 },
   marketQuotes:     { key: 'seed-meta:market:stocks',         maxStaleMin: 30 },
   commodityQuotes:  { key: 'seed-meta:market:commodities',    maxStaleMin: 30 },

--- a/scripts/seed-prediction-markets.mjs
+++ b/scripts/seed-prediction-markets.mjs
@@ -10,7 +10,7 @@ import predictionTags from './data/prediction-tags.json' with { type: 'json' };
 loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'prediction:markets-bootstrap:v1';
-const CACHE_TTL = 1800; // 30 min — matches client poll interval
+const CACHE_TTL = 10800; // 3h — 6x the 30 min cron interval (gold standard: survive 5 missed runs)
 
 const GAMMA_BASE = 'https://gamma-api.polymarket.com';
 const KALSHI_BASE = 'https://api.elections.kalshi.com/trade-api/v2';


### PR DESCRIPTION
## Summary
- `prediction:markets-bootstrap:v1` was seeded with `CACHE_TTL = 1800` (30 min) — exactly equal to the cron interval
- Any missed cron run or Polymarket API timeout caused the key to expire
- RPC handler returns `{ markets: [] }` on null key → circuit breaker returns `[]` → panel shows **"Predictions temporarily unavailable"**
- Raises `CACHE_TTL` to `10800` (3h = 6× the 30 min interval) per gold standard
- Raises `health.js` `maxStaleMin`: 30 → 90 to stop false-positive alerts on slightly-delayed runs

## Root cause
TTL == interval is always broken for any required check — the key expires exactly when the next seed should be running. A single Railway cold start, Polymarket 429, or scheduler jitter of >0s makes the panel go dark.

## Test plan
- [ ] Deploy Railway cron, verify panel stays visible across multiple cron cycles
- [ ] Health check: `predictions` stays green even if one run is delayed