### PR TITLE
fix(csp): skip null blocked URI from in-app browser iframe injections

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -354,6 +354,8 @@ window.addEventListener('securitypolicyviolation', (e) => {
   if (/_vercel\/insights\/script\.js/.test(blocked)) return;
   // Skip inline script blocks — browser extension or in-app browser injection, not actionable
   if (blocked === 'inline' && e.effectiveDirective === 'script-src-elem') return;
+  // Skip null blocked URI — in-app browsers (Baidu, WeChat, Instagram) inject null-src iframes
+  if (blocked === 'null') return;
   Sentry.captureMessage(`CSP: ${e.effectiveDirective} blocked ${blocked || '(inline)'}`, {
     level: 'warning',
     tags: { kind: 'csp_violation' },


### PR DESCRIPTION
## Summary
Adds a filter for `blockedURI === 'null'` CSP violations, which are generated by in-app browsers (Baidu, WeChat, Instagram) injecting null-src iframes into the page. Not actionable.

Resolves WORLDMONITOR-7370592325.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: frontend noise filter only.