### PR TITLE
fix(search): live callsign lookup — "flight EK528" now works globally

### DIFF
--- a/src/app/search-manager.ts
+++ b/src/app/search-manager.ts
@@ -26,6 +26,7 @@ import { t } from '@/services/i18n';
 import { saveToStorage, setTheme } from '@/utils';
 import { CountryIntelManager } from '@/app/country-intel';
 import type { PositionSample } from '@/services/aviation';
+import { fetchAircraftPositions } from '@/services/aviation';
 import type { MilitaryFlight } from '@/types';
 import { isProUser } from '@/services/widget-store';
 
@@ -209,6 +210,36 @@ export class SearchManager implements AppModule {
     this.ctx.searchModal.setActivePanels(Object.keys(this.ctx.panels));
     this.ctx.searchModal.setOnSelect((result) => this.handleSearchResult(result));
     this.ctx.searchModal.setOnCommand((cmd) => this.handleCommand(cmd));
+
+    if (isProUser()) {
+      let flightLookupTimer: ReturnType<typeof setTimeout> | null = null;
+      this.ctx.searchModal.setOnQueryChange((rawInput) => {
+        if (!rawInput.startsWith('flight ')) return;
+        const callsign = rawInput.slice(7).trim().toUpperCase();
+        if (callsign.length < 2) return;
+        if (flightLookupTimer) clearTimeout(flightLookupTimer);
+        flightLookupTimer = setTimeout(() => {
+          fetchAircraftPositions({ callsign }).then((positions) => {
+            if (!this.ctx.searchModal) return;
+            this.ctx.searchModal.registerSource('flight', positions.map(p => {
+              const fl = Number.isFinite(p.altitudeFt) ? Math.round(p.altitudeFt / 100) : null;
+              const kts = Number.isFinite(p.groundSpeedKts) ? Math.round(p.groundSpeedKts) : null;
+              return {
+                id: p.icao24,
+                title: (p.callsign || p.icao24).trim().toUpperCase(),
+                subtitle: p.onGround
+                  ? t('modals.search.flightOnGround')
+                  : fl !== null && kts !== null
+                    ? t('modals.search.flightAirborne', { fl: String(fl), kts: String(kts) })
+                    : fl !== null ? `FL${fl}` : t('modals.search.flightOnGround'),
+                data: { kind: 'adsb' as const, lat: p.lat, lon: p.lon, layer: 'flights' as const },
+              };
+            }));
+            this.ctx.searchModal.refreshSearch();
+          }).catch(() => {/* silent — stale results remain */});
+        }, 400);
+      });
+    }
 
     this.boundKeydownHandler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {

--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -92,6 +92,7 @@ export class SearchModal {
   private recentSearches: string[] = [];
   private onSelect?: (result: SearchResult) => void;
   private onCommand?: (command: Command) => void;
+  private onQueryChange?: (rawInput: string) => void;
   private placeholder: string;
   private activePanelIds: Set<string> = new Set();
   private isMobile: boolean;
@@ -120,6 +121,14 @@ export class SearchModal {
 
   public setOnCommand(callback: (command: Command) => void): void {
     this.onCommand = callback;
+  }
+
+  public setOnQueryChange(callback: (rawInput: string) => void): void {
+    this.onQueryChange = callback;
+  }
+
+  public refreshSearch(): void {
+    if (this.overlay) this.handleSearch();
   }
 
   public setActivePanels(panelIds: string[]): void {
@@ -283,6 +292,7 @@ export class SearchModal {
     }
 
     this.commandResults = this.matchCommands(query);
+    this.onQueryChange?.(rawInput);
 
     const byType = new Map<SearchResultType, (SearchResult & { _score: number })[]>();
 


### PR DESCRIPTION
## Root cause

The flight source was populated only from the **viewport-limited position cache** (`fetchViewportAircraft`), which:
1. Only runs when the `flights` layer is enabled
2. Only returns aircraft in the current map viewport
3. Returns nothing at zoom < 2 (global view)

So typing "flight EK528" at global zoom → empty source → no results, always.

## Fix

**SearchModal** now fires an `onQueryChange` callback on every keystroke.

**SearchManager** (PRO only) listens for `"flight "` prefix, debounces 400ms, then calls `fetchAircraftPositions({ callsign })` — the same API the map uses but with a direct callsign parameter for global lookup. When results arrive, it registers them into the flight source and calls `refreshSearch()`.

## Flow

```
user types "flight EK528"
  → onQueryChange("flight ek528")
  → debounce 400ms
  → fetchAircraftPositions({ callsign: "EK528" })
  → registerSource('flight', [{ title: 'EK528', subtitle: 'FL350 · 490 kts', ... }])
  → refreshSearch() → results appear
```

## Test plan

- [ ] Type `flight EK528` at global zoom → result appears after ~400ms debounce
- [ ] Type `flight UAE` → all UAE-prefixed callsigns appear
- [ ] Select result → map centers on the aircraft, flights layer enabled
- [ ] Non-PRO user → no lookup fires, no results
- [ ] Unknown callsign → empty results (silent, no error shown)