### PR TITLE
fix(consumer-prices): disable migros_ch, coop_ch, sainsburys_gb (0/12 every run)

### DIFF
--- a/consumer-prices-core/configs/retailers/coop_ch.yaml
+++ b/consumer-prices-core/configs/retailers/coop_ch.yaml
@@ -5,7 +5,8 @@ retailer:
   currencyCode: CHF
   adapter: search
   baseUrl: https://www.coop.ch
-  enabled: true
+  # disabled 2026-03: Exa returns competitor domain URLs (domain bleed) for CH queries; 0/12 every run.
+  enabled: false
 
   searchConfig:
     numResults: 5

--- a/consumer-prices-core/configs/retailers/migros_ch.yaml
+++ b/consumer-prices-core/configs/retailers/migros_ch.yaml
@@ -5,7 +5,8 @@ retailer:
   currencyCode: CHF
   adapter: search
   baseUrl: https://www.migros.ch
-  enabled: true
+  # disabled 2026-03: Exa returns competitor domain URLs (domain bleed) for all CH queries; 0/12 every run.
+  enabled: false
 
   searchConfig:
     numResults: 5

--- a/consumer-prices-core/configs/retailers/sainsburys_gb.yaml
+++ b/consumer-prices-core/configs/retailers/sainsburys_gb.yaml
@@ -5,7 +5,8 @@ retailer:
   currencyCode: GBP
   adapter: search
   baseUrl: https://groceries.sainsburys.co.uk
-  enabled: true
+  # disabled 2026-03: Exa returns "no pages found" for all GB grocery queries; 0/12 every run.
+  enabled: false
 
   searchConfig:
     numResults: 5


### PR DESCRIPTION
## Summary
- **migros_ch**: disabled — Exa returns competitor domain URLs (domain bleed) for all CH queries, 0/12 every run
- **coop_ch**: disabled — same Exa domain bleed issue for CH market
- **sainsburys_gb**: disabled — Exa returns "no pages found" for all GB grocery queries, 0/12 every run

All three have been consistently failing across multiple runs with no sign of Exa's index improving for these domains. Each config has a dated comment explaining the root cause.

## Test plan
- [ ] Confirm `scrapeAll()` skips these three retailers (logged as "disabled, skipping")
- [ ] Run count drops from ~17 to ~14 enabled retailers
- [ ] No impact on other markets (GB coverage from tesco_gb + waitrose_gb, CH was already single-source)