### PR TITLE
feat(seeds): BIS DSR + property prices (2 of 7)

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -20,6 +20,9 @@ const BOOTSTRAP_CACHE_KEYS = {
   bisPolicy:        'economic:bis:policy:v1',
   bisExchange:      'economic:bis:eer:v1',
   bisCredit:        'economic:bis:credit:v1',
+  bisDsr:           'economic:bis:dsr:v1',
+  bisPropertyResidential: 'economic:bis:property-residential:v1',
+  bisPropertyCommercial:  'economic:bis:property-commercial:v1',
   imfMacro:         'economic:imf:macro:v2',
   imfGrowth:        'economic:imf:growth:v1',
   imfLabor:         'economic:imf:labor:v1',
@@ -108,7 +111,9 @@ const BOOTSTRAP_CACHE_KEYS = {
 };
 
 const SLOW_KEYS = new Set([
-  'bisPolicy', 'bisExchange', 'bisCredit', 'imfMacro', 'imfGrowth', 'imfLabor', 'imfExternal', 'minerals', 'giving',
+  'bisPolicy', 'bisExchange', 'bisCredit',
+  'bisDsr', 'bisPropertyResidential', 'bisPropertyCommercial',
+  'imfMacro', 'imfGrowth', 'imfLabor', 'imfExternal', 'minerals', 'giving',
   'sectors', 'etfFlows', 'wildfires', 'climateAnomalies', 'climateDisasters', 'co2Monitoring', 'oceanIce', 'climateNews',
   'radiationWatch', 'thermalEscalation', 'crossSourceSignals',
   'cyberThreats', 'techReadiness', 'progressData', 'renewableEnergy',

--- a/api/health.js
+++ b/api/health.js
@@ -216,12 +216,13 @@ const SEED_META = {
   cableHealth:      { key: 'seed-meta:cable-health',              maxStaleMin: 90 }, // ais-relay warm-ping runs every 30min; 90min = 3× interval catches missed pings without false positives
   macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 20 },
   bisPolicy:        { key: 'seed-meta:economic:bis',              maxStaleMin: 10080 }, // runSeed('economic','bis',...) writes seed-meta:economic:bis
-  // seed-bis-extended.mjs: runSeed('economic','bis-extended',...) writes a
-  // single seed-meta key; DSR / property-residential / property-commercial
-  // are extras written via afterPublish on the same run. 24h = 2× 12h cron.
-  bisDsr:                { key: 'seed-meta:economic:bis-extended', maxStaleMin: 1440 },
-  bisPropertyResidential:{ key: 'seed-meta:economic:bis-extended', maxStaleMin: 1440 },
-  bisPropertyCommercial: { key: 'seed-meta:economic:bis-extended', maxStaleMin: 1440 },
+  // seed-bis-extended.mjs writes per-dataset seed-meta keys ONLY when that
+  // specific dataset published fresh entries — so a single-dataset BIS outage
+  // (e.g. WS_DSR 500s) goes stale in health without falsely dragging down the
+  // healthy ones. 24h = 2× 12h cron.
+  bisDsr:                { key: 'seed-meta:economic:bis-dsr',                  maxStaleMin: 1440 },
+  bisPropertyResidential:{ key: 'seed-meta:economic:bis-property-residential', maxStaleMin: 1440 },
+  bisPropertyCommercial: { key: 'seed-meta:economic:bis-property-commercial',  maxStaleMin: 1440 },
   imfMacro:         { key: 'seed-meta:economic:imf-macro',        maxStaleMin: 100800 }, // monthly seed; 100800min = 70 days = 2× interval (absorbs one missed run)
   imfGrowth:        { key: 'seed-meta:economic:imf-growth',       maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro (same WEO release cadence)
   imfLabor:         { key: 'seed-meta:economic:imf-labor',        maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro

--- a/api/health.js
+++ b/api/health.js
@@ -104,6 +104,9 @@ const STANDALONE_KEYS = {
   bisPolicy:             'economic:bis:policy:v1',
   bisExchange:           'economic:bis:eer:v1',
   bisCredit:             'economic:bis:credit:v1',
+  bisDsr:                'economic:bis:dsr:v1',
+  bisPropertyResidential: 'economic:bis:property-residential:v1',
+  bisPropertyCommercial:  'economic:bis:property-commercial:v1',
   imfMacro:             'economic:imf:macro:v2',
   imfGrowth:            'economic:imf:growth:v1',
   imfLabor:             'economic:imf:labor:v1',
@@ -213,6 +216,12 @@ const SEED_META = {
   cableHealth:      { key: 'seed-meta:cable-health',              maxStaleMin: 90 }, // ais-relay warm-ping runs every 30min; 90min = 3× interval catches missed pings without false positives
   macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 20 },
   bisPolicy:        { key: 'seed-meta:economic:bis',              maxStaleMin: 10080 }, // runSeed('economic','bis',...) writes seed-meta:economic:bis
+  // seed-bis-extended.mjs: runSeed('economic','bis-extended',...) writes a
+  // single seed-meta key; DSR / property-residential / property-commercial
+  // are extras written via afterPublish on the same run. 24h = 2× 12h cron.
+  bisDsr:                { key: 'seed-meta:economic:bis-extended', maxStaleMin: 1440 },
+  bisPropertyResidential:{ key: 'seed-meta:economic:bis-extended', maxStaleMin: 1440 },
+  bisPropertyCommercial: { key: 'seed-meta:economic:bis-extended', maxStaleMin: 1440 },
   imfMacro:         { key: 'seed-meta:economic:imf-macro',        maxStaleMin: 100800 }, // monthly seed; 100800min = 70 days = 2× interval (absorbs one missed run)
   imfGrowth:        { key: 'seed-meta:economic:imf-growth',       maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro (same WEO release cadence)
   imfLabor:         { key: 'seed-meta:economic:imf-labor',        maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro
@@ -350,6 +359,8 @@ const ON_DEMAND_KEYS = new Set([
   'riskScoresLive',
   'usniFleetStale', 'positiveEventsLive',
   'bisPolicy', 'bisExchange', 'bisCredit',
+  // bisDsr/bisPropertyResidential/bisPropertyCommercial have dedicated SEED_META
+  // entries (seed-bis-extended.mjs), so they are not on-demand.
   'macroSignals', 'shippingRates', 'chokepoints', 'minerals', 'giving',
   'cyberThreatsRpc', 'militaryBases', 'temporalAnomalies', 'displacement',
   'corridorrisk', // intermediate key; data flows through transit-summaries:v1

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -173,7 +173,13 @@ const TOOL_REGISTRY: ToolDef[] = [
     _maxStaleMin: 1440,
     _freshnessChecks: [
       { key: 'seed-meta:economic:econ-calendar', maxStaleMin: 1440 },
-      { key: 'seed-meta:economic:bis-extended', maxStaleMin: 1440 }, // 12h cron × 2
+      // Per-dataset BIS seed-meta keys — the aggregate
+      // `seed-meta:economic:bis-extended` would report "fresh" even if only
+      // one of the three datasets (DSR / SPP / CPP) is current, matching the
+      // false-freshness bug already fixed for /api/health and resilience.
+      { key: 'seed-meta:economic:bis-dsr', maxStaleMin: 1440 }, // 12h cron × 2
+      { key: 'seed-meta:economic:bis-property-residential', maxStaleMin: 1440 },
+      { key: 'seed-meta:economic:bis-property-commercial', maxStaleMin: 1440 },
     ],
   },
   {

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -154,7 +154,7 @@ const TOOL_REGISTRY: ToolDef[] = [
   },
   {
     name: 'get_economic_data',
-    description: 'Macro economic indicators: Fed Funds rate (FRED), economic calendar events, fuel prices, ECB FX rates, EU yield curve, earnings calendar, COT positioning, and energy storage data.',
+    description: 'Macro economic indicators: Fed Funds rate (FRED), economic calendar events, fuel prices, ECB FX rates, EU yield curve, earnings calendar, COT positioning, energy storage data, BIS household debt service ratio (DSR, quarterly, leading indicator of household financial stress across ~40 advanced economies), and BIS residential + commercial property price indices (real, quarterly).',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'economic:fred:v1:FEDFUNDS:0',
@@ -165,9 +165,16 @@ const TOOL_REGISTRY: ToolDef[] = [
       'economic:spending:v1',
       'market:earnings-calendar:v1',
       'market:cot:v1',
+      'economic:bis:dsr:v1',
+      'economic:bis:property-residential:v1',
+      'economic:bis:property-commercial:v1',
     ],
     _seedMetaKey: 'seed-meta:economic:econ-calendar',
     _maxStaleMin: 1440,
+    _freshnessChecks: [
+      { key: 'seed-meta:economic:econ-calendar', maxStaleMin: 1440 },
+      { key: 'seed-meta:economic:bis-extended', maxStaleMin: 1440 }, // 12h cron × 2
+    ],
   },
   {
     name: 'get_country_macro',

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -58,6 +58,7 @@ const SEED_DOMAINS = {
   'economic:worldbank-techreadiness': { key: 'seed-meta:economic:worldbank-techreadiness:v1', intervalMin: 5040 },
   'economic:worldbank-progress':      { key: 'seed-meta:economic:worldbank-progress:v1',     intervalMin: 5040 },
   'economic:worldbank-renewable':     { key: 'seed-meta:economic:worldbank-renewable:v1',    intervalMin: 5040 },
+  'economic:bis-extended':    { key: 'seed-meta:economic:bis-extended',    intervalMin: 720 }, // 12h Railway cron; intervalMin = maxStaleMin / 2 (1440 / 2)
   'research:tech-events':    { key: 'seed-meta:research:tech-events',     intervalMin: 240 },
   'intelligence:gdelt-intel': { key: 'seed-meta:intelligence:gdelt-intel', intervalMin: 210 }, // 420min maxStaleMin / 2 — aligned with health.js (6h cron + 1h grace)
   'correlation:cards':        { key: 'seed-meta:correlation:cards',        intervalMin: 5 },

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -58,7 +58,10 @@ const SEED_DOMAINS = {
   'economic:worldbank-techreadiness': { key: 'seed-meta:economic:worldbank-techreadiness:v1', intervalMin: 5040 },
   'economic:worldbank-progress':      { key: 'seed-meta:economic:worldbank-progress:v1',     intervalMin: 5040 },
   'economic:worldbank-renewable':     { key: 'seed-meta:economic:worldbank-renewable:v1',    intervalMin: 5040 },
-  'economic:bis-extended':    { key: 'seed-meta:economic:bis-extended',    intervalMin: 720 }, // 12h Railway cron; intervalMin = maxStaleMin / 2 (1440 / 2)
+  'economic:bis-extended':    { key: 'seed-meta:economic:bis-extended',    intervalMin: 720 }, // 12h Railway cron; "seeder ran" aggregate — per-dataset freshness lives below
+  'economic:bis-dsr':                  { key: 'seed-meta:economic:bis-dsr',                  intervalMin: 720 }, // 12h cron; only written when DSR slice fetched fresh entries
+  'economic:bis-property-residential': { key: 'seed-meta:economic:bis-property-residential', intervalMin: 720 }, // 12h cron; only written when SPP slice fetched fresh entries
+  'economic:bis-property-commercial':  { key: 'seed-meta:economic:bis-property-commercial',  intervalMin: 720 }, // 12h cron; only written when CPP slice fetched fresh entries
   'research:tech-events':    { key: 'seed-meta:research:tech-events',     intervalMin: 240 },
   'intelligence:gdelt-intel': { key: 'seed-meta:intelligence:gdelt-intel', intervalMin: 210 }, // 420min maxStaleMin / 2 — aligned with health.js (6h cron + 1h grace)
   'correlation:cards':        { key: 'seed-meta:correlation:cards',        intervalMin: 5 },

--- a/scripts/seed-bis-extended.mjs
+++ b/scripts/seed-bis-extended.mjs
@@ -391,15 +391,21 @@ export async function fetchAll() {
   await publishDatasetIndependently(KEYS.spp, spp, META_KEYS.spp);
   await publishDatasetIndependently(KEYS.cpp, cpp, META_KEYS.cpp);
 
-  // DSR seed-meta is written here (not via runSeed's generic seed-meta) ONLY
-  // when DSR fetch succeeded. runSeed still writes the aggregate
-  // seed-meta:economic:bis-extended key via publishTransform/validate, but
-  // that is a "seeder ran" marker, not a DSR freshness signal.
-  if (planDatasetAction(dsr) === 'write') {
-    await writeSeedMeta(KEYS.dsr, dsr.entries.length, META_KEYS.dsr).catch(() => {});
-  }
+  // NOTE: DSR per-dataset seed-meta is written by `dsrAfterPublish` (passed to
+  // runSeed below), NOT here. That guarantees seed-meta:economic:bis-dsr is
+  // refreshed only AFTER atomicPublish succeeds on the canonical DSR key — a
+  // Redis hiccup at publish time must not leave health reporting "fresh"
+  // while the canonical key is stale.
 
   return { dsr, spp, cpp };
+}
+
+// runSeed afterPublish hook — fires only on a successful atomicPublish of the
+// canonical DSR key. `data` is the raw fetchAll() return value; we re-derive
+// the DSR slice and refresh its per-dataset seed-meta.
+export async function dsrAfterPublish(data) {
+  if (planDatasetAction(data?.dsr) !== 'write') return;
+  await writeSeedMeta(KEYS.dsr, data.dsr.entries.length, META_KEYS.dsr).catch(() => {});
 }
 
 // Pure decision function: classifies what action should be taken for a
@@ -452,6 +458,7 @@ if (process.argv[1]?.endsWith('seed-bis-extended.mjs')) {
     ttlSeconds: TTL,
     sourceVersion: 'bis-sdmx-csv-extended',
     publishTransform,
+    afterPublish: dsrAfterPublish,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-bis-extended.mjs
+++ b/scripts/seed-bis-extended.mjs
@@ -23,7 +23,7 @@
  *   - health maxStaleMin = 24h = 2× interval (see api/health.js)
  */
 
-import { loadEnvFile, CHROME_UA, runSeed, writeExtraKey } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, writeExtraKey, extendExistingTtl } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -366,6 +366,14 @@ async function fetchAll() {
   ]);
   const total = (dsr?.entries?.length || 0) + (spp?.entries?.length || 0) + (cpp?.entries?.length || 0);
   if (total === 0) throw new Error('All BIS extended fetches returned empty');
+  // When DSR is empty the publishTransform yields { entries: [] }, validate()
+  // fails, and runSeed rejects the publish — that would skip afterPublish and
+  // silently expire SPP/CPP even when their fetches succeeded. Extend existing
+  // SPP/CPP TTLs here so they survive the rejected publish; refreshed SPP/CPP
+  // data still writes through afterPublish on the next successful DSR run.
+  if (!dsr || !(dsr.entries?.length > 0)) {
+    await extendExistingTtl([KEYS.spp, KEYS.cpp], TTL).catch(() => {});
+  }
   return { dsr, spp, cpp };
 }
 

--- a/scripts/seed-bis-extended.mjs
+++ b/scripts/seed-bis-extended.mjs
@@ -272,15 +272,17 @@ function pctChange(latest, prev) {
 
 // ── Dataflow builders ──────────────────────────────────────────────────────
 
-// Household debt service ratio (private non-financial sector, consolidated,
-// adjusted). Typical BIS_DSR key dimensions: FREQ.BORROWERS_CTY.DSR_BORROWERS
-// e.g. Q.US.H (households), Q.US.P (private non-financial). Select the
-// private-sector, adjusted variant where available.
+// Household debt service ratio. BIS_DSR key dimensions:
+// FREQ.BORROWERS_CTY.DSR_BORROWERS e.g. Q.US.H (households), Q.US.P (private
+// non-financial). The UI labels this "Household DSR" and resilience scoring
+// uses it as `householdDebtService`, so we MUST prefer H — picking P would
+// mislabel private-non-financial data as household data. Countries without
+// an H series are dropped (honest absence beats silent mis-attribution).
 export function buildDsr(rows) {
   const byCountry = selectBestSeriesByCountry(rows, {
     countryColumns: ['BORROWERS_CTY', 'REF_AREA', 'Reference area', 'Borrowers\u2019 country'],
     prefs: {
-      DSR_BORROWERS: 'P', // private non-financial
+      DSR_BORROWERS: 'H', // households
       DSR_ADJUST: 'A',    // adjusted
     },
   });

--- a/scripts/seed-bis-extended.mjs
+++ b/scripts/seed-bis-extended.mjs
@@ -23,7 +23,7 @@
  *   - health maxStaleMin = 24h = 2× interval (see api/health.js)
  */
 
-import { loadEnvFile, CHROME_UA, runSeed, writeExtraKey, extendExistingTtl } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, writeExtraKey, extendExistingTtl, writeSeedMeta } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -82,6 +82,17 @@ export const KEYS = {
   dsr: 'economic:bis:dsr:v1',
   spp: 'economic:bis:property-residential:v1',
   cpp: 'economic:bis:property-commercial:v1',
+};
+
+// Per-dataset seed-meta keys. Each is ONLY written when that dataset actually
+// published fresh entries — so a DSR-only outage cleanly stales bisDsr in
+// health.js while leaving bisPropertyResidential / bisPropertyCommercial green.
+// The aggregate seed-meta:economic:bis-extended (written by runSeed) is kept
+// as a "seeder ran at all" signal in api/seed-health.js.
+export const META_KEYS = {
+  dsr: 'seed-meta:economic:bis-dsr',
+  spp: 'seed-meta:economic:bis-property-residential',
+  cpp: 'seed-meta:economic:bis-property-commercial',
 };
 
 // Quarterly data, seeded on 12h cron. 3-day TTL absorbs 2 missed cycles.
@@ -377,8 +388,16 @@ export async function fetchAll() {
   // Publish SPP/CPP independently NOW — they must not be gated on DSR. Any
   // that came back empty get their existing snapshot's TTL extended so a
   // transient upstream failure doesn't silently expire healthy data.
-  await publishDatasetIndependently(KEYS.spp, spp);
-  await publishDatasetIndependently(KEYS.cpp, cpp);
+  await publishDatasetIndependently(KEYS.spp, spp, META_KEYS.spp);
+  await publishDatasetIndependently(KEYS.cpp, cpp, META_KEYS.cpp);
+
+  // DSR seed-meta is written here (not via runSeed's generic seed-meta) ONLY
+  // when DSR fetch succeeded. runSeed still writes the aggregate
+  // seed-meta:economic:bis-extended key via publishTransform/validate, but
+  // that is a "seeder ran" marker, not a DSR freshness signal.
+  if (planDatasetAction(dsr) === 'write') {
+    await writeSeedMeta(KEYS.dsr, dsr.entries.length, META_KEYS.dsr).catch(() => {});
+  }
 
   return { dsr, spp, cpp };
 }
@@ -393,11 +412,17 @@ export function planDatasetAction(payload) {
   return 'extend';
 }
 
-export async function publishDatasetIndependently(key, payload) {
+export async function publishDatasetIndependently(key, payload, metaKey) {
   const action = planDatasetAction(payload);
   if (action === 'write') {
     try {
       await writeExtraKey(key, payload, TTL);
+      // Per-dataset seed-meta is written ONLY on a successful fresh write.
+      // On the extend-TTL branch we deliberately do NOT refresh seed-meta —
+      // that is what lets api/health.js flag a stale per-dataset outage.
+      if (metaKey) {
+        await writeSeedMeta(key, payload.entries.length, metaKey).catch(() => {});
+      }
     } catch (err) {
       console.warn(`  ${key}: write failed (${err.message}); extending existing TTL`);
       await extendExistingTtl([key], TTL).catch(() => {});

--- a/scripts/seed-bis-extended.mjs
+++ b/scripts/seed-bis-extended.mjs
@@ -1,0 +1,400 @@
+#!/usr/bin/env node
+
+/**
+ * BIS Extended seeder — ships 2 of 7 BIS dataflows flagged as genuinely new
+ * signals with clear plug-ins (see issue koala73/worldmonitor#3026):
+ *
+ *   WS_DSR   household debt service ratio (% income, quarterly)
+ *            → leading indicator of household financial stress
+ *   WS_SPP   residential property prices (real, index, quarterly)
+ *            → housing cycle early-warning
+ *   WS_CPP   commercial property prices (real, index, quarterly)
+ *            → commercial-property cycle companion to WS_SPP
+ *
+ * The 3 legacy BIS dataflows (WS_CBPOL, WS_EER, WS_TC) continue to live in
+ * seed-bis-data.mjs; this script stays isolated so a schema change in one
+ * batch doesn't take the other down. Extras are written via the same
+ * afterPublish + writeExtraKey pattern used by seed-bis-data.mjs.
+ *
+ * Gold-standard pattern:
+ *   - TTL = 3 days ≥ 3× 12h cron interval
+ *   - atomic publish + extras written via writeExtraKey
+ *   - seed-meta written under seed-meta:economic:bis-extended (runSeed)
+ *   - health maxStaleMin = 24h = 2× interval (see api/health.js)
+ */
+
+import { loadEnvFile, CHROME_UA, runSeed, writeExtraKey } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const BIS_BASE = 'https://stats.bis.org/api/v1/data';
+
+// Keep this aligned with the BIS_COUNTRIES map in seed-bis-data.mjs and
+// server/worldmonitor/economic/v1/_bis-shared.ts. BIS uses XM for Euro Area.
+const BIS_COUNTRIES = {
+  US: { name: 'United States' },
+  GB: { name: 'United Kingdom' },
+  JP: { name: 'Japan' },
+  XM: { name: 'Euro Area' },
+  CH: { name: 'Switzerland' },
+  SG: { name: 'Singapore' },
+  IN: { name: 'India' },
+  AU: { name: 'Australia' },
+  CN: { name: 'China' },
+  CA: { name: 'Canada' },
+  KR: { name: 'South Korea' },
+  BR: { name: 'Brazil' },
+  DE: { name: 'Germany' },
+  FR: { name: 'France' },
+  IT: { name: 'Italy' },
+  ES: { name: 'Spain' },
+  NL: { name: 'Netherlands' },
+  SE: { name: 'Sweden' },
+  NO: { name: 'Norway' },
+  DK: { name: 'Denmark' },
+  FI: { name: 'Finland' },
+  BE: { name: 'Belgium' },
+  IE: { name: 'Ireland' },
+  PT: { name: 'Portugal' },
+  AT: { name: 'Austria' },
+  GR: { name: 'Greece' },
+  PL: { name: 'Poland' },
+  CZ: { name: 'Czech Republic' },
+  HU: { name: 'Hungary' },
+  TR: { name: 'Türkiye' },
+  ZA: { name: 'South Africa' },
+  MX: { name: 'Mexico' },
+  CL: { name: 'Chile' },
+  CO: { name: 'Colombia' },
+  NZ: { name: 'New Zealand' },
+  HK: { name: 'Hong Kong SAR' },
+  ID: { name: 'Indonesia' },
+  MY: { name: 'Malaysia' },
+  TH: { name: 'Thailand' },
+  PH: { name: 'Philippines' },
+  RU: { name: 'Russia' },
+  IL: { name: 'Israel' },
+};
+
+const BIS_COUNTRY_KEYS = Object.keys(BIS_COUNTRIES).join('+');
+
+export const KEYS = {
+  dsr: 'economic:bis:dsr:v1',
+  spp: 'economic:bis:property-residential:v1',
+  cpp: 'economic:bis:property-commercial:v1',
+};
+
+// Quarterly data, seeded on 12h cron. 3-day TTL absorbs 2 missed cycles.
+const TTL = 3 * 24 * 3600;
+
+// ── HTTP / CSV helpers ─────────────────────────────────────────────────────
+
+async function fetchBisCSV(dataset, keySuffix) {
+  const url = `${BIS_BASE}/${dataset}/${keySuffix}${keySuffix.includes('?') ? '&' : '?'}format=csv`;
+  const resp = await fetch(url, {
+    headers: { 'User-Agent': CHROME_UA, Accept: 'text/csv' },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!resp.ok) throw Object.assign(new Error(`BIS HTTP ${resp.status} for ${dataset} (${keySuffix})`), { status: resp.status });
+  return resp.text();
+}
+
+// BIS sometimes rejects startPeriod/endPeriod on specific dataflows. Retry
+// without them before surrendering. Broader key (wildcards) is tried last.
+export async function fetchBisDataflow(dataset, { countryKeys, startPeriod }) {
+  const variants = [];
+  if (startPeriod) variants.push(`Q.${countryKeys}?startPeriod=${startPeriod}&detail=dataonly`);
+  variants.push(`Q.${countryKeys}?detail=dataonly`);
+  variants.push(`Q.${countryKeys}`);
+  let lastErr;
+  for (const suffix of variants) {
+    try {
+      return await fetchBisCSV(dataset, suffix);
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr ?? new Error(`${dataset}: all fetch variants exhausted`);
+}
+
+export function parseCSVLine(line) {
+  const result = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"' && line[i + 1] === '"') { current += '"'; i++; }
+      else if (ch === '"') { inQuotes = false; }
+      else { current += ch; }
+    } else {
+      if (ch === '"') { inQuotes = true; }
+      else if (ch === ',') { result.push(current.trim()); current = ''; }
+      else { current += ch; }
+    }
+  }
+  result.push(current.trim());
+  return result;
+}
+
+export function parseBisCSV(csv) {
+  const lines = csv.split('\n');
+  if (lines.length < 2) return [];
+  const headers = parseCSVLine(lines[0]);
+  const rows = [];
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    const vals = parseCSVLine(line);
+    const row = {};
+    for (let j = 0; j < headers.length; j++) row[headers[j]] = vals[j] || '';
+    rows.push(row);
+  }
+  return rows;
+}
+
+function parseBisNumber(val) {
+  if (!val || val === '.' || val.trim() === '') return null;
+  const n = Number(val);
+  return Number.isFinite(n) ? n : null;
+}
+
+// Shift a BIS quarter string by `delta` quarters. Returns null on unparsable
+// inputs so callers can fall back to their empty-data path.
+export function shiftQuarter(period, delta) {
+  const m = /^(\d{4})-Q([1-4])$/.exec(period ?? '');
+  if (!m) return null;
+  let year = Number(m[1]);
+  let quarter = Number(m[2]) + delta;
+  while (quarter < 1) { quarter += 4; year -= 1; }
+  while (quarter > 4) { quarter -= 4; year += 1; }
+  return `${year}-Q${quarter}`;
+}
+
+// BIS returns quarters as `2023-Q3`. Normalise to first day of quarter.
+export function quarterToDate(period) {
+  if (!period) return null;
+  const m = /^(\d{4})-Q([1-4])$/.exec(period);
+  if (!m) return period; // let through anything that's already YYYY-MM or YYYY-MM-DD
+  const year = m[1];
+  const month = ({ '1': '01', '2': '04', '3': '07', '4': '10' })[m[2]];
+  return `${year}-${month}-01`;
+}
+
+// ── Series selection ───────────────────────────────────────────────────────
+
+// Score a CSV row's series fit against a preferences map.
+// Each dimension preference either:
+//   - 'match' adds +2
+//   - 'mismatch' subtracts −1
+//   - 'unknown' (column absent) is neutral
+// Ties broken by observation count (longer series wins).
+function scoreSeriesMatch(firstRow, prefs) {
+  let score = 0;
+  for (const [dim, want] of Object.entries(prefs)) {
+    const v = firstRow[dim];
+    if (v === undefined || v === null || v === '') continue;
+    score += (v === want) ? 2 : -1;
+  }
+  return score;
+}
+
+// A "series" = all rows sharing the same dimension key (all columns except
+// TIME_PERIOD / OBS_VALUE). Pick the best series per country using prefs and
+// observation count, then emit the full time-series for the winner.
+export function selectBestSeriesByCountry(rows, { countryColumns, prefs }) {
+  const groupedByCountry = new Map();
+  for (const row of rows) {
+    const cc = countryColumns.map(col => row[col]).find(v => v && /^[A-Z]{2}$/.test(v));
+    if (!cc) continue;
+    const date = row.TIME_PERIOD || row['Time period'] || '';
+    const val = parseBisNumber(row.OBS_VALUE ?? row['Observation value']);
+    if (!date || val === null) continue;
+
+    // Build a stable series key from the row (everything that uniquely
+    // identifies a time series, minus the observation coordinates).
+    const omit = new Set(['TIME_PERIOD', 'Time period', 'OBS_VALUE', 'Observation value']);
+    const sigParts = [];
+    for (const [k, v] of Object.entries(row)) {
+      if (omit.has(k)) continue;
+      sigParts.push(`${k}=${v}`);
+    }
+    const seriesKey = sigParts.join('|');
+    if (!groupedByCountry.has(cc)) groupedByCountry.set(cc, new Map());
+    const perCountry = groupedByCountry.get(cc);
+    if (!perCountry.has(seriesKey)) perCountry.set(seriesKey, { firstRow: row, obs: [] });
+    perCountry.get(seriesKey).obs.push({ date, value: val });
+  }
+
+  const out = new Map();
+  for (const [cc, perCountry] of groupedByCountry) {
+    let best = null;
+    let bestScore = -Infinity;
+    let bestLen = -1;
+    for (const info of perCountry.values()) {
+      const s = scoreSeriesMatch(info.firstRow, prefs);
+      if (s > bestScore || (s === bestScore && info.obs.length > bestLen)) {
+        best = info;
+        bestScore = s;
+        bestLen = info.obs.length;
+      }
+    }
+    if (best) {
+      best.obs.sort((a, b) => a.date.localeCompare(b.date));
+      out.set(cc, best.obs);
+    }
+  }
+  return out;
+}
+
+function latestTwo(obs) {
+  if (!obs || obs.length === 0) return { latest: null, previous: null };
+  const latest = obs[obs.length - 1];
+  const previous = obs.length >= 2 ? obs[obs.length - 2] : null;
+  return { latest, previous };
+}
+
+function pctChange(latest, prev) {
+  if (latest == null || prev == null || prev === 0) return null;
+  return Math.round(((latest - prev) / prev) * 1000) / 10;
+}
+
+// ── Dataflow builders ──────────────────────────────────────────────────────
+
+// Household debt service ratio (private non-financial sector, consolidated,
+// adjusted). Typical BIS_DSR key dimensions: FREQ.BORROWERS_CTY.DSR_BORROWERS
+// e.g. Q.US.H (households), Q.US.P (private non-financial). Select the
+// private-sector, adjusted variant where available.
+export function buildDsr(rows) {
+  const byCountry = selectBestSeriesByCountry(rows, {
+    countryColumns: ['BORROWERS_CTY', 'REF_AREA', 'Reference area', 'Borrowers\u2019 country'],
+    prefs: {
+      DSR_BORROWERS: 'P', // private non-financial
+      DSR_ADJUST: 'A',    // adjusted
+    },
+  });
+
+  const entries = [];
+  for (const [cc, obs] of byCountry) {
+    const info = BIS_COUNTRIES[cc];
+    if (!info) continue;
+    const { latest, previous } = latestTwo(obs);
+    if (!latest) continue;
+    entries.push({
+      countryCode: cc,
+      countryName: info.name,
+      dsrPct: Math.round(latest.value * 10) / 10,
+      previousDsrPct: previous ? Math.round(previous.value * 10) / 10 : null,
+      change: pctChange(latest.value, previous?.value),
+      date: quarterToDate(latest.date),
+      period: latest.date,
+    });
+  }
+  return entries;
+}
+
+// Residential or commercial property prices, real (PP_VALUATION=R) index
+// (UNIT_MEASURE=628). Some series use UNIT_MEASURE=771 (YoY change %) which
+// we de-prefer so that the headline value is the price index level.
+export function buildPropertyPrices(rows, kind /* 'residential' | 'commercial' */) {
+  const byCountry = selectBestSeriesByCountry(rows, {
+    countryColumns: ['REF_AREA', 'Reference area'],
+    prefs: {
+      PP_VALUATION: 'R',   // real
+      UNIT_MEASURE: '628', // index
+    },
+  });
+
+  const entries = [];
+  for (const [cc, obs] of byCountry) {
+    const info = BIS_COUNTRIES[cc];
+    if (!info) continue;
+    const { latest, previous } = latestTwo(obs);
+    if (!latest) continue;
+    // Year-over-year = same quarter one year ago. Match by exact period
+    // rather than index-offset so missing quarters don't silently skew YoY.
+    const yoyPeriod = shiftQuarter(latest.date, -4);
+    const yoyPrev = yoyPeriod ? obs.find(o => o.date === yoyPeriod) : null;
+    entries.push({
+      countryCode: cc,
+      countryName: info.name,
+      kind,
+      indexValue: Math.round(latest.value * 10) / 10,
+      previousIndex: previous ? Math.round(previous.value * 10) / 10 : null,
+      qoqChange: pctChange(latest.value, previous?.value),
+      yoyChange: pctChange(latest.value, yoyPrev?.value),
+      date: quarterToDate(latest.date),
+      period: latest.date,
+    });
+  }
+  return entries;
+}
+
+// ── Fetchers ───────────────────────────────────────────────────────────────
+
+function startPeriodYearsAgo(years) {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - years);
+  return `${d.getFullYear()}-Q1`;
+}
+
+async function fetchDsr() {
+  const csv = await fetchBisDataflow('WS_DSR', {
+    countryKeys: BIS_COUNTRY_KEYS,
+    startPeriod: startPeriodYearsAgo(3),
+  });
+  const entries = buildDsr(parseBisCSV(csv));
+  console.log(`  BIS DSR: ${entries.length} countries`);
+  return entries.length > 0 ? { entries, fetchedAt: new Date().toISOString() } : null;
+}
+
+async function fetchProperty(dataset, kind) {
+  const csv = await fetchBisDataflow(dataset, {
+    countryKeys: BIS_COUNTRY_KEYS,
+    startPeriod: startPeriodYearsAgo(5),
+  });
+  const entries = buildPropertyPrices(parseBisCSV(csv), kind);
+  console.log(`  BIS ${dataset}: ${entries.length} countries`);
+  return entries.length > 0 ? { entries, fetchedAt: new Date().toISOString() } : null;
+}
+
+async function fetchAll() {
+  const [dsr, spp, cpp] = await Promise.all([
+    fetchDsr().catch(err => { console.warn(`  DSR failed: ${err.message}`); return null; }),
+    fetchProperty('WS_SPP', 'residential').catch(err => { console.warn(`  SPP failed: ${err.message}`); return null; }),
+    fetchProperty('WS_CPP', 'commercial').catch(err => { console.warn(`  CPP failed: ${err.message}`); return null; }),
+  ]);
+  const total = (dsr?.entries?.length || 0) + (spp?.entries?.length || 0) + (cpp?.entries?.length || 0);
+  if (total === 0) throw new Error('All BIS extended fetches returned empty');
+  return { dsr, spp, cpp };
+}
+
+function validate(data) {
+  return Array.isArray(data?.entries) && data.entries.length > 0;
+}
+
+// Primary publish key is DSR (required for resilience macroFiscal). Property
+// prices are written as extras through afterPublish so a single seed run
+// keeps all three keys in sync.
+function publishTransform(data) {
+  return data.dsr ?? { entries: [] };
+}
+
+async function afterPublish(data) {
+  if (data.spp) await writeExtraKey(KEYS.spp, data.spp, TTL);
+  if (data.cpp) await writeExtraKey(KEYS.cpp, data.cpp, TTL);
+}
+
+if (process.argv[1]?.endsWith('seed-bis-extended.mjs')) {
+  runSeed('economic', 'bis-extended', KEYS.dsr, fetchAll, {
+    validateFn: validate,
+    ttlSeconds: TTL,
+    sourceVersion: 'bis-sdmx-csv-extended',
+    publishTransform,
+    afterPublish,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
+    console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-bis-extended.mjs
+++ b/scripts/seed-bis-extended.mjs
@@ -358,7 +358,14 @@ async function fetchProperty(dataset, kind) {
   return entries.length > 0 ? { entries, fetchedAt: new Date().toISOString() } : null;
 }
 
-async function fetchAll() {
+// Each dataset is handled independently: a single fetch failure in any ONE
+// of DSR/SPP/CPP must not block the healthy ones from publishing fresh data.
+// We do SPP/CPP writes as side-effects of fetchAll (via writeExtraKey or
+// extendExistingTtl, per-dataset). The DSR slice flows through the normal
+// runSeed canonical-write path; when DSR is empty, publishTransform yields
+// an empty payload that fails validate() → atomicPublish.skipped=true →
+// runSeed extends the canonical DSR key's TTL in its own skipped branch.
+export async function fetchAll() {
   const [dsr, spp, cpp] = await Promise.all([
     fetchDsr().catch(err => { console.warn(`  DSR failed: ${err.message}`); return null; }),
     fetchProperty('WS_SPP', 'residential').catch(err => { console.warn(`  SPP failed: ${err.message}`); return null; }),
@@ -366,31 +373,52 @@ async function fetchAll() {
   ]);
   const total = (dsr?.entries?.length || 0) + (spp?.entries?.length || 0) + (cpp?.entries?.length || 0);
   if (total === 0) throw new Error('All BIS extended fetches returned empty');
-  // When DSR is empty the publishTransform yields { entries: [] }, validate()
-  // fails, and runSeed rejects the publish — that would skip afterPublish and
-  // silently expire SPP/CPP even when their fetches succeeded. Extend existing
-  // SPP/CPP TTLs here so they survive the rejected publish; refreshed SPP/CPP
-  // data still writes through afterPublish on the next successful DSR run.
-  if (!dsr || !(dsr.entries?.length > 0)) {
-    await extendExistingTtl([KEYS.spp, KEYS.cpp], TTL).catch(() => {});
-  }
+
+  // Publish SPP/CPP independently NOW — they must not be gated on DSR. Any
+  // that came back empty get their existing snapshot's TTL extended so a
+  // transient upstream failure doesn't silently expire healthy data.
+  await publishDatasetIndependently(KEYS.spp, spp);
+  await publishDatasetIndependently(KEYS.cpp, cpp);
+
   return { dsr, spp, cpp };
 }
 
-function validate(data) {
-  return Array.isArray(data?.entries) && data.entries.length > 0;
+// Pure decision function: classifies what action should be taken for a
+// dataset slice (write fresh vs. extend existing TTL). Unit-testable; the
+// Redis side-effects live in publishDatasetIndependently below.
+export function planDatasetAction(payload) {
+  if (payload && Array.isArray(payload.entries) && payload.entries.length > 0) {
+    return 'write';
+  }
+  return 'extend';
 }
 
-// Primary publish key is DSR (required for resilience macroFiscal). Property
-// prices are written as extras through afterPublish so a single seed run
-// keeps all three keys in sync.
-function publishTransform(data) {
-  return data.dsr ?? { entries: [] };
+export async function publishDatasetIndependently(key, payload) {
+  const action = planDatasetAction(payload);
+  if (action === 'write') {
+    try {
+      await writeExtraKey(key, payload, TTL);
+    } catch (err) {
+      console.warn(`  ${key}: write failed (${err.message}); extending existing TTL`);
+      await extendExistingTtl([key], TTL).catch(() => {});
+    }
+  } else {
+    await extendExistingTtl([key], TTL).catch(() => {});
+  }
 }
 
-async function afterPublish(data) {
-  if (data.spp) await writeExtraKey(KEYS.spp, data.spp, TTL);
-  if (data.cpp) await writeExtraKey(KEYS.cpp, data.cpp, TTL);
+// validate() is invoked by atomicPublish against the POST-publishTransform
+// payload (the DSR slice). Returning false when DSR is empty makes runSeed
+// take its skipped branch, which extends the canonical DSR key's TTL and
+// refreshes seed-meta without overwriting the existing DSR snapshot.
+export function validate(publishData) {
+  return Array.isArray(publishData?.entries) && publishData.entries.length > 0;
+}
+
+export function publishTransform(data) {
+  return data.dsr && data.dsr.entries?.length > 0
+    ? data.dsr
+    : { entries: [] };
 }
 
 if (process.argv[1]?.endsWith('seed-bis-extended.mjs')) {
@@ -399,7 +427,6 @@ if (process.argv[1]?.endsWith('seed-bis-extended.mjs')) {
     ttlSeconds: TTL,
     sourceVersion: 'bis-sdmx-csv-extended',
     publishTransform,
-    afterPublish,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-bundle-macro.mjs
+++ b/scripts/seed-bundle-macro.mjs
@@ -3,6 +3,7 @@ import { runBundle, HOUR, DAY } from './_bundle-runner.mjs';
 
 await runBundle('macro', [
   { label: 'BIS-Data', script: 'seed-bis-data.mjs', seedMetaKey: 'economic:bis', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
+  { label: 'BIS-Extended', script: 'seed-bis-extended.mjs', seedMetaKey: 'economic:bis-extended', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
   { label: 'BLS-Series', script: 'seed-bls-series.mjs', seedMetaKey: 'economic:bls-series', intervalMs: DAY, timeoutMs: 120_000 },
   { label: 'Eurostat', script: 'seed-eurostat-country-data.mjs', seedMetaKey: 'economic:eurostat-country-data', intervalMs: DAY, timeoutMs: 300_000 },
   { label: 'Eurostat-HousePrices', script: 'seed-eurostat-house-prices.mjs', seedMetaKey: 'economic:eurostat-house-prices', intervalMs: 7 * DAY, timeoutMs: 300_000 },

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -125,6 +125,9 @@ export const BOOTSTRAP_CACHE_KEYS: Record<string, string> = {
   bisPolicy:        'economic:bis:policy:v1',
   bisExchange:      'economic:bis:eer:v1',
   bisCredit:        'economic:bis:credit:v1',
+  bisDsr:           'economic:bis:dsr:v1',
+  bisPropertyResidential: 'economic:bis:property-residential:v1',
+  bisPropertyCommercial:  'economic:bis:property-commercial:v1',
   imfMacro:         'economic:imf:macro:v2',
   imfGrowth:        'economic:imf:growth:v1',
   imfLabor:         'economic:imf:labor:v1',
@@ -218,7 +221,9 @@ export const PORTWATCH_PORT_ACTIVITY_KEY_PREFIX = 'supply_chain:portwatch-ports:
 export const PORTWATCH_PORT_ACTIVITY_COUNTRIES_KEY = 'supply_chain:portwatch-ports:v1:_countries';
 
 export const BOOTSTRAP_TIERS: Record<string, 'slow' | 'fast'> = {
-  bisPolicy: 'slow', bisExchange: 'slow', bisCredit: 'slow', imfMacro: 'slow', imfGrowth: 'slow', imfLabor: 'slow', imfExternal: 'slow',
+  bisPolicy: 'slow', bisExchange: 'slow', bisCredit: 'slow',
+  bisDsr: 'slow', bisPropertyResidential: 'slow', bisPropertyCommercial: 'slow',
+  imfMacro: 'slow', imfGrowth: 'slow', imfLabor: 'slow', imfExternal: 'slow',
   minerals: 'slow', giving: 'slow', sectors: 'slow',
   progressData: 'slow', renewableEnergy: 'slow',
   etfFlows: 'slow', shippingRates: 'fast', wildfires: 'slow',

--- a/server/_shared/resilience-freshness.ts
+++ b/server/_shared/resilience-freshness.ts
@@ -28,7 +28,7 @@
 // cadences the methodology document lists without per-cadence ad-hoc
 // numbers.
 
-export type ResilienceCadence = 'realtime' | 'daily' | 'weekly' | 'monthly' | 'annual';
+export type ResilienceCadence = 'realtime' | 'daily' | 'weekly' | 'monthly' | 'quarterly' | 'annual';
 
 export type StalenessLevel = 'fresh' | 'aging' | 'stale';
 
@@ -40,6 +40,7 @@ const CADENCE_UNIT_MS: Record<ResilienceCadence, number> = {
   daily: 24 * 60 * 60 * 1000,                   // 1 day
   weekly: 7 * 24 * 60 * 60 * 1000,              // 7 days
   monthly: 30 * 24 * 60 * 60 * 1000,            // 30 days
+  quarterly: 91 * 24 * 60 * 60 * 1000,          // 91 days
   annual: 365 * 24 * 60 * 60 * 1000,            // 365 days
 };
 

--- a/server/worldmonitor/resilience/v1/_dimension-freshness.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-freshness.ts
@@ -75,6 +75,13 @@ const SOURCE_KEY_META_OVERRIDES: Readonly<Record<string, string>> = {
   // seed-meta:economic:bis (the sub-resource 'eer' is only in the data
   // key, not the meta key).
   'economic:bis:eer': 'economic:bis',
+  // seed-bis-extended.mjs: runSeed('economic', 'bis-extended', ...) writes
+  // seed-meta:economic:bis-extended. DSR is the published key; property-*
+  // keys are extras written via afterPublish on the same seed run, so all
+  // three share this seed-meta.
+  'economic:bis:dsr': 'economic:bis-extended',
+  'economic:bis:property-residential': 'economic:bis-extended',
+  'economic:bis:property-commercial': 'economic:bis-extended',
   // seed-economy.mjs: runSeed('economic', 'energy-prices', ...) writes
   // seed-meta:economic:energy-prices for the economic:energy:v1:all key.
   // The :v1:all tail means neither template-strip nor version-strip

--- a/server/worldmonitor/resilience/v1/_dimension-freshness.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-freshness.ts
@@ -75,13 +75,17 @@ const SOURCE_KEY_META_OVERRIDES: Readonly<Record<string, string>> = {
   // seed-meta:economic:bis (the sub-resource 'eer' is only in the data
   // key, not the meta key).
   'economic:bis:eer': 'economic:bis',
-  // seed-bis-extended.mjs: runSeed('economic', 'bis-extended', ...) writes
-  // seed-meta:economic:bis-extended. DSR is the published key; property-*
-  // keys are extras written via afterPublish on the same seed run, so all
-  // three share this seed-meta.
-  'economic:bis:dsr': 'economic:bis-extended',
-  'economic:bis:property-residential': 'economic:bis-extended',
-  'economic:bis:property-commercial': 'economic:bis-extended',
+  // seed-bis-extended.mjs writes per-dataset seed-meta keys
+  // (seed-meta:economic:bis-dsr, seed-meta:economic:bis-property-residential,
+  // seed-meta:economic:bis-property-commercial) so a DSR-only outage does
+  // not falsely mark the property datasets as fresh (and vice versa).
+  // These mirror the per-dataset SEED_META entries in api/health.js.
+  // The aggregate seed-meta:economic:bis-extended key still exists as a
+  // "seeder ran" signal read by api/seed-health.js; do not remove it, but
+  // this resilience-freshness map must not collapse to it.
+  'economic:bis:dsr': 'economic:bis-dsr',
+  'economic:bis:property-residential': 'economic:bis-property-residential',
+  'economic:bis:property-commercial': 'economic:bis-property-commercial',
   // seed-economy.mjs: runSeed('economic', 'energy-prices', ...) writes
   // seed-meta:economic:energy-prices for the economic:energy:v1:all key.
   // The :v1:all tail means neither template-strip nor version-strip

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -236,6 +236,7 @@ const RESILIENCE_STATIC_PREFIX = 'resilience:static:';
 const RESILIENCE_SHIPPING_STRESS_KEY = 'supply_chain:shipping_stress:v1';
 const RESILIENCE_TRANSIT_SUMMARIES_KEY = 'supply_chain:transit-summaries:v1';
 const RESILIENCE_BIS_EXCHANGE_KEY = 'economic:bis:eer:v1';
+const RESILIENCE_BIS_DSR_KEY = 'economic:bis:dsr:v1';
 const RESILIENCE_NATIONAL_DEBT_KEY = 'economic:national-debt:v1';
 const RESILIENCE_IMF_MACRO_KEY = 'economic:imf:macro:v2';
 const RESILIENCE_IMF_LABOR_KEY = 'economic:imf:labor:v1';
@@ -780,18 +781,35 @@ function scoreAquastatValue(record: ResilienceStaticCountryRecord | null): numbe
     : normalizeLowerBetter(value, 0, 5000);
 }
 
+// BIS household debt service ratio for a specific country. Returns the most
+// recent DSR (% income) from seed-bis-extended, or null when the country is
+// outside the curated BIS sample.
+function getBisDsrEntry(
+  raw: unknown,
+  countryCode: string,
+): { dsrPct: number; date: string } | null {
+  const entries = (raw as { entries?: Array<{ countryCode: string; dsrPct: number; date: string }> } | null)?.entries;
+  if (!Array.isArray(entries)) return null;
+  const hit = entries.find(e => e?.countryCode === countryCode);
+  return hit && typeof hit.dsrPct === 'number'
+    ? { dsrPct: hit.dsrPct, date: hit.date ?? '' }
+    : null;
+}
+
 export async function scoreMacroFiscal(
   countryCode: string,
   reader: ResilienceSeedReader = defaultSeedReader,
 ): Promise<ResilienceDimensionScore> {
-  const [debtRaw, imfMacroRaw, imfLaborRaw] = await Promise.all([
+  const [debtRaw, imfMacroRaw, imfLaborRaw, bisDsrRaw] = await Promise.all([
     reader(RESILIENCE_NATIONAL_DEBT_KEY),
     reader(RESILIENCE_IMF_MACRO_KEY),
     reader(RESILIENCE_IMF_LABOR_KEY),
+    reader(RESILIENCE_BIS_DSR_KEY),
   ]);
   const debtEntry = getLatestDebtEntry(debtRaw, countryCode);
   const imfEntry = getImfMacroEntry(imfMacroRaw, countryCode);
   const laborEntry = getImfLaborEntry(imfLaborRaw, countryCode);
+  const dsrEntry = getBisDsrEntry(bisDsrRaw, countryCode);
 
   return weightedBlend([
     // Government revenue/GDP: fiscal capacity — how much the state can actually mobilise.
@@ -805,15 +823,14 @@ export async function scoreMacroFiscal(
     { score: extractMetric(debtEntry, (entry) => normalizeLowerBetter(Math.max(0, safeNum(entry.annualGrowth) ?? 0), 0, 20)), weight: 0.2 },
     // Current account balance: external position — deficit = more vulnerable to FX shocks.
     imfMacroRaw == null
-      ? { score: null, weight: 0.25 }
-      : { score: imfEntry?.currentAccountPct == null ? null : normalizeHigherBetter(Math.max(-20, Math.min(imfEntry.currentAccountPct, 20)), -20, 20), weight: 0.25 },
-    // Phase 2 (#3027): IMF WEO LUR. Unemployment is a leading indicator for
-    // fiscal absorption capacity. Anchor: 25% → 0 (structural distress),
-    // 3% → 100 (tight labor market). Coverage ~150 countries — null-tolerant
-    // so weightedBlend redistributes when LUR is unavailable.
+      ? { score: null, weight: 0.2 }
+      : { score: imfEntry?.currentAccountPct == null ? null : normalizeHigherBetter(Math.max(-20, Math.min(imfEntry.currentAccountPct, 20)), -20, 20), weight: 0.2 },
     imfLaborRaw == null
       ? { score: null, weight: 0.15 }
       : { score: laborEntry?.unemploymentPct == null ? null : normalizeLowerBetter(Math.max(3, Math.min(laborEntry.unemploymentPct, 25)), 3, 25), weight: 0.15 },
+    bisDsrRaw == null || dsrEntry == null
+      ? { score: null, weight: 0.05 }
+      : { score: normalizeLowerBetter(Math.max(0, Math.min(dsrEntry.dsrPct, 20)), 0, 20), weight: 0.05 },
   ]);
 }
 

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -26,7 +26,7 @@ export type IndicatorSpec = {
   weight: number;
   sourceKey: string;
   scope: 'global' | 'curated';
-  cadence: 'realtime' | 'daily' | 'weekly' | 'monthly' | 'annual';
+  cadence: 'realtime' | 'daily' | 'weekly' | 'monthly' | 'quarterly' | 'annual';
   imputation?: { type: 'absenceSignal' | 'conservative'; score: number; certainty: number };
   // Phase 2 T2.2a additions (REQUIRED on every entry):
   tier: IndicatorTier; // Core = moves the public overall score, Enrichment = drill-down only, Experimental = internal
@@ -70,7 +70,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     description: 'Current account balance as % of GDP (IMF); external position vulnerability',
     direction: 'higherBetter',
     goalposts: { worst: -20, best: 20 },
-    weight: 0.25,
+    weight: 0.2,
     sourceKey: 'economic:imf:macro:v2',
     scope: 'global',
     cadence: 'annual',
@@ -79,12 +79,6 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     license: 'open-data',
   },
   {
-    // Phase 2 (#3027): IMF WEO LUR. Labor-market slack is a leading
-    // indicator for fiscal absorption capacity — 20%+ unemployment marks
-    // structural distress, sub-5% indicates tight labor markets.
-    // Coverage is patchier than the other WEO macro series (~150 countries
-    // — many emerging markets don't report LUR to the IMF), hence enrichment
-    // tier and a smaller weight.
     id: 'unemploymentPct',
     dimension: 'macroFiscal',
     description: 'Unemployment rate (IMF WEO LUR); higher = labor-market slack & lower fiscal absorption capacity',
@@ -97,6 +91,21 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'enrichment',
     coverage: 150,
     license: 'open-data',
+  },
+  {
+    id: 'householdDebtService',
+    dimension: 'macroFiscal',
+    description: 'BIS household debt service ratio (% income, quarterly). DSR > 10% precedes banking crises (Drehmann 2011). Lower is safer; goalposts anchor 20% → 0, 0% → 100.',
+    direction: 'lowerBetter',
+    goalposts: { worst: 20, best: 0 },
+    weight: 0.05,
+    sourceKey: 'economic:bis:dsr:v1',
+    scope: 'curated',
+    cadence: 'quarterly',
+    imputation: { type: 'conservative', score: 60, certainty: 0.3 },
+    tier: 'enrichment',
+    coverage: 40,
+    license: 'non-commercial',
   },
 
   // ── currencyExternal (3 sub-metrics, plus IMF inflation fallback for non-BIS) ─

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -675,7 +675,7 @@ export class CountryIntelManager implements AppModule {
       const pick = <T extends { countryCode: string }>(arr: T[] | undefined, cc: string): T | null =>
         arr?.find(e => e?.countryCode === cc) ?? null;
       // Euro area (XM) fallback for EU countries that BIS only publishes as a bloc aggregate.
-      const EURO_AREA = new Set(['DE', 'FR', 'IT', 'ES', 'NL', 'BE', 'AT', 'IE', 'PT', 'GR', 'FI', 'SK', 'SI', 'LV', 'LT', 'EE', 'CY', 'MT', 'LU']);
+      const EURO_AREA = new Set(['DE', 'FR', 'IT', 'ES', 'NL', 'BE', 'AT', 'IE', 'PT', 'GR', 'FI', 'SK', 'SI', 'LV', 'LT', 'EE', 'CY', 'MT', 'LU', 'HR']);
       const fallbackCC = EURO_AREA.has(code) ? 'XM' : null;
       const res = pick(body.data?.bisPropertyResidential?.entries, code) ?? (fallbackCC ? pick(body.data?.bisPropertyResidential?.entries, fallbackCC) : null);
       const com = pick(body.data?.bisPropertyCommercial?.entries, code) ?? (fallbackCC ? pick(body.data?.bisPropertyCommercial?.entries, fallbackCC) : null);

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -648,6 +648,48 @@ export class CountryIntelManager implements AppModule {
         this.ctx.countryBriefPage.updateProductImports?.(null);
       }
     });
+
+    // Housing cycle tile — BIS WS_SPP (residential), WS_CPP (commercial), WS_DSR.
+    // All three keys are seeded by the bis-extended cron and exposed via the
+    // public bootstrap endpoint, so one scoped bootstrap call covers the tile.
+    this.fetchHousingCycle(code);
+  }
+
+  private fetchHousingCycle(code: string): void {
+    const page = this.ctx.countryBriefPage;
+    if (!page?.updateHousingCycle) return;
+    const keys = 'bisDsr,bisPropertyResidential,bisPropertyCommercial';
+    fetch(toApiUrl(`/api/bootstrap?keys=${keys}`), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      signal: page.signal,
+    }).then(async resp => {
+      if (!resp.ok) return null;
+      return resp.json() as Promise<{ data?: {
+        bisDsr?: { entries?: Array<{ countryCode: string; dsrPct: number; change: number | null; period: string }> };
+        bisPropertyResidential?: { entries?: Array<{ countryCode: string; indexValue: number; qoqChange: number | null; yoyChange: number | null; period: string }> };
+        bisPropertyCommercial?: { entries?: Array<{ countryCode: string; indexValue: number; qoqChange: number | null; yoyChange: number | null; period: string }> };
+      } }>;
+    }).then(body => {
+      if (!body || this.ctx.countryBriefPage?.getCode() !== code) return;
+      const pick = <T extends { countryCode: string }>(arr: T[] | undefined, cc: string): T | null =>
+        arr?.find(e => e?.countryCode === cc) ?? null;
+      // Euro area (XM) fallback for EU countries that BIS only publishes as a bloc aggregate.
+      const EURO_AREA = new Set(['DE', 'FR', 'IT', 'ES', 'NL', 'BE', 'AT', 'IE', 'PT', 'GR', 'FI', 'SK', 'SI', 'LV', 'LT', 'EE', 'CY', 'MT', 'LU']);
+      const fallbackCC = EURO_AREA.has(code) ? 'XM' : null;
+      const res = pick(body.data?.bisPropertyResidential?.entries, code) ?? (fallbackCC ? pick(body.data?.bisPropertyResidential?.entries, fallbackCC) : null);
+      const com = pick(body.data?.bisPropertyCommercial?.entries, code) ?? (fallbackCC ? pick(body.data?.bisPropertyCommercial?.entries, fallbackCC) : null);
+      const dsr = pick(body.data?.bisDsr?.entries, code) ?? (fallbackCC ? pick(body.data?.bisDsr?.entries, fallbackCC) : null);
+      this.ctx.countryBriefPage?.updateHousingCycle?.({
+        residential: res ? { indexValue: res.indexValue, qoqChange: res.qoqChange, yoyChange: res.yoyChange, period: res.period } : null,
+        commercial: com ? { indexValue: com.indexValue, qoqChange: com.qoqChange, yoyChange: com.yoyChange, period: com.period } : null,
+        dsr: dsr ? { dsrPct: dsr.dsrPct, change: dsr.change, period: dsr.period } : null,
+      });
+    }).catch(() => {
+      if (this.ctx.countryBriefPage?.getCode() === code) {
+        this.ctx.countryBriefPage.updateHousingCycle?.(null);
+      }
+    });
   }
 
 

--- a/src/components/CountryBriefPanel.ts
+++ b/src/components/CountryBriefPanel.ts
@@ -194,4 +194,9 @@ export interface CountryBriefPanel {
   updateTariffTrends?(data: { currentRate: number; trend: string; datapoints: Array<{ year: number; tariffRate: number }> } | null): void;
   updateMultiSectorCostShock?(data: MultiSectorShockResponse | null): void;
   updateProductImports?(data: CountryProductsResponse | null): void;
+  updateHousingCycle?(data: {
+    residential?: { indexValue: number; qoqChange: number | null; yoyChange: number | null; period: string } | null;
+    commercial?: { indexValue: number; qoqChange: number | null; yoyChange: number | null; period: string } | null;
+    dsr?: { dsrPct: number; change: number | null; period: string } | null;
+  } | null): void;
 }

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -562,19 +562,19 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     if (data.residential) {
       grid.append(
         this.proMetricBox('Residential (real)', `${data.residential.indexValue.toFixed(1)}`),
-        this.proMetricBox('Residential YoY', this.formatPctTrend(data.residential.yoyChange ?? 0)),
+        this.proMetricBox('Residential YoY', this.formatPctTrend(data.residential.yoyChange)),
       );
     }
     if (data.commercial) {
       grid.append(
         this.proMetricBox('Commercial (real)', `${data.commercial.indexValue.toFixed(1)}`),
-        this.proMetricBox('Commercial YoY', this.formatPctTrend(data.commercial.yoyChange ?? 0)),
+        this.proMetricBox('Commercial YoY', this.formatPctTrend(data.commercial.yoyChange)),
       );
     }
     if (data.dsr) {
       grid.append(
         this.proMetricBox('Household DSR', `${data.dsr.dsrPct.toFixed(1)}%`),
-        this.proMetricBox('DSR QoQ', this.formatPctTrend(data.dsr.change ?? 0)),
+        this.proMetricBox('DSR QoQ', this.formatPctTrend(data.dsr.change)),
       );
     }
     this.housingBody.append(grid);
@@ -857,7 +857,8 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     return 'var(--text-muted, #64748b)';
   }
 
-  private formatPctTrend(pct: number): string {
+  private formatPctTrend(pct: number | null | undefined): string {
+    if (pct == null || !Number.isFinite(pct)) return '\u2014';
     const sign = pct >= 0 ? '+' : '';
     return `${sign}${pct.toFixed(1)}%`;
   }

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -99,6 +99,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   private militaryBody: HTMLElement | null = null;
   private infrastructureBody: HTMLElement | null = null;
   private economicBody: HTMLElement | null = null;
+  private housingBody: HTMLElement | null = null;
   private marketsBody: HTMLElement | null = null;
   private briefBody: HTMLElement | null = null;
   private timelineBody: HTMLElement | null = null;
@@ -544,6 +545,44 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     grid.append(this.factItem(t('countryBrief.facts.currencies'), data.currencies.join(', ')));
 
     this.factsBody.append(grid);
+  }
+
+  public updateHousingCycle(data: {
+    residential?: { indexValue: number; qoqChange: number | null; yoyChange: number | null; period: string } | null;
+    commercial?: { indexValue: number; qoqChange: number | null; yoyChange: number | null; period: string } | null;
+    dsr?: { dsrPct: number; change: number | null; period: string } | null;
+  } | null): void {
+    if (!this.housingBody) return;
+    this.housingBody.replaceChildren();
+    if (!data || (!data.residential && !data.commercial && !data.dsr)) {
+      this.housingBody.append(this.makeEmpty('No BIS housing cycle data for this country'));
+      return;
+    }
+    const grid = this.el('div', 'cdp-pro-metric-grid');
+    if (data.residential) {
+      grid.append(
+        this.proMetricBox('Residential (real)', `${data.residential.indexValue.toFixed(1)}`),
+        this.proMetricBox('Residential YoY', this.formatPctTrend(data.residential.yoyChange ?? 0)),
+      );
+    }
+    if (data.commercial) {
+      grid.append(
+        this.proMetricBox('Commercial (real)', `${data.commercial.indexValue.toFixed(1)}`),
+        this.proMetricBox('Commercial YoY', this.formatPctTrend(data.commercial.yoyChange ?? 0)),
+      );
+    }
+    if (data.dsr) {
+      grid.append(
+        this.proMetricBox('Household DSR', `${data.dsr.dsrPct.toFixed(1)}%`),
+        this.proMetricBox('DSR QoQ', this.formatPctTrend(data.dsr.change ?? 0)),
+      );
+    }
+    this.housingBody.append(grid);
+    const src = data.residential?.period || data.commercial?.period || data.dsr?.period || '';
+    if (src) {
+      const note = this.el('div', 'cdp-economic-source', `Source: BIS SDMX · latest ${src}`);
+      this.housingBody.append(note);
+    }
   }
 
   public updateNationalDebt(entry: { debtToGdp: number; debtUsd: number; annualGrowth: number; source: string } | null): void {
@@ -2164,6 +2203,10 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     const [militaryCard, militaryBody] = this.sectionCard(t('countryBrief.militaryActivity'));
     const [infraCard, infraBody] = this.sectionCard(t('countryBrief.infrastructure'));
     const [economicCard, economicBody] = this.sectionCard(t('countryBrief.economicIndicators'));
+    const [housingCard, housingBody] = this.sectionCard(
+      'Housing Cycle',
+      'BIS quarterly real residential and commercial property price indices plus household debt service ratio — early-warning signals for credit / property cycle turns.',
+    );
     const [marketsCard, marketsBody] = this.sectionCard(t('countryBrief.predictionMarkets'));
     const [briefCard, briefBody] = this.sectionCard(t('countryBrief.intelBrief'));
 
@@ -2224,6 +2267,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.militaryBody = militaryBody;
     this.infrastructureBody = infraBody;
     this.economicBody = economicBody;
+    this.housingBody = housingBody;
     this.marketsBody = marketsBody;
     this.briefBody = briefBody;
 
@@ -2232,10 +2276,11 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     militaryBody.append(this.makeLoading('Loading flights, vessels, and nearby bases…'));
     infraBody.append(this.makeLoading('Computing nearby critical infrastructure…'));
     economicBody.append(this.makeLoading('Loading available indicators…'));
+    housingBody.append(this.makeLoading('Loading housing cycle data…'));
     marketsBody.append(this.makeLoading(t('countryBrief.loadingMarkets')));
     briefBody.append(this.makeLoading(t('countryBrief.generatingBrief')));
 
-    bodyGrid.append(briefCard, factsExpanded, energyCard, maritimeCard, tradeCard, costShockCalcCard, productImportsCard, debtCard, sanctionsCard, comtradeCard, tariffCard, signalsCard, timelineCard, newsCard, militaryCard, infraCard, economicCard, marketsCard);
+    bodyGrid.append(briefCard, factsExpanded, energyCard, maritimeCard, tradeCard, costShockCalcCard, productImportsCard, debtCard, sanctionsCard, comtradeCard, tariffCard, signalsCard, timelineCard, newsCard, militaryCard, infraCard, economicCard, housingCard, marketsCard);
     shell.append(header, summaryGrid, bodyGrid);
     this.content.append(shell);
   }
@@ -2259,6 +2304,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.tradeExposureBody = null;
     this.productImportsBody = null;
     this.debtBody = null;
+    this.housingBody = null;
     this.sanctionsBody = null;
     this.comtradeBody = null;
     this.tariffBody = null;

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -1,0 +1,105 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  parseBisCSV,
+  selectBestSeriesByCountry,
+  buildDsr,
+  buildPropertyPrices,
+  quarterToDate,
+  KEYS,
+} from '../scripts/seed-bis-extended.mjs';
+
+// Minimal BIS-style SDMX CSV fixture covering:
+//   - Two DSR series per country (one private/adjusted → preferred, one
+//     households/unadjusted → deprioritised) so selectBestSeriesByCountry
+//     has to use dimension prefs to pick.
+//   - A real-index SPP series plus a YoY-pct series — the real-index
+//     variant (UNIT_MEASURE=628, PP_VALUATION=R) must win.
+//   - Missing values (`.`) and empty rows — must be discarded.
+const DSR_CSV = [
+  'FREQ,BORROWERS_CTY,DSR_BORROWERS,DSR_ADJUST,TIME_PERIOD,OBS_VALUE',
+  'Q,US,P,A,2023-Q2,9.8',
+  'Q,US,P,A,2023-Q3,10.1',
+  'Q,US,P,A,2023-Q4,10.4',
+  'Q,US,H,U,2023-Q2,7.5',
+  'Q,US,H,U,2023-Q3,7.6',
+  'Q,GB,P,A,2023-Q3,8.2',
+  'Q,GB,P,A,2023-Q4,.',
+  'Q,GB,P,A,2023-Q4,8.5',
+  '',
+].join('\n');
+
+const SPP_CSV = [
+  'FREQ,REF_AREA,UNIT_MEASURE,PP_VALUATION,TIME_PERIOD,OBS_VALUE',
+  'Q,US,628,R,2022-Q4,100.0',
+  'Q,US,628,R,2023-Q1,101.2',
+  'Q,US,628,R,2023-Q2,102.5',
+  'Q,US,628,R,2023-Q3,103.0',
+  'Q,US,628,R,2023-Q4,104.1',
+  'Q,US,628,R,2024-Q4,108.5',
+  'Q,US,771,R,2023-Q3,5.4', // YoY-change variant — must not be chosen
+  'Q,XM,628,R,2023-Q4,99.0',
+  'Q,XM,628,R,2024-Q4,100.5',
+].join('\n');
+
+describe('seed-bis-extended parser', () => {
+  it('exports the canonical Redis keys', () => {
+    assert.equal(KEYS.dsr, 'economic:bis:dsr:v1');
+    assert.equal(KEYS.spp, 'economic:bis:property-residential:v1');
+    assert.equal(KEYS.cpp, 'economic:bis:property-commercial:v1');
+  });
+
+  it('maps BIS quarter strings to first day of the quarter', () => {
+    assert.equal(quarterToDate('2023-Q3'), '2023-07-01');
+    assert.equal(quarterToDate('2024-Q1'), '2024-01-01');
+    assert.equal(quarterToDate('2024-Q4'), '2024-10-01');
+    // Non-quarterly strings pass through unchanged (monthly or daily BIS periods).
+    assert.equal(quarterToDate('2024-06'), '2024-06');
+  });
+
+  it('parses CSV rows and drops blank lines', () => {
+    const rows = parseBisCSV(DSR_CSV);
+    assert.ok(rows.length >= 7, 'expected at least 7 non-empty rows');
+    assert.equal(rows[0].TIME_PERIOD, '2023-Q2');
+    assert.equal(rows[0].BORROWERS_CTY, 'US');
+  });
+
+  it('buildDsr prefers DSR_BORROWERS=P / DSR_ADJUST=A and returns latest+QoQ', () => {
+    const rows = parseBisCSV(DSR_CSV);
+    const entries = buildDsr(rows);
+    const us = entries.find(e => e.countryCode === 'US');
+    assert.ok(us, 'expected US entry');
+    // The adjusted-private series wins, so latest must be 10.4 not 7.6.
+    assert.equal(us.dsrPct, 10.4);
+    assert.equal(us.previousDsrPct, 10.1);
+    assert.equal(us.period, '2023-Q4');
+    assert.equal(us.date, '2023-10-01');
+    assert.ok(us.change !== null);
+  });
+
+  it('buildPropertyPrices picks the real-index series (628/R) and computes YoY', () => {
+    const rows = parseBisCSV(SPP_CSV);
+    const entries = buildPropertyPrices(rows, 'residential');
+    const us = entries.find(e => e.countryCode === 'US');
+    assert.ok(us, 'expected US entry');
+    assert.equal(us.indexValue, 108.5); // latest observation
+    assert.equal(us.period, '2024-Q4');
+    assert.equal(us.kind, 'residential');
+    // YoY: 108.5 / 104.1 − 1 ≈ 4.2%.
+    assert.ok(us.yoyChange !== null && Math.abs(us.yoyChange - 4.2) < 0.2, `yoyChange=${us.yoyChange}`);
+    // Euro Area (XM) should also come through.
+    const xm = entries.find(e => e.countryCode === 'XM');
+    assert.ok(xm, 'expected XM entry');
+    assert.equal(xm.kind, 'residential');
+  });
+
+  it('selectBestSeriesByCountry ignores series with no usable observations', () => {
+    const rows = [
+      { FREQ: 'Q', REF_AREA: 'US', UNIT_MEASURE: '628', PP_VALUATION: 'R', TIME_PERIOD: '2023-Q1', OBS_VALUE: '.' },
+      { FREQ: 'Q', REF_AREA: 'US', UNIT_MEASURE: '628', PP_VALUATION: 'R', TIME_PERIOD: '2023-Q2', OBS_VALUE: '' },
+    ];
+    const out = selectBestSeriesByCountry(rows, { countryColumns: ['REF_AREA'], prefs: { PP_VALUATION: 'R' } });
+    assert.equal(out.size, 0);
+  });
+});

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -11,6 +11,7 @@ import {
   publishTransform,
   planDatasetAction,
   publishDatasetIndependently,
+  dsrAfterPublish,
   KEYS,
   META_KEYS,
 } from '../scripts/seed-bis-extended.mjs';
@@ -194,6 +195,53 @@ describe('seed-bis-extended parser', () => {
       // Any SET at all on the extend path is wrong — only EXPIRE-style calls expected.
       const canonicalSets = calls.filter(c => c[0] === 'SET' && c[1] === KEYS.dsr);
       assert.equal(canonicalSets.length, 0, `canonical key must NOT be re-written on extend-TTL path`);
+    } finally {
+      globalThis.fetch = origFetch;
+      if (origUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL; else process.env.UPSTASH_REDIS_REST_URL = origUrl;
+      if (origTok === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN; else process.env.UPSTASH_REDIS_REST_TOKEN = origTok;
+    }
+  });
+
+  it('dsrAfterPublish writes seed-meta:economic:bis-dsr only after a successful canonical DSR publish', async () => {
+    // Regression for the ordering bug: previously seed-meta was written
+    // INSIDE fetchAll() before runSeed/atomicPublish ran. If atomicPublish
+    // then failed (Redis hiccup), seed-meta would already be bumped → health
+    // reports DSR fresh while the canonical key is stale. The fix moves the
+    // write into an afterPublish callback that fires only on successful
+    // canonical publish.
+    const origUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const origTok = process.env.UPSTASH_REDIS_REST_TOKEN;
+    const origFetch = globalThis.fetch;
+    process.env.UPSTASH_REDIS_REST_URL = 'https://mock.upstash.invalid';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'mock-token';
+    const calls = [];
+    globalThis.fetch = async (_url, opts) => {
+      const body = JSON.parse(opts.body);
+      calls.push(body);
+      return { ok: true, status: 200, json: async () => ({ result: 'OK' }) };
+    };
+    try {
+      // 1. DSR populated → seed-meta IS written (this is the post-publish path).
+      calls.length = 0;
+      await dsrAfterPublish({
+        dsr: { entries: [{ countryCode: 'US', dsrPct: 10.4 }], fetchedAt: 't' },
+        spp: null,
+        cpp: null,
+      });
+      const metaSets = calls.filter(c => c[0] === 'SET' && c[1] === META_KEYS.dsr);
+      assert.equal(metaSets.length, 1, `expected SET on ${META_KEYS.dsr} after successful publish, got ${JSON.stringify(calls)}`);
+
+      // 2. DSR null/empty → seed-meta NOT written. atomicPublish would have
+      //    skipped the canonical write in this case anyway (validate=false),
+      //    but this guards against a future caller invoking the hook with an
+      //    empty slice.
+      calls.length = 0;
+      await dsrAfterPublish({ dsr: null, spp: null, cpp: null });
+      assert.equal(calls.length, 0, `expected no Redis calls when DSR slice is empty, got ${JSON.stringify(calls)}`);
+
+      calls.length = 0;
+      await dsrAfterPublish({ dsr: { entries: [] }, spp: null, cpp: null });
+      assert.equal(calls.length, 0, `expected no Redis calls when DSR slice has zero entries`);
     } finally {
       globalThis.fetch = origFetch;
       if (origUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL; else process.env.UPSTASH_REDIS_REST_URL = origUrl;

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -7,6 +7,9 @@ import {
   buildDsr,
   buildPropertyPrices,
   quarterToDate,
+  validate,
+  publishTransform,
+  planDatasetAction,
   KEYS,
 } from '../scripts/seed-bis-extended.mjs';
 
@@ -92,6 +95,53 @@ describe('seed-bis-extended parser', () => {
     const xm = entries.find(e => e.countryCode === 'XM');
     assert.ok(xm, 'expected XM entry');
     assert.equal(xm.kind, 'residential');
+  });
+
+  it('decouples DSR / SPP / CPP: DSR empty + SPP+CPP healthy → SPP+CPP written, DSR TTL extended', () => {
+    // Simulated fetchAll() output when WS_DSR fetch failed but WS_SPP / WS_CPP
+    // succeeded. The previous code hard-gated everything on DSR: publishTransform
+    // would yield { entries: [] }, validate() would fail on the full object, and
+    // afterPublish() never ran → fresh SPP/CPP data silently dropped. The fix
+    // must classify each dataset independently.
+    const data = {
+      dsr: null,
+      spp: { entries: [{ countryCode: 'US', indexValue: 108.5 }], fetchedAt: 't' },
+      cpp: { entries: [{ countryCode: 'US', indexValue: 95.2 }], fetchedAt: 't' },
+    };
+    // SPP/CPP must be WRITTEN (fresh data).
+    assert.equal(planDatasetAction(data.spp), 'write');
+    assert.equal(planDatasetAction(data.cpp), 'write');
+    // DSR must have its EXISTING TTL extended (no canonical overwrite).
+    assert.equal(planDatasetAction(data.dsr), 'extend');
+    // publishTransform yields an empty DSR payload → validate() returns false
+    // → atomicPublish skips the canonical DSR write and extends its TTL via
+    // runSeed's own skipped branch (preserving the previous DSR snapshot).
+    const publishData = publishTransform(data);
+    assert.deepEqual(publishData, { entries: [] });
+    assert.equal(validate(publishData), false);
+  });
+
+  it('decouples DSR / SPP / CPP: DSR healthy + SPP+CPP empty → DSR written, SPP+CPP TTLs extended', () => {
+    // Reverse failure mode: DSR fetch succeeded, SPP/CPP both returned empty
+    // (e.g. BIS property-price endpoint hiccup). DSR must still publish fresh
+    // data; SPP/CPP old snapshots must survive via TTL extension.
+    const data = {
+      dsr: { entries: [{ countryCode: 'US', dsrPct: 10.4 }], fetchedAt: 't' },
+      spp: null,
+      cpp: null,
+    };
+    assert.equal(planDatasetAction(data.dsr), 'write');
+    assert.equal(planDatasetAction(data.spp), 'extend');
+    assert.equal(planDatasetAction(data.cpp), 'extend');
+    const publishData = publishTransform(data);
+    assert.equal(publishData, data.dsr); // passes DSR slice straight through
+    assert.equal(validate(publishData), true); // canonical DSR write proceeds
+  });
+
+  it('planDatasetAction treats a {entries:[]} slice as extend-TTL (not write)', () => {
+    assert.equal(planDatasetAction({ entries: [] }), 'extend');
+    assert.equal(planDatasetAction(null), 'extend');
+    assert.equal(planDatasetAction(undefined), 'extend');
   });
 
   it('selectBestSeriesByCountry ignores series with no usable observations', () => {

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -10,7 +10,9 @@ import {
   validate,
   publishTransform,
   planDatasetAction,
+  publishDatasetIndependently,
   KEYS,
+  META_KEYS,
 } from '../scripts/seed-bis-extended.mjs';
 
 // Minimal BIS-style SDMX CSV fixture covering:
@@ -51,6 +53,19 @@ describe('seed-bis-extended parser', () => {
     assert.equal(KEYS.dsr, 'economic:bis:dsr:v1');
     assert.equal(KEYS.spp, 'economic:bis:property-residential:v1');
     assert.equal(KEYS.cpp, 'economic:bis:property-commercial:v1');
+  });
+
+  it('exports per-dataset seed-meta keys distinct from the aggregate', () => {
+    // Health monitoring (api/health.js bisDsr / bisPropertyResidential /
+    // bisPropertyCommercial) points at these keys — the whole point of the
+    // P1 fix is that a DSR-only outage stales ONLY bisDsr, not all three.
+    assert.equal(META_KEYS.dsr, 'seed-meta:economic:bis-dsr');
+    assert.equal(META_KEYS.spp, 'seed-meta:economic:bis-property-residential');
+    assert.equal(META_KEYS.cpp, 'seed-meta:economic:bis-property-commercial');
+    // Must not collide with the aggregate "seeder ran" marker.
+    assert.notEqual(META_KEYS.dsr, 'seed-meta:economic:bis-extended');
+    assert.notEqual(META_KEYS.spp, 'seed-meta:economic:bis-extended');
+    assert.notEqual(META_KEYS.cpp, 'seed-meta:economic:bis-extended');
   });
 
   it('maps BIS quarter strings to first day of the quarter', () => {
@@ -142,6 +157,48 @@ describe('seed-bis-extended parser', () => {
     assert.equal(planDatasetAction({ entries: [] }), 'extend');
     assert.equal(planDatasetAction(null), 'extend');
     assert.equal(planDatasetAction(undefined), 'extend');
+  });
+
+  it('publishDatasetIndependently writes per-dataset seed-meta ONLY on fresh write, not on extend-TTL', async () => {
+    // Capture every Upstash REST call so we can assert which keys were touched.
+    const origUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const origTok = process.env.UPSTASH_REDIS_REST_TOKEN;
+    const origFetch = globalThis.fetch;
+    process.env.UPSTASH_REDIS_REST_URL = 'https://mock.upstash.invalid';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'mock-token';
+    const calls = [];
+    globalThis.fetch = async (_url, opts) => {
+      const body = JSON.parse(opts.body);
+      calls.push(body); // e.g. ['SET', 'key', 'value', 'EX', 123] or ['EXPIRE', ...]
+      return { ok: true, status: 200, json: async () => ({ result: 'OK' }) };
+    };
+    try {
+      // 1. Fresh payload → canonical key written + per-dataset seed-meta written.
+      calls.length = 0;
+      await publishDatasetIndependently(
+        KEYS.spp,
+        { entries: [{ countryCode: 'US', indexValue: 108.5 }], fetchedAt: 't' },
+        META_KEYS.spp,
+      );
+      const sets = calls.filter(c => c[0] === 'SET').map(c => c[1]);
+      assert.ok(sets.includes(KEYS.spp), `expected SET on canonical key ${KEYS.spp}, got ${JSON.stringify(sets)}`);
+      assert.ok(sets.includes(META_KEYS.spp), `expected SET on seed-meta key ${META_KEYS.spp}, got ${JSON.stringify(sets)}`);
+
+      // 2. Empty payload → canonical key TTL extended, seed-meta NOT written.
+      //    (This is the core P1 invariant: a DSR outage must not refresh
+      //     seed-meta:economic:bis-dsr, otherwise health lies "fresh".)
+      calls.length = 0;
+      await publishDatasetIndependently(KEYS.dsr, null, META_KEYS.dsr);
+      const metaSets = calls.filter(c => c[0] === 'SET' && c[1] === META_KEYS.dsr);
+      assert.equal(metaSets.length, 0, `seed-meta must NOT be written on extend-TTL path, got ${JSON.stringify(metaSets)}`);
+      // Any SET at all on the extend path is wrong — only EXPIRE-style calls expected.
+      const canonicalSets = calls.filter(c => c[0] === 'SET' && c[1] === KEYS.dsr);
+      assert.equal(canonicalSets.length, 0, `canonical key must NOT be re-written on extend-TTL path`);
+    } finally {
+      globalThis.fetch = origFetch;
+      if (origUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL; else process.env.UPSTASH_REDIS_REST_URL = origUrl;
+      if (origTok === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN; else process.env.UPSTASH_REDIS_REST_TOKEN = origTok;
+    }
   });
 
   it('selectBestSeriesByCountry ignores series with no usable observations', () => {

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -253,7 +253,17 @@ describe('Bootstrap key hydration coverage', () => {
     const allSrc = srcFiles.map(f => readFileSync(f, 'utf-8')).join('\n');
 
     // Keys with planned but not-yet-wired consumers
-    const PENDING_CONSUMERS = new Set(['correlationCards', 'euGasStorage', 'chokepointBaselines', 'imfMacro', 'imfGrowth', 'imfLabor', 'imfExternal', 'portwatchChokepointsRef', 'portwatchPortActivity', 'sprPolicies', 'wsbTickers', 'electricityPrices', 'jodiOil', 'eurostatHousePrices', 'eurostatGovDebtQ', 'eurostatIndProd']);
+    const PENDING_CONSUMERS = new Set([
+      'correlationCards', 'euGasStorage', 'chokepointBaselines', 'imfMacro',
+      'imfGrowth', 'imfLabor', 'imfExternal',
+      'portwatchChokepointsRef', 'portwatchPortActivity', 'sprPolicies',
+      'wsbTickers', 'electricityPrices', 'jodiOil',
+      'eurostatHousePrices', 'eurostatGovDebtQ', 'eurostatIndProd',
+      // BIS extended dataflows are consumed via a direct scoped bootstrap
+      // fetch in CountryDeepDivePanel (housing cycle tile), not through the
+      // getHydratedData session cache — fetched on-click per country.
+      'bisDsr', 'bisPropertyResidential', 'bisPropertyCommercial',
+    ]);
     for (const key of keys) {
       if (PENDING_CONSUMERS.has(key)) continue;
       assert.ok(

--- a/tests/resilience-dimension-freshness.test.mts
+++ b/tests/resilience-dimension-freshness.test.mts
@@ -355,6 +355,19 @@ describe('resolveSeedMetaKey (T1.5 propagation pass, P1 fix)', () => {
     // Overrides for sourceKeys that still diverge after strip.
     assert.equal(resolveSeedMetaKey('economic:imf:macro:v2'), 'seed-meta:economic:imf-macro');
     assert.equal(resolveSeedMetaKey('economic:bis:eer:v1'), 'seed-meta:economic:bis');
+    // Per-dataset BIS seed-meta keys (P1 fix): seed-bis-extended.mjs writes
+    // seed-meta:economic:bis-dsr / bis-property-residential / bis-property-commercial
+    // independently. Must NOT collapse to the aggregate bis-extended key or a
+    // DSR-only outage would falsely report macroFiscal inputs as fresh.
+    assert.equal(resolveSeedMetaKey('economic:bis:dsr:v1'), 'seed-meta:economic:bis-dsr');
+    assert.equal(
+      resolveSeedMetaKey('economic:bis:property-residential:v1'),
+      'seed-meta:economic:bis-property-residential',
+    );
+    assert.equal(
+      resolveSeedMetaKey('economic:bis:property-commercial:v1'),
+      'seed-meta:economic:bis-property-commercial',
+    );
     assert.equal(resolveSeedMetaKey('economic:energy:v1:all'), 'seed-meta:economic:energy-prices');
     assert.equal(resolveSeedMetaKey('energy:mix:v1:{ISO2}'), 'seed-meta:economic:owid-energy-mix');
     assert.equal(

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -327,12 +327,15 @@ describe('resilience dimension scorers', () => {
       if (key === 'economic:national-debt:v1') return { entries: [{ iso3: 'HRV', debtToGdp: 70, annualGrowth: 1.5 }] };
       if (key === 'economic:imf:macro:v2') return { countries: { HR: { inflationPct: 3.0, currentAccountPct: caPct, govRevenuePct: 40, year: 2024 } } };
       if (key === 'economic:imf:labor:v1') return { countries: { HR: { unemploymentPct: 7, populationMillions: 4, year: 2024 } } };
+      if (key === 'economic:bis:dsr:v1') return { entries: [] };
       return null;
     };
     const surplus = await scoreMacroFiscal('HR', makeReader(10));
     const deficit = await scoreMacroFiscal('HR', makeReader(-15));
     assert.ok(surplus.score > deficit.score, `surplus (${surplus.score}) must score higher than deficit (${deficit.score})`);
-    assert.equal(surplus.coverage, 1, 'all real data → coverage=1');
+    // BIS DSR has weight 0.05 and is absent for HR (no BIS coverage); the
+    // remaining 0.95 of weight is observed → coverage=0.95, not 1.0.
+    assert.equal(surplus.coverage, 0.95, 'all non-BIS data → coverage=0.95 (DSR=0.05 absent for HR)');
   });
 
   it('scoreMacroFiscal: IMF macro seed outage does not impute — debt growth still scores', async () => {

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -360,14 +360,15 @@ describe('resilience dimension scorers', () => {
     const makeReader = (lur: number) => async (key: string): Promise<unknown | null> => {
       if (key in baseFixtures) return (baseFixtures as Record<string, unknown>)[key];
       if (key === 'economic:imf:labor:v1') return { countries: { HR: { unemploymentPct: lur, populationMillions: 4, year: 2024 } } };
+      if (key === 'economic:bis:dsr:v1') return { entries: [{ countryCode: 'HR', dsrPct: 8, date: '2024-Q4' }] };
       return null;
     };
     const tightLabor = await scoreMacroFiscal('HR', makeReader(3.5));
     const slackLabor = await scoreMacroFiscal('HR', makeReader(20));
     assert.ok(tightLabor.score > slackLabor.score,
       `tight labor (LUR=3.5%, score=${tightLabor.score}) must outrank slack (LUR=20%, score=${slackLabor.score})`);
-    assert.equal(tightLabor.coverage, 1, 'all four sub-metrics observed → coverage=1');
-    assert.equal(slackLabor.coverage, 1, 'all four sub-metrics observed → coverage=1');
+    assert.equal(tightLabor.coverage, 1, 'all five sub-metrics observed → coverage=1');
+    assert.equal(slackLabor.coverage, 1, 'all five sub-metrics observed → coverage=1');
   });
 
   it('scoreFoodWater: country absent from FAO/IPC DB gets crisis_monitoring_absent imputation (not WGI proxy)', async () => {

--- a/tests/resilience-indicator-registry.test.mts
+++ b/tests/resilience-indicator-registry.test.mts
@@ -28,7 +28,7 @@ describe('indicator registry', () => {
   });
 
   it('every indicator has valid cadence and scope', () => {
-    const validCadences = new Set(['realtime', 'daily', 'weekly', 'monthly', 'annual']);
+    const validCadences = new Set(['realtime', 'daily', 'weekly', 'monthly', 'quarterly', 'annual']);
     const validScopes = new Set(['global', 'curated']);
     for (const spec of INDICATOR_REGISTRY) {
       assert.ok(validCadences.has(spec.cadence), `${spec.id} has invalid cadence: ${spec.cadence}`);

--- a/tests/resilience-scorers.test.mts
+++ b/tests/resilience-scorers.test.mts
@@ -93,7 +93,7 @@ describe('resilience scorer contracts', () => {
     }));
 
     assert.deepEqual(domainAverages, {
-      economic: 66.67,
+      economic: 68.33,
       infrastructure: 79,
       energy: 80,
       'social-governance': 61.75,
@@ -126,7 +126,7 @@ describe('resilience scorer contracts', () => {
     const stressScore = round(coverageWeightedMean(stressDims));
     const stressFactor = round(Math.max(0, Math.min(1 - stressScore / 100, 0.5)), 4);
 
-    assert.equal(baselineScore, 62.3);
+    assert.equal(baselineScore, 62.64);
     assert.equal(stressScore, 65.84);
     assert.equal(stressFactor, 0.3416);
 
@@ -140,7 +140,7 @@ describe('resilience scorer contracts', () => {
         return round(cwMean) * getResilienceDomainWeight(domainId);
       }).reduce((sum, v) => sum + v, 0),
     );
-    assert.equal(overallScore, 65.3);
+    assert.equal(overallScore, 65.57);
   });
 
   it('baselineScore is computed from baseline + mixed dimensions only', async () => {
@@ -211,7 +211,7 @@ describe('resilience scorer contracts', () => {
     );
 
     assert.ok(expected > 0, 'overall should be positive');
-    assert.equal(expected, 65.3, 'overallScore should match sum(domainScore * domainWeight)');
+    assert.equal(expected, 65.57, 'overallScore should match sum(domainScore * domainWeight)');
   });
 
   it('stressFactor is still computed (informational) and clamped to [0, 0.5]', () => {

--- a/tests/resilience-scorers.test.mts
+++ b/tests/resilience-scorers.test.mts
@@ -93,7 +93,7 @@ describe('resilience scorer contracts', () => {
     }));
 
     assert.deepEqual(domainAverages, {
-      economic: 68,
+      economic: 66.67,
       infrastructure: 79,
       energy: 80,
       'social-governance': 61.75,
@@ -126,7 +126,7 @@ describe('resilience scorer contracts', () => {
     const stressScore = round(coverageWeightedMean(stressDims));
     const stressFactor = round(Math.max(0, Math.min(1 - stressScore / 100, 0.5)), 4);
 
-    assert.equal(baselineScore, 62.59);
+    assert.equal(baselineScore, 62.3);
     assert.equal(stressScore, 65.84);
     assert.equal(stressFactor, 0.3416);
 
@@ -140,7 +140,7 @@ describe('resilience scorer contracts', () => {
         return round(cwMean) * getResilienceDomainWeight(domainId);
       }).reduce((sum, v) => sum + v, 0),
     );
-    assert.equal(overallScore, 65.52);
+    assert.equal(overallScore, 65.3);
   });
 
   it('baselineScore is computed from baseline + mixed dimensions only', async () => {
@@ -211,7 +211,7 @@ describe('resilience scorer contracts', () => {
     );
 
     assert.ok(expected > 0, 'overall should be positive');
-    assert.equal(expected, 65.52, 'overallScore should match sum(domainScore * domainWeight)');
+    assert.equal(expected, 65.3, 'overallScore should match sum(domainScore * domainWeight)');
   });
 
   it('stressFactor is still computed (informational) and clamped to [0, 0.5]', () => {


### PR DESCRIPTION
Ships 2 of 7 BIS dataflows flagged as genuinely new signals in #3026 —
the rest are redundant with IMF/WB or are low-fit global aggregates.

New seeder: scripts/seed-bis-extended.mjs
  - WS_DSR   household debt service ratio (% income, quarterly)
  - WS_SPP   residential property prices (real index, quarterly)
  - WS_CPP   commercial property prices (real index, quarterly)

Gold-standard pattern: atomic publish + writeExtraKey for extras, retry
on missing startPeriod, TTL = 3 days (3× 12h cron), runSeed drives
seed-meta:economic:bis-extended. Series selection scores dimension
matches (PP_VALUATION=R / UNIT_MEASURE=628 for property, DSR_BORROWERS=P
/ DSR_ADJUST=A for DSR), then falls back to observation count.

Wired into:
  - bootstrap (slow tier) + cache-keys.ts
  - api/health.js (STANDALONE_KEYS + SEED_META, maxStaleMin = 24h)
  - api/mcp.ts get_economic_data tool (_cacheKeys + _freshnessChecks)
  - resilience macroFiscal: new householdDebtService sub-metric
    (weight 0.05, currentAccountPct rebalanced 0.3 → 0.25)
  - Housing Cycle tile on CountryDeepDivePanel (Economic Indicators card)
    with euro-area (XM) fallback for EU member states
  - seed-bundle-macro Railway cron (BIS-Extended, 12h interval)

Tests: tests/bis-extended-seed.test.mjs covers CSV parsing, series
selection, quarter math + YoY. Updated resilience golden-value tests
for the macroFiscal weight rebalance.

Closes #3026

https://claude.ai/code/session_01DDo39mPD9N2fNHtUntHDqN