### PR TITLE
fix(forecast): preserve llm narratives on publish refresh

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -10725,6 +10725,10 @@ function buildFeedSummary(pred) {
   return `Base case for ${pred.title} remains live at ${roundPct(pred.probability)} over the ${pred.timeHorizon}.`;
 }
 
+function isLlmNarrativeSource(source = '') {
+  return /^llm_/.test(String(source || ''));
+}
+
 function buildFallbackPerspectives(pred) {
   const firstSignal = pred.caseFile?.supportingEvidence?.[0]?.summary || pred.signals?.[0]?.value || pred.title;
   const contrarian = pred.caseFile?.contrarianCase || buildFallbackContrarianCase(pred);
@@ -10769,14 +10773,25 @@ function populateFallbackNarratives(predictions) {
 function refreshPublishedNarratives(predictions) {
   for (const pred of predictions || []) {
     if (!pred.caseFile) buildForecastCase(pred);
-    pred.caseFile.baseCase = buildFallbackBaseCase(pred);
-    pred.caseFile.escalatoryCase = buildFallbackEscalatoryCase(pred);
-    pred.caseFile.contrarianCase = buildFallbackContrarianCase(pred);
-    if ((pred?.traceMeta?.narrativeSource || 'fallback') === 'fallback') {
+    const preserveNarratives = isLlmNarrativeSource(pred?.traceMeta?.narrativeSource || '');
+    if (!preserveNarratives || !pred.caseFile.baseCase) {
+      pred.caseFile.baseCase = buildFallbackBaseCase(pred);
+    }
+    if (!preserveNarratives || !pred.caseFile.escalatoryCase) {
+      pred.caseFile.escalatoryCase = buildFallbackEscalatoryCase(pred);
+    }
+    if (!preserveNarratives || !pred.caseFile.contrarianCase) {
+      pred.caseFile.contrarianCase = buildFallbackContrarianCase(pred);
+    }
+    if (!preserveNarratives || !pred.scenario) {
       pred.scenario = buildFallbackScenario(pred);
+    }
+    if (!preserveNarratives || !pred.perspectives) {
       pred.perspectives = buildFallbackPerspectives(pred);
     }
-    pred.feedSummary = buildFeedSummary(pred);
+    if (!preserveNarratives || !pred.feedSummary) {
+      pred.feedSummary = buildFeedSummary(pred);
+    }
   }
 }
 

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -67,6 +67,7 @@ import {
   buildFeedSummary,
   buildFallbackPerspectives,
   populateFallbackNarratives,
+  refreshPublishedNarratives,
   loadCascadeRules,
   evaluateRuleConditions,
   summarizePublishFiltering,
@@ -1297,6 +1298,27 @@ describe('forecast narrative fallbacks', () => {
     assert.ok(summary.length > 180);
     assert.ok(!summary.endsWith('...'));
     assert.match(summary, /Iran CII 87/);
+  });
+
+  it('refreshPublishedNarratives preserves validated llm narratives and only fills gaps', () => {
+    const pred = makePrediction('market', 'Strait of Hormuz', 'Inflation and rates pressure from Strait of Hormuz maritime disruption state', 0.69, 0.64, '30d', [
+      { type: 'shipping_cost_shock', value: 'Strait of Hormuz shipping costs remain elevated', weight: 0.42 },
+    ]);
+    buildForecastCase(pred);
+    pred.traceMeta = { narrativeSource: 'llm_combined', llmProvider: 'openrouter' };
+    pred.caseFile.baseCase = 'LLM base case keeps Hormuz freight and energy repricing tied to persistent shipping disruption over the next 30d.';
+    pred.caseFile.escalatoryCase = 'LLM escalatory case sees a sharper repricing if maritime insurance and rerouting costs jump again.';
+    pred.caseFile.contrarianCase = 'LLM contrarian case assumes corridor access stabilizes before the freight shock spreads further.';
+    pred.scenario = 'LLM scenario keeps Hormuz inflation pressure elevated while the corridor remains contested.';
+    pred.feedSummary = '';
+
+    refreshPublishedNarratives([pred]);
+
+    assert.equal(pred.caseFile.baseCase, 'LLM base case keeps Hormuz freight and energy repricing tied to persistent shipping disruption over the next 30d.');
+    assert.equal(pred.caseFile.escalatoryCase, 'LLM escalatory case sees a sharper repricing if maritime insurance and rerouting costs jump again.');
+    assert.equal(pred.caseFile.contrarianCase, 'LLM contrarian case assumes corridor access stabilizes before the freight shock spreads further.');
+    assert.equal(pred.scenario, 'LLM scenario keeps Hormuz inflation pressure elevated while the corridor remains contested.');
+    assert.equal(pred.feedSummary, 'LLM base case keeps Hormuz freight and energy repricing tied to persistent shipping disruption over the next 30d.');
   });
 });
 

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -381,6 +381,37 @@ describe('forecast trace artifact builder', () => {
     assert.ok(!a.scenario.includes('broader cluster'));
     assert.ok(!a.feedSummary.includes('broader'));
   });
+
+  it('preserves llm narratives after projected situation context refresh', () => {
+    const a = makePrediction('market', 'Strait of Hormuz', 'Inflation and rates pressure from Strait of Hormuz maritime disruption state', 0.72, 0.66, '30d', [
+      { type: 'shipping_cost_shock', value: 'Hormuz shipping costs are feeding inflation pressure', weight: 0.42 },
+    ]);
+    const b = makePrediction('market', 'Strait of Hormuz', 'Oil price impact from Strait of Hormuz disruption', 0.67, 0.58, '30d', [
+      { type: 'commodity_price', value: 'Oil pricing remains sensitive to Strait of Hormuz disruption', weight: 0.38 },
+    ]);
+
+    buildForecastCase(a);
+    buildForecastCase(b);
+    populateFallbackNarratives([a, b]);
+
+    a.traceMeta = { narrativeSource: 'llm_combined', llmProvider: 'openrouter' };
+    a.caseFile.baseCase = 'LLM base case keeps Hormuz inflation pressure elevated while freight rerouting and insurance costs remain sticky.';
+    a.caseFile.escalatoryCase = 'LLM escalatory case sees a broader price shock if corridor access worsens again.';
+    a.caseFile.contrarianCase = 'LLM contrarian case assumes shipping normalization starts before downstream pass-through broadens.';
+    a.scenario = 'LLM scenario keeps Hormuz repricing elevated without a full break in corridor access.';
+    a.feedSummary = 'LLM base case keeps Hormuz inflation pressure elevated while freight rerouting and insurance costs remain sticky.';
+
+    const fullRunSituationClusters = attachSituationContext([a, b]);
+    const publishedPredictions = [a];
+    const projectedClusters = projectSituationClusters(fullRunSituationClusters, publishedPredictions);
+    attachSituationContext(publishedPredictions, projectedClusters);
+    refreshPublishedNarratives(publishedPredictions);
+
+    assert.equal(a.caseFile.situationContext.forecastCount, 1);
+    assert.equal(a.caseFile.baseCase, 'LLM base case keeps Hormuz inflation pressure elevated while freight rerouting and insurance costs remain sticky.');
+    assert.equal(a.scenario, 'LLM scenario keeps Hormuz repricing elevated without a full break in corridor access.');
+    assert.equal(a.feedSummary, 'LLM base case keeps Hormuz inflation pressure elevated while freight rerouting and insurance costs remain sticky.');
+  });
 });
 
 describe('market transmission macro state', () => {


### PR DESCRIPTION
## Summary
- preserve validated LLM baseCase, scenario, perspectives, and feedSummary during the publish refresh step instead of unconditionally rebuilding fallback copy
- keep the fallback refresh behavior for non-LLM forecasts and fill only missing narrative fields for LLM-enriched forecasts
- add detector and trace regressions covering publish-time narrative preservation

## Validation
- node --check scripts/seed-forecasts.mjs
- tsx --test tests/forecast-detectors.test.mjs
- tsx --test tests/forecast-trace-export.test.mjs
- biome lint scripts/seed-forecasts.mjs tests/forecast-detectors.test.mjs tests/forecast-trace-export.test.mjs
- full pre-push checks passed during git push