### PR TITLE
chore(sentry): filter ConvexError CONFLICT noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -245,6 +245,7 @@ Sentry.init({
     /ClerkJS: Network error/, // Clerk SDK transient network failures on user devices
     /doesn't provide an export named/, // stale cached chunk after deploy references removed export
     /Possible side-effect in debug-evaluate/, // Chrome DevTools internal EvalError
+    /ConvexError: CONFLICT/, // Expected OCC rejection on concurrent preference saves
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary

- WORLDMONITOR-M1: `Uncaught ConvexError: CONFLICT` (18 events, 6 users)
- Expected OCC rejection when concurrent tabs save preferences
- Client already handles at HTTP layer (409 status), but Convex real-time client throws as unhandled rejection
- Added to `ignoreErrors` in Sentry config (unambiguously Convex SDK, not our code)
- Issue resolved in Sentry with `inNextRelease`

## Test plan

- [x] `tsc --noEmit` passes
- [x] Pattern added to `ignoreErrors` (not `beforeSend`) since `ConvexError: CONFLICT` is unambiguously third-party