### PR TITLE
feat(mcp): expose /mcp as clean public endpoint

### DIFF
--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -16,7 +16,7 @@ const getCacheHeaderValue = (sourcePath) => {
 
 describe('deploy/cache configuration guardrails', () => {
   it('disables caching for HTML entry routes on Vercel', () => {
-    const spaNoCache = getCacheHeaderValue('/((?!api|assets|blog|docs|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|\\.well-known|wm-widget-sandbox\\.html).*)');
+    const spaNoCache = getCacheHeaderValue('/((?!api|mcp|assets|blog|docs|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|\\.well-known|wm-widget-sandbox\\.html).*)');
     assert.equal(spaNoCache, 'no-cache, no-store, must-revalidate');
   });
 

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,8 @@
   "rewrites": [
     { "source": "/docs/:match*", "destination": "https://worldmonitor.mintlify.dev/docs/:match*" },
     { "source": "/pro", "destination": "/pro/index.html" },
-    { "source": "/((?!api|assets|blog|docs|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|\\.well-known|wm-widget-sandbox\\.html).*)", "destination": "/index.html" }
+    { "source": "/mcp", "destination": "/api/mcp" },
+    { "source": "/((?!api|mcp|assets|blog|docs|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|\\.well-known|wm-widget-sandbox\\.html).*)", "destination": "/index.html" }
   ],
   "headers": [
     {
@@ -16,6 +17,14 @@
         { "key": "Access-Control-Allow-Origin", "value": "*" },
         { "key": "Access-Control-Allow-Methods", "value": "GET, POST, OPTIONS" },
         { "key": "Access-Control-Allow-Headers", "value": "Content-Type, Authorization, X-WorldMonitor-Key, X-Widget-Key, X-Pro-Key" }
+      ]
+    },
+    {
+      "source": "/mcp",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET, POST, OPTIONS" },
+        { "key": "Access-Control-Allow-Headers", "value": "Content-Type, Authorization, X-WorldMonitor-Key" }
       ]
     },
     {
@@ -50,7 +59,7 @@
       ]
     },
     {
-      "source": "/((?!api|assets|blog|docs|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|\\.well-known|wm-widget-sandbox\\.html).*)",
+      "source": "/((?!api|mcp|assets|blog|docs|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|\\.well-known|wm-widget-sandbox\\.html).*)",
       "headers": [
         { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
       ]


### PR DESCRIPTION
## Summary

- Adds `/mcp` rewrite in `vercel.json` → `api/mcp` (Vercel edge function)
- MCP clients now connect to `https://api.worldmonitor.app/mcp` (clean URL)
- Excludes `/mcp` from SPA catch-all rewrite and no-cache header rule
- Adds CORS headers for `/mcp` path
- Updates `deploy-config.test.mjs` to match new exclusion pattern

## Why /mcp instead of /api/mcp

CF bot-blocking rules target `/api/*` only — MCP clients (Claude Desktop, custom agents) sending requests without a browser User-Agent were getting 403'd. The `/mcp` path bypasses those rules entirely without needing additional CF WAF exceptions.

## Claude Desktop config
```json
{
  "mcpServers": {
    "worldmonitor": {
      "url": "https://api.worldmonitor.app/mcp",
      "headers": { "X-WorldMonitor-Key": "YOUR_KEY" }
    }
  }
}
```

## Test plan
- [ ] Deploy and confirm `POST https://api.worldmonitor.app/mcp` with `X-WorldMonitor-Key` returns tools/list JSON
- [ ] Confirm `curl` (no browser UA) to `/mcp` gets through CF (not 403)
- [ ] Confirm `/api/mcp` still works for backwards compat
- [ ] `node --test tests/deploy-config.test.mjs` passes locally