### PR TITLE
fix(panels): remove Source column from FuelPricesPanel, fix updatedAt i18n key

### DIFF
--- a/src/components/BigMacPanel.ts
+++ b/src/components/BigMacPanel.ts
@@ -90,7 +90,7 @@ export class BigMacPanel extends Panel {
             <tbody>${rows}</tbody>
           </table>
         </div>
-        ${updatedAt ? `<div class="gb-updated">${t('common.updatedAt')}: ${updatedAt}</div>` : ''}
+        ${updatedAt ? `<div class="gb-updated">${t('components.status.updatedAt', { time: updatedAt })}</div>` : ''}
       </div>
     `;
 

--- a/src/components/FuelPricesPanel.ts
+++ b/src/components/FuelPricesPanel.ts
@@ -66,16 +66,10 @@ export class FuelPricesPanel extends Panel {
         return `<td class="gb-cell ${cls}">$${fuel.usdPrice.toFixed(3)}${wowStr}</td>`;
       }
 
-      const sourceText = ((gas ?? dsl)?.source ?? '').replace(/^https?:\/\//, '').split('/')[0];
-      const sourceLabel = sourceText
-        ? `<td class="gb-cell fuel-source">${escapeHtml(sourceText)}</td>`
-        : `<td class="gb-cell gb-na">—</td>`;
-
       return `<tr>
         <td class="gb-item-name">${escapeHtml(c.flag)} ${escapeHtml(c.name)}</td>
         ${fuelCell(gas, cheapestGas, priceiestGas, c.code)}
         ${fuelCell(dsl, cheapestDsl, priciestDsl, c.code)}
-        ${sourceLabel}
       </tr>`;
     }).join('');
 
@@ -90,12 +84,11 @@ export class FuelPricesPanel extends Panel {
               <th class="gb-item-col">${t('panels.fuelPricesCountry')}</th>
               <th class="gb-cell">${t('panels.fuelPricesGasoline')}</th>
               <th class="gb-cell">${t('panels.fuelPricesDiesel')}</th>
-              <th class="gb-cell">${t('panels.fuelPricesSource')}</th>
             </tr></thead>
             <tbody>${rows}</tbody>
           </table>
         </div>
-        ${updatedAt ? `<div class="gb-updated">${t('common.updatedAt')}: ${updatedAt}${countLabel}</div>` : ''}
+        ${updatedAt ? `<div class="gb-updated">${t('components.status.updatedAt', { time: updatedAt })}${countLabel}</div>` : ''}
       </div>
     `;
 

--- a/src/components/GroceryBasketPanel.ts
+++ b/src/components/GroceryBasketPanel.ts
@@ -99,7 +99,7 @@ export class GroceryBasketPanel extends Panel {
             <tbody>${rows}${totalRow}</tbody>
           </table>
         </div>
-        ${updatedAt ? `<div class="gb-updated">${t('common.updatedAt')}: ${updatedAt}</div>` : ''}
+        ${updatedAt ? `<div class="gb-updated">${t('components.status.updatedAt', { time: updatedAt })}</div>` : ''}
       </div>
     `;
 


### PR DESCRIPTION
## Summary
- **FuelPricesPanel**: remove Source column (header + cells) as requested
- **FuelPricesPanel + BigMacPanel + GroceryBasketPanel**: fix footer showing raw key `common.updatedAt` (key doesn't exist). Use `components.status.updatedAt` with `{ time }` interpolation instead — renders as "Updated 3/23/2026"

## Root cause
`common.updatedAt` was never defined. The key lives at `components.status.updatedAt` and takes a `{{time}}` parameter. All three panels were broken since they were written.