### PR TITLE
fix(forecast): fix impact expansion LLM prompt + pre-filter validation diagnostic

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -120,6 +120,12 @@ const CHOKEPOINT_MARKET_REGIONS = {
   'Strait of Malacca': 'South China Sea',
   'Kerch Strait': 'Black Sea',
   'Bosporus Strait': 'Black Sea',
+  'Baltic Sea': 'Northern Europe',
+  'Danish Straits': 'Northern Europe',
+  'Strait of Gibraltar': 'Mediterranean',
+  'Panama Canal': 'Central America',
+  'Lombok Strait': 'Southeast Asia',
+  'Cape of Good Hope': 'Southern Africa',
 };
 
 const MARKET_INPUT_KEYS = {
@@ -371,7 +377,7 @@ const FORECAST_DOMAINS = [
   'infrastructure',
 ];
 const MARKET_CLUSTER_DOMAINS = new Set(['market', 'supply_chain']);
-const IMPACT_EXPANSION_REGISTRY_VERSION = 'v2';
+const IMPACT_EXPANSION_REGISTRY_VERSION = 'v3';
 const IMPACT_EXPANSION_MAX_CANDIDATES = 6;
 const IMPACT_EXPANSION_CACHE_TTL_SECONDS = 30 * 60;
 const IMPACT_EXPANSION_ORDERS = ['direct', 'second_order', 'third_order'];
@@ -2286,12 +2292,16 @@ Rules:
 - Each hypothesis must use a (variableKey, channel, targetBucket) triple that is VALID per the constraint table above. Both conditions must hold: (1) the channel must be in the variableKey's channels list, and (2) the targetBucket must accept that channel per the bucket-channel constraints.
 - Causal ordering: variables with orders=[direct,second_order] are root causes (shipping/energy disruptions). Variables with orders=[second_order,third_order] are downstream consequences. Example chain: route_disruption(direct,freight) → inflation_pass_through(second_order,rates_inflation) → sovereign_funding_stress(third_order,sovereign_risk).
 - direct hypotheses go in directHypotheses. second_order in secondOrderHypotheses. third_order in thirdOrderHypotheses. Match the orderAllowed for each variableKey.
-- dependsOnKey: for second_order, set to the variableKey of the direct hypothesis it causally follows. For third_order, set to the variableKey of the second_order hypothesis it follows. For direct, leave empty.
+- dependsOnKey: For second_order, MUST be the exact variableKey string of one of your direct hypotheses for this same candidate (e.g., if your direct uses variableKey "route_disruption", your second_order dependsOnKey MUST be "route_disruption"). For third_order, set to the variableKey of a second_order in this response. For direct, leave as empty string "".
+- If you cannot construct a second_order that depends on an existing direct hypothesis in your response, omit the second_order entirely rather than leaving dependsOnKey empty or guessing.
+- Structure: For each candidate, generate at minimum: (1) one direct hypothesis with the strongest channel, then (2) one second_order consequence with dependsOnKey set to the direct's variableKey. This direct+second_order pair is the core unit. Additional hypotheses are optional and only if well-evidenced.
 - Use ONLY these analogTag values: ${IMPACT_EXPANSION_ANALOG_TAGS.join(', ')}.
 - Cite evidence ONLY with exact E# keys from the candidate packet.
+- Each hypothesis MUST reference at least 2 evidence keys. A hypothesis with fewer than 2 references will receive no evidence credit in scoring and cannot drive expanded paths.
 - Never invent events, routes, facilities, commodities, or countries beyond the candidate packet.
 - Prefer omission over weak guesses.
 - Keep strength and confidence between 0 and 1.
+- Score calibration: For well-evidenced direct disruptions with named routes or commodities, assign strength 0.82-0.95 and confidence 0.80-0.92. For second_order consequences with clear causal link, assign strength 0.72-0.85 and confidence 0.70-0.82. For speculative or weakly-evidenced connections, assign 0.45-0.65. Do NOT assign 0.70 uniformly — differentiate based on evidence quality.
 - Keep summaries concise and evidence-grounded.
 - Return no prose outside the JSON object.
 - Do NOT wrap the JSON in markdown fences.
@@ -3088,6 +3098,14 @@ function tryParseImpactExpansionCandidate(candidate) {
     const parsed = JSON.parse(candidate);
     if (Array.isArray(parsed?.candidates)) return { candidates: parsed.candidates, stage: 'object_candidates' };
     if (Array.isArray(parsed)) return { candidates: parsed, stage: 'direct_array' };
+  } catch {
+    // continue
+  }
+  // Gemini sometimes returns '"candidates": [...]' without outer braces (especially when
+  // wrapping in a markdown code fence). Try wrapping in {} to recover.
+  try {
+    const wrapped = JSON.parse(`{${candidate}}`);
+    if (Array.isArray(wrapped?.candidates)) return { candidates: wrapped.candidates, stage: 'wrapped_candidates' };
   } catch {
     // continue
   }
@@ -4432,6 +4450,7 @@ function buildImpactExpansionDebugPayload(data = {}, worldState = null, runId = 
     validatedCount: (rawValidation.validated || []).length,
     mappedCount: (rawValidation.mapped || []).length,
     rejectionReasonCounts: rawValidation.rejectionReasonCounts || {},
+    // rejectedHypotheses kept for backwards compatibility — only structurally-rejected items.
     rejectedHypotheses: (rawValidation.hypotheses || [])
       .filter((item) => item.rejectionReason)
       .map((item) => ({
@@ -4443,6 +4462,23 @@ function buildImpactExpansionDebugPayload(data = {}, worldState = null, runId = 
         order: item.order,
         rejectionReason: item.rejectionReason,
       })),
+    // scoringBreakdown includes ALL hypotheses (mapped, trace_only, rejected) with their input
+    // scoring factors. Use this for iterative prompt/threshold calibration.
+    scoringBreakdown: (rawValidation.hypotheses || []).map((item) => ({
+      candidateIndex: item.candidateIndex,
+      candidateStateId: item.candidateStateId,
+      variableKey: item.variableKey,
+      channel: item.channel,
+      targetBucket: item.targetBucket,
+      order: item.order,
+      validationScore: item.validationScore,
+      validationStatus: item.validationStatus,
+      rejectionReason: item.rejectionReason || '',
+      candidateSalience: item.candidateSalience,
+      specificitySupport: item.specificitySupport,
+      continuitySupport: item.continuitySupport,
+      evidenceSupport: item.evidenceSupport,
+    })),
   } : null;
   return {
     runId,
@@ -4454,6 +4490,13 @@ function buildImpactExpansionDebugPayload(data = {}, worldState = null, runId = 
     candidatePackets: candidates,
     impactExpansionSummary: worldState?.impactExpansion || null,
     hypothesisValidation,
+    // gateDetails records the active thresholds at time of execution for self-documenting artifacts.
+    gateDetails: {
+      secondOrderMappedFloor: 0.58,
+      secondOrderMultiplier: 0.88,
+      pathScoreThreshold: 0.50,
+      acceptanceThreshold: 0.60,
+    },
     selectedPaths: (data?.deepPathEvaluation?.selectedPaths || []).map(summarizeImpactPathScore).filter(Boolean),
     rejectedPaths: (data?.deepPathEvaluation?.rejectedPaths || []).map(summarizeImpactPathScore).filter(Boolean),
   };
@@ -10163,7 +10206,7 @@ function getImpactValidationFloors(order = 'direct') {
     return { internal: 0.66, mapped: 0.74, multiplier: 0.72 };
   }
   if (order === 'second_order') {
-    return { internal: 0.58, mapped: 0.66, multiplier: 0.85 };
+    return { internal: 0.50, mapped: 0.58, multiplier: 0.88 };
   }
   return { internal: 0.5, mapped: 0.58, multiplier: 1 };
 }
@@ -10256,7 +10299,9 @@ function validateImpactHypotheses(bundle = null) {
         ? clampUnitInterval(IMPACT_ANALOG_PRIORS[hypothesis.analogTag].confidenceMultiplier - 1.0)
         : 0;
       const candidateSalience = clampUnitInterval(Number(candidate.rankingScore || 0));
-      const evidenceSupport = clampUnitInterval((hypothesis.evidenceRefs || []).length / 2);
+      // Two or more evidence references are required for full evidence credit.
+      // A hypothesis with only one reference receives no evidence contribution and cannot reach mapped.
+      const evidenceSupport = (hypothesis.evidenceRefs || []).length >= 2 ? 1 : 0;
       const specificitySupport = clampUnitInterval(Number(candidate.specificityScore || 0));
       const continuitySupport = clampUnitInterval(Number(candidate.continuityScore || 0));
       const contradictionPenalty = clampUnitInterval(Number(candidate.marketContext?.contradictionScore || 0));
@@ -10301,6 +10346,30 @@ function validateImpactHypotheses(bundle = null) {
         if (hypothesis.order === 'direct') validatedDirectKeys.add(hypothesis.variableKey);
         if (hypothesis.order === 'second_order') validatedSecondOrderKeys.add(hypothesis.variableKey);
       }
+    }
+  }
+
+  // Invariant: a mapped second_order must have a mapped direct parent; a mapped third_order must
+  // have a mapped second_order parent. validatedDirectKeys/validatedSecondOrderKeys above include
+  // trace_only items, so a second_order could pass the missing_dependency check against a trace_only
+  // direct yet still fail to build a path (buildImpactPathsForCandidate only uses validation.mapped).
+  // Downgrade such orphaned mapped items to trace_only so the debug artifact reflects reality.
+  const mappedDirectKeySet = new Set(
+    results.filter((r) => r.order === 'direct' && r.validationStatus === 'mapped').map((r) => r.variableKey),
+  );
+  for (const item of results) {
+    if (item.order === 'second_order' && item.validationStatus === 'mapped'
+        && item.dependsOnKey && !mappedDirectKeySet.has(item.dependsOnKey)) {
+      item.validationStatus = 'trace_only';
+    }
+  }
+  const mappedSecondKeySet = new Set(
+    results.filter((r) => r.order === 'second_order' && r.validationStatus === 'mapped').map((r) => r.variableKey),
+  );
+  for (const item of results) {
+    if (item.order === 'third_order' && item.validationStatus === 'mapped'
+        && item.dependsOnKey && !mappedSecondKeySet.has(item.dependsOnKey)) {
+      item.validationStatus = 'trace_only';
     }
   }
 
@@ -10698,7 +10767,7 @@ function buildImpactPathsForCandidate(candidatePacket, validation = null) {
     if (thirdMatches.length === 0) {
       const pathScore = buildImpactPathScore(candidatePacket, direct, second, null);
       const key = `${direct.variableKey}:${second.variableKey}:`;
-      if (!seen.has(key) && pathScore >= 0.66) {
+      if (!seen.has(key) && pathScore >= 0.50) {
         expanded.push({
           pathId: buildImpactPathId(candidatePacket, direct, second, null),
           candidateStateId: candidatePacket.candidateStateId,
@@ -10718,7 +10787,7 @@ function buildImpactPathsForCandidate(candidatePacket, validation = null) {
     for (const third of thirdMatches) {
       const pathScore = buildImpactPathScore(candidatePacket, direct, second, third);
       const key = `${direct.variableKey}:${second.variableKey}:${third.variableKey}`;
-      if (seen.has(key) || pathScore < 0.66) continue;
+      if (seen.has(key) || pathScore < 0.50) continue;
       expanded.push({
         pathId: buildImpactPathId(candidatePacket, direct, second, third),
         candidateStateId: candidatePacket.candidateStateId,
@@ -14473,6 +14542,10 @@ export {
   selectImpactExpansionCandidates,
   selectDeepForecastCandidates,
   buildRegistryConstraintTable,
+  buildImpactExpansionSystemPrompt,
+  extractImpactExpansionPayload,
+  extractImpactRouteFacilityKey,
+  extractImpactCommodityKey,
   buildImpactExpansionCandidateHash,
   recoverImpactExpansionDrafts,
   extractImpactExpansionBundle,

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -38,6 +38,10 @@ import {
   validateDeepForecastSnapshot,
   buildCanonicalStateUnits,
   buildRegistryConstraintTable,
+  buildImpactExpansionSystemPrompt,
+  extractImpactExpansionPayload,
+  extractImpactRouteFacilityKey,
+  extractImpactCommodityKey,
   IMPACT_VARIABLE_REGISTRY,
   MARKET_BUCKET_ALLOWED_CHANNELS,
 } from '../scripts/seed-forecasts.mjs';
@@ -3329,6 +3333,64 @@ describe('cross-theater gate', () => {
   });
 });
 
+describe('impact expansion payload parsing', () => {
+  // Gemini wraps responses in ```json fences AND omits outer {} braces,
+  // producing '"candidates": [...]' inside the fenced block.
+  // Verified on production run 1774322111327-kj6f91 (parseStage: no_json_object).
+  it('parses Gemini-style fenced response with missing outer braces (wrapped_candidates)', () => {
+    const geminiFencedNoBraces = `\`\`\`json
+  "candidates": [
+    {
+      "candidateIndex": 0,
+      "candidateStateId": "state-abc",
+      "directHypotheses": [],
+      "secondOrderHypotheses": [],
+      "thirdOrderHypotheses": []
+    }
+  ]
+\`\`\``;
+    const result = extractImpactExpansionPayload(geminiFencedNoBraces);
+    assert.ok(Array.isArray(result.candidates), 'must parse candidates');
+    assert.equal(result.candidates.length, 1);
+    assert.equal(result.candidates[0].candidateStateId, 'state-abc');
+    assert.equal(result.diagnostics.stage, 'wrapped_candidates');
+  });
+
+  it('still parses well-formed fenced response (object_candidates)', () => {
+    const wellFormed = `\`\`\`json
+{
+  "candidates": [
+    {
+      "candidateIndex": 0,
+      "candidateStateId": "state-xyz",
+      "directHypotheses": [],
+      "secondOrderHypotheses": [],
+      "thirdOrderHypotheses": []
+    }
+  ]
+}
+\`\`\``;
+    const result = extractImpactExpansionPayload(wellFormed);
+    assert.ok(Array.isArray(result.candidates));
+    assert.equal(result.candidates[0].candidateStateId, 'state-xyz');
+    assert.equal(result.diagnostics.stage, 'object_candidates');
+  });
+
+  it('still parses bare JSON without fences (object_candidates)', () => {
+    const bare = `{"candidates":[{"candidateIndex":0,"candidateStateId":"state-bare","directHypotheses":[],"secondOrderHypotheses":[],"thirdOrderHypotheses":[]}]}`;
+    const result = extractImpactExpansionPayload(bare);
+    assert.ok(Array.isArray(result.candidates));
+    assert.equal(result.candidates[0].candidateStateId, 'state-bare');
+    assert.equal(result.diagnostics.stage, 'object_candidates');
+  });
+
+  it('returns no_json_object for genuinely unparseable response', () => {
+    const result = extractImpactExpansionPayload('Sorry, I cannot help with that.');
+    assert.equal(result.candidates, null);
+    assert.equal(result.diagnostics.stage, 'no_json_object');
+  });
+});
+
 describe('impact expansion layer', () => {
   function makeImpactCandidatePacket(stateId = 'state-1', label = 'Strait of Hormuz maritime disruption state', overrides = {}) {
     return {
@@ -4844,5 +4906,317 @@ describe('forecast replay lifecycle helpers', () => {
     assert.equal(diff.publishedDomainDelta.supply_chain, 3);
     assert.ok(diff.addedTopForecastTitles.includes('Supply chain stress from Strait of Hormuz disruption state'));
     assert.ok(diff.removedTopForecastTitles.includes('FX stress from Germany cyber pressure state'));
+  });
+});
+
+describe('phase 2 scoring recalibration + prompt excellence', () => {
+  // Builds a minimal bundle with controlled quality inputs for scoring tests.
+  // Uses a generic (non-Hormuz) candidate to simulate the typical low-specificity case.
+  function makeGenericBundle({
+    specificityScore = 0.2,
+    rankingScore = 0.70,
+    continuityScore = 0.5,
+    evidenceRefs = ['E1', 'E2'],
+    directEvidenceRefs,       // override evidenceRefs for direct only
+    secondEvidenceRefs,       // override evidenceRefs for second_order only
+    directStrength = 0.75,
+    directConfidence = 0.75,
+    secondStrength = 0.75,
+    secondConfidence = 0.75,
+    directDependsOnKey = '',
+    secondDependsOnKey = 'route_disruption',
+  } = {}) {
+    const packet = {
+      candidateIndex: 0,
+      candidateStateId: 'state-generic',
+      candidateStateLabel: 'Baltic Sea shipping pressure state',
+      stateKind: 'maritime_disruption',
+      dominantRegion: 'Northern Europe',
+      macroRegions: ['EMEA'],
+      countries: ['Northern Europe'],
+      marketBucketIds: ['freight', 'rates_inflation'],
+      transmissionChannels: ['shipping_cost_shock'],
+      topSignalTypes: ['shipping_cost_shock'],
+      criticalSignalTypes: ['shipping_cost_shock'],
+      routeFacilityKey: '',
+      commodityKey: '',
+      specificityScore,
+      continuityMode: 'persistent',
+      continuityScore,
+      rankingScore,
+      evidenceTable: [
+        { key: 'E1', kind: 'state_summary', text: 'Baltic Sea shipping pressure is active.' },
+        { key: 'E2', kind: 'headline', text: 'Baltic freight rates are climbing on route uncertainty.' },
+      ],
+      marketContext: {
+        topBucketId: 'freight',
+        topBucketLabel: 'Freight',
+        topBucketPressure: 0.55,
+        confirmationScore: 0.40,
+        contradictionScore: 0.08,
+        topChannel: 'shipping_cost_shock',
+        topTransmissionStrength: 0.52,
+        topTransmissionConfidence: 0.48,
+        transmissionEdgeCount: 2,
+        criticalSignalLift: 0.30,
+        criticalSignalTypes: ['shipping_cost_shock'],
+        linkedBucketIds: ['freight', 'rates_inflation'],
+        consequenceSummary: 'Baltic Sea is transmitting into Freight through shipping cost shock.',
+      },
+    };
+    const extracted = {
+      candidateIndex: 0,
+      candidateStateId: 'state-generic',
+      directHypotheses: [{
+        variableKey: 'route_disruption',
+        channel: 'shipping_cost_shock',
+        targetBucket: 'freight',
+        region: 'Northern Europe',
+        macroRegion: 'EMEA',
+        countries: ['Northern Europe'],
+        assetsOrSectors: [],
+        commodity: '',
+        dependsOnKey: directDependsOnKey,
+        strength: directStrength,
+        confidence: directConfidence,
+        analogTag: '',
+        summary: 'Route disruption is transmitting through shipping cost shock.',
+        evidenceRefs: directEvidenceRefs !== undefined ? directEvidenceRefs : evidenceRefs,
+      }],
+      secondOrderHypotheses: [{
+        variableKey: 'inflation_pass_through',
+        channel: 'inflation_impulse',
+        targetBucket: 'rates_inflation',
+        region: 'Northern Europe',
+        macroRegion: 'EMEA',
+        countries: ['Northern Europe'],
+        assetsOrSectors: [],
+        commodity: '',
+        dependsOnKey: secondDependsOnKey,
+        strength: secondStrength,
+        confidence: secondConfidence,
+        analogTag: '',
+        summary: 'Freight cost shock is feeding through to inflation.',
+        evidenceRefs: secondEvidenceRefs !== undefined ? secondEvidenceRefs : evidenceRefs,
+      }],
+      thirdOrderHypotheses: [],
+    };
+    return { candidatePackets: [packet], extractedCandidates: [extracted] };
+  }
+
+  it('T1: second_order with moderate LLM quality and 2 evidence refs reaches mapped', () => {
+    const bundle = makeGenericBundle({
+      specificityScore: 0.2,
+      rankingScore: 0.70,
+      continuityScore: 0.50,
+      directStrength: 0.75,
+      directConfidence: 0.75,
+      secondStrength: 0.75,
+      secondConfidence: 0.75,
+      evidenceRefs: ['E1', 'E2'],
+    });
+    const validation = validateImpactHypotheses(bundle);
+    const secondOrder = validation.hypotheses.find((h) => h.order === 'second_order');
+    assert.ok(secondOrder, 'must have a second_order hypothesis');
+    assert.equal(secondOrder.validationStatus, 'mapped',
+      `second_order should be mapped but got ${secondOrder.validationStatus} (score=${secondOrder.validationScore})`);
+  });
+
+  it('T2: second_order with only 1 evidence ref does NOT reach mapped', () => {
+    const bundle = makeGenericBundle({
+      specificityScore: 0.2,
+      rankingScore: 0.70,
+      continuityScore: 0.50,
+      directStrength: 0.75,
+      directConfidence: 0.75,
+      secondStrength: 0.75,
+      secondConfidence: 0.75,
+      evidenceRefs: ['E1'],  // only 1 ref
+    });
+    const validation = validateImpactHypotheses(bundle);
+    const secondOrder = validation.hypotheses.find((h) => h.order === 'second_order');
+    assert.ok(secondOrder, 'must have a second_order hypothesis');
+    assert.notEqual(secondOrder.validationStatus, 'mapped',
+      `second_order with 1 ref should NOT be mapped but got ${secondOrder.validationStatus} (score=${secondOrder.validationScore})`);
+  });
+
+  it('T3: mapped second_order with only trace_only parent is downgraded to trace_only', () => {
+    // Direct: low specificityScore (0.2), low rankingScore (0.4), low continuityScore (0.1),
+    // low strength/confidence (0.30/0.30), and only 1 evidence ref (evidenceSupport=0).
+    // baseScore = 0.4*0.12 + 0.30*0.16 + 0.30*0.14 + 0 + 0.12 + 0.10 + 0 + 0.2*0.08 + 0.1*0.05
+    //           = 0.048 + 0.048 + 0.042 + 0 + 0.12 + 0.10 + 0 + 0.016 + 0.005 = 0.379 < 0.58 → trace_only
+    // Second_order: same low candidate salience but high strength/confidence (0.95/0.92), 2 refs.
+    // baseScore = 0.4*0.12 + 0.95*0.16 + 0.92*0.14 + 1 + 0.12 + 0.10 + 0 + 0.2*0.08 + 0.1*0.05
+    //           = 0.048 + 0.152 + 0.129 + 0.140 + 0.12 + 0.10 + 0 + 0.016 + 0.005 = 0.710
+    // validationScore = 0.710 * 0.88 = 0.625 >= 0.58 → would normally be mapped
+    // But parent direct is trace_only → invariant downgrades second_order to trace_only.
+    const bundle = makeGenericBundle({
+      specificityScore: 0.2,
+      rankingScore: 0.40,
+      continuityScore: 0.10,
+      directStrength: 0.30,
+      directConfidence: 0.30,
+      directEvidenceRefs: ['E1'],   // 1 ref → evidenceSupport=0 → direct trace_only
+      secondStrength: 0.95,
+      secondConfidence: 0.92,
+      secondEvidenceRefs: ['E1', 'E2'],  // 2 refs → evidenceSupport=1 → second_order would be mapped
+    });
+    const validation = validateImpactHypotheses(bundle);
+    const directHyp = validation.hypotheses.find((h) => h.order === 'direct');
+    const secondOrder = validation.hypotheses.find((h) => h.order === 'second_order');
+    assert.ok(directHyp, 'must have a direct hypothesis');
+    assert.ok(secondOrder, 'must have a second_order hypothesis');
+    assert.notEqual(directHyp.validationStatus, 'mapped',
+      `direct should be trace_only due to 1 ref + low inputs, got ${directHyp.validationStatus} (score=${directHyp.validationScore})`);
+    assert.notEqual(secondOrder.validationStatus, 'mapped',
+      `second_order should be downgraded to trace_only when parent direct is not mapped, got ${secondOrder.validationStatus} (score=${secondOrder.validationScore})`);
+  });
+
+  it('T4: expanded path is generated when both direct and second_order are mapped', () => {
+    // Use the Hormuz fixture (high quality) to confirm path builds under new thresholds.
+    // Previously this was the ONLY scenario that worked; now generic candidates should also work (T1).
+    const bundle = makeGenericBundle({
+      specificityScore: 0.5,
+      rankingScore: 0.80,
+      continuityScore: 0.80,
+      directStrength: 0.85,
+      directConfidence: 0.85,
+      secondStrength: 0.82,
+      secondConfidence: 0.80,
+      evidenceRefs: ['E1', 'E2'],
+    });
+    const validation = validateImpactHypotheses(bundle);
+    const packet = bundle.candidatePackets[0];
+    const paths = buildImpactPathsForCandidate(packet, validation);
+    const expanded = paths.filter((p) => p.type === 'expanded');
+    assert.ok(expanded.length > 0, `expected at least 1 expanded path but got ${expanded.length}`);
+    assert.ok(expanded[0].pathScore >= 0.50,
+      `pathScore ${expanded[0].pathScore} must be >= 0.50`);
+  });
+
+  it('T5: scoringBreakdown in debug artifact includes ALL hypotheses with scoring factors', () => {
+    const bundle = makeGenericBundle({
+      specificityScore: 0.5,
+      rankingScore: 0.80,
+      continuityScore: 0.70,
+      directStrength: 0.85,
+      directConfidence: 0.85,
+      secondStrength: 0.82,
+      secondConfidence: 0.80,
+      evidenceRefs: ['E1', 'E2'],
+    });
+    const rawValidation = validateImpactHypotheses(bundle);
+
+    // Inject a structurally rejected hypothesis to ensure scoringBreakdown covers all statuses
+    const invalidHyp = {
+      variableKey: 'route_disruption',
+      channel: 'sovereign_stress',   // invalid: sovereign_stress not allowed for route_disruption
+      targetBucket: 'sovereign_risk',
+      region: 'Northern Europe',
+      macroRegion: 'EMEA',
+      countries: [],
+      assetsOrSectors: [],
+      commodity: '',
+      dependsOnKey: '',
+      strength: 0.7,
+      confidence: 0.7,
+      analogTag: '',
+      summary: 'Invalid combination.',
+      evidenceRefs: ['E1', 'E2'],
+      candidateIndex: 0,
+      candidateStateId: 'state-generic',
+      candidateStateLabel: 'Baltic Sea shipping pressure state',
+      order: 'direct',
+      rejectionReason: 'unsupported_variable_channel',
+      validationScore: 0,
+      validationStatus: 'rejected',
+      candidateSalience: 0,
+      specificitySupport: 0,
+      evidenceSupport: 0,
+      continuitySupport: 0,
+    };
+    const enrichedValidation = {
+      ...rawValidation,
+      hypotheses: [...rawValidation.hypotheses, invalidHyp],
+    };
+
+    const artifacts = buildForecastTraceArtifacts({
+      generatedAt: Date.parse('2026-03-24T12:00:00Z'),
+      predictions: [],
+      impactExpansionBundle: bundle,
+      impactExpansionCandidates: bundle.candidatePackets,
+      deepPathEvaluation: {
+        status: 'completed_no_material_change',
+        selectedPaths: [],
+        rejectedPaths: [],
+        impactExpansionBundle: bundle,
+        deepWorldState: null,
+        validation: enrichedValidation,
+      },
+    }, { runId: 'test-scoring-breakdown' });
+
+    const hv = artifacts.impactExpansionDebug?.hypothesisValidation;
+    assert.ok(hv, 'hypothesisValidation must be present');
+    assert.ok(Array.isArray(hv.scoringBreakdown), 'scoringBreakdown must be an array');
+    assert.ok(hv.scoringBreakdown.length === enrichedValidation.hypotheses.length,
+      `scoringBreakdown length ${hv.scoringBreakdown.length} must equal total hypothesis count ${enrichedValidation.hypotheses.length}`);
+    for (const entry of hv.scoringBreakdown) {
+      assert.ok(typeof entry.validationScore === 'number', 'entry must have validationScore');
+      assert.ok(typeof entry.validationStatus === 'string', 'entry must have validationStatus');
+      assert.ok(typeof entry.candidateSalience === 'number', 'entry must have candidateSalience');
+      assert.ok(typeof entry.specificitySupport === 'number', 'entry must have specificitySupport');
+      assert.ok(typeof entry.evidenceSupport === 'number', 'entry must have evidenceSupport');
+    }
+  });
+
+  it('T6: gateDetails in debug artifact records active thresholds', () => {
+    const bundle = makeGenericBundle({});
+    const validation = validateImpactHypotheses(bundle);
+
+    const artifacts = buildForecastTraceArtifacts({
+      generatedAt: Date.parse('2026-03-24T12:00:00Z'),
+      predictions: [],
+      impactExpansionBundle: bundle,
+      impactExpansionCandidates: bundle.candidatePackets,
+      deepPathEvaluation: {
+        status: 'completed_no_material_change',
+        selectedPaths: [],
+        rejectedPaths: [],
+        impactExpansionBundle: bundle,
+        deepWorldState: null,
+        validation,
+      },
+    }, { runId: 'test-gate-details' });
+
+    const gd = artifacts.impactExpansionDebug?.gateDetails;
+    assert.ok(gd, 'gateDetails must be present');
+    assert.equal(gd.secondOrderMappedFloor, 0.58);
+    assert.equal(gd.secondOrderMultiplier, 0.88);
+    assert.equal(gd.pathScoreThreshold, 0.50);
+    assert.equal(gd.acceptanceThreshold, 0.60);
+  });
+
+  it('T7: prompt v3 contains all required guidance strings', () => {
+    const prompt = buildImpactExpansionSystemPrompt();
+    assert.ok(prompt.includes('at least 2 evidence keys'),
+      'prompt must mention 2-evidence requirement');
+    assert.ok(prompt.includes('MUST be the exact variableKey string'),
+      'prompt must have dependsOnKey exactness rule');
+    assert.ok(prompt.includes('strength 0.82-0.95'),
+      'prompt must include confidence calibration guidance');
+    assert.ok(prompt.includes('direct+second_order pair is the core unit'),
+      'prompt must describe pair structure');
+  });
+
+  it('T8: new chokepoints are detected by extractImpactRouteFacilityKey', () => {
+    assert.equal(extractImpactRouteFacilityKey(['Baltic Sea shipping disruption']), 'Baltic Sea');
+    assert.equal(extractImpactRouteFacilityKey(['Danish Straits closure impacts Scandinavian trade']), 'Danish Straits');
+    assert.equal(extractImpactRouteFacilityKey(['Strait of Gibraltar blockade scenario']), 'Strait of Gibraltar');
+    assert.equal(extractImpactRouteFacilityKey(['Panama Canal drought cuts transit']), 'Panama Canal');
+    assert.equal(extractImpactRouteFacilityKey(['Lombok Strait alternative route pressure']), 'Lombok Strait');
+    assert.equal(extractImpactRouteFacilityKey(['Cape of Good Hope rerouting surge']), 'Cape of Good Hope');
+    // Original chokepoints must still work
+    assert.equal(extractImpactRouteFacilityKey(['Strait of Hormuz tanker attack']), 'Strait of Hormuz');
+    assert.equal(extractImpactRouteFacilityKey(['Suez Canal blockage ongoing']), 'Suez Canal');
   });
 });


### PR DESCRIPTION
## Why this PR?

Two-phase fix for deep forecasts always returning \`completed_no_material_change\`.

**Phase 1** (commits 1-3): Fixed structural bugs — Gemini JSON fence parsing, constraint table in LLM prompt, validation flow-through to debug artifacts, label disambiguation. The pipeline now reaches the LLM and gets back syntactically valid hypotheses.

**Phase 2** (this commit): Three cascading scoring gates were mathematically impossible to clear with typical LLM output. Every second_order hypothesis scored as \`trace_only\` → no expanded paths were ever built.

Root causes:
- second_order mapped floor (0.66) required \`baseScore ≥ 0.776\` but typical inputs yield 0.710 → \`trace_only\`
- pathScore threshold (0.66) blocked barely-mapped pairs from generating expanded paths
- \`validatedDirectKeys\` included \`trace_only\` items, so a mapped second_order could have no mapped direct parent in \`buildImpactPathsForCandidate\`
- "at least 2 evidence keys" was prompt-only text, not enforced at scoring layer

## Changes

**\`scripts/seed-forecasts.mjs\`**
- Lower second_order validation floors (mapped: 0.66→0.58, internal: 0.58→0.50) and raise multiplier (0.85→0.88) — typical quality (strength~0.75, conf~0.75, 2 refs, specificityScore=0.2) now reaches \`mapped\`
- Binary \`evidenceSupport\`: \`refs >= 2 → 1, else → 0\` — 1-ref hypotheses remain \`trace_only\` (enforced at scoring layer, not just prompt text)
- Parent-must-be-mapped invariant: post-validation pass downgrades mapped second_order/third_order whose \`dependsOnKey\` has no mapped parent
- Lower \`pathScore\` threshold 0.66 → 0.50
- Add 6 missing maritime chokepoints to \`CHOKEPOINT_MARKET_REGIONS\` (Baltic Sea, Danish Straits, Strait of Gibraltar, Panama Canal, Lombok Strait, Cape of Good Hope)
- Bump \`IMPACT_EXPANSION_REGISTRY_VERSION\` v2 → v3 (invalidates stale LLM cache)
- Prompt v3: explicit \`dependsOnKey\` pairing rule, 2-evidence citation requirement, confidence calibration guidance (strength 0.82-0.95 for direct, 0.72-0.85 for second_order), direct+second_order pair structure instruction
- Add \`scoringBreakdown\` (all hypotheses with full scoring factors) and \`gateDetails\` (active thresholds) to debug artifact for observability
- Export \`buildImpactExpansionSystemPrompt\`, \`extractImpactRouteFacilityKey\`, \`extractImpactCommodityKey\` for testability

**\`tests/forecast-trace-export.test.mjs\`**
- 8 new tests (T1-T8) covering all phase 2 changes
- T1: second_order with typical quality (2 refs) reaches \`mapped\`
- T2: second_order with 1 ref stays \`trace_only\`
- T3: mapped second_order with \`trace_only\` parent is downgraded by invariant pass
- T4: expanded path generated when both direct and second_order are mapped with pathScore ≥ 0.50
- T5: \`scoringBreakdown\` includes all hypotheses with scoring factors
- T6: \`gateDetails\` present with correct threshold values
- T7: prompt v3 contains all required guidance strings
- T8: new chokepoints detected by \`extractImpactRouteFacilityKey\`

## Test plan
- [x] All 111 tests pass (\`node --test tests/forecast-trace-export.test.mjs\`)
- [ ] Run \`node scripts/seed-forecasts.mjs && node scripts/process-deep-forecast-tasks.mjs --once\`
- [ ] Confirm status is NOT \`completed_no_material_change\`
- [ ] Read R2 debug artifact — confirm \`scoringBreakdown\` populated, \`mappedCount >= 2\`, at least one second_order with \`validationStatus: 'mapped'\`
- [ ] Confirm \`gateDetails\` shows correct thresholds