### PR TITLE
fix(panels): wire DiseaseOutbreaksPanel and SocialVelocityPanel into layout

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -65,6 +65,8 @@ import {
   EarningsCalendarPanel,
   EconomicCalendarPanel,
   CotPositioningPanel,
+  DiseaseOutbreaksPanel,
+  SocialVelocityPanel,
 } from '@/components';
 import { SatelliteFiresPanel } from '@/components/SatelliteFiresPanel';
 import { focusInvestmentOnMap } from '@/services/investments-focus';
@@ -801,6 +803,9 @@ export class PanelLayoutManager implements AppModule {
       });
       this.ctx.panels['ucdp-events'] = ucdpEventsPanel;
     }
+
+    this.createPanel('disease-outbreaks', () => new DiseaseOutbreaksPanel());
+    this.createPanel('social-velocity', () => new SocialVelocityPanel());
 
     this.lazyPanel('displacement', () =>
       import('@/components/DisplacementPanel').then(m => {

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -74,6 +74,8 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'etf-flows': { name: 'BTC ETF Tracker', enabled: true, priority: 2 },
   stablecoins: { name: 'Stablecoins', enabled: true, priority: 2 },
   'ucdp-events': { name: 'UCDP Conflict Events', enabled: true, priority: 2 },
+  'disease-outbreaks': { name: 'Disease Outbreaks', enabled: true, priority: 2 },
+  'social-velocity': { name: 'Social Velocity', enabled: true, priority: 2 },
   giving: { name: 'Global Giving', enabled: false, priority: 2 },
   displacement: { name: 'UNHCR Displacement', enabled: true, priority: 2 },
   climate: { name: 'Climate Anomalies', enabled: true, priority: 2 },


### PR DESCRIPTION
## Root cause
Both panels were added as components in #2383 but never wired into the app:

- `panels.ts` was missing `'disease-outbreaks'` and `'social-velocity'` entries in `FULL_PANELS` — panels never appeared in the panel grid
- `panel-layout.ts` was missing `createPanel()` calls and imports — components were never instantiated, so `data-loader`'s `this.ctx.panels['disease-outbreaks']` lookups always returned `undefined`

The map layer for disease outbreaks worked because it uses `MapContainer.setDiseaseOutbreaks()` directly (not the panel instance), which is why dots appeared on the map but the panel feed was invisible.

## Changes
- `src/config/panels.ts`: added `'disease-outbreaks'` and `'social-velocity'` to `FULL_PANELS`
- `src/app/panel-layout.ts`: added imports + `createPanel()` calls adjacent to `ucdp-events`

## Test plan
- [ ] Disease Outbreaks panel appears in the panel list and renders outbreak feed
- [ ] Social Velocity panel appears in the panel list and renders Reddit posts
- [ ] `npm run typecheck` passes