### PR TITLE
fix(sw-update): dwell timer + debug instrumentation against background reload loop

### DIFF
--- a/src/bootstrap/sw-update.ts
+++ b/src/bootstrap/sw-update.ts
@@ -18,18 +18,49 @@ export interface SwUpdateHandlerOptions {
   reload?: () => void;
   /** Override requestAnimationFrame for testing (defaults to global rAF). */
   raf?: (cb: () => void) => void;
+  /** Override setTimeout for testing. */
+  setTimer?: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  /** Override clearTimeout for testing. */
+  clearTimer?: (id: ReturnType<typeof setTimeout> | null) => void;
+  /** Enable debug logging. Defaults to localStorage.getItem('wm-debug-sw') === '1'. */
+  debug?: boolean;
+  /** App version string included in debug log entries. */
+  version?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Debug logging (opt-in via localStorage.setItem('wm-debug-sw', '1'))
+// Persists a rolling 30-entry log in sessionStorage so it survives page reloads.
+// Copy with: JSON.parse(sessionStorage.getItem('wm-sw-debug-log'))
+// ---------------------------------------------------------------------------
+
+export const SW_DEBUG_LOG_KEY = 'wm-sw-debug-log';
+const SW_DEBUG_LOG_MAX = 30;
+
+function appendDebugLog(entry: Record<string, unknown>): void {
+  try {
+    const raw = sessionStorage.getItem(SW_DEBUG_LOG_KEY);
+    const log = (raw ? JSON.parse(raw) : []) as unknown[];
+    log.push(entry);
+    if (log.length > SW_DEBUG_LOG_MAX) log.splice(0, log.length - SW_DEBUG_LOG_MAX);
+    sessionStorage.setItem(SW_DEBUG_LOG_KEY, JSON.stringify(log));
+  } catch {}
 }
 
 /**
  * Wires up the SW update toast.
  *
  * On each controllerchange after the first (first = initial claim on a new session),
- * shows a dismissible "Update Available" toast. If the user dismisses the toast,
- * the tab auto-reloads the next time it goes to background — but only after the tab
- * has been visible at least once since the toast appeared. This prevents an infinite
- * reload loop when an update is detected while the tab is already in the background:
- * without this guard, onHidden would fire immediately, reload the hidden page, the
- * new page would detect the same update, fire again, and loop forever.
+ * shows a dismissible "Update Available" toast.
+ *
+ * Auto-reload on tab-hide requires the tab to have been visible for at least
+ * VISIBLE_DWELL_MS continuously since the toast appeared. This prevents two failure modes:
+ *
+ * 1. Background infinite loop: update detected in a hidden tab → onHidden fires
+ *    immediately → reload → new page → same → loop forever.
+ *
+ * 2. Session-restore ghost reload: session-restore briefly marks tabs visible for
+ *    one animation frame, which would allow a hidden-tab auto-reload prematurely.
  *
  * Dismissing one version never suppresses toasts for future deploys.
  */
@@ -38,13 +69,45 @@ export function installSwUpdateHandler(options: SwUpdateHandlerOptions = {}): vo
   const doc = options.document ?? (document as unknown as DocumentLike);
   const reload = options.reload ?? (() => window.location.reload());
   const raf = options.raf ?? ((cb: () => void) => requestAnimationFrame(() => requestAnimationFrame(cb)));
+  const setTimer = options.setTimer ?? ((cb: () => void, ms: number) => setTimeout(cb, ms));
+  const clearTimer = options.clearTimer ?? ((id: ReturnType<typeof setTimeout> | null) => { if (id !== null) clearTimeout(id); });
+
+  const debugEnabled = options.debug ?? (() => {
+    try { return localStorage.getItem('wm-debug-sw') === '1'; } catch { return false; }
+  })();
+  const version = options.version;
+
+  function logSw(event: string, extra: Record<string, unknown> = {}): void {
+    if (!debugEnabled) return;
+    const entry: Record<string, unknown> = {
+      event,
+      ts: new Date().toISOString(),
+      visibility: doc.visibilityState,
+      hasController: !!swContainer.controller,
+      ...extra,
+    };
+    if (version !== undefined) entry.version = version;
+    console.log('[SWDEBUG]', entry);
+    appendDebugLog(entry);
+  }
+
+  // Minimum time the tab must remain visible after the toast appears before
+  // auto-reload on tab-hide is enabled.
+  const VISIBLE_DWELL_MS = 5_000;
 
   let currentOnHidden: (() => void) | null = null;
+  let currentDwellCancel: (() => void) | null = null;
 
   const showToast = (): void => {
     if (currentOnHidden) {
       doc.removeEventListener('visibilitychange', currentOnHidden);
       currentOnHidden = null;
+    }
+    // P2: cancel stale dwell timer from the superseded toast so it cannot
+    // fire after the toast is gone (prevents debug log pollution).
+    if (currentDwellCancel) {
+      currentDwellCancel();
+      currentDwellCancel = null;
     }
     doc.querySelector('.update-toast')?.remove();
 
@@ -66,19 +129,41 @@ export function installSwUpdateHandler(options: SwUpdateHandlerOptions = {}): vo
     `;
 
     let dismissed = false;
-    // Auto-reload on tab-hide is only allowed after the tab has been visible at least
-    // once since the toast appeared. If the update fires while the tab is already hidden,
-    // this starts false and becomes true when the user returns — preventing the immediate
-    // onHidden → reload → new page → onHidden → reload infinite background loop.
-    let autoReloadAllowed = doc.visibilityState === 'visible';
+    let autoReloadAllowed = false;
+    let dwellTimerId: ReturnType<typeof setTimer> | null = null;
+
+    const startDwellTimer = (): void => {
+      if (dwellTimerId !== null || dismissed || autoReloadAllowed) return;
+      logSw('dwell-timer-started', { delayMs: VISIBLE_DWELL_MS });
+      dwellTimerId = setTimer(() => {
+        dwellTimerId = null;
+        autoReloadAllowed = true;
+        logSw('dwell-timer-expired', { autoReloadAllowed: true });
+      }, VISIBLE_DWELL_MS);
+    };
+
+    // If already visible when the toast appears, start the dwell timer immediately.
+    if (doc.visibilityState === 'visible') startDwellTimer();
+
+    logSw('toast-shown', { wasVisible: doc.visibilityState === 'visible' });
 
     const onHidden = (): void => {
       if (doc.visibilityState === 'visible') {
-        // Tab returned to foreground — user has now seen the toast, allow auto-reload.
-        autoReloadAllowed = true;
+        // Tab returned to foreground — start dwell timer if not already running.
+        logSw('visibility-visible');
+        startDwellTimer();
         return;
       }
+      // P1: hidden time must not count toward the dwell window — cancel the
+      // in-flight timer so the full VISIBLE_DWELL_MS restarts on next foreground.
+      if (!autoReloadAllowed && dwellTimerId !== null) {
+        clearTimer(dwellTimerId);
+        dwellTimerId = null;
+        logSw('dwell-timer-cancelled-on-hide');
+      }
+      logSw('visibility-hidden', { autoReloadAllowed, dismissed });
       if (!dismissed && autoReloadAllowed && doc.body.contains(toast)) {
+        logSw('auto-reload-triggered');
         reload();
       }
     };
@@ -86,9 +171,17 @@ export function installSwUpdateHandler(options: SwUpdateHandlerOptions = {}): vo
     toast.addEventListener('click', (e) => {
       const action = (e.target as HTMLElement).closest<HTMLElement>('[data-action]')?.dataset.action;
       if (action === 'reload') {
+        clearTimer(dwellTimerId);
+        dwellTimerId = null;
+        currentDwellCancel = null;
+        logSw('reload-clicked');
         reload();
       } else if (action === 'dismiss') {
+        clearTimer(dwellTimerId);
+        dwellTimerId = null;
+        currentDwellCancel = null;
         dismissed = true;
+        logSw('dismiss-clicked');
         doc.removeEventListener('visibilitychange', onHidden);
         currentOnHidden = null;
         toast.classList.remove('visible');
@@ -97,13 +190,16 @@ export function installSwUpdateHandler(options: SwUpdateHandlerOptions = {}): vo
     });
 
     currentOnHidden = onHidden;
+    currentDwellCancel = () => { clearTimer(dwellTimerId); dwellTimerId = null; };
     doc.addEventListener('visibilitychange', onHidden);
     doc.body.appendChild(toast);
     raf(() => toast.classList.add('visible'));
   };
 
   let hadController = !!swContainer.controller;
+  logSw('handler-installed', { hadController });
   swContainer.addEventListener('controllerchange', () => {
+    logSw('controllerchange', { hadController });
     if (!hadController) {
       hadController = true;
       return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -428,7 +428,7 @@ if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) {
 }
 
 if (!('__TAURI_INTERNALS__' in window) && !('__TAURI__' in window) && 'serviceWorker' in navigator) {
-  installSwUpdateHandler();
+  installSwUpdateHandler({ version: __APP_VERSION__ });
 
   const SW_UPDATE_SUCCESS_INTERVAL_MS = 60 * 60 * 1000;
   const SW_UPDATE_FAILURE_INTERVAL_MS = 5 * 60 * 1000;

--- a/tests/sw-update.test.mts
+++ b/tests/sw-update.test.mts
@@ -43,11 +43,14 @@ interface FakeEnv {
   reloadCalls: number[];
   appendedToasts: FakeElement[];
   visibilityListeners: Array<() => void>;
+  /** Pending dwell-timer callbacks. Each entry is the cb passed to setTimer (or a no-op if cleared). */
+  pendingTimers: Array<() => void>;
 }
 
 function makeEnv(): FakeEnv {
   const visibilityListeners: Array<() => void> = [];
   const appendedToasts: FakeElement[] = [];
+  const pendingTimers: Array<() => void> = [];
   let _visibilityState = 'visible';
 
   const doc: FakeEnv['doc'] = {
@@ -121,7 +124,7 @@ function makeEnv(): FakeEnv {
   const reloadCalls: number[] = [];
   const reload = () => reloadCalls.push(Date.now());
 
-  return { doc, swContainer, reload, reloadCalls, appendedToasts, visibilityListeners };
+  return { doc, swContainer, reload, reloadCalls, appendedToasts, visibilityListeners, pendingTimers };
 }
 
 function install(env: FakeEnv) {
@@ -129,13 +132,34 @@ function install(env: FakeEnv) {
     swContainer: env.swContainer,
     document: env.doc,
     reload: env.reload,
-    raf: (cb) => cb(), // synchronous in tests — skips real rAF
+    raf: (cb) => cb(), // synchronous — skips real rAF
+    setTimer: (cb, _ms) => {
+      const idx = env.pendingTimers.length;
+      env.pendingTimers.push(cb);
+      return idx as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearTimer: (_id) => {
+      const idx = _id as unknown as number;
+      if (idx !== null && idx >= 0 && idx < env.pendingTimers.length) {
+        env.pendingTimers.splice(idx, 1);
+      }
+    },
   });
 }
 
 /** Simulate tab visibility change (e.g. going to background). */
 function fireVisibility(env: FakeEnv) {
   for (const cb of [...env.visibilityListeners]) cb();
+}
+
+/**
+ * Fire the next pending dwell timer (simulates VISIBLE_DWELL_MS elapsing).
+ * If the timer was cleared (dismiss/reload), the no-op is harmless.
+ */
+function fireDwellTimer(env: FakeEnv) {
+  const cb = env.pendingTimers.shift();
+  assert.ok(cb !== undefined, 'No pending dwell timer to fire');
+  cb();
 }
 
 /** Simulate a button click inside the latest toast. */
@@ -206,15 +230,26 @@ describe('installSwUpdateHandler', () => {
     assert.equal(env.visibilityListeners.length, 0);
   });
 
-  // --- hidden-tab auto-reload -------------------------------------------------
+  // --- hidden-tab auto-reload (requires dwell) --------------------------------
 
-  it('calls reload when tab goes hidden with an active toast', () => {
+  it('calls reload when tab goes hidden after dwell timer elapses', () => {
     env.swContainer._controller = {};
     install(env);
-    env.swContainer.fireControllerChange();
+    env.swContainer.fireControllerChange(); // visible → dwell timer starts
+    fireDwellTimer(env);                    // 5 s elapsed → autoReloadAllowed = true
     env.doc.setVisibilityState('hidden');
     fireVisibility(env);
     assert.equal(env.reloadCalls.length, 1);
+  });
+
+  it('does NOT call reload when tab goes hidden before dwell timer fires', () => {
+    env.swContainer._controller = {};
+    install(env);
+    env.swContainer.fireControllerChange(); // visible → dwell timer pending
+    // Do NOT call fireDwellTimer — autoReloadAllowed stays false
+    env.doc.setVisibilityState('hidden');
+    fireVisibility(env);
+    assert.equal(env.reloadCalls.length, 0, 'no reload before dwell elapses');
   });
 
   it('does NOT call reload when tab goes hidden after dismiss', () => {
@@ -225,6 +260,35 @@ describe('installSwUpdateHandler', () => {
     env.doc.setVisibilityState('hidden');
     fireVisibility(env);
     assert.equal(env.reloadCalls.length, 0);
+  });
+
+  // --- dwell timer start/cancel mechanics -------------------------------------
+
+  it('starts dwell timer when toast appears while tab is visible', () => {
+    env.swContainer._controller = {};
+    install(env);
+    env.swContainer.fireControllerChange();
+    assert.equal(env.pendingTimers.length, 1, 'dwell timer queued on visible toast');
+  });
+
+  it('does NOT start dwell timer when toast appears while tab is hidden', () => {
+    env.swContainer._controller = {};
+    install(env);
+    env.doc.setVisibilityState('hidden');
+    env.swContainer.fireControllerChange();
+    assert.equal(env.pendingTimers.length, 0, 'no dwell timer when tab already hidden');
+  });
+
+  it('starts dwell timer when tab returns to visible after a hidden-tab toast', () => {
+    env.swContainer._controller = {};
+    install(env);
+    env.doc.setVisibilityState('hidden');
+    env.swContainer.fireControllerChange();
+    assert.equal(env.pendingTimers.length, 0, 'no timer while hidden');
+
+    env.doc.setVisibilityState('visible');
+    fireVisibility(env); // onHidden sees visible → startDwellTimer
+    assert.equal(env.pendingTimers.length, 1, 'dwell timer started on return to visible');
   });
 
   // --- PRIMARY: multi-deploy same-tab scenario --------------------------------
@@ -250,15 +314,16 @@ describe('installSwUpdateHandler', () => {
     env.swContainer._controller = {};
     install(env);
 
-    // Deploy N — dismiss
+    // Deploy N — dismiss (dwell timer cleared)
     env.swContainer.fireControllerChange();
     clickToastButton(env, 'dismiss');
     assert.equal(env.reloadCalls.length, 0);
 
-    // Deploy N+1 — do nothing, then hide tab
+    // Deploy N+1 — dwell then hide
     env.swContainer.fireControllerChange();
     assert.equal(env.appendedToasts.length, 2, 'new toast shown for N+1');
 
+    fireDwellTimer(env); // 5 s visible → autoReloadAllowed
     env.doc.setVisibilityState('hidden');
     fireVisibility(env);
     assert.equal(env.reloadCalls.length, 1, 'reload fires on hidden after N+1 toast');
@@ -279,12 +344,69 @@ describe('installSwUpdateHandler', () => {
     assert.equal(env.reloadCalls.length, 0, 'no reload — both toasts dismissed');
   });
 
+  // --- P1 regression: hidden time must not count toward dwell ----------------
+
+  it('does NOT reload when dwell timer fires after the tab went hidden (background tick)', () => {
+    env.swContainer._controller = {};
+    install(env);
+    env.swContainer.fireControllerChange(); // visible → dwell starts
+
+    // Tab hides before dwell completes — timer should be cancelled
+    env.doc.setVisibilityState('hidden');
+    fireVisibility(env);
+    assert.equal(env.pendingTimers.length, 0, 'dwell timer cancelled on hide');
+
+    // Tab stays hidden — no reload
+    fireVisibility(env);
+    assert.equal(env.reloadCalls.length, 0, 'no reload — dwell never completed');
+  });
+
+  it('requires a full fresh dwell after hide/show cycle before auto-reload', () => {
+    env.swContainer._controller = {};
+    install(env);
+    env.swContainer.fireControllerChange(); // visible → dwell starts
+
+    // Hide at "1 s" — cancels dwell
+    env.doc.setVisibilityState('hidden');
+    fireVisibility(env);
+    assert.equal(env.pendingTimers.length, 0, 'dwell cancelled on hide');
+
+    // Return to visible — new dwell starts
+    env.doc.setVisibilityState('visible');
+    fireVisibility(env);
+    assert.equal(env.pendingTimers.length, 1, 'fresh dwell timer started on return');
+
+    // Complete the new dwell → autoReloadAllowed
+    fireDwellTimer(env);
+
+    // Hide → auto-reload fires
+    env.doc.setVisibilityState('hidden');
+    fireVisibility(env);
+    assert.equal(env.reloadCalls.length, 1, 'reload fires only after full dwell completes');
+  });
+
+  // --- P2 regression: stale dwell timer cleared when newer deploy supersedes --
+
+  it('cancels the previous dwell timer when a newer deploy supersedes the toast', () => {
+    env.swContainer._controller = {};
+    install(env);
+
+    // Deploy N: visible → dwell timer starts
+    env.swContainer.fireControllerChange();
+    assert.equal(env.pendingTimers.length, 1, 'N dwell timer queued');
+
+    // Deploy N+1: supersedes toast → old dwell must be cancelled
+    env.swContainer.fireControllerChange();
+    assert.equal(env.pendingTimers.length, 1, 'exactly one dwell timer active (N+1 only)');
+  });
+
   // --- visible-transition must NOT reload (P1 regression guard) ---------------
 
   it('does NOT reload when visibilitychange fires while state is still visible', () => {
     env.swContainer._controller = {};
     install(env);
     env.swContainer.fireControllerChange();
+    fireDwellTimer(env);
     // tab stays visible — fire visibilitychange anyway (e.g. focus events on some browsers)
     env.doc.setVisibilityState('visible');
     fireVisibility(env);
@@ -295,13 +417,14 @@ describe('installSwUpdateHandler', () => {
     env.swContainer._controller = {};
     install(env);
     env.swContainer.fireControllerChange();
+    fireDwellTimer(env); // dwell elapsed → autoReloadAllowed
 
     // go hidden → should reload
     env.doc.setVisibilityState('hidden');
     fireVisibility(env);
     assert.equal(env.reloadCalls.length, 1);
 
-    // just confirming the first hidden fired; now visible would not add a second reload
+    // now visible would not add a second reload
     env.doc.setVisibilityState('visible');
     fireVisibility(env);
     assert.equal(env.reloadCalls.length, 1, 'no second reload on visible transition');
@@ -332,10 +455,13 @@ describe('installSwUpdateHandler', () => {
     fireVisibility(env);
     assert.equal(env.reloadCalls.length, 0, 'no reload yet — tab still hidden');
 
-    // User returns to the tab — now they can see the toast
+    // User returns to the tab — dwell timer starts
     env.doc.setVisibilityState('visible');
     fireVisibility(env);
     assert.equal(env.reloadCalls.length, 0, 'no reload on becoming visible');
+
+    // Dwell elapses → autoReloadAllowed = true
+    fireDwellTimer(env);
 
     // User switches away — auto-reload is now allowed
     env.doc.setVisibilityState('hidden');


### PR DESCRIPTION
## Summary

- **Dwell timer (5 s)**: auto-reload on tab-hide only arms after the tab has been visible for `VISIBLE_DWELL_MS` continuously since the toast appeared. Prevents the infinite background-tab reload loop (hidden tab → SW update detected → `onHidden` fires immediately → reload → still hidden → same cycle) and session-restore ghost reloads.
- **Rolling debug log**: opt-in via `localStorage.setItem('wm-debug-sw', '1')`. Stores up to 30 timestamped entries in `sessionStorage['wm-sw-debug-log']` covering the full toast lifecycle. Useful for diagnosing future SW reload reports post-mortem.
- `__APP_VERSION__` wired into the handler so log entries carry the deployed build version.

## Test plan

- [ ] 19 unit tests pass (`node --test tests/sw-update.test.mts`)
- [ ] New tests cover: dwell timer start on visible toast, no timer when hidden, timer starts on return to visible, timer cleared on dismiss/reload, no auto-reload before dwell elapses
- [ ] Typecheck clean
- [ ] Deploy a new version → confirm toast appears instead of immediate page reload
- [ ] Leave toast up for 5 s while visible, switch away → confirm page reloads
- [ ] Switch away within 5 s → confirm no reload
- [ ] Dismiss toast, switch away → confirm no reload