### PR TITLE
feat(iran-events): add Kafr Qasim, Taybad, Sweihan to LOCATION_COORDS

### DIFF
--- a/scripts/seed-iran-events.mjs
+++ b/scripts/seed-iran-events.mjs
@@ -155,6 +155,9 @@ const LOCATION_COORDS = {
   'al-ahmadi':     { lat: 29.0769, lon: 48.0839 },
   'mina al-ahmadi': { lat: 29.0769, lon: 48.0839 },
   'mina abdullah': { lat: 28.9600, lon: 48.1600 },
+  'kafr qasim':    { lat: 32.1161, lon: 34.9750 },
+  'taybad':        { lat: 35.1884, lon: 60.7814 },
+  'sweihan':       { lat: 24.4041, lon: 55.3325 },
 };
 
 const CATEGORY_MAP = {


### PR DESCRIPTION
## Summary
- Adds 3 new locations to `LOCATION_COORDS` in `seed-iran-events.mjs` referenced in March 2026 Iran conflict events
- Kafr Qasim (Israeli Arab city, ~32.1°N 34.9°E) — appeared in cluster munitions event
- Taybad (northeast Iran border city, ~35.2°N 60.8°E) — appeared in air defense activation event
- Sweihan (Abu Dhabi area, ~24.4°N 55.3°E) — appeared in ballistic missile interception event

## Test plan
- [ ] Events seeded successfully (30 events from March 25-26 2026 batch confirmed written to Redis)
- [ ] New locations geocode to correct regions instead of falling back to Iran center