### PR TITLE
fix(husky): block commits and pushes to merged/closed PR branches

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,16 @@
+BRANCH=$(git branch --show-current)
+if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ]; then
+  PR_STATE=$(gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null)
+  if [ "$PR_STATE" = "MERGED" ] || [ "$PR_STATE" = "CLOSED" ]; then
+    echo ""
+    echo "============================================================"
+    echo "ERROR: PR for branch '$BRANCH' is $PR_STATE."
+    echo "Do NOT commit to a merged/closed PR branch — commits will be orphaned."
+    echo "Run: git checkout main && git pull && git checkout -b fix/new-branch"
+    echo "============================================================"
+    exit 1
+  fi
+fi
+
 echo "Running Unicode safety check (staged files)..."
 node scripts/check-unicode-safety.mjs --staged || exit 1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,7 +7,7 @@ fi
 echo "Checking PR status for current branch..."
 BRANCH=$(git branch --show-current)
 if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ]; then
-  PR_STATE=$(gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null)
+  PR_STATE=$(gh pr view "$BRANCH" --json state --jq '.state' 2>&1)
   if [ "$PR_STATE" = "MERGED" ] || [ "$PR_STATE" = "CLOSED" ]; then
     echo ""
     echo "============================================================"
@@ -17,6 +17,7 @@ if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ]; the
     echo "============================================================"
     exit 1
   fi
+  echo "  Branch PR state: ${PR_STATE:-unknown}"
 fi
 
 echo "Running type check..."


### PR DESCRIPTION
## Why this PR?

Orphaned commits happened on PRs #1893, #1898, and #1974 because git allows committing/pushing to branches whose PRs have already been merged or closed. The existing pre-push check had `2>/dev/null` silencing `gh` errors, so it failed silently on new branches with no PR yet.

## Changes

- **`.husky/pre-commit`**: Added merged/closed PR guard at the top — `gh pr view` checks branch state before any commit is created. Exits 1 with a clear remediation message if `MERGED` or `CLOSED`.
- **`.husky/pre-push`**: Changed `2>/dev/null` → `2>&1` so `gh` errors surface visibly. Added `echo "Branch PR state: ..."` so the current state is always logged during push.

## Test plan

- [ ] Commit to a branch with a merged PR → pre-commit blocks with clear error
- [ ] Push to a branch with a merged PR → pre-push blocks (was already there, now more visible)
- [ ] Normal commit on open-PR branch → passes through unchanged