### PR TITLE
feat(notifications): PRO entitlement check before delivery

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -596,6 +596,45 @@ http.route({
 });
 
 http.route({
+  path: "/relay/entitlement",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const secret = process.env.RELAY_SHARED_SECRET ?? "";
+    const provided = (request.headers.get("Authorization") ?? "").replace(/^Bearer\s+/, "");
+    if (!secret || !(await timingSafeEqualStrings(provided, secret))) {
+      return new Response(JSON.stringify({ error: "UNAUTHORIZED" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    let body: { userId?: string };
+    try {
+      body = await request.json() as typeof body;
+    } catch {
+      return new Response(JSON.stringify({ error: "INVALID_BODY" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (!body.userId) {
+      return new Response(JSON.stringify({ error: "userId required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    const ent = await ctx.runQuery(
+      internal.entitlements.getEntitlementsByUserId,
+      { userId: body.userId },
+    );
+    const tier = ent?.features?.tier ?? 0;
+    return new Response(JSON.stringify({ tier }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }),
+});
+
+http.route({
   path: "/dodopayments-webhook",
   method: "POST",
   handler: webhookHandler,

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -80,6 +80,32 @@ async function deactivateChannel(userId, channelType) {
   }
 }
 
+// ── Entitlement check (PRO gate for delivery) ───────────────────────────────
+
+const ENTITLEMENT_CACHE_TTL = 900; // 15 min
+
+async function isUserPro(userId) {
+  const cacheKey = `relay:entitlement:${userId}`;
+  try {
+    const cached = await upstashRest('GET', cacheKey);
+    if (cached !== null) return Number(cached) >= 1;
+  } catch { /* miss */ }
+  try {
+    const res = await fetch(`${CONVEX_SITE_URL}/relay/entitlement`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${RELAY_SECRET}`, 'User-Agent': 'worldmonitor-relay/1.0' },
+      body: JSON.stringify({ userId }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return true; // fail-open: don't block delivery on entitlement service failure
+    const { tier } = await res.json();
+    await upstashRest('SET', cacheKey, String(tier ?? 0), 'EX', String(ENTITLEMENT_CACHE_TTL));
+    return (tier ?? 0) >= 1;
+  } catch {
+    return true; // fail-open
+  }
+}
+
 // ── Private IP guard ─────────────────────────────────────────────────────────
 
 function isPrivateIP(ip) {
@@ -662,6 +688,12 @@ async function processEvent(event) {
   const eventSeverity = event.severity ?? 'high';
 
   for (const rule of matching) {
+    const pro = await isUserPro(rule.userId);
+    if (!pro) {
+      console.log(`[relay] Skipping ${rule.userId} — not PRO`);
+      continue;
+    }
+
     const quietAction = resolveQuietAction(rule, eventSeverity);
 
     if (quietAction === 'suppress') {

--- a/scripts/proactive-intelligence.mjs
+++ b/scripts/proactive-intelligence.mjs
@@ -50,6 +50,7 @@ const convex = CONVEX_URL ? new ConvexHttpClient(CONVEX_URL) : null;
 
 const LANDSCAPE_TTL = 172800; // 48h
 const DIFF_THRESHOLD = 3; // minimum diff score to generate a brief
+const ENTITLEMENT_CACHE_TTL = 900; // 15 min
 
 // ── Redis helpers ──────────────────────────────────────────────────────────────
 
@@ -68,6 +69,30 @@ async function upstashGet(key) {
   const raw = await upstashRest('GET', key);
   if (!raw) return null;
   try { return JSON.parse(raw); } catch { return null; }
+}
+
+// ── Entitlement check ────────────────────────────────────────────────────────
+
+async function isUserPro(userId) {
+  const cacheKey = `relay:entitlement:${userId}`;
+  try {
+    const cached = await upstashRest('GET', cacheKey);
+    if (cached !== null) return Number(cached) >= 1;
+  } catch { /* miss */ }
+  try {
+    const res = await fetch(`${CONVEX_SITE_URL}/relay/entitlement`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${RELAY_SECRET}`, 'User-Agent': 'worldmonitor-proactive/1.0' },
+      body: JSON.stringify({ userId }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return true; // fail-open
+    const { tier } = await res.json();
+    await upstashRest('SET', cacheKey, String(tier ?? 0), 'EX', String(ENTITLEMENT_CACHE_TTL));
+    return (tier ?? 0) >= 1;
+  } catch {
+    return true; // fail-open
+  }
 }
 
 // ── Signal reading ───────────────────────────────────────────────────────────
@@ -443,6 +468,13 @@ async function main() {
     const { changes, score } = computeDiff(prevLandscape, currentLandscape);
     if (score < DIFF_THRESHOLD) {
       console.log(`[proactive] No significant changes for ${rule.userId} (score=${score})`);
+      await upstashRest('SET', landscapeKey, JSON.stringify(currentLandscape), 'EX', String(LANDSCAPE_TTL));
+      continue;
+    }
+
+    const pro = await isUserPro(rule.userId);
+    if (!pro) {
+      console.log(`[proactive] Skipping ${rule.userId} — not PRO`);
       await upstashRest('SET', landscapeKey, JSON.stringify(currentLandscape), 'EX', String(LANDSCAPE_TTL));
       continue;
     }

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -56,6 +56,7 @@ const DIGEST_HIGH_LIMIT = 15;
 const DIGEST_MEDIUM_LIMIT = 10;
 const AI_SUMMARY_CACHE_TTL = 3600; // 1h
 const AI_DIGEST_ENABLED = process.env.AI_DIGEST_ENABLED !== '0';
+const ENTITLEMENT_CACHE_TTL = 900; // 15 min
 
 // ── Redis helpers ──────────────────────────────────────────────────────────────
 
@@ -699,6 +700,30 @@ async function sendWebhook(userId, webhookEnvelope, stories, aiSummary) {
   }
 }
 
+// ── Entitlement check ────────────────────────────────────────────────────────
+
+async function isUserPro(userId) {
+  const cacheKey = `relay:entitlement:${userId}`;
+  try {
+    const cached = await upstashRest('GET', cacheKey);
+    if (cached !== null) return Number(cached) >= 1;
+  } catch { /* miss */ }
+  try {
+    const res = await fetch(`${CONVEX_SITE_URL}/relay/entitlement`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${RELAY_SECRET}`, 'User-Agent': 'worldmonitor-digest/1.0' },
+      body: JSON.stringify({ userId }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return true; // fail-open
+    const { tier } = await res.json();
+    await upstashRest('SET', cacheKey, String(tier ?? 0), 'EX', String(ENTITLEMENT_CACHE_TTL));
+    return (tier ?? 0) >= 1;
+  } catch {
+    return true; // fail-open
+  }
+}
+
 // ── Main ──────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -746,6 +771,12 @@ async function main() {
     } catch { /* first send */ }
 
     if (!isDue(rule, lastSentAt)) continue;
+
+    const pro = await isUserPro(rule.userId);
+    if (!pro) {
+      console.log(`[digest] Skipping ${rule.userId} — not PRO`);
+      continue;
+    }
 
     const windowStart = lastSentAt ?? (nowMs - DIGEST_LOOKBACK_MS);
     const stories = await buildDigest(rule, windowStart);

--- a/src/services/preferences-content.ts
+++ b/src/services/preferences-content.ts
@@ -901,6 +901,7 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
                 </div>
                 <select class="unified-settings-select" id="usDigestHour" style="width:auto">${hourOptionsDigest}</select>
               </div>
+              <div id="usTwiceDailyHint" class="ai-flow-toggle-desc" style="margin-top:4px;${digestMode === 'twice_daily' ? '' : 'display:none'}">Also sends at ${((digestHour + 12) % 24) === 0 ? '12 AM' : ((digestHour + 12) % 24) < 12 ? `${(digestHour + 12) % 24} AM` : ((digestHour + 12) % 24) === 12 ? '12 PM' : `${((digestHour + 12) % 24) - 12} PM`}</div>
               <div class="ai-flow-toggle-row" style="margin-top:8px">
                 <div class="ai-flow-toggle-label-wrap">
                   <div class="ai-flow-toggle-label">AI executive summary</div>
@@ -1024,8 +1025,10 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
             const isRt = target.value === 'realtime';
             const realtimeSection = container.querySelector<HTMLElement>('#usRealtimeSection');
             const digestDetails = container.querySelector<HTMLElement>('#usDigestDetails');
+            const twiceHint = container.querySelector<HTMLElement>('#usTwiceDailyHint');
             if (realtimeSection) realtimeSection.style.display = isRt ? '' : 'none';
             if (digestDetails) digestDetails.style.display = isRt ? 'none' : '';
+            if (twiceHint) twiceHint.style.display = target.value === 'twice_daily' ? '' : 'none';
             saveDigestSettings();
             // Switching to digest mode: auto-enable the alert rule so the
             // backend schedules digests. The enable toggle is hidden in
@@ -1040,6 +1043,11 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
             return;
           }
           if (target.id === 'usDigestHour') {
+            const twiceHint = container.querySelector<HTMLElement>('#usTwiceDailyHint');
+            if (twiceHint) {
+              const h = (Number(target.value) + 12) % 24;
+              twiceHint.textContent = `Also sends at ${h === 0 ? '12 AM' : h < 12 ? `${h} AM` : h === 12 ? '12 PM' : `${h - 12} PM`}`;
+            }
             saveDigestSettings();
             return;
           }


### PR DESCRIPTION
## Summary

All three notification delivery paths (relay, digest cron, proactive agent) now verify PRO tier before sending. Prevents downgraded users from continuing to receive notifications after subscription expires.

- New `/relay/entitlement` Convex HTTP endpoint (RELAY_SHARED_SECRET auth)
- `isUserPro(userId)` helper added to relay, digest, and proactive scripts
- 15min Redis cache per user (`relay:entitlement:{userId}`)
- Fail-open: if entitlement service is unreachable, delivery proceeds

**Requires Convex deploy** for the new `/relay/entitlement` route.

## Test plan

- [ ] Convex deploy succeeds
- [ ] PRO user: notifications delivered normally
- [ ] Free user with existing rules: skipped with `[relay] Skipping <userId> — not PRO` log
- [ ] Entitlement service down: delivery proceeds (fail-open)
- [ ] Cache: second check within 15min hits Redis, no Convex call
- [ ] All three scripts: relay, digest, proactive check before delivery