### PR TITLE
feat(ui): importanceScore relevance sort + phase badges in NewsPanel

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3312,6 +3312,33 @@ body.live-news-fullscreen-active .panels-grid > *:not(.live-news-fullscreen) {
   line-height: normal;
 }
 
+.phase-badge {
+  display: inline-block;
+  padding: 1px 4px;
+  border-radius: 2px;
+  font-size: 8px;
+  font-weight: bold;
+  margin-inline-start: 4px;
+  vertical-align: middle;
+  line-height: normal;
+}
+
+.phase-badge.breaking {
+  background: var(--orange, #f97316);
+  color: var(--bg);
+  animation: pulse-alert 1.5s infinite;
+}
+
+.phase-badge.developing {
+  background: var(--yellow, #eab308);
+  color: var(--bg);
+}
+
+.phase-badge.sustained {
+  background: var(--slate, #64748b);
+  color: var(--bg);
+}
+
 @keyframes pulse-alert {
 
   0%,


### PR DESCRIPTION
## Summary

- **`src/styles/main.css`**: adds `.phase-badge`, `.phase-badge.breaking` (pulsing orange), `.phase-badge.developing` (yellow), `.phase-badge.sustained` (slate) CSS classes used by NewsPanel.

All other feature work landed in main via prerequisite PRs:
- `importanceScore` + `corroborationCount` types → PR #2604 (merged)
- `storyMeta?: StoryMeta` on `NewsItem`, `StoryPhase` client type → PR #2620 E3 (merged)  
- `data-loader.ts` storyMeta mapping with `PROTO_TO_CLIENT_PHASE` → PR #2620 E3 (merged)
- `NewsPanel.ts` relevance sort + phase badge rendering (`item.storyMeta?.phase`) → PR #2620 E3 (merged)

This PR was rebased onto main after those merges; the CSS was the only missing piece.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (no errors)
- [x] Diff is CSS-only (27 lines added)

## Post-Deploy Monitoring & Validation

- **What to monitor**: Phase badges render in NewsPanel for breaking/developing/sustained stories
- **Expected healthy behavior**: BREAKING badge (orange, pulsing) appears on first-cycle stories; DEVELOPING ×N (yellow) on repeat stories; ONGOING (slate) on sustained stories
- **Failure signal**: No visual badges despite storyMeta being populated in digest → check CSS selector specificity
- **No additional operational monitoring required**: pure CSS addition, no backend impact

🤖 Generated with Claude Sonnet 4.6 via Claude Code + Compound Engineering v2.49.0

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>