### PR TITLE
fix(health): correct stale SEED_META entries for bisPolicy, minerals, giving

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -109,13 +109,11 @@ const SEED_META = {
   // serviceStatuses: moved to ON_DEMAND — RPC-populated, no dedicated seed, goes stale when no users visit
   cableHealth:      { key: 'seed-meta:cable-health',              maxStaleMin: 90 }, // ais-relay warm-ping runs every 30min; 90min = 3× interval catches missed pings without false positives
   macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 20 },
-  bisPolicy:        { key: 'seed-meta:economic:bis:policy',       maxStaleMin: 10080 },
-  bisExchange:      { key: 'seed-meta:economic:bis:eer',          maxStaleMin: 10080 },
-  bisCredit:        { key: 'seed-meta:economic:bis:credit',       maxStaleMin: 10080 },
+  bisPolicy:        { key: 'seed-meta:economic:bis',              maxStaleMin: 10080 }, // runSeed('economic','bis',...) writes seed-meta:economic:bis
   shippingRates:    { key: 'seed-meta:supply_chain:shipping',     maxStaleMin: 420 },
   chokepoints:      { key: 'seed-meta:supply_chain:chokepoints',  maxStaleMin: 60 },
-  minerals:         { key: 'seed-meta:supply_chain:minerals',     maxStaleMin: 10080 },
-  giving:           { key: 'seed-meta:giving:summary',            maxStaleMin: 10080 },
+  // minerals + giving: on-demand cachedFetchJson only, no seed-meta writer — freshness checked via TTL
+  // bisExchange + bisCredit: extras written by same BIS script via writeExtraKey, no dedicated seed-meta
   gpsjam:           { key: 'seed-meta:intelligence:gpsjam',       maxStaleMin: 720 },
   positiveGeoEvents:{ key: 'seed-meta:positive-events:geo',       maxStaleMin: 60 },
   riskScores:       { key: 'seed-meta:intelligence:risk-scores',  maxStaleMin: 30 }, // CII warm-ping every 8min; 30min = ~3.5x interval,


### PR DESCRIPTION
## Summary

Fixes 3 false `STALE_SEED` warnings in the health endpoint caused by mismatched or nonexistent seed-meta keys:

- **`bisPolicy`**: `runSeed('economic', 'bis', ...)` writes `seed-meta:economic:bis` but health checked `seed-meta:economic:bis:policy` (never written) → always STALE_SEED. Fixed to match actual key.
- **`bisExchange` / `bisCredit`**: extra keys written by same BIS script via `writeExtraKey` with no dedicated seed-meta. Removed their SEED_META entries — correctly show `EMPTY_ON_DEMAND` when empty.
- **`minerals`**: on-demand `cachedFetchJson` (24h TTL), nothing writes `seed-meta:supply_chain:minerals`. Removed SEED_META entry.
- **`giving`**: on-demand `cachedFetchJson` (1h TTL), nothing writes `seed-meta:giving:summary`. Removed SEED_META entry.

Result: 6 WARNs → 3 WARNs (only `EMPTY_ON_DEMAND` ones remain, which are expected behavior).

## Test plan

- [ ] 2182 data tests pass
- [ ] Edge function bundles cleanly
- [ ] After deploy: `bisPolicy` shows `OK` (not `STALE_SEED`)
- [ ] `minerals` and `giving` show `OK` (not `STALE_SEED`)