### PR TITLE
fix(seed-economy): retry proxy/EIA transients; gate stress index on full FRED coverage

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -365,17 +365,28 @@ export async function httpsProxyFetchRaw(url, proxyAuth, { accept = '*/*', timeo
 // so try proxy first to avoid 20s timeout on every direct attempt.
 export async function fredFetchJson(url, proxyAuth) {
   if (proxyAuth) {
-    try {
-      return await httpsProxyFetchJson(url, proxyAuth);
-    } catch (proxyErr) {
-      console.warn(`  [fredFetch] proxy failed (${proxyErr.message}) — retrying direct`);
+    // Decodo proxy flaps on 5xx/522 — retry up to 3 times with backoff before falling back direct.
+    let lastProxyErr;
+    for (let attempt = 1; attempt <= 3; attempt++) {
       try {
-        const r = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(20_000) });
-        if (r.ok) return r.json();
-        throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
-      } catch (directErr) {
-        throw Object.assign(new Error(`direct: ${directErr.message}`), { cause: directErr });
+        return await httpsProxyFetchJson(url, proxyAuth);
+      } catch (proxyErr) {
+        lastProxyErr = proxyErr;
+        const transient = /HTTP 5\d{2}|522|timeout|ECONNRESET|ETIMEDOUT|EAI_AGAIN/i.test(proxyErr.message || '');
+        if (attempt < 3 && transient) {
+          await new Promise((r) => setTimeout(r, 400 * attempt + Math.random() * 300));
+          continue;
+        }
+        break;
       }
+    }
+    console.warn(`  [fredFetch] proxy failed after retries (${lastProxyErr?.message}) — retrying direct`);
+    try {
+      const r = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(20_000) });
+      if (r.ok) return r.json();
+      throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
+    } catch (directErr) {
+      throw Object.assign(new Error(`direct: ${directErr.message}`), { cause: directErr });
     }
   }
   const r = await fetch(url, { headers: { Accept: 'application/json' }, signal: AbortSignal.timeout(20_000) });

--- a/scripts/seed-economy.mjs
+++ b/scripts/seed-economy.mjs
@@ -35,6 +35,13 @@ const SPR_MIN_WEEKS = 4; // require at least 4 weeks to guard against quota-hit 
 const REFINERY_MIN_WEEKS = 4; // require at least 4 weeks to guard against quota-hit empty responses
 
 // EIA retries transient upstream failures: timeouts and 5xx. Returns parsed JSON.
+// 4xx and other non-network errors are thrown immediately (no retry).
+function isTransientFetchError(e) {
+  const msg = e?.message || '';
+  return e?.name === 'TimeoutError' || e?.name === 'AbortError' ||
+    /timeout|ECONNRESET|ETIMEDOUT|EAI_AGAIN|ENETUNREACH|ECONNREFUSED|socket hang up/i.test(msg);
+}
+
 async function eiaFetchJson(url, label, { timeoutMs = 20_000, attempts = 3 } = {}) {
   let lastErr;
   for (let i = 1; i <= attempts; i++) {
@@ -44,10 +51,13 @@ async function eiaFetchJson(url, label, { timeoutMs = 20_000, attempts = 3 } = {
         signal: AbortSignal.timeout(timeoutMs),
       });
       if (resp.ok) return await resp.json();
-      const err = new Error(`EIA ${label}: HTTP ${resp.status}`);
-      if (resp.status < 500 || i === attempts) throw err;
+      const err = Object.assign(new Error(`EIA ${label}: HTTP ${resp.status}`), { status: resp.status });
+      // Only 5xx is transient; 4xx is a permanent config/request error — bail immediately.
+      if (resp.status < 500) throw err;
       lastErr = err;
+      if (i === attempts) throw err;
     } catch (e) {
+      if (!isTransientFetchError(e) && !(e?.status >= 500)) throw e;
       lastErr = e;
       if (i === attempts) throw e;
     }
@@ -859,13 +869,14 @@ async function fetchAll() {
     } else {
       console.warn('  [StressIndex] GSCPI not in Redis yet (ais-relay lag or first run) — excluding');
     }
+    let stressResult = null;
     try {
-      const stressResult = computeStressIndex(fr);
-      if (stressResult) {
-        await writeExtraKeyWithMeta(STRESS_INDEX_KEY, stressResult, STRESS_INDEX_TTL, STRESS_COMPONENTS.length);
-      }
+      stressResult = computeStressIndex(fr);
     } catch (e) {
       console.warn(`  [StressIndex] skipped write — ${e.message}`);
+    }
+    if (stressResult) {
+      await writeExtraKeyWithMeta(STRESS_INDEX_KEY, stressResult, STRESS_INDEX_TTL, STRESS_COMPONENTS.length);
     }
   }
 

--- a/scripts/seed-economy.mjs
+++ b/scripts/seed-economy.mjs
@@ -34,6 +34,28 @@ export const REFINERY_INPUTS_TTL = 1_814_400; // 21 days (3× weekly)
 const SPR_MIN_WEEKS = 4; // require at least 4 weeks to guard against quota-hit empty responses
 const REFINERY_MIN_WEEKS = 4; // require at least 4 weeks to guard against quota-hit empty responses
 
+// EIA retries transient upstream failures: timeouts and 5xx. Returns parsed JSON.
+async function eiaFetchJson(url, label, { timeoutMs = 20_000, attempts = 3 } = {}) {
+  let lastErr;
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      const resp = await fetch(url, {
+        headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (resp.ok) return await resp.json();
+      const err = new Error(`EIA ${label}: HTTP ${resp.status}`);
+      if (resp.status < 500 || i === attempts) throw err;
+      lastErr = err;
+    } catch (e) {
+      lastErr = e;
+      if (i === attempts) throw e;
+    }
+    await new Promise((r) => setTimeout(r, 500 * i + Math.random() * 400));
+  }
+  throw lastErr;
+}
+
 const FRED_SERIES = ['WALCL', 'FEDFUNDS', 'T10Y2Y', 'UNRATE', 'CPIAUCSL', 'DGS10', 'VIXCLS', 'GDP', 'M2SL', 'DCOILWTICO', 'BAMLH0A0HYM2', 'ICSA', 'MORTGAGE30US', 'BAMLC0A0CM', 'SOFR', 'DGS1MO', 'DGS3MO', 'DGS6MO', 'DGS1', 'DGS2', 'DGS5', 'DGS30', 'T10Y3M', 'STLFSI4'];
 
 // ─── Economic Stress Index (computed last from FRED data in fetchAll) ───
@@ -118,7 +140,11 @@ function computeStressIndex(fr) {
 
     if (rawValue === null) {
       missingCount++;
-      if (comp.id !== 'GSCPI') console.warn(`  [StressIndex] ${comp.id} missing from FRED — excluding`);
+      if (comp.id !== 'GSCPI') {
+        // FRED-sourced component missing = refuse to publish degraded composite.
+        throw new Error(`StressIndex: required FRED component ${comp.id} missing — refusing to publish partial composite`);
+      }
+      console.warn(`  [StressIndex] ${comp.id} missing (ais-relay lag) — excluding`);
       components.push({ id: comp.id, label: comp.label, rawValue: null, missing: true, score: 0, weight: comp.weight });
       continue;
     }
@@ -163,12 +189,10 @@ async function fetchEnergyPrices() {
       'sort[0][direction]': 'desc',
       length: '2',
     });
-    const resp = await fetch(`https://api.eia.gov${c.apiPath}?${params}`, {
-      headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!resp.ok) { console.warn(`  EIA ${c.commodity}: HTTP ${resp.status}`); continue; }
-    const data = await resp.json();
+    let data;
+    try {
+      data = await eiaFetchJson(`https://api.eia.gov${c.apiPath}?${params}`, c.commodity);
+    } catch (e) { console.warn(`  EIA ${c.commodity}: ${e.message}`); continue; }
     const rows = data.response?.data;
     if (!rows || rows.length === 0) continue;
     const current = rows[0];
@@ -542,12 +566,7 @@ async function fetchCrudeInventories() {
     'sort[0][direction]': 'desc',
     length: '9', // fetch 9 so the oldest of 8 has a prior week for weeklyChangeMb
   });
-  const resp = await fetch(`https://api.eia.gov/v2/petroleum/stoc/wstk/data/?${params}`, {
-    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!resp.ok) throw new Error(`EIA WCRSTUS1: HTTP ${resp.status}`);
-  const data = await resp.json();
+  const data = await eiaFetchJson(`https://api.eia.gov/v2/petroleum/stoc/wstk/data/?${params}`, 'WCRSTUS1');
   const rows = data.response?.data;
   if (!rows || rows.length === 0) throw new Error('EIA WCRSTUS1: no data rows');
 
@@ -596,12 +615,7 @@ async function fetchNatGasStorage() {
     'sort[0][direction]': 'desc',
     length: '9', // fetch 9 so the oldest of 8 has a prior week for weeklyChangeBcf
   });
-  const resp = await fetch(`https://api.eia.gov/v2/natural-gas/stor/wkly/data/?${params}`, {
-    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!resp.ok) throw new Error(`EIA NW2_EPG0_SWO_R48_BCF: HTTP ${resp.status}`);
-  const data = await resp.json();
+  const data = await eiaFetchJson(`https://api.eia.gov/v2/natural-gas/stor/wkly/data/?${params}`, 'NW2_EPG0_SWO_R48_BCF');
   const rows = data.response?.data;
   if (!rows || rows.length === 0) throw new Error('EIA NW2_EPG0_SWO_R48_BCF: no data rows');
 
@@ -662,12 +676,7 @@ async function fetchSprLevels() {
     'sort[0][direction]': 'desc',
     length: '9', // fetch 9 so we can compute 4-week change
   });
-  const resp = await fetch(`https://api.eia.gov/v2/petroleum/stoc/wstk/data/?${params}`, {
-    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!resp.ok) throw new Error(`EIA WCSSTUS1: HTTP ${resp.status}`);
-  const data = await resp.json();
+  const data = await eiaFetchJson(`https://api.eia.gov/v2/petroleum/stoc/wstk/data/?${params}`, 'WCSSTUS1');
   const rows = data.response?.data;
   if (!rows || rows.length === 0) throw new Error('EIA WCSSTUS1: no data rows');
 
@@ -733,12 +742,7 @@ async function fetchRefineryInputs() {
     'sort[0][direction]': 'desc',
     length: '9', // fetch 9 so the oldest of 8 has a prior week for WoW change
   });
-  const resp = await fetch(`https://api.eia.gov/v2/petroleum/pnp/wiup/data/?${params}`, {
-    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!resp.ok) throw new Error(`EIA WCRRIUS2: HTTP ${resp.status}`);
-  const data = await resp.json();
+  const data = await eiaFetchJson(`https://api.eia.gov/v2/petroleum/pnp/wiup/data/?${params}`, 'WCRRIUS2');
   const rows = data.response?.data;
   if (!rows || rows.length === 0) throw new Error('EIA WCRRIUS2: no data rows');
 
@@ -855,9 +859,13 @@ async function fetchAll() {
     } else {
       console.warn('  [StressIndex] GSCPI not in Redis yet (ais-relay lag or first run) — excluding');
     }
-    const stressResult = computeStressIndex(fr);
-    if (stressResult) {
-      await writeExtraKeyWithMeta(STRESS_INDEX_KEY, stressResult, STRESS_INDEX_TTL, STRESS_COMPONENTS.length);
+    try {
+      const stressResult = computeStressIndex(fr);
+      if (stressResult) {
+        await writeExtraKeyWithMeta(STRESS_INDEX_KEY, stressResult, STRESS_INDEX_TTL, STRESS_COMPONENTS.length);
+      }
+    } catch (e) {
+      console.warn(`  [StressIndex] skipped write — ${e.message}`);
     }
   }
 


### PR DESCRIPTION
## Summary
Log review of 16 seed-economy runs (2026-04-14 00:45–04:31 UTC) showed 50% degraded, 2 `no write` failures, and silent StressIndex degradation. Zero-tolerance fixes:

- **`fredFetchJson`**: retry Decodo proxy 3× with jittered backoff on 5xx/522/timeout before falling back direct (was: one direct retry → FRED's datacenter 500 instantly dropped the series).
- **New `eiaFetchJson` helper**: 20s timeout (was 10s) + 3× retry on 5xx/timeout. Wired into all 5 EIA call-sites (energy prices, crude, nat-gas, SPR, refinery). Eliminates the lockstep timeout cascade that produced full `no write` runs at 01:00 and 02:00.
- **StressIndex**: throw when any FRED-sourced component (T10Y2Y, T10Y3M, VIXCLS, STLFSI4, ICSA) is missing — no more silently-degraded composites (same bug class as PR #3072). GSCPI (ais-relay) still tolerated as absent. Caught in `fetchAll` so other secondary writes proceed.

No cadence, TTL, or key changes.

## Test plan
- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` (no new errors)
- [x] `npm run test:data` — 5174/5174 pass
- [x] `node --test tests/edge-functions.test.mjs` — 167/167 pass
- [x] `npm run lint:md` / `version:check`
- [x] esbuild edge bundle check (all api/*.js)
- [ ] Observe next 24h of Railway `seed-economy` logs for FRED 24/24 rate and absence of `StressIndex … missing` + silent composite writes