### PR TITLE
debug(relay): logs + fix ctx.waitUntil in Slack OAuth callback

### DIFF
--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -46,10 +46,14 @@ async function encryptSlackWebhook(webhookUrl: string): Promise<string> {
 }
 
 async function publishWelcome(userId: string, channelType: string): Promise<void> {
-  if (!UPSTASH_URL || !UPSTASH_TOKEN) return;
+  if (!UPSTASH_URL || !UPSTASH_TOKEN) {
+    console.error('[notification-channels] publishWelcome: UPSTASH env vars missing — welcome not queued');
+    return;
+  }
+  console.log(`[notification-channels] publishWelcome: queuing ${channelType} for ${userId}`);
   const msg = JSON.stringify({ eventType: 'channel_welcome', userId, channelType });
   try {
-    await fetch(`${UPSTASH_URL}/lpush/wm:events:queue/${encodeURIComponent(msg)}`, {
+    const res = await fetch(`${UPSTASH_URL}/lpush/wm:events:queue/${encodeURIComponent(msg)}`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${UPSTASH_TOKEN}`,
@@ -57,8 +61,10 @@ async function publishWelcome(userId: string, channelType: string): Promise<void
       },
       signal: AbortSignal.timeout(5000),
     });
-  } catch {
-    // best-effort
+    const data = await res.json().catch(() => null) as { result?: unknown } | null;
+    console.log(`[notification-channels] publishWelcome LPUSH: status=${res.status} result=${JSON.stringify(data?.result)}`);
+  } catch (err) {
+    console.error('[notification-channels] publishWelcome LPUSH failed:', (err as Error).message);
   }
 }
 
@@ -172,6 +178,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
           return json({ error: 'Operation failed' }, 500, corsHeaders);
         }
         const setResult = await resp.json() as { ok: boolean; isNew?: boolean };
+        console.log(`[notification-channels] set-channel ${channelType}: isNew=${setResult.isNew}`);
         // Only send welcome on first connect, not re-links; use waitUntil so the edge isolate doesn't terminate early
         if (setResult.isNew) ctx.waitUntil(publishWelcome(session.userId, channelType));
         return json({ ok: true }, 200, corsHeaders);

--- a/api/slack/oauth/callback.ts
+++ b/api/slack/oauth/callback.ts
@@ -63,11 +63,23 @@ function escapeHtml(s: string): string {
 }
 
 async function publishWelcome(userId: string, channelType: string): Promise<void> {
+  if (!UPSTASH_URL || !UPSTASH_TOKEN) {
+    console.error('[slack-oauth] publishWelcome: UPSTASH env vars missing — welcome not queued');
+    return;
+  }
+  console.log(`[slack-oauth] publishWelcome: queuing ${channelType} for ${userId}`);
   const msg = JSON.stringify({ eventType: 'channel_welcome', userId, channelType });
-  await fetch(`${UPSTASH_URL}/lpush/wm:events:queue/${encodeURIComponent(msg)}`, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${UPSTASH_TOKEN}`, 'User-Agent': 'worldmonitor-edge/1.0' },
-  }).catch(() => {});
+  try {
+    const res = await fetch(`${UPSTASH_URL}/lpush/wm:events:queue/${encodeURIComponent(msg)}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${UPSTASH_TOKEN}`, 'User-Agent': 'worldmonitor-edge/1.0' },
+      signal: AbortSignal.timeout(5000),
+    });
+    const data = await res.json().catch(() => null) as { result?: unknown } | null;
+    console.log(`[slack-oauth] publishWelcome LPUSH: status=${res.status} result=${JSON.stringify(data?.result)}`);
+  } catch (err) {
+    console.error('[slack-oauth] publishWelcome LPUSH failed:', (err as Error).message);
+  }
 }
 
 function htmlResponse(script: string, body: string): Response {
@@ -98,7 +110,7 @@ function errorAndClose(error: string): Response {
   );
 }
 
-export default async function handler(req: Request): Promise<Response> {
+export default async function handler(req: Request, ctx: { waitUntil: (p: Promise<unknown>) => void }): Promise<Response> {
   const url = new URL(req.url);
   const code = url.searchParams.get('code');
   const state = url.searchParams.get('state');
@@ -173,7 +185,8 @@ export default async function handler(req: Request): Promise<Response> {
   if (!convexRes?.ok) return errorAndClose('storage_failed');
 
   const stored = await convexRes.json() as { ok: boolean; isNew?: boolean };
-  if (stored.isNew) void publishWelcome(userId, 'slack');
+  console.log(`[slack-oauth] Convex set-slack-oauth: isNew=${stored.isNew}`);
+  if (stored.isNew) ctx.waitUntil(publishWelcome(userId, 'slack'));
 
   return postAndClose({
     type: 'wm:slack_connected',

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -274,10 +274,15 @@ async function processEvent(event) {
 
 async function subscribe() {
   console.log('[relay] Starting notification relay...');
+  console.log('[relay] UPSTASH_URL set:', !!UPSTASH_URL, '| CONVEX_URL set:', !!CONVEX_URL, '| RELAY_SECRET set:', !!RELAY_SECRET);
+  console.log('[relay] TELEGRAM_BOT_TOKEN set:', !!TELEGRAM_BOT_TOKEN, '| RESEND_API_KEY set:', !!RESEND_API_KEY);
+  let idleCount = 0;
   while (true) {
     try {
       const result = await upstashRest('RPOP', 'wm:events:queue');
       if (result) {
+        idleCount = 0;
+        console.log('[relay] RPOP dequeued message:', String(result).slice(0, 200));
         try {
           const event = JSON.parse(result);
           await processEvent(event);
@@ -285,7 +290,11 @@ async function subscribe() {
           console.warn('[relay] Failed to parse event:', err.message, '| raw:', String(result).slice(0, 120));
         }
       } else {
-        // Queue empty — wait 1s before polling again
+        idleCount++;
+        // Log a heartbeat every 60s so we know the relay is alive and connected
+        if (idleCount % 60 === 0) {
+          console.log(`[relay] Heartbeat: idle ${idleCount}s, queue empty, Upstash OK`);
+        }
         await new Promise(r => setTimeout(r, 1000));
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

- **Bug fix**: `api/slack/oauth/callback.ts` used `void publishWelcome(...)` without `ctx.waitUntil` — Vercel edge isolate terminates after returning the response, killing the in-flight LPUSH fetch. Switched to `ctx.waitUntil(publishWelcome(...))` to match `api/notification-channels.ts`.
- **Debug logs** added throughout the entire publish/relay pipeline so we can trace failures in Vercel Function logs and Railway container logs:
  - Relay: env var presence at startup, RPOP message content, 60s heartbeat when idle
  - `notification-channels`: `isNew` value, missing UPSTASH vars warning, LPUSH HTTP status + result
  - `slack-oauth`: same

## What to look for after merging

**Vercel Function Logs** (when connecting Slack via OAuth):
```
[slack-oauth] Convex set-slack-oauth: isNew=true
[slack-oauth] publishWelcome: queuing slack for <userId>
[slack-oauth] publishWelcome LPUSH: status=200 result=1
```

**Railway Logs** (every 60s + on message):
```
[relay] UPSTASH_URL set: true | CONVEX_URL set: true | ...
[relay] Heartbeat: idle 60s, queue empty, Upstash OK
[relay] RPOP dequeued message: {"eventType":"channel_welcome",...}
[relay] Processing event: channel_welcome
```

## Post-Deploy Monitoring

- If Vercel logs show `UPSTASH env vars missing` → add `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` to Vercel
- If Vercel logs show LPUSH `status=200 result=1` but Railway shows no RPOP → key name mismatch (shouldn't happen)
- If Railway heartbeat shows `Upstash OK` but no RPOP after Vercel publishes → investigate Upstash instance