### PR TITLE
feat(resilience): add Pro gating for resilience RPCs

### DIFF
--- a/src/shared/premium-paths.ts
+++ b/src/shared/premium-paths.ts
@@ -10,4 +10,6 @@ export const PREMIUM_RPC_PATHS = new Set<string>([
   '/api/market/v1/backtest-stock',
   '/api/market/v1/list-stored-stock-backtests',
   '/api/intelligence/v1/deduct-situation',
+  '/api/resilience/v1/get-resilience-score',
+  '/api/resilience/v1/get-resilience-ranking',
 ]);

--- a/tests/premium-stock-gateway.test.mts
+++ b/tests/premium-stock-gateway.test.mts
@@ -12,12 +12,22 @@ afterEach(() => {
   else process.env.WORLDMONITOR_VALID_KEYS = originalKeys;
 });
 
-describe('premium stock gateway enforcement', () => {
+describe('premium gateway API key enforcement', () => {
   it('requires credentials for premium endpoints regardless of origin', async () => {
     const handler = createDomainGateway([
       {
         method: 'GET',
         path: '/api/market/v1/analyze-stock',
+        handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      },
+      {
+        method: 'GET',
+        path: '/api/resilience/v1/get-resilience-score',
+        handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      },
+      {
+        method: 'GET',
+        path: '/api/resilience/v1/get-resilience-ranking',
         handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
       },
       {
@@ -35,6 +45,16 @@ describe('premium stock gateway enforcement', () => {
     }));
     assert.equal(browserNoKey.status, 401);
 
+    const resilienceScoreNoKey = await handler(new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=US', {
+      headers: { Origin: 'https://worldmonitor.app' },
+    }));
+    assert.equal(resilienceScoreNoKey.status, 401);
+
+    const resilienceRankingNoKey = await handler(new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-ranking', {
+      headers: { Origin: 'https://worldmonitor.app' },
+    }));
+    assert.equal(resilienceRankingNoKey.status, 401);
+
     // Trusted browser origin with a valid key — also allowed
     const browserWithKey = await handler(new Request('https://worldmonitor.app/api/market/v1/analyze-stock?symbol=AAPL', {
       headers: {
@@ -43,6 +63,22 @@ describe('premium stock gateway enforcement', () => {
       },
     }));
     assert.equal(browserWithKey.status, 200);
+
+    const resilienceScoreWithKey = await handler(new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=US', {
+      headers: {
+        Origin: 'https://worldmonitor.app',
+        'X-WorldMonitor-Key': 'real-key-123',
+      },
+    }));
+    assert.equal(resilienceScoreWithKey.status, 200);
+
+    const resilienceRankingWithKey = await handler(new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-ranking', {
+      headers: {
+        Origin: 'https://worldmonitor.app',
+        'X-WorldMonitor-Key': 'real-key-123',
+      },
+    }));
+    assert.equal(resilienceRankingWithKey.status, 200);
 
     // Unknown origin — blocked (403 from isDisallowedOrigin before key check)
     const unknownNoKey = await handler(new Request('https://external.example.com/api/market/v1/analyze-stock?symbol=AAPL', {
@@ -62,7 +98,7 @@ describe('premium stock gateway enforcement', () => {
 // Bearer token auth path for premium endpoints
 // ---------------------------------------------------------------------------
 
-describe('premium stock gateway bearer token auth', () => {
+describe('premium gateway bearer token auth', () => {
   let privateKey: CryptoKey;
   let wrongPrivateKey: CryptoKey;
   let jwksServer: Server;
@@ -109,6 +145,11 @@ describe('premium stock gateway bearer token auth', () => {
       },
       {
         method: 'GET',
+        path: '/api/resilience/v1/get-resilience-score',
+        handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      },
+      {
+        method: 'GET',
         path: '/api/market/v1/list-market-quotes',
         handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
       },
@@ -134,6 +175,17 @@ describe('premium stock gateway bearer token auth', () => {
   it('accepts valid Pro bearer token on premium endpoint → 200', async () => {
     const token = await signToken({ sub: 'user_pro', plan: 'pro' });
     const res = await handler(new Request('https://worldmonitor.app/api/market/v1/analyze-stock?symbol=AAPL', {
+      headers: {
+        Origin: 'https://worldmonitor.app',
+        Authorization: `Bearer ${token}`,
+      },
+    }));
+    assert.equal(res.status, 200);
+  });
+
+  it('accepts valid Pro bearer token on resilience premium endpoint → 200', async () => {
+    const token = await signToken({ sub: 'user_pro', plan: 'pro' });
+    const res = await handler(new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=US', {
       headers: {
         Origin: 'https://worldmonitor.app',
         Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- add the two resilience RPCs to `src/shared/premium-paths.ts`
- extend the premium gateway test to cover resilience score/ranking API-key gating
- add a Pro bearer-token assertion for the resilience score endpoint

## Testing
- `node --import tsx --test tests/premium-stock-gateway.test.mts`
- `node_modules/@biomejs/biome/bin/biome check src/shared/premium-paths.ts tests/premium-stock-gateway.test.mts`

## Notes
- This keeps the change scoped to T7 and uses the existing shared premium-path source of truth consumed by both the gateway and web runtime.
- The live endpoint dependency from T1 still applies; this PR wires the gating list and test coverage so the resilience routes are protected once they exist.

Refs #2484.

AI assistance: drafted and iterated with Codex, then reviewed and validated locally before opening this PR.