### PR TITLE
fix(resilience): unbreak validation cron — Node 22 tsx loader path

### DIFF
--- a/Dockerfile.seed-bundle-resilience-validation
+++ b/Dockerfile.seed-bundle-resilience-validation
@@ -4,33 +4,46 @@
 # Runs scripts/seed-bundle-resilience-validation.mjs which spawns:
 #   - benchmark-resilience-external.mjs
 #   - backtest-resilience-outcomes.mjs
-#   - validate-resilience-sensitivity.mjs (imports from ../server/ via tsx)
+#   - validate-resilience-sensitivity.mjs (imports ../server/*.ts via tsx)
 #
-# Needs both scripts/ and server/ in the container + tsx resolvable from /app/.
+# The validation scripts only touch node: builtins, local helpers, and .ts
+# files under ../server/ via dynamic import. The ONLY external runtime dep
+# is tsx (to register the ESM loader for .ts imports).
 # =============================================================================
 
 FROM node:22-alpine
 
 WORKDIR /app
 
-# Root dependencies (includes tsx in devDependencies — install all for build-time
-# access, then prune won't help because tsx is needed at runtime). Install with
-# NODE_ENV unset so devDependencies land in /app/node_modules.
-COPY package.json package-lock.json ./
-RUN NODE_ENV=development npm ci --ignore-scripts --no-audit --no-fund
+# Install only tsx at /app/node_modules/tsx. Single-package install keeps the
+# image small and eliminates the previous ambiguity where tsx existed at both
+# /app/node_modules and /app/scripts/node_modules and Node 22 resolved the
+# wrong one (which had an incomplete dist/). The test is a build-time assert
+# that tsx's ESM loader is at the path referenced by NODE_OPTIONS below.
+RUN npm install --prefix /app --no-save --no-audit --no-fund --no-package-lock tsx@4.21.0 \
+    && test -f /app/node_modules/tsx/dist/loader.mjs
 
-# Scripts/ dependencies (telegram, fast-xml-parser, resend, etc. — most are
-# not needed by validation, but keep parity with nixpacks behavior)
-COPY scripts/package.json scripts/package-lock.json ./scripts/
-RUN npm ci --prefix scripts --omit=dev --no-audit --no-fund
-
-# Copy scripts + server + shared + data (everything the validation bundle touches)
-COPY scripts/ ./scripts/
+# Copy only the scripts the bundle actually runs + their local helpers.
+# _seed-utils.mjs eagerly createRequire()s _proxy-utils.cjs at module load,
+# so the .cjs helper must ship alongside even if unused by these validators.
+# validate-resilience-sensitivity.mjs dynamic-imports ../server/*.ts so the
+# full server/ tree is copied (scorers pull from shared/ and data/ at runtime).
+COPY scripts/_seed-utils.mjs scripts/_bundle-runner.mjs scripts/_proxy-utils.cjs ./scripts/
+COPY scripts/seed-bundle-resilience-validation.mjs ./scripts/
+COPY scripts/benchmark-resilience-external.mjs ./scripts/
+COPY scripts/backtest-resilience-outcomes.mjs ./scripts/
+COPY scripts/validate-resilience-sensitivity.mjs ./scripts/
 COPY server/ ./server/
 COPY shared/ ./shared/
 COPY data/ ./data/
 COPY tsconfig.json tsconfig.api.json ./
 
-ENV NODE_OPTIONS="--max-old-space-size=8192 --dns-result-order=ipv4first --import tsx/esm"
+# Absolute path sidesteps bare-specifier resolution entirely — Node 22 can
+# resolve "tsx/esm" to the wrong node_modules when multiple exist, and "tsx/esm"
+# also triggers ERR_REQUIRE_CYCLE_MODULE under Node 22 when the loaded .ts
+# has its own imports. dist/loader.mjs is tsx's default ESM loader and works
+# for both the parent process and children spawned via execFile (which inherit
+# NODE_OPTIONS).
+ENV NODE_OPTIONS="--max-old-space-size=8192 --dns-result-order=ipv4first --import=file:///app/node_modules/tsx/dist/loader.mjs"
 
 CMD ["node", "scripts/seed-bundle-resilience-validation.mjs"]

--- a/scripts/seed-bundle-resilience-validation.mjs
+++ b/scripts/seed-bundle-resilience-validation.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
-// Railway: rootDirectory="" + NIXPACKS builder + NODE_OPTIONS --import tsx/esm
+// Railway: dockerfilePath=Dockerfile.seed-bundle-resilience-validation.
+// The Dockerfile wires NODE_OPTIONS --import to tsx's loader via absolute
+// path so that dynamic imports of ../server/*.ts work in spawned children.
 import { runBundle, WEEK } from './_bundle-runner.mjs';
 
 await runBundle('resilience-validation', [


### PR DESCRIPTION
## Why this PR?

The `seed-bundle-resilience-validation` Railway cron has been crashing since creation (PR #2988), and the follow-up fixes in #3023 (Nixpacks) and #3031 (dedicated Dockerfile) didn't unblock it. Logs keep showing:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/scripts/node_modules/tsx/dist/esm/index.mjs' imported from /app/
```

Two separate Node-22 bugs were compounding. Both are fixed here.

## Root cause

**Bug 1 — tsx resolution ambiguity.** The previous Dockerfile installed tsx at both `/app/node_modules/tsx/` (root devDeps via `NODE_ENV=development npm ci`) and `/app/scripts/node_modules/tsx/` (scripts deps via `npm ci --prefix scripts`). When Node resolved `--import tsx/esm`, it found the wrong copy whose `dist/` was incomplete.

**Bug 2 — `tsx/esm` triggers `ERR_REQUIRE_CYCLE_MODULE` on Node 22.** Even with a clean install, `tsx/esm` (`dist/esm/index.mjs`) errors out as soon as the loaded `.ts` graph has its own imports — tsx's esm-only loader uses `require()` internally and Node 22's stricter require-of-esm cycle detection rejects it. Reproduced locally against `node-v22.22.2`:

```
Error [ERR_REQUIRE_CYCLE_MODULE]: Cannot require() ES Module /.../server/scorer.ts in a cycle.
```

Switching `--import` to tsx's default export (`dist/loader.mjs`) sidesteps both the cycle and the bare-specifier resolution.

## Fix summary

- Install only tsx at `/app/node_modules/tsx/` via `npm install --prefix /app --no-save --no-package-lock tsx@4.21.0` (no more double-install).
- `ENV NODE_OPTIONS=--import=file:///app/node_modules/tsx/dist/loader.mjs` — absolute path, default export.
- Build-time `test -f /app/node_modules/tsx/dist/loader.mjs` fails the image build if tsx is missing.
- Copy only the scripts the bundle actually touches, including `_proxy-utils.cjs` (which `_seed-utils.mjs` top-level `createRequire`s).

Net: smaller image, single tsx install, no cycle error.

## Verification

Ran the full bundle end-to-end against Node 22.22.2 with the same install layout the Dockerfile produces:

```
[Bundle:resilience-validation] Starting (3 sections)
  [External-Benchmark] Done (0.8s)
  [Outcome-Backtest] Done (2.2s)
  [Sensitivity-Suite] === PASS 1..4 === Max top-50 rank swing: 5/7/7
```

All three validators complete. Redis misses are expected locally (no UPSTASH env).

## Test plan

- [ ] After merge, confirm the next scheduled Railway cron run completes without `ERR_MODULE_NOT_FOUND` / `ERR_REQUIRE_CYCLE_MODULE`.
- [ ] Confirm validation artifacts (`data/validation/*`) update on the weekly cadence.
- [ ] Tests: `node --test tests/seed-bundle-resilience-validation.test.mjs` (6/6 pass).