### PR TITLE
fix(seeds): extend seed-meta TTL on ecb-short-rates all-fail + fix ecb-fx-rates recordCount

### DIFF
--- a/scripts/seed-ecb-fx-rates.mjs
+++ b/scripts/seed-ecb-fx-rates.mjs
@@ -128,6 +128,7 @@ if (process.argv[1]?.endsWith('seed-ecb-fx-rates.mjs')) {
     validateFn: validate,
     ttlSeconds: TTL,
     sourceVersion: 'ecb-data-portal',
+    recordCount: (data) => Object.keys(data?.rates ?? {}).length,
   }).catch(err => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-ecb-short-rates.mjs
+++ b/scripts/seed-ecb-short-rates.mjs
@@ -173,6 +173,8 @@ async function main() {
 
   if (successCount === 0) {
     await releaseLock(`${domain}:${resource}`, runId);
+    // Extend seed-meta TTL so health checks don't see STALE_SEED on transient ECB outages.
+    await extendExistingTtl([`seed-meta:${domain}:${resource}`], TTL).catch(() => {});
     throw new Error(`All ECB series failed: ${failedSeries.join(', ')}`);
   }
 


### PR DESCRIPTION
## Why this PR?

Audit of the 4 new economic seeds merged in the past 24h found two issues:

### 1. `seed-ecb-short-rates`: seed-meta TTL not extended on total failure (P1)

When all 4 ECB series fail, `successCount === 0` releases the lock and throws. The `.catch()` at the top level logs and calls `process.exit(1)` — but neither path extends `seed-meta:economic:ecb-short-rates` TTL. After 3 days of consecutive total failures, health would report `STALE_SEED` even though the seeder is still scheduled and running.

**Fix:** Call `extendExistingTtl(['seed-meta:economic:ecb-short-rates'], TTL)` before throwing, matching the `runSeed()` fetch-failure path pattern. Partial failures (≥1 series succeeds) already write seed-meta correctly via `writeFreshnessMetadata()`.

### 2. `seed-ecb-fx-rates`: `recordCount=0` in seed_complete log (cosmetic)

`runSeed()` resolves `recordCount` via `Array.isArray(data) ? data.length : ...` — the FX data is a `{ rates: {...}, date: '...' }` object, not an array, so it always logged `recordCount=0` despite writing 7 pairs. Added `recordCount: (data) => Object.keys(data?.rates ?? {}).length`.

## Test plan
- [ ] `npm run test:data` passes (2404 tests)
- [ ] No typecheck errors
- [ ] Next Railway run of `seed-ecb-short-rates` logs `recordCount=168` (4 series × ~36-60 obs)
- [ ] Next Railway run of `seed-ecb-fx-rates` logs `recordCount=7`