### PR TITLE
fix(health): bump wildfires maxStaleMin 120→360 for FIRMS NRT midnight reset

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -101,7 +101,7 @@ const STANDALONE_KEYS = {
 
 const SEED_META = {
   earthquakes:      { key: 'seed-meta:seismology:earthquakes',  maxStaleMin: 30 },
-  wildfires:        { key: 'seed-meta:wildfire:fires',          maxStaleMin: 120 },
+  wildfires:        { key: 'seed-meta:wildfire:fires',          maxStaleMin: 360 }, // FIRMS NRT resets at midnight UTC; new-day data takes 3-6h to accumulate
   outages:          { key: 'seed-meta:infra:outages',           maxStaleMin: 30 },
   climateAnomalies: { key: 'seed-meta:climate:anomalies',       maxStaleMin: 120 }, // runs as independent Railway cron (0 */2 * * *)
   unrestEvents:     { key: 'seed-meta:unrest:events',           maxStaleMin: 120 }, // 45min cron; 120 = 2h grace (was 75 = 30min buffer, too tight)


### PR DESCRIPTION
## Why this PR?

Wildfires showing STALE_SEED for 6+ hours every night. Not a real outage.

## Root cause

FIRMS NRT (Near Real-Time) satellite data resets at midnight UTC. All three VIIRS sources (SNPP, NOAA20, NOAA21) return 0 records for 3-6h after the cutover as new satellite passes accumulate throughout the new day. The seed correctly detects this and skips writing (extends TTL instead), but `maxStaleMin: 120` was shorter than the typical 3-6h reset window — causing nightly false-alarm health warnings.

Confirmed from logs: last write `2026-03-24T23:34Z`, then 5+ consecutive runs returning `0 total` across all satellites, health alerting `STALE_SEED` from `~01:40Z` onward.

## Fix

`maxStaleMin: 120` → `maxStaleMin: 360` (6h) to cover the full FIRMS NRT midnight reset window.

## Test plan

- [ ] Health check shows OK (not STALE_SEED) during the ~00:00-06:00 UTC window
- [ ] Genuine outages (>6h since last write) still surface as STALE_SEED