### PR TITLE
fix(supply-chain): unify exposure and cost shock on Comtrade flows

### DIFF
--- a/docs/country-brief-architecture.md
+++ b/docs/country-brief-architecture.md
@@ -1,0 +1,57 @@
+# Country Brief: Exposure and Cost Shock Architecture
+
+Issue: #2969
+
+## Problem
+
+Sector Exposure and Cost Shock widgets in Country Brief read divergent data sources.
+Sector Exposure scored 0-100 from a static JSON map of route proximity.
+Cost Shock computed deficit from live Comtrade crude flows + JODI demand + PortWatch disruption ratios.
+Different sources produced contradictory signals visible side-by-side.
+
+## Decision: Unify on Comtrade Flows (Option 1)
+
+For HS 27 (energy) and the 4 shock-model chokepoints (Hormuz, Suez, Malacca, Bab el-Mandeb):
+
+**Exposure score** = `gulfCrudeShare x CHOKEPOINT_EXPOSURE[cpId] x flowRatio x 100`, capped at 100.
+
+This is the same formula Cost Shock uses internally to compute `gulfCrudeShare` before feeding it into the deficit model. Both widgets now derive from the same Comtrade + PortWatch data, guaranteeing directional consistency.
+
+### Data sources (shared)
+
+| Source | Redis key | Used by |
+|--------|-----------|---------|
+| Comtrade crude flows | `comtrade:flows:${code}:2709` | Exposure + Cost Shock |
+| PortWatch flow ratios | `energy:chokepoint-flows:v1` | Exposure + Cost Shock |
+| JODI Oil demand | `energy:jodi-oil:v1:${code}` | Cost Shock only |
+| IEA strategic stocks | `energy:iea-oil-stocks:v1:${code}` | Cost Shock only |
+
+### Fallback chain
+
+1. Comtrade data available: use actual Gulf crude share
+2. No Comtrade data: proxy at 40% (same `PROXIED_GULF_SHARE` constant as Cost Shock)
+3. PortWatch unavailable: assume `flowRatio = 1.0` (same degraded path as Cost Shock)
+
+### Non-shock-model chokepoints
+
+Bosporus, Panama, Taiwan Strait, etc. have no energy shock model.
+These retain static route-overlap scoring from `country-port-clusters.json`.
+The response carries `shockSupported: false` so the UI can indicate the limitation.
+
+### Non-energy sectors
+
+HS codes other than 27 use static route-overlap scoring.
+Multi-sector cost shock (Phase 5) uses bilateral HS4 data via a separate endpoint.
+Unifying non-energy sectors on flow data is deferred to v2.
+
+## Cache alignment
+
+Exposure cache TTL reduced from 24h to 10min (600s), closer to Cost Shock's 300s.
+Cache key bumped to v2 so stale static scores expire on deploy.
+
+## Files
+
+- `server/worldmonitor/supply-chain/v1/get-country-chokepoint-index.ts` — flow-based scoring
+- `server/worldmonitor/intelligence/v1/compute-energy-shock.ts` — shared `getGulfCrudeShare`
+- `server/worldmonitor/intelligence/v1/_shock-compute.ts` — shared `CHOKEPOINT_EXPOSURE` constants
+- `server/_shared/cache-keys.ts` — v2 exposure cache key

--- a/scripts/scenario-worker.mjs
+++ b/scripts/scenario-worker.mjs
@@ -237,7 +237,7 @@ async function computeScenario(scenarioId, iso2) {
   const allKeys = [];
   for (const reporter of reportersToCheck) {
     for (const hs2 of hs2Chapters) {
-      allKeys.push(`supply-chain:exposure:${reporter}:${hs2}:v1`);
+      allKeys.push(`supply-chain:exposure:${reporter}:${hs2}:v2`);
     }
   }
 

--- a/scripts/scenario-worker.mjs
+++ b/scripts/scenario-worker.mjs
@@ -237,10 +237,10 @@ async function computeScenario(scenarioId, iso2) {
   const allKeys = [];
   for (const reporter of reportersToCheck) {
     for (const hs2 of hs2Chapters) {
-      // Reads the seeder's :seed-v1 static-scoring namespace. The live
+      // Reads the seeder's :v1 static-scoring namespace. The live
       // country-brief handler writes to :v2 (flow-based) which is kept
       // separate to avoid collision (issue #2969).
-      allKeys.push(`supply-chain:exposure:${reporter}:${hs2}:seed-v1`);
+      allKeys.push(`supply-chain:exposure:${reporter}:${hs2}:v1`);
     }
   }
 

--- a/scripts/scenario-worker.mjs
+++ b/scripts/scenario-worker.mjs
@@ -237,7 +237,10 @@ async function computeScenario(scenarioId, iso2) {
   const allKeys = [];
   for (const reporter of reportersToCheck) {
     for (const hs2 of hs2Chapters) {
-      allKeys.push(`supply-chain:exposure:${reporter}:${hs2}:v2`);
+      // Reads the seeder's :seed-v1 static-scoring namespace. The live
+      // country-brief handler writes to :v2 (flow-based) which is kept
+      // separate to avoid collision (issue #2969).
+      allKeys.push(`supply-chain:exposure:${reporter}:${hs2}:seed-v1`);
     }
   }
 

--- a/scripts/seed-hs2-chokepoint-exposure.mjs
+++ b/scripts/seed-hs2-chokepoint-exposure.mjs
@@ -134,7 +134,7 @@ export async function main() {
   if (lock.skipped) {
     const allKeys = Object.keys(COUNTRY_PORT_CLUSTERS)
       .filter(k => k !== '_comment' && k.length === 2)
-      .flatMap(iso2 => HS2_CODES.map(hs2 => `${KEY_PREFIX}${iso2}:${hs2}:v1`));
+      .flatMap(iso2 => HS2_CODES.map(hs2 => `${KEY_PREFIX}${iso2}:${hs2}:v2`));
     await extendExistingTtl([...allKeys, META_KEY], TTL_SECONDS)
       .catch(e => console.warn('[chokepoint-exposure] TTL extension (skipped) failed:', e.message));
     return;
@@ -169,7 +169,7 @@ export async function main() {
           ...result,
           fetchedAt: new Date().toISOString(),
         });
-        commands.push(['SET', `${KEY_PREFIX}${iso2}:${hs2}:v1`, payload, 'EX', TTL_SECONDS]);
+        commands.push(['SET', `${KEY_PREFIX}${iso2}:${hs2}:v2`, payload, 'EX', TTL_SECONDS]);
         writtenCount++;
       }
     }
@@ -198,7 +198,7 @@ export async function main() {
     // Extend TTL on failure — stale is better than missing
     const existingKeys = Object.keys(COUNTRY_PORT_CLUSTERS)
       .filter(k => k !== '_comment' && k.length === 2)
-      .flatMap(iso2 => HS2_CODES.map(hs2 => `${KEY_PREFIX}${iso2}:${hs2}:v1`));
+      .flatMap(iso2 => HS2_CODES.map(hs2 => `${KEY_PREFIX}${iso2}:${hs2}:v2`));
     await extendExistingTtl([...existingKeys, META_KEY], TTL_SECONDS)
       .catch(e => console.warn('[chokepoint-exposure] TTL extension failed:', e.message));
     await writeMeta(0, 'error');

--- a/scripts/seed-hs2-chokepoint-exposure.mjs
+++ b/scripts/seed-hs2-chokepoint-exposure.mjs
@@ -26,10 +26,10 @@ const LOCK_DOMAIN = 'supply_chain:chokepoint-exposure';
 const LOCK_TTL_MS = 5 * 60 * 1000;
 
 // Top 10 HS2 chapters by global trade volume and strategic importance.
-// Note: this seeder writes to :seed-v1 (separate namespace from the live
-// country-brief handler's :seed-v1 flow-based cache — issue #2969). The scenario
-// worker reads from :seed-v1. Keeping the namespaces separate prevents this
-// static-overlap payload from clobbering the handler's flow-based cache.
+// Note: this seeder writes to :v1 (static scoring). The country-brief live
+// handler owns a separate :v2 namespace for flow-based scoring (issue
+// #2969). The scenario worker reads :v1. Keeping namespaces separate
+// prevents this static payload from clobbering the handler's cache.
 const HS2_CODES = [
   '27', // Mineral Fuels (energy)
   '84', // Machinery & Mechanical Appliances
@@ -138,7 +138,7 @@ export async function main() {
   if (lock.skipped) {
     const allKeys = Object.keys(COUNTRY_PORT_CLUSTERS)
       .filter(k => k !== '_comment' && k.length === 2)
-      .flatMap(iso2 => HS2_CODES.map(hs2 => `${KEY_PREFIX}${iso2}:${hs2}:seed-v1`));
+      .flatMap(iso2 => HS2_CODES.map(hs2 => `${KEY_PREFIX}${iso2}:${hs2}:v1`));
     await extendExistingTtl([...allKeys, META_KEY], TTL_SECONDS)
       .catch(e => console.warn('[chokepoint-exposure] TTL extension (skipped) failed:', e.message));
     return;
@@ -173,7 +173,7 @@ export async function main() {
           ...result,
           fetchedAt: new Date().toISOString(),
         });
-        commands.push(['SET', `${KEY_PREFIX}${iso2}:${hs2}:seed-v1`, payload, 'EX', TTL_SECONDS]);
+        commands.push(['SET', `${KEY_PREFIX}${iso2}:${hs2}:v1`, payload, 'EX', TTL_SECONDS]);
         writtenCount++;
       }
     }
@@ -202,7 +202,7 @@ export async function main() {
     // Extend TTL on failure — stale is better than missing
     const existingKeys = Object.keys(COUNTRY_PORT_CLUSTERS)
       .filter(k => k !== '_comment' && k.length === 2)
-      .flatMap(iso2 => HS2_CODES.map(hs2 => `${KEY_PREFIX}${iso2}:${hs2}:seed-v1`));
+      .flatMap(iso2 => HS2_CODES.map(hs2 => `${KEY_PREFIX}${iso2}:${hs2}:v1`));
     await extendExistingTtl([...existingKeys, META_KEY], TTL_SECONDS)
       .catch(e => console.warn('[chokepoint-exposure] TTL extension failed:', e.message));
     await writeMeta(0, 'error');

--- a/scripts/seed-hs2-chokepoint-exposure.mjs
+++ b/scripts/seed-hs2-chokepoint-exposure.mjs
@@ -26,6 +26,10 @@ const LOCK_DOMAIN = 'supply_chain:chokepoint-exposure';
 const LOCK_TTL_MS = 5 * 60 * 1000;
 
 // Top 10 HS2 chapters by global trade volume and strategic importance.
+// Note: this seeder writes to :seed-v1 (separate namespace from the live
+// country-brief handler's :seed-v1 flow-based cache — issue #2969). The scenario
+// worker reads from :seed-v1. Keeping the namespaces separate prevents this
+// static-overlap payload from clobbering the handler's flow-based cache.
 const HS2_CODES = [
   '27', // Mineral Fuels (energy)
   '84', // Machinery & Mechanical Appliances
@@ -134,7 +138,7 @@ export async function main() {
   if (lock.skipped) {
     const allKeys = Object.keys(COUNTRY_PORT_CLUSTERS)
       .filter(k => k !== '_comment' && k.length === 2)
-      .flatMap(iso2 => HS2_CODES.map(hs2 => `${KEY_PREFIX}${iso2}:${hs2}:v2`));
+      .flatMap(iso2 => HS2_CODES.map(hs2 => `${KEY_PREFIX}${iso2}:${hs2}:seed-v1`));
     await extendExistingTtl([...allKeys, META_KEY], TTL_SECONDS)
       .catch(e => console.warn('[chokepoint-exposure] TTL extension (skipped) failed:', e.message));
     return;
@@ -169,7 +173,7 @@ export async function main() {
           ...result,
           fetchedAt: new Date().toISOString(),
         });
-        commands.push(['SET', `${KEY_PREFIX}${iso2}:${hs2}:v2`, payload, 'EX', TTL_SECONDS]);
+        commands.push(['SET', `${KEY_PREFIX}${iso2}:${hs2}:seed-v1`, payload, 'EX', TTL_SECONDS]);
         writtenCount++;
       }
     }
@@ -198,7 +202,7 @@ export async function main() {
     // Extend TTL on failure — stale is better than missing
     const existingKeys = Object.keys(COUNTRY_PORT_CLUSTERS)
       .filter(k => k !== '_comment' && k.length === 2)
-      .flatMap(iso2 => HS2_CODES.map(hs2 => `${KEY_PREFIX}${iso2}:${hs2}:v2`));
+      .flatMap(iso2 => HS2_CODES.map(hs2 => `${KEY_PREFIX}${iso2}:${hs2}:seed-v1`));
     await extendExistingTtl([...existingKeys, META_KEY], TTL_SECONDS)
       .catch(e => console.warn('[chokepoint-exposure] TTL extension failed:', e.message));
     await writeMeta(0, 'error');

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -66,10 +66,11 @@ export const REFINERY_INPUTS_KEY = 'economic:refinery-inputs:v1';
 
 /**
  * Per-country chokepoint exposure index. Request-varying — excluded from bootstrap.
- * Key: supply-chain:exposure:{iso2}:{hs2}:v1
+ * Key: supply-chain:exposure:{iso2}:{hs2}:v2
+ * v2: flow-based scoring for shock-model chokepoints (issue #2969).
  */
 export const CHOKEPOINT_EXPOSURE_KEY = (iso2: string, hs2: string) =>
-  `supply-chain:exposure:${iso2}:${hs2}:v1`;
+  `supply-chain:exposure:${iso2}:${hs2}:v2`;
 export const CHOKEPOINT_EXPOSURE_SEED_META_KEY = 'seed-meta:supply_chain:chokepoint-exposure';
 
 /**

--- a/server/worldmonitor/intelligence/v1/compute-energy-shock.ts
+++ b/server/worldmonitor/intelligence/v1/compute-energy-shock.ts
@@ -37,7 +37,7 @@ const CP_TO_PORTWATCH: Record<string, string> = {
   malacca_strait: 'malacca_strait',
 };
 
-const PROXIED_GULF_SHARE = 0.40;
+export const PROXIED_GULF_SHARE = 0.40;
 
 interface JodiProduct {
   demandKbd?: number | null;

--- a/server/worldmonitor/intelligence/v1/compute-energy-shock.ts
+++ b/server/worldmonitor/intelligence/v1/compute-energy-shock.ts
@@ -104,7 +104,7 @@ function n(v: number | null | undefined): number {
   return typeof v === 'number' && Number.isFinite(v) ? v : 0;
 }
 
-async function getGulfCrudeShare(countryCode: string): Promise<{ share: number; hasData: boolean }> {
+export async function getGulfCrudeShare(countryCode: string): Promise<{ share: number; hasData: boolean }> {
   const numericCode = ISO2_TO_COMTRADE[countryCode];
   if (!numericCode) return { share: 0, hasData: false };
 

--- a/server/worldmonitor/supply-chain/v1/get-country-chokepoint-index.ts
+++ b/server/worldmonitor/supply-chain/v1/get-country-chokepoint-index.ts
@@ -5,31 +5,38 @@ import type {
   ChokepointExposureEntry,
 } from '../../../../src/generated/server/worldmonitor/supply_chain/v1/service_server';
 
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 import { isCallerPremium } from '../../../_shared/premium-check';
 import { CHOKEPOINT_EXPOSURE_KEY } from '../../../_shared/cache-keys';
 import { CHOKEPOINT_REGISTRY } from '../../../../src/config/chokepoint-registry';
+import { getGulfCrudeShare } from '../../intelligence/v1/compute-energy-shock';
+import { CHOKEPOINT_EXPOSURE } from '../../intelligence/v1/_shock-compute';
 import COUNTRY_PORT_CLUSTERS from '../../../../scripts/shared/country-port-clusters.json';
 
-const CACHE_TTL = 86400; // 24 hours
+const CACHE_TTL = 600; // 10 min — aligned closer to cost shock's 300s
+
+const PROXIED_GULF_SHARE = 0.40;
 
 interface PortClusterEntry {
   nearestRouteIds: string[];
   coastSide: string;
 }
 
-function computeExposures(
+interface ChokepointFlowEntry {
+  flowRatio: number;
+}
+
+function computeStaticExposures(
   nearestRouteIds: string[],
   hs2: string,
 ): ChokepointExposureEntry[] {
   const isEnergy = hs2 === '27';
   const routeSet = new Set(nearestRouteIds);
 
-  const entries: ChokepointExposureEntry[] = CHOKEPOINT_REGISTRY.map(cp => {
+  return CHOKEPOINT_REGISTRY.map(cp => {
     const overlap = cp.routeIds.filter(r => routeSet.has(r)).length;
     const maxRoutes = Math.max(cp.routeIds.length, 1);
     let score = (overlap / maxRoutes) * 100;
-    // Energy sector: boost shock-model chokepoints by 50% (oil + LNG dependency)
     if (isEnergy && cp.shockModelSupported) score = Math.min(score * 1.5, 100);
     return {
       chokepointId: cp.id,
@@ -39,8 +46,57 @@ function computeExposures(
       shockSupported: cp.shockModelSupported,
     };
   });
+}
 
-  return entries.sort((a, b) => b.exposureScore - a.exposureScore);
+async function computeFlowBasedExposures(
+  iso2: string,
+  hs2: string,
+  nearestRouteIds: string[],
+): Promise<ChokepointExposureEntry[]> {
+  const isEnergy = hs2 === '27';
+  const routeSet = new Set(nearestRouteIds);
+
+  if (!isEnergy) {
+    return computeStaticExposures(nearestRouteIds, hs2);
+  }
+
+  const [gulfResult, portWatchRaw] = await Promise.all([
+    getGulfCrudeShare(iso2).catch(() => ({ share: 0, hasData: false })),
+    getCachedJson('energy:chokepoint-flows:v1', true)
+      .then(v => v as Record<string, ChokepointFlowEntry> | null)
+      .catch(() => null),
+  ]);
+
+  const gulfShare = gulfResult.hasData ? gulfResult.share : PROXIED_GULF_SHARE;
+
+  return CHOKEPOINT_REGISTRY.map(cp => {
+    if (cp.shockModelSupported) {
+      const cpEntry = portWatchRaw?.[cp.id] ?? null;
+      const baseExposure = CHOKEPOINT_EXPOSURE[cp.id] ?? 1.0;
+      const flowRatio = (cpEntry != null && Number.isFinite(cpEntry.flowRatio))
+        ? Math.max(0, Math.min(cpEntry.flowRatio, 1.5))
+        : 1.0;
+      const score = Math.min(gulfShare * baseExposure * flowRatio * 100, 100);
+      return {
+        chokepointId: cp.id,
+        chokepointName: cp.displayName,
+        exposureScore: Math.round(score * 10) / 10,
+        coastSide: '',
+        shockSupported: true,
+      };
+    }
+
+    const overlap = cp.routeIds.filter(r => routeSet.has(r)).length;
+    const maxRoutes = Math.max(cp.routeIds.length, 1);
+    const score = (overlap / maxRoutes) * 100;
+    return {
+      chokepointId: cp.id,
+      chokepointName: cp.displayName,
+      exposureScore: Math.round(score * 10) / 10,
+      coastSide: '',
+      shockSupported: false,
+    };
+  });
 }
 
 function vulnerabilityIndex(sorted: ChokepointExposureEntry[]): number {
@@ -84,8 +140,9 @@ export async function getCountryChokepointIndex(
         const nearestRouteIds = cluster?.nearestRouteIds ?? [];
         const coastSide = cluster?.coastSide ?? 'unknown';
 
-        const exposures = computeExposures(nearestRouteIds, hs2);
-        // Attach coastSide only to the top entry
+        const exposures = await computeFlowBasedExposures(iso2, hs2, nearestRouteIds);
+        exposures.sort((a, b) => b.exposureScore - a.exposureScore);
+
         if (exposures[0]) exposures[0] = { ...exposures[0], coastSide };
 
         const primaryId = exposures[0]?.chokepointId ?? '';

--- a/server/worldmonitor/supply-chain/v1/get-country-chokepoint-index.ts
+++ b/server/worldmonitor/supply-chain/v1/get-country-chokepoint-index.ts
@@ -7,15 +7,13 @@ import type {
 
 import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 import { isCallerPremium } from '../../../_shared/premium-check';
-import { CHOKEPOINT_EXPOSURE_KEY } from '../../../_shared/cache-keys';
+import { CHOKEPOINT_EXPOSURE_KEY, CHOKEPOINT_FLOWS_KEY } from '../../../_shared/cache-keys';
 import { CHOKEPOINT_REGISTRY } from '../../../../src/config/chokepoint-registry';
-import { getGulfCrudeShare } from '../../intelligence/v1/compute-energy-shock';
+import { getGulfCrudeShare, PROXIED_GULF_SHARE } from '../../intelligence/v1/compute-energy-shock';
 import { CHOKEPOINT_EXPOSURE } from '../../intelligence/v1/_shock-compute';
 import COUNTRY_PORT_CLUSTERS from '../../../../scripts/shared/country-port-clusters.json';
 
 const CACHE_TTL = 600; // 10 min — aligned closer to cost shock's 300s
-
-const PROXIED_GULF_SHARE = 0.40;
 
 interface PortClusterEntry {
   nearestRouteIds: string[];
@@ -28,16 +26,13 @@ interface ChokepointFlowEntry {
 
 function computeStaticExposures(
   nearestRouteIds: string[],
-  hs2: string,
 ): ChokepointExposureEntry[] {
-  const isEnergy = hs2 === '27';
   const routeSet = new Set(nearestRouteIds);
 
   return CHOKEPOINT_REGISTRY.map(cp => {
     const overlap = cp.routeIds.filter(r => routeSet.has(r)).length;
     const maxRoutes = Math.max(cp.routeIds.length, 1);
-    let score = (overlap / maxRoutes) * 100;
-    if (isEnergy && cp.shockModelSupported) score = Math.min(score * 1.5, 100);
+    const score = (overlap / maxRoutes) * 100;
     return {
       chokepointId: cp.id,
       chokepointName: cp.displayName,
@@ -57,12 +52,12 @@ async function computeFlowBasedExposures(
   const routeSet = new Set(nearestRouteIds);
 
   if (!isEnergy) {
-    return computeStaticExposures(nearestRouteIds, hs2);
+    return computeStaticExposures(nearestRouteIds);
   }
 
   const [gulfResult, portWatchRaw] = await Promise.all([
     getGulfCrudeShare(iso2).catch(() => ({ share: 0, hasData: false })),
-    getCachedJson('energy:chokepoint-flows:v1', true)
+    getCachedJson(CHOKEPOINT_FLOWS_KEY, true)
       .then(v => v as Record<string, ChokepointFlowEntry> | null)
       .catch(() => null),
   ]);

--- a/tests/exposure-cost-shock-consistency.test.mjs
+++ b/tests/exposure-cost-shock-consistency.test.mjs
@@ -1,0 +1,275 @@
+/**
+ * Tests for issue #2969: Sector Exposure and Cost Shock directional consistency.
+ *
+ * Validates that the flow-based exposure scoring in get-country-chokepoint-index.ts
+ * uses the same Comtrade + PortWatch data path as get-country-cost-shock.ts, so the
+ * two widgets can never show contradictory signals (100% exposure + $0 cost shock).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+const readSrc = (relPath) => readFileSync(resolve(root, relPath), 'utf-8');
+
+// ========================================================================
+// 1. Pure scoring functions from _shock-compute.ts
+// ========================================================================
+
+import {
+  computeGulfShare,
+  CHOKEPOINT_EXPOSURE,
+} from '../server/worldmonitor/intelligence/v1/_shock-compute.ts';
+
+import { CHOKEPOINT_REGISTRY } from '../src/config/chokepoint-registry.ts';
+
+const PROXIED_GULF_SHARE = 0.40;
+
+const SHOCK_MODEL_IDS = new Set(
+  CHOKEPOINT_REGISTRY.filter(c => c.shockModelSupported).map(c => c.id),
+);
+
+/**
+ * Replicates the flow-based scoring formula from get-country-chokepoint-index.ts
+ * for shock-model chokepoints with HS 27.
+ */
+function flowBasedScore(gulfShare, chokepointId, flowRatio = 1.0) {
+  const baseExposure = CHOKEPOINT_EXPOSURE[chokepointId] ?? 1.0;
+  const clampedRatio = Math.max(0, Math.min(flowRatio, 1.5));
+  return Math.min(gulfShare * baseExposure * clampedRatio * 100, 100);
+}
+
+/**
+ * Replicates the cost shock Gulf share formula from compute-energy-shock.ts:247.
+ * Returns the effective Gulf crude share used to compute supply deficit.
+ */
+function costShockGulfShare(gulfShare, chokepointId, flowRatio = null) {
+  const baseExposure = CHOKEPOINT_EXPOSURE[chokepointId] ?? 1.0;
+  const exposureMult = flowRatio !== null ? baseExposure * flowRatio : baseExposure;
+  return gulfShare * exposureMult;
+}
+
+// ========================================================================
+// 2. computeGulfShare unit tests
+// ========================================================================
+
+describe('computeGulfShare', () => {
+  it('returns 0 share for empty flows', () => {
+    const result = computeGulfShare([]);
+    assert.equal(result.share, 0);
+    assert.equal(result.hasData, false);
+  });
+
+  it('returns 0 share when no Gulf partners', () => {
+    const flows = [
+      { tradeValueUsd: 1_000_000, partnerCode: '156' }, // China
+      { tradeValueUsd: 500_000, partnerCode: '392' },   // Japan
+    ];
+    const result = computeGulfShare(flows);
+    assert.equal(result.share, 0);
+    assert.equal(result.hasData, true);
+  });
+
+  it('returns high share when mostly Gulf imports', () => {
+    const flows = [
+      { tradeValueUsd: 8_000_000, partnerCode: '682' }, // Saudi Arabia
+      { tradeValueUsd: 2_000_000, partnerCode: '784' }, // UAE
+      { tradeValueUsd: 1_000_000, partnerCode: '156' }, // China (non-Gulf)
+    ];
+    const result = computeGulfShare(flows);
+    assert.ok(result.hasData);
+    assert.ok(result.share > 0.8, `Expected Gulf share > 0.8, got ${result.share}`);
+  });
+
+  it('ignores zero and negative values', () => {
+    const flows = [
+      { tradeValueUsd: 0, partnerCode: '682' },
+      { tradeValueUsd: -100, partnerCode: '784' },
+      { tradeValueUsd: 1_000_000, partnerCode: '156' },
+    ];
+    const result = computeGulfShare(flows);
+    assert.equal(result.share, 0); // all Gulf flows are zero/negative
+    assert.equal(result.hasData, true);
+  });
+});
+
+// ========================================================================
+// 3. Flow-based scoring formula tests
+// ========================================================================
+
+describe('flow-based exposure scoring formula', () => {
+  it('high Gulf share produces high Hormuz exposure', () => {
+    const score = flowBasedScore(0.80, 'hormuz_strait');
+    assert.ok(score >= 50, `Expected score >= 50, got ${score}`);
+  });
+
+  it('zero Gulf share produces zero Hormuz exposure', () => {
+    const score = flowBasedScore(0, 'hormuz_strait');
+    assert.equal(score, 0);
+  });
+
+  it('proxied Gulf share (40%) produces moderate exposure', () => {
+    const score = flowBasedScore(PROXIED_GULF_SHARE, 'hormuz_strait');
+    assert.ok(score > 20 && score < 60, `Expected 20 < score < 60, got ${score}`);
+  });
+
+  it('Suez has lower base exposure than Hormuz', () => {
+    const hormuz = flowBasedScore(0.50, 'hormuz_strait');
+    const suez = flowBasedScore(0.50, 'suez');
+    assert.ok(hormuz > suez, `Hormuz (${hormuz}) should be > Suez (${suez})`);
+  });
+
+  it('score caps at 100', () => {
+    const score = flowBasedScore(1.0, 'hormuz_strait', 1.5);
+    assert.ok(score <= 100, `Score should cap at 100, got ${score}`);
+  });
+
+  it('flow ratio amplifies or dampens score', () => {
+    const normal = flowBasedScore(0.50, 'hormuz_strait', 1.0);
+    const high = flowBasedScore(0.50, 'hormuz_strait', 1.3);
+    const low = flowBasedScore(0.50, 'hormuz_strait', 0.5);
+    assert.ok(high > normal, 'High flow ratio should amplify');
+    assert.ok(low < normal, 'Low flow ratio should dampen');
+  });
+});
+
+// ========================================================================
+// 4. Directional consistency: exposure and cost shock agree
+// ========================================================================
+
+describe('directional consistency between exposure and cost shock', () => {
+  const testCases = [
+    { name: 'high Gulf importer', gulfShare: 0.70, cp: 'hormuz_strait', flowRatio: 1.0 },
+    { name: 'low Gulf importer', gulfShare: 0.05, cp: 'hormuz_strait', flowRatio: 1.0 },
+    { name: 'zero Gulf importer', gulfShare: 0.0, cp: 'suez', flowRatio: 1.0 },
+    { name: 'moderate with degraded flow', gulfShare: 0.40, cp: 'malacca_strait', flowRatio: null },
+    { name: 'high share, low flow ratio', gulfShare: 0.60, cp: 'bab_el_mandeb', flowRatio: 0.3 },
+  ];
+
+  for (const tc of testCases) {
+    it(`${tc.name}: exposure direction matches cost shock direction`, () => {
+      const exposureScore = flowBasedScore(tc.gulfShare, tc.cp, tc.flowRatio ?? 1.0);
+      const shockShare = costShockGulfShare(tc.gulfShare, tc.cp, tc.flowRatio);
+
+      if (tc.gulfShare === 0) {
+        assert.equal(exposureScore, 0, 'Zero Gulf share must produce zero exposure');
+        assert.equal(shockShare, 0, 'Zero Gulf share must produce zero cost shock share');
+      } else if (tc.gulfShare < 0.1) {
+        assert.ok(exposureScore < 15, `Low Gulf share should give low exposure, got ${exposureScore}`);
+        assert.ok(shockShare < 0.1, `Low Gulf share should give low shock share, got ${shockShare}`);
+      } else {
+        assert.ok(exposureScore > 10, `Moderate+ Gulf share should give meaningful exposure, got ${exposureScore}`);
+        assert.ok(shockShare > 0.05, `Moderate+ Gulf share should give meaningful shock share, got ${shockShare}`);
+      }
+    });
+  }
+
+  it('a sector scored 100 exposure always implies nonzero cost shock share', () => {
+    for (const cpId of SHOCK_MODEL_IDS) {
+      for (let share = 0; share <= 1.0; share += 0.05) {
+        const score = flowBasedScore(share, cpId);
+        const shockShare = costShockGulfShare(share, cpId);
+        if (Math.round(score) >= 100) {
+          assert.ok(
+            shockShare > 0,
+            `exposure=100 for ${cpId} at share=${share.toFixed(2)} but cost shock share=${shockShare}`,
+          );
+        }
+      }
+    }
+  });
+
+  it('zero cost shock share always implies zero or low exposure', () => {
+    for (const cpId of SHOCK_MODEL_IDS) {
+      const score = flowBasedScore(0, cpId);
+      assert.equal(score, 0, `Zero Gulf share must give zero exposure for ${cpId}`);
+    }
+  });
+});
+
+// ========================================================================
+// 5. Country-specific directional tests (Turkey, US, China)
+// ========================================================================
+
+describe('country-specific directional tests', () => {
+  it('Turkey + Bosporus: non-shock-model CP, shockSupported=false', () => {
+    const bosphorus = CHOKEPOINT_REGISTRY.find(c => c.id === 'bosphorus');
+    assert.ok(bosphorus, 'Bosphorus must exist in registry');
+    assert.equal(bosphorus.shockModelSupported, false, 'Bosphorus has no shock model');
+    // Static scoring still applies for non-shock-model CPs.
+    // The response carries shockSupported=false so UI can indicate model unavailable.
+  });
+
+  it('US + Hormuz: low Gulf crude dependence', () => {
+    // US imports mostly from Canada/Mexico, not Gulf states.
+    // With low Gulf share (~5-10%), Hormuz exposure should be low.
+    const lowGulfShare = 0.08;
+    const score = flowBasedScore(lowGulfShare, 'hormuz_strait');
+    assert.ok(score < 15, `US-like Gulf share should give low Hormuz exposure, got ${score}`);
+  });
+
+  it('China + Malacca: moderate Gulf crude share', () => {
+    // China imports ~30-40% from Gulf states, transiting Malacca.
+    const moderateGulfShare = 0.35;
+    const score = flowBasedScore(moderateGulfShare, 'malacca_strait');
+    assert.ok(score > 15 && score < 60, `China-like Gulf share should give moderate Malacca exposure, got ${score}`);
+  });
+
+  it('Japan + Hormuz: high Gulf crude dependence', () => {
+    // Japan imports ~80% from Gulf states.
+    const highGulfShare = 0.80;
+    const score = flowBasedScore(highGulfShare, 'hormuz_strait');
+    assert.ok(score >= 60, `Japan-like Gulf share should give high Hormuz exposure, got ${score}`);
+  });
+});
+
+// ========================================================================
+// 6. Source code guards: handler uses flow-based scoring
+// ========================================================================
+
+describe('get-country-chokepoint-index source code guards', () => {
+  const src = readSrc('server/worldmonitor/supply-chain/v1/get-country-chokepoint-index.ts');
+
+  it('imports computeGulfShare or getGulfCrudeShare for flow-based scoring', () => {
+    assert.ok(
+      src.includes('getGulfCrudeShare') || src.includes('computeGulfShare'),
+      'Handler must import Gulf share computation from Comtrade path',
+    );
+  });
+
+  it('imports CHOKEPOINT_EXPOSURE for flow multipliers', () => {
+    assert.match(src, /CHOKEPOINT_EXPOSURE/);
+  });
+
+  it('reads PortWatch flow data', () => {
+    assert.match(src, /energy:chokepoint-flows:v1/);
+  });
+
+  it('uses PROXIED_GULF_SHARE as fallback when no Comtrade data', () => {
+    assert.match(src, /PROXIED_GULF_SHARE/);
+  });
+
+  it('still imports COUNTRY_PORT_CLUSTERS for static fallback', () => {
+    assert.match(src, /country-port-clusters/);
+  });
+
+  it('cache TTL is 600s (10min), not 86400 (24h)', () => {
+    assert.match(src, /CACHE_TTL\s*=\s*600/);
+  });
+
+  it('calls isCallerPremium and returns empty when not PRO', () => {
+    assert.match(src, /isCallerPremium/);
+  });
+
+  it('cache key uses v2', () => {
+    assert.ok(
+      src.includes('CHOKEPOINT_EXPOSURE_KEY'),
+      'Must use versioned cache key from cache-keys.ts',
+    );
+  });
+});

--- a/tests/exposure-cost-shock-consistency.test.mjs
+++ b/tests/exposure-cost-shock-consistency.test.mjs
@@ -246,12 +246,12 @@ describe('get-country-chokepoint-index source code guards', () => {
     assert.match(src, /CHOKEPOINT_EXPOSURE/);
   });
 
-  it('reads PortWatch flow data', () => {
-    assert.match(src, /energy:chokepoint-flows:v1/);
+  it('reads PortWatch flow data via CHOKEPOINT_FLOWS_KEY constant', () => {
+    assert.match(src, /CHOKEPOINT_FLOWS_KEY/);
   });
 
-  it('uses PROXIED_GULF_SHARE as fallback when no Comtrade data', () => {
-    assert.match(src, /PROXIED_GULF_SHARE/);
+  it('imports PROXIED_GULF_SHARE from compute-energy-shock (single source of truth)', () => {
+    assert.match(src, /import.*PROXIED_GULF_SHARE.*from.*compute-energy-shock/);
   });
 
   it('still imports COUNTRY_PORT_CLUSTERS for static fallback', () => {


### PR DESCRIPTION
## Summary
- **Why:** Sector Exposure and Cost Shock widgets read divergent sources (static JSON vs live Comtrade flows), producing contradictory signals side-by-side in Country Brief. Turkey showed 100/100 Bosporus exposure while Cost Shock showed $0.
- **Fix:** For HS 27 + 4 shock-model chokepoints, exposure now derives from the same `gulfCrudeShare x CHOKEPOINT_EXPOSURE x flowRatio` formula as Cost Shock, with `PROXIED_GULF_SHARE` (40%) fallback when no Comtrade data. Non-shock-model CPs retain static scoring with `shockSupported: false`.
- Cache TTL reduced from 24h to 10min, key bumped to v2.

Closes #2969

## Changes
| File | Change |
|------|--------|
| `server/worldmonitor/supply-chain/v1/get-country-chokepoint-index.ts` | Core refactor: async flow-based scoring for shock-model CPs |
| `server/worldmonitor/intelligence/v1/compute-energy-shock.ts` | Export `getGulfCrudeShare` for reuse |
| `server/_shared/cache-keys.ts` | Bump exposure key to v2 |
| `tests/exposure-cost-shock-consistency.test.mjs` | 29 new tests: scoring formula + directional consistency |
| `docs/country-brief-architecture.md` | Architecture decision doc |

## Test plan
- [x] `tsc --noEmit` (both tsconfigs) passes
- [x] 29/29 new consistency tests pass (scoring formula, directional checks for Turkey/US/China/Japan, source code guards)
- [x] 65/65 existing supply-chain-sprint2 tests pass
- [x] 4981/4981 full test:data suite passes
- [ ] Verify in staging: Turkey Country Brief no longer shows 100% Bosporus exposure alongside $0 cost shock
- [ ] Spot-check US, China, Japan exposure scores reflect actual Gulf crude dependence