### PR TITLE
fix(ci): use dynamic repository owner for Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,11 +28,11 @@ jobs:
       - uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         id: meta
         with:
-          images: ghcr.io/koala73/worldmonitor
+          images: ghcr.io/${{ github.repository_owner }}/worldmonitor
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
             type=sha,prefix=sha-
 
       - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7


### PR DESCRIPTION
## Summary
- Replace hardcoded `ghcr.io/koala73` with `ghcr.io/${{ github.repository_owner }}` so forks can publish to their own GHCR namespace without modifying the workflow
- Enable `latest` tag on `workflow_dispatch` in addition to release events

## Motivation
Forks currently cannot use the Docker publish workflow as-is because the image name is hardcoded to `koala73`. Using `github.repository_owner` makes the workflow portable across forks while maintaining the same behavior for the upstream repo.

The `latest` tag on `workflow_dispatch` allows manual builds to produce a usable tag without creating a full release.

## Test plan
- [x] Triggered `workflow_dispatch` on fork — image pushed to `ghcr.io/roeidalm/worldmonitor:latest`
- [x] Verified `${{ github.repository_owner }}` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)