### PR TITLE
fix(map): disable imagery footprint stroke to prevent Intel GPU shader crash

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -3496,8 +3496,7 @@ export class DeckGLMap {
         } catch { return []; }
       },
       getFillColor: [0, 180, 255, 40] as [number, number, number, number],
-      getLineColor: [0, 180, 255, 180] as [number, number, number, number],
-      lineWidthMinPixels: 1,
+      stroked: false,
       pickable: true,
     });
   }


### PR DESCRIPTION
## Summary

- `PolygonLayer` with `getLineColor` causes deck.gl to spawn an internal `PathLayer` stroke sublayer
- Its fragment shader (`satellite-imagery-layer-stroke-fragment`) fails to compile on Intel integrated GPUs (i11-series, Windows 11), crashing the orbital surveillance / satellite imagery layer
- Fix: set `stroked: false` — removes the stroke sublayer entirely, eliminating the shader compilation failure

Fixes #2518

## Test plan

- [ ] Verify satellite imagery footprints still render (translucent fill) on all GPU types
- [ ] Confirm no WebGL errors in console on Intel GPU (Windows)
- [ ] `npm run typecheck` passes