### PR TITLE
fix(resilience): address PR #2947 post-merge review feedback

### DIFF
--- a/server/_shared/resilience-freshness.ts
+++ b/server/_shared/resilience-freshness.ts
@@ -64,8 +64,19 @@ export interface ClassifyStalenessArgs {
 
 export interface StalenessResult {
   staleness: StalenessLevel;
+  /**
+   * Age in milliseconds. `Number.POSITIVE_INFINITY` when `lastObservedAtMs`
+   * is null, undefined, NaN, or in the future. Always check for `Infinity`
+   * (or use `Number.isFinite`) before using this value in arithmetic or
+   * display formatting, otherwise downstream string concatenation will
+   * silently emit `Infinity` and `NaN`.
+   */
   ageMs: number;
-  /** The age expressed as a multiple of the cadence unit. Handy for debugging. */
+  /**
+   * The age expressed as a multiple of the cadence unit. Handy for
+   * debugging. Same infinity contract as `ageMs`: returns
+   * `Number.POSITIVE_INFINITY` in the defensive branches.
+   */
   ageInCadenceUnits: number;
 }
 
@@ -94,7 +105,11 @@ export function classifyStaleness(args: ClassifyStalenessArgs): StalenessResult 
     return { staleness: 'stale', ageMs: Number.POSITIVE_INFINITY, ageInCadenceUnits: Number.POSITIVE_INFINITY };
   }
 
-  const ageMs = Math.max(0, nowMs - lastObservedAtMs);
+  // The defensive branch above already rejected null, undefined, NaN,
+  // and future timestamps, so `nowMs - lastObservedAtMs` is guaranteed
+  // to be >= 0 by the time execution reaches this line. No Math.max
+  // clamp is needed. Removed in PR #2947 review.
+  const ageMs = nowMs - lastObservedAtMs;
   const ageInCadenceUnits = ageMs / unit;
 
   let staleness: StalenessLevel;

--- a/tests/resilience-freshness.test.mts
+++ b/tests/resilience-freshness.test.mts
@@ -80,16 +80,26 @@ describe('resilience freshness classifier (T1.5)', () => {
   });
 
   it('stale when lastObservedAtMs is null, undefined, NaN, or in the future', () => {
+    // Raised in PR #2947 review: pin `ageMs` AND `ageInCadenceUnits` as
+    // POSITIVE_INFINITY on every defensive branch so a future regression
+    // that accidentally omits one field from the defensive return is
+    // caught immediately. The earlier version only checked `ageMs` on
+    // the null branch and staleness on the rest.
     for (const cadence of CADENCES) {
       const missingNull = classifyStaleness({ lastObservedAtMs: null, cadence, nowMs: NOW });
       assert.equal(missingNull.staleness, 'stale', `${cadence} null should be stale`);
-      assert.equal(missingNull.ageMs, Number.POSITIVE_INFINITY);
+      assert.equal(missingNull.ageMs, Number.POSITIVE_INFINITY, `${cadence} null ageMs should be Infinity`);
+      assert.equal(missingNull.ageInCadenceUnits, Number.POSITIVE_INFINITY, `${cadence} null ageInCadenceUnits should be Infinity`);
 
       const missingUndefined = classifyStaleness({ lastObservedAtMs: undefined, cadence, nowMs: NOW });
       assert.equal(missingUndefined.staleness, 'stale', `${cadence} undefined should be stale`);
+      assert.equal(missingUndefined.ageMs, Number.POSITIVE_INFINITY, `${cadence} undefined ageMs should be Infinity`);
+      assert.equal(missingUndefined.ageInCadenceUnits, Number.POSITIVE_INFINITY, `${cadence} undefined ageInCadenceUnits should be Infinity`);
 
       const nanResult = classifyStaleness({ lastObservedAtMs: Number.NaN, cadence, nowMs: NOW });
       assert.equal(nanResult.staleness, 'stale', `${cadence} NaN should be stale`);
+      assert.equal(nanResult.ageMs, Number.POSITIVE_INFINITY, `${cadence} NaN ageMs should be Infinity`);
+      assert.equal(nanResult.ageInCadenceUnits, Number.POSITIVE_INFINITY, `${cadence} NaN ageInCadenceUnits should be Infinity`);
 
       // A timestamp 10 minutes in the future is nonsensical and treated as stale.
       const futureResult = classifyStaleness({
@@ -98,6 +108,8 @@ describe('resilience freshness classifier (T1.5)', () => {
         nowMs: NOW,
       });
       assert.equal(futureResult.staleness, 'stale', `${cadence} future timestamp should be stale`);
+      assert.equal(futureResult.ageMs, Number.POSITIVE_INFINITY, `${cadence} future ageMs should be Infinity`);
+      assert.equal(futureResult.ageInCadenceUnits, Number.POSITIVE_INFINITY, `${cadence} future ageInCadenceUnits should be Infinity`);
     }
   });
 


### PR DESCRIPTION
## Why this PR?

Post-merge follow-up addressing the three P2 Greptile review comments on [PR #2947](https://github.com/koala73/worldmonitor/pull/2947) (staleness classifier foundation, T1.5). The fixes were committed while #2947 was still open but never pushed before #2947 merged, so this PR lands them as a minimal follow-up on top of the merged branch.

## What this PR commits

1. **Remove redundant `Math.max(0, ...)` guard** (PR #2947 comment id 3067874033).
   The defensive branch at the top of `classifyStaleness` already rejects null, undefined, NaN, and future timestamps, so `nowMs - lastObservedAtMs` is guaranteed to be `>= 0` by the time execution reaches the age calculation. The `Math.max` was a misleading hint that a negative value could arrive. Removed, with a comment explaining why the branch above covers the case.

2. **JSDoc the `ageMs` / `ageInCadenceUnits` fields with the `POSITIVE_INFINITY` contract** (PR #2947 comment id 3067874047).
   When the defensive branch returns, both fields are `Number.POSITIVE_INFINITY`, but the field type was just `number`, so callers doing arithmetic or string formatting on the value (e.g. a "last seen X ago" label) would silently emit `Infinity` / `NaN` strings. Added JSDoc to both fields explaining the infinity contract and recommending `Number.isFinite` before arithmetic.

3. **Harden the defensive-cases test** (PR #2947 comment id 3067874066).
   The earlier test only checked `ageMs === POSITIVE_INFINITY` for the null branch and never checked `ageInCadenceUnits` at all. Coverage is now 8/8 field/branch pairs (both `ageMs` and `ageInCadenceUnits` pinned as `POSITIVE_INFINITY` across null, undefined, NaN, and future timestamps). If a future regression drops `ageInCadenceUnits` from the defensive return, the test now fails loudly.

## Why this is a follow-up PR and not a commit on #2947

PR #2947 merged while my review-fix commit was still unpushed (the push round was deferred because several PRs were being pushed back-to-back and one batch was interrupted). Rather than amend a merged PR, the cleanest way to land the reviewer-requested changes is a tiny follow-up against main.

## Testing

- `npx tsx --test tests/resilience-freshness.test.mts`: 10/10 pass
- `npm run typecheck`: clean
- Pre-push hook (typecheck + `build:full` + `version:check`) passes

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this PR only refines a pure classifier function and its tests. No runtime behavior change for any well-formed input, no schema change, no new Redis keys.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)
