### PR TITLE
fix(intelligence): extend country intel brief cache TTL 2h → 6h

### DIFF
--- a/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
@@ -10,7 +10,7 @@ import { callLlm } from '../../../_shared/llm';
 import { isCallerPremium } from '../../../_shared/premium-check';
 import { sanitizeForPrompt } from '../../../_shared/llm-sanitize.js';
 
-const INTEL_CACHE_TTL = 7200;
+const INTEL_CACHE_TTL = 21600;
 
 export async function getCountryIntelBrief(
   ctx: ServerContext,


### PR DESCRIPTION
## Summary

- Extend `INTEL_CACHE_TTL` from `7200` (2h) to `21600` (6h) in `get-country-intel-brief.ts`
- Country intel briefs are grounded in seeded world-state data (CII scores, conflict events, infrastructure) that changes slowly — 2h TTL was causing unnecessary LLM cold starts on every seeder cycle
- 6h matches the effective rate of meaningful context change; all users clicking the same country within that window share the same cached response

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS (warnings pre-existing, 0 errors)
- [x] `npm run lint` — PASS
- [x] `npm run test:data` — 2442 pass, 0 fail
- [x] `node --test tests/edge-functions.test.mjs` — PASS
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK