### PR TITLE
fix(webcam): guard replaceWith race in retry button click

### DIFF
--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -375,8 +375,12 @@ export class LiveWebcamsPanel extends Panel {
       // Fall back to appending the fresh iframe to the container.
       this.clearIframeTimeout(oldIframe);
       this.iframeTrackers.delete(oldIframe);
+      oldIframe.src = 'about:blank';
       tracker.container.querySelector('.webcam-embed-fallback')?.remove();
       tracker.container.appendChild(freshIframe);
+      const idx = this.iframes.indexOf(oldIframe);
+      if (idx >= 0) this.iframes[idx] = freshIframe;
+      else this.iframes.push(freshIframe);
       this.trackIframe(freshIframe, tracker.feed, tracker.container);
       return;
     }


### PR DESCRIPTION
## Summary
- Sentry WORLDMONITOR-D9: `NotFoundError: Failed to execute 'replaceWith' on 'Element'` (2 events, 2 users)
- Webcam retry button click fires `retryIframe()`, but the iframe's parent DOM can be restructured by scroll, channel switch, or concurrent retry between the `parentNode` check and `replaceWith` call
- Fix: wrap `replaceWith` in try/catch, fall back to `appendChild` on the tracker's container

## Test plan
- [x] `npm run typecheck` + `typecheck:api` pass
- [x] `npm run test:data` (2748/2748)
- [x] Edge function tests (146/146)
- [x] Biome lint pass
- [x] Resolved in Sentry with `inNextRelease`