### PR TITLE
fix(gold-intelligence): read correct Redis key and data shape

### DIFF
--- a/server/worldmonitor/market/v1/get-gold-intelligence.ts
+++ b/server/worldmonitor/market/v1/get-gold-intelligence.ts
@@ -7,7 +7,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
 import { getCachedJson } from '../../../_shared/redis';
 
-const COMMODITY_KEY = 'market:commodity-quotes:v1';
+const COMMODITY_KEY = 'market:commodities-bootstrap:v1';
 const COT_KEY = 'market:cot:v1';
 
 interface RawQuote {
@@ -44,12 +44,13 @@ export async function getGoldIntelligence(
   _req: GetGoldIntelligenceRequest,
 ): Promise<GetGoldIntelligenceResponse> {
   try {
-    const [rawQuotes, rawCot] = await Promise.all([
-      getCachedJson(COMMODITY_KEY, true) as Promise<RawQuote[] | null>,
+    const [rawPayload, rawCot] = await Promise.all([
+      getCachedJson(COMMODITY_KEY, true) as Promise<{ quotes?: RawQuote[] } | null>,
       getCachedJson(COT_KEY, true) as Promise<{ instruments?: RawCotInstrument[]; reportDate?: string } | null>,
     ]);
 
-    if (!rawQuotes || !Array.isArray(rawQuotes)) {
+    const rawQuotes = rawPayload?.quotes;
+    if (!rawQuotes || !Array.isArray(rawQuotes) || rawQuotes.length === 0) {
       return { goldPrice: 0, goldChangePct: 0, goldSparkline: [], silverPrice: 0, platinumPrice: 0, palladiumPrice: 0, crossCurrencyPrices: [], updatedAt: '', unavailable: true };
     }
 

--- a/server/worldmonitor/market/v1/get-gold-intelligence.ts
+++ b/server/worldmonitor/market/v1/get-gold-intelligence.ts
@@ -57,6 +57,9 @@ export async function getGoldIntelligence(
     const quoteMap = new Map(rawQuotes.map(q => [q.symbol, q]));
 
     const gold = quoteMap.get('GC=F');
+    if (!gold) {
+      return { goldPrice: 0, goldChangePct: 0, goldSparkline: [], silverPrice: 0, platinumPrice: 0, palladiumPrice: 0, crossCurrencyPrices: [], updatedAt: '', unavailable: true };
+    }
     const silver = quoteMap.get('SI=F');
     const platinum = quoteMap.get('PL=F');
     const palladium = quoteMap.get('PA=F');

--- a/tests/gold-intelligence.test.mjs
+++ b/tests/gold-intelligence.test.mjs
@@ -97,6 +97,26 @@ describe('Gold Intelligence', () => {
     assert.ok(Math.abs(premium - ((3200 - 950) / 950) * 100) < 0.01);
   });
 
+  it('returns unavailable when GC=F is missing from commodity snapshot', () => {
+    const quotes = [
+      { symbol: 'SI=F', price: 35 },
+      { symbol: 'PL=F', price: 950 },
+      { symbol: 'PA=F', price: 1020 },
+      { symbol: 'EURUSD=X', price: 1.08 },
+    ];
+    const quoteMap = new Map(quotes.map(q => [q.symbol, q]));
+    const gold = quoteMap.get('GC=F');
+    assert.strictEqual(gold, undefined);
+
+    const goldPrice = gold?.price ?? 0;
+    assert.strictEqual(goldPrice, 0);
+
+    const ratio = computeGoldSilverRatio(goldPrice, 35);
+    assert.strictEqual(ratio, null);
+    const cross = computeCrossCurrency(goldPrice, quotes);
+    assert.strictEqual(cross.length, 0);
+  });
+
   it('partial availability: price works when cot is null, and vice versa', () => {
     const goldPrice = 3200;
     const silverPrice = 35;


### PR DESCRIPTION
## Summary
Gold Intelligence panel shows "Gold data unavailable" permanently because the RPC handler reads the wrong Redis key with the wrong shape.

**Bug 1**: Handler reads `market:commodity-quotes:v1` which doesn't exist. The actual seeded key is `market:commodities-bootstrap:v1` (written by `seed-commodity-quotes.mjs`).

**Bug 2**: Handler expects a raw `RawQuote[]` array, but the seeder writes `{ quotes: [...] }`. The array check fails and returns `unavailable: true`.

## Fix
- Changed `COMMODITY_KEY` to `market:commodities-bootstrap:v1`
- Changed type cast to `{ quotes?: RawQuote[] }` and extract `.quotes`

## Test plan
- [ ] Panel shows gold price, sparkline, ratio, cross-currency, and CFTC positioning
- [ ] Typecheck clean