### PR TITLE
fix(wingbits): handle abbreviated ECS keys so FROM/TO route shows + remove duplicate label

### DIFF
--- a/server/worldmonitor/military/v1/get-wingbits-live-flight.ts
+++ b/server/worldmonitor/military/v1/get-wingbits-live-flight.ts
@@ -39,6 +39,7 @@ interface PlanespottersPhoto {
 }
 
 interface EcsFlightRaw {
+  // Full-name fields (details/enrichment endpoint)
   icao24?: string;
   callsign?: string;
   lat?: number;
@@ -55,23 +56,35 @@ interface EcsFlightRaw {
   on_ground?: boolean;
   lastSeen?: number;
   last_seen?: number;
+  // Abbreviated fields returned by the live position endpoint
+  h?: string;   // icao24
+  f?: string;   // callsign
+  la?: number;  // lat
+  lo?: number;  // lon
+  ab?: number;  // altitude (barometric, feet)
+  gs?: number;  // ground speed (knots)
+  tr?: number;  // track/heading (degrees)
+  rs?: number;  // vertical rate (ft/min)
+  og?: boolean; // on ground
+  ra?: string;  // last seen (ISO timestamp)
 }
 
 function mapEcsFlight(icao24: string, raw: EcsFlightRaw): WingbitsLiveFlight {
+  const lastSeenTs = raw.lastSeen ?? raw.last_seen ?? (raw.ra ? Math.floor(new Date(raw.ra).getTime() / 1000) : 0);
   return {
-    icao24,
-    callsign: raw.callsign ?? '',
-    lat: raw.lat ?? 0,
-    lon: raw.lon ?? 0,
-    altitude: raw.altitude ?? 0,
-    speed: raw.speed ?? 0,
-    heading: raw.heading ?? 0,
-    verticalRate: raw.verticalRate ?? raw.vertical_rate ?? 0,
+    icao24: raw.icao24 ?? raw.h ?? icao24,
+    callsign: raw.callsign ?? raw.f ?? '',
+    lat: raw.lat ?? raw.la ?? 0,
+    lon: raw.lon ?? raw.lo ?? 0,
+    altitude: raw.altitude ?? raw.ab ?? 0,
+    speed: raw.speed ?? raw.gs ?? 0,
+    heading: raw.heading ?? raw.tr ?? 0,
+    verticalRate: raw.verticalRate ?? raw.vertical_rate ?? raw.rs ?? 0,
     registration: raw.registration ?? '',
     model: raw.model ?? '',
     operator: raw.operator ?? '',
-    onGround: raw.onGround ?? raw.on_ground ?? false,
-    lastSeen: String(raw.lastSeen ?? raw.last_seen ?? 0),
+    onGround: raw.onGround ?? raw.on_ground ?? raw.og ?? false,
+    lastSeen: String(lastSeenTs),
     // Schedule fields — populated later by fetchSchedule
     depIata: '', arrIata: '', depTimeUtc: '', arrTimeUtc: '',
     depEstimatedUtc: '', arrEstimatedUtc: '', depDelayedMin: 0,

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -939,9 +939,7 @@ export class MapPopup {
 
       const statsHtml = rows.length > 0 ? `<div class="popup-stats">${rows.join('')}</div>` : '';
       section.innerHTML = `
-        <div class="popup-section-label" style="font-size:10px;opacity:0.5;text-transform:uppercase;letter-spacing:.05em;margin-top:8px">
-          <a href="https://wingbits.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">wingbits.com</a>
-        </div>
+        <div class="popup-section-label" style="font-size:10px;opacity:0.5;text-transform:uppercase;letter-spacing:.05em;margin-top:8px">Live Data</div>
         ${parts.join('')}
         ${statsHtml}
       `;


### PR DESCRIPTION
## Why this PR?

Two bugs in the Wingbits flight popup introduced in #1947:

1. **FROM/TO route never showed** — The ECS live endpoint (`/v1/flights/{icao24}`) returns abbreviated JSON keys (`f`, `la`, `lo`, `ab`, `gs`, `tr`, `rs`, `og`, `h`, `ra`) but `EcsFlightRaw` only declared full-name keys (`callsign`, `lat`, `lon` etc.). Every live fetch resolved `callsign` to `''`, which caused the schedule lookup (`/v1/flights/schedule/{callsign}`) to be skipped silently, leaving `depIata`/`arrIata` blank.

2. **Two "wingbits.com" labels** — The section header in `loadWingbitsLiveFlight` rendered a `wingbits.com` link, but the SOURCE field row already shows `wingbits.com` via `formatPositionSource`. Replaced header with neutral "Live Data" label.

## Changes

- `server/worldmonitor/military/v1/get-wingbits-live-flight.ts`: add abbreviated key aliases to `EcsFlightRaw` (`h`, `f`, `la`, `lo`, `ab`, `gs`, `tr`, `rs`, `og`, `ra`) and update `mapEcsFlight` to coalesce short keys before long keys. Also parse ISO timestamp in `ra` field when numeric `lastSeen`/`last_seen` are absent.
- `src/components/MapPopup.ts`: replace `wingbits.com` anchor in section header with plain "Live Data" text.

## Test plan

- [ ] Open a military aircraft popup for a flight tracked by Wingbits (e.g. ICAO 4bbd04 / TKJ609)
- [ ] Confirm FROM/TO route (ESB → JED) and scheduled times appear
- [ ] Confirm only one "wingbits.com" link appears (in SOURCE row, not also as section header)
- [ ] Confirm plane photo still loads