### PR TITLE
feat(forecast): add impact expansion simulation layer

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -3416,7 +3416,6 @@ ${candidatePackets.map((packet) => [
 }
 
 async function extractImpactExpansionBundle({
-  inputs: _inputs = {},
   stateUnits = [],
   worldSignals = null,
   marketTransmission = null,
@@ -9591,7 +9590,7 @@ function evaluateImpactHypothesisRejection(hypothesis, context = {}) {
   if (!registry || !(registry.allowedChannels || []).includes(hypothesis.channel)) return 'unsupported_variable_channel';
 
   const targetBucketAllowed = (registry.targetBuckets || []).includes(hypothesis.targetBucket);
-  const bucketSignalTypes = MARKET_BUCKET_CRITICAL_SIGNAL_TYPES[hypothesis.targetBucket] || [];
+  const bucketSignalTypes = MARKET_BUCKET_ALLOWED_CHANNELS[hypothesis.targetBucket] || [];
   if (!targetBucketAllowed || !bucketSignalTypes.includes(hypothesis.channel)) return 'weak_bucket_coherence';
 
   if (hypothesis.order !== 'direct' && !lowerOrderKeys.has(hypothesis.dependsOnKey)) return 'missing_dependency';
@@ -9634,8 +9633,8 @@ function validateImpactHypotheses(bundle = null) {
     if (!candidate) continue;
     const evidenceKeys = new Set((candidate.evidenceTable || []).map((entry) => entry.key));
     const duplicateKeys = new Set();
-    const directKeys = new Set((items.filter((item) => item.order === 'direct')).map((item) => item.variableKey).filter(Boolean));
-    const secondOrderKeys = new Set((items.filter((item) => item.order === 'second_order')).map((item) => item.variableKey).filter(Boolean));
+    const validatedDirectKeys = new Set();
+    const validatedSecondOrderKeys = new Set();
 
     const ordered = items.slice().sort((left, right) => (
       IMPACT_EXPANSION_ORDERS.indexOf(left.order) - IMPACT_EXPANSION_ORDERS.indexOf(right.order)
@@ -9645,9 +9644,9 @@ function validateImpactHypotheses(bundle = null) {
 
     for (const hypothesis of ordered) {
       const lowerOrderKeys = hypothesis.order === 'second_order'
-        ? directKeys
+        ? validatedDirectKeys
         : hypothesis.order === 'third_order'
-          ? secondOrderKeys
+          ? validatedSecondOrderKeys
           : new Set();
       const rejectionReason = evaluateImpactHypothesisRejection(hypothesis, {
         candidate,
@@ -9701,6 +9700,10 @@ function validateImpactHypotheses(bundle = null) {
       });
 
       duplicateKeys.add(`${hypothesis.order}:${hypothesis.variableKey}:${hypothesis.targetBucket}`);
+      if (validationStatus !== 'rejected' && hypothesis.variableKey) {
+        if (hypothesis.order === 'direct') validatedDirectKeys.add(hypothesis.variableKey);
+        if (hypothesis.order === 'second_order') validatedSecondOrderKeys.add(hypothesis.variableKey);
+      }
     }
   }
 

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -3326,6 +3326,136 @@ describe('impact expansion layer', () => {
     assert.equal(thirdOrder.rejectionReason, '');
   });
 
+  it('accepts valid risk-off channels for sovereign-risk impact hypotheses', () => {
+    const bundle = makeImpactExpansionBundle('state-risk', 'Global risk-off repricing state', {
+      marketBucketIds: ['sovereign_risk', 'fx_stress'],
+      transmissionChannels: ['risk_off_rotation', 'volatility_shock'],
+      topSignalTypes: ['risk_off_rotation'],
+      criticalSignalTypes: ['risk_off_rotation'],
+      commodityKey: '',
+      routeFacilityKey: '',
+      marketContext: {
+        topBucketId: 'sovereign_risk',
+        topBucketLabel: 'Sovereign Risk',
+        topBucketPressure: 0.8,
+        confirmationScore: 0.74,
+        contradictionScore: 0.06,
+        topChannel: 'risk_off_rotation',
+        topTransmissionStrength: 0.72,
+        topTransmissionConfidence: 0.68,
+        transmissionEdgeCount: 3,
+        criticalSignalLift: 0.55,
+        criticalSignalTypes: ['risk_off_rotation'],
+        linkedBucketIds: ['sovereign_risk', 'fx_stress'],
+        consequenceSummary: 'Risk-off rotation is transmitting into sovereign repricing.',
+      },
+    });
+    bundle.extractedCandidateCount = 1;
+    bundle.extractedHypothesisCount = 2;
+    bundle.extractedCandidates = [{
+      candidateIndex: 0,
+      candidateStateId: 'state-risk',
+      directHypotheses: [
+        {
+          variableKey: 'route_disruption',
+          channel: 'shipping_cost_shock',
+          targetBucket: 'freight',
+          region: 'Global',
+          macroRegion: 'GLOBAL',
+          countries: ['United States'],
+          assetsOrSectors: ['Shipping'],
+          commodity: '',
+          dependsOnKey: '',
+          strength: 0.93,
+          confidence: 0.9,
+          analogTag: 'shipping_insurance_spike',
+          summary: 'Shipping stress is spilling out of the primary route network.',
+          evidenceRefs: ['E1', 'E2'],
+        },
+      ],
+      secondOrderHypotheses: [
+        {
+          variableKey: 'risk_off_rotation',
+          channel: 'risk_off_rotation',
+          targetBucket: 'sovereign_risk',
+          region: 'Global',
+          macroRegion: 'GLOBAL',
+          countries: ['United States'],
+          assetsOrSectors: ['Sovereign bonds'],
+          commodity: '',
+          dependsOnKey: 'route_disruption',
+          strength: 0.93,
+          confidence: 0.9,
+          analogTag: 'risk_off_flight_to_safety',
+          summary: 'Risk-off rotation is spilling into sovereign repricing.',
+          evidenceRefs: ['E1', 'E2'],
+        },
+      ],
+      thirdOrderHypotheses: [],
+    }];
+
+    const validation = validateImpactHypotheses(bundle);
+    const riskOff = validation.hypotheses.find((item) => item.variableKey === 'risk_off_rotation');
+
+    assert.equal(validation.mapped.length, 2);
+    assert.equal(riskOff.validationStatus, 'mapped');
+    assert.equal(riskOff.rejectionReason, '');
+  });
+
+  it('requires higher-order hypotheses to depend on lower-order items that survived validation', () => {
+    const bundle = makeImpactExpansionBundle();
+    bundle.extractedCandidates = [{
+      candidateIndex: 0,
+      candidateStateId: bundle.candidatePackets[0].candidateStateId,
+      directHypotheses: [
+        {
+          variableKey: 'lng_export_stress',
+          channel: 'gas_supply_stress',
+          targetBucket: 'energy',
+          region: 'Middle East',
+          macroRegion: 'EMEA',
+          countries: ['Qatar'],
+          assetsOrSectors: ['LNG exports'],
+          commodity: 'lng',
+          dependsOnKey: '',
+          strength: 0.95,
+          confidence: 0.92,
+          analogTag: 'lng_export_disruption',
+          summary: 'This direct hypothesis should fail evidence validation.',
+          evidenceRefs: ['E9'],
+        },
+      ],
+      secondOrderHypotheses: [
+        {
+          variableKey: 'inflation_pass_through',
+          channel: 'inflation_impulse',
+          targetBucket: 'rates_inflation',
+          region: 'Middle East',
+          macroRegion: 'EMEA',
+          countries: ['Qatar'],
+          assetsOrSectors: ['Importers'],
+          commodity: 'lng',
+          dependsOnKey: 'lng_export_stress',
+          strength: 0.92,
+          confidence: 0.9,
+          analogTag: 'inflation_pass_through',
+          summary: 'This should fail because its parent did not survive validation.',
+          evidenceRefs: ['E1', 'E2'],
+        },
+      ],
+      thirdOrderHypotheses: [],
+    }];
+    bundle.extractedHypothesisCount = 2;
+
+    const validation = validateImpactHypotheses(bundle);
+    const direct = validation.hypotheses.find((item) => item.order === 'direct');
+    const secondOrder = validation.hypotheses.find((item) => item.order === 'second_order');
+
+    assert.equal(direct.rejectionReason, 'no_valid_evidence_refs');
+    assert.equal(secondOrder.rejectionReason, 'missing_dependency');
+    assert.equal(secondOrder.validationStatus, 'rejected');
+  });
+
   it('threads mapped expansion signals into simulation rounds without mutating observed world signals', () => {
     const prediction = makePrediction('supply_chain', 'Red Sea', 'Shipping disruption: Strait of Hormuz', 0.68, 0.6, '7d', [
       { type: 'shipping_cost_shock', value: 'Shipping costs are rising around Strait of Hormuz rerouting.', weight: 0.5 },


### PR DESCRIPTION
## Summary
- add a schema-constrained impact-expansion layer that selects top state candidates, extracts structured direct/second/third-order hypotheses, and validates them deterministically
- map only strong validated hypotheses into simulation-only world-signal layers while keeping selection-time state-derived forecast generation observed-signal-only to avoid double-counting
- persist impact-expansion telemetry into world-state and trace artifacts and add regression coverage for cache stability, exact evidence refs, mapping thresholds, and round-layer injection

## Validation
- `node --check scripts/seed-forecasts.mjs`
- `tsx --test tests/forecast-trace-export.test.mjs`
- `tsx --test tests/forecast-detectors.test.mjs`
- `biome lint scripts/seed-forecasts.mjs tests/forecast-trace-export.test.mjs`
- full pre-push suite passed during `git push`
