### PR TITLE
fix(forecast): style Analysis Signals expanded panel in probability bets

### DIFF
--- a/src/components/ForecastPanel.ts
+++ b/src/components/ForecastPanel.ts
@@ -194,9 +194,10 @@ function injectStyles(): void {
     .fc-perspective { font-size: 11px; color: var(--text-secondary, #999); padding: 2px 0; line-height: 1.4; }
     .fc-perspective strong { color: var(--text-primary, #ccc); font-weight: 600; }
     .fc-scenario { font-style: italic; }
-    .fc-signals { margin-top: 2px; }
-    .fc-signal { color: var(--text-secondary, #999); font-size: 11px; padding: 1px 0; }
-    .fc-signal::before { content: ''; display: inline-block; width: 6px; height: 1px; background: var(--text-secondary, #666); margin-right: 6px; vertical-align: middle; }
+    .fc-signals { padding: 8px 14px 4px; border-top: 1px solid var(--border-color, #2a2a2a); display: grid; gap: 2px; }
+    .fc-signals-title { color: var(--text-secondary, #888); font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 4px; }
+    .fc-signal { color: var(--text-secondary, #a0a0a0); font-size: 11px; padding: 3px 0 3px 12px; line-height: 1.45; position: relative; }
+    .fc-signal::before { content: ''; position: absolute; left: 0; top: 9px; display: inline-block; width: 6px; height: 1px; background: var(--text-secondary, #555); }
     .fc-empty { padding: 20px; text-align: center; color: var(--text-secondary, #888); }
   `;
   document.head.appendChild(style);
@@ -431,9 +432,12 @@ export class ForecastPanel extends Panel {
     const trendText  = f.trend === 'rising' ? '↑ rising' : f.trend === 'falling' ? '↓ falling' : '→ stable';
     const trendColor = f.trend === 'rising' ? '#3fb950' : f.trend === 'falling' ? '#e05252' : '#7d8590';
 
-    const signalsHtml = (f.signals || []).map(s =>
-      `<div class="fc-signal">${escapeHtml(s.value)}</div>`
-    ).join('');
+    const sigs = f.signals || [];
+    const signalsHtml = sigs.length > 0
+      ? `<div class="fc-signals-title">Analysis Signals (${sigs.length})</div>${sigs.map(s =>
+          `<div class="fc-signal">${escapeHtml(s.value.replace(/^[\s\u2013\u2014\-]+/, ''))}</div>`
+        ).join('')}`
+      : '';
 
     return `
       <div class="fc-prob-item">
@@ -456,7 +460,7 @@ export class ForecastPanel extends Panel {
         </div>
         <div class="fc-toggle-row">
           <span class="fc-toggle" data-fc-toggle="detail-${escapeHtml(f.id)}">Analysis</span>
-          ${(f.signals || []).length > 0 ? `<span class="fc-toggle" data-fc-toggle="signals-${escapeHtml(f.id)}">Signals (${(f.signals || []).length})</span>` : ''}
+          ${sigs.length > 0 ? `<span class="fc-toggle" data-fc-toggle="signals-${escapeHtml(f.id)}">Signals (${sigs.length})</span>` : ''}
         </div>
         <div class="fc-detail fc-hidden" data-fc-panel="detail-${escapeHtml(f.id)}">${this.renderDetailBody(f)}</div>
         ${signalsHtml ? `<div class="fc-signals fc-hidden" data-fc-panel="signals-${escapeHtml(f.id)}">${signalsHtml}</div>` : ''}


### PR DESCRIPTION
## Summary
- `fc-signals` container had `margin-top: 2px` only — looked like raw unstyled text below the toggle row
- Signals are now wrapped in a styled container matching `fc-detail` (padding + border-top)
- Section title "ANALYSIS SIGNALS (N)" rendered inside the collapsible panel (not just on the toggle button)
- Signal items: indented with `padding-left: 12px`, positioned `::before` dash indicator, proper line-height
- Strips leading `–`, `—`, `-` characters from signal values to prevent double-dash rendering (LLM outputs already include dash prefixes)

## Before / After
**Before:** Plain monospace text floated below the toggle row with no visual container  
**After:** Labeled section with padding, border separator, and properly spaced list items

## Test plan
- [ ] Hover over a probability bet row: toggle row shows "Analysis" and "Signals (N)"
- [ ] Click "Signals (N)": panel expands with "ANALYSIS SIGNALS (N)" title and indented items
- [ ] Click "Analysis": detail panel expands with structured sections as before
- [ ] Both panels can be open simultaneously