### PR TITLE
fix(health): bump iranEvents maxStaleMin 10080→20160 (14d buffer)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -133,7 +133,7 @@ const SEED_META = {
   gpsjam:           { key: 'seed-meta:intelligence:gpsjam',       maxStaleMin: 720 },
   positiveGeoEvents:{ key: 'seed-meta:positive-events:geo',       maxStaleMin: 60 },
   riskScores:       { key: 'seed-meta:intelligence:risk-scores',  maxStaleMin: 30 }, // CII warm-ping every 8min; 30min = ~3.5x interval,
-  iranEvents:       { key: 'seed-meta:conflict:iran-events',      maxStaleMin: 10080 },
+  iranEvents:       { key: 'seed-meta:conflict:iran-events',      maxStaleMin: 20160 }, // manual seed from LiveUAMap; 20160 = 14d = 2× weekly cadence
   ucdpEvents:       { key: 'seed-meta:conflict:ucdp-events',      maxStaleMin: 420 },
   militaryFlights:  { key: 'seed-meta:military:flights',           maxStaleMin: 30 }, // cron ~10min (LIVE_TTL=600s); 30min = 3x interval,
   satellites:       { key: 'seed-meta:intelligence:satellites',    maxStaleMin: 240 }, // CelesTrak every 120min; 240min = absorbs one missed cycle


### PR DESCRIPTION
## Why this PR?

`iranEvents` showing `STALE_SEED` — seeded 10096 min ago (7 days) against a 10080 min threshold. That's 1× cadence with zero buffer, so any week where the manual seed runs even slightly late fires a warning.

Iran events are seeded **manually** from LiveUAMap (not an automated cron), so a full 7-day window with no slack is too tight.

## Fix

`maxStaleMin`: 10080 → 20160 (14 days = 2× weekly cadence). Absorbs one missed seed week without alerting.

## Test plan
- [ ] `iranEvents` shows `OK` after deploy (seedAgeMin 10096 < new threshold 20160)