### PR TITLE
fix(relay): install scripts/package.json deps in Dockerfile.relay

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -2,16 +2,18 @@
 # AIS Relay Sidecar
 # =============================================================================
 # Runs scripts/ais-relay.cjs as a standalone container.
-# Only dependency beyond Node stdlib is the 'ws' WebSocket library.
-# Set AISSTREAM_API_KEY in docker-compose.yml.
+# Dependencies: ws (WebSocket), telegram (OSINT polling), plus others in
+# scripts/package.json (fast-xml-parser, @anthropic-ai/sdk, etc.)
+# Set AISSTREAM_API_KEY in docker-compose.yml or Railway env.
 # =============================================================================
 
 FROM node:22-alpine
 
 WORKDIR /app
 
-# Install only the ws package (everything else is Node stdlib)
-RUN npm install --omit=dev ws@8.19.0
+# Install scripts/ runtime dependencies (telegram, ws, fast-xml-parser, etc.)
+COPY scripts/package.json scripts/package-lock.json ./scripts/
+RUN npm ci --prefix scripts --omit=dev
 
 # Relay script
 COPY scripts/ais-relay.cjs ./scripts/ais-relay.cjs


### PR DESCRIPTION
## Root cause

**Telegram Intel panel shows "No messages available"** — relay health reports:
\`\`\`json
{"telegram": {"enabled": true, "items": 0, "lastError": "telegram package not installed"}}
\`\`\`

`Dockerfile.relay` was created in #1521 for the self-hosted Docker stack and only installed `ws@8.19.0`. But `ais-relay.cjs` dynamically imports `'telegram'` (GramJS) for OSINT channel polling. Since that package was never installed in the container, the import fails with `ERR_MODULE_NOT_FOUND`, permanently disabling the Telegram poll loop on every relay restart.

## Fix

Replace the single `npm install ws` with `npm ci --prefix scripts` so all `scripts/package.json` deps (telegram, fast-xml-parser, @anthropic-ai/sdk, etc.) are installed via the lockfile.

## Test plan
- [ ] Relay container rebuilds and Telegram poll loop starts
- [ ] `/health` endpoint shows `telegram.lastError: null`
- [ ] Telegram Intel panel shows messages