### PR TITLE
feat(regulatory): add regulatory RSS fetch seeder

### DIFF
--- a/scripts/seed-regulatory-actions.mjs
+++ b/scripts/seed-regulatory-actions.mjs
@@ -37,11 +37,9 @@ function decodeEntities(input) {
 }
 
 function stripHtml(input) {
-  return decodeEntities(
-    String(input || '')
-      .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
-      .replace(/<[^>]+>/g, ' ')
-  ).replace(/\s+/g, ' ').trim();
+  const unwrapped = String(input || '').replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1');
+  const decoded = decodeEntities(unwrapped);
+  return decoded.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
 function getTagValue(block, tagName) {

--- a/tests/regulatory-seed-unit.test.mjs
+++ b/tests/regulatory-seed-unit.test.mjs
@@ -52,6 +52,10 @@ describe('stripHtml', () => {
   it('removes tags and CDATA while preserving text', () => {
     assert.equal(stripHtml('<![CDATA[Hello <strong>world</strong>]]>'), 'Hello world');
   });
+
+  it('strips entity-escaped HTML tags (FINRA-style descriptions)', () => {
+    assert.equal(stripHtml('&lt;h2&gt;Summary&lt;/h2&gt;&lt;p&gt;FINRA amends Rule 4210.&lt;/p&gt;'), 'Summary FINRA amends Rule 4210.');
+  });
 });
 
 describe('parseRssItems', () => {


### PR DESCRIPTION
## Summary
This adds the first regulatory RSS pipeline step for `seed-regulatory-actions.mjs`: fetch live SEC, CFTC, Federal Reserve, FDIC, and FINRA feeds concurrently, parse RSS/Atom natively, normalize the output, and emit JSON for the fetch/parse-only phase.

## Root cause
The repository did not have a regulatory-actions seeder yet, and several URLs from the initial issue description are no longer the live official feed endpoints. Without a dedicated fetch/parse layer, the rest of the regulatory pipeline cannot be built on stable input.

## Changes
- add `scripts/seed-regulatory-actions.mjs` as an import-safe standalone seeder with concurrent fetch, partial-failure tolerance, native RSS/Atom parsing, deterministic IDs, deduplication, and sorted normalized output
- use current working official feed endpoints for SEC, CFTC, Federal Reserve, FDIC, and FINRA
- use a declared WorldMonitor `User-Agent` only for SEC because the current SEC endpoint rejects generic browser spoofing
- add `tests/regulatory-seed-unit.test.mjs` covering RSS/Atom parsing, href extraction, HTML cleanup, deduplication, ordering, partial failure, and all-feeds-fail behavior

## Validation
- `node --test tests/regulatory-seed-unit.test.mjs`
- `node scripts/seed-regulatory-actions.mjs | head -n 40`
- `node -e "import('./scripts/seed-regulatory-actions.mjs').then(() => process.stdout.write('import-ok\\n'))"`

## Risk
Low risk. This PR only adds a new standalone script and a focused unit test; it does not write to Redis or change runtime application behavior yet.

Closes #2492
Refs #2493
Refs #2494
Refs #2495
