### PR TITLE
fix(seed-utils): payloadBytes>0 fallback for runSeed recordCount auto-detect

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -676,6 +676,42 @@ export async function readSeedSnapshot(canonicalKey) {
   }
 }
 
+/**
+ * Resolve recordCount for runSeed's freshness metadata write.
+ *
+ * Resolution order:
+ *   1. opts.recordCount (function or number) — the seeder declared it explicitly
+ *   2. Auto-detect from a known shape (Array.isArray, .predictions, .events, ...)
+ *   3. payloadBytes > 0 → 1 (proven-payload fallback) + warn so the seeder author
+ *      adds an explicit opts.recordCount
+ *   4. 0
+ *
+ * The fallback exists because seeders publishing custom shapes would otherwise
+ * trigger phantom EMPTY_DATA in /api/health even though the payload is fully
+ * populated. See ~/.claude/skills/seed-recordcount-autodetect-phantom-empty.
+ *
+ * Pure function — extracted from runSeed for unit testing.
+ */
+export function computeRecordCount({ opts = {}, data, payloadBytes = 0, topicArticleCount, onPhantomFallback }) {
+  if (opts.recordCount != null) {
+    return typeof opts.recordCount === 'function' ? opts.recordCount(data) : opts.recordCount;
+  }
+  const detectedFromShape = Array.isArray(data)
+    ? data.length
+    : (topicArticleCount
+      ?? data?.predictions?.length
+      ?? data?.events?.length ?? data?.earthquakes?.length ?? data?.outages?.length
+      ?? data?.fireDetections?.length ?? data?.anomalies?.length ?? data?.threats?.length
+      ?? data?.quotes?.length ?? data?.stablecoins?.length
+      ?? data?.cables?.length);
+  if (detectedFromShape != null) return detectedFromShape;
+  if (payloadBytes > 0) {
+    if (typeof onPhantomFallback === 'function') onPhantomFallback();
+    return 1;
+  }
+  return 0;
+}
+
 export function parseYahooChart(data, symbol) {
   const result = data?.chart?.result?.[0];
   const meta = result?.meta;
@@ -772,15 +808,12 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     const topicArticleCount = Array.isArray(data?.topics)
       ? data.topics.reduce((n, t) => n + (t?.articles?.length || t?.events?.length || 0), 0)
       : undefined;
-    const recordCount = opts.recordCount != null
-      ? (typeof opts.recordCount === 'function' ? opts.recordCount(data) : opts.recordCount)
-      : Array.isArray(data) ? data.length
-      : (topicArticleCount
-        ?? data?.predictions?.length
-        ?? data?.events?.length ?? data?.earthquakes?.length ?? data?.outages?.length
-        ?? data?.fireDetections?.length ?? data?.anomalies?.length ?? data?.threats?.length
-        ?? data?.quotes?.length ?? data?.stablecoins?.length
-        ?? data?.cables?.length ?? 0);
+    const recordCount = computeRecordCount({
+      opts, data, payloadBytes, topicArticleCount,
+      onPhantomFallback: () => console.warn(
+        `  [recordCount] auto-detect did not match a known shape (payloadBytes=${payloadBytes}); falling back to 1. Add opts.recordCount to ${domain}:${resource} for accurate health metrics.`
+      ),
+    });
 
     // Write extra keys (e.g., bootstrap hydration keys)
     if (extraKeys) {

--- a/tests/seed-utils.test.mjs
+++ b/tests/seed-utils.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { isTransientRedisError } from '../scripts/_seed-utils.mjs';
+import { isTransientRedisError, computeRecordCount } from '../scripts/_seed-utils.mjs';
 
 describe('seed utils redis error handling', () => {
   it('treats undici connect timeout as transient', () => {
@@ -46,5 +46,108 @@ describe('seed utils redis error handling', () => {
   it('does not treat payload size errors as transient', () => {
     const err = new Error('Payload too large: 6.2MB > 5MB limit');
     assert.equal(isTransientRedisError(err), false);
+  });
+});
+
+describe('computeRecordCount', () => {
+  it('uses opts.recordCount as a number when provided', () => {
+    assert.equal(
+      computeRecordCount({ opts: { recordCount: 42 }, data: { foo: 'bar' }, payloadBytes: 1000 }),
+      42,
+    );
+  });
+
+  it('uses opts.recordCount as a function when provided', () => {
+    const data = { items: [1, 2, 3, 4, 5] };
+    assert.equal(
+      computeRecordCount({ opts: { recordCount: (d) => d.items.length * 2 }, data, payloadBytes: 100 }),
+      10,
+    );
+  });
+
+  it('respects opts.recordCount=0 even when payload has bytes (explicit zero)', () => {
+    // A seeder that explicitly says "0 records" must be trusted — used by
+    // seeders like seed-owid-energy-mix that never have a meaningful count.
+    assert.equal(
+      computeRecordCount({ opts: { recordCount: 0 }, data: { stuff: 1 }, payloadBytes: 500 }),
+      0,
+    );
+  });
+
+  it('auto-detects array length when data is an array', () => {
+    assert.equal(
+      computeRecordCount({ data: [1, 2, 3, 4], payloadBytes: 100 }),
+      4,
+    );
+  });
+
+  it.each = undefined; // node:test doesn't have it.each; explicit cases below
+  it('auto-detects data.events.length', () => {
+    assert.equal(
+      computeRecordCount({ data: { events: [{}, {}, {}] }, payloadBytes: 50 }),
+      3,
+    );
+  });
+
+  it('auto-detects data.predictions.length', () => {
+    assert.equal(
+      computeRecordCount({ data: { predictions: [{}, {}] }, payloadBytes: 30 }),
+      2,
+    );
+  });
+
+  it('auto-detects topicArticleCount when topics shape', () => {
+    assert.equal(
+      computeRecordCount({ data: { topics: [{}] }, topicArticleCount: 17, payloadBytes: 200 }),
+      17,
+    );
+  });
+
+  it('FALLBACK: returns 1 when payloadBytes>0 and shape unknown (phantom EMPTY_DATA fix)', () => {
+    // This is the proven-payload fallback. Without it, a seeder that publishes
+    // {score, inputs} (e.g. seed-fear-greed) would write recordCount=0 to
+    // seed-meta and trigger phantom EMPTY_DATA in /api/health even though the
+    // panel renders fine.
+    let warned = false;
+    const result = computeRecordCount({
+      data: { score: 42, inputs: { foo: 'bar' } },  // unknown shape
+      payloadBytes: 6093,
+      onPhantomFallback: () => { warned = true; },
+    });
+    assert.equal(result, 1);
+    assert.equal(warned, true, 'expected onPhantomFallback to fire');
+  });
+
+  it('returns 0 when neither known shape nor payloadBytes > 0', () => {
+    let warned = false;
+    const result = computeRecordCount({
+      data: { unknownShape: true },
+      payloadBytes: 0,
+      onPhantomFallback: () => { warned = true; },
+    });
+    assert.equal(result, 0);
+    assert.equal(warned, false, 'no fallback warn when payload is empty');
+  });
+
+  it('does not fire fallback when shape matches (no spurious warn)', () => {
+    let warned = false;
+    computeRecordCount({
+      data: [1, 2, 3],
+      payloadBytes: 100,
+      onPhantomFallback: () => { warned = true; },
+    });
+    assert.equal(warned, false);
+  });
+
+  it('opts.recordCount=0 from a function suppresses fallback (explicit-zero precedence)', () => {
+    let warned = false;
+    const result = computeRecordCount({
+      opts: { recordCount: () => 0 },
+      data: { mystery: true },
+      payloadBytes: 9999,
+      onPhantomFallback: () => { warned = true; },
+    });
+    assert.equal(result, 0);
+    assert.equal(warned, false);
   });
 });

--- a/tests/seed-utils.test.mjs
+++ b/tests/seed-utils.test.mjs
@@ -81,7 +81,7 @@ describe('computeRecordCount', () => {
     );
   });
 
-  it.each = undefined; // node:test doesn't have it.each; explicit cases below
+  // Note: node:test does not provide it.each — explicit cases below.
   it('auto-detects data.events.length', () => {
     assert.equal(
       computeRecordCount({ data: { events: [{}, {}, {}] }, payloadBytes: 50 }),
@@ -101,6 +101,23 @@ describe('computeRecordCount', () => {
       computeRecordCount({ data: { topics: [{}] }, topicArticleCount: 17, payloadBytes: 200 }),
       17,
     );
+  });
+
+  it('does NOT fire fallback when known shape returns 0 (empty array, payloadBytes>0)', () => {
+    // Regression guard: if a seeder publishes {events: []} (genuinely zero
+    // events upstream), the JSON serialization is non-empty (~12 bytes for
+    // {"events":[]}). detectedFromShape resolves to 0 (a real number, not
+    // null), so the chain MUST stop there and report 0 — not flip to the
+    // payloadBytes>0 fallback. Otherwise we'd silently mask genuine empty
+    // upstream cycles as "1 record" and break the SKIPPED/EMPTY signal.
+    let warned = false;
+    const result = computeRecordCount({
+      data: { events: [] },
+      payloadBytes: 12,
+      onPhantomFallback: () => { warned = true; },
+    });
+    assert.equal(result, 0);
+    assert.equal(warned, false, 'no fallback when known shape is present but empty');
   });
 
   it('FALLBACK: returns 1 when payloadBytes>0 and shape unknown (phantom EMPTY_DATA fix)', () => {


### PR DESCRIPTION
## Why this PR?

Health dashboard 2026-04-14 08:44 UTC reported **18 EMPTY_DATA CRITs** in /api/health. After cross-referencing 12 Railway seeder logs, **16 of them are phantoms**: the seeders ran on schedule, wrote payloads to Redis, and emitted \`Verified: data present in Redis\` in the same line that reported \`recordCount:0\`.

Smoking-gun signature (BLS-Series example):
\`\`\`
[BLS-Series] {"event":"seed_complete","recordCount":0,"durationMs":3925,"payloadBytes":6093}
[BLS-Series]   Verified: data present in Redis
\`\`\`

VPD-Tracker is the most striking: **3 MB** of payload, count reported as 0.

## Root cause

\`scripts/_seed-utils.mjs\` \`runSeed()\` auto-detects \`recordCount\` from a hardcoded list of payload shapes:

\`\`\`js
Array.isArray(data) ? data.length
: (topicArticleCount
   ?? data?.predictions?.length
   ?? data?.events?.length ?? data?.earthquakes?.length ?? data?.outages?.length
   ?? data?.fireDetections?.length ?? data?.anomalies?.length ?? data?.threats?.length
   ?? data?.quotes?.length ?? data?.stablecoins?.length
   ?? data?.cables?.length ?? 0);
\`\`\`

If a seeder publishes a custom shape (\`{score, inputs}\` for fear-greed, \`{geopolitical, tech}\` for prediction-markets, \`{primaryTitle, ...}\` per-topic for insights, etc.) AND doesn't pass \`opts.recordCount\`, the chain falls through to **0**. seed-meta is written with \`{fetchedAt, recordCount: 0}\`. health.js reads this and flips to EMPTY_DATA.

Audit: of 19 failing-health seeders, only **2** pass \`opts.recordCount\` to \`runSeed\` (\`seed-spr-policies\`, \`seed-owid-energy-mix\`). The other 17 rely on auto-detect.

## Fix

Add a final \`payloadBytes > 0 → 1\` fallback to the resolution chain. When triggered, \`console.warn\` names the seeder so the author can add an explicit \`opts.recordCount\` for accurate dashboards.

Also extracted the resolution logic into a pure exported \`computeRecordCount()\` function so it can be unit-tested without a real Redis connection.

**Resolution order (unchanged for existing callers):**
1. \`opts.recordCount\` (function or number) — explicit declaration wins
2. Auto-detect from known shape
3. **NEW**: \`payloadBytes > 0\` → 1 + warn
4. 0

Explicit \`opts.recordCount: 0\` still wins (test covers it) — for cases like \`seed-owid-energy-mix\` which deliberately reports 0.

## Files

- \`scripts/_seed-utils.mjs\` — extract \`computeRecordCount()\`, wire fallback into \`runSeed\`
- \`tests/seed-utils.test.mjs\` — 11 new test cases

## Effect

- **Clears 16 phantom CRITs** on the next bundle cycle (one cron tick per affected seeder).
- Per-seeder \`console.warn\` will surface in logs so we know which seeders still need explicit \`opts.recordCount\` for accurate dashboards.
- One genuine intermittent (\`unrestEvents\` — ACLED quiet periods) is unchanged; that hits the SKIPPED-validation path which deliberately writes count=0.
- \`goldExtended\` and \`sprPolicies\` are NOT covered by this PR — those are real bugs (dead \`.then()\` block in seed-commodity-quotes; missing Railway runner). Separate PRs incoming.

## Testing

- \`node --test tests/seed-utils.test.mjs\` → 18/18 (11 new + 7 existing)
- \`node --test tests/seed-utils-empty-data-failure.test.mjs\` → 2/2
- \`npm run typecheck\` → clean

## Post-Deploy Monitoring & Validation

- **Logs**: Watch the next 1-2 bundle cycles on Railway (\`seed-bundle-macro\`, \`seed-bundle-health\`, \`seed-bundle-energy-sources\`, \`seed-bundle-ecb-eu\`, plus standalone services). Seeders that previously logged \`recordCount:0, payloadBytes:>0\` will now log \`recordCount:1\` AND a one-time \`[recordCount] auto-detect did not match a known shape (payloadBytes=N); falling back to 1. Add opts.recordCount to <domain>:<resource> for accurate health metrics.\` warning.
- **Health endpoint**: \`curl -sL https://worldmonitor.app/api/health | jq '.summary'\` — \`crit\` count should drop from 18 to ~5 within 1 hour (only the genuine cases remain: \`unrestEvents\` intermittent + \`goldExtended\`/\`sprPolicies\` until separate PRs land).
- **Failure signal / rollback**: if a seeder that previously reported a meaningful recordCount now reports 1 (regression), check whether its known-shape detection broke. Revert is one-line. No data is at risk — this only affects metadata write.
- **Validation window**: 1 hour post-deploy.
- **Owner**: @koala73

## Related

- Sibling PRs: PR-B (seed-commodity-quotes afterPublish fix → goldExtended) and PR-C (wire seed-spr-policies into bundle) — incoming.
- Skill: \`seed-recordcount-autodetect-phantom-empty\` documents the diagnosis methodology.