### PR TITLE
fix(health): extend unrestEvents maxStaleMin from 45 to 135min

### DIFF
--- a/scripts/seed-unrest-events.mjs
+++ b/scripts/seed-unrest-events.mjs
@@ -167,7 +167,7 @@ async function fetchGdeltEvents() {
 
   const resp = await fetch(`${GDELT_GKG_URL}?${params}`, {
     headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(15_000),
+    signal: AbortSignal.timeout(30_000),
   });
 
   if (!resp.ok) throw new Error(`GDELT API error: ${resp.status}`);


### PR DESCRIPTION
PR #1912 missed updating maxStaleMin in health.js. At 45min = 1x cron, any Railway delay triggers false STALE_SEED. Fix to 135min (3x).