### PR TITLE
fix(aviation): route callsign search through Wingbits relay, no simulated fallback

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3085,20 +3085,25 @@ async function handleWingbitsTrackRequest(req, res) {
 
   const url = new URL(req.url, 'http://localhost');
   const params = url.searchParams;
+  const callsignFilter = (params.get('callsign') || '').trim().toUpperCase();
   const laminStr = params.get('lamin');
   const lominStr = params.get('lomin');
   const lamaxStr = params.get('lamax');
   const lomaxStr = params.get('lomax');
 
-  if (!laminStr || !lominStr || !lamaxStr || !lomaxStr) {
+  // For callsign-only searches (no bbox), use a global area so Wingbits can find the aircraft
+  // regardless of where it currently is.
+  const isGlobalSearch = callsignFilter && (!laminStr || !lominStr || !lamaxStr || !lomaxStr);
+
+  if (!isGlobalSearch && (!laminStr || !lominStr || !lamaxStr || !lomaxStr)) {
     return safeEnd(res, 400, { 'Content-Type': 'application/json' },
       JSON.stringify({ error: 'Missing bbox params: lamin, lomin, lamax, lomax', positions: [] }));
   }
 
-  const lamin = Number(laminStr);
-  const lomin = Number(lominStr);
-  const lamax = Number(lamaxStr);
-  const lomax = Number(lomaxStr);
+  const lamin = isGlobalSearch ? -80 : Number(laminStr);
+  const lomin = isGlobalSearch ? -180 : Number(lominStr);
+  const lamax = isGlobalSearch ? 80 : Number(lamaxStr);
+  const lomax = isGlobalSearch ? 180 : Number(lomaxStr);
 
   if (!Number.isFinite(lamin) || !Number.isFinite(lomin) || !Number.isFinite(lamax) || !Number.isFinite(lomax)) {
     return safeEnd(res, 400, { 'Content-Type': 'application/json' },
@@ -3109,7 +3114,8 @@ async function handleWingbitsTrackRequest(req, res) {
   const centerLon = (lomin + lomax) / 2;
   const widthNm = Math.abs(lomax - lomin) * 60 * Math.cos(centerLat * Math.PI / 180);
   const heightNm = Math.abs(lamax - lamin) * 60;
-  const areas = [{ alias: 'viewport', by: 'box', la: centerLat, lo: centerLon, w: widthNm, h: heightNm, unit: 'nm' }];
+  const alias = isGlobalSearch ? `callsign-search-${callsignFilter}` : 'viewport';
+  const areas = [{ alias, by: 'box', la: centerLat, lo: centerLon, w: widthNm, h: heightNm, unit: 'nm' }];
 
   try {
     const resp = await fetch('https://customer-api.wingbits.com/v1/flights', {
@@ -3142,6 +3148,11 @@ async function handleWingbitsTrackRequest(req, res) {
       for (const f of flightList) {
         const icao24 = f.h || f.icao24 || f.id || '';
         if (!icao24 || seenIds.has(icao24)) continue;
+        // For callsign searches, skip non-matching flights early to keep response small.
+        if (callsignFilter) {
+          const cs = (f.f || f.callsign || f.flight || '').trim().toUpperCase();
+          if (!cs.includes(callsignFilter)) continue;
+        }
         seenIds.add(icao24);
         const lat = f.la ?? f.latitude ?? f.lat ?? 0;
         const lon = f.lo ?? f.longitude ?? f.lon ?? f.lng ?? 0;

--- a/server/worldmonitor/aviation/v1/track-aircraft.ts
+++ b/server/worldmonitor/aviation/v1/track-aircraft.ts
@@ -138,18 +138,29 @@ export async function trackAircraft(
                     console.warn(`[Aviation] Direct OpenSky anonymous failed: ${err instanceof Error ? err.message : err}`);
                 }
 
-                // Try Wingbits relay (bbox only — no global fallback)
-                if (relayBase && req.swLat != null && req.neLat != null) {
+                // Try Wingbits relay. Supports bbox queries and, for callsign-only searches,
+                // a global bbox so we can find the aircraft regardless of position.
+                if (relayBase) {
                     try {
-                        const wbUrl = `${relayBase}/wingbits/track?lamin=${req.swLat}&lomin=${req.swLon}&lamax=${req.neLat}&lomax=${req.neLon}`;
-                        const wbResp = await fetch(wbUrl, {
-                            headers: getRelayHeaders({}),
-                            signal: AbortSignal.timeout(15_000),
-                        });
-                        if (wbResp.ok) {
-                            const wbData = await wbResp.json() as WingbitsRelayResponse;
-                            if (wbData.positions && wbData.positions.length > 0) {
-                                return { positions: wbData.positions, source: 'wingbits' };
+                        let wbUrl: string;
+                        if (req.swLat != null && req.neLat != null) {
+                            wbUrl = `${relayBase}/wingbits/track?lamin=${req.swLat}&lomin=${req.swLon}&lamax=${req.neLat}&lomax=${req.neLon}`;
+                        } else if (req.callsign) {
+                            // Global search — relay uses a worldwide box and filters by callsign.
+                            wbUrl = `${relayBase}/wingbits/track?callsign=${encodeURIComponent(req.callsign)}`;
+                        } else {
+                            wbUrl = '';
+                        }
+                        if (wbUrl) {
+                            const wbResp = await fetch(wbUrl, {
+                                headers: getRelayHeaders({}),
+                                signal: AbortSignal.timeout(15_000),
+                            });
+                            if (wbResp.ok) {
+                                const wbData = await wbResp.json() as WingbitsRelayResponse;
+                                if (wbData.positions && wbData.positions.length > 0) {
+                                    return { positions: wbData.positions, source: 'wingbits' };
+                                }
                             }
                         }
                     } catch (err) {
@@ -171,7 +182,14 @@ export async function trackAircraft(
         return { positions, source: result.source, updatedAt: Date.now() };
     }
 
-    // Fallback to simulated data (not cached — random each time)
+    // For explicit callsign/icao24 lookups (search modal), return empty rather than fake planes.
+    // Simulated fallback only makes sense for viewport display — scattering random planes near (0,0)
+    // with the searched callsign produces misleading results in the Gulf of Guinea.
+    if (req.callsign || req.icao24) {
+        return { positions: [], source: 'none', updatedAt: Date.now() };
+    }
+
+    // Fallback to simulated data for viewport display when all real sources are down.
     const positions = buildSimulatedPositions(req.icao24, req.callsign, req.swLat, req.swLon, req.neLat, req.neLon);
     return { positions, source: 'simulated', updatedAt: Date.now() };
 }

--- a/src/app/search-manager.ts
+++ b/src/app/search-manager.ts
@@ -215,9 +215,12 @@ export class SearchManager implements AppModule {
       this.ctx.searchModal.setOnFlightSearch((callsign) => {
         fetchAircraftPositions({ callsign }).then((positions) => {
           if (!this.ctx.searchModal) return;
+          // Reject simulated fallback positions — they're fake data near (0°,0°) and should
+          // never appear in search results. Real sources use POSITION_SOURCE_OPENSKY etc.
+          const real = positions.filter(p => !p.source?.toLowerCase().includes('simulated'));
           // Deduplicate by callsign: keep the most recently observed entry per callsign.
           const seen = new Map<string, PositionSample>();
-          for (const p of positions) {
+          for (const p of real) {
             const key = (p.callsign || p.icao24).trim().toUpperCase();
             const existing = seen.get(key);
             if (!existing || p.observedAt > existing.observedAt) {


### PR DESCRIPTION
## Summary

- **Relay**: `/wingbits/track` now accepts `?callsign=EK36` without a bounding box, falling back to a global bbox (`-80/-180/80/180`) for worldwide aircraft lookup. Callsign filtering applied server-side in the relay response loop.
- **Server**: `track-aircraft.ts` now tries Wingbits for callsign-only searches (previously Wingbits was only tried for bbox queries). Returns empty positions instead of simulated fallback for explicit callsign/icao24 lookups.
- **Client**: `search-manager.ts` filters out simulated-source positions before displaying results, preventing fake planes from appearing in the search modal.

Previously, searching for a flight like `EK36` via the CMD+K trigger would:
1. Skip Wingbits (no bbox) → fall through to simulated
2. Show 10-15 fake planes near (0°, 0°) in the Gulf of Guinea labeled "Source: Simulated"

Now: Wingbits is tried first with a global bbox + callsign filter, returning real live positions.

## Test plan

- [ ] Open CMD+K, type `flight EK36`, press Enter
- [ ] Verify "Searching for EK36…" shows briefly then results appear (real aircraft, not simulated)
- [ ] Verify no planes appear in Africa/Gulf of Guinea with `Source: Simulated` label
- [ ] Verify clicking a result centers map on correct coordinates
- [ ] Verify searching an unknown callsign returns empty results (not fake planes)
- [ ] Verify viewport aircraft loading still works (bbox queries unaffected)