### PR TITLE
fix(perf): align circuit breaker TTLs with panel refresh intervals

### DIFF
--- a/src/services/climate/index.ts
+++ b/src/services/climate/index.ts
@@ -40,7 +40,7 @@ export interface ClimateFetchResult {
 }
 
 const client = new ClimateServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
-const breaker = createCircuitBreaker<ListClimateAnomaliesResponse>({ name: 'Climate Anomalies', cacheTtlMs: 10 * 60 * 1000, persistCache: true });
+const breaker = createCircuitBreaker<ListClimateAnomaliesResponse>({ name: 'Climate Anomalies', cacheTtlMs: 20 * 60 * 1000, persistCache: true });
 
 const emptyClimateFallback: ListClimateAnomaliesResponse = { anomalies: [] };
 

--- a/src/services/pizzint.ts
+++ b/src/services/pizzint.ts
@@ -28,7 +28,7 @@ const gdeltBreaker = createCircuitBreaker<GdeltTensionPair[]>({
   name: 'GDELT Tensions',
   maxFailures: 3,
   cooldownMs: 5 * 60 * 1000,
-  cacheTtlMs: 10 * 60 * 1000,
+  cacheTtlMs: 15 * 60 * 1000,
   persistCache: true,
 });
 

--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -27,7 +27,7 @@ export type {
 const client = new SupplyChainServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
 
 const shippingBreaker = createCircuitBreaker<GetShippingRatesResponse>({ name: 'Shipping Rates', cacheTtlMs: 60 * 60 * 1000, persistCache: true });
-const chokepointBreaker = createCircuitBreaker<GetChokepointStatusResponse>({ name: 'Chokepoint Status', cacheTtlMs: 5 * 60 * 1000, persistCache: true });
+const chokepointBreaker = createCircuitBreaker<GetChokepointStatusResponse>({ name: 'Chokepoint Status', cacheTtlMs: 90 * 60 * 1000, persistCache: true });
 const mineralsBreaker = createCircuitBreaker<GetCriticalMineralsResponse>({ name: 'Critical Minerals', cacheTtlMs: 24 * 60 * 60 * 1000, persistCache: true });
 
 const emptyShipping: GetShippingRatesResponse = { indices: [], fetchedAt: '', upstreamUnavailable: false };

--- a/tests/supply-chain-v2.test.mjs
+++ b/tests/supply-chain-v2.test.mjs
@@ -358,8 +358,8 @@ describe('Client-side circuit breaker TTLs', () => {
     assert.match(src, /name:\s*'Shipping Rates'.*cacheTtlMs:\s*60\s*\*\s*60\s*\*\s*1000/);
   });
 
-  it('chokepoint breaker uses 5 min TTL', () => {
-    assert.match(src, /name:\s*'Chokepoint Status'.*cacheTtlMs:\s*5\s*\*\s*60\s*\*\s*1000/);
+  it('chokepoint breaker uses 90 min TTL (aligned with 60 min supplyChain refresh)', () => {
+    assert.match(src, /name:\s*'Chokepoint Status'.*cacheTtlMs:\s*90\s*\*\s*60\s*\*\s*1000/);
   });
 
   it('minerals breaker uses 24 hour TTL', () => {


### PR DESCRIPTION
## Problem

Three circuit breakers had TTLs shorter than their panel refresh intervals, making `persistCache: true` effectively useless — cache always expired before the next refresh cycle could reuse it.

| Breaker | Old TTL | Refresh Interval | New TTL |
|---|---|---|---|
| `chokepointBreaker` | 5 min | 60 min (supplyChain) | 90 min |
| `climateBreaker` | 10 min | 15 min (intelligence) | 20 min |
| `gdeltBreaker` | 10 min | 10 min (pizzint) | 15 min |

## Fix

- `chokepointBreaker`: 5 min → 90 min (1.5× the 60 min refresh)
- `climateBreaker`: 10 min → 20 min (1.3× the 15 min refresh)
- `gdeltBreaker`: 10 min → 15 min (1.5× the 10 min refresh, avoids timing races)

All new TTLs are set to ~1.3–1.5× their refresh intervals so cache reliably survives a full refresh cycle, including a small margin for cold starts.

Updated `supply-chain-v2.test.mjs` assertion to match new chokepoint TTL.