### PR TITLE
feat(map): color aircraft icons by altitude (cyan → red gradient)

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -291,14 +291,15 @@ const ALTITUDE_COLOR_STOPS: Array<{ alt: number; r: number; g: number; b: number
 
 function altitudeToColor(altFt: number): [number, number, number] {
   const stops = ALTITUDE_COLOR_STOPS;
-  if (altFt <= stops[0]!.alt) return [stops[0]!.r, stops[0]!.g, stops[0]!.b];
+  const alt = Number.isFinite(altFt) ? altFt : 0;
+  if (alt <= stops[0]!.alt) return [stops[0]!.r, stops[0]!.g, stops[0]!.b];
   const last = stops[stops.length - 1]!;
-  if (altFt >= last.alt) return [last.r, last.g, last.b];
+  if (alt >= last.alt) return [last.r, last.g, last.b];
   for (let i = 1; i < stops.length; i++) {
     const hi = stops[i]!;
     const lo = stops[i - 1]!;
-    if (altFt <= hi.alt) {
-      const t = (altFt - lo.alt) / (hi.alt - lo.alt);
+    if (alt <= hi.alt) {
+      const t = (alt - lo.alt) / (hi.alt - lo.alt);
       return [
         Math.round(lo.r + (hi.r - lo.r) * t),
         Math.round(lo.g + (hi.g - lo.g) * t),


### PR DESCRIPTION
## Summary

- Adds `altitudeToColor(altFt)` — a 7-stop linear interpolation from cyan at sea level to deep red at cruise altitude, matching the color intuition used by Wingbits and other flight trackers
- Applies to the civilian ADS-B `IconLayer` (replaces flat purple) and military `ScatterplotLayer` (replaces fixed red)
- Ground aircraft keep the existing gray color; only airborne aircraft get altitude-coded color

**Color scale:**
| Altitude | Color |
|---|---|
| 0 ft | Cyan `[0, 217, 255]` |
| 5,000 ft | Blue-green |
| 10,000 ft | Yellow-green |
| 20,000 ft | Orange |
| 30,000 ft | Red-orange |
| 40,000+ ft | Deep red |

Cruise-altitude flights (35k ft) appear red/orange; departing/arriving traffic shifts toward cyan/yellow — making traffic patterns visually readable at a glance.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run test:data` passes (2179 tests)
- [ ] Open map with flights layer active — commercial cruising flights should appear red/orange
- [ ] Open map in area with departing/landing traffic (e.g. DXB, LHR) — low-altitude aircraft should appear cyan/blue
- [ ] Military layer: same gradient (was fixed red before)
- [ ] On-ground aircraft remain gray