### PR TITLE
fix(health): bump weatherAlerts maxStaleMin 30→45 (3× 15min relay interval)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -134,7 +134,7 @@ const SEED_META = {
   ucdpEvents:       { key: 'seed-meta:conflict:ucdp-events',      maxStaleMin: 420 },
   militaryFlights:  { key: 'seed-meta:military:flights',           maxStaleMin: 30 }, // cron ~10min (LIVE_TTL=600s); 30min = 3x interval,
   satellites:       { key: 'seed-meta:intelligence:satellites',    maxStaleMin: 240 }, // CelesTrak every 120min; 240min = absorbs one missed cycle
-  weatherAlerts:    { key: 'seed-meta:weather:alerts',             maxStaleMin: 30 },
+  weatherAlerts:    { key: 'seed-meta:weather:alerts',             maxStaleMin: 45 }, // relay loop every 15min; 45 = 3× interval (was 30 = 2×, too tight on relay hiccup)
   spending:         { key: 'seed-meta:economic:spending',          maxStaleMin: 120 },
   techEvents:       { key: 'seed-meta:research:tech-events',       maxStaleMin: 480 },
   gdeltIntel:       { key: 'seed-meta:intelligence:gdelt-intel',   maxStaleMin: 420 }, // 6h cron + 1h grace; CACHE_TTL is 24h so per-topic merge always has a prior snapshot


### PR DESCRIPTION
## Why

\`weatherAlerts\` fired \`STALE_SEED\` at age 38min against a 30min threshold. Seed TTL is 15min but any relay hiccup pushes past 2×. Bumping to 3× (45min) matches the same pattern applied to \`usniFleet\` (PR #2235) and \`wildfires\` (PR #2227).

| Key | Interval | Before | After |
|-----|----------|--------|-------|
| \`weatherAlerts\` | 15min | 30min | 45min |