### PR TITLE
fix(outages): null description crashes popup — no click popup on Internet Disruptions layer

### DIFF
--- a/scripts/seed-internet-outages.mjs
+++ b/scripts/seed-internet-outages.mjs
@@ -109,7 +109,7 @@ async function fetchOutages() {
       id: `cf-${raw.id}`,
       title: raw.scope ? `${raw.scope} outage in ${countryName}` : `Internet disruption in ${countryName}`,
       link: raw.linkedUrl || 'https://radar.cloudflare.com/outage-center',
-      description: raw.description,
+      description: raw.description ?? '',
       detectedAt: toEpochMs(raw.startDate),
       country: countryName,
       region: '',

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -3658,7 +3658,7 @@ export class DeckGLMap {
         return { html: `<div class="deckgl-tooltip"><strong>${text(obj.event || t('components.deckgl.layers.weatherAlerts'))}</strong><br/>${text(obj.severity)}${area}</div>` };
       }
       case 'outages-layer':
-        return { html: `<div class="deckgl-tooltip"><strong>${text(obj.asn || t('components.deckgl.tooltip.internetOutage'))}</strong><br/>${text(obj.country)}</div>` };
+        return { html: `<div class="deckgl-tooltip"><strong>${text(obj.title || t('components.deckgl.tooltip.internetOutage'))}</strong><br/>${text(obj.country)}</div>` };
       case 'traffic-anomalies-layer':
         return { html: `<div class="deckgl-tooltip"><strong>${text(obj.type || 'Traffic Anomaly')}</strong><br/>${text(obj.locationName || obj.asnName || '')}</div>` };
       case 'ddos-locations-layer':

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -1897,7 +1897,7 @@ ${isFeatureAvailable('wingbitsEnrichment') ? '<div class="wingbits-live-section"
             </div>
           </div>
         ` : ''}
-        <p class="popup-description">${escapeHtml(outage.description.slice(0, 250))}${outage.description.length > 250 ? '...' : ''}</p>
+        ${outage.description ? `<p class="popup-description">${escapeHtml(outage.description.slice(0, 250))}${outage.description.length > 250 ? '...' : ''}</p>` : ''}
         <a href="${sanitizeUrl(outage.link)}" target="_blank" class="popup-link">${t('popups.outage.readReport')} →</a>
       </div>
     `;


### PR DESCRIPTION
## Why this PR?

Clicking orange dots on the **Internet Disruptions** layer showed no popup at all. Only the hover tooltip (country name) was visible. Root cause was a silent crash inside the popup renderer.

## Root cause

`renderOutagePopup()` calls `outage.description.slice(0, 250)` unconditionally. Cloudflare Radar annotation responses can have `null` for the `description` field — the seed stored it as-is. Calling `.slice()` on null throws `TypeError`, which DeckGL's onClick callback silently swallows. Result: no popup ever appeared.

## Changes

**`MapPopup.ts`** — guard the description paragraph: renders only if `outage.description` is truthy, skips the `<p>` entirely otherwise.

**`DeckGLMap.ts`** — fix hover tooltip: was referencing `obj.asn` which doesn't exist on `InternetOutage`. Changed to `obj.title` (always set in the seed: "Regional outage in Haiti" etc.).

**`seed-internet-outages.mjs`** — normalize `null` description to `''` at seed time for future robustness.

## Test plan
- [ ] Click any orange dot on the Internet Disruptions layer → popup appears with country, severity, categories, source link
- [ ] Hover over dot → tooltip shows the outage title + country (not generic "Internet Outage")
- [ ] Dots where Cloudflare provides no description render without a description paragraph (no crash)