### PR TITLE
perf: reduce redundant API calls and fix aviation cache key bugs

### DIFF
--- a/src/components/AirlineIntelPanel.ts
+++ b/src/components/AirlineIntelPanel.ts
@@ -175,7 +175,8 @@ export class AirlineIntelPanel extends Panel {
     }
 
     private async refresh(): Promise<void> {
-        void this.loadOps();
+        // Skip loadOps when on the ops tab — loadTab('ops') fetches the same data
+        if (this.activeTab !== 'ops') void this.loadOps();
         void this.loadTab(this.activeTab);
     }
 

--- a/src/components/NationalDebtPanel.ts
+++ b/src/components/NationalDebtPanel.ts
@@ -112,6 +112,8 @@ export class NationalDebtPanel extends Panel {
   private lastFetch = 0;
   private visibleCount = PAGE_SIZE;
   private tickerInterval: ReturnType<typeof setInterval> | null = null;
+  private tickerElements = new Map<string, HTMLElement>();
+  private lastTickerValues = new Map<string, string>();
   private readonly REFRESH_INTERVAL = 6 * 60 * 60 * 1000;
 
   constructor() {
@@ -295,17 +297,35 @@ export class NationalDebtPanel extends Panel {
     this.stopTicker();
     if (this.filteredEntries.length === 0) return;
 
-    this.tickerInterval = setInterval(() => {
-      const globalEl = this.content.querySelector<HTMLElement>('.debt-global-ticker');
-      if (globalEl) {
-        globalEl.textContent = formatDebt(this.getGlobalDebt());
-      }
-      const container = this.content.querySelector('.debt-list');
-      if (!container) return;
+    // Pre-cache element references to avoid per-tick DOM queries
+    this.tickerElements.clear();
+    this.lastTickerValues.clear();
+    const globalEl = this.content.querySelector<HTMLElement>('.debt-global-ticker');
+    if (globalEl) this.tickerElements.set('__global__', globalEl);
+    const container = this.content.querySelector('.debt-list');
+    if (container) {
       for (const entry of this.filteredEntries.slice(0, this.visibleCount)) {
         const el = container.querySelector<HTMLElement>(`.debt-ticker[data-iso3="${entry.iso3}"]`);
-        if (el) {
-          el.textContent = formatDebt(getCurrentDebt(entry));
+        if (el) this.tickerElements.set(entry.iso3, el);
+      }
+    }
+
+    this.tickerInterval = setInterval(() => {
+      const gEl = this.tickerElements.get('__global__');
+      if (gEl) {
+        const v = formatDebt(this.getGlobalDebt());
+        if (this.lastTickerValues.get('__global__') !== v) {
+          gEl.textContent = v;
+          this.lastTickerValues.set('__global__', v);
+        }
+      }
+      for (const entry of this.filteredEntries.slice(0, this.visibleCount)) {
+        const el = this.tickerElements.get(entry.iso3);
+        if (!el) continue;
+        const v = formatDebt(getCurrentDebt(entry));
+        if (this.lastTickerValues.get(entry.iso3) !== v) {
+          el.textContent = v;
+          this.lastTickerValues.set(entry.iso3, v);
         }
       }
     }, 1000);
@@ -316,6 +336,8 @@ export class NationalDebtPanel extends Panel {
       clearInterval(this.tickerInterval);
       this.tickerInterval = null;
     }
+    this.tickerElements.clear();
+    this.lastTickerValues.clear();
   }
 
   private restartTicker(): void {

--- a/src/services/aviation/index.ts
+++ b/src/services/aviation/index.ts
@@ -277,7 +277,7 @@ const breakerDelays = createCircuitBreaker<AirportDelayAlert[]>({ name: 'Flight 
 const breakerOps = createCircuitBreaker<AirportOpsSummary[]>({ name: 'Airport Ops', cacheTtlMs: 6 * 60 * 1000, persistCache: true });
 const breakerFlights = createCircuitBreaker<FlightInstance[]>({ name: 'Airport Flights', cacheTtlMs: 5 * 60 * 1000, persistCache: false });
 const breakerCarrier = createCircuitBreaker<CarrierOps[]>({ name: 'Carrier Ops', cacheTtlMs: 5 * 60 * 1000, persistCache: false });
-const breakerStatus = createCircuitBreaker<FlightInstance[]>({ name: 'Flight Status', cacheTtlMs: 2 * 60 * 1000, persistCache: false });
+const breakerStatus = createCircuitBreaker<FlightInstance[]>({ name: 'Flight Status', cacheTtlMs: 6 * 60 * 1000, persistCache: false });
 const breakerTrack = createCircuitBreaker<PositionSample[]>({ name: 'Track Aircraft', cacheTtlMs: 15 * 1000, persistCache: false });
 const breakerPrices = createCircuitBreaker<{ quotes: PriceQuote[]; isDemoMode: boolean }>({ name: 'Flight Prices', cacheTtlMs: 10 * 60 * 1000, persistCache: true });
 const breakerNews = createCircuitBreaker<AviationNewsItem[]>({ name: 'Aviation News', cacheTtlMs: 15 * 60 * 1000, persistCache: true });
@@ -298,7 +298,7 @@ export async function fetchAirportOpsSummary(airports: string[]): Promise<Airpor
   return breakerOps.execute(async () => {
     const r = await client.getAirportOpsSummary({ airports });
     return r.summaries.map(toDisplayOps);
-  }, []);
+  }, [], { cacheKey: airports.join(',') });
 }
 
 export async function fetchAirportFlights(airport: string, direction: 'departure' | 'arrival' | 'both' = 'both', limit = 30): Promise<FlightInstance[]> {
@@ -306,28 +306,28 @@ export async function fetchAirportFlights(airport: string, direction: 'departure
   return breakerFlights.execute(async () => {
     const r = await client.listAirportFlights({ airport, direction: dirMap[direction], limit });
     return r.flights.map(toDisplayFlight);
-  }, []);
+  }, [], { cacheKey: `${airport}:${direction}:${limit}` });
 }
 
 export async function fetchCarrierOps(airports: string[]): Promise<CarrierOps[]> {
   return breakerCarrier.execute(async () => {
     const r = await client.getCarrierOps({ airports, minFlights: 3 });
     return r.carriers.map(toDisplayCarrierOps);
-  }, []);
+  }, [], { cacheKey: airports.join(',') });
 }
 
 export async function fetchFlightStatus(flightNumber: string, date?: string, origin?: string): Promise<FlightInstance[]> {
   return breakerStatus.execute(async () => {
     const r = await client.getFlightStatus({ flightNumber, date: date ?? '', origin: origin ?? '' });
     return r.flights.map(toDisplayFlight);
-  }, []);
+  }, [], { cacheKey: `${flightNumber}:${date ?? ''}:${origin ?? ''}` });
 }
 
 export async function fetchAircraftPositions(opts: { icao24?: string; callsign?: string; swLat?: number; swLon?: number; neLat?: number; neLon?: number }): Promise<PositionSample[]> {
   return breakerTrack.execute(async () => {
     const r = await client.trackAircraft({ icao24: opts.icao24 ?? '', callsign: opts.callsign ?? '', swLat: opts.swLat ?? 0, swLon: opts.swLon ?? 0, neLat: opts.neLat ?? 0, neLon: opts.neLon ?? 0 });
     return r.positions.map(toDisplayPosition);
-  }, []);
+  }, [], { cacheKey: `${opts.icao24 ?? ''}:${opts.callsign ?? ''}:${opts.swLat ?? 0}:${opts.swLon ?? 0}:${opts.neLat ?? 0}:${opts.neLon ?? 0}` });
 }
 
 export async function fetchFlightPrices(opts: { origin: string; destination: string; departureDate: string; returnDate?: string; adults?: number; cabin?: CabinClass; nonstopOnly?: boolean; maxResults?: number; currency?: string; market?: string }): Promise<{ quotes: PriceQuote[]; isDemoMode: boolean; isIndicative: boolean; provider: string }> {

--- a/src/services/conflict/index.ts
+++ b/src/services/conflict/index.ts
@@ -303,19 +303,25 @@ export async function fetchHapiSummary(): Promise<Map<string, HapiConflictSummar
     } catch (err: unknown) {
       // 404 deploy-skew fallback: batch endpoint not yet deployed, use per-item calls
       if (err instanceof ApiError && err.statusCode === 404) {
-        const results = await Promise.allSettled(
-          HAPI_COUNTRY_CODES.map(async (iso2) => {
-            const r = await getHapiBreaker(iso2).execute(async () => {
-              return client.getHumanitarianSummary({ countryCode: iso2 });
-            }, emptyHapiFallback);
-            return { iso2, r };
-          }),
-        );
-        const fallbackResults: Record<string, ProtoHumanSummary> = {};
-        for (const result of results) {
-          if (result.status === 'fulfilled' && result.value.r.summary) {
-            fallbackResults[result.value.iso2] = result.value.r.summary;
+        const HAPI_CONCURRENT = 5;
+        const allFallback: Array<{ iso2: string; r: GetHumanitarianSummaryResponse }> = [];
+        for (let i = 0; i < HAPI_COUNTRY_CODES.length; i += HAPI_CONCURRENT) {
+          const batch = HAPI_COUNTRY_CODES.slice(i, i + HAPI_CONCURRENT);
+          const results = await Promise.allSettled(
+            batch.map(async (iso2) => {
+              const r = await getHapiBreaker(iso2).execute(async () => {
+                return client.getHumanitarianSummary({ countryCode: iso2 });
+              }, emptyHapiFallback);
+              return { iso2, r };
+            }),
+          );
+          for (const result of results) {
+            if (result.status === 'fulfilled') allFallback.push(result.value);
           }
+        }
+        const fallbackResults: Record<string, ProtoHumanSummary> = {};
+        for (const { iso2, r } of allFallback) {
+          if (r.summary) fallbackResults[iso2] = r.summary;
         }
         return { results: fallbackResults, fetched: Object.keys(fallbackResults).length, requested: HAPI_COUNTRY_CODES.length };
       }

--- a/src/services/population-exposure.ts
+++ b/src/services/population-exposure.ts
@@ -12,7 +12,7 @@ const exposureBreaker = createCircuitBreaker<ExposureResponse | null>({
   name: 'PopExposure',
   cacheTtlMs: 6 * 60 * 60 * 1000,
   persistCache: true,
-  maxCacheEntries: 64,
+  maxCacheEntries: 256,
 });
 
 export async function fetchCountryPopulations(): Promise<CountryPopulation[]> {
@@ -31,7 +31,7 @@ interface ExposureResponse {
 }
 
 export async function fetchExposure(lat: number, lon: number, radiusKm: number): Promise<ExposureResponse | null> {
-  const cacheKey = `${lat.toFixed(4)},${lon.toFixed(4)},${radiusKm}`;
+  const cacheKey = `${lat.toFixed(1)},${lon.toFixed(1)},${radiusKm}`;
   return exposureBreaker.execute(
     async () => {
       const result = await client.getPopulationExposure({ mode: 'exposure', lat, lon, radius: radiusKm });


### PR DESCRIPTION
## Summary

- **AirlineIntelPanel**: Skip `loadOps()` when active tab is already `ops` — eliminates duplicate `fetchAirportOpsSummary` RPC on every 5-min refresh (was firing 2 identical calls concurrently)
- **Population exposure cache**: Raise `maxCacheEntries` 64→256; coarsen coord key from `toFixed(4)` (~11m) to `toFixed(1)` (~11km) — appropriate for 30-100km exposure radii, dramatically improves hit rate
- **Aviation breakers — correctness bug**: Add `cacheKey` to all 5 breaker calls (`fetchAirportOpsSummary`, `fetchAirportFlights`, `fetchFlightStatus`, `fetchCarrierOps`, `fetchAircraftPositions`). Without this, all calls shared `__default__` slot — looking up TK2 within 2min of TK1 returned TK1's cached data
- **Aviation `breakerStatus` TTL**: Raise 2min→6min so it outlives the 5-min panel refresh cycle (was guaranteed cache miss on every refresh)
- **HAPI 404 fallback**: Batch 20 concurrent per-country RPCs in groups of 5 to avoid burst during deploy-skew events
- **NationalDebtPanel ticker**: Cache DOM element references after render; skip `textContent` writes when formatted value unchanged — eliminates 20+ `querySelector` calls and redundant DOM writes per second

## Context

Top Vercel analytics paths: `/api/displacement/v1/get-population-exposure` (24.72M/week) and `/api/aviation/v1/get-airport-ops-summary` (10.74M/week). These fixes address the double-call and cache miss patterns contributing to that volume.

## Test plan

- [ ] TypeScript: `npm run typecheck` passes
- [ ] Tests: `npm run test:data` passes (2357 tests)
- [ ] Lint: `npm run lint` clean
- [ ] Manual: Open Airline Intel panel on ops tab, verify Network tab shows 1 RPC per 5-min refresh (not 2)
- [ ] Manual: Open National Debt panel, verify ticker still updates smoothly with no visible lag