### PR TITLE
feat(resilience): surface dataVersion in widget footer (T1.4)

### DIFF
--- a/src/components/ResilienceWidget.ts
+++ b/src/components/ResilienceWidget.ts
@@ -11,6 +11,7 @@ import {
   formatBaselineStress,
   formatResilienceChange30d,
   formatResilienceConfidence,
+  formatResilienceDataVersion,
   getResilienceDomainLabel,
   getResilienceTrendArrow,
   getResilienceVisualLevel,
@@ -298,6 +299,16 @@ export class ResilienceWidget {
           formatResilienceConfidence(data),
         ),
         h('span', { className: 'resilience-widget__delta' }, formatResilienceChange30d(data.change30d)),
+        ...(formatResilienceDataVersion(data.dataVersion)
+          ? [h(
+              'span',
+              {
+                className: 'resilience-widget__data-version',
+                title: 'Date the underlying source data was last refreshed by the Railway static-seed job.',
+              },
+              formatResilienceDataVersion(data.dataVersion),
+            )]
+          : []),
       ),
     );
   }

--- a/src/components/ResilienceWidget.ts
+++ b/src/components/ResilienceWidget.ts
@@ -299,16 +299,23 @@ export class ResilienceWidget {
           formatResilienceConfidence(data),
         ),
         h('span', { className: 'resilience-widget__delta' }, formatResilienceChange30d(data.change30d)),
-        ...(formatResilienceDataVersion(data.dataVersion)
-          ? [h(
-              'span',
-              {
-                className: 'resilience-widget__data-version',
-                title: 'Date the underlying source data was last refreshed by the Railway static-seed job.',
-              },
-              formatResilienceDataVersion(data.dataVersion),
-            )]
-          : []),
+        ...(() => {
+          // Hoisted so the formatter (which runs a regex + Date parse) is
+          // only invoked once per render instead of twice (guard + child).
+          // Raised in review of PR #2943 for consistency with the existing
+          // scoreInterval / baselineScore blocks in this file.
+          const dataVersionLabel = formatResilienceDataVersion(data.dataVersion);
+          return dataVersionLabel
+            ? [h(
+                'span',
+                {
+                  className: 'resilience-widget__data-version',
+                  title: 'Date the underlying source data was last refreshed by the Railway static-seed job.',
+                },
+                dataVersionLabel,
+              )]
+            : [];
+        })(),
       ),
     );
   }

--- a/src/components/resilience-widget-utils.ts
+++ b/src/components/resilience-widget-utils.ts
@@ -58,3 +58,13 @@ export function formatBaselineStress(baseline: number, stress: number): string {
   const s = Number.isFinite(stress) ? Math.round(stress) : 0;
   return `Baseline: ${b} | Stress: ${s}`;
 }
+
+// Formats the dataVersion field (ISO date YYYY-MM-DD, sourced from the
+// seed-meta key) for display in the widget footer. Returns an empty string
+// when dataVersion is missing or malformed so the caller can skip rendering.
+// Format is stable and regex-tested by resilience-widget.test.mts.
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+export function formatResilienceDataVersion(dataVersion: string | null | undefined): string {
+  if (typeof dataVersion !== 'string' || !ISO_DATE_PATTERN.test(dataVersion)) return '';
+  return `Data ${dataVersion}`;
+}

--- a/src/components/resilience-widget-utils.ts
+++ b/src/components/resilience-widget-utils.ts
@@ -61,10 +61,20 @@ export function formatBaselineStress(baseline: number, stress: number): string {
 
 // Formats the dataVersion field (ISO date YYYY-MM-DD, sourced from the
 // seed-meta key) for display in the widget footer. Returns an empty string
-// when dataVersion is missing or malformed so the caller can skip rendering.
-// Format is stable and regex-tested by resilience-widget.test.mts.
+// when dataVersion is missing, malformed, or not a real calendar date so
+// the caller can skip rendering. Format is stable and regex + calendar
+// tested by resilience-widget.test.mts.
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 export function formatResilienceDataVersion(dataVersion: string | null | undefined): string {
   if (typeof dataVersion !== 'string' || !ISO_DATE_PATTERN.test(dataVersion)) return '';
+  // Regex-shape is not enough: `/^\d{4}-\d{2}-\d{2}$/` accepts values like
+  // `9999-99-99` or `2024-13-45`. A stale or corrupted Redis key could emit
+  // one, and the widget would render it without complaint. Defensively
+  // verify the string parses to a real calendar date AND round-trips back
+  // to the same YYYY-MM-DD slice (so e.g. `2024-02-30` does not silently
+  // become `2024-03-01`). Raised in review of PR #2943.
+  const parsed = new Date(dataVersion);
+  if (Number.isNaN(parsed.getTime())) return '';
+  if (parsed.toISOString().slice(0, 10) !== dataVersion) return '';
   return `Data ${dataVersion}`;
 }

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -100,6 +100,23 @@ test('formatResilienceDataVersion returns empty for missing or malformed dataVer
   assert.equal(formatResilienceDataVersion('not-a-date'), '');
 });
 
+test('formatResilienceDataVersion rejects regex-valid but calendar-invalid dates (PR #2943 review)', () => {
+  // Regex `/^\d{4}-\d{2}-\d{2}$/` accepts these strings but they are not
+  // real calendar dates. A stale or corrupted Redis key could emit one,
+  // and without the round-trip check the widget would render it unchecked.
+  assert.equal(formatResilienceDataVersion('9999-99-99'), '');
+  assert.equal(formatResilienceDataVersion('2024-13-45'), '');
+  assert.equal(formatResilienceDataVersion('2024-00-15'), '');
+  // February 30th parses as a real Date in JS but not the same string
+  // when round-tripped through toISOString; the round-trip check catches
+  // this slip, so `2024-02-30` silently rolling to `2024-03-01` is rejected.
+  assert.equal(formatResilienceDataVersion('2024-02-30'), '');
+  assert.equal(formatResilienceDataVersion('2024-02-31'), '');
+  // Legitimate calendar dates still pass.
+  assert.equal(formatResilienceDataVersion('2024-02-29'), 'Data 2024-02-29'); // leap year
+  assert.equal(formatResilienceDataVersion('2023-02-28'), 'Data 2023-02-28');
+});
+
 test('baseResponse includes dataVersion (regression for T1.4 wiring)', () => {
   // Guards against a future change that accidentally drops the dataVersion
   // field from the service response shape. The scorer writes it from the

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -5,6 +5,7 @@ import {
   formatBaselineStress,
   formatResilienceChange30d,
   formatResilienceConfidence,
+  formatResilienceDataVersion,
   getResilienceDomainLabel,
   getResilienceTrendArrow,
   getResilienceVisualLevel,
@@ -74,4 +75,36 @@ test('formatBaselineStress renders the expected breakdown string (no Impact)', (
   assert.equal(formatBaselineStress(80, 100), 'Baseline: 80 | Stress: 100');
   assert.equal(formatBaselineStress(50, 0), 'Baseline: 50 | Stress: 0');
   assert.equal(formatBaselineStress(NaN, 50), 'Baseline: 0 | Stress: 50');
+});
+
+// T1.4 Phase 1 of the country-resilience reference-grade upgrade plan.
+// dataVersion is sourced from the Railway static-seed job's seed-meta key
+// (fetchedAt → ISO date in _shared.ts buildResilienceScore). The widget
+// renders a footer label so analysts can see how fresh the underlying
+// source data is; a missing or malformed dataVersion returns an empty
+// string so the caller skips rendering rather than showing a dangling label.
+test('formatResilienceDataVersion renders a label for a valid ISO date', () => {
+  assert.equal(formatResilienceDataVersion('2026-04-11'), 'Data 2026-04-11');
+  assert.equal(formatResilienceDataVersion('2024-01-01'), 'Data 2024-01-01');
+});
+
+test('formatResilienceDataVersion returns empty for missing or malformed dataVersion', () => {
+  assert.equal(formatResilienceDataVersion(''), '');
+  assert.equal(formatResilienceDataVersion(null), '');
+  assert.equal(formatResilienceDataVersion(undefined), '');
+  // Guard against partially-formatted or non-ISO strings that the fallback
+  // path in _shared.ts should never emit but downstream code should still
+  // reject defensively:
+  assert.equal(formatResilienceDataVersion('2026-04'), '');
+  assert.equal(formatResilienceDataVersion('04/11/2026'), '');
+  assert.equal(formatResilienceDataVersion('not-a-date'), '');
+});
+
+test('baseResponse includes dataVersion (regression for T1.4 wiring)', () => {
+  // Guards against a future change that accidentally drops the dataVersion
+  // field from the service response shape. The scorer writes it from the
+  // seed-meta key; the widget footer renders it via formatResilienceDataVersion.
+  assert.equal(typeof baseResponse.dataVersion, 'string');
+  assert.ok(baseResponse.dataVersion.length > 0, 'baseResponse should carry a non-empty dataVersion for regression coverage');
+  assert.equal(formatResilienceDataVersion(baseResponse.dataVersion), `Data ${baseResponse.dataVersion}`);
 });


### PR DESCRIPTION
## Why this PR?

Ships Phase 1 T1.4 of the country-resilience reference-grade upgrade plan (PR #2938): surface the `dataVersion` field in the resilience widget footer so analysts can see how fresh the underlying source data is.

The `dataVersion` field was added to the response proto in PR #2821 and is already populated end-to-end on the server side: the Railway static-seed job writes `fetchedAt` into `seed-meta:resilience:static`, and `buildResilienceScore` in `server/worldmonitor/resilience/v1/_shared.ts` reads it back, slices to YYYY-MM-DD, and returns it on every country score response. The handler test at `tests/resilience-handlers.test.mts` already verifies that round-trip. The only missing piece was the UI: the widget never rendered the field, and this PR closes that gap with a narrow UI-only change.

## What this PR commits

- `formatResilienceDataVersion(dataVersion)` helper in `src/components/resilience-widget-utils.ts`. Validates the value is an ISO date `YYYY-MM-DD` via regex; returns an empty string for null, undefined, or malformed inputs so the caller skips rendering instead of showing a dangling "Data " label.
- `ResilienceWidget.ts` footer render: adds a `resilience-widget__data-version` span next to the existing confidence and 30d-delta spans, only when the formatter returns non-empty. Tooltip explains the source.
- Three new widget-format tests in `tests/resilience-widget.test.mts`:
  1. Formats a valid ISO date as `Data YYYY-MM-DD`.
  2. Returns empty for malformed or missing input (covers `null`, `undefined`, `''`, `'2026-04'`, `'04/11/2026'`, `'not-a-date'`).
  3. Regression assertion that `baseResponse` still carries `dataVersion`, so future schema edits that drop the field break visibly.

## Scope boundaries (not in this PR)

- **No per-dimension freshness badges.** That is T1.5 (source-recency badges, `lastObservedAt` + staleness per signal) and has its own plan task and its own PR.
- **No existing em-dash cleanup.** The string `'Low confidence , sparse data'` at line 42 of `resilience-widget-utils.ts` predates this PR and is a separate memory-rule violation; left to a dedicated cleanup PR.

## Prerequisite PRs (verified merged)

- #2821 (baseline/stress engine, added the `dataVersion` field)
- #2847 (formula revert + RSF direction fix)
- #2858 (seed direct scoring)

## Testing

- `npx tsx --test tests/resilience-widget.test.mts`: 9/9 passing
- `npx tsx --test tests/resilience-*.test.mts tests/resilience-*.test.mjs`: 174/174 passing
- `npm run typecheck`: clean
- Pre-push hook passes (typecheck + build:full + version:check)

## Post-Deploy Monitoring & Validation

- **What to monitor:** watch for widget render failures in Sentry after deploy. The new footer span is rendered defensively (only when `formatResilienceDataVersion` returns non-empty), so a missing or malformed `dataVersion` will degrade silently rather than throw.
- **Expected healthy signal:** the resilience widget footer shows a `Data YYYY-MM-DD` label alongside the existing confidence and 30d-delta labels. Date should match what the handler test asserts: the ISO date slice of `seed-meta:resilience:static.fetchedAt`.
- **Failure signal / rollback trigger:** Sentry spike in `resilience-widget__data-version` render errors, or the label shows a stale date older than the static-seed cadence (48h). Rollback by reverting this PR; server-side behavior is unchanged.
- **Validation window & owner:** first 24h after merge, widget-owning team.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)
