### PR TITLE
fix(commodity-quotes): move .then() block to opts.afterPublish — resurrect 3 dead Redis writes

### DIFF
--- a/scripts/seed-commodity-quotes.mjs
+++ b/scripts/seed-commodity-quotes.mjs
@@ -262,14 +262,32 @@ function validate(data) {
  *
  * See ~/.claude/skills/runseed-then-after-process-exit for full diagnosis.
  */
-async function writeCompanionKeys(data) {
-  if (!data) return;
+/**
+ * Required companion writes — alias keys that must succeed alongside the
+ * canonical commodity publish. Any failure here MUST propagate up so runSeed's
+ * outer try/catch rejects the run, the lock is released, and process.exit(1)
+ * fires via the outer .catch. Otherwise seed-meta on the canonical key gets
+ * stamped as fresh while the alias keys are stale or missing — phantom-success.
+ *
+ * Per Codex review on PR #3088: only the OPTIONAL gold-extended branch is
+ * downgraded to a warning. Required writes are not.
+ */
+async function writeRequiredCompanionKeys(data) {
   const commodityKey = `market:commodities:v1:${[...COMMODITY_SYMBOLS].sort().join(',')}`;
   const quotesKey = `market:quotes:v1:${[...COMMODITY_SYMBOLS].sort().join(',')}`;
   const quotesPayload = { ...data, finnhubSkipped: false, skipReason: '', rateLimited: false };
   await writeExtraKey(commodityKey, data, CACHE_TTL);
   await writeExtraKey(quotesKey, quotesPayload, CACHE_TTL);
+}
 
+/**
+ * Optional gold-extended write — Yahoo cross-currency XAU + drivers. Has its
+ * own seed-meta:market:gold-extended key with independent maxStaleMin in
+ * api/health.js, so a Yahoo outage here degrades only the gold panel; the
+ * canonical commodity publish stays healthy. Errors are caught and logged so
+ * Yahoo flakiness does NOT poison runSeed's success path.
+ */
+async function writeOptionalGoldExtended() {
   try {
     const extended = await fetchGoldExtended();
     // Require gold (the core metal) AND at least one driver or silver. Writing a
@@ -296,13 +314,18 @@ runSeed('market', 'commodities', CANONICAL_KEY, fetchCommodityQuotes, {
   sourceVersion: 'alphavantage+yahoo-chart',
   afterPublish: async (data) => {
     // afterPublish is awaited inside runSeed BEFORE process.exit, so these
-    // writes actually run. Wrap in try so any companion-key failure logs
-    // explicitly instead of falling through to the runSeed catch.
-    try {
-      await writeCompanionKeys(data);
-    } catch (e) {
-      console.warn(`  [Companion] write failed: ${e?.message || e}`);
-    }
+    // writes actually run. SPLIT semantics:
+    //
+    //   - Required alias keys (commodityKey, quotesKey): errors PROPAGATE so
+    //     the seed run fails (lock released, process.exit(1) via outer catch,
+    //     seed-meta NOT stamped fresh). Health correctly flags STALE_SEED.
+    //
+    //   - Optional gold-extended: errors are caught + warned inside
+    //     writeOptionalGoldExtended; gold has its own seed-meta key that goes
+    //     stale independently if Yahoo XAU is down.
+    if (!data) return;
+    await writeRequiredCompanionKeys(data);
+    await writeOptionalGoldExtended();
   },
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-commodity-quotes.mjs
+++ b/scripts/seed-commodity-quotes.mjs
@@ -244,23 +244,30 @@ function validate(data) {
   return Array.isArray(data?.quotes) && data.quotes.length >= 1;
 }
 
-let seedData = null;
+// fetchCommodityQuotes returns the canonical {quotes} payload that runSeed
+// then writes to CANONICAL_KEY. The same value is passed to opts.afterPublish
+// as `data`, which is where the companion-key writes happen.
 
-async function fetchAndStash() {
-  seedData = await fetchCommodityQuotes();
-  return seedData;
-}
-
-runSeed('market', 'commodities', CANONICAL_KEY, fetchAndStash, {
-  validateFn: validate,
-  ttlSeconds: CACHE_TTL,
-  sourceVersion: 'alphavantage+yahoo-chart',
-}).then(async (result) => {
-  if (result?.skipped || !seedData) return;
+/**
+ * Write companion / derived keys after the canonical commodity publish.
+ *
+ * MUST be invoked via runSeed's opts.afterPublish (NOT via .then() chained on
+ * the runSeed promise). runSeed ends with process.exit(0) on success, which
+ * terminates the process before any chained .then() microtask runs — so a
+ * .then-chained version of this code silently never executes and three
+ * Redis keys (market:commodities:v1:<symbols>, market:quotes:v1:<symbols>,
+ * market:gold-extended:v1) get permanently dropped. Verified against
+ * Railway log 2026-04-14 08:50:31: zero [Gold] log lines, zero extra-key
+ * writes, goldExtended health=EMPTY for months.
+ *
+ * See ~/.claude/skills/runseed-then-after-process-exit for full diagnosis.
+ */
+async function writeCompanionKeys(data) {
+  if (!data) return;
   const commodityKey = `market:commodities:v1:${[...COMMODITY_SYMBOLS].sort().join(',')}`;
   const quotesKey = `market:quotes:v1:${[...COMMODITY_SYMBOLS].sort().join(',')}`;
-  const quotesPayload = { ...seedData, finnhubSkipped: false, skipReason: '', rateLimited: false };
-  await writeExtraKey(commodityKey, seedData, CACHE_TTL);
+  const quotesPayload = { ...data, finnhubSkipped: false, skipReason: '', rateLimited: false };
+  await writeExtraKey(commodityKey, data, CACHE_TTL);
   await writeExtraKey(quotesKey, quotesPayload, CACHE_TTL);
 
   try {
@@ -281,6 +288,22 @@ runSeed('market', 'commodities', CANONICAL_KEY, fetchAndStash, {
   } catch (e) {
     console.warn(`  [Gold] extended fetch error: ${e?.message || e} — skipping write, letting seed-meta go stale`);
   }
+}
+
+runSeed('market', 'commodities', CANONICAL_KEY, fetchCommodityQuotes, {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: 'alphavantage+yahoo-chart',
+  afterPublish: async (data) => {
+    // afterPublish is awaited inside runSeed BEFORE process.exit, so these
+    // writes actually run. Wrap in try so any companion-key failure logs
+    // explicitly instead of falling through to the runSeed catch.
+    try {
+      await writeCompanionKeys(data);
+    } catch (e) {
+      console.warn(`  [Companion] write failed: ${e?.message || e}`);
+    }
+  },
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-commodity-quotes.mjs
+++ b/scripts/seed-commodity-quotes.mjs
@@ -249,35 +249,40 @@ function validate(data) {
 // as `data`, which is where the companion-key writes happen.
 
 /**
- * Write companion / derived keys after the canonical commodity publish.
- *
- * MUST be invoked via runSeed's opts.afterPublish (NOT via .then() chained on
- * the runSeed promise). runSeed ends with process.exit(0) on success, which
- * terminates the process before any chained .then() microtask runs — so a
- * .then-chained version of this code silently never executes and three
- * Redis keys (market:commodities:v1:<symbols>, market:quotes:v1:<symbols>,
- * market:gold-extended:v1) get permanently dropped. Verified against
- * Railway log 2026-04-14 08:50:31: zero [Gold] log lines, zero extra-key
- * writes, goldExtended health=EMPTY for months.
- *
- * See ~/.claude/skills/runseed-then-after-process-exit for full diagnosis.
- */
-/**
  * Required companion writes — alias keys that must succeed alongside the
- * canonical commodity publish. Any failure here MUST propagate up so runSeed's
- * outer try/catch rejects the run, the lock is released, and process.exit(1)
- * fires via the outer .catch. Otherwise seed-meta on the canonical key gets
- * stamped as fresh while the alias keys are stale or missing — phantom-success.
+ * canonical commodity publish.
  *
- * Per Codex review on PR #3088: only the OPTIONAL gold-extended branch is
- * downgraded to a warning. Required writes are not.
+ * BACKGROUND (do NOT regress to .then() pattern):
+ * runSeed() in scripts/_seed-utils.mjs ends with process.exit(0) on success,
+ * which terminates Node before any .then() microtask chained on its returned
+ * promise can run. The previous implementation used `runSeed(...).then(write...)`
+ * and these three keys (market:commodities:v1:<symbols>, market:quotes:v1:<symbols>,
+ * market:gold-extended:v1) were silently dead for months — Railway log
+ * 2026-04-14 08:50:31 confirms zero [Gold] log lines and goldExtended
+ * health=EMPTY since the seeder was added. The fix is to wire post-publish
+ * writes via opts.afterPublish, which runSeed awaits BEFORE process.exit
+ * (see _seed-utils.mjs runSeed() lines ~792-794).
+ *
+ * ERROR SEMANTICS (per Codex review on PR #3088):
+ * Required alias writes propagate errors. Any failure here MUST bubble up so
+ * runSeed's outer try/catch rejects the run, the lock is released, and
+ * process.exit(1) fires via the outer .catch. Otherwise seed-meta on the
+ * canonical key would be stamped fresh while the alias keys are stale or
+ * missing — phantom-success returns by a different door. Only the OPTIONAL
+ * gold-extended branch (separate function below) is downgraded to a warning,
+ * because it has its own independent seed-meta key.
+ *
+ * Writes are parallelized via Promise.all — independent Redis writes, no
+ * read-after-write ordering required (per Greptile review on PR #3088).
  */
 async function writeRequiredCompanionKeys(data) {
   const commodityKey = `market:commodities:v1:${[...COMMODITY_SYMBOLS].sort().join(',')}`;
   const quotesKey = `market:quotes:v1:${[...COMMODITY_SYMBOLS].sort().join(',')}`;
   const quotesPayload = { ...data, finnhubSkipped: false, skipReason: '', rateLimited: false };
-  await writeExtraKey(commodityKey, data, CACHE_TTL);
-  await writeExtraKey(quotesKey, quotesPayload, CACHE_TTL);
+  await Promise.all([
+    writeExtraKey(commodityKey, data, CACHE_TTL),
+    writeExtraKey(quotesKey, quotesPayload, CACHE_TTL),
+  ]);
 }
 
 /**


### PR DESCRIPTION
## Why this PR?

\`scripts/seed-commodity-quotes.mjs\` had a \`.then()\` block chained on \`runSeed()\` that was supposed to write 3 companion Redis keys after the canonical commodity publish:

- \`market:commodities:v1:<symbols>\` (alias for canonical key)
- \`market:quotes:v1:<symbols>\` (with \`finnhubSkipped\` flags)
- \`market:gold-extended:v1\` (cross-currency XAU + drivers)

**Those three writes have been silently dead.** \`runSeed()\` ends with \`process.exit(0)\` on its happy path, terminating Node before any chained \`.then()\` microtask runs.

Production proof from Railway log 2026-04-14 08:50:31:
\`\`\`
=== market:commodities Seed ===
[Yahoo] ^VIX: $18.64 (-2.51%)
... 33 Yahoo symbols ...
Verified: data present in Redis
=== Done (8691ms) ===
Starting Container          ← next cron starts; ZERO [Gold] log lines
\`\`\`

\`/api/health\` shows \`goldExtended\` as EMPTY with \`seedAgeMin: null\` — that key has literally never been written.

## Root cause

\`runSeed()\` calls \`process.exit(0)\` on success (and \`(0)\`/\`(1)\` on skipped/failed paths). \`process.exit()\` does NOT drain the microtask queue. Any \`.then()\` chained on the returned promise becomes unreachable code.

This is a fundamental Node behavior — not a runSeed bug per se, but it makes any \`runSeed(...).then(...)\` pattern silently broken regardless of how correct the \`.then\` body is.

See \`~/.claude/skills/runseed-then-after-process-exit\` for the full failure-mode write-up.

## Fix

Move the post-publish writes into \`opts.afterPublish\`, which IS awaited inside \`runSeed\` BEFORE \`process.exit\` (see \`scripts/_seed-utils.mjs\` ~L792-794):

\`\`\`js
// runSeed body:
//   if (afterPublish) {
//     await afterPublish(data, { canonicalKey, ttlSeconds, recordCount, runId });
//   }
//   const meta = await writeFreshnessMetadata(...);
//   ... verify ...
//   process.exit(0);
\`\`\`

Refactored:
- Extracted post-publish writes into \`writeCompanionKeys(data)\`.
- Wired via \`opts.afterPublish\` with try/catch around the call so a companion-key failure logs explicitly rather than masking the canonical write success.
- Removed the now-redundant module-level \`seedData\` and \`fetchAndStash\` wrapper — \`afterPublish\` receives the canonical data as its first argument.

Outer \`.catch()\` is preserved — it still catches errors from \`runSeed\` itself.

## Files

- \`scripts/seed-commodity-quotes.mjs\` (1 file, +37 / -14)

## Testing

- \`node --check scripts/seed-commodity-quotes.mjs\` → clean
- \`npm run typecheck\` → clean
- No new unit tests — the fix is structural (move from dead .then to live afterPublish) and the runSeed contract guarantees afterPublish runs before process.exit.

## Post-Deploy Monitoring & Validation

- **Logs**: Next \`seed-commodity-quotes\` Railway run (~5 min cadence) — should now log either \`[Gold] extended: gold=true silver=true drivers=N\` (success) or \`[Gold] extended: incomplete\` / \`[Gold] extended fetch error\` (graceful skip). Currently emits zero \`[Gold]\` lines.
- **Redis (Upstash)**:
  - \`GET market:gold-extended:v1\` → non-empty payload
  - \`GET seed-meta:market:gold-extended\` → fresh \`fetchedAt\`
  - \`GET market:commodities:v1:<symbols>\` and \`market:quotes:v1:<symbols>\` → present (alias keys)
- **Health**: \`curl -sL https://worldmonitor.app/api/health | jq '.checks.goldExtended'\` — should flip from \`EMPTY (seedAgeMin: null)\` to \`OK\` within 1 cycle once Yahoo XAU data is fetchable.
- **Failure signal / rollback**: if \`fetchGoldExtended()\` is broken upstream, the seeder will now log \`[Gold] extended: incomplete\` or \`[Gold] extended fetch error\` and skip the write — the canonical commodity key still publishes. That's the correct degradation. Revert is one commit.
- **Validation window**: 2 cycles (10 min).
- **Owner**: @koala73

## Related

- Sibling PRs: #3087 (PR-A: runSeed recordCount fallback) and incoming PR-C (wire seed-spr-policies into bundle).
- Skill: \`~/.claude/skills/runseed-then-after-process-exit\` documents the failure mode for future seeders.