### PR TITLE
feat(contact): add IP and country to enterprise notification email

### DIFF
--- a/api/contact.js
+++ b/api/contact.js
@@ -29,7 +29,7 @@ const RATE_WINDOW_MS = 60 * 60 * 1000;
 
 const rateLimiter = createIpRateLimiter({ limit: RATE_LIMIT, windowMs: RATE_WINDOW_MS });
 
-async function sendNotificationEmail(name, email, organization, phone, message) {
+async function sendNotificationEmail(name, email, organization, phone, message, ip, country) {
   const resendKey = process.env.RESEND_API_KEY;
   if (!resendKey) {
     console.error('[contact] RESEND_API_KEY not set — lead stored in Convex but notification NOT sent');
@@ -58,6 +58,8 @@ async function sendNotificationEmail(name, email, organization, phone, message) 
               <tr><td style="padding: 8px; font-weight: bold; color: #666;">Company</td><td style="padding: 8px;">${escapeHtml(organization)}</td></tr>
               <tr><td style="padding: 8px; font-weight: bold; color: #666;">Phone</td><td style="padding: 8px;"><a href="tel:${escapeHtml(phone)}">${escapeHtml(phone)}</a></td></tr>
               <tr><td style="padding: 8px; font-weight: bold; color: #666;">Message</td><td style="padding: 8px;">${escapeHtml(message || 'N/A')}</td></tr>
+              <tr><td style="padding: 8px; font-weight: bold; color: #666;">IP</td><td style="padding: 8px; font-family: monospace;">${escapeHtml(ip || 'unknown')}</td></tr>
+              ${country ? `<tr><td style="padding: 8px; font-weight: bold; color: #666;">Country</td><td style="padding: 8px;">${escapeHtml(country)}</td></tr>` : ''}
             </table>
             <p style="color: #999; font-size: 12px; margin-top: 24px;">Sent from worldmonitor.app enterprise contact form</p>
           </div>`,
@@ -103,6 +105,7 @@ export default async function handler(req) {
   }
 
   const ip = getClientIp(req);
+  const country = req.headers.get('cf-ipcountry') || req.headers.get('x-vercel-ip-country') || null;
 
   if (rateLimiter.isRateLimited(ip)) {
     return jsonResponse({ error: 'Too many requests' }, 429, cors);
@@ -172,7 +175,7 @@ export default async function handler(req) {
       source: safeSource,
     });
 
-    const emailSent = await sendNotificationEmail(safeName, email.trim(), safeOrg, safePhone, safeMsg);
+    const emailSent = await sendNotificationEmail(safeName, email.trim(), safeOrg, safePhone, safeMsg, ip, country);
 
     return jsonResponse({ status: 'sent', emailSent }, 200, cors);
   } catch (err) {


### PR DESCRIPTION
## Why

Enterprise form submissions currently have no sender metadata. Adds IP address and country to the notification email for quick authenticity checks (e.g. \`business@palantir.com\` submitting from RU/CN is a red flag).

## How

- `ip`: already extracted via `getClientIp()` (reads `cf-connecting-ip` first, per rate-limit pattern)
- `country`: reads `cf-ipcountry` header (set by Cloudflare on every request) with `x-vercel-ip-country` as fallback
- Both appended as new rows in the notification email table after Message
- Country row omitted entirely if header is absent (non-CF environments)

## Test plan
- [ ] Submit enterprise form → email shows IP and country rows