### PR TITLE
fix(sentry): filter Convex connection-lost, WebGL shader, and minified constructor noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -321,7 +321,7 @@ Sentry.init({
       /\.(?:toLowerCase|trim|indexOf|findIndex) is not a function/.test(msg)
       || /Maximum call stack size exceeded/.test(msg)
       || /out of memory/i.test(msg)
-      || /^\w{1,2} is not a function/.test(msg)
+      || /^\w{1,2} is not a (?:function|constructor)/.test(msg)
       || /Cannot add property \w+, object is not extensible/.test(msg)
       || /^TypeError: Internal error$/.test(msg)
       || /NotSupportedError/.test(msg)
@@ -337,6 +337,8 @@ Sentry.init({
       || /^Operation timed out/.test(msg)
       || /signal timed out/.test(msg)
       || /Cannot inject key into script value/.test(msg)
+      || /Connection lost while action was in flight/.test(msg)
+      || /WEBGLRenderPipeline.*Link error/.test(msg)
     )) return null;
     return event;
   },


### PR DESCRIPTION
## Summary
- Extend `^\w{1,2} is not a function` to also match `is not a constructor` (M2, M5: Convex SDK init failure in Firefox/Linux)
- Add `Connection lost while action was in flight` filter (M4: Convex WebSocket reconnect during billing action, already has fallback)
- Add `WEBGLRenderPipeline.*Link error` filter (M3: GPU shader compilation failure on Edge/Windows)
- All in `beforeSend` with `!hasFirstParty` stack-gating (safe: won't suppress our own code)

## Test plan
- [ ] `npm run typecheck` passes
- [ ] Patterns only fire when no first-party stack frames exist