### PR TITLE
fix(settings): show PRO badge on entitled panels for PRO users

### DIFF
--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -366,7 +366,7 @@ export class UnifiedSettings {
         <div class="panel-toggle-item ${panel.enabled && !locked ? 'active' : ''}${changed ? ' changed' : ''}${locked ? ' pro-locked' : ''}" data-panel="${escapeHtml(key)}" aria-pressed="${panel.enabled && !locked}" ${locked ? 'data-pro-locked="1"' : ''}>
           <div class="panel-toggle-checkbox">${panel.enabled && !locked ? '\u2713' : ''}${locked ? '\uD83D\uDD12' : ''}</div>
           <span class="panel-toggle-label">${escapeHtml(displayName)}</span>
-          ${locked ? '<span class="panel-toggle-pro-badge">PRO</span>' : ''}
+          ${(locked || (ALL_PANELS[key] ?? panel).premium) ? '<span class="panel-toggle-pro-badge">PRO</span>' : ''}
         </div>
       `;
     }).join('');


### PR DESCRIPTION
PRO badge in the panels list was only shown when locked=true. PRO users saw their entitled PRO panels as plain checkboxes with no differentiation. Now shows the badge whenever the panel config has a premium field, regardless of locked state — lock icon for free users, checkmark+PRO for entitled PRO users.