### PR TITLE
fix(simulation): key evaluationTargets and constraints by theaterId

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -12130,17 +12130,18 @@ function buildSimulationPackageEventSeeds(selectedTheaters, candidates) {
 }
 
 function buildSimulationPackageConstraints(selectedTheaters, candidates) {
-  const constraints = [];
+  const result = {};
   let idx = 0;
 
   for (const theater of selectedTheaters) {
     const candidate = candidates.find((c) => c.candidateStateId === theater.candidateStateId);
     if (!candidate) continue;
     const src = `candidate:${theater.candidateStateId}`;
+    const theaterConstraints = [];
 
     if (theater.routeFacilityKey) {
       const hardDisruption = Number(candidate.marketContext?.criticalSignalLift || 0) >= 0.25;
-      constraints.push({
+      theaterConstraints.push({
         constraintId: `c-${++idx}`,
         theaterId: theater.theaterId,
         class: 'route_chokepoint_status',
@@ -12151,7 +12152,7 @@ function buildSimulationPackageConstraints(selectedTheaters, candidates) {
     }
 
     if (theater.commodityKey) {
-      constraints.push({
+      theaterConstraints.push({
         constraintId: `c-${++idx}`,
         theaterId: theater.theaterId,
         class: 'commodity_exposure',
@@ -12162,7 +12163,7 @@ function buildSimulationPackageConstraints(selectedTheaters, candidates) {
     }
 
     if (theater.topBucketId && theater.topChannel) {
-      constraints.push({
+      theaterConstraints.push({
         constraintId: `c-${++idx}`,
         theaterId: theater.theaterId,
         class: 'market_admissibility',
@@ -12174,7 +12175,7 @@ function buildSimulationPackageConstraints(selectedTheaters, candidates) {
 
     const contradictionScore = Number(candidate.marketContext?.contradictionScore || 0);
     if (contradictionScore >= 0.1) {
-      constraints.push({
+      theaterConstraints.push({
         constraintId: `c-${++idx}`,
         theaterId: theater.theaterId,
         class: 'known_invalidators',
@@ -12183,13 +12184,16 @@ function buildSimulationPackageConstraints(selectedTheaters, candidates) {
         source: `${src}:contradictionScore=${contradictionScore}`,
       });
     }
+
+    result[theater.theaterId] = theaterConstraints;
   }
 
-  return constraints;
+  return result;
 }
 
 function buildSimulationPackageEvaluationTargets(selectedTheaters, candidates) {
-  return selectedTheaters.map((theater) => {
+  const result = {};
+  for (const theater of selectedTheaters) {
     const candidate = candidates.find((c) => c.candidateStateId === theater.candidateStateId);
     if (!candidate) {
       console.warn(`[SimulationPackage] No candidate for theaterId=${theater.theaterId} (evaluationTargets)`);
@@ -12200,7 +12204,7 @@ function buildSimulationPackageEvaluationTargets(selectedTheaters, candidates) {
     const channel = theater.topChannel ? theater.topChannel.replace(/_/g, ' ') : 'transmission';
     const macroRegion = theater.macroRegions?.[0] || theater.dominantRegion;
     const actors = (candidate?.stateSummary?.actors || []).slice(0, 3).join(', ') || 'key actors';
-    return {
+    result[theater.theaterId] = {
       theaterId: theater.theaterId,
       requiredPaths: [
         {
@@ -12224,7 +12228,8 @@ function buildSimulationPackageEvaluationTargets(selectedTheaters, candidates) {
       ],
       actorResponseFocus: actors,
     };
-  });
+  }
+  return result;
 }
 
 function buildSimulationStructuralWorld(selectedTheaters, { stateUnits, worldSignals, marketTransmission, marketState, situationClusters, situationFamilies }) {
@@ -15494,10 +15499,11 @@ function buildSimulationRound1SystemPrompt(theater, pkg) {
     (s) => `- ${sanitizeForPrompt(s.seedId)} [${sanitizeForPrompt(s.type)}] ${sanitizeForPrompt(s.summary)} (${sanitizeForPrompt(s.timing)})`,
   ).join('\n');
 
-  const constraints = (pkg.constraints?.[theater.theaterId] || pkg.constraints?.theater || [])
-    .map((c) => `- ${sanitizeForPrompt(c)}`).join('\n') || '- No explicit constraints';
-  const evalTargets = (pkg.evaluationTargets?.[theater.theaterId] || pkg.evaluationTargets?.theater || [])
-    .map((t) => `- ${sanitizeForPrompt(t)}`).join('\n') || '- General market and security dynamics';
+  const constraints = (pkg.constraints?.[theater.theaterId] || [])
+    .map((c) => `- [${c.hard ? 'hard' : 'soft'}] ${sanitizeForPrompt(c.class)}: ${sanitizeForPrompt(c.statement)}`).join('\n') || '- No explicit constraints';
+  const theaterEvalTargets = pkg.evaluationTargets?.[theater.theaterId];
+  const evalTargets = (theaterEvalTargets?.requiredPaths || [])
+    .map((p) => `- ${sanitizeForPrompt(p.pathType)}: ${sanitizeForPrompt(p.question)}`).join('\n') || '- General market and security dynamics';
   const requirement = sanitizeForPrompt(
     pkg.simulationRequirement?.[theater.theaterId] || theater.theaterLabel || theater.theaterId,
   );
@@ -15562,8 +15568,9 @@ function buildSimulationRound2SystemPrompt(theater, pkg, round1) {
   );
   const entityIds = theaterEntities.slice(0, 10).map((e) => sanitizeForPrompt(e.entityId || '')).join(', ');
 
-  const evalTargets = (pkg.evaluationTargets?.[theater.theaterId] || pkg.evaluationTargets?.theater || [])
-    .map((t) => `- ${sanitizeForPrompt(t)}`).join('\n') || '- General market and security dynamics';
+  const r2EvalTargets = pkg.evaluationTargets?.[theater.theaterId];
+  const evalTargets = (r2EvalTargets?.requiredPaths || [])
+    .map((p) => `- ${sanitizeForPrompt(p.pathType)}: ${sanitizeForPrompt(p.question)}`).join('\n') || '- General market and security dynamics';
 
   return `You are a geopolitical simulation engine. This is ROUND 2 of a 2-round theater simulation.
 

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -5572,8 +5572,8 @@ describe('simulation package export', () => {
     assert.ok(pkg.structuralWorld);
     assert.ok(Array.isArray(pkg.entities));
     assert.ok(Array.isArray(pkg.eventSeeds));
-    assert.ok(Array.isArray(pkg.constraints));
-    assert.ok(Array.isArray(pkg.evaluationTargets));
+    assert.ok(pkg.constraints && typeof pkg.constraints === 'object' && !Array.isArray(pkg.constraints));
+    assert.ok(pkg.evaluationTargets && typeof pkg.evaluationTargets === 'object' && !Array.isArray(pkg.evaluationTargets));
   });
 
   it('selectedTheaters has correct shape with theater-1 id', () => {
@@ -5606,35 +5606,40 @@ describe('simulation package export', () => {
     assert.ok(newsSeeds[0].strength > 0);
   });
 
-  it('constraints includes route_chokepoint_status for hard disruption', () => {
+  it('constraints is keyed by theaterId with route_chokepoint_status for hard disruption', () => {
     const hardCandidate = makeCandidate();
     hardCandidate.marketContext.criticalSignalLift = 0.28;
     const pkg = buildSimulationPackageFromDeepSnapshot(makeSnapshot([hardCandidate]));
-    const routeConstraint = pkg.constraints.find((c) => c.class === 'route_chokepoint_status');
+    const theaterConstraints = pkg.constraints['theater-1'];
+    assert.ok(Array.isArray(theaterConstraints));
+    const routeConstraint = theaterConstraints.find((c) => c.class === 'route_chokepoint_status');
     assert.ok(routeConstraint);
     assert.equal(routeConstraint.hard, true);
     assert.equal(routeConstraint.theaterId, 'theater-1');
   });
 
-  it('constraints includes commodity_exposure as hard constraint', () => {
+  it('constraints theater-1 includes commodity_exposure as hard constraint', () => {
     const pkg = buildSimulationPackageFromDeepSnapshot(makeSnapshot());
-    const commodityConstraint = pkg.constraints.find((c) => c.class === 'commodity_exposure');
+    const theaterConstraints = pkg.constraints['theater-1'];
+    const commodityConstraint = theaterConstraints.find((c) => c.class === 'commodity_exposure');
     assert.ok(commodityConstraint);
     assert.equal(commodityConstraint.hard, true);
     assert.ok(commodityConstraint.statement.includes('crude oil'));
   });
 
-  it('constraints includes market_admissibility as soft constraint', () => {
+  it('constraints theater-1 includes market_admissibility as soft constraint', () => {
     const pkg = buildSimulationPackageFromDeepSnapshot(makeSnapshot());
-    const admissibility = pkg.constraints.find((c) => c.class === 'market_admissibility');
+    const theaterConstraints = pkg.constraints['theater-1'];
+    const admissibility = theaterConstraints.find((c) => c.class === 'market_admissibility');
     assert.ok(admissibility);
     assert.equal(admissibility.hard, false);
     assert.ok(admissibility.statement.includes('energy'));
   });
 
-  it('evaluationTargets has required escalation, containment, market_cascade paths and timing markers', () => {
+  it('evaluationTargets is keyed by theaterId with escalation, containment, market_cascade paths', () => {
     const pkg = buildSimulationPackageFromDeepSnapshot(makeSnapshot());
-    const target = pkg.evaluationTargets[0];
+    const target = pkg.evaluationTargets['theater-1'];
+    assert.ok(target, 'evaluationTargets must have theater-1 key');
     assert.equal(target.theaterId, 'theater-1');
     const pathTypes = target.requiredPaths.map((p) => p.pathType);
     assert.ok(pathTypes.includes('escalation'));
@@ -5809,8 +5814,25 @@ const minimalPkg = {
     { seedId: 'seed-1', theaterId: 'test-theater-1', type: 'live_news', summary: 'Houthi missile attack on Red Sea shipping', evidenceRefs: ['E1'], timing: 'T+0h' },
     { seedId: 'seed-2', theaterId: 'test-theater-1', type: 'state_signal', summary: 'Oil tanker rerouting Cape of Good Hope', evidenceRefs: ['E2'], timing: 'T+12h' },
   ],
-  constraints: { 'test-theater-1': ['No actor may unilaterally close the Strait of Bab-el-Mandeb'] },
-  evaluationTargets: { 'test-theater-1': ['Oil price trajectory over 72h', 'Shipping diversion extent'] },
+  constraints: {
+    'test-theater-1': [
+      { constraintId: 'c-1', theaterId: 'test-theater-1', class: 'route_chokepoint_status', statement: 'Red Sea is under elevated risk per current world signals.', hard: false, source: 'test' },
+      { constraintId: 'c-2', theaterId: 'test-theater-1', class: 'commodity_exposure', statement: 'crude oil is the primary exposed commodity.', hard: true, source: 'test' },
+    ],
+  },
+  evaluationTargets: {
+    'test-theater-1': {
+      theaterId: 'test-theater-1',
+      requiredPaths: [
+        { pathType: 'escalation', question: 'How does disruption at Red Sea escalate into a broader energy shock?' },
+        { pathType: 'containment', question: 'What conditions contain the Red Sea disruption before energy repricing?' },
+        { pathType: 'market_cascade', question: 'What are the 2nd and 3rd order economic consequences? Model $/bbl direction and freight rate delta.' },
+      ],
+      requiredOutputs: ['key_invalidators', 'timing_markers', 'actor_response_summary'],
+      timingMarkers: [{ label: 'T+24h', description: 'Initial response' }, { label: 'T+48h', description: 'Repricing signals' }, { label: 'T+72h', description: 'Bifurcation point' }],
+      actorResponseFocus: 'key actors',
+    },
+  },
   simulationRequirement: { 'test-theater-1': 'Simulate how a Red Sea disruption propagates through energy and logistics markets' },
 };
 
@@ -5851,6 +5873,28 @@ describe('simulation runner — prompt builders', () => {
     assert.ok(prompt.includes('market_cascade'), 'should include market_cascade path name');
     assert.ok(prompt.includes('$/bbl') || prompt.includes('freight rate'), 'should include economic cascade language ($/bbl or freight rate)');
     assert.ok(!prompt.includes('"spillover"'), 'spillover must not appear as a path ID');
+  });
+
+  it('Round 1 prompt renders evaluationTargets questions from requiredPaths (not fallback)', () => {
+    const prompt = buildSimulationRound1SystemPrompt(minimalTheater, minimalPkg);
+    assert.ok(prompt.includes('escalation:'), 'evalTargets escalation question must appear');
+    assert.ok(prompt.includes('containment:'), 'evalTargets containment question must appear');
+    assert.ok(prompt.includes('market_cascade:'), 'evalTargets market_cascade question must appear');
+    assert.ok(!prompt.includes('General market and security dynamics'), 'fallback text must not appear when evalTargets are present');
+  });
+
+  it('Round 1 prompt renders constraints with hard/soft labels (not fallback)', () => {
+    const prompt = buildSimulationRound1SystemPrompt(minimalTheater, minimalPkg);
+    assert.ok(prompt.includes('[soft] route_chokepoint_status:'), 'soft constraint must appear');
+    assert.ok(prompt.includes('[hard] commodity_exposure:'), 'hard constraint must appear');
+    assert.ok(!prompt.includes('No explicit constraints'), 'fallback text must not appear when constraints are present');
+  });
+
+  it('Round 2 prompt renders evaluationTargets questions from requiredPaths (not fallback)', () => {
+    const round1 = { paths: [{ pathId: 'escalation', summary: 'Escalation summary', initialReactions: [] }] };
+    const prompt = buildSimulationRound2SystemPrompt(minimalTheater, minimalPkg, round1);
+    assert.ok(prompt.includes('escalation:'), 'evalTargets escalation question must appear in round 2');
+    assert.ok(!prompt.includes('General market and security dynamics'), 'fallback text must not appear in round 2');
   });
 
   it('Round 2 prompt contains Round 1 path summaries', () => {


### PR DESCRIPTION
## Problem

`buildSimulationPackageEvaluationTargets` and `buildSimulationPackageConstraints` both returned **flat arrays**. The prompt builders consumed them as:

```js
pkg.evaluationTargets?.[theater.theaterId]  // object lookup on an array → always undefined
pkg.constraints?.[theater.theaterId]         // same
```

Both fell through to their fallback strings on every simulation run:
- EVALUATION TARGETS: `"- General market and security dynamics"`
- CONSTRAINTS: `"- No explicit constraints"`

The specific evaluation questions (escalation/containment/market_cascade framing) and WorldMonitor structural constraints (route status, commodity exposure, market admissibility) **never reached the LLM**.

## Fix

Both builders now return `Record<theaterId, ...>`:

- `constraints['theater-1']` → array of `{ class, statement, hard, ... }` per theater
- `evaluationTargets['theater-1']` → `{ requiredPaths, timingMarkers, ... }` per theater

Prompt builders updated to render each item explicitly:
- Constraints: `- [hard|soft] class: statement`
- Eval targets: `- pathType: question`

Applied to both Round 1 and Round 2 prompt builders.

## Tests

- Updated 4 existing tests (shape assertions + constraint/evalTargets lookups)
- Updated `minimalPkg` fixture to use Record shape
- Added 4 new tests asserting structured text appears in prompts (not fallback)

**179 tests, 0 failures**