### PR TITLE
fix(seeds): re-add military-bases with 10min timeout

### DIFF
--- a/scripts/seed-bundle-static-ref.mjs
+++ b/scripts/seed-bundle-static-ref.mjs
@@ -4,4 +4,5 @@ import { runBundle, DAY, WEEK } from './_bundle-runner.mjs';
 await runBundle('static-ref', [
   { label: 'Submarine-Cables', script: 'seed-submarine-cables.mjs', seedMetaKey: 'infrastructure:submarine-cables', intervalMs: WEEK, timeoutMs: 300_000 },
   { label: 'Chokepoint-Baselines', script: 'seed-chokepoint-baselines.mjs', seedMetaKey: 'energy:chokepoint-baselines', intervalMs: 400 * DAY, timeoutMs: 60_000 },
+  { label: 'Military-Bases', script: 'seed-military-bases.mjs', seedMetaKey: 'military:bases', intervalMs: 30 * DAY, timeoutMs: 600_000 },
 ]);


### PR DESCRIPTION
## Summary

- Re-adds `military-bases` to the `static-ref` bundle (was removed in #2893)
- Increased timeout from 120s to 600s (10min) to allow processing of 125K records
- The script was timing out at 120s after writing ~70K/125K records

## Test plan

- [ ] Verify static-ref bundle logs show Military-Bases completing successfully