### PR TITLE
fix(panels): show PRO badge on all premium panel headers (web + desktop)

### DIFF
--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -250,7 +250,7 @@ export class Panel {
       headerLeft.appendChild(this.newBadgeEl);
     }
 
-    if (isDesktopRuntime() && options.premium === 'enhanced' && !getSecretState('WORLDMONITOR_API_KEY').present) {
+    if (options.premium && !getSecretState('WORLDMONITOR_API_KEY').present) {
       const proBadge = h('span', { className: 'panel-pro-badge' }, t('premium.pro'));
       headerLeft.appendChild(proBadge);
     }


### PR DESCRIPTION
PRO badge was only rendered on desktop for premium=enhanced panels. Removed isDesktopRuntime() and enhanced-only restrictions so any panel with a premium field shows the PRO badge in its header — both for PRO users (reinforcing value) and free users (upgrade nudge).