### PR TITLE
fix(consumer-prices): fold validate into aggregate job, remove separate cron step

### DIFF
--- a/consumer-prices-core/package.json
+++ b/consumer-prices-core/package.json
@@ -8,7 +8,6 @@
     "start": "node dist/api/server.js",
     "dev": "tsx watch src/api/server.ts",
     "jobs:scrape": "tsx src/jobs/scrape.ts",
-    "jobs:validate": "tsx src/jobs/validate.ts",
     "jobs:aggregate": "tsx src/jobs/aggregate.ts",
     "jobs:publish": "tsx src/jobs/publish.ts",
     "migrate": "tsx src/db/migrate.ts",

--- a/consumer-prices-core/src/jobs/aggregate.ts
+++ b/consumer-prices-core/src/jobs/aggregate.ts
@@ -5,6 +5,7 @@
  */
 import { query, closePool } from '../db/client.js';
 import { loadAllBasketConfigs } from '../config/loader.js';
+import { validateAll } from './validate.js';
 
 const logger = {
   info: (msg: string, ...args: unknown[]) => console.log(`[aggregate] ${msg}`, ...args),
@@ -275,6 +276,11 @@ export async function aggregateAll() {
   if (failed > 0) throw new Error(`${failed}/${configs.length} basket(s) failed`);
 }
 
+export async function validateAndAggregateAll() {
+  await validateAll();
+  await aggregateAll();
+}
+
 if (import.meta.url === `file://${process.argv[1]}`) {
-  aggregateAll().finally(() => closePool()).catch(console.error);
+  validateAndAggregateAll().finally(() => closePool()).catch(console.error);
 }


### PR DESCRIPTION
## Summary
- `aggregate.ts` now runs `validateAll()` then `aggregateAll()` in sequence via `validateAndAggregateAll()`
- Removed `jobs:validate` npm script (no longer needed as a standalone Railway cron)
- Railway pipeline stays `scrape → aggregate → publish` (3 services, not 4)

validate takes ~2s so there's no reason to run it as a separate cron between scrape and aggregate.