### PR TITLE
fix(checkout): surface Dodo API errors instead of generic Server Error

### DIFF
--- a/convex/payments/checkout.ts
+++ b/convex/payments/checkout.ts
@@ -64,20 +64,27 @@ export const createCheckout = action({
       metadata.affonso_referral = args.referralCode;
     }
 
-    const result = await checkout(ctx, {
-      payload: {
-        product_cart: [{ product_id: args.productId, quantity: 1 }],
-        return_url: returnUrl,
-        ...(args.discountCode ? { discount_code: args.discountCode } : {}),
-        ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
-        feature_flags: {
-          allow_discount_code: true, // PROMO-01: Always show discount input
+    let result;
+    try {
+      result = await checkout(ctx, {
+        payload: {
+          product_cart: [{ product_id: args.productId, quantity: 1 }],
+          return_url: returnUrl,
+          ...(args.discountCode ? { discount_code: args.discountCode } : {}),
+          ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+          feature_flags: {
+            allow_discount_code: true, // PROMO-01: Always show discount input
+          },
+          customization: {
+            theme: "dark",
+          },
         },
-        customization: {
-          theme: "dark",
-        },
-      },
-    });
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[checkout] createCheckout failed for user=${userId} product=${args.productId}: ${msg}`);
+      throw new ConvexError(`Checkout failed: ${msg}`);
+    }
 
     return result;
   },


### PR DESCRIPTION
## Summary

Sentry WORLDMONITOR-K0: `createCheckout` action threw generic "Server Error" with no useful info. Convex masks unhandled errors for security.

Wrapped the Dodo API call in try/catch, re-throwing as `ConvexError` with the actual error message. ConvexError messages are sent to the client, so Sentry and the browser console will now show the real failure reason.

**This requires `npx convex deploy` after merge** (Convex server code change).

## Test plan

- [ ] After Convex deploy: trigger checkout failure → verify Sentry shows actual error message