### PR TITLE
fix(map): prevent deck.gl picking crash when apt-groups-layer fails initialization

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -338,6 +338,7 @@ export class DeckGLMap {
   private cyberThreats: CyberThreat[] = [];
   private aptGroups: import('@/types').APTGroup[] = [];
   private aptGroupsLoaded = false;
+  private aptGroupsLayerFailed = false;
   private iranEvents: IranEvent[] = [];
   private aisDisruptions: AisDisruptionEvent[] = [];
   private aisDensity: AisDensityZone[] = [];
@@ -800,7 +801,12 @@ export class DeckGLMap {
       onClick: (info: PickingInfo) => this.handleClick(info),
       pickingRadius: 10,
       useDevicePixels: window.devicePixelRatio > 2 ? 2 : true,
-      onError: (error: Error) => console.warn('[DeckGLMap] Render error (non-fatal):', error.message),
+      onError: (error: Error) => {
+        console.warn('[DeckGLMap] Render error (non-fatal):', error.message);
+        if (error.message.includes('apt-groups-layer')) {
+          this.aptGroupsLayerFailed = true;
+        }
+      },
     });
 
     this.maplibreMap.addControl(this.deckOverlay as unknown as maplibregl.IControl);
@@ -1574,7 +1580,7 @@ export class DeckGLMap {
     }
 
     // APT Groups layer — loaded lazily when cyberThreats layer is enabled
-    if (mapLayers.cyberThreats && SITE_VARIANT !== 'tech' && SITE_VARIANT !== 'happy' && this.aptGroups.length > 0) {
+    if (mapLayers.cyberThreats && SITE_VARIANT !== 'tech' && SITE_VARIANT !== 'happy' && this.aptGroups.length > 0 && !this.aptGroupsLayerFailed) {
       layers.push(this.createAPTGroupsLayer());
     }
 


### PR DESCRIPTION
## Summary

- When the `apt-groups-layer` ScatterplotLayer fails a deck.gl assertion during its init cycle, the existing `onError` handler logged a warning but left the broken layer in deck.gl's internal pool
- The next hover/click triggered `_pickClosestObject` → `_getPickable` → `shouldDrawLayer`, which crashed with `Cannot read properties of undefined (reading 'includes')` (Sentry WORLDMONITOR-H4)
- Fix: track failure with `aptGroupsLayerFailed` flag; once set, `buildLayers()` skips the APT groups layer so the broken entry is never presented to deck.gl's picking pass again

## Test plan

- [ ] TypeScript typecheck: PASS
- [ ] API typecheck: PASS
- [ ] Biome lint: PASS (warnings only, no errors)
- [ ] test:data (2175 tests): PASS
- [ ] Edge function bundle check: PASS
- [ ] Edge function tests (121 tests): PASS
- [ ] Markdown lint: PASS
- [ ] Version sync check: PASS