### PR TITLE
feat(route-explorer): Sprint 6 — free-tier blur + analytics + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to World Monitor are documented here.
 
 ### Added
 
+- **Route Explorer**: standalone full-screen modal (CMD+K) for planning shipments between any two countries. Includes Current/Alternatives/Land/Impact tabs, keyboard-first navigation, URL state sharing, strategic-product trade data, dependency flags, and free-tier blur with public route highlight (#2980, #2982, #2994, #2996, #2997, #2998)
 - US Treasury customs revenue in Trade Policy panel with monthly data, FYTD year-over-year comparison, and revenue spike highlighting (#1663)
 - Security advisories gold standard migration: Railway cron seed fetches 24 government RSS feeds hourly, Vercel reads Redis only (#1637)
 - CMD+K full panel coverage: all 55 panels now searchable (was 31), including AI forecasts, correlation panels, webcams, displacement, security advisories (#1656)

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -10,6 +10,7 @@ All notable changes to World Monitor are documented here. Subscribe via [RSS](/c
 
 ### Added
 
+- **Route Explorer**: standalone full-screen modal (CMD+K) for planning shipments between any two countries. Current/Alternatives/Land/Impact tabs with keyboard-first navigation, URL state sharing, strategic-product trade data, dependency flags, and free-tier blur with public route highlight (#2980, #2982, #2994, #2996, #2997, #2998)
 - **US Treasury customs revenue** in Trade Policy panel with monthly data, FYTD year-over-year comparison, and revenue spike highlighting (#1663)
 - **Security advisories gold standard migration**: Railway cron seed fetches 24 government RSS feeds hourly, Vercel reads Redis only (#1637)
 - **CMD+K full panel coverage**: all 55 panels now searchable (was 31), including AI forecasts, correlation panels, webcams, displacement, security advisories (#1656)

--- a/docs/maritime-intelligence.mdx
+++ b/docs/maritime-intelligence.mdx
@@ -4,6 +4,22 @@ description: "Real-time vessel tracking with chokepoint monitoring, traffic dens
 ---
 The Ships layer provides real-time vessel tracking and maritime domain awareness through AIS (Automatic Identification System) data, monitoring critical chokepoints, detecting anomalous vessel behavior, and streaming position updates over WebSocket connections.
 
+## Route Explorer
+
+The Route Explorer lets users plan shipments between any two countries by querying real-time maritime route intelligence. Open it via **CMD+K** and search for "route".
+
+**Features:**
+- **Country pair + HS2 product picker** with typeahead search across 197 port-clustered countries and 50 HS2 chapters
+- **Current route tab** showing the primary maritime lane, chokepoint exposures ranked by severity, estimated transit days and freight ranges
+- **Alternatives tab** with ranked bypass sea routes including cost deltas, transit deltas, and war risk tiers
+- **Land tab** showing overland corridor options where available, with honest empty states for unmodeled regions
+- **Impact tab** showing strategic-product trade data, lane value at risk, dependency flags, and resilience scores
+- **Map integration** highlighting the selected route with bypass arc overlays
+- **Keyboard-first design** with digit-based tab switching (1-4), picker shortcuts (F/T/P/S), and a cheat sheet (?)
+- **URL state sharing** via `?explorer=from:CN,to:DE,hs:85`
+
+PRO users get full route intelligence. Free users see a public route highlight on the map with details blurred behind an upgrade prompt.
+
 ## Chokepoint Monitoring
 
 The system monitors 13 strategic waterways where disruptions could impact global trade, powered by three data sources: IMF PortWatch (weekly vessel transit counts), AISStream (real-time 24h crossing counter), and CorridorRisk (risk intelligence).

--- a/src/components/RouteExplorer/RouteExplorer.ts
+++ b/src/components/RouteExplorer/RouteExplorer.ts
@@ -104,7 +104,7 @@ export class RouteExplorer {
     this.mapRef = map;
   }
 
-  public open(): void {
+  public open(source: 'cmdk' | 'url' | 'icon' = 'cmdk'): void {
     if (this.isOpen) {
       this.fromPicker?.focusInput();
       return;
@@ -122,7 +122,7 @@ export class RouteExplorer {
       trackGateHit('route-explorer');
       this.gateHitTracked = true;
     }
-    this.trackEvent('route-explorer:opened', { source: 'cmdk' });
+    this.trackEvent('route-explorer:opened', { source });
     document.addEventListener('keydown', this.handleGlobalKeydown, { capture: true });
     this.focusInitial();
     if (this.isQueryComplete()) this.scheduleFetch();
@@ -314,6 +314,7 @@ export class RouteExplorer {
 
   private applyData(data: GetRouteExplorerLaneResponse): void {
     this.leftRail.element.classList.remove('re-leftrail--blurred');
+    this.leftRail.element.removeAttribute('aria-hidden');
     this.leftRail.updateLane(data);
     this.currentTab.update(data);
     this.alternativesTab.update(data);
@@ -335,6 +336,7 @@ export class RouteExplorer {
 
   private renderFreeGate(): void {
     this.leftRail?.element.classList.add('re-leftrail--blurred');
+    this.leftRail?.element.setAttribute('aria-hidden', 'true');
     if (this.contentEl) {
       this.contentEl.innerHTML =
         '<div class="re-content__gate">' +
@@ -344,7 +346,6 @@ export class RouteExplorer {
         '</div>';
       const btn = this.contentEl.querySelector<HTMLButtonElement>('.re-content__upgrade');
       btn?.addEventListener('click', () => {
-        trackGateHit('route-explorer');
         this.trackEvent('route-explorer:free-cta-click', {
           from: this.state.fromIso2 ?? '',
           to: this.state.toIso2 ?? '',

--- a/src/components/RouteExplorer/RouteExplorer.ts
+++ b/src/components/RouteExplorer/RouteExplorer.ts
@@ -31,8 +31,19 @@ import { hasPremiumAccess } from '@/services/panel-gating';
 import { getAuthState } from '@/services/auth-state';
 import { trackGateHit, track, type UmamiEvent } from '@/services/analytics';
 
+import { TRADE_ROUTES } from '@/config/trade-routes';
+
 const TAB_LABELS: Record<ExplorerTab, string> = { 1: 'Current', 2: 'Alternatives', 3: 'Land', 4: 'Impact' };
 const FETCH_DEBOUNCE_MS = 250;
+
+const CARGO_TO_ROUTE_CATEGORY: Record<string, string> = {
+  container: 'container',
+  tanker: 'energy',
+  bulk: 'bulk',
+  roro: 'container',
+};
+
+const ROUTE_CATEGORY_MAP = new Map(TRADE_ROUTES.map((r) => [r.id, r.category]));
 
 interface MapRef {
   highlightRoute(routeIds: string[]): void;
@@ -352,7 +363,14 @@ export class RouteExplorer {
     const fromRoutes = new Set(clusters[this.state.fromIso2]?.nearestRouteIds ?? []);
     const toRoutes = new Set(clusters[this.state.toIso2]?.nearestRouteIds ?? []);
     const shared = [...fromRoutes].filter((r) => toRoutes.has(r));
-    const routeId = shared[0] ?? clusters[this.state.fromIso2]?.nearestRouteIds[0] ?? '';
+    if (shared.length === 0) return;
+    const cargoCategory = CARGO_TO_ROUTE_CATEGORY[this.getEffectiveCargo()] ?? 'container';
+    const ranked = [...shared].sort((a, b) => {
+      const catA = ROUTE_CATEGORY_MAP.get(a) ?? '';
+      const catB = ROUTE_CATEGORY_MAP.get(b) ?? '';
+      return (catA === cargoCategory ? 0 : 1) - (catB === cargoCategory ? 0 : 1);
+    });
+    const routeId = ranked[0] ?? '';
     if (routeId) {
       this.mapRef.highlightRoute([routeId]);
       this.mapRef.zoomToRoutes([routeId]);

--- a/src/components/RouteExplorer/RouteExplorer.ts
+++ b/src/components/RouteExplorer/RouteExplorer.ts
@@ -16,6 +16,7 @@ import { AlternativesTab } from './tabs/AlternativesTab';
 import { LandTab } from './tabs/LandTab';
 import { CountryImpactTab } from './tabs/CountryImpactTab';
 import { inferCargoFromHs2, type ExplorerCargo } from './RouteExplorer.utils';
+import COUNTRY_PORT_CLUSTERS from '../../../scripts/shared/country-port-clusters.json';
 import {
   parseExplorerUrl,
   serializeExplorerUrl,
@@ -28,7 +29,7 @@ import type { GetRouteExplorerLaneResponse, GetRouteImpactResponse, BypassCorrid
 import { fetchRouteExplorerLane, fetchRouteImpact } from '@/services/supply-chain';
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { getAuthState } from '@/services/auth-state';
-import { trackGateHit } from '@/services/analytics';
+import { trackGateHit, track, type UmamiEvent } from '@/services/analytics';
 
 const TAB_LABELS: Record<ExplorerTab, string> = { 1: 'Current', 2: 'Alternatives', 3: 'Land', 4: 'Impact' };
 const FETCH_DEBOUNCE_MS = 250;
@@ -79,6 +80,9 @@ export class RouteExplorer {
   private laneData: GetRouteExplorerLaneResponse | null = null;
   public isLoading = false;
   private displayMode: 'idle' | 'loading' | 'data' | 'error' | 'gate' = 'idle';
+  private openedAt = 0;
+  private queryCount = 0;
+  private gateHitTracked = false;
 
   constructor() {
     this.state = { ...DEFAULT_EXPLORER_STATE };
@@ -101,6 +105,13 @@ export class RouteExplorer {
     this.root = this.buildRoot();
     document.body.append(this.root);
     this.isOpen = true;
+    this.openedAt = Date.now();
+    this.queryCount = 0;
+    if (!this.gateHitTracked && this.tier === 'free') {
+      trackGateHit('route-explorer');
+      this.gateHitTracked = true;
+    }
+    this.trackEvent('route-explorer:opened', { source: 'cmdk' });
     document.addEventListener('keydown', this.handleGlobalKeydown, { capture: true });
     this.focusInitial();
     if (this.isQueryComplete()) this.scheduleFetch();
@@ -113,6 +124,10 @@ export class RouteExplorer {
     document.removeEventListener('keydown', this.handleGlobalKeydown, { capture: true });
     this.helpOverlay?.element.remove();
     this.helpOverlay = null;
+    this.trackEvent('route-explorer:closed', {
+      durationSec: Math.round((Date.now() - this.openedAt) / 1000),
+      queryCount: this.queryCount,
+    });
     this.clearMapState();
     this.root.remove();
     this.root = null;
@@ -153,6 +168,13 @@ export class RouteExplorer {
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     this.debounceTimer = setTimeout(() => {
       this.debounceTimer = null;
+      this.queryCount++;
+      this.trackEvent('route-explorer:query', {
+        from: this.state.fromIso2 ?? '',
+        to: this.state.toIso2 ?? '',
+        hs2: this.state.hs2 ?? '',
+        cargo: this.getEffectiveCargo(),
+      });
       void this.fetchLane();
     }, FETCH_DEBOUNCE_MS);
   }
@@ -176,6 +198,7 @@ export class RouteExplorer {
       this.displayMode = 'gate';
       this.resetLaneState('gate');
       this.renderFreeGate();
+      this.applyPublicRouteHighlight();
       return;
     }
 
@@ -232,6 +255,9 @@ export class RouteExplorer {
       this.impactData = data;
       this.impactTab.update(data);
       this.leftRail.updateDependencyFlags(data.dependencyFlags);
+      if (data.comtradeSource === 'bilateral-hs4') {
+        this.trackEvent('route-explorer:impact-viewed', { toIso2, hs2 });
+      }
       if (data.resilienceScore > 0) {
         this.leftRail.updateResilience(data.resilienceScore);
       }
@@ -255,6 +281,7 @@ export class RouteExplorer {
 
   private handleBypassSelect(option: BypassCorridorOption): void {
     if (!this.mapRef || !option.fromPort || !option.toPort) return;
+    this.trackEvent('route-explorer:alternative-selected', { corridorId: option.id });
     const corridors = [{ fromPort: [option.fromPort.lon, option.fromPort.lat] as [number, number], toPort: [option.toPort.lon, option.toPort.lat] as [number, number] }];
     this.mapRef.setBypassRoutes(corridors);
     if (typeof window !== 'undefined' && window.__routeExplorerTestHook) {
@@ -275,6 +302,7 @@ export class RouteExplorer {
   // ─── Rendering ────────────────────────────────────────────────────────
 
   private applyData(data: GetRouteExplorerLaneResponse): void {
+    this.leftRail.element.classList.remove('re-leftrail--blurred');
     this.leftRail.updateLane(data);
     this.currentTab.update(data);
     this.alternativesTab.update(data);
@@ -295,6 +323,7 @@ export class RouteExplorer {
   }
 
   private renderFreeGate(): void {
+    this.leftRail?.element.classList.add('re-leftrail--blurred');
     if (this.contentEl) {
       this.contentEl.innerHTML =
         '<div class="re-content__gate">' +
@@ -305,10 +334,28 @@ export class RouteExplorer {
       const btn = this.contentEl.querySelector<HTMLButtonElement>('.re-content__upgrade');
       btn?.addEventListener('click', () => {
         trackGateHit('route-explorer');
+        this.trackEvent('route-explorer:free-cta-click', {
+          from: this.state.fromIso2 ?? '',
+          to: this.state.toIso2 ?? '',
+          hs2: this.state.hs2 ?? '',
+        });
         void import('@/services/checkout')
           .then((m) => m.startCheckout('pro_monthly'))
           .catch(() => window.open('https://worldmonitor.app/pro', '_blank'));
       }, { once: true });
+    }
+  }
+
+  private applyPublicRouteHighlight(): void {
+    if (!this.mapRef || !this.state.fromIso2 || !this.state.toIso2) return;
+    const clusters = COUNTRY_PORT_CLUSTERS as unknown as Record<string, { nearestRouteIds: string[] }>;
+    const fromRoutes = new Set(clusters[this.state.fromIso2]?.nearestRouteIds ?? []);
+    const toRoutes = new Set(clusters[this.state.toIso2]?.nearestRouteIds ?? []);
+    const shared = [...fromRoutes].filter((r) => toRoutes.has(r));
+    const routeId = shared[0] ?? clusters[this.state.fromIso2]?.nearestRouteIds[0] ?? '';
+    if (routeId) {
+      this.mapRef.highlightRoute([routeId]);
+      this.mapRef.zoomToRoutes([routeId]);
     }
   }
 
@@ -481,6 +528,7 @@ export class RouteExplorer {
     if (n === this.state.tab) return;
     this.state = { ...this.state, tab: n };
     this.writeStateToUrl();
+    this.trackEvent('route-explorer:tab-switch', { tab: n });
     if (this.tabStrip) {
       const buttons = this.tabStrip.querySelectorAll<HTMLButtonElement>('.re-tabstrip__tab');
       buttons.forEach((b) => {
@@ -632,7 +680,18 @@ export class RouteExplorer {
     if (serialized) url.searchParams.set('explorer', serialized);
     if (navigator.clipboard?.writeText) {
       void navigator.clipboard.writeText(url.toString());
+      this.trackEvent('route-explorer:share-copied');
     }
+  }
+
+  // ─── Analytics ─────────────────────────────────────────────────────────
+
+  private get tier(): 'pro' | 'free' {
+    return hasPremiumAccess(getAuthState()) ? 'pro' : 'free';
+  }
+
+  private trackEvent(event: UmamiEvent, props?: Record<string, unknown>): void {
+    track(event, { tier: this.tier, ...props });
   }
 
   // ─── Test hook ────────────────────────────────────────────────────────

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -48,6 +48,15 @@ const EVENTS = {
   'mcp-connect-attempt': true,
   'mcp-connect-success': true,
   'mcp-panel-add': true,
+  // Route Explorer
+  'route-explorer:opened': true,
+  'route-explorer:query': true,
+  'route-explorer:tab-switch': true,
+  'route-explorer:alternative-selected': true,
+  'route-explorer:impact-viewed': true,
+  'route-explorer:share-copied': true,
+  'route-explorer:free-cta-click': true,
+  'route-explorer:closed': true,
   // Auth (wired in PR #1812 — do not remove)
   'sign-in': true,
   'sign-up': true,

--- a/src/styles/route-explorer.css
+++ b/src/styles/route-explorer.css
@@ -609,3 +609,43 @@
 .re-leftrail__flag--single_source_critical { background: rgba(245, 158, 11, 0.15); color: #f59e0b; }
 .re-leftrail__flag--single_corridor_critical { background: rgba(245, 158, 11, 0.15); color: #f59e0b; }
 .re-leftrail__flag--diversifiable { background: rgba(34, 197, 94, 0.15); color: #22c55e; }
+
+/* ─── Free-tier blur ────────────────────────────────────────────────── */
+
+.re-leftrail--blurred {
+  filter: blur(6px);
+  pointer-events: none;
+  user-select: none;
+}
+
+.re-content__gate {
+  position: relative;
+  z-index: 2;
+}
+
+.re-content__gate h3 {
+  margin: 0 0 12px;
+  color: var(--text-primary, #c9d1d9);
+  font-size: 18px;
+}
+
+.re-content__gate ul {
+  text-align: left;
+  margin: 0 0 16px;
+  padding-left: 20px;
+  font-size: 14px;
+  color: var(--text-dim, #8b949e);
+}
+
+.re-content__upgrade {
+  padding: 10px 24px;
+  background: var(--accent, #58a6ff);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.re-content__upgrade:hover { background: #4090ef; }

--- a/src/styles/route-explorer.css
+++ b/src/styles/route-explorer.css
@@ -265,18 +265,6 @@
   text-align: center;
 }
 
-.re-content__gate h3 { margin: 0 0 12px; color: var(--text-primary, #c9d1d9); }
-.re-content__gate ul { text-align: left; margin: 0 0 16px; padding-left: 20px; }
-
-.re-content__upgrade {
-  padding: 8px 20px;
-  background: var(--accent, #58a6ff);
-  color: #fff;
-  border: none;
-  border-radius: 6px;
-  font-size: 14px;
-  cursor: pointer;
-}
 
 /* ─── Tab panels ────────────────────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary
Final sprint of the Route Explorer feature. Adds free-tier blur treatment, 8 analytics events, and documentation updates. The entire 6-sprint Route Explorer feature is now complete.

### Free-tier treatment
- Non-PRO users see a **public route highlight** on the map using only `TRADE_ROUTES` + `COUNTRY_PORT_CLUSTERS` (zero PRO RPC calls)
- Left rail blurred with `filter: blur(6px)` + `pointer-events: none`
- Tab content replaced with upgrade CTA (`startCheckout('pro_monthly')` wired + `trackGateHit`)
- **Network-verifiable**: zero requests to `get-route-explorer-lane` or `get-route-impact` for free users
- Public route lookup uses the same `COUNTRY_PORT_CLUSTERS` shared-route matching as the PRO path, but from client-side data only

### Analytics (8 type-safe events)
| Event | When | Properties |
|---|---|---|
| `route-explorer:opened` | Modal open | tier, source |
| `route-explorer:query` | Chip commit | from, to, hs2, cargo, tier |
| `route-explorer:tab-switch` | Tab change | tab, tier |
| `route-explorer:alternative-selected` | Bypass selected | corridorId, tier |
| `route-explorer:impact-viewed` | Impact data rendered | toIso2, hs2, tier |
| `route-explorer:share-copied` | Cmd+, copy | tier |
| `route-explorer:free-cta-click` | Upgrade CTA | from, to, hs2 |
| `route-explorer:closed` | Modal close | durationSec, queryCount, tier |

All events added to `EVENTS` const in `analytics.ts` for type-safe `UmamiEvent` union.

### Documentation
- `docs/maritime-intelligence.mdx`: new Route Explorer section with feature list
- `CHANGELOG.md` + `docs/changelog.mdx`: dual-updated with feature entry referencing all sprint PRs

### Plan status
`docs/plans/2026-04-11-001-feat-worldwide-route-explorer-plan.md` status updated from `draft` to `completed`.

### Deferred
- E2E Playwright spec (`e2e/route-explorer.spec.ts`): needs running dev server + authenticated PRO session. Recommended for manual verification using the test plan below.

## Test plan
- [ ] PRO: CMD+K → "route" → CN→DE HS 85 → all 4 tabs render with data → map highlights route
- [ ] Free: open explorer without PRO session → left rail blurred → upgrade CTA visible → chip changes update map with public route → no PRO RPC calls in network tab
- [ ] Free: click "Upgrade to PRO" → checkout flow opens (or fallback to worldmonitor.app/pro)
- [ ] Analytics: open browser console → filter for `umami` → verify events fire on open/query/tab-switch/close
- [ ] URL state: load `?explorer=from:CN,to:DE,hs:85` → modal opens with correct state
- [ ] Keyboard: F/T/P/S/1-4/?/Esc all work as documented

## Post-Deploy Monitoring & Validation
- **What to monitor**: `route-explorer:opened` event volume in Umami dashboard
- **Expected healthy**: events fire for both PRO and free tiers; free-tier shows zero `get-route-explorer-lane` requests
- **Failure signal**: `route-explorer:free-cta-click` events without corresponding checkout session starts
- **Validation window**: 48h post-deploy