### PR TITLE
fix(energy-complex): remove duplicate WTI/Brent price cards when live tape is available

### DIFF
--- a/src/components/EnergyComplexPanel.ts
+++ b/src/components/EnergyComplexPanel.ts
@@ -35,9 +35,15 @@ export class EnergyComplexPanel extends Panel {
   }
 
   private render(): void {
+    // Suppress EIA price cards when live tape already covers the same commodity
+    // to avoid showing two different prices for the same product (EIA is weekly/stale).
+    const tapeCoveredSymbols = new Set(this.tape.filter(d => d.price !== null).map(d => d.symbol));
+    const wtiInTape = tapeCoveredSymbols.has('CL=F');
+    const brentInTape = tapeCoveredSymbols.has('BZ=F');
+
     const metrics = [
-      this.analytics?.wtiPrice,
-      this.analytics?.brentPrice,
+      wtiInTape ? null : this.analytics?.wtiPrice,
+      brentInTape ? null : this.analytics?.brentPrice,
       this.analytics?.usProduction,
       this.analytics?.usInventory,
     ].filter(Boolean);


### PR DESCRIPTION
## Summary

- **Bug**: The Energy Complex panel showed two different prices for both WTI and Brent simultaneously — EIA weekly survey prices in the top cards ($91.85 / $96.16) and Yahoo Finance real-time futures in the Live Tape ($98.23 / $106.41). No context explaining why they differ, so it looks like a data error.
- **Root cause**: EIA `wtiPrice`/`brentPrice` are weekly survey spot prices (up to 7 days stale). The Live Tape shows `CL=F` and `BZ=F` futures which are real-time. Both sections rendered unconditionally.
- **Fix**: In `EnergyComplexPanel.render()`, check if the live tape has a live price for `CL=F` (WTI) or `BZ=F` (Brent). If so, suppress the corresponding EIA price card — the live tape is more current. EIA `usProduction` and `usInventory` are always shown (they have no live tape equivalent).

## Result

| Before | After |
|---|---|
| WTI Crude Oil $91.85 (EIA) + WTI $98.23 (Live Tape) | WTI $98.23 (Live Tape only) |
| Brent Crude Oil $96.16 (EIA) + BRENT $106.41 (Live Tape) | BRENT $106.41 (Live Tape only) |
| US Production + US Inventory (EIA) | US Production + US Inventory (EIA, unchanged) |

## Test plan

- [ ] Open Energy Complex panel — WTI and Brent should appear only once each (in Live Tape)
- [ ] US Production and US Inventory EIA cards still render
- [ ] If commodities data is unavailable (live tape empty), EIA WTI/Brent cards fall back and appear as before