### PR TITLE
fix(seeds): migrate IMF seeders to SDMX 3.0 API

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -401,6 +401,52 @@ export async function imfFetchJson(url, proxyAuth) {
 }
 
 // ---------------------------------------------------------------------------
+// IMF SDMX 3.0 API (api.imf.org) — replaces blocked DataMapper API
+// ---------------------------------------------------------------------------
+const IMF_SDMX_BASE = 'https://api.imf.org/external/sdmx/3.0';
+
+export async function imfSdmxFetchIndicator(indicator, { database = 'WEO', years } = {}) {
+  const agencyMap = { WEO: 'IMF.RES', FM: 'IMF.FAD' };
+  const agency = agencyMap[database] || 'IMF.RES';
+  const url = `${IMF_SDMX_BASE}/data/dataflow/${agency}/${database}/+/*.${indicator}.A?dimensionAtObservation=TIME_PERIOD&attributes=dsd&measures=all`;
+  const r = await fetch(url, {
+    headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!r.ok) throw new Error(`IMF SDMX ${indicator}: HTTP ${r.status}`);
+  const json = await r.json();
+
+  const struct = json?.data?.structures?.[0];
+  const ds = json?.data?.dataSets?.[0];
+  if (!struct || !ds?.series) return {};
+
+  const countryDim = struct.dimensions.series.find(d => d.id === 'COUNTRY');
+  const timeDim = struct.dimensions.observation.find(d => d.id === 'TIME_PERIOD');
+  if (!countryDim || !timeDim) return {};
+
+  const countryValues = countryDim.values.map(v => v.id);
+  const timeValues = timeDim.values.map(v => v.value || v.id);
+  const yearSet = years ? new Set(years.map(String)) : null;
+
+  const result = {};
+  for (const [seriesKey, seriesData] of Object.entries(ds.series)) {
+    const countryIdx = parseInt(seriesKey.split(':')[0], 10);
+    const iso3 = countryValues[countryIdx];
+    if (!iso3) continue;
+
+    const byYear = {};
+    for (const [obsKey, obsVal] of Object.entries(seriesData.observations || {})) {
+      const year = timeValues[parseInt(obsKey, 10)];
+      if (!year || (yearSet && !yearSet.has(year))) continue;
+      const v = obsVal?.[0];
+      if (v != null) byYear[year] = parseFloat(v);
+    }
+    if (Object.keys(byYear).length > 0) result[iso3] = byYear;
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
 // Learned Routes — persist successful scrape URLs across seed runs
 // ---------------------------------------------------------------------------
 

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -409,20 +409,24 @@ export async function imfSdmxFetchIndicator(indicator, { database = 'WEO', years
   const agencyMap = { WEO: 'IMF.RES', FM: 'IMF.FAD' };
   const agency = agencyMap[database] || 'IMF.RES';
   const url = `${IMF_SDMX_BASE}/data/dataflow/${agency}/${database}/+/*.${indicator}.A?dimensionAtObservation=TIME_PERIOD&attributes=dsd&measures=all`;
-  const r = await fetch(url, {
-    headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
-    signal: AbortSignal.timeout(60_000),
-  });
-  if (!r.ok) throw new Error(`IMF SDMX ${indicator}: HTTP ${r.status}`);
-  const json = await r.json();
+
+  const json = await withRetry(async () => {
+    const r = await fetch(url, {
+      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+      signal: AbortSignal.timeout(60_000),
+    });
+    if (!r.ok) throw new Error(`IMF SDMX ${indicator}: HTTP ${r.status}`);
+    return r.json();
+  }, 2, 2000);
 
   const struct = json?.data?.structures?.[0];
   const ds = json?.data?.dataSets?.[0];
   if (!struct || !ds?.series) return {};
 
   const countryDim = struct.dimensions.series.find(d => d.id === 'COUNTRY');
+  const countryDimPos = struct.dimensions.series.findIndex(d => d.id === 'COUNTRY');
   const timeDim = struct.dimensions.observation.find(d => d.id === 'TIME_PERIOD');
-  if (!countryDim || !timeDim) return {};
+  if (!countryDim || countryDimPos === -1 || !timeDim) return {};
 
   const countryValues = countryDim.values.map(v => v.id);
   const timeValues = timeDim.values.map(v => v.value || v.id);
@@ -430,7 +434,8 @@ export async function imfSdmxFetchIndicator(indicator, { database = 'WEO', years
 
   const result = {};
   for (const [seriesKey, seriesData] of Object.entries(ds.series)) {
-    const countryIdx = parseInt(seriesKey.split(':')[0], 10);
+    const keyParts = seriesKey.split(':');
+    const countryIdx = parseInt(keyParts[countryDimPos], 10);
     const iso3 = countryValues[countryIdx];
     if (!iso3) continue;
 

--- a/scripts/seed-imf-macro.mjs
+++ b/scripts/seed-imf-macro.mjs
@@ -1,20 +1,15 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, runSeed, loadSharedConfig, resolveProxyForConnect, imfFetchJson } from './_seed-utils.mjs';
+import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
-const IMF_BASE = 'https://www.imf.org/external/datamapper/api/v1';
-const _proxyAuth = resolveProxyForConnect();
 const CANONICAL_KEY = 'economic:imf:macro:v2';
 const CACHE_TTL = 35 * 24 * 3600; // 35 days — monthly IMF WEO release
 
-// Invert iso2→iso3 map to convert IMF's ISO3 codes to our ISO2 keys.
-// loadSharedConfig tries ../shared/ (local dev) then ./shared/ (Railway rootDirectory=scripts).
 const ISO2_TO_ISO3 = loadSharedConfig('iso2-to-iso3.json');
 const ISO3_TO_ISO2 = Object.fromEntries(Object.entries(ISO2_TO_ISO3).map(([k, v]) => [v, k]));
 
-// IMF WEO regional aggregate and non-sovereign codes
 const AGGREGATE_CODES = new Set([
   'ADVEC', 'EMEDE', 'EURO', 'MECA', 'OEMDC', 'WEOWORLD', 'EU',
   'AS5', 'DA', 'EDE', 'MAE', 'OAE', 'SSA', 'WE', 'EMDE', 'G20',
@@ -25,20 +20,11 @@ function isAggregate(code) {
   return AGGREGATE_CODES.has(code) || code.endsWith('Q');
 }
 
-// Request the three most-recent years at call time so the monthly cron always picks up the
-// latest WEO vintage without requiring a code edit (e.g. 2025,2024,2023 once 2025 publishes).
 function weoYears() {
   const y = new Date().getFullYear();
   return [`${y}`, `${y - 1}`, `${y - 2}`];
 }
 
-async function fetchImfIndicator(indicator) {
-  const url = `${IMF_BASE}/${indicator}?periods=${weoYears().join(',')}`;
-  const data = await imfFetchJson(url, _proxyAuth);
-  return data?.values?.[indicator] ?? {};
-}
-
-// Pick the most recent year with a finite value, searching newest-first.
 function latestValue(byYear) {
   for (const year of weoYears()) {
     const v = Number(byYear?.[year]);
@@ -48,10 +34,11 @@ function latestValue(byYear) {
 }
 
 async function fetchImfMacro() {
+  const years = weoYears();
   const [inflationData, currentAccountData, govRevenueData] = await Promise.all([
-    fetchImfIndicator('PCPIPCH'),        // CPI inflation, annual % change
-    fetchImfIndicator('BCA_NGDPD'),      // Current account balance, % of GDP
-    fetchImfIndicator('GGR_G01_GDP_PT'), // General government revenue, % of GDP (Fiscal Monitor)
+    imfSdmxFetchIndicator('PCPIPCH', { years }),
+    imfSdmxFetchIndicator('BCA_NGDPD', { years }),
+    imfSdmxFetchIndicator('GGR_NGDP', { years }),
   ]);
 
   const countries = {};
@@ -91,7 +78,7 @@ if (process.argv[1]?.endsWith('seed-imf-macro.mjs')) {
   runSeed('economic', 'imf-macro', CANONICAL_KEY, fetchImfMacro, {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
-    sourceVersion: `imf-weo-${new Date().getFullYear()}`,
+    sourceVersion: `imf-sdmx-weo-${new Date().getFullYear()}`,
     recordCount: (data) => Object.keys(data?.countries ?? {}).length,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';

--- a/scripts/seed-national-debt.mjs
+++ b/scripts/seed-national-debt.mjs
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, imfSdmxFetchIndicator } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
-const IMF_BASE = 'https://www.imf.org/external/datamapper/api/v1';
 const TREASURY_URL = 'https://api.fiscaldata.treasury.gov/services/api/v1/accounting/od/debt_to_penny?fields=record_date,tot_pub_debt_out_amt&sort=-record_date&page[size]=1';
 
 const CANONICAL_KEY = 'economic:national-debt:v1';
@@ -22,17 +21,6 @@ const TERRITORY_CODES = new Set(['ABW', 'PRI', 'WBG']);
 function isAggregate(code) {
   if (!code || code.length !== 3) return true;
   return AGGREGATE_CODES.has(code) || TERRITORY_CODES.has(code) || code.endsWith('Q');
-}
-
-async function fetchImfIndicator(indicator, periods, timeoutMs) {
-  const url = `${IMF_BASE}/${indicator}?periods=${periods}`;
-  const resp = await fetch(url, {
-    headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
-    signal: AbortSignal.timeout(timeoutMs),
-  });
-  if (!resp.ok) throw new Error(`IMF ${indicator}: HTTP ${resp.status}`);
-  const data = await resp.json();
-  return data?.values?.[indicator] ?? {};
 }
 
 async function fetchTreasury() {
@@ -117,9 +105,9 @@ export function computeEntries(debtPctByCountry, gdpByCountry, deficitPctByCount
 
 async function fetchNationalDebt() {
   const [debtPctData, gdpData, deficitData, treasury] = await Promise.all([
-    fetchImfIndicator('GGXWDG_NGDP', '2023,2024', 30_000),
-    fetchImfIndicator('NGDPD', '2024', 30_000),
-    fetchImfIndicator('GGXCNL_NGDP', '2024', 30_000),
+    imfSdmxFetchIndicator('GGXWDG_NGDP', { years: ['2023', '2024'] }),
+    imfSdmxFetchIndicator('NGDPD', { years: ['2024'] }),
+    imfSdmxFetchIndicator('GGXCNL_NGDP', { years: ['2024'] }),
     fetchTreasury().catch(() => null),
   ]);
 
@@ -140,7 +128,7 @@ if (process.argv[1]?.endsWith('seed-national-debt.mjs')) {
   runSeed('economic', 'national-debt', CANONICAL_KEY, fetchNationalDebt, {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
-    sourceVersion: 'imf-weo-2024',
+    sourceVersion: 'imf-sdmx-weo-2024',
     recordCount: (data) => data?.entries?.length ?? 0,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';

--- a/scripts/seed-recovery-fiscal-space.mjs
+++ b/scripts/seed-recovery-fiscal-space.mjs
@@ -1,11 +1,9 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, runSeed, loadSharedConfig, sleep, resolveProxyForConnect, imfFetchJson } from './_seed-utils.mjs';
+import { loadEnvFile, runSeed, loadSharedConfig, sleep, imfSdmxFetchIndicator } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
-const IMF_BASE = 'https://www.imf.org/external/datamapper/api/v1';
-const _proxyAuth = resolveProxyForConnect();
 const CANONICAL_KEY = 'resilience:recovery:fiscal-space:v1';
 const CACHE_TTL = 35 * 24 * 3600;
 
@@ -27,12 +25,6 @@ function weoYears() {
   return [`${y}`, `${y - 1}`, `${y - 2}`];
 }
 
-async function fetchImfIndicator(indicator) {
-  const url = `${IMF_BASE}/${indicator}?periods=${weoYears().join(',')}`;
-  const data = await imfFetchJson(url, _proxyAuth);
-  return data?.values?.[indicator] ?? {};
-}
-
 function latestValue(byYear) {
   for (const year of weoYears()) {
     const v = Number(byYear?.[year]);
@@ -42,13 +34,13 @@ function latestValue(byYear) {
 }
 
 async function fetchFiscalSpace() {
-  // Sequential with delays to avoid IMF rate limiter. seed-imf-macro.mjs
-  // may run in the same cron window, so concurrent Promise.all risks 403.
-  const revenueData = await fetchImfIndicator('GGR_G01_GDP_PT');
-  await sleep(1000);
-  const balanceData = await fetchImfIndicator('GGXCNL_G01_GDP_PT');
-  await sleep(1000);
-  const debtData = await fetchImfIndicator('GGXWDG_NGDP_PT');
+  const years = weoYears();
+  // WEO equivalents: GGR_G01_GDP_PT→GGR_NGDP, GGXCNL_G01_GDP_PT→GGXCNL_NGDP, GGXWDG_NGDP_PT→GGXWDG_NGDP
+  const revenueData = await imfSdmxFetchIndicator('GGR_NGDP', { years });
+  await sleep(1500);
+  const balanceData = await imfSdmxFetchIndicator('GGXCNL_NGDP', { years });
+  await sleep(1500);
+  const debtData = await imfSdmxFetchIndicator('GGXWDG_NGDP', { years });
 
   const countries = {};
   const allIso3 = new Set([
@@ -86,7 +78,7 @@ if (process.argv[1]?.endsWith('seed-recovery-fiscal-space.mjs')) {
   runSeed('resilience', 'recovery:fiscal-space', CANONICAL_KEY, fetchFiscalSpace, {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
-    sourceVersion: `imf-weo-fiscal-${new Date().getFullYear()}`,
+    sourceVersion: `imf-sdmx-weo-fiscal-${new Date().getFullYear()}`,
     recordCount: (data) => Object.keys(data?.countries ?? {}).length,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';

--- a/scripts/seed-recovery-fiscal-space.mjs
+++ b/scripts/seed-recovery-fiscal-space.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, runSeed, loadSharedConfig, sleep, imfSdmxFetchIndicator } from './_seed-utils.mjs';
+import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -35,12 +35,11 @@ function latestValue(byYear) {
 
 async function fetchFiscalSpace() {
   const years = weoYears();
-  // WEO equivalents: GGR_G01_GDP_PT→GGR_NGDP, GGXCNL_G01_GDP_PT→GGXCNL_NGDP, GGXWDG_NGDP_PT→GGXWDG_NGDP
-  const revenueData = await imfSdmxFetchIndicator('GGR_NGDP', { years });
-  await sleep(1500);
-  const balanceData = await imfSdmxFetchIndicator('GGXCNL_NGDP', { years });
-  await sleep(1500);
-  const debtData = await imfSdmxFetchIndicator('GGXWDG_NGDP', { years });
+  const [revenueData, balanceData, debtData] = await Promise.all([
+    imfSdmxFetchIndicator('GGR_NGDP', { years }),
+    imfSdmxFetchIndicator('GGXCNL_NGDP', { years }),
+    imfSdmxFetchIndicator('GGXWDG_NGDP', { years }),
+  ]);
 
   const countries = {};
   const allIso3 = new Set([


### PR DESCRIPTION
## Summary
- IMF DataMapper API (`www.imf.org/external/datamapper/api/v1`) is now blocked by Akamai WAF via JA3 TLS fingerprinting (HTTP 403 for all non-browser clients, including residential proxies)
- The old SDMX endpoint (`dataservices.imf.org`) was decommissioned by IMF in 2025
- Migrates all 3 IMF-consuming seeders to the new **SDMX 3.0 API** at `api.imf.org/external/sdmx/3.0/` which works without proxy
- Adds shared `imfSdmxFetchIndicator()` to `_seed-utils.mjs` that returns data in the same ISO3-keyed shape

### Indicator mapping (DataMapper to WEO SDMX)
| Old (DataMapper/FM) | New (WEO SDMX) | Coverage |
|---|---|---|
| `GGR_G01_GDP_PT` | `GGR_NGDP` | 207 countries |
| `GGXCNL_G01_GDP_PT` | `GGXCNL_NGDP` | 207 countries |
| `GGXWDG_NGDP_PT` | `GGXWDG_NGDP` | 204 countries |
| `PCPIPCH` | `PCPIPCH` | 210 countries |
| `BCA_NGDPD` | `BCA_NGDPD` | 208 countries |
| `NGDPD` | `NGDPD` | verified |

## Test plan
- [x] `imfSdmxFetchIndicator` smoke test: 208 countries, correct values for USA/GBR/DEU
- [x] All fiscal-space indicators verified: revenue, balance, debt
- [x] `node --test tests/seed-bundle-resilience-recovery.test.mjs` passes (13/13)
- [x] `node --test tests/national-debt-seed.test.mjs` passes (10/10)
- [x] All 3 scripts import cleanly
- [x] Pre-push hooks pass (typecheck, boundaries, seed tests)
- [ ] Deploy to Railway and verify seed runs complete successfully