### PR TITLE
refactor(economic): remove dead checkEiaStatus function

### DIFF
--- a/src/services/economic/index.ts
+++ b/src/services/economic/index.ts
@@ -336,18 +336,6 @@ function protoEnergyToOilMetric(proto: ProtoEnergyPrice): OilMetric {
   };
 }
 
-export async function checkEiaStatus(): Promise<boolean> {
-  if (!isFeatureAvailable('energyEia')) return false;
-  try {
-    const resp = await eiaBreaker.execute(async () => {
-      return client.getEnergyPrices({ commodities: ['wti'] }, { signal: AbortSignal.timeout(20_000) });
-    }, emptyEiaFallback);
-    return resp.prices.length > 0;
-  } catch {
-    return false;
-  }
-}
-
 export async function fetchOilAnalytics(): Promise<OilAnalytics> {
   const empty: OilAnalytics = {
     wtiPrice: null, brentPrice: null, usProduction: null, usInventory: null, fetchedAt: new Date(),


### PR DESCRIPTION
Never had a caller since introduced in Jan 2026 (`8f00e09`).

Would have caused a silent cache key collision with `fetchOilAnalytics` — both shared `eiaBreaker` with no `cacheKey`, so a `checkEiaStatus` call first would poison the `__default__` cache slot with a single-commodity response, causing `brentPrice`, `usProduction`, and `usInventory` to silently return `null` for 15 minutes.

Since it was dead code, the bug was latent. Easiest fix: delete it.