### PR TITLE
fix(commands): add missing CMD+K entries for 9 panels

### DIFF
--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -168,7 +168,7 @@ export const COMMANDS: Command[] = [
   { id: 'panel:economic-calendar', keywords: ['economic calendar', 'macro events', 'nonfarm payrolls', 'gdp release', 'fomc'], label: 'Panel: Economic Calendar', icon: '\u{1F4C6}', category: 'panels' },
   { id: 'panel:cot-positioning', keywords: ['cot', 'cot positioning', 'commitments of traders', 'futures positioning', 'cftc'], label: 'Panel: CFTC COT Positioning', icon: '\u{1F4CA}', category: 'panels' },
   { id: 'panel:macro-tiles', keywords: ['macro tiles', 'macro indicators', 'macro overview'], label: 'Panel: Macro Indicators', icon: '\u{1F9E9}', category: 'panels' },
-  { id: 'panel:defense-patents', keywords: ['defense patents', 'r&d signal', 'military research', 'defense r&d'], label: "Panel: R\u0026D Signal", icon: '\u{1F9EA}', category: 'panels' },
+  { id: 'panel:defense-patents', keywords: ['defense patents', 'r&d signal', 'military research', 'defense r&d'], label: 'Panel: R&D Signal', icon: '\u{1F9EA}', category: 'panels' },
   { id: 'panel:disease-outbreaks', keywords: ['disease outbreaks', 'outbreaks', 'who alerts', 'epidemic', 'health alerts', 'promed'], label: 'Panel: Disease Outbreaks', icon: '\u{1F9A0}', category: 'panels' },
   { id: 'panel:social-velocity', keywords: ['social velocity', 'reddit trending', 'social signals', 'viral', 'trending posts'], label: 'Panel: Social Velocity', icon: '\u{1F4F1}', category: 'panels' },
 


### PR DESCRIPTION
## Summary
9 panels were invisible in CMD+K search because they had no entry in `commands.ts`:

**Existing panels (visible in screenshot):**
| Panel | Key |
|-------|-----|
| Financial Stress Indicator | `fsi` |
| Yield Curve & Rates | `yield-curve` |
| Earnings Calendar | `earnings-calendar` |
| Economic Calendar | `economic-calendar` |
| CFTC COT Positioning | `cot-positioning` |
| Macro Indicators | `macro-tiles` |
| R&D Signal | `defense-patents` |

**New panels (added in #2383/#2389):**
| Panel | Key |
|-------|-----|
| Disease Outbreaks | `disease-outbreaks` |
| Social Velocity | `social-velocity` |

## Test plan
- [ ] CMD+K → type "financial stress" → `Panel: Financial Stress Indicator` appears
- [ ] CMD+K → type "yield curve" → `Panel: Yield Curve & Rates` appears
- [ ] CMD+K → type "earnings" → `Panel: Earnings Calendar` appears
- [ ] CMD+K → type "disease" → `Panel: Disease Outbreaks` appears
- [ ] CMD+K → type "reddit" → `Panel: Social Velocity` appears