### PR TITLE
fix(panels): drag from anywhere in panel body

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1587,7 +1587,7 @@ export class PanelLayoutManager implements AppModule {
         target.classList?.contains('panel-col-resize-handle') ||
         target.closest?.('.panel-col-resize-handle')
       ) return;
-      if (target.closest('button, a, input, select, textarea, .panel-content')) return;
+      if (target.closest('button, a, input, select, textarea')) return;
 
       isDragging = true;
       dragStarted = false;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1809,6 +1809,7 @@ body.panel-resize-active iframe {
   overflow-y: auto;
   padding: 8px;
   min-width: 0;
+  user-select: none;
 }
 
 .panel-content::-webkit-scrollbar {


### PR DESCRIPTION
## Problem

Dragging a panel required finding the narrow strip above the content area. Clicking anywhere inside the panel (e.g., the time digits in World Clock) would select text instead of starting a drag.

## Fix

- **`panel-layout.ts`**: Remove `.panel-content` from the `mousedown` exclusion list. The exclusion still covers `button, a, input, select, textarea` so interactive elements remain clickable.
- **`main.css`**: Add `user-select: none` to `.panel-content` so text doesn't get highlighted when initiating a drag from inside the panel.