### PR TITLE
fix(relay): restore AI impact analysis by destructuring fetchUserPreferences

### DIFF
--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -596,8 +596,17 @@ async function shadowLogScore(event) {
 async function generateEventImpact(event, rule) {
   if (!AI_IMPACT_ENABLED) return null;
 
-  const prefs = await fetchUserPreferences(rule.userId, rule.variant ?? 'full');
-  if (!prefs) return null;
+  // fetchUserPreferences returns { data, error } — must destructure `data`.
+  // Without this the wrapper object was passed to extractUserContext, which
+  // read no keys, so ctx was always empty and the gate below returned null
+  // for every user, silently disabling AI impact analysis entirely.
+  const { data: prefs, error: prefsFetchError } = await fetchUserPreferences(rule.userId, rule.variant ?? 'full');
+  if (!prefs) {
+    if (prefsFetchError) {
+      console.warn(`[relay] Prefs fetch failed for ${rule.userId} — skipping AI impact`);
+    }
+    return null;
+  }
 
   const ctx = extractUserContext(prefs);
   if (ctx.tickers.length === 0 && ctx.airports.length === 0 && !ctx.frameworkName) return null;


### PR DESCRIPTION
## Summary
- Discovered via Greptile review on #2939: `scripts/notification-relay.cjs` was still using the old `fetchUserPreferences` API, assigning the full `{ data, error }` wrapper to `prefs`.
- Net effect: `generateEventImpact()` returned `null` for every user and the "Impact" section on realtime notifications has been silently disabled for everyone. No log, no error, just absent.
- Three things broke at once:
  1. `if (!prefs) return null` never tripped because the wrapper is always truthy, so transient fetch failures were invisible.
  2. `extractUserContext(prefs)` read from the wrapper (no `wm-market-watchlist-v1` etc. keys) and always returned an empty context.
  3. The gate `if (ctx.tickers.length === 0 && ctx.airports.length === 0 && !ctx.frameworkName) return null` then fired for every user.
- Fix: destructure `{ data: prefs, error: prefsFetchError }` and warn-log the transient-failure case so ops can see it. Behavior for genuinely-missing rows is unchanged (skip the impact block for users who never synced app settings) , matching the pre-regression design. Impact analysis depends on ticker/airport/framework context by design, so a generic fallback would be pointless.

## Related
- Discovered via Greptile review on #2939 (same fetchUserPreferences API drift in `seed-digest-notifications.mjs` , that one is fixed in #2939).
- `scripts/proactive-intelligence.mjs` already uses the correct destructured API (line 502) , no change needed there.

## Test plan
- [ ] After deploy, confirm Railway relay log shows `[relay] AI impact generated for user_...` when an event matches a PRO user's watchlist/airports/framework.
- [ ] Confirm the "Impact" section reappears on realtime notification messages (email/Telegram/Slack/Discord).
- [ ] Confirm `[relay] Prefs fetch failed for user_... skipping AI impact` appears if the Convex endpoint is unreachable.
- [ ] No regression in notification delivery itself (skipping AI impact must not block the underlying notification).