### PR TITLE
perf(relay): batch PRO entitlement check instead of per-user-per-event

### DIFF
--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -683,16 +683,20 @@ async function processEvent(event) {
 
   if (matching.length === 0) return;
 
+  // Batch PRO check: resolve all unique userIds in parallel instead of one-by-one.
+  // isUserPro() has a 15-min Redis cache, so this is cheap after the first call.
+  const uniqueUserIds = [...new Set(matching.map(r => r.userId))];
+  const proResults = await Promise.all(uniqueUserIds.map(async uid => [uid, await isUserPro(uid)]));
+  const proSet = new Set(proResults.filter(([, isPro]) => isPro).map(([uid]) => uid));
+  const skippedCount = uniqueUserIds.length - proSet.size;
+  if (skippedCount > 0) console.log(`[relay] Skipping ${skippedCount} non-PRO user(s)`);
+
   const text = formatMessage(event);
   const subject = `WorldMonitor Alert: ${event.payload?.title ?? event.eventType}`;
   const eventSeverity = event.severity ?? 'high';
 
   for (const rule of matching) {
-    const pro = await isUserPro(rule.userId);
-    if (!pro) {
-      console.log(`[relay] Skipping ${rule.userId} — not PRO`);
-      continue;
-    }
+    if (!proSet.has(rule.userId)) continue;
 
     const quietAction = resolveQuietAction(rule, eventSeverity);
 


### PR DESCRIPTION
## Summary
- Replaces sequential per-user `isUserPro()` calls inside the per-rule delivery loop with a single batch `Promise.all` check before the loop
- Deduplicates userIds so each user is checked once, not once per matching rule
- Reduces log noise from N individual "Skipping userXXX" lines to 1 summary line showing the count of non-PRO users

## Why
With 7+ non-PRO users, every incoming event triggered 7 sequential Redis GETs and 7 noisy log lines. After this change, the same 7 checks happen in parallel (and hit the 15-min cache on subsequent events), and logs show a single `Skipping 7 non-PRO user(s)` line.

## Test plan
- [ ] Deploy to Railway staging, trigger a test event with multiple matching rules from non-PRO users
- [ ] Verify only 1 summary log line appears instead of N individual "Skipping" lines
- [ ] Verify PRO users still receive notifications as before
- [ ] Confirm no regression in quiet-hours or dedup behavior