### PR TITLE
fix(grocery-basket): fix JP sites, TRY/EGP/INR currency floors, evict bad routes

### DIFF
--- a/scripts/seed-grocery-basket.mjs
+++ b/scripts/seed-grocery-basket.mjs
@@ -139,9 +139,11 @@ const SYMBOL_MAP = { '£': 'GBP', '€': 'EUR', '¥': 'JPY', '₩': 'KRW', '₹'
 
 // Minimum plausible local price per currency — prevents matching product codes / IDs
 // e.g. IDR 4 = $0.0003 (nonsense), NGN 20 = $0.01 (nonsense), KRW 5 = $0.004 (nonsense)
-// JPY: even the cheapest grocery item in Japan (instant noodles) costs 100+ yen; anything
-// under 50 is a product code, portion weight, or sub-unit price, never a 1kg/1L shelf price.
-const CURRENCY_MIN = { NGN: 50, IDR: 500, ARS: 50, KRW: 1000, ZAR: 2, PKR: 20, LBP: 1000, JPY: 50 };
+// JPY: grocery items in Japan cost 100+ yen; under 50 = product code or sub-unit price.
+// TRY: Turkish supermarket shelf prices ≥ 10 TRY; under 10 = per-100g sub-unit match.
+// EGP: Egyptian supermarket prices ≥ 5 EGP; under 5 = subsidised/fractional unit.
+// INR: Indian supermarket prices ≥ 12 INR; under 12 = product code or stale clearance.
+const CURRENCY_MIN = { NGN: 50, IDR: 500, ARS: 50, KRW: 1000, ZAR: 2, PKR: 20, LBP: 1000, JPY: 50, TRY: 10, EGP: 5, INR: 12 };
 
 // Maximum plausible USD price per item — catches bulk/wholesale/specialty products.
 // Set to ~2× the most expensive legitimate retail price globally for each item.
@@ -213,9 +215,10 @@ async function fetchGroceryBasketPrices(prevSnapshot) {
   const countriesResult = [];
 
   // Load all learned routes in one pipeline request before the country loop.
-  // Include a one-time migration sentinel so the oil eviction only fires once.
+  // Include sentinel keys for one-time migrations so each eviction only fires once.
   const OIL_MIGRATION_KEY = '_migration:canola-oil-v1';
-  const routeKeys = [...config.countries.flatMap(c => config.items.map(i => `${c.code}:${i.id}`)), OIL_MIGRATION_KEY];
+  const BAD_PRICES_KEY    = '_migration:bad-prices-v1'; // JP/TR/EG/IN sub-unit scrapes + JP site change
+  const routeKeys = [...config.countries.flatMap(c => config.items.map(i => `${c.code}:${i.id}`)), OIL_MIGRATION_KEY, BAD_PRICES_KEY];
   const learnedRoutes = await bulkReadLearnedRoutes('grocery-basket', routeKeys).catch((err) => {
     console.warn(`  [routes] load failed (non-fatal): ${err.message}`);
     return new Map();
@@ -236,6 +239,26 @@ async function fetchGroceryBasketPrices(prevSnapshot) {
       for (const k of oilEvictions) learnedRoutes.delete(k);
     }
     routeUpdates.set(OIL_MIGRATION_KEY, 'done'); // persisted at end of run alongside other route updates
+  }
+
+  // One-time eviction: clear known-bad routes from the previous site config (JP) and
+  // from confirmed sub-unit price scrapes (TR/EG/IN). Forces fresh EXA searches on next run.
+  // All JP routes evicted because sites changed from aggregators (kakaku.com) to supermarkets.
+  if (!learnedRoutes.has(BAD_PRICES_KEY)) {
+    const knownBad = new Set([
+      ...config.countries.filter(c => c.code === 'JP').flatMap(c => config.items.map(i => `JP:${i.id}`)),
+      'TR:sugar', 'TR:eggs', 'TR:milk', 'TR:oil',
+      'EG:salt', 'EG:bread', 'EG:milk',
+      'IN:potatoes', 'IN:milk',
+    ].filter(k => learnedRoutes.has(k)));
+    if (knownBad.size > 0) {
+      console.log(`  [routes] one-time eviction: clearing ${knownBad.size} known-bad price routes (JP sites + TR/EG/IN sub-unit)`);
+      await bulkWriteLearnedRoutes('grocery-basket', new Map(), knownBad).catch(err =>
+        console.warn(`  [routes] bad-prices eviction failed (non-fatal): ${err.message}`)
+      );
+      for (const k of knownBad) learnedRoutes.delete(k);
+    }
+    routeUpdates.set(BAD_PRICES_KEY, 'done');
   }
 
   for (const country of config.countries) {

--- a/scripts/shared/grocery-basket.json
+++ b/scripts/shared/grocery-basket.json
@@ -114,8 +114,9 @@
       "currency": "JPY",
       "flag": "🇯🇵",
       "sites": [
-        "kakaku.com",
-        "price.com"
+        "seiyu.co.jp",
+        "life.co.jp",
+        "aeon-net.com"
       ]
     },
     {

--- a/shared/grocery-basket.json
+++ b/shared/grocery-basket.json
@@ -114,8 +114,9 @@
       "currency": "JPY",
       "flag": "🇯🇵",
       "sites": [
-        "kakaku.com",
-        "price.com"
+        "seiyu.co.jp",
+        "life.co.jp",
+        "aeon-net.com"
       ]
     },
     {


### PR DESCRIPTION
## Why this PR?

Follow-up to #2322 (bilateral outlier gate). The gate catches bad prices after scraping, but doesn't prevent them from being written as learned routes in the first place. Three root causes remained:

**1. Japan sites were price-comparison aggregators, not supermarkets**
`kakaku.com` and `price.com` are price-comparison portals that surface per-gram, per-serving, and multi-seller blended prices in EXA LLM summaries. `price.com` is not even Japan-specific. This is why Japan rice/oil/milk all showed `$0.01–$0.03`.

**2. Missing `CURRENCY_MIN` for TRY, EGP, INR**
The TRY bad values (2.75–5.61 TRY) match a common Turkish supermarket display pattern: per-100g price listed first, then the per-kg price further down. EXA summary picked up the sub-unit value. Same for EGP and INR. With no currency floor, these passed straight through.

**3. Stale learned routes not evicted**
Even with the new bilateral gate, the bad routes would be replayed once more (14-day TTL) before expiring. Without explicit eviction, the items show as N/A for one seed cycle instead of getting fresh data immediately.

## What changed

**`shared/grocery-basket.json` + `scripts/shared/grocery-basket.json`**
- Japan sites: `kakaku.com, price.com` → `seiyu.co.jp, life.co.jp, aeon-net.com`
  (Seiyu/Walmart Japan, Life supermarket, AEON — Japan's largest chain)

**`scripts/seed-grocery-basket.mjs`**
- `CURRENCY_MIN` additions: `TRY: 10, EGP: 5, INR: 12` — blocks sub-unit price matches at extraction time, before they can be written as learned routes
- One-time migration `_migration:bad-prices-v1`: evicts all JP routes (stale after site change) + confirmed bad TR/EG/IN routes on the very next seed run, forcing fresh EXA searches

## Expected result after next seed run

| Country | Items fixed |
|---------|------------|
| Japan | All 10 items re-scraped from real supermarket pages |
| Turkey | sugar, eggs, milk, oil — fresh EXA search, min floor rejects sub-unit prices |
| Egypt | salt, bread, milk — fresh EXA search |
| India | potatoes, milk — fresh EXA search |