### PR TITLE
fix(sentry): filter Android WebView JS bridge ReferenceErrors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -123,7 +123,7 @@ Sentry.init({
     /(?:AbortError: )?The user aborted a request/,
     /\w+ is not a function.*\/uv\/service\//,
     /__isInQueue__/,
-    /^(?:LIDNotify(?:Id)?|onWebViewAppeared|onGetWiFiBSSID) is not defined$/,
+    /^(?:LIDNotify(?:Id)?|onWebViewAppeared|onGetWiFiBSSID|onHide|onShow|onReady|tapAt|removeHighlight) is not defined$/,
     /signal timed out/,
     /Se requiere plan premium/,
     /hybridExecute is not defined/,


### PR DESCRIPTION
## Summary

- All 5 unresolved Sentry errors (`onHide`, `onShow`, `onReady`, `tapAt`, `removeHighlight is not defined`) originated from the same Chrome Mobile WebView 146 / Android 16 session
- A native Android host app was calling these functions as global JS callbacks via `evaluateJavascript()` — our page doesn't expose them, causing `ReferenceError` from an `<anonymous>` eval context
- Extended the existing WebView callback `ignoreErrors` pattern on line 126 to cover all 5 names — no new entries needed
- All 5 Sentry issues marked resolved with `inNextRelease: true`

## Test plan

- [ ] `src/main.ts` WebView callback regex includes `onHide|onShow|onReady|tapAt|removeHighlight`
- [ ] `npx tsc --noEmit` passes
- [ ] No new Sentry noise from Android WebView bridge callbacks after next deploy