### PR TITLE
fix(wingbits): clamp bbox to valid geographic ranges to prevent 400 errors

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3421,10 +3421,16 @@ async function handleWingbitsTrackRequest(req, res) {
       JSON.stringify({ error: 'Invalid bbox params: must be finite numbers', positions: [] }));
   }
 
-  const centerLat = (lamin + lamax) / 2;
-  const centerLon = (lomin + lomax) / 2;
-  const widthNm = Math.min(Math.abs(lomax - lomin) * 60 * Math.cos(centerLat * Math.PI / 180), WINGBITS_MAX_BOX_NM);
-  const heightNm = Math.min(Math.abs(lamax - lamin) * 60, WINGBITS_MAX_BOX_NM);
+  // Clamp bbox to valid geographic ranges before computing center.
+  // Map projections can produce slightly out-of-range values; Wingbits rejects la outside [-90,90].
+  const clampedLamin = Math.max(-90, Math.min(90, lamin));
+  const clampedLamax = Math.max(-90, Math.min(90, lamax));
+  const clampedLomin = Math.max(-180, Math.min(180, lomin));
+  const clampedLomax = Math.max(-180, Math.min(180, lomax));
+  const centerLat = (clampedLamin + clampedLamax) / 2;
+  const centerLon = (clampedLomin + clampedLomax) / 2;
+  const widthNm = Math.min(Math.abs(clampedLomax - clampedLomin) * 60 * Math.cos(centerLat * Math.PI / 180), WINGBITS_MAX_BOX_NM);
+  const heightNm = Math.min(Math.abs(clampedLamax - clampedLamin) * 60, WINGBITS_MAX_BOX_NM);
   const areas = [{ alias: 'viewport', by: 'box', la: centerLat, lo: centerLon, w: widthNm, h: heightNm, unit: 'nm' }];
 
   try {


### PR DESCRIPTION
## Summary

- Wingbits API returns HTTP 400 with Zod `too_small` error when `la < -90` (latitude out of range)
- Root cause: map projection can produce `lamin`/`lamax` outside `[-90, 90]` on wide viewports; the existing `isFinite` check passes these through unchanged
- Fix: clamp all four bbox values to valid geographic ranges (`lat → [-90,90]`, `lon → [-180,180]`) before computing `centerLat`/`centerLon` and constructing the Wingbits payload

## Test plan

- [ ] Drag map to a very zoomed-out view — no more 400 errors in relay logs for `[Wingbits Track]`
- [ ] Normal viewport bbox still works correctly
- [ ] Polar regions (lat near ±90) handled gracefully