### PR TITLE
fix(health): calendar keys are OK when empty (between seasons)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -331,11 +331,31 @@ export default async function handler(req) {
 
     let status;
     if (!parsed || raw === NEG_SENTINEL) {
-      status = 'EMPTY';
-      critCount++;
+      if (EMPTY_DATA_OK_KEYS.has(name)) {
+        if (seedStale === true) {
+          status = 'STALE_SEED';
+          warnCount++;
+        } else {
+          status = 'OK';
+          okCount++;
+        }
+      } else {
+        status = 'EMPTY';
+        critCount++;
+      }
     } else if (size === 0) {
-      status = 'EMPTY_DATA';
-      critCount++;
+      if (EMPTY_DATA_OK_KEYS.has(name)) {
+        if (seedStale === true) {
+          status = 'STALE_SEED';
+          warnCount++;
+        } else {
+          status = 'OK';
+          okCount++;
+        }
+      } else {
+        status = 'EMPTY_DATA';
+        critCount++;
+      }
     } else if (seedStale === true) {
       status = 'STALE_SEED';
       warnCount++;


### PR DESCRIPTION
## Why this PR?

Health endpoint is returning 503 (DEGRADED) because `earningsCalendar`, `econCalendar`, and `cotPositioning` all show 0 records. This pushes critCount to exactly 3, which hits the DEGRADED threshold.

## Root cause

Calendar data is legitimately empty during quiet periods:
- **earningsCalendar / econCalendar**: seeds validate non-empty before publishing. When no events are scheduled in the next 14 days, the seed extends existing TTLs but doesn't publish. Once the old data TTL expires, the key is gone.
- **cotPositioning**: CFTC releases data weekly on Fridays. Between releases or if the cron misses a run, the key can be empty.

Treating these as CRIT causes 503s that don't reflect a real outage.

## Fix

Add the three keys to `EMPTY_DATA_OK_KEYS`. Behavior after this change:
- Key empty + seed-meta fresh → `OK` (seed ran, nothing to publish yet)
- Key empty + seed-meta stale → `STALE_SEED` (warn, not crit) — alerts us if cron dies

## Test plan
- [ ] Verify health returns 200 after deploy (critCount drops from 3 to 0)
- [ ] Confirm earningsCalendar/econCalendar show `OK` or `STALE_SEED` rather than `EMPTY`/`CRIT`