### PR TITLE
fix(panels): skip LiveNewsPanel on variants with no channels

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -625,6 +625,7 @@ export class App {
       ensureCorrectZones: () => this.panelLayout.ensureCorrectZones(),
       refreshOpenCountryBrief: () => this.countryIntel.refreshOpenBrief(),
       stopLayerActivity: (layer) => this.dataLoader.stopLayerActivity(layer),
+      mountLiveNewsIfReady: () => this.panelLayout.mountLiveNewsIfReady(),
     });
 
     // Wire cross-module callback: DataLoader → SearchManager

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -71,6 +71,7 @@ export interface EventHandlerCallbacks {
   ensureCorrectZones: () => void;
   refreshOpenCountryBrief?: () => void;
   stopLayerActivity?: (layer: keyof MapLayers) => void;
+  mountLiveNewsIfReady?: () => void;
 }
 
 export class EventHandlerManager implements AppModule {
@@ -328,8 +329,12 @@ export class EventHandlerManager implements AppModule {
       }
       if (e.key === STORAGE_KEYS.liveChannels && e.newValue) {
         const panel = this.ctx.panels['live-news'];
-        if (panel && typeof (panel as unknown as { refreshChannelsFromStorage?: () => void }).refreshChannelsFromStorage === 'function') {
-          (panel as unknown as { refreshChannelsFromStorage: () => void }).refreshChannelsFromStorage();
+        if (panel) {
+          if (typeof (panel as unknown as { refreshChannelsFromStorage?: () => void }).refreshChannelsFromStorage === 'function') {
+            (panel as unknown as { refreshChannelsFromStorage: () => void }).refreshChannelsFromStorage();
+          }
+        } else {
+          this.callbacks.mountLiveNewsIfReady?.();
         }
       }
     };

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -487,6 +487,28 @@ export class PanelLayoutManager implements AppModule {
     });
   }
 
+  /**
+   * Lazily instantiates and mounts LiveNewsPanel when channels become available
+   * mid-session (e.g. user adds channels via the standalone manager on a variant
+   * whose defaults are empty). No-op if the panel already exists or still has no
+   * channels. Called from the liveChannels storage event handler.
+   */
+  mountLiveNewsIfReady(): void {
+    if (this.ctx.panels['live-news']) return;
+    if (getDefaultLiveChannels().length === 0 && loadChannelsFromStorage().length === 0) return;
+    const panel = new LiveNewsPanel();
+    this.ctx.panels['live-news'] = panel;
+    const el = panel.getElement();
+    this.makeDraggable(el, 'live-news');
+    const grid = document.getElementById('panelsGrid');
+    if (grid) {
+      const addBlock = grid.querySelector('.add-panel-block');
+      if (addBlock) grid.insertBefore(el, addBlock);
+      else grid.appendChild(el);
+    }
+    this.applyPanelSettings();
+  }
+
   private shouldCreatePanel(key: string): boolean {
     return Object.prototype.hasOwnProperty.call(this.ctx.panelSettings, key);
   }

--- a/tests/live-news-panel-guard.test.mts
+++ b/tests/live-news-panel-guard.test.mts
@@ -102,4 +102,37 @@ describe('LiveNewsPanel instantiation guard', () => {
       'panel-layout.ts must import loadChannelsFromStorage',
     );
   });
+
+  // -------------------------------------------------------------------------
+  // 4. Mid-session lazy instantiation path
+  //    When a happy-variant user adds channels after page load, the panel
+  //    must be mountable without a full reload.
+  // -------------------------------------------------------------------------
+
+  it('panel-layout.ts exposes mountLiveNewsIfReady() for mid-session instantiation', () => {
+    const layout = src('src/app/panel-layout.ts');
+    assert.ok(
+      layout.includes('mountLiveNewsIfReady'),
+      'panel-layout.ts must expose mountLiveNewsIfReady() so channels added mid-session can trigger panel creation',
+    );
+  });
+
+  it('event-handlers.ts calls mountLiveNewsIfReady when liveChannels changes and panel is missing', () => {
+    const handlers = src('src/app/event-handlers.ts');
+    // The liveChannels branch must have an else clause that calls mountLiveNewsIfReady
+    const liveChannelsBlock = handlers.match(/liveChannels.*?(?=if \(e\.key)/s);
+    assert.ok(liveChannelsBlock, 'liveChannels storage handler not found');
+    assert.ok(
+      handlers.includes('mountLiveNewsIfReady'),
+      'event-handlers.ts must call mountLiveNewsIfReady when liveChannels fires and panel does not exist',
+    );
+  });
+
+  it('App.ts wires mountLiveNewsIfReady callback to panelLayout', () => {
+    const app = src('src/App.ts');
+    assert.ok(
+      app.includes('mountLiveNewsIfReady'),
+      'App.ts must wire mountLiveNewsIfReady callback so EventHandlerManager can trigger lazy panel creation',
+    );
+  });
 });

--- a/tests/panel-config-guardrails.test.mjs
+++ b/tests/panel-config-guardrails.test.mjs
@@ -41,6 +41,7 @@ describe('panel-config guardrails', () => {
       /this\.ctx\.panels\[key\]\s*=/,             // createPanel helper
       /this\.ctx\.panels\['deduction'\]/,          // desktop-only, intentionally ungated
       /this\.ctx\.panels\['runtime-config'\]/,     // desktop-only, intentionally ungated
+      /this\.ctx\.panels\['live-news'\]/,          // mountLiveNewsIfReady — has its own channel guard
       /panel as unknown as/,                       // lazyPanel generic cast
       /this\.ctx\.panels\[panelKey\]\s*=/,         // FEEDS loop (guarded by DEFAULT_PANELS check)
       /this\.ctx\.panels\[spec\.id\]\s*=/,         // custom widgets (cw- prefix, always enabled)


### PR DESCRIPTION
## Summary

- After PR #1911 unified the panel registry, `LiveNewsPanel` was being instantiated on the happy variant where `DEFAULT_LIVE_CHANNELS = []`
- The constructor calls `this.channels[0]!` unconditionally, which is `undefined` on happy, causing a crash before the panel could render
- Fix: guard the instantiation in `panel-layout.ts` with `getDefaultLiveChannels().length > 0` so the panel simply isn't created when there are no channels to show
- No variant-specific branching inside the component; the panel stays unaware of variants

## Test plan

- [ ] Confirm happy.worldmonitor.app loads without JS crash in console
- [ ] Confirm full/tech/finance/commodity variants still show Live News panel normally
- [ ] Confirm Live News panel can still be user-enabled on happy variant (it won't be listed in the registry since the class isn't instantiated, which is the correct behavior)