### PR TITLE
feat(resilience): dedicated Dockerfile for validation cron

### DIFF
--- a/Dockerfile.seed-bundle-resilience-validation
+++ b/Dockerfile.seed-bundle-resilience-validation
@@ -1,0 +1,36 @@
+# =============================================================================
+# Seed Bundle: Resilience Validation (weekly cron)
+# =============================================================================
+# Runs scripts/seed-bundle-resilience-validation.mjs which spawns:
+#   - benchmark-resilience-external.mjs
+#   - backtest-resilience-outcomes.mjs
+#   - validate-resilience-sensitivity.mjs (imports from ../server/ via tsx)
+#
+# Needs both scripts/ and server/ in the container + tsx resolvable from /app/.
+# =============================================================================
+
+FROM node:22-alpine
+
+WORKDIR /app
+
+# Root dependencies (includes tsx in devDependencies — install all for build-time
+# access, then prune won't help because tsx is needed at runtime). Install with
+# NODE_ENV unset so devDependencies land in /app/node_modules.
+COPY package.json package-lock.json ./
+RUN NODE_ENV=development npm ci --ignore-scripts --no-audit --no-fund
+
+# Scripts/ dependencies (telegram, fast-xml-parser, resend, etc. — most are
+# not needed by validation, but keep parity with nixpacks behavior)
+COPY scripts/package.json scripts/package-lock.json ./scripts/
+RUN npm ci --prefix scripts --omit=dev --no-audit --no-fund
+
+# Copy scripts + server + shared + data (everything the validation bundle touches)
+COPY scripts/ ./scripts/
+COPY server/ ./server/
+COPY shared/ ./shared/
+COPY data/ ./data/
+COPY tsconfig.json tsconfig.api.json ./
+
+ENV NODE_OPTIONS="--max-old-space-size=8192 --dns-result-order=ipv4first --import tsx/esm"
+
+CMD ["node", "scripts/seed-bundle-resilience-validation.mjs"]


### PR DESCRIPTION
## Summary
Railway auto-detects the root `Dockerfile` even when `builder=NIXPACKS` is set, so the validation cron kept building the nginx/vite app — which strips `scripts/` and `server/` from the runtime image and causes `ERR_MODULE_NOT_FOUND` for `tsx` and the sensitivity suite's dimension-scorers.

Adds `Dockerfile.seed-bundle-resilience-validation`:
- Installs **root dependencies with `NODE_ENV=development`** so `tsx` (in devDeps) lands in `/app/node_modules/` and `--import tsx/esm` resolves
- Installs `scripts/` production deps
- Copies `scripts/` + `server/` + `shared/` + `data/` + tsconfigs so `validate-resilience-sensitivity.mjs` dynamic imports from `../server/worldmonitor/resilience/v1/*.ts` work
- Sets `NODE_OPTIONS` with `--import tsx/esm` at container level

## Railway service changes (applied via GraphQL API)
- `dockerfilePath`: `Dockerfile.seed-bundle-resilience-validation`
- `rootDirectory`: `""` (repo root)
- `startCommand`: `node scripts/seed-bundle-resilience-validation.mjs`
- `NODE_OPTIONS`: `--max-old-space-size=8192 --dns-result-order=ipv4first --import tsx/esm`
- `watchPatterns`: includes `server/worldmonitor/resilience/v1/**`, validation sub-scripts, and the new Dockerfile

## Context
Previous attempts failed:
1. `rootDirectory=scripts` — `../server/` didn't exist in container (sensitivity crash)
2. `rootDirectory=""` + `builder=NIXPACKS` — Railway still auto-detected root Dockerfile
3. `dockerfilePath="__no-such-dockerfile__"` — ignored; Railway still used root Dockerfile
4. `NODE_OPTIONS --import file:///app/scripts/node_modules/tsx/...` — tsx not in container at all because Dockerfile only copies `api/` + `data/`

Only a dedicated Dockerfile works because the root Dockerfile's content is load-bearing for the main `worldmonitor` service and Railway's builder auto-detection doesn't cleanly disable.

## Test plan
- [ ] After merge: build uses `Dockerfile.seed-bundle-resilience-validation` (build logs confirm)
- [ ] After merge: `/app/node_modules/tsx` present in runtime image
- [ ] After merge: all 3 validation scripts complete without `ERR_MODULE_NOT_FOUND`