### PR TITLE
fix(sentry): broaden ss_bootstrap_config filter + 2 new noise patterns

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -249,9 +249,11 @@ Sentry.init({
     /start offset of Int16Array should be a multiple of 2/,
     /Cannot read properties of undefined \(reading 'then'\)/,
     /^(?:Error: )?uncaught exception: undefined$/,
-    /Can't find variable: ss_bootstrap_config/,
+    /ss_bootstrap_config/, // Surfly proxy — "Can't find variable: ss_bootstrap_config" (Safari) or "ss_bootstrap_config is not defined" (Chrome)
     /undefined is not an object \(evaluating '[a-z]\.includes'\)/,
     /^"use strict" is not a function$/,
+    /Can only call Window\.setTimeout on instances of Window/, // iOS Safari cross-frame setTimeout from 3rd-party injected script
+    /^Can't find variable: _G$/, // browser extension/userscript injecting _G global
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary

- **WORLDMONITOR-HJ** (Surfly proxy): existing `/Can't find variable: ss_bootstrap_config/` only matched Safari wording; Chrome reports `ss_bootstrap_config is not defined`. Widened to `/ss_bootstrap_config/` to cover both.
- **WORLDMONITOR-HK** (iOS 18.7): `Can only call Window.setTimeout on instances of Window` — third-party injected script calling setTimeout in a detached cross-frame context; only native frames, not our code.
- **WORLDMONITOR-23** (33 events / 18 users): `Can't find variable: _G` — browser extension/userscript injecting `_G` global; frame is root URL "global code", not our source.

All three resolved in Sentry with `inNextRelease: true`.

## Test plan

- [ ] TypeScript typecheck passes
- [ ] Data tests pass (2296)
- [ ] Lint clean
- [ ] On next deploy: all three issues stay resolved (auto-reopen if they recur)