### PR TITLE
fix(fuel-prices): skip WoW when observedAt unchanged

### DIFF
--- a/scripts/seed-fuel-prices.mjs
+++ b/scripts/seed-fuel-prices.mjs
@@ -636,7 +636,8 @@ if (wowAvailable) {
     const prev = prevMap.get(country.code);
     if (!prev) continue;
 
-    if (country.gasoline && prev.gasoline?.usdPrice > 0 && country.gasoline.usdPrice > 0) {
+    if (country.gasoline && prev.gasoline?.usdPrice > 0 && country.gasoline.usdPrice > 0
+        && country.gasoline.observedAt !== prev.gasoline?.observedAt) {
       const raw = +((country.gasoline.usdPrice - prev.gasoline.usdPrice) / prev.gasoline.usdPrice * 100).toFixed(2);
       if (Math.abs(raw) > WOW_ANOMALY_THRESHOLD) {
         console.warn(`  [WoW] ANOMALY ${country.flag} ${country.name} gasoline: ${raw}% — omitting`);
@@ -644,7 +645,8 @@ if (wowAvailable) {
         country.gasoline.wowPct = raw;
       }
     }
-    if (country.diesel && prev.diesel?.usdPrice > 0 && country.diesel.usdPrice > 0) {
+    if (country.diesel && prev.diesel?.usdPrice > 0 && country.diesel.usdPrice > 0
+        && country.diesel.observedAt !== prev.diesel?.observedAt) {
       const raw = +((country.diesel.usdPrice - prev.diesel.usdPrice) / prev.diesel.usdPrice * 100).toFixed(2);
       if (Math.abs(raw) > WOW_ANOMALY_THRESHOLD) {
         console.warn(`  [WoW] ANOMALY ${country.flag} ${country.name} diesel: ${raw}% — omitting`);


### PR DESCRIPTION
## Why

EU Oil Bulletin is a weekly XLSX updated in-place. The `:prev` backfill we wrote used the same file as the current seed run (both `observedAt=2026-03-16`). Without this guard the seeder computes `wowPct=0.00` for all 26 EU countries and writes it to Redis.

While the panel already filters out `wowPct === 0` from display (line 61 in FuelPricesPanel), storing semantic noise in the cache is misleading: a `0` should mean "price actually didn't change", not "we compared the same data twice".

## What

Skip WoW computation for a fuel entry when `current.observedAt === prev.observedAt`. The field stays `undefined`, the panel shows nothing for that country — same as when there's no prev data at all.

EU countries will start showing real WoW once the March 26 XLSX is published and the seeder runs (2 days from now). US already shows real WoW (period 2026-03-09 → 2026-03-16).

## Test plan
- [ ] EU countries show no WoW indicator until next XLSX update
- [ ] US shows real WoW (different EIA periods)
- [ ] Run seeder again after EU update — EU WoW appears correctly