### PR TITLE
fix(forecast): tighten state coherence and promotion

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -274,6 +274,9 @@ const MARKET_BUCKET_ALLOWED_CHANNELS = {
   crypto_stablecoins: ['fx_stress', 'risk_off_rotation', 'liquidity_withdrawal', 'sovereign_stress'],
   defense: ['defense_repricing', 'security_escalation'],
 };
+// Adjacent-path gating intentionally stays aligned with direct gating for most buckets for now.
+// The one explicit exception is sovereign risk, where yield-curve and safe-haven confirmation
+// are treated as direct-only signals until we have enough live evidence to broaden the adjacent set.
 const MARKET_BUCKET_ADJACENT_CHANNELS = {
   energy: ['shipping_cost_shock', 'energy_supply_shock', 'gas_supply_stress', 'commodity_repricing', 'oil_macro_shock', 'global_crude_spread_stress'],
   freight: ['shipping_cost_shock', 'energy_supply_shock', 'gas_supply_stress', 'commodity_repricing'],
@@ -959,7 +962,7 @@ function computeStateDerivedBucketCandidate(domain, stateUnit, bucket, marketCon
   const channel = bucketContext?.topChannel || marketContext?.topChannel || '';
   const channelMatch = channel && supportedTypes.includes(channel);
   const channelAllowed = isMarketBucketChannelAllowed(bucket.id, channel, 'direct');
-  const signalMatchCount = overlapTypes.length + (channelMatch && !overlapTypes.includes(channel) ? 1 : 0);
+  const signalMatchCount = overlapTypes.length;
   const stateDomainMatch = intersectAny(stateUnit?.domains || [], domain === 'supply_chain'
     ? ['supply_chain', 'market', 'conflict', 'infrastructure']
     : ['market', 'supply_chain', 'conflict', 'political', 'infrastructure', 'cyber']);
@@ -976,7 +979,7 @@ function computeStateDerivedBucketCandidate(domain, stateUnit, bucket, marketCon
 
   const eligible = (
     (signalMatchCount > 0 && channelAllowed)
-    || (channelAllowed && stateDomainMatch && directBucket && bucketSignalTypes.length > 0)
+    || (channelAllowed && stateDomainMatch && directBucket && channelMatch)
     || (domain === 'supply_chain' && bucket.id === 'freight' && stateDomainMatch && directBucket && channel === 'shipping_cost_shock')
   );
   if (!eligible) return null;
@@ -5041,6 +5044,15 @@ function inferSystemEffectRelationFromChannel(channel, targetDomain) {
   return relationMap[`${channel}:${targetDomain}`] || inferSystemEffectRelation('', targetDomain);
 }
 
+function compareTransmissionEdgePriority(left, right) {
+  return (Number(right?.strength || 0) + Number(right?.confidence || 0)) - (Number(left?.strength || 0) + Number(left?.confidence || 0))
+    || Number(right?.strength || 0) - Number(left?.strength || 0)
+    || Number(right?.confidence || 0) - Number(left?.confidence || 0)
+    || String(left?.channel || '').localeCompare(String(right?.channel || ''))
+    || String(left?.sourceSituationId || '').localeCompare(String(right?.sourceSituationId || ''))
+    || String(left?.edgeId || '').localeCompare(String(right?.edgeId || ''));
+}
+
 function buildActorRoundActions(stage, situation, actors = []) {
   return actors.slice(0, 6).map((actor) => {
     let summary = '';
@@ -5525,9 +5537,12 @@ function buildSimulationMarketConsequences(simulationState, marketState, options
           ...(simulation.marketContext?.criticalSignalTypes || []),
         ]);
         const channelAllowed = isMarketBucketChannelAllowed(candidateBucketId, channel, consequenceType);
+        const bucketSupportSignalTypes = MARKET_BUCKET_CRITICAL_SIGNAL_TYPES[candidateBucketId]
+          || MARKET_BUCKET_CONFIG.find((item) => item.id === candidateBucketId)?.signalTypes
+          || [];
         const bucketSignalSupport = intersectCount(
           supportingSignalTypes,
-          MARKET_BUCKET_CRITICAL_SIGNAL_TYPES[candidateBucketId] || [],
+          bucketSupportSignalTypes,
         );
         const criticalSignalLift = Number(simulation.marketContext?.criticalSignalLift || 0);
         const criticalSignalTypes = simulation.marketContext?.criticalSignalTypes || [];
@@ -8595,7 +8610,7 @@ function buildSituationMarketContextIndex(worldSignals, marketTransmission, mark
         .filter(Boolean);
       const topEdge = bucketEdges
         .slice()
-        .sort((a, b) => (b.strength + b.confidence) - (a.strength + a.confidence) || a.targetLabel.localeCompare(b.targetLabel))[0] || null;
+        .sort(compareTransmissionEdgePriority)[0] || null;
       bucketContexts[bucketId] = {
         bucketId,
         bucketLabel: bucket.label,
@@ -8659,7 +8674,7 @@ function buildSituationMarketContextIndex(worldSignals, marketTransmission, mark
       .sort((a, b) => (b.pressureScore + b.confidence) - (a.pressureScore + a.confidence) || a.label.localeCompare(b.label))[0];
     const topEdge = situationEdges
       .slice()
-      .sort((a, b) => (b.strength + b.confidence) - (a.strength + a.confidence) || a.targetLabel.localeCompare(b.targetLabel))[0];
+      .sort(compareTransmissionEdgePriority)[0];
     const topBucketCoverageScore = topBucket ? computeMarketBucketCoverageScore(topBucket.id, marketInputCoverage) : 0;
 
     contexts.set(source.id, {

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -904,6 +904,97 @@ describe('state-driven domain derivation', () => {
     assert.equal(derived[0].stateDerivedBackfill, true);
   });
 
+  it('does not derive a market forecast when the direct bucket only has an allowed but semantically mismatched channel', () => {
+    const base = makePrediction('conflict', 'Red Sea', 'Escalation risk: Red Sea maritime pressure', 0.69, 0.58, '7d', [
+      { type: 'shipping_cost_shock', value: 'Shipping routes remain under pressure', weight: 0.35 },
+    ]);
+    base.stateContext = {
+      id: 'state-red-sea-mismatch',
+      label: 'Red Sea maritime disruption state',
+      dominantRegion: 'Red Sea',
+      dominantDomain: 'conflict',
+      domains: ['conflict', 'supply_chain'],
+      topSignals: [{ type: 'shipping_cost_shock' }],
+    };
+
+    const derived = deriveStateDrivenForecasts({
+      existingPredictions: [base],
+      stateUnits: [
+        {
+          id: 'state-red-sea-mismatch',
+          label: 'Red Sea maritime disruption state',
+          stateKind: 'transport_pressure',
+          dominantRegion: 'Red Sea',
+          dominantDomain: 'conflict',
+          regions: ['Red Sea'],
+          domains: ['conflict', 'supply_chain'],
+          actors: ['Regional shipping operators'],
+          branchKinds: ['base_case'],
+          signalTypes: ['shipping_cost_shock'],
+          sourceSituationIds: ['sit-red-sea-mismatch'],
+          situationIds: ['sit-red-sea-mismatch'],
+          situationCount: 1,
+          forecastIds: [base.id],
+          forecastCount: 1,
+          avgProbability: 0.69,
+          avgConfidence: 0.58,
+          topSignals: [{ type: 'shipping_cost_shock', count: 3 }],
+          sampleTitles: [base.title],
+        },
+      ],
+      worldSignals: {
+        signals: [
+          {
+            id: 'sig-ship-only',
+            type: 'shipping_cost_shock',
+            sourceType: 'critical_news',
+            region: 'Red Sea',
+            macroRegion: 'EMEA',
+            strength: 0.73,
+            confidence: 0.66,
+            label: 'Red Sea shipping costs are surging',
+          },
+        ],
+      },
+      marketTransmission: {
+        edges: [
+          {
+            sourceSituationId: 'state-red-sea-mismatch',
+            sourceLabel: 'Red Sea maritime disruption state',
+            targetBucketId: 'energy',
+            targetLabel: 'Energy',
+            channel: 'shipping_cost_shock',
+            strength: 0.72,
+            confidence: 0.64,
+            supportingSignalIds: ['sig-ship-only'],
+          },
+        ],
+      },
+      marketState: {
+        buckets: [
+          {
+            id: 'energy',
+            label: 'Energy',
+            pressureScore: 0.74,
+            confidence: 0.66,
+            macroConfirmation: 0.04,
+          },
+        ],
+      },
+      marketInputCoverage: {
+        commodities: 14,
+        gulfQuotes: 10,
+        shippingRates: 0,
+        fredSeries: 0,
+        bisExchange: 0,
+        bisPolicy: 0,
+        correlationCards: 0,
+      },
+    });
+
+    assert.equal(derived.some((pred) => pred.domain === 'market'), false);
+  });
+
   it('keeps state-derived market clustering coherent across source states and buckets', () => {
     const indiaFx = makePrediction('market', 'India', 'FX stress from India cyber pressure state', 0.58, 0.56, '14d', [
       { type: 'risk_off_rotation', value: 'Risk-off pricing is pressuring India FX', weight: 0.36 },
@@ -2110,6 +2201,79 @@ describe('forecast run world state', () => {
     assert.equal(effects.length, 0);
     assert.ok(Array.isArray(effects.blocked));
     assert.equal(effects.blocked.length, 0);
+  });
+
+  it('returns reportable effects and blocked metadata when the reportable interaction ledger is populated', () => {
+    const effects = buildCrossSituationEffects({
+      situationSimulations: [
+        {
+          situationId: 'sit-source',
+          label: 'Baltic Sea supply chain situation',
+          dominantDomain: 'supply_chain',
+          familyId: 'fam-baltic',
+          familyLabel: 'Baltic maritime supply family',
+          regions: ['Baltic Sea'],
+          actorIds: ['actor-shipping'],
+          effectChannels: [{ type: 'logistics_disruption', count: 3 }],
+          posture: 'escalatory',
+          postureScore: 0.74,
+          totalPressure: 0.84,
+          totalStabilization: 0.21,
+        },
+        {
+          situationId: 'sit-target',
+          label: 'Black Sea market situation',
+          dominantDomain: 'market',
+          familyId: 'fam-black-sea',
+          familyLabel: 'Black Sea market repricing family',
+          regions: ['Black Sea'],
+          actorIds: ['actor-market'],
+          effectChannels: [],
+          posture: 'contested',
+          postureScore: 0.49,
+          totalPressure: 0.58,
+          totalStabilization: 0.31,
+        },
+      ],
+      reportableInteractionLedger: [
+        {
+          sourceSituationId: 'sit-source',
+          targetSituationId: 'sit-target',
+          sourceLabel: 'Baltic Sea supply chain situation',
+          targetLabel: 'Black Sea market situation',
+          sourceActorName: 'Shipping operator',
+          targetActorName: 'Commodity desk',
+          interactionType: 'regional_spillover',
+          strongestChannel: 'logistics_disruption',
+          score: 5.2,
+          confidence: 0.79,
+          actorSpecificity: 0.91,
+          sharedActor: false,
+          regionLink: false,
+          stage: 'round_2',
+        },
+        {
+          sourceSituationId: 'sit-source',
+          targetSituationId: 'sit-target',
+          sourceLabel: 'Baltic Sea supply chain situation',
+          targetLabel: 'Black Sea market situation',
+          sourceActorName: 'Shipping operator',
+          targetActorName: 'Commodity desk',
+          interactionType: 'regional_spillover',
+          strongestChannel: 'logistics_disruption',
+          score: 5.1,
+          confidence: 0.78,
+          actorSpecificity: 0.91,
+          sharedActor: false,
+          regionLink: false,
+          stage: 'round_3',
+        },
+      ],
+    }, { mode: 'reportable' });
+
+    assert.ok(effects.length >= 1);
+    assert.ok(effects.some((item) => item.channel === 'logistics_disruption'));
+    assert.ok(Array.isArray(effects.blocked));
   });
 
   it('aggregates cross-situation effects across reportable interaction ledgers larger than 32 rows', () => {


### PR DESCRIPTION
## Summary
- keep market and supply-chain state compression coherent by splitting clusters on source state, bucket, macro-region, and channel context
- tighten market consequence admissibility and align reportable effects with promoted interactions and blocked-reason watchlists
- narrow urgent critical-news triage to transmission-relevant items and add regression coverage for the new coherence rules

## Validation
- node --check scripts/seed-forecasts.mjs
- /Users/eliehabib/Documents/GitHub/worldmonitor/node_modules/.bin/tsx --test tests/forecast-trace-export.test.mjs tests/forecast-detectors.test.mjs
- /Users/eliehabib/Documents/GitHub/worldmonitor/node_modules/.bin/biome lint scripts/seed-forecasts.mjs tests/forecast-trace-export.test.mjs