### PR TITLE
fix(seed-forecasts): pipeline timeout 10s→45s + BATCH_SIZE 10→5

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -693,7 +693,15 @@ async function readInputKeys() {
     'conflict:ema-windows:v1',
     ...fredKeys,
   ];
-  const BATCH_SIZE = 10;
+  // BATCH_SIZE=5 + 45s timeout absorbs the worst-case ~1.9 MB co-located batch
+  // (3 heavies + 2 mediums) at Upstash REST's observed ~100 KB/s slow-spike
+  // floor. STRLEN-probed 2026-04-14: 40 keys total ~2.27 MB, top 5 keys
+  // (ucdp 657KB + chokepoints 500KB + cyber 390KB + commodities 192KB +
+  // gpsjam 174KB) = 90% of payload. Original 10s budget deterministically
+  // failed every retry on ~1.5 MB co-located batches (Railway log
+  // 2026-04-14 10:01 UTC: 12 consecutive abort-timeouts).
+  // See ~/.claude/skills/upstash-pipeline-payload-timeout for diagnosis methodology.
+  const BATCH_SIZE = 5;
   const results = [];
   for (let i = 0; i < keys.length; i += BATCH_SIZE) {
     const batchNum = i / BATCH_SIZE + 1;
@@ -703,7 +711,7 @@ async function readInputKeys() {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify(batch),
-        signal: AbortSignal.timeout(10_000),
+        signal: AbortSignal.timeout(45_000),
       });
       if (!resp.ok) throw new Error(`Redis pipeline batch ${batchNum} failed: ${resp.status}`);
       return resp.json();

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -695,19 +695,23 @@ async function readInputKeys() {
   ];
   // Sized for Upstash REST /pipeline payload limits.
   //
-  // STRLEN audit 2026-04-14: 40 input keys total ~2.27 MB; the top 5 keys
+  // STRLEN audit 2026-04-14: 40 input keys total ~2.27 MB; top 5 keys
   // (ucdp 657KB + chokepoints 500KB + cyber 390KB + commodities 192KB +
-  // gpsjam 174KB) account for 90% of payload. Worst-case co-located batch
-  // at BATCH_SIZE=5 is ~1.9 MB (3 heavies + 2 mediums).
+  // gpsjam 174KB) = 90% of payload. Because BATCH_SIZE divides the keys
+  // array deterministically by index, the worst batch is fixed by array
+  // order — currently batch 2 (indices 5-9: chokepoints + iran + ucdp +
+  // unrest + outages) at **1.17 MB** verified live. Not random
+  // co-location — deterministic.
   //
-  // The original 10s timeout deterministically failed every retry on ~1.5
-  // MB batches at Upstash REST's observed slow-spike floor of ~100 KB/s
-  // (Railway log 2026-04-14 10:01 UTC showed 12 consecutive abort-timeouts).
-  // 45s gives ~4.5× headroom at that floor.
+  // The original 10s timeout deterministically failed every retry on this
+  // batch at Upstash REST's observed slow-spike floor of ~100 KB/s
+  // (Railway log 2026-04-14 10:01 UTC: 12 consecutive abort-timeouts).
+  // At 100 KB/s, 1.17 MB takes ~12s. 45s gives ~3.7× headroom.
   //
-  // Diagnostic methodology: STRLEN-probe each input key, sum sizes, multiply
-  // by max likely co-location count, then time-budget against the observed
-  // slow-spike throughput floor inferred from the original failure.
+  // Future improvement: interleave heavy keys (chokepoints + ucdp) with
+  // smalls in the keys array above. Would split the deterministic
+  // worst-case across two batches, halving the per-request payload.
+  // Tracked as follow-up; not in scope for this hotfix.
   const BATCH_SIZE = 5;
   const results = [];
   for (let i = 0; i < keys.length; i += BATCH_SIZE) {

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -693,14 +693,21 @@ async function readInputKeys() {
     'conflict:ema-windows:v1',
     ...fredKeys,
   ];
-  // BATCH_SIZE=5 + 45s timeout absorbs the worst-case ~1.9 MB co-located batch
-  // (3 heavies + 2 mediums) at Upstash REST's observed ~100 KB/s slow-spike
-  // floor. STRLEN-probed 2026-04-14: 40 keys total ~2.27 MB, top 5 keys
+  // Sized for Upstash REST /pipeline payload limits.
+  //
+  // STRLEN audit 2026-04-14: 40 input keys total ~2.27 MB; the top 5 keys
   // (ucdp 657KB + chokepoints 500KB + cyber 390KB + commodities 192KB +
-  // gpsjam 174KB) = 90% of payload. Original 10s budget deterministically
-  // failed every retry on ~1.5 MB co-located batches (Railway log
-  // 2026-04-14 10:01 UTC: 12 consecutive abort-timeouts).
-  // See ~/.claude/skills/upstash-pipeline-payload-timeout for diagnosis methodology.
+  // gpsjam 174KB) account for 90% of payload. Worst-case co-located batch
+  // at BATCH_SIZE=5 is ~1.9 MB (3 heavies + 2 mediums).
+  //
+  // The original 10s timeout deterministically failed every retry on ~1.5
+  // MB batches at Upstash REST's observed slow-spike floor of ~100 KB/s
+  // (Railway log 2026-04-14 10:01 UTC showed 12 consecutive abort-timeouts).
+  // 45s gives ~4.5× headroom at that floor.
+  //
+  // Diagnostic methodology: STRLEN-probe each input key, sum sizes, multiply
+  // by max likely co-location count, then time-budget against the observed
+  // slow-spike throughput floor inferred from the original failure.
   const BATCH_SIZE = 5;
   const results = [];
   for (let i = 0; i < keys.length; i += BATCH_SIZE) {


### PR DESCRIPTION
## Why this PR?

\`/api/health\` 2026-04-14 10:43 UTC reported \`forecasts: STALE_SEED, seedAgeMin: 97, maxStaleMin: 90\` — the hourly seeder missed exactly one cycle. Railway log for the 10:01 run shows the read failed deterministically:

\`\`\`
=== forecast:predictions Seed ===
Reading input data from Redis...
Retry 1/2 in 1000ms: The operation was aborted due to timeout
... 12 consecutive abort-timeouts (4 outer × ~3 inner) ...
FETCH FAILED: The operation was aborted due to timeout
=== Failed gracefully (188070ms) ===
\`\`\`

Inter-attempt gaps cluster at ~10–11s — exactly the \`AbortSignal.timeout(10_000)\` budget. Every retry hits the wall. Not transient.

## Root cause (validated by direct STRLEN probe)

\`scripts/seed-forecasts.mjs:696-712\` batches 10 GETs per Upstash REST \`/pipeline\` POST with a 10s timeout. STRLEN-probed every input key on 2026-04-14:

| Key | Size | % of total |
|---|---:|---:|
| \`conflict:ucdp-events:v1\` | 657 KB | 29% |
| \`supply_chain:chokepoints:v4\` | 500 KB | 22% |
| \`cyber:threats-bootstrap:v2\` | 390 KB | 17% |
| \`market:commodities-bootstrap:v1\` | 192 KB | 8% |
| \`intelligence:gpsjam:v2\` | 174 KB | 8% |
| 34 other keys | ~220 KB | 10% |
| **Total (~40 keys)** | **~2.27 MB** | |

Worst-case batch payload at BATCH_SIZE=10 ≈ **1.55 MB** (3 heavies + 7 small). At Upstash REST's observed slow-spike floor (~100 KB/s, implied by the failure), 1.55 MB needs ~16s — exceeding the 10s budget.

## Fix

\`\`\`diff
- const BATCH_SIZE = 10;
+ const BATCH_SIZE = 5;     // reduces probability of tail co-location
...
-       signal: AbortSignal.timeout(10_000),
+       signal: AbortSignal.timeout(45_000),  // 2.4× headroom at observed floor
\`\`\`

- BATCH_SIZE=5 still allows ~1.9 MB co-located batch (3 heavies + 2 mediums); 45s gives ~30s headroom even at slow-spike rates.
- Round-trips 4 → 8; per-batch overhead ~150–500ms total amortized by undici keep-alive. Negligible vs hourly cadence.

## What this PR does NOT do (5-agent deepen-plan review caught these)

1. **Does NOT remove input keys.** Initial draft proposed dropping 3 "stub" keys (\`news:digest:v1:full:en\`, \`conflict:acled:v1:all:0:0\`, \`conflict:ema-windows:v1\`). Architecture review traced all 3 to LIVE producers/consumers:
   - \`news:digest:v1:full:en\` → produced by \`seed-insights.mjs:10\`, consumed at \`seed-forecasts.mjs:746\` (\`newsDigest\`) AND \`server/worldmonitor/intelligence/v1/chat-analyst-context.ts:666\`. 0-byte probe = inter-cycle gap, not dead.
   - \`conflict:acled:v1:all:0:0\` → produced by \`seed-conflict-intel.mjs:23\` (TTL 900s), consumed at \`:761\` (\`acledEvents\`), core to EMA windows. 13-byte probe = 15-min cycle gap.
   - \`conflict:ema-windows:v1\` → **produced by seed-forecasts itself** at \`:14919\` (self-referential state). 2-byte probe = documented cold-start \`{}\` path. Removing the read would break EMA continuity.
   
   Removing those reads would have broken the forecaster. Classic zero-byte-snapshot misdiagnosis (per \`feedback_audit_upstream_before_curating\`).

2. **Does NOT bump \`api/health.js\` maxStaleMin.** Current 90 min for hourly cadence is borderline tight, but the right fix is to make the read succeed, not widen the alarm.

3. **Does NOT extract a shared \`batchedPipelineGet\` helper.** Architectural refactor; tracked as follow-up.

## Testing

- \`node --check scripts/seed-forecasts.mjs\` clean
- \`npm run typecheck\` clean
- \`npm run typecheck:api\` clean
- No unit test possible without real Redis (the change is config tuning); verification is post-deploy.
- \`grep\` confirms all 3 contested keys preserved in both \`keys\` array AND consumer accesses (\`parsedByKey[...]\`, \`results[keys.indexOf(...)]\`).

## Post-Deploy Monitoring & Validation

- **Logs:** Railway service \`seed-forecasts\` next hourly run — \`Reading input data from Redis...\` should be followed within seconds by clean \`Done (Nms)\`. **Zero \`Retry N/M ... aborted due to timeout\` lines** is the success signal. The 188s failure duration should drop to baseline ~30–60s.
- **Health endpoint:** \`curl -sL https://worldmonitor.app/api/health | jq '.checks.forecasts'\` — should report \`{ status: \"OK\", seedAgeMin < 60, ... }\` across 24 consecutive hourly cycles. Baseline today: 1 STALE per ~24 h.
- **Failure signal / rollback trigger:** if Railway log still shows \`aborted due to timeout\` on the 45s budget, the underlying issue is bigger than payload (Upstash regional throttling on this Railway IP). Escalate to Phase 2 (dedicated reads for the 3 heaviest keys outside the batch loop).
- **Validation window:** 24 h post-deploy.
- **Owner:** @koala73
- **Rollback:** \`git revert\` this commit. Railway auto-redeploys on push to \`main\` (NIXPACKS watch on \`scripts/**\`). Zero data loss — read-only change.

## Latent sibling bugs (NOT this PR — separate per \`feedback_no_pr_pollution\`)

Architecture + scan review surfaced 4 other seeders with the same risk class:

| File | Current timeout | Batch / key count | Priority |
|---|---|---|---|
| \`scripts/seed-cross-source-signals.mjs:163\` | 15s | unbatched, 23 keys (same heavy-key set) | High follow-up |
| \`scripts/seed-correlation.mjs:26\` | 10s | unbatched, 9 market keys | High follow-up |
| \`scripts/seed-energy-spine.mjs:71\` | 30s | 300 GET commands per batch (60 countries × 5 keys) | Medium |
| \`scripts/seed-resilience-scores.mjs:73\` | 30s | BATCH=50 writes | Medium |

Each will be its own STRLEN-validated PR.

## Architectural follow-ups (out of scope)

- **Phase 2:** dedicated single-key reads for ucdp-events, chokepoints, cyber-threats outside the batch loop — caps tail at max(individual-key-size).
- **Phase 3:** pre-compute a derived \`forecast:inputs:v1\` blob upstream → seed-forecasts reads ONE ~50 KB key. Highest payoff, biggest change.
- **Phase 4:** switch to \`ioredis\` binary protocol for Node-side seeders (no docs-backed guidance either way; defensible engineering choice).
- **Architectural smell:** seed-forecasts is coupled to 15+ producers' internal Redis schemas with no versioned contract. Add SEED_META assertion test.

## Related

- Plan: \`docs/plans/2026-04-14-001-fix-seed-forecasts-pipeline-timeout-plan.md\` (deepened via 5-agent review on 2026-04-14)
- Skill: \`~/.claude/skills/upstash-pipeline-payload-timeout/SKILL.md\` (full diagnosis methodology + STRLEN probe recipe)
- Sibling PRs in flight: #3087 (runSeed recordCount), #3088 (commodity afterPublish), #3089 (SPR bundle wiring) — all orthogonal.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, high reasoning) via [Claude Code](https://claude.com/claude-code)