### PR TITLE
test(resilience): methodology doc linter enforces dimension parity (T1.8)

### DIFF
--- a/tests/resilience-methodology-lint.test.mts
+++ b/tests/resilience-methodology-lint.test.mts
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import {
+  RESILIENCE_DIMENSION_ORDER,
+  type ResilienceDimensionId,
+} from '../server/worldmonitor/resilience/v1/_dimension-scorers.ts';
+
+// T1.8 Phase 1 of the country-resilience reference-grade upgrade plan.
+//
+// Enforces parity between the published methodology document and the
+// indicator registry in _dimension-scorers.ts. Every scorer must have a
+// documented subsection; every documented subsection must map to a real
+// scorer. This prevents the methodology doc from drifting silently when
+// a new dimension lands (a forever risk on composite indices per the
+// OECD/JRC handbook).
+//
+// The linter is location-agnostic: it looks for the methodology file at
+// a short list of candidate paths and prefers the newer .mdx path once
+// T1.3 lands on main. This keeps T1.8 independent of T1.3's merge order.
+
+const METHODOLOGY_CANDIDATES = [
+  'docs/methodology/country-resilience-index.mdx',
+  'docs/methodology/resilience-index.md',
+];
+
+// Mapping from H4 subsection headings used in the methodology doc to the
+// canonical dimension IDs used by the scorer. Hardcoded deliberately so
+// the test file is the single source of truth for how the doc labels map
+// to scorer IDs; if a new dimension lands, this map must be updated at
+// the same time as the scorer and the doc, which is exactly the drift
+// prevention we want. The test fails loudly if either side of this map
+// desyncs.
+const HEADING_TO_DIMENSION: Readonly<Record<string, ResilienceDimensionId>> = {
+  'Macro-Fiscal': 'macroFiscal',
+  'Currency & External': 'currencyExternal',
+  'Trade & Sanctions': 'tradeSanctions',
+  'Cyber & Digital': 'cyberDigital',
+  'Logistics & Supply': 'logisticsSupply',
+  'Infrastructure': 'infrastructure',
+  'Energy': 'energy',
+  'Governance': 'governanceInstitutional',
+  'Social Cohesion': 'socialCohesion',
+  'Border Security': 'borderSecurity',
+  'Information & Cognitive': 'informationCognitive',
+  'Health & Public Service': 'healthPublicService',
+  'Food & Water': 'foodWater',
+};
+
+function findMethodologyFile(): string {
+  for (const candidate of METHODOLOGY_CANDIDATES) {
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new Error(
+    `Methodology file not found. Looked for: ${METHODOLOGY_CANDIDATES.join(', ')}. ` +
+    `The linter must be able to find at least one methodology document to validate.`,
+  );
+}
+
+function extractH4Headings(source: string): string[] {
+  // Matches lines of the form `#### <text>` and captures the text.
+  // Ignores nested # (H5+) and H3 domain headers so the linter only
+  // checks dimension-level subsections.
+  const pattern = /^####\s+(.+?)\s*$/gm;
+  const headings: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(source)) !== null) {
+    headings.push(match[1]);
+  }
+  return headings;
+}
+
+describe('resilience methodology doc linter (T1.8)', () => {
+  const methodologyPath = findMethodologyFile();
+  const source = readFileSync(methodologyPath, 'utf8');
+  const headings = extractH4Headings(source);
+
+  it(`locates a methodology file (${methodologyPath})`, () => {
+    assert.ok(source.length > 0, 'methodology file should be non-empty');
+    assert.ok(headings.length > 0, 'methodology file should contain at least one H4 subsection');
+  });
+
+  it('every dimension in RESILIENCE_DIMENSION_ORDER has a documented subsection', () => {
+    const documentedIds = new Set(
+      headings
+        .map((heading) => HEADING_TO_DIMENSION[heading])
+        .filter((id): id is ResilienceDimensionId => id != null),
+    );
+
+    const missing = RESILIENCE_DIMENSION_ORDER.filter((id) => !documentedIds.has(id));
+
+    assert.deepEqual(
+      missing,
+      [],
+      `Dimensions in RESILIENCE_DIMENSION_ORDER without a matching subsection in ${methodologyPath}: ${missing.join(', ')}. ` +
+      `Add an H4 heading for each missing dimension (see HEADING_TO_DIMENSION in this test file for the expected heading text) ` +
+      `or update RESILIENCE_DIMENSION_ORDER if the dimension was removed.`,
+    );
+  });
+
+  it('every H4 subsection in the methodology maps to a real scorer dimension', () => {
+    const knownDimensionIds = new Set<string>(RESILIENCE_DIMENSION_ORDER);
+    const stale = headings.filter((heading) => {
+      const id = HEADING_TO_DIMENSION[heading];
+      return id != null && !knownDimensionIds.has(id);
+    });
+
+    assert.deepEqual(
+      stale,
+      [],
+      `Methodology subsections whose mapped dimension no longer exists in RESILIENCE_DIMENSION_ORDER: ${stale.join(', ')}. ` +
+      `Either restore the dimension to the scorer or remove the subsection from ${methodologyPath}.`,
+    );
+  });
+
+  it('every H4 subsection is either a mapped dimension or explicitly non-dimension', () => {
+    // Catches typos and new subsections that are not yet wired up. A
+    // non-dimension heading is allowed only if it is clearly not a
+    // dimension name (e.g., a sub-section under Data Sources). The
+    // strict interpretation here is: any H4 heading must be in the
+    // mapping. If a future edit adds a legitimate non-dimension H4
+    // (rare), either upgrade it to H3 or add an explicit allowlist.
+    const unmapped = headings.filter((heading) => HEADING_TO_DIMENSION[heading] == null);
+    assert.deepEqual(
+      unmapped,
+      [],
+      `H4 subsections in ${methodologyPath} that do not map to a known dimension via HEADING_TO_DIMENSION: ${unmapped.join(', ')}. ` +
+      `Either (a) add an entry to HEADING_TO_DIMENSION in this test file if it is a real dimension, ` +
+      `or (b) promote the section to H3 if it is a non-dimension subsection, or ` +
+      `(c) fix the typo.`,
+    );
+  });
+
+  it('HEADING_TO_DIMENSION covers exactly the scorer dimensions (no extras, no missing)', () => {
+    const mappedIds = new Set(Object.values(HEADING_TO_DIMENSION));
+    const registryIds = new Set(RESILIENCE_DIMENSION_ORDER);
+
+    const mappedNotInRegistry = [...mappedIds].filter((id) => !registryIds.has(id));
+    const registryNotMapped = [...registryIds].filter((id) => !mappedIds.has(id));
+
+    assert.deepEqual(
+      mappedNotInRegistry,
+      [],
+      `HEADING_TO_DIMENSION maps to dimension IDs that are not in RESILIENCE_DIMENSION_ORDER: ${mappedNotInRegistry.join(', ')}`,
+    );
+    assert.deepEqual(
+      registryNotMapped,
+      [],
+      `RESILIENCE_DIMENSION_ORDER contains dimensions that are not in HEADING_TO_DIMENSION: ${registryNotMapped.join(', ')}`,
+    );
+  });
+});


### PR DESCRIPTION
## Why this PR?

Ships Phase 1 T1.8 of the country-resilience reference-grade upgrade plan (PR #2938): a linter test that fails loudly if the published methodology document drifts from the scorer's `RESILIENCE_DIMENSION_ORDER`. This is the discipline that keeps the methodology page trustworthy over time, a forever risk on composite indices per the OECD/JRC handbook.

Without this test, a new scorer dimension can land with no matching methodology subsection (the doc is silently incomplete), or a scorer dimension can be removed without cleaning up the doc (the doc silently describes behavior that no longer exists). Either drift is invisible until a reader catches it.

## What the linter checks

1. **Every dimension in `RESILIENCE_DIMENSION_ORDER` has an H4 subsection in the methodology document.** Fails with the list of missing dimensions if any scorer dimension is undocumented.
2. **Every H4 subsection in the methodology maps to a real scorer dimension.** Fails if the doc describes a dimension the scorer no longer has.
3. **Every H4 subsection is either a mapped dimension or explicitly allowlisted.** Catches typos in headings and unwired new sections.
4. **`HEADING_TO_DIMENSION` covers exactly `RESILIENCE_DIMENSION_ORDER`.** The mapping table in the test file itself is kept in lockstep with the scorer so there is a single source of truth for heading-to-ID translation.

## What this PR commits

- New test file `tests/resilience-methodology-lint.test.mts` with 5 scenarios covering the four checks above plus a smoke test that the file locator works.
- Hardcoded `HEADING_TO_DIMENSION` map (13 entries, one per scorer dimension). Any future dimension add must update this map in lockstep with the scorer and the methodology doc, which is exactly the drift prevention this task targets.

## Location-agnostic by design

The linter looks for the methodology file at a short candidate list and prefers `docs/methodology/country-resilience-index.mdx` (the post-T1.3 path from PR #2945) but falls back to `docs/methodology/resilience-index.md` (the pre-T1.3 path on `origin/main`). That keeps this PR independent of T1.3 merge order. The linter passes on today's `main` against the older `.md` file and auto-switches to the `.mdx` once T1.3 merges.

## What is NOT in this PR

- **No changes to the methodology document or the scorer.** The linter only reads existing content.
- **No automated HTML comment markers in the mdx.** The hardcoded map in the test file is simpler and produces the same drift-detection signal.
- **No integration with `lint-staged` or CI-specific gating.** The linter runs as part of the standard `test:data` suite, so it fires on every pre-push hook run and on CI.

## Prerequisite PRs verified merged

- #2821 (baseline/stress engine)
- #2847 (formula revert + RSF direction fix)
- #2858 (seed direct scoring)

## Related (not prerequisite) in-flight Phase 1 PRs from this session

- #2941 T1.1 regression test for the origin-doc ceiling claim
- #2943 T1.4 `dataVersion` widget wire
- #2944 T1.7 imputation taxonomy foundation
- #2945 T1.3 methodology mdx promotion

## Testing

- `npx tsx --test tests/resilience-methodology-lint.test.mts`: 5/5 passing against the pre-T1.3 methodology file on `origin/main`
- `npx tsx --test tests/resilience-*.test.mts tests/resilience-*.test.mjs`: 176/176 passing
- `npm run typecheck`: clean

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: test-only change, no runtime impact. The linter runs in CI on every push so any future methodology drift blocks the offending PR before merge.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)
