### PR TITLE
fix(digest): skip Groq + fix Telegram 400 from oversized messages

### DIFF
--- a/scripts/lib/llm-chain.cjs
+++ b/scripts/lib/llm-chain.cjs
@@ -60,9 +60,11 @@ const LLM_PROVIDERS = [
  * @returns {Promise<string|null>} Generated text, or null if all providers fail
  */
 async function callLLM(systemPrompt, userPrompt, opts = {}) {
-  const { maxTokens = 500, temperature = 0.3, timeoutMs } = opts;
+  const { maxTokens = 500, temperature = 0.3, timeoutMs, skipProviders } = opts;
+  const skipSet = skipProviders ? new Set(skipProviders) : null;
 
   for (const provider of LLM_PROVIDERS) {
+    if (skipSet?.has(provider.name)) continue;
     const envVal = process.env[provider.envKey];
     if (!envVal) continue;
 

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -567,7 +567,10 @@ function sanitizeTelegramHtml(html) {
 }
 
 function truncateTelegramHtml(html, limit = TELEGRAM_MAX_LEN) {
-  if (html.length <= limit) return sanitizeTelegramHtml(html);
+  if (html.length <= limit) {
+    const sanitized = sanitizeTelegramHtml(html);
+    return sanitized.length <= limit ? sanitized : truncateTelegramHtml(sanitized, limit);
+  }
   const truncated = html.slice(0, limit - 30);
   const lastNewline = truncated.lastIndexOf('\n');
   const cutPoint = lastNewline > limit * 0.6 ? lastNewline : truncated.length;

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -512,7 +512,7 @@ Rules:
 - End with "Signals to watch:" (1-2 items)
 - Under 250 words`;
 
-  const summary = await callLLM(systemPrompt, storyList, { maxTokens: 600, temperature: 0.3, timeoutMs: 15_000 });
+  const summary = await callLLM(systemPrompt, storyList, { maxTokens: 600, temperature: 0.3, timeoutMs: 15_000, skipProviders: ['groq'] });
   if (!summary) {
     console.warn(`[digest] AI summary generation failed for ${rule.userId}`);
     return null;
@@ -554,11 +554,33 @@ function isPrivateIP(ip) {
 
 // ── Send functions ────────────────────────────────────────────────────────────
 
+const TELEGRAM_MAX_LEN = 4096;
+
+function sanitizeTelegramHtml(html) {
+  let out = html;
+  for (const tag of ['b', 'i', 'u', 's', 'code', 'pre']) {
+    const opens = (out.match(new RegExp(`<${tag}>`, 'g')) || []).length;
+    const closes = (out.match(new RegExp(`</${tag}>`, 'g')) || []).length;
+    for (let i = closes; i < opens; i++) out += `</${tag}>`;
+  }
+  out = out.replace(/<[^>]*$/, '');
+  return out;
+}
+
+function truncateTelegramHtml(html, limit = TELEGRAM_MAX_LEN) {
+  if (html.length <= limit) return sanitizeTelegramHtml(html);
+  const truncated = html.slice(0, limit - 30);
+  const lastNewline = truncated.lastIndexOf('\n');
+  const cutPoint = lastNewline > limit * 0.6 ? lastNewline : truncated.length;
+  return sanitizeTelegramHtml(truncated.slice(0, cutPoint) + '\n\n[truncated]');
+}
+
 async function sendTelegram(userId, chatId, text) {
   if (!TELEGRAM_BOT_TOKEN) {
     console.warn('[digest] Telegram: TELEGRAM_BOT_TOKEN not set, skipping');
     return false;
   }
+  const safeText = truncateTelegramHtml(text);
   try {
     const res = await fetch(
       `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`,
@@ -567,7 +589,7 @@ async function sendTelegram(userId, chatId, text) {
         headers: { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-digest/1.0' },
         body: JSON.stringify({
           chat_id: chatId,
-          text,
+          text: safeText,
           parse_mode: 'HTML',
           disable_web_page_preview: true,
         }),
@@ -579,7 +601,8 @@ async function sendTelegram(userId, chatId, text) {
       await deactivateChannel(userId, 'telegram');
       return false;
     } else if (!res.ok) {
-      console.warn(`[digest] Telegram send failed ${res.status} for ${userId}`);
+      const body = await res.text().catch(() => '');
+      console.warn(`[digest] Telegram send failed ${res.status} for ${userId}: ${body.slice(0, 300)}`);
       return false;
     }
     console.log(`[digest] Telegram delivered to ${userId}`);

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -557,13 +557,12 @@ function isPrivateIP(ip) {
 const TELEGRAM_MAX_LEN = 4096;
 
 function sanitizeTelegramHtml(html) {
-  let out = html;
+  let out = html.replace(/<[^>]*$/, '');
   for (const tag of ['b', 'i', 'u', 's', 'code', 'pre']) {
     const opens = (out.match(new RegExp(`<${tag}>`, 'g')) || []).length;
     const closes = (out.match(new RegExp(`</${tag}>`, 'g')) || []).length;
     for (let i = closes; i < opens; i++) out += `</${tag}>`;
   }
-  out = out.replace(/<[^>]*$/, '');
   return out;
 }
 


### PR DESCRIPTION
## Summary
- **Telegram 400 fix**: Digest messages with 30 stories + AI summary = ~5600 chars, exceeding Telegram's 4096 char limit. Added `truncateTelegramHtml()` that cuts at the last newline before the limit, plus `sanitizeTelegramHtml()` to close any unclosed HTML tags from truncation mid-tag. Now also logs Telegram's error response body (was blind before).
- **Skip Groq**: Added `skipProviders` option to `callLLM()` in `llm-chain.cjs`. Digest now skips Groq (always 429 rate-limited), going straight to Ollama/OpenRouter and saving ~1s latency per run.

## Test plan
- [x] `npm run typecheck` + `typecheck:api` pass
- [x] CJS syntax check passes
- [x] Biome lint passes (warnings pre-existing)
- [x] `npm run test:data` passes (4936 tests)
- [x] Edge function tests pass (165 tests)
- [x] `digest-dedup.test.mjs` passes (11 tests)
- [x] Markdown lint + version sync pass
- [ ] Deploy to Railway, verify next digest run delivers Telegram successfully
- [ ] Verify logs show Groq skipped (no more `groq API error: 429` lines)