### PR TITLE
feat(seed): flow-weighted pre-computation for chokepoint exposure

### DIFF
--- a/scripts/seed-hs2-chokepoint-exposure.mjs
+++ b/scripts/seed-hs2-chokepoint-exposure.mjs
@@ -24,6 +24,7 @@ export const KEY_PREFIX = 'supply-chain:exposure:';
 export const TTL_SECONDS = 172800; // 48h — 2× daily cron interval
 const LOCK_DOMAIN = 'supply_chain:chokepoint-exposure';
 const LOCK_TTL_MS = 5 * 60 * 1000;
+const COMTRADE_KEY_PREFIX = 'comtrade:bilateral-hs4:';
 
 // Top 10 HS2 chapters by global trade volume and strategic importance.
 const HS2_CODES = [
@@ -67,12 +68,85 @@ const COUNTRY_PORT_CLUSTERS = require('./shared/country-port-clusters.json');
 // ── Exposure computation ──────────────────────────────────────────────────────
 
 /**
+ * @typedef {{ hs4: string, description: string, totalValue: number, topExporters: Array<{partnerCode: number, partnerIso2: string, value: number, share: number}>, year: number }} ComtradeProduct
+ */
+
+/**
+ * Convert HS4 code to HS2 chapter (matches chokepoint-exposure-utils.ts:hs4ToHs2).
+ * @param {string} hs4
+ * @returns {string}
+ */
+function hs4ToHs2(hs4) {
+  return String(Number.parseInt(hs4.slice(0, 2), 10));
+}
+
+/**
+ * Flow-weighted exposure — mirrors chokepoint-exposure-utils.ts:computeFlowWeightedExposures.
+ * Uses importerRoutes OR exporterRoutes union for route coverage (same as handler).
+ * @param {string} importerIso2
+ * @param {string} hs2
+ * @param {ComtradeProduct[]} products
+ * @returns {object[]}
+ */
+export function computeFlowWeightedExposures(importerIso2, hs2, products) {
+  const isEnergy = hs2 === '27';
+  const normalizedHs2 = String(Number.parseInt(hs2, 10));
+  const matchingProducts = products.filter(p => hs4ToHs2(p.hs4) === normalizedHs2);
+
+  if (matchingProducts.length === 0) return [];
+
+  const importerCluster = COUNTRY_PORT_CLUSTERS[importerIso2];
+  const importerRoutes = new Set(importerCluster?.nearestRouteIds ?? []);
+  const totalSectorValue = matchingProducts.reduce((s, p) => s + p.totalValue, 0);
+
+  /** @type {Map<string, number>} */
+  const cpScores = new Map();
+  for (const cp of CHOKEPOINT_REGISTRY) cpScores.set(cp.id, 0);
+
+  for (const product of matchingProducts) {
+    const productWeight = totalSectorValue > 0 ? product.totalValue / totalSectorValue : 0;
+
+    for (const exporter of product.topExporters) {
+      if (!exporter.partnerIso2) continue;
+      const exporterCluster = COUNTRY_PORT_CLUSTERS[exporter.partnerIso2];
+      const exporterRoutes = new Set(exporterCluster?.nearestRouteIds ?? []);
+
+      for (const cp of CHOKEPOINT_REGISTRY) {
+        let overlap = 0;
+        for (const r of cp.routeIds) {
+          if (importerRoutes.has(r) || exporterRoutes.has(r)) overlap++;
+        }
+        const routeCoverage = overlap / Math.max(cp.routeIds.length, 1);
+        const contribution = routeCoverage * exporter.share * productWeight * 100;
+        cpScores.set(cp.id, (cpScores.get(cp.id) ?? 0) + contribution);
+      }
+    }
+  }
+
+  const entries = CHOKEPOINT_REGISTRY.map(cp => {
+    let score = cpScores.get(cp.id) ?? 0;
+    if (isEnergy && cp.shockModelSupported) score = Math.min(score * 1.5, 100);
+    score = Math.min(score, 100);
+    return {
+      chokepointId: cp.id,
+      chokepointName: cp.displayName,
+      exposureScore: Math.round(score * 10) / 10,
+      coastSide: '',
+      shockSupported: cp.shockModelSupported,
+    };
+  });
+
+  return entries.sort((a, b) => b.exposureScore - a.exposureScore);
+}
+
+/**
+ * Country-level route-based fallback — mirrors chokepoint-exposure-utils.ts:computeFallbackExposures.
  * @param {string[]} nearestRouteIds
  * @param {string} coastSide
  * @param {string} hs2
  * @returns {{ exposures: object[], primaryChokepointId: string, vulnerabilityIndex: number }}
  */
-function computeExposure(nearestRouteIds, coastSide, hs2) {
+export function computeCountryLevelExposure(nearestRouteIds, coastSide, hs2) {
   const isEnergy = hs2 === '27';
   const routeSet = new Set(nearestRouteIds);
 
@@ -89,7 +163,6 @@ function computeExposure(nearestRouteIds, coastSide, hs2) {
     };
   }).sort((a, b) => b.exposureScore - a.exposureScore);
 
-  // Attach coastSide to top entry only
   if (entries[0]) entries[0] = { ...entries[0], coastSide };
 
   const weights = [0.5, 0.3, 0.2];
@@ -124,6 +197,45 @@ async function redisPipeline(commands) {
   return resp.json();
 }
 
+// ── Comtrade data loader ─────────────────────────────────────────────────────
+
+/**
+ * Batch-read Comtrade bilateral HS4 data for all countries from Redis.
+ * @param {string[]} iso2List
+ * @returns {Promise<Map<string, ComtradeProduct[]>>}
+ */
+async function loadComtradeData(iso2List) {
+  const keys = iso2List.map(iso2 => `${COMTRADE_KEY_PREFIX}${iso2}:v1`);
+  const { url, token } = getRedisCredentials();
+  const commands = keys.map(k => ['GET', k]);
+
+  const resp = await fetch(`${url}/pipeline`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(commands),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!resp.ok) {
+    console.warn(`[chokepoint-exposure] Comtrade MGET failed: HTTP ${resp.status}`);
+    return new Map();
+  }
+
+  const results = await resp.json();
+  /** @type {Map<string, ComtradeProduct[]>} */
+  const map = new Map();
+  for (let i = 0; i < iso2List.length; i++) {
+    const raw = results[i]?.result;
+    if (!raw) continue;
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed?.products && Array.isArray(parsed.products)) {
+        map.set(iso2List[i], parsed.products);
+      }
+    } catch { /* skip malformed */ }
+  }
+  return map;
+}
+
 // ── Main ──────────────────────────────────────────────────────────────────────
 
 export async function main() {
@@ -155,14 +267,51 @@ export async function main() {
     const countries = Object.entries(COUNTRY_PORT_CLUSTERS).filter(
       ([k]) => k !== '_comment' && k.length === 2,
     );
+    const iso2List = countries.map(([iso2]) => iso2);
+
+    console.log(`[chokepoint-exposure] Loading Comtrade bilateral data for ${iso2List.length} countries...`);
+    const comtradeMap = await loadComtradeData(iso2List);
+    console.log(`[chokepoint-exposure] Comtrade data loaded for ${comtradeMap.size}/${iso2List.length} countries`);
     console.log(`[chokepoint-exposure] Computing exposure for ${countries.length} countries × ${HS2_CODES.length} HS2 code(s)...`);
 
     const commands = [];
     let writtenCount = 0;
+    let flowWeightedCount = 0;
+    let fallbackCount = 0;
+
+    /** @param {object[]} exposures */
+    const buildVulnIndex = (exposures) => {
+      const weights = [0.5, 0.3, 0.2];
+      return Math.round(
+        exposures.slice(0, 3).reduce((sum, e, i) => sum + e.exposureScore * weights[i], 0) * 10,
+      ) / 10;
+    };
 
     for (const hs2 of HS2_CODES) {
       for (const [iso2, cluster] of countries) {
-        const result = computeExposure(cluster.nearestRouteIds ?? [], cluster.coastSide ?? '', hs2);
+        const comtradeProducts = comtradeMap.get(iso2);
+        let result;
+
+        if (comtradeProducts && comtradeProducts.length > 0) {
+          const exposures = computeFlowWeightedExposures(iso2, hs2, comtradeProducts);
+          if (exposures.length > 0 && exposures.some(e => e.exposureScore > 0)) {
+            const coastSide = cluster.coastSide ?? '';
+            if (exposures[0]) exposures[0] = { ...exposures[0], coastSide };
+            result = {
+              exposures,
+              primaryChokepointId: exposures[0]?.chokepointId ?? '',
+              vulnerabilityIndex: buildVulnIndex(exposures),
+            };
+            flowWeightedCount++;
+          } else {
+            result = computeCountryLevelExposure(cluster.nearestRouteIds ?? [], cluster.coastSide ?? '', hs2);
+            fallbackCount++;
+          }
+        } else {
+          result = computeCountryLevelExposure(cluster.nearestRouteIds ?? [], cluster.coastSide ?? '', hs2);
+          fallbackCount++;
+        }
+
         const payload = JSON.stringify({
           iso2,
           hs2,
@@ -174,7 +323,6 @@ export async function main() {
       }
     }
 
-    // Write seed-meta in same pipeline
     commands.push([
       'SET', META_KEY,
       JSON.stringify({ fetchedAt: Date.now(), recordCount: writtenCount, status: 'ok' }),
@@ -190,12 +338,14 @@ export async function main() {
     logSeedResult('supply_chain:chokepoint-exposure', writtenCount, Date.now() - startedAt, {
       countries: countries.length,
       hs2Codes: HS2_CODES,
+      flowWeighted: flowWeightedCount,
+      fallback: fallbackCount,
+      comtradeCountries: comtradeMap.size,
       ttlH: TTL_SECONDS / 3600,
     });
-    console.log(`[chokepoint-exposure] Seeded ${writtenCount} exposure keys`);
+    console.log(`[chokepoint-exposure] Seeded ${writtenCount} keys (${flowWeightedCount} flow-weighted, ${fallbackCount} fallback)`);
   } catch (err) {
     console.error('[chokepoint-exposure] Seed failed:', err.message || err);
-    // Extend TTL on failure — stale is better than missing
     const existingKeys = Object.keys(COUNTRY_PORT_CLUSTERS)
       .filter(k => k !== '_comment' && k.length === 2)
       .flatMap(iso2 => HS2_CODES.map(hs2 => `${KEY_PREFIX}${iso2}:${hs2}:v1`));

--- a/tests/chokepoint-exposure-seed.test.mjs
+++ b/tests/chokepoint-exposure-seed.test.mjs
@@ -1,0 +1,179 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeFlowWeightedExposures,
+  computeCountryLevelExposure,
+} from '../scripts/seed-hs2-chokepoint-exposure.mjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const CLUSTERS = require('../scripts/shared/country-port-clusters.json');
+
+function getCluster(iso2) {
+  const c = CLUSTERS[iso2];
+  if (!c || typeof c === 'string') return { nearestRouteIds: [], coastSide: 'unknown' };
+  return c;
+}
+
+// Mock Comtrade data: Turkey imports
+const TURKEY_COMTRADE = [
+  {
+    hs4: '2709', description: 'Crude Petroleum', totalValue: 10_000_000,
+    topExporters: [
+      { partnerCode: 682, partnerIso2: 'SA', value: 4_000_000, share: 0.4 },
+      { partnerCode: 643, partnerIso2: 'RU', value: 3_000_000, share: 0.3 },
+      { partnerCode: 368, partnerIso2: 'IQ', value: 2_000_000, share: 0.2 },
+    ],
+    year: 2023,
+  },
+  {
+    hs4: '8542', description: 'Semiconductors', totalValue: 5_000_000,
+    topExporters: [
+      { partnerCode: 158, partnerIso2: 'TW', value: 2_000_000, share: 0.4 },
+      { partnerCode: 156, partnerIso2: 'CN', value: 1_500_000, share: 0.3 },
+      { partnerCode: 410, partnerIso2: 'KR', value: 1_000_000, share: 0.2 },
+    ],
+    year: 2023,
+  },
+  {
+    hs4: '6204', description: 'Garments', totalValue: 2_000_000,
+    topExporters: [
+      { partnerCode: 156, partnerIso2: 'CN', value: 1_000_000, share: 0.5 },
+      { partnerCode: 50, partnerIso2: 'BD', value: 600_000, share: 0.3 },
+    ],
+    year: 2023,
+  },
+];
+
+// Mock Comtrade data: US imports
+const US_COMTRADE = [
+  {
+    hs4: '2709', description: 'Crude Petroleum', totalValue: 100_000_000,
+    topExporters: [
+      { partnerCode: 682, partnerIso2: 'SA', value: 30_000_000, share: 0.3 },
+      { partnerCode: 124, partnerIso2: 'CA', value: 50_000_000, share: 0.5 },
+    ],
+    year: 2023,
+  },
+  {
+    hs4: '8542', description: 'Semiconductors', totalValue: 50_000_000,
+    topExporters: [
+      { partnerCode: 158, partnerIso2: 'TW', value: 20_000_000, share: 0.4 },
+      { partnerCode: 156, partnerIso2: 'CN', value: 15_000_000, share: 0.3 },
+      { partnerCode: 410, partnerIso2: 'KR', value: 10_000_000, share: 0.2 },
+    ],
+    year: 2023,
+  },
+];
+
+describe('computeFlowWeightedExposures (seed)', () => {
+  it('Turkey: Energy and Electronics produce different vulnerability indices', () => {
+    const energy = computeFlowWeightedExposures('TR', '27', TURKEY_COMTRADE);
+    const elec = computeFlowWeightedExposures('TR', '85', TURKEY_COMTRADE);
+
+    assert.ok(energy.length > 0, 'Energy should have exposures');
+    assert.ok(elec.length > 0, 'Electronics should have exposures');
+
+    const energyVuln = energy.slice(0, 3).reduce((s, e, i) => s + e.exposureScore * [0.5, 0.3, 0.2][i], 0);
+    const elecVuln = elec.slice(0, 3).reduce((s, e, i) => s + e.exposureScore * [0.5, 0.3, 0.2][i], 0);
+    assert.notEqual(Math.round(energyVuln * 10) / 10, Math.round(elecVuln * 10) / 10,
+      'Energy and Electronics vulnerability indices must differ');
+  });
+
+  it('Turkey: at least 2 of 3 sectors have different top chokepoints or scores', () => {
+    const energy = computeFlowWeightedExposures('TR', '27', TURKEY_COMTRADE);
+    const elec = computeFlowWeightedExposures('TR', '85', TURKEY_COMTRADE);
+    const apparel = computeFlowWeightedExposures('TR', '62', TURKEY_COMTRADE);
+
+    const tops = [energy[0], elec[0], apparel[0]].filter(Boolean);
+    const uniqueScores = new Set(tops.map(t => `${t.chokepointId}:${t.exposureScore}`));
+    assert.ok(uniqueScores.size >= 2, `At least 2 unique top chokepoint+score combos expected, got ${uniqueScores.size}`);
+  });
+
+  it('US: Energy and Electronics have different Hormuz exposure', () => {
+    const energy = computeFlowWeightedExposures('US', '27', US_COMTRADE);
+    const elec = computeFlowWeightedExposures('US', '85', US_COMTRADE);
+
+    const energyHormuz = energy.find(e => e.chokepointId === 'hormuz_strait');
+    const elecHormuz = elec.find(e => e.chokepointId === 'hormuz_strait');
+
+    assert.ok(energyHormuz, 'Energy should have Hormuz entry');
+    assert.ok(elecHormuz, 'Electronics should have Hormuz entry');
+    assert.notEqual(energyHormuz.exposureScore, elecHormuz.exposureScore,
+      'Energy and Electronics Hormuz scores must differ (different exporter mixes)');
+  });
+
+  it('no matching HS4 rows returns empty', () => {
+    const result = computeFlowWeightedExposures('TR', '99', TURKEY_COMTRADE);
+    assert.equal(result.length, 0);
+  });
+
+  it('unknown partnerIso2 is skipped gracefully', () => {
+    const badData = [{
+      hs4: '2709', description: 'Crude', totalValue: 1_000_000,
+      topExporters: [
+        { partnerCode: 999, partnerIso2: '', value: 500_000, share: 0.5 },
+        { partnerCode: 682, partnerIso2: 'SA', value: 500_000, share: 0.5 },
+      ],
+      year: 2023,
+    }];
+    const result = computeFlowWeightedExposures('TR', '27', badData);
+    assert.ok(result.length > 0, 'Should still produce results from valid exporter');
+  });
+
+  it('energy boost never exceeds 100', () => {
+    const energy = computeFlowWeightedExposures('TR', '27', TURKEY_COMTRADE);
+    for (const e of energy) {
+      assert.ok(e.exposureScore <= 100, `Score ${e.exposureScore} for ${e.chokepointId} exceeds 100`);
+    }
+  });
+
+  it('all scores in 0-100 range', () => {
+    const result = computeFlowWeightedExposures('TR', '27', TURKEY_COMTRADE);
+    for (const e of result) {
+      assert.ok(e.exposureScore >= 0 && e.exposureScore <= 100,
+        `Score ${e.exposureScore} for ${e.chokepointId} out of range`);
+    }
+  });
+});
+
+describe('computeCountryLevelExposure (seed fallback)', () => {
+  it('produces non-empty exposures for countries with routes', () => {
+    const trCluster = getCluster('TR');
+    const result = computeCountryLevelExposure(trCluster.nearestRouteIds, trCluster.coastSide, '27');
+    assert.ok(result.exposures.length > 0);
+    assert.ok(result.primaryChokepointId !== '');
+  });
+
+  it('non-energy sectors produce identical scores (the original bug)', () => {
+    const trCluster = getCluster('TR');
+    const elec = computeCountryLevelExposure(trCluster.nearestRouteIds, trCluster.coastSide, '85');
+    const apparel = computeCountryLevelExposure(trCluster.nearestRouteIds, trCluster.coastSide, '62');
+    assert.deepEqual(
+      elec.exposures.map(e => e.exposureScore),
+      apparel.exposures.map(e => e.exposureScore),
+      'Fallback should give identical scores for non-energy sectors (demonstrating the old bug)',
+    );
+  });
+
+  it('energy boost clamps to 100', () => {
+    const trCluster = getCluster('TR');
+    const result = computeCountryLevelExposure(trCluster.nearestRouteIds, trCluster.coastSide, '27');
+    for (const e of result.exposures) {
+      assert.ok(e.exposureScore <= 100, `Fallback score ${e.exposureScore} exceeds 100`);
+    }
+  });
+});
+
+describe('algorithm parity with handler', () => {
+  it('seed flow-weighted matches handler algorithm (union-based route coverage)', () => {
+    // The handler (chokepoint-exposure-utils.ts) uses:
+    //   if (importerRoutes.has(r) || exporterRoutes.has(r)) overlap++
+    // Verify the seed produces the same pattern: SA→TR Energy should show
+    // Hormuz (SA exporter route) even though TR importer doesn't have Gulf routes
+    const energy = computeFlowWeightedExposures('TR', '27', TURKEY_COMTRADE);
+    const hormuz = energy.find(e => e.chokepointId === 'hormuz_strait');
+    assert.ok(hormuz && hormuz.exposureScore > 0,
+      'Hormuz should appear from SA exporter routes via union-based coverage');
+  });
+});


### PR DESCRIPTION
## Why

PR #3017 added on-demand flow-weighted chokepoint exposure computation in the handler, but the seed script still pre-computes country-level-only scores (the old uniform algorithm). This means the first request for any country+sector hits the handler's on-demand path, which requires a Redis read for Comtrade bilateral data plus computation.

## What changed

Upgraded `scripts/seed-hs2-chokepoint-exposure.mjs` to:
- Batch-read all `comtrade:bilateral-hs4:{iso2}:v1` keys from Redis at startup
- Pre-compute flow-weighted exposure scores using the same union-based route coverage algorithm as `chokepoint-exposure-utils.ts`
- Fall back to country-level route scoring for countries without Comtrade data
- Log flow-weighted vs fallback counts for monitoring

No handler changes. Same `:v1` cache keys. Pre-populated cache entries now contain differentiated per-sector scores, so the handler serves them directly from cache instead of computing on-demand.

## Test plan
- [x] 11 unit tests: sector differentiation (TR, US), energy boost clamp, fallback, algorithm parity with handler
- [x] TypeScript typecheck passes
- [x] Full test:data suite passes (4,973 tests)
- [ ] Spot-check Redis after first seed run: TR:27 vs TR:85 scores differ

Follow-up to #3017.