### PR TITLE
fix(seed): fall back to hardcoded FOMC dates on Finnhub 403

### DIFF
--- a/scripts/seed-economic-calendar.mjs
+++ b/scripts/seed-economic-calendar.mjs
@@ -81,6 +81,11 @@ async function fetchEconomicCalendar() {
   });
 
   if (!resp.ok) {
+    if (resp.status === 403) {
+      console.warn('  Finnhub HTTP 403 (premium endpoint) — falling back to hardcoded FOMC dates');
+      const events = buildFallbackEvents();
+      return { events, fromDate: from, toDate: to, total: events.length };
+    }
     throw new Error(`Finnhub HTTP ${resp.status}`);
   }
 


### PR DESCRIPTION
## Why this PR?

The `seed-economic-calendar` Railway cron was deployed as part of PR #2258, but the first run failed immediately after that PR merged. Logs showed Finnhub's `/calendar/economic` endpoint returning HTTP 403 on all 4 attempts (3 retries + original), then exiting with keys expired.

Root cause: `/calendar/economic` is a **premium Finnhub endpoint**. The free tier API key returns 403. The script already had `buildFallbackEvents()` that returns hardcoded 2026 FOMC dates (used when no API key is set), but it was not invoked on HTTP 403 — only on missing key.

## Fix

Add a 403 branch in the `!resp.ok` block that mirrors the "no API key" path: warn and return the FOMC fallback. The key now always seeds successfully regardless of Finnhub subscription tier.

```
[err]  Retry 1/3 in 1000ms: Finnhub HTTP 403
[err]  Retry 2/3 in 2000ms: Finnhub HTTP 403
[err]  Retry 3/3 in 4000ms: Finnhub HTTP 403
[err]  FETCH FAILED: Finnhub HTTP 403
[err]  WARNING: 2 key(s) were expired/missing — EXPIRE was a no-op; manual seed required
```

After this fix the seed will log `Finnhub HTTP 403 (premium endpoint) — falling back to hardcoded FOMC dates` and write the FOMC dates successfully.

## Test plan

- [ ] Trigger Railway `seed-economic-calendar` service manually and confirm seed succeeds with FOMC fallback
- [ ] Verify `economic:econ-calendar:v1` key is present in Redis after the run