### PR TITLE
fix(analyze-stock): catch cachedFetchJson timeout to prevent 500s

### DIFF
--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -832,29 +832,34 @@ export async function analyzeStock(
   const nameSuffix = name !== symbol ? `:${name.replace(/[^a-zA-Z0-9]/g, '').slice(0, 30).toLowerCase()}` : '';
   const cacheKey = `market:analyze-stock:v1:${symbol}:${includeNews ? 'news' : 'no-news'}${nameSuffix}`;
 
-  const cached = await cachedFetchJson<AnalyzeStockResponse>(cacheKey, CACHE_TTL_SECONDS, async () => {
-    const history = await fetchYahooHistory(symbol);
-    if (!history) return null;
+  let cached: AnalyzeStockResponse | null = null;
+  try {
+    cached = await cachedFetchJson<AnalyzeStockResponse>(cacheKey, CACHE_TTL_SECONDS, async () => {
+      const history = await fetchYahooHistory(symbol);
+      if (!history) return null;
 
-    const technical = buildTechnicalSnapshot(history.candles);
-    technical.currency = history.currency || 'USD';
-    const headlines = includeNews ? (await searchRecentStockHeadlines(symbol, name, NEWS_LIMIT)).headlines : [];
-    const overlay = await buildAiOverlay(symbol, name, technical, headlines);
-    const analysisAt = history.candles[history.candles.length - 1]?.timestamp || Date.now();
-    const response = buildAnalysisResponse({
-      symbol,
-      name,
-      currency: history.currency || 'USD',
-      technical,
-      headlines,
-      overlay,
-      includeNews,
-      analysisAt,
-      generatedAt: new Date().toISOString(),
+      const technical = buildTechnicalSnapshot(history.candles);
+      technical.currency = history.currency || 'USD';
+      const headlines = includeNews ? (await searchRecentStockHeadlines(symbol, name, NEWS_LIMIT)).headlines : [];
+      const overlay = await buildAiOverlay(symbol, name, technical, headlines);
+      const analysisAt = history.candles[history.candles.length - 1]?.timestamp || Date.now();
+      const response = buildAnalysisResponse({
+        symbol,
+        name,
+        currency: history.currency || 'USD',
+        technical,
+        headlines,
+        overlay,
+        includeNews,
+        analysisAt,
+        generatedAt: new Date().toISOString(),
+      });
+      await storeStockAnalysisSnapshot(response, includeNews);
+      return response;
     });
-    await storeStockAnalysisSnapshot(response, includeNews);
-    return response;
-  });
+  } catch {
+    // fetcher timed out or threw — fall through to empty response
+  }
 
   if (cached) return cached;
 


### PR DESCRIPTION
## Why this PR?

`analyze-stock` was returning random 500s. Log evidence:
```
[redis] cachedFetchJson fetcher failed for "market:analyze-stock:v1:NVDA:news:nvidia": The operation was aborted due to timeout
[error-mapper] Unhandled error: The operation was aborted due to timeout
```

## Root cause

`cachedFetchJson` (in `server/_shared/redis.ts`) catches fetcher errors, logs them, and **re-throws** (`throw err` on line 171). The outer call in `analyze-stock.ts` was not wrapped in try-catch, so any `AbortSignal.timeout()` expiry in the chain (Yahoo history fetch, news search, or LLM call) propagated up as an unhandled error and became a 500.

## Fix

Wrap the `cachedFetchJson` call in `analyze-stock.ts` in try-catch. A timeout now falls through to `buildEmptyAnalysisResponse` (200 with empty data) instead of crashing.

## Test plan

- [ ] Deploy and confirm no more 500s on analyze-stock in Vercel logs during timeout windows
- [ ] `tsc --noEmit` passes