### PR TITLE
fix(forecast): restore collapsed-by-default signals panel

### DIFF
--- a/src/components/ForecastPanel.ts
+++ b/src/components/ForecastPanel.ts
@@ -194,9 +194,9 @@ function injectStyles(): void {
     .fc-perspective { font-size: 11px; color: var(--text-secondary, #999); padding: 2px 0; line-height: 1.4; }
     .fc-perspective strong { color: var(--text-primary, #ccc); font-weight: 600; }
     .fc-scenario { font-style: italic; }
-    .fc-signals { padding: 8px 14px 4px; border-top: 1px solid var(--border-color, #2a2a2a); display: grid; gap: 2px; }
+    .fc-signals { padding: 8px 14px 4px; border-top: 1px solid var(--border-color, #2a2a2a); }
     .fc-signals-title { color: var(--text-secondary, #888); font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 4px; }
-    .fc-signal { color: var(--text-secondary, #a0a0a0); font-size: 11px; padding: 3px 0 3px 12px; line-height: 1.45; position: relative; }
+    .fc-signal { color: var(--text-secondary, #a0a0a0); font-size: 11px; padding: 3px 0 3px 12px; line-height: 1.45; position: relative; margin-top: 2px; }
     .fc-signal::before { content: ''; position: absolute; left: 0; top: 9px; display: inline-block; width: 6px; height: 1px; background: var(--text-secondary, #555); }
     .fc-empty { padding: 20px; text-align: center; color: var(--text-secondary, #888); }
   `;


### PR DESCRIPTION
## Summary

- `display: grid` added to `.fc-signals` in #2450 silently broke the collapsed-by-default behavior of the Analysis Signals panel
- CSS specificity tie (both `.fc-hidden` and `.fc-signals` are single-class selectors): last rule wins, so `display: grid` overrode `display: none` from `fc-hidden`
- Fix: remove `display: grid` from `.fc-signals`; preserve item spacing via `margin-top` on `.fc-signal` instead

## Test plan

- [ ] Open AI Forecasts panel, expand Probability Bets section
- [ ] Verify Analysis Signals section is collapsed by default (not visible)
- [ ] Click "Signals (N)" toggle — confirms it opens correctly
- [ ] Styling (padding, dash indicators, uppercase title) is preserved