### PR TITLE
fix(supply-chain): UX polish + multi-sector exposure + dependency badges

### DIFF
--- a/scripts/seed-hs2-chokepoint-exposure.mjs
+++ b/scripts/seed-hs2-chokepoint-exposure.mjs
@@ -25,8 +25,19 @@ export const TTL_SECONDS = 172800; // 48h — 2× daily cron interval
 const LOCK_DOMAIN = 'supply_chain:chokepoint-exposure';
 const LOCK_TTL_MS = 5 * 60 * 1000;
 
-// HS2 chapters to pre-seed. '27' = energy/mineral fuels (primary use case).
-const HS2_CODES = ['27'];
+// Top 10 HS2 chapters by global trade volume and strategic importance.
+const HS2_CODES = [
+  '27', // Mineral Fuels (energy)
+  '84', // Machinery & Mechanical Appliances
+  '85', // Electrical Machinery & Electronics
+  '87', // Vehicles
+  '30', // Pharmaceuticals
+  '72', // Iron & Steel
+  '39', // Plastics
+  '29', // Organic Chemicals
+  '10', // Cereals (food security)
+  '62', // Apparel (textiles)
+];
 
 // Lightweight copy of the chokepoint registry fields needed for exposure computation.
 // Kept in sync with src/config/chokepoint-registry.ts — update both together.

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -48,7 +48,7 @@ import { toFlagEmoji } from '@/utils/country-flag';
 import { iso2ToIso3, iso2ToUnCode } from '@/utils/country-codes';
 import { buildDependencyGraph } from '@/services/infrastructure-cascade';
 import { getActiveFrameworkForPanel, subscribeFrameworkChange } from '@/services/analysis-framework-store';
-import { fetchCountryChokepointIndex } from '@/services/supply-chain';
+import { fetchCountryChokepointIndex, fetchMultiSectorExposure } from '@/services/supply-chain';
 
 type IntlDisplayNamesCtor = new (
   locales: string | string[],
@@ -403,11 +403,23 @@ export class CountryIntelManager implements AppModule {
         this.ctx.countryBriefPage.updateMaritimeActivity?.({ available: false, ports: [], fetchedAt: '' });
       });
 
-    // hs2='27' (mineral fuels) is the default; omit explicit arg to use the function default
-    fetchCountryChokepointIndex(code)
-      .then((result) => {
+    // Fetch multi-sector exposure (all 10 seeded HS2 codes in parallel)
+    fetchMultiSectorExposure(code)
+      .then((sectors) => {
         if (this.ctx.countryBriefPage?.getCode() !== code) return;
-        this.ctx.countryBriefPage.updateTradeExposure?.(result);
+        // Pass the original single-sector result for backward compat, plus the multi-sector data
+        if (sectors.length === 0) {
+          this.ctx.countryBriefPage.updateTradeExposure?.(null);
+        } else {
+          // Build a compat response from the energy sector (hs2=27) or first available
+          const energySector = sectors.find(s => s.hs2 === '27');
+          fetchCountryChokepointIndex(code, energySector ? '27' : sectors[0]!.hs2)
+            .then(result => {
+              if (this.ctx.countryBriefPage?.getCode() !== code) return;
+              this.ctx.countryBriefPage.updateTradeExposure?.(result, sectors);
+            })
+            .catch(() => this.ctx.countryBriefPage?.updateTradeExposure?.(null));
+        }
       })
       .catch(() => {
         if (this.ctx.countryBriefPage?.getCode() !== code) return;

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -48,7 +48,7 @@ import { toFlagEmoji } from '@/utils/country-flag';
 import { iso2ToIso3, iso2ToUnCode } from '@/utils/country-codes';
 import { buildDependencyGraph } from '@/services/infrastructure-cascade';
 import { getActiveFrameworkForPanel, subscribeFrameworkChange } from '@/services/analysis-framework-store';
-import { fetchCountryChokepointIndex, fetchMultiSectorExposure } from '@/services/supply-chain';
+import { fetchMultiSectorExposure } from '@/services/supply-chain';
 
 type IntlDisplayNamesCtor = new (
   locales: string | string[],
@@ -407,19 +407,27 @@ export class CountryIntelManager implements AppModule {
     fetchMultiSectorExposure(code)
       .then((sectors) => {
         if (this.ctx.countryBriefPage?.getCode() !== code) return;
-        // Pass the original single-sector result for backward compat, plus the multi-sector data
         if (sectors.length === 0) {
           this.ctx.countryBriefPage.updateTradeExposure?.(null);
-        } else {
-          // Build a compat response from the energy sector (hs2=27) or first available
-          const energySector = sectors.find(s => s.hs2 === '27');
-          fetchCountryChokepointIndex(code, energySector ? '27' : sectors[0]!.hs2)
-            .then(result => {
-              if (this.ctx.countryBriefPage?.getCode() !== code) return;
-              this.ctx.countryBriefPage.updateTradeExposure?.(result, sectors);
-            })
-            .catch(() => this.ctx.countryBriefPage?.updateTradeExposure?.(null));
+          return;
         }
+        // Build a synthetic compat response from sector data (no extra fetch needed)
+        const top = sectors[0]!;
+        const syntheticResponse = {
+          iso2: code,
+          hs2: top.hs2,
+          exposures: sectors.slice(0, 3).map(s => ({
+            chokepointId: s.primaryChokepointId,
+            chokepointName: s.primaryChokepointName,
+            exposureScore: s.exposureScore,
+            coastSide: '',
+            shockSupported: s.hs2 === '27',
+          })),
+          primaryChokepointId: top.primaryChokepointId,
+          vulnerabilityIndex: top.vulnerabilityIndex,
+          fetchedAt: new Date().toISOString(),
+        };
+        this.ctx.countryBriefPage.updateTradeExposure?.(syntheticResponse, sectors);
       })
       .catch(() => {
         if (this.ctx.countryBriefPage?.getCode() !== code) return;

--- a/src/components/CountryBriefPanel.ts
+++ b/src/components/CountryBriefPanel.ts
@@ -2,7 +2,7 @@ import type { CountryBriefSignals } from '@/types';
 import type { CountryScore } from '@/services/country-instability';
 import type { PredictionMarket } from '@/services/prediction';
 import type { NewsItem } from '@/types';
-import type { GetCountryChokepointIndexResponse } from '@/services/supply-chain';
+import type { GetCountryChokepointIndexResponse, SectorExposureSummary } from '@/services/supply-chain';
 
 export interface CountryIntelData {
   brief: string;
@@ -183,7 +183,7 @@ export interface CountryBriefPanel {
   updateCountryFacts?(data: CountryFactsData): void;
   updateEnergyProfile?(data: CountryEnergyProfileData): void;
   updateMaritimeActivity?(data: CountryPortActivityData): void;
-  updateTradeExposure?(data: GetCountryChokepointIndexResponse | null): void;
+  updateTradeExposure?(data: GetCountryChokepointIndexResponse | null, sectors?: SectorExposureSummary[]): void;
   maximize?(): void;
   minimize?(): void;
   getIsMaximized?(): boolean;

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -26,7 +26,7 @@ import type {
   CountryEnergyProfileData,
   CountryPortActivityData,
 } from './CountryBriefPanel';
-import type { GetCountryChokepointIndexResponse } from '@/services/supply-chain';
+import type { GetCountryChokepointIndexResponse, SectorExposureSummary } from '@/services/supply-chain';
 import type { MapContainer } from './MapContainer';
 import { ResilienceWidget } from './ResilienceWidget';
 import { toApiUrl } from '@/services/runtime';
@@ -1290,7 +1290,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     }
   }
 
-  public updateTradeExposure(data: GetCountryChokepointIndexResponse | null): void {
+  public updateTradeExposure(data: GetCountryChokepointIndexResponse | null, sectors?: SectorExposureSummary[]): void {
     if (!this.tradeExposureBody) return;
 
     if (data == null || data.exposures.length === 0) {
@@ -1301,28 +1301,74 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
 
     this.tradeExposureBody.replaceChildren();
 
+    // Vulnerability index header
     const vulnDiv = this.el('div', 'cdp-vuln-index', `Vulnerability: ${Math.round(data.vulnerabilityIndex)}/100`);
     this.tradeExposureBody.append(vulnDiv);
 
-    const sorted = [...data.exposures].sort((a, b) => b.exposureScore - a.exposureScore).slice(0, 3);
-    const table = this.el('table', 'cdp-trade-exposure-table');
-    const tbody = this.el('tbody');
-    for (const entry of sorted) {
-      const tr = this.el('tr');
-      const nameCell = this.el('td', 'cdp-chokepoint-name');
-      nameCell.textContent = entry.chokepointName || entry.chokepointId.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-      const barWrap = this.el('td', 'cdp-exposure-bar-wrap');
-      const bar = this.el('div', 'cdp-exposure-bar');
-      bar.style.width = `${Math.min(entry.exposureScore, 100)}%`;
-      barWrap.append(bar);
-      const pctCell = this.el('td', 'cdp-exposure-pct', `${entry.exposureScore.toFixed(1)}%`);
-      tr.append(nameCell, barWrap, pctCell);
-      tbody.append(tr);
-    }
-    table.append(tbody);
-    this.tradeExposureBody.append(table);
+    // Sector-by-chokepoint matrix (if multi-sector data available)
+    if (sectors && sectors.length > 0) {
+      const sectorLabel = this.el('div', 'cdp-section-sublabel', 'Sector exposure by primary chokepoint');
+      this.tradeExposureBody.append(sectorLabel);
 
-    const footer = this.el('div', 'cdp-card-footer', 'Source: Comtrade \u00B7 HS2 sectors');
+      const table = this.el('table', 'cdp-trade-exposure-table');
+      const thead = this.el('thead');
+      const headerRow = this.el('tr');
+      headerRow.append(this.el('th', '', 'Sector'));
+      headerRow.append(this.el('th', '', 'Chokepoint'));
+      headerRow.append(this.el('th', 'cdp-exposure-score-header', 'Risk'));
+      thead.append(headerRow);
+      table.append(thead);
+
+      const FLAG_LABELS: Record<string, { text: string; cls: string }> = {
+        SINGLE_SOURCE_CRITICAL:   { text: 'Single Source',   cls: 'cdp-dep-critical' },
+        SINGLE_CORRIDOR_CRITICAL: { text: 'Single Corridor', cls: 'cdp-dep-critical' },
+        COMPOUND_RISK:            { text: 'Compound Risk',   cls: 'cdp-dep-compound' },
+        DIVERSIFIABLE:            { text: 'Diversifiable',   cls: 'cdp-dep-ok' },
+      };
+
+      const tbody = this.el('tbody');
+      for (const s of sectors.slice(0, 10)) {
+        const tr = this.el('tr');
+        const sectorCell = this.el('td', 'cdp-sector-label');
+        sectorCell.textContent = s.label;
+        const flag = FLAG_LABELS[s.dependencyFlag];
+        if (flag) {
+          const badge = this.el('span', `cdp-dep-badge ${flag.cls}`, flag.text);
+          sectorCell.append(document.createTextNode(' '), badge);
+        }
+        const cpCell = this.el('td', 'cdp-chokepoint-name');
+        cpCell.textContent = s.primaryChokepointName;
+        const scoreCell = this.el('td', 'cdp-exposure-score');
+        const scoreColor = s.exposureScore >= 70 ? 'var(--danger, #ef4444)' : s.exposureScore > 30 ? 'var(--warning, #f59e0b)' : 'var(--text-muted, #64748b)';
+        scoreCell.textContent = `${s.exposureScore.toFixed(0)}`;
+        scoreCell.style.color = scoreColor;
+        tr.append(sectorCell, cpCell, scoreCell);
+        tbody.append(tr);
+      }
+      table.append(tbody);
+      this.tradeExposureBody.append(table);
+    } else {
+      // Fallback: original chokepoint-only bars
+      const sorted = [...data.exposures].sort((a, b) => b.exposureScore - a.exposureScore).slice(0, 3);
+      const table = this.el('table', 'cdp-trade-exposure-table');
+      const tbody = this.el('tbody');
+      for (const entry of sorted) {
+        const tr = this.el('tr');
+        const nameCell = this.el('td', 'cdp-chokepoint-name');
+        nameCell.textContent = entry.chokepointName || entry.chokepointId.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+        const barWrap = this.el('td', 'cdp-exposure-bar-wrap');
+        const bar = this.el('div', 'cdp-exposure-bar');
+        bar.style.width = `${Math.min(entry.exposureScore, 100)}%`;
+        barWrap.append(bar);
+        const pctCell = this.el('td', 'cdp-exposure-pct', `${entry.exposureScore.toFixed(1)}`);
+        tr.append(nameCell, barWrap, pctCell);
+        tbody.append(tr);
+      }
+      table.append(tbody);
+      this.tradeExposureBody.append(table);
+    }
+
+    const footer = this.el('div', 'cdp-card-footer', 'Source: Comtrade \u00B7 HS2 sectors \u00B7 Scores indicate route overlap, not share');
     this.tradeExposureBody.append(footer);
   }
 

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -29,6 +29,13 @@ import type {
 import type { GetCountryChokepointIndexResponse, SectorExposureSummary } from '@/services/supply-chain';
 import type { MapContainer } from './MapContainer';
 import { ResilienceWidget } from './ResilienceWidget';
+
+const DEPENDENCY_FLAG_LABELS: Record<string, { text: string; cls: string }> = {
+  DEPENDENCY_FLAG_SINGLE_SOURCE_CRITICAL:   { text: 'Single Source',   cls: 'cdp-dep-critical' },
+  DEPENDENCY_FLAG_SINGLE_CORRIDOR_CRITICAL: { text: 'Single Corridor', cls: 'cdp-dep-critical' },
+  DEPENDENCY_FLAG_COMPOUND_RISK:            { text: 'Compound Risk',   cls: 'cdp-dep-compound' },
+  DEPENDENCY_FLAG_DIVERSIFIABLE:            { text: 'Diversifiable',   cls: 'cdp-dep-ok' },
+};
 import { toApiUrl } from '@/services/runtime';
 import type { ComputeEnergyShockScenarioResponse, ProductImpact } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 
@@ -1319,19 +1326,12 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
       thead.append(headerRow);
       table.append(thead);
 
-      const FLAG_LABELS: Record<string, { text: string; cls: string }> = {
-        DEPENDENCY_FLAG_SINGLE_SOURCE_CRITICAL:   { text: 'Single Source',   cls: 'cdp-dep-critical' },
-        DEPENDENCY_FLAG_SINGLE_CORRIDOR_CRITICAL: { text: 'Single Corridor', cls: 'cdp-dep-critical' },
-        DEPENDENCY_FLAG_COMPOUND_RISK:            { text: 'Compound Risk',   cls: 'cdp-dep-compound' },
-        DEPENDENCY_FLAG_DIVERSIFIABLE:            { text: 'Diversifiable',   cls: 'cdp-dep-ok' },
-      };
-
       const tbody = this.el('tbody');
       for (const s of sectors.slice(0, 10)) {
         const tr = this.el('tr');
         const sectorCell = this.el('td', 'cdp-sector-label');
         sectorCell.textContent = s.label;
-        const flag = FLAG_LABELS[s.dependencyFlag];
+        const flag = DEPENDENCY_FLAG_LABELS[s.dependencyFlag];
         if (flag) {
           const badge = this.el('span', `cdp-dep-badge ${flag.cls}`, flag.text);
           sectorCell.append(document.createTextNode(' '), badge);

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -1320,10 +1320,10 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
       table.append(thead);
 
       const FLAG_LABELS: Record<string, { text: string; cls: string }> = {
-        SINGLE_SOURCE_CRITICAL:   { text: 'Single Source',   cls: 'cdp-dep-critical' },
-        SINGLE_CORRIDOR_CRITICAL: { text: 'Single Corridor', cls: 'cdp-dep-critical' },
-        COMPOUND_RISK:            { text: 'Compound Risk',   cls: 'cdp-dep-compound' },
-        DIVERSIFIABLE:            { text: 'Diversifiable',   cls: 'cdp-dep-ok' },
+        DEPENDENCY_FLAG_SINGLE_SOURCE_CRITICAL:   { text: 'Single Source',   cls: 'cdp-dep-critical' },
+        DEPENDENCY_FLAG_SINGLE_CORRIDOR_CRITICAL: { text: 'Single Corridor', cls: 'cdp-dep-critical' },
+        DEPENDENCY_FLAG_COMPOUND_RISK:            { text: 'Compound Risk',   cls: 'cdp-dep-compound' },
+        DEPENDENCY_FLAG_DIVERSIFIABLE:            { text: 'Diversifiable',   cls: 'cdp-dep-ok' },
       };
 
       const tbody = this.el('tbody');

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -5442,7 +5442,7 @@ export class DeckGLMap {
     this.tradeRouteSegments = initialSegments.map(seg => {
       const waypoints = ROUTE_WAYPOINTS_MAP.get(seg.routeId) ?? [];
       const maxScore = waypoints.reduce((max, id) => Math.max(max, scoreMap.get(id) ?? 0), 0);
-      const status: TradeRouteStatus = maxScore > 70 ? 'disrupted' : maxScore > 30 ? 'high_risk' : 'active';
+      const status: TradeRouteStatus = maxScore >= 70 ? 'disrupted' : maxScore > 30 ? 'high_risk' : 'active';
       return { ...seg, status };
     });
     this.render();

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -53,7 +53,7 @@ function renderSectorRing(sectors: Array<{ label: string; share: number; color: 
     cumulativeOffset += dash;
     return segment;
   });
-  const legend = sectors.map(s => `<span class="sector-legend-item"><span class="sector-dot" style="background:${s.color}"></span>${escapeHtml(s.label)}&nbsp;${s.share}%</span>`).join('');
+  const legend = sectors.map(s => `<span class="sector-legend-item"><span class="sector-dot" style="background:${s.color}"></span>${escapeHtml(s.label)}&nbsp;${s.share}%</span>`).join(' \u00B7 ');
   return `
     <div class="sector-ring-wrap">
       <svg width="72" height="72" viewBox="0 0 72 72" style="transform:rotate(-90deg)">${segments.join('')}</svg>
@@ -1297,8 +1297,8 @@ export class MapPopup {
     const isPro = hasPremiumAccess(getAuthState());
     const sectors = CHOKEPOINT_HS2_SECTORS[waterway.chokepointId];
 
-    // Sector mix is always visible (static data, drives engagement)
-    const sectorSection = sectors
+    // Sector mix: only show the compact SVG ring for free users (PRO users get the full HS2RingChart below)
+    const sectorSection = (sectors && !isPro)
       ? `<div class="popup-section-title" style="margin-top:10px;font-size:10px;text-transform:uppercase;opacity:.6;letter-spacing:.06em">Trade Sector Mix</div>
          ${renderSectorRing(sectors)}`
       : '';

--- a/src/components/SupplyChainPanel.ts
+++ b/src/components/SupplyChainPanel.ts
@@ -52,6 +52,7 @@ export class SupplyChainPanel extends Panel {
         }
         return;
       }
+      if ((e.target as HTMLElement).closest('.sc-scenario-trigger')) return;
       const card = (e.target as HTMLElement).closest('.trade-restriction-card') as HTMLElement | null;
       if (card?.dataset.cpId) {
         const newId = this.expandedChokepoint === card.dataset.cpId ? null : card.dataset.cpId;
@@ -319,7 +320,7 @@ export class SupplyChainPanel extends Panel {
         const warRiskBadge = `<span class="sc-war-risk-badge sc-war-risk-badge--${tierClass[tier] ?? 'normal'}">${tierLabel[tier] ?? 'Normal'}</span>`;
 
         const bypassSection = expanded
-          ? `<div class="sc-bypass-section" data-bypass-cp="${escapeHtml(cp.id)}"><div class="sc-bypass-loading">Loading bypass options\u2026</div></div>`
+          ? `<div class="sc-bypass-section" data-bypass-cp="${escapeHtml(cp.id)}"><div class="sc-bypass-heading">Bypass Options</div><div class="sc-bypass-loading">Loading bypass options\u2026</div></div>`
           : '';
 
         const scenarioSection = expanded ? (() => {

--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -121,6 +121,59 @@ export async function fetchCountryChokepointIndex(
   }
 }
 
+/** Top 10 HS2 sectors seeded for chokepoint exposure. */
+export const SEEDED_HS2_CODES = ['27', '84', '85', '87', '30', '72', '39', '29', '10', '62'] as const;
+
+/** Short labels for display. */
+export const HS2_SHORT_LABELS: Record<string, string> = {
+  '27': 'Energy', '84': 'Machinery', '85': 'Electronics', '87': 'Vehicles',
+  '30': 'Pharma', '72': 'Iron & Steel', '39': 'Plastics', '29': 'Chemicals',
+  '10': 'Cereals', '62': 'Apparel',
+};
+
+export interface SectorExposureSummary {
+  hs2: string;
+  label: string;
+  primaryChokepointId: string;
+  primaryChokepointName: string;
+  exposureScore: number;
+  vulnerabilityIndex: number;
+  dependencyFlag: string;
+  primaryExporterIso2: string;
+  primaryExporterShare: number;
+}
+
+/**
+ * Fetch chokepoint exposure + dependency flags for all seeded sectors in parallel.
+ * Returns sorted by vulnerability index descending.
+ */
+export async function fetchMultiSectorExposure(iso2: string): Promise<SectorExposureSummary[]> {
+  const [exposureResults, depResults] = await Promise.all([
+    Promise.all(SEEDED_HS2_CODES.map(hs2 => fetchCountryChokepointIndex(iso2, hs2))),
+    Promise.all(SEEDED_HS2_CODES.map(hs2 => fetchSectorDependency(iso2, hs2))),
+  ]);
+
+  const depMap = new Map(depResults.map(d => [d.hs2, d]));
+
+  return exposureResults
+    .filter(r => r.exposures.length > 0)
+    .map(r => {
+      const dep = depMap.get(r.hs2);
+      return {
+        hs2: r.hs2,
+        label: HS2_SHORT_LABELS[r.hs2] ?? r.hs2,
+        primaryChokepointId: r.primaryChokepointId,
+        primaryChokepointName: r.exposures[0]?.chokepointName ?? r.primaryChokepointId,
+        exposureScore: r.exposures[0]?.exposureScore ?? 0,
+        vulnerabilityIndex: r.vulnerabilityIndex,
+        dependencyFlag: dep?.flags?.[0] ?? '',
+        primaryExporterIso2: dep?.primaryExporterIso2 ?? '',
+        primaryExporterShare: dep?.primaryExporterShare ?? 0,
+      };
+    })
+    .sort((a, b) => b.vulnerabilityIndex - a.vulnerabilityIndex);
+}
+
 export async function fetchBypassOptions(
   chokepointId: string,
   cargoType: CargoType = 'container',

--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -144,14 +144,17 @@ export interface SectorExposureSummary {
 }
 
 /**
- * Fetch chokepoint exposure + dependency flags for all seeded sectors in parallel.
- * Returns sorted by vulnerability index descending.
+ * Fetch chokepoint exposure + dependency flags for all seeded sectors.
+ * Exposure fetched first (10 requests), then dependency only for sectors with data (fewer requests).
  */
 export async function fetchMultiSectorExposure(iso2: string): Promise<SectorExposureSummary[]> {
-  const [exposureResults, depResults] = await Promise.all([
-    Promise.all(SEEDED_HS2_CODES.map(hs2 => fetchCountryChokepointIndex(iso2, hs2))),
-    Promise.all(SEEDED_HS2_CODES.map(hs2 => fetchSectorDependency(iso2, hs2))),
-  ]);
+  const exposureResults = await Promise.all(
+    SEEDED_HS2_CODES.map(hs2 => fetchCountryChokepointIndex(iso2, hs2)),
+  );
+  const activeCodes = exposureResults.filter(r => r.exposures.length > 0).map(r => r.hs2);
+  const depResults = activeCodes.length > 0
+    ? await Promise.all(activeCodes.map(hs2 => fetchSectorDependency(iso2, hs2)))
+    : [];
 
   const depMap = new Map(depResults.map(d => [d.hs2, d]));
 

--- a/src/styles/country-deep-dive.css
+++ b/src/styles/country-deep-dive.css
@@ -1108,11 +1108,21 @@
 .cdp-facts-grid .cdp-fact-label { color: var(--cdp-muted); text-transform: uppercase; font-size: 0.65rem; }
 
 .cdp-vuln-index { font-size: 13px; color: #94a3b8; margin-bottom: 8px; }
+.cdp-section-sublabel { font-size: 10px; color: #64748b; margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.04em; }
 .cdp-trade-exposure-table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 8px; }
-.cdp-chokepoint-name { color: #cbd5e1; padding: 3px 0; width: 45%; }
+.cdp-trade-exposure-table th { color: #64748b; font-weight: 500; padding: 3px 0; text-align: left; border-bottom: 1px solid rgba(100,116,139,0.15); font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em; }
+.cdp-trade-exposure-table th.cdp-exposure-score-header { text-align: right; }
+.cdp-chokepoint-name { color: #cbd5e1; padding: 3px 0; }
+.cdp-sector-label { color: #e2e8f0; padding: 3px 0; font-weight: 500; }
+.cdp-exposure-score { text-align: right; padding: 3px 0; font-weight: 600; font-variant-numeric: tabular-nums; }
+.cdp-trade-exposure-table tbody tr { border-bottom: 1px solid rgba(100,116,139,0.08); }
 .cdp-exposure-bar-wrap { width: 40%; padding: 3px 6px; }
 .cdp-exposure-bar { height: 6px; background: linear-gradient(90deg, #3b82f6, #60a5fa); border-radius: 3px; min-width: 2px; }
 .cdp-exposure-pct { color: #64748b; text-align: right; font-size: 11px; white-space: nowrap; }
+.cdp-dep-badge { display: inline-block; font-size: 9px; padding: 1px 5px; border-radius: 3px; margin-left: 4px; font-weight: 600; vertical-align: middle; letter-spacing: 0.02em; }
+.cdp-dep-critical { background: rgba(220,38,38,0.12); color: #f87171; }
+.cdp-dep-compound { background: rgba(220,38,38,0.18); color: #ef4444; }
+.cdp-dep-ok { background: rgba(34,197,94,0.12); color: #4ade80; }
 .cdp-card-footer { font-size: 10px; color: #475569; margin-top: 6px; }
 
 .cdp-pro-locked {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -7237,18 +7237,20 @@ a.prediction-link:hover {
 
 .popup-hs2-ring-container {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
+  gap: 12px;
   padding: 6px 0;
 }
 
 .popup-hs2-ring-canvas {
   display: block;
+  flex-shrink: 0;
 }
 
 .popup-hs2-ring-legend {
-  width: 100%;
-  margin-top: 6px;
+  flex: 1;
+  min-width: 0;
 }
 
 .popup-hs2-ring-legend-item {
@@ -7277,6 +7279,32 @@ a.prediction-link:hover {
 .popup-hs2-ring-pct {
   color: var(--text-muted, #64748b);
   font-size: 10px;
+}
+
+.sector-ring-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 0;
+}
+
+.sector-legend {
+  font-size: 11px;
+  color: var(--text-secondary, #cbd5e1);
+  line-height: 1.6;
+}
+
+.sector-legend-item {
+  white-space: nowrap;
+}
+
+.sector-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 4px;
+  vertical-align: middle;
 }
 
 /* Collapsible sections */

--- a/src/styles/supply-chain-panel.css
+++ b/src/styles/supply-chain-panel.css
@@ -14,6 +14,7 @@
 .sc-war-risk-badge--normal { background: rgba(100,116,139,0.1); color: #94a3b8; border: 1px solid rgba(100,116,139,0.2); }
 
 .sc-bypass-section { margin-top: 10px; }
+.sc-bypass-heading { font-size: 11px; font-weight: 600; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; }
 .sc-bypass-table { width: 100%; border-collapse: collapse; font-size: 12px; }
 .sc-bypass-table th { color: #64748b; font-weight: 500; padding: 4px 6px; text-align: left; border-bottom: 1px solid rgba(100,116,139,0.15); }
 .sc-bypass-table td { padding: 4px 6px; border-bottom: 1px solid rgba(100,116,139,0.08); }

--- a/src/utils/hs2-ring-chart.ts
+++ b/src/utils/hs2-ring-chart.ts
@@ -10,11 +10,11 @@ export class HS2RingChart {
 
     const total = sectors.reduce((s, e) => s + e.share, 0) || 1;
 
-    const size = 110;
+    const size = 80;
     const cx = size / 2;
     const cy = size / 2;
-    const r = 42;
-    const innerR = 24;
+    const r = 34;
+    const innerR = 18;
 
     const dpr = window.devicePixelRatio || 1;
     const canvas = document.createElement('canvas');


### PR DESCRIPTION
## Summary
- Fix Simulate Closure button collapsing the expanded chokepoint card
- Add missing Bypass Options section heading
- Remove redundant double donut in chokepoint popup (PRO users see one clean chart)
- Side-by-side donut + legend layout
- Arc coloring threshold fix (>= 70 for red, was > 70)
- Expand HS2 seeder from 1 to 10 sectors
- Trade Exposure card now shows sector-by-chokepoint matrix with dependency flags
- Wire get-sector-dependency into UI with color-coded badges

## Test plan
- [ ] Expand a chokepoint card, click Simulate Closure, card stays expanded
- [ ] Bypass table shows "Bypass Options" heading above it
- [ ] PRO user chokepoint popup shows one donut (side-by-side with legend), not two
- [ ] Hormuz arcs show red (disruption 70/100)
- [ ] Click country (US/CN/IN/IR/RU/TW), Trade Exposure shows 10 sectors with chokepoint + dependency badge
- [ ] npm run typecheck + typecheck:api pass