### PR TITLE
fix(seed): change hormuz chart window from 24h to 30 days

### DIFF
--- a/scripts/seed-hormuz.mjs
+++ b/scripts/seed-hormuz.mjs
@@ -10,6 +10,7 @@
 // Redis key: supply_chain:hormuz_tracker:v1
 // Cron: every 24 hours (0 6 * * *)
 // TTL: 108000s (30h — daily + 6h buffer)
+// Chart window: last 30 days
 
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
 
@@ -84,7 +85,7 @@ async function fetchPbiCharts() {
   if (!modelId) throw new Error('Could not find Power BI modelId');
   console.log(`  Model ID: ${modelId}, containers: ${allContainers.length}`);
 
-  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
 
   const charts = [];
 
@@ -169,7 +170,7 @@ async function fetchPbiCharts() {
       .filter(Boolean)
       .sort((a, b) => a.date.localeCompare(b.date));
 
-    console.log(`  ${cfg.label}: ${series.length} points (last 24h)`);
+    console.log(`  ${cfg.label}: ${series.length} points (last 30d)`);
     charts.push({ label: cfg.label, title: cfg.title, series });
   }
 


### PR DESCRIPTION
## Why this PR?

Hormuz Trade Tracker panel showing empty charts despite seed running successfully.

## Root cause

`fetchPbiCharts()` had a 24-hour cutoff that filtered out all Power BI data points. Since WTO/AXSMarine data consists of daily shipping statistics (always dated yesterday or earlier), the 24h window left every chart with `seriesCount: 0`.

Confirmed via API: all 4 charts returned with `series: []`.

The panel was always supposed to show 30 days of trend data.

## Fix

`Date.now() - 24h` → `Date.now() - 30d`

After re-seeding, each chart will show up to 30 days of daily shipment data points.

## Test plan

- [ ] Re-run `seed-hormuz.mjs` and confirm each chart logs `N points (last 30d)` with N > 0
- [ ] Panel shows bar charts with shipment history