### PR TITLE
fix(oauth): use www.worldmonitor.app in discovery doc to match MCP URL

### DIFF
--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -1,6 +1,6 @@
 {
-  "issuer": "https://worldmonitor.app",
-  "token_endpoint": "https://worldmonitor.app/oauth/token",
+  "issuer": "https://www.worldmonitor.app",
+  "token_endpoint": "https://www.worldmonitor.app/oauth/token",
   "grant_types_supported": ["client_credentials"],
   "token_endpoint_auth_methods_supported": ["client_secret_post"],
   "scopes_supported": ["mcp"]


### PR DESCRIPTION
## Problem

claude.ai MCP connector was failing to connect. Two root causes:

1. **Wrong URL in connector** — `api.worldmonitor.app/mcp` routes to the Railway relay (returns 401). The MCP lives on Vercel at `https://www.worldmonitor.app/mcp`.

2. **RFC 8414 issuer mismatch** — `worldmonitor.app` 307-redirects to `www.worldmonitor.app`. The discovery doc was served from `www.worldmonitor.app/.well-known/oauth-authorization-server` but had `issuer: https://worldmonitor.app`. Per RFC 8414 §3, the issuer must match the URL it's served from — claude.ai rejects mismatches.

3. **Token endpoint redirect** — `token_endpoint` pointed to non-www, causing POST to 307 (POST→GET on redirect = broken OAuth flow).

## Fix

Update `.well-known/oauth-authorization-server` to use `https://www.worldmonitor.app` for both `issuer` and `token_endpoint`.

## Connector Setup

Configure the claude.ai MCP connector with:
- **URL**: `https://www.worldmonitor.app/mcp`
- **Auth**: OAuth 2.0 (client_credentials)
- **Client Secret**: your `WORLDMONITOR_VALID_KEYS` API key

## Post-Deploy Monitoring

No operational risk — static JSON file change. Verify with:
```
curl https://www.worldmonitor.app/.well-known/oauth-authorization-server
```
Expected: `issuer` = `https://www.worldmonitor.app`