### PR TITLE
fix(fred): remove GSCPI — series does not exist on FRED API

### DIFF
--- a/scripts/seed-economy.mjs
+++ b/scripts/seed-economy.mjs
@@ -17,7 +17,7 @@ const ENERGY_TTL = 3600;
 const CAPACITY_TTL = 86400;
 const MACRO_TTL = 21600; // 6h — survive extended Yahoo outages
 
-const FRED_SERIES = ['WALCL', 'FEDFUNDS', 'T10Y2Y', 'UNRATE', 'CPIAUCSL', 'DGS10', 'VIXCLS', 'GDP', 'M2SL', 'DCOILWTICO', 'BAMLH0A0HYM2', 'ICSA', 'MORTGAGE30US', 'GSCPI'];
+const FRED_SERIES = ['WALCL', 'FEDFUNDS', 'T10Y2Y', 'UNRATE', 'CPIAUCSL', 'DGS10', 'VIXCLS', 'GDP', 'M2SL', 'DCOILWTICO', 'BAMLH0A0HYM2', 'ICSA', 'MORTGAGE30US'];
 
 // ─── EIA Energy Prices (WTI + Brent) ───
 


### PR DESCRIPTION
## Summary

- Validated with real `FRED_API_KEY`: `GSCPI` returns `"The series does not exist."` (HTTP 400)
- Was causing a `fetch failed` warning on every seed run (13/14 series written)
- Removed from `FRED_SERIES` array

## Test plan
- [ ] Next seed run logs `FRED series: 13/13` with no warnings