### PR TITLE
feat(panels): wire GeoHubsPanel, TechHubsPanel, and RegulationPanel

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -186,6 +186,10 @@ import { fetchMarketImplications } from '@/services/market-implications';
 import { fetchDiseaseOutbreaks } from '@/services/disease-outbreaks';
 import { fetchSocialVelocity } from '@/services/social-velocity';
 import { fetchShippingStress } from '@/services/supply-chain';
+import { getTopActiveGeoHubs } from '@/services/geo-activity';
+import { getTopActiveHubs } from '@/services/tech-activity';
+import type { GeoHubsPanel } from '@/components/GeoHubsPanel';
+import type { TechHubsPanel } from '@/components/TechHubsPanel';
 
 const PROTO_TO_CLIENT_LEVEL: Record<ProtoThreatLevel, ClientThreatLevel> = {
   THREAT_LEVEL_UNSPECIFIED: 'info',
@@ -1121,6 +1125,11 @@ export class DataLoaderManager implements AppModule {
 
       const insightsPanel = this.ctx.panels['insights'] as InsightsPanel | undefined;
       insightsPanel?.updateInsights(this.ctx.latestClusters);
+
+      (this.ctx.panels['geo-hubs'] as GeoHubsPanel | undefined)
+        ?.setActivities(getTopActiveGeoHubs(this.ctx.latestClusters));
+      (this.ctx.panels['tech-hubs'] as TechHubsPanel | undefined)
+        ?.setActivities(getTopActiveHubs(this.ctx.latestClusters));
 
       const geoLocated = this.ctx.latestClusters
         .filter((c): c is typeof c & { lat: number; lon: number } => c.lat != null && c.lon != null)
@@ -2765,6 +2774,10 @@ export class DataLoaderManager implements AppModule {
         ingestNewsForCII(this.ctx.latestClusters);
         dataFreshness.recordUpdate('gdelt', this.ctx.latestClusters.length);
         this.refreshCiiAndBrief();
+        (this.ctx.panels['geo-hubs'] as GeoHubsPanel | undefined)
+          ?.setActivities(getTopActiveGeoHubs(this.ctx.latestClusters));
+        (this.ctx.panels['tech-hubs'] as TechHubsPanel | undefined)
+          ?.setActivities(getTopActiveHubs(this.ctx.latestClusters));
       }
 
       const signals = await analysisWorker.analyzeCorrelations(

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -953,6 +953,26 @@ export class PanelLayoutManager implements AppModule {
       import('@/components/CrossSourceSignalsPanel').then(m => new m.CrossSourceSignalsPanel()),
     );
 
+    this.lazyPanel('geo-hubs', () =>
+      import('@/components/GeoHubsPanel').then(m => {
+        const p = new m.GeoHubsPanel();
+        p.setOnHubClick((hub) => { this.ctx.map?.setCenter(hub.lat, hub.lon, 4); });
+        return p;
+      }),
+    );
+
+    this.lazyPanel('tech-hubs', () =>
+      import('@/components/TechHubsPanel').then(m => {
+        const p = new m.TechHubsPanel();
+        p.setOnHubClick((hub) => { this.ctx.map?.setCenter(hub.lat, hub.lon, 4); });
+        return p;
+      }),
+    );
+
+    this.lazyPanel('ai-regulation', () =>
+      import('@/components/RegulationPanel').then(m => new m.RegulationPanel('ai-regulation')),
+    );
+
     this.createPanel('macro-signals', () => new MacroSignalsPanel());
     this.createPanel('fear-greed', () => new FearGreedPanel());
     this.createPanel('macro-tiles', () => new MacroTilesPanel());

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -94,6 +94,8 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'cross-source-signals': { name: 'Cross-Source Signals', enabled: true, priority: 2 },
   'market-implications': { name: 'AI Market Implications', enabled: true, priority: 1, premium: 'locked' as const },
   'deduction': { name: 'Deduct Situation', enabled: true, priority: 1, premium: 'locked' as const },
+  'geo-hubs': { name: 'Geopolitical Hubs', enabled: false, priority: 2 },
+  'tech-hubs': { name: 'Hot Tech Hubs', enabled: false, priority: 2 },
 };
 
 const FULL_MAP_LAYERS: MapLayers = {
@@ -238,7 +240,7 @@ const TECH_PANELS: Record<string, PanelConfig> = {
   accelerators: { name: 'Accelerators & Demo Days', enabled: true, priority: 1 },
   security: { name: 'Cybersecurity', enabled: true, priority: 1 },
   policy: { name: 'AI Policy & Regulation', enabled: true, priority: 1 },
-  regulation: { name: 'AI Regulation Dashboard', enabled: true, priority: 1 },
+  regulation: { name: 'AI Regulation News', enabled: true, priority: 1 },
   layoffs: { name: 'Layoffs Tracker', enabled: true, priority: 1 },
   markets: { name: 'Tech Stocks', enabled: true, priority: 2 },
   finance: { name: 'Financial News', enabled: true, priority: 2 },
@@ -262,6 +264,8 @@ const TECH_PANELS: Record<string, PanelConfig> = {
   'airline-intel': { name: 'Airline Intelligence', enabled: true, priority: 2 },
   'world-clock': { name: 'World Clock', enabled: true, priority: 2 },
   monitors: { name: 'My Monitors', enabled: true, priority: 2 },
+  'tech-hubs': { name: 'Hot Tech Hubs', enabled: false, priority: 2 },
+  'ai-regulation': { name: 'AI Regulation Dashboard', enabled: false, priority: 2 },
 };
 
 const TECH_MAP_LAYERS: MapLayers = {


### PR DESCRIPTION
## Why this PR

Three panels were fully implemented (component, i18n translations, service functions) but never registered or wired up, making them completely unreachable.

**Dead panels found:**
- `GeoHubsPanel` (`geo-hubs`, "Geopolitical Hubs") — `setActivities()` ready, `getTopActiveGeoHubs()` in `geo-activity.ts` — never called
- `TechHubsPanel` (`tech-hubs`, "Hot Tech Hubs") — `setActivities()` ready, `getTopActiveHubs()` in `tech-activity.ts` — never called
- `RegulationPanel` (`ai-regulation`, "AI Regulation Dashboard") — static data from 486-line `AI_REGULATIONS` config — never instantiated

## Changes

**`src/config/panels.ts`**
- `FULL_PANELS`: add `geo-hubs` and `tech-hubs` (disabled by default, priority 2)
- `TECH_PANELS`: add `tech-hubs` and `ai-regulation` (disabled by default, priority 2)

**`src/app/panel-layout.ts`**
- `lazyPanel('geo-hubs', ...)` with `setOnHubClick` map-center handler
- `lazyPanel('tech-hubs', ...)` with `setOnHubClick` map-center handler
- `lazyPanel('ai-regulation', ...)` — static, no data wiring needed

**`src/app/data-loader.ts`**
- After each `latestClusters` assignment (main load path + `runCorrelationAnalysis` fallback path), call `getTopActiveGeoHubs()` and `getTopActiveHubs()` and push to the panels

## Test plan
- All 2425 tests pass
- TypeScript clean (both `tsc` and `tsc -p tsconfig.api.json`)
- `panel-config-guardrails.test.mjs` passes (no unguarded panel assignments)

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: panels are disabled by default (priority 2, `enabled: false`) and only activate when user toggles them on. No new network requests — GeoHubs/TechHubs derive from existing `latestClusters`; RegulationPanel is purely static.