### PR TITLE
fix(economic): BIS seed — write exchange/credit keys via afterPublish (Central Banks tab fix)

### DIFF
--- a/scripts/seed-bis-data.mjs
+++ b/scripts/seed-bis-data.mjs
@@ -188,7 +188,6 @@ async function fetchCreditToGdp() {
 }
 
 // --- Main seed ---
-let seedData = null;
 
 async function fetchAll() {
   const [policy, exchange, credit] = await Promise.all([
@@ -196,25 +195,36 @@ async function fetchAll() {
     fetchExchangeRates(),
     fetchCreditToGdp(),
   ]);
-  seedData = { policy, exchange, credit };
   const total = (policy?.rates?.length || 0) + (exchange?.rates?.length || 0) + (credit?.entries?.length || 0);
   if (total === 0) throw new Error('All BIS fetches returned empty');
-  return seedData;
+  return { policy, exchange, credit };
 }
 
 function validate(data) {
   return data?.policy || data?.exchange || data?.credit;
 }
 
-runSeed('economic', 'bis', KEYS.policy, fetchAll, {
-  validateFn: validate,
-  ttlSeconds: TTL,
-  sourceVersion: 'bis-sdmx-csv',
-}).then(async (result) => {
-  if (result?.skipped || !seedData) return;
-  if (seedData.exchange) await writeExtraKey(KEYS.exchange, seedData.exchange, TTL);
-  if (seedData.credit) await writeExtraKey(KEYS.credit, seedData.credit, TTL);
-}).catch((err) => {
-  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
-  process.exit(1);
-});
+// publishTransform: store only policy data (correct shape) at canonical key.
+// runSeed() calls process.exit(0) — .then() is unreachable; use afterPublish instead.
+function publishTransform(data) {
+  return data.policy ?? { rates: [] };
+}
+
+async function afterPublish(data) {
+  if (data.exchange) await writeExtraKey(KEYS.exchange, data.exchange, TTL);
+  if (data.credit) await writeExtraKey(KEYS.credit, data.credit, TTL);
+}
+
+if (process.argv[1]?.endsWith('seed-bis-data.mjs')) {
+  runSeed('economic', 'bis', KEYS.policy, fetchAll, {
+    validateFn: validate,
+    ttlSeconds: TTL,
+    sourceVersion: 'bis-sdmx-csv',
+    publishTransform,
+    afterPublish,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
+    console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(0);
+  });
+}

--- a/scripts/seed-bis-data.mjs
+++ b/scripts/seed-bis-data.mjs
@@ -200,8 +200,9 @@ async function fetchAll() {
   return { policy, exchange, credit };
 }
 
+// validateFn receives the post-transform data ({ rates: [...] }), not the raw fetchAll shape.
 function validate(data) {
-  return data?.policy || data?.exchange || data?.credit;
+  return Array.isArray(data?.rates) && data.rates.length > 0;
 }
 
 // publishTransform: store only policy data (correct shape) at canonical key.
@@ -225,6 +226,6 @@ if (process.argv[1]?.endsWith('seed-bis-data.mjs')) {
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);
-    process.exit(0);
+    process.exit(1);
   });
 }


### PR DESCRIPTION
## Why this PR?

The **Central Banks** and **Labor Market** tabs in the Macro Stress panel were permanently hidden despite the BIS seed running successfully. Root cause was a double bug in `seed-bis-data.mjs`.

## Root causes

**Bug 1 — Unreachable `.then()`**
`runSeed()` calls `process.exit(0)` internally. The `.then()` that was supposed to write `economic:bis:eer:v1` and `economic:bis:credit:v1` never ran. Both Redis keys stayed empty on every seed cycle.

**Bug 2 — Wrong shape at canonical key**
`fetchAll()` returns `{ policy, exchange, credit }`. This compound object was stored directly at `economic:bis:policy:v1`. The `getBisPolicyRates` handler expected `{ rates: [...] }` there. It got a truthy object with no `.rates` → returned `{ rates: [] }` → `policyRates = []` → `hasBis = false` → tab hidden.

## Fix

- `publishTransform`: store only `data.policy` (`{ rates: [...] }`) at the canonical key — correct shape for the RPC handler
- `afterPublish`: write `data.exchange` and `data.credit` to their respective keys — this hook runs inside `runSeed()` before `process.exit(0)`
- Added `isMain` guard (consistent with other seed scripts)

## Test plan
- [ ] `npm run test:data` — 2238 pass
- [ ] `npm run typecheck` — clean
- [ ] After next Railway seed run: `economic:bis:eer:v1` and `economic:bis:credit:v1` will be populated
- [ ] Central Banks tab appears in Macro Stress panel (once seed reruns with this fix)