### PR TITLE
fix(wingbits): re-clamp popup after photo loads to prevent bottom overflow

### DIFF
--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -905,7 +905,7 @@ export class MapPopup {
         if (photoSrc) {
           const photoLink = live.photoLink ? sanitizeUrl(live.photoLink) : '#';
           const credit = live.photoCredit ? `<span class="flight-photo-credit">\u00a9 ${escapeHtml(live.photoCredit)}</span>` : '';
-          photoHtml = `<div class="flight-photo"><a href="${photoLink}" target="_blank" rel="noopener"><img src="${photoSrc}" alt="${escapeHtml(live.callsign)}" loading="lazy" style="width:100%;border-radius:4px;display:block"></a>${credit}</div>`;
+          photoHtml = `<div class="flight-photo"><a href="${photoLink}" target="_blank" rel="noopener"><img src="${photoSrc}" alt="${escapeHtml(live.callsign)}" style="width:100%;border-radius:4px;display:block"></a>${credit}</div>`;
         }
       }
 
@@ -959,7 +959,15 @@ export class MapPopup {
         ${statsHtml}
         ${photoHtml}
       `;
+      // Clamp for text content immediately, then re-clamp once the photo is sized.
       this.clampPopupToViewport();
+      if (photoHtml) {
+        const img = section.querySelector<HTMLImageElement>('img');
+        if (img && !img.complete) {
+          img.addEventListener('load', () => { this.clampPopupToViewport(); }, { once: true });
+          img.addEventListener('error', () => { this.clampPopupToViewport(); }, { once: true });
+        }
+      }
     } catch {
       if (section.isConnected) {
         section.innerHTML = '';


### PR DESCRIPTION
## Why this PR?

Previous `clampPopupToViewport()` call fired immediately after `section.innerHTML` was set, but the photo image was `loading="lazy"` — so the browser hadn't assigned it any height yet. The clamp measured a shorter popup and adjusted `top` only for the text content. When the image then loaded and expanded the popup by ~160px, it overflowed the viewport again.

## Fix

- Removed `loading="lazy"` from the photo `<img>` — it's a single popup image that's immediately visible, lazy-loading gives no benefit.
- Added `load`/`error` event listeners on the img element (if not already complete/cached) that call `clampPopupToViewport()` again after the image renders.
- Kept the initial `clampPopupToViewport()` call so text-only popups are still clamped immediately.

## On the callsign question (UAE528 vs EK528)

The Wingbits live API returns ICAO airline callsigns (`UAE528` = Emirates using ICAO prefix `UAE`). Converting to IATA (`EK528`) requires a full ICAO→IATA airline code mapping table — not in scope here. `EZY13BU` is a non-standard positional callsign for easyJet with no commercial schedule entry anywhere, so the FROM/TO will always be blank for that flight.

## Test plan

- [ ] Click aircraft near the bottom of the map with a photo — popup should fully fit on screen after photo loads
- [ ] Popup with no photo: clamp still works for text-only content
- [ ] Photo renders immediately (no lazy flicker)