### PR TITLE
fix(fear-greed): route CBOE+CNN through residential proxy, update Chrome UA to 134

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -4,7 +4,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36';
 const MAX_PAYLOAD_BYTES = 5 * 1024 * 1024; // 5MB per key
 
 const __seed_dirname = dirname(fileURLToPath(import.meta.url));

--- a/scripts/seed-fear-greed.mjs
+++ b/scripts/seed-fear-greed.mjs
@@ -1,8 +1,15 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, runSeed, readSeedSnapshot, sleep } from './_seed-utils.mjs';
+import { ProxyAgent, fetch as undiciF } from 'undici';
 
 loadEnvFile(import.meta.url);
+
+const _proxyAuth = process.env.OREF_PROXY_AUTH || '';
+const _proxyAgent = _proxyAuth ? new ProxyAgent(`http://${_proxyAuth}`) : null;
+const fetchViaProxy = _proxyAgent
+  ? (url, opts = {}) => undiciF(url, { ...opts, dispatcher: _proxyAgent })
+  : fetch;
 
 const FEAR_GREED_KEY = 'market:fear-greed:v1';
 const FEAR_GREED_TTL = 64800; // 18h = 3x 6h interval
@@ -44,18 +51,20 @@ async function fetchAllYahoo() {
 
 // --- CBOE P/C ratios ---
 async function fetchCBOE() {
+  const headers = { 'User-Agent': CHROME_UA, Referer: 'https://www.cboe.com/' };
   const [totalResp, equityResp] = await Promise.allSettled([
-    fetch('https://cdn.cboe.com/api/global/us_indices/daily_prices/totalpc.csv', { headers: { 'User-Agent': CHROME_UA }, signal: AbortSignal.timeout(10_000) }),
-    fetch('https://cdn.cboe.com/api/global/us_indices/daily_prices/equitypc.csv', { headers: { 'User-Agent': CHROME_UA }, signal: AbortSignal.timeout(10_000) }),
+    fetchViaProxy('https://cdn.cboe.com/api/global/us_indices/daily_prices/totalpc.csv', { headers, signal: AbortSignal.timeout(10_000) }),
+    fetchViaProxy('https://cdn.cboe.com/api/global/us_indices/daily_prices/equitypc.csv', { headers, signal: AbortSignal.timeout(10_000) }),
   ]);
-  const parseLastValue = async (resp) => {
-    if (resp.status !== 'fulfilled' || !resp.value.ok) return null;
+  const parseLastValue = async (resp, name) => {
+    if (resp.status !== 'fulfilled') return null;
+    if (!resp.value.ok) { console.warn(`  CBOE ${name}: HTTP ${resp.value.status}`); return null; }
     const text = await resp.value.text();
     const lines = text.trim().split('\n').filter(l => l.trim());
     const last = lines.at(-1)?.split(',');
     return last?.length >= 2 ? parseFloat(last[1]) : null;
   };
-  const [totalPc, equityPc] = await Promise.all([parseLastValue(totalResp), parseLastValue(equityResp)]);
+  const [totalPc, equityPc] = await Promise.all([parseLastValue(totalResp, 'totalpc'), parseLastValue(equityResp, 'equitypc')]);
   return { totalPc, equityPc };
 }
 
@@ -79,16 +88,16 @@ async function fetchBarchartS5TH() {
 async function fetchCNN() {
   try {
     const date = new Date().toISOString().slice(0,10).replace(/-/g,'');
-    const resp = await fetch(`https://production.dataviz.cnn.io/index/fearandgreed/graphdata/${date}`, {
-      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+    const resp = await fetchViaProxy(`https://production.dataviz.cnn.io/index/fearandgreed/graphdata/${date}`, {
+      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json', Referer: 'https://www.cnn.com/markets/fear-and-greed' },
       signal: AbortSignal.timeout(8_000),
     });
-    if (!resp.ok) return null;
+    if (!resp.ok) { console.warn(`  CNN F&G: HTTP ${resp.status}`); return null; }
     const data = await resp.json();
     const score = data?.fear_and_greed?.score;
     const rating = data?.fear_and_greed?.rating;
     return score != null ? { score: Math.round(score), label: rating ?? labelFromScore(Math.round(score)) } : null;
-  } catch { return null; }
+  } catch (e) { console.warn(`  CNN F&G: ${e.message}`); return null; }
 }
 
 // --- AAII Sentiment (LOW reliability, always wrapped, non-blocking) ---


### PR DESCRIPTION
## Why this PR?

Fear & Greed panel shows N/A for P/C Ratio and CNN F&G score because both upstream sources block Railway datacenter IPs:

- **CBOE CDN** (`cdn.cboe.com`) returns **HTTP 403** to Railway's datacenter IPs
- **CNN dataviz** returns **HTTP 418** (I'm a teapot — bot detection) to Railway

Both failures were silent: the seed completed with exit 0 and no warning in logs, because the old code checked `resp.status !== 'fulfilled'` (network error) but not `!resp.value.ok` (HTTP error status).

## Changes

### `scripts/seed-fear-greed.mjs`
- Add `undici` `ProxyAgent` import — built into Node.js 20, no new dependency
- Create `fetchViaProxy()` helper that routes through `OREF_PROXY_AUTH` residential proxy (froxy.com) when set, falls back to native `fetch` for local dev
- Update `fetchCBOE()`: use `fetchViaProxy` + `Referer: https://www.cboe.com/` + explicit HTTP status warning logs
- Update `fetchCNN()`: use `fetchViaProxy` + `Referer: https://www.cnn.com/markets/fear-and-greed` + explicit HTTP status/exception logs

### `scripts/_seed-utils.mjs`
- Update `CHROME_UA` from Chrome/120 → Chrome/134 (current stable as of March 2026)

### Railway
- `OREF_PROXY_AUTH=${{shared.OREF_PROXY_AUTH}}` already set on `seed-fear-greed` service (shared variable — no secret in code)

## Test plan
- [ ] Seed runs on Railway → no `CBOE totalpc: HTTP 403` or `CNN F&G: HTTP 418` warnings
- [ ] Redis `market:fear-greed:v1` → `putCall` and `cnnFearGreed` are non-null
- [ ] Fear & Greed panel header shows P/C Ratio and CNN F&G values (not N/A)