### PR TITLE
fix(health): bump satellites maxStaleMin 180→240

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -122,7 +122,7 @@ const SEED_META = {
   iranEvents:       { key: 'seed-meta:conflict:iran-events',      maxStaleMin: 10080 },
   ucdpEvents:       { key: 'seed-meta:conflict:ucdp-events',      maxStaleMin: 420 },
   militaryFlights:  { key: 'seed-meta:military:flights',           maxStaleMin: 30 }, // cron ~10min (LIVE_TTL=600s); 30min = 3x interval,
-  satellites:       { key: 'seed-meta:intelligence:satellites',    maxStaleMin: 180 },
+  satellites:       { key: 'seed-meta:intelligence:satellites',    maxStaleMin: 240 }, // CelesTrak every 120min; 240min = absorbs one missed cycle
   weatherAlerts:    { key: 'seed-meta:weather:alerts',             maxStaleMin: 30 },
   spending:         { key: 'seed-meta:economic:spending',          maxStaleMin: 120 },
   techEvents:       { key: 'seed-meta:research:tech-events',       maxStaleMin: 480 },


### PR DESCRIPTION
## Summary
- Satellite TLE seed interval is 120min; health threshold was 180min
- If one CelesTrak cycle fails (timeout / 0 TLEs returned), the next cycle fires 240min after the last successful write, breaching the 180min threshold and triggering a false-positive WARN
- 240min = exactly 2x seed interval, absorbs one missed cycle cleanly

## Root cause (from log analysis)
- Last successful seed: ~03:16 UTC; expected next at 05:16 UTC
- 05:16 cycle produced no log entry (CelesTrak likely timed out or returned 0 matching TLEs)
- Health at 06:18 showed seedAgeMin=202 > maxStaleMin=180 → WARN