### PR TITLE
fix(relay): isolate per-channel delivery errors; improve Telegram diagnostics

### DIFF
--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -82,6 +82,10 @@ function isPrivateIP(ip) {
 // ── Delivery: Telegram ────────────────────────────────────────────────────────
 
 async function sendTelegram(userId, chatId, text) {
+  if (!TELEGRAM_BOT_TOKEN) {
+    console.warn('[relay] Telegram: TELEGRAM_BOT_TOKEN not set — skipping');
+    return;
+  }
   const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-relay/1.0' },
@@ -90,8 +94,9 @@ async function sendTelegram(userId, chatId, text) {
   });
   if (res.status === 403 || res.status === 400) {
     const body = await res.json().catch(() => ({}));
+    console.warn(`[relay] Telegram ${res.status} for ${userId}: ${body.description ?? '(no description)'}`);
     if (res.status === 403 || body.description?.includes('chat not found')) {
-      console.warn(`[relay] Telegram 403/400 for ${userId} — deactivating channel`);
+      console.warn(`[relay] Telegram deactivating channel for ${userId}`);
       await deactivateChannel(userId, 'telegram');
     }
     return;
@@ -102,7 +107,15 @@ async function sendTelegram(userId, chatId, text) {
     await new Promise(r => setTimeout(r, wait));
     return sendTelegram(userId, chatId, text); // single retry
   }
-  if (!res.ok) console.warn(`[relay] Telegram send failed: ${res.status}`);
+  if (res.status === 401) {
+    console.error('[relay] Telegram 401 Unauthorized — TELEGRAM_BOT_TOKEN is invalid or belongs to a different bot; Telegram delivery will be disabled until the token is corrected');
+    return;
+  }
+  if (!res.ok) {
+    console.warn(`[relay] Telegram send failed: ${res.status}`);
+    return;
+  }
+  console.log(`[relay] Telegram delivered to ${userId} (chatId: ${chatId})`);
 }
 
 // ── Delivery: Slack ───────────────────────────────────────────────────────────
@@ -255,12 +268,16 @@ async function processEvent(event) {
     const verifiedChannels = channels.filter(c => c.verified && rule.channels.includes(c.channelType));
 
     for (const ch of verifiedChannels) {
-      if (ch.channelType === 'telegram' && ch.chatId) {
-        await sendTelegram(rule.userId, ch.chatId, text);
-      } else if (ch.channelType === 'slack' && ch.webhookEnvelope) {
-        await sendSlack(rule.userId, ch.webhookEnvelope, text);
-      } else if (ch.channelType === 'email' && ch.email) {
-        await sendEmail(ch.email, subject, text);
+      try {
+        if (ch.channelType === 'telegram' && ch.chatId) {
+          await sendTelegram(rule.userId, ch.chatId, text);
+        } else if (ch.channelType === 'slack' && ch.webhookEnvelope) {
+          await sendSlack(rule.userId, ch.webhookEnvelope, text);
+        } else if (ch.channelType === 'email' && ch.email) {
+          await sendEmail(ch.email, subject, text);
+        }
+      } catch (err) {
+        console.warn(`[relay] Delivery error for ${rule.userId}/${ch.channelType}:`, err.message);
       }
     }
   }

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -108,7 +108,7 @@ async function sendTelegram(userId, chatId, text) {
     return sendTelegram(userId, chatId, text); // single retry
   }
   if (res.status === 401) {
-    console.error('[relay] Telegram 401 Unauthorized — TELEGRAM_BOT_TOKEN is invalid or belongs to a different bot; Telegram delivery will be disabled until the token is corrected');
+    console.error('[relay] Telegram 401 Unauthorized — TELEGRAM_BOT_TOKEN is invalid or belongs to a different bot; correct the Railway env var to restore Telegram delivery');
     return;
   }
   if (!res.ok) {
@@ -277,7 +277,7 @@ async function processEvent(event) {
           await sendEmail(ch.email, subject, text);
         }
       } catch (err) {
-        console.warn(`[relay] Delivery error for ${rule.userId}/${ch.channelType}:`, err.message);
+        console.warn(`[relay] Delivery error for ${rule.userId}/${ch.channelType}:`, err instanceof Error ? err.message : String(err));
       }
     }
   }


### PR DESCRIPTION
## Summary

- Wraps each channel send in try/catch so a Telegram timeout/AbortError cannot abort delivery to remaining channels (email, Slack) in the same rule
- Adds explicit 401 error identifying TELEGRAM_BOT_TOKEN mismatch between Railway relay and Convex (the most likely reason Telegram does not receive alerts when email/Slack do)
- Logs the Bot API error description on 400/403 so "bot was blocked" vs "chat not found" is visible in Railway logs
- Adds confirmation log on successful Telegram delivery and early-return guard when token is absent

## Root cause

The relay and Convex use separate TELEGRAM_BOT_TOKEN env vars. Welcome messages are sent by Convex (on pairing), so users see them successfully. Actual alert delivery is done by the Railway relay. If that token is wrong or stale, every send fails with 401, previously logged only as a generic warning with no indication that the token is the problem.

## Post-Deploy Monitoring & Validation

- **Logs**: Railway relay logs after next alert event
- **Healthy**: [relay] Telegram delivered to <userId> (chatId: ...)
- **Failure**: [relay] Telegram 401 Unauthorized - TELEGRAM_BOT_TOKEN is invalid or belongs to a different bot
- **Action on 401**: check Railway TELEGRAM_BOT_TOKEN env var matches the active bot token
- **Failure**: [relay] Telegram deactivating channel for <userId> - user blocked the bot, needs to re-pair
- **Validation window**: first alert after deploy