### PR TITLE
fix(seeds): add proxy fallback for IMF DataMapper (403 from Railway IPs)

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -321,7 +321,10 @@ export function resolveProxyForConnect() {
 // Do NOT call from standalone seed scripts; use fredFetchJson or httpsProxyFetchJson instead.
 export function curlFetch(url, proxyAuth, headers = {}) {
   const args = ['-sS', '--compressed', '--max-time', '15', '-L'];
-  if (proxyAuth) args.push('-x', `http://${proxyAuth}`);
+  if (proxyAuth) {
+    const proxyUrl = /^https?:\/\//i.test(proxyAuth) ? proxyAuth : `http://${proxyAuth}`;
+    args.push('-x', proxyUrl);
+  }
   for (const [k, v] of Object.entries(headers)) args.push('-H', `${k}: ${v}`);
   args.push('-w', '\n%{http_code}');
   args.push(url);

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -317,8 +317,9 @@ export function resolveProxyForConnect() {
 }
 
 // curl-based fetch; throws on non-2xx. Returns response body as string.
-// NOTE: requires curl binary — only available in Dockerfile.relay (apk add curl).
-// Do NOT call from standalone seed scripts; use fredFetchJson or httpsProxyFetchJson instead.
+// NOTE: requires curl binary — available in Dockerfile.relay (apk add curl) and Railway.
+// Prefer httpsProxyFetchJson (pure Node.js) when possible; use curlFetch when curl-specific
+// features are needed (e.g. --compressed, -L redirect following with proxy).
 export function curlFetch(url, proxyAuth, headers = {}) {
   const args = ['-sS', '--compressed', '--max-time', '15', '-L'];
   if (proxyAuth) {
@@ -376,6 +377,23 @@ export async function fredFetchJson(url, proxyAuth) {
   const r = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(20_000) });
   if (r.ok) return r.json();
   throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
+}
+
+// Fetch JSON from an IMF DataMapper URL, direct-first with proxy fallback.
+// Direct timeout is short (10s) since IMF blocks Railway IPs with 403 quickly.
+export async function imfFetchJson(url, proxyAuth) {
+  try {
+    const r = await fetch(url, {
+      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return await r.json();
+  } catch (directErr) {
+    if (!proxyAuth) throw directErr;
+    console.warn(`  [IMF] Direct fetch failed (${directErr.message}); retrying via proxy`);
+    return httpsProxyFetchJson(url, proxyAuth);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/seed-imf-macro.mjs
+++ b/scripts/seed-imf-macro.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, loadSharedConfig, resolveProxyForConnect, curlFetch } from './_seed-utils.mjs';
+import { loadEnvFile, runSeed, loadSharedConfig, resolveProxyForConnect, imfFetchJson } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -34,21 +34,8 @@ function weoYears() {
 
 async function fetchImfIndicator(indicator) {
   const url = `${IMF_BASE}/${indicator}?periods=${weoYears().join(',')}`;
-  try {
-    const resp = await fetch(url, {
-      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
-      signal: AbortSignal.timeout(30_000),
-    });
-    if (!resp.ok) throw new Error(`IMF ${indicator}: HTTP ${resp.status}`);
-    const data = await resp.json();
-    return data?.values?.[indicator] ?? {};
-  } catch (directErr) {
-    if (!_proxyAuth) throw directErr;
-    console.warn(`  [IMF] Direct fetch failed for ${indicator}: ${directErr.message}; retrying via proxy`);
-    const raw = curlFetch(url, _proxyAuth, { 'User-Agent': CHROME_UA, Accept: 'application/json' });
-    const data = JSON.parse(raw);
-    return data?.values?.[indicator] ?? {};
-  }
+  const data = await imfFetchJson(url, _proxyAuth);
+  return data?.values?.[indicator] ?? {};
 }
 
 // Pick the most recent year with a finite value, searching newest-first.

--- a/scripts/seed-imf-macro.mjs
+++ b/scripts/seed-imf-macro.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, loadSharedConfig } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, loadSharedConfig, resolveProxyForConnect, curlFetch } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
 const IMF_BASE = 'https://www.imf.org/external/datamapper/api/v1';
+const _proxyAuth = resolveProxyForConnect();
 const CANONICAL_KEY = 'economic:imf:macro:v2';
 const CACHE_TTL = 35 * 24 * 3600; // 35 days — monthly IMF WEO release
 
@@ -33,13 +34,21 @@ function weoYears() {
 
 async function fetchImfIndicator(indicator) {
   const url = `${IMF_BASE}/${indicator}?periods=${weoYears().join(',')}`;
-  const resp = await fetch(url, {
-    headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!resp.ok) throw new Error(`IMF ${indicator}: HTTP ${resp.status}`);
-  const data = await resp.json();
-  return data?.values?.[indicator] ?? {};
+  try {
+    const resp = await fetch(url, {
+      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!resp.ok) throw new Error(`IMF ${indicator}: HTTP ${resp.status}`);
+    const data = await resp.json();
+    return data?.values?.[indicator] ?? {};
+  } catch (directErr) {
+    if (!_proxyAuth) throw directErr;
+    console.warn(`  [IMF] Direct fetch failed for ${indicator}: ${directErr.message}; retrying via proxy`);
+    const raw = curlFetch(url, _proxyAuth, { 'User-Agent': CHROME_UA, Accept: 'application/json' });
+    const data = JSON.parse(raw);
+    return data?.values?.[indicator] ?? {};
+  }
 }
 
 // Pick the most recent year with a finite value, searching newest-first.

--- a/scripts/seed-recovery-fiscal-space.mjs
+++ b/scripts/seed-recovery-fiscal-space.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, loadSharedConfig } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, loadSharedConfig, sleep, resolveProxyForConnect, curlFetch } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
 const IMF_BASE = 'https://www.imf.org/external/datamapper/api/v1';
+const _proxyAuth = resolveProxyForConnect();
 const CANONICAL_KEY = 'resilience:recovery:fiscal-space:v1';
 const CACHE_TTL = 35 * 24 * 3600;
 
@@ -28,13 +29,21 @@ function weoYears() {
 
 async function fetchImfIndicator(indicator) {
   const url = `${IMF_BASE}/${indicator}?periods=${weoYears().join(',')}`;
-  const resp = await fetch(url, {
-    headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!resp.ok) throw new Error(`IMF ${indicator}: HTTP ${resp.status}`);
-  const data = await resp.json();
-  return data?.values?.[indicator] ?? {};
+  try {
+    const resp = await fetch(url, {
+      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!resp.ok) throw new Error(`IMF ${indicator}: HTTP ${resp.status}`);
+    const data = await resp.json();
+    return data?.values?.[indicator] ?? {};
+  } catch (directErr) {
+    if (!_proxyAuth) throw directErr;
+    console.warn(`  [IMF] Direct fetch failed for ${indicator}: ${directErr.message}; retrying via proxy`);
+    const raw = curlFetch(url, _proxyAuth, { 'User-Agent': CHROME_UA, Accept: 'application/json' });
+    const data = JSON.parse(raw);
+    return data?.values?.[indicator] ?? {};
+  }
 }
 
 function latestValue(byYear) {

--- a/scripts/seed-recovery-fiscal-space.mjs
+++ b/scripts/seed-recovery-fiscal-space.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, loadSharedConfig, sleep, resolveProxyForConnect, curlFetch } from './_seed-utils.mjs';
+import { loadEnvFile, runSeed, loadSharedConfig, sleep, resolveProxyForConnect, imfFetchJson } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -29,21 +29,8 @@ function weoYears() {
 
 async function fetchImfIndicator(indicator) {
   const url = `${IMF_BASE}/${indicator}?periods=${weoYears().join(',')}`;
-  try {
-    const resp = await fetch(url, {
-      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
-      signal: AbortSignal.timeout(30_000),
-    });
-    if (!resp.ok) throw new Error(`IMF ${indicator}: HTTP ${resp.status}`);
-    const data = await resp.json();
-    return data?.values?.[indicator] ?? {};
-  } catch (directErr) {
-    if (!_proxyAuth) throw directErr;
-    console.warn(`  [IMF] Direct fetch failed for ${indicator}: ${directErr.message}; retrying via proxy`);
-    const raw = curlFetch(url, _proxyAuth, { 'User-Agent': CHROME_UA, Accept: 'application/json' });
-    const data = JSON.parse(raw);
-    return data?.values?.[indicator] ?? {};
-  }
+  const data = await imfFetchJson(url, _proxyAuth);
+  return data?.values?.[indicator] ?? {};
 }
 
 function latestValue(byYear) {

--- a/scripts/seed-recovery-import-hhi.mjs
+++ b/scripts/seed-recovery-import-hhi.mjs
@@ -34,13 +34,23 @@ function parseRecords(data) {
   if (!Array.isArray(records)) return [];
   const valid = records.filter(r => r && Number(r.primaryValue ?? 0) > 0);
   if (valid.length === 0) return [];
-  const maxPeriod = Math.max(...valid.map(r => Number(r.period ?? r.refPeriodId ?? 0)));
-  return valid
-    .filter(r => Number(r.period ?? r.refPeriodId ?? 0) === maxPeriod)
-    .map(r => ({
-      partnerCode: String(r.partnerCode ?? r.partner2Code ?? '000'),
-      primaryValue: Number(r.primaryValue ?? 0),
-    }));
+  // Group by period, pick the year with the MOST partners (most complete dataset).
+  // If Y-1 is sparse (few rows) while Y-2 is complete, use Y-2.
+  const byPeriod = new Map();
+  for (const r of valid) {
+    const p = String(r.period ?? r.refPeriodId ?? '0');
+    if (!byPeriod.has(p)) byPeriod.set(p, []);
+    byPeriod.get(p).push(r);
+  }
+  let bestPeriod = '';
+  let bestCount = 0;
+  for (const [p, rows] of byPeriod) {
+    if (rows.length > bestCount) { bestCount = rows.length; bestPeriod = p; }
+  }
+  return byPeriod.get(bestPeriod).map(r => ({
+    partnerCode: String(r.partnerCode ?? r.partner2Code ?? '000'),
+    primaryValue: Number(r.primaryValue ?? 0),
+  }));
 }
 
 async function fetchImportsForReporter(reporterCode) {

--- a/scripts/seed-recovery-import-hhi.mjs
+++ b/scripts/seed-recovery-import-hhi.mjs
@@ -49,7 +49,8 @@ async function fetchImportsForReporter(reporterCode) {
   // Omit partnerCode to get ALL bilateral partners (matching the pattern
   // in seed-comtrade-bilateral-hs4.mjs). Setting partnerCode=0 returns
   // only the world-aggregate row which computeHhi() then discards.
-  url.searchParams.set('period', String(new Date().getFullYear() - 1));
+  // Comtrade annual data lags ~6-12 months; request both years so the API returns whichever has data.
+  url.searchParams.set('period', `${new Date().getFullYear() - 1},${new Date().getFullYear() - 2}`);
   url.searchParams.set('subscription-key', nextKey());
 
   const resp = await fetch(url.toString(), {

--- a/scripts/seed-recovery-import-hhi.mjs
+++ b/scripts/seed-recovery-import-hhi.mjs
@@ -34,8 +34,8 @@ function parseRecords(data) {
   if (!Array.isArray(records)) return [];
   const valid = records.filter(r => r && Number(r.primaryValue ?? 0) > 0);
   if (valid.length === 0) return [];
-  // Group by period, pick the year with the MOST partners (most complete dataset).
-  // If Y-1 is sparse (few rows) while Y-2 is complete, use Y-2.
+  // Group by period, pick the year with the most USABLE partners (excluding
+  // aggregate codes 0/000 that computeHhi discards). Ties break toward newest.
   const byPeriod = new Map();
   for (const r of valid) {
     const p = String(r.period ?? r.refPeriodId ?? '0');
@@ -45,7 +45,14 @@ function parseRecords(data) {
   let bestPeriod = '';
   let bestCount = 0;
   for (const [p, rows] of byPeriod) {
-    if (rows.length > bestCount) { bestCount = rows.length; bestPeriod = p; }
+    const usable = rows.filter(r => {
+      const pc = String(r.partnerCode ?? r.partner2Code ?? '000');
+      return pc !== '0' && pc !== '000';
+    }).length;
+    if (usable > bestCount || (usable === bestCount && p > bestPeriod)) {
+      bestCount = usable;
+      bestPeriod = p;
+    }
   }
   return byPeriod.get(bestPeriod).map(r => ({
     partnerCode: String(r.partnerCode ?? r.partner2Code ?? '000'),

--- a/scripts/seed-recovery-import-hhi.mjs
+++ b/scripts/seed-recovery-import-hhi.mjs
@@ -32,8 +32,11 @@ const ALL_REPORTERS = Object.values(UN_TO_ISO2).filter(c => c.length === 2);
 function parseRecords(data) {
   const records = data?.data ?? [];
   if (!Array.isArray(records)) return [];
-  return records
-    .filter(r => r && Number(r.primaryValue ?? 0) > 0)
+  const valid = records.filter(r => r && Number(r.primaryValue ?? 0) > 0);
+  if (valid.length === 0) return [];
+  const maxPeriod = Math.max(...valid.map(r => Number(r.period ?? r.refPeriodId ?? 0)));
+  return valid
+    .filter(r => Number(r.period ?? r.refPeriodId ?? 0) === maxPeriod)
     .map(r => ({
       partnerCode: String(r.partnerCode ?? r.partner2Code ?? '000'),
       primaryValue: Number(r.primaryValue ?? 0),


### PR DESCRIPTION
## Summary
- IMF DataMapper API (`imf.org/external/datamapper/api/v1`) returns HTTP 403 from Railway datacenter IPs
- `recoveryFiscalSpace` health shows STALE_SEED with 0 records (confirmed from Railway logs)
- `seed-imf-macro.mjs` has the same vulnerability (currently OK because it ran before the block, but will fail on next seed)
- Added proxy fallback via PROXY_URL (HTTP CONNECT tunnel through curlFetch), same pattern as FRED in seed-economy.mjs
- Direct fetch first, proxy retry on failure

## Files changed
- `scripts/seed-recovery-fiscal-space.mjs`: import proxy utils, wrap fetchImfIndicator with try/catch + curlFetch fallback
- `scripts/seed-imf-macro.mjs`: same fix

## Test plan
- [ ] After deploy, verify `recoveryFiscalSpace` health transitions from STALE_SEED to OK
- [ ] Verify `imfMacro` continues to seed successfully on next cron run
- [ ] Railway logs should show proxy fallback message on 403