### PR TITLE
fix(sanctions): add sax to Railway package.json + fix consumer-prices health thresholds

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -151,11 +151,12 @@ const SEED_META = {
   thermalEscalation:   { key: 'seed-meta:thermal:escalation',                 maxStaleMin: 240 },
   nationalDebt:        { key: 'seed-meta:economic:national-debt',              maxStaleMin: 10080 }, // 7 days — monthly seed
   tariffTrendsUs:      { key: 'seed-meta:trade:tariffs:v1:840:all:10',        maxStaleMin: 900 },
-  consumerPricesOverview:   { key: 'seed-meta:consumer-prices:overview:ae',     maxStaleMin: 90 }, // seed TTL=30min; 3× interval
-  consumerPricesCategories: { key: 'seed-meta:consumer-prices:categories:ae:30d',            maxStaleMin: 90 },
-  consumerPricesMovers:     { key: 'seed-meta:consumer-prices:movers:ae:30d',               maxStaleMin: 90 },
-  consumerPricesSpread:     { key: 'seed-meta:consumer-prices:retailer-spread:ae:essentials-ae', maxStaleMin: 120 }, // TTL=60min; 2× interval
-  consumerPricesFreshness:  { key: 'seed-meta:consumer-prices:freshness:ae',    maxStaleMin: 90 }, // publish.ts runs independently; align with other consumer-prices keys
+  // publish.ts runs once daily (02:30 UTC); seed-meta TTL=52h — maxStaleMin must cover the full 24h cycle
+  consumerPricesOverview:   { key: 'seed-meta:consumer-prices:overview:ae',     maxStaleMin: 1500 }, // 25h = 24h cadence + 1h grace
+  consumerPricesCategories: { key: 'seed-meta:consumer-prices:categories:ae:30d',            maxStaleMin: 1500 },
+  consumerPricesMovers:     { key: 'seed-meta:consumer-prices:movers:ae:30d',               maxStaleMin: 1500 },
+  consumerPricesSpread:     { key: 'seed-meta:consumer-prices:retailer-spread:ae:essentials-ae', maxStaleMin: 1500 },
+  consumerPricesFreshness:  { key: 'seed-meta:consumer-prices:freshness:ae',    maxStaleMin: 1500 },
   // defiTokens/aiTokens/otherTokens all share one seed run (seed-token-panels cron, every 30min)
   defiTokens:        { key: 'seed-meta:market:token-panels', maxStaleMin: 90 },
   aiTokens:          { key: 'seed-meta:market:token-panels', maxStaleMin: 90 },

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.79.0",
         "@aws-sdk/client-s3": "^3.1009.0",
-        "fast-xml-parser": "^5.5.8",
         "h3-js": "^4.2.1",
+        "sax": "^1.6.0",
         "telegram": "^2.22.2",
         "ws": "^8.18.0"
       },
@@ -1914,26 +1914,6 @@
         "path-expression-matcher": "^1.1.3"
       }
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2106,6 +2086,15 @@
       "resolved": "https://registry.npmjs.org/real-cancellable-promise/-/real-cancellable-promise-1.2.3.tgz",
       "integrity": "sha512-hBI5Gy/55VEeeMtImMgEirD7eq5UmqJf1J8dFZtbJZA/3rB0pYFZ7PayMGueb6v4UtUtpKpP+05L0VwyE1hI9Q==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/slide": {
       "version": "1.1.6",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.79.0",
     "@aws-sdk/client-s3": "^3.1009.0",
-    "fast-xml-parser": "^5.5.8",
+    "sax": "^1.6.0",
     "h3-js": "^4.2.1",
     "telegram": "^2.22.2",
     "ws": "^8.18.0"


### PR DESCRIPTION
## Summary

- **CRIT fix — sanctions seed crashing since PR #2008**: `ERR_MODULE_NOT_FOUND: Cannot find package 'sax'`. PR #2008 replaced `fast-xml-parser` with SAX streaming but only updated root `package.json`. The Railway cron container builds from `scripts/package.json`. Added `sax ^1.6.0`, removed `fast-xml-parser`.
- **WARN fix — consumer-prices STALE_SEED false positives**: `publish.ts` runs once daily (02:30 UTC). All 5 consumer-prices SEED_META thresholds were 90-120 min, causing permanent STALE_SEED warnings for 22+ hours/day. Raised to 1500 min (25h = 24h cadence + 1h grace).

## Test plan

- [ ] Deploy triggers Railway redeploy of seed-sanctions-pressure service
- [ ] Next sanctions cron run completes without `ERR_MODULE_NOT_FOUND`
- [ ] `sanctionsPressure` clears from health within 12h of cron running
- [ ] Consumer-prices keys show OK outside the 1h post-publish window