### PR TITLE
fix(fear-greed): fix SMA200 null (range=1y) and VIX neutral calibration

### DIFF
--- a/scripts/seed-fear-greed.mjs
+++ b/scripts/seed-fear-greed.mjs
@@ -44,7 +44,7 @@ const FRED_PREFIX = 'economic:fred:v1';
 const YAHOO_SYMBOLS = ['^GSPC','^VIX','^VIX9D','^VIX3M','^SKEW','C:ISSU','GLD','TLT','SPY','RSP','DX-Y.NYB','XLK','XLF','XLE','XLV'];
 
 async function fetchYahooSymbol(symbol) {
-  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=1d&range=3mo`;
+  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?interval=1d&range=1y`;
   const headers = { 'User-Agent': CHROME_UA, Accept: 'application/json' };
   try {
     // Use curl+proxy when available — Railway container IPs are periodically blocked by Yahoo.
@@ -271,7 +271,8 @@ function scoreCategory(name, inputs) {
     case 'volatility': {
       const { vix, vix9d, vix3m } = inputs;
       if (vix == null) return { score: 50, inputs };
-      const vixScore = clamp(100 - ((vix - 12) / 28) * 100, 0, 100);
+      // VIX range 12–35: neutral at ~23.5 (historical avg ~19-20). Old range 12-40 centered neutral at VIX=26 — too permissive.
+      const vixScore = clamp(100 - ((vix - 12) / 23) * 100, 0, 100);
       const termScore = (vix9d != null && vix3m != null) ? (vix / vix3m < 1 ? 70 : 30) : 50;
       const termStructure = (vix9d != null && vix3m != null) ? (vix / vix3m < 1 ? 'contango' : 'backwardation') : 'unknown';
       return { score: Math.round(vixScore * 0.7 + termScore * 0.3), inputs: { vix, vix9d, vix3m, termStructure } };


### PR DESCRIPTION
## Why This PR

Follow-up to #2222. Two more data/calibration bugs causing the Fear & Greed panel to misread current market conditions (VIX=26.57, CNN F&G=15, AAII Bear=52%).

## Bugs Fixed

### 1. SMA200 always null — 200-day trend completely missing

`fetchYahooSymbol` was using `range=3mo` (~63 trading days). Computing SMA200 requires 200 bars, so it was **always null**. The trend formula handles null SMA200 by substituting `dist200=0`, producing a floor score of 25 regardless of whether SPX is above or below its 200-day MA. Changed to `range=1y` (~252 trading days).

With proper data, SPX at 6576 is still above its ~200-day MA (est. ~6200-6300) despite the current correction. Trend will correctly score as "short-term bearish but long-term bullish" (~47-53 neutral) rather than 25 (misleadingly deep fear territory).

### 2. VIX neutral point miscalibrated

The old VIX scoring used range 12–40, centering neutral at VIX=26. Historical long-run VIX average is **~19-20**. At VIX=26.57, the score was **48 (neutral)** — when VIX that elevated should register as mild fear.

Changed range to 12–35, shifting neutral to ~23.5:
- VIX=19 (normal): ~57 (mild greed) ✓
- VIX=26.57 (current): **~37 (mild fear)** vs 48 before ✓
- VIX=35 (crisis onset): 0 ✓

## Context

Combined with #2222 (Credit 88→68, Liquidity 69→59), the composite now more faithfully reflects the mixed picture: credit/liquidity still relatively accommodative, but sentiment/volatility/breadth/trend all pointing toward fear.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run typecheck:api` passes
- [x] `npm run test:data` passes (2296/2296)
- [ ] Trigger manual seed on Railway — verify SMA200 is populated in trend inputs and VIX score lands ~37