### PR TITLE
fix(sentry): filter opaque Safari [object Event] noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -227,6 +227,7 @@ Sentry.init({
     /WKErrorDomain/,
     /Content-Length header of network response exceeds response Body/,
     /^Uncaught \[object ErrorEvent\]$/,
+    /^\[object Event\]$/,
     /trsMethod\w+ is not defined/,
     /checkLogin is not a function/,
     /VConsole is not defined/,


### PR DESCRIPTION
## Summary
- Add `ignoreErrors` pattern for Safari 18.6 opaque `Error: [object Event]` with no stack trace
- Also resolved 2 CSP report noise issues in Sentry (img-src `cdn.css-tricks.com` from browser extensions, frame-src `about` from Samsung Tizen)
- All 3 issues marked resolved (inNextRelease) in Sentry

## Test plan
- [x] TypeScript type check passes
- [x] Biome lint passes
- [x] All 2748 unit/data tests pass
- [x] Edge function bundle + isolation tests pass (146/146)
- [x] Markdown lint passes
- [x] Version sync passes