### PR TITLE
fix(consumer-prices): reduce CDN cache from static(4h) to slow(1h), fix unavailable hydration guard

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -163,11 +163,11 @@ const RPC_CACHE_TIER: Record<string, CacheTier> = {
   '/api/webcam/v1/get-webcam-image': 'no-store',
   '/api/webcam/v1/list-webcams': 'no-store',
 
-  '/api/consumer-prices/v1/get-consumer-price-overview': 'static',
+  '/api/consumer-prices/v1/get-consumer-price-overview': 'slow',
   '/api/consumer-prices/v1/get-consumer-price-basket-series': 'slow',
-  '/api/consumer-prices/v1/list-consumer-price-categories': 'static',
-  '/api/consumer-prices/v1/list-consumer-price-movers': 'static',
-  '/api/consumer-prices/v1/list-retailer-price-spreads': 'static',
+  '/api/consumer-prices/v1/list-consumer-price-categories': 'slow',
+  '/api/consumer-prices/v1/list-consumer-price-movers': 'slow',
+  '/api/consumer-prices/v1/list-retailer-price-spreads': 'slow',
   '/api/consumer-prices/v1/get-consumer-price-freshness': 'slow',
 
   '/api/aviation/v1/get-youtube-live-stream-info': 'fast',

--- a/src/services/consumer-prices/index.ts
+++ b/src/services/consumer-prices/index.ts
@@ -135,7 +135,7 @@ export async function fetchConsumerPriceOverview(
   basketSlug = DEFAULT_BASKET,
 ): Promise<GetConsumerPriceOverviewResponse> {
   const hydrated = getHydratedData('consumerPricesOverview') as GetConsumerPriceOverviewResponse | undefined;
-  if (hydrated?.asOf) return hydrated;
+  if (hydrated?.asOf && !hydrated.upstreamUnavailable) return hydrated;
 
   try {
     return await overviewBreaker.execute(


### PR DESCRIPTION
## Summary

- **Root cause**: Consumer prices RPC endpoints (`overview`, `categories`, `movers`, `spread`) were using `static` CDN tier (4h `s-maxage`). When the CDN cached a response with `upstreamUnavailable: true` (before first data landed in Redis from the new Railway cron), it served stale for up to 4 hours — blocking the panel even after data was successfully published.
- **Secondary bug**: `fetchConsumerPriceOverview` had `if (hydrated?.asOf) return hydrated` — but `asOf: '0'` (the empty fallback) is truthy in JS, so bootstrap could return unavailable data and the function would short-circuit without ever calling the RPC.

## Changes

- `server/gateway.ts`: downgrade overview/categories/movers/spread from `static` → `slow` (CDN 1h instead of 4h). Deploying this PR purges Vercel's CDN cache for those paths immediately.
- `src/services/consumer-prices/index.ts`: add `!hydrated.upstreamUnavailable` guard so stale unavailable bootstrap data doesn't silently skip the live RPC call.

## Test plan

- [ ] After merge + deploy, hard-refresh worldmonitor — Consumer Prices panel shows real data (not "Data collection in progress")
- [ ] Verify `/api/consumer-prices/v1/get-consumer-price-overview` response has `upstreamUnavailable: false`
- [ ] Confirm cache headers changed to `slow` tier (`max-age=300`)