### PR TITLE
fix(search): flight prefix detection broken by trim — use raw input

### DIFF
--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -271,7 +271,8 @@ export class SearchModal {
   }
 
   private handleSearch(): void {
-    const query = this.input?.value.trim().toLowerCase() || '';
+    const rawInput = this.input?.value.toLowerCase() || '';
+    const query = rawInput.trim();
 
     if (!query) {
       this.showingAllCommands = false;
@@ -285,9 +286,9 @@ export class SearchModal {
 
     const byType = new Map<SearchResultType, (SearchResult & { _score: number })[]>();
 
-    // "flight {callsign}" prefix: route the callsign fragment directly to the flight source.
-    if (query.startsWith('flight ')) {
-      const callsign = query.slice(7).trim();
+    // "flight {callsign}" prefix: use rawInput so a trailing space after "flight" is detected.
+    if (rawInput.startsWith('flight ')) {
+      const callsign = rawInput.slice(7).trim();
       if (callsign.length > 0) {
         const flightSource = this.sources.find(s => s.type === 'flight');
         if (flightSource) {


### PR DESCRIPTION
## Bug

`handleSearch` does `query = input.value.trim()`. Typing "flight UAE528" works fine, but the moment the user presses space after "flight", the trimmed query is still "flight" — so `'flight'.startsWith('flight ')` is always false and the prefix path never fires.

## Fix

Split into two variables:
- `rawInput = input.value.toLowerCase()` — used only for the `startsWith('flight ')` check
- `query = rawInput.trim()` — used everywhere else (commands, fuzzy match, tracking)

## Test

- Type `flight ` (with space) → prefix path activates, waits for callsign
- Type `flight UAE528` → shows UAE-prefixed flight results
- Type `flight EK` → shows EK-prefixed results
- Type `UAE528` directly → still works via normal title match