### PR TITLE
feat(supply-chain): Sprint B — disruption-score arc coloring + arc click route breakdown

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -95,11 +95,12 @@ import {
   SANCTIONED_COUNTRIES_ALPHA2,
 } from '@/config';
 import type { GulfInvestment } from '@/types';
-import { resolveTradeRouteSegments, TRADE_ROUTES as TRADE_ROUTES_LIST, type TradeRouteSegment } from '@/config/trade-routes';
+import { resolveTradeRouteSegments, TRADE_ROUTES as TRADE_ROUTES_LIST, type TradeRouteSegment, type TradeRouteStatus } from '@/config/trade-routes';
 import type { ScenarioVisualState } from '@/config/scenario-templates';
 import { getLayersForVariant, resolveLayerLabel, bindLayerSearch, type MapVariant } from '@/config/map-layer-definitions';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { hasPremiumAccess } from '@/services/panel-gating';
+import { trackGateHit } from '@/services/analytics';
 import { MapPopup, type PopupType } from './MapPopup';
 import type { GetChokepointStatusResponse } from '@/services/supply-chain';
 import {
@@ -398,6 +399,7 @@ export class DeckGLMap {
   private radiationObservations: RadiationObservation[] = [];
   private diseaseOutbreaks: DiseaseOutbreakItem[] = [];
   private tradeRouteSegments: TradeRouteSegment[] = resolveTradeRouteSegments();
+  private storedChokepointData: GetChokepointStatusResponse | null = null;
   private scenarioState: ScenarioVisualState | null = null;
   private positiveEvents: PositiveGeoEvent[] = [];
   private kindnessPoints: KindnessPoint[] = [];
@@ -430,6 +432,7 @@ export class DeckGLMap {
 
   // Callbacks
   private onHotspotClick?: (hotspot: Hotspot) => void;
+  private onTradeArcClick?: (segment: TradeRouteSegment, waypoints: string[], x: number, y: number) => void;
   private onTimeRangeChange?: (range: TimeRange) => void;
   private onCountryClick?: (country: CountryClickPayload) => void;
   private onMapContextMenu?: (payload: { lat: number; lon: number; screenX: number; screenY: number; countryCode?: string; countryName?: string }) => void;
@@ -4051,6 +4054,18 @@ export class DeckGLMap {
       return;
     }
 
+    if (layerId === 'trade-routes-layer') {
+      const segment = info.object as TradeRouteSegment;
+      if (!hasPremiumAccess(getAuthState())) {
+        trackGateHit('trade-arc-intel');
+        return;
+      }
+      const waypoints = ROUTE_WAYPOINTS_MAP.get(segment.routeId) ?? [];
+      this.popup.showRouteBreakdown(segment, waypoints, info.x, info.y);
+      this.onTradeArcClick?.(segment, waypoints, info.x, info.y);
+      return;
+    }
+
     // Map layer IDs to popup types
     const layerToPopupType: Record<string, PopupType> = {
       'conflict-zones-layer': 'conflict',
@@ -4984,6 +4999,7 @@ export class DeckGLMap {
           return scenario;
         }
       }
+      if (!hasPremiumAccess(getAuthState())) return active;  // free users: always blue
       return colorFor(d.status);
     };
 
@@ -4998,7 +5014,7 @@ export class DeckGLMap {
       widthMinPixels: 1,
       widthMaxPixels: 6,
       greatCircle: true,
-      pickable: false,
+      pickable: true,
     });
   }
 
@@ -5395,6 +5411,20 @@ export class DeckGLMap {
 
   public setChokepointData(data: GetChokepointStatusResponse | null): void {
     this.popup.setChokepointData(data);
+    this.storedChokepointData = data;
+    if (this.storedChokepointData) this.refreshTradeRouteStatus(this.storedChokepointData);
+  }
+
+  private refreshTradeRouteStatus(data: GetChokepointStatusResponse): void {
+    const scoreMap = new Map(data.chokepoints.map(cp => [cp.id, cp.disruptionScore ?? 0]));
+    const initialSegments = resolveTradeRouteSegments();
+    this.tradeRouteSegments = initialSegments.map(seg => {
+      const waypoints = ROUTE_WAYPOINTS_MAP.get(seg.routeId) ?? [];
+      const maxScore = waypoints.reduce((max, id) => Math.max(max, scoreMap.get(id) ?? 0), 0);
+      const status: TradeRouteStatus = maxScore > 70 ? 'disrupted' : maxScore > 30 ? 'high_risk' : 'active';
+      return { ...seg, status };
+    });
+    this.render();
   }
 
   /**
@@ -5540,6 +5570,10 @@ export class DeckGLMap {
 
   public setOnHotspotClick(callback: (hotspot: Hotspot) => void): void {
     this.onHotspotClick = callback;
+  }
+
+  public setOnTradeArcClick(cb: (segment: TradeRouteSegment, waypoints: string[], x: number, y: number) => void): void {
+    this.onTradeArcClick = cb;
   }
 
   public setOnTimeRangeChange(callback: (range: TimeRange) => void): void {

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -414,13 +414,8 @@ export class MapPopup {
     if (this.outsideListenerTimeoutId !== null) clearTimeout(this.outsideListenerTimeoutId);
     this.outsideListenerTimeoutId = window.setTimeout(() => {
       this.outsideListenerTimeoutId = null;
-      const outsideHandler = (e: MouseEvent) => {
-        if (this.popup && !this.popup.contains(e.target as Node)) {
-          this.hide();
-          document.removeEventListener('click', outsideHandler);
-        }
-      };
-      document.addEventListener('click', outsideHandler);
+      document.addEventListener('click', this.handleOutsideClick);
+      document.addEventListener('keydown', this.handleEscapeKey);
     }, 200);
   }
 

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -346,8 +346,14 @@ export class MapPopup {
   ): void {
     this.hide();
 
-    const primaryCpId = chokepointIds[0] ?? '';
-    const cp = this.chokepointData?.chokepoints?.find(c => c.id === primaryCpId);
+    // Pick the waypoint with the highest disruption score — this is the driver of the arc
+    // color computed in refreshTradeRouteStatus() and must match what the user sees on the arc.
+    const allCps = this.chokepointData?.chokepoints ?? [];
+    const primaryCpId =
+      chokepointIds
+        .map(id => ({ id, score: allCps.find(c => c.id === id)?.disruptionScore ?? 0 }))
+        .sort((a, b) => b.score - a.score)[0]?.id ?? chokepointIds[0] ?? '';
+    const cp = allCps.find(c => c.id === primaryCpId);
     const sectors = primaryCpId ? (CHOKEPOINT_HS2_SECTORS[primaryCpId] ?? []) : [];
 
     const tierLabel: Record<string, string> = {

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -1,4 +1,5 @@
 import type { ConflictZone, Hotspot, NewsItem, MilitaryBase, StrategicWaterway, APTGroup, NuclearFacility, EconomicCenter, GammaIrradiator, Pipeline, UnderseaCable, CableAdvisory, RepairShip, InternetOutage, AIDataCenter, AisDisruptionEvent, SocialUnrestEvent, MilitaryFlight, MilitaryVessel, MilitaryFlightCluster, MilitaryVesselCluster, NaturalEvent, Port, Spaceport, CriticalMineralProject, CyberThreat } from '@/types';
+import type { TradeRouteSegment } from '@/config/trade-routes';
 import type { AirportDelayAlert, PositionSample } from '@/services/aviation';
 import type { Earthquake } from '@/services/earthquakes';
 import type { WeatherAlert } from '@/services/weather';
@@ -335,6 +336,86 @@ export class MapPopup {
       document.addEventListener('keydown', this.handleEscapeKey);
       this.outsideListenerTimeoutId = null;
     }, 0);
+  }
+
+  public showRouteBreakdown(
+    segment: TradeRouteSegment,
+    chokepointIds: string[],
+    x: number,
+    y: number,
+  ): void {
+    this.hide();
+
+    const primaryCpId = chokepointIds[0] ?? '';
+    const cp = this.chokepointData?.chokepoints?.find(c => c.id === primaryCpId);
+    const sectors = primaryCpId ? (CHOKEPOINT_HS2_SECTORS[primaryCpId] ?? []) : [];
+
+    const tierLabel: Record<string, string> = {
+      WAR_RISK_TIER_WAR_ZONE: 'War Zone', WAR_RISK_TIER_CRITICAL: 'Critical',
+      WAR_RISK_TIER_HIGH: 'High', WAR_RISK_TIER_ELEVATED: 'Elevated',
+      WAR_RISK_TIER_NORMAL: 'Normal',
+    };
+    const tierColor: Record<string, string> = {
+      WAR_RISK_TIER_WAR_ZONE: '#ef4444', WAR_RISK_TIER_CRITICAL: '#ef4444',
+      WAR_RISK_TIER_HIGH: '#f59e0b', WAR_RISK_TIER_ELEVATED: '#f59e0b',
+      WAR_RISK_TIER_NORMAL: 'var(--text-dim,#888)',
+    };
+
+    const tier = cp?.warRiskTier ?? 'WAR_RISK_TIER_NORMAL';
+    const disruptionScore = cp?.disruptionScore ?? 0;
+    const scoreColor = disruptionScore > 70 ? '#ef4444' : disruptionScore > 30 ? '#f59e0b' : 'var(--text-dim,#888)';
+
+    const topSectors = sectors.slice(0, 2);
+    const sectorHtml = topSectors.length
+      ? topSectors.map(s =>
+          `<span style="display:inline-flex;align-items:center;gap:3px;margin-right:6px">` +
+          `<span style="width:8px;height:8px;border-radius:50%;background:${s.color};display:inline-block"></span>` +
+          `<span style="font-size:10px">${escapeHtml(s.label)} ${s.share}%</span></span>`
+        ).join('')
+      : `<span style="font-size:10px;opacity:.5">No sector data</span>`;
+
+    const html = `
+      <div class="popup-header">
+        <span class="popup-title" style="font-size:12px">${escapeHtml(segment.routeName)}</span>
+        <button class="popup-close" aria-label="Close">×</button>
+      </div>
+      <div class="popup-body" style="padding:8px 12px;min-width:200px">
+        ${cp ? `<div style="font-size:11px;font-weight:600;margin-bottom:6px">${escapeHtml(cp.name)}</div>` : ''}
+        <div style="display:flex;gap:10px;margin-bottom:6px">
+          <span style="font-size:10px;opacity:.6">Disruption</span>
+          <span style="font-size:10px;font-weight:600;color:${scoreColor}">${disruptionScore}/100</span>
+        </div>
+        <div style="display:flex;gap:10px;margin-bottom:6px">
+          <span style="font-size:10px;opacity:.6">War Risk</span>
+          <span style="font-size:10px;font-weight:600;color:${tierColor[tier] ?? 'inherit'}">${tierLabel[tier] ?? 'Normal'}</span>
+        </div>
+        <div style="margin-top:4px">${sectorHtml}</div>
+      </div>`;
+
+    this.isMobileSheet = false;
+    this.popup = document.createElement('div');
+    this.popup.className = 'map-popup map-popup-route-breakdown';
+    this.popup.innerHTML = html;
+
+    const containerRect = this.container.getBoundingClientRect();
+    this.positionDesktopPopup({ x, y, type: 'waterway', data: {} as never }, containerRect);
+    document.body.appendChild(this.popup);
+
+    this.popup.addEventListener('click', (e) => {
+      if ((e.target as HTMLElement).closest('.popup-close')) this.hide();
+    });
+
+    if (this.outsideListenerTimeoutId !== null) clearTimeout(this.outsideListenerTimeoutId);
+    this.outsideListenerTimeoutId = window.setTimeout(() => {
+      this.outsideListenerTimeoutId = null;
+      const outsideHandler = (e: MouseEvent) => {
+        if (this.popup && !this.popup.contains(e.target as Node)) {
+          this.hide();
+          document.removeEventListener('click', outsideHandler);
+        }
+      };
+      document.addEventListener('click', outsideHandler);
+    }, 200);
   }
 
   private positionDesktopPopup(data: PopupData, containerRect: DOMRect): void {


### PR DESCRIPTION
## Summary

- **B1**: Live chokepoint disruption scores now drive trade route arc colors. Routes transiting a chokepoint with score >70 turn red, >30 amber, else blue. PRO-gated — free users always see default blue arcs. `DeckGLMap.refreshTradeRouteStatus()` is called whenever `setChokepointData()` updates.
- **B2**: Trade route arcs are now pickable. PRO users clicking an arc see a mini breakdown popup: route name, primary chokepoint, disruption score (color-coded), war risk tier, top 2 HS2 sectors. Free users get a `trackGateHit('trade-arc-intel')` but no popup.

## Files changed
- `src/components/DeckGLMap.ts` — `refreshTradeRouteStatus()`, pickable arcs, `trade-routes-layer` click case, PRO gate in `getColor`
- `src/components/MapPopup.ts` — `showRouteBreakdown()` method

## Post-Deploy Monitoring & Validation
- **Expected**: Red/amber arcs visible on map for routes through Bab el-Mandeb / Hormuz (currently high disruption)
- **Failure signal**: All arcs stay blue despite chokepoint data loading
- **No additional operational monitoring required** — client-side only, no new API calls

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.6 via Claude Code