### PR TITLE
fix(mcp): truncate long tool descriptions; strip null defaults from args

### DIFF
--- a/src/components/McpConnectModal.ts
+++ b/src/components/McpConnectModal.ts
@@ -346,9 +346,12 @@ export function openMcpConnectModal(options: McpConnectOptions): void {
     for (const tool of list) {
       const item = document.createElement('div');
       item.className = 'mcp-tool-item';
+      const shortDesc = tool.description
+        ? (tool.description.length > 100 ? tool.description.slice(0, 97) + '…' : tool.description)
+        : '';
       item.innerHTML = `
         <span class="mcp-tool-name">${escapeHtml(tool.name)}</span>
-        ${tool.description ? `<span class="mcp-tool-desc">${escapeHtml(tool.description)}</span>` : ''}
+        ${shortDesc ? `<span class="mcp-tool-desc">${escapeHtml(shortDesc)}</span>` : ''}
       `;
       item.addEventListener('click', () => {
         toolsList.querySelectorAll('.mcp-tool-item').forEach(el => el.classList.remove('selected'));
@@ -360,9 +363,10 @@ export function openMcpConnectModal(options: McpConnectOptions): void {
           const defaults: Record<string, unknown> = {};
           for (const [k, v] of Object.entries(schema.properties)) {
             const prop = v as { default?: unknown };
-            if (prop.default !== undefined) defaults[k] = prop.default;
+            // Skip null defaults — they add noise without value
+            if (prop.default !== undefined && prop.default !== null) defaults[k] = prop.default;
           }
-          argsInput.value = JSON.stringify(defaults, null, 2) || '{}';
+          argsInput.value = Object.keys(defaults).length ? JSON.stringify(defaults, null, 2) : '{}';
         } else {
           argsInput.value = '{}';
         }

--- a/src/services/mcp-store.ts
+++ b/src/services/mcp-store.ts
@@ -239,8 +239,8 @@ export const MCP_PRESETS: McpPreset[] = [
     serverUrl: 'https://api.datacommons.org/mcp',
     authNote: 'Requires x-api-key: <API_KEY> (free at console.cloud.google.com)',
     apiKeyHeader: 'x-api-key: {key}',
-    defaultTool: 'query',
-    defaultArgs: { q: 'What is the GDP of France?' },
+    defaultTool: 'search_indicators',
+    defaultArgs: { query: 'GDP per capita' },
     defaultTitle: 'Data Commons',
   },
 ];


### PR DESCRIPTION
## Summary

- **Tool description overflow**: descriptions are now capped at 100 chars in the SELECT A TOOL list — `get_observations` was rendering 1000+ chars of markdown in a tiny box, making tool selection unusable
- **Noisy null args**: args pre-fill now skips `null` defaults from the schema — the JSON textarea starts with only meaningful values instead of `"field": null` for every optional parameter
- **Data Commons preset fix**: corrects default tool from nonexistent `query` to `search_indicators` (the actual first tool to call)

## Test plan

- [ ] Connect to DataCommons MCP — tool list shows short readable descriptions, not walls of text
- [ ] Clicking `get_observations` pre-fills args with only non-null defaults (`date: "latest"` etc), not the 10+ null fields
- [ ] Clicking `search_indicators` pre-fills args cleanly
- [ ] Other presets with normal-length descriptions are unaffected