### PR TITLE
refactor(app): extract panel refresh intervals to REFRESH_INTERVALS constants

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1224,37 +1224,37 @@ export class App {
     this.refreshScheduler.scheduleRefresh(
       'macro-tiles',
       () => (this.state.panels['macro-tiles'] as MacroTilesPanel).fetchData(),
-      30 * 60 * 1000,
+      REFRESH_INTERVALS.macroTiles,
       () => this.isPanelNearViewport('macro-tiles')
     );
     this.refreshScheduler.scheduleRefresh(
       'fsi',
       () => (this.state.panels['fsi'] as FSIPanel).fetchData(),
-      30 * 60 * 1000,
+      REFRESH_INTERVALS.fsi,
       () => this.isPanelNearViewport('fsi')
     );
     this.refreshScheduler.scheduleRefresh(
       'yield-curve',
       () => (this.state.panels['yield-curve'] as YieldCurvePanel).fetchData(),
-      30 * 60 * 1000,
+      REFRESH_INTERVALS.yieldCurve,
       () => this.isPanelNearViewport('yield-curve')
     );
     this.refreshScheduler.scheduleRefresh(
       'earnings-calendar',
       () => (this.state.panels['earnings-calendar'] as EarningsCalendarPanel).fetchData(),
-      60 * 60 * 1000,
+      REFRESH_INTERVALS.earningsCalendar,
       () => this.isPanelNearViewport('earnings-calendar')
     );
     this.refreshScheduler.scheduleRefresh(
       'economic-calendar',
       () => (this.state.panels['economic-calendar'] as EconomicCalendarPanel).fetchData(),
-      60 * 60 * 1000,
+      REFRESH_INTERVALS.economicCalendar,
       () => this.isPanelNearViewport('economic-calendar')
     );
     this.refreshScheduler.scheduleRefresh(
       'cot-positioning',
       () => (this.state.panels['cot-positioning'] as CotPositioningPanel).fetchData(),
-      60 * 60 * 1000,
+      REFRESH_INTERVALS.cotPositioning,
       () => this.isPanelNearViewport('cot-positioning')
     );
 

--- a/src/config/variants/base.ts
+++ b/src/config/variants/base.ts
@@ -51,6 +51,12 @@ export const REFRESH_INTERVALS = {
   correlationEngine: 5 * 60 * 1000,
   crossSourceSignals: 15 * 60 * 1000,
   hormuzTracker: 60 * 60 * 1000, // 1h — data updates daily
+  macroTiles: 30 * 60 * 1000,
+  fsi: 30 * 60 * 1000,
+  yieldCurve: 30 * 60 * 1000,
+  earningsCalendar: 60 * 60 * 1000,
+  economicCalendar: 60 * 60 * 1000,
+  cotPositioning: 60 * 60 * 1000,
 };
 
 // Monitor colors - shared


### PR DESCRIPTION
## Summary

- Replaces 6 hardcoded `30 * 60 * 1000` / `60 * 60 * 1000` literals in `App.ts` `scheduleRefresh` calls with named constants in `REFRESH_INTERVALS`
- Adds `macroTiles`, `fsi`, `yieldCurve`, `earningsCalendar`, `economicCalendar`, `cotPositioning` entries alongside the existing `hormuzTracker` constant
- No behavior change — values are identical; purely a maintainability refactor

## Test plan

- [x] TypeScript typecheck passes
- [x] API typecheck passes
- [x] Biome lint passes
- [x] Unit + data tests pass (125/125)
- [x] Edge function bundle check passes
- [x] Edge function tests pass (125/125)
- [x] Markdown lint passes
- [x] Version sync check passes