### PR TITLE
fix(simulation): skip NEGATION_TERMS guard for simulation-curated invalidators

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -11322,11 +11322,13 @@ const NEGATION_TERMS = ['ceasefire', 'reopen', 'reopened', 'resolv', 'diplomatic
 const SIMULATION_MERGE_ACCEPT_THRESHOLD = 0.50;
 const SIMULATION_ELIGIBILITY_RANK_THRESHOLD = 0.40;
 
-function contradictsPremise(invalidator, expandedPath) {
+function contradictsPremise(invalidator, expandedPath, fromSimulation = false) {
   if (!invalidator || typeof invalidator !== 'string') return false;
   const text = invalidator.toLowerCase();
-  const hasNegation = NEGATION_TERMS.some((t) => text.includes(t));
-  if (!hasNegation) return false;
+  if (!fromSimulation) {
+    const hasNegation = NEGATION_TERMS.some((t) => text.includes(t));
+    if (!hasNegation) return false;
+  }
   const routeKey = expandedPath?.candidate?.routeFacilityKey || '';
   const commodityKey = expandedPath?.candidate?.commodityKey || '';
   if (routeKey || commodityKey) {
@@ -11389,7 +11391,7 @@ function computeSimulationAdjustment(expandedPath, simTheaterResult, candidatePa
   }
 
   for (const inv of invalidators) {
-    if (contradictsPremise(inv, expandedPath)) {
+    if (contradictsPremise(inv, expandedPath, true)) {
       adjustment -= 0.12;
       details.invalidatorHit = true;
       break;

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -6502,9 +6502,18 @@ describe('phase 3 simulation re-ingestion — matching helpers', () => {
     assert.ok(!contradictsPremise('Red Sea shipping restored', path));
   });
 
-  it('contradictsPremise returns false without negation language', () => {
+  it('contradictsPremise returns false without negation language (default)', () => {
     const path = { candidate: { routeFacilityKey: 'Strait of Hormuz', commodityKey: '' } };
     assert.ok(!contradictsPremise('Strait of Hormuz under continued risk', path));
+  });
+
+  it('contradictsPremise fromSimulation=true: fires on simulation-style invalidator without negation terms', () => {
+    // Regression: simulation invalidators use neutral language ("clearance of the Suez Canal")
+    // not geopolitical resolution language ("reopened"). fromSimulation=true skips the negation guard.
+    const path = { candidate: { routeFacilityKey: 'Suez Canal', commodityKey: '' } };
+    assert.ok(contradictsPremise('Immediate and complete clearance of the Suez Canal within 24 hours.', path, true));
+    // Still false when route not mentioned, even in simulation context
+    assert.ok(!contradictsPremise('Global economic downturn dampening energy demand.', path, true));
   });
 
   it('negatesDisruption detects commodity restoration', () => {


### PR DESCRIPTION
## Summary

- `contradictsPremise()` required negation language (ceasefire/reopened/resolved) in order to register a hit, but simulation invalidators use neutral counterfactual wording like _"clearance of the Suez Canal within 24 hours"_
- These conditions are pre-curated by MiroFish as path-contradicting conditions — the negation guard is redundant and was silently blocking all Phase 3 invalidator hits since deployment
- Fix: add `fromSimulation = false` param to `contradictsPremise()`; pass `true` from `computeSimulationAdjustment()`
- Existing tests (non-simulation context) unchanged; new test (T15) covers the regression

## Test plan

- [ ] `npm run test:data` passes (2433 tests, 0 fail)
- [ ] `npm run typecheck` + `typecheck:api` pass
- [ ] Simulation invalidators with neutral counterfactual wording now register hits in Phase 3 merge