### PR TITLE
chore(mcp): audit coverage — expose 13 missing seed keys + new resilience tool

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -76,7 +76,7 @@ type ToolDef = CacheToolDef | RpcToolDef;
 const TOOL_REGISTRY: ToolDef[] = [
   {
     name: 'get_market_data',
-    description: 'Real-time equity quotes, commodity prices (including gold futures GC=F), crypto prices, forex FX rates (USD/EUR, USD/JPY etc.), sector performance, ETF flows, and Gulf market quotes from WorldMonitor\'s curated bootstrap cache.',
+    description: 'Real-time equity quotes, commodity prices (including gold futures GC=F), crypto prices, forex FX rates (USD/EUR, USD/JPY etc.), sector performance, ETF flows, Gulf market quotes, crypto sector performance, stablecoin market data, and wholesale FX rates from WorldMonitor\'s curated bootstrap cache.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'market:stocks-bootstrap:v1',
@@ -86,6 +86,9 @@ const TOOL_REGISTRY: ToolDef[] = [
       'market:etf-flows:v1',
       'market:gulf-quotes:v1',
       'market:fear-greed:v1',
+      'market:crypto-sectors:v1',
+      'market:stablecoins:v1',
+      'shared:fx-rates:v1',
     ],
     _seedMetaKey: 'seed-meta:market:stocks',
     _maxStaleMin: 30,
@@ -154,7 +157,7 @@ const TOOL_REGISTRY: ToolDef[] = [
   },
   {
     name: 'get_economic_data',
-    description: 'Macro economic indicators: Fed Funds rate (FRED), economic calendar events, fuel prices, ECB FX rates, EU yield curve, earnings calendar, COT positioning, and energy storage data.',
+    description: 'Macro economic indicators: Fed Funds rate (FRED), economic calendar events, fuel prices, ECB FX rates, EU yield curve, earnings calendar, COT positioning, energy storage, IMF WEO macro (inflation, GDP, debt, 200+ countries), national debt-to-GDP timeseries, Big Mac PPP index, FAO Food Price Index, and Eurostat EU statistics from WorldMonitor\'s seed cache.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'economic:fred:v1:FEDFUNDS:0',
@@ -165,6 +168,11 @@ const TOOL_REGISTRY: ToolDef[] = [
       'economic:spending:v1',
       'market:earnings-calendar:v1',
       'market:cot:v1',
+      'economic:imf:macro:v2',
+      'economic:national-debt:v1',
+      'economic:bigmac:v1',
+      'economic:fao-ffpi:v1',
+      'economic:eurostat-country-data:v1',
     ],
     _seedMetaKey: 'seed-meta:economic:econ-calendar',
     _maxStaleMin: 1440,
@@ -212,12 +220,17 @@ const TOOL_REGISTRY: ToolDef[] = [
   },
   {
     name: 'get_supply_chain_data',
-    description: 'Dry bulk shipping stress index, customs revenue flows, and COMTRADE bilateral trade data. Tracks global supply chain pressure and trade disruptions.',
+    description: 'Dry bulk shipping stress index, customs revenue flows, COMTRADE bilateral trade data, Hormuz tracker, port chokepoint reference data, active disruptions, energy crisis policies, and energy intelligence feeds. Tracks global supply chain pressure and trade disruptions.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'supply_chain:shipping_stress:v1',
       'trade:customs-revenue:v1',
       'comtrade:flows:v1',
+      'supply_chain:hormuz_tracker:v1',
+      'portwatch:chokepoints:ref:v1',
+      'portwatch:disruptions:active:v1',
+      'energy:crisis-policies:v1',
+      'energy:intelligence:feed:v1',
     ],
     _seedMetaKey: 'seed-meta:trade:customs-revenue',
     _maxStaleMin: 2880,
@@ -265,6 +278,24 @@ const TOOL_REGISTRY: ToolDef[] = [
     _cacheKeys: ['intelligence:social:reddit:v1'],
     _seedMetaKey: 'seed-meta:intelligence:social-reddit',
     _maxStaleMin: 30,
+  },
+
+  // -------------------------------------------------------------------------
+  // Resilience recovery — cache read (IMF WEO-derived resilience indicators)
+  // -------------------------------------------------------------------------
+  {
+    name: 'get_resilience_recovery',
+    description: 'IMF WEO-derived resilience and recovery indicators: fiscal space (revenue vs. spending headroom), reserve adequacy (external reserves vs. imports), external debt sustainability, import concentration (HHI), and strategic fuel stock levels. Covers 200+ countries with monthly/quarterly cadence.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    _cacheKeys: [
+      'resilience:recovery:fiscal-space:v1',
+      'resilience:recovery:reserve-adequacy:v1',
+      'resilience:recovery:external-debt:v1',
+      'resilience:recovery:import-hhi:v1',
+      'resilience:recovery:fuel-stocks:v1',
+    ],
+    _seedMetaKey: 'seed-meta:resilience:recovery:fiscal-space',
+    _maxStaleMin: 43200,
   },
 
   // -------------------------------------------------------------------------

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -295,7 +295,7 @@ const TOOL_REGISTRY: ToolDef[] = [
       'resilience:recovery:fuel-stocks:v1',
     ],
     _seedMetaKey: 'seed-meta:resilience:recovery:fiscal-space',
-    _maxStaleMin: 43200,
+    _maxStaleMin: 86400,  // 60d = 2x monthly cron interval (matches health.js recoveryFiscalSpace maxStaleMin)
   },
 
   // -------------------------------------------------------------------------

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -252,12 +252,22 @@ export class CountryIntelManager implements AppModule {
       const ourPos = CountryIntelManager.firstMentionPosition(t, searchTerms);
       const otherPos = CountryIntelManager.firstMentionPosition(t, otherCountryTerms);
       return ourPos !== Infinity && (otherPos === Infinity || ourPos <= otherPos);
-    }).sort((a, b) => {
+    });
+    const seen = new Set<string>();
+    const deduped: typeof filteredNews = [];
+    for (const n of filteredNews) {
+      const normalized = n.title.toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/\s+/g, ' ').trim();
+      if (normalized.length > 0 && !seen.has(normalized)) {
+        seen.add(normalized);
+        deduped.push(n);
+      }
+    }
+    deduped.sort((a, b) => {
       const severityDelta = this.newsSeverityRank(b) - this.newsSeverityRank(a);
       if (severityDelta !== 0) return severityDelta;
       return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
     });
-    this.ctx.countryBriefPage.updateNews(filteredNews.slice(0, 10));
+    this.ctx.countryBriefPage.updateNews(deduped.slice(0, 10));
 
     this.ctx.countryBriefPage.updateInfrastructure(code);
 

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -253,20 +253,21 @@ export class CountryIntelManager implements AppModule {
       const otherPos = CountryIntelManager.firstMentionPosition(t, otherCountryTerms);
       return ourPos !== Infinity && (otherPos === Infinity || ourPos <= otherPos);
     });
+    // Sort first so highest-severity/freshest item wins deduplication
+    const sorted = [...filteredNews].sort((a, b) => {
+      const severityDelta = this.newsSeverityRank(b) - this.newsSeverityRank(a);
+      if (severityDelta !== 0) return severityDelta;
+      return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
+    });
     const seen = new Set<string>();
     const deduped: typeof filteredNews = [];
-    for (const n of filteredNews) {
+    for (const n of sorted) {
       const normalized = n.title.toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/\s+/g, ' ').trim();
       if (normalized.length > 0 && !seen.has(normalized)) {
         seen.add(normalized);
         deduped.push(n);
       }
     }
-    deduped.sort((a, b) => {
-      const severityDelta = this.newsSeverityRank(b) - this.newsSeverityRank(a);
-      if (severityDelta !== 0) return severityDelta;
-      return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
-    });
     this.ctx.countryBriefPage.updateNews(deduped.slice(0, 10));
 
     this.ctx.countryBriefPage.updateInfrastructure(code);

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -339,7 +339,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
 
       const top = this.el('div', 'cdp-news-top');
       const tier = item.tier ?? getSourceTier(item.source);
-      top.append(this.badge(`Tier ${tier}`, `cdp-tier-badge tier-${Math.max(1, Math.min(4, tier))}`));
+      top.append(this.badge(`Tier ${tier}`, `cdp-tier-badge tier-${Math.max(1, Math.min(4, tier))}`, t('countryBrief.tierBadgeTooltip')));
 
       const severity = this.toThreatLevel(item.threat?.level);
       const levelKey = severity === 'info' ? 'low' : severity === 'medium' ? 'moderate' : severity;
@@ -2472,8 +2472,10 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     return this.el('div', 'cdp-empty', text);
   }
 
-  private badge(text: string, className: string): HTMLElement {
-    return this.el('span', className, text);
+  private badge(text: string, className: string, title?: string): HTMLElement {
+    const el = this.el('span', className, text);
+    if (title) el.title = title;
+    return el;
   }
 
   private formatBrief(text: string, headlineCount = 0): string {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -81,6 +81,7 @@
     "predictionMarkets": "Prediction Markets",
     "loadingMarkets": "Loading prediction markets...",
     "infrastructure": "Infrastructure Exposure",
+    "tierBadgeTooltip": "Source reliability tier — Tier 1 = highest confidence, Tier 4 = emerging sources",
     "briefUnavailable": "AI brief unavailable — configure GROQ_API_KEY in Settings.",
     "cached": "Cached",
     "fresh": "Fresh",

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -123,7 +123,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.result?.tools), 'result.tools must be an array');
-    assert.equal(body.result.tools.length, 28, `Expected 28 tools, got ${body.result.tools.length}`);
+    assert.equal(body.result.tools.length, 29, `Expected 29 tools, got ${body.result.tools.length}`);
     for (const tool of body.result.tools) {
       assert.ok(tool.name, 'tool.name must be present');
       assert.ok(tool.description, 'tool.description must be present');


### PR DESCRIPTION
## Summary

Issue #3029 — Phase 1 close of MCP coverage gap for 13 high-value seed keys across 4 tools.

### Changes

**get_market_data** (+3 keys):
-  — crypto sector performance
-  — stablecoin market data
-  — wholesale FX rates

**get_economic_data** (+5 keys):
-  — IMF WEO: inflation, GDP growth, debt, 200+ countries
-  — US Treasury + IMF debt-to-GDP timeseries
-  — Big Mac PPP index ~50 countries
-  — FAO Food Price Index
-  — EU GDP/unemployment/CPI

**get_supply_chain_data** (+5 keys):
-  — Hormuz strait shipping tracker
-  — port chokepoint reference data
-  — active port disruptions
-  — energy crisis policy responses
-  — energy intelligence signals

**New tool: get_resilience_recovery** (+5 keys — entire pillar previously 0% exposed):
- 
- 
- 
- 
- 

Total: 28 → 29 MCP tools. Test assertion updated accordingly.

### Priority rationale
Per issue #3029: resilience pillar (entirely unexposed), IMF macro (200+ countries, highest consumer count), energy/supply chain (geopolitical analysis core) are the three highest-value domains.

### Remaining work
~26 keys still unexposed (Phase 1 can continue in follow-up issues). Phase 2 (CI drift prevention) also not yet implemented.

Closes #3029