### PR TITLE
feat(simulation): post-simulation re-score to fix stale-sim pipeline sequencing

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -16158,14 +16158,16 @@ async function applyPostSimulationRescore(runId, freshOutcome, storageConfig) {
 
     // Only re-score if there is actionable opportunity:
     // - 'completed_no_material_change': always proceed — any simulation evidence could promote a rejected path
-    // - 'completed': proceed if (a) a selected expanded path risks demotion (acceptanceScore < 0.62
-    //   means a -0.12 invalidator could push it below 0.50), or (b) a rejected expanded path is
-    //   near-threshold (0.42–0.50) and could be promoted via +0.08 bucketChannelMatch into CASE 3.
+    // - 'completed': proceed if (a) a selected expanded path risks demotion, or (b) a rejected expanded
+    //   path could be promoted. Thresholds are derived from the max adjustments in computeSimulationAdjustment:
+    //     max positive: +0.08 (bucketChannelMatch) + 0.04 (actor overlap >= 2) = +0.12
+    //     max negative: -0.15 (stabilizer) — larger than invalidator -0.12
+    //   Demotion risk threshold: 0.50 + 0.15 = 0.65. Promotion window: [0.50 - 0.12, 0.50) = [0.38, 0.50).
     const hasDemotionRisk = (evalData.selectedPaths || []).some(
-      (p) => p.type === 'expanded' && p.acceptanceScore < 0.62,
+      (p) => p.type === 'expanded' && p.acceptanceScore < 0.65,
     );
     const hasPromotionOpportunity = (evalData.rejectedPaths || []).some(
-      (p) => p.type === 'expanded' && p.acceptanceScore >= 0.42 && p.acceptanceScore < SIMULATION_MERGE_ACCEPT_THRESHOLD,
+      (p) => p.type === 'expanded' && p.acceptanceScore >= 0.38 && p.acceptanceScore < SIMULATION_MERGE_ACCEPT_THRESHOLD,
     );
     if (evalData.status !== 'completed_no_material_change' && !hasDemotionRisk && !hasPromotionOpportunity) {
       return { skipped: true, reason: 'no_actionable_paths' };

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -6949,6 +6949,98 @@ describe('phase 3 simulation re-ingestion — applyPostSimulationRescore', () =>
     assert.ok(!rejectedIds.includes(stateA), 'promoted path removed from rejectedPaths');
   });
 
+  it('R-8: applySimulationMerge promotes path at 0.39 via +0.12 (bucketChannelMatch + actor overlap)', () => {
+    // Boundary: old guard required >= 0.42; correct lower bound is 0.38 (= 0.50 - 0.12 max bonus).
+    // Path at 0.39 + 0.08 (bucketChannelMatch) + 0.04 (2 shared actors) = 0.51 → promoted.
+    const stateA = 'state-r8a';
+    const stateB = 'state-r8b';
+    const candidateA = makeRescoreCandidatePacket(stateA);
+    const candidateB = makeRescoreCandidatePacket(stateB);
+    // Override affectedAssets with 2 actors that will also appear in topPath.keyActors
+    const pathA = {
+      ...makeRescorePath(stateA, 0.39),
+      candidate: candidateA,
+      direct: { variableKey: 'route_disruption', targetBucket: '', channel: 'supply_disruption', affectedAssets: ['Red Sea Oil Tankers', 'Saudi Aramco'] },
+    };
+    const pathB = { ...makeRescorePath(stateB, 0.75), candidate: candidateB };
+    const evaluation = {
+      status: 'completed_no_material_change',
+      selectedPaths: [pathB],
+      rejectedPaths: [pathA],
+      impactExpansionBundle: null,
+      deepWorldState: null,
+    };
+    const simOutcome = {
+      runId: 'sim-r8',
+      isCurrentRun: true,
+      theaterResults: [{
+        theaterId: 'theater-1',
+        candidateStateId: stateA,
+        // Summary matches energy bucket + energy_supply_shock channel; keyActors match path actors (2 overlap → +0.04)
+        topPaths: [{ label: 'Oil Supply Shock', summary: 'oil supply disruption from Red Sea energy shock', keyActors: ['Red Sea Oil Tankers', 'Saudi Aramco'] }],
+        invalidators: [],
+        stabilizers: [],
+      }],
+    };
+    const snapshot = {
+      ...makeRescoreSnapshot(stateA),
+      impactExpansionCandidates: [candidateA, candidateB],
+    };
+    const { evaluation: updatedEval, simulationEvidence } = applySimulationMerge(
+      evaluation, simOutcome, snapshot.impactExpansionCandidates, snapshot, null,
+    );
+    const adj = simulationEvidence.adjustments.find((a) => a.candidateStateId === stateA);
+    assert.ok(adj, 'adjustment entry for stateA');
+    assert.equal(adj.details.actorOverlapCount, 2, 'two actors overlap → +0.04 applied');
+    assert.equal(adj.simulationAdjustment, 0.12, 'total adjustment is +0.12');
+    assert.equal(simulationEvidence.pathsPromoted, 1, 'path at 0.39 should be promoted');
+    assert.ok(updatedEval.selectedPaths.some((p) => p.candidateStateId === stateA), 'promoted path in selectedPaths');
+  });
+
+  it('R-9: applySimulationMerge demotes path at 0.64 via -0.15 stabilizer (boundary above old 0.62 guard)', () => {
+    // Boundary: old guard required < 0.62; correct upper bound is 0.65 (= 0.50 + 0.15 max stabilizer).
+    // Path at 0.64 - 0.15 (stabilizer) = 0.49 → demoted. Second path at 0.75 stays; CASE 3 fires.
+    const stateA = 'state-r9a'; // 0.64 — at risk from stabilizer but above old 0.62 threshold
+    const stateB = 'state-r9b'; // 0.75 — safe
+    const candidateA = makeRescoreCandidatePacket(stateA);
+    const candidateB = makeRescoreCandidatePacket(stateB);
+    const pathA = { ...makeRescorePath(stateA, 0.64), candidate: candidateA };
+    const pathB = { ...makeRescorePath(stateB, 0.75), candidate: candidateB };
+    const evaluation = {
+      status: 'completed',
+      selectedPaths: [pathA, pathB],
+      rejectedPaths: [],
+      impactExpansionBundle: null,
+      deepWorldState: null,
+    };
+    const simOutcome = {
+      runId: 'sim-r9',
+      isCurrentRun: true,
+      theaterResults: [{
+        theaterId: 'theater-1',
+        candidateStateId: stateA,
+        topPaths: [],
+        invalidators: [],
+        // stabilizer matches routeFacilityKey='Red Sea' + contains negation term 'normaliz' → -0.15
+        stabilizers: ['red sea shipping lanes normaliz'],
+      }],
+    };
+    const snapshot = {
+      ...makeRescoreSnapshot(stateA),
+      impactExpansionCandidates: [candidateA, candidateB],
+    };
+    const { evaluation: updatedEval, simulationEvidence } = applySimulationMerge(
+      evaluation, simOutcome, snapshot.impactExpansionCandidates, snapshot, null,
+    );
+    const adj = simulationEvidence.adjustments.find((a) => a.candidateStateId === stateA);
+    assert.ok(adj, 'adjustment entry for stateA');
+    assert.equal(adj.simulationAdjustment, -0.15, 'stabilizer applies -0.15');
+    assert.equal(simulationEvidence.pathsDemoted, 1, 'path at 0.64 should be demoted');
+    assert.equal(updatedEval.status, 'completed', 'status stays completed — stateB still selected');
+    assert.ok(!updatedEval.selectedPaths.some((p) => p.candidateStateId === stateA), 'demoted path removed');
+    assert.ok(updatedEval.selectedPaths.some((p) => p.candidateStateId === stateB), 'safe path remains');
+  });
+
   it('R-5: simulation adjustments use marketContext fallback when direct.channel is an LLM-generated invalid key', () => {
     // supply_disruption is not in CHANNEL_KEYWORDS — should fall back to marketContext.topChannel=energy_supply_shock
     const stateId = 'state-r5';


### PR DESCRIPTION
## Why this PR

The deep forecast worker always runs before the current run's simulation completes. When `applySimulationMerge` reads from Redis, it gets a prior-run simulation (`isCurrentRun=false`). The prior run's `candidateStateId`s don't match the current run's paths, so `simByTheater.get(path.candidateStateId)` returns `undefined` for every path → `adjustments=[]`, `bucketChannelMatch` never fires, near-threshold rejected paths stay rejected.

This means all the channel/bucket fixes in PR #2422 were correct but could never fire in production due to this sequencing gap.

## Fix: fire-and-forget post-simulation re-score (Option A)

After `writeSimulationOutcome` + `completeSimulationTask`, `processNextSimulationTask` fires `applyPostSimulationRescore` in the background. No latency added to the simulation run itself.

**New `forecast-eval.json` artifact** — stores full `selectedPaths` + `rejectedPaths` (including `direct/second/third` hypothesis data) so the re-score can:
- Run `computeSimulationAdjustment` with the same path data the deep worker used
- Rebuild the impact expansion bundle for promoted paths (needed for world state update)

**`applyPostSimulationRescore`** — reads `forecast-eval.json` + snapshot from R2, reconstructs evaluation, runs `applySimulationMerge` with `isCurrentRun: true`, re-writes trace artifacts if paths changed.

**Guard**: only re-scores when `status='completed_no_material_change'` OR a rejected expanded path has `acceptanceScore` in 0.42–0.50 (within reach of +0.08 `bucketChannelMatch` bonus). Skips silently otherwise.

## Tests

R-1 through R-5 covering:
- Skip conditions (null storageConfig, empty theaterResults)
- No-change case (adjustment computes but no promotion/demotion)
- Path promotion: near-threshold rejected path (0.44) gets +0.08 → 0.52 → promoted, evaluation status → `completed`
- `marketContext` fallback: `supply_disruption` (invalid LLM key) falls back to `marketContext.topChannel=energy_supply_shock` → `bucketChannelMatch=true`

238 tests pass.