### PR TITLE
fix(fear-greed): always refresh from RPC after bootstrap render

### DIFF
--- a/src/components/FearGreedPanel.ts
+++ b/src/components/FearGreedPanel.ts
@@ -117,30 +117,37 @@ export class FearGreedPanel extends Panel {
 
   public async fetchData(): Promise<boolean> {
     const hydrated = getHydratedData('fearGreedIndex') as Record<string, unknown> | undefined;
-    if (hydrated && !hydrated.unavailable) {
+    const hasBootstrap = hydrated && !hydrated.unavailable;
+    if (hasBootstrap) {
       const mapped = mapSeedPayload(hydrated);
       if (mapped && mapped.compositeScore > 0) {
         this.data = mapped;
         this.renderPanel();
+        // Always refresh from RPC to pick up complete data (bootstrap may have partial fields)
+        void this.refreshFromRpc();
         return true;
       }
     }
 
     this.showLoading();
+    return this.refreshFromRpc();
+  }
+
+  private async refreshFromRpc(): Promise<boolean> {
     try {
       const { MarketServiceClient } = await import('@/generated/client/worldmonitor/market/v1/service_client');
       const { getRpcBaseUrl } = await import('@/services/rpc-client');
       const client = new MarketServiceClient(getRpcBaseUrl(), { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) });
       const resp = await client.getFearGreedIndex({});
       if (resp.unavailable) {
-        this.showError(t('common.noDataShort'), () => void this.fetchData());
+        if (!this.data) this.showError(t('common.noDataShort'), () => void this.fetchData());
         return false;
       }
       this.data = resp as FearGreedData;
       this.renderPanel();
       return true;
     } catch (e) {
-      this.showError(e instanceof Error ? e.message : t('common.failedToLoad'), () => void this.fetchData());
+      if (!this.data) this.showError(e instanceof Error ? e.message : t('common.failedToLoad'), () => void this.fetchData());
       return false;
     }
   }


### PR DESCRIPTION
## Why this PR?

P/C Ratio and CNN F&G show N/A permanently if the page was loaded when those fields were null in Redis (failed seed run). Bootstrap hydration is one-shot — the panel renders from it and returns `true` with no way to self-heal.

## Root cause

`fetchData()` returned early when `compositeScore > 0`, even if CNN/putCall were null. No auto-refresh means the panel stays at N/A until full page reload.

## Fix

Render from bootstrap immediately (fast first paint), then always fire a background `refreshFromRpc()`. The RPC result replaces bootstrap data, filling in any partial fields. If the RPC fails and bootstrap already rendered something, no error state is shown.

## Test plan
- [ ] Load page — panel renders quickly from bootstrap
- [ ] Within ~1s, P/C Ratio and CNN F&G values update from live RPC
- [ ] If RPC fails with valid bootstrap data, panel stays visible (no error overlay)