### PR TITLE
fix(bootstrap): suppress CACHED banner for mixed hydration state

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -118,7 +118,7 @@ export class App {
 
   private getCachedBootstrapUpdatedAt(): number | null {
     const cachedTierTimestamps = Object.values(this.bootstrapHydrationState.tiers)
-      .filter((tier) => tier.source === 'cached' || tier.source === 'mixed')
+      .filter((tier) => tier.source === 'cached')
       .map((tier) => tier.updatedAt)
       .filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
 
@@ -130,16 +130,26 @@ export class App {
     const statusIndicator = this.state.container.querySelector('.status-indicator');
     const statusLabel = statusIndicator?.querySelector('span:last-child');
     const online = typeof navigator === 'undefined' ? true : navigator.onLine !== false;
-    const usingCachedBootstrap = this.bootstrapHydrationState.source === 'cached' || this.bootstrapHydrationState.source === 'mixed';
+    // Only treat a complete cache fallback (no live data at all) as "cached" for UI purposes.
+    // 'mixed' means live data was partially fetched — showing "Live data unavailable" would be misleading.
+    const usingCachedBootstrap = this.bootstrapHydrationState.source === 'cached';
     const cachedUpdatedAt = this.getCachedBootstrapUpdatedAt();
 
     let statusMode: 'live' | 'cached' | 'unavailable' = 'live';
     let bannerMessage: string | null = null;
 
     if (!online) {
-      if (usingCachedBootstrap) {
+      // Offline: show banner regardless of mixed/cached (any cached data is better than nothing)
+      const hasAnyCached = this.bootstrapHydrationState.source === 'cached' || this.bootstrapHydrationState.source === 'mixed';
+      if (hasAnyCached) {
         statusMode = 'cached';
-        const freshness = cachedUpdatedAt ? describeFreshness(cachedUpdatedAt) : t('common.cached').toLowerCase();
+        const offlineCachedAt = this.bootstrapHydrationState.tiers
+          ? Math.min(...Object.values(this.bootstrapHydrationState.tiers)
+              .filter((tier) => tier.source === 'cached' || tier.source === 'mixed')
+              .map((tier) => tier.updatedAt)
+              .filter((v): v is number => typeof v === 'number' && Number.isFinite(v)))
+          : NaN;
+        const freshness = Number.isFinite(offlineCachedAt) ? describeFreshness(offlineCachedAt) : t('common.cached').toLowerCase();
         bannerMessage = t('connectivity.offlineCached', { freshness });
       } else {
         statusMode = 'unavailable';


### PR DESCRIPTION
## Summary

- `mixed` bootstrap state (some tiers live, some from IDB cache) was incorrectly showing "Live data unavailable" banner — factually wrong since live data *was* partially fetched
- The banner flashed on every load then disappeared (because `markBootstrapAsLive()` clears it after panels load), creating confusing noise
- Now only `source === 'cached'` (complete fallback, zero live data returned) triggers the CACHED banner and header indicator
- Offline mode still shows the banner for both `cached` and `mixed` — any cached snapshot is valuable when truly offline

## Root cause

`updateConnectivityUi()` treated `cached` and `mixed` identically for the online case. With the previous fix (#2028) correctly timestamping `mixed` entries as "just now", users saw "Live data unavailable – showing cached data from just now" which is contradictory.

## Test plan

- [ ] Normal load with partial bootstrap missing keys: no CACHED banner, no amber header indicator
- [ ] Bootstrap completely unavailable (e.g., airplane mode before load): CACHED banner still appears
- [ ] Going offline mid-session: CACHED banner appears for both cached and mixed states
- [ ] `markBootstrapAsLive()` still promotes state to live after panels load