### PR TITLE
fix(pizzint): move fetch to Railway seed, fix stale CLOSED data

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -123,6 +123,7 @@ const STANDALONE_KEYS = {
   simulationOutcomeLatest:  'forecast:simulation-outcome:latest',
   newsThreatSummary:        'news:threat:summary:v1',
   climateNews:              'climate:news-intelligence:v1',
+  pizzint:                  'intelligence:pizzint:seed:v1',
 };
 
 const SEED_META = {
@@ -226,6 +227,7 @@ const SEED_META = {
   shippingStress:    { key: 'seed-meta:supply_chain:shipping_stress',  maxStaleMin: 45 }, // relay loop every 15min; 45 = 3x interval (was 30 = 2×, too tight on relay hiccup)
   diseaseOutbreaks:  { key: 'seed-meta:health:disease-outbreaks',      maxStaleMin: 2880 }, // daily seed; 2880 = 48h = 2x interval
   socialVelocity:    { key: 'seed-meta:intelligence:social-reddit',    maxStaleMin: 30 }, // relay loop every 10min; 30 = 3x interval (was 20 = equals retry window, too tight)
+  pizzint:           { key: 'seed-meta:intelligence:pizzint',          maxStaleMin: 30 }, // relay loop every 10min; 30 = 3x interval
   vpdTrackerRealtime:   { key: 'seed-meta:health:vpd-tracker',         maxStaleMin: 2880 }, // daily seed (0 2 * * *); 2880min = 48h = 2x interval
   vpdTrackerHistorical: { key: 'seed-meta:health:vpd-tracker',         maxStaleMin: 2880 }, // shares seed-meta key with vpdTrackerRealtime (same run)
 };

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -5567,6 +5567,137 @@ function startClimateNewsSeedLoop() {
   }, CLIMATE_NEWS_SEED_INTERVAL_MS).unref?.();
 }
 
+// ─────────────────────────────────────────────────────────────
+// PizzINT Seed — Pentagon Pizza Index + GDELT tensions → Redis
+// Fetches from pizzint.watch on Railway (datacenter IPs blocked
+// from Vercel Edge). Vercel handler reads from seed key only.
+// ─────────────────────────────────────────────────────────────
+const PIZZINT_SEED_INTERVAL_MS = 10 * 60 * 1000; // 10 min
+const PIZZINT_SEED_TTL = 1800; // 30 min (3× interval)
+const PIZZINT_REDIS_KEY = 'intelligence:pizzint:seed:v1';
+const PIZZINT_API = 'https://www.pizzint.watch/api/dashboard-data';
+const GDELT_BATCH_API = 'https://www.pizzint.watch/api/gdelt/batch';
+const DEFAULT_GDELT_PAIRS = 'usa_russia,russia_ukraine,usa_china,china_taiwan,usa_iran,usa_venezuela';
+let pizzintSeedInFlight = false;
+
+async function seedPizzint() {
+  if (pizzintSeedInFlight) return;
+  pizzintSeedInFlight = true;
+  const t0 = Date.now();
+  try {
+    const resp = await fetch(PIZZINT_API, {
+      headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!resp.ok) {
+      console.warn(`[PizzINT] Seed failed: HTTP ${resp.status}`);
+      return;
+    }
+    const raw = await resp.json();
+    if (!raw.success || !Array.isArray(raw.data)) {
+      console.warn('[PizzINT] No data in API response');
+      return;
+    }
+
+    const locations = raw.data.map((d) => ({
+      placeId: d.place_id || '',
+      name: d.name || '',
+      address: d.address || '',
+      currentPopularity: typeof d.current_popularity === 'number' ? d.current_popularity : 0,
+      percentageOfUsual: typeof d.percentage_of_usual === 'number' ? d.percentage_of_usual : 0,
+      isSpike: !!d.is_spike,
+      spikeMagnitude: typeof d.spike_magnitude === 'number' ? d.spike_magnitude : 0,
+      dataSource: d.data_source || '',
+      recordedAt: d.recorded_at || '',
+      dataFreshness: d.data_freshness === 'fresh' ? 'DATA_FRESHNESS_FRESH' : 'DATA_FRESHNESS_STALE',
+      isClosedNow: !!d.is_closed_now,
+      lat: d.lat ?? 0,
+      lng: d.lng ?? 0,
+    }));
+
+    const openLocations = locations.filter((l) => !l.isClosedNow);
+    const activeSpikes = locations.filter((l) => l.isSpike).length;
+    const avgPop = openLocations.length > 0
+      ? openLocations.reduce((s, l) => s + l.currentPopularity, 0) / openLocations.length
+      : 0;
+
+    let adjusted = avgPop;
+    if (activeSpikes > 0) adjusted += activeSpikes * 10;
+    adjusted = Math.min(100, adjusted);
+    let defconLevel = 5;
+    let defconLabel = 'Normal Activity';
+    if (adjusted >= 85) { defconLevel = 1; defconLabel = 'Maximum Activity'; }
+    else if (adjusted >= 70) { defconLevel = 2; defconLabel = 'High Activity'; }
+    else if (adjusted >= 50) { defconLevel = 3; defconLabel = 'Elevated Activity'; }
+    else if (adjusted >= 25) { defconLevel = 4; defconLabel = 'Above Normal'; }
+
+    const hasFresh = locations.some((l) => l.dataFreshness === 'DATA_FRESHNESS_FRESH');
+
+    const pizzint = {
+      defconLevel,
+      defconLabel,
+      aggregateActivity: Math.round(avgPop),
+      activeSpikes,
+      locationsMonitored: locations.length,
+      locationsOpen: openLocations.length,
+      updatedAt: Date.now(),
+      dataFreshness: hasFresh ? 'DATA_FRESHNESS_FRESH' : 'DATA_FRESHNESS_STALE',
+      locations,
+    };
+
+    // Fetch GDELT tensions (non-fatal if unavailable)
+    let tensionPairs = [];
+    try {
+      const gdeltUrl = `${GDELT_BATCH_API}?pairs=${encodeURIComponent(DEFAULT_GDELT_PAIRS)}&method=gpr`;
+      const gdeltResp = await fetch(gdeltUrl, {
+        headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (gdeltResp.ok) {
+        const gdeltRaw = await gdeltResp.json();
+        tensionPairs = Object.entries(gdeltRaw).map(([pairKey, dataPoints]) => {
+          const countries = pairKey.split('_');
+          const latest = dataPoints[dataPoints.length - 1];
+          const prev = dataPoints.length > 1 ? dataPoints[dataPoints.length - 2] : latest;
+          const change = prev && prev.v > 0 ? ((latest.v - prev.v) / prev.v) * 100 : 0;
+          const trend = change > 5 ? 'TREND_DIRECTION_RISING' : change < -5 ? 'TREND_DIRECTION_FALLING' : 'TREND_DIRECTION_STABLE';
+          return {
+            id: pairKey,
+            countries,
+            label: countries.map((c) => c.toUpperCase()).join(' - '),
+            score: latest?.v ?? 0,
+            trend,
+            changePercent: Math.round(change * 10) / 10,
+            region: 'global',
+          };
+        });
+      }
+    } catch { /* GDELT unavailable — non-fatal */ }
+
+    const payload = { pizzint, tensionPairs };
+    const ok1 = await upstashSet(PIZZINT_REDIS_KEY, payload, PIZZINT_SEED_TTL);
+    const ok2 = await upstashSet('seed-meta:intelligence:pizzint', { fetchedAt: Date.now(), recordCount: locations.length }, 604800);
+    console.log(`[PizzINT] Seeded ${locations.length} locations (open:${openLocations.length} spikes:${activeSpikes} defcon:${defconLevel} gdelt:${tensionPairs.length} redis:${ok1 && ok2 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+  } catch (e) {
+    console.warn('[PizzINT] Seed error:', e?.message || e);
+  } finally {
+    pizzintSeedInFlight = false;
+  }
+}
+
+function startPizzintSeedLoop() {
+  if (!UPSTASH_ENABLED) {
+    console.log('[PizzINT] Disabled (no Upstash Redis)');
+    return;
+  }
+  console.log(`[PizzINT] Seed loop starting (interval ${PIZZINT_SEED_INTERVAL_MS / 1000 / 60}min)`);
+  seedPizzint().catch((e) => console.warn('[PizzINT] Initial seed error:', e?.message || e));
+  setInterval(() => {
+    seedPizzint().catch((e) => console.warn('[PizzINT] Seed error:', e?.message || e));
+  }, PIZZINT_SEED_INTERVAL_MS).unref?.();
+}
+
+
 function gzipSyncBuffer(body) {
   try {
     return zlib.gzipSync(typeof body === 'string' ? Buffer.from(body) : body);
@@ -10051,6 +10182,7 @@ server.listen(PORT, () => {
   startShippingStressSeedLoop();
   startSocialVelocitySeedLoop();
   startClimateNewsSeedLoop();
+  startPizzintSeedLoop();
 });
 
 wss.on('connection', (ws, req) => {

--- a/server/worldmonitor/intelligence/v1/get-pizzint-status.ts
+++ b/server/worldmonitor/intelligence/v1/get-pizzint-status.ts
@@ -2,160 +2,21 @@ import type {
   ServerContext,
   GetPizzintStatusRequest,
   GetPizzintStatusResponse,
-  PizzintStatus,
-  PizzintLocation,
-  GdeltTensionPair,
-  TrendDirection,
-  DataFreshness,
 } from '../../../../src/generated/server/worldmonitor/intelligence/v1/service_server';
 
-import { UPSTREAM_TIMEOUT_MS } from './_shared';
-import { CHROME_UA } from '../../../_shared/constants';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { getCachedJson } from '../../../_shared/redis';
 
-const REDIS_CACHE_KEY = 'intel:pizzint:v1';
-const REDIS_CACHE_TTL = 600; // 10 min
-
-// ========================================================================
-// Constants
-// ========================================================================
-
-const PIZZINT_API = 'https://www.pizzint.watch/api/dashboard-data';
-const GDELT_BATCH_API = 'https://www.pizzint.watch/api/gdelt/batch';
-const DEFAULT_GDELT_PAIRS = 'usa_russia,russia_ukraine,usa_china,china_taiwan,usa_iran,usa_venezuela';
-
-// ========================================================================
-// RPC handler
-// ========================================================================
+const SEED_KEY = 'intelligence:pizzint:seed:v1';
 
 export async function getPizzintStatus(
   _ctx: ServerContext,
   req: GetPizzintStatusRequest,
 ): Promise<GetPizzintStatusResponse> {
-  const cacheKey = `${REDIS_CACHE_KEY}:${req.includeGdelt ? 'gdelt' : 'base'}`;
-
-  let result: GetPizzintStatusResponse | null = null;
   try {
-    result = await cachedFetchJson<GetPizzintStatusResponse>(cacheKey, REDIS_CACHE_TTL, async () => {
-      let pizzint: PizzintStatus | undefined;
-      try {
-        const resp = await fetch(PIZZINT_API, {
-          headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-          signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
-        });
-        if (!resp.ok) throw new Error(`PizzINT API returned ${resp.status}`);
-
-        const raw = (await resp.json()) as {
-          success?: boolean;
-          data?: Array<{
-            place_id: string;
-            name: string;
-            address: string;
-            current_popularity: number;
-            percentage_of_usual: number | null;
-            is_spike: boolean;
-            spike_magnitude: number | null;
-            data_source: string;
-            recorded_at: string;
-            data_freshness: string;
-            is_closed_now?: boolean;
-            lat?: number;
-            lng?: number;
-          }>;
-        };
-        if (raw.success && raw.data) {
-          const locations: PizzintLocation[] = raw.data.map((d) => ({
-            placeId: d.place_id,
-            name: d.name,
-            address: d.address,
-            currentPopularity: d.current_popularity,
-            percentageOfUsual: d.percentage_of_usual ?? 0,
-            isSpike: d.is_spike,
-            spikeMagnitude: d.spike_magnitude ?? 0,
-            dataSource: d.data_source,
-            recordedAt: d.recorded_at,
-            dataFreshness: (d.data_freshness === 'fresh' ? 'DATA_FRESHNESS_FRESH' : 'DATA_FRESHNESS_STALE') as DataFreshness,
-            isClosedNow: d.is_closed_now ?? false,
-            lat: d.lat ?? 0,
-            lng: d.lng ?? 0,
-          }));
-
-          const openLocations = locations.filter((l) => !l.isClosedNow);
-          const activeSpikes = locations.filter((l) => l.isSpike).length;
-          const avgPop = openLocations.length > 0
-            ? openLocations.reduce((s, l) => s + l.currentPopularity, 0) / openLocations.length
-            : 0;
-
-          // DEFCON calculation
-          let adjusted = avgPop;
-          if (activeSpikes > 0) adjusted += activeSpikes * 10;
-          adjusted = Math.min(100, adjusted);
-          let defconLevel = 5;
-          let defconLabel = 'Normal Activity';
-          if (adjusted >= 85) { defconLevel = 1; defconLabel = 'Maximum Activity'; }
-          else if (adjusted >= 70) { defconLevel = 2; defconLabel = 'High Activity'; }
-          else if (adjusted >= 50) { defconLevel = 3; defconLabel = 'Elevated Activity'; }
-          else if (adjusted >= 25) { defconLevel = 4; defconLabel = 'Above Normal'; }
-
-          const hasFresh = locations.some((l) => l.dataFreshness === 'DATA_FRESHNESS_FRESH');
-
-          pizzint = {
-            defconLevel,
-            defconLabel,
-            aggregateActivity: Math.round(avgPop),
-            activeSpikes,
-            locationsMonitored: locations.length,
-            locationsOpen: openLocations.length,
-            updatedAt: Date.now(),
-            dataFreshness: (hasFresh ? 'DATA_FRESHNESS_FRESH' : 'DATA_FRESHNESS_STALE') as DataFreshness,
-            locations,
-          };
-        }
-      } catch (_) { /* PizzINT unavailable — continue to GDELT */ }
-
-      // Fetch GDELT tension pairs
-      let tensionPairs: GdeltTensionPair[] = [];
-      if (req.includeGdelt) {
-        try {
-          const url = `${GDELT_BATCH_API}?pairs=${encodeURIComponent(DEFAULT_GDELT_PAIRS)}&method=gpr`;
-          const resp = await fetch(url, {
-            headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-            signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
-          });
-          if (resp.ok) {
-            const raw = (await resp.json()) as Record<string, Array<{ t: number; v: number }>>;
-            tensionPairs = Object.entries(raw).map(([pairKey, dataPoints]) => {
-              const countries = pairKey.split('_');
-              const latest = dataPoints[dataPoints.length - 1]!;
-              const prev = dataPoints.length > 1 ? dataPoints[dataPoints.length - 2]! : latest;
-              const change = prev.v > 0 ? ((latest.v - prev.v) / prev.v) * 100 : 0;
-              const trend: TrendDirection = change > 5
-                ? 'TREND_DIRECTION_RISING'
-                : change < -5
-                  ? 'TREND_DIRECTION_FALLING'
-                  : 'TREND_DIRECTION_STABLE';
-
-              return {
-                id: pairKey,
-                countries,
-                label: countries.map((c) => c.toUpperCase()).join(' - '),
-                score: latest?.v ?? 0,
-                trend,
-                changePercent: Math.round(change * 10) / 10,
-                region: 'global',
-              };
-            });
-          }
-        } catch { /* gdelt unavailable */ }
-      }
-
-      // Only cache if PizzINT data was retrieved
-      if (!pizzint) return null;
-      return { pizzint, tensionPairs };
-    });
+    const result = await getCachedJson(SEED_KEY, true) as GetPizzintStatusResponse | null;
+    if (!result?.pizzint) return { pizzint: undefined, tensionPairs: [] };
+    return req.includeGdelt ? result : { pizzint: result.pizzint, tensionPairs: [] };
   } catch {
     return { pizzint: undefined, tensionPairs: [] };
   }
-
-  return result || { pizzint: undefined, tensionPairs: [] };
 }

--- a/src/services/pizzint.ts
+++ b/src/services/pizzint.ts
@@ -61,7 +61,7 @@ function toLocation(proto: ProtoLocation): PizzIntLocation {
     current_popularity: proto.currentPopularity,
     percentage_of_usual: proto.percentageOfUsual || null,
     is_spike: proto.isSpike,
-    spike_magnitude: proto.spikeMagnitude || null,
+    spike_magnitude: typeof proto.spikeMagnitude === 'number' ? proto.spikeMagnitude : null,
     data_source: proto.dataSource,
     recorded_at: proto.recordedAt,
     data_freshness: FRESHNESS_REVERSE[proto.dataFreshness] || 'stale',


### PR DESCRIPTION
## Summary

- **Root cause**: PizzINT API (`pizzint.watch`) blocks Vercel datacenter IPs with 403, causing the Pentagon Pizza Index panel to serve stale persistent cache (5h old) showing all locations as CLOSED
- **Fix**: Moved PizzINT + GDELT fetching to ais-relay seed loop on Railway (10min interval, 30min TTL), following the gold standard pattern. Vercel handler now reads from Redis seed key only (22 lines replacing 150)
- **Secondary fix**: `spike_magnitude` upstream API changed from `number` to string `"HIGH"` — added `typeof` guard in both seed and client

## Changes

| File | What |
|---|---|
| `scripts/ais-relay.cjs` | New `seedPizzint()` — fetches PizzINT + GDELT from Railway, processes into proto format, writes to Redis |
| `server/.../get-pizzint-status.ts` | Replaced upstream-fetching handler with Redis-read-only (`getCachedJson`) |
| `api/health.js` | Added `pizzint` to `STANDALONE_KEYS` and `SEED_META` (maxStaleMin: 30) |
| `src/services/pizzint.ts` | Fixed `spike_magnitude` string guard on client side |

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run typecheck:api` — pass
- [x] CJS syntax check (all scripts/*.cjs) — pass
- [x] `npm run lint` — pass (pre-existing warnings only)
- [x] `npm run test:data` — 2758 tests pass
- [x] Edge function bundle check — pass
- [x] Edge function isolation test — pass
- [x] Markdown lint — pass
- [x] Version sync — pass
- [ ] After deploy: verify `/api/health` shows `pizzint` key with fresh seed-meta
- [ ] After Railway deploy: check logs for `[PizzINT] Seeded N locations` output