### PR TITLE
fix(health): suppress CRIT/stale alerts for defense-patents (PatentsView API 410)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -35,7 +35,6 @@ const BOOTSTRAP_KEYS = {
   forecasts:         'forecast:predictions:v2',
   securityAdvisories: 'intelligence:advisories-bootstrap:v1',
   customsRevenue:    'trade:customs-revenue:v1',
-  defensePatents:    'patents:defense:latest',
   comtradeFlows:     'comtrade:flows:v1',
   blsSeries:         'bls:series:v1',
   sanctionsPressure: 'sanctions:pressure:v1',
@@ -158,7 +157,6 @@ const SEED_META = {
   usniFleet:           { key: 'seed-meta:military:usni-fleet',               maxStaleMin: 720 }, // relay loop every 6h; 720 = 2× interval (was 480 = 1.3×, too tight)
   securityAdvisories:  { key: 'seed-meta:intelligence:advisories',           maxStaleMin: 120 },
   customsRevenue:      { key: 'seed-meta:trade:customs-revenue',              maxStaleMin: 1440 },
-  defensePatents:      { key: 'seed-meta:military:defense-patents',           maxStaleMin: 20160 }, // weekly seed; 20160 = 2× 7-day interval
   comtradeFlows:       { key: 'seed-meta:trade:comtrade-flows',               maxStaleMin: 2880 }, // 24h cron; 2880min = 48h = 2x interval
   blsSeries:           { key: 'seed-meta:economic:bls-series',                maxStaleMin: 2880 }, // daily seed; 2880min = 48h = 2x interval
   sanctionsPressure:   { key: 'seed-meta:sanctions:pressure',                 maxStaleMin: 720 },


### PR DESCRIPTION
## Why this PR?

PatentsView's legacy API (`search.patentsview.org`) migrated to `data.uspto.gov` on March 20, 2026. All IPC category fetches now return **HTTP 410**. The seed script gracefully extends the existing Redis TTL but cannot write fresh data, so health fires continuous **CRIT** (empty key) and **STALE_SEED** alerts with no actionable fix.

## What changed

`api/health.js` — removed `defensePatents` from:
- `BOOTSTRAP_KEYS` (was triggering CRIT alerts on empty key)
- `SEED_META` (was triggering STALE_SEED alerts)

## Next steps (separate PR)

Update `scripts/seed-defense-patents.mjs` to use the new `data.uspto.gov` endpoint once the new API schema is confirmed.