### PR TITLE
fix(health): marketImplications EMPTY → WARN not CRIT

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -186,6 +186,7 @@ const ON_DEMAND_KEYS = new Set([
   'corridorrisk', // intermediate key; data flows through transit-summaries:v1
   'serviceStatuses', // RPC-populated; seed-meta written on fresh fetch only, goes stale between visits
   'militaryForecastInputs', // intermediate seed-to-seed pipeline key; only populated after seed-military-flights runs
+  'marketImplications', // LLM-generated inside forecast cron; can fail silently on LLM errors — degrade to WARN not CRIT
 ]);
 
 // Keys where 0 records is a valid healthy state (e.g. no airports closed).


### PR DESCRIPTION
## Why this PR?

After PR #2165 (AI Market Implications) merged, health has been returning 503 because `marketImplications` is in `STANDALONE_KEYS` but not in `ON_DEMAND_KEYS`. For non-ON_DEMAND standalone keys, `EMPTY` increments `critCount` → health returns 503.

## Root cause

The `intelligence:market-implications:v1` key is **LLM-generated** inside `buildAndSeedMarketImplications()` at the tail of the `seed-forecasts` cron. If the LLM call fails (silently caught), the 75min TTL key expires and health returns 503 for the next ~7 hours until the next successful write.

This is the wrong severity: LLM-generated signal data should degrade gracefully, not take down the uptime monitor.

## Fix

Add `marketImplications` to `ON_DEMAND_KEYS`. Semantics: `EMPTY_ON_DEMAND` = WARN not CRIT. The key will still show STALE_SEED (WARN) when `seedAgeMin > maxStaleMin: 150` so freshness is still tracked.

## Test plan
- [ ] Confirm `/api/health` returns 200 after deploy even while key is empty
- [ ] Confirm `marketImplications` shows `EMPTY_ON_DEMAND` in health check output