### PR TITLE
fix(economic): expand bigmac to global, add panel CSS, improve consumer prices empty state

### DIFF
--- a/scripts/seed-bigmac.mjs
+++ b/scripts/seed-bigmac.mjs
@@ -9,30 +9,84 @@ const CACHE_TTL = 86400; // 24h — Big Mac prices change rarely
 const EXA_DELAY_MS = 150;
 
 const FX_FALLBACKS = {
+  // Middle East
   AED: 0.2723, SAR: 0.2666, QAR: 0.2747, KWD: 3.2520,
   BHD: 2.6525, OMR: 2.5974, JOD: 1.4104, EGP: 0.0204, LBP: 0.0000112,
+  // Major currencies
+  USD: 1.0000, GBP: 1.2700, EUR: 1.0850, JPY: 0.0067, CHF: 1.1300,
+  CNY: 0.1380, INR: 0.0120, AUD: 0.6500, CAD: 0.7400, NZD: 0.5900,
+  BRL: 0.1900, MXN: 0.0490, ZAR: 0.0540, TRY: 0.0290, KRW: 0.0007,
+  SGD: 0.7400, HKD: 0.1280, TWD: 0.0310, THB: 0.0280, IDR: 0.000063,
+  NOK: 0.0920, SEK: 0.0930, DKK: 0.1450, PLN: 0.2450, CZK: 0.0430,
+  HUF: 0.0028, RON: 0.2200, PHP: 0.0173, VND: 0.000040, MYR: 0.2250,
+  PKR: 0.0036, ILS: 0.2750, ARS: 0.00084, COP: 0.000240, CLP: 0.00108,
+  UAH: 0.0240, NGN: 0.00062, KES: 0.0077,
 };
 
 const COUNTRIES = [
-  { code: 'AE', name: 'UAE',          currency: 'AED', flag: '🇦🇪' },
-  { code: 'SA', name: 'Saudi Arabia', currency: 'SAR', flag: '🇸🇦' },
-  { code: 'QA', name: 'Qatar',        currency: 'QAR', flag: '🇶🇦' },
-  { code: 'KW', name: 'Kuwait',       currency: 'KWD', flag: '🇰🇼' },
-  { code: 'BH', name: 'Bahrain',      currency: 'BHD', flag: '🇧🇭' },
-  { code: 'OM', name: 'Oman',         currency: 'OMR', flag: '🇴🇲' },
-  { code: 'EG', name: 'Egypt',        currency: 'EGP', flag: '🇪🇬' },
-  { code: 'JO', name: 'Jordan',       currency: 'JOD', flag: '🇯🇴' },
-  { code: 'LB', name: 'Lebanon',      currency: 'LBP', flag: '🇱🇧' },
+  // Americas
+  { code: 'US', name: 'United States', currency: 'USD', flag: '🇺🇸' },
+  { code: 'CA', name: 'Canada',        currency: 'CAD', flag: '🇨🇦' },
+  { code: 'MX', name: 'Mexico',        currency: 'MXN', flag: '🇲🇽' },
+  { code: 'BR', name: 'Brazil',        currency: 'BRL', flag: '🇧🇷' },
+  { code: 'AR', name: 'Argentina',     currency: 'ARS', flag: '🇦🇷' },
+  { code: 'CO', name: 'Colombia',      currency: 'COP', flag: '🇨🇴' },
+  { code: 'CL', name: 'Chile',         currency: 'CLP', flag: '🇨🇱' },
+  // Europe
+  { code: 'GB', name: 'UK',            currency: 'GBP', flag: '🇬🇧' },
+  { code: 'DE', name: 'Germany',       currency: 'EUR', flag: '🇩🇪' },
+  { code: 'FR', name: 'France',        currency: 'EUR', flag: '🇫🇷' },
+  { code: 'IT', name: 'Italy',         currency: 'EUR', flag: '🇮🇹' },
+  { code: 'ES', name: 'Spain',         currency: 'EUR', flag: '🇪🇸' },
+  { code: 'CH', name: 'Switzerland',   currency: 'CHF', flag: '🇨🇭' },
+  { code: 'NO', name: 'Norway',        currency: 'NOK', flag: '🇳🇴' },
+  { code: 'SE', name: 'Sweden',        currency: 'SEK', flag: '🇸🇪' },
+  { code: 'DK', name: 'Denmark',       currency: 'DKK', flag: '🇩🇰' },
+  { code: 'PL', name: 'Poland',        currency: 'PLN', flag: '🇵🇱' },
+  { code: 'CZ', name: 'Czechia',       currency: 'CZK', flag: '🇨🇿' },
+  { code: 'HU', name: 'Hungary',       currency: 'HUF', flag: '🇭🇺' },
+  { code: 'RO', name: 'Romania',       currency: 'RON', flag: '🇷🇴' },
+  { code: 'UA', name: 'Ukraine',       currency: 'UAH', flag: '🇺🇦' },
+  // Asia-Pacific
+  { code: 'CN', name: 'China',         currency: 'CNY', flag: '🇨🇳' },
+  { code: 'JP', name: 'Japan',         currency: 'JPY', flag: '🇯🇵' },
+  { code: 'KR', name: 'South Korea',   currency: 'KRW', flag: '🇰🇷' },
+  { code: 'AU', name: 'Australia',     currency: 'AUD', flag: '🇦🇺' },
+  { code: 'NZ', name: 'New Zealand',   currency: 'NZD', flag: '🇳🇿' },
+  { code: 'SG', name: 'Singapore',     currency: 'SGD', flag: '🇸🇬' },
+  { code: 'HK', name: 'Hong Kong',     currency: 'HKD', flag: '🇭🇰' },
+  { code: 'TW', name: 'Taiwan',        currency: 'TWD', flag: '🇹🇼' },
+  { code: 'TH', name: 'Thailand',      currency: 'THB', flag: '🇹🇭' },
+  { code: 'MY', name: 'Malaysia',      currency: 'MYR', flag: '🇲🇾' },
+  { code: 'ID', name: 'Indonesia',     currency: 'IDR', flag: '🇮🇩' },
+  { code: 'PH', name: 'Philippines',   currency: 'PHP', flag: '🇵🇭' },
+  { code: 'VN', name: 'Vietnam',       currency: 'VND', flag: '🇻🇳' },
+  { code: 'IN', name: 'India',         currency: 'INR', flag: '🇮🇳' },
+  { code: 'PK', name: 'Pakistan',      currency: 'PKR', flag: '🇵🇰' },
+  // Middle East
+  { code: 'AE', name: 'UAE',           currency: 'AED', flag: '🇦🇪' },
+  { code: 'SA', name: 'Saudi Arabia',  currency: 'SAR', flag: '🇸🇦' },
+  { code: 'QA', name: 'Qatar',         currency: 'QAR', flag: '🇶🇦' },
+  { code: 'KW', name: 'Kuwait',        currency: 'KWD', flag: '🇰🇼' },
+  { code: 'BH', name: 'Bahrain',       currency: 'BHD', flag: '🇧🇭' },
+  { code: 'OM', name: 'Oman',          currency: 'OMR', flag: '🇴🇲' },
+  { code: 'EG', name: 'Egypt',         currency: 'EGP', flag: '🇪🇬' },
+  { code: 'JO', name: 'Jordan',        currency: 'JOD', flag: '🇯🇴' },
+  { code: 'LB', name: 'Lebanon',       currency: 'LBP', flag: '🇱🇧' },
+  { code: 'IL', name: 'Israel',        currency: 'ILS', flag: '🇮🇱' },
+  // Africa
+  { code: 'ZA', name: 'South Africa',  currency: 'ZAR', flag: '🇿🇦' },
+  { code: 'NG', name: 'Nigeria',       currency: 'NGN', flag: '🇳🇬' },
+  { code: 'KE', name: 'Kenya',         currency: 'KES', flag: '🇰🇪' },
 ];
 
-const FX_SYMBOLS = {
-  AED: 'AEDUSD=X', SAR: 'SARUSD=X', QAR: 'QARUSD=X', KWD: 'KWDUSD=X',
-  BHD: 'BHDUSD=X', OMR: 'OMRUSD=X', EGP: 'EGPUSD=X', JOD: 'JODUSD=X', LBP: 'LBPUSD=X',
-};
+const FX_SYMBOLS = Object.fromEntries(
+  [...new Set(COUNTRIES.map(c => c.currency))].map(ccy => [ccy, `${ccy}USD=X`])
+);
 
-// Handle both plain numbers and thousands-separated (480,000 LBP)
+// Handle both plain numbers and thousands-separated (480,000 LBP or 12,000 KRW)
 const NUM = '\\d{1,3}(?:[,\\s]\\d{3})*(?:\\.\\d{1,3})?';
-const CCY = 'AED|SAR|QAR|KWD|BHD|OMR|EGP|JOD|LBP|USD';
+const CCY = 'USD|GBP|EUR|JPY|CHF|CNY|INR|AUD|CAD|NZD|BRL|MXN|ZAR|TRY|KRW|SGD|HKD|TWD|THB|IDR|NOK|SEK|DKK|PLN|CZK|HUF|RON|PHP|VND|MYR|PKR|ILS|ARS|COP|CLP|UAH|NGN|KES|AED|SAR|QAR|KWD|BHD|OMR|EGP|JOD|LBP';
 const PRICE_PATTERNS = [
   new RegExp(`(${NUM})\\s*(${CCY})`, 'i'),
   new RegExp(`(${CCY})\\s*(${NUM})`, 'i'),

--- a/src/components/ConsumerPricesPanel.ts
+++ b/src/components/ConsumerPricesPanel.ts
@@ -197,9 +197,25 @@ export class ConsumerPricesPanel extends Panel {
       </div>
     `;
 
-    let bodyHtml = '';
     const noData = this.overview?.upstreamUnavailable;
 
+    // When seed hasn't run yet, show a single full-panel placeholder instead
+    // of the ugly "No price data available yet" text inside each tab body
+    if (noData) {
+      this.setContent(`
+        <div class="consumer-prices-panel">
+          ${tabsHtml}
+          <div class="cp-body cp-seeding-state">
+            <div class="cp-seeding-icon">📊</div>
+            <div class="cp-seeding-title">Data collection in progress</div>
+            <div class="cp-seeding-sub">Retail prices are being aggregated — check back in a few hours.</div>
+          </div>
+        </div>
+      `);
+      return;
+    }
+
+    let bodyHtml = '';
     switch (tab) {
       case 'overview':
         bodyHtml = this.renderOverview();
@@ -223,7 +239,6 @@ export class ConsumerPricesPanel extends Panel {
     this.setContent(`
       <div class="consumer-prices-panel">
         ${tabsHtml}
-        ${noData && tab === 'overview' ? '<div class="cp-upstream-warn">Data collection starting — check back soon</div>' : ''}
         <div class="cp-body">${bodyHtml}</div>
       </div>
     `);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -20511,3 +20511,330 @@ body.has-breaking-alert .panels-grid {
   color: var(--accent);
   font-variant-numeric: tabular-nums;
 }
+
+/* ── Consumer Prices Panel ─────────────────────────────────────────────── */
+.consumer-prices-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.cp-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.cp-seeding-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 40px 16px;
+  text-align: center;
+  min-height: 200px;
+}
+
+.cp-seeding-icon {
+  font-size: 2rem;
+  opacity: 0.7;
+}
+
+.cp-seeding-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary, #e0e0e0);
+}
+
+.cp-seeding-sub {
+  font-size: 0.75rem;
+  color: var(--text-muted, #888);
+  max-width: 240px;
+  line-height: 1.5;
+}
+
+.cp-empty-state {
+  padding: 24px 16px;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--text-muted, #888);
+}
+
+.cp-filter-bar {
+  display: flex;
+  gap: 4px;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+
+.cp-range-btn {
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.cp-range-btn.active {
+  background: var(--overlay-subtle);
+  color: var(--text-primary, #e0e0e0);
+}
+
+.cp-section-label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+  margin: 10px 0 4px;
+}
+
+.cp-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.cp-stat-card {
+  padding: 8px;
+  border: 1px solid var(--border);
+  background: var(--overlay-subtle);
+}
+
+.cp-stat-label {
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.cp-stat-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary, #e0e0e0);
+  font-variant-numeric: tabular-nums;
+}
+
+.cp-stat-sub {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+}
+
+.cp-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-variant-numeric: tabular-nums;
+}
+.cp-badge--green { background: rgba(34,197,94,0.15); color: #4ade80; }
+.cp-badge--red   { background: rgba(239,68,68,0.15);  color: #f87171; }
+.cp-badge--neutral { background: var(--overlay-subtle); color: var(--text-dim); }
+
+.cp-pressure {
+  display: inline-block;
+  font-size: 0.65rem;
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+.cp-pressure--steady  { background: rgba(148,163,184,0.15); color: #94a3b8; }
+.cp-pressure--watch   { background: rgba(245,158,11,0.15);  color: #fbbf24; }
+.cp-pressure--stress  { background: rgba(239,68,68,0.15);   color: #f87171; }
+.cp-pressure--green   { background: rgba(34,197,94,0.15);   color: #4ade80; }
+
+.cp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.75rem;
+}
+
+.cp-table th, .cp-table td {
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+.cp-col-header { cursor: pointer; }
+.cp-col-header--up::after   { content: ' ↑'; }
+.cp-col-header--down::after { content: ' ↓'; }
+
+.cp-cat-row { cursor: pointer; }
+.cp-cat-row:hover { background: var(--overlay-subtle); }
+.cp-cat-name { font-weight: 500; }
+.cp-cat-spark { width: 60px; }
+.cp-empty-col { text-align: center; color: var(--text-dim); }
+
+.cp-category-mini { padding: 4px 8px; }
+.cp-cat-mini-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 0;
+  font-size: 0.72rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.cp-movers-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.cp-movers-col > .cp-section-label { margin-top: 4px; }
+
+.cp-mover-row {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.72rem;
+}
+
+.cp-mover-title { font-weight: 500; color: var(--text-primary, #e0e0e0); }
+.cp-mover-meta  { color: var(--text-dim); font-size: 0.65rem; }
+.cp-mover-cat, .cp-mover-retailer { font-size: 0.65rem; color: var(--text-dim); }
+.cp-mover-pct   { font-weight: 600; font-variant-numeric: tabular-nums; }
+.cp-mover-row--up   .cp-mover-pct { color: #f87171; }
+.cp-mover-row--down .cp-mover-pct { color: #4ade80; }
+
+.cp-spread-list { display: flex; flex-direction: column; gap: 4px; }
+
+.cp-spread-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 6px;
+  border: 1px solid var(--border);
+  font-size: 0.72rem;
+}
+
+.cp-spread-row--cheapest { border-color: rgba(34,197,94,0.3); background: rgba(34,197,94,0.06); }
+
+.cp-spread-rank  { font-size: 0.65rem; color: var(--text-dim); width: 18px; text-align: center; }
+.cp-spread-name  { flex: 1; font-weight: 500; }
+.cp-spread-basket { color: var(--text-dim); font-size: 0.65rem; }
+.cp-spread-total { font-variant-numeric: tabular-nums; font-weight: 600; }
+.cp-spread-delta { font-size: 0.65rem; font-variant-numeric: tabular-nums; }
+.cp-spread-items { font-size: 0.65rem; color: var(--text-dim); }
+.cp-spread-fresh { font-size: 0.6rem; color: var(--text-dim); }
+.cp-spread-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 6px 4px;
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.cp-stalled-badge {
+  font-size: 0.6rem;
+  padding: 1px 4px;
+  background: rgba(245,158,11,0.15);
+  color: #fbbf24;
+  border-radius: 2px;
+}
+
+.cp-health-summary { font-size: 0.75rem; margin-bottom: 8px; color: var(--text-dim); }
+
+.cp-health-list { display: flex; flex-direction: column; gap: 3px; }
+
+.cp-health-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.72rem;
+}
+
+.cp-health-name   { flex: 1; }
+.cp-health-rate   { font-size: 0.65rem; color: var(--text-dim); font-variant-numeric: tabular-nums; }
+.cp-health-status { font-size: 0.65rem; padding: 1px 5px; border-radius: 3px; }
+.cp-health-status--ok      { background: rgba(34,197,94,0.15);  color: #4ade80; }
+.cp-health-status--stale   { background: rgba(245,158,11,0.15); color: #fbbf24; }
+.cp-health-status--missing { background: rgba(239,68,68,0.15);  color: #f87171; }
+
+.cp-range-bar {
+  display: flex;
+  gap: 4px;
+}
+
+/* ── Grocery Basket Panel ──────────────────────────────────────────────── */
+.gb-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.gb-scroll {
+  flex: 1;
+  overflow: auto;
+}
+
+.gb-table {
+  border-collapse: collapse;
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.gb-table th, .gb-table td {
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.gb-item-col { min-width: 100px; }
+
+.gb-country-header {
+  text-align: center;
+  font-size: 0.7rem;
+  min-width: 80px;
+  background: var(--overlay-subtle);
+}
+
+.gb-country-name { font-size: 0.6rem; display: block; }
+
+.gb-item-name {
+  font-weight: 500;
+  background: var(--overlay-subtle);
+  position: sticky;
+  left: 0;
+}
+
+.gb-unit {
+  display: block;
+  font-size: 0.6rem;
+  color: var(--text-dim);
+  font-weight: 400;
+}
+
+.gb-cell { text-align: right; font-variant-numeric: tabular-nums; }
+
+.gb-local {
+  display: block;
+  font-size: 0.6rem;
+  color: var(--text-dim);
+}
+
+.gb-na { text-align: center; color: var(--text-dim); }
+
+.gb-cheapest { background: rgba(34,197,94,0.12); color: #4ade80; }
+.gb-priciest { background: rgba(239,68,68,0.12);  color: #f87171; }
+
+.gb-total-row td { font-weight: 600; background: var(--overlay-subtle); }
+.gb-total { font-size: 0.8rem; }
+
+.gb-updated {
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  padding: 4px 8px;
+  text-align: right;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
## Summary

Follow-up to #1904 (merged).

- **BigMac global coverage**: `seed-bigmac.mjs` expanded from 9 ME-only countries to 50+ worldwide (Americas, Europe, Asia-Pacific, Middle East, Africa) — covers the full Economist Big Mac Index. `FX_SYMBOLS` now derived from the `COUNTRIES` array; extended `FX_FALLBACKS` and `CCY` regex to match.
- **Panel CSS**: `main.css` was missing all `cp-*` (ConsumerPricesPanel) and `gb-*` (GroceryBasketPanel) CSS classes. Added complete styles for both panels.
- **Consumer Prices empty state**: When `upstreamUnavailable: true` (seeder hasn't run yet), replaces bare unstyled text with a structured placeholder (icon + title + subtitle) inside the panel tabs layout.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run test:data` passes (2120 tests)
- [ ] `node --test tests/edge-functions.test.mjs` passes (119 tests)
- [ ] BigMac panel shows global countries after next seed run
- [ ] Consumer Prices panel shows styled seeding placeholder when data not yet available