### PR TITLE
feat(economic): add global debt ticker header with deficit/surplus breakdown

### DIFF
--- a/src/components/NationalDebtPanel.ts
+++ b/src/components/NationalDebtPanel.ts
@@ -205,7 +205,7 @@ export class NationalDebtPanel extends Panel {
     const html = `
       <div class="debt-panel-container">
         <div class="debt-summary">
-          <div class="debt-summary-card debt-summary-card-deficit">
+          <div class="debt-summary-card debt-summary-card-deficit debt-summary-card-world">
             <span class="debt-summary-label">World Debt</span>
             <span class="debt-summary-value debt-global-ticker">${escapeHtml(formatDebt(this.getGlobalDebt()))}</span>
           </div>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -20281,10 +20281,14 @@ body.has-breaking-alert .panels-grid {
 
 .debt-summary {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: 1fr 1fr;
   gap: 6px;
   margin-bottom: 8px;
   flex-shrink: 0;
+}
+
+.debt-summary-card-world {
+  grid-column: 1 / -1;
 }
 
 .debt-summary-card {


### PR DESCRIPTION
## Summary
- Adds a 3-card summary grid at the top of the National Debt Clock panel, matching the radiation panel's stat header pattern
- **World Debt** card: ticking global total (sum of all entries via `getCurrentDebt`), updates every second via the existing ticker interval
- **In Deficit** card: live count of countries where `perSecondRate > 0` (red-ish border)
- **Running Surplus** card: count of countries where `perSecondRate === 0` (green border)

## Test plan
- [ ] Biome check passes (no lint errors)
- [ ] TypeScript typecheck passes (no NationalDebt errors)
- [ ] All 10 unit tests pass (`national-debt-ticker` + `national-debt-seed`)
- [ ] World Debt value ticks every second and matches sum of all per-row tickers
- [ ] Deficit/surplus counts reflect actual data distribution
- [ ] Card colors match design: red for deficit, orange for warning, green for surplus