### PR TITLE
fix(aviation): use 'Flights from X to Y' query — fixes Google Flights blank page

### DIFF
--- a/src/components/AviationCommandBar.ts
+++ b/src/components/AviationCommandBar.ts
@@ -191,11 +191,7 @@ async function executeIntent(intent: Intent): Promise<CommandResult> {
                 const stopLabel = f.stops === 0 ? 'nonstop' : `${f.stops} stop${f.stops > 1 ? 's' : ''}`;
                 const safeDepTime = escapeHtml(depTime);
                 const safeArrTime = escapeHtml(arrTime);
-                const flightCode = leg ? `${leg.airlineCode}${leg.flightNumber}` : '';
-                const qParam = flightCode
-                    ? `${encodeURIComponent(flightCode)}+from+${encodeURIComponent(intent.origin)}+to+${encodeURIComponent(intent.destination)}+on+${encodeURIComponent(date)}`
-                    : `Flights+from+${encodeURIComponent(intent.origin)}+to+${encodeURIComponent(intent.destination)}+on+${encodeURIComponent(date)}`;
-                const rowUrl = sanitizeUrl(`https://www.google.com/travel/flights/search?q=${qParam}`);
+                const rowUrl = sanitizeUrl(`https://www.google.com/travel/flights/search?q=Flights+from+${encodeURIComponent(intent.origin)}+to+${encodeURIComponent(intent.destination)}+on+${encodeURIComponent(date)}`);
                 return `<a class="cmd-row" href="${rowUrl}" target="_blank" rel="noopener" style="padding:5px 0;border-bottom:1px solid rgba(255,255,255,.05);text-decoration:none;cursor:pointer;color:var(--text,#e8e8e8)">
           <div style="flex:1;min-width:0">
             <span style="font-size:13px">${carrier}</span>
@@ -216,7 +212,7 @@ async function executeIntent(intent: Intent): Promise<CommandResult> {
         const rows = [...quotes].sort((a, b) => a.stops !== b.stops ? a.stops - b.stops : a.priceAmount - b.priceAmount).slice(0, 5).map(q => {
             const stopColor = q.stops === 0 ? 'var(--green,#44ff88)' : 'var(--text-dim,#9ca3af)';
             const stopLabel = q.stops === 0 ? 'nonstop' : `${q.stops} stop${q.stops > 1 ? 's' : ''}`;
-            const rowUrl = sanitizeUrl(`https://www.google.com/travel/flights/search?q=${encodeURIComponent(q.carrierIata)}+from+${encodeURIComponent(intent.origin)}+to+${encodeURIComponent(intent.destination)}+on+${encodeURIComponent(date)}`);
+            const rowUrl = sanitizeUrl(`https://www.google.com/travel/flights/search?q=Flights+from+${encodeURIComponent(intent.origin)}+to+${encodeURIComponent(intent.destination)}+on+${encodeURIComponent(date)}`);
             return `<a class="cmd-row" href="${rowUrl}" target="_blank" rel="noopener" style="padding:5px 0;border-bottom:1px solid rgba(255,255,255,.05);text-decoration:none;cursor:pointer;color:var(--text,#e8e8e8)">
           <div style="flex:1">${escapeHtml(q.carrierName || q.carrierIata)}<span style="color:${stopColor};font-size:11px;margin-left:6px">${stopLabel}</span></div>
           <div style="color:var(--green,#44ff88);font-weight:600">$${Math.round(q.priceAmount)}</div>

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -947,8 +947,7 @@ export class MapPopup {
         // Book this route CTA
         const today = new Date();
         const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-        const flightQ = live.callsignIata ? `${encodeURIComponent(live.callsignIata)}+` : '';
-        const bookUrl = sanitizeUrl(`https://www.google.com/travel/flights/search?q=${flightQ}from+${encodeURIComponent(live.depIata)}+to+${encodeURIComponent(live.arrIata)}+on+${encodeURIComponent(todayStr)}`);
+        const bookUrl = sanitizeUrl(`https://www.google.com/travel/flights/search?q=Flights+from+${encodeURIComponent(live.depIata)}+to+${encodeURIComponent(live.arrIata)}+on+${encodeURIComponent(todayStr)}`);
         parts.push(`<a href="${bookUrl}" target="_blank" rel="noopener" style="display:block;margin-top:8px;padding:7px 12px;background:rgba(68,255,136,.06);border:1px solid rgba(68,255,136,.18);border-radius:6px;color:var(--green,#44ff88);text-decoration:none;font-size:12px;text-align:center">Book this route &rarr;</a>`);
       }
 


### PR DESCRIPTION
## Summary

- Google Flights `?q=` only pre-populates the route search when the query starts with `Flights from <origin> to <destination>`. A flight number prefix (e.g. `ME426 from BEY to DXB`) causes Google to render the blank homepage instead.
- Fixed in 3 places: per-row links (live results), per-row links (TravelPayouts fallback), and \"Book this route\" CTA in aircraft popup.
- Removed now-unused `flightCode` / `flightQ` variables.

## Test plan

- [ ] `fly BEY DXB` in aviation command bar — click any row — should open Google Flights with BEY→DXB pre-filled for the correct date
- [ ] Click aircraft on map with a known route — \"Book this route\" CTA should open Google Flights pre-filled for that route