### PR TITLE
fix(panels): replace inline magic numbers with REFRESH_INTERVALS constants

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1224,37 +1224,37 @@ export class App {
     this.refreshScheduler.scheduleRefresh(
       'macro-tiles',
       () => (this.state.panels['macro-tiles'] as MacroTilesPanel).fetchData(),
-      30 * 60 * 1000,
+      REFRESH_INTERVALS.macroTiles,
       () => this.isPanelNearViewport('macro-tiles')
     );
     this.refreshScheduler.scheduleRefresh(
       'fsi',
       () => (this.state.panels['fsi'] as FSIPanel).fetchData(),
-      30 * 60 * 1000,
+      REFRESH_INTERVALS.fsi,
       () => this.isPanelNearViewport('fsi')
     );
     this.refreshScheduler.scheduleRefresh(
       'yield-curve',
       () => (this.state.panels['yield-curve'] as YieldCurvePanel).fetchData(),
-      30 * 60 * 1000,
+      REFRESH_INTERVALS.yieldCurve,
       () => this.isPanelNearViewport('yield-curve')
     );
     this.refreshScheduler.scheduleRefresh(
       'earnings-calendar',
       () => (this.state.panels['earnings-calendar'] as EarningsCalendarPanel).fetchData(),
-      60 * 60 * 1000,
+      REFRESH_INTERVALS.earningsCalendar,
       () => this.isPanelNearViewport('earnings-calendar')
     );
     this.refreshScheduler.scheduleRefresh(
       'economic-calendar',
       () => (this.state.panels['economic-calendar'] as EconomicCalendarPanel).fetchData(),
-      60 * 60 * 1000,
+      REFRESH_INTERVALS.economicCalendar,
       () => this.isPanelNearViewport('economic-calendar')
     );
     this.refreshScheduler.scheduleRefresh(
       'cot-positioning',
       () => (this.state.panels['cot-positioning'] as CotPositioningPanel).fetchData(),
-      60 * 60 * 1000,
+      REFRESH_INTERVALS.cotPositioning,
       () => this.isPanelNearViewport('cot-positioning')
     );
 

--- a/src/config/variants/base.ts
+++ b/src/config/variants/base.ts
@@ -51,6 +51,12 @@ export const REFRESH_INTERVALS = {
   correlationEngine: 5 * 60 * 1000,
   crossSourceSignals: 15 * 60 * 1000,
   hormuzTracker: 60 * 60 * 1000, // 1h — data updates daily
+  macroTiles: 30 * 60 * 1000,
+  fsi: 30 * 60 * 1000,
+  yieldCurve: 30 * 60 * 1000,
+  earningsCalendar: 60 * 60 * 1000,
+  economicCalendar: 60 * 60 * 1000,
+  cotPositioning: 60 * 60 * 1000,
 };
 
 // Monitor colors - shared


### PR DESCRIPTION
## Why this PR?

Follow-up to #2290. Greptile flagged that `scheduleRefresh` calls for the 6 new panels used inline magic numbers (`30 * 60 * 1000`, `60 * 60 * 1000`) instead of `REFRESH_INTERVALS` constants, breaking the pattern used by all ~30 other refresh registrations in the file.

## Changes

- `src/config/variants/base.ts`: adds 6 new keys to `REFRESH_INTERVALS`:
  - `macroTiles`, `fsi`, `yieldCurve`: 30 min
  - `earningsCalendar`, `economicCalendar`, `cotPositioning`: 60 min
- `src/App.ts`: replaces the 6 inline literals with the named constants

No behavior change — only the literals are replaced with named references.