### PR TITLE
fix(simulation): TypeScript types for simulation pipeline + remove dead legacy fallbacks

### DIFF
--- a/scripts/jsconfig.json
+++ b/scripts/jsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "strict": false,
+    "noImplicitAny": false,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "maxNodeModuleJsDepth": 0,
+    "skipLibCheck": true
+  },
+  "include": ["seed-forecasts.mjs", "seed-forecasts.types.d.ts"],
+  "exclude": []
+}

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// @ts-check
+/// <reference path="./seed-forecasts.types.d.ts" />
 
 import crypto from 'node:crypto';
 import { readFileSync } from 'node:fs';
@@ -11322,6 +11324,12 @@ const NEGATION_TERMS = ['ceasefire', 'reopen', 'reopened', 'resolv', 'diplomatic
 const SIMULATION_MERGE_ACCEPT_THRESHOLD = 0.50;
 const SIMULATION_ELIGIBILITY_RANK_THRESHOLD = 0.40;
 
+/**
+ * @param {string} invalidator
+ * @param {ExpandedPath} expandedPath
+ * @param {boolean} [fromSimulation]
+ * @returns {boolean}
+ */
 function contradictsPremise(invalidator, expandedPath, fromSimulation = false) {
   if (!invalidator || typeof invalidator !== 'string') return false;
   const text = invalidator.toLowerCase();
@@ -11346,6 +11354,11 @@ function contradictsPremise(invalidator, expandedPath, fromSimulation = false) {
   return subjectKeywords.some((kw) => text.includes(kw));
 }
 
+/**
+ * @param {string} stabilizer
+ * @param {CandidatePacket} candidatePacket
+ * @returns {boolean}
+ */
 function negatesDisruption(stabilizer, candidatePacket) {
   if (!stabilizer || typeof stabilizer !== 'string') return false;
   const text = stabilizer.toLowerCase();
@@ -11361,19 +11374,25 @@ function negatesDisruption(stabilizer, candidatePacket) {
   }
   // Non-maritime: match on stateKind and bucket keywords.
   const stateKind = candidatePacket?.stateKind || '';
-  const bucket = candidatePacket?.marketContext?.topBucketId || candidatePacket?.topBucketId || '';
+  const bucket = candidatePacket?.marketContext?.topBucketId || '';
   const subjectKeywords = [...stateKind.toLowerCase().split('_'), ...bucket.toLowerCase().split('_')]
     .filter((w) => w.length >= 4);
   return subjectKeywords.some((kw) => text.includes(kw));
 }
 
+/**
+ * @param {ExpandedPath} expandedPath
+ * @param {TheaterResult} simTheaterResult
+ * @param {CandidatePacket} candidatePacket
+ * @returns {{ adjustment: number; details: SimulationAdjustmentDetail }}
+ */
 function computeSimulationAdjustment(expandedPath, simTheaterResult, candidatePacket) {
   let adjustment = 0;
   const details = { bucketChannelMatch: false, actorOverlapCount: 0, invalidatorHit: false, stabilizerHit: false };
 
   const { topPaths = [], invalidators = [], stabilizers = [] } = simTheaterResult || {};
-  const pathBucket = expandedPath?.direct?.targetBucket || candidatePacket?.marketContext?.topBucketId || candidatePacket?.topBucketId || '';
-  const pathChannel = expandedPath?.direct?.channel || candidatePacket?.marketContext?.topChannel || candidatePacket?.topChannel || '';
+  const pathBucket = expandedPath?.direct?.targetBucket || candidatePacket?.marketContext?.topBucketId || '';
+  const pathChannel = expandedPath?.direct?.channel || candidatePacket?.marketContext?.topChannel || '';
   const pathActors = extractPathActors(expandedPath);
 
   const bucketChannelMatch = topPaths.find(
@@ -11409,6 +11428,14 @@ function computeSimulationAdjustment(expandedPath, simTheaterResult, candidatePa
   return { adjustment: +adjustment.toFixed(3), details };
 }
 
+/**
+ * @param {object} evaluation
+ * @param {SimulationOutcome} simulationOutcome
+ * @param {CandidatePacket[]} candidatePackets
+ * @param {object} snapshot
+ * @param {object | null} priorWorldState
+ * @returns {{ evaluation: object; simulationEvidence: SimulationEvidence | null }}
+ */
 function applySimulationMerge(evaluation, simulationOutcome, candidatePackets, snapshot, priorWorldState) {
   if (!simulationOutcome?.theaterResults?.length) {
     return { evaluation, simulationEvidence: null };

--- a/scripts/seed-forecasts.types.d.ts
+++ b/scripts/seed-forecasts.types.d.ts
@@ -1,0 +1,195 @@
+/**
+ * TypeScript type definitions for seed-forecasts.mjs simulation pipeline.
+ *
+ * These types are used via JSDoc (@type/@param/@returns) annotations in seed-forecasts.mjs
+ * with `// @ts-check` to enable compile-time shape validation.
+ *
+ * CRITICAL SHAPE NOTES (lessons from production bugs):
+ *  - topBucketId / topChannel live under candidatePacket.marketContext — NOT at top level
+ *  - commodityKey may contain underscores (e.g. 'crude_oil') and MUST be .replace(/_/g, ' ')
+ *    before text-matching against LLM output
+ *  - theaterResults MUST store candidateStateId so applySimulationMerge can key the lookup
+ *    map by semantic ID, not by positional theaterId
+ */
+
+// ---------------------------------------------------------------------------
+// Candidate packet (impact expansion input)
+// ---------------------------------------------------------------------------
+
+interface CandidateMarketContext {
+  topBucketId: string;
+  topBucketLabel?: string;
+  topBucketPressure?: string;
+  topChannel: string;
+  topTransmissionStrength?: number;
+  topTransmissionConfidence?: number;
+  transmissionEdgeCount?: number;
+  confirmationScore?: number;
+  contradictionScore?: number;
+  criticalSignalCount?: number;
+  criticalSignalLift?: number;
+  criticalSignalTypes?: string[];
+  linkedBucketIds?: string[];
+  linkedSignalIds?: string[];
+  bucketContexts?: Record<string, unknown>;
+  consequenceSummary?: string;
+}
+
+/** Shape of each entry in snapshot.impactExpansionCandidates */
+interface CandidatePacket {
+  candidateStateId: string;
+  candidateIndex?: number;
+  /** Internal commodity key — may contain underscores. Normalize with .replace(/_/g, ' ') before text matching. */
+  commodityKey?: string;
+  routeFacilityKey?: string;
+  stateKind?: string;
+  rankingScore?: number;
+  /**
+   * Market context block — topBucketId and topChannel live HERE, NOT at the top level of CandidatePacket.
+   * BUG HISTORY: PRs #2404/#2410 fixed crashes caused by reading candidatePacket.topBucketId directly.
+   */
+  marketContext: CandidateMarketContext;
+}
+
+// ---------------------------------------------------------------------------
+// Expanded path (deep forecast evaluation output)
+// ---------------------------------------------------------------------------
+
+interface ExpandedPathDirect {
+  variableKey?: string;
+  hypothesisKey?: string;
+  description?: string;
+  geography?: string;
+  affectedAssets?: string[];
+  marketImpact?: string;
+  causalLink?: string;
+  channel?: string;
+  targetBucket?: string;
+  region?: string;
+  macroRegion?: string;
+  countries?: string[];
+  assetsOrSectors?: string[];
+  commodity?: string;
+  dependsOnKey?: string;
+  strength?: number;
+  confidence?: number;
+  analogTag?: string;
+  summary?: string;
+  evidenceRefs?: string[];
+}
+
+interface ExpandedPathCandidate {
+  commodityKey?: string;
+  routeFacilityKey?: string;
+  stateKind?: string;
+  topBucketId?: string;
+}
+
+/** A single expanded path produced by the deep forecast LLM evaluation. */
+interface ExpandedPath {
+  pathId: string;
+  type: 'expanded' | 'fast' | string;
+  candidateStateId: string;
+  acceptanceScore: number;
+  mergedAcceptanceScore?: number;
+  simulationAdjustment?: number;
+  demotedBySimulation?: boolean;
+  promotedBySimulation?: boolean;
+  direct?: ExpandedPathDirect;
+  candidate?: ExpandedPathCandidate;
+}
+
+// ---------------------------------------------------------------------------
+// Theater simulation structures
+// ---------------------------------------------------------------------------
+
+interface SimulationTopPath {
+  pathId: string;
+  label: string;
+  summary: string;
+  confidence: number;
+  keyActors: string[];
+  roundByRoundEvolution?: Array<{ round: number; summary: string }>;
+  timingMarkers?: Array<{ event: string; timing: string }>;
+}
+
+/**
+ * One theater's simulation result stored in SimulationOutcome.theaterResults.
+ *
+ * CRITICAL: candidateStateId MUST be stored here (fix from PR #2374).
+ * applySimulationMerge keys its lookup Map by candidateStateId, not theaterId.
+ */
+interface TheaterResult {
+  /** Positional ID assigned during simulation run: "theater-1", "theater-2", etc. */
+  theaterId: string;
+  /** Semantic ID linking back to CandidatePacket — REQUIRED for merge lookup. */
+  candidateStateId: string;
+  theaterLabel?: string;
+  stateKind?: string;
+  topPaths: SimulationTopPath[];
+  stabilizers: string[];
+  invalidators: string[];
+  dominantReactions?: string[];
+  timingMarkers?: Array<{ event: string; timing: string }>;
+}
+
+/** Full simulation outcome artifact written to R2 and referenced from Redis pointer. */
+interface SimulationOutcome {
+  runId: string;
+  schemaVersion: string;
+  runnerVersion?: string;
+  sourceSimulationPackageKey?: string;
+  theaterResults: TheaterResult[];
+  failedTheaters?: Array<{ theaterId: string; reason: string }>;
+  globalObservations?: string;
+  confidenceNotes?: string;
+  generatedAt?: number;
+  /** Injected by fetchSimulationOutcomeForMerge to indicate same-run vs fresh-but-different. */
+  isCurrentRun?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Simulation merge output
+// ---------------------------------------------------------------------------
+
+interface SimulationAdjustmentDetail {
+  bucketChannelMatch: boolean;
+  /** Number of overlapping actors between path and simulation top paths (>=2 triggers +0.04 bonus). */
+  actorOverlapCount: number;
+  invalidatorHit: boolean;
+  stabilizerHit: boolean;
+}
+
+interface SimulationAdjustmentRecord {
+  pathId: string;
+  candidateStateId: string;
+  originalAcceptanceScore: number;
+  simulationAdjustment: number;
+  mergedAcceptanceScore: number;
+  details: SimulationAdjustmentDetail;
+  wasAccepted: boolean;
+  nowAccepted: boolean;
+}
+
+interface SimulationEvidence {
+  outcomeRunId: string;
+  isCurrentRun: boolean;
+  theaterCount: number;
+  adjustments: SimulationAdjustmentRecord[];
+  pathsPromoted: number;
+  pathsDemoted: number;
+  pathsUnchanged: number;
+}
+
+// ---------------------------------------------------------------------------
+// Redis pointer for latest simulation outcome
+// ---------------------------------------------------------------------------
+
+interface SimulationOutcomePointer {
+  runId: string;
+  outcomeKey: string;
+  schemaVersion: string;
+  theaterCount: number;
+  generatedAt: number;
+  uiTheaters?: unknown[];
+}

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -6275,8 +6275,7 @@ describe('phase 3 simulation re-ingestion — computeSimulationAdjustment', () =
     candidateIndex: 0,
     routeFacilityKey,
     commodityKey,
-    topBucketId: 'energy',
-    topChannel: 'energy_supply_shock',
+    marketContext: { topBucketId: 'energy', topChannel: 'energy_supply_shock' },
   });
 
   it('T1: bucket+channel match gives +0.08', () => {
@@ -6410,7 +6409,7 @@ describe('phase 3 simulation re-ingestion — applySimulationMerge', () => {
     third: null,
     pathScore: 0.60,
     acceptanceScore,
-    candidate: { routeFacilityKey: 'Red Sea', commodityKey: 'crude_oil', topBucketId: 'energy', topChannel: 'energy_supply_shock' },
+    candidate: { routeFacilityKey: 'Red Sea', commodityKey: 'crude_oil' },
   });
 
   const makeSimOutcome = (theaterId, topPaths, invalidators = [], stabilizers = []) => ({
@@ -6429,7 +6428,7 @@ describe('phase 3 simulation re-ingestion — applySimulationMerge', () => {
     const path = makeExpandedPath('state-1', 0.52);
     const evaluation = makeEval('completed', [path]);
     const simOutcome = makeSimOutcome('state-1', [], ['Red Sea reopened after diplomatic ceasefire']);
-    const candidatePackets = [{ candidateStateId: 'state-1', routeFacilityKey: 'Red Sea', commodityKey: 'crude_oil', topBucketId: 'energy', topChannel: 'energy_supply_shock' }];
+    const candidatePackets = [{ candidateStateId: 'state-1', routeFacilityKey: 'Red Sea', commodityKey: 'crude_oil', marketContext: { topBucketId: 'energy', topChannel: 'energy_supply_shock' } }];
     const { simulationEvidence } = applySimulationMerge(evaluation, simOutcome, candidatePackets, { generatedAt: Date.now(), impactExpansionCandidates: candidatePackets }, null);
     assert.equal(simulationEvidence.pathsDemoted, 1);
     assert.equal(evaluation.status, 'completed_no_material_change');
@@ -6441,7 +6440,7 @@ describe('phase 3 simulation re-ingestion — applySimulationMerge', () => {
     rejectedPath.direct.affectedAssets = ['Iran', 'Houthi', 'Saudi Aramco'];
     const evaluation = makeEval('completed_no_material_change', [acceptedBase], [rejectedPath]);
     const simOutcome = makeSimOutcome('state-1', [{ label: 'Oil energy supply shock escalation', summary: 'Crude supply disruption energy', keyActors: ['Iran', 'Houthi'] }]);
-    const candidatePackets = [{ candidateStateId: 'state-1', routeFacilityKey: 'Red Sea', commodityKey: 'crude_oil', topBucketId: 'energy', topChannel: 'energy_supply_shock' }];
+    const candidatePackets = [{ candidateStateId: 'state-1', routeFacilityKey: 'Red Sea', commodityKey: 'crude_oil', marketContext: { topBucketId: 'energy', topChannel: 'energy_supply_shock' } }];
     const snapshot = { generatedAt: Date.now(), impactExpansionCandidates: candidatePackets, fullRunPredictions: [], predictions: [], inputs: {}, deepForecast: {} };
     const { simulationEvidence } = applySimulationMerge(evaluation, simOutcome, candidatePackets, snapshot, null);
     assert.equal(simulationEvidence.pathsPromoted, 1);
@@ -6452,7 +6451,7 @@ describe('phase 3 simulation re-ingestion — applySimulationMerge', () => {
     const path = makeExpandedPath('state-999', 0.60);
     const evaluation = makeEval('completed', [path]);
     const simOutcome = makeSimOutcome('state-1', [{ label: 'energy shock', summary: 'energy supply disruption', keyActors: [] }]);
-    const candidatePackets = [{ candidateStateId: 'state-999', routeFacilityKey: '', commodityKey: '', topBucketId: 'energy', topChannel: 'energy_supply_shock' }];
+    const candidatePackets = [{ candidateStateId: 'state-999', routeFacilityKey: '', commodityKey: '', marketContext: { topBucketId: 'energy', topChannel: 'energy_supply_shock' } }];
     const { simulationEvidence } = applySimulationMerge(evaluation, simOutcome, candidatePackets, null, null);
     assert.equal(simulationEvidence.adjustments.length, 0);
     assert.equal(evaluation.status, 'completed');
@@ -6462,7 +6461,7 @@ describe('phase 3 simulation re-ingestion — applySimulationMerge', () => {
     const path = makeExpandedPath('state-1', 0.60);
     const evaluation = makeEval('completed', [path]);
     const simOutcome = makeSimOutcome('state-1', [{ label: 'Oil energy supply shock', summary: 'Crude energy disruption', keyActors: [] }]);
-    const candidatePackets = [{ candidateStateId: 'state-1', routeFacilityKey: '', commodityKey: '', topBucketId: 'energy', topChannel: 'energy_supply_shock' }];
+    const candidatePackets = [{ candidateStateId: 'state-1', routeFacilityKey: '', commodityKey: '', marketContext: { topBucketId: 'energy', topChannel: 'energy_supply_shock' } }];
     const { simulationEvidence } = applySimulationMerge(evaluation, simOutcome, candidatePackets, null, null);
     assert.equal(simulationEvidence.outcomeRunId, 'sim-run-001');
     assert.equal(simulationEvidence.theaterCount, 1);
@@ -6486,7 +6485,7 @@ describe('phase 3 simulation re-ingestion — applySimulationMerge', () => {
         stabilizers: [],
       }],
     };
-    const candidatePackets = [{ candidateStateId, routeFacilityKey: 'Red Sea', commodityKey: 'crude_oil', topBucketId: 'energy', topChannel: 'energy_supply_shock' }];
+    const candidatePackets = [{ candidateStateId, routeFacilityKey: 'Red Sea', commodityKey: 'crude_oil', marketContext: { topBucketId: 'energy', topChannel: 'energy_supply_shock' } }];
     const { simulationEvidence } = applySimulationMerge(evaluation, simOutcome, candidatePackets, { generatedAt: Date.now(), impactExpansionCandidates: candidatePackets }, null);
     assert.equal(simulationEvidence.pathsDemoted, 1, 'path should be demoted via candidateStateId lookup');
     assert.equal(simulationEvidence.adjustments.length, 1);
@@ -6568,12 +6567,12 @@ describe('phase 3 simulation re-ingestion — matching helpers', () => {
   });
 
   it('negatesDisruption — non-maritime: rates_inflation bucket + negation term matches', () => {
-    const candidatePacket = { routeFacilityKey: '', commodityKey: '', stateKind: 'market_repricing', topBucketId: 'rates_inflation' };
+    const candidatePacket = { routeFacilityKey: '', commodityKey: '', stateKind: 'market_repricing', marketContext: { topBucketId: 'rates_inflation', topChannel: 'policy_rate_pressure' } };
     assert.ok(negatesDisruption('inflation pressures stabilized as Fed signals rate normalization', candidatePacket));
   });
 
   it('negatesDisruption — non-maritime: unrelated stateKind text does not match', () => {
-    const candidatePacket = { routeFacilityKey: '', commodityKey: '', stateKind: 'cyber_pressure', topBucketId: 'rates_inflation' };
+    const candidatePacket = { routeFacilityKey: '', commodityKey: '', stateKind: 'cyber_pressure', marketContext: { topBucketId: 'rates_inflation', topChannel: '' } };
     // stabilizer text mentions "shipping restored" but theater is cyber/rates — no keyword match
     assert.ok(!negatesDisruption('Red Sea shipping lanes restored to normal', candidatePacket));
   });


### PR DESCRIPTION
## Why this PR?

Five consecutive production bugs in the simulation merge pipeline were all caused by shape mismatches that TypeScript would have caught at write time:
- `candidatePacket.topBucketId` (wrong) vs `candidatePacket.marketContext.topBucketId` (correct) — PR #2404
- `commodityKey` underscore not normalized — PR #2410
- `candidateStateId` missing from `theaterResults` — PR #2374

This PR adds compile-time enforcement so these classes of bugs cannot recur silently.

## Changes

- **`scripts/seed-forecasts.types.d.ts`** (new): Ambient TypeScript interfaces for all simulation data structures. Includes inline comments documenting the production shape gotchas (e.g. `topBucketId` lives under `marketContext`, not at root level).
- **`scripts/jsconfig.json`** (new): Enables `tsc --checkJs` on `seed-forecasts.mjs`.
- **`scripts/seed-forecasts.mjs`**: Added `// @ts-check` + `/// <reference>` + JSDoc `@param`/`@returns` on `contradictsPremise`, `negatesDisruption`, `computeSimulationAdjustment`, `applySimulationMerge`. Removed dead legacy fallbacks `candidatePacket?.topBucketId` and `candidatePacket?.topChannel` (these fields were never at top level in production artifacts; TypeScript now enforces this).
- **`tests/forecast-trace-export.test.mjs`**: Updated all simulation test fixtures to use `marketContext: { topBucketId, topChannel }` — the correct production shape.

## Test plan

- [x] `npm run test:data` — 2434/2434 pass
- [x] `npx tsc --project scripts/jsconfig.json --noEmit` — zero simulation-related type errors