### PR TITLE
fix(mcp): add PRO badge to CONNECT MCP tile

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1190,8 +1190,12 @@ export class PanelLayoutManager implements AppModule {
     const mcpLabel = document.createElement('span');
     mcpLabel.className = 'add-panel-block-label';
     mcpLabel.textContent = t('mcp.connectPanel');
+    const mcpBadge = document.createElement('span');
+    mcpBadge.className = 'widget-pro-badge';
+    mcpBadge.textContent = t('widgets.proBadge');
     mcpBlock.appendChild(mcpIcon);
     mcpBlock.appendChild(mcpLabel);
+    mcpBlock.appendChild(mcpBadge);
     mcpBlock.addEventListener('click', () => {
       openMcpConnectModal({
         onComplete: (spec) => this.addMcpPanel(spec),


### PR DESCRIPTION
## Summary

The CONNECT MCP tile was missing the PRO badge that the CREATE INTERACTIVE WIDGET tile has, even though both are hidden for non-pro users via the same `applyProBlockGating` logic. Adds the `widget-pro-badge` span (reusing the existing CSS class) to make the PRO requirement visible.

## Test plan

- [ ] As a PRO user: both tiles show the yellow PRO badge
- [ ] As a free user: both tiles remain hidden (no regression)