### PR TITLE
fix(relay): add explicit start command to nixpacks.toml — bust build cache

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -15,3 +15,6 @@ cmds = ["npm ci"]
 
 [phases.build]
 cmds = ["npm install", "npm install --prefix scripts"]
+
+[start]
+cmd = "node scripts/ais-relay.cjs"


### PR DESCRIPTION
## Problem

Relay crashes with `Cannot find module './_proxy-utils.cjs'` after PR #2399 deployed. Even after redeploying from main (which has the file), Railway serves a stale cached image.

## Fix

Add explicit `[start]` section to root `nixpacks.toml`:
```toml
[start]
cmd = "node scripts/ais-relay.cjs"
```

Changing `nixpacks.toml` busts Railway's layer cache and forces a clean rebuild that picks up `scripts/_proxy-utils.cjs` from the current `main`.

## Note

The start command itself is not the root issue — the container ran fine before. This change is primarily a **cache-busting mechanism** to force Railway to rebuild with all new files intact.