### PR TITLE
fix(widget-agent): allow PRO key alone to pass access gate

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -8330,7 +8330,10 @@ function requireWidgetAgentAccess(req, res) {
   }
 
   const providedKey = getWidgetAgentProvidedKey(req);
-  if (!providedKey || providedKey !== WIDGET_AGENT_KEY) {
+  const providedProKey = getWidgetAgentProvidedProKey(req);
+  const hasValidWidgetKey = providedKey && providedKey === WIDGET_AGENT_KEY;
+  const hasValidProKey = PRO_WIDGET_KEY && providedProKey && providedProKey === PRO_WIDGET_KEY;
+  if (!hasValidWidgetKey && !hasValidProKey) {
     safeEnd(res, 403, { 'Content-Type': 'application/json' }, JSON.stringify({ ...status, error: 'Forbidden' }));
     return null;
   }


### PR DESCRIPTION
## Root cause

PRO users who have `wm-pro-key` but no `wm-widget-key` were always getting `403 Forbidden` from `POST /widget-agent`.

`requireWidgetAgentAccess` validates `X-Widget-Key` against `WIDGET_AGENT_KEY` before anything else. For PRO users, `getWidgetAgentKey()` returns `''` (they only have a pro key, not a widget key), so the header is empty and the gate rejects them immediately — the PRO key check further down in `handleWidgetAgentRequest` is never reached.

## Fix

In `requireWidgetAgentAccess`, also accept a valid `X-Pro-Key` as sufficient authorization. PRO tier is a superset of basic, so holding a valid pro key is at least as trusted as holding the basic widget key.

```js
// Before: only widget key accepted
const providedKey = getWidgetAgentProvidedKey(req);
if (!providedKey || providedKey !== WIDGET_AGENT_KEY) { return 403 }

// After: widget key OR pro key
const hasValidWidgetKey = providedKey && providedKey === WIDGET_AGENT_KEY;
const hasValidProKey = PRO_WIDGET_KEY && providedProKey && providedProKey === PRO_WIDGET_KEY;
if (!hasValidWidgetKey && !hasValidProKey) { return 403 }
```

## Test plan

- [ ] PRO user (has `wm-pro-key`, no `wm-widget-key`) can POST `/widget-agent` without 403
- [ ] Basic widget user (has `wm-widget-key`) still works unchanged
- [ ] Request with neither key still gets 403
- [ ] PRO auth double-check inside `handleWidgetAgentRequest` still runs when `tier: 'pro'`