### PR TITLE
fix(consumer-prices): allow self-signed SSL cert for Railway Postgres

### DIFF
--- a/consumer-prices-core/src/db/client.ts
+++ b/consumer-prices-core/src/db/client.ts
@@ -14,7 +14,7 @@ export function getPool(): pg.Pool {
       max: 10,
       idleTimeoutMillis: 30_000,
       connectionTimeoutMillis: 5_000,
-      ssl: databaseUrl.includes('localhost') ? false : true,
+      ssl: databaseUrl.includes('localhost') ? false : { rejectUnauthorized: false },
     });
 
     _pool.on('error', (err) => {


### PR DESCRIPTION
Railway Postgres uses a self-signed certificate. `ssl: true` causes `SELF_SIGNED_CERT_IN_CHAIN` — fix by passing `{ rejectUnauthorized: false }` instead.