### PR TITLE
Phase 3 PR3: Regime drift timeline + weekly brief in RegionalIntelligenceBoard

### DIFF
--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -123,9 +123,11 @@ export class RegionalIntelligenceBoard extends Panel {
       const transitions: RegimeTransition[] | null = historyResp.status === 'fulfilled'
         ? (historyResp.value.transitions ?? [])
         : null;
+      // Distinguish: RPC failed (null) vs RPC succeeded with no brief (undefined).
+      // null → omit block. undefined → show "no brief yet" empty state.
       const brief: RegionalBrief | undefined | null = briefResp.status === 'fulfilled'
-        ? (briefResp.value.brief ?? null)
-        : null;
+        ? briefResp.value.brief  // undefined when server returns {} (no brief exists yet)
+        : null;                  // null when RPC itself failed
 
       this.renderBoard(snapshot, transitions, brief);
     } catch (err) {
@@ -161,7 +163,9 @@ export class RegionalIntelligenceBoard extends Panel {
     if (transitions !== null && transitions !== undefined) {
       html += buildRegimeHistoryBlock(transitions);
     }
-    if (brief !== null && brief !== undefined) {
+    // brief: null = RPC failed (omit), undefined = no brief yet (show empty state),
+    // RegionalBrief = render content. Only null omits the block.
+    if (brief !== null) {
       html += buildWeeklyBriefBlock(brief);
     }
     this.body.innerHTML = html;

--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -117,7 +117,12 @@ export class RegionalIntelligenceBoard extends Panel {
     }
 
     // Render the snapshot blocks immediately — the user sees content now.
-    this.renderBoard(snapshot);
+    // Pass null for both Phase 3 blocks so they're omitted entirely during
+    // the initial paint. They'll be appended (or shown as empty-state) once
+    // the background enrichment RPCs resolve. Without null here, the default
+    // undefined would render a false "No weekly brief available yet" while
+    // the fetch is still in flight. PR #2995 review.
+    this.renderBoard(snapshot, null, null);
 
     // Phase 2: fire history + brief RPCs in background. When they resolve,
     // re-render with the enrichments appended — but only if this sequence

--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -113,12 +113,14 @@ export class RegionalIntelligenceBoard extends Panel {
         return;
       }
 
-      const transitions: RegimeTransition[] = historyResp.status === 'fulfilled'
+      // Distinguish RPC success (render block, even if empty) from RPC failure
+      // (omit block entirely). null = RPC failed, array/object = RPC succeeded.
+      const transitions: RegimeTransition[] | null = historyResp.status === 'fulfilled'
         ? (historyResp.value.transitions ?? [])
-        : [];
-      const brief: RegionalBrief | undefined = briefResp.status === 'fulfilled'
-        ? briefResp.value.brief
-        : undefined;
+        : null;
+      const brief: RegionalBrief | undefined | null = briefResp.status === 'fulfilled'
+        ? (briefResp.value.brief ?? null)
+        : null;
 
       this.renderBoard(snapshot, transitions, brief);
     } catch (err) {
@@ -142,15 +144,21 @@ export class RegionalIntelligenceBoard extends Panel {
     this.body.innerHTML = `<div class="rib-status rib-status-error" style="padding:16px;color:var(--danger);font-size:12px">Failed to load snapshot: ${escapeHtml(message)}</div>`;
   }
 
-  /** Render the full board HTML from a hydrated snapshot + optional Phase 3 data. */
-  public renderBoard(snapshot: RegionalSnapshot, transitions?: RegimeTransition[], brief?: RegionalBrief): void {
+  /** Render the full board HTML from a hydrated snapshot + optional Phase 3 data.
+   *  null = RPC failed (omit block entirely), array/object = RPC succeeded (render, even if empty). */
+  public renderBoard(snapshot: RegionalSnapshot, transitions?: RegimeTransition[] | null, brief?: RegionalBrief | null): void {
     let html = buildBoardHtml(snapshot);
-    // Phase 3 blocks render AFTER the snapshot blocks:
-    // regime drift timeline, then weekly brief.
-    if (transitions && transitions.length > 0) {
+    // Phase 3 blocks: only render when the RPC succeeded (non-null).
+    // null means the RPC failed — omit the block so we don't show a
+    // misleading "no data yet" message for a transient outage.
+    // An empty array/undefined-brief from a successful RPC correctly
+    // shows the "no transitions" / "no brief" empty state.
+    if (transitions !== null && transitions !== undefined) {
       html += buildRegimeHistoryBlock(transitions);
     }
-    html += buildWeeklyBriefBlock(brief);
+    if (brief !== null && brief !== undefined) {
+      html += buildWeeklyBriefBlock(brief);
+    }
     this.body.innerHTML = html;
   }
 }

--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -107,7 +107,12 @@ export class RegionalIntelligenceBoard extends Panel {
       ]);
       if (!isLatestSequence(mySequence, this.latestSequence)) return;
 
-      const snapshot = snapshotResp.status === 'fulfilled' ? snapshotResp.value.snapshot : undefined;
+      if (snapshotResp.status === 'rejected') {
+        const err = snapshotResp.reason;
+        this.renderError(err instanceof Error ? err.message : String(err));
+        return;
+      }
+      const snapshot = snapshotResp.value.snapshot;
       if (!snapshot?.regionId) {
         this.renderEmpty();
         return;

--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -96,45 +96,56 @@ export class RegionalIntelligenceBoard extends Panel {
     const myRegion = this.currentRegion;
     this.renderLoading();
 
+    // Phase 1: render the snapshot immediately — never blocked by Phase 3
+    // enrichments. History + brief fire in parallel but don't gate the
+    // board's core render path. PR #2995 review: the old Promise.allSettled
+    // approach blocked the entire panel on slow enrichment RPCs.
+    let snapshot: RegionalSnapshot | undefined;
     try {
-      // Fire all 3 RPCs in parallel — snapshot is required, history + brief
-      // are best-effort enhancements. If either fails, the board still renders
-      // with just the snapshot data.
-      const [snapshotResp, historyResp, briefResp] = await Promise.allSettled([
-        client.getRegionalSnapshot({ regionId: myRegion }),
-        client.getRegimeHistory({ regionId: myRegion, limit: 20 }),
-        client.getRegionalBrief({ regionId: myRegion }),
-      ]);
+      const resp = await client.getRegionalSnapshot({ regionId: myRegion });
       if (!isLatestSequence(mySequence, this.latestSequence)) return;
-
-      if (snapshotResp.status === 'rejected') {
-        const err = snapshotResp.reason;
-        this.renderError(err instanceof Error ? err.message : String(err));
-        return;
-      }
-      const snapshot = snapshotResp.value.snapshot;
-      if (!snapshot?.regionId) {
-        this.renderEmpty();
-        return;
-      }
-
-      // Distinguish RPC success (render block, even if empty) from RPC failure
-      // (omit block entirely). null = RPC failed, array/object = RPC succeeded.
-      const transitions: RegimeTransition[] | null = historyResp.status === 'fulfilled'
-        ? (historyResp.value.transitions ?? [])
-        : null;
-      // Distinguish: RPC failed (null) vs RPC succeeded with no brief (undefined).
-      // null → omit block. undefined → show "no brief yet" empty state.
-      const brief: RegionalBrief | undefined | null = briefResp.status === 'fulfilled'
-        ? briefResp.value.brief  // undefined when server returns {} (no brief exists yet)
-        : null;                  // null when RPC itself failed
-
-      this.renderBoard(snapshot, transitions, brief);
+      snapshot = resp.snapshot;
     } catch (err) {
       if (!isLatestSequence(mySequence, this.latestSequence)) return;
-      console.error('[RegionalIntelligenceBoard] load failed', err);
       this.renderError(err instanceof Error ? err.message : String(err));
+      return;
     }
+
+    if (!snapshot?.regionId) {
+      this.renderEmpty();
+      return;
+    }
+
+    // Render the snapshot blocks immediately — the user sees content now.
+    this.renderBoard(snapshot);
+
+    // Phase 2: fire history + brief RPCs in background. When they resolve,
+    // re-render with the enrichments appended — but only if this sequence
+    // is still current (user hasn't switched regions in the meantime).
+    const historyPromise = client.getRegimeHistory({ regionId: myRegion, limit: 20 }).catch(() => null);
+    const briefPromise = client.getRegionalBrief({ regionId: myRegion }).catch(() => null);
+
+    Promise.allSettled([historyPromise, briefPromise]).then(([hResult, bResult]) => {
+      if (!isLatestSequence(mySequence, this.latestSequence)) return;
+
+      // Distinguish: RPC failed or upstreamUnavailable (null → omit block)
+      // vs RPC succeeded with real data (render block, even if empty).
+      // The server returns upstreamUnavailable:true in the body on Redis
+      // failure, which still resolves as a fulfilled promise. Check for it.
+      const hValue = hResult.status === 'fulfilled' ? hResult.value : null;
+      const transitions: RegimeTransition[] | null =
+        hValue && !(hValue as unknown as { upstreamUnavailable?: boolean }).upstreamUnavailable
+          ? (hValue.transitions ?? [])
+          : null;
+
+      const bValue = bResult.status === 'fulfilled' ? bResult.value : null;
+      const brief: RegionalBrief | undefined | null =
+        bValue && !(bValue as unknown as { upstreamUnavailable?: boolean }).upstreamUnavailable
+          ? bValue.brief   // undefined = no brief yet, RegionalBrief = render
+          : null;          // null = RPC or upstream failed → omit block
+
+      this.renderBoard(snapshot!, transitions, brief);
+    });
   }
 
   private renderLoading(): void {

--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -1,10 +1,10 @@
 import { Panel } from './Panel';
 import { getRpcBaseUrl } from '@/services/rpc-client';
 import { IntelligenceServiceClient } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
-import type { RegionalSnapshot } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
+import type { RegionalSnapshot, RegimeTransition, RegionalBrief } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 import { h, replaceChildren } from '@/utils/dom-utils';
 import { escapeHtml } from '@/utils/sanitize';
-import { BOARD_REGIONS, DEFAULT_REGION_ID, buildBoardHtml, isLatestSequence } from './regional-intelligence-board-utils';
+import { BOARD_REGIONS, DEFAULT_REGION_ID, buildBoardHtml, buildRegimeHistoryBlock, buildWeeklyBriefBlock, isLatestSequence } from './regional-intelligence-board-utils';
 
 const client = new IntelligenceServiceClient(getRpcBaseUrl(), {
   fetch: (...args) => globalThis.fetch(...args),
@@ -97,14 +97,30 @@ export class RegionalIntelligenceBoard extends Panel {
     this.renderLoading();
 
     try {
-      const resp = await client.getRegionalSnapshot({ regionId: myRegion });
+      // Fire all 3 RPCs in parallel — snapshot is required, history + brief
+      // are best-effort enhancements. If either fails, the board still renders
+      // with just the snapshot data.
+      const [snapshotResp, historyResp, briefResp] = await Promise.allSettled([
+        client.getRegionalSnapshot({ regionId: myRegion }),
+        client.getRegimeHistory({ regionId: myRegion, limit: 20 }),
+        client.getRegionalBrief({ regionId: myRegion }),
+      ]);
       if (!isLatestSequence(mySequence, this.latestSequence)) return;
-      const snapshot = resp.snapshot;
+
+      const snapshot = snapshotResp.status === 'fulfilled' ? snapshotResp.value.snapshot : undefined;
       if (!snapshot?.regionId) {
         this.renderEmpty();
         return;
       }
-      this.renderBoard(snapshot);
+
+      const transitions: RegimeTransition[] = historyResp.status === 'fulfilled'
+        ? (historyResp.value.transitions ?? [])
+        : [];
+      const brief: RegionalBrief | undefined = briefResp.status === 'fulfilled'
+        ? briefResp.value.brief
+        : undefined;
+
+      this.renderBoard(snapshot, transitions, brief);
     } catch (err) {
       if (!isLatestSequence(mySequence, this.latestSequence)) return;
       console.error('[RegionalIntelligenceBoard] load failed', err);
@@ -126,8 +142,15 @@ export class RegionalIntelligenceBoard extends Panel {
     this.body.innerHTML = `<div class="rib-status rib-status-error" style="padding:16px;color:var(--danger);font-size:12px">Failed to load snapshot: ${escapeHtml(message)}</div>`;
   }
 
-  /** Render the full board HTML from a hydrated snapshot. Public for tests. */
-  public renderBoard(snapshot: RegionalSnapshot): void {
-    this.body.innerHTML = buildBoardHtml(snapshot);
+  /** Render the full board HTML from a hydrated snapshot + optional Phase 3 data. */
+  public renderBoard(snapshot: RegionalSnapshot, transitions?: RegimeTransition[], brief?: RegionalBrief): void {
+    let html = buildBoardHtml(snapshot);
+    // Phase 3 blocks render AFTER the snapshot blocks:
+    // regime drift timeline, then weekly brief.
+    if (transitions && transitions.length > 0) {
+      html += buildRegimeHistoryBlock(transitions);
+    }
+    html += buildWeeklyBriefBlock(brief);
+    this.body.innerHTML = html;
   }
 }

--- a/src/components/regional-intelligence-board-utils.ts
+++ b/src/components/regional-intelligence-board-utils.ts
@@ -15,6 +15,8 @@ import type {
   Trigger,
   NarrativeSection,
   RegionalNarrative,
+  RegimeTransition,
+  RegionalBrief,
 } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 
 /** Non-global regions available in the dropdown. Matches shared/geography.js REGIONS. */
@@ -372,4 +374,75 @@ export function buildMetaFooter(snapshot: RegionalSnapshot): string {
       <span>narrative: ${narrativeSrc}</span>
     </div>
   `;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Regime drift timeline (Phase 3 PR3)
+// ────────────────────────────────────────────────────────────────────────────
+
+function formatDate(ms: number): string {
+  if (!ms) return '—';
+  return new Date(ms).toISOString().replace('T', ' ').slice(0, 16) + 'Z';
+}
+
+export function buildRegimeHistoryBlock(transitions: RegimeTransition[]): string {
+  if (!transitions || transitions.length === 0) {
+    return section('Regime History', '<div style="font-size:11px;color:var(--text-dim)">No regime transitions recorded yet</div>');
+  }
+  const rows = transitions.slice(0, 20).map((t) => {
+    const from = t.previousLabel ? escapeHtml(t.previousLabel.replace(/_/g, ' ')) : 'none';
+    const to = escapeHtml((t.label ?? '').replace(/_/g, ' '));
+    const driver = t.transitionDriver ? ` · ${escapeHtml(t.transitionDriver)}` : '';
+    const date = formatDate(t.transitionedAt);
+    return `
+      <div style="display:grid;grid-template-columns:130px 1fr;gap:8px;padding:3px 0;border-bottom:1px dashed rgba(255,255,255,0.06)">
+        <div style="font-size:10px;color:var(--text-dim);font-variant-numeric:tabular-nums">${escapeHtml(date)}</div>
+        <div style="font-size:11px"><span style="color:var(--text-dim)">${from}</span> → <span style="font-weight:500;text-transform:capitalize">${to}</span>${driver}</div>
+      </div>
+    `;
+  }).join('');
+  return section('Regime History', rows);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Weekly brief (Phase 3 PR3)
+// ────────────────────────────────────────────────────────────────────────────
+
+export function buildWeeklyBriefBlock(brief: RegionalBrief | undefined): string {
+  if (!brief || !brief.situationRecap) {
+    return section('Weekly Brief', '<div style="font-size:11px;color:var(--text-dim)">No weekly brief available yet</div>');
+  }
+
+  const periodStart = brief.periodStart ? (new Date(brief.periodStart).toISOString().split('T')[0] ?? '?') : '?';
+  const periodEnd = brief.periodEnd ? (new Date(brief.periodEnd).toISOString().split('T')[0] ?? '?') : '?';
+  const provider = brief.provider ? `${escapeHtml(brief.provider)}/${escapeHtml(brief.model || '?')}` : '';
+
+  const developmentItems = (brief.keyDevelopments ?? [])
+    .filter((d) => d.length > 0)
+    .map((d) => `<div style="padding:2px 0;font-size:11px"><span style="color:var(--text-dim)">▸</span> ${escapeHtml(d)}</div>`)
+    .join('');
+
+  const body = `
+    <div style="font-size:10px;color:var(--text-dim);margin-bottom:6px">${escapeHtml(periodStart)} — ${escapeHtml(periodEnd)}${provider ? ` · ${provider}` : ''}</div>
+    ${brief.situationRecap ? `<div style="font-size:12px;line-height:1.5;margin-bottom:8px">${escapeHtml(brief.situationRecap)}</div>` : ''}
+    ${brief.regimeTrajectory ? `
+      <div style="margin-bottom:6px">
+        <div style="font-size:10px;color:var(--text-dim);text-transform:uppercase;margin-bottom:2px">Regime Trajectory</div>
+        <div style="font-size:11px;line-height:1.4">${escapeHtml(brief.regimeTrajectory)}</div>
+      </div>
+    ` : ''}
+    ${developmentItems ? `
+      <div style="margin-bottom:6px">
+        <div style="font-size:10px;color:var(--text-dim);text-transform:uppercase;margin-bottom:2px">Key Developments</div>
+        ${developmentItems}
+      </div>
+    ` : ''}
+    ${brief.riskOutlook ? `
+      <div>
+        <div style="font-size:10px;color:var(--text-dim);text-transform:uppercase;margin-bottom:2px">Risk Outlook</div>
+        <div style="font-size:11px;line-height:1.4">${escapeHtml(brief.riskOutlook)}</div>
+      </div>
+    ` : ''}
+  `;
+  return section('Weekly Brief', body);
 }

--- a/src/components/regional-intelligence-board-utils.ts
+++ b/src/components/regional-intelligence-board-utils.ts
@@ -419,6 +419,7 @@ export function buildWeeklyBriefBlock(brief: RegionalBrief | undefined): string 
 
   const developmentItems = (brief.keyDevelopments ?? [])
     .filter((d) => d.length > 0)
+    .slice(0, 5)
     .map((d) => `<div style="padding:2px 0;font-size:11px"><span style="color:var(--text-dim)">▸</span> ${escapeHtml(d)}</div>`)
     .join('');
 

--- a/tests/regional-intelligence-board.test.mts
+++ b/tests/regional-intelligence-board.test.mts
@@ -15,6 +15,8 @@ import {
   buildTransmissionBlock,
   buildWatchlistBlock,
   buildMetaFooter,
+  buildRegimeHistoryBlock,
+  buildWeeklyBriefBlock,
   isLatestSequence,
 } from '../src/components/regional-intelligence-board-utils';
 import type {
@@ -645,5 +647,102 @@ describe('loadCurrent race simulation', () => {
     }
     await loadCurrent('mena', Promise.resolve('snap'));
     assert.deepEqual(state.rendered, ['mena:snap']);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Regime History block (Phase 3 PR3)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('buildRegimeHistoryBlock', () => {
+  it('renders transitions newest-first with date + from → to', () => {
+    const transitions = [
+      { regionId: 'mena', label: 'escalation_ladder', previousLabel: 'coercive_stalemate', transitionedAt: 1700000000000, transitionDriver: 'regime_shift', snapshotId: 's1' },
+      { regionId: 'mena', label: 'coercive_stalemate', previousLabel: 'calm', transitionedAt: 1699900000000, transitionDriver: '', snapshotId: 's0' },
+    ];
+    const html = buildRegimeHistoryBlock(transitions);
+    assert.match(html, /Regime History/);
+    assert.match(html, /escalation ladder/);
+    assert.match(html, /coercive stalemate/);
+    assert.match(html, /calm/);
+    assert.match(html, /regime_shift/);
+  });
+
+  it('shows "no transitions" for empty array', () => {
+    const html = buildRegimeHistoryBlock([]);
+    assert.match(html, /No regime transitions/);
+  });
+
+  it('caps at 20 entries', () => {
+    const transitions = Array.from({ length: 30 }, (_, i) => ({
+      regionId: 'mena', label: 'calm', previousLabel: 'calm',
+      transitionedAt: Date.now() - i * 86400000, transitionDriver: '', snapshotId: `s${i}`,
+    }));
+    const html = buildRegimeHistoryBlock(transitions);
+    const count = (html.match(/rib-section/g) ?? []).length;
+    // Still just one section wrapper, but not 30 rows visible
+    assert.ok(count >= 1);
+  });
+
+  it('escapes HTML in labels', () => {
+    const transitions = [
+      { regionId: 'mena', label: '<script>x</script>', previousLabel: '', transitionedAt: 0, transitionDriver: '', snapshotId: '' },
+    ];
+    const html = buildRegimeHistoryBlock(transitions);
+    assert.doesNotMatch(html, /<script>x<\/script>/);
+    assert.match(html, /&lt;script&gt;/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Weekly Brief block (Phase 3 PR3)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('buildWeeklyBriefBlock', () => {
+  const brief = {
+    regionId: 'mena',
+    generatedAt: Date.now(),
+    periodStart: Date.now() - 7 * 86400000,
+    periodEnd: Date.now(),
+    situationRecap: 'Iran increased naval posture near Hormuz.',
+    regimeTrajectory: 'Shifted from calm to coercive stalemate mid-week.',
+    keyDevelopments: ['Hormuz transit dropped 15%', 'CII spike for Iran'],
+    riskOutlook: 'Escalation risk remains elevated.',
+    provider: 'groq',
+    model: 'llama-3.3-70b-versatile',
+  };
+
+  it('renders all brief sections when populated', () => {
+    const html = buildWeeklyBriefBlock(brief);
+    assert.match(html, /Weekly Brief/);
+    assert.match(html, /Iran increased naval posture/);
+    assert.match(html, /Shifted from calm/);
+    assert.match(html, /Hormuz transit dropped/);
+    assert.match(html, /CII spike/);
+    assert.match(html, /Escalation risk/);
+    assert.match(html, /groq/);
+  });
+
+  it('shows "no brief" for undefined', () => {
+    const html = buildWeeklyBriefBlock(undefined);
+    assert.match(html, /No weekly brief available/);
+  });
+
+  it('shows "no brief" when situationRecap is empty', () => {
+    const html = buildWeeklyBriefBlock({ ...brief, situationRecap: '' });
+    assert.match(html, /No weekly brief available/);
+  });
+
+  it('renders period date range', () => {
+    const html = buildWeeklyBriefBlock(brief);
+    // Should contain date strings like 2026-04-04
+    assert.match(html, /\d{4}-\d{2}-\d{2}/);
+  });
+
+  it('escapes HTML in brief content', () => {
+    const malicious = { ...brief, situationRecap: '<img onerror=alert(1)>' };
+    const html = buildWeeklyBriefBlock(malicious);
+    assert.doesNotMatch(html, /<img onerror/);
+    assert.match(html, /&lt;img/);
   });
 });


### PR DESCRIPTION
## Summary

Phase 3 PR3 of the Regional Intelligence Model. Adds regime drift timeline + weekly brief blocks to the existing RegionalIntelligenceBoard panel, completing the full UI surface. This is the final PR in the Regional Intelligence pipeline.

## What landed

### Regime drift timeline block
Renders the region's transition log newest-first. Each row: date, previous → current label, driver. Capped at 20 entries. Empty-state when no transitions exist.

### Weekly brief block
Renders: period range, situation recap, regime trajectory, key developments (up to 5 bullets), risk outlook, provider/model source. Empty-state when no brief available.

### Panel RPC upgrade
\`loadCurrent()\` now fires 3 RPCs in parallel via \`Promise.allSettled\`:
1. \`getRegionalSnapshot\` (required)
2. \`getRegimeHistory\` (best-effort)
3. \`getRegionalBrief\` (best-effort)

Snapshot failure → empty board. History/brief failures → board renders without those blocks. Sequence arbitration still active.

## Testing
9 new unit tests (4 history + 5 brief). 54/54 board tests pass. 4831/4831 full suite. Typecheck + lint clean.

## Post-Deploy Monitoring & Validation
- **No additional operational monitoring required**: purely UI-side change consuming existing premium RPCs. The server-side data flow is already monitored via the Phase 3 PR1 + PR2 health entries.

## PR sequence — COMPLETE
- [x] Phase 0: #2940, #2942, #2952
- [x] Phase 1: #2951, #2960, #2963
- [x] Phase 2: #2966, #2976
- [x] Phase 3 PR1 (#2981): regime drift history
- [x] Phase 3 PR2 (#2989): weekly briefs
- [ ] **Phase 3 PR3 (this PR)**: UI for both

**This PR completes the Regional Intelligence Model.**