### PR TITLE
fix(seeds): proxy-first FRED, proxy fallback for fuel prices, fix FOMC/ECB parsers

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -353,20 +353,26 @@ export async function httpsProxyFetchRaw(url, proxyAuth, { accept = '*/*', timeo
 }
 
 // Fetch JSON from a FRED URL, routing through proxy when available.
+// Proxy-first: FRED consistently blocks/throttles Railway datacenter IPs,
+// so try proxy first to avoid 20s timeout on every direct attempt.
 export async function fredFetchJson(url, proxyAuth) {
-  try {
-    const r = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(20_000) });
-    if (r.ok) return r.json();
-    throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
-  } catch (directErr) {
-    if (!proxyAuth) throw directErr;
-    console.warn(`  [fredFetch] direct failed (${directErr.message}) — retrying via proxy`);
+  if (proxyAuth) {
     try {
       return await httpsProxyFetchJson(url, proxyAuth);
     } catch (proxyErr) {
-      throw Object.assign(new Error(`proxy: ${proxyErr.message}`), { cause: proxyErr });
+      console.warn(`  [fredFetch] proxy failed (${proxyErr.message}) — retrying direct`);
+      try {
+        const r = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(20_000) });
+        if (r.ok) return r.json();
+        throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
+      } catch (directErr) {
+        throw Object.assign(new Error(`direct: ${directErr.message}`), { cause: directErr });
+      }
     }
   }
+  const r = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(20_000) });
+  if (r.ok) return r.json();
+  throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/seed-economic-calendar.mjs
+++ b/scripts/seed-economic-calendar.mjs
@@ -64,18 +64,44 @@ async function fetchFomcDates(fallback) {
     };
     const MON = Object.keys(MONTHS).join('|');
     const dates = [];
-    // Same-month: "January 27-28, 2026" → day2=28
+
+    // Strategy A: inline format "January 27-28, 2026" (legacy)
     const reSame = new RegExp(`\\b(${MON})\\s+\\d{1,2}[-\u2013](\\d{1,2})\\*?\\s*,\\s*(20\\d{2})`, 'g');
-    // Cross-month: "January 28 - February 1, 2026" → month2+day2
     const reCross = new RegExp(`\\b${MON}\\s+\\d{1,2}\\s*[-\u2013]\\s*(${MON})\\s+(\\d{1,2})\\*?\\s*,\\s*(20\\d{2})`, 'g');
     let m;
     while ((m = reSame.exec(html)) !== null) {
       const [, month, day2, year] = m;
-      dates.push(`${year}-${MONTHS[month]}-${day2.padStart(2, '0')}`);
+      if (month && day2 && year) dates.push(`${year}-${MONTHS[month]}-${day2.padStart(2, '0')}`);
     }
     while ((m = reCross.exec(html)) !== null) {
       const [, month2, day2, year] = m;
-      dates.push(`${year}-${MONTHS[month2]}-${day2.padStart(2, '0')}`);
+      if (month2 && day2 && year) dates.push(`${year}-${MONTHS[month2]}-${day2.padStart(2, '0')}`);
+    }
+
+    // Strategy B: structured sections — year in heading, month + "dd-dd" in body.
+    // Matches pages where year/month/range are in separate HTML elements.
+    if (dates.length === 0) {
+      const yearRe = /\b(20\d{2})\s+FOMC\s+Meetings/gi;
+      let yearMatch;
+      while ((yearMatch = yearRe.exec(html)) !== null) {
+        const year = yearMatch[1];
+        const sectionStart = yearMatch.index;
+        const nextYearIdx = html.indexOf(' FOMC Meetings', sectionStart + 20);
+        const sectionEnd = nextYearIdx > sectionStart ? nextYearIdx : html.length;
+        const section = html.slice(sectionStart, sectionEnd);
+
+        const monthRe = new RegExp(`\\b(${MON})\\b`, 'g');
+        let monthMatch;
+        while ((monthMatch = monthRe.exec(section)) !== null) {
+          const month = monthMatch[1];
+          const afterMonth = section.slice(monthMatch.index + month.length, monthMatch.index + month.length + 80);
+          const rangeMatch = afterMonth.match(/(\d{1,2})\s*[-\u2013]\s*(\d{1,2})/);
+          if (rangeMatch) {
+            const day2 = rangeMatch[2];
+            dates.push(`${year}-${MONTHS[month]}-${day2.padStart(2, '0')}`);
+          }
+        }
+      }
     }
 
     const unique = [...new Set(dates)].sort();
@@ -101,8 +127,8 @@ async function fetchEcbCouncilDates(fallback) {
     const html = await resp.text();
 
     const dates = [];
-    // Find all datetime="YYYY-MM-DD" positions; for each, scan only up to the NEXT datetime= attr
-    // to avoid bleeding context from adjacent calendar entries
+
+    // Strategy A: datetime="YYYY-MM-DD" attributes with "monetary policy" + "Day 2" context
     const dateRe = /datetime="(\d{4}-\d{2}-\d{2})"/g;
     const allMatches = [...html.matchAll(dateRe)];
     for (let i = 0; i < allMatches.length; i++) {
@@ -111,6 +137,37 @@ async function fetchEcbCouncilDates(fallback) {
       const ctx = html.slice(match.index, nextIdx);
       if (/monetary policy/i.test(ctx) && /\bDay\s*2\b/i.test(ctx)) {
         dates.push(match[1]);
+      }
+    }
+
+    // Strategy B: DD/MM/YYYY format in text near "monetary policy" + "Day 2"
+    if (dates.length === 0) {
+      const dateRe2 = /(\d{1,2})\/(\d{2})\/(\d{4})/g;
+      const allMatches2 = [...html.matchAll(dateRe2)];
+      for (let i = 0; i < allMatches2.length; i++) {
+        const match = allMatches2[i];
+        const ctxStart = Math.max(0, match.index - 400);
+        const ctxEnd = Math.min(html.length, match.index + 400);
+        const ctx = html.slice(ctxStart, ctxEnd);
+        if (/monetary policy/i.test(ctx) && /\bDay\s*2\b/i.test(ctx)) {
+          const [, dd, mm, yyyy] = match;
+          dates.push(`${yyyy}-${mm}-${dd.padStart(2, '0')}`);
+        }
+      }
+    }
+
+    // Strategy C: ISO dates (YYYY-MM-DD) in text near "monetary policy" + "Day 2"
+    if (dates.length === 0) {
+      const dateRe3 = /\b(20\d{2}-\d{2}-\d{2})\b/g;
+      const allMatches3 = [...html.matchAll(dateRe3)];
+      for (let i = 0; i < allMatches3.length; i++) {
+        const match = allMatches3[i];
+        const ctxStart = Math.max(0, match.index - 400);
+        const ctxEnd = Math.min(html.length, match.index + 400);
+        const ctx = html.slice(ctxStart, ctxEnd);
+        if (/monetary policy/i.test(ctx) && /\bDay\s*2\b/i.test(ctx)) {
+          dates.push(match[1]);
+        }
       }
     }
 

--- a/scripts/seed-fuel-prices.mjs
+++ b/scripts/seed-fuel-prices.mjs
@@ -1,9 +1,28 @@
 #!/usr/bin/env node
 
 import ExcelJS from 'exceljs';
-import { loadEnvFile, CHROME_UA, runSeed, readSeedSnapshot, getSharedFxRates, SHARED_FX_FALLBACKS } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, readSeedSnapshot, getSharedFxRates, SHARED_FX_FALLBACKS, resolveProxyForConnect, httpsProxyFetchRaw } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
+
+const _proxyAuth = resolveProxyForConnect();
+
+// Fetch with proxy fallback for government APIs that block datacenter IPs.
+async function fetchWithProxyFallback(url, { timeoutMs = 20_000, accept = 'text/csv,text/plain,*/*' } = {}) {
+  try {
+    const r = await globalThis.fetch(url, {
+      headers: { 'User-Agent': CHROME_UA, Accept: accept },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (r.ok) return r;
+    throw new Error(`HTTP ${r.status}`);
+  } catch (directErr) {
+    if (!_proxyAuth) throw directErr;
+    console.warn(`    direct failed (${directErr.message}) — retrying via proxy`);
+    const { buffer, contentType } = await httpsProxyFetchRaw(url, _proxyAuth, { accept, timeoutMs });
+    return new Response(buffer, { headers: { 'Content-Type': contentType || 'text/plain' } });
+  }
+}
 
 const CANONICAL_KEY = 'economic:fuel-prices:v1';
 const CACHE_TTL = 864000; // 10 days — weekly seed with 3-day cron-drift buffer
@@ -145,10 +164,7 @@ async function fetchMexico() {
   try {
     const url = 'https://api.datos.gob.mx/v2/precio.gasolina.publico?pageSize=1000';
     console.log(`  [MX] API: ${url}`);
-    const resp = await globalThis.fetch(url, {
-      headers: { 'User-Agent': CHROME_UA },
-      signal: AbortSignal.timeout(20000),
-    });
+    const resp = await fetchWithProxyFallback(url, { accept: 'application/json' });
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     const data = await resp.json();
     const results = data?.results;
@@ -404,9 +420,9 @@ async function fetchBrazil() {
     console.log(`  [BR] dsl CSV: ${DSL_URL}`);
     // Use allSettled so a 429 on the diesel CSV doesn't discard gasoline data
     const [gasResult, dslResult] = await Promise.allSettled([
-      globalThis.fetch(GAS_URL, { headers: { 'User-Agent': CHROME_UA }, signal: AbortSignal.timeout(30000) })
+      fetchWithProxyFallback(GAS_URL, { timeoutMs: 30000 })
         .then(r => r.ok ? r.text() : Promise.reject(new Error(`Gas HTTP ${r.status}`))),
-      globalThis.fetch(DSL_URL, { headers: { 'User-Agent': CHROME_UA }, signal: AbortSignal.timeout(30000) })
+      fetchWithProxyFallback(DSL_URL, { timeoutMs: 30000 })
         .then(r => r.ok ? r.text() : Promise.reject(new Error(`Dsl HTTP ${r.status}`))),
     ]);
     if (gasResult.status === 'rejected') console.warn(`  [BR] gas CSV failed: ${gasResult.reason.message}`);
@@ -434,10 +450,7 @@ async function fetchNewZealand() {
   const url = 'https://www.mbie.govt.nz/assets/Data-Files/Energy/Weekly-fuel-price-monitoring/weekly-table.csv';
   try {
     console.log(`  [NZ] CSV: ${url}`);
-    const resp = await globalThis.fetch(url, {
-      headers: { 'User-Agent': CHROME_UA },
-      signal: AbortSignal.timeout(20000),
-    });
+    const resp = await fetchWithProxyFallback(url);
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     const text = await resp.text();
     const lines = text.split('\n').map(l => l.trim()).filter(Boolean);

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -263,7 +263,9 @@ async function fetchBudgetLabEffectiveTariffRate() {
     const html = await resp.text();
     const parsed = parseBudgetLabEffectiveTariffHtml(html);
     if (!parsed) {
-      console.warn('  Budget Lab tariffs: effective tariff rate not found in page content');
+      const hasBody = html.length > 5000 && /<body/i.test(html);
+      const reason = hasBody ? 'page structure changed' : 'JS-rendered SPA (no static content)';
+      console.log(`  Budget Lab tariffs: skipped (${reason})`);
       return null;
     }
     console.log(`  Budget Lab effective tariff: ${parsed.tariffRate.toFixed(1)}%${parsed.observationPeriod ? ` (${parsed.observationPeriod})` : ''}`);


### PR DESCRIPTION
## Summary

- **FRED proxy-first**: Switch `fredFetchJson()` to try proxy before direct. Railway IPs consistently timeout on FRED (5/5 direct fetches timeout per run, ~20s wasted each), proxy works reliably.
- **Fuel price proxy fallback**: Add `fetchWithProxyFallback()` for NZ (HTTP 403), BR (fetch failed), MX (fetch failed) government APIs that block datacenter IPs.
- **FOMC parser fix**: Add Strategy B for new Fed page HTML structure where year is in heading (`2026 FOMC Meetings`) and month/dates are in separate elements. Fixes `Cannot read properties of undefined (reading 'padStart')` every run.
- **ECB parser fix**: Add Strategy B (DD/MM/YYYY format) and Strategy C (ISO dates in text) for changed ECB calendar page structure. Fixes `no dates parsed from ECB page` every run.
- **Budget Lab noise reduction**: Downgrade warning to log for known JS-rendered SPA limitation. Was emitting `effective tariff rate not found` warning every run despite being expected behavior.

## Test plan

- [ ] Verify FRED fetches succeed via proxy on Railway (check seed logs for `[fredFetch] proxy` path)
- [ ] Verify NZ/BR/MX fuel prices appear in seed output (check for proxy fallback messages)
- [ ] Verify FOMC dates parse correctly from live federalreserve.gov page
- [ ] Verify ECB dates parse correctly from live ecb.europa.eu page
- [ ] Confirm Budget Lab now logs at info level instead of warn