### PR TITLE
fix(country-brief): Active Signals count 'near' military assets (#2972 bug 2)

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -930,11 +930,19 @@ export class CountryIntelManager implements AppModule {
 
     let militaryFlights = 0;
     let militaryVessels = 0;
+    let militaryFlightsInCountry = 0;
+    let militaryVesselsInCountry = 0;
     if (this.ctx.intelligenceCache.military) {
       militaryFlights = this.ctx.intelligenceCache.military.flights.filter((f) =>
-        hasGeoShape ? this.isInCountry(f.lat, f.lon, code) : f.operatorCountry?.toUpperCase() === code
+        hasGeoShape ? this.isNearCountry(f.lat, f.lon, code) : f.operatorCountry?.toUpperCase() === code
       ).length;
       militaryVessels = this.ctx.intelligenceCache.military.vessels.filter((v) =>
+        hasGeoShape ? this.isNearCountry(v.lat, v.lon, code) : v.operatorCountry?.toUpperCase() === code
+      ).length;
+      militaryFlightsInCountry = this.ctx.intelligenceCache.military.flights.filter((f) =>
+        hasGeoShape ? this.isInCountry(f.lat, f.lon, code) : f.operatorCountry?.toUpperCase() === code
+      ).length;
+      militaryVesselsInCountry = this.ctx.intelligenceCache.military.vessels.filter((v) =>
         hasGeoShape ? this.isInCountry(v.lat, v.lon, code) : v.operatorCountry?.toUpperCase() === code
       ).length;
     }
@@ -1013,6 +1021,8 @@ export class CountryIntelManager implements AppModule {
       protests,
       militaryFlights,
       militaryVessels,
+      militaryFlightsInCountry,
+      militaryVesselsInCountry,
       outages,
       aisDisruptions: signalTypeCounts.aisDisruptions,
       satelliteFires: signalTypeCounts.satelliteFires,
@@ -1265,6 +1275,18 @@ export class CountryIntelManager implements AppModule {
     const b = CountryIntelManager.COUNTRY_BOUNDS[code];
     if (!b) return false;
     return lat >= b.s && lat <= b.n && lon >= b.w && lon <= b.e;
+  }
+
+  // Near = bounding-box padded by ~2° (~220 km). Captures vessels/aircraft in
+  // adjacent waters/airspace so the risk chip reflects proximity, not just
+  // strict territory. See issue #2972 bug 2.
+  private static readonly NEAR_BUFFER_DEG = 2;
+  private isNearCountry(lat: number, lon: number, code: string): boolean {
+    if (this.isInCountry(lat, lon, code)) return true;
+    const b = CountryIntelManager.COUNTRY_BOUNDS[code];
+    if (!b) return false;
+    const pad = CountryIntelManager.NEAR_BUFFER_DEG;
+    return lat >= b.s - pad && lat <= b.n + pad && lon >= b.w - pad && lon <= b.e + pad;
   }
 
   static COUNTRY_BOUNDS: Record<string, { n: number; s: number; e: number; w: number }> = {

--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -237,8 +237,14 @@ export class CountryBriefPage implements CountryBriefPanel {
     const chips: string[] = [];
     if (signals.criticalNews > 0) chips.push(`<span class="signal-chip conflict">🚨 ${signals.criticalNews} Critical News</span>`);
     if (signals.protests > 0) chips.push(`<span class="signal-chip protest">📢 ${signals.protests} ${t('modals.countryBrief.signals.protests')}</span>`);
-    if (signals.militaryFlights > 0) chips.push(`<span class="signal-chip military">✈️ ${signals.militaryFlights} ${t('modals.countryBrief.signals.militaryAir')}</span>`);
-    if (signals.militaryVessels > 0) chips.push(`<span class="signal-chip military">⚓ ${signals.militaryVessels} ${t('modals.countryBrief.signals.militarySea')}</span>`);
+    if (signals.militaryFlights > 0) {
+      const tip = `${signals.militaryFlights} near · ${signals.militaryFlightsInCountry} inside borders`;
+      chips.push(`<span class="signal-chip military" title="${tip}">✈️ ${signals.militaryFlights} ${t('modals.countryBrief.signals.militaryAir')}</span>`);
+    }
+    if (signals.militaryVessels > 0) {
+      const tip = `${signals.militaryVessels} near · ${signals.militaryVesselsInCountry} inside borders`;
+      chips.push(`<span class="signal-chip military" title="${tip}">⚓ ${signals.militaryVessels} ${t('modals.countryBrief.signals.militarySea')}</span>`);
+    }
     if (signals.outages > 0) chips.push(`<span class="signal-chip outage">🌐 ${signals.outages} ${t('modals.countryBrief.signals.outages')}</span>`);
     if (signals.aisDisruptions > 0) chips.push(`<span class="signal-chip outage">🚢 ${signals.aisDisruptions} AIS Disruptions</span>`);
     if (signals.satelliteFires > 0) chips.push(`<span class="signal-chip climate">🔥 ${signals.satelliteFires} Satellite Fires</span>`);

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -2254,8 +2254,8 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     const chips = this.el('div', 'cdp-signal-chips');
     this.addSignalChip(chips, signals.criticalNews, t('countryBrief.chips.criticalNews'), '🚨', 'conflict');
     this.addSignalChip(chips, signals.protests, t('countryBrief.chips.protests'), '📢', 'protest');
-    this.addSignalChip(chips, signals.militaryFlights, t('countryBrief.chips.militaryAir'), '✈️', 'military');
-    this.addSignalChip(chips, signals.militaryVessels, t('countryBrief.chips.navalVessels'), '⚓', 'military');
+    this.addSignalChip(chips, signals.militaryFlights, t('countryBrief.chips.militaryAir'), '✈️', 'military', `${signals.militaryFlights} near · ${signals.militaryFlightsInCountry} inside borders`);
+    this.addSignalChip(chips, signals.militaryVessels, t('countryBrief.chips.navalVessels'), '⚓', 'military', `${signals.militaryVessels} near · ${signals.militaryVesselsInCountry} inside borders`);
     this.addSignalChip(chips, signals.outages, t('countryBrief.chips.outages'), '🌐', 'outage');
     this.addSignalChip(chips, signals.aisDisruptions, t('countryBrief.chips.aisDisruptions'), '🚢', 'outage');
     this.addSignalChip(chips, signals.satelliteFires, t('countryBrief.chips.satelliteFires'), '🔥', 'climate');
@@ -2299,13 +2299,15 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.signalRecentBody.append(this.makeLoading('Loading top high-severity signals…'));
   }
 
-  private addSignalChip(container: HTMLElement, count: number, label: string, icon: string, cls: string): void {
+  private addSignalChip(container: HTMLElement, count: number, label: string, icon: string, cls: string, tooltip?: string): void {
     if (count <= 0) return;
-    container.append(this.makeSignalChip(`${icon} ${count} ${label}`, cls));
+    container.append(this.makeSignalChip(`${icon} ${count} ${label}`, cls, tooltip));
   }
 
-  private makeSignalChip(text: string, cls: string): HTMLElement {
-    return this.el('span', `cdp-signal-chip chip-${cls}`, text);
+  private makeSignalChip(text: string, cls: string, tooltip?: string): HTMLElement {
+    const chip = this.el('span', `cdp-signal-chip chip-${cls}`, text);
+    if (tooltip) chip.title = tooltip;
+    return chip;
   }
 
   private renderComponentBars(components: CountryScore['components']): HTMLElement {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1476,6 +1476,8 @@ export interface CountryBriefSignals {
   protests: number;
   militaryFlights: number;
   militaryVessels: number;
+  militaryFlightsInCountry: number;
+  militaryVesselsInCountry: number;
   outages: number;
   aisDisruptions: number;
   satelliteFires: number;


### PR DESCRIPTION
Fixes bug 2 on #2972 (follow-up to merged #3035).

## Why this PR?
The Active Signals chip showed 168 naval vessels while the featured story read '96 near region'. The chip used strict in-country geofence, so if 2 vessels are inside borders but 200 nearby, the chip hid the real risk story.

Product call (@koala73): the chip must show the **near** count, because that is what matters for risk.

## Changes
- `src/app/country-intel.ts`: new `isNearCountry(lat, lon, code)` pads `COUNTRY_BOUNDS` by ~2° (~220 km). `getCountrySignals()` now sets `militaryFlights` / `militaryVessels` to the near count and adds `militaryFlightsInCountry` / `militaryVesselsInCountry` for the strict figure.
- `src/types/index.ts`: `CountryBriefSignals` gains the two new `*InCountry` fields.
- `CountryBriefPage.ts` + `CountryDeepDivePanel.ts`: chips render tooltip `'N near, M inside borders'`.

## Test plan
- [x] `npm run typecheck` clean
- [ ] Manual: open a coastal country brief (e.g. IR, TR), verify chip count exceeds strict in-country and tooltip shows both numbers
- [ ] Manual: inland country (e.g. CH) count should be unchanged