### PR TITLE
fix(contact): route admin emails to elie.habib@gmail.com

### DIFF
--- a/api/contact.js
+++ b/api/contact.js
@@ -35,7 +35,7 @@ async function sendNotificationEmail(name, email, organization, phone, message) 
     console.error('[contact] RESEND_API_KEY not set — lead stored in Convex but notification NOT sent');
     return false;
   }
-  const notifyEmail = process.env.CONTACT_NOTIFY_EMAIL || 'sales@worldmonitor.app';
+  const notifyEmail = process.env.CONTACT_NOTIFY_EMAIL || 'elie.habib@gmail.com';
   const emailDomain = (email.split('@')[1] || '').toLowerCase();
   try {
     const res = await fetch('https://api.resend.com/emails', {

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,4 +1,4 @@
-Contact: mailto:elie@worldmonitor.app
+Contact: mailto:elie.habib@gmail.com
 Contact: https://github.com/eliehabib/worldmonitor/security/advisories
 Policy: https://github.com/eliehabib/worldmonitor/security/advisories
 Preferred-Languages: en


### PR DESCRIPTION
## Summary
- `api/contact.js`: hardcoded fallback changed from `sales@worldmonitor.app` → `elie.habib@gmail.com`
- `public/.well-known/security.txt`: contact address updated to match

## Action required after merge
If `CONTACT_NOTIFY_EMAIL` is set in the **Vercel dashboard** to `elie@worldmonitor.app`, update it to `elie.habib@gmail.com` there as well — the env var takes priority over the hardcoded fallback.

## Test plan
- [ ] Submit the enterprise contact form → notification arrives at elie.habib@gmail.com
- [ ] Verify `/.well-known/security.txt` shows updated contact address