### PR TITLE
fix(sentry): filter Greasemonkey/Tampermonkey x-plugin-script noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -251,6 +251,7 @@ Sentry.init({
     /^(?:Error: )?uncaught exception: undefined$/,
     /Can't find variable: ss_bootstrap_config/,
     /undefined is not an object \(evaluating '[a-z]\.includes'\)/,
+    /^"use strict" is not a function$/,
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';
@@ -296,6 +297,8 @@ Sentry.init({
     if (frames.length > 0 && frames.every(f => /^blob:/.test(f.filename ?? ''))) return null;
     // Suppress errors originating from UV proxy (Ultraviolet service worker)
     if (frames.some(f => /\/uv\/service\//.test(f.filename ?? '') || /uv\.handler/.test(f.filename ?? ''))) return null;
+    // Suppress Greasemonkey/Tampermonkey userscript errors (x-plugin-script)
+    if (frames.length > 0 && frames.every(f => !f.filename || /\/x-plugin-script\//.test(f.filename))) return null;
     // Suppress YouTube IFrame widget API internal errors
     if (frames.some(f => /www-widgetapi\.js/.test(f.filename ?? ''))) return null;
     // Suppress Sentry beacon XHR transport errors (readyState on aborted XHR — not our code)


### PR DESCRIPTION
## Summary

Two unresolved Sentry issues traced to Greasemonkey/Tampermonkey userscript runner errors — not our code. Both came from a Chrome WebView on Android where the user has a userscript manager installed.

- **7360458445** — `"use strict" is not a function` from `/x-plugin-script/gm_idle_user_script/plugin-13.js`
- **7360459898** — `Cannot read properties of null (reading 'includes')` from `/x-plugin-script/gm_start_user_script/plugin-25.js` (`registerMenuCommand` in stack)

Both were marked resolved in Sentry (`inNextRelease: true`) during triage.

## Changes

- `ignoreErrors`: added `/^"use strict" is not a function$/` — belt-and-suspenders for the gm_idle pattern (error message is distinctive enough for a literal match)
- `beforeSend`: added `x-plugin-script` filename guard — suppresses any event where **all** frames originate from `/x-plugin-script/` paths. This one rule covers both `gm_idle_user_script` and `gm_start_user_script` variants and any future userscript plugin errors from the same runner

## Test plan
- [ ] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Sentry issues 7360458445 and 7360459898 do not re-open after next deploy
- [ ] Real `TypeError` crashes in our source files still reach Sentry (no first-party frames suppressed)