### PR TITLE
fix(dev): add lint:boundaries to pre-push hook to match CI

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -61,6 +61,9 @@ done
 echo "Running Unicode safety check..."
 node scripts/check-unicode-safety.mjs || exit 1
 
+echo "Running architectural boundary check..."
+npm run lint:boundaries || exit 1
+
 echo "Running edge function bundle check..."
 for f in api/*.js; do
   case "$(basename "$f")" in _*) continue;; esac


### PR DESCRIPTION
## Why this PR?

The CI `lint-code.yml` workflow runs `npm run lint:boundaries` but the pre-push hook only ran `npm run lint` (biome). This gap allowed architectural boundary violations (e.g. services importing from components) to slip through locally and only fail in CI.

## What changed

`.husky/pre-push`: added `npm run lint:boundaries` step after the unicode safety check, matching CI order.

## Impact

Future pushes will catch boundary violations locally before they reach GitHub CI.