### PR TITLE
fix(seed-gdelt): extend tone/vol TTL when GDELT rate-limits a topic

### DIFF
--- a/scripts/seed-gdelt-intel.mjs
+++ b/scripts/seed-gdelt-intel.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, sleep, verifySeedKey, writeExtraKey } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, sleep, verifySeedKey, writeExtraKey, extendExistingTtl } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -177,16 +177,38 @@ function publishTransform(data) {
   };
 }
 
-// Write per-topic tone/vol timeline keys (1h TTL) — separate from the 24h canonical key.
+// Write per-topic tone/vol timeline keys (TIMELINE_TTL, separate from the
+// 24h canonical key). When GDELT rate-limits a topic's TimelineTone/Vol
+// sub-fetch, _tone / _vol arrive empty for that topic — rather than let
+// the existing Redis key silently expire mid-cycle, extend its TTL with
+// EXPIRE so downstream consumers (cross-source-signals, etc.) keep seeing
+// the last successful snapshot until the next cron cycle refreshes it.
 async function afterPublish(data, _meta) {
+  const toneKeysToExtend = [];
+  const volKeysToExtend = [];
   for (const topic of data.topics ?? []) {
     const fetchedAt = topic.fetchedAt ?? data.fetchedAt;
+    const toneKey = `gdelt:intel:tone:${topic.id}`;
+    const volKey = `gdelt:intel:vol:${topic.id}`;
+
     if (Array.isArray(topic._tone) && topic._tone.length > 0) {
-      await writeExtraKey(`gdelt:intel:tone:${topic.id}`, { data: topic._tone, fetchedAt }, TIMELINE_TTL);
+      await writeExtraKey(toneKey, { data: topic._tone, fetchedAt }, TIMELINE_TTL);
+    } else {
+      toneKeysToExtend.push(toneKey);
     }
     if (Array.isArray(topic._vol) && topic._vol.length > 0) {
-      await writeExtraKey(`gdelt:intel:vol:${topic.id}`, { data: topic._vol, fetchedAt }, TIMELINE_TTL);
+      await writeExtraKey(volKey, { data: topic._vol, fetchedAt }, TIMELINE_TTL);
+    } else {
+      volKeysToExtend.push(volKey);
     }
+  }
+  if (toneKeysToExtend.length > 0) {
+    console.log(`  Extending tone TTL for ${toneKeysToExtend.length} rate-limited topic(s): ${toneKeysToExtend.map((k) => k.split(':').pop()).join(', ')}`);
+    await extendExistingTtl(toneKeysToExtend, TIMELINE_TTL);
+  }
+  if (volKeysToExtend.length > 0) {
+    console.log(`  Extending vol TTL for ${volKeysToExtend.length} rate-limited topic(s): ${volKeysToExtend.map((k) => k.split(':').pop()).join(', ')}`);
+    await extendExistingTtl(volKeysToExtend, TIMELINE_TTL);
   }
 }
 


### PR DESCRIPTION
## Summary
`seed-gdelt-intel.mjs` writes per-topic `gdelt:intel:tone:<topic>` and `gdelt:intel:vol:<topic>` extras via `afterPublish`, with `TIMELINE_TTL=43200` (12h, exactly 2x the 6h cron cadence = zero buffer). When GDELT rate-limits a specific topic's TimelineTone or TimelineVol sub-fetch, `_tone` / `_vol` arrive empty and the existing code silently skipped `writeExtraKey`, leaving the last successful key to expire mid-cycle with no health signal (only the canonical key is tracked in `api/health.js`).

## Observed failure
Railway log 2026-04-11 15:40 UTC (derived-signals bundle):
```
[Cross-Source-Signals]   Missing keys (4): supply_chain:shipping:v2, gdelt:intel:tone:military, gdelt:intel:tone:nuclear, gdelt:intel:tone:maritime
[Cross-Source-Signals]   Detected 0 composite escalation zone(s)
```

Notice 3 of 6 topics missing but not all, confirms partial GDELT rate-limiting, not a total outage.

## Fix
When `_tone` / `_vol` is empty for a topic, call `extendExistingTtl([key], TIMELINE_TTL)` on the existing Redis key. `extendExistingTtl` uses `EXPIRE` via the Upstash pipeline (already defined in `scripts/_seed-utils.mjs`), which is a no-op if the key is already gone and already warn-logs that case. This mirrors the existing article-reuse pattern in the same seeder (lines ~149-156), but for tone/vol which cannot be reused from the canonical snapshot because `publishTransform` strips `_tone`/`_vol` before persisting the canonical key.

Companion PR: #2955 fixes the parallel `supply_chain:shipping:v2` issue (TTL 1h under a 6h cron).

## Test plan
- [ ] After deploy, when GDELT rate-limits a topic, Railway log shows `Extending tone TTL for N rate-limited topic(s): ...` instead of silent failure
- [ ] `gdelt:intel:tone:<topic>` stays present across cron cycles even during partial rate-limits
- [ ] Next derived-signals bundle run reports 22 or 23 of 23 source keys populated (up from 19/23)
- [ ] Cross-source-signals detects composite escalation zones when conditions warrant