### PR TITLE
feat(regulatory): classify and publish regulatory actions

### DIFF
--- a/scripts/seed-regulatory-actions.mjs
+++ b/scripts/seed-regulatory-actions.mjs
@@ -8,7 +8,7 @@ loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'regulatory:actions:v1';
 const FEED_TIMEOUT_MS = 15_000;
-const TTL_SECONDS = 7200;
+const TTL_SECONDS = 21600;
 const XML_ACCEPT = 'application/atom+xml, application/rss+xml, application/xml, text/xml, */*';
 const SEC_USER_AGENT = 'WorldMonitor/2.0 (monitor@worldmonitor.app)';
 const DEFAULT_FETCH = (...args) => globalThis.fetch(...args);
@@ -16,12 +16,18 @@ const HIGH_KEYWORDS = [
   'enforcement', 'charges', 'charged', 'fraud', 'failure', 'failed bank',
   'emergency', 'halt', 'suspension', 'suspended', 'cease', 'desist',
   'penalty', 'fine', 'fined', 'settlement', 'indictment', 'manipulation',
-  'ban', 'revocation', 'insolvency',
+  'ban', 'revocation', 'insolvency', 'injunction', 'cease and desist',
+  'cease-and-desist', 'consent order', 'debarment', 'suspension order',
 ];
 const MEDIUM_KEYWORDS = [
   'proposed rule', 'final rule', 'rulemaking', 'guidance', 'warning',
-  'notice', 'advisory', 'review', 'examination', 'investigation',
+  'advisory', 'review', 'examination', 'investigation',
   'stress test', 'capital requirement', 'disclosure requirement',
+  'resolves action', 'settled charges', 'administrative proceeding', 'remedial action',
+];
+const LOW_PRIORITY_TITLE_PATTERNS = [
+  /^(Regulatory|Information|Technical) Notice\b/i,
+  /\bmonthly (highlights|bulletin)\b/i,
 ];
 
 const REGULATORY_FEEDS = [
@@ -257,23 +263,37 @@ function compileKeywordPattern(keyword) {
 const HIGH_KEYWORD_PATTERNS = HIGH_KEYWORDS.map(compileKeywordPattern);
 const MEDIUM_KEYWORD_PATTERNS = MEDIUM_KEYWORDS.map(compileKeywordPattern);
 
-function findMatchedKeywords(title, keywordPatterns) {
-  const lowerTitle = stripHtml(title).toLowerCase();
-  return keywordPatterns.filter(({ regex }) => regex.test(lowerTitle)).map(({ keyword }) => keyword);
+function findMatchedKeywords(text, keywordPatterns) {
+  const normalizedText = stripHtml(text).toLowerCase();
+  return keywordPatterns.filter(({ regex }) => regex.test(normalizedText)).map(({ keyword }) => keyword);
+}
+
+function buildClassificationText(action) {
+  return [action.title, action.description].filter(Boolean).join(' ');
+}
+
+function isLowPriorityRoutineTitle(title) {
+  const normalizedTitle = stripHtml(title);
+  return LOW_PRIORITY_TITLE_PATTERNS.some((pattern) => pattern.test(normalizedTitle));
 }
 
 function classifyAction(action) {
-  const highMatches = findMatchedKeywords(action.title, HIGH_KEYWORD_PATTERNS);
+  const classificationText = buildClassificationText(action);
+  const highMatches = findMatchedKeywords(classificationText, HIGH_KEYWORD_PATTERNS);
   if (highMatches.length > 0) {
     return { ...action, tier: 'high', matchedKeywords: [...new Set(highMatches)] };
   }
 
-  const mediumMatches = findMatchedKeywords(action.title, MEDIUM_KEYWORD_PATTERNS);
+  if (isLowPriorityRoutineTitle(action.title)) {
+    return { ...action, tier: 'low', matchedKeywords: [] };
+  }
+
+  const mediumMatches = findMatchedKeywords(classificationText, MEDIUM_KEYWORD_PATTERNS);
   if (mediumMatches.length > 0) {
     return { ...action, tier: 'medium', matchedKeywords: [...new Set(mediumMatches)] };
   }
 
-  return { ...action, tier: 'low', matchedKeywords: [] };
+  return { ...action, tier: 'unknown', matchedKeywords: [] };
 }
 
 function buildSeedPayload(actions, fetchedAt = Date.now()) {
@@ -334,6 +354,7 @@ export {
   fetchRegulatoryActionPayload,
   findMatchedKeywords,
   getTagValue,
+  isLowPriorityRoutineTitle,
   main,
   normalizeFeedItems,
   parseAtomEntries,

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -5,6 +5,7 @@
  */
 export const SIMULATION_OUTCOME_LATEST_KEY = 'forecast:simulation-outcome:latest';
 export const SIMULATION_PACKAGE_LATEST_KEY = 'forecast:simulation-package:latest';
+export const REGULATORY_ACTIONS_KEY = 'regulatory:actions:v1';
 
 /**
  * Static cache keys for the bootstrap endpoint.

--- a/tests/regulatory-contract.test.mjs
+++ b/tests/regulatory-contract.test.mjs
@@ -1,0 +1,18 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+describe('regulatory cache contracts', () => {
+  it('exports REGULATORY_ACTIONS_KEY from cache-keys.ts', () => {
+    const cacheKeysSrc = readFileSync(join(root, 'server', '_shared', 'cache-keys.ts'), 'utf8');
+    assert.match(
+      cacheKeysSrc,
+      /export const REGULATORY_ACTIONS_KEY = 'regulatory:actions:v1';/
+    );
+  });
+});

--- a/tests/regulatory-seed-unit.test.mjs
+++ b/tests/regulatory-seed-unit.test.mjs
@@ -216,39 +216,60 @@ describe('fetchAllFeeds', () => {
 });
 
 describe('classifyAction', () => {
-  it('marks high priority actions and captures matched keywords', () => {
+  it('marks high priority actions from combined title and description text', () => {
     const action = normalize(classifyAction({
       id: 'sec-a',
       agency: 'SEC',
-      title: 'SEC Charges Bank for Accounting Fraud',
+      title: 'SEC action against issuer',
+      description: 'The SEC secured a permanent injunction for accounting fraud.',
       link: 'https://example.test/sec-a',
       publishedAt: '2026-03-30T18:00:00.000Z',
     }));
 
     assert.equal(action.tier, 'high');
-    assert.deepEqual(action.matchedKeywords, ['charges', 'fraud']);
+    assert.deepEqual(action.matchedKeywords, ['fraud', 'injunction']);
   });
 
-  it('falls back to medium and then low', () => {
+  it('marks medium actions from description text', () => {
     const medium = normalize(classifyAction({
       id: 'fed-a',
       agency: 'Federal Reserve',
-      title: 'Federal Reserve Issues Capital Requirement Guidance',
+      title: 'Federal Reserve update',
+      description: 'The board resolves action through a remedial action plan.',
       link: 'https://example.test/fed-a',
-      publishedAt: '2026-03-30T18:00:00.000Z',
-    }));
-    const low = normalize(classifyAction({
-      id: 'finra-a',
-      agency: 'FINRA',
-      title: 'FINRA Publishes Monthly Highlights',
-      link: 'https://example.test/finra-a',
       publishedAt: '2026-03-30T18:00:00.000Z',
     }));
 
     assert.equal(medium.tier, 'medium');
-    assert.deepEqual(medium.matchedKeywords, ['guidance', 'capital requirement']);
+    assert.deepEqual(medium.matchedKeywords, ['resolves action', 'remedial action']);
+  });
+
+  it('uses low only for explicit routine notice titles', () => {
+    const low = normalize(classifyAction({
+      id: 'finra-a',
+      agency: 'FINRA',
+      title: 'Technical Notice 26-01',
+      description: 'Routine operational bulletin for members.',
+      link: 'https://example.test/finra-a',
+      publishedAt: '2026-03-30T18:00:00.000Z',
+    }));
+
     assert.equal(low.tier, 'low');
     assert.deepEqual(low.matchedKeywords, []);
+  });
+
+  it('falls back to unknown for unmatched actions', () => {
+    const unknown = normalize(classifyAction({
+      id: 'fdic-a',
+      agency: 'FDIC',
+      title: 'FDIC consumer outreach update',
+      description: 'General event recap for community stakeholders.',
+      link: 'https://example.test/fdic-a',
+      publishedAt: '2026-03-30T18:00:00.000Z',
+    }));
+
+    assert.equal(unknown.tier, 'unknown');
+    assert.deepEqual(unknown.matchedKeywords, []);
   });
 });
 
@@ -258,31 +279,43 @@ describe('buildSeedPayload', () => {
       {
         id: 'sec-a',
         agency: 'SEC',
-        title: 'SEC Charges Bank for Fraud',
+        title: 'SEC action against issuer',
+        description: 'The SEC secured a permanent injunction for accounting fraud.',
         link: 'https://example.test/sec-a',
         publishedAt: '2026-03-30T18:00:00.000Z',
       },
       {
         id: 'fed-a',
         agency: 'Federal Reserve',
-        title: 'Federal Reserve Issues Guidance',
+        title: 'Federal Reserve update',
+        description: 'The board resolves action through a remedial action plan.',
         link: 'https://example.test/fed-a',
         publishedAt: '2026-03-29T18:00:00.000Z',
       },
       {
         id: 'finra-a',
         agency: 'FINRA',
-        title: 'FINRA Monthly Bulletin',
+        title: 'Regulatory Notice 26-01',
+        description: 'Routine bulletin for members.',
         link: 'https://example.test/finra-a',
         publishedAt: '2026-03-28T18:00:00.000Z',
+      },
+      {
+        id: 'fdic-a',
+        agency: 'FDIC',
+        title: 'FDIC consumer outreach update',
+        description: 'General event recap for community stakeholders.',
+        link: 'https://example.test/fdic-a',
+        publishedAt: '2026-03-27T18:00:00.000Z',
       },
     ], 1711718400000));
 
     assert.equal(payload.fetchedAt, 1711718400000);
-    assert.equal(payload.recordCount, 3);
+    assert.equal(payload.recordCount, 4);
     assert.equal(payload.highCount, 1);
     assert.equal(payload.mediumCount, 1);
     assert.equal(payload.actions[2].tier, 'low');
+    assert.equal(payload.actions[3].tier, 'unknown');
   });
 });
 
@@ -290,14 +323,14 @@ describe('fetchRegulatoryActionPayload', () => {
   it('returns classified payload from fetched actions', async () => {
     const payload = normalize(await fetchRegulatoryActionPayload(async (url) => ({
       ok: true,
-      text: async () => `<rss><channel><item><title>FDIC Publishes Enforcement Orders</title><link>${url}/item</link><pubDate>Mon, 30 Mar 2026 18:00:00 GMT</pubDate></item></channel></rss>`,
+      text: async () => `<rss><channel><item><title>FDIC update</title><description>FDIC resolves action through a remedial action plan.</description><link>${url}/item</link><pubDate>Mon, 30 Mar 2026 18:00:00 GMT</pubDate></item></channel></rss>`,
     })));
 
     assert.equal(payload.actions.length, 5);
     assert.equal(payload.recordCount, 5);
     assert.ok(typeof payload.fetchedAt === 'number');
-    assert.equal(payload.actions[0].tier, 'high');
-    assert.deepEqual(payload.actions[0].matchedKeywords, ['enforcement']);
+    assert.equal(payload.actions[0].tier, 'medium');
+    assert.deepEqual(payload.actions[0].matchedKeywords, ['resolves action', 'remedial action']);
   });
 });
 
@@ -319,7 +352,7 @@ describe('main', () => {
     assert.equal(calls[0].domain, 'regulatory');
     assert.equal(calls[0].resource, 'actions');
     assert.equal(calls[0].canonicalKey, 'regulatory:actions:v1');
-    assert.equal(calls[0].opts.ttlSeconds, 7200);
+    assert.equal(calls[0].opts.ttlSeconds, 21600);
     assert.equal(calls[0].opts.validateFn({ actions: [] }), true);
     assert.equal(calls[0].payload.recordCount, 5);
   });


### PR DESCRIPTION
## Summary
This adds the second regulatory RSS step by classifying normalized actions into `high` / `medium` / `low`, computing aggregate counts, and publishing the final payload to `regulatory:actions:v1` via `runSeed`.

## Root cause
The fetch/parse seeder from #2564 produces stable normalized actions, but the pipeline still needed tiering logic and Redis publication before cross-source signals could consume regulatory events.

## Changes
- add the `HIGH_KEYWORDS` and `MEDIUM_KEYWORDS` classification rules from #2493
- classify each action with `tier` and `matchedKeywords`, using word-boundary matching to avoid false positives like `ban` inside `bank`
- build the final seed payload with `actions`, `fetchedAt`, `recordCount`, `highCount`, and `mediumCount`
- wire `main()` through `runSeed('regulatory', 'actions', 'regulatory:actions:v1', ...)` with TTL `7200` and an empty-array-safe `validateFn`
- expand `tests/regulatory-seed-unit.test.mjs` to cover classification, payload counts, fetch-to-payload flow, and the `runSeed` wiring

## Validation
- `node --test tests/regulatory-seed-unit.test.mjs`
- `node -e "import('./scripts/seed-regulatory-actions.mjs').then(async (m) => { const data = await m.fetchRegulatoryActionPayload(); process.stdout.write(JSON.stringify({recordCount: data.recordCount, highCount: data.highCount, mediumCount: data.mediumCount, first: data.actions[0]}, null, 2) + '\\n'); })"`
- `node -e "import('./scripts/seed-regulatory-actions.mjs').then(() => process.stdout.write('import-ok\\n'))"`

## Risk
Low risk. This only evolves the new regulatory seeder introduced in #2564 and adds focused test coverage around the new classification/publish behavior.

## Note
This branch is currently stacked on #2564. Until #2564 merges, this PR includes the parent fetch/parse commit in the diff.

Depends on #2564
Closes #2493
Refs #2494
Refs #2495
