### PR TITLE
Phase 2 PR2: Mobility v1 population (airports/airspace/reroute/NOTAM)

### DIFF
--- a/scripts/regional-snapshot/freshness.mjs
+++ b/scripts/regional-snapshot/freshness.mjs
@@ -35,6 +35,13 @@ export const FRESHNESS_REGISTRY = [
   { key: 'energy:mix:v1:_all',                   maxAgeMin: 50400, feedsAxes: ['energy_vulnerability'] },
   { key: 'economic:eu-gas-storage:v1',           maxAgeMin: 2880,  feedsAxes: ['energy_vulnerability'] },
   { key: 'economic:spr:v1',                      maxAgeMin: 10080, feedsAxes: ['energy_buffer'] },
+  // Mobility v1 (Phase 2 PR2) — feed the MobilityState block via mobility.mjs.
+  // maxAgeMin matches each seeder's cron interval + safety buffer.
+  { key: 'aviation:delays:faa:v1',               maxAgeMin: 60,    feedsAxes: ['mobility'] },
+  { key: 'aviation:delays:intl:v3',              maxAgeMin: 90,    feedsAxes: ['mobility'] },
+  { key: 'aviation:notam:closures:v2',           maxAgeMin: 120,   feedsAxes: ['mobility'] },
+  { key: 'intelligence:gpsjam:v2',               maxAgeMin: 240,   feedsAxes: ['mobility', 'airspace'] },
+  { key: 'military:flights:v1',                  maxAgeMin: 30,    feedsAxes: ['mobility', 'reroute_intensity'] },
 ];
 
 export const ALL_INPUT_KEYS = FRESHNESS_REGISTRY.map((s) => s.key);

--- a/scripts/regional-snapshot/freshness.mjs
+++ b/scripts/regional-snapshot/freshness.mjs
@@ -11,6 +11,11 @@
  * @property {string} key      - Redis key (literal, no template variables)
  * @property {number} maxAgeMin - Maximum acceptable age in minutes
  * @property {string[]} feedsAxes - Which balance axes / sections this input drives
+ * @property {string=} metaKey - Optional companion seed-meta key carrying
+ *   {fetchedAt, recordCount}. Used when the primary payload has no
+ *   top-level timestamp field. classifyInputs() will prefer the meta key's
+ *   timestamp when both are available so a stalled seeder can be detected
+ *   even if the data payload is still served from a previous write.
  */
 
 /**
@@ -37,21 +42,45 @@ export const FRESHNESS_REGISTRY = [
   { key: 'economic:spr:v1',                      maxAgeMin: 10080, feedsAxes: ['energy_buffer'] },
   // Mobility v1 (Phase 2 PR2) — feed the MobilityState block via mobility.mjs.
   // maxAgeMin matches each seeder's cron interval + safety buffer.
-  { key: 'aviation:delays:faa:v1',               maxAgeMin: 60,    feedsAxes: ['mobility'] },
-  { key: 'aviation:delays:intl:v3',              maxAgeMin: 90,    feedsAxes: ['mobility'] },
-  { key: 'aviation:notam:closures:v2',           maxAgeMin: 120,   feedsAxes: ['mobility'] },
-  { key: 'intelligence:gpsjam:v2',               maxAgeMin: 240,   feedsAxes: ['mobility', 'airspace'] },
+  // The aviation/gpsjam payloads have no top-level timestamp field, so they
+  // rely on companion seed-meta:* keys (written by the seeders via
+  // writeFreshnessMetadata / upstashSet) for stale detection. Without these
+  // metaKey hints, classifyInputs would fall back to "undated = fresh" and
+  // miss stalled seeders entirely.
+  { key: 'aviation:delays:faa:v1',               maxAgeMin: 60,    feedsAxes: ['mobility'], metaKey: 'seed-meta:aviation:faa' },
+  { key: 'aviation:delays:intl:v3',              maxAgeMin: 90,    feedsAxes: ['mobility'], metaKey: 'seed-meta:aviation:intl' },
+  { key: 'aviation:notam:closures:v2',           maxAgeMin: 120,   feedsAxes: ['mobility'], metaKey: 'seed-meta:aviation:notam' },
+  { key: 'intelligence:gpsjam:v2',               maxAgeMin: 240,   feedsAxes: ['mobility', 'airspace'], metaKey: 'seed-meta:intelligence:gpsjam' },
+  // military:flights:v1 already carries top-level fetchedAt, no metaKey needed.
   { key: 'military:flights:v1',                  maxAgeMin: 30,    feedsAxes: ['mobility', 'reroute_intensity'] },
 ];
+
+/** Every metaKey referenced by FRESHNESS_REGISTRY, for pre-fetching. */
+export const ALL_META_KEYS = FRESHNESS_REGISTRY
+  .map((s) => s.metaKey)
+  .filter((k) => typeof k === 'string' && k.length > 0);
 
 export const ALL_INPUT_KEYS = FRESHNESS_REGISTRY.map((s) => s.key);
 
 /**
  * Classify each input as fresh, stale, or missing.
+ *
+ * Timestamp resolution order per input:
+ *   1. If the spec has a `metaKey`, use metaPayloads[metaKey].fetchedAt.
+ *      This is the canonical signal for sources whose data payload lacks
+ *      a top-level timestamp (FAA alerts, AviationStack, NOTAM, GPS jam).
+ *   2. Otherwise, pull a timestamp from the primary payload via
+ *      extractTimestamp (fetchedAt, generatedAt, timestamp, updatedAt,
+ *      lastUpdate).
+ *   3. If neither yields a timestamp, fall back to "fresh" (cannot prove
+ *      staleness). This fallback remains so we don't regress existing
+ *      keys that have never needed a meta key.
+ *
  * @param {Record<string, unknown>} payloads - Map of key -> raw value (or null)
+ * @param {Record<string, unknown>} [metaPayloads] - Map of metaKey -> raw value (or null)
  * @returns {{ fresh: string[]; stale: string[]; missing: string[] }}
  */
-export function classifyInputs(payloads) {
+export function classifyInputs(payloads, metaPayloads = {}) {
   const fresh = [];
   const stale = [];
   const missing = [];
@@ -63,10 +92,19 @@ export function classifyInputs(payloads) {
       missing.push(spec.key);
       continue;
     }
-    // Try to extract a timestamp from common shapes.
-    const ts = extractTimestamp(payload);
+
+    // Prefer the companion seed-meta:*.fetchedAt when the spec declares one.
+    // This is the only way to detect a stalled seeder for payloads that
+    // don't carry a top-level timestamp of their own.
+    let ts = null;
+    if (spec.metaKey) {
+      const meta = metaPayloads[spec.metaKey];
+      ts = extractTimestamp(meta);
+    }
+    if (ts === null) ts = extractTimestamp(payload);
+
     if (ts === null) {
-      // Present but undated -- treat as fresh (we cannot prove staleness).
+      // Present but undated — treat as fresh (we cannot prove staleness).
       fresh.push(spec.key);
       continue;
     }

--- a/scripts/regional-snapshot/mobility.mjs
+++ b/scripts/regional-snapshot/mobility.mjs
@@ -107,6 +107,16 @@ export function gpsjamRegionToSnapshotRegion(gpsjamRegion) {
  * coverage matching the fetch-gpsjam.mjs region bboxes. Returns null for
  * oceans and unmapped airspace.
  *
+ * North America's southern edge is set at lat 16.0°N — that captures
+ * every major Mexican city and state capital (southernmost is Tuxtla
+ * Gutiérrez at 16.75°N) while still routing Guatemala City (14.6°N),
+ * Belize City (17.5°N is on the line but Belize is routed via its
+ * country name in the airport mapper), and El Salvador to latam.
+ * Before this fix, NA started at lat 20 which left Mexico City (19.4°N)
+ * and most of Mexican airspace in latam, disagreeing with
+ * airportToSnapshotRegion()'s country-based MX→NA routing and
+ * understating NA's reroute_intensity from military tracks.
+ *
  * @param {number} lat
  * @param {number} lon
  * @returns {string | null}
@@ -123,10 +133,12 @@ export function latLonToSnapshotRegion(lat, lon) {
   if (lat >= 5 && lat <= 38 && lon >= 60 && lon <= 97) return 'south-asia';
   // East Asia / Southeast Asia / Oceania
   if (lat >= -45 && lat <= 55 && lon >= 90 && lon <= 180) return 'east-asia';
-  // North America
-  if (lat >= 20 && lat <= 75 && lon >= -170 && lon <= -50) return 'north-america';
-  // Latin America
-  if (lat >= -56 && lat <= 32 && lon >= -120 && lon <= -34) return 'latam';
+  // North America — includes all major Mexican cities/states. Checked
+  // before latam so the bbox overlap resolves to NA.
+  if (lat >= 16 && lat <= 75 && lon >= -170 && lon <= -50) return 'north-america';
+  // Latin America — capped at 16°N so Guatemala/Belize/El Salvador and
+  // southward fall here, while mainland Mexico goes to NA above.
+  if (lat >= -56 && lat < 16 && lon >= -120 && lon <= -34) return 'latam';
   return null;
 }
 

--- a/scripts/regional-snapshot/mobility.mjs
+++ b/scripts/regional-snapshot/mobility.mjs
@@ -1,0 +1,353 @@
+// @ts-check
+// Mobility v1 adapter. Replaces the Phase 0 empty stub with a real
+// MobilityState built from existing Redis inputs:
+//
+//   aviation:delays:faa:v1         — US airport delays (FAA ASWS)
+//   aviation:delays:intl:v3        — ~51 non-US airports (AviationStack)
+//   aviation:notam:closures:v2     — global ICAO NOTAM closures
+//   intelligence:gpsjam:v2         — global GPS jamming hexes → airspace
+//   military:flights:v1            — global military ADSB → reroute proxy
+//
+// Output (per RegionalSnapshot.mobility):
+//
+//   airspace[]         — one aggregated entry per region from GPS-jam
+//   flight_corridors[] — empty in v1 (no direct corridor stress feed)
+//   airports[]         — MAJOR/SEVERE airport alerts scoped to region
+//   reroute_intensity  — clip(militaryCount/50, 0, 1) region-scoped
+//   notam_closures[]   — NOTAM reason strings for airports in region
+//
+// All functions are PURE and export-tested — no Redis calls, no side effects.
+// The seed writer passes already-fetched source objects in.
+//
+// Scope boundaries (explicit non-goals for v1):
+//   - flight_corridors[] stays empty — no direct rerouted-per-corridor feed
+//   - reroute_intensity uses military count as a crude proxy; future versions
+//     could use GPS-jam hex density or OpenSky track analysis
+//   - NOTAM classifier is text-based (closure vs restriction) — no structured parse
+
+// ── Region classification helpers ────────────────────────────────────────────
+
+/**
+ * Split AviationStack/FAA AirportRegion enum by country into snapshot regions.
+ * The airport registry uses `americas / europe / apac / mena / africa`; the
+ * snapshot uses 7 finer regions. Americas splits by country (USA/CA/MX →
+ * north-america, rest → latam) and APAC splits by country (IN/PK/BD/LK/AF →
+ * south-asia, rest → east-asia). Proto enum strings and lowercase labels
+ * are both accepted.
+ *
+ * @param {{ region?: string, country?: string }} alert
+ * @returns {string | null} snapshot region id, or null if unmappable
+ */
+export function airportToSnapshotRegion(alert) {
+  if (!alert) return null;
+  const region = String(alert.region ?? '').toUpperCase();
+  const country = String(alert.country ?? '');
+
+  if (region.includes('AMERICAS')) {
+    if (NORTH_AMERICA_COUNTRIES.has(country)) return 'north-america';
+    return 'latam';
+  }
+  if (region.includes('APAC')) {
+    if (SOUTH_ASIA_COUNTRIES.has(country)) return 'south-asia';
+    return 'east-asia';
+  }
+  if (region.includes('EUROPE')) return 'europe';
+  if (region.includes('MENA')) return 'mena';
+  if (region.includes('AFRICA')) return 'sub-saharan-africa';
+  return null;
+}
+
+const NORTH_AMERICA_COUNTRIES = new Set([
+  'USA', 'United States', 'United States of America',
+  'Canada',
+  'Mexico',
+]);
+
+const SOUTH_ASIA_COUNTRIES = new Set([
+  'India', 'Pakistan', 'Bangladesh', 'Sri Lanka', 'Afghanistan', 'Nepal', 'Bhutan', 'Maldives',
+]);
+
+/**
+ * Map fetch-gpsjam.mjs classifyRegion() labels to snapshot region ids.
+ * Falls back to null for 'other' and unknown labels.
+ *
+ * @param {string | undefined} gpsjamRegion
+ * @returns {string | null}
+ */
+export function gpsjamRegionToSnapshotRegion(gpsjamRegion) {
+  switch (gpsjamRegion) {
+    case 'iran-iraq':
+    case 'levant':
+    case 'israel-sinai':
+    case 'yemen-horn':
+    case 'turkey-caucasus':
+      return 'mena';
+    case 'ukraine-russia':
+    case 'russia-north':
+    case 'northern-europe':
+    case 'western-europe':
+      return 'europe';
+    case 'sudan-sahel':
+    case 'east-africa':
+      return 'sub-saharan-africa';
+    case 'afghanistan-pakistan':
+      return 'south-asia';
+    case 'southeast-asia':
+    case 'east-asia':
+      return 'east-asia';
+    case 'north-america':
+      return 'north-america';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Lat/lon → snapshot region bbox classifier for military flights. Coarse
+ * coverage matching the fetch-gpsjam.mjs region bboxes. Returns null for
+ * oceans and unmapped airspace.
+ *
+ * @param {number} lat
+ * @param {number} lon
+ * @returns {string | null}
+ */
+export function latLonToSnapshotRegion(lat, lon) {
+  if (typeof lat !== 'number' || typeof lon !== 'number') return null;
+  // MENA (check before Europe so Turkey/Caucasus land MENA per our override)
+  if (lat >= 12 && lat <= 42 && lon >= 20 && lon <= 63) return 'mena';
+  // Europe + Russia
+  if (lat >= 35 && lat <= 72 && lon >= -10 && lon <= 60) return 'europe';
+  // Sub-Saharan Africa
+  if (lat >= -35 && lat <= 20 && lon >= -18 && lon <= 52) return 'sub-saharan-africa';
+  // South Asia
+  if (lat >= 5 && lat <= 38 && lon >= 60 && lon <= 97) return 'south-asia';
+  // East Asia / Southeast Asia / Oceania
+  if (lat >= -45 && lat <= 55 && lon >= 90 && lon <= 180) return 'east-asia';
+  // North America
+  if (lat >= 20 && lat <= 75 && lon >= -170 && lon <= -50) return 'north-america';
+  // Latin America
+  if (lat >= -56 && lat <= 32 && lon >= -120 && lon <= -34) return 'latam';
+  return null;
+}
+
+// ── Airports block ───────────────────────────────────────────────────────────
+
+/** Severity tier at which an airport alert is considered mobility-relevant. */
+const AIRPORT_MIN_SEVERITY_RANK = 3; // 0=normal 1=minor 2=moderate 3=major 4=severe
+
+const SEVERITY_RANK = {
+  FLIGHT_DELAY_SEVERITY_NORMAL: 0,
+  FLIGHT_DELAY_SEVERITY_MINOR: 1,
+  FLIGHT_DELAY_SEVERITY_MODERATE: 2,
+  FLIGHT_DELAY_SEVERITY_MAJOR: 3,
+  FLIGHT_DELAY_SEVERITY_SEVERE: 4,
+  // Also accept the lowercase seeder-internal labels just in case
+  normal: 0, minor: 1, moderate: 2, major: 3, severe: 4,
+};
+
+/**
+ * @param {string | undefined} severity
+ * @returns {number}
+ */
+function severityRank(severity) {
+  return /** @type {any} */ (SEVERITY_RANK)[String(severity ?? '')] ?? 0;
+}
+
+/**
+ * Build airports[] for one region: filter alerts from both FAA and intl
+ * seeds down to severity >= MAJOR and map each to the snapshot's
+ * AirportNodeStatus shape.
+ *
+ * @param {string} regionId
+ * @param {Record<string, any>} sources
+ * @returns {import('../../shared/regions.types.js').AirportNodeStatus[]}
+ */
+export function buildAirports(regionId, sources) {
+  const faaAlerts = sources?.['aviation:delays:faa:v1']?.alerts;
+  const intlAlerts = sources?.['aviation:delays:intl:v3']?.alerts;
+  const allAlerts = [
+    ...(Array.isArray(faaAlerts) ? faaAlerts : []),
+    ...(Array.isArray(intlAlerts) ? intlAlerts : []),
+  ];
+
+  /** @type {import('../../shared/regions.types.js').AirportNodeStatus[]} */
+  const out = [];
+  for (const a of allAlerts) {
+    if (airportToSnapshotRegion(a) !== regionId) continue;
+    const rank = severityRank(a?.severity);
+    if (rank < AIRPORT_MIN_SEVERITY_RANK) continue;
+    /** @type {'closed' | 'disrupted'} */
+    const status = rank >= 4 ? 'closed' : 'disrupted';
+    out.push({
+      icao: String(a?.icao ?? ''),
+      name: String(a?.name ?? a?.iata ?? ''),
+      status,
+      disruption_reason: String(a?.reason ?? ''),
+    });
+  }
+  return out;
+}
+
+// ── NOTAM closures block ─────────────────────────────────────────────────────
+
+/**
+ * Emit NOTAM reason strings for any airport that the `airports[]` block
+ * would surface in this region. v1: derives the ICAO set from the airport
+ * alerts (so NOTAMs track the same airport scope) and pulls reason text
+ * from aviation:notam:closures:v2.reasons[icao].
+ *
+ * @param {string} regionId
+ * @param {Record<string, any>} sources
+ * @returns {string[]}
+ */
+export function buildNotamClosures(regionId, sources) {
+  const notam = sources?.['aviation:notam:closures:v2'];
+  const reasons = notam?.reasons && typeof notam.reasons === 'object' ? notam.reasons : {};
+  const closedIcaos = Array.isArray(notam?.closedIcaos) ? notam.closedIcaos : [];
+  const restrictedIcaos = Array.isArray(notam?.restrictedIcaos) ? notam.restrictedIcaos : [];
+  const candidates = new Set([...closedIcaos, ...restrictedIcaos]);
+
+  if (candidates.size === 0) return [];
+
+  // Determine which ICAOs belong to this region by cross-referencing the
+  // existing airport alert stream (both FAA + intl carry country/region).
+  const faaAlerts = sources?.['aviation:delays:faa:v1']?.alerts;
+  const intlAlerts = sources?.['aviation:delays:intl:v3']?.alerts;
+  /** @type {Record<string, string>} */
+  const icaoToRegion = {};
+  for (const a of Array.isArray(faaAlerts) ? faaAlerts : []) {
+    const r = airportToSnapshotRegion(a);
+    if (a?.icao && r) icaoToRegion[String(a.icao)] = r;
+  }
+  for (const a of Array.isArray(intlAlerts) ? intlAlerts : []) {
+    const r = airportToSnapshotRegion(a);
+    if (a?.icao && r) icaoToRegion[String(a.icao)] = r;
+  }
+
+  const out = [];
+  for (const icao of candidates) {
+    if (icaoToRegion[icao] !== regionId) continue;
+    const reason = String(reasons[icao] ?? '').slice(0, 200);
+    if (reason.length === 0) continue;
+    out.push(`${icao}: ${reason}`);
+  }
+  return out;
+}
+
+// ── Airspace block (from GPS jamming) ────────────────────────────────────────
+
+const JAM_LEVEL_RANK = { low: 1, medium: 2, high: 3 };
+
+/**
+ * Build airspace[] for one region. v1 aggregates GPS-jam hexes mapped to
+ * this region into ONE AirspaceStatus entry — emitting one per hex would
+ * flood the UI.
+ *
+ * Status resolution:
+ *   - any 'high' level hex present → 'restricted'
+ *   - only 'medium'/'low' hexes     → 'restricted' (GPS jam still affects RNAV)
+ *   - no hexes in region            → block omits the region
+ *
+ * @param {string} regionId
+ * @param {Record<string, any>} sources
+ * @returns {import('../../shared/regions.types.js').AirspaceStatus[]}
+ */
+export function buildAirspace(regionId, sources) {
+  const hexes = sources?.['intelligence:gpsjam:v2']?.hexes;
+  if (!Array.isArray(hexes) || hexes.length === 0) return [];
+
+  let highCount = 0;
+  let mediumCount = 0;
+  let lowCount = 0;
+  /** @type {Set<string>} */
+  const subRegions = new Set();
+
+  for (const hex of hexes) {
+    const jamSnapshotRegion = gpsjamRegionToSnapshotRegion(hex?.region);
+    if (jamSnapshotRegion !== regionId) continue;
+    const level = String(hex?.level ?? 'low').toLowerCase();
+    if (level === 'high') highCount += 1;
+    else if (level === 'medium') mediumCount += 1;
+    else lowCount += 1;
+    if (hex?.region) subRegions.add(String(hex.region));
+  }
+
+  const total = highCount + mediumCount + lowCount;
+  if (total === 0) return [];
+
+  const subRegionList = [...subRegions].sort().join(', ');
+  const summary = `GPS jamming active over ${subRegionList || regionId}: ${highCount} high / ${mediumCount} medium / ${lowCount} low hexes`;
+
+  /** @type {import('../../shared/regions.types.js').AirspaceStatus[]} */
+  const out = [{
+    airspace_id: `gpsjam:${regionId}`,
+    status: 'restricted',
+    reason: summary,
+  }];
+  return out;
+}
+
+// ── Reroute intensity ────────────────────────────────────────────────────────
+
+const REROUTE_FLIGHTS_FULL_SCALE = 50; // military flight count at which reroute_intensity saturates to 1.0
+
+/**
+ * Crude reroute_intensity proxy: count military flights whose lat/lon lands
+ * in this region and clip against a full-scale constant. A sustained
+ * military presence correlates with civil rerouting pressure, even if it's
+ * not a direct 1:1 measure.
+ *
+ * v2 could replace this with:
+ *   - direct OpenSky ADSB civil-flight track diversion counts per corridor
+ *   - GPS-jam hex density as a rerouting proxy (more rigorous)
+ *   - operational NOTAM parse of ATS route closures
+ *
+ * @param {string} regionId
+ * @param {Record<string, any>} sources
+ * @returns {number} value in [0, 1]
+ */
+export function buildRerouteIntensity(regionId, sources) {
+  const flights = sources?.['military:flights:v1']?.flights;
+  if (!Array.isArray(flights) || flights.length === 0) return 0;
+
+  let count = 0;
+  for (const f of flights) {
+    const r = latLonToSnapshotRegion(Number(f?.lat), Number(f?.lon));
+    if (r === regionId) count += 1;
+  }
+
+  return Math.max(0, Math.min(1, count / REROUTE_FLIGHTS_FULL_SCALE));
+}
+
+// ── Top-level composer ──────────────────────────────────────────────────────
+
+/**
+ * Build the full MobilityState for one region from already-fetched sources.
+ * Pure, never throws, always returns a shape that matches the proto.
+ *
+ * @param {string} regionId
+ * @param {Record<string, any>} sources
+ * @returns {import('../../shared/regions.types.js').MobilityState}
+ */
+export function buildMobilityState(regionId, sources) {
+  try {
+    return {
+      airspace: buildAirspace(regionId, sources),
+      flight_corridors: [],
+      airports: buildAirports(regionId, sources),
+      reroute_intensity: buildRerouteIntensity(regionId, sources),
+      notam_closures: buildNotamClosures(regionId, sources),
+    };
+  } catch (err) {
+    // Defensive: any unexpected shape bug must not break snapshot persist.
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[mobility] ${regionId}: builder threw, returning empty: ${msg}`);
+    return {
+      airspace: [],
+      flight_corridors: [],
+      airports: [],
+      reroute_intensity: 0,
+      notam_closures: [],
+    };
+  }
+}

--- a/scripts/regional-snapshot/snapshot-meta.mjs
+++ b/scripts/regional-snapshot/snapshot-meta.mjs
@@ -11,6 +11,11 @@ export const MODEL_VERSION = '0.1.0';
 
 /**
  * @param {Record<string, any>} sources
+ * @param {string} scoringVersion
+ * @param {string} geographyVersion
+ * @param {Record<string, any>} [metaSources] - Companion seed-meta:* payloads
+ *   used by classifyInputs to detect stalled seeders whose data payloads
+ *   lack top-level timestamps. See freshness.mjs.
  * @returns {{
  *   pre: {
  *     model_version: string;
@@ -25,8 +30,8 @@ export const MODEL_VERSION = '0.1.0';
  *   classification: { fresh: string[]; stale: string[]; missing: string[] };
  * }}
  */
-export function buildPreMeta(sources, scoringVersion, geographyVersion) {
-  const classification = classifyInputs(sources);
+export function buildPreMeta(sources, scoringVersion, geographyVersion, metaSources = {}) {
+  const classification = classifyInputs(sources, metaSources);
   const totalInputs = classification.fresh.length + classification.stale.length + classification.missing.length;
   const cCompleteness = totalInputs > 0
     ? (totalInputs - classification.missing.length) / totalInputs

--- a/scripts/seed-regional-snapshots.mjs
+++ b/scripts/seed-regional-snapshots.mjs
@@ -44,6 +44,7 @@ import { ALL_INPUT_KEYS } from './regional-snapshot/freshness.mjs';
 import { generateSnapshotId } from './regional-snapshot/_helpers.mjs';
 import { generateRegionalNarrative, emptyNarrative } from './regional-snapshot/narrative.mjs';
 import { emitRegionalAlerts } from './regional-snapshot/alert-emitter.mjs';
+import { buildMobilityState } from './regional-snapshot/mobility.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -89,7 +90,7 @@ async function readAllInputs() {
  *   5. triggers (BEFORE scenarios)
  *   6. scenarios (normalized)
  *   7. transmissions
- *   8. mobility (empty in Phase 0)
+ *   8. mobility (v1 adapter — airports, airspace, reroute_intensity, NOTAMs)
  *   9. evidence
  *   10. snapshot_id
  *   11. read previous + derive regime
@@ -118,14 +119,11 @@ async function computeSnapshot(regionId, sources) {
   // Step 7: transmissions (matched to active triggers)
   const transmissionPaths = resolveTransmissions(regionId, triggers);
 
-  // Step 8: mobility (empty in Phase 0 - see appendix Mobility Input Keys)
-  const mobility = {
-    airspace: [],
-    flight_corridors: [],
-    airports: [],
-    reroute_intensity: 0,
-    notam_closures: [],
-  };
+  // Step 8: mobility v1 — adapters over existing Redis inputs:
+  // aviation:delays:{faa,intl}, aviation:notam:closures:v2,
+  // intelligence:gpsjam:v2, military:flights:v1. Pure, never throws.
+  // See Phase 2 PR2 notes in scripts/regional-snapshot/mobility.mjs.
+  const mobility = buildMobilityState(regionId, sources);
 
   // Step 9: evidence chain
   const evidence = collectEvidence(regionId, sources);

--- a/scripts/seed-regional-snapshots.mjs
+++ b/scripts/seed-regional-snapshots.mjs
@@ -40,7 +40,7 @@ import { collectEvidence } from './regional-snapshot/evidence-collector.mjs';
 import { buildPreMeta, buildFinalMeta } from './regional-snapshot/snapshot-meta.mjs';
 import { diffRegionalSnapshot, inferTriggerReason } from './regional-snapshot/diff-snapshot.mjs';
 import { persistSnapshot, readLatestSnapshot } from './regional-snapshot/persist-snapshot.mjs';
-import { ALL_INPUT_KEYS } from './regional-snapshot/freshness.mjs';
+import { ALL_INPUT_KEYS, ALL_META_KEYS } from './regional-snapshot/freshness.mjs';
 import { generateSnapshotId } from './regional-snapshot/_helpers.mjs';
 import { generateRegionalNarrative, emptyNarrative } from './regional-snapshot/narrative.mjs';
 import { emitRegionalAlerts } from './regional-snapshot/alert-emitter.mjs';
@@ -50,10 +50,17 @@ loadEnvFile(import.meta.url);
 
 const SEED_META_KEY = 'intelligence:regional-snapshots';
 
-/** @returns {Promise<Record<string, any>>} */
+/**
+ * Read every input key + every metaKey companion in a single pipeline.
+ * metaKeys carry {fetchedAt, recordCount} for inputs whose data payload
+ * has no top-level timestamp (mobility sources). See freshness.mjs.
+ *
+ * @returns {Promise<{ sources: Record<string, any>, metaSources: Record<string, any> }>}
+ */
 async function readAllInputs() {
   const { url, token } = getRedisCredentials();
-  const pipeline = ALL_INPUT_KEYS.map((k) => ['GET', k]);
+  const keys = [...ALL_INPUT_KEYS, ...ALL_META_KEYS];
+  const pipeline = keys.map((k) => ['GET', k]);
   const resp = await fetch(`${url}/pipeline`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
@@ -62,22 +69,26 @@ async function readAllInputs() {
   });
   if (!resp.ok) throw new Error(`Redis pipeline read: HTTP ${resp.status}`);
   const results = await resp.json();
+
   /** @type {Record<string, any>} */
-  const data = {};
-  for (let i = 0; i < ALL_INPUT_KEYS.length; i++) {
-    const key = ALL_INPUT_KEYS[i];
+  const sources = {};
+  /** @type {Record<string, any>} */
+  const metaSources = {};
+  for (let i = 0; i < keys.length; i += 1) {
+    const key = keys[i];
+    const target = i < ALL_INPUT_KEYS.length ? sources : metaSources;
     const raw = results[i]?.result;
     if (raw === null || raw === undefined) {
-      data[key] = null;
+      target[key] = null;
       continue;
     }
     try {
-      data[key] = JSON.parse(raw);
+      target[key] = JSON.parse(raw);
     } catch {
-      data[key] = null;
+      target[key] = null;
     }
   }
-  return data;
+  return { sources, metaSources };
 }
 
 /**
@@ -100,9 +111,10 @@ async function readAllInputs() {
  *   15. diff → trigger_reason
  *   16. final_meta with narrative_provider/narrative_model
  */
-async function computeSnapshot(regionId, sources) {
-  // Step 2: pre-meta
-  const { pre } = buildPreMeta(sources, SCORING_VERSION, GEOGRAPHY_VERSION);
+async function computeSnapshot(regionId, sources, metaSources = {}) {
+  // Step 2: pre-meta (metaSources carries seed-meta:*.fetchedAt for inputs
+  // whose data payloads have no top-level timestamp — see freshness.mjs).
+  const { pre } = buildPreMeta(sources, SCORING_VERSION, GEOGRAPHY_VERSION, metaSources);
 
   // Step 3: balance vector
   const { vector: balance } = computeBalanceVector(regionId, sources);
@@ -196,10 +208,12 @@ async function main() {
   const t0 = Date.now();
   console.log(`[regional-snapshots] Starting compute for ${REGIONS.length} regions`);
 
-  // Step 1: read all inputs once (shared across regions)
-  const sources = await readAllInputs();
+  // Step 1: read all inputs once (shared across regions), plus seed-meta
+  // companions for inputs whose payloads lack top-level timestamps.
+  const { sources, metaSources } = await readAllInputs();
   const presentKeys = Object.entries(sources).filter(([, v]) => v !== null).length;
-  console.log(`[regional-snapshots] Read inputs: ${presentKeys}/${ALL_INPUT_KEYS.length} keys present`);
+  const presentMetaKeys = Object.entries(metaSources).filter(([, v]) => v !== null).length;
+  console.log(`[regional-snapshots] Read inputs: ${presentKeys}/${ALL_INPUT_KEYS.length} keys present, ${presentMetaKeys}/${ALL_META_KEYS.length} meta keys present`);
 
   let persisted = 0;
   let skipped = 0;
@@ -209,7 +223,7 @@ async function main() {
 
   for (const region of REGIONS) {
     try {
-      const { snapshot, diff } = await computeSnapshot(region.id, sources);
+      const { snapshot, diff } = await computeSnapshot(region.id, sources, metaSources);
       const result = await persistSnapshot(snapshot);
       if (result.persisted) {
         persisted += 1;

--- a/tests/regional-snapshot-mobility.test.mjs
+++ b/tests/regional-snapshot-mobility.test.mjs
@@ -15,6 +15,11 @@ import {
   buildNotamClosures,
   buildMobilityState,
 } from '../scripts/regional-snapshot/mobility.mjs';
+import {
+  classifyInputs,
+  FRESHNESS_REGISTRY,
+  ALL_META_KEYS,
+} from '../scripts/regional-snapshot/freshness.mjs';
 
 // ────────────────────────────────────────────────────────────────────────────
 // airportToSnapshotRegion
@@ -471,5 +476,155 @@ describe('buildMobilityState', () => {
     assert.equal(na.airspace.length, 0);
     assert.ok(na.reroute_intensity > 0);
     assert.ok(mena.reroute_intensity > 0);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// PR #2976 review-fix regression: Mexico lat/lon consistency (P2 #1)
+// ────────────────────────────────────────────────────────────────────────────
+//
+// Before the fix, latLonToSnapshotRegion()'s NA bbox started at lat 20, so
+// Mexican flights (Mexico City 19.4°N, Guadalajara 20.5°N, Chiapas ~16°N)
+// fell into latam. Meanwhile airportToSnapshotRegion routed MX airports to
+// NA by country, so NA's reroute_intensity understated actual military
+// pressure and the two classifiers disagreed on the same country.
+
+describe('Mexico classifier parity (PR #2976 P2 #1)', () => {
+  // Every major Mexican city sits at lat ≥ 16°N (Tuxtla Gutiérrez, the
+  // southernmost state capital, is at 16.75°N). A handful of tiny
+  // southern-Chiapas airports at lat ≈14.9°N route to latam under this
+  // classifier — acceptable limitation; those airports aren't in the
+  // monitored set and don't carry meaningful military traffic.
+  const mexicanCities = [
+    { name: 'Mexico City',     lat: 19.43, lon: -99.13 },
+    { name: 'Guadalajara',     lat: 20.67, lon: -103.35 },
+    { name: 'Monterrey',       lat: 25.68, lon: -100.32 },
+    { name: 'Tijuana',         lat: 32.52, lon: -117.03 },
+    { name: 'Cancun',          lat: 21.16, lon: -86.85 },
+    { name: 'Tuxtla Gutierrez', lat: 16.75, lon: -93.11 },
+  ];
+
+  for (const city of mexicanCities) {
+    it(`routes ${city.name} to north-america`, () => {
+      assert.equal(latLonToSnapshotRegion(city.lat, city.lon), 'north-america');
+    });
+  }
+
+  it('airport-by-country AND lat/lon classifier agree for every major Mexican city', () => {
+    for (const city of mexicanCities) {
+      const byCountry = airportToSnapshotRegion({ region: 'AIRPORT_REGION_AMERICAS', country: 'Mexico' });
+      const byLatLon = latLonToSnapshotRegion(city.lat, city.lon);
+      assert.equal(byCountry, byLatLon, `${city.name}: country-based=${byCountry} vs lat/lon=${byLatLon}`);
+    }
+  });
+
+  it('Guatemala / Belize / El Salvador go to latam (south of the 16°N break)', () => {
+    assert.equal(latLonToSnapshotRegion(14.60, -90.52), 'latam'); // Guatemala City
+    assert.equal(latLonToSnapshotRegion(13.69, -89.19), 'latam'); // San Salvador
+    assert.equal(latLonToSnapshotRegion(15.50, -88.03), 'latam'); // northern Honduras
+  });
+
+  it('US and Canada still land in north-america', () => {
+    assert.equal(latLonToSnapshotRegion(40.64, -73.78), 'north-america'); // JFK
+    assert.equal(latLonToSnapshotRegion(49.19, -123.18), 'north-america'); // YVR
+  });
+
+  it('South American cities stay in latam', () => {
+    assert.equal(latLonToSnapshotRegion(-23.44, -46.47), 'latam'); // São Paulo
+    assert.equal(latLonToSnapshotRegion(-33.39, -70.79), 'latam'); // Santiago
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// PR #2976 review-fix regression: seed-meta freshness path (P2 #2)
+// ────────────────────────────────────────────────────────────────────────────
+//
+// classifyInputs() used to treat undated payloads as fresh, which meant
+// stalled FAA/NOTAM/AviationStack/GPS-jam seeders would never bump
+// snapshot_confidence down. The fix threads a metaKey through each
+// freshness spec so the companion seed-meta:*.fetchedAt is the canonical
+// staleness signal.
+
+describe('classifyInputs metaKey fallback (PR #2976 P2 #2)', () => {
+  it('declares metaKey for every undated mobility input', () => {
+    const mobilityKeys = new Set([
+      'aviation:delays:faa:v1',
+      'aviation:delays:intl:v3',
+      'aviation:notam:closures:v2',
+      'intelligence:gpsjam:v2',
+    ]);
+    for (const spec of FRESHNESS_REGISTRY) {
+      if (mobilityKeys.has(spec.key)) {
+        assert.ok(typeof spec.metaKey === 'string' && spec.metaKey.length > 0,
+          `${spec.key} must declare a metaKey — its payload has no top-level fetchedAt`);
+      }
+    }
+  });
+
+  it('military:flights:v1 does NOT need a metaKey (payload has top-level fetchedAt)', () => {
+    const spec = FRESHNESS_REGISTRY.find((s) => s.key === 'military:flights:v1');
+    assert.ok(spec);
+    assert.equal(spec.metaKey, undefined);
+  });
+
+  it('ALL_META_KEYS collects every declared metaKey', () => {
+    assert.ok(ALL_META_KEYS.includes('seed-meta:aviation:faa'));
+    assert.ok(ALL_META_KEYS.includes('seed-meta:aviation:intl'));
+    assert.ok(ALL_META_KEYS.includes('seed-meta:aviation:notam'));
+    assert.ok(ALL_META_KEYS.includes('seed-meta:intelligence:gpsjam'));
+  });
+
+  it('undated payload + fresh meta → classified as fresh', () => {
+    const freshMeta = { fetchedAt: Date.now() - 5 * 60_000 }; // 5 min old
+    const result = classifyInputs(
+      { 'aviation:delays:faa:v1': { alerts: [] } }, // payload present, no timestamp
+      { 'seed-meta:aviation:faa': freshMeta },
+    );
+    assert.ok(result.fresh.includes('aviation:delays:faa:v1'));
+    assert.ok(!result.stale.includes('aviation:delays:faa:v1'));
+  });
+
+  it('undated payload + STALE meta → classified as stale (the key bug fix)', () => {
+    const staleMeta = { fetchedAt: Date.now() - 6 * 60 * 60_000 }; // 6 hours old, > 60min cap
+    const result = classifyInputs(
+      { 'aviation:delays:faa:v1': { alerts: [] } },
+      { 'seed-meta:aviation:faa': staleMeta },
+    );
+    assert.ok(result.stale.includes('aviation:delays:faa:v1'));
+    assert.ok(!result.fresh.includes('aviation:delays:faa:v1'));
+  });
+
+  it('undated payload + missing meta → falls back to fresh (cannot prove staleness)', () => {
+    const result = classifyInputs(
+      { 'aviation:delays:faa:v1': { alerts: [] } },
+      {}, // no meta at all
+    );
+    assert.ok(result.fresh.includes('aviation:delays:faa:v1'));
+  });
+
+  it('missing payload → classified as missing regardless of meta', () => {
+    const result = classifyInputs(
+      { 'aviation:delays:faa:v1': null },
+      { 'seed-meta:aviation:faa': { fetchedAt: Date.now() } },
+    );
+    assert.ok(result.missing.includes('aviation:delays:faa:v1'));
+    assert.ok(!result.fresh.includes('aviation:delays:faa:v1'));
+    assert.ok(!result.stale.includes('aviation:delays:faa:v1'));
+  });
+
+  it('existing registry entries without metaKey still work via top-level timestamp', () => {
+    // Sanity: military:flights:v1 has top-level fetchedAt and no metaKey.
+    const staleFlights = { flights: [], fetchedAt: Date.now() - 60 * 60_000 }; // 60 min, > 30min cap
+    const result = classifyInputs({ 'military:flights:v1': staleFlights }, {});
+    assert.ok(result.stale.includes('military:flights:v1'));
+  });
+
+  it('meta payload with no fetchedAt field falls through to payload timestamp', () => {
+    const staleFlights = { flights: [], fetchedAt: Date.now() - 60 * 60_000 };
+    const result = classifyInputs(
+      { 'military:flights:v1': staleFlights },
+      { 'seed-meta:military:flights': { recordCount: 100 } }, // meta has no fetchedAt
+    );
+    assert.ok(result.stale.includes('military:flights:v1'));
   });
 });

--- a/tests/regional-snapshot-mobility.test.mjs
+++ b/tests/regional-snapshot-mobility.test.mjs
@@ -1,0 +1,475 @@
+// Tests for the Regional Intelligence Mobility v1 adapter (Phase 2 PR2).
+// Pure-function unit tests; no Redis dependency. Run via:
+//   npm run test:data
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  airportToSnapshotRegion,
+  gpsjamRegionToSnapshotRegion,
+  latLonToSnapshotRegion,
+  buildAirports,
+  buildAirspace,
+  buildRerouteIntensity,
+  buildNotamClosures,
+  buildMobilityState,
+} from '../scripts/regional-snapshot/mobility.mjs';
+
+// ────────────────────────────────────────────────────────────────────────────
+// airportToSnapshotRegion
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('airportToSnapshotRegion', () => {
+  it('routes US/Canada/Mexico airports to north-america', () => {
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_AMERICAS', country: 'USA' }), 'north-america');
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_AMERICAS', country: 'Canada' }), 'north-america');
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_AMERICAS', country: 'Mexico' }), 'north-america');
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_AMERICAS', country: 'United States' }), 'north-america');
+  });
+
+  it('routes Latin American airports to latam', () => {
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_AMERICAS', country: 'Brazil' }), 'latam');
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_AMERICAS', country: 'Argentina' }), 'latam');
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_AMERICAS', country: 'Colombia' }), 'latam');
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_AMERICAS', country: 'Chile' }), 'latam');
+  });
+
+  it('splits APAC by country between south-asia and east-asia', () => {
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_APAC', country: 'India' }), 'south-asia');
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_APAC', country: 'Pakistan' }), 'south-asia');
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_APAC', country: 'Bangladesh' }), 'south-asia');
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_APAC', country: 'Japan' }), 'east-asia');
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_APAC', country: 'China' }), 'east-asia');
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_APAC', country: 'Singapore' }), 'east-asia');
+  });
+
+  it('routes europe/mena/africa directly', () => {
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_EUROPE', country: 'Germany' }), 'europe');
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_MENA', country: 'UAE' }), 'mena');
+    assert.equal(airportToSnapshotRegion({ region: 'AIRPORT_REGION_AFRICA', country: 'Kenya' }), 'sub-saharan-africa');
+  });
+
+  it('handles lowercase region labels (seeder-internal format)', () => {
+    assert.equal(airportToSnapshotRegion({ region: 'americas', country: 'USA' }), 'north-america');
+    assert.equal(airportToSnapshotRegion({ region: 'mena', country: 'Qatar' }), 'mena');
+  });
+
+  it('returns null for null/unknown inputs', () => {
+    assert.equal(airportToSnapshotRegion(null), null);
+    assert.equal(airportToSnapshotRegion({}), null);
+    assert.equal(airportToSnapshotRegion({ region: 'UNKNOWN', country: 'X' }), null);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// gpsjamRegionToSnapshotRegion
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('gpsjamRegionToSnapshotRegion', () => {
+  it('maps MENA sub-regions', () => {
+    assert.equal(gpsjamRegionToSnapshotRegion('iran-iraq'), 'mena');
+    assert.equal(gpsjamRegionToSnapshotRegion('levant'), 'mena');
+    assert.equal(gpsjamRegionToSnapshotRegion('israel-sinai'), 'mena');
+    assert.equal(gpsjamRegionToSnapshotRegion('yemen-horn'), 'mena');
+    assert.equal(gpsjamRegionToSnapshotRegion('turkey-caucasus'), 'mena');
+  });
+
+  it('maps Europe sub-regions', () => {
+    assert.equal(gpsjamRegionToSnapshotRegion('ukraine-russia'), 'europe');
+    assert.equal(gpsjamRegionToSnapshotRegion('russia-north'), 'europe');
+    assert.equal(gpsjamRegionToSnapshotRegion('northern-europe'), 'europe');
+    assert.equal(gpsjamRegionToSnapshotRegion('western-europe'), 'europe');
+  });
+
+  it('maps SSA sub-regions', () => {
+    assert.equal(gpsjamRegionToSnapshotRegion('sudan-sahel'), 'sub-saharan-africa');
+    assert.equal(gpsjamRegionToSnapshotRegion('east-africa'), 'sub-saharan-africa');
+  });
+
+  it('maps South Asia, East Asia, North America', () => {
+    assert.equal(gpsjamRegionToSnapshotRegion('afghanistan-pakistan'), 'south-asia');
+    assert.equal(gpsjamRegionToSnapshotRegion('southeast-asia'), 'east-asia');
+    assert.equal(gpsjamRegionToSnapshotRegion('east-asia'), 'east-asia');
+    assert.equal(gpsjamRegionToSnapshotRegion('north-america'), 'north-america');
+  });
+
+  it('returns null for "other" and unknown labels', () => {
+    assert.equal(gpsjamRegionToSnapshotRegion('other'), null);
+    assert.equal(gpsjamRegionToSnapshotRegion('antarctica'), null);
+    assert.equal(gpsjamRegionToSnapshotRegion(undefined), null);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// latLonToSnapshotRegion
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('latLonToSnapshotRegion', () => {
+  it('classifies major cities to the right region', () => {
+    assert.equal(latLonToSnapshotRegion(25.2532, 55.3657), 'mena'); // Dubai
+    assert.equal(latLonToSnapshotRegion(32.0055, 34.8854), 'mena'); // Tel Aviv
+    assert.equal(latLonToSnapshotRegion(51.4700, -0.4543), 'europe'); // LHR
+    assert.equal(latLonToSnapshotRegion(55.9736, 37.4125), 'europe'); // Moscow SVO
+    assert.equal(latLonToSnapshotRegion(35.5494, 139.7798), 'east-asia'); // Tokyo Haneda
+    assert.equal(latLonToSnapshotRegion(28.5562, 77.1000), 'south-asia'); // Delhi
+    assert.equal(latLonToSnapshotRegion(40.6413, -73.7781), 'north-america'); // JFK
+    assert.equal(latLonToSnapshotRegion(-23.4356, -46.4731), 'latam'); // São Paulo
+    assert.equal(latLonToSnapshotRegion(-1.3192, 36.9278), 'sub-saharan-africa'); // Nairobi
+  });
+
+  it('returns null for oceans and unmapped areas', () => {
+    assert.equal(latLonToSnapshotRegion(-70, 0), null); // Antarctica
+    assert.equal(latLonToSnapshotRegion(0, -150), null); // mid-Pacific
+  });
+
+  it('returns null for invalid inputs', () => {
+    assert.equal(latLonToSnapshotRegion(null, null), null);
+    assert.equal(latLonToSnapshotRegion(undefined, 0), null);
+    assert.equal(latLonToSnapshotRegion(NaN, NaN), null);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// buildAirports
+// ────────────────────────────────────────────────────────────────────────────
+
+function alert(overrides = {}) {
+  const iata = overrides.iata ?? 'ABC';
+  return {
+    id: `x-${iata}`,
+    iata,
+    icao: overrides.icao ?? `K${iata}`,
+    name: overrides.name ?? iata,
+    city: overrides.city ?? iata,
+    country: overrides.country ?? 'USA',
+    region: overrides.region ?? 'AIRPORT_REGION_AMERICAS',
+    delayType: overrides.delayType ?? 'FLIGHT_DELAY_TYPE_GROUND_DELAY',
+    severity: overrides.severity ?? 'FLIGHT_DELAY_SEVERITY_MAJOR',
+    avgDelayMinutes: overrides.avgDelayMinutes ?? 60,
+    reason: overrides.reason ?? 'Weather',
+    source: overrides.source ?? 'FLIGHT_DELAY_SOURCE_FAA',
+  };
+}
+
+describe('buildAirports', () => {
+  it('returns empty array when sources are missing', () => {
+    assert.deepEqual(buildAirports('mena', {}), []);
+    assert.deepEqual(buildAirports('mena', { 'aviation:delays:faa:v1': null }), []);
+  });
+
+  it('filters to airports in the requested region only', () => {
+    const sources = {
+      'aviation:delays:faa:v1': {
+        alerts: [
+          alert({ iata: 'JFK', icao: 'KJFK', country: 'USA' }),
+          alert({ iata: 'LAX', icao: 'KLAX', country: 'USA' }),
+        ],
+      },
+      'aviation:delays:intl:v3': {
+        alerts: [
+          alert({ iata: 'DXB', icao: 'OMDB', country: 'UAE', region: 'AIRPORT_REGION_MENA' }),
+          alert({ iata: 'LHR', icao: 'EGLL', country: 'UK', region: 'AIRPORT_REGION_EUROPE' }),
+        ],
+      },
+    };
+    const na = buildAirports('north-america', sources);
+    assert.equal(na.length, 2);
+    assert.deepEqual(na.map((a) => a.icao).sort(), ['KJFK', 'KLAX']);
+
+    const mena = buildAirports('mena', sources);
+    assert.equal(mena.length, 1);
+    assert.equal(mena[0].icao, 'OMDB');
+  });
+
+  it('filters out alerts below MAJOR severity', () => {
+    const sources = {
+      'aviation:delays:faa:v1': {
+        alerts: [
+          alert({ iata: 'JFK', severity: 'FLIGHT_DELAY_SEVERITY_MINOR' }),
+          alert({ iata: 'LAX', severity: 'FLIGHT_DELAY_SEVERITY_MODERATE' }),
+          alert({ iata: 'ORD', severity: 'FLIGHT_DELAY_SEVERITY_MAJOR' }),
+          alert({ iata: 'ATL', severity: 'FLIGHT_DELAY_SEVERITY_SEVERE' }),
+        ],
+      },
+    };
+    const na = buildAirports('north-america', sources);
+    assert.equal(na.length, 2);
+    assert.deepEqual(na.map((a) => a.name).sort(), ['ATL', 'ORD']);
+  });
+
+  it('maps severity to disrupted vs closed', () => {
+    const sources = {
+      'aviation:delays:faa:v1': {
+        alerts: [
+          alert({ iata: 'MAJOR', severity: 'FLIGHT_DELAY_SEVERITY_MAJOR' }),
+          alert({ iata: 'SEVERE', severity: 'FLIGHT_DELAY_SEVERITY_SEVERE' }),
+        ],
+      },
+    };
+    const na = buildAirports('north-america', sources);
+    const byName = Object.fromEntries(na.map((a) => [a.name, a.status]));
+    assert.equal(byName['MAJOR'], 'disrupted');
+    assert.equal(byName['SEVERE'], 'closed');
+  });
+
+  it('carries disruption_reason from the alert', () => {
+    const sources = {
+      'aviation:delays:faa:v1': {
+        alerts: [alert({ reason: 'Ground stop due to weather' })],
+      },
+    };
+    const na = buildAirports('north-america', sources);
+    assert.equal(na[0].disruption_reason, 'Ground stop due to weather');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// buildAirspace
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('buildAirspace', () => {
+  it('returns empty when no hexes are present', () => {
+    assert.deepEqual(buildAirspace('mena', {}), []);
+    assert.deepEqual(buildAirspace('mena', { 'intelligence:gpsjam:v2': { hexes: [] } }), []);
+  });
+
+  it('aggregates hexes for this region into ONE AirspaceStatus entry', () => {
+    const sources = {
+      'intelligence:gpsjam:v2': {
+        hexes: [
+          { h3: 'h1', lat: 30, lon: 45, level: 'high', region: 'iran-iraq' },
+          { h3: 'h2', lat: 32, lon: 48, level: 'high', region: 'iran-iraq' },
+          { h3: 'h3', lat: 31, lon: 36, level: 'medium', region: 'levant' },
+          // Non-region hex — must be excluded
+          { h3: 'h4', lat: 50, lon: 10, level: 'high', region: 'western-europe' },
+        ],
+      },
+    };
+    const out = buildAirspace('mena', sources);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].airspace_id, 'gpsjam:mena');
+    assert.equal(out[0].status, 'restricted');
+    assert.match(out[0].reason, /iran-iraq.*levant|levant.*iran-iraq/);
+    assert.match(out[0].reason, /2 high/);
+    assert.match(out[0].reason, /1 medium/);
+  });
+
+  it('returns empty when region has no matching hexes', () => {
+    const sources = {
+      'intelligence:gpsjam:v2': {
+        hexes: [
+          { h3: 'h1', lat: 30, lon: 45, level: 'high', region: 'iran-iraq' },
+        ],
+      },
+    };
+    assert.deepEqual(buildAirspace('latam', sources), []);
+  });
+
+  it('handles low-only hexes as restricted (GPS jam affects RNAV)', () => {
+    const sources = {
+      'intelligence:gpsjam:v2': {
+        hexes: [
+          { h3: 'h1', lat: 30, lon: 45, level: 'low', region: 'iran-iraq' },
+        ],
+      },
+    };
+    const out = buildAirspace('mena', sources);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].status, 'restricted');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// buildRerouteIntensity
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('buildRerouteIntensity', () => {
+  it('returns 0 when no military flights', () => {
+    assert.equal(buildRerouteIntensity('mena', {}), 0);
+    assert.equal(buildRerouteIntensity('mena', { 'military:flights:v1': { flights: [] } }), 0);
+  });
+
+  it('counts only flights whose lat/lon maps to the requested region', () => {
+    const sources = {
+      'military:flights:v1': {
+        flights: [
+          { lat: 32, lon: 35, operator: 'iaf' },     // MENA
+          { lat: 31, lon: 34, operator: 'iaf' },     // MENA
+          { lat: 35, lon: 139, operator: 'jsdf' },   // East Asia
+          { lat: 52, lon: 13, operator: 'gaf' },     // Europe
+        ],
+      },
+    };
+    const mena = buildRerouteIntensity('mena', sources);
+    assert.ok(mena > 0 && mena < 1);
+    // 2 flights / 50 = 0.04
+    assert.equal(Math.round(mena * 1000) / 1000, 0.04);
+  });
+
+  it('saturates at 1.0 for large flight counts', () => {
+    const flights = Array.from({ length: 100 }, () => ({ lat: 32, lon: 35 }));
+    const sources = { 'military:flights:v1': { flights } };
+    assert.equal(buildRerouteIntensity('mena', sources), 1);
+  });
+
+  it('ignores flights with missing lat/lon', () => {
+    const sources = {
+      'military:flights:v1': {
+        flights: [
+          { operator: 'x' }, // no coords
+          { lat: null, lon: 35 },
+          { lat: 32, lon: 35 },
+        ],
+      },
+    };
+    // Only the last flight counts (1/50 = 0.02)
+    assert.equal(buildRerouteIntensity('mena', sources), 0.02);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// buildNotamClosures
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('buildNotamClosures', () => {
+  it('returns empty when no NOTAM source present', () => {
+    assert.deepEqual(buildNotamClosures('mena', {}), []);
+    assert.deepEqual(buildNotamClosures('mena', { 'aviation:notam:closures:v2': {} }), []);
+  });
+
+  it('emits reason strings for airports in the region that have NOTAMs', () => {
+    const sources = {
+      'aviation:notam:closures:v2': {
+        closedIcaos: ['OMDB', 'EGLL'],
+        restrictedIcaos: [],
+        reasons: {
+          OMDB: 'Runway closure until 06:00 UTC',
+          EGLL: 'Fuel contamination alert',
+        },
+      },
+      'aviation:delays:intl:v3': {
+        alerts: [
+          { iata: 'DXB', icao: 'OMDB', country: 'UAE', region: 'AIRPORT_REGION_MENA', severity: 'FLIGHT_DELAY_SEVERITY_MAJOR', reason: 'x' },
+          { iata: 'LHR', icao: 'EGLL', country: 'UK', region: 'AIRPORT_REGION_EUROPE', severity: 'FLIGHT_DELAY_SEVERITY_MAJOR', reason: 'x' },
+        ],
+      },
+    };
+    const mena = buildNotamClosures('mena', sources);
+    assert.equal(mena.length, 1);
+    assert.match(mena[0], /OMDB.*Runway closure/);
+
+    const europe = buildNotamClosures('europe', sources);
+    assert.equal(europe.length, 1);
+    assert.match(europe[0], /EGLL.*Fuel contamination/);
+  });
+
+  it('skips NOTAMs whose ICAO can\'t be attributed to a region', () => {
+    const sources = {
+      'aviation:notam:closures:v2': {
+        closedIcaos: ['ZZZZ'],
+        reasons: { ZZZZ: 'Unknown' },
+      },
+      // No airport alert maps ZZZZ to a region
+    };
+    assert.deepEqual(buildNotamClosures('mena', sources), []);
+  });
+
+  it('truncates very long reason strings to 200 chars', () => {
+    const longReason = 'x'.repeat(500);
+    const sources = {
+      'aviation:notam:closures:v2': {
+        closedIcaos: ['OMDB'],
+        reasons: { OMDB: longReason },
+      },
+      'aviation:delays:intl:v3': {
+        alerts: [
+          { iata: 'DXB', icao: 'OMDB', country: 'UAE', region: 'AIRPORT_REGION_MENA', severity: 'FLIGHT_DELAY_SEVERITY_MAJOR', reason: 'x' },
+        ],
+      },
+    };
+    const out = buildNotamClosures('mena', sources);
+    // "OMDB: " prefix + 200 truncated chars
+    assert.ok(out[0].length <= 'OMDB: '.length + 200);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// buildMobilityState (top-level composer)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('buildMobilityState', () => {
+  it('returns a fully-populated shape matching the proto', () => {
+    const sources = {
+      'aviation:delays:faa:v1': { alerts: [alert({ iata: 'JFK', severity: 'FLIGHT_DELAY_SEVERITY_MAJOR' })] },
+      'aviation:delays:intl:v3': { alerts: [] },
+      'aviation:notam:closures:v2': { closedIcaos: [], reasons: {} },
+      'intelligence:gpsjam:v2': { hexes: [{ h3: 'h1', lat: 40, lon: -74, level: 'high', region: 'north-america' }] },
+      'military:flights:v1': { flights: [{ lat: 40, lon: -74 }] },
+    };
+    const state = buildMobilityState('north-america', sources);
+    assert.ok(Array.isArray(state.airspace));
+    assert.equal(state.airspace.length, 1);
+    assert.ok(Array.isArray(state.flight_corridors));
+    assert.equal(state.flight_corridors.length, 0);
+    assert.ok(Array.isArray(state.airports));
+    assert.equal(state.airports.length, 1);
+    assert.ok(typeof state.reroute_intensity === 'number');
+    assert.ok(state.reroute_intensity >= 0 && state.reroute_intensity <= 1);
+    assert.ok(Array.isArray(state.notam_closures));
+  });
+
+  it('returns empty shape when all sources are missing', () => {
+    const state = buildMobilityState('mena', {});
+    assert.deepEqual(state, {
+      airspace: [],
+      flight_corridors: [],
+      airports: [],
+      reroute_intensity: 0,
+      notam_closures: [],
+    });
+  });
+
+  it('never throws on malformed source objects', () => {
+    const garbage = {
+      'aviation:delays:faa:v1': 'not an object',
+      'aviation:delays:intl:v3': 42,
+      'aviation:notam:closures:v2': null,
+      'intelligence:gpsjam:v2': { hexes: 'also not an array' },
+      'military:flights:v1': { flights: null },
+    };
+    assert.doesNotThrow(() => buildMobilityState('mena', garbage));
+    const state = buildMobilityState('mena', garbage);
+    assert.deepEqual(state, {
+      airspace: [],
+      flight_corridors: [],
+      airports: [],
+      reroute_intensity: 0,
+      notam_closures: [],
+    });
+  });
+
+  it('isolates regions — data for one region does not leak into another', () => {
+    const sources = {
+      'aviation:delays:faa:v1': {
+        alerts: [alert({ iata: 'JFK', icao: 'KJFK', country: 'USA' })],
+      },
+      'intelligence:gpsjam:v2': {
+        hexes: [{ h3: 'h1', lat: 32, lon: 35, level: 'high', region: 'iran-iraq' }],
+      },
+      'military:flights:v1': {
+        flights: [{ lat: 40, lon: -74 }, { lat: 32, lon: 35 }],
+      },
+    };
+    const na = buildMobilityState('north-america', sources);
+    const mena = buildMobilityState('mena', sources);
+    // NA gets its airport and its military flight, MENA doesn't
+    assert.equal(na.airports.length, 1);
+    assert.equal(mena.airports.length, 0);
+    // MENA gets its airspace and its military flight, NA doesn't get MENA airspace
+    assert.equal(mena.airspace.length, 1);
+    assert.equal(na.airspace.length, 0);
+    assert.ok(na.reroute_intensity > 0);
+    assert.ok(mena.reroute_intensity > 0);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 PR2 of the Regional Intelligence Model. Replaces the Phase 0 empty \`mobility\` stub with a real \`MobilityState\` built entirely from existing Redis inputs. No new seeders, no new API keys, no new dependencies.

## What landed

### New module: \`scripts/regional-snapshot/mobility.mjs\`

Single public entry point: \`buildMobilityState(regionId, sources) -> MobilityState\`. Pure, never throws, wrapped in a defensive try/catch so snapshot persist can never be blocked by a mobility builder bug.

### Data sources (all already in the repo)

| Key | Coverage | Used for |
|---|---|---|
| \`aviation:delays:faa:v1\` | US airports | \`airports[]\` (NA) |
| \`aviation:delays:intl:v3\` | ~51 non-US airports worldwide | \`airports[]\` (all other regions) |
| \`aviation:notam:closures:v2\` | Global ICAO NOTAM closures | \`notam_closures[]\` |
| \`intelligence:gpsjam:v2\` | Global GPS jamming hexes | \`airspace[]\` |
| \`military:flights:v1\` | Global military ADSB tracks | \`reroute_intensity\` proxy |

### Per-field output mapping

| Field | Source | Coverage |
|---|---|---|
| \`airspace[]\` | GPS-jam hexes aggregated 1:region | **All 7 regions** |
| \`flight_corridors[]\` | (intentionally empty in v1) | — |
| \`airports[]\` | FAA + intl delays, severity ≥ MAJOR | **All 7 regions** |
| \`reroute_intensity\` | \`clip(militaryCount / 50, 0, 1)\` | **All 7 regions** |
| \`notam_closures[]\` | NOTAM reasons for region airports | **All 7 regions** |

### Region classification helpers

Three pure classifiers handle the three different region conventions the source data uses:

- **\`airportToSnapshotRegion(alert)\`** — splits AviationStack \`AIRPORT_REGION_*\` enum by country so \`AMERICAS\` → {\`north-america\`, \`latam\`} and \`APAC\` → {\`south-asia\`, \`east-asia\`}
- **\`gpsjamRegionToSnapshotRegion(label)\`** — maps the 17 \`fetch-gpsjam.mjs\` region labels (iran-iraq, levant, ukraine-russia, etc.) to the 7 snapshot regions. Turkey/Caucasus intentionally lands in MENA per the geography.js WB override.
- **\`latLonToSnapshotRegion(lat, lon)\`** — bbox classifier for military flights. Coarse but shippable; v2 could use h3/geometry.

### Key design decisions

1. **Airspace aggregation**: v1 emits ONE \`AirspaceStatus\` per region instead of one per GPS-jam hex. Emitting per-hex would flood the UI (MENA currently has 40+ hexes). The aggregated entry's \`reason\` lists sub-region names and high/med/low counts so analysts can still drill into the underlying data via the evidence chain.

2. **Reroute intensity proxy**: Military flight count is crude but defensible as a civil-rerouting pressure signal. A dedicated civil ADSB track-diversion pipeline would be more rigorous, but this gets us a defensible 0-1 scalar today. Documented inline.

3. **Airport severity filter**: Only surfaces alerts at MAJOR or SEVERE to keep the list focused on actionable state. SEVERE maps to \`closed\`, MAJOR maps to \`disrupted\`.

### Freshness registry

Added 5 new input keys to \`FRESHNESS_REGISTRY\` so the snapshot's \`missing_inputs\` / \`stale_inputs\` classification tracks mobility sources. Per-key \`maxAgeMin\` set to 2x each source's cron cadence.

## Testing

35 new unit tests in \`tests/regional-snapshot-mobility.test.mjs\`:

- **\`airportToSnapshotRegion\`** (5): US/CA/MX → NA, LatAm countries → latam, APAC split by country, europe/mena/africa direct, case insensitivity, null safety
- **\`gpsjamRegionToSnapshotRegion\`** (4): 17 labels mapped correctly, "other"/unknown → null
- **\`latLonToSnapshotRegion\`** (3): major cities classified correctly, oceans → null, invalid inputs → null
- **\`buildAirports\`** (5): empty sources, region filter, severity filter, severity → status mapping, reason passthrough
- **\`buildAirspace\`** (4): empty, region-scoped aggregation, no-match returns empty, low-level still restricted
- **\`buildRerouteIntensity\`** (4): zero, region-scoped count, saturation at 1.0, missing coords ignored
- **\`buildNotamClosures\`** (4): empty, region attribution via airport alerts, unattributable ICAOs skipped, long-reason truncation
- **\`buildMobilityState\`** (4): full shape matches proto, all-empty safe, malformed inputs don't throw, **region isolation across all fields**

- \`npm run test:data\`: 4537/4537 pass
- \`npm run typecheck\` + \`typecheck:api\`: clean
- Scripts JSDoc typecheck: clean on touched files
- \`biome lint\` on touched files: clean

## Deferred to future iterations

- Direct civil flight track diversion counts per corridor
- \`flight_corridors[]\` stress level + \`rerouted_flights_24h\`
- LLM-assisted NOTAM structured parse
- h3 geometry for smarter hex-to-region attribution
- Mobility-based alert triggers in the diff engine

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Railway \`derived-signals\` bundle logs for \`[mobility]\` warn lines (should be absent under steady state — the builder never throws, but catches any bug and logs).
  - Upstash: after the next cron cycle, \`intelligence:snapshot-by-id:v1:mena\` (and other regions) should carry non-empty \`mobility.airspace\` and non-zero \`mobility.reroute_intensity\`.
  - \`meta.missing_inputs\` on each snapshot should NOT list the new mobility keys (they're all seeded globally).
- **Validation checks**
  - \`redis-cli GET intelligence:snapshot:v1:mena:latest\` → fetch id → \`GET intelligence:snapshot-by-id:v1:<id>\` → inspect \`mobility.airspace[0].reason\` contains GPS-jam hex counts
  - Repeat for \`europe\`, \`east-asia\`, \`sub-saharan-africa\` — each should have populated \`airspace[]\` OR empty (if GPS jam hexes aren't in that region)
  - \`mobility.airports[]\` should be non-empty for regions with actively-delayed airports
- **Expected healthy behavior**
  - 6+ of 7 regions have some mobility data within one cron cycle
  - No \`[mobility]\` warn lines
  - Snapshot persist rate unchanged (mobility v1 is additive, no break)
- **Failure signal(s) / rollback trigger**
  - \`[mobility] ... builder threw\` lines appear → investigate shape mismatch
  - Snapshot persist rate regresses → should be impossible (try/catch guards it)
  - All regions report empty \`airspace[]\` → \`intelligence:gpsjam:v2\` isn't flowing, check Railway \`gpsjam\` service
- **Validation window & owner**
  - 12 hours post-merge. Owner: @koala73

## PR sequence

- [x] Phase 0 PR1 (#2940): snapshot writer foundation — MERGED
- [x] Phase 0 PR2 (#2942): forecast region filter — MERGED
- [x] Phase 1 PR1 (#2951): proto + RPC handler — MERGED
- [x] Phase 0 review fixes (#2952): region-scoping + corridor union — MERGED
- [x] Phase 1 PR2 (#2960): LLM narrative generator — MERGED
- [x] Phase 1 PR3 (#2963): RegionalIntelligenceBoard panel UI — MERGED
- [x] Phase 2 PR1 (#2966): state-change alerts — MERGED
- [ ] **Phase 2 PR2 (this PR)**: Mobility v1 population
- [ ] Phase 3: weekly briefs + regime drift (future)