### PR TITLE
fix(notifications): only auto-add telegram to alert rules on first-time pairing

### DIFF
--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -156,7 +156,9 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
 
     try {
       if (action === 'create-pairing-token') {
-        const resp = await convexRelay({ action: 'create-pairing-token', userId: session.userId });
+        const relayBody: Record<string, unknown> = { action: 'create-pairing-token', userId: session.userId };
+        if (body.variant) relayBody.variant = body.variant;
+        const resp = await convexRelay(relayBody);
         if (!resp.ok) {
           console.error('[notification-channels] POST create-pairing-token relay error:', resp.status);
           return json({ error: 'Operation failed' }, 500, corsHeaders);

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -352,7 +352,10 @@ http.route({
       }
 
       if (action === "create-pairing-token") {
-        const result = await ctx.runMutation(internal.notificationChannels.createPairingTokenForUser, { userId });
+        const result = await ctx.runMutation(internal.notificationChannels.createPairingTokenForUser, {
+          userId,
+          variant: body.variant,
+        });
         return new Response(JSON.stringify(result), { status: 200, headers: { "Content-Type": "application/json" } });
       }
 

--- a/convex/notificationChannels.ts
+++ b/convex/notificationChannels.ts
@@ -107,9 +107,9 @@ export const deleteChannelForUser = internalMutation({
 });
 
 export const createPairingTokenForUser = internalMutation({
-  args: { userId: v.string() },
+  args: { userId: v.string(), variant: v.optional(v.string()) },
   handler: async (ctx, args) => {
-    const { userId } = args;
+    const { userId, variant } = args;
     const existing = await ctx.db
       .query("telegramPairingTokens")
       .withIndex("by_user", (q) => q.eq("userId", userId))
@@ -124,7 +124,7 @@ export const createPairingTokenForUser = internalMutation({
       .replace(/\//g, "_")
       .replace(/=+$/, "");
     const expiresAt = Date.now() + 15 * 60 * 1000;
-    await ctx.db.insert("telegramPairingTokens", { userId, token, expiresAt, used: false });
+    await ctx.db.insert("telegramPairingTokens", { userId, token, expiresAt, used: false, variant });
     return { token, expiresAt };
   },
 });
@@ -259,8 +259,8 @@ export const deactivateChannel = mutation({
 });
 
 export const createPairingToken = mutation({
-  args: {},
-  handler: async (ctx) => {
+  args: { variant: v.optional(v.string()) },
+  handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new ConvexError("UNAUTHENTICATED");
     const userId = identity.subject;
@@ -289,6 +289,7 @@ export const createPairingToken = mutation({
       token,
       expiresAt,
       used: false,
+      variant: args.variant,
     });
 
     return { token, expiresAt };
@@ -332,15 +333,24 @@ export const claimPairingToken = mutation({
       await ctx.db.insert("notificationChannels", doc);
     }
 
-    // On first-time pairing only, add 'telegram' to all alert rules so alerts
+    // On first-time pairing only, add 'telegram' to the alert rule so alerts
     // are delivered immediately without requiring a manual rule edit.
     // Skip on re-pair (existing channel) to preserve any intentional per-rule
     // customization the user may have made (e.g. removed Telegram from a variant).
+    // If the token carries a variant, scope the update to that variant's rule only.
+    // Fall back to all rules when variant is absent (backward compat for old tokens).
     if (!existing) {
-      const rules = await ctx.db
-        .query("alertRules")
-        .withIndex("by_user", (q) => q.eq("userId", record.userId))
-        .collect();
+      const rules = await (record.variant
+        ? ctx.db
+            .query("alertRules")
+            .withIndex("by_user_variant", (q) =>
+              q.eq("userId", record.userId).eq("variant", record.variant as string),
+            )
+            .collect()
+        : ctx.db
+            .query("alertRules")
+            .withIndex("by_user", (q) => q.eq("userId", record.userId))
+            .collect());
       for (const rule of rules) {
         if (!rule.channels.includes("telegram")) {
           await ctx.db.patch(rule._id, { channels: [...rule.channels, "telegram"] });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -61,6 +61,7 @@ export default defineSchema({
     token: v.string(),
     expiresAt: v.number(),
     used: v.boolean(),
+    variant: v.optional(v.string()),
   })
     .index("by_token", ["token"])
     .index("by_user", ["userId"]),

--- a/src/services/notification-channels.ts
+++ b/src/services/notification-channels.ts
@@ -1,4 +1,5 @@
 import { getClerkToken } from '@/services/clerk';
+import { SITE_VARIANT } from '@/config/variant';
 
 export type ChannelType = 'telegram' | 'slack' | 'email';
 export type Sensitivity = 'all' | 'high' | 'critical';
@@ -49,7 +50,7 @@ export async function createPairingToken(): Promise<{ token: string; expiresAt: 
   const res = await authFetch('/api/notification-channels', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ action: 'create-pairing-token' }),
+    body: JSON.stringify({ action: 'create-pairing-token', variant: SITE_VARIANT }),
   });
   if (!res.ok) throw new Error(`create pairing token: ${res.status}`);
   return res.json();


### PR DESCRIPTION
## Summary
- On first-time Telegram pairing, auto-add \`telegram\` to the user's alert rule so notifications are delivered immediately (no manual rule edit needed)
- Guard with \`!existing\` so re-pairing (e.g. phone change) does not override intentional per-rule customization
- **P2 fix**: Thread \`variant\` through the pairing token creation chain so the rule update is scoped to the variant the user was on when pairing — matching the behavior of email/Slack channel linking (\`preferences-content.ts\` uses \`SITE_VARIANT\` for \`saveAlertRules\`). Falls back to all rules when token has no variant (backward compat for old tokens)

## Files changed
- \`convex/schema.ts\` — add optional \`variant\` to \`telegramPairingTokens\`
- \`convex/notificationChannels.ts\` — \`createPairingToken\`/\`createPairingTokenForUser\` accept variant; \`claimPairingToken\` scopes rule update by variant
- \`convex/http.ts\` — forward \`body.variant\` into \`createPairingTokenForUser\`
- \`src/services/notification-channels.ts\` — pass \`SITE_VARIANT\` when creating pairing token
- \`api/notification-channels.ts\` — forward \`variant\` from POST body to Convex relay

## Test plan
- [ ] Pair Telegram on a variant (e.g. \`worldmonitor\`) — only that variant's alert rule gets \`telegram\` added
- [ ] Pair Telegram on a second variant — that rule also gets \`telegram\`; first rule unchanged
- [ ] Re-pair (deactivate and re-link) — existing rules not modified
- [ ] Old pairing tokens with no variant — all rules still get \`telegram\` (backward compat)

## Post-Deploy Monitoring & Validation
- **Log query**: Railway relay logs for \`[relay] Telegram delivered\` or \`[relay] Telegram deactivating\`
- **Expected**: \`[relay] Telegram delivered to <userId> (chatId: ...)\` after first pairing
- **Failure signal**: \`verifiedChannels\` empty for telegram → check alertRules.channels in Convex dashboard
- **Validation window**: 30 min post-deploy, trigger a test event via the relay queue