### PR TITLE
feat(thermal): simplify panel cards + wire into country brief

### DIFF
--- a/src/app/app-context.ts
+++ b/src/app/app-context.ts
@@ -10,6 +10,7 @@ export type { CountryBriefSignals } from '@/types';
 
 export interface IntelligenceCache {
   flightDelays?: AirportDelayAlert[];
+  thermalEscalation?: import('@/services/thermal-escalation').ThermalEscalationWatch;
   aircraftPositions?: PositionSample[];
   outages?: InternetOutage[];
   protests?: { events: SocialUnrestEvent[]; sources: { acled: number; gdelt: number } };

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -364,6 +364,7 @@ export class CountryIntelManager implements AppModule {
           if (signals.satelliteFires > 0) lines.push(`🔥 Satellite fire detections: ${signals.satelliteFires}`);
           if (signals.radiationAnomalies > 0) lines.push(`☢️ Radiation anomalies: ${signals.radiationAnomalies}`);
           if (signals.temporalAnomalies > 0) lines.push(`⏱️ Temporal anomaly alerts: ${signals.temporalAnomalies}`);
+          if (signals.thermalEscalations > 0) lines.push(`🌡️ Thermal escalation clusters: ${signals.thermalEscalations}`);
           if (signals.earthquakes > 0) lines.push(t('countryBrief.fallback.recentEarthquakes', { count: String(signals.earthquakes) }));
           if (signals.orefHistory24h > 0) lines.push(`🚨 Sirens in past 24h: ${signals.orefHistory24h}`);
           if (context.stockIndex) lines.push(t('countryBrief.fallback.stockIndex', { value: context.stockIndex }));
@@ -431,7 +432,7 @@ export class CountryIntelManager implements AppModule {
     }
 
     lines.push(
-      `Signals: critical_news=${signals.criticalNews}, protests=${signals.protests}, active_strikes=${signals.activeStrikes}, military_flights=${signals.militaryFlights}, military_vessels=${signals.militaryVessels}, outages=${signals.outages}, aviation_disruptions=${signals.aviationDisruptions}, travel_advisories=${signals.travelAdvisories}, oref_sirens=${signals.orefSirens}, oref_24h=${signals.orefHistory24h}, gps_jamming_hexes=${signals.gpsJammingHexes}, ais_disruptions=${signals.aisDisruptions}, satellite_fires=${signals.satelliteFires}, radiation_anomalies=${signals.radiationAnomalies}, temporal_anomalies=${signals.temporalAnomalies}, cyber_threats=${signals.cyberThreats}, earthquakes=${signals.earthquakes}, conflict_events=${signals.conflictEvents}`,
+      `Signals: critical_news=${signals.criticalNews}, protests=${signals.protests}, active_strikes=${signals.activeStrikes}, military_flights=${signals.militaryFlights}, military_vessels=${signals.militaryVessels}, outages=${signals.outages}, aviation_disruptions=${signals.aviationDisruptions}, travel_advisories=${signals.travelAdvisories}, oref_sirens=${signals.orefSirens}, oref_24h=${signals.orefHistory24h}, gps_jamming_hexes=${signals.gpsJammingHexes}, ais_disruptions=${signals.aisDisruptions}, satellite_fires=${signals.satelliteFires}, radiation_anomalies=${signals.radiationAnomalies}, temporal_anomalies=${signals.temporalAnomalies}, cyber_threats=${signals.cyberThreats}, earthquakes=${signals.earthquakes}, conflict_events=${signals.conflictEvents}, thermal_escalations=${signals.thermalEscalations}`,
     );
 
     if (signals.travelAdvisoryMaxLevel) {
@@ -657,6 +658,13 @@ export class CountryIntelManager implements AppModule {
       }).length;
     }
 
+    let thermalEscalations = 0;
+    if (this.ctx.intelligenceCache.thermalEscalation) {
+      thermalEscalations = this.ctx.intelligenceCache.thermalEscalation.clusters.filter(
+        (c) => c.countryCode.toUpperCase() === code && c.status !== 'normal',
+      ).length;
+    }
+
     return {
       criticalNews,
       protests,
@@ -680,6 +688,7 @@ export class CountryIntelManager implements AppModule {
       travelAdvisoryMaxLevel,
       gpsJammingHexes: (ciiData?.gpsJammingHighCount ?? 0) + (ciiData?.gpsJammingMediumCount ?? 0),
       isTier1,
+      thermalEscalations,
     };
   }
 

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2790,6 +2790,7 @@ export class DataLoaderManager implements AppModule {
   async loadThermalEscalations(): Promise<void> {
     try {
       const result = await fetchThermalEscalations();
+      this.ctx.intelligenceCache.thermalEscalation = result;
       this.callPanel('thermal-escalation', 'setData', result);
       dataFreshness.recordUpdate('thermal-escalation' as DataSourceId, result.clusters.length);
     } catch (error) {

--- a/src/components/ThermalEscalationPanel.ts
+++ b/src/components/ThermalEscalationPanel.ts
@@ -6,9 +6,6 @@ import { escapeHtml } from '@/utils/sanitize';
 const STATUS_CLASS: Record<string, string> = {
   spike: 'spike', persistent: 'persistent', elevated: 'elevated', normal: 'normal',
 };
-const CONFIDENCE_CLASS: Record<string, string> = {
-  high: 'high', medium: 'medium', low: 'low',
-};
 
 export class ThermalEscalationPanel extends Panel {
   private clusters: ThermalEscalationCluster[] = [];
@@ -77,32 +74,25 @@ export class ThermalEscalationPanel extends Panel {
 
   private renderSummary(): string {
     const { clusterCount, elevatedCount, spikeCount, persistentCount, conflictAdjacentCount, highRelevanceCount } = this.summary;
+    // Only show non-zero sub-stats to reduce visual noise
+    const stats = [
+      { val: elevatedCount, label: 'Elevated', cls: 'te-stat-elevated' },
+      { val: spikeCount, label: 'Spikes', cls: 'te-stat-spike' },
+      { val: persistentCount, label: 'Persist', cls: 'te-stat-persistent' },
+      { val: conflictAdjacentCount, label: 'Conflict', cls: 'te-stat-conflict' },
+      { val: highRelevanceCount, label: 'Strategic', cls: 'te-stat-strategic' },
+    ].filter(s => s.val > 0);
     return `
       <div class="te-summary">
         <div class="te-stat">
           <span class="te-stat-val">${clusterCount}</span>
           <span class="te-stat-label">Total</span>
         </div>
-        <div class="te-stat te-stat-elevated">
-          <span class="te-stat-val">${elevatedCount}</span>
-          <span class="te-stat-label">Elevated</span>
-        </div>
-        <div class="te-stat te-stat-spike">
-          <span class="te-stat-val">${spikeCount}</span>
-          <span class="te-stat-label">Spikes</span>
-        </div>
-        <div class="te-stat te-stat-persistent">
-          <span class="te-stat-val">${persistentCount}</span>
-          <span class="te-stat-label">Persist</span>
-        </div>
-        <div class="te-stat te-stat-conflict">
-          <span class="te-stat-val">${conflictAdjacentCount}</span>
-          <span class="te-stat-label">Conflict</span>
-        </div>
-        <div class="te-stat te-stat-strategic">
-          <span class="te-stat-val">${highRelevanceCount}</span>
-          <span class="te-stat-label">Strategic</span>
-        </div>
+        ${stats.map(s => `
+        <div class="te-stat ${s.cls}">
+          <span class="te-stat-val">${s.val}</span>
+          <span class="te-stat-label">${s.label}</span>
+        </div>`).join('')}
       </div>
     `;
   }
@@ -110,7 +100,6 @@ export class ThermalEscalationPanel extends Panel {
   private renderCard(c: ThermalEscalationCluster): string {
     // P1: use allowlisted class names, never raw API strings in attributes
     const statusClass = STATUS_CLASS[c.status] ?? 'normal';
-    const confClass = CONFIDENCE_CLASS[c.confidence] ?? 'low';
 
     const persistence = c.persistenceHours >= 24
       ? `${Math.round(c.persistenceHours / 24)}d`
@@ -119,22 +108,17 @@ export class ThermalEscalationPanel extends Panel {
     const deltaSign = c.countDelta > 0 ? '+' : '';
     const deltaClass = c.countDelta > 0 ? 'pos' : c.countDelta < 0 ? 'neg' : '';
 
-    // P2: confidence badge reinstated
+    // Status badge + at most one context badge (conflict > energy > industrial) + strategic if high
+    const contextBadge =
+      c.context === 'conflict_adjacent' ? '<span class="te-badge te-badge-conflict">conflict-adj</span>' :
+      c.context === 'energy_adjacent' ? '<span class="te-badge te-badge-energy">energy-adj</span>' :
+      c.context === 'industrial' ? '<span class="te-badge te-badge-industrial">industrial</span>' : '';
     const badges = [
       `<span class="te-badge te-badge-${statusClass}">${escapeHtml(c.status)}</span>`,
-      `<span class="te-badge te-badge-conf-${confClass}">${escapeHtml(c.confidence)}</span>`,
+      contextBadge,
       c.strategicRelevance === 'high' ? '<span class="te-badge te-badge-strategic">strategic</span>' : '',
-      c.context === 'conflict_adjacent' ? '<span class="te-badge te-badge-conflict">conflict-adj</span>' : '',
-      c.context === 'energy_adjacent' ? '<span class="te-badge te-badge-energy">energy-adj</span>' : '',
-      c.context === 'industrial' ? '<span class="te-badge te-badge-industrial">industrial</span>' : '',
     ].filter(Boolean).join('');
 
-    // P2: nearbyAssets reinstated (up to 3)
-    const assets = c.nearbyAssets.length > 0
-      ? `<div class="te-assets">${c.nearbyAssets.slice(0, 3).map(a => escapeHtml(a)).join(' · ')}</div>`
-      : '';
-
-    // P2: lastDetectedAt reinstated
     const age = formatAge(c.lastDetectedAt);
 
     return `
@@ -142,9 +126,8 @@ export class ThermalEscalationPanel extends Panel {
         <div class="te-card-accent"></div>
         <div class="te-card-body">
           <div class="te-region">${escapeHtml(c.regionLabel)}</div>
-          <div class="te-meta">${escapeHtml(c.countryName)} · ${c.observationCount} obs · ${c.uniqueSourceCount} src</div>
+          <div class="te-meta">${c.observationCount} obs · ${c.uniqueSourceCount} src</div>
           <div class="te-badges">${badges}</div>
-          ${assets}
         </div>
         <div class="te-metrics">
           <div class="te-frp">${escapeHtml(frpDisplay)} <span class="te-frp-unit">MW</span></div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1475,4 +1475,5 @@ export interface CountryBriefSignals {
   travelAdvisoryMaxLevel: string | null;
   gpsJammingHexes: number;
   isTier1: boolean;
+  thermalEscalations: number;
 }


### PR DESCRIPTION
## Why this PR?

Thermal Escalation panel was too visually busy (4 badges per card, repeated country name, always-visible zero stats). Thermal data was also isolated to the panel and never fed into country brief generation.

## Panel simplification

**Before:** each card had 4 badges (status + confidence + strategic + context), country name repeated in meta line, nearbyAssets list, and the summary bar always showed all 6 stats including zeros.

**After:**
- Max 2 badges per card: status (PERSISTENT/SPIKE/ELEVATED) + most notable context (conflict-adj > energy-adj > industrial), strategic only if high
- Confidence badge removed (MEDIUM/HIGH/LOW is an internal metric, not actionable for users)
- `nearbyAssets` line removed
- Country name removed from meta (already the card title) — now just `82 obs · 3 src`
- Summary bar hides zero-value stats (e.g., no ELEVATED row when elevatedCount=0)

## Country brief integration

Thermal data was loaded and pushed only to the panel, never cached for other systems.

- `IntelligenceCache` gets `thermalEscalation?: ThermalEscalationWatch`
- `loadThermalEscalations()` stores the result there after loading
- `getCountrySignals()` counts non-normal clusters matching the country code
- `thermalEscalations` added to `CountryBriefSignals` type, LLM context snapshot, and fallback brief text

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test:data` — 2118/2118 pass
- [ ] Open any conflict-zone country (Ukraine, North Korea) — country brief should mention thermal escalation clusters in context
- [ ] Verify panel cards now show max 2 badges, no confidence label, no asset list
- [ ] Verify summary bar hides zeros when all clusters are the same status