### PR TITLE
fix(health): correct consumerPricesFreshness maxStaleMin + fix token SEED_META mismatch

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -155,8 +155,11 @@ const SEED_META = {
   consumerPricesCategories: { key: 'seed-meta:consumer-prices:categories:ae:30d',            maxStaleMin: 90 },
   consumerPricesMovers:     { key: 'seed-meta:consumer-prices:movers:ae:30d',               maxStaleMin: 90 },
   consumerPricesSpread:     { key: 'seed-meta:consumer-prices:retailer-spread:ae:essentials-ae', maxStaleMin: 120 }, // TTL=60min; 2× interval
-  consumerPricesFreshness:  { key: 'seed-meta:consumer-prices:freshness:ae',    maxStaleMin: 30  }, // TTL=10min; 3× interval
-  tokenPanels:       { key: 'seed-meta:market:token-panels',                   maxStaleMin: 90 }, // cron every 30min; 3× interval
+  consumerPricesFreshness:  { key: 'seed-meta:consumer-prices:freshness:ae',    maxStaleMin: 90 }, // publish.ts runs independently; align with other consumer-prices keys
+  // defiTokens/aiTokens/otherTokens all share one seed run (seed-token-panels cron, every 30min)
+  defiTokens:        { key: 'seed-meta:market:token-panels', maxStaleMin: 90 },
+  aiTokens:          { key: 'seed-meta:market:token-panels', maxStaleMin: 90 },
+  otherTokens:       { key: 'seed-meta:market:token-panels', maxStaleMin: 90 },
 };
 
 // Standalone keys that are populated on-demand by RPC handlers (not seeds).


### PR DESCRIPTION
## Summary

- **`consumerPricesFreshness` false STALE_SEED**: maxStaleMin was 30, set from the old manual seed script TTL assumption (10 min). The authoritative writer is `consumer-prices-core/publish.ts` which runs independently. Changed to 90 min, matching all other consumer-prices keys (overview/categories/movers already at 90).
- **Token panel SEED_META name mismatch (PR #1977 bug)**: `defiTokens`, `aiTokens`, `otherTokens` were added to BOOTSTRAP_KEYS but the SEED_META entry was named `tokenPanels` — never matching any key. Health looked up `SEED_META['defiTokens'] = undefined`, so when token keys expired (TTL=1h) health jumped straight to CRIT with no STALE_SEED early warning. Fixed: renamed to the three BOOTSTRAP_KEY names, all pointing to `seed-meta:market:token-panels`.

## Test plan

- [ ] Health endpoint shows no STALE_SEED for `consumerPricesFreshness` (was 54 min, max was 30)
- [ ] Token panel keys now show STALE_SEED warning before going CRIT when Railway cron misses
- [ ] All 2173 unit tests pass
- [ ] All 121 edge function tests pass