### PR TITLE
fix(csp): suppress localhost/loopback CSP violations

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -382,6 +382,8 @@ function shouldSuppressCspViolation(
   if (blockedURI === 'inline' && directive === 'script-src-elem') return true;
   // Null blocked URI from in-app browsers.
   if (blockedURI === 'null') return true;
+  // localhost/loopback — Smart TV browsers (Tizen, webOS) and dev tools inject local service calls.
+  if (/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?\//.test(blockedURI)) return true;
   return false;
 }
 // Detect once whether BOTH the meta tag and HTTP header CSP allow https: in connect-src.

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -140,6 +140,20 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
     });
   });
 
+  describe('localhost/loopback', () => {
+    it('suppresses http://localhost:9009 (Smart TV tuner service)', () => {
+      assert.ok(suppress('enforce', 'connect-src', 'http://localhost:9009/service/tvinfo', '', false));
+    });
+
+    it('suppresses http://127.0.0.1:8080', () => {
+      assert.ok(suppress('enforce', 'connect-src', 'http://127.0.0.1:8080/api', '', false));
+    });
+
+    it('suppresses https://localhost:3000', () => {
+      assert.ok(suppress('enforce', 'connect-src', 'https://localhost:3000/dev', '', false));
+    });
+  });
+
   describe('real violations pass through', () => {
     it('reports third-party script-src violation', () => {
       assert.ok(!suppress('enforce', 'script-src', 'https://evil.com/crypto-miner.js', '', true));


### PR DESCRIPTION
## Summary
- Smart TV browsers (Samsung Tizen, LG webOS) inject scripts that call `localhost` services (`localhost:9009/service/tvinfo`, `127.0.0.1:8080`, etc.)
- CSP correctly blocks these, but the violation listener was reporting them to Sentry as noise
- Adds `/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?\//.test(blockedURI)` filter — matches any port on both hostnames
- 3 new test cases in `tests/csp-filter.test.mjs` (total now 34)

## Test plan
- [x] `npm run typecheck` + `typecheck:api` pass
- [x] `npm run test:data` (2732/2732)
- [x] Edge function tests (146/146)
- [x] CSP filter tests (34/34)
- [x] Biome lint pass
- [x] CJS syntax pass