### PR TITLE
fix(resilience): warm all countries + invalidate ranking after laggards

### DIFF
--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -195,10 +195,10 @@ async function seedResilienceScores() {
     if (stillMissing.length > 0 && !WM_KEY) {
       console.warn(`[resilience-scores] ${stillMissing.length} laggards found but neither WORLDMONITOR_API_KEY nor WORLDMONITOR_VALID_KEYS is set — skipping individual warmup`);
     }
+    let laggardsWarmed = 0;
     if (stillMissing.length > 0 && WM_KEY) {
       console.log(`[resilience-scores] Warming ${stillMissing.length} laggards individually...`);
       const BATCH = 5;
-      let warmed = 0;
       for (let i = 0; i < stillMissing.length; i += BATCH) {
         const batch = stillMissing.slice(i, i + BATCH);
         const results = await Promise.allSettled(batch.map(async (cc) => {
@@ -210,9 +210,23 @@ async function seedResilienceScores() {
           if (!resp.ok) throw new Error(`${cc}: HTTP ${resp.status}`);
           return cc;
         }));
-        warmed += results.filter(r => r.status === 'fulfilled').length;
+        laggardsWarmed += results.filter(r => r.status === 'fulfilled').length;
       }
-      console.log(`[resilience-scores] Laggards warmed: ${warmed}/${stillMissing.length}`);
+      console.log(`[resilience-scores] Laggards warmed: ${laggardsWarmed}/${stillMissing.length}`);
+    }
+
+    // If any laggards were warmed, the ranking cache (written earlier by the
+    // bulk endpoint) no longer reflects them — it froze them as coverage-0
+    // greyedOut entries. Delete the key so the next RPC call rebuilds the
+    // ranking from the now-complete per-country cache. Without this, the
+    // stale ranking persists for the full 6h TTL.
+    if (laggardsWarmed > 0) {
+      try {
+        await redisPipeline(url, token, [['DEL', RESILIENCE_RANKING_CACHE_KEY]]);
+        console.log(`[resilience-scores] Invalidated ${RESILIENCE_RANKING_CACHE_KEY} — next call will rebuild with ${laggardsWarmed} new scores`);
+      } catch (err) {
+        console.warn(`[resilience-scores] Failed to invalidate ranking cache: ${err.message}`);
+      }
     }
 
     const finalResults = await redisPipeline(url, token, getCommands);

--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -217,15 +217,30 @@ async function seedResilienceScores() {
 
     // If any laggards were warmed, the ranking cache (written earlier by the
     // bulk endpoint) no longer reflects them — it froze them as coverage-0
-    // greyedOut entries. Delete the key so the next RPC call rebuilds the
-    // ranking from the now-complete per-country cache. Without this, the
-    // stale ranking persists for the full 6h TTL.
+    // greyedOut entries. DEL the key AND re-call the ranking endpoint to
+    // rebuild from the now-complete per-country cache. Don't stop at DEL:
+    // downstream consumers (benchmark-resilience-external.mjs) read
+    // resilience:ranking:v9 directly from Redis and skip on null, so a
+    // null-until-next-user-RPC window would leave the weekly validation
+    // cron with no ranking to benchmark against.
     if (laggardsWarmed > 0) {
       try {
         await redisPipeline(url, token, [['DEL', RESILIENCE_RANKING_CACHE_KEY]]);
-        console.log(`[resilience-scores] Invalidated ${RESILIENCE_RANKING_CACHE_KEY} — next call will rebuild with ${laggardsWarmed} new scores`);
+        const rebuildHeaders = { 'User-Agent': SEED_UA, 'Accept': 'application/json' };
+        if (WM_KEY) rebuildHeaders['X-WorldMonitor-Key'] = WM_KEY;
+        const rebuildResp = await fetch(`${API_BASE}/api/resilience/v1/get-resilience-ranking`, {
+          headers: rebuildHeaders,
+          signal: AbortSignal.timeout(60_000),
+        });
+        if (rebuildResp.ok) {
+          const rebuilt = await rebuildResp.json();
+          const total = (rebuilt.items?.length ?? 0) + (rebuilt.greyedOut?.length ?? 0);
+          console.log(`[resilience-scores] Rebuilt ${RESILIENCE_RANKING_CACHE_KEY} with ${total} countries after ${laggardsWarmed} laggard warms`);
+        } else {
+          console.warn(`[resilience-scores] Rebuild ranking HTTP ${rebuildResp.status} — ranking cache is null until next RPC call`);
+        }
       } catch (err) {
-        console.warn(`[resilience-scores] Failed to invalidate ranking cache: ${err.message}`);
+        console.warn(`[resilience-scores] Failed to rebuild ranking cache: ${err.message}`);
       }
     }
 

--- a/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
@@ -22,19 +22,22 @@ import {
 const RESILIENCE_RANKING_META_KEY = 'seed-meta:resilience:ranking';
 const RESILIENCE_RANKING_META_TTL_SECONDS = 7 * 24 * 60 * 60;
 
-// How many missing countries to score synchronously per ranking request.
-// The shared memoized reader means global Redis keys are fetched once total
-// (not once per country), so the actual Upstash burst is:
+// Hard ceiling on one synchronous warm pass — purely a safety net against a
+// runaway static index. The shared memoized reader means global Redis keys are
+// fetched once total (not once per country), so the Upstash burst is
 //   17 shared reads + N×3 per-country reads + N pipeline writes
-// Wall time does NOT scale with N because all countries run via Promise.allSettled
-// in parallel; it is bounded by ~2-3 sequential RTTs within one country (~60-150 ms).
-// 200 covers the full static index (~130-180 countries) in a single cold-cache pass.
-const SYNC_WARM_LIMIT = 200;
+// and wall time does NOT scale with N because all countries run via
+// Promise.allSettled in parallel; it is bounded by ~2-3 sequential RTTs within
+// one country (~60-150 ms). 1000 is several multiples above the current static
+// index (~222 countries) so every warm pass is unconditionally complete.
+const SYNC_WARM_LIMIT = 1000;
 
 // Minimum fraction of scorable countries that must have a cached score before we
 // persist the ranking to Redis. Prevents a cold-start (0% cached) from being
 // locked in, while still allowing partial-state writes (e.g. 90%) to succeed so
-// the next call doesn't re-warm everything.
+// the next call doesn't re-warm everything. This is a safety rail against genuine
+// warm failures (Redis blips, data gaps) — it must NOT be tripped by the handler
+// capping how many countries it attempts. See SYNC_WARM_LIMIT above.
 const RANKING_CACHE_MIN_COVERAGE = 0.75;
 
 async function fetchIntervals(countryCodes: string[]): Promise<Map<string, ScoreInterval>> {


### PR DESCRIPTION
## Why this PR?

Follow-up to #3045 addressing a reviewer-blocker that landed after merge.

**#3045 fixed the all-or-nothing cache gate** (100% required → 75% threshold), but left two holes that the reviewer caught after merge:

1. `SYNC_WARM_LIMIT` was still `200` in `get-resilience-ranking.ts`, while the prod static index has **222 countries**. Under the new 75% gate, the handler attempts only the first 200, reaches `200/222 = 90%` coverage, and caches a partial ranking with 22 countries frozen as coverage-0 greyedOut entries for the full 6h TTL. The old all-or-nothing gate had hidden this by refusing to cache partials; the new gate needed a matching expansion of the warm loop.

2. The seeder's per-country laggard warmup populates `resilience:score:v9:{CC}` for countries the handler's bulk warm failed on, but never invalidated `resilience:ranking:v9`. The ranking cache would therefore serve stale entries (with warmed laggards still showing as greyedOut) until the 6h TTL expired.

## Root cause of the "21 silently failing" symptom in #3045

It wasn't 21 silent failures — it was **22 never attempted**:

```
222 total countries in index
-   1 pre-cached (TR)
- 200 the handler's slice cap allowed
= 21 never warmed
```

Matches the log exactly. The new `warm failed for N/M` logging from #3045 would have reported 0 failures on the 200 attempted.

## Changes

**`server/worldmonitor/resilience/v1/get-resilience-ranking.ts`**
- `SYNC_WARM_LIMIT: 200 → 1000`. `Promise.allSettled` runs countries in parallel so wall time doesn't scale with N; the cap is a safety ceiling, not a tuning knob. 1000 is several multiples above any realistic static-index size.
- Rewrote the comment on `RANKING_CACHE_MIN_COVERAGE` to make it explicit that 75% is a safety rail against *genuine* warm failures (Redis blips, data gaps) — it must NOT be tripped by the handler capping how many countries it attempts.

**`scripts/seed-resilience-scores.mjs`**
- After successful laggard warmup (`laggardsWarmed > 0`), issue `DEL resilience:ranking:v9`. Next RPC call rebuilds the ranking from the now-complete per-country cache. Without this, the stale ranking persists until the 6h TTL fires.

## Test plan

- [x] `node --test tests/resilience-ranking.test.mts` — all 8 tests pass (7 existing + 1 partial-coverage)
- [x] Full resilience suite: 357/357
- [x] `npm run typecheck` + `npm run typecheck:api` clean
- [x] Biome clean
- [ ] After merge: next `seed-bundle-resilience` cron run (every 6h at minute 0) should warm all 222 countries in a single pass. If any genuine failures occur, the `[resilience] warm failed for N/M countries` log from #3045 will surface them with country code + reason. Current prediction: 0 real failures once the slice cap is gone.