### PR TITLE
fix(search): show 'no live position found' when flight search returns empty

### DIFF
--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -95,6 +95,7 @@ export class SearchModal {
   private onQueryChange?: (rawInput: string) => void;
   private onFlightSearch?: (callsign: string) => void;
   private currentFlightCallsign: string | null = null;
+  private flightSearchFired = false;
   private placeholder: string;
   private activePanelIds: Set<string> = new Set();
   private isMobile: boolean;
@@ -154,6 +155,7 @@ export class SearchModal {
     const flightIdx = this.sources.findIndex(s => s.type === 'flight');
     if (flightIdx >= 0) this.sources[flightIdx] = { type: 'flight', items: [] };
     this.currentFlightCallsign = null;
+    this.flightSearchFired = false;
     this.createModal();
     this.input?.focus();
     this.showingAllCommands = false;
@@ -178,6 +180,7 @@ export class SearchModal {
         this.commandResults = [];
         this.selectedIndex = 0;
         this.currentFlightCallsign = null;
+        this.flightSearchFired = false;
       };
       if (this.isMobile) {
         this.closeTimeoutId = setTimeout(() => {
@@ -309,6 +312,7 @@ export class SearchModal {
     // "flight {callsign}" prefix: bypass command matching entirely — "flight ek36" contains
     // substrings like "light" that spuriously match unrelated commands (e.g. "Switch to light mode").
     this.currentFlightCallsign = null;
+    this.flightSearchFired = false;
     if (rawInput.startsWith('flight ') && this.onFlightSearch) {
       const callsign = rawInput.slice(7).trim().toUpperCase();
       if (callsign.length > 0) {
@@ -565,7 +569,15 @@ export class SearchModal {
 
     if (this.commandResults.length === 0 && this.results.length === 0) {
       if (this.currentFlightCallsign && this.onFlightSearch) {
-        this.renderFlightSearchTrigger(this.currentFlightCallsign);
+        if (this.flightSearchFired) {
+          this.resultsList.innerHTML = `
+            <div class="search-empty">
+              <div class="search-empty-icon">\u2708\uFE0F</div>
+              <div>${escapeHtml(t('modals.search.flightNotFound', { callsign: this.currentFlightCallsign }))}</div>
+            </div>`;
+        } else {
+          this.renderFlightSearchTrigger(this.currentFlightCallsign);
+        }
         return;
       }
       this.resultsList.innerHTML = `
@@ -667,6 +679,7 @@ export class SearchModal {
 
   private triggerFlightSearch(callsign: string): void {
     if (!this.onFlightSearch || !this.resultsList) return;
+    this.flightSearchFired = true;
     this.resultsList.innerHTML = `
       <div class="search-result-item">
         <span class="search-result-icon">\u2708\uFE0F</span>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -503,7 +503,8 @@
       "flightAirborne": "FL{{fl}} · {{kts}} kts",
       "flightMilitary": "Military · {{type}} · FL{{fl}}",
       "flightMilitaryOnGround": "Military · {{type}} · on ground",
-      "flightSearchHint": "Press Enter or click to look up live position"
+      "flightSearchHint": "Press Enter or click to look up live position",
+      "flightNotFound": "No live position found for {{callsign}}"
     },
     "signal": {
       "title": "INTELLIGENCE FINDING",


### PR DESCRIPTION
## Summary

When CMD+K flight search fired and returned `positions: []`, `registerSource('flight', [])` + `refreshSearch()` caused `renderResults` to re-render the "Search live flight" trigger again (since `currentFlightCallsign` was still set), creating an infinite loop appearance.

Added `flightSearchFired` flag to distinguish pre-search (show trigger) from post-search-with-no-results (show "No live position found for EK36").

## Test plan

- [ ] Type `flight EK36`, press Enter — shows "Searching for EK36…" then "No live position found for EK36" (not the trigger again)
- [ ] Type `flight SWR785B` when flight is in viewport — shows the flight result
- [ ] Re-open CMD+K — trigger shows fresh (not empty state)