### PR TITLE
fix(relay): install curl in Alpine image for OREF polling

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -9,6 +9,9 @@
 
 FROM node:22-alpine
 
+# curl required by OREF polling (Node.js JA3 fingerprint blocked by Akamai; curl passes)
+RUN apk add --no-cache curl
+
 WORKDIR /app
 
 # Install scripts/ runtime dependencies (telegram, ws, fast-xml-parser, etc.)


### PR DESCRIPTION
## Summary
- Adds `RUN apk add --no-cache curl` to `Dockerfile.relay`
- OREF siren alert polling uses `execFileSync('curl')` intentionally — Node.js fetch gets blocked by Akamai's JA3 TLS fingerprint detection on `oref.org.il`, but curl's fingerprint passes
- Alpine Linux does not include curl by default, causing `spawnSync curl ENOENT` on every OREF poll cycle (every ~30s in logs)

## Test plan
- [ ] After deploy: `curl https://proxy.worldmonitor.app/health | jq .oref` — `lastPollAt` should be non-null and `lastError` should clear
- [ ] No more `OREF poll error: spawnSync curl ENOENT` in Railway logs