### PR TITLE
fix: analysis worker timeout + token panel crash + token null guard

### DIFF
--- a/src/services/analysis-core.ts
+++ b/src/services/analysis-core.ts
@@ -34,7 +34,49 @@ import {
   findNewsForMarketSymbol,
 } from './entity-extraction';
 import { getEntityIndex } from './entity-index';
-import { aggregateThreats } from './threat-classifier';
+import type { ThreatLevel, EventCategory, ThreatClassification } from '@/types';
+
+const THREAT_PRIORITY: Record<ThreatLevel, number> = {
+  critical: 5, high: 4, medium: 3, low: 2, info: 1,
+};
+
+function aggregateThreats(
+  items: Array<{ threat?: ThreatClassification; tier?: number }>
+): ThreatClassification {
+  const withThreat = items.filter(i => i.threat);
+  if (withThreat.length === 0) {
+    return { level: 'info', category: 'general', confidence: 0.3, source: 'keyword' };
+  }
+  let maxLevel: ThreatLevel = 'info';
+  let maxPriority = 0;
+  for (const item of withThreat) {
+    const p = THREAT_PRIORITY[item.threat!.level];
+    if (p > maxPriority) { maxPriority = p; maxLevel = item.threat!.level; }
+  }
+  const catCounts = new Map<EventCategory, number>();
+  for (const item of withThreat) {
+    const cat = item.threat!.category;
+    catCounts.set(cat, (catCounts.get(cat) ?? 0) + 1);
+  }
+  let topCat: EventCategory = 'general';
+  let topCount = 0;
+  for (const [cat, count] of catCounts) {
+    if (count > topCount) { topCount = count; topCat = cat; }
+  }
+  let weightedSum = 0;
+  let weightTotal = 0;
+  for (const item of withThreat) {
+    const weight = item.tier ? (6 - Math.min(item.tier, 5)) : 1;
+    weightedSum += item.threat!.confidence * weight;
+    weightTotal += weight;
+  }
+  return {
+    level: maxLevel,
+    category: topCat,
+    confidence: weightTotal > 0 ? weightedSum / weightTotal : 0.5,
+    source: 'keyword',
+  };
+}
 
 const TOPIC_BASELINE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 const TOPIC_BASELINE_SPIKE_MULTIPLIER = 3;
@@ -66,7 +108,7 @@ export interface NewsItemCore {
   isAlert: boolean;
   monitorColor?: string;
   tier?: number;
-  threat?: import('./threat-classifier').ThreatClassification;
+  threat?: ThreatClassification;
   lat?: number;
   lon?: number;
   locationName?: string;
@@ -88,7 +130,7 @@ export interface ClusteredEventCore {
   isAlert: boolean;
   monitorColor?: string;
   velocity?: { sourcesPerHour?: number };
-  threat?: import('./threat-classifier').ThreatClassification;
+  threat?: ThreatClassification;
   lat?: number;
   lon?: number;
   lang?: string;

--- a/src/services/market/index.ts
+++ b/src/services/market/index.ts
@@ -209,11 +209,14 @@ export async function fetchCryptoSectors(): Promise<CryptoSector[]> {
 // ========================================================================
 
 function toTokenData(q: ProtoCryptoQuote): TokenData {
+  // Bootstrap hydration delivers the raw seed shape ({change24h}) while the RPC
+  // handler normalises to the proto field name ({change}).  Handle both.
+  const raw = q as unknown as { change?: number; change24h?: number };
   return {
     name: q.name,
     symbol: q.symbol,
-    price: q.price,
-    change24h: q.change,
+    price: q.price ?? 0,
+    change24h: (raw.change ?? raw.change24h) ?? 0,
     change7d: q.change7d ?? 0,
   };
 }


### PR DESCRIPTION
## Why

Three console errors investigated:

### 1. `[AnalysisWorker] Worker failed to become ready within timeout` (repeated)

`analysis.worker.ts` → `analysis-core.ts` → `threat-classifier.ts` → `i18next-browser-languagedetector` + `getCSSColor`.

Both access `window`/`document` at ES module evaluation time. In a production Web Worker, this crashes the module before `self.postMessage({ type: 'ready' })` fires. The manager sees a 10s timeout, cleans up, and retries on every call — so NewsPanel always falls back to flat list and correlation analysis always fails.

Fix: inline `aggregateThreats` + `THREAT_PRIORITY` (pure functions, zero browser deps) directly into `analysis-core.ts`. `threat-classifier` is no longer in the worker import chain.

### 2. `TypeError: Cannot read properties of undefined (reading 'toFixed')` — token panels

Bootstrap hydration returns the raw seed shape `{ change24h: X }` but `toTokenData(q)` reads `q.change` (proto field name). Through the RPC path the handler normalises `change24h → change`, but bootstrap bypasses the handler. `formatChange(undefined)` → `undefined.toFixed(2)` crashes.

Fix: `toTokenData` now reads `raw.change ?? raw.change24h ?? 0` and adds `?? 0` on `price`.

### 3. `THREE.THREE.Clock: This module has been deprecated`

This deprecation warning originates inside `globe.gl`'s bundled three.js (r178+). Not directly fixable in our code without patching globe.gl.

## Test plan

- [ ] Verify NewsPanel shows clusters (not flat list fallback) after deploy
- [ ] Verify no `[AnalysisWorker] Worker failed to become ready within timeout` in console
- [ ] Verify DeFi/AI/Alt token panels render without crash when loaded from bootstrap
- [ ] Verify correlation signals appear in UI