### PR TITLE
fix(seeder): force HTTP/1.1 ALPN in proxy tunnel to prevent h2 parse error

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -408,7 +408,7 @@ async function httpsProxyFetchJson(url, proxyAuth) {
 // Fetch JSON from a FRED URL, routing through proxy when available.
 export async function fredFetchJson(url, proxyAuth) {
   try {
-    const r = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(10_000) });
+    const r = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(20_000) });
     if (r.ok) return r.json();
     throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
   } catch (directErr) {


### PR DESCRIPTION
## Summary
- After PR #2451, the direct path works for 21/22 FRED series
- WALCL fails with `Parse Error: Expected HTTP/, RTSP/ or ICE/` — this is the proxy fallback path
- `api.stlouisfed.org` supports HTTP/2; `tls.connect()` includes `h2` in ALPN by default
- Server negotiates HTTP/2, but `https.request` uses HTTP/1.1 parser → binary h2 frames fail with parse error

## Fix
Add `ALPNProtocols: ['http/1.1']` to `tls.connect()` in `httpsProxyFetchJson` — forces HTTP/1.1 negotiation over the proxy tunnel.

## Test plan
- [ ] Deploy relay — next cron should show `FRED series: 22/22`
- [ ] No more `Parse Error: Expected HTTP/` in logs