### PR TITLE
fix(fear-greed): fix AAII wrong reading

### DIFF
--- a/scripts/seed-fear-greed.mjs
+++ b/scripts/seed-fear-greed.mjs
@@ -132,6 +132,11 @@ async function fetchCNN() {
 }
 
 // --- AAII Sentiment (LOW reliability, always wrapped, non-blocking) ---
+// Table layout: Reported Date | Bullish | Neutral | Bearish
+// Extract the 3 percentage cells from the first (most recent) data row
+// using class="tableTxt" cells — positional, not label-based.
+// Label-based regexes fail because "Bearish" header precedes the Bullish
+// data cell (30.4%) in the DOM before the actual Bearish cell (52.0%).
 async function fetchAAII() {
   try {
     const resp = await fetch('https://www.aaii.com/sentimentsurvey/sent_results', {
@@ -140,10 +145,11 @@ async function fetchAAII() {
     });
     if (!resp.ok) return null;
     const html = await resp.text();
-    const bullMatch = html.match(/Bullish[^%]*?([\d.]+)%/i);
-    const bearMatch = html.match(/Bearish[^%]*?([\d.]+)%/i);
-    if (!bullMatch || !bearMatch) return null;
-    return { bull: parseFloat(bullMatch[1]), bear: parseFloat(bearMatch[1]) };
+    // Columns 1,2,3 of first data row = Bullish%, Neutral%, Bearish%
+    const pcts = [...html.matchAll(/<td[^>]*class="tableTxt"[^>]*>([\d.]+)%/g)]
+      .map(m => parseFloat(m[1]));
+    if (pcts.length < 3) return null;
+    return { bull: pcts[0], bear: pcts[2] };
   } catch (e) {
     console.warn('  AAII: fetch failed:', e.message, '(using degraded Sentiment)');
     return null;


### PR DESCRIPTION
## Root cause

The AAII Sentiment Survey page (`sent_results`) renders a table with this structure:

```html
<tr>  <!-- Header row -->
  <th>Reported Date</th><th>Bullish</th><th>Neutral</th><th>Bearish</th>
</tr>
<tr>  <!-- First data row (most recent week) -->
  <td>Mar 18</td>
  <td class="tableTxt">30.4%</td>   ← Bullish
  <td class="tableTxt">17.6%</td>   ← Neutral
  <td class="tableTxt">52.0%</td>   ← Bearish
</tr>
```

The old regex `/Bearish[^%]*?([\d.]+)%/i` matches the **Bearish column header** (not a data cell), then scans forward for the first `number%` it can find — which is the **Bullish** data cell `30.4%`, since it appears before `52.0%` in the DOM.

Result: both `aaiBull` and `aaiBear` were reporting `30.4%` (the bullish value).

## Fix

Extract the first 3 `class="tableTxt"` percentage cells **positionally**:
- `pcts[0]` = Bullish (30.4%)
- `pcts[1]` = Neutral (17.6%)
- `pcts[2]` = Bearish (52.0%) ✓

```js
const pcts = [...html.matchAll(/<td[^>]*class="tableTxt"[^>]*>([\d.]+)%/g)]
  .map(m => parseFloat(m[1]));
return { bull: pcts[0], bear: pcts[2] };
```

## Impact

AAII Bearish sentiment is currently **52.0%** (extreme fear) but was being reported as **30.4%** (historical average). This directly understated the Sentiment category score in the composite Fear & Greed index.

## Test plan

- [ ] Run seeder locally: `node scripts/seed-fear-greed.mjs`
- [ ] Confirm log shows: `AAII bull=30.4 | bear=52.0` (not `30.4 | 30.4`)
- [ ] Verify composite score reflects higher bearish sentiment