### PR TITLE
feat(forecasts): EMA-based threat velocity spike detection

### DIFF
--- a/scripts/_ema-threat-engine.mjs
+++ b/scripts/_ema-threat-engine.mjs
@@ -36,23 +36,17 @@ function normalizeCountry(name) {
 
 /**
  * @param {number[]} window
- * @returns {{ ema: number, mean: number, stddev: number }}
+ * @returns {{ mean: number, stddev: number }}
  */
 export function computeWindowStats(window) {
-  if (window.length === 0) return { ema: 0, mean: 0, stddev: 0 };
+  if (window.length === 0) return { mean: 0, stddev: 0 };
 
   const mean = window.reduce((s, v) => s + v, 0) / window.length;
 
   const variance = window.reduce((s, v) => s + (v - mean) ** 2, 0) / window.length;
   const stddev = Math.sqrt(variance);
 
-  const last = window[window.length - 1] ?? 0;
-  let ema = window[0] ?? 0;
-  for (let i = 1; i < window.length; i++) {
-    ema = ALPHA * window[i] + (1 - ALPHA) * ema;
-  }
-
-  return { ema, mean, stddev };
+  return { mean, stddev };
 }
 
 /**

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -950,7 +950,7 @@ function detectConflictScenarios(inputs, emaRiskScores) {
         value: `EMA z-score: ${emaRisk.zscore.toFixed(1)} (${emaRisk.risk24h}/100 risk)`,
         weight: 0.35,
       });
-      prob = Math.min(0.99, (prob ?? 0) + 0.08);
+      prob = Math.min(0.99, prob + 0.08);
       sourceCount++;
     }
 
@@ -14806,6 +14806,8 @@ async function updateEmaWindows(inputs, url, token) {
   const ttl = 26 * 3600;
   await redisCommand(url, token, ['SET', 'conflict:ema-windows:v1', JSON.stringify(windowsObj), 'EX', ttl])
     .catch(err => console.warn(`  [EMA] Failed to persist windows: ${err.message}`));
+  await redisCommand(url, token, ['SET', 'seed-meta:conflict:ema-windows:v1', JSON.stringify({ fetchedAt: new Date().toISOString(), recordCount: updatedWindows.size }), 'EX', ttl])
+    .catch(err => console.warn(`  [EMA] Failed to persist seed-meta: ${err.message}`));
 
   const spikeCount = [...riskScores.values()].filter(r => r.velocitySpike).length;
   if (spikeCount > 0) {


### PR DESCRIPTION
## Summary

- Adds `scripts/_ema-threat-engine.mjs`: pure-math module (no I/O) with `updateWindow`, `computeWindowStats`, `computeEmaWindows`, and `computeRisk24h` — all `@ts-check` annotated
- Enriches `seed-forecasts.mjs` with EMA velocity signals: ACLED and EMA-windows keys added to the Redis pipeline batch, windows persisted with 26h TTL, and `velocity_spike` signals injected into `detectConflictScenarios` and `detectUcdpConflictZones` (weight 0.35, +0.08 prob boost, triggers at risk24h >= 75)
- EMA uses `ALPHA=0.3`, 24-entry sliding window, population stddev; z-score guards against stddev=0

## Test plan

- [ ] `node --input-type=module --eval "import('./scripts/_ema-threat-engine.mjs').then(m => console.log(Object.keys(m)))"` prints all 4 exports
- [ ] `npm run typecheck` and `npm run typecheck:api` pass clean
- [ ] Velocity spike log line appears in Railway seed-forecasts logs when any country crosses risk24h >= 75
- [ ] Forecasts for high-CII countries with recent event spikes show `velocity_spike` signal in the signals array