### PR TITLE
fix(sentry): filter .at() noise from Instagram/old Android browsers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -259,6 +259,7 @@ Sentry.init({
     /Can only call Window\.setTimeout on instances of Window/, // iOS Safari cross-frame setTimeout from 3rd-party injected script
     /^Can't find variable: _G$/, // browser extension/userscript injecting _G global
     /onAppPageCallback is not defined/, // Android Chrome WebView injection (Huawei/Samsung browsers)
+    /\.at is not a function/, // Instagram/older Android in-app browsers missing Array.at()
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary
- Add `/\.at is not a function/` to Sentry `ignoreErrors` in `src/main.ts`
- Instagram in-app browser on Android 10 lacks `Array.at()` support, producing non-actionable TypeErrors with no usable stack trace
- Resolved 5 Sentry issues (WORLDMONITOR-JG/JJ/JK/JH/JF) as `inNextRelease`

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run typecheck:api` passes
- [x] `npm run lint` passes (warnings only, no errors)
- [x] `npm run test:data` passes
- [x] Edge function tests pass