### PR TITLE
fix(consumer-prices): write retailer_spread_pct metric in aggregate job

### DIFF
--- a/consumer-prices-core/src/jobs/aggregate.ts
+++ b/consumer-prices-core/src/jobs/aggregate.ts
@@ -193,6 +193,17 @@ export async function aggregateBasket(basketSlug: string, marketCode: string) {
   await writeComputedIndex(basketId, null, null, 'value_index', valueIndex);
   await writeComputedIndex(basketId, null, null, 'coverage_pct', coveragePct);
 
+  // Retailer spread: (most expensive basket - cheapest basket) / cheapest × 100
+  const retailerTotals = new Map<string, number>();
+  for (const r of rows) {
+    retailerTotals.set(r.retailerSlug, (retailerTotals.get(r.retailerSlug) ?? 0) + r.price);
+  }
+  if (retailerTotals.size >= 2) {
+    const totals = [...retailerTotals.values()];
+    const spreadPct = ((Math.max(...totals) - Math.min(...totals)) / Math.min(...totals)) * 100;
+    await writeComputedIndex(basketId, null, null, 'retailer_spread_pct', Math.round(spreadPct * 10) / 10);
+  }
+
   // Per-category indices for buildTopCategories snapshot
   const byCategory = new Map<string, BasketRow[]>();
   for (const r of rows) {


### PR DESCRIPTION
## Why this PR?

`buildOverviewSnapshot` (in `worldmonitor.ts`) queries `metric_key = 'retailer_spread_pct'` from `computed_indices`, but `aggregate.ts` never wrote this metric. The spread column was always `NULL`.

## What changed

- `aggregateBasket` now sums each retailer's total basket cost, then computes:
  `(max − min) / min × 100`, rounded to 1 decimal place
- Only written when ≥ 2 retailers have data (avoids division by zero)

## Test plan
- [ ] Deploy `seed-consumer-prices`, verify `retailer_spread_pct` row appears in `computed_indices`
- [ ] Confirm overview snapshot no longer returns `null` for spread