### PR TITLE
fix(chat-analyst): tester key auth bypass + active chip invisible text

### DIFF
--- a/server/_shared/premium-check.ts
+++ b/server/_shared/premium-check.ts
@@ -8,6 +8,15 @@ import { validateBearerToken } from '../auth-session';
  * (e.g. framework/systemAppend) should only be honored for premium callers.
  */
 export async function isCallerPremium(request: Request): Promise<boolean> {
+  // Browser tester keys — validateApiKey returns required:false for trusted origins
+  // even when a valid key is present, so we check the header directly first.
+  const wmKey = request.headers.get('X-WorldMonitor-Key') ?? '';
+  if (wmKey) {
+    const validKeys = (process.env.WORLDMONITOR_VALID_KEYS ?? '')
+      .split(',').map((k) => k.trim()).filter(Boolean);
+    if (validKeys.length > 0 && validKeys.includes(wmKey)) return true;
+  }
+
   const keyCheck = validateApiKey(request, {}) as { valid: boolean; required: boolean };
   // Only treat as premium when an explicit API key was validated (required: true).
   // Trusted-origin short-circuits (required: false) do NOT imply PRO entitlement.

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -22203,7 +22203,7 @@ body.map-width-resizing {
 .chat-chip.active {
   background: var(--accent);
   border-color: var(--accent);
-  color: #fff;
+  color: var(--bg);
 }
 .chat-analyst-messages {
   flex: 1;


### PR DESCRIPTION
## Summary

Two bugs in the WM Analyst panel introduced in #2459.

**Bug 1: "Pro subscription required" for tester key holders**

`isCallerPremium()` guards `/api/chat-analyst`. It checks `validateApiKey(req, {})` and only returns true when `required: true`. But for trusted browser origins (`worldmonitor.app`), `validateApiKey` always returns `required: false` — even when a valid `X-WorldMonitor-Key` is present — because trusted origins don't _require_ a key. So tester keys sent from the browser were silently failing the check despite being valid.

Fix: read `X-WorldMonitor-Key` directly and validate against `WORLDMONITOR_VALID_KEYS` before the `validateApiKey` path. Same pattern already used in `api/widget-agent.ts`.

**Bug 2: "All" domain chip is invisible (white on white)**

`.chat-chip.active` sets `background: var(--accent)` and `color: #fff`. In the dark theme `--accent = #fff`, so both background and text are white → chip appears as a blank white rectangle with no visible label.

Fix: `color: var(--bg)` instead of `color: #fff`. In dark theme: white chip + near-black text. In light theme: dark chip + light background text.

## Test plan
- [ ] Add tester key to localStorage, open WM Analyst, ask a question — should get a response instead of "Pro subscription required"
- [ ] Verify "All" chip shows readable text (dark text on white chip in dark mode)
- [ ] Verify other domain chips (Geo, Market, Military, Economic) still look correct when selected