### PR TITLE
fix(seed-economy): add missing FRED series (BAMLH0A0HYM2, ICSA, MORTGAGE30US, GSCPI)

### DIFF
--- a/src/bootstrap/sw-update.ts
+++ b/src/bootstrap/sw-update.ts
@@ -25,8 +25,13 @@ export interface SwUpdateHandlerOptions {
  *
  * On each controllerchange after the first (first = initial claim on a new session),
  * shows a dismissible "Update Available" toast. If the user dismisses the toast,
- * the tab auto-reloads the next time it goes to background. Dismissing one version
- * never suppresses toasts for future deploys.
+ * the tab auto-reloads the next time it goes to background — but only after the tab
+ * has been visible at least once since the toast appeared. This prevents an infinite
+ * reload loop when an update is detected while the tab is already in the background:
+ * without this guard, onHidden would fire immediately, reload the hidden page, the
+ * new page would detect the same update, fire again, and loop forever.
+ *
+ * Dismissing one version never suppresses toasts for future deploys.
  */
 export function installSwUpdateHandler(options: SwUpdateHandlerOptions = {}): void {
   const swContainer = options.swContainer ?? navigator.serviceWorker;
@@ -61,9 +66,19 @@ export function installSwUpdateHandler(options: SwUpdateHandlerOptions = {}): vo
     `;
 
     let dismissed = false;
+    // Auto-reload on tab-hide is only allowed after the tab has been visible at least
+    // once since the toast appeared. If the update fires while the tab is already hidden,
+    // this starts false and becomes true when the user returns — preventing the immediate
+    // onHidden → reload → new page → onHidden → reload infinite background loop.
+    let autoReloadAllowed = doc.visibilityState === 'visible';
 
     const onHidden = (): void => {
-      if (!dismissed && doc.visibilityState === 'hidden' && doc.body.contains(toast)) {
+      if (doc.visibilityState === 'visible') {
+        // Tab returned to foreground — user has now seen the toast, allow auto-reload.
+        autoReloadAllowed = true;
+        return;
+      }
+      if (!dismissed && autoReloadAllowed && doc.body.contains(toast)) {
         reload();
       }
     };

--- a/tests/sw-update.test.mts
+++ b/tests/sw-update.test.mts
@@ -307,6 +307,42 @@ describe('installSwUpdateHandler', () => {
     assert.equal(env.reloadCalls.length, 1, 'no second reload on visible transition');
   });
 
+  // --- background-loop prevention (infinite reload bug fix) -------------------
+
+  it('does NOT auto-reload when update fires while tab is already hidden', () => {
+    env.swContainer._controller = {};
+    install(env);
+
+    // Tab is in the background when the SW update activates
+    env.doc.setVisibilityState('hidden');
+    env.swContainer.fireControllerChange();
+
+    // visibilitychange fires but tab is still hidden — must NOT reload (prevents infinite loop)
+    fireVisibility(env);
+    assert.equal(env.reloadCalls.length, 0, 'no auto-reload when already in background');
+  });
+
+  it('allows auto-reload after user returns to the tab that received a background update', () => {
+    env.swContainer._controller = {};
+    install(env);
+
+    // Update fires while hidden
+    env.doc.setVisibilityState('hidden');
+    env.swContainer.fireControllerChange();
+    fireVisibility(env);
+    assert.equal(env.reloadCalls.length, 0, 'no reload yet — tab still hidden');
+
+    // User returns to the tab — now they can see the toast
+    env.doc.setVisibilityState('visible');
+    fireVisibility(env);
+    assert.equal(env.reloadCalls.length, 0, 'no reload on becoming visible');
+
+    // User switches away — auto-reload is now allowed
+    env.doc.setVisibilityState('hidden');
+    fireVisibility(env);
+    assert.equal(env.reloadCalls.length, 1, 'reload fires when user switches away after seeing toast');
+  });
+
   // --- listener leak regression -----------------------------------------------
 
   it('removes the previous visibilitychange handler when a newer deploy replaces the toast', () => {


### PR DESCRIPTION
## Why this PR?

Four FRED series were present in the server allowlist and frontend config but missing from the seeder, causing empty data in production on every request.

## Change

Added `BAMLH0A0HYM2`, `ICSA`, `MORTGAGE30US`, `GSCPI` to `FRED_SERIES` in `scripts/seed-economy.mjs` line 20.

All three files are now in sync:
- `server/worldmonitor/economic/v1/get-fred-series-batch.ts` (allowlist)
- `src/services/economic/index.ts` (frontend config)
- `scripts/seed-economy.mjs` (seeder)

Closes #2041