### PR TITLE
fix(news): title dedup + Tier badge tooltip for Country Brief (#2972)

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -252,12 +252,22 @@ export class CountryIntelManager implements AppModule {
       const ourPos = CountryIntelManager.firstMentionPosition(t, searchTerms);
       const otherPos = CountryIntelManager.firstMentionPosition(t, otherCountryTerms);
       return ourPos !== Infinity && (otherPos === Infinity || ourPos <= otherPos);
-    }).sort((a, b) => {
+    });
+    const seen = new Set<string>();
+    const deduped: typeof filteredNews = [];
+    for (const n of filteredNews) {
+      const normalized = n.title.toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/\s+/g, ' ').trim();
+      if (normalized.length > 0 && !seen.has(normalized)) {
+        seen.add(normalized);
+        deduped.push(n);
+      }
+    }
+    deduped.sort((a, b) => {
       const severityDelta = this.newsSeverityRank(b) - this.newsSeverityRank(a);
       if (severityDelta !== 0) return severityDelta;
       return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
     });
-    this.ctx.countryBriefPage.updateNews(filteredNews.slice(0, 10));
+    this.ctx.countryBriefPage.updateNews(deduped.slice(0, 10));
 
     this.ctx.countryBriefPage.updateInfrastructure(code);
 

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -253,6 +253,12 @@ export class CountryIntelManager implements AppModule {
       const otherPos = CountryIntelManager.firstMentionPosition(t, otherCountryTerms);
       return ourPos !== Infinity && (otherPos === Infinity || ourPos <= otherPos);
     });
+    // Sort by severity then recency BEFORE deduplication so the highest-quality item wins dedup
+    filteredNews.sort((a, b) => {
+      const severityDelta = this.newsSeverityRank(b) - this.newsSeverityRank(a);
+      if (severityDelta !== 0) return severityDelta;
+      return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
+    });
     const seen = new Set<string>();
     const deduped: typeof filteredNews = [];
     for (const n of filteredNews) {
@@ -262,11 +268,6 @@ export class CountryIntelManager implements AppModule {
         deduped.push(n);
       }
     }
-    deduped.sort((a, b) => {
-      const severityDelta = this.newsSeverityRank(b) - this.newsSeverityRank(a);
-      if (severityDelta !== 0) return severityDelta;
-      return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
-    });
     this.ctx.countryBriefPage.updateNews(deduped.slice(0, 10));
 
     this.ctx.countryBriefPage.updateInfrastructure(code);

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -339,7 +339,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
 
       const top = this.el('div', 'cdp-news-top');
       const tier = item.tier ?? getSourceTier(item.source);
-      top.append(this.badge(`Tier ${tier}`, `cdp-tier-badge tier-${Math.max(1, Math.min(4, tier))}`));
+      top.append(this.badge(`Tier ${tier}`, `cdp-tier-badge tier-${Math.max(1, Math.min(4, tier))}`, t('countryBrief.tierBadgeTooltip')));
 
       const severity = this.toThreatLevel(item.threat?.level);
       const levelKey = severity === 'info' ? 'low' : severity === 'medium' ? 'moderate' : severity;
@@ -2472,8 +2472,10 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     return this.el('div', 'cdp-empty', text);
   }
 
-  private badge(text: string, className: string): HTMLElement {
-    return this.el('span', className, text);
+  private badge(text: string, className: string, title?: string): HTMLElement {
+    const el = this.el('span', className, text);
+    if (title) el.title = title;
+    return el;
   }
 
   private formatBrief(text: string, headlineCount = 0): string {

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "أسواق التنبؤ",
     "loadingMarkets": "جارٍ تحميل أسواق التنبؤ...",
     "infrastructure": "التعرض البنيوي",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "الموجز الذكي غير متاح — قم بتهيئة GROQ_API_KEY في الإعدادات.",
     "cached": "مخزّن مؤقتاً",
     "fresh": "محدّث",
@@ -2503,5 +2504,6 @@
   "contextMenu": {
     "openCountryBrief": "فتح ملخص البلد",
     "copyCoordinates": "نسخ الإحداثيات"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "Пазари на предвиждане",
     "loadingMarkets": "Зареждане на пазарите на предвиждане...",
     "infrastructure": "Експозиция на инфраструктура",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "AI преглед недостъпен — конфигурирайте GROQ_API_KEY в Settings.",
     "cached": "Кеширан",
     "fresh": "Свеж",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "Отвори обзор на страната",
     "copyCoordinates": "Копирай координати"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "Predikční trhy",
     "loadingMarkets": "Načítám predikční trhy...",
     "infrastructure": "Ohrožení infrastruktury",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "AI svodka není k dispozici — nastavte GROQ_API_KEY v Nastavení.",
     "cached": "Z mezipaměti",
     "fresh": "Aktuální",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "Otevřít přehled země",
     "copyCoordinates": "Kopírovat souřadnice"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "Prognosemärkte",
     "loadingMarkets": "Prognosemärkte werden geladen...",
     "infrastructure": "Infrastrukturexposition",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "KI-Brief nicht verfügbar – konfigurieren Sie GROQ_API_KEY in den Einstellungen.",
     "cached": "Zwischengespeichert",
     "fresh": "Aktuell",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "Länderübersicht öffnen",
     "copyCoordinates": "Koordinaten kopieren"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "Αγορές Προβλέψεων",
     "loadingMarkets": "Φόρτωση αγορών προβλέψεων...",
     "infrastructure": "Έκθεση Υποδομών",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "Ενημέρωση AI μη διαθέσιμη — ρυθμίστε το GROQ_API_KEY στις Ρυθμίσεις.",
     "cached": "Αποθηκευμένο",
     "fresh": "Πρόσφατο",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "Άνοιγμα επισκόπησης χώρας",
     "copyCoordinates": "Αντιγραφή συντεταγμένων"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -81,6 +81,7 @@
     "predictionMarkets": "Prediction Markets",
     "loadingMarkets": "Loading prediction markets...",
     "infrastructure": "Infrastructure Exposure",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "AI brief unavailable — configure GROQ_API_KEY in Settings.",
     "cached": "Cached",
     "fresh": "Fresh",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "Mercados de predicción",
     "loadingMarkets": "Cargando mercados de predicción...",
     "infrastructure": "Exposición de infraestructura",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "Resumen de IA no disponible: configure GROQ_API_KEY en Configuración.",
     "cached": "En caché",
     "fresh": "Actual",
@@ -2503,5 +2504,6 @@
   "contextMenu": {
     "openCountryBrief": "Abrir resumen del país",
     "copyCoordinates": "Copiar coordenadas"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "Marchés de prédiction",
     "loadingMarkets": "Chargement des marchés...",
     "infrastructure": "Exposition infrastructure",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "Brief IA indisponible — configurez GROQ_API_KEY dans les paramètres.",
     "cached": "En cache",
     "fresh": "Frais",
@@ -2511,5 +2512,6 @@
   "contextMenu": {
     "openCountryBrief": "Ouvrir la fiche pays",
     "copyCoordinates": "Copier les coordonnées"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "Mercati predittivi",
     "loadingMarkets": "Caricamento mercati predittivi...",
     "infrastructure": "Esposizione infrastrutturale",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "Rapporto IA non disponibile — configura GROQ_API_KEY nelle Impostazioni.",
     "cached": "In cache",
     "fresh": "Aggiornato",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "Apri scheda paese",
     "copyCoordinates": "Copia coordinate"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "予測市場",
     "loadingMarkets": "予測市場を読み込み中...",
     "infrastructure": "インフラ露出度",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "AIブリーフ利用不可 — 設定でGROQ_API_KEYを構成してください。",
     "cached": "キャッシュ済",
     "fresh": "最新",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "国の概要を開く",
     "copyCoordinates": "座標をコピー"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "예측 시장",
     "loadingMarkets": "예측 시장 불러오는 중...",
     "infrastructure": "인프라 노출",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "AI 브리핑 불가 — 설정에서 GROQ_API_KEY를 구성하세요.",
     "cached": "캐시됨",
     "fresh": "최신",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "국가 개요 열기",
     "copyCoordinates": "좌표 복사"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -2366,6 +2366,7 @@
     "predictionMarkets": "Voorspellingsmarkten",
     "loadingMarkets": "Voorspellingsmarkten laden...",
     "infrastructure": "Blootstelling aan infrastructuur",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "AI-overzicht niet beschikbaar — configureer GROQ_API_KEY in Instellingen.",
     "cached": "In cache",
     "fresh": "Vers",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "Landenoverzicht openen",
     "copyCoordinates": "Coördinaten kopiëren"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "Rynki prognostyczne",
     "loadingMarkets": "Ładowanie rynków prognostycznych...",
     "infrastructure": "Ekspozycja infrastruktury",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "Raport AI niedostępny — skonfiguruj GROQ_API_KEY w Ustawieniach.",
     "cached": "Z pamięci podręcznej",
     "fresh": "Aktualne",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "Otwórz przegląd kraju",
     "copyCoordinates": "Kopiuj współrzędne"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -2366,6 +2366,7 @@
     "predictionMarkets": "Mercados de Previsão",
     "loadingMarkets": "Carregando mercados de previsão...",
     "infrastructure": "Exposição de Infraestrutura",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "Resumo de IA indisponível — configure GROQ_API_KEY em Configurações.",
     "cached": "Em cache",
     "fresh": "Atualizado",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "Abrir resumo do país",
     "copyCoordinates": "Copiar coordenadas"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "Piețe de predicții",
     "loadingMarkets": "Se încarcă piețele de predicții...",
     "infrastructure": "Expunerea infrastructurii",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "Brief AI indisponibil — configurați GROQ_API_KEY în Setări.",
     "cached": "În cache",
     "fresh": "Proaspăt",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "Deschide prezentarea țării",
     "copyCoordinates": "Copiază coordonatele"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "Рынки прогнозов",
     "loadingMarkets": "Загрузка рынков прогнозов...",
     "infrastructure": "Инфраструктурная уязвимость",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "ИИ-сводка недоступна — настройте GROQ_API_KEY в Настройках.",
     "cached": "Кэш",
     "fresh": "Свежие",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "Открыть обзор страны",
     "copyCoordinates": "Скопировать координаты"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -2366,6 +2366,7 @@
     "predictionMarkets": "Förutsägelsemarknader",
     "loadingMarkets": "Laddar förutsägelsemarknader...",
     "infrastructure": "Infrastrukturexponering",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "AI-sammanfattning ej tillgänglig — konfigurera GROQ_API_KEY i Inställningar.",
     "cached": "Cachelagrad",
     "fresh": "Aktuell",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "Öppna landsöversikt",
     "copyCoordinates": "Kopiera koordinater"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "ตลาดพยากรณ์",
     "loadingMarkets": "กำลังโหลดตลาดพยากรณ์...",
     "infrastructure": "โครงสร้างพื้นฐานที่เปิดเผย",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "สรุป AI ไม่พร้อมใช้งาน — กรุณาตั้งค่า GROQ_API_KEY ในการตั้งค่า",
     "cached": "แคชแล้ว",
     "fresh": "ใหม่",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "เปิดภาพรวมประเทศ",
     "copyCoordinates": "คัดลอกพิกัด"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "Tahmin Piyasalari",
     "loadingMarkets": "Tahmin piyasalari yukleniyor...",
     "infrastructure": "Altyapi Maruziyeti",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "Yapay zeka brifingi kullanilamaz — Ayarlar'dan GROQ_API_KEY yapilandiriniz.",
     "cached": "Onbellekten",
     "fresh": "Guncel",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "Ülke özetini aç",
     "copyCoordinates": "Koordinatları kopyala"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "Thị trường Dự đoán",
     "loadingMarkets": "Đang tải thị trường dự đoán...",
     "infrastructure": "Mức độ phơi bày Hạ tầng",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "Bản tin AI không khả dụng — cấu hình GROQ_API_KEY trong Cài đặt.",
     "cached": "Đã lưu cache",
     "fresh": "Mới cập nhật",
@@ -2502,5 +2503,6 @@
   "contextMenu": {
     "openCountryBrief": "Mở tổng quan quốc gia",
     "copyCoordinates": "Sao chép tọa độ"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -20,6 +20,7 @@
     "predictionMarkets": "预测市场",
     "loadingMarkets": "正在加载预测市场...",
     "infrastructure": "基础设施暴露",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "AI简报不可用 — 请在设置中配置GROQ_API_KEY。",
     "cached": "已缓存",
     "fresh": "最新",
@@ -2503,5 +2504,6 @@
   "contextMenu": {
     "openCountryBrief": "打开国家简报",
     "copyCoordinates": "复制坐标"
-  }
+  },
+  "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
 }


### PR DESCRIPTION
## Summary
Fixes two of five acceptance criteria from issue #2972:

1. **Tier badge tooltip (AC5)**: Tier badge now has a native HTML title attribute explaining "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources"
2. **News deduplication (AC3)**: News items with the same normalized title are now collapsed to a single card before rendering

## Changes
- `src/components/CountryDeepDivePanel.ts`: Extend badge() helper to accept optional title param; Tier badge now passes hover tooltip
- `src/app/country-intel.ts`: Deduplicate filtered news by normalized title (strip punctuation/whitespace) before passing to updateNews()
- `src/locales/en.json`: Add tierBadgeTooltip i18n string

## Remaining (non-blocking)
- AC1: Active Signals count appears global — requires further signalAggregator scoping
- AC2: Aggregate count mismatch — tracked separately  
- AC4: Turkey filter includes Kennedy Center — requires first-mention position tightening