### PR TITLE
feat(deep-dive): alternative supplier risk assessment with chokepoint routing

### DIFF
--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -1721,8 +1721,10 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     mount.append(table, recsMount);
 
     const importerIso2 = this.currentCode;
+    const capturedCode = this.getCode();
     if (importerIso2) {
       fetchChokepointStatus().then(resp => {
+        if (this.getCode() !== capturedCode) return;
         if (!resp.chokepoints.length) return;
         const scores: ChokepointScoreMap = new Map();
         for (const cp of resp.chokepoints) {

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -1452,7 +1452,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     const waterwayMap = new Map(STRATEGIC_WATERWAYS.map(w => [w.id, w.name]));
 
     const cpName = waterwayMap.get(sector.primaryChokepointId) ?? sector.primaryChokepointName;
-    const routesLabel = this.el('div', 'cdp-bypass-heading', `Routes via ${escapeHtml(cpName)}:`);
+    const routesLabel = this.el('div', 'cdp-bypass-heading', `Routes via ${cpName}:`);
     wrap.append(routesLabel);
 
     for (const route of matchingRoutes) {
@@ -1632,17 +1632,20 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     const tbody = this.el('tbody');
     const recsMount = this.el('div', 'cdp-recommendations');
 
+    type ExporterRow = { partnerIso2: string; share: number; value: number; risk: EnrichedExporter['risk'] | null };
+
     const renderRows = (enriched: EnrichedExporter[] | null) => {
       tbody.replaceChildren();
       recsMount.replaceChildren();
 
-      const exporters = enriched ?? product.topExporters.map(exp => ({
-        ...exp,
-        risk: null as null,
-        safeAlternative: null as string | null,
+      const rows: ExporterRow[] = enriched ?? product.topExporters.map(exp => ({
+        partnerIso2: exp.partnerIso2,
+        share: exp.share,
+        value: exp.value,
+        risk: null,
       }));
 
-      for (const exp of exporters) {
+      for (const exp of rows) {
         const tr = this.el('tr');
         const supplierTd = this.el('td', 'cdp-product-supplier');
         const flag = exp.partnerIso2 ? CountryDeepDivePanel.toFlagEmoji(exp.partnerIso2) : '';
@@ -1671,7 +1674,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
 
           if (exp.risk.transitChokepoints.length > 0) {
             const cpNames = exp.risk.transitChokepoints
-              .map(cp => escapeHtml(cp.chokepointName))
+              .map(cp => cp.chokepointName)
               .join(', ');
             const cpInfo = this.el('div', 'cdp-risk-chokepoints');
             cpInfo.textContent = cpNames;
@@ -1689,16 +1692,18 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         if (hasCritical) {
           for (const exp of enriched) {
             if (exp.risk.riskLevel === 'safe') continue;
-            const item = this.el('div', `cdp-recommendation-item cdp-recommendation-warn`);
+            const recCls = exp.risk.riskLevel === 'critical' ? 'cdp-recommendation-critical' : 'cdp-recommendation-warn';
+            const item = this.el('div', `cdp-recommendation-item ${recCls}`);
             const expPct = Math.round(exp.share * 100);
-            let text = `\u26A0 ${escapeHtml(product.description)} imports from ${escapeHtml(exp.partnerIso2)} (${expPct}%) transit`;
+            let text = `\u26A0 ${product.description} imports from ${exp.partnerIso2} (${expPct}%) transit`;
+            if (exp.risk.transitChokepoints.length === 0) continue;
             const worstCp = exp.risk.transitChokepoints.reduce((a, b) => a.disruptionScore > b.disruptionScore ? a : b);
-            text += ` ${escapeHtml(worstCp.chokepointName)} (disruption ${worstCp.disruptionScore}/100).`;
+            text += ` ${worstCp.chokepointName} (disruption ${worstCp.disruptionScore}/100).`;
             if (exp.safeAlternative) {
               const alt = enriched.find(e => e.partnerIso2 === exp.safeAlternative);
               const altPct = alt ? Math.round(alt.share * 100) : 0;
               const altFlag = CountryDeepDivePanel.toFlagEmoji(exp.safeAlternative);
-              text += ` ${altFlag} ${escapeHtml(exp.safeAlternative)} supplies ${altPct}% via routes avoiding this chokepoint.`;
+              text += ` ${altFlag} ${exp.safeAlternative} supplies ${altPct}% via routes avoiding this chokepoint.`;
             }
             item.textContent = text;
             recsMount.append(item);
@@ -1725,7 +1730,9 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         }
         const enriched = computeAlternativeSuppliers(product.topExporters, importerIso2, scores);
         renderRows(enriched);
-      }).catch(() => {});
+      }).catch(() => {
+        console.warn('[deep-dive] Chokepoint status unavailable for route risk enrichment');
+      });
     }
 
     const source = this.el('div', 'cdp-card-footer', `Source: UN Comtrade HS4 bilateral \u00B7 ${product.year}`);

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -1668,7 +1668,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         const riskTd = this.el('td', 'cdp-product-risk');
         if (exp.risk) {
           const badgeCls = `cdp-risk-badge cdp-risk-${exp.risk.riskLevel.replace('_', '-')}`;
-          const badgeLabels: Record<string, string> = { safe: 'Safe', at_risk: 'At Risk', critical: 'Critical' };
+          const badgeLabels: Record<string, string> = { safe: 'Safe', at_risk: 'At Risk', critical: 'Critical', unknown: 'Unknown' };
           const badge = this.el('span', badgeCls, badgeLabels[exp.risk.riskLevel] ?? exp.risk.riskLevel);
           riskTd.append(badge);
 
@@ -1691,7 +1691,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         const hasCritical = enriched.some(e => e.risk.riskLevel === 'critical' || e.risk.riskLevel === 'at_risk');
         if (hasCritical) {
           for (const exp of enriched) {
-            if (exp.risk.riskLevel === 'safe') continue;
+            if (exp.risk.riskLevel === 'safe' || exp.risk.riskLevel === 'unknown') continue;
             const recCls = exp.risk.riskLevel === 'critical' ? 'cdp-recommendation-critical' : 'cdp-recommendation-warn';
             const item = this.el('div', `cdp-recommendation-item ${recCls}`);
             const expPct = Math.round(exp.share * 100);

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -7,6 +7,7 @@ import { getCountryInfrastructure } from '@/services/related-assets';
 import type { PredictionMarket } from '@/services/prediction';
 import type { AssetType, NewsItem, RelatedAsset } from '@/types';
 import { sanitizeUrl, escapeHtml } from '@/utils/sanitize';
+import { computeAlternativeSuppliers, type ChokepointScoreMap, type EnrichedExporter } from '@/utils/supplier-route-risk';
 import { formatIntelBrief } from '@/utils/format-intel-brief';
 import { getCSSColor } from '@/utils';
 import { toFlagEmoji } from '@/utils/country-flag';
@@ -16,7 +17,7 @@ import { STRATEGIC_WATERWAYS } from '@/config/geo';
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { getAuthState } from '@/services/auth-state';
 import { trackGateHit } from '@/services/analytics';
-import { fetchBypassOptions } from '@/services/supply-chain';
+import { fetchBypassOptions, fetchChokepointStatus } from '@/services/supply-chain';
 import { haversineDistanceKm } from '@/services/related-assets';
 import type {
   CountryBriefPanel,
@@ -1624,33 +1625,108 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     hr.append(this.el('th', '', 'Supplier'));
     hr.append(this.el('th', '', 'Share'));
     hr.append(this.el('th', '', 'Value'));
+    hr.append(this.el('th', '', 'Route Risk'));
     thead.append(hr);
     table.append(thead);
 
     const tbody = this.el('tbody');
-    for (const exp of product.topExporters) {
-      const tr = this.el('tr');
-      const supplierTd = this.el('td', 'cdp-product-supplier');
-      const flag = exp.partnerIso2 ? CountryDeepDivePanel.toFlagEmoji(exp.partnerIso2) : '';
-      supplierTd.textContent = `${flag} ${exp.partnerIso2 || 'N/A'}`;
-      tr.append(supplierTd);
+    const recsMount = this.el('div', 'cdp-recommendations');
 
-      const shareTd = this.el('td', 'cdp-product-share');
-      const pct = Math.round(exp.share * 100);
-      shareTd.textContent = `${pct}%`;
-      const barWrap = this.el('div', 'cdp-product-share-bar-wrap');
-      const bar = this.el('div', 'cdp-product-share-bar');
-      bar.style.width = `${Math.min(pct, 100)}%`;
-      if (pct >= 50) bar.classList.add('cdp-product-share-high');
-      barWrap.append(bar);
-      shareTd.append(barWrap);
-      tr.append(shareTd);
+    const renderRows = (enriched: EnrichedExporter[] | null) => {
+      tbody.replaceChildren();
+      recsMount.replaceChildren();
 
-      tr.append(this.el('td', 'cdp-product-val', this.formatMoney(exp.value)));
-      tbody.append(tr);
-    }
+      const exporters = enriched ?? product.topExporters.map(exp => ({
+        ...exp,
+        risk: null as null,
+        safeAlternative: null as string | null,
+      }));
+
+      for (const exp of exporters) {
+        const tr = this.el('tr');
+        const supplierTd = this.el('td', 'cdp-product-supplier');
+        const flag = exp.partnerIso2 ? CountryDeepDivePanel.toFlagEmoji(exp.partnerIso2) : '';
+        supplierTd.textContent = `${flag} ${exp.partnerIso2 || 'N/A'}`;
+        tr.append(supplierTd);
+
+        const shareTd = this.el('td', 'cdp-product-share');
+        const pct = Math.round(exp.share * 100);
+        shareTd.textContent = `${pct}%`;
+        const barWrap = this.el('div', 'cdp-product-share-bar-wrap');
+        const bar = this.el('div', 'cdp-product-share-bar');
+        bar.style.width = `${Math.min(pct, 100)}%`;
+        if (pct >= 50) bar.classList.add('cdp-product-share-high');
+        barWrap.append(bar);
+        shareTd.append(barWrap);
+        tr.append(shareTd);
+
+        tr.append(this.el('td', 'cdp-product-val', this.formatMoney(exp.value)));
+
+        const riskTd = this.el('td', 'cdp-product-risk');
+        if (exp.risk) {
+          const badgeCls = `cdp-risk-badge cdp-risk-${exp.risk.riskLevel.replace('_', '-')}`;
+          const badgeLabels: Record<string, string> = { safe: 'Safe', at_risk: 'At Risk', critical: 'Critical' };
+          const badge = this.el('span', badgeCls, badgeLabels[exp.risk.riskLevel] ?? exp.risk.riskLevel);
+          riskTd.append(badge);
+
+          if (exp.risk.transitChokepoints.length > 0) {
+            const cpNames = exp.risk.transitChokepoints
+              .map(cp => escapeHtml(cp.chokepointName))
+              .join(', ');
+            const cpInfo = this.el('div', 'cdp-risk-chokepoints');
+            cpInfo.textContent = cpNames;
+            riskTd.append(cpInfo);
+          }
+        } else {
+          riskTd.textContent = '\u2014';
+        }
+        tr.append(riskTd);
+        tbody.append(tr);
+      }
+
+      if (enriched) {
+        const hasCritical = enriched.some(e => e.risk.riskLevel === 'critical' || e.risk.riskLevel === 'at_risk');
+        if (hasCritical) {
+          for (const exp of enriched) {
+            if (exp.risk.riskLevel === 'safe') continue;
+            const item = this.el('div', `cdp-recommendation-item cdp-recommendation-warn`);
+            const expPct = Math.round(exp.share * 100);
+            let text = `\u26A0 ${escapeHtml(product.description)} imports from ${escapeHtml(exp.partnerIso2)} (${expPct}%) transit`;
+            const worstCp = exp.risk.transitChokepoints.reduce((a, b) => a.disruptionScore > b.disruptionScore ? a : b);
+            text += ` ${escapeHtml(worstCp.chokepointName)} (disruption ${worstCp.disruptionScore}/100).`;
+            if (exp.safeAlternative) {
+              const alt = enriched.find(e => e.partnerIso2 === exp.safeAlternative);
+              const altPct = alt ? Math.round(alt.share * 100) : 0;
+              const altFlag = CountryDeepDivePanel.toFlagEmoji(exp.safeAlternative);
+              text += ` ${altFlag} ${escapeHtml(exp.safeAlternative)} supplies ${altPct}% via routes avoiding this chokepoint.`;
+            }
+            item.textContent = text;
+            recsMount.append(item);
+          }
+        } else {
+          const safeItem = this.el('div', 'cdp-recommendation-item cdp-recommendation-safe');
+          safeItem.textContent = '\u2713 All current suppliers use routes that avoid disrupted chokepoints.';
+          recsMount.append(safeItem);
+        }
+      }
+    };
+
+    renderRows(null);
     table.append(tbody);
-    mount.append(table);
+    mount.append(table, recsMount);
+
+    const importerIso2 = this.currentCode;
+    if (importerIso2) {
+      fetchChokepointStatus().then(resp => {
+        if (!resp.chokepoints.length) return;
+        const scores: ChokepointScoreMap = new Map();
+        for (const cp of resp.chokepoints) {
+          scores.set(cp.id, cp.disruptionScore);
+        }
+        const enriched = computeAlternativeSuppliers(product.topExporters, importerIso2, scores);
+        renderRows(enriched);
+      }).catch(() => {});
+    }
 
     const source = this.el('div', 'cdp-card-footer', `Source: UN Comtrade HS4 bilateral \u00B7 ${product.year}`);
     mount.append(source);

--- a/src/styles/country-deep-dive.css
+++ b/src/styles/country-deep-dive.css
@@ -1421,3 +1421,62 @@
   text-align: right;
   white-space: nowrap;
 }
+
+.cdp-product-risk {
+  white-space: nowrap;
+}
+
+.cdp-risk-badge {
+  display: inline-block;
+  font-size: 9px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-weight: 600;
+}
+
+.cdp-risk-safe {
+  background: rgba(34,197,94,0.12);
+  color: #4ade80;
+}
+
+.cdp-risk-at-risk {
+  background: rgba(249,115,22,0.12);
+  color: #fb923c;
+}
+
+.cdp-risk-critical {
+  background: rgba(220,38,38,0.15);
+  color: #ef4444;
+}
+
+.cdp-risk-chokepoints {
+  font-size: 10px;
+  color: #64748b;
+  margin-top: 2px;
+}
+
+.cdp-recommendations {
+  margin-top: 10px;
+  padding: 8px;
+  background: rgba(100,116,139,0.06);
+  border-radius: 6px;
+  font-size: 11px;
+}
+
+.cdp-recommendations:empty {
+  display: none;
+}
+
+.cdp-recommendation-item {
+  padding: 4px 0;
+  color: #cbd5e1;
+  line-height: 1.5;
+}
+
+.cdp-recommendation-safe {
+  color: #4ade80;
+}
+
+.cdp-recommendation-warn {
+  color: #fb923c;
+}

--- a/src/styles/country-deep-dive.css
+++ b/src/styles/country-deep-dive.css
@@ -1480,3 +1480,7 @@
 .cdp-recommendation-warn {
   color: #fb923c;
 }
+
+.cdp-recommendation-critical {
+  color: #ef4444;
+}

--- a/src/styles/country-deep-dive.css
+++ b/src/styles/country-deep-dive.css
@@ -1449,6 +1449,11 @@
   color: #ef4444;
 }
 
+.cdp-risk-unknown {
+  background: rgba(100,116,139,0.1);
+  color: #94a3b8;
+}
+
 .cdp-risk-chokepoints {
   font-size: 10px;
   color: #64748b;

--- a/src/utils/supplier-route-risk.ts
+++ b/src/utils/supplier-route-risk.ts
@@ -2,7 +2,7 @@ import COUNTRY_PORT_CLUSTERS from '../../scripts/shared/country-port-clusters.js
 import { TRADE_ROUTES } from '@/config/trade-routes';
 import { CHOKEPOINT_REGISTRY } from '@/config/chokepoint-registry';
 
-export type SupplierRiskLevel = 'safe' | 'at_risk' | 'critical';
+export type SupplierRiskLevel = 'safe' | 'at_risk' | 'critical' | 'unknown';
 
 export interface TransitChokepoint {
   chokepointId: string;
@@ -82,7 +82,8 @@ function collectTransitChokepoints(routeIds: string[], scores: ChokepointScoreMa
   return result;
 }
 
-function determineRiskLevel(chokepoints: TransitChokepoint[]): SupplierRiskLevel {
+function determineRiskLevel(chokepoints: TransitChokepoint[], hasRouteData: boolean): SupplierRiskLevel {
+  if (!hasRouteData) return 'unknown';
   for (const cp of chokepoints) {
     if (cp.disruptionScore >= 70) return 'critical';
   }
@@ -93,6 +94,7 @@ function determineRiskLevel(chokepoints: TransitChokepoint[]): SupplierRiskLevel
 }
 
 function buildRecommendation(riskLevel: SupplierRiskLevel, chokepoints: TransitChokepoint[]): string {
+  if (riskLevel === 'unknown') return 'No modeled maritime route data available for this pair.';
   if (chokepoints.length === 0) return 'No transit chokepoints detected.';
   if (riskLevel === 'critical') {
     const worst = chokepoints.reduce((a, b) => a.disruptionScore > b.disruptionScore ? a : b);
@@ -111,9 +113,12 @@ export function computeSupplierRouteRisk(
   importerIso2: string,
   chokepointScores: ChokepointScoreMap,
 ): SupplierRouteRisk {
+  const hasExporterCluster = !!getCluster(exporterIso2);
+  const hasImporterCluster = !!getCluster(importerIso2);
   const routeIds = findOverlappingRoutes(exporterIso2, importerIso2);
+  const hasRouteData = hasExporterCluster && hasImporterCluster && routeIds.length > 0;
   const transitChokepoints = collectTransitChokepoints(routeIds, chokepointScores);
-  const riskLevel = determineRiskLevel(transitChokepoints);
+  const riskLevel = determineRiskLevel(transitChokepoints, hasRouteData);
   const maxDisruptionScore = transitChokepoints.length > 0
     ? Math.max(...transitChokepoints.map(cp => cp.disruptionScore))
     : 0;

--- a/src/utils/supplier-route-risk.ts
+++ b/src/utils/supplier-route-risk.ts
@@ -27,7 +27,12 @@ interface ClusterEntry {
   coastSide: string;
 }
 
-const clusters = COUNTRY_PORT_CLUSTERS as unknown as Record<string, ClusterEntry | string>;
+interface CountryPortClustersJson {
+  _comment: string;
+  [iso2: string]: ClusterEntry | string;
+}
+
+const clusters: CountryPortClustersJson = COUNTRY_PORT_CLUSTERS;
 
 const chokepointByRoute = new Map<string, string[]>();
 for (const route of TRADE_ROUTES) {
@@ -88,6 +93,7 @@ function determineRiskLevel(chokepoints: TransitChokepoint[]): SupplierRiskLevel
 }
 
 function buildRecommendation(riskLevel: SupplierRiskLevel, chokepoints: TransitChokepoint[]): string {
+  if (chokepoints.length === 0) return 'No transit chokepoints detected.';
   if (riskLevel === 'critical') {
     const worst = chokepoints.reduce((a, b) => a.disruptionScore > b.disruptionScore ? a : b);
     return `Route transits ${worst.chokepointName} (disruption: ${worst.disruptionScore}/100). Consider alternative suppliers.`;
@@ -143,11 +149,6 @@ export function computeAlternativeSuppliers(
     risk: computeSupplierRouteRisk(exp.partnerIso2, importerIso2, chokepointScores),
     safeAlternative: null,
   }));
-
-  enriched.sort((a, b) => {
-    const order: Record<SupplierRiskLevel, number> = { safe: 0, at_risk: 1, critical: 2 };
-    return order[a.risk.riskLevel] - order[b.risk.riskLevel];
-  });
 
   const safeExporters = enriched.filter(e => e.risk.riskLevel === 'safe');
   for (const exp of enriched) {

--- a/src/utils/supplier-route-risk.ts
+++ b/src/utils/supplier-route-risk.ts
@@ -1,0 +1,161 @@
+import COUNTRY_PORT_CLUSTERS from '../../scripts/shared/country-port-clusters.json';
+import { TRADE_ROUTES } from '@/config/trade-routes';
+import { CHOKEPOINT_REGISTRY } from '@/config/chokepoint-registry';
+
+export type SupplierRiskLevel = 'safe' | 'at_risk' | 'critical';
+
+export interface TransitChokepoint {
+  chokepointId: string;
+  chokepointName: string;
+  disruptionScore: number;
+}
+
+export interface SupplierRouteRisk {
+  exporterIso2: string;
+  importerIso2: string;
+  routeIds: string[];
+  transitChokepoints: TransitChokepoint[];
+  riskLevel: SupplierRiskLevel;
+  maxDisruptionScore: number;
+  recommendation: string;
+}
+
+export type ChokepointScoreMap = Map<string, number>;
+
+interface ClusterEntry {
+  nearestRouteIds: string[];
+  coastSide: string;
+}
+
+const clusters = COUNTRY_PORT_CLUSTERS as unknown as Record<string, ClusterEntry | string>;
+
+const chokepointByRoute = new Map<string, string[]>();
+for (const route of TRADE_ROUTES) {
+  if (route.waypoints.length > 0) {
+    chokepointByRoute.set(route.id, route.waypoints);
+  }
+}
+
+const chokepointNameMap = new Map<string, string>();
+for (const cp of CHOKEPOINT_REGISTRY) {
+  chokepointNameMap.set(cp.id, cp.displayName);
+}
+
+function getCluster(iso2: string): ClusterEntry | undefined {
+  const entry = clusters[iso2];
+  if (!entry || typeof entry === 'string') return undefined;
+  return entry;
+}
+
+function findOverlappingRoutes(exporterIso2: string, importerIso2: string): string[] {
+  const exporterCluster = getCluster(exporterIso2);
+  const importerCluster = getCluster(importerIso2);
+  if (!exporterCluster || !importerCluster) return [];
+
+  const importerSet = new Set(importerCluster.nearestRouteIds);
+  return exporterCluster.nearestRouteIds.filter(r => importerSet.has(r));
+}
+
+function collectTransitChokepoints(routeIds: string[], scores: ChokepointScoreMap): TransitChokepoint[] {
+  const seen = new Set<string>();
+  const result: TransitChokepoint[] = [];
+
+  for (const routeId of routeIds) {
+    const waypoints = chokepointByRoute.get(routeId);
+    if (!waypoints) continue;
+    for (const cpId of waypoints) {
+      if (seen.has(cpId)) continue;
+      seen.add(cpId);
+      result.push({
+        chokepointId: cpId,
+        chokepointName: chokepointNameMap.get(cpId) ?? cpId,
+        disruptionScore: scores.get(cpId) ?? 0,
+      });
+    }
+  }
+
+  return result;
+}
+
+function determineRiskLevel(chokepoints: TransitChokepoint[]): SupplierRiskLevel {
+  for (const cp of chokepoints) {
+    if (cp.disruptionScore >= 70) return 'critical';
+  }
+  for (const cp of chokepoints) {
+    if (cp.disruptionScore > 30) return 'at_risk';
+  }
+  return 'safe';
+}
+
+function buildRecommendation(riskLevel: SupplierRiskLevel, chokepoints: TransitChokepoint[]): string {
+  if (riskLevel === 'critical') {
+    const worst = chokepoints.reduce((a, b) => a.disruptionScore > b.disruptionScore ? a : b);
+    return `Route transits ${worst.chokepointName} (disruption: ${worst.disruptionScore}/100). Consider alternative suppliers.`;
+  }
+  if (riskLevel === 'at_risk') {
+    const elevated = chokepoints.filter(cp => cp.disruptionScore > 30);
+    const names = elevated.map(cp => cp.chokepointName).join(', ');
+    return `Route transits ${names} (elevated risk). Monitor closely.`;
+  }
+  return 'Route avoids all currently disrupted chokepoints.';
+}
+
+export function computeSupplierRouteRisk(
+  exporterIso2: string,
+  importerIso2: string,
+  chokepointScores: ChokepointScoreMap,
+): SupplierRouteRisk {
+  const routeIds = findOverlappingRoutes(exporterIso2, importerIso2);
+  const transitChokepoints = collectTransitChokepoints(routeIds, chokepointScores);
+  const riskLevel = determineRiskLevel(transitChokepoints);
+  const maxDisruptionScore = transitChokepoints.length > 0
+    ? Math.max(...transitChokepoints.map(cp => cp.disruptionScore))
+    : 0;
+  const recommendation = buildRecommendation(riskLevel, transitChokepoints);
+
+  return {
+    exporterIso2,
+    importerIso2,
+    routeIds,
+    transitChokepoints,
+    riskLevel,
+    maxDisruptionScore,
+    recommendation,
+  };
+}
+
+export interface EnrichedExporter {
+  partnerCode: number;
+  partnerIso2: string;
+  value: number;
+  share: number;
+  risk: SupplierRouteRisk;
+  safeAlternative: string | null;
+}
+
+export function computeAlternativeSuppliers(
+  exporters: Array<{ partnerCode: number; partnerIso2: string; value: number; share: number }>,
+  importerIso2: string,
+  chokepointScores: ChokepointScoreMap,
+): EnrichedExporter[] {
+  const enriched: EnrichedExporter[] = exporters.map(exp => ({
+    ...exp,
+    risk: computeSupplierRouteRisk(exp.partnerIso2, importerIso2, chokepointScores),
+    safeAlternative: null,
+  }));
+
+  enriched.sort((a, b) => {
+    const order: Record<SupplierRiskLevel, number> = { safe: 0, at_risk: 1, critical: 2 };
+    return order[a.risk.riskLevel] - order[b.risk.riskLevel];
+  });
+
+  const safeExporters = enriched.filter(e => e.risk.riskLevel === 'safe');
+  for (const exp of enriched) {
+    if (exp.risk.riskLevel === 'critical' || exp.risk.riskLevel === 'at_risk') {
+      const alt = safeExporters.find(s => s.partnerIso2 !== exp.partnerIso2);
+      exp.safeAlternative = alt?.partnerIso2 ?? null;
+    }
+  }
+
+  return enriched;
+}

--- a/tests/helpers/country-deep-dive-panel-harness.mjs
+++ b/tests/helpers/country-deep-dive-panel-harness.mjs
@@ -87,12 +87,22 @@ async function loadCountryDeepDivePanel() {
     `],
     ['country-flag-stub', `export function toFlagEmoji(code, fallback = '🌍') { return code ? ':' + code + ':' : fallback; }`],
     ['ports-stub', `export const PORTS = [];`],
-    ['trade-routes-stub', `export function getChokepointRoutes() { return []; }`],
+    ['trade-routes-stub', `export function getChokepointRoutes() { return []; } export const TRADE_ROUTES = [];`],
     ['geo-stub', `export const STRATEGIC_WATERWAYS = [];`],
     ['analytics-stub', `export function trackGateHit() {}`],
+    ['chokepoint-registry-stub', `export const CHOKEPOINT_REGISTRY = [];`],
+    ['supplier-route-risk-stub', `
+      export function computeAlternativeSuppliers(exporters) {
+        return exporters.map(e => ({ ...e, risk: { riskLevel: 'safe', transitChokepoints: [], maxDisruptionScore: 0, recommendation: '', routeIds: [], exporterIso2: e.partnerIso2, importerIso2: '' }, safeAlternative: null }));
+      }
+      export function computeSupplierRouteRisk() {
+        return { riskLevel: 'safe', transitChokepoints: [], maxDisruptionScore: 0, recommendation: '', routeIds: [], exporterIso2: '', importerIso2: '' };
+      }
+    `],
     ['supply-chain-stub', `
       export function fetchBypassOptions() { return Promise.resolve({ corridors: [] }); }
       export function getCountryChokepointIndex() { return null; }
+      export function fetchChokepointStatus() { return Promise.resolve({ chokepoints: [], fetchedAt: '', upstreamUnavailable: false }); }
     `],
     ['runtime-stub', `
       export function toApiUrl(path) { return path; }
@@ -144,6 +154,8 @@ async function loadCountryDeepDivePanel() {
     ['@/config/trade-routes', 'trade-routes-stub'],
     ['@/config/geo', 'geo-stub'],
     ['@/services/analytics', 'analytics-stub'],
+    ['@/config/chokepoint-registry', 'chokepoint-registry-stub'],
+    ['@/utils/supplier-route-risk', 'supplier-route-risk-stub'],
     ['@/services/supply-chain', 'supply-chain-stub'],
     ['./ResilienceWidget', 'resilience-widget-stub'],
     ['@/services/runtime', 'runtime-stub'],

--- a/tests/supplier-route-risk.test.mjs
+++ b/tests/supplier-route-risk.test.mjs
@@ -34,12 +34,13 @@ describe('computeSupplierRouteRisk', () => {
     }
   });
 
-  it('returns safe when no overlapping routes exist', () => {
+  it('returns unknown when no cluster entry exists for exporter/importer', () => {
     const scores = new Map([['hormuz_strait', 90]]);
     const risk = computeSupplierRouteRisk('ZZ', 'YY', scores);
-    assert.equal(risk.riskLevel, 'safe');
+    assert.equal(risk.riskLevel, 'unknown');
     assert.equal(risk.transitChokepoints.length, 0);
     assert.equal(risk.routeIds.length, 0);
+    assert.ok(risk.recommendation.includes('No modeled maritime route'));
   });
 
   it('marks at_risk when chokepoint score is between 31 and 69', () => {
@@ -106,6 +107,19 @@ describe('computeAlternativeSuppliers', () => {
     }
   });
 
+  it('does not recommend unknown-risk exporters as safe alternatives', () => {
+    const mixedExporters = [
+      { partnerCode: 682, partnerIso2: 'SA', value: 5e9, share: 0.40 },
+      { partnerCode: 999, partnerIso2: 'ZZ', value: 3e9, share: 0.25 },
+    ];
+    const scores = new Map([['hormuz_strait', 80]]);
+    const result = computeAlternativeSuppliers(mixedExporters, 'IN', scores);
+    const sa = result.find(e => e.partnerIso2 === 'SA');
+    const zz = result.find(e => e.partnerIso2 === 'ZZ');
+    assert.equal(zz.risk.riskLevel, 'unknown');
+    assert.equal(sa.safeAlternative, null, 'Should not recommend unknown-risk ZZ as a safe alternative');
+  });
+
   it('preserves all original exporter fields', () => {
     const scores = new Map();
     const result = computeAlternativeSuppliers(exporters, 'US', scores);
@@ -130,6 +144,7 @@ describe('CSS classes and integration', () => {
     assert.ok(css.includes('.cdp-risk-safe'), 'Missing .cdp-risk-safe class');
     assert.ok(css.includes('.cdp-risk-at-risk'), 'Missing .cdp-risk-at-risk class');
     assert.ok(css.includes('.cdp-risk-critical'), 'Missing .cdp-risk-critical class');
+    assert.ok(css.includes('.cdp-risk-unknown'), 'Missing .cdp-risk-unknown class');
     assert.ok(css.includes('.cdp-recommendations'), 'Missing .cdp-recommendations class');
     assert.ok(css.includes('.cdp-recommendation-item'), 'Missing .cdp-recommendation-item class');
     assert.ok(css.includes('.cdp-recommendation-safe'), 'Missing .cdp-recommendation-safe class');

--- a/tests/supplier-route-risk.test.mjs
+++ b/tests/supplier-route-risk.test.mjs
@@ -69,16 +69,13 @@ describe('computeAlternativeSuppliers', () => {
     { partnerCode: 840, partnerIso2: 'US', value: 2e9, share: 0.15 },
   ];
 
-  it('sorts safe exporters first when one is critical', () => {
+  it('preserves original trade-share order (no sorting by risk)', () => {
     const scores = new Map([['hormuz_strait', 80]]);
     const result = computeAlternativeSuppliers(exporters, 'IN', scores);
-    assert.ok(result.length === 3);
-    assert.notEqual(result[0].risk.riskLevel, 'critical');
-    const criticalIndex = result.findIndex(e => e.risk.riskLevel === 'critical');
-    const safeIndex = result.findIndex(e => e.risk.riskLevel === 'safe');
-    if (criticalIndex >= 0 && safeIndex >= 0) {
-      assert.ok(safeIndex < criticalIndex, 'Safe exporters should come before critical ones');
-    }
+    assert.equal(result.length, 3);
+    assert.equal(result[0].partnerIso2, 'SA', 'First exporter should remain SA (original order)');
+    assert.equal(result[1].partnerIso2, 'CA', 'Second exporter should remain CA (original order)');
+    assert.equal(result[2].partnerIso2, 'US', 'Third exporter should remain US (original order)');
   });
 
   it('generates safeAlternative for critical/at-risk exporters', () => {
@@ -137,6 +134,7 @@ describe('CSS classes and integration', () => {
     assert.ok(css.includes('.cdp-recommendation-item'), 'Missing .cdp-recommendation-item class');
     assert.ok(css.includes('.cdp-recommendation-safe'), 'Missing .cdp-recommendation-safe class');
     assert.ok(css.includes('.cdp-recommendation-warn'), 'Missing .cdp-recommendation-warn class');
+    assert.ok(css.includes('.cdp-recommendation-critical'), 'Missing .cdp-recommendation-critical class');
   });
 
   it('CountryDeepDivePanel renders Route Risk header', async () => {

--- a/tests/supplier-route-risk.test.mjs
+++ b/tests/supplier-route-risk.test.mjs
@@ -1,0 +1,153 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeSupplierRouteRisk,
+  computeAlternativeSuppliers,
+} from '../src/utils/supplier-route-risk.ts';
+
+describe('computeSupplierRouteRisk', () => {
+  it('detects Hormuz as transit chokepoint for Gulf exporters to India', () => {
+    const scores = new Map([['hormuz_strait', 80], ['malacca_strait', 10]]);
+    const risk = computeSupplierRouteRisk('SA', 'IN', scores);
+
+    const hormuz = risk.transitChokepoints.find(cp => cp.chokepointId === 'hormuz_strait');
+    assert.ok(hormuz, 'Should detect Hormuz on SA-to-IN route');
+    assert.equal(hormuz.disruptionScore, 80);
+  });
+
+  it('marks route as critical when Hormuz disruptionScore is 80', () => {
+    const scores = new Map([['hormuz_strait', 80]]);
+    const risk = computeSupplierRouteRisk('SA', 'IN', scores);
+    assert.equal(risk.riskLevel, 'critical');
+    assert.ok(risk.recommendation.includes('Hormuz'));
+    assert.ok(risk.recommendation.includes('Consider alternative'));
+  });
+
+  it('marks Canada to US as safe (no chokepoints on direct routes)', () => {
+    const scores = new Map([['hormuz_strait', 90], ['suez', 85]]);
+    const risk = computeSupplierRouteRisk('CA', 'US', scores);
+    const directRoutes = risk.routeIds;
+    assert.ok(directRoutes.length > 0, 'Should have overlapping routes (transatlantic, china-us-west)');
+    const hasDisruptedCp = risk.transitChokepoints.some(cp => cp.disruptionScore >= 70);
+    if (!hasDisruptedCp) {
+      assert.equal(risk.riskLevel, 'safe');
+    }
+  });
+
+  it('returns safe when no overlapping routes exist', () => {
+    const scores = new Map([['hormuz_strait', 90]]);
+    const risk = computeSupplierRouteRisk('ZZ', 'YY', scores);
+    assert.equal(risk.riskLevel, 'safe');
+    assert.equal(risk.transitChokepoints.length, 0);
+    assert.equal(risk.routeIds.length, 0);
+  });
+
+  it('marks at_risk when chokepoint score is between 31 and 69', () => {
+    const scores = new Map([['hormuz_strait', 50]]);
+    const risk = computeSupplierRouteRisk('SA', 'IN', scores);
+    assert.equal(risk.riskLevel, 'at_risk');
+    assert.ok(risk.recommendation.includes('elevated risk'));
+  });
+
+  it('marks safe when all chokepoint scores are at or below 30', () => {
+    const scores = new Map([['hormuz_strait', 30], ['malacca_strait', 10]]);
+    const risk = computeSupplierRouteRisk('SA', 'IN', scores);
+    assert.equal(risk.riskLevel, 'safe');
+  });
+
+  it('returns maxDisruptionScore correctly', () => {
+    const scores = new Map([['hormuz_strait', 45], ['malacca_strait', 20]]);
+    const risk = computeSupplierRouteRisk('QA', 'JP', scores);
+    assert.equal(risk.maxDisruptionScore, 45);
+  });
+});
+
+describe('computeAlternativeSuppliers', () => {
+  const exporters = [
+    { partnerCode: 682, partnerIso2: 'SA', value: 5e9, share: 0.40 },
+    { partnerCode: 124, partnerIso2: 'CA', value: 3e9, share: 0.25 },
+    { partnerCode: 840, partnerIso2: 'US', value: 2e9, share: 0.15 },
+  ];
+
+  it('sorts safe exporters first when one is critical', () => {
+    const scores = new Map([['hormuz_strait', 80]]);
+    const result = computeAlternativeSuppliers(exporters, 'IN', scores);
+    assert.ok(result.length === 3);
+    assert.notEqual(result[0].risk.riskLevel, 'critical');
+    const criticalIndex = result.findIndex(e => e.risk.riskLevel === 'critical');
+    const safeIndex = result.findIndex(e => e.risk.riskLevel === 'safe');
+    if (criticalIndex >= 0 && safeIndex >= 0) {
+      assert.ok(safeIndex < criticalIndex, 'Safe exporters should come before critical ones');
+    }
+  });
+
+  it('generates safeAlternative for critical/at-risk exporters', () => {
+    const scores = new Map([['hormuz_strait', 80]]);
+    const result = computeAlternativeSuppliers(exporters, 'IN', scores);
+    for (const exp of result) {
+      if (exp.risk.riskLevel === 'critical' || exp.risk.riskLevel === 'at_risk') {
+        assert.ok(
+          exp.safeAlternative !== null || result.filter(e => e.risk.riskLevel === 'safe').length === 0,
+          `Should suggest alternative for ${exp.partnerIso2} or no safe alternatives available`,
+        );
+      }
+    }
+  });
+
+  it('sets safeAlternative to null when no safe exporters exist', () => {
+    const allGulf = [
+      { partnerCode: 682, partnerIso2: 'SA', value: 5e9, share: 0.50 },
+      { partnerCode: 784, partnerIso2: 'AE', value: 3e9, share: 0.30 },
+      { partnerCode: 414, partnerIso2: 'KW', value: 2e9, share: 0.20 },
+    ];
+    const scores = new Map([['hormuz_strait', 80]]);
+    const result = computeAlternativeSuppliers(allGulf, 'IN', scores);
+    for (const exp of result) {
+      if (exp.risk.riskLevel === 'critical') {
+        assert.equal(exp.safeAlternative, null);
+      }
+    }
+  });
+
+  it('preserves all original exporter fields', () => {
+    const scores = new Map();
+    const result = computeAlternativeSuppliers(exporters, 'US', scores);
+    for (const exp of result) {
+      assert.ok(typeof exp.partnerCode === 'number');
+      assert.ok(typeof exp.partnerIso2 === 'string');
+      assert.ok(typeof exp.value === 'number');
+      assert.ok(typeof exp.share === 'number');
+      assert.ok(exp.risk !== null && exp.risk !== undefined);
+    }
+  });
+});
+
+describe('CSS classes and integration', () => {
+  it('risk badge CSS classes follow naming convention', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const css = await readFile(
+      new URL('../src/styles/country-deep-dive.css', import.meta.url),
+      'utf8',
+    );
+    assert.ok(css.includes('.cdp-risk-badge'), 'Missing .cdp-risk-badge class');
+    assert.ok(css.includes('.cdp-risk-safe'), 'Missing .cdp-risk-safe class');
+    assert.ok(css.includes('.cdp-risk-at-risk'), 'Missing .cdp-risk-at-risk class');
+    assert.ok(css.includes('.cdp-risk-critical'), 'Missing .cdp-risk-critical class');
+    assert.ok(css.includes('.cdp-recommendations'), 'Missing .cdp-recommendations class');
+    assert.ok(css.includes('.cdp-recommendation-item'), 'Missing .cdp-recommendation-item class');
+    assert.ok(css.includes('.cdp-recommendation-safe'), 'Missing .cdp-recommendation-safe class');
+    assert.ok(css.includes('.cdp-recommendation-warn'), 'Missing .cdp-recommendation-warn class');
+  });
+
+  it('CountryDeepDivePanel renders Route Risk header', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const src = await readFile(
+      new URL('../src/components/CountryDeepDivePanel.ts', import.meta.url),
+      'utf8',
+    );
+    assert.ok(src.includes("'Route Risk'"), 'Should have Route Risk column header');
+    assert.ok(src.includes('cdp-risk-badge'), 'Should render risk badges');
+    assert.ok(src.includes('cdp-recommendations'), 'Should render recommendations section');
+    assert.ok(src.includes('computeAlternativeSuppliers'), 'Should use computeAlternativeSuppliers');
+  });
+});


### PR DESCRIPTION
## Summary
- Each product exporter now shows a route risk badge (Safe/At Risk/Critical) based on whether its trade routes transit disrupted chokepoints
- Risk computed client-side: exporter's routes from `country-port-clusters.json` cross-referenced against live chokepoint disruption scores via `fetchChokepointStatus()`
- Transit chokepoints listed per supplier in the table
- Recommendations section: suggests safer alternatives when suppliers route through disrupted chokepoints, or shows "All suppliers use safe routes" when none are disrupted
- New utility `src/utils/supplier-route-risk.ts` with `computeSupplierRouteRisk` and `computeAlternativeSuppliers`

## Test plan
- [ ] Open Country Deep Dive for a country (e.g. India), select a product with diverse exporters
- [ ] Exporters whose routes transit Hormuz/Suez (score 70+) show "Critical" red badge
- [ ] Exporters routing through safe chokepoints show "Safe" green badge
- [ ] Recommendations section suggests alternatives for critical suppliers
- [ ] `npm run typecheck` passes
- [ ] `npm run typecheck:api` passes
- [ ] `npx tsx --test tests/supplier-route-risk.test.mjs` passes (13 tests)
- [ ] `npx tsx --test tests/resilience-country-brief.test.mjs` passes (harness stubs updated)

## Post-Deploy Monitoring & Validation
- No new endpoints or RPCs (client-side computation only)
- Monitor: JS console errors when product is selected (null guards on cluster lookups)
- Expected: risk badges render correctly based on live chokepoint scores