### PR TITLE
fix(CII): log-scale HAPI fallback + finer displacement tiers

### DIFF
--- a/src/services/country-instability.ts
+++ b/src/services/country-instability.ts
@@ -873,7 +873,7 @@ function calcConflictScore(data: CountryData, countryCode: string): number {
   let hapiFallback = 0;
   if (events.length === 0 && data.hapiSummary) {
     const h = data.hapiSummary;
-    hapiFallback = Math.min(60, h.eventsPoliticalViolence * 3 * multiplier);
+    hapiFallback = Math.min(60, Math.log1p(h.eventsPoliticalViolence * multiplier) * 12);
   }
 
   let newsFloor = 0;
@@ -1003,8 +1003,12 @@ export function calculateCII(): CountryScore[] {
       : focalUrgency === 'elevated' ? 4
       : 0;
 
-    const displacementBoost = data.displacementOutflow >= 1_000_000 ? 8
+    const displacementBoost = data.displacementOutflow >= 10_000_000 ? 12
+      : data.displacementOutflow >= 5_000_000 ? 10
+      : data.displacementOutflow >= 1_000_000 ? 8
+      : data.displacementOutflow >= 500_000 ? 6
       : data.displacementOutflow >= 100_000 ? 4
+      : data.displacementOutflow >= 10_000 ? 2
       : 0;
     const climateBoost = data.climateStress;
 
@@ -1059,8 +1063,12 @@ export function getCountryScore(code: string): number | null {
   const focalBoost = focalUrgency === 'critical' ? 8
     : focalUrgency === 'elevated' ? 4
     : 0;
-  const displacementBoost = data.displacementOutflow >= 1_000_000 ? 8
+  const displacementBoost = data.displacementOutflow >= 10_000_000 ? 12
+    : data.displacementOutflow >= 5_000_000 ? 10
+    : data.displacementOutflow >= 1_000_000 ? 8
+    : data.displacementOutflow >= 500_000 ? 6
     : data.displacementOutflow >= 100_000 ? 4
+    : data.displacementOutflow >= 10_000 ? 2
     : 0;
   const climateBoost = data.climateStress;
   const advisoryBoost = getAdvisoryBoost(data);

--- a/src/services/country-instability.ts
+++ b/src/services/country-instability.ts
@@ -971,6 +971,16 @@ function getTrend(code: string, current: number): CountryScore['trend'] {
   return 'stable';
 }
 
+function getDisplacementBoost(outflow: number): number {
+  return outflow >= 10_000_000 ? 12
+    : outflow >= 5_000_000 ? 10
+    : outflow >= 1_000_000 ? 8
+    : outflow >= 500_000 ? 6
+    : outflow >= 100_000 ? 4
+    : outflow >= 10_000 ? 2
+    : 0;
+}
+
 export function calculateCII(): CountryScore[] {
   const scores: CountryScore[] = [];
   const focalUrgencies = focalPointDetector.getCountryUrgencyMap();
@@ -1003,13 +1013,7 @@ export function calculateCII(): CountryScore[] {
       : focalUrgency === 'elevated' ? 4
       : 0;
 
-    const displacementBoost = data.displacementOutflow >= 10_000_000 ? 12
-      : data.displacementOutflow >= 5_000_000 ? 10
-      : data.displacementOutflow >= 1_000_000 ? 8
-      : data.displacementOutflow >= 500_000 ? 6
-      : data.displacementOutflow >= 100_000 ? 4
-      : data.displacementOutflow >= 10_000 ? 2
-      : 0;
+    const displacementBoost = getDisplacementBoost(data.displacementOutflow);
     const climateBoost = data.climateStress;
 
     const advisoryBoost = getAdvisoryBoost(data);
@@ -1063,13 +1067,7 @@ export function getCountryScore(code: string): number | null {
   const focalBoost = focalUrgency === 'critical' ? 8
     : focalUrgency === 'elevated' ? 4
     : 0;
-  const displacementBoost = data.displacementOutflow >= 10_000_000 ? 12
-    : data.displacementOutflow >= 5_000_000 ? 10
-    : data.displacementOutflow >= 1_000_000 ? 8
-    : data.displacementOutflow >= 500_000 ? 6
-    : data.displacementOutflow >= 100_000 ? 4
-    : data.displacementOutflow >= 10_000 ? 2
-    : 0;
+  const displacementBoost = getDisplacementBoost(data.displacementOutflow);
   const climateBoost = data.climateStress;
   const advisoryBoost = getAdvisoryBoost(data);
   const supplementalSignalBoost = getSupplementalSignalBoost(data);


### PR DESCRIPTION
## Summary

Fix for issue #2457 — the CII scoring design produces politically skewed results that compress the real-world gap between a heavily-covered geopolitical rival (China) and active conflict states (Iran, Syria).

## Root Causes

**1. HAPI fallback linear cap** — `min(60, events * 3 * multiplier)` flattens enormous severity differences. China (46 events) and Iran (1549 events) both cap at 60.

**2. Displacement boosts too coarse** — only two tiers (+8 for ≥1M, +4 for ≥100K). Syria at 5.6M gets only +4 more than China at 332K.

## Fixes

### 1. Log-scale HAPI fallback

```
// Before (linear, compresses moderate→extreme):
hapiFallback = Math.min(60, h.eventsPoliticalViolence * 3 * multiplier);

// After (log-scale, preserves relative distance):
hapiFallback = Math.min(60, Math.log1p(h.eventsPoliticalViolence * multiplier) * 12);
```

The log scale means moderate and extreme event counts remain distinguishable after capping, preserving meaningful separation between countries at different conflict intensities.

### 2. Finer displacement tiers (6 tiers vs 2)

| Displacement | Old boost | New boost |
|---|---|---|
| ≥10M | — | +12 |
| ≥5M | — | +10 |
| ≥1M | +8 | +8 |
| ≥500K | — | +6 |
| ≥100K | +4 | +4 |
| ≥10K | — | +2 |
| <10K | 0 | 0 |

Syria (5.6M) now gets +10 instead of +8, maintaining meaningful humanitarian distance from countries barely over the 1M threshold.

## Note

Country multipliers and keyword aliases are intentionally left unchanged — those are political/design decisions for maintainers. This fix addresses the algorithmic compression without changing the curated parameters.

Fixes: koala73/worldmonitor#2457