### PR TITLE
fix(panels): show radar error state on fetch failure across 22 panels

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1152,7 +1152,6 @@ export class DataLoaderManager implements AppModule {
       panel.renderAnalyses(results, nextHistory, 'live');
     } catch (error) {
       console.error('[StockAnalysis] failed:', error);
-      this.callPanel('stock-analysis', 'showError');
       const cachedHistory = await fetchStockAnalysisHistory().catch(() => ({}));
       const cachedSnapshots = getLatestStockAnalysisSnapshots(cachedHistory);
       if (cachedSnapshots.length > 0) {
@@ -1190,7 +1189,6 @@ export class DataLoaderManager implements AppModule {
       panel.renderBacktests(results);
     } catch (error) {
       console.error('[StockBacktest] failed:', error);
-      this.callPanel('stock-backtest', 'showError');
       const stored = await fetchStoredStockBacktests().catch(() => []);
       if (stored.length > 0) {
         panel.renderBacktests(stored, 'cached');
@@ -2387,7 +2385,7 @@ export class DataLoaderManager implements AppModule {
       }
     } catch (e) {
       console.error('[App] Oil analytics failed:', e);
-      this.callPanel('energy-complex', 'showError');
+      this.callPanel('energy-complex', 'showError', undefined, () => void this.loadOilAnalytics());
       this.ctx.statusPanel?.updateApi('EIA', { status: 'error' });
       dataFreshness.recordError('oil', String(e));
     }
@@ -2489,7 +2487,7 @@ export class DataLoaderManager implements AppModule {
       }
     } catch (e) {
       console.error('[App] Trade policy failed:', e);
-      this.callPanel('trade-policy', 'showError');
+      this.callPanel('trade-policy', 'showError', undefined, () => void this.loadTradePolicy());
       this.ctx.statusPanel?.updateApi('WTO', { status: 'error' });
       dataFreshness.recordError('wto_trade', String(e));
     }
@@ -2526,7 +2524,7 @@ export class DataLoaderManager implements AppModule {
       }
     } catch (e) {
       console.error('[App] Supply chain failed:', e);
-      this.callPanel('supply-chain', 'showError');
+      this.callPanel('supply-chain', 'showError', undefined, () => void this.loadSupplyChain());
       this.ctx.statusPanel?.updateApi('SupplyChain', { status: 'error' });
       dataFreshness.recordError('supply_chain', String(e));
     }


### PR DESCRIPTION
## Why this PR?

Panels were silently staying on the "Loading..." state when upstream fetches failed, instead of showing the standard radar error state that all other panels use. Users had no visual feedback that a panel had encountered an error.

## Changes

- Added `this.callPanel('panel-id', 'showError')` in `catch` blocks for loaders in `data-loader.ts`
- Added `onRetry` callbacks for long-interval panels (energy-complex 6h, trade-policy 1h, supply-chain 1h) so transient failures show a retry button
- Replaced `update([], 0)` with `showError()` in satellite-fires catch (was semantically wrong — "zero fires" ≠ "fetch failed")

## Panels covered

`stock-analysis`, `stock-backtest`, `displacement`, `climate`, `oref-sirens`, `population-exposure`, `internet-disruptions`, `energy-complex`, `trade-policy`, `supply-chain`, `satellite-fires`, `security-advisories`, `sanctions-pressure`, `radiation-watch`, `thermal-escalation`

## Panels intentionally excluded

- `loadGovernmentSpending` / `loadBisData` / `loadBlsData`: feed sub-sections of `EconomicPanel` (partial failure acceptable)
- `loadAisSignals` / `loadMilitary`: feed the map layer, not a panel
- `loadTechEvents`: map-layer-only query; `TechEventsPanel` self-fetches independently
- `AirlineIntelPanel`: intentional silent catch (progressive loading)
- `ConsumerPricesPanel`: `upstreamUnavailable:true` is returned for both cache miss and transport failure — indistinguishable client-side; existing seeding placeholder is correct for both

## Test plan

- [ ] Confirm typecheck passes
- [ ] Confirm unit tests pass
- [ ] Force a fetch failure and verify the red radar error state appears
- [ ] Verify long-interval panels show a retry button on failure