### PR TITLE
fix(health): positiveGeoEvents EMPTY_DATA → OK when events=[]

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -192,7 +192,7 @@ const ON_DEMAND_KEYS = new Set([
 
 // Keys where 0 records is a valid healthy state (e.g. no airports closed).
 // The key must still exist in Redis; only the record count can be 0.
-const EMPTY_DATA_OK_KEYS = new Set(['notamClosures', 'faaDelays', 'gpsjam']);
+const EMPTY_DATA_OK_KEYS = new Set(['notamClosures', 'faaDelays', 'gpsjam', 'positiveGeoEvents']);
 
 // Cascade groups: if any key in the group has data, all empty siblings are OK.
 // Theater posture uses live → stale → backup fallback chain.


### PR DESCRIPTION
## Why this PR?

Health is returning 503 (DEGRADED, crit=1) because `positiveGeoEvents` has `events: []` in Redis. The key exists, was seeded 9min ago, but the seeder found 0 positive events. This is valid — positive events are sparse by nature.

## Root cause

`positiveGeoEvents` is a BOOTSTRAP key not in `EMPTY_DATA_OK_KEYS`. For bootstrap keys, `size === 0` → `EMPTY_DATA` → `critCount++` → 503. Having zero events is no different from having zero NOTAM closures or zero GPSJam anomalies (both already in `EMPTY_DATA_OK_KEYS`).

## Fix

One line: add `positiveGeoEvents` to `EMPTY_DATA_OK_KEYS`. The key must still exist in Redis (proving the seeder ran); only an empty array is accepted as healthy.

## Test plan
- [ ] `/api/health` returns 200 after deploy when events is empty
- [ ] Still shows STALE_SEED (WARN) if seed-meta goes stale