### PR TITLE
feat(wingbits): add UTM tracking to attribution link

### DIFF
--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -21,7 +21,7 @@ import { sparkline } from '@/utils/sparkline';
 
 function formatPositionSource(source: string): string {
   if (source === 'POSITION_SOURCE_WINGBITS') {
-    return '<a href="https://wingbits.com" target="_blank" rel="noopener" style="color:inherit">wingbits.com</a>';
+    return '<a href="https://wingbits.com?utm_source=worldmonitor&utm_medium=referral&utm_campaign=worldmonitor" target="_blank" rel="noopener" style="color:inherit">wingbits.com</a>';
   }
   if (source === 'POSITION_SOURCE_OPENSKY') {
     return '<a href="https://opensky-network.org" target="_blank" rel="noopener" style="color:inherit">opensky-network.org</a>';


### PR DESCRIPTION
Adds UTM parameters to the wingbits.com link in the SOURCE field of the flight popup:

`https://wingbits.com?utm_source=worldmonitor&utm_medium=referral&utm_campaign=worldmonitor`

The registration link in `settings-constants.ts` is unchanged.