### PR TITLE
fix(widget-agent): downgrade tier:pro to tier:basic when isPro is false

### DIFF
--- a/api/widget-agent.ts
+++ b/api/widget-agent.ts
@@ -104,16 +104,15 @@ export default async function handler(req: Request): Promise<Response> {
   // ── Agent call (POST, SSE stream) ─────────────────────────────────────────
   let rawBody = await req.text();
 
-  // For Clerk PRO users, ensure tier:pro is present in the body (relay requires it
-  // to enable PRO model, bigger HTML limit, and PRO rate-limit bucket).
-  if (isPro) {
-    try {
-      const parsed = JSON.parse(rawBody) as Record<string, unknown>;
-      if (parsed.tier !== 'pro') {
-        rawBody = JSON.stringify({ ...parsed, tier: 'pro' });
-      }
-    } catch { /* malformed body — relay will return 400 */ }
-  }
+  // Normalise tier in body to match the server-validated isPro flag.
+  // Prevents the relay from seeing tier:pro without the matching X-Pro-Key.
+  try {
+    const parsed = JSON.parse(rawBody) as Record<string, unknown>;
+    const expectedTier = isPro ? 'pro' : 'basic';
+    if (parsed.tier !== expectedTier) {
+      rawBody = JSON.stringify({ ...parsed, tier: expectedTier });
+    }
+  } catch { /* malformed body — relay will return 400 */ }
 
   const relayRes = await fetch(`${RELAY_BASE}/widget-agent`, {
     method: 'POST',


### PR DESCRIPTION
## Why

The relay returns 403 when it receives `tier:pro` in the body but no `X-Pro-Key` header. This happens when a user has a basic widget key (not a pro key) but the modal sends `tier:pro` (hardcoded in `panel-layout.ts`).

Edge function: auth passes (`hasWidgetKey = true`), `isPro = false` (no valid pro key), so `X-Pro-Key` is NOT injected into the relay request. Body still has `tier:pro` from client. Relay rejects.

## What

Normalize the tier in the request body to match the server-validated `isPro` flag: always set `tier:pro` when `isPro = true`, always downgrade to `tier:basic` when `isPro = false`. Relay always receives a consistent `tier` + key combination.

## Test plan
- [ ] Basic widget key only: request goes through as `tier:basic`, relay accepts
- [ ] Pro key: `tier:pro` + `X-Pro-Key` injected, relay accepts
- [ ] Clerk pro JWT: `isPro = true`, `tier:pro` + `X-Pro-Key` injected, relay accepts