### PR TITLE
fix(cross-source-signals): show radar error state when seeder hasn't run or fetch fails

### DIFF
--- a/scripts/seed-cross-source-signals.mjs
+++ b/scripts/seed-cross-source-signals.mjs
@@ -759,7 +759,11 @@ async function aggregateCrossSourceSignals() {
   console.log('  Reading source keys...');
   const sourceData = await readAllSourceKeys();
   const foundKeys = Object.keys(sourceData);
+  const missingKeys = SOURCE_KEYS.filter(k => !foundKeys.includes(k));
   console.log(`  Found ${foundKeys.length}/${SOURCE_KEYS.length} source keys populated`);
+  if (missingKeys.length > 0) {
+    console.log(`  Missing keys (${missingKeys.length}): ${missingKeys.join(', ')}`);
+  }
 
   const allSignals = [];
 

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2886,6 +2886,7 @@ export class DataLoaderManager implements AppModule {
       dataFreshness.recordUpdate('cross-source-signals' as DataSourceId, result.signals?.length ?? 0);
     } catch (error) {
       console.error('[App] Cross-source signals fetch failed:', error);
+      this.callPanel('cross-source-signals', 'showFetchError');
     }
   }
 }

--- a/src/components/CrossSourceSignalsPanel.ts
+++ b/src/components/CrossSourceSignalsPanel.ts
@@ -107,7 +107,12 @@ export class CrossSourceSignalsPanel extends Panel {
     this.evaluatedAt = data.evaluatedAt ? new Date(data.evaluatedAt) : null;
     this.compositeCount = data.compositeCount ?? 0;
     this.setCount(this.signals.length);
+    this.resetRetryBackoff();
     this.render();
+  }
+
+  public showFetchError(): void {
+    this.showError('Signal data unavailable — upstream feeds unreachable.', () => {/* refreshed by scheduler */});
   }
 
   private ageSuffix(ts: number): string {
@@ -159,7 +164,11 @@ export class CrossSourceSignalsPanel extends Panel {
 
   private render(): void {
     if (this.signals.length === 0) {
-      this.setContent('<div style="padding:16px 0;text-align:center;font-size:12px;color:var(--text-dim)">No cross-source signals detected.</div>');
+      if (!this.evaluatedAt) {
+        this.showError('Signal aggregator is initializing. First evaluation runs within 15 minutes.', () => {/* refreshed by scheduler */});
+      } else {
+        this.setContent('<div style="padding:16px 0;text-align:center;font-size:12px;color:var(--text-dim)">No cross-source signals detected.</div>');
+      }
       return;
     }
 


### PR DESCRIPTION
## Why

The panel showed a plain text "No cross-source signals detected." message (with count badge = 0) when the Redis key was empty — which happens until the Railway cron seeder runs for the first time. No visual distinction between "seeder never ran" vs "no signals found after evaluation".

## Changes

- **Panel**: `evaluatedAt === null` (seeder never ran, `evaluatedAt: 0` from API) → calls `showError()` which renders the standard red radar error screen with a message
- **Panel**: `evaluatedAt` set but signals empty → keeps the soft "No cross-source signals detected." message (correct state)
- **Panel**: adds `showFetchError()` method for network failure path
- **data-loader**: `catch` block now calls `showFetchError()` instead of only logging
- **Seeder**: logs the actual missing key names in addition to the count (was: `Found 18/22`, now: `Found 18/22 … Missing keys (4): gdelt:intel:tone:military, ...`)

## Test plan
- [ ] Deploy and check panel before seeder has run — should show radar error state
- [ ] After seeder runs and returns signals — normal signal list renders
- [ ] After seeder runs with all sources empty — soft "No cross-source signals detected." message