### PR TITLE
fix(cloud-sync): report 'conflict' state when retry POST also gets 409 (#3058)

### DIFF
--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -278,8 +278,10 @@ async function uploadNow(variant: string): Promise<void> {
         if (!('conflict' in retryResult)) {
           setSyncVersion(retryResult.syncVersion);
           Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
+          setState('synced');
+        } else {
+          setState('conflict');
         }
-        setState('synced');
       } else {
         setState('error');
       }


### PR DESCRIPTION
## Summary

- **Context:** Found during a validation pass of the server-side preferences sync feature (#2173).
- In `uploadNow`, `setState('synced')` ran unconditionally after the retry POST to resolve a 409 conflict, even when the retry itself also received a 409. This caused the UI to show "synced" while local changes were silently dropped.
- Moved `setState('synced')` inside the success branch (no conflict in retry result) and added an explicit `setState('conflict')` for the failure branch.

Closes #3058

## Test plan

- [ ] Simulate a double-409 scenario (e.g., concurrent edits from two tabs) and verify the UI shows "conflict" status instead of "synced"
- [ ] Verify normal upload flow still transitions to "synced" after a successful retry
- [ ] Verify first-try success (no conflict) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)