### PR TITLE
fix(premium): check tester key before Clerk token — fixes 403 for tester-key users

### DIFF
--- a/src/services/premium-fetch.ts
+++ b/src/services/premium-fetch.ts
@@ -26,17 +26,9 @@ export async function premiumFetch(
     }
   } catch { /* not available — fall through */ }
 
-  // 2. Clerk Pro session token.
-  try {
-    const { getClerkToken } = await import('@/services/clerk');
-    const token = await getClerkToken();
-    if (token) {
-      existing.set('Authorization', `Bearer ${token}`);
-      return globalThis.fetch(input, { ...init, headers: existing });
-    }
-  } catch { /* not signed in — fall through */ }
-
-  // 3. Tester / widget key from localStorage (wm-pro-key or wm-widget-key).
+  // 2. Tester / widget key from localStorage (wm-pro-key or wm-widget-key).
+  // Must run BEFORE Clerk to prevent a free Clerk session from intercepting the
+  // request and returning 403 before the tester key is ever checked.
   try {
     const { getProWidgetKey, getWidgetAgentKey } = await import('@/services/widget-store');
     const testerKey = getProWidgetKey() || getWidgetAgentKey();
@@ -45,6 +37,16 @@ export async function premiumFetch(
       return globalThis.fetch(input, { ...init, headers: existing });
     }
   } catch { /* not available — fall through */ }
+
+  // 3. Clerk Pro session token (fallback for users without a tester key).
+  try {
+    const { getClerkToken } = await import('@/services/clerk');
+    const token = await getClerkToken();
+    if (token) {
+      existing.set('Authorization', `Bearer ${token}`);
+      return globalThis.fetch(input, { ...init, headers: existing });
+    }
+  } catch { /* not signed in — fall through */ }
 
   // 4. No auth — let the request through (gateway will return 401).
   return globalThis.fetch(input, init);

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -784,17 +784,19 @@ export function installWebApiRedirect(): void {
         return { ...init, headers };
       }
     } catch { /* runtime-config unavailable — fall through */ }
-    // Clerk Pro: inject Bearer token
-    const token = await getClerkToken();
-    if (token) {
-      headers.set('Authorization', `Bearer ${token}`);
-      return { ...init, headers };
-    }
-    // Tester key (wm-pro-key / wm-widget-key): forward as API key header
+    // Tester key (wm-pro-key / wm-widget-key): forward as API key header.
+    // Must run BEFORE Clerk to prevent a free Clerk session from intercepting
+    // the request and returning 403 before the tester key is ever tried.
     const { getProWidgetKey, getWidgetAgentKey } = await import('@/services/widget-store');
     const testerKey = getProWidgetKey() || getWidgetAgentKey();
     if (testerKey) {
       headers.set('X-WorldMonitor-Key', testerKey);
+      return { ...init, headers };
+    }
+    // Clerk Pro: inject Bearer token (fallback for users without a tester key)
+    const token = await getClerkToken();
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
       return { ...init, headers };
     }
     return init;


### PR DESCRIPTION
## Root Cause

`premiumFetch` (PR #2310) and `enrichInitForPremium` (PR #2303) both injected the Clerk Bearer token in step 2, **before** checking for the tester key in step 3. For users who have:

- A tester key (`wm-pro-key` / `wm-widget-key`) in localStorage, AND
- An active Clerk session as a **free** user

...the free Bearer token was injected and the request returned early. The gateway validated the Bearer, found `role !== 'pro'`, and returned **403**. The tester key in step 3 was never reached.

## Fix

Swap order in both `premiumFetch` and `enrichInitForPremium`:

1. `WORLDMONITOR_API_KEY` (env/runtime config)
2. **Tester key** (`wm-pro-key` / `wm-widget-key`) — now runs before Clerk
3. Clerk Bearer token (fallback for pure Clerk Pro users without a tester key)
4. No auth → let gateway return 401

## Effect

| User type | Before | After |
|-----------|--------|-------|
| Tester key + free Clerk account | 403 (free Bearer injected, tester key skipped) | Uses tester key → 200 if key in VALID_KEYS |
| Pure Clerk Pro (no tester key) | 200 | 200 (unchanged) |
| Desktop with API key | 200 | 200 (unchanged) |
| Free user, no key | 401 | 401 (unchanged, panel gating prevents the call) |

## Test plan

- [ ] `npm run typecheck` passes
- [ ] Log in to Clerk as free user, set `wm-pro-key` in settings, verify stock analysis and backtesting load (no 403)
- [ ] Clerk Pro user without tester key: verify panels still load (Bearer token fallback intact)