### PR TITLE
fix(search): scroll to specific news item in panel after search selection

### DIFF
--- a/src/app/search-manager.ts
+++ b/src/app/search-manager.ts
@@ -265,8 +265,20 @@ export class SearchManager implements AppModule {
     switch (result.type) {
       case 'news': {
         const item = result.data as NewsItem;
-        this.scrollToPanel('politics');
-        this.highlightNewsItem(item.link);
+        // Find which panel contains this item (may not always be 'politics')
+        let targetPanelId = 'politics';
+        let targetPanel = this.ctx.newsPanels['politics'] ?? null;
+        for (const [panelId, panel] of Object.entries(this.ctx.newsPanels)) {
+          if (panel.hasNewsItem(item.link)) {
+            targetPanelId = panelId;
+            targetPanel = panel;
+            break;
+          }
+        }
+        this.scrollToPanel(targetPanelId);
+        if (targetPanel) {
+          setTimeout(() => targetPanel!.scrollToNewsItem(item.link), 300);
+        }
         break;
       }
       case 'hotspot': {
@@ -545,16 +557,6 @@ export class SearchManager implements AppModule {
       panel.scrollIntoView({ behavior: 'smooth', block: 'center' });
       this.applyHighlight(panel);
     }
-  }
-
-  private highlightNewsItem(itemId: string): void {
-    setTimeout(() => {
-      const item = document.querySelector(`[data-news-id="${CSS.escape(itemId)}"]`);
-      if (item) {
-        item.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        this.applyHighlight(item);
-      }
-    }, 100);
   }
 
   private applyHighlight(el: Element): void {

--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -735,6 +735,58 @@ export class NewsPanel extends Panel {
   }
 
   /**
+   * Returns true if this panel contains a news item with the given link
+   * (either as a cluster primary or secondary article).
+   */
+  public hasNewsItem(link: string): boolean {
+    if (this.lastRawClusters) {
+      return this.lastRawClusters.some(
+        c => c.primaryLink === link || c.allItems.some(i => i.link === link)
+      );
+    }
+    if (this.lastRawItems) {
+      return this.lastRawItems.some(i => i.link === link);
+    }
+    return false;
+  }
+
+  /**
+   * Scroll the panel to the item with the given link and flash-highlight it.
+   * For virtual-scrolled panels, renders the containing chunk first.
+   */
+  public scrollToNewsItem(link: string): void {
+    // In clustered mode, scroll via windowedList so off-screen chunks are rendered first
+    if (this.lastRawClusters && this.windowedList) {
+      const found = this.windowedList.scrollToItem(
+        (p: { cluster: ClusteredEvent }) =>
+          p.cluster.primaryLink === link || p.cluster.allItems.some((i: { link: string }) => i.link === link)
+      );
+      if (found) {
+        setTimeout(() => {
+          const el = this.content.querySelector(`[data-news-id="${CSS.escape(link)}"]`)
+            ?? this.content.querySelector(`a[href="${CSS.escape(link)}"]`);
+          if (el) this.flashHighlight(el);
+        }, 350);
+        return;
+      }
+    }
+    // Flat mode or small lists rendered directly in DOM
+    const el = this.content.querySelector(`[data-news-id="${CSS.escape(link)}"]`)
+      ?? this.content.querySelector(`a[href="${CSS.escape(link)}"]`);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      this.flashHighlight(el);
+    }
+  }
+
+  private flashHighlight(el: Element): void {
+    el.classList.remove('search-highlight');
+    void (el as HTMLElement).offsetWidth;
+    el.classList.add('search-highlight');
+    setTimeout(() => el.classList.remove('search-highlight'), 3100);
+  }
+
+  /**
    * Clean up resources
    */
   public destroy(): void {

--- a/src/components/VirtualList.ts
+++ b/src/components/VirtualList.ts
@@ -396,6 +396,27 @@ export class WindowedList<T> {
   }
 
   /**
+   * Scroll to the first item matching the predicate, rendering its chunk if needed.
+   * Returns true if found.
+   */
+  scrollToItem(predicate: (item: T) => boolean): boolean {
+    const index = this.items.findIndex(predicate);
+    if (index === -1) return false;
+
+    const chunkIndex = Math.floor(index / this.chunkSize);
+    const chunkEl = this.chunkElements.get(chunkIndex);
+    if (!chunkEl) return false;
+
+    if (!this.renderedChunks.has(chunkIndex)) {
+      this.renderChunk(chunkIndex);
+      this.onRendered?.();
+    }
+
+    chunkEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    return true;
+  }
+
+  /**
    * Clean up resources
    */
   destroy(): void {


### PR DESCRIPTION
## Why this PR?

When selecting a news result from the search modal, the app was scrolling to the panel but not to the actual item. Users had to manually scan a long list.

Root cause: `highlightNewsItem()` used `document.querySelector('[data-news-id="..."]')` which returns `null` for items not currently in the DOM (virtual scroll only renders visible chunks). Also, the handler hardcoded `scrollToPanel('politics')` regardless of which panel the item actually belonged to.

## Changes

- **`WindowedList.scrollToItem(predicate)`** — new method that finds the item, renders its chunk if not yet in DOM, then scrolls the chunk into view
- **`NewsPanel.hasNewsItem(link)`** — checks if this panel contains the given link as a cluster primary or secondary article
- **`NewsPanel.scrollToNewsItem(link)`** — finds and scrolls to the item using `windowedList.scrollToItem`, then flashes `search-highlight` once the DOM element is available
- **`search-manager`** — iterates `ctx.newsPanels` to find the right panel (not always `'politics'`), scrolls to it, then calls `panel.scrollToNewsItem()` after 300ms

## Test plan
- [ ] Search for a news headline, select result → panel scrolls into view AND item highlights within the panel
- [ ] Verify works for items in non-politics panels (tech, finance, intel, etc.)
- [ ] Verify works for items deep in the list (off-screen in virtual scroll)
- [ ] Verify no regression when news panels are empty / not yet loaded