### PR TITLE
fix(panels): PRO badge on all locked panel headers + settings for PRO users

### DIFF
--- a/src/components/DailyMarketBriefPanel.ts
+++ b/src/components/DailyMarketBriefPanel.ts
@@ -40,7 +40,7 @@ function formatChange(change: number | null): string {
 
 export class DailyMarketBriefPanel extends Panel {
   constructor() {
-    super({ id: 'daily-market-brief', title: 'Daily Market Brief', infoTooltip: t('components.dailyMarketBrief.infoTooltip') });
+    super({ id: 'daily-market-brief', title: 'Daily Market Brief', infoTooltip: t('components.dailyMarketBrief.infoTooltip'), premium: 'locked' });
   }
 
   public renderBrief(brief: DailyMarketBrief, source: BriefSource = 'live'): void {

--- a/src/components/StockAnalysisPanel.ts
+++ b/src/components/StockAnalysisPanel.ts
@@ -29,7 +29,7 @@ function list(items: string[], cssClass: string): string {
 
 export class StockAnalysisPanel extends Panel {
   constructor() {
-    super({ id: 'stock-analysis', title: 'Premium Stock Analysis', infoTooltip: t('components.stockAnalysis.infoTooltip') });
+    super({ id: 'stock-analysis', title: 'Premium Stock Analysis', infoTooltip: t('components.stockAnalysis.infoTooltip'), premium: 'locked' });
   }
 
   public renderAnalyses(items: StockAnalysisResult[], historyBySymbol: StockAnalysisHistory = {}, source: 'live' | 'cached' = 'live'): void {

--- a/src/components/StockBacktestPanel.ts
+++ b/src/components/StockBacktestPanel.ts
@@ -16,7 +16,7 @@ function fmtPct(value: number): string {
 
 export class StockBacktestPanel extends Panel {
   constructor() {
-    super({ id: 'stock-backtest', title: 'Premium Backtesting', infoTooltip: t('components.stockBacktest.infoTooltip') });
+    super({ id: 'stock-backtest', title: 'Premium Backtesting', infoTooltip: t('components.stockBacktest.infoTooltip'), premium: 'locked' });
   }
 
   public renderBacktests(items: StockBacktestResult[], source: 'live' | 'cached' = 'live'): void {

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -366,7 +366,7 @@ export class UnifiedSettings {
         <div class="panel-toggle-item ${panel.enabled && !locked ? 'active' : ''}${changed ? ' changed' : ''}${locked ? ' pro-locked' : ''}" data-panel="${escapeHtml(key)}" aria-pressed="${panel.enabled && !locked}" ${locked ? 'data-pro-locked="1"' : ''}>
           <div class="panel-toggle-checkbox">${panel.enabled && !locked ? '\u2713' : ''}${locked ? '\uD83D\uDD12' : ''}</div>
           <span class="panel-toggle-label">${escapeHtml(displayName)}</span>
-          ${locked ? '<span class="panel-toggle-pro-badge">PRO</span>' : ''}
+          ${(locked || (ALL_PANELS[key] ?? panel).premium) ? '<span class="panel-toggle-pro-badge">PRO</span>' : ''}
         </div>
       `;
     }).join('');


### PR DESCRIPTION
## Why this PR?

PRO badge was only visible in the AI Market Implications panel header. Premium Stock Analysis, Premium Backtesting, and Daily Market Brief were missing it — PRO users had no visual signal that these were PRO panels.

Also, in settings, the PRO badge only appeared on panels that were *locked* (free user view). Entitled PRO users saw no PRO badge on their accessible PRO panels.

## Changes

- Add `premium: 'locked'` to `StockAnalysisPanel`, `StockBacktestPanel`, and `DailyMarketBriefPanel` constructors — `Panel.ts` renders the badge in the header only when `options.premium` is set
- `UnifiedSettings.ts`: show PRO badge for any panel with `premium` field, regardless of entitlement — PRO users now see the badge on panels they can use, free users see it on locked panels

## Verification

- Free user: 4 PRO panels show lock icon + PRO badge in settings, locked state in panel header
- PRO user: 4 PRO panels show PRO badge in settings (no lock), PRO badge in panel header
- 2255 tests pass, tsc clean