### PR TITLE
fix(health): usniFleet empty → WARN not CRIT

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -233,6 +233,7 @@ const ON_DEMAND_KEYS = new Set([
 const EMPTY_DATA_OK_KEYS = new Set([
   'notamClosures', 'faaDelays', 'gpsjam', 'positiveGeoEvents', 'weatherAlerts',
   'earningsCalendar', 'econCalendar', 'cotPositioning',
+  'usniFleet', // usniFleetStale covers the fallback; relay outages → WARN not CRIT
 ]);
 
 // Cascade groups: if any key in the group has data, all empty siblings are OK.


### PR DESCRIPTION
## Problem

When the ais-relay USNI loop stalls, `usni-fleet:sebuf:v1` goes empty → `usniFleet` CRIT → `"status":"DEGRADED"` in response body → UptimeRobot treats site as down.

`usniFleetStale` already covers the frontend fallback, so the user impact is zero.

## Fix

Add `usniFleet` to `EMPTY_DATA_OK_KEYS` — empty becomes `STALE_SEED` (WARN) instead of `EMPTY` (CRIT). With 0 crits, overall stays `WARNING` not `DEGRADED`, HTTP 200, UptimeRobot stays green.