### PR TITLE
feat(seeds): expand IMF WEO coverage — growth, labor, external themes (#3027)

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -21,6 +21,9 @@ const BOOTSTRAP_CACHE_KEYS = {
   bisExchange:      'economic:bis:eer:v1',
   bisCredit:        'economic:bis:credit:v1',
   imfMacro:         'economic:imf:macro:v2',
+  imfGrowth:        'economic:imf:growth:v1',
+  imfLabor:         'economic:imf:labor:v1',
+  imfExternal:      'economic:imf:external:v1',
   shippingRates:    'supply_chain:shipping:v2',
   chokepoints:      'supply_chain:chokepoints:v4',
   minerals:         'supply_chain:minerals:v2',
@@ -102,7 +105,7 @@ const BOOTSTRAP_CACHE_KEYS = {
 };
 
 const SLOW_KEYS = new Set([
-  'bisPolicy', 'bisExchange', 'bisCredit', 'imfMacro', 'minerals', 'giving',
+  'bisPolicy', 'bisExchange', 'bisCredit', 'imfMacro', 'imfGrowth', 'imfLabor', 'imfExternal', 'minerals', 'giving',
   'sectors', 'etfFlows', 'wildfires', 'climateAnomalies', 'climateDisasters', 'co2Monitoring', 'oceanIce', 'climateNews',
   'radiationWatch', 'thermalEscalation', 'crossSourceSignals',
   'cyberThreats', 'techReadiness', 'progressData', 'renewableEnergy',

--- a/api/health.js
+++ b/api/health.js
@@ -102,6 +102,9 @@ const STANDALONE_KEYS = {
   bisExchange:           'economic:bis:eer:v1',
   bisCredit:             'economic:bis:credit:v1',
   imfMacro:             'economic:imf:macro:v2',
+  imfGrowth:            'economic:imf:growth:v1',
+  imfLabor:             'economic:imf:labor:v1',
+  imfExternal:          'economic:imf:external:v1',
   climateZoneNormals:    'climate:zone-normals:v1',
   shippingRates:         'supply_chain:shipping:v2',
   chokepoints:           'supply_chain:chokepoints:v4',
@@ -207,6 +210,9 @@ const SEED_META = {
   macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 20 },
   bisPolicy:        { key: 'seed-meta:economic:bis',              maxStaleMin: 10080 }, // runSeed('economic','bis',...) writes seed-meta:economic:bis
   imfMacro:         { key: 'seed-meta:economic:imf-macro',        maxStaleMin: 100800 }, // monthly seed; 100800min = 70 days = 2× interval (absorbs one missed run)
+  imfGrowth:        { key: 'seed-meta:economic:imf-growth',       maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro (same WEO release cadence)
+  imfLabor:         { key: 'seed-meta:economic:imf-labor',        maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro
+  imfExternal:      { key: 'seed-meta:economic:imf-external',     maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro
   shippingRates:    { key: 'seed-meta:supply_chain:shipping',     maxStaleMin: 420 },
   chokepoints:      { key: 'seed-meta:supply_chain:chokepoints',  maxStaleMin: 60 },
   // minerals + giving: on-demand cachedFetchJson only, no seed-meta writer — freshness checked via TTL

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -170,6 +170,25 @@ const TOOL_REGISTRY: ToolDef[] = [
     _maxStaleMin: 1440,
   },
   {
+    name: 'get_country_macro',
+    description: 'Per-country macroeconomic indicators from IMF WEO (~210 countries, monthly cadence). Bundles fiscal/external balance (inflation, current account, gov revenue/expenditure/primary balance, CPI), growth & per-capita (real GDP growth, GDP/capita USD & PPP, savings & investment rates, savings-investment gap), labor & demographics (unemployment, population), and external trade (exports, imports, trade balance, BOP, import/export volume changes). Latest available year per series. Use for country-level economic screening, peer benchmarking, and stagflation/imbalance flags.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    _cacheKeys: [
+      'economic:imf:macro:v2',
+      'economic:imf:growth:v1',
+      'economic:imf:labor:v1',
+      'economic:imf:external:v1',
+    ],
+    _seedMetaKey: 'seed-meta:economic:imf-macro',
+    _maxStaleMin: 100800, // monthly WEO release; 70d = 2× interval (absorbs one missed run)
+    _freshnessChecks: [
+      { key: 'seed-meta:economic:imf-macro', maxStaleMin: 100800 },
+      { key: 'seed-meta:economic:imf-growth', maxStaleMin: 100800 },
+      { key: 'seed-meta:economic:imf-labor', maxStaleMin: 100800 },
+      { key: 'seed-meta:economic:imf-external', maxStaleMin: 100800 },
+    ],
+  },
+  {
     name: 'get_prediction_markets',
     description: 'Active Polymarket event contracts with current probabilities. Covers geopolitical, economic, and election prediction markets.',
     inputSchema: { type: 'object', properties: {}, required: [] },

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -75,6 +75,9 @@ const SEED_DOMAINS = {
   'regulatory:actions':       { key: 'seed-meta:regulatory:actions',       intervalMin: 120 }, // 2h cron; intervalMin = maxStaleMin / 3
   'economic:owid-energy-mix': { key: 'seed-meta:economic:owid-energy-mix', intervalMin: 25200 }, // monthly cron on 1st; intervalMin = health.js maxStaleMin / 2 (50400 / 2)
   'economic:fao-ffpi':        { key: 'seed-meta:economic:fao-ffpi',        intervalMin: 43200 }, // monthly seed; intervalMin = health.js maxStaleMin / 2 (86400 / 2)
+  'economic:imf-growth':      { key: 'seed-meta:economic:imf-growth',      intervalMin: 50400 }, // monthly WEO seed; intervalMin = health.js maxStaleMin / 2 (100800 / 2)
+  'economic:imf-labor':       { key: 'seed-meta:economic:imf-labor',       intervalMin: 50400 }, // monthly WEO seed; intervalMin = health.js maxStaleMin / 2 (100800 / 2)
+  'economic:imf-external':    { key: 'seed-meta:economic:imf-external',    intervalMin: 50400 }, // monthly WEO seed; intervalMin = health.js maxStaleMin / 2 (100800 / 2)
   'product-catalog':          { key: 'seed-meta:product-catalog',          intervalMin: 360 }, // relay loop every 6h; intervalMin = health.js maxStaleMin / 3 (1080 / 3)
   'portwatch:chokepoints-ref': { key: 'seed-meta:portwatch:chokepoints-ref', intervalMin: 1440 }, // daily cron (0 0 * * *)
   'supply_chain:portwatch-ports': { key: 'seed-meta:supply_chain:portwatch-ports', intervalMin: 720 }, // 12h cron (0 */12 * * *); intervalMin = maxStaleMin / 3 (2160 / 3)

--- a/scripts/seed-bundle-imf-extended.mjs
+++ b/scripts/seed-bundle-imf-extended.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+//
+// IMF WEO extended bundle — sequences the four WEO seeders that share the
+// IMF SDMX 3.0 API. Run on the same monthly cadence as seed-imf-macro
+// (wrapped via Railway cron). Spacing them within one bundle keeps API
+// bursts low and shares the seed-bundle observability surface.
+//
+// Per WorldMonitor #3027.
+
+import { runBundle, DAY } from './_bundle-runner.mjs';
+
+await runBundle('imf-extended', [
+  { label: 'IMF-Macro',    script: 'seed-imf-macro.mjs',    seedMetaKey: 'economic:imf-macro',    intervalMs: 30 * DAY, timeoutMs: 600_000 },
+  { label: 'IMF-Growth',   script: 'seed-imf-growth.mjs',   seedMetaKey: 'economic:imf-growth',   intervalMs: 30 * DAY, timeoutMs: 600_000 },
+  { label: 'IMF-Labor',    script: 'seed-imf-labor.mjs',    seedMetaKey: 'economic:imf-labor',    intervalMs: 30 * DAY, timeoutMs: 600_000 },
+  { label: 'IMF-External', script: 'seed-imf-external.mjs', seedMetaKey: 'economic:imf-external', intervalMs: 30 * DAY, timeoutMs: 600_000 },
+]);

--- a/scripts/seed-imf-external.mjs
+++ b/scripts/seed-imf-external.mjs
@@ -105,8 +105,11 @@ export async function fetchImfExternal() {
   };
 }
 
+// IMF WEO external indicators (BX/BM/BCA) report ~210 countries. Require
+// >=190 to reject partial snapshots where a bad IMF run silently drops
+// dozens of countries.
 export function validate(data) {
-  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 190;
 }
 
 export { CANONICAL_KEY, CACHE_TTL };

--- a/scripts/seed-imf-external.mjs
+++ b/scripts/seed-imf-external.mjs
@@ -73,7 +73,9 @@ export function buildExternalCountries({
 
     if (!ex && !im && !ca && !tm && !tx) continue;
 
-    const tradeBalance = ex && im ? Number((ex.value - im.value).toFixed(3)) : null;
+    const tradeBalance = ex && im && ex.year === im.year
+      ? Number((ex.value - im.value).toFixed(3))
+      : null;
 
     countries[iso2] = {
       exportsUsd:           ex?.value ?? null,

--- a/scripts/seed-imf-external.mjs
+++ b/scripts/seed-imf-external.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+//
+// IMF WEO — external balance, BOP & trade volumes
+// Canonical key: economic:imf:external:v1
+//
+// Indicators:
+//   BX        — Exports of goods & services, USD
+//   BM        — Imports of goods & services, USD
+//   BCA       — Current account balance, USD
+//   TM_RPCH   — Volume of imports of goods & services, % change
+//   TX_RPCH   — Volume of exports of goods & services, % change
+//
+// Per WorldMonitor #3027 — feeds Trade Flows card.
+
+import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY = 'economic:imf:external:v1';
+const CACHE_TTL = 35 * 24 * 3600;
+
+const ISO2_TO_ISO3 = loadSharedConfig('iso2-to-iso3.json');
+const ISO3_TO_ISO2 = Object.fromEntries(Object.entries(ISO2_TO_ISO3).map(([k, v]) => [v, k]));
+
+const AGGREGATE_CODES = new Set([
+  'ADVEC', 'EMEDE', 'EURO', 'MECA', 'OEMDC', 'WEOWORLD', 'EU',
+  'AS5', 'DA', 'EDE', 'MAE', 'OAE', 'SSA', 'WE', 'EMDE', 'G20',
+]);
+
+export function isAggregate(code) {
+  if (!code || code.length !== 3) return true;
+  return AGGREGATE_CODES.has(code) || code.endsWith('Q');
+}
+
+export function weoYears() {
+  const y = new Date().getFullYear();
+  return [`${y}`, `${y - 1}`, `${y - 2}`];
+}
+
+export function latestValue(byYear) {
+  for (const year of weoYears()) {
+    const v = Number(byYear?.[year]);
+    if (Number.isFinite(v)) return { value: v, year: Number(year) };
+  }
+  return null;
+}
+
+export function buildExternalCountries({
+  exports = {},
+  imports = {},
+  currentAccount = {},
+  importVol = {},
+  exportVol = {},
+}) {
+  const countries = {};
+  const allIso3 = new Set([
+    ...Object.keys(exports),
+    ...Object.keys(imports),
+    ...Object.keys(currentAccount),
+    ...Object.keys(importVol),
+    ...Object.keys(exportVol),
+  ]);
+  for (const iso3 of allIso3) {
+    if (isAggregate(iso3)) continue;
+    const iso2 = ISO3_TO_ISO2[iso3];
+    if (!iso2) continue;
+
+    const ex   = latestValue(exports[iso3]);
+    const im   = latestValue(imports[iso3]);
+    const ca   = latestValue(currentAccount[iso3]);
+    const tm   = latestValue(importVol[iso3]);
+    const tx   = latestValue(exportVol[iso3]);
+
+    if (!ex && !im && !ca && !tm && !tx) continue;
+
+    const tradeBalance = ex && im ? Number((ex.value - im.value).toFixed(3)) : null;
+
+    countries[iso2] = {
+      exportsUsd:           ex?.value ?? null,
+      importsUsd:           im?.value ?? null,
+      tradeBalanceUsd:      tradeBalance,
+      currentAccountUsd:    ca?.value ?? null,
+      importVolumePctChg:   tm?.value ?? null,
+      exportVolumePctChg:   tx?.value ?? null,
+      year: ex?.year ?? im?.year ?? ca?.year ?? tm?.year ?? tx?.year ?? null,
+    };
+  }
+  return countries;
+}
+
+export async function fetchImfExternal() {
+  const years = weoYears();
+  const [exports, imports, currentAccount, importVol, exportVol] = await Promise.all([
+    imfSdmxFetchIndicator('BX', { years }),
+    imfSdmxFetchIndicator('BM', { years }),
+    imfSdmxFetchIndicator('BCA', { years }),
+    imfSdmxFetchIndicator('TM_RPCH', { years }),
+    imfSdmxFetchIndicator('TX_RPCH', { years }),
+  ]);
+  return {
+    countries: buildExternalCountries({ exports, imports, currentAccount, importVol, exportVol }),
+    seededAt: new Date().toISOString(),
+  };
+}
+
+export function validate(data) {
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
+}
+
+export { CANONICAL_KEY, CACHE_TTL };
+
+if (process.argv[1]?.endsWith('seed-imf-external.mjs')) {
+  runSeed('economic', 'imf-external', CANONICAL_KEY, fetchImfExternal, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: `imf-sdmx-weo-${new Date().getFullYear()}`,
+    recordCount: (data) => Object.keys(data?.countries ?? {}).length,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
+    console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-imf-growth.mjs
+++ b/scripts/seed-imf-growth.mjs
@@ -137,8 +137,10 @@ export async function fetchImfGrowth() {
   return { countries, seededAt: new Date().toISOString() };
 }
 
+// IMF WEO growth indicators report ~210 countries. Require >=190 to reject
+// partial snapshots where a bad IMF run silently drops dozens of countries.
 export function validate(data) {
-  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 190;
 }
 
 export { CANONICAL_KEY, CACHE_TTL };

--- a/scripts/seed-imf-growth.mjs
+++ b/scripts/seed-imf-growth.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+//
+// IMF WEO — growth & per-capita aggregates
+// Canonical key: economic:imf:growth:v1
+//
+// Indicators:
+//   NGDP_RPCH   — Real GDP growth, % change
+//   NGDPDPC     — Nominal GDP per capita, USD
+//   NGDP_R      — Real GDP, national currency (constant prices)
+//   PPPPC       — GDP per capita, PPP USD
+//   PPPGDP      — GDP, PPP USD
+//   NID_NGDP    — Total investment % GDP
+//   NGSD_NGDP   — Gross national savings % GDP
+//
+// Per WorldMonitor #3027 — backfills CountryDeepDivePanel Economic
+// Indicators + Country Facts tiles from the same SDMX 3.0 fetcher already
+// used by seed-imf-macro.mjs.
+
+import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY = 'economic:imf:growth:v1';
+const CACHE_TTL = 35 * 24 * 3600; // 35 days — monthly IMF WEO release cadence
+
+const ISO2_TO_ISO3 = loadSharedConfig('iso2-to-iso3.json');
+const ISO3_TO_ISO2 = Object.fromEntries(Object.entries(ISO2_TO_ISO3).map(([k, v]) => [v, k]));
+
+const AGGREGATE_CODES = new Set([
+  'ADVEC', 'EMEDE', 'EURO', 'MECA', 'OEMDC', 'WEOWORLD', 'EU',
+  'AS5', 'DA', 'EDE', 'MAE', 'OAE', 'SSA', 'WE', 'EMDE', 'G20',
+]);
+
+export function isAggregate(code) {
+  if (!code || code.length !== 3) return true;
+  return AGGREGATE_CODES.has(code) || code.endsWith('Q');
+}
+
+export function weoYears() {
+  const y = new Date().getFullYear();
+  return [`${y}`, `${y - 1}`, `${y - 2}`];
+}
+
+export function latestValue(byYear) {
+  for (const year of weoYears()) {
+    const v = Number(byYear?.[year]);
+    if (Number.isFinite(v)) return { value: v, year: Number(year) };
+  }
+  return null;
+}
+
+export function buildGrowthCountries(perIndicator) {
+  const {
+    realGdpGrowth = {},
+    nominalGdpPerCapita = {},
+    realGdp = {},
+    pppPerCapita = {},
+    pppGdp = {},
+    investmentPct = {},
+    savingsPct = {},
+  } = perIndicator;
+
+  const countries = {};
+  const allIso3 = new Set([
+    ...Object.keys(realGdpGrowth),
+    ...Object.keys(nominalGdpPerCapita),
+    ...Object.keys(realGdp),
+    ...Object.keys(pppPerCapita),
+    ...Object.keys(pppGdp),
+    ...Object.keys(investmentPct),
+    ...Object.keys(savingsPct),
+  ]);
+
+  for (const iso3 of allIso3) {
+    if (isAggregate(iso3)) continue;
+    const iso2 = ISO3_TO_ISO2[iso3];
+    if (!iso2) continue;
+
+    const growth   = latestValue(realGdpGrowth[iso3]);
+    const gdpPc    = latestValue(nominalGdpPerCapita[iso3]);
+    const realGdpV = latestValue(realGdp[iso3]);
+    const pppPc    = latestValue(pppPerCapita[iso3]);
+    const pppGdpV  = latestValue(pppGdp[iso3]);
+    const inv      = latestValue(investmentPct[iso3]);
+    const sav      = latestValue(savingsPct[iso3]);
+
+    if (!growth && !gdpPc && !realGdpV && !pppPc && !pppGdpV && !inv && !sav) continue;
+
+    // savings - investment gap is a leading indicator for BOP pressure.
+    const savInvGap = inv && sav ? Number((sav.value - inv.value).toFixed(2)) : null;
+
+    countries[iso2] = {
+      realGdpGrowthPct:   growth?.value ?? null,
+      gdpPerCapitaUsd:    gdpPc?.value ?? null,
+      realGdp:            realGdpV?.value ?? null,
+      gdpPerCapitaPpp:    pppPc?.value ?? null,
+      gdpPpp:             pppGdpV?.value ?? null,
+      investmentPct:      inv?.value ?? null,
+      savingsPct:         sav?.value ?? null,
+      savingsInvestmentGap: savInvGap,
+      year: growth?.year ?? gdpPc?.year ?? realGdpV?.year ?? pppPc?.year ?? pppGdpV?.year ?? inv?.year ?? sav?.year ?? null,
+    };
+  }
+  return countries;
+}
+
+export async function fetchImfGrowth() {
+  const years = weoYears();
+  const [
+    realGdpGrowth,
+    nominalGdpPerCapita,
+    realGdp,
+    pppPerCapita,
+    pppGdp,
+    investmentPct,
+    savingsPct,
+  ] = await Promise.all([
+    imfSdmxFetchIndicator('NGDP_RPCH', { years }),
+    imfSdmxFetchIndicator('NGDPDPC', { years }),
+    imfSdmxFetchIndicator('NGDP_R', { years }),
+    imfSdmxFetchIndicator('PPPPC', { years }),
+    imfSdmxFetchIndicator('PPPGDP', { years }),
+    imfSdmxFetchIndicator('NID_NGDP', { years }),
+    imfSdmxFetchIndicator('NGSD_NGDP', { years }),
+  ]);
+
+  const countries = buildGrowthCountries({
+    realGdpGrowth,
+    nominalGdpPerCapita,
+    realGdp,
+    pppPerCapita,
+    pppGdp,
+    investmentPct,
+    savingsPct,
+  });
+
+  return { countries, seededAt: new Date().toISOString() };
+}
+
+export function validate(data) {
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
+}
+
+export { CANONICAL_KEY, CACHE_TTL };
+
+if (process.argv[1]?.endsWith('seed-imf-growth.mjs')) {
+  runSeed('economic', 'imf-growth', CANONICAL_KEY, fetchImfGrowth, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: `imf-sdmx-weo-${new Date().getFullYear()}`,
+    recordCount: (data) => Object.keys(data?.countries ?? {}).length,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
+    console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-imf-labor.mjs
+++ b/scripts/seed-imf-labor.mjs
@@ -77,9 +77,12 @@ export async function fetchImfLabor() {
   };
 }
 
+// LUR (unemployment) is reported for ~100 countries while population (LP) is
+// reported for ~210. Since buildLaborCountries unions the two, healthy runs
+// yield ~210 countries. Require >=190 to reject partial snapshots; this still
+// accommodates indicators that have slightly narrower reporting.
 export function validate(data) {
-  // LUR coverage is patchier than population; require at least 100 countries.
-  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 100;
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 190;
 }
 
 export { CANONICAL_KEY, CACHE_TTL };

--- a/scripts/seed-imf-labor.mjs
+++ b/scripts/seed-imf-labor.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+//
+// IMF WEO — labor & demographics
+// Canonical key: economic:imf:labor:v1
+//
+// Indicators:
+//   LUR — Unemployment rate, %
+//   LP  — Population, persons (millions)
+//
+// Per WorldMonitor #3027 — feeds resilience macroFiscal scoring (LUR
+// sub-metric) and CountryDeepDivePanel demographic tiles (LP).
+
+import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY = 'economic:imf:labor:v1';
+const CACHE_TTL = 35 * 24 * 3600;
+
+const ISO2_TO_ISO3 = loadSharedConfig('iso2-to-iso3.json');
+const ISO3_TO_ISO2 = Object.fromEntries(Object.entries(ISO2_TO_ISO3).map(([k, v]) => [v, k]));
+
+const AGGREGATE_CODES = new Set([
+  'ADVEC', 'EMEDE', 'EURO', 'MECA', 'OEMDC', 'WEOWORLD', 'EU',
+  'AS5', 'DA', 'EDE', 'MAE', 'OAE', 'SSA', 'WE', 'EMDE', 'G20',
+]);
+
+export function isAggregate(code) {
+  if (!code || code.length !== 3) return true;
+  return AGGREGATE_CODES.has(code) || code.endsWith('Q');
+}
+
+export function weoYears() {
+  const y = new Date().getFullYear();
+  return [`${y}`, `${y - 1}`, `${y - 2}`];
+}
+
+export function latestValue(byYear) {
+  for (const year of weoYears()) {
+    const v = Number(byYear?.[year]);
+    if (Number.isFinite(v)) return { value: v, year: Number(year) };
+  }
+  return null;
+}
+
+export function buildLaborCountries({ unemployment = {}, population = {} }) {
+  const countries = {};
+  const allIso3 = new Set([...Object.keys(unemployment), ...Object.keys(population)]);
+  for (const iso3 of allIso3) {
+    if (isAggregate(iso3)) continue;
+    const iso2 = ISO3_TO_ISO2[iso3];
+    if (!iso2) continue;
+
+    const lur = latestValue(unemployment[iso3]);
+    const lp = latestValue(population[iso3]);
+
+    if (!lur && !lp) continue;
+
+    countries[iso2] = {
+      unemploymentPct: lur?.value ?? null,
+      populationMillions: lp?.value ?? null,
+      year: lur?.year ?? lp?.year ?? null,
+    };
+  }
+  return countries;
+}
+
+export async function fetchImfLabor() {
+  const years = weoYears();
+  const [unemployment, population] = await Promise.all([
+    imfSdmxFetchIndicator('LUR', { years }),
+    imfSdmxFetchIndicator('LP', { years }),
+  ]);
+  return {
+    countries: buildLaborCountries({ unemployment, population }),
+    seededAt: new Date().toISOString(),
+  };
+}
+
+export function validate(data) {
+  // LUR coverage is patchier than population; require at least 100 countries.
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 100;
+}
+
+export { CANONICAL_KEY, CACHE_TTL };
+
+if (process.argv[1]?.endsWith('seed-imf-labor.mjs')) {
+  runSeed('economic', 'imf-labor', CANONICAL_KEY, fetchImfLabor, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: `imf-sdmx-weo-${new Date().getFullYear()}`,
+    recordCount: (data) => Object.keys(data?.countries ?? {}).length,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
+    console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-imf-macro.mjs
+++ b/scripts/seed-imf-macro.mjs
@@ -35,10 +35,22 @@ function latestValue(byYear) {
 
 async function fetchImfMacro() {
   const years = weoYears();
-  const [inflationData, currentAccountData, govRevenueData] = await Promise.all([
-    imfSdmxFetchIndicator('PCPIPCH', { years }),
-    imfSdmxFetchIndicator('BCA_NGDPD', { years }),
-    imfSdmxFetchIndicator('GGR_NGDP', { years }),
+  const [
+    inflationData,
+    currentAccountData,
+    govRevenueData,
+    cpiIndexData,
+    cpiEopData,
+    govExpData,
+    primaryBalanceData,
+  ] = await Promise.all([
+    imfSdmxFetchIndicator('PCPIPCH', { years }),     // CPI inflation, period avg %
+    imfSdmxFetchIndicator('BCA_NGDPD', { years }),    // Current account % GDP
+    imfSdmxFetchIndicator('GGR_NGDP', { years }),     // Gov revenue % GDP
+    imfSdmxFetchIndicator('PCPI', { years }),         // CPI index level
+    imfSdmxFetchIndicator('PCPIEPCH', { years }),     // CPI inflation, end-of-period %
+    imfSdmxFetchIndicator('GGX_NGDP', { years }),     // Gov total expenditure % GDP
+    imfSdmxFetchIndicator('GGXONLB_NGDP', { years }), // Gov primary net lending/borrowing % GDP
   ]);
 
   const countries = {};
@@ -46,6 +58,10 @@ async function fetchImfMacro() {
     ...Object.keys(inflationData),
     ...Object.keys(currentAccountData),
     ...Object.keys(govRevenueData),
+    ...Object.keys(cpiIndexData),
+    ...Object.keys(cpiEopData),
+    ...Object.keys(govExpData),
+    ...Object.keys(primaryBalanceData),
   ]);
 
   for (const iso3 of allIso3) {
@@ -53,16 +69,25 @@ async function fetchImfMacro() {
     const iso2 = ISO3_TO_ISO2[iso3];
     if (!iso2) continue;
 
-    const infl = latestValue(inflationData[iso3]);
-    const ca   = latestValue(currentAccountData[iso3]);
-    const rev  = latestValue(govRevenueData[iso3]);
-    if (!infl && !ca && !rev) continue;
+    const infl    = latestValue(inflationData[iso3]);
+    const ca      = latestValue(currentAccountData[iso3]);
+    const rev     = latestValue(govRevenueData[iso3]);
+    const cpi     = latestValue(cpiIndexData[iso3]);
+    const cpiEop  = latestValue(cpiEopData[iso3]);
+    const govExp  = latestValue(govExpData[iso3]);
+    const primBal = latestValue(primaryBalanceData[iso3]);
+
+    if (!infl && !ca && !rev && !cpi && !cpiEop && !govExp && !primBal) continue;
 
     countries[iso2] = {
-      inflationPct:    infl?.value ?? null,
-      currentAccountPct: ca?.value ?? null,
-      govRevenuePct:   rev?.value  ?? null,
-      year: infl?.year ?? ca?.year ?? rev?.year ?? null,
+      inflationPct:        infl?.value ?? null,
+      currentAccountPct:   ca?.value ?? null,
+      govRevenuePct:       rev?.value ?? null,
+      cpiIndex:            cpi?.value ?? null,
+      cpiEopPct:           cpiEop?.value ?? null,
+      govExpenditurePct:   govExp?.value ?? null,
+      primaryBalancePct:   primBal?.value ?? null,
+      year: infl?.year ?? ca?.year ?? rev?.year ?? cpi?.year ?? cpiEop?.year ?? govExp?.year ?? primBal?.year ?? null,
     };
   }
 
@@ -72,6 +97,9 @@ async function fetchImfMacro() {
 function validate(data) {
   return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
 }
+
+// Exported for tests
+export { fetchImfMacro, latestValue, isAggregate, CANONICAL_KEY, CACHE_TTL };
 
 // Guard: only run when executed directly, not when imported by tests
 if (process.argv[1]?.endsWith('seed-imf-macro.mjs')) {

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -126,6 +126,9 @@ export const BOOTSTRAP_CACHE_KEYS: Record<string, string> = {
   bisExchange:      'economic:bis:eer:v1',
   bisCredit:        'economic:bis:credit:v1',
   imfMacro:         'economic:imf:macro:v2',
+  imfGrowth:        'economic:imf:growth:v1',
+  imfLabor:         'economic:imf:labor:v1',
+  imfExternal:      'economic:imf:external:v1',
   shippingRates:    'supply_chain:shipping:v2',
   chokepoints:      'supply_chain:chokepoints:v4',
   minerals:         'supply_chain:minerals:v2',
@@ -212,7 +215,7 @@ export const PORTWATCH_PORT_ACTIVITY_KEY_PREFIX = 'supply_chain:portwatch-ports:
 export const PORTWATCH_PORT_ACTIVITY_COUNTRIES_KEY = 'supply_chain:portwatch-ports:v1:_countries';
 
 export const BOOTSTRAP_TIERS: Record<string, 'slow' | 'fast'> = {
-  bisPolicy: 'slow', bisExchange: 'slow', bisCredit: 'slow', imfMacro: 'slow',
+  bisPolicy: 'slow', bisExchange: 'slow', bisCredit: 'slow', imfMacro: 'slow', imfGrowth: 'slow', imfLabor: 'slow', imfExternal: 'slow',
   minerals: 'slow', giving: 'slow', sectors: 'slow',
   progressData: 'slow', renewableEnergy: 'slow',
   etfFlows: 'slow', shippingRates: 'fast', wildfires: 'slow',

--- a/server/worldmonitor/resilience/v1/_dimension-freshness.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-freshness.ts
@@ -66,6 +66,11 @@ const SOURCE_KEY_META_OVERRIDES: Readonly<Record<string, string>> = {
   // seed-imf-macro.mjs: runSeed('economic', 'imf-macro', ...) writes
   // seed-meta:economic:imf-macro (dash, not colon).
   'economic:imf:macro': 'economic:imf-macro',
+  // seed-imf-growth.mjs / seed-imf-labor.mjs / seed-imf-external.mjs all use
+  // runSeed('economic', 'imf-{theme}', ...) → seed-meta key uses dash.
+  'economic:imf:growth': 'economic:imf-growth',
+  'economic:imf:labor': 'economic:imf-labor',
+  'economic:imf:external': 'economic:imf-external',
   // seed-bis-data.mjs: runSeed('economic', 'bis', ...) writes
   // seed-meta:economic:bis (the sub-resource 'eer' is only in the data
   // key, not the meta key).

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -238,6 +238,7 @@ const RESILIENCE_TRANSIT_SUMMARIES_KEY = 'supply_chain:transit-summaries:v1';
 const RESILIENCE_BIS_EXCHANGE_KEY = 'economic:bis:eer:v1';
 const RESILIENCE_NATIONAL_DEBT_KEY = 'economic:national-debt:v1';
 const RESILIENCE_IMF_MACRO_KEY = 'economic:imf:macro:v2';
+const RESILIENCE_IMF_LABOR_KEY = 'economic:imf:labor:v1';
 const RESILIENCE_SANCTIONS_KEY = 'sanctions:country-counts:v1';
 const RESILIENCE_TRADE_RESTRICTIONS_KEY = 'trade:restrictions:v1:tariff-overview:50';
 const RESILIENCE_TRADE_BARRIERS_KEY = 'trade:barriers:v1:tariff-gap:50';
@@ -569,6 +570,18 @@ function getImfMacroEntry(raw: unknown, countryCode: string): ImfMacroEntry | nu
   return (countries[countryCode] as ImfMacroEntry | undefined) ?? null;
 }
 
+interface ImfLaborEntry {
+  unemploymentPct?: number | null;
+  populationMillions?: number | null;
+  year?: number | null;
+}
+
+function getImfLaborEntry(raw: unknown, countryCode: string): ImfLaborEntry | null {
+  const countries = (raw as { countries?: Record<string, ImfLaborEntry> } | null)?.countries;
+  if (!countries || typeof countries !== 'object') return null;
+  return (countries[countryCode] as ImfLaborEntry | undefined) ?? null;
+}
+
 function getCountryBisExchangeRates(raw: unknown, countryCode: string): BisExchangeRate[] {
   const rates: BisExchangeRate[] = Array.isArray((raw as { rates?: unknown[] } | null)?.rates)
     ? ((raw as { rates?: BisExchangeRate[] }).rates ?? [])
@@ -771,12 +784,14 @@ export async function scoreMacroFiscal(
   countryCode: string,
   reader: ResilienceSeedReader = defaultSeedReader,
 ): Promise<ResilienceDimensionScore> {
-  const [debtRaw, imfMacroRaw] = await Promise.all([
+  const [debtRaw, imfMacroRaw, imfLaborRaw] = await Promise.all([
     reader(RESILIENCE_NATIONAL_DEBT_KEY),
     reader(RESILIENCE_IMF_MACRO_KEY),
+    reader(RESILIENCE_IMF_LABOR_KEY),
   ]);
   const debtEntry = getLatestDebtEntry(debtRaw, countryCode);
   const imfEntry = getImfMacroEntry(imfMacroRaw, countryCode);
+  const laborEntry = getImfLaborEntry(imfLaborRaw, countryCode);
 
   return weightedBlend([
     // Government revenue/GDP: fiscal capacity — how much the state can actually mobilise.
@@ -784,14 +799,21 @@ export async function scoreMacroFiscal(
     // states (Somalia 5% debt ≠ fiscal prudence; it reflects that no one will lend to them).
     // Anchor: 5% (Somalia, war-torn states) → 0, 45% (OECD median) → 100.
     imfMacroRaw == null
-      ? { score: null, weight: 0.5 }
-      : { score: imfEntry?.govRevenuePct == null ? null : normalizeHigherBetter(imfEntry.govRevenuePct, 5, 45), weight: 0.5 },
+      ? { score: null, weight: 0.4 }
+      : { score: imfEntry?.govRevenuePct == null ? null : normalizeHigherBetter(imfEntry.govRevenuePct, 5, 45), weight: 0.4 },
     // Debt growth rate: rapid debt accumulation = fiscal stress even at moderate levels.
     { score: extractMetric(debtEntry, (entry) => normalizeLowerBetter(Math.max(0, safeNum(entry.annualGrowth) ?? 0), 0, 20)), weight: 0.2 },
     // Current account balance: external position — deficit = more vulnerable to FX shocks.
     imfMacroRaw == null
-      ? { score: null, weight: 0.3 }
-      : { score: imfEntry?.currentAccountPct == null ? null : normalizeHigherBetter(Math.max(-20, Math.min(imfEntry.currentAccountPct, 20)), -20, 20), weight: 0.3 },
+      ? { score: null, weight: 0.25 }
+      : { score: imfEntry?.currentAccountPct == null ? null : normalizeHigherBetter(Math.max(-20, Math.min(imfEntry.currentAccountPct, 20)), -20, 20), weight: 0.25 },
+    // Phase 2 (#3027): IMF WEO LUR. Unemployment is a leading indicator for
+    // fiscal absorption capacity. Anchor: 25% → 0 (structural distress),
+    // 3% → 100 (tight labor market). Coverage ~150 countries — null-tolerant
+    // so weightedBlend redistributes when LUR is unavailable.
+    imfLaborRaw == null
+      ? { score: null, weight: 0.15 }
+      : { score: laborEntry?.unemploymentPct == null ? null : normalizeLowerBetter(Math.max(3, Math.min(laborEntry.unemploymentPct, 25)), 3, 25), weight: 0.15 },
   ]);
 }
 

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -35,14 +35,14 @@ export type IndicatorSpec = {
 };
 
 export const INDICATOR_REGISTRY: IndicatorSpec[] = [
-  // ── macroFiscal (3 sub-metrics) ───────────────────────────────────────────
+  // ── macroFiscal (4 sub-metrics) ───────────────────────────────────────────
   {
     id: 'govRevenuePct',
     dimension: 'macroFiscal',
     description: 'Government revenue as % of GDP (IMF GGR_G01_GDP_PT); fiscal capacity proxy',
     direction: 'higherBetter',
     goalposts: { worst: 5, best: 45 },
-    weight: 0.5,
+    weight: 0.4,
     sourceKey: 'economic:imf:macro:v2',
     scope: 'global',
     cadence: 'annual',
@@ -70,12 +70,32 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     description: 'Current account balance as % of GDP (IMF); external position vulnerability',
     direction: 'higherBetter',
     goalposts: { worst: -20, best: 20 },
-    weight: 0.3,
+    weight: 0.25,
     sourceKey: 'economic:imf:macro:v2',
     scope: 'global',
     cadence: 'annual',
     tier: 'core',
     coverage: 190,
+    license: 'open-data',
+  },
+  {
+    // Phase 2 (#3027): IMF WEO LUR. Labor-market slack is a leading
+    // indicator for fiscal absorption capacity — 20%+ unemployment marks
+    // structural distress, sub-5% indicates tight labor markets.
+    // Coverage is patchier than the other WEO macro series (~150 countries
+    // — many emerging markets don't report LUR to the IMF), hence enrichment
+    // tier and a smaller weight.
+    id: 'unemploymentPct',
+    dimension: 'macroFiscal',
+    description: 'Unemployment rate (IMF WEO LUR); higher = labor-market slack & lower fiscal absorption capacity',
+    direction: 'lowerBetter',
+    goalposts: { worst: 25, best: 3 },
+    weight: 0.15,
+    sourceKey: 'economic:imf:labor:v1',
+    scope: 'global',
+    cadence: 'annual',
+    tier: 'enrichment',
+    coverage: 150,
     license: 'open-data',
   },
 

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -48,6 +48,7 @@ import { iso2ToIso3, iso2ToUnCode } from '@/utils/country-codes';
 import { buildDependencyGraph } from '@/services/infrastructure-cascade';
 import { getActiveFrameworkForPanel, subscribeFrameworkChange } from '@/services/analysis-framework-store';
 import { fetchMultiSectorExposure, fetchCountryProducts, fetchMultiSectorCostShock } from '@/services/supply-chain';
+import { getImfCountryBundle, buildImfEconomicIndicators, type ImfCountryBundle } from '@/services/imf-country-data';
 
 type IntlDisplayNamesCtor = new (
   locales: string | string[],
@@ -227,11 +228,23 @@ export class CountryIntelManager implements AppModule {
       }))
       .catch(() => ({ available: false as const, code: '', symbol: '', indexName: '', price: '0', weekChangePercent: '0', currency: '' }));
 
+    let latestStock: CountryStockSnapshot | null = null;
+    let latestImf: ImfCountryBundle | null = null;
+
     stockPromise.then((stock) => {
+      latestStock = stock;
       if (this.ctx.countryBriefPage?.getCode() !== code) return;
       this.ctx.countryBriefPage.updateStock(stock);
-      this.ctx.countryBriefPage.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, stock));
+      this.ctx.countryBriefPage.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, stock, latestImf));
     });
+
+    // IMF WEO bundle (issue #3027): macro / growth / labor / external from
+    // the SDMX-3.0 seeded keys. Tolerant: missing data leaves card unchanged.
+    getImfCountryBundle(code).then((bundle) => {
+      latestImf = bundle;
+      if (this.ctx.countryBriefPage?.getCode() !== code) return;
+      this.ctx.countryBriefPage.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, latestStock, bundle));
+    }).catch(() => { /* non-fatal */ });
 
     fetchCountryMarkets(country)
       .then((markets) => {
@@ -1134,6 +1147,7 @@ export class CountryIntelManager implements AppModule {
     code: string,
     score: CountryScore | null,
     stock: CountryStockSnapshot | null,
+    imfBundle?: ImfCountryBundle | null,
   ): CountryDeepDiveEconomicIndicator[] {
     const indicators: CountryDeepDiveEconomicIndicator[] = [];
 
@@ -1182,7 +1196,16 @@ export class CountryIntelManager implements AppModule {
       });
     }
 
-    return indicators.slice(0, 3);
+    // IMF WEO indicators (issue #3027): real GDP growth, inflation,
+    // unemployment, GDP/capita. Appended after the live signals so that
+    // markets-driven rows take priority on the limited card surface.
+    if (imfBundle) {
+      for (const ind of buildImfEconomicIndicators(imfBundle)) {
+        indicators.push(ind);
+      }
+    }
+
+    return indicators.slice(0, 6);
   }
 
   private sameCountry(code: string, country: string, raw: string | undefined): boolean {

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -1988,7 +1988,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
       trend,
       source: 'Market Service',
     });
-    this.economicIndicators = base.slice(0, 3);
+    this.economicIndicators = base.slice(0, 6);
     this.renderEconomicIndicators();
   }
 
@@ -2413,7 +2413,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
       return;
     }
 
-    for (const indicator of this.economicIndicators.slice(0, 3)) {
+    for (const indicator of this.economicIndicators.slice(0, 6)) {
       const row = this.el('div', 'cdp-economic-item');
       const top = this.el('div', 'cdp-economic-top');
       const isMarketRow = indicator.label === 'Stock Index' || indicator.label === 'Weekly Momentum';

--- a/src/services/imf-country-data.ts
+++ b/src/services/imf-country-data.ts
@@ -1,0 +1,173 @@
+/**
+ * IMF WEO per-country data — fetches the four IMF SDMX-3.0 seeded keys
+ * (macro, growth, labor, external) via /api/bootstrap and returns the
+ * subset for one country. Used by CountryDeepDivePanel Economic
+ * Indicators + Country Facts cards (issue #3027).
+ *
+ * Network policy: single bootstrap GET with comma-separated keys; result
+ * is memoised for ~10 min since WEO is a monthly release.
+ */
+
+import { toApiUrl } from '@/services/runtime';
+
+export interface ImfMacroEntry {
+  inflationPct: number | null;
+  currentAccountPct: number | null;
+  govRevenuePct: number | null;
+  cpiIndex: number | null;
+  cpiEopPct: number | null;
+  govExpenditurePct: number | null;
+  primaryBalancePct: number | null;
+  year: number | null;
+}
+
+export interface ImfGrowthEntry {
+  realGdpGrowthPct: number | null;
+  gdpPerCapitaUsd: number | null;
+  realGdp: number | null;
+  gdpPerCapitaPpp: number | null;
+  gdpPpp: number | null;
+  investmentPct: number | null;
+  savingsPct: number | null;
+  savingsInvestmentGap: number | null;
+  year: number | null;
+}
+
+export interface ImfLaborEntry {
+  unemploymentPct: number | null;
+  populationMillions: number | null;
+  year: number | null;
+}
+
+export interface ImfExternalEntry {
+  exportsUsd: number | null;
+  importsUsd: number | null;
+  tradeBalanceUsd: number | null;
+  currentAccountUsd: number | null;
+  importVolumePctChg: number | null;
+  exportVolumePctChg: number | null;
+  year: number | null;
+}
+
+export interface ImfCountryBundle {
+  macro: ImfMacroEntry | null;
+  growth: ImfGrowthEntry | null;
+  labor: ImfLaborEntry | null;
+  external: ImfExternalEntry | null;
+  fetchedAt: number;
+}
+
+interface ImfBootstrapPayload {
+  data?: {
+    imfMacro?: { countries?: Record<string, ImfMacroEntry> };
+    imfGrowth?: { countries?: Record<string, ImfGrowthEntry> };
+    imfLabor?: { countries?: Record<string, ImfLaborEntry> };
+    imfExternal?: { countries?: Record<string, ImfExternalEntry> };
+  };
+}
+
+const CACHE_TTL_MS = 10 * 60 * 1000;
+let cachedBundle: { fetchedAt: number; payload: ImfBootstrapPayload['data'] } | null = null;
+let inFlight: Promise<ImfBootstrapPayload['data']> | null = null;
+
+async function fetchBundle(): Promise<ImfBootstrapPayload['data']> {
+  if (cachedBundle && Date.now() - cachedBundle.fetchedAt < CACHE_TTL_MS) {
+    return cachedBundle.payload;
+  }
+  if (inFlight) return inFlight;
+
+  inFlight = (async () => {
+    try {
+      const resp = await fetch(
+        toApiUrl('/api/bootstrap?keys=imfMacro,imfGrowth,imfLabor,imfExternal'),
+        { signal: AbortSignal.timeout(8_000) },
+      );
+      if (!resp.ok) return undefined;
+      const payload = (await resp.json()) as ImfBootstrapPayload;
+      cachedBundle = { fetchedAt: Date.now(), payload: payload.data };
+      return payload.data;
+    } catch {
+      return undefined;
+    } finally {
+      inFlight = null;
+    }
+  })();
+  return inFlight;
+}
+
+/**
+ * Look up a country's IMF data across all four themed seeders.
+ * Returns null entries for any theme that has no data for this country
+ * (or whose seeder is offline). Never throws.
+ */
+export async function getImfCountryBundle(iso2Code: string): Promise<ImfCountryBundle> {
+  const code = iso2Code.toUpperCase();
+  const data = await fetchBundle();
+  return {
+    macro: data?.imfMacro?.countries?.[code] ?? null,
+    growth: data?.imfGrowth?.countries?.[code] ?? null,
+    labor: data?.imfLabor?.countries?.[code] ?? null,
+    external: data?.imfExternal?.countries?.[code] ?? null,
+    fetchedAt: cachedBundle?.fetchedAt ?? Date.now(),
+  };
+}
+
+/**
+ * Pure helper — selects up to N IMF-derived indicators ranked by
+ * highest-signal-first ordering for the Economic Indicators card.
+ * Exported so unit tests don't need to mock the network.
+ */
+export function buildImfEconomicIndicators(bundle: ImfCountryBundle): {
+  label: string;
+  value: string;
+  trend: 'up' | 'down' | 'flat';
+  source: string;
+}[] {
+  const out: { label: string; value: string; trend: 'up' | 'down' | 'flat'; source: string }[] = [];
+
+  const growth = bundle.growth?.realGdpGrowthPct;
+  if (growth != null && Number.isFinite(growth)) {
+    out.push({
+      label: 'Real GDP Growth',
+      value: `${growth >= 0 ? '+' : ''}${growth.toFixed(1)}%`,
+      trend: growth > 0.5 ? 'up' : growth < -0.5 ? 'down' : 'flat',
+      source: 'IMF WEO',
+    });
+  }
+
+  const inflation = bundle.macro?.inflationPct;
+  if (inflation != null && Number.isFinite(inflation)) {
+    out.push({
+      label: 'CPI Inflation',
+      value: `${inflation >= 0 ? '+' : ''}${inflation.toFixed(1)}%`,
+      // High inflation = bad for stability; flag downward trend on >5%.
+      trend: inflation > 5 ? 'down' : inflation < 1 ? 'flat' : 'up',
+      source: 'IMF WEO',
+    });
+  }
+
+  const lur = bundle.labor?.unemploymentPct;
+  if (lur != null && Number.isFinite(lur)) {
+    out.push({
+      label: 'Unemployment',
+      value: `${lur.toFixed(1)}%`,
+      trend: lur > 10 ? 'down' : lur < 5 ? 'up' : 'flat',
+      source: 'IMF WEO',
+    });
+  }
+
+  const gdpPc = bundle.growth?.gdpPerCapitaUsd;
+  if (gdpPc != null && Number.isFinite(gdpPc)) {
+    const formatted = gdpPc >= 1000
+      ? `$${(gdpPc / 1000).toFixed(1)}k`
+      : `$${gdpPc.toFixed(0)}`;
+    out.push({
+      label: 'GDP / Capita',
+      value: formatted,
+      trend: 'flat',
+      source: 'IMF WEO',
+    });
+  }
+
+  return out;
+}

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -253,7 +253,7 @@ describe('Bootstrap key hydration coverage', () => {
     const allSrc = srcFiles.map(f => readFileSync(f, 'utf-8')).join('\n');
 
     // Keys with planned but not-yet-wired consumers
-    const PENDING_CONSUMERS = new Set(['correlationCards', 'euGasStorage', 'chokepointBaselines', 'imfMacro', 'portwatchChokepointsRef', 'portwatchPortActivity', 'sprPolicies', 'wsbTickers', 'electricityPrices', 'jodiOil']);
+    const PENDING_CONSUMERS = new Set(['correlationCards', 'euGasStorage', 'chokepointBaselines', 'imfMacro', 'imfGrowth', 'imfLabor', 'imfExternal', 'portwatchChokepointsRef', 'portwatchPortActivity', 'sprPolicies', 'wsbTickers', 'electricityPrices', 'jodiOil']);
     for (const key of keys) {
       if (PENDING_CONSUMERS.has(key)) continue;
       assert.ok(

--- a/tests/helpers/resilience-fixtures.mts
+++ b/tests/helpers/resilience-fixtures.mts
@@ -177,6 +177,15 @@ export const RESILIENCE_FIXTURES: FixtureMap = {
       YE: { inflationPct: 22.0, currentAccountPct: -6.0, govRevenuePct: 8.0, year: 2024 },
     },
   },
+  // IMF WEO labor (issue #3027) — LUR sub-metric for scoreMacroFiscal.
+  // Coverage ~150 countries; null-tolerant in the scorer.
+  'economic:imf:labor:v1': {
+    countries: {
+      NO: { unemploymentPct: 3.7, populationMillions: 5.5, year: 2024 },
+      US: { unemploymentPct: 4.1, populationMillions: 333.3, year: 2024 },
+      YE: { unemploymentPct: 18.0, populationMillions: 33.7, year: 2024 },
+    },
+  },
   'economic:bis:eer:v1': {
     rates: [
       { countryCode: 'NO', realChange: 1.0, realEer: 100, date: '2025-08' },

--- a/tests/imf-country-data.test.mts
+++ b/tests/imf-country-data.test.mts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildImfEconomicIndicators, type ImfCountryBundle } from '../src/services/imf-country-data.ts';
+
+function bundle(overrides: Partial<ImfCountryBundle> = {}): ImfCountryBundle {
+  return {
+    macro: null,
+    growth: null,
+    labor: null,
+    external: null,
+    fetchedAt: 0,
+    ...overrides,
+  };
+}
+
+describe('buildImfEconomicIndicators (panel rendering)', () => {
+  it('returns no rows when no IMF data is present', () => {
+    assert.deepEqual(buildImfEconomicIndicators(bundle()), []);
+  });
+
+  it('renders real GDP growth + inflation + unemployment + GDP/capita rows', () => {
+    const rows = buildImfEconomicIndicators(bundle({
+      macro: {
+        inflationPct: 3.4, currentAccountPct: -2.1, govRevenuePct: 30,
+        cpiIndex: null, cpiEopPct: null, govExpenditurePct: null, primaryBalancePct: null,
+        year: 2025,
+      },
+      growth: {
+        realGdpGrowthPct: 2.7, gdpPerCapitaUsd: 78500, realGdp: null,
+        gdpPerCapitaPpp: null, gdpPpp: null, investmentPct: null, savingsPct: null,
+        savingsInvestmentGap: null, year: 2025,
+      },
+      labor: {
+        unemploymentPct: 4.2, populationMillions: 333.3, year: 2025,
+      },
+    }));
+    assert.deepEqual(rows.map(r => r.label), [
+      'Real GDP Growth', 'CPI Inflation', 'Unemployment', 'GDP / Capita',
+    ]);
+    assert.equal(rows[0].value, '+2.7%');
+    assert.equal(rows[0].trend, 'up');
+    assert.equal(rows[1].value, '+3.4%');
+    assert.equal(rows[1].trend, 'up'); // 3.4% inflation: warning but not crisis
+    assert.equal(rows[2].value, '4.2%');
+    assert.equal(rows[2].trend, 'up'); // <5% unemployment is good
+    assert.equal(rows[3].value, '$78.5k');
+    for (const row of rows) assert.equal(row.source, 'IMF WEO');
+  });
+
+  it('flags stagflation: rising inflation + contracting growth', () => {
+    const rows = buildImfEconomicIndicators(bundle({
+      macro: {
+        inflationPct: 12, currentAccountPct: null, govRevenuePct: null,
+        cpiIndex: null, cpiEopPct: null, govExpenditurePct: null, primaryBalancePct: null,
+        year: 2025,
+      },
+      growth: {
+        realGdpGrowthPct: -1.4, gdpPerCapitaUsd: null, realGdp: null,
+        gdpPerCapitaPpp: null, gdpPpp: null, investmentPct: null, savingsPct: null,
+        savingsInvestmentGap: null, year: 2025,
+      },
+    }));
+    const growth = rows.find(r => r.label === 'Real GDP Growth')!;
+    const infl = rows.find(r => r.label === 'CPI Inflation')!;
+    assert.equal(growth.value, '-1.4%');
+    assert.equal(growth.trend, 'down');
+    assert.equal(infl.value, '+12.0%');
+    assert.equal(infl.trend, 'down'); // >5% inflation flagged downward
+  });
+
+  it('marks high unemployment with a downward trend', () => {
+    const rows = buildImfEconomicIndicators(bundle({
+      labor: { unemploymentPct: 22.5, populationMillions: null, year: 2025 },
+    }));
+    const lur = rows.find(r => r.label === 'Unemployment')!;
+    assert.equal(lur.value, '22.5%');
+    assert.equal(lur.trend, 'down');
+  });
+
+  it('formats sub-$1k GDP/capita with the dollar prefix', () => {
+    const rows = buildImfEconomicIndicators(bundle({
+      growth: {
+        realGdpGrowthPct: null, gdpPerCapitaUsd: 850, realGdp: null,
+        gdpPerCapitaPpp: null, gdpPpp: null, investmentPct: null, savingsPct: null,
+        savingsInvestmentGap: null, year: 2025,
+      },
+    }));
+    const gdp = rows.find(r => r.label === 'GDP / Capita')!;
+    assert.equal(gdp.value, '$850');
+  });
+
+  it('skips rows whose values are null or non-finite', () => {
+    const rows = buildImfEconomicIndicators(bundle({
+      macro: {
+        inflationPct: NaN, currentAccountPct: null, govRevenuePct: null,
+        cpiIndex: null, cpiEopPct: null, govExpenditurePct: null, primaryBalancePct: null,
+        year: 2025,
+      },
+    }));
+    assert.equal(rows.length, 0);
+  });
+});

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -118,12 +118,12 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
   // --- tools/list ---
 
-  it('tools/list returns 28 tools with name, description, inputSchema', async () => {
+  it('tools/list returns 29 tools with name, description, inputSchema', async () => {
     const res = await handler(makeReq('POST', { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.result?.tools), 'result.tools must be an array');
-    assert.equal(body.result.tools.length, 28, `Expected 28 tools, got ${body.result.tools.length}`);
+    assert.equal(body.result.tools.length, 29, `Expected 29 tools, got ${body.result.tools.length}`);
     for (const tool of body.result.tools) {
       assert.ok(tool.name, 'tool.name must be present');
       assert.ok(tool.description, 'tool.description must be present');

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -326,6 +326,7 @@ describe('resilience dimension scorers', () => {
     const makeReader = (caPct: number) => async (key: string): Promise<unknown | null> => {
       if (key === 'economic:national-debt:v1') return { entries: [{ iso3: 'HRV', debtToGdp: 70, annualGrowth: 1.5 }] };
       if (key === 'economic:imf:macro:v2') return { countries: { HR: { inflationPct: 3.0, currentAccountPct: caPct, govRevenuePct: 40, year: 2024 } } };
+      if (key === 'economic:imf:labor:v1') return { countries: { HR: { unemploymentPct: 7, populationMillions: 4, year: 2024 } } };
       return null;
     };
     const surplus = await scoreMacroFiscal('HR', makeReader(10));
@@ -337,14 +338,33 @@ describe('resilience dimension scorers', () => {
   it('scoreMacroFiscal: IMF macro seed outage does not impute — debt growth still scores', async () => {
     const reader = async (key: string): Promise<unknown | null> => {
       if (key === 'economic:national-debt:v1') return { entries: [{ iso3: 'HRV', debtToGdp: 70, annualGrowth: 1.5 }] };
-      return null; // economic:imf:macro:v1 null = seed outage
+      return null; // economic:imf:macro:v1 + economic:imf:labor:v1 null = seed outage
     };
     const score = await scoreMacroFiscal('HR', reader);
-    // govRevenuePct (0.5) and currentAccountPct (0.3) come from IMF macro (null = outage).
+    // govRevenuePct (0.4), currentAccountPct (0.25) come from IMF macro (null = outage).
+    // unemploymentPct (0.15) comes from IMF labor (null = outage).
     // Only debtGrowth (weight=0.2) has real data → coverage = 0.2.
     assert.ok(score.coverage > 0.15 && score.coverage < 0.25,
       `coverage should be ~0.2 (debt growth only, IMF outage), got ${score.coverage}`);
     assert.ok(score.score > 0, 'debt growth data alone should produce a non-zero score');
+  });
+
+  it('scoreMacroFiscal: IMF labor LUR sub-metric — high unemployment lowers macroFiscal score', async () => {
+    const baseFixtures = {
+      'economic:national-debt:v1': { entries: [{ iso3: 'HRV', debtToGdp: 70, annualGrowth: 1.5 }] },
+      'economic:imf:macro:v2': { countries: { HR: { inflationPct: 3.0, currentAccountPct: 1.0, govRevenuePct: 40, year: 2024 } } },
+    };
+    const makeReader = (lur: number) => async (key: string): Promise<unknown | null> => {
+      if (key in baseFixtures) return (baseFixtures as Record<string, unknown>)[key];
+      if (key === 'economic:imf:labor:v1') return { countries: { HR: { unemploymentPct: lur, populationMillions: 4, year: 2024 } } };
+      return null;
+    };
+    const tightLabor = await scoreMacroFiscal('HR', makeReader(3.5));
+    const slackLabor = await scoreMacroFiscal('HR', makeReader(20));
+    assert.ok(tightLabor.score > slackLabor.score,
+      `tight labor (LUR=3.5%, score=${tightLabor.score}) must outrank slack (LUR=20%, score=${slackLabor.score})`);
+    assert.equal(tightLabor.coverage, 1, 'all four sub-metrics observed → coverage=1');
+    assert.equal(slackLabor.coverage, 1, 'all four sub-metrics observed → coverage=1');
   });
 
   it('scoreFoodWater: country absent from FAO/IPC DB gets crisis_monitoring_absent imputation (not WGI proxy)', async () => {

--- a/tests/resilience-scorers.test.mts
+++ b/tests/resilience-scorers.test.mts
@@ -93,7 +93,7 @@ describe('resilience scorer contracts', () => {
     }));
 
     assert.deepEqual(domainAverages, {
-      economic: 66.33,
+      economic: 68,
       infrastructure: 79,
       energy: 80,
       'social-governance': 61.75,
@@ -126,7 +126,7 @@ describe('resilience scorer contracts', () => {
     const stressScore = round(coverageWeightedMean(stressDims));
     const stressFactor = round(Math.max(0, Math.min(1 - stressScore / 100, 0.5)), 4);
 
-    assert.equal(baselineScore, 62.23);
+    assert.equal(baselineScore, 62.59);
     assert.equal(stressScore, 65.84);
     assert.equal(stressFactor, 0.3416);
 
@@ -140,7 +140,7 @@ describe('resilience scorer contracts', () => {
         return round(cwMean) * getResilienceDomainWeight(domainId);
       }).reduce((sum, v) => sum + v, 0),
     );
-    assert.equal(overallScore, 65.23);
+    assert.equal(overallScore, 65.52);
   });
 
   it('baselineScore is computed from baseline + mixed dimensions only', async () => {
@@ -211,7 +211,7 @@ describe('resilience scorer contracts', () => {
     );
 
     assert.ok(expected > 0, 'overall should be positive');
-    assert.equal(expected, 65.23, 'overallScore should match sum(domainScore * domainWeight)');
+    assert.equal(expected, 65.52, 'overallScore should match sum(domainScore * domainWeight)');
   });
 
   it('stressFactor is still computed (informational) and clamped to [0, 0.5]', () => {

--- a/tests/seed-imf-extended.test.mjs
+++ b/tests/seed-imf-extended.test.mjs
@@ -1,0 +1,173 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildGrowthCountries,
+  isAggregate as isAggregateGrowth,
+  latestValue as latestValueGrowth,
+  validate as validateGrowth,
+  CANONICAL_KEY as GROWTH_KEY,
+  CACHE_TTL as GROWTH_TTL,
+} from '../scripts/seed-imf-growth.mjs';
+
+import {
+  buildLaborCountries,
+  validate as validateLabor,
+  CANONICAL_KEY as LABOR_KEY,
+  CACHE_TTL as LABOR_TTL,
+} from '../scripts/seed-imf-labor.mjs';
+
+import {
+  buildExternalCountries,
+  validate as validateExternal,
+  CANONICAL_KEY as EXTERNAL_KEY,
+  CACHE_TTL as EXTERNAL_TTL,
+} from '../scripts/seed-imf-external.mjs';
+
+const YEAR = String(new Date().getFullYear());
+
+describe('seed-imf shared helpers', () => {
+  it('isAggregate flags WEO regional aggregates and rejects 2-letter codes', () => {
+    assert.equal(isAggregateGrowth('USA'), false);
+    assert.equal(isAggregateGrowth('GBR'), false);
+    assert.equal(isAggregateGrowth('EUROQ'), true); // ends with Q
+    assert.equal(isAggregateGrowth('WEOWORLD'), true);
+    assert.equal(isAggregateGrowth('EU'), true);   // not 3-letter
+    assert.equal(isAggregateGrowth(''), true);
+    assert.equal(isAggregateGrowth('G20'), true);
+  });
+
+  it('latestValue picks the most recent finite year-keyed value', () => {
+    const y = Number(YEAR);
+    const series = { [`${y - 2}`]: 1.1, [`${y - 1}`]: 2.2 };
+    const result = latestValueGrowth(series);
+    assert.deepEqual(result, { value: 2.2, year: y - 1 });
+
+    assert.equal(latestValueGrowth({}), null);
+    assert.equal(latestValueGrowth({ [`${y}`]: 'NaN' }), null);
+  });
+});
+
+describe('seed-imf-growth', () => {
+  it('uses the v1 economic:imf:growth canonical key with 35-day TTL', () => {
+    assert.equal(GROWTH_KEY, 'economic:imf:growth:v1');
+    assert.equal(GROWTH_TTL, 35 * 24 * 3600);
+  });
+
+  it('buildGrowthCountries maps ISO3 → ISO2, drops aggregates, and computes savings-investment gap', () => {
+    const countries = buildGrowthCountries({
+      realGdpGrowth:       { USA: { [YEAR]: 2.5 }, GBR: { [YEAR]: 1.1 }, WEOWORLD: { [YEAR]: 3 } },
+      nominalGdpPerCapita: { USA: { [YEAR]: 80000 }, GBR: { [YEAR]: 50000 } },
+      realGdp:             { USA: { [YEAR]: 22000 } },
+      pppPerCapita:        { USA: { [YEAR]: 80000 }, GBR: { [YEAR]: 55000 } },
+      pppGdp:              { USA: { [YEAR]: 27000 } },
+      investmentPct:       { USA: { [YEAR]: 21 }, GBR: { [YEAR]: 17.5 } },
+      savingsPct:          { USA: { [YEAR]: 18 }, GBR: { [YEAR]: 14 } },
+    });
+
+    assert.ok(countries.US, 'USA → US');
+    assert.equal(countries.US.realGdpGrowthPct, 2.5);
+    assert.equal(countries.US.gdpPerCapitaUsd, 80000);
+    assert.equal(countries.US.savingsInvestmentGap, -3);
+    assert.equal(countries.US.year, Number(YEAR));
+
+    assert.ok(countries.GB, 'GBR → GB');
+    assert.equal(countries.GB.savingsInvestmentGap, -3.5);
+
+    // Aggregates dropped (no entry for WEOWORLD).
+    assert.ok(!('WEOWORLD' in countries));
+    assert.ok(!('WW' in countries));
+  });
+
+  it('buildGrowthCountries omits countries with no usable data', () => {
+    const countries = buildGrowthCountries({
+      realGdpGrowth: { USA: { '1970': 2 } }, // year falls outside weoYears window
+    });
+    assert.ok(!('US' in countries), 'no IMF series for current window → no entry');
+  });
+
+  it('validate accepts 150+ countries and rejects sparse data', () => {
+    const countries = {};
+    for (let i = 0; i < 160; i++) countries[`X${i}`] = { realGdpGrowthPct: 1, year: 2025 };
+    assert.equal(validateGrowth({ countries }), true);
+    assert.equal(validateGrowth({ countries: {} }), false);
+    assert.equal(validateGrowth(null), false);
+  });
+});
+
+describe('seed-imf-labor', () => {
+  it('uses the v1 labor canonical key with 35-day TTL', () => {
+    assert.equal(LABOR_KEY, 'economic:imf:labor:v1');
+    assert.equal(LABOR_TTL, 35 * 24 * 3600);
+  });
+
+  it('buildLaborCountries surfaces unemployment and population per ISO2', () => {
+    const countries = buildLaborCountries({
+      unemployment: { USA: { [YEAR]: 4.1 }, FRA: { [YEAR]: 7.5 } },
+      population:   { USA: { [YEAR]: 333.3 }, FRA: { [YEAR]: 67.9 }, ZAF: { [YEAR]: 60.2 } },
+    });
+    assert.deepEqual(countries.US, {
+      unemploymentPct: 4.1, populationMillions: 333.3, year: Number(YEAR),
+    });
+    assert.deepEqual(countries.FR, {
+      unemploymentPct: 7.5, populationMillions: 67.9, year: Number(YEAR),
+    });
+    // South Africa: only population (no LUR); still included.
+    assert.deepEqual(countries.ZA, {
+      unemploymentPct: null, populationMillions: 60.2, year: Number(YEAR),
+    });
+  });
+
+  it('validate accepts 100+ countries (LUR coverage is patchier than other series)', () => {
+    const countries = {};
+    for (let i = 0; i < 110; i++) countries[`X${i}`] = { unemploymentPct: 5, year: 2025 };
+    assert.equal(validateLabor({ countries }), true);
+
+    const sparse = {};
+    for (let i = 0; i < 50; i++) sparse[`X${i}`] = { unemploymentPct: 5, year: 2025 };
+    assert.equal(validateLabor({ countries: sparse }), false);
+  });
+});
+
+describe('seed-imf-external', () => {
+  it('uses the v1 external canonical key with 35-day TTL', () => {
+    assert.equal(EXTERNAL_KEY, 'economic:imf:external:v1');
+    assert.equal(EXTERNAL_TTL, 35 * 24 * 3600);
+  });
+
+  it('buildExternalCountries computes trade balance from exports - imports', () => {
+    const countries = buildExternalCountries({
+      exports:        { USA: { [YEAR]: 3000 }, DEU: { [YEAR]: 2100 } },
+      imports:        { USA: { [YEAR]: 4000 }, DEU: { [YEAR]: 1750 } },
+      currentAccount: { USA: { [YEAR]: -800 } },
+      importVol:      { USA: { [YEAR]: 4.2 } },
+      exportVol:      { USA: { [YEAR]: 3.1 } },
+    });
+    assert.equal(countries.US.exportsUsd, 3000);
+    assert.equal(countries.US.importsUsd, 4000);
+    assert.equal(countries.US.tradeBalanceUsd, -1000);
+    assert.equal(countries.US.currentAccountUsd, -800);
+    assert.equal(countries.US.importVolumePctChg, 4.2);
+    assert.equal(countries.US.exportVolumePctChg, 3.1);
+
+    // Germany has trade surplus.
+    assert.equal(countries.DE.tradeBalanceUsd, 350);
+    // CA / volumes absent → null
+    assert.equal(countries.DE.currentAccountUsd, null);
+  });
+
+  it('buildExternalCountries leaves trade balance null when only one side is reported', () => {
+    const countries = buildExternalCountries({
+      exports: { USA: { [YEAR]: 3000 } },
+    });
+    assert.equal(countries.US.exportsUsd, 3000);
+    assert.equal(countries.US.tradeBalanceUsd, null);
+  });
+
+  it('validate gates >=150 country coverage', () => {
+    const countries = {};
+    for (let i = 0; i < 160; i++) countries[`X${i}`] = { exportsUsd: 1, year: 2025 };
+    assert.equal(validateExternal({ countries }), true);
+    assert.equal(validateExternal({ countries: {} }), false);
+  });
+});

--- a/tests/seed-imf-extended.test.mjs
+++ b/tests/seed-imf-extended.test.mjs
@@ -86,10 +86,15 @@ describe('seed-imf-growth', () => {
     assert.ok(!('US' in countries), 'no IMF series for current window → no entry');
   });
 
-  it('validate accepts 150+ countries and rejects sparse data', () => {
+  it('validate accepts 190+ countries and rejects partial snapshots', () => {
     const countries = {};
-    for (let i = 0; i < 160; i++) countries[`X${i}`] = { realGdpGrowthPct: 1, year: 2025 };
+    for (let i = 0; i < 200; i++) countries[`X${i}`] = { realGdpGrowthPct: 1, year: 2025 };
     assert.equal(validateGrowth({ countries }), true);
+
+    const partial = {};
+    for (let i = 0; i < 170; i++) partial[`X${i}`] = { realGdpGrowthPct: 1, year: 2025 };
+    assert.equal(validateGrowth({ countries: partial }), false, 'rejects 170 countries (dozens missing)');
+
     assert.equal(validateGrowth({ countries: {} }), false);
     assert.equal(validateGrowth(null), false);
   });
@@ -118,10 +123,14 @@ describe('seed-imf-labor', () => {
     });
   });
 
-  it('validate accepts 100+ countries (LUR coverage is patchier than other series)', () => {
+  it('validate accepts 190+ countries and rejects partial snapshots', () => {
     const countries = {};
-    for (let i = 0; i < 110; i++) countries[`X${i}`] = { unemploymentPct: 5, year: 2025 };
+    for (let i = 0; i < 200; i++) countries[`X${i}`] = { populationMillions: 10, year: 2025 };
     assert.equal(validateLabor({ countries }), true);
+
+    const partial = {};
+    for (let i = 0; i < 170; i++) partial[`X${i}`] = { populationMillions: 10, year: 2025 };
+    assert.equal(validateLabor({ countries: partial }), false, 'rejects 170 countries (dozens missing)');
 
     const sparse = {};
     for (let i = 0; i < 50; i++) sparse[`X${i}`] = { unemploymentPct: 5, year: 2025 };
@@ -164,10 +173,15 @@ describe('seed-imf-external', () => {
     assert.equal(countries.US.tradeBalanceUsd, null);
   });
 
-  it('validate gates >=150 country coverage', () => {
+  it('validate gates >=190 country coverage and rejects partial snapshots', () => {
     const countries = {};
-    for (let i = 0; i < 160; i++) countries[`X${i}`] = { exportsUsd: 1, year: 2025 };
+    for (let i = 0; i < 200; i++) countries[`X${i}`] = { exportsUsd: 1, year: 2025 };
     assert.equal(validateExternal({ countries }), true);
+
+    const partial = {};
+    for (let i = 0; i < 170; i++) partial[`X${i}`] = { exportsUsd: 1, year: 2025 };
+    assert.equal(validateExternal({ countries: partial }), false, 'rejects 170 countries (dozens missing)');
+
     assert.equal(validateExternal({ countries: {} }), false);
   });
 });


### PR DESCRIPTION
Adds three new SDMX-3.0 seeders alongside the existing imf-macro seeder
to surface 15+ additional WEO indicators across ~210 countries at zero
incremental API cost. Bundled into seed-bundle-imf-extended.mjs on the
same monthly Railway cron cadence.

Seeders + Redis keys:
- seed-imf-growth.mjs    → economic:imf:growth:v1
  NGDP_RPCH, NGDPDPC, NGDP_R, PPPPC, PPPGDP, NID_NGDP, NGSD_NGDP
- seed-imf-labor.mjs     → economic:imf:labor:v1
  LUR (unemployment), LP (population)
- seed-imf-external.mjs  → economic:imf:external:v1
  BX, BM, BCA, TM_RPCH, TX_RPCH (+ derived trade balance)
- seed-imf-macro.mjs extended with PCPI, PCPIEPCH, GGX_NGDP, GGXONLB_NGDP

All four seeders share the 35-day TTL (monthly WEO release) and ~210
country coverage via the same imfSdmxFetchIndicator helper.

Wiring:
- api/bootstrap.js, api/health.js, server/_shared/cache-keys.ts —
  register new keys, mark them slow-tier, add SEED_META freshness
  thresholds matching the imfMacro entry (70d = 2× monthly cadence)
- server/worldmonitor/resilience/v1/_dimension-freshness.ts —
  override entries for the dash-vs-colon seed-meta key shape
- _indicator-registry.ts — add LUR as a 4th macroFiscal sub-metric
  (enrichment tier, weight 0.15); rebalance govRevenuePct (0.5→0.4)
  and currentAccountPct (0.3→0.25) so weights still sum to 1.0
- _dimension-scorers.ts — read economic:imf:labor:v1 in scoreMacroFiscal,
  normalize LUR with goalposts 3% (best) → 25% (worst); null-tolerant so
  weightedBlend redistributes when labor data is unavailable
- api/mcp.ts — new get_country_macro tool bundling all four IMF keys
  with a single freshness check; describes per-country fields including
  growth/inflation/labor/BOP for LLM-driven country screening
- src/services/imf-country-data.ts — bootstrap-cached client + pure
  buildImfEconomicIndicators helper
- src/app/country-intel.ts — async-fetch the IMF bundle on country
  selection and merge real GDP growth, CPI inflation, unemployment, and
  GDP/capita rows into the Economic Indicators card; bumps card cap
  from 3 → 6 rows to fit live signals + IMF context

Tests:
- tests/seed-imf-extended.test.mjs — 13 unit tests across the three new
  seeders' pure helpers (canonical keys, ISO3→ISO2 mapping, aggregate
  filtering, derived savings-investment gap & trade balance, validate
  thresholds)
- tests/imf-country-data.test.mts — 6 tests for the panel rendering
  helper, including stagflation flag and high-unemployment trend
- tests/resilience-dimension-scorers.test.mts — new LUR sub-metric test
  (tight vs slack labor); existing scoreMacroFiscal coverage assertions
  updated for the new 4-metric weight split
- tests/helpers/resilience-fixtures.mts — labor fixture for NO/US/YE so
  the existing macroFiscal ordering test still resolves the LUR weight
- tests/bootstrap.test.mjs — register imfGrowth/imfLabor/imfExternal as
  pending consumers (matching imfMacro)
- tests/mcp.test.mjs — bump tools/list count 28 → 29

https://claude.ai/code/session_018enRzZuRqaMudKsLD5RLZv