### PR TITLE
fix(panels): wire consumer-prices loading + fix bigmac/grocery UI (reviewed)

### DIFF
--- a/src/components/BigMacPanel.ts
+++ b/src/components/BigMacPanel.ts
@@ -38,16 +38,17 @@ export class BigMacPanel extends Panel {
     }
 
     const sorted = [...data.countries]
-      .filter(c => c.usdPrice)
-      .sort((a, b) => (b.usdPrice ?? 0) - (a.usdPrice ?? 0));
+      .filter((c): c is typeof c & { usdPrice: number } => c.usdPrice != null && c.usdPrice > 0)
+      .sort((a, b) => b.usdPrice - a.usdPrice);
+
+    const maxCode = sorted[0]?.code;
+    const minCode = sorted[sorted.length - 1]?.code;
 
     const rows = sorted.map(c => {
-      const isHigh = c.code === data.mostExpensiveCountry;
-      const isLow = c.code === data.cheapestCountry;
-      const cls = isLow ? 'gb-cheapest' : isHigh ? 'gb-priciest' : '';
+      const cls = c.code === minCode ? 'gb-cheapest' : c.code === maxCode ? 'gb-priciest' : '';
       return `<tr>
         <td class="gb-item-name">${escapeHtml(c.flag)} ${escapeHtml(c.name)}</td>
-        <td class="gb-cell ${cls}">$${(c.usdPrice ?? 0).toFixed(2)}</td>
+        <td class="gb-cell ${cls}">$${c.usdPrice.toFixed(2)}</td>
       </tr>`;
     }).join('');
 

--- a/src/components/ConsumerPricesPanel.ts
+++ b/src/components/ConsumerPricesPanel.ts
@@ -130,7 +130,7 @@ export class ConsumerPricesPanel extends Panel {
     if (rangeBtn?.dataset.range) {
       this.settings.range = rangeBtn.dataset.range as PanelSettings['range'];
       saveSettings(this.settings);
-      this.loadData();
+      void this.fetchData();
       return;
     }
 
@@ -142,11 +142,7 @@ export class ConsumerPricesPanel extends Panel {
     }
   }
 
-  public fetchData(): Promise<void> {
-    return this.loadData();
-  }
-
-  public async loadData(): Promise<void> {
+  public async fetchData(): Promise<void> {
     if (this.loading) return;
     this.loading = true;
     this.showLoading();
@@ -160,6 +156,8 @@ export class ConsumerPricesPanel extends Panel {
       fetchRetailerPriceSpreads(market, basket),
       fetchConsumerPriceFreshness(market),
     ]);
+
+    if (!this.element?.isConnected) { this.loading = false; return; }
 
     this.overview = overview;
     this.categories = categories;

--- a/src/components/GroceryBasketPanel.ts
+++ b/src/components/GroceryBasketPanel.ts
@@ -46,21 +46,21 @@ export class GroceryBasketPanel extends Panel {
 
     const rows = itemIds.map(itemId => {
       const firstItem = countries[0]?.items?.find(i => i.itemId === itemId);
-      // Compute per-item min/max USD across countries that have data
-      const available = countries
-        .map(c => ({ code: c.code, usd: c.items?.find(i => i.itemId === itemId)?.usdPrice }))
-        .filter(x => x.usd);
-      const prices = available.map(x => x.usd as number);
-      const rowMin = prices.length ? Math.min(...prices) : null;
-      const rowMax = prices.length ? Math.max(...prices) : null;
+      // Per-item min/max USD: only countries with real data, type-safe filter
+      const prices = countries
+        .map(c => c.items?.find(i => i.itemId === itemId)?.usdPrice)
+        .filter((p): p is number => p != null && p > 0);
+      const rowMin = prices.length > 1 ? Math.min(...prices) : null;
+      const rowMax = prices.length > 1 ? Math.max(...prices) : null;
+      const eps = 0.001;
 
       const cells = countries.map(country => {
         const item = country.items?.find(i => i.itemId === itemId);
         if (!item?.available || !item.usdPrice || !item.localPrice) {
           return `<td class="gb-cell gb-na">—</td>`;
         }
-        const isHigh = rowMax !== null && item.usdPrice === rowMax && prices.length > 1;
-        const isLow = rowMin !== null && item.usdPrice === rowMin && prices.length > 1;
+        const isHigh = rowMax !== null && Math.abs(item.usdPrice - rowMax) < eps;
+        const isLow = rowMin !== null && Math.abs(item.usdPrice - rowMin) < eps;
         const cls = isLow ? 'gb-cheapest' : isHigh ? 'gb-priciest' : '';
         return `<td class="gb-cell ${cls}">$${item.usdPrice.toFixed(2)}<span class="gb-local">${item.localPrice.toFixed(2)} ${escapeHtml(country.currency)}</span></td>`;
       }).join('');


### PR DESCRIPTION
Supersedes #1951. All code review findings addressed.

## Changes

### Consumer Prices — stuck on Loading forever (root cause fix)
`ConsumerPricesPanel` used `loadData()` but the Panel lifecycle only calls `fetchData()`. Panel was created but spinner never cleared.
- Consolidated `loadData()` into `fetchData()` (remove the two-method split)
- Added `isConnected` guard after `Promise.all` (defensive: avoid rendering detached element if panel removed mid-fetch)
- Wired `primeTask('consumer-prices', ...)` into `App.ts`

### Big Mac Index
- Filter countries without price data so no `—` rows appear
- Compute `maxCode`/`minCode` locally from the filtered+sorted array — server-side `mostExpensiveCountry`/`cheapestCountry` may reference filtered-out countries, causing no row to get green/red
- Type-safe predicate filter `(c): c is ... => c.usdPrice != null && c.usdPrice > 0`
- Removed dead `?? 0` fallback (unreachable after filter)
- Removed Local price column (confusing alongside USD normalization)

### Grocery Index  
- Per-row red/green: highest price per item is red, lowest is green (was using basket-level `mostExpensiveCountry` → always same country column)
- Type-safe predicate filter on prices array (removes `as number` cast)
- Removed dead `code` property from intermediate prices array
- Epsilon comparison (`Math.abs(a - b) < 0.001`) for float equality instead of `===`
- Moved `prices.length > 1` guard into `rowMin`/`rowMax` derivation (not repeated per cell)

## Test plan
- [ ] Consumer Prices loads (no eternal spinner)
- [ ] Big Mac Index shows only countries with price data, no `—` rows, no Local column, correct green/red on cheapest/priciest
- [ ] Grocery Index: each item row has its own cheapest (green) and priciest (red) country cell