### PR TITLE
fix(seeds): upstream API drift — SPDR XLSX + IMF IRFCL + IMF-External BX/BM drop

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -184,7 +184,7 @@ const TOOL_REGISTRY: ToolDef[] = [
   },
   {
     name: 'get_country_macro',
-    description: 'Per-country macroeconomic indicators from IMF WEO (~210 countries, monthly cadence). Bundles fiscal/external balance (inflation, current account, gov revenue/expenditure/primary balance, CPI), growth & per-capita (real GDP growth, GDP/capita USD & PPP, savings & investment rates, savings-investment gap), labor & demographics (unemployment, population), and external trade (exports, imports, trade balance, BOP, import/export volume changes). Latest available year per series. Use for country-level economic screening, peer benchmarking, and stagflation/imbalance flags.',
+    description: 'Per-country macroeconomic indicators from IMF WEO (~210 countries, monthly cadence). Bundles fiscal/external balance (inflation, current account, gov revenue/expenditure/primary balance, CPI), growth & per-capita (real GDP growth, GDP/capita USD & PPP, savings & investment rates, savings-investment gap), labor & demographics (unemployment, population), and external trade (current account USD, import/export volume % changes). Latest available year per series. Use for country-level economic screening, peer benchmarking, and stagflation/imbalance flags. NOTE: export/import LEVELS in USD (exportsUsd, importsUsd, tradeBalanceUsd) are returned as null — WEO retracted broad coverage for BX/BM indicators in 2026-04; use currentAccountUsd or volume changes (import/exportVolumePctChg) instead.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'economic:imf:macro:v2',

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "convex-test": "^0.0.43",
         "cross-env": "^10.1.0",
         "esbuild": "^0.27.3",
+        "exceljs": "^4.4.0",
         "h3-js": "^4.4.0",
         "markdownlint-cli2": "^0.21.0",
         "tsx": "^4.21.0",
@@ -4265,6 +4266,51 @@
       "bin": {
         "spriter": "bin/spriter.js"
       }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-4.3.5.tgz",
+      "integrity": "sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/format/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-4.3.6.tgz",
+      "integrity": "sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.1",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "node_modules/@fast-csv/parse/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
@@ -9530,6 +9576,79 @@
         "node": ">= 8"
       }
     },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -10061,6 +10180,20 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -10109,6 +10242,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bn.js": {
       "version": "5.2.3",
@@ -10160,7 +10300,6 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -10282,11 +10421,40 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.2.0"
+      }
     },
     "node_modules/bufferutil": {
       "version": "4.1.0",
@@ -10413,6 +10581,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -10671,12 +10852,42 @@
         "@floating-ui/utils": "^0.2.5"
       }
     },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/connect": {
       "version": "3.7.0",
@@ -11313,6 +11524,48 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
       "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
       "engines": {
         "node": ">= 6"
       }
@@ -12040,6 +12293,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -12424,6 +12684,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
       }
     },
     "node_modules/earcut": {
@@ -12897,6 +13167,42 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/exceljs": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
+      "integrity": "sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver": "^5.0.0",
+        "dayjs": "^1.8.34",
+        "fast-csv": "^4.3.1",
+        "jszip": "^3.10.1",
+        "readable-stream": "^3.6.0",
+        "saxes": "^5.0.1",
+        "tmp": "^0.2.0",
+        "unzipper": "^0.10.11",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/exceljs/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -12939,6 +13245,20 @@
       "peer": true,
       "engines": {
         "node": "> 0.1.90"
+      }
+    },
+    "node_modules/fast-csv": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
+      "integrity": "sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@fast-csv/parse": "4.3.6"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -13332,8 +13652,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -13347,6 +13666,50 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/fstream/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/fstream/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/function-bind": {
@@ -13532,7 +13895,6 @@
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -14026,7 +14388,6 @@
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -15474,6 +15835,19 @@
       "integrity": "sha512-FeA3g56ksdFNwjXJJsc1CCc7co+AJYDp6ipIp878zZ2bU8kWROatLYf39TQEd4/XRSUvBXovQ8gaVKWPXsCLEQ==",
       "license": "MIT"
     },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -15535,6 +15909,13 @@
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
+    },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/lit": {
       "version": "3.3.2",
@@ -15601,6 +15982,84 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -15614,6 +16073,20 @@
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "3.2.0",
@@ -17076,7 +17549,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -17293,7 +17765,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17725,7 +18196,6 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18675,6 +19145,39 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/real-cancellable-promise": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/real-cancellable-promise/-/real-cancellable-promise-1.2.3.tgz",
@@ -19113,6 +19616,19 @@
       "peer": true,
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/scheduler": {
@@ -20575,6 +21091,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -20636,6 +21162,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
@@ -20991,6 +21527,25 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unzipper": {
+      "version": "0.10.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
+      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      }
+    },
     "node_modules/upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -21083,7 +21638,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -22698,6 +23252,13 @@
         }
       }
     },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/xmldoc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-2.0.3.tgz",
@@ -22845,6 +23406,58 @@
       "dependencies": {
         "@bufbuild/protobuf": "^2.0.0",
         "meriyah": "^6.1.4"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "convex-test": "^0.0.43",
     "cross-env": "^10.1.0",
     "esbuild": "^0.27.3",
+    "exceljs": "^4.4.0",
     "h3-js": "^4.4.0",
     "markdownlint-cli2": "^0.21.0",
     "tsx": "^4.21.0",

--- a/scripts/seed-gold-cb-reserves.mjs
+++ b/scripts/seed-gold-cb-reserves.mjs
@@ -131,7 +131,7 @@ export function monthOffset(period, deltaMonths) {
   return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
 }
 
-export function buildReservesPayload(raw, indicator) {
+export function buildReservesPayload(raw, indicator, goldUsdByCountry = {}, totalReservesUsdByCountry = {}) {
   const asOfMonth = (() => {
     const all = new Set();
     for (const c of Object.values(raw)) {
@@ -150,6 +150,20 @@ export function buildReservesPayload(raw, indicator) {
   const valueIsOunces = /_FTO|_OZT|OUNCE/i.test(indicator);
 
   const toTonnes = (v) => valueIsOunces ? v / TROY_OZ_PER_TONNE : null;
+
+  // Find latest month within a country's byMonth map at or before asOfMonth.
+  // IRFCL reporting lags vary per country — use the most recent available
+  // value within the last 3 months to compute pctOfReserves so we don't drop
+  // countries that report one month late.
+  const latestAtOrBefore = (byMonth, cutoff) => {
+    if (!byMonth) return null;
+    for (let back = 0; back < 3; back++) {
+      const m = monthOffset(cutoff, -back);
+      const v = byMonth[m];
+      if (v != null && Number.isFinite(v) && v > 0) return v;
+    }
+    return null;
+  };
 
   const holders = [];
   for (const [iso3, rec] of Object.entries(raw)) {
@@ -172,12 +186,22 @@ export function buildReservesPayload(raw, indicator) {
       tonnes = 0; // mark "unknown in tonnes"
     }
 
+    // pctOfReserves = gold's share of total official reserve assets (both in
+    // USD). Requires the two parallel indicator series — falls back to 0 when
+    // either side is missing for this country (small reporters often publish
+    // only the core ounces series).
+    const goldUsd = latestAtOrBefore(goldUsdByCountry[iso3]?.byMonth, asOfMonth);
+    const totalUsd = latestAtOrBefore(totalReservesUsdByCountry[iso3]?.byMonth, asOfMonth);
+    const pctOfReserves = (goldUsd != null && totalUsd != null && totalUsd > 0)
+      ? +((goldUsd / totalUsd) * 100).toFixed(2)
+      : 0;
+
     holders.push({
       iso3,
       name: ISO3_NAMES[iso3] || rec.name || iso3,
       tonnes: Number.isFinite(tonnes) ? +tonnes.toFixed(2) : 0,
-      pctOfReserves: 0, // IFS doesn't give us total reserves side-by-side in this series
-      valueUsd: valueIsOunces ? 0 : +current.toFixed(0),
+      pctOfReserves,
+      valueUsd: valueIsOunces ? (goldUsd ?? 0) : +current.toFixed(0),
       deltaTonnes12m,
     });
   }
@@ -211,10 +235,33 @@ export function buildReservesPayload(raw, indicator) {
   };
 }
 
+// Indicators used to compute pctOfReserves = gold_usd / total_reserves_usd.
+// Both are IRFCLDT1 USD-denominated; fetched in parallel with the primary
+// tonnage indicator so the share is computed from matched-month values.
+const GOLD_USD_INDICATOR = 'IRFCLDT1_IRFCL56_USD';   // Official reserve assets, gold (USD market value)
+const TOTAL_RESERVES_USD = 'IRFCLDT1_IRFCL65_USD';   // Official reserve assets (total, USD market value)
+
 async function fetchCbReserves() {
-  const res = await fetchFirstAvailableIndicator();
-  if (!res) throw new Error('All IMF IFS candidate indicators returned empty / failed');
-  const payload = buildReservesPayload(res.data, res.indicator);
+  // Fetch the tonnage indicator + the two USD series for pctOfReserves in
+  // parallel. The pct series are optional — on failure we still publish the
+  // tonnage payload with pctOfReserves=0 rather than blocking the seed.
+  const [primary, goldUsdRes, totalUsdRes] = await Promise.allSettled([
+    fetchFirstAvailableIndicator(),
+    fetchIrfclMonthlySeries(GOLD_USD_INDICATOR),
+    fetchIrfclMonthlySeries(TOTAL_RESERVES_USD),
+  ]);
+
+  const res = primary.status === 'fulfilled' ? primary.value : null;
+  if (!res) throw new Error('All IMF IRFCL candidate tonnage indicators returned empty / failed');
+
+  const goldUsd = goldUsdRes.status === 'fulfilled' ? goldUsdRes.value : {};
+  const totalUsd = totalUsdRes.status === 'fulfilled' ? totalUsdRes.value : {};
+  const pctCoverage = Object.keys(goldUsd).length && Object.keys(totalUsd).length
+    ? Math.min(Object.keys(goldUsd).length, Object.keys(totalUsd).length)
+    : 0;
+  console.log(`  [IMF IRFCL] pctOfReserves denominator coverage: ${pctCoverage} countries (gold_usd=${Object.keys(goldUsd).length}, total_usd=${Object.keys(totalUsd).length})`);
+
+  const payload = buildReservesPayload(res.data, res.indicator, goldUsd, totalUsd);
   if (!payload) throw new Error(`buildReservesPayload returned null (indicator=${res.indicator})`);
   return payload;
 }

--- a/scripts/seed-gold-cb-reserves.mjs
+++ b/scripts/seed-gold-cb-reserves.mjs
@@ -6,17 +6,26 @@ loadEnvFile(import.meta.url);
 const CB_KEY = 'market:gold-cb-reserves:v1';
 const CB_TTL = 2_592_000; // 30 days — data is monthly, TTL long to survive missed runs
 
-// IMF IFS dataset via SDMX 3.0 — public, no auth. Gold reserves series.
-// Candidate indicator codes, tried in ORDER OF PREFERENCE. Ounces-denominated
-// series come first because USD values conflate real buying with gold-price
-// moves; we only fall back to USD when no ounces series is available (in
-// which case buildReservesPayload emits holders with tonnes=0 and suppresses
-// the 12M buyers/sellers lists — see valueIsOunces handling there).
+// IMF IRFCL (International Reserves and Foreign Currency Liquidity) dataflow
+// via SDMX 3.0 — public, no auth. The original PR (#3038) targeted
+// IMF.STA/IFS which returns HTTP 404 — IFS isn't an exposed dataflow on
+// api.imf.org; gold-reserves data lives under IMF.STA/IRFCL.
+//
+// Dimensions: COUNTRY.INDICATOR.SECTOR.FREQUENCY (4, not 3). Key pattern
+// requires explicit wildcards `*.<indicator>.*.M`; empty segments return
+// HTTP 400 / zero series. Verified against live API: *._FTO.*.M returns
+// 111 series at ~798 KB.
+//
+// Candidate indicators in order of preference. _FTO (fine troy ounces)
+// values convert directly to tonnes — USD suffix is last-resort fallback
+// because price moves contaminate delta calculations.
 const IMF_SDMX_BASE = 'https://api.imf.org/external/sdmx/3.0';
+const IRFCL_DATAFLOW = `${IMF_SDMX_BASE}/data/dataflow/IMF.STA/IRFCL/+`;
 const CANDIDATE_INDICATORS = [
-  'RAFAGOLDV_OZT',  // Reserve assets: gold, fine troy ounces (IFS) — PREFERRED
-  'AFAGOLD',        // Legacy IFS ounces code
-  'RAFAGOLD_USD',   // USD fallback (last resort; price-contaminated deltas)
+  'IRFCLDT1_IRFCL56_FTO',   // Reserve assets: gold, fine troy ounces — PREFERRED
+  'IRFCLDT1_IRFCL56GB_FTO', // Gold bullion only, troy ounces
+  'IRFCLDT1_IRFCL56UG_FTO', // Unallocated gold, troy ounces
+  'IRFCLDT1_IRFCL56_USD',   // USD fallback (last resort; price-contaminated deltas)
 ];
 
 const TROY_OZ_PER_TONNE = 32_150.7;
@@ -44,18 +53,17 @@ const AGGREGATE_CODES = new Set([
   'UMC', 'HIC', 'SSA', 'LAC', 'MEA', 'SAS', 'EAP', 'ECA', 'ADVEC', 'EMDE',
 ]);
 
-async function fetchIfsMonthlySeries(indicator) {
-  // IFS uses frequency .M (monthly). URL pattern mirrors imfSdmxFetchIndicator
-  // in _seed-utils.mjs but we keep it inline here since IFS has a different
-  // dimension layout than WEO.
-  const url = `${IMF_SDMX_BASE}/data/dataflow/IMF.STA/IFS/+/M..${indicator}?dimensionAtObservation=TIME_PERIOD&attributes=dsd&measures=all`;
+async function fetchIrfclMonthlySeries(indicator) {
+  // IRFCL dimensions: COUNTRY.INDICATOR.SECTOR.FREQUENCY. We wildcard COUNTRY
+  // and SECTOR; FREQUENCY=M for monthly.
+  const url = `${IRFCL_DATAFLOW}/*.${indicator}.*.M?dimensionAtObservation=TIME_PERIOD&attributes=dsd&measures=all`;
 
   const json = await withRetry(async () => {
     const r = await fetch(url, {
       headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
       signal: AbortSignal.timeout(90_000),
     });
-    if (!r.ok) throw new Error(`IMF IFS ${indicator}: HTTP ${r.status}`);
+    if (!r.ok) throw new Error(`IMF IRFCL ${indicator}: HTTP ${r.status}`);
     return r.json();
   }, 2, 3000);
 
@@ -98,15 +106,15 @@ async function fetchIfsMonthlySeries(indicator) {
 async function fetchFirstAvailableIndicator() {
   for (const indicator of CANDIDATE_INDICATORS) {
     try {
-      const data = await fetchIfsMonthlySeries(indicator);
+      const data = await fetchIrfclMonthlySeries(indicator);
       const countries = Object.keys(data).length;
       if (countries >= 20) {
-        console.log(`  [IMF IFS] ${indicator}: ${countries} countries`);
+        console.log(`  [IMF IRFCL] ${indicator}: ${countries} countries`);
         return { indicator, data };
       }
-      console.warn(`  [IMF IFS] ${indicator}: only ${countries} countries — trying next`);
+      console.warn(`  [IMF IRFCL] ${indicator}: only ${countries} countries — trying next`);
     } catch (e) {
-      console.warn(`  [IMF IFS] ${indicator} failed: ${e.message} — trying next`);
+      console.warn(`  [IMF IRFCL] ${indicator} failed: ${e.message} — trying next`);
     }
   }
   return null;
@@ -135,7 +143,11 @@ export function buildReservesPayload(raw, indicator) {
   if (!asOfMonth) return null;
 
   const priorMonth = monthOffset(asOfMonth, -12);
-  const valueIsOunces = indicator.includes('_OZT') || indicator.includes('OUNCE');
+  // IRFCL `_FTO` suffix = Fine Troy Ounces (convertible to tonnes). `_USD`
+  // values are price-contaminated, so we flag non-ounces and skip deltas.
+  // Backward-compat: legacy `_OZT`/`OUNCE` substrings (from pre-merge PR) also
+  // satisfy the check.
+  const valueIsOunces = /_FTO|_OZT|OUNCE/i.test(indicator);
 
   const toTonnes = (v) => valueIsOunces ? v / TROY_OZ_PER_TONNE : null;
 

--- a/scripts/seed-gold-etf-flows.mjs
+++ b/scripts/seed-gold-etf-flows.mjs
@@ -1,105 +1,90 @@
 #!/usr/bin/env node
 
+import { createRequire } from 'node:module';
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+
 loadEnvFile(import.meta.url);
+
+const require = createRequire(import.meta.url);
 
 const GLD_KEY = 'market:gold-etf-flows:v1';
 const GLD_TTL = 86400;
-const GLD_URL = 'https://www.spdrgoldshares.com/assets/dynamic/GLD/GLD_US_archive_EN.csv';
 
-// SPDR publishes a daily CSV of GLD holdings. Columns observed (header order):
-// Date, Gold (oz), Total Net Assets, NAV, Shares Outstanding
-// Some archive versions use tonnes directly. We parse defensively — either Gold
-// column is converted to tonnes on the way out (1 tonne = 32,150.7 troy oz).
-const TROY_OZ_PER_TONNE = 32_150.7;
+// SPDR migrated from the legacy CSV archive to a Next.js JSON/XLSX API in
+// early 2026. The old URL (/assets/dynamic/GLD/GLD_US_archive_EN.csv) now
+// silently returns a PDF (Content-Type: application/pdf, ~700 KB) which
+// broke the original CSV parser with "Parsed only 0 rows" on every run.
+//
+// The new endpoint serves the full history as XLSX (~530 KB, sheet "US GLD
+// Historical Archive", ~5500 rows). Parse with exceljs (already in scripts
+// package deps).
+const GLD_API_BASE = 'https://api.spdrgoldshares.com/api/v1';
+const GLD_ORIGIN = 'https://www.spdrgoldshares.com';
+const GLD_HIST_URL = `${GLD_API_BASE}/historical-archive?product=gld&exchange=NYSE&lang=en`;
 
-function parseCsv(text) {
-  const lines = text.split(/\r?\n/).filter(l => l.trim().length > 0);
-  if (lines.length < 2) return { header: [], rows: [] };
-  const splitLine = (l) => {
-    // Handles simple CSV with optional double-quoted cells containing commas.
-    const out = [];
-    let cur = '';
-    let inQuote = false;
-    for (let i = 0; i < l.length; i++) {
-      const ch = l[i];
-      if (ch === '"') { inQuote = !inQuote; continue; }
-      if (ch === ',' && !inQuote) { out.push(cur.trim()); cur = ''; continue; }
-      cur += ch;
-    }
-    out.push(cur.trim());
-    return out;
-  };
-  // Strip UTF-8 BOM from first header cell — SPDR's CSV has been observed
-  // both with and without one; without this, findCol('date') silently returns
-  // -1 and the outer 30-row guard throws a misleading "format may have changed".
-  const header = splitLine(lines[0]).map(h => h.trim().toLowerCase().replace(/^\ufeff/, ''));
-  const rows = lines.slice(1).map(splitLine);
-  return { header, rows };
-}
-
-function toNum(s) {
-  if (!s) return NaN;
-  const n = parseFloat(String(s).replace(/[,$"]/g, ''));
+function parseSpdrNumber(raw) {
+  if (raw == null) return NaN;
+  const s = String(raw).replace(/[$,\s£€¥]/g, '').replace(/^US\$/i, '').trim();
+  const n = parseFloat(s);
   return Number.isFinite(n) ? n : NaN;
 }
 
-function parseIsoDate(s) {
-  // SPDR typically writes "DD-MMM-YY" (e.g. 10-Apr-26) or "M/D/YYYY". Normalize.
-  if (!s) return '';
-  const raw = String(s).trim();
-  if (/^\d{4}-\d{2}-\d{2}/.test(raw)) return raw.slice(0, 10);
-  const m1 = raw.match(/^(\d{1,2})[-/](\w{3})[-/](\d{2,4})$/);
+function parseSpdrDate(raw) {
+  if (!raw) return '';
+  if (raw instanceof Date) return raw.toISOString().slice(0, 10);
+  const s = String(raw).trim();
+  if (/^\d{4}-\d{2}-\d{2}/.test(s)) return s.slice(0, 10);
+  // "18-Nov-2004" / "10-Apr-2026"
+  const m1 = s.match(/^(\d{1,2})-(\w{3})-(\d{4})$/);
   if (m1) {
-    const [, d, mon, y] = m1;
     const months = { jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6, jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12 };
-    const mm = months[mon.toLowerCase()];
-    if (!mm) return '';
-    const yyyy = y.length === 2 ? (parseInt(y, 10) >= 50 ? `19${y}` : `20${y}`) : y;
-    return `${yyyy}-${String(mm).padStart(2, '0')}-${String(parseInt(d, 10)).padStart(2, '0')}`;
+    const mm = months[m1[2].toLowerCase()];
+    if (mm) return `${m1[3]}-${String(mm).padStart(2, '0')}-${m1[1].padStart(2, '0')}`;
   }
-  const m2 = raw.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  // "April 13, 2026" (used by the /data endpoint; kept for forward compat if
+  // we ever backfill from that source).
+  const m2 = s.match(/^(\w+)\s+(\d{1,2}),\s+(\d{4})$/);
   if (m2) {
-    const [, mm, dd, yyyy] = m2;
-    return `${yyyy}-${mm.padStart(2, '0')}-${dd.padStart(2, '0')}`;
+    const months = { january: 1, february: 2, march: 3, april: 4, may: 5, june: 6, july: 7, august: 8, september: 9, october: 10, november: 11, december: 12 };
+    const mm = months[m2[1].toLowerCase()];
+    if (mm) return `${m2[3]}-${String(mm).padStart(2, '0')}-${m2[2].padStart(2, '0')}`;
   }
   return '';
 }
 
-export function parseGldArchive(csvText) {
-  const { header, rows } = parseCsv(csvText);
-  if (!header.length || !rows.length) return [];
+/**
+ * Parse the XLSX historical archive into an ascending-by-date array of
+ * `{ date, tonnes, aum, nav }` records. Exposed for unit tests.
+ */
+export async function parseGldArchiveXlsx(xlsxBuffer) {
+  const ExcelJS = require('exceljs');
+  const wb = new ExcelJS.Workbook();
+  await wb.xlsx.load(xlsxBuffer);
+  const ws = wb.worksheets.find(w => w.name !== 'Disclaimer') || wb.worksheets[1] || wb.worksheets[0];
+  if (!ws || ws.rowCount < 10) return [];
 
-  const findCol = (...candidates) => {
-    for (const c of candidates) {
-      const idx = header.findIndex(h => h === c || h.startsWith(c));
-      if (idx !== -1) return idx;
-    }
-    return -1;
-  };
-  const idxDate = findCol('date');
-  const idxOz = findCol('gold troy oz', 'gold (oz)', 'gold oz', 'ounces');
-  const idxTonnes = findCol('gold (tonnes)', 'gold tonnes', 'tonnes', 'metric tonnes');
-  const idxAum = findCol('total net assets', 'net assets', 'aum');
-  const idxNav = findCol('nav', 'price per share', 'share price');
-  if (idxDate === -1 || (idxOz === -1 && idxTonnes === -1)) return [];
+  // Column layout (header row 1; observed 2026-04):
+  //   1 Date | 2 Closing Price | 3 Ounces/Share | 4 NAV/Share | 5 IOPV | 6 Mid
+  //   7 Premium/Discount | 8 Volume | 9 Total Ounces | 10 Tonnes | 11 Total NAV USD
+  const COL_DATE = 1, COL_NAV = 2, COL_TONNES = 10, COL_AUM = 11;
 
   const out = [];
-  for (const r of rows) {
-    const date = parseIsoDate(r[idxDate]);
+  for (let r = 2; r <= ws.rowCount; r++) {
+    const row = ws.getRow(r);
+    const date = parseSpdrDate(row.getCell(COL_DATE).value);
     if (!date) continue;
-    let tonnes = NaN;
-    if (idxTonnes !== -1) tonnes = toNum(r[idxTonnes]);
-    if (!Number.isFinite(tonnes) && idxOz !== -1) {
-      const oz = toNum(r[idxOz]);
-      if (Number.isFinite(oz) && oz > 0) tonnes = oz / TROY_OZ_PER_TONNE;
-    }
+    const tonnes = parseSpdrNumber(row.getCell(COL_TONNES).value);
     if (!Number.isFinite(tonnes) || tonnes <= 0) continue;
-    const aum = idxAum !== -1 ? toNum(r[idxAum]) : NaN;
-    const nav = idxNav !== -1 ? toNum(r[idxNav]) : NaN;
-    out.push({ date, tonnes, aum: Number.isFinite(aum) ? aum : 0, nav: Number.isFinite(nav) ? nav : 0 });
+    const aum = parseSpdrNumber(row.getCell(COL_AUM).value);
+    const nav = parseSpdrNumber(row.getCell(COL_NAV).value);
+    out.push({
+      date,
+      tonnes,
+      aum: Number.isFinite(aum) ? aum : 0,
+      nav: Number.isFinite(nav) ? nav : 0,
+    });
   }
-  // Sort ascending by date so index arithmetic for deltas is obvious.
+  // Sort ascending so index arithmetic for deltas is obvious.
   out.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
   return out;
 }
@@ -129,14 +114,25 @@ export function computeFlows(history) {
 }
 
 async function fetchGldFlows() {
-  const resp = await fetch(GLD_URL, {
-    headers: { 'User-Agent': CHROME_UA, Accept: 'text/csv,text/plain,*/*' },
-    signal: AbortSignal.timeout(20_000),
+  const resp = await fetch(GLD_HIST_URL, {
+    headers: {
+      'User-Agent': CHROME_UA,
+      Accept: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/octet-stream,*/*',
+      // The SPDR API silently swaps the payload for a PDF when these headers
+      // are absent — always send browser-ish Origin/Referer.
+      Origin: GLD_ORIGIN,
+      Referer: `${GLD_ORIGIN}/usa/historical-data/`,
+    },
+    signal: AbortSignal.timeout(30_000),
   });
-  if (!resp.ok) throw new Error(`SPDR GLD archive HTTP ${resp.status}`);
-  const text = await resp.text();
-  const history = parseGldArchive(text);
-  if (history.length < 30) throw new Error(`Parsed only ${history.length} rows — SPDR format may have changed`);
+  if (!resp.ok) throw new Error(`SPDR historical-archive HTTP ${resp.status}`);
+  const ct = resp.headers.get('content-type') || '';
+  if (!/spreadsheet|xlsx|octet-stream/i.test(ct)) {
+    throw new Error(`SPDR historical-archive returned non-XLSX content-type: ${ct}`);
+  }
+  const buf = Buffer.from(await resp.arrayBuffer());
+  const history = await parseGldArchiveXlsx(buf);
+  if (history.length < 30) throw new Error(`Parsed only ${history.length} rows — SPDR XLSX format may have changed`);
   const flows = computeFlows(history);
   if (!flows) throw new Error('flows computation returned null');
   return { updatedAt: new Date().toISOString(), ...flows };

--- a/scripts/seed-imf-external.mjs
+++ b/scripts/seed-imf-external.mjs
@@ -4,11 +4,15 @@
 // Canonical key: economic:imf:external:v1
 //
 // Indicators:
-//   BX        — Exports of goods & services, USD
-//   BM        — Imports of goods & services, USD
-//   BCA       — Current account balance, USD
-//   TM_RPCH   — Volume of imports of goods & services, % change
-//   TX_RPCH   — Volume of exports of goods & services, % change
+//   BCA       — Current account balance, USD (broad coverage, ~209 countries)
+//   TM_RPCH   — Volume of imports of goods & services, % change (~189 countries)
+//   TX_RPCH   — Volume of exports of goods & services, % change (~190 countries)
+//
+// NOTE: BX/BM (export/import LEVELS in USD) were dropped 2026-04 — WEO
+// currently publishes these for only ~10 countries, so joining on them
+// collapsed the result set below the 190-country validate floor and the
+// whole seed was rejected on every run. If WEO republishes BX/BM with
+// broader coverage, re-add them + restore the tradeBalance join.
 //
 // Per WorldMonitor #3027 — feeds Trade Flows card.
 
@@ -46,16 +50,12 @@ export function latestValue(byYear) {
 }
 
 export function buildExternalCountries({
-  exports = {},
-  imports = {},
   currentAccount = {},
   importVol = {},
   exportVol = {},
 }) {
   const countries = {};
   const allIso3 = new Set([
-    ...Object.keys(exports),
-    ...Object.keys(imports),
     ...Object.keys(currentAccount),
     ...Object.keys(importVol),
     ...Object.keys(exportVol),
@@ -65,26 +65,23 @@ export function buildExternalCountries({
     const iso2 = ISO3_TO_ISO2[iso3];
     if (!iso2) continue;
 
-    const ex   = latestValue(exports[iso3]);
-    const im   = latestValue(imports[iso3]);
-    const ca   = latestValue(currentAccount[iso3]);
-    const tm   = latestValue(importVol[iso3]);
-    const tx   = latestValue(exportVol[iso3]);
+    const ca = latestValue(currentAccount[iso3]);
+    const tm = latestValue(importVol[iso3]);
+    const tx = latestValue(exportVol[iso3]);
 
-    if (!ex && !im && !ca && !tm && !tx) continue;
-
-    const tradeBalance = ex && im && ex.year === im.year
-      ? Number((ex.value - im.value).toFixed(3))
-      : null;
+    if (!ca && !tm && !tx) continue;
 
     countries[iso2] = {
-      exportsUsd:           ex?.value ?? null,
-      importsUsd:           im?.value ?? null,
-      tradeBalanceUsd:      tradeBalance,
-      currentAccountUsd:    ca?.value ?? null,
-      importVolumePctChg:   tm?.value ?? null,
-      exportVolumePctChg:   tx?.value ?? null,
-      year: ex?.year ?? im?.year ?? ca?.year ?? tm?.year ?? tx?.year ?? null,
+      // BX/BM dropped — WEO coverage is ~10 countries. Fields kept as null so
+      // downstream consumers that probed for their presence see an explicit
+      // gap rather than a missing field.
+      exportsUsd:         null,
+      importsUsd:         null,
+      tradeBalanceUsd:    null,
+      currentAccountUsd:  ca?.value ?? null,
+      importVolumePctChg: tm?.value ?? null,
+      exportVolumePctChg: tx?.value ?? null,
+      year: ca?.year ?? tm?.year ?? tx?.year ?? null,
     };
   }
   return countries;
@@ -92,24 +89,22 @@ export function buildExternalCountries({
 
 export async function fetchImfExternal() {
   const years = weoYears();
-  const [exports, imports, currentAccount, importVol, exportVol] = await Promise.all([
-    imfSdmxFetchIndicator('BX', { years }),
-    imfSdmxFetchIndicator('BM', { years }),
+  const [currentAccount, importVol, exportVol] = await Promise.all([
     imfSdmxFetchIndicator('BCA', { years }),
     imfSdmxFetchIndicator('TM_RPCH', { years }),
     imfSdmxFetchIndicator('TX_RPCH', { years }),
   ]);
   return {
-    countries: buildExternalCountries({ exports, imports, currentAccount, importVol, exportVol }),
+    countries: buildExternalCountries({ currentAccount, importVol, exportVol }),
     seededAt: new Date().toISOString(),
   };
 }
 
-// IMF WEO external indicators (BX/BM/BCA) report ~210 countries. Require
-// >=190 to reject partial snapshots where a bad IMF run silently drops
-// dozens of countries.
+// BCA ~209 / TM_RPCH ~189 / TX_RPCH ~190. The union typically yields 189-210
+// non-aggregate countries. 180 is a safe floor that rejects a broken IMF run
+// while absorbing normal per-indicator sparseness.
 export function validate(data) {
-  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 190;
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 180;
 }
 
 export { CANONICAL_KEY, CACHE_TTL };

--- a/tests/gold-cb-reserves-seed.test.mjs
+++ b/tests/gold-cb-reserves-seed.test.mjs
@@ -94,3 +94,67 @@ describe('seed-gold-cb-reserves: buildReservesPayload (USD indicator)', () => {
     assert.equal(payload.topBuyers12m.length, 0);
   });
 });
+
+describe('seed-gold-cb-reserves: pctOfReserves computation', () => {
+  it('computes gold share of total reserves when both USD series are supplied', () => {
+    const raw = {
+      USA: { name: 'United States', byMonth: { '2026-01': 261_500_000 } },
+      DEU: { name: 'Germany',       byMonth: { '2026-01': 108_000_000 } },
+      CHN: { name: 'China',         byMonth: { '2026-01':  74_000_000 } },
+    };
+    // Gold USD value per country (market value, approximate)
+    const goldUsd = {
+      USA: { byMonth: { '2026-01': 400_000_000_000 } },
+      DEU: { byMonth: { '2026-01': 170_000_000_000 } },
+      CHN: { byMonth: { '2026-01': 115_000_000_000 } },
+    };
+    // Total reserve assets per country
+    const totalUsd = {
+      USA: { byMonth: { '2026-01': 800_000_000_000 } },  // US: 50% gold share (synthetic)
+      DEU: { byMonth: { '2026-01': 250_000_000_000 } },  // DE: 68% (synthetic, realistic)
+      CHN: { byMonth: { '2026-01': 3_300_000_000_000 } }, // CN: ~3.5% (realistic — mostly FX)
+    };
+    const payload = buildReservesPayload(raw, 'IRFCLDT1_IRFCL56_FTO', goldUsd, totalUsd);
+    assert.ok(payload);
+
+    const by = Object.fromEntries(payload.topHolders.map(h => [h.iso3, h]));
+    assert.equal(by.USA.pctOfReserves, 50);
+    assert.equal(by.DEU.pctOfReserves, 68);
+    assert.equal(by.CHN.pctOfReserves, 3.48);
+  });
+
+  it('falls back to pctOfReserves=0 when denominator series is missing for a country', () => {
+    const raw = {
+      USA: { name: 'United States', byMonth: { '2026-01': 261_500_000 } },
+    };
+    // Gold USD present, but total reserves missing for USA
+    const goldUsd = { USA: { byMonth: { '2026-01': 400_000_000_000 } } };
+    const totalUsd = {};
+    const payload = buildReservesPayload(raw, 'IRFCLDT1_IRFCL56_FTO', goldUsd, totalUsd);
+    assert.equal(payload.topHolders[0].pctOfReserves, 0, 'no denominator → 0');
+  });
+
+  it('accepts a denominator from 1-2 months before asOfMonth (per-country reporting lag)', () => {
+    // Primary tonnage reports 2026-03. Total reserves only has 2026-02 (1mo lag).
+    // Should still compute pctOfReserves using the 2026-02 denominator.
+    const raw = {
+      USA: { name: 'United States', byMonth: { '2026-03': 261_500_000 } },
+    };
+    const goldUsd = { USA: { byMonth: { '2026-03': 400_000_000_000 } } };
+    const totalUsd = { USA: { byMonth: { '2026-02': 800_000_000_000 } } };
+    const payload = buildReservesPayload(raw, 'IRFCLDT1_IRFCL56_FTO', goldUsd, totalUsd);
+    assert.equal(payload.asOfMonth, '2026-03');
+    assert.equal(payload.topHolders[0].pctOfReserves, 50, '2026-02 total is within the 3-month lookback window');
+  });
+
+  it('rejects a denominator older than 3 months (stale data shouldn\'t contaminate current pct)', () => {
+    const raw = {
+      USA: { name: 'United States', byMonth: { '2026-06': 261_500_000 } },
+    };
+    const goldUsd = { USA: { byMonth: { '2026-06': 400_000_000_000 } } };
+    // Total reserves last reported 2026-01 — 5 months before; outside the window.
+    const totalUsd = { USA: { byMonth: { '2026-01': 800_000_000_000 } } };
+    const payload = buildReservesPayload(raw, 'IRFCLDT1_IRFCL56_FTO', goldUsd, totalUsd);
+    assert.equal(payload.topHolders[0].pctOfReserves, 0, 'stale denominator (>3mo) is dropped');
+  });
+});

--- a/tests/gold-etf-flows-seed.test.mjs
+++ b/tests/gold-etf-flows-seed.test.mjs
@@ -1,74 +1,99 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
 
-import { parseGldArchive, computeFlows } from '../scripts/seed-gold-etf-flows.mjs';
+import { parseGldArchiveXlsx, computeFlows } from '../scripts/seed-gold-etf-flows.mjs';
 
-describe('seed-gold-etf-flows: parseGldArchive', () => {
-  it('parses tonnes column directly when present', () => {
-    const csv = `Date,Gold (Tonnes),Total Net Assets,NAV
-10-Apr-26,905.20,90500000000,78.50
-09-Apr-26,904.10,90000000000,78.20`;
-    const rows = parseGldArchive(csv);
-    assert.equal(rows.length, 2);
+// exceljs lives in scripts/node_modules (not the repo root) — resolve from
+// the scripts package the seeder itself ships from.
+const require = createRequire(new URL('../scripts/package.json', import.meta.url));
+
+// Build a synthetic XLSX in memory that mirrors the real SPDR layout:
+//   sheet "US GLD Historical Archive"
+//   row 1 = headers; col 1=Date, 2=Close, 10=Tonnes, 11=AUM
+async function buildSyntheticXlsx(rows, sheetName = 'US GLD Historical Archive') {
+  const ExcelJS = require('exceljs');
+  const wb = new ExcelJS.Workbook();
+  wb.addWorksheet('Disclaimer').addRow(['SPDR GOLD SHARES DISCLAIMER — synthetic test data']);
+  const ws = wb.addWorksheet(sheetName);
+  ws.addRow([
+    'Date', 'Closing Price', 'Ounces of Gold per Share', 'NAV/Share',
+    'IOPV', 'Mid', 'Premium/Discount', 'Volume',
+    'Total Ounces', 'Tonnes of Gold', 'Total Net Asset Value',
+  ]);
+  for (const r of rows) {
+    ws.addRow([r.date, r.nav ?? 0, 0, 0, 0, 0, 0, 0, 0, r.tonnes ?? 0, r.aum ?? 0]);
+  }
+  return Buffer.from(await wb.xlsx.writeBuffer());
+}
+
+// Parser guards on rowCount < 10 to reject nearly-empty sheets; tests that
+// want data back must supply ≥ 9 data rows.
+function daysAgoIso(n) {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+function spdrDate(iso) {
+  const d = new Date(iso + 'T00:00:00Z');
+  const mon = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'][d.getUTCMonth()];
+  return `${String(d.getUTCDate()).padStart(2,'0')}-${mon}-${d.getUTCFullYear()}`;
+}
+
+async function buildHistoricalXlsx(n, { tonnesBase = 900, aumBase = 90e9, navBase = 78 } = {}) {
+  const rows = [];
+  for (let i = n - 1; i >= 0; i--) {
+    const iso = daysAgoIso(i);
+    rows.push({ date: spdrDate(iso), nav: navBase + i * 0.01, tonnes: tonnesBase + i, aum: aumBase + i * 1e6 });
+  }
+  return buildSyntheticXlsx(rows);
+}
+
+describe('seed-gold-etf-flows: parseGldArchiveXlsx', () => {
+  it('parses the real SPDR column layout (Date=1, Close=2, Tonnes=10, AUM=11)', async () => {
+    const buf = await buildHistoricalXlsx(15);
+    const rows = await parseGldArchiveXlsx(buf);
+    assert.equal(rows.length, 15);
     // Sorted ascending
-    assert.equal(rows[0].date, '2026-04-09');
-    assert.equal(rows[1].date, '2026-04-10');
-    assert.equal(rows[1].tonnes, 905.20);
-    assert.equal(rows[1].aum, 90500000000);
+    for (let i = 1; i < rows.length; i++) assert.ok(rows[i - 1].date <= rows[i].date);
+    // Column mapping sanity
+    assert.ok(rows[0].tonnes > 0);
+    assert.ok(rows[0].aum > 0);
+    assert.ok(rows[0].nav > 0);
   });
 
-  it('falls back to troy oz → tonnes conversion', () => {
-    const csv = `Date,Gold Troy Oz,Total Net Assets,NAV
-10-Apr-26,29097063.5,90500000000,78.50`;
-    const rows = parseGldArchive(csv);
-    assert.equal(rows.length, 1);
-    // 29,097,063.5 / 32,150.7 ≈ 905.02
-    assert.ok(Math.abs(rows[0].tonnes - 905.02) < 0.1, `got ${rows[0].tonnes}`);
+  it('accepts "DD-MMM-YYYY" dates (real SPDR format)', async () => {
+    const buf = await buildSyntheticXlsx(
+      Array.from({ length: 11 }, (_, i) => ({ date: `${String(i + 1).padStart(2,'0')}-Nov-2004`, tonnes: 8 + i * 0.1, aum: 1e8, nav: 44 })),
+    );
+    const rows = await parseGldArchiveXlsx(buf);
+    assert.ok(rows.length >= 11);
+    assert.ok(rows[0].date.startsWith('2004-11-'), `got ${rows[0].date}`);
   });
 
-  it('handles M/D/YYYY date format', () => {
-    const csv = `Date,Gold (Tonnes)
-4/10/2026,905.20`;
-    const rows = parseGldArchive(csv);
-    assert.equal(rows[0]?.date, '2026-04-10');
+  it('skips rows with zero or negative tonnage', async () => {
+    const good = Array.from({ length: 11 }, (_, i) => ({ date: spdrDate(daysAgoIso(i + 3)), tonnes: 900 + i }));
+    const bad = [
+      { date: spdrDate(daysAgoIso(1)), tonnes: 0 },
+      { date: spdrDate(daysAgoIso(2)), tonnes: -5 },
+    ];
+    const buf = await buildSyntheticXlsx([...good, ...bad]);
+    const rows = await parseGldArchiveXlsx(buf);
+    assert.equal(rows.length, 11, 'zero/negative tonnage rows dropped');
   });
 
-  it('skips rows with zero or negative tonnage', () => {
-    const csv = `Date,Gold (Tonnes)
-10-Apr-26,905.20
-09-Apr-26,0
-08-Apr-26,-5`;
-    const rows = parseGldArchive(csv);
-    assert.equal(rows.length, 1);
-    assert.equal(rows[0].tonnes, 905.20);
-  });
-
-  it('strips UTF-8 BOM from the first header cell', () => {
-    // Regression guard (PR #3037 review): SPDR has been observed serving the
-    // CSV with a leading UTF-8 BOM. Without stripping, findCol('date') would
-    // return -1 and parseGldArchive silently returns [].
-    const csv = `\uFEFFDate,Gold (Tonnes)
-10-Apr-26,905.20`;
-    const rows = parseGldArchive(csv);
-    assert.equal(rows.length, 1);
-    assert.equal(rows[0].tonnes, 905.20);
-  });
-
-  it('returns empty on malformed CSV', () => {
-    assert.deepEqual(parseGldArchive(''), []);
-    assert.deepEqual(parseGldArchive('junk\ndata'), []);
-  });
-
-  it('strips commas and dollar signs from numeric cells', () => {
-    const csv = `Date,Gold (Tonnes),Total Net Assets
-10-Apr-26,"905.20","$90,500,000,000"`;
-    const rows = parseGldArchive(csv);
-    assert.equal(rows[0].aum, 90500000000);
+  it('returns empty when the data sheet has fewer than 10 rows (too little to trust)', async () => {
+    const buf = await buildSyntheticXlsx([
+      { date: '10-Apr-2026', tonnes: 905.20 },
+      { date: '09-Apr-2026', tonnes: 904.10 },
+    ]);
+    const rows = await parseGldArchiveXlsx(buf);
+    assert.equal(rows.length, 0);
   });
 });
 
 describe('seed-gold-etf-flows: computeFlows', () => {
-  // Build a 260-day synthetic history (~1 trading year + slack)
   const buildHistory = (tonnesFn) => {
     const out = [];
     const start = new Date('2025-04-15T00:00:00Z');
@@ -84,7 +109,6 @@ describe('seed-gold-etf-flows: computeFlows', () => {
   });
 
   it('computes 1W / 1M / 1Y tonnage deltas correctly', () => {
-    // Linear +1 tonne/day
     const history = buildHistory(i => 800 + i);
     const flows = computeFlows(history);
     // latest = 800 + 259 = 1059; 5d ago = 1054 → +5 tonnes; 21d ago = 1038 → +21; 252d ago = 807 → +252
@@ -98,7 +122,7 @@ describe('seed-gold-etf-flows: computeFlows', () => {
     const history = buildHistory(i => 800 + i);
     const flows = computeFlows(history);
     assert.equal(flows.sparkline90d.length, 90);
-    assert.equal(flows.sparkline90d[0], 800 + 170); // 260 - 90 = index 170
+    assert.equal(flows.sparkline90d[0], 800 + 170);
     assert.equal(flows.sparkline90d[89], 1059);
   });
 
@@ -106,7 +130,6 @@ describe('seed-gold-etf-flows: computeFlows', () => {
     const history = buildHistory(i => 800 + i).slice(0, 10);
     const flows = computeFlows(history);
     assert.ok(flows !== null);
-    // With <5 days of prior data, changeW1 uses oldest row as baseline
     assert.ok(Number.isFinite(flows.changeW1Tonnes));
     assert.ok(Number.isFinite(flows.changeY1Tonnes));
   });

--- a/tests/seed-imf-extended.test.mjs
+++ b/tests/seed-imf-extended.test.mjs
@@ -144,43 +144,51 @@ describe('seed-imf-external', () => {
     assert.equal(EXTERNAL_TTL, 35 * 24 * 3600);
   });
 
-  it('buildExternalCountries computes trade balance from exports - imports', () => {
+  it('buildExternalCountries maps current account + volume changes and nulls out legacy BX/BM fields', () => {
+    // BX/BM (export/import levels in USD) were removed 2026-04 — WEO coverage
+    // dropped to ~10 countries on those indicators, collapsing the result
+    // below the validate floor. Fields remain on the output as explicit null
+    // so downstream consumers see a deliberate gap rather than a missing key.
     const countries = buildExternalCountries({
-      exports:        { USA: { [YEAR]: 3000 }, DEU: { [YEAR]: 2100 } },
-      imports:        { USA: { [YEAR]: 4000 }, DEU: { [YEAR]: 1750 } },
-      currentAccount: { USA: { [YEAR]: -800 } },
+      currentAccount: { USA: { [YEAR]: -800 }, DEU: { [YEAR]: 250 } },
       importVol:      { USA: { [YEAR]: 4.2 } },
       exportVol:      { USA: { [YEAR]: 3.1 } },
     });
-    assert.equal(countries.US.exportsUsd, 3000);
-    assert.equal(countries.US.importsUsd, 4000);
-    assert.equal(countries.US.tradeBalanceUsd, -1000);
+    assert.equal(countries.US.exportsUsd, null);
+    assert.equal(countries.US.importsUsd, null);
+    assert.equal(countries.US.tradeBalanceUsd, null);
     assert.equal(countries.US.currentAccountUsd, -800);
     assert.equal(countries.US.importVolumePctChg, 4.2);
     assert.equal(countries.US.exportVolumePctChg, 3.1);
 
-    // Germany has trade surplus.
-    assert.equal(countries.DE.tradeBalanceUsd, 350);
-    // CA / volumes absent → null
-    assert.equal(countries.DE.currentAccountUsd, null);
+    // Germany has only currentAccount — still included.
+    assert.equal(countries.DE.currentAccountUsd, 250);
+    assert.equal(countries.DE.importVolumePctChg, null);
   });
 
-  it('buildExternalCountries leaves trade balance null when only one side is reported', () => {
+  it('buildExternalCountries drops countries with no usable indicator data', () => {
     const countries = buildExternalCountries({
-      exports: { USA: { [YEAR]: 3000 } },
+      currentAccount: { USA: { [YEAR]: -800 } },
+      importVol: {},
+      exportVol: {},
     });
-    assert.equal(countries.US.exportsUsd, 3000);
-    assert.equal(countries.US.tradeBalanceUsd, null);
+    assert.equal(Object.keys(countries).length, 1);
+    assert.ok(countries.US);
   });
 
-  it('validate gates >=190 country coverage and rejects partial snapshots', () => {
+  it('validate gates >=180 country coverage (relaxed from 190 after BX/BM removal)', () => {
     const countries = {};
-    for (let i = 0; i < 200; i++) countries[`X${i}`] = { exportsUsd: 1, year: 2025 };
+    for (let i = 0; i < 200; i++) countries[`X${i}`] = { currentAccountUsd: 1, year: 2025 };
     assert.equal(validateExternal({ countries }), true);
 
+    // 180 is the new minimum (BCA ~209 / TM ~189 / TX ~190; union floor).
+    const at180 = {};
+    for (let i = 0; i < 180; i++) at180[`X${i}`] = { currentAccountUsd: 1, year: 2025 };
+    assert.equal(validateExternal({ countries: at180 }), true, 'exactly 180 passes');
+
     const partial = {};
-    for (let i = 0; i < 170; i++) partial[`X${i}`] = { exportsUsd: 1, year: 2025 };
-    assert.equal(validateExternal({ countries: partial }), false, 'rejects 170 countries (dozens missing)');
+    for (let i = 0; i < 170; i++) partial[`X${i}`] = { currentAccountUsd: 1, year: 2025 };
+    assert.equal(validateExternal({ countries: partial }), false, 'rejects 170 countries');
 
     assert.equal(validateExternal({ countries: {} }), false);
   });


### PR DESCRIPTION
## Why this PR?

Three seed regressions found by reading the market-backup + imf-extended bundle logs after Railway provisioned the new services. All three are upstream API drifts (not logic bugs in the seeders themselves), validated by live probes before coding.

## Fixes

### 1. `seed-gold-etf-flows.mjs` — SPDR API migration
SPDR's legacy CSV archive at `https://www.spdrgoldshares.com/assets/dynamic/GLD/GLD_US_archive_EN.csv` now silently returns a PDF (Content-Type: application/pdf, ~700 KB). The parser saw 0 CSV rows and threw "Parsed only 0 rows — SPDR format may have changed" on every run.

SPDR migrated to `https://api.spdrgoldshares.com/api/v1/historical-archive?product=gld&exchange=NYSE&lang=en` (XLSX, ~530 KB, sheet `US GLD Historical Archive`, ~5500 rows). Parse with `exceljs` (already in `scripts/package.json`). Column layout: Date=1, Closing=2, Tonnes=10, AUM=11. Browser-ish `Origin`/`Referer` headers are now required — SPDR swaps payload for PDF without them. Content-Type guard rejects non-spreadsheet responses loudly.

### 2. `seed-gold-cb-reserves.mjs` — wrong dataflow (PR #3038 regression)
My PR #3038 shipped with `IMF.STA/IFS` dataflow and 3-segment key `M..<indicator>`. Both wrong:
- `IMF.STA/IFS` returns HTTP 204 — IFS isn't exposed on api.imf.org.
- Gold-reserves data lives under `IMF.STA/IRFCL` (International Reserves and Foreign Currency Liquidity) with **4 dimensions**: `COUNTRY.INDICATOR.SECTOR.FREQUENCY`.
- Key requires explicit wildcards: `*.<indicator>.*.M` (empty segments → HTTP 400).

Verified live: `*.IRFCLDT1_IRFCL56_FTO.*.M` returns 111 series at ~798 KB. Switched indicators to `IRFCLDT1_IRFCL56_FTO` (preferred fine troy ounces), `IRFCLDT1_IRFCL56GB_FTO` (gold bullion only), `IRFCLDT1_IRFCL56UG_FTO` (unallocated gold), with `IRFCLDT1_IRFCL56_USD` as last-resort fallback. `valueIsOunces` detector now matches `_FTO` suffix.

### 3. `seed-imf-external.mjs` — BX/BM WEO coverage collapsed
WEO dataflow recently cut export/import **level** indicators (`BX`, `BM`) to only ~10 countries. Since the seeder joined on them, union coverage fell below the 190-country validate floor → SKIPPED every run.

Dropped `BX`/`BM` from fetch + join. Retained `BCA` (current account, ~209 countries), `TM_RPCH` (import volume %, ~189), `TX_RPCH` (export volume %, ~190). Output schema unchanged — `exportsUsd`/`importsUsd`/`tradeBalanceUsd` fields stay as explicit `null` so downstream consumers see a deliberate gap. `validate` floor lowered 190 → 180 to reflect union coverage.

## Files

- `scripts/seed-gold-etf-flows.mjs` — CSV parser replaced with XLSX (exceljs)
- `scripts/seed-gold-cb-reserves.mjs` — IFS → IRFCL, 3-seg key → 4-seg wildcard key
- `scripts/seed-imf-external.mjs` — drop BX/BM indicators, null out level fields
- `tests/gold-etf-flows-seed.test.mjs` — full rewrite w/ synthetic XLSX fixtures (exceljs resolved from `scripts/package.json`)
- `tests/seed-imf-extended.test.mjs` — updated to new indicator set + 180-country gate

## Test plan

- [x] `npm run typecheck` + `typecheck:api` clean
- [x] biome lint on all 5 files clean
- [x] Targeted tests 32/32 (gold-etf-flows + gold-cb-reserves + seed-imf-extended)
- [ ] After deploy: watch next market-backup + imf-extended bundle runs — `market:gold-etf-flows:v1`, `market:gold-cb-reserves:v1`, and `economic:imf:external:v1` should all populate.

## Post-Deploy Monitoring & Validation

- **Logs** (Railway):
  - `seed-bundle-market-backup`: `Gold-ETF-Flows` and `Gold-CB-Reserves` sections should show `Done` (not `Failed gracefully`)
  - `seed-bundle-imf-extended`: `IMF-External` should show `recordCount: 180+` (not `SKIPPED: validation failed`)
- **Redis**:
  - `GET market:gold-etf-flows:v1` → non-empty, `tonnes > 900`
  - `GET market:gold-cb-reserves:v1` → non-empty, `topHolders.length >= 10`
  - `GET economic:imf:external:v1` → `Object.keys(countries).length >= 180`
- **Health**: `/api/health` drops `goldEtfFlows`, `goldCbReserves`, `imfExternal` from EMPTY within 24h.
- **Rollback**: revert this commit; no data-destructive ops (seeders only write caches).
- **Validation window**: 24h post-deploy (covers 1 gold + 1 imf cycle).
- **Owner**: @koala73