### PR TITLE
feat(notifications): per-event AI impact analysis (Phase 2)

### DIFF
--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -501,8 +501,9 @@ async function generateEventImpact(event, rule) {
   const ctx = extractUserContext(prefs);
   if (ctx.tickers.length === 0 && ctx.airports.length === 0 && !ctx.frameworkName) return null;
 
+  const variant = rule.variant ?? 'full';
   const eventHash = sha256Hex(`${event.eventType}:${event.payload?.title ?? ''}`);
-  const ctxHash = sha256Hex(JSON.stringify(ctx)).slice(0, 16);
+  const ctxHash = sha256Hex(JSON.stringify({ ...ctx, variant })).slice(0, 16);
   const cacheKey = `impact:ai:v1:${eventHash.slice(0, 16)}:${ctxHash}`;
 
   try {
@@ -510,18 +511,29 @@ async function generateEventImpact(event, rule) {
     if (cached) return cached;
   } catch { /* miss */ }
 
-  const profile = formatUserProfile(ctx, rule.variant ?? 'full');
+  const profile = formatUserProfile(ctx, variant);
+  const safeTitle = String(event.payload?.title ?? event.eventType).replace(/[\r\n]/g, ' ').slice(0, 300);
+  const safeSource = event.payload?.source ? String(event.payload.source).replace(/[\r\n]/g, ' ').slice(0, 100) : '';
   const systemPrompt = `Assess how this event impacts a specific investor/analyst.
 Return 1-2 sentences: (1) direct impact on their assets/regions, (2) action implication.
 If no clear impact: "Low direct impact on your portfolio."
 Be specific about tickers and regions. No preamble.`;
 
-  const userPrompt = `Event: [${(event.severity ?? 'high').toUpperCase()}] ${event.payload?.title ?? event.eventType}
-${event.payload?.source ? `Source: ${event.payload.source}` : ''}
+  const userPrompt = `Event: [${(event.severity ?? 'high').toUpperCase()}] ${safeTitle}
+${safeSource ? `Source: ${safeSource}` : ''}
 
 ${profile}`;
 
-  const impact = await callLLM(systemPrompt, userPrompt, { maxTokens: 200, temperature: 0.2, timeoutMs: 8000 });
+  let impact;
+  try {
+    impact = await Promise.race([
+      callLLM(systemPrompt, userPrompt, { maxTokens: 200, temperature: 0.2, timeoutMs: 8000 }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('global timeout')), 10000)),
+    ]);
+  } catch {
+    console.warn(`[relay] AI impact global timeout for ${rule.userId}`);
+    return null;
+  }
   if (!impact) return null;
 
   try {

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -5,6 +5,8 @@ const dns = require('node:dns').promises;
 const { ConvexHttpClient } = require('convex/browser');
 const { Resend } = require('resend');
 const { decrypt } = require('./lib/crypto.cjs');
+const { callLLM } = require('./lib/llm-chain.cjs');
+const { fetchUserPreferences, extractUserContext, formatUserProfile } = require('./lib/user-context.cjs');
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -20,6 +22,8 @@ const RESEND_FROM = process.env.RESEND_FROM_EMAIL ?? 'WorldMonitor <alerts@world
 // When QUIET_HOURS_BATCH_ENABLED=0, treat batch_on_wake as critical_only.
 // Useful during relay rollout to disable queued batching before drainBatchOnWake is fully tested.
 const QUIET_HOURS_BATCH_ENABLED = process.env.QUIET_HOURS_BATCH_ENABLED !== '0';
+const AI_IMPACT_ENABLED = process.env.AI_IMPACT_ENABLED === '1';
+const AI_IMPACT_CACHE_TTL = 1800; // 30 min, matches dedup window
 
 if (!UPSTASH_URL || !UPSTASH_TOKEN) { console.error('[relay] UPSTASH_REDIS_REST_URL/TOKEN not set'); process.exit(1); }
 if (!CONVEX_URL) { console.error('[relay] CONVEX_URL not set'); process.exit(1); }
@@ -486,6 +490,48 @@ async function shadowLogScore(event) {
   } catch {}
 }
 
+// ── AI impact analysis ───────────────────────────────────────────────────────
+
+async function generateEventImpact(event, rule) {
+  if (!AI_IMPACT_ENABLED) return null;
+
+  const prefs = await fetchUserPreferences(rule.userId, rule.variant ?? 'full');
+  if (!prefs) return null;
+
+  const ctx = extractUserContext(prefs);
+  if (ctx.tickers.length === 0 && ctx.airports.length === 0 && !ctx.frameworkName) return null;
+
+  const eventHash = sha256Hex(`${event.eventType}:${event.payload?.title ?? ''}`);
+  const ctxHash = sha256Hex(JSON.stringify(ctx)).slice(0, 16);
+  const cacheKey = `impact:ai:v1:${eventHash.slice(0, 16)}:${ctxHash}`;
+
+  try {
+    const cached = await upstashRest('GET', cacheKey);
+    if (cached) return cached;
+  } catch { /* miss */ }
+
+  const profile = formatUserProfile(ctx, rule.variant ?? 'full');
+  const systemPrompt = `Assess how this event impacts a specific investor/analyst.
+Return 1-2 sentences: (1) direct impact on their assets/regions, (2) action implication.
+If no clear impact: "Low direct impact on your portfolio."
+Be specific about tickers and regions. No preamble.`;
+
+  const userPrompt = `Event: [${(event.severity ?? 'high').toUpperCase()}] ${event.payload?.title ?? event.eventType}
+${event.payload?.source ? `Source: ${event.payload.source}` : ''}
+
+${profile}`;
+
+  const impact = await callLLM(systemPrompt, userPrompt, { maxTokens: 200, temperature: 0.2, timeoutMs: 8000 });
+  if (!impact) return null;
+
+  try {
+    await upstashRest('SET', cacheKey, impact, 'EX', String(AI_IMPACT_CACHE_TTL));
+  } catch { /* best-effort */ }
+
+  console.log(`[relay] AI impact generated for ${rule.userId} (${impact.length} chars)`);
+  return impact;
+}
+
 async function processEvent(event) {
   if (event.eventType === 'channel_welcome') { await processWelcome(event); return; }
   if (event.eventType === 'flush_quiet_held') { await processFlushQuietHeld(event); return; }
@@ -567,17 +613,24 @@ async function processEvent(event) {
     }
 
     const verifiedChannels = channels.filter(c => c.verified && rule.channels.includes(c.channelType));
+    if (verifiedChannels.length === 0) continue;
+
+    let deliveryText = text;
+    if (AI_IMPACT_ENABLED) {
+      const impact = await generateEventImpact(event, rule);
+      if (impact) deliveryText = `${text}\n\n— Impact —\n${impact}`;
+    }
 
     for (const ch of verifiedChannels) {
       try {
         if (ch.channelType === 'telegram' && ch.chatId) {
-          await sendTelegram(rule.userId, ch.chatId, text);
+          await sendTelegram(rule.userId, ch.chatId, deliveryText);
         } else if (ch.channelType === 'slack' && ch.webhookEnvelope) {
-          await sendSlack(rule.userId, ch.webhookEnvelope, text);
+          await sendSlack(rule.userId, ch.webhookEnvelope, deliveryText);
         } else if (ch.channelType === 'discord' && ch.webhookEnvelope) {
-          await sendDiscord(rule.userId, ch.webhookEnvelope, text);
+          await sendDiscord(rule.userId, ch.webhookEnvelope, deliveryText);
         } else if (ch.channelType === 'email' && ch.email) {
-          await sendEmail(ch.email, subject, text);
+          await sendEmail(ch.email, subject, deliveryText);
         }
       } catch (err) {
         console.warn(`[relay] Delivery error for ${rule.userId}/${ch.channelType}:`, err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Summary

- Real-time events now include a personalized 1-2 sentence impact assessment before delivery
- Uses user's watchlist, airports, and analysis framework to project how the event affects them
- Reuses Phase 1 shared infrastructure (`llm-chain.cjs`, `user-context.cjs`, `/relay/user-preferences`)
- Feature-flagged: `AI_IMPACT_ENABLED=0` (default off), set to `1` to enable
- 8s hard timeout on Groq LLM call, never blocks delivery
- Cached per event+userContext hash (30 min TTL, matches dedup window)
- Skips LLM when user has no meaningful preferences or no verified channels

## Example output

```
[HIGH] Iran expands sanctions on oil exports
Source: Reuters
https://reuters.com/...

— Impact —
Your energy holdings (XLE, BP) face supply disruption risk as Iran sanctions
tighten crude export capacity. Consider reviewing exposure to Middle East-linked
commodity positions.
```

## Test plan

- [ ] Default off: verify `AI_IMPACT_ENABLED` unset, events delivered without impact section
- [ ] Enable: set `AI_IMPACT_ENABLED=1`, verify impact text appended to delivered messages
- [ ] No prefs: user without saved preferences, verify no LLM call (plain event delivered)
- [ ] No channels: user with no verified channels, verify no LLM call
- [ ] Timeout: Groq unreachable, verify event delivered without impact (no delay beyond 8s)
- [ ] Cache: same event to user with same prefs, verify cache hit on second delivery
- [ ] CJS syntax + typecheck + edge function tests + data tests: all pass

## Post-Deploy Monitoring & Validation

- **Logs**: `[relay] AI impact generated for <userId>` (success), `[llm-chain] all providers failed` (LLM failure)
- **Redis**: `impact:ai:v1:*` keys with 1800s TTL
- **Expected**: impact generated only for users with tickers/airports/framework in prefs
- **Failure signal**: relay poll loop slowing down (LLM adding >8s latency consistently)
- **Rollback**: set `AI_IMPACT_ENABLED=0`, no redeploy needed (relay reads env on each event)