### PR TITLE
fix(sentry): filter inject-key + CSP noise (3 issues resolved)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -335,6 +335,7 @@ Sentry.init({
       || /Invalid or unexpected token/.test(msg)
       || /^Operation timed out/.test(msg)
       || /signal timed out/.test(msg)
+      || /Cannot inject key into script value/.test(msg)
     )) return null;
     return event;
   },


### PR DESCRIPTION
## Summary
- Adds `Cannot inject key into script value` to beforeSend `!hasFirstParty` noise filter
- Resolves 3 Sentry issues as noise (all third-party injections):
  - WORLDMONITOR-M0: Safari extension injection (14 events, 1 user)
  - WORLDMONITOR-KZ: CSP wasm-eval blocked (1 event, browser extension)
  - WORLDMONITOR-KW: CSP searchwidget blocked (1 event, Samsung WebView)

## Test plan
- [x] TypeScript typecheck passes
- [x] All tests pass
- [x] Biome lint passes
- [x] Edge function tests pass
- [x] Issues resolved in Sentry with `inNextRelease: true`