### PR TITLE
fix(heatmap): derive sectorBars from sectors data to fix missing bar chart (#2327)

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1273,17 +1273,19 @@ export class DataLoaderManager implements AppModule {
         name: sectorNameMap.get(s.symbol) ?? s.name,
         change: s.change,
       });
-      const hydratedFg = getHydratedData('fearGreedIndex') as Record<string, unknown> | undefined;
-      const sectorBars = Array.isArray(hydratedFg?.sectorPerformance)
-        ? (hydratedFg!.sectorPerformance as Array<{ symbol: string; name: string; change1d: number }>)
-        : undefined;
+      const toSectorBar = (s: { symbol?: string; name: string; change: number | null }) =>
+        s.symbol && Number.isFinite(s.change) ? { symbol: s.symbol, name: s.name, change1d: s.change as number } : null;
       if (hydratedSectors?.sectors?.length) {
         warmSectorCache(hydratedSectors);
-        heatmapPanel?.renderHeatmap(hydratedSectors.sectors.map(toHeatmapItem), sectorBars);
+        const items = hydratedSectors.sectors.map(toHeatmapItem);
+        const sectorBars = items.map(toSectorBar).filter((s): s is NonNullable<typeof s> => s !== null);
+        heatmapPanel?.renderHeatmap(items, sectorBars.length ? sectorBars : undefined);
       } else {
         const sectorsResp = await fetchSectors();
         if (sectorsResp.sectors.length > 0) {
-          heatmapPanel?.renderHeatmap(sectorsResp.sectors.map(toHeatmapItem), sectorBars);
+          const items = sectorsResp.sectors.map(toHeatmapItem);
+          const sectorBars = items.map(toSectorBar).filter((s): s is NonNullable<typeof s> => s !== null);
+          heatmapPanel?.renderHeatmap(items, sectorBars.length ? sectorBars : undefined);
         } else if (stocksResult.skipped) {
           this.ctx.panels['heatmap']?.showConfigError(finnhubConfigMsg);
         }


### PR DESCRIPTION
## Why this PR?

The bar chart added in #2326 never rendered in practice due to a one-shot cache race condition.

## Root cause

`getHydratedData()` deletes the cache entry after reading it (single-read by design). Both `FearGreedPanel.fetchData()` and `loadMarkets()` called `getHydratedData('fearGreedIndex')` concurrently (both kicked off by `primeVisiblePanelData` via `Promise.allSettled`).

`FearGreedPanel.fetchData()` **always wins**: it reads `fearGreedIndex` synchronously at the top of the function. `loadMarkets()` reads it much later, after multiple awaits (fetch market quotes, process stocks, etc.). By the time `loadMarkets()` reaches `getHydratedData('fearGreedIndex')`, the entry is deleted → `sectorBars = undefined` → no bar chart.

Side effect: consuming `fearGreedIndex` in `loadMarkets()` also silently broke `FearGreedPanel` hydration in the reverse race scenario.

## Fix

Derive `sectorBars` from the sectors data already available in `loadMarkets()`. `sectors[].change` is identical to `sectorPerformance.change1d` (both are the 1-day % change for the same ETFs from the same Yahoo source). No extra RPC call, no race condition, no side effect on `FearGreedPanel` hydration.

The proto/RPC changes from #2326 are kept — `sectorPerformance` in `GetFearGreedIndexResponse` remains useful for direct API consumers.