### PR TITLE
fix(mcp): preserve response labels and enforce seed coverage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,7 @@
 - [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
 - [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
 - [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
+- [ ] New canonical seed data is exposed via MCP in `api/mcp.ts` (or intentionally covered by an existing MCP tool)
 - [ ] No API keys or secrets committed
 - [ ] TypeScript compiles without errors (`npm run typecheck`)
 

--- a/api/health.js
+++ b/api/health.js
@@ -100,6 +100,7 @@ const BOOTSTRAP_KEYS = {
 
 const STANDALONE_KEYS = {
   serviceStatuses:       'infra:service-statuses:v1',
+  submarineCables:       'infrastructure:submarine-cables:v1',
   macroSignals:          'economic:macro-signals:v1',
   bisPolicy:             'economic:bis:policy:v1',
   bisExchange:           'economic:bis:eer:v1',
@@ -130,6 +131,7 @@ const STANDALONE_KEYS = {
   cableHealth:           'cable-health-v1',
   cyberThreatsRpc:       'cyber:threats:v2',
   militaryBases:         'military:bases:active',
+  defensePatents:        'patents:defense:latest',
   militaryFlights:       'military:flights:v1',
   militaryFlightsStale:  'military:flights:stale:v1',
   temporalAnomalies:     'temporal:anomalies:v1',
@@ -138,6 +140,7 @@ const STANDALONE_KEYS = {
   satellites:            'intelligence:satellites:tle:v1',
   portwatch:             'supply_chain:portwatch:v1',
   portwatchPortActivity: 'supply_chain:portwatch-ports:v1:_countries',
+  portwatchDisruptions:  'portwatch:disruptions:active:v1',
   corridorrisk:          'supply_chain:corridorrisk:v1',
   chokepointTransits:    'supply_chain:chokepoint_transits:v1',
   transitSummaries:      'supply_chain:transit-summaries:v1',
@@ -183,6 +186,7 @@ const STANDALONE_KEYS = {
   goldExtended:             'market:gold-extended:v1',
   goldEtfFlows:             'market:gold-etf-flows:v1',
   goldCbReserves:           'market:gold-cb-reserves:v1',
+  sharedFxRates:            'shared:fx-rates:v1',
 };
 
 const SEED_META = {
@@ -214,6 +218,7 @@ const SEED_META = {
   goldCbReserves:   { key: 'seed-meta:market:gold-cb-reserves', maxStaleMin: 44640 }, // IMF IFS is monthly w/ ~2-3mo lag; 31d tolerance
   // RPC/warm-ping keys — seed-meta written by relay loops or handlers
   // serviceStatuses: moved to ON_DEMAND — RPC-populated, no dedicated seed, goes stale when no users visit
+  submarineCables: { key: 'seed-meta:infrastructure:submarine-cables', maxStaleMin: 20160 }, // weekly cron; 20160min = 14d = 2x interval
   cableHealth:      { key: 'seed-meta:cable-health',              maxStaleMin: 90 }, // ais-relay warm-ping runs every 30min; 90min = 3× interval catches missed pings without false positives
   macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 20 },
   bisPolicy:        { key: 'seed-meta:economic:bis',              maxStaleMin: 10080 }, // runSeed('economic','bis',...) writes seed-meta:economic:bis
@@ -242,6 +247,7 @@ const SEED_META = {
   weatherAlerts:    { key: 'seed-meta:weather:alerts',             maxStaleMin: 45 }, // relay loop every 15min; 45 = 3× interval (was 30 = 2×, too tight on relay hiccup)
   spending:         { key: 'seed-meta:economic:spending',          maxStaleMin: 120 },
   techEvents:       { key: 'seed-meta:research:tech-events',       maxStaleMin: 480 },
+  defensePatents:   { key: 'seed-meta:military:defense-patents',   maxStaleMin: 20160 }, // weekly cron; 20160min = 14d = 2x interval
   gdeltIntel:       { key: 'seed-meta:intelligence:gdelt-intel',   maxStaleMin: 420 }, // 6h cron + 1h grace; CACHE_TTL is 24h so per-topic merge always has a prior snapshot
   forecasts:        { key: 'seed-meta:forecast:predictions',       maxStaleMin: 90 },
   sectors:          { key: 'seed-meta:market:sectors',             maxStaleMin: 30 },
@@ -254,6 +260,7 @@ const SEED_META = {
   correlationCards: { key: 'seed-meta:correlation:cards',       maxStaleMin: 15 },
   portwatch:           { key: 'seed-meta:supply_chain:portwatch',            maxStaleMin: 720 },
   portwatchPortActivity: { key: 'seed-meta:supply_chain:portwatch-ports',   maxStaleMin: 2160 }, // 12h cron; 2160min = 36h = 3x interval
+  portwatchDisruptions: { key: 'seed-meta:portwatch:disruptions',            maxStaleMin: 120 }, // hourly cron; 120min = 2x interval
   corridorrisk:        { key: 'seed-meta:supply_chain:corridorrisk',         maxStaleMin: 120 },
   chokepointTransits:  { key: 'seed-meta:supply_chain:chokepoint_transits',  maxStaleMin: 30 }, // relay every 10min; 30min = 3x interval,
   transitSummaries:    { key: 'seed-meta:supply_chain:transit-summaries',    maxStaleMin: 30 }, // relay every 10min; 30min = 3x interval,
@@ -302,6 +309,7 @@ const SEED_META = {
   spr:               { key: 'seed-meta:economic:spr',                 maxStaleMin: 20160 }, // weekly EIA data; 20160min = 14 days = 2x weekly cadence
   refineryInputs:    { key: 'seed-meta:economic:refinery-inputs',     maxStaleMin: 20160 }, // weekly EIA data; 20160min = 14 days = 2x weekly cadence
   ecbFxRates:        { key: 'seed-meta:economic:ecb-fx-rates',        maxStaleMin: 5760 }, // daily seed (weekdays + holidays); 5760min = 96h = covers Wed→Mon Easter gap
+  sharedFxRates:     { key: 'seed-meta:shared:fx-rates',              maxStaleMin: 1500 }, // daily seed; 1500min = 25h = 24h cadence + 1h drift buffer
   eurostatCountryData: { key: 'seed-meta:economic:eurostat-country-data', maxStaleMin: 4320 }, // daily seed; 4320min = 3 days = 3x interval
   eurostatHousePrices: { key: 'seed-meta:economic:eurostat-house-prices', maxStaleMin: 60 * 24 * 50 }, // weekly cron, annual data; 50d threshold = 35d TTL + 15d buffer
   eurostatGovDebtQ:    { key: 'seed-meta:economic:eurostat-gov-debt-q',   maxStaleMin: 60 * 24 * 14 }, // 2d cron, quarterly data; 14d threshold matches TTL + quarterly release drift

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -59,6 +59,7 @@ interface CacheToolDef extends BaseToolDef {
   _seedMetaKey: string;
   _maxStaleMin: number;
   _freshnessChecks?: FreshnessCheck[];
+  _outputLabels?: Record<string, string>;
   _execute?: never;
 }
 
@@ -68,15 +69,16 @@ interface RpcToolDef extends BaseToolDef {
   _seedMetaKey?: never;
   _maxStaleMin?: never;
   _freshnessChecks?: never;
+  _outputLabels?: never;
   _execute: (params: Record<string, unknown>, base: string, apiKey: string) => Promise<unknown>;
 }
 
 type ToolDef = CacheToolDef | RpcToolDef;
 
-const TOOL_REGISTRY: ToolDef[] = [
+export const TOOL_REGISTRY: ToolDef[] = [
   {
     name: 'get_market_data',
-    description: 'Real-time equity quotes, commodity prices (including gold futures GC=F), crypto prices, forex FX rates (USD/EUR, USD/JPY etc.), sector performance, ETF flows, and Gulf market quotes from WorldMonitor\'s curated bootstrap cache.',
+    description: 'Real-time market dashboard: equity and commodity quotes, crypto prices, crypto sector breadth, stablecoin peg health, shared FX rates, ETF flows, sector performance, fear/greed, and Gulf market quotes. Useful for cross-asset risk and sentiment checks.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'market:stocks-bootstrap:v1',
@@ -86,9 +88,28 @@ const TOOL_REGISTRY: ToolDef[] = [
       'market:etf-flows:v1',
       'market:gulf-quotes:v1',
       'market:fear-greed:v1',
+      'market:crypto-sectors:v1',
+      'market:stablecoins:v1',
+      'shared:fx-rates:v1',
     ],
     _seedMetaKey: 'seed-meta:market:stocks',
     _maxStaleMin: 30,
+    _freshnessChecks: [
+      { key: 'seed-meta:market:stocks', maxStaleMin: 30 },
+      { key: 'seed-meta:market:commodities', maxStaleMin: 30 },
+      { key: 'seed-meta:market:crypto', maxStaleMin: 30 },
+      { key: 'seed-meta:market:sectors', maxStaleMin: 30 },
+      { key: 'seed-meta:market:etf-flows', maxStaleMin: 60 },
+      { key: 'seed-meta:market:gulf-quotes', maxStaleMin: 30 },
+      { key: 'seed-meta:market:fear-greed', maxStaleMin: 720 },
+      { key: 'seed-meta:market:crypto-sectors', maxStaleMin: 120 },
+      { key: 'seed-meta:market:stablecoins', maxStaleMin: 60 },
+      { key: 'seed-meta:shared:fx-rates', maxStaleMin: 1500 },
+    ],
+    _outputLabels: {
+      'market:crypto-sectors:v1': 'crypto_sectors',
+      'shared:fx-rates:v1': 'fx_rates',
+    },
   },
   {
     name: 'get_conflict_events',
@@ -113,48 +134,71 @@ const TOOL_REGISTRY: ToolDef[] = [
   },
   {
     name: 'get_news_intelligence',
-    description: 'AI-classified geopolitical threat news summaries, GDELT intelligence signals, cross-source signals, and security advisories from WorldMonitor\'s intelligence layer.',
+    description: 'AI-classified geopolitical intelligence: news summaries, GDELT signals, cross-source corroboration, and official security advisories. Useful for grounding a situation report in current reporting and government warnings.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'news:insights:v1',
       'intelligence:gdelt-intel:v1',
       'intelligence:cross-source-signals:v1',
       'intelligence:advisories-bootstrap:v1',
+      'intelligence:advisories:v1',
     ],
     _seedMetaKey: 'seed-meta:news:insights',
     _maxStaleMin: 30,
+    _freshnessChecks: [
+      { key: 'seed-meta:news:insights', maxStaleMin: 30 },
+      { key: 'seed-meta:intelligence:gdelt-intel', maxStaleMin: 420 },
+      { key: 'seed-meta:intelligence:cross-source-signals', maxStaleMin: 30 },
+      { key: 'seed-meta:intelligence:advisories', maxStaleMin: 120 },
+    ],
+    _outputLabels: {
+      'intelligence:advisories:v1': 'security_advisories',
+    },
   },
   {
     name: 'get_natural_disasters',
-    description: 'Recent earthquakes (USGS), active wildfires (NASA FIRMS), and natural hazard events. Includes magnitude, location, and threat severity.',
+    description: 'Recent earthquakes (USGS), active wildfires (NASA FIRMS), natural hazard events, and thermal escalation clusters derived from wildfire heat signatures. Use for disaster monitoring and fast-moving environmental escalation.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'seismology:earthquakes:v1',
       'wildfire:fires:v1',
       'natural:events:v1',
+      'thermal:escalation:v1',
     ],
     _seedMetaKey: 'seed-meta:seismology:earthquakes',
     _maxStaleMin: 30,
+    _freshnessChecks: [
+      { key: 'seed-meta:seismology:earthquakes', maxStaleMin: 30 },
+      { key: 'seed-meta:wildfire:fires', maxStaleMin: 360 },
+      { key: 'seed-meta:natural:events', maxStaleMin: 360 },
+      { key: 'seed-meta:thermal:escalation', maxStaleMin: 360 },
+    ],
+    _outputLabels: {
+      'thermal:escalation:v1': 'thermal_escalation',
+    },
   },
   {
     name: 'get_military_posture',
     description: 'Theater posture assessment and military risk scores. Reflects aggregated military positioning and escalation signals across global theaters.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: ['theater_posture:sebuf:stale:v1'],
-    _seedMetaKey: 'seed-meta:intelligence:risk-scores',
-    _maxStaleMin: 120,
+    _seedMetaKey: 'seed-meta:theater-posture',
+    _maxStaleMin: 60,
   },
   {
     name: 'get_cyber_threats',
-    description: 'Active cyber threat intelligence: malware IOCs (URLhaus, Feodotracker), CISA known exploited vulnerabilities, and active command-and-control infrastructure.',
+    description: 'Active cyber threat intelligence from WorldMonitor\'s bootstrap and canonical feeds: malware IOCs (URLhaus, Feodotracker), CISA known exploited vulnerabilities, command-and-control infrastructure, and deduplicated threat records.',
     inputSchema: { type: 'object', properties: {}, required: [] },
-    _cacheKeys: ['cyber:threats-bootstrap:v2'],
+    _cacheKeys: ['cyber:threats-bootstrap:v2', 'cyber:threats:v2'],
     _seedMetaKey: 'seed-meta:cyber:threats',
     _maxStaleMin: 240,
+    _outputLabels: {
+      'cyber:threats:v2': 'threats',
+    },
   },
   {
     name: 'get_economic_data',
-    description: 'Macro economic indicators: Fed Funds rate (FRED), economic calendar events, fuel prices, ECB FX rates, EU yield curve, earnings calendar, COT positioning, energy storage data, BIS household debt service ratio (DSR, quarterly, leading indicator of household financial stress across ~40 advanced economies), and BIS residential + commercial property price indices (real, quarterly).',
+    description: 'Macro and real-economy bundle: Fed Funds, economic calendar, fuel prices, ECB FX, EU yield curve, earnings calendar, COT positioning, BIS household stress/property series, World Bank tech-readiness/progress/renewable snapshots, national debt, Big Mac PPP, grocery basket prices, FAO food inflation, Eurostat country data, and curated US BLS series.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'economic:fred:v1:FEDFUNDS:0',
@@ -168,11 +212,27 @@ const TOOL_REGISTRY: ToolDef[] = [
       'economic:bis:dsr:v1',
       'economic:bis:property-residential:v1',
       'economic:bis:property-commercial:v1',
+      'economic:worldbank-techreadiness:v1',
+      'economic:worldbank-progress:v1',
+      'economic:worldbank-renewable:v1',
+      'economic:national-debt:v1',
+      'economic:bigmac:v1',
+      'economic:grocery-basket:v1',
+      'economic:fao-ffpi:v1',
+      'economic:eurostat-country-data:v1',
+      'bls:series:v1',
     ],
     _seedMetaKey: 'seed-meta:economic:econ-calendar',
     _maxStaleMin: 1440,
     _freshnessChecks: [
+      { key: 'seed-meta:economic:fred:v1:FEDFUNDS:0', maxStaleMin: 1500 },
       { key: 'seed-meta:economic:econ-calendar', maxStaleMin: 1440 },
+      { key: 'seed-meta:economic:fuel-prices', maxStaleMin: 10080 },
+      { key: 'seed-meta:economic:ecb-fx-rates', maxStaleMin: 5760 },
+      { key: 'seed-meta:economic:yield-curve-eu', maxStaleMin: 4320 },
+      { key: 'seed-meta:economic:spending', maxStaleMin: 120 },
+      { key: 'seed-meta:market:earnings-calendar', maxStaleMin: 1440 },
+      { key: 'seed-meta:market:cot', maxStaleMin: 14400 },
       // Per-dataset BIS seed-meta keys — the aggregate
       // `seed-meta:economic:bis-extended` would report "fresh" even if only
       // one of the three datasets (DSR / SPP / CPP) is current, matching the
@@ -180,7 +240,27 @@ const TOOL_REGISTRY: ToolDef[] = [
       { key: 'seed-meta:economic:bis-dsr', maxStaleMin: 1440 }, // 12h cron × 2
       { key: 'seed-meta:economic:bis-property-residential', maxStaleMin: 1440 },
       { key: 'seed-meta:economic:bis-property-commercial', maxStaleMin: 1440 },
+      { key: 'seed-meta:economic:worldbank-techreadiness:v1', maxStaleMin: 10080 },
+      { key: 'seed-meta:economic:worldbank-progress:v1', maxStaleMin: 10080 },
+      { key: 'seed-meta:economic:worldbank-renewable:v1', maxStaleMin: 10080 },
+      { key: 'seed-meta:economic:national-debt', maxStaleMin: 10080 },
+      { key: 'seed-meta:economic:bigmac', maxStaleMin: 10080 },
+      { key: 'seed-meta:economic:grocery-basket', maxStaleMin: 10080 },
+      { key: 'seed-meta:economic:fao-ffpi', maxStaleMin: 86400 },
+      { key: 'seed-meta:economic:eurostat-country-data', maxStaleMin: 4320 },
+      { key: 'seed-meta:economic:bls-series', maxStaleMin: 2880 },
     ],
+    _outputLabels: {
+      'economic:worldbank-techreadiness:v1': 'tech_readiness',
+      'economic:worldbank-progress:v1': 'worldbank_progress',
+      'economic:worldbank-renewable:v1': 'renewable_energy',
+      'economic:national-debt:v1': 'national_debt',
+      'economic:bigmac:v1': 'bigmac_index',
+      'economic:grocery-basket:v1': 'grocery_basket',
+      'economic:fao-ffpi:v1': 'fao_food_price_index',
+      'economic:eurostat-country-data:v1': 'eurostat_country_data',
+      'bls:series:v1': 'bls_series',
+    },
   },
   {
     name: 'get_country_macro',
@@ -260,23 +340,129 @@ const TOOL_REGISTRY: ToolDef[] = [
   },
   {
     name: 'get_infrastructure_status',
-    description: 'Internet infrastructure health: Cloudflare Radar outages and service status for major cloud providers and internet services.',
+    description: 'Operational infrastructure watch: internet outages, major cloud/software service-status pages, and submarine cable network topology. Useful for outage triage, dependency monitoring, and communications-route context.',
     inputSchema: { type: 'object', properties: {}, required: [] },
-    _cacheKeys: ['infra:outages:v1'],
+    _cacheKeys: [
+      'infra:outages:v1',
+      'infra:service-statuses:v1',
+      'infrastructure:submarine-cables:v1',
+    ],
     _seedMetaKey: 'seed-meta:infra:outages',
     _maxStaleMin: 30,
+    _freshnessChecks: [
+      { key: 'seed-meta:infra:outages', maxStaleMin: 30 },
+      { key: 'seed-meta:infra:service-statuses', maxStaleMin: 60 },
+      { key: 'seed-meta:infrastructure:submarine-cables', maxStaleMin: 20160 },
+    ],
+    _outputLabels: {
+      'infra:service-statuses:v1': 'service_statuses',
+      'infrastructure:submarine-cables:v1': 'submarine_cables',
+    },
   },
   {
     name: 'get_supply_chain_data',
-    description: 'Dry bulk shipping stress index, customs revenue flows, and COMTRADE bilateral trade data. Tracks global supply chain pressure and trade disruptions.',
+    description: 'Global supply-chain and maritime access data: shipping stress, customs revenue, COMTRADE flows, Strait of Hormuz tracker, PortWatch chokepoint and port-activity snapshots, and active port disruptions.',
     inputSchema: { type: 'object', properties: {}, required: [] },
     _cacheKeys: [
       'supply_chain:shipping_stress:v1',
       'trade:customs-revenue:v1',
       'comtrade:flows:v1',
+      'supply_chain:hormuz_tracker:v1',
+      'supply_chain:portwatch:v1',
+      'supply_chain:portwatch-ports:v1:_countries',
+      'portwatch:chokepoints:ref:v1',
+      'portwatch:disruptions:active:v1',
     ],
     _seedMetaKey: 'seed-meta:trade:customs-revenue',
     _maxStaleMin: 2880,
+    _freshnessChecks: [
+      { key: 'seed-meta:supply_chain:shipping_stress', maxStaleMin: 45 },
+      { key: 'seed-meta:trade:customs-revenue', maxStaleMin: 1440 },
+      { key: 'seed-meta:trade:comtrade-flows', maxStaleMin: 2880 },
+      { key: 'seed-meta:supply_chain:hormuz_tracker', maxStaleMin: 2880 },
+      { key: 'seed-meta:supply_chain:portwatch', maxStaleMin: 720 },
+      { key: 'seed-meta:supply_chain:portwatch-ports', maxStaleMin: 2160 },
+      { key: 'seed-meta:portwatch:chokepoints-ref', maxStaleMin: 20160 },
+      { key: 'seed-meta:portwatch:disruptions', maxStaleMin: 120 },
+    ],
+    _outputLabels: {
+      'supply_chain:portwatch-ports:v1:_countries': 'port_activity_by_country',
+      'portwatch:chokepoints:ref:v1': 'portwatch_chokepoints',
+      'portwatch:disruptions:active:v1': 'portwatch_disruptions',
+    },
+  },
+  {
+    name: 'get_resilience_recovery',
+    description: 'Country recovery-capacity indicators across fiscal space, reserve adequacy, debt-vs-reserves, import concentration, and strategic fuel stocks. Monthly cross-country resilience inputs for recovery and shock-absorption analysis.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    _cacheKeys: [
+      'resilience:recovery:fiscal-space:v1',
+      'resilience:recovery:reserve-adequacy:v1',
+      'resilience:recovery:external-debt:v1',
+      'resilience:recovery:import-hhi:v1',
+      'resilience:recovery:fuel-stocks:v1',
+    ],
+    _seedMetaKey: 'seed-meta:resilience:recovery:fiscal-space',
+    _maxStaleMin: 86400,
+    _freshnessChecks: [
+      { key: 'seed-meta:resilience:recovery:fiscal-space', maxStaleMin: 86400 },
+      { key: 'seed-meta:resilience:recovery:reserve-adequacy', maxStaleMin: 86400 },
+      { key: 'seed-meta:resilience:recovery:external-debt', maxStaleMin: 86400 },
+      { key: 'seed-meta:resilience:recovery:import-hhi', maxStaleMin: 86400 },
+      { key: 'seed-meta:resilience:recovery:fuel-stocks', maxStaleMin: 86400 },
+    ],
+    _outputLabels: {
+      'resilience:recovery:fiscal-space:v1': 'fiscal_space',
+      'resilience:recovery:reserve-adequacy:v1': 'reserve_adequacy',
+      'resilience:recovery:external-debt:v1': 'external_debt',
+      'resilience:recovery:import-hhi:v1': 'import_hhi',
+      'resilience:recovery:fuel-stocks:v1': 'fuel_stocks',
+    },
+  },
+  {
+    name: 'get_energy_security',
+    description: 'Energy-security and chokepoint data: EU gas storage, EIA baseline chokepoints, live chokepoint flow estimates, SPR registries, energy-crisis policies, IEA oil-stock coverage, JODI oil/gas balances, LNG import vulnerability, and curated energy intelligence headlines.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    _cacheKeys: [
+      'economic:eu-gas-storage:v1',
+      'energy:chokepoint-baselines:v1',
+      'energy:chokepoint-flows:v1',
+      'energy:crisis-policies:v1',
+      'energy:iea-oil-stocks:v1:index',
+      'energy:oil-stocks-analysis:v1',
+      'energy:intelligence:feed:v1',
+      'energy:jodi-gas:v1:_countries',
+      'energy:lng-vulnerability:v1',
+      'energy:jodi-oil:v1:_countries',
+      'energy:spr-policies:v1',
+    ],
+    _seedMetaKey: 'seed-meta:economic:eu-gas-storage',
+    _maxStaleMin: 2880,
+    _freshnessChecks: [
+      { key: 'seed-meta:economic:eu-gas-storage', maxStaleMin: 2880 },
+      { key: 'seed-meta:energy:chokepoint-baselines', maxStaleMin: 60 * 24 * 400 },
+      { key: 'seed-meta:energy:chokepoint-flows', maxStaleMin: 720 },
+      { key: 'seed-meta:energy:crisis-policies', maxStaleMin: 60 * 24 * 400 },
+      { key: 'seed-meta:energy:iea-oil-stocks', maxStaleMin: 60 * 24 * 40 },
+      { key: 'seed-meta:energy:oil-stocks-analysis', maxStaleMin: 60 * 24 * 50 },
+      { key: 'seed-meta:energy:intelligence', maxStaleMin: 720 },
+      { key: 'seed-meta:energy:jodi-gas', maxStaleMin: 60 * 24 * 40 },
+      { key: 'seed-meta:energy:jodi-oil', maxStaleMin: 60 * 24 * 40 },
+      { key: 'seed-meta:energy:spr-policies', maxStaleMin: 60 * 24 * 400 },
+    ],
+    _outputLabels: {
+      'economic:eu-gas-storage:v1': 'eu_gas_storage',
+      'energy:chokepoint-baselines:v1': 'chokepoint_baselines',
+      'energy:chokepoint-flows:v1': 'chokepoint_flows',
+      'energy:crisis-policies:v1': 'energy_crisis_policies',
+      'energy:iea-oil-stocks:v1:index': 'iea_oil_stocks',
+      'energy:oil-stocks-analysis:v1': 'oil_stocks_analysis',
+      'energy:intelligence:feed:v1': 'energy_intelligence',
+      'energy:jodi-gas:v1:_countries': 'jodi_gas_countries',
+      'energy:lng-vulnerability:v1': 'lng_vulnerability',
+      'energy:jodi-oil:v1:_countries': 'jodi_oil_countries',
+      'energy:spr-policies:v1': 'spr_policies',
+    },
   },
   {
     name: 'get_positive_events',
@@ -296,11 +482,61 @@ const TOOL_REGISTRY: ToolDef[] = [
   },
   {
     name: 'get_research_signals',
-    description: 'Tech and research event signals: emerging technology events bootstrap data from curated research feeds.',
+    description: 'Emerging technology and defense-innovation signals: curated tech event feed plus the latest defense and dual-use patent filings by strategic CPC category.',
     inputSchema: { type: 'object', properties: {}, required: [] },
-    _cacheKeys: ['research:tech-events-bootstrap:v1'],
+    _cacheKeys: ['research:tech-events-bootstrap:v1', 'patents:defense:latest'],
     _seedMetaKey: 'seed-meta:research:tech-events',
     _maxStaleMin: 480,
+    _freshnessChecks: [
+      { key: 'seed-meta:research:tech-events', maxStaleMin: 480 },
+      { key: 'seed-meta:military:defense-patents', maxStaleMin: 20160 },
+    ],
+    _outputLabels: {
+      'patents:defense:latest': 'defense_patents',
+    },
+  },
+  {
+    name: 'get_health_data',
+    description: 'Global health surveillance: WHO/CDC/outbreak feeds plus the ThinkGlobalHealth vaccine-preventable disease tracker. Returns realtime outbreak alerts and historical annual case series.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    _cacheKeys: [
+      'health:disease-outbreaks:v1',
+      'health:vpd-tracker:realtime:v1',
+      'health:vpd-tracker:historical:v1',
+    ],
+    _seedMetaKey: 'seed-meta:health:disease-outbreaks',
+    _maxStaleMin: 2880,
+    _freshnessChecks: [
+      { key: 'seed-meta:health:disease-outbreaks', maxStaleMin: 2880 },
+      { key: 'seed-meta:health:vpd-tracker', maxStaleMin: 2880 },
+    ],
+    _outputLabels: {
+      'health:disease-outbreaks:v1': 'disease_outbreaks',
+      'health:vpd-tracker:realtime:v1': 'vpd_realtime',
+      'health:vpd-tracker:historical:v1': 'vpd_historical',
+    },
+  },
+  {
+    name: 'get_regulatory_actions',
+    description: 'Latest high-signal regulatory actions from SEC, CFTC, Federal Reserve, FDIC, and FINRA feeds. Includes enforcement, rulemaking, guidance, and bank or systems-risk actions.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    _cacheKeys: ['regulatory:actions:v1'],
+    _seedMetaKey: 'seed-meta:regulatory:actions',
+    _maxStaleMin: 360,
+    _outputLabels: {
+      'regulatory:actions:v1': 'regulatory_actions',
+    },
+  },
+  {
+    name: 'get_correlation_signals',
+    description: 'Cross-domain correlation cards that fuse military, unrest, outages, disasters, markets, and news into fast-moving systemic signal clusters. Seeded every 5 minutes for situational correlation checks.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    _cacheKeys: ['correlation:cards-bootstrap:v1'],
+    _seedMetaKey: 'seed-meta:correlation:cards',
+    _maxStaleMin: 15,
+    _outputLabels: {
+      'correlation:cards-bootstrap:v1': 'correlation_cards',
+    },
   },
   {
     name: 'get_forecast_predictions',
@@ -774,6 +1010,16 @@ export function evaluateFreshness(checks: FreshnessCheck[], metas: unknown[], no
   };
 }
 
+function deriveCacheOutputLabel(key: string): string {
+  const parts = key.split(':');
+  const NON_LABEL = /^(v\d+|\d+|stale|sebuf|_countries|_all|latest|index|feed|ref|active)$/;
+  for (let idx = parts.length - 1; idx >= 0; idx--) {
+    const seg = parts[idx] ?? '';
+    if (!NON_LABEL.test(seg)) return seg;
+  }
+  return parts[0] ?? key;
+}
+
 // ---------------------------------------------------------------------------
 // Tool execution
 // ---------------------------------------------------------------------------
@@ -787,17 +1033,12 @@ async function executeTool(tool: CacheToolDef): Promise<{ cached_at: string | nu
   const { cached_at, stale } = evaluateFreshness(freshnessChecks, metas);
 
   const data: Record<string, unknown> = {};
-  // Walk backward through ':'-delimited segments, skipping non-informative suffixes
-  // (version tags, bare numbers, internal format names) to produce a readable label.
-  const NON_LABEL = /^(v\d+|\d+|stale|sebuf)$/;
   tool._cacheKeys.forEach((key, i) => {
-    const parts = key.split(':');
-    let label = '';
-    for (let idx = parts.length - 1; idx >= 0; idx--) {
-      const seg = parts[idx] ?? '';
-      if (!NON_LABEL.test(seg)) { label = seg; break; }
+    let label = tool._outputLabels?.[key] ?? deriveCacheOutputLabel(key);
+    if (!label || Object.prototype.hasOwnProperty.call(data, label)) {
+      label = key.replace(/[^a-zA-Z0-9]+/g, '_').replace(/^_+|_+$/g, '');
     }
-    data[label || (parts[0] ?? key)] = results[i];
+    data[label] = results[i];
   });
 
   return { cached_at, stale, data };

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -49,6 +49,7 @@ const SEED_DOMAINS = {
   'military:flights':         { key: 'seed-meta:military:flights',         intervalMin: 8 },
   'military-forecast-inputs': { key: 'seed-meta:military-forecast-inputs', intervalMin: 8 },
   'infra:service-statuses':   { key: 'seed-meta:infra:service-statuses',   intervalMin: 60 },
+  'infrastructure:submarine-cables': { key: 'seed-meta:infrastructure:submarine-cables', intervalMin: 10080 }, // weekly cron; intervalMin = maxStaleMin / 2 (20160 / 2)
   'supply_chain:shipping':    { key: 'seed-meta:supply_chain:shipping',    intervalMin: 120 },
   'supply_chain:chokepoints': { key: 'seed-meta:supply_chain:chokepoints', intervalMin: 30 },
   'cable-health':             { key: 'seed-meta:cable-health',             intervalMin: 30 },
@@ -74,6 +75,7 @@ const SEED_DOMAINS = {
   'health:air-quality':       { key: 'seed-meta:health:air-quality',       intervalMin: 60 },  // hourly cron (shared seeder writes health + climate keys)
   'economic:grocery-basket':  { key: 'seed-meta:economic:grocery-basket',  intervalMin: 5040 }, // weekly seed; intervalMin = maxStaleMin / 2
   'economic:bigmac':          { key: 'seed-meta:economic:bigmac',          intervalMin: 5040 }, // weekly seed; intervalMin = maxStaleMin / 2
+  'shared:fx-rates':          { key: 'seed-meta:shared:fx-rates',          intervalMin: 750 }, // daily seed; intervalMin = maxStaleMin / 2 (1500 / 2)
   'resilience:static':        { key: 'seed-meta:resilience:static',        intervalMin: 288000 }, // annual October snapshot; intervalMin = health.js maxStaleMin / 2 (400d alert threshold)
   'resilience:intervals':     { key: 'seed-meta:resilience:intervals',     intervalMin: 10080 }, // weekly cron; intervalMin = health.js maxStaleMin / 2 (20160 / 2)
   'regulatory:actions':       { key: 'seed-meta:regulatory:actions',       intervalMin: 120 }, // 2h cron; intervalMin = maxStaleMin / 3
@@ -85,11 +87,13 @@ const SEED_DOMAINS = {
   'product-catalog':          { key: 'seed-meta:product-catalog',          intervalMin: 360 }, // relay loop every 6h; intervalMin = health.js maxStaleMin / 3 (1080 / 3)
   'portwatch:chokepoints-ref': { key: 'seed-meta:portwatch:chokepoints-ref', intervalMin: 10080 }, // seed-bundle-portwatch runs this at WEEK cadence; intervalMin*2 = 14d matches api/health.js SEED_META.portwatchChokepointsRef
   'supply_chain:portwatch-ports': { key: 'seed-meta:supply_chain:portwatch-ports', intervalMin: 720 }, // 12h cron (0 */12 * * *); intervalMin = maxStaleMin / 3 (2160 / 3)
+  'portwatch:disruptions':    { key: 'seed-meta:portwatch:disruptions',    intervalMin: 60 }, // hourly cron; intervalMin = maxStaleMin / 2 (120 / 2)
   'energy:chokepoint-flows': { key: 'seed-meta:energy:chokepoint-flows', intervalMin: 360 }, // 6h relay loop; intervalMin = maxStaleMin / 2 (720 / 2)
   'energy:spine':                 { key: 'seed-meta:energy:spine',                 intervalMin: 1440 }, // daily cron (0 6 * * *); intervalMin = maxStaleMin / 2 (2880 / 2)
   'energy:ember': { key: 'seed-meta:energy:ember', intervalMin: 1440 }, // daily cron (0 8 * * *); intervalMin = maxStaleMin / 2 (2880 / 2)
   'energy:spr-policies': { key: 'seed-meta:energy:spr-policies', intervalMin: 288000 }, // annual static registry; intervalMin = health.js maxStaleMin / 2 (576000 / 2)
   'market:aaii-sentiment': { key: 'seed-meta:market:aaii-sentiment', intervalMin: 10080 }, // weekly cron; intervalMin = maxStaleMin / 2 (20160 / 2)
+  'military:defense-patents': { key: 'seed-meta:military:defense-patents', intervalMin: 10080 }, // weekly cron; intervalMin = maxStaleMin / 2 (20160 / 2)
   'intelligence:regional-briefs': { key: 'seed-meta:intelligence:regional-briefs', intervalMin: 10080 }, // weekly cron; intervalMin = health.js maxStaleMin / 2 (20160 / 2)
   'economic:eurostat-house-prices': { key: 'seed-meta:economic:eurostat-house-prices', intervalMin: 36000 }, // weekly cron, annual data; intervalMin = health.js maxStaleMin / 2 (72000 / 2)
   'economic:eurostat-gov-debt-q':   { key: 'seed-meta:economic:eurostat-gov-debt-q',   intervalMin: 10080 }, // 2d cron, quarterly data; intervalMin = health.js maxStaleMin / 2 (20160 / 2)

--- a/tests/mcp-seed-coverage.test.mjs
+++ b/tests/mcp-seed-coverage.test.mjs
@@ -1,0 +1,137 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+import { TOOL_REGISTRY } from '../api/mcp.ts';
+
+const REPO_ROOT = new URL('..', import.meta.url).pathname;
+const SCRIPTS_DIR = join(REPO_ROOT, 'scripts');
+const PUBLIC_SEED_KEY_RE = /(?:export\s+)?const\s+([A-Z0-9_]+)\s*=\s*'([^']+)'/g;
+const MCP_VISIBLE_KEY_NAME_RE = /^(?:CANONICAL|BOOTSTRAP|HISTORICAL|ANALYSIS|PROGRESS|RENEWABLE)_KEY$|^[A-Z0-9_]*VULNERABILITY_KEY$|^(?:KEY|REDIS_KEY)$/;
+const MCP_HEALTH_BRIDGE_KEYS = [
+  {
+    healthName: 'sharedFxRates',
+    redisKey: 'shared:fx-rates:v1',
+    metaKey: 'seed-meta:shared:fx-rates',
+    seedDomain: 'shared:fx-rates',
+  },
+  {
+    healthName: 'submarineCables',
+    redisKey: 'infrastructure:submarine-cables:v1',
+    metaKey: 'seed-meta:infrastructure:submarine-cables',
+    seedDomain: 'infrastructure:submarine-cables',
+  },
+  {
+    healthName: 'portwatchDisruptions',
+    redisKey: 'portwatch:disruptions:active:v1',
+    metaKey: 'seed-meta:portwatch:disruptions',
+    seedDomain: 'portwatch:disruptions',
+  },
+  {
+    healthName: 'defensePatents',
+    redisKey: 'patents:defense:latest',
+    metaKey: 'seed-meta:military:defense-patents',
+    seedDomain: 'military:defense-patents',
+  },
+];
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const file = join(dir, name);
+    const stat = statSync(file);
+    if (stat.isDirectory()) {
+      out.push(...walk(file));
+    } else {
+      out.push(file);
+    }
+  }
+  return out;
+}
+
+function collectSeedPublicKeys() {
+  const entries = [];
+  for (const file of walk(SCRIPTS_DIR).filter((path) => /seed-.*\.mjs$/.test(path))) {
+    const text = readFileSync(file, 'utf8');
+    for (const match of text.matchAll(PUBLIC_SEED_KEY_RE)) {
+      const [, name, key] = match;
+      if (!MCP_VISIBLE_KEY_NAME_RE.test(name)) continue;
+      entries.push({ key, file: relative(REPO_ROOT, file), name });
+    }
+  }
+  return entries;
+}
+
+describe('MCP seed coverage', () => {
+  it('exposes every MCP-visible seed key declared in scripts/seed-*.mjs', () => {
+    const publicEntries = collectSeedPublicKeys();
+    assert.ok(publicEntries.length >= 65, `expected >=65 MCP-visible seed keys, found ${publicEntries.length}`);
+
+    for (const key of [
+      'health:vpd-tracker:historical:v1',
+      'intelligence:advisories-bootstrap:v1',
+      'energy:oil-stocks-analysis:v1',
+      'energy:lng-vulnerability:v1',
+      'economic:worldbank-techreadiness:v1',
+      'economic:worldbank-progress:v1',
+      'economic:worldbank-renewable:v1',
+    ]) {
+      assert.ok(
+        publicEntries.some((entry) => entry.key === key),
+        `coverage scan missed public companion key ${key}`,
+      );
+    }
+
+    const duplicates = publicEntries.filter(
+      (entry, idx) => publicEntries.findIndex((candidate) => candidate.key === entry.key) !== idx,
+    );
+    assert.deepEqual(
+      duplicates,
+      [],
+      `duplicate MCP-visible key declarations found: ${duplicates.map((entry) => `${entry.key} (${entry.file}:${entry.name})`).join(', ')}`,
+    );
+
+    const mcpCacheKeys = new Set(
+      TOOL_REGISTRY.flatMap((tool) => ('_cacheKeys' in tool ? tool._cacheKeys : [])),
+    );
+
+    const missing = publicEntries.filter(({ key }) => !mcpCacheKeys.has(key));
+    assert.deepEqual(
+      missing,
+      [],
+      [
+        'Every MCP-visible seed key must be exposed through `api/mcp.ts`.',
+        'If a new seeder lands, add its public companion keys (for example CANONICAL_KEY / BOOTSTRAP_KEY / HISTORICAL_KEY / ANALYSIS_KEY) to an existing MCP tool or create a new one in `api/mcp.ts` in the same PR.',
+        `Missing: ${missing.map((entry) => `${entry.key} (${entry.file}:${entry.name})`).join(', ')}`,
+      ].join('\n'),
+    );
+  });
+
+  it('tracks MCP-exposed seed keys in health and seed-health registries', () => {
+    const healthSrc = readFileSync(join(REPO_ROOT, 'api/health.js'), 'utf8');
+    const seedHealthSrc = readFileSync(join(REPO_ROOT, 'api/seed-health.js'), 'utf8');
+
+    for (const { healthName, redisKey, metaKey, seedDomain } of MCP_HEALTH_BRIDGE_KEYS) {
+      assert.match(
+        healthSrc,
+        new RegExp(`${escapeRegExp(healthName)}:\\s*'${escapeRegExp(redisKey)}'`),
+        `api/health.js STANDALONE_KEYS missing ${healthName} -> ${redisKey}`,
+      );
+      assert.match(
+        healthSrc,
+        new RegExp(`${escapeRegExp(healthName)}:\\s*\\{[^}]*key:\\s*'${escapeRegExp(metaKey)}'`),
+        `api/health.js SEED_META missing ${healthName} -> ${metaKey}`,
+      );
+      assert.match(
+        seedHealthSrc,
+        new RegExp(`'${escapeRegExp(seedDomain)}':\\s*\\{[^}]*key:\\s*'${escapeRegExp(metaKey)}'`),
+        `api/seed-health.js SEED_DOMAINS missing ${seedDomain} -> ${metaKey}`,
+      );
+    }
+  });
+});

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -27,8 +27,66 @@ function initBody(id = 1) {
   };
 }
 
+const MCP_TOOL_NAMES = [
+  'get_market_data',
+  'get_conflict_events',
+  'get_aviation_status',
+  'get_news_intelligence',
+  'get_natural_disasters',
+  'get_military_posture',
+  'get_cyber_threats',
+  'get_economic_data',
+  'get_country_macro',
+  'get_eu_housing_cycle',
+  'get_eu_quarterly_gov_debt',
+  'get_eu_industrial_production',
+  'get_prediction_markets',
+  'get_sanctions_data',
+  'get_climate_data',
+  'get_infrastructure_status',
+  'get_supply_chain_data',
+  'get_resilience_recovery',
+  'get_energy_security',
+  'get_positive_events',
+  'get_radiation_data',
+  'get_research_signals',
+  'get_health_data',
+  'get_regulatory_actions',
+  'get_correlation_signals',
+  'get_forecast_predictions',
+  'get_social_velocity',
+  'get_world_brief',
+  'get_country_brief',
+  'get_country_risk',
+  'get_airspace',
+  'get_maritime_activity',
+  'analyze_situation',
+  'generate_forecasts',
+  'search_flights',
+  'search_flight_prices_by_date',
+  'get_commodity_geo',
+];
+
+const CACHE_TOOL_SMOKE_CASES = [
+  { name: 'get_market_data', expectedKeys: ['fear-greed', 'gulf-quotes', 'crypto_sectors', 'stablecoins', 'fx_rates'] },
+  { name: 'get_news_intelligence', expectedKeys: ['advisories-bootstrap', 'security_advisories'] },
+  { name: 'get_natural_disasters', expectedKeys: ['fires', 'events', 'thermal_escalation'] },
+  { name: 'get_cyber_threats', expectedKeys: ['threats-bootstrap', 'threats'] },
+  { name: 'get_economic_data', expectedKeys: ['FEDFUNDS', 'econ-calendar', 'tech_readiness', 'worldbank_progress', 'renewable_energy', 'national_debt', 'bigmac_index', 'grocery_basket', 'fao_food_price_index', 'eurostat_country_data', 'bls_series'] },
+  { name: 'get_country_macro', expectedKeys: ['macro', 'growth', 'labor', 'external'] },
+  { name: 'get_infrastructure_status', expectedKeys: ['outages', 'service_statuses', 'submarine_cables'] },
+  { name: 'get_supply_chain_data', expectedKeys: ['customs-revenue', 'flows', 'hormuz_tracker', 'port_activity_by_country', 'portwatch_chokepoints', 'portwatch_disruptions'] },
+  { name: 'get_research_signals', expectedKeys: ['tech-events-bootstrap', 'defense_patents'] },
+  { name: 'get_resilience_recovery', expectedKeys: ['fiscal_space', 'reserve_adequacy', 'external_debt', 'import_hhi', 'fuel_stocks'] },
+  { name: 'get_energy_security', expectedKeys: ['eu_gas_storage', 'chokepoint_baselines', 'chokepoint_flows', 'iea_oil_stocks', 'jodi_gas_countries', 'jodi_oil_countries', 'spr_policies'] },
+  { name: 'get_health_data', expectedKeys: ['disease_outbreaks', 'vpd_realtime', 'vpd_historical'] },
+  { name: 'get_regulatory_actions', expectedKeys: ['regulatory_actions'] },
+  { name: 'get_correlation_signals', expectedKeys: ['correlation_cards'] },
+];
+
 let handler;
 let evaluateFreshness;
+let toolRegistry;
 
 describe('api/mcp.ts — PRO MCP Server', () => {
   beforeEach(async () => {
@@ -40,6 +98,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const mod = await import(`../api/mcp.ts?t=${Date.now()}`);
     handler = mod.default;
     evaluateFreshness = mod.evaluateFreshness;
+    toolRegistry = mod.TOOL_REGISTRY;
   });
 
   afterEach(() => {
@@ -118,12 +177,17 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
   // --- tools/list ---
 
-  it('tools/list returns 32 tools with name, description, inputSchema', async () => {
+  it('tools/list returns 37 tools with name, description, inputSchema', async () => {
     const res = await handler(makeReq('POST', { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.result?.tools), 'result.tools must be an array');
-    assert.equal(body.result.tools.length, 32, `Expected 32 tools, got ${body.result.tools.length}`);
+    assert.equal(body.result.tools.length, 37, `Expected 37 tools, got ${body.result.tools.length}`);
+    assert.deepEqual(
+      body.result.tools.map((tool) => tool.name),
+      MCP_TOOL_NAMES,
+      'tools/list names drifted unexpectedly',
+    );
     for (const tool of body.result.tools) {
       assert.ok(tool.name, 'tool.name must be present');
       assert.ok(tool.description, 'tool.description must be present');
@@ -131,6 +195,13 @@ describe('api/mcp.ts — PRO MCP Server', () => {
       assert.ok(!('_cacheKeys' in tool), 'Internal _cacheKeys must not be exposed in tools/list');
       assert.ok(!('_execute' in tool), 'Internal _execute must not be exposed in tools/list');
     }
+  });
+
+  it('get_military_posture freshness is tied to theater-posture heartbeat', () => {
+    const tool = toolRegistry.find((entry) => entry.name === 'get_military_posture');
+    assert.ok(tool, 'get_military_posture must exist');
+    assert.equal(tool._seedMetaKey, 'seed-meta:theater-posture');
+    assert.equal(tool._maxStaleMin, 60);
   });
 
   // --- tools/call ---
@@ -159,6 +230,22 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(data.stale, true, 'stale must be true when cache is empty');
     assert.equal(data.cached_at, null, 'cached_at must be null when no seed-meta');
     assert.ok('data' in data, 'data field must be present');
+  });
+
+  it('expanded cache tools expose the expected data labels when Redis is empty', async () => {
+    for (const { name, expectedKeys } of CACHE_TOOL_SMOKE_CASES) {
+      const res = await handler(makeReq('POST', {
+        jsonrpc: '2.0', id: name, method: 'tools/call',
+        params: { name, arguments: {} },
+      }));
+      assert.equal(res.status, 200, `${name}: expected HTTP 200`);
+      const body = await res.json();
+      const payload = JSON.parse(body.result.content[0].text);
+      assert.equal(payload.stale, true, `${name}: cache-empty tool must report stale=true`);
+      for (const key of expectedKeys) {
+        assert.ok(key in payload.data, `${name}: missing expected MCP label '${key}'`);
+      }
+    }
   });
 
   it('evaluateFreshness marks bundled data stale when any required source meta is missing', () => {


### PR DESCRIPTION
## Summary

This PR fixes MCP cache-tool payload stability and closes seed coverage gaps by:
- Expanding `api/mcp.ts` tool coverage (32 → 37 tools) so MCP-visible seeded datasets are exposed.
- Preserving stable response field names with explicit `_outputLabels` (instead of suffix-only key derivation), including collision-safe fallbacks.
- Aligning MCP-exposed datasets with health/seed-health monitoring (`api/health.js`, `api/seed-health.js`) for freshness tracking.
- Adding guardrail tests to prevent drift:
  - `tests/mcp-seed-coverage.test.mjs` validates that MCP-visible seed keys are exposed and health registries are wired.
  - `tests/mcp.test.mjs` validates tool list/name set, freshness config, and expected cache output labels.



## Type of change

- [x] Bug fix
- [x] Refactor / code cleanup
- [x] CI / Build / Infrastructure

## Affected areas

- [x] API endpoints (`/api/*`)
- [x] Other: MCP tooling + seed/health test coverage

## Checklist

- [x] New canonical seed data is exposed via MCP in `api/mcp.ts` (or intentionally covered by an existing MCP tool)
- [x] No API keys or secrets committed
