### PR TITLE
fix(market-implications): load in parallel with daily-brief, add prime + refresh

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -302,6 +302,9 @@ export class App {
       if (shouldPrime('daily-market-brief')) {
         primeTask('dailyMarketBrief', () => this.dataLoader.loadDailyMarketBrief());
       }
+      if (shouldPrime('market-implications')) {
+        primeTask('marketImplications', () => this.dataLoader.loadMarketImplications());
+      }
     }
 
     if (tasks.length > 0) {
@@ -1045,6 +1048,12 @@ export class App {
         () => this.dataLoader.loadStockBacktest(),
         REFRESH_INTERVALS.stockBacktest,
         () => (getSecretState('WORLDMONITOR_API_KEY').present || isProUser()) && this.isPanelNearViewport('stock-backtest'),
+      );
+      this.refreshScheduler.scheduleRefresh(
+        'market-implications',
+        () => this.dataLoader.loadMarketImplications(),
+        REFRESH_INTERVALS.marketImplications,
+        () => (getSecretState('WORLDMONITOR_API_KEY').present || isProUser()) && this.isPanelNearViewport('market-implications'),
       );
     }
 

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -530,8 +530,10 @@ export class DataLoaderManager implements AppModule {
     this.updateSearchIndex();
 
     if (getSecretState('WORLDMONITOR_API_KEY').present || isProUser()) {
-      await this.loadDailyMarketBrief();
-      await this.loadMarketImplications();
+      await Promise.allSettled([
+        this.loadDailyMarketBrief(),
+        this.loadMarketImplications(),
+      ]);
     }
 
     const bootstrapTemporal = consumeServerAnomalies();

--- a/src/config/variants/base.ts
+++ b/src/config/variants/base.ts
@@ -31,6 +31,7 @@ export const REFRESH_INTERVALS = {
   cyberThreats: 10 * 60 * 1000,
   stockAnalysis: 15 * 60 * 1000,
   dailyMarketBrief: 60 * 60 * 1000,
+  marketImplications: 75 * 60 * 1000,
   stockBacktest: 4 * 60 * 60 * 1000,
   serviceStatus: 3 * 60 * 1000,
   stablecoins: 15 * 60 * 1000,


### PR DESCRIPTION
## Why this PR?

Both AI panels showed \"Loading...\" for many seconds. Root causes:

1. **Sequential await bottleneck**: `loadDailyMarketBrief()` was awaited before `loadMarketImplications()`. When Daily Brief needs to generate AI content (first load or daily refresh), the LLM call takes 5–10s and blocked Market Implications from even starting its fast Redis read (~100ms).

2. **market-implications missing from `primeVisiblePanelData`**: Panel never primed on viewport entry — only loaded during the main init flow.

3. **market-implications missing from `scheduleRefresh`**: No periodic refresh in long-lived sessions.

## Changes

- `data-loader.ts`: `Promise.allSettled([loadDailyMarketBrief(), loadMarketImplications()])` — both run in parallel
- `App.ts`: Add `market-implications` to `primeVisiblePanelData` and `scheduleRefresh` (finance variant block, PRO-gated)
- `base.ts`: Add `REFRESH_INTERVALS.marketImplications = 75 * 60 * 1000` (matches seed cadence)

## Result

Market Implications now loads in ~100–200ms (Redis read) regardless of whether Daily Brief is building AI content.