### PR TITLE
fix(digest): render AI summary markdown across all channels

### DIFF
--- a/scripts/_digest-markdown.mjs
+++ b/scripts/_digest-markdown.mjs
@@ -1,0 +1,141 @@
+/**
+ * Pure markdown → channel-specific format converters for the digest
+ * notification script. Extracted so tests can import without triggering
+ * the seed script's top-level execution (Upstash init, main()).
+ *
+ * Converters cover the AI executive summary markdown that Claude emits:
+ *   **bold** / __bold__
+ *   *italic*
+ *   * / - bullet lists
+ *   "Assessment:" / "Signals to watch:" section headers
+ */
+
+// ── HTML escape (email: " encoded too for attribute safety) ──────────────────
+
+export function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// ── Email HTML ──────────────────────────────────────────────────────────────
+
+// Inline markdown → HTML (operates on already-HTML-escaped text, no block markup).
+export function renderEmailInline(text) {
+  let out = text;
+  // Bold: **text** or __text__
+  out = out.replace(/\*\*(.+?)\*\*/g, '<strong style="color:#fff;">$1</strong>');
+  out = out.replace(/__(.+?)__/g, '<strong style="color:#fff;">$1</strong>');
+  // Italic: *text* (not adjacent to another asterisk, avoids collision w/ bold)
+  out = out.replace(/(?<!\*)\*([^*\n]+?)\*(?!\*)/g, '<em>$1</em>');
+  // Section header (label at start of the block, e.g. "Assessment:", "Signals to watch:")
+  out = out.replace(
+    /^([A-Z][A-Za-z ]+): */,
+    '<strong style="color:#4ade80;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">$1:</strong> ',
+  );
+  return out;
+}
+
+// Block-level markdown → HTML. Splits the summary into paragraph and list
+// blocks first, then applies inline formatting within each block, so we
+// never nest <ul> inside <p> or split a list across paragraphs.
+export function markdownToEmailHtml(md) {
+  const escaped = escapeHtml(md);
+  const lines = escaped.split('\n');
+
+  /** @type {Array<{type:'p'|'ul', items:string[]}>} */
+  const blocks = [];
+  let current = null;
+  const flush = () => { if (current) { blocks.push(current); current = null; } };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) { flush(); continue; }
+
+    const bullet = line.match(/^\s*[\*\-]\s+(.+)$/);
+    if (bullet) {
+      if (!current || current.type !== 'ul') { flush(); current = { type: 'ul', items: [] }; }
+      current.items.push(bullet[1]);
+    } else {
+      if (!current || current.type !== 'p') { flush(); current = { type: 'p', items: [] }; }
+      current.items.push(trimmed);
+    }
+  }
+  flush();
+
+  return blocks.map((block) => {
+    if (block.type === 'ul') {
+      const items = block.items
+        .map((item) => `<li style="margin-bottom:6px;">${renderEmailInline(item)}</li>`)
+        .join('');
+      return `<ul style="margin:12px 0;padding-left:20px;list-style:disc;">${items}</ul>`;
+    }
+    const joined = block.items.map(renderEmailInline).join('<br/>');
+    return `<p style="margin:0 0 12px;">${joined}</p>`;
+  }).join('');
+}
+
+// ── Telegram HTML (parse_mode:'HTML') ────────────────────────────────────────
+// Telegram HTML escape: only &, <, > (no " or ')
+// See https://core.telegram.org/bots/api#html-style
+
+export function escapeTelegramHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export function markdownToTelegramHtml(md) {
+  let html = escapeTelegramHtml(md);
+  // Bullets first (Telegram HTML has no list elements, render as • char)
+  html = html.replace(/^[\*\-]\s+/gm, '• ');
+  // Bold: **text** or __text__
+  html = html.replace(/\*\*(.+?)\*\*/g, '<b>$1</b>');
+  html = html.replace(/__(.+?)__/g, '<b>$1</b>');
+  // Italic: *text* (single asterisk, not part of bold)
+  html = html.replace(/(?<!\*)\*([^*\n]+?)\*(?!\*)/g, '<i>$1</i>');
+  // Section headers: Assessment: / Signals to watch:
+  html = html.replace(/^([A-Z][A-Za-z ]+): */gm, '<b>$1:</b> ');
+  return html;
+}
+
+// ── Slack mrkdwn ─────────────────────────────────────────────────────────────
+// Slack escapes &, <, > (Slack auto-parses these in regular text).
+
+export function escapeSlackMrkdwn(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export function markdownToSlackMrkdwn(md) {
+  let txt = escapeSlackMrkdwn(md);
+  // Bullets first (avoid collision with italic single-asterisk regex)
+  txt = txt.replace(/^[\*\-]\s+/gm, '• ');
+  // Bold: **text** or __text__ → *text* (Slack uses single asterisk).
+  // Use \u0001 placeholder so italic pass below doesn't re-match.
+  txt = txt.replace(/\*\*(.+?)\*\*/g, '\u0001$1\u0001');
+  txt = txt.replace(/__(.+?)__/g, '\u0001$1\u0001');
+  // Italic: *text* → _text_
+  txt = txt.replace(/(?<!\*)\*([^*\n]+?)\*(?!\*)/g, '_$1_');
+  // Restore bold markers
+  txt = txt.replace(/\u0001/g, '*');
+  // Section headers → *bold*
+  txt = txt.replace(/^([A-Z][A-Za-z ]+): */gm, '*$1:* ');
+  return txt;
+}
+
+// ── Discord CommonMark (natively supports **bold**, *italic*) ────────────────
+// Only normalize what Discord doesn't handle: * bullets (Discord lists require -)
+// and trailing-colon section headers.
+
+export function markdownToDiscord(md) {
+  let txt = String(md);
+  txt = txt.replace(/^\*\s+/gm, '- ');
+  txt = txt.replace(/^([A-Z][A-Za-z ]+): */gm, '**$1:** ');
+  return txt;
+}

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -14,6 +14,15 @@
 import { createRequire } from 'node:module';
 import { createHash } from 'node:crypto';
 import dns from 'node:dns/promises';
+import {
+  escapeHtml,
+  escapeTelegramHtml,
+  escapeSlackMrkdwn,
+  markdownToEmailHtml,
+  markdownToTelegramHtml,
+  markdownToSlackMrkdwn,
+  markdownToDiscord,
+} from './_digest-markdown.mjs';
 
 const require = createRequire(import.meta.url);
 const { decrypt } = require('./lib/crypto.cjs');
@@ -317,127 +326,6 @@ function formatDigest(stories, nowMs) {
 
   lines.push('View full dashboard \u2192 worldmonitor.app');
   return lines.join('\n');
-}
-
-function escapeHtml(str) {
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}
-
-// Inline markdown → HTML (operates on already-HTML-escaped text, no block markup).
-function renderEmailInline(text) {
-  let out = text;
-  // Bold: **text** or __text__
-  out = out.replace(/\*\*(.+?)\*\*/g, '<strong style="color:#fff;">$1</strong>');
-  out = out.replace(/__(.+?)__/g, '<strong style="color:#fff;">$1</strong>');
-  // Italic: *text* (not adjacent to another asterisk, avoids collision w/ bold)
-  out = out.replace(/(?<!\*)\*([^*\n]+?)\*(?!\*)/g, '<em>$1</em>');
-  // Section header (label at start of the block, e.g. "Assessment:", "Signals to watch:")
-  out = out.replace(
-    /^([A-Z][A-Za-z ]+): */,
-    '<strong style="color:#4ade80;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">$1:</strong> ',
-  );
-  return out;
-}
-
-// Block-level markdown → HTML. Splits the summary into paragraph and list
-// blocks first, then applies inline formatting within each block, so we
-// never nest <ul> inside <p> or split a list across paragraphs.
-function markdownToEmailHtml(md) {
-  const escaped = escapeHtml(md);
-  const lines = escaped.split('\n');
-
-  /** @type {Array<{type:'p'|'ul', items:string[]}>} */
-  const blocks = [];
-  let current = null;
-  const flush = () => { if (current) { blocks.push(current); current = null; } };
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed) { flush(); continue; }
-
-    const bullet = line.match(/^\s*[\*\-]\s+(.+)$/);
-    if (bullet) {
-      if (!current || current.type !== 'ul') { flush(); current = { type: 'ul', items: [] }; }
-      current.items.push(bullet[1]);
-    } else {
-      if (!current || current.type !== 'p') { flush(); current = { type: 'p', items: [] }; }
-      current.items.push(trimmed);
-    }
-  }
-  flush();
-
-  return blocks.map((block) => {
-    if (block.type === 'ul') {
-      const items = block.items
-        .map((item) => `<li style="margin-bottom:6px;">${renderEmailInline(item)}</li>`)
-        .join('');
-      return `<ul style="margin:12px 0;padding-left:20px;list-style:disc;">${items}</ul>`;
-    }
-    const joined = block.items.map(renderEmailInline).join('<br/>');
-    return `<p style="margin:0 0 12px;">${joined}</p>`;
-  }).join('');
-}
-
-// Telegram HTML parse_mode escape: only &, <, > (no " or ')
-// See https://core.telegram.org/bots/api#html-style
-function escapeTelegramHtml(str) {
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
-
-function markdownToTelegramHtml(md) {
-  let html = escapeTelegramHtml(md);
-  // Bullets first (Telegram HTML has no list elements, render as • char)
-  html = html.replace(/^[\*\-]\s+/gm, '• ');
-  // Bold: **text** or __text__
-  html = html.replace(/\*\*(.+?)\*\*/g, '<b>$1</b>');
-  html = html.replace(/__(.+?)__/g, '<b>$1</b>');
-  // Italic: *text* (single asterisk, not part of bold)
-  html = html.replace(/(?<!\*)\*([^*\n]+?)\*(?!\*)/g, '<i>$1</i>');
-  // Section headers: Assessment: / Signals to watch:
-  html = html.replace(/^([A-Z][A-Za-z ]+): */gm, '<b>$1:</b> ');
-  return html;
-}
-
-// Slack mrkdwn: escape &, <, > (Slack auto-parses these in regular text)
-function escapeSlackMrkdwn(str) {
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
-
-function markdownToSlackMrkdwn(md) {
-  let txt = escapeSlackMrkdwn(md);
-  // Bullets first (avoid collision with italic single-asterisk regex)
-  txt = txt.replace(/^[\*\-]\s+/gm, '• ');
-  // Bold: **text** or __text__ → *text* (Slack uses single asterisk).
-  // Use \u0001 placeholder so italic pass below doesn't re-match.
-  txt = txt.replace(/\*\*(.+?)\*\*/g, '\u0001$1\u0001');
-  txt = txt.replace(/__(.+?)__/g, '\u0001$1\u0001');
-  // Italic: *text* → _text_
-  txt = txt.replace(/(?<!\*)\*([^*\n]+?)\*(?!\*)/g, '_$1_');
-  // Restore bold markers
-  txt = txt.replace(/\u0001/g, '*');
-  // Section headers → *bold*
-  txt = txt.replace(/^([A-Z][A-Za-z ]+): */gm, '*$1:* ');
-  return txt;
-}
-
-// Discord supports CommonMark **bold** and *italic* natively. Only normalize
-// what Discord doesn't handle: * bullets (Discord lists require -) and
-// trailing-colon section headers.
-function markdownToDiscord(md) {
-  let txt = String(md);
-  txt = txt.replace(/^\*\s+/gm, '- ');
-  txt = txt.replace(/^([A-Z][A-Za-z ]+): */gm, '**$1:** ');
-  return txt;
 }
 
 function formatDigestHtml(stories, nowMs) {

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -340,12 +340,71 @@ function markdownToEmailHtml(md) {
   // Wrap consecutive <li> in <ul>
   html = html.replace(/((?:<li[^>]*>.*?<\/li>\s*)+)/g, '<ul style="margin:12px 0;padding-left:20px;list-style:disc;">$1</ul>');
   // Section headers: lines ending with colon (Assessment:, Signals to watch:)
-  html = html.replace(/^([A-Z][A-Za-z\s]+):\s*/gm, '<strong style="color:#4ade80;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">$1:</strong> ');
+  // Use [A-Za-z ] (not \s) and ` *` to avoid swallowing newlines.
+  html = html.replace(/^([A-Z][A-Za-z ]+): */gm, '<strong style="color:#4ade80;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">$1:</strong> ');
   // Paragraphs: double newlines
   html = html.replace(/\n\n+/g, '</p><p style="margin:12px 0;">');
   // Single newlines (not inside lists)
   html = html.replace(/(?<!<\/li>)\n(?!<)/g, '<br/>');
   return `<p style="margin:0 0 12px;">${html}</p>`;
+}
+
+// Telegram HTML parse_mode escape: only &, <, > (no " or ')
+// See https://core.telegram.org/bots/api#html-style
+function escapeTelegramHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function markdownToTelegramHtml(md) {
+  let html = escapeTelegramHtml(md);
+  // Bullets first (Telegram HTML has no list elements, render as • char)
+  html = html.replace(/^[\*\-]\s+/gm, '• ');
+  // Bold: **text** or __text__
+  html = html.replace(/\*\*(.+?)\*\*/g, '<b>$1</b>');
+  html = html.replace(/__(.+?)__/g, '<b>$1</b>');
+  // Italic: *text* (single asterisk, not part of bold)
+  html = html.replace(/(?<!\*)\*([^*\n]+?)\*(?!\*)/g, '<i>$1</i>');
+  // Section headers: Assessment: / Signals to watch:
+  html = html.replace(/^([A-Z][A-Za-z ]+): */gm, '<b>$1:</b> ');
+  return html;
+}
+
+// Slack mrkdwn: escape &, <, > (Slack auto-parses these in regular text)
+function escapeSlackMrkdwn(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function markdownToSlackMrkdwn(md) {
+  let txt = escapeSlackMrkdwn(md);
+  // Bullets first (avoid collision with italic single-asterisk regex)
+  txt = txt.replace(/^[\*\-]\s+/gm, '• ');
+  // Bold: **text** or __text__ → *text* (Slack uses single asterisk).
+  // Use \u0001 placeholder so italic pass below doesn't re-match.
+  txt = txt.replace(/\*\*(.+?)\*\*/g, '\u0001$1\u0001');
+  txt = txt.replace(/__(.+?)__/g, '\u0001$1\u0001');
+  // Italic: *text* → _text_
+  txt = txt.replace(/(?<!\*)\*([^*\n]+?)\*(?!\*)/g, '_$1_');
+  // Restore bold markers
+  txt = txt.replace(/\u0001/g, '*');
+  // Section headers → *bold*
+  txt = txt.replace(/^([A-Z][A-Za-z ]+): */gm, '*$1:* ');
+  return txt;
+}
+
+// Discord supports CommonMark **bold** and *italic* natively. Only normalize
+// what Discord doesn't handle: * bullets (Discord lists require -) and
+// trailing-colon section headers.
+function markdownToDiscord(md) {
+  let txt = String(md);
+  txt = txt.replace(/^\*\s+/gm, '- ');
+  txt = txt.replace(/^([A-Z][A-Za-z ]+): */gm, '**$1:** ');
+  return txt;
 }
 
 function formatDigestHtml(stories, nowMs) {
@@ -572,7 +631,12 @@ async function sendTelegram(userId, chatId, text) {
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-digest/1.0' },
-        body: JSON.stringify({ chat_id: chatId, text }),
+        body: JSON.stringify({
+          chat_id: chatId,
+          text,
+          parse_mode: 'HTML',
+          disable_web_page_preview: true,
+        }),
         signal: AbortSignal.timeout(10000),
       },
     );
@@ -843,20 +907,39 @@ async function main() {
       aiSummary = await generateAISummary(stories, rule);
     }
 
-    let text = formatDigest(stories, nowMs);
-    if (!text) continue;
+    const storyListPlain = formatDigest(stories, nowMs);
+    if (!storyListPlain) continue;
     let html = formatDigestHtml(stories, nowMs);
 
-    if (aiSummary) {
-      text = `EXECUTIVE SUMMARY\n\n${aiSummary}\n\n${'─'.repeat(40)}\n\n${text}`;
-      if (html) {
-        const formattedSummary = markdownToEmailHtml(aiSummary);
-        const summaryHtml = `<div style="background:#161616;border:1px solid #222;border-left:3px solid #4ade80;padding:18px 22px;margin:0 0 24px 0;">
+    const divider = '─'.repeat(40);
+
+    // Plain text (email .txt fallback, webhook passthrough)
+    let text = aiSummary
+      ? `EXECUTIVE SUMMARY\n\n${aiSummary}\n\n${divider}\n\n${storyListPlain}`
+      : storyListPlain;
+
+    // Telegram HTML (parse_mode: 'HTML')
+    const telegramText = aiSummary
+      ? `<b>EXECUTIVE SUMMARY</b>\n\n${markdownToTelegramHtml(aiSummary)}\n\n${divider}\n\n${escapeTelegramHtml(storyListPlain)}`
+      : escapeTelegramHtml(storyListPlain);
+
+    // Slack mrkdwn
+    const slackText = aiSummary
+      ? `*EXECUTIVE SUMMARY*\n\n${markdownToSlackMrkdwn(aiSummary)}\n\n${divider}\n\n${escapeSlackMrkdwn(storyListPlain)}`
+      : escapeSlackMrkdwn(storyListPlain);
+
+    // Discord CommonMark (normalizes bullets + headers only)
+    const discordText = aiSummary
+      ? `**EXECUTIVE SUMMARY**\n\n${markdownToDiscord(aiSummary)}\n\n${divider}\n\n${storyListPlain}`
+      : storyListPlain;
+
+    if (aiSummary && html) {
+      const formattedSummary = markdownToEmailHtml(aiSummary);
+      const summaryHtml = `<div style="background:#161616;border:1px solid #222;border-left:3px solid #4ade80;padding:18px 22px;margin:0 0 24px 0;">
 <div style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:1.5px;color:#4ade80;margin-bottom:10px;">Executive Summary</div>
 <div style="font-size:13px;line-height:1.7;color:#ccc;">${formattedSummary}</div>
 </div>`;
-        html = html.replace('<div data-ai-summary-slot></div>', summaryHtml);
-      }
+      html = html.replace('<div data-ai-summary-slot></div>', summaryHtml);
     } else if (html) {
       html = html.replace('<div data-ai-summary-slot></div>', '');
     }
@@ -869,11 +952,11 @@ async function main() {
     for (const ch of deliverableChannels) {
       let ok = false;
       if (ch.channelType === 'telegram' && ch.chatId) {
-        ok = await sendTelegram(rule.userId, ch.chatId, text);
+        ok = await sendTelegram(rule.userId, ch.chatId, telegramText);
       } else if (ch.channelType === 'slack' && ch.webhookEnvelope) {
-        ok = await sendSlack(rule.userId, ch.webhookEnvelope, text);
+        ok = await sendSlack(rule.userId, ch.webhookEnvelope, slackText);
       } else if (ch.channelType === 'discord' && ch.webhookEnvelope) {
-        ok = await sendDiscord(rule.userId, ch.webhookEnvelope, text);
+        ok = await sendDiscord(rule.userId, ch.webhookEnvelope, discordText);
       } else if (ch.channelType === 'email' && ch.email) {
         ok = await sendEmail(ch.email, subject, text, html);
       } else if (ch.channelType === 'webhook' && ch.webhookEnvelope) {

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -738,6 +738,47 @@ async function isUserPro(userId) {
   }
 }
 
+// ── Per-channel body composition ─────────────────────────────────────────────
+
+const DIVIDER = '─'.repeat(40);
+
+/**
+ * Compose the per-channel message bodies for a single digest rule.
+ * Keeps the per-channel formatting logic out of main() so its cognitive
+ * complexity stays within the lint budget.
+ */
+function buildChannelBodies(storyListPlain, aiSummary) {
+  if (!aiSummary) {
+    return {
+      text: storyListPlain,
+      telegramText: escapeTelegramHtml(storyListPlain),
+      slackText: escapeSlackMrkdwn(storyListPlain),
+      discordText: storyListPlain,
+    };
+  }
+  return {
+    text: `EXECUTIVE SUMMARY\n\n${aiSummary}\n\n${DIVIDER}\n\n${storyListPlain}`,
+    telegramText: `<b>EXECUTIVE SUMMARY</b>\n\n${markdownToTelegramHtml(aiSummary)}\n\n${DIVIDER}\n\n${escapeTelegramHtml(storyListPlain)}`,
+    slackText: `*EXECUTIVE SUMMARY*\n\n${markdownToSlackMrkdwn(aiSummary)}\n\n${DIVIDER}\n\n${escapeSlackMrkdwn(storyListPlain)}`,
+    discordText: `**EXECUTIVE SUMMARY**\n\n${markdownToDiscord(aiSummary)}\n\n${DIVIDER}\n\n${storyListPlain}`,
+  };
+}
+
+/**
+ * Inject the formatted AI summary into the HTML email template's slot,
+ * or strip the slot placeholder when there is no summary.
+ */
+function injectEmailSummary(html, aiSummary) {
+  if (!html) return html;
+  if (!aiSummary) return html.replace('<div data-ai-summary-slot></div>', '');
+  const formattedSummary = markdownToEmailHtml(aiSummary);
+  const summaryHtml = `<div style="background:#161616;border:1px solid #222;border-left:3px solid #4ade80;padding:18px 22px;margin:0 0 24px 0;">
+<div style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:1.5px;color:#4ade80;margin-bottom:10px;">Executive Summary</div>
+<div style="font-size:13px;line-height:1.7;color:#ccc;">${formattedSummary}</div>
+</div>`;
+  return html.replace('<div data-ai-summary-slot></div>', summaryHtml);
+}
+
 // ── Main ──────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -830,40 +871,10 @@ async function main() {
 
     const storyListPlain = formatDigest(stories, nowMs);
     if (!storyListPlain) continue;
-    let html = formatDigestHtml(stories, nowMs);
+    const htmlRaw = formatDigestHtml(stories, nowMs);
 
-    const divider = '─'.repeat(40);
-
-    // Plain text (email .txt fallback, webhook passthrough)
-    let text = aiSummary
-      ? `EXECUTIVE SUMMARY\n\n${aiSummary}\n\n${divider}\n\n${storyListPlain}`
-      : storyListPlain;
-
-    // Telegram HTML (parse_mode: 'HTML')
-    const telegramText = aiSummary
-      ? `<b>EXECUTIVE SUMMARY</b>\n\n${markdownToTelegramHtml(aiSummary)}\n\n${divider}\n\n${escapeTelegramHtml(storyListPlain)}`
-      : escapeTelegramHtml(storyListPlain);
-
-    // Slack mrkdwn
-    const slackText = aiSummary
-      ? `*EXECUTIVE SUMMARY*\n\n${markdownToSlackMrkdwn(aiSummary)}\n\n${divider}\n\n${escapeSlackMrkdwn(storyListPlain)}`
-      : escapeSlackMrkdwn(storyListPlain);
-
-    // Discord CommonMark (normalizes bullets + headers only)
-    const discordText = aiSummary
-      ? `**EXECUTIVE SUMMARY**\n\n${markdownToDiscord(aiSummary)}\n\n${divider}\n\n${storyListPlain}`
-      : storyListPlain;
-
-    if (aiSummary && html) {
-      const formattedSummary = markdownToEmailHtml(aiSummary);
-      const summaryHtml = `<div style="background:#161616;border:1px solid #222;border-left:3px solid #4ade80;padding:18px 22px;margin:0 0 24px 0;">
-<div style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:1.5px;color:#4ade80;margin-bottom:10px;">Executive Summary</div>
-<div style="font-size:13px;line-height:1.7;color:#ccc;">${formattedSummary}</div>
-</div>`;
-      html = html.replace('<div data-ai-summary-slot></div>', summaryHtml);
-    } else if (html) {
-      html = html.replace('<div data-ai-summary-slot></div>', '');
-    }
+    const { text, telegramText, slackText, discordText } = buildChannelBodies(storyListPlain, aiSummary);
+    const html = injectEmailSummary(htmlRaw, aiSummary);
 
     const shortDate = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' }).format(new Date(nowMs));
     const subject = aiSummary ? `WorldMonitor Intelligence Brief — ${shortDate}` : `WorldMonitor Digest — ${shortDate}`;

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -327,26 +327,59 @@ function escapeHtml(str) {
     .replace(/"/g, '&quot;');
 }
 
-function markdownToEmailHtml(md) {
-  // Escape HTML first, then convert markdown formatting
-  let html = escapeHtml(md);
+// Inline markdown → HTML (operates on already-HTML-escaped text, no block markup).
+function renderEmailInline(text) {
+  let out = text;
   // Bold: **text** or __text__
-  html = html.replace(/\*\*(.+?)\*\*/g, '<strong style="color:#fff;">$1</strong>');
-  html = html.replace(/__(.+?)__/g, '<strong style="color:#fff;">$1</strong>');
-  // Italic: *text* (single asterisk, but not bullet points at line start)
-  html = html.replace(/(?<!\n|\*)\*([^*\n]+?)\*/g, '<em>$1</em>');
-  // Bullet points: lines starting with * or -
-  html = html.replace(/^[\*\-]\s+(.+)$/gm, '<li style="margin-bottom:6px;">$1</li>');
-  // Wrap consecutive <li> in <ul>
-  html = html.replace(/((?:<li[^>]*>.*?<\/li>\s*)+)/g, '<ul style="margin:12px 0;padding-left:20px;list-style:disc;">$1</ul>');
-  // Section headers: lines ending with colon (Assessment:, Signals to watch:)
-  // Use [A-Za-z ] (not \s) and ` *` to avoid swallowing newlines.
-  html = html.replace(/^([A-Z][A-Za-z ]+): */gm, '<strong style="color:#4ade80;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">$1:</strong> ');
-  // Paragraphs: double newlines
-  html = html.replace(/\n\n+/g, '</p><p style="margin:12px 0;">');
-  // Single newlines (not inside lists)
-  html = html.replace(/(?<!<\/li>)\n(?!<)/g, '<br/>');
-  return `<p style="margin:0 0 12px;">${html}</p>`;
+  out = out.replace(/\*\*(.+?)\*\*/g, '<strong style="color:#fff;">$1</strong>');
+  out = out.replace(/__(.+?)__/g, '<strong style="color:#fff;">$1</strong>');
+  // Italic: *text* (not adjacent to another asterisk, avoids collision w/ bold)
+  out = out.replace(/(?<!\*)\*([^*\n]+?)\*(?!\*)/g, '<em>$1</em>');
+  // Section header (label at start of the block, e.g. "Assessment:", "Signals to watch:")
+  out = out.replace(
+    /^([A-Z][A-Za-z ]+): */,
+    '<strong style="color:#4ade80;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">$1:</strong> ',
+  );
+  return out;
+}
+
+// Block-level markdown → HTML. Splits the summary into paragraph and list
+// blocks first, then applies inline formatting within each block, so we
+// never nest <ul> inside <p> or split a list across paragraphs.
+function markdownToEmailHtml(md) {
+  const escaped = escapeHtml(md);
+  const lines = escaped.split('\n');
+
+  /** @type {Array<{type:'p'|'ul', items:string[]}>} */
+  const blocks = [];
+  let current = null;
+  const flush = () => { if (current) { blocks.push(current); current = null; } };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) { flush(); continue; }
+
+    const bullet = line.match(/^\s*[\*\-]\s+(.+)$/);
+    if (bullet) {
+      if (!current || current.type !== 'ul') { flush(); current = { type: 'ul', items: [] }; }
+      current.items.push(bullet[1]);
+    } else {
+      if (!current || current.type !== 'p') { flush(); current = { type: 'p', items: [] }; }
+      current.items.push(trimmed);
+    }
+  }
+  flush();
+
+  return blocks.map((block) => {
+    if (block.type === 'ul') {
+      const items = block.items
+        .map((item) => `<li style="margin-bottom:6px;">${renderEmailInline(item)}</li>`)
+        .join('');
+      return `<ul style="margin:12px 0;padding-left:20px;list-style:disc;">${items}</ul>`;
+    }
+    const joined = block.items.map(renderEmailInline).join('<br/>');
+    return `<p style="margin:0 0 12px;">${joined}</p>`;
+  }).join('');
 }
 
 // Telegram HTML parse_mode escape: only &, <, > (no " or ')

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -327,6 +327,27 @@ function escapeHtml(str) {
     .replace(/"/g, '&quot;');
 }
 
+function markdownToEmailHtml(md) {
+  // Escape HTML first, then convert markdown formatting
+  let html = escapeHtml(md);
+  // Bold: **text** or __text__
+  html = html.replace(/\*\*(.+?)\*\*/g, '<strong style="color:#fff;">$1</strong>');
+  html = html.replace(/__(.+?)__/g, '<strong style="color:#fff;">$1</strong>');
+  // Italic: *text* (single asterisk, but not bullet points at line start)
+  html = html.replace(/(?<!\n|\*)\*([^*\n]+?)\*/g, '<em>$1</em>');
+  // Bullet points: lines starting with * or -
+  html = html.replace(/^[\*\-]\s+(.+)$/gm, '<li style="margin-bottom:6px;">$1</li>');
+  // Wrap consecutive <li> in <ul>
+  html = html.replace(/((?:<li[^>]*>.*?<\/li>\s*)+)/g, '<ul style="margin:12px 0;padding-left:20px;list-style:disc;">$1</ul>');
+  // Section headers: lines ending with colon (Assessment:, Signals to watch:)
+  html = html.replace(/^([A-Z][A-Za-z\s]+):\s*/gm, '<strong style="color:#4ade80;font-size:12px;text-transform:uppercase;letter-spacing:0.5px;">$1:</strong> ');
+  // Paragraphs: double newlines
+  html = html.replace(/\n\n+/g, '</p><p style="margin:12px 0;">');
+  // Single newlines (not inside lists)
+  html = html.replace(/(?<!<\/li>)\n(?!<)/g, '<br/>');
+  return `<p style="margin:0 0 12px;">${html}</p>`;
+}
+
 function formatDigestHtml(stories, nowMs) {
   if (!stories || stories.length === 0) return null;
   const dateStr = new Intl.DateTimeFormat('en-US', {
@@ -829,9 +850,10 @@ async function main() {
     if (aiSummary) {
       text = `EXECUTIVE SUMMARY\n\n${aiSummary}\n\n${'─'.repeat(40)}\n\n${text}`;
       if (html) {
+        const formattedSummary = markdownToEmailHtml(aiSummary);
         const summaryHtml = `<div style="background:#161616;border:1px solid #222;border-left:3px solid #4ade80;padding:18px 22px;margin:0 0 24px 0;">
 <div style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:1.5px;color:#4ade80;margin-bottom:10px;">Executive Summary</div>
-<div style="font-size:13px;line-height:1.7;color:#ccc;white-space:pre-wrap;">${escapeHtml(aiSummary)}</div>
+<div style="font-size:13px;line-height:1.7;color:#ccc;">${formattedSummary}</div>
 </div>`;
         html = html.replace('<div data-ai-summary-slot></div>', summaryHtml);
       }

--- a/tests/digest-markdown.test.mjs
+++ b/tests/digest-markdown.test.mjs
@@ -1,0 +1,293 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  escapeHtml,
+  escapeTelegramHtml,
+  escapeSlackMrkdwn,
+  markdownToEmailHtml,
+  markdownToTelegramHtml,
+  markdownToSlackMrkdwn,
+  markdownToDiscord,
+} from '../scripts/_digest-markdown.mjs';
+
+// Representative AI summary that exercises every feature: section headers,
+// bullet lists (twice), inline bold, inline italic, paragraph breaks, and
+// characters that must be escaped per channel.
+const REALISTIC_SUMMARY = `Assessment: Regional escalation in the Levant.
+
+* Israeli strikes killed 25 people in **Lebanon**
+* Hezbollah response expected within *48 hours*
+* Situation is <unknown> & still developing
+
+Signals to watch:
+
+* IDF troop movements
+* Diplomatic cables from Beirut`;
+
+// ── escapeHtml ───────────────────────────────────────────────────────────────
+
+describe('escapeHtml', () => {
+  it('escapes &, <, >, "', () => {
+    assert.equal(escapeHtml('a & b <c> "d"'), 'a &amp; b &lt;c&gt; &quot;d&quot;');
+  });
+
+  it('coerces non-strings', () => {
+    assert.equal(escapeHtml(null), 'null');
+    assert.equal(escapeHtml(42), '42');
+  });
+});
+
+// ── Email HTML ───────────────────────────────────────────────────────────────
+
+describe('markdownToEmailHtml', () => {
+  it('produces only sibling <p>/<ul> blocks — no mis-nesting', () => {
+    const html = markdownToEmailHtml(REALISTIC_SUMMARY);
+    // Tempered quantifiers: capture exactly what's between a block and its
+    // own closing tag without crossing into adjacent blocks.
+    const pBlockRe = /<p[^>]*>((?:(?!<\/p>)[^])*)<\/p>/g;
+    const ulBlockRe = /<ul[^>]*>((?:(?!<\/ul>)[^])*)<\/ul>/g;
+    for (const [, inside] of html.matchAll(pBlockRe)) {
+      assert.doesNotMatch(inside, /<p[\s>]/, '<p> must not contain another <p>');
+      assert.doesNotMatch(inside, /<ul[\s>]/, '<p> must not contain a <ul>');
+    }
+    for (const [, inside] of html.matchAll(ulBlockRe)) {
+      assert.doesNotMatch(inside, /<p[\s>]/, '<ul> must not contain a <p>');
+    }
+    // Opening and closing tags balance 1:1
+    const pOpens = (html.match(/<p[\s>]/g) ?? []).length;
+    const pCloses = (html.match(/<\/p>/g) ?? []).length;
+    const ulOpens = (html.match(/<ul[\s>]/g) ?? []).length;
+    const ulCloses = (html.match(/<\/ul>/g) ?? []).length;
+    assert.equal(pOpens, pCloses, '<p> opens must equal </p> closes');
+    assert.equal(ulOpens, ulCloses, '<ul> opens must equal </ul> closes');
+    assert.equal(ulOpens, 2, 'realistic sample should produce exactly 2 lists');
+    // Every top-level block should be <p>...</p> or <ul>...</ul>; the
+    // concatenation of matched block lengths should equal the whole string.
+    const topLevel = /<(p|ul)[^>]*>(?:(?!<\/\1>)[^])*<\/\1>/g;
+    const consumed = [...html.matchAll(topLevel)].reduce((n, m) => n + m[0].length, 0);
+    assert.equal(consumed, html.length, 'HTML must be a flat sequence of <p>/<ul> blocks');
+  });
+
+  it('styles both section headers (Assessment, Signals to watch)', () => {
+    const html = markdownToEmailHtml(REALISTIC_SUMMARY);
+    const headerColorMatches = html.match(/color:#4ade80/g) ?? [];
+    assert.equal(headerColorMatches.length, 2);
+    assert.match(html, /Assessment:<\/strong>/);
+    assert.match(html, /Signals to watch:<\/strong>/);
+  });
+
+  it('renders bold inside a bullet without leaking tags', () => {
+    const html = markdownToEmailHtml('* Killed 25 in **Lebanon**');
+    assert.match(html, /<li[^>]*>Killed 25 in <strong[^>]*>Lebanon<\/strong><\/li>/);
+  });
+
+  it('renders italic inside a bullet', () => {
+    const html = markdownToEmailHtml('* within *48 hours*');
+    assert.match(html, /<em>48 hours<\/em>/);
+  });
+
+  it('escapes HTML-unsafe characters before applying markdown', () => {
+    const html = markdownToEmailHtml('* Status: <unknown> & still <script>alert(1)</script>');
+    assert.match(html, /&lt;unknown&gt;/);
+    assert.match(html, /&amp;/);
+    assert.match(html, /&lt;script&gt;/);
+    assert.doesNotMatch(html, /<script>/);
+  });
+
+  it('treats blank line as block boundary', () => {
+    const html = markdownToEmailHtml('line one\n\nline two');
+    const pCount = (html.match(/<p[\s>]/g) ?? []).length;
+    assert.equal(pCount, 2);
+  });
+
+  it('joins consecutive non-blank non-bullet lines with <br/>', () => {
+    const html = markdownToEmailHtml('line one\nline two\nline three');
+    assert.match(html, /line one<br\/>line two<br\/>line three/);
+  });
+
+  it('handles a header-only paragraph', () => {
+    const html = markdownToEmailHtml('Signals to watch:');
+    assert.match(html, /<p[^>]*><strong[^>]*>Signals to watch:<\/strong>/);
+  });
+
+  it('handles lists prefixed with - instead of *', () => {
+    const html = markdownToEmailHtml('- item one\n- item two');
+    assert.match(html, /<ul[^>]*><li[^>]*>item one<\/li><li[^>]*>item two<\/li><\/ul>/);
+  });
+
+  it('returns empty string for empty input', () => {
+    assert.equal(markdownToEmailHtml(''), '');
+  });
+});
+
+// ── Telegram HTML ────────────────────────────────────────────────────────────
+
+describe('escapeTelegramHtml', () => {
+  it('escapes only &, <, > (not " or \')', () => {
+    assert.equal(escapeTelegramHtml('a & <b> "c" \'d\''), 'a &amp; &lt;b&gt; "c" \'d\'');
+  });
+});
+
+describe('markdownToTelegramHtml', () => {
+  it('converts bold to <b> and italic to <i>', () => {
+    const out = markdownToTelegramHtml('This is **bold** and *italic*.');
+    assert.equal(out, 'This is <b>bold</b> and <i>italic</i>.');
+  });
+
+  it('converts bullets to • char (Telegram HTML has no list tags)', () => {
+    const out = markdownToTelegramHtml('* one\n* two\n- three');
+    assert.equal(out, '• one\n• two\n• three');
+  });
+
+  it('preserves bullet followed by bold marker', () => {
+    const out = markdownToTelegramHtml('* **Lebanon** is impacted');
+    assert.equal(out, '• <b>Lebanon</b> is impacted');
+  });
+
+  it('bolds section headers at line start', () => {
+    const out = markdownToTelegramHtml('Assessment: escalating\nbody');
+    assert.match(out, /^<b>Assessment:<\/b> escalating/);
+  });
+
+  it('escapes &, <, > before inserting tags', () => {
+    const out = markdownToTelegramHtml('a <script>alert("xss")</script> & **bold**');
+    assert.match(out, /&lt;script&gt;/);
+    assert.match(out, /&amp;/);
+    assert.match(out, /<b>bold<\/b>/);
+    // The injected <b> tag must not itself be escaped
+    assert.doesNotMatch(out, /&lt;b&gt;bold/);
+  });
+
+  it('does not convert bullets inside a bold span to italics', () => {
+    // `**a**` should become `<b>a</b>`; intervening single `*` should not match italic
+    const out = markdownToTelegramHtml('prefix **Lebanon** suffix');
+    assert.equal(out, 'prefix <b>Lebanon</b> suffix');
+  });
+});
+
+// ── Slack mrkdwn ─────────────────────────────────────────────────────────────
+
+describe('escapeSlackMrkdwn', () => {
+  it('escapes only &, <, >', () => {
+    assert.equal(escapeSlackMrkdwn('a & <b> "c"'), 'a &amp; &lt;b&gt; "c"');
+  });
+});
+
+describe('markdownToSlackMrkdwn', () => {
+  it('converts **bold** to Slack single-asterisk *bold*', () => {
+    const out = markdownToSlackMrkdwn('the **Lebanon** region');
+    assert.equal(out, 'the *Lebanon* region');
+  });
+
+  it('converts *italic* to Slack _italic_', () => {
+    const out = markdownToSlackMrkdwn('within *48 hours*');
+    assert.equal(out, 'within _48 hours_');
+  });
+
+  it('handles bold and italic together on one line', () => {
+    const out = markdownToSlackMrkdwn('This is **bold** and *italic*.');
+    assert.equal(out, 'This is *bold* and _italic_.');
+  });
+
+  it('converts bullets to • (Slack has no list primitive)', () => {
+    const out = markdownToSlackMrkdwn('* one\n* two\n- three');
+    assert.equal(out, '• one\n• two\n• three');
+  });
+
+  it('bolds section headers via Slack single-asterisk', () => {
+    const out = markdownToSlackMrkdwn('Assessment: escalating\nbody');
+    assert.match(out, /^\*Assessment:\* escalating/);
+  });
+
+  it('escapes &, <, > before conversion', () => {
+    const out = markdownToSlackMrkdwn('<html> & **tag**');
+    assert.match(out, /&lt;html&gt;/);
+    assert.match(out, /&amp;/);
+    assert.match(out, /\*tag\*/);
+  });
+
+  it('bold placeholder does not leak \\u0001 into output', () => {
+    const out = markdownToSlackMrkdwn('**one** and **two**');
+    assert.doesNotMatch(out, /\u0001/);
+    assert.equal(out, '*one* and *two*');
+  });
+
+  it('bullet then bold does not collapse into italic', () => {
+    // The * at line start would otherwise also be a potential italic opener
+    const out = markdownToSlackMrkdwn('* **Lebanon** strikes');
+    assert.equal(out, '• *Lebanon* strikes');
+  });
+});
+
+// ── Discord CommonMark ───────────────────────────────────────────────────────
+
+describe('markdownToDiscord', () => {
+  it('normalizes * bullets to - (Discord lists only accept -)', () => {
+    const out = markdownToDiscord('* one\n* two');
+    assert.equal(out, '- one\n- two');
+  });
+
+  it('leaves - bullets untouched', () => {
+    const out = markdownToDiscord('- one\n- two');
+    assert.equal(out, '- one\n- two');
+  });
+
+  it('wraps section headers in **bold**', () => {
+    const out = markdownToDiscord('Assessment: escalating');
+    assert.equal(out, '**Assessment:** escalating');
+  });
+
+  it('leaves **bold** and *italic* untouched (Discord parses CommonMark natively)', () => {
+    const out = markdownToDiscord('the **Lebanon** region is *critical*');
+    assert.equal(out, 'the **Lebanon** region is *critical*');
+  });
+
+  it('converts a realistic summary end-to-end', () => {
+    const out = markdownToDiscord(REALISTIC_SUMMARY);
+    assert.match(out, /^\*\*Assessment:\*\* Regional/);
+    assert.match(out, /^- Israeli strikes killed 25 people in \*\*Lebanon\*\*/m);
+    assert.match(out, /^\*\*Signals to watch:\*\*/m);
+  });
+});
+
+// ── Full integration: realistic summary on all channels ─────────────────────
+
+describe('realistic AI summary — cross-channel smoke test', () => {
+  it('email output is well-formed with 2 lists and 2 headers', () => {
+    const html = markdownToEmailHtml(REALISTIC_SUMMARY);
+    assert.equal((html.match(/<ul[\s>]/g) ?? []).length, 2);
+    assert.equal((html.match(/<\/ul>/g) ?? []).length, 2);
+    assert.equal((html.match(/color:#4ade80/g) ?? []).length, 2);
+  });
+
+  it('telegram output has bold tags, bullet chars, and escaped entities', () => {
+    const out = markdownToTelegramHtml(REALISTIC_SUMMARY);
+    assert.match(out, /<b>Lebanon<\/b>/);
+    assert.match(out, /<b>Assessment:<\/b>/);
+    assert.match(out, /<b>Signals to watch:<\/b>/);
+    assert.match(out, /^• Israeli/m);
+    assert.match(out, /&lt;unknown&gt;/);
+    assert.match(out, /&amp;/);
+  });
+
+  it('slack output uses single-asterisk bold, underscore italic, bullet chars', () => {
+    const out = markdownToSlackMrkdwn(REALISTIC_SUMMARY);
+    assert.match(out, /\*Lebanon\*/);
+    assert.match(out, /_48 hours_/);
+    assert.match(out, /^\*Assessment:\*/m);
+    assert.match(out, /^\*Signals to watch:\*/m);
+    assert.match(out, /^• Israeli/m);
+    assert.match(out, /&lt;unknown&gt;/);
+  });
+
+  it('discord output uses - bullets, **bold** headers, and CommonMark-native emphasis', () => {
+    const out = markdownToDiscord(REALISTIC_SUMMARY);
+    assert.match(out, /^\*\*Assessment:\*\*/m);
+    assert.match(out, /^\*\*Signals to watch:\*\*/m);
+    assert.match(out, /^- Israeli strikes killed 25 people in \*\*Lebanon\*\*/m);
+    // Discord is told the raw markdown — it should NOT have the escaped entities
+    assert.match(out, /<unknown>/);
+    assert.match(out, / & still/);
+  });
+});

--- a/tests/digest-markdown.test.mjs
+++ b/tests/digest-markdown.test.mjs
@@ -45,8 +45,8 @@ describe('markdownToEmailHtml', () => {
     const html = markdownToEmailHtml(REALISTIC_SUMMARY);
     // Tempered quantifiers: capture exactly what's between a block and its
     // own closing tag without crossing into adjacent blocks.
-    const pBlockRe = /<p[^>]*>((?:(?!<\/p>)[^])*)<\/p>/g;
-    const ulBlockRe = /<ul[^>]*>((?:(?!<\/ul>)[^])*)<\/ul>/g;
+    const pBlockRe = /<p[^>]*>((?:(?!<\/p>)[\s\S])*)<\/p>/g;
+    const ulBlockRe = /<ul[^>]*>((?:(?!<\/ul>)[\s\S])*)<\/ul>/g;
     for (const [, inside] of html.matchAll(pBlockRe)) {
       assert.doesNotMatch(inside, /<p[\s>]/, '<p> must not contain another <p>');
       assert.doesNotMatch(inside, /<ul[\s>]/, '<p> must not contain a <ul>');
@@ -64,7 +64,7 @@ describe('markdownToEmailHtml', () => {
     assert.equal(ulOpens, 2, 'realistic sample should produce exactly 2 lists');
     // Every top-level block should be <p>...</p> or <ul>...</ul>; the
     // concatenation of matched block lengths should equal the whole string.
-    const topLevel = /<(p|ul)[^>]*>(?:(?!<\/\1>)[^])*<\/\1>/g;
+    const topLevel = /<(p|ul)[^>]*>(?:(?!<\/\1>)[\s\S])*<\/\1>/g;
     const consumed = [...html.matchAll(topLevel)].reduce((n, m) => n + m[0].length, 0);
     assert.equal(consumed, html.length, 'HTML must be a flat sequence of <p>/<ul> blocks');
   });


### PR DESCRIPTION
## Summary
- Render the AI executive summary markdown (`**bold**`, `*italic*`, `* bullets`, `Assessment:` headers) correctly in email, Telegram, Slack, and Discord — previously users saw literal `**asterisks**` everywhere except Discord (which got lucky on `**bold**` only).
- **Email** (HTML): new `markdownToEmailHtml()` converts markdown to inline-styled HTML, injected via the `<div data-ai-summary-slot>` placeholder.
- **Telegram**: now sends with `parse_mode: 'HTML'` and `disable_web_page_preview: true`. New `markdownToTelegramHtml()` outputs `<b>`, `<i>`, `•` bullets, and escapes `&<>` first.
- **Slack**: new `markdownToSlackMrkdwn()` converts `**bold**` → `*bold*` (Slack uses single-asterisk), `*italic*` → `_italic_`, bullets → `•`, headers → `*bold*`. Uses a placeholder during the bold pass to avoid the italic regex re-matching.
- **Discord**: new `markdownToDiscord()` normalizes `* bullets` → `- ` (Discord's list syntax) and wraps `Assessment:` headers in `**bold**`. Leaves `**bold**` and `*italic*` alone since Discord parses CommonMark natively.
- **Email regex fix**: tightened the section-header regex (was using `\s*` which swallowed the trailing newline, making `Signals to watch:` run into the next line).
- Per-channel bodies are built once per digest rule. The plain-text `text` is still used for the email `.txt` fallback and the webhook passthrough (consumer parses as it likes).

## Test plan
- [ ] Trigger a digest email — bold/bullets/headers render correctly
- [ ] Trigger a digest Telegram message — confirm `<b>` renders as bold, no literal HTML tags visible, no link preview
- [ ] Trigger a digest Slack message — confirm `*Lebanon*` renders as bold (not italic), bullets render as `•`
- [ ] Trigger a digest Discord message — confirm `**Lebanon**` renders as bold, `-` bullets render as a list, `Assessment:` is bold
- [ ] Regular (non-markdown) text still renders correctly in all four channels
- [ ] Titles containing `<`, `>`, `&` render correctly in Telegram/Slack (no broken HTML/mrkdwn)