### PR TITLE
fix(notifications): unblock GET /api/notification-channels for PRO users

### DIFF
--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -148,15 +148,6 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
   const session = await validateBearerToken(token);
   if (!session.valid || !session.userId) return json({ error: 'Unauthorized' }, 401, corsHeaders);
 
-  const ent = await getEntitlements(session.userId);
-  if (!ent || ent.features.tier < 1) {
-    return json({
-      error: 'pro_required',
-      message: 'Real-time alerts are available on the Pro plan.',
-      upgradeUrl: 'https://worldmonitor.app/pro',
-    }, 403, corsHeaders);
-  }
-
   if (!CONVEX_SITE_URL || !RELAY_SHARED_SECRET) {
     return json({ error: 'Service unavailable' }, 503, corsHeaders);
   }
@@ -179,6 +170,15 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
   }
 
   if (req.method === 'POST') {
+    const ent = await getEntitlements(session.userId);
+    if (!ent || ent.features.tier < 1) {
+      return json({
+        error: 'pro_required',
+        message: 'Real-time alerts are available on the Pro plan.',
+        upgradeUrl: 'https://worldmonitor.app/pro',
+      }, 403, corsHeaders);
+    }
+
     let body: PostBody;
     try {
       body = (await req.json()) as PostBody;


### PR DESCRIPTION
## Summary

The entitlement check added in PR #2852 blocks GET requests when `getEntitlements()` returns null (fail-closed on Redis miss + Convex fallback failure). This causes 403 for PRO users, making the settings UI show all channels as "Not connected" despite working delivery.

**Fix**: Move entitlement gate to POST-only. GET (reading own channels) requires only auth. POST (creating/modifying) still requires PRO tier.

## Root cause

`getEntitlements()` in `server/_shared/entitlement-check.ts` is fail-closed: Redis cache miss + missing `CONVEX_SERVER_SHARED_SECRET` = null = 403. The GET path was gated alongside POST, so any entitlement lookup failure broke the entire notification settings UI.

## Test plan

- [ ] PRO user: GET `/api/notification-channels` returns 200 with channels
- [ ] PRO user: POST actions still work (set-channel, set-alert-rules, etc.)
- [ ] Free user: POST returns 403 with `pro_required`
- [ ] Free user: GET returns 200 (can see empty state, no channels to show)