### PR TITLE
ci: gate the Convex production deploy on the merge gate

### DIFF
--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -91,9 +91,70 @@ jobs:
             echo "convex=false" >> "$GITHUB_OUTPUT"
           fi
 
-  deploy:
+  gate:
+    # Hold the deploy until the required merge gate has passed on this commit.
+    # Without this, a push to main deploys Convex concurrently with the checks
+    # that decide whether the commit is safe, so a red main can reach prod.
+    #
+    # Poll the commit status instead of chaining another workflow_run. Keeping
+    # this workflow on push preserves github.event.before/after, which the
+    # change-detection job above needs.
     needs: changes
     if: needs.changes.outputs.convex == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      statuses: read
+    steps:
+      - name: Wait for the merge gate on this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Manual runs are the operator override for hotfixes and recovery.
+          # An off-cycle dispatch may never receive a gate status.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "workflow_dispatch: skipping gate wait (operator override)"
+            exit 0
+          fi
+
+          # ~25 minute budget. The gate aggregates Test, Typecheck, Lint Code,
+          # and Security Audit, which normally finish well inside this window.
+          for _ in $(seq 1 75); do
+            # Status history is newest-first. Preserve API order because
+            # created_at has only second resolution and sorting can invert ties.
+            state=$(
+              gh api --paginate --slurp \
+                "repos/$REPO/commits/$SHA/statuses?per_page=100" |
+                jq -r 'flatten | map(select(.context == "gate")) | first | .state // "missing"'
+            )
+
+            case "$state" in
+              success)
+                echo "gate: success — proceeding with the Convex deploy"
+                exit 0
+                ;;
+              failure|error)
+                echo "::error::merge gate concluded '$state' for $SHA; not deploying Convex"
+                exit 1
+                ;;
+              *)
+                echo "gate: '$state' — waiting..."
+                ;;
+            esac
+            sleep 20
+          done
+
+          echo "::error::timed out waiting for the merge gate on $SHA; not deploying Convex"
+          exit 1
+
+  deploy:
+    needs: [changes, gate]
+    if: needs.changes.outputs.convex == 'true' && needs.gate.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/tests/convex-deploy-workflow.test.mjs
+++ b/tests/convex-deploy-workflow.test.mjs
@@ -1,0 +1,55 @@
+// The Convex workflow mutates production on its own. These tests pin the gate
+// that prevents a failing main commit from being deployed while preserving the
+// existing explicit operator override for manual recovery runs.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import YAML from 'yaml';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const source = readFileSync(resolve(repoRoot, '.github/workflows/convex-deploy.yml'), 'utf8');
+const workflow = YAML.parse(source);
+const gate = workflow.jobs.gate;
+const deploy = workflow.jobs.deploy;
+const waitStep = gate.steps.find((step) => step.name === 'Wait for the merge gate on this commit');
+
+describe('Convex deploy workflow', () => {
+  it('waits for the required gate before deploying a push', () => {
+    assert.ok(waitStep, 'the workflow must define a merge-gate wait step');
+    assert.match(waitStep.run, /context == "gate"/);
+    assert.match(waitStep.run, /failure\|error/);
+    assert.match(waitStep.run, /timed out[\s\S]*exit 1/);
+  });
+
+  it('reads the complete newest-first gate status history', () => {
+    assert.match(waitStep.run, /gh api --paginate --slurp/);
+    assert.match(waitStep.run, /statuses\?per_page=100/);
+    assert.match(waitStep.run, /map\(select\(\.context == "gate"\)\) \| first/);
+    assert.doesNotMatch(waitStep.run, /sort_by/);
+  });
+
+  it('grants only the gate job permission to read statuses', () => {
+    assert.equal(workflow.permissions?.statuses, undefined);
+    assert.equal(gate.permissions?.contents, 'read');
+    assert.equal(gate.permissions?.statuses, 'read');
+  });
+
+  it('requires the gate job to succeed before the deploy job can run', () => {
+    assert.deepEqual(deploy.needs, ['changes', 'gate']);
+    assert.match(String(deploy.if), /needs\.gate\.result == 'success'/);
+  });
+
+  it('keeps the explicit manual recovery override inside the non-mutating gate job', () => {
+    assert.match(waitStep.run, /github\.event_name[^\n]*workflow_dispatch/);
+    assert.match(waitStep.run, /workflow_dispatch: skipping gate wait/);
+    assert.doesNotMatch(String(deploy.if), /workflow_dispatch/);
+  });
+
+  it('never cancels a production deployment in progress', () => {
+    assert.equal(workflow.concurrency?.['cancel-in-progress'], false);
+  });
+});


### PR DESCRIPTION
## Summary

- hold automatic Convex production deploys until the repository's required `gate` status succeeds for the pushed commit
- fail closed when the gate reports failure/error or does not resolve within the bounded wait
- preserve `workflow_dispatch` as the existing explicit operator override for hotfix and recovery runs
- add regression tests for gate ordering, pagination, permissions, timeout behavior, and deploy dependencies

## Why

`convex-deploy.yml` runs on `push: main`. Before this change, it could deploy the new Convex code while Test, Typecheck, Lint Code, and Security Audit were still deciding whether that same commit was safe. A failing commit could therefore reach production before the aggregate merge gate turned red.

The workflow remains push-triggered so the existing authoritative `github.event.before`/`after` change detection remains intact. A new non-mutating `gate` job reads the `gate` commit-status history newest-first, matching the repository's existing deploy/reconciliation controls, and only releases the production job after success.

## Safety details

- `statuses: read` is scoped to the gate job; the deployment job does not receive it.
- Status pagination is complete and API ordering is preserved to avoid timestamp-tie inversions.
- `failure`, `error`, and timeout all stop the deployment.
- The deploy job explicitly requires both `changes` and a successful `gate` result.
- Production runs remain serialized with `cancel-in-progress: false`.

## Validation

- `tsx --test tests/convex-deploy-workflow.test.mjs` — 6/6 passed
- `tsx --test tests/ci-workflow-coverage.test.mts` — 22/22 passed
- `.github/workflows/convex-deploy.yml` parses with the repository-pinned `yaml` package
- `git diff --check` — passed

The external Vercel authorization status requires a World Monitor team member and is unrelated to this workflow change.

Assisted-by: OpenAI Codex