### PR TITLE
fix(seed): skip writing empty per-key flow entries to preserve good data

### DIFF
--- a/scripts/seed-trade-flows.mjs
+++ b/scripts/seed-trade-flows.mjs
@@ -135,7 +135,9 @@ function publishTransform(data) {
 
 async function afterPublish(data, _meta) {
   for (const [key, value] of Object.entries(data.perKeyFlows ?? {})) {
-    await writeExtraKey(key, value, CACHE_TTL);
+    if ((value.flows?.length ?? 0) > 0) {
+      await writeExtraKey(key, value, CACHE_TTL);
+    }
   }
 }
 


### PR DESCRIPTION
## Why this PR?

The Strategic Flows tab was showing empty data despite the seed script running successfully. A second seed run hitting Comtrade API quota limits was overwriting good per-key Redis entries (`comtrade:flows:{reporter}:{cmdCode}`) with empty `flows: []` arrays.

## Root cause

`afterPublish` in `seed-trade-flows.mjs` unconditionally wrote all `perKeyFlows` entries to Redis, including those where the current run returned 0 records (due to API quota exhaustion or no data for that period).

Run 1 (2026-03-23 16:28): `USA/Crude = 18 flows, China/Crude = 7 flows, ...` — good data  
Run 2 (2026-03-24 05:05): most pairs returned `0 flows` due to quota — **clobbered run 1's data**

The handler (`list-comtrade-flows.ts`) found keys (so `upstreamUnavailable = false`) but accumulated 0 flows, rendering an empty table with no error message.

## Fix

Skip writing extra keys when the current run returns 0 records for that country/commodity pair — preserving the last valid data in Redis.

```js
// Before: always overwrites, even with empty arrays
await writeExtraKey(key, value, CACHE_TTL);

// After: only write if this run has actual data
if ((value.flows?.length ?? 0) > 0) {
  await writeExtraKey(key, value, CACHE_TTL);
}
```

## Test plan

- [ ] Verify Strategic Flows tab shows data after next seed run
- [ ] Confirm that a quota-limited run no longer empties previously populated keys