### PR TITLE
fix(auth): forward tester key as X-WorldMonitor-Key on premium RPC paths

### DIFF
--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -781,20 +781,33 @@ export function installWebApiRedirect(): void {
   };
 
   /**
-   * For premium API paths, inject an Authorization: Bearer header when the
-   * user has an active session and no existing auth header is present.
+   * For premium API paths, inject auth when the user has premium access but no
+   * existing auth header is present. Handles three paths:
+   *   1. Clerk Pro: Authorization: Bearer <token>
+   *   2. Tester key (wm-pro-key / wm-widget-key): X-WorldMonitor-Key: <key>
+   *   3. API key users: already set X-WorldMonitor-Key — left unchanged
    * Returns the original init unchanged for non-premium paths (zero overhead).
    */
   const enrichInitForPremium = async (pathWithQuery: string, init?: RequestInit): Promise<RequestInit | undefined> => {
     const path = pathWithQuery.split('?')[0] ?? pathWithQuery;
     if (!WEB_PREMIUM_API_PATHS.has(path)) return init;
-    const token = await getClerkToken();
-    if (!token) return init;
     const headers = new Headers(init?.headers);
     // Don't overwrite existing auth headers (API key users keep their flow)
     if (headers.has('Authorization') || headers.has('X-WorldMonitor-Key')) return init;
-    headers.set('Authorization', `Bearer ${token}`);
-    return { ...init, headers };
+    // Clerk Pro: inject Bearer token
+    const token = await getClerkToken();
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
+      return { ...init, headers };
+    }
+    // Tester key (wm-pro-key / wm-widget-key): forward as API key header
+    const { getProWidgetKey, getWidgetAgentKey } = await import('@/services/widget-store');
+    const testerKey = getProWidgetKey() || getWidgetAgentKey();
+    if (testerKey) {
+      headers.set('X-WorldMonitor-Key', testerKey);
+      return { ...init, headers };
+    }
+    return init;
   };
 
   window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {


### PR DESCRIPTION
## Why this PR?

After PR #2299 (consolidated `hasPremiumAccess()`), tester key users (`wm-pro-key` / `wm-widget-key`) saw **"temporarily unavailable"** on Stock Analysis and Backtesting panels. The gating was fixed, but the actual data fetch fails with 401.

## Root cause

The server gateway enforces `PREMIUM_RPC_PATHS` (`/api/market/v1/analyze-stock`, `/backtest-stock`, `/get-stock-analysis-history`, `/list-stored-stock-backtests`) — it requires either an API key (`X-WorldMonitor-Key`) or a Clerk Bearer token.

`runtime.ts`'s `enrichInitForPremium()` only injected a Clerk Bearer token — it had no path for tester key users who have no Clerk session. So their RPC calls hit the server with no auth → 401 → `analyzeStock` / `backtestStock` throw → catch block → "temporarily unavailable".

## Fix

`enrichInitForPremium` now falls back to the tester key when no Clerk token is available:

1. If `Authorization` or `X-WorldMonitor-Key` already set: leave unchanged (API key users)
2. Clerk Pro: inject `Authorization: Bearer <token>` (unchanged)
3. **New**: tester key (`wm-pro-key` / `wm-widget-key`): inject as `X-WorldMonitor-Key` so `validateApiKey` can validate it against `WORLDMONITOR_VALID_KEYS`

> **Note**: This requires the tester key value to be present in `WORLDMONITOR_VALID_KEYS` on Vercel/Railway. If it isn't already there, add it.

## Test plan

- [ ] Set `wm-pro-key` to a value that's in `WORLDMONITOR_VALID_KEYS`, reload — Stock Analysis and Backtesting should load data (no "temporarily unavailable")
- [ ] Clerk Pro user still works (path 2 unchanged)
- [ ] Desktop API key user still works (path 1 unchanged — header already present)
- [ ] `npm run typecheck` passes
- [ ] `npm run test:data` passes (2357 tests)