### PR TITLE
fix(relay): copy data/ into Docker image for telegram-channels.json

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -21,6 +21,9 @@ COPY scripts/ais-relay.cjs ./scripts/ais-relay.cjs
 # Shared helper required by the relay (rss-allowed-domains.cjs)
 COPY shared/ ./shared/
 
+# Data files required by the relay (telegram-channels.json, etc.)
+COPY data/ ./data/
+
 EXPOSE 3004
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \


### PR DESCRIPTION
## Problem

After #1950 fixed the missing `telegram` package, the relay now reports:
```
"lastError": "failed to load telegram-channels.json: ENOENT: no such file or directory, open '/app/data/telegram-channels.json'"
```

`ais-relay.cjs` loads channel config via:
```js
path.join(__dirname, '..', 'data', 'telegram-channels.json')
```

But `data/` was never copied into the Docker image.

## Fix

Add `COPY data/ ./data/` to `Dockerfile.relay`. The directory contains only 3 JSON files (telegram-channels, gamma-irradiators).

## Test plan
- [ ] Relay rebuilds and `/health` shows `telegram.lastError: null`
- [ ] Telegram Intel panel shows messages after first poll cycle (~60s startup delay)