### PR TITLE
feat(sa): add ananinja_sa retailer + fix OOS price hallucination

### DIFF
--- a/consumer-prices-core/configs/retailers/ananinja_sa.yaml
+++ b/consumer-prices-core/configs/retailers/ananinja_sa.yaml
@@ -1,0 +1,22 @@
+retailer:
+  slug: ananinja_sa
+  name: AnaNinja Saudi Arabia
+  marketCode: sa
+  currencyCode: SAR
+  adapter: search
+  baseUrl: https://ananinja.com/sa/en
+  enabled: true
+
+  searchConfig:
+    numResults: 5
+    queryTemplate: "{canonicalName} ananinja saudi"
+
+  rateLimit:
+    requestsPerMinute: 10
+    maxConcurrency: 1
+    delayBetweenRequestsMs: 6000
+
+  discovery:
+    mode: search
+    maxPages: 20
+    seeds: []

--- a/consumer-prices-core/configs/retailers/carrefour_sa.yaml
+++ b/consumer-prices-core/configs/retailers/carrefour_sa.yaml
@@ -1,0 +1,23 @@
+retailer:
+  slug: carrefour_sa
+  name: Carrefour Saudi Arabia
+  marketCode: sa
+  currencyCode: SAR
+  adapter: search
+  baseUrl: https://www.carrefourksa.com/mafsau/en
+  enabled: false # disabled 2026-03-23: most products OOS, Exa finds correct URLs but Carrefour KSA shows no price for OOS items
+
+  searchConfig:
+    numResults: 5
+    queryTemplate: "{canonicalName} carrefour saudi"
+    urlPathContains: /p/
+
+  rateLimit:
+    requestsPerMinute: 10
+    maxConcurrency: 1
+    delayBetweenRequestsMs: 6000
+
+  discovery:
+    mode: search
+    maxPages: 20
+    seeds: []

--- a/consumer-prices-core/configs/retailers/panda_sa.yaml
+++ b/consumer-prices-core/configs/retailers/panda_sa.yaml
@@ -1,0 +1,22 @@
+retailer:
+  slug: panda_sa
+  name: Panda Saudi Arabia
+  marketCode: sa
+  currencyCode: SAR
+  adapter: search
+  baseUrl: https://www.panda.sa/en
+  enabled: false # disabled 2026-03-23: panda.sa not indexed by Exa (0 domain matches for 10/12 items)
+
+  searchConfig:
+    numResults: 5
+    queryTemplate: "{canonicalName} panda supermarket saudi"
+
+  rateLimit:
+    requestsPerMinute: 10
+    maxConcurrency: 1
+    delayBetweenRequestsMs: 6000
+
+  discovery:
+    mode: search
+    maxPages: 20
+    seeds: []

--- a/consumer-prices-core/configs/retailers/tamimi_sa.yaml
+++ b/consumer-prices-core/configs/retailers/tamimi_sa.yaml
@@ -5,7 +5,7 @@ retailer:
   currencyCode: SAR
   adapter: search
   baseUrl: https://tamimimarkets.com
-  enabled: true
+  enabled: false # disabled 2026-03-23: 0/12 products after query tweak, Firecrawl can't extract tamimimarkets.com
 
   searchConfig:
     numResults: 5

--- a/consumer-prices-core/src/adapters/search.ts
+++ b/consumer-prices-core/src/adapters/search.ts
@@ -157,7 +157,7 @@ export class SearchAdapter implements RetailerAdapter {
     currency: string,
   ): Promise<ExtractedProduct | null> {
     const extractSchema = {
-      prompt: `Find the listed retail price of this product in ${currency}. The price may be displayed as two parts split across lines — like "3" and ".95" next to "${currency}" — combine them to get 3.95. Return the listed price even if the product is currently out of stock. Return the product name, the numeric price in ${currency}, the currency code, and whether it is in stock.`,
+      prompt: `Extract the retail price of THIS specific product from the main product section of the page. The price may be displayed as two parts split across lines — like "3" and ".95" next to "${currency}" — combine them to get 3.95. ONLY extract the price shown for the main product itself. If the page shows "Out of Stock" and no price is displayed for the main product, return null for price — do NOT use prices from related products, recommendations, or carousels. Return the product name, the numeric price in ${currency} (null if not shown), the currency code, and whether it is in stock.`,
       fields: {
         productName: { type: 'string' as const, description: 'Name or title of the product' },
         price: { type: 'number' as const, description: `Retail price in ${currency} as a single number (e.g. 4.69)` },


### PR DESCRIPTION
## Summary
- Adds `ananinja_sa` as the SA market retailer — **9/12 items scraped with real prices** (eggs 23 SAR, milk 6 SAR, chicken 17 SAR)
- Disables `tamimi_sa` (0/12 after query tweak, Firecrawl can't extract the site)
- Adds `carrefour_sa` and `panda_sa` as disabled configs for future use
- **Fixes Firecrawl extraction prompt** that told it to return a price "even if out of stock" — caused it to grab carousel prices (always 3.95 SAR) when the main product had no displayed price. Prompt now returns `null` for OOS/no-price products

## Test plan
- [ ] Verify `ananinja_sa` scrapes successfully in next run
- [ ] Verify no items with uniform `3.95 SAR` prices appear for any retailer
- [ ] SA market appears with real data after aggregate + publish