### PR TITLE
fix(research): add cacheKey to arxivBreaker, trendingBreaker, hnBreaker

### DIFF
--- a/src/services/research/index.ts
+++ b/src/services/research/index.ts
@@ -29,7 +29,7 @@ export async function fetchArxivPapers(
       cursor: '',
     });
     return resp.papers;
-  }, []);
+  }, [], { cacheKey: `${category}:${query}:${pageSize}` });
 }
 
 export async function fetchTrendingRepos(
@@ -45,7 +45,7 @@ export async function fetchTrendingRepos(
       cursor: '',
     });
     return resp.repos;
-  }, []);
+  }, [], { cacheKey: `${language}:${period}:${pageSize}` });
 }
 
 export async function fetchHackernewsItems(
@@ -59,5 +59,5 @@ export async function fetchHackernewsItems(
       cursor: '',
     });
     return resp.items;
-  }, []);
+  }, [], { cacheKey: `${feedType}:${pageSize}` });
 }


### PR DESCRIPTION
## Why this PR?

All three research breakers have `persistCache: true` but no `cacheKey`, so distinct calls share the `__default__` slot:

- `fetchArxivPapers(category, query, pageSize)`: `cs.AI` query cached, `physics.optics` returns cs.AI papers until 10min TTL
- `fetchTrendingRepos(language, period, pageSize)`: `python/daily` cached, `rust/weekly` returns Python repos
- `fetchHackernewsItems(feedType, pageSize)`: `top` cached, `new` feed returns top stories

## Changes

`src/services/research/index.ts`:
- `fetchArxivPapers`: `cacheKey: \`${category}:${query}:${pageSize}\``
- `fetchTrendingRepos`: `cacheKey: \`${language}:${period}:${pageSize}\``
- `fetchHackernewsItems`: `cacheKey: \`${feedType}:${pageSize}\``

Same pattern as `fetchAircraftPositions` and the aviation fixes in #2323.

## Test plan
- [ ] Typecheck clean on `research/index.ts`
- [ ] Manual: open Research panel, switch between ArXiv categories, confirm distinct results