### PR TITLE
fix(relay): clear proxy CONNECT timeout before downloading response body

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -7489,6 +7489,7 @@ function ytFetchViaProxy(targetUrl, proxy) {
     }
     const connectReq = http.request(connectOpts);
     connectReq.on('connect', (_res, socket) => {
+      connectReq.setTimeout(0);
       const req = https.request({
         hostname: target.hostname,
         path: target.pathname + target.search,


### PR DESCRIPTION
## Why this PR?

USNI fleet tracker was timing out during proxy download. The `ytFetchViaProxy` function sets a 12s timeout on the `connectReq` (HTTP CONNECT tunnel), but that timer kept running after the tunnel was established. USNI's WordPress API returns ~23KB and takes 30-45s through the Decodo proxy, so the timer fired mid-download and destroyed the socket with `'Proxy timeout'`. The seed then fell back to direct fetch, which gets 403 from Cloudflare.

## Fix

One line: `connectReq.setTimeout(0)` inside the `connect` handler clears the timer once the tunnel is established. The CONNECT itself takes <2s; only the response body download is slow.

## Test

Confirmed via local curl through Decodo proxy: HTTP 200 with full body in ~45s. Relay will now wait for the download to complete instead of aborting it.