### PR TITLE
feat(resilience): staleness classifier foundation (T1.5)

### DIFF
--- a/server/_shared/resilience-freshness.ts
+++ b/server/_shared/resilience-freshness.ts
@@ -1,0 +1,110 @@
+// T1.5 Phase 1 of the country-resilience reference-grade upgrade plan
+// (docs/internal/country-resilience-upgrade-plan.md).
+//
+// Foundation-only slice: the staleness classifier. This module defines
+// the cadence taxonomy (Realtime, Daily, Weekly, Monthly, Annual), the
+// three-level staleness output (fresh, aging, stale), and a pure
+// classifier function that maps a `lastObservedAt` timestamp and a
+// source cadence to a staleness level.
+//
+// What is deliberately NOT in this module:
+//
+// - No changes to the 13 dimension scorers. Propagating `lastObservedAt`
+//   through each scorer and aggregating max age per dimension is the
+//   next slice of T1.5 and will depend on this classifier. Keeping the
+//   classifier in its own module means that slice becomes a simple
+//   consumer wiring pass with no test surface for the classifier itself.
+// - No schema changes (proto, OpenAPI, ResilienceDimension response
+//   type). The schema field `freshness: { lastObservedAt, staleness }`
+//   lands alongside the widget rendering in T1.6 and consumes this
+//   classifier.
+// - No widget rendering. T1.6 owns the per-dimension freshness badge
+//   UI and will call `classifyStaleness` from the widget path at render
+//   time given the already-exposed `lastObservedAt` field.
+//
+// The multiplier thresholds below come from a simple rule: a source is
+// fresh if its age is less than 1.5 times its cadence, aging if less
+// than 3 times, stale otherwise. This scales gracefully across the 5
+// cadences the methodology document lists without per-cadence ad-hoc
+// numbers.
+
+export type ResilienceCadence = 'realtime' | 'daily' | 'weekly' | 'monthly' | 'annual';
+
+export type StalenessLevel = 'fresh' | 'aging' | 'stale';
+
+// Canonical cadence duration in milliseconds. A "unit" of each cadence.
+// Realtime sources are expected to refresh within an hour; daily within
+// a day; annual within a year. A simple, defensible base.
+const CADENCE_UNIT_MS: Record<ResilienceCadence, number> = {
+  realtime: 60 * 60 * 1000,                     // 1 hour
+  daily: 24 * 60 * 60 * 1000,                   // 1 day
+  weekly: 7 * 24 * 60 * 60 * 1000,              // 7 days
+  monthly: 30 * 24 * 60 * 60 * 1000,            // 30 days
+  annual: 365 * 24 * 60 * 60 * 1000,            // 365 days
+};
+
+// Multiplier thresholds applied to the cadence unit. A source is fresh
+// when its age is less than `FRESH_MULTIPLIER * cadenceUnit`, aging when
+// less than `AGING_MULTIPLIER * cadenceUnit`, stale otherwise.
+export const FRESH_MULTIPLIER = 1.5;
+export const AGING_MULTIPLIER = 3;
+
+export function cadenceUnitMs(cadence: ResilienceCadence): number {
+  return CADENCE_UNIT_MS[cadence];
+}
+
+export interface ClassifyStalenessArgs {
+  /** Unix milliseconds when the signal was last observed. */
+  lastObservedAtMs: number | null | undefined;
+  /** Cadence of the source publishing the signal. */
+  cadence: ResilienceCadence;
+  /** Override the current time for deterministic testing. Defaults to Date.now(). */
+  nowMs?: number;
+}
+
+export interface StalenessResult {
+  staleness: StalenessLevel;
+  ageMs: number;
+  /** The age expressed as a multiple of the cadence unit. Handy for debugging. */
+  ageInCadenceUnits: number;
+}
+
+/**
+ * Classify how fresh a signal is relative to its cadence.
+ *
+ * Returns `'stale'` when `lastObservedAtMs` is null, undefined, NaN, or
+ * in the future. Returns `'fresh'` when age is strictly less than
+ * `FRESH_MULTIPLIER * cadenceUnit`. Returns `'aging'` when age is
+ * strictly less than `AGING_MULTIPLIER * cadenceUnit`. Returns `'stale'`
+ * otherwise.
+ *
+ * The function is pure: same inputs, same outputs, no side effects.
+ * `nowMs` is accepted for deterministic unit tests.
+ */
+export function classifyStaleness(args: ClassifyStalenessArgs): StalenessResult {
+  const { lastObservedAtMs, cadence } = args;
+  const nowMs = args.nowMs ?? Date.now();
+  const unit = cadenceUnitMs(cadence);
+
+  if (
+    lastObservedAtMs == null ||
+    !Number.isFinite(lastObservedAtMs) ||
+    lastObservedAtMs > nowMs
+  ) {
+    return { staleness: 'stale', ageMs: Number.POSITIVE_INFINITY, ageInCadenceUnits: Number.POSITIVE_INFINITY };
+  }
+
+  const ageMs = Math.max(0, nowMs - lastObservedAtMs);
+  const ageInCadenceUnits = ageMs / unit;
+
+  let staleness: StalenessLevel;
+  if (ageInCadenceUnits < FRESH_MULTIPLIER) {
+    staleness = 'fresh';
+  } else if (ageInCadenceUnits < AGING_MULTIPLIER) {
+    staleness = 'aging';
+  } else {
+    staleness = 'stale';
+  }
+
+  return { staleness, ageMs, ageInCadenceUnits };
+}

--- a/tests/resilience-freshness.test.mts
+++ b/tests/resilience-freshness.test.mts
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  AGING_MULTIPLIER,
+  FRESH_MULTIPLIER,
+  cadenceUnitMs,
+  classifyStaleness,
+  type ResilienceCadence,
+} from '../server/_shared/resilience-freshness.ts';
+
+// T1.5 Phase 1 of the country-resilience reference-grade upgrade plan.
+//
+// Foundation-only slice: these tests pin the staleness classifier so
+// T1.6 (widget dimension confidence bar) and the later T1.5 scorer
+// propagation pass can consume the classifier with confidence.
+
+describe('resilience freshness classifier (T1.5)', () => {
+  const NOW = 1_700_000_000_000; // fixed anchor: any arbitrary ms timestamp
+
+  const CADENCES: ResilienceCadence[] = ['realtime', 'daily', 'weekly', 'monthly', 'annual'];
+
+  it('cadenceUnitMs returns a positive duration for every cadence', () => {
+    for (const cadence of CADENCES) {
+      const unit = cadenceUnitMs(cadence);
+      assert.ok(unit > 0, `${cadence} should have a positive cadence unit`);
+    }
+  });
+
+  it('cadence units are ordered strictly: realtime < daily < weekly < monthly < annual', () => {
+    const units = CADENCES.map((c) => cadenceUnitMs(c));
+    for (let i = 1; i < units.length; i += 1) {
+      assert.ok(
+        units[i] > units[i - 1],
+        `${CADENCES[i]} cadence unit (${units[i]}) should be strictly greater than ${CADENCES[i - 1]} (${units[i - 1]})`,
+      );
+    }
+  });
+
+  it('fresh when age is well below FRESH_MULTIPLIER * cadence unit', () => {
+    for (const cadence of CADENCES) {
+      const unit = cadenceUnitMs(cadence);
+      // Age = 0.5 * unit, well under FRESH_MULTIPLIER = 1.5
+      const result = classifyStaleness({
+        lastObservedAtMs: NOW - unit * 0.5,
+        cadence,
+        nowMs: NOW,
+      });
+      assert.equal(result.staleness, 'fresh', `${cadence} at 0.5x should be fresh`);
+      assert.ok(result.ageInCadenceUnits >= 0 && result.ageInCadenceUnits < FRESH_MULTIPLIER);
+    }
+  });
+
+  it('aging when age sits between FRESH_MULTIPLIER and AGING_MULTIPLIER', () => {
+    for (const cadence of CADENCES) {
+      const unit = cadenceUnitMs(cadence);
+      // Age = 2 * unit, between FRESH_MULTIPLIER (1.5) and AGING_MULTIPLIER (3)
+      const result = classifyStaleness({
+        lastObservedAtMs: NOW - unit * 2,
+        cadence,
+        nowMs: NOW,
+      });
+      assert.equal(result.staleness, 'aging', `${cadence} at 2x should be aging`);
+      assert.ok(result.ageInCadenceUnits >= FRESH_MULTIPLIER && result.ageInCadenceUnits < AGING_MULTIPLIER);
+    }
+  });
+
+  it('stale when age is at or beyond AGING_MULTIPLIER * cadence unit', () => {
+    for (const cadence of CADENCES) {
+      const unit = cadenceUnitMs(cadence);
+      // Age = 5 * unit, well beyond AGING_MULTIPLIER
+      const result = classifyStaleness({
+        lastObservedAtMs: NOW - unit * 5,
+        cadence,
+        nowMs: NOW,
+      });
+      assert.equal(result.staleness, 'stale', `${cadence} at 5x should be stale`);
+      assert.ok(result.ageInCadenceUnits >= AGING_MULTIPLIER);
+    }
+  });
+
+  it('stale when lastObservedAtMs is null, undefined, NaN, or in the future', () => {
+    for (const cadence of CADENCES) {
+      const missingNull = classifyStaleness({ lastObservedAtMs: null, cadence, nowMs: NOW });
+      assert.equal(missingNull.staleness, 'stale', `${cadence} null should be stale`);
+      assert.equal(missingNull.ageMs, Number.POSITIVE_INFINITY);
+
+      const missingUndefined = classifyStaleness({ lastObservedAtMs: undefined, cadence, nowMs: NOW });
+      assert.equal(missingUndefined.staleness, 'stale', `${cadence} undefined should be stale`);
+
+      const nanResult = classifyStaleness({ lastObservedAtMs: Number.NaN, cadence, nowMs: NOW });
+      assert.equal(nanResult.staleness, 'stale', `${cadence} NaN should be stale`);
+
+      // A timestamp 10 minutes in the future is nonsensical and treated as stale.
+      const futureResult = classifyStaleness({
+        lastObservedAtMs: NOW + 10 * 60 * 1000,
+        cadence,
+        nowMs: NOW,
+      });
+      assert.equal(futureResult.staleness, 'stale', `${cadence} future timestamp should be stale`);
+    }
+  });
+
+  it('defaults to Date.now() when nowMs is omitted', () => {
+    const now = Date.now();
+    // A recent observation should always be fresh against real Date.now()
+    // without specifying nowMs explicitly. Small tolerance for clock drift.
+    const result = classifyStaleness({
+      lastObservedAtMs: now - 60_000, // 60 seconds ago
+      cadence: 'daily',
+    });
+    assert.equal(result.staleness, 'fresh');
+    assert.ok(result.ageMs >= 60_000 && result.ageMs < 120_000);
+  });
+
+  it('exact threshold boundaries (FRESH and AGING multipliers are strict upper bounds for their class)', () => {
+    const unit = cadenceUnitMs('daily');
+
+    // age = FRESH_MULTIPLIER * unit (exactly at boundary) should be aging,
+    // not fresh, because the comparison is strict `<`.
+    const atFreshBoundary = classifyStaleness({
+      lastObservedAtMs: NOW - unit * FRESH_MULTIPLIER,
+      cadence: 'daily',
+      nowMs: NOW,
+    });
+    assert.equal(atFreshBoundary.staleness, 'aging', 'exact FRESH_MULTIPLIER boundary is aging');
+
+    // age = AGING_MULTIPLIER * unit (exactly at boundary) should be stale,
+    // not aging, because the comparison is strict `<`.
+    const atAgingBoundary = classifyStaleness({
+      lastObservedAtMs: NOW - unit * AGING_MULTIPLIER,
+      cadence: 'daily',
+      nowMs: NOW,
+    });
+    assert.equal(atAgingBoundary.staleness, 'stale', 'exact AGING_MULTIPLIER boundary is stale');
+
+    // age = 0 should be fresh.
+    const atZero = classifyStaleness({
+      lastObservedAtMs: NOW,
+      cadence: 'daily',
+      nowMs: NOW,
+    });
+    assert.equal(atZero.staleness, 'fresh', 'zero age is fresh');
+  });
+
+  it('ageMs and ageInCadenceUnits are internally consistent', () => {
+    const result = classifyStaleness({
+      lastObservedAtMs: NOW - 36 * 60 * 60 * 1000, // 36 hours ago
+      cadence: 'daily',
+      nowMs: NOW,
+    });
+    assert.equal(result.ageMs, 36 * 60 * 60 * 1000);
+    assert.equal(result.ageInCadenceUnits, 1.5);
+    // 36 hours at daily cadence is exactly FRESH_MULTIPLIER, so aging.
+    assert.equal(result.staleness, 'aging');
+  });
+
+  it('classifier is pure: same inputs produce same outputs', () => {
+    const args = {
+      lastObservedAtMs: NOW - 12 * 60 * 60 * 1000,
+      cadence: 'daily' as const,
+      nowMs: NOW,
+    };
+    const a = classifyStaleness(args);
+    const b = classifyStaleness(args);
+    const c = classifyStaleness({ ...args });
+    assert.deepEqual(a, b);
+    assert.deepEqual(a, c);
+  });
+});


### PR DESCRIPTION
## Why this PR?

Ships the **foundation-only slice** of Phase 1 T1.5 of the country-resilience reference-grade upgrade plan (PR #2938): a pure staleness classifier that maps a `lastObservedAt` timestamp and a source cadence to one of three staleness levels (`fresh`, `aging`, `stale`). This is the primitive that T1.6 (widget dimension confidence bar with freshness badge) and the later T1.5 scorer propagation pass both consume.

Same pattern as the T1.7 foundation PR (#2944): define the type and the primitive in isolation with comprehensive tests, then land the consumer wiring in separate PRs so each unit is bounded and reviewable.

## What this PR commits

- New module `server/_shared/resilience-freshness.ts`:
  - `ResilienceCadence` type union covering the 5 cadences listed in the methodology document (`realtime`, `daily`, `weekly`, `monthly`, `annual`).
  - `StalenessLevel` type union: `fresh` / `aging` / `stale`.
  - `cadenceUnitMs(cadence)` helper returning a canonical duration per cadence: realtime 1 hour, daily 1 day, weekly 7 days, monthly 30 days, annual 365 days.
  - `FRESH_MULTIPLIER` = 1.5 and `AGING_MULTIPLIER` = 3 exported constants. A signal is fresh when age is strictly less than 1.5x its cadence unit, aging when strictly less than 3x, stale otherwise.
  - `classifyStaleness({ lastObservedAtMs, cadence, nowMs })` pure function returning `{ staleness, ageMs, ageInCadenceUnits }`. Null / undefined / NaN / future timestamps return stale with positive-infinity age. `nowMs` is accepted as a deterministic override for unit testing.
- New test file `tests/resilience-freshness.test.mts` with 10 tests covering cadence ordering, fresh/aging/stale classification across all 5 cadences, defensive handling of null/undefined/NaN/future timestamps, exact threshold boundaries, internal consistency of `ageMs` and `ageInCadenceUnits`, and classifier purity.

## What is deliberately NOT in this PR

- **No changes to the 13 dimension scorers.** Propagating `lastObservedAt` through each scorer and aggregating max age per dimension is the next slice of T1.5 and will consume this classifier as a pure import. Splitting it this way keeps the classifier testable in isolation.
- **No schema changes** (proto, OpenAPI, `ResilienceDimension` response type). The schema field `freshness: { lastObservedAt, staleness }` lands alongside the widget rendering in T1.6.
- **No widget rendering.** T1.6 owns the per-dimension freshness badge UI and will call `classifyStaleness` at render time.

## Prerequisite PRs verified merged

- #2821 (baseline/stress engine)
- #2847 (formula revert + RSF direction fix)
- #2858 (seed direct scoring)

## Related in-flight Phase 1 PRs from this session

- #2941 T1.1 regression test
- #2943 T1.4 `dataVersion` widget wire
- #2944 T1.7 imputation taxonomy foundation
- #2945 T1.3 methodology mdx promotion
- #2946 T1.8 methodology doc linter

## Testing

- `npx tsx --test tests/resilience-freshness.test.mts`: 10/10 passing
- `npm run typecheck`: clean
- Pre-push hook (typecheck + `build:full` + version:check) passes

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this PR only adds a new pure module and its tests. No runtime behavior change, no schema change, no new Redis keys, no new API surface. No existing file is modified.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)
