### PR TITLE
fix(simulation): surface market_cascade path in UI (topPaths cap 2→3)

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -15704,7 +15704,7 @@ async function writeSimulationOutcome(pkg, outcome, { storageConfig } = {}) {
     theaterId: tr.theaterId,
     theaterLabel: tr.theaterLabel || tr.theaterId,
     stateKind: tr.stateKind || '',
-    topPaths: (tr.topPaths || []).slice(0, 2).map((p) => ({
+    topPaths: (tr.topPaths || []).slice(0, 3).map((p) => ({
       label: p.label,
       summary: p.summary,
       confidence: p.confidence,


### PR DESCRIPTION
## Summary

- `writeSimulationOutcome` was slicing `topPaths` to 2 entries before writing the Redis pointer
- With 3 paths (`escalation`, `containment`, `market_cascade`), `market_cascade` was always dropped
- The UI and ForecastPanel never saw the economic cascade path despite the LLM correctly producing it
- Fix: `slice(0, 2)` → `slice(0, 3)`

Verified against latest R2 artifact (`1774512157905-j7b1kw`): LLM produces `market_cascade` with economic framing ("Global Economic Shock Deepens", $95/bbl timing, OPEC/IMF actors) — it was simply being truncated before Redis write.

## Test plan

- [x] All 176 existing tests pass
- [x] `market_cascade` path will now appear in `uiTheaters` on the next simulation run

## Post-Deploy Monitoring & Validation

- **Logs**: Check `simulation-worker` logs for `Completed N theaters`
- **Redis**: `forecast:simulation-outcome:latest` → `uiTheaters[0].topPaths` should have 3 entries including `market_cascade`
- **Expected**: Next simulation run writes 3 paths to Redis pointer
- **Failure signal**: Still only 2 paths → investigation needed
- **Validation window**: Next simulation run (~1h)