### PR TITLE
fix(notifications): auto-add Telegram to alert rules on pairing

### DIFF
--- a/convex/notificationChannels.ts
+++ b/convex/notificationChannels.ts
@@ -332,6 +332,19 @@ export const claimPairingToken = mutation({
       await ctx.db.insert("notificationChannels", doc);
     }
 
+    // Add 'telegram' to all existing alert rules for this user so alerts
+    // are delivered immediately without requiring a manual rule edit.
+    // Mirrors the reverse logic in deleteChannelForUser which removes the channel.
+    const rules = await ctx.db
+      .query("alertRules")
+      .withIndex("by_user", (q) => q.eq("userId", record.userId))
+      .collect();
+    for (const rule of rules) {
+      if (!rule.channels.includes("telegram")) {
+        await ctx.db.patch(rule._id, { channels: [...rule.channels, "telegram"] });
+      }
+    }
+
     return { ok: true, reason: null };
   },
 });


### PR DESCRIPTION
## Root cause

`claimPairingToken` stored the `chatId` and set `verified: true` but never touched `alertRules`. The relay's delivery filter is:

\`\`\`js
channels.filter(c => c.verified && rule.channels.includes(c.channelType))
\`\`\`

So even with a valid paired channel, Telegram was silently excluded because `alertRules.channels` was `["email", "slack"]` — Telegram was never added when it was connected.

## Fix

After upserting the Telegram channel, `claimPairingToken` now patches all of the user's alert rules to include `"telegram"` if it's not already there. Mirrors the reverse logic in `deleteChannelForUser`.

## User action required after deploy

In the Notifications settings: **Remove Telegram, then re-pair**. Re-pairing calls `claimPairingToken` (the fixed version) which automatically adds `"telegram"` to the alert rule.

## Post-Deploy Monitoring & Validation

- **Healthy**: after re-pair, `alertRules.channels` in Convex dashboard includes `"telegram"`
- **Healthy**: relay logs show `[relay] Telegram delivered to <userId>` on next alert
- **No operational monitoring needed beyond re-pair verification**