### PR TITLE
fix(resilience): ship full scripts/ tree in validation Docker image

### DIFF
--- a/Dockerfile.seed-bundle-resilience-validation
+++ b/Dockerfile.seed-bundle-resilience-validation
@@ -23,16 +23,19 @@ WORKDIR /app
 RUN npm install --prefix /app --no-save --no-audit --no-fund --no-package-lock tsx@4.21.0 \
     && test -f /app/node_modules/tsx/dist/loader.mjs
 
-# Copy only the scripts the bundle actually runs + their local helpers.
-# _seed-utils.mjs eagerly createRequire()s _proxy-utils.cjs at module load,
-# so the .cjs helper must ship alongside even if unused by these validators.
+# Ship the full scripts/ tree rather than a hand-picked file list. The cherry-
+# picked approach broke twice: once when _seed-utils.mjs started eagerly
+# createRequire()ing _proxy-utils.cjs (PR #3041 post-merge fix), and again
+# when backtest-resilience-outcomes.mjs imported _country-resolver.mjs
+# (PR #3052 post-merge fix — this file). Each time the bundle's scripts add
+# a new local import, the cherry-picked Dockerfile list becomes a hidden
+# dependency contract that nobody remembers to update until the cron
+# crashes with ERR_MODULE_NOT_FOUND in production. Copying the whole scripts/
+# dir is ~2 MB larger and robust to the next import.
+#
 # validate-resilience-sensitivity.mjs dynamic-imports ../server/*.ts so the
 # full server/ tree is copied (scorers pull from shared/ and data/ at runtime).
-COPY scripts/_seed-utils.mjs scripts/_bundle-runner.mjs scripts/_proxy-utils.cjs ./scripts/
-COPY scripts/seed-bundle-resilience-validation.mjs ./scripts/
-COPY scripts/benchmark-resilience-external.mjs ./scripts/
-COPY scripts/backtest-resilience-outcomes.mjs ./scripts/
-COPY scripts/validate-resilience-sensitivity.mjs ./scripts/
+COPY scripts/ ./scripts/
 COPY server/ ./server/
 COPY shared/ ./shared/
 COPY data/ ./data/


### PR DESCRIPTION
## Why this PR?

The weekly validation cron crashed again after #3052 merged:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/scripts/_country-resolver.mjs'
  imported from /app/scripts/backtest-resilience-outcomes.mjs
    at finalizeResolution (node:internal/modules/esm/resolve:275:11)
    ...
Outcome-Backtest failed after 0.5s: 1
```

Root cause: `Dockerfile.seed-bundle-resilience-validation` copies a **cherry-picked list of scripts** meant to "only ship what the bundle actually runs". PR #3052 added `import { resolveIso2 } from './_country-resolver.mjs'` to `backtest-resilience-outcomes.mjs` — and the Dockerfile's hand-written COPY list wasn't updated, so the container image is missing the import target.

**This is the second time this exact class of bug has bitten us** in the same Dockerfile:

1. PR #3041 post-merge: `_seed-utils.mjs` top-level-`createRequire`s `_proxy-utils.cjs` → crashed until Dockerfile was patched.
2. PR #3052 post-merge (this one): `backtest-resilience-outcomes.mjs` imports `_country-resolver.mjs` → crashed until this fix.

## Fix

Replace the cherry-picked `COPY` list with `COPY scripts/ ./scripts/` (whole directory).

- Image size penalty: ~2 MB of unused seeders on disk.
- Robustness gain: any future local import in a bundle script just works.
- Safety: none of the other `scripts/*.mjs` / `.cjs` run at container start — only the `CMD` (`seed-bundle-resilience-validation.mjs`) executes, and it only imports what the bundle actually touches. Unused scripts sit dormant on disk.

Comment in the Dockerfile explains the trade-off + the two prior breakages so the next editor doesn't "trim" it back to a hand-picked list.

## Test plan

- [x] Confirmed the crash reproduces from the current deployed image (user-provided log from 2026-04-13T11:27 UTC)
- [x] Diff is a single-line Dockerfile change (+comment) — no application-code risk
- [ ] After merge: Railway rebuilds the image, next `seed-bundle-resilience-validation` cron run should complete Outcome-Backtest instead of dying at `ERR_MODULE_NOT_FOUND`
- [ ] Memory note added so the next person touching this Dockerfile sees the trap documented

## Also: External-Benchmark is now doing real work

Same log shows the benchmark side is healthy after the earlier PR chain:

```
[External-Benchmark] [benchmark] Read 217 WM resilience scores from Redis
[External-Benchmark] [benchmark] Fetched ND-GAIN live (2186502 bytes)
[External-Benchmark] [benchmark] Wrote to Redis key resilience:benchmark:external:v1
```

INFORM / WorldRiskIndex / FSI still 404 on live fetch because the source URLs are outdated, but that's an orthogonal methodology issue — not blocking the cron anymore.