### PR TITLE
feat(notifications): move alert detection fully server-side

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -257,6 +257,90 @@ function upstashMGet(keys) {
   });
 }
 
+function upstashLpush(key, value) {
+  return new Promise((resolve) => {
+    if (!UPSTASH_ENABLED) return resolve(false);
+    const url = new URL('/', UPSTASH_REDIS_REST_URL);
+    const serialized = typeof value === 'string' ? value : JSON.stringify(value);
+    const body = JSON.stringify(['LPUSH', key, serialized]);
+    const req = https.request(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      timeout: 5000,
+    }, (resp) => {
+      let data = '';
+      resp.on('data', (chunk) => { data += chunk; });
+      resp.on('end', () => {
+        try {
+          const parsed = JSON.parse(data);
+          resolve(typeof parsed?.result === 'number' && parsed.result > 0);
+        } catch { resolve(false); }
+      });
+    });
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => { req.destroy(); resolve(false); });
+    req.end(body);
+  });
+}
+
+function upstashSetNx(key, value, ttlSeconds) {
+  return new Promise((resolve) => {
+    if (!UPSTASH_ENABLED) return resolve(null);
+    const url = new URL('/', UPSTASH_REDIS_REST_URL);
+    const serialized = typeof value === 'string' ? value : JSON.stringify(value);
+    const body = JSON.stringify(['SET', key, serialized, 'NX', 'EX', String(ttlSeconds)]);
+    const req = https.request(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      timeout: 5000,
+    }, (resp) => {
+      let data = '';
+      resp.on('data', (chunk) => { data += chunk; });
+      resp.on('end', () => {
+        try {
+          const parsed = JSON.parse(data);
+          resolve(parsed?.result === 'OK' ? 'OK' : null);
+        } catch { resolve(null); }
+      });
+    });
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => { req.destroy(); resolve(null); });
+    req.end(body);
+  });
+}
+
+function notifySimpleHash(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
+  return Math.abs(h).toString(36);
+}
+
+async function publishNotificationEvent({ eventType, payload, severity, variant }) {
+  try {
+    const dedupKey = `wm:notif:scan-dedup:${eventType}:${notifySimpleHash(`${eventType}:${payload.title ?? ''}`)}`;
+    const isNew = await upstashSetNx(dedupKey, '1', 1800);
+    if (!isNew) {
+      console.log(`[Notify] Dedup hit — ${eventType}: ${String(payload.title ?? '').slice(0, 60)}`);
+      return;
+    }
+    const msg = JSON.stringify({ eventType, payload, severity, ...(variant ? { variant } : {}), publishedAt: Date.now() });
+    const ok = await upstashLpush('wm:events:queue', msg);
+    if (ok) {
+      console.log(`[Notify] Queued ${severity} event: ${eventType} — ${String(payload.title ?? '').slice(0, 60)}`);
+    } else {
+      console.warn(`[Notify] LPUSH failed for ${eventType}`);
+    }
+  } catch (e) {
+    console.warn(`[Notify] publishNotificationEvent error (${eventType}):`, e?.message || e);
+  }
+}
+
 let upstreamSocket = null;
 let upstreamPaused = false;
 let upstreamQueue = [];
@@ -717,6 +801,20 @@ async function orefFetchAlerts() {
         timestamp: new Date().toISOString(),
       });
       orefState._persistVersion++;
+
+      const orefTitle = alerts[0]?.title || 'Siren alert';
+      const orefLocations = alerts.flatMap(a => Array.isArray(a.data) ? a.data : []);
+      const orefShown = orefLocations.slice(0, 3);
+      const orefOverflow = orefLocations.length - orefShown.length;
+      const orefLocationSuffix = orefShown.length
+        ? ' — ' + orefShown.join(', ') + (orefOverflow > 0 ? ` +${orefOverflow} areas` : '')
+        : '';
+      publishNotificationEvent({
+        eventType: 'oref_siren',
+        payload: { title: orefTitle + orefLocationSuffix, source: 'OREF Pikud HaOref' },
+        severity: 'critical',
+        variant: undefined,
+      }).catch(e => console.warn('[Notify] OREF publish error:', e?.message));
     }
 
     const cutoff = Date.now() - 24 * 60 * 60 * 1000;
@@ -2088,6 +2186,17 @@ async function seedAviationDelays() {
     const ok = await upstashSet(AVIATION_REDIS_KEY, { alerts }, AVIATION_SEED_TTL);
     await upstashSet('seed-meta:aviation:intl', { fetchedAt: Date.now(), recordCount: alerts.length }, 604800);
     console.log(`[Aviation] Seeded ${alerts.length} alerts (${succeeded} ok, ${failed} failed, redis: ${ok ? 'OK' : 'FAIL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+    const notifyAlerts = alerts.filter(a =>
+      a.severity === 'FLIGHT_DELAY_SEVERITY_SEVERE' || a.severity === 'FLIGHT_DELAY_SEVERITY_MAJOR'
+    );
+    for (const a of notifyAlerts.slice(0, 3)) {
+      publishNotificationEvent({
+        eventType: 'aviation_closure',
+        payload: { title: `${a.iata}${a.city ? ` (${a.city})` : ''}: ${a.reason || 'Airport disruption'}`, source: 'AviationStack' },
+        severity: a.severity === 'FLIGHT_DELAY_SEVERITY_SEVERE' ? 'critical' : 'high',
+        variant: undefined,
+      }).catch(e => console.warn('[Notify] Aviation publish error:', e?.message));
+    }
   } catch (e) {
     console.warn('[Aviation] Seed error:', e?.message || e, '— extending TTL, retrying in 20min');
     try { await upstashExpire(AVIATION_REDIS_KEY, AVIATION_SEED_TTL); } catch {}
@@ -2123,6 +2232,7 @@ const NOTAM_RETRY_MS = 20 * 60 * 1000;
 const NOTAM_QUOTA_BACKOFF_MS = 24 * 60 * 60 * 1000; // 24h backoff when ICAO quota is exhausted
 const NOTAM_REDIS_KEY = 'aviation:notam:closures:v2';
 const NOTAM_CLOSURE_QCODES = new Set(['FA', 'AH', 'AL', 'AW', 'AC', 'AM']);
+const notamPrevClosed = new Set();
 const NOTAM_MONITORED_ICAO = [
   // MENA
   'OEJN', 'OERK', 'OEMA', 'OEDF', 'OMDB', 'OMAA', 'OMSJ',
@@ -2244,6 +2354,17 @@ async function seedNotamClosures() {
   await upstashSet('seed-meta:aviation:notam', { fetchedAt: Date.now(), recordCount: closedIcaos.length }, 604800);
   const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
   console.log(`[NOTAM-Seed] ${notams.length} raw NOTAMs, ${closedIcaos.length} closures (redis: ${ok ? 'OK' : 'FAIL'}) in ${elapsed}s`);
+  const newClosures = closedIcaos.filter(icao => !notamPrevClosed.has(icao));
+  notamPrevClosed.clear();
+  closedIcaos.forEach(icao => notamPrevClosed.add(icao));
+  for (const icao of newClosures.slice(0, 3)) {
+    publishNotificationEvent({
+      eventType: 'notam_closure',
+      payload: { title: `NOTAM: ${icao} — ${reasons[icao] || 'Airport closure'}`, source: 'ICAO NOTAM' },
+      severity: 'high',
+      variant: undefined,
+    }).catch(e => console.warn('[Notify] NOTAM publish error:', e?.message));
+  }
   } catch (e) {
     console.warn('[NOTAM-Seed] Seed error:', e?.message || e, '— extending TTL, retrying in 20min');
     try { await upstashExpire(NOTAM_REDIS_KEY, NOTAM_SEED_TTL); } catch {}
@@ -3086,6 +3207,14 @@ async function seedClassifyForVariant(variant, seenTitles) {
           if (!byCountry[code]) byCountry[code] = emptyLevel();
           byCountry[code][level]++;
         }
+        if (level === 'critical' || level === 'high') {
+          publishNotificationEvent({
+            eventType: 'rss_alert',
+            payload: { title: chunk[idx], source: variant },
+            severity: level,
+            variant,
+          }).catch(e => console.warn('[Notify] Classify publish error:', e?.message));
+        }
       }
     }
 
@@ -3862,6 +3991,15 @@ async function seedWeatherAlerts() {
     const ok1 = await upstashSet(WEATHER_REDIS_KEY, payload, WEATHER_CACHE_TTL);
     const ok2 = await upstashSet('seed-meta:weather:alerts', { fetchedAt: Date.now(), recordCount: alerts.length }, 604800);
     console.log(`[Weather] Seeded ${alerts.length} alerts (redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+    const highSeverityAlerts = alerts.filter(a => a.severity === 'Extreme' || a.severity === 'Severe');
+    for (const a of highSeverityAlerts.slice(0, 3)) {
+      publishNotificationEvent({
+        eventType: 'weather_alert',
+        payload: { title: a.headline || a.event, source: 'NWS' },
+        severity: a.severity === 'Extreme' ? 'critical' : 'high',
+        variant: undefined,
+      }).catch(e => console.warn('[Notify] Weather publish error:', e?.message));
+    }
   } catch (e) {
     console.warn('[Weather] Seed error:', e?.message || e);
   } finally {

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2266,15 +2266,22 @@ async function seedAviationDelays() {
     const ok = await upstashSet(AVIATION_REDIS_KEY, { alerts }, AVIATION_SEED_TTL);
     await upstashSet('seed-meta:aviation:intl', { fetchedAt: Date.now(), recordCount: alerts.length }, 604800);
     console.log(`[Aviation] Seeded ${alerts.length} alerts (${succeeded} ok, ${failed} failed, redis: ${ok ? 'OK' : 'FAIL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
-    const notifyAlerts = alerts.filter(a =>
+    const severeAlerts = alerts.filter(a =>
       a.severity === 'FLIGHT_DELAY_SEVERITY_SEVERE' || a.severity === 'FLIGHT_DELAY_SEVERITY_MAJOR'
     );
-    for (const a of notifyAlerts.slice(0, 3)) {
+    // Change detection: only notify for airports newly entering severe/major state.
+    // aviationPrevAlertedSet persists across polls in-memory; dedupTtl (4h) guards restarts.
+    const currentIatas = new Set(severeAlerts.map(a => a.iata).filter(Boolean));
+    const newAlerts = severeAlerts.filter(a => a.iata && !aviationPrevAlertedSet.has(a.iata));
+    aviationPrevAlertedSet.clear();
+    currentIatas.forEach(iata => aviationPrevAlertedSet.add(iata));
+    for (const a of newAlerts.slice(0, 3)) {
       publishNotificationEvent({
         eventType: 'aviation_closure',
         payload: { title: `${a.iata}${a.city ? ` (${a.city})` : ''}: ${a.reason || 'Airport disruption'}`, source: 'AviationStack' },
         severity: a.severity === 'FLIGHT_DELAY_SEVERITY_SEVERE' ? 'critical' : 'high',
         variant: undefined,
+        dedupTtl: 14400, // 4h — well above the 30min poll interval
       }).catch(e => console.warn('[Notify] Aviation publish error:', e?.message));
     }
   } catch (e) {
@@ -2313,6 +2320,8 @@ const NOTAM_QUOTA_BACKOFF_MS = 24 * 60 * 60 * 1000; // 24h backoff when ICAO quo
 const NOTAM_REDIS_KEY = 'aviation:notam:closures:v2';
 const NOTAM_CLOSURE_QCODES = new Set(['FA', 'AH', 'AL', 'AW', 'AC', 'AM']);
 const notamPrevClosed = new Set();
+let notamStateLoaded = false; // true after first Redis load — prevents false positives on restart
+const aviationPrevAlertedSet = new Set(); // tracks IATA codes currently in severe/major state
 const cyberPrevAlertedIds = new Set(); // tracks indicators notified this session; cleared at 500 entries
 const ucdpPrevAlertedIds = new Set();  // tracks UCDP event IDs notified; cleared at 500 entries
 const NOTAM_MONITORED_ICAO = [
@@ -2436,15 +2445,27 @@ async function seedNotamClosures() {
   await upstashSet('seed-meta:aviation:notam', { fetchedAt: Date.now(), recordCount: closedIcaos.length }, 604800);
   const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
   console.log(`[NOTAM-Seed] ${notams.length} raw NOTAMs, ${closedIcaos.length} closures (redis: ${ok ? 'OK' : 'FAIL'}) in ${elapsed}s`);
+  // On first run after a restart, pre-populate notamPrevClosed from Redis so
+  // airports that were already closed before the restart are not treated as new.
+  if (!notamStateLoaded) {
+    notamStateLoaded = true;
+    try {
+      const saved = await upstashGet('notam:prev-closed-state:v1');
+      if (Array.isArray(saved)) saved.forEach(icao => notamPrevClosed.add(icao));
+    } catch {}
+  }
   const newClosures = closedIcaos.filter(icao => !notamPrevClosed.has(icao));
   notamPrevClosed.clear();
   closedIcaos.forEach(icao => notamPrevClosed.add(icao));
+  // Persist current closed set so next restart doesn't re-fire existing closures.
+  upstashSet('notam:prev-closed-state:v1', closedIcaos, NOTAM_SEED_TTL * 2).catch(() => {});
   for (const icao of newClosures.slice(0, 3)) {
     publishNotificationEvent({
       eventType: 'notam_closure',
       payload: { title: `NOTAM: ${icao} — ${reasons[icao] || 'Airport closure'}`, source: 'ICAO NOTAM' },
       severity: 'high',
       variant: undefined,
+      dedupTtl: 21600, // 6h — well above the 2h poll interval; guards across restarts
     }).catch(e => console.warn('[Notify] NOTAM publish error:', e?.message));
   }
   } catch (e) {
@@ -4095,7 +4116,7 @@ async function seedWeatherAlerts() {
     for (const a of highSeverityAlerts.slice(0, 3)) {
       publishNotificationEvent({
         eventType: 'weather_alert',
-        payload: { title: a.headline || a.event, source: 'NWS' },
+        payload: { title: a.headline || a.event || 'Weather alert', source: 'NWS' },
         severity: a.severity === 'Extreme' ? 'critical' : 'high',
         variant: undefined,
       }).catch(e => console.warn('[Notify] Weather publish error:', e?.message));

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3298,21 +3298,23 @@ async function seedClassifyForVariant(variant, seenTitles) {
       classifiedSet.add(idx);
       await upstashSet(classifyCacheKey(chunk[idx]), { level, category, timestamp: Date.now() }, CLASSIFY_CACHE_TTL);
       classified++;
-      // Attribute newly classified title while it's still in scope
+      // Attribute newly classified title to country stats (global dedup via seenTitles)
       if (!seenTitles.has(chunk[idx])) {
         seenTitles.add(chunk[idx]);
         for (const code of matchCountryNamesInText(chunk[idx])) {
           if (!byCountry[code]) byCountry[code] = emptyLevel();
           byCountry[code][level]++;
         }
-        if (level === 'critical' || level === 'high') {
-          publishNotificationEvent({
-            eventType: 'rss_alert',
-            payload: { title: chunk[idx], source: variant },
-            severity: level,
-            variant,
-          }).catch(e => console.warn('[Notify] Classify publish error:', e?.message));
-        }
+      }
+      // Notifications are outside seenTitles guard — each variant publishes
+      // independently, protected by the variant-scoped Redis scan-dedup key.
+      if (level === 'critical' || level === 'high') {
+        publishNotificationEvent({
+          eventType: 'rss_alert',
+          payload: { title: chunk[idx], source: variant },
+          severity: level,
+          variant,
+        }).catch(e => console.warn('[Notify] Classify publish error:', e?.message));
       }
     }
 

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -321,10 +321,10 @@ function notifySimpleHash(str) {
   return Math.abs(h).toString(36);
 }
 
-async function publishNotificationEvent({ eventType, payload, severity, variant }) {
+async function publishNotificationEvent({ eventType, payload, severity, variant, dedupTtl = 1800 }) {
   try {
     const dedupKey = `wm:notif:scan-dedup:${eventType}:${notifySimpleHash(`${eventType}:${payload.title ?? ''}`)}`;
-    const isNew = await upstashSetNx(dedupKey, '1', 1800);
+    const isNew = await upstashSetNx(dedupKey, '1', dedupTtl);
     if (!isNew) {
       console.log(`[Notify] Dedup hit — ${eventType}: ${String(payload.title ?? '').slice(0, 60)}`);
       return;
@@ -1223,6 +1223,19 @@ async function seedUcdpEvents() {
     const ok = await upstashSet(UCDP_REDIS_KEY, payload, UCDP_TTL_SECONDS);
     await upstashSet('seed-meta:conflict:ucdp-events', { fetchedAt: Date.now(), recordCount: mapped.length }, 604800);
     console.log(`[UCDP] Seeded ${mapped.length} events (raw: ${allEvents.length}, failed pages: ${failedPages}, redis: ${ok ? 'OK' : 'FAIL'})`);
+    const newConflicts = mapped.filter(e => e.deathsBest >= 10 && !ucdpPrevAlertedIds.has(e.id)).sort((a, b) => b.deathsBest - a.deathsBest);
+    for (const e of newConflicts.slice(0, 2)) {
+      ucdpPrevAlertedIds.add(e.id);
+      const parties = e.sideA && e.sideB ? `${e.sideA.slice(0, 40)} vs ${e.sideB.slice(0, 40)}` : e.sideA || e.sideB || 'Unknown parties';
+      publishNotificationEvent({
+        eventType: 'conflict_escalation',
+        payload: { title: `${e.country}: ${parties} — ${e.deathsBest} casualties`, source: 'UCDP' },
+        severity: e.deathsBest >= 50 ? 'critical' : 'high',
+        variant: undefined,
+        dedupTtl: 86400,
+      }).catch(err => console.warn('[Notify] UCDP publish error:', err?.message));
+    }
+    if (ucdpPrevAlertedIds.size > 500) ucdpPrevAlertedIds.clear();
   } catch (e) {
     console.warn('[UCDP] Seed error:', e?.message || e);
   }
@@ -1507,6 +1520,18 @@ async function seedMarketQuotes() {
   const ok2 = await upstashSet('market:stocks-bootstrap:v1', payload, MARKET_SEED_TTL);
   const ok3 = await upstashSet('seed-meta:market:stocks', { fetchedAt: Date.now(), recordCount: quotes.length }, 604800);
   console.log(`[Market] Seeded ${quotes.length}/${MARKET_SYMBOLS.length} quotes (redis: ${ok && ok2 && ok3 ? 'OK' : 'PARTIAL'})`);
+  const movingStocks = quotes.filter(q => Math.abs(q.change ?? 0) >= 5).sort((a, b) => Math.abs(b.change) - Math.abs(a.change));
+  for (const q of movingStocks.slice(0, 3)) {
+    const pct = Math.round(q.change);
+    const dir = q.change < 0 ? 'decline' : 'surge';
+    publishNotificationEvent({
+      eventType: 'market_alert',
+      payload: { title: `${q.symbol}: ${pct > 0 ? '+' : ''}${pct}% ${dir}`, source: 'Equity Market' },
+      severity: Math.abs(q.change) >= 10 ? 'critical' : 'high',
+      variant: undefined,
+      dedupTtl: 3600,
+    }).catch(e => console.warn('[Notify] Market stock publish error:', e?.message));
+  }
   return quotes.length;
 }
 
@@ -1549,6 +1574,18 @@ async function seedCommodityQuotes() {
   const ok3 = await upstashSet('market:commodities-bootstrap:v1', quotesPayload, MARKET_SEED_TTL);
   const ok4 = await upstashSet('seed-meta:market:commodities', { fetchedAt: Date.now(), recordCount: quotes.length }, 604800);
   console.log(`[Market] Seeded ${quotes.length}/${COMMODITY_SYMBOLS.length} commodities (redis: ${ok && ok2 && ok3 && ok4 ? 'OK' : 'PARTIAL'})`);
+  const movingCommodities = quotes.filter(q => Math.abs(q.change ?? 0) >= 5).sort((a, b) => Math.abs(b.change) - Math.abs(a.change));
+  for (const q of movingCommodities.slice(0, 3)) {
+    const pct = Math.round(q.change);
+    const dir = q.change < 0 ? 'decline' : 'surge';
+    publishNotificationEvent({
+      eventType: 'market_alert',
+      payload: { title: `${q.name || q.symbol}: ${pct > 0 ? '+' : ''}${pct}% ${dir}`, source: 'Commodity Market' },
+      severity: Math.abs(q.change) >= 10 ? 'critical' : 'high',
+      variant: undefined,
+      dedupTtl: 3600,
+    }).catch(e => console.warn('[Notify] Commodity publish error:', e?.message));
+  }
   return quotes.length;
 }
 
@@ -1737,6 +1774,18 @@ async function seedCryptoQuotes() {
   const ok1 = await upstashSet('market:crypto:v1', { quotes }, CRYPTO_SEED_TTL);
   const ok2 = await upstashSet('seed-meta:market:crypto', { fetchedAt: Date.now(), recordCount: quotes.length }, 604800);
   console.log(`[Crypto] Seeded ${quotes.length}/${CRYPTO_IDS.length} quotes (redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'})`);
+  const movingCrypto = quotes.filter(q => Math.abs(q.change ?? 0) >= 10).sort((a, b) => Math.abs(b.change) - Math.abs(a.change));
+  for (const q of movingCrypto.slice(0, 3)) {
+    const pct = Math.round(q.change);
+    const dir = q.change < 0 ? 'decline' : 'surge';
+    publishNotificationEvent({
+      eventType: 'market_alert',
+      payload: { title: `${q.symbol}: ${pct > 0 ? '+' : ''}${pct}% ${dir}`, source: 'Crypto Market' },
+      severity: Math.abs(q.change) >= 20 ? 'critical' : 'high',
+      variant: undefined,
+      dedupTtl: 3600,
+    }).catch(e => console.warn('[Notify] Crypto publish error:', e?.message));
+  }
   return quotes.length;
 }
 
@@ -2233,6 +2282,8 @@ const NOTAM_QUOTA_BACKOFF_MS = 24 * 60 * 60 * 1000; // 24h backoff when ICAO quo
 const NOTAM_REDIS_KEY = 'aviation:notam:closures:v2';
 const NOTAM_CLOSURE_QCODES = new Set(['FA', 'AH', 'AL', 'AW', 'AC', 'AM']);
 const notamPrevClosed = new Set();
+const cyberPrevAlertedIds = new Set(); // tracks indicators notified this session; cleared at 500 entries
+const ucdpPrevAlertedIds = new Set();  // tracks UCDP event IDs notified; cleared at 500 entries
 const NOTAM_MONITORED_ICAO = [
   // MENA
   'OEJN', 'OERK', 'OEMA', 'OEDF', 'OMDB', 'OMAA', 'OMSJ',
@@ -2726,6 +2777,22 @@ async function seedCyberThreats() {
     const ok2 = await upstashSet(CYBER_BOOTSTRAP_KEY, payload, CYBER_SEED_TTL);
     const ok3 = await upstashSet('seed-meta:cyber:threats', { fetchedAt: Date.now(), recordCount: threats.length }, 604800);
     console.log(`[Cyber] Seeded ${threats.length} threats (feodo:${feodo.length} urlhaus:${urlhaus.length} c2intel:${c2intel.length} otx:${otx.length} abuseipdb:${abuseipdb.length} redis:${ok1 && ok2 && ok3 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+    const newCyber = hydrated.filter(t =>
+      (t.severity === 'critical' || t.severity === 'high') && !cyberPrevAlertedIds.has(t.indicator)
+    );
+    for (const t of newCyber.slice(0, 2)) {
+      cyberPrevAlertedIds.add(t.indicator);
+      const typeLabel = (t.type || 'threat').replace(/_/g, ' ');
+      const familyTag = t.malwareFamily ? ` (${t.malwareFamily.slice(0, 30)})` : '';
+      publishNotificationEvent({
+        eventType: 'cyber_threat',
+        payload: { title: `${typeLabel}: ${t.indicator?.slice(0, 50)}${familyTag}`, source: t.source || 'Cyber Intel' },
+        severity: t.severity === 'critical' ? 'critical' : 'high',
+        variant: undefined,
+        dedupTtl: 43200,
+      }).catch(err => console.warn('[Notify] Cyber publish error:', err?.message));
+    }
+    if (cyberPrevAlertedIds.size > 500) cyberPrevAlertedIds.clear();
     return threats.length;
   } catch (e) {
     console.warn('[Cyber] Seed error:', e?.message || e, '— extending TTL, retrying in 20min');
@@ -4883,6 +4950,17 @@ async function seedCorridorRisk() {
     await upstashSet('seed-meta:supply_chain:corridorrisk', { fetchedAt: Date.now(), recordCount: Object.keys(result).length }, 604800);
     console.log(`[CorridorRisk] Seeded ${Object.keys(result).length} corridors (redis: ${ok ? 'OK' : 'FAIL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
     seedTransitSummaries().catch(e => console.warn('[TransitSummary] Post-CorridorRisk seed error:', e?.message || e));
+    for (const [corridorId, c] of Object.entries(result)) {
+      if (c.riskScore < 50) continue;
+      const label = corridorId.replace(/_/g, ' ').replace(/\b\w/g, ch => ch.toUpperCase());
+      publishNotificationEvent({
+        eventType: 'corridor_risk',
+        payload: { title: `${label}: risk score ${c.riskScore}${c.riskSummary ? ' — ' + c.riskSummary.slice(0, 80) : ''}`, source: 'Corridor Risk' },
+        severity: c.riskScore >= 70 ? 'critical' : 'high',
+        variant: undefined,
+        dedupTtl: 3600,
+      }).catch(err => console.warn('[Notify] CorridorRisk publish error:', err?.message));
+    }
   } catch (e) {
     console.warn('[CorridorRisk] Seed error:', e?.message || e);
   } finally {
@@ -5203,6 +5281,15 @@ async function seedShippingStress() {
     const ok = await upstashSet(SHIPPING_STRESS_REDIS_KEY, payload, SHIPPING_STRESS_TTL);
     await upstashSet('seed-meta:supply_chain:shipping_stress', { fetchedAt: Date.now(), recordCount: results.length }, 604800);
     console.log(`[ShippingStress] Seeded ${results.length} carriers score=${stressScore}/${stressLevel} (redis: ${ok ? 'OK' : 'FAIL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+    if (stressScore >= 75) {
+      publishNotificationEvent({
+        eventType: 'shipping_stress',
+        payload: { title: `Global shipping stress: score ${stressScore}/100 (${stressLevel})`, source: 'Shipping Index' },
+        severity: stressScore >= 90 ? 'critical' : 'high',
+        variant: undefined,
+        dedupTtl: 7200,
+      }).catch(err => console.warn('[Notify] ShippingStress publish error:', err?.message));
+    }
   } catch (e) {
     console.warn('[ShippingStress] Seed error:', e?.message || e, '— extending TTL, retrying in 20min');
     try { await upstashExpire(SHIPPING_STRESS_REDIS_KEY, SHIPPING_STRESS_TTL); } catch {}

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -315,6 +315,31 @@ function upstashSetNx(key, value, ttlSeconds) {
   });
 }
 
+function upstashDel(key) {
+  return new Promise((resolve) => {
+    if (!UPSTASH_ENABLED) return resolve(false);
+    const url = new URL('/', UPSTASH_REDIS_REST_URL);
+    const body = JSON.stringify(['DEL', key]);
+    const req = https.request(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${UPSTASH_REDIS_REST_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      timeout: 5000,
+    }, (resp) => {
+      let data = '';
+      resp.on('data', (chunk) => { data += chunk; });
+      resp.on('end', () => {
+        try { resolve(JSON.parse(data)?.result === 1); } catch { resolve(false); }
+      });
+    });
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => { req.destroy(); resolve(false); });
+    req.end(body);
+  });
+}
+
 function notifySimpleHash(str) {
   let h = 0;
   for (let i = 0; i < str.length; i++) h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
@@ -323,7 +348,10 @@ function notifySimpleHash(str) {
 
 async function publishNotificationEvent({ eventType, payload, severity, variant, dedupTtl = 1800 }) {
   try {
-    const dedupKey = `wm:notif:scan-dedup:${eventType}:${notifySimpleHash(`${eventType}:${payload.title ?? ''}`)}`;
+    // Include variant in dedup key so each variant can independently publish the same title
+    // (e.g. finance and world users both receive an alert for the same headline)
+    const variantSuffix = variant ? `:${variant}` : '';
+    const dedupKey = `wm:notif:scan-dedup:${eventType}${variantSuffix}:${notifySimpleHash(`${eventType}:${payload.title ?? ''}`)}`;
     const isNew = await upstashSetNx(dedupKey, '1', dedupTtl);
     if (!isNew) {
       console.log(`[Notify] Dedup hit — ${eventType}: ${String(payload.title ?? '').slice(0, 60)}`);
@@ -334,7 +362,10 @@ async function publishNotificationEvent({ eventType, payload, severity, variant,
     if (ok) {
       console.log(`[Notify] Queued ${severity} event: ${eventType} — ${String(payload.title ?? '').slice(0, 60)}`);
     } else {
-      console.warn(`[Notify] LPUSH failed for ${eventType}`);
+      // Rollback the dedup key so the next poll cycle can retry — avoids silent
+      // suppression for the full dedupTtl when a transient LPUSH fails.
+      console.warn(`[Notify] LPUSH failed for ${eventType} — rolling back dedup key`);
+      upstashDel(dedupKey).catch(() => {});
     }
   } catch (e) {
     console.warn(`[Notify] publishNotificationEvent error (${eventType}):`, e?.message || e);


### PR DESCRIPTION
## Summary

- Notifications previously only fired when a browser tab was open. The relay queue (`wm:events:queue`) was permanently empty without an active session.
- All alert detection is now wired in `ais-relay.cjs`, which runs 24/7 on Railway, independent of any browser.
- Five detection points added, covering every major alert-generating pipeline:

| Detector | Trigger | Severity | Interval |
|----------|---------|----------|----------|
| OREF sirens | `changed && alerts.length > 0` | `critical` | every 5 min |
| News classify | newly LLM-classified critical/high title | `critical`/`high` | every 15 min |
| NWS weather | Extreme or Severe active alerts | `critical`/`high` | every 15 min |
| Aviation | closure/severe/major disruption | `critical`/`high` | every 30 min |
| NOTAM | newly appeared ICAO closure | `high` | every 2 h |

**Infrastructure added**: `upstashLpush`, `upstashSetNx`, `publishNotificationEvent` with 30-min server-side scan-dedup (`wm:notif:scan-dedup:{eventType}:{hash}`) to prevent duplicates across polling cycles.

**No changes to**: `notification-relay.cjs` (relay already broadcasts to all matching alertRules), `/api/notify` Vercel edge, `breaking-news-alerts.ts` (stays as belt-and-suspenders fallback), Convex schema.

## Testing

- `node -c scripts/ais-relay.cjs` — syntax clean
- `npm run typecheck` — pass
- `npm run typecheck:api` — pass
- `npm run test:data` — 2676 tests, 0 failures
- `npm run lint` — no issues in ais-relay.cjs

## Post-Deploy Monitoring & Validation

- **Logs to watch** (Railway ais-relay service):
  - `[Notify] Queued critical event: oref_siren` — OREF wiring live
  - `[Notify] Queued critical/high event: rss_alert` — classify wiring live
  - `[Notify] Queued critical/high event: weather_alert` — weather wiring live
  - `[Notify] Dedup hit —` — confirms dedup is working, not a failure
- **Validation command**: Check queue depth: `LLEN wm:events:queue` in Upstash console; should see non-zero values when events are active
- **Relay delivery**: Railway `notification-relay` logs should show `[relay] RPOP dequeued message:` within 60s of an event being queued
- **Expected healthy behavior**: After deploy, within the first 15 min (one classify cycle), relay logs show at least one processed `rss_alert` event if any current news classifies as critical/high
- **Failure signal**: If `[Notify] LPUSH failed` appears in ais-relay logs, check `UPSTASH_REDIS_REST_URL`/`TOKEN` env vars in Railway ais-relay service
- **Rollback**: Revert this commit; browser path remains fully functional as fallback
- **Validation window**: First 30 min post-deploy (one full classify + OREF + weather cycle)