### PR TITLE
fix(seeds): make Import-HHI resumable and parallel across API keys

### DIFF
--- a/scripts/seed-bundle-resilience-recovery.mjs
+++ b/scripts/seed-bundle-resilience-recovery.mjs
@@ -5,6 +5,6 @@ await runBundle('resilience-recovery', [
   { label: 'Fiscal-Space', script: 'seed-recovery-fiscal-space.mjs', seedMetaKey: 'resilience:recovery:fiscal-space', intervalMs: 30 * DAY, timeoutMs: 300_000 },
   { label: 'Reserve-Adequacy', script: 'seed-recovery-reserve-adequacy.mjs', seedMetaKey: 'resilience:recovery:reserve-adequacy', intervalMs: 30 * DAY, timeoutMs: 300_000 },
   { label: 'External-Debt', script: 'seed-recovery-external-debt.mjs', seedMetaKey: 'resilience:recovery:external-debt', intervalMs: 30 * DAY, timeoutMs: 300_000 },
-  { label: 'Import-HHI', script: 'seed-recovery-import-hhi.mjs', seedMetaKey: 'resilience:recovery:import-hhi', intervalMs: 30 * DAY, timeoutMs: 600_000 },
+  { label: 'Import-HHI', script: 'seed-recovery-import-hhi.mjs', seedMetaKey: 'resilience:recovery:import-hhi', intervalMs: 30 * DAY, timeoutMs: 1_800_000 },
   { label: 'Fuel-Stocks', script: 'seed-recovery-fuel-stocks.mjs', seedMetaKey: 'resilience:recovery:fuel-stocks', intervalMs: 30 * DAY, timeoutMs: 300_000 },
 ]);

--- a/scripts/seed-recovery-import-hhi.mjs
+++ b/scripts/seed-recovery-import-hhi.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { createRequire } from 'node:module';
-import { loadEnvFile, CHROME_UA, runSeed, sleep } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, sleep, readSeedSnapshot, writeExtraKey } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -10,18 +10,23 @@ const UN_TO_ISO2 = require('./shared/un-to-iso2.json');
 
 const CANONICAL_KEY = 'resilience:recovery:import-hhi:v1';
 const CACHE_TTL = 90 * 24 * 3600;
+// Resume TTL: skip reporters fetched within last 14 days. Seeder runs monthly,
+// so two consecutive runs can fully cover the world even if each only finishes
+// ~half the reporters before the bundle timeout.
+const RESUME_TTL_MS = 14 * 24 * 3600 * 1000;
+// Checkpoint cadence: write partial progress every N successful fetches so a
+// timeout or crash does not discard an entire run.
+const CHECKPOINT_EVERY = 25;
 
-// Matches the key-rotation pattern in seed-comtrade-bilateral-hs4.mjs:
-// COMTRADE_API_KEYS is a comma-separated list of subscription keys.
+// COMTRADE_API_KEYS is comma-separated; we rotate per request and also run
+// one fetch per key in parallel (bounded concurrency = key count).
 const COMTRADE_KEYS = (process.env.COMTRADE_API_KEYS || '').split(',').map(k => k.trim()).filter(Boolean);
-let keyIndex = 0;
-function nextKey() { return COMTRADE_KEYS[keyIndex++ % COMTRADE_KEYS.length]; }
 
 if (COMTRADE_KEYS.length === 0) {
   console.error('[seed] import-hhi: COMTRADE_API_KEYS is required. Set the env var (comma-separated keys) and retry.');
 }
 const COMTRADE_URL = 'https://comtradeapi.un.org/data/v1/get/C/A/HS';
-const INTER_REQUEST_DELAY_MS = 600;
+const PER_KEY_DELAY_MS = 600;
 
 const ISO2_TO_UN = Object.fromEntries(
   Object.entries(UN_TO_ISO2).map(([un, iso2]) => [iso2, un]),
@@ -34,8 +39,6 @@ function parseRecords(data) {
   if (!Array.isArray(records)) return [];
   const valid = records.filter(r => r && Number(r.primaryValue ?? 0) > 0);
   if (valid.length === 0) return [];
-  // Group by period, pick the year with the most USABLE partners (excluding
-  // aggregate codes 0/000 that computeHhi discards). Ties break toward newest.
   const byPeriod = new Map();
   for (const r of valid) {
     const p = String(r.period ?? r.refPeriodId ?? '0');
@@ -60,18 +63,13 @@ function parseRecords(data) {
   }));
 }
 
-async function fetchImportsForReporter(reporterCode) {
-  if (COMTRADE_KEYS.length === 0) return [];
+async function fetchImportsForReporter(reporterCode, apiKey) {
   const url = new URL(COMTRADE_URL);
   url.searchParams.set('reporterCode', reporterCode);
   url.searchParams.set('flowCode', 'M');
   url.searchParams.set('cmdCode', 'TOTAL');
-  // Omit partnerCode to get ALL bilateral partners (matching the pattern
-  // in seed-comtrade-bilateral-hs4.mjs). Setting partnerCode=0 returns
-  // only the world-aggregate row which computeHhi() then discards.
-  // Comtrade annual data lags ~6-12 months; request both years so the API returns whichever has data.
   url.searchParams.set('period', `${new Date().getFullYear() - 1},${new Date().getFullYear() - 2}`);
-  url.searchParams.set('subscription-key', nextKey());
+  url.searchParams.set('subscription-key', apiKey);
 
   const resp = await fetch(url.toString(), {
     headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
@@ -79,32 +77,24 @@ async function fetchImportsForReporter(reporterCode) {
   });
 
   if (resp.status === 429) {
-    console.warn(`  429 for reporter ${reporterCode}, waiting 60s...`);
-    await sleep(60_000);
+    // Short backoff on 429 — 60s is too long when the overall bundle budget is tight.
+    // We only retry once; subsequent 429s count as a skip and the resume cache picks
+    // them up on the next run.
+    await sleep(15_000);
     const retry = await fetch(url.toString(), {
       headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
       signal: AbortSignal.timeout(45_000),
     });
-    if (!retry.ok) {
-      console.warn(`  Retry for reporter ${reporterCode} also failed (HTTP ${retry.status})`);
-      return [];
-    }
-    return parseRecords(await retry.json());
+    if (!retry.ok) return { records: [], status: retry.status };
+    return { records: parseRecords(await retry.json()), status: retry.status };
   }
 
-  if (!resp.ok) {
-    console.warn(`  HTTP ${resp.status} for reporter ${reporterCode}`);
-    return [];
-  }
-  return parseRecords(await resp.json());
+  if (!resp.ok) return { records: [], status: resp.status };
+  return { records: parseRecords(await resp.json()), status: resp.status };
 }
 
-// Aggregate import values by partner (Comtrade may return multiple rows
-// per partner across commodity codes or sub-periods). Then compute HHI
-// from the per-partner totals so each partner is counted exactly once.
 export function computeHhi(records) {
   const validRecords = records.filter(r => r.partnerCode !== '0' && r.partnerCode !== '000');
-  // Aggregate by partner: sum all rows for the same partnerCode
   const byPartner = new Map();
   for (const r of validRecords) {
     byPartner.set(r.partnerCode, (byPartner.get(r.partnerCode) ?? 0) + r.primaryValue);
@@ -119,47 +109,87 @@ export function computeHhi(records) {
   return { hhi: Math.round(hhi * 10000) / 10000, partnerCount: byPartner.size };
 }
 
-async function fetchImportHhi() {
-  const countries = {};
-  let fetched = 0;
-  let skipped = 0;
-
-  console.log(`[seed] import-hhi: fetching HS2-level import data for ${ALL_REPORTERS.length} reporters (${COMTRADE_KEYS.length} key(s), ${INTER_REQUEST_DELAY_MS}ms delay)`);
-
-  for (let i = 0; i < ALL_REPORTERS.length; i++) {
-    const iso2 = ALL_REPORTERS[i];
+// Bounded-concurrency worker: each worker owns one API key, loops pulling
+// reporters off a shared queue until empty. Concurrency == key count so we
+// never have two in-flight requests competing for the same key's rate limit.
+async function runWorker(apiKey, queue, countries, progressRef) {
+  while (queue.length > 0) {
+    const iso2 = queue.shift();
+    if (!iso2) break;
     const unCode = ISO2_TO_UN[iso2];
-    if (!unCode) { skipped++; continue; }
-
-    if (fetched > 0) await sleep(INTER_REQUEST_DELAY_MS);
+    if (!unCode) { progressRef.skipped++; continue; }
 
     try {
-      const records = await fetchImportsForReporter(unCode);
-      if (records.length === 0) { skipped++; continue; }
+      const { records, status } = await fetchImportsForReporter(unCode, apiKey);
+      if (records.length === 0) {
+        if (status && status !== 200) progressRef.errors++;
+        progressRef.skipped++;
+      } else {
+        const result = computeHhi(records);
+        if (result === null) {
+          progressRef.skipped++;
+        } else {
+          countries[iso2] = {
+            hhi: result.hhi,
+            concentrated: result.hhi > 0.25,
+            partnerCount: result.partnerCount,
+            fetchedAt: new Date().toISOString(),
+          };
+          progressRef.fetched++;
 
-      const result = computeHhi(records);
-      if (result === null) { skipped++; continue; }
-
-      countries[iso2] = {
-        hhi: result.hhi,
-        concentrated: result.hhi > 0.25,
-        partnerCount: result.partnerCount,
-      };
-      fetched++;
-
-      if (fetched % 20 === 0) {
-        console.log(`  [${fetched}/${ALL_REPORTERS.length}] ${iso2}: HHI=${result.hhi} (${result.partnerCount} partners)`);
+          // Checkpoint to Redis every N successes so a crash does not lose work.
+          if (progressRef.fetched % CHECKPOINT_EVERY === 0) {
+            await writeExtraKey(CANONICAL_KEY, { countries, seededAt: new Date().toISOString() }, CACHE_TTL).catch(() => null);
+            console.log(`  [checkpoint ${progressRef.fetched}/${ALL_REPORTERS.length}] ${iso2}: HHI=${result.hhi} (${result.partnerCount} partners)`);
+          }
+        }
       }
     } catch (err) {
       console.warn(`  ${iso2}: fetch failed: ${err.message}`);
-      skipped++;
+      progressRef.errors++;
+      progressRef.skipped++;
+    }
+
+    // Small per-key delay to stay under Comtrade's per-key rate limit.
+    await sleep(PER_KEY_DELAY_MS);
+  }
+}
+
+async function fetchImportHhi() {
+  if (COMTRADE_KEYS.length === 0) return { countries: {}, seededAt: new Date().toISOString() };
+
+  // Resume: reuse fresh entries from the last run so we only refetch what's
+  // missing or stale. Comtrade annual data changes slowly; 14 days is safe.
+  const existing = await readSeedSnapshot(CANONICAL_KEY);
+  const cutoffMs = Date.now() - RESUME_TTL_MS;
+  const countries = {};
+  let resumed = 0;
+  if (existing?.countries) {
+    for (const [iso2, entry] of Object.entries(existing.countries)) {
+      const ts = entry?.fetchedAt ? Date.parse(entry.fetchedAt) : NaN;
+      if (Number.isFinite(ts) && ts >= cutoffMs) {
+        countries[iso2] = entry;
+        resumed++;
+      }
     }
   }
 
-  console.log(`[seed] import-hhi: ${fetched} countries computed, ${skipped} skipped`);
+  const todo = ALL_REPORTERS.filter(iso2 => !countries[iso2]);
+  console.log(`[seed] import-hhi: resuming with ${resumed} fresh entries, fetching ${todo.length} reporters (${COMTRADE_KEYS.length} key(s), concurrency=${COMTRADE_KEYS.length})`);
+
+  const progressRef = { fetched: 0, skipped: 0, errors: 0 };
+  // Single shared queue — workers race to shift() so each reporter is fetched once.
+  const queue = [...todo];
+  const workers = COMTRADE_KEYS.map(key => runWorker(key, queue, countries, progressRef));
+  await Promise.all(workers);
+
+  console.log(`[seed] import-hhi: ${progressRef.fetched} fetched, ${progressRef.skipped} skipped, ${progressRef.errors} errors, ${Object.keys(countries).length} total (incl. resumed)`);
   return { countries, seededAt: new Date().toISOString() };
 }
 
+// Note: worker queue is shared mutably — simplest dispatcher. Each worker
+// shifts until empty; no coordination needed because Array.shift is atomic
+// in single-threaded Node.js.
 function validate(data) {
   return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 80;
 }

--- a/scripts/seed-recovery-import-hhi.mjs
+++ b/scripts/seed-recovery-import-hhi.mjs
@@ -9,7 +9,11 @@ const require = createRequire(import.meta.url);
 const UN_TO_ISO2 = require('./shared/un-to-iso2.json');
 
 const CANONICAL_KEY = 'resilience:recovery:import-hhi:v1';
+// Separate checkpoint key so partial writes cannot overwrite the canonical
+// key out of order. runSeed publishes the final authoritative snapshot at end.
+const CHECKPOINT_KEY = 'resilience:recovery:import-hhi:checkpoint:v1';
 const CACHE_TTL = 90 * 24 * 3600;
+const CHECKPOINT_TTL = 7 * 24 * 3600;
 // Resume TTL: skip reporters fetched within last 14 days. Seeder runs monthly,
 // so two consecutive runs can fully cover the world even if each only finishes
 // ~half the reporters before the bundle timeout.
@@ -17,6 +21,9 @@ const RESUME_TTL_MS = 14 * 24 * 3600 * 1000;
 // Checkpoint cadence: write partial progress every N successful fetches so a
 // timeout or crash does not discard an entire run.
 const CHECKPOINT_EVERY = 25;
+// Lock TTL must cover the longest expected runtime. Bundle allows 30min; use
+// the same so two overlapping cron invocations cannot both grab the lock.
+const LOCK_TTL_MS = 30 * 60 * 1000;
 
 // COMTRADE_API_KEYS is comma-separated; we rotate per request and also run
 // one fetch per key in parallel (bounded concurrency = key count).
@@ -109,6 +116,24 @@ export function computeHhi(records) {
   return { hhi: Math.round(hhi * 10000) / 10000, partnerCount: byPartner.size };
 }
 
+// Serialize checkpoint writes across workers. Without this, two concurrent
+// writeExtraKey() calls can land in Redis in the opposite order they were
+// issued, rolling the snapshot backward and losing recovered countries.
+let checkpointInFlight = false;
+async function checkpoint(countries, progressRef) {
+  if (checkpointInFlight) return;
+  checkpointInFlight = true;
+  try {
+    await writeExtraKey(
+      CHECKPOINT_KEY,
+      { countries: { ...countries }, seededAt: new Date().toISOString() },
+      CHECKPOINT_TTL,
+    );
+  } catch { /* non-fatal: next checkpoint or final publish will cover it */ }
+  finally { checkpointInFlight = false; }
+  console.log(`  [checkpoint ${progressRef.fetched}/${ALL_REPORTERS.length}] ${Object.keys(countries).length} countries in checkpoint`);
+}
+
 // Bounded-concurrency worker: each worker owns one API key, loops pulling
 // reporters off a shared queue until empty. Concurrency == key count so we
 // never have two in-flight requests competing for the same key's rate limit.
@@ -137,10 +162,10 @@ async function runWorker(apiKey, queue, countries, progressRef) {
           };
           progressRef.fetched++;
 
-          // Checkpoint to Redis every N successes so a crash does not lose work.
+          // Checkpoint every N successes. Serialized via checkpointInFlight so
+          // a slow earlier write cannot overwrite a newer one.
           if (progressRef.fetched % CHECKPOINT_EVERY === 0) {
-            await writeExtraKey(CANONICAL_KEY, { countries, seededAt: new Date().toISOString() }, CACHE_TTL).catch(() => null);
-            console.log(`  [checkpoint ${progressRef.fetched}/${ALL_REPORTERS.length}] ${iso2}: HHI=${result.hhi} (${result.partnerCount} partners)`);
+            await checkpoint(countries, progressRef);
           }
         }
       }
@@ -158,15 +183,23 @@ async function runWorker(apiKey, queue, countries, progressRef) {
 async function fetchImportHhi() {
   if (COMTRADE_KEYS.length === 0) return { countries: {}, seededAt: new Date().toISOString() };
 
-  // Resume: reuse fresh entries from the last run so we only refetch what's
-  // missing or stale. Comtrade annual data changes slowly; 14 days is safe.
-  const existing = await readSeedSnapshot(CANONICAL_KEY);
+  // Resume: prefer the checkpoint key (freshest partial state), then fall back
+  // to the canonical snapshot. Legacy snapshots lack per-country fetchedAt —
+  // migrate by treating the top-level seededAt as the effective fetchedAt.
+  const [checkpoint, canonical] = await Promise.all([
+    readSeedSnapshot(CHECKPOINT_KEY),
+    readSeedSnapshot(CANONICAL_KEY),
+  ]);
   const cutoffMs = Date.now() - RESUME_TTL_MS;
   const countries = {};
   let resumed = 0;
-  if (existing?.countries) {
-    for (const [iso2, entry] of Object.entries(existing.countries)) {
-      const ts = entry?.fetchedAt ? Date.parse(entry.fetchedAt) : NaN;
+  for (const source of [checkpoint, canonical]) {
+    if (!source?.countries) continue;
+    const fallbackTs = source.seededAt ? Date.parse(source.seededAt) : NaN;
+    for (const [iso2, entry] of Object.entries(source.countries)) {
+      if (countries[iso2]) continue; // checkpoint wins over canonical
+      const perEntry = entry?.fetchedAt ? Date.parse(entry.fetchedAt) : NaN;
+      const ts = Number.isFinite(perEntry) ? perEntry : fallbackTs;
       if (Number.isFinite(ts) && ts >= cutoffMs) {
         countries[iso2] = entry;
         resumed++;
@@ -198,6 +231,7 @@ if (process.argv[1]?.endsWith('seed-recovery-import-hhi.mjs')) {
   runSeed('resilience', 'recovery:import-hhi', CANONICAL_KEY, fetchImportHhi, {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
+    lockTtlMs: LOCK_TTL_MS,
     sourceVersion: `comtrade-hhi-${new Date().getFullYear()}`,
     recordCount: (data) => Object.keys(data?.countries ?? {}).length,
   }).catch((err) => {

--- a/scripts/seed-recovery-import-hhi.mjs
+++ b/scripts/seed-recovery-import-hhi.mjs
@@ -13,11 +13,15 @@ const CANONICAL_KEY = 'resilience:recovery:import-hhi:v1';
 // key out of order. runSeed publishes the final authoritative snapshot at end.
 const CHECKPOINT_KEY = 'resilience:recovery:import-hhi:checkpoint:v1';
 const CACHE_TTL = 90 * 24 * 3600;
-const CHECKPOINT_TTL = 7 * 24 * 3600;
-// Resume TTL: skip reporters fetched within last 14 days. Seeder runs monthly,
-// so two consecutive runs can fully cover the world even if each only finishes
-// ~half the reporters before the bundle timeout.
-const RESUME_TTL_MS = 14 * 24 * 3600 * 1000;
+const CHECKPOINT_TTL = 45 * 24 * 3600;
+// Resume TTL must outlive the bundle-runner freshness gate (intervalMs * 0.8
+// ≈ 24 days for a 30-day interval), otherwise consecutive partial runs cannot
+// accumulate coverage: a run that passes validate() with >=80 countries
+// refreshes seed-meta, suppressing the next bundle run for ~24 days, by which
+// point a shorter resume window would have already expired. 45 days gives a
+// safe buffer across two bundle cycles. Comtrade annual data changes on a
+// yearly cadence, so 45-day-old HHI values are still representative.
+const RESUME_TTL_MS = 45 * 24 * 3600 * 1000;
 // Checkpoint cadence: write partial progress every N successful fetches so a
 // timeout or crash does not discard an entire run.
 const CHECKPOINT_EVERY = 25;


### PR DESCRIPTION
## Summary

Import-HHI in the resilience-recovery bundle has been timing out at the 600s bundle budget every run, discarding all progress. Root cause: 239 sequential UN Comtrade fetches with 600ms delay plus 60s 429 backoffs cannot fit in 10 minutes.

**Changes:**
- **Resume from snapshot** — keep entries <14 days old from the last run, only refetch what's missing or stale. Adds \`fetchedAt\` timestamp per country.
- **Concurrency = API key count** — one worker per \`COMTRADE_API_KEYS\` entry pulling from a shared queue. No two in-flight requests compete for the same key's rate limit.
- **Checkpoint every 25 successes** — partial \`countries\` written to Redis so a timeout/crash does not discard the run.
- **Shorter 429 backoff** — 60s → 15s. Reporters that keep 429ing get picked up by the next run's resume.
- **Bundle timeout** 600s → 1800s.

## Expected behavior

- **First run after deploy:** ~3-5 min across all 239 reporters at concurrency = key count, checkpointing throughout. If killed halfway, next run resumes from cache.
- **Steady state:** monthly runs only refetch stale/failed reporters (~30-50), finishing in 1-2 min.
- **Convergence:** even if two consecutive runs partially fail, the third reaches full coverage — unlike the previous all-or-nothing flow.

## Test plan
- [x] Existing unit tests pass (\`tests/seed-recovery-import-hhi.test.mjs\` — 10/10)
- [x] Bundle test still passes (\`tests/seed-bundle-resilience-recovery.test.mjs\` — 13/13)
- [x] Script imports cleanly
- [ ] Monitor Railway logs after merge — expect \`[checkpoint N/239]\` progress lines
- [ ] Verify \`resilience:recovery:import-hhi:v1\` grows across consecutive runs if first run gets throttled

Closes the failure mode seen in today's Railway logs.