### PR TITLE
fix(notif-ui): notification card CSS missing in web app + double-# in Slack channel

### DIFF
--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -1,3 +1,4 @@
+import '@/styles/settings-window.css';
 import { FEEDS, INTEL_SOURCES, SOURCE_REGION_MAP } from '@/config/feeds';
 import { PANEL_CATEGORY_MAP, ALL_PANELS, VARIANT_DEFAULTS, getEffectivePanelConfig, isPanelEntitled, FREE_MAX_PANELS } from '@/config/panels';
 import { isProUser } from '@/services/widget-store';

--- a/src/services/preferences-content.ts
+++ b/src/services/preferences-content.ts
@@ -639,7 +639,8 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
               sub = escapeHtml(channel.email ?? 'connected');
             } else {
               // Slack: show #channel · team from OAuth metadata
-              const ch = channel.slackChannelName ? `#${escapeHtml(channel.slackChannelName)}` : 'connected';
+              const rawCh = channel.slackChannelName ?? '';
+              const ch = rawCh ? `#${escapeHtml(rawCh.startsWith('#') ? rawCh.slice(1) : rawCh)}` : 'connected';
               const team = channel.slackTeamName ? ` · ${escapeHtml(channel.slackTeamName)}` : '';
               sub = ch + team;
               if (channel.slackConfigurationUrl) {


### PR DESCRIPTION
## Summary

- **Root cause of broken layout**: `UnifiedSettings.ts` (the web app's inline settings panel) was not importing `settings-window.css`. That stylesheet defines all `.us-notif-ch-*` flex card styles. Without it, every channel row rendered as plain block elements stacked vertically — icon on its own line, name on next line, etc.
- **Fix**: add `import '@/styles/settings-window.css'` to `UnifiedSettings.ts` so the notification styles load in the main app bundle (not just the desktop standalone window via `settings-main.ts`)
- **Double-hash bug**: `slackChannelName` returned by Slack OAuth sometimes already includes a leading `#`. Prepending another `#` produces `##channel-name`. Fixed by stripping any leading `#` before adding ours.

## Test plan

- [ ] Open settings → Notifications: channels render as horizontal cards (icon + name + actions on one row)
- [ ] Connected Slack shows `#channel-name · Team Name` (single `#`, no double hash)
- [ ] Connected Telegram shows `@chatId`
- [ ] Typecheck passes