### PR TITLE
fix(cors): add X-WorldMonitor-Key to widget-agent OPTIONS preflight (#2323)

### DIFF
--- a/api/widget-agent.ts
+++ b/api/widget-agent.ts
@@ -38,7 +38,7 @@ export default async function handler(req: Request): Promise<Response> {
       headers: {
         ...corsHeaders,
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Widget-Key, X-Pro-Key',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Widget-Key, X-Pro-Key',
       },
     });
   }


### PR DESCRIPTION
## Why this PR?

`api/widget-agent.ts` explicitly overrides the `Access-Control-Allow-Headers` in its OPTIONS handler with a hardcoded value that was missing `X-WorldMonitor-Key`. Because edge function OPTIONS responses are self-contained, `vercel.json` header rules and `api/_cors.js` cannot override this — the explicit value is what browsers receive.

This caused CORS preflight failures for any widget-agent request sent with `X-WorldMonitor-Key` (e.g. from widget embeds or pro API users), despite PRs #2316 and #2321 having added the header in `_cors.js` and `vercel.json`.

## Change

**`api/widget-agent.ts`** (line 41): Added `X-WorldMonitor-Key` to the explicit `Access-Control-Allow-Headers` override in the OPTIONS preflight handler.

```diff
- 'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Widget-Key, X-Pro-Key',
+ 'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Widget-Key, X-Pro-Key',
```

## Root cause chain

PRs #2316 → #2321 fixed `vercel.json` + `_cors.js`, but `widget-agent.ts` has its own explicit `Access-Control-Allow-Headers` that takes precedence and was never updated.