### PR TITLE
fix(chat-analyst): extend visual intent regex to match give/get/make me a chart

### DIFF
--- a/server/worldmonitor/intelligence/v1/chat-analyst-actions.ts
+++ b/server/worldmonitor/intelligence/v1/chat-analyst-actions.ts
@@ -13,7 +13,7 @@ export interface AnalystActionEvent {
 // (e.g. "UN Charter", "GDP", "chart a course"). Requires visual-specific
 // compound phrases or unambiguous single terms like "dashboard".
 export const VISUAL_INTENT_RE =
-  /\b(chart(\s+\w+)?\s+(prices?|data|rates?|trends?|performance|comparison|history)|graph(\s+\w+)?\s+(prices?|data|rates?|trends?|performance)|plot(\s+\w+)?\s+(prices?|data|rates?|trends?|performance)|visuali[sz]e|create\s+a\s+(chart|graph|dashboard|visualization)|show\s+(me\s+)?(a\s+)?(chart|graph|plot|dashboard|trend)|price\s+(history|over\s+time|comparison|trend|chart)|compare\s+(prices?|rates?|data|performance)|dashboard|candlestick)\b/i;
+  /\b(chart(\s+\w+)?\s+(prices?|data|rates?|trends?|performance|comparison|history)|graph(\s+\w+)?\s+(prices?|data|rates?|trends?|performance)|plot(\s+\w+)?\s+(prices?|data|rates?|trends?|performance)|visuali[sz]e|(show|give|get|make|build)\s+(me\s+)?(a\s+)?(chart|graph|plot|dashboard|trend|visualization)|create\s+a\s+(chart|graph|dashboard|visualization)|price\s+(history|over\s+time|comparison|trend|chart)|compare\s+(prices?|rates?|data|performance)|dashboard|candlestick)\b/i;
 
 export function buildActionEvents(query: string): AnalystActionEvent[] {
   if (!VISUAL_INTENT_RE.test(query)) return [];

--- a/tests/chat-analyst.test.mts
+++ b/tests/chat-analyst.test.mts
@@ -240,6 +240,18 @@ describe('buildActionEvents — visual intent detection', () => {
     assert.equal(events[0]?.type, 'suggest-widget');
   });
 
+  it('returns suggest-widget action for give me a chart', () => {
+    const events = buildActionEvents('give me a chart of the gold over past 30 days');
+    assert.equal(events.length, 1);
+    assert.equal(events[0]?.type, 'suggest-widget');
+  });
+
+  it('returns suggest-widget action for get me a chart', () => {
+    const events = buildActionEvents('get me a chart of oil prices');
+    assert.equal(events.length, 1);
+    assert.equal(events[0]?.type, 'suggest-widget');
+  });
+
   it('returns suggest-widget action for price history query', () => {
     const events = buildActionEvents('What is the price history of crude oil?');
     assert.equal(events.length, 1);


### PR DESCRIPTION
## Summary
- `VISUAL_INTENT_RE` previously only matched `show (me) (a) chart` — other natural phrasings like "give me a chart of gold" or "get me a chart of oil prices" fell through, so no action chip was shown
- Extend the verb arm to `show|give|get|make|build` so all common request phrasings fire the Widget Creator suggestion
- Add 2 test cases covering the new verbs

## Root cause
The query "give me a chart of the gold over past 30 days" doesn't match any arm in the old regex. Only `show` was covered in the noun-chart pattern.

## Test plan
- [x] `give me a chart of the gold over past 30 days` → suggest-widget action
- [x] `get me a chart of oil prices` → suggest-widget action
- [x] `show me a chart of S&P 500 performance` → still matches
- [x] `build me a dashboard` → still matches (standalone `dashboard` keyword)
- [x] All existing negative cases (UN Charter, chart a course, quick actions) → still empty
- [x] `npm run test:data` — 2639 pass, 0 fail

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: pure client-side regex change, no server state affected.