### PR TITLE
feat(analytics): send sub status & planKey with Umami identity

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -846,9 +846,7 @@ export class App {
 
     // Verify OAuth OTT and hydrate auth session BEFORE any UI subscribes to auth state
     await initAuthState();
-    if (isProUser()) {
-      initAuthAnalytics();
-    }
+    initAuthAnalytics();
     installCloudPrefsSync(SITE_VARIANT);
     this.enforceFreeTierLimits();
 

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -5,7 +5,8 @@
  * even if the Umami script has not loaded yet (e.g. ad blockers, SSR).
  */
 
-import { subscribeAuthState } from './auth-state';
+import { subscribeAuthState, type AuthSession } from './auth-state';
+import { onSubscriptionChange, type SubscriptionInfo } from './billing';
 
 // ---------------------------------------------------------------------------
 // Type-safe event catalog — every event name lives here.
@@ -80,29 +81,55 @@ export async function initAnalytics(): Promise<void> {
 // by user/plan. Safe to call before Umami script loads.
 // ---------------------------------------------------------------------------
 
-export function identifyUser(userId: string, plan: string): void {
-  window.umami?.identify({ userId, plan });
+export function identifyUser(
+  userId: string,
+  plan: string,
+  subStatus?: SubscriptionInfo['status'] | null,
+  planKey?: string | null,
+): void {
+  window.umami?.identify({
+    userId,
+    plan,
+    ...(subStatus != null && { subStatus }),
+    ...(planKey != null && { planKey }),
+  });
 }
 
 export function clearIdentity(): void {
   window.umami?.identify({});
 }
 
-let _unsubscribeAuthAnalytics: (() => void) | null = null;
+let _unsubAuth: (() => void) | null = null;
+
+// Cached latest values so either subscription firing can re-identify with full data
+let _lastAuth: AuthSession | null = null;
+let _lastSub: SubscriptionInfo | null = null;
+
+function _syncIdentity(): void {
+  const user = _lastAuth?.user;
+  if (user) {
+    identifyUser(user.id, user.role, _lastSub?.status ?? null, _lastSub?.planKey ?? null);
+  } else {
+    clearIdentity();
+  }
+}
 
 /**
  * Call once after initAuthState() to keep Umami identity in sync with
- * the authenticated user. Re-entrant safe: subsequent calls are no-ops.
+ * the authenticated user and their subscription status.
+ * Re-entrant safe: subsequent calls are no-ops.
  */
 export function initAuthAnalytics(): void {
-  if (_unsubscribeAuthAnalytics) return;
+  if (_unsubAuth) return;
 
-  _unsubscribeAuthAnalytics = subscribeAuthState((state) => {
-    if (state.user) {
-      identifyUser(state.user.id, state.user.role);
-    } else {
-      clearIdentity();
-    }
+  _unsubAuth = subscribeAuthState((state) => {
+    _lastAuth = state;
+    _syncIdentity();
+  });
+
+  onSubscriptionChange((sub) => {
+    _lastSub = sub;
+    _syncIdentity();
   });
 }
 

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -111,6 +111,7 @@ function _syncIdentity(): void {
   if (user) {
     identifyUser(user.id, user.role, _lastSub?.status ?? null, _lastSub?.planKey ?? null);
   } else {
+    _lastSub = null;
     clearIdentity();
   }
 }

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -100,6 +100,7 @@ export function clearIdentity(): void {
 }
 
 let _unsubAuth: (() => void) | null = null;
+let _unsubBilling: (() => void) | null = null;
 
 // Cached latest values so either subscription firing can re-identify with full data
 let _lastAuth: AuthSession | null = null;
@@ -127,10 +128,21 @@ export function initAuthAnalytics(): void {
     _syncIdentity();
   });
 
-  onSubscriptionChange((sub) => {
+  _unsubBilling = onSubscriptionChange((sub) => {
     _lastSub = sub;
     _syncIdentity();
   });
+}
+
+/** Tear down auth + billing listeners. Symmetric with initAuthAnalytics(). */
+export function destroyAuthAnalytics(): void {
+  _unsubAuth?.();
+  _unsubBilling?.();
+  _unsubAuth = null;
+  _unsubBilling = null;
+  _lastAuth = null;
+  _lastSub = null;
+  clearIdentity();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -125,6 +125,11 @@ export function initAuthAnalytics(): void {
   if (_unsubAuth) return;
 
   _unsubAuth = subscribeAuthState((state) => {
+    const prevUserId = _lastAuth?.user?.id ?? null;
+    const nextUserId = state.user?.id ?? null;
+    if (prevUserId !== nextUserId) {
+      _lastSub = null;
+    }
     _lastAuth = state;
     _syncIdentity();
   });


### PR DESCRIPTION
## Summary
- Enhance `identifyUser()` to send `subStatus` and `planKey` alongside `userId`/`plan` to Umami
- Subscribe to billing changes in `initAuthAnalytics()` so identity re-syncs when subscription data arrives via Convex WebSocket
- Remove `isProUser()` guard — all authenticated users are now identified in Umami for proper free vs pro segmentation

Closes #3092

## Test plan
- [ ] Sign in as free user → verify Umami identify payload includes `userId` and `plan` (no `subStatus`/`planKey` until billing loads)
- [ ] Sign in as pro user → verify identify payload includes `subStatus: 'active'` and `planKey` once billing data arrives
- [ ] Cancel subscription → verify re-identify fires with updated `subStatus`

🤖 Generated with [Claude Code](https://claude.com/claude-code)