### PR TITLE
feat(analytics): type-safe Umami event catalog

### DIFF
--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -42,6 +42,7 @@ import {
   disconnectAisStream,
 } from '@/services';
 import {
+  track,
   trackPanelView,
   trackVariantSwitch,
   trackThemeChanged,
@@ -290,15 +291,15 @@ export class EventHandlerManager implements AppModule {
       this.ctx.searchModal?.open();
     };
     document.getElementById('searchBtn')?.addEventListener('click', () => {
-      window.umami?.track('search-open', { source: 'desktop' });
+      track('search-open', { source: 'desktop' });
       openSearch();
     });
     document.getElementById('mobileSearchBtn')?.addEventListener('click', () => {
-      window.umami?.track('search-open', { source: 'mobile' });
+      track('search-open', { source: 'mobile' });
       openSearch();
     });
     document.getElementById('searchMobileFab')?.addEventListener('click', () => {
-      window.umami?.track('search-open', { source: 'fab' });
+      track('search-open', { source: 'fab' });
       openSearch();
     });
 

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -8,6 +8,7 @@ import { escapeHtml, sanitizeUrl } from '@/utils/sanitize';
 
 import { getStreamQuality } from '@/services/ai-flow-settings';
 import { getLiveStreamsAlwaysOn, subscribeLiveStreamsSettingsChange } from '@/services/live-stream-settings';
+import { track } from '@/services/analytics';
 
 // YouTube IFrame Player API types
 type YouTubePlayer = {
@@ -754,7 +755,7 @@ export class LiveNewsPanel extends Panel {
     this.fullscreenBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/></svg>';
     this.fullscreenBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      window.umami?.track('live-news-fullscreen', { entering: !this.isFullscreen });
+      track('live-news-fullscreen', { entering: !this.isFullscreen });
       this.toggleFullscreen();
     });
     const header = this.element.querySelector('.panel-header');

--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -3,7 +3,7 @@ import { IDLE_PAUSE_MS, STORAGE_KEYS } from '@/config';
 import { isDesktopRuntime, getLocalApiPort } from '@/services/runtime';
 import { escapeHtml } from '@/utils/sanitize';
 import { t } from '../services/i18n';
-import { trackWebcamSelected, trackWebcamRegionFiltered } from '@/services/analytics';
+import { track, trackWebcamSelected, trackWebcamRegionFiltered } from '@/services/analytics';
 import { getStreamQuality, subscribeStreamQualityChange } from '@/services/ai-flow-settings';
 import { isMobileDevice, loadFromStorage, saveToStorage } from '@/utils';
 import { getLiveStreamsAlwaysOn, subscribeLiveStreamsSettingsChange } from '@/services/live-stream-settings';
@@ -154,7 +154,7 @@ export class LiveWebcamsPanel extends Panel {
     this.fullscreenBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/></svg>';
     this.fullscreenBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      window.umami?.track('webcam-fullscreen', { entering: !this.isFullscreen });
+      track('webcam-fullscreen', { entering: !this.isFullscreen });
       this.toggleFullscreen();
     });
     const header = this.element.querySelector('.panel-header');

--- a/src/components/McpConnectModal.ts
+++ b/src/components/McpConnectModal.ts
@@ -3,6 +3,7 @@ import { MCP_PRESETS } from '@/services/mcp-store';
 import { t } from '@/services/i18n';
 import { escapeHtml } from '@/utils/sanitize';
 import { proxyUrl } from '@/utils/proxy';
+import { track } from '@/services/analytics';
 
 interface McpConnectOptions {
   existingSpec?: McpPanelSpec;
@@ -209,7 +210,7 @@ export function openMcpConnectModal(options: McpConnectOptions): void {
   connectBtn.addEventListener('click', async () => {
     const serverUrl = urlInput.value.trim();
     if (!serverUrl) return;
-    window.umami?.track('mcp-connect-attempt');
+    track('mcp-connect-attempt');
     connectStatus.textContent = t('mcp.connecting');
     connectStatus.className = 'mcp-connect-status mcp-status-loading';
     connectBtn.disabled = true;
@@ -225,7 +226,7 @@ export function openMcpConnectModal(options: McpConnectOptions): void {
       tools = data.tools ?? [];
       connectStatus.textContent = t('mcp.foundTools', { count: String(tools.length) });
       connectStatus.className = 'mcp-connect-status mcp-status-ok';
-      window.umami?.track('mcp-connect-success', { toolCount: tools.length });
+      track('mcp-connect-success', { toolCount: tools.length });
       toolsSection.style.display = '';
       renderTools(tools);
     } catch (err) {
@@ -239,7 +240,7 @@ export function openMcpConnectModal(options: McpConnectOptions): void {
 
   addBtn.addEventListener('click', () => {
     if (!selectedTool) return;
-    window.umami?.track('mcp-panel-add', { tool: selectedTool.name });
+    track('mcp-panel-add', { tool: selectedTool.name });
     argsError.style.display = 'none';
     let toolArgs: Record<string, unknown> = {};
     try {

--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -8,6 +8,7 @@ import { analysisWorker, enrichWithVelocityML, getClusterAssetContext, MAX_DISTA
 import { getSourcePropagandaRisk, getSourceTier, getSourceType } from '@/config/feeds';
 import { SITE_VARIANT } from '@/config';
 import { t, getCurrentLanguage } from '@/services/i18n';
+import { track } from '@/services/analytics';
 
 type SortMode = 'relevance' | 'newest';
 
@@ -144,7 +145,7 @@ export class NewsPanel extends Panel {
     this.updateSortButtonLabel();
     this.sortBtn.addEventListener('click', () => {
       this.sortMode = this.sortMode === 'relevance' ? 'newest' : 'relevance';
-      window.umami?.track('news-sort-toggle', { mode: this.sortMode });
+      track('news-sort-toggle', { mode: this.sortMode });
       this.saveSortMode();
       this.updateSortButtonLabel();
       // Re-render with cached data
@@ -199,7 +200,7 @@ export class NewsPanel extends Panel {
     this.summaryBtn.innerHTML = '✨';
     this.summaryBtn.title = t('components.newsPanel.summarize');
     this.summaryBtn.addEventListener('click', () => {
-      window.umami?.track('news-summarize', { panelId: this.panelId });
+      track('news-summarize', { panelId: this.panelId });
       this.handleSummarize();
     });
 

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -6,6 +6,7 @@ import type { MapProvider } from '@/config/basemap';
 import { escapeHtml } from '@/utils/sanitize';
 import type { PanelConfig } from '@/types';
 import { renderPreferences } from '@/services/preferences-content';
+import { track } from '@/services/analytics';
 
 const GEAR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`;
 
@@ -159,7 +160,7 @@ export class UnifiedSettings {
     this.overlay.classList.add('active');
     localStorage.setItem('wm-settings-open', '1');
     document.addEventListener('keydown', this.escapeHandler);
-    window.umami?.track('settings-open', { tab: tab ?? 'default' });
+    track('settings-open', { tab: tab ?? 'default' });
   }
 
   public close(): void {

--- a/src/components/WidgetChatModal.ts
+++ b/src/components/WidgetChatModal.ts
@@ -4,6 +4,7 @@ import { t } from '@/services/i18n';
 import { escapeHtml } from '@/utils/sanitize';
 import { widgetAgentHealthUrl, widgetAgentUrl } from '@/utils/proxy';
 import { wrapWidgetHtml, wrapProWidgetHtml } from '@/utils/widget-sanitizer';
+import { track } from '@/services/analytics';
 
 interface WidgetChatOptions {
   mode: 'create' | 'modify';
@@ -42,7 +43,7 @@ let clientTimeout: ReturnType<typeof setTimeout> | null = null;
 
 export function openWidgetChatModal(options: WidgetChatOptions): void {
   closeWidgetChatModal();
-  window.umami?.track('widget-ai-open', { panelId: options.existingSpec?.id });
+  track('widget-ai-open', { panelId: options.existingSpec?.id });
 
   const currentTier: 'basic' | 'pro' = options.tier ?? options.existingSpec?.tier ?? 'basic';
   const isPro = currentTier === 'pro';
@@ -187,7 +188,7 @@ export function openWidgetChatModal(options: WidgetChatOptions): void {
   const submit = async () => {
     const prompt = inputEl.value.trim();
     if (!prompt || sendBtn.disabled) return;
-    window.umami?.track('widget-ai-generate');
+    track('widget-ai-generate');
 
     inputEl.value = '';
     requestInFlight = true;
@@ -278,7 +279,7 @@ export function openWidgetChatModal(options: WidgetChatOptions): void {
           } else if (event.type === 'done') {
             resultTitle = String(event.title ?? 'Custom Widget');
             radarEl.remove();
-            window.umami?.track('widget-ai-success', { title: resultTitle });
+            track('widget-ai-success', { title: resultTitle });
             const assistantSummary = t('widgets.generatedWidget', { title: resultTitle });
             sessionHistory.push(
               { role: 'user' as const, content: prompt },

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -5,6 +5,56 @@
  * even if the Umami script has not loaded yet (e.g. ad blockers, SSR).
  */
 
+// ---------------------------------------------------------------------------
+// Type-safe event catalog — every event name lives here.
+// Typo in an event string = compile error.
+// ---------------------------------------------------------------------------
+
+const EVENTS = {
+  // Search
+  'search-open': true,
+  'search-used': true,
+  'search-result-selected': true,
+  // Country / map
+  'country-selected': true,
+  'country-brief-opened': true,
+  'map-layer-toggle': true,
+  // Panels
+  'panel-toggle': true,
+  // Settings
+  'settings-open': true,
+  'variant-switch': true,
+  'theme-changed': true,
+  'language-change': true,
+  'feature-toggle': true,
+  // News
+  'news-sort-toggle': true,
+  'news-summarize': true,
+  'live-news-fullscreen': true,
+  // Webcams
+  'webcam-selected': true,
+  'webcam-region-filter': true,
+  'webcam-fullscreen': true,
+  // Downloads / banners
+  'download-clicked': true,
+  'critical-banner': true,
+  // AI widget
+  'widget-ai-open': true,
+  'widget-ai-generate': true,
+  'widget-ai-success': true,
+  // MCP
+  'mcp-connect-attempt': true,
+  'mcp-connect-success': true,
+  'mcp-panel-add': true,
+} as const;
+
+export type UmamiEvent = keyof typeof EVENTS;
+
+/** Type-safe Umami wrapper. Safe to call even if the script hasn't loaded. */
+export function track(event: UmamiEvent, data?: Record<string, unknown>): void {
+  window.umami?.track(event, data);
+}
+
 export async function initAnalytics(): Promise<void> {
   // No-op: Umami initialises itself via the script tag in index.html.
 }
@@ -27,11 +77,11 @@ export function trackDownloadBannerDismissed(): void {}
 // ---------------------------------------------------------------------------
 
 export function trackSearchUsed(queryLength: number, resultCount: number): void {
-  window.umami?.track('search-used', { queryLength, resultCount });
+  track('search-used', { queryLength, resultCount });
 }
 
 export function trackSearchResultSelected(resultType: string): void {
-  window.umami?.track('search-result-selected', { type: resultType });
+  track('search-result-selected', { type: resultType });
 }
 
 // ---------------------------------------------------------------------------
@@ -39,16 +89,16 @@ export function trackSearchResultSelected(resultType: string): void {
 // ---------------------------------------------------------------------------
 
 export function trackCountrySelected(code: string, name: string, source: string): void {
-  window.umami?.track('country-selected', { code, name, source });
+  track('country-selected', { code, name, source });
 }
 
 export function trackCountryBriefOpened(countryCode: string): void {
-  window.umami?.track('country-brief-opened', { code: countryCode });
+  track('country-brief-opened', { code: countryCode });
 }
 
 export function trackMapLayerToggle(layerId: string, enabled: boolean, source: 'user' | 'programmatic'): void {
   if (source !== 'user') return;
-  window.umami?.track('map-layer-toggle', { layerId, enabled });
+  track('map-layer-toggle', { layerId, enabled });
 }
 
 export function trackMapViewChange(_view: string): void {
@@ -60,7 +110,7 @@ export function trackMapViewChange(_view: string): void {
 // ---------------------------------------------------------------------------
 
 export function trackPanelToggled(panelId: string, enabled: boolean): void {
-  window.umami?.track('panel-toggle', { panelId, enabled });
+  track('panel-toggle', { panelId, enabled });
 }
 
 export function trackPanelResized(_panelId: string, _newSpan: number): void {
@@ -72,19 +122,19 @@ export function trackPanelResized(_panelId: string, _newSpan: number): void {
 // ---------------------------------------------------------------------------
 
 export function trackVariantSwitch(from: string, to: string): void {
-  window.umami?.track('variant-switch', { from, to });
+  track('variant-switch', { from, to });
 }
 
 export function trackThemeChanged(theme: string): void {
-  window.umami?.track('theme-changed', { theme });
+  track('theme-changed', { theme });
 }
 
 export function trackLanguageChange(language: string): void {
-  window.umami?.track('language-change', { language });
+  track('language-change', { language });
 }
 
 export function trackFeatureToggle(featureId: string, enabled: boolean): void {
-  window.umami?.track('feature-toggle', { featureId, enabled });
+  track('feature-toggle', { featureId, enabled });
 }
 
 // ---------------------------------------------------------------------------
@@ -104,11 +154,11 @@ export function trackLLMFailure(_lastProvider: string): void {
 // ---------------------------------------------------------------------------
 
 export function trackWebcamSelected(webcamId: string, city: string, viewMode: string): void {
-  window.umami?.track('webcam-selected', { webcamId, city, viewMode });
+  track('webcam-selected', { webcamId, city, viewMode });
 }
 
 export function trackWebcamRegionFiltered(region: string): void {
-  window.umami?.track('webcam-region-filter', { region });
+  track('webcam-region-filter', { region });
 }
 
 // ---------------------------------------------------------------------------
@@ -116,11 +166,11 @@ export function trackWebcamRegionFiltered(region: string): void {
 // ---------------------------------------------------------------------------
 
 export function trackDownloadClicked(platform: string): void {
-  window.umami?.track('download-clicked', { platform });
+  track('download-clicked', { platform });
 }
 
 export function trackCriticalBannerAction(action: string, theaterId: string): void {
-  window.umami?.track('critical-banner', { action, theaterId });
+  track('critical-banner', { action, theaterId });
 }
 
 export function trackFindingClicked(_id: string, _source: string, _type: string, _priority: string): void {


### PR DESCRIPTION
## Summary

- Adds `EVENTS` const in `analytics.ts` as the single source of truth for all 26 Umami event names
- Exports `UmamiEvent = keyof typeof EVENTS` and a typed `track()` wrapper — any typo in an event name is now a **compile error**
- Migrates all 7 component files (`WidgetChatModal`, `McpConnectModal`, `NewsPanel`, `LiveNewsPanel`, `LiveWebcamsPanel`, `UnifiedSettings`, `event-handlers`) from raw `window.umami?.track()` to the typed `track()` import
- The analytics facade itself also uses `track()` internally — `window.umami?.track` appears only once (in the wrapper)

## Test plan

- [ ] `npm run typecheck` passes
- [ ] Introduce a typo in any `track(...)` call (e.g. `'serach-open'`) — TypeScript rejects it
- [ ] Restore correct name — builds clean
- [ ] Open/close search, settings, MCP modal, AI widget — events appear in Umami dashboard