### PR TITLE
fix(country-brief): unify Cost Shock and Sector Exposure sources

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -408,6 +408,7 @@ export class CountryIntelManager implements AppModule {
         if (this.ctx.countryBriefPage?.getCode() !== code) return;
         if (sectors.length === 0) {
           this.ctx.countryBriefPage.updateTradeExposure?.(null);
+          if (hasPremiumAccess(getAuthState())) this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
           return;
         }
         // Build a synthetic compat response from sector data (no extra fetch needed)
@@ -436,14 +437,14 @@ export class CountryIntelManager implements AppModule {
           }).catch(() => {
             if (this.ctx.countryBriefPage?.getCode() === code) this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
           });
-        } else {
+        } else if (hasPremiumAccess(getAuthState())) {
           this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
         }
       })
       .catch(() => {
         if (this.ctx.countryBriefPage?.getCode() !== code) return;
         this.ctx.countryBriefPage.updateTradeExposure?.(null);
-        this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
+        if (hasPremiumAccess(getAuthState())) this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
       });
 
     if (hasPremiumAccess(getAuthState())) {

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -29,7 +29,6 @@ import { openStoryModal } from '@/components/StoryModal';
 import { MarketServiceClient } from '@/generated/client/worldmonitor/market/v1/service_client';
 import { IntelligenceServiceClient } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 import { TradeServiceClient } from '@/generated/client/worldmonitor/trade/v1/service_client';
-import { SupplyChainServiceClient } from '@/generated/client/worldmonitor/supply_chain/v1/service_client';
 import { EconomicServiceClient } from '@/generated/client/worldmonitor/economic/v1/service_client';
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { getAuthState } from '@/services/auth-state';
@@ -428,10 +427,23 @@ export class CountryIntelManager implements AppModule {
           fetchedAt: new Date().toISOString(),
         };
         this.ctx.countryBriefPage.updateTradeExposure?.(syntheticResponse, sectors);
+
+        // Trigger multi-sector cost shock calculator from the same primary chokepoint.
+        if (hasPremiumAccess(getAuthState()) && top.primaryChokepointId) {
+          fetchMultiSectorCostShock(code, top.primaryChokepointId, 30).then(multi => {
+            if (this.ctx.countryBriefPage?.getCode() !== code) return;
+            this.ctx.countryBriefPage.updateMultiSectorCostShock?.(multi);
+          }).catch(() => {
+            if (this.ctx.countryBriefPage?.getCode() === code) this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
+          });
+        } else {
+          this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
+        }
       })
       .catch(() => {
         if (this.ctx.countryBriefPage?.getCode() !== code) return;
         this.ctx.countryBriefPage.updateTradeExposure?.(null);
+        this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
       });
 
     if (hasPremiumAccess(getAuthState())) {
@@ -559,8 +571,6 @@ export class CountryIntelManager implements AppModule {
     const economicClient = new EconomicServiceClient(rpcBase, { fetch: fetchFn });
     const intelClientPro = new IntelligenceServiceClient(rpcBase, { fetch: fetchFn });
     const tradeClient = new TradeServiceClient(rpcBase, { fetch: fetchFn });
-    const supplyChainClient = new SupplyChainServiceClient(rpcBase, { fetch: fetchFn });
-
     const iso3 = iso2ToIso3(code);
 
     economicClient.getNationalDebt({}).then(resp => {
@@ -615,45 +625,6 @@ export class CountryIntelManager implements AppModule {
       this.ctx.countryBriefPage?.updateComtradeFlows?.(null);
       this.ctx.countryBriefPage?.updateTariffTrends?.(null);
     }
-
-    supplyChainClient.getCountryChokepointIndex({ iso2: code, hs2: '27' }).then(resp => {
-      if (this.ctx.countryBriefPage?.getCode() !== code) return;
-      const exps = resp.exposures || [];
-      this.ctx.countryBriefPage.updateChokepointExposure?.(exps.length > 0 ? {
-        vulnerabilityIndex: resp.vulnerabilityIndex,
-        exposures: exps.slice(0, 3).map(e => ({ chokepointName: e.chokepointName, exposureScore: e.exposureScore })),
-      } : null);
-
-      if (resp.primaryChokepointId) {
-        supplyChainClient.getCountryCostShock({ iso2: code, chokepointId: resp.primaryChokepointId, hs2: '27' }).then(shock => {
-          if (this.ctx.countryBriefPage?.getCode() !== code) return;
-          this.ctx.countryBriefPage.updateCostShock?.((shock.supplyDeficitPct > 0 || shock.coverageDays > 0) ? {
-            supplyDeficitPct: shock.supplyDeficitPct,
-            coverageDays: shock.coverageDays,
-            warRiskTier: shock.warRiskTier,
-          } : null);
-        }).catch(() => {
-          if (this.ctx.countryBriefPage?.getCode() === code) this.ctx.countryBriefPage.updateCostShock?.(null);
-        });
-
-        // Multi-sector cost shock calculator (Phase 5) — default 30-day closure.
-        fetchMultiSectorCostShock(code, resp.primaryChokepointId, 30).then(multi => {
-          if (this.ctx.countryBriefPage?.getCode() !== code) return;
-          this.ctx.countryBriefPage.updateMultiSectorCostShock?.(multi);
-        }).catch(() => {
-          if (this.ctx.countryBriefPage?.getCode() === code) this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
-        });
-      } else {
-        this.ctx.countryBriefPage.updateCostShock?.(null);
-        this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
-      }
-    }).catch(() => {
-      if (this.ctx.countryBriefPage?.getCode() === code) {
-        this.ctx.countryBriefPage.updateChokepointExposure?.(null);
-        this.ctx.countryBriefPage.updateCostShock?.(null);
-        this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
-      }
-    });
 
     fetchCountryProducts(code).then(resp => {
       if (this.ctx.countryBriefPage?.getCode() !== code) return;

--- a/src/components/CountryBriefPanel.ts
+++ b/src/components/CountryBriefPanel.ts
@@ -192,8 +192,6 @@ export interface CountryBriefPanel {
   updateSanctionsPressure?(data: { entryCount: number; sanctionsActive?: boolean } | null): void;
   updateComtradeFlows?(flows: Array<{ partnerName: string; cmdDesc: string; tradeValueUsd: number; yoyChange: number }> | null): void;
   updateTariffTrends?(data: { currentRate: number; trend: string; datapoints: Array<{ year: number; tariffRate: number }> } | null): void;
-  updateChokepointExposure?(data: { vulnerabilityIndex: number; exposures: Array<{ chokepointName: string; exposureScore: number }> } | null): void;
-  updateCostShock?(data: { supplyDeficitPct: number; coverageDays: number; warRiskTier: string } | null): void;
   updateMultiSectorCostShock?(data: MultiSectorShockResponse | null): void;
   updateProductImports?(data: CountryProductsResponse | null): void;
 }

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -116,8 +116,6 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   private sanctionsBody: HTMLElement | null = null;
   private comtradeBody: HTMLElement | null = null;
   private tariffBody: HTMLElement | null = null;
-  private chokepointBody: HTMLElement | null = null;
-  private costShockBody: HTMLElement | null = null;
   // ── Phase 5: Multi-sector Cost Shock Calculator ─────────────────────────
   private costShockCalcBody: HTMLElement | null = null;
   private costShockCalcTable: HTMLElement | null = null;
@@ -611,32 +609,6 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.tariffBody.append(grid);
   }
 
-  public updateChokepointExposure(data: { vulnerabilityIndex: number; exposures: Array<{ chokepointName: string; exposureScore: number }> } | null): void {
-    if (!this.chokepointBody) return;
-    this.chokepointBody.replaceChildren();
-    if (!data) {
-      this.chokepointBody.append(this.makeEmpty('No chokepoint exposure data'));
-      return;
-    }
-    const vulnClass = data.vulnerabilityIndex >= 75 ? 'cdp-pro-badge-critical'
-      : data.vulnerabilityIndex >= 50 ? 'cdp-pro-badge-high'
-      : data.vulnerabilityIndex >= 25 ? 'cdp-pro-badge-elevated'
-      : 'cdp-pro-badge-normal';
-    const badge = this.el('span', `cdp-pro-badge ${vulnClass}`, `Vulnerability: ${data.vulnerabilityIndex.toFixed(0)}`);
-    this.chokepointBody.append(badge);
-    for (const exp of data.exposures.slice(0, 3)) {
-      const row = this.el('div', 'cdp-pro-exposure-item');
-      row.append(this.el('span', 'cdp-pro-exposure-name', exp.chokepointName));
-      const scoreEl = this.el('span', 'cdp-pro-exposure-score');
-      scoreEl.textContent = exp.exposureScore.toFixed(1);
-      scoreEl.style.background = exp.exposureScore >= 60
-        ? 'color-mix(in srgb, var(--semantic-critical) 20%, transparent)'
-        : 'color-mix(in srgb, var(--semantic-normal) 20%, transparent)';
-      row.append(scoreEl);
-      this.chokepointBody.append(row);
-    }
-  }
-
   /**
    * Mount the Cost Shock Calculator with its initial data and slider.
    * Called once per country load with the first (default 30-day) response.
@@ -774,30 +746,6 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     } catch {
       // Ignore — either aborted or transient network; leave prior values visible.
     }
-  }
-
-  public updateCostShock(data: { supplyDeficitPct: number; coverageDays: number; warRiskTier: string } | null): void {
-    if (!this.costShockBody) return;
-    this.costShockBody.replaceChildren();
-    if (!data) {
-      this.costShockBody.append(this.makeEmpty('No cost shock data'));
-      return;
-    }
-    const grid = this.el('div', 'cdp-pro-metric-grid');
-    grid.append(
-      this.proMetricBox('Supply Deficit', `${data.supplyDeficitPct.toFixed(1)}%`),
-      this.proMetricBox('Coverage Days', String(Math.round(data.coverageDays))),
-    );
-    this.costShockBody.append(grid);
-    const tierLabel = data.warRiskTier.replace('WAR_RISK_TIER_', '').replace(/_/g, ' ');
-    const tierClass = tierLabel === 'CRITICAL' || tierLabel === 'WAR ZONE' ? 'cdp-pro-badge-critical'
-      : tierLabel === 'HIGH' ? 'cdp-pro-badge-high'
-      : tierLabel === 'ELEVATED' ? 'cdp-pro-badge-elevated'
-      : 'cdp-pro-badge-normal';
-    const tierBadge = this.el('span', `cdp-pro-badge ${tierClass}`, `War Risk: ${tierLabel}`);
-    tierBadge.style.marginTop = '8px';
-    tierBadge.style.display = 'inline-block';
-    this.costShockBody.append(tierBadge);
   }
 
   private makeProLocked(text: string): HTMLElement {
@@ -1582,6 +1530,8 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.selectedSectorHs2 = hs2;
     this.renderTradeExposureContent();
 
+    this.costShockCalcBody?.closest('.cdp-section-card')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
     const sector = this.cachedSectors.find(s => s.hs2 === hs2);
     if (!sector) return;
 
@@ -2187,13 +2137,6 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.tariffBody = tariffBody;
     tariffBody.append(isPro ? this.makeLoading('Loading tariff data\u2026') : this.makeProLocked('Upgrade to PRO for tariff trend data'));
 
-    const [chokepointCard, chokepointBody] = this.sectionCard('Chokepoint Exposure', 'Vulnerability index and top chokepoint exposures for energy imports (HS 27).');
-    this.chokepointBody = chokepointBody;
-    chokepointBody.append(isPro ? this.makeLoading('Loading chokepoint data\u2026') : this.makeProLocked('Upgrade to PRO for chokepoint exposure'));
-
-    const [costShockCard, costShockBody] = this.sectionCard('Cost Shock', 'Supply deficit, coverage days, and war risk tier for the primary chokepoint.');
-    this.costShockBody = costShockBody;
-    costShockBody.append(isPro ? this.makeLoading('Loading cost shock data\u2026') : this.makeProLocked('Upgrade to PRO for cost shock analysis'));
 
     this.signalsBody = signalBody;
     this.timelineBody = timelineBody;
@@ -2213,7 +2156,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     marketsBody.append(this.makeLoading(t('countryBrief.loadingMarkets')));
     briefBody.append(this.makeLoading(t('countryBrief.generatingBrief')));
 
-    bodyGrid.append(briefCard, factsExpanded, energyCard, maritimeCard, tradeCard, costShockCalcCard, productImportsCard, debtCard, sanctionsCard, comtradeCard, tariffCard, chokepointCard, costShockCard, signalsCard, timelineCard, newsCard, militaryCard, infraCard, economicCard, marketsCard);
+    bodyGrid.append(briefCard, factsExpanded, energyCard, maritimeCard, tradeCard, costShockCalcCard, productImportsCard, debtCard, sanctionsCard, comtradeCard, tariffCard, signalsCard, timelineCard, newsCard, militaryCard, infraCard, economicCard, marketsCard);
     shell.append(header, summaryGrid, bodyGrid);
     this.content.append(shell);
   }
@@ -2240,8 +2183,6 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.sanctionsBody = null;
     this.comtradeBody = null;
     this.tariffBody = null;
-    this.chokepointBody = null;
-    this.costShockBody = null;
     this.costShockCalcAbort?.abort();
     this.costShockCalcAbort = null;
     if (this.costShockCalcDebounceTimer) {

--- a/tests/multi-sector-cost-shock.test.mjs
+++ b/tests/multi-sector-cost-shock.test.mjs
@@ -374,7 +374,7 @@ describe('country-intel.ts: multi-sector cost shock fetch', () => {
   });
 
   it('calls fetchMultiSectorCostShock with default 30-day window', () => {
-    assert.match(src, /fetchMultiSectorCostShock\(code, resp\.primaryChokepointId, 30\)/);
+    assert.match(src, /fetchMultiSectorCostShock\(code, top\.primaryChokepointId, 30\)/);
   });
 
   it('clears the card on catch paths', () => {


### PR DESCRIPTION
## Summary
- Remove redundant "Chokepoint Exposure" (HS27-only) and "Cost Shock" (energy-only) cards, superseded by flow-weighted Trade Exposure (#3017) and multi-sector Cost Shock Calculator
- Move Cost Shock Calculator trigger into Trade Exposure handler so both derive from the same `comtrade:bilateral-hs4` data source
- Clicking a sector row in Trade Exposure now scrolls the Cost Shock Calculator into view

Closes #2969

## Context
After #3017 shipped flow-weighted per-sector exposure, the backend already unified on Comtrade bilateral HS4 data. The old cards showed contradictory numbers: a sector at 100% exposure with $0 cost shock. Removing them eliminates the contradiction with zero backend changes.

## Test plan
- [x] `tsc --noEmit` passes (both tsconfig.json and tsconfig.api.json)
- [x] `npm run test:data` passes (4962 tests, 0 failures)
- [ ] Manual: Turkey Country Brief shows no "Chokepoint Exposure" or "Cost Shock" cards
- [ ] Manual: Trade Exposure shows differentiated sector scores
- [ ] Manual: Cost Shock Calculator loads with data from the same primary chokepoint
- [ ] Manual: Clicking a sector row scrolls to Cost Shock Calculator