### PR TITLE
fix(relay): refresh seed-meta on empty NWS response to prevent false STALE_SEED

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -200,7 +200,7 @@ const ON_DEMAND_KEYS = new Set([
 
 // Keys where 0 records is a valid healthy state (e.g. no airports closed).
 // The key must still exist in Redis; only the record count can be 0.
-const EMPTY_DATA_OK_KEYS = new Set(['notamClosures', 'faaDelays', 'gpsjam', 'positiveGeoEvents']);
+const EMPTY_DATA_OK_KEYS = new Set(['notamClosures', 'faaDelays', 'gpsjam', 'positiveGeoEvents', 'weatherAlerts']);
 
 // Cascade groups: if any key in the group has data, all empty siblings are OK.
 // Theater posture uses live → stale → backup fallback chain.

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3709,7 +3709,10 @@ async function seedWeatherAlerts() {
         };
       });
     if (alerts.length === 0) {
-      console.warn('[Weather] No alerts returned — preserving last good data');
+      // NWS responded successfully but has no active alerts — valid quiet state.
+      // Still bump seed-meta so health.js knows the loop ran (avoids false STALE_SEED).
+      await upstashSet('seed-meta:weather:alerts', { fetchedAt: Date.now(), recordCount: 0 }, 604800);
+      console.log('[Weather] No active alerts — seed-meta refreshed, existing data preserved');
       return;
     }
     const payload = { alerts };


### PR DESCRIPTION
## Root cause

`seedWeatherAlerts()` had two early-return paths that skipped the `seed-meta:weather:alerts` write:

1. `alerts.length === 0` — NWS responded successfully but has no active alerts (valid quiet state)
2. `!resp.ok` — HTTP error from NWS

After the transient `fetch failed` error seen in logs at 18:49 UTC, subsequent runs that returned empty alerts never bumped `fetchedAt`. Health.js saw the old timestamp grow from 30min → 55min+ → false \`STALE_SEED\` alarm even though the relay loop was running fine (15 other keys fresh <10min confirmed).

## Changes

- **`ais-relay.cjs`**: On `alerts.length === 0` path, write seed-meta with \`fetchedAt: now, recordCount: 0\` before returning. NWS succeeding with zero alerts is a valid state (no severe weather) — the loop should still be acknowledged as running.
- **`api/health.js`**: Add \`weatherAlerts\` to \`EMPTY_DATA_OK_KEYS\` — zero active alerts is healthy (same as \`notamClosures\`, \`faaDelays\`).
- HTTP error path left unchanged: prolonged NWS outage should still surface as STALE_SEED.

## Test plan
- [ ] After relay deploy, health shows \`weatherAlerts: OK\` when NWS returns no active alerts
- [ ] STALE_SEED still triggers if NWS is unreachable for >45min (separate PR #2240)