### PR TITLE
fix(daily-brief): use market-change class for green/red change colors

### DIFF
--- a/src/components/DailyMarketBriefPanel.ts
+++ b/src/components/DailyMarketBriefPanel.ts
@@ -79,7 +79,7 @@ export class DailyMarketBriefPanel extends Panel {
                 </div>
                 <div style="text-align:right">
                   <div style="font-size:12px;font-weight:600">${escapeHtml(formatPrice(item.price))}</div>
-                  <div class="${getChangeClass(item.change ?? 0)}" style="font-size:11px">${escapeHtml(formatChange(item.change))}</div>
+                  <div class="market-change ${getChangeClass(item.change ?? 0)}" style="font-size:11px">${escapeHtml(formatChange(item.change))}</div>
                 </div>
               </div>
               <div style="display:flex;align-items:center;justify-content:space-between;gap:12px">


### PR DESCRIPTION
## Summary
- `getChangeClass()` returns `'up'` or `'down'`, but CSS only defines `.market-change.up` and `.market-change.down` — not standalone `.up`/`.down`
- PR #2111 applied the class but missed the `market-change` parent class, so no color was rendered
- Fix: `class="market-change ${getChangeClass(...)}"` — now uses `var(--green)` for positive and `var(--red)` for negative, consistent with Markets, Energy, Forex panels

## Test plan
- [ ] Open Daily Market Brief panel and verify positive changes show green, negative show red