### PR TITLE
fix(fear-greed): mark breadth as degraded when ^MMTH unavailable (404)

### DIFF
--- a/scripts/seed-fear-greed.mjs
+++ b/scripts/seed-fear-greed.mjs
@@ -66,13 +66,13 @@ async function fetchBarchartS5TH() {
       headers: { 'User-Agent': CHROME_UA, Accept: 'text/html,application/xhtml+xml' },
       signal: AbortSignal.timeout(10_000),
     });
-    if (!resp.ok) return null;
+    if (!resp.ok) { console.warn(`  Barchart $S5TH: HTTP ${resp.status}`); return null; }
     const html = await resp.text();
     const block = html.match(/<script id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/)?.[1] ?? html;
     const m = block.match(/"lastPrice"\s*:\s*"?([\d.]+)"?/);
     const val = m ? parseFloat(m[1]) : NaN;
     return Number.isFinite(val) ? val : null;
-  } catch { return null; }
+  } catch (e) { console.warn('  Barchart $S5TH fetch failed:', e.message); return null; }
 }
 
 // --- CNN Fear & Greed ---
@@ -353,19 +353,10 @@ async function fetchAll() {
   const skewPrice = skew?.price ?? null;
   const sofrRate = fredLatest(sofrObs);
 
-  // pctAbove200dScore: Barchart $S5TH only — used for breadth scoring to avoid
-  // double-counting RSP/SPY (rspScore already captures that signal in scoreCategory).
-  const pctAbove200dScore = barchartResult.status === 'fulfilled' ? barchartResult.value : null;
-
-  // pctAbove200dDisplay: Barchart or RSP/SPY proxy — shown in header metric only.
-  // Proxy: (RSP/mean(RSP)) / (SPY/mean(SPY)) normalized to 0-100 over ±20% band.
-  let pctAbove200dDisplay = pctAbove200dScore;
-  if (pctAbove200dDisplay == null && rsp?.closes?.length >= 20 && spy?.closes?.length >= 20) {
-    const mean = arr => arr.reduce((a, b) => a + b, 0) / arr.length;
-    const rspRatio = rsp.closes.at(-1) / mean(rsp.closes);
-    const spyRatio = spy.closes.at(-1) / mean(spy.closes);
-    if (spyRatio > 0) pctAbove200dDisplay = Math.round(clamp((rspRatio / spyRatio - 0.8) / 0.4 * 100, 0, 100));
-  }
+  // Barchart $S5TH: exact % of S&P 500 above 200d MA.
+  // Used for both breadth scoring and header display. Null → header shows N/A, breadth
+  // defaults to neutral 50 (rspScore still captures RSP/SPY signal independently).
+  const pctAbove200d = barchartResult.status === 'fulfilled' ? barchartResult.value : null;
   const cryptoFg = macro?.fearGreed?.score ?? macro?.signals?.fearGreed?.value ?? null;
 
   let advDecRatio = null;
@@ -378,7 +369,7 @@ async function fetchAll() {
     volatility: scoreCategory('volatility', { vix: vixLive, vix9d: vix9dPrice, vix3m: vix3mPrice }),
     positioning: scoreCategory('positioning', { totalPc: cboe.totalPc, equityPc: cboe.equityPc, skew: skewPrice }),
     trend: scoreCategory('trend', { prices: gspc?.closes ?? [] }),
-    breadth: scoreCategory('breadth', { mmthPrice: pctAbove200dScore, rspCloses: rsp?.closes, spyCloses: spy?.closes, advDecRatio }),
+    breadth: scoreCategory('breadth', { mmthPrice: pctAbove200d, rspCloses: rsp?.closes, spyCloses: spy?.closes, advDecRatio }),
     momentum: scoreCategory('momentum', { spxCloses: gspc?.closes, sectorCloses: { XLK: xlk?.closes, XLF: xlf?.closes, XLE: xle?.closes, XLV: xlv?.closes } }),
     liquidity: scoreCategory('liquidity', { m2Obs, walclObs, sofr: sofrRate }),
     credit: scoreCategory('credit', { hyObs, igObs }),
@@ -417,7 +408,7 @@ async function fetchAll() {
       putCall:  cboe.totalPc != null ? { value: cboe.totalPc } : null,
       vix:      vixLive != null ? { value: vixLive } : null,
       hySpread: hySpreadVal != null ? { value: hySpreadVal } : null,
-      pctAbove200d: pctAbove200dDisplay != null ? { value: pctAbove200dDisplay } : null,
+      pctAbove200d: pctAbove200d != null ? { value: pctAbove200d } : null,
       yield10y: fredLatest(dgs10Obs) != null ? { value: fredLatest(dgs10Obs) } : null,
       fedRate:  fedRateStr ? { value: fedRateStr } : null,
     },


### PR DESCRIPTION
## What

`^MMTH` (% of S&P 500 stocks above 200-day MA) returns HTTP 404 from Yahoo Finance.

The breadth scoring already fell back to neutral 50 when `mmthPrice` is null, but did so silently — no `degraded` flag was propagated, so the panel rendered the breadth category at full confidence despite the missing input.

Confirmed in Railway logs from the first seed run:
```
Yahoo ^MMTH: HTTP 404
```

## Changes

- `scoreCategory('breadth')`: add `degraded: mmthPrice == null` to return
- `payload.categories.breadth`: propagate `degraded: cats.breadth.degraded ?? false` (consistent with `sentiment` which already does this)

## Effect

When `^MMTH` is unavailable, the breadth category bar in the panel now shows the "degraded" badge (orange indicator), making it clear the score is estimated rather than measured.