### PR TITLE
feat(deep-dive): donut charts for energy mix + styled maritime table

### DIFF
--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -1091,9 +1091,10 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
       const trendCell = this.el('td', 'cdp-maritime-trend');
       const pct = port.trendDeltaPct;
       if (pct !== 0 || port.tankerCalls30d > 0) {
-        const sign = pct >= 0 ? '+' : '';
+        const sign = pct > 0 ? '+' : '';
         trendCell.textContent = `${sign}${pct.toFixed(1)}%`;
-        trendCell.classList.add(pct >= 0 ? 'cdp-trend-up' : 'cdp-trend-down');
+        if (pct > 0) trendCell.classList.add('cdp-trend-up');
+        else if (pct < 0) trendCell.classList.add('cdp-trend-down');
       } else {
         trendCell.textContent = 'n/a';
       }

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -521,31 +521,21 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
       const total = segments.reduce((s, seg) => s + seg.value, 0);
       const norm = total > 0 ? total : 1;
 
-      const bar = this.el('div', '');
-      bar.style.cssText = 'display:flex;width:100%;height:12px;border-radius:4px;overflow:hidden;margin-bottom:8px';
+      const wrap = this.el('div', 'cdp-energy-donut-wrap');
+      wrap.append(this.buildDonutSvg(segments, norm, 'Primary\nEnergy'));
+      const legend = this.el('div', 'cdp-energy-legend');
       for (const seg of segments) {
         const pct = (seg.value / norm) * 100;
         if (pct <= 0.5) continue;
-        const span = this.el('span', '');
-        span.style.cssText = `width:${pct}%;background:${seg.color}`;
-        bar.append(span);
-      }
-      this.energyBody.append(bar);
-
-      const legend = this.el('div', '');
-      for (const seg of segments) {
-        const pct = (seg.value / norm) * 100;
-        if (pct <= 0.5) continue;
-        const row = this.el('div', '');
-        row.style.cssText = 'font-size:11px;color:#aaa;display:flex;gap:4px;align-items:center';
-        const dot = this.el('span', '');
-        dot.textContent = '\u25CF';
-        dot.style.color = seg.color;
+        const row = this.el('div', 'cdp-energy-legend-row');
+        const dot = this.el('span', 'cdp-energy-legend-dot');
+        dot.style.background = seg.color;
         const label = this.el('span', '', `${seg.label}  ${Math.round(pct)}%`);
         row.append(dot, label);
         legend.append(row);
       }
-      this.energyBody.append(legend);
+      wrap.append(legend);
+      this.energyBody.append(wrap);
 
       const src = this.el('div', 'cdp-economic-source', `Data: ${data.mixYear} (OWID)`);
       this.energyBody.append(src);
@@ -745,31 +735,21 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
       const total = segments.reduce((acc, seg) => acc + seg.value, 0);
       const norm = total > 0 ? total : 1;
 
-      const bar = this.el('div', '');
-      bar.style.cssText = 'display:flex;width:100%;height:10px;border-radius:4px;overflow:hidden;margin-bottom:6px';
+      const wrap = this.el('div', 'cdp-energy-donut-wrap');
+      wrap.append(this.buildDonutSvg(segments, norm, 'Monthly\nMix'));
+      const legend = this.el('div', 'cdp-energy-legend');
       for (const seg of segments) {
         const pct = (seg.value / norm) * 100;
         if (pct <= 0.5) continue;
-        const span = this.el('span', '');
-        span.style.cssText = `width:${pct}%;background:${seg.color}`;
-        bar.append(span);
-      }
-      section.append(bar);
-
-      const legend = this.el('div', '');
-      for (const seg of segments) {
-        const pct = (seg.value / norm) * 100;
-        if (pct <= 0.5) continue;
-        const row = this.el('div', '');
-        row.style.cssText = 'font-size:11px;color:#aaa;display:flex;gap:4px;align-items:center';
-        const dot = this.el('span', '');
-        dot.textContent = '\u25CF';
-        dot.style.color = seg.color;
+        const row = this.el('div', 'cdp-energy-legend-row');
+        const dot = this.el('span', 'cdp-energy-legend-dot');
+        dot.style.background = seg.color;
         const label = this.el('span', '', `${seg.label}  ${Math.round(pct)}%`);
         row.append(dot, label);
         legend.append(row);
       }
-      section.append(legend);
+      wrap.append(legend);
+      section.append(wrap);
 
       if (data.emberCoalShare > 0 || data.emberGasShare > 0) {
         const breakdown = this.el('div', '');
@@ -795,6 +775,51 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     if (data.jodiOilAvailable || data.jodiGasAvailable) {
       this.energyBody.append(this.renderShockScenarioWidget());
     }
+  }
+
+  private buildDonutSvg(
+    segments: Array<{ label: string; color: string; value: number }>,
+    norm: number,
+    centerText: string,
+  ): HTMLElement {
+    const size = 90;
+    const r = 35;
+    const stroke = 14;
+    const cx = size / 2;
+    const cy = size / 2;
+    const circ = 2 * Math.PI * r;
+
+    const ns = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('width', String(size));
+    svg.setAttribute('height', String(size));
+    svg.setAttribute('viewBox', `0 0 ${size} ${size}`);
+
+    let offset = 0;
+    for (const seg of segments) {
+      const pct = (seg.value / norm) * 100;
+      if (pct <= 0.5) continue;
+      const dash = (pct / 100) * circ;
+      const gap = circ - dash;
+      const circle = document.createElementNS(ns, 'circle');
+      circle.setAttribute('cx', String(cx));
+      circle.setAttribute('cy', String(cy));
+      circle.setAttribute('r', String(r));
+      circle.setAttribute('fill', 'none');
+      circle.setAttribute('stroke', seg.color);
+      circle.setAttribute('stroke-width', String(stroke));
+      circle.setAttribute('stroke-dasharray', `${dash} ${gap}`);
+      circle.setAttribute('stroke-dashoffset', String(-offset));
+      svg.append(circle);
+      offset += dash;
+    }
+
+    const wrap = this.el('div', 'cdp-energy-donut');
+    wrap.append(svg);
+    const label = this.el('div', 'cdp-energy-donut-label');
+    label.textContent = centerText;
+    wrap.append(label);
+    return wrap;
   }
 
   private renderShockScenarioWidget(): HTMLElement {

--- a/src/styles/country-deep-dive.css
+++ b/src/styles/country-deep-dive.css
@@ -295,6 +295,116 @@
   font-size: 11px;
 }
 
+/* Maritime Activity Table */
+.cdp-maritime-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 11px;
+}
+
+.cdp-maritime-table th {
+  text-align: left;
+  color: var(--text-muted);
+  font-weight: 600;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.cdp-maritime-table td {
+  padding: 6px 8px;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.cdp-maritime-table tbody tr:hover {
+  background: var(--surface-hover);
+}
+
+.cdp-maritime-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.cdp-maritime-port {
+  font-weight: 500;
+  color: var(--text);
+}
+
+.cdp-maritime-anomaly {
+  margin-left: 4px;
+  color: var(--semantic-warning);
+  font-size: 12px;
+}
+
+.cdp-maritime-trend.cdp-trend-up {
+  color: var(--semantic-positive, #22c55e);
+  font-weight: 600;
+}
+
+.cdp-maritime-trend.cdp-trend-down {
+  color: var(--semantic-critical, #ef4444);
+  font-weight: 600;
+}
+
+/* Energy Donut Charts */
+.cdp-energy-donut-wrap {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+
+.cdp-energy-donut {
+  position: relative;
+  width: 90px;
+  height: 90px;
+  flex-shrink: 0;
+}
+
+.cdp-energy-donut svg {
+  transform: rotate(-90deg);
+}
+
+.cdp-energy-donut-label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-align: center;
+  line-height: 1.2;
+  pointer-events: none;
+}
+
+.cdp-energy-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.cdp-energy-legend-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.cdp-energy-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
 .cdp-score-row {
   display: flex;
   align-items: center;

--- a/src/styles/country-deep-dive.css
+++ b/src/styles/country-deep-dive.css
@@ -380,6 +380,7 @@
   text-align: center;
   line-height: 1.2;
   pointer-events: none;
+  white-space: pre;
 }
 
 .cdp-energy-legend {


### PR DESCRIPTION
## Summary
- **Energy Profile**: replaces horizontal stacked bars with SVG donut charts for both primary energy mix (OWID) and monthly generation mix (Ember). Donut + legend layout shows proportional data much better at a glance.
- **Maritime Activity**: adds proper CSS styling for the port table with colored trends (green for positive, red for negative), styled headers, hover rows, and anomaly badges.

## Changes
- `src/components/CountryDeepDivePanel.ts`: new `buildDonutSvg()` helper, replaced bar rendering in both energy sections
- `src/styles/country-deep-dive.css`: `.cdp-maritime-*` table styles, `.cdp-energy-donut-*` chart styles, `.cdp-trend-up`/`.cdp-trend-down` colors

## Test plan
- [x] TypeScript typecheck passes
- [x] All tests pass
- [ ] Visual: open country brief for any country with energy data (e.g. India, Germany, US)
- [ ] Visual: donut charts show correct proportions with legend
- [ ] Visual: maritime table has colored trends (red for negative %)
- [ ] Visual: hover rows highlight on maritime table