### PR TITLE
fix(auth): add CLERK_PUBLISHABLE_KEY server env + fix CDN cache tests

### DIFF
--- a/tests/gateway-cdn-origin-policy.test.mts
+++ b/tests/gateway-cdn-origin-policy.test.mts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import { createDomainGateway } from '../server/gateway.ts';
+
+const originalKeys = process.env.WORLDMONITOR_VALID_KEYS;
+
+afterEach(() => {
+  if (originalKeys == null) delete process.env.WORLDMONITOR_VALID_KEYS;
+  else process.env.WORLDMONITOR_VALID_KEYS = originalKeys;
+});
+
+function createHandler() {
+  return createDomainGateway([
+    {
+      method: 'GET',
+      path: '/api/market/v1/list-market-quotes',
+      handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    },
+    {
+      method: 'GET',
+      path: '/api/market/v1/analyze-stock',
+      handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    },
+  ]);
+}
+
+async function requestPublicRoute(origin: string) {
+  const handler = createHandler();
+  return handler(new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
+    headers: { Origin: origin },
+  }));
+}
+
+describe('gateway CDN origin policy', () => {
+  it('keeps per-origin CORS and enables CDN caching for worldmonitor.app', async () => {
+    const res = await requestPublicRoute('https://worldmonitor.app');
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
+    assert.equal(res.headers.get('Vary'), 'Origin');
+    assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+  });
+
+  it('keeps per-origin CORS and enables CDN caching for production subdomains', async () => {
+    const res = await requestPublicRoute('https://tech.worldmonitor.app');
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://tech.worldmonitor.app');
+    assert.equal(res.headers.get('Vary'), 'Origin');
+    assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+  });
+
+  it('enables CDN caching for preview origins', async () => {
+    const origin = 'https://worldmonitor-feature-elie-abc123.vercel.app';
+    const res = await requestPublicRoute(origin);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), origin);
+    assert.equal(res.headers.get('Vary'), 'Origin');
+    assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+  });
+
+  it('enables CDN caching for localhost origins', async () => {
+    const origin = 'http://127.0.0.1:5173';
+    const res = await requestPublicRoute(origin);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), origin);
+    assert.equal(res.headers.get('Vary'), 'Origin');
+    assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+  });
+
+  it('enables CDN caching for Tauri origins', async () => {
+    const origin = 'tauri://localhost';
+    process.env.WORLDMONITOR_VALID_KEYS = 'real-key-123';
+    const handler = createHandler();
+    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
+      headers: {
+        Origin: origin,
+        'X-WorldMonitor-Key': 'real-key-123',
+      },
+    }));
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), origin);
+    assert.equal(res.headers.get('Vary'), 'Origin');
+    assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+  });
+
+  it('still blocks disallowed origins before route handling', async () => {
+    const handler = createHandler();
+    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
+      headers: { Origin: 'https://evil.example.com' },
+    }));
+    assert.equal(res.status, 403);
+  });
+
+  it('preserves premium auth behavior', async () => {
+    process.env.WORLDMONITOR_VALID_KEYS = 'real-key-123';
+    const handler = createHandler();
+
+    const noCreds = await handler(new Request('https://worldmonitor.app/api/market/v1/analyze-stock?symbol=AAPL', {
+      headers: { Origin: 'https://worldmonitor.app' },
+    }));
+    assert.equal(noCreds.status, 401);
+
+    const withKey = await handler(new Request('https://worldmonitor.app/api/market/v1/analyze-stock?symbol=AAPL', {
+      headers: {
+        Origin: 'https://worldmonitor.app',
+        'X-WorldMonitor-Key': 'real-key-123',
+      },
+    }));
+    assert.equal(withKey.status, 200);
+    assert.equal(withKey.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
+    assert.equal(withKey.headers.get('Vary'), 'Origin');
+    assert.match(withKey.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `CLERK_PUBLISHABLE_KEY` server-side env var to Vercel (already done via CLI)
- Fixes 3 failing tests in `gateway-cdn-origin-policy.test.mts` that were broken by #2566 (CDN cache now enabled for preview/localhost/Tauri origins per gateway comment)

## Root cause of 401 on /api/notification-channels
PR #2024 added audience checking to `validateBearerToken`. Standard Clerk session tokens have `aud: 'pk_live_...'` but `CLERK_PUBLISHABLE_KEY` was not set as a server env var (only `VITE_CLERK_PUBLISHABLE_KEY` existed for the frontend build). This caused `getAllowedAudiences()` to return only `['convex']`, rejecting all standard session tokens.

**Fix**: `CLERK_PUBLISHABLE_KEY=pk_live_Y2xlcmsud29ybGRtb25pdG9yLmFwcCQ` added to Vercel production. This deploy picks it up.

## Test plan
- [ ] Merge triggers Vercel production deploy with the new env var
- [ ] `GET /api/notification-channels` returns 200 instead of 401