### PR TITLE
fix(resilience): stagger IMF fetches to avoid 403 rate limit

### DIFF
--- a/scripts/seed-recovery-fiscal-space.mjs
+++ b/scripts/seed-recovery-fiscal-space.mjs
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, loadSharedConfig, resolveProxyForConnect, httpsProxyFetchRaw } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, loadSharedConfig } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
 const IMF_BASE = 'https://www.imf.org/external/datamapper/api/v1';
-const _proxyAuth = resolveProxyForConnect();
 const CANONICAL_KEY = 'resilience:recovery:fiscal-space:v1';
 const CACHE_TTL = 35 * 24 * 3600;
 
@@ -29,25 +28,13 @@ function weoYears() {
 
 async function fetchImfIndicator(indicator) {
   const url = `${IMF_BASE}/${indicator}?periods=${weoYears().join(',')}`;
-  // Try direct first, fall back to proxy (IMF blocks Railway container IPs)
-  try {
-    const resp = await fetch(url, {
-      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
-      signal: AbortSignal.timeout(30_000),
-    });
-    if (!resp.ok) throw new Error(`IMF ${indicator}: HTTP ${resp.status}`);
-    const data = await resp.json();
-    return data?.values?.[indicator] ?? {};
-  } catch (directErr) {
-    if (!_proxyAuth) throw directErr;
-    console.warn(`  IMF ${indicator}: direct failed (${directErr.message}), retrying via proxy`);
-    const { buffer } = await httpsProxyFetchRaw(url, _proxyAuth, {
-      accept: 'application/json',
-      timeoutMs: 30_000,
-    });
-    const data = JSON.parse(buffer.toString('utf8'));
-    return data?.values?.[indicator] ?? {};
-  }
+  const resp = await fetch(url, {
+    headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!resp.ok) throw new Error(`IMF ${indicator}: HTTP ${resp.status}`);
+  const data = await resp.json();
+  return data?.values?.[indicator] ?? {};
 }
 
 function latestValue(byYear) {
@@ -59,11 +46,13 @@ function latestValue(byYear) {
 }
 
 async function fetchFiscalSpace() {
-  const [revenueData, balanceData, debtData] = await Promise.all([
-    fetchImfIndicator('GGR_G01_GDP_PT'),
-    fetchImfIndicator('GGXCNL_G01_GDP_PT'),
-    fetchImfIndicator('GGXWDG_NGDP_PT'),
-  ]);
+  // Sequential with delays to avoid IMF rate limiter. seed-imf-macro.mjs
+  // may run in the same cron window, so concurrent Promise.all risks 403.
+  const revenueData = await fetchImfIndicator('GGR_G01_GDP_PT');
+  await sleep(1000);
+  const balanceData = await fetchImfIndicator('GGXCNL_G01_GDP_PT');
+  await sleep(1000);
+  const debtData = await fetchImfIndicator('GGXWDG_NGDP_PT');
 
   const countries = {};
   const allIso3 = new Set([


### PR DESCRIPTION
seed-recovery-fiscal-space.mjs got IMF 403 on Railway. Not an IP block (seed-imf-macro.mjs works from the same service). The 403 was from IMF rate limiting when 3 concurrent requests fired via Promise.all while seed-imf-macro.mjs runs in the same cron window. Fixed: sequential fetches with 1s delays. Removed the unnecessary proxy fallback.