### PR TITLE
feat: extend IMF WEO coverage across MCP, resilience, and country intel

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,7 @@
 - [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
 - [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
 - [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
+- [ ] New seed / canonical Redis key is exposed via MCP in `api/mcp.ts` (if adding or changing seeds)
 - [ ] No API keys or secrets committed
 - [ ] TypeScript compiles without errors (`npm run typecheck`)
 

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -21,6 +21,9 @@ const BOOTSTRAP_CACHE_KEYS = {
   bisExchange:      'economic:bis:eer:v1',
   bisCredit:        'economic:bis:credit:v1',
   imfMacro:         'economic:imf:macro:v2',
+  imfGrowth:        'economic:imf:growth:v1',
+  imfLabor:         'economic:imf:labor:v1',
+  imfExternal:      'economic:imf:external:v1',
   shippingRates:    'supply_chain:shipping:v2',
   chokepoints:      'supply_chain:chokepoints:v4',
   minerals:         'supply_chain:minerals:v2',
@@ -102,7 +105,7 @@ const BOOTSTRAP_CACHE_KEYS = {
 };
 
 const SLOW_KEYS = new Set([
-  'bisPolicy', 'bisExchange', 'bisCredit', 'imfMacro', 'minerals', 'giving',
+  'bisPolicy', 'bisExchange', 'bisCredit', 'imfMacro', 'imfGrowth', 'imfLabor', 'imfExternal', 'minerals', 'giving',
   'sectors', 'etfFlows', 'wildfires', 'climateAnomalies', 'climateDisasters', 'co2Monitoring', 'oceanIce', 'climateNews',
   'radiationWatch', 'thermalEscalation', 'crossSourceSignals',
   'cyberThreats', 'techReadiness', 'progressData', 'renewableEnergy',

--- a/api/health.js
+++ b/api/health.js
@@ -101,7 +101,10 @@ const STANDALONE_KEYS = {
   bisPolicy:             'economic:bis:policy:v1',
   bisExchange:           'economic:bis:eer:v1',
   bisCredit:             'economic:bis:credit:v1',
-  imfMacro:             'economic:imf:macro:v2',
+  imfMacro:              'economic:imf:macro:v2',
+  imfGrowth:             'economic:imf:growth:v1',
+  imfLabor:              'economic:imf:labor:v1',
+  imfExternal:           'economic:imf:external:v1',
   climateZoneNormals:    'climate:zone-normals:v1',
   shippingRates:         'supply_chain:shipping:v2',
   chokepoints:           'supply_chain:chokepoints:v4',
@@ -207,6 +210,9 @@ const SEED_META = {
   macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 20 },
   bisPolicy:        { key: 'seed-meta:economic:bis',              maxStaleMin: 10080 }, // runSeed('economic','bis',...) writes seed-meta:economic:bis
   imfMacro:         { key: 'seed-meta:economic:imf-macro',        maxStaleMin: 100800 }, // monthly seed; 100800min = 70 days = 2× interval (absorbs one missed run)
+  imfGrowth:        { key: 'seed-meta:economic:imf-growth',       maxStaleMin: 100800 }, // monthly IMF WEO seed; 70d = 2× 35-day cadence
+  imfLabor:         { key: 'seed-meta:economic:imf-labor',        maxStaleMin: 100800 }, // monthly IMF WEO seed; 70d = 2× 35-day cadence
+  imfExternal:      { key: 'seed-meta:economic:imf-external',     maxStaleMin: 100800 }, // monthly IMF WEO seed; 70d = 2× 35-day cadence
   shippingRates:    { key: 'seed-meta:supply_chain:shipping',     maxStaleMin: 420 },
   chokepoints:      { key: 'seed-meta:supply_chain:chokepoints',  maxStaleMin: 60 },
   // minerals + giving: on-demand cachedFetchJson only, no seed-meta writer — freshness checked via TTL

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -59,6 +59,7 @@ interface CacheToolDef extends BaseToolDef {
   _seedMetaKey: string;
   _maxStaleMin: number;
   _freshnessChecks?: FreshnessCheck[];
+  _resultLabels?: string[];
   _execute?: never;
 }
 
@@ -73,10 +74,10 @@ interface RpcToolDef extends BaseToolDef {
 
 type ToolDef = CacheToolDef | RpcToolDef;
 
-const TOOL_REGISTRY: ToolDef[] = [
+export const TOOL_REGISTRY: ToolDef[] = [
   {
     name: 'get_market_data',
-    description: 'Real-time equity quotes, commodity prices (including gold futures GC=F), crypto prices, forex FX rates (USD/EUR, USD/JPY etc.), sector performance, ETF flows, and Gulf market quotes from WorldMonitor\'s curated bootstrap cache.',
+    description: 'Market snapshot across liquid global assets: equities, commodities, crypto, sector heatmaps, ETF flows, Gulf market quotes, stablecoin market structure, crypto sector rotation, and seeded FX rates. Mixes intraday relay-fed caches with daily FX reference data for fast cross-asset monitoring.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'market:stocks-bootstrap:v1',
@@ -86,9 +87,36 @@ const TOOL_REGISTRY: ToolDef[] = [
       'market:etf-flows:v1',
       'market:gulf-quotes:v1',
       'market:fear-greed:v1',
+      'market:stablecoins:v1',
+      'market:crypto-sectors:v1',
+      'shared:fx-rates:v1',
     ],
     _seedMetaKey: 'seed-meta:market:stocks',
     _maxStaleMin: 30,
+    _freshnessChecks: [
+      { key: 'seed-meta:market:stocks', maxStaleMin: 30 },
+      { key: 'seed-meta:market:commodities', maxStaleMin: 30 },
+      { key: 'seed-meta:market:crypto', maxStaleMin: 30 },
+      { key: 'seed-meta:market:sectors', maxStaleMin: 30 },
+      { key: 'seed-meta:market:etf-flows', maxStaleMin: 60 },
+      { key: 'seed-meta:market:gulf-quotes', maxStaleMin: 30 },
+      { key: 'seed-meta:market:fear-greed', maxStaleMin: 720 },
+      { key: 'seed-meta:market:stablecoins', maxStaleMin: 60 },
+      { key: 'seed-meta:market:crypto-sectors', maxStaleMin: 120 },
+      { key: 'seed-meta:shared:fx-rates', maxStaleMin: 1500 },
+    ],
+    _resultLabels: [
+      'stocks-bootstrap',
+      'commodities-bootstrap',
+      'crypto',
+      'sectors',
+      'etf-flows',
+      'gulf-quotes',
+      'fear-greed',
+      'stablecoins',
+      'crypto-sectors',
+      'fx-rates',
+    ],
   },
   {
     name: 'get_conflict_events',
@@ -113,16 +141,31 @@ const TOOL_REGISTRY: ToolDef[] = [
   },
   {
     name: 'get_news_intelligence',
-    description: 'AI-classified geopolitical threat news summaries, GDELT intelligence signals, cross-source signals, and security advisories from WorldMonitor\'s intelligence layer.',
+    description: 'Geopolitical intelligence layer: AI-classified threat summaries, GDELT event signals, cross-source fused alerts, and both bootstrap and canonical security advisories. Optimized for fast global monitoring with relay-fed freshness measured in minutes to hours.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'news:insights:v1',
       'intelligence:gdelt-intel:v1',
       'intelligence:cross-source-signals:v1',
       'intelligence:advisories-bootstrap:v1',
+      'intelligence:advisories:v1',
     ],
     _seedMetaKey: 'seed-meta:news:insights',
     _maxStaleMin: 30,
+    _freshnessChecks: [
+      { key: 'seed-meta:news:insights', maxStaleMin: 30 },
+      { key: 'seed-meta:intelligence:gdelt-intel', maxStaleMin: 420 },
+      { key: 'seed-meta:intelligence:cross-source-signals', maxStaleMin: 30 },
+      { key: 'seed-meta:intelligence:advisories', maxStaleMin: 120 },
+      { key: 'seed-meta:intelligence:advisories', maxStaleMin: 120 },
+    ],
+    _resultLabels: [
+      'news-insights',
+      'gdelt-intel',
+      'cross-source-signals',
+      'advisories-bootstrap',
+      'advisories',
+    ],
   },
   {
     name: 'get_natural_disasters',
@@ -146,15 +189,20 @@ const TOOL_REGISTRY: ToolDef[] = [
   },
   {
     name: 'get_cyber_threats',
-    description: 'Active cyber threat intelligence: malware IOCs (URLhaus, Feodotracker), CISA known exploited vulnerabilities, and active command-and-control infrastructure.',
+    description: 'Active cyber threat intelligence including the fast bootstrap summary and the full canonical threat corpus. Covers malware IOCs, CISA KEVs, active command-and-control infrastructure, and country-attributed cyber signals updated on a multi-hour cadence.',
     inputSchema: { type: 'object', properties: {}, required: [] },
-    _cacheKeys: ['cyber:threats-bootstrap:v2'],
+    _cacheKeys: ['cyber:threats-bootstrap:v2', 'cyber:threats:v2'],
     _seedMetaKey: 'seed-meta:cyber:threats',
     _maxStaleMin: 240,
+    _freshnessChecks: [
+      { key: 'seed-meta:cyber:threats', maxStaleMin: 240 },
+      { key: 'seed-meta:cyber:threats', maxStaleMin: 240 },
+    ],
+    _resultLabels: ['threats-bootstrap', 'threats'],
   },
   {
     name: 'get_economic_data',
-    description: 'Macro economic indicators: Fed Funds rate (FRED), economic calendar events, fuel prices, ECB FX rates, EU yield curve, earnings calendar, COT positioning, and energy storage data.',
+    description: 'Macro and price intelligence: policy rates, economic calendar events, fuel prices, ECB FX and yield data, IMF WEO macro indicators for 200+ countries, sovereign debt, Big Mac PPP, grocery baskets, FAO food prices, Eurostat country metrics, EU gas storage, BLS series, earnings, and COT positioning.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'economic:fred:v1:FEDFUNDS:0',
@@ -165,9 +213,81 @@ const TOOL_REGISTRY: ToolDef[] = [
       'economic:spending:v1',
       'market:earnings-calendar:v1',
       'market:cot:v1',
+      'economic:imf:macro:v2',
+      'economic:national-debt:v1',
+      'economic:bigmac:v1',
+      'economic:grocery-basket:v1',
+      'economic:fao-ffpi:v1',
+      'economic:eurostat-country-data:v1',
+      'economic:eu-gas-storage:v1',
+      'bls:series:v1',
     ],
     _seedMetaKey: 'seed-meta:economic:econ-calendar',
     _maxStaleMin: 1440,
+    _freshnessChecks: [
+      { key: 'seed-meta:economic:fred:v1:FEDFUNDS:0', maxStaleMin: 1500 },
+      { key: 'seed-meta:economic:econ-calendar', maxStaleMin: 1440 },
+      { key: 'seed-meta:economic:fuel-prices', maxStaleMin: 10080 },
+      { key: 'seed-meta:economic:ecb-fx-rates', maxStaleMin: 5760 },
+      { key: 'seed-meta:economic:yield-curve-eu', maxStaleMin: 4320 },
+      { key: 'seed-meta:economic:spending', maxStaleMin: 120 },
+      { key: 'seed-meta:market:earnings-calendar', maxStaleMin: 1440 },
+      { key: 'seed-meta:market:cot', maxStaleMin: 14400 },
+      { key: 'seed-meta:economic:imf-macro', maxStaleMin: 100800 },
+      { key: 'seed-meta:economic:national-debt', maxStaleMin: 10080 },
+      { key: 'seed-meta:economic:bigmac', maxStaleMin: 10080 },
+      { key: 'seed-meta:economic:grocery-basket', maxStaleMin: 10080 },
+      { key: 'seed-meta:economic:fao-ffpi', maxStaleMin: 86400 },
+      { key: 'seed-meta:economic:eurostat-country-data', maxStaleMin: 4320 },
+      { key: 'seed-meta:economic:eu-gas-storage', maxStaleMin: 2880 },
+      { key: 'seed-meta:economic:bls-series', maxStaleMin: 2880 },
+    ],
+    _resultLabels: [
+      'fedfunds',
+      'econ-calendar',
+      'fuel-prices',
+      'ecb-fx-rates',
+      'yield-curve-eu',
+      'spending',
+      'earnings-calendar',
+      'cot-positioning',
+      'imf-macro',
+      'national-debt',
+      'bigmac',
+      'grocery-basket',
+      'fao-ffpi',
+      'eurostat-country-data',
+      'eu-gas-storage',
+      'bls-series',
+    ],
+  },
+  {
+    name: 'get_resilience_recovery_data',
+    description: 'Recovery and fiscal resilience indicators across roughly 150+ countries. Bundles monthly fiscal space, reserve adequacy, external debt, import concentration, and fuel stock buffers used by WorldMonitor\'s resilience scoring system.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    _cacheKeys: [
+      'resilience:recovery:fiscal-space:v1',
+      'resilience:recovery:reserve-adequacy:v1',
+      'resilience:recovery:external-debt:v1',
+      'resilience:recovery:import-hhi:v1',
+      'resilience:recovery:fuel-stocks:v1',
+    ],
+    _seedMetaKey: 'seed-meta:resilience:recovery:fiscal-space',
+    _maxStaleMin: 86400,
+    _freshnessChecks: [
+      { key: 'seed-meta:resilience:recovery:fiscal-space', maxStaleMin: 86400 },
+      { key: 'seed-meta:resilience:recovery:reserve-adequacy', maxStaleMin: 86400 },
+      { key: 'seed-meta:resilience:recovery:external-debt', maxStaleMin: 86400 },
+      { key: 'seed-meta:resilience:recovery:import-hhi', maxStaleMin: 86400 },
+      { key: 'seed-meta:resilience:recovery:fuel-stocks', maxStaleMin: 86400 },
+    ],
+    _resultLabels: [
+      'fiscal-space',
+      'reserve-adequacy',
+      'external-debt',
+      'import-hhi',
+      'fuel-stocks',
+    ],
   },
   {
     name: 'get_prediction_markets',
@@ -204,23 +324,111 @@ const TOOL_REGISTRY: ToolDef[] = [
   },
   {
     name: 'get_infrastructure_status',
-    description: 'Internet infrastructure health: Cloudflare Radar outages and service status for major cloud providers and internet services.',
+    description: 'Infrastructure status across internet and physical backbones: outage telemetry, major service status boards, and strategic submarine cable inventory. Covers rapidly changing outages plus slower-moving cable topology snapshots.',
     inputSchema: { type: 'object', properties: {}, required: [] },
-    _cacheKeys: ['infra:outages:v1'],
+    _cacheKeys: [
+      'infra:outages:v1',
+      'infra:service-statuses:v1',
+      'infrastructure:submarine-cables:v1',
+    ],
     _seedMetaKey: 'seed-meta:infra:outages',
     _maxStaleMin: 30,
+    _freshnessChecks: [
+      { key: 'seed-meta:infra:outages', maxStaleMin: 30 },
+      { key: 'seed-meta:infra:service-statuses', maxStaleMin: 120 },
+      { key: 'seed-meta:infrastructure:submarine-cables', maxStaleMin: 20160 },
+    ],
+    _resultLabels: ['outages', 'service-statuses', 'submarine-cables'],
+  },
+  {
+    name: 'get_energy_security_data',
+    description: 'Energy security monitoring: live chokepoint flow baselines and disruptions, strategic reserve policy registries, IEA oil stock coverage, JODI oil and gas balances, and a curated energy intelligence feed. Mixes 6-hour geopolitical signals with monthly or static strategic datasets.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    _cacheKeys: [
+      'energy:chokepoint-baselines:v1',
+      'energy:chokepoint-flows:v1',
+      'energy:crisis-policies:v1',
+      'energy:iea-oil-stocks:v1:index',
+      'energy:intelligence:feed:v1',
+      'energy:jodi-gas:v1:_countries',
+      'energy:jodi-oil:v1:_countries',
+      'energy:spr-policies:v1',
+    ],
+    _seedMetaKey: 'seed-meta:energy:intelligence',
+    _maxStaleMin: 720,
+    _freshnessChecks: [
+      { key: 'seed-meta:energy:chokepoint-baselines', maxStaleMin: 576000 },
+      { key: 'seed-meta:energy:chokepoint-flows', maxStaleMin: 720 },
+      { key: 'seed-meta:energy:crisis-policies', maxStaleMin: 576000 },
+      { key: 'seed-meta:energy:iea-oil-stocks', maxStaleMin: 57600 },
+      { key: 'seed-meta:energy:intelligence', maxStaleMin: 720 },
+      { key: 'seed-meta:energy:jodi-gas', maxStaleMin: 57600 },
+      { key: 'seed-meta:energy:jodi-oil', maxStaleMin: 57600 },
+      { key: 'seed-meta:energy:spr-policies', maxStaleMin: 576000 },
+    ],
+    _resultLabels: [
+      'chokepoint-baselines',
+      'chokepoint-flows',
+      'crisis-policies',
+      'iea-oil-stocks',
+      'energy-intelligence',
+      'jodi-gas',
+      'jodi-oil',
+      'spr-policies',
+    ],
   },
   {
     name: 'get_supply_chain_data',
-    description: 'Dry bulk shipping stress index, customs revenue flows, and COMTRADE bilateral trade data. Tracks global supply chain pressure and trade disruptions.',
+    description: 'Supply chain monitoring across trade flows and chokepoints: shipping stress, customs revenue, COMTRADE trade flows, Hormuz tracker, PortWatch global port activity, chokepoint reference geometry, and active maritime disruptions.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'supply_chain:shipping_stress:v1',
       'trade:customs-revenue:v1',
       'comtrade:flows:v1',
+      'supply_chain:hormuz_tracker:v1',
+      'supply_chain:portwatch-ports:v1:_countries',
+      'supply_chain:portwatch:v1',
+      'portwatch:chokepoints:ref:v1',
+      'portwatch:disruptions:active:v1',
     ],
-    _seedMetaKey: 'seed-meta:trade:customs-revenue',
+    _seedMetaKey: 'seed-meta:supply_chain:shipping_stress',
+    _maxStaleMin: 45,
+    _freshnessChecks: [
+      { key: 'seed-meta:supply_chain:shipping_stress', maxStaleMin: 45 },
+      { key: 'seed-meta:trade:customs-revenue', maxStaleMin: 1440 },
+      { key: 'seed-meta:trade:comtrade-flows', maxStaleMin: 2880 },
+      { key: 'seed-meta:supply_chain:hormuz_tracker', maxStaleMin: 2880 },
+      { key: 'seed-meta:supply_chain:portwatch-ports', maxStaleMin: 2160 },
+      { key: 'seed-meta:supply_chain:portwatch', maxStaleMin: 720 },
+      { key: 'seed-meta:portwatch:chokepoints-ref', maxStaleMin: 2880 },
+      { key: 'seed-meta:portwatch:disruptions', maxStaleMin: 120 },
+    ],
+    _resultLabels: [
+      'shipping-stress',
+      'customs-revenue',
+      'comtrade-flows',
+      'hormuz-tracker',
+      'portwatch-ports',
+      'portwatch',
+      'portwatch-chokepoints',
+      'portwatch-disruptions',
+    ],
+  },
+  {
+    name: 'get_public_health_data',
+    description: 'Global public health monitoring with disease outbreak summaries and real-time vaccine-preventable disease alerts. Covers country-level outbreak feeds, geo-located alerts, and daily-to-near-daily health security snapshots.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    _cacheKeys: [
+      'health:disease-outbreaks:v1',
+      'health:vpd-tracker:realtime:v1',
+    ],
+    _seedMetaKey: 'seed-meta:health:disease-outbreaks',
     _maxStaleMin: 2880,
+    _freshnessChecks: [
+      { key: 'seed-meta:health:disease-outbreaks', maxStaleMin: 2880 },
+      { key: 'seed-meta:health:vpd-tracker', maxStaleMin: 2880 },
+    ],
+    _resultLabels: ['disease-outbreaks', 'vpd-tracker'],
   },
   {
     name: 'get_positive_events',
@@ -240,11 +448,16 @@ const TOOL_REGISTRY: ToolDef[] = [
   },
   {
     name: 'get_research_signals',
-    description: 'Tech and research event signals: emerging technology events bootstrap data from curated research feeds.',
+    description: 'Research and innovation signals from curated emerging-tech feeds plus recent defense and dual-use patent filings. Combines frequent research-event refreshes with slower weekly patent intelligence.',
     inputSchema: { type: 'object', properties: {}, required: [] },
-    _cacheKeys: ['research:tech-events-bootstrap:v1'],
+    _cacheKeys: ['research:tech-events-bootstrap:v1', 'patents:defense:latest'],
     _seedMetaKey: 'seed-meta:research:tech-events',
     _maxStaleMin: 480,
+    _freshnessChecks: [
+      { key: 'seed-meta:research:tech-events', maxStaleMin: 480 },
+      { key: 'seed-meta:military:defense-patents', maxStaleMin: 20160 },
+    ],
+    _resultLabels: ['tech-events-bootstrap', 'defense-patents'],
   },
   {
     name: 'get_forecast_predictions',
@@ -265,6 +478,24 @@ const TOOL_REGISTRY: ToolDef[] = [
     _cacheKeys: ['intelligence:social:reddit:v1'],
     _seedMetaKey: 'seed-meta:intelligence:social-reddit',
     _maxStaleMin: 30,
+  },
+  {
+    name: 'get_cross_domain_signals',
+    description: 'Cross-domain signal pack for fast agent grounding: correlation cards linking economic, market, and geopolitical shocks; thermal escalation watchlists; and live regulatory actions from official agencies. Data refresh ranges from minutes to a few hours.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    _cacheKeys: [
+      'correlation:cards-bootstrap:v1',
+      'thermal:escalation:v1',
+      'regulatory:actions:v1',
+    ],
+    _seedMetaKey: 'seed-meta:correlation:cards',
+    _maxStaleMin: 15,
+    _freshnessChecks: [
+      { key: 'seed-meta:correlation:cards', maxStaleMin: 15 },
+      { key: 'seed-meta:thermal:escalation', maxStaleMin: 360 },
+      { key: 'seed-meta:regulatory:actions', maxStaleMin: 360 },
+    ],
+    _resultLabels: ['correlation-cards', 'thermal-escalation', 'regulatory-actions'],
   },
 
   // -------------------------------------------------------------------------
@@ -718,6 +949,16 @@ export function evaluateFreshness(checks: FreshnessCheck[], metas: unknown[], no
   };
 }
 
+function deriveResultLabel(key: string): string {
+  const parts = key.split(':');
+  const NON_LABEL = /^(v\d+|\d+|stale|sebuf)$/;
+  for (let idx = parts.length - 1; idx >= 0; idx--) {
+    const seg = parts[idx] ?? '';
+    if (!NON_LABEL.test(seg)) return seg;
+  }
+  return parts[0] ?? key;
+}
+
 // ---------------------------------------------------------------------------
 // Tool execution
 // ---------------------------------------------------------------------------
@@ -731,17 +972,9 @@ async function executeTool(tool: CacheToolDef): Promise<{ cached_at: string | nu
   const { cached_at, stale } = evaluateFreshness(freshnessChecks, metas);
 
   const data: Record<string, unknown> = {};
-  // Walk backward through ':'-delimited segments, skipping non-informative suffixes
-  // (version tags, bare numbers, internal format names) to produce a readable label.
-  const NON_LABEL = /^(v\d+|\d+|stale|sebuf)$/;
   tool._cacheKeys.forEach((key, i) => {
-    const parts = key.split(':');
-    let label = '';
-    for (let idx = parts.length - 1; idx >= 0; idx--) {
-      const seg = parts[idx] ?? '';
-      if (!NON_LABEL.test(seg)) { label = seg; break; }
-    }
-    data[label || (parts[0] ?? key)] = results[i];
+    const label = tool._resultLabels?.[i] || deriveResultLabel(key);
+    data[label] = results[i];
   });
 
   return { cached_at, stale, data };

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -58,6 +58,11 @@ const SEED_DOMAINS = {
   'economic:worldbank-techreadiness': { key: 'seed-meta:economic:worldbank-techreadiness:v1', intervalMin: 5040 },
   'economic:worldbank-progress':      { key: 'seed-meta:economic:worldbank-progress:v1',     intervalMin: 5040 },
   'economic:worldbank-renewable':     { key: 'seed-meta:economic:worldbank-renewable:v1',    intervalMin: 5040 },
+  // Monthly IMF WEO seeds; aligned with health.js maxStaleMin=100800 (70d).
+  'economic:imf-macro':     { key: 'seed-meta:economic:imf-macro',     intervalMin: 50400 },
+  'economic:imf-growth':    { key: 'seed-meta:economic:imf-growth',    intervalMin: 50400 },
+  'economic:imf-labor':     { key: 'seed-meta:economic:imf-labor',     intervalMin: 50400 },
+  'economic:imf-external':  { key: 'seed-meta:economic:imf-external',  intervalMin: 50400 },
   'research:tech-events':    { key: 'seed-meta:research:tech-events',     intervalMin: 240 },
   'intelligence:gdelt-intel': { key: 'seed-meta:intelligence:gdelt-intel', intervalMin: 210 }, // 420min maxStaleMin / 2 — aligned with health.js (6h cron + 1h grace)
   'correlation:cards':        { key: 'seed-meta:correlation:cards',        intervalMin: 5 },

--- a/scripts/seed-bundle-imf-extended.mjs
+++ b/scripts/seed-bundle-imf-extended.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import { runBundle, DAY } from './_bundle-runner.mjs';
+
+await runBundle('imf-extended', [
+  { label: 'IMF-Macro', script: 'seed-imf-macro.mjs', seedMetaKey: 'economic:imf-macro', intervalMs: 30 * DAY, timeoutMs: 300_000 },
+  { label: 'IMF-Growth', script: 'seed-imf-growth.mjs', seedMetaKey: 'economic:imf-growth', intervalMs: 30 * DAY, timeoutMs: 300_000 },
+  { label: 'IMF-Labor', script: 'seed-imf-labor.mjs', seedMetaKey: 'economic:imf-labor', intervalMs: 30 * DAY, timeoutMs: 300_000 },
+  { label: 'IMF-External', script: 'seed-imf-external.mjs', seedMetaKey: 'economic:imf-external', intervalMs: 30 * DAY, timeoutMs: 300_000 },
+]);

--- a/scripts/seed-imf-external.mjs
+++ b/scripts/seed-imf-external.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY = 'economic:imf:external:v1';
+const CACHE_TTL = 35 * 24 * 3600; // 35 days — monthly IMF WEO release cadence
+
+const ISO2_TO_ISO3 = loadSharedConfig('iso2-to-iso3.json');
+const ISO3_TO_ISO2 = Object.fromEntries(Object.entries(ISO2_TO_ISO3).map(([k, v]) => [v, k]));
+
+const AGGREGATE_CODES = new Set([
+  'ADVEC', 'EMEDE', 'EURO', 'MECA', 'OEMDC', 'WEOWORLD', 'EU',
+  'AS5', 'DA', 'EDE', 'MAE', 'OAE', 'SSA', 'WE', 'EMDE', 'G20',
+]);
+
+function isAggregate(code) {
+  if (!code || code.length !== 3) return true;
+  return AGGREGATE_CODES.has(code) || code.endsWith('Q');
+}
+
+function weoYears() {
+  const y = new Date().getFullYear();
+  return [`${y}`, `${y - 1}`, `${y - 2}`];
+}
+
+function latestValue(byYear) {
+  for (const year of weoYears()) {
+    const v = Number(byYear?.[year]);
+    if (Number.isFinite(v)) return { value: v, year: Number(year) };
+  }
+  return null;
+}
+
+export function buildImfExternalCountries({
+  exportsData,
+  importsData,
+  currentAccountData,
+  importVolumeGrowthData,
+  exportVolumeGrowthData,
+}) {
+  const countries = {};
+  const allIso3 = new Set([
+    ...Object.keys(exportsData),
+    ...Object.keys(importsData),
+    ...Object.keys(currentAccountData),
+    ...Object.keys(importVolumeGrowthData),
+    ...Object.keys(exportVolumeGrowthData),
+  ]);
+
+  for (const iso3 of allIso3) {
+    if (isAggregate(iso3)) continue;
+    const iso2 = ISO3_TO_ISO2[iso3];
+    if (!iso2) continue;
+
+    const exportsUsd = latestValue(exportsData[iso3]);
+    const importsUsd = latestValue(importsData[iso3]);
+    const currentAccountUsd = latestValue(currentAccountData[iso3]);
+    const importVolumeGrowth = latestValue(importVolumeGrowthData[iso3]);
+    const exportVolumeGrowth = latestValue(exportVolumeGrowthData[iso3]);
+
+    if (!exportsUsd && !importsUsd && !currentAccountUsd && !importVolumeGrowth && !exportVolumeGrowth) continue;
+
+    countries[iso2] = {
+      exportsUsd: exportsUsd?.value ?? null,
+      importsUsd: importsUsd?.value ?? null,
+      currentAccountUsd: currentAccountUsd?.value ?? null,
+      importVolumeGrowthPct: importVolumeGrowth?.value ?? null,
+      exportVolumeGrowthPct: exportVolumeGrowth?.value ?? null,
+      tradeBalanceUsd:
+        exportsUsd?.value != null && importsUsd?.value != null
+          ? Number((exportsUsd.value - importsUsd.value).toFixed(2))
+          : null,
+      year:
+        exportsUsd?.year
+        ?? importsUsd?.year
+        ?? currentAccountUsd?.year
+        ?? importVolumeGrowth?.year
+        ?? exportVolumeGrowth?.year
+        ?? null,
+    };
+  }
+
+  return countries;
+}
+
+async function fetchImfExternal() {
+  const years = weoYears();
+  const [
+    exportsData,
+    importsData,
+    currentAccountData,
+    importVolumeGrowthData,
+    exportVolumeGrowthData,
+  ] = await Promise.all([
+    imfSdmxFetchIndicator('BX', { years }),
+    imfSdmxFetchIndicator('BM', { years }),
+    imfSdmxFetchIndicator('BCA', { years }),
+    imfSdmxFetchIndicator('TM_RPCH', { years }),
+    imfSdmxFetchIndicator('TX_RPCH', { years }),
+  ]);
+
+  const countries = buildImfExternalCountries({
+    exportsData,
+    importsData,
+    currentAccountData,
+    importVolumeGrowthData,
+    exportVolumeGrowthData,
+  });
+
+  return { countries, seededAt: new Date().toISOString() };
+}
+
+function validate(data) {
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
+}
+
+if (process.argv[1]?.endsWith('seed-imf-external.mjs')) {
+  runSeed('economic', 'imf-external', CANONICAL_KEY, fetchImfExternal, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: `imf-sdmx-weo-external-${new Date().getFullYear()}`,
+    recordCount: (data) => Object.keys(data?.countries ?? {}).length,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
+    console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-imf-growth.mjs
+++ b/scripts/seed-imf-growth.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY = 'economic:imf:growth:v1';
+const CACHE_TTL = 35 * 24 * 3600; // 35 days — monthly IMF WEO release cadence
+
+const ISO2_TO_ISO3 = loadSharedConfig('iso2-to-iso3.json');
+const ISO3_TO_ISO2 = Object.fromEntries(Object.entries(ISO2_TO_ISO3).map(([k, v]) => [v, k]));
+
+const AGGREGATE_CODES = new Set([
+  'ADVEC', 'EMEDE', 'EURO', 'MECA', 'OEMDC', 'WEOWORLD', 'EU',
+  'AS5', 'DA', 'EDE', 'MAE', 'OAE', 'SSA', 'WE', 'EMDE', 'G20',
+]);
+
+function isAggregate(code) {
+  if (!code || code.length !== 3) return true;
+  return AGGREGATE_CODES.has(code) || code.endsWith('Q');
+}
+
+function weoYears() {
+  const y = new Date().getFullYear();
+  return [`${y}`, `${y - 1}`, `${y - 2}`];
+}
+
+function latestValue(byYear) {
+  for (const year of weoYears()) {
+    const v = Number(byYear?.[year]);
+    if (Number.isFinite(v)) return { value: v, year: Number(year) };
+  }
+  return null;
+}
+
+export function buildImfGrowthCountries({
+  realGdpGrowthData,
+  nominalGdpPerCapitaData,
+  realGdpLocalData,
+  pppPerCapitaData,
+  pppGdpData,
+  investmentData,
+  savingsData,
+}) {
+  const countries = {};
+  const allIso3 = new Set([
+    ...Object.keys(realGdpGrowthData),
+    ...Object.keys(nominalGdpPerCapitaData),
+    ...Object.keys(realGdpLocalData),
+    ...Object.keys(pppPerCapitaData),
+    ...Object.keys(pppGdpData),
+    ...Object.keys(investmentData),
+    ...Object.keys(savingsData),
+  ]);
+
+  for (const iso3 of allIso3) {
+    if (isAggregate(iso3)) continue;
+    const iso2 = ISO3_TO_ISO2[iso3];
+    if (!iso2) continue;
+
+    const growth = latestValue(realGdpGrowthData[iso3]);
+    const gdpPerCapita = latestValue(nominalGdpPerCapitaData[iso3]);
+    const realGdpLocal = latestValue(realGdpLocalData[iso3]);
+    const pppPerCapita = latestValue(pppPerCapitaData[iso3]);
+    const pppGdp = latestValue(pppGdpData[iso3]);
+    const investment = latestValue(investmentData[iso3]);
+    const savings = latestValue(savingsData[iso3]);
+
+    if (!growth && !gdpPerCapita && !realGdpLocal && !pppPerCapita && !pppGdp && !investment && !savings) continue;
+
+    countries[iso2] = {
+      realGdpGrowthPct: growth?.value ?? null,
+      nominalGdpPerCapitaUsd: gdpPerCapita?.value ?? null,
+      realGdpLocal: realGdpLocal?.value ?? null,
+      pppGdpPerCapita: pppPerCapita?.value ?? null,
+      pppGdp: pppGdp?.value ?? null,
+      investmentPctGdp: investment?.value ?? null,
+      savingsPctGdp: savings?.value ?? null,
+      savingsInvestmentGapPctGdp:
+        savings?.value != null && investment?.value != null
+          ? Number((savings.value - investment.value).toFixed(2))
+          : null,
+      year:
+        growth?.year
+        ?? gdpPerCapita?.year
+        ?? realGdpLocal?.year
+        ?? pppPerCapita?.year
+        ?? pppGdp?.year
+        ?? investment?.year
+        ?? savings?.year
+        ?? null,
+    };
+  }
+
+  return countries;
+}
+
+async function fetchImfGrowth() {
+  const years = weoYears();
+  const [
+    realGdpGrowthData,
+    nominalGdpPerCapitaData,
+    realGdpLocalData,
+    pppPerCapitaData,
+    pppGdpData,
+    investmentData,
+    savingsData,
+  ] = await Promise.all([
+    imfSdmxFetchIndicator('NGDP_RPCH', { years }),
+    imfSdmxFetchIndicator('NGDPDPC', { years }),
+    imfSdmxFetchIndicator('NGDP_R', { years }),
+    imfSdmxFetchIndicator('PPPPC', { years }),
+    imfSdmxFetchIndicator('PPPGDP', { years }),
+    imfSdmxFetchIndicator('NID_NGDP', { years }),
+    imfSdmxFetchIndicator('NGSD_NGDP', { years }),
+  ]);
+
+  const countries = buildImfGrowthCountries({
+    realGdpGrowthData,
+    nominalGdpPerCapitaData,
+    realGdpLocalData,
+    pppPerCapitaData,
+    pppGdpData,
+    investmentData,
+    savingsData,
+  });
+
+  return { countries, seededAt: new Date().toISOString() };
+}
+
+function validate(data) {
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
+}
+
+if (process.argv[1]?.endsWith('seed-imf-growth.mjs')) {
+  runSeed('economic', 'imf-growth', CANONICAL_KEY, fetchImfGrowth, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: `imf-sdmx-weo-growth-${new Date().getFullYear()}`,
+    recordCount: (data) => Object.keys(data?.countries ?? {}).length,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
+    console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-imf-labor.mjs
+++ b/scripts/seed-imf-labor.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const CANONICAL_KEY = 'economic:imf:labor:v1';
+const CACHE_TTL = 35 * 24 * 3600; // 35 days — monthly IMF WEO release cadence
+
+const ISO2_TO_ISO3 = loadSharedConfig('iso2-to-iso3.json');
+const ISO3_TO_ISO2 = Object.fromEntries(Object.entries(ISO2_TO_ISO3).map(([k, v]) => [v, k]));
+
+const AGGREGATE_CODES = new Set([
+  'ADVEC', 'EMEDE', 'EURO', 'MECA', 'OEMDC', 'WEOWORLD', 'EU',
+  'AS5', 'DA', 'EDE', 'MAE', 'OAE', 'SSA', 'WE', 'EMDE', 'G20',
+]);
+
+function isAggregate(code) {
+  if (!code || code.length !== 3) return true;
+  return AGGREGATE_CODES.has(code) || code.endsWith('Q');
+}
+
+function weoYears() {
+  const y = new Date().getFullYear();
+  return [`${y}`, `${y - 1}`, `${y - 2}`];
+}
+
+function latestValue(byYear) {
+  for (const year of weoYears()) {
+    const v = Number(byYear?.[year]);
+    if (Number.isFinite(v)) return { value: v, year: Number(year) };
+  }
+  return null;
+}
+
+export function buildImfLaborCountries({ unemploymentData, populationData }) {
+  const countries = {};
+  const allIso3 = new Set([...Object.keys(unemploymentData), ...Object.keys(populationData)]);
+
+  for (const iso3 of allIso3) {
+    if (isAggregate(iso3)) continue;
+    const iso2 = ISO3_TO_ISO2[iso3];
+    if (!iso2) continue;
+
+    const unemployment = latestValue(unemploymentData[iso3]);
+    const population = latestValue(populationData[iso3]);
+    if (!unemployment && !population) continue;
+
+    countries[iso2] = {
+      unemploymentPct: unemployment?.value ?? null,
+      populationMillions: population?.value ?? null,
+      year: unemployment?.year ?? population?.year ?? null,
+    };
+  }
+
+  return countries;
+}
+
+async function fetchImfLabor() {
+  const years = weoYears();
+  const [unemploymentData, populationData] = await Promise.all([
+    imfSdmxFetchIndicator('LUR', { years }),
+    imfSdmxFetchIndicator('LP', { years }),
+  ]);
+
+  const countries = buildImfLaborCountries({ unemploymentData, populationData });
+  return { countries, seededAt: new Date().toISOString() };
+}
+
+function validate(data) {
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
+}
+
+if (process.argv[1]?.endsWith('seed-imf-labor.mjs')) {
+  runSeed('economic', 'imf-labor', CANONICAL_KEY, fetchImfLabor, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: `imf-sdmx-weo-labor-${new Date().getFullYear()}`,
+    recordCount: (data) => Object.keys(data?.countries ?? {}).length,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
+    console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-imf-macro.mjs
+++ b/scripts/seed-imf-macro.mjs
@@ -33,19 +33,24 @@ function latestValue(byYear) {
   return null;
 }
 
-async function fetchImfMacro() {
-  const years = weoYears();
-  const [inflationData, currentAccountData, govRevenueData] = await Promise.all([
-    imfSdmxFetchIndicator('PCPIPCH', { years }),
-    imfSdmxFetchIndicator('BCA_NGDPD', { years }),
-    imfSdmxFetchIndicator('GGR_NGDP', { years }),
-  ]);
-
+export function buildImfMacroCountries({
+  inflationData = {},
+  currentAccountData = {},
+  govRevenueData = {},
+  cpiIndexData = {},
+  cpiEndPeriodInflationData = {},
+  govExpenditureData = {},
+  primaryBalanceData = {},
+} = {}) {
   const countries = {};
   const allIso3 = new Set([
     ...Object.keys(inflationData),
     ...Object.keys(currentAccountData),
     ...Object.keys(govRevenueData),
+    ...Object.keys(cpiIndexData),
+    ...Object.keys(cpiEndPeriodInflationData),
+    ...Object.keys(govExpenditureData),
+    ...Object.keys(primaryBalanceData),
   ]);
 
   for (const iso3 of allIso3) {
@@ -56,16 +61,69 @@ async function fetchImfMacro() {
     const infl = latestValue(inflationData[iso3]);
     const ca   = latestValue(currentAccountData[iso3]);
     const rev  = latestValue(govRevenueData[iso3]);
-    if (!infl && !ca && !rev) continue;
+    const cpi  = latestValue(cpiIndexData[iso3]);
+    const cpiEpch = latestValue(cpiEndPeriodInflationData[iso3]);
+    const exp  = latestValue(govExpenditureData[iso3]);
+    const primaryBal = latestValue(primaryBalanceData[iso3]);
+    if (!infl && !ca && !rev && !cpi && !cpiEpch && !exp && !primaryBal) continue;
 
     countries[iso2] = {
       inflationPct:    infl?.value ?? null,
       currentAccountPct: ca?.value ?? null,
       govRevenuePct:   rev?.value  ?? null,
-      year: infl?.year ?? ca?.year ?? rev?.year ?? null,
+      cpiIndex: cpi?.value ?? null,
+      cpiEndPeriodInflationPct: cpiEpch?.value ?? null,
+      govExpenditurePct: exp?.value ?? null,
+      primaryBalancePct: primaryBal?.value ?? null,
+      year: infl?.year ?? ca?.year ?? rev?.year ?? cpi?.year ?? cpiEpch?.year ?? exp?.year ?? primaryBal?.year ?? null,
     };
   }
 
+  return countries;
+}
+
+async function fetchOptionalIndicator(indicator, years, fetchIndicator = imfSdmxFetchIndicator, warn = console.warn) {
+  try {
+    return await fetchIndicator(indicator, { years });
+  } catch (err) {
+    warn(`  Optional IMF macro indicator ${indicator} unavailable: ${err.message || err}`);
+    return {};
+  }
+}
+
+export async function fetchImfMacroCountries(fetchIndicator = imfSdmxFetchIndicator, warn = console.warn) {
+  const years = weoYears();
+  const [inflationData, currentAccountData, govRevenueData] = await Promise.all([
+    fetchIndicator('PCPIPCH', { years }),
+    fetchIndicator('BCA_NGDPD', { years }),
+    fetchIndicator('GGR_NGDP', { years }),
+  ]);
+
+  const [
+    cpiIndexData,
+    cpiEndPeriodInflationData,
+    govExpenditureData,
+    primaryBalanceData,
+  ] = await Promise.all([
+    fetchOptionalIndicator('PCPI', years, fetchIndicator, warn),
+    fetchOptionalIndicator('PCPIEPCH', years, fetchIndicator, warn),
+    fetchOptionalIndicator('GGX', years, fetchIndicator, warn),
+    fetchOptionalIndicator('GGXONLB_NGDP', years, fetchIndicator, warn),
+  ]);
+
+  return buildImfMacroCountries({
+    inflationData,
+    currentAccountData,
+    govRevenueData,
+    cpiIndexData,
+    cpiEndPeriodInflationData,
+    govExpenditureData,
+    primaryBalanceData,
+  });
+}
+
+async function fetchImfMacro() {
+  const countries = await fetchImfMacroCountries();
   return { countries, seededAt: new Date().toISOString() };
 }
 

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -126,6 +126,9 @@ export const BOOTSTRAP_CACHE_KEYS: Record<string, string> = {
   bisExchange:      'economic:bis:eer:v1',
   bisCredit:        'economic:bis:credit:v1',
   imfMacro:         'economic:imf:macro:v2',
+  imfGrowth:        'economic:imf:growth:v1',
+  imfLabor:         'economic:imf:labor:v1',
+  imfExternal:      'economic:imf:external:v1',
   shippingRates:    'supply_chain:shipping:v2',
   chokepoints:      'supply_chain:chokepoints:v4',
   minerals:         'supply_chain:minerals:v2',
@@ -212,7 +215,7 @@ export const PORTWATCH_PORT_ACTIVITY_KEY_PREFIX = 'supply_chain:portwatch-ports:
 export const PORTWATCH_PORT_ACTIVITY_COUNTRIES_KEY = 'supply_chain:portwatch-ports:v1:_countries';
 
 export const BOOTSTRAP_TIERS: Record<string, 'slow' | 'fast'> = {
-  bisPolicy: 'slow', bisExchange: 'slow', bisCredit: 'slow', imfMacro: 'slow',
+  bisPolicy: 'slow', bisExchange: 'slow', bisCredit: 'slow', imfMacro: 'slow', imfGrowth: 'slow', imfLabor: 'slow', imfExternal: 'slow',
   minerals: 'slow', giving: 'slow', sectors: 'slow',
   progressData: 'slow', renewableEnergy: 'slow',
   etfFlows: 'slow', shippingRates: 'fast', wildfires: 'slow',

--- a/server/worldmonitor/resilience/v1/_dimension-freshness.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-freshness.ts
@@ -66,6 +66,9 @@ const SOURCE_KEY_META_OVERRIDES: Readonly<Record<string, string>> = {
   // seed-imf-macro.mjs: runSeed('economic', 'imf-macro', ...) writes
   // seed-meta:economic:imf-macro (dash, not colon).
   'economic:imf:macro': 'economic:imf-macro',
+  // seed-imf-labor.mjs: runSeed('economic', 'imf-labor', ...) writes
+  // seed-meta:economic:imf-labor (dash, not colon).
+  'economic:imf:labor': 'economic:imf-labor',
   // seed-bis-data.mjs: runSeed('economic', 'bis', ...) writes
   // seed-meta:economic:bis (the sub-resource 'eer' is only in the data
   // key, not the meta key).

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -167,6 +167,12 @@ interface ImfMacroEntry {
   year?: number | null;
 }
 
+interface ImfLaborEntry {
+  unemploymentPct?: number | null;
+  populationMillions?: number | null;
+  year?: number | null;
+}
+
 interface BisExchangeRate {
   countryCode?: string;
   realEer?: number;
@@ -238,6 +244,7 @@ const RESILIENCE_TRANSIT_SUMMARIES_KEY = 'supply_chain:transit-summaries:v1';
 const RESILIENCE_BIS_EXCHANGE_KEY = 'economic:bis:eer:v1';
 const RESILIENCE_NATIONAL_DEBT_KEY = 'economic:national-debt:v1';
 const RESILIENCE_IMF_MACRO_KEY = 'economic:imf:macro:v2';
+const RESILIENCE_IMF_LABOR_KEY = 'economic:imf:labor:v1';
 const RESILIENCE_SANCTIONS_KEY = 'sanctions:country-counts:v1';
 const RESILIENCE_TRADE_RESTRICTIONS_KEY = 'trade:restrictions:v1:tariff-overview:50';
 const RESILIENCE_TRADE_BARRIERS_KEY = 'trade:barriers:v1:tariff-gap:50';
@@ -569,6 +576,12 @@ function getImfMacroEntry(raw: unknown, countryCode: string): ImfMacroEntry | nu
   return (countries[countryCode] as ImfMacroEntry | undefined) ?? null;
 }
 
+function getImfLaborEntry(raw: unknown, countryCode: string): ImfLaborEntry | null {
+  const countries = (raw as { countries?: Record<string, ImfLaborEntry> } | null)?.countries;
+  if (!countries || typeof countries !== 'object') return null;
+  return (countries[countryCode] as ImfLaborEntry | undefined) ?? null;
+}
+
 function getCountryBisExchangeRates(raw: unknown, countryCode: string): BisExchangeRate[] {
   const rates: BisExchangeRate[] = Array.isArray((raw as { rates?: unknown[] } | null)?.rates)
     ? ((raw as { rates?: BisExchangeRate[] }).rates ?? [])
@@ -771,12 +784,14 @@ export async function scoreMacroFiscal(
   countryCode: string,
   reader: ResilienceSeedReader = defaultSeedReader,
 ): Promise<ResilienceDimensionScore> {
-  const [debtRaw, imfMacroRaw] = await Promise.all([
+  const [debtRaw, imfMacroRaw, imfLaborRaw] = await Promise.all([
     reader(RESILIENCE_NATIONAL_DEBT_KEY),
     reader(RESILIENCE_IMF_MACRO_KEY),
+    reader(RESILIENCE_IMF_LABOR_KEY),
   ]);
   const debtEntry = getLatestDebtEntry(debtRaw, countryCode);
   const imfEntry = getImfMacroEntry(imfMacroRaw, countryCode);
+  const laborEntry = getImfLaborEntry(imfLaborRaw, countryCode);
 
   return weightedBlend([
     // Government revenue/GDP: fiscal capacity — how much the state can actually mobilise.
@@ -784,14 +799,18 @@ export async function scoreMacroFiscal(
     // states (Somalia 5% debt ≠ fiscal prudence; it reflects that no one will lend to them).
     // Anchor: 5% (Somalia, war-torn states) → 0, 45% (OECD median) → 100.
     imfMacroRaw == null
-      ? { score: null, weight: 0.5 }
-      : { score: imfEntry?.govRevenuePct == null ? null : normalizeHigherBetter(imfEntry.govRevenuePct, 5, 45), weight: 0.5 },
+      ? { score: null, weight: 0.4 }
+      : { score: imfEntry?.govRevenuePct == null ? null : normalizeHigherBetter(imfEntry.govRevenuePct, 5, 45), weight: 0.4 },
     // Debt growth rate: rapid debt accumulation = fiscal stress even at moderate levels.
     { score: extractMetric(debtEntry, (entry) => normalizeLowerBetter(Math.max(0, safeNum(entry.annualGrowth) ?? 0), 0, 20)), weight: 0.2 },
     // Current account balance: external position — deficit = more vulnerable to FX shocks.
     imfMacroRaw == null
-      ? { score: null, weight: 0.3 }
-      : { score: imfEntry?.currentAccountPct == null ? null : normalizeHigherBetter(Math.max(-20, Math.min(imfEntry.currentAccountPct, 20)), -20, 20), weight: 0.3 },
+      ? { score: null, weight: 0.25 }
+      : { score: imfEntry?.currentAccountPct == null ? null : normalizeHigherBetter(Math.max(-20, Math.min(imfEntry.currentAccountPct, 20)), -20, 20), weight: 0.25 },
+    // Labor-market pressure: persistent high unemployment weakens tax base and raises social transfer stress.
+    imfLaborRaw == null
+      ? { score: null, weight: 0.15 }
+      : { score: laborEntry?.unemploymentPct == null ? null : normalizeLowerBetter(Math.max(2, Math.min(laborEntry.unemploymentPct, 35)), 2, 35), weight: 0.15 },
   ]);
 }
 

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -35,14 +35,14 @@ export type IndicatorSpec = {
 };
 
 export const INDICATOR_REGISTRY: IndicatorSpec[] = [
-  // ── macroFiscal (3 sub-metrics) ───────────────────────────────────────────
+  // ── macroFiscal (4 sub-metrics) ───────────────────────────────────────────
   {
     id: 'govRevenuePct',
     dimension: 'macroFiscal',
     description: 'Government revenue as % of GDP (IMF GGR_G01_GDP_PT); fiscal capacity proxy',
     direction: 'higherBetter',
     goalposts: { worst: 5, best: 45 },
-    weight: 0.5,
+    weight: 0.4,
     sourceKey: 'economic:imf:macro:v2',
     scope: 'global',
     cadence: 'annual',
@@ -70,8 +70,22 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     description: 'Current account balance as % of GDP (IMF); external position vulnerability',
     direction: 'higherBetter',
     goalposts: { worst: -20, best: 20 },
-    weight: 0.3,
+    weight: 0.25,
     sourceKey: 'economic:imf:macro:v2',
+    scope: 'global',
+    cadence: 'annual',
+    tier: 'core',
+    coverage: 190,
+    license: 'open-data',
+  },
+  {
+    id: 'unemploymentPct',
+    dimension: 'macroFiscal',
+    description: 'Unemployment rate (IMF LUR); labor-market stress proxy for fiscal and social fragility',
+    direction: 'lowerBetter',
+    goalposts: { worst: 35, best: 2 },
+    weight: 0.15,
+    sourceKey: 'economic:imf:labor:v1',
     scope: 'global',
     cadence: 'annual',
     tier: 'core',

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -3,6 +3,7 @@ import { getRpcBaseUrl } from '@/services/rpc-client';
 import type { TimelineEvent } from '@/components/CountryTimeline';
 import { CountryTimeline } from '@/components/CountryTimeline';
 import type {
+  CountryFactsData,
   CountryDeepDiveEconomicIndicator,
   CountryDeepDiveMilitarySummary,
   CountryDeepDiveSignalDetails,
@@ -40,6 +41,7 @@ import { isHeadlineMemoryEnabled } from '@/services/ai-flow-settings';
 import { t, getCurrentLanguage } from '@/services/i18n';
 import { trackCountrySelected, trackCountryBriefOpened } from '@/services/analytics';
 import { toApiUrl } from '@/services/runtime';
+import { getHydratedData } from '@/services/bootstrap';
 import type { StrategicPosturePanel } from '@/components/StrategicPosturePanel';
 import type { NewsItem } from '@/types';
 import { getNearbyInfrastructure } from '@/services/related-assets';
@@ -64,11 +66,54 @@ type CountryStockSnapshot = {
   currency: string;
 };
 
+type ImfMacroCountryEntry = {
+  inflationPct?: number | null;
+  cpiEndPeriodInflationPct?: number | null;
+  year?: number | null;
+};
+
+type ImfGrowthCountryEntry = {
+  realGdpGrowthPct?: number | null;
+  nominalGdpPerCapitaUsd?: number | null;
+  pppGdpPerCapita?: number | null;
+  year?: number | null;
+};
+
+type ImfLaborCountryEntry = {
+  unemploymentPct?: number | null;
+  populationMillions?: number | null;
+  year?: number | null;
+};
+
+type ImfExternalCountryEntry = {
+  currentAccountUsd?: number | null;
+  exportsUsd?: number | null;
+  importsUsd?: number | null;
+  exportVolumeGrowthPct?: number | null;
+  importVolumeGrowthPct?: number | null;
+  year?: number | null;
+};
+
+type ImfCountrySnapshot = {
+  inflationPct: number | null;
+  realGdpGrowthPct: number | null;
+  unemploymentPct: number | null;
+  nominalGdpPerCapitaUsd: number | null;
+  pppGdpPerCapitaUsd: number | null;
+  populationMillions: number | null;
+  year: number | null;
+};
+
 export class CountryIntelManager implements AppModule {
   private ctx: AppContext;
   private briefRequestToken = 0;
   private frameworkUnsubscribe: (() => void) | null = null;
   private _fwDebounce: ReturnType<typeof setTimeout> | null = null;
+  private imfSeedLoadPromise: Promise<void> | null = null;
+  private imfMacroCountries: Record<string, ImfMacroCountryEntry> = {};
+  private imfGrowthCountries: Record<string, ImfGrowthCountryEntry> = {};
+  private imfLaborCountries: Record<string, ImfLaborCountryEntry> = {};
+  private imfExternalCountries: Record<string, ImfExternalCountryEntry> = {};
 
   constructor(ctx: AppContext) {
     this.ctx = ctx;
@@ -197,6 +242,15 @@ export class CountryIntelManager implements AppModule {
     }
 
     const signals = this.getCountrySignals(code, country);
+    let latestStock: CountryStockSnapshot | null = null;
+    let latestFacts: CountryFactsData | null = null;
+    const refreshImfEnrichment = () => {
+      if (this.ctx.countryBriefPage?.getCode() !== code) return;
+      this.ctx.countryBriefPage.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, latestStock));
+      if (latestFacts) {
+        this.ctx.countryBriefPage.updateCountryFacts?.(this.mergeCountryFactsWithImf(latestFacts, code));
+      }
+    };
 
     this.ctx.countryBriefPage.show(country, code, score, signals);
     this.ctx.map?.highlightCountry(code);
@@ -212,7 +266,12 @@ export class CountryIntelManager implements AppModule {
     }
     this.ctx.countryBriefPage.updateSignalDetails?.(this.buildSignalDetails(code));
     this.ctx.countryBriefPage.updateMilitaryActivity?.(this.buildMilitarySummary(code, country));
-    this.ctx.countryBriefPage.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, null));
+    this.ctx.countryBriefPage.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, latestStock));
+    void this.ensureImfSeedDataLoaded()
+      .then(() => {
+        refreshImfEnrichment();
+      })
+      .catch(() => {});
 
     const marketClient = new MarketServiceClient(getRpcBaseUrl(), { fetch: (...args: Parameters<typeof globalThis.fetch>) => globalThis.fetch(...args) });
     const stockPromise = marketClient.getCountryStockIndex({ countryCode: code })
@@ -229,8 +288,9 @@ export class CountryIntelManager implements AppModule {
 
     stockPromise.then((stock) => {
       if (this.ctx.countryBriefPage?.getCode() !== code) return;
+      latestStock = stock;
       this.ctx.countryBriefPage.updateStock(stock);
-      this.ctx.countryBriefPage.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, stock));
+      refreshImfEnrichment();
     });
 
     fetchCountryMarkets(country)
@@ -267,7 +327,7 @@ export class CountryIntelManager implements AppModule {
     intelClient.getCountryFacts({ countryCode: code })
       .then((facts) => {
         if (this.ctx.countryBriefPage?.getCode() !== code) return;
-        this.ctx.countryBriefPage.updateCountryFacts?.({
+        const baseFacts: CountryFactsData = {
           headOfState: facts.headOfState,
           headOfStateTitle: facts.headOfStateTitle,
           wikipediaSummary: facts.wikipediaSummary,
@@ -278,15 +338,19 @@ export class CountryIntelManager implements AppModule {
           currencies: facts.currencies,
           areaSqKm: facts.areaSqKm,
           countryName: facts.countryName,
-        });
+        };
+        latestFacts = baseFacts;
+        this.ctx.countryBriefPage.updateCountryFacts?.(this.mergeCountryFactsWithImf(baseFacts, code));
       })
       .catch(() => {
         if (this.ctx.countryBriefPage?.getCode() !== code) return;
-        this.ctx.countryBriefPage.updateCountryFacts?.({
+        const emptyFacts: CountryFactsData = {
           headOfState: '', headOfStateTitle: '', wikipediaSummary: '',
           wikipediaThumbnailUrl: '', population: 0, capital: '',
           languages: [], currencies: [], areaSqKm: 0, countryName: '',
-        });
+        };
+        latestFacts = emptyFacts;
+        this.ctx.countryBriefPage.updateCountryFacts?.(this.mergeCountryFactsWithImf(emptyFacts, code));
       });
 
     intelClient.getCountryEnergyProfile({ countryCode: code })
@@ -1130,25 +1194,143 @@ export class CountryIntelManager implements AppModule {
     };
   }
 
+  private toFiniteNumber(value: unknown): number | null {
+    const parsed = typeof value === 'number' ? value : Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  private extractImfCountries<T extends object>(raw: unknown): Record<string, T> | null {
+    const countries = (raw as { countries?: unknown } | null)?.countries;
+    if (!countries || typeof countries !== 'object') return null;
+    return countries as Record<string, T>;
+  }
+
+  private getMissingImfDatasetKeys(): string[] {
+    const missing: string[] = [];
+    if (Object.keys(this.imfMacroCountries).length === 0) missing.push('imfMacro');
+    if (Object.keys(this.imfGrowthCountries).length === 0) missing.push('imfGrowth');
+    if (Object.keys(this.imfLaborCountries).length === 0) missing.push('imfLabor');
+    if (Object.keys(this.imfExternalCountries).length === 0) missing.push('imfExternal');
+    return missing;
+  }
+
+  private async loadImfSeedData(): Promise<void> {
+    const hydratedMacro = this.extractImfCountries<ImfMacroCountryEntry>(getHydratedData('imfMacro'));
+    const hydratedGrowth = this.extractImfCountries<ImfGrowthCountryEntry>(getHydratedData('imfGrowth'));
+    const hydratedLabor = this.extractImfCountries<ImfLaborCountryEntry>(getHydratedData('imfLabor'));
+    const hydratedExternal = this.extractImfCountries<ImfExternalCountryEntry>(getHydratedData('imfExternal'));
+
+    if (hydratedMacro) this.imfMacroCountries = hydratedMacro;
+    if (hydratedGrowth) this.imfGrowthCountries = hydratedGrowth;
+    if (hydratedLabor) this.imfLaborCountries = hydratedLabor;
+    if (hydratedExternal) this.imfExternalCountries = hydratedExternal;
+
+    const missing = this.getMissingImfDatasetKeys();
+    if (missing.length === 0) return;
+
+    try {
+      const params = new URLSearchParams({ keys: missing.join(',') });
+      const resp = await fetch(toApiUrl(`/api/bootstrap?${params.toString()}`), {
+        signal: AbortSignal.timeout(8_000),
+      });
+      if (!resp.ok) return;
+      const json = await resp.json() as { data?: Record<string, unknown> };
+      const data = json?.data ?? {};
+
+      const fallbackMacro = this.extractImfCountries<ImfMacroCountryEntry>(data.imfMacro);
+      const fallbackGrowth = this.extractImfCountries<ImfGrowthCountryEntry>(data.imfGrowth);
+      const fallbackLabor = this.extractImfCountries<ImfLaborCountryEntry>(data.imfLabor);
+      const fallbackExternal = this.extractImfCountries<ImfExternalCountryEntry>(data.imfExternal);
+
+      if (fallbackMacro) this.imfMacroCountries = fallbackMacro;
+      if (fallbackGrowth) this.imfGrowthCountries = fallbackGrowth;
+      if (fallbackLabor) this.imfLaborCountries = fallbackLabor;
+      if (fallbackExternal) this.imfExternalCountries = fallbackExternal;
+    } catch {
+      // Non-blocking enrichment path.
+    }
+  }
+
+  private async ensureImfSeedDataLoaded(): Promise<void> {
+    if (!this.imfSeedLoadPromise) {
+      this.imfSeedLoadPromise = this.loadImfSeedData().finally(() => {
+        if (this.getMissingImfDatasetKeys().length > 0) {
+          this.imfSeedLoadPromise = null;
+        }
+      });
+    }
+    await this.imfSeedLoadPromise;
+  }
+
+  private getImfCountrySnapshot(countryCode: string): ImfCountrySnapshot {
+    const code = countryCode.toUpperCase();
+    const macro = this.imfMacroCountries[code];
+    const growth = this.imfGrowthCountries[code];
+    const labor = this.imfLaborCountries[code];
+    const external = this.imfExternalCountries[code];
+
+    const inflationPct =
+      this.toFiniteNumber(macro?.inflationPct)
+      ?? this.toFiniteNumber(macro?.cpiEndPeriodInflationPct);
+
+    const years = [
+      this.toFiniteNumber(macro?.year),
+      this.toFiniteNumber(growth?.year),
+      this.toFiniteNumber(labor?.year),
+      this.toFiniteNumber(external?.year),
+    ].filter((year): year is number => year != null);
+
+    return {
+      inflationPct,
+      realGdpGrowthPct: this.toFiniteNumber(growth?.realGdpGrowthPct),
+      unemploymentPct: this.toFiniteNumber(labor?.unemploymentPct),
+      nominalGdpPerCapitaUsd: this.toFiniteNumber(growth?.nominalGdpPerCapitaUsd),
+      pppGdpPerCapitaUsd: this.toFiniteNumber(growth?.pppGdpPerCapita),
+      populationMillions: this.toFiniteNumber(labor?.populationMillions),
+      year: years.length ? Math.max(...years) : null,
+    };
+  }
+
+  private mergeCountryFactsWithImf(baseFacts: CountryFactsData, countryCode: string): CountryFactsData {
+    const snapshot = this.getImfCountrySnapshot(countryCode);
+    const mergedPopulation = baseFacts.population > 0
+      ? baseFacts.population
+      : snapshot.populationMillions != null
+        ? Math.round(snapshot.populationMillions * 1_000_000)
+        : 0;
+
+    return {
+      ...baseFacts,
+      population: mergedPopulation,
+      nominalGdpPerCapitaUsd: snapshot.nominalGdpPerCapitaUsd,
+      pppGdpPerCapitaUsd: snapshot.pppGdpPerCapitaUsd,
+      imfPopulationMillions: snapshot.populationMillions,
+      imfDataYear: snapshot.year,
+    };
+  }
+
   private buildEconomicIndicators(
     code: string,
     score: CountryScore | null,
     stock: CountryStockSnapshot | null,
   ): CountryDeepDiveEconomicIndicator[] {
-    const indicators: CountryDeepDiveEconomicIndicator[] = [];
+    const imf = this.getImfCountrySnapshot(code);
+    const imfSource = imf.year ? `IMF WEO ${imf.year}` : 'IMF WEO';
+    const primaryIndicators: CountryDeepDiveEconomicIndicator[] = [];
+    const contextualIndicators: CountryDeepDiveEconomicIndicator[] = [];
 
     if (stock?.available) {
       const weekly = Number.parseFloat(stock.weekChangePercent);
       const weeklyTrend = Number.isFinite(weekly)
         ? weekly > 0 ? 'up' : weekly < 0 ? 'down' : 'flat'
         : 'flat';
-      indicators.push({
+      primaryIndicators.push({
         label: 'Stock Index',
         value: `${stock.indexName}: ${stock.price} ${stock.currency}`,
         trend: weeklyTrend,
         source: 'Market Service',
       });
-      indicators.push({
+      contextualIndicators.push({
         label: 'Weekly Momentum',
         value: `${weekly >= 0 ? '+' : ''}${stock.weekChangePercent}%`,
         trend: weeklyTrend,
@@ -1161,11 +1343,38 @@ export class CountryIntelManager implements AppModule {
         : score.trend === 'falling'
           ? 'down'
           : 'flat';
-      indicators.push({
+      primaryIndicators.push({
         label: 'Instability Regime',
         value: `${score.score}/100 (${score.level})`,
         trend,
         source: 'CII',
+      });
+    }
+
+    if (imf.realGdpGrowthPct != null) {
+      contextualIndicators.push({
+        label: 'GDP Growth',
+        value: `${imf.realGdpGrowthPct.toFixed(1)}%`,
+        trend: imf.realGdpGrowthPct > 1 ? 'up' : imf.realGdpGrowthPct < 0 ? 'down' : 'flat',
+        source: imfSource,
+      });
+    }
+
+    if (imf.unemploymentPct != null) {
+      contextualIndicators.push({
+        label: 'Unemployment',
+        value: `${imf.unemploymentPct.toFixed(1)}%`,
+        trend: imf.unemploymentPct <= 5 ? 'up' : imf.unemploymentPct >= 10 ? 'down' : 'flat',
+        source: imfSource,
+      });
+    }
+
+    if (imf.inflationPct != null) {
+      contextualIndicators.push({
+        label: 'Inflation',
+        value: `${imf.inflationPct.toFixed(1)}%`,
+        trend: imf.inflationPct <= 4 ? 'up' : imf.inflationPct >= 8 ? 'down' : 'flat',
+        source: imfSource,
       });
     }
 
@@ -1174,7 +1383,7 @@ export class CountryIntelManager implements AppModule {
       const displaced = countryData.displacementOutflow >= 1_000_000
         ? `${(countryData.displacementOutflow / 1_000_000).toFixed(1)}M`
         : `${Math.round(countryData.displacementOutflow / 1000)}K`;
-      indicators.push({
+      contextualIndicators.push({
         label: 'Displacement Outflow',
         value: displaced,
         trend: 'up',
@@ -1182,7 +1391,7 @@ export class CountryIntelManager implements AppModule {
       });
     }
 
-    return indicators.slice(0, 3);
+    return [...primaryIndicators, ...contextualIndicators].slice(0, 3);
   }
 
   private sameCountry(code: string, country: string, raw: string | undefined): boolean {

--- a/src/components/CountryBriefPanel.ts
+++ b/src/components/CountryBriefPanel.ts
@@ -78,6 +78,10 @@ export interface CountryFactsData {
   currencies: string[];
   areaSqKm: number;
   countryName: string;
+  nominalGdpPerCapitaUsd?: number | null;
+  pppGdpPerCapitaUsd?: number | null;
+  imfPopulationMillions?: number | null;
+  imfDataYear?: number | null;
 }
 
 export interface CountryEnergyProfileData {

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -506,7 +506,20 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     if (!this.factsBody) return;
     this.factsBody.replaceChildren();
 
-    if (!data.headOfState && !data.wikipediaSummary && data.population === 0 && !data.capital) {
+    const resolvedPopulation = data.population > 0
+      ? data.population
+      : data.imfPopulationMillions != null
+        ? Math.round(data.imfPopulationMillions * 1_000_000)
+        : 0;
+
+    if (
+      !data.headOfState
+      && !data.wikipediaSummary
+      && resolvedPopulation === 0
+      && !data.capital
+      && data.nominalGdpPerCapitaUsd == null
+      && data.pppGdpPerCapitaUsd == null
+    ) {
       this.factsBody.append(this.makeEmpty(t('countryBrief.noFacts')));
       return;
     }
@@ -528,20 +541,34 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
 
     const grid = this.el('div', 'cdp-facts-grid');
 
-    const popStr = data.population >= 1_000_000_000
-      ? `${(data.population / 1_000_000_000).toFixed(1)}B`
-      : data.population >= 1_000_000
-        ? `${(data.population / 1_000_000).toFixed(1)}M`
-        : data.population.toLocaleString();
+    const popStr = resolvedPopulation >= 1_000_000_000
+      ? `${(resolvedPopulation / 1_000_000_000).toFixed(1)}B`
+      : resolvedPopulation >= 1_000_000
+        ? `${(resolvedPopulation / 1_000_000).toFixed(1)}M`
+        : resolvedPopulation > 0
+          ? resolvedPopulation.toLocaleString()
+          : '—';
     grid.append(this.factItem(t('countryBrief.facts.population'), popStr));
     grid.append(this.factItem(t('countryBrief.facts.capital'), data.capital));
-    grid.append(this.factItem(t('countryBrief.facts.area'), `${data.areaSqKm.toLocaleString()} km\u00B2`));
+    grid.append(this.factItem(t('countryBrief.facts.area'), data.areaSqKm > 0 ? `${data.areaSqKm.toLocaleString()} km\u00B2` : '—'));
 
     const rawTitle = data.headOfStateTitle || '';
     const hosLabel = rawTitle.length > 30 ? t('countryBrief.facts.headOfState') : (rawTitle || t('countryBrief.facts.headOfState'));
     grid.append(this.factItem(hosLabel, data.headOfState));
     grid.append(this.factItem(t('countryBrief.facts.languages'), data.languages.join(', ')));
     grid.append(this.factItem(t('countryBrief.facts.currencies'), data.currencies.join(', ')));
+    if (data.nominalGdpPerCapitaUsd != null) {
+      grid.append(this.factItem('GDP / Capita (Nominal)', this.formatMoney(data.nominalGdpPerCapitaUsd)));
+    }
+    if (data.pppGdpPerCapitaUsd != null) {
+      grid.append(this.factItem('GDP / Capita (PPP)', this.formatMoney(data.pppGdpPerCapitaUsd)));
+    }
+    if (data.imfPopulationMillions != null) {
+      grid.append(this.factItem('Population (IMF)', `${data.imfPopulationMillions.toFixed(1)}M`));
+    }
+    if (data.imfDataYear != null) {
+      grid.append(this.factItem('IMF Data Year', String(Math.round(data.imfDataYear))));
+    }
 
     this.factsBody.append(grid);
   }

--- a/tests/helpers/resilience-fixtures.mts
+++ b/tests/helpers/resilience-fixtures.mts
@@ -177,6 +177,13 @@ export const RESILIENCE_FIXTURES: FixtureMap = {
       YE: { inflationPct: 22.0, currentAccountPct: -6.0, govRevenuePct: 8.0, year: 2024 },
     },
   },
+  'economic:imf:labor:v1': {
+    countries: {
+      NO: { unemploymentPct: 3.8, populationMillions: 5.6, year: 2024 },
+      US: { unemploymentPct: 4.2, populationMillions: 341.8, year: 2024 },
+      YE: { unemploymentPct: 17.5, populationMillions: 34.1, year: 2024 },
+    },
+  },
   'economic:bis:eer:v1': {
     rates: [
       { countryCode: 'NO', realChange: 1.0, realEer: 100, date: '2025-08' },

--- a/tests/mcp-seed-coverage.test.mjs
+++ b/tests/mcp-seed-coverage.test.mjs
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { TOOL_REGISTRY } from '../api/mcp.ts';
+
+const repoRoot = fileURLToPath(new URL('../', import.meta.url));
+
+function listTrackedSeedScripts() {
+  return execFileSync('git', ['ls-files', 'scripts'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+    .split('\n')
+    .filter(Boolean)
+    .filter((file) => /^scripts\/seed-.*\.mjs$/.test(file));
+}
+
+function readCanonicalKey(file) {
+  const src = fs.readFileSync(path.join(repoRoot, file), 'utf8');
+  const match = src.match(/(?:export\s+)?const\s+CANONICAL_KEY\s*=\s*'([^']+)'/);
+  return match?.[1] ?? null;
+}
+
+describe('MCP seed coverage', () => {
+  it('references every tracked seed script canonical key from the MCP cache tool registry', () => {
+    const cacheKeys = new Set(
+      TOOL_REGISTRY
+        .filter((tool) => Array.isArray(tool._cacheKeys))
+        .flatMap((tool) => tool._cacheKeys),
+    );
+
+    const missing = [];
+    for (const file of listTrackedSeedScripts()) {
+      const canonicalKey = readCanonicalKey(file);
+      if (canonicalKey && !cacheKeys.has(canonicalKey)) {
+        missing.push({ file, canonicalKey });
+      }
+    }
+
+    assert.deepEqual(
+      missing,
+      [],
+      `Tracked seed scripts missing MCP exposure:\n${missing.map(({ file, canonicalKey }) => `${file} -> ${canonicalKey}`).join('\n')}`,
+    );
+  });
+});

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -6,6 +6,53 @@ const originalEnv = { ...process.env };
 
 const VALID_KEY = 'wm_test_key_123';
 const BASE_URL = 'https://api.worldmonitor.app/mcp';
+const EXPECTED_GAP_KEYS = [
+  'economic:imf:macro:v2',
+  'economic:national-debt:v1',
+  'economic:bigmac:v1',
+  'economic:grocery-basket:v1',
+  'economic:fao-ffpi:v1',
+  'economic:eurostat-country-data:v1',
+  'resilience:recovery:fiscal-space:v1',
+  'resilience:recovery:reserve-adequacy:v1',
+  'resilience:recovery:external-debt:v1',
+  'resilience:recovery:import-hhi:v1',
+  'resilience:recovery:fuel-stocks:v1',
+  'economic:eu-gas-storage:v1',
+  'energy:chokepoint-baselines:v1',
+  'energy:chokepoint-flows:v1',
+  'energy:crisis-policies:v1',
+  'energy:iea-oil-stocks:v1:index',
+  'energy:intelligence:feed:v1',
+  'energy:jodi-gas:v1:_countries',
+  'energy:jodi-oil:v1:_countries',
+  'energy:spr-policies:v1',
+  'supply_chain:hormuz_tracker:v1',
+  'supply_chain:portwatch-ports:v1:_countries',
+  'supply_chain:portwatch:v1',
+  'portwatch:chokepoints:ref:v1',
+  'portwatch:disruptions:active:v1',
+  'market:crypto-sectors:v1',
+  'market:stablecoins:v1',
+  'shared:fx-rates:v1',
+  'health:disease-outbreaks:v1',
+  'health:vpd-tracker:realtime:v1',
+  'cyber:threats:v2',
+  'patents:defense:latest',
+  'infra:service-statuses:v1',
+  'infrastructure:submarine-cables:v1',
+  'regulatory:actions:v1',
+  'bls:series:v1',
+  'correlation:cards-bootstrap:v1',
+  'intelligence:advisories:v1',
+  'thermal:escalation:v1',
+];
+const EXPECTED_NEW_TOOL_NAMES = [
+  'get_resilience_recovery_data',
+  'get_energy_security_data',
+  'get_public_health_data',
+  'get_cross_domain_signals',
+];
 
 function makeReq(method = 'POST', body = null, headers = {}) {
   return new Request(BASE_URL, {
@@ -29,6 +76,7 @@ function initBody(id = 1) {
 
 let handler;
 let evaluateFreshness;
+let toolRegistry;
 
 describe('api/mcp.ts — PRO MCP Server', () => {
   beforeEach(async () => {
@@ -40,6 +88,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const mod = await import(`../api/mcp.ts?t=${Date.now()}`);
     handler = mod.default;
     evaluateFreshness = mod.evaluateFreshness;
+    toolRegistry = mod.TOOL_REGISTRY;
   });
 
   afterEach(() => {
@@ -118,18 +167,21 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
   // --- tools/list ---
 
-  it('tools/list returns 28 tools with name, description, inputSchema', async () => {
+  it('tools/list returns the full registry with the expanded MCP cache surface', async () => {
     const res = await handler(makeReq('POST', { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.result?.tools), 'result.tools must be an array');
-    assert.equal(body.result.tools.length, 28, `Expected 28 tools, got ${body.result.tools.length}`);
+    assert.equal(body.result.tools.length, toolRegistry.length, `Expected ${toolRegistry.length} tools, got ${body.result.tools.length}`);
     for (const tool of body.result.tools) {
       assert.ok(tool.name, 'tool.name must be present');
       assert.ok(tool.description, 'tool.description must be present');
       assert.ok(tool.inputSchema, 'tool.inputSchema must be present');
       assert.ok(!('_cacheKeys' in tool), 'Internal _cacheKeys must not be exposed in tools/list');
       assert.ok(!('_execute' in tool), 'Internal _execute must not be exposed in tools/list');
+    }
+    for (const name of EXPECTED_NEW_TOOL_NAMES) {
+      assert.ok(body.result.tools.some((tool) => tool.name === name), `tools/list must include ${name}`);
     }
   });
 
@@ -160,6 +212,42 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(data.cached_at, null, 'cached_at must be null when no seed-meta');
     assert.ok('data' in data, 'data field must be present');
   });
+
+  it('cache tool registry covers every canonical seed key that was missing from MCP', () => {
+    const cacheKeys = new Set(
+      toolRegistry
+        .filter((tool) => Array.isArray(tool._cacheKeys))
+        .flatMap((tool) => tool._cacheKeys),
+    );
+
+    const uncovered = EXPECTED_GAP_KEYS.filter((key) => !cacheKeys.has(key));
+    assert.deepEqual(uncovered, []);
+  });
+
+  for (const [toolName, expectedLabels] of Object.entries({
+    get_resilience_recovery_data: ['fiscal-space', 'reserve-adequacy', 'external-debt', 'import-hhi', 'fuel-stocks'],
+    get_energy_security_data: ['chokepoint-baselines', 'chokepoint-flows', 'crisis-policies', 'iea-oil-stocks', 'energy-intelligence', 'jodi-gas', 'jodi-oil', 'spr-policies'],
+    get_supply_chain_data: ['shipping-stress', 'customs-revenue', 'comtrade-flows', 'hormuz-tracker', 'portwatch-ports', 'portwatch', 'portwatch-chokepoints', 'portwatch-disruptions'],
+    get_public_health_data: ['disease-outbreaks', 'vpd-tracker'],
+    get_research_signals: ['tech-events-bootstrap', 'defense-patents'],
+    get_cyber_threats: ['threats-bootstrap', 'threats'],
+    get_infrastructure_status: ['outages', 'service-statuses', 'submarine-cables'],
+    get_cross_domain_signals: ['correlation-cards', 'thermal-escalation', 'regulatory-actions'],
+  })) {
+    it(`${toolName} returns the expected labeled payload shape when cache is empty`, async () => {
+      const res = await handler(makeReq('POST', {
+        jsonrpc: '2.0',
+        id: `${toolName}-shape`,
+        method: 'tools/call',
+        params: { name: toolName, arguments: {} },
+      }));
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      const data = JSON.parse(body.result.content[0].text);
+      assert.equal(data.stale, true);
+      assert.deepEqual(Object.keys(data.data).sort(), expectedLabels.slice().sort());
+    });
+  }
 
   it('evaluateFreshness marks bundled data stale when any required source meta is missing', () => {
     const now = Date.UTC(2026, 3, 1, 12, 0, 0);

--- a/tests/resilience-country-brief.test.mjs
+++ b/tests/resilience-country-brief.test.mjs
@@ -92,3 +92,54 @@ test('country deep-dive panel destroys each resilience widget exactly once acros
     harness.cleanup();
   }
 });
+
+test('country deep-dive panel renders IMF-populated economic indicators and country facts fields', async () => {
+  const harness = await createCountryDeepDivePanelHarness();
+  try {
+    const panel = harness.createPanel();
+    panel.show('United States', 'US', sampleScore, emptySignals);
+
+    panel.updateEconomicIndicators([
+      { label: 'GDP Growth', value: '2.4%', trend: 'up', source: 'IMF WEO 2025' },
+      { label: 'Unemployment', value: '4.1%', trend: 'up', source: 'IMF WEO 2025' },
+      { label: 'Inflation', value: '3.2%', trend: 'up', source: 'IMF WEO 2025' },
+    ]);
+
+    panel.updateCountryFacts({
+      headOfState: 'President',
+      headOfStateTitle: 'Head of State',
+      wikipediaSummary: 'United States overview.',
+      wikipediaThumbnailUrl: '',
+      population: 334_000_000,
+      capital: 'Washington, D.C.',
+      languages: ['English'],
+      currencies: ['USD'],
+      areaSqKm: 9_833_520,
+      countryName: 'United States',
+      nominalGdpPerCapitaUsd: 54_321,
+      pppGdpPerCapitaUsd: 65_800,
+      imfPopulationMillions: 334.2,
+      imfDataYear: 2025,
+    });
+
+    const root = harness.getPanelRoot();
+    assert.ok(root, 'expected panel root to be created');
+
+    const economicLabels = Array.from(root.querySelectorAll('.cdp-economic-item'))
+      .map((item) => item.querySelector('.cdp-economic-label')?.textContent?.trim())
+      .filter(Boolean);
+    assert.deepEqual(economicLabels, ['GDP Growth', 'Unemployment', 'Inflation']);
+
+    const factsText = root.querySelector('.cdp-facts-grid')?.textContent ?? '';
+    assert.match(factsText, /GDP \/ Capita \(Nominal\)/);
+    assert.match(factsText, /\$54\.3K/);
+    assert.match(factsText, /GDP \/ Capita \(PPP\)/);
+    assert.match(factsText, /\$65\.8K/);
+    assert.match(factsText, /Population \(IMF\)/);
+    assert.match(factsText, /334\.2M/);
+    assert.match(factsText, /IMF Data Year/);
+    assert.match(factsText, /2025/);
+  } finally {
+    harness.cleanup();
+  }
+});

--- a/tests/resilience-dimension-freshness.test.mts
+++ b/tests/resilience-dimension-freshness.test.mts
@@ -51,8 +51,8 @@ function buildAllFreshMap(dimensionId: ResilienceDimensionId): Map<string, numbe
 
 describe('classifyDimensionFreshness (T1.5 propagation pass)', () => {
   it('all indicators fresh returns fresh and the oldest fetchedAt', () => {
-    // macroFiscal has three indicators; two share a sourceKey but the map
-    // is keyed by sourceKey so duplicates collapse to one entry.
+    // macroFiscal has four indicators; two share a sourceKey. The map is
+    // keyed by sourceKey so duplicates collapse to one entry.
     const map = buildAllFreshMap('macroFiscal');
     const result = classifyDimensionFreshness('macroFiscal', map, NOW);
     assert.equal(result.staleness, 'fresh');
@@ -354,6 +354,7 @@ describe('resolveSeedMetaKey (T1.5 propagation pass, P1 fix)', () => {
   it('applies SOURCE_KEY_META_OVERRIDES for the drift cases', () => {
     // Overrides for sourceKeys that still diverge after strip.
     assert.equal(resolveSeedMetaKey('economic:imf:macro:v2'), 'seed-meta:economic:imf-macro');
+    assert.equal(resolveSeedMetaKey('economic:imf:labor:v1'), 'seed-meta:economic:imf-labor');
     assert.equal(resolveSeedMetaKey('economic:bis:eer:v1'), 'seed-meta:economic:bis');
     assert.equal(resolveSeedMetaKey('economic:energy:v1:all'), 'seed-meta:economic:energy-prices');
     assert.equal(resolveSeedMetaKey('energy:mix:v1:{ISO2}'), 'seed-meta:economic:owid-energy-mix');

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -326,6 +326,7 @@ describe('resilience dimension scorers', () => {
     const makeReader = (caPct: number) => async (key: string): Promise<unknown | null> => {
       if (key === 'economic:national-debt:v1') return { entries: [{ iso3: 'HRV', debtToGdp: 70, annualGrowth: 1.5 }] };
       if (key === 'economic:imf:macro:v2') return { countries: { HR: { inflationPct: 3.0, currentAccountPct: caPct, govRevenuePct: 40, year: 2024 } } };
+      if (key === 'economic:imf:labor:v1') return { countries: { HR: { unemploymentPct: 4.2, year: 2024 } } };
       return null;
     };
     const surplus = await scoreMacroFiscal('HR', makeReader(10));
@@ -337,10 +338,11 @@ describe('resilience dimension scorers', () => {
   it('scoreMacroFiscal: IMF macro seed outage does not impute — debt growth still scores', async () => {
     const reader = async (key: string): Promise<unknown | null> => {
       if (key === 'economic:national-debt:v1') return { entries: [{ iso3: 'HRV', debtToGdp: 70, annualGrowth: 1.5 }] };
-      return null; // economic:imf:macro:v1 null = seed outage
+      return null; // economic:imf:macro + economic:imf:labor null = seed outage
     };
     const score = await scoreMacroFiscal('HR', reader);
-    // govRevenuePct (0.5) and currentAccountPct (0.3) come from IMF macro (null = outage).
+    // govRevenuePct (0.4), currentAccountPct (0.25), and unemploymentPct (0.15)
+    // come from IMF seeds (null = outage).
     // Only debtGrowth (weight=0.2) has real data → coverage = 0.2.
     assert.ok(score.coverage > 0.15 && score.coverage < 0.25,
       `coverage should be ~0.2 (debt growth only, IMF outage), got ${score.coverage}`);

--- a/tests/resilience-scorers.test.mts
+++ b/tests/resilience-scorers.test.mts
@@ -93,7 +93,7 @@ describe('resilience scorer contracts', () => {
     }));
 
     assert.deepEqual(domainAverages, {
-      economic: 66.33,
+      economic: 67.67,
       infrastructure: 79,
       energy: 80,
       'social-governance': 61.75,
@@ -126,7 +126,7 @@ describe('resilience scorer contracts', () => {
     const stressScore = round(coverageWeightedMean(stressDims));
     const stressFactor = round(Math.max(0, Math.min(1 - stressScore / 100, 0.5)), 4);
 
-    assert.equal(baselineScore, 62.23);
+    assert.equal(baselineScore, 62.52);
     assert.equal(stressScore, 65.84);
     assert.equal(stressFactor, 0.3416);
 
@@ -140,7 +140,7 @@ describe('resilience scorer contracts', () => {
         return round(cwMean) * getResilienceDomainWeight(domainId);
       }).reduce((sum, v) => sum + v, 0),
     );
-    assert.equal(overallScore, 65.23);
+    assert.equal(overallScore, 65.46);
   });
 
   it('baselineScore is computed from baseline + mixed dimensions only', async () => {
@@ -211,7 +211,7 @@ describe('resilience scorer contracts', () => {
     );
 
     assert.ok(expected > 0, 'overall should be positive');
-    assert.equal(expected, 65.23, 'overallScore should match sum(domainScore * domainWeight)');
+    assert.equal(expected, 65.46, 'overallScore should match sum(domainScore * domainWeight)');
   });
 
   it('stressFactor is still computed (informational) and clamped to [0, 0.5]', () => {

--- a/tests/seed-bundle-imf-extended.test.mjs
+++ b/tests/seed-bundle-imf-extended.test.mjs
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const scriptsDir = join(__dirname, '..', 'scripts');
+
+const bundleSource = readFileSync(join(scriptsDir, 'seed-bundle-imf-extended.mjs'), 'utf8');
+
+const EXPECTED_ENTRIES = [
+  { label: 'IMF-Macro', script: 'seed-imf-macro.mjs', seedMetaKey: 'economic:imf-macro' },
+  { label: 'IMF-Growth', script: 'seed-imf-growth.mjs', seedMetaKey: 'economic:imf-growth' },
+  { label: 'IMF-Labor', script: 'seed-imf-labor.mjs', seedMetaKey: 'economic:imf-labor' },
+  { label: 'IMF-External', script: 'seed-imf-external.mjs', seedMetaKey: 'economic:imf-external' },
+];
+
+describe('seed-bundle-imf-extended', () => {
+  it('contains all IMF extended seeder entries', () => {
+    for (const entry of EXPECTED_ENTRIES) {
+      assert.ok(bundleSource.includes(entry.label), `Missing label: ${entry.label}`);
+      assert.ok(bundleSource.includes(entry.script), `Missing script: ${entry.script}`);
+      assert.ok(bundleSource.includes(entry.seedMetaKey), `Missing seedMetaKey: ${entry.seedMetaKey}`);
+    }
+  });
+
+  it('all referenced scripts exist on disk', () => {
+    for (const entry of EXPECTED_ENTRIES) {
+      assert.ok(existsSync(join(scriptsDir, entry.script)), `Missing script file: ${entry.script}`);
+    }
+  });
+
+  it('uses 30 * DAY cadence for all entries', () => {
+    const intervalMatches = bundleSource.match(/intervalMs:\s*30\s*\*\s*DAY/g) ?? [];
+    assert.equal(intervalMatches.length, EXPECTED_ENTRIES.length);
+  });
+});

--- a/tests/seed-imf-external.test.mjs
+++ b/tests/seed-imf-external.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildImfExternalCountries } from '../scripts/seed-imf-external.mjs';
+
+describe('seed-imf-external', () => {
+  it('maps balance-of-payments indicators and derives trade balance', () => {
+    const year = String(new Date().getFullYear());
+    const countries = buildImfExternalCountries({
+      exportsData: { USA: { [year]: 3100 } },
+      importsData: { USA: { [year]: 4100 } },
+      currentAccountData: { USA: { [year]: -950 } },
+      importVolumeGrowthData: { USA: { [year]: 2.0 } },
+      exportVolumeGrowthData: { USA: { [year]: 1.4 } },
+    });
+
+    assert.ok(countries.US, 'USA should map to US');
+    assert.equal(countries.US.exportsUsd, 3100);
+    assert.equal(countries.US.importsUsd, 4100);
+    assert.equal(countries.US.tradeBalanceUsd, -1000);
+    assert.equal(countries.US.currentAccountUsd, -950);
+  });
+
+  it('filters IMF aggregate rows', () => {
+    const year = String(new Date().getFullYear());
+    const countries = buildImfExternalCountries({
+      exportsData: { WEOWORLD: { [year]: 1000 }, USA: { [year]: 100 } },
+      importsData: {},
+      currentAccountData: {},
+      importVolumeGrowthData: {},
+      exportVolumeGrowthData: {},
+    });
+
+    assert.ok(countries.US, 'country rows should be preserved');
+    assert.ok(!countries.WEOWORLD, 'WEOWORLD aggregate should be excluded');
+  });
+});

--- a/tests/seed-imf-growth.test.mjs
+++ b/tests/seed-imf-growth.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildImfGrowthCountries } from '../scripts/seed-imf-growth.mjs';
+
+describe('seed-imf-growth', () => {
+  it('maps IMF growth indicators into ISO2 countries and derives savings-investment gap', () => {
+    const year = String(new Date().getFullYear());
+    const prev = String(Number(year) - 1);
+
+    const countries = buildImfGrowthCountries({
+      realGdpGrowthData: { USA: { [prev]: 1.5, [year]: 2.4 } },
+      nominalGdpPerCapitaData: { USA: { [year]: 81200 } },
+      realGdpLocalData: { USA: { [year]: 23000 } },
+      pppPerCapitaData: { USA: { [year]: 90000 } },
+      pppGdpData: { USA: { [year]: 29500 } },
+      investmentData: { USA: { [year]: 21.2 } },
+      savingsData: { USA: { [year]: 18.7 } },
+    });
+
+    assert.ok(countries.US, 'USA should map to US');
+    assert.equal(countries.US.realGdpGrowthPct, 2.4);
+    assert.equal(countries.US.nominalGdpPerCapitaUsd, 81200);
+    assert.equal(countries.US.savingsInvestmentGapPctGdp, -2.5);
+    assert.equal(countries.US.year, Number(year));
+  });
+
+  it('filters IMF aggregate rows', () => {
+    const year = String(new Date().getFullYear());
+    const countries = buildImfGrowthCountries({
+      realGdpGrowthData: {
+        USA: { [year]: 2.1 },
+        WEOWORLD: { [year]: 3.0 },
+        G20: { [year]: 2.6 },
+      },
+      nominalGdpPerCapitaData: {},
+      realGdpLocalData: {},
+      pppPerCapitaData: {},
+      pppGdpData: {},
+      investmentData: {},
+      savingsData: {},
+    });
+
+    assert.ok(countries.US, 'country rows should be preserved');
+    assert.ok(!countries.WEOWORLD, 'WEOWORLD aggregate should be excluded');
+    assert.ok(!countries.G20, 'G20 aggregate should be excluded');
+  });
+});

--- a/tests/seed-imf-labor.test.mjs
+++ b/tests/seed-imf-labor.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildImfLaborCountries } from '../scripts/seed-imf-labor.mjs';
+
+describe('seed-imf-labor', () => {
+  it('maps unemployment and population to ISO2 countries', () => {
+    const year = String(new Date().getFullYear());
+    const countries = buildImfLaborCountries({
+      unemploymentData: { USA: { [year]: 4.1 } },
+      populationData: { USA: { [year]: 342.1 } },
+    });
+
+    assert.ok(countries.US, 'USA should map to US');
+    assert.equal(countries.US.unemploymentPct, 4.1);
+    assert.equal(countries.US.populationMillions, 342.1);
+    assert.equal(countries.US.year, Number(year));
+  });
+
+  it('filters IMF aggregate rows', () => {
+    const year = String(new Date().getFullYear());
+    const countries = buildImfLaborCountries({
+      unemploymentData: { WEOWORLD: { [year]: 6.0 }, USA: { [year]: 4.2 } },
+      populationData: {},
+    });
+
+    assert.ok(countries.US, 'country rows should be preserved');
+    assert.ok(!countries.WEOWORLD, 'WEOWORLD aggregate should be excluded');
+  });
+});

--- a/tests/seed-imf-macro.test.mjs
+++ b/tests/seed-imf-macro.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildImfMacroCountries, fetchImfMacroCountries } from '../scripts/seed-imf-macro.mjs';
+
+describe('seed-imf-macro', () => {
+  it('maps IMF macro indicators into ISO2 countries', () => {
+    const year = String(new Date().getFullYear());
+
+    const countries = buildImfMacroCountries({
+      inflationData: { USA: { [year]: 3.2 } },
+      currentAccountData: { USA: { [year]: -2.4 } },
+      govRevenueData: { USA: { [year]: 27.8 } },
+      cpiIndexData: { USA: { [year]: 144.2 } },
+      cpiEndPeriodInflationData: { USA: { [year]: 3.6 } },
+      govExpenditureData: { USA: { [year]: 36.1 } },
+      primaryBalanceData: { USA: { [year]: -1.9 } },
+    });
+
+    assert.ok(countries.US, 'USA should map to US');
+    assert.equal(countries.US.inflationPct, 3.2);
+    assert.equal(countries.US.currentAccountPct, -2.4);
+    assert.equal(countries.US.govRevenuePct, 27.8);
+    assert.equal(countries.US.cpiIndex, 144.2);
+    assert.equal(countries.US.cpiEndPeriodInflationPct, 3.6);
+    assert.equal(countries.US.govExpenditurePct, 36.1);
+    assert.equal(countries.US.primaryBalancePct, -1.9);
+    assert.equal(countries.US.year, Number(year));
+  });
+
+  it('keeps the core macro payload when optional IMF indicators fail', async () => {
+    const year = String(new Date().getFullYear());
+    const optionalFailures = new Set(['PCPI', 'PCPIEPCH', 'GGX', 'GGXONLB_NGDP']);
+    const warnings = [];
+
+    const countries = await fetchImfMacroCountries(async (indicator) => {
+      if (indicator === 'PCPIPCH') return { USA: { [year]: 3.1 } };
+      if (indicator === 'BCA_NGDPD') return { USA: { [year]: -2.0 } };
+      if (indicator === 'GGR_NGDP') return { USA: { [year]: 28.4 } };
+      if (optionalFailures.has(indicator)) throw new Error(`missing ${indicator}`);
+      throw new Error(`unexpected indicator ${indicator}`);
+    }, (message) => {
+      warnings.push(message);
+    });
+
+    assert.ok(countries.US, 'core IMF macro data should still map even if optional series fail');
+    assert.equal(countries.US.inflationPct, 3.1);
+    assert.equal(countries.US.currentAccountPct, -2.0);
+    assert.equal(countries.US.govRevenuePct, 28.4);
+    assert.equal(countries.US.cpiIndex, null);
+    assert.equal(countries.US.cpiEndPeriodInflationPct, null);
+    assert.equal(countries.US.govExpenditurePct, null);
+    assert.equal(countries.US.primaryBalancePct, null);
+    assert.equal(warnings.length, optionalFailures.size);
+  });
+});

--- a/todos/193-pending-p3-oecd-openecon-parked-until-concrete-consumer.md
+++ b/todos/193-pending-p3-oecd-openecon-parked-until-concrete-consumer.md
@@ -1,0 +1,137 @@
+---
+status: pending
+priority: p3
+issue_id: 193
+tags: [planning, resilience, data-source, oecd, openecon]
+dependencies: []
+---
+
+# OECD OpenEcon SDMX seeding is parked until a concrete consumer exists
+
+## Problem Statement
+
+OpenEcon exposes the full OECD SDMX 3.0 API with no key requirement, but this
+workstream should stay parked as of 2026-04-13.
+
+Prioritization review across #3025 to #3028 set OECD integration to lowest
+priority because there is no concrete in-product consumer yet and the coverage
+shape conflicts with world-coverage goals.
+
+## Findings
+
+1. Coverage ceiling:
+   most OECD datasets are a 38-member subset, so naive integration would create
+   blanks or OECD-only bias in global tiles/dimensions.
+2. Existing overlap with current seed stack:
+   - GDP, CPI, unemployment, fiscal balances are already covered by IMF WEO
+     expansions.
+   - Tax revenue as percent of GDP is already seeded via IMF
+     `GGR_G01_GDP_PT`.
+3. No active consumer:
+   `server/worldmonitor/resilience/v1/_indicator-registry.ts` has no current
+   slot waiting for OECD-only education, R&D, or health share inputs.
+   No current panel renders these fields.
+
+## Proposed Solutions
+
+### Option 1: Keep parked until consumer exists (recommended)
+
+Do not land OECD seeders now. Keep this issue as a parking lot and only un-park
+when a named panel tile or resilience dimension requires it.
+
+**Pros:** Avoids global coverage regression and duplicate source complexity.
+**Cons:** Defers potentially useful OECD-only signals.
+**Effort:** None now.
+**Risk:** Low.
+
+### Option 2: Seed now and gate later
+
+Build seeders immediately, then decide rendering behavior after.
+
+**Pros:** Data available earlier for prototyping.
+**Cons:** High risk of unused infra, blank tiles, and source duplication.
+**Effort:** Medium-high.
+**Risk:** Medium-high.
+
+## Recommended Action
+
+Keep parked.
+
+Revisit only when a concrete consumer is named and non-OECD behavior is fully
+defined.
+
+## Technical Details
+
+### Candidate future use-cases (trigger-based)
+
+| OECD dataflow | Future consumer trigger |
+|---|---|
+| `OECD.SDD.TPS / DSD_PDB@DF_PDB_LV` (labor productivity levels) | Revisit only if a "competitiveness" resilience dimension is added |
+| `OECD.STI.PIE` (R&D percent GDP) | Revisit only if an "innovation capacity" resilience dimension is added |
+| `OECD.SDD.EDSTAT` (education spending percent GDP) | Revisit only if a social-investment resilience dimension is added |
+| `OECD.SDD.TPS / DSD_SHA` (health expenditure) | Revisit only if `healthPublicService` expands beyond current WHO/FSI inputs |
+| `OECD.ELS.SAE / DSD_HW@DF_AVG_ANN_HRS_WKD` (average hours worked) | Revisit only if a labor-market tile is introduced as an OECD-only overlay |
+| Governance indicators (product market regulation, rule-of-law variants) | Prefer broader global alternatives first (for example V-Dem, WGI) |
+
+When any OECD source is scoped:
+- define explicit non-OECD behavior (hide tile, never blank tile),
+- pair with a world-coverage fallback source where possible.
+
+### SDMX implementation notes for future activation
+
+- Base URL: `https://sdmx.oecd.org/public/rest`
+- Data endpoint:
+  `/data/{agency},{dsd_id}@{dataflow_id},{version}/{filter_key}?dimensionAtObservation=AllDimensions&startPeriod=2019&endPeriod=2025`
+- Data Accept header:
+  `application/vnd.sdmx.data+json; version=2.0.0`
+- Structure endpoint:
+  `/datastructure/{agency}/{dsd_id}/{version}`
+- Structure Accept header:
+  `application/vnd.sdmx.structure+json; version=2.0.0`
+- Country format: ISO3 (`USA`, `DEU`, `GBR`)
+- Aggregates include: `OECD`, `EA19`, `EU27_2020`, `G7`, `G20`
+- Rate envelope: approximately `60 req/hr` per IP
+- Timeout target: `50s`
+- Backoff target: 3 attempts (`3s`, `6s`, `12s`) with jitter
+- No auth required
+
+Gotchas:
+- Dimension `position` can be missing/unreliable; map by dimension ID.
+- Filter-key ordering varies by DSD; always introspect DSD first.
+
+Sample working query:
+
+```bash
+curl -H "Accept: application/vnd.sdmx.data+json; version=2.0.0" \
+  "https://sdmx.oecd.org/public/rest/data/OECD.SDD.NAD,DSD_NAMAIN10@DF_TABLE1_EXPENDITURE,1.0/.USA..........?dimensionAtObservation=AllDimensions&startPeriod=2020&endPeriod=2025"
+```
+
+Response parse pattern:
+
+```ts
+const observations = json.data.dataSets[0].observations;
+const dims = json.data.structures[0].dimensions.observation;
+const timeValues = dims.find(d => d.id === 'TIME_PERIOD').values;
+
+for (const [obsKey, obsVal] of Object.entries(observations)) {
+  const indices = obsKey.split(':').map(Number);
+  const timePeriod = timeValues[indices.at(-1)].id;
+  const value = obsVal[0];
+}
+```
+
+## Acceptance Criteria
+
+- [ ] A specific panel tile or resilience dimension is named before any OECD seeder lands.
+- [ ] Non-OECD rendering path is explicit (hidden vs blank) and does not degrade existing panels.
+- [ ] A world-coverage fallback source is paired wherever feasible.
+
+## Work Log
+
+- 2026-04-13: parked based on #3025-#3028 reprioritization and consumer-first rule.
+
+## Resources
+
+- GitHub issues: #3025, #3026, #3027, #3028
+- Candidate consumer touchpoint:
+  `server/worldmonitor/resilience/v1/_indicator-registry.ts`


### PR DESCRIPTION
## Summary

- Expanded IMF WEO coverage with new seeders for growth, labor, and external sector data (`economic:imf:growth:v1`, `economic:imf:labor:v1`, `economic:imf:external:v1`), and extended IMF macro shaping with optional CPI/expenditure/primary-balance fields.
- Wired new IMF datasets into bootstrap + health surfaces (`api/bootstrap.js`, `api/health.js`, `api/seed-health.js`, `server/_shared/cache-keys.ts`) and added a monthly IMF extended bundle runner.
- Expanded MCP cache exposure in `api/mcp.ts` to cover previously missing canonical keys (economic/resilience/energy/supply-chain/health/infrastructure/research/cross-domain), with clearer tool descriptions, per-source freshness checks, and stable labeled payloads.
- Added drift prevention so new canonical seed keys must be represented in MCP (`tests/mcp-seed-coverage.test.mjs`) and added a PR checklist gate for MCP exposure.
- Updated resilience scoring + indicator registry to include IMF labor unemployment in macro-fiscal scoring, and enhanced country intel/deep-dive facts/economic indicators with IMF enrichment (GDP growth, unemployment, inflation, GDP/capita, IMF population/year).
- Added/updated tests across IMF seeders, MCP coverage/shape, resilience scoring, and country brief behavior.

## Type of change

- [x] New feature
- [x] New data source / feed
- [x] Refactor / code cleanup
- [x] Documentation
- [x] CI / Build / Infrastructure

## Affected areas

- [x] API endpoints (`/api/*`)
- [x] Other: seed pipeline, resilience scoring, country intel/deep-dive UI

## Checklist

- [x] New seed / canonical Redis key is exposed via MCP in `api/mcp.ts` (if adding or changing seeds)
- [x] No API keys or secrets committed
