### PR TITLE
fix(wingbits): move photo to bottom, taller popup, fix Sched/Est labels

### DIFF
--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -883,14 +883,15 @@ export class MapPopup {
       }
 
       const parts: string[] = [];
+      let photoHtml = '';
 
-      // Photo — sanitizeUrl validates scheme, preventing javascript: injection in img src
+      // Photo — built separately so it renders at the bottom after route/times/stats
       if (live.photoUrl) {
         const photoSrc = sanitizeUrl(live.photoUrl);
         if (photoSrc) {
           const photoLink = live.photoLink ? sanitizeUrl(live.photoLink) : '#';
           const credit = live.photoCredit ? `<span class="flight-photo-credit">\u00a9 ${escapeHtml(live.photoCredit)}</span>` : '';
-          parts.push(`<div class="flight-photo"><a href="${photoLink}" target="_blank" rel="noopener"><img src="${photoSrc}" alt="${escapeHtml(live.callsign)}" loading="lazy" style="width:100%;border-radius:4px;display:block"></a>${credit}</div>`);
+          photoHtml = `<div class="flight-photo"><a href="${photoLink}" target="_blank" rel="noopener"><img src="${photoSrc}" alt="${escapeHtml(live.callsign)}" loading="lazy" style="width:100%;border-radius:4px;display:block"></a>${credit}</div>`;
         }
       }
 
@@ -932,7 +933,7 @@ export class MapPopup {
       if (live.operator) rows.push(`<div class="popup-stat"><span class="stat-label">Operator</span><span class="stat-value">${escapeHtml(live.operator)}</span></div>`);
       if (live.verticalRate !== 0) rows.push(`<div class="popup-stat"><span class="stat-label">Climb</span><span class="stat-value">${live.verticalRate > 0 ? '+' : ''}${Math.round(live.verticalRate)} fpm</span></div>`);
 
-      if (parts.length === 0 && rows.length === 0) {
+      if (parts.length === 0 && rows.length === 0 && !photoHtml) {
         section.innerHTML = '';
         return;
       }
@@ -942,6 +943,7 @@ export class MapPopup {
         <div class="popup-section-label" style="font-size:10px;opacity:0.5;text-transform:uppercase;letter-spacing:.05em;margin-top:8px">Live Data</div>
         ${parts.join('')}
         ${statsHtml}
+        ${photoHtml}
       `;
     } catch {
       if (section.isConnected) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1986,6 +1986,8 @@
       "h3Hex": "H3 Hex"
     },
     "flight": {
+      "scheduled": "Sched",
+      "estimated": "Est",
       "groundStop": "GROUND STOP",
       "groundDelay": "GROUND DELAY PROGRAM",
       "departureDelay": "DEPARTURE DELAYS",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -6725,7 +6725,7 @@ a.prediction-link:hover {
 .map-popup {
   position: fixed;
   width: 360px;
-  max-height: 380px;
+  max-height: min(560px, 80vh);
   background: var(--bg);
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 6px;
@@ -11989,7 +11989,7 @@ a.prediction-link:hover {
   /* Map popup positioning for mobile - ensure it's visible */
   .map-popup {
     max-width: calc(100vw - 32px);
-    max-height: 60vh;
+    max-height: 75vh;
     overflow-y: auto;
   }
 


### PR DESCRIPTION
## Why this PR?

Three UX issues with the Wingbits live data section in the flight popup:

1. **Photo at top hid route/times behind scroll** — The aircraft photo rendered first, pushing LHR→MLE route and scheduled/estimated times off screen. Users had to scroll to see the most useful info. Photo moved to the bottom of the section so route, times, and stats are immediately visible.

2. **Popup too short** — Desktop popup was capped at `380px` max-height, not enough to show photo + route + times without scrolling. Increased to `min(560px, 80vh)` (desktop) and `75vh` (mobile responsive breakpoint). The sheet variant on mobile already uses `min(72vh, ...)`.

3. **`Sched`/`Est` row labels showed raw i18n keys** — `t('popups.flight.scheduled')` and `t('popups.flight.estimated')` were not present in `src/locales/en.json`, so i18next returned the key string verbatim (`popups.flight.scheduled`). The `|| 'Sched'` fallback never fired because the key string is truthy. Added both keys to the en locale.

## Changes

- `src/components/MapPopup.ts`: extract photo into `photoHtml` variable, append it after route/times/stats
- `src/styles/main.css`: `max-height: 380px` → `min(560px, 80vh)` (desktop), `60vh` → `75vh` (mobile)
- `src/locales/en.json`: add `popups.flight.scheduled: "Sched"` and `popups.flight.estimated: "Est"`

## Test plan

- [ ] Open Wingbits-enriched flight popup (e.g. BAW61 / 406a34)
- [ ] Route (LHR → MLE) and scheduled times visible without scrolling
- [ ] Photo visible at the bottom of the Live Data section
- [ ] "Sched" and "Est" labels show correctly (not raw key strings)
- [ ] Popup fits full content on desktop without feeling too large