### PR TITLE
fix(resilience): trigger Nixpacks rebuild for validation bundle

### DIFF
--- a/scripts/seed-bundle-resilience-validation.mjs
+++ b/scripts/seed-bundle-resilience-validation.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// Railway: rootDirectory="" + NIXPACKS builder + NODE_OPTIONS --import tsx/esm
 import { runBundle, WEEK } from './_bundle-runner.mjs';
 
 await runBundle('resilience-validation', [


### PR DESCRIPTION
## Summary
- Adds a comment to `seed-bundle-resilience-validation.mjs` documenting the Railway service config
- Triggers a git-based deploy which respects `builder=NIXPACKS` (railway up auto-detects root Dockerfile)

**Railway service config changes (applied via GraphQL API):**
- `rootDirectory`: `""` (repo root, so `../server/` imports from sensitivity suite resolve)
- `startCommand`: `node scripts/seed-bundle-resilience-validation.mjs`
- `NODE_OPTIONS`: `--max-old-space-size=8192 --dns-result-order=ipv4first --import tsx/esm`
- `watchPatterns`: added `server/worldmonitor/resilience/v1/**` and `scripts/_seed-utils.mjs`

**Root cause:** The validation bundle's sensitivity script dynamically imports from `../server/worldmonitor/resilience/v1/*.ts`. With `rootDirectory=scripts`, those paths don't exist in the container. Changing to repo root requires Nixpacks builder (not the root Dockerfile which builds the full nginx/vite app).

## Test plan
- [x] Pre-push checks pass (typecheck, boundaries, resilience tests)
- [ ] After merge: Railway git deploy uses Nixpacks (check build logs for "Nixpacks" not "Dockerfile")
- [ ] After merge: All 3 validation scripts complete without MODULE_NOT_FOUND