### PR TITLE
feat(deduction): redesign UI with section cards and add to CMD+K palette

### DIFF
--- a/src/components/DeductionPanel.ts
+++ b/src/components/DeductionPanel.ts
@@ -44,7 +44,7 @@ export class DeductionPanel extends Panel {
         this.geoInputEl = h('input', {
             className: 'deduction-geo-input',
             type: 'text',
-            placeholder: 'Optional geographic or situation context...',
+            placeholder: 'Geographic or situation context (optional)...',
         }) as HTMLInputElement;
 
         this.submitBtn = h('button', {
@@ -52,10 +52,14 @@ export class DeductionPanel extends Panel {
             type: 'submit',
         }, 'Analyze') as HTMLButtonElement;
 
+        const formRow = h('div', { className: 'deduction-form-row' },
+            this.geoInputEl,
+            this.submitBtn,
+        );
+
         this.formEl = h('form', { className: 'deduction-form' },
             this.inputEl,
-            this.geoInputEl,
-            this.submitBtn
+            formRow,
         ) as HTMLFormElement;
 
         this.formEl.addEventListener('submit', this.handleSubmit.bind(this));
@@ -104,6 +108,109 @@ export class DeductionPanel extends Panel {
         super.destroy();
     }
 
+    /** Post-process parsed markdown HTML into visually structured sections. */
+    private reformatResult(container: HTMLElement): void {
+        const SECTIONS = [
+            { re: /^bottom\s+line/i,       cls: 'ds-verdict',   label: 'Bottom Line' },
+            { re: /^what\s+we\s+know/i,    cls: 'ds-evidence',  label: 'What We Know' },
+            { re: /^most\s+likely\s+path/i, cls: 'ds-primary',  label: 'Most Likely Path' },
+            { re: /^alternative\s+path/i,  cls: 'ds-alt',       label: 'Alternative Paths' },
+            { re: /^confidence/i,          cls: 'ds-confidence', label: 'Confidence' },
+        ] as const;
+
+        // Collect top-level children; group by section boundary
+        const nodes = Array.from(container.childNodes) as HTMLElement[];
+        const groups: { cls: string; label: string; nodes: HTMLElement[] }[] = [];
+        let current: { cls: string; label: string; nodes: HTMLElement[] } | null = null;
+
+        for (const node of nodes) {
+            const strongText = (node.querySelector?.('strong')?.textContent ?? node.textContent ?? '').trim();
+            const match = SECTIONS.find(s => s.re.test(strongText));
+            if (match) {
+                current = { cls: match.cls, label: match.label, nodes: [] };
+                groups.push(current);
+            }
+            if (current) current.nodes.push(node);
+            else if (!match) groups.push({ cls: '', label: '', nodes: [node] }); // unsectioned
+        }
+
+        if (groups.every(g => !g.cls)) return; // nothing to restructure
+
+        container.replaceChildren();
+        for (const group of groups) {
+            if (!group.cls) {
+                group.nodes.forEach(n => container.appendChild(n));
+                continue;
+            }
+
+            const section = document.createElement('div');
+            section.className = group.cls;
+
+            // Inject section label (remove the <strong> header from content)
+            const labelEl = document.createElement('div');
+            labelEl.className = 'ds-section-label';
+
+            // For primary path, extract probability from heading text
+            if (group.cls === 'ds-primary') {
+                const headingNode = group.nodes[0];
+                const fullText = headingNode?.textContent ?? '';
+                const probMatch = /(\d{1,3})\s*%/.exec(fullText);
+                const timeMatch = /\(([^)]+)\)/.exec(fullText);
+                labelEl.textContent = group.label;
+                if (timeMatch) {
+                    const timeSpan = document.createElement('span');
+                    timeSpan.style.cssText = 'font-size:10px;color:var(--text-dim);font-weight:400;text-transform:none;letter-spacing:0';
+                    timeSpan.textContent = timeMatch[1] ?? '';
+                    labelEl.appendChild(timeSpan);
+                }
+                if (probMatch) {
+                    const badge = document.createElement('span');
+                    badge.className = 'ds-prob-badge';
+                    badge.textContent = `${probMatch[1]}%`;
+                    labelEl.appendChild(badge);
+                }
+            } else {
+                labelEl.textContent = group.label;
+            }
+            section.appendChild(labelEl);
+
+            // Add body nodes (skip first node which was the header paragraph)
+            const bodyNodes = group.nodes.slice(1);
+            if (bodyNodes.length === 0 && group.nodes[0]) {
+                // Inline header: strip the strong header, keep the rest as body
+                const clone = group.nodes[0].cloneNode(true) as HTMLElement;
+                clone.querySelector('strong')?.remove();
+                const bodyDiv = document.createElement('div');
+                bodyDiv.className = group.cls === 'ds-primary' ? 'ds-primary-body' : '';
+                bodyDiv.innerHTML = clone.innerHTML.replace(/^[\s:–—-]+/, '');
+                section.appendChild(bodyDiv);
+            } else {
+                // For alt paths: inject probability badges into li items
+                if (group.cls === 'ds-alt') {
+                    bodyNodes.forEach(n => {
+                        if (n.tagName === 'UL') {
+                            n.querySelectorAll('li').forEach(li => {
+                                const probMatch = /^(\d{1,3})\s*%\s*[:\s]?(.*)/.exec(li.textContent ?? '');
+                                if (probMatch) {
+                                    const badge = document.createElement('span');
+                                    badge.className = 'ds-alt-prob';
+                                    badge.textContent = `${probMatch[1]}%`;
+                                    li.textContent = (probMatch[2] ?? '').replace(/^\s*[:\s]+/, '').trim();
+                                    li.insertBefore(badge, li.firstChild);
+                                }
+                            });
+                        }
+                        section.appendChild(n);
+                    });
+                } else {
+                    bodyNodes.forEach(n => section.appendChild(n));
+                }
+            }
+
+            container.appendChild(section);
+        }
+    }
+
     private async handleSubmit(e: Event) {
         e.preventDefault();
         if (this.isSubmitting) return;
@@ -126,7 +233,7 @@ export class DeductionPanel extends Panel {
         this.submitBtn.disabled = true;
 
         this.resultContainer.className = 'deduction-result loading';
-        this.resultContainer.textContent = 'Analyzing timeline and impact...';
+        this.resultContainer.innerHTML = '<div class="deduction-loading-dots"><span></span><span></span><span></span></div>Analyzing…';
 
         try {
             const resp = await client.deductSituation({
@@ -140,10 +247,12 @@ export class DeductionPanel extends Panel {
             if (resp.analysis) {
                 const parsed = await marked.parse(resp.analysis);
                 if (!this.element?.isConnected) return;
-                this.resultContainer.innerHTML = DOMPurify.sanitize(parsed);
+                const safe = DOMPurify.sanitize(parsed);
+                this.resultContainer.innerHTML = safe;
+                this.reformatResult(this.resultContainer);
 
-                const meta = h('div', { style: 'margin-top: 12px; font-size: 0.75em; color: #888;' },
-                    `Generated by ${resp.provider || 'AI'}${resp.model ? ` (${resp.model})` : ''}`
+                const meta = h('div', { className: 'deduction-meta' },
+                    `${resp.provider || 'AI'}${resp.model ? ` · ${resp.model}` : ''}`
                 );
                 this.resultContainer.appendChild(meta);
             } else {

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -133,6 +133,7 @@ export const COMMANDS: Command[] = [
   { id: 'panel:insights', keywords: ['insights', 'ai insights', 'analysis'], label: 'Panel: AI Insights', icon: '\u{1F4A1}', category: 'panels' },
   { id: 'panel:strategic-posture', keywords: ['strategic posture', 'ai posture', 'posture assessment'], label: 'Panel: AI Strategic Posture', icon: '\u{1F3AF}', category: 'panels' },
   { id: 'panel:forecast', keywords: ['forecast', 'ai forecast', 'predictions ai'], label: 'Panel: AI Forecasts', icon: '\u{1F52E}', category: 'panels' },
+  { id: 'panel:deduction', keywords: ['deduct', 'deduction', 'ai deduction', 'situation analysis', 'scenario analysis'], label: 'Panel: AI Deduction', icon: '\u{1F9E0}', category: 'panels' },
   { id: 'panel:military-correlation', keywords: ['force posture', 'military correlation', 'military posture'], label: 'Panel: Force Posture', icon: '\u{1F396}\uFE0F', category: 'panels' },
   { id: 'panel:escalation-correlation', keywords: ['escalation', 'escalation monitor', 'escalation risk'], label: 'Panel: Escalation Monitor', icon: '\u{1F4C8}', category: 'panels' },
   { id: 'panel:economic-correlation', keywords: ['economic warfare', 'economic correlation', 'sanctions impact'], label: 'Economic Warfare', icon: '\u{1F4B1}', category: 'panels' },

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -2141,20 +2141,141 @@
   min-height: 150px;
 }
 
-/* DeductionPanel (PERF-012: extracted from inline <style>) */
-.deduction-panel-content { display: flex; flex-direction: column; gap: 12px; padding: 8px; height: 100%; overflow-y: auto; }
-.deduction-form { display: flex; flex-direction: column; gap: 8px; }
-.deduction-input,
-.deduction-geo-input { width: 100%; padding: 8px; background: var(--bg-secondary, #2a2a2a); border: 1px solid var(--border-color, #444); color: var(--text-primary, #fff); border-radius: 4px; font-family: inherit; resize: vertical; box-sizing: border-box; }
-.deduction-submit-btn { padding: 8px 16px; background: var(--accent-color, #3b82f6); color: white; border: none; border-radius: 4px; cursor: pointer; align-self: flex-end; font-weight: 500; }
-.deduction-submit-btn:hover { background: var(--accent-hover, #2563eb); }
-.deduction-submit-btn:disabled { opacity: 0.5; cursor: not-allowed; }
-.deduction-result { flex: 1; margin-top: 8px; line-height: 1.5; font-size: 0.9em; color: var(--text-primary, #ddd); }
-.deduction-result.loading { opacity: 0.7; font-style: italic; }
-.deduction-result.error { color: var(--semantic-critical, #ef4444); }
-.deduction-result h3 { margin-top: 12px; margin-bottom: 4px; font-size: 1.1em; color: var(--text-bright, #fff); }
-.deduction-result ul { padding-left: 20px; margin-top: 4px; }
-.deduction-result li { margin-bottom: 4px; }
+/* ── DeductionPanel ─────────────────────────────────────── */
+.deduction-panel-content {
+  display: flex; flex-direction: column; gap: 10px;
+  padding: 10px 12px; height: 100%; overflow-y: auto;
+  font-family: var(--font-body-base, system-ui, sans-serif);
+}
+
+/* Form */
+.deduction-form { display: flex; flex-direction: column; gap: 6px; }
+.deduction-input {
+  width: 100%; padding: 9px 11px; box-sizing: border-box;
+  background: var(--bg-secondary); border: 1px solid var(--border-strong);
+  border-radius: 6px; color: var(--text-secondary);
+  font-family: var(--font-body-base, system-ui, sans-serif);
+  font-size: 13px; resize: vertical; min-height: 68px;
+  transition: border-color 0.15s, box-shadow 0.15s; outline: none;
+}
+.deduction-input:focus {
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 8%, transparent);
+  color: var(--text, #fff);
+}
+.deduction-form-row { display: flex; gap: 6px; align-items: center; }
+.deduction-geo-input {
+  flex: 1; padding: 7px 10px; box-sizing: border-box;
+  background: transparent; border: 1px solid var(--border);
+  border-radius: 5px; color: var(--text-dim);
+  font-family: var(--font-body-base, system-ui, sans-serif);
+  font-size: 12px; transition: border-color 0.15s; outline: none;
+}
+.deduction-geo-input:focus { border-color: var(--border-strong); color: var(--text-secondary); }
+.deduction-submit-btn {
+  padding: 7px 16px; flex-shrink: 0;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  border-radius: 5px; color: var(--accent); cursor: pointer;
+  font-family: var(--font-body-base, system-ui, sans-serif);
+  font-size: 11px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+  transition: background 0.15s, border-color 0.15s;
+}
+.deduction-submit-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+}
+.deduction-submit-btn:disabled { opacity: 0.35; cursor: not-allowed; }
+
+/* Loading dots */
+.deduction-result.loading {
+  display: flex; align-items: center; gap: 8px;
+  padding: 16px 0; color: var(--text-dim); font-size: 12px;
+}
+.deduction-loading-dots { display: flex; gap: 4px; }
+.deduction-loading-dots span {
+  width: 5px; height: 5px; border-radius: 50%;
+  background: var(--text-dim); animation: deduction-pulse 1.2s ease-in-out infinite;
+}
+.deduction-loading-dots span:nth-child(2) { animation-delay: 0.2s; }
+.deduction-loading-dots span:nth-child(3) { animation-delay: 0.4s; }
+@keyframes deduction-pulse { 0%,80%,100% { opacity: 0.2; transform: scale(0.8); } 40% { opacity: 1; transform: scale(1); } }
+
+/* Result base */
+.deduction-result {
+  flex: 1; font-family: var(--font-body-base, system-ui, sans-serif);
+  font-size: 13px; line-height: 1.6; color: var(--text-secondary);
+}
+.deduction-result.error { color: var(--red); padding: 12px 0; font-size: 12px; }
+
+/* Section: Verdict (Bottom line) */
+.ds-verdict {
+  background: color-mix(in srgb, var(--yellow) 7%, transparent);
+  border-left: 2px solid var(--yellow);
+  padding: 10px 12px; border-radius: 0 5px 5px 0; margin-bottom: 12px;
+  color: var(--text, #fff); font-size: 13px; line-height: 1.6;
+}
+.ds-section-label {
+  font-size: 10px; font-weight: 700; letter-spacing: 0.1em;
+  text-transform: uppercase; display: flex; align-items: center; gap: 8px;
+  margin-bottom: 8px;
+}
+.ds-section-label::after { content: ''; flex: 1; height: 1px; background: var(--border); }
+.ds-verdict .ds-section-label { color: var(--yellow); margin-bottom: 6px; }
+.ds-verdict .ds-section-label::after { background: color-mix(in srgb, var(--yellow) 20%, transparent); }
+
+/* Section: Evidence (What we know) */
+.ds-evidence { margin-bottom: 12px; }
+.ds-evidence .ds-section-label { color: var(--text-dim); }
+.ds-evidence ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
+.ds-evidence li {
+  padding: 6px 10px 6px 22px; background: var(--bg-secondary);
+  border-radius: 4px; font-size: 12px; line-height: 1.5;
+  color: var(--text-secondary); position: relative;
+}
+.ds-evidence li::before { content: '·'; position: absolute; left: 10px; color: var(--text-dim); font-size: 16px; line-height: 1.3; }
+
+/* Section: Primary path (Most likely) */
+.ds-primary {
+  background: color-mix(in srgb, var(--green) 5%, transparent);
+  border-left: 2px solid var(--green);
+  padding: 10px 12px; border-radius: 0 5px 5px 0; margin-bottom: 12px;
+}
+.ds-primary .ds-section-label { color: var(--green); margin-bottom: 6px; }
+.ds-primary .ds-section-label::after { background: color-mix(in srgb, var(--green) 20%, transparent); }
+.ds-prob-badge {
+  background: color-mix(in srgb, var(--green) 18%, transparent);
+  color: var(--green); border-radius: 20px; padding: 1px 7px;
+  font-size: 10px; font-weight: 700; font-family: var(--font-mono);
+  letter-spacing: 0.04em; white-space: nowrap;
+}
+.ds-primary-body { font-size: 13px; line-height: 1.6; color: var(--text, #fff); }
+
+/* Section: Alternative paths */
+.ds-alt { margin-bottom: 12px; }
+.ds-alt .ds-section-label { color: var(--text-dim); }
+.ds-alt ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; }
+.ds-alt li {
+  padding: 6px 10px 6px 10px; background: transparent;
+  border: 1px solid var(--border); border-radius: 4px;
+  font-size: 12px; line-height: 1.5; color: var(--text-dim); display: flex; gap: 8px;
+}
+.ds-alt-prob {
+  background: color-mix(in srgb, var(--text-dim) 15%, transparent);
+  color: var(--text-secondary); border-radius: 20px; padding: 1px 7px;
+  font-size: 10px; font-weight: 700; font-family: var(--font-mono);
+  white-space: nowrap; flex-shrink: 0; align-self: flex-start; margin-top: 1px;
+}
+
+/* Section: Confidence */
+.ds-confidence { margin-bottom: 10px; }
+.ds-confidence .ds-section-label { color: var(--text-dim); }
+
+/* Attribution footer */
+.deduction-meta {
+  margin-top: 14px; padding-top: 8px; border-top: 1px solid var(--border-subtle);
+  font-size: 10px; color: var(--text-dim); letter-spacing: 0.03em;
+}
 
 /* ----------------------------------------------------------
    Thermal Escalation Panel (Option A — Dense Intel)


### PR DESCRIPTION
## Summary
- Redesigns the DeductionPanel result output from bare monospace markdown to structured visual cards
- Adds `panel:deduction` to CMD+K command palette

## UI Changes

**Before**: Plain rendered markdown with monospace font, no visual hierarchy.

**After**: Structured section cards:
- **Bottom Line** — yellow left border, verdict at a glance
- **What We Know** — evidence summary
- **Most Likely Path** — green left border with probability badge and timeframe
- **Alternative Paths** — bullet list with per-item probability pills
- **Confidence** — confidence assessment
- Loading state: animated dot pulse instead of static text
- Attribution footer with provider and model
- Font overridden to `var(--font-body-base)` (was inheriting monospace from parent)

## CMD+K
`panel:deduction` registered in `src/config/commands.ts` so typing "deduction", "ai deduction", or "situation analysis" opens the panel via CMD+K. Uses the existing generic `scrollToPanel('deduction')` handler.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: purely frontend/CSS change with no server-side logic.