### PR TITLE
fix(route-explorer): prevent lazy-fetch transients from poisoning 24h impact cache

### DIFF
--- a/server/worldmonitor/supply-chain/v1/_bilateral-hs4-lazy.ts
+++ b/server/worldmonitor/supply-chain/v1/_bilateral-hs4-lazy.ts
@@ -147,13 +147,19 @@ export interface LazyFetchResult {
 
 /**
  * Attempt a lazy fetch for a destination country's bilateral HS4 data.
- * Returns null if the fetch is already in-flight (concurrency cap) or
- * if a negative-cache sentinel exists (recent 429 or known-empty).
+ * Returns null only for truly transient states (concurrent fetch in-flight).
+ * When a sentinel exists, returns the sentinel's encoded reason so callers
+ * can distinguish permanent empties from transient rate-limits.
  */
 export async function lazyFetchBilateralHs4(iso2: string): Promise<LazyFetchResult | null> {
   const sentinelKey = `${LAZY_SENTINEL_PREFIX}${iso2}:v1`;
-  const sentinel = await getCachedJson(sentinelKey, true).catch(() => null);
-  if (sentinel) return null;
+  const sentinel = await getCachedJson(sentinelKey, true).catch(() => null) as { empty?: boolean; rateLimited?: boolean } | null;
+  if (sentinel) {
+    if (sentinel.rateLimited) {
+      return { products: [], comtradeSource: 'lazy', rateLimited: true };
+    }
+    return { products: [], comtradeSource: 'empty' };
+  }
 
   if (fetchInFlight) return null;
   fetchInFlight = true;

--- a/server/worldmonitor/supply-chain/v1/get-route-impact.ts
+++ b/server/worldmonitor/supply-chain/v1/get-route-impact.ts
@@ -152,12 +152,18 @@ async function computeImpact(req: GetRouteImpactRequest): Promise<GetRouteImpact
 
   if (!rawPayload) {
     const lazyResult = await lazyFetchBilateralHs4(toIso2);
-    if (!lazyResult || lazyResult.products.length === 0) {
-      // Transient failure (concurrency miss, timeout, 429). Return null so
-      // cachedFetchJson uses its short negative-TTL (120s) instead of the
-      // 24h success TTL. This prevents one temporary miss from poisoning
-      // the cache for a full day.
+    if (!lazyResult) {
+      // null = sentinel exists (permanent negative) or concurrent fetch in-flight (transient).
+      // Return null so cachedFetchJson uses short negative-TTL (120s).
       return null;
+    }
+    if (lazyResult.products.length === 0) {
+      if (lazyResult.comtradeSource === 'lazy' || lazyResult.rateLimited) {
+        // Transient: fetch error, timeout, or 429. Short-cache via null.
+        return null;
+      }
+      // Permanent empty: country has no bilateral data in Comtrade. Safe to cache long-term.
+      return emptyResponse(req, 'empty');
     }
     rawPayload = { iso2: toIso2, products: lazyResult.products, fetchedAt: new Date().toISOString() };
   }

--- a/server/worldmonitor/supply-chain/v1/get-route-impact.ts
+++ b/server/worldmonitor/supply-chain/v1/get-route-impact.ts
@@ -138,7 +138,7 @@ async function readResilienceScore(iso2: string): Promise<number> {
   }
 }
 
-async function computeImpact(req: GetRouteImpactRequest): Promise<GetRouteImpactResponse> {
+async function computeImpact(req: GetRouteImpactRequest): Promise<GetRouteImpactResponse | null> {
   const fromIso2 = req.fromIso2.trim().toUpperCase();
   const toIso2 = req.toIso2.trim().toUpperCase();
   const hs2 = req.hs2.trim().replace(/\D/g, '') || '27';
@@ -153,10 +153,11 @@ async function computeImpact(req: GetRouteImpactRequest): Promise<GetRouteImpact
   if (!rawPayload) {
     const lazyResult = await lazyFetchBilateralHs4(toIso2);
     if (!lazyResult || lazyResult.products.length === 0) {
-      const source = lazyResult?.comtradeSource ?? 'lazy';
-      const resp = emptyResponse(req, source);
-      if (lazyResult?.rateLimited) (resp as unknown as Record<string, unknown>).meta = { rateLimited: true };
-      return resp;
+      // Transient failure (concurrency miss, timeout, 429). Return null so
+      // cachedFetchJson uses its short negative-TTL (120s) instead of the
+      // 24h success TTL. This prevents one temporary miss from poisoning
+      // the cache for a full day.
+      return null;
     }
     rawPayload = { iso2: toIso2, products: lazyResult.products, fetchedAt: new Date().toISOString() };
   }
@@ -234,5 +235,5 @@ export async function getRouteImpact(
     CACHE_TTL_SECONDS,
     async () => computeImpact({ fromIso2, toIso2, hs2 }),
   );
-  return result ?? emptyResponse(req, 'missing');
+  return result ?? emptyResponse(req, 'lazy');
 }

--- a/src/components/RouteExplorer/tabs/CountryImpactTab.ts
+++ b/src/components/RouteExplorer/tabs/CountryImpactTab.ts
@@ -51,6 +51,7 @@ export class CountryImpactTab {
     if (!data) { this.renderPlaceholder(); return; }
     if (data.comtradeSource === 'missing') { this.renderMissing(); return; }
     if (data.comtradeSource === 'empty') { this.renderEmpty(); return; }
+    if (data.comtradeSource === 'lazy') { this.renderLazy(); return; }
     this.renderData(data);
   }
 
@@ -72,6 +73,15 @@ export class CountryImpactTab {
       '<div class="re-tab__empty">' +
       '<h3>No strategic products found</h3>' +
       '<p>The bilateral trade store returned empty data for this destination.</p>' +
+      '</div>';
+  }
+
+  private renderLazy(): void {
+    this.element.innerHTML =
+      '<div class="re-tab__empty">' +
+      '<h3>Loading trade data</h3>' +
+      '<p>WorldMonitor is fetching trade data for this destination for the first time. ' +
+      'Try again in a few seconds.</p>' +
       '</div>';
   }
 


### PR DESCRIPTION
## Summary
Followup to Sprint 5 (#2997). Fixes two bugs in the lazy bilateral-hs4 fetch integration:

### P1: 24h cache poisoning from transient failures
When `lazyFetchBilateralHs4` returned empty results due to concurrency miss, timeout, or 429 rate-limiting, `computeImpact` returned a valid-looking empty response that `cachedFetchJson` cached for 24h under `ROUTE_IMPACT_KEY`. One temporary miss locked a specific `(fromIso2, toIso2, hs2)` query into empty results for a full day, even after the bilateral data was later fetched successfully.

**Fix**: `computeImpact` now returns `null` for transient lazy-fetch states. `cachedFetchJson` treats `null` as a negative result and uses its short negative-TTL (120s) instead of the 24h success TTL. The `getRouteImpact` handler's `result ?? emptyResponse(req, 'lazy')` fallback returns `comtradeSource: 'lazy'` to the client, distinguishing "data not yet available" from "country not in any dataset".

### P2: `comtradeSource: 'lazy'` not handled by Impact tab
`CountryImpactTab.update()` only checked for `'missing'` and `'empty'`; the `'lazy'` source fell through to `renderData()`, showing a normal Impact tab shell with "No products available" instead of an honest loading/retry state.

**Fix**: Added `renderLazy()` that shows "Loading trade data" with a retry hint, matching the other `comtradeSource` states.

## Test plan
- [ ] Request Impact tab for an unseeded country that triggers lazy-fetch timeout → shows "Loading trade data" (not "No products available")
- [ ] Second request after 2 min → retry succeeds (not locked for 24h)
- [ ] Seeded countries → unchanged behavior (lazy-fetch never triggered)
- [ ] `comtradeSource: 'missing'` and `'empty'` still render correctly

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: this fixes a cache-poisoning bug; no new infrastructure or data flows added.