### PR TITLE
fix(grocery-index): canola oil, tighter caps, outlier gate, sticky col, wow badge

### DIFF
--- a/scripts/seed-grocery-basket.mjs
+++ b/scripts/seed-grocery-basket.mjs
@@ -8,6 +8,8 @@ const config = loadSharedConfig('grocery-basket.json');
 
 const CANONICAL_KEY = 'economic:grocery-basket:v1';
 const CACHE_TTL = 864000; // 10 days — weekly seed with 3-day cron-drift buffer
+// Bump when basket composition changes materially — invalidates WoW until a new baseline runs.
+const BASKET_VERSION = 2; // v2: oil changed from sunflower to canola
 const EXA_DELAY_MS = 150;
 
 const FIRECRAWL_DELAY_MS = 500;
@@ -208,8 +210,10 @@ async function fetchGroceryBasketPrices(prevSnapshot) {
 
   const countriesResult = [];
 
-  // Load all learned routes in one pipeline request before the country loop
-  const routeKeys = config.countries.flatMap(c => config.items.map(i => `${c.code}:${i.id}`));
+  // Load all learned routes in one pipeline request before the country loop.
+  // Include a one-time migration sentinel so the oil eviction only fires once.
+  const OIL_MIGRATION_KEY = '_migration:canola-oil-v1';
+  const routeKeys = [...config.countries.flatMap(c => config.items.map(i => `${c.code}:${i.id}`)), OIL_MIGRATION_KEY];
   const learnedRoutes = await bulkReadLearnedRoutes('grocery-basket', routeKeys).catch((err) => {
     console.warn(`  [routes] load failed (non-fatal): ${err.message}`);
     return new Map();
@@ -218,16 +222,18 @@ async function fetchGroceryBasketPrices(prevSnapshot) {
   const routeDeletes = new Set();
   console.log(`  [routes] loaded ${learnedRoutes.size} learned routes`);
 
-  // Evict all learned routes for "oil" — query changed from "sunflower cooking oil" to "canola oil".
-  // Old cached URLs may point to sunflower/vegetable oil pages; force fresh EXA discovery.
-  const oilRouteKeys = config.countries.map(c => `${c.code}:oil`);
-  const oilEvictions = new Set(oilRouteKeys.filter(k => learnedRoutes.has(k)));
-  if (oilEvictions.size > 0) {
-    console.log(`  [routes] evicting ${oilEvictions.size} stale oil routes (query changed to canola oil)`);
-    await bulkWriteLearnedRoutes('grocery-basket', new Map(), oilEvictions).catch(err =>
-      console.warn(`  [routes] oil eviction failed (non-fatal): ${err.message}`)
-    );
-    for (const k of oilEvictions) learnedRoutes.delete(k);
+  // One-time migration: evict stale oil routes when query changed sunflower → canola.
+  // Guarded by OIL_MIGRATION_KEY so it only fires once; subsequent runs skip entirely.
+  if (!learnedRoutes.has(OIL_MIGRATION_KEY)) {
+    const oilEvictions = new Set(config.countries.map(c => `${c.code}:oil`).filter(k => learnedRoutes.has(k)));
+    if (oilEvictions.size > 0) {
+      console.log(`  [routes] one-time migration: evicting ${oilEvictions.size} stale oil routes (sunflower → canola)`);
+      await bulkWriteLearnedRoutes('grocery-basket', new Map(), oilEvictions).catch(err =>
+        console.warn(`  [routes] oil eviction failed (non-fatal): ${err.message}`)
+      );
+      for (const k of oilEvictions) learnedRoutes.delete(k);
+    }
+    routeUpdates.set(OIL_MIGRATION_KEY, 'done'); // persisted at end of run alongside other route updates
   }
 
   for (const country of config.countries) {
@@ -384,8 +390,9 @@ async function fetchGroceryBasketPrices(prevSnapshot) {
   const cheapest = rankable.length ? rankable.reduce((a, b) => a.totalUsd < b.totalUsd ? a : b).code : '';
   const mostExpensive = rankable.length ? rankable.reduce((a, b) => a.totalUsd > b.totalUsd ? a : b).code : '';
 
-  // Compute WoW per country
-  const wowAvailable = prevSnapshot?.countries?.length > 0;
+  // Compute WoW per country — only valid when prev snapshot used the same basket composition.
+  // A version mismatch (e.g. oil changed from sunflower to canola) would produce bogus deltas.
+  const wowAvailable = prevSnapshot?.countries?.length > 0 && prevSnapshot.basketVersion === BASKET_VERSION;
   if (wowAvailable) {
     const prevMap = Object.fromEntries(prevSnapshot.countries.map(c => [c.code, c.totalUsd]));
     for (const country of countriesResult) {
@@ -410,6 +417,7 @@ async function fetchGroceryBasketPrices(prevSnapshot) {
     wowAvgPct,
     wowAvailable,
     prevFetchedAt: wowAvailable ? (prevSnapshot.fetchedAt ?? '') : '',
+    basketVersion: BASKET_VERSION,
   };
 }
 

--- a/scripts/seed-grocery-basket.mjs
+++ b/scripts/seed-grocery-basket.mjs
@@ -139,9 +139,10 @@ const SYMBOL_MAP = { '£': 'GBP', '€': 'EUR', '¥': 'JPY', '₩': 'KRW', '₹'
 // e.g. IDR 4 = $0.0003 (nonsense), NGN 20 = $0.01 (nonsense), KRW 5 = $0.004 (nonsense)
 const CURRENCY_MIN = { NGN: 50, IDR: 500, ARS: 50, KRW: 1000, ZAR: 2, PKR: 20, LBP: 1000 };
 
-// Maximum plausible USD price per item — catches bulk/wholesale products (e.g. 25lb salt bag)
-// Applied only to USD-denominated countries; other currencies vary too widely in purchasing power
-const ITEM_USD_MAX = { sugar: 8, salt: 5, rice: 6, pasta: 4, potatoes: 6, oil: 15, flour: 8, eggs: 12, milk: 8, bread: 8 };
+// Maximum plausible USD price per item — catches bulk/wholesale/specialty products.
+// Set to ~2× the most expensive legitimate retail price globally for each item.
+// Previous caps were too loose (e.g. sugar: 8 allowed 5.99 EUR organic sugar from carrefour.fr).
+const ITEM_USD_MAX = { sugar: 3.5, salt: 2.5, rice: 6, pasta: 3.5, potatoes: 6, oil: 10, flour: 4.5, eggs: 12, milk: 5, bread: 6 };
 
 // Pattern order matters: try currency-FIRST (e.g. "GBP 1.50") before number-first
 // to avoid matching pack sizes / weights that precede a currency token (e.g. "12 SAR" in "eggs 12 SAR 8.99")
@@ -216,6 +217,18 @@ async function fetchGroceryBasketPrices(prevSnapshot) {
   const routeUpdates = new Map();
   const routeDeletes = new Set();
   console.log(`  [routes] loaded ${learnedRoutes.size} learned routes`);
+
+  // Evict all learned routes for "oil" — query changed from "sunflower cooking oil" to "canola oil".
+  // Old cached URLs may point to sunflower/vegetable oil pages; force fresh EXA discovery.
+  const oilRouteKeys = config.countries.map(c => `${c.code}:oil`);
+  const oilEvictions = new Set(oilRouteKeys.filter(k => learnedRoutes.has(k)));
+  if (oilEvictions.size > 0) {
+    console.log(`  [routes] evicting ${oilEvictions.size} stale oil routes (query changed to canola oil)`);
+    await bulkWriteLearnedRoutes('grocery-basket', new Map(), oilEvictions).catch(err =>
+      console.warn(`  [routes] oil eviction failed (non-fatal): ${err.message}`)
+    );
+    for (const k of oilEvictions) learnedRoutes.delete(k);
+  }
 
   for (const country of config.countries) {
     console.log(`\n  Processing ${country.flag} ${country.name} (${country.currency})...`);
@@ -327,6 +340,40 @@ async function fetchGroceryBasketPrices(prevSnapshot) {
     console.warn(`  [routes] write failed (non-fatal): ${err.message}`)
   );
 
+  // Cross-country outlier gate — reject per-item prices > 4× the median USD price
+  // across all countries for that item. Prevents bad scrapes (bulk/wholesale/specialty)
+  // from distorting per-row colouring and basket totals.
+  // Also evicts the learned route from Redis so the bad URL isn't replayed next seed.
+  const itemIds = config.items.map(i => i.id);
+  const outlierEvictions = new Set();
+  for (const itemId of itemIds) {
+    const pricePoints = countriesResult
+      .map(c => c.items.find(i => i.itemId === itemId)?.usdPrice)
+      .filter(p => p != null && p > 0);
+    if (pricePoints.length < 3) continue; // need ≥ 3 data points for meaningful median
+    pricePoints.sort((a, b) => a - b);
+    const median = pricePoints[Math.floor(pricePoints.length / 2)];
+    const ceiling = median * 4;
+    for (const country of countriesResult) {
+      const item = country.items.find(i => i.itemId === itemId);
+      if (!item?.usdPrice || item.usdPrice <= ceiling) continue;
+      console.warn(`  [outlier] ${country.code}/${itemId}: $${item.usdPrice.toFixed(2)} > 4× median $${median.toFixed(2)} — clearing + evicting learned route`);
+      item.available = false;
+      item.localPrice = null;
+      item.usdPrice = null;
+      outlierEvictions.add(`${country.code}:${itemId}`);
+    }
+  }
+  if (outlierEvictions.size > 0) {
+    await bulkWriteLearnedRoutes('grocery-basket', new Map(), outlierEvictions).catch(err =>
+      console.warn(`  [routes] outlier eviction write failed (non-fatal): ${err.message}`)
+    );
+  }
+  // Recompute totals after outlier pass
+  for (const country of countriesResult) {
+    country.totalUsd = +country.items.reduce((s, ip) => s + (ip.usdPrice ?? 0), 0).toFixed(2);
+  }
+
   // Only rank countries with enough items found — a country with 4/10 items
   // could appear "cheapest" purely due to missing data, not actual prices.
   const MIN_ITEMS_FOR_RANKING = Math.ceil(config.items.length * 0.7); // ≥ 70% coverage
@@ -370,7 +417,13 @@ const prevSnapshot = await readSeedSnapshot(CANONICAL_KEY);
 
 await runSeed('economic', 'grocery-basket', CANONICAL_KEY, () => fetchGroceryBasketPrices(prevSnapshot), {
   ttlSeconds: CACHE_TTL,
-  validateFn: (data) => data?.countries?.length > 0,
+  validateFn: (data) => {
+    if (!data?.countries?.length) return false;
+    const minItems = Math.ceil(config.items.length * 0.4); // 40% item coverage per country
+    const covered = data.countries.filter(c => c.items.filter(i => i.available).length >= minItems);
+    if (covered.length < 5) { console.warn(`  [validate] only ${covered.length} countries with ≥40% item coverage — rejecting`); return false; }
+    return true;
+  },
   recordCount: (data) => data?.countries?.length || 0,
   extraKeys: prevSnapshot ? [{
     key: `${CANONICAL_KEY}:prev`,

--- a/scripts/shared/grocery-basket.json
+++ b/scripts/shared/grocery-basket.json
@@ -32,8 +32,8 @@
     },
     {
       "id": "oil",
-      "name": "Cooking Oil",
-      "query": "sunflower cooking oil 1L",
+      "name": "Canola Oil",
+      "query": "canola oil 1L",
       "unit": "1L"
     },
     {

--- a/shared/grocery-basket.json
+++ b/shared/grocery-basket.json
@@ -32,8 +32,8 @@
     },
     {
       "id": "oil",
-      "name": "Cooking Oil",
-      "query": "sunflower cooking oil 1L",
+      "name": "Canola Oil",
+      "query": "canola oil 1L",
       "unit": "1L"
     },
     {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -21145,7 +21145,7 @@ body.has-breaking-alert .panels-grid {
   vertical-align: top;
 }
 
-.gb-table .gb-item-col { min-width: 100px; text-align: left; }
+.gb-table .gb-item-col { min-width: 110px; text-align: left; position: sticky; left: 0; z-index: 2; background: var(--panel-bg); }
 
 .gb-country-header {
   text-align: center;
@@ -21158,9 +21158,11 @@ body.has-breaking-alert .panels-grid {
 
 .gb-table .gb-item-name {
   font-weight: 500;
-  background: var(--overlay-subtle);
+  min-width: 110px;
   position: sticky;
   left: 0;
+  z-index: 2;
+  background: var(--panel-bg);
   text-align: left;
 }
 
@@ -21204,6 +21206,8 @@ body.has-breaking-alert .panels-grid {
   text-align: right;
 }
 .gb-wow {
-  font-size: 0.7rem;
-  margin-left: 4px;
+  display: block;
+  font-size: 0.6rem;
+  opacity: 0.85;
+  margin-top: 1px;
 }

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -2403,7 +2403,7 @@
 .gb-scroll { overflow-x: auto; }
 .gb-table { border-collapse: collapse; width: 100%; font-size: 0.75rem; }
 .gb-table th, .gb-table td { padding: 4px 6px; border: 1px solid rgba(255,255,255,0.08); text-align: right; white-space: nowrap; }
-.gb-item-col, .gb-item-name { text-align: left; min-width: 100px; }
+.gb-item-col, .gb-item-name { text-align: left; min-width: 110px; position: sticky; left: 0; z-index: 2; background: var(--panel-bg); }
 .gb-country-header { text-align: center; font-weight: 600; min-width: 80px; }
 .gb-country-name { font-size: 0.65rem; opacity: 0.7; }
 .gb-cell { position: relative; }
@@ -2413,4 +2413,5 @@
 .gb-cheapest { background: rgba(34,197,94,0.15); color: #4ade80; }
 .gb-priciest { background: rgba(239,68,68,0.1); color: #f87171; }
 .gb-total-row td { border-top: 2px solid rgba(255,255,255,0.2); }
+.gb-wow { display: block; font-size: 0.6rem; opacity: 0.85; margin-top: 1px; }
 .gb-updated { font-size: 0.65rem; opacity: 0.4; text-align: right; padding: 4px 6px; }


### PR DESCRIPTION
## Why this PR?

Four interrelated data quality and UX issues in the Grocery Price Index panel.

## Changes

**Oil item accuracy**
- Rename "Cooking Oil" → "Canola Oil", query `"sunflower cooking oil 1L"` → `"canola oil 1L"`
- Tighter cap: `ITEM_USD_MAX.oil` 15 → 10 (canola oil globally tops ~$7; $10 gives buffer)
- Auto-evict all cached `*:oil` learned routes on next seed run since the product type changed

**Tighter per-item USD caps** (root cause of France sugar $6.94 = organic 5.99 EUR slipping through)
- sugar 8 → 3.5, salt 5 → 2.5, pasta 4 → 3.5, flour 8 → 4.5, milk 8 → 5, bread 8 → 6

**4x median outlier gate with Redis eviction**
- After all countries are scraped, compute per-item median across countries
- Flag any price > 4x median, mark item unavailable, evict its learned route from Redis
- Prevents bad URLs from permanently poisoning subsequent runs

**Stronger validateFn**
- Reject entire seed if fewer than 5 countries have ≥40% item coverage

**CSS: sticky first column**
- `.gb-item-col` and `.gb-item-name` get `position: sticky; left: 0; z-index: 2; background: var(--panel-bg)` so item names stay visible when scrolling right

**CSS: .gb-wow rule**
- WoW badges in the total row were invisible (class was generated but had no style); added `display: block; font-size: 0.6rem; opacity: 0.85; margin-top: 1px`

## Test plan

- [ ] All 2294 data tests pass (`npm run test:data`)
- [ ] TypeScript typecheck passes
- [ ] Biome lint clean
- [ ] Edge function tests pass (125 tests)
- [ ] On next Railway seed run: observe `[routes] evicting N stale oil routes` in logs
- [ ] Verify oil column shows canola oil prices (not avocado/sunflower/bulk oil)
- [ ] Verify item names stay fixed while scrolling the table horizontally
- [ ] Verify WoW % badges appear in the Total row