### PR TITLE
fix(cors): reduce Max-Age 86400→3600 and sync X-Widget-Key + X-Pro-Key to _cors.js

### DIFF
--- a/api/_cors.js
+++ b/api/_cors.js
@@ -22,8 +22,8 @@ export function getCorsHeaders(req, methods = 'GET, OPTIONS') {
   return {
     'Access-Control-Allow-Origin': allowOrigin,
     'Access-Control-Allow-Methods': methods,
-    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key',
-    'Access-Control-Max-Age': '86400',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Widget-Key, X-Pro-Key',
+    'Access-Control-Max-Age': '3600',
     'Vary': 'Origin',
   };
 }
@@ -40,8 +40,8 @@ export function getPublicCorsHeaders(methods = 'GET, OPTIONS') {
   return {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': methods,
-    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key',
-    'Access-Control-Max-Age': '86400',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Widget-Key, X-Pro-Key',
+    'Access-Control-Max-Age': '3600',
   };
 }
 

--- a/server/cors.ts
+++ b/server/cors.ts
@@ -34,8 +34,8 @@ export function getCorsHeaders(req: Request): Record<string, string> {
   return {
     'Access-Control-Allow-Origin': allowOrigin,
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Widget-Key',
-    'Access-Control-Max-Age': '86400',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Widget-Key, X-Pro-Key',
+    'Access-Control-Max-Age': '3600',
     'Vary': 'Origin',
   };
 }


### PR DESCRIPTION
## Problem

`Access-Control-Max-Age: 86400` causes browsers to cache CORS preflight responses for **24 hours**. When we added `X-Widget-Key` to the allowed headers (PRs #2314, #2316), users who had already cached the old preflight continued to see:

> `x-widget-key is not allowed by Access-Control-Allow-Headers in preflight response`

...until their 24-hour cache expired — even after the fix was deployed. This is why the error persisted after multiple deployed fixes.

Additionally, `api/_cors.js` (used by standalone edge functions) was never updated with `X-Widget-Key` or `X-Pro-Key`.

## Fix

- `Access-Control-Max-Age`: `86400` → `3600` in both `server/cors.ts` and `api/_cors.js`
- `api/_cors.js`: add `X-Widget-Key, X-Pro-Key` to `Access-Control-Allow-Headers` (in sync with `server/cors.ts`)

## Immediate fix for affected users

Users currently seeing the CORS error need to clear their browser's preflight cache:
- Chrome/Edge: DevTools → Application → Storage → **Clear site data**
- Or: open an Incognito tab

## Test plan

- [ ] After deploy, verify OPTIONS response on `api.worldmonitor.app/api/widget-agent` has `Access-Control-Allow-Headers` including `X-Widget-Key`
- [ ] Verify `Access-Control-Max-Age` is `3600` not `86400`