### PR TITLE
feat(scorecard): add simDetail to path-scorecards.json for simulation audit

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -4601,6 +4601,19 @@ function summarizeImpactPathScore(path = null) {
     if (path.simulationSignal !== undefined) {
       summary.simulationSignal = path.simulationSignal;
     }
+    if (path.simulationAdjustmentDetail !== undefined) {
+      const d = path.simulationAdjustmentDetail;
+      summary.simDetail = {
+        bucketChannelMatch:  Boolean(d.bucketChannelMatch),
+        actorOverlapCount:   Number(d.actorOverlapCount),
+        candidateActorCount: Number(d.candidateActorCount),
+        actorSource:         d.actorSource,
+        resolvedChannel:     d.resolvedChannel || '',
+        channelSource:       d.channelSource,
+        invalidatorHit:      Boolean(d.invalidatorHit),
+        stabilizerHit:       Boolean(d.stabilizerHit),
+      };
+    }
   }
   return summary;
 }
@@ -11568,6 +11581,7 @@ function applySimulationMerge(evaluation, simulationOutcome, candidatePackets, s
       demoted: wasAccepted && mergedAcceptanceScore < SIMULATION_MERGE_ACCEPT_THRESHOLD,
       simPathConfidence: details.simPathConfidence,
     };
+    path.simulationAdjustmentDetail = details;
 
     if (wasAccepted && mergedAcceptanceScore < SIMULATION_MERGE_ACCEPT_THRESHOLD) {
       path.demotedBySimulation = true;

--- a/scripts/seed-forecasts.types.d.ts
+++ b/scripts/seed-forecasts.types.d.ts
@@ -118,6 +118,8 @@ interface ExpandedPath {
   promotedBySimulation?: boolean;
   /** Compact simulation signal. Present only when applySimulationMerge produced a non-zero adjustment. */
   simulationSignal?: SimulationSignal;
+  /** Full SimulationAdjustmentDetail for audit. Present only when simulationAdjustment is set. */
+  simulationAdjustmentDetail?: SimulationAdjustmentDetail;
   direct?: ExpandedPathDirect;
   candidate?: ExpandedPathCandidate;
 }
@@ -202,6 +204,18 @@ interface SimulationAdjustmentRecord {
   details: SimulationAdjustmentDetail;
   wasAccepted: boolean;
   nowAccepted: boolean;
+}
+
+/** Flat projection of SimulationAdjustmentDetail written into path-scorecards.json entries. simPathConfidence is omitted (already in simulationSignal). */
+interface ScorecardSimDetail {
+  bucketChannelMatch:  boolean;
+  actorOverlapCount:   number;
+  candidateActorCount: number;
+  actorSource:         'stateSummary' | 'affectedAssets' | 'none';
+  resolvedChannel:     string;
+  channelSource:       'direct' | 'market' | 'none';
+  invalidatorHit:      boolean;
+  stabilizerHit:       boolean;
 }
 
 interface SimulationEvidence {

--- a/tests/forecast-trace-export.test.mjs
+++ b/tests/forecast-trace-export.test.mjs
@@ -7123,6 +7123,74 @@ describe('phase 3 simulation re-ingestion — applySimulationMerge', () => {
     assert.ok(summary);
     assert.equal(Object.prototype.hasOwnProperty.call(summary, 'simulationSignal'), false);
   });
+
+  it('T-SC-1: simDetail written when simulationAdjustment and simulationAdjustmentDetail are set', () => {
+    const path = {
+      pathId: 'p-sc1', type: 'expanded', candidateStateId: 'state-sc1',
+      acceptanceScore: 0.45, mergedAcceptanceScore: 0.53,
+      simulationAdjustment: 0.08,
+      simulationAdjustmentDetail: {
+        bucketChannelMatch: true, actorOverlapCount: 0, candidateActorCount: 2,
+        actorSource: 'stateSummary', resolvedChannel: 'energy_supply_shock',
+        channelSource: 'direct', invalidatorHit: false, stabilizerHit: false,
+        simPathConfidence: 0.7,
+      },
+    };
+    const result = summarizeImpactPathScore(path);
+    assert.ok(result.simDetail, 'simDetail must be present');
+    assert.strictEqual(result.simDetail.bucketChannelMatch, true);
+    assert.strictEqual(result.simDetail.actorOverlapCount, 0);
+    assert.strictEqual(result.simDetail.candidateActorCount, 2);
+    assert.strictEqual(result.simDetail.actorSource, 'stateSummary');
+    assert.strictEqual(result.simDetail.resolvedChannel, 'energy_supply_shock');
+    assert.strictEqual(result.simDetail.channelSource, 'direct');
+    assert.strictEqual(result.simDetail.invalidatorHit, false);
+    assert.strictEqual(result.simDetail.stabilizerHit, false);
+    assert.strictEqual(result.simDetail.simPathConfidence, undefined, 'simPathConfidence must not be duplicated in simDetail');
+  });
+
+  it('T-SC-2: simDetail absent when simulationAdjustment not set', () => {
+    const path = { pathId: 'p-sc2', type: 'expanded', candidateStateId: 'state-sc2', acceptanceScore: 0.45 };
+    const result = summarizeImpactPathScore(path);
+    assert.strictEqual(result.simDetail, undefined);
+  });
+
+  it('T-SC-3: simDetail absent when simulationAdjustment set but simulationAdjustmentDetail absent (backward compat)', () => {
+    const path = {
+      pathId: 'p-sc3', type: 'expanded', candidateStateId: 'state-sc3',
+      acceptanceScore: 0.45, simulationAdjustment: 0.08,
+    };
+    const result = summarizeImpactPathScore(path);
+    assert.strictEqual(result.simDetail, undefined);
+    assert.strictEqual(result.simulationAdjustment, 0.08);
+  });
+
+  it('T-SC-4: computeSimulationAdjustment details flow through to summarizeImpactPathScore simDetail', () => {
+    const path = {
+      type: 'expanded', pathId: 'path-sc4', candidateStateId: 'state-sc4',
+      direct: { variableKey: 'route_disruption', targetBucket: 'energy', channel: 'energy_supply_shock', affectedAssets: [] },
+      second: null, third: null, pathScore: 0.60, acceptanceScore: 0.55,
+    };
+    const candidatePacket = {
+      candidateStateId: 'state-sc4', candidateIndex: 0,
+      routeFacilityKey: 'Strait of Hormuz', commodityKey: 'crude_oil',
+      marketContext: { topBucketId: 'energy', topChannel: 'energy_supply_shock' },
+      stateSummary: { actors: ['Iran', 'Saudi Arabia'] },
+    };
+    const simResult = {
+      topPaths: [{ label: 'Supply shock', summary: 'energy supply disruption', keyActors: ['Iran', 'Saudi_Arabia'] }],
+      invalidators: [], stabilizers: [],
+    };
+    const { adjustment, details } = computeSimulationAdjustment(path, simResult, candidatePacket);
+    path.simulationAdjustment = adjustment;
+    path.simulationAdjustmentDetail = details;
+    const scorecard = summarizeImpactPathScore(path);
+    assert.ok(scorecard.simDetail, 'simDetail must be present after flow-through');
+    assert.strictEqual(scorecard.simDetail.bucketChannelMatch, true);
+    assert.ok(scorecard.simDetail.actorOverlapCount >= 2, `actorOverlapCount should be >=2, got ${scorecard.simDetail.actorOverlapCount}`);
+    assert.strictEqual(scorecard.simDetail.actorSource, 'stateSummary');
+    assert.strictEqual(scorecard.simDetail.channelSource, 'direct');
+  });
 });
 
 describe('phase 3 simulation re-ingestion — matching helpers', () => {


### PR DESCRIPTION
## Summary

- Each `path-scorecards.json` R2 artifact entry now includes a `simDetail` object with the full `SimulationAdjustmentDetail` fields
- Previously `details` from `computeSimulationAdjustment` was only stored in the in-memory `adjustments[]` array (used for the sim-log artifact) — it never reached `path-scorecards.json`
- This makes every production run self-auditable: you can read the R2 artifact and immediately see whether the +0.04 actor-overlap bonus fired, which channel matched, what actor source was used, and whether an invalidator or stabilizer triggered

## Fields added to each scored path entry

```json
"simDetail": {
  "bucketChannelMatch": true,
  "actorOverlapCount": 2,
  "candidateActorCount": 3,
  "actorSource": "stateSummary",
  "resolvedChannel": "energy_supply_shock",
  "channelSource": "direct",
  "invalidatorHit": false,
  "stabilizerHit": false
}
```

`simPathConfidence` is intentionally omitted — it is already in `simulationSignal.simPathConfidence`.

## Changes

| File | Change |
|---|---|
| `scripts/seed-forecasts.mjs:applySimulationMerge` | Attach `details` to `path.simulationAdjustmentDetail` (one line) |
| `scripts/seed-forecasts.mjs:summarizeImpactPathScore` | Project `simDetail` from `simulationAdjustmentDetail` when present |
| `scripts/seed-forecasts.types.d.ts` | Add `simulationAdjustmentDetail?` to `ExpandedPath`; add `ScorecardSimDetail` interface |

## Testing

- T-SC-1: `simDetail` written when both `simulationAdjustment` and `simulationAdjustmentDetail` are set
- T-SC-2: `simDetail` absent when `simulationAdjustment` not set
- T-SC-3: `simDetail` absent when `simulationAdjustment` set but `simulationAdjustmentDetail` absent (backward compat for old paths)
- T-SC-4: end-to-end flow — `computeSimulationAdjustment` details flow through `path.simulationAdjustmentDetail` to `simDetail` in scorecard
- **301/301 tests passing**, typecheck clean

## Backward compatibility

`simDetail` is additive. Old `path-scorecards.json` artifacts have no `simDetail` key — readers using `?.simDetail?.actorOverlapCount` get `undefined` (no crash).

## Post-Deploy Monitoring & Validation

- **What to monitor**: Next deep forecast run — fetch `path-scorecards.json` from R2 for any run after this deploys
- **Validation check**: `node scripts/inspect-r2.mjs <runId> path-scorecards.json | jq '.selectedPaths[0].simDetail'` — should return a non-null object for any path with `simulationAdjustment != 0`
- **Expected healthy behavior**: Every entry with `simulationAdjustment` has a `simDetail` object with `bucketChannelMatch: true` and a non-empty `resolvedChannel`
- **Failure signal**: `simDetail` is `undefined` on paths that have `simulationAdjustment` — indicates `simulationAdjustmentDetail` was not attached in `applySimulationMerge`
- **Validation window**: first deep run after deploy (typically within 1 hour)