### PR TITLE
fix(styling): align MarketImplications and StockAnalysis with design system

### DIFF
--- a/src/components/MarketImplicationsPanel.ts
+++ b/src/components/MarketImplicationsPanel.ts
@@ -6,36 +6,41 @@ import type { MarketImplicationCard, MarketImplicationsData } from '@/services/m
 
 const DISCLAIMER = 'AI-generated trade signals for informational purposes only. Not investment advice. Always do your own research.';
 
-function directionStyle(dir: string): { color: string; label: string } {
+function directionClass(dir: string): string {
   const d = dir.toUpperCase();
-  if (d === 'LONG') return { color: '#8df0b2', label: 'LONG' };
-  if (d === 'SHORT') return { color: '#ff8c8c', label: 'SHORT' };
-  return { color: '#f4d06f', label: 'HEDGE' };
+  if (d === 'LONG') return 'badge-bullish';
+  if (d === 'SHORT') return 'badge-bearish';
+  return 'badge-neutral';
 }
 
-function confidenceColor(conf: string): string {
+function confidenceClass(conf: string): string {
   const c = conf.toUpperCase();
-  if (c === 'HIGH') return '#8df0b2';
-  if (c === 'LOW') return '#ff8c8c';
-  return '#f4d06f';
+  if (c === 'HIGH') return 'badge-bullish';
+  if (c === 'LOW') return 'badge-bearish';
+  return 'badge-neutral';
+}
+
+function directionLabel(dir: string): string {
+  const d = dir.toUpperCase();
+  if (d === 'LONG') return 'LONG';
+  if (d === 'SHORT') return 'SHORT';
+  return 'HEDGE';
 }
 
 function renderCard(card: MarketImplicationCard): string {
-  const dir = directionStyle(card.direction);
-  const confColor = confidenceColor(card.confidence);
   return `
-    <div style="border:1px solid var(--border);background:rgba(255,255,255,0.03);padding:14px;display:flex;flex-direction:column;gap:10px">
-      <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
-        <span style="font-size:12px;padding:3px 8px;border:1px solid ${dir.color};color:${dir.color};font-family:var(--font-mono);text-transform:uppercase;letter-spacing:0.08em;font-weight:700">${dir.label}</span>
-        <strong style="font-size:15px;letter-spacing:-0.02em">${escapeHtml(card.ticker)}</strong>
+    <div class="signal-card">
+      <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:8px">
+        <span class="signal-badge ${directionClass(card.direction)}">${directionLabel(card.direction)}</span>
+        <strong style="font-size:14px;letter-spacing:-0.02em">${escapeHtml(card.ticker)}</strong>
         ${card.name ? `<span style="font-size:11px;color:var(--text-dim)">${escapeHtml(card.name)}</span>` : ''}
-        ${card.timeframe ? `<span style="font-size:11px;padding:2px 6px;border:1px solid var(--border);color:var(--text-dim);font-family:var(--font-mono)">${escapeHtml(card.timeframe)}</span>` : ''}
-        ${card.confidence ? `<span style="font-size:11px;padding:2px 6px;border:1px solid ${confColor};color:${confColor};font-family:var(--font-mono);text-transform:uppercase">${escapeHtml(card.confidence)}</span>` : ''}
+        ${card.timeframe ? `<span class="signal-badge badge-neutral" style="font-family:var(--font-mono)">${escapeHtml(card.timeframe)}</span>` : ''}
+        ${card.confidence ? `<span class="signal-badge ${confidenceClass(card.confidence)}">${escapeHtml(card.confidence)}</span>` : ''}
       </div>
-      <div style="font-size:13px;font-weight:600;line-height:1.4">${escapeHtml(card.title)}</div>
-      <div style="font-size:12px;line-height:1.55;color:var(--text)">${escapeHtml(card.narrative)}</div>
-      ${card.driver ? `<div style="font-size:11px;color:var(--text-dim)"><span style="text-transform:uppercase;letter-spacing:0.06em">Driver:</span> ${escapeHtml(card.driver)}</div>` : ''}
-      ${card.riskCaveat ? `<div style="font-size:11px;color:#f4d06f;padding:6px 8px;border:1px solid rgba(244,208,111,0.3);background:rgba(244,208,111,0.06)">${escapeHtml(card.riskCaveat)}</div>` : ''}
+      <div style="font-size:13px;font-weight:600;line-height:1.4;margin-bottom:6px">${escapeHtml(card.title)}</div>
+      <div style="font-size:12px;line-height:1.55;color:var(--text-dim)">${escapeHtml(card.narrative)}</div>
+      ${card.driver ? `<div style="font-size:11px;color:var(--text-dim);margin-top:6px"><span style="text-transform:uppercase;letter-spacing:0.06em">Driver:</span> ${escapeHtml(card.driver)}</div>` : ''}
+      ${card.riskCaveat ? `<div style="font-size:11px;color:var(--yellow);padding:6px 8px;border:1px solid color-mix(in srgb,var(--yellow) 30%,transparent);background:color-mix(in srgb,var(--yellow) 8%,transparent);margin-top:6px">${escapeHtml(card.riskCaveat)}</div>` : ''}
     </div>
   `;
 }
@@ -61,7 +66,7 @@ export class MarketImplicationsPanel extends Panel {
     this.resetRetryBackoff();
 
     const html = `
-      <div style="display:flex;flex-direction:column;gap:12px">
+      <div style="display:flex;flex-direction:column;gap:10px">
         <div style="font-size:12px;color:var(--text-dim);line-height:1.5">
           LLM-generated trade signals derived from live geopolitical, commodity, and market state. Updated each forecast cycle.
         </div>
@@ -76,10 +81,7 @@ export class MarketImplicationsPanel extends Panel {
   public showUnavailable(message = 'AI market implications are generated after each forecast run. Check back shortly.'): void {
     this.setDataBadge('unavailable');
     const html = `
-      <div style="display:flex;flex-direction:column;gap:12px">
-        <div style="font-size:12px;color:var(--text-dim);line-height:1.5;padding:16px 0;text-align:center">${escapeHtml(message)}</div>
-        <div style="font-size:10px;color:var(--text-dim);padding:8px;border-top:1px solid var(--border);line-height:1.5;text-align:center">${escapeHtml(DISCLAIMER)}</div>
-      </div>
+      <div style="font-size:12px;color:var(--text-dim);line-height:1.5;padding:16px 0;text-align:center">${escapeHtml(message)}</div>
     `;
     this.setContent(html);
   }

--- a/src/components/StockAnalysisPanel.ts
+++ b/src/components/StockAnalysisPanel.ts
@@ -15,16 +15,16 @@ function formatPrice(price: number, currency: string): string {
   return `${currency === 'USD' ? '$' : ''}${price.toFixed(2)}${currency && currency !== 'USD' ? ` ${currency}` : ''}`;
 }
 
-function stockSignalTone(signal: string): string {
+function stockSignalClass(signal: string): string {
   const normalized = signal.toLowerCase();
-  if (normalized.includes('buy')) return '#8df0b2';
-  if (normalized.includes('hold') || normalized.includes('watch')) return '#f4d06f';
-  return '#ff8c8c';
+  if (normalized.includes('buy')) return 'badge-bullish';
+  if (normalized.includes('hold') || normalized.includes('watch')) return 'badge-neutral';
+  return 'badge-bearish';
 }
 
-function list(items: string[], tone: string): string {
+function list(items: string[], cssClass: string): string {
   if (items.length === 0) return '';
-  return `<ul style="margin:8px 0 0;padding-left:18px;color:${tone};font-size:12px;line-height:1.5">${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`;
+  return `<ul class="${cssClass}" style="margin:8px 0 0;padding-left:18px;font-size:12px;line-height:1.5">${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`;
 }
 
 export class StockAnalysisPanel extends Panel {
@@ -54,7 +54,7 @@ export class StockAnalysisPanel extends Panel {
   }
 
   private renderCard(item: StockAnalysisResult, history: StockAnalysisResult[]): string {
-    const tone = stockSignalTone(item.signal);
+    const tone = stockSignalClass(item.signal);
     const priorRuns = history.filter((entry) => entry.generatedAt !== item.generatedAt).slice(0, 3);
     const previous = priorRuns[0];
     const signalDelta = previous ? item.signalScore - previous.signalScore : null;
@@ -66,26 +66,26 @@ export class StockAnalysisPanel extends Panel {
     }).join('');
 
     return `
-      <section style="border:1px solid var(--border);background:rgba(255,255,255,0.03);padding:14px;display:flex;flex-direction:column;gap:10px">
+      <section class="signal-card" style="padding:14px;display:flex;flex-direction:column;gap:10px">
         <div style="display:flex;justify-content:space-between;gap:12px;align-items:flex-start">
           <div>
             <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
               <strong style="font-size:16px;letter-spacing:-0.02em">${escapeHtml(item.name || item.symbol)}</strong>
               <span style="font-size:11px;color:var(--text-dim);font-family:var(--font-mono);text-transform:uppercase">${escapeHtml(item.display || item.symbol)}</span>
-              <span style="font-size:11px;padding:3px 6px;border:1px solid ${tone};color:${tone};font-family:var(--font-mono);text-transform:uppercase;letter-spacing:0.08em">${escapeHtml(item.signal)}</span>
+              <span class="signal-badge ${tone}" style="font-family:var(--font-mono)">${escapeHtml(item.signal)}</span>
             </div>
             <div style="margin-top:6px;font-size:12px;color:var(--text-dim);line-height:1.5">${escapeHtml(item.summary)}</div>
           </div>
           <div style="text-align:right;min-width:110px">
             <div style="font-size:18px;font-weight:700">${escapeHtml(formatPrice(item.currentPrice, item.currency))}</div>
-            <div style="font-size:12px;color:${item.changePercent >= 0 ? '#8df0b2' : '#ff8c8c'}">${escapeHtml(formatChange(item.changePercent))}</div>
+            <div style="font-size:12px;color:${item.changePercent >= 0 ? 'var(--semantic-normal)' : 'var(--semantic-critical)'}">${escapeHtml(formatChange(item.changePercent))}</div>
             <div style="margin-top:6px;font-size:11px;color:var(--text-dim)">Score ${escapeHtml(String(item.signalScore))} · ${escapeHtml(item.confidence)}</div>
           </div>
           ${history.length >= 2 ? (() => {
             const scores = history.slice(0, 6).reverse().map(e => e.signalScore);
             const last = scores[scores.length - 1] ?? 0;
             const prev = scores[scores.length - 2] ?? last;
-            return sparkline(scores, last >= prev ? '#8df0b2' : '#ff8c8c', 60, 20, 'display:block;margin-top:4px;align-self:flex-end');
+            return sparkline(scores, last >= prev ? 'var(--semantic-normal)' : 'var(--semantic-critical)', 60, 20, 'display:block;margin-top:4px;align-self:flex-end');
           })() : ''}
         </div>
         <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(110px,1fr));gap:8px;font-size:11px">
@@ -98,11 +98,11 @@ export class StockAnalysisPanel extends Panel {
         <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px">
           <div>
             <div style="font-size:11px;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-dim)">Bullish Factors</div>
-            ${list(item.bullishFactors.slice(0, 3), '#8df0b2')}
+            ${list(item.bullishFactors.slice(0, 3), 'badge-bullish')}
           </div>
           <div>
             <div style="font-size:11px;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-dim)">Risk Factors</div>
-            ${list(item.riskFactors.slice(0, 3), '#ffb0b0')}
+            ${list(item.riskFactors.slice(0, 3), 'badge-bearish')}
           </div>
         </div>
         <div style="font-size:12px;line-height:1.55;color:var(--text-dim)">


### PR DESCRIPTION
Both panels were using hardcoded hex colors (#8df0b2, #ff8c8c, #f4d06f) and hardcoded rgba values instead of CSS variables, breaking light mode and diverging from the design system.

**MarketImplicationsPanel:**
- LONG/SHORT/HEDGE and confidence badges now use shared signal-badge + badge-bullish/badge-bearish/badge-neutral CSS classes
- Card wrapper uses signal-card class (border-radius: 6px, overlay-subtle background, hover state)
- Risk caveat uses var(--yellow) + color-mix() for border/background instead of hardcoded rgba

**StockAnalysisPanel:**
- Signal badge (BUY/WATCH/SELL) uses signal-badge + badge-* classes
- Card wrapper uses signal-card class
- Change percent color uses var(--semantic-normal) / var(--semantic-critical)
- Sparkline color uses same semantic variables
- Bullish/risk factor lists use badge-bullish / badge-bearish CSS classes for color