### PR TITLE
feat(resilience): signal tiering registry, Core/Enrichment/Experimental (Phase 2 T2.2a)

### DIFF
--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -1,5 +1,22 @@
 import type { ResilienceDimensionId } from './_dimension-scorers.ts';
 
+// Phase 2 T2.2a signal tiering. See docs/internal/country-resilience-upgrade-plan.md
+// section "Signal tiering (Core / Enrichment / Experimental)".
+export type IndicatorTier = 'core' | 'enrichment' | 'experimental';
+
+// Phase 2 T2.2a license audit field. The values come from the parent plan's
+// licensing audit workstream (Phase 2 A9). New entries that have not yet been
+// audited use 'unknown' as a placeholder; the linter test reports the count
+// without failing so the audit can chase them.
+export type IndicatorLicense =
+  | 'public-domain' // WGI, WHO GHO, FRED, UN Comtrade (openly usable)
+  | 'open-data' // ND-GAIN, World Bank Open Data, IMF Open Data (CC-BY or similar)
+  | 'open-attribution' // GDELT, RSF Index, OWID (attribution required)
+  | 'research-only' // UCDP (Uppsala), ACLED (academic/press), INFORM-Global (CC-BY-NC)
+  | 'non-commercial' // FSI, BIS EER, GPI/IEP (free with carve-out)
+  | 'proprietary' // Bloomberg, S&P Global Platts (not used in Core)
+  | 'unknown'; // placeholder for any indicator still awaiting license audit
+
 export type IndicatorSpec = {
   id: string;
   dimension: ResilienceDimensionId;
@@ -11,6 +28,10 @@ export type IndicatorSpec = {
   scope: 'global' | 'curated';
   cadence: 'realtime' | 'daily' | 'weekly' | 'monthly' | 'annual';
   imputation?: { type: 'absenceSignal' | 'conservative'; score: number; certainty: number };
+  // Phase 2 T2.2a additions (REQUIRED on every entry):
+  tier: IndicatorTier; // Core = moves the public overall score, Enrichment = drill-down only, Experimental = internal
+  coverage: number; // expected country count; the tier linter enforces Core >= 180
+  license: IndicatorLicense; // source license category for the audit trail
 };
 
 export const INDICATOR_REGISTRY: IndicatorSpec[] = [
@@ -25,6 +46,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'economic:imf:macro:v2',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 212,
+    license: 'open-data',
   },
   {
     id: 'debtGrowthRate',
@@ -36,6 +60,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'economic:national-debt:v1',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 190,
+    license: 'open-data',
   },
   {
     id: 'currentAccountPct',
@@ -47,6 +74,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'economic:imf:macro:v2',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 190,
+    license: 'open-data',
   },
 
   // ── currencyExternal (3 sub-metrics, plus IMF inflation fallback for non-BIS) ─
@@ -61,6 +91,12 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     scope: 'curated',
     cadence: 'monthly',
     imputation: { type: 'conservative', score: 50, certainty: 0.3 },
+    // BIS REER is curated (~60 countries). Demoted to Enrichment by the
+    // Phase 2 A4 coverage gate; the IMF inflation + WB reserves fallback
+    // chain still feeds the Core fxReservesAdequacy signal globally.
+    tier: 'enrichment',
+    coverage: 60,
+    license: 'non-commercial',
   },
   {
     id: 'fxDeviation',
@@ -73,6 +109,10 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     scope: 'curated',
     cadence: 'monthly',
     imputation: { type: 'conservative', score: 50, certainty: 0.3 },
+    // BIS REER curated source, same coverage limitation as fxVolatility.
+    tier: 'enrichment',
+    coverage: 60,
+    license: 'non-commercial',
   },
   {
     id: 'fxReservesAdequacy',
@@ -84,6 +124,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:*',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 188,
+    license: 'open-data',
   },
 
   // ── tradeSanctions (4 sub-metrics) ────────────────────────────────────────
@@ -97,6 +140,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'sanctions:country-counts:v1',
     scope: 'global',
     cadence: 'daily',
+    tier: 'core',
+    coverage: 200,
+    license: 'public-domain',
   },
   {
     id: 'tradeRestrictions',
@@ -109,6 +155,12 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     scope: 'curated',
     cadence: 'weekly',
     imputation: { type: 'conservative', score: 60, certainty: 0.4 },
+    // WTO tariff-overview reporter set is the curated top-50 reporters; below
+    // the Core 180 gate so the signal sits in Enrichment until a wider seeder
+    // ships in a future PR.
+    tier: 'enrichment',
+    coverage: 50,
+    license: 'open-data',
   },
   {
     id: 'tradeBarriers',
@@ -121,6 +173,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     scope: 'curated',
     cadence: 'weekly',
     imputation: { type: 'conservative', score: 60, certainty: 0.4 },
+    tier: 'enrichment',
+    coverage: 50,
+    license: 'open-data',
   },
   {
     id: 'appliedTariffRate',
@@ -132,6 +187,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 188,
+    license: 'open-data',
   },
 
   // ── cyberDigital (3 sub-metrics) ──────────────────────────────────────────
@@ -145,6 +203,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'cyber:threats:v2',
     scope: 'global',
     cadence: 'daily',
+    tier: 'core',
+    coverage: 195,
+    license: 'open-attribution',
   },
   {
     id: 'internetOutages',
@@ -156,6 +217,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'infra:outages:v1',
     scope: 'global',
     cadence: 'realtime',
+    tier: 'core',
+    coverage: 195,
+    license: 'open-attribution',
   },
   {
     id: 'gpsJamming',
@@ -167,6 +231,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'intelligence:gpsjam:v2',
     scope: 'global',
     cadence: 'daily',
+    tier: 'core',
+    coverage: 195,
+    license: 'open-attribution',
   },
 
   // ── logisticsSupply (3 sub-metrics) ───────────────────────────────────────
@@ -180,6 +247,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 188,
+    license: 'open-data',
   },
   {
     id: 'shippingStress',
@@ -191,6 +261,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'supply_chain:shipping_stress:v1',
     scope: 'global',
     cadence: 'daily',
+    tier: 'core',
+    coverage: 195,
+    license: 'open-attribution',
   },
   {
     id: 'transitDisruption',
@@ -202,6 +275,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'supply_chain:transit-summaries:v1',
     scope: 'global',
     cadence: 'daily',
+    tier: 'core',
+    coverage: 195,
+    license: 'open-attribution',
   },
 
   // ── infrastructure (3 sub-metrics) ────────────────────────────────────────
@@ -215,6 +291,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 217,
+    license: 'open-data',
   },
   {
     id: 'roadsPavedInfra',
@@ -226,6 +305,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 188,
+    license: 'open-data',
   },
   {
     id: 'infraOutages',
@@ -237,6 +319,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'infra:outages:v1',
     scope: 'global',
     cadence: 'realtime',
+    tier: 'core',
+    coverage: 195,
+    license: 'open-attribution',
   },
 
   // ── energy (7 sub-metrics) ────────────────────────────────────────────────
@@ -250,6 +335,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 188,
+    license: 'open-data',
   },
   {
     id: 'gasShare',
@@ -261,6 +349,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'energy:mix:v1:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 195,
+    license: 'open-attribution',
   },
   {
     id: 'coalShare',
@@ -272,6 +363,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'energy:mix:v1:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 195,
+    license: 'open-attribution',
   },
   {
     id: 'renewShare',
@@ -283,6 +377,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'energy:mix:v1:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 195,
+    license: 'open-attribution',
   },
   {
     id: 'gasStorageStress',
@@ -294,6 +391,11 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'energy:gas-storage:v1:{ISO2}',
     scope: 'global',
     cadence: 'daily',
+    // GIE AGSI+ covers EU + a few neighbours; below the Core 180 gate so the
+    // signal lives in Enrichment until a wider gas-storage feed lands.
+    tier: 'enrichment',
+    coverage: 38,
+    license: 'open-attribution',
   },
   {
     id: 'energyPriceStress',
@@ -305,6 +407,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'economic:energy:v1:all',
     scope: 'global',
     cadence: 'daily',
+    tier: 'core',
+    coverage: 195,
+    license: 'public-domain',
   },
   {
     id: 'electricityConsumption',
@@ -316,6 +421,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 217,
+    license: 'open-data',
   },
 
   // ── governanceInstitutional (6 sub-metrics, equal weight) ─────────────────
@@ -329,6 +437,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 214,
+    license: 'public-domain',
   },
   {
     id: 'wgiPoliticalStability',
@@ -340,6 +451,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 214,
+    license: 'public-domain',
   },
   {
     id: 'wgiGovernmentEffectiveness',
@@ -351,6 +465,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 214,
+    license: 'public-domain',
   },
   {
     id: 'wgiRegulatoryQuality',
@@ -362,6 +479,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 214,
+    license: 'public-domain',
   },
   {
     id: 'wgiRuleOfLaw',
@@ -373,6 +493,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 214,
+    license: 'public-domain',
   },
   {
     id: 'wgiControlOfCorruption',
@@ -384,6 +507,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 214,
+    license: 'public-domain',
   },
 
   // ── socialCohesion (3 sub-metrics) ────────────────────────────────────────
@@ -397,6 +523,14 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    // GPI/IEP covers 163 economies, below the Phase 2 A4 Core gate of 180.
+    // Demoted to Enrichment so the overall public score is not driven by a
+    // signal that misses ~30 countries; PR 4 (T2.3) aggregation will respect
+    // this. The license is also non-commercial (IEP carve-out), which would
+    // independently disqualify Core. See parent plan, "Signal tiering" section.
+    tier: 'enrichment',
+    coverage: 163,
+    license: 'non-commercial',
   },
   {
     id: 'displacementTotal',
@@ -408,6 +542,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'displacement:summary:v1:{year}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 200,
+    license: 'open-data',
   },
   {
     id: 'unrestEvents',
@@ -419,6 +556,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'unrest:events:v1',
     scope: 'global',
     cadence: 'realtime',
+    tier: 'core',
+    coverage: 195,
+    license: 'open-attribution',
   },
 
   // ── borderSecurity (2 sub-metrics) ────────────────────────────────────────
@@ -432,6 +572,13 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'conflict:ucdp-events:v1',
     scope: 'global',
     cadence: 'realtime',
+    // UCDP is global (193 countries) but the license is research-only
+    // (Uppsala). The parent plan keeps UCDP Core; the linter allowlist
+    // KNOWN_EXCEPTIONS in tests/resilience-indicator-tiering.test.mts holds
+    // the carve-out until Phase 2 A9 licensing review resolves it.
+    tier: 'core',
+    coverage: 193,
+    license: 'research-only',
   },
   {
     id: 'displacementHosted',
@@ -444,9 +591,18 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     scope: 'global',
     cadence: 'annual',
     imputation: { type: 'absenceSignal', score: 85, certainty: 0.6 },
+    tier: 'core',
+    coverage: 200,
+    license: 'open-data',
   },
 
   // ── informationCognitive (3 sub-metrics) ──────────────────────────────────
+  // The whole informationCognitive dimension is demoted to Enrichment until
+  // Phase 2 T2.9 ships the language / source-density normalization. See the
+  // parent plan, "Signal tiering" section: "Existing 13 dimensions default
+  // to Core, with one exception: informationCognitive is demoted to
+  // Enrichment until the language / source-density normalization lands in
+  // T2.9, at which point it re-enters Core."
   {
     id: 'rsfPressFreedom',
     dimension: 'informationCognitive',
@@ -457,6 +613,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'enrichment',
+    coverage: 180,
+    license: 'open-attribution',
   },
   {
     id: 'socialVelocity',
@@ -468,6 +627,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'intelligence:social:reddit:v1',
     scope: 'global',
     cadence: 'realtime',
+    tier: 'enrichment',
+    coverage: 195,
+    license: 'open-attribution',
   },
   {
     id: 'newsThreatScore',
@@ -479,6 +641,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'news:threat:summary:v1',
     scope: 'global',
     cadence: 'daily',
+    tier: 'enrichment',
+    coverage: 195,
+    license: 'open-attribution',
   },
 
   // ── healthPublicService (3 sub-metrics) ───────────────────────────────────
@@ -492,6 +657,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 194,
+    license: 'public-domain',
   },
   {
     id: 'measlesCoverage',
@@ -503,6 +671,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 194,
+    license: 'public-domain',
   },
   {
     id: 'hospitalBeds',
@@ -514,6 +685,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 194,
+    license: 'public-domain',
   },
 
   // ── foodWater (3 sub-metrics) ─────────────────────────────────────────────
@@ -528,6 +702,12 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     scope: 'global',
     cadence: 'annual',
     imputation: { type: 'absenceSignal', score: 88, certainty: 0.7 },
+    // IPC measured coverage is ~52 crisis-tracked countries; absence is a
+    // strong positive signal (stable-absence imputation, score 88), so the
+    // effective country coverage is global. Stays Core per the parent plan.
+    tier: 'core',
+    coverage: 195,
+    license: 'open-data',
   },
   {
     id: 'ipcPhase',
@@ -540,6 +720,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     scope: 'global',
     cadence: 'annual',
     imputation: { type: 'absenceSignal', score: 88, certainty: 0.7 },
+    tier: 'core',
+    coverage: 195,
+    license: 'open-data',
   },
   {
     id: 'aquastatWaterStress',
@@ -551,6 +734,9 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 188,
+    license: 'open-data',
   },
   {
     id: 'aquastatWaterAvailability',
@@ -562,5 +748,8 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:static:{ISO2}',
     scope: 'global',
     cadence: 'annual',
+    tier: 'core',
+    coverage: 188,
+    license: 'open-data',
   },
 ];

--- a/tests/resilience-indicator-tiering.test.mts
+++ b/tests/resilience-indicator-tiering.test.mts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { INDICATOR_REGISTRY } from '../server/worldmonitor/resilience/v1/_indicator-registry.ts';
+
+const CORE_MIN_COVERAGE = 180;
+
+describe('signal tiering registry (Phase 2 T2.2a)', () => {
+  it('every indicator has tier, coverage, license populated', () => {
+    for (const entry of INDICATOR_REGISTRY) {
+      assert.ok(
+        entry.tier === 'core' || entry.tier === 'enrichment' || entry.tier === 'experimental',
+        `${entry.id} missing or invalid tier`,
+      );
+      assert.ok(
+        Number.isFinite(entry.coverage) && entry.coverage > 0,
+        `${entry.id} missing or non-positive coverage`,
+      );
+      assert.ok(
+        typeof entry.license === 'string' && entry.license.length > 0,
+        `${entry.id} missing license`,
+      );
+    }
+  });
+
+  it('Core indicators have coverage >= 180 countries (Phase 2 A4 invariant)', () => {
+    const offending = INDICATOR_REGISTRY
+      .filter((e) => e.tier === 'core' && e.coverage < CORE_MIN_COVERAGE)
+      .map((e) => `${e.id} (${e.coverage} countries, dimension=${e.dimension})`);
+    assert.deepEqual(
+      offending,
+      [],
+      `Core indicators must cover at least ${CORE_MIN_COVERAGE} countries. Demote to Enrichment or fix coverage: ${offending.join(', ')}`,
+    );
+  });
+
+  it('Core indicators use a license compatible with commercial use', () => {
+    const commercialOk = new Set(['public-domain', 'open-data', 'open-attribution']);
+    const offending = INDICATOR_REGISTRY
+      .filter((e) => e.tier === 'core' && !commercialOk.has(e.license))
+      .map((e) => `${e.id} (license=${e.license})`);
+    // Known exceptions the plan allows: GPI (IEP non-commercial, already
+    // demoted to Enrichment) and UCDP (research-only, kept Core because it
+    // is the canonical global conflict event source). These stay on the
+    // allowlist until the Phase 2 A9 Licensing & Legal Review workstream
+    // resolves carve-outs.
+    const KNOWN_EXCEPTIONS = new Set<string>([
+      // UCDP global conflict events: research-only license, kept Core per
+      // parent plan section "Signal tiering". Tracked in Phase 2 A9.
+      'ucdpConflict',
+    ]);
+    const unexcused = offending.filter((s) => {
+      const id = s.split(' ')[0];
+      return !KNOWN_EXCEPTIONS.has(id);
+    });
+    assert.deepEqual(
+      unexcused,
+      [],
+      `Core indicators with incompatible licenses must be demoted or added to KNOWN_EXCEPTIONS: ${unexcused.join(', ')}`,
+    );
+  });
+
+  it('informationCognitive dimension indicators are Enrichment (plan mandate, demoted until T2.9)', () => {
+    const infoCogIndicators = INDICATOR_REGISTRY.filter((e) => e.dimension === 'informationCognitive');
+    assert.ok(infoCogIndicators.length > 0, 'expected informationCognitive indicators in registry');
+    for (const e of infoCogIndicators) {
+      assert.equal(
+        e.tier,
+        'enrichment',
+        `${e.id}: informationCognitive indicators must be 'enrichment' until PR 9 / T2.9 lands the language normalization. See parent plan, "Signal tiering" section.`,
+      );
+    }
+  });
+
+  it('reports unknown-license count for the licensing audit workstream', () => {
+    const unknown = INDICATOR_REGISTRY.filter((e) => e.license === 'unknown');
+    // This is a visibility report, not a failure. Phase 2 A9 (Licensing &
+    // Legal Review) chases these.
+    if (unknown.length > 0) {
+      console.warn(
+        `[T2.2a] ${unknown.length} indicators have license='unknown': ${unknown.map((e) => e.id).join(', ')}`,
+      );
+    }
+    assert.ok(unknown.length < INDICATOR_REGISTRY.length, 'every indicator has unknown license');
+  });
+});


### PR DESCRIPTION
## Summary
Phase 2 T2.2a signal tiering registry. Every entry in `INDICATOR_REGISTRY` gets `tier`, `coverage`, and `license` audit fields. CI-enforced invariants via a new linter test.

This is PR 2 of 10 in the Phase 2 structural rebuild. Does not depend on PR 1 (#2977) at the code level, both can merge in any order.

## What this PR commits
- **Three new fields** on `IndicatorSpec`:
  - `tier: 'core' | 'enrichment' | 'experimental'`
  - `coverage: number` (expected country count)
  - `license: IndicatorLicense` (union of 7 known license categories)
- **Every existing indicator tagged** per the parent plan defaults:
  - Default Core, with `informationCognitive` dimension indicators demoted to Enrichment until PR 9 / T2.9 language normalization
  - Curated-source signals below the 180-country Core gate (BIS REER, WTO curated reporters, GIE AGSI+ gas storage, GPI/IEP) auto-demoted to Enrichment
- **Linter test** `tests/resilience-indicator-tiering.test.mts` with 5 invariants:
  1. Every indicator has tier/coverage/license populated (no defaults, no missing)
  2. Core indicators have coverage at least 180 countries (Phase 2 A4 gate)
  3. Core indicators use a license compatible with commercial use (allowlist for UCDP research-only carve-out)
  4. `informationCognitive` indicators are Enrichment (plan mandate)
  5. Unknown-license visibility report (non-failing, for the A9 licensing audit workstream)

## Tier distribution after this PR
47 indicators total: **38 Core**, **9 Enrichment**, **0 Experimental**, **0 unknown-license**.

Enrichment entries: `fxVolatility`, `fxDeviation`, `tradeRestrictions`, `tradeBarriers`, `gasStorageStress`, `gpiScore`, `rsfPressFreedom`, `socialVelocity`, `newsThreatScore`.

Core with a license carve-out (allowlisted): `ucdpConflict` (research-only license, global 193-country coverage; Phase 2 A9 tracks the legal review).

## Resolved defaults (user-approved)
- All existing indicators default to Core
- `informationCognitive` tier forced to Enrichment until PR 9 re-promotes it
- License audit tracked via `unknown` placeholder plus visibility report
- No runtime behavior change; tier field is metadata only until PR 4 consumes it

## What is NOT in this PR
- **No aggregation change**, PR 4 will consume `tier` to decide which signals contribute to the public overall score
- **No new indicators**, PR 3 / T2.2b ships the recovery-capacity signals
- **No informationCognitive promotion**, PR 9 / T2.9 owns that
- **No methodology doc changes**, PR 10 close-out surfaces the tiering breakdown in the v2.0 changelog

## Phase 2 dependency chain
- PR 1 #2977, schema plus flag (parallel, unblocked)
- **PR 2 (this)**, tiering registry
- PR 3, recovery-capacity signals (stacked on this)
- PR 9, language normalization (stacked on this, promotes infoCog back to Core)
- PR 4, pillar aggregation (stacked on PR 3)
- PR 5/6/7/8/10, see plan file

## Test plan
- [x] `npm run typecheck` plus `typecheck:api` clean
- [x] `tests/resilience-indicator-tiering.test.mts` 5/5 pass
- [x] Full resilience suite (272 tests) passes, no scorer behavior change
- [x] `npm run test:data` clean (4582 tests)
- [x] `npm run lint` clean on the two files touched by this PR
- [ ] Licensing audit workstream (Phase 2 A9) runs through the visibility-report output to chase `license: 'unknown'` entries

## Post-Deploy Monitoring and Validation
No additional operational monitoring required: this PR is a metadata-only refactor of the indicator registry. No runtime code consumes `tier`/`coverage`/`license` yet. Response shapes, cache keys, and scorer behavior are all unchanged. Future PRs (4, 5, 9) will consume the fields.