### PR TITLE
feat(aviation): city name search + multi-option sorted price results in command bar

### DIFF
--- a/src/components/AviationCommandBar.ts
+++ b/src/components/AviationCommandBar.ts
@@ -38,15 +38,17 @@ function resolveIata(token: string): string | undefined {
 
 function extractAirports(words: string[]): string[] {
     const result: string[] = [];
+    const seen = new Set<string>();
     let i = 0;
     while (i < words.length) {
         if (i + 1 < words.length) {
             const two = `${words[i]} ${words[i + 1]}`;
             const m = MONITORED_AIRPORTS.find(a => a.city.toLowerCase() === two.toLowerCase());
-            if (m) { result.push(m.iata); i += 2; continue; }
+            if (m) { if (!seen.has(m.iata)) { result.push(m.iata); seen.add(m.iata); } i += 2; continue; }
         }
         const iata = resolveIata(words[i]!);
-        if (iata) result.push(iata);
+        if (iata && !seen.has(iata)) { result.push(iata); seen.add(iata); }
+        else if (iata) seen.add(iata); // consume the token even if already seen
         i++;
     }
     return result;


### PR DESCRIPTION
## Summary

- **City name support**: the command bar now accepts city and airport names in addition to IATA codes. `ops Lisbon`, `ops Dubai`, `ops Abu Dhabi`, `price London Dubai` all resolve correctly via `MONITORED_AIRPORTS`. Two-word city names (Abu Dhabi, New York, etc.) are handled.
- **Price results show up to 5 options, sorted nonstop-first**: previously the command bar returned only the single cheapest flight — which was often a 1-stop itinerary. Results are now sorted nonstop first, then by price, and up to 5 rows are shown with per-row: airline+flight, stop label (green for nonstop), dep/arr times, duration, and price.
- **Date shown**: the search date is displayed next to the route header so it's clear what day is being quoted.
- **Suggestions and placeholder** updated with natural-language examples (`ops Dubai`, `price London Dubai`, `flight EK3`).
- **Error hint** updated to match new natural language style.

## Test plan

- [ ] `ops Lisbon` resolves to LIS and returns ops data
- [ ] `ops Abu Dhabi` resolves to AUH
- [ ] `price London Dubai` resolves LHR/DXB and shows multiple results
- [ ] `price BEY DXB` returns nonstop options first, with $-sorted fallback
- [ ] `price LHR DXB 2026-04-15` uses explicit date
- [ ] Results show dep–arr times and duration per row
- [ ] Date label visible in result header