### PR TITLE
fix(grocery-basket): bilateral outlier gate + JPY floor — catch suspiciously cheap scrapes

### DIFF
--- a/scripts/seed-grocery-basket.mjs
+++ b/scripts/seed-grocery-basket.mjs
@@ -139,7 +139,9 @@ const SYMBOL_MAP = { '£': 'GBP', '€': 'EUR', '¥': 'JPY', '₩': 'KRW', '₹'
 
 // Minimum plausible local price per currency — prevents matching product codes / IDs
 // e.g. IDR 4 = $0.0003 (nonsense), NGN 20 = $0.01 (nonsense), KRW 5 = $0.004 (nonsense)
-const CURRENCY_MIN = { NGN: 50, IDR: 500, ARS: 50, KRW: 1000, ZAR: 2, PKR: 20, LBP: 1000 };
+// JPY: even the cheapest grocery item in Japan (instant noodles) costs 100+ yen; anything
+// under 50 is a product code, portion weight, or sub-unit price, never a 1kg/1L shelf price.
+const CURRENCY_MIN = { NGN: 50, IDR: 500, ARS: 50, KRW: 1000, ZAR: 2, PKR: 20, LBP: 1000, JPY: 50 };
 
 // Maximum plausible USD price per item — catches bulk/wholesale/specialty products.
 // Set to ~2× the most expensive legitimate retail price globally for each item.
@@ -346,10 +348,10 @@ async function fetchGroceryBasketPrices(prevSnapshot) {
     console.warn(`  [routes] write failed (non-fatal): ${err.message}`)
   );
 
-  // Cross-country outlier gate — reject per-item prices > 4× the median USD price
-  // across all countries for that item. Prevents bad scrapes (bulk/wholesale/specialty)
-  // from distorting per-row colouring and basket totals.
-  // Also evicts the learned route from Redis so the bad URL isn't replayed next seed.
+  // Cross-country outlier gate — bilateral: rejects per-item prices that are either
+  //   > 4× the median (bulk/wholesale/specialty scrape error)
+  //   < ¼ the median (sub-unit price, product code, stale scraped value)
+  // Both directions evict the learned route so the bad URL isn't replayed next seed.
   const itemIds = config.items.map(i => i.id);
   const outlierEvictions = new Set();
   for (const itemId of itemIds) {
@@ -360,10 +362,17 @@ async function fetchGroceryBasketPrices(prevSnapshot) {
     pricePoints.sort((a, b) => a - b);
     const median = pricePoints[Math.floor(pricePoints.length / 2)];
     const ceiling = median * 4;
+    const floor = median / 4;
     for (const country of countriesResult) {
       const item = country.items.find(i => i.itemId === itemId);
-      if (!item?.usdPrice || item.usdPrice <= ceiling) continue;
-      console.warn(`  [outlier] ${country.code}/${itemId}: $${item.usdPrice.toFixed(2)} > 4× median $${median.toFixed(2)} — clearing + evicting learned route`);
+      if (!item?.usdPrice || item.usdPrice <= 0) continue;
+      const isHigh = item.usdPrice > ceiling;
+      const isLow  = item.usdPrice < floor;
+      if (!isHigh && !isLow) continue;
+      const reason = isHigh
+        ? `$${item.usdPrice.toFixed(4)} > 4× median $${median.toFixed(2)}`
+        : `$${item.usdPrice.toFixed(4)} < ¼ median $${median.toFixed(2)}`;
+      console.warn(`  [outlier] ${country.code}/${itemId}: ${reason} — clearing + evicting learned route`);
       item.available = false;
       item.localPrice = null;
       item.usdPrice = null;


### PR DESCRIPTION
## Why this PR?

The grocery basket outlier gate was one-sided: it only removed prices **above** 4× the cross-country median (bulk/wholesale scrapes). It never removed prices **below** ¼ the median, so stale or malformed learned routes producing absurdly cheap values went undetected.

**Observed bad values in production:**

| Country | Item | Local | USD | Expected USD |
|---------|------|-------|-----|-------------|
| Japan | Rice | 1.50 JPY | $0.01 | ~$2–3 |
| Japan | Canola Oil | 5.00 JPY | $0.03 | ~$3–4 |
| Japan | Milk | 2.00 JPY | $0.01 | ~$1.40–1.60 |
| Turkey | Sugar | 5.00 TRY | $0.11 | ~$0.90–1.30 |
| Turkey | Eggs | 3.27 TRY | $0.07 | ~$2.20–4.40 |
| Turkey | Milk | 2.75 TRY | $0.06 | ~$1.10–1.76 |
| Turkey | Canola Oil | 5.61 TRY | $0.13 | ~$1.76–3.30 |
| Egypt | Salt | 2.95 EGP | $0.06 | ~$0.32–0.53 |
| Egypt | Bread | 3.25 EGP | $0.06 | ~$0.32–0.64 |
| Egypt | Milk | 10.00 EGP | $0.19 | ~$0.74–1.06 |
| India | Potatoes | 10.00 INR | $0.11 | ~$0.24–0.36 |

All are 5–150× below the median for that item across 20+ countries. The bad values come from stale learned routes that matched sub-unit prices, product codes, or portion weights instead of shelf prices.

## What changed

**`scripts/seed-grocery-basket.mjs`**

1. **Bilateral outlier gate** — adds `floor = median / 4` alongside the existing `ceiling = median * 4`. Prices below the floor are cleared and their learned routes are evicted from Redis, forcing a clean re-scrape on the next seed run.

2. **`CURRENCY_MIN.JPY = 50`** — belt-and-suspenders for Japan. Grocery items in Japan always cost at least 100+ yen; anything under 50 is a product code, sub-unit price, or portion weight.

## Effect on next seed run

All 11 bad cells above (plus any others below ¼ median) will be cleared and their learned routes evicted. The subsequent run re-scrapes those items from fresh EXA/Firecrawl results.