### PR TITLE
fix(seed): use Comtrade reporter codes for US, FR, IT (not UN M49)

### DIFF
--- a/scripts/seed-comtrade-bilateral-hs4.mjs
+++ b/scripts/seed-comtrade-bilateral-hs4.mjs
@@ -79,6 +79,12 @@ const ISO2_TO_UN = Object.fromEntries(
   Object.entries(UN_TO_ISO2).map(([un, iso2]) => [iso2, un]),
 );
 
+// UN Comtrade uses non-standard reporter codes for some countries.
+// These override the standard UN M49 codes from un-to-iso2.json.
+const COMTRADE_REPORTER_OVERRIDES = {
+  US: '842', // UN M49 standard is 840, but Comtrade registers the US as reporter 842
+};
+
 /**
  * @param {Array<string[]>} commands
  */
@@ -242,7 +248,7 @@ export async function main() {
 
     for (let i = 0; i < countries.length; i++) {
       const [iso2] = countries[i];
-      const unCode = ISO2_TO_UN[iso2];
+      const unCode = COMTRADE_REPORTER_OVERRIDES[iso2] ?? ISO2_TO_UN[iso2];
       if (!unCode) {
         console.warn(`  ${iso2}: no UN code, skipping`);
         continue;

--- a/scripts/seed-comtrade-bilateral-hs4.mjs
+++ b/scripts/seed-comtrade-bilateral-hs4.mjs
@@ -82,6 +82,8 @@ const ISO2_TO_UN = Object.fromEntries(
 // UN Comtrade uses non-standard reporter codes for some countries.
 // These override the standard UN M49 codes from un-to-iso2.json.
 const COMTRADE_REPORTER_OVERRIDES = {
+  FR: '251', // UN M49 standard is 250, but Comtrade registers France as reporter 251
+  IT: '381', // UN M49 standard is 380, but Comtrade registers Italy as reporter 381
   US: '842', // UN M49 standard is 840, but Comtrade registers the US as reporter 842
 };
 

--- a/tests/comtrade-bilateral-hs4.test.mjs
+++ b/tests/comtrade-bilateral-hs4.test.mjs
@@ -295,6 +295,30 @@ describe('Comtrade bilateral HS4 seeder (scripts/seed-comtrade-bilateral-hs4.mjs
       'seeder: must call extendExistingTtl when lock is skipped',
     );
   });
+
+  it('defines COMTRADE_REPORTER_OVERRIDES with US mapped to 842 (not standard UN M49 840)', () => {
+    assert.ok(
+      src.includes('COMTRADE_REPORTER_OVERRIDES'),
+      'seeder: must define COMTRADE_REPORTER_OVERRIDES to handle non-standard Comtrade reporter codes',
+    );
+    assert.ok(
+      src.includes("US: '842'"),
+      "seeder: COMTRADE_REPORTER_OVERRIDES must map US to '842' (Comtrade reporter code, not UN M49 840)",
+    );
+  });
+
+  it('applies COMTRADE_REPORTER_OVERRIDES before falling back to ISO2_TO_UN for reporter code lookup', () => {
+    const overrideIdx = src.indexOf('COMTRADE_REPORTER_OVERRIDES[iso2]');
+    const iso2ToUnIdx = src.indexOf('ISO2_TO_UN[iso2]', overrideIdx);
+    assert.ok(
+      overrideIdx !== -1,
+      'seeder: must use COMTRADE_REPORTER_OVERRIDES when resolving the Comtrade reporter code',
+    );
+    assert.ok(
+      iso2ToUnIdx !== -1 && iso2ToUnIdx > overrideIdx,
+      'seeder: COMTRADE_REPORTER_OVERRIDES must be checked before ISO2_TO_UN (override takes precedence)',
+    );
+  });
 });
 
 // ─── Service function ────────────────────────────────────────────────────────

--- a/tests/comtrade-bilateral-hs4.test.mjs
+++ b/tests/comtrade-bilateral-hs4.test.mjs
@@ -296,10 +296,18 @@ describe('Comtrade bilateral HS4 seeder (scripts/seed-comtrade-bilateral-hs4.mjs
     );
   });
 
-  it('defines COMTRADE_REPORTER_OVERRIDES with US mapped to 842 (not standard UN M49 840)', () => {
+  it('defines COMTRADE_REPORTER_OVERRIDES for all countries with non-standard Comtrade codes', () => {
     assert.ok(
       src.includes('COMTRADE_REPORTER_OVERRIDES'),
       'seeder: must define COMTRADE_REPORTER_OVERRIDES to handle non-standard Comtrade reporter codes',
+    );
+    assert.ok(
+      src.includes("FR: '251'"),
+      "seeder: COMTRADE_REPORTER_OVERRIDES must map FR to '251' (Comtrade reporter code, not UN M49 250)",
+    );
+    assert.ok(
+      src.includes("IT: '381'"),
+      "seeder: COMTRADE_REPORTER_OVERRIDES must map IT to '381' (Comtrade reporter code, not UN M49 380)",
     );
     assert.ok(
       src.includes("US: '842'"),


### PR DESCRIPTION
Fixes #2967

## Problem

The `seed-comtrade-bilateral-hs4.mjs` script builds its `ISO2_TO_UN` lookup from `scripts/shared/un-to-iso2.json`, which maps standard UN M49 codes. However, UN Comtrade registers three countries with non-standard reporter codes that differ from M49:

| Country | ISO2 | UN M49 (was used) | Comtrade code (correct) |
|---------|------|-------------------|------------------------|
| France  | FR   | 250               | **251**                |
| Italy   | IT   | 380               | **381**                |
| USA     | US   | 840               | **842**                |

Every call to `fetchBilateral()` for these countries silently returned empty responses, so their `comtrade:bilateral-hs4:*:v1` keys were never written to Redis. Downstream widgets (Product Imports, Trade Flows, Cost Shock) all show "No data available" for US, FR, and IT.

This was confirmed by diffing every entry in `_comtrade-reporters.ts` (the authoritative Comtrade code map) against the inverted `un-to-iso2.json`. Only these three countries have mismatches.

## Solution

Introduce a `COMTRADE_REPORTER_OVERRIDES` map that overrides the standard UN M49 lookup for countries where Comtrade uses a non-standard reporter code:

```js
const COMTRADE_REPORTER_OVERRIDES = {
  FR: '251',
  IT: '381',
  US: '842',
};
```

The per-country loop now uses:
```js
const unCode = COMTRADE_REPORTER_OVERRIDES[iso2] ?? ISO2_TO_UN[iso2];
```

This matches the `ISO2_TO_COMTRADE` mapping already used by `_comtrade-reporters.ts`, `seed-energy-spine.mjs`, and `seed-trade-flows.mjs`.

## Testing

- Regression tests in `tests/comtrade-bilateral-hs4.test.mjs` verify all three overrides are defined and applied before the `ISO2_TO_UN` fallback
- All 44 tests pass