### PR TITLE
feat(resilience): 4-class imputation taxonomy foundation (T1.7)

### DIFF
--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -47,25 +47,70 @@ interface WeightedMetric {
   imputed?: boolean;
 }
 
+// Four-class imputation taxonomy (Phase 1 T1.7 of the country-resilience
+// reference-grade upgrade plan, docs/internal/country-resilience-upgrade-plan.md).
+//
+// Every absence-based imputation is tagged with one of these classes so
+// downstream consumers (widget confidence bar, benchmark per-family gates,
+// methodology changelog) can distinguish:
+//   - stable-absence: the source publishes globally and the country is not
+//     listed, which means the tracked phenomenon is not happening (e.g.,
+//     no IPC Phase 3+ = no food crisis; no UCDP event = no conflict).
+//     Score is a strong positive with high certainty.
+//   - unmonitored: the source is a curated list that may not cover every
+//     country. Absence is ambiguous; we penalize conservatively with
+//     low certainty.
+//   - source-failure: the upstream API was unavailable at seed time.
+//     Should be rare and transient; detected from seed-meta failedDatasets.
+//     (Not currently represented in the tables below; reserved for the
+//     runtime path that consults seed-meta and injects this class when a
+//     dataset is in failedDatasets. Wired in T1.9.)
+//   - not-applicable: the dimension is structurally N/A for this country
+//     (e.g., a landlocked country has no maritime exposure). Score is
+//     neutral with high certainty since the absence is by definition.
+//     (Reserved for future dimensions that need structural N/A handling;
+//     no current scorer branches on it.)
+//
+// This is the foundation-only slice of T1.7. It lands the type, tags the
+// existing imputation tables, and is covered by tests that assert every
+// entry carries a class and the class matches its semantic family. The
+// schema-level propagation (imputationBreakdown field on the response and
+// widget rendering of per-dimension imputation icons) is deliberately
+// deferred to T1.5 / T1.6 so each task has a bounded, reviewable PR.
+export type ImputationClass =
+  | 'stable-absence'
+  | 'unmonitored'
+  | 'source-failure'
+  | 'not-applicable';
+
+export interface ImputationEntry {
+  score: number;
+  certaintyCoverage: number;
+  imputationClass: ImputationClass;
+}
+
 // Absence of a data source is a typed signal, not an unknown gap.
-// Each value is { score, certaintyCoverage } applied when the source is absent.
-const IMPUTATION = {
+// Each value is { score, certaintyCoverage, imputationClass } applied when
+// the source is absent.
+export const IMPUTATION = {
   // Country not in IPC/UNHCR/UCDP because it's stable, not because data is missing.
   // Absence = strong positive signal.
-  crisis_monitoring_absent: { score: 85, certaintyCoverage: 0.7 },
+  crisis_monitoring_absent: { score: 85, certaintyCoverage: 0.7, imputationClass: 'stable-absence' },
   // Country not in BIS/WTO curated list. Data exists but country wasn't selected.
   // Absence = neutral-to-negative (unknown, penalized conservatively).
-  curated_list_absent: { score: 50, certaintyCoverage: 0.3 },
-} as const;
+  curated_list_absent: { score: 50, certaintyCoverage: 0.3, imputationClass: 'unmonitored' },
+} as const satisfies Record<string, ImputationEntry>;
 
 // Per-metric overrides where the generic imputation table values differ.
-const IMPUTE = {
-  ipcFood:      { score: 88, certaintyCoverage: 0.7 },  // crisis_monitoring_absent, food-specific
-  wtoData:      { score: 60, certaintyCoverage: 0.4 },  // curated_list_absent, trade-specific
-  bisEer:       IMPUTATION.curated_list_absent,
-  bisCredit:    IMPUTATION.curated_list_absent,
-  unhcrDisplacement: { score: 85, certaintyCoverage: 0.6 }, // crisis_monitoring_absent, displacement-specific
-} as const;
+// Every override carries its own imputationClass tag so the class is
+// preserved at every call site, not inferred from naming.
+export const IMPUTE = {
+  ipcFood:           { score: 88, certaintyCoverage: 0.7, imputationClass: 'stable-absence' },  // crisis_monitoring_absent, food-specific
+  wtoData:           { score: 60, certaintyCoverage: 0.4, imputationClass: 'unmonitored' },      // curated_list_absent, trade-specific
+  bisEer:            IMPUTATION.curated_list_absent,
+  bisCredit:         IMPUTATION.curated_list_absent,
+  unhcrDisplacement: { score: 85, certaintyCoverage: 0.6, imputationClass: 'stable-absence' },  // crisis_monitoring_absent, displacement-specific
+} as const satisfies Record<string, ImputationEntry>;
 
 interface StaticIndicatorValue {
   value?: number;

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -755,18 +755,47 @@ describe('resilience imputation taxonomy (T1.7)', () => {
     }
   });
 
-  it('stable-absence entries score higher than unmonitored (semantic sanity)', () => {
+  it('stable-absence entries score higher than unmonitored, across BOTH tables (semantic sanity)', () => {
     // stable-absence = strong positive signal (feed is comprehensive,
     // nothing happened). unmonitored = we do not know, penalized.
-    // If this assertion ever fails, the semantic meaning of the classes
-    // has drifted and the taxonomy needs to be re-argued.
+    // The invariant must hold across every entry in both IMPUTATION and
+    // IMPUTE, otherwise a per-metric override can silently break the
+    // ordering (e.g. a `stable-absence` override with a score lower than
+    // an `unmonitored` entry would pass a tables-only check but violate
+    // the taxonomy's semantic meaning).
+    //
+    // Raised in review of PR #2944: the earlier version of this test
+    // only checked the two base entries in IMPUTATION and would have
+    // missed a regression in an IMPUTE override.
+    const allEntries = [
+      ...Object.entries(IMPUTATION).map(([k, v]) => ({ label: `IMPUTATION.${k}`, entry: v })),
+      ...Object.entries(IMPUTE).map(([k, v]) => ({ label: `IMPUTE.${k}`, entry: v })),
+    ];
+
+    const stableAbsence = allEntries.filter((e) => e.entry.imputationClass === 'stable-absence');
+    const unmonitored = allEntries.filter((e) => e.entry.imputationClass === 'unmonitored');
+
+    assert.ok(stableAbsence.length > 0, 'expected at least one stable-absence entry across both tables');
+    assert.ok(unmonitored.length > 0, 'expected at least one unmonitored entry across both tables');
+
+    const minStableScore = Math.min(...stableAbsence.map((e) => e.entry.score));
+    const maxUnmonitoredScore = Math.max(...unmonitored.map((e) => e.entry.score));
     assert.ok(
-      IMPUTATION.crisis_monitoring_absent.score > IMPUTATION.curated_list_absent.score,
-      `stable-absence score (${IMPUTATION.crisis_monitoring_absent.score}) should be higher than unmonitored (${IMPUTATION.curated_list_absent.score})`,
+      minStableScore > maxUnmonitoredScore,
+      `every stable-absence entry must score higher than every unmonitored entry. ` +
+      `min stable-absence score = ${minStableScore}, max unmonitored score = ${maxUnmonitoredScore}. ` +
+      `stable-absence entries: ${stableAbsence.map((e) => `${e.label}=${e.entry.score}`).join(', ')}. ` +
+      `unmonitored entries: ${unmonitored.map((e) => `${e.label}=${e.entry.score}`).join(', ')}.`,
     );
+
+    const minStableCertainty = Math.min(...stableAbsence.map((e) => e.entry.certaintyCoverage));
+    const maxUnmonitoredCertainty = Math.max(...unmonitored.map((e) => e.entry.certaintyCoverage));
     assert.ok(
-      IMPUTATION.crisis_monitoring_absent.certaintyCoverage > IMPUTATION.curated_list_absent.certaintyCoverage,
-      `stable-absence certainty (${IMPUTATION.crisis_monitoring_absent.certaintyCoverage}) should be higher than unmonitored (${IMPUTATION.curated_list_absent.certaintyCoverage})`,
+      minStableCertainty > maxUnmonitoredCertainty,
+      `every stable-absence entry must have higher certaintyCoverage than every unmonitored entry. ` +
+      `min stable-absence certainty = ${minStableCertainty}, max unmonitored certainty = ${maxUnmonitoredCertainty}. ` +
+      `stable-absence entries: ${stableAbsence.map((e) => `${e.label}=${e.entry.certaintyCoverage}`).join(', ')}. ` +
+      `unmonitored entries: ${unmonitored.map((e) => `${e.label}=${e.entry.certaintyCoverage}`).join(', ')}.`,
     );
   });
 });

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -2,6 +2,9 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
+  IMPUTATION,
+  IMPUTE,
+  type ImputationClass,
   RESILIENCE_DIMENSION_ORDER,
   RESILIENCE_DIMENSION_TYPES,
   scoreAllDimensions,
@@ -685,5 +688,85 @@ describe('resilience dimension scorers', () => {
     const lowExp = await scoreHealthPublicService('XX', makeReader(100));
     assert.ok(highExp.score > lowExp.score,
       `High health expenditure (${highExp.score}) should score better than low (${lowExp.score})`);
+  });
+});
+
+// T1.7 Phase 1 of the country-resilience reference-grade upgrade plan.
+// Foundation-only slice: the 4-class imputation taxonomy (stable-absence,
+// unmonitored, source-failure, not-applicable) is defined as an exported
+// type, and every entry in the IMPUTATION and IMPUTE tables carries an
+// imputationClass tag. These tests pin the classification so downstream
+// work (T1.5 source-recency badges, T1.6 widget dimension confidence) can
+// consume the taxonomy without risk of drift.
+describe('resilience imputation taxonomy (T1.7)', () => {
+  const VALID_CLASSES: readonly ImputationClass[] = [
+    'stable-absence',
+    'unmonitored',
+    'source-failure',
+    'not-applicable',
+  ] as const;
+
+  function assertValidClass(label: string, value: string): void {
+    assert.ok(
+      (VALID_CLASSES as readonly string[]).includes(value),
+      `${label} has imputationClass="${value}", expected one of [${VALID_CLASSES.join(', ')}]`,
+    );
+  }
+
+  it('IMPUTATION entries carry the expected semantic classes', () => {
+    // Crisis-monitoring sources (IPC, UCDP, UNHCR) publish globally; absence
+    // means the country is stable, so it is tagged stable-absence.
+    assert.equal(IMPUTATION.crisis_monitoring_absent.imputationClass, 'stable-absence');
+    assert.equal(IMPUTATION.crisis_monitoring_absent.score, 85);
+    assert.equal(IMPUTATION.crisis_monitoring_absent.certaintyCoverage, 0.7);
+
+    // Curated-list sources (BIS, WTO) may not cover every country; absence
+    // is ambiguous, so it is tagged unmonitored.
+    assert.equal(IMPUTATION.curated_list_absent.imputationClass, 'unmonitored');
+    assert.equal(IMPUTATION.curated_list_absent.score, 50);
+    assert.equal(IMPUTATION.curated_list_absent.certaintyCoverage, 0.3);
+  });
+
+  it('every IMPUTATION entry has a valid imputationClass', () => {
+    for (const [key, entry] of Object.entries(IMPUTATION)) {
+      assertValidClass(`IMPUTATION.${key}`, entry.imputationClass);
+    }
+  });
+
+  it('IMPUTE per-metric overrides inherit or override the class consistently', () => {
+    // Food-specific crisis-monitoring override (IPC phase data).
+    assert.equal(IMPUTE.ipcFood.imputationClass, 'stable-absence');
+    // Trade-specific curated-list override (WTO trade restrictions).
+    assert.equal(IMPUTE.wtoData.imputationClass, 'unmonitored');
+    // Displacement-specific crisis-monitoring override (UNHCR flows).
+    assert.equal(IMPUTE.unhcrDisplacement.imputationClass, 'stable-absence');
+
+    // Shared references: bisEer and bisCredit alias IMPUTATION.curated_list_absent
+    // so their class must match exactly (same object reference, same tag).
+    assert.equal(IMPUTE.bisEer.imputationClass, 'unmonitored');
+    assert.equal(IMPUTE.bisCredit.imputationClass, 'unmonitored');
+    assert.equal(IMPUTE.bisEer, IMPUTATION.curated_list_absent);
+    assert.equal(IMPUTE.bisCredit, IMPUTATION.curated_list_absent);
+  });
+
+  it('every IMPUTE entry has a valid imputationClass', () => {
+    for (const [key, entry] of Object.entries(IMPUTE)) {
+      assertValidClass(`IMPUTE.${key}`, entry.imputationClass);
+    }
+  });
+
+  it('stable-absence entries score higher than unmonitored (semantic sanity)', () => {
+    // stable-absence = strong positive signal (feed is comprehensive,
+    // nothing happened). unmonitored = we do not know, penalized.
+    // If this assertion ever fails, the semantic meaning of the classes
+    // has drifted and the taxonomy needs to be re-argued.
+    assert.ok(
+      IMPUTATION.crisis_monitoring_absent.score > IMPUTATION.curated_list_absent.score,
+      `stable-absence score (${IMPUTATION.crisis_monitoring_absent.score}) should be higher than unmonitored (${IMPUTATION.curated_list_absent.score})`,
+    );
+    assert.ok(
+      IMPUTATION.crisis_monitoring_absent.certaintyCoverage > IMPUTATION.curated_list_absent.certaintyCoverage,
+      `stable-absence certainty (${IMPUTATION.crisis_monitoring_absent.certaintyCoverage}) should be higher than unmonitored (${IMPUTATION.curated_list_absent.certaintyCoverage})`,
+    );
   });
 });


### PR DESCRIPTION
## Why this PR?

Ships the **foundation slice** of Phase 1 T1.7 of the country-resilience reference-grade upgrade plan (PR #2938): tag every absence-based imputation in the resilience scorer with one of four semantic classes so downstream consumers can distinguish "nothing is happening" from "we do not know" from "upstream is down" from "the dimension does not apply."

The current scorer already handles absence as a typed signal via the `IMPUTATION` / `IMPUTE` tables, but the tables only carry `score` and `certaintyCoverage`. Downstream code (widget confidence label, benchmark gates, methodology changelog) cannot ask *why* a dimension is imputed. This PR adds that why.

## What this PR commits

- New exported type `ImputationClass`:
  - `stable-absence`: source publishes globally; absence means the tracked phenomenon is not happening (IPC, UCDP, UNHCR). Strong positive signal.
  - `unmonitored`: source is a curated list that may not cover every country. Absence is ambiguous; penalized conservatively.
  - `source-failure`: reserved for runtime path that consults `seed-meta` `failedDatasets`. Not yet wired; documented as landing with T1.9.
  - `not-applicable`: reserved for structural N/A (landlocked maritime exposure, etc.). No current scorer branches on it.
- New exported interface `ImputationEntry` so `IMPUTATION` and `IMPUTE` share a single shape: `{ score, certaintyCoverage, imputationClass }`.
- Every table entry tagged:
  - `crisis_monitoring_absent` (IPC/UCDP/UNHCR) `=>` `stable-absence`
  - `curated_list_absent` (BIS/WTO) `=>` `unmonitored`
  - `ipcFood` `=>` `stable-absence`
  - `wtoData` `=>` `unmonitored`
  - `unhcrDisplacement` `=>` `stable-absence`
  - `bisEer`, `bisCredit` inherit via shared reference (same object, same class)
- Uses `as const satisfies Record<string, ImputationEntry>` so literal types stay narrow for existing call sites while the compiler enforces the shape on every entry.
- Exports `IMPUTATION`, `IMPUTE`, and `ImputationClass` for downstream consumers.
- 5 new scorer tests: every entry has a valid class, `crisis_monitoring_absent` / `curated_list_absent` constants unchanged, per-metric overrides carry the right class, shared-reference aliases preserve semantics, semantic sanity check that stable-absence score and certainty both exceed unmonitored.

## What is deliberately NOT in this PR

- **No response-schema changes.** The `imputationBreakdown` field on `ResilienceDimension` lands with T1.6 (widget dimension confidence bar with imputation icon). Keeping the proto clean here avoids an `as never` cascade across the generated types.
- **No scorer-aggregation changes.** The taxonomy is tagged at definition time, not yet propagated through each of the 13 dimension scorers. Propagation lands with T1.5 so the two schema additions ship together.
- **No seed-time storage refactor.** The plan's T1.7 description mentions writing `imputationClass` to per-signal Redis keys, but the current storage model is global source keys (UCDP, UNHCR, etc.) fetched once per request and keyed by ISO2 inside. A per-signal refactor is out of scope; classification at read time via the IMPUTATION table achieves the same downstream effect at zero storage cost.
- **No `source-failure` wiring.** The seed-meta `failedDatasets` array is already written by the seeder; wiring the scorer to consult it and re-tag imputations is tracked for T1.9.

## Prerequisite PRs (verified merged)

- #2821 (baseline/stress engine)
- #2847 (formula revert + RSF direction fix)
- #2858 (seed direct scoring)

## Testing

- `npx tsx --test tests/resilience-dimension-scorers.test.mts`: 51/51 passing (46 existing + 5 new)
- `npx tsx --test tests/resilience-*.test.mts tests/resilience-*.test.mjs`: 176/176 passing
- `npm run typecheck`: clean
- Pre-push hook passes (typecheck + build:full + version:check)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this PR only adds a classification field to existing in-memory constants and tests. No runtime behavior change, no schema change, no new Redis keys, no new API surface. The scorer returns identical `ResilienceDimensionScore` values byte-for-byte with or without this PR.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)
