### PR TITLE
fix(relay): parse Upstash SSE stream instead of calling res.json()

### DIFF
--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -270,8 +270,10 @@ async function processEvent(event) {
 
 async function subscribe() {
   console.log('[relay] Starting notification relay...');
-  const decoder = new TextDecoder();
   while (true) {
+    // Fresh decoder per connection — avoids stale multibyte state from a mid-chunk disconnect
+    const decoder = new TextDecoder();
+    let reader;
     try {
       const res = await fetch(
         `${UPSTASH_URL}/subscribe/wm:events:notify`,
@@ -288,30 +290,34 @@ async function subscribe() {
       // Upstash subscribe returns an SSE stream, not a single JSON blob.
       // Each line format: "data: message,<channel>,<payload>"
       //                or "data: subscribe,<channel>,<count>"
-      const reader = res.body.getReader();
+      reader = res.body.getReader();
       let buf = '';
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buf += decoder.decode(value, { stream: true });
-        let nl;
-        while ((nl = buf.indexOf('\n')) !== -1) {
-          const line = buf.slice(0, nl).trimEnd();
-          buf = buf.slice(nl + 1);
-          if (!line.startsWith('data:')) continue;
-          const raw = line.slice(5).trim(); // e.g. "message,wm:events:notify,<json>"
-          if (!raw.startsWith('message,')) continue;
-          // Split on second comma; message payload may contain commas
-          const secondComma = raw.indexOf(',', 8); // 'message,'.length === 8
-          if (secondComma === -1) continue;
-          const message = raw.slice(secondComma + 1);
-          try {
-            const event = JSON.parse(message);
-            await processEvent(event);
-          } catch (err) {
-            console.warn('[relay] Failed to parse event:', err.message);
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          let nl;
+          while ((nl = buf.indexOf('\n')) !== -1) {
+            const line = buf.slice(0, nl).trimEnd();
+            buf = buf.slice(nl + 1);
+            if (!line.startsWith('data:')) continue;
+            const raw = line.slice(5).trim(); // e.g. "message,wm:events:notify,<json>"
+            if (!raw.startsWith('message,')) continue;
+            // Split on second comma; message payload may contain commas
+            const secondComma = raw.indexOf(',', 8); // 'message,'.length === 8
+            if (secondComma === -1) continue;
+            const message = raw.slice(secondComma + 1);
+            try {
+              const event = JSON.parse(message);
+              await processEvent(event);
+            } catch (err) {
+              console.warn('[relay] Failed to parse event:', err.message);
+            }
           }
         }
+      } finally {
+        reader.cancel().catch(() => {});
       }
     } catch (err) {
       if (err?.name !== 'TimeoutError' && err?.name !== 'AbortError') {


### PR DESCRIPTION
## Summary

- The Railway notification relay's subscribe loop was calling `res.json()` on Upstash's `/subscribe` endpoint
- Upstash pub/sub subscribe returns an **SSE stream**, not a single JSON blob
- `res.json()` was silently failing (`.catch(() => null)`) every time, so `json?.message` was always `undefined` — no events were ever processed
- Welcome notifications (Telegram, Slack, email on first connect) were never delivered
- Real-time event alerts were silently dropped even though Upstash confirmed delivery (`{"result":1}`)

**Fix:** Switch to reading the response body as a stream, parsing each `data:` line as an SSE envelope `{type, channel, message}`, and only processing lines where `type === "message"`.

## Test plan

- [ ] Deploy relay to Railway — logs should now show `[relay] Processing event:` lines when events are published
- [ ] Connect a Slack/email channel — welcome message should arrive
- [ ] Pair Telegram — bot should send welcome message (via Convex directly, not relay)
- [ ] Trigger a real notification event — all connected channels should receive it

## Post-Deploy Monitoring & Validation

- **Logs (Railway):** Look for `[relay] Processing event:` — confirms SSE stream is being read
- **Failure signal:** Only `[relay] Starting notification relay...` on repeat with no processing lines = still broken
- **Healthy signal:** Events appear within a few seconds of being published to Upstash
- **Validation window:** 10 minutes after deploy