### PR TITLE
fix(tokens): add CoinPaprika fallback, runSeed wrapper, and Railway cron for token panels

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -45,6 +45,9 @@ const BOOTSTRAP_KEYS = {
   groceryBasket:     'economic:grocery-basket:v1',
   bigmac:            'economic:bigmac:v1',
   nationalDebt:      'economic:national-debt:v1',
+  defiTokens:        'market:defi-tokens:v1',
+  aiTokens:          'market:ai-tokens:v1',
+  otherTokens:       'market:other-tokens:v1',
 };
 
 const STANDALONE_KEYS = {
@@ -153,6 +156,7 @@ const SEED_META = {
   consumerPricesMovers:     { key: 'seed-meta:consumer-prices:movers:ae:30d',               maxStaleMin: 90 },
   consumerPricesSpread:     { key: 'seed-meta:consumer-prices:retailer-spread:ae:essentials-ae', maxStaleMin: 120 }, // TTL=60min; 2× interval
   consumerPricesFreshness:  { key: 'seed-meta:consumer-prices:freshness:ae',    maxStaleMin: 30  }, // TTL=10min; 3× interval
+  tokenPanels:       { key: 'seed-meta:market:token-panels',                   maxStaleMin: 90 }, // cron every 30min; 3× interval
 };
 
 // Standalone keys that are populated on-demand by RPC handlers (not seeds).

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1711,6 +1711,7 @@ async function seedCryptoSectors() {
 const _defiCfg = requireShared('defi-tokens.json');
 const _aiCfg = requireShared('ai-tokens.json');
 const _otherCfg = requireShared('other-tokens.json');
+const TOKEN_PANELS_PAPRIKA_MAP = { ..._defiCfg.coinpaprika, ..._aiCfg.coinpaprika, ..._otherCfg.coinpaprika };
 const TOKEN_PANELS_SEED_TTL = 3600; // 1h
 
 function _mapTokens(ids, meta, byId) {
@@ -1730,6 +1731,21 @@ function _mapTokens(ids, meta, byId) {
   return tokens;
 }
 
+async function fetchTokenPanelsCoinPaprika(allIds) {
+  const data = await cyberHttpGetJson('https://api.coinpaprika.com/v1/tickers?quotes=USD', { Accept: 'application/json' }, 15000);
+  if (!Array.isArray(data)) throw new Error('CoinPaprika returned non-array');
+  const paprikaIds = new Set(allIds.map((id) => TOKEN_PANELS_PAPRIKA_MAP[id]).filter(Boolean));
+  const reverseMap = Object.fromEntries(Object.entries(TOKEN_PANELS_PAPRIKA_MAP).map(([g, p]) => [p, g]));
+  return data.filter((t) => paprikaIds.has(t.id)).map((t) => ({
+    id: reverseMap[t.id] || t.id,
+    current_price: t.quotes.USD.price,
+    price_change_percentage_24h: t.quotes.USD.percent_change_24h,
+    price_change_percentage_7d_in_currency: t.quotes.USD.percent_change_7d,
+    symbol: t.symbol.toLowerCase(),
+    name: t.name,
+  }));
+}
+
 async function seedTokenPanels() {
   const allIds = [...new Set([..._defiCfg.ids, ..._aiCfg.ids, ..._otherCfg.ids])];
   let data;
@@ -1742,8 +1758,8 @@ async function seedTokenPanels() {
     data = await cyberHttpGetJson(url, headers, 15000);
     if (!Array.isArray(data) || data.length === 0) throw new Error('CoinGecko returned no data');
   } catch (err) {
-    console.warn(`[TokenPanels] CoinGecko failed: ${err.message} — skipping`);
-    return 0;
+    console.warn(`[TokenPanels] CoinGecko failed: ${err.message} — trying CoinPaprika`);
+    try { data = await fetchTokenPanelsCoinPaprika(allIds); } catch (e2) { console.warn(`[TokenPanels] CoinPaprika also failed: ${e2.message} — skipping`); return 0; }
   }
   const byId = new Map(data.map((c) => [c.id, c]));
   const defi = { tokens: _mapTokens(_defiCfg.ids, _defiCfg.meta, byId) };

--- a/scripts/seed-token-panels.mjs
+++ b/scripts/seed-token-panels.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, loadSharedConfig, CHROME_UA, writeExtraKey, sleep } from './_seed-utils.mjs';
+import { loadEnvFile, loadSharedConfig, CHROME_UA, runSeed, sleep } from './_seed-utils.mjs';
 
 const defiConfig = loadSharedConfig('defi-tokens.json');
 const aiConfig = loadSharedConfig('ai-tokens.json');
@@ -12,6 +12,9 @@ const DEFI_KEY = 'market:defi-tokens:v1';
 const AI_KEY = 'market:ai-tokens:v1';
 const OTHER_KEY = 'market:other-tokens:v1';
 const CACHE_TTL = 3600;
+
+const ALL_IDS = [...new Set([...defiConfig.ids, ...aiConfig.ids, ...otherConfig.ids])];
+const COINPAPRIKA_ID_MAP = { ...defiConfig.coinpaprika, ...aiConfig.coinpaprika, ...otherConfig.coinpaprika };
 
 async function fetchWithRateLimitRetry(url, maxAttempts = 5, headers = { Accept: 'application/json', 'User-Agent': CHROME_UA }) {
   for (let i = 0; i < maxAttempts; i++) {
@@ -26,6 +29,41 @@ async function fetchWithRateLimitRetry(url, maxAttempts = 5, headers = { Accept:
     return resp;
   }
   throw new Error('CoinGecko rate limit exceeded after retries');
+}
+
+async function fetchFromCoinGecko() {
+  const apiKey = process.env.COINGECKO_API_KEY;
+  const baseUrl = apiKey ? 'https://pro-api.coingecko.com/api/v3' : 'https://api.coingecko.com/api/v3';
+  const url = `${baseUrl}/coins/markets?vs_currency=usd&ids=${ALL_IDS.join(',')}&order=market_cap_desc&sparkline=false&price_change_percentage=24h,7d`;
+  const headers = { Accept: 'application/json', 'User-Agent': CHROME_UA };
+  if (apiKey) headers['x-cg-pro-api-key'] = apiKey;
+
+  const resp = await fetchWithRateLimitRetry(url, 5, headers);
+  const data = await resp.json();
+  if (!Array.isArray(data) || data.length === 0) throw new Error('CoinGecko returned no data');
+  return data;
+}
+
+async function fetchFromCoinPaprika() {
+  console.log('  [CoinPaprika] Falling back to CoinPaprika...');
+  const resp = await fetch('https://api.coinpaprika.com/v1/tickers?quotes=USD', {
+    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) throw new Error(`CoinPaprika HTTP ${resp.status}`);
+  const allTickers = await resp.json();
+  const paprikaIds = new Set(ALL_IDS.map((id) => COINPAPRIKA_ID_MAP[id]).filter(Boolean));
+  const reverseMap = new Map(Object.entries(COINPAPRIKA_ID_MAP).map(([g, p]) => [p, g]));
+  return allTickers
+    .filter((t) => paprikaIds.has(t.id))
+    .map((t) => ({
+      id: reverseMap.get(t.id) || t.id,
+      current_price: t.quotes.USD.price,
+      price_change_percentage_24h: t.quotes.USD.percent_change_24h,
+      price_change_percentage_7d_in_currency: t.quotes.USD.percent_change_7d,
+      symbol: t.symbol.toLowerCase(),
+      name: t.name,
+    }));
 }
 
 function mapTokens(ids, meta, byId) {
@@ -45,42 +83,47 @@ function mapTokens(ids, meta, byId) {
   return tokens;
 }
 
-async function main() {
-  const allIds = [...new Set([...defiConfig.ids, ...aiConfig.ids, ...otherConfig.ids])];
+async function fetchTokenPanels() {
+  let raw;
+  try {
+    raw = await fetchFromCoinGecko();
+  } catch (err) {
+    console.warn(`  [CoinGecko] Failed: ${err.message}`);
+    raw = await fetchFromCoinPaprika();
+  }
 
-  const apiKey = process.env.COINGECKO_API_KEY;
-  const baseUrl = apiKey ? 'https://pro-api.coingecko.com/api/v3' : 'https://api.coingecko.com/api/v3';
-  const url = `${baseUrl}/coins/markets?vs_currency=usd&ids=${allIds.join(',')}&order=market_cap_desc&sparkline=false&price_change_percentage=24h,7d`;
-  const headers = { Accept: 'application/json', 'User-Agent': CHROME_UA };
-  if (apiKey) headers['x-cg-pro-api-key'] = apiKey;
-
-  console.log('=== market:token-panels Seed ===');
-  console.log(`  Keys:    ${DEFI_KEY}, ${AI_KEY}, ${OTHER_KEY}`);
-
-  const resp = await fetchWithRateLimitRetry(url, 5, headers);
-  const data = await resp.json();
-  if (!Array.isArray(data) || data.length === 0) throw new Error('CoinGecko returned no data');
-
-  const byId = new Map(data.map(c => [c.id, c]));
-
+  const byId = new Map(raw.map((c) => [c.id, c]));
   const defi = { tokens: mapTokens(defiConfig.ids, defiConfig.meta, byId) };
   const ai = { tokens: mapTokens(aiConfig.ids, aiConfig.meta, byId) };
   const other = { tokens: mapTokens(otherConfig.ids, otherConfig.meta, byId) };
-
-  if (defi.tokens.length === 0 && ai.tokens.length === 0 && other.tokens.length === 0) {
-    throw new Error('All token panels returned empty — refusing to overwrite cache');
-  }
-
-  await writeExtraKey(DEFI_KEY, defi, CACHE_TTL);
-  await writeExtraKey(AI_KEY, ai, CACHE_TTL);
-  await writeExtraKey(OTHER_KEY, other, CACHE_TTL);
-
   const total = defi.tokens.length + ai.tokens.length + other.tokens.length;
-  console.log(`  Seeded: ${defi.tokens.length} DeFi, ${ai.tokens.length} AI, ${other.tokens.length} Other (${total} total)`);
-  console.log('\n=== Done ===');
+
+  if (total === 0) throw new Error('All token panels returned empty');
+
+  return { defi, ai, other, total };
 }
 
-main().catch(err => {
+function validate(data) {
+  return (
+    Array.isArray(data?.defi?.tokens) &&
+    data.defi.tokens.length >= 1 &&
+    (data.defi.tokens.some((t) => t.price > 0) ||
+      data.ai.tokens.some((t) => t.price > 0) ||
+      data.other.tokens.some((t) => t.price > 0))
+  );
+}
+
+runSeed('market', 'token-panels', DEFI_KEY, fetchTokenPanels, {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: 'coingecko-paprika-fallback',
+  recordCount: (data) => data.total,
+  publishTransform: (data) => data.defi,
+  extraKeys: [
+    { key: AI_KEY, transform: (data) => data.ai, ttl: CACHE_TTL },
+    { key: OTHER_KEY, transform: (data) => data.other, ttl: CACHE_TTL },
+  ],
+}).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
   console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);


### PR DESCRIPTION
## Why this PR?

DeFi Tokens, AI Tokens, and Alt Tokens panels were showing \"Crypto data temporarily unavailable\" because the token panels had no CoinPaprika fallback. The relay's `seedTokenPanels()` was silently returning 0 on every run (CoinGecko rate-limited, no API key on relay), so Redis keys expired after 1h TTL and never refreshed. Health was also blind to the staleness.

## Changes

- **`scripts/seed-token-panels.mjs`**: rewrite with `runSeed()` wrapper (replaces raw `main()`) and CoinGecko → CoinPaprika fallback. Writes `seed-meta:market:token-panels` for health monitoring. Matches the same pattern as `seed-crypto-quotes.mjs`.
- **`scripts/ais-relay.cjs`**: add `fetchTokenPanelsCoinPaprika()` fallback to `seedTokenPanels()`. Relay no longer silently drops token panel data when CoinGecko returns nothing.
- **`api/health.js`**: add `defiTokens`, `aiTokens`, `otherTokens` to `BOOTSTRAP_KEYS`; add `tokenPanels` to `SEED_META` (`maxStaleMin: 90`, matching 30-min cron × 3).
- **Railway**: provisioned `seed-token-panels` cron service (`*/30 * * * *`, 1 vCPU / 1 GB, scoped `watchPatterns`).

## Root cause

The relay runs `seedTokenPanels()` every 5 min inside `seedAllMarketData()`. Without a `COINGECKO_API_KEY`, it hit the free CoinGecko endpoint which was already rate-limited by the main crypto seed loop running in the same loop. No fallback meant it returned 0 every time. With CoinPaprika fallback, the panels will recover automatically.

## Test plan

- [ ] Check `/api/health` after deploy: `defiTokens`, `aiTokens`, `otherTokens` all `OK` (not `CRIT`)
- [ ] `seed-meta:market:token-panels` present in Redis and `tokenPanels` health entry is `OK`
- [ ] DeFi Tokens, AI Tokens, Alt Tokens panels load data in UI
- [ ] If CoinGecko fails, relay logs `[TokenPanels] CoinGecko failed ... trying CoinPaprika` (not `skipping`)