### PR TITLE
feat: Comtrade bilateral HS4 seeder and product imports UI

### DIFF
--- a/api/supply-chain/v1/country-products.ts
+++ b/api/supply-chain/v1/country-products.ts
@@ -1,0 +1,49 @@
+export const config = { runtime: 'edge' };
+
+import { isCallerPremium } from '../../../server/_shared/premium-check';
+// @ts-expect-error — JS module, no declaration file
+import { readJsonFromUpstash } from '../../_upstash-json.js';
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method !== 'GET') {
+    return new Response('', { status: 405 });
+  }
+
+  const isPro = await isCallerPremium(req);
+  if (!isPro) {
+    return new Response(
+      JSON.stringify({ error: 'PRO subscription required' }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const { searchParams } = new URL(req.url);
+  const iso2 = searchParams.get('iso2')?.toUpperCase();
+  if (!iso2 || !/^[A-Z]{2}$/.test(iso2)) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid or missing iso2 parameter' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const key = `comtrade:bilateral-hs4:${iso2}:v1`;
+
+  try {
+    const data = await readJsonFromUpstash(key, 5_000);
+    if (!data) {
+      return new Response(
+        JSON.stringify({ iso2, products: [], fetchedAt: '' }),
+        { status: 200, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=300' } },
+      );
+    }
+    return new Response(
+      JSON.stringify(data),
+      { status: 200, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=1800' } },
+    );
+  } catch {
+    return new Response(
+      JSON.stringify({ error: 'Failed to fetch product data' }),
+      { status: 502, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+}

--- a/api/supply-chain/v1/country-products.ts
+++ b/api/supply-chain/v1/country-products.ts
@@ -33,12 +33,19 @@ export default async function handler(req: Request): Promise<Response> {
     if (!data) {
       return new Response(
         JSON.stringify({ iso2, products: [], fetchedAt: '' }),
-        { status: 200, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=300' } },
+        { status: 200, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } },
       );
     }
     return new Response(
       JSON.stringify(data),
-      { status: 200, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=1800' } },
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'private, max-age=3600',
+          'Vary': 'Authorization, Cookie',
+        },
+      },
     );
   } catch {
     return new Response(

--- a/scripts/seed-comtrade-bilateral-hs4.mjs
+++ b/scripts/seed-comtrade-bilateral-hs4.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+
+// @ts-check
+
+import { createRequire } from 'node:module';
+import {
+  acquireLockSafely,
+  CHROME_UA,
+  extendExistingTtl,
+  getRedisCredentials,
+  loadEnvFile,
+  logSeedResult,
+  releaseLock,
+  sleep,
+} from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const META_KEY = 'seed-meta:comtrade:bilateral-hs4';
+const KEY_PREFIX = 'comtrade:bilateral-hs4:';
+const TTL_SECONDS = 259200; // 72h
+const LOCK_DOMAIN = 'comtrade:bilateral-hs4';
+const LOCK_TTL_MS = 30 * 60 * 1000; // 30 min
+const COMTRADE_BASE = 'https://comtradeapi.un.org/public/v1';
+const INTER_REQUEST_DELAY_MS = 3500;
+
+const HS4_CODES = [
+  '2709', '2711', '8542', '8517', '8703', '3004', '7108', '2710',
+  '8471', '8411', '7601', '7202', '3901', '2902', '1001', '1201',
+  '6204', '0203', '8704', '8708',
+];
+
+const HS4_LABELS = {
+  '2709': 'Crude Petroleum',
+  '2711': 'LNG & Petroleum Gas',
+  '8542': 'Semiconductors',
+  '8517': 'Smartphones & Telecom',
+  '8703': 'Passenger Vehicles',
+  '3004': 'Pharmaceuticals',
+  '7108': 'Gold',
+  '2710': 'Refined Petroleum',
+  '8471': 'Computers',
+  '8411': 'Turbojets & Turbines',
+  '7601': 'Aluminium',
+  '7202': 'Ferroalloys (Steel)',
+  '3901': 'Plastics (Polyethylene)',
+  '2902': 'Chemicals (Hydrocarbons)',
+  '1001': 'Wheat',
+  '1201': 'Soybeans',
+  '6204': 'Garments',
+  '0203': 'Pork',
+  '8704': 'Trucks',
+  '8708': 'Vehicle Parts',
+};
+
+const BATCH_1 = HS4_CODES.slice(0, 10);
+const BATCH_2 = HS4_CODES.slice(10);
+
+const require = createRequire(import.meta.url);
+/** @type {Record<string, {nearestRouteIds: string[], coastSide: string}>} */
+const COUNTRY_PORT_CLUSTERS = require('./shared/country-port-clusters.json');
+/** @type {Record<string, string>} */
+const UN_TO_ISO2 = require('./shared/un-to-iso2.json');
+
+const ISO2_TO_UN = Object.fromEntries(
+  Object.entries(UN_TO_ISO2).map(([un, iso2]) => [iso2, un]),
+);
+
+/**
+ * @param {Array<string[]>} commands
+ */
+async function redisPipeline(commands) {
+  const { url, token } = getRedisCredentials();
+  const resp = await fetch(`${url}/pipeline`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(commands),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    throw new Error(`Redis pipeline failed: HTTP ${resp.status} — ${text.slice(0, 200)}`);
+  }
+  return resp.json();
+}
+
+/**
+ * @param {string} reporterCode
+ * @param {string[]} hs4Batch
+ * @returns {Promise<Array<{cmdCode: string, partnerCode: string, primaryValue: number, year: number}>>}
+ */
+async function fetchBilateral(reporterCode, hs4Batch) {
+  const url = new URL(`${COMTRADE_BASE}/preview/C/A/HS`);
+  url.searchParams.set('reporterCode', reporterCode);
+  url.searchParams.set('cmdCode', hs4Batch.join(','));
+  url.searchParams.set('flowCode', 'M');
+
+  const resp = await fetch(url.toString(), {
+    headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+    signal: AbortSignal.timeout(20_000),
+  });
+
+  if (resp.status === 429) {
+    console.warn(`  429 rate-limited for reporter ${reporterCode}, waiting 60s...`);
+    await sleep(60_000);
+    const retry = await fetch(url.toString(), {
+      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (!retry.ok) return [];
+    const retryData = await retry.json();
+    return parseRecords(retryData);
+  }
+
+  if (!resp.ok) return [];
+  const data = await resp.json();
+  return parseRecords(data);
+}
+
+/**
+ * @param {unknown} data
+ * @returns {Array<{cmdCode: string, partnerCode: string, primaryValue: number, year: number}>}
+ */
+function parseRecords(data) {
+  const records = /** @type {any[]} */ (/** @type {any} */ (data)?.data ?? []);
+  if (!Array.isArray(records)) return [];
+  return records
+    .filter(r => r && Number(r.primaryValue ?? 0) > 0)
+    .map(r => ({
+      cmdCode: String(r.cmdCode ?? ''),
+      partnerCode: String(r.partnerCode ?? r.partner2Code ?? '000'),
+      primaryValue: Number(r.primaryValue ?? 0),
+      year: Number(r.period ?? r.refYear ?? 0),
+    }));
+}
+
+/**
+ * @param {Array<{cmdCode: string, partnerCode: string, primaryValue: number, year: number}>} records
+ * @returns {Array<{hs4: string, description: string, totalValue: number, topExporters: Array<{partnerCode: number, partnerIso2: string, value: number, share: number}>, year: number}>}
+ */
+function groupByProduct(records) {
+  /** @type {Map<string, Map<string, {value: number, year: number}>>} */
+  const byCode = new Map();
+  for (const r of records) {
+    if (!byCode.has(r.cmdCode)) byCode.set(r.cmdCode, new Map());
+    const partners = byCode.get(r.cmdCode);
+    const existing = partners.get(r.partnerCode);
+    if (!existing || r.primaryValue > existing.value) {
+      partners.set(r.partnerCode, { value: r.primaryValue, year: r.year });
+    }
+  }
+
+  const products = [];
+  for (const [hs4, partners] of byCode) {
+    const sorted = [...partners.entries()]
+      .sort((a, b) => b[1].value - a[1].value)
+      .filter(([pc]) => pc !== '0' && pc !== '000');
+    const totalValue = sorted.reduce((s, [, v]) => s + v.value, 0);
+    if (totalValue <= 0) continue;
+    const top5 = sorted.slice(0, 5);
+    const latestYear = Math.max(...sorted.map(([, v]) => v.year).filter(y => y > 0));
+    products.push({
+      hs4,
+      description: HS4_LABELS[hs4] ?? hs4,
+      totalValue,
+      topExporters: top5.map(([pc, v]) => ({
+        partnerCode: Number(pc),
+        partnerIso2: UN_TO_ISO2[pc.padStart(3, '0')] ?? '',
+        value: v.value,
+        share: Math.round((v.value / totalValue) * 1000) / 1000,
+      })),
+      year: latestYear || 2023,
+    });
+  }
+  return products.sort((a, b) => b.totalValue - a.totalValue);
+}
+
+export async function main() {
+  const startedAt = Date.now();
+  const runId = `${LOCK_DOMAIN}:${startedAt}`;
+  const lock = await acquireLockSafely(LOCK_DOMAIN, runId, LOCK_TTL_MS, { label: LOCK_DOMAIN });
+
+  const countries = Object.entries(COUNTRY_PORT_CLUSTERS)
+    .filter(([k]) => k !== '_comment' && k.length === 2);
+  const allKeys = countries.map(([iso2]) => `${KEY_PREFIX}${iso2}:v1`);
+
+  if (lock.skipped) {
+    await extendExistingTtl([...allKeys, META_KEY], TTL_SECONDS)
+      .catch(e => console.warn('[bilateral-hs4] TTL extension (skipped) failed:', e.message));
+    return;
+  }
+  if (!lock.locked) {
+    console.log('[bilateral-hs4] Lock held, skipping');
+    return;
+  }
+
+  const writeMeta = async (count, status = 'ok') => {
+    const meta = JSON.stringify({ fetchedAt: Date.now(), recordCount: count, status });
+    await redisPipeline([['SET', META_KEY, meta, 'EX', String(TTL_SECONDS * 3)]])
+      .catch(e => console.warn('[bilateral-hs4] Failed to write seed-meta:', e.message));
+  };
+
+  try {
+    console.log(`[bilateral-hs4] Fetching bilateral HS4 data for ${countries.length} countries × ${HS4_CODES.length} products...`);
+
+    const commands = [];
+    let writtenCount = 0;
+    let requestCount = 0;
+
+    for (let i = 0; i < countries.length; i++) {
+      const [iso2] = countries[i];
+      const unCode = ISO2_TO_UN[iso2];
+      if (!unCode) {
+        console.warn(`  ${iso2}: no UN code, skipping`);
+        continue;
+      }
+
+      if (requestCount > 0) await sleep(INTER_REQUEST_DELAY_MS);
+
+      let allRecords = [];
+      try {
+        console.log(`  [${i + 1}/${countries.length}] ${iso2} batch 1/2...`);
+        const batch1 = await fetchBilateral(unCode, BATCH_1);
+        allRecords.push(...batch1);
+        requestCount++;
+
+        await sleep(INTER_REQUEST_DELAY_MS);
+
+        console.log(`  [${i + 1}/${countries.length}] ${iso2} batch 2/2...`);
+        const batch2 = await fetchBilateral(unCode, BATCH_2);
+        allRecords.push(...batch2);
+        requestCount++;
+      } catch (err) {
+        console.warn(`  ${iso2}: fetch failed (${err.message})`);
+      }
+
+      const products = groupByProduct(allRecords);
+      const payload = JSON.stringify({
+        iso2,
+        products,
+        fetchedAt: new Date().toISOString(),
+      });
+      commands.push(['SET', `${KEY_PREFIX}${iso2}:v1`, payload, 'EX', String(TTL_SECONDS)]);
+      writtenCount++;
+
+      if (products.length > 0) {
+        console.log(`    ${iso2}: ${products.length} products, ${allRecords.length} records`);
+      }
+
+      if (commands.length >= 50) {
+        await redisPipeline(commands.splice(0));
+      }
+    }
+
+    if (commands.length > 0) {
+      await redisPipeline(commands);
+    }
+
+    await writeMeta(writtenCount);
+
+    logSeedResult('comtrade:bilateral-hs4', writtenCount, Date.now() - startedAt, {
+      countries: countries.length,
+      hs4Codes: HS4_CODES.length,
+      requests: requestCount,
+      ttlH: TTL_SECONDS / 3600,
+    });
+    console.log(`[bilateral-hs4] Seeded ${writtenCount} country keys`);
+  } catch (err) {
+    console.error('[bilateral-hs4] Seed failed:', err.message || err);
+    await extendExistingTtl([...allKeys, META_KEY], TTL_SECONDS)
+      .catch(e => console.warn('[bilateral-hs4] TTL extension failed:', e.message));
+    await writeMeta(0, 'error');
+    throw err;
+  } finally {
+    await releaseLock(LOCK_DOMAIN, runId);
+  }
+}
+
+const isMain = process.argv[1]?.endsWith('seed-comtrade-bilateral-hs4.mjs');
+if (isMain) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-comtrade-bilateral-hs4.mjs
+++ b/scripts/seed-comtrade-bilateral-hs4.mjs
@@ -128,7 +128,10 @@ async function fetchBilateral(reporterCode, hs4Batch) {
       headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
       signal: AbortSignal.timeout(20_000),
     });
-    if (!retry.ok) return [];
+    if (!retry.ok) {
+      console.warn(`  Retry for reporter ${reporterCode} also failed (HTTP ${retry.status})`);
+      return [];
+    }
     const retryData = await retry.json();
     return parseRecords(retryData);
   }
@@ -252,15 +255,16 @@ export async function main() {
         requestCount++;
 
         const products = groupByProduct([...batch1, ...batch2]);
-        const payload = JSON.stringify({
-          iso2,
-          products,
-          fetchedAt: new Date().toISOString(),
-        });
-        commands.push(['SET', `${KEY_PREFIX}${iso2}:v1`, payload, 'EX', String(TTL_SECONDS)]);
-        writtenCount++;
-
-        if (products.length > 0) {
+        if (products.length === 0) {
+          console.warn(`    ${iso2}: no products after grouping, skipping write`);
+        } else {
+          const payload = JSON.stringify({
+            iso2,
+            products,
+            fetchedAt: new Date().toISOString(),
+          });
+          commands.push(['SET', `${KEY_PREFIX}${iso2}:v1`, payload, 'EX', String(TTL_SECONDS)]);
+          writtenCount++;
           console.log(`    ${iso2}: ${products.length} products, ${batch1.length + batch2.length} records`);
         }
       } catch (err) {

--- a/scripts/seed-comtrade-bilateral-hs4.mjs
+++ b/scripts/seed-comtrade-bilateral-hs4.mjs
@@ -227,6 +227,7 @@ export async function main() {
 
     const commands = [];
     let writtenCount = 0;
+    let failedCount = 0;
     let requestCount = 0;
 
     for (let i = 0; i < countries.length; i++) {
@@ -239,34 +240,32 @@ export async function main() {
 
       if (requestCount > 0) await sleep(INTER_REQUEST_DELAY_MS);
 
-      let allRecords = [];
       try {
         console.log(`  [${i + 1}/${countries.length}] ${iso2} batch 1/2...`);
         const batch1 = await fetchBilateral(unCode, BATCH_1);
-        allRecords.push(...batch1);
         requestCount++;
 
         await sleep(INTER_REQUEST_DELAY_MS);
 
         console.log(`  [${i + 1}/${countries.length}] ${iso2} batch 2/2...`);
         const batch2 = await fetchBilateral(unCode, BATCH_2);
-        allRecords.push(...batch2);
         requestCount++;
+
+        const products = groupByProduct([...batch1, ...batch2]);
+        const payload = JSON.stringify({
+          iso2,
+          products,
+          fetchedAt: new Date().toISOString(),
+        });
+        commands.push(['SET', `${KEY_PREFIX}${iso2}:v1`, payload, 'EX', String(TTL_SECONDS)]);
+        writtenCount++;
+
+        if (products.length > 0) {
+          console.log(`    ${iso2}: ${products.length} products, ${batch1.length + batch2.length} records`);
+        }
       } catch (err) {
-        console.warn(`  ${iso2}: fetch failed (${err.message})`);
-      }
-
-      const products = groupByProduct(allRecords);
-      const payload = JSON.stringify({
-        iso2,
-        products,
-        fetchedAt: new Date().toISOString(),
-      });
-      commands.push(['SET', `${KEY_PREFIX}${iso2}:v1`, payload, 'EX', String(TTL_SECONDS)]);
-      writtenCount++;
-
-      if (products.length > 0) {
-        console.log(`    ${iso2}: ${products.length} products, ${allRecords.length} records`);
+        console.warn(`  [bilateral-hs4] ${iso2}: fetch failed, preserving existing data: ${err.message}`);
+        failedCount++;
       }
 
       if (commands.length >= 50) {
@@ -282,11 +281,12 @@ export async function main() {
 
     logSeedResult('comtrade:bilateral-hs4', writtenCount, Date.now() - startedAt, {
       countries: countries.length,
+      failed: failedCount,
       hs4Codes: HS4_CODES.length,
       requests: requestCount,
       ttlH: TTL_SECONDS / 3600,
     });
-    console.log(`[bilateral-hs4] Seeded ${writtenCount} country keys`);
+    console.log(`[bilateral-hs4] Seeded ${writtenCount} country keys (${failedCount} failed, existing data preserved)`);
   } catch (err) {
     console.error('[bilateral-hs4] Seed failed:', err.message || err);
     await extendExistingTtl([...allKeys, META_KEY], TTL_SECONDS)

--- a/scripts/seed-comtrade-bilateral-hs4.mjs
+++ b/scripts/seed-comtrade-bilateral-hs4.mjs
@@ -21,8 +21,21 @@ const KEY_PREFIX = 'comtrade:bilateral-hs4:';
 const TTL_SECONDS = 259200; // 72h
 const LOCK_DOMAIN = 'comtrade:bilateral-hs4';
 const LOCK_TTL_MS = 30 * 60 * 1000; // 30 min
-const COMTRADE_BASE = 'https://comtradeapi.un.org/public/v1';
-const INTER_REQUEST_DELAY_MS = 3500;
+
+const COMTRADE_KEYS = (process.env.COMTRADE_API_KEYS || '').split(',').map(k => k.trim()).filter(Boolean);
+let keyIndex = 0;
+function getNextKey() {
+  if (COMTRADE_KEYS.length === 0) return '';
+  const key = COMTRADE_KEYS[keyIndex % COMTRADE_KEYS.length];
+  keyIndex++;
+  return key;
+}
+
+const usePublicApi = COMTRADE_KEYS.length === 0;
+const COMTRADE_FETCH_URL = usePublicApi
+  ? 'https://comtradeapi.un.org/public/v1/preview/C/A/HS'
+  : 'https://comtradeapi.un.org/data/v1/get/C/A/HS';
+const INTER_REQUEST_DELAY_MS = usePublicApi ? 3500 : 1500;
 
 const HS4_CODES = [
   '2709', '2711', '8542', '8517', '8703', '3004', '7108', '2710',
@@ -90,10 +103,12 @@ async function redisPipeline(commands) {
  * @returns {Promise<Array<{cmdCode: string, partnerCode: string, primaryValue: number, year: number}>>}
  */
 async function fetchBilateral(reporterCode, hs4Batch) {
-  const url = new URL(`${COMTRADE_BASE}/preview/C/A/HS`);
+  const url = new URL(COMTRADE_FETCH_URL);
   url.searchParams.set('reporterCode', reporterCode);
   url.searchParams.set('cmdCode', hs4Batch.join(','));
   url.searchParams.set('flowCode', 'M');
+  const key = getNextKey();
+  if (key) url.searchParams.set('subscription-key', key);
 
   const resp = await fetch(url.toString(), {
     headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
@@ -103,7 +118,13 @@ async function fetchBilateral(reporterCode, hs4Batch) {
   if (resp.status === 429) {
     console.warn(`  429 rate-limited for reporter ${reporterCode}, waiting 60s...`);
     await sleep(60_000);
-    const retry = await fetch(url.toString(), {
+    const retryKey = getNextKey();
+    const retryUrl = new URL(COMTRADE_FETCH_URL);
+    retryUrl.searchParams.set('reporterCode', reporterCode);
+    retryUrl.searchParams.set('cmdCode', hs4Batch.join(','));
+    retryUrl.searchParams.set('flowCode', 'M');
+    if (retryKey) retryUrl.searchParams.set('subscription-key', retryKey);
+    const retry = await fetch(retryUrl.toString(), {
       headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
       signal: AbortSignal.timeout(20_000),
     });
@@ -201,7 +222,8 @@ export async function main() {
   };
 
   try {
-    console.log(`[bilateral-hs4] Fetching bilateral HS4 data for ${countries.length} countries × ${HS4_CODES.length} products...`);
+    const apiMode = usePublicApi ? 'public preview (no COMTRADE_API_KEYS)' : `authenticated (${COMTRADE_KEYS.length} key(s), ${INTER_REQUEST_DELAY_MS}ms delay)`;
+    console.log(`[bilateral-hs4] Fetching bilateral HS4 data for ${countries.length} countries × ${HS4_CODES.length} products [${apiMode}]...`);
 
     const commands = [];
     let writtenCount = 0;

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -48,7 +48,7 @@ import { toFlagEmoji } from '@/utils/country-flag';
 import { iso2ToIso3, iso2ToUnCode } from '@/utils/country-codes';
 import { buildDependencyGraph } from '@/services/infrastructure-cascade';
 import { getActiveFrameworkForPanel, subscribeFrameworkChange } from '@/services/analysis-framework-store';
-import { fetchMultiSectorExposure } from '@/services/supply-chain';
+import { fetchMultiSectorExposure, fetchCountryProducts } from '@/services/supply-chain';
 
 type IntlDisplayNamesCtor = new (
   locales: string | string[],
@@ -642,6 +642,15 @@ export class CountryIntelManager implements AppModule {
       if (this.ctx.countryBriefPage?.getCode() === code) {
         this.ctx.countryBriefPage.updateChokepointExposure?.(null);
         this.ctx.countryBriefPage.updateCostShock?.(null);
+      }
+    });
+
+    fetchCountryProducts(code).then(resp => {
+      if (this.ctx.countryBriefPage?.getCode() !== code) return;
+      this.ctx.countryBriefPage.updateProductImports?.(resp.products.length > 0 ? resp : null);
+    }).catch(() => {
+      if (this.ctx.countryBriefPage?.getCode() === code) {
+        this.ctx.countryBriefPage.updateProductImports?.(null);
       }
     });
   }

--- a/src/components/CountryBriefPanel.ts
+++ b/src/components/CountryBriefPanel.ts
@@ -2,7 +2,7 @@ import type { CountryBriefSignals } from '@/types';
 import type { CountryScore } from '@/services/country-instability';
 import type { PredictionMarket } from '@/services/prediction';
 import type { NewsItem } from '@/types';
-import type { GetCountryChokepointIndexResponse, SectorExposureSummary } from '@/services/supply-chain';
+import type { GetCountryChokepointIndexResponse, SectorExposureSummary, CountryProductsResponse } from '@/services/supply-chain';
 
 export interface CountryIntelData {
   brief: string;
@@ -194,4 +194,5 @@ export interface CountryBriefPanel {
   updateTariffTrends?(data: { currentRate: number; trend: string; datapoints: Array<{ year: number; tariffRate: number }> } | null): void;
   updateChokepointExposure?(data: { vulnerabilityIndex: number; exposures: Array<{ chokepointName: string; exposureScore: number }> } | null): void;
   updateCostShock?(data: { supplyDeficitPct: number; coverageDays: number; warRiskTier: string } | null): void;
+  updateProductImports?(data: CountryProductsResponse | null): void;
 }

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -30,7 +30,7 @@ import type {
   CountryEnergyProfileData,
   CountryPortActivityData,
 } from './CountryBriefPanel';
-import type { GetCountryChokepointIndexResponse, SectorExposureSummary } from '@/services/supply-chain';
+import type { GetCountryChokepointIndexResponse, SectorExposureSummary, CountryProductsResponse, CountryProduct } from '@/services/supply-chain';
 import type { MapContainer } from './MapContainer';
 import { ResilienceWidget } from './ResilienceWidget';
 
@@ -102,6 +102,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   private sectorBypassAbort: AbortController | null = null;
   private cachedTradeExposureData: GetCountryChokepointIndexResponse | null = null;
   private cachedSectors: SectorExposureSummary[] = [];
+  private productImportsBody: HTMLElement | null = null;
   private debtBody: HTMLElement | null = null;
   private sanctionsBody: HTMLElement | null = null;
   private comtradeBody: HTMLElement | null = null;
@@ -1542,6 +1543,119 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     return wrap;
   }
 
+  public updateProductImports(data: CountryProductsResponse | null): void {
+    if (!this.productImportsBody) return;
+    this.productImportsBody.replaceChildren();
+    if (!data || data.products.length === 0) {
+      this.productImportsBody.append(this.makeEmpty('No product import data available'));
+      return;
+    }
+    this.renderProductSelector(data.products);
+  }
+
+  private renderProductSelector(products: CountryProduct[]): void {
+    if (!this.productImportsBody) return;
+    const wrap = this.el('div', 'cdp-product-selector');
+    const input = this.el('input', 'cdp-product-search');
+    input.type = 'text';
+    input.placeholder = 'Search products...';
+    input.setAttribute('autocomplete', 'off');
+
+    const list = this.el('div', 'cdp-product-list');
+    const detailMount = this.el('div', 'cdp-product-detail');
+
+    const renderList = (filter: string) => {
+      list.replaceChildren();
+      const lower = filter.toLowerCase();
+      const filtered = lower
+        ? products.filter(p => p.description.toLowerCase().includes(lower) || p.hs4.includes(lower))
+        : products;
+      for (const p of filtered.slice(0, 12)) {
+        const item = this.el('button', 'cdp-product-item');
+        item.type = 'button';
+        item.textContent = `${p.description} (HS ${p.hs4})`;
+        item.addEventListener('click', () => {
+          input.value = p.description;
+          list.replaceChildren();
+          this.renderProductDetail(detailMount, p);
+        });
+        list.append(item);
+      }
+    };
+
+    input.addEventListener('input', () => renderList(input.value));
+    input.addEventListener('focus', () => {
+      if (list.children.length === 0) renderList(input.value);
+    });
+
+    this.productImportsBody.addEventListener('click', (e) => {
+      if (!(e.target instanceof HTMLElement) || e.target.closest('.cdp-product-selector')) return;
+      list.replaceChildren();
+    });
+
+    wrap.append(input, list);
+    this.productImportsBody.append(wrap, detailMount);
+
+    const first = products[0];
+    if (first) {
+      input.value = first.description;
+      this.renderProductDetail(detailMount, first);
+    }
+  }
+
+  private renderProductDetail(mount: HTMLElement, product: CountryProduct): void {
+    mount.replaceChildren();
+
+    const header = this.el('div', 'cdp-product-header');
+    header.append(
+      this.el('span', 'cdp-product-name', `${product.description} (HS ${product.hs4})`),
+      this.el('span', 'cdp-product-value', this.formatMoney(product.totalValue)),
+    );
+    mount.append(header);
+
+    if (product.topExporters.length === 0) {
+      mount.append(this.makeEmpty('No exporter data'));
+      return;
+    }
+
+    const table = this.el('table', 'cdp-product-suppliers-table');
+    const thead = this.el('thead');
+    const hr = this.el('tr');
+    hr.append(this.el('th', '', 'Supplier'));
+    hr.append(this.el('th', '', 'Share'));
+    hr.append(this.el('th', '', 'Value'));
+    thead.append(hr);
+    table.append(thead);
+
+    const tbody = this.el('tbody');
+    for (const exp of product.topExporters) {
+      const tr = this.el('tr');
+      const supplierTd = this.el('td', 'cdp-product-supplier');
+      const flag = exp.partnerIso2 ? CountryDeepDivePanel.toFlagEmoji(exp.partnerIso2) : '';
+      supplierTd.textContent = `${flag} ${exp.partnerIso2 || 'N/A'}`;
+      tr.append(supplierTd);
+
+      const shareTd = this.el('td', 'cdp-product-share');
+      const pct = Math.round(exp.share * 100);
+      shareTd.textContent = `${pct}%`;
+      const barWrap = this.el('div', 'cdp-product-share-bar-wrap');
+      const bar = this.el('div', 'cdp-product-share-bar');
+      bar.style.width = `${Math.min(pct, 100)}%`;
+      if (pct >= 50) bar.classList.add('cdp-product-share-high');
+      barWrap.append(bar);
+      shareTd.append(barWrap);
+      tr.append(shareTd);
+
+      tr.append(this.el('td', 'cdp-product-val', this.formatMoney(exp.value)));
+      tbody.append(tr);
+    }
+    table.append(tbody);
+    mount.append(table);
+
+    const source = this.el('div', 'cdp-card-footer', `Source: UN Comtrade HS4 bilateral \u00B7 ${product.year}`);
+    mount.append(source);
+  }
+
   private factItem(label: string, value: string): HTMLElement {
     const wrapper = this.el('div', 'cdp-fact-item');
     wrapper.append(this.el('div', 'cdp-fact-label', label));
@@ -1790,6 +1904,10 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
 
     const isPro = hasPremiumAccess(getAuthState());
 
+    const [productImportsCard, productImportsCardBody] = this.sectionCard('Product Imports', 'Top imported products by HS4 code with supplier breakdown and concentration risk.');
+    this.productImportsBody = productImportsCardBody;
+    productImportsCardBody.append(isPro ? this.makeLoading('Loading product data\u2026') : this.makeProLocked('Upgrade to PRO for product import data'));
+
     const [debtCard, debtBody] = this.sectionCard('National Debt', 'Government debt-to-GDP ratio, total debt, and year-over-year growth.');
     this.debtBody = debtBody;
     debtBody.append(isPro ? this.makeLoading('Loading debt data\u2026') : this.makeProLocked('Upgrade to PRO for national debt data'));
@@ -1832,7 +1950,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     marketsBody.append(this.makeLoading(t('countryBrief.loadingMarkets')));
     briefBody.append(this.makeLoading(t('countryBrief.generatingBrief')));
 
-    bodyGrid.append(briefCard, factsExpanded, energyCard, maritimeCard, tradeCard, debtCard, sanctionsCard, comtradeCard, tariffCard, chokepointCard, costShockCard, signalsCard, timelineCard, newsCard, militaryCard, infraCard, economicCard, marketsCard);
+    bodyGrid.append(briefCard, factsExpanded, energyCard, maritimeCard, tradeCard, productImportsCard, debtCard, sanctionsCard, comtradeCard, tariffCard, chokepointCard, costShockCard, signalsCard, timelineCard, newsCard, militaryCard, infraCard, economicCard, marketsCard);
     shell.append(header, summaryGrid, bodyGrid);
     this.content.append(shell);
   }
@@ -1854,6 +1972,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.energyBody = null;
     this.maritimeBody = null;
     this.tradeExposureBody = null;
+    this.productImportsBody = null;
     this.debtBody = null;
     this.sanctionsBody = null;
     this.comtradeBody = null;

--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -227,6 +227,7 @@ export async function fetchSectorDependency(
 }
 
 export interface ProductExporter {
+  partnerCode: number;
   partnerIso2: string;
   value: number;
   share: number;

--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -225,3 +225,39 @@ export async function fetchSectorDependency(
     return { ...emptySectorDependency, iso2, hs2 };
   }
 }
+
+export interface ProductExporter {
+  partnerIso2: string;
+  value: number;
+  share: number;
+}
+
+export interface CountryProduct {
+  hs4: string;
+  description: string;
+  totalValue: number;
+  topExporters: ProductExporter[];
+  year: number;
+}
+
+export interface CountryProductsResponse {
+  iso2: string;
+  products: CountryProduct[];
+  fetchedAt: string;
+}
+
+const emptyProducts: CountryProductsResponse = { iso2: '', products: [], fetchedAt: '' };
+
+export async function fetchCountryProducts(iso2: string): Promise<CountryProductsResponse> {
+  try {
+    const { premiumFetch } = await import('@/services/premium-fetch');
+    const { toApiUrl } = await import('@/services/runtime');
+    const resp = await premiumFetch(
+      toApiUrl(`/api/supply-chain/v1/country-products?iso2=${encodeURIComponent(iso2)}`),
+    );
+    if (!resp.ok) return { ...emptyProducts, iso2 };
+    return await resp.json() as CountryProductsResponse;
+  } catch {
+    return { ...emptyProducts, iso2 };
+  }
+}

--- a/src/styles/country-deep-dive.css
+++ b/src/styles/country-deep-dive.css
@@ -1294,3 +1294,130 @@
 .cdp-sector-detail-row td {
   padding: 0 4px 8px;
 }
+
+.cdp-product-selector {
+  position: relative;
+  margin-bottom: 8px;
+}
+
+.cdp-product-search {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-secondary, #1a1a2e);
+  color: var(--text);
+  font-size: 12px;
+  outline: none;
+}
+
+.cdp-product-search:focus {
+  border-color: var(--accent, #3b82f6);
+}
+
+.cdp-product-list {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  background: var(--bg-secondary, #1a1a2e);
+  border: 1px solid var(--border);
+  border-radius: 0 0 6px 6px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.cdp-product-list:empty {
+  display: none;
+}
+
+.cdp-product-item {
+  display: block;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.cdp-product-item:hover {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.06));
+}
+
+.cdp-product-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 6px;
+  gap: 8px;
+}
+
+.cdp-product-name {
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--text);
+}
+
+.cdp-product-value {
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--accent, #3b82f6);
+  white-space: nowrap;
+}
+
+.cdp-product-suppliers-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+}
+
+.cdp-product-suppliers-table th {
+  text-align: left;
+  font-weight: 600;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.cdp-product-suppliers-table td {
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+}
+
+.cdp-product-supplier {
+  white-space: nowrap;
+}
+
+.cdp-product-share {
+  min-width: 80px;
+}
+
+.cdp-product-share-bar-wrap {
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  margin-top: 2px;
+}
+
+.cdp-product-share-bar {
+  height: 100%;
+  background: var(--accent, #3b82f6);
+  border-radius: 2px;
+  min-width: 2px;
+}
+
+.cdp-product-share-bar.cdp-product-share-high {
+  background: var(--warning, #f59e0b);
+}
+
+.cdp-product-val {
+  text-align: right;
+  white-space: nowrap;
+}

--- a/tests/comtrade-bilateral-hs4.test.mjs
+++ b/tests/comtrade-bilateral-hs4.test.mjs
@@ -1,0 +1,465 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const root = join(import.meta.dirname, '..');
+
+// ─── Edge endpoint ──────────────────────────────────────────────────────────
+
+describe('Country products endpoint (api/supply-chain/v1/country-products.ts)', () => {
+  const filePath = join(root, 'api', 'supply-chain', 'v1', 'country-products.ts');
+  const src = readFileSync(filePath, 'utf-8');
+
+  it('exports edge config with runtime: edge', () => {
+    assert.ok(
+      src.includes("runtime: 'edge'"),
+      'country-products.ts: must export edge config with runtime: "edge"',
+    );
+  });
+
+  it('has a default export handler function', () => {
+    assert.ok(
+      /export\s+default\s+async\s+function\s+handler/.test(src),
+      'country-products.ts: must have a default async function handler export',
+    );
+  });
+
+  it('returns 405 for non-GET requests', () => {
+    assert.ok(
+      src.includes("req.method !== 'GET'") || src.includes('req.method !== "GET"'),
+      'country-products.ts: must check for GET method and return 405 for other methods',
+    );
+    assert.ok(
+      src.includes('status: 405'),
+      'country-products.ts: must return 405 status for non-GET',
+    );
+  });
+
+  it('validates iso2 parameter with /^[A-Z]{2}$/ pattern', () => {
+    assert.ok(
+      src.includes('[A-Z]{2}'),
+      'country-products.ts: must validate iso2 with a two-uppercase-letter regex',
+    );
+  });
+
+  it('returns 400 for invalid iso2', () => {
+    assert.ok(
+      src.includes('status: 400'),
+      'country-products.ts: must return 400 for invalid or missing iso2',
+    );
+  });
+
+  it('uses isCallerPremium for PRO gating', () => {
+    assert.ok(
+      src.includes('isCallerPremium'),
+      'country-products.ts: must use isCallerPremium for PRO-gating',
+    );
+    const importIdx = src.indexOf('isCallerPremium');
+    const callIdx = src.indexOf('isCallerPremium(req)');
+    assert.ok(
+      importIdx !== -1 && callIdx !== -1,
+      'country-products.ts: must import and invoke isCallerPremium(req)',
+    );
+  });
+
+  it('returns 403 for non-PRO users', () => {
+    assert.ok(
+      src.includes('status: 403'),
+      'country-products.ts: must return 403 for non-PRO callers',
+    );
+    assert.ok(
+      src.includes('PRO subscription required'),
+      'country-products.ts: 403 response must include descriptive error message',
+    );
+  });
+
+  it('uses private Cache-Control (not public) for successful responses', () => {
+    assert.ok(
+      src.includes("'Cache-Control': 'private"),
+      'country-products.ts: Cache-Control for PRO data must be private, not public',
+    );
+    assert.ok(
+      !src.includes("'Cache-Control': 'public"),
+      'country-products.ts: must not use public Cache-Control for PRO-gated data',
+    );
+  });
+
+  it('Vary header includes Authorization', () => {
+    assert.ok(
+      src.includes("'Vary'") || src.includes('"Vary"'),
+      'country-products.ts: must include Vary header',
+    );
+    assert.ok(
+      src.includes('Authorization'),
+      'country-products.ts: Vary header must include Authorization for PRO-gated responses',
+    );
+  });
+
+  it('non-PRO/empty-data path uses no-store cache control', () => {
+    assert.ok(
+      src.includes('no-store'),
+      'country-products.ts: empty data / fallback path must use no-store cache control',
+    );
+  });
+
+  it('reads from Upstash Redis via readJsonFromUpstash', () => {
+    assert.ok(
+      src.includes('readJsonFromUpstash'),
+      'country-products.ts: must read cached data from Upstash Redis',
+    );
+  });
+
+  it('passes a timeout to readJsonFromUpstash', () => {
+    const match = src.match(/readJsonFromUpstash\(\s*key\s*,\s*(\d[\d_]*)\s*\)/);
+    assert.ok(
+      match,
+      'country-products.ts: must pass a timeout parameter to readJsonFromUpstash to bound Redis reads',
+    );
+    const timeout = Number(match[1].replace(/_/g, ''));
+    assert.ok(
+      timeout > 0 && timeout <= 10_000,
+      `country-products.ts: readJsonFromUpstash timeout should be reasonable (got ${timeout}ms)`,
+    );
+  });
+
+  it('iso2 validation happens after PRO gate (prevents free users probing keys)', () => {
+    const proIdx = src.indexOf('isCallerPremium');
+    const isoIdx = src.indexOf('[A-Z]{2}');
+    assert.ok(
+      proIdx < isoIdx,
+      'country-products.ts: PRO gate must come before iso2 validation to prevent free users probing parameter patterns',
+    );
+  });
+});
+
+// ─── Seeder structure ────────────────────────────────────────────────────────
+
+describe('Comtrade bilateral HS4 seeder (scripts/seed-comtrade-bilateral-hs4.mjs)', () => {
+  const filePath = join(root, 'scripts', 'seed-comtrade-bilateral-hs4.mjs');
+  const src = readFileSync(filePath, 'utf-8');
+
+  it('uses acquireLockSafely for distributed locking', () => {
+    assert.ok(
+      src.includes('acquireLockSafely'),
+      'seeder: must use acquireLockSafely to prevent concurrent runs',
+    );
+  });
+
+  it('calls releaseLock in a finally block', () => {
+    const finallyIdx = src.lastIndexOf('finally');
+    const releaseIdx = src.indexOf('releaseLock', finallyIdx);
+    assert.ok(
+      finallyIdx !== -1 && releaseIdx !== -1 && releaseIdx > finallyIdx,
+      'seeder: must call releaseLock in a finally block to guarantee lock cleanup',
+    );
+  });
+
+  it('has isMain guard at the bottom (prevents automatic execution on import)', () => {
+    assert.ok(
+      src.includes("process.argv[1]?.endsWith('seed-comtrade-bilateral-hs4.mjs')"),
+      'seeder: must have isMain guard checking process.argv[1]',
+    );
+    const isMainIdx = src.indexOf('isMain');
+    const mainCallIdx = src.indexOf('main()', isMainIdx);
+    assert.ok(
+      isMainIdx !== -1 && mainCallIdx !== -1,
+      'seeder: isMain guard must gate the main() call',
+    );
+  });
+
+  it('reads COMTRADE_API_KEYS from environment', () => {
+    assert.ok(
+      src.includes('process.env.COMTRADE_API_KEYS'),
+      'seeder: must read COMTRADE_API_KEYS from environment for API authentication',
+    );
+  });
+
+  it('implements key rotation via getNextKey pattern', () => {
+    assert.ok(
+      src.includes('getNextKey'),
+      'seeder: must implement getNextKey for API key rotation across requests',
+    );
+    assert.ok(
+      src.includes('keyIndex'),
+      'seeder: key rotation must track index via keyIndex',
+    );
+    assert.ok(
+      src.includes('COMTRADE_KEYS.length'),
+      'seeder: key rotation must cycle through all available keys',
+    );
+  });
+
+  it('TTL_SECONDS is 259200 (72 hours)', () => {
+    assert.ok(
+      src.includes('TTL_SECONDS = 259200'),
+      'seeder: TTL_SECONDS must be 259200 (72h) to match the cache interval',
+    );
+  });
+
+  it('META_KEY follows seed-meta: convention', () => {
+    const match = src.match(/META_KEY\s*=\s*'(seed-meta:[^']+)'/);
+    assert.ok(
+      match,
+      'seeder: META_KEY must follow the seed-meta: prefix convention',
+    );
+    assert.strictEqual(
+      match[1],
+      'seed-meta:comtrade:bilateral-hs4',
+      'seeder: META_KEY must be seed-meta:comtrade:bilateral-hs4',
+    );
+  });
+
+  it('KEY_PREFIX follows expected pattern', () => {
+    const match = src.match(/KEY_PREFIX\s*=\s*'([^']+)'/);
+    assert.ok(
+      match,
+      'seeder: KEY_PREFIX must be defined',
+    );
+    assert.strictEqual(
+      match[1],
+      'comtrade:bilateral-hs4:',
+      'seeder: KEY_PREFIX must be comtrade:bilateral-hs4:',
+    );
+  });
+
+  it('defines exactly 20 HS4 codes', () => {
+    const match = src.match(/HS4_CODES\s*=\s*\[([\s\S]*?)\]/);
+    assert.ok(match, 'seeder: HS4_CODES array must be defined');
+    const codes = match[1].match(/'(\d{4})'/g);
+    assert.ok(codes, 'seeder: HS4_CODES must contain quoted 4-digit codes');
+    assert.strictEqual(
+      codes.length,
+      20,
+      `seeder: HS4_CODES must have exactly 20 codes, got ${codes.length}`,
+    );
+  });
+
+  it('does NOT write empty data to Redis on fetch failure (preserves existing data)', () => {
+    assert.ok(
+      src.includes('preserving existing data'),
+      'seeder: catch block must log that existing data is preserved on failure',
+    );
+    const catchBlock = src.slice(
+      src.indexOf("fetch failed, preserving existing data"),
+    );
+    assert.ok(
+      catchBlock.includes('failedCount++'),
+      'seeder: failed fetches must increment failedCount without writing empty data to Redis',
+    );
+    assert.ok(
+      !catchBlock.startsWith('commands.push'),
+      'seeder: catch block must NOT push SET commands for failed countries',
+    );
+  });
+
+  it('handles 429 rate limiting with sleep and retry', () => {
+    assert.ok(
+      src.includes('429'),
+      'seeder: must detect HTTP 429 rate limit responses',
+    );
+    assert.ok(
+      src.includes('rate-limited'),
+      'seeder: must log rate limit events',
+    );
+    assert.ok(
+      src.includes('sleep(60_000)') || src.includes('sleep(60000)'),
+      'seeder: must wait 60 seconds on 429 before retrying',
+    );
+  });
+
+  it('exports main() function for external invocation', () => {
+    assert.ok(
+      /export\s+async\s+function\s+main/.test(src),
+      'seeder: must export main() for use by orchestration scripts',
+    );
+  });
+
+  it('writes seed-meta with fetchedAt and recordCount fields', () => {
+    assert.ok(
+      src.includes('fetchedAt'),
+      'seeder: seed-meta must include fetchedAt timestamp',
+    );
+    assert.ok(
+      src.includes('recordCount'),
+      'seeder: seed-meta must include recordCount',
+    );
+  });
+
+  it('extends TTL on lock-skipped path (prevents stale data when another instance runs)', () => {
+    const skippedIdx = src.indexOf('lock.skipped');
+    assert.ok(skippedIdx !== -1, 'seeder: must check lock.skipped');
+    const extendIdx = src.indexOf('extendExistingTtl', skippedIdx);
+    assert.ok(
+      extendIdx !== -1 && extendIdx - skippedIdx < 300,
+      'seeder: must call extendExistingTtl when lock is skipped',
+    );
+  });
+});
+
+// ─── Service function ────────────────────────────────────────────────────────
+
+describe('fetchCountryProducts service (src/services/supply-chain/index.ts)', () => {
+  const filePath = join(root, 'src', 'services', 'supply-chain', 'index.ts');
+  const src = readFileSync(filePath, 'utf-8');
+
+  it('fetchCountryProducts function exists', () => {
+    assert.ok(
+      /export\s+async\s+function\s+fetchCountryProducts/.test(src),
+      'supply-chain/index.ts: must export fetchCountryProducts function',
+    );
+  });
+
+  it('CountryProductsResponse type is exported', () => {
+    assert.ok(
+      src.includes('export interface CountryProductsResponse'),
+      'supply-chain/index.ts: must export CountryProductsResponse interface',
+    );
+  });
+
+  it('CountryProduct type is exported', () => {
+    assert.ok(
+      src.includes('export interface CountryProduct'),
+      'supply-chain/index.ts: must export CountryProduct interface',
+    );
+  });
+
+  it('ProductExporter type is exported', () => {
+    assert.ok(
+      src.includes('export interface ProductExporter'),
+      'supply-chain/index.ts: must export ProductExporter interface',
+    );
+  });
+
+  it('uses premiumFetch (not plain fetch) for PRO-gated data', () => {
+    const fnStart = src.indexOf('async function fetchCountryProducts');
+    const fnBody = src.slice(fnStart, src.indexOf('\n}\n', fnStart) + 3);
+    assert.ok(
+      fnBody.includes('premiumFetch'),
+      'fetchCountryProducts: must use premiumFetch to attach auth credentials',
+    );
+    assert.ok(
+      !fnBody.includes('globalThis.fetch('),
+      'fetchCountryProducts: must not use globalThis.fetch directly for PRO endpoints',
+    );
+  });
+
+  it('returns empty products array on error (graceful fallback)', () => {
+    assert.ok(
+      src.includes("products: [], fetchedAt: ''"),
+      'fetchCountryProducts: emptyProducts fallback must have empty products array and empty fetchedAt',
+    );
+    const fnStart = src.indexOf('async function fetchCountryProducts');
+    const fnBody = src.slice(fnStart, src.indexOf('\n}\n', fnStart) + 3);
+    assert.ok(
+      fnBody.includes('catch'),
+      'fetchCountryProducts: must have catch block for graceful fallback',
+    );
+    assert.ok(
+      fnBody.includes('emptyProducts'),
+      'fetchCountryProducts: catch block must return emptyProducts',
+    );
+  });
+
+  it('CountryProduct interface has expected fields', () => {
+    const ifaceStart = src.indexOf('export interface CountryProduct');
+    const ifaceEnd = src.indexOf('}', ifaceStart);
+    const iface = src.slice(ifaceStart, ifaceEnd + 1);
+    assert.ok(iface.includes('hs4: string'), 'CountryProduct must have hs4: string');
+    assert.ok(iface.includes('description: string'), 'CountryProduct must have description: string');
+    assert.ok(iface.includes('totalValue: number'), 'CountryProduct must have totalValue: number');
+    assert.ok(iface.includes('topExporters: ProductExporter[]'), 'CountryProduct must have topExporters: ProductExporter[]');
+    assert.ok(iface.includes('year: number'), 'CountryProduct must have year: number');
+  });
+});
+
+// ─── CountryDeepDivePanel product imports ────────────────────────────────────
+
+describe('CountryDeepDivePanel product imports section', () => {
+  const filePath = join(root, 'src', 'components', 'CountryDeepDivePanel.ts');
+  const src = readFileSync(filePath, 'utf-8');
+
+  it('updateProductImports method exists as public', () => {
+    assert.ok(
+      src.includes('public updateProductImports'),
+      'CountryDeepDivePanel: must have a public updateProductImports method',
+    );
+  });
+
+  it('has product search/filter input', () => {
+    assert.ok(
+      src.includes("'cdp-product-search'") || src.includes('"cdp-product-search"'),
+      'CountryDeepDivePanel: must create a search input element for product filtering',
+    );
+    assert.ok(
+      src.includes("placeholder = 'Search products") || src.includes('placeholder = "Search products'),
+      'CountryDeepDivePanel: product search input must have a search placeholder',
+    );
+  });
+
+  it('implements filter logic on product list', () => {
+    assert.ok(
+      src.includes('.filter(p =>') || src.includes('.filter((p)'),
+      'CountryDeepDivePanel: must filter products by search term',
+    );
+    assert.ok(
+      src.includes('toLowerCase'),
+      'CountryDeepDivePanel: filter must be case-insensitive via toLowerCase',
+    );
+  });
+
+  it('PRO gate check (hasPremiumAccess) guards product imports card', () => {
+    assert.ok(
+      src.includes("import { hasPremiumAccess }"),
+      'CountryDeepDivePanel: must import hasPremiumAccess for PRO gating',
+    );
+    const productImportsIdx = src.indexOf('productImportsCardBody');
+    assert.ok(
+      productImportsIdx !== -1,
+      'CountryDeepDivePanel: must have productImportsCardBody',
+    );
+    const nearbyIsPro = src.slice(Math.max(0, productImportsIdx - 200), productImportsIdx + 300);
+    assert.ok(
+      nearbyIsPro.includes('isPro'),
+      'CountryDeepDivePanel: productImportsCardBody must be gated by isPro check',
+    );
+  });
+
+  it('uses textContent for product rendering (XSS-safe, no innerHTML)', () => {
+    const renderStart = src.indexOf('private renderProductDetail');
+    assert.ok(renderStart !== -1, 'CountryDeepDivePanel: must have private renderProductDetail method');
+    const renderBody = src.slice(renderStart, src.indexOf('\n  }\n', renderStart + 100) + 5);
+    assert.ok(
+      renderBody.includes('.textContent'),
+      'renderProductDetail: must use textContent for safe text rendering',
+    );
+    assert.ok(
+      !renderBody.includes('.innerHTML'),
+      'renderProductDetail: must not use innerHTML (XSS risk with user-influenced product data)',
+    );
+  });
+
+  it('resetPanelContent clears productImportsBody', () => {
+    const resetIdx = src.indexOf('private resetPanelContent');
+    assert.ok(resetIdx !== -1, 'CountryDeepDivePanel: must have private resetPanelContent method');
+    const resetBody = src.slice(resetIdx, src.indexOf('\n  }\n', resetIdx + 50) + 5);
+    assert.ok(
+      resetBody.includes('this.productImportsBody = null'),
+      'resetPanelContent: must set productImportsBody to null',
+    );
+  });
+
+  it('sectionCard is used for the product imports card', () => {
+    assert.ok(
+      src.includes("this.sectionCard('Product Imports'"),
+      'CountryDeepDivePanel: product imports must use sectionCard for consistent card structure',
+    );
+  });
+
+  it('product imports card is appended to the body grid', () => {
+    assert.ok(
+      src.includes('productImportsCard'),
+      'CountryDeepDivePanel: productImportsCard must be appended to bodyGrid',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- New seeder `scripts/seed-comtrade-bilateral-hs4.mjs` fetches bilateral import data from UN Comtrade public API at HS4 product level for all 197 countries across 20 strategic product codes (crude oil, semiconductors, vehicles, pharma, wheat, etc.)
- New PRO-gated Vercel edge function `api/supply-chain/v1/country-products.ts` serves the cached data from Redis
- New "Product Imports" card in CountryDeepDivePanel with searchable product dropdown, top-5 exporter table with share bars, and value formatting

## Test plan
- [ ] Run `node scripts/seed-comtrade-bilateral-hs4.mjs` manually against dev Redis to verify data flows
- [ ] Verify `GET /api/supply-chain/v1/country-products?iso2=US` returns product data for PRO users
- [ ] Verify free users get 403 on the endpoint
- [ ] Open country deep dive for US, verify "Product Imports" card shows with searchable dropdown
- [ ] Select different products in the dropdown, verify exporter table updates
- [ ] Verify free users see locked placeholder instead of product data
- [ ] `npm run typecheck` and `npm run typecheck:api` pass (verified pre-push)