### PR TITLE
fix(fear-greed): recalibrate Credit and Liquidity scoring formulas

### DIFF
--- a/scripts/seed-fear-greed.mjs
+++ b/scripts/seed-fear-greed.mjs
@@ -226,6 +226,14 @@ function fredNMonthsAgo(obs, months) {
   const v = parseFloat(obs[idx]?.value ?? 'NaN');
   return Number.isFinite(v) ? v : null;
 }
+// For daily FRED series, 1 "month" ≈ 20 trading days — use this for trend comparisons
+function fredNTradingDaysAgo(obs, days) {
+  if (!obs) return null;
+  const idx = obs.length - 1 - days;
+  if (idx < 0) return null;
+  const v = parseFloat(obs[idx]?.value ?? 'NaN');
+  return Number.isFinite(v) ? v : null;
+}
 function labelFromScore(s) {
   if (s <= 20) return 'Extreme Fear';
   if (s <= 40) return 'Fear';
@@ -313,7 +321,8 @@ function scoreCategory(name, inputs) {
       const m2Yoy = (m2Latest && m2Ago && m2Ago !== 0) ? ((m2Latest - m2Ago) / m2Ago) * 100 : null;
       const walclLatest = fredLatest(walclObs), walclAgo = fredNMonthsAgo(walclObs, 1);
       const fedBsMom = (walclLatest && walclAgo && walclAgo !== 0) ? ((walclLatest - walclAgo) / walclAgo) * 100 : null;
-      const m2Score = m2Yoy != null ? clamp(m2Yoy * 10 + 50, 0, 100) : 50;
+      // M2 YoY: normal annual growth is 4-6%; use 5x multiplier so 5% YoY ≈ 75 (not pegged at 100 like 10x was)
+      const m2Score = m2Yoy != null ? clamp(m2Yoy * 5 + 50, 0, 100) : 50;
       const fedScore = fedBsMom != null ? clamp(fedBsMom * 20 + 50, 0, 100) : 50;
       const sofrScore = sofr != null ? clamp(100 - sofr * 15, 0, 100) : 50;
       return { score: Math.round(m2Score * 0.4 + fedScore * 0.3 + sofrScore * 0.3), inputs: { m2Yoy, fedBsMom, sofr } };
@@ -321,9 +330,14 @@ function scoreCategory(name, inputs) {
     case 'credit': {
       const { hyObs, igObs } = inputs;
       const hySpread = fredLatest(hyObs), igSpread = fredLatest(igObs);
-      const hyScore = hySpread != null ? clamp(100 - ((hySpread - 3.0) / 5.0) * 100, 0, 100) : 50;
-      const igScore = igSpread != null ? clamp(100 - ((igSpread - 0.8) / 2.0) * 100, 0, 100) : 50;
-      const hyPrev = fredNMonthsAgo(hyObs, 1);
+      // HY OAS: historical range 2.0% (all-time tights) to 10.0% (crisis). Long-run avg ~5%.
+      // Old baseline was 3.0% (near tights), causing scores near 100 in normal conditions.
+      const hyScore = hySpread != null ? clamp(100 - ((hySpread - 2.0) / 8.0) * 100, 0, 100) : 50;
+      // IG OAS: historical range 0.4% (tights) to 3.0% (stressed). Long-run avg ~1.3%.
+      const igScore = igSpread != null ? clamp(100 - ((igSpread - 0.4) / 2.6) * 100, 0, 100) : 50;
+      // Use ~20 trading days (1 calendar month) for trend — fredNMonthsAgo(obs,1) only steps back
+      // 1 observation on daily data (= yesterday), which is noise not a trend signal.
+      const hyPrev = fredNTradingDaysAgo(hyObs, 20);
       const hyTrend = (hySpread != null && hyPrev != null) ? (hySpread < hyPrev ? 'narrowing' : hySpread > hyPrev ? 'widening' : 'stable') : 'stable';
       const trendScore = hyTrend === 'narrowing' ? 70 : hyTrend === 'widening' ? 30 : 50;
       return { score: Math.round(hyScore * 0.4 + igScore * 0.3 + trendScore * 0.3), inputs: { hySpread, igSpread, hyTrend30d: hyTrend } };


### PR DESCRIPTION
## Why This PR

Credit was scoring **88** and Liquidity **69** during a period when VIX=26.57, CNN F&G=15 (Extreme Fear), and AAII Bear=52%. Three formula bugs were producing inflated scores.

## Bugs Fixed

### 1. HY trend comparison used yesterday, not 1 month ago (Credit)
`fredNMonthsAgo(hyObs, 1)` steps back 1 index. With daily FRED observations this is the previous business day, not 1 calendar month. Comparing Friday (3.24%) to Monday (3.19%) flagged the trend as "narrowing" (+8pts to trendScore), when the true 1-month comparison (3.0% → 3.19%) is widening (-20pts). Added `fredNTradingDaysAgo(obs, 20)` for daily trend lookbacks.

### 2. Credit baselines anchored to all-time tights (Credit)
HY OAS baseline was 3.0% — near historical all-time tights (1997, 2021). The formula scored HY at **96/100 at 3.19%**, a perfectly ordinary post-QE level. Historical long-run average is ~5.0%. Recalibrated to a 2.0–10.0% range so 5% HY ≈ score 62 (neutral-ish), 3.19% ≈ 85 (tight, but not near-100). Same fix for IG OAS (0.4–3.0% range, avg ~1.3%).

### 3. M2 YoY multiplier too aggressive (Liquidity)
`m2Yoy * 10 + 50` pins the score at **100** for any 5%+ annual M2 growth — which is perfectly normal in most years. This masked SOFR's restrictive signal. Changed to `5x` so 5% M2 growth ≈ 75 (moderately accommodative, not pegged at max).

## Net Effect at Current Market Values

| Category | Before | After |
|----------|--------|-------|
| Credit | 88 | 68 |
| Liquidity | 69 | 59 |

More consistent with the fear signals from VIX, CNN F&G, AAII, and volatility categories.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run typecheck:api` passes
- [x] `npm run test:data` passes (2296/2296)
- [ ] Trigger manual seed on Railway to observe updated scores