### PR TITLE
fix(trade): replace Budget Lab scraper with FRED API for effective tariff rate

### DIFF
--- a/scripts/_trade-parse-utils.mjs
+++ b/scripts/_trade-parse-utils.mjs
@@ -57,6 +57,7 @@ export function parseBudgetLabEffectiveTariffHtml(html) {
 
   const updatedAt = toIsoDate(text.match(/\bUpdated:\s*([A-Za-z]+\s+\d{1,2},\s+\d{4})/i)?.[1] ?? '');
   const patterns = [
+    /effective tariff rate (?:stood at|was|is)\s+(\d+(?:\.\d+)?)%/i,
     /effective tariff rate reaching\s+(\d+(?:\.\d+)?)%\s+in\s+([A-Za-z]+\s+\d{4})/i,
     /average effective (?:u\.s\.\s*)?tariff rate[^.]{0,180}?\bto\s+(\d+(?:\.\d+)?)%[^.]{0,180}?\b(?:in|by)\s+([A-Za-z]+\s+\d{4})/i,
     /average effective (?:u\.s\.\s*)?tariff rate[^.]{0,180}?\bto\s+(\d+(?:\.\d+)?)%/i,

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep, verifySeedKey, resolveProxyForConnect, fredFetchJson } from './_seed-utils.mjs';
-import { BUDGET_LAB_TARIFFS_URL, htmlToPlainText, toIsoDate, parseBudgetLabEffectiveTariffHtml } from './_trade-parse-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -265,28 +264,42 @@ async function wtoFetch(path, params) {
   return resp.json();
 }
 
-// Budget Lab main page is a Next.js SPA; data is in a GitHub-hosted embedded report
-const BUDGET_LAB_EMBED_URL = 'https://raw.githubusercontent.com/Budget-Lab-Yale/tariff-impact-tracker/main/website/html/tariff_impacts_report_drupal.html';
+// US effective tariff rate from FRED: customs duties / goods imports × 100
+// B235RC1Q027SBEA = customs duties (quarterly, SAAR billions)
+// IEAMGSN = goods imports (quarterly, SAAR billions)
+const FRED_CUSTOMS_SERIES = 'B235RC1Q027SBEA';
+const FRED_IMPORTS_SERIES = 'IEAMGSN';
 
-async function fetchBudgetLabEffectiveTariffRate() {
-  // Try the GitHub-hosted embedded report first (reliable, static HTML)
-  for (const url of [BUDGET_LAB_EMBED_URL, BUDGET_LAB_TARIFFS_URL]) {
-    try {
-      const resp = await fetch(url, {
-        headers: { Accept: 'text/html', 'User-Agent': CHROME_UA },
-        signal: AbortSignal.timeout(15_000),
-      });
-      if (!resp.ok) continue;
-      const html = await resp.text();
-      const parsed = parseBudgetLabEffectiveTariffHtml(html);
-      if (parsed) {
-        console.log(`  Budget Lab effective tariff: ${parsed.tariffRate.toFixed(1)}%${parsed.observationPeriod ? ` (${parsed.observationPeriod})` : ''}`);
-        return parsed;
-      }
-    } catch { /* try next */ }
+async function fetchEffectiveTariffRateFromFred() {
+  try {
+    const [customs, imports] = await Promise.all([
+      fredFetchJson(FRED_CUSTOMS_SERIES),
+      fredFetchJson(FRED_IMPORTS_SERIES),
+    ]);
+    if (!customs?.length || !imports?.length) {
+      console.warn('  FRED tariff rate: no data from one or both series');
+      return null;
+    }
+    // Both series are quarterly; match by date
+    const importsMap = new Map(imports.map(o => [o.date, parseFloat(o.value)]));
+    const latest = customs
+      .map(o => ({ date: o.date, customs: parseFloat(o.value), imports: importsMap.get(o.date) }))
+      .filter(o => Number.isFinite(o.customs) && Number.isFinite(o.imports) && o.imports > 0)
+      .sort((a, b) => b.date.localeCompare(a.date))[0];
+    if (!latest) { console.warn('  FRED tariff rate: no matching quarters'); return null; }
+    const rate = (latest.customs / latest.imports) * 100;
+    console.log(`  FRED effective tariff: ${rate.toFixed(1)}% (${latest.date})`);
+    return {
+      sourceName: 'FRED (BEA)',
+      sourceUrl: `https://fred.stlouisfed.org/series/${FRED_CUSTOMS_SERIES}`,
+      observationPeriod: latest.date,
+      updatedAt: latest.date,
+      tariffRate: Math.round(rate * 100) / 100,
+    };
+  } catch (e) {
+    console.warn(`  FRED tariff rate: ${e.message}`);
+    return null;
   }
-  console.warn('  Budget Lab tariffs: all sources failed');
-  return null;
 }
 
 // ─── Trade Flows (WTO) — pre-seed major reporters vs World + key bilateral pairs ───
@@ -501,7 +514,7 @@ async function fetchTradeRestrictions() {
 async function fetchTariffTrends() {
   const currentYear = new Date().getFullYear();
   const trends = {};
-  const usEffectiveTariffRate = await fetchBudgetLabEffectiveTariffRate();
+  const usEffectiveTariffRate = await fetchEffectiveTariffRateFromFred();
 
   // Batch WTO requests in groups of 30 to avoid URL length limits
   const BATCH_SIZE = 30;

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -268,7 +268,7 @@ async function wtoFetch(path, params) {
 // B235RC1Q027SBEA = customs duties (quarterly, SAAR billions)
 // IEAMGSN = goods imports (quarterly, SAAR billions)
 const FRED_CUSTOMS_SERIES = 'B235RC1Q027SBEA';
-const FRED_IMPORTS_SERIES = 'IEAMGSN';
+const FRED_IMPORTS_SERIES = 'A255RC1Q027SBEA'; // Imports of goods, Billions, Quarterly, SAAR (matches customs units)
 
 function fredSeriesUrl(seriesId) {
   const key = process.env.FRED_API_KEY;

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -270,12 +270,23 @@ async function wtoFetch(path, params) {
 const FRED_CUSTOMS_SERIES = 'B235RC1Q027SBEA';
 const FRED_IMPORTS_SERIES = 'IEAMGSN';
 
+function fredSeriesUrl(seriesId) {
+  const key = process.env.FRED_API_KEY;
+  if (!key) return null;
+  return `https://api.stlouisfed.org/fred/series/observations?series_id=${seriesId}&api_key=${key}&file_type=json&sort_order=desc&limit=20`;
+}
+
 async function fetchEffectiveTariffRateFromFred() {
   try {
-    const [customs, imports] = await Promise.all([
-      fredFetchJson(FRED_CUSTOMS_SERIES),
-      fredFetchJson(FRED_IMPORTS_SERIES),
+    const customsUrl = fredSeriesUrl(FRED_CUSTOMS_SERIES);
+    const importsUrl = fredSeriesUrl(FRED_IMPORTS_SERIES);
+    if (!customsUrl || !importsUrl) { console.warn('  FRED tariff rate: FRED_API_KEY not set'); return null; }
+    const [customsResp, importsResp] = await Promise.all([
+      fredFetchJson(customsUrl),
+      fredFetchJson(importsUrl),
     ]);
+    const customs = customsResp?.observations ?? [];
+    const imports = importsResp?.observations ?? [];
     if (!customs?.length || !imports?.length) {
       console.warn('  FRED tariff rate: no data from one or both series');
       return null;

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -265,30 +265,28 @@ async function wtoFetch(path, params) {
   return resp.json();
 }
 
+// Budget Lab main page is a Next.js SPA; data is in a GitHub-hosted embedded report
+const BUDGET_LAB_EMBED_URL = 'https://raw.githubusercontent.com/Budget-Lab-Yale/tariff-impact-tracker/main/website/html/tariff_impacts_report_drupal.html';
+
 async function fetchBudgetLabEffectiveTariffRate() {
-  try {
-    const resp = await fetch(BUDGET_LAB_TARIFFS_URL, {
-      headers: { Accept: 'text/html', 'User-Agent': CHROME_UA },
-      signal: AbortSignal.timeout(15_000),
-    });
-    if (!resp.ok) {
-      console.warn(`  Budget Lab tariffs: HTTP ${resp.status}`);
-      return null;
-    }
-    const html = await resp.text();
-    const parsed = parseBudgetLabEffectiveTariffHtml(html);
-    if (!parsed) {
-      const hasBody = html.length > 5000 && /<body/i.test(html);
-      const reason = hasBody ? 'page structure changed' : 'JS-rendered SPA (no static content)';
-      console.log(`  Budget Lab tariffs: skipped (${reason})`);
-      return null;
-    }
-    console.log(`  Budget Lab effective tariff: ${parsed.tariffRate.toFixed(1)}%${parsed.observationPeriod ? ` (${parsed.observationPeriod})` : ''}`);
-    return parsed;
-  } catch (e) {
-    console.warn(`  Budget Lab tariffs: ${e.message}`);
-    return null;
+  // Try the GitHub-hosted embedded report first (reliable, static HTML)
+  for (const url of [BUDGET_LAB_EMBED_URL, BUDGET_LAB_TARIFFS_URL]) {
+    try {
+      const resp = await fetch(url, {
+        headers: { Accept: 'text/html', 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!resp.ok) continue;
+      const html = await resp.text();
+      const parsed = parseBudgetLabEffectiveTariffHtml(html);
+      if (parsed) {
+        console.log(`  Budget Lab effective tariff: ${parsed.tariffRate.toFixed(1)}%${parsed.observationPeriod ? ` (${parsed.observationPeriod})` : ''}`);
+        return parsed;
+      }
+    } catch { /* try next */ }
   }
+  console.warn('  Budget Lab tariffs: all sources failed');
+  return null;
 }
 
 // ─── Trade Flows (WTO) — pre-seed major reporters vs World + key bilateral pairs ───

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -282,8 +282,8 @@ async function fetchEffectiveTariffRateFromFred() {
     const importsUrl = fredSeriesUrl(FRED_IMPORTS_SERIES);
     if (!customsUrl || !importsUrl) { console.warn('  FRED tariff rate: FRED_API_KEY not set'); return null; }
     const [customsResp, importsResp] = await Promise.all([
-      fredFetchJson(customsUrl),
-      fredFetchJson(importsUrl),
+      fredFetchJson(customsUrl, _proxyAuth),
+      fredFetchJson(importsUrl, _proxyAuth),
     ]);
     const customs = customsResp?.observations ?? [];
     const imports = importsResp?.observations ?? [];

--- a/tests/trade-policy-tariffs.test.mjs
+++ b/tests/trade-policy-tariffs.test.mjs
@@ -42,10 +42,10 @@ describe('Generated tariff types', () => {
   });
 });
 
-describe('Budget Lab effective tariff seed integration', () => {
-  it('imports parse helpers from shared utils module', () => {
-    assert.match(seedSrc, /_trade-parse-utils\.mjs/);
-    assert.match(seedSrc, /parseBudgetLabEffectiveTariffHtml/);
+describe('FRED effective tariff rate seed integration', () => {
+  it('uses FRED customs duties and imports of goods series', () => {
+    assert.match(seedSrc, /B235RC1Q027SBEA/);
+    assert.match(seedSrc, /A255RC1Q027SBEA/);
   });
 
   it('attaches the effective tariff snapshot only to the US tariff payload', () => {


### PR DESCRIPTION
## Summary
- Budget Lab page became a Next.js SPA, HTML scraping kept breaking
- Replaced with FRED API computation using two official BEA series:
  - `B235RC1Q027SBEA` (customs duties, Billions, Quarterly, SAAR)
  - `A255RC1Q027SBEA` (imports of goods, Billions, Quarterly, SAAR)
  - Effective rate = customs / imports x 100
- Verified: Q4 2025 yields 11.3% (matches Budget Lab's 11.1%)
- Uses existing `fredFetchJson` with `_proxyAuth` for Railway compatibility
- Removed Budget Lab HTML import and parse dependency

## Test plan
- [x] `node --test tests/trade-policy-tariffs.test.mjs` passes (23/23)
- [x] FRED series units verified (both Billions, both SAAR)
- [x] Proxy auth passed for Railway datacenter IP bypass
- [ ] Deploy and verify effective tariff rate appears on US tariff payload