### PR TITLE
fix(telegram): normalize edge relay response to fix silent empty-feed

### DIFF
--- a/api/telegram-feed.js
+++ b/api/telegram-feed.js
@@ -4,6 +4,35 @@ import { jsonResponse } from './_json-response.js';
 
 export const config = { runtime: 'edge' };
 
+/**
+ * Normalize relay Telegram message to the browser UI model.
+ * The relay may return either `messages[]` or `items[]` with varying field names.
+ * The browser UI (TelegramIntelPanel) expects `items[]` with:
+ *   id, source, channel, channelTitle, url, ts, text, topic, tags, earlySignal, mediaUrls
+ */
+function normalizeTelegramMessage(msg) {
+  const timestamp = msg.timestamp ?? msg.ts ?? msg.timestampMs ?? null;
+  const ts = timestamp === null
+    ? null
+    : typeof timestamp === 'number'
+      ? (timestamp > 1e12 ? new Date(timestamp).toISOString() : new Date(timestamp * 1000).toISOString())
+      : (timestamp ? new Date(timestamp).toISOString() : null);
+
+  return {
+    id: String(msg.id ?? ''),
+    source: 'telegram',
+    channel: String(msg.channelName ?? msg.channel ?? ''),
+    channelTitle: String(msg.channelTitle ?? msg.channelName ?? msg.channel ?? ''),
+    url: String(msg.sourceUrl ?? msg.url ?? ''),
+    ts,
+    text: String(msg.text ?? ''),
+    topic: String(msg.topic ?? ''),
+    tags: Array.isArray(msg.tags) ? msg.tags : [],
+    earlySignal: Boolean(msg.earlySignal ?? false),
+    mediaUrls: Array.isArray(msg.mediaUrls) ? msg.mediaUrls.map(String) : [],
+  };
+}
+
 export default async function handler(req) {
   const corsHeaders = getCorsHeaders(req, 'GET, OPTIONS');
 
@@ -42,9 +71,25 @@ export default async function handler(req) {
     let cacheControl = 'public, max-age=30, s-maxage=120, stale-while-revalidate=60, stale-if-error=120';
     try {
       const parsed = JSON.parse(body);
-      if (!parsed || parsed.count === 0 || !parsed.items || parsed.items.length === 0) {
+      // Normalize: extract messages from messages[] OR items[], then normalize each to UI model
+      const rawMessages = Array.isArray(parsed?.messages) ? parsed.messages
+        : Array.isArray(parsed?.items) ? parsed.items
+        : [];
+      const normalizedItems = rawMessages.map(normalizeTelegramMessage);
+      const normalizedCount = parsed?.count ?? normalizedItems.length;
+      const normalizedResponse = {
+        enabled: parsed?.enabled ?? true,
+        count: normalizedCount,
+        updatedAt: parsed?.updatedAt ?? null,
+        items: normalizedItems,
+      };
+      if (!parsed || normalizedCount === 0 || normalizedItems.length === 0) {
         cacheControl = 'public, max-age=0, s-maxage=15, stale-while-revalidate=10';
       }
+      return buildRelayResponse(response, JSON.stringify(normalizedResponse), {
+        'Cache-Control': response.ok ? cacheControl : 'no-store',
+        ...corsHeaders,
+      });
     } catch {}
 
     return buildRelayResponse(response, body, {

--- a/api/telegram-feed.js
+++ b/api/telegram-feed.js
@@ -16,7 +16,7 @@ function normalizeTelegramMessage(msg) {
     ? null
     : typeof timestamp === 'number'
       ? (timestamp > 1e12 ? new Date(timestamp).toISOString() : new Date(timestamp * 1000).toISOString())
-      : (timestamp ? new Date(timestamp).toISOString() : null);
+      : (() => { const d = new Date(timestamp); return isNaN(d.getTime()) ? null : d.toISOString(); })();
 
   return {
     id: String(msg.id ?? ''),
@@ -76,7 +76,7 @@ export default async function handler(req) {
         : Array.isArray(parsed?.items) ? parsed.items
         : [];
       const normalizedItems = rawMessages.map(normalizeTelegramMessage);
-      const normalizedCount = parsed?.count ?? normalizedItems.length;
+      const normalizedCount = normalizedItems.length;
       const normalizedResponse = {
         enabled: parsed?.enabled ?? true,
         count: normalizedCount,


### PR DESCRIPTION
## Summary

Normalizes the edge relay /api/telegram-feed response so the browser UI (TelegramIntelPanel) always receives items[] in the expected shape, regardless of whether the upstream relay returns messages[] or items[].

## Root cause

The relay may return either messages[] or items[] with varying field names:
- ts/timestamp/timestampMs
- sourceUrl/url
- channelName/channelTitle

The browser UI panel expects items[] with specific field names (ts, url, channelTitle). When the relay returns messages[], the browser reads items (undefined) and silently renders an empty list with zero count.

The cache TTL short-circuit also misfired on messages[] payloads since it only checked parsed.items.

## Fix

1. **normalizeTelegramMessage() helper**: Maps relay fields to the UI model shape:
   - Accepts ts/timestamp/timestampMs → ISO string ts
   - Accepts sourceUrl/url → url
   - Accepts channelTitle/channelName/channel → channelTitle + channel
   - Adds source: 'telegram', tags: [], earlySignal: false defaults

2. **messages[] OR items[]**: Extracts from whichever field the relay provides (consistent with server handler)

3. **Normalized response shape**: Always returns {items[], count, updatedAt, enabled} to the browser

4. **Correct cache TTL**: Uses normalized count/items for empty-feed cache decision

## Testing

- Node.js syntax check passes (node --check api/telegram-feed.js)
- No breaking changes to existing relay passthrough for non-JSON responses
- Single file change, minimal blast radius

Fixes koala73/worldmonitor#2593