### PR TITLE
fix(simulation): negatesDisruption missing legacy topBucketId fallback

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -11345,7 +11345,7 @@ function negatesDisruption(stabilizer, candidatePacket) {
   }
   // Non-maritime: match on stateKind and bucket keywords.
   const stateKind = candidatePacket?.stateKind || '';
-  const bucket = candidatePacket?.marketContext?.topBucketId || '';
+  const bucket = candidatePacket?.marketContext?.topBucketId || candidatePacket?.topBucketId || '';
   const subjectKeywords = [...stateKind.toLowerCase().split('_'), ...bucket.toLowerCase().split('_')]
     .filter((w) => w.length >= 4);
   return subjectKeywords.some((kw) => text.includes(kw));


### PR DESCRIPTION
## Why this PR?

Follow-up to #2422, flagged by Greptile in the review.

`negatesDisruption` non-maritime path read `candidatePacket?.marketContext?.topBucketId` only. Flat-schema packets (root-level `topBucketId`) always produced `bucket = ''`, so stabilizer negation never fired for non-maritime flat-schema candidates.

One-line fix: add `|| candidatePacket?.topBucketId` as legacy fallback — same pattern as the bucket fix in #2422.

Extracted from #2423 (closed — that PR had unrelated oauth changes, a false-positive `repricing` keyword, and reverted the `Object.hasOwn()` channel validation from #2422).