### PR TITLE
feat(notifications): generic webhook channel (Phase 3)

### DIFF
--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -203,6 +203,21 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
       if (action === 'set-channel') {
         const { channelType, email, webhookEnvelope, webhookLabel } = body;
         if (!channelType) return json({ error: 'channelType required' }, 400, corsHeaders);
+
+        if (channelType === 'webhook' && webhookEnvelope) {
+          try {
+            const parsed = new URL(webhookEnvelope);
+            if (parsed.protocol !== 'https:') {
+              return json({ error: 'Webhook URL must use HTTPS' }, 400, corsHeaders);
+            }
+            if (/^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|::1|0\.0\.0\.0)/.test(parsed.hostname)) {
+              return json({ error: 'Webhook URL must not point to a private/local address' }, 400, corsHeaders);
+            }
+          } catch {
+            return json({ error: 'Invalid webhook URL' }, 400, corsHeaders);
+          }
+        }
+
         const relayBody: Record<string, unknown> = { action: 'set-channel', userId: session.userId, channelType };
         if (email !== undefined) relayBody.email = email;
         if (webhookLabel !== undefined) relayBody.webhookLabel = String(webhookLabel).slice(0, 100);

--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -110,6 +110,7 @@ interface PostBody {
   channelType?: string;
   email?: string;
   webhookEnvelope?: string;
+  webhookLabel?: string;
   variant?: string;
   enabled?: boolean;
   eventTypes?: string[];
@@ -200,10 +201,11 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
       }
 
       if (action === 'set-channel') {
-        const { channelType, email, webhookEnvelope } = body;
+        const { channelType, email, webhookEnvelope, webhookLabel } = body;
         if (!channelType) return json({ error: 'channelType required' }, 400, corsHeaders);
         const relayBody: Record<string, unknown> = { action: 'set-channel', userId: session.userId, channelType };
         if (email !== undefined) relayBody.email = email;
+        if (webhookLabel !== undefined) relayBody.webhookLabel = String(webhookLabel).slice(0, 100);
         if (webhookEnvelope !== undefined) {
           try {
             relayBody.webhookEnvelope = await encryptSlackWebhook(webhookEnvelope);

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -5,6 +5,7 @@ export const channelTypeValidator = v.union(
   v.literal("slack"),
   v.literal("email"),
   v.literal("discord"),
+  v.literal("webhook"),
 );
 
 export const sensitivityValidator = v.union(

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -355,6 +355,7 @@ http.route({
       channelType?: string;
       chatId?: string;
       webhookEnvelope?: string;
+      webhookLabel?: string;
       email?: string;
       variant?: string;
       enabled?: boolean;
@@ -419,10 +420,11 @@ http.route({
         }
         const setResult = await ctx.runMutation((internal as any).notificationChannels.setChannelForUser, {
           userId,
-          channelType: body.channelType as "telegram" | "slack" | "email",
+          channelType: body.channelType as "telegram" | "slack" | "email" | "webhook",
           chatId: body.chatId,
           webhookEnvelope: body.webhookEnvelope,
           email: body.email,
+          webhookLabel: body.webhookLabel,
         });
         return new Response(JSON.stringify({ ok: true, isNew: setResult.isNew }), { status: 200, headers: { "Content-Type": "application/json" } });
       }

--- a/convex/notificationChannels.ts
+++ b/convex/notificationChannels.ts
@@ -19,9 +19,10 @@ export const setChannelForUser = internalMutation({
     chatId: v.optional(v.string()),
     webhookEnvelope: v.optional(v.string()),
     email: v.optional(v.string()),
+    webhookLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const { userId, channelType, chatId, webhookEnvelope, email } = args;
+    const { userId, channelType, chatId, webhookEnvelope, email, webhookLabel } = args;
     const existing = await ctx.db
       .query("notificationChannels")
       .withIndex("by_user_channel", (q) =>
@@ -44,7 +45,7 @@ export const setChannelForUser = internalMutation({
       if (existing) { await ctx.db.replace(existing._id, doc); } else { await ctx.db.insert("notificationChannels", doc); }
     } else if (channelType === "webhook") {
       if (!webhookEnvelope) throw new ConvexError("webhookEnvelope required for webhook channel");
-      const doc = { userId, channelType: "webhook" as const, webhookEnvelope, verified: true, linkedAt: now };
+      const doc = { userId, channelType: "webhook" as const, webhookEnvelope, verified: true, linkedAt: now, webhookLabel };
       if (existing) { await ctx.db.replace(existing._id, doc); } else { await ctx.db.insert("notificationChannels", doc); }
     } else {
       throw new ConvexError("discord channel must be set via set-discord-oauth");

--- a/convex/notificationChannels.ts
+++ b/convex/notificationChannels.ts
@@ -187,6 +187,7 @@ export const setChannel = mutation({
     chatId: v.optional(v.string()),
     webhookEnvelope: v.optional(v.string()),
     email: v.optional(v.string()),
+    webhookLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
@@ -228,7 +229,7 @@ export const setChannel = mutation({
       }
     } else if (args.channelType === "webhook") {
       if (!args.webhookEnvelope) throw new ConvexError("webhookEnvelope required for webhook channel");
-      const doc = { userId, channelType: "webhook" as const, webhookEnvelope: args.webhookEnvelope, verified: true, linkedAt: now };
+      const doc = { userId, channelType: "webhook" as const, webhookEnvelope: args.webhookEnvelope, verified: true, linkedAt: now, webhookLabel: args.webhookLabel };
       if (existing) {
         await ctx.db.replace(existing._id, doc);
       } else {

--- a/convex/notificationChannels.ts
+++ b/convex/notificationChannels.ts
@@ -42,6 +42,10 @@ export const setChannelForUser = internalMutation({
       if (!email) throw new ConvexError("email required for email channel");
       const doc = { userId, channelType: "email" as const, email, verified: true, linkedAt: now };
       if (existing) { await ctx.db.replace(existing._id, doc); } else { await ctx.db.insert("notificationChannels", doc); }
+    } else if (channelType === "webhook") {
+      if (!webhookEnvelope) throw new ConvexError("webhookEnvelope required for webhook channel");
+      const doc = { userId, channelType: "webhook" as const, webhookEnvelope, verified: true, linkedAt: now };
+      if (existing) { await ctx.db.replace(existing._id, doc); } else { await ctx.db.insert("notificationChannels", doc); }
     } else {
       throw new ConvexError("discord channel must be set via set-discord-oauth");
     }
@@ -216,6 +220,14 @@ export const setChannel = mutation({
     } else if (args.channelType === "email") {
       if (!args.email) throw new ConvexError("email required for email channel");
       const doc = { userId, channelType: "email" as const, email: args.email, verified: true, linkedAt: now };
+      if (existing) {
+        await ctx.db.replace(existing._id, doc);
+      } else {
+        await ctx.db.insert("notificationChannels", doc);
+      }
+    } else if (args.channelType === "webhook") {
+      if (!args.webhookEnvelope) throw new ConvexError("webhookEnvelope required for webhook channel");
+      const doc = { userId, channelType: "webhook" as const, webhookEnvelope: args.webhookEnvelope, verified: true, linkedAt: now };
       if (existing) {
         await ctx.db.replace(existing._id, doc);
       } else {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -65,6 +65,15 @@ export default defineSchema({
         discordGuildId: v.optional(v.string()),
         discordChannelId: v.optional(v.string()),
       }),
+      v.object({
+        userId: v.string(),
+        channelType: v.literal("webhook"),
+        webhookEnvelope: v.string(),
+        verified: v.boolean(),
+        linkedAt: v.number(),
+        webhookLabel: v.optional(v.string()),
+        webhookSecret: v.optional(v.string()),
+      }),
     ),
   )
     .index("by_user", ["userId"])

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -178,7 +178,15 @@ async function drainHeldForUser(userId, variant, allowedChannelTypes) {
       else if (ch.channelType === 'slack' && ch.webhookEnvelope) ok = await sendSlack(userId, ch.webhookEnvelope, text);
       else if (ch.channelType === 'discord' && ch.webhookEnvelope) ok = await sendDiscord(userId, ch.webhookEnvelope, text);
       else if (ch.channelType === 'email' && ch.email) ok = await sendEmail(ch.email, subject, text);
-      else if (ch.channelType === 'webhook' && ch.webhookEnvelope) ok = await sendWebhook(userId, ch.webhookEnvelope, { eventType: 'digest_batch', severity: 'info', payload: { title: subject } });
+      else if (ch.channelType === 'webhook' && ch.webhookEnvelope) ok = await sendWebhook(userId, ch.webhookEnvelope, {
+        eventType: 'quiet_hours_batch',
+        severity: 'info',
+        payload: {
+          title: subject,
+          alertCount: events.length,
+          alerts: events.map(ev => ({ eventType: ev.eventType, severity: ev.severity ?? 'high', title: ev.payload?.title ?? ev.eventType })),
+        },
+      });
       if (ok) anyDelivered = true;
     } catch (err) {
       console.warn(`[relay] drainHeldForUser: delivery error for ${userId}/${ch.channelType}:`, err.message);

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -178,6 +178,7 @@ async function drainHeldForUser(userId, variant, allowedChannelTypes) {
       else if (ch.channelType === 'slack' && ch.webhookEnvelope) ok = await sendSlack(userId, ch.webhookEnvelope, text);
       else if (ch.channelType === 'discord' && ch.webhookEnvelope) ok = await sendDiscord(userId, ch.webhookEnvelope, text);
       else if (ch.channelType === 'email' && ch.email) ok = await sendEmail(ch.email, subject, text);
+      else if (ch.channelType === 'webhook' && ch.webhookEnvelope) ok = await sendWebhook(userId, ch.webhookEnvelope, { eventType: 'digest_batch', severity: 'info', payload: { title: subject } });
       if (ok) anyDelivered = true;
     } catch (err) {
       console.warn(`[relay] drainHeldForUser: delivery error for ${userId}/${ch.channelType}:`, err.message);
@@ -397,6 +398,72 @@ async function sendEmail(email, subject, text) {
   }
 }
 
+async function sendWebhook(userId, webhookEnvelope, event) {
+  let url;
+  try {
+    url = decrypt(webhookEnvelope);
+  } catch (err) {
+    console.warn(`[relay] Webhook decrypt failed for ${userId}:`, err.message);
+    return false;
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    console.warn(`[relay] Webhook invalid URL for ${userId}`);
+    await deactivateChannel(userId, 'webhook');
+    return false;
+  }
+
+  if (parsed.protocol !== 'https:') {
+    console.warn(`[relay] Webhook rejected non-HTTPS for ${userId}`);
+    return false;
+  }
+
+  try {
+    const addrs = await dns.resolve4(parsed.hostname);
+    if (addrs.some(isPrivateIP)) {
+      console.warn(`[relay] Webhook SSRF blocked (private IP) for ${userId}`);
+      return false;
+    }
+  } catch (err) {
+    console.warn(`[relay] Webhook DNS resolve failed for ${userId}:`, err.message);
+    return false;
+  }
+
+  const payload = JSON.stringify({
+    version: '1',
+    eventType: event.eventType,
+    severity: event.severity ?? 'high',
+    timestamp: event.publishedAt ?? Date.now(),
+    payload: event.payload ?? {},
+    variant: event.variant ?? null,
+  });
+
+  try {
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-relay/1.0' },
+      body: payload,
+      signal: AbortSignal.timeout(10000),
+    });
+    if (resp.status === 404 || resp.status === 410 || resp.status === 403) {
+      console.warn(`[relay] Webhook ${resp.status} for ${userId} — deactivating`);
+      await deactivateChannel(userId, 'webhook');
+      return false;
+    }
+    if (!resp.ok) {
+      console.warn(`[relay] Webhook delivery failed for ${userId}: HTTP ${resp.status}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.warn(`[relay] Webhook delivery error for ${userId}:`, err.message);
+    return false;
+  }
+}
+
 // ── Event processing ──────────────────────────────────────────────────────────
 
 function matchesSensitivity(ruleSensitivity, eventSeverity) {
@@ -578,6 +645,8 @@ async function processEvent(event) {
           await sendDiscord(rule.userId, ch.webhookEnvelope, text);
         } else if (ch.channelType === 'email' && ch.email) {
           await sendEmail(ch.email, subject, text);
+        } else if (ch.channelType === 'webhook' && ch.webhookEnvelope) {
+          await sendWebhook(rule.userId, ch.webhookEnvelope, event);
         }
       } catch (err) {
         console.warn(`[relay] Delivery error for ${rule.userId}/${ch.channelType}:`, err instanceof Error ? err.message : String(err));

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -650,9 +650,12 @@ async function sendWebhook(userId, webhookEnvelope, stories, aiSummary) {
     return false;
   }
   try {
-    const addrs = await dns.resolve4(parsed.hostname).catch(() => []);
+    const addrs = await dns.resolve4(parsed.hostname);
     if (addrs.some(isPrivateIP)) { console.warn(`[digest] Webhook SSRF blocked for ${userId}`); return false; }
-  } catch { return false; }
+  } catch {
+    console.warn(`[digest] Webhook DNS resolve failed for ${userId}`);
+    return false;
+  }
   const payload = JSON.stringify({
     version: '1',
     eventType: 'digest',

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -633,6 +633,54 @@ async function sendEmail(email, subject, text, html) {
   }
 }
 
+async function sendWebhook(userId, webhookEnvelope, stories, aiSummary) {
+  let url;
+  try { url = decrypt(webhookEnvelope); } catch (err) {
+    console.warn(`[digest] Webhook decrypt failed for ${userId}:`, err.message);
+    return false;
+  }
+  let parsed;
+  try { parsed = new URL(url); } catch {
+    console.warn(`[digest] Webhook invalid URL for ${userId}`);
+    await deactivateChannel(userId, 'webhook');
+    return false;
+  }
+  if (parsed.protocol !== 'https:') {
+    console.warn(`[digest] Webhook rejected non-HTTPS for ${userId}`);
+    return false;
+  }
+  try {
+    const addrs = await dns.resolve4(parsed.hostname).catch(() => []);
+    if (addrs.some(isPrivateIP)) { console.warn(`[digest] Webhook SSRF blocked for ${userId}`); return false; }
+  } catch { return false; }
+  const payload = JSON.stringify({
+    version: '1',
+    eventType: 'digest',
+    stories: stories.map(s => ({ title: s.title, severity: s.severity, phase: s.phase, sources: s.sources })),
+    summary: aiSummary ?? null,
+    storyCount: stories.length,
+  });
+  try {
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-digest/1.0' },
+      body: payload,
+      signal: AbortSignal.timeout(10000),
+    });
+    if (resp.status === 404 || resp.status === 410 || resp.status === 403) {
+      console.warn(`[digest] Webhook ${resp.status} for ${userId} — deactivating`);
+      await deactivateChannel(userId, 'webhook');
+      return false;
+    }
+    if (!resp.ok) { console.warn(`[digest] Webhook ${resp.status} for ${userId}`); return false; }
+    console.log(`[digest] Webhook delivered for ${userId}`);
+    return true;
+  } catch (err) {
+    console.warn(`[digest] Webhook error for ${userId}:`, err.message);
+    return false;
+  }
+}
+
 // ── Main ──────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -750,6 +798,8 @@ async function main() {
         ok = await sendDiscord(rule.userId, ch.webhookEnvelope, text);
       } else if (ch.channelType === 'email' && ch.email) {
         ok = await sendEmail(ch.email, subject, text, html);
+      } else if (ch.channelType === 'webhook' && ch.webhookEnvelope) {
+        ok = await sendWebhook(rule.userId, ch.webhookEnvelope, stories, aiSummary);
       }
       if (ok) anyDelivered = true;
     }

--- a/src/services/notification-channels.ts
+++ b/src/services/notification-channels.ts
@@ -1,7 +1,7 @@
 import { getClerkToken } from '@/services/clerk';
 import { SITE_VARIANT } from '@/config/variant';
 
-export type ChannelType = 'telegram' | 'slack' | 'email' | 'discord';
+export type ChannelType = 'telegram' | 'slack' | 'email' | 'discord' | 'webhook';
 export type Sensitivity = 'all' | 'high' | 'critical';
 export type QuietHoursOverride = 'critical_only' | 'silence_all' | 'batch_on_wake';
 export type DigestMode = 'realtime' | 'daily' | 'twice_daily' | 'weekly';
@@ -15,6 +15,7 @@ export interface NotificationChannel {
   slackChannelName?: string;
   slackTeamName?: string;
   slackConfigurationUrl?: string;
+  webhookLabel?: string;
 }
 
 export interface AlertRule {
@@ -88,6 +89,15 @@ export async function setSlackChannel(webhookEnvelope: string): Promise<void> {
     body: JSON.stringify({ action: 'set-channel', channelType: 'slack', webhookEnvelope }),
   });
   if (!res.ok) throw new Error(`set slack channel: ${res.status}`);
+}
+
+export async function setWebhookChannel(webhookUrl: string, label?: string): Promise<void> {
+  const res = await authFetch('/api/notification-channels', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action: 'set-channel', channelType: 'webhook', webhookEnvelope: webhookUrl, webhookLabel: label }),
+  });
+  if (!res.ok) throw new Error(`set webhook channel: ${res.status}`);
 }
 
 export async function startSlackOAuth(): Promise<string> {

--- a/src/services/preferences-content.ts
+++ b/src/services/preferences-content.ts
@@ -656,7 +656,7 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
           return `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zm10.122 2.521a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zm-1.268 0a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zm-2.523 10.122a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zm0-1.268a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/></svg>`;
         }
 
-        const CHANNEL_LABELS: Record<ChannelType, string> = { telegram: 'Telegram', email: 'Email', slack: 'Slack', discord: 'Discord' };
+        const CHANNEL_LABELS: Record<ChannelType, string> = { telegram: 'Telegram', email: 'Email', slack: 'Slack', discord: 'Discord', webhook: 'Webhook' };
 
         function renderChannelRow(channel: NotificationChannel | null, type: ChannelType): string {
           const icon = channelIcon(type);

--- a/src/services/preferences-content.ts
+++ b/src/services/preferences-content.ts
@@ -14,6 +14,7 @@ import {
   getChannelsData,
   createPairingToken,
   setEmailChannel,
+  setWebhookChannel,
   startSlackOAuth,
   startDiscordOAuth,
   deleteChannel,
@@ -652,6 +653,7 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
         function channelIcon(type: ChannelType): string {
           if (type === 'telegram') return `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>`;
           if (type === 'email') return `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>`;
+          if (type === 'webhook') return `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>`;
           if (type === 'discord') return `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>`;
           return `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zm10.122 2.521a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zm-1.268 0a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zm-2.523 10.122a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zm0-1.268a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/></svg>`;
         }
@@ -671,6 +673,8 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
               sub = escapeHtml(channel.email ?? 'connected');
             } else if (type === 'discord') {
               sub = 'Connected';
+            } else if (type === 'webhook') {
+              sub = channel.webhookLabel ? escapeHtml(channel.webhookLabel) : 'Connected';
             } else {
               // Slack: show #channel · team from OAuth metadata
               const rawCh = channel.slackChannelName ?? '';
@@ -753,13 +757,26 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
             </div>`;
           }
 
+          if (type === 'webhook') {
+            return `<div class="us-notif-ch-row" data-channel-type="webhook">
+              <div class="us-notif-ch-icon">${icon}</div>
+              <div class="us-notif-ch-body">
+                <div class="us-notif-ch-name">${name}</div>
+                <div class="us-notif-ch-sub">Send structured JSON to any HTTPS endpoint</div>
+              </div>
+              <div class="us-notif-ch-actions">
+                <button type="button" class="us-notif-ch-btn us-notif-ch-btn-primary" id="usConnectWebhook">Add URL</button>
+              </div>
+            </div>`;
+          }
+
           return '';
         }
 
         const detectedTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
         function renderNotifContent(data: Awaited<ReturnType<typeof getChannelsData>>): string {
-          const channelTypes: ChannelType[] = ['telegram', 'email', 'slack', 'discord'];
+          const channelTypes: ChannelType[] = ['telegram', 'email', 'slack', 'discord', 'webhook'];
           const alertRule = data.alertRules?.[0] ?? null;
           const sensitivity = alertRule?.sensitivity ?? 'all';
 
@@ -1248,6 +1265,44 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
             }).catch(() => {
               if (btn && !signal.aborted) btn.textContent = 'Connect Discord';
             });
+            return;
+          }
+
+          if (target.closest('#usConnectWebhook')) {
+            const rowEl = target.closest<HTMLElement>('[data-channel-type="webhook"]');
+            if (!rowEl) return;
+            rowEl.querySelector('.us-notif-ch-actions')!.innerHTML = `
+              <div style="display:flex;flex-direction:column;gap:6px;width:100%">
+                <input type="url" id="usWebhookUrl" placeholder="https://hooks.example.com/..." class="unified-settings-input" style="font-size:12px;width:100%">
+                <input type="text" id="usWebhookLabel" placeholder="Label (optional)" class="unified-settings-input" style="font-size:12px;width:100%">
+                <div style="display:flex;gap:6px">
+                  <button type="button" class="us-notif-ch-btn us-notif-ch-btn-primary" id="usWebhookSave">Save</button>
+                  <button type="button" class="us-notif-ch-btn" id="usWebhookCancel">Cancel</button>
+                </div>
+              </div>`;
+            const urlInput = rowEl.querySelector<HTMLInputElement>('#usWebhookUrl');
+            urlInput?.focus();
+            return;
+          }
+          if (target.closest('#usWebhookSave')) {
+            const urlInput = container.querySelector<HTMLInputElement>('#usWebhookUrl');
+            const labelInput = container.querySelector<HTMLInputElement>('#usWebhookLabel');
+            const url = urlInput?.value?.trim() ?? '';
+            if (!url || !url.startsWith('https://')) {
+              urlInput?.classList.add('us-notif-input-error');
+              return;
+            }
+            const saveBtn = target.closest<HTMLButtonElement>('#usWebhookSave');
+            if (saveBtn) saveBtn.textContent = 'Saving...';
+            setWebhookChannel(url, labelInput?.value?.trim() || undefined).then(() => {
+              if (!signal.aborted) { saveRuleWithNewChannel('webhook'); reloadNotifSection(); }
+            }).catch(() => {
+              if (saveBtn && !signal.aborted) saveBtn.textContent = 'Save';
+            });
+            return;
+          }
+          if (target.closest('#usWebhookCancel')) {
+            reloadNotifSection();
             return;
           }
 


### PR DESCRIPTION
## Summary

- Add `webhook` as a 5th notification channel type
- Users provide an HTTPS URL, WorldMonitor POSTs structured JSON payloads
- Enables Zapier, n8n, IFTTT, and custom pipeline integrations
- SSRF protection: DNS resolve + private IP check + HTTPS-only
- Auto-deactivation on 404/410/403 responses
- Webhook URLs encrypted at rest (AES-256-GCM, same pattern as Slack)
- Both real-time relay and digest cron deliver to webhooks

**Requires Convex deploy** for schema changes.

### Payload format (real-time)
```json
{
  "version": "1",
  "eventType": "rss_alert",
  "severity": "high",
  "timestamp": 1712000000000,
  "payload": { "title": "...", "source": "...", "link": "..." },
  "variant": "full"
}
```

### Payload format (digest)
```json
{
  "version": "1",
  "eventType": "digest",
  "stories": [{ "title": "...", "severity": "high", "phase": "developing", "sources": [...] }],
  "summary": "AI executive summary...",
  "storyCount": 15
}
```

## Test plan

- [ ] Convex deploy succeeds with new schema
- [ ] Set webhook channel via API: POST set-channel with channelType=webhook
- [ ] Verify webhook URL encrypted in Convex
- [ ] Real-time event delivered to webhook endpoint as JSON
- [ ] Digest delivered to webhook endpoint as JSON with stories array
- [ ] SSRF: private IP webhook URL rejected
- [ ] SSRF: HTTP (non-HTTPS) webhook URL rejected
- [ ] 404 response from webhook deactivates channel
- [ ] typecheck + CJS/MJS syntax: pass

## Post-Deploy Monitoring & Validation

- **Logs**: `[relay] Webhook delivered for <userId>` or `[relay] Webhook SSRF blocked`
- **Failure signal**: `[relay] Webhook decrypt failed` (encryption key mismatch)
- **Rollback**: remove webhook channel from user's alert rules in Convex dashboard