### PR TITLE
feat(settings): add save feedback for preferences changes

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -42,6 +42,7 @@ import { getNearbyInfrastructure } from '@/services/related-assets';
 import { toFlagEmoji } from '@/utils/country-flag';
 import { buildDependencyGraph } from '@/services/infrastructure-cascade';
 import { getActiveFrameworkForPanel, subscribeFrameworkChange } from '@/services/analysis-framework-store';
+import { showToast } from '@/utils/toast';
 
 type IntlDisplayNamesCtor = new (
   locales: string | string[],
@@ -980,7 +981,7 @@ export class CountryIntelManager implements AppModule {
 
   openCountryStory(code: string, name: string): void {
     if (!dataFreshness.hasSufficientData() || this.ctx.latestClusters.length === 0) {
-      this.showToast('Data still loading — try again in a moment');
+      showToast('Data still loading — try again in a moment');
       return;
     }
     const posturePanel = this.ctx.panels['strategic-posture'] as StrategicPosturePanel | undefined;
@@ -995,16 +996,6 @@ export class CountryIntelManager implements AppModule {
     } : null;
     const data = collectStoryData(code, name, this.ctx.latestClusters, postures, this.ctx.latestPredictions, signals, convergence);
     openStoryModal(data);
-  }
-
-  showToast(msg: string): void {
-    document.querySelector('.toast-notification')?.remove();
-    const el = document.createElement('div');
-    el.className = 'toast-notification';
-    el.textContent = msg;
-    document.body.appendChild(el);
-    requestAnimationFrame(() => el.classList.add('visible'));
-    setTimeout(() => { el.classList.remove('visible'); setTimeout(() => el.remove(), 300); }, 3000);
   }
 
   private getCountryStrikes(code: string, hasGeoShape: boolean): typeof this.ctx.intelligenceCache.iranEvents & object {

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -66,6 +66,7 @@ import { AuthHeaderWidget } from '@/components/AuthHeaderWidget';
 import { t } from '@/services/i18n';
 import { TvModeController } from '@/services/tv-mode';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
+import { showToast } from '@/utils/toast';
 
 export interface EventHandlerCallbacks {
   updateSearchIndex: () => void;
@@ -1039,7 +1040,7 @@ export class EventHandlerManager implements AppModule {
           const allSources = this.getAllSourceNames();
           const currentlyEnabled = allSources.filter(n => !this.ctx.disabledSources.has(n)).length;
           if (currentlyEnabled + 1 > FREE_MAX_SOURCES) {
-            this.showToast(t('modals.settingsWindow.freeSourceLimit', { max: String(FREE_MAX_SOURCES) }));
+            showToast(t('modals.settingsWindow.freeSourceLimit', { max: String(FREE_MAX_SOURCES) }));
             return;
           }
         }
@@ -1056,7 +1057,7 @@ export class EventHandlerManager implements AppModule {
           const currentlyEnabled = allSources.filter(n => !this.ctx.disabledSources.has(n)).length;
           const wouldEnable = names.filter(n => this.ctx.disabledSources.has(n) && allSources.includes(n)).length;
           if (currentlyEnabled + wouldEnable > FREE_MAX_SOURCES) {
-            this.showToast(t('modals.settingsWindow.freeSourceLimit', { max: String(FREE_MAX_SOURCES) }));
+            showToast(t('modals.settingsWindow.freeSourceLimit', { max: String(FREE_MAX_SOURCES) }));
             return;
           }
         }
@@ -1253,16 +1254,6 @@ export class EventHandlerManager implements AppModule {
         }
       }
     }
-  }
-
-  showToast(msg: string): void {
-    document.querySelector('.toast-notification')?.remove();
-    const el = document.createElement('div');
-    el.className = 'toast-notification';
-    el.textContent = msg;
-    document.body.appendChild(el);
-    requestAnimationFrame(() => el.classList.add('visible'));
-    setTimeout(() => { el.classList.remove('visible'); setTimeout(() => el.remove(), 300); }, 3000);
   }
 
   shouldShowIntelligenceNotifications(): boolean {

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -5,20 +5,11 @@ import { SITE_VARIANT } from '@/config/variant';
 import { t } from '@/services/i18n';
 import type { MapProvider } from '@/config/basemap';
 import { escapeHtml } from '@/utils/sanitize';
+import { showToast } from '@/utils/toast';
 import type { PanelConfig } from '@/types';
 import { renderPreferences } from '@/services/preferences-content';
 import { getAuthState } from '@/services/auth-state';
 import { track } from '@/services/analytics';
-
-function showToast(msg: string): void {
-  document.querySelector('.toast-notification')?.remove();
-  const el = document.createElement('div');
-  el.className = 'toast-notification';
-  el.textContent = msg;
-  document.body.appendChild(el);
-  requestAnimationFrame(() => el.classList.add('visible'));
-  setTimeout(() => { el.classList.remove('visible'); setTimeout(() => el.remove(), 300); }, 4000);
-}
 
 const GEAR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`;
 
@@ -219,6 +210,8 @@ export class UnifiedSettings {
       isDesktopApp: this.config.isDesktopApp,
       onMapProviderChange: this.config.onMapProviderChange,
       isSignedIn: !this.config.isDesktopApp && (getAuthState().user !== null),
+      isSignedIn: !this.config.isDesktopApp && (getAuthState().user !== null),
+      onSettingSaved: () => showToast(t('modals.settingsWindow.saved')),
     });
 
     this.overlay.innerHTML = `

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -210,8 +210,7 @@ export class UnifiedSettings {
       isDesktopApp: this.config.isDesktopApp,
       onMapProviderChange: this.config.onMapProviderChange,
       isSignedIn: !this.config.isDesktopApp && (getAuthState().user !== null),
-      isSignedIn: !this.config.isDesktopApp && (getAuthState().user !== null),
-      onSettingSaved: () => showToast(t('modals.settingsWindow.saved')),
+      onSettingSaved: () => showToast(t('modals.settingsWindow.saved'), 4000),
     });
 
     this.overlay.innerHTML = `
@@ -399,7 +398,7 @@ export class UnifiedSettings {
     if (!panel.enabled && !isProUser()) {
       const enabledCount = Object.entries(this.draftPanelSettings).filter(([k, p]) => p.enabled && !k.startsWith('cw-')).length;
       if (enabledCount >= FREE_MAX_PANELS) {
-        showToast(t('modals.settingsWindow.freePanelLimit', { max: String(FREE_MAX_PANELS) }));
+        showToast(t('modals.settingsWindow.freePanelLimit', { max: String(FREE_MAX_PANELS) }), 4000);
         return;
       }
     }

--- a/src/services/preferences-content.ts
+++ b/src/services/preferences-content.ts
@@ -37,8 +37,6 @@ export interface PreferencesHost {
   onMapProviderChange?: (provider: MapProvider) => void;
   isSignedIn?: boolean;
   onSettingSaved?: () => void;
-  isSignedIn?: boolean;
-  onSettingSaved?: () => void;
 }
 
 export interface PreferencesResult {

--- a/src/services/preferences-content.ts
+++ b/src/services/preferences-content.ts
@@ -36,6 +36,9 @@ export interface PreferencesHost {
   isDesktopApp: boolean;
   onMapProviderChange?: (provider: MapProvider) => void;
   isSignedIn?: boolean;
+  onSettingSaved?: () => void;
+  isSignedIn?: boolean;
+  onSettingSaved?: () => void;
 }
 
 export interface PreferencesResult {
@@ -87,6 +90,88 @@ function updateAiStatus(container: HTMLElement): void {
     dot.classList.add('disabled');
     text.textContent = t('components.insights.aiFlowStatusDisabled');
   }
+}
+
+function handleSettingsImport(target: HTMLInputElement, container: HTMLElement): boolean {
+  if (target.id !== 'usImportInput') return false;
+
+  const file = target.files?.[0];
+  if (!file) return true;
+
+  importSettings(file).then((result: ImportResult) => {
+    showToast(container, t('components.settings.importSuccess', { count: String(result.keysImported) }), true);
+  }).catch(() => {
+    showToast(container, t('components.settings.importFailed'), false);
+  });
+  target.value = '';
+  return true;
+}
+
+function handlePreferenceChange(target: HTMLInputElement, container: HTMLElement, host: PreferencesHost): boolean {
+  if (target.id === 'us-stream-quality') {
+    setStreamQuality(target.value as StreamQuality);
+    return true;
+  }
+  if (target.id === 'us-globe-visual-preset') {
+    setGlobeVisualPreset(target.value as GlobeVisualPreset);
+    return true;
+  }
+  if (target.id === 'us-theme') {
+    setThemePreference(target.value as ThemePreference);
+    return true;
+  }
+  if (target.id === 'us-font-family') {
+    setFontFamily(target.value as FontFamily);
+    return true;
+  }
+  if (target.id === 'us-map-provider') {
+    const provider = target.value as MapProvider;
+    setMapProvider(provider);
+    renderMapThemeDropdown(container, provider);
+    host.onMapProviderChange?.(provider);
+    window.dispatchEvent(new CustomEvent('map-theme-changed'));
+    return true;
+  }
+  if (target.id === 'us-map-theme') {
+    const provider = getMapProvider();
+    setMapTheme(provider, target.value);
+    window.dispatchEvent(new CustomEvent('map-theme-changed'));
+    return true;
+  }
+  if (target.id === 'us-live-streams-always-on') {
+    setLiveStreamsAlwaysOn(target.checked);
+    return true;
+  }
+  if (target.id === 'us-language') {
+    trackLanguageChange(target.value);
+    void changeLanguage(target.value);
+    return true;
+  }
+  if (target.id === 'us-cloud') {
+    setAiFlowSetting('cloudLlm', target.checked);
+    updateAiStatus(container);
+    return true;
+  }
+  if (target.id === 'us-browser') {
+    setAiFlowSetting('browserModel', target.checked);
+    const warn = container.querySelector('.ai-flow-toggle-warn') as HTMLElement;
+    if (warn) warn.style.display = target.checked ? 'block' : 'none';
+    updateAiStatus(container);
+    return true;
+  }
+  if (target.id === 'us-map-flash') {
+    setAiFlowSetting('mapNewsFlash', target.checked);
+    return true;
+  }
+  if (target.id === 'us-headline-memory') {
+    setAiFlowSetting('headlineMemory', target.checked);
+    return true;
+  }
+  if (target.id === 'us-badge-anim') {
+    setAiFlowSetting('badgeAnimation', target.checked);
+    return true;
+  }
+  return false;
 }
 
 export function renderPreferences(host: PreferencesHost): PreferencesResult {
@@ -371,72 +456,9 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
       container.addEventListener('change', (e) => {
         const target = e.target as HTMLInputElement;
 
-        if (target.id === 'usImportInput') {
-          const file = target.files?.[0];
-          if (!file) return;
-          importSettings(file).then((result: ImportResult) => {
-            showToast(container, t('components.settings.importSuccess', { count: String(result.keysImported) }), true);
-          }).catch(() => {
-            showToast(container, t('components.settings.importFailed'), false);
-          });
-          target.value = '';
-          return;
-        }
-
-        if (target.id === 'us-stream-quality') {
-          setStreamQuality(target.value as StreamQuality);
-          return;
-        }
-        if (target.id === 'us-globe-visual-preset') {
-          setGlobeVisualPreset(target.value as GlobeVisualPreset);
-          return;
-        }
-        if (target.id === 'us-theme') {
-          setThemePreference(target.value as ThemePreference);
-          return;
-        }
-        if (target.id === 'us-font-family') {
-          setFontFamily(target.value as FontFamily);
-          return;
-        }
-        if (target.id === 'us-map-provider') {
-          const provider = target.value as MapProvider;
-          setMapProvider(provider);
-          renderMapThemeDropdown(container, provider);
-          host.onMapProviderChange?.(provider);
-          window.dispatchEvent(new CustomEvent('map-theme-changed'));
-          return;
-        }
-        if (target.id === 'us-map-theme') {
-          const provider = getMapProvider();
-          setMapTheme(provider, target.value);
-          window.dispatchEvent(new CustomEvent('map-theme-changed'));
-          return;
-        }
-        if (target.id === 'us-live-streams-always-on') {
-          setLiveStreamsAlwaysOn(target.checked);
-          return;
-        }
-        if (target.id === 'us-language') {
-          trackLanguageChange(target.value);
-          void changeLanguage(target.value);
-          return;
-        }
-        if (target.id === 'us-cloud') {
-          setAiFlowSetting('cloudLlm', target.checked);
-          updateAiStatus(container);
-        } else if (target.id === 'us-browser') {
-          setAiFlowSetting('browserModel', target.checked);
-          const warn = container.querySelector('.ai-flow-toggle-warn') as HTMLElement;
-          if (warn) warn.style.display = target.checked ? 'block' : 'none';
-          updateAiStatus(container);
-        } else if (target.id === 'us-map-flash') {
-          setAiFlowSetting('mapNewsFlash', target.checked);
-        } else if (target.id === 'us-headline-memory') {
-          setAiFlowSetting('headlineMemory', target.checked);
-        } else if (target.id === 'us-badge-anim') {
-          setAiFlowSetting('badgeAnimation', target.checked);
-        }
+        if (handleSettingsImport(target, container)) return;
+        if (!handlePreferenceChange(target, container, host)) return;
+        host.onSettingSaved?.();
       }, { signal });
 
       container.addEventListener('click', (e) => {

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,0 +1,15 @@
+export function showToast(message: string): void {
+  document.querySelector('.toast-notification')?.remove();
+
+  const toast = document.createElement('div');
+  toast.className = 'toast-notification';
+  toast.setAttribute('role', 'status');
+  toast.textContent = message;
+
+  document.body.appendChild(toast);
+  requestAnimationFrame(() => toast.classList.add('visible'));
+  setTimeout(() => {
+    toast.classList.remove('visible');
+    setTimeout(() => toast.remove(), 300);
+  }, 3000);
+}

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,4 +1,4 @@
-export function showToast(message: string): void {
+export function showToast(message: string, durationMs = 3000): void {
   document.querySelector('.toast-notification')?.remove();
 
   const toast = document.createElement('div');
@@ -11,5 +11,5 @@ export function showToast(message: string): void {
   setTimeout(() => {
     toast.classList.remove('visible');
     setTimeout(() => toast.remove(), 300);
-  }, 3000);
+  }, durationMs);
 }

--- a/tests/settings-save-feedback.test.mjs
+++ b/tests/settings-save-feedback.test.mjs
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+function src(path) {
+  return readFileSync(join(root, path), 'utf-8');
+}
+
+describe('settings save feedback guardrails', () => {
+  const toastSrc = src('src/utils/toast.ts');
+  const settingsSrc = src('src/components/UnifiedSettings.ts');
+  const prefsSrc = src('src/services/preferences-content.ts');
+  const handlersSrc = src('src/app/event-handlers.ts');
+  const countryIntelSrc = src('src/app/country-intel.ts');
+
+  it('uses a shared body-level toast utility with role=status', () => {
+    assert.match(toastSrc, /export function showToast\(message: string\): void/);
+    assert.match(toastSrc, /toast\.setAttribute\('role', 'status'\)/);
+    assert.match(toastSrc, /document\.querySelector\('\.toast-notification'\)\?\.remove\(\)/);
+  });
+
+  it('shows saved feedback for Preferences through renderPreferences callback', () => {
+    assert.match(settingsSrc, /onSettingSaved:\s*\(\)\s*=>\s*showToast\(t\('modals\.settingsWindow\.saved'\)\)/);
+    assert.match(prefsSrc, /onSettingSaved\?: \(\) => void;/);
+    assert.match(prefsSrc, /host\.onSettingSaved\?\.\(\);/);
+  });
+
+  it('keeps Panels save on inline status only', () => {
+    const saveMatch = settingsSrc.match(/private savePanelChanges\(\): void \{([\s\S]*?)\n {2}\}/);
+    assert.ok(saveMatch, 'savePanelChanges() not found');
+    assert.doesNotMatch(saveMatch[1], /showToast\(/);
+  });
+
+  it('removes duplicate global toast implementations from event handlers and country intel', () => {
+    assert.match(handlersSrc, /import \{ showToast \} from '@\/utils\/toast';/);
+    assert.match(countryIntelSrc, /import \{ showToast \} from '@\/utils\/toast';/);
+    assert.doesNotMatch(handlersSrc, /\n\s*showToast\(msg: string\): void \{/);
+    assert.doesNotMatch(countryIntelSrc, /\n\s*showToast\(msg: string\): void \{/);
+  });
+});

--- a/tests/settings-save-feedback.test.mjs
+++ b/tests/settings-save-feedback.test.mjs
@@ -11,6 +11,24 @@ function src(path) {
   return readFileSync(join(root, path), 'utf-8');
 }
 
+function extractMethodBody(source, methodName) {
+  const signature = `${methodName}(): void {`;
+  const start = source.indexOf(signature);
+  assert.notEqual(start, -1, `${methodName}() not found`);
+
+  let depth = 1;
+  let i = start + signature.length;
+  while (i < source.length && depth > 0) {
+    const char = source[i];
+    if (char === '{') depth += 1;
+    if (char === '}') depth -= 1;
+    i += 1;
+  }
+
+  assert.equal(depth, 0, `${methodName}() body did not terminate`);
+  return source.slice(start + signature.length, i - 1);
+}
+
 describe('settings save feedback guardrails', () => {
   const toastSrc = src('src/utils/toast.ts');
   const settingsSrc = src('src/components/UnifiedSettings.ts');
@@ -31,9 +49,8 @@ describe('settings save feedback guardrails', () => {
   });
 
   it('keeps Panels save on inline status only', () => {
-    const saveMatch = settingsSrc.match(/private savePanelChanges\(\): void \{([\s\S]*?)\n {2}\}/);
-    assert.ok(saveMatch, 'savePanelChanges() not found');
-    assert.doesNotMatch(saveMatch[1], /showToast\(/);
+    const saveBody = extractMethodBody(settingsSrc, 'savePanelChanges');
+    assert.doesNotMatch(saveBody, /showToast\(/);
   });
 
   it('removes duplicate global toast implementations from event handlers and country intel', () => {

--- a/tests/settings-save-feedback.test.mjs
+++ b/tests/settings-save-feedback.test.mjs
@@ -37,13 +37,14 @@ describe('settings save feedback guardrails', () => {
   const countryIntelSrc = src('src/app/country-intel.ts');
 
   it('uses a shared body-level toast utility with role=status', () => {
-    assert.match(toastSrc, /export function showToast\(message: string\): void/);
+    assert.match(toastSrc, /export function showToast\(message: string, durationMs = 3000\): void/);
     assert.match(toastSrc, /toast\.setAttribute\('role', 'status'\)/);
     assert.match(toastSrc, /document\.querySelector\('\.toast-notification'\)\?\.remove\(\)/);
+    assert.match(toastSrc, /}, durationMs\);/);
   });
 
   it('shows saved feedback for Preferences through renderPreferences callback', () => {
-    assert.match(settingsSrc, /onSettingSaved:\s*\(\)\s*=>\s*showToast\(t\('modals\.settingsWindow\.saved'\)\)/);
+    assert.match(settingsSrc, /onSettingSaved:\s*\(\)\s*=>\s*showToast\(t\('modals\.settingsWindow\.saved'\), 4000\)/);
     assert.match(prefsSrc, /onSettingSaved\?: \(\) => void;/);
     assert.match(prefsSrc, /host\.onSettingSaved\?\.\(\);/);
   });
@@ -58,5 +59,9 @@ describe('settings save feedback guardrails', () => {
     assert.match(countryIntelSrc, /import \{ showToast \} from '@\/utils\/toast';/);
     assert.doesNotMatch(handlersSrc, /\n\s*showToast\(msg: string\): void \{/);
     assert.doesNotMatch(countryIntelSrc, /\n\s*showToast\(msg: string\): void \{/);
+  });
+
+  it('preserves UnifiedSettings toast duration for modal-originated feedback', () => {
+    assert.match(settingsSrc, /showToast\(t\('modals\.settingsWindow\.freePanelLimit', \{ max: String\(FREE_MAX_PANELS\) \}\), 4000\)/);
   });
 });


### PR DESCRIPTION
## Summary

Reapplies the settings save feedback work from #1269 on top of current `main`, without carrying the stale branch drift that is now breaking that PR.

## Root cause

The app already had inline `Saved` feedback for the Panels tab, but Preferences changes (theme, map provider, language, AI toggles, etc.) still had no equivalent confirmation. The older PR branch also diverged badly from `main` and no longer typechecked cleanly.

## Changes

- add a shared global toast helper in `src/utils/toast.ts` with `role="status"`
- wire `renderPreferences()` to accept `onSettingSaved` and fire it once after persisted preference changes
- show the global `Saved` toast only for Preferences changes
- keep the Panels tab on its existing inline `Saved` status, so there is no duplicate feedback there
- replace duplicate body-level toast implementations in `UnifiedSettings`, `event-handlers`, and `country-intel`
- add a guardrail test covering the shared toast path and the no-duplicate Panels behavior

## Validation

- `npx tsx --test tests/settings-save-feedback.test.mjs`
- `npm run typecheck`
- `npx biome lint src/utils/toast.ts src/components/UnifiedSettings.ts src/services/preferences-content.ts src/app/event-handlers.ts src/app/country-intel.ts tests/settings-save-feedback.test.mjs`

## Risk

Low risk. The change is limited to settings-related feedback paths and a shared toast helper, with the Panels tab intentionally left on its existing inline status behavior.

Ref #1247
Supersedes #1269
