### PR TITLE
fix(simulation): skip NEGATION_TERMS guard for simulation-curated invalidators

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -11322,11 +11322,13 @@ const NEGATION_TERMS = ['ceasefire', 'reopen', 'reopened', 'resolv', 'diplomatic
 const SIMULATION_MERGE_ACCEPT_THRESHOLD = 0.50;
 const SIMULATION_ELIGIBILITY_RANK_THRESHOLD = 0.40;
 
-function contradictsPremise(invalidator, expandedPath) {
+function contradictsPremise(invalidator, expandedPath, fromSimulation = false) {
   if (!invalidator || typeof invalidator !== 'string') return false;
   const text = invalidator.toLowerCase();
-  const hasNegation = NEGATION_TERMS.some((t) => text.includes(t));
-  if (!hasNegation) return false;
+  if (!fromSimulation) {
+    const hasNegation = NEGATION_TERMS.some((t) => text.includes(t));
+    if (!hasNegation) return false;
+  }
   const routeKey = expandedPath?.candidate?.routeFacilityKey || '';
   const commodityKey = expandedPath?.candidate?.commodityKey || '';
   if (routeKey || commodityKey) {
@@ -11389,7 +11391,7 @@ function computeSimulationAdjustment(expandedPath, simTheaterResult, candidatePa
   }
 
   for (const inv of invalidators) {
-    if (contradictsPremise(inv, expandedPath)) {
+    if (contradictsPremise(inv, expandedPath, true)) {
       adjustment -= 0.12;
       details.invalidatorHit = true;
       break;

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -6502,9 +6502,18 @@ describe('phase 3 simulation re-ingestion — matching helpers', () => {
     assert.ok(!contradictsPremise('Red Sea shipping restored', path));
   });
 
-  it('contradictsPremise returns false without negation language', () => {
+  it('contradictsPremise returns false without negation language (default)', () => {
     const path = { candidate: { routeFacilityKey: 'Strait of Hormuz', commodityKey: '' } };
     assert.ok(!contradictsPremise('Strait of Hormuz under continued risk', path));
+  });
+
+  it('contradictsPremise fromSimulation=true: fires on simulation-style invalidator without negation terms', () => {
+    // Regression: simulation invalidators use neutral language ("clearance of the Suez Canal")
+    // not geopolitical resolution language ("reopened"). fromSimulation=true skips the negation guard.
+    const path = { candidate: { routeFacilityKey: 'Suez Canal', commodityKey: '' } };
+    assert.ok(contradictsPremise('Immediate and complete clearance of the Suez Canal within 24 hours.', path, true));
+    // Still false when route not mentioned, even in simulation context
+    assert.ok(!contradictsPremise('Global economic downturn dampening energy demand.', path, true));
   });
 
   it('negatesDisruption detects commodity restoration', () => {


### PR DESCRIPTION
## Why this PR?

Phase 3 simulation merge has been running but producing **zero adjustments** on every run since deployment. Root cause: `contradictsPremise()` requires negation terms (`ceasefire`, `reopened`, `resolved`...) but MiroFish generates invalidators as neutral counterfactual conditions:

> "Immediate and complete clearance of the Suez Canal within 24 hours."
> "Major alternative shipping routes becoming immediately available."

None contain NEGATION_TERMS → `contradictsPremise` always returns false → `invalidatorHit` always false → adjustment always 0.

## What changed

- `contradictsPremise`: add `fromSimulation = false` param; when `true`, skip the negation guard since simulation invalidators are pre-curated by MiroFish as path-contradicting conditions
- `computeSimulationAdjustment`: pass `fromSimulation = true` to `contradictsPremise`
- Add test covering simulation-style invalidator without negation terms

The non-simulation path is unchanged (existing tests pass unmodified).

## Verified from R2 data

Post-PR #2374 runs (Mar 28 02:00-04:00 UTC): `simulationEvidence.adjustments = 0` on every run despite `theaterCount=1` and paths with `candidateStateId` matching the theater. Simulation invalidators confirmed to be negation-free.

## Test plan
- [ ] 223 tests pass
- [ ] Next simulation run: `invalidatorHit: true` appears in `simulationEvidence.adjustments` for paths matching theater with invalidators mentioning route facility