### PR TITLE
fix(seeder): TLS proxy CONNECT — fixes FRED fetch failures (FSI, yield curve, macro)

### DIFF
--- a/scripts/_proxy-utils.cjs
+++ b/scripts/_proxy-utils.cjs
@@ -83,7 +83,7 @@ function resolveProxyString() {
  * Returns proxy as "user:pass@host:port" string for use with HTTP CONNECT tunneling.
  * Does NOT replace gate.decodo.com → us.decodo.com; CONNECT endpoint is gate.decodo.com.
  * When PROXY_URL uses https:// (TLS proxy), returns "https://user:pass@host:port" so
- * httpsProxyFetchJson can detect and use https.request instead of http.request.
+ * httpsProxyFetchJson uses tls.connect to the proxy instead of plain net.connect.
  * Returns empty string if no proxy configured.
  */
 function resolveProxyStringConnect() {

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -6,7 +6,6 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import * as net from 'node:net';
-import * as http from 'node:http';
 import * as tls from 'node:tls';
 import * as https from 'node:https';
 import { promisify } from 'node:util';


### PR DESCRIPTION
## Problem

All 24 FRED series have been failing since at least 01:53 UTC (2026-03-30), causing FSI data unavailable, yield curve blanks, and any FRED-dependent panel going stale.

Two root causes found by local validation:

**1. Wrong connection type to proxy**
`httpsProxyFetchJson` used `http.request` (plain TCP) to connect to `gate.decodo.com:10001`. The proxy requires TLS. Plain TCP received SOCKS5 rejection bytes (`\x05\xff`) from the proxy, causing Node.js to throw `Parse Error: Expected HTTP/, RTSP/ or ICE/`.

**2. Node.js `http.request` sets wrong `Host` header for CONNECT**
`http.request` auto-sets `Host: gate.decodo.com:10001` (the proxy host). For HTTP CONNECT the `Host` must be the target (`api.stlouisfed.org:443`). Decodo rejects the wrong `Host` with SOCKS5 bytes.

## Fix

Replace `http.request` CONNECT with `tls.connect` + manual CONNECT handshake:
1. `tls.connect` to proxy (always TLS — no dependence on PROXY_URL format)
2. Write `CONNECT target:443 HTTP/1.1\r\nHost: target:443` manually over the TLS socket
3. Read `HTTP/1.1 200 OK` response
4. `tls.connect` over the tunnel for the target (TLS-in-TLS)

Handles both `user:pass@host:port` and `https://user:pass@host:port` PROXY_URL formats.

## Validation

Tested locally — `BAMLH0A0HYM2` (HY spread, the FSI input that was null):
```
{ date: '2026-03-26', value: '3.21' }
```

Both plain and `https://` proxy URL formats confirmed working.