### PR TITLE
feat(seed): switch economic calendar from Finnhub to FRED API

### DIFF
--- a/scripts/seed-economic-calendar.mjs
+++ b/scripts/seed-economic-calendar.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, runSeed } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -50,7 +50,10 @@ async function fetchFredReleaseDates(releaseId, apiKey, today, toDate) {
     `&api_key=${apiKey}` +
     `&file_type=json`;
 
-  const resp = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+  const resp = await fetch(url, {
+    headers: { 'User-Agent': CHROME_UA },
+    signal: AbortSignal.timeout(15_000),
+  });
   if (!resp.ok) throw new Error(`FRED release/dates HTTP ${resp.status} (release_id=${releaseId})`);
 
   const data = await resp.json();
@@ -65,6 +68,10 @@ async function fetchEconomicCalendar() {
   const toDate = new Date(Date.now() + 30 * 86400_000).toISOString().slice(0, 10);
 
   const fomcEvents = buildFomcEvents(today);
+
+  if (fomcEvents.length === 0) {
+    console.warn('  WARNING: no upcoming FOMC dates — FOMC_DATES_2026 needs updating for the new year');
+  }
 
   if (!apiKey) {
     console.warn('  FRED_API_KEY missing — returning FOMC dates only');


### PR DESCRIPTION
## Why this PR?

Finnhub's \`/calendar/economic\` requires a \$3,500/month premium subscription. The free key returns HTTP 403 on every call, confirmed in production logs from the first Railway run after PR #2258 merged.

FRED (St. Louis Fed) provides official government-scheduled release dates for free. We already have \`FRED_API_KEY\` in Railway for \`seed-economy\` and \`seed-bls-series\` — zero new cost or keys needed.

## What changed

Replaced the Finnhub fetch with 5 parallel FRED \`release/dates\` queries + hardcoded FOMC dates:

| Event | Source | FRED Release ID |
|---|---|---|
| CPI | BLS | 10 |
| Nonfarm Payrolls | BLS | 50 |
| GDP | BEA | 53 |
| PCE / Personal Income | BEA | 54 |
| Retail Sales | Census Bureau | 9 |
| FOMC Rate Decision | Fed (hardcoded 2026) | — |

FRED tracks the full year schedule in advance via \`include_release_dates_with_no_data=true\`.

## Tested locally

\`\`\`
=== economic:econ-calendar Seed ===
  Fetching FRED economic release calendar 2026-03-26 → 2026-04-25
  CPI (release_id=10): 1 upcoming date(s)
  Nonfarm Payrolls (release_id=50): 1 upcoming date(s)
  GDP (release_id=53): 1 upcoming date(s)
  PCE (release_id=54): 1 upcoming date(s)
  Retail Sales (release_id=9): 1 upcoming date(s)
  Total events: 11
  Verified: data present in Redis
=== Done (7085ms) ===
\`\`\`

## Test plan

- [ ] Add \`FRED_API_KEY\` to \`seed-economic-calendar\` Railway service (copy from \`seed-economy\`)
- [ ] Trigger manual run, confirm 6+ events seeded successfully
- [ ] Close PR #2268 (superseded)