### PR TITLE
fix(resilience): WB API mrnev to mrv param

### DIFF
--- a/scripts/seed-recovery-external-debt.mjs
+++ b/scripts/seed-recovery-external-debt.mjs
@@ -19,7 +19,7 @@ async function fetchWbIndicator(indicator) {
   let totalPages = 1;
 
   while (page <= totalPages) {
-    const url = `${WB_BASE}/country/all/indicator/${indicator}?format=json&per_page=500&page=${page}&mrnev=1`;
+    const url = `${WB_BASE}/country/all/indicator/${indicator}?format=json&per_page=500&page=${page}&mrv=1`;
     let json;
     try {
       const resp = await fetch(url, {

--- a/scripts/seed-recovery-reserve-adequacy.mjs
+++ b/scripts/seed-recovery-reserve-adequacy.mjs
@@ -16,7 +16,7 @@ async function fetchReserveAdequacy() {
   let totalPages = 1;
 
   while (page <= totalPages) {
-    const url = `${WB_BASE}/country/all/indicator/${INDICATOR}?format=json&per_page=500&page=${page}&mrnev=1`;
+    const url = `${WB_BASE}/country/all/indicator/${INDICATOR}?format=json&per_page=500&page=${page}&mrv=1`;
     const resp = await fetch(url, {
       headers: { 'User-Agent': CHROME_UA },
       signal: AbortSignal.timeout(30_000),


### PR DESCRIPTION
World Bank v2 API parameter is mrv=1 (Most Recent Value), not mrnev=1 (non-existent). The API returns 400 for IDS indicators with the wrong param. Reserve-adequacy happened to work because WB ignores unknown params for some indicator families.