### PR TITLE
fix(resilience): relax ranking cache gate, reuse WORLDMONITOR_VALID_KEYS

### DIFF
--- a/scripts/seed-resilience-intervals.mjs
+++ b/scripts/seed-resilience-intervals.mjs
@@ -11,7 +11,11 @@ import {
 loadEnvFile(import.meta.url);
 
 const API_BASE = process.env.API_BASE_URL || 'https://api.worldmonitor.app';
-const WM_KEY = process.env.WORLDMONITOR_API_KEY || '';
+// Reuse WORLDMONITOR_VALID_KEYS when a dedicated WORLDMONITOR_API_KEY isn't set.
+// See seed-resilience-scores.mjs for the rationale.
+const WM_KEY = process.env.WORLDMONITOR_API_KEY
+  || (process.env.WORLDMONITOR_VALID_KEYS ?? '').split(',').map((k) => k.trim()).filter(Boolean)[0]
+  || '';
 const SEED_UA = 'Mozilla/5.0 (compatible; WorldMonitor-Seed/1.0)';
 
 const INTERVAL_KEY_PREFIX = 'resilience:intervals:v1:';

--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -9,7 +9,13 @@ import {
 loadEnvFile(import.meta.url);
 
 const API_BASE = process.env.API_BASE_URL || 'https://api.worldmonitor.app';
-const WM_KEY = process.env.WORLDMONITOR_API_KEY || '';
+// Reuse WORLDMONITOR_VALID_KEYS when a dedicated WORLDMONITOR_API_KEY isn't set —
+// any entry in that comma-separated list is accepted by the API (same
+// validation list that server/_shared/premium-check.ts and validateApiKey read).
+// Avoids duplicating the same secret under a second env-var name per service.
+const WM_KEY = process.env.WORLDMONITOR_API_KEY
+  || (process.env.WORLDMONITOR_VALID_KEYS ?? '').split(',').map((k) => k.trim()).filter(Boolean)[0]
+  || '';
 const SEED_UA = 'Mozilla/5.0 (compatible; WorldMonitor-Seed/1.0)';
 
 export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v9:';
@@ -187,7 +193,7 @@ async function seedResilienceScores() {
 
     // Warm laggards individually (countries the bulk ranking timed out on)
     if (stillMissing.length > 0 && !WM_KEY) {
-      console.warn(`[resilience-scores] ${stillMissing.length} laggards found but WORLDMONITOR_API_KEY not set — skipping individual warmup`);
+      console.warn(`[resilience-scores] ${stillMissing.length} laggards found but neither WORLDMONITOR_API_KEY nor WORLDMONITOR_VALID_KEYS is set — skipping individual warmup`);
     }
     if (stillMissing.length > 0 && WM_KEY) {
       console.log(`[resilience-scores] Warming ${stillMissing.length} laggards individually...`);

--- a/server/worldmonitor/resilience/v1/_shared.ts
+++ b/server/worldmonitor/resilience/v1/_shared.ts
@@ -411,5 +411,21 @@ export async function warmMissingResilienceScores(countryCodes: string[]): Promi
   // Share one memoized reader across all countries so global Redis keys (conflict events,
   // sanctions, unrest, etc.) are fetched only once instead of once per country.
   const sharedReader = createMemoizedSeedReader();
-  await Promise.allSettled(uniqueCodes.map((countryCode) => ensureResilienceScoreCached(countryCode, sharedReader)));
+  const results = await Promise.allSettled(
+    uniqueCodes.map((countryCode) => ensureResilienceScoreCached(countryCode, sharedReader)),
+  );
+  const failures: Array<{ countryCode: string; reason: string }> = [];
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result?.status === 'rejected') {
+      failures.push({
+        countryCode: uniqueCodes[i]!,
+        reason: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      });
+    }
+  }
+  if (failures.length > 0) {
+    const sample = failures.slice(0, 10).map((f) => `${f.countryCode}(${f.reason})`).join(', ');
+    console.warn(`[resilience] warm failed for ${failures.length}/${uniqueCodes.length} countries: ${sample}${failures.length > 10 ? '...' : ''}`);
+  }
 }

--- a/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
@@ -31,6 +31,12 @@ const RESILIENCE_RANKING_META_TTL_SECONDS = 7 * 24 * 60 * 60;
 // 200 covers the full static index (~130-180 countries) in a single cold-cache pass.
 const SYNC_WARM_LIMIT = 200;
 
+// Minimum fraction of scorable countries that must have a cached score before we
+// persist the ranking to Redis. Prevents a cold-start (0% cached) from being
+// locked in, while still allowing partial-state writes (e.g. 90%) to succeed so
+// the next call doesn't re-warm everything.
+const RANKING_CACHE_MIN_COVERAGE = 0.75;
+
 async function fetchIntervals(countryCodes: string[]): Promise<Map<string, ScoreInterval>> {
   if (countryCodes.length === 0) return new Map();
   const results = await runRedisPipeline(countryCodes.map((cc) => ['GET', `${RESILIENCE_INTERVAL_KEY_PREFIX}${cc}`]), true);
@@ -76,12 +82,24 @@ export const getResilienceRanking: ResilienceServiceHandler['getResilienceRankin
     greyedOut: allItems.filter((item) => item.overallCoverage < GREY_OUT_COVERAGE_THRESHOLD),
   };
 
-  const stillMissing = countryCodes.filter((countryCode) => !cachedScores.has(countryCode));
-  if (stillMissing.length === 0) {
+  // Cache the ranking when we have substantive coverage — don't hold out for 100%.
+  // The previous gate (stillMissing === 0) meant a single failing-to-warm country
+  // permanently blocked the write, leaving the cache null for days while the 6h TTL
+  // expired between cron ticks. Countries that fail to warm already land in
+  // `greyedOut` with coverage 0, so the response is correct for partial states.
+  const coverageRatio = cachedScores.size / countryCodes.length;
+  if (coverageRatio >= RANKING_CACHE_MIN_COVERAGE) {
     await runRedisPipeline([
       ['SET', RESILIENCE_RANKING_CACHE_KEY, JSON.stringify(response), 'EX', RESILIENCE_RANKING_CACHE_TTL_SECONDS],
-      ['SET', RESILIENCE_RANKING_META_KEY, JSON.stringify({ fetchedAt: Date.now(), count: response.items.length + response.greyedOut.length }), 'EX', RESILIENCE_RANKING_META_TTL_SECONDS],
+      ['SET', RESILIENCE_RANKING_META_KEY, JSON.stringify({
+        fetchedAt: Date.now(),
+        count: response.items.length + response.greyedOut.length,
+        scored: cachedScores.size,
+        total: countryCodes.length,
+      }), 'EX', RESILIENCE_RANKING_META_TTL_SECONDS],
     ]);
+  } else {
+    console.warn(`[resilience] ranking not cached — coverage ${cachedScores.size}/${countryCodes.length} below ${RANKING_CACHE_MIN_COVERAGE * 100}% threshold`);
   }
 
   return response;

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -130,6 +130,36 @@ describe('resilience ranking contracts', () => {
     assert.equal(us?.rankStable, false, 'US interval width 22 should be unstable');
   });
 
+  it('caches the ranking when partial coverage meets the 75% threshold (4 countries, 3 scored)', async () => {
+    const { redis } = installRedis(RESILIENCE_FIXTURES);
+    // Override the static index so we have an un-scoreable extra country (ZZ has
+    // no fixture → warm will throw and ZZ stays missing).
+    redis.set('resilience:static:index:v1', JSON.stringify({
+      countries: ['NO', 'US', 'YE', 'ZZ'],
+      recordCount: 4,
+      failedDatasets: [],
+      seedYear: 2025,
+    }));
+    const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
+    redis.set('resilience:score:v9:NO', JSON.stringify({
+      countryCode: 'NO', overallScore: 82, level: 'high',
+      domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
+      lowConfidence: false, imputationShare: 0.05,
+    }));
+    redis.set('resilience:score:v9:US', JSON.stringify({
+      countryCode: 'US', overallScore: 61, level: 'medium',
+      domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
+      lowConfidence: false, imputationShare: 0.1,
+    }));
+
+    await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
+
+    // 3 of 4 (NO + US pre-cached, YE warmed from fixtures, ZZ can't be warmed)
+    // = 75% which meets the threshold — must cache.
+    assert.ok(redis.has('resilience:ranking:v9'), 'ranking must be cached at exactly 75% coverage');
+    assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written alongside the ranking');
+  });
+
   it('defaults rankStable=false when no interval data exists', () => {
     const item = buildRankingItem('ZZ', {
       countryCode: 'ZZ', overallScore: 50, level: 'medium',


### PR DESCRIPTION
## Why this PR?

`resilience:ranking:v9` has been `null` in prod Redis for ~4 days and per-country `resilience:score:v9:*` has **1 key out of 222 countries**. This breaks two validators in the weekly resilience-validation cron (benchmark can't find WM scores; backtest loads only 1 country and aborts) and silently turns the on-demand RPC cache into a cold compute every call. The broken state was masked by the fact that the Sensitivity-Suite validator recomputes from raw dimensions and so still passes.

## Root cause — three bugs compounding

**1. The ranking cache gate required 100% country coverage.**
`get-resilience-ranking.ts` only wrote to Redis when `stillMissing.length === 0`. A single country silently failing inside `warmMissingResilienceScores` (whose `Promise.allSettled` discards rejection reasons) prevented the write forever. The handler threw away a perfectly valid response where failing countries already landed in `greyedOut` with coverage 0.

**2. The seeder needed `WORLDMONITOR_API_KEY` but the service already had `WORLDMONITOR_VALID_KEYS`.**
Without a key, `seed-resilience-scores.mjs` and `seed-resilience-intervals.mjs` skip the per-country laggard warmup (line 189-190). `WORLDMONITOR_VALID_KEYS` was already set on the `seed-bundle-resilience` Railway service — same secret list, different env-var name. Adding another variable would have been duplication.

**3. `Promise.allSettled` hid which countries failed.**
When the handler warmed 222 countries and 21 silently errored, nothing got logged. No way to triage which countries were broken without modifying the code.

## Verification against prod

Direct Redis probe (via `UPSTASH_REDIS_REST_URL`):

| Key | Before this PR | Meaning |
|---|---|---|
| `resilience:ranking:v9` | `null` | Empty — benchmark's "No WM scores" complaint was real |
| `seed-meta:resilience:ranking` | `{fetchedAt, count: 222}` (85.6h old) | Written once 4 days ago when all 222 happened to warm before the 6h TTL expired, then never again |
| `resilience:score:v9:*` keys | **1** (TR only) | Confirms backtest's "Loaded scores for 1 countries" was accurate, not a filter bug |
| `resilience:intervals:v1:*` keys | 222 | 7-day TTL so intervals accumulate, not blocked |

One manual call to `GET /api/resilience/v1/get-resilience-ranking` (seeder UA + valid key):

- HTTP 200 in **8s** — so 60s seeder abort isn't the bottleneck
- Response: 197 items + 25 greyedOut = 222 total
- Post-call: `resilience:score:v9:*` keys **1 → 201** (handler warmed 200 countries)
- Post-call: `resilience:ranking:v9` **still `null`** — gate tripped (21 countries silently failed to warm → `stillMissing = 21 ≠ 0`)

Gate confirmed as the primary blocker.

## Fix shape

### 1. `server/worldmonitor/resilience/v1/get-resilience-ranking.ts`
Replace the all-or-nothing gate with a 75% coverage threshold. Always write `seed-meta:resilience:ranking` alongside the cache so staleness monitoring works. Log when the threshold isn't met.

```ts
const RANKING_CACHE_MIN_COVERAGE = 0.75;
// ...
const coverageRatio = cachedScores.size / countryCodes.length;
if (coverageRatio >= RANKING_CACHE_MIN_COVERAGE) {
  await runRedisPipeline([...]);
} else {
  console.warn(`[resilience] ranking not cached — coverage X/Y below threshold`);
}
```

### 2. `scripts/seed-resilience-{scores,intervals}.mjs`
```diff
-const WM_KEY = process.env.WORLDMONITOR_API_KEY || '';
+const WM_KEY = process.env.WORLDMONITOR_API_KEY
+  || (process.env.WORLDMONITOR_VALID_KEYS ?? '').split(',').map((k) => k.trim()).filter(Boolean)[0]
+  || '';
```
Matches the pattern in `server/_shared/premium-check.ts`. No new Railway env var needed.

### 3. `server/worldmonitor/resilience/v1/_shared.ts` — `warmMissingResilienceScores`
Inspect `Promise.allSettled` results, log rejections with country code + reason (first 10 + count). Turns silent failures into triageable signal.

## Test plan

- [x] `node --test tests/resilience-ranking.test.mts` — 7 existing + 1 new (partial-coverage caching at 75%) all pass
- [x] Full resilience suite: 357/357
- [x] `npm run typecheck` + `npm run typecheck:api` clean
- [x] Biome clean
- [ ] After merge: next scheduled `seed-bundle-resilience` cron run (every 6h, `0 */6 * * *`) should write `resilience:ranking:v9` and `seed-meta:resilience:ranking`, and warm a substantial fraction of `resilience:score:v9:*` keys. Any remaining laggards will show up in new `[resilience] warm failed for N/M countries` logs.
- [ ] Next weekly `seed-bundle-resilience-validation` run: External-Benchmark should report real correlations instead of "no-wm-scores"; Outcome-Backtest should load >= 40 countries.