### PR TITLE
fix(cyber): load APT groups when cyberThreats already on at init

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -510,6 +510,10 @@ export class DeckGLMap {
     if (this.state.layers.weatherRadar) {
       this.startWeatherRadar();
     }
+    // Kick off lazy APT load if cyberThreats is already on at init (e.g. from URL/localStorage)
+    if (this.state.layers.cyberThreats && SITE_VARIANT !== 'tech' && SITE_VARIANT !== 'happy') {
+      this.loadAptGroups();
+    }
   }
 
   private startDayNightTimer(): void {

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -224,6 +224,11 @@ export class MapComponent {
       this.render();
     };
     window.addEventListener('theme-changed', this.handleThemeChange);
+
+    // Kick off lazy APT load if cyberThreats is already on at init (e.g. from URL/localStorage)
+    if (this.state.layers.cyberThreats && SITE_VARIANT !== 'tech' && SITE_VARIANT !== 'happy') {
+      this.loadAptGroups();
+    }
   }
 
   private setupResizeObserver(): void {


### PR DESCRIPTION
## Summary

- **Bug**: APT groups (159 MITRE ATT&CK markers from PR #1869) never appeared when the map booted with `cyberThreats` already enabled via URL params or localStorage
- **Root cause**: `setLayers()` guards the lazy-load with `!prevCyber`, but `prevCyber` is read from `this.state.layers.cyberThreats` which the constructor already sets to `true` from `initialState` — so the condition is always false and `loadAptGroups()` never fires
- **Fix**: Mirror the `weatherRadar` pattern — call `loadAptGroups()` in the constructor if `cyberThreats` is initially enabled. Applied to both `DeckGLMap.ts` and `Map.ts`

The toggle on/off path (`setLayers()` guard) continues to work correctly for users who enable the layer after load.

## Test plan

- [ ] Navigate to `https://worldmonitor.app/?layers=cyberThreats` — APT group orange markers should appear on load without toggling
- [ ] Enable `cyberThreats` toggle from off state — markers appear correctly (existing path still works)
- [ ] Reload with saved preferences containing `cyberThreats: true` — markers load on boot
- [ ] Verify tech and happy variants still exclude APT markers even if `cyberThreats` is enabled