### PR TITLE
fix(thermal): bump TTL 3h->6h and maxStaleMin 240->360 to stop 503 flapping

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -163,7 +163,7 @@ const SEED_META = {
   groceryBasket:       { key: 'seed-meta:economic:grocery-basket',            maxStaleMin: 10080 }, // weekly seed; 10080 = 7 days
   bigmac:              { key: 'seed-meta:economic:bigmac',                    maxStaleMin: 10080 }, // weekly seed; 10080 = 7 days
   fuelPrices:          { key: 'seed-meta:economic:fuel-prices',               maxStaleMin: 10080 }, // weekly seed; 10080 = 7 days
-  thermalEscalation:   { key: 'seed-meta:thermal:escalation',                 maxStaleMin: 240 },
+  thermalEscalation:   { key: 'seed-meta:thermal:escalation',                 maxStaleMin: 360 }, // cron every 2h; 360 = 3x interval (was 240 = 2x)
   nationalDebt:        { key: 'seed-meta:economic:national-debt',              maxStaleMin: 10080 }, // 7 days — monthly seed
   tariffTrendsUs:      { key: 'seed-meta:trade:tariffs:v1:840:all:10',        maxStaleMin: 900 },
   // publish.ts runs once daily (02:30 UTC); seed-meta TTL=52h — maxStaleMin must cover the full 24h cycle

--- a/scripts/seed-thermal-escalation.mjs
+++ b/scripts/seed-thermal-escalation.mjs
@@ -7,7 +7,7 @@ loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'thermal:escalation:v1';
 const HISTORY_KEY = 'thermal:escalation:history:v1';
-const CACHE_TTL = 3 * 60 * 60;
+const CACHE_TTL = 6 * 60 * 60; // 6h — cron runs every 2h; 3x interval so one missed run does not expire the key (was 3h = 1.5x, too tight)
 const SOURCE_VERSION = 'thermal-escalation-v1';
 let latestHistoryPayload = { updatedAt: '', cells: {} };
 


### PR DESCRIPTION
Root cause: `thermalEscalation` cron runs every 2h but CACHE_TTL was 3h (1.5x). Confirmed via Redis `health:last-failure`: `thermalEscalation:EMPTY(183min)` at 00:04 UTC. Key had 57s left at investigation time. Fix: TTL 3h->6h, maxStaleMin 240->360 (both 3x the 2h interval, consistent with wildfires/usniFleet/weatherAlerts pattern).