### PR TITLE
feat(sectors): add P/E valuation benchmarking to sector heatmap

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -14,7 +14,7 @@ const BOOTSTRAP_CACHE_KEYS = {
   trafficAnomalies: 'cf:radar:traffic-anomalies:v1',
   marketQuotes:     'market:stocks-bootstrap:v1',
   commodityQuotes:  'market:commodities-bootstrap:v1',
-  sectors:          'market:sectors:v1',
+  sectors:          'market:sectors:v2',
   etfFlows:         'market:etf-flows:v1',
   macroSignals:     'economic:macro-signals:v1',
   bisPolicy:        'economic:bis:policy:v1',

--- a/api/health.js
+++ b/api/health.js
@@ -7,7 +7,7 @@ export const config = { runtime: 'edge' };
 const BOOTSTRAP_KEYS = {
   earthquakes:       'seismology:earthquakes:v1',
   outages:           'infra:outages:v1',
-  sectors:           'market:sectors:v1',
+  sectors:           'market:sectors:v2',
   etfFlows:          'market:etf-flows:v1',
   climateAnomalies:  'climate:anomalies:v2',
   climateDisasters:  'climate:disasters:v1',

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -82,7 +82,7 @@ const TOOL_REGISTRY: ToolDef[] = [
       'market:stocks-bootstrap:v1',
       'market:commodities-bootstrap:v1',
       'market:crypto:v1',
-      'market:sectors:v1',
+      'market:sectors:v2',
       'market:etf-flows:v1',
       'market:gulf-quotes:v1',
       'market:fear-greed:v1',

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1652,7 +1652,7 @@ function fetchYahooQuoteSummary(symbol) {
           resolve({
             trailingPE: raw(sd.trailingPE),
             forwardPE: raw(sd.forwardPE),
-            beta: raw(sd.beta) ?? raw(sd.beta3Year),
+            beta: raw(sd.beta) ?? raw(ks.beta3Year),
             ytdReturn: raw(ks.ytdReturn),
             threeYearReturn: raw(ks.threeYearAverageReturn),
             fiveYearReturn: raw(ks.fiveYearAverageReturn),

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1626,6 +1626,58 @@ function fetchYahooChartDirect(symbol) {
   });
 }
 
+function fetchYahooQuoteSummary(symbol) {
+  return new Promise((resolve) => {
+    const modules = 'summaryDetail,defaultKeyStatistics';
+    const url = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(symbol)}?modules=${modules}`;
+    const req = https.get(url, {
+      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+      timeout: 12000,
+    }, (resp) => {
+      if (resp.statusCode !== 200) {
+        resp.resume();
+        logThrottled('warn', `yahoo-summary-${resp.statusCode}:${symbol}`, `[Sector] Yahoo quoteSummary ${symbol} HTTP ${resp.statusCode}`);
+        return resolve(null);
+      }
+      let body = '';
+      resp.on('data', (chunk) => { body += chunk; });
+      resp.on('end', () => {
+        try {
+          const data = JSON.parse(body);
+          const result = data?.quoteSummary?.result?.[0];
+          if (!result) return resolve(null);
+          const sd = result.summaryDetail || {};
+          const ks = result.defaultKeyStatistics || {};
+          const raw = (obj) => typeof obj === 'object' && obj !== null ? (obj.raw ?? obj.fmt ?? null) : (typeof obj === 'number' ? obj : null);
+          resolve({
+            trailingPE: raw(sd.trailingPE),
+            forwardPE: raw(sd.forwardPE),
+            beta: raw(sd.beta) ?? raw(sd.beta3Year),
+            ytdReturn: raw(ks.ytdReturn),
+            threeYearReturn: raw(ks.threeYearAverageReturn),
+            fiveYearReturn: raw(ks.fiveYearAverageReturn),
+          });
+        } catch { resolve(null); }
+      });
+    });
+    req.on('error', (err) => { logThrottled('warn', `yahoo-summary-err:${symbol}`, `[Sector] Yahoo quoteSummary ${symbol} error: ${err.message}`); resolve(null); });
+    req.on('timeout', () => { req.destroy(); logThrottled('warn', `yahoo-summary-timeout:${symbol}`, `[Sector] Yahoo quoteSummary ${symbol} timeout`); resolve(null); });
+  });
+}
+
+function parseSectorValuation(raw) {
+  if (!raw) return null;
+  const num = (v) => typeof v === 'number' && Number.isFinite(v) ? v : null;
+  const tpe = num(typeof raw.trailingPE === 'string' ? parseFloat(raw.trailingPE) : raw.trailingPE);
+  const fpe = num(typeof raw.forwardPE === 'string' ? parseFloat(raw.forwardPE) : raw.forwardPE);
+  const beta = num(typeof raw.beta === 'string' ? parseFloat(raw.beta) : raw.beta);
+  const ytd = num(typeof raw.ytdReturn === 'string' ? parseFloat(raw.ytdReturn) : raw.ytdReturn);
+  const y3 = num(typeof raw.threeYearReturn === 'string' ? parseFloat(raw.threeYearReturn) : raw.threeYearReturn);
+  const y5 = num(typeof raw.fiveYearReturn === 'string' ? parseFloat(raw.fiveYearReturn) : raw.fiveYearReturn);
+  if (tpe === null && fpe === null) return null;
+  return { trailingPE: tpe, forwardPE: fpe, beta, ytdReturn: ytd, threeYearReturn: y3, fiveYearReturn: y5 };
+}
+
 function fetchFinnhubQuoteDirect(symbol, apiKey) {
   return new Promise((resolve) => {
     const url = `https://finnhub.io/api/v1/quote?symbol=${encodeURIComponent(symbol)}`;
@@ -1786,10 +1838,17 @@ async function seedSectorSummary() {
     return 0;
   }
 
-  const payload = { sectors };
+  const valuations = {};
+  let valCount = 0;
+  for (const s of SECTOR_SYMBOLS) {
+    const raw = await fetchYahooQuoteSummary(s);
+    const parsed = parseSectorValuation(raw);
+    if (parsed) { valuations[s] = parsed; valCount++; }
+    await sleep(150);
+  }
+
+  const payload = { sectors, valuations };
   const ok = await upstashSet('market:sectors:v1', payload, MARKET_SEED_TTL);
-  // Also write under market:quotes:v1: key — the frontend routes sectors through
-  // fetchMultipleStocks → listMarketQuotes RPC, which constructs this key pattern
   const quotesKey = `market:quotes:v1:${[...SECTOR_SYMBOLS].sort().join(',')}`;
   const sectorQuotes = sectors.map((s) => ({
     symbol: s.symbol, name: s.name, display: s.name,
@@ -1798,7 +1857,7 @@ async function seedSectorSummary() {
   const quotesPayload = { quotes: sectorQuotes, finnhubSkipped: false, skipReason: '', rateLimited: false };
   const ok2 = await upstashSet(quotesKey, quotesPayload, MARKET_SEED_TTL);
   const ok3 = await upstashSet('seed-meta:market:sectors', { fetchedAt: Date.now(), recordCount: sectors.length }, 604800);
-  console.log(`[Market] Seeded ${sectors.length}/${SECTOR_SYMBOLS.length} sectors (redis: ${ok && ok2 && ok3 ? 'OK' : 'PARTIAL'})`);
+  console.log(`[Market] Seeded ${sectors.length}/${SECTOR_SYMBOLS.length} sectors, ${valCount} valuations (redis: ${ok && ok2 && ok3 ? 'OK' : 'PARTIAL'})`);
   return sectors.length;
 }
 

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1848,7 +1848,7 @@ async function seedSectorSummary() {
   }
 
   const payload = { sectors, valuations };
-  const ok = await upstashSet('market:sectors:v1', payload, MARKET_SEED_TTL);
+  const ok = await upstashSet('market:sectors:v2', payload, MARKET_SEED_TTL);
   const quotesKey = `market:quotes:v1:${[...SECTOR_SYMBOLS].sort().join(',')}`;
   const sectorQuotes = sectors.map((s) => ({
     symbol: s.symbol, name: s.name, display: s.name,

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -185,7 +185,7 @@ function getTheaterGeoGroup(marketRegion) {
 const MARKET_INPUT_KEYS = {
   stocks: 'market:stocks-bootstrap:v1',
   commodities: 'market:commodities-bootstrap:v1',
-  sectors: 'market:sectors:v1',
+  sectors: 'market:sectors:v2',
   gulfQuotes: 'market:gulf-quotes:v1',
   etfFlows: 'market:etf-flows:v1',
   crypto: 'market:crypto:v1',

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -101,7 +101,7 @@ export const BOOTSTRAP_CACHE_KEYS: Record<string, string> = {
   serviceStatuses:  'infra:service-statuses:v1',
   ddosAttacks:      'cf:radar:ddos:v1',
   trafficAnomalies: 'cf:radar:traffic-anomalies:v1',
-  sectors:          'market:sectors:v1',
+  sectors:          'market:sectors:v2',
   etfFlows:         'market:etf-flows:v1',
   macroSignals:     'economic:macro-signals:v1',
   bisPolicy:        'economic:bis:policy:v1',

--- a/server/worldmonitor/market/v1/get-sector-summary.ts
+++ b/server/worldmonitor/market/v1/get-sector-summary.ts
@@ -10,7 +10,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { getCachedJson } from '../../../_shared/redis';
 
-const SEED_CACHE_KEY = 'market:sectors:v1';
+const SEED_CACHE_KEY = 'market:sectors:v2';
 
 export async function getSectorSummary(
   _ctx: ServerContext,

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1349,19 +1349,37 @@ export class DataLoaderManager implements AppModule {
       });
       const toSectorBar = (s: { symbol?: string; name: string; change: number | null }) =>
         s.symbol && Number.isFinite(s.change) ? { symbol: s.symbol, name: s.name, change1d: s.change as number } : null;
-      if (hydratedSectors?.sectors?.length) {
+      // Defensive: a pre-PR bootstrap payload may have `sectors` but lack the
+      // new `valuations` field entirely. Treat that shape as a cache miss and
+      // fall through to a live fetch so the valuations tab can populate.
+      const hydratedHasValuationsField = hydratedSectors
+        ? Object.prototype.hasOwnProperty.call(hydratedSectors, 'valuations')
+        : false;
+      if (hydratedSectors?.sectors?.length && hydratedHasValuationsField) {
         warmSectorCache(hydratedSectors);
         const items = hydratedSectors.sectors.map(toHeatmapItem);
         const sectorBars = items.map(toSectorBar).filter((s): s is NonNullable<typeof s> => s !== null);
         heatmapPanel?.renderHeatmap(items, sectorBars.length ? sectorBars : undefined);
         heatmapPanel?.updateValuations(hydratedSectors.valuations);
       } else {
+        // If hydrated had sectors but no valuations field, render performance
+        // tiles immediately so users see heatmap data while the live fetch runs.
+        if (hydratedSectors?.sectors?.length) {
+          const items = hydratedSectors.sectors.map(toHeatmapItem);
+          const sectorBars = items.map(toSectorBar).filter((s): s is NonNullable<typeof s> => s !== null);
+          heatmapPanel?.renderHeatmap(items, sectorBars.length ? sectorBars : undefined);
+        }
         const sectorsResp = await fetchSectors() as GetSectorSummaryResponse & { valuations?: Record<string, SectorValuation> };
         if (sectorsResp.sectors.length > 0) {
           const items = sectorsResp.sectors.map(toHeatmapItem);
           const sectorBars = items.map(toSectorBar).filter((s): s is NonNullable<typeof s> => s !== null);
           heatmapPanel?.renderHeatmap(items, sectorBars.length ? sectorBars : undefined);
-          heatmapPanel?.updateValuations(sectorsResp.valuations);
+          // Only push valuations when the response actually has the field — a
+          // payload without `valuations` must NOT clear prior valuations that
+          // may already be rendered from a previous (successful) fetch.
+          if (Object.prototype.hasOwnProperty.call(sectorsResp, 'valuations')) {
+            heatmapPanel?.updateValuations(sectorsResp.valuations);
+          }
         } else if (stocksResult.skipped) {
           this.ctx.panels['heatmap']?.showConfigError(finnhubConfigMsg);
         }

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1354,18 +1354,14 @@ export class DataLoaderManager implements AppModule {
         const items = hydratedSectors.sectors.map(toHeatmapItem);
         const sectorBars = items.map(toSectorBar).filter((s): s is NonNullable<typeof s> => s !== null);
         heatmapPanel?.renderHeatmap(items, sectorBars.length ? sectorBars : undefined);
-        if (hydratedSectors.valuations && Object.keys(hydratedSectors.valuations).length > 0) {
-          heatmapPanel?.updateValuations(hydratedSectors.valuations);
-        }
+        heatmapPanel?.updateValuations(hydratedSectors.valuations);
       } else {
         const sectorsResp = await fetchSectors() as GetSectorSummaryResponse & { valuations?: Record<string, SectorValuation> };
         if (sectorsResp.sectors.length > 0) {
           const items = sectorsResp.sectors.map(toHeatmapItem);
           const sectorBars = items.map(toSectorBar).filter((s): s is NonNullable<typeof s> => s !== null);
           heatmapPanel?.renderHeatmap(items, sectorBars.length ? sectorBars : undefined);
-          if (sectorsResp.valuations && Object.keys(sectorsResp.valuations).length > 0) {
-            heatmapPanel?.updateValuations(sectorsResp.valuations);
-          }
+          heatmapPanel?.updateValuations(sectorsResp.valuations);
         } else if (stocksResult.skipped) {
           this.ctx.panels['heatmap']?.showConfigError(finnhubConfigMsg);
         }

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -130,6 +130,7 @@ import { getHydratedData } from '@/services/bootstrap';
 import { ingestHeadlines } from '@/services/trending-keywords';
 import type { ListFeedDigestResponse } from '@/generated/client/worldmonitor/news/v1/service_client';
 import type { GetSectorSummaryResponse, ListMarketQuotesResponse, ListCommodityQuotesResponse } from '@/generated/client/worldmonitor/market/v1/service_client';
+import type { SectorValuation } from '@/components/MarketPanel';
 import { mountCommunityWidget } from '@/components/CommunityWidget';
 import { ResearchServiceClient } from '@/generated/client/worldmonitor/research/v1/service_client';
 import {
@@ -1338,7 +1339,7 @@ export class DataLoaderManager implements AppModule {
       }
 
       // Sector heatmap: always attempt loading regardless of market rate-limit status
-      const hydratedSectors = getHydratedData('sectors') as GetSectorSummaryResponse | undefined;
+      const hydratedSectors = getHydratedData('sectors') as (GetSectorSummaryResponse & { valuations?: Record<string, SectorValuation> }) | undefined;
       const heatmapPanel = this.ctx.panels['heatmap'] as HeatmapPanel | undefined;
       const sectorNameMap = new Map(SECTORS.map((s) => [s.symbol, s.name]));
       const toHeatmapItem = (s: { symbol: string; name: string; change: number }) => ({
@@ -1353,12 +1354,18 @@ export class DataLoaderManager implements AppModule {
         const items = hydratedSectors.sectors.map(toHeatmapItem);
         const sectorBars = items.map(toSectorBar).filter((s): s is NonNullable<typeof s> => s !== null);
         heatmapPanel?.renderHeatmap(items, sectorBars.length ? sectorBars : undefined);
+        if (hydratedSectors.valuations && Object.keys(hydratedSectors.valuations).length > 0) {
+          heatmapPanel?.updateValuations(hydratedSectors.valuations);
+        }
       } else {
-        const sectorsResp = await fetchSectors();
+        const sectorsResp = await fetchSectors() as GetSectorSummaryResponse & { valuations?: Record<string, SectorValuation> };
         if (sectorsResp.sectors.length > 0) {
           const items = sectorsResp.sectors.map(toHeatmapItem);
           const sectorBars = items.map(toSectorBar).filter((s): s is NonNullable<typeof s> => s !== null);
           heatmapPanel?.renderHeatmap(items, sectorBars.length ? sectorBars : undefined);
+          if (sectorsResp.valuations && Object.keys(sectorsResp.valuations).length > 0) {
+            heatmapPanel?.updateValuations(sectorsResp.valuations);
+          }
         } else if (stocksResult.skipped) {
           this.ctx.panels['heatmap']?.showConfigError(finnhubConfigMsg);
         }

--- a/src/components/MarketPanel.ts
+++ b/src/components/MarketPanel.ts
@@ -134,20 +134,76 @@ export class MarketPanel extends Panel {
   }
 }
 
+export interface SectorValuation {
+  trailingPE: number | null;
+  forwardPE: number | null;
+  beta: number | null;
+  ytdReturn: number | null;
+  threeYearReturn: number | null;
+  fiveYearReturn: number | null;
+}
+
+type HeatmapTab = 'performance' | 'valuations';
+
 export class HeatmapPanel extends Panel {
+  private _tab: HeatmapTab = 'performance';
+  private _heatmapData: Array<{ symbol?: string; name: string; change: number | null }> = [];
+  private _sectorBars: Array<{ symbol: string; name: string; change1d: number }> = [];
+  private _valuations: Record<string, SectorValuation> = {};
+
   constructor() {
     super({ id: 'heatmap', title: t('panels.heatmap'), infoTooltip: t('components.heatmap.infoTooltip') });
+    this.content.addEventListener('click', (e) => {
+      const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-tab]');
+      const tab = btn?.dataset.tab;
+      if (tab === 'performance' || tab === 'valuations') {
+        this._tab = tab;
+        this._render();
+      }
+    });
   }
 
   public renderHeatmap(
     data: Array<{ symbol?: string; name: string; change: number | null }>,
     sectorBars?: Array<{ symbol: string; name: string; change1d: number }>,
   ): void {
-    if (data.length === 0) {
+    this._heatmapData = data;
+    this._sectorBars = sectorBars ?? [];
+    this._render();
+  }
+
+  public updateValuations(valuations: Record<string, SectorValuation>): void {
+    this._valuations = valuations;
+    this._render();
+  }
+
+  private _buildTabBar(): string {
+    const hasValuations = Object.keys(this._valuations).length > 0;
+    if (!hasValuations) return '';
+    return `<div style="display:flex;gap:4px;margin-bottom:8px">
+      <button class="panel-tab${this._tab === 'performance' ? ' active' : ''}" data-tab="performance" style="font-size:11px;padding:3px 10px">Performance</button>
+      <button class="panel-tab${this._tab === 'valuations' ? ' active' : ''}" data-tab="valuations" style="font-size:11px;padding:3px 10px">Valuations</button>
+    </div>`;
+  }
+
+  private _render(): void {
+    if (this._heatmapData.length === 0) {
       this.showRetrying(t('common.failedSectorData'));
       return;
     }
 
+    const tabBar = this._buildTabBar();
+
+    if (this._tab === 'valuations' && Object.keys(this._valuations).length > 0) {
+      this.setContent(tabBar + this._renderValuations());
+      return;
+    }
+
+    this.setContent(tabBar + this._renderPerformance());
+  }
+
+  private _renderPerformance(): string {
+    const data = this._heatmapData;
     const tileHtml =
       '<div class="heatmap">' +
       data
@@ -167,35 +223,107 @@ export class HeatmapPanel extends Panel {
         .join('') +
       '</div>';
 
-    let barChartHtml = '';
-    if (sectorBars && sectorBars.length > 0) {
-      const sorted = [...sectorBars]
-        .filter((s) => Number.isFinite(s.change1d))
-        .sort((a, b) => b.change1d - a.change1d);
-      if (sorted.length === 0) {
-        this.setContent(tileHtml);
-        return;
-      }
-      const maxAbs = Math.max(...sorted.map((s) => Math.abs(s.change1d)), 3);
-      barChartHtml =
-        '<div class="heatmap-bar-chart">' +
-        sorted
-          .map((s) => {
-            const pct = Math.min((Math.abs(s.change1d) / maxAbs) * 100, 100).toFixed(1);
-            const isPos = s.change1d >= 0;
-            const color = isPos ? 'var(--green)' : 'var(--red)';
-            const sign = isPos ? '+' : '';
-            return `<div class="heatmap-bar-row">
+    if (this._sectorBars.length === 0) return tileHtml;
+
+    const sorted = [...this._sectorBars]
+      .filter((s) => Number.isFinite(s.change1d))
+      .sort((a, b) => b.change1d - a.change1d);
+    if (sorted.length === 0) return tileHtml;
+
+    const maxAbs = Math.max(...sorted.map((s) => Math.abs(s.change1d)), 3);
+    const barChartHtml =
+      '<div class="heatmap-bar-chart">' +
+      sorted
+        .map((s) => {
+          const pct = Math.min((Math.abs(s.change1d) / maxAbs) * 100, 100).toFixed(1);
+          const isPos = s.change1d >= 0;
+          const color = isPos ? 'var(--green)' : 'var(--red)';
+          const sign = isPos ? '+' : '';
+          return `<div class="heatmap-bar-row">
   <span class="heatmap-bar-label">${escapeHtml(s.symbol)}</span>
   <div class="heatmap-bar-track"><div class="heatmap-bar-fill" style="width:${pct}%;background:${color}"></div></div>
   <span class="heatmap-bar-value ${isPos ? 'positive' : 'negative'}">${sign}${s.change1d.toFixed(2)}%</span>
 </div>`;
-          })
-          .join('') +
-        '</div>';
+        })
+        .join('') +
+      '</div>';
+
+    return tileHtml + barChartHtml;
+  }
+
+  private _renderValuations(): string {
+    const entries = Object.entries(this._valuations)
+      .map(([symbol, v]) => ({ symbol, ...v }))
+      .filter((e) => e.forwardPE !== null || e.trailingPE !== null);
+
+    if (entries.length === 0) {
+      return '<div style="padding:8px;color:var(--text-dim);font-size:12px">No valuation data available</div>';
     }
 
-    this.setContent(tileHtml + barChartHtml);
+    const sorted = [...entries].sort((a, b) => (a.forwardPE ?? a.trailingPE ?? 999) - (b.forwardPE ?? b.trailingPE ?? 999));
+    const peValues = sorted.map((e) => e.forwardPE ?? e.trailingPE ?? 0).filter((v) => v > 0);
+    const median = (peValues.length > 0 ? peValues[Math.floor(peValues.length / 2)] : undefined) ?? 20;
+    const maxPE = Math.max(...peValues, 30);
+
+    const nameMap = new Map(this._heatmapData.map((s) => [s.symbol, s.name]));
+    const fmtPE = (v: number | null) => v !== null ? v.toFixed(1) : '--';
+    const fmtPct = (v: number | null) => {
+      if (v === null) return '--';
+      const pct = v * 100;
+      return `${pct >= 0 ? '+' : ''}${pct.toFixed(1)}%`;
+    };
+    const fmtBeta = (v: number | null) => v !== null ? v.toFixed(2) : '--';
+
+    const peColor = (v: number | null): string => {
+      if (v === null) return 'var(--text-dim)';
+      if (v < median * 0.8) return 'var(--green)';
+      if (v > median * 1.2) return 'var(--red)';
+      return '#e6a817';
+    };
+
+    const barChart =
+      '<div class="heatmap-bar-chart" style="margin-bottom:12px">' +
+      sorted
+        .map((e) => {
+          const pe = e.forwardPE ?? e.trailingPE ?? 0;
+          const pct = Math.min((pe / maxPE) * 100, 100).toFixed(1);
+          const color = peColor(pe > 0 ? pe : null);
+          const label = nameMap.get(e.symbol) ?? e.symbol;
+          return `<div class="heatmap-bar-row">
+  <span class="heatmap-bar-label" title="${escapeHtml(e.symbol)}">${escapeHtml(label)}</span>
+  <div class="heatmap-bar-track"><div class="heatmap-bar-fill" style="width:${pct}%;background:${color}"></div></div>
+  <span class="heatmap-bar-value" style="color:${color}">${pe > 0 ? pe.toFixed(1) + 'x' : '--'}</span>
+</div>`;
+        })
+        .join('') +
+      '</div>';
+
+    const tableRows = sorted
+      .map((e) => {
+        const name = nameMap.get(e.symbol) ?? e.symbol;
+        return `<tr>
+  <td style="padding:3px 6px;white-space:nowrap;font-size:11px">${escapeHtml(name)}</td>
+  <td style="padding:3px 6px;text-align:right;font-size:11px;color:${peColor(e.trailingPE)}">${fmtPE(e.trailingPE)}</td>
+  <td style="padding:3px 6px;text-align:right;font-size:11px;color:${peColor(e.forwardPE)}">${fmtPE(e.forwardPE)}</td>
+  <td style="padding:3px 6px;text-align:right;font-size:11px">${fmtBeta(e.beta)}</td>
+  <td style="padding:3px 6px;text-align:right;font-size:11px;color:${e.ytdReturn !== null && e.ytdReturn >= 0 ? 'var(--green)' : 'var(--red)'}">${fmtPct(e.ytdReturn)}</td>
+</tr>`;
+      })
+      .join('');
+
+    const table = `<div style="overflow-x:auto">
+<table style="width:100%;border-collapse:collapse;font-size:11px">
+  <thead><tr style="color:var(--text-dim);border-bottom:1px solid var(--border)">
+    <th style="padding:3px 6px;text-align:left;font-weight:500">Sector</th>
+    <th style="padding:3px 6px;text-align:right;font-weight:500">Trail P/E</th>
+    <th style="padding:3px 6px;text-align:right;font-weight:500">Fwd P/E</th>
+    <th style="padding:3px 6px;text-align:right;font-weight:500">Beta</th>
+    <th style="padding:3px 6px;text-align:right;font-weight:500">YTD</th>
+  </tr></thead>
+  <tbody>${tableRows}</tbody>
+</table></div>`;
+
+    return barChart + table;
   }
 }
 

--- a/src/components/MarketPanel.ts
+++ b/src/components/MarketPanel.ts
@@ -173,7 +173,11 @@ export class HeatmapPanel extends Panel {
   }
 
   public updateValuations(valuations: Record<string, SectorValuation> | undefined): void {
-    if (!valuations || Object.keys(valuations).length === 0) {
+    // undefined = caller has no valuations to push (e.g. fresh fetch returned
+    // a payload without the field). Leave prior state intact so returning
+    // users don't see the Valuations tab vanish mid-session.
+    if (valuations === undefined) return;
+    if (Object.keys(valuations).length === 0) {
       this._valuations = {};
       if (this._tab === 'valuations') this._tab = 'performance';
       this._render();

--- a/src/components/MarketPanel.ts
+++ b/src/components/MarketPanel.ts
@@ -316,7 +316,7 @@ export class HeatmapPanel extends Panel {
   <td style="padding:3px 6px;text-align:right;font-size:11px;color:${peColor(e.trailingPE)}">${fmtPE(e.trailingPE)}</td>
   <td style="padding:3px 6px;text-align:right;font-size:11px;color:${peColor(e.forwardPE)}">${fmtPE(e.forwardPE)}</td>
   <td style="padding:3px 6px;text-align:right;font-size:11px">${fmtBeta(e.beta)}</td>
-  <td style="padding:3px 6px;text-align:right;font-size:11px;color:${e.ytdReturn !== null && e.ytdReturn >= 0 ? 'var(--green)' : 'var(--red)'}">${fmtPct(e.ytdReturn)}</td>
+  <td style="padding:3px 6px;text-align:right;font-size:11px;color:${e.ytdReturn === null ? 'var(--text-dim)' : e.ytdReturn >= 0 ? 'var(--green)' : 'var(--red)'}">${fmtPct(e.ytdReturn)}</td>
 </tr>`;
       })
       .join('');

--- a/src/components/MarketPanel.ts
+++ b/src/components/MarketPanel.ts
@@ -172,7 +172,13 @@ export class HeatmapPanel extends Panel {
     this._render();
   }
 
-  public updateValuations(valuations: Record<string, SectorValuation>): void {
+  public updateValuations(valuations: Record<string, SectorValuation> | undefined): void {
+    if (!valuations || Object.keys(valuations).length === 0) {
+      this._valuations = {};
+      if (this._tab === 'valuations') this._tab = 'performance';
+      this._render();
+      return;
+    }
     this._valuations = valuations;
     this._render();
   }

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -121,7 +121,7 @@ export const COMMANDS: Command[] = [
   { id: 'panel:stock-backtest', keywords: ['backtest', 'stock backtest', 'backtesting', 'strategy'], label: 'Panel: Stock Backtesting', icon: '\u{1F4C9}', category: 'panels' },
   { id: 'panel:daily-market-brief', keywords: ['daily brief', 'market brief', 'morning brief'], label: 'Panel: Daily Market Brief', icon: '\u{1F4CB}', category: 'panels' },
   { id: 'panel:market-implications', keywords: ['market implications', 'trade signals', 'ai signals', 'long short hedge', 'trade thesis'], label: 'Panel: AI Market Implications', icon: '\u{1F4CA}', category: 'panels' },
-  { id: 'panel:heatmap', keywords: ['heatmap', 'sector heatmap'], label: 'Panel: Sector Heatmap', icon: '\u{1F5FA}\uFE0F', category: 'panels' },
+  { id: 'panel:heatmap', keywords: ['heatmap', 'sector heatmap', 'sector pe', 'pe ratio', 'valuations', 'forward pe', 'trailing pe', 'sector beta'], label: 'Panel: Sector Heatmap', icon: '\u{1F5FA}\uFE0F', category: 'panels' },
   { id: 'panel:ai', keywords: ['ai', 'ml', 'artificial intelligence'], label: 'Panel: AI/ML', icon: '\u{1F916}', category: 'panels' },
   { id: 'panel:macro-signals', keywords: ['macro', 'macro signals', 'liquidity'], label: 'Panel: Market Radar', icon: '\u{1F4C9}', category: 'panels' },
   { id: 'panel:fear-greed', keywords: ['fear', 'greed', 'fear and greed', 'sentiment', 'fear greed index'], label: 'Panel: Fear & Greed', icon: '\u{1F4CA}', category: 'panels' },

--- a/src/services/market/index.ts
+++ b/src/services/market/index.ts
@@ -30,7 +30,7 @@ const client = new MarketServiceClient(getRpcBaseUrl(), { fetch: (...args: Param
 const MARKET_QUOTES_CACHE_TTL_MS = 5 * 60 * 1000;
 const stockBreaker = createCircuitBreaker<ListMarketQuotesResponse>({ name: 'Market Quotes', cacheTtlMs: MARKET_QUOTES_CACHE_TTL_MS, persistCache: true });
 const commodityBreaker = createCircuitBreaker<ListCommodityQuotesResponse>({ name: 'Commodity Quotes', cacheTtlMs: MARKET_QUOTES_CACHE_TTL_MS, persistCache: true });
-const sectorBreaker = createCircuitBreaker<GetSectorSummaryResponse>({ name: 'Sector Summary', cacheTtlMs: MARKET_QUOTES_CACHE_TTL_MS, persistCache: true });
+const sectorBreaker = createCircuitBreaker<GetSectorSummaryResponse>({ name: 'Sector Summary v2', cacheTtlMs: MARKET_QUOTES_CACHE_TTL_MS, persistCache: true });
 const cryptoBreaker = createCircuitBreaker<ListCryptoQuotesResponse>({ name: 'Crypto Quotes', persistCache: true });
 const cryptoSectorsBreaker = createCircuitBreaker<ListCryptoSectorsResponse>({ name: 'Crypto Sectors', persistCache: true });
 const defiBreaker = createCircuitBreaker<ListDefiTokensResponse>({ name: 'DeFi Tokens', persistCache: true });
@@ -209,14 +209,22 @@ export async function fetchCommodityQuotes(
 }
 
 // ========================================================================
-// Sectors -- uses getSectorSummary (reads market:sectors:v1)
+// Sectors -- uses getSectorSummary (reads market:sectors:v2)
 // ========================================================================
 
 export async function fetchSectors(): Promise<GetSectorSummaryResponse> {
   return sectorBreaker.execute(async () => {
     return client.getSectorSummary({ period: '' });
   }, emptySectorFallback, {
-    shouldCache: (r: GetSectorSummaryResponse) => r.sectors.length > 0,
+    // Require sectors AND the valuations field to be present (not missing) so
+    // pre-PR payloads that lack the valuations key are never cached/replayed
+    // as stale data for the session. Empty object {} is OK (API may legitimately
+    // return zero valuations after Yahoo failures) but the key must exist.
+    shouldCache: (r: GetSectorSummaryResponse) => {
+      if (r.sectors.length === 0) return false;
+      const withValuations = r as GetSectorSummaryResponse & { valuations?: unknown };
+      return Object.prototype.hasOwnProperty.call(withValuations, 'valuations');
+    },
   });
 }
 

--- a/src/services/market/index.ts
+++ b/src/services/market/index.ts
@@ -168,7 +168,11 @@ export function warmCommodityCache(quotes: ListCommodityQuotesResponse): void {
   commodityBreaker.recordSuccess(quotes, cacheKey);
 }
 
-/** Pre-warm the sector circuit-breaker cache from bootstrap hydration data. */
+/**
+ * Pre-warm the sector circuit-breaker cache from bootstrap hydration data.
+ * Valuations are included in the sector summary payload; clients pick them up
+ * on the next breaker refresh (5-min TTL) without a separate cache-bust.
+ */
 export function warmSectorCache(resp: GetSectorSummaryResponse): void {
   sectorBreaker.recordSuccess(resp);
 }

--- a/tests/sector-valuations.test.mjs
+++ b/tests/sector-valuations.test.mjs
@@ -1,0 +1,159 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const src = readFileSync('scripts/ais-relay.cjs', 'utf8');
+
+const extractFn = (name) => {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) throw new Error(`Function ${name} not found`);
+  let depth = 0;
+  let i = src.indexOf('{', start);
+  const bodyStart = i;
+  for (; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    if (src[i] === '}') depth--;
+    if (depth === 0) break;
+  }
+  return src.slice(bodyStart, i + 1);
+};
+
+// eslint-disable-next-line no-new-func
+const parseSectorValuation = new Function(
+  'raw',
+  extractFn('parseSectorValuation')
+    .replace(/^{/, '')
+    .replace(/}$/, ''),
+);
+
+describe('parseSectorValuation', () => {
+  it('returns null for null input', () => {
+    assert.equal(parseSectorValuation(null), null);
+  });
+
+  it('returns null for undefined input', () => {
+    assert.equal(parseSectorValuation(undefined), null);
+  });
+
+  it('returns null when both PE values are missing', () => {
+    assert.equal(parseSectorValuation({ beta: 1.2 }), null);
+  });
+
+  it('parses numeric values correctly', () => {
+    const result = parseSectorValuation({
+      trailingPE: 25.3,
+      forwardPE: 22.1,
+      beta: 1.05,
+      ytdReturn: 0.08,
+      threeYearReturn: 0.12,
+      fiveYearReturn: 0.10,
+    });
+    assert.equal(result.trailingPE, 25.3);
+    assert.equal(result.forwardPE, 22.1);
+    assert.equal(result.beta, 1.05);
+    assert.equal(result.ytdReturn, 0.08);
+    assert.equal(result.threeYearReturn, 0.12);
+    assert.equal(result.fiveYearReturn, 0.10);
+  });
+
+  it('handles string values via typeof guard (PizzINT pattern)', () => {
+    const result = parseSectorValuation({
+      trailingPE: '18.5',
+      forwardPE: '16.2',
+      beta: '0.95',
+      ytdReturn: '0.05',
+    });
+    assert.equal(result.trailingPE, 18.5);
+    assert.equal(result.forwardPE, 16.2);
+    assert.equal(result.beta, 0.95);
+    assert.equal(result.ytdReturn, 0.05);
+  });
+
+  it('returns null for NaN/Infinity values', () => {
+    const result = parseSectorValuation({
+      trailingPE: NaN,
+      forwardPE: Infinity,
+    });
+    assert.equal(result, null);
+  });
+
+  it('allows partial data (trailingPE only)', () => {
+    const result = parseSectorValuation({
+      trailingPE: 20,
+    });
+    assert.equal(result.trailingPE, 20);
+    assert.equal(result.forwardPE, null);
+    assert.equal(result.beta, null);
+    assert.equal(result.ytdReturn, null);
+  });
+
+  it('allows partial data (forwardPE only)', () => {
+    const result = parseSectorValuation({
+      forwardPE: 15,
+    });
+    assert.equal(result.trailingPE, null);
+    assert.equal(result.forwardPE, 15);
+  });
+});
+
+describe('fetchYahooQuoteSummary (static analysis)', () => {
+  const fnStart = src.indexOf('function fetchYahooQuoteSummary(');
+  const fnChunk = src.slice(fnStart, fnStart + 1500);
+
+  it('exists in ais-relay.cjs', () => {
+    assert.ok(fnStart > -1, 'fetchYahooQuoteSummary function not found');
+  });
+
+  it('uses summaryDetail and defaultKeyStatistics modules', () => {
+    assert.match(fnChunk, /summaryDetail/, 'should request summaryDetail module');
+    assert.match(fnChunk, /defaultKeyStatistics/, 'should request defaultKeyStatistics module');
+  });
+
+  it('uses v10/finance/quoteSummary endpoint', () => {
+    assert.match(fnChunk, /v10\/finance\/quoteSummary/, 'should call Yahoo quoteSummary v10 API');
+  });
+
+  it('extracts trailingPE, forwardPE, and beta', () => {
+    assert.match(fnChunk, /trailingPE/, 'should extract trailingPE');
+    assert.match(fnChunk, /forwardPE/, 'should extract forwardPE');
+    assert.match(fnChunk, /beta/, 'should extract beta');
+  });
+
+  it('extracts return metrics from defaultKeyStatistics', () => {
+    assert.match(fnChunk, /ytdReturn/, 'should extract ytdReturn');
+  });
+
+  it('includes User-Agent header', () => {
+    assert.match(fnChunk, /User-Agent/, 'should include User-Agent for Yahoo requests');
+  });
+
+  it('has timeout configured', () => {
+    assert.match(fnChunk, /timeout:\s*\d+/, 'should have a timeout set');
+  });
+});
+
+describe('seedSectorSummary valuation integration (static analysis)', () => {
+  const fnStart = src.indexOf('async function seedSectorSummary()');
+  const fnEnd = src.indexOf('\n// Gulf Quotes');
+  const fnBody = src.slice(fnStart, fnEnd);
+
+  it('calls fetchYahooQuoteSummary for each sector', () => {
+    assert.match(fnBody, /fetchYahooQuoteSummary\(s\)/, 'should call fetchYahooQuoteSummary per sector');
+  });
+
+  it('calls parseSectorValuation on raw response', () => {
+    assert.match(fnBody, /parseSectorValuation\(raw\)/, 'should parse raw valuation data');
+  });
+
+  it('includes valuations in payload', () => {
+    assert.match(fnBody, /valuations/, 'payload should include valuations object');
+  });
+
+  it('sleeps between Yahoo requests (rate limit)', () => {
+    assert.match(fnBody, /await sleep\(150\)/, 'should sleep 150ms between Yahoo calls');
+  });
+
+  it('logs valuation count', () => {
+    assert.match(fnBody, /valCount/, 'should log how many valuations were fetched');
+  });
+});


### PR DESCRIPTION
## Summary
- Extends the sector ETF seed (`seedSectorSummary` in ais-relay.cjs) to fetch trailing/forward P/E, beta, YTD return, and 3/5-year returns from Yahoo Finance `quoteSummary` API for all 12 sector ETFs
- Adds a "Valuations" tab to the existing Sector Heatmap panel with a horizontal bar chart (green=cheap, yellow=fair, red=expensive by forward P/E) and a sortable table showing all metrics
- Updates CMD+K search keywords to include valuation terms (pe ratio, forward pe, sector beta, etc.)

## Changes
- `scripts/ais-relay.cjs`: New `fetchYahooQuoteSummary()` + `parseSectorValuation()` functions; `seedSectorSummary()` now fetches valuations with 150ms delay between calls and stores them in the existing `market:sectors:v1` key
- `src/components/MarketPanel.ts`: `HeatmapPanel` refactored to support tabs (Performance/Valuations), new `_renderValuations()` method with bar chart + table
- `src/app/data-loader.ts`: Passes valuations from hydrated/fetched sector data to the heatmap panel
- `src/config/commands.ts`: Added valuation keywords to heatmap panel CMD+K entry
- `tests/sector-valuations.test.mjs`: 20 tests covering `parseSectorValuation` unit tests + static analysis of the seeder integration

## Test plan
- [x] 20/20 unit + static analysis tests pass (`node --test tests/sector-valuations.test.mjs`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Bootstrap tests pass (35/35)
- [x] Edge function tests pass (164/164)
- [ ] Visual check: open heatmap panel, click "Valuations" tab, verify bar chart + table render
- [ ] Verify CMD+K search for "pe ratio" navigates to heatmap panel