### PR TITLE
fix(seeds): extend Redis TTLs to 6x cron interval across 6 standalone seeds

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -87,7 +87,7 @@ const SEED_META = {
   etfFlows:         { key: 'seed-meta:market:etf-flows',        maxStaleMin: 60 },
   gulfQuotes:       { key: 'seed-meta:market:gulf-quotes',      maxStaleMin: 30 },
   stablecoinMarkets:{ key: 'seed-meta:market:stablecoins',      maxStaleMin: 60 },
-  naturalEvents:    { key: 'seed-meta:natural:events',          maxStaleMin: 120 },
+  naturalEvents:    { key: 'seed-meta:natural:events',          maxStaleMin: 360 }, // 2h cron; 3x interval; was 120 (TTL was 60min — panel went dark before health alarmed)
   flightDelays:     { key: 'seed-meta:aviation:faa',            maxStaleMin: 60 },
   notamClosures:    { key: 'seed-meta:aviation:notam',          maxStaleMin: 90 },
   predictions:      { key: 'seed-meta:prediction:markets',      maxStaleMin: 30 },

--- a/scripts/seed-earthquakes.mjs
+++ b/scripts/seed-earthquakes.mjs
@@ -6,7 +6,7 @@ loadEnvFile(import.meta.url);
 
 const USGS_FEED_URL = 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_day.geojson';
 const CANONICAL_KEY = 'seismology:earthquakes:v1';
-const CACHE_TTL = 3600; // 1 hour
+const CACHE_TTL = 21600; // 6h — 6x the 1h cron interval (was 2x = survived only 1 missed run)
 
 async function fetchEarthquakes() {
   const resp = await fetch(USGS_FEED_URL, {

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -12,7 +12,7 @@ if (_isDirectRun) loadEnvFile(import.meta.url);
 const CANONICAL_KEY = 'forecast:predictions:v2';
 const PRIOR_KEY = 'forecast:predictions:prior:v2';
 const HISTORY_KEY = 'forecast:predictions:history:v1';
-const TTL_SECONDS = 6300; // 105min (cron runs hourly; outlives maxStaleMin:90 with 15min buffer)
+const TTL_SECONDS = 21600; // 6h — 6x the 1h cron interval (was 1.75x; hourly miss → 15 min panel gap)
 const HISTORY_MAX_RUNS = 200;
 const HISTORY_MAX_FORECASTS = 25;
 const HISTORY_TTL_SECONDS = 45 * 24 * 60 * 60;

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -7,7 +7,7 @@ loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'news:insights:v1';
 const DIGEST_KEY = 'news:digest:v1:full:en';
-const CACHE_TTL = 1800; // 30 min — matches health maxStaleMin; survives missed cron runs
+const CACHE_TTL = 10800; // 3h — 6x the 30 min cron interval (was 1x = key expired on any missed run)
 const MAX_HEADLINES = 10;
 const MAX_HEADLINE_LEN = 500;
 const GROQ_MODEL = 'llama-3.1-8b-instant';

--- a/scripts/seed-internet-outages.mjs
+++ b/scripts/seed-internet-outages.mjs
@@ -6,7 +6,7 @@ loadEnvFile(import.meta.url);
 
 const CF_RADAR_URL = 'https://api.cloudflare.com/client/v4/radar/annotations/outages';
 const CANONICAL_KEY = 'infra:outages:v1';
-const CACHE_TTL = 1800; // 30 min
+const CACHE_TTL = 10800; // 3h — 6x the 30 min cron interval (was 1x = key expired on any missed run)
 
 const COUNTRY_COORDS = {
   AF:[33.94,67.71],AL:[41.15,20.17],DZ:[28.03,1.66],AO:[-11.20,17.87],

--- a/scripts/seed-natural-events.mjs
+++ b/scripts/seed-natural-events.mjs
@@ -8,7 +8,7 @@ const EONET_API_URL = 'https://eonet.gsfc.nasa.gov/api/v3/events';
 const GDACS_API = 'https://www.gdacs.org/gdacsapi/api/events/geteventlist/MAP';
 const NHC_BASE = 'https://mapservices.weather.noaa.gov/tropical/rest/services/tropical/NHC_tropical_weather/MapServer';
 const CANONICAL_KEY = 'natural:events:v1';
-const CACHE_TTL = 3600; // 1 hour
+const CACHE_TTL = 43200; // 12h — 6x the 2h cron interval; was 1h (TTL < maxStaleMin:120 — panel went dark before health alarmed)
 
 const DAYS = 30;
 const WILDFIRE_MAX_AGE_MS = 48 * 60 * 60 * 1000;

--- a/scripts/seed-unrest-events.mjs
+++ b/scripts/seed-unrest-events.mjs
@@ -8,7 +8,7 @@ loadEnvFile(import.meta.url);
 const GDELT_GKG_URL = 'https://api.gdeltproject.org/api/v1/gkg_geojson';
 const ACLED_API_URL = 'https://acleddata.com/api/acled/read';
 const CANONICAL_KEY = 'unrest:events:v1';
-const CACHE_TTL = 3600;
+const CACHE_TTL = 16200; // 4.5h — 6x the 45 min cron interval (was 1.3x)
 
 // ---------- ACLED Event Type Mapping (from _shared.ts) ----------
 


### PR DESCRIPTION
## Summary
All 6 seeds had `CACHE_TTL ≤ 2x cron interval` — any missed Railway run or upstream API timeout causes the key to expire and the panel to show unavailable.

**Worst case:** `seed-natural-events` had `TTL=1h < maxStaleMin=2h`. Panel goes dark 60 min after the last successful seed, but health doesn't alarm for another 60 min. Silent failure.

## Changes

| Seed | Old TTL | New TTL | Cron | Ratio |
|---|---|---|---|---|
| seed-natural-events | 3600 (1h) | 43200 (12h) | 2h | 1→6x |
| seed-insights | 1800 (30m) | 10800 (3h) | 30m | 1→6x |
| seed-internet-outages | 1800 (30m) | 10800 (3h) | 30m | 1→6x |
| seed-earthquakes | 3600 (1h) | 21600 (6h) | 1h | 1→6x |
| seed-unrest-events | 3600 (1h) | 16200 (4.5h) | 45m | 1.3→6x |
| seed-forecasts | 6300 (105m) | 21600 (6h) | 1h | 1.75→6x |

Also raises `health.js naturalEvents.maxStaleMin`: 120 → 360 to match the corrected 2h cron cadence.

## Test plan
- [ ] Deploy Railway crons, verify panels stay visible across multiple cycles
- [ ] Simulate a missed run; verify panel remains visible for 5+ intervals
- [ ] Health check stays green