### PR TITLE
fix(llm): strip markdown fences + skip groq in analyze-stock

### DIFF
--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -237,6 +237,9 @@ export async function callLlm(opts: LlmCallOptions): Promise<LlmCallResult | nul
         }
       }
 
+      // Strip markdown code fences (e.g. ```json ... ```) that some models add
+      content = content.replace(/^```(?:\w+)?\s*/m, '').replace(/\s*```\s*$/m, '').trim();
+
       if (validate && !validate(content)) {
         console.warn(`[llm:${providerName}] validate() rejected response, trying next`);
         if (forcedProvider) return null;

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -643,6 +643,7 @@ async function buildAiOverlay(
     temperature: 0.2,
     maxTokens: 500,
     timeoutMs: 20_000,
+    providerOrder: ['openrouter', 'generic'],
     validate: (content) => {
       try {
         const parsed = JSON.parse(content) as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Strip \`\`\`json ... \`\`\` markdown fences from all LLM responses in \`callLlm\` before validation — Gemini 2.5 Flash via OpenRouter wraps JSON in code fences, causing \`validate()\` to fail on every request and silently fall back to the rules-based overlay
- Add \`providerOrder: ['openrouter', 'generic']\` to \`analyze-stock\` \`callLlm\` call to skip Groq entirely (consistently 429 rate-limited) and go direct to OpenRouter

## Root cause (from Vercel log analysis)
Every \`analyze-stock\` call was logging:
\`[llm:groq] HTTP 429\` → \`[llm:openrouter] validate() rejected response, trying next\`

Groq was always 429. OpenRouter/Gemini 2.5 Flash was returning valid content but wrapped in markdown fences, failing \`JSON.parse()\` in the validate function. Result: \`callLlm\` returned null on every call → rules-based fallback used instead of real LLM analysis.

## Test plan
- [ ] Deploy to Vercel preview
- [ ] Trigger \`analyze-stock\` for AAPL — response time should drop from ~6-8s to ~2-3s
- [ ] Verify \`fallback: false\` in response (real LLM output, not rules-based)
- [ ] Verify no \`validate() rejected\` warnings in Vercel function logs