### PR TITLE
fix(community-widget): rename pill label to Help Shape What's Next

### DIFF
--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -924,7 +924,7 @@
       "nuclear": "نووي"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "عدم العرض مجدداً",
       "sectionLabel": "المجتمع"

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -958,7 +958,7 @@
       "nuclear": "Ядрена"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Не показвай отново",
       "sectionLabel": "Общност"

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -948,7 +948,7 @@
       "nuclear": "Jaderné zařízení"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Příště nezobrazovat",
       "sectionLabel": "Komunita"

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1060,7 +1060,7 @@
       "nuclear": "Nuklear"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Nicht mehr anzeigen",
       "sectionLabel": "Gemeinschaft"

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -958,7 +958,7 @@
       "nuclear": "Πυρηνικό"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Να μην εμφανιστεί ξανά",
       "sectionLabel": "Κοινότητα"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1148,7 +1148,7 @@
       "nuclear": "Nuclear"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Don't show again",
       "sectionLabel": "Community"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1060,7 +1060,7 @@
       "nuclear": "Nuclear"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "No mostrar de nuevo",
       "sectionLabel": "Comunidad"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -924,7 +924,7 @@
       "nuclear": "Nucléaire"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Ne plus afficher",
       "sectionLabel": "Communauté"

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -1060,7 +1060,7 @@
       "nuclear": "Nucleare"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Non mostrare più",
       "sectionLabel": "Comunità"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -958,7 +958,7 @@
       "nuclear": "核施設"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "今後表示しない",
       "sectionLabel": "コミュニティ"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -958,7 +958,7 @@
       "nuclear": "핵 시설"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "다시 표시하지 않기",
       "sectionLabel": "커뮤니티"

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -739,7 +739,7 @@
       "nuclear": "Nucleair"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Niet meer tonen",
       "sectionLabel": "Gemeenschap"

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1036,7 +1036,7 @@
       "nuclear": "Obiekt jądrowy"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Nie pokazuj ponownie",
       "sectionLabel": "Społeczność"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -739,7 +739,7 @@
       "nuclear": "Nuclear"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Não mostrar novamente",
       "sectionLabel": "Comunidade"

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -958,7 +958,7 @@
       "nuclear": "Nuclear"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Nu mai afișa",
       "sectionLabel": "Comunitate"

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -958,7 +958,7 @@
       "nuclear": "Ядерный"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Больше не показывать",
       "sectionLabel": "Сообщество"

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -739,7 +739,7 @@
       "nuclear": "Kärnteknisk"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Visa inte igen",
       "sectionLabel": "Gemenskap"

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -958,7 +958,7 @@
       "nuclear": "นิวเคลียร์"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "ไม่แสดงอีก",
       "sectionLabel": "ชุมชน"

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -958,7 +958,7 @@
       "nuclear": "Nukleer"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Bir daha gosterme",
       "sectionLabel": "Topluluk"

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -958,7 +958,7 @@
       "nuclear": "Hạt nhân"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "Không hiển thị lại",
       "sectionLabel": "Cộng đồng"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -958,7 +958,7 @@
       "nuclear": "核设施"
     },
     "community": {
-      "joinDiscussion": "Join Discord",
+      "joinDiscussion": "Help Shape What's Next",
       "openDiscussion": "Join Discord",
       "dontShowAgain": "不再显示",
       "sectionLabel": "社区"


### PR DESCRIPTION
## Summary
- Updates the community widget's left pill text from "Join Discord" to "Help Shape What's Next" across all 21 locale files
- The right CTA button ("Join Discord") remains unchanged

## Test plan
- [ ] Community widget pill shows "Help Shape What's Next" on left side
- [ ] "Join Discord" button still links to Discord correctly
- [ ] No visual layout breakage from longer text