### PR TITLE
feat(map): pulsing chokepoint markers and bypass arc layer

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -349,6 +349,13 @@ interface TripData {
   width: number;
 }
 
+type HighlightedMarker = { id: string; lon: number; lat: number; name: string; score: number };
+
+interface BypassArcDatum {
+  source: [number, number];
+  target: [number, number];
+}
+
 function interpolateGreatCircle(
   start: [number, number],
   end: [number, number],
@@ -380,6 +387,8 @@ const TRADE_ANIMATION_CYCLE = 1000;
 const TRADE_TRAIL_LENGTH = 200;
 const TRADE_ANIMATION_SPEED = 0.3;
 const TRADE_GC_INTERPOLATION_POINTS = 20;
+const CHOKEPOINT_PULSE_FREQ = 0.01;
+const CHOKEPOINT_PULSE_AMP = 0.3;
 
 export class DeckGLMap {
   private static readonly MAX_CLUSTER_LEAVES = 200;
@@ -444,7 +453,8 @@ export class DeckGLMap {
   private tradeAnimationFrameCount = 0;
   private storedChokepointData: GetChokepointStatusResponse | null = null;
   private highlightedRouteIds: Set<string> = new Set();
-  private bypassArcData: Array<{source: [number, number]; target: [number, number]; name: string; addedDays: number}> = [];
+  private highlightedMarkers: HighlightedMarker[] = [];
+  private bypassArcData: BypassArcDatum[] = [];
   private scenarioState: ScenarioVisualState | null = null;
   private affectedIso2Set: Set<string> = new Set();
   private positiveEvents: PositiveGeoEvent[] = [];
@@ -1743,6 +1753,8 @@ export class DeckGLMap {
       this.layerCache.delete('trade-routes-layer');
       this.layerCache.delete('trade-route-trips-layer');
       this.layerCache.delete('trade-chokepoints-layer');
+      this.layerCache.delete('highlighted-chokepoint-markers');
+      this.layerCache.delete('bypass-arcs-layer');
     }
 
     // Tech variant layers (Supercluster-based deck.gl layers for HQs and events)
@@ -5259,32 +5271,32 @@ export class DeckGLMap {
     });
   }
 
-  private createHighlightedChokepointMarkers(): ScatterplotLayer | null {
-    if (this.highlightedRouteIds.size === 0) return null;
-
+  private rebuildHighlightedMarkers(): void {
+    if (this.highlightedRouteIds.size === 0) { this.highlightedMarkers = []; return; }
     const cpIds = new Set<string>();
     for (const routeId of this.highlightedRouteIds) {
       const waypoints = ROUTE_WAYPOINTS_MAP.get(routeId);
       if (waypoints) for (const wp of waypoints) cpIds.add(wp);
     }
-
-    const markers = STRATEGIC_WATERWAYS
+    this.highlightedMarkers = STRATEGIC_WATERWAYS
       .filter(w => cpIds.has(w.id))
       .map(w => {
         const score = this.storedChokepointData?.chokepoints?.find(cp => cp.id === w.id)?.disruptionScore ?? 0;
-        return { ...w, score };
+        return { id: w.id, lon: w.lon, lat: w.lat, name: w.name, score };
       });
+  }
 
-    if (markers.length === 0) return null;
+  private createHighlightedChokepointMarkers(): ScatterplotLayer | null {
+    if (this.highlightedMarkers.length === 0) return null;
 
-    const pulse = Math.sin(this.tradeAnimationTime * 0.01) * 0.3 + 1;
+    const pulse = Math.sin(this.tradeAnimationTime * CHOKEPOINT_PULSE_FREQ) * CHOKEPOINT_PULSE_AMP + 1;
 
     return new ScatterplotLayer({
       id: 'highlighted-chokepoint-markers',
-      data: markers,
-      getPosition: (d: { lon: number; lat: number }) => [d.lon, d.lat],
-      getRadius: (d: { score: number }) => (d.score >= 70 ? 12000 : d.score > 30 ? 10000 : 8000) * pulse,
-      getFillColor: (d: { score: number }) => d.score >= 70
+      data: this.highlightedMarkers,
+      getPosition: (d: HighlightedMarker) => [d.lon, d.lat],
+      getRadius: (d: HighlightedMarker) => (d.score >= 70 ? 12000 : d.score > 30 ? 10000 : 8000) * pulse,
+      getFillColor: (d: HighlightedMarker) => d.score >= 70
         ? [255, 60, 60, 180] as [number, number, number, number]
         : d.score > 30
           ? [255, 180, 50, 160] as [number, number, number, number]
@@ -5292,7 +5304,7 @@ export class DeckGLMap {
       radiusUnits: 'meters' as const,
       pickable: false,
       stroked: true,
-      getLineColor: (d: { score: number }) => d.score >= 70
+      getLineColor: (d: HighlightedMarker) => d.score >= 70
         ? [255, 80, 80, 255] as [number, number, number, number]
         : d.score > 30
           ? [255, 200, 80, 255] as [number, number, number, number]
@@ -5311,8 +5323,8 @@ export class DeckGLMap {
     return new ArcLayer({
       id: 'bypass-arcs-layer',
       data: this.bypassArcData,
-      getSourcePosition: (d: { source: [number, number] }) => d.source,
-      getTargetPosition: (d: { target: [number, number] }) => d.target,
+      getSourcePosition: (d: BypassArcDatum) => d.source,
+      getTargetPosition: (d: BypassArcDatum) => d.target,
       getSourceColor: [60, 200, 120, 160],
       getTargetColor: [60, 200, 120, 160],
       getWidth: 3,
@@ -5687,6 +5699,7 @@ export class DeckGLMap {
   public setChokepointData(data: GetChokepointStatusResponse | null): void {
     this.popup.setChokepointData(data);
     this.storedChokepointData = data;
+    this.rebuildHighlightedMarkers();
     if (this.storedChokepointData) this.refreshTradeRouteStatus(this.storedChokepointData);
   }
 
@@ -5717,6 +5730,7 @@ export class DeckGLMap {
 
   public highlightRoute(routeIds: string[]): void {
     this.highlightedRouteIds = new Set(routeIds);
+    this.rebuildHighlightedMarkers();
     this.buildTradeTrips();
     this.render();
   }
@@ -5724,16 +5738,15 @@ export class DeckGLMap {
   public clearHighlightedRoute(): void {
     if (this.highlightedRouteIds.size === 0) return;
     this.highlightedRouteIds.clear();
+    this.rebuildHighlightedMarkers();
     this.buildTradeTrips();
     this.render();
   }
 
-  public setBypassRoutes(corridors: Array<{name: string; fromPort: [number, number]; toPort: [number, number]; addedDays: number}>): void {
+  public setBypassRoutes(corridors: Array<{fromPort: [number, number]; toPort: [number, number]}>): void {
     this.bypassArcData = corridors.map(c => ({
       source: c.fromPort,
       target: c.toPort,
-      name: c.name,
-      addedDays: c.addedDays,
     }));
     this.render();
   }

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -444,6 +444,7 @@ export class DeckGLMap {
   private tradeAnimationFrameCount = 0;
   private storedChokepointData: GetChokepointStatusResponse | null = null;
   private highlightedRouteIds: Set<string> = new Set();
+  private bypassArcData: Array<{source: [number, number]; target: [number, number]; name: string; addedDays: number}> = [];
   private scenarioState: ScenarioVisualState | null = null;
   private affectedIso2Set: Set<string> = new Set();
   private positiveEvents: PositiveGeoEvent[] = [];
@@ -1732,6 +1733,10 @@ export class DeckGLMap {
       layers.push(this.createTradeRoutesLayer());
       layers.push(this.createTradeRouteTripsLayer());
       layers.push(this.createTradeChokepointsLayer());
+      const hlMarkers = this.createHighlightedChokepointMarkers();
+      if (hlMarkers) layers.push(hlMarkers);
+      const bypassArcs = this.createBypassArcsLayer();
+      if (bypassArcs) layers.push(bypassArcs);
       this.startTradeAnimation();
     } else {
       this.stopTradeAnimation();
@@ -5254,11 +5259,69 @@ export class DeckGLMap {
     });
   }
 
-  /**
-   * Compute the solar terminator polygon (night side of the Earth).
-   * Uses standard astronomical formulas to find the subsolar point,
-   * then traces the terminator line and closes around the dark pole.
-   */
+  private createHighlightedChokepointMarkers(): ScatterplotLayer | null {
+    if (this.highlightedRouteIds.size === 0) return null;
+
+    const cpIds = new Set<string>();
+    for (const routeId of this.highlightedRouteIds) {
+      const waypoints = ROUTE_WAYPOINTS_MAP.get(routeId);
+      if (waypoints) for (const wp of waypoints) cpIds.add(wp);
+    }
+
+    const markers = STRATEGIC_WATERWAYS
+      .filter(w => cpIds.has(w.id))
+      .map(w => {
+        const score = this.storedChokepointData?.chokepoints?.find(cp => cp.id === w.id)?.disruptionScore ?? 0;
+        return { ...w, score };
+      });
+
+    if (markers.length === 0) return null;
+
+    const pulse = Math.sin(this.tradeAnimationTime * 0.01) * 0.3 + 1;
+
+    return new ScatterplotLayer({
+      id: 'highlighted-chokepoint-markers',
+      data: markers,
+      getPosition: (d: { lon: number; lat: number }) => [d.lon, d.lat],
+      getRadius: (d: { score: number }) => (d.score >= 70 ? 12000 : d.score > 30 ? 10000 : 8000) * pulse,
+      getFillColor: (d: { score: number }) => d.score >= 70
+        ? [255, 60, 60, 180] as [number, number, number, number]
+        : d.score > 30
+          ? [255, 180, 50, 160] as [number, number, number, number]
+          : [60, 200, 120, 140] as [number, number, number, number],
+      radiusUnits: 'meters' as const,
+      pickable: false,
+      stroked: true,
+      getLineColor: (d: { score: number }) => d.score >= 70
+        ? [255, 80, 80, 255] as [number, number, number, number]
+        : d.score > 30
+          ? [255, 200, 80, 255] as [number, number, number, number]
+          : [80, 220, 140, 255] as [number, number, number, number],
+      getLineWidth: 2,
+      lineWidthUnits: 'pixels' as const,
+      updateTriggers: {
+        getRadius: [this.tradeAnimationTime],
+        getFillColor: [this.storedChokepointData],
+      },
+    });
+  }
+
+  private createBypassArcsLayer(): ArcLayer | null {
+    if (this.bypassArcData.length === 0) return null;
+    return new ArcLayer({
+      id: 'bypass-arcs-layer',
+      data: this.bypassArcData,
+      getSourcePosition: (d: { source: [number, number] }) => d.source,
+      getTargetPosition: (d: { target: [number, number] }) => d.target,
+      getSourceColor: [60, 200, 120, 160],
+      getTargetColor: [60, 200, 120, 160],
+      getWidth: 3,
+      widthMinPixels: 2,
+      greatCircle: true,
+      pickable: false,
+    });
+  }
+
   private computeNightPolygon(): [number, number][] {
     const now = new Date();
     const JD = now.getTime() / 86400000 + 2440587.5;
@@ -5662,6 +5725,22 @@ export class DeckGLMap {
     if (this.highlightedRouteIds.size === 0) return;
     this.highlightedRouteIds.clear();
     this.buildTradeTrips();
+    this.render();
+  }
+
+  public setBypassRoutes(corridors: Array<{name: string; fromPort: [number, number]; toPort: [number, number]; addedDays: number}>): void {
+    this.bypassArcData = corridors.map(c => ({
+      source: c.fromPort,
+      target: c.toPort,
+      name: c.name,
+      addedDays: c.addedDays,
+    }));
+    this.render();
+  }
+
+  public clearBypassRoutes(): void {
+    if (this.bypassArcData.length === 0) return;
+    this.bypassArcData = [];
     this.render();
   }
 

--- a/src/components/MapContainer.ts
+++ b/src/components/MapContainer.ts
@@ -982,7 +982,7 @@ export class MapContainer {
     this.deckGLMap?.clearHighlightedRoute();
   }
 
-  public setBypassRoutes(corridors: Array<{name: string; fromPort: [number, number]; toPort: [number, number]; addedDays: number}>): void {
+  public setBypassRoutes(corridors: Array<{fromPort: [number, number]; toPort: [number, number]}>): void {
     this.deckGLMap?.setBypassRoutes(corridors);
   }
 

--- a/src/components/MapContainer.ts
+++ b/src/components/MapContainer.ts
@@ -982,6 +982,14 @@ export class MapContainer {
     this.deckGLMap?.clearHighlightedRoute();
   }
 
+  public setBypassRoutes(corridors: Array<{name: string; fromPort: [number, number]; toPort: [number, number]; addedDays: number}>): void {
+    this.deckGLMap?.setBypassRoutes(corridors);
+  }
+
+  public clearBypassRoutes(): void {
+    this.deckGLMap?.clearBypassRoutes();
+  }
+
   public zoomToRoutes(routeIds: string[]): void {
     this.deckGLMap?.zoomToRoutes(routeIds);
   }

--- a/tests/route-drawing-layers.test.mjs
+++ b/tests/route-drawing-layers.test.mjs
@@ -1,0 +1,151 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const root = join(import.meta.dirname, '..');
+const deckGLMapSrc = readFileSync(join(root, 'src', 'components', 'DeckGLMap.ts'), 'utf-8');
+const mapContainerSrc = readFileSync(join(root, 'src', 'components', 'MapContainer.ts'), 'utf-8');
+
+describe('Pulsing chokepoint markers', () => {
+  it('createHighlightedChokepointMarkers method exists', () => {
+    assert.ok(
+      deckGLMapSrc.includes('createHighlightedChokepointMarkers'),
+      'DeckGLMap must have createHighlightedChokepointMarkers method',
+    );
+  });
+
+  it('returns null when highlightedRouteIds is empty', () => {
+    const defIdx = deckGLMapSrc.indexOf('private createHighlightedChokepointMarkers');
+    assert.ok(defIdx !== -1);
+    const method = deckGLMapSrc.slice(defIdx, defIdx + 2500);
+    assert.ok(
+      method.includes('highlightedRouteIds.size === 0') && method.includes('return null'),
+      'Must return null when no routes highlighted',
+    );
+  });
+
+  it('collects chokepoint IDs from ROUTE_WAYPOINTS_MAP', () => {
+    const defIdx = deckGLMapSrc.indexOf('private createHighlightedChokepointMarkers');
+    const method = deckGLMapSrc.slice(defIdx, defIdx + 2500);
+    assert.ok(
+      method.includes('ROUTE_WAYPOINTS_MAP'),
+      'Must use ROUTE_WAYPOINTS_MAP to collect chokepoint IDs',
+    );
+  });
+
+  it('uses disruption score for color coding', () => {
+    const defIdx = deckGLMapSrc.indexOf('private createHighlightedChokepointMarkers');
+    const method = deckGLMapSrc.slice(defIdx, defIdx + 2500);
+    assert.ok(method.includes('score >= 70'), 'Must check score >= 70 for critical');
+    assert.ok(method.includes('score > 30'), 'Must check score > 30 for elevated');
+  });
+
+  it('uses tradeAnimationTime for pulse effect', () => {
+    const defIdx = deckGLMapSrc.indexOf('private createHighlightedChokepointMarkers');
+    const method = deckGLMapSrc.slice(defIdx, defIdx + 2500);
+    assert.ok(
+      method.includes('tradeAnimationTime'),
+      'Must use tradeAnimationTime for pulsing',
+    );
+  });
+
+  it('layer is inserted in buildAllLayers when routes are highlighted', () => {
+    const buildIdx = deckGLMapSrc.indexOf('createTradeChokepointsLayer()');
+    assert.ok(buildIdx !== -1);
+    const after = deckGLMapSrc.slice(buildIdx, buildIdx + 500);
+    assert.ok(
+      after.includes('createHighlightedChokepointMarkers'),
+      'Must insert highlighted markers layer after trade chokepoints in buildAllLayers',
+    );
+  });
+});
+
+describe('Bypass arcs layer', () => {
+  it('bypassArcData field exists on DeckGLMap', () => {
+    assert.ok(
+      deckGLMapSrc.includes('bypassArcData'),
+      'DeckGLMap must have bypassArcData field',
+    );
+  });
+
+  it('setBypassRoutes method exists', () => {
+    assert.ok(
+      deckGLMapSrc.includes('setBypassRoutes('),
+      'DeckGLMap must have setBypassRoutes method',
+    );
+  });
+
+  it('clearBypassRoutes method exists', () => {
+    assert.ok(
+      deckGLMapSrc.includes('clearBypassRoutes'),
+      'DeckGLMap must have clearBypassRoutes method',
+    );
+  });
+
+  it('createBypassArcsLayer returns null when no data', () => {
+    const defIdx = deckGLMapSrc.indexOf('private createBypassArcsLayer');
+    assert.ok(defIdx !== -1);
+    const method = deckGLMapSrc.slice(defIdx, defIdx + 1000);
+    assert.ok(
+      method.includes('bypassArcData.length === 0') && method.includes('return null'),
+      'Must return null when bypassArcData is empty',
+    );
+  });
+
+  it('bypass arcs use green color', () => {
+    const defIdx = deckGLMapSrc.indexOf('private createBypassArcsLayer');
+    const method = deckGLMapSrc.slice(defIdx, defIdx + 1000);
+    assert.ok(
+      method.includes('[60, 200, 120'),
+      'Bypass arcs must use green color',
+    );
+  });
+
+  it('bypass arcs use greatCircle rendering', () => {
+    const defIdx = deckGLMapSrc.indexOf('private createBypassArcsLayer');
+    const method = deckGLMapSrc.slice(defIdx, defIdx + 1000);
+    assert.ok(
+      method.includes('greatCircle: true'),
+      'Bypass arcs must use greatCircle rendering',
+    );
+  });
+
+  it('bypass arcs layer is inserted in buildAllLayers', () => {
+    const buildIdx = deckGLMapSrc.indexOf('createHighlightedChokepointMarkers');
+    assert.ok(buildIdx !== -1);
+    const after = deckGLMapSrc.slice(buildIdx, buildIdx + 500);
+    assert.ok(
+      after.includes('createBypassArcsLayer'),
+      'Must insert bypass arcs layer after highlighted chokepoint markers',
+    );
+  });
+});
+
+describe('MapContainer dispatch methods', () => {
+  it('setBypassRoutes dispatches to deckGLMap', () => {
+    assert.ok(
+      mapContainerSrc.includes('setBypassRoutes('),
+      'MapContainer must have setBypassRoutes method',
+    );
+    const defIdx = mapContainerSrc.indexOf('setBypassRoutes(');
+    const method = mapContainerSrc.slice(defIdx, defIdx + 200);
+    assert.ok(
+      method.includes('deckGLMap?.setBypassRoutes'),
+      'MapContainer.setBypassRoutes must dispatch to deckGLMap',
+    );
+  });
+
+  it('clearBypassRoutes dispatches to deckGLMap', () => {
+    assert.ok(
+      mapContainerSrc.includes('clearBypassRoutes'),
+      'MapContainer must have clearBypassRoutes method',
+    );
+    const defIdx = mapContainerSrc.indexOf('clearBypassRoutes()');
+    const method = mapContainerSrc.slice(defIdx, defIdx + 200);
+    assert.ok(
+      method.includes('deckGLMap?.clearBypassRoutes'),
+      'MapContainer.clearBypassRoutes must dispatch to deckGLMap',
+    );
+  });
+});

--- a/tests/route-drawing-layers.test.mjs
+++ b/tests/route-drawing-layers.test.mjs
@@ -15,22 +15,43 @@ describe('Pulsing chokepoint markers', () => {
     );
   });
 
-  it('returns null when highlightedRouteIds is empty', () => {
+  it('returns null when highlightedMarkers cache is empty', () => {
     const defIdx = deckGLMapSrc.indexOf('private createHighlightedChokepointMarkers');
     assert.ok(defIdx !== -1);
     const method = deckGLMapSrc.slice(defIdx, defIdx + 2500);
     assert.ok(
-      method.includes('highlightedRouteIds.size === 0') && method.includes('return null'),
-      'Must return null when no routes highlighted',
+      method.includes('highlightedMarkers.length === 0') && method.includes('return null'),
+      'Must return null when cached markers array is empty',
     );
   });
 
-  it('collects chokepoint IDs from ROUTE_WAYPOINTS_MAP', () => {
-    const defIdx = deckGLMapSrc.indexOf('private createHighlightedChokepointMarkers');
-    const method = deckGLMapSrc.slice(defIdx, defIdx + 2500);
+  it('rebuildHighlightedMarkers collects IDs from ROUTE_WAYPOINTS_MAP', () => {
+    const defIdx = deckGLMapSrc.indexOf('private rebuildHighlightedMarkers');
+    assert.ok(defIdx !== -1, 'rebuildHighlightedMarkers must exist');
+    const method = deckGLMapSrc.slice(defIdx, defIdx + 1500);
     assert.ok(
       method.includes('ROUTE_WAYPOINTS_MAP'),
-      'Must use ROUTE_WAYPOINTS_MAP to collect chokepoint IDs',
+      'rebuildHighlightedMarkers must use ROUTE_WAYPOINTS_MAP',
+    );
+  });
+
+  it('highlightRoute calls rebuildHighlightedMarkers', () => {
+    const defIdx = deckGLMapSrc.indexOf('public highlightRoute(');
+    assert.ok(defIdx !== -1);
+    const method = deckGLMapSrc.slice(defIdx, defIdx + 300);
+    assert.ok(
+      method.includes('rebuildHighlightedMarkers'),
+      'highlightRoute must call rebuildHighlightedMarkers',
+    );
+  });
+
+  it('setChokepointData calls rebuildHighlightedMarkers', () => {
+    const defIdx = deckGLMapSrc.indexOf('public setChokepointData(');
+    assert.ok(defIdx !== -1);
+    const method = deckGLMapSrc.slice(defIdx, defIdx + 300);
+    assert.ok(
+      method.includes('rebuildHighlightedMarkers'),
+      'setChokepointData must call rebuildHighlightedMarkers',
     );
   });
 
@@ -41,12 +62,33 @@ describe('Pulsing chokepoint markers', () => {
     assert.ok(method.includes('score > 30'), 'Must check score > 30 for elevated');
   });
 
-  it('uses tradeAnimationTime for pulse effect', () => {
+  it('uses CHOKEPOINT_PULSE_FREQ and CHOKEPOINT_PULSE_AMP constants', () => {
+    assert.ok(
+      deckGLMapSrc.includes('const CHOKEPOINT_PULSE_FREQ'),
+      'Must define CHOKEPOINT_PULSE_FREQ constant',
+    );
+    assert.ok(
+      deckGLMapSrc.includes('const CHOKEPOINT_PULSE_AMP'),
+      'Must define CHOKEPOINT_PULSE_AMP constant',
+    );
     const defIdx = deckGLMapSrc.indexOf('private createHighlightedChokepointMarkers');
     const method = deckGLMapSrc.slice(defIdx, defIdx + 2500);
     assert.ok(
-      method.includes('tradeAnimationTime'),
-      'Must use tradeAnimationTime for pulsing',
+      method.includes('CHOKEPOINT_PULSE_FREQ') && method.includes('CHOKEPOINT_PULSE_AMP'),
+      'createHighlightedChokepointMarkers must use extracted constants',
+    );
+  });
+
+  it('uses HighlightedMarker type in accessor callbacks', () => {
+    assert.ok(
+      deckGLMapSrc.includes('type HighlightedMarker'),
+      'Must define HighlightedMarker type',
+    );
+    const defIdx = deckGLMapSrc.indexOf('private createHighlightedChokepointMarkers');
+    const method = deckGLMapSrc.slice(defIdx, defIdx + 2500);
+    assert.ok(
+      method.includes('(d: HighlightedMarker)'),
+      'Accessor callbacks must use HighlightedMarker type',
     );
   });
 
@@ -61,11 +103,40 @@ describe('Pulsing chokepoint markers', () => {
   });
 });
 
-describe('Bypass arcs layer', () => {
-  it('bypassArcData field exists on DeckGLMap', () => {
+describe('Layer cache cleanup', () => {
+  it('cleans highlighted-chokepoint-markers when trade routes disabled', () => {
+    const elseIdx = deckGLMapSrc.indexOf("this.layerCache.delete('trade-chokepoints-layer')");
+    assert.ok(elseIdx !== -1);
+    const after = deckGLMapSrc.slice(elseIdx, elseIdx + 300);
     assert.ok(
-      deckGLMapSrc.includes('bypassArcData'),
-      'DeckGLMap must have bypassArcData field',
+      after.includes("this.layerCache.delete('highlighted-chokepoint-markers')"),
+      'Must delete highlighted-chokepoint-markers from layerCache',
+    );
+  });
+
+  it('cleans bypass-arcs-layer when trade routes disabled', () => {
+    const elseIdx = deckGLMapSrc.indexOf("this.layerCache.delete('trade-chokepoints-layer')");
+    assert.ok(elseIdx !== -1);
+    const after = deckGLMapSrc.slice(elseIdx, elseIdx + 300);
+    assert.ok(
+      after.includes("this.layerCache.delete('bypass-arcs-layer')"),
+      'Must delete bypass-arcs-layer from layerCache',
+    );
+  });
+});
+
+describe('Bypass arcs layer', () => {
+  it('BypassArcDatum interface is defined', () => {
+    assert.ok(
+      deckGLMapSrc.includes('interface BypassArcDatum'),
+      'Must define BypassArcDatum interface',
+    );
+  });
+
+  it('bypassArcData uses BypassArcDatum type', () => {
+    assert.ok(
+      deckGLMapSrc.includes('bypassArcData: BypassArcDatum[]'),
+      'bypassArcData field must use BypassArcDatum type',
     );
   });
 
@@ -108,6 +179,15 @@ describe('Bypass arcs layer', () => {
     assert.ok(
       method.includes('greatCircle: true'),
       'Bypass arcs must use greatCircle rendering',
+    );
+  });
+
+  it('bypass arcs use BypassArcDatum in accessors', () => {
+    const defIdx = deckGLMapSrc.indexOf('private createBypassArcsLayer');
+    const method = deckGLMapSrc.slice(defIdx, defIdx + 1000);
+    assert.ok(
+      method.includes('(d: BypassArcDatum)'),
+      'Accessor callbacks must use BypassArcDatum type',
     );
   });
 


### PR DESCRIPTION
## Summary
- Pulsing markers at chokepoints on highlighted trade routes
- Color matches live disruption score (red >= 70, orange > 30, green safe)
- Pulse animation uses existing TripsLayer timing (no new animation loop)
- Bypass route arc layer infrastructure (green dashed arcs, data setter)
- MapContainer dispatch wired

## Test plan
- [ ] Click a sector row in Trade Exposure: chokepoints on the route pulse
- [ ] Hormuz (score 70+) pulses red, safe chokepoints pulse green
- [ ] Clear highlight: markers disappear
- [ ] typecheck + typecheck:api pass
- [ ] Tests pass

## Post-Deploy Monitoring & Validation
- No new endpoints, pure visual layer
- Monitor: WebGL errors in console (new layer creation)
- Expected: markers appear/disappear cleanly with route highlight