### PR TITLE
fix(relay): add seed-chokepoint-flows.mjs to Dockerfile.relay

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -23,6 +23,7 @@ COPY scripts/ais-relay.cjs ./scripts/ais-relay.cjs
 COPY scripts/_proxy-utils.cjs ./scripts/_proxy-utils.cjs
 COPY scripts/_seed-utils.mjs ./scripts/_seed-utils.mjs
 COPY scripts/seed-climate-news.mjs ./scripts/seed-climate-news.mjs
+COPY scripts/seed-chokepoint-flows.mjs ./scripts/seed-chokepoint-flows.mjs
 
 # Shared helper required by the relay (rss-allowed-domains.cjs)
 COPY shared/ ./shared/


### PR DESCRIPTION
seed-chokepoint-flows.mjs was wired into the relay loop in PR #2797 but missing from Dockerfile.relay's explicit COPY list. Runtime crash when the 6h seed loop fires after next relay deploy.