### PR TITLE
fix(settings): show locked Notifications [PRO] section for all non-PRO users

### DIFF
--- a/src/services/preferences-content.ts
+++ b/src/services/preferences-content.ts
@@ -27,7 +27,7 @@ import {
   type DigestMode,
 } from '@/services/notification-channels';
 import { getCurrentClerkUser } from '@/services/clerk';
-import { hasTier, getEntitlementState } from '@/services/entitlements';
+import { hasTier } from '@/services/entitlements';
 import { SITE_VARIANT } from '@/config/variant';
 // When VITE_QUIET_HOURS_BATCH_ENABLED=0 the relay does not honour batch_on_wake.
 // Hide that option so users cannot select a mode that silently behaves as critical_only.
@@ -359,20 +359,22 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
   html += `</div></details>`;
 
   // ── Notifications group (web-only) ──
+  // Three states: (a) confirmed PRO → full UI, (b) everything else → locked [PRO] section.
+  // When entitlements haven't loaded yet (null), show locked to avoid flashing full UI to free users.
   if (!host.isDesktopApp) {
-    if (!host.isSignedIn || (getEntitlementState() !== null && !hasTier(1))) {
-      html += `<details class="wm-pref-group">`;
-      html += `<summary>Notifications <span class="panel-toggle-pro-badge">PRO</span></summary>`;
-      html += `<div class="wm-pref-group-content">`;
-      html += `<div class="ai-flow-toggle-desc">Get real-time intelligence alerts delivered to Telegram, Slack, Discord, and Email with configurable sensitivity, quiet hours, and digest scheduling.</div>`;
-      html += `<button type="button" class="panel-locked-cta" id="usNotifUpgradeBtn">Upgrade to Pro</button>`;
-      html += `</div></details>`;
-    } else if (host.isSignedIn && (getEntitlementState() === null || hasTier(1))) {
+    if (host.isSignedIn && hasTier(1)) {
       html += `<details class="wm-pref-group" id="usNotifGroup">`;
       html += `<summary>Notifications</summary>`;
       html += `<div class="wm-pref-group-content">`;
       html += `<div class="us-notif-loading" id="usNotifLoading">Loading...</div>`;
       html += `<div class="us-notif-content" id="usNotifContent" style="display:none"></div>`;
+      html += `</div></details>`;
+    } else {
+      html += `<details class="wm-pref-group">`;
+      html += `<summary>Notifications <span class="panel-toggle-pro-badge">PRO</span></summary>`;
+      html += `<div class="wm-pref-group-content">`;
+      html += `<div class="ai-flow-toggle-desc">Get real-time intelligence alerts delivered to Telegram, Slack, Discord, and Email with configurable sensitivity, quiet hours, and digest scheduling.</div>`;
+      html += `<button type="button" class="panel-locked-cta" id="usNotifUpgradeBtn">Upgrade to Pro</button>`;
       html += `</div></details>`;
     }
   }
@@ -625,8 +627,8 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
 
       if (!host.isDesktopApp) updateAiStatus(container);
 
-      // ── Notifications section ──
-      if (!host.isDesktopApp && (!host.isSignedIn || (getEntitlementState() !== null && !hasTier(1)))) {
+      // ── Notifications section: locked [PRO] upgrade button ──
+      if (!host.isDesktopApp && !(host.isSignedIn && hasTier(1))) {
         const upgradeBtn = container.querySelector<HTMLButtonElement>('#usNotifUpgradeBtn');
         if (upgradeBtn) {
           upgradeBtn.addEventListener('click', () => {
@@ -642,7 +644,8 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
           }, { signal });
         }
       }
-      if (!host.isDesktopApp && host.isSignedIn && (getEntitlementState() === null || hasTier(1))) {
+      // ── Notifications section: full PRO UI ──
+      if (!host.isDesktopApp && host.isSignedIn && hasTier(1)) {
         let notifPollInterval: ReturnType<typeof setInterval> | null = null;
 
         function clearNotifPoll(): void {

--- a/src/services/preferences-content.ts
+++ b/src/services/preferences-content.ts
@@ -358,18 +358,16 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
   </a>`;
   html += `</div></details>`;
 
-  // ── Notifications group (web-only, signed-in, PRO only) ──
+  // ── Notifications group (web-only) ──
   if (!host.isDesktopApp) {
-    if (!host.isSignedIn) {
-      html += `<div class="ai-flow-toggle-desc us-notif-signin">Sign in to link notification channels.</div>`;
-    } else if (getEntitlementState() !== null && !hasTier(1)) {
+    if (!host.isSignedIn || (getEntitlementState() !== null && !hasTier(1))) {
       html += `<details class="wm-pref-group">`;
       html += `<summary>Notifications <span class="panel-toggle-pro-badge">PRO</span></summary>`;
       html += `<div class="wm-pref-group-content">`;
       html += `<div class="ai-flow-toggle-desc">Get real-time intelligence alerts delivered to Telegram, Slack, Discord, and Email with configurable sensitivity, quiet hours, and digest scheduling.</div>`;
       html += `<button type="button" class="panel-locked-cta" id="usNotifUpgradeBtn">Upgrade to Pro</button>`;
       html += `</div></details>`;
-    } else {
+    } else if (host.isSignedIn && (getEntitlementState() === null || hasTier(1))) {
       html += `<details class="wm-pref-group" id="usNotifGroup">`;
       html += `<summary>Notifications</summary>`;
       html += `<div class="wm-pref-group-content">`;
@@ -628,10 +626,16 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
       if (!host.isDesktopApp) updateAiStatus(container);
 
       // ── Notifications section ──
-      if (!host.isDesktopApp && host.isSignedIn && getEntitlementState() !== null && !hasTier(1)) {
+      if (!host.isDesktopApp && (!host.isSignedIn || (getEntitlementState() !== null && !hasTier(1)))) {
         const upgradeBtn = container.querySelector<HTMLButtonElement>('#usNotifUpgradeBtn');
         if (upgradeBtn) {
           upgradeBtn.addEventListener('click', () => {
+            if (!host.isSignedIn) {
+              import('@/services/clerk').then(m => m.openSignIn()).catch(() => {
+                window.open('https://worldmonitor.app/pro', '_blank');
+              });
+              return;
+            }
             import('@/services/checkout').then(m => import('@/config/products').then(p => m.startCheckout(p.DEFAULT_UPGRADE_PRODUCT))).catch(() => {
               window.open('https://worldmonitor.app/pro', '_blank');
             });


### PR DESCRIPTION
## Summary

- Anonymous users, free-tier users, and users with unloaded entitlements now all see the Notifications section as a locked **[PRO]** details group with an "Upgrade to Pro" CTA button
- Previously, anonymous users saw plain text ("Sign in to link notification channels") and free users with unloaded entitlements could fall into the wrong rendering branch
- Anonymous users clicking "Upgrade to Pro" get the Clerk sign-in modal (`openSignIn()`) instead of the checkout flow

## Three user states

| User state | Before | After |
|---|---|---|
| **Anonymous** (not signed in) | Plain text "Sign in to link notification channels" | Locked [PRO] details group with upgrade CTA (opens sign-in) |
| **Free tier** (signed in, no PRO) | Locked [PRO] details group (when entitlements loaded) | Same locked [PRO] details group (upgrade CTA opens checkout) |
| **PRO subscriber** | Full notification channel management UI | No change |

## Changes

- `renderPreferences()` HTML: OR'd `!host.isSignedIn` with `getEntitlementState() !== null && !hasTier(1)` so both anonymous and free users render the locked PRO section
- `attach()` event handler: matching guard condition so the upgrade button is wired for both user types
- Anonymous click handler: calls `openSignIn()` from `clerk.ts` instead of starting checkout

## Test plan

- [ ] Open settings panel while signed out: verify Notifications shows as locked [PRO] with upgrade button
- [ ] Click upgrade button while signed out: verify Clerk sign-in modal appears
- [ ] Sign in as free user: verify Notifications still shows as locked [PRO] with upgrade button
- [ ] Click upgrade button as free user: verify checkout flow starts
- [ ] Sign in as PRO user: verify full Notifications management UI renders