### PR TITLE
fix(simulation): normalize commodityKey underscores and expand CHANNEL_KEYWORDS

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -11289,8 +11289,8 @@ const CHANNEL_KEYWORDS = {
   global_crude_spread_stress: ['crude spread', 'brent wti', 'grade spread'],
   shipping_cost_shock: ['shipping cost', 'freight cost', 'freight rate', 'route disruption', 'chokepoint', 'transit'],
   sovereign_stress: ['sovereign', 'debt stress', 'default risk', 'credit stress', 'bond spread'],
-  risk_off_rotation: ['risk off', 'risk aversion', 'flight to safety', 'sell off'],
-  security_escalation: ['escalat', 'military action', 'conflict', 'war', 'strike', 'attack'],
+  risk_off_rotation: ['risk off', 'risk aversion', 'flight to safety', 'sell off', 'selloff', 'sell-off', 'capital flight', 'capital outflow', 'risk premium', 'avers', 'retreat', 'flight to'],
+  security_escalation: ['escalat', 'military action', 'conflict', 'war', 'strike', 'attack', 'military', 'geopolit'],
   yield_curve_stress: ['yield curve', 'yield spread', 'term premium'],
   volatility_shock: ['volatility', 'vix', 'vol spike'],
   safe_haven_bid: ['safe haven', 'gold', 'yen', 'swiss franc', 'treasur'],
@@ -11330,7 +11330,7 @@ function contradictsPremise(invalidator, expandedPath, fromSimulation = false) {
     if (!hasNegation) return false;
   }
   const routeKey = expandedPath?.candidate?.routeFacilityKey || '';
-  const commodityKey = expandedPath?.candidate?.commodityKey || '';
+  const commodityKey = (expandedPath?.candidate?.commodityKey || '').replace(/_/g, ' ');
   if (routeKey || commodityKey) {
     return (
       (routeKey && text.includes(routeKey.toLowerCase())) ||
@@ -11352,7 +11352,7 @@ function negatesDisruption(stabilizer, candidatePacket) {
   const hasNegation = NEGATION_TERMS.some((t) => text.includes(t));
   if (!hasNegation) return false;
   const routeKey = candidatePacket?.routeFacilityKey || '';
-  const commodityKey = candidatePacket?.commodityKey || '';
+  const commodityKey = (candidatePacket?.commodityKey || '').replace(/_/g, ' ');
   if (routeKey || commodityKey) {
     return (
       (routeKey && text.includes(routeKey.toLowerCase())) ||

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -6540,7 +6540,10 @@ describe('phase 3 simulation re-ingestion — matching helpers', () => {
 
   it('negatesDisruption detects commodity restoration', () => {
     const candidatePacket = { routeFacilityKey: '', commodityKey: 'crude_oil' };
-    assert.ok(negatesDisruption('crude_oil supply chain restored to normal operations', candidatePacket));
+    // commodityKey is normalized to "crude oil" (space) before text matching — LLM text uses natural language
+    assert.ok(negatesDisruption('crude oil supply restored to normal operations', candidatePacket));
+    // underscore form in text would no longer match (correct — LLM never emits "crude_oil")
+    assert.ok(!negatesDisruption('crude_oil supply chain restored to normal operations', candidatePacket));
   });
 
   it('negatesDisruption returns false when no route/commodity and no stateKind/bucket on candidate', () => {


### PR DESCRIPTION
## Why this PR?

Two more matching bugs found from R2 data that keep `adjustments=0` post #2402+#2404:

### Bug 1 — `commodityKey` underscore mismatch

Code checks `text.includes('crude_oil')` but LLM-generated invalidator/stabilizer text uses natural language:
> "Failure of alternative **oil** export routes..." / "**crude oil** supply restored..."

`'crude_oil'.includes()` never matches natural language → `invalidatorHit` and `stabilizerHit` always false for commodity-keyed theaters. Fix: `.replace(/_/g, ' ')` before text comparison.

### Bug 2 — `CHANNEL_KEYWORDS['risk_off_rotation']` too narrow

Only matched 4 exact phrases. Actual simulation paths use:
> "Regional Conflict & **Sovereign Risk Spiral** / Iran's retaliatory strikes lead to **capital flight**..."

None of the 4 original terms appear. Expanded to include: `sell-off`, `capital flight`, `capital outflow`, `risk premium`, `avers`, `retreat`, `flight to`.

Also expanded `security_escalation` to include `military`, `geopolit` for broader LLM vocabulary coverage.

## Verified from R2 data

Mar 28 07:04 UTC run: theater `state-7cc5738b6f` (Strait of Hormuz, `sovereign_risk` bucket, `risk_off_rotation` channel) matched simulation outcome but produced `adjustments=0` due to both bugs above.

## Test plan
- [x] 2434 tests pass, 0 fail
- [x] `negatesDisruption` test updated to use natural language text (matches what LLM actually emits)