### PR TITLE
fix(seed-fear-greed): declare _proxyAuth — resolves ReferenceError in fetchAll()

### DIFF
--- a/scripts/seed-fear-greed.mjs
+++ b/scripts/seed-fear-greed.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, readSeedSnapshot, sleep } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, readSeedSnapshot, sleep, resolveProxyForConnect } from './_seed-utils.mjs';
 loadEnvFile(import.meta.url);
+
+const _proxyAuth = resolveProxyForConnect();
 
 const FEAR_GREED_KEY = 'market:fear-greed:v1';
 const FEAR_GREED_TTL = 64800; // 18h = 3x 6h interval


### PR DESCRIPTION
## Summary
- `_proxyAuth` was referenced in the `console.log` source summary at line 362 but never declared
- This caused a `ReferenceError` on every seeder run in strict ES module mode
- `runSeed()` catches the error and extends TTL without writing seed-meta, so FSI stays stale

## Fix
Import `resolveProxyForConnect` from `_seed-utils.mjs` and declare `const _proxyAuth` at module level.

## Test plan
- [ ] Verify seeder no longer crashes with `ReferenceError: _proxyAuth is not defined`
- [ ] Confirm `proxy=yes` or `proxy=no` appears correctly in Railway container logs