### PR TITLE
fix(happy): disable cross-variant panels on variant switch

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -302,6 +302,9 @@ export class App {
     let mapLayers: MapLayers;
     let panelSettings: Record<string, PanelConfig>;
 
+    // Panels that must survive variant switches: desktop config, user-created widgets, MCP panels.
+    const isDynamicPanel = (k: string) => k === 'runtime-config' || k.startsWith('cw-') || k.startsWith('mcp-');
+
     // Check if variant changed - reset all settings to variant defaults
     const storedVariant = localStorage.getItem('worldmonitor-variant');
     const currentVariant = SITE_VARIANT;
@@ -317,7 +320,7 @@ export class App {
       panelSettings = loadFromStorage<Record<string, PanelConfig>>(STORAGE_KEYS.panels, {});
       const newVariantKeys = new Set(VARIANT_DEFAULTS[currentVariant] ?? []);
       for (const key of Object.keys(panelSettings)) {
-        if (!newVariantKeys.has(key) && key !== 'runtime-config' && panelSettings[key]) {
+        if (!newVariantKeys.has(key) && !isDynamicPanel(key) && panelSettings[key]) {
           panelSettings[key] = { ...panelSettings[key]!, enabled: false };
         }
       }
@@ -386,7 +389,7 @@ export class App {
         const happyKeys = new Set(VARIANT_DEFAULTS['happy'] ?? []);
         let fixed = false;
         for (const key of Object.keys(panelSettings)) {
-          if (!happyKeys.has(key) && key !== 'runtime-config' && panelSettings[key]?.enabled) {
+          if (!happyKeys.has(key) && !isDynamicPanel(key) && panelSettings[key]?.enabled) {
             panelSettings[key] = { ...panelSettings[key]!, enabled: false };
             fixed = true;
           }


### PR DESCRIPTION
## Why this PR?

Regression from #1911 (unified panel registry). The happy variant (`happy.worldmonitor.app`) was showing full-variant panels like UNHCR Displacement, Climate Anomalies, Radiation Watch, Thermal Escalation, Israel Sirens, Telegram Intel, etc., all stuck in loading state forever.

## Root cause

PR #1911 changed the variant-switch handler to **preserve** existing panel settings instead of clearing them. Before #1911, switching variants called `localStorage.removeItem(STORAGE_KEYS.panels)` to wipe the slate clean. After #1911, the code loads the existing panelSettings and only *adds* the new variant's panels — never disabling cross-variant ones. Any user who previously visited the full variant had those panels stored with `enabled: true`, and they carried over to the happy variant unchanged.

Since the happy variant doesn't load data for any of those panels (displacement, radiation, thermal, etc.), they all render the loading spinner indefinitely.

## Fixes

1. **Variant switch handler** (`src/App.ts:318-328`): After loading saved prefs, explicitly set `enabled: false` on any panel not in the new variant's `VARIANT_DEFAULTS` before seeding the new variant's panels.

2. **One-time migration** (`worldmonitor-happy-panel-fix-v1`): Runs once on existing happy sessions to disable any cross-variant panels that are currently `enabled: true` in localStorage. Saves to storage so the fix persists.

## Test plan

- [ ] Visit `happy.worldmonitor.app` — only the 10 happy panels should render (map, positive-feed, progress, counters, spotlight, breakthroughs, digest, species, renewable, giving)
- [ ] Verify no full-variant panels (displacement, radiation-watch, thermal-escalation, telegram-intel, etc.) appear
- [ ] Open DevTools → Application → LocalStorage and confirm `worldmonitor-happy-panel-fix-v1` is set after load
- [ ] From full variant, navigate to happy variant — confirm cross-variant panels are disabled immediately