### PR TITLE
fix(seed): correct un-to-iso2.json path for Railway container

### DIFF
--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -26,7 +26,7 @@ import { readFileSync as _readFileSync } from 'node:fs';
 import { dirname as _dirname, join as _join } from 'node:path';
 import { fileURLToPath as _fileURLToPath } from 'node:url';
 const __dirname = _dirname(_fileURLToPath(import.meta.url));
-const _un2iso2 = JSON.parse(_readFileSync(_join(__dirname, '..', 'shared', 'un-to-iso2.json'), 'utf8'));
+const _un2iso2 = JSON.parse(_readFileSync(_join(__dirname, 'shared', 'un-to-iso2.json'), 'utf8'));
 
 // Populated by fetchWtoReporters() before any data fetches
 let ALL_REPORTERS = [];


### PR DESCRIPTION
## Summary
Fix ENOENT crash on Railway: `seed-supply-chain-trade.mjs` resolved `un-to-iso2.json` via `__dirname/../shared/` which works locally but fails in Railway where `rootDirectory: scripts` makes `__dirname=/app` and `../shared` resolves to `/shared/` (doesn't exist).

Changed to `__dirname/shared/` which correctly resolves to `scripts/shared/un-to-iso2.json`.

## Test plan
- [ ] Railway deploy succeeds without ENOENT
- [ ] `node scripts/seed-supply-chain-trade.mjs` runs locally