### PR TITLE
chore(auth): document required server env vars (force deploy)

### DIFF
--- a/server/auth-session.ts
+++ b/server/auth-session.ts
@@ -3,6 +3,7 @@
  *
  * Validates Clerk-issued bearer tokens using local JWT verification
  * with jose + cached JWKS. No Convex round-trip needed.
+ * Requires CLERK_PUBLISHABLE_KEY (server-side) and CLERK_JWT_ISSUER_DOMAIN.
  *
  * This module must NOT import anything from `src/` -- it runs in the
  * Vercel edge runtime, not the browser.


### PR DESCRIPTION
Forces Vercel to rebuild with the CLERK_PUBLISHABLE_KEY env var that was added separately. Fixes 401 on /api/notification-channels introduced by #2024.