### PR TITLE
fix(health): add FRED + militaryForecastInputs monitoring, dedup seed-meta GET

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -225,7 +225,8 @@ function dataSize(parsed) {
                       'chokepoints', 'minerals', 'anomalies', 'flows', 'bases', 'flights',
                       'theaters', 'fleets', 'warnings', 'closures', 'cables',
                       'airports', 'closedIcaos', 'categories', 'regions', 'entries', 'satellites',
-                      'sectors', 'statuses', 'scores', 'topics', 'advisories', 'months']) {
+                      'sectors', 'statuses', 'scores', 'topics', 'advisories', 'months',
+                      'observations', 'datapoints', 'clusters']) {
       if (Array.isArray(parsed[k])) return parsed[k].length;
     }
     return Object.keys(parsed).length;


### PR DESCRIPTION
## Summary

- **FRED now monitored**: `economic:fred:v1:FEDFUNDS:0` added to `BOOTSTRAP_KEYS` with seed-meta freshness check (maxStaleMin=90, matching 15min Railway cron × 6). FRED going stale previously caused the Macro Stress panel to show "Upstream API unavailable" with zero visibility in health
- **militaryForecastInputs gap closed**: `military:forecast-inputs:stale:v1` added to `STANDALONE_KEYS` — this intermediate key is written by `seed-military-flights.mjs` and consumed by `seed-forecasts.mjs`; if the seed stopped writing it, forecast quality would silently degrade. Classified as `ON_DEMAND` (WARN not CRIT) since it only exists after the first seed run
- **Removed duplicate faaDelays SEED_META entry**: `flightDelays` and `faaDelays` share the same seed-meta key (`seed-meta:aviation:faa`); the duplicate fired two identical Redis GETs per health check

## Test plan

- [ ] Hit `/api/health` and verify `fredBatch` appears in checks (OK or STALE_SEED depending on when seed-economy last ran)
- [ ] Verify `militaryForecastInputs` appears in checks as WARN/EMPTY_ON_DEMAND if seed hasn't run, OK otherwise
- [ ] Confirm no duplicate keys in the pipeline (Redis GET count reduced by 1)