### PR TITLE
fix(seeder): surface FRED 0-series failure in health + logs

### DIFF
--- a/scripts/seed-economy.mjs
+++ b/scripts/seed-economy.mjs
@@ -550,7 +550,7 @@ async function fetchAll() {
   // Write secondary keys BEFORE returning (runSeed calls process.exit after primary write)
   if (ec?.series?.length > 0) await writeExtraKeyWithMeta(KEYS.energyCapacity, ec, CAPACITY_TTL, ec.series.length);
 
-  if (fr) {
+  if (frHasData) {
     for (const [seriesId, series] of Object.entries(fr)) {
       await writeExtraKeyWithMeta(`${FRED_KEY_PREFIX}:${seriesId}:0`, { series }, FRED_TTL, series.observations?.length ?? 0);
     }


### PR DESCRIPTION
## Summary
- Log actual rejection reason when a FRED series fetch fails (was logging generic "fetch failed" with no details)
- Warn explicitly when all 22 FRED series return empty (0/22 case) so the failure is visible in relay logs
- Fix truthiness guard: `fetchFredSeries()` returns `{}` on total failure, which is truthy — `!fr` never fired, so the "all fetches failed" error never threw when FRED was down but EIA/Macro succeeded

## Root cause
When all 22 FRED series fail, `fetchFredSeries()` returns an empty object `{}`. The guard `if (!ep && !fr && !ms)` evaluates `!fr` as `false` (empty object is truthy), so the seeder exits successfully. FRED panels then silently retain stale Redis data until the 26h TTL expires. Health shows `STALE_SEED` (warning) rather than `DEGRADED` until keys fully expire.

## Test plan
- [ ] Deploy relay — next 15-min run should log actual FRED failure reason (HTTP status, error message) if FRED_API_KEY or PROXY_URL is misconfigured
- [ ] If FRED was failing due to transient issue: logs will show 22/22 series fetched again
- [ ] With the truthiness fix: when FRED fails but EIA+Macro succeed, seeder still completes (other data written) — but FRED panels will reflect stale state more visibly in logs