### PR TITLE
fix(enrichment): add per-upstream Redis caching to company enrichment and signals RPCs

### DIFF
--- a/server/worldmonitor/intelligence/v1/get-company-enrichment.ts
+++ b/server/worldmonitor/intelligence/v1/get-company-enrichment.ts
@@ -167,7 +167,7 @@ async function fetchGitHubTechStack(orgName: string): Promise<TechStackItem[] | 
 
 async function fetchSECData(companyName: string): Promise<SECResult | null> {
   return cachedFetchJson<SECResult>(
-    `intel:enrichment:sec:${encodeURIComponent(companyName.toLowerCase())}`,
+    `intel:enrichment:sec:${encodeURIComponent(companyName.toLowerCase())}:${getTodayISO()}`,
     3600,
     async () => {
       const url = `https://efts.sec.gov/LATEST/search-index?q=${encodeURIComponent(companyName)}&dateRange=custom&startdt=${getDateMonthsAgo(6)}&enddt=${getTodayISO()}&forms=10-K,10-Q,8-K&from=0&size=5`;

--- a/server/worldmonitor/intelligence/v1/list-company-signals.ts
+++ b/server/worldmonitor/intelligence/v1/list-company-signals.ts
@@ -86,9 +86,13 @@ function slugFromDomain(domain: string): string {
   return domain.replace(/\.(com|io|co|org|net|ai|dev|app)$/, '').split('.').pop() || domain;
 }
 
+function hourBucket(): number {
+  return Math.floor(Date.now() / 3_600_000);
+}
+
 async function fetchHNSignals(companyName: string): Promise<CompanySignal[] | null> {
   return cachedFetchJson<CompanySignal[]>(
-    `intel:signals:hn:${encodeURIComponent(companyName.toLowerCase())}`,
+    `intel:signals:hn:${encodeURIComponent(companyName.toLowerCase())}:${hourBucket()}`,
     1800,
     async () => {
       const thirtyDaysAgo = Math.floor(Date.now() / 1000) - 30 * 86400;
@@ -124,7 +128,7 @@ async function fetchHNSignals(companyName: string): Promise<CompanySignal[] | nu
 
 async function fetchGitHubSignals(orgName: string): Promise<CompanySignal[] | null> {
   return cachedFetchJson<CompanySignal[]>(
-    `intel:signals:gh:${encodeURIComponent(orgName.toLowerCase())}`,
+    `intel:signals:gh:${encodeURIComponent(orgName.toLowerCase())}:${hourBucket()}`,
     3600,
     async () => {
       const repos = await fetchJson<GitHubSignalRepo[]>(`https://api.github.com/orgs/${encodeURIComponent(orgName)}/repos?sort=created&per_page=10`);
@@ -157,7 +161,7 @@ async function fetchGitHubSignals(orgName: string): Promise<CompanySignal[] | nu
 
 async function fetchJobSignals(companyName: string): Promise<CompanySignal[] | null> {
   return cachedFetchJson<CompanySignal[]>(
-    `intel:signals:jobs:${encodeURIComponent(companyName.toLowerCase())}`,
+    `intel:signals:jobs:${encodeURIComponent(companyName.toLowerCase())}:${hourBucket()}`,
     1800,
     async () => {
       const sixtyDaysAgo = Math.floor(Date.now() / 1000) - 60 * 86400;

--- a/tests/enrichment-caching.test.mjs
+++ b/tests/enrichment-caching.test.mjs
@@ -213,6 +213,10 @@ describe('cachedFetchJson — import verification', () => {
     assert.ok(src.includes('intel:enrichment:gh-tech:'), 'must use gh-tech cache key');
     assert.ok(src.includes('intel:enrichment:sec:'), 'must use sec cache key');
     assert.ok(src.includes('intel:enrichment:hn:'), 'must use hn cache key');
+    assert.ok(
+      src.includes('intel:enrichment:sec:') && src.includes('getTodayISO()'),
+      'SEC cache key must include getTodayISO() daily bucket to track date-window changes',
+    );
   });
 
   it('list-company-signals.ts imports cachedFetchJson', async () => {
@@ -224,6 +228,10 @@ describe('cachedFetchJson — import verification', () => {
     assert.ok(src.includes('intel:signals:hn:'), 'must use signals:hn cache key');
     assert.ok(src.includes('intel:signals:gh:'), 'must use signals:gh cache key');
     assert.ok(src.includes('intel:signals:jobs:'), 'must use signals:jobs cache key');
+    assert.ok(
+      src.includes('hourBucket()'),
+      'all signal cache keys must include hourBucket() to prevent stale rolling-window results',
+    );
   });
 
   it('cache keys do not collide with existing bootstrap keys', async () => {


### PR DESCRIPTION
## Summary

- Wraps each upstream fetcher in `get-company-enrichment.ts` and `list-company-signals.ts` with `cachedFetchJson` from `server/_shared/redis.ts`
- Prevents N parallel external calls (GitHub, SEC EDGAR, Hacker News) on every RPC invocation
- Cache semantics: `null` from fetcher → negative cache (120s), `[]` for successful empty results → normal TTL
- Cache keys use `encodeURIComponent()` for safety with special company names (e.g., `AT%26T`)
- TTLs: GitHub org/tech/SEC → 3600s, HN mentions/signals/jobs → 1800s, GitHub signals → 3600s

## Test plan

- [x] Functional tests in `tests/enrichment-caching.test.mjs` (12 new tests):
  - `null` fetcher path → writes `__WM_NEG__` sentinel with 120s TTL
  - `[]` fetcher path → cached with normal TTL (not treated as failure)
  - Cache hit → upstream fetcher NOT called
  - `encodeURIComponent` keys tested with `AT&T`, `Johnson & Johnson`
  - Lowercased names produce consistent keys
  - Key prefix collision check against `cache-keys.ts` bootstrap keys
- [x] TypeScript clean (`npm run typecheck`)
- [x] All 2172 tests pass (`npm run test:data`)