### PR TITLE
fix(usni): use https.request for proxy CONNECT (Decodo port 10001 is HTTPS)

### DIFF
--- a/scripts/_proxy-utils.cjs
+++ b/scripts/_proxy-utils.cjs
@@ -12,7 +12,7 @@
 function parseProxyConfig(raw) {
   if (!raw) return null;
 
-  // Standard URL format: http://user:pass@host:port
+  // Standard URL format: http://user:pass@host:port or https://user:pass@host:port
   try {
     const u = new URL(raw);
     if (u.hostname) {
@@ -20,6 +20,7 @@ function parseProxyConfig(raw) {
         host: u.hostname,
         port: parseInt(u.port, 10),
         auth: u.username ? `${decodeURIComponent(u.username)}:${decodeURIComponent(u.password)}` : null,
+        tls: u.protocol === 'https:',
       };
     }
   } catch { /* fall through */ }

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -4946,7 +4946,7 @@ async function seedUsniFleet() {
     // Use PROXY_URL (US-targeted proxy). OREF_PROXY_AUTH is IL-only and must NOT be used here.
     let wpData;
     const proxiesToTry = [
-      PROXY_URL ? parseProxyUrl(PROXY_URL) : null,
+      PROXY_URL ? { ...parseProxyUrl(PROXY_URL), tls: true } : null, // Decodo gate.*.com:10001 is HTTPS
     ].filter(Boolean);
     let fetched = false;
     for (const proxy of proxiesToTry) {
@@ -7487,7 +7487,8 @@ function ytFetchViaProxy(targetUrl, proxy) {
     if (proxy.auth) {
       connectOpts.headers['Proxy-Authorization'] = 'Basic ' + Buffer.from(proxy.auth).toString('base64');
     }
-    const connectReq = http.request(connectOpts);
+    // Use TLS to connect to proxy if required (e.g. Decodo port 10001); plain HTTP otherwise
+    const connectReq = proxy.tls ? https.request(connectOpts) : http.request(connectOpts);
     connectReq.on('connect', (_res, socket) => {
       connectReq.setTimeout(0);
       const req = https.request({


### PR DESCRIPTION
## Root Cause
`ytFetchViaProxy` was using `http.request` for the CONNECT tunnel. Decodo's port 10001 (`gate.decodo.com:10001`) requires TLS for the proxy connection itself — it's an HTTPS proxy endpoint. Plain HTTP to an HTTPS server causes Node.js HTTP parser to fail: `Parse Error: Expected HTTP/, RTSP/ or ICE/`.

## Fix
One-line change: `http.request` → `https.request` for the CONNECT. The `socket` returned in the `connect` event is the decrypted channel through the outer TLS; the inner `https.request({ socket, agent: false })` then does TLS to the target site on top of it.

## Post-Deploy Monitoring & Validation
- **What to monitor:** `usniFleet` status in `/api/health`
- **Expected:** `status: "OK"` with `records > 0` within 2 min of deploy
- **Failure signal:** `STALE_SEED` or `[USNI] Parse Error` in Railway logs