### PR TITLE
fix(wingbits): guard ra timestamp parse against invalid date strings

### DIFF
--- a/server/worldmonitor/military/v1/get-wingbits-live-flight.ts
+++ b/server/worldmonitor/military/v1/get-wingbits-live-flight.ts
@@ -70,7 +70,8 @@ interface EcsFlightRaw {
 }
 
 function mapEcsFlight(icao24: string, raw: EcsFlightRaw): WingbitsLiveFlight {
-  const lastSeenTs = raw.lastSeen ?? raw.last_seen ?? (raw.ra ? Math.floor(new Date(raw.ra).getTime() / 1000) : 0);
+  const raTsMs = raw.ra ? new Date(raw.ra).getTime() : Number.NaN;
+  const lastSeenTs = raw.lastSeen ?? raw.last_seen ?? (Number.isFinite(raTsMs) ? Math.floor(raTsMs / 1000) : 0);
   return {
     icao24: raw.icao24 ?? raw.h ?? icao24,
     callsign: raw.callsign ?? raw.f ?? '',


### PR DESCRIPTION
## Why this PR?

Follow-up to #1954. The `ra` field (ISO timestamp from the ECS abbreviated endpoint) was parsed as:

```ts
const lastSeenTs = raw.lastSeen ?? raw.last_seen ?? (raw.ra ? Math.floor(new Date(raw.ra).getTime() / 1000) : 0);
```

The `raw.ra ?` guard only checks truthiness, not date validity. If the API ever returns a non-ISO string, `new Date(raw.ra).getTime()` returns `NaN`, `Math.floor(NaN)` stays `NaN`, and `String(NaN)` produces `"NaN"` as the `lastSeen` proto field, which silently propagates to the frontend.

## Fix

Validate with `Number.isFinite` before using the parsed timestamp:

```ts
const raTsMs = raw.ra ? new Date(raw.ra).getTime() : Number.NaN;
const lastSeenTs = raw.lastSeen ?? raw.last_seen ?? (Number.isFinite(raTsMs) ? Math.floor(raTsMs / 1000) : 0);
```

Falls back to `0` (the safe default) for any unparseable value.

## Test plan

- [ ] Verify popup still shows correct last-seen timestamps for tracked flights
- [ ] No `"NaN"` values in `lastSeen` field under any API response shape