### PR TITLE
fix(consumer-prices): call closePool() so scrape→aggregate→publish chain exits

### DIFF
--- a/consumer-prices-core/src/jobs/aggregate.ts
+++ b/consumer-prices-core/src/jobs/aggregate.ts
@@ -2,7 +2,7 @@
  * Aggregate job: computes basket indices from latest price observations.
  * Produces Fixed Basket Index and Value Basket Index per methodology.
  */
-import { query } from '../db/client.js';
+import { query, closePool } from '../db/client.js';
 import { loadAllBasketConfigs } from '../config/loader.js';
 
 const logger = {
@@ -232,5 +232,5 @@ export async function aggregateAll() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  aggregateAll().catch(console.error);
+  aggregateAll().finally(() => closePool()).catch(console.error);
 }

--- a/consumer-prices-core/src/jobs/publish.ts
+++ b/consumer-prices-core/src/jobs/publish.ts
@@ -11,6 +11,7 @@ import {
   buildRetailerSpreadSnapshot,
 } from '../snapshots/worldmonitor.js';
 import { loadAllBasketConfigs, loadAllRetailerConfigs } from '../config/loader.js';
+import { closePool } from '../db/client.js';
 
 const logger = {
   info: (msg: string, ...args: unknown[]) => console.log(`[publish] ${msg}`, ...args),
@@ -137,5 +138,5 @@ export async function publishAll() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  publishAll().catch(console.error);
+  publishAll().finally(() => closePool()).catch(console.error);
 }

--- a/consumer-prices-core/src/jobs/scrape.ts
+++ b/consumer-prices-core/src/jobs/scrape.ts
@@ -2,7 +2,7 @@
  * Scrape job: discovers targets and writes price observations to Postgres.
  * Respects per-retailer rate limits and acquisition provider config.
  */
-import { query } from '../db/client.js';
+import { query, closePool } from '../db/client.js';
 import { insertObservation } from '../db/queries/observations.js';
 import { upsertRetailerProduct } from '../db/queries/products.js';
 import { parseSize, unitPrice as calcUnitPrice } from '../normalizers/size.js';
@@ -197,7 +197,7 @@ export async function scrapeAll() {
 }
 
 if (process.argv[2]) {
-  scrapeRetailer(process.argv[2]).catch(console.error);
+  scrapeRetailer(process.argv[2]).finally(() => closePool()).catch(console.error);
 } else {
-  scrapeAll().catch(console.error);
+  scrapeAll().finally(() => closePool()).catch(console.error);
 }


### PR DESCRIPTION
## Why

The consumer-prices Railway cron runs:
```
node dist/jobs/scrape.js && node dist/jobs/aggregate.js && node dist/jobs/publish.js
```

But **only scrape was running**. The `pg.Pool` keeps the Node.js event loop alive after a job finishes — without `pool.end()` the process never exits, so `&&` never chains to aggregate or publish. All `consumer-prices:*` Redis keys were missing, causing the Consumer Prices panel to show "Data collection in progress" indefinitely.

## Fix

Call `closePool()` (already existed in `db/client.ts`) in a `.finally()` on the top-level promise of each job, so each process exits cleanly after completion.

## Test plan
- [ ] Railway cron next run shows `[aggregate]` and `[publish]` log lines after `[scrape]`
- [ ] `consumer-prices:overview:ae` key present in Redis after cron run
- [ ] Consumer Prices panel shows real data instead of empty state