### PR TITLE
fix(notif-ui): stop poll on pairing success, abort on close, no-cache GET

### DIFF
--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -68,10 +68,14 @@ async function publishWelcome(userId: string, channelType: string): Promise<void
   }
 }
 
-function json(body: unknown, status: number, cors: Record<string, string>): Response {
+function json(body: unknown, status: number, cors: Record<string, string>, noCache = false): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { 'Content-Type': 'application/json', ...cors },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(noCache ? { 'Cache-Control': 'no-store' } : {}),
+      ...cors,
+    },
   });
 }
 
@@ -132,7 +136,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
         return json({ error: 'Failed to fetch' }, 500, corsHeaders);
       }
       const data = await resp.json();
-      return json(data, 200, corsHeaders);
+      return json(data, 200, corsHeaders, true);
     } catch (err) {
       console.error('[notification-channels] GET error:', err);
       void captureEdgeException(err, { handler: 'notification-channels', method: 'GET' });

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -183,6 +183,8 @@ export class UnifiedSettings {
   public close(): void {
     if (this.hasPendingPanelChanges() && !confirm(t('header.unsavedChanges'))) return;
     this.overlay.classList.remove('active');
+    this.prefsCleanup?.();
+    this.prefsCleanup = null;
     this.resetPanelDraft();
     localStorage.removeItem('wm-settings-open');
     document.removeEventListener('keydown', this.escapeHandler);

--- a/src/services/preferences-content.ts
+++ b/src/services/preferences-content.ts
@@ -887,6 +887,7 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
                 getChannelsData().then((data) => {
                   const tg = data.channels.find(c => c.channelType === 'telegram');
                   if (tg?.verified) {
+                    clearNotifPoll();
                     saveRuleWithNewChannel('telegram');
                     reloadNotifSection();
                   }


### PR DESCRIPTION
## Summary

Three fixes for the \"Not connected\" UI state persisting after successful Telegram pairing:

- **Stop poll when pairing succeeds**: `clearNotifPoll()` was missing before `reloadNotifSection()` in the interval's success branch. Without it, the poll kept firing every 3s, repeatedly calling `reloadNotifSection()`. Each call hid the Connected row (loading flash) before re-rendering it, and concurrent renders could race.

- **Abort prefs controller on settings close**: `UnifiedSettings.close()` was not calling `prefsCleanup?.()`. The `AbortController` and any running poll interval survived until the user *reopened* settings (which called cleanup before re-rendering). This meant the poll could run in the background after the user closed settings, burning extra network requests and potentially interfering with state.

- **Cache-Control: no-store on GET /api/notification-channels**: The response had no cache headers. Added `no-store` so Cloudflare (or any CDN/proxy) never serves a stale channel list that was cached before the Telegram channel was verified.

## Files changed

- `src/services/preferences-content.ts` — add `clearNotifPoll()` in poll success branch
- `src/components/UnifiedSettings.ts` — call `prefsCleanup?.()` in `close()`
- `api/notification-channels.ts` — emit `Cache-Control: no-store` on GET 200 response

## Test plan

- [ ] Connect Telegram: click Connect, copy `/start TOKEN`, paste in bot, receive "✅ WorldMonitor connected!" → row immediately switches to Connected without any loading flash
- [ ] Close settings while pairing UI is showing → reopen → should see the token row, not "Failed to load"
- [ ] After successful pairing, close and reopen settings → Telegram row shows Connected
- [ ] Verify no extra `getChannelsData` network calls after pairing (poll should stop)

## Post-Deploy Monitoring & Validation

- **No operational impact** — three client-side / edge-function fixes; no schema or backend changes. No additional operational monitoring required.