### PR TITLE
fix(intelligence): fail-closed on any upstream miss + counts key TTL extension

### DIFF
--- a/scripts/seed-sanctions-pressure.mjs
+++ b/scripts/seed-sanctions-pressure.mjs
@@ -562,6 +562,11 @@ runSeed('sanctions', 'pressure', CANONICAL_KEY, fetchSanctionsPressure, {
       ttl: CACHE_TTL,
       transform: (data) => data._state,
     },
+    {
+      key: COUNTRY_COUNTS_KEY,
+      ttl: CACHE_TTL,
+      transform: (data) => data._countryCounts,
+    },
   ],
   afterPublish: async (data, _ctx) => {
     // Write entity lookup index with seed-meta so health.js can monitor it.

--- a/server/worldmonitor/intelligence/v1/get-country-risk.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-risk.ts
@@ -45,9 +45,10 @@ export async function getCountryRisk(
     getCachedJson(SANCTIONS_COUNTS_KEY, true),
   ]);
 
-  // Sanctions-specific outage: return unavailable immediately rather than
-  // silently emitting sanctionsActive:false (a false negative for screening use).
-  if (sanctionsRaw === null) {
+  // Any missing upstream key: fail closed to prevent CDN-caching of partial
+  // data as if it were valid (e.g. sanctionsActive:false or cii:undefined when
+  // the Redis key itself is simply absent, not just untracked for this country).
+  if (sanctionsRaw === null || riskRaw === null || advisoriesRaw === null) {
     return {
       countryCode: code,
       countryName: resolveCountryName(code, (advisoriesRaw as any)?.byCountryName),


### PR DESCRIPTION
## Summary

Follow-up to #2502 addressing two P1 findings from post-merge review.

- **P1 (handler):** The null guard in `get-country-risk.ts` only checked `sanctionsRaw === null`. A transient Redis miss on `risk:scores:sebuf:stale:v1` or `intelligence:advisories:v1` would return `cii: undefined` / `advisoryLevel: ''` with `upstreamUnavailable: false`, allowing the CDN to cache partial data as valid. Guard now covers all three upstream keys.

- **P1 (seeder):** `sanctions:country-counts:v1` was written only from `afterPublish`, which is not included in `runSeed`'s `extendExistingTtl` call on fetch failure. A failed OFAC run extended TTL on `sanctions:pressure:v1` but not `sanctions:country-counts:v1`, allowing the counts key to expire while the pressure key stayed alive. Adding it to `extraKeys` puts it on the same TTL-extension path.

## Test plan

- [ ] TypeScript typechecks pass (`typecheck` + `typecheck:api`)
- [ ] Data tests pass (`test:data`)
- [ ] Edge function tests pass
- [ ] Verify handler returns `upstreamUnavailable: true` when any of the three Redis keys is null
- [ ] Verify failed OFAC seed run extends TTL on `sanctions:country-counts:v1` alongside `sanctions:pressure:v1`