### PR TITLE
fix(resilience): Railway deploy fixes for validation + recovery bundles

### DIFF
--- a/scripts/backtest-resilience-outcomes.mjs
+++ b/scripts/backtest-resilience-outcomes.mjs
@@ -10,7 +10,7 @@ loadEnvFile(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const VALIDATION_DIR = join(__dirname, '..', 'docs', 'methodology', 'country-resilience-index', 'validation');
 
-const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v8:';
+const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v9:';
 const BACKTEST_RESULT_KEY = 'resilience:backtest:outcomes:v1';
 const BACKTEST_TTL_SECONDS = 7 * 24 * 60 * 60;
 

--- a/scripts/benchmark-resilience-external.mjs
+++ b/scripts/benchmark-resilience-external.mjs
@@ -290,13 +290,19 @@ function median(arr) {
 
 async function readWmScoresFromRedis() {
   const { url, token } = getRedisCredentials();
-  const rankingResp = await fetch(`${url}/get/${encodeURIComponent('resilience:ranking:v8')}`, {
+  const rankingResp = await fetch(`${url}/get/${encodeURIComponent('resilience:ranking:v9')}`, {
     headers: { Authorization: `Bearer ${token}` },
     signal: AbortSignal.timeout(10_000),
   });
-  if (!rankingResp.ok) throw new Error(`Failed to read ranking: HTTP ${rankingResp.status}`);
+  if (!rankingResp.ok) {
+    console.warn(`[benchmark] Failed to read ranking: HTTP ${rankingResp.status} — skipping (scores may not be populated yet after cache key bump)`);
+    return new Map();
+  }
   const rankingData = await rankingResp.json();
-  if (!rankingData.result) throw new Error('No ranking data in Redis');
+  if (!rankingData.result) {
+    console.warn('[benchmark] No ranking data in Redis — skipping (cold start after cache key bump)');
+    return new Map();
+  }
   const ranking = JSON.parse(rankingData.result);
   const scores = new Map();
   for (const item of ranking) {
@@ -331,6 +337,11 @@ function evaluateHypothesis(hypothesis, sp) {
 
 export async function runBenchmark(opts = {}) {
   const wmScores = opts.wmScores || await readWmScoresFromRedis();
+
+  if (wmScores.size === 0) {
+    console.warn('[benchmark] No WM resilience scores available — skipping benchmark run (cold start after cache key bump)');
+    return { skipped: true, reason: 'no-wm-scores', generatedAt: Date.now() };
+  }
 
   const fetchers = [
     { name: 'INFORM', fn: opts.fetchInform || fetchInformGlobal },

--- a/scripts/benchmark-resilience-external.mjs
+++ b/scripts/benchmark-resilience-external.mjs
@@ -303,7 +303,10 @@ async function readWmScoresFromRedis() {
     console.warn('[benchmark] No ranking data in Redis — skipping (cold start after cache key bump)');
     return new Map();
   }
-  const ranking = JSON.parse(rankingData.result);
+  const parsed = JSON.parse(rankingData.result);
+  // The ranking cache stores a GetResilienceRankingResponse object
+  // with { items, greyedOut }, not a bare array.
+  const ranking = Array.isArray(parsed) ? parsed : (parsed?.items ?? []);
   const scores = new Map();
   for (const item of ranking) {
     if (item.countryCode && typeof item.overallScore === 'number' && item.overallScore > 0) {
@@ -439,17 +442,21 @@ const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv
 if (isMain) {
   runBenchmark()
     .then(result => {
+      if (result.skipped) {
+        console.log(`\n[benchmark] Skipped: ${result.reason}`);
+        return;
+      }
       console.log('\n=== Benchmark Results ===');
-      console.log(`Hypotheses: ${result.hypotheses.filter(h => h.pass).length}/${result.hypotheses.length} passed`);
-      for (const h of result.hypotheses) {
+      console.log(`Hypotheses: ${(result.hypotheses ?? []).filter(h => h.pass).length}/${(result.hypotheses ?? []).length} passed`);
+      for (const h of (result.hypotheses ?? [])) {
         console.log(`  ${h.pass ? 'PASS' : 'FAIL'} ${h.index} (${h.pillar}): expected ${h.direction} >= ${h.expected}, got ${h.actual}`);
       }
       console.log(`\nCorrelations:`);
-      for (const [name, c] of Object.entries(result.correlations)) {
+      for (const [name, c] of Object.entries(result.correlations ?? {})) {
         console.log(`  ${name}: spearman=${c.spearman}, pearson=${c.pearson}, n=${c.n}`);
       }
-      console.log(`\nOutliers: ${result.outliers.length}`);
-      for (const o of result.outliers.slice(0, 10)) {
+      console.log(`\nOutliers: ${(result.outliers ?? []).length}`);
+      for (const o of (result.outliers ?? []).slice(0, 10)) {
         console.log(`  ${o.countryCode} (${o.index}): residual=${o.residual} - ${o.commentary}`);
       }
     })

--- a/scripts/seed-recovery-external-debt.mjs
+++ b/scripts/seed-recovery-external-debt.mjs
@@ -1,9 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, resolveProxyForConnect } from './_seed-utils.mjs';
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
-const { httpsProxyFetchRaw } = require('./_proxy-utils.cjs');
+import { loadEnvFile, CHROME_UA, runSeed, resolveProxyForConnect, httpsProxyFetchRaw } from './_seed-utils.mjs';
 import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
 
 loadEnvFile(import.meta.url);

--- a/scripts/seed-recovery-external-debt.mjs
+++ b/scripts/seed-recovery-external-debt.mjs
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, resolveProxyForConnect } from './_seed-utils.mjs';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { httpsProxyFetchRaw } = require('./_proxy-utils.cjs');
 import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
 
 loadEnvFile(import.meta.url);
 
 const WB_BASE = 'https://api.worldbank.org/v2';
+const _proxyAuth = resolveProxyForConnect();
 const CANONICAL_KEY = 'resilience:recovery:external-debt:v1';
 const CACHE_TTL = 35 * 24 * 3600;
 
@@ -19,12 +23,20 @@ async function fetchWbIndicator(indicator) {
 
   while (page <= totalPages) {
     const url = `${WB_BASE}/country/all/indicator/${indicator}?format=json&per_page=500&page=${page}&mrnev=1`;
-    const resp = await fetch(url, {
-      headers: { 'User-Agent': CHROME_UA },
-      signal: AbortSignal.timeout(30_000),
-    });
-    if (!resp.ok) throw new Error(`World Bank ${indicator}: HTTP ${resp.status}`);
-    const json = await resp.json();
+    let json;
+    try {
+      const resp = await fetch(url, {
+        headers: { 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      json = await resp.json();
+    } catch (directErr) {
+      if (!_proxyAuth) throw new Error(`World Bank ${indicator}: ${directErr.message}`);
+      console.warn(`  WB ${indicator} p${page}: direct failed (${directErr.message}), retrying via proxy`);
+      const { buffer } = await httpsProxyFetchRaw(url, _proxyAuth, { accept: 'application/json', timeoutMs: 30_000 });
+      json = JSON.parse(buffer.toString('utf8'));
+    }
     const meta = json[0];
     const records = json[1] ?? [];
     totalPages = meta?.pages ?? 1;

--- a/scripts/seed-recovery-fiscal-space.mjs
+++ b/scripts/seed-recovery-fiscal-space.mjs
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, loadSharedConfig } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, loadSharedConfig, resolveProxyForConnect } from './_seed-utils.mjs';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { httpsProxyFetchRaw } = require('./_proxy-utils.cjs');
 
 loadEnvFile(import.meta.url);
 
 const IMF_BASE = 'https://www.imf.org/external/datamapper/api/v1';
+const _proxyAuth = resolveProxyForConnect();
 const CANONICAL_KEY = 'resilience:recovery:fiscal-space:v1';
 const CACHE_TTL = 35 * 24 * 3600;
 
@@ -28,13 +32,25 @@ function weoYears() {
 
 async function fetchImfIndicator(indicator) {
   const url = `${IMF_BASE}/${indicator}?periods=${weoYears().join(',')}`;
-  const resp = await fetch(url, {
-    headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!resp.ok) throw new Error(`IMF ${indicator}: HTTP ${resp.status}`);
-  const data = await resp.json();
-  return data?.values?.[indicator] ?? {};
+  // Try direct first, fall back to proxy (IMF blocks Railway container IPs)
+  try {
+    const resp = await fetch(url, {
+      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!resp.ok) throw new Error(`IMF ${indicator}: HTTP ${resp.status}`);
+    const data = await resp.json();
+    return data?.values?.[indicator] ?? {};
+  } catch (directErr) {
+    if (!_proxyAuth) throw directErr;
+    console.warn(`  IMF ${indicator}: direct failed (${directErr.message}), retrying via proxy`);
+    const { buffer } = await httpsProxyFetchRaw(url, _proxyAuth, {
+      accept: 'application/json',
+      timeoutMs: 30_000,
+    });
+    const data = JSON.parse(buffer.toString('utf8'));
+    return data?.values?.[indicator] ?? {};
+  }
 }
 
 function latestValue(byYear) {

--- a/scripts/seed-recovery-fiscal-space.mjs
+++ b/scripts/seed-recovery-fiscal-space.mjs
@@ -1,9 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, loadSharedConfig, resolveProxyForConnect } from './_seed-utils.mjs';
-import { createRequire } from 'node:module';
-const require = createRequire(import.meta.url);
-const { httpsProxyFetchRaw } = require('./_proxy-utils.cjs');
+import { loadEnvFile, CHROME_UA, runSeed, loadSharedConfig, resolveProxyForConnect, httpsProxyFetchRaw } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 


### PR DESCRIPTION
## Summary
Both Railway resilience bundles failed on first deploy. Four fixes:

1. **Benchmark + backtest**: hardcoded `resilience:ranking:v8` / `resilience:score:v8` but cache was bumped to v9 in PR #2990. Fixed + benchmark now gracefully skips on empty ranking data (cold start after cache bump).
2. **Fiscal-space seeder**: IMF DataMapper HTTP 403 from Railway IPs. Added proxy fallback (same pattern as `seed-resilience-static.mjs`).
3. **External-debt seeder**: World Bank API HTTP 400 from Railway IPs. Same proxy fallback.
4. **Sensitivity suite**: `ERR_MODULE_NOT_FOUND: /server/...` because rootDirectory=scripts meant `../server/` escaped the deploy root. Changed Railway service config to rootDirectory="" (repo root) so the dynamic imports resolve correctly.

## Test plan
- [x] All 4 scripts pass `node -c` syntax check
- [ ] After merge: `resilience-validation` cron runs without ERR_MODULE_NOT_FOUND
- [ ] After merge: benchmark reads from v9 ranking key
- [ ] After merge: fiscal-space seeds via proxy instead of 403
- [ ] After merge: external-debt seeds via proxy instead of 400