### PR TITLE
feat(consumer-prices): add second retailers for 5 markets + re-enable carrefour_sa

### DIFF
--- a/consumer-prices-core/configs/retailers/carrefour_br.yaml
+++ b/consumer-prices-core/configs/retailers/carrefour_br.yaml
@@ -1,0 +1,23 @@
+retailer:
+  slug: carrefour_br
+  name: Carrefour Brasil
+  marketCode: br
+  currencyCode: BRL
+  adapter: search
+  baseUrl: https://mercado.carrefour.com.br
+  enabled: true
+
+  searchConfig:
+    numResults: 5
+    queryTemplate: "{canonicalName} supermercado brasil {currency} preço"
+    urlPathContains: /p/
+
+  rateLimit:
+    requestsPerMinute: 10
+    maxConcurrency: 1
+    delayBetweenRequestsMs: 6000
+
+  discovery:
+    mode: search
+    maxPages: 20
+    seeds: []

--- a/consumer-prices-core/configs/retailers/carrefour_sa.yaml
+++ b/consumer-prices-core/configs/retailers/carrefour_sa.yaml
@@ -5,7 +5,7 @@ retailer:
   currencyCode: SAR
   adapter: search
   baseUrl: https://www.carrefourksa.com/mafsau/en
-  enabled: false # disabled 2026-03-23: most products OOS, Exa finds correct URLs but Carrefour KSA shows no price for OOS items
+  enabled: true # re-enabled 2026-03-23: #2148 fixed OOS prompt (returns null price instead of carousel fallback); may have low coverage if most products still OOS
 
   searchConfig:
     numResults: 5

--- a/consumer-prices-core/configs/retailers/coldstorage_sg.yaml
+++ b/consumer-prices-core/configs/retailers/coldstorage_sg.yaml
@@ -1,0 +1,23 @@
+retailer:
+  slug: coldstorage_sg
+  name: Cold Storage Singapore
+  marketCode: sg
+  currencyCode: SGD
+  adapter: search
+  baseUrl: https://coldstorage.com.sg
+  enabled: true
+
+  searchConfig:
+    numResults: 5
+    queryTemplate: "{canonicalName} grocery singapore {currency} price"
+    urlPathContains: /product/
+
+  rateLimit:
+    requestsPerMinute: 10
+    maxConcurrency: 1
+    delayBetweenRequestsMs: 6000
+
+  discovery:
+    mode: search
+    maxPages: 20
+    seeds: []

--- a/consumer-prices-core/configs/retailers/coles_au.yaml
+++ b/consumer-prices-core/configs/retailers/coles_au.yaml
@@ -1,0 +1,23 @@
+retailer:
+  slug: coles_au
+  name: Coles Australia
+  marketCode: au
+  currencyCode: AUD
+  adapter: search
+  baseUrl: https://www.coles.com.au
+  enabled: true
+
+  searchConfig:
+    numResults: 5
+    queryTemplate: "{canonicalName} grocery {market} {currency} price"
+    urlPathContains: /product/
+
+  rateLimit:
+    requestsPerMinute: 10
+    maxConcurrency: 1
+    delayBetweenRequestsMs: 6000
+
+  discovery:
+    mode: search
+    maxPages: 20
+    seeds: []

--- a/consumer-prices-core/configs/retailers/jiomart_in.yaml
+++ b/consumer-prices-core/configs/retailers/jiomart_in.yaml
@@ -1,0 +1,23 @@
+retailer:
+  slug: jiomart_in
+  name: JioMart India
+  marketCode: in
+  currencyCode: INR
+  adapter: search
+  baseUrl: https://www.jiomart.com
+  enabled: true
+
+  searchConfig:
+    numResults: 5
+    queryTemplate: "{canonicalName} grocery {market} {currency} price"
+    urlPathContains: /p/
+
+  rateLimit:
+    requestsPerMinute: 10
+    maxConcurrency: 1
+    delayBetweenRequestsMs: 6000
+
+  discovery:
+    mode: search
+    maxPages: 20
+    seeds: []

--- a/consumer-prices-core/configs/retailers/noon_sa.yaml
+++ b/consumer-prices-core/configs/retailers/noon_sa.yaml
@@ -1,0 +1,23 @@
+retailer:
+  slug: noon_sa
+  name: Noon Saudi Arabia
+  marketCode: sa
+  currencyCode: SAR
+  adapter: search
+  baseUrl: https://www.noon.com/saudi-en
+  enabled: true
+
+  searchConfig:
+    numResults: 5
+    queryTemplate: "{canonicalName} grocery SAR saudi noon"
+    urlPathContains: /saudi-en/  # restrict to SA storefront; noon.com also serves UAE (/uae-en/) and Egypt
+
+  rateLimit:
+    requestsPerMinute: 10
+    maxConcurrency: 1
+    delayBetweenRequestsMs: 6000
+
+  discovery:
+    mode: search
+    maxPages: 20
+    seeds: []

--- a/consumer-prices-core/configs/retailers/ocado_gb.yaml
+++ b/consumer-prices-core/configs/retailers/ocado_gb.yaml
@@ -1,0 +1,23 @@
+retailer:
+  slug: ocado_gb
+  name: Ocado UK
+  marketCode: gb
+  currencyCode: GBP
+  adapter: search
+  baseUrl: https://www.ocado.com
+  enabled: true
+
+  searchConfig:
+    numResults: 5
+    queryTemplate: "{canonicalName} grocery {market} {currency} price"
+    urlPathContains: /products/
+
+  rateLimit:
+    requestsPerMinute: 10
+    maxConcurrency: 1
+    delayBetweenRequestsMs: 6000
+
+  discovery:
+    mode: search
+    maxPages: 20
+    seeds: []


### PR DESCRIPTION
## Why this PR?

6 of 8 markets had exactly 1 active retailer. With only 1 retailer there is no cross-validation: a bad pin or extraction failure produces an undetected wrong number. We need ≥2 retailers per market for any basic data confidence.

## Changes

| Market | Before | After |
|--------|--------|-------|
| SA | ananinja only | ananinja + **noon_sa** + carrefour_sa (re-enabled) |
| AU | woolworths only | woolworths + **coles_au** |
| GB | tesco only | tesco + **ocado_gb** |
| IN | bigbasket only | bigbasket + **jiomart_in** |
| SG | fairprice only | fairprice + **coldstorage_sg** |
| BR | pão de açúcar only | pão de açúcar + **carrefour_br** |
| US | kroger + walmart | unchanged (already 2) |
| AE | 4 retailers | unchanged |

**carrefour_sa**: re-enabled after #2148 fixed the OOS prompt. Previously Firecrawl returned carousel prices for OOS items; now it returns null price and the item is cleanly skipped. Coverage may still be low if carrefourksa.com has stock issues, but data will be correct when items are in stock.

**noon_sa**: Exa already finds `noon.com/saudi-en/` URLs in scrape logs. Uses `urlPathContains: /saudi-en/` to isolate SA from UAE (`/uae-en/`) and Egypt (`/egypt-en/`) storefronts sharing the same domain.

**carrefour_br**: Uses `mercado.carrefour.com.br` with Portuguese query template for better Exa relevance.

## DB cleanup (already applied)
- Disabled Walmart organic jasmine rice pinned as "Long Grain White Rice 2lb" (organic ≠ regular; 2.4× price inflation)
- Disabled Kroger PLU-4093 individual yellow onion (by-weight produce PLU sold per piece, not 3lb bag)

## Test plan
- [ ] Typecheck and unit tests pass
- [ ] After deploy: trigger Railway scrape, check logs for each new retailer
- [ ] Expect noon_sa and coles_au to get 6-10/12 items (big mainstream retailers)
- [ ] Expect carrefour_sa coverage to vary; if still <4/12 after 2 runs, disable again
- [ ] GB/IN/SG/BR second retailers may need query template tuning after first run