### PR TITLE
feat(pro): consolidate pro tier — unlock panels with either wm-widget-key or wm-pro-key

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -70,7 +70,7 @@ import { trackCriticalBannerAction } from '@/services/analytics';
 import { getSecretState } from '@/services/runtime-config';
 import { CustomWidgetPanel } from '@/components/CustomWidgetPanel';
 import { openWidgetChatModal } from '@/components/WidgetChatModal';
-import { isWidgetFeatureEnabled, isProWidgetEnabled, loadWidgets, saveWidget } from '@/services/widget-store';
+import { isProUser, loadWidgets, saveWidget } from '@/services/widget-store';
 import type { CustomWidgetSpec } from '@/services/widget-store';
 import { McpDataPanel } from '@/components/McpDataPanel';
 import { openMcpConnectModal } from '@/components/McpConnectModal';
@@ -528,7 +528,7 @@ export class PanelLayoutManager implements AppModule {
     this.createPanel('heatmap', () => new HeatmapPanel());
     this.createPanel('markets', () => new MarketPanel());
     const stockAnalysisPanel = this.createPanel('stock-analysis', () => new StockAnalysisPanel());
-    if (stockAnalysisPanel && !getSecretState('WORLDMONITOR_API_KEY').present && !isProWidgetEnabled()) {
+    if (stockAnalysisPanel && !getSecretState('WORLDMONITOR_API_KEY').present && !isProUser()) {
       stockAnalysisPanel.showLocked([
         'AI stock briefs with technical + news synthesis',
         'Trend scoring from MA, MACD, RSI, and volume structure',
@@ -536,7 +536,7 @@ export class PanelLayoutManager implements AppModule {
       ]);
     }
     const stockBacktestPanel = this.createPanel('stock-backtest', () => new StockBacktestPanel());
-    if (stockBacktestPanel && !getSecretState('WORLDMONITOR_API_KEY').present && !isProWidgetEnabled()) {
+    if (stockBacktestPanel && !getSecretState('WORLDMONITOR_API_KEY').present && !isProUser()) {
       stockBacktestPanel.showLocked([
         'Historical replay of premium stock-analysis signals',
         'Win-rate, accuracy, and simulated-return metrics',
@@ -733,12 +733,12 @@ export class PanelLayoutManager implements AppModule {
     );
 
     const _wmKeyPresent = getSecretState('WORLDMONITOR_API_KEY').present;
-    const _lockPanels = this.ctx.isDesktopApp && !_wmKeyPresent;
+    const _lockPanels = this.ctx.isDesktopApp && !_wmKeyPresent && !isProUser();
 
     this.lazyPanel('daily-market-brief', () =>
       import('@/components/DailyMarketBriefPanel').then(m => new m.DailyMarketBriefPanel()),
       undefined,
-      (!_wmKeyPresent && !isProWidgetEnabled()) ? ['Pre-market watchlist priorities', 'Action plan for the session', 'Risk watch tied to current finance headlines'] : undefined,
+      (!_wmKeyPresent && !isProUser()) ? ['Pre-market watchlist priorities', 'Action plan for the session', 'Risk watch tied to current finance headlines'] : undefined,
     );
 
     this.lazyPanel('forecast', () =>
@@ -906,7 +906,7 @@ export class PanelLayoutManager implements AppModule {
       );
     }
 
-    if (isWidgetFeatureEnabled() || isProWidgetEnabled()) {
+    if (isProUser()) {
       for (const spec of loadWidgets()) {
         const panel = new CustomWidgetPanel(spec);
         this.ctx.panels[spec.id] = panel;
@@ -1022,7 +1022,7 @@ export class PanelLayoutManager implements AppModule {
     });
     panelsGrid.appendChild(addPanelBlock);
 
-    if (isWidgetFeatureEnabled()) {
+    if (isProUser()) {
       const aiBlock = document.createElement('button');
       aiBlock.className = 'add-panel-block ai-widget-block';
       aiBlock.setAttribute('aria-label', t('widgets.createWithAi'));
@@ -1044,7 +1044,7 @@ export class PanelLayoutManager implements AppModule {
       panelsGrid.appendChild(aiBlock);
     }
 
-    if (isProWidgetEnabled()) {
+    if (isProUser()) {
       const proBlock = document.createElement('button');
       proBlock.className = 'add-panel-block ai-widget-block ai-widget-block-pro';
       proBlock.setAttribute('aria-label', t('widgets.createInteractive'));

--- a/src/services/widget-store.ts
+++ b/src/services/widget-store.ts
@@ -119,6 +119,10 @@ export function isProWidgetEnabled(): boolean {
   }
 }
 
+export function isProUser(): boolean {
+  return isWidgetFeatureEnabled() || isProWidgetEnabled();
+}
+
 export function getProWidgetKey(): string {
   try {
     return localStorage.getItem('wm-pro-key') ?? '';

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -465,8 +465,8 @@ describe('panel guardrails — cw- prefix handling', () => {
 
   it('panel-layout loads widgets when feature is enabled', () => {
     assert.ok(
-      layout.includes('isWidgetFeatureEnabled'),
-      'panel-layout must check isWidgetFeatureEnabled before loading widgets',
+      layout.includes('isProUser'),
+      'panel-layout must check isProUser before loading widgets',
     );
     assert.ok(
       layout.includes('loadWidgets'),
@@ -481,12 +481,10 @@ describe('panel guardrails — cw- prefix handling', () => {
     );
   });
 
-  it('panel-layout AI button is gated by isWidgetFeatureEnabled', () => {
-    // The AI button creation should be inside an isWidgetFeatureEnabled block
-    const featureIdx = layout.indexOf('isWidgetFeatureEnabled');
+  it('panel-layout AI button is gated by isProUser', () => {
+    const featureIdx = layout.indexOf('isProUser');
     const buttonIdx = layout.indexOf('ai-widget-block');
-    // Button CSS class or AI text should appear after the feature check
-    assert.ok(featureIdx !== -1, 'isWidgetFeatureEnabled not found in panel-layout');
+    assert.ok(featureIdx !== -1, 'isProUser not found in panel-layout');
     assert.ok(buttonIdx !== -1, 'AI widget button not found in panel-layout');
   });
 
@@ -1207,10 +1205,10 @@ describe('PRO widget — modal and layout integration', () => {
     );
   });
 
-  it('layout has PRO create button when isProWidgetEnabled', () => {
+  it('layout has PRO create button when isProUser', () => {
     assert.ok(
-      layout.includes('isProWidgetEnabled'),
-      'panel-layout must import/call isProWidgetEnabled',
+      layout.includes('isProUser'),
+      'panel-layout must import/call isProUser',
     );
     assert.ok(
       layout.includes('ai-widget-block-pro'),


### PR DESCRIPTION
## Summary

- Add `isProUser()` helper in `widget-store.ts` that returns `true` if EITHER `wm-widget-key` OR `wm-pro-key` is present in localStorage
- Replace all scattered `isWidgetFeatureEnabled()` / `isProWidgetEnabled()` checks in `panel-layout.ts` with the unified `isProUser()`
- `daily-market-brief`, `stock-analysis`, `stock-backtest`, `forecast`, `oref-sirens`, `telegram-intel`, custom widget loading, and the Add with AI / Create Interactive buttons all now unlock with either key
- Desktop `_lockPanels` gate also respects web pro keys, so desktop users with a wm-widget-key or wm-pro-key see those panels unlocked
- Update static-analysis tests in `widget-builder.test.mjs` to match the new function name

## Test plan
- [ ] Set only `wm-widget-key` in localStorage — verify all pro panels unlock (daily-market-brief, stock-analysis, stock-backtest, Add with AI, Create Interactive)
- [ ] Set only `wm-pro-key` in localStorage — same panels unlock
- [ ] Remove both keys — panels revert to locked state
- [ ] `npm run test:data` passes (2118 pass, 0 fail)
- [ ] `npm run typecheck` passes clean