### PR TITLE
fix(relay): treat quiet hours start === end as disabled, not 24/7 (#3061)

### DIFF
--- a/convex/alertRules.ts
+++ b/convex/alertRules.ts
@@ -208,6 +208,13 @@ export const setQuietHours = mutation({
       )
       .unique();
 
+    // Cross-check against persisted value for single-field updates
+    const effectiveStart = args.quietHoursStart ?? existing?.quietHoursStart;
+    const effectiveEnd = args.quietHoursEnd ?? existing?.quietHoursEnd;
+    if (effectiveStart !== undefined && effectiveEnd !== undefined && effectiveStart === effectiveEnd) {
+      throw new ConvexError("quietHoursStart and quietHoursEnd must differ (same value = no quiet window)");
+    }
+
     const now = Date.now();
     const patch = {
       quietHoursEnabled: args.quietHoursEnabled,
@@ -284,6 +291,13 @@ export const setQuietHoursForUser = internalMutation({
         q.eq("userId", userId).eq("variant", rest.variant),
       )
       .unique();
+
+    // Cross-check against persisted value for single-field updates
+    const effectiveStart = rest.quietHoursStart ?? existing?.quietHoursStart;
+    const effectiveEnd = rest.quietHoursEnd ?? existing?.quietHoursEnd;
+    if (effectiveStart !== undefined && effectiveEnd !== undefined && effectiveStart === effectiveEnd) {
+      throw new ConvexError("quietHoursStart and quietHoursEnd must differ (same value = no quiet window)");
+    }
 
     const now = Date.now();
     const patch = {

--- a/convex/alertRules.ts
+++ b/convex/alertRules.ts
@@ -181,9 +181,6 @@ function validateQuietHoursArgs(args: {
   if (args.quietHoursEnd !== undefined && (args.quietHoursEnd < 0 || args.quietHoursEnd > 23 || !Number.isInteger(args.quietHoursEnd))) {
     throw new ConvexError("quietHoursEnd must be an integer 0–23");
   }
-  if (args.quietHoursStart !== undefined && args.quietHoursEnd !== undefined && args.quietHoursStart === args.quietHoursEnd) {
-    throw new ConvexError("quietHoursStart and quietHoursEnd must differ (same value = no quiet window)");
-  }
   if (args.quietHoursTimezone !== undefined) {
     try {
       Intl.DateTimeFormat(undefined, { timeZone: args.quietHoursTimezone });

--- a/convex/alertRules.ts
+++ b/convex/alertRules.ts
@@ -181,6 +181,9 @@ function validateQuietHoursArgs(args: {
   if (args.quietHoursEnd !== undefined && (args.quietHoursEnd < 0 || args.quietHoursEnd > 23 || !Number.isInteger(args.quietHoursEnd))) {
     throw new ConvexError("quietHoursEnd must be an integer 0–23");
   }
+  if (args.quietHoursStart !== undefined && args.quietHoursEnd !== undefined && args.quietHoursStart === args.quietHoursEnd) {
+    throw new ConvexError("quietHoursStart and quietHoursEnd must differ (same value = no quiet window)");
+  }
   if (args.quietHoursTimezone !== undefined) {
     try {
       Intl.DateTimeFormat(undefined, { timeZone: args.quietHoursTimezone });

--- a/convex/alertRules.ts
+++ b/convex/alertRules.ts
@@ -208,11 +208,14 @@ export const setQuietHours = mutation({
       )
       .unique();
 
-    // Cross-check against persisted value for single-field updates
-    const effectiveStart = args.quietHoursStart ?? existing?.quietHoursStart;
-    const effectiveEnd = args.quietHoursEnd ?? existing?.quietHoursEnd;
-    if (effectiveStart !== undefined && effectiveEnd !== undefined && effectiveStart === effectiveEnd) {
-      throw new ConvexError("quietHoursStart and quietHoursEnd must differ (same value = no quiet window)");
+    // Only enforce start !== end when quiet hours are effectively enabled
+    const effectiveEnabled = args.quietHoursEnabled ?? existing?.quietHoursEnabled ?? false;
+    if (effectiveEnabled) {
+      const effectiveStart = args.quietHoursStart ?? existing?.quietHoursStart;
+      const effectiveEnd = args.quietHoursEnd ?? existing?.quietHoursEnd;
+      if (effectiveStart !== undefined && effectiveEnd !== undefined && effectiveStart === effectiveEnd) {
+        throw new ConvexError("quietHoursStart and quietHoursEnd must differ (same value = no quiet window)");
+      }
     }
 
     const now = Date.now();
@@ -292,11 +295,14 @@ export const setQuietHoursForUser = internalMutation({
       )
       .unique();
 
-    // Cross-check against persisted value for single-field updates
-    const effectiveStart = rest.quietHoursStart ?? existing?.quietHoursStart;
-    const effectiveEnd = rest.quietHoursEnd ?? existing?.quietHoursEnd;
-    if (effectiveStart !== undefined && effectiveEnd !== undefined && effectiveStart === effectiveEnd) {
-      throw new ConvexError("quietHoursStart and quietHoursEnd must differ (same value = no quiet window)");
+    // Only enforce start !== end when quiet hours are effectively enabled
+    const effectiveEnabled = rest.quietHoursEnabled ?? existing?.quietHoursEnabled ?? false;
+    if (effectiveEnabled) {
+      const effectiveStart = rest.quietHoursStart ?? existing?.quietHoursStart;
+      const effectiveEnd = rest.quietHoursEnd ?? existing?.quietHoursEnd;
+      if (effectiveStart !== undefined && effectiveEnd !== undefined && effectiveStart === effectiveEnd) {
+        throw new ConvexError("quietHoursStart and quietHoursEnd must differ (same value = no quiet window)");
+      }
     }
 
     const now = Date.now();

--- a/scripts/lib/quiet-hours.cjs
+++ b/scripts/lib/quiet-hours.cjs
@@ -1,0 +1,31 @@
+'use strict';
+
+function toLocalHour(nowMs, timezone) {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hour: 'numeric',
+      hour12: false,
+    }).formatToParts(new Date(nowMs));
+    const h = parts.find(p => p.type === 'hour');
+    return h ? parseInt(h.value, 10) : -1;
+  } catch {
+    return -1;
+  }
+}
+
+function isInQuietHours(rule, nowMs = Date.now()) {
+  if (!rule.quietHoursEnabled) return false;
+  const start = rule.quietHoursStart ?? 22;
+  const end = rule.quietHoursEnd ?? 7;
+  if (start === end) return false; // same hour = no quiet window
+  const tz = rule.quietHoursTimezone ?? 'UTC';
+  const localHour = toLocalHour(nowMs, tz);
+  if (localHour === -1) return false;
+  // spans midnight when start > end (e.g. 23:00-07:00)
+  return start < end
+    ? localHour >= start && localHour < end
+    : localHour >= start || localHour < end;
+}
+
+module.exports = { toLocalHour, isInQuietHours };

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -132,10 +132,11 @@ function isInQuietHours(rule) {
   if (!rule.quietHoursEnabled) return false;
   const start = rule.quietHoursStart ?? 22;
   const end = rule.quietHoursEnd ?? 7;
+  if (start === end) return false; // same hour = no quiet window
   const tz = rule.quietHoursTimezone ?? 'UTC';
   const localHour = toLocalHour(Date.now(), tz);
   if (localHour === -1) return false;
-  // spans midnight when start >= end (e.g. 23:00-07:00)
+  // spans midnight when start > end (e.g. 23:00-07:00)
   return start < end
     ? localHour >= start && localHour < end
     : localHour >= start || localHour < end;

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -114,33 +114,7 @@ function isPrivateIP(ip) {
 
 // ── Quiet hours ───────────────────────────────────────────────────────────────
 
-function toLocalHour(nowMs, timezone) {
-  try {
-    const parts = new Intl.DateTimeFormat('en-US', {
-      timeZone: timezone,
-      hour: 'numeric',
-      hour12: false,
-    }).formatToParts(new Date(nowMs));
-    const h = parts.find(p => p.type === 'hour');
-    return h ? parseInt(h.value, 10) : -1;
-  } catch {
-    return -1;
-  }
-}
-
-function isInQuietHours(rule) {
-  if (!rule.quietHoursEnabled) return false;
-  const start = rule.quietHoursStart ?? 22;
-  const end = rule.quietHoursEnd ?? 7;
-  if (start === end) return false; // same hour = no quiet window
-  const tz = rule.quietHoursTimezone ?? 'UTC';
-  const localHour = toLocalHour(Date.now(), tz);
-  if (localHour === -1) return false;
-  // spans midnight when start > end (e.g. 23:00-07:00)
-  return start < end
-    ? localHour >= start && localHour < end
-    : localHour >= start || localHour < end;
-}
+const { toLocalHour, isInQuietHours } = require('./lib/quiet-hours.cjs');
 
 // Returns 'deliver' | 'suppress' | 'hold'
 function resolveQuietAction(rule, severity) {

--- a/tests/quiet-hours.test.mjs
+++ b/tests/quiet-hours.test.mjs
@@ -1,0 +1,140 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { isInQuietHours, toLocalHour } = require('../scripts/lib/quiet-hours.cjs');
+
+// Fixed instant: 2026-04-14T03:00:00Z → 03:00 UTC, 23:00 America/New_York (EDT, -04)
+const NOW_UTC_03 = Date.parse('2026-04-14T03:00:00Z');
+// Fixed instant: 2026-04-14T12:00:00Z → 12:00 UTC
+const NOW_UTC_12 = Date.parse('2026-04-14T12:00:00Z');
+
+describe('isInQuietHours', () => {
+  it('returns false when quietHoursEnabled is false', () => {
+    assert.equal(
+      isInQuietHours(
+        { quietHoursEnabled: false, quietHoursStart: 22, quietHoursEnd: 7, quietHoursTimezone: 'UTC' },
+        NOW_UTC_03,
+      ),
+      false,
+    );
+  });
+
+  it('returns false when start === end (regression #3061: must not silently suppress 24/7)', () => {
+    for (const hour of [0, 7, 12, 22, 23]) {
+      assert.equal(
+        isInQuietHours(
+          { quietHoursEnabled: true, quietHoursStart: hour, quietHoursEnd: hour, quietHoursTimezone: 'UTC' },
+          NOW_UTC_03,
+        ),
+        false,
+        `expected start===end===${hour} to be treated as disabled`,
+      );
+    }
+  });
+
+  it('handles midnight-spanning window (22→7): inside at 03:00 UTC', () => {
+    assert.equal(
+      isInQuietHours(
+        { quietHoursEnabled: true, quietHoursStart: 22, quietHoursEnd: 7, quietHoursTimezone: 'UTC' },
+        NOW_UTC_03,
+      ),
+      true,
+    );
+  });
+
+  it('handles midnight-spanning window (22→7): outside at 12:00 UTC', () => {
+    assert.equal(
+      isInQuietHours(
+        { quietHoursEnabled: true, quietHoursStart: 22, quietHoursEnd: 7, quietHoursTimezone: 'UTC' },
+        NOW_UTC_12,
+      ),
+      false,
+    );
+  });
+
+  it('handles same-day window (9→17): inside at 12:00 UTC', () => {
+    assert.equal(
+      isInQuietHours(
+        { quietHoursEnabled: true, quietHoursStart: 9, quietHoursEnd: 17, quietHoursTimezone: 'UTC' },
+        NOW_UTC_12,
+      ),
+      true,
+    );
+  });
+
+  it('handles same-day window (9→17): outside at 03:00 UTC', () => {
+    assert.equal(
+      isInQuietHours(
+        { quietHoursEnabled: true, quietHoursStart: 9, quietHoursEnd: 17, quietHoursTimezone: 'UTC' },
+        NOW_UTC_03,
+      ),
+      false,
+    );
+  });
+
+  it('end is exclusive: at hour === end, not in quiet window', () => {
+    // 9→17 at exactly 17:00 UTC should be outside
+    const at17 = Date.parse('2026-04-14T17:00:00Z');
+    assert.equal(
+      isInQuietHours(
+        { quietHoursEnabled: true, quietHoursStart: 9, quietHoursEnd: 17, quietHoursTimezone: 'UTC' },
+        at17,
+      ),
+      false,
+    );
+  });
+
+  it('start is inclusive: at hour === start, in quiet window', () => {
+    const at22 = Date.parse('2026-04-14T22:00:00Z');
+    assert.equal(
+      isInQuietHours(
+        { quietHoursEnabled: true, quietHoursStart: 22, quietHoursEnd: 7, quietHoursTimezone: 'UTC' },
+        at22,
+      ),
+      true,
+    );
+  });
+
+  it('returns false when timezone is invalid (toLocalHour returns -1)', () => {
+    assert.equal(
+      isInQuietHours(
+        { quietHoursEnabled: true, quietHoursStart: 22, quietHoursEnd: 7, quietHoursTimezone: 'Not/A_Zone' },
+        NOW_UTC_03,
+      ),
+      false,
+    );
+  });
+
+  it('respects timezone: 22→7 NYC at 2026-04-14T03:00Z (23:00 EDT) is inside', () => {
+    assert.equal(
+      isInQuietHours(
+        { quietHoursEnabled: true, quietHoursStart: 22, quietHoursEnd: 7, quietHoursTimezone: 'America/New_York' },
+        NOW_UTC_03,
+      ),
+      true,
+    );
+  });
+
+  it('defaults: missing start/end fall back to 22→7', () => {
+    assert.equal(
+      isInQuietHours({ quietHoursEnabled: true, quietHoursTimezone: 'UTC' }, NOW_UTC_03),
+      true,
+    );
+    assert.equal(
+      isInQuietHours({ quietHoursEnabled: true, quietHoursTimezone: 'UTC' }, NOW_UTC_12),
+      false,
+    );
+  });
+});
+
+describe('toLocalHour', () => {
+  it('returns integer hour for valid timezone', () => {
+    assert.equal(toLocalHour(NOW_UTC_12, 'UTC'), 12);
+  });
+
+  it('returns -1 for invalid timezone', () => {
+    assert.equal(toLocalHour(NOW_UTC_12, 'Not/A_Zone'), -1);
+  });
+});


### PR DESCRIPTION
## Summary

Found during a validation pass of the notification delivery feature (#2173).

- **`scripts/notification-relay.cjs`**: When `quietHoursStart === quietHoursEnd` (e.g. both 22), the midnight-spanning branch evaluated `localHour >= 22 || localHour < 22` which is true for every hour (0–23), silently suppressing all non-critical alerts 24/7. Added an early `return false` when `start === end` so the quiet window is treated as disabled instead.
- **`convex/alertRules.ts`**: Added validation in `validateQuietHoursArgs` to reject `start === end` at the API layer, preventing the invalid configuration from being persisted.

Closes #3061

## Test plan

- [ ] Verify `isInQuietHours` returns `false` when `quietHoursStart === quietHoursEnd`
- [ ] Verify Convex `setQuietHours` mutation throws when `start === end`
- [ ] Verify normal quiet hour ranges (e.g. 22–7, 9–17) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)