### PR TITLE
feat(supply-chain): multi-sector cost shock calculator with closure duration slider

### DIFF
--- a/api/supply-chain/v1/multi-sector-cost-shock.ts
+++ b/api/supply-chain/v1/multi-sector-cost-shock.ts
@@ -1,0 +1,157 @@
+export const config = { runtime: 'edge' };
+
+import { isCallerPremium } from '../../../server/_shared/premium-check';
+import { CHOKEPOINT_REGISTRY } from '../../../server/_shared/chokepoint-registry';
+import { CHOKEPOINT_STATUS_KEY } from '../../../server/_shared/cache-keys';
+import {
+  aggregateAnnualImportsByHs2,
+  clampClosureDays,
+  computeMultiSectorShocks,
+  SEEDED_HS2_CODES,
+  type MultiSectorCostShock,
+  type SeededProduct,
+} from '../../../server/worldmonitor/supply-chain/v1/_multi-sector-shock';
+// @ts-expect-error — JS module, no declaration file
+import { readJsonFromUpstash } from '../../_upstash-json.js';
+
+interface ChokepointStatusCache {
+  chokepoints?: Array<{ id: string; warRiskTier?: string }>;
+}
+
+interface CountryProductsCache {
+  iso2: string;
+  products?: SeededProduct[];
+  fetchedAt?: string;
+}
+
+export interface MultiSectorCostShockResponse {
+  iso2: string;
+  chokepointId: string;
+  closureDays: number;
+  warRiskTier: string;
+  sectors: MultiSectorCostShock[];
+  totalAddedCost: number;
+  fetchedAt: string;
+  unavailableReason: string;
+}
+
+function emptyResponse(
+  iso2: string,
+  chokepointId: string,
+  closureDays: number,
+  reason = '',
+): MultiSectorCostShockResponse {
+  return {
+    iso2,
+    chokepointId,
+    closureDays,
+    warRiskTier: 'WAR_RISK_TIER_UNSPECIFIED',
+    sectors: [],
+    totalAddedCost: 0,
+    fetchedAt: new Date().toISOString(),
+    unavailableReason: reason,
+  };
+}
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method !== 'GET') {
+    return new Response('', { status: 405 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const iso2 = (searchParams.get('iso2') ?? '').toUpperCase();
+  const chokepointId = (searchParams.get('chokepointId') ?? '').trim().toLowerCase();
+  const rawDays = Number(searchParams.get('closureDays') ?? '30');
+  const closureDays = clampClosureDays(rawDays);
+
+  if (!/^[A-Z]{2}$/.test(iso2)) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid or missing iso2 parameter' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+  if (!chokepointId) {
+    return new Response(
+      JSON.stringify({ error: 'Invalid or missing chokepointId parameter' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+  if (!CHOKEPOINT_REGISTRY.some(c => c.id === chokepointId)) {
+    return new Response(
+      JSON.stringify({ error: `Unknown chokepointId: ${chokepointId}` }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const isPro = await isCallerPremium(req);
+  if (!isPro) {
+    return new Response(
+      JSON.stringify({ error: 'PRO subscription required' }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  // Parallel Redis reads: country products + chokepoint status (for war risk tier).
+  const productsKey = `comtrade:bilateral-hs4:${iso2}:v1`;
+  const [productsCache, statusCache] = await Promise.all([
+    readJsonFromUpstash(productsKey, 5_000).catch(() => null) as Promise<CountryProductsCache | null>,
+    readJsonFromUpstash(CHOKEPOINT_STATUS_KEY, 5_000).catch(() => null) as Promise<ChokepointStatusCache | null>,
+  ]);
+
+  const products = Array.isArray(productsCache?.products) ? productsCache.products : [];
+  const importsByHs2 = aggregateAnnualImportsByHs2(products);
+  const hasAnyImports = Object.values(importsByHs2).some(v => v > 0);
+  const warRiskTier = statusCache?.chokepoints?.find(c => c.id === chokepointId)?.warRiskTier
+    ?? 'WAR_RISK_TIER_NORMAL';
+
+  if (!hasAnyImports) {
+    return new Response(
+      JSON.stringify({
+        ...emptyResponse(iso2, chokepointId, closureDays, 'No seeded import data available for this country'),
+        // Still emit the empty sector skeleton so the UI can render rows at 0.
+        sectors: SEEDED_HS2_CODES.map(hs2 => ({
+          hs2,
+          hs2Label: hs2,
+          importValueAnnual: 0,
+          freightAddedPctPerTon: 0,
+          warRiskPremiumBps: 0,
+          addedTransitDays: 0,
+          totalCostShockPerDay: 0,
+          totalCostShock30Days: 0,
+          totalCostShock90Days: 0,
+          totalCostShock: 0,
+          closureDays,
+        })),
+        warRiskTier,
+      } satisfies MultiSectorCostShockResponse),
+      { status: 200, headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' } },
+    );
+  }
+
+  const sectors = computeMultiSectorShocks(importsByHs2, chokepointId, warRiskTier, closureDays);
+  const totalAddedCost = sectors.reduce((sum, s) => sum + s.totalCostShock, 0);
+
+  const response: MultiSectorCostShockResponse = {
+    iso2,
+    chokepointId,
+    closureDays,
+    warRiskTier,
+    sectors,
+    totalAddedCost,
+    fetchedAt: new Date().toISOString(),
+    unavailableReason: '',
+  };
+
+  return new Response(
+    JSON.stringify(response),
+    {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        // Closure duration is user-controlled, so cache is private + short.
+        'Cache-Control': 'private, max-age=60',
+        'Vary': 'Authorization, Cookie, X-WorldMonitor-Key',
+      },
+    },
+  );
+}

--- a/server/worldmonitor/supply-chain/v1/_multi-sector-shock.ts
+++ b/server/worldmonitor/supply-chain/v1/_multi-sector-shock.ts
@@ -1,0 +1,168 @@
+/**
+ * Multi-sector cost shock model (Phase 5).
+ *
+ * Extends the energy-only shock model to all 10 seeded HS2 sectors with a simpler
+ * freight + war-risk based estimator. For each sector we compute:
+ *
+ *   warRiskPremiumBps   = basis-point surcharge from chokepoint tier
+ *   freightAddedPctPerTon = (addedCostMultiplier - 1) from best suitable bypass
+ *   addedTransitDays    = bypass transit penalty (informational)
+ *   dailyAddedCost      = importValueAnnual * (freightAddedPctPerTon + bps/10000) / 365
+ *   totalCostShockNDays = dailyAddedCost * N
+ *
+ * HS27 (energy) keeps its dedicated energy shock model in get-country-cost-shock.ts;
+ * this computation runs for HS!=27 and for presentation in the multi-sector calculator.
+ */
+
+import { BYPASS_CORRIDORS_BY_CHOKEPOINT, type BypassCorridor } from '../../../_shared/bypass-corridors';
+import { warRiskTierToInsurancePremiumBps } from './_insurance-tier';
+
+/** Top 10 HS2 sectors seeded by scripts/seed-comtrade-bilateral-hs4.mjs. */
+export const SEEDED_HS2_CODES = ['27', '84', '85', '87', '30', '72', '39', '29', '10', '62'] as const;
+
+/** Friendly labels for display. Mirrors HS2_SHORT_LABELS in src/services/supply-chain. */
+export const MULTI_SECTOR_HS2_LABELS: Record<string, string> = {
+  '27': 'Energy',
+  '84': 'Machinery',
+  '85': 'Electronics',
+  '87': 'Vehicles',
+  '30': 'Pharma',
+  '72': 'Iron & Steel',
+  '39': 'Plastics',
+  '29': 'Chemicals',
+  '10': 'Cereals',
+  '62': 'Apparel',
+};
+
+/** HS4 → HS2 is always the first two digits, zero-padded. */
+export function hs4ToHs2(hs4: string): string {
+  const padded = hs4.padStart(4, '0');
+  return padded.slice(0, 2).replace(/^0+/, '') || '0';
+}
+
+export interface MultiSectorCostShock {
+  hs2: string;
+  hs2Label: string;
+  importValueAnnual: number;
+  freightAddedPctPerTon: number;
+  warRiskPremiumBps: number;
+  addedTransitDays: number;
+  totalCostShockPerDay: number;
+  totalCostShock30Days: number;
+  totalCostShock90Days: number;
+  /** Cost for the requested closureDays window (matches clampClosureDays(closureDays)). */
+  totalCostShock: number;
+  /** Echoes the clamped closure duration used for totalCostShock (1-365). */
+  closureDays: number;
+}
+
+/** Product row as persisted by seed-comtrade-bilateral-hs4. */
+export interface SeededProduct {
+  hs4: string;
+  description: string;
+  totalValue: number;
+  year: number;
+}
+
+/**
+ * Pick the cheapest viable bypass corridor for a chokepoint.
+ * Excludes "no-bypass" placeholder entries (suitableCargoTypes.length === 0),
+ * hypothetical/proposed corridors with negative uplift (addedCostMultiplier < 1),
+ * and full-closure-only corridors (which only activate on 100% closure scenarios).
+ * Prefers lower addedTransitDays, then lower addedCostMultiplier as tiebreaker.
+ */
+export function pickBestBypass(chokepointId: string): BypassCorridor | null {
+  const corridors = BYPASS_CORRIDORS_BY_CHOKEPOINT[chokepointId] ?? [];
+  const viable = corridors.filter(c =>
+    c.suitableCargoTypes.length > 0
+    && c.addedCostMultiplier >= 1
+    && c.activationThreshold === 'partial_closure',
+  );
+  if (viable.length === 0) return null;
+  return [...viable].sort((a, b) => {
+    if (a.addedTransitDays !== b.addedTransitDays) return a.addedTransitDays - b.addedTransitDays;
+    return a.addedCostMultiplier - b.addedCostMultiplier;
+  })[0] ?? null;
+}
+
+/** Aggregate seeded HS4 product values to annual import totals keyed by HS2. */
+export function aggregateAnnualImportsByHs2(
+  products: readonly SeededProduct[] | undefined,
+): Record<string, number> {
+  const totals: Record<string, number> = {};
+  for (const hs2 of SEEDED_HS2_CODES) totals[hs2] = 0;
+  if (!Array.isArray(products)) return totals;
+  for (const p of products) {
+    if (!p || typeof p.totalValue !== 'number' || !Number.isFinite(p.totalValue) || p.totalValue <= 0) continue;
+    const hs2 = hs4ToHs2(String(p.hs4 ?? ''));
+    if (!(hs2 in totals)) continue;
+    totals[hs2] = (totals[hs2] ?? 0) + p.totalValue;
+  }
+  return totals;
+}
+
+/**
+ * Compute cost shock for a single sector. Pure function; no I/O.
+ *
+ * @param hs2               HS2 sector code (e.g. "85")
+ * @param importValueAnnual total annual import value (USD) for this sector
+ * @param chokepointId      which chokepoint is assumed closed
+ * @param warRiskTier       war risk tier string (proto enum format)
+ * @param closureDays       how many days of closure to model (1-365)
+ */
+export function computeMultiSectorShock(
+  hs2: string,
+  importValueAnnual: number,
+  chokepointId: string,
+  warRiskTier: string,
+  closureDays: number,
+): MultiSectorCostShock {
+  const normalizedDays = clampClosureDays(closureDays);
+  const warRiskPremiumBps = warRiskTierToInsurancePremiumBps(warRiskTier);
+  const bypass = pickBestBypass(chokepointId);
+  const freightAddedPctPerTon = bypass ? Math.max(0, bypass.addedCostMultiplier - 1) : 0;
+  const addedTransitDays = bypass?.addedTransitDays ?? 0;
+
+  const annualImpactRate = freightAddedPctPerTon + warRiskPremiumBps / 10_000;
+  const safeImports = Number.isFinite(importValueAnnual) && importValueAnnual > 0 ? importValueAnnual : 0;
+  const dailyAddedCost = (safeImports * annualImpactRate) / 365;
+
+  return {
+    hs2,
+    hs2Label: MULTI_SECTOR_HS2_LABELS[hs2] ?? `HS ${hs2}`,
+    importValueAnnual: Math.round(safeImports),
+    freightAddedPctPerTon: Math.round(freightAddedPctPerTon * 10_000) / 10_000,
+    warRiskPremiumBps,
+    addedTransitDays,
+    totalCostShockPerDay: Math.round(dailyAddedCost),
+    totalCostShock30Days: Math.round(dailyAddedCost * 30),
+    totalCostShock90Days: Math.round(dailyAddedCost * 90),
+    totalCostShock: Math.round(dailyAddedCost * normalizedDays),
+    closureDays: normalizedDays,
+  };
+}
+
+/** Bound user-supplied closure duration to a sane 1-365 day window. */
+export function clampClosureDays(days: number | undefined | null): number {
+  if (!Number.isFinite(days as number)) return 30;
+  const n = Math.floor(days as number);
+  if (n < 1) return 1;
+  if (n > 365) return 365;
+  return n;
+}
+
+/**
+ * Compute shocks for all 10 seeded HS2 sectors in one pass.
+ * Sorted by totalCostShockPerDay descending so top entries dominate the UI.
+ */
+export function computeMultiSectorShocks(
+  importsByHs2: Record<string, number>,
+  chokepointId: string,
+  warRiskTier: string,
+  closureDays: number,
+): MultiSectorCostShock[] {
+  const shocks = SEEDED_HS2_CODES.map(hs2 =>
+    computeMultiSectorShock(hs2, importsByHs2[hs2] ?? 0, chokepointId, warRiskTier, closureDays),
+  );
+  return shocks.sort((a, b) => b.totalCostShockPerDay - a.totalCostShockPerDay);
+}

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -48,7 +48,7 @@ import { toFlagEmoji } from '@/utils/country-flag';
 import { iso2ToIso3, iso2ToUnCode } from '@/utils/country-codes';
 import { buildDependencyGraph } from '@/services/infrastructure-cascade';
 import { getActiveFrameworkForPanel, subscribeFrameworkChange } from '@/services/analysis-framework-store';
-import { fetchMultiSectorExposure, fetchCountryProducts } from '@/services/supply-chain';
+import { fetchMultiSectorExposure, fetchCountryProducts, fetchMultiSectorCostShock } from '@/services/supply-chain';
 
 type IntlDisplayNamesCtor = new (
   locales: string | string[],
@@ -635,13 +635,23 @@ export class CountryIntelManager implements AppModule {
         }).catch(() => {
           if (this.ctx.countryBriefPage?.getCode() === code) this.ctx.countryBriefPage.updateCostShock?.(null);
         });
+
+        // Multi-sector cost shock calculator (Phase 5) — default 30-day closure.
+        fetchMultiSectorCostShock(code, resp.primaryChokepointId, 30).then(multi => {
+          if (this.ctx.countryBriefPage?.getCode() !== code) return;
+          this.ctx.countryBriefPage.updateMultiSectorCostShock?.(multi);
+        }).catch(() => {
+          if (this.ctx.countryBriefPage?.getCode() === code) this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
+        });
       } else {
         this.ctx.countryBriefPage.updateCostShock?.(null);
+        this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
       }
     }).catch(() => {
       if (this.ctx.countryBriefPage?.getCode() === code) {
         this.ctx.countryBriefPage.updateChokepointExposure?.(null);
         this.ctx.countryBriefPage.updateCostShock?.(null);
+        this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
       }
     });
 

--- a/src/components/CountryBriefPanel.ts
+++ b/src/components/CountryBriefPanel.ts
@@ -2,7 +2,7 @@ import type { CountryBriefSignals } from '@/types';
 import type { CountryScore } from '@/services/country-instability';
 import type { PredictionMarket } from '@/services/prediction';
 import type { NewsItem } from '@/types';
-import type { GetCountryChokepointIndexResponse, SectorExposureSummary, CountryProductsResponse } from '@/services/supply-chain';
+import type { GetCountryChokepointIndexResponse, SectorExposureSummary, CountryProductsResponse, MultiSectorShockResponse } from '@/services/supply-chain';
 
 export interface CountryIntelData {
   brief: string;
@@ -194,5 +194,6 @@ export interface CountryBriefPanel {
   updateTariffTrends?(data: { currentRate: number; trend: string; datapoints: Array<{ year: number; tariffRate: number }> } | null): void;
   updateChokepointExposure?(data: { vulnerabilityIndex: number; exposures: Array<{ chokepointName: string; exposureScore: number }> } | null): void;
   updateCostShock?(data: { supplyDeficitPct: number; coverageDays: number; warRiskTier: string } | null): void;
+  updateMultiSectorCostShock?(data: MultiSectorShockResponse | null): void;
   updateProductImports?(data: CountryProductsResponse | null): void;
 }

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -31,7 +31,15 @@ import type {
   CountryEnergyProfileData,
   CountryPortActivityData,
 } from './CountryBriefPanel';
-import type { GetCountryChokepointIndexResponse, SectorExposureSummary, CountryProductsResponse, CountryProduct } from '@/services/supply-chain';
+import type {
+  GetCountryChokepointIndexResponse,
+  SectorExposureSummary,
+  CountryProductsResponse,
+  CountryProduct,
+  MultiSectorShockResponse,
+  MultiSectorShock,
+} from '@/services/supply-chain';
+import { fetchMultiSectorCostShock } from '@/services/supply-chain';
 import type { MapContainer } from './MapContainer';
 import { ResilienceWidget } from './ResilienceWidget';
 
@@ -110,6 +118,15 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   private tariffBody: HTMLElement | null = null;
   private chokepointBody: HTMLElement | null = null;
   private costShockBody: HTMLElement | null = null;
+  // ── Phase 5: Multi-sector Cost Shock Calculator ─────────────────────────
+  private costShockCalcBody: HTMLElement | null = null;
+  private costShockCalcTable: HTMLElement | null = null;
+  private costShockCalcDurationLabel: HTMLElement | null = null;
+  private costShockCalcTotalLabel: HTMLElement | null = null;
+  private costShockCalcPrimaryChokepoint: string | null = null;
+  private costShockCalcClosureDays = 30;
+  private costShockCalcAbort: AbortController | null = null;
+  private costShockCalcDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   private readonly handleGlobalKeydown = (event: KeyboardEvent): void => {
     if (!this.panel.classList.contains('active')) return;
@@ -617,6 +634,145 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         : 'color-mix(in srgb, var(--semantic-normal) 20%, transparent)';
       row.append(scoreEl);
       this.chokepointBody.append(row);
+    }
+  }
+
+  /**
+   * Mount the Cost Shock Calculator with its initial data and slider.
+   * Called once per country load with the first (default 30-day) response.
+   */
+  public updateMultiSectorCostShock(data: MultiSectorShockResponse | null): void {
+    if (!this.costShockCalcBody) return;
+    this.costShockCalcBody.replaceChildren();
+
+    if (!data || (!data.sectors.length && !data.unavailableReason)) {
+      this.costShockCalcBody.append(this.makeEmpty('No multi-sector cost shock data'));
+      return;
+    }
+
+    this.costShockCalcPrimaryChokepoint = data.chokepointId;
+    this.costShockCalcClosureDays = Number.isFinite(data.closureDays) && data.closureDays > 0 ? data.closureDays : 30;
+
+    // ── Header line: chokepoint + war risk tier badge ────────────────────
+    const header = this.el('div', 'cdp-cost-shock-calc-header');
+    const cpName = STRATEGIC_WATERWAYS.find(w => w.id === data.chokepointId)?.name
+      ?? data.chokepointId.replace(/_/g, ' ');
+    header.append(this.el('span', 'cdp-cost-shock-calc-cp', `Primary: ${cpName}`));
+    const tierShort = data.warRiskTier.replace('WAR_RISK_TIER_', '').replace(/_/g, ' ');
+    header.append(this.el('span', 'cdp-cost-shock-calc-tier', `War risk: ${tierShort || 'NORMAL'}`));
+    this.costShockCalcBody.append(header);
+
+    // ── Slider ──────────────────────────────────────────────────────────
+    const sliderWrap = this.el('div', 'cdp-cost-shock-calc-slider-wrap');
+    const sliderLabel = this.el('label', 'cdp-cost-shock-calc-slider-label');
+    sliderLabel.append(document.createTextNode('Closure duration: '));
+    this.costShockCalcDurationLabel = this.el('strong', 'cdp-cost-shock-calc-duration-value', `${this.costShockCalcClosureDays} days`);
+    sliderLabel.append(this.costShockCalcDurationLabel);
+    sliderWrap.append(sliderLabel);
+
+    const slider = this.el('input', 'cdp-cost-shock-calc-slider');
+    slider.type = 'range';
+    slider.min = '1';
+    slider.max = '90';
+    slider.step = '1';
+    slider.value = String(this.costShockCalcClosureDays);
+    slider.setAttribute('aria-label', 'Chokepoint closure duration in days');
+    slider.addEventListener('input', this.handleCostShockSliderInput);
+    sliderWrap.append(slider);
+
+    const ticks = this.el('div', 'cdp-cost-shock-calc-ticks');
+    for (const label of ['1d', '30d', '60d', '90d']) {
+      ticks.append(this.el('span', 'cdp-cost-shock-calc-tick', label));
+    }
+    sliderWrap.append(ticks);
+    this.costShockCalcBody.append(sliderWrap);
+
+    // ── Table ───────────────────────────────────────────────────────────
+    const table = this.el('table', 'cdp-cost-shock-calc-table');
+    const thead = this.el('thead');
+    const headerRow = this.el('tr');
+    headerRow.append(this.el('th', '', 'Sector'));
+    headerRow.append(this.el('th', 'cdp-cost-shock-calc-cost-col', 'Added Cost'));
+    thead.append(headerRow);
+    table.append(thead);
+    const tbody = this.el('tbody');
+    table.append(tbody);
+    this.costShockCalcTable = tbody;
+    this.costShockCalcBody.append(table);
+
+    // ── Total row ───────────────────────────────────────────────────────
+    const totalRow = this.el('div', 'cdp-cost-shock-calc-total-row');
+    totalRow.append(this.el('span', 'cdp-cost-shock-calc-total-label', 'Total'));
+    this.costShockCalcTotalLabel = this.el('span', 'cdp-cost-shock-calc-total-value', '$0');
+    totalRow.append(this.costShockCalcTotalLabel);
+    this.costShockCalcBody.append(totalRow);
+
+    if (data.unavailableReason) {
+      this.costShockCalcBody.append(this.el('div', 'cdp-card-footer', data.unavailableReason));
+    } else {
+      this.costShockCalcBody.append(
+        this.el('div', 'cdp-card-footer', 'Added cost = annual imports × (bypass freight uplift + war risk bps) × closure days / 365'),
+      );
+    }
+
+    this.renderMultiSectorShockRows(data.sectors);
+  }
+
+  /** Render (or re-render) just the cost-shock table rows + total. */
+  private renderMultiSectorShockRows(sectors: MultiSectorShock[]): void {
+    if (!this.costShockCalcTable || !this.costShockCalcTotalLabel) return;
+    const tbody = this.costShockCalcTable;
+    tbody.replaceChildren();
+
+    const sorted = [...sectors].sort((a, b) => b.totalCostShock - a.totalCostShock);
+    let total = 0;
+    for (const s of sorted) {
+      const tr = this.el('tr', 'cdp-cost-shock-calc-row');
+      const labelCell = this.el('td', 'cdp-cost-shock-calc-sector', s.hs2Label || `HS${s.hs2}`);
+      const costCell = this.el('td', 'cdp-cost-shock-calc-cost', this.formatMoney(s.totalCostShock));
+      if (s.totalCostShock === 0) costCell.classList.add('cdp-cost-shock-calc-cost--zero');
+      tr.append(labelCell, costCell);
+      tbody.append(tr);
+      total += s.totalCostShock;
+    }
+    this.costShockCalcTotalLabel.textContent = this.formatMoney(total);
+  }
+
+  private readonly handleCostShockSliderInput = (ev: Event): void => {
+    const target = ev.target as HTMLInputElement | null;
+    if (!target) return;
+    const days = Math.max(1, Math.min(90, Number(target.value) || 30));
+    this.costShockCalcClosureDays = days;
+    if (this.costShockCalcDurationLabel) {
+      this.costShockCalcDurationLabel.textContent = `${days} day${days === 1 ? '' : 's'}`;
+    }
+    this.scheduleCostShockRefetch(days);
+  };
+
+  /** Debounce re-fetch by 300ms so rapid slider drags don't spam the API. */
+  private scheduleCostShockRefetch(days: number): void {
+    if (this.costShockCalcDebounceTimer) clearTimeout(this.costShockCalcDebounceTimer);
+    this.costShockCalcDebounceTimer = setTimeout(() => {
+      this.costShockCalcDebounceTimer = null;
+      void this.refetchMultiSectorShock(days);
+    }, 300);
+  }
+
+  private async refetchMultiSectorShock(days: number): Promise<void> {
+    const iso2 = this.currentCode;
+    const cp = this.costShockCalcPrimaryChokepoint;
+    if (!iso2 || !cp) return;
+
+    // Abort any in-flight fetch before starting a new one.
+    this.costShockCalcAbort?.abort();
+    this.costShockCalcAbort = new AbortController();
+    try {
+      const resp = await fetchMultiSectorCostShock(iso2, cp, days, { signal: this.costShockCalcAbort.signal });
+      if (this.currentCode !== iso2) return;
+      if (this.costShockCalcClosureDays !== days) return; // a newer slider move superseded this
+      this.renderMultiSectorShockRows(resp.sectors);
+    } catch {
+      // Ignore — either aborted or transient network; leave prior values visible.
     }
   }
 
@@ -1989,6 +2145,15 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
 
     const isPro = hasPremiumAccess(getAuthState());
 
+    const [costShockCalcCard, costShockCalcBody] = this.sectionCard(
+      'Cost Shock Calculator',
+      'Model the per-sector added cost of a prolonged chokepoint closure. Drag the slider to change closure duration (1-90 days). Uses war risk premium + best bypass freight uplift × annual import value.',
+    );
+    this.costShockCalcBody = costShockCalcBody;
+    costShockCalcBody.append(
+      isPro ? this.makeLoading('Loading cost shock calculator\u2026') : this.makeProLocked('Upgrade to PRO for multi-sector cost shock modelling'),
+    );
+
     const [productImportsCard, productImportsCardBody] = this.sectionCard('Product Imports', 'Top imported products by HS4 code with supplier breakdown and concentration risk.');
     this.productImportsBody = productImportsCardBody;
     productImportsCardBody.append(isPro ? this.makeLoading('Loading product data\u2026') : this.makeProLocked('Upgrade to PRO for product import data'));
@@ -2035,7 +2200,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     marketsBody.append(this.makeLoading(t('countryBrief.loadingMarkets')));
     briefBody.append(this.makeLoading(t('countryBrief.generatingBrief')));
 
-    bodyGrid.append(briefCard, factsExpanded, energyCard, maritimeCard, tradeCard, productImportsCard, debtCard, sanctionsCard, comtradeCard, tariffCard, chokepointCard, costShockCard, signalsCard, timelineCard, newsCard, militaryCard, infraCard, economicCard, marketsCard);
+    bodyGrid.append(briefCard, factsExpanded, energyCard, maritimeCard, tradeCard, costShockCalcCard, productImportsCard, debtCard, sanctionsCard, comtradeCard, tariffCard, chokepointCard, costShockCard, signalsCard, timelineCard, newsCard, militaryCard, infraCard, economicCard, marketsCard);
     shell.append(header, summaryGrid, bodyGrid);
     this.content.append(shell);
   }
@@ -2064,6 +2229,18 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.tariffBody = null;
     this.chokepointBody = null;
     this.costShockBody = null;
+    this.costShockCalcAbort?.abort();
+    this.costShockCalcAbort = null;
+    if (this.costShockCalcDebounceTimer) {
+      clearTimeout(this.costShockCalcDebounceTimer);
+      this.costShockCalcDebounceTimer = null;
+    }
+    this.costShockCalcBody = null;
+    this.costShockCalcTable = null;
+    this.costShockCalcDurationLabel = null;
+    this.costShockCalcTotalLabel = null;
+    this.costShockCalcPrimaryChokepoint = null;
+    this.costShockCalcClosureDays = 30;
     this.content.replaceChildren();
   }
 

--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -262,3 +262,66 @@ export async function fetchCountryProducts(iso2: string): Promise<CountryProduct
     return { ...emptyProducts, iso2 };
   }
 }
+
+export interface MultiSectorShock {
+  hs2: string;
+  hs2Label: string;
+  importValueAnnual: number;
+  freightAddedPctPerTon: number;
+  warRiskPremiumBps: number;
+  addedTransitDays: number;
+  totalCostShockPerDay: number;
+  totalCostShock30Days: number;
+  totalCostShock90Days: number;
+  /** Cost for the currently-requested closure duration (server-clamped). */
+  totalCostShock: number;
+  closureDays: number;
+}
+
+export interface MultiSectorShockResponse {
+  iso2: string;
+  chokepointId: string;
+  closureDays: number;
+  warRiskTier: string;
+  sectors: MultiSectorShock[];
+  totalAddedCost: number;
+  fetchedAt: string;
+  unavailableReason: string;
+}
+
+const emptyMultiSectorShock: MultiSectorShockResponse = {
+  iso2: '',
+  chokepointId: '',
+  closureDays: 30,
+  warRiskTier: 'WAR_RISK_TIER_UNSPECIFIED',
+  sectors: [],
+  totalAddedCost: 0,
+  fetchedAt: '',
+  unavailableReason: '',
+};
+
+/**
+ * Fetch multi-sector cost shock for a country+chokepoint+closureDays window.
+ * PRO-gated: non-premium callers receive HTTP 403 and this function returns an empty response.
+ */
+export async function fetchMultiSectorCostShock(
+  iso2: string,
+  chokepointId: string,
+  closureDays: number,
+  options?: { signal?: AbortSignal },
+): Promise<MultiSectorShockResponse> {
+  try {
+    const { premiumFetch } = await import('@/services/premium-fetch');
+    const { toApiUrl } = await import('@/services/runtime');
+    const url = toApiUrl(
+      `/api/supply-chain/v1/multi-sector-cost-shock?iso2=${encodeURIComponent(iso2)}`
+      + `&chokepointId=${encodeURIComponent(chokepointId)}`
+      + `&closureDays=${encodeURIComponent(String(closureDays))}`,
+    );
+    const resp = await premiumFetch(url, { signal: options?.signal });
+    if (!resp.ok) return { ...emptyMultiSectorShock, iso2, chokepointId, closureDays };
+    return await resp.json() as MultiSectorShockResponse;
+  } catch {
+    return { ...emptyMultiSectorShock, iso2, chokepointId, closureDays };
+  }
+}

--- a/src/shared/premium-paths.ts
+++ b/src/shared/premium-paths.ts
@@ -16,6 +16,7 @@ export const PREMIUM_RPC_PATHS = new Set<string>([
   '/api/supply-chain/v1/get-country-chokepoint-index',
   '/api/supply-chain/v1/get-bypass-options',
   '/api/supply-chain/v1/get-country-cost-shock',
+  '/api/supply-chain/v1/multi-sector-cost-shock',
   '/api/economic/v1/get-national-debt',
   '/api/sanctions/v1/list-sanctions-pressure',
   '/api/trade/v1/list-comtrade-flows',

--- a/src/styles/country-deep-dive.css
+++ b/src/styles/country-deep-dive.css
@@ -1489,3 +1489,111 @@
 .cdp-recommendation-critical {
   color: #ef4444;
 }
+
+/* ── Phase 5: Cost Shock Calculator ───────────────────────────────────── */
+.cdp-cost-shock-calc-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  font-size: 12px;
+  color: var(--text-muted, #94a3b8);
+}
+
+.cdp-cost-shock-calc-tier {
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--warning, #f59e0b) 20%, transparent);
+  color: var(--warning, #fb923c);
+  font-weight: 500;
+}
+
+.cdp-cost-shock-calc-slider-wrap {
+  margin: 10px 0 14px;
+}
+
+.cdp-cost-shock-calc-slider-label {
+  display: block;
+  font-size: 12px;
+  color: var(--text-muted, #94a3b8);
+  margin-bottom: 6px;
+}
+
+.cdp-cost-shock-calc-duration-value {
+  color: var(--text, #e2e8f0);
+  font-weight: 600;
+}
+
+.cdp-cost-shock-calc-slider {
+  width: 100%;
+  accent-color: var(--accent, #60a5fa);
+  cursor: pointer;
+}
+
+.cdp-cost-shock-calc-ticks {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  color: var(--text-muted, #64748b);
+  margin-top: 4px;
+}
+
+.cdp-cost-shock-calc-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.cdp-cost-shock-calc-table th {
+  text-align: left;
+  font-weight: 500;
+  padding: 4px 6px;
+  color: var(--text-muted, #94a3b8);
+  border-bottom: 1px solid color-mix(in srgb, var(--text-muted, #475569) 25%, transparent);
+}
+
+.cdp-cost-shock-calc-cost-col {
+  text-align: right;
+}
+
+.cdp-cost-shock-calc-row td {
+  padding: 4px 6px;
+  border-bottom: 1px solid color-mix(in srgb, var(--text-muted, #334155) 15%, transparent);
+}
+
+.cdp-cost-shock-calc-sector {
+  color: var(--text, #e2e8f0);
+}
+
+.cdp-cost-shock-calc-cost {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--text, #e2e8f0);
+  font-weight: 500;
+}
+
+.cdp-cost-shock-calc-cost--zero {
+  color: var(--text-muted, #64748b);
+  font-weight: 400;
+}
+
+.cdp-cost-shock-calc-total-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 6px 6px;
+  border-top: 2px solid color-mix(in srgb, var(--accent, #60a5fa) 40%, transparent);
+  margin-top: 4px;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.cdp-cost-shock-calc-total-label {
+  color: var(--text-muted, #94a3b8);
+}
+
+.cdp-cost-shock-calc-total-value {
+  color: var(--accent, #60a5fa);
+  font-variant-numeric: tabular-nums;
+}

--- a/tests/helpers/country-deep-dive-panel-harness.mjs
+++ b/tests/helpers/country-deep-dive-panel-harness.mjs
@@ -103,6 +103,7 @@ async function loadCountryDeepDivePanel() {
       export function fetchBypassOptions() { return Promise.resolve({ corridors: [] }); }
       export function getCountryChokepointIndex() { return null; }
       export function fetchChokepointStatus() { return Promise.resolve({ chokepoints: [], fetchedAt: '', upstreamUnavailable: false }); }
+      export function fetchMultiSectorCostShock() { return Promise.resolve({ iso2: '', chokepointId: '', closureDays: 30, warRiskTier: 'WAR_RISK_TIER_UNSPECIFIED', sectors: [], totalAddedCost: 0, fetchedAt: '', unavailableReason: '' }); }
     `],
     ['runtime-stub', `
       export function toApiUrl(path) { return path; }

--- a/tests/multi-sector-cost-shock.test.mjs
+++ b/tests/multi-sector-cost-shock.test.mjs
@@ -1,0 +1,383 @@
+/**
+ * Phase 5: Multi-sector cost shock calculator tests.
+ *
+ * Covers:
+ *   1. Pure helper math (_multi-sector-shock.ts): HS4→HS2, aggregate,
+ *      pickBestBypass, clampClosureDays, computeMultiSectorShock(s).
+ *   2. Vercel edge function contract: PRO-gate, params validation,
+ *      Redis reads, cache-key shape.
+ *   3. Client service wrapper.
+ *   4. Premium paths registration.
+ *   5. CountryDeepDivePanel surface: card, slider, debounced re-fetch, reset.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const readSrc = (relPath) => readFileSync(resolve(root, relPath), 'utf-8');
+
+// ========================================================================
+// 1. Pure helper: _multi-sector-shock.ts
+// ========================================================================
+
+import {
+  SEEDED_HS2_CODES,
+  hs4ToHs2,
+  pickBestBypass,
+  aggregateAnnualImportsByHs2,
+  clampClosureDays,
+  computeMultiSectorShock,
+  computeMultiSectorShocks,
+} from '../server/worldmonitor/supply-chain/v1/_multi-sector-shock.ts';
+
+describe('hs4ToHs2', () => {
+  it('strips leading zeros for 4-digit HS codes', () => {
+    assert.equal(hs4ToHs2('2709'), '27');
+    assert.equal(hs4ToHs2('8542'), '85');
+    assert.equal(hs4ToHs2('0203'), '2');
+  });
+
+  it('pads and strips 3-digit HS codes', () => {
+    assert.equal(hs4ToHs2('203'), '2');
+  });
+});
+
+describe('clampClosureDays', () => {
+  it('defaults to 30 when NaN or undefined', () => {
+    assert.equal(clampClosureDays(undefined), 30);
+    assert.equal(clampClosureDays(null), 30);
+    assert.equal(clampClosureDays(Number.NaN), 30);
+  });
+
+  it('floors fractional values', () => {
+    assert.equal(clampClosureDays(30.9), 30);
+  });
+
+  it('clamps to [1, 365]', () => {
+    assert.equal(clampClosureDays(0), 1);
+    assert.equal(clampClosureDays(-5), 1);
+    assert.equal(clampClosureDays(10000), 365);
+  });
+
+  it('passes through 1-365 unchanged', () => {
+    assert.equal(clampClosureDays(1), 1);
+    assert.equal(clampClosureDays(30), 30);
+    assert.equal(clampClosureDays(90), 90);
+    assert.equal(clampClosureDays(365), 365);
+  });
+});
+
+describe('pickBestBypass', () => {
+  it('returns null for chokepoints without viable bypasses', () => {
+    assert.equal(pickBestBypass('gibraltar'), null); // only no-bypass placeholder
+  });
+
+  it('picks the lowest-transit-days viable corridor for suez', () => {
+    const best = pickBestBypass('suez');
+    assert.ok(best, 'should find a suez bypass');
+    // SUMED pipeline (2 days) beats Cape of Good Hope (12 days).
+    assert.equal(best.id, 'sumed_pipeline');
+  });
+
+  it('picks sunda_strait for malacca (1 day)', () => {
+    const best = pickBestBypass('malacca_strait');
+    assert.ok(best);
+    assert.equal(best.addedTransitDays, 1);
+  });
+
+  it('returns null for unknown chokepoints', () => {
+    assert.equal(pickBestBypass('atlantis'), null);
+  });
+});
+
+describe('aggregateAnnualImportsByHs2', () => {
+  it('returns zeros when products array is empty/undefined', () => {
+    const totals = aggregateAnnualImportsByHs2(undefined);
+    for (const hs2 of SEEDED_HS2_CODES) {
+      assert.equal(totals[hs2], 0);
+    }
+  });
+
+  it('aggregates HS4 values to HS2 buckets', () => {
+    const products = [
+      { hs4: '2709', description: 'Crude', totalValue: 100, year: 2023 },
+      { hs4: '2710', description: 'Refined', totalValue: 50, year: 2023 },
+      { hs4: '2711', description: 'LNG', totalValue: 25, year: 2023 },
+      { hs4: '8542', description: 'Semis', totalValue: 200, year: 2023 },
+      { hs4: '8703', description: 'Vehicles', totalValue: 300, year: 2023 },
+      { hs4: '8704', description: 'Trucks', totalValue: 150, year: 2023 },
+    ];
+    const totals = aggregateAnnualImportsByHs2(products);
+    assert.equal(totals['27'], 175);
+    assert.equal(totals['85'], 200);
+    assert.equal(totals['87'], 450);
+    assert.equal(totals['30'], 0);
+  });
+
+  it('ignores negative and non-finite values', () => {
+    const totals = aggregateAnnualImportsByHs2([
+      { hs4: '2709', description: '', totalValue: -100, year: 2023 },
+      { hs4: '2709', description: '', totalValue: Number.NaN, year: 2023 },
+      { hs4: '2709', description: '', totalValue: 50, year: 2023 },
+    ]);
+    assert.equal(totals['27'], 50);
+  });
+});
+
+describe('computeMultiSectorShock', () => {
+  it('returns zero cost when importValueAnnual is zero', () => {
+    const shock = computeMultiSectorShock('85', 0, 'suez', 'WAR_RISK_TIER_NORMAL', 30);
+    assert.equal(shock.importValueAnnual, 0);
+    assert.equal(shock.totalCostShockPerDay, 0);
+    assert.equal(shock.totalCostShock30Days, 0);
+    assert.equal(shock.totalCostShock, 0);
+  });
+
+  it('scales linearly with closureDays', () => {
+    const imports = 365_000_000; // $365M annual → $1M per day base
+    const s30 = computeMultiSectorShock('85', imports, 'hormuz_strait', 'WAR_RISK_TIER_CRITICAL', 30);
+    const s90 = computeMultiSectorShock('85', imports, 'hormuz_strait', 'WAR_RISK_TIER_CRITICAL', 90);
+    // Per-day cost is the same; 90-day total ~= 3x 30-day total.
+    assert.equal(s30.totalCostShockPerDay, s90.totalCostShockPerDay);
+    assert.ok(Math.abs(s90.totalCostShock - s30.totalCostShock * 3) <= 5);
+    assert.equal(s30.closureDays, 30);
+    assert.equal(s90.closureDays, 90);
+  });
+
+  it('war_zone tier yields higher cost than normal for same inputs', () => {
+    const imports = 1_000_000_000;
+    const normal = computeMultiSectorShock('85', imports, 'suez', 'WAR_RISK_TIER_NORMAL', 30);
+    const warZone = computeMultiSectorShock('85', imports, 'suez', 'WAR_RISK_TIER_WAR_ZONE', 30);
+    assert.ok(warZone.totalCostShock > normal.totalCostShock);
+    assert.equal(warZone.warRiskPremiumBps, 300);
+    assert.equal(normal.warRiskPremiumBps, 5);
+  });
+
+  it('includes bypass freight uplift when bypass exists', () => {
+    const shock = computeMultiSectorShock('85', 1_000_000_000, 'hormuz_strait', 'WAR_RISK_TIER_NORMAL', 30);
+    assert.ok(shock.freightAddedPctPerTon > 0);
+    assert.ok(shock.addedTransitDays > 0);
+  });
+
+  it('emits per-day, 30-day, and 90-day totals regardless of closureDays', () => {
+    const shock = computeMultiSectorShock('27', 365_000_000, 'suez', 'WAR_RISK_TIER_NORMAL', 7);
+    assert.ok('totalCostShockPerDay' in shock);
+    assert.ok('totalCostShock30Days' in shock);
+    assert.ok('totalCostShock90Days' in shock);
+    assert.ok('totalCostShock' in shock);
+  });
+
+  it('clamps closureDays to [1, 365]', () => {
+    const s = computeMultiSectorShock('85', 1_000_000, 'suez', 'WAR_RISK_TIER_NORMAL', 500);
+    assert.equal(s.closureDays, 365);
+    const s2 = computeMultiSectorShock('85', 1_000_000, 'suez', 'WAR_RISK_TIER_NORMAL', -5);
+    assert.equal(s2.closureDays, 1);
+  });
+});
+
+describe('computeMultiSectorShocks', () => {
+  it('returns exactly 10 seeded sectors', () => {
+    const imports = { '27': 1_000, '85': 2_000, '87': 3_000 };
+    const results = computeMultiSectorShocks(imports, 'suez', 'WAR_RISK_TIER_NORMAL', 30);
+    assert.equal(results.length, 10);
+    assert.equal(new Set(results.map(r => r.hs2)).size, 10);
+  });
+
+  it('sorts sectors by totalCostShockPerDay descending', () => {
+    const imports = {
+      '27': 100_000_000,
+      '87': 500_000_000, // vehicles largest
+      '85': 200_000_000,
+    };
+    const results = computeMultiSectorShocks(imports, 'suez', 'WAR_RISK_TIER_HIGH', 30);
+    for (let i = 1; i < results.length; i++) {
+      assert.ok(
+        results[i - 1].totalCostShockPerDay >= results[i].totalCostShockPerDay,
+        `results not sorted DESC at ${i}`,
+      );
+    }
+    assert.equal(results[0].hs2, '87');
+  });
+
+  it('zero-imports sectors appear at the bottom with 0 cost', () => {
+    const imports = { '27': 1_000_000 };
+    const results = computeMultiSectorShocks(imports, 'hormuz_strait', 'WAR_RISK_TIER_CRITICAL', 30);
+    const last = results[results.length - 1];
+    assert.equal(last.totalCostShockPerDay, 0);
+  });
+});
+
+// ========================================================================
+// 2. Edge function: api/supply-chain/v1/multi-sector-cost-shock.ts
+// ========================================================================
+
+describe('multi-sector-cost-shock edge function', () => {
+  const src = readSrc('api/supply-chain/v1/multi-sector-cost-shock.ts');
+
+  it('is declared as a Vercel edge function', () => {
+    assert.match(src, /export const config = \{ runtime: 'edge' \}/);
+  });
+
+  it('calls isCallerPremium for PRO-gating', () => {
+    assert.match(src, /isCallerPremium/);
+    assert.match(src, /PRO subscription required/);
+  });
+
+  it('validates iso2 with a 2-letter regex', () => {
+    assert.match(src, /\/\^\[A-Z\]\{2\}\$\/\.test/);
+  });
+
+  it('validates chokepointId against the registry', () => {
+    assert.match(src, /CHOKEPOINT_REGISTRY\.some/);
+  });
+
+  it('clamps closureDays via clampClosureDays', () => {
+    assert.match(src, /clampClosureDays/);
+  });
+
+  it('reads country products from comtrade:bilateral-hs4 key', () => {
+    assert.match(src, /comtrade:bilateral-hs4:\$\{iso2\}:v1/);
+  });
+
+  it('reads chokepoint status for war risk tier', () => {
+    assert.match(src, /CHOKEPOINT_STATUS_KEY/);
+  });
+
+  it('returns JSON with sectors, totalAddedCost, and closureDays', () => {
+    assert.match(src, /sectors/);
+    assert.match(src, /totalAddedCost/);
+    assert.match(src, /closureDays/);
+  });
+
+  it('uses short private Cache-Control (slider state is user-controlled)', () => {
+    assert.match(src, /private, max-age=60/);
+  });
+});
+
+// ========================================================================
+// 3. Client service: src/services/supply-chain/index.ts
+// ========================================================================
+
+describe('supply-chain client service: fetchMultiSectorCostShock', () => {
+  const src = readSrc('src/services/supply-chain/index.ts');
+
+  it('exports fetchMultiSectorCostShock', () => {
+    assert.match(src, /export async function fetchMultiSectorCostShock/);
+  });
+
+  it('exports MultiSectorShock and MultiSectorShockResponse interfaces', () => {
+    assert.match(src, /export interface MultiSectorShock/);
+    assert.match(src, /export interface MultiSectorShockResponse/);
+  });
+
+  it('uses premiumFetch for PRO-gated access', () => {
+    assert.match(src, /fetchMultiSectorCostShock[\s\S]*?premiumFetch/);
+  });
+
+  it('passes iso2, chokepointId, and closureDays as query params', () => {
+    assert.match(src, /iso2=\$\{encodeURIComponent\(iso2\)\}/);
+    assert.match(src, /chokepointId=\$\{encodeURIComponent\(chokepointId\)\}/);
+    assert.match(src, /closureDays=\$\{encodeURIComponent\(String\(closureDays\)\)\}/);
+  });
+
+  it('supports AbortSignal passthrough', () => {
+    assert.match(src, /signal\?: AbortSignal/);
+  });
+});
+
+// ========================================================================
+// 4. Premium paths: multi-sector-cost-shock is PRO-gated at the gateway.
+// ========================================================================
+
+describe('premium-paths: multi-sector-cost-shock registration', () => {
+  const src = readSrc('src/shared/premium-paths.ts');
+
+  it('includes /api/supply-chain/v1/multi-sector-cost-shock', () => {
+    assert.match(src, /\/api\/supply-chain\/v1\/multi-sector-cost-shock/);
+  });
+});
+
+// ========================================================================
+// 5. CountryDeepDivePanel: Cost Shock Calculator card + slider.
+// ========================================================================
+
+describe('CountryDeepDivePanel Cost Shock Calculator', () => {
+  const src = readSrc('src/components/CountryDeepDivePanel.ts');
+
+  it('imports fetchMultiSectorCostShock', () => {
+    assert.match(src, /import[^;]*fetchMultiSectorCostShock/);
+  });
+
+  it('declares a Cost Shock Calculator section card', () => {
+    assert.match(src, /Cost Shock Calculator/);
+  });
+
+  it('registers updateMultiSectorCostShock public method', () => {
+    assert.match(src, /updateMultiSectorCostShock\(/);
+  });
+
+  it('builds a range input slider with min=1 and max=90', () => {
+    assert.match(src, /slider\.type = 'range'/);
+    assert.match(src, /slider\.min = '1'/);
+    assert.match(src, /slider\.max = '90'/);
+  });
+
+  it('listens for input events on the slider', () => {
+    assert.match(src, /slider\.addEventListener\('input'/);
+  });
+
+  it('debounces re-fetches by 300ms', () => {
+    assert.match(src, /scheduleCostShockRefetch/);
+    assert.match(src, /setTimeout\([^,]+,\s*300\)/);
+  });
+
+  it('aborts prior in-flight fetches when a new slider value arrives', () => {
+    assert.match(src, /costShockCalcAbort\?\.abort\(\)/);
+    assert.match(src, /new AbortController\(\)/);
+  });
+
+  it('renders a sector table with Total row', () => {
+    assert.match(src, /renderMultiSectorShockRows/);
+    assert.match(src, /cdp-cost-shock-calc-total-row/);
+  });
+
+  it('sorts rows by totalCostShock descending', () => {
+    assert.match(src, /\.sort\(\(a, b\) => b\.totalCostShock - a\.totalCostShock\)/);
+  });
+
+  it('gates the card as PRO when the user is not premium', () => {
+    assert.match(src, /makeProLocked\('Upgrade to PRO for multi-sector cost shock modelling'\)/);
+  });
+
+  it('resetPanelContent clears all cost shock calculator state', () => {
+    assert.match(src, /this\.costShockCalcBody = null;/);
+    assert.match(src, /this\.costShockCalcTable = null;/);
+    assert.match(src, /this\.costShockCalcAbort\?\.abort\(\);/);
+    assert.match(src, /this\.costShockCalcDebounceTimer[\s\S]*?clearTimeout/);
+  });
+});
+
+// ========================================================================
+// 6. country-intel.ts wires the initial fetch after primary chokepoint.
+// ========================================================================
+
+describe('country-intel.ts: multi-sector cost shock fetch', () => {
+  const src = readSrc('src/app/country-intel.ts');
+
+  it('imports fetchMultiSectorCostShock from services/supply-chain', () => {
+    assert.match(src, /fetchMultiSectorCostShock/);
+  });
+
+  it('calls fetchMultiSectorCostShock with default 30-day window', () => {
+    assert.match(src, /fetchMultiSectorCostShock\(code, resp\.primaryChokepointId, 30\)/);
+  });
+
+  it('clears the card on catch paths', () => {
+    assert.match(src, /updateMultiSectorCostShock\?\.\(null\)/);
+  });
+});


### PR DESCRIPTION
## Why this PR?
The existing Cost Shock card only speaks to HS27 (energy/mineral fuels) and shows coverage days. For non-oil-dependent countries it feels hollow, and for PRO users there is no concrete dollar figure they can put in front of a board. Phase 5 closes that gap.

## Summary
- Adds a new PRO-gated Cost Shock Calculator card to Country Deep Dive with an interactive 1-90 day closure-duration slider (debounced 300ms) and a sorted table showing added cost per HS2 sector.
- Ships a new edge function `POST/GET /api/supply-chain/v1/multi-sector-cost-shock` that takes `(iso2, chokepointId, closureDays)`, reads seeded Comtrade bilateral HS4 data from Redis, aggregates to HS2, and returns per-sector shock figures plus a total.
- Shared pure helper `_multi-sector-shock.ts` exposes the model and is covered by unit tests; edge function and client wrapper are covered by static-analysis guards.
- Model: `daily_added_cost = annual_imports * (bypass_freight_uplift + war_risk_bps / 10000) / 365`. Best bypass picked as the lowest-transit, partial-closure corridor with at least one suitable cargo type.
- HS27 continues to use the dedicated energy shock model in `get-country-cost-shock`; no double-counting.

## Test plan
- [x] `npm run test:data` passes (4043 tests; 51 new).
- [x] `npm run typecheck:all` clean.
- [x] `npx biome lint` shows only pre-existing complexity warnings (unchanged).
- [ ] Open a PRO Country Deep Dive for India (top 10 importer coverage): the Cost Shock Calculator card appears between Trade Exposure and Product Imports.
- [ ] Default 30-day closure shows per-sector costs ordered DESC with a total row at the bottom.
- [ ] Drag slider to 90 days: total roughly triples; per-day figures stay consistent.
- [ ] Drag slider to 1 day: total collapses proportionally; no pending fetches visible after stop.
- [ ] Free users see the locked upgrade CTA instead of the calculator.
- [ ] Landlocked / countries with empty seeded imports still render the card with zero rows and an "unavailable" footer.

## Post-deploy monitoring
- New RPC: watch 4xx/5xx rate on `/api/supply-chain/v1/multi-sector-cost-shock` in Vercel analytics. Expected p95 well under 200ms because the compute is pure; only Redis reads matter.
- Expected response shape: `sectors.length === 10` for every non-empty country; `totalAddedCost > 0` when the primary chokepoint has at least one viable partial-closure bypass.