### PR TITLE
feat(seed): compute intervals inline in resilience scores seed

### DIFF
--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -3,6 +3,7 @@ import {
   getRedisCredentials,
   loadEnvFile,
   logSeedResult,
+  writeFreshnessMetadata,
 } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
@@ -15,6 +16,42 @@ export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v7:';
 export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v7';
 export const RESILIENCE_RANKING_CACHE_TTL_SECONDS = 6 * 60 * 60;
 export const RESILIENCE_STATIC_INDEX_KEY = 'resilience:static:index:v1';
+
+const INTERVAL_KEY_PREFIX = 'resilience:intervals:v1:';
+const INTERVAL_TTL_SECONDS = 7 * 24 * 60 * 60;
+const DRAWS = 100;
+
+const DOMAIN_WEIGHTS = {
+  economic: 0.22,
+  infrastructure: 0.20,
+  energy: 0.15,
+  'social-governance': 0.25,
+  'health-food': 0.18,
+};
+
+const DOMAIN_ORDER = [
+  'economic',
+  'infrastructure',
+  'energy',
+  'social-governance',
+  'health-food',
+];
+
+export function computeIntervals(domainScores, domainWeights, draws = DRAWS) {
+  const samples = [];
+  for (let i = 0; i < draws; i++) {
+    const jittered = domainWeights.map((w) => w * (0.9 + Math.random() * 0.2));
+    const sum = jittered.reduce((s, w) => s + w, 0);
+    const normalized = jittered.map((w) => w / sum);
+    const score = domainScores.reduce((s, d, idx) => s + d * normalized[idx], 0);
+    samples.push(score);
+  }
+  samples.sort((a, b) => a - b);
+  return {
+    p05: Math.round(samples[Math.max(0, Math.ceil(draws * 0.05) - 1)] * 10) / 10,
+    p95: Math.round(samples[Math.min(draws - 1, Math.ceil(draws * 0.95) - 1)] * 10) / 10,
+  };
+}
 
 async function redisGetJson(url, token, key) {
   const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
@@ -49,6 +86,48 @@ function countCachedFromPipeline(results) {
     }
   }
   return count;
+}
+
+async function computeAndWriteIntervals(url, token, countryCodes, pipelineResults) {
+  const weights = DOMAIN_ORDER.map((id) => DOMAIN_WEIGHTS[id]);
+  const commands = [];
+
+  for (let i = 0; i < countryCodes.length; i++) {
+    const raw = pipelineResults[i]?.result ?? null;
+    if (!raw || raw === 'null') continue;
+    try {
+      const score = JSON.parse(raw);
+      if (!score.domains?.length) continue;
+
+      const domainScores = DOMAIN_ORDER.map((id) => {
+        const d = score.domains.find((dom) => dom.id === id);
+        return d?.score ?? 0;
+      });
+
+      const interval = computeIntervals(domainScores, weights, DRAWS);
+      const payload = {
+        p05: interval.p05,
+        p95: interval.p95,
+        draws: DRAWS,
+        computedAt: new Date().toISOString(),
+      };
+      commands.push(['SET', `${INTERVAL_KEY_PREFIX}${countryCodes[i]}`, JSON.stringify(payload), 'EX', INTERVAL_TTL_SECONDS]);
+    } catch { /* skip malformed */ }
+  }
+
+  if (commands.length === 0) {
+    console.log('[resilience-scores] No domain data available for intervals');
+    return 0;
+  }
+
+  const PIPE_BATCH = 50;
+  for (let i = 0; i < commands.length; i += PIPE_BATCH) {
+    await redisPipeline(url, token, commands.slice(i, i + PIPE_BATCH));
+  }
+  console.log(`[resilience-scores] Wrote ${commands.length} interval keys`);
+
+  await writeFreshnessMetadata('resilience', 'intervals', commands.length, '', INTERVAL_TTL_SECONDS);
+  return commands.length;
 }
 
 async function seedResilienceScores() {
@@ -133,10 +212,13 @@ async function seedResilienceScores() {
     const finalResults = await redisPipeline(url, token, getCommands);
     const finalWarmed = countCachedFromPipeline(finalResults);
     console.log(`[resilience-scores] Final: ${finalWarmed}/${countryCodes.length} cached`);
-    return { skipped: false, recordCount: finalWarmed, total: countryCodes.length };
+
+    const intervalsWritten = await computeAndWriteIntervals(url, token, countryCodes, finalResults);
+    return { skipped: false, recordCount: finalWarmed, total: countryCodes.length, intervalsWritten };
   }
 
-  return { skipped: false, recordCount: preWarmed, total: countryCodes.length };
+  const intervalsWritten = await computeAndWriteIntervals(url, token, countryCodes, preResults);
+  return { skipped: false, recordCount: preWarmed, total: countryCodes.length, intervalsWritten };
 }
 
 async function main() {
@@ -146,6 +228,7 @@ async function main() {
     skipped: Boolean(result.skipped),
     ...(result.total != null && { total: result.total }),
     ...(result.reason != null && { reason: result.reason }),
+    ...(result.intervalsWritten != null && { intervalsWritten: result.intervalsWritten }),
   });
 }
 

--- a/tests/resilience-scores-seed.test.mjs
+++ b/tests/resilience-scores-seed.test.mjs
@@ -6,6 +6,7 @@ import {
   RESILIENCE_RANKING_CACHE_TTL_SECONDS,
   RESILIENCE_SCORE_CACHE_PREFIX,
   RESILIENCE_STATIC_INDEX_KEY,
+  computeIntervals,
 } from '../scripts/seed-resilience-scores.mjs';
 
 describe('exported constants', () => {
@@ -50,6 +51,42 @@ describe('seed script does not export tsx/esm helpers', () => {
   it('buildRankingPayload is not exported (ranking write removed)', async () => {
     const mod = await import('../scripts/seed-resilience-scores.mjs');
     assert.equal(typeof mod.buildRankingPayload, 'undefined');
+  });
+});
+
+describe('computeIntervals', () => {
+  it('returns p05 <= p95', () => {
+    const domainScores = [65, 70, 55, 80, 60];
+    const weights = [0.22, 0.20, 0.15, 0.25, 0.18];
+    const result = computeIntervals(domainScores, weights, 200);
+    assert.ok(result.p05 <= result.p95, `p05 (${result.p05}) should be <= p95 (${result.p95})`);
+  });
+
+  it('returns values within the domain score range', () => {
+    const domainScores = [40, 60, 50, 70, 55];
+    const weights = [0.22, 0.20, 0.15, 0.25, 0.18];
+    const result = computeIntervals(domainScores, weights, 200);
+    assert.ok(result.p05 >= 30, `p05 (${result.p05}) should be >= 30`);
+    assert.ok(result.p95 <= 80, `p95 (${result.p95}) should be <= 80`);
+  });
+
+  it('returns identical p05/p95 for uniform domain scores', () => {
+    const domainScores = [50, 50, 50, 50, 50];
+    const weights = [0.22, 0.20, 0.15, 0.25, 0.18];
+    const result = computeIntervals(domainScores, weights, 100);
+    assert.equal(result.p05, 50);
+    assert.equal(result.p95, 50);
+  });
+
+  it('produces wider interval for more diverse domain scores', () => {
+    const uniform = [50, 50, 50, 50, 50];
+    const diverse = [20, 90, 30, 80, 40];
+    const weights = [0.22, 0.20, 0.15, 0.25, 0.18];
+    const uResult = computeIntervals(uniform, weights, 500);
+    const dResult = computeIntervals(diverse, weights, 500);
+    const uWidth = uResult.p95 - uResult.p05;
+    const dWidth = dResult.p95 - dResult.p05;
+    assert.ok(dWidth > uWidth, `Diverse width (${dWidth}) should be > uniform width (${uWidth})`);
   });
 });
 


### PR DESCRIPTION
## Summary
- Merges Monte Carlo confidence interval computation from `seed-resilience-intervals.mjs` into `seed-resilience-scores.mjs`
- After warming scores and reading cached domain data, computes p05/p95 per country and writes `resilience:intervals:v1:{ISO2}` keys to Redis
- Writes `seed-meta:resilience:intervals` for health monitoring via `writeFreshnessMetadata`
- Eliminates the need for a separate Railway cron service (avoids 100-service limit)

## Changes
- `scripts/seed-resilience-scores.mjs`: Added `computeIntervals()`, domain weight constants, and `computeAndWriteIntervals()` helper that runs after final cache read on both code paths (post-warmup and pre-warmed)
- `tests/resilience-scores-seed.test.mjs`: Added 4 tests for `computeIntervals` (p05<=p95, value range, uniform scores, diverse vs uniform width)

## Test plan
- [x] All 15 existing + new tests pass (`node --test tests/resilience-scores-seed.test.mjs`)
- [x] Biome lint clean
- [x] Pre-push hook passes (typecheck, boundary check, full test suite)
- [ ] Verify interval keys appear in Redis after next scores cron run
- [ ] Confirm `seed-meta:resilience:intervals` freshness in health check