### PR TITLE
fix(convex): cast request.json() in HTTP actions for TS compatibility

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -83,7 +83,7 @@ http.route({
       schemaVersion?: number;
     };
     try {
-      body = await request.json();
+      body = await request.json() as typeof body;
     } catch {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
@@ -153,7 +153,7 @@ http.route({
       };
     };
     try {
-      update = await request.json();
+      update = await request.json() as typeof update;
     } catch {
       return new Response("OK", { status: 200 });
     }
@@ -198,7 +198,7 @@ http.route({
 
     let body: { userId?: string; channelType?: string };
     try {
-      body = await request.json();
+      body = await request.json() as typeof body;
     } catch {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,
@@ -244,7 +244,7 @@ http.route({
 
     let body: { userId?: string };
     try {
-      body = await request.json();
+      body = await request.json() as typeof body;
     } catch {
       return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
         status: 400,


### PR DESCRIPTION
## Summary

Convex's TypeScript environment types `request.json()` as `unknown`, stricter than our local `tsconfig.json`. This caused 4 type errors that blocked `convex deploy`:

- `convex/http.ts:86` — user-prefs POST body
- `convex/http.ts:156` — telegram-pair-callback update
- `convex/http.ts:201` — relay/deactivate body
- `convex/http.ts:247` — relay/channels body

Fix: `await request.json() as typeof body/update` on each assignment.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: type-only fix, no runtime behavior change.