### PR TITLE
fix(sw-update): prevent infinite reload loop when update fires in background tab

### DIFF
--- a/src/bootstrap/sw-update.ts
+++ b/src/bootstrap/sw-update.ts
@@ -25,8 +25,13 @@ export interface SwUpdateHandlerOptions {
  *
  * On each controllerchange after the first (first = initial claim on a new session),
  * shows a dismissible "Update Available" toast. If the user dismisses the toast,
- * the tab auto-reloads the next time it goes to background. Dismissing one version
- * never suppresses toasts for future deploys.
+ * the tab auto-reloads the next time it goes to background — but only after the tab
+ * has been visible at least once since the toast appeared. This prevents an infinite
+ * reload loop when an update is detected while the tab is already in the background:
+ * without this guard, onHidden would fire immediately, reload the hidden page, the
+ * new page would detect the same update, fire again, and loop forever.
+ *
+ * Dismissing one version never suppresses toasts for future deploys.
  */
 export function installSwUpdateHandler(options: SwUpdateHandlerOptions = {}): void {
   const swContainer = options.swContainer ?? navigator.serviceWorker;
@@ -61,9 +66,19 @@ export function installSwUpdateHandler(options: SwUpdateHandlerOptions = {}): vo
     `;
 
     let dismissed = false;
+    // Auto-reload on tab-hide is only allowed after the tab has been visible at least
+    // once since the toast appeared. If the update fires while the tab is already hidden,
+    // this starts false and becomes true when the user returns — preventing the immediate
+    // onHidden → reload → new page → onHidden → reload infinite background loop.
+    let autoReloadAllowed = doc.visibilityState === 'visible';
 
     const onHidden = (): void => {
-      if (!dismissed && doc.visibilityState === 'hidden' && doc.body.contains(toast)) {
+      if (doc.visibilityState === 'visible') {
+        // Tab returned to foreground — user has now seen the toast, allow auto-reload.
+        autoReloadAllowed = true;
+        return;
+      }
+      if (!dismissed && autoReloadAllowed && doc.body.contains(toast)) {
         reload();
       }
     };

--- a/tests/sw-update.test.mts
+++ b/tests/sw-update.test.mts
@@ -307,6 +307,42 @@ describe('installSwUpdateHandler', () => {
     assert.equal(env.reloadCalls.length, 1, 'no second reload on visible transition');
   });
 
+  // --- background-loop prevention (infinite reload bug fix) -------------------
+
+  it('does NOT auto-reload when update fires while tab is already hidden', () => {
+    env.swContainer._controller = {};
+    install(env);
+
+    // Tab is in the background when the SW update activates
+    env.doc.setVisibilityState('hidden');
+    env.swContainer.fireControllerChange();
+
+    // visibilitychange fires but tab is still hidden — must NOT reload (prevents infinite loop)
+    fireVisibility(env);
+    assert.equal(env.reloadCalls.length, 0, 'no auto-reload when already in background');
+  });
+
+  it('allows auto-reload after user returns to the tab that received a background update', () => {
+    env.swContainer._controller = {};
+    install(env);
+
+    // Update fires while hidden
+    env.doc.setVisibilityState('hidden');
+    env.swContainer.fireControllerChange();
+    fireVisibility(env);
+    assert.equal(env.reloadCalls.length, 0, 'no reload yet — tab still hidden');
+
+    // User returns to the tab — now they can see the toast
+    env.doc.setVisibilityState('visible');
+    fireVisibility(env);
+    assert.equal(env.reloadCalls.length, 0, 'no reload on becoming visible');
+
+    // User switches away — auto-reload is now allowed
+    env.doc.setVisibilityState('hidden');
+    fireVisibility(env);
+    assert.equal(env.reloadCalls.length, 1, 'reload fires when user switches away after seeing toast');
+  });
+
   // --- listener leak regression -----------------------------------------------
 
   it('removes the previous visibilitychange handler when a newer deploy replaces the toast', () => {


### PR DESCRIPTION
## Summary

- Fixes an infinite reload loop in long-lived backgrounded tabs
- When the 15-minute SW update check fires while the tab is hidden, the detected update would activate via `skipWaiting` → `clients.claim()` → `controllerchange` → show toast → `onHidden` fires immediately (tab already hidden) → `reload()` → new page → same cycle → **forever**
- Root cause: `onHidden` had no guard against firing when the tab was already hidden when the toast appeared

## Fix

Added `autoReloadAllowed` flag (starts `true` if tab was visible at toast time, `false` if hidden):
- Update fires while tab hidden → `autoReloadAllowed = false` → `onHidden` is a no-op
- User returns to tab → `visibilityState === 'visible'` → `autoReloadAllowed = true`
- User then switches away → auto-reload fires normally

This preserves the intended UX (auto-reload when user switches away after seeing toast) while breaking the background infinite loop.

## Why only old sessions?

Fresh tabs start with the latest SW — no `controllerchange` fires on load. Old backgrounded tabs had the update detected during an interval check, triggering the loop. Fresh sessions never hit this path.

## Test plan

- [ ] 15 sw-update tests all pass (2 new: background loop prevention + recovery path)
- [ ] Open tab, background it for >1hr, return → toast shows but no immediate reload
- [ ] With toast visible, switch to another app → page reloads once (not infinite)
- [ ] Reload button still works immediately