### PR TITLE
fix(discord): style Connect Discord button

### DIFF
--- a/src/styles/settings-window.css
+++ b/src/styles/settings-window.css
@@ -1374,6 +1374,26 @@ tr.diag-err td { color: var(--settings-red); }
   border-color: #611f69;
 }
 
+/* Discord OAuth button */
+.us-notif-discord-oauth {
+  display: inline-flex;
+  align-items: center;
+  background: #5865f2;
+  border: 1px solid #5865f2;
+  color: #fff;
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.us-notif-discord-oauth:hover {
+  background: #4752c4;
+  border-color: #4752c4;
+}
+
 /* Manage in Slack link */
 .us-notif-manage-link {
   font-size: 10px;


### PR DESCRIPTION
## Summary

- Adds `.us-notif-discord-oauth` CSS rule matching the same pattern as `.us-notif-slack-oauth`
- Discord brand color `#5865f2` (Blurple), hover darkens to `#4752c4`
- Fixes unstyled browser-default button appearance in the Notifications settings panel

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: CSS-only change, no runtime impact.