### PR TITLE
fix(supply-chain): gate get-sector-dependency via premium-paths

### DIFF
--- a/src/shared/premium-paths.ts
+++ b/src/shared/premium-paths.ts
@@ -20,6 +20,7 @@ export const PREMIUM_RPC_PATHS = new Set<string>([
   '/api/supply-chain/v1/get-bypass-options',
   '/api/supply-chain/v1/get-country-cost-shock',
   '/api/supply-chain/v1/get-route-explorer-lane',
+  '/api/supply-chain/v1/get-sector-dependency',
   '/api/supply-chain/v1/multi-sector-cost-shock',
   '/api/economic/v1/get-national-debt',
   '/api/sanctions/v1/list-sanctions-pressure',

--- a/tests/supply-chain-sprint2.test.mjs
+++ b/tests/supply-chain-sprint2.test.mjs
@@ -275,6 +275,10 @@ describe('Premium paths registration', () => {
   it('get-country-cost-shock is in PREMIUM_RPC_PATHS', () => {
     assert.match(src, /\/api\/supply-chain\/v1\/get-country-cost-shock/);
   });
+
+  it('get-sector-dependency is in PREMIUM_RPC_PATHS', () => {
+    assert.match(src, /\/api\/supply-chain\/v1\/get-sector-dependency/);
+  });
 });
 
 // ========================================================================


### PR DESCRIPTION
## Summary
- `/api/supply-chain/v1/get-sector-dependency` was missing from `PREMIUM_RPC_PATHS` in `src/shared/premium-paths.ts`
- Effect: gateway never enforced the premium check; non-PRO browser callers got `HTTP 200` with an empty-shape payload from `get-sector-dependency.ts` instead of `HTTP 401/403` from the gateway
- Handler-level `isCallerPremium` was silently returning the empty fallback, masking the gating hole
- Fix: add the RPC path to `PREMIUM_RPC_PATHS` so the gateway's legacy-pro-bearer check runs and returns the correct error status
- Defense-in-depth: handler-level `isCallerPremium` still returns empty payload as fallback if anything ever slipped past the gateway
- Discovered during Codex review of the worldwide Route Explorer plan (`docs/plans/2026-04-11-001-feat-worldwide-route-explorer-plan.md`); split out as an independent fix so it ships without waiting on the larger feature

## Test plan
- [ ] Non-PRO anonymous request to `/api/supply-chain/v1/get-sector-dependency` returns `401` (was `200` with empty payload)
- [ ] PRO authenticated request still returns valid payload
- [ ] Existing consumers (CountryDeepDivePanel, SupplyChainPanel) still work for PRO users