### PR TITLE
fix(bootstrap): stop perpetuating stale cached timestamp across sessions

### DIFF
--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -144,8 +144,7 @@ async function fetchTier(tier: 'fast' | 'slow', signal: AbortSignal): Promise<Bo
         }
       }
       if (filledAny) {
-        tierState = { source: 'mixed', updatedAt: cached.updatedAt };
-        saveUpdatedAt = cached.updatedAt; // preserve staleness: don't let cache write reset the age clock
+        tierState = { source: 'mixed', updatedAt: Date.now() };
       }
     }
   }


### PR DESCRIPTION
## Summary

- Fixes the CACHED banner persistently showing "7h ago" (growing staler each visit) after a bootstrap response with missing keys
- When the live bootstrap returns but some keys are absent (filled from IDB cache), the tier was previously saved back to IndexedDB with the **old** `updatedAt` — causing the stale timestamp to round-trip on every load
- Now the IDB is written with `Date.now()` and the in-memory `tierState.updatedAt` also reflects the current time, so the brief pre-`markBootstrapAsLive` flash shows "just now" instead of the preserved stale age

## Root cause

`fetchTier()` had `saveUpdatedAt = cached.updatedAt` when filling missing keys from cache (mixed state). This perpetuated a loop: each load read the old timestamp, showed "Xh ago" in the banner, then wrote it back unchanged — making the banner grow staler with each session.

## Test plan

- [ ] Open app — CACHED banner (if it appears) shows "just now" not "7h ago"
- [ ] Reload — IDB timestamp is now fresh, no stale age shown on next visit
- [ ] `markBootstrapAsLive()` still clears the banner after panels load as before
- [ ] All 2173 unit tests pass