### PR TITLE
fix(bigmac): left-align country column

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -21094,7 +21094,7 @@ body.has-breaking-alert .panels-grid {
   vertical-align: top;
 }
 
-.gb-item-col { min-width: 100px; }
+.gb-item-col { min-width: 100px; text-align: left; }
 
 .gb-country-header {
   text-align: center;
@@ -21110,6 +21110,7 @@ body.has-breaking-alert .panels-grid {
   background: var(--overlay-subtle);
   position: sticky;
   left: 0;
+  text-align: left;
 }
 
 .gb-unit {


### PR DESCRIPTION
## Summary

- Country header (`gb-item-col`) and country cells (`gb-item-name`) had no explicit `text-align`, causing right-alignment inheritance
- Added `text-align: left` to both

## Test plan

- [ ] Verify Big Mac Index panel shows country names left-aligned