### PR TITLE
fix(search): submit-on-enter flight lookup, deduplicate ADS-B positions

### DIFF
--- a/src/app/search-manager.ts
+++ b/src/app/search-manager.ts
@@ -212,32 +212,35 @@ export class SearchManager implements AppModule {
     this.ctx.searchModal.setOnCommand((cmd) => this.handleCommand(cmd));
 
     if (isProUser()) {
-      let flightLookupTimer: ReturnType<typeof setTimeout> | null = null;
-      this.ctx.searchModal.setOnQueryChange((rawInput) => {
-        if (!rawInput.startsWith('flight ')) return;
-        const callsign = rawInput.slice(7).trim().toUpperCase();
-        if (callsign.length < 2) return;
-        if (flightLookupTimer) clearTimeout(flightLookupTimer);
-        flightLookupTimer = setTimeout(() => {
-          fetchAircraftPositions({ callsign }).then((positions) => {
-            if (!this.ctx.searchModal) return;
-            this.ctx.searchModal.registerSource('flight', positions.map(p => {
-              const fl = Number.isFinite(p.altitudeFt) ? Math.round(p.altitudeFt / 100) : null;
-              const kts = Number.isFinite(p.groundSpeedKts) ? Math.round(p.groundSpeedKts) : null;
-              return {
-                id: p.icao24,
-                title: (p.callsign || p.icao24).trim().toUpperCase(),
-                subtitle: p.onGround
-                  ? t('modals.search.flightOnGround')
-                  : fl !== null && kts !== null
-                    ? t('modals.search.flightAirborne', { fl: String(fl), kts: String(kts) })
-                    : fl !== null ? `FL${fl}` : t('modals.search.flightOnGround'),
-                data: { kind: 'adsb' as const, lat: p.lat, lon: p.lon, layer: 'flights' as const },
-              };
-            }));
-            this.ctx.searchModal.refreshSearch();
-          }).catch(() => {/* silent — stale results remain */});
-        }, 400);
+      this.ctx.searchModal.setOnFlightSearch((callsign) => {
+        fetchAircraftPositions({ callsign }).then((positions) => {
+          if (!this.ctx.searchModal) return;
+          // Deduplicate by callsign: keep the most recently observed entry per callsign.
+          const seen = new Map<string, PositionSample>();
+          for (const p of positions) {
+            const key = (p.callsign || p.icao24).trim().toUpperCase();
+            const existing = seen.get(key);
+            if (!existing || p.observedAt > existing.observedAt) {
+              seen.set(key, p);
+            }
+          }
+          const items = [...seen.values()].map(p => {
+            const fl = Number.isFinite(p.altitudeFt) ? Math.round(p.altitudeFt / 100) : null;
+            const kts = Number.isFinite(p.groundSpeedKts) ? Math.round(p.groundSpeedKts) : null;
+            return {
+              id: p.icao24,
+              title: (p.callsign || p.icao24).trim().toUpperCase(),
+              subtitle: p.onGround
+                ? t('modals.search.flightOnGround')
+                : fl !== null && kts !== null
+                  ? t('modals.search.flightAirborne', { fl: String(fl), kts: String(kts) })
+                  : fl !== null ? `FL${fl}` : t('modals.search.flightOnGround'),
+              data: { kind: 'adsb' as const, lat: p.lat, lon: p.lon, layer: 'flights' as const },
+            };
+          });
+          this.ctx.searchModal.registerSource('flight', items);
+          this.ctx.searchModal.refreshSearch();
+        }).catch(() => {/* silent — show no results */});
       });
     }
 

--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -93,6 +93,8 @@ export class SearchModal {
   private onSelect?: (result: SearchResult) => void;
   private onCommand?: (command: Command) => void;
   private onQueryChange?: (rawInput: string) => void;
+  private onFlightSearch?: (callsign: string) => void;
+  private currentFlightCallsign: string | null = null;
   private placeholder: string;
   private activePanelIds: Set<string> = new Set();
   private isMobile: boolean;
@@ -127,6 +129,10 @@ export class SearchModal {
     this.onQueryChange = callback;
   }
 
+  public setOnFlightSearch(callback: (callsign: string) => void): void {
+    this.onFlightSearch = callback;
+  }
+
   public refreshSearch(): void {
     if (this.overlay) this.handleSearch();
   }
@@ -144,6 +150,10 @@ export class SearchModal {
     }
     if (this.overlay) return;
     this.isMobile = isMobileDevice();
+    // Clear stale flight results from previous session so they don't bleed through.
+    const flightIdx = this.sources.findIndex(s => s.type === 'flight');
+    if (flightIdx >= 0) this.sources[flightIdx] = { type: 'flight', items: [] };
+    this.currentFlightCallsign = null;
     this.createModal();
     this.input?.focus();
     this.showingAllCommands = false;
@@ -167,6 +177,7 @@ export class SearchModal {
         this.results = [];
         this.commandResults = [];
         this.selectedIndex = 0;
+        this.currentFlightCallsign = null;
       };
       if (this.isMobile) {
         this.closeTimeoutId = setTimeout(() => {
@@ -297,20 +308,22 @@ export class SearchModal {
     const byType = new Map<SearchResultType, (SearchResult & { _score: number })[]>();
 
     // "flight {callsign}" prefix: use rawInput so a trailing space after "flight" is detected.
+    this.currentFlightCallsign = null;
     if (rawInput.startsWith('flight ')) {
-      const callsign = rawInput.slice(7).trim();
+      const callsign = rawInput.slice(7).trim().toUpperCase();
       if (callsign.length > 0) {
+        this.currentFlightCallsign = callsign;
         const flightSource = this.sources.find(s => s.type === 'flight');
-        if (flightSource) {
+        if (flightSource?.items.length) {
           byType.set('flight', flightSource.items
-            .filter(item => item.title.toLowerCase().includes(callsign))
+            .filter(item => item.title.toUpperCase().includes(callsign))
             .map(item => ({
               type: 'flight' as SearchResultType,
               id: item.id,
               title: item.title,
               subtitle: item.subtitle,
               data: item.data,
-              _score: item.title.toLowerCase().startsWith(callsign) ? 2 : 1,
+              _score: item.title.toUpperCase().startsWith(callsign) ? 2 : 1,
             })) as (SearchResult & { _score: number })[]);
         }
       }
@@ -548,6 +561,10 @@ export class SearchModal {
     if (!this.resultsList) return;
 
     if (this.commandResults.length === 0 && this.results.length === 0) {
+      if (this.currentFlightCallsign && this.onFlightSearch) {
+        this.renderFlightSearchTrigger(this.currentFlightCallsign);
+        return;
+      }
       this.resultsList.innerHTML = `
         <div class="search-empty">
           <div class="search-empty-icon">\u2205</div>
@@ -629,6 +646,34 @@ export class SearchModal {
     });
   }
 
+  private renderFlightSearchTrigger(callsign: string): void {
+    if (!this.resultsList) return;
+    this.resultsList.innerHTML = `
+      <div class="search-result-item selected" data-flight-trigger="${escapeHtml(callsign)}">
+        <span class="search-result-icon">\u2708\uFE0F</span>
+        <div class="search-result-content">
+          <div class="search-result-title">Search live flight <strong>${escapeHtml(callsign)}</strong></div>
+          <div class="search-result-subtitle">${escapeHtml(t('modals.search.flightSearchHint'))}</div>
+        </div>
+        <span class="search-result-type">${escapeHtml(t('modals.search.types.flight'))}</span>
+      </div>`;
+    this.resultsList.querySelector('[data-flight-trigger]')?.addEventListener('click', () => {
+      this.triggerFlightSearch(callsign);
+    });
+  }
+
+  private triggerFlightSearch(callsign: string): void {
+    if (!this.onFlightSearch || !this.resultsList) return;
+    this.resultsList.innerHTML = `
+      <div class="search-result-item">
+        <span class="search-result-icon">\u2708\uFE0F</span>
+        <div class="search-result-content">
+          <div class="search-result-title">Searching for <strong>${escapeHtml(callsign)}</strong>\u2026</div>
+        </div>
+      </div>`;
+    this.onFlightSearch(callsign);
+  }
+
   private renderChips(query?: string): void {
     if (!this.chipsContainer) return;
     if (query && query.length >= 1) {
@@ -685,6 +730,10 @@ export class SearchModal {
         break;
       case 'Enter':
         e.preventDefault();
+        if (this.currentFlightCallsign && this.onFlightSearch && this.results.length === 0 && this.commandResults.length === 0) {
+          this.triggerFlightSearch(this.currentFlightCallsign);
+          return;
+        }
         this.selectResult(this.selectedIndex);
         break;
       case 'Escape':

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -502,7 +502,8 @@
       "flightOnGround": "On ground",
       "flightAirborne": "FL{{fl}} · {{kts}} kts",
       "flightMilitary": "Military · {{type}} · FL{{fl}}",
-      "flightMilitaryOnGround": "Military · {{type}} · on ground"
+      "flightMilitaryOnGround": "Military · {{type}} · on ground",
+      "flightSearchHint": "Press Enter or click to look up live position"
     },
     "signal": {
       "title": "INTELLIGENCE FINDING",


### PR DESCRIPTION
## Summary

- **Submit UX**: typing `flight EK36` now shows a single \"Search live flight EK36\" trigger item instead of firing an API call on every keystroke. Pressing Enter or clicking it fires one lookup, shows \"Searching for EK36...\" while pending, then populates results.
- **Deduplication**: `fetchAircraftPositions` can return multiple `PositionSample` entries for the same callsign (different ADS-B receivers). Results are now deduplicated by callsign, keeping the most recently observed entry. Fixes the 3x EK3/EK36 duplicates shown to users.
- **Wrong coordinates fix**: the stale receiver entry (wrong location) was previously displayed alongside fresher ones. Dedup-by-recency ensures the most current position is used, fixing the Africa click bug on EK36.
- **No bleed-through**: stale flight results from a previous search are cleared when the modal opens.
- **Non-PRO unchanged**: all changes are behind the `isProUser()` guard; non-PRO users see no difference.

## Test plan

- [ ] Type `flight EK36` as a PRO user — see single \"Search live flight EK36\" item, no results yet
- [ ] Press Enter — see \"Searching for EK36...\" then results appear (one result per callsign, not duplicates)
- [ ] Click the result — map centers on correct location (not Africa)
- [ ] Close modal, reopen, type a different callsign — no stale results from previous search
- [ ] Repeat as non-PRO user — no flight trigger or results visible, normal empty state