### PR TITLE
fix(layers): unhide sanctions layer on flat map

### DIFF
--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -116,8 +116,6 @@ const VARIANT_LAYER_ORDER: Record<MapVariant, Array<keyof MapLayers>> = {
   ],
 };
 
-const SVG_ONLY_LAYERS: Partial<Record<MapVariant, Array<keyof MapLayers>>> = {};
-
 const I18N_PREFIX = 'components.deckgl.layers.';
 
 export function getLayersForVariant(variant: MapVariant, renderer: MapRenderer): LayerDefinition[] {
@@ -128,9 +126,7 @@ export function getLayersForVariant(variant: MapVariant, renderer: MapRenderer):
 }
 
 export function getAllowedLayerKeys(variant: MapVariant): Set<keyof MapLayers> {
-  const keys = new Set(VARIANT_LAYER_ORDER[variant] ?? VARIANT_LAYER_ORDER.full);
-  for (const k of SVG_ONLY_LAYERS[variant] ?? []) keys.add(k);
-  return keys;
+  return new Set(VARIANT_LAYER_ORDER[variant] ?? VARIANT_LAYER_ORDER.full);
 }
 
 export function sanitizeLayersForVariant(layers: MapLayers, variant: MapVariant): MapLayers {

--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -59,7 +59,7 @@ export const LAYER_REGISTRY: Record<keyof MapLayers, LayerDefinition> = {
   gpsJamming:               def('gpsJamming',               '&#128225;', 'gpsJamming',               'GPS Jamming', ['flat', 'globe'], _desktop ? 'locked' : undefined),
   ciiChoropleth:            def('ciiChoropleth',            '&#127758;', 'ciiChoropleth',            'CII Instability', ['flat'], _desktop ? 'enhanced' : undefined),
   dayNight:                 def('dayNight',                 '&#127763;', 'dayNight',                 'Day/Night', ['flat']),
-  sanctions:                def('sanctions',                '&#128683;', 'sanctions',                'Sanctions', []),
+  sanctions:                def('sanctions',                '&#128683;', 'sanctions',                'Sanctions', ['flat']),
   startupHubs:              def('startupHubs',              '&#128640;', 'startupHubs',              'Startup Hubs'),
   techHQs:                  def('techHQs',                  '&#127970;', 'techHQs',                  'Tech HQs'),
   accelerators:             def('accelerators',             '&#9889;',   'accelerators',             'Accelerators'),
@@ -91,7 +91,7 @@ const VARIANT_LAYER_ORDER: Record<MapVariant, Array<keyof MapLayers>> = {
     'ucdpEvents', 'displacement', 'climate', 'weather',
     'outages', 'cyberThreats', 'natural', 'fires',
     'waterways', 'economic', 'minerals', 'gpsJamming',
-    'satellites', 'ciiChoropleth', 'dayNight', 'webcams', 'weatherRadar',
+    'satellites', 'ciiChoropleth', 'sanctions', 'dayNight', 'webcams', 'weatherRadar',
   ],
   tech: [
     'startupHubs', 'techHQs', 'accelerators', 'cloudRegions',
@@ -102,7 +102,7 @@ const VARIANT_LAYER_ORDER: Record<MapVariant, Array<keyof MapLayers>> = {
     'stockExchanges', 'financialCenters', 'centralBanks', 'commodityHubs',
     'gulfInvestments', 'tradeRoutes', 'cables', 'pipelines',
     'outages', 'weather', 'economic', 'waterways',
-    'natural', 'cyberThreats', 'dayNight', 'weatherRadar',
+    'natural', 'cyberThreats', 'sanctions', 'dayNight', 'weatherRadar',
   ],
   happy: [
     'positiveEvents', 'kindness', 'happiness',
@@ -112,15 +112,11 @@ const VARIANT_LAYER_ORDER: Record<MapVariant, Array<keyof MapLayers>> = {
     'miningSites', 'processingPlants', 'commodityPorts', 'commodityHubs',
     'minerals', 'pipelines', 'waterways', 'tradeRoutes',
     'ais', 'economic', 'fires', 'climate',
-    'natural', 'weather', 'outages', 'dayNight', 'weatherRadar',
+    'natural', 'weather', 'outages', 'sanctions', 'dayNight', 'weatherRadar',
   ],
 };
 
-const SVG_ONLY_LAYERS: Partial<Record<MapVariant, Array<keyof MapLayers>>> = {
-  full: ['sanctions'],
-  finance: ['sanctions'],
-  commodity: ['sanctions'],
-};
+const SVG_ONLY_LAYERS: Partial<Record<MapVariant, Array<keyof MapLayers>>> = {};
 
 const I18N_PREFIX = 'components.deckgl.layers.';
 


### PR DESCRIPTION
## Summary

- Sanctions layer was registered with `renderers: []` (empty), making it invisible in the layers panel on all variants
- Changed to `['flat']` and added to `VARIANT_LAYER_ORDER` for `full`, `finance`, and `commodity` variants
- Removed the now-redundant `SVG_ONLY_LAYERS` workaround that was added as a patch

## Test plan

- [ ] Search "sanction" in the layers panel on full/finance/commodity variants — layer appears
- [ ] Toggle on: sanctioned countries show red/orange/yellow fills on flat map
- [ ] Globe map: layer not shown (flat-only, correct)
- [ ] Cmd+K "Panel: Sanctions Pressure" still works