### PR TITLE
fix(widget): fall back to Clerk JWT when no tester key set

### DIFF
--- a/src/components/WidgetChatModal.ts
+++ b/src/components/WidgetChatModal.ts
@@ -46,7 +46,8 @@ async function buildWidgetAuthHeaders(isPro: boolean): Promise<Record<string, st
   const widgetKey = getWidgetAgentKey();
   const proKey = getProWidgetKey();
   if (widgetKey || proKey) {
-    const headers: Record<string, string> = { 'X-Widget-Key': widgetKey };
+    const headers: Record<string, string> = {};
+    if (widgetKey) headers['X-Widget-Key'] = widgetKey;
     if (isPro && proKey) headers['X-Pro-Key'] = proKey;
     return headers;
   }


### PR DESCRIPTION
## Why

Widget modal only used tester keys from localStorage. Clerk pro users with no localStorage keys got a 403 from the relay: modal sends `tier: pro` in the body, edge fn has `isPro = false` (no pro key match), relay rejects `tier: pro` without a valid pro key.

## What

Add `buildWidgetAuthHeaders(isPro)`: tester key first, Clerk JWT fallback. Same pattern as `premiumFetch` but with widget-specific header names. Applied to both preflight and POST.

```
wm-widget-key in localStorage → X-Widget-Key (+ X-Pro-Key if isPro + wm-pro-key set)
no tester key → Authorization: Bearer <clerkToken>
```

## Test plan
- [ ] Clerk pro user with no localStorage keys: widget submits via Bearer token
- [ ] Tester with wm-widget-key: still uses X-Widget-Key (no regression)
- [ ] Tester with wm-pro-key: still uses X-Pro-Key for pro tier