### PR TITLE
chore: bump version to 2.6.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "world-monitor",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "world-monitor",
-      "version": "2.6.5",
+      "version": "2.6.6",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "world-monitor",
   "private": true,
-  "version": "2.6.5",
+  "version": "2.6.6",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-monitor"
-version = "2.6.5"
+version = "2.6.6"
 description = "World Monitor desktop application"
 authors = ["World Monitor"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "World Monitor",
   "mainBinaryName": "world-monitor",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "identifier": "app.worldmonitor.desktop",
   "build": {
     "beforeDevCommand": "npm run build:sidecar-sebuf && node scripts/build-sidecar-handlers.mjs && npm run dev",


### PR DESCRIPTION
## Summary
- Bump 2.6.5 → 2.6.6 across package.json, tauri.conf.json, Cargo.toml
- New Sentry release tag (`worldmonitor@2.6.6`) lets us distinguish sessions running the CSP listener fix from stale 2.6.5 tabs

## Test plan
- [x] `npm run version:check` passes (all 3 files in sync)