### PR TITLE
docs: add Wingbits flight data attribution to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Full stack details in the **[architecture docs](https://docs.worldmonitor.app/ar
 
 ---
 
+## Flight Data
+
+Flight data provided gracefully by [Wingbits](https://wingbits.com?utm_source=worldmonitor&utm_medium=referral&utm_campaign=worldmonitor), the most advanced ADS-B flight data solution.
+
+---
+
 ## Contributing
 
 Contributions welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## Summary
- Adds a "Flight Data" section to README.md just before the Contributing section
- Credits [Wingbits](https://wingbits.com?utm_source=worldmonitor&utm_medium=referral&utm_campaign=worldmonitor) as the ADS-B flight data provider
- Uses the same UTM-tracked URL already present in `src/components/MapPopup.ts`

## Test plan
- [ ] Verify README renders correctly on GitHub with the Wingbits link working
- [ ] Confirm link uses UTM params consistent with the rest of the codebase