### PR TITLE
fix(widget-modal): disambiguate widget and pro key auth errors

### DIFF
--- a/api/widget-agent.ts
+++ b/api/widget-agent.ts
@@ -275,7 +275,10 @@ async function proxyWidgetAgent(
       const hasWidgetKey = await timingSafeEqualSecret(widgetKey, WIDGET_AGENT_KEY);
       const hasProKey = await timingSafeEqualSecret(proKey, PRO_WIDGET_KEY);
       if (!hasWidgetKey && !hasProKey) {
-        return json({ error: 'Forbidden' }, 403, corsHeaders);
+        const errorCode = !WIDGET_AGENT_KEY && PRO_WIDGET_KEY
+          ? 'invalid_pro_key'
+          : 'invalid_widget_key';
+        return json({ error: 'Forbidden', errorCode }, 403, corsHeaders);
       }
       isPro = hasProKey;
     }

--- a/e2e/widget-builder.spec.ts
+++ b/e2e/widget-builder.spec.ts
@@ -644,4 +644,74 @@ test.describe('AI widget builder — PRO tier', () => {
     await expect(modal).not.toBeVisible();
     await expect(page.locator('#panelsGrid .ai-widget-block-pro')).toBeVisible();
   });
+
+  test('health 403 in PRO mode shows widget key guidance instead of PRO key guidance', async ({ page }) => {
+    await page.route('**/widget-agent/health', async (route) => {
+      expect(route.request().headers()['x-widget-key']).toBe(widgetKey);
+      expect(route.request().headers()['x-pro-key']).toBe(proWidgetKey);
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: false,
+          agentEnabled: true,
+          widgetKeyConfigured: true,
+          anthropicConfigured: true,
+          proKeyConfigured: true,
+          error: 'Forbidden',
+          errorCode: 'invalid_widget_key',
+        }),
+      });
+    });
+
+    await page.goto('/');
+    await expect(page.locator('#panelsGrid .ai-widget-block-pro')).toBeVisible({ timeout: 30000 });
+    await page.locator('#panelsGrid .ai-widget-block-pro').click();
+
+    const modal = page.locator('.widget-chat-modal');
+    await expect(modal).toBeVisible();
+    await expect(modal.locator('.widget-chat-readiness')).toContainText('Widget key rejected', { timeout: 15000 });
+    await expect(modal.locator('.widget-chat-readiness')).not.toContainText('PRO key rejected');
+    await expect(modal.locator('.widget-chat-send')).toBeDisabled();
+  });
+
+  test('POST 403 with invalid_pro_key shows PRO key guidance on generation failure', async ({ page }) => {
+    await page.route('**/widget-agent/health', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ok: true,
+          agentEnabled: true,
+          widgetKeyConfigured: true,
+          anthropicConfigured: true,
+          proKeyConfigured: true,
+        }),
+      });
+    });
+
+    await page.route('**/widget-agent', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 403,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Forbidden', errorCode: 'invalid_pro_key' }),
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.goto('/');
+    await expect(page.locator('#panelsGrid .ai-widget-block-pro')).toBeVisible({ timeout: 30000 });
+    await page.locator('#panelsGrid .ai-widget-block-pro').click();
+
+    const modal = page.locator('.widget-chat-modal');
+    await expect(modal.locator('.widget-chat-readiness')).toContainText('Connected', { timeout: 15000 });
+    await modal.locator('.widget-chat-input').fill('Interactive oil gold chart');
+    await modal.locator('.widget-chat-send').click();
+
+    await expect(modal.locator('.widget-chat-messages')).toContainText('PRO key rejected', { timeout: 15000 });
+    await expect(modal.locator('.widget-chat-messages')).not.toContainText('Widget key rejected');
+  });
 });

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -13367,7 +13367,10 @@ function requireWidgetAgentAccess(req, res) {
   const hasValidWidgetKey = Boolean(status.widgetKeyConfigured && providedKey && safeTokenEquals(providedKey, WIDGET_AGENT_KEY));
   const hasValidProKey = Boolean(status.proKeyConfigured && providedProKey && safeTokenEquals(providedProKey, PRO_WIDGET_KEY));
   if (!hasValidWidgetKey && !hasValidProKey) {
-    safeEnd(res, 403, { 'Content-Type': 'application/json' }, JSON.stringify({ ...status, error: 'Forbidden' }));
+    const errorCode = !status.widgetKeyConfigured && status.proKeyConfigured
+      ? 'invalid_pro_key'
+      : 'invalid_widget_key';
+    safeEnd(res, 403, { 'Content-Type': 'application/json' }, JSON.stringify({ ...status, error: 'Forbidden', errorCode }));
     return null;
   }
 
@@ -13445,7 +13448,7 @@ async function handleWidgetAgentRequest(req, res) {
     if (status.admittedAs !== 'pro') {
       const providedProKey = getWidgetAgentProvidedProKey(req);
       if (!providedProKey || !safeTokenEquals(providedProKey, PRO_WIDGET_KEY)) {
-        return safeEnd(res, 403, { 'Content-Type': 'application/json' }, JSON.stringify({ error: 'Forbidden' }));
+        return safeEnd(res, 403, { 'Content-Type': 'application/json' }, JSON.stringify({ ...status, error: 'Forbidden', errorCode: 'invalid_pro_key' }));
       }
     }
   }

--- a/src/components/WidgetChatModal.ts
+++ b/src/components/WidgetChatModal.ts
@@ -30,6 +30,7 @@ type WidgetAgentHealth = {
   widgetKeyConfigured?: boolean;
   anthropicConfigured?: boolean;
   proKeyConfigured?: boolean;
+  errorCode?: 'invalid_widget_key' | 'invalid_pro_key';
   error?: string;
 };
 
@@ -202,8 +203,7 @@ export function openWidgetChatModal(options: WidgetChatOptions): void {
       const requestUserId = requestAuthState.user?.id ?? null;
       const requestBelief = readClientEntitlementBelief(requestAuthState);
       const res = await fetch(widgetAgentHealthUrl(), { headers: auth.headers });
-      let payload: WidgetAgentHealth | null = null;
-      try { payload = await res.json() as WidgetAgentHealth; } catch { /* ignore */ }
+      const payload = await parseWidgetAgentJson(res);
 
       if (!res.ok) {
         const message = resolvePreflightMessage(
@@ -305,8 +305,7 @@ export function openWidgetChatModal(options: WidgetChatOptions): void {
       });
 
       if (!res.ok) {
-        let payload: WidgetAgentHealth | null = null;
-        try { payload = await res.json() as WidgetAgentHealth; } catch { /* ignore */ }
+        const payload = await parseWidgetAgentJson(res);
         reportWidgetEntitlementDesync(
           res.status,
           payload,
@@ -314,7 +313,14 @@ export function openWidgetChatModal(options: WidgetChatOptions): void {
           requestBelief,
           requestUserId,
         );
-        throw new Error(t('widgets.serverError', { status: res.status }));
+        throw new Error(resolveRequestErrorMessage(
+          res.status,
+          payload,
+          isPro,
+          auth.usedTesterKey,
+          requestBelief,
+          requestUserId,
+        ));
       }
       if (!res.body) {
         throw new Error(t('widgets.serverError', { status: res.status }));
@@ -452,6 +458,41 @@ function renderExampleChips(container: HTMLElement, inputEl: HTMLTextAreaElement
   }
 }
 
+async function parseWidgetAgentJson(res: Response): Promise<WidgetAgentHealth | null> {
+  try {
+    return await res.json() as WidgetAgentHealth;
+  } catch {
+    return null;
+  }
+}
+
+function resolveWidgetAgentFailureMessage(
+  status: number,
+  payload: WidgetAgentHealth | null,
+  isPro: boolean,
+  usedTesterKey: boolean,
+  requestBelief: ClientEntitlementBelief,
+  requestUserId: string | null,
+): string | null {
+  if (status === 403) {
+    if (payload?.errorCode === 'invalid_pro_key') {
+      return t('widgets.preflightInvalidProKey');
+    }
+    if (payload?.errorCode === 'invalid_widget_key') {
+      return t('widgets.preflightInvalidKey');
+    }
+    // Tester-key path without structured errorCode: branch on tier.
+    if (usedTesterKey) {
+      return isPro ? t('widgets.preflightInvalidProKey') : t('widgets.preflightInvalidKey');
+    }
+    reportWidgetEntitlementDesync(status, payload, usedTesterKey, requestBelief, requestUserId);
+    return isPro ? t('widgets.preflightProSubscriptionRequired') : t('widgets.preflightProRequired');
+  }
+  if (status === 503 && payload?.proKeyConfigured === false) return t('widgets.preflightProUnavailable');
+  if (payload?.anthropicConfigured === false) return t('widgets.preflightAiUnavailable');
+  return null;
+}
+
 function resolvePreflightMessage(
   status: number,
   payload: WidgetAgentHealth | null,
@@ -460,25 +501,36 @@ function resolvePreflightMessage(
   requestBelief: ClientEntitlementBelief,
   requestUserId: string | null,
 ): string {
-  if (status === 403) {
-    // Tester-key path: tell the operator to update the wm-*-key they actually have.
-    if (usedTesterKey) return isPro ? t('widgets.preflightInvalidProKey') : t('widgets.preflightInvalidKey');
-    reportWidgetEntitlementDesync(status, payload, usedTesterKey, requestBelief, requestUserId);
-    // Clerk-auth copy stays keyed to the requested widget tier. Telemetry above
-    // separately classifies the account belief so the two concepts cannot be
-    // conflated.
-    //   isPro=true  — the modal requested a Pro widget; a 403 means either
-    //                 (a) they just upgraded (entitlement still propagating)
-    //                 or (b) the entitlement service is degraded. Tell them to
-    //                 refresh / contact support.
-    //   isPro=false — a free user reached a Pro action; "contact support" is
-    //                 wrong, they need to upgrade. Surface a clean upgrade ask
-    //                 without the "just upgraded" language.
-    return isPro ? t('widgets.preflightProSubscriptionRequired') : t('widgets.preflightProRequired');
-  }
-  if (status === 503 && payload?.proKeyConfigured === false) return t('widgets.preflightProUnavailable');
-  if (payload?.anthropicConfigured === false) return t('widgets.preflightAiUnavailable');
+  const message = resolveWidgetAgentFailureMessage(
+    status,
+    payload,
+    isPro,
+    usedTesterKey,
+    requestBelief,
+    requestUserId,
+  );
+  if (message) return message;
   return t('widgets.preflightUnavailable');
+}
+
+function resolveRequestErrorMessage(
+  status: number,
+  payload: WidgetAgentHealth | null,
+  isPro: boolean,
+  usedTesterKey: boolean,
+  requestBelief: ClientEntitlementBelief,
+  requestUserId: string | null,
+): string {
+  const message = resolveWidgetAgentFailureMessage(
+    status,
+    payload,
+    isPro,
+    usedTesterKey,
+    requestBelief,
+    requestUserId,
+  );
+  if (message) return message;
+  return t('widgets.serverError', { status });
 }
 
 function setReadinessState(container: HTMLElement, tone: 'checking' | 'ready' | 'error', text: string): void {

--- a/tests/widget-agent-auth.test.mts
+++ b/tests/widget-agent-auth.test.mts
@@ -188,8 +188,9 @@ describe('widget-agent unified tester key auth', () => {
     assert.equal(res.status, 403);
     assert.equal(fetchMock.mock.calls.length, 0);
 
-    const body = await res.json() as { error: string };
+    const body = await res.json() as { error: string; errorCode?: string };
     assert.equal(body.error, 'Forbidden');
+    assert.equal(body.errorCode, 'invalid_widget_key');
   });
 
   it('rejects prefix and length mismatches for browser and legacy tester keys', async () => {

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -84,7 +84,7 @@ describe('widget-agent relay — security', () => {
   it('widget-key auth 403 includes invalid_widget_key error code', () => {
     const gateIdx = relay.indexOf('function requireWidgetAgentAccess');
     assert.ok(gateIdx !== -1, 'requireWidgetAgentAccess must be defined');
-    const region = relay.slice(gateIdx, gateIdx + 800);
+    const region = relay.slice(gateIdx, gateIdx + 1500);
     assert.ok(
       region.includes("'invalid_widget_key'") || region.includes('"invalid_widget_key"'),
       'Widget-key 403 responses must identify the invalid widget key cause',
@@ -2311,14 +2311,14 @@ describe('WidgetChatModal — preflight 403 message branches on auth mode', () =
   });
 
   it('resolvePreflightMessage takes usedTesterKey and branches Clerk path on isPro', () => {
-    const fnIdx = modal.indexOf('function resolvePreflightMessage');
-    assert.ok(fnIdx !== -1, 'resolvePreflightMessage not found');
-    const fnEnd = modal.indexOf('\nfunction setReadinessState', fnIdx);
-    assert.ok(fnEnd !== -1, 'resolvePreflightMessage boundary not found');
+    const fnIdx = modal.indexOf('function resolveWidgetAgentFailureMessage');
+    assert.ok(fnIdx !== -1, 'resolveWidgetAgentFailureMessage not found');
+    const fnEnd = modal.indexOf('\nfunction resolvePreflightMessage', fnIdx);
+    assert.ok(fnEnd !== -1, 'resolveWidgetAgentFailureMessage boundary not found');
     const region = modal.slice(fnIdx, fnEnd);
     assert.ok(
       region.includes('usedTesterKey'),
-      'resolvePreflightMessage must take usedTesterKey to branch on auth mode',
+      'resolveWidgetAgentFailureMessage must take usedTesterKey to branch on auth mode',
     );
     assert.ok(
       region.includes('preflightProSubscriptionRequired'),

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -81,6 +81,24 @@ describe('widget-agent relay — security', () => {
     assert.ok(authCheckIdx < sseHeaderIdx, 'Auth check must come before SSE headers');
   });
 
+  it('widget-key auth 403 includes invalid_widget_key error code', () => {
+    const gateIdx = relay.indexOf('function requireWidgetAgentAccess');
+    assert.ok(gateIdx !== -1, 'requireWidgetAgentAccess must be defined');
+    const region = relay.slice(gateIdx, gateIdx + 800);
+    assert.ok(
+      region.includes("'invalid_widget_key'") || region.includes('"invalid_widget_key"'),
+      'Widget-key 403 responses must identify the invalid widget key cause',
+    );
+    assert.ok(
+      region.includes('!status.widgetKeyConfigured && status.proKeyConfigured'),
+      'PRO-only deployments must branch to invalid_pro_key',
+    );
+    assert.ok(
+      region.includes("'invalid_pro_key'") || region.includes('"invalid_pro_key"'),
+      'PRO-only gate 403 must emit invalid_pro_key',
+    );
+  });
+
   it('body size limit is enforced (160KB for PRO, covers basic too)', () => {
     assert.ok(
       relay.includes('163840'),
@@ -1014,6 +1032,7 @@ describe('PRO widget — relay auth and configuration', () => {
     assert.ok(keyCompareIdx !== -1, 'PRO key comparison must be present');
     const region = relay.slice(keyCompareIdx, keyCompareIdx + 200);
     assert.ok(region.includes('403'), 'Wrong PRO key must return 403');
+    assert.ok(region.includes('invalid_pro_key'), 'Wrong PRO key must return an invalid_pro_key error code');
   });
 
   it('invalid tier value rejected with 400', () => {
@@ -1817,6 +1836,40 @@ describe('PRO widget — modal and layout integration', () => {
     assert.ok(
       modal.includes('proKeyConfigured') || modal.includes('preflightProUnavailable'),
       'Modal must handle proKeyConfigured=false from health endpoint',
+    );
+  });
+
+  it('modal treats preflight 403 as a widget key failure even in PRO mode', () => {
+    const resolverIdx = modal.indexOf('function resolveWidgetAgentFailureMessage');
+    assert.ok(resolverIdx !== -1, 'Modal must define resolveWidgetAgentFailureMessage');
+    const resolverRegion = modal.slice(resolverIdx, resolverIdx + 500);
+    assert.ok(
+      resolverRegion.includes("status === 403") && resolverRegion.includes("preflightInvalidKey"),
+      'Preflight 403 must map to the widget key guidance',
+    );
+  });
+
+  it('modal maps invalid_pro_key failures to PRO key guidance', () => {
+    const resolverIdx = modal.indexOf('function resolveWidgetAgentFailureMessage');
+    assert.ok(resolverIdx !== -1, 'Modal must define resolveWidgetAgentFailureMessage');
+    const resolverRegion = modal.slice(resolverIdx, resolverIdx + 500);
+    assert.ok(
+      resolverRegion.includes("invalid_pro_key") && resolverRegion.includes('preflightInvalidProKey'),
+      'Modal must surface PRO key guidance when the relay reports invalid_pro_key',
+    );
+  });
+
+  it('modal parses JSON request errors before falling back to generic serverError', () => {
+    const submitFetchIdx = modal.indexOf('fetch(widgetAgentUrl()');
+    assert.ok(submitFetchIdx !== -1, 'Modal must POST to widget-agent');
+    const submitErrorRegion = modal.slice(submitFetchIdx, submitFetchIdx + 600);
+    assert.ok(
+      submitErrorRegion.includes('if (!res.ok)'),
+      'Modal must check non-OK widget-agent responses',
+    );
+    assert.ok(
+      submitErrorRegion.includes('parseWidgetAgentJson') && submitErrorRegion.includes('resolveRequestErrorMessage'),
+      'Modal must inspect JSON error payloads before falling back to generic server errors',
     );
   });
 


### PR DESCRIPTION
## Summary

Fix misleading auth error messaging in the widget builder for PRO mode. A `403` from `/widget-agent/health` now correctly points users to `wm-widget-key`, and widget generation errors now distinguish invalid widget keys from invalid PRO keys.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Other: Widget builder modal / widget relay auth

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

