### PR TITLE
fix(aviation): fix callsign search via relay in-memory position index

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3076,6 +3076,37 @@ const THEATER_QUERY_REGIONS = [
   { name: 'PACIFIC', lamin: 4, lamax: 44, lomin: 104, lomax: 133 },
 ];
 
+// In-memory index of recently-seen Wingbits positions, keyed by ICAO24.
+// Populated on every successful bbox response; served for callsign-only lookups.
+// Entries expire after 5 minutes (Wingbits data is live, stale beyond that is misleading).
+const WINGBITS_POS_INDEX = new Map(); // icao24 -> { position, ts }
+const WINGBITS_POS_INDEX_TTL_MS = 5 * 60 * 1000;
+
+function wingbitsIndexUpdate(positions) {
+  const ts = Date.now();
+  for (const p of positions) {
+    if (p.icao24) WINGBITS_POS_INDEX.set(p.icao24, { position: p, ts });
+  }
+  // Prune stale entries to prevent unbounded growth.
+  if (WINGBITS_POS_INDEX.size > 5000) {
+    const cutoff = ts - WINGBITS_POS_INDEX_TTL_MS;
+    for (const [k, v] of WINGBITS_POS_INDEX) {
+      if (v.ts < cutoff) WINGBITS_POS_INDEX.delete(k);
+    }
+  }
+}
+
+function wingbitsIndexLookupCallsign(callsign) {
+  const cutoff = Date.now() - WINGBITS_POS_INDEX_TTL_MS;
+  const results = [];
+  for (const { position, ts } of WINGBITS_POS_INDEX.values()) {
+    if (ts < cutoff) continue;
+    const cs = (position.callsign || '').trim().toUpperCase();
+    if (cs.includes(callsign)) results.push(position);
+  }
+  return results;
+}
+
 async function handleWingbitsTrackRequest(req, res) {
   const apiKey = process.env.WINGBITS_API_KEY;
   if (!apiKey) {
@@ -3091,19 +3122,25 @@ async function handleWingbitsTrackRequest(req, res) {
   const lamaxStr = params.get('lamax');
   const lomaxStr = params.get('lomax');
 
-  // For callsign-only searches (no bbox), use a global area so Wingbits can find the aircraft
-  // regardless of where it currently is.
-  const isGlobalSearch = callsignFilter && (!laminStr || !lominStr || !lamaxStr || !lomaxStr);
+  // For callsign-only searches (no bbox), serve from the in-memory position index populated
+  // by recent bbox responses. A worldwide Wingbits API call is unreliable (too large an area).
+  const isBboxMissing = !laminStr || !lominStr || !lamaxStr || !lomaxStr;
+  if (callsignFilter && isBboxMissing) {
+    const hits = wingbitsIndexLookupCallsign(callsignFilter);
+    return sendCompressed(req, res, 200,
+      { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+      JSON.stringify({ positions: hits, source: 'wingbits' }));
+  }
 
-  if (!isGlobalSearch && (!laminStr || !lominStr || !lamaxStr || !lomaxStr)) {
+  if (isBboxMissing) {
     return safeEnd(res, 400, { 'Content-Type': 'application/json' },
       JSON.stringify({ error: 'Missing bbox params: lamin, lomin, lamax, lomax', positions: [] }));
   }
 
-  const lamin = isGlobalSearch ? -80 : Number(laminStr);
-  const lomin = isGlobalSearch ? -180 : Number(lominStr);
-  const lamax = isGlobalSearch ? 80 : Number(lamaxStr);
-  const lomax = isGlobalSearch ? 180 : Number(lomaxStr);
+  const lamin = Number(laminStr);
+  const lomin = Number(lominStr);
+  const lamax = Number(lamaxStr);
+  const lomax = Number(lomaxStr);
 
   if (!Number.isFinite(lamin) || !Number.isFinite(lomin) || !Number.isFinite(lamax) || !Number.isFinite(lomax)) {
     return safeEnd(res, 400, { 'Content-Type': 'application/json' },
@@ -3114,8 +3151,7 @@ async function handleWingbitsTrackRequest(req, res) {
   const centerLon = (lomin + lomax) / 2;
   const widthNm = Math.abs(lomax - lomin) * 60 * Math.cos(centerLat * Math.PI / 180);
   const heightNm = Math.abs(lamax - lamin) * 60;
-  const alias = isGlobalSearch ? `callsign-search-${callsignFilter}` : 'viewport';
-  const areas = [{ alias, by: 'box', la: centerLat, lo: centerLon, w: widthNm, h: heightNm, unit: 'nm' }];
+  const areas = [{ alias: 'viewport', by: 'box', la: centerLat, lo: centerLon, w: widthNm, h: heightNm, unit: 'nm' }];
 
   try {
     const resp = await fetch('https://customer-api.wingbits.com/v1/flights', {
@@ -3172,6 +3208,8 @@ async function handleWingbitsTrackRequest(req, res) {
       }
     }
 
+    // Populate in-memory index so callsign-only lookups can resolve without a global API call.
+    wingbitsIndexUpdate(positions);
     logThrottled('log', 'wingbits-track', `[Wingbits Track] ${positions.length} flights for bbox ${lamin},${lomin},${lamax},${lomax}`);
     return sendCompressed(req, res, 200,
       { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=30', 'CDN-Cache-Control': 'public, max-age=15' },

--- a/server/worldmonitor/aviation/v1/track-aircraft.ts
+++ b/server/worldmonitor/aviation/v1/track-aircraft.ts
@@ -10,6 +10,10 @@ import { CHROME_UA } from '../../../_shared/constants';
 
 // 120s for anonymous OpenSky tier (~10 req/min limit); TODO: reduce to 10s on commercial tier
 const CACHE_TTL = 120;
+// Callsign searches hit the relay's in-memory index (5min TTL); cache positive hits 60s,
+// negative hits 10s so a retry after panning into view returns fresh data quickly.
+const CALLSIGN_CACHE_TTL = 60;
+const CALLSIGN_NEGATIVE_TTL = 10;
 
 interface OpenSkyResponse {
     states?: unknown[][];
@@ -64,8 +68,9 @@ async function fetchOpenSkyAnonymous(req: TrackAircraftRequest): Promise<Positio
 function buildCacheKey(req: TrackAircraftRequest): string {
     if (req.icao24) return `aviation:track:icao:${req.icao24}:v1`;
     if (req.swLat != null && req.neLat != null) {
-        return `aviation:track:${Math.floor(req.swLat)}:${Math.floor(req.swLon)}:${Math.ceil(req.neLat)}:${Math.ceil(req.neLon)}:v1`;
+        return `aviation:track:bbox:${Math.floor(req.swLat)}:${Math.floor(req.swLon)}:${Math.ceil(req.neLat)}:${Math.ceil(req.neLon)}:v1`;
     }
+    if (req.callsign) return `aviation:track:callsign:${req.callsign.toUpperCase()}:v1`;
     return 'aviation:track:all:v1';
 }
 
@@ -82,8 +87,10 @@ export async function trackAircraft(
 
     let result: { positions: PositionSample[]; source: string } | null = null;
     try {
+        const positiveTtl = req.callsign ? CALLSIGN_CACHE_TTL : CACHE_TTL;
+        const negativeTtl = req.callsign ? CALLSIGN_NEGATIVE_TTL : CACHE_TTL;
         result = await cachedFetchJson<{ positions: PositionSample[]; source: string }>(
-            cacheKey, CACHE_TTL, async () => {
+            cacheKey, positiveTtl, async () => {
                 const relayBase = getRelayBaseUrl();
 
                 // Try relay first if configured
@@ -154,7 +161,7 @@ export async function trackAircraft(
                 }
 
                 return null; // negative-cached briefly
-            }, CACHE_TTL, // negative TTL same as positive — retry quickly
+            }, negativeTtl,
         );
     } catch {
         /* Redis unavailable — fall through to simulated */


### PR DESCRIPTION
## Root cause

`?callsign=CTN465` was triggering a global Wingbits API call with bbox `lamin=-80, lomin=-180, lamax=80, lomax=180`. Wingbits returns 401/empty for such an area — the API is designed for regional queries, not worldwide ones.

Additionally, callsign-only searches all shared the Redis cache key `aviation:track:all:v1` (no callsign in the key), so the first empty result poisoned the cache for all subsequent searches.

## Fix

**Relay**: Remove the global Wingbits API call entirely. Instead:
- Maintain an in-memory `WINGBITS_POS_INDEX` (Map of icao24 → position + timestamp)
- After every successful bbox response, call `wingbitsIndexUpdate(positions)` to populate it
- For callsign-only queries (`?callsign=CTN465`), call `wingbitsIndexLookupCallsign(callsign)` to search the index (fresh within 5 min)
- Prune entries older than 5 min and cap at 5000 entries

**Server**: Fix `buildCacheKey` to include callsign (`aviation:track:callsign:CTN465:v1`), and use shorter TTLs for callsign searches (60s positive, 10s negative).

## How it works after this fix

1. User pans map → viewport bbox query hits Wingbits → relay populates index with all visible aircraft
2. User opens CMD+K, types `flight CTN465` → relay checks index → returns position immediately
3. Works for any flight that has appeared in any recent viewport query

## Test plan

- [ ] Pan to a region with Wingbits coverage (Europe)
- [ ] Click an aircraft to confirm `POSITION_SOURCE_WINGBITS` popup
- [ ] Open CMD+K, type `flight {callsign}` where callsign is from the visible plane
- [ ] Press Enter → should return the flight with correct position
- [ ] Type unknown callsign → shows "No live position found for X"