### PR TITLE
fix(consumer-prices): fix tsc errors — highlights cast + QueryResultRow constraint

### DIFF
--- a/consumer-prices-core/src/acquisition/exa.ts
+++ b/consumer-prices-core/src/acquisition/exa.ts
@@ -43,7 +43,7 @@ export class ExaProvider implements AcquisitionProvider {
       url: r.url,
       title: r.title ?? '',
       text: r.text,
-      highlights: r.highlights,
+      highlights: (r as Record<string, unknown>).highlights as string[] | undefined,
       score: r.score,
       publishedDate: r.publishedDate,
     }));

--- a/consumer-prices-core/src/db/client.ts
+++ b/consumer-prices-core/src/db/client.ts
@@ -24,7 +24,7 @@ export function getPool(): pg.Pool {
   return _pool;
 }
 
-export async function query<T = Record<string, unknown>>(
+export async function query<T extends pg.QueryResultRow = Record<string, unknown>>(
   sql: string,
   params?: unknown[],
 ): Promise<pg.QueryResult<T>> {


### PR DESCRIPTION
Two TypeScript errors surfaced during Railway build:

1. `exa.ts` — `highlights` property doesn't exist on `SearchResult<{}>` in the Exa SDK types. Cast via `as Record<string, unknown>` to access it.
2. `db/client.ts` — `query<T>` default type `Record<string, unknown>` doesn't satisfy `QueryResultRow` constraint. Fix: `T extends pg.QueryResultRow`.