### PR TITLE
fix(ci): unblock docs-only PRs from required check deadlock

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -52,13 +52,16 @@ jobs:
             exit 0
           fi
 
-          if [ "$unit" != "success" ] || [ "$typecheck" != "success" ]; then
-            gh api "repos/$REPO/statuses/$SHA" --method POST \
-              --field state="failure" \
-              --field context="gate" \
-              --field description="Required checks did not pass (unit=$unit typecheck=$typecheck)"
-            exit 0
-          fi
+          # Treat "skipped" as passing (docs-only PRs skip code checks)
+          for v in "$unit" "$typecheck"; do
+            if [ "$v" != "success" ] && [ "$v" != "skipped" ]; then
+              gh api "repos/$REPO/statuses/$SHA" --method POST \
+                --field state="failure" \
+                --field context="gate" \
+                --field description="Required checks did not pass (unit=$unit typecheck=$typecheck)"
+              exit 0
+            fi
+          done
 
           gh api "repos/$REPO/statuses/$SHA" --method POST \
             --field state="success" \

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -2,14 +2,6 @@ name: Lint Code
 
 on:
   pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'src-tauri/**'
-      - 'CHANGELOG.md'
-      - 'LICENSE'
-      - '.github/workflows/build-desktop.yml'
-      - '.github/workflows/docker-publish.yml'
   push:
     branches: [main]
 
@@ -17,7 +9,29 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.diff.outputs.code }}
+    steps:
+      - id: diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" \
+            --paginate --jq '.[].filename')
+          CODE=$(echo "$FILES" | grep -vcE '\.md$|^docs/|^src-tauri/|^CHANGELOG\.md$|^LICENSE$|\.github/workflows/(build-desktop|docker-publish)\.yml$' || echo 0)
+          echo "code=$( [ "$CODE" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+
   biome:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,14 +2,6 @@ name: Test
 
 on:
   pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'src-tauri/**'
-      - 'CHANGELOG.md'
-      - 'LICENSE'
-      - '.github/workflows/build-desktop.yml'
-      - '.github/workflows/docker-publish.yml'
   push:
     branches: [main]
 
@@ -17,7 +9,29 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.diff.outputs.code }}
+    steps:
+      - id: diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" \
+            --paginate --jq '.[].filename')
+          CODE=$(echo "$FILES" | grep -vcE '\.md$|^docs/|^src-tauri/|^CHANGELOG\.md$|^LICENSE$|\.github/workflows/(build-desktop|docker-publish)\.yml$' || echo 0)
+          echo "code=$( [ "$CODE" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+
   unit:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -2,14 +2,6 @@ name: Typecheck
 
 on:
   pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'src-tauri/**'
-      - 'CHANGELOG.md'
-      - 'LICENSE'
-      - '.github/workflows/build-desktop.yml'
-      - '.github/workflows/docker-publish.yml'
   push:
     branches: [main]
 
@@ -17,9 +9,30 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.diff.outputs.code }}
+    steps:
+      - id: diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" \
+            --paginate --jq '.[].filename')
+          CODE=$(echo "$FILES" | grep -vcE '\.md$|^docs/|^src-tauri/|^CHANGELOG\.md$|^LICENSE$|\.github/workflows/(build-desktop|docker-publish)\.yml$' || echo 0)
+          echo "code=$( [ "$CODE" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+
   typecheck:
     # No secrets needed — run for all PRs including forks
-
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

- Docs-only PRs (e.g. #2619, #2639) get stuck with required checks "Waiting for status to be reported" forever
- Root cause: `paths-ignore: '**/*.md'` at the workflow trigger level means the workflow never fires, so GitHub never creates the check run
- Branch protection requires `biome`, `typecheck`, `unit`, `gate` to pass, creating a deadlock

**Fix:** Move path filtering from workflow-level `paths-ignore` to job-level `if:` conditions via a lightweight `changes` job that queries the GitHub API for changed files. When a job is skipped via `if:`, GitHub reports it as passed for required checks.

Also updates `deploy-gate` to treat `skipped` conclusions as passing.

## Test plan

- [ ] Merge #2639 (docs-only PR) first to confirm manual skip statuses worked
- [ ] After this PR merges, create a test docs-only PR to verify checks auto-skip
- [ ] Verify code PRs still run all checks normally