### PR TITLE
docs: health and climate variant full implementation plans

### DIFF
--- a/docs/climate-variant-full.md
+++ b/docs/climate-variant-full.md
@@ -227,8 +227,8 @@ message IceTrendPoint {
 |--------|----------|-----|-----|
 | `seed-climate-anomalies.mjs` | Every 3h (existing, fix baseline) | `climate:anomalies:v1` | 3h |
 | `seed-co2-monitoring.mjs` | Daily 06:00 UTC | `climate:co2-monitoring:v1` | 24h |
-| `seed-climate-disasters.mjs` | Every 6h | `climate:disasters:v1` | 12h |
-| `seed-health-air-quality.mjs` | Every 1h (shared) | `climate:air-quality:v1` | 3h |
+| `seed-climate-disasters.mjs` | Every 6h | `climate:disasters:v1` | 6h |
+| `seed-health-air-quality.mjs` | Every 1h (shared) | `climate:air-quality:v1` | 1h |
 | `seed-climate-ocean-ice.mjs` | Daily 08:00 UTC | `climate:ocean-ice:v1` | 24h |
 | `seed-climate-news.mjs` | Every 30min (or relay loop) | `climate:news-intelligence:v1` | 1h |
 
@@ -261,16 +261,24 @@ service ClimateService {
 
 ## Cache Keys to Register
 
-In `server/_shared/cache-keys.ts` and `api/health.js` BOOTSTRAP_KEYS:
+Per AGENTS.md, adding a new seeded key requires changes in **4 files**:
+
+1. **`server/_shared/cache-keys.ts`** — add to `BOOTSTRAP_CACHE_KEYS`:
 
 ```ts
-// Add to BOOTSTRAP_CACHE_KEYS:
 co2Monitoring: 'climate:co2-monitoring:v1',
 climateDisasters: 'climate:disasters:v1',
 climateAirQuality: 'climate:air-quality:v1',
 oceanIce: 'climate:ocean-ice:v1',
 climateNews: 'climate:news-intelligence:v1',
+climateZoneNormals: 'climate:zone-normals:v1',
 ```
+
+2. **`api/health.js`** — add each data key (not zone-normals) to the `BOOTSTRAP_KEYS` array (startup hydration on deploy)
+
+3. **`api/mcp.ts`** — add keys to the `get_climate_data` tool's `_cacheKeys` array (see MCP Tool section below)
+
+4. **Each seed script** — must call `runSeed()` with the correct canonical key so it writes `seed-meta:<domain>:<name>` automatically. The seed-meta key is required for health monitoring (`_seedMetaKey` in the MCP tool).
 
 ---
 
@@ -327,12 +335,12 @@ Replace current entry in `api/mcp.ts`:
 
 ```js
 // WRONG (current): compare last 7d vs previous 23d of same 30d window
-// RIGHT: compare last 7d vs 30-year monthly mean (1991–2020)
+// RIGHT: compare last 7d vs 30-year monthly mean (1991–2020 WMO standard)
 
-// Open-Meteo archive supports this:
-const REFERENCE_YEARS = Array.from({length: 10}, (_, i) => 2014 + i); // 2014-2023 (decade proxy for 30yr normal)
-// Or fetch 1991-2020 mean by requesting archive with start_date/end_date spanning 30 years
-// and grouping by calendar month. Cache this reference data separately.
+// Implementation: fetch Open-Meteo archive with start_date=1991-01-01 end_date=2020-12-31,
+// aggregate daily values by calendar month to get monthly mean per zone.
+// IMPORTANT: use the full 1991-2020 period — do NOT use a shorter "proxy" window
+// (e.g., 2014-2023) as a warm decade would systematically understate current anomalies.
 const NORMALS_KEY = 'climate:zone-normals:v1';
 const NORMALS_TTL = 30 * 86400; // 30 days — recalculate monthly
 ```

--- a/docs/health-variant-full.md
+++ b/docs/health-variant-full.md
@@ -82,6 +82,7 @@ message DataPoint {
 
 ```proto
 message VaccinationCoverageItem {
+  string id = 1;                // "{country_code}:{vaccine}:{year}"
   string country_code = 2;
   string country = 3;
   string vaccine = 4;           // "MCV1", "DTP3", etc.
@@ -187,7 +188,7 @@ message PathogenAlert {
 | `seed-vpd-tracker.mjs` | Daily (existing) | `health:vpd-tracker:realtime:v1` | 72h |
 | `seed-epidemic-trends.mjs` | Daily | `health:epidemic-trends:v1` | 24h |
 | `seed-vaccination-coverage.mjs` | Weekly (Sunday 02:00 UTC) | `health:vaccination-coverage:v1` | 7 days |
-| `seed-health-air-quality.mjs` | Every 1h | `health:air-quality:v1` | 3h |
+| `seed-health-air-quality.mjs` | Every 1h | `health:air-quality:v1` | 1h |
 | `seed-pathogen-surveillance.mjs` | Every 12h | `health:pathogen-surveillance:v1` | 24h |
 | `seed-health-news.mjs` | Every 30min (or relay loop) | `health:news-intelligence:v1` | 1h |
 
@@ -221,16 +222,23 @@ service HealthService {
 
 ## Cache Keys to Register
 
-In `server/_shared/cache-keys.ts` and `api/health.js` BOOTSTRAP_KEYS:
+Per AGENTS.md, adding a new seeded key requires changes in **4 files**:
+
+1. **`server/_shared/cache-keys.ts`** — add to `BOOTSTRAP_CACHE_KEYS`:
 
 ```ts
-// Add to BOOTSTRAP_CACHE_KEYS:
 epidemicTrends: 'health:epidemic-trends:v1',
 vaccinationCoverage: 'health:vaccination-coverage:v1',
 airQuality: 'health:air-quality:v1',
 pathogenSurveillance: 'health:pathogen-surveillance:v1',
 healthNews: 'health:news-intelligence:v1',
 ```
+
+2. **`api/health.js`** — add each key to the `BOOTSTRAP_KEYS` array (startup hydration on deploy)
+
+3. **`api/mcp.ts`** — add keys to the relevant MCP tool's `_cacheKeys` array (see MCP Tool section below)
+
+4. **Each seed script** — must call `runSeed()` with the correct canonical key so it writes `seed-meta:<domain>:<name>` automatically. The seed-meta key is required for health monitoring (`_seedMetaKey` in the MCP tool).
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `docs/health-variant-full.md`: 6-layer health variant spec covering disease outbreaks (enhanced), epidemic trends (WHO GHO time-series), vaccination coverage, air quality health risk, pathogen surveillance (Nextstrain), and health news intelligence
- Adds `docs/climate-variant-full.md`: 6-layer climate variant spec covering anomalies (with 30-year WMO baseline fix), CO2 monitoring (NOAA Mauna Loa), disaster alerts (ReliefWeb + GDACS reuse), air quality (shared with health), ocean/ice data (NSIDC/NOAA), and climate news
- Documents required seed scripts, proto RPCs, cache keys, MCP tool registrations, and API keys (minimal — mostly keyless APIs) for each variant
- Notes critical bug in existing `seed-climate-anomalies.mjs`: 30-day rolling baseline is not climatologically meaningful; must be replaced with 30-year WMO normals

## Test plan

- [x] TypeScript typecheck passes
- [x] API typecheck passes
- [x] Biome lint passes
- [x] All 2513 unit/data tests pass
- [x] Edge function bundle check passes (24 functions)
- [x] Edge function tests pass (131 tests)
- [x] Markdown lint passes (0 errors)
- [x] Version sync check passes