### PR TITLE
perf(aviation): halve seed cadence to 30min + extend Redis TTLs

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -249,7 +249,7 @@ The `SmartPollLoop` is the core refresh orchestration primitive used by all data
 | `seed-research` | arXiv + HN + tech events + GitHub | 6 hours | N/A (extra keys) |
 | `seed-correlation` | Cross-domain correlation engine | 5 min | `correlation:cards-bootstrap:v1` |
 | `seed-gpsjam` | GPSJam.org H3 interference hexes | 6 hours | N/A |
-| `seed-aviation` | Airport ops summaries + aviation news | 15 min | N/A (warm-ping) |
+| `seed-aviation` | Airport ops summaries + aviation news | 30 min | N/A (warm-ping) |
 
 Seeds use `cachedFetchJson` with in-flight promise coalescing — if a seed run overlaps with a previous run still writing, the concurrent write is deduplicated. Each seed script is self-contained (single `.mjs` file, no build step), runs on Node.js 20+, and connects to Upstash Redis via REST API. Failed seed runs log errors but never corrupt existing cached data — the previous cache entry persists until a successful run replaces it.
 

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -19,8 +19,8 @@ loadEnvFile(import.meta.url);
 const DEFAULT_AIRPORTS = ['IST', 'ESB', 'SAW', 'LHR', 'FRA', 'CDG'];
 const OPS_CACHE_KEY = `aviation:ops-summary:v1:${[...DEFAULT_AIRPORTS].sort().join(',')}`;
 const NEWS_CACHE_KEY = 'aviation:news::24:v1'; // empty entities, 24h window
-const OPS_TTL = 2100;
-const NEWS_TTL = 2100;
+const OPS_TTL = 2400;
+const NEWS_TTL = 2400;
 
 const AVIATIONSTACK_URL = 'https://api.aviationstack.com/v1/flights';
 

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -19,8 +19,8 @@ loadEnvFile(import.meta.url);
 const DEFAULT_AIRPORTS = ['IST', 'ESB', 'SAW', 'LHR', 'FRA', 'CDG'];
 const OPS_CACHE_KEY = `aviation:ops-summary:v1:${[...DEFAULT_AIRPORTS].sort().join(',')}`;
 const NEWS_CACHE_KEY = 'aviation:news::24:v1'; // empty entities, 24h window
-const OPS_TTL = 300;
-const NEWS_TTL = 900;
+const OPS_TTL = 2100;
+const NEWS_TTL = 2100;
 
 const AVIATIONSTACK_URL = 'https://api.aviationstack.com/v1/flights';
 


### PR DESCRIPTION
## Summary
- Bump `seed-aviation` Redis TTLs to 2100s (35 min) so keys span the new 30-min cron interval with buffer
- Update architecture doc to reflect the new 30-min cadence
- Paired with a Railway dashboard cron change on service `a8e49386-64c1-4e1e-9f82-4eb69a55fce3` (15min → 30min), done out of band
- Motivation: AviationStack upstream call volume has been climbing over the past few days; this cuts the seeder's contribution from ~576/day to ~288/day

## Test plan
- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `npm run lint` + `npm run lint:md`
- [x] `node --test tests/edge-functions.test.mjs`
- [ ] After Railway cron is switched, confirm `seed-meta:aviation:ops-news` updates every 30 min and `aviation:ops-summary:v1:...` key never TTL-expires between runs