### PR TITLE
fix(git): block push to merged/closed PR branches

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,6 +4,21 @@ if [ ! -d node_modules ]; then
   npm install --prefer-offline || exit 1
 fi
 
+echo "Checking PR status for current branch..."
+BRANCH=$(git branch --show-current)
+if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ]; then
+  PR_STATE=$(gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null)
+  if [ "$PR_STATE" = "MERGED" ] || [ "$PR_STATE" = "CLOSED" ]; then
+    echo ""
+    echo "============================================================"
+    echo "ERROR: PR for branch '$BRANCH' is $PR_STATE."
+    echo "Do NOT push to a merged/closed PR branch — commits will be orphaned."
+    echo "Run: git checkout main && git pull && git checkout -b fix/new-branch"
+    echo "============================================================"
+    exit 1
+  fi
+fi
+
 echo "Running type check..."
 npm run typecheck || exit 1
 


### PR DESCRIPTION
## Summary

- Adds a merged/closed PR guard at the top of `.husky/pre-push`
- Uses `gh pr view <branch> --json state` to check PR state before running any tests
- Exits 1 with a clear error if the branch's PR is MERGED or CLOSED
- Prints exact recovery instructions: `git checkout main && git pull && git checkout -b fix/new-branch`

## Why

Orphaned commits on PRs #1893, #1898, #1911, #1921 — all caused by pushing to a branch after its PR was squash-merged. The hook runs BEFORE the 2-minute test suite so the failure is instant.

## Test plan

- [ ] On a branch with an open PR: push proceeds normally
- [ ] On a branch with a merged PR: push immediately exits with the error message
- [ ] On `main`: guard is skipped (no PR to check)