### PR TITLE
fix(deduction): correct error message + add LLM keys to Vercel edge

### DIFF
--- a/src/components/DeductionPanel.ts
+++ b/src/components/DeductionPanel.ts
@@ -147,7 +147,9 @@ export class DeductionPanel extends Panel {
                 );
                 this.resultContainer.appendChild(meta);
             } else {
-                this.resultContainer.textContent = 'No analysis available for this query.';
+                this.resultContainer.textContent = resp.provider === 'error'
+                    ? 'AI analysis temporarily unavailable. Please try again in a moment.'
+                    : 'No analysis available for this query.';
             }
         } catch (err) {
             if (!this.element?.isConnected) return;


### PR DESCRIPTION
## Why this PR?

The Deduct Situation panel always returned \"No analysis available for this query.\" for every submission. Root cause: `deductSituation` calls `callLlm()` directly from the Vercel edge function, but `GROQ_API_KEY`/`OPENROUTER_API_KEY` were only set on Railway (for cron jobs), not on Vercel. `callLlm()` skipped all providers and returned `null`, which the handler converted to `{ analysis: '', provider: 'error' }` — but the panel treated it identically to a genuinely empty analysis.

## Changes

**Code fix** (`DeductionPanel.ts`): Check `resp.provider === 'error'` before showing the no-analysis message. Now shows \"AI analysis temporarily unavailable. Please try again in a moment.\" for infrastructure failures vs \"No analysis available for this query.\" for legitimately empty results.

**Infrastructure** (done outside PR): Added `GROQ_API_KEY` and `OPENROUTER_API_KEY` to Vercel production env so `callLlm()` has live providers on the edge. No hardcoding — the existing `callLlm()` chain (`ollama → groq → openrouter → generic`) is unchanged.

## Post-Deploy Monitoring & Validation

- **Validate**: Submit a query in the Deduct Situation panel on prod. Should return an AI analysis (not the error message).
- **Logs**: Vercel function logs for `intelligence/v1/deduct` — look for successful LLM responses vs `provider: error`.
- **Failure signal**: If still returning error, check Vercel env vars (`GROQ_API_KEY`, `OPENROUTER_API_KEY`) are deployed to the current deployment (redeploy may be needed to pick up new vars).