### PR TITLE
fix(seed-economy): route FRED fetches through PROXY_URL to bypass Railway IP blocks

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -296,6 +297,44 @@ export async function extendExistingTtl(keys, ttlSeconds = 600) {
 
 export function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+// ─── Proxy helpers for sources that block Railway container IPs ───
+// Supports PROXY_URL="host:port:user:pass" (Decodo) or OREF_PROXY_AUTH="user:pass@host:port" (Froxy).
+
+export function resolveProxy() {
+  const raw = process.env.PROXY_URL || '';
+  if (raw) {
+    const parts = raw.split(':');
+    if (parts.length === 4) {
+      const [host, port, user, pass] = parts;
+      return `${user}:${pass}@${host.replace(/^gate\./, 'us.')}:${port}`;
+    }
+    return raw;
+  }
+  return process.env.OREF_PROXY_AUTH || '';
+}
+
+// curl-based fetch; throws on non-2xx. Returns response body as string.
+export function curlFetch(url, proxyAuth, headers = {}) {
+  const args = ['-sS', '--compressed', '--max-time', '15', '-L'];
+  if (proxyAuth) args.push('-x', `http://${proxyAuth}`);
+  for (const [k, v] of Object.entries(headers)) args.push('-H', `${k}: ${v}`);
+  args.push('-w', '\n%{http_code}');
+  args.push(url);
+  const raw = execFileSync('curl', args, { encoding: 'utf8', timeout: 20000, stdio: ['pipe', 'pipe', 'pipe'] });
+  const nl = raw.lastIndexOf('\n');
+  const status = parseInt(raw.slice(nl + 1).trim(), 10);
+  if (status < 200 || status >= 300) throw Object.assign(new Error(`HTTP ${status}`), { status });
+  return raw.slice(0, nl);
+}
+
+// Fetch JSON from a FRED URL, routing through proxy when available.
+export async function fredFetchJson(url, proxyAuth) {
+  if (proxyAuth) return JSON.parse(curlFetch(url, proxyAuth, { Accept: 'application/json' }));
+  const r = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(10_000) });
+  if (!r.ok) throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
+  return r.json();
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/seed-bls-series.mjs
+++ b/scripts/seed-bls-series.mjs
@@ -4,9 +4,11 @@
 // FRED mirrors the national BLS series with identical data and no IP restrictions.
 // Metro-area unemployment rates (LAUMT*) are dropped; no FRED equivalent exists.
 
-import { loadEnvFile, runSeed, writeExtraKeyWithMeta, sleep } from './_seed-utils.mjs';
+import { loadEnvFile, runSeed, writeExtraKeyWithMeta, sleep, resolveProxy, fredFetchJson } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
+
+const _proxyAuth = resolveProxy();
 
 const CANONICAL_KEY = 'bls:series:v1';
 const KEY_PREFIX = 'bls:series';
@@ -45,14 +47,7 @@ async function fetchFredSeries(fredId) {
     observation_start: startDate,
   });
 
-  const resp = await fetch(`https://api.stlouisfed.org/fred/series/observations?${params}`, {
-    headers: { Accept: 'application/json' },
-    signal: AbortSignal.timeout(15_000),
-  });
-
-  if (!resp.ok) throw new Error(`FRED HTTP ${resp.status} for ${fredId}`);
-
-  const data = await resp.json();
+  const data = await fredFetchJson(`https://api.stlouisfed.org/fred/series/observations?${params}`, _proxyAuth);
   const raw = data?.observations ?? [];
 
   const observations = raw

--- a/scripts/seed-economic-calendar.mjs
+++ b/scripts/seed-economic-calendar.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, resolveProxy, fredFetchJson } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
+
+const _proxyAuth = resolveProxy();
 
 const CANONICAL_KEY = 'economic:econ-calendar:v1';
 const CACHE_TTL = 129600; // 36h — 3× a 12h cron interval
@@ -163,13 +165,7 @@ async function fetchFredReleaseDates(releaseId, apiKey, today, toDate) {
     `&api_key=${apiKey}` +
     `&file_type=json`;
 
-  const resp = await fetch(url, {
-    headers: { 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (!resp.ok) throw new Error(`FRED release/dates HTTP ${resp.status} (release_id=${releaseId})`);
-
-  const data = await resp.json();
+  const data = await fredFetchJson(url, _proxyAuth);
   return (data.release_dates ?? [])
     .map((e) => e.date)
     .filter((d) => d >= today && d <= toDate);

--- a/scripts/seed-economy.mjs
+++ b/scripts/seed-economy.mjs
@@ -1,40 +1,10 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep } from './_seed-utils.mjs';
-import { execFileSync } from 'child_process';
+import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep, resolveProxy, fredFetchJson } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
-// Proxy for FRED — Railway container IPs get rate-limited/blocked by api.stlouisfed.org.
-// Supports PROXY_URL="host:port:user:pass" (Decodo) or OREF_PROXY_AUTH="user:pass@host:port" (Froxy).
-function resolveProxy() {
-  const raw = process.env.PROXY_URL || '';
-  if (raw) {
-    const parts = raw.split(':');
-    if (parts.length === 4) {
-      const [host, port, user, pass] = parts;
-      return `${user}:${pass}@${host.replace(/^gate\./, 'us.')}:${port}`;
-    }
-    return raw;
-  }
-  return process.env.OREF_PROXY_AUTH || '';
-}
 const _proxyAuth = resolveProxy();
-
-// curl-based fetch for sources that block Railway IPs.
-// Returns response body as string; throws on non-2xx.
-function curlFetch(url, headers = {}) {
-  const args = ['-sS', '--compressed', '--max-time', '15', '-L'];
-  if (_proxyAuth) args.push('-x', `http://${_proxyAuth}`);
-  for (const [k, v] of Object.entries(headers)) args.push('-H', `${k}: ${v}`);
-  args.push('-w', '\n%{http_code}');
-  args.push(url);
-  const raw = execFileSync('curl', args, { encoding: 'utf8', timeout: 20000, stdio: ['pipe', 'pipe', 'pipe'] });
-  const nl = raw.lastIndexOf('\n');
-  const status = parseInt(raw.slice(nl + 1).trim(), 10);
-  if (status < 200 || status >= 300) throw Object.assign(new Error(`HTTP ${status}`), { status });
-  return raw.slice(0, nl);
-}
 
 // ─── Keys (must match handler cache keys exactly) ───
 const KEYS = {
@@ -191,16 +161,9 @@ async function fetchFredSeries() {
         series_id: seriesId, api_key: apiKey, file_type: 'json',
       });
 
-      const fredFetchJson = async (url) => {
-        if (_proxyAuth) return JSON.parse(curlFetch(url, { Accept: 'application/json' }));
-        const r = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(10_000) });
-        if (!r.ok) throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
-        return r.json();
-      };
-
       const [obsResp, metaResp] = await Promise.allSettled([
-        fredFetchJson(`https://api.stlouisfed.org/fred/series/observations?${obsParams}`),
-        fredFetchJson(`https://api.stlouisfed.org/fred/series?${metaParams}`),
+        fredFetchJson(`https://api.stlouisfed.org/fred/series/observations?${obsParams}`, _proxyAuth),
+        fredFetchJson(`https://api.stlouisfed.org/fred/series?${metaParams}`, _proxyAuth),
       ]);
 
       if (obsResp.status === 'rejected') {
@@ -288,7 +251,7 @@ async function fetchFredJpyFallback() {
   if (!apiKey) return [];
   try {
     const params = new URLSearchParams({ series_id: 'DEXJPUS', api_key: apiKey, file_type: 'json', sort_order: 'desc', limit: '250' });
-    const data = await fetchJsonSafe(`https://api.stlouisfed.org/fred/series/observations?${params}`, 10_000);
+    const data = await fredFetchJson(`https://api.stlouisfed.org/fred/series/observations?${params}`, _proxyAuth);
     return (data.observations || [])
       .map((o) => { const v = parseFloat(o.value); return Number.isNaN(v) || o.value === '.' ? null : v; })
       .filter(Boolean)

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep, verifySeedKey } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep, verifySeedKey, resolveProxy, fredFetchJson } from './_seed-utils.mjs';
 import { BUDGET_LAB_TARIFFS_URL, htmlToPlainText, toIsoDate, parseBudgetLabEffectiveTariffHtml } from './_trade-parse-utils.mjs';
 
 loadEnvFile(import.meta.url);
+
+const _proxyAuth = resolveProxy();
 
 // ─── Keys (must match handler cache keys exactly) ───
 const KEYS = {
@@ -56,12 +58,11 @@ async function fetchShippingRates() {
         series_id: cfg.seriesId, api_key: apiKey, file_type: 'json',
         frequency: cfg.frequency, sort_order: 'desc', limit: '24',
       });
-      const resp = await fetch(`https://api.stlouisfed.org/fred/series/observations?${params}`, {
-        headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-        signal: AbortSignal.timeout(10_000),
+      const data = await fredFetchJson(`https://api.stlouisfed.org/fred/series/observations?${params}`, _proxyAuth).catch((e) => {
+        console.warn(`  FRED ${cfg.seriesId}: ${e.message}`);
+        return null;
       });
-      if (!resp.ok) { console.warn(`  FRED ${cfg.seriesId}: HTTP ${resp.status}`); continue; }
-      const data = await resp.json();
+      if (!data) continue;
       const observations = (data.observations || [])
         .map(o => { const v = parseFloat(o.value); return Number.isNaN(v) || o.value === '.' ? null : { date: o.date, value: v }; })
         .filter(Boolean).reverse();


### PR DESCRIPTION
## Summary
- All 22 FRED series were timing out (10s each, ~4min of wasted cron time per run)
- `api.stlouisfed.org` blocks/rate-limits Railway container IPs
- Routes FRED fetches through `PROXY_URL` or `OREF_PROXY_AUTH` using the same `curl` pattern already used by `seed-fear-greed.mjs`

## How it works
- `PROXY_URL=host:port:user:pass` (Decodo format) or `OREF_PROXY_AUTH=user:pass@host:port` (Froxy format)
- Falls back to direct `fetch()` when no proxy env var is set
- Also fixes meta response parsing: previously checked `.value.ok` on a Response object, now `fredFetchJson` throws on non-2xx so `metaResp.value` is already parsed JSON

## Post-Deploy Monitoring & Validation
- **Logs to watch:** Railway seed-economy cron logs — look for `FRED series: N/22` where N > 0
- **Failure signal:** All `FRED X: fetch failed` — means proxy is misconfigured or not set
- **Healthy signal:** `FRED series: 22/22` (or close to it)
- **Validation window:** Next cron run after deploy