### PR TITLE
fix(widget-agent): correct Sonnet 4.6 model ID (no date suffix)

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -8429,7 +8429,7 @@ async function handleWidgetAgentRequest(req, res) {
   if (!Array.isArray(conversationHistory)) return safeEnd(res, 400, {}, '');
 
   // Tier-specific settings
-  const model = isPro ? 'claude-sonnet-4-6-20250514' : 'claude-haiku-4-5-20251001';
+  const model = isPro ? 'claude-sonnet-4-6' : 'claude-haiku-4-5-20251001';
   const maxTokens = isPro ? 8192 : 4096;
   const maxTurns = isPro ? 10 : 6;
   const maxHtml = isPro ? WIDGET_PRO_MAX_HTML : WIDGET_MAX_HTML;


### PR DESCRIPTION
## Summary

Widget creation fails with 404 from Anthropic API:

```
[widget-agent] Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-6-20250514"}}
```

Claude 4.x models don't use date suffixes in their IDs. Fix: `claude-sonnet-4-6-20250514` → `claude-sonnet-4-6`.

The Haiku model (`claude-haiku-4-5-20251001`) uses the correct format and is unaffected.