### PR TITLE
fix(national-debt): retry refresh via rAF when element not yet in DOM

### DIFF
--- a/src/components/NationalDebtPanel.ts
+++ b/src/components/NationalDebtPanel.ts
@@ -161,7 +161,13 @@ export class NationalDebtPanel extends Panel {
 
     try {
       const data = await getNationalDebtData();
-      if (!this.element?.isConnected) return;
+      if (!this.element?.isConnected) {
+        // Race condition: bootstrap data resolved synchronously before lazyPanel inserted
+        // the element into the DOM. Retry after the current paint cycle.
+        this.loading = false;
+        requestAnimationFrame(() => { void this.refresh(); });
+        return;
+      }
       this.entries = data.entries ?? [];
       this.lastFetch = Date.now();
       this.applyFilters();


### PR DESCRIPTION
## Root cause

National debt panel was the only one stuck at "Loading debt data from IMF..." indefinitely, even though the API returns data in ~400ms and the bootstrap endpoint returns 187 entries.

**Race condition:** When bootstrap pre-populates `getHydratedData('nationalDebt')`, `getNationalDebtData()` resolves as a **microtask** (synchronously). The sequence:

1. `lazyPanel` factory: `new NationalDebtPanel`, `A.refresh()` called
2. `refresh()`: `showLoadingState()`, then `await getNationalDebtData()`
3. `getNationalDebtData()` resolves immediately (data in hydration cache)
4. Microtask: `refresh()` continuation runs — checks `this.element?.isConnected` → **false** (element not in DOM yet!)
5. `refresh()` returns early, panel stays at "Loading..."
6. `lazyPanel` callback then inserts the element into the DOM (too late)

All other panels work because their data fetches take real network time (100ms+), giving `lazyPanel` time to insert the element before the data arrives.

## Fix

Instead of returning permanently when `isConnected` is false, reset `loading` and retry via `requestAnimationFrame`. This defers the retry until after the current browser paint cycle, by which time `lazyPanel` has already inserted the element.

## Test plan
- [ ] Deploy to staging/production and verify national debt panel loads correctly
- [ ] All 2118 existing tests pass
- [ ] TypeScript clean