### PR TITLE
fix(tamimi-sa): disable after 0/12 products

### DIFF
--- a/consumer-prices-core/configs/retailers/tamimi_sa.yaml
+++ b/consumer-prices-core/configs/retailers/tamimi_sa.yaml
@@ -5,7 +5,7 @@ retailer:
   currencyCode: SAR
   adapter: search
   baseUrl: https://tamimimarkets.com
-  enabled: true
+  enabled: false # disabled 2026-03-23: 0/12 products after query tweak, Firecrawl can't extract tamimimarkets.com
 
   searchConfig:
     numResults: 5


### PR DESCRIPTION
## Summary
- Sets `enabled: false` on `tamimi_sa` with a dated comment (2026-03-23)
- Retailer returned 0/12 products even after the query template tweak in #2136 — Firecrawl can't extract tamimimarkets.com
- SA market data stays in DB; re-enable when extraction is unblocked

## Test plan
- [ ] Verify `scrapeAll()` skips tamimi_sa but still writes `active=false` to DB