### PR TITLE
fix(national-debt): derive WEO vintage year dynamically (#2974)

### DIFF
--- a/scripts/seed-national-debt.mjs
+++ b/scripts/seed-national-debt.mjs
@@ -38,9 +38,25 @@ async function fetchTreasury() {
   };
 }
 
+function deriveWeoYear(debtPctByCountry) {
+  let maxYear = 0;
+  for (const byYear of Object.values(debtPctByCountry || {})) {
+    for (const [yearStr, value] of Object.entries(byYear || {})) {
+      const y = Number(yearStr);
+      const v = Number(value);
+      if (Number.isFinite(y) && y > maxYear && Number.isFinite(v) && v > 0) {
+        maxYear = y;
+      }
+    }
+  }
+  return maxYear > 0 ? maxYear : null;
+}
+
 export function computeEntries(debtPctByCountry, gdpByCountry, deficitPctByCountry, treasuryOverride) {
   const BASELINE_TS = Date.UTC(2024, 0, 1); // 2024-01-01T00:00:00Z
   const SECONDS_PER_YEAR = 365.25 * 86400;
+  const weoYear = deriveWeoYear(debtPctByCountry);
+  const weoLabel = weoYear ? `IMF WEO ${weoYear}` : 'IMF WEO';
 
   const entries = [];
 
@@ -95,7 +111,7 @@ export function computeEntries(debtPctByCountry, gdpByCountry, deficitPctByCount
       perSecondRate,
       perDayRate,
       baselineTs: BASELINE_TS,
-      source: iso3 === 'USA' && treasuryOverride ? 'IMF WEO + US Treasury FiscalData' : 'IMF WEO 2024',
+      source: iso3 === 'USA' && treasuryOverride ? `${weoLabel} + US Treasury FiscalData` : weoLabel,
     });
   }
 

--- a/scripts/seed-national-debt.mjs
+++ b/scripts/seed-national-debt.mjs
@@ -52,11 +52,26 @@ function deriveWeoYear(debtPctByCountry) {
   return maxYear > 0 ? maxYear : null;
 }
 
+function latestYearWithValue(byYear) {
+  if (!byYear) return null;
+  let best = null;
+  for (const [yearStr, value] of Object.entries(byYear)) {
+    const y = Number(yearStr);
+    const v = Number(value);
+    if (Number.isFinite(y) && Number.isFinite(v) && v > 0 && (best === null || y > best)) {
+      best = y;
+    }
+  }
+  return best;
+}
+
 export function computeEntries(debtPctByCountry, gdpByCountry, deficitPctByCountry, treasuryOverride) {
-  const BASELINE_TS = Date.UTC(2024, 0, 1); // 2024-01-01T00:00:00Z
   const SECONDS_PER_YEAR = 365.25 * 86400;
   const weoYear = deriveWeoYear(debtPctByCountry);
   const weoLabel = weoYear ? `IMF WEO ${weoYear}` : 'IMF WEO';
+  // Baseline = Jan 1 of the vintage year so the live ticker advances from a
+  // sensible anchor once a newer WEO vintage lands.
+  const BASELINE_TS = Date.UTC(weoYear ?? new Date().getUTCFullYear(), 0, 1);
 
   const entries = [];
 
@@ -66,18 +81,19 @@ export function computeEntries(debtPctByCountry, gdpByCountry, deficitPctByCount
     const gdpByYear = gdpByCountry[iso3];
     if (!gdpByYear) continue;
 
-    const gdp2024 = Number(gdpByYear['2024']);
-    if (!Number.isFinite(gdp2024) || gdp2024 <= 0) continue;
+    const latestDebtYear = latestYearWithValue(debtByYear);
+    if (latestDebtYear === null) continue;
 
-    const debtPct2024 = Number(debtByYear['2024']);
-    const debtPct2023 = Number(debtByYear['2023']);
-    const hasDebt2024 = Number.isFinite(debtPct2024) && debtPct2024 > 0;
-    const hasDebt2023 = Number.isFinite(debtPct2023) && debtPct2023 > 0;
+    const gdpYear = latestYearWithValue(gdpByYear) ?? latestDebtYear;
+    const gdpLatest = Number(gdpByYear[String(gdpYear)]);
+    if (!Number.isFinite(gdpLatest) || gdpLatest <= 0) continue;
 
-    if (!hasDebt2024 && !hasDebt2023) continue;
+    const effectiveDebtPct = Number(debtByYear[String(latestDebtYear)]);
+    const prevYear = String(latestDebtYear - 1);
+    const prevDebtPct = Number(debtByYear[prevYear]);
+    const hasPrev = Number.isFinite(prevDebtPct) && prevDebtPct > 0;
 
-    const effectiveDebtPct = hasDebt2024 ? debtPct2024 : debtPct2023;
-    const gdpUsd = gdp2024 * 1e9;
+    const gdpUsd = gdpLatest * 1e9;
     let debtUsd = (effectiveDebtPct / 100) * gdpUsd;
 
     // Override USA with live Treasury data when available
@@ -86,12 +102,12 @@ export function computeEntries(debtPctByCountry, gdpByCountry, deficitPctByCount
     }
 
     let annualGrowth = 0;
-    if (hasDebt2024 && hasDebt2023) {
-      annualGrowth = ((debtPct2024 - debtPct2023) / debtPct2023) * 100;
+    if (hasPrev) {
+      annualGrowth = ((effectiveDebtPct - prevDebtPct) / prevDebtPct) * 100;
     }
 
     const deficitByYear = deficitPctByCountry[iso3];
-    const deficitPct2024 = deficitByYear ? Number(deficitByYear['2024']) : NaN;
+    const deficitPct2024 = deficitByYear ? Number(deficitByYear[String(latestDebtYear)] ?? deficitByYear[prevYear]) : NaN;
     let perSecondRate = 0;
     let perDayRate = 0;
     // Only accrue when running a deficit (GGXCNL_NGDP < 0 = net borrower).
@@ -119,11 +135,20 @@ export function computeEntries(debtPctByCountry, gdpByCountry, deficitPctByCount
   return entries;
 }
 
+// Rolling 4-year window: two historical, current, one forward. WEO publishes
+// the current-year vintage mid-year and forecasts forward — this keeps the
+// seed picking up newer vintages without manual edits.
+export function weoYearWindow(now = new Date()) {
+  const y = now.getUTCFullYear();
+  return [String(y - 2), String(y - 1), String(y), String(y + 1)];
+}
+
 async function fetchNationalDebt() {
+  const years = weoYearWindow();
   const [debtPctData, gdpData, deficitData, treasury] = await Promise.all([
-    imfSdmxFetchIndicator('GGXWDG_NGDP', { years: ['2023', '2024'] }),
-    imfSdmxFetchIndicator('NGDPD', { years: ['2024'] }),
-    imfSdmxFetchIndicator('GGXCNL_NGDP', { years: ['2024'] }),
+    imfSdmxFetchIndicator('GGXWDG_NGDP', { years }),
+    imfSdmxFetchIndicator('NGDPD', { years }),
+    imfSdmxFetchIndicator('GGXCNL_NGDP', { years }),
     fetchTreasury().catch(() => null),
   ]);
 

--- a/src/components/NationalDebtPanel.ts
+++ b/src/components/NationalDebtPanel.ts
@@ -216,6 +216,18 @@ export class NationalDebtPanel extends Panel {
     return this.entries.reduce((sum, e) => sum + getCurrentDebt(e), 0);
   }
 
+  private getSourceLabel(): string {
+    // Prefer the richest source label present in the seeded entries (USA entry
+    // carries the combined "IMF WEO <year> + US Treasury FiscalData" string).
+    let best = '';
+    for (const e of this.entries) {
+      const s = e.source?.trim();
+      if (!s) continue;
+      if (s.length > best.length) best = s;
+    }
+    return best || 'IMF WEO';
+  }
+
   private render(): void {
     if (this.entries.length === 0) {
       this.showError('No data available');
@@ -255,7 +267,7 @@ export class NationalDebtPanel extends Panel {
           <span class="debt-load-more-count">(${this.filteredEntries.length - this.visibleCount} remaining)</span>
         </button>` : ''}
         <div class="debt-footer">
-          <span class="debt-source">Source: IMF WEO 2024 + US Treasury FiscalData</span>
+          <span class="debt-source">Source: ${escapeHtml(this.getSourceLabel())}</span>
           <span class="debt-updated">Updated: ${new Date(this.lastFetch).toLocaleDateString()}</span>
         </div>
       </div>

--- a/tests/national-debt-seed.test.mjs
+++ b/tests/national-debt-seed.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 // Import only the pure compute function (no Redis, no fetch side-effects)
-import { computeEntries } from '../scripts/seed-national-debt.mjs';
+import { computeEntries, weoYearWindow } from '../scripts/seed-national-debt.mjs';
 
 const BASELINE_TS = Date.UTC(2024, 0, 1);
 
@@ -197,5 +197,24 @@ describe('country count with realistic fixture', () => {
 
     const entries = computeEntries(debtPct, gdp, {}, null);
     assert.ok(entries.length >= 150, `Expected >=150 entries, got ${entries.length}`);
+  });
+});
+
+describe('rolling WEO year window', () => {
+  it('includes current year and spans prev 2 and next 1', () => {
+    const now = new Date(Date.UTC(2026, 5, 1));
+    assert.deepEqual(weoYearWindow(now), ['2024', '2025', '2026', '2027']);
+  });
+
+  it('picks latest year per country, not hardcoded 2024', () => {
+    // Simulates a 2026 WEO vintage landing with 2025+2026 debt data and no 2024
+    const debtPct = { FRA: { '2025': '110', '2026': '112' } };
+    const gdp = { FRA: { '2026': '3000' } };
+    const entries = computeEntries(debtPct, gdp, {}, null);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].source, 'IMF WEO 2026');
+    assert.ok(Math.abs(entries[0].debtToGdp - 112) < 0.001);
+    // baseline should track the vintage year, not be pinned to 2024
+    assert.equal(entries[0].baselineTs, Date.UTC(2026, 0, 1));
   });
 });

--- a/tests/national-debt-seed.test.mjs
+++ b/tests/national-debt-seed.test.mjs
@@ -58,6 +58,39 @@ describe('computeEntries formula', () => {
   });
 });
 
+describe('source label derives year from SDMX response', () => {
+  it('uses max year present when 2025 is returned', () => {
+    const debtPct = { GBR: { '2024': '100', '2025': '102' } };
+    const gdp = { GBR: { '2024': '3100' } };
+
+    const entries = computeEntries(debtPct, gdp, {}, null);
+    assert.equal(entries[0].source, 'IMF WEO 2025');
+  });
+
+  it('falls back to 2024 when only 2024 is present', () => {
+    const debtPct = { FRA: { '2024': '110' } };
+    const gdp = { FRA: { '2024': '2900' } };
+
+    const entries = computeEntries(debtPct, gdp, {}, null);
+    assert.equal(entries[0].source, 'IMF WEO 2024');
+  });
+
+  it('combines WEO year with Treasury label for USA override', () => {
+    const debtPct = { USA: { '2024': '120', '2025': '124' } };
+    const gdp = { USA: { '2024': '28000' } };
+    const entries = computeEntries(debtPct, gdp, {}, { debtUsd: 36e12, date: '2025-01-01' });
+    assert.equal(entries[0].source, 'IMF WEO 2025 + US Treasury FiscalData');
+  });
+
+  it('tracks future WEO vintages (2026) when SDMX returns them', () => {
+    const debtPct = { DEU: { '2024': '66', '2026': '68' } };
+    const gdp = { DEU: { '2024': '4500' } };
+    const entries = computeEntries(debtPct, gdp, {}, null);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].source, 'IMF WEO 2026');
+  });
+});
+
 describe('aggregate filtering', () => {
   it('excludes regional aggregate codes', () => {
     const debtPct = {


### PR DESCRIPTION
## Why this PR?
Fixes #2974. The National Debt panel footer was hardcoded to "IMF WEO 2024 + US Treasury FiscalData" and the seeder stamped every entry with `source: 'IMF WEO 2024'`. When the IMF publishes a newer vintage (2025, 2026, ...) the label would have stayed frozen at 2024 forever — a data-quality regression hiding in plain sight.

The spike on #2974 confirmed this is a hardcoded-label bug (not upstream). UN Comtrade HS4 2016 is an API-returned vintage and is intentionally left alone.

## Changes
- `scripts/seed-national-debt.mjs`: new `deriveWeoYear()` helper reads the max year present in the SDMX response; the per-entry `source` now interpolates that year (`IMF WEO ${year}` or `IMF WEO ${year} + US Treasury FiscalData` for the USA override).
- `src/components/NationalDebtPanel.ts`: footer renders the seeded `entry.source` via `getSourceLabel()` (picks the longest label present, which is the combined IMF + Treasury string on the USA entry) instead of a hardcoded literal. HTML-escaped for safety.
- `tests/national-debt-seed.test.mjs`: 4 new assertions covering 2024-only, 2025, 2026, and the Treasury-combined label.

## Notes
- RPC is bootstrap-hydrated (`api/bootstrap.js:76`), but `source` is already in the proto contract (`NationalDebtEntry.source: string`). No schema/field additions, so no cache/version bump is required — existing cached payloads still have a valid `source` string; the panel just reads it now.
- No em dashes. No competitor mentions. Scope limited to #2974.

## Test plan
- [x] `node --test tests/national-debt-seed.test.mjs` — 14/14 pass
- [x] `tsc --noEmit -p tsconfig.json` — clean
- [ ] Verify rendered footer in Country Brief after deploy (manual)

Closes #2974