### PR TITLE
fix(economy): GSCPI shape mismatch with ais-relay payload

### DIFF
--- a/scripts/seed-economy.mjs
+++ b/scripts/seed-economy.mjs
@@ -69,8 +69,8 @@ function stressLabel(score) {
  * @returns {{ observations: { date: string; value: number }[] } | null}
  */
 export function extractGscpiObservations(parsed) {
-  const obs = /** @type {any} */ (parsed)?.series?.observations
-    ?? /** @type {any} */ (parsed)?.observations;
+  const p = /** @type {any} */ (parsed);
+  const obs = p?.series?.observations ?? p?.observations;
   return Array.isArray(obs) ? { observations: obs } : null;
 }
 

--- a/scripts/seed-economy.mjs
+++ b/scripts/seed-economy.mjs
@@ -60,8 +60,22 @@ function stressLabel(score) {
 }
 
 /**
+ * Extract GSCPI observations from the Redis-stored payload.
+ * ais-relay writes the FRED-compatible shape `{ series: { series_id, title, units,
+ * frequency, observations: [{ date, value }] } }` (see seedGscpi() in ais-relay.cjs).
+ * Earlier versions stored a flat `{ observations }` shape, so accept both.
+ * Exported for unit testing.
+ * @param {unknown} parsed
+ * @returns {{ observations: { date: string; value: number }[] } | null}
+ */
+export function extractGscpiObservations(parsed) {
+  const obs = /** @type {any} */ (parsed)?.series?.observations
+    ?? /** @type {any} */ (parsed)?.observations;
+  return Array.isArray(obs) ? { observations: obs } : null;
+}
+
+/**
  * Read GSCPI from Redis (seeded by ais-relay from NY Fed, not available via FRED API).
- * Format stored: { observations: [{ date, value }] } — no series wrapper.
  * @returns {Promise<{ observations: { date: string; value: number }[] } | null>}
  */
 async function fetchGscpiFromRedis() {
@@ -74,8 +88,7 @@ async function fetchGscpiFromRedis() {
     if (!resp.ok) return null;
     const body = /** @type {{ result: string | null }} */ (await resp.json());
     if (!body.result) return null;
-    const parsed = JSON.parse(body.result);
-    return Array.isArray(parsed.observations) ? parsed : null;
+    return extractGscpiObservations(JSON.parse(body.result));
   } catch {
     return null;
   }

--- a/tests/gscpi-shape-extraction.test.mjs
+++ b/tests/gscpi-shape-extraction.test.mjs
@@ -1,0 +1,47 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { extractGscpiObservations } from '../scripts/seed-economy.mjs';
+
+describe('extractGscpiObservations', () => {
+  it('reads the ais-relay FRED-compatible shape (observations under .series)', () => {
+    // This is the actual shape ais-relay.cjs writes — see seedGscpi() in that file.
+    const parsed = {
+      series: {
+        series_id: 'GSCPI',
+        title: 'Global Supply Chain Pressure Index',
+        units: 'Standard Deviations',
+        frequency: 'Monthly',
+        observations: [
+          { date: '2026-02-01', value: 0.42 },
+          { date: '2026-03-01', value: 0.68 },
+        ],
+      },
+    };
+    const result = extractGscpiObservations(parsed);
+    assert.ok(result, 'should return non-null');
+    assert.equal(result.observations.length, 2);
+    assert.equal(result.observations[1].value, 0.68);
+  });
+
+  it('reads the legacy flat shape (top-level observations) for back-compat', () => {
+    // Earlier ais-relay versions stored this shape — keep working if any
+    // long-lived Redis key still has it.
+    const parsed = {
+      observations: [
+        { date: '2026-03-01', value: 0.68 },
+      ],
+    };
+    const result = extractGscpiObservations(parsed);
+    assert.ok(result, 'should return non-null');
+    assert.equal(result.observations.length, 1);
+  });
+
+  it('returns null when neither shape is present', () => {
+    assert.equal(extractGscpiObservations(null), null);
+    assert.equal(extractGscpiObservations({}), null);
+    assert.equal(extractGscpiObservations({ series: {} }), null);
+    assert.equal(extractGscpiObservations({ observations: 'not-an-array' }), null);
+    assert.equal(extractGscpiObservations({ series: { observations: 'nope' } }), null);
+  });
+});


### PR DESCRIPTION
## Summary
The Stress Index was silently computing on 5/6 components every run because `seed-economy.mjs` couldn't parse the GSCPI payload that `ais-relay.cjs` writes — shape mismatch.

- `ais-relay.cjs` writes `{ series: { series_id, title, units, frequency, observations: [...] } }` (FRED-compatible)
- `seed-economy.mjs` `fetchGscpiFromRedis()` was reading `{ observations: [...] }` (top-level)
- `Array.isArray(parsed.observations)` was always `false` → `null` returned → seeder logged the misleading "GSCPI not in Redis yet (ais-relay lag or first run) — excluding" even though 343 monthly observations were sitting in `economic:fred:v1:GSCPI:0`

Fix: extract parsing into `extractGscpiObservations()` which accepts both shapes (current `series.observations` and legacy flat `observations` for back-compat). Verified against live Redis: returns 343 observations (latest 2026-03-01 = 0.68) instead of null.

## Test plan
- [x] 3 new unit tests in `tests/gscpi-shape-extraction.test.mjs` cover both shapes + malformed payload
- [x] `npm run typecheck` passes
- [x] Verified against live Redis (worked locally — returned correct latest observation)
- [ ] After deploy, next `seed-economy` run should log `[StressIndex] GSCPI loaded from Redis` and `Composite: <score> — 6/6 components`