### PR TITLE
feat(settings): restructure notification settings UX

### DIFF
--- a/src/services/preferences-content.ts
+++ b/src/services/preferences-content.ts
@@ -754,12 +754,10 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
           const qhEnabled = alertRule?.quietHoursEnabled ?? false;
           const qhStart = alertRule?.quietHoursStart ?? 22;
           const qhEnd = alertRule?.quietHoursEnd ?? 7;
-          const qhTz = alertRule?.quietHoursTimezone ?? detectedTz;
           const qhOverride = alertRule?.quietHoursOverride ?? 'critical_only';
 
           const digestMode = alertRule?.digestMode ?? 'realtime';
           const digestHour = alertRule?.digestHour ?? 8;
-          const digestTz = alertRule?.digestTimezone ?? detectedTz;
 
           const hourOptions = Array.from({ length: 24 }, (_, h) => {
             const label = h === 0 ? '12 AM' : h < 12 ? `${h} AM` : h === 12 ? '12 PM' : `${h - 12} PM`;
@@ -798,7 +796,9 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
           };
 
           const isRealtime = !DIGEST_CRON_ENABLED || digestMode === 'realtime';
-          const sharedTz = qhTz || digestTz || detectedTz;
+          const sharedTz = isRealtime
+            ? (alertRule?.quietHoursTimezone ?? alertRule?.digestTimezone ?? detectedTz)
+            : (alertRule?.digestTimezone ?? alertRule?.quietHoursTimezone ?? detectedTz);
 
           html += `<div class="ai-flow-section-label" style="margin-top:8px">Delivery Mode</div>
             ${!DIGEST_CRON_ENABLED ? '<div class="ai-flow-toggle-desc" style="margin-bottom:4px">Digest delivery is not yet active.</div>' : ''}
@@ -980,6 +980,16 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
             if (realtimeSection) realtimeSection.style.display = isRt ? '' : 'none';
             if (digestDetails) digestDetails.style.display = isRt ? 'none' : '';
             saveDigestSettings();
+            // Switching to digest mode: auto-enable the alert rule so the
+            // backend schedules digests. The enable toggle is hidden in
+            // digest mode, so the user has no other way to turn it on.
+            if (!isRt) {
+              const enabledEl = container.querySelector<HTMLInputElement>('#usNotifEnabled');
+              if (enabledEl && !enabledEl.checked) {
+                enabledEl.checked = true;
+                enabledEl.dispatchEvent(new Event('change', { bubbles: true }));
+              }
+            }
             return;
           }
           if (target.id === 'usDigestHour') {


### PR DESCRIPTION
## Summary

Notification settings had a UX confusion: "Enable notifications" toggle, sensitivity, quiet hours, and digest mode were all shown simultaneously with no clear relationship.

**New layout:**
1. **Delivery Mode** first (real-time vs daily/twice daily/weekly digest)
2. **Real-time section** (enable toggle + sensitivity + quiet hours) only visible when real-time selected
3. **Digest section** (send-at hour) only visible when digest selected
4. **Single shared timezone** at bottom (writes to both quietHoursTimezone and digestTimezone)

No API, schema, or server changes. Pure client-side restructure.

## Test plan

- [x] `npm run typecheck` pass
- [x] `npm run test:data` (0 failures)
- [ ] Open Settings → Notifications: delivery mode dropdown is first after channels
- [ ] Select "Daily digest": real-time section hides, send-at picker shows
- [ ] Switch back to "Real-time": alert rules + quiet hours reappear
- [ ] Change timezone: both quiet hours and digest settings saved