### PR TITLE
fix(daily-market-brief): remove attribution, fix change colors, fix LLM prompt

### DIFF
--- a/src/components/DailyMarketBriefPanel.ts
+++ b/src/components/DailyMarketBriefPanel.ts
@@ -3,6 +3,7 @@ import { t } from '@/services/i18n';
 import type { DailyMarketBrief } from '@/services/daily-market-brief';
 import { describeFreshness } from '@/services/persistent-cache';
 import { escapeHtml } from '@/utils/sanitize';
+import { getChangeClass } from '@/utils';
 
 type BriefSource = 'live' | 'cached';
 
@@ -78,7 +79,7 @@ export class DailyMarketBriefPanel extends Panel {
                 </div>
                 <div style="text-align:right">
                   <div style="font-size:12px;font-weight:600">${escapeHtml(formatPrice(item.price))}</div>
-                  <div style="font-size:11px;color:var(--text-dim)">${escapeHtml(formatChange(item.change))}</div>
+                  <div class="${getChangeClass(item.change ?? 0)}" style="font-size:11px">${escapeHtml(formatChange(item.change))}</div>
                 </div>
               </div>
               <div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
@@ -90,9 +91,6 @@ export class DailyMarketBriefPanel extends Panel {
           `).join('')}
         </div>
 
-        <div style="font-size:11px;color:var(--text-dim)">
-          ${escapeHtml(brief.fallback ? 'Rules-based brief' : `AI-assisted brief via ${brief.provider}${brief.model ? ` (${brief.model})` : ''}`)}
-        </div>
       </div>
     `;
 

--- a/src/services/daily-market-brief.ts
+++ b/src/services/daily-market-brief.ts
@@ -263,15 +263,14 @@ function buildRiskWatch(items: DailyMarketBriefItem[], headlines: NewsItem[]): s
   return 'Risk watch is centered on macro follow-through, index breadth, and any abrupt reversal in the strongest names.';
 }
 
-function buildSummaryInputs(items: DailyMarketBriefItem[], headlines: NewsItem[]): string[] {
-  const marketLines = items.map((item) => {
+function buildSummaryInputs(items: DailyMarketBriefItem[], headlines: NewsItem[]): { headlines: string[]; marketContext: string } {
+  const marketContext = items.map((item) => {
     const change = formatSignedPercent(item.change);
-    const price = typeof item.price === 'number' ? ` at ${item.price.toLocaleString(undefined, { maximumFractionDigits: 2 })}` : '';
-    return `${item.name} (${item.display}) is ${change}${price}; stance is ${item.stance}.`;
-  });
+    return `${item.name} (${item.display}) ${change}`;
+  }).join(', ');
 
   const headlineLines = headlines.slice(0, 6).map((item) => item.title.trim()).filter(Boolean);
-  return [...marketLines, ...headlineLines];
+  return { headlines: headlineLines, marketContext };
 }
 
 export function shouldRefreshDailyBrief(
@@ -337,19 +336,19 @@ export async function buildDailyMarketBrief(options: BuildDailyMarketBriefOption
     };
   }
 
-  const summaryInputs = buildSummaryInputs(items, relevantHeadlines);
+  const { headlines: summaryHeadlines, marketContext } = buildSummaryInputs(items, relevantHeadlines);
   let summary = buildRuleSummary(items, relevantHeadlines.length);
   let provider = 'rules';
   let model = '';
   let fallback = true;
 
-  if (summaryInputs.length >= 2) {
+  if (summaryHeadlines.length >= 1) {
     try {
       const summaryProvider = options.summarize || await getDefaultSummarizer();
       const generated = await summaryProvider(
-        summaryInputs,
+        summaryHeadlines,
         undefined,
-        'Daily market briefing for a tracked watchlist',
+        `Market context: ${marketContext}`,
         'en',
       );
       if (generated?.summary) {


### PR DESCRIPTION
## Summary

- Remove "AI-assisted brief via openrouter (google/gemini-2.5-flash)" attribution footer — unprofessional
- Apply `getChangeClass` to price change values so negative shows red, positive shows green (was always dim gray)
- Fix root cause of "No geopolitical context is relevant to the provided headlines": `buildSummaryInputs` was mixing market data lines (e.g. "Apple (AAPL) is -0.4%") in with actual news headlines, causing the LLM to pick a market data line as the "headline" and respond that no geopolitical context applies. Now passes only real news headlines to LLM with market data as geoContext

## Test plan
- [ ] Attribution footer no longer appears at bottom of panel
- [ ] Negative change values show in red, positive in green
- [ ] Brief summary reflects actual news headlines (Trump/Iran, tariffs, etc.) not market data lines