### PR TITLE
fix(relay): remove duplicate shadowLogScore call for rss_alert events - WHEN READY (#3059)

### DIFF
--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -680,9 +680,6 @@ async function processEvent(event) {
     return;
   }
 
-  // Shadow log the score on every rss_alert event (fire-and-forget, no await needed)
-  if (event.eventType === 'rss_alert') shadowLogScore(event).catch(() => {});
-
   const matching = enabledRules.filter(r =>
     (!r.digestMode || r.digestMode === 'realtime') &&   // skip digest-mode rules — handled by seed-digest-notifications cron
     (r.eventTypes.length === 0 || r.eventTypes.includes(event.eventType)) &&


### PR DESCRIPTION
## Summary

- **Context:** Found during a validation pass of the server-side preferences sync and notification delivery feature (#2173).
- `shadowLogScore(event)` was called unconditionally for all event types on line 663, then called again conditionally for `rss_alert` events on line 684. This caused duplicate shadow-log writes for every `rss_alert` event.
- Removed the redundant conditional call (lines 683-684), keeping only the unconditional call that already covers all event types.

Closes #3059

## Test plan

- [ ] Verify `rss_alert` events produce exactly one shadow-log entry (not two)
- [ ] Verify other event types continue to shadow-log normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)