### PR TITLE
test(resilience): T1.1 regression test for origin-doc ceiling claim

### DIFF
--- a/tests/resilience-release-gate.test.mts
+++ b/tests/resilience-release-gate.test.mts
@@ -187,11 +187,16 @@ describe('resilience release gate', () => {
       `Norway (elite fixture, ${no.overallScore}) should score higher than the US (strong fixture, ${us.overallScore})`,
     );
     // Guard against a near-tie that would still break meaningful ranking.
-    // Actual measured delta at commit time is 13.78; the threshold of 3
-    // leaves room for future fixture tuning without over-fitting this test.
+    // Actual measured delta at commit time is 13.78 points; the threshold
+    // of 8 (about 60% of the measured delta) leaves room for fixture
+    // tuning while catching a tier-separation collapse before the ordering
+    // degrades into a near-tie. An earlier version of this test used a
+    // threshold of 3, which would have silently accepted a ~71% erosion
+    // of the elite-strong separation signal. Bumped in response to PR
+    // review feedback on #2941.
     assert.ok(
-      no.overallScore - us.overallScore >= 3,
-      `Norway should lead the US by at least 3 points (NO=${no.overallScore}, US=${us.overallScore}, delta=${no.overallScore - us.overallScore})`,
+      no.overallScore - us.overallScore >= 8,
+      `Norway should lead the US by at least 8 points (NO=${no.overallScore}, US=${us.overallScore}, delta=${no.overallScore - us.overallScore})`,
     );
   });
 

--- a/tests/resilience-release-gate.test.mts
+++ b/tests/resilience-release-gate.test.mts
@@ -134,6 +134,67 @@ describe('resilience release gate', () => {
     assert.equal(us.lowConfidence, false, `US has full 9/9 dataset coverage in fixtures and should not be flagged low-confidence`);
   });
 
+  // T1.1 regression test (Phase 1 of the country-resilience reference-grade
+  // upgrade plan, docs/internal/country-resilience-upgrade-plan.md).
+  //
+  // The origin review document (docs/internal/upgrading-country-resilience.md)
+  // claims: "Norway and the US both hit 100 under current fixtures, which
+  // broke the intended ordering and exposed a ceiling effect at the top end
+  // of the ranking."
+  //
+  // Investigation outcome (2026-04-11): the claim does NOT reproduce.
+  //
+  // Measured scores under the current release-gate fixtures and the
+  // post-PR-#2847 domain-weighted-average formula:
+  //
+  //     NO (elite tier)   overallScore = 86.58, baseline 86.85, stress 84.36
+  //     US (strong tier)  overallScore = 72.80, baseline 73.15, stress 70.58
+  //     Delta             NO - US = 13.78 points
+  //     Ceiling           neither country approaches 100; all 5 domains stay
+  //                       well inside the [0, 100] clamp range
+  //
+  // The ordering elite > strong > stressed > fragile is preserved. There is
+  // no hard 100 ceiling in the scorer, and nothing in _dimension-scorers.ts
+  // can produce a top-of-ranking tie between NO and US given the 14-point
+  // quality differential wired into the fixtures.
+  //
+  // Conclusion: the origin-doc symptom is misattributed or stale (it likely
+  // predates PR #2847's formula revert or references an older fixture set).
+  // The origin-doc changelog will be updated in a trailing commit after
+  // PR #2938 (the reference-grade plan) merges, since the origin doc is
+  // part of that PR.
+  //
+  // This test pins the current correct behavior so any future regression to
+  // a real top-of-ranking ceiling bug is caught immediately by CI.
+  it('T1.1 regression: Norway and US do not both pin at 100 and preserve elite > strong ordering', async () => {
+    installRedisFixtures();
+
+    const [no, us] = await Promise.all([
+      getResilienceScore({ request: new Request('https://example.com?countryCode=NO') } as never, { countryCode: 'NO' }),
+      getResilienceScore({ request: new Request('https://example.com?countryCode=US') } as never, { countryCode: 'US' }),
+    ]);
+
+    assert.ok(
+      no.overallScore < 100,
+      `Norway should not pin at the ceiling (overallScore=${no.overallScore})`,
+    );
+    assert.ok(
+      us.overallScore < 100,
+      `US should not pin at the ceiling (overallScore=${us.overallScore})`,
+    );
+    assert.ok(
+      no.overallScore > us.overallScore,
+      `Norway (elite fixture, ${no.overallScore}) should score higher than the US (strong fixture, ${us.overallScore})`,
+    );
+    // Guard against a near-tie that would still break meaningful ranking.
+    // Actual measured delta at commit time is 13.78; the threshold of 3
+    // leaves room for future fixture tuning without over-fitting this test.
+    assert.ok(
+      no.overallScore - us.overallScore >= 3,
+      `Norway should lead the US by at least 3 points (NO=${no.overallScore}, US=${us.overallScore}, delta=${no.overallScore - us.overallScore})`,
+    );
+  });
+
   it('produces complete ranking and choropleth entries for the full G20 + EU27 release set', async () => {
     installRedisFixtures();
 


### PR DESCRIPTION
## Why this PR?

Ships Phase 1 T1.1 of the country-resilience reference-grade upgrade plan (PR #2938): a regression test that reproduces, or rather fails to reproduce, the origin-doc "Norway and US both hit 100" ceiling claim.

The plan explicitly committed to reproducing-before-fixing and to updating the origin doc's changelog if the symptom turned out to be misattributed. This PR documents the measured outcome and pins the current correct top-of-ranking behavior so any future regression to a real ceiling bug is caught by CI.

## Investigation outcome

The origin-doc claim does **not** reproduce under the current release-gate fixtures and the post-PR-#2847 domain-weighted-average formula:

| Country | Tier | overallScore | baseline | stress |
| --- | --- | ---: | ---: | ---: |
| NO | elite | 86.58 | 86.85 | 84.36 |
| US | strong | 72.80 | 73.15 | 70.58 |

Delta NO minus US: 13.78 points. Neither approaches 100. The elite > strong > stressed > fragile ordering is preserved. The domain-weighted average cannot reach 100 unless every dimension saturates, which does not happen for any fixture tier.

The origin claim is misattributed or stale, probably predating PR #2847 which reverted the multiplicative `baseline * (1 - stressFactor)` formula that had over-penalized all countries.

## What this PR commits

- New regression test in `tests/resilience-release-gate.test.mts` asserting that NO and US are not pinned at 100, that NO > US, and that the delta is at least 3 points. The threshold leaves room for fixture tuning without over-fitting to the measured 13.78 delta.
- A detailed comment block inside the test capturing the measured numbers, the conclusion, and the rationale, so the origin-doc changelog update (tracked separately) has a cite-able evidence base.

## Follow-ups (not in this PR)

1. **Origin-doc changelog update.** Deliberately deferred to a trailing commit after PR #2938 (the reference-grade plan, which contains the origin doc) merges, to avoid a cross-branch conflict.
2. **Release-gate fixture same-tier collision.** Side finding discovered during investigation: `qualityFor(profile)` derives every input from a single quality value per tier, so every country within a tier produces identical scores. This means the release-gate suite cannot detect within-tier ordering issues. Not a scorer bug, a fixture-design limitation. Worth a separate issue for Phase 2.

## Prerequisite PRs (verified merged)

- #2821 (baseline/stress engine)
- #2847 (formula revert + RSF direction fix)
- #2858 (seed direct scoring)

## Testing

- `npx tsx --test tests/resilience-*.test.mts tests/resilience-*.test.mjs`: 172/172 passing
- `npm run typecheck`: clean
- Pre-push hook runs `typecheck` + `build:full` + `version:check`; all pass

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: test-only change, no runtime impact. The new test runs in CI on every push.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)
