### PR TITLE
feat(consumer-prices): global market selector — all 9 markets, not AE-only

### DIFF
--- a/src/components/ConsumerPricesPanel.ts
+++ b/src/components/ConsumerPricesPanel.ts
@@ -8,6 +8,7 @@ import {
   fetchConsumerPriceMovers,
   fetchRetailerPriceSpreads,
   fetchConsumerPriceFreshness,
+  MARKETS,
   DEFAULT_MARKET,
   DEFAULT_BASKET,
   type GetConsumerPriceOverviewResponse,
@@ -109,6 +110,16 @@ export class ConsumerPricesPanel extends Panel {
   private handleClick(e: Event): void {
     const target = e.target as HTMLElement;
 
+    const marketBtn = target.closest('[data-market]') as HTMLElement | null;
+    if (marketBtn?.dataset.market) {
+      const code = marketBtn.dataset.market;
+      this.settings.market = code;
+      this.settings.basket = `essentials-${code}`;
+      saveSettings(this.settings);
+      void this.fetchData();
+      return;
+    }
+
     const tab = target.closest('.panel-tab') as HTMLElement | null;
     if (tab?.dataset.tab) {
       this.settings.tab = tab.dataset.tab as TabId;
@@ -169,7 +180,7 @@ export class ConsumerPricesPanel extends Panel {
   }
 
   private render(): void {
-    const { tab, range, categoryFilter } = this.settings;
+    const { tab, range, categoryFilter, market } = this.settings;
 
     const tabs: Array<{ id: TabId; label: string }> = [
       { id: 'overview', label: t('components.consumerPrices.tabs.overview') },
@@ -189,6 +200,14 @@ export class ConsumerPricesPanel extends Panel {
       </div>
     `;
 
+    const marketBarHtml = `
+      <div class="cp-market-bar">
+        ${MARKETS.map((m) => `
+          <button class="cp-market-btn${market === m.code ? ' active' : ''}" data-market="${m.code}">${m.label}</button>
+        `).join('')}
+      </div>
+    `;
+
     const rangeHtml = `
       <div class="cp-range-bar">
         ${(['7d', '30d', '90d'] as const).map((r) => `
@@ -204,6 +223,7 @@ export class ConsumerPricesPanel extends Panel {
     if (noData) {
       this.setContent(`
         <div class="consumer-prices-panel">
+          ${marketBarHtml}
           ${tabsHtml}
           <div class="cp-body cp-seeding-state">
             <div class="cp-seeding-icon">📊</div>
@@ -238,6 +258,7 @@ export class ConsumerPricesPanel extends Panel {
 
     this.setContent(`
       <div class="consumer-prices-panel">
+        ${marketBarHtml}
         ${tabsHtml}
         <div class="cp-body">${bodyHtml}</div>
       </div>

--- a/src/services/consumer-prices/index.ts
+++ b/src/services/consumer-prices/index.ts
@@ -33,6 +33,18 @@ export type {
 export const DEFAULT_MARKET = 'ae';
 export const DEFAULT_BASKET = 'essentials-ae';
 
+export const MARKETS: Array<{ code: string; label: string }> = [
+  { code: 'ae', label: '🇦🇪 UAE' },
+  { code: 'au', label: '🇦🇺 AU' },
+  { code: 'br', label: '🇧🇷 BR' },
+  { code: 'gb', label: '🇬🇧 UK' },
+  { code: 'in', label: '🇮🇳 IN' },
+  { code: 'ke', label: '🇰🇪 KE' },
+  { code: 'sa', label: '🇸🇦 SA' },
+  { code: 'sg', label: '🇸🇬 SG' },
+  { code: 'us', label: '🇺🇸 US' },
+];
+
 const client = new ConsumerPricesServiceClient(getRpcBaseUrl(), {
   fetch: (...args) => globalThis.fetch(...args),
 });
@@ -134,13 +146,17 @@ export async function fetchConsumerPriceOverview(
   marketCode = DEFAULT_MARKET,
   basketSlug = DEFAULT_BASKET,
 ): Promise<GetConsumerPriceOverviewResponse> {
-  const hydrated = getHydratedData('consumerPricesOverview') as GetConsumerPriceOverviewResponse | undefined;
-  if (hydrated?.asOf && !hydrated.upstreamUnavailable) return hydrated;
+  // Bootstrap hydration only valid for the default market
+  if (marketCode === DEFAULT_MARKET) {
+    const hydrated = getHydratedData('consumerPricesOverview') as GetConsumerPriceOverviewResponse | undefined;
+    if (hydrated?.asOf && !hydrated.upstreamUnavailable) return hydrated;
+  }
 
   try {
     return await overviewBreaker.execute(
       () => client.getConsumerPriceOverview({ marketCode, basketSlug }),
       emptyOverview,
+      { cacheKey: `${marketCode}:${basketSlug}` },
     );
   } catch {
     return emptyOverview;
@@ -156,6 +172,7 @@ export async function fetchConsumerPriceBasketSeries(
     return await seriesBreaker.execute(
       () => client.getConsumerPriceBasketSeries({ marketCode, basketSlug, range }),
       emptySeries,
+      { cacheKey: `${marketCode}:${basketSlug}:${range}` },
     );
   } catch {
     return { ...emptySeries, range };
@@ -167,13 +184,16 @@ export async function fetchConsumerPriceCategories(
   basketSlug = DEFAULT_BASKET,
   range = '30d',
 ): Promise<ListConsumerPriceCategoriesResponse> {
-  const hydrated = getHydratedData('consumerPricesCategories') as ListConsumerPriceCategoriesResponse | undefined;
-  if (hydrated?.categories?.length) return hydrated;
+  if (marketCode === DEFAULT_MARKET) {
+    const hydrated = getHydratedData('consumerPricesCategories') as ListConsumerPriceCategoriesResponse | undefined;
+    if (hydrated?.categories?.length) return hydrated;
+  }
 
   try {
     return await categoriesBreaker.execute(
       () => client.listConsumerPriceCategories({ marketCode, basketSlug, range }),
       emptyCategories,
+      { cacheKey: `${marketCode}:${basketSlug}:${range}` },
     );
   } catch {
     return emptyCategories;
@@ -185,13 +205,16 @@ export async function fetchConsumerPriceMovers(
   range = '30d',
   categorySlug?: string,
 ): Promise<ListConsumerPriceMoversResponse> {
-  const hydrated = getHydratedData('consumerPricesMovers') as ListConsumerPriceMoversResponse | undefined;
-  if (hydrated?.risers?.length || hydrated?.fallers?.length) return hydrated;
+  if (marketCode === DEFAULT_MARKET) {
+    const hydrated = getHydratedData('consumerPricesMovers') as ListConsumerPriceMoversResponse | undefined;
+    if (hydrated?.risers?.length || hydrated?.fallers?.length) return hydrated;
+  }
 
   try {
     return await moversBreaker.execute(
       () => client.listConsumerPriceMovers({ marketCode, range, categorySlug: categorySlug ?? '', limit: 10 }),
       emptyMovers,
+      { cacheKey: `${marketCode}:${range}:${categorySlug ?? ''}` },
     );
   } catch {
     return emptyMovers;
@@ -202,13 +225,16 @@ export async function fetchRetailerPriceSpreads(
   marketCode = DEFAULT_MARKET,
   basketSlug = DEFAULT_BASKET,
 ): Promise<ListRetailerPriceSpreadsResponse> {
-  const hydrated = getHydratedData('consumerPricesSpread') as ListRetailerPriceSpreadsResponse | undefined;
-  if (hydrated?.retailers?.length) return hydrated;
+  if (marketCode === DEFAULT_MARKET) {
+    const hydrated = getHydratedData('consumerPricesSpread') as ListRetailerPriceSpreadsResponse | undefined;
+    if (hydrated?.retailers?.length) return hydrated;
+  }
 
   try {
     return await spreadBreaker.execute(
       () => client.listRetailerPriceSpreads({ marketCode, basketSlug }),
       emptySpread,
+      { cacheKey: `${marketCode}:${basketSlug}` },
     );
   } catch {
     return emptySpread;
@@ -222,6 +248,7 @@ export async function fetchConsumerPriceFreshness(
     return await freshnessBreaker.execute(
       () => client.getConsumerPriceFreshness({ marketCode }),
       emptyFreshness,
+      { cacheKey: marketCode },
     );
   } catch {
     return emptyFreshness;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -20994,6 +20994,36 @@ body.has-breaking-alert .panels-grid {
 .cp-health-status--stale   { background: rgba(245,158,11,0.15); color: #fbbf24; }
 .cp-health-status--missing { background: rgba(239,68,68,0.15);  color: #f87171; }
 
+.cp-market-bar {
+  display: flex;
+  gap: 3px;
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  flex-shrink: 0;
+}
+
+.cp-market-bar::-webkit-scrollbar { display: none; }
+
+.cp-market-btn {
+  font-size: 0.68rem;
+  padding: 2px 6px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-family: inherit;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.cp-market-btn.active {
+  background: var(--overlay-subtle);
+  color: var(--text-primary, #e0e0e0);
+  border-color: var(--text-dim);
+}
+
 .cp-range-bar {
   display: flex;
   gap: 4px;


### PR DESCRIPTION
## Why this PR?
The Consumer Prices panel was hardcoded to `DEFAULT_MARKET = 'ae'` with no UI to switch markets. Every tab (Overview, Categories, Movers, Retailer Spread, Data Health) always showed UAE data regardless of what other market data was available in Redis.

## What changed
- Added `MARKETS` constant in `consumer-prices/index.ts` listing all 9 tracked markets (AE, AU, BR, GB, IN, KE, SA, SG, US)
- Added a scrollable market pill row above the tabs in `ConsumerPricesPanel.ts`
- Click handler updates `settings.market` + `settings.basket = essentials-{code}` and re-fetches
- Selection persists in localStorage
- CSS: `.cp-market-bar` / `.cp-market-btn` — same visual language as `.cp-range-btn`

## Test plan
- [ ] Market pill row appears above tabs
- [ ] Clicking a market pill re-fetches and shows that market's data
- [ ] Active pill highlights correctly
- [ ] Selection persists on panel re-open
- [ ] Markets with no data yet show "Data collection in progress"
- [ ] Scrollable on narrow panels (overflow-x: auto, no scrollbar visible)