### PR TITLE
fix(resilience): rebuild ranking key when bulk-RPC race leaves it null

### DIFF
--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -240,11 +240,32 @@ async function seedResilienceScores() {
     // null in Redis after the bulk call. Path (b) catches the race; the
     // second RPC call sees warm per-country scores in cache and the handler's
     // re-read succeeds.
-    const rankingExists = await redisGetJson(url, token, RESILIENCE_RANKING_CACHE_KEY);
+    // Inline GET so we can distinguish "key absent" (rebuild needed) from
+    // "GET failed" (rebuild as a precaution but log it for incident triage).
+    // The shared redisGetJson() collapses both into null, which would silently
+    // mask transient Upstash hiccups in the rebuild trigger reason.
+    let rankingExists = null;
+    let rankingProbeFailed = false;
+    try {
+      const probeResp = await fetch(`${url}/get/${encodeURIComponent(RESILIENCE_RANKING_CACHE_KEY)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (!probeResp.ok) {
+        rankingProbeFailed = true;
+        console.warn(`[resilience-scores] Ranking probe HTTP ${probeResp.status}; rebuilding as a precaution`);
+      } else {
+        const data = await probeResp.json();
+        rankingExists = data?.result || null;
+      }
+    } catch (err) {
+      rankingProbeFailed = true;
+      console.warn(`[resilience-scores] Ranking probe failed (${err.message}); rebuilding as a precaution`);
+    }
     if (laggardsWarmed > 0 || rankingExists == null) {
       const reason = laggardsWarmed > 0
         ? `${laggardsWarmed} laggard warms`
-        : 'bulk-call race left ranking:v9 null';
+        : (rankingProbeFailed ? 'ranking probe failed (precautionary)' : 'bulk-call race left ranking:v9 null');
       try {
         if (laggardsWarmed > 0) {
           await redisPipeline(url, token, [['DEL', RESILIENCE_RANKING_CACHE_KEY]]);

--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -215,17 +215,40 @@ async function seedResilienceScores() {
       console.log(`[resilience-scores] Laggards warmed: ${laggardsWarmed}/${stillMissing.length}`);
     }
 
-    // If any laggards were warmed, the ranking cache (written earlier by the
-    // bulk endpoint) no longer reflects them — it froze them as coverage-0
-    // greyedOut entries. DEL the key AND re-call the ranking endpoint to
-    // rebuild from the now-complete per-country cache. Don't stop at DEL:
-    // downstream consumers (benchmark-resilience-external.mjs) read
-    // resilience:ranking:v9 directly from Redis and skip on null, so a
-    // null-until-next-user-RPC window would leave the weekly validation
-    // cron with no ranking to benchmark against.
-    if (laggardsWarmed > 0) {
+    // The ranking cache (resilience:ranking:v9) needs to reflect the
+    // freshly-warmed per-country scores. Two failure modes have to be handled:
+    //
+    //   1. Laggards were warmed individually after the bulk RPC. The ranking
+    //      cache (written earlier) froze those countries as coverage-0
+    //      greyedOut entries. Rebuild needed.
+    //
+    //   2. The bulk RPC's handler hit a read-after-write race: it called
+    //      warmMissingResilienceScores() (writing 222 per-country keys), then
+    //      its own re-read of those same keys returned an empty Map (Upstash
+    //      pipeline visibility lag in the same Vercel invocation). Result:
+    //      cachedScores.size = 0, every item built with `undefined` payload =
+    //      coverage 0 = all 222 in greyedOut, coverage gate (cachedScores.size
+    //      / countryCodes.length) = 0% < 75% → handler skips the SET → ranking
+    //      cache stays null.
+    //
+    //      stillMissing is computed from the seeder's OWN pipeline GET (which
+    //      sees the writes), so it correctly reports 0 laggards. The original
+    //      `if (laggardsWarmed > 0)` gate would skip the rebuild — and we'd
+    //      end up with all per-country scores cached but no ranking key.
+    //
+    // Fix: rebuild whenever (a) we warmed laggards OR (b) the ranking key is
+    // null in Redis after the bulk call. Path (b) catches the race; the
+    // second RPC call sees warm per-country scores in cache and the handler's
+    // re-read succeeds.
+    const rankingExists = await redisGetJson(url, token, RESILIENCE_RANKING_CACHE_KEY);
+    if (laggardsWarmed > 0 || rankingExists == null) {
+      const reason = laggardsWarmed > 0
+        ? `${laggardsWarmed} laggard warms`
+        : 'bulk-call race left ranking:v9 null';
       try {
-        await redisPipeline(url, token, [['DEL', RESILIENCE_RANKING_CACHE_KEY]]);
+        if (laggardsWarmed > 0) {
+          await redisPipeline(url, token, [['DEL', RESILIENCE_RANKING_CACHE_KEY]]);
+        }
         const rebuildHeaders = { 'User-Agent': SEED_UA, 'Accept': 'application/json' };
         if (WM_KEY) rebuildHeaders['X-WorldMonitor-Key'] = WM_KEY;
         const rebuildResp = await fetch(`${API_BASE}/api/resilience/v1/get-resilience-ranking`, {
@@ -235,7 +258,7 @@ async function seedResilienceScores() {
         if (rebuildResp.ok) {
           const rebuilt = await rebuildResp.json();
           const total = (rebuilt.items?.length ?? 0) + (rebuilt.greyedOut?.length ?? 0);
-          console.log(`[resilience-scores] Rebuilt ${RESILIENCE_RANKING_CACHE_KEY} with ${total} countries after ${laggardsWarmed} laggard warms`);
+          console.log(`[resilience-scores] Rebuilt ${RESILIENCE_RANKING_CACHE_KEY} with ${total} countries (${reason})`);
         } else {
           console.warn(`[resilience-scores] Rebuild ranking HTTP ${rebuildResp.status} — ranking cache is null until next RPC call`);
         }

--- a/tests/resilience-scores-seed.test.mjs
+++ b/tests/resilience-scores-seed.test.mjs
@@ -113,3 +113,43 @@ describe('script is self-contained .mjs', () => {
     }
   });
 });
+
+describe('rebuilds ranking key on race-condition or laggards', () => {
+  // Locks in the defensive rebuild added after the bulk RPC. The bulk call's
+  // handler can suffer a read-after-write race in Vercel where its own
+  // re-read of the per-country cache returns empty even though writes
+  // landed; this leaves resilience:ranking:v9 null even with all 222 score
+  // keys present. The seeder must verify and re-call the RPC in that case.
+  let src;
+  it('reads ranking key after bulk RPC', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, join } = await import('node:path');
+    const dir = dirname(fileURLToPath(import.meta.url));
+    src = readFileSync(join(dir, '..', 'scripts', 'seed-resilience-scores.mjs'), 'utf8');
+    assert.match(
+      src,
+      /redisGetJson\(url,\s*token,\s*RESILIENCE_RANKING_CACHE_KEY\)/,
+      'must GET resilience:ranking:v9 after bulk warmup to verify it was written',
+    );
+  });
+
+  it('triggers rebuild when ranking is null OR laggards were warmed', () => {
+    assert.match(
+      src,
+      /if\s*\(laggardsWarmed\s*>\s*0\s*\|\|\s*rankingExists\s*==\s*null\)/,
+      'rebuild gate must fire on EITHER laggard warms OR null ranking key',
+    );
+  });
+
+  it('only DELs ranking when laggards were warmed (not on race-condition retry)', () => {
+    // On the race path, the key is already null — skipping DEL avoids a
+    // pointless extra Redis call. On the laggard path, DEL forces the
+    // handler to recompute fresh ranking with the now-warmed laggards.
+    assert.match(
+      src,
+      /if\s*\(laggardsWarmed\s*>\s*0\)\s*{\s*await\s+redisPipeline\([^)]+\['DEL',\s*RESILIENCE_RANKING_CACHE_KEY\]\]/,
+      'DEL must be guarded by laggardsWarmed > 0',
+    );
+  });
+});

--- a/tests/resilience-scores-seed.test.mjs
+++ b/tests/resilience-scores-seed.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
@@ -121,16 +121,27 @@ describe('rebuilds ranking key on race-condition or laggards', () => {
   // landed; this leaves resilience:ranking:v9 null even with all 222 score
   // keys present. The seeder must verify and re-call the RPC in that case.
   let src;
-  it('reads ranking key after bulk RPC', async () => {
+  before(async () => {
+    // Read once in a hook so all assertions get a meaningful failure if the
+    // file read itself breaks — instead of cascading TypeErrors from
+    // `assert.match(undefined, …)` in dependent tests.
     const { readFileSync } = await import('node:fs');
     const { fileURLToPath } = await import('node:url');
     const { dirname, join } = await import('node:path');
     const dir = dirname(fileURLToPath(import.meta.url));
     src = readFileSync(join(dir, '..', 'scripts', 'seed-resilience-scores.mjs'), 'utf8');
+  });
+
+  it('probes the ranking key after bulk RPC and distinguishes absent from probe-failed', () => {
     assert.match(
       src,
-      /redisGetJson\(url,\s*token,\s*RESILIENCE_RANKING_CACHE_KEY\)/,
+      /\$\{encodeURIComponent\(RESILIENCE_RANKING_CACHE_KEY\)\}/,
       'must GET resilience:ranking:v9 after bulk warmup to verify it was written',
+    );
+    assert.match(
+      src,
+      /rankingProbeFailed\s*=\s*true/,
+      'must distinguish probe failure from genuinely-absent key for incident triage',
     );
   });
 


### PR DESCRIPTION
## Why this PR?

`seed-bundle-resilience` ran cleanly today (12:03 UTC) — wrote all 222 per-country resilience scores to Redis. But `resilience:ranking:v9` was left **null**, which then made the weekly validation cron's External-Benchmark skip with `[benchmark] No WM resilience scores available`.

The seeder log was the smoking gun:

```
[resilience-scores] 0/222 scores pre-warmed
[resilience-scores] Warming 222 missing via ranking endpoint...
[resilience-scores] Ranking: 0 ranked, 222 greyed out      ← the bug
[resilience-scores] Final: 222/222 cached                  ← scores DID land
```

Direct Redis probe a few minutes later confirmed: `seed-meta:resilience:ranking` was fresh, all 222 per-country score keys were populated, but `resilience:ranking:v9` was null. A manual call to the same RPC at that point completed in 2.5s and populated the key correctly.

## The race

`server/worldmonitor/resilience/v1/get-resilience-ranking.ts` flow on a cold cache:

```ts
let cachedScores = await getCachedResilienceScores(countryCodes);   // empty (cold cache)
const missing = countryCodes.filter((cc) => !cachedScores.has(cc));  // = all 222
await warmMissingResilienceScores(missing);   // Promise.allSettled writes 222 keys to Redis
cachedScores = await getCachedResilienceScores(countryCodes);  // ← can return empty here
const allItems = countryCodes.map((cc) => buildRankingItem(cc, cachedScores.get(cc), …));
//                                                          ^^^^^^^^^^^^^^^^^^^^^ undefined
//                                                          → coverage 0 → all greyedOut
const coverageRatio = cachedScores.size / countryCodes.length; // = 0/222 = 0%
if (coverageRatio >= 0.75) { ... write ... }                    // gate fails → no SET
```

The re-read inside the same Vercel invocation can return an empty Map because the Upstash REST pipeline writes from `Promise.allSettled` aren't always visible to the immediately-following pipeline GET. The seeder's OWN pipeline GET a few hundred milliseconds later sees them fine — that's why `Final: 222/222 cached` was reported correctly while the handler returned the degenerate `0 ranked / 222 greyed out` response.

## Why the existing rebuild path didn't catch it

#3049 added a `DEL + re-call` rebuild after laggard warmup, but it was gated `if (laggardsWarmed > 0)`. In the race scenario, the seeder's pipeline GET sees all 222 cached → `stillMissing = 0` → `laggardsWarmed = 0` → rebuild is skipped. Outcome: 222 score keys in Redis but ranking key null until either the 6h TTL window resets the state or someone hits the RPC.

## Fix

Widen the rebuild gate to fire on **either** condition:

```js
const rankingExists = await redisGetJson(url, token, RESILIENCE_RANKING_CACHE_KEY);
if (laggardsWarmed > 0 || rankingExists == null) {
  // Path A (laggards):    DEL stale ranking, then RPC to rebuild fresh
  // Path B (race-recover): skip DEL (key is already null), RPC to populate
  ...
}
```

The seeder's `redisGetJson` here runs after its own pipeline GET sees the writes, which means it's after the race window. By the time we re-call the RPC, per-country scores are visible to the handler too, so the second invocation's re-read succeeds, the gate passes at 100%, ranking gets written.

Failure path is no worse than today: if the rebuild call fails, log + leave key null until next user RPC.

## Test plan

- [x] 18 / 18 tests pass in `tests/resilience-scores-seed.test.mjs` (3 new source-string assertions lock the rebuild gate condition + DEL-only-when-laggards behavior)
- [x] biome clean
- [ ] After merge: next `seed-bundle-resilience` cron tick should leave `resilience:ranking:v9` populated even on cold-cache runs. Expected log: `Rebuilt resilience:ranking:v9 with 222 countries (bulk-call race left ranking:v9 null)` if path B fires; silent no-op if path A succeeded normally.
- [ ] After merge: next `seed-bundle-resilience-validation` cron tick should report real External-Benchmark output (Spearman correlations vs. INFORM/ND-GAIN/etc.) instead of `Skipped: no-wm-scores`.

## Stack

Continues #3041 → #3045 → #3049 → #3050 → #3052 → #3054. Closes the last reproducible "validation cron skips silently" path I've found in the resilience pipeline.