### PR TITLE
fix(simulation): expand CHANNEL_KEYWORDS bridge terms for geopolitical scenario language

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -11282,14 +11282,14 @@ const BUCKET_KEYWORDS = {
 };
 
 const CHANNEL_KEYWORDS = {
-  energy_supply_shock: ['oil supply', 'crude supply', 'energy supply', 'oil shock', 'energy shock', 'petroleum supply'],
+  energy_supply_shock: ['oil supply', 'crude supply', 'energy supply', 'oil shock', 'energy shock', 'petroleum supply', 'oil infrastructure', 'supply disruption', 'oil price spike', 'crude price', 'energy price'],
   gas_supply_stress: ['gas supply', 'lng supply', 'natural gas', 'gas price'],
   commodity_repricing: ['commodity', 'repricing', 'shortage', 'supply chain'],
   oil_macro_shock: ['oil macro', 'crude macro', 'oil price macro', 'petro macro'],
   global_crude_spread_stress: ['crude spread', 'brent wti', 'grade spread'],
-  shipping_cost_shock: ['shipping cost', 'freight cost', 'freight rate', 'route disruption', 'chokepoint', 'transit'],
+  shipping_cost_shock: ['shipping cost', 'freight cost', 'freight rate', 'route disruption', 'chokepoint', 'transit', 'shipping interrupt', 'rerouting', 'vessel', 'shipping lane', 'maritime'],
   sovereign_stress: ['sovereign', 'debt stress', 'default risk', 'credit stress', 'bond spread'],
-  risk_off_rotation: ['risk off', 'risk aversion', 'flight to safety', 'sell off', 'selloff', 'sell-off', 'capital flight', 'capital outflow', 'risk premium', 'avers', 'retreat', 'flight to'],
+  risk_off_rotation: ['risk off', 'risk aversion', 'flight to safety', 'sell off', 'selloff', 'sell-off', 'capital flight', 'capital outflow', 'risk premium', 'avers', 'retreat', 'flight to', 'sovereign risk', 'shockwave', 'shock wave', 'economic shock', 'contagion', 'spiral', 'crisis'],
   security_escalation: ['escalat', 'military action', 'conflict', 'war', 'strike', 'attack', 'military', 'geopolit'],
   yield_curve_stress: ['yield curve', 'yield spread', 'term premium'],
   volatility_shock: ['volatility', 'vix', 'vol spike'],

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -6510,6 +6510,22 @@ describe('phase 3 simulation re-ingestion — matching helpers', () => {
     assert.ok(matchesChannel({ label: 'Crude supply disruption energy', summary: '' }, 'energy_supply_shock'));
   });
 
+  it('matchesChannel energy_supply_shock matches oil infrastructure scenario (bridge keyword)', () => {
+    assert.ok(matchesChannel({ label: 'Oil infrastructure damage leads to supply disruption', summary: '' }, 'energy_supply_shock'));
+    assert.ok(matchesChannel({ label: 'Crude price spike from Persian Gulf closure', summary: '' }, 'energy_supply_shock'));
+  });
+
+  it('matchesChannel shipping_cost_shock matches maritime rerouting scenario (bridge keyword)', () => {
+    assert.ok(matchesChannel({ label: 'Tanker rerouting via Cape of Good Hope raises freight costs', summary: '' }, 'shipping_cost_shock'));
+    assert.ok(matchesChannel({ label: 'Vessel traffic diverted from Suez Canal shipping lane', summary: '' }, 'shipping_cost_shock'));
+  });
+
+  it('matchesChannel risk_off_rotation matches geopolitical sovereign risk scenario (bridge keyword)', () => {
+    assert.ok(matchesChannel({ label: 'Regional Conflict & Sovereign Risk Spiral', summary: 'rapid repricing of sovereign risk' }, 'risk_off_rotation'));
+    assert.ok(matchesChannel({ label: 'Global Economic Shockwave', summary: '' }, 'risk_off_rotation'));
+    assert.ok(matchesChannel({ label: 'Market contagion from India FX crisis', summary: '' }, 'risk_off_rotation'));
+  });
+
   it('matchesChannel returns false for unrelated text', () => {
     assert.ok(!matchesChannel({ label: 'Political talks', summary: 'Ceasefire' }, 'shipping_cost_shock'));
   });


### PR DESCRIPTION
## Summary

- Expands `CHANNEL_KEYWORDS` with bridge terms that connect simulation LLM scenario text (geopolitical language) to financial market channels
- `risk_off_rotation`: adds `sovereign risk`, `shockwave`, `shock wave`, `economic shock`, `contagion`, `spiral`, `crisis`
- `energy_supply_shock`: adds `oil infrastructure`, `supply disruption`, `oil price spike`, `crude price`, `energy price`
- `shipping_cost_shock`: adds `rerouting`, `vessel`, `shipping lane`, `maritime`

## Root Cause

The simulation LLM produces scenario paths like "Regional Conflict & Sovereign Risk Spiral" and "Global Economic Shockwave". The existing `risk_off_rotation` keywords only contained financial jargon ("risk off", "capital flight") which never appeared in geopolitical scenario text. This caused `matchesChannel` to return false, preventing `bucketChannelMatch=true` and blocking the +0.08 promotion bonus.

## Validation

Ran full pipeline locally 2x end-to-end:
- `node scripts/seed-forecasts.mjs` (enqueues sim + deep tasks)
- `node scripts/process-simulation-tasks.mjs --once` (runs LLM theater simulation)
- `node scripts/process-deep-forecast-tasks.mjs --once` (applies simulation merge)

Both runs confirmed `simulationEvidence.isCurrentRun=true` and `adjustments` array non-empty (invalidator demotion fired correctly).

## Test plan

- [x] 3 new `matchesChannel` bridge keyword tests added
- [x] 227/227 tests pass (`node --test tests/forecast-trace-export.test.mjs`)
- [x] Typecheck clean