### PR TITLE
fix(country-brief): dedupe news headlines and clarify Tier badge (#2972)

### DIFF
--- a/src/components/CountryDeepDivePanel-news-utils.ts
+++ b/src/components/CountryDeepDivePanel-news-utils.ts
@@ -1,0 +1,36 @@
+import type { NewsItem } from '../types';
+
+export function normalizeHeadlineKey(title: string): string {
+  return title
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .split(' ')
+    .filter((w) => w.length > 2)
+    .slice(0, 8)
+    .join(' ');
+}
+
+export interface DedupedHeadline {
+  item: NewsItem;
+  extraSources: string[];
+}
+
+export function dedupeHeadlines(items: NewsItem[]): DedupedHeadline[] {
+  const byKey = new Map<string, DedupedHeadline>();
+  for (const it of items) {
+    const key = normalizeHeadlineKey(it.title);
+    if (!key) continue;
+    const existing = byKey.get(key);
+    if (!existing) {
+      byKey.set(key, { item: it, extraSources: [] });
+      continue;
+    }
+    if (it.source && it.source !== existing.item.source && !existing.extraSources.includes(it.source)) {
+      existing.extraSources.push(it.source);
+    }
+  }
+  return [...byKey.values()];
+}

--- a/src/components/CountryDeepDivePanel-news-utils.ts
+++ b/src/components/CountryDeepDivePanel-news-utils.ts
@@ -1,7 +1,18 @@
 import type { NewsItem } from '../types';
 
+export function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&#x2F;/g, '/');
+}
+
 export function normalizeHeadlineKey(title: string): string {
-  return title
+  return decodeHtmlEntities(title)
     .toLowerCase()
     .normalize('NFKD')
     .replace(/[\u0300-\u036f]/g, '')
@@ -13,24 +24,57 @@ export function normalizeHeadlineKey(title: string): string {
     .join(' ');
 }
 
+function fallbackHeadlineKey(title: string): string {
+  return decodeHtmlEntities(title).toLowerCase().trim().replace(/\s+/g, ' ');
+}
+
 export interface DedupedHeadline {
   item: NewsItem;
   extraSources: string[];
 }
 
-export function dedupeHeadlines(items: NewsItem[]): DedupedHeadline[] {
-  const byKey = new Map<string, DedupedHeadline>();
+export type TierLookup = (item: NewsItem) => number;
+
+export function dedupeHeadlines(
+  items: NewsItem[],
+  tierOf?: TierLookup,
+): DedupedHeadline[] {
+  const getTier: TierLookup = tierOf ?? ((it) => (typeof it.tier === 'number' ? it.tier : 4));
+  const groups = new Map<string, NewsItem[]>();
+  const order: string[] = [];
   for (const it of items) {
-    const key = normalizeHeadlineKey(it.title);
-    if (!key) continue;
-    const existing = byKey.get(key);
-    if (!existing) {
-      byKey.set(key, { item: it, extraSources: [] });
-      continue;
-    }
-    if (it.source && it.source !== existing.item.source && !existing.extraSources.includes(it.source)) {
-      existing.extraSources.push(it.source);
+    let key = normalizeHeadlineKey(it.title);
+    if (!key) key = fallbackHeadlineKey(it.title);
+    if (!key) key = it.link || `__idx_${order.length}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(it);
+    } else {
+      groups.set(key, [it]);
+      order.push(key);
     }
   }
-  return [...byKey.values()];
+
+  const out: DedupedHeadline[] = [];
+  for (const key of order) {
+    const group = groups.get(key);
+    if (!group || group.length === 0) continue;
+    const primary = [...group].sort((a, b) => {
+      const ta = getTier(a);
+      const tb = getTier(b);
+      if (ta !== tb) return ta - tb;
+      const da = a.pubDate instanceof Date ? a.pubDate.getTime() : new Date(a.pubDate).getTime();
+      const db = b.pubDate instanceof Date ? b.pubDate.getTime() : new Date(b.pubDate).getTime();
+      return (Number.isFinite(db) ? db : 0) - (Number.isFinite(da) ? da : 0);
+    })[0]!;
+    const extraSources: string[] = [];
+    for (const other of group) {
+      if (other === primary) continue;
+      if (other.source && other.source !== primary.source && !extraSources.includes(other.source)) {
+        extraSources.push(other.source);
+      }
+    }
+    out.push({ item: primary, extraSources });
+  }
+  return out;
 }

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -42,6 +42,7 @@ import type {
 import { fetchMultiSectorCostShock } from '@/services/supply-chain';
 import type { MapContainer } from './MapContainer';
 import { ResilienceWidget } from './ResilienceWidget';
+import { dedupeHeadlines } from './CountryDeepDivePanel-news-utils';
 
 const DEPENDENCY_FLAG_LABELS: Record<string, { text: string; cls: string }> = {
   DEPENDENCY_FLAG_SINGLE_SOURCE_CRITICAL:   { text: 'Single Source',   cls: 'cdp-dep-critical' },
@@ -308,24 +309,25 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     if (!this.newsBody) return;
     this.newsBody.replaceChildren();
 
-    const items = [...headlines]
+    const sorted = [...headlines]
       .sort((a, b) => {
         const sa = SEVERITY_ORDER[this.toThreatLevel(a.threat?.level)];
         const sb = SEVERITY_ORDER[this.toThreatLevel(b.threat?.level)];
         if (sb !== sa) return sb - sa;
         return this.toTimestamp(b.pubDate) - this.toTimestamp(a.pubDate);
-      })
-      .slice(0, 10);
+      });
 
-    this.currentHeadlineCount = items.length;
+    const deduped = dedupeHeadlines(sorted).slice(0, 10);
 
-    if (items.length === 0) {
+    this.currentHeadlineCount = deduped.length;
+
+    if (deduped.length === 0) {
       this.newsBody.append(this.makeEmpty(t('countryBrief.noNews')));
       return;
     }
 
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i]!;
+    for (let i = 0; i < deduped.length; i++) {
+      const { item, extraSources } = deduped[i]!;
       const row = this.el('a', 'cdp-news-item');
       row.id = `cdp-news-${i + 1}`;
       const href = sanitizeUrl(item.link);
@@ -339,12 +341,17 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
 
       const top = this.el('div', 'cdp-news-top');
       const tier = item.tier ?? getSourceTier(item.source);
-      top.append(this.badge(`Tier ${tier}`, `cdp-tier-badge tier-${Math.max(1, Math.min(4, tier))}`));
+      const clampedTier = Math.max(1, Math.min(4, tier));
+      const tierBadge = this.badge(`T${clampedTier} SRC`, `cdp-tier-badge tier-${clampedTier}`);
+      tierBadge.setAttribute('title', `Source tier ${clampedTier}: reflects publication credibility (1 = top wire services, 4 = specialty/low-reach). Independent of article severity.`);
+      top.append(tierBadge);
 
       const severity = this.toThreatLevel(item.threat?.level);
       const levelKey = severity === 'info' ? 'low' : severity === 'medium' ? 'moderate' : severity;
       const severityLabel = t(`countryBrief.levels.${levelKey}`);
-      top.append(this.badge(severityLabel.toUpperCase(), `cdp-severity-badge sev-${severity}`));
+      const sevBadge = this.badge(severityLabel.toUpperCase(), `cdp-severity-badge sev-${severity}`);
+      sevBadge.setAttribute('title', 'Article severity: how serious the event is. Independent of source tier.');
+      top.append(sevBadge);
 
       const risk = getSourcePropagandaRisk(item.source);
       if (risk.stateAffiliated) {
@@ -352,7 +359,13 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
       }
 
       const title = this.el('div', 'cdp-news-title', this.decodeEntities(item.title));
-      const meta = this.el('div', 'cdp-news-meta', `${item.source} • ${this.formatRelativeTime(item.pubDate)}`);
+      const metaText = extraSources.length > 0
+        ? `${item.source} +${extraSources.length} ${extraSources.length === 1 ? 'source' : 'sources'} • ${this.formatRelativeTime(item.pubDate)}`
+        : `${item.source} • ${this.formatRelativeTime(item.pubDate)}`;
+      const meta = this.el('div', 'cdp-news-meta', metaText);
+      if (extraSources.length > 0) {
+        meta.setAttribute('title', `Also reported by: ${extraSources.join(', ')}`);
+      }
       row.append(top, title, meta);
 
       if (i >= 5) {
@@ -364,6 +377,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
       }
     }
   }
+
 
   public updateMilitaryActivity(summary: CountryDeepDiveMilitarySummary): void {
     if (!this.militaryBody) return;

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -317,7 +317,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         return this.toTimestamp(b.pubDate) - this.toTimestamp(a.pubDate);
       });
 
-    const deduped = dedupeHeadlines(sorted).slice(0, 10);
+    const deduped = dedupeHeadlines(sorted, (it) => it.tier ?? getSourceTier(it.source)).slice(0, 10);
 
     this.currentHeadlineCount = deduped.length;
 

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -309,15 +309,18 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     if (!this.newsBody) return;
     this.newsBody.replaceChildren();
 
-    const sorted = [...headlines]
-      .sort((a, b) => {
-        const sa = SEVERITY_ORDER[this.toThreatLevel(a.threat?.level)];
-        const sb = SEVERITY_ORDER[this.toThreatLevel(b.threat?.level)];
-        if (sb !== sa) return sb - sa;
-        return this.toTimestamp(b.pubDate) - this.toTimestamp(a.pubDate);
-      });
+    const compare = (a: NewsItem, b: NewsItem) => {
+      const sa = SEVERITY_ORDER[this.toThreatLevel(a.threat?.level)];
+      const sb = SEVERITY_ORDER[this.toThreatLevel(b.threat?.level)];
+      if (sb !== sa) return sb - sa;
+      return this.toTimestamp(b.pubDate) - this.toTimestamp(a.pubDate);
+    };
 
-    const deduped = dedupeHeadlines(sorted, (it) => it.tier ?? getSourceTier(it.source)).slice(0, 10);
+    const sorted = [...headlines].sort(compare);
+
+    const deduped = dedupeHeadlines(sorted, (it) => it.tier ?? getSourceTier(it.source))
+      .sort((a, b) => compare(a.item, b.item))
+      .slice(0, 10);
 
     this.currentHeadlineCount = deduped.length;
 

--- a/tests/country-news-dedupe.test.mts
+++ b/tests/country-news-dedupe.test.mts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  dedupeHeadlines,
+  normalizeHeadlineKey,
+} from '../src/components/CountryDeepDivePanel-news-utils.ts';
+import type { NewsItem } from '../src/types/index.ts';
+
+function h(title: string, source: string, pubDate = '2026-04-12T00:00:00Z'): NewsItem {
+  return {
+    title,
+    link: `https://example.com/${encodeURIComponent(title)}`,
+    source,
+    pubDate,
+  } as NewsItem;
+}
+
+describe('normalizeHeadlineKey', () => {
+  it('produces identical keys for near-duplicate titles across punctuation and casing', () => {
+    const a = normalizeHeadlineKey('Pentagon, FAA sign agreement on deploying anti-drone laser system near Mexico');
+    const b = normalizeHeadlineKey('Pentagon FAA Sign Agreement On Deploying Anti Drone Laser System Near Mexico');
+    assert.equal(a, b);
+    assert.ok(a.length > 0);
+  });
+
+  it('strips diacritics so accented duplicates collapse', () => {
+    const a = normalizeHeadlineKey('México reaches new trade pact');
+    const b = normalizeHeadlineKey('Mexico reaches new trade pact');
+    assert.equal(a, b);
+  });
+
+  it('returns empty string for titles with only short words', () => {
+    assert.equal(normalizeHeadlineKey('a of in'), '');
+  });
+});
+
+describe('dedupeHeadlines', () => {
+  it('collapses same-story items from different sources and records extras', () => {
+    const items = [
+      h('Pentagon, FAA sign agreement on anti-drone laser system near Mexico', 'Military Times'),
+      h('Pentagon FAA Sign Agreement on Anti-Drone Laser System Near Mexico', 'DefenseOne'),
+      h('Unrelated headline about shipping delays in the Gulf', 'Reuters'),
+    ];
+    const out = dedupeHeadlines(items);
+    assert.equal(out.length, 2);
+    const primary = out[0]!;
+    assert.equal(primary.item.source, 'Military Times');
+    assert.deepEqual(primary.extraSources, ['DefenseOne']);
+    assert.equal(out[1]!.extraSources.length, 0);
+  });
+
+  it('does not count the same source twice in extras', () => {
+    const items = [
+      h('Shared headline text here', 'SourceA'),
+      h('Shared headline text here', 'SourceA'),
+      h('Shared headline text here', 'SourceB'),
+    ];
+    const [only] = dedupeHeadlines(items);
+    assert.deepEqual(only!.extraSources, ['SourceB']);
+  });
+});

--- a/tests/country-news-dedupe.test.mts
+++ b/tests/country-news-dedupe.test.mts
@@ -95,6 +95,41 @@ describe('dedupeHeadlines', () => {
     assert.equal(out[0]!.extraSources.length, 1);
   });
 
+  it('caller re-sort by primary positions the displayed card, not the first-seen duplicate', () => {
+    // Repro: A and B are duplicates. A is newer + higher-severity + tier 4 (low quality),
+    // B is older + lower-severity + tier 1 (Reuters). C is unrelated, medium severity.
+    // dedupeHeadlines picks B (tier 1) as primary for the A/B group. The caller must re-sort
+    // by the chosen primary's severity/time; otherwise the group stays anchored at A's
+    // pre-dedupe position and slice(0, N) picks the wrong cards.
+    type Sev = 'high' | 'medium' | 'low';
+    const SEV: Record<Sev, number> = { low: 0, medium: 1, high: 2 };
+    const mk = (title: string, source: string, t: string, tier: number, sev: Sev) => {
+      const it = h(title, source, t, tier) as NewsItem & { __sev: Sev };
+      it.__sev = sev;
+      return it;
+    };
+
+    const A = mk('Sanctions package advances in Brussels', 'RandoBlog', '2026-04-12T12:00:00Z', 4, 'high');
+    const B = mk('Sanctions package advances in Brussels', 'Reuters', '2026-04-12T09:00:00Z', 1, 'low');
+    const C = mk('Shipping lanes reopen near Hormuz', 'AP', '2026-04-12T10:00:00Z', 1, 'medium');
+
+    const compare = (a: NewsItem, b: NewsItem) => {
+      const sa = SEV[(a as NewsItem & { __sev: Sev }).__sev];
+      const sb = SEV[(b as NewsItem & { __sev: Sev }).__sev];
+      if (sb !== sa) return sb - sa;
+      return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
+    };
+
+    const sorted = [A, B, C].sort(compare);
+    const deduped = dedupeHeadlines(sorted).sort((x, y) => compare(x.item, y.item));
+
+    assert.equal(deduped.length, 2);
+    // B (primary chosen for A/B group) is 'low', C is 'medium' — C must come first now.
+    assert.equal(deduped[0]!.item.source, 'AP');
+    assert.equal(deduped[1]!.item.source, 'Reuters');
+    assert.deepEqual(deduped[1]!.extraSources, ['RandoBlog']);
+  });
+
   it('picks the highest-tier source as primary even when a lower-tier item appears first', () => {
     // Lower tier number = better source. T4 arrives first/newer, T1 arrives second/older.
     const items = [

--- a/tests/country-news-dedupe.test.mts
+++ b/tests/country-news-dedupe.test.mts
@@ -7,13 +7,21 @@ import {
 } from '../src/components/CountryDeepDivePanel-news-utils.ts';
 import type { NewsItem } from '../src/types/index.ts';
 
-function h(title: string, source: string, pubDate = '2026-04-12T00:00:00Z'): NewsItem {
-  return {
+function h(
+  title: string,
+  source: string,
+  pubDate: string = '2026-04-12T00:00:00Z',
+  tier?: number,
+): NewsItem {
+  const item: NewsItem = {
     title,
-    link: `https://example.com/${encodeURIComponent(title)}`,
+    link: `https://example.com/${encodeURIComponent(title)}::${source}`,
     source,
-    pubDate,
+    pubDate: new Date(pubDate),
+    isAlert: false,
   } as NewsItem;
+  if (typeof tier === 'number') item.tier = tier;
+  return item;
 }
 
 describe('normalizeHeadlineKey', () => {
@@ -30,17 +38,23 @@ describe('normalizeHeadlineKey', () => {
     assert.equal(a, b);
   });
 
-  it('returns empty string for titles with only short words', () => {
+  it('returns empty string for titles with only short words (fallback handled by dedupeHeadlines)', () => {
     assert.equal(normalizeHeadlineKey('a of in'), '');
+  });
+
+  it('decodes HTML entities so encoded and plain titles normalize the same way', () => {
+    const a = normalizeHeadlineKey('AT&amp;T announces new tower buildout');
+    const b = normalizeHeadlineKey('AT&T announces new tower buildout');
+    assert.equal(a, b);
   });
 });
 
 describe('dedupeHeadlines', () => {
   it('collapses same-story items from different sources and records extras', () => {
     const items = [
-      h('Pentagon, FAA sign agreement on anti-drone laser system near Mexico', 'Military Times'),
-      h('Pentagon FAA Sign Agreement on Anti-Drone Laser System Near Mexico', 'DefenseOne'),
-      h('Unrelated headline about shipping delays in the Gulf', 'Reuters'),
+      h('Pentagon, FAA sign agreement on anti-drone laser system near Mexico', 'Military Times', '2026-04-12T00:00:00Z', 2),
+      h('Pentagon FAA Sign Agreement on Anti-Drone Laser System Near Mexico', 'DefenseOne', '2026-04-12T00:00:00Z', 3),
+      h('Unrelated headline about shipping delays in the Gulf', 'Reuters', '2026-04-12T00:00:00Z', 1),
     ];
     const out = dedupeHeadlines(items);
     assert.equal(out.length, 2);
@@ -58,5 +72,38 @@ describe('dedupeHeadlines', () => {
     ];
     const [only] = dedupeHeadlines(items);
     assert.deepEqual(only!.extraSources, ['SourceB']);
+  });
+
+  it('never drops items whose normalized key is empty (two-letter-only titles)', () => {
+    const items = [
+      h('UK PM in US', 'BBC'),
+      h('US-EU in talks', 'FT'),
+    ];
+    const out = dedupeHeadlines(items);
+    assert.equal(out.length, 2);
+    assert.equal(out[0]!.item.title, 'UK PM in US');
+    assert.equal(out[1]!.item.title, 'US-EU in talks');
+  });
+
+  it('treats AT&T and AT&amp;T as the same story', () => {
+    const items = [
+      h('AT&T expands fiber rollout across the Southeast', 'Bloomberg'),
+      h('AT&amp;T expands fiber rollout across the Southeast', 'SomeBlog'),
+    ];
+    const out = dedupeHeadlines(items);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.extraSources.length, 1);
+  });
+
+  it('picks the highest-tier source as primary even when a lower-tier item appears first', () => {
+    // Lower tier number = better source. T4 arrives first/newer, T1 arrives second/older.
+    const items = [
+      h('Sanctions package advances in Brussels against major bank', 'RandoBlog', '2026-04-12T12:00:00Z', 4),
+      h('Sanctions package advances in Brussels against major bank', 'Reuters', '2026-04-12T09:00:00Z', 1),
+    ];
+    const out = dedupeHeadlines(items);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.item.source, 'Reuters');
+    assert.deepEqual(out[0]!.extraSources, ['RandoBlog']);
   });
 });


### PR DESCRIPTION
## Why this PR?
Partial fix for #2972. The Country Brief news list suffered from two user-visible problems that are independently addressable in the frontend: (a) the "Tier N" badge sat next to a severity badge with no explanation, producing confusing pairs like "Tier 4 HIGH" and "Tier 3 HIGH", and (b) the same story was shown once per wire service (Military Times + DefenseOne running the same Pentagon/FAA headline).

## Summary
- Normalize headline titles (lowercase, strip diacritics, drop punctuation, keep the first meaningful words) and collapse duplicates into one card that shows `+N sources` with a hover listing the extra outlets.
- Rename the ambiguous `Tier N` badge to `T{N} SRC` and add `title=` tooltips on both the source-tier badge and the severity badge, clarifying that source tier (credibility) and severity (how serious) are independent axes.
- Extract the dedupe helpers into `CountryDeepDivePanel-news-utils.ts` so they can be unit-tested without pulling in the full panel (which imports `i18n` and breaks under `node:test`).
- Add `tests/country-news-dedupe.test.mts` covering title normalization (casing, punctuation, diacritics) and dedupe behavior (multi-source merge, same-source idempotence).

## Out of scope (still open on #2972)
- Active Signals scoping vs global counts (bugs 2 and 3) — needs design call on whether to relabel or to exclude global clusters from the country panel.
- Country relevance filter investigation (bug 4) — the filter is already in place via `getCountrySearchTerms` / `firstMentionPosition`; reproducing the Kennedy Center case needs a specific alert snapshot.

## Test plan
- [x] `npx tsx --test tests/country-news-dedupe.test.mts` (5 pass)
- [x] `npx tsc --noEmit` clean
- [ ] Manual: open a country brief, confirm news cards show `T{N} SRC` badges with tooltips and that repeated stories collapse to a single card with `+N sources` meta.