### PR TITLE
fix(map): store auth unsubscribe handle + auto-cleanup on unlock

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -356,6 +356,7 @@ export class DeckGLMap {
   private cyberThreats: CyberThreat[] = [];
   private aptGroups: import('@/types').APTGroup[] = [];
   private aptGroupsLoaded = false;
+  private _unsubscribeAuthState: (() => void) | null = null;
   private aptGroupsLayerFailed = false;
   private satelliteImageryLayerFailed = false;
   private iranEvents: IranEvent[] = [];
@@ -4309,8 +4310,8 @@ export class DeckGLMap {
     this.container.appendChild(toggles);
 
     // Unlock premium layers when auth state resolves (e.g., Clerk JWT arrives after map init)
-    subscribeAuthState(() => {
-      if (!hasPremiumAccess(getAuthState())) return;
+    this._unsubscribeAuthState = subscribeAuthState((state) => {
+      if (!hasPremiumAccess(state)) return;
       toggles.querySelectorAll('.layer-toggle-locked').forEach(label => {
         label.classList.remove('layer-toggle-locked');
         const input = label.querySelector('input') as HTMLInputElement | null;
@@ -4318,6 +4319,8 @@ export class DeckGLMap {
         const labelSpan = label.querySelector('.toggle-label');
         if (labelSpan) labelSpan.textContent = labelSpan.textContent!.replace(' \uD83D\uDD12', '');
       });
+      this._unsubscribeAuthState?.();
+      this._unsubscribeAuthState = null;
     });
 
     // Bind toggle events
@@ -6057,6 +6060,8 @@ export class DeckGLMap {
   }
 
   public destroy(): void {
+    this._unsubscribeAuthState?.();
+    this._unsubscribeAuthState = null;
     window.removeEventListener('theme-changed', this.handleThemeChange);
     window.removeEventListener('map-theme-changed', this.handleMapThemeChange);
     this.debouncedRebuildLayers.cancel();

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -4309,7 +4309,9 @@ export class DeckGLMap {
 
     this.container.appendChild(toggles);
 
-    // Unlock premium layers when auth state resolves (e.g., Clerk JWT arrives after map init)
+    // Unlock premium layers when auth state resolves (e.g., Clerk JWT arrives after map init).
+    // subscribeAuthState fires the callback synchronously if state is already available,
+    // so we defer the self-unsubscribe with queueMicrotask to ensure the assignment completes.
     this._unsubscribeAuthState = subscribeAuthState((state) => {
       if (!hasPremiumAccess(state)) return;
       toggles.querySelectorAll('.layer-toggle-locked').forEach(label => {
@@ -4319,8 +4321,10 @@ export class DeckGLMap {
         const labelSpan = label.querySelector('.toggle-label');
         if (labelSpan) labelSpan.textContent = labelSpan.textContent!.replace(' \uD83D\uDD12', '');
       });
-      this._unsubscribeAuthState?.();
-      this._unsubscribeAuthState = null;
+      queueMicrotask(() => {
+        this._unsubscribeAuthState?.();
+        this._unsubscribeAuthState = null;
+      });
     });
 
     // Bind toggle events


### PR DESCRIPTION
## Summary
Follow-up to #2840. Fixes memory leak and redundant call:
- Store `subscribeAuthState` return as class field `_unsubscribeAuthState`
- Clean up in `destroy()` to prevent leaked subscriptions on map teardown
- Use passed `AuthSession` state instead of redundant `getAuthState()` call
- Auto-unsubscribe after first unlock (one-shot pattern)

## Test plan
- [x] TypeScript typecheck passes
- [ ] Verify no console errors on variant switch (map destroy/recreate)