### PR TITLE
fix(consumer-prices): target partial index in upsertCanonicalProduct ON CONFLICT

### DIFF
--- a/consumer-prices-core/src/db/queries/products.ts
+++ b/consumer-prices-core/src/db/queries/products.ts
@@ -69,7 +69,8 @@ export async function upsertCanonicalProduct(input: {
        (canonical_name, brand_norm, category, variant_norm, size_value, size_unit,
         base_quantity, base_unit)
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
-     ON CONFLICT (canonical_name, brand_norm, category, variant_norm, size_value, size_unit)
+     ON CONFLICT (canonical_name, category)
+       WHERE brand_norm IS NULL AND variant_norm IS NULL AND size_value IS NULL AND size_unit IS NULL
      DO UPDATE SET base_quantity = EXCLUDED.base_quantity, base_unit = EXCLUDED.base_unit
      RETURNING id`,
     [


### PR DESCRIPTION
PostgreSQL `ON CONFLICT (col1, col2, ...)` cannot match NULL values — NULLs are never equal in unique constraints. So when all variant fields are NULL, the conflict clause never fires, the partial unique index catches the duplicate and throws instead.

Fix: use `ON CONFLICT (canonical_name, category) WHERE brand_norm IS NULL AND ...` to target the partial index directly — the correct PostgreSQL syntax for partial index conflict handling.