### PR TITLE
fix(forecast): guarantee military forecast inclusion in publish selection pool

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -5391,6 +5391,17 @@ function selectPublishedForecastPool(predictions, options = {}) {
     if (canSelect(pred, 'fill')) take(pred);
   }
 
+  // Domain guarantee: data-driven detectors (military) structurally can't match LLM-enriched
+  // readiness scores, so they get buried in ranking. If no military forecast was selected
+  // and we have room below the hard cap, inject the best-scoring eligible one.
+  if (selected.length < MAX_TARGET_PUBLISHED_FORECASTS) {
+    for (const guaranteedDomain of ['military']) {
+      if (selected.some((p) => p.domain === guaranteedDomain)) continue;
+      const candidate = ranked.find((p) => p.domain === guaranteedDomain && canSelect(p, 'fill'));
+      if (candidate) take(candidate);
+    }
+  }
+
   const deferredCandidates = ranked.filter((pred) => !selectedIds.has(pred.id));
   if (deferredCandidates.length > 0) {
     console.log(`  [filterPublished] Deferred ${deferredCandidates.length} forecast(s) in family selection`);

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -15,6 +15,7 @@ import {
   attachSituationContext,
   projectSituationClusters,
   refreshPublishedNarratives,
+  selectPublishedForecastPool,
 } from '../scripts/seed-forecasts.mjs';
 
 import {
@@ -2055,5 +2056,45 @@ describe('cross-theater gate', () => {
       ],
     });
     assert.equal(effects.length, 0, 'Cuba → Iran via generic civil-protection actor should be blocked');
+  });
+});
+
+describe('military domain guarantee in publish selection', () => {
+  function makeMinimalPred(id, domain, prob, confidence = 0.5) {
+    const pred = makePrediction(domain, 'Test Region', `Test ${domain} forecast ${id}`, prob, confidence, '30d', []);
+    pred.id = id;
+    return pred;
+  }
+
+  it('injects military forecast when buried below high-scoring non-military forecasts', () => {
+    // 14 well-scored conflict forecasts would fill the pool, leaving military out
+    const nonMilitary = Array.from({ length: 14 }, (_, i) =>
+      makeMinimalPred(`conflict-${i}`, 'conflict', 0.7 + (i * 0.001), 0.75),
+    );
+    const military = makeMinimalPred('mil-baltic', 'military', 0.41, 0.30);
+    const pool = selectPublishedForecastPool([...nonMilitary, military]);
+    const hasMilitary = pool.some((p) => p.domain === 'military');
+    assert.equal(hasMilitary, true, 'military forecast should be included via domain guarantee');
+  });
+
+  it('does not inject military when none are eligible (prob = 0)', () => {
+    const nonMilitary = Array.from({ length: 5 }, (_, i) =>
+      makeMinimalPred(`conflict-${i}`, 'conflict', 0.6, 0.6),
+    );
+    const pool = selectPublishedForecastPool(nonMilitary);
+    const hasMilitary = pool.some((p) => p.domain === 'military');
+    assert.equal(hasMilitary, false, 'no military forecast should appear when none were input');
+  });
+
+  it('does not double-inject military when it already ranks into selection naturally', () => {
+    const forecasts = [
+      makeMinimalPred('mil-1', 'military', 0.80, 0.75),
+      makeMinimalPred('conflict-1', 'conflict', 0.60, 0.60),
+      makeMinimalPred('conflict-2', 'conflict', 0.55, 0.55),
+    ];
+    const pool = selectPublishedForecastPool(forecasts);
+    const militaryCount = pool.filter((p) => p.domain === 'military').length;
+    assert.equal(militaryCount, 1, 'only one military forecast should appear, no duplication');
+
   });
 });


### PR DESCRIPTION
## Why this PR?

Military forecasts have been absent from published runs despite a valid elevated theater signal. Diagnosis from live R2 data (run `1773983083084-bu6b1f`).

## Root Cause

**Path B confirmed.** The military detector IS generating forecasts. Baltic theater shows `postureLevel: 'elevated'` (6 active flights, Germany/NATO operators), producing a forecast at prob=0.41, confidence=0.30.

The problem: `selectPublishedForecastPool` ranks candidates by `publishSelectionScore` which is built on `readiness.overall`. Military detections are data-driven (ADS-B flight tracking + theater posture API) and structurally can't produce the LLM-enriched caseFile content that readiness measures:

- `groundingScore` requires news headlines, prediction market calibration, or triggers (all LLM artifacts) → **0**
- `evidenceScore` requires `caseFile.supportingEvidence` (LLM artifacts) → **0**
- `analysisPriority` gets penalized for both low grounding and low evidence → **~0.061**
- `publishSelectionScore` → **~0.136** vs well-grounded situation forecasts at **0.4–0.5+**

With 15-20 eligible forecasts and target=10-14, military lands at rank 15+ and is deferred every run.

## Fix

Domain guarantee post-pass at the end of `selectPublishedForecastPool`:

```js
if (selected.length < MAX_TARGET_PUBLISHED_FORECASTS) {
  for (const guaranteedDomain of ['military']) {
    if (selected.some((p) => p.domain === guaranteedDomain)) continue;
    const candidate = ranked.find((p) => p.domain === guaranteedDomain && canSelect(p, 'fill'));
    if (candidate) take(candidate);
  }
}
```

Properties:
- Only fires if no military forecast was already selected by the 3 main passes
- Respects `MAX_TARGET_PUBLISHED_FORECASTS` hard cap (won't push over 14)
- All existing family/situation caps apply via `canSelect(p, 'fill')`
- Does not displace any already-selected forecast

## Tests

3 new assertions:
1. Military buried below 14 high-scoring non-military forecasts → guaranteed inclusion
2. No military forecasts in input → no phantom injection
3. Military naturally in top-N → no duplication (count stays 1)

```
ℹ tests 43
ℹ pass 43
ℹ fail 0
```