### PR TITLE
fix(electricity): fix EIA v2 API query params (400 on all US regions)

### DIFF
--- a/scripts/seed-electricity-prices.mjs
+++ b/scripts/seed-electricity-prices.mjs
@@ -179,12 +179,12 @@ async function fetchAllEntsoE(token, today, yesterday) {
 async function fetchEiaRegion(region, apiKey, today) {
   const dateStr = isoDate(today);
   const params = new URLSearchParams({
-    'data[]': 'D',
+    'data[]': 'value',
     'facets[respondent][]': region.region,
     start: isoDate(new Date(Date.now() - 2 * 24 * 3600 * 1000)),
     end: dateStr,
-    sort: 'period',
-    sortDirection: 'desc',
+    'sort[0][column]': 'period',
+    'sort[0][direction]': 'desc',
     length: '1',
     api_key: apiKey,
   });


### PR DESCRIPTION
## Summary
All 6 US electricity regions (CISO, NYISO, PJM, MISO, ERCO, SPP) returning HTTP 400.

## Root cause
Two EIA v2 API parameter errors:
1. `data[]=D` — v1 field name. v2 requires `data[]=value`
2. `sort=period&sortDirection=desc` — v1 format. v2 requires `sort[0][column]=period&sort[0][direction]=desc`

## Verified
Tested locally: CISO returns `{"value": "20093", "value-units": "megawatthours"}` after fix.

## Test plan
- [ ] Deploy and verify Railway logs show successful EIA-930 fetches
- [ ] Check Redis for `energy:electricity:v1:CISO` etc.