### PR TITLE
fix(health+seed): hormuz accurate record count and stronger validateFn

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -243,7 +243,8 @@ function dataSize(parsed) {
                       'theaters', 'fleets', 'warnings', 'closures', 'cables',
                       'airports', 'closedIcaos', 'categories', 'regions', 'entries', 'satellites',
                       'sectors', 'statuses', 'scores', 'topics', 'advisories', 'months',
-                      'observations', 'datapoints', 'clusters']) {
+                      'observations', 'datapoints', 'clusters',
+                      'charts']) {
       if (Array.isArray(parsed[k])) return parsed[k].length;
     }
     return Object.keys(parsed).length;

--- a/scripts/seed-hormuz.mjs
+++ b/scripts/seed-hormuz.mjs
@@ -296,5 +296,5 @@ async function buildPayload() {
 
 await runSeed('supply_chain', 'hormuz_tracker', CANONICAL_KEY, buildPayload, {
   ttlSeconds: CACHE_TTL,
-  validateFn: (d) => !!(d?.updatedDate || d?.summary || d?.title),
+  validateFn: (d) => !!(d?.updatedDate || d?.summary || d?.title) && d?.charts?.some(c => (c.series?.length ?? 0) > 0),
 });


### PR DESCRIPTION
## Why this PR?

Two related blind spots discovered while debugging empty Hormuz charts:

## 1. health.js dataSize() false positive

`dataSize()` falls back to `Object.keys(parsed).length` when no known array field matches. The hormuz data object has 8 top-level keys, so health reported `records: 8 / OK` even when `charts: []` was empty. Added `'charts'` to the known-fields list.

**Before:** `hormuzTracker: { status: OK, records: 8 }` ← charts were empty  
**After:** `hormuzTracker: { status: OK, records: 0 }` ← truthful count

## 2. seed validateFn allowed empty charts

`validateFn` only checked for WTO page text presence (`updatedDate || summary || title`). Power BI chart fetches can fail silently (non-fatal), leaving `charts: []`. A seed run that scraped text but got no chart data would publish and overwrite the last good payload.

Now requires at least one chart with actual series data:
```js
validateFn: (d) => !!(d?.updatedDate || d?.summary || d?.title)
  && d?.charts?.some(c => (c.series?.length ?? 0) > 0),
```

If Power BI fails, seed skips publish and extends the existing TTL.

## Test plan
- [ ] Health shows `records: N` where N = number of charts (4) after a healthy seed
- [ ] A seed run where Power BI fails shows `SKIPPED: validation failed` and does not overwrite existing data