### PR TITLE
feat(map): hourglass loading indicator on aviation layer toggle

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -4947,6 +4947,7 @@ export class DeckGLMap {
     const sw = bounds.getSouthWest();
     const ne = bounds.getNorthEast();
     const seq = ++this.aircraftFetchSeq;
+    this.setLayerLoading('flights', true);
     fetchAircraftPositions({
       swLat: sw.lat, swLon: sw.lng,
       neLat: ne.lat, neLon: ne.lng,
@@ -4959,9 +4960,11 @@ export class DeckGLMap {
         this.lastAircraftFetchCenter = [center.lng, center.lat];
         this.lastAircraftFetchZoom = this.maplibreMap!.getZoom();
       }
+      this.setLayerReady('flights', positions.length > 0);
       this.render();
     }).catch((err) => {
       console.error('[aircraft] fetch error', err);
+      this.setLayerLoading('flights', false);
     });
   }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -15078,6 +15078,15 @@ a.prediction-link:hover {
   animation: layer-loading 0.8s ease-in-out infinite;
 }
 
+.deckgl-layer-toggles .layer-toggle.loading .toggle-icon {
+  font-size: 0;
+}
+
+.deckgl-layer-toggles .layer-toggle.loading .toggle-icon::after {
+  content: '\23F3';
+  font-size: 12px;
+}
+
 .deckgl-layer-toggles .layer-toggle.has-data .toggle-label {
   color: var(--green);
 }


### PR DESCRIPTION
## Summary

- While `fetchViewportAircraft()` is in flight, the Aviation layer toggle now shows ⏳ (replacing ✈) and the label pulses yellow via the existing `layer-loading` animation
- Once data arrives, the toggle resolves to its normal state: ✈ icon restored, green-bordered `active` class if planes were found
- On fetch error, loading state is cleared cleanly
- Indicator only fires when a real fetch starts (viewport actually changed) — never on cache hits or stale-response discards (sequence guard)
- Uses the existing `setLayerLoading` / `setLayerReady` API in DeckGLMap — previously wired for other layers but unused for flights

## Test plan

- [ ] Enable Aviation layer, pan/zoom to a region — ⏳ appears on the toggle while loading, ✈ restores when planes render
- [ ] Pan rapidly — hourglass stays on until the final fetch resolves (stale intermediates don't clear it early)
- [ ] Zoom out past level 2 — no hourglass (no fetch fires)
- [ ] Disable aviation layer — toggle returns to unchecked state, no ghost loading indicator