### PR TITLE
fix(oauth): set issuer to api.worldmonitor.app to match MCP connector URL

### DIFF
--- a/public/.well-known/oauth-authorization-server
+++ b/public/.well-known/oauth-authorization-server
@@ -1,6 +1,6 @@
 {
-  "issuer": "https://www.worldmonitor.app",
-  "token_endpoint": "https://www.worldmonitor.app/oauth/token",
+  "issuer": "https://api.worldmonitor.app",
+  "token_endpoint": "https://api.worldmonitor.app/oauth/token",
   "grant_types_supported": ["client_credentials"],
   "token_endpoint_auth_methods_supported": ["client_secret_post"],
   "scopes_supported": ["mcp"]


### PR DESCRIPTION
## Problem

PR #2426 used `www.worldmonitor.app` as the issuer — still wrong. The MCP connector is configured at `https://api.worldmonitor.app/mcp`. Per RFC 8414, the issuer in the discovery doc must match the domain the doc is fetched from. claude.ai will fetch `https://api.worldmonitor.app/.well-known/oauth-authorization-server` and reject a mismatched issuer.

`api.worldmonitor.app` is behind Cloudflare and already proxies to Vercel — both `/mcp` and `/oauth/token` work there (verified: returns correct 401 with `WWW-Authenticate` header, not a Railway error).

## Fix

Update `issuer` and `token_endpoint` to `https://api.worldmonitor.app`.

## Connector setup (after merge)

- **URL**: `https://api.worldmonitor.app/mcp`
- **Auth**: OAuth 2.0 / client_credentials  
- **Client Secret**: API key from `WORLDMONITOR_VALID_KEYS`

## Post-Deploy Validation

```bash
curl https://api.worldmonitor.app/.well-known/oauth-authorization-server
# Expected: issuer = "https://api.worldmonitor.app"
```