### PR TITLE
fix(health): enforce 1h+ TTL buffer across all seed jobs (full audit)

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1582,7 +1582,7 @@ const _cryptoCfg = requireShared('crypto.json');
 const CRYPTO_IDS = _cryptoCfg.ids;
 const CRYPTO_META = _cryptoCfg.meta;
 const CRYPTO_PAPRIKA_MAP = _cryptoCfg.coinpaprika;
-const CRYPTO_SEED_TTL = 3600; // 1h
+const CRYPTO_SEED_TTL = 7200; // 2h — 1h buffer over 5min cron cadence (was 1h = 55min buffer)
 
 async function fetchCryptoCoinPaprika() {
   const data = await cyberHttpGetJson('https://api.coinpaprika.com/v1/tickers?quotes=USD', { Accept: 'application/json' }, 15000);
@@ -1628,7 +1628,7 @@ async function seedCryptoQuotes() {
 // Stablecoin Markets — CoinGecko → CoinPaprika fallback
 const STABLECOIN_IDS = 'tether,usd-coin,dai,first-digital-usd,ethena-usde';
 const STABLECOIN_PAPRIKA_MAP = { tether: 'usdt-tether', 'usd-coin': 'usdc-usd-coin', dai: 'dai-dai', 'first-digital-usd': 'fdusd-first-digital-usd', 'ethena-usde': 'usde-ethena-usde' };
-const STABLECOIN_SEED_TTL = 3600; // 1h
+const STABLECOIN_SEED_TTL = 7200; // 2h — 1h buffer over 5min cron cadence (was 1h = 55min buffer)
 
 async function fetchStablecoinCoinPaprika() {
   const data = await cyberHttpGetJson('https://api.coinpaprika.com/v1/tickers?quotes=USD', { Accept: 'application/json' }, 15000);
@@ -1678,7 +1678,7 @@ async function seedStablecoinMarkets() {
 // Crypto Sectors Heatmap — CoinGecko sector averages
 const _sectorsCfg = requireShared('crypto-sectors.json');
 const SECTORS_LIST = _sectorsCfg.sectors;
-const SECTORS_SEED_TTL = 3600; // 1h
+const SECTORS_SEED_TTL = 7200; // 2h — 1h buffer over 5min cron cadence (was 1h = 55min buffer)
 
 async function seedCryptoSectors() {
   const allIds = [...new Set(SECTORS_LIST.flatMap((s) => s.tokens))];

--- a/scripts/seed-crypto-quotes.mjs
+++ b/scripts/seed-crypto-quotes.mjs
@@ -7,7 +7,7 @@ const cryptoConfig = loadSharedConfig('crypto.json');
 loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'market:crypto:v1';
-const CACHE_TTL = 3600; // 1 hour
+const CACHE_TTL = 7200; // 2h — 1h buffer over 5min cron cadence (was 60min = 55min buffer)
 
 const CRYPTO_IDS = cryptoConfig.ids;
 const CRYPTO_META = cryptoConfig.meta;

--- a/scripts/seed-etf-flows.mjs
+++ b/scripts/seed-etf-flows.mjs
@@ -7,7 +7,7 @@ const etfConfig = loadSharedConfig('etfs.json');
 loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'market:etf-flows:v1';
-const CACHE_TTL = 3600;
+const CACHE_TTL = 5400; // 90min — 1h buffer over 15min cron cadence (was 60min = 45min buffer)
 const YAHOO_DELAY_MS = 200;
 
 const ETF_LIST = etfConfig.btcSpot;

--- a/scripts/seed-gulf-quotes.mjs
+++ b/scripts/seed-gulf-quotes.mjs
@@ -7,7 +7,7 @@ const gulfConfig = loadSharedConfig('gulf.json');
 loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'market:gulf-quotes:v1';
-const CACHE_TTL = 3600;
+const CACHE_TTL = 5400; // 90min — 1h buffer over 10min cron cadence (was 60min = 50min buffer)
 const YAHOO_DELAY_MS = 200;
 
 const GULF_SYMBOLS = gulfConfig.symbols;

--- a/scripts/seed-sanctions-pressure.mjs
+++ b/scripts/seed-sanctions-pressure.mjs
@@ -12,7 +12,7 @@ loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'sanctions:pressure:v1';
 const STATE_KEY = 'sanctions:pressure:state:v1';
-const CACHE_TTL = 12 * 60 * 60;
+const CACHE_TTL = 15 * 60 * 60; // 15h — 3h buffer over 12h cron cadence (was 12h = 0 buffer)
 const DEFAULT_RECENT_LIMIT = 60;
 const OFAC_TIMEOUT_MS = 45_000;
 const PROGRAM_CODE_RE = /^[A-Z0-9][A-Z0-9-]{1,24}$/;

--- a/scripts/seed-security-advisories.mjs
+++ b/scripts/seed-security-advisories.mjs
@@ -6,7 +6,7 @@ loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'intelligence:advisories:v1';
 const BOOTSTRAP_KEY = 'intelligence:advisories-bootstrap:v1';
-const TTL = 7200; // 120min (2x cron interval; ensures data outlives maxStaleMin:120)
+const TTL = 10800; // 180min — 2h buffer over 1h cron cadence (was 120min = exactly 1h buffer)
 
 const ALLOWED_DOMAINS = new Set(loadSharedConfig('rss-allowed-domains.json'));
 

--- a/scripts/seed-stablecoin-markets.mjs
+++ b/scripts/seed-stablecoin-markets.mjs
@@ -7,7 +7,7 @@ const stablecoinConfig = loadSharedConfig('stablecoins.json');
 loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'market:stablecoins:v1';
-const CACHE_TTL = 3600; // 1 hour
+const CACHE_TTL = 5400; // 90min — 1h buffer over 10min cron cadence (was 60min = 50min buffer)
 
 const STABLECOIN_IDS = stablecoinConfig.ids.join(',');
 

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -15,7 +15,8 @@ const KEYS = {
 
 const SHIPPING_TTL = 3600;
 const TRADE_TTL = 21600;
-const CUSTOMS_TTL = 86400;
+const TARIFF_TTL = 28800; // 8h — 2h buffer over 6h cron cadence (was TRADE_TTL=6h = 0 buffer)
+const CUSTOMS_TTL = 86400; // 24h — monthly Treasury data, matches maxStaleMin:1440 (was TRADE_TTL=6h = 0 buffer)
 
 const MAJOR_REPORTERS = ['840', '156', '276', '392', '826', '356', '076', '643', '410', '036', '124', '484', '250', '380', '528'];
 
@@ -583,7 +584,7 @@ async function fetchAll() {
   if (ba) await writeExtraKeyWithMeta(KEYS.barriers, ba, TRADE_TTL, ba.barriers?.length ?? 0);
   if (re) await writeExtraKeyWithMeta(KEYS.restrictions, re, TRADE_TTL, re.restrictions?.length ?? 0);
   if (fl) { for (const [key, data] of Object.entries(fl)) await writeExtraKeyWithMeta(key, data, TRADE_TTL, data.flows?.length ?? 0); }
-  if (ta) { for (const [key, data] of Object.entries(ta)) await writeExtraKeyWithMeta(key, data, TRADE_TTL, data.datapoints?.length ?? 0); }
+  if (ta) { for (const [key, data] of Object.entries(ta)) await writeExtraKeyWithMeta(key, data, TARIFF_TTL, data.datapoints?.length ?? 0); }
   if (cu) await writeExtraKeyWithMeta(KEYS.customsRevenue, cu, CUSTOMS_TTL, cu.months?.length ?? 0);
 
   return mergedIndices.length > 0

--- a/scripts/seed-token-panels.mjs
+++ b/scripts/seed-token-panels.mjs
@@ -11,7 +11,7 @@ loadEnvFile(import.meta.url);
 const DEFI_KEY = 'market:defi-tokens:v1';
 const AI_KEY = 'market:ai-tokens:v1';
 const OTHER_KEY = 'market:other-tokens:v1';
-const CACHE_TTL = 3600;
+const CACHE_TTL = 5400; // 90min — 1h buffer over 30min cron cadence (was 60min = 30min buffer)
 
 const ALL_IDS = [...new Set([...defiConfig.ids, ...aiConfig.ids, ...otherConfig.ids])];
 const COINPAPRIKA_ID_MAP = { ...defiConfig.coinpaprika, ...aiConfig.coinpaprika, ...otherConfig.coinpaprika };

--- a/scripts/seed-usa-spending.mjs
+++ b/scripts/seed-usa-spending.mjs
@@ -6,7 +6,7 @@ loadEnvFile(import.meta.url);
 
 const API_BASE = 'https://api.usaspending.gov/api/v2';
 const CANONICAL_KEY = 'economic:spending:v1';
-const CACHE_TTL = 3600; // 1 hour
+const CACHE_TTL = 7200; // 2h — 1h buffer over 1h cron cadence (was 1h = 0 buffer)
 
 const AWARD_TYPE_MAP = {
   'A': 'contract', 'B': 'contract', 'C': 'contract', 'D': 'contract',


### PR DESCRIPTION
## Summary

Full audit of all seed jobs: every key's TTL must be ≥ cron interval + 1h.
Discovered 4 CRITICAL cases (TTL = cron → data expires before next run) and 9 warnings (<1h buffer).

## Changes

| File | Key | Old TTL | New TTL | Cron | Buffer (old → new) |
|------|-----|---------|---------|------|--------------------|
| seed-supply-chain-trade | tariffTrendsUs | 6h | 8h | 6h | 0 → 2h ❌→✅ |
| seed-supply-chain-trade | customsRevenue | 6h | 24h | 6h | 0 → 18h ❌→✅ |
| seed-sanctions-pressure | sanctionsPressure | 12h | 15h | ~12h | ~0 → 3h ❌→✅ |
| seed-usa-spending | spending | 1h | 2h | 1h | 0 → 1h ❌→✅ |
| seed-security-advisories | securityAdvisories | 2h | 3h | 1h | 1h → 2h ⚠️→✅ |
| seed-token-panels | defiTokens/aiTokens/otherTokens | 1h | 90min | 30min | 30m → 60m ⚠️→✅ |
| seed-etf-flows | etfFlows | 1h | 90min | 15min | 45m → 75m ⚠️→✅ |
| seed-stablecoin-markets | stablecoinMarkets | 1h | 90min | 10min | 50m → 80m ⚠️→✅ |
| seed-gulf-quotes | gulfQuotes | 1h | 90min | 10min | 50m → 80m ⚠️→✅ |
| seed-crypto-quotes | cryptoQuotes | 1h | 2h | 5min | 55m → 115m ⚠️→✅ |
| ais-relay CRYPTO_SEED_TTL | cryptoQuotes (relay) | 1h | 2h | 5min | 55m → 115m ⚠️→✅ |
| ais-relay STABLECOIN_SEED_TTL | stablecoinMarkets (relay) | 1h | 2h | 5min | 55m → 115m ⚠️→✅ |
| ais-relay SECTORS_SEED_TTL | sectors (relay) | 1h | 2h | 5min | 55m → 115m ⚠️→✅ |

Note: This PR supersedes #2070 (customsRevenue fix) — includes that change plus all others.

## Test plan
- [ ] After next Railway cron runs, all health BOOTSTRAP_KEYS remain OK
- [ ] `tariffTrendsUs` stays populated for full 24h cycle
- [ ] `customsRevenue` stays populated between seed runs
- [ ] `sanctionsPressure` stays populated between 12h runs
- [ ] Health endpoint shows no EMPTY CRITs for the above keys