### PR TITLE
fix(ui): inline timestamp in Security Advisories cards

### DIFF
--- a/src/components/SecurityAdvisoriesPanel.ts
+++ b/src/components/SecurityAdvisoriesPanel.ts
@@ -168,8 +168,10 @@ export class SecurityAdvisoriesPanel extends Panel {
             <span class="sa-badge ${levelCls}">${levelLabel}</span>
             <span class="sa-source">${flag} ${escapeHtml(a.source)}</span>
           </div>
-          <a href="${escapeHtml(a.link)}" target="_blank" rel="noopener" class="sa-title">${escapeHtml(a.title)}</a>
-          <div class="sa-time">${this.formatTime(a.pubDate)}</div>
+          <div class="sa-body">
+            <a href="${escapeHtml(a.link)}" target="_blank" rel="noopener" class="sa-title">${escapeHtml(a.title)}</a>
+            <span class="sa-time">${this.formatTime(a.pubDate)}</span>
+          </div>
         </div>`;
       }).join('');
     }

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -1059,8 +1059,15 @@
   margin-left: auto;
 }
 
+.sa-body {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
 .sa-title {
-  display: block;
+  flex: 1;
+  min-width: 0;
   color: var(--text-secondary);
   text-decoration: none;
   font-size: 11px;
@@ -1073,9 +1080,10 @@
 }
 
 .sa-time {
+  flex-shrink: 0;
   font-size: 9px;
   color: var(--text-muted);
-  margin-top: 3px;
+  white-space: nowrap;
 }
 
 .sa-footer {


### PR DESCRIPTION
## Summary
- Move the time label (e.g. "7h ago") from a separate row below the title to a flex-aligned column on the right
- Reduces each advisory card height by one line

## Test plan
- [x] TypeScript type check passes
- [x] Visual: timestamp appears right-aligned next to the advisory title