### PR TITLE
fix(health): bump usniFleet maxStaleMin 480→720 (2× 6h relay interval)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -150,7 +150,7 @@ const SEED_META = {
   corridorrisk:        { key: 'seed-meta:supply_chain:corridorrisk',         maxStaleMin: 120 },
   chokepointTransits:  { key: 'seed-meta:supply_chain:chokepoint_transits',  maxStaleMin: 30 }, // relay every 10min; 30min = 3x interval,
   transitSummaries:    { key: 'seed-meta:supply_chain:transit-summaries',    maxStaleMin: 30 }, // relay every 10min; 30min = 3x interval,
-  usniFleet:           { key: 'seed-meta:military:usni-fleet',               maxStaleMin: 480 },
+  usniFleet:           { key: 'seed-meta:military:usni-fleet',               maxStaleMin: 720 }, // relay loop every 6h; 720 = 2× interval (was 480 = 1.3×, too tight)
   securityAdvisories:  { key: 'seed-meta:intelligence:advisories',           maxStaleMin: 120 },
   customsRevenue:      { key: 'seed-meta:trade:customs-revenue',              maxStaleMin: 1440 },
   comtradeFlows:       { key: 'seed-meta:trade:comtrade-flows',               maxStaleMin: 2880 }, // 24h cron; 2880min = 48h = 2x interval


### PR DESCRIPTION
## Why

\`usniFleet\` kept firing \`STALE_SEED\` warnings because the relay loop runs every 6h but \`maxStaleMin\` was set to 480min (1.3× interval). Any slight relay delay triggers a false alarm.

**Pattern:** \`maxStaleMin\` should be ≥ 2× write interval. USNI relay is 6h (360min) → threshold should be 720min, matching the Redis TTL (\`USNI_TTL = 43200s = 12h\`).

## Change

| Key | Before | After | Interval |
|-----|--------|-------|----------|
| \`usniFleet\` | 480min | 720min | 6h relay loop |

## Test plan
- [ ] Health shows \`usniFleet: OK\` after deploy