### PR TITLE
fix(consumer-prices): fix GROUP BY error in publish overview/categories queries

### DIFF
--- a/consumer-prices-core/src/snapshots/worldmonitor.ts
+++ b/consumer-prices-core/src/snapshots/worldmonitor.ts
@@ -137,7 +137,7 @@ async function buildTopCategories(basketId: string): Promise<WMCategorySnapshot[
          )
      )
      SELECT
-       t.category,
+       cats.category,
        MAX(CASE WHEN t.metric_key = 'essentials_index' THEN t.metric_value END) AS current_index,
        MAX(CASE WHEN lw.metric_key = 'essentials_index' THEN lw.metric_value END) AS prev_week_index,
        MAX(CASE WHEN t.metric_key = 'coverage_pct' THEN t.metric_value END) AS coverage_pct


### PR DESCRIPTION
## Summary
- \`buildTopCategories()\` selected \`t.category\` in SELECT but grouped by \`cats.category\`
- PostgreSQL requires every non-aggregated column in SELECT to appear in GROUP BY
- \`t.category = cats.category\` by the JOIN but PG doesn't fold them — changed \`SELECT t.category\` to \`SELECT cats.category\` (already in GROUP BY)
- Fixes 4 errors in publish log: \`overview:ae\`, \`categories:ae:7d\`, \`categories:ae:30d\`, \`categories:ae:90d\`

## Test plan
- [ ] Trigger manual run of \`seed-consumer-prices-publish\` and confirm no GROUP BY errors
- [ ] Confirm \`consumer-prices:overview:ae\` key is written to Redis