### PR TITLE
feat(scorecards): project stateKind, routeFacilityKey, topBucketId into path-scorecards.json

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -4589,7 +4589,7 @@ function summarizeImpactPathScore(path = null) {
     candidateStateId: path.candidateStateId || '',
     stateKind: path.candidate?.stateKind || '',
     routeFacilityKey: path.candidate?.routeFacilityKey || '',
-    topBucketId: path.candidate?.marketContext?.topBucketId || '',
+    topBucketId: path.candidate?.marketContext?.topBucketId || path.candidate?.topBucketId || '',
     directVariableKey: path.direct?.variableKey || '',
     secondVariableKey: path.second?.variableKey || '',
     thirdVariableKey: path.third?.variableKey || '',


### PR DESCRIPTION
## Summary

- Adds `stateKind`, `routeFacilityKey`, and `topBucketId` to the flat path summary written into `path-scorecards.json` by `summarizeImpactPathScore`
- All three fields are read from `path.candidate` — the `CandidatePacket` reference that `buildImpactPathsForCandidate` attaches to every path at construction time
- `ExpandedPathCandidate` already declared all three fields as optional strings; no type changes needed

## Why

These three fields are required for the composite continuity key (`stateKind + routeFacilityKey + topBucketId`) used by the ML training data pipeline. They were present on `CandidatePacket` but not projected into the scorecard summary, leaving 100% null slots in `collect-training-data.mjs` output. Adding them unblocks:

- The composite continuity key (prerequisite for fixing ≥58% drift in Tier C training labels)
- Complete feature vectors for Scope B training data collection
- Domain classification for the 54/110 "unknown domain" rows in the expired-rows breakdown (resolvedChannel heuristic misses most rows; `stateKind` resolves them exactly)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run test:data` — 2676/2676 pass
- [x] `npm run lint` — exit 0
- [x] edge function bundle check — all pass
- [x] `node --test tests/edge-functions.test.mjs` — 146/146 pass
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK

## Post-Deploy Monitoring & Validation

- **What to monitor:** `path-scorecards.json` entries in R2 after next deep forecast run
- **Validation:** `node scripts/_list-all-runs.mjs` — check that `stateKind`/`routeFacilityKey`/`topBucketId` are non-empty in newly written scorecards
- **Expected healthy signal:** fields populated on expanded paths; empty string only for candidates where `stateKind` is genuinely absent
- **Failure signal:** fields still null/empty after deploy — check that `buildImpactPathsForCandidate` is setting `candidate: candidatePacket` on path objects
- **Validation window:** first deep forecast run post-deploy