### PR TITLE
fix: update contact email to elie@worldmonitor.app

### DIFF
--- a/api/contact.js
+++ b/api/contact.js
@@ -35,7 +35,7 @@ async function sendNotificationEmail(name, email, organization, phone, message, 
     console.error('[contact] RESEND_API_KEY not set — lead stored in Convex but notification NOT sent');
     return false;
   }
-  const notifyEmail = process.env.CONTACT_NOTIFY_EMAIL || 'elie.habib@gmail.com';
+  const notifyEmail = process.env.CONTACT_NOTIFY_EMAIL || 'elie@worldmonitor.app';
   const emailDomain = (email.split('@')[1] || '').toLowerCase();
   try {
     const res = await fetch('https://api.resend.com/emails', {

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,4 +1,4 @@
-Contact: mailto:elie.habib@gmail.com
+Contact: mailto:elie@worldmonitor.app
 Contact: https://github.com/eliehabib/worldmonitor/security/advisories
 Policy: https://github.com/eliehabib/worldmonitor/security/advisories
 Preferred-Languages: en


### PR DESCRIPTION
## Summary
- Replace `elie.habib@gmail.com` with `elie@worldmonitor.app` in the contact form notification fallback (`api/contact.js`)
- Update `public/.well-known/security.txt` to use the branded domain email

## Test plan
- [x] TypeScript type check passes
- [x] Biome lint passes
- [x] Edge function bundle + isolation tests pass (146/146)
- [x] Data tests pass
- [x] Markdown lint passes
- [x] Version sync passes