### PR TITLE
feat(aviation): date chips, Google Flights link, city name aliases

### DIFF
--- a/src/components/AviationCommandBar.ts
+++ b/src/components/AviationCommandBar.ts
@@ -157,12 +157,16 @@ async function executeIntent(intent: Intent): Promise<CommandResult> {
     }
 
     if (intent.type === 'PRICE_WATCH') {
-        const date = intent.date ?? new Date(Date.now() + 86400000).toISOString().slice(0, 10); // default: tomorrow
+        // Use local calendar arithmetic — never toISOString() which truncates at UTC midnight
+        const addLocalDays = (n: number): string => {
+            const d = new Date(); d.setDate(d.getDate() + n);
+            return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+        };
+        const date = intent.date ?? addLocalDays(1); // default: tomorrow in user's local timezone
         const dateLabel = new Date(date + 'T12:00:00').toLocaleDateString([], { month: 'short', day: 'numeric' });
         const gfUrl = `https://www.google.com/travel/flights/search?q=Flights+from+${encodeURIComponent(intent.origin)}+to+${encodeURIComponent(intent.destination)}+on+${encodeURIComponent(date)}`;
-        const todayBase = new Date(); todayBase.setHours(12, 0, 0, 0);
         const dateChips = ([1, 3, 7, 14, 30] as const).map(days => {
-            const d = new Date(todayBase.getTime() + days * 86400000).toISOString().slice(0, 10);
+            const d = addLocalDays(days);
             const lbl = days === 1 ? 'Tomorrow' : `+${days}d`;
             const active = d === date;
             const cmd = `price ${intent.origin} ${intent.destination} ${d}`;


### PR DESCRIPTION
## Summary

- **Default date is now tomorrow** (not +7 days). +7 was arbitrary and confusing.
- **Clickable date chips**: `Tomorrow · +3d · +7d · +14d · +30d` appear below the result header. Clicking any chip reruns the price query with that date and updates the input field. The active date is highlighted.
- **Google Flights link**: result header now has a "Google Flights →" link that opens the exact route+date in a new tab.
- **City name aliases**: added `EXTRA_CITY_IATA` table for airports not in `MONITORED_AIRPORTS` — `newcastle → NCL`, `manchester → MAN`, `birmingham → BHX`, `edinburgh → EDI`, `glasgow → GLA`, `brussels → BRU`, `milan → MXP`, `oslo → OSL`, `stockholm → ARN`, `copenhagen → CPH`, and more. `price newcastle dubai` now resolves correctly.

## Test plan

- [ ] `price newcastle dubai` resolves and returns results
- [ ] `price manchester DXB` resolves MAN correctly
- [ ] Default date in results is tomorrow (not 7 days out)
- [ ] Date chips render below the route header
- [ ] Clicking `+7d` chip reruns with correct date, input updates, active chip highlights
- [ ] "Google Flights →" link opens correct Google Flights search in new tab
- [ ] Existing `price LHR DXB` and `price London Dubai` still work