### PR TITLE
fix(spr-policies): wire seed-spr-policies into seed-bundle-energy-sources

### DIFF
--- a/scripts/seed-bundle-energy-sources.mjs
+++ b/scripts/seed-bundle-energy-sources.mjs
@@ -9,4 +9,10 @@ await runBundle('energy-sources', [
   { label: 'OWID-Energy-Mix', script: 'seed-owid-energy-mix.mjs', seedMetaKey: 'economic:owid-energy-mix', intervalMs: 35 * DAY, timeoutMs: 600_000 },
   { label: 'IEA-Oil-Stocks', script: 'seed-iea-oil-stocks.mjs', seedMetaKey: 'energy:iea-oil-stocks', intervalMs: 40 * DAY, timeoutMs: 300_000 },
   { label: 'IEA-Crisis-Policies', script: 'seed-energy-crisis-policies.mjs', seedMetaKey: 'energy:crisis-policies', intervalMs: 7 * DAY, timeoutMs: 120_000 },
+  // SPR-Policies: static registry (data lives in scripts/data/spr-policies.json), TTL 400d
+  // in api/health.js (maxStaleMin: 576000). Weekly cadence is generous — only needs to run
+  // once after deploys + restarts to populate energy:spr-policies:v1. No prior Railway
+  // service exists for it, so health has been EMPTY (seedAgeMin: null) since the seeder
+  // was added.
+  { label: 'SPR-Policies', script: 'seed-spr-policies.mjs', seedMetaKey: 'energy:spr-policies', intervalMs: 7 * DAY, timeoutMs: 60_000 },
 ]);


### PR DESCRIPTION
## Why this PR?

\`scripts/seed-spr-policies.mjs\` exists as a complete, runnable seeder with proper \`isMain\` guard at line 57-59. But **no Railway service ever invokes it.** \`/api/health\` shows \`sprPolicies\` as EMPTY with \`seedAgeMin: null\` — \`energy:spr-policies:v1\` has literally never been written to Redis since the seeder was added.

\`scripts/seed-energy-spine.mjs\` references the SPR key but only READS it; doesn't seed it. \`api/health.js\` registers \`maxStaleMin: 576000\` (400 days), confirming the intent for a static registry.

## Fix

Add an entry to \`scripts/seed-bundle-energy-sources.mjs\` so the existing Railway bundle service runs SPR alongside its energy siblings.

\`\`\`js
{ label: 'SPR-Policies', script: 'seed-spr-policies.mjs', seedMetaKey: 'energy:spr-policies', intervalMs: 7 * DAY, timeoutMs: 60_000 },
\`\`\`

Weekly cadence is generous — the data is a static JSON registry (\`scripts/data/spr-policies.json\`); it only needs to run once after deploys + restarts. The 60s timeout is generous for a JSON-file read + Redis write.

## Files

- \`scripts/seed-bundle-energy-sources.mjs\` (1 file, +6 / -0)

## Testing

- \`node --check scripts/seed-bundle-energy-sources.mjs\` → clean
- \`npm run typecheck\` → clean

## Post-Deploy Monitoring & Validation

- **Logs**: Next \`seed-bundle-energy-sources\` run (Railway bundle service watches \`scripts/**\` so it auto-redeploys on merge) — bundle should now show 8 sections including \`[SPR-Policies] === energy:spr-policies Seed === ... Done\` and \`Verified: data present in Redis\`.
- **Redis**: \`GET energy:spr-policies:v1\` → non-empty payload with policy entries for required countries (CN, IN, JP, SA, US per the seeder's whitelist).
- **Health**: \`curl -sL https://worldmonitor.app/api/health | jq '.checks.sprPolicies'\` — should flip from \`EMPTY (seedAgeMin: null)\` to \`OK\` within 1 cycle (~weekly first run).
- **Failure signal / rollback**: if the JSON file is missing or malformed, the seeder will fail loudly with \`FATAL:\` and the bundle reports \`failed:1\`. Revert is one-line.
- **Validation window**: 1 hour for the first scheduled run.
- **Owner**: @koala73

## Related

- Sibling PRs: #3087 (PR-A: runSeed recordCount fallback), #3088 (PR-B: commodity-quotes afterPublish fix).
- Together these 3 PRs clear ~18 of 21 health CRITs — only \`unrestEvents\` (genuine ACLED intermittent) remains.