### PR TITLE
fix(simulation): hoist VALID_RUN_ID_RE to fix TDZ crash on enqueue

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -38,6 +38,7 @@ const SIMULATION_RUNNER_VERSION = 'v1';
 const SIMULATION_TASK_KEY_PREFIX = 'forecast:simulation-task:v1';
 const SIMULATION_TASK_QUEUE_KEY = 'forecast:simulation-task-queue:v1';
 const SIMULATION_LOCK_KEY_PREFIX = 'forecast:simulation-lock:v1';
+const VALID_RUN_ID_RE = /^\d{13,}-[a-z0-9-]{1,64}$/i;
 const SIMULATION_ROUND1_MAX_TOKENS = 2200;
 const SIMULATION_ROUND2_MAX_TOKENS = 2500;
 const SIMULATION_LOCK_TTL_SECONDS = 20 * 60;
@@ -15632,7 +15633,6 @@ async function writeSimulationOutcome(pkg, outcome, { storageConfig } = {}) {
   return { outcomeKey };
 }
 
-const VALID_RUN_ID_RE = /^\d{13,}-[a-z0-9-]{1,64}$/i;
 function validateRunId(runId) { return typeof runId === 'string' && VALID_RUN_ID_RE.test(runId); }
 
 function buildSimulationTaskKey(runId) { return `${SIMULATION_TASK_KEY_PREFIX}:${runId}`; }


### PR DESCRIPTION
## Problem

After the seed-forecasts run writes the simulation package, it calls `.then(() => enqueueSimulationTask(runId))`. This `.then()` microtask fires while the module is still evaluating (inside the top-level `await runSeed(...)` at line ~15331). At that point, `VALID_RUN_ID_RE` — declared at line 15689 — is still in the Temporal Dead Zone, causing:

```
[SimulationPackage] Write/enqueue failed: Cannot access 'VALID_RUN_ID_RE' before initialization
```

## Fix

Moved `VALID_RUN_ID_RE` to line 40 (beside the other simulation constants, well before `_isDirectRun`), and removed the now-duplicate declaration at the old location.

## Post-Deploy Validation

- Run seed-forecasts → check logs for absence of `Cannot access 'VALID_RUN_ID_RE'`
- Check `forecast:simulation-task-queue:v1` in Redis → should have a runId entry after the run
- simulation-worker cron should then pick it up and log `[Simulation] completed`