### PR TITLE
fix(sentry): suppress globe.gl __globeObjType null crash

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -269,8 +269,10 @@ Sentry.init({
     if ((excType === 'TypeError' || /^TypeError:/.test(msg)) && frames.length > 0) {
       if (nonInfraFrames.length > 0 && nonInfraFrames.every(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     }
-    // Suppress Three.js/globe.gl TypeError crashes in main bundle (reading 'type'/'pathType'/'count'/'__globeObjType' on undefined during WebGL traversal/raycast)
-    if (/reading '(?:type|pathType|count|__globeObjType)'|can't access property "(?:type|pathType|count|__globeObjType)",? \w+ is (?:undefined|null)|undefined is not an object \(evaluating '\w+\.(?:pathType|count|__globeObjType)'\)|null is not an object \(evaluating '\w+\.__globeObjType'\)/.test(msg)) {
+    // Suppress Three.js/globe.gl TypeError crashes in main bundle (reading 'type'/'pathType'/'count'/'__globeObjType' on undefined during WebGL traversal/raycast).
+    // __globeObjType is exclusively set by three-globe on its own objects and we have no user onClick/onHover handler, so it is always globe.gl internal even when the stack shows the bundled main chunk (WORLDMONITOR-ME).
+    if (/reading '__globeObjType'|__globeObjType/.test(msg)) return null;
+    if (/reading '(?:type|pathType|count)'|can't access property "(?:type|pathType|count|__globeObjType)",? \w+ is (?:undefined|null)|undefined is not an object \(evaluating '\w+\.(?:pathType|count)'\)/.test(msg)) {
       if (!hasFirstParty) return null;
     }
     // Suppress minified Three.js/globe.gl crashes (e.g. "l is undefined" in raycast, "b is undefined" in update/initGlobe)


### PR DESCRIPTION
## Summary
- Split the three-globe `__globeObjType` pattern out of the shared `!hasFirstParty`-gated filter so it suppresses unconditionally.
- `__globeObjType` is set exclusively by three-globe on its own objects, and we register no user `onClick`/`onHover` handler, so the null-access crash is always library-internal even when the stack shows the bundled main chunk.
- Resolves WORLDMONITOR-ME (and WORLDMONITOR-MB, already covered by the existing `www-widgetapi.js` filter on the current release).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run typecheck:api`
- [x] `npm run test:data` (5020 pass)
- [x] `node --test tests/edge-functions.test.mjs` (165 pass)
- [x] `npm run version:check`