### PR TITLE
fix(deduction): remove LLM provider/model attribution footer

### DIFF
--- a/src/components/DeductionPanel.ts
+++ b/src/components/DeductionPanel.ts
@@ -250,11 +250,6 @@ export class DeductionPanel extends Panel {
                 const safe = DOMPurify.sanitize(parsed);
                 this.resultContainer.innerHTML = safe;
                 this.reformatResult(this.resultContainer);
-
-                const meta = h('div', { className: 'deduction-meta' },
-                    `${resp.provider || 'AI'}${resp.model ? ` · ${resp.model}` : ''}`
-                );
-                this.resultContainer.appendChild(meta);
             } else {
                 this.resultContainer.textContent = resp.provider === 'error'
                     ? 'AI analysis temporarily unavailable. Please try again in a moment.'

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -2271,12 +2271,6 @@
 .ds-confidence { margin-bottom: 10px; }
 .ds-confidence .ds-section-label { color: var(--text-dim); }
 
-/* Attribution footer */
-.deduction-meta {
-  margin-top: 14px; padding-top: 8px; border-top: 1px solid var(--border-subtle);
-  font-size: 10px; color: var(--text-dim); letter-spacing: 0.03em;
-}
-
 /* ----------------------------------------------------------
    Thermal Escalation Panel (Option A — Dense Intel)
    ---------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- Removes the `openrouter · google/gemini-2.5-flash` attribution line from DeductionPanel results
- Removes the unused `.deduction-meta` CSS rule

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: purely frontend display change.