### PR TITLE
fix(health): heal portwatch-disruptions + three stale-registry false alarms

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -314,7 +314,7 @@ const SEED_META = {
   sprPolicies:          { key: 'seed-meta:energy:spr-policies',         maxStaleMin: 60 * 24 * 400 }, // 400 days; static registry, same cadence as chokepoint baselines
   energyCrisisPolicies: { key: 'seed-meta:energy:crisis-policies',      maxStaleMin: 60 * 24 * 400 }, // static data, ~400d TTL matches seeder
   aaiiSentiment:        { key: 'seed-meta:market:aaii-sentiment',       maxStaleMin: 20160 }, // weekly cron; 20160min = 14 days = 2x weekly cadence
-  portwatchChokepointsRef: { key: 'seed-meta:portwatch:chokepoints-ref', maxStaleMin: 60 * 24 * 2 }, // daily cron; 2d = 2× interval
+  portwatchChokepointsRef: { key: 'seed-meta:portwatch:chokepoints-ref', maxStaleMin: 60 * 24 * 14 }, // seed-bundle-portwatch runs this at WEEK cadence; 14d = 2× interval
   chokepointFlows:      { key: 'seed-meta:energy:chokepoint-flows',     maxStaleMin: 720 }, // 6h cron; 720min = 2x interval
   emberElectricity:     { key: 'seed-meta:energy:ember',                maxStaleMin: 2880 }, // daily cron (08:00 UTC); 2880min = 48h = 2x interval
   cryptoSectors:        { key: 'seed-meta:market:crypto-sectors',             maxStaleMin: 120 }, // relay loop every ~30min; 120min = 2h = 4x interval

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -76,7 +76,7 @@ const SEED_DOMAINS = {
   'economic:owid-energy-mix': { key: 'seed-meta:economic:owid-energy-mix', intervalMin: 25200 }, // monthly cron on 1st; intervalMin = health.js maxStaleMin / 2 (50400 / 2)
   'economic:fao-ffpi':        { key: 'seed-meta:economic:fao-ffpi',        intervalMin: 43200 }, // monthly seed; intervalMin = health.js maxStaleMin / 2 (86400 / 2)
   'product-catalog':          { key: 'seed-meta:product-catalog',          intervalMin: 360 }, // relay loop every 6h; intervalMin = health.js maxStaleMin / 3 (1080 / 3)
-  'portwatch:chokepoints-ref': { key: 'seed-meta:portwatch:chokepoints-ref', intervalMin: 1440 }, // daily cron (0 0 * * *)
+  'portwatch:chokepoints-ref': { key: 'seed-meta:portwatch:chokepoints-ref', intervalMin: 10080 }, // seed-bundle-portwatch runs this at WEEK cadence; intervalMin*2 = 14d matches api/health.js SEED_META.portwatchChokepointsRef
   'supply_chain:portwatch-ports': { key: 'seed-meta:supply_chain:portwatch-ports', intervalMin: 720 }, // 12h cron (0 */12 * * *); intervalMin = maxStaleMin / 3 (2160 / 3)
   'energy:chokepoint-flows': { key: 'seed-meta:energy:chokepoint-flows', intervalMin: 360 }, // 6h relay loop; intervalMin = maxStaleMin / 2 (720 / 2)
   'energy:spine':                 { key: 'seed-meta:energy:spine',                 intervalMin: 1440 }, // daily cron (0 6 * * *); intervalMin = maxStaleMin / 2 (2880 / 2)

--- a/scripts/backtest-resilience-outcomes.mjs
+++ b/scripts/backtest-resilience-outcomes.mjs
@@ -458,7 +458,11 @@ async function runBacktest() {
   const scores = await fetchAllResilienceScores(url, token);
   console.log(`Loaded resilience scores for ${scores.size} countries`);
   if (scores.size < 50) {
-    console.error('FATAL: Too few resilience scores loaded from Redis');
+    // Not actually fatal — the validation bundle runner reports ran:N failed:0
+    // for this branch. Happens on cold start when the validation bundle runs
+    // before the scores seeder populates Redis. Warn (not error) so ops pages
+    // don't trip on a transient.
+    console.warn(`[backtest] Skipping: only ${scores.size}/196 scores in Redis — scores seeder likely hasn't run yet`);
     return null;
   }
   console.log('');

--- a/scripts/seed-portwatch-disruptions.mjs
+++ b/scripts/seed-portwatch-disruptions.mjs
@@ -12,11 +12,22 @@ const ARCGIS_BASE =
 const FETCH_TIMEOUT = 30_000;
 const DAYS_BACK = 30; // events that ended within 30 days, or are still active
 
+// Format a JS timestamp as an ArcGIS SQL timestamp literal:
+//   timestamp 'YYYY-MM-DD HH:MM:SS'
+// The ArcGIS SQL parser rejects bare epoch-ms numbers against Date-typed
+// fields with "Cannot perform query. Invalid query parameters." (observed
+// 3× retry failure in prod, every run, portwatch:disruptions:active:v1
+// missing from Redis).
+export function toArcgisTimestamp(epochMs) {
+  return new Date(epochMs).toISOString().slice(0, 19).replace('T', ' ');
+}
+
 export async function fetchAll() {
   const sinceEpoch = Date.now() - DAYS_BACK * 86_400_000;
+  const sinceSql = toArcgisTimestamp(sinceEpoch);
 
   const params = new URLSearchParams({
-    where: `todate > ${sinceEpoch} OR todate IS NULL`,
+    where: `todate > timestamp '${sinceSql}' OR todate IS NULL`,
     outFields: [
       'eventid', 'eventtype', 'eventname', 'alertlevel', 'country',
       'fromdate', 'todate', 'severitytext', 'lat', 'long',

--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -266,12 +266,20 @@ async function writeRankingSeedMeta(recordCount) {
   try {
     const { url, token } = getRedisCredentials();
     const meta = { fetchedAt: Date.now(), recordCount };
-    await fetch(url, {
+    const resp = await fetch(url, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
       body: JSON.stringify(['SET', 'seed-meta:resilience:ranking', JSON.stringify(meta), 'EX', 86400 * 7]),
       signal: AbortSignal.timeout(5_000),
     });
+    // fetch() doesn't throw on non-2xx — we must check resp.ok explicitly.
+    // Otherwise a 401/429/500 from Upstash silently looks like success, the
+    // seed-meta stays stale, and /api/health keeps alerting without ops
+    // knowing the write ever failed.
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '<unreadable>');
+      console.warn(`[resilience-scores] seed-meta:resilience:ranking write failed: HTTP ${resp.status} — ${body.slice(0, 200)}`);
+    }
   } catch (err) {
     console.warn('[resilience-scores] seed-meta:resilience:ranking write failed:', err?.message || err);
   }

--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -256,6 +256,27 @@ async function seedResilienceScores() {
   return { skipped: false, recordCount: preWarmed, total: countryCodes.length, intervalsWritten };
 }
 
+// Write seed-meta:resilience:ranking so api/health.js can track data freshness.
+// Without this, the meta key is only written by the get-resilience-ranking RPC
+// handler when a user hits it, and goes silently stale during quiet Pro usage —
+// firing a misleading "7× stale" alarm in the health endpoint even while the
+// underlying scores are fresh. Non-fatal on Redis failure; seed itself still
+// completed successfully.
+async function writeRankingSeedMeta(recordCount) {
+  try {
+    const { url, token } = getRedisCredentials();
+    const meta = { fetchedAt: Date.now(), recordCount };
+    await fetch(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(['SET', 'seed-meta:resilience:ranking', JSON.stringify(meta), 'EX', 86400 * 7]),
+      signal: AbortSignal.timeout(5_000),
+    });
+  } catch (err) {
+    console.warn('[resilience-scores] seed-meta:resilience:ranking write failed:', err?.message || err);
+  }
+}
+
 async function main() {
   const startedAt = Date.now();
   const result = await seedResilienceScores();
@@ -265,6 +286,9 @@ async function main() {
     ...(result.reason != null && { reason: result.reason }),
     ...(result.intervalsWritten != null && { intervalsWritten: result.intervalsWritten }),
   });
+  if (!result.skipped && (result.recordCount ?? 0) > 0) {
+    await writeRankingSeedMeta(result.recordCount);
+  }
 }
 
 if (process.argv[1]?.endsWith('seed-resilience-scores.mjs')) {

--- a/tests/portwatch-disruptions-seed.test.mjs
+++ b/tests/portwatch-disruptions-seed.test.mjs
@@ -17,6 +17,21 @@ describe('seed-portwatch-disruptions.mjs exports', () => {
     assert.match(src, /export\s+async\s+function\s+fetchAll/);
   });
 
+  // Regression guard: ArcGIS SQL parser rejects bare epoch-ms integers against
+  // Date-typed fields with "Cannot perform query. Invalid query parameters."
+  // The WHERE clause must use `timestamp '...'` literals, produced by
+  // toArcgisTimestamp(). Reverting to a raw ${sinceEpoch} breaks every run.
+  it('WHERE clause uses ArcGIS timestamp literal, not raw epoch-ms', () => {
+    assert.match(src, /todate\s*>\s*timestamp\s*'\$\{sinceSql\}'/, 'WHERE clause must compare against an ArcGIS timestamp literal');
+    assert.doesNotMatch(src, /todate\s*>\s*\$\{sinceEpoch\}/, 'WHERE clause must NOT compare against a raw epoch-ms integer');
+  });
+
+  it('toArcgisTimestamp formats epoch-ms as "YYYY-MM-DD HH:MM:SS"', async () => {
+    const mod = await import('../scripts/seed-portwatch-disruptions.mjs');
+    const formatted = mod.toArcgisTimestamp(Date.UTC(2026, 3, 13, 8, 30, 45)); // 2026-04-13T08:30:45Z
+    assert.equal(formatted, '2026-04-13 08:30:45');
+  });
+
   it('exports validateFn', () => {
     assert.match(src, /export\s+function\s+validateFn/);
   });


### PR DESCRIPTION
## Why this PR?

`/api/health` was reporting 19 CRIT + 7 WARN on prod. Service-log inspection + Redis validation isolated 4 items: one real data-collection failure plus three monitoring-registry bugs firing noise on a healthy pipeline. Plan: [`docs/plans/2026-04-13-001-fix-resilience-portwatch-health-cleanup-plan.md`](../blob/fix/resilience-health-pass/docs/plans/2026-04-13-001-fix-resilience-portwatch-health-cleanup-plan.md).

## Fixes

1. **seed-portwatch-disruptions (P0, real)** — ArcGIS `WHERE todate > ${sinceEpoch}` compared a raw JS epoch-ms integer against a Date-typed field; SQL parser rejected every request with "Cannot perform query. Invalid query parameters." `portwatch:disruptions:active:v1` was missing from Redis entirely. Now formats `sinceEpoch` as an ArcGIS SQL timestamp literal via new `toArcgisTimestamp()` export + regression guard in the seeder test.

2. **seed-resilience-scores writes `seed-meta:resilience:ranking`** — previously only the `get-resilience-ranking` RPC handler wrote this meta (on user request), so during quiet Pro usage `/api/health` fired a misleading "7× stale" alarm on fresh scores. Now inline Upstash `SET ... EX 604800` after every successful run. Non-fatal on Redis failure.

3. **backtest-resilience-outcomes: `FATAL` → `warn`** — when the validation bundle runs before the scores seeder populates Redis (cold start ordering), the script logged `FATAL: Too few resilience scores loaded from Redis` then returned null. The bundle runner already reports `failed:0` for this branch, so the log line was misleading ops. Swapped to a clear `[backtest] Skipping: only N/196 scores…` warn.

4. **`api/health.js` `portwatchChokepointsRef.maxStaleMin` 2d → 14d** — `seed-bundle-portwatch.mjs:8` runs this at `intervalMs: WEEK`, not daily; 2d stale threshold fires at 0.29× cadence. 14d matches the `2× interval` convention from the existing `health-maxstalemin-write-cadence` skill. Comment updated.

## Files

- `scripts/seed-portwatch-disruptions.mjs` — new `toArcgisTimestamp()`, WHERE clause
- `scripts/seed-resilience-scores.mjs` — `writeRankingSeedMeta()` helper + call in `main()`
- `scripts/backtest-resilience-outcomes.mjs` — 1-line log level + improved copy
- `api/health.js` — 1-line SEED_META threshold
- `tests/portwatch-disruptions-seed.test.mjs` — 2 regression guards for the WHERE shape + `toArcgisTimestamp()` formatting

## Out of scope → follow-up PR B

Import-HHI proxy fallback (#3030's checkpoint/resume model already converges over multiple runs; proxy only helps single-run coverage — deferred).

## Test plan

- [x] `npm run typecheck` + `typecheck:api` clean
- [x] Targeted subset (`portwatch-disruptions-seed`, `resilience-scores-seed`, `backtest-resilience-outcomes`, `bootstrap`) — 116/116 pass (+2 new)
- [x] `biome lint` on touched files — 0 errors (pre-existing complexity warning on health.js unrelated)
- [x] `npm run lint:md` + `version:check` clean

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: Railway `seed-bundle-portwatch` service — search `PW-Disruptions` lines for "FETCH FAILED" → should disappear
  - Logs: Railway `seed-resilience-scores` — search `seed-meta:resilience:ranking write failed` → should be absent (write should succeed silently)
  - Redis: `seed-meta:portwatch:disruptions`, `seed-meta:resilience:ranking`, `portwatch:disruptions:active:v1`
- **Validation checks**
  - `curl https://www.worldmonitor.app/api/health | jq '.checks.portwatchChokepointsRef'` → `status: "OK"`
  - `curl https://www.worldmonitor.app/api/health | jq '.checks.resilienceRanking'` → `seedAgeMin < 720`
  - Upstash get: `GET portwatch:disruptions:active:v1` → non-null, events array
- **Expected healthy**
  - 2 fewer CRIT / EMPTY_ON_DEMAND entries in /api/health within 1h of the next cron cycles
  - PW-Disruptions log shows success, events count > 0
- **Failure signal / rollback**
  - If ArcGIS still rejects the timestamp literal, fall back to `where: '1=1'` (filter client-side). Second commit, no rollback needed.
  - If `writeRankingSeedMeta` throws loud enough to break runs, wrap is already try/catch — rollback = revert that helper block.
- **Validation window & owner**
  - Window: first 2h after deploy (covers 1 PW cycle + 1 scores cycle)
  - Owner: @koala73
