### PR TITLE
polish(country-brief): unify empty copy, row color scale, unit suffixes, timeline clamp

### DIFF
--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -582,7 +582,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     if (!this.comtradeBody) return;
     this.comtradeBody.replaceChildren();
     if (!flows || flows.length === 0) {
-      this.comtradeBody.append(this.makeEmpty('No trade flow data available'));
+      this.comtradeBody.append(this.makeEmpty('No data available'));
       return;
     }
     const table = this.el('table', 'cdp-pro-flow-table');
@@ -635,7 +635,10 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.costShockCalcBody.replaceChildren();
 
     if (!data || (!data.sectors.length && !data.unavailableReason)) {
-      this.costShockCalcBody.append(this.makeEmpty('No multi-sector cost shock data'));
+      // Remove the card entirely to avoid showing an empty "Cost Shock" widget
+      // alongside the Trade Exposure sector table (issue #2973 bug 1).
+      this.costShockCalcBody.closest('.cdp-section-card')?.remove();
+      this.costShockCalcBody = null;
       return;
     }
 
@@ -787,7 +790,30 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     if (usd >= 1e12) return `$${(usd / 1e12).toFixed(1)}T`;
     if (usd >= 1e9) return `$${(usd / 1e9).toFixed(1)}B`;
     if (usd >= 1e6) return `$${(usd / 1e6).toFixed(1)}M`;
+    if (usd >= 1e3) return `$${(usd / 1e3).toFixed(1)}K`;
     return `$${Math.round(usd).toLocaleString()}`;
+  }
+
+  /**
+   * Format a USD value using the same scale as a reference value so row totals
+   * and supplier rows share a unit suffix (issue #2973 bug 5).
+   */
+  private formatMoneyAtScale(usd: number, referenceUsd: number): string {
+    if (referenceUsd >= 1e12) return `$${(usd / 1e12).toFixed(2)}T`;
+    if (referenceUsd >= 1e9) return `$${(usd / 1e9).toFixed(2)}B`;
+    if (referenceUsd >= 1e6) return `$${(usd / 1e6).toFixed(2)}M`;
+    if (referenceUsd >= 1e3) return `$${(usd / 1e3).toFixed(2)}K`;
+    return `$${Math.round(usd).toLocaleString()}`;
+  }
+
+  /**
+   * Shared exposure-score color scale used by vuln header and row scores
+   * (issue #2973 bug 4).
+   */
+  private static exposureScoreColor(score: number): string {
+    if (score >= 70) return 'var(--danger, #ef4444)';
+    if (score > 30) return 'var(--warning, #f59e0b)';
+    return 'var(--text-muted, #64748b)';
   }
 
   private formatPctTrend(pct: number): string {
@@ -1469,7 +1495,9 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
 
     this.tradeExposureBody.replaceChildren();
 
-    const vulnDiv = this.el('div', 'cdp-vuln-index', `Vulnerability: ${Math.round(data.vulnerabilityIndex)}/100`);
+    const vulnScore = Math.round(data.vulnerabilityIndex);
+    const vulnDiv = this.el('div', 'cdp-vuln-index', `Vulnerability: ${vulnScore}/100`);
+    vulnDiv.style.color = CountryDeepDivePanel.exposureScoreColor(vulnScore);
     this.tradeExposureBody.append(vulnDiv);
 
     if (sectors && sectors.length > 0) {
@@ -1501,9 +1529,8 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         const cpCell = this.el('td', 'cdp-chokepoint-name');
         cpCell.textContent = s.primaryChokepointName;
         const scoreCell = this.el('td', 'cdp-exposure-score');
-        const scoreColor = s.exposureScore >= 70 ? 'var(--danger, #ef4444)' : s.exposureScore > 30 ? 'var(--warning, #f59e0b)' : 'var(--text-muted, #64748b)';
         scoreCell.textContent = `${s.exposureScore.toFixed(0)}`;
-        scoreCell.style.color = scoreColor;
+        scoreCell.style.color = CountryDeepDivePanel.exposureScoreColor(s.exposureScore);
         tr.append(sectorCell, cpCell, scoreCell);
         tbody.append(tr);
 
@@ -1539,6 +1566,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         bar.style.width = `${Math.min(entry.exposureScore, 100)}%`;
         barWrap.append(bar);
         const pctCell = this.el('td', 'cdp-exposure-pct', `${entry.exposureScore.toFixed(1)}`);
+        pctCell.style.color = CountryDeepDivePanel.exposureScoreColor(entry.exposureScore);
         tr.append(nameCell, barWrap, pctCell);
         tbody.append(tr);
       }
@@ -1690,7 +1718,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     if (!this.productImportsBody) return;
     this.productImportsBody.replaceChildren();
     if (!data || data.products.length === 0) {
-      this.productImportsBody.append(this.makeEmpty('No product import data available'));
+      this.productImportsBody.append(this.makeEmpty('No data available'));
       return;
     }
     this.renderProductSelector(data.products);
@@ -1818,7 +1846,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         shareTd.append(barWrap);
         tr.append(shareTd);
 
-        tr.append(this.el('td', 'cdp-product-val', this.formatMoney(exp.value)));
+        tr.append(this.el('td', 'cdp-product-val', this.formatMoneyAtScale(exp.value, product.totalValue)));
 
         const riskTd = this.el('td', 'cdp-product-risk');
         if (exp.risk) {

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -637,7 +637,9 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     if (!data || (!data.sectors.length && !data.unavailableReason)) {
       // Remove the card entirely to avoid showing an empty "Cost Shock" widget
       // alongside the Trade Exposure sector table (issue #2973 bug 1).
-      this.costShockCalcBody.closest('.cdp-section-card')?.remove();
+      // sectionCard() creates a .cdp-card (not .cdp-section-card); parentElement
+      // is the card wrapper. Matches the updateTradeExposure cleanup pattern.
+      this.costShockCalcBody.parentElement?.remove();
       this.costShockCalcBody = null;
       return;
     }

--- a/src/components/CountryTimeline.ts
+++ b/src/components/CountryTimeline.ts
@@ -86,6 +86,15 @@ export class CountryTimeline {
     const width = this.container.clientWidth;
     if (width <= 0) return;
 
+    // Clamp timestamps to the visible 7-day domain so dots align with the
+    // axis labels they describe (issue #2973 bug 3). Events with missing or
+    // future timestamps would otherwise plot off-axis.
+    const nowMs = Date.now();
+    const domainStart = nowMs - SEVEN_DAYS_MS;
+    const visibleEvents = events
+      .filter((e) => Number.isFinite(e.timestamp) && e.timestamp >= domainStart)
+      .map((e) => (e.timestamp > nowMs ? { ...e, timestamp: nowMs } : e));
+
     const innerW = width - MARGIN.left - MARGIN.right;
     const innerH = HEIGHT - MARGIN.top - MARGIN.bottom;
 
@@ -100,10 +109,10 @@ export class CountryTimeline {
       .append('g')
       .attr('transform', `translate(${MARGIN.left},${MARGIN.top})`);
 
-    const now = Date.now();
+    const now = nowMs;
     const xScale = d3
       .scaleTime()
-      .domain([new Date(now - SEVEN_DAYS_MS), new Date(now)])
+      .domain([new Date(domainStart), new Date(now)])
       .range([0, innerW]);
 
     const yScale = d3
@@ -115,8 +124,8 @@ export class CountryTimeline {
     this.drawGrid(g, xScale, innerH);
     this.drawAxes(g, xScale, yScale, innerH);
     this.drawNowMarker(g, xScale, new Date(now), innerH);
-    this.drawEmptyLaneLabels(g, events, yScale, innerW);
-    this.drawEvents(g, events, xScale, yScale);
+    this.drawEmptyLaneLabels(g, visibleEvents, yScale, innerW);
+    this.drawEvents(g, visibleEvents, xScale, yScale);
   }
 
   private drawGrid(


### PR DESCRIPTION
## Why this PR?
Closes #2973 — the Country Brief / Country Deep Dive panels had several polish bugs: duplicated Cost Shock widgets, four different empty-state phrasings, unstyled row scores, mixed unit suffixes on supplier rows, and timeline dots drifting off their axis labels.

## Changes
- **Bug 1 (duplicate Cost Shock widgets)**: When the multi-sector cost-shock payload is empty, remove the Cost Shock Calculator card entirely (same pattern Trade Exposure already uses), so users no longer see both a "sector table" card and a separate empty "COST SHOCK" card at once.
- **Bug 2 (empty-state copy)**: Normalize Trade Flows and Product Imports empty-state strings to a single `"No data available"` phrase.
- **Bug 3 (protest dot misaligned)**: `CountryTimeline.render` now filters out non-finite timestamps and clamps events with timestamps past `now` back to `now`, using a single `nowMs` value shared by both the filter and the `xScale` domain so dots can never land outside the drawn axis.
- **Bug 4 (row score colors inconsistent)**: Extract `exposureScoreColor(score)` and apply it to the Vulnerability header, the sector rows, and the chokepoint fallback rows (Panama / Taiwan / Suez). All three now use one scale.
- **Bug 5 (mixed units)**: New `formatMoneyAtScale(value, referenceUsd)` helper picks the unit from the reference total so supplier rows carry the same `K` / `M` / `B` / `T` suffix as the product's header value. `formatMoney` also gains a `K` tier so small raw USD values no longer render as bare integers alongside `$15.6B` totals.
- **Bug 6 (timestamps)**: Already consistent via `formatRelativeTime` (`Xm` < 60 min, `Xh` < 24 h, `Xd` otherwise) — no change required.

## Test plan
- [x] `npm run typecheck:all`
- [x] `npm run test:data` — 4978 passing
- [x] Pre-push hook: typecheck, api typecheck, boundaries, edge-function tests, unicode safety all pass
- [ ] Visual: open a country with sector exposure data; confirm single Cost Shock card, colored Vulnerability header, consistent `$X.XXB` supplier values, and protest dots aligned with their axis labels