### PR TITLE
fix(supply-chain): post-Sprint D follow-ups (orphaned fixes + war risk tier display)

### DIFF
--- a/src/components/SupplyChainPanel.ts
+++ b/src/components/SupplyChainPanel.ts
@@ -197,6 +197,7 @@ export class SupplyChainPanel extends Panel {
         const days = opt.addedTransitDays > 0 ? `+${opt.addedTransitDays}d` : '-';
         const cost = opt.addedCostMultiplier > 1 ? `+${((opt.addedCostMultiplier - 1) * 100).toFixed(0)}%` : '-';
         const riskTierMap: Record<string, string> = {
+          WAR_RISK_TIER_UNSPECIFIED: 'Normal',
           WAR_RISK_TIER_WAR_ZONE: 'War Zone',
           WAR_RISK_TIER_CRITICAL: 'Critical',
           WAR_RISK_TIER_HIGH: 'High',


### PR DESCRIPTION
## Why this PR?

These 5 commits were pushed to `feat/supply-chain-sprint-d` after PR #2905 was merged and therefore were not included in that merge. This PR recovers them.

## Summary

- **Move boundary violations**: `bypass-corridors` + `chokepoint-registry` copied to `server/_shared/` so `api/v2/` edge functions don't violate the `src/config/` import boundary
- **Webhook security fixes**: persist HMAC secret on registration, fix sub-resource route parsing (`/wh_xxx/rotate-secret` was unreachable), add SHA-256 owner fingerprinting + Redis Set ownership index + GET list route
- **SSRF hardening**: HTTPS-only requirement, expanded metadata hostname blocklist, DNS rebinding limitation documented
- **`get-sector-dependency.ts` stale imports**: fix `src/config/` → `server/_shared/` (Greptile P1)
- **Landlocked country bug**: `computeExposures()` returned a fake `primaryChokepointId` (Suez) when `nearestRouteIds` was empty; now returns `[]`
- **`WAR_RISK_TIER_UNSPECIFIED` display bug**: raw proto enum was rendering in the bypass corridor Risk column; mapped to 'Normal'

## Post-Deploy Monitoring & Validation
- **Webhooks**: `POST /api/v2/shipping/webhooks` with valid HTTPS URL should return 201; `GET /api/v2/shipping/webhooks` should return list for same key
- **Sector dependency**: landlocked countries (LI, AD, SM, BT) should return `primaryChokepointId: ''` and `primaryChokepointExposure: 0`
- **UI**: bypass corridor table Risk column should never show `WAR_RISK_TIER_*` raw strings
- **Validation window**: 30 min post-deploy