### PR TITLE
fix(feeds+seeds): graceful ACLED skip + USNI Google News proxy

### DIFF
--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -70,7 +70,10 @@ async function fetchAcledToken() {
 
 async function fetchAcledEvents() {
   const token = await fetchAcledToken();
-  if (!token) throw new Error('Missing ACLED credentials (ACLED_EMAIL+ACLED_PASSWORD or ACLED_ACCESS_TOKEN)');
+  if (!token) {
+    console.log('  ACLED: no credentials configured, skipping');
+    return null;
+  }
 
   const now = Date.now();
   const startDate = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -1236,7 +1236,7 @@ export const INTEL_SOURCES: Feed[] = [
   { name: 'Janes', url: rss('https://news.google.com/rss/search?q=site:janes.com+when:3d&hl=en-US&gl=US&ceid=US:en'), type: 'defense' },
   { name: 'Military Times', url: rss('https://www.militarytimes.com/arc/outboundfeeds/rss/?outputType=xml'), type: 'defense' },
   { name: 'Task & Purpose', url: rss('https://taskandpurpose.com/feed/'), type: 'defense' },
-  { name: 'USNI News', url: rss('https://news.usni.org/feed'), type: 'defense' },
+  { name: 'USNI News', url: rss('https://news.google.com/rss/search?q=site:news.usni.org+when:3d&hl=en-US&gl=US&ceid=US:en'), type: 'defense' },
   { name: 'gCaptain', url: rss('https://gcaptain.com/feed/'), type: 'defense' },
   { name: 'Oryx OSINT', url: rss('https://www.oryxspioenkop.com/feeds/posts/default?alt=rss'), type: 'defense' },
   { name: 'UK MOD', url: rss('https://www.gov.uk/government/organisations/ministry-of-defence.atom'), type: 'defense' },


### PR DESCRIPTION
## Summary
- **ACLED graceful skip**: `seed-conflict-intel.mjs` was throwing when `ACLED_EMAIL`/`ACLED_PASSWORD`/`ACLED_ACCESS_TOKEN` are absent, crashing the entire seed. Now logs `ACLED: no credentials configured, skipping` and returns null. The caller already handles null via `Promise.allSettled`.
- **USNI feed**: `news.usni.org/feed` was returning 403 in production, causing repeated backoff cycles in the relay's error logs. Switched to Google News proxy URL (same pattern as Janes and CSIS already use).

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run test:data` passes (2330 tests)
- [ ] `node --test tests/edge-functions.test.mjs` passes (125 tests)
- [ ] Verify Railway seed logs no longer show ACLED throw on envs without creds
- [ ] Verify relay logs no longer show USNI 403 backoff cycles