### PR TITLE
fix(mcp): use public CORS (*) so claude.ai and external MCP clients connect

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -1,7 +1,7 @@
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 // @ts-expect-error — JS module, no declaration file
-import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { getPublicCorsHeaders } from './_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { jsonResponse } from './_json-response.js';
 // @ts-expect-error — JS module, no declaration file
@@ -416,14 +416,11 @@ async function executeTool(tool: CacheToolDef): Promise<{ cached_at: string | nu
 // Main handler
 // ---------------------------------------------------------------------------
 export default async function handler(req: Request): Promise<Response> {
-  const corsHeaders = getCorsHeaders(req, 'POST, OPTIONS');
+  // MCP is a public API endpoint secured by API key — allow all origins (claude.ai, Claude Desktop, custom agents)
+  const corsHeaders = getPublicCorsHeaders('POST, OPTIONS');
 
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: corsHeaders });
-  }
-
-  if (isDisallowedOrigin(req)) {
-    return rpcError(null, -32001, 'Origin not allowed');
   }
 
   // Auth — always require API key (MCP clients are never same-origin browser requests)


### PR DESCRIPTION
## Root cause

`getCorsHeaders()` only allows worldmonitor.app origins. When claude.ai connects as an MCP client, it sends `Origin: https://claude.ai`, which:

1. Hits `isDisallowedOrigin()` → blocked with `-32001 Origin not allowed`
2. Even if it passed auth, `getCorsHeaders()` returns `Access-Control-Allow-Origin: https://worldmonitor.app` — browser CORS check rejects it

## Fix

Switch to `getPublicCorsHeaders()` (`ACAO: *`) and remove `isDisallowedOrigin` block.

**This is safe** — security is provided by `validateApiKey(req, { forceKey: true })` which requires a valid `X-WorldMonitor-Key` on every request. Origin-based restriction adds no security here and breaks all external MCP clients.

## Affected clients that were broken
- claude.ai web MCP connector
- Any browser-based MCP client
- Any client sending an `Origin` header not on the worldmonitor.app allowlist

## Test plan
- [ ] After deploy: connect claude.ai to `https://api.worldmonitor.app/mcp` — tools should appear
- [ ] `curl` with `Origin: https://claude.ai` header should return `ACAO: *`
- [ ] Bad API key still returns `-32001`