### PR TITLE
[codex] fix premium fetch tester-key fallback ordering

### DIFF
--- a/src/services/premium-fetch.ts
+++ b/src/services/premium-fetch.ts
@@ -12,6 +12,7 @@
  */
 let _testProviders: {
   getTesterKey?: () => string;
+  getTesterKeys?: () => string[];
   getClerkToken?: () => Promise<string | null>;
 } | null = null;
 
@@ -19,6 +20,36 @@ export function _setTestProviders(
   p: typeof _testProviders,
 ): void {
   _testProviders = p;
+}
+
+function uniqueNonEmptyKeys(keys: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of keys) {
+    const key = raw?.trim();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    result.push(key);
+  }
+  return result;
+}
+
+async function loadTesterKeys(): Promise<string[]> {
+  try {
+    if (_testProviders?.getTesterKeys) {
+      return uniqueNonEmptyKeys(_testProviders.getTesterKeys());
+    }
+    if (_testProviders?.getTesterKey) {
+      return uniqueNonEmptyKeys([_testProviders.getTesterKey()]);
+    }
+    const { getProWidgetKey, getWidgetAgentKey } = await import('@/services/widget-store');
+    return uniqueNonEmptyKeys([
+      getProWidgetKey(),
+      getWidgetAgentKey(),
+    ]);
+  } catch {
+    return [];
+  }
 }
 
 export async function premiumFetch(
@@ -41,32 +72,22 @@ export async function premiumFetch(
     }
   } catch { /* not available — fall through */ }
 
-  // 2. Tester / widget key from localStorage (wm-pro-key or wm-widget-key).
+  // 2. Tester / widget keys from localStorage.
   // Must run BEFORE Clerk to prevent a free Clerk session from intercepting the
   // request and returning 403 before the tester key is ever checked.
-  // If the gateway returns 401 (key not in WORLDMONITOR_VALID_KEYS), fall through
-  // to Clerk JWT rather than surfacing the error — widget relay keys and gateway
-  // API keys can be different sets.
-  let testerKey: string | null = null;
-  try {
-    if (_testProviders?.getTesterKey) {
-      testerKey = _testProviders.getTesterKey();
-    } else {
-      const { getProWidgetKey, getWidgetAgentKey } = await import('@/services/widget-store');
-      testerKey = getProWidgetKey() || getWidgetAgentKey();
-    }
-  } catch { /* widget-store not available — fall through */ }
-
-  if (testerKey) {
+  // Try wm-pro-key first, then wm-widget-key. A relay-only pro key can be invalid
+  // for the gateway even when the widget key is valid for premium RPC access.
+  const testerKeys = await loadTesterKeys();
+  for (const testerKey of testerKeys) {
     const testerHeaders = new Headers(existing);
     testerHeaders.set('X-WorldMonitor-Key', testerKey);
     const res = await globalThis.fetch(input, { ...init, headers: testerHeaders });
     if (res.status !== 401) return res;
-    // 401 → tester key not in WORLDMONITOR_VALID_KEYS; fall through to Clerk.
+    // 401 → try the next tester key, then fall through to Clerk if none work.
   }
 
-  // 3. Clerk Pro session token (fallback for users without a tester key, or when
-  //    the tester key is not in WORLDMONITOR_VALID_KEYS).
+  // 3. Clerk Pro session token (fallback for users without tester keys, or when
+  //    none of the tester keys are in WORLDMONITOR_VALID_KEYS).
   try {
     let token: string | null = null;
     if (_testProviders?.getClerkToken) {

--- a/tests/premium-fetch.test.mts
+++ b/tests/premium-fetch.test.mts
@@ -5,10 +5,11 @@
  *  - Passthrough when caller already sets auth header
  *  - Tester key: valid key → returns response immediately (no second fetch)
  *  - Tester key: 401 → falls through to Clerk JWT
+ *  - wm-pro-key 401 → retries with wm-widget-key before Clerk
  *  - Tester key: non-401 returned immediately (no fallback)
  *  - Tester key: network error / AbortError propagates to caller (not swallowed)
  *  - No keys, no Clerk → unauthenticated request forwarded
- *  - wm-widget-key / wm-pro-key precedence
+ *  - wm-pro-key / wm-widget-key order is deterministic and deduped
  */
 
 import assert from 'node:assert/strict';
@@ -47,11 +48,12 @@ describe('premiumFetch', () => {
 
   function setup(opts: {
     testerKey?: string;
+    testerKeys?: string[];
     clerkToken?: string | null;
     fetchImpl?: () => Promise<Response>;
   } = {}) {
     _setTestProviders({
-      getTesterKey: () => opts.testerKey ?? '',
+      getTesterKeys: () => opts.testerKeys ?? (opts.testerKey ? [opts.testerKey] : []),
       getClerkToken: async () => opts.clerkToken ?? null,
     });
     fetchMock.mock.resetCalls();
@@ -98,6 +100,23 @@ describe('premiumFetch', () => {
     // Second call: Clerk Bearer sent, no tester key
     assert.equal(sentHeaders(1).get('Authorization'), 'Bearer clerk-jwt-abc');
     assert.equal(sentHeaders(1).get('X-WorldMonitor-Key'), null);
+  });
+
+  it('wm-pro-key 401 retries with wm-widget-key before Clerk', async () => {
+    let n = 0;
+    setup({
+      testerKeys: ['relay-only-pro-key', 'valid-widget-key'],
+      clerkToken: 'clerk-jwt-should-not-be-used',
+      fetchImpl: () => Promise.resolve(fakeRes(n++ === 0 ? 401 : 200)),
+    });
+
+    const res = await premiumFetch(TARGET);
+    assert.equal(res.status, 200);
+    assert.equal(fetchMock.mock.calls.length, 2, 'Expected pro-key attempt then widget-key retry');
+    assert.equal(sentHeaders(0).get('X-WorldMonitor-Key'), 'relay-only-pro-key');
+    assert.equal(sentHeaders(0).get('Authorization'), null);
+    assert.equal(sentHeaders(1).get('X-WorldMonitor-Key'), 'valid-widget-key');
+    assert.equal(sentHeaders(1).get('Authorization'), null);
   });
 
   it('tester key: 403 returned immediately, no Clerk fallback', async () => {


### PR DESCRIPTION
## Summary
- update `premiumFetch(...)` to try all stored tester keys before falling back to Clerk
- preserve the existing `401 -> Clerk` behavior from #2345 once no tester key is accepted
- add a regression test for the `wm-pro-key -> 401 -> wm-widget-key -> 200` flow

## Root Cause
The merged #2345 fix correctly retried with Clerk after a `401`, but `premiumFetch(...)` still chose only a single tester key via `getProWidgetKey() || getWidgetAgentKey()`. In sessions where `wm-pro-key` was present but only `wm-widget-key` was in `WORLDMONITOR_VALID_KEYS`, premium RPC calls never tried the valid widget key. The request path became:

1. `wm-pro-key` -> `401 Invalid API key`
2. Clerk fallback -> `403 Pro subscription required`
3. `wm-widget-key` never attempted

This patch exhausts the tester-key list before using Clerk.

## Impact
- tester sessions with both keys set can now reach premium market RPCs using the gateway-valid key
- relay-only pro keys no longer mask a valid gateway widget key
- network rejections and non-`401` statuses still preserve the current behavior covered by the existing tests

## Validation
- `/Users/eliehabib/Documents/GitHub/worldmonitor/node_modules/.bin/tsx --test tests/premium-fetch.test.mts`
- pre-push hook passed during `git push`:
  - `npm run typecheck`
  - `npm run typecheck:api`
  - `npm run test:data`
  - edge function bundle/import checks
  - markdown + MDX lint
  - version sync check
