### PR TITLE
fix(llm): pin LLM edge functions to US/EU regions to fix geo-block 403s

### DIFF
--- a/api/chat-analyst.ts
+++ b/api/chat-analyst.ts
@@ -11,7 +11,7 @@
  *   data: {"error":"..."}    — on auth/llm failure
  */
 
-export const config = { runtime: 'edge' };
+export const config = { runtime: 'edge', regions: ['iad1', 'lhr1', 'fra1', 'sfo1'] };
 
 // @ts-expect-error — JS module, no declaration file
 import { getCorsHeaders } from './_cors.js';

--- a/api/intelligence/v1/[rpc].ts
+++ b/api/intelligence/v1/[rpc].ts
@@ -1,4 +1,4 @@
-export const config = { runtime: 'edge' };
+export const config = { runtime: 'edge', regions: ['iad1', 'lhr1', 'fra1', 'sfo1'] };
 
 import { createDomainGateway, serverOptions } from '../../../server/gateway';
 import { createIntelligenceServiceRoutes } from '../../../src/generated/server/worldmonitor/intelligence/v1/service_server';

--- a/api/news/v1/[rpc].ts
+++ b/api/news/v1/[rpc].ts
@@ -1,4 +1,4 @@
-export const config = { runtime: 'edge' };
+export const config = { runtime: 'edge', regions: ['iad1', 'lhr1', 'fra1', 'sfo1'] };
 
 import { createDomainGateway, serverOptions } from '../../../server/gateway';
 import { createNewsServiceRoutes } from '../../../src/generated/server/worldmonitor/news/v1/service_server';

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -293,7 +293,8 @@ export function callLlmReasoningStream(opts: LlmStreamOptions): ReadableStream<U
 
           if (!resp.ok || !resp.body) {
             clearTimeout(timeoutId);
-            console.warn(`[llm-stream:${providerName}] HTTP ${resp.status}`);
+            const errBody = resp.body ? await resp.text().catch(() => '') : '';
+            console.warn(`[llm-stream:${providerName}] HTTP ${resp.status} model=${creds.model} body=${errBody.slice(0, 300)}`);
             continue;
           }
 


### PR DESCRIPTION
## Summary

- **Root cause:** OpenRouter returns `403 "This model is not available in your region"` when Vercel routes LLM-calling edge functions through nodes in regions where Google Gemini is geo-blocked (Middle East, East Asia, etc.)
- **Affected endpoints:** `/api/chat-analyst`, `/api/news/v1/*` (article summarization), `/api/intelligence/v1/*`
- **Fix:** Pin the three edge functions to `['iad1', 'lhr1', 'fra1', 'sfo1']` (Virginia, London, Frankfurt, San Francisco) where all OpenRouter-routed LLM providers have full availability
- **Also:** Improves `callLlmReasoningStream` error logging to include model name + full response body on non-2xx for easier future diagnosis

Diagnosed by pulling Vercel production logs which revealed:
```
[SummarizeArticle:openrouter] API error: 403 {"error":{"message":"This model is not available in your region.","code":403}}
```

## Test plan

- [ ] Deploy and trigger `/api/chat-analyst` from a VPN endpoint in a geo-blocked region (e.g. UAE, Turkey)
- [ ] Confirm no `llm_unavailable` errors in Vercel function logs
- [ ] Confirm article summarization still works globally
- [ ] Verify latency impact is minimal (LLM inference dominates, not routing hop)