### PR TITLE
fix(search-modal): strip duplicate 'Panel:' prefix in CMD+K panel labels

### DIFF
--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -35,7 +35,8 @@ function resolveCommandLabel(cmd: Command): string {
     case 'country-map':
       return `${t('commands.prefixes.map')}: ${cmd.label}`;
     case 'panel': {
-      const panelName = t('panels.' + kebabToCamel(action), { defaultValue: cmd.label });
+      const fallback = cmd.label.startsWith('Panel: ') ? cmd.label.slice(7) : cmd.label;
+      const panelName = t('panels.' + kebabToCamel(action), { defaultValue: fallback });
       return `${t('commands.prefixes.panel')}: ${panelName}`;
     }
     case 'country':


### PR DESCRIPTION
## Summary
- When a panel's i18n key is missing, `SearchModal.ts` fell back to `cmd.label` (e.g. `'Panel: Yield Curve & Rates'`), then prepended `Panel: ` again via i18n prefix — producing `'Panel: Panel: Yield Curve & Rates'`
- Fix: strip the leading `'Panel: '` from `cmd.label` before using it as the i18n fallback default value

## Affected panels (examples)
- `Panel: Panel: Yield Curve & Rates` → `Panel: Yield Curve & Rates`
- `Panel: Panel: Economic Calendar` → `Panel: Economic Calendar`
- `Panel: Panel: Macro Indicators` → `Panel: Macro Indicators`
- `Panel: Panel: WM Analyst` → `Panel: WM Analyst`

Panels that had matching i18n keys were already correct and are unaffected.

## Test plan
- [ ] Search "yield" in CMD+K → shows `Panel: Yield Curve & Rates` (not `Panel: Panel: ...`)
- [ ] Search "macro" → shows `Panel: Macro Indicators`, `Panel: Economic Calendar` correctly
- [ ] Search "analyst" → shows `Panel: WM Analyst` correctly
- [ ] Panels with existing i18n keys (e.g. BTC Regime, Live News) still display correctly