### PR TITLE
fix(seed-cot): unblock CFTC fetch — switch to publicreporting.cftc.gov Socrata API

### DIFF
--- a/scripts/railway-set-watch-paths.mjs
+++ b/scripts/railway-set-watch-paths.mjs
@@ -71,14 +71,14 @@ async function main() {
   // 2. Check each service's watchPatterns and startCommand
   for (const svc of services) {
     const { service } = await gql(token, `
-      query ($id: String!) {
+      query ($id: String!, $envId: String!) {
         service(id: $id) {
-          serviceInstances(first: 1) {
+          serviceInstances(first: 1, environmentId: $envId) {
             edges { node { watchPatterns startCommand } }
           }
         }
       }
-    `, { id: svc.id });
+    `, { id: svc.id, envId: ENV_ID });
 
     const instance = service.serviceInstances.edges[0]?.node || {};
     const currentPatterns = instance.watchPatterns || [];

--- a/scripts/seed-cot.mjs
+++ b/scripts/seed-cot.mjs
@@ -36,7 +36,7 @@ function parseDate(raw) {
     const year = parseInt(yy, 10) >= 50 ? `19${yy}` : `20${yy}`;
     return `${year}-${mm}-${dd}`;
   }
-  return s;
+  return s.slice(0, 10);
 }
 
 async function fetchSocrata(datasetId, extraParams = '') {


### PR DESCRIPTION
## Why

`www.cftc.gov/dea/newcot/c_disaggrt.txt` returns HTTP 403 from Railway container IPs (same block pattern as `api.bls.gov` before PR #2238). The seed was writing empty data and extending the stale TTL every run.

## What changed

Replaced the blocked TXT endpoint with two CFTC Socrata API datasets that explicitly support programmatic access:

| Dataset | ID | Covers |
|---|---|---|
| TFF Combined | `yw9f-hn96` | ES, NQ, ZN, ZT, EC, JY |
| Disaggregated All Combined | `rxbv-e226` | GC, CL |

Market name patterns updated to match current Socrata naming (e.g. `UST 10Y NOTE` instead of `10-YEAR U.S. TREASURY NOTE`, `NASDAQ MINI` instead of `E-MINI NASDAQ-100`, `WTI-PHYSICAL` instead of `CRUDE OIL, LIGHT SWEET`).

Field name differences handled per dataset:
- Financial: `asset_mgr_positions_long`, `lev_money_positions_long`, `dealer_positions_long_all`
- Commodities: `m_money_positions_long_all` (mapped to assetManager), `swap_positions_long_all` (mapped to dealer)

Output shape is unchanged — same 8 instruments, same field names, same Redis key.

## Test plan

- [ ] Verify Railway `seed-cot` run logs show all 8 instruments with non-zero values
- [ ] Confirm no more `CFTC fetch failed: HTTP 403` in logs
- [ ] COT panel in Macro Stress renders correctly