### PR TITLE
fix(notification): add map theme + live-stream keys to CLOUD_SYNC_KEYS

### DIFF
--- a/src/utils/sync-keys.ts
+++ b/src/utils/sync-keys.ts
@@ -20,6 +20,13 @@ export const CLOUD_SYNC_KEYS = [
   'wm-ai-flow-cloud-llm',
   'wm-analysis-frameworks',
   'wm-panel-frameworks',
+  // Provider-specific map themes (wm-map-theme:<provider>)
+  'wm-map-theme:auto',
+  'wm-map-theme:pmtiles',
+  'wm-map-theme:openfreemap',
+  'wm-map-theme:carto',
+  // Live-stream mode
+  'wm-live-streams-always-on',
 ] as const;
 
 export type CloudSyncKey = (typeof CLOUD_SYNC_KEYS)[number];


### PR DESCRIPTION
## Summary

Closes the remaining gap in #2173's "all personalization syncs" scope.

Two pref categories were excluded from `CLOUD_SYNC_KEYS` and remained device-local:

- **Provider-specific map themes** (`wm-map-theme:auto`, `wm-map-theme:pmtiles`, `wm-map-theme:openfreemap`, `wm-map-theme:carto`) — stored by `setMapTheme()` in `src/config/basemap.ts`
- **Live-stream always-on mode** (`wm-live-streams-always-on`) — stored by `src/services/live-stream-settings.ts`

Both are static keys so they're a direct addition to the array. `buildCloudBlob`, `applyCloudBlob`, and the `setItem`/`removeItem` patches all pick them up automatically.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: change is additive only (new keys included in existing sync blob). First sign-in after deploy will upload these prefs to cloud and restore them on other devices.