### PR TITLE
chore(sentry): silence Fireglass + Chrome WebView duplex noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -308,6 +308,20 @@ Sentry.init({
     if (frames.some(f => /www-widgetapi\.js/.test(f.filename ?? ''))) return null;
     // Suppress Sentry beacon XHR transport errors (readyState on aborted XHR — not our code)
     if (frames.some(f => /beacon\.min\.js/.test(f.filename ?? ''))) return null;
+    // Suppress Fireglass (Symantec/Broadcom CloudSOC) console-hook recursion.
+    // Fireglass wraps console.log and recurses on its own debug output, producing
+    // "Maximum call stack size exceeded". Stack frames are <anonymous> so the
+    // generic hasFirstParty gate below can't see it — match by function name
+    // (WORLDMONITOR-MK).
+    if (frames.some(f => /FireglassUtils/.test(f.function ?? ''))) return null;
+    // Suppress Chrome Mobile WebView 105+ Request constructor quirk: vendored
+    // SDKs (Sentry/Clerk/Dodo fetch wrappers) pass ReadableStream bodies without
+    // duplex: 'half'. The message is exact-match unique to this spec requirement
+    // (Fetch § Request(), "duplex member must be specified"); cannot arise from
+    // other failure modes. Checkout flow already falls back to the pricing page
+    // (src/services/checkout.ts), so this is a non-user-facing Sentry event
+    // (WORLDMONITOR-MH).
+    if (/Failed to construct 'Request': The `duplex` member must be specified/.test(msg)) return null;
     // Suppress "options is not defined" from browser extension overriding Navigator getter (WORLDMONITOR-JN).
     // Only suppress when stack has no first-party frames (filename=<anonymous> is the extension getter).
     if (/^options is not defined$/.test(msg) && frames.every(f => !f.filename || f.filename === '<anonymous>' || f.filename === '[native code]')) return null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -314,14 +314,16 @@ Sentry.init({
     // generic hasFirstParty gate below can't see it — match by function name
     // (WORLDMONITOR-MK).
     if (frames.some(f => /FireglassUtils/.test(f.function ?? ''))) return null;
-    // Suppress Chrome Mobile WebView 105+ Request constructor quirk: vendored
-    // SDKs (Sentry/Clerk/Dodo fetch wrappers) pass ReadableStream bodies without
-    // duplex: 'half'. The message is exact-match unique to this spec requirement
-    // (Fetch § Request(), "duplex member must be specified"); cannot arise from
-    // other failure modes. Checkout flow already falls back to the pricing page
-    // (src/services/checkout.ts), so this is a non-user-facing Sentry event
-    // (WORLDMONITOR-MH).
-    if (/Failed to construct 'Request': The `duplex` member must be specified/.test(msg)) return null;
+    // Suppress Chrome Mobile WebView 105+ Request constructor quirk ONLY when
+    // the Dodo checkout lazy chunk is in the stack (WORLDMONITOR-MH). The
+    // exact message is unique to the Fetch § Request() duplex requirement, but
+    // src/services/runtime.ts (runtime fetch patch) also constructs `new
+    // Request(init)` at lines 861/869/902 — without this provenance guard the
+    // same filter would hide a real first-party streaming-fetch regression.
+    // Guard on the vendored chunk name (checkout-*.js = Dodo SDK, lazy-loaded
+    // only when startCheckout runs) so a runtime.ts failure still surfaces.
+    if (/Failed to construct 'Request': The `duplex` member must be specified/.test(msg)
+        && frames.some(f => /\/assets\/checkout-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     // Suppress "options is not defined" from browser extension overriding Navigator getter (WORLDMONITOR-JN).
     // Only suppress when stack has no first-party frames (filename=<anonymous> is the extension getter).
     if (/^options is not defined$/.test(msg) && frames.every(f => !f.filename || f.filename === '<anonymous>' || f.filename === '[native code]')) return null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -311,9 +311,11 @@ Sentry.init({
     // Suppress Fireglass (Symantec/Broadcom CloudSOC) console-hook recursion.
     // Fireglass wraps console.log and recurses on its own debug output, producing
     // "Maximum call stack size exceeded". Stack frames are <anonymous> so the
-    // generic hasFirstParty gate below can't see it — match by function name
-    // (WORLDMONITOR-MK).
-    if (frames.some(f => /FireglassUtils/.test(f.function ?? ''))) return null;
+    // generic hasFirstParty gate below can't see it — match by function name.
+    // Gated on excType === 'RangeError' (mirrors the sortedTrackListForMenu
+    // pattern above) so an unrelated exception with a FireglassUtils frame
+    // isn't silently dropped (WORLDMONITOR-MK).
+    if (excType === 'RangeError' && frames.some(f => /FireglassUtils/.test(f.function ?? ''))) return null;
     // Suppress Chrome Mobile WebView 105+ Request constructor quirk ONLY when
     // the Dodo checkout lazy chunk is in the stack (WORLDMONITOR-MH). The
     // exact message is unique to the Fetch § Request() duplex requirement, but

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -285,4 +285,43 @@ describe('existing beforeSend filters', () => {
     ]);
     assert.ok(beforeSend(event) !== null);
   });
+
+  // WORLDMONITOR-MK: Fireglass (Symantec/Broadcom CloudSOC) console-hook recursion.
+  it('suppresses Fireglass RangeError with FireglassUtils frame', () => {
+    const event = makeEvent('Maximum call stack size exceeded', 'RangeError', [
+      { filename: '<anonymous>', lineno: 1, function: 'FireglassUtils.logInternal' },
+      { filename: '<anonymous>', lineno: 1, function: 'Object.debug' },
+    ]);
+    assert.equal(beforeSend(event), null);
+  });
+
+  it('does NOT suppress non-RangeError that happens to have a FireglassUtils frame', () => {
+    const event = makeEvent('Something else entirely', 'TypeError', [
+      firstPartyFrame(),
+      { filename: '<anonymous>', lineno: 1, function: 'FireglassUtils.logInternal' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'RangeError gate must limit blast radius');
+  });
+
+  // WORLDMONITOR-MH: Chrome Mobile WebView 105+ duplex requirement, Dodo SDK path.
+  it('suppresses duplex error ONLY when checkout-*.js chunk is in the stack', () => {
+    const event = makeEvent(
+      "Failed to construct 'Request': The `duplex` member must be specified for a request with a streaming body",
+      'TypeError',
+      [
+        { filename: '/assets/panels-DvZJT691.js', lineno: 1, function: 'Mw.window.fetch' },
+        { filename: '/assets/checkout-BZBMtluV.js', lineno: 1, function: 'Module.cn' },
+      ],
+    );
+    assert.equal(beforeSend(event), null);
+  });
+
+  it('does NOT suppress duplex error when only first-party frames are present (runtime.ts regression must surface)', () => {
+    const event = makeEvent(
+      "Failed to construct 'Request': The `duplex` member must be specified for a request with a streaming body",
+      'TypeError',
+      [firstPartyFrame('src/services/runtime.ts', 'patchedFetch')],
+    );
+    assert.ok(beforeSend(event) !== null, 'first-party runtime regression must still surface');
+  });
 });


### PR DESCRIPTION
## Summary

Two beforeSend filters addressing unresolved Sentry issues from triage:

- **WORLDMONITOR-MK** (Max call stack, Fireglass): Symantec/Broadcom CloudSOC "Fireglass" browser security tool wraps console.log and recurses on its own debug output, producing "Maximum call stack size exceeded". Stack frames are `<anonymous>` so the existing `!hasFirstParty` gate in beforeSend can't see it. Matched by function name (`FireglassUtils`) instead, same pattern as the existing `sortedTrackListForMenu` filter.
- **WORLDMONITOR-MH** (Failed to construct 'Request': duplex member must be specified): Chrome Mobile WebView 105+ rejects Request construction when vendored SDKs (Sentry/Clerk/Dodo fetch wrappers) pass a ReadableStream body without `duplex: 'half'`. Exact-message regex is unique to the Fetch § Request() spec requirement. Checkout flow already falls back to the pricing page, so these are cosmetic events for ops (1 event across Android WebView).

Both issues already resolved in Sentry with `inNextRelease=true`; they'll auto-reopen if the patterns recur after this deploys.

## Test plan

- [x] `npm run typecheck` + `typecheck:api` clean
- [x] `tests/sentry-beforesend.test.mjs` — 80/80 pass
- [x] Edge bundle check + `edge-functions.test.mjs` (165/165) pass
- [x] `biome lint src/main.ts` clean
- [x] `lint:md` + `version:check` pass
- [ ] After deploy: verify MK + MH don't reappear in Sentry within 7 days