### PR TITLE
fix(seed-economy): add missing FRED series (BAMLH0A0HYM2, ICSA, MORTGAGE30US, GSCPI)

### DIFF
--- a/scripts/seed-economy.mjs
+++ b/scripts/seed-economy.mjs
@@ -17,7 +17,7 @@ const ENERGY_TTL = 3600;
 const CAPACITY_TTL = 86400;
 const MACRO_TTL = 21600; // 6h — survive extended Yahoo outages
 
-const FRED_SERIES = ['WALCL', 'FEDFUNDS', 'T10Y2Y', 'UNRATE', 'CPIAUCSL', 'DGS10', 'VIXCLS', 'GDP', 'M2SL', 'DCOILWTICO'];
+const FRED_SERIES = ['WALCL', 'FEDFUNDS', 'T10Y2Y', 'UNRATE', 'CPIAUCSL', 'DGS10', 'VIXCLS', 'GDP', 'M2SL', 'DCOILWTICO', 'BAMLH0A0HYM2', 'ICSA', 'MORTGAGE30US', 'GSCPI'];
 
 // ─── EIA Energy Prices (WTI + Brent) ───
 


### PR DESCRIPTION
## Why this PR?

Four FRED series were present in the server allowlist and frontend config but missing from the seeder, causing empty data in production on every request.

## Change

Added `BAMLH0A0HYM2`, `ICSA`, `MORTGAGE30US`, `GSCPI` to `FRED_SERIES` in `scripts/seed-economy.mjs` line 20.

All three files are now in sync:
- `server/worldmonitor/economic/v1/get-fred-series-batch.ts` (allowlist)
- `src/services/economic/index.ts` (frontend config)
- `scripts/seed-economy.mjs` (seeder)

Closes #2041