### PR TITLE
fix(i18n): flatten panels.wsbTickerScanner to string

### DIFF
--- a/src/components/WsbTickerScannerPanel.ts
+++ b/src/components/WsbTickerScannerPanel.ts
@@ -39,8 +39,8 @@ export class WsbTickerScannerPanel extends Panel {
   constructor() {
     super({
       id: 'wsb-ticker-scanner',
-      title: t('panels.wsbTickerScanner.title') || 'WSB Ticker Scanner',
-      infoTooltip: t('components.wsbTickerScanner.infoTooltip') || '<strong>WSB Ticker Scanner</strong> Real-time ticker mentions from r/wallstreetbets, r/stocks, and r/investing. Ranked by mention frequency and engagement.',
+      title: t('panels.wsbTickerScanner'),
+      infoTooltip: t('components.wsbTickerScanner.infoTooltip'),
       showCount: true,
       premium: 'locked',
     });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -319,10 +319,7 @@
     "etfFlows": "BTC ETF Tracker",
     "stablecoins": "Stablecoins",
     "deduction": "Deduct Situation",
-    "wsbTickerScanner": {
-      "title": "WSB Ticker Scanner",
-      "tooltip": "Real-time ticker mentions from r/wallstreetbets, r/stocks, and r/investing ranked by frequency and engagement."
-    },
+    "wsbTickerScanner": "WSB Ticker Scanner",
     "ucdpEvents": "Armed Conflict Events",
     "giving": "Global Giving",
     "displacement": "UNHCR Displacement",


### PR DESCRIPTION
## Summary
- PR #2916 added `panels.wsbTickerScanner` as a nested `{title, tooltip}` object in `src/locales/en.json`, but siblings at that level (`macroSignals`, `etfFlows`, …) are plain strings.
- `getLocalizedPanelName()` in `src/app/panel-layout.ts:2098` dynamically calls `t(\`panels.${camelCaseId}\`)` for every panel, which resolved to an object for WSB Ticker Scanner and triggered i18next's "returned an object instead of string" warning in the UI.
- Same dynamic lookup exists in `src/settings-window.ts:19` and `src/app/event-handlers.ts:1538`.

## Fix
- Flatten `panels.wsbTickerScanner` in `en.json` to `"WSB Ticker Scanner"` (tooltip is already duplicated at `components.wsbTickerScanner.infoTooltip`).
- `WsbTickerScannerPanel.ts`: `t('panels.wsbTickerScanner.title')` → `t('panels.wsbTickerScanner')`, matching `MacroSignalsPanel` / `ETFFlowsPanel`.
- Only `en.json` needs the change; other locales fall back to en.

## Test plan
- [ ] Open the app with WSB Ticker Scanner panel enabled; confirm no i18next "returned an object" warning.
- [ ] Drag-reorder panels / open settings window; confirm localized panel name shows "WSB Ticker Scanner" (verifies `getLocalizedPanelName` path).
- [ ] Panel header tooltip still renders correctly.