### PR TITLE
fix(deps): patch node-forge, srvx, yaml via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14553,6 +14553,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -29241,6 +29250,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -129,8 +129,7 @@
   "overrides": {
     "fast-xml-parser": "^5.3.7",
     "serialize-javascript": "^7.0.4",
-    "node-forge": "1.4.0",
-    "srvx": "0.11.13",
-    "yaml": "2.8.3"
+    "node-forge": "^1.4.0",
+    "srvx": "^0.11.13"
   }
 }


### PR DESCRIPTION
## Why

17 open Dependabot alerts (9 HIGH, 8 MEDIUM) — all transitive. Upstream packages haven't pinned the patched versions yet.

## What's patched

**Via npm overrides** (upstream packages don't yet enforce the patched versions):

| Package | Vuln | From | To |
|---------|------|------|----|
| `node-forge` | Cert chain bypass, Ed25519/RSA forgery, BigInt DoS (4× HIGH) | `1.3.3` | `^1.4.0` |
| `srvx` | Middleware bypass via absolute URI (MEDIUM) | `0.11.9` | `^0.11.13` |

Dependency chain: `@vercel/analytics` → `nuxt` → `@nuxt/cli` → `listhen` → `node-forge` / `srvx`

**Via natural semver resolution** (no override needed — already resolved by existing `^` ranges):

| Package | Vuln | Result |
|---------|------|--------|
| `yaml` | Stack overflow via deeply nested YAML (MEDIUM) | `2.8.3` resolved by vite/nuxt's `^2.x` range |

Note: `cosmiconfig@7` retains its own nested `yaml@1.10.3` (requires `^1.10.0`) — untouched.

## What's NOT patched (intentional)

- **picomatch** (9 alerts, HIGH/MEDIUM): exists in both v2 and v4 majors. Forcing v4 globally breaks `micromatch@4` which requires v2 API. These are build-only tools — no untrusted input reaches glob patterns at runtime.
- **brace-expansion** (1 alert, MEDIUM): vulnerable version is `1.x`, patched version is `5.x` — cross-major override would break consumers expecting v1/v2 API. Also build-only.
- **yaml `1.10.3`** (via cosmiconfig@7): left intact — cross-major jump to v2 would break cosmiconfig's config parser.

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run typecheck:api` — pass
- [x] `npm run lint` — pass (warnings pre-existing)
- [x] `npm ls node-forge srvx` confirms `overridden` markers on both
- [x] `npm install --package-lock-only --ignore-scripts` produces no diff — lockfile is reproducible