### PR TITLE
fix(settings-window.ts): escape user-controlled data in template literal

### DIFF
--- a/src/settings-window.ts
+++ b/src/settings-window.ts
@@ -48,9 +48,9 @@ export function initSettingsWindow(): void {
     const panelHtml = panelEntries
       .map(
         ([key, panel]) => `
-        <div class="panel-toggle-item ${panel.enabled ? 'active' : ''}" data-panel="${key}">
+        <div class="panel-toggle-item ${panel.enabled ? 'active' : ''}" data-panel="${escapeHtml(key)}">
           <div class="panel-toggle-checkbox">${panel.enabled ? '✓' : ''}</div>
-          <span class="panel-toggle-label">${getLocalizedPanelName(key, panel.name)}</span>
+          <span class="panel-toggle-label">${escapeHtml(getLocalizedPanelName(key, panel.name))}</span>
         </div>
       `
       )


### PR DESCRIPTION
## Summary

Fixes a DOM-based XSS vulnerability in the settings window where `escapeHtml` was imported but not applied to user-controlled values interpolated into an HTML template literal.

## Type of change

- [x] Bug fix

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [x] Config / Settings
- [ ] Other: <!-- specify -->

## Bug description

`escapeHtml` was imported at line 11 of `settings-window.ts` but left unused. The `key` (used in `data-panel="${key}"`) and the result of `getLocalizedPanelName(key, panel.name)` (which falls back to `panel.name`) were both interpolated without sanitization.

## Fix

Applied `escapeHtml()` to both values before interpolation:
- `data-panel="${escapeHtml(key)}"` — sanitizes the panel key  
- `escapeHtml(getLocalizedPanelName(key, panel.name))` — sanitizes the display name

## Checklist

- [x] Tested on worldmonitor.app variant
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [x] No API keys or secrets committed

---

Fixes #2022

🤖 Generated with [Claude Code](https://claude.com/claude-code)