### PR TITLE
fix(emails): redesign intelligence brief email template

### DIFF
--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -382,55 +382,63 @@ function formatDigestHtml(stories, nowMs) {
     .map((sev) => sectionHtml(sev, buckets[sev]))
     .join('');
 
-  return `<div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto; background: #0a0a0a; color: #e0e0e0;">
-  <div style="background: #4ade80; height: 4px;"></div>
-  <div style="padding: 40px 32px 0;">
-    <table cellpadding="0" cellspacing="0" border="0" style="margin: 0 auto 32px;">
-      <tr>
-        <td style="width: 40px; height: 40px; vertical-align: middle;">
-          <img src="https://www.worldmonitor.app/favico/android-chrome-192x192.png" width="40" height="40" alt="WorldMonitor" style="border-radius: 50%; display: block;" />
-        </td>
-        <td style="padding-left: 12px;">
-          <div style="font-size: 16px; font-weight: 800; color: #fff; letter-spacing: -0.5px;">WORLD MONITOR</div>
-          <div style="font-size: 10px; color: #666; text-transform: uppercase; letter-spacing: 2px;">Daily Intelligence Digest</div>
-        </td>
-      </tr>
-    </table>
-    <div style="background: #111; border: 1px solid #1a1a1a; border-left: 3px solid #4ade80; padding: 20px 24px; margin-bottom: 28px;">
-      <p style="font-size: 18px; font-weight: 600; color: #fff; margin: 0 0 8px;">Your Digest &mdash; ${dateStr}</p>
-      <p style="font-size: 14px; color: #999; margin: 0; line-height: 1.5;">${totalCount} event${totalCount !== 1 ? 's' : ''} tracked across monitored regions.</p>
+  return `<div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #111; color: #e0e0e0;">
+  <div style="max-width: 680px; margin: 0 auto;">
+    <div style="background: #4ade80; height: 3px;"></div>
+    <div style="background: #0d0d0d; padding: 32px 36px 0;">
+      <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-bottom: 28px;">
+        <tr>
+          <td style="vertical-align: middle;">
+            <table cellpadding="0" cellspacing="0" border="0">
+              <tr>
+                <td style="width: 36px; height: 36px; vertical-align: middle;">
+                  <img src="https://www.worldmonitor.app/favico/android-chrome-192x192.png" width="36" height="36" alt="WorldMonitor" style="border-radius: 50%; display: block;" />
+                </td>
+                <td style="padding-left: 10px;">
+                  <div style="font-size: 15px; font-weight: 800; color: #fff; letter-spacing: -0.3px;">WORLD MONITOR</div>
+                </td>
+              </tr>
+            </table>
+          </td>
+          <td style="text-align: right; vertical-align: middle;">
+            <span style="font-size: 11px; color: #555; text-transform: uppercase; letter-spacing: 1px;">${dateStr}</span>
+          </td>
+        </tr>
+      </table>
+      <div data-ai-summary-slot></div>
+      <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-bottom: 24px;">
+        <tr>
+          <td style="text-align: center; padding: 14px 8px; width: 33%; background: #161616; border: 1px solid #222;">
+            <div style="font-size: 24px; font-weight: 800; color: #4ade80;">${totalCount}</div>
+            <div style="font-size: 9px; color: #666; text-transform: uppercase; letter-spacing: 1.5px; margin-top: 2px;">Events</div>
+          </td>
+          <td style="width: 1px;"></td>
+          <td style="text-align: center; padding: 14px 8px; width: 33%; background: #161616; border: 1px solid #222;">
+            <div style="font-size: 24px; font-weight: 800; color: #ef4444;">${criticalCount}</div>
+            <div style="font-size: 9px; color: #666; text-transform: uppercase; letter-spacing: 1.5px; margin-top: 2px;">Critical</div>
+          </td>
+          <td style="width: 1px;"></td>
+          <td style="text-align: center; padding: 14px 8px; width: 33%; background: #161616; border: 1px solid #222;">
+            <div style="font-size: 24px; font-weight: 800; color: #f97316;">${highCount}</div>
+            <div style="font-size: 9px; color: #666; text-transform: uppercase; letter-spacing: 1.5px; margin-top: 2px;">High</div>
+          </td>
+        </tr>
+      </table>
+      ${sectionsHtml}
+      <div style="text-align: center; padding: 12px 0 36px;">
+        <a href="https://worldmonitor.app" style="display: inline-block; background: #4ade80; color: #0a0a0a; padding: 12px 32px; text-decoration: none; font-weight: 700; font-size: 12px; text-transform: uppercase; letter-spacing: 1.5px; border-radius: 3px;">Open Dashboard</a>
+      </div>
     </div>
-    <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-bottom: 28px; background: #111; border: 1px solid #1a1a1a;">
-      <tr>
-        <td style="text-align: center; padding: 16px 8px; width: 33%;">
-          <div style="font-size: 22px; font-weight: 800; color: #4ade80;">${totalCount}</div>
-          <div style="font-size: 10px; color: #666; text-transform: uppercase; letter-spacing: 1px;">Total</div>
-        </td>
-        <td style="text-align: center; padding: 16px 8px; width: 33%; border-left: 1px solid #1a1a1a; border-right: 1px solid #1a1a1a;">
-          <div style="font-size: 22px; font-weight: 800; color: #ef4444;">${criticalCount}</div>
-          <div style="font-size: 10px; color: #666; text-transform: uppercase; letter-spacing: 1px;">Critical</div>
-        </td>
-        <td style="text-align: center; padding: 16px 8px; width: 33%;">
-          <div style="font-size: 22px; font-weight: 800; color: #f97316;">${highCount}</div>
-          <div style="font-size: 10px; color: #666; text-transform: uppercase; letter-spacing: 1px;">High</div>
-        </td>
-      </tr>
-    </table>
-    ${sectionsHtml}
-    <div style="text-align: center; margin-bottom: 36px;">
-      <a href="https://worldmonitor.app" style="display: inline-block; background: #4ade80; color: #0a0a0a; padding: 14px 36px; text-decoration: none; font-weight: 800; font-size: 13px; text-transform: uppercase; letter-spacing: 1.5px; border-radius: 2px;">View Full Dashboard</a>
+    <div style="background: #0a0a0a; border-top: 1px solid #1a1a1a; padding: 20px 36px; text-align: center;">
+      <div style="margin-bottom: 12px;">
+        <a href="https://x.com/worldmonitorapp" style="color: #555; text-decoration: none; font-size: 11px; margin: 0 10px;">X / Twitter</a>
+        <a href="https://github.com/koala73/worldmonitor" style="color: #555; text-decoration: none; font-size: 11px; margin: 0 10px;">GitHub</a>
+        <a href="https://discord.gg/re63kWKxaz" style="color: #555; text-decoration: none; font-size: 11px; margin: 0 10px;">Discord</a>
+      </div>
+      <p style="font-size: 10px; color: #444; margin: 0; line-height: 1.5;">
+        <a href="https://worldmonitor.app" style="color: #4ade80; text-decoration: none;">worldmonitor.app</a>
+      </p>
     </div>
-  </div>
-  <div style="border-top: 1px solid #1a1a1a; padding: 24px 32px; text-align: center;">
-    <div style="margin-bottom: 16px;">
-      <a href="https://x.com/eliehabib" style="color: #666; text-decoration: none; font-size: 12px; margin: 0 12px;">X / Twitter</a>
-      <a href="https://github.com/koala73/worldmonitor" style="color: #666; text-decoration: none; font-size: 12px; margin: 0 12px;">GitHub</a>
-      <a href="https://worldmonitor.app" style="color: #666; text-decoration: none; font-size: 12px; margin: 0 12px;">worldmonitor.app</a>
-    </div>
-    <p style="font-size: 11px; color: #444; margin: 0; line-height: 1.6;">
-      World Monitor &mdash; Real-time intelligence for a connected world.<br />
-      <a href="https://worldmonitor.app" style="color: #4ade80; text-decoration: none;">worldmonitor.app</a>
-    </p>
   </div>
 </div>`;
 }
@@ -821,15 +829,14 @@ async function main() {
     if (aiSummary) {
       text = `EXECUTIVE SUMMARY\n\n${aiSummary}\n\n${'─'.repeat(40)}\n\n${text}`;
       if (html) {
-        const summaryHtml = `<div style="background:#111;border-left:3px solid #4ade80;padding:16px 20px;margin:0 0 24px 0;border-radius:4px;">
-<div style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:1.5px;color:#4ade80;margin-bottom:12px;">Executive Summary</div>
-<div style="font-size:14px;line-height:1.7;color:#d4d4d4;white-space:pre-wrap;">${escapeHtml(aiSummary)}</div>
+        const summaryHtml = `<div style="background:#161616;border:1px solid #222;border-left:3px solid #4ade80;padding:18px 22px;margin:0 0 24px 0;">
+<div style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:1.5px;color:#4ade80;margin-bottom:10px;">Executive Summary</div>
+<div style="font-size:13px;line-height:1.7;color:#ccc;white-space:pre-wrap;">${escapeHtml(aiSummary)}</div>
 </div>`;
-        html = html.replace(
-          /(<div style="padding: 40px 32px 0;">)/,
-          (_, p1) => `${p1}\n${summaryHtml}`,
-        );
+        html = html.replace('<div data-ai-summary-slot></div>', summaryHtml);
       }
+    } else if (html) {
+      html = html.replace('<div data-ai-summary-slot></div>', '');
     }
 
     const shortDate = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' }).format(new Date(nowMs));


### PR DESCRIPTION
## Summary
- Wider layout (680px vs 600px)
- Not fully dark: outer #111, content #0d0d0d (subtle depth)
- Header: logo + date on same row (was stacked with subtitle)
- AI Executive Summary now renders BELOW the header, ABOVE stats (was injected above the header via regex, appearing before the logo)
- Stats cards: separated with individual borders
- Slot-based summary injection (`data-ai-summary-slot`) replaces fragile regex
- Footer: cleaned up, added Discord

## Test plan
- [x] `node -c scripts/seed-digest-notifications.mjs` passes
- [ ] Trigger a test digest and verify email layout in Gmail