### PR TITLE
perf(map): request high-performance GPU for MapLibre canvas context

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -687,6 +687,7 @@ export class DeckGLMap {
       renderWorldCopies: false,
       attributionControl: false,
       interactive: true,
+      canvasContextAttributes: { powerPreference: 'high-performance' },
       ...(MAP_INTERACTION_MODE === 'flat'
         ? {
           maxPitch: 0,
@@ -715,6 +716,7 @@ export class DeckGLMap {
         renderWorldCopies: false,
         attributionControl: false,
         interactive: true,
+        canvasContextAttributes: { powerPreference: 'high-performance' },
         ...(MAP_INTERACTION_MODE === 'flat'
           ? {
             maxPitch: 0,


### PR DESCRIPTION
## Summary

- Adds `canvasContextAttributes: { powerPreference: 'high-performance' }` to both MapLibre `Map` constructors in `DeckGLMap` (primary style and fallback recreation path)
- Hints the browser to prefer the dedicated GPU on dual-GPU systems (e.g. MacBook with Intel + AMD/NVIDIA)
- No conditional needed since `DeckGLMap` is desktop-only by design (mobile degrades to D3/SVG map)
- Sourced from seilorjunior/worldmonitor@dce4d0c (issue #930); the other changes in that commit (RAF coalescing, `antialias: false`, unconditional `powerPreference` on GlobeMap) were rejected as they duplicate or downgrade existing logic

## Test plan

- [ ] Verified no TypeScript errors
- [ ] All 2509 unit/data tests pass
- [ ] Edge function bundle + isolation tests pass
- [ ] No lint or markdown errors
- [ ] On a dual-GPU machine, confirm the flat map renders on the discrete GPU (check via GPU activity monitor or `WEBGL_debug_renderer_info`)