### PR TITLE
Phase 2 PR1: Regional state-change alerts from diff engine

### DIFF
--- a/scripts/regional-snapshot/alert-emitter.mjs
+++ b/scripts/regional-snapshot/alert-emitter.mjs
@@ -221,38 +221,118 @@ async function upstashLpush(url, token, key, value) {
   return typeof json?.result === 'number';
 }
 
+async function upstashDel(url, token, key) {
+  try {
+    const resp = await fetch(
+      `${url}/del/${encodeURIComponent(key)}`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(5_000),
+      },
+    );
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Default publisher. Walks the same SET-NX-then-LPUSH path as ais-relay.cjs
- * publishNotificationEvent(). Never throws; returns false on any failure or
- * dedup hit.
+ * Redis operations needed by the publish-with-rollback path. Callers
+ * (including tests) inject these so the orchestration logic is fully
+ * testable without fetch stubs.
+ *
+ * @typedef {{
+ *   setNx: (key: string, ttlSeconds: number) => Promise<boolean>,
+ *   lpush: (key: string, value: string) => Promise<boolean>,
+ *   del: (key: string) => Promise<boolean>,
+ * }} RedisPublishOps
+ */
+
+/**
+ * Publish one event through injected Redis operations with dedup-rollback
+ * on LPUSH failure. Exported for unit tests — the default publisher below
+ * is a thin wrapper that builds real Upstash REST calls and delegates here.
+ *
+ * Flow:
+ *   1. SET NX dedup key (6h TTL). If already set → dedup hit, return false.
+ *   2. LPUSH event onto wm:events:queue.
+ *   3. If LPUSH fails → DEL the dedup key so the next cron cycle can retry.
+ *      Otherwise the alert would be silently suppressed for 6h even though
+ *      nothing was enqueued. Matches the rollback path in ais-relay.cjs
+ *      publishNotificationEvent().
+ *
+ * Never throws. Returns an outcome object so tests can assert exactly
+ * which branch fired without relying on log scraping.
+ *
+ * @param {object} event
+ * @param {RedisPublishOps} ops
+ * @returns {Promise<{ enqueued: boolean, dedupHit: boolean, rolledBack: boolean }>}
+ */
+export async function publishEventWithOps(event, ops) {
+  const outcome = { enqueued: false, dedupHit: false, rolledBack: false };
+  try {
+    const dedupKey = buildDedupKey(event);
+    const isNew = await ops.setNx(dedupKey, DEDUP_TTL_SECONDS);
+    if (!isNew) {
+      outcome.dedupHit = true;
+      const title = String(event.payload?.title ?? '');
+      console.log(`[alerts] dedup skip: ${event.eventType} — ${title.slice(0, 60)}`);
+      return outcome;
+    }
+    const msg = JSON.stringify({ ...event, publishedAt: Date.now() });
+    const ok = await ops.lpush('wm:events:queue', msg);
+    if (ok) {
+      outcome.enqueued = true;
+      const title = String(event.payload?.title ?? '');
+      console.log(`[alerts] queued ${event.severity} ${event.eventType}: ${title.slice(0, 60)}`);
+      return outcome;
+    }
+    // LPUSH failed — roll back the dedup key so the next cron cycle can
+    // retry this alert instead of suppressing it for the full 6h window.
+    console.warn(`[alerts] LPUSH failed for ${event.eventType} — rolling back dedup key`);
+    try {
+      await ops.del(dedupKey);
+    } catch {
+      // Even rollback failed — ignore; next retry will still suppress this
+      // alert for 6h, but we logged the LPUSH failure so operators can see.
+    }
+    outcome.rolledBack = true;
+    return outcome;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[alerts] publish failed for ${event?.eventType}: ${msg}`);
+    return outcome;
+  }
+}
+
+/**
+ * Default publisher. Walks the same SET-NX → LPUSH → DEL-on-failure path
+ * as ais-relay.cjs publishNotificationEvent(). Thin wrapper over
+ * publishEventWithOps that binds real Upstash REST calls.
  *
  * @param {object} event
  * @returns {Promise<boolean>} true when enqueued, false on dedup or failure
  */
 async function defaultPublishEvent(event) {
+  let url;
+  let token;
   try {
-    const { url, token } = getRedisCredentials();
-    const dedupKey = buildDedupKey(event);
-    const isNew = await upstashSetNx(url, token, dedupKey, DEDUP_TTL_SECONDS);
-    if (!isNew) {
-      const title = String(event.payload?.title ?? '');
-      console.log(`[alerts] dedup skip: ${event.eventType} — ${title.slice(0, 60)}`);
-      return false;
-    }
-    const msg = JSON.stringify({ ...event, publishedAt: Date.now() });
-    const ok = await upstashLpush(url, token, 'wm:events:queue', msg);
-    if (ok) {
-      const title = String(event.payload?.title ?? '');
-      console.log(`[alerts] queued ${event.severity} ${event.eventType}: ${title.slice(0, 60)}`);
-    } else {
-      console.warn(`[alerts] LPUSH failed for ${event.eventType}`);
-    }
-    return ok;
+    const creds = getRedisCredentials();
+    url = creds.url;
+    token = creds.token;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(`[alerts] publish failed for ${event?.eventType}: ${msg}`);
     return false;
   }
+  const ops = /** @type {RedisPublishOps} */ ({
+    setNx: (key, ttl) => upstashSetNx(url, token, key, ttl),
+    lpush: (key, value) => upstashLpush(url, token, key, value),
+    del: (key) => upstashDel(url, token, key),
+  });
+  const outcome = await publishEventWithOps(event, ops);
+  return outcome.enqueued;
 }
 
 // ── Public: emit alerts for one region snapshot ──────────────────────────────

--- a/scripts/regional-snapshot/alert-emitter.mjs
+++ b/scripts/regional-snapshot/alert-emitter.mjs
@@ -1,0 +1,289 @@
+// @ts-check
+// Regional Intelligence state-change alert emitter.
+//
+// Phase 2 PR1 — reads the SnapshotDiff produced by diffRegionalSnapshot()
+// and enqueues one notification event per meaningful state change onto the
+// existing wm:events:queue Redis list consumed by notification-relay.cjs.
+//
+// Emits on 4 event types:
+//   regional_regime_shift      — diff.regime_changed set
+//   regional_trigger_activation — one per entry in diff.trigger_activations
+//   regional_corridor_break    — one per entry in diff.corridor_breaks
+//   regional_buffer_failure    — one per entry in diff.buffer_failures
+//
+// Scenario jumps and leverage shifts are intentionally NOT emitted —
+// probability fluctuations are noisy and not actionable as alerts.
+//
+// Severity mapping:
+//   - critical when regime shifts to escalation_ladder or fragmentation_risk
+//   - critical for every corridor_break
+//   - high for other regime shifts, trigger activations, buffer failures
+//   - nothing below high is emitted
+//
+// Best-effort: `emitRegionalAlerts` never throws. Each event publisher
+// call is guarded independently, so one failure cannot block other events
+// or the snapshot persist that called it. The default publisher uses the
+// same Upstash REST pattern as ais-relay.cjs:
+//   1. SET NX on wm:notif:scan-dedup:{eventType}:{hash} (6h TTL)
+//   2. LPUSH on wm:events:queue with JSON {eventType, payload, severity,
+//      publishedAt}
+//
+// The `publishEvent` function is dependency-injectable via opts so unit
+// tests can exercise the full event-building + dedup pipeline without
+// touching the network.
+
+import { getRedisCredentials } from '../_seed-utils.mjs';
+
+// ── Event type constants ─────────────────────────────────────────────────────
+
+const EVENT_REGIME_SHIFT = 'regional_regime_shift';
+const EVENT_TRIGGER_ACTIVATION = 'regional_trigger_activation';
+const EVENT_CORRIDOR_BREAK = 'regional_corridor_break';
+const EVENT_BUFFER_FAILURE = 'regional_buffer_failure';
+
+/** Regime labels that upgrade a regime shift from high to critical severity. */
+const CRITICAL_REGIME_LABELS = new Set(['escalation_ladder', 'fragmentation_risk']);
+
+/** Dedup TTL for the notification queue. Matches the 6h snapshot cron cadence. */
+const DEDUP_TTL_SECONDS = 6 * 60 * 60;
+
+// ── Humanization helpers (pure) ──────────────────────────────────────────────
+
+function humanRegime(label) {
+  return String(label ?? '').replace(/_/g, ' ') || 'unknown';
+}
+
+function humanAxis(axis) {
+  return String(axis ?? '').replace(/_/g, ' ');
+}
+
+// ── Pure event builders ──────────────────────────────────────────────────────
+
+/**
+ * @param {{id: string, label: string}} region
+ * @param {import('../../shared/regions.types.js').RegionalSnapshot} snapshot
+ * @param {{from: string, to: string}} regimeChange
+ */
+function buildRegimeShiftEvent(region, snapshot, regimeChange) {
+  const severity = CRITICAL_REGIME_LABELS.has(regimeChange.to) ? 'critical' : 'high';
+  const fromLabel = regimeChange.from || 'none';
+  return {
+    eventType: EVENT_REGIME_SHIFT,
+    severity,
+    payload: {
+      title: `${region.label}: regime ${humanRegime(fromLabel)} → ${humanRegime(regimeChange.to)}`,
+      region_id: region.id,
+      snapshot_id: snapshot.meta?.snapshot_id ?? '',
+      triggered_at: snapshot.generated_at,
+      details: { from: fromLabel, to: regimeChange.to },
+    },
+  };
+}
+
+/**
+ * @param {{id: string, label: string}} region
+ * @param {import('../../shared/regions.types.js').RegionalSnapshot} snapshot
+ * @param {{id: string, description: string}[]} activations
+ */
+function buildTriggerActivationEvents(region, snapshot, activations) {
+  return (activations ?? []).map((t) => ({
+    eventType: EVENT_TRIGGER_ACTIVATION,
+    severity: 'high',
+    payload: {
+      title: `${region.label}: trigger ${t.id}${t.description ? ` — ${t.description}` : ''}`,
+      region_id: region.id,
+      snapshot_id: snapshot.meta?.snapshot_id ?? '',
+      triggered_at: snapshot.generated_at,
+      details: { trigger_id: t.id, description: t.description ?? '' },
+    },
+  }));
+}
+
+/**
+ * @param {{id: string, label: string}} region
+ * @param {import('../../shared/regions.types.js').RegionalSnapshot} snapshot
+ * @param {{corridor_id: string, from: string, to: string}[]} breaks
+ */
+function buildCorridorBreakEvents(region, snapshot, breaks) {
+  return (breaks ?? []).map((b) => ({
+    eventType: EVENT_CORRIDOR_BREAK,
+    severity: 'critical',
+    payload: {
+      title: `${region.label}: corridor degraded — ${b.corridor_id} (${b.from} → ${b.to})`,
+      region_id: region.id,
+      snapshot_id: snapshot.meta?.snapshot_id ?? '',
+      triggered_at: snapshot.generated_at,
+      details: { corridor_id: b.corridor_id, from: b.from, to: b.to },
+    },
+  }));
+}
+
+/**
+ * @param {{id: string, label: string}} region
+ * @param {import('../../shared/regions.types.js').RegionalSnapshot} snapshot
+ * @param {{axis: string, from: number, to: number}[]} failures
+ */
+function buildBufferFailureEvents(region, snapshot, failures) {
+  return (failures ?? []).map((f) => ({
+    eventType: EVENT_BUFFER_FAILURE,
+    severity: 'high',
+    payload: {
+      title: `${region.label}: buffer failure — ${humanAxis(f.axis)} ${f.from.toFixed(2)} → ${f.to.toFixed(2)}`,
+      region_id: region.id,
+      snapshot_id: snapshot.meta?.snapshot_id ?? '',
+      triggered_at: snapshot.generated_at,
+      details: { axis: f.axis, from: f.from, to: f.to },
+    },
+  }));
+}
+
+// ── Public: build all events from a diff (pure) ──────────────────────────────
+
+/**
+ * Pure event builder. Returns every alert event that should be emitted for
+ * a (region, snapshot, diff) triple in stable order: regime shift first,
+ * then trigger activations, then corridor breaks, then buffer failures.
+ *
+ * @param {{id: string, label: string}} region
+ * @param {import('../../shared/regions.types.js').RegionalSnapshot} snapshot
+ * @param {import('../../shared/regions.types.js').SnapshotDiff} diff
+ * @returns {object[]}
+ */
+export function buildAlertEvents(region, snapshot, diff) {
+  if (!region || !snapshot || !diff) return [];
+  const events = [];
+  if (diff.regime_changed) {
+    events.push(buildRegimeShiftEvent(region, snapshot, diff.regime_changed));
+  }
+  events.push(...buildTriggerActivationEvents(region, snapshot, diff.trigger_activations));
+  events.push(...buildCorridorBreakEvents(region, snapshot, diff.corridor_breaks));
+  events.push(...buildBufferFailureEvents(region, snapshot, diff.buffer_failures));
+  return events;
+}
+
+// ── Dedup key derivation (pure, exported for tests) ──────────────────────────
+
+/**
+ * FNV-1a-ish 32-bit hash. Matches the `notifySimpleHash` style used in
+ * ais-relay.cjs so dedup keys don't collide across emitters.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+export function simpleHash(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    h = ((h << 5) - h + str.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(36);
+}
+
+/**
+ * Build the Upstash dedup key for an event. Exposed so tests can assert the
+ * exact key shape without reaching into the default publisher.
+ *
+ * @param {{eventType: string, payload: {title?: string}}} event
+ * @returns {string}
+ */
+export function buildDedupKey(event) {
+  const title = String(event.payload?.title ?? '');
+  return `wm:notif:scan-dedup:${event.eventType}:${simpleHash(`${event.eventType}:${title}`)}`;
+}
+
+// ── Default Upstash publisher ────────────────────────────────────────────────
+
+async function upstashSetNx(url, token, key, ttlSeconds) {
+  // Path-based REST call: /set/{key}/{value}?NX=true&EX={ttl}
+  const resp = await fetch(
+    `${url}/set/${encodeURIComponent(key)}/1?NX=true&EX=${ttlSeconds}`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5_000),
+    },
+  );
+  if (!resp.ok) return false;
+  const json = await resp.json().catch(() => null);
+  return json?.result === 'OK';
+}
+
+async function upstashLpush(url, token, key, value) {
+  const resp = await fetch(
+    `${url}/lpush/${encodeURIComponent(key)}/${encodeURIComponent(value)}`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5_000),
+    },
+  );
+  if (!resp.ok) return false;
+  const json = await resp.json().catch(() => null);
+  return typeof json?.result === 'number';
+}
+
+/**
+ * Default publisher. Walks the same SET-NX-then-LPUSH path as ais-relay.cjs
+ * publishNotificationEvent(). Never throws; returns false on any failure or
+ * dedup hit.
+ *
+ * @param {object} event
+ * @returns {Promise<boolean>} true when enqueued, false on dedup or failure
+ */
+async function defaultPublishEvent(event) {
+  try {
+    const { url, token } = getRedisCredentials();
+    const dedupKey = buildDedupKey(event);
+    const isNew = await upstashSetNx(url, token, dedupKey, DEDUP_TTL_SECONDS);
+    if (!isNew) {
+      const title = String(event.payload?.title ?? '');
+      console.log(`[alerts] dedup skip: ${event.eventType} — ${title.slice(0, 60)}`);
+      return false;
+    }
+    const msg = JSON.stringify({ ...event, publishedAt: Date.now() });
+    const ok = await upstashLpush(url, token, 'wm:events:queue', msg);
+    if (ok) {
+      const title = String(event.payload?.title ?? '');
+      console.log(`[alerts] queued ${event.severity} ${event.eventType}: ${title.slice(0, 60)}`);
+    } else {
+      console.warn(`[alerts] LPUSH failed for ${event.eventType}`);
+    }
+    return ok;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[alerts] publish failed for ${event?.eventType}: ${msg}`);
+    return false;
+  }
+}
+
+// ── Public: emit alerts for one region snapshot ──────────────────────────────
+
+/**
+ * Emit all state-change alerts for one region's newly-persisted snapshot.
+ * Ship-on-every-diff, best-effort, never throws. Returns the count of
+ * events successfully enqueued and the full list that was considered
+ * (so callers can log / telemetry independently of the queue result).
+ *
+ * @param {{id: string, label: string}} region
+ * @param {import('../../shared/regions.types.js').RegionalSnapshot} snapshot
+ * @param {import('../../shared/regions.types.js').SnapshotDiff} diff
+ * @param {{publishEvent?: (event: object) => Promise<boolean>}} [opts]
+ * @returns {Promise<{enqueued: number, events: object[]}>}
+ */
+export async function emitRegionalAlerts(region, snapshot, diff, opts = {}) {
+  if (!region || !snapshot || !diff) return { enqueued: 0, events: [] };
+  const events = buildAlertEvents(region, snapshot, diff);
+  if (events.length === 0) return { enqueued: 0, events };
+
+  const publisher = opts.publishEvent ?? defaultPublishEvent;
+  let enqueued = 0;
+  for (const event of events) {
+    try {
+      const ok = await publisher(event);
+      if (ok) enqueued += 1;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[alerts] ${event.eventType} publish threw: ${msg}`);
+    }
+  }
+  return { enqueued, events };
+}

--- a/scripts/seed-regional-snapshots.mjs
+++ b/scripts/seed-regional-snapshots.mjs
@@ -43,6 +43,7 @@ import { persistSnapshot, readLatestSnapshot } from './regional-snapshot/persist
 import { ALL_INPUT_KEYS } from './regional-snapshot/freshness.mjs';
 import { generateSnapshotId } from './regional-snapshot/_helpers.mjs';
 import { generateRegionalNarrative, emptyNarrative } from './regional-snapshot/narrative.mjs';
+import { emitRegionalAlerts } from './regional-snapshot/alert-emitter.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -210,7 +211,7 @@ async function main() {
 
   for (const region of REGIONS) {
     try {
-      const { snapshot } = await computeSnapshot(region.id, sources);
+      const { snapshot, diff } = await computeSnapshot(region.id, sources);
       const result = await persistSnapshot(snapshot);
       if (result.persisted) {
         persisted += 1;
@@ -222,6 +223,19 @@ async function main() {
           trigger_reason: snapshot.meta.trigger_reason,
         });
         console.log(`[${region.id}] persisted regime=${snapshot.regime.label} confidence=${snapshot.meta.snapshot_confidence} triggers=${snapshot.triggers.active.length} reason=${snapshot.meta.trigger_reason}`);
+
+        // Emit state-change alerts for this diff. Best-effort — never blocks
+        // or throws out of the main loop. Alerts are deduped on a 6h window
+        // by wm:notif:scan-dedup:{eventType}:{hash}, matching the cron cadence.
+        try {
+          const alertResult = await emitRegionalAlerts(region, snapshot, diff);
+          if (alertResult.events.length > 0) {
+            console.log(`[${region.id}] alerts: ${alertResult.enqueued}/${alertResult.events.length} enqueued`);
+          }
+        } catch (alertErr) {
+          const alertMsg = /** @type {any} */ (alertErr)?.message ?? alertErr;
+          console.warn(`[${region.id}] alert emitter threw: ${alertMsg}`);
+        }
       } else {
         skipped += 1;
         console.log(`[${region.id}] skipped: ${result.reason}`);

--- a/tests/regional-snapshot-alerts.test.mjs
+++ b/tests/regional-snapshot-alerts.test.mjs
@@ -1,0 +1,410 @@
+// Tests for the Regional Intelligence state-change alert emitter (Phase 2 PR1).
+// Pure-function + injectable-publisher unit tests; no network. Run via:
+//   npm run test:data
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildAlertEvents,
+  buildDedupKey,
+  simpleHash,
+  emitRegionalAlerts,
+} from '../scripts/regional-snapshot/alert-emitter.mjs';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ────────────────────────────────────────────────────────────────────────────
+
+const menaRegion = { id: 'mena', label: 'Middle East & North Africa' };
+const eastAsiaRegion = { id: 'east-asia', label: 'East Asia & Pacific' };
+
+function snapshotFixture(overrides = {}) {
+  return {
+    region_id: 'mena',
+    generated_at: 1_700_000_000_000,
+    meta: {
+      snapshot_id: 'snap-mena-1',
+      model_version: '0.1.0',
+      scoring_version: '1.0.0',
+      geography_version: '1.0.0',
+      snapshot_confidence: 0.9,
+      missing_inputs: [],
+      stale_inputs: [],
+      valid_until: 0,
+      trigger_reason: 'scheduled_6h',
+      narrative_provider: '',
+      narrative_model: '',
+    },
+    regime: { label: 'coercive_stalemate', previous_label: 'calm', transitioned_at: 0, transition_driver: '' },
+    balance: {
+      coercive_pressure: 0.5,
+      domestic_fragility: 0.5,
+      capital_stress: 0.5,
+      energy_vulnerability: 0.5,
+      alliance_cohesion: 0.5,
+      maritime_access: 0.5,
+      energy_leverage: 0.5,
+      net_balance: 0,
+      pressures: [],
+      buffers: [],
+    },
+    actors: [],
+    leverage_edges: [],
+    scenario_sets: [],
+    transmission_paths: [],
+    triggers: { active: [], watching: [], dormant: [] },
+    mobility: { airspace: [], flight_corridors: [], airports: [], reroute_intensity: 0, notam_closures: [] },
+    evidence: [],
+    narrative: {
+      situation: { text: '', evidence_ids: [] },
+      balance_assessment: { text: '', evidence_ids: [] },
+      outlook_24h: { text: '', evidence_ids: [] },
+      outlook_7d: { text: '', evidence_ids: [] },
+      outlook_30d: { text: '', evidence_ids: [] },
+      watch_items: [],
+    },
+    ...overrides,
+  };
+}
+
+function emptyDiff(overrides = {}) {
+  return {
+    regime_changed: null,
+    scenario_jumps: [],
+    trigger_activations: [],
+    trigger_deactivations: [],
+    corridor_breaks: [],
+    leverage_shifts: [],
+    buffer_failures: [],
+    reroute_waves: null,
+    mobility_disruptions: [],
+    ...overrides,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// buildAlertEvents — pure event builder
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('buildAlertEvents', () => {
+  it('returns [] when the diff has no meaningful changes', () => {
+    const events = buildAlertEvents(menaRegion, snapshotFixture(), emptyDiff());
+    assert.deepEqual(events, []);
+  });
+
+  it('emits a regime_shift event with high severity for non-critical labels', () => {
+    const events = buildAlertEvents(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({ regime_changed: { from: 'calm', to: 'coercive_stalemate' } }),
+    );
+    assert.equal(events.length, 1);
+    assert.equal(events[0].eventType, 'regional_regime_shift');
+    assert.equal(events[0].severity, 'high');
+    assert.match(events[0].payload.title, /calm → coercive stalemate/);
+    assert.equal(events[0].payload.region_id, 'mena');
+    assert.equal(events[0].payload.snapshot_id, 'snap-mena-1');
+  });
+
+  it('marks regime_shift critical when target is escalation_ladder', () => {
+    const events = buildAlertEvents(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({ regime_changed: { from: 'stressed_equilibrium', to: 'escalation_ladder' } }),
+    );
+    assert.equal(events[0].severity, 'critical');
+  });
+
+  it('marks regime_shift critical when target is fragmentation_risk', () => {
+    const events = buildAlertEvents(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({ regime_changed: { from: 'calm', to: 'fragmentation_risk' } }),
+    );
+    assert.equal(events[0].severity, 'critical');
+  });
+
+  it('labels "none" when previous regime is empty (first snapshot)', () => {
+    const events = buildAlertEvents(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({ regime_changed: { from: '', to: 'coercive_stalemate' } }),
+    );
+    assert.match(events[0].payload.title, /none → coercive stalemate/);
+  });
+
+  it('emits one trigger_activation event per activated trigger', () => {
+    const events = buildAlertEvents(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({
+        trigger_activations: [
+          { id: 'mena_coercive_high', description: 'Coercive pressure crossed 0.7' },
+          { id: 'hormuz_transit_drop', description: 'Transit volume fell 30%' },
+        ],
+      }),
+    );
+    assert.equal(events.length, 2);
+    assert.equal(events[0].eventType, 'regional_trigger_activation');
+    assert.equal(events[0].severity, 'high');
+    assert.match(events[0].payload.title, /mena_coercive_high/);
+    assert.equal(events[1].payload.details.trigger_id, 'hormuz_transit_drop');
+  });
+
+  it('trigger_activation with empty description still renders a clean title', () => {
+    const events = buildAlertEvents(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({ trigger_activations: [{ id: 'raw_trigger', description: '' }] }),
+    );
+    assert.match(events[0].payload.title, /trigger raw_trigger/);
+    assert.doesNotMatch(events[0].payload.title, /—$/); // no trailing em dash
+  });
+
+  it('emits one corridor_break event per break with critical severity', () => {
+    const events = buildAlertEvents(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({
+        corridor_breaks: [
+          { corridor_id: 'aggregate', from: '0.80', to: '0.45' },
+        ],
+      }),
+    );
+    assert.equal(events.length, 1);
+    assert.equal(events[0].eventType, 'regional_corridor_break');
+    assert.equal(events[0].severity, 'critical');
+    assert.match(events[0].payload.title, /aggregate.*0\.80.*0\.45/);
+  });
+
+  it('emits one buffer_failure event per axis with high severity', () => {
+    const events = buildAlertEvents(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({
+        buffer_failures: [
+          { axis: 'alliance_cohesion', from: 0.70, to: 0.40 },
+          { axis: 'maritime_access', from: 0.90, to: 0.50 },
+        ],
+      }),
+    );
+    assert.equal(events.length, 2);
+    assert.equal(events[0].eventType, 'regional_buffer_failure');
+    assert.equal(events[0].severity, 'high');
+    assert.match(events[0].payload.title, /alliance cohesion.*0\.70.*0\.40/);
+  });
+
+  it('skips scenario_jumps and leverage_shifts (intentionally not emitted)', () => {
+    const events = buildAlertEvents(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({
+        scenario_jumps: [{ horizon: '24h', lane: 'escalation', from: 0.2, to: 0.5 }],
+        leverage_shifts: [{ actor_id: 'IR', from: 0.5, to: 0.8, delta: 0.3 }],
+      }),
+    );
+    assert.deepEqual(events, []);
+  });
+
+  it('returns events in stable order: regime → triggers → corridors → buffers', () => {
+    const events = buildAlertEvents(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({
+        regime_changed: { from: 'calm', to: 'coercive_stalemate' },
+        trigger_activations: [{ id: 'trig1', description: '' }],
+        corridor_breaks: [{ corridor_id: 'hormuz', from: '0.9', to: '0.4' }],
+        buffer_failures: [{ axis: 'alliance_cohesion', from: 0.7, to: 0.4 }],
+      }),
+    );
+    assert.equal(events[0].eventType, 'regional_regime_shift');
+    assert.equal(events[1].eventType, 'regional_trigger_activation');
+    assert.equal(events[2].eventType, 'regional_corridor_break');
+    assert.equal(events[3].eventType, 'regional_buffer_failure');
+  });
+
+  it('returns [] for null/undefined arguments (defensive)', () => {
+    assert.deepEqual(buildAlertEvents(null, snapshotFixture(), emptyDiff()), []);
+    assert.deepEqual(buildAlertEvents(menaRegion, null, emptyDiff()), []);
+    assert.deepEqual(buildAlertEvents(menaRegion, snapshotFixture(), null), []);
+  });
+
+  it('carries region.label into the title verbatim', () => {
+    const events = buildAlertEvents(
+      eastAsiaRegion,
+      snapshotFixture({ region_id: 'east-asia' }),
+      emptyDiff({ regime_changed: { from: 'calm', to: 'coercive_stalemate' } }),
+    );
+    assert.ok(events[0].payload.title.startsWith('East Asia & Pacific:'));
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Dedup key derivation
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('buildDedupKey + simpleHash', () => {
+  it('produces the expected key shape', () => {
+    const key = buildDedupKey({
+      eventType: 'regional_regime_shift',
+      payload: { title: 'MENA: regime calm → coercive stalemate' },
+    });
+    assert.match(key, /^wm:notif:scan-dedup:regional_regime_shift:[a-z0-9]+$/);
+  });
+
+  it('produces the same hash for the same title + eventType', () => {
+    const a = buildDedupKey({ eventType: 'x', payload: { title: 'hello' } });
+    const b = buildDedupKey({ eventType: 'x', payload: { title: 'hello' } });
+    assert.equal(a, b);
+  });
+
+  it('produces different hashes for different titles', () => {
+    const a = buildDedupKey({ eventType: 'x', payload: { title: 'one' } });
+    const b = buildDedupKey({ eventType: 'x', payload: { title: 'two' } });
+    assert.notEqual(a, b);
+  });
+
+  it('produces different hashes for the same title under different eventTypes', () => {
+    const a = buildDedupKey({ eventType: 'x', payload: { title: 'hi' } });
+    const b = buildDedupKey({ eventType: 'y', payload: { title: 'hi' } });
+    assert.notEqual(a, b);
+  });
+
+  it('handles missing payload.title safely', () => {
+    const key = buildDedupKey({ eventType: 'x', payload: {} });
+    assert.match(key, /^wm:notif:scan-dedup:x:/);
+  });
+
+  it('simpleHash returns a non-empty base36 string for any input', () => {
+    assert.ok(simpleHash('').length > 0);
+    assert.ok(simpleHash('a').length > 0);
+    assert.ok(simpleHash('a much longer input string').length > 0);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// emitRegionalAlerts — integration with injected publisher
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('emitRegionalAlerts', () => {
+  function mockPublisher() {
+    const calls = [];
+    const publish = async (event) => {
+      calls.push(event);
+      return true;
+    };
+    return { publish, calls };
+  }
+
+  it('no-ops on an empty diff without calling the publisher', async () => {
+    const pub = mockPublisher();
+    const result = await emitRegionalAlerts(menaRegion, snapshotFixture(), emptyDiff(), {
+      publishEvent: pub.publish,
+    });
+    assert.equal(result.enqueued, 0);
+    assert.equal(result.events.length, 0);
+    assert.equal(pub.calls.length, 0);
+  });
+
+  it('enqueues each event through the injected publisher', async () => {
+    const pub = mockPublisher();
+    const result = await emitRegionalAlerts(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({
+        regime_changed: { from: 'calm', to: 'coercive_stalemate' },
+        trigger_activations: [{ id: 'mena_coercive_high', description: 'x' }],
+      }),
+      { publishEvent: pub.publish },
+    );
+    assert.equal(result.enqueued, 2);
+    assert.equal(pub.calls.length, 2);
+    assert.equal(pub.calls[0].eventType, 'regional_regime_shift');
+    assert.equal(pub.calls[1].eventType, 'regional_trigger_activation');
+  });
+
+  it('counts only successful enqueues when the publisher returns false', async () => {
+    let n = 0;
+    const publish = async () => {
+      n += 1;
+      return n === 1; // only the first succeeds
+    };
+    const result = await emitRegionalAlerts(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({
+        regime_changed: { from: 'calm', to: 'coercive_stalemate' },
+        buffer_failures: [{ axis: 'alliance_cohesion', from: 0.7, to: 0.4 }],
+      }),
+      { publishEvent: publish },
+    );
+    assert.equal(result.enqueued, 1);
+    assert.equal(result.events.length, 2);
+  });
+
+  it('swallows publisher exceptions and continues the loop', async () => {
+    let n = 0;
+    const publish = async () => {
+      n += 1;
+      if (n === 1) throw new Error('upstream down');
+      return true;
+    };
+    const result = await emitRegionalAlerts(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({
+        regime_changed: { from: 'calm', to: 'coercive_stalemate' },
+        trigger_activations: [{ id: 't1', description: '' }],
+      }),
+      { publishEvent: publish },
+    );
+    // First event threw, second succeeded → enqueued === 1
+    assert.equal(result.enqueued, 1);
+    assert.equal(result.events.length, 2);
+  });
+
+  it('returns empty result when region/snapshot/diff are missing', async () => {
+    const pub = mockPublisher();
+    const a = await emitRegionalAlerts(null, snapshotFixture(), emptyDiff(), { publishEvent: pub.publish });
+    const b = await emitRegionalAlerts(menaRegion, null, emptyDiff(), { publishEvent: pub.publish });
+    const c = await emitRegionalAlerts(menaRegion, snapshotFixture(), null, { publishEvent: pub.publish });
+    for (const r of [a, b, c]) {
+      assert.equal(r.enqueued, 0);
+      assert.deepEqual(r.events, []);
+    }
+    assert.equal(pub.calls.length, 0);
+  });
+
+  it('works end-to-end on a realistic escalation scenario', async () => {
+    const pub = mockPublisher();
+    const result = await emitRegionalAlerts(
+      menaRegion,
+      snapshotFixture(),
+      emptyDiff({
+        regime_changed: { from: 'stressed_equilibrium', to: 'escalation_ladder' },
+        trigger_activations: [
+          { id: 'mena_coercive_high', description: 'Coercive pressure > 0.7' },
+          { id: 'hormuz_transit_drop', description: 'Transit volume < 70% baseline' },
+        ],
+        corridor_breaks: [{ corridor_id: 'hormuz', from: '0.90', to: '0.45' }],
+        buffer_failures: [
+          { axis: 'maritime_access', from: 0.90, to: 0.45 },
+          { axis: 'alliance_cohesion', from: 0.70, to: 0.45 },
+        ],
+      }),
+      { publishEvent: pub.publish },
+    );
+    assert.equal(result.enqueued, 6);
+    // regime_shift should be critical (target = escalation_ladder)
+    assert.equal(pub.calls[0].severity, 'critical');
+    // corridor_break should always be critical
+    const corridorEvent = pub.calls.find((e) => e.eventType === 'regional_corridor_break');
+    assert.equal(corridorEvent.severity, 'critical');
+    // Every event carries the same region_id + snapshot_id
+    for (const ev of pub.calls) {
+      assert.equal(ev.payload.region_id, 'mena');
+      assert.equal(ev.payload.snapshot_id, 'snap-mena-1');
+    }
+  });
+});

--- a/tests/regional-snapshot-alerts.test.mjs
+++ b/tests/regional-snapshot-alerts.test.mjs
@@ -10,6 +10,7 @@ import {
   buildDedupKey,
   simpleHash,
   emitRegionalAlerts,
+  publishEventWithOps,
 } from '../scripts/regional-snapshot/alert-emitter.mjs';
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -406,5 +407,124 @@ describe('emitRegionalAlerts', () => {
       assert.equal(ev.payload.region_id, 'mena');
       assert.equal(ev.payload.snapshot_id, 'snap-mena-1');
     }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// publishEventWithOps — dedup rollback on LPUSH failure (P1 fix for PR #2966)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('publishEventWithOps — dedup rollback', () => {
+  /** Minimal in-memory Redis that tracks keys and the queue list. */
+  function memoryOps({ lpushFails = false, setNxFails = false } = {}) {
+    /** @type {Record<string, boolean>} */
+    const dedupKeys = {};
+    /** @type {string[]} */
+    const queue = [];
+    /** @type {string[]} */
+    const deletedKeys = [];
+    const ops = {
+      setNx: async (key, _ttl) => {
+        if (setNxFails) return false;
+        if (dedupKeys[key]) return false;
+        dedupKeys[key] = true;
+        return true;
+      },
+      lpush: async (_key, value) => {
+        if (lpushFails) return false;
+        queue.push(value);
+        return true;
+      },
+      del: async (key) => {
+        delete dedupKeys[key];
+        deletedKeys.push(key);
+        return true;
+      },
+    };
+    return { ops, dedupKeys, queue, deletedKeys };
+  }
+
+  const sampleEvent = {
+    eventType: 'regional_regime_shift',
+    severity: 'high',
+    payload: { title: 'MENA: regime shift test' },
+  };
+
+  it('happy path: SET NX + LPUSH both succeed, no rollback', async () => {
+    const mem = memoryOps();
+    const outcome = await publishEventWithOps(sampleEvent, mem.ops);
+    assert.deepEqual(outcome, { enqueued: true, dedupHit: false, rolledBack: false });
+    assert.equal(mem.queue.length, 1);
+    assert.equal(Object.keys(mem.dedupKeys).length, 1);
+    assert.equal(mem.deletedKeys.length, 0);
+  });
+
+  it('dedup hit: returns dedupHit=true without touching the queue', async () => {
+    const mem = memoryOps();
+    // Pre-populate the dedup key so the second call hits it.
+    mem.dedupKeys[buildDedupKey(sampleEvent)] = true;
+    const outcome = await publishEventWithOps(sampleEvent, mem.ops);
+    assert.deepEqual(outcome, { enqueued: false, dedupHit: true, rolledBack: false });
+    assert.equal(mem.queue.length, 0);
+    assert.equal(mem.deletedKeys.length, 0);
+  });
+
+  it('LPUSH failure: dedup key is rolled back via DEL', async () => {
+    const mem = memoryOps({ lpushFails: true });
+    const outcome = await publishEventWithOps(sampleEvent, mem.ops);
+    assert.deepEqual(outcome, { enqueued: false, dedupHit: false, rolledBack: true });
+    // Queue untouched...
+    assert.equal(mem.queue.length, 0);
+    // ...and dedup key was removed so next cycle can retry.
+    assert.equal(Object.keys(mem.dedupKeys).length, 0);
+    assert.equal(mem.deletedKeys.length, 1);
+    assert.equal(mem.deletedKeys[0], buildDedupKey(sampleEvent));
+  });
+
+  it('retry-after-rollback: next call enqueues normally', async () => {
+    // First call fails LPUSH and rolls back.
+    const mem = memoryOps({ lpushFails: true });
+    await publishEventWithOps(sampleEvent, mem.ops);
+    assert.equal(Object.keys(mem.dedupKeys).length, 0);
+
+    // Switch to a working LPUSH (new memory ops instance preserves dedup state).
+    const retryOps = {
+      setNx: mem.ops.setNx,
+      lpush: async (_key, value) => {
+        mem.queue.push(value);
+        return true;
+      },
+      del: mem.ops.del,
+    };
+    const outcome = await publishEventWithOps(sampleEvent, retryOps);
+    assert.equal(outcome.enqueued, true);
+    assert.equal(mem.queue.length, 1);
+  });
+
+  it('LPUSH failure + DEL failure still returns rolledBack=true (best-effort)', async () => {
+    const mem = memoryOps({ lpushFails: true });
+    const opsWithBrokenDel = {
+      setNx: mem.ops.setNx,
+      lpush: mem.ops.lpush,
+      del: async () => {
+        throw new Error('del broke');
+      },
+    };
+    const outcome = await publishEventWithOps(sampleEvent, opsWithBrokenDel);
+    // We attempted rollback; del threw; still report rolledBack=true.
+    assert.equal(outcome.rolledBack, true);
+    assert.equal(outcome.enqueued, false);
+  });
+
+  it('swallows exceptions from setNx/lpush and returns a non-enqueued outcome', async () => {
+    const brokenOps = {
+      setNx: async () => {
+        throw new Error('network blown up');
+      },
+      lpush: async () => true,
+      del: async () => true,
+    };
+    const outcome = await publishEventWithOps(sampleEvent, brokenOps);
+    assert.deepEqual(outcome, { enqueued: false, dedupHit: false, rolledBack: false });
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 PR1 of the Regional Intelligence Model. Wires the existing \`diffRegionalSnapshot\` output into the existing \`wm:events:queue\` so the notification relay on Railway routes state changes to Telegram / email / Slack / Convex for Pro subscribers. Server-only; no UI changes.

## What landed

### New module: \`scripts/regional-snapshot/alert-emitter.mjs\`

Single public entry point:

\`\`\`js
emitRegionalAlerts(region, snapshot, diff, { publishEvent? })
  -> { enqueued: number, events: object[] }
\`\`\`

Emits on 4 event types:

| Event | Source | Default severity |
|---|---|---|
| \`regional_regime_shift\` | \`diff.regime_changed\` | \`high\` (\`critical\` when target is \`escalation_ladder\` or \`fragmentation_risk\`) |
| \`regional_trigger_activation\` | one per entry in \`diff.trigger_activations\` | \`high\` |
| \`regional_corridor_break\` | one per entry in \`diff.corridor_breaks\` | \`critical\` (always) |
| \`regional_buffer_failure\` | one per entry in \`diff.buffer_failures\` | \`high\` |

\`scenario_jumps\` and \`leverage_shifts\` are intentionally NOT emitted — probability fluctuations are noisy and not actionable as push alerts.

### Dedup

6h TTL on \`wm:notif:scan-dedup:{eventType}:{hash}\`, matching the cron cadence and mirroring \`ais-relay.cjs\` \`publishNotificationEvent\`'s path-based Upstash REST calls.

### Best-effort contract

\`emitRegionalAlerts\` NEVER throws. Three layers of guarding:

1. Null/undefined arguments short-circuit to \`{ enqueued: 0, events: [] }\`
2. Each publisher call is individually \`try\`/\`catch\`'d so one failure can't block other events in the same region
3. The seed writer wraps the call in its own \`try\`/\`catch\` so alert emission can never block snapshot persist

This matches how \`ais-relay.cjs\` handles \`rss_alert\` events today.

### \`seed-regional-snapshots.mjs\` hook

After \`persistSnapshot\` succeeds in \`main()\`, the diff already computed in step 15 is passed to \`emitRegionalAlerts\`. Logs per-region alert counts:

\`[mena] alerts: 3/3 enqueued\`

Zero impact on the persist path when the diff is empty (steady state between state changes).

### Testability via dependency-injected publisher

\`opts.publishEvent\` is the single injection point. Default is the Upstash REST path-based publisher that walks SET NX → LPUSH. Unit tests inject a mock that captures events in an array, so the full diff → events → dedup pipeline runs offline without touching Redis.

## Testing

25 new unit tests (\`tests/regional-snapshot-alerts.test.mjs\`), all running offline via the injected publisher:

- **\`buildAlertEvents\`** (13): empty diff → [], regime shift high vs critical, 'none' fallback when previous regime is empty, one event per trigger/break/failure, \`scenario_jumps\` + \`leverage_shifts\` excluded, stable output order, defensive null/undefined, region.label carried into titles
- **\`buildDedupKey\` + \`simpleHash\`** (6): key shape matches ais-relay convention, deterministic output, collision-free across titles and event types, missing-title safety
- **\`emitRegionalAlerts\`** (6): no-op on empty diff, per-event enqueue, publisher-returns-false only counts successes, publisher-throws is swallowed + loop continues, null/undefined guard, end-to-end realistic escalation scenario enqueues all 6 event types with correct severities

- \`npm run test:data\`: 4377/4377 pass
- \`npm run typecheck\` + \`typecheck:api\`: clean
- \`biome lint\` on touched files: clean

## Dependency on notification-relay

The relay already handles generic events with a \`[SEVERITY] title\` fallback formatter. No relay-side changes are required — the new event types flow through the same default path as \`rss_alert\`. If we later want custom templates per regional event type, that's a follow-up to \`scripts/notification-relay.cjs\`.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Railway \`derived-signals\` bundle logs for \`[alerts]\` lines per region. \`queued\` lines indicate new events; \`dedup skip\` indicates repeats within the 6h window.
  - Railway \`notification-relay\` logs for \`Queued\`/\`Processing event\` lines with the new event types (\`regional_regime_shift\`, etc.).
  - Upstash monitor: \`wm:events:queue\` list length should stay near 0 under steady state (relay drains promptly).
- **Validation checks**
  - After merge + first cron cycle: \`redis-cli LLEN wm:events:queue\` should be ≤ small N.
  - \`redis-cli KEYS 'wm:notif:scan-dedup:regional_*'\` should show dedup keys from any emitted events.
  - Pro subscriber with a Telegram channel subscribed to \`regional_*\` event types should receive a message on the first state change.
- **Expected healthy behavior**
  - Steady state (no diffs): zero \`queued\` log lines, zero \`regional_*\` dedup keys accumulating.
  - On a genuine state change: one event per change flows through the relay within ~30 seconds of the cron run.
- **Failure signal(s) / rollback trigger**
  - \`[alerts] LPUSH failed\` or \`publish failed\` warn lines for >2 consecutive cycles → Upstash connectivity issue, investigate.
  - Alert events enqueued but not delivered after 5 minutes → relay drain issue, check \`notification-relay\` logs.
  - Snapshot persist rate regresses → alert emitter throwing despite the try/catch, investigate immediately (should be impossible).
- **Validation window & owner**
  - 12 hours post-merge (covers 2 full cron cycles). Owner: @koala73.

## PR sequence

- [x] Phase 0 PR1 (#2940): snapshot writer foundation — MERGED
- [x] Phase 0 PR2 (#2942): forecast region filter — MERGED
- [x] Phase 1 PR1 (#2951): proto + RPC handler — MERGED
- [x] Phase 0 review fixes (#2952): region-scoping + corridor union — MERGED
- [ ] Phase 1 PR2 (#2960): LLM narrative generator
- [ ] Phase 1 PR3 (#2963): RegionalIntelligenceBoard panel UI
- [ ] **Phase 2 PR1 (this PR)**: state-change alerts from diff engine
- [ ] Phase 2 PR2: Mobility v1 population (deferred — needs global aviation data sources)