### PR TITLE
debug(auth): expose key comparison detail in 401 response

### DIFF
--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -52,8 +52,18 @@ export function validateApiKey(req, options = {}) {
       return { valid: false, required: true, error: 'API key required' };
     }
     if (key) {
-      const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);
-      if (!validKeys.includes(key)) return { valid: false, required: true, error: 'Invalid API key' };
+      const rawEnv = process.env.WORLDMONITOR_VALID_KEYS || '';
+      const validKeys = rawEnv.split(',').filter(Boolean);
+      if (!validKeys.includes(key)) return {
+        valid: false, required: true, error: 'Invalid API key',
+        _debug: {
+          receivedKey: key,
+          receivedKeyLen: key.length,
+          envVarRaw: rawEnv,
+          parsedKeys: validKeys,
+          envVarLen: rawEnv.length,
+        },
+      };
     }
     return { valid: true, required: forceKey };
   }

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -252,7 +252,7 @@ export function createDomainGateway(
           }
           // Valid pro session — fall through to route handling
         } else {
-          return new Response(JSON.stringify({ error: keyCheck.error }), {
+          return new Response(JSON.stringify({ error: keyCheck.error, _debug: (keyCheck as any)._debug }), {
             status: 401,
             headers: { 'Content-Type': 'application/json', ...corsHeaders },
           });


### PR DESCRIPTION
Temporary debug: adds receivedKey, parsedKeys, and rawEnv to the Invalid API key 401 response body so we can see exactly what is being compared server-side. Remove after issue is identified.