### PR TITLE
feat(export): complete non-AI data export with LLM threat sanitization

### DIFF
--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -55,6 +55,7 @@ import {
 import { detectPlatform, allButtons, buttonsForPlatform } from '@/components/DownloadBanner';
 import type { Platform } from '@/components/DownloadBanner';
 import { invokeTauri } from '@/services/tauri-bridge';
+import { getCachedGpsInterference } from '@/services/gps-interference';
 import { dataFreshness } from '@/services/data-freshness';
 import { mlWorker } from '@/services/ml-worker';
 import { UnifiedSettings } from '@/components/UnifiedSettings';
@@ -922,12 +923,29 @@ export class EventHandlerManager implements AppModule {
 
   setupExportPanel(): void {
     if (!isProUser()) return;
-    this.ctx.exportPanel = new ExportPanel(() => ({
-      news: this.ctx.latestClusters.length > 0 ? this.ctx.latestClusters : this.ctx.allNews,
-      markets: this.ctx.latestMarkets,
-      predictions: this.ctx.latestPredictions,
-      timestamp: Date.now(),
-    }));
+    this.ctx.exportPanel = new ExportPanel(() => {
+      const allCards = this.ctx.correlationEngine?.getAllCards() ?? [];
+      const disabledCount = this.ctx.disabledSources.size;
+      return {
+        meta: {
+          exportedAt: new Date().toISOString(),
+          note: disabledCount > 0
+            ? `Export reflects currently enabled sources only. ${disabledCount} source(s) are disabled and not included.`
+            : 'Export reflects all active sources.',
+        },
+        timestamp: Date.now(),
+        news: this.ctx.allNews,
+        newsClusters: this.ctx.latestClusters.length > 0 ? this.ctx.latestClusters : undefined,
+        newsByCategory: this.ctx.newsByCategory,
+        markets: this.ctx.latestMarkets,
+        predictions: this.ctx.latestPredictions,
+        intelligence: this.ctx.intelligenceCache,
+        cyberThreats: this.ctx.cyberThreatsCache ?? undefined,
+        gpsJamming: getCachedGpsInterference() ?? undefined,
+        convergenceCards: allCards.map(({ assessment: _a, ...card }) => card),
+        monitors: this.ctx.monitors.length > 0 ? this.ctx.monitors : undefined,
+      };
+    });
 
     const headerRight = this.ctx.container.querySelector('.header-right');
     if (headerRight) {

--- a/src/services/correlation-engine/engine.ts
+++ b/src/services/correlation-engine/engine.ts
@@ -85,6 +85,10 @@ export class CorrelationEngine {
     return this.cards.get(domain) ?? [];
   }
 
+  getAllCards(): ConvergenceCard[] {
+    return Array.from(this.cards.values()).flat();
+  }
+
   // ── Clustering ──────────────────────────────────────────────
 
   private clusterSignals(

--- a/src/services/gps-interference.ts
+++ b/src/services/gps-interference.ts
@@ -25,6 +25,10 @@ let cachedData: GpsJamData | null = null;
 let cachedAt = 0;
 const CACHE_TTL = 5 * 60 * 1000;
 
+export function getCachedGpsInterference(): GpsJamData | null {
+  return cachedData;
+}
+
 export async function fetchGpsInterference(): Promise<GpsJamData | null> {
   const now = Date.now();
   if (cachedData && now - cachedAt < CACHE_TTL) return cachedData;

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,66 +1,274 @@
-import type { NewsItem, ClusteredEvent, MarketData } from '@/types';
+import type { NewsItem, ClusteredEvent, MarketData, CyberThreat, Monitor } from '@/types';
 import type { PredictionMarket } from '@/services/prediction';
+import type { IntelligenceCache } from '@/app/app-context';
+import type { GpsJamData } from '@/services/gps-interference';
+import type { ConvergenceCard } from '@/services/correlation-engine';
 import { t } from '@/services/i18n';
 
 type ExportFormat = 'json' | 'csv';
 
-interface ExportData {
-  news?: NewsItem[] | ClusteredEvent[];
+export interface ExportMeta {
+  exportedAt: string;
+  note: string;
+}
+
+export interface ExportData {
+  meta?: ExportMeta;
+  timestamp: number;
+  news?: NewsItem[];
+  newsClusters?: ClusteredEvent[];
+  newsByCategory?: Record<string, NewsItem[]>;
   markets?: MarketData[];
   predictions?: PredictionMarket[];
-  signals?: unknown[];
-  timestamp: number;
+  intelligence?: IntelligenceCache;
+  cyberThreats?: CyberThreat[];
+  gpsJamming?: GpsJamData;
+  convergenceCards?: Omit<ConvergenceCard, 'assessment'>[];
+  monitors?: Monitor[];
+}
+
+// Strip LLM-derived threat annotations so AI does not feed back into itself.
+// Keyword and ML (local model) classifications are retained.
+function sanitizeNewsItem(item: NewsItem): NewsItem {
+  if (item.threat?.source !== 'llm') return item;
+  const { threat: _t, ...rest } = item;
+  return rest as NewsItem;
+}
+
+function sanitizeCluster(cluster: ClusteredEvent): ClusteredEvent {
+  return {
+    ...cluster,
+    threat: cluster.threat?.source === 'llm' ? undefined : cluster.threat,
+    allItems: cluster.allItems.map(sanitizeNewsItem),
+  };
+}
+
+function sanitizeData(data: ExportData): ExportData {
+  return {
+    ...data,
+    news: data.news?.map(sanitizeNewsItem),
+    newsClusters: data.newsClusters?.map(sanitizeCluster),
+    newsByCategory: data.newsByCategory
+      ? Object.fromEntries(
+          Object.entries(data.newsByCategory).map(([k, items]) => [k, items.map(sanitizeNewsItem)]),
+        )
+      : undefined,
+  };
 }
 
 export function exportToJSON(data: ExportData, filename = 'worldmonitor-export'): void {
-  const jsonStr = JSON.stringify(data, null, 2);
+  const jsonStr = JSON.stringify(sanitizeData(data), null, 2);
   downloadFile(jsonStr, `${filename}.json`, 'application/json');
 }
 
 export function exportToCSV(data: ExportData, filename = 'worldmonitor-export'): void {
+  const clean = sanitizeData(data);
   const lines: string[] = [];
 
-  if (data.news && data.news.length > 0) {
+  lines.push(`# WorldMonitor Export — ${new Date(clean.timestamp).toISOString()}`);
+  lines.push('# Note: CSV is a structured summary. Use JSON export for full fidelity.');
+  if (clean.meta?.note) lines.push(`# ${clean.meta.note}`);
+  lines.push('');
+
+  // News — prefer raw items over clusters; clusters lose individual sources
+  const newsItems = clean.news ?? [];
+  if (newsItems.length > 0) {
     lines.push('=== NEWS ===');
-    lines.push('Title,Source,Link,Published,IsAlert');
-    data.news.forEach(item => {
-      if ('primaryTitle' in item) {
-        const cluster = item as ClusteredEvent;
-        lines.push(csvRow([
-          cluster.primaryTitle,
-          cluster.primarySource,
-          cluster.primaryLink,
-          cluster.lastUpdated.toISOString(),
-          String(cluster.isAlert),
-        ]));
-      } else {
-        const news = item as NewsItem;
-        lines.push(csvRow([
-          news.title,
-          news.source,
-          news.link,
-          news.pubDate?.toISOString() || '',
-          String(news.isAlert),
-        ]));
-      }
+    lines.push('Title,Source,Link,Published,IsAlert,ThreatLevel,ThreatCategory');
+    newsItems.forEach(item => {
+      lines.push(csvRow([
+        item.title,
+        item.source,
+        item.link,
+        item.pubDate?.toISOString() || '',
+        String(item.isAlert),
+        item.threat?.level ?? '',
+        item.threat?.category ?? '',
+      ]));
     });
     lines.push('');
   }
 
-  if (data.markets && data.markets.length > 0) {
+  if (clean.markets && clean.markets.length > 0) {
     lines.push('=== MARKETS ===');
     lines.push('Symbol,Name,Price,Change');
-    data.markets.forEach(m => {
+    clean.markets.forEach(m => {
       lines.push(csvRow([m.symbol, m.name, String(m.price ?? ''), String(m.change ?? '')]));
     });
     lines.push('');
   }
 
-  if (data.predictions && data.predictions.length > 0) {
+  if (clean.predictions && clean.predictions.length > 0) {
     lines.push('=== PREDICTIONS ===');
     lines.push('Title,Yes Price,Volume');
-    data.predictions.forEach(p => {
+    clean.predictions.forEach(p => {
       lines.push(csvRow([p.title, String(p.yesPrice), String(p.volume ?? '')]));
+    });
+    lines.push('');
+  }
+
+  const intel = clean.intelligence;
+  if (intel) {
+    if (intel.protests?.events && intel.protests.events.length > 0) {
+      lines.push('=== PROTESTS ===');
+      lines.push('Title,Country,EventType,Severity,Time');
+      intel.protests.events.forEach(e => {
+        lines.push(csvRow([e.title, e.country, e.eventType, e.severity, e.time.toISOString()]));
+      });
+      lines.push('');
+    }
+
+    if (intel.earthquakes && intel.earthquakes.length > 0) {
+      lines.push('=== EARTHQUAKES ===');
+      lines.push('Place,Magnitude,DepthKm,OccurredAt,URL');
+      intel.earthquakes.forEach(e => {
+        lines.push(csvRow([e.place, String(e.magnitude), String(e.depthKm), new Date(e.occurredAt * 1000).toISOString(), e.sourceUrl]));
+      });
+      lines.push('');
+    }
+
+    if (intel.outages && intel.outages.length > 0) {
+      lines.push('=== INTERNET OUTAGES ===');
+      lines.push('Title,Country,Severity,PubDate,Link');
+      intel.outages.forEach(o => {
+        lines.push(csvRow([o.title, o.country, o.severity, o.pubDate.toISOString(), o.link]));
+      });
+      lines.push('');
+    }
+
+    if (intel.flightDelays && intel.flightDelays.length > 0) {
+      lines.push('=== FLIGHT DELAYS ===');
+      lines.push('Airport,IATA,City,Country,DelayType,Severity,AvgDelayMin,Source');
+      intel.flightDelays.forEach(d => {
+        lines.push(csvRow([d.name, d.iata, d.city, d.country, d.delayType, d.severity, String(d.avgDelayMinutes), d.source]));
+      });
+      lines.push('');
+    }
+
+    if (intel.military?.flights && intel.military.flights.length > 0) {
+      lines.push('=== MILITARY FLIGHTS ===');
+      lines.push('Callsign,HexCode,AircraftType,Operator,Country,Lat,Lon');
+      intel.military.flights.forEach(f => {
+        lines.push(csvRow([f.callsign, f.hexCode, f.aircraftType, f.operator, f.operatorCountry, String(f.lat), String(f.lon)]));
+      });
+      lines.push('');
+    }
+
+    if (intel.military?.vessels && intel.military.vessels.length > 0) {
+      lines.push('=== MILITARY VESSELS ===');
+      lines.push('Name,MMSI,Country,VesselType,Lat,Lon');
+      intel.military.vessels.forEach(v => {
+        lines.push(csvRow([v.name, v.mmsi, v.operatorCountry, v.vesselType, String(v.lat), String(v.lon)]));
+      });
+      lines.push('');
+    }
+
+    if (intel.iranEvents && intel.iranEvents.length > 0) {
+      lines.push('=== IRAN EVENTS ===');
+      lines.push('Title,Category,Location,Severity,Timestamp');
+      intel.iranEvents.forEach(e => {
+        lines.push(csvRow([e.title, e.category, e.locationName, e.severity, e.timestamp]));
+      });
+      lines.push('');
+    }
+
+    if (intel.orefAlerts) {
+      lines.push('=== OREF ALERTS ===');
+      lines.push('ActiveAlerts,History24h');
+      lines.push(csvRow([String(intel.orefAlerts.alertCount), String(intel.orefAlerts.historyCount24h)]));
+      lines.push('');
+    }
+
+    if (intel.advisories && intel.advisories.length > 0) {
+      lines.push('=== SECURITY ADVISORIES ===');
+      lines.push('Title,Source,Level,Country,PubDate,Link');
+      intel.advisories.forEach(a => {
+        lines.push(csvRow([a.title, a.source, a.level ?? '', a.country ?? '', a.pubDate.toISOString(), a.link]));
+      });
+      lines.push('');
+    }
+
+    if (intel.radiation?.observations && intel.radiation.observations.length > 0) {
+      lines.push('=== RADIATION MONITORING ===');
+      lines.push('Location,Country,Value,Unit,ObservedAt');
+      intel.radiation.observations.forEach(s => {
+        lines.push(csvRow([s.location, s.country, String(s.value), s.unit, s.observedAt.toISOString()]));
+      });
+      lines.push('');
+    }
+
+    if (intel.imageryScenes && intel.imageryScenes.length > 0) {
+      lines.push('=== SATELLITE IMAGERY ===');
+      lines.push('ID,Satellite,DateTime,ResolutionM,Mode');
+      intel.imageryScenes.forEach(s => {
+        lines.push(csvRow([s.id, s.satellite, s.datetime, String(s.resolutionM), s.mode]));
+      });
+      lines.push('');
+    }
+
+    if (intel.sanctions) {
+      lines.push('=== SANCTIONS ===');
+      lines.push('# See JSON export for full sanctions data');
+      lines.push(`TotalCount,${intel.sanctions.totalCount}`);
+      lines.push(`SDNCount,${intel.sanctions.sdnCount}`);
+      lines.push(`NewEntries,${intel.sanctions.newEntryCount}`);
+      lines.push('');
+    }
+
+    if (intel.thermalEscalation) {
+      lines.push('=== THERMAL ESCALATION ===');
+      lines.push('# See JSON export for full thermal data');
+      lines.push(`ClusterCount,${intel.thermalEscalation.summary.clusterCount}`);
+      lines.push(`ElevatedCount,${intel.thermalEscalation.summary.elevatedCount}`);
+      lines.push('');
+    }
+
+    if (intel.usniFleet) {
+      lines.push('=== USNI FLEET ===');
+      lines.push('# See JSON export for full fleet data');
+      lines.push(`Vessels,${intel.usniFleet.vessels?.length ?? 0}`);
+      lines.push('');
+    }
+
+    if (intel.aircraftPositions && intel.aircraftPositions.length > 0) {
+      lines.push('=== AIRCRAFT POSITIONS ===');
+      lines.push(`# ${intel.aircraftPositions.length} positions — see JSON for full data`);
+      lines.push('');
+    }
+  }
+
+  if (clean.cyberThreats && clean.cyberThreats.length > 0) {
+    lines.push('=== CYBER THREATS ===');
+    lines.push('Indicator,Type,Severity,Country,Source,FirstSeen');
+    clean.cyberThreats.forEach(c => {
+      lines.push(csvRow([c.indicator, c.indicatorType, String(c.severity), c.country ?? '', c.source, c.firstSeen ?? '']));
+    });
+    lines.push('');
+  }
+
+  if (clean.gpsJamming) {
+    lines.push('=== GPS JAMMING ===');
+    lines.push('FetchedAt,TotalHexes,HighCount,MediumCount');
+    const s = clean.gpsJamming.stats;
+    lines.push(csvRow([clean.gpsJamming.fetchedAt, String(s.totalHexes), String(s.highCount), String(s.mediumCount)]));
+    lines.push('# Per-hex data available in JSON export');
+    lines.push('');
+  }
+
+  if (clean.convergenceCards && clean.convergenceCards.length > 0) {
+    lines.push('=== SIGNAL CONVERGENCE ===');
+    lines.push('Domain,Title,Score,Trend,Countries');
+    clean.convergenceCards.forEach(c => {
+      lines.push(csvRow([c.domain, c.title, String(c.score), c.trend, c.countries.join(';')]));
+    });
+    lines.push('');
+  }
+
+  if (clean.monitors && clean.monitors.length > 0) {
+    lines.push('=== MONITORS ===');
+    lines.push('Name,Keywords,Color');
+    clean.monitors.forEach(m => {
+      lines.push(csvRow([m.name ?? '', m.keywords.join(';'), m.color]));
     });
     lines.push('');
   }


### PR DESCRIPTION
## Summary

- Expands the pro export panel from 3 fields (news clusters, markets, predictions) to the full non-AI signal corpus: flight delays, military flights/vessels, protests, earthquakes, internet outages, Iran events, Oref alerts, advisories, sanctions, radiation, imagery scenes, thermal escalation, GPS jamming, cyber threats, convergence cards, and user monitors
- Strips LLM-derived `threat` annotations from all exported `NewsItem`/`ClusteredEvent` records before serialization (keyword and local-ML classifications kept) — prevents AI output from feeding back into itself
- Adds `meta.note` to every export documenting whether any sources were disabled at export time
- CSV export now covers all sections: full rows for flat data, summary stats for complex nested types, explicit header comment that CSV is a structured summary and JSON is full-fidelity
- Adds `getCachedGpsInterference()` sync accessor (zero network cost on export)
- Adds `CorrelationEngine.getAllCards()` to aggregate all domain cards in one call

## Test plan

- [ ] Export JSON as a Pro user — verify all sections present (news, markets, predictions, intelligence.*, cyberThreats, gpsJamming, convergenceCards, monitors)
- [ ] Verify no `threat.source === "llm"` values appear in exported news or clusters
- [ ] Disable a feed source, export — confirm `meta.note` says "N source(s) are disabled and not included"
- [ ] Export CSV — verify header comment, all sections present with correct column names, GPS jamming shows stats only with "See JSON" note
- [ ] `npx tsc --noEmit` passes (pre-push hook confirms)