### PR TITLE
fix(energy): decouple LNG fetch from energy panel

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2627,9 +2627,10 @@ export class DataLoaderManager implements AppModule {
       if (oilStocksResp.status === 'fulfilled' && !oilStocksResp.value.unavailable) {
         energyPanel?.setOilStocksAnalysis(oilStocksResp.value);
       }
+      // Fire-and-forget: LNG vulnerability is hydration-only today (no network fallback).
+      // Decoupled so a future fetch path does not delay core energy panel rendering.
       fetchLngVulnerability().then(lngData => {
-        if (lngData) energyPanel?.updateLngVulnerability(lngData);
-        else energyPanel?.updateLngVulnerability(null);
+        energyPanel?.updateLngVulnerability(lngData);
       }).catch(() => {
         energyPanel?.updateLngVulnerability(null);
       });

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2591,13 +2591,12 @@ export class DataLoaderManager implements AppModule {
   async loadOilAnalytics(): Promise<void> {
     const energyPanel = this.ctx.panels['energy-complex'] as EnergyComplexPanel | undefined;
     try {
-      const [data, crudeResp, natGasResp, euGasResp, oilStocksResp, lngResp] = await Promise.allSettled([
+      const [data, crudeResp, natGasResp, euGasResp, oilStocksResp] = await Promise.allSettled([
         fetchOilAnalytics(),
         fetchCrudeInventoriesRpc(),
         fetchNatGasStorageRpc(),
         getEuGasStorageData(),
         getOilStocksAnalysisData(),
-        fetchLngVulnerability(),
       ]);
       if (data.status === 'fulfilled') {
         energyPanel?.updateAnalytics(data.value);
@@ -2628,9 +2627,12 @@ export class DataLoaderManager implements AppModule {
       if (oilStocksResp.status === 'fulfilled' && !oilStocksResp.value.unavailable) {
         energyPanel?.setOilStocksAnalysis(oilStocksResp.value);
       }
-      if (lngResp.status === 'fulfilled' && lngResp.value) {
-        energyPanel?.updateLngVulnerability(lngResp.value);
-      }
+      fetchLngVulnerability().then(lngData => {
+        if (lngData) energyPanel?.updateLngVulnerability(lngData);
+        else energyPanel?.updateLngVulnerability(null);
+      }).catch(() => {
+        energyPanel?.updateLngVulnerability(null);
+      });
     } catch (e) {
       console.error('[App] Oil analytics failed:', e);
       this.callPanel('energy-complex', 'showError', undefined, () => void this.loadOilAnalytics());

--- a/src/components/EnergyComplexPanel.ts
+++ b/src/components/EnergyComplexPanel.ts
@@ -59,8 +59,8 @@ export class EnergyComplexPanel extends Panel {
     this.render();
   }
 
-  public updateLngVulnerability(data: LngVulnerabilityData): void {
-    this.lngVulnerability = data.top20LngDependent?.length ? data : null;
+  public updateLngVulnerability(data: LngVulnerabilityData | null): void {
+    this.lngVulnerability = data?.top20LngDependent?.length ? data : null;
     this.render();
   }
 


### PR DESCRIPTION
## Summary
- Moved `fetchLngVulnerability()` out of the energy panel's `Promise.allSettled` so it no longer blocks the core energy data (oil analytics, crude inventories, nat gas, EU gas, oil stocks) from rendering.
- LNG fetch is now fire-and-forget: it updates the panel when it completes, or clears stale data on error/null.
- `updateLngVulnerability` now accepts `null`, ensuring stale LNG data is cleared when the fetch fails.

## Test plan
- [ ] Verify energy panel renders immediately with core data (oil, gas, inventories) without waiting for LNG
- [ ] Verify LNG vulnerability section appears after its fetch completes
- [ ] Simulate LNG fetch failure and confirm the section is cleared (no stale data)
- [ ] `npx tsc --noEmit` passes