### PR TITLE
fix(health): add DATA_KEYS entry for energyCrisisPolicies

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -157,6 +157,7 @@ const STANDALONE_KEYS = {
   emberElectricity:         'energy:ember:v1:_all',
   resilienceIntervals:      'resilience:intervals:v1:US',
   sprPolicies:              'energy:spr-policies:v1',
+  energyCrisisPolicies:     'energy:crisis-policies:v1',
   regionalSnapshots:        'intelligence:regional-snapshots:summary:v1',
   regionalBriefs:           'intelligence:regional-briefs:summary:v1',
   recoveryFiscalSpace:      'resilience:recovery:fiscal-space:v1',


### PR DESCRIPTION
## Summary
health.js had a SEED_META entry for energyCrisisPolicies but was missing the DATA_KEYS entry. Without it, /api/health never reports on the energy:crisis-policies:v1 key, so empty data goes undetected.

Also: the energy-crisis seeder (in seed-bundle-energy-sources) has not run yet since PR #3009 merged. The cron fires daily at 07:00 UTC. First run will populate Redis. Until then the panel shows "No energy crisis policies tracked."

## Test plan
- [ ] After merge, /api/health response includes energyCrisisPolicies with EMPTY status (until first seed run)
- [ ] After first cron run (07:00 UTC), status transitions to OK with 142 records