### PR TITLE
fix(health): extend customsRevenue TTL to 24h to prevent expiry gap

### DIFF
--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -15,6 +15,7 @@ const KEYS = {
 
 const SHIPPING_TTL = 3600;
 const TRADE_TTL = 21600;
+const CUSTOMS_TTL = 86400;
 
 const MAJOR_REPORTERS = ['840', '156', '276', '392', '826', '356', '076', '643', '410', '036', '124', '484', '250', '380', '528'];
 
@@ -583,7 +584,7 @@ async function fetchAll() {
   if (re) await writeExtraKeyWithMeta(KEYS.restrictions, re, TRADE_TTL, re.restrictions?.length ?? 0);
   if (fl) { for (const [key, data] of Object.entries(fl)) await writeExtraKeyWithMeta(key, data, TRADE_TTL, data.flows?.length ?? 0); }
   if (ta) { for (const [key, data] of Object.entries(ta)) await writeExtraKeyWithMeta(key, data, TRADE_TTL, data.datapoints?.length ?? 0); }
-  if (cu) await writeExtraKeyWithMeta(KEYS.customsRevenue, cu, TRADE_TTL, cu.months?.length ?? 0);
+  if (cu) await writeExtraKeyWithMeta(KEYS.customsRevenue, cu, CUSTOMS_TTL, cu.months?.length ?? 0);
 
   return mergedIndices.length > 0
     ? { indices: mergedIndices, fetchedAt: new Date().toISOString(), upstreamUnavailable: false }


### PR DESCRIPTION
## Summary
- `TRADE_TTL` (6h = 21600s) matched the cron cadence exactly, so `trade:customs-revenue:v1` expired seconds before the next seed run
- This caused recurring `EMPTY` CRITs on the health endpoint (`records: 0, seedAgeMin: ~360`)
- Treasury customs revenue is monthly data; a 24h TTL (`CUSTOMS_TTL = 86400`) is appropriate and matches the existing `maxStaleMin: 1440` health threshold

## Root cause
`seedAgeMin: 364 > TRADE_TTL: 360` — data key expired, seed-meta key survived, health reported EMPTY.

## Test plan
- [ ] After next Railway cron run, `customsRevenue` shows `records > 0`
- [ ] No EMPTY CRIT on health for `customsRevenue` over a 24h window