### PR TITLE
fix(earnings-calendar): filter micro-caps, show largest companies first

### DIFF
--- a/scripts/seed-earnings-calendar.mjs
+++ b/scripts/seed-earnings-calendar.mjs
@@ -63,11 +63,14 @@ async function fetchAll() {
       };
     })
     // Keep companies with meaningful analyst coverage:
-    // - revenue estimate >= $10M (eliminates micro/nano-caps with near-zero revenue)
-    // - OR no revenue estimate but |EPS estimate| >= $0.10 (financials, REITs, etc.)
+    // - revenue estimate > 0 && >= $10M → large/mid-cap (primary filter)
+    // - revenue estimate === 0 OR null → pre-revenue (biotech, SPACs) or financial/REIT
+    //   with no revenue line — use |EPS| >= $0.05 as proxy for analyst coverage depth
+    //   ($0.05 keeps well-covered loss-making companies; $0.10 was too aggressive)
+    // - revenue estimate > 0 && < $10M → small-cap / micro-cap → always drop
     .filter(e => {
-      if (e.revenueEstimate != null) return e.revenueEstimate >= 10_000_000;
-      if (e.epsEstimate != null) return Math.abs(e.epsEstimate) >= 0.10;
+      if (e.revenueEstimate != null && e.revenueEstimate > 0) return e.revenueEstimate >= 10_000_000;
+      if (e.epsEstimate != null) return Math.abs(e.epsEstimate) >= 0.05;
       return false;
     })
     // Within same date, largest companies first; across dates, chronological
@@ -82,7 +85,8 @@ async function fetchAll() {
 }
 
 function validate(data) {
-  return Array.isArray(data?.earnings) && data.earnings.length > 0;
+  // >= 3 distinguishes a healthy result from an over-aggressive filter or a near-empty API response
+  return Array.isArray(data?.earnings) && data.earnings.length >= 3;
 }
 
 if (process.argv[1]?.endsWith('seed-earnings-calendar.mjs')) {

--- a/scripts/seed-earnings-calendar.mjs
+++ b/scripts/seed-earnings-calendar.mjs
@@ -62,7 +62,19 @@ async function fetchAll() {
         surpriseDirection,
       };
     })
-    .sort((a, b) => a.date.localeCompare(b.date))
+    // Keep companies with meaningful analyst coverage:
+    // - revenue estimate >= $10M (eliminates micro/nano-caps with near-zero revenue)
+    // - OR no revenue estimate but |EPS estimate| >= $0.10 (financials, REITs, etc.)
+    .filter(e => {
+      if (e.revenueEstimate != null) return e.revenueEstimate >= 10_000_000;
+      if (e.epsEstimate != null) return Math.abs(e.epsEstimate) >= 0.10;
+      return false;
+    })
+    // Within same date, largest companies first; across dates, chronological
+    .sort((a, b) => {
+      if (a.date !== b.date) return a.date.localeCompare(b.date);
+      return Math.abs(b.revenueEstimate ?? 0) - Math.abs(a.revenueEstimate ?? 0);
+    })
     .slice(0, 100);
 
   console.log(`  Fetched ${earnings.length} earnings entries`);

--- a/scripts/seed-earnings-calendar.mjs
+++ b/scripts/seed-earnings-calendar.mjs
@@ -73,11 +73,11 @@ async function fetchAll() {
     // Within same date, largest companies first; across dates, chronological
     .sort((a, b) => {
       if (a.date !== b.date) return a.date.localeCompare(b.date);
-      return Math.abs(b.revenueEstimate ?? 0) - Math.abs(a.revenueEstimate ?? 0);
+      return (b.revenueEstimate ?? 0) - (a.revenueEstimate ?? 0);
     })
     .slice(0, 100);
 
-  console.log(`  Fetched ${earnings.length} earnings entries`);
+  console.log(`  Fetched ${earnings.length} earnings entries (from ${raw.length} total)`);
   return { earnings, unavailable: false };
 }
 


### PR DESCRIPTION
## Summary

The earnings calendar was showing penny stocks (PVCT, PKTX, NAKA, etc.) because `.slice(0, 100)` on date-sorted results picked the first 100 without any size filter. Finnhub returns all reporting companies including hundreds of micro-caps with no analyst coverage.

**Filter logic:**
- Keep `revenueEstimate >= $10M` — eliminates nano/micro-caps with near-zero revenue
- OR `|epsEstimate| >= $0.10` — keeps financials/REITs that have no revenue estimate but meaningful earnings
- Discard anything with no analyst coverage at all

**Sort:** within each date, largest companies (by revenue estimate) appear first.

## Result
Today's calendar should show meaningful names (e.g. companies with $10M+ quarterly revenue) instead of obscure penny stocks.

## Test plan
- [ ] Verify today's earnings show recognizable/notable companies
- [ ] Verify BEAT/MISS badges still work for reported companies
- [ ] Verify BMO/AMC hour labels still display correctly