### PR TITLE
fix(auth): unify browser tester key

### DIFF
--- a/api/widget-agent.ts
+++ b/api/widget-agent.ts
@@ -4,7 +4,10 @@
  * Auth paths:
  *   1. Clerk JWT (Authorization: Bearer <token>) — validates plan === 'pro',
  *      then injects real server keys and proxies to the Railway relay.
- *   2. Tester keys (X-Widget-Key / X-Pro-Key) — validated directly here
+ *   2. Browser tester key (X-WorldMonitor-Key) — validated against
+ *      WORLDMONITOR_VALID_KEYS so one browser-held key can unlock premium
+ *      testing paths across the app.
+ *   3. Legacy tester keys (X-Widget-Key / X-Pro-Key) — validated directly here
  *      so the relay's WIDGET_AGENT_KEY / PRO_WIDGET_KEY are never exposed
  *      to the browser.
  *
@@ -21,6 +24,12 @@ import { validateBearerToken } from '../server/auth-session';
 const RELAY_BASE = 'https://proxy.worldmonitor.app';
 const WIDGET_AGENT_KEY = process.env.WIDGET_AGENT_KEY ?? '';
 const PRO_WIDGET_KEY = process.env.PRO_WIDGET_KEY ?? '';
+
+function hasValidWorldMonitorKey(key: string): boolean {
+  if (!key) return false;
+  const validKeys = (process.env.WORLDMONITOR_VALID_KEYS ?? '').split(',').map((v) => v.trim()).filter(Boolean);
+  return validKeys.includes(key);
+}
 
 function json(body: unknown, status: number, cors: Record<string, string>): Response {
   return new Response(JSON.stringify(body), {
@@ -46,27 +55,32 @@ export default async function handler(req: Request): Promise<Response> {
   // ── Auth ──────────────────────────────────────────────────────────────────
   let isPro = false;
 
-  const authHeader = req.headers.get('Authorization');
-  if (authHeader?.startsWith('Bearer ')) {
-    // Clerk JWT path (web users with active subscription)
-    const session = await validateBearerToken(authHeader.slice(7));
-    if (!session.valid) {
-      return json({ error: 'Invalid or expired session' }, 401, corsHeaders);
-    }
-    if (session.role !== 'pro') {
-      return json({ error: 'Pro subscription required' }, 403, corsHeaders);
-    }
+  const worldMonitorKey = req.headers.get('X-WorldMonitor-Key') ?? '';
+  if (hasValidWorldMonitorKey(worldMonitorKey)) {
     isPro = true;
   } else {
-    // Tester key path (wm-widget-key / wm-pro-key)
-    const widgetKey = req.headers.get('X-Widget-Key') ?? '';
-    const proKey = req.headers.get('X-Pro-Key') ?? '';
-    const hasWidgetKey = Boolean(WIDGET_AGENT_KEY && widgetKey === WIDGET_AGENT_KEY);
-    const hasProKey = Boolean(PRO_WIDGET_KEY && proKey === PRO_WIDGET_KEY);
-    if (!hasWidgetKey && !hasProKey) {
-      return json({ error: 'Forbidden' }, 403, corsHeaders);
+    const authHeader = req.headers.get('Authorization');
+    if (authHeader?.startsWith('Bearer ')) {
+      // Clerk JWT path (web users with active subscription)
+      const session = await validateBearerToken(authHeader.slice(7));
+      if (!session.valid) {
+        return json({ error: 'Invalid or expired session' }, 401, corsHeaders);
+      }
+      if (session.role !== 'pro') {
+        return json({ error: 'Pro subscription required' }, 403, corsHeaders);
+      }
+      isPro = true;
+    } else {
+      // Legacy tester key path (wm-widget-key / wm-pro-key)
+      const widgetKey = req.headers.get('X-Widget-Key') ?? '';
+      const proKey = req.headers.get('X-Pro-Key') ?? '';
+      const hasWidgetKey = Boolean(WIDGET_AGENT_KEY && widgetKey === WIDGET_AGENT_KEY);
+      const hasProKey = Boolean(PRO_WIDGET_KEY && proKey === PRO_WIDGET_KEY);
+      if (!hasWidgetKey && !hasProKey) {
+        return json({ error: 'Forbidden' }, 403, corsHeaders);
+      }
+      isPro = hasProKey;
     }
-    isPro = hasProKey;
   }
 
   // Mirror the relay P2 fix: allow PRO-only deployments (no basic key, but PRO key present)

--- a/src/components/McpDataPanel.ts
+++ b/src/components/McpDataPanel.ts
@@ -4,7 +4,7 @@ import { t } from '@/services/i18n';
 import { h } from '@/utils/dom-utils';
 import { proxyUrl, widgetAgentUrl } from '@/utils/proxy';
 import { escapeHtml } from '@/utils/sanitize';
-import { isProWidgetEnabled, getWidgetAgentKey, getProWidgetKey } from '@/services/widget-store';
+import { isProWidgetEnabled, getBrowserTesterKey, getWidgetAgentKey, getProWidgetKey } from '@/services/widget-store';
 import { wrapProWidgetHtml } from '@/utils/widget-sanitizer';
 
 type McpResult = {
@@ -175,13 +175,16 @@ export class McpDataPanel extends Panel {
     const timeoutId = setTimeout(() => timeoutController.abort(), 120_000);
 
     try {
+      const testerKey = getBrowserTesterKey();
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'X-Widget-Key': getWidgetAgentKey(),
+        'X-Pro-Key': getProWidgetKey(),
+      };
+      if (testerKey) headers['X-WorldMonitor-Key'] = testerKey;
       const res = await fetch(widgetAgentUrl(), {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Widget-Key': getWidgetAgentKey(),
-          'X-Pro-Key': getProWidgetKey(),
-        },
+        headers,
         body: JSON.stringify({ prompt, mode: 'create', tier: 'pro' }),
         signal: this.destroyController.signal.aborted
           ? this.destroyController.signal

--- a/src/components/WidgetChatModal.ts
+++ b/src/components/WidgetChatModal.ts
@@ -1,5 +1,5 @@
 import type { CustomWidgetSpec } from '@/services/widget-store';
-import { getWidgetAgentKey, getProWidgetKey } from '@/services/widget-store';
+import { getBrowserTesterKey, getWidgetAgentKey, getProWidgetKey } from '@/services/widget-store';
 import { getClerkToken } from '@/services/clerk';
 import { t } from '@/services/i18n';
 import { escapeHtml } from '@/utils/sanitize';
@@ -43,10 +43,12 @@ let abortController: AbortController | null = null;
 let clientTimeout: ReturnType<typeof setTimeout> | null = null;
 
 async function buildWidgetAuthHeaders(isPro: boolean): Promise<Record<string, string>> {
+  const testerKey = getBrowserTesterKey();
   const widgetKey = getWidgetAgentKey();
   const proKey = getProWidgetKey();
-  if (widgetKey || proKey) {
+  if (testerKey || widgetKey || proKey) {
     const headers: Record<string, string> = {};
+    if (testerKey) headers['X-WorldMonitor-Key'] = testerKey;
     if (widgetKey) headers['X-Widget-Key'] = widgetKey;
     if (isPro && proKey) headers['X-Pro-Key'] = proKey;
     return headers;

--- a/src/services/premium-fetch.ts
+++ b/src/services/premium-fetch.ts
@@ -42,11 +42,8 @@ async function loadTesterKeys(): Promise<string[]> {
     if (_testProviders?.getTesterKey) {
       return uniqueNonEmptyKeys([_testProviders.getTesterKey()]);
     }
-    const { getProWidgetKey, getWidgetAgentKey } = await import('@/services/widget-store');
-    return uniqueNonEmptyKeys([
-      getProWidgetKey(),
-      getWidgetAgentKey(),
-    ]);
+    const { getBrowserTesterKeys } = await import('@/services/widget-store');
+    return uniqueNonEmptyKeys(getBrowserTesterKeys());
   } catch {
     return [];
   }

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -764,8 +764,8 @@ export function installWebApiRedirect(): void {
    * existing auth header is present. Priority order:
    *   1. Existing auth headers — left unchanged (API key users keep their flow)
    *   2. WORLDMONITOR_API_KEY from runtime config → X-WorldMonitor-Key
-   *   3. Clerk Pro session → Authorization: Bearer <token>
-   *   4. Tester key (wm-pro-key / wm-widget-key) → X-WorldMonitor-Key
+   *   3. Tester key (wm-pro-key / wm-widget-key) → X-WorldMonitor-Key
+   *   4. Clerk Pro session → Authorization: Bearer <token>
    * Runs on every web deployment (with or without API base redirect).
    * Returns the original init unchanged for non-premium paths (zero overhead).
    */
@@ -787,8 +787,8 @@ export function installWebApiRedirect(): void {
     // Tester key (wm-pro-key / wm-widget-key): forward as API key header.
     // Must run BEFORE Clerk to prevent a free Clerk session from intercepting
     // the request and returning 403 before the tester key is ever tried.
-    const { getProWidgetKey, getWidgetAgentKey } = await import('@/services/widget-store');
-    const testerKey = getProWidgetKey() || getWidgetAgentKey();
+    const { getBrowserTesterKey } = await import('@/services/widget-store');
+    const testerKey = getBrowserTesterKey();
     if (testerKey) {
       headers.set('X-WorldMonitor-Key', testerKey);
       return { ...init, headers };

--- a/src/services/widget-store.ts
+++ b/src/services/widget-store.ts
@@ -146,6 +146,23 @@ export function getWidgetAgentKey(): string {
   return getKey('wm-widget-key');
 }
 
+export function getBrowserTesterKeys(): string[] {
+  const keys = [getProWidgetKey(), getWidgetAgentKey()];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of keys) {
+    const key = raw.trim();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    result.push(key);
+  }
+  return result;
+}
+
+export function getBrowserTesterKey(): string {
+  return getBrowserTesterKeys()[0] ?? '';
+}
+
 export function isProWidgetEnabled(): boolean {
   return !!getKey('wm-pro-key');
 }

--- a/tests/widget-agent-auth.test.mts
+++ b/tests/widget-agent-auth.test.mts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { after, before, beforeEach, describe, it, mock } from 'node:test';
+
+const originalWidgetKey = process.env.WIDGET_AGENT_KEY;
+const originalProKey = process.env.PRO_WIDGET_KEY;
+const originalValidKeys = process.env.WORLDMONITOR_VALID_KEYS;
+
+function fakeRelayResponse(
+  body = 'data: {"type":"done"}\n\n',
+  status = 200,
+  contentType = 'text/event-stream',
+): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': contentType },
+  });
+}
+
+describe('widget-agent unified tester key auth', () => {
+  let handler: (req: Request) => Promise<Response>;
+  let fetchMock: ReturnType<typeof mock.method<typeof globalThis, 'fetch'>>;
+
+  before(async () => {
+    process.env.WIDGET_AGENT_KEY = 'server-widget-key';
+    process.env.PRO_WIDGET_KEY = 'server-pro-key';
+    process.env.WORLDMONITOR_VALID_KEYS = 'browser-test-key';
+
+    fetchMock = mock.method(globalThis, 'fetch', () => Promise.resolve(fakeRelayResponse()));
+    ({ default: handler } = await import('../api/widget-agent.ts'));
+  });
+
+  beforeEach(() => {
+    fetchMock.mock.resetCalls();
+    fetchMock.mock.mockImplementation(() => Promise.resolve(fakeRelayResponse()));
+  });
+
+  after(() => {
+    fetchMock.mock.restore();
+
+    if (originalWidgetKey == null) delete process.env.WIDGET_AGENT_KEY;
+    else process.env.WIDGET_AGENT_KEY = originalWidgetKey;
+
+    if (originalProKey == null) delete process.env.PRO_WIDGET_KEY;
+    else process.env.PRO_WIDGET_KEY = originalProKey;
+
+    if (originalValidKeys == null) delete process.env.WORLDMONITOR_VALID_KEYS;
+    else process.env.WORLDMONITOR_VALID_KEYS = originalValidKeys;
+  });
+
+  it('accepts X-WorldMonitor-Key and upgrades relay request to pro', async () => {
+    const res = await handler(new Request('https://www.worldmonitor.app/api/widget-agent', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://www.worldmonitor.app',
+        'Content-Type': 'application/json',
+        'X-WorldMonitor-Key': 'browser-test-key',
+      },
+      body: JSON.stringify({ prompt: 'Build a widget', mode: 'create', tier: 'basic' }),
+    }));
+
+    assert.equal(res.status, 200);
+    assert.equal(fetchMock.mock.calls.length, 1);
+
+    const call = fetchMock.mock.calls[0];
+    assert.equal(call.arguments[0], 'https://proxy.worldmonitor.app/widget-agent');
+
+    const init = call.arguments[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    assert.equal(headers.get('X-Widget-Key'), 'server-widget-key');
+    assert.equal(headers.get('X-Pro-Key'), 'server-pro-key');
+    assert.equal(headers.get('X-WorldMonitor-Key'), null);
+
+    assert.deepEqual(JSON.parse(String(init.body)), {
+      prompt: 'Build a widget',
+      mode: 'create',
+      tier: 'pro',
+    });
+  });
+
+  it('rejects invalid X-WorldMonitor-Key before relay fetch', async () => {
+    const res = await handler(new Request('https://www.worldmonitor.app/api/widget-agent', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://www.worldmonitor.app',
+        'Content-Type': 'application/json',
+        'X-WorldMonitor-Key': 'wrong-key',
+      },
+      body: JSON.stringify({ prompt: 'Build a widget', mode: 'create', tier: 'pro' }),
+    }));
+
+    assert.equal(res.status, 403);
+    assert.equal(fetchMock.mock.calls.length, 0);
+
+    const body = await res.json() as { error: string };
+    assert.equal(body.error, 'Forbidden');
+  });
+});


### PR DESCRIPTION
## Summary
- unify browser tester-key access around \ with \ as fallback
- let premium fetch and widget-agent both honor \ values from \
- preserve legacy widget/pro headers while adding regression coverage for the new auth path

## Validation
- \
- \
> world-monitor@2.6.5 typecheck
> tsc --noEmit
- pre-push suite passed during \Checking PR status for current branch...
  Branch PR state: no pull requests found for branch "codex/widget-agent-unified-tester-key-test"
Checking scripts/package-lock.json sync...
Running type check...

> world-monitor@2.6.5 typecheck
> tsc --noEmit

Running API type check...

> world-monitor@2.6.5 typecheck:api
> tsc --noEmit -p tsconfig.api.json

Running CJS syntax check...
Running Unicode safety check...
Unicode safety: scanned 882 file(s), no suspicious hidden Unicode found.
Running architectural boundary check...

> world-monitor@2.6.5 lint:boundaries
> node scripts/lint-boundaries.mjs

✓ No architectural boundary violations found.
Running edge function bundle check...
Running unit tests...

> world-monitor@2.6.5 test:data
> tsx --test tests/*.test.mjs tests/*.test.mts
