### PR TITLE
fix(heatmap): 3-column layout, ticker → value → name

### DIFF
--- a/src/components/MarketPanel.ts
+++ b/src/components/MarketPanel.ts
@@ -155,8 +155,8 @@ export class HeatmapPanel extends Panel {
           return `
         <div class="heatmap-cell ${getHeatmapClass(change)}">
           ${tickerHtml}
-          <div class="sector-name">${escapeHtml(sector.name)}</div>
           <div class="sector-change ${getChangeClass(change)}">${formatChange(change)}</div>
+          <div class="sector-name">${escapeHtml(sector.name)}</div>
         </div>
       `;
         })

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -5798,16 +5798,20 @@ body.playback-mode .status-dot {
 /* Heatmap */
 .heatmap {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 4px;
   padding: 4px;
 }
 
 .heatmap-cell {
-  padding: 8px 4px;
+  padding: 10px 6px;
   text-align: center;
   border-radius: 2px;
   background: var(--border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
 }
 
 .heatmap-cell.up-3 {
@@ -5835,23 +5839,22 @@ body.playback-mode .status-dot {
 }
 
 .sector-ticker {
-  font-size: 8px;
-  font-weight: 600;
+  font-size: 10px;
+  font-weight: 700;
   color: var(--text-dim);
-  letter-spacing: 0.03em;
-  opacity: 0.6;
-  margin-bottom: 1px;
+  letter-spacing: 0.05em;
 }
 
 .sector-name {
-  font-size: 8px;
+  font-size: 9px;
   color: var(--text-muted);
-  margin-bottom: 2px;
+  margin-top: 1px;
 }
 
 .sector-change {
-  font-size: 11px;
+  font-size: 14px;
   font-weight: bold;
+  line-height: 1;
 }
 
 .sector-change.up {


### PR DESCRIPTION
## What

- 4 columns → 3 columns (wider cells, more breathing room)
- Cell order: **XLK** (acronym, top) → **+1.23%** (value, 14px prominent) → **Technology** (name, 9px muted, bottom)
- Flex column layout on cells with consistent 2px gap

Before: cramped 4-col with ticker/name/value stacked awkwardly
After: clean 3-col with clear visual hierarchy