### PR TITLE
fix(consumer-prices): block restaurant URLs + reject null productName in parseListing

### DIFF
--- a/consumer-prices-core/configs/retailers/ananinja_sa.yaml
+++ b/consumer-prices-core/configs/retailers/ananinja_sa.yaml
@@ -10,6 +10,7 @@ retailer:
   searchConfig:
     numResults: 5
     queryTemplate: "{canonicalName} ananinja saudi"
+    urlPathContains: /product/  # ananinja.com also indexes restaurant menus (/restaurants/); restrict to product pages
     inStockFromPrice: true  # ananinja.com is a price aggregator; Firecrawl misreads availability
 
   rateLimit:

--- a/consumer-prices-core/src/adapters/search.ts
+++ b/consumer-prices-core/src/adapters/search.ts
@@ -348,10 +348,17 @@ export class SearchAdapter implements RetailerAdapter {
       return [];
     }
 
+    // Require Firecrawl to return a real product name — using canonical name as rawTitle
+    // silently poisons the DB with unverifiable matches (e.g. extraction failures, wrong pages).
+    if (!extracted.productName) {
+      ctx.logger.warn(`  [search] ${canonicalName}: no productName from Firecrawl, rejecting ${productUrl}`);
+      return [];
+    }
+
     return [
       {
         sourceUrl: productUrl,
-        rawTitle: extracted.productName ?? canonicalName,
+        rawTitle: extracted.productName,
         rawBrand: null,
         rawSizeText: extracted.sizeText ?? null,
         imageUrl: null,


### PR DESCRIPTION
## Why this PR?

The 2026-03-23 scrape produced garbage data in SA and continued the AE/US quality problems found in the audit:

**SA (ananinja.com)**
- "Onions 1kg" → burger-king onion rings (restaurant menu URL) — `isTitlePlausible` passes "onion" substring
- "Tomatoes Fresh 1kg" → saudia tomato paste 60g
- 24 other pins had `raw_title = canonical_name` (Firecrawl returned nothing, we stored the canonical name as if it were a real product title)

**US/AE**
- Walmart White Sandwich Bread stored at $18.51 (extraction error — should be ~$3-4)
- Lulu mango juice pinned as White Sugar 1kg
- Noon matched chicken URL as Eggs Fresh 12 Pack

## What changed

**`ananinja_sa.yaml`**
- Add `urlPathContains: /product/` — same pattern used by tamimi/carrefour to restrict Exa to product pages only, filtering out `/restaurants/` URLs

**`search.ts parseListing`**
- Reject when `extracted.productName` is null/missing — previously fell back to `canonicalName` which silently poisoned the DB with unverifiable matches
- Log at WARN level so operators know which URLs are failing to extract names

## DB cleanup (already applied)
- Disabled 30 bad pins via `pin_disabled_at` directly in prod DB:
  - 24 canonical-name=raw-title extraction failures across AE/US/SA retailers
  - 2 restaurant URLs (ananinja onion rings, ananinja tomato paste)
  - Walmart 1-gallon oil pinned as 48oz (size mismatch)
  - Walmart bread at $18.51 (bundle extraction error)
  - Kroger Organic Valley gallon at $3.95 (suspicious, likely carousel price)
  - Walmart 5lb rice pinned as 2lb

## Expected outcome after next scrape
- SA: will fall back to Exa search for all disabled pins, finding correct `/product/` URLs
- US spread: should drop significantly without the bread $18.51 and oil size mismatch
- No more `raw_title = canonical_name` stored in DB