### PR TITLE
fix(hormuz): coerce Power BI series values to number

### DIFF
--- a/scripts/seed-hormuz.mjs
+++ b/scripts/seed-hormuz.mjs
@@ -165,7 +165,7 @@ async function fetchPbiCharts() {
         const dateStr = `${yr}-${String(mo).padStart(2, '0')}-${String(dy).padStart(2, '0')}`;
         const d = new Date(dateStr);
         if (isNaN(d.getTime()) || d < cutoff) return null;
-        return { date: dateStr, value: val ?? 0 };
+        return { date: dateStr, value: typeof val === 'number' ? val : (Number(val) || 0) };
       })
       .filter(Boolean)
       .sort((a, b) => a.date.localeCompare(b.date));

--- a/src/components/HormuzPanel.ts
+++ b/src/components/HormuzPanel.ts
@@ -43,7 +43,7 @@ function barChart(series: HormuzSeries[], color: string, unit: string, width = 2
 function renderChart(chart: HormuzChart, idx: number): string {
   const color = CHART_COLORS[idx % CHART_COLORS.length] ?? '#3498db';
   const last = chart.series[chart.series.length - 1];
-  const lastVal = last ? last.value.toFixed(0) : 'N/A';
+  const lastVal = last ? Number(last.value).toFixed(0) : 'N/A';
   const lastDate = last ? last.date.slice(5) : '';
   const unit = chart.label.includes('crude_oil') ? 'kt/day' : 'units';
 


### PR DESCRIPTION
## Summary

Fixes `a.value.toFixed is not a function` crash in the Hormuz Trade Tracker panel.

**Root cause:** Power BI's DSR format returns numeric column values as JavaScript strings in some responses. The seed used `val ?? 0` which only guards against `null`/`undefined`, so string values like `"28.5"` were stored in Redis as-is. The panel then called `.toFixed(0)` on a string, crashing the render.

**Fixes:**
- `seed-hormuz.mjs`: `typeof val === 'number' ? val : (Number(val) || 0)` — coerce at write time
- `HormuzPanel.ts`: `Number(last.value).toFixed(0)` — defensive coerce at render time

## Test plan
- [ ] Deploy and verify Hormuz Trade Tracker panel renders without error
- [ ] Confirm bar charts show correct numeric values (not NaN)