### PR TITLE
feat(seed-contract): PR 1 foundation — envelope + contract + conformance test

### DIFF
--- a/api/_seed-envelope.js
+++ b/api/_seed-envelope.js
@@ -1,0 +1,38 @@
+// DO NOT EDIT DIRECTLY. This file mirrors scripts/_seed-envelope-source.mjs.
+// Parity is enforced by scripts/verify-seed-envelope-parity.mjs.
+//
+// AGENTS.md:80 forbids `api/*.js` from importing `../server/` — this file exists
+// so edge handlers (api/bootstrap.js, api/health.js, api/mcp.ts, ...) have a
+// same-directory envelope helper.
+
+export function unwrapEnvelope(raw) {
+  if (raw == null) return { _seed: null, data: null };
+  let value = raw;
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return { _seed: null, data: raw };
+    }
+  }
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    return { _seed: null, data: value };
+  }
+  const seed = value._seed;
+  if (seed && typeof seed === 'object' && typeof seed.fetchedAt === 'number') {
+    return { _seed: seed, data: value.data };
+  }
+  return { _seed: null, data: value };
+}
+
+export function stripSeedEnvelope(raw) {
+  return unwrapEnvelope(raw).data;
+}
+
+export function buildEnvelope({ fetchedAt, recordCount, sourceVersion, schemaVersion, state, failedDatasets, errorReason, groupId, data }) {
+  const _seed = { fetchedAt, recordCount, sourceVersion, schemaVersion, state };
+  if (failedDatasets != null) _seed.failedDatasets = failedDatasets;
+  if (errorReason != null) _seed.errorReason = errorReason;
+  if (groupId != null) _seed.groupId = groupId;
+  return { _seed, data };
+}

--- a/api/health.js
+++ b/api/health.js
@@ -1,4 +1,9 @@
 import { jsonResponse } from './_json-response.js';
+// Seed-envelope helper. PR 1 imports it here so PR 2 can wire envelope-aware
+// reads at specific call sites without further plumbing. It's a no-op on
+// legacy-shape seed-meta values (they have no `_seed` wrapper and pass through
+// as `.data`), so importing it is behavior-preserving.
+import { unwrapEnvelope } from './_seed-envelope.js';
 // @ts-expect-error — JS module, no declaration file
 import { redisPipeline, getRedisCredentials } from './_upstash-json.js';
 
@@ -443,7 +448,12 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   if (keyMetaErrors.get(seedCfg.key)) {
     return { seedAge: null, seedStale: null, seedError: false, metaReadFailed: true, metaCount: null };
   }
-  const meta = parseRedisValue(keyMetaValues.get(seedCfg.key));
+  // Unwrap through the envelope helper. Legacy seed-meta is a bare
+  // `{ fetchedAt, recordCount, sourceVersion, status? }` object with no `_seed`
+  // wrapper, so `unwrapEnvelope` returns it as `.data` unchanged. PR 2 wires
+  // true envelope reads at the canonical-key layer; this import establishes
+  // the dependency so behavior stays byte-identical in PR 1.
+  const meta = unwrapEnvelope(parseRedisValue(keyMetaValues.get(seedCfg.key))).data;
   if (meta?.status === 'error') {
     return { seedAge: null, seedStale: true, seedError: true, metaReadFailed: false, metaCount: null };
   }

--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -54,11 +54,14 @@ async function readRedisKey(key) {
  * migrates bundles to `canonicalKey`, this function starts reading envelopes.
  */
 async function readSectionFreshness(section) {
+  // Try the envelope path first when a canonicalKey is declared. If the canonical
+  // key isn't yet written as an envelope (PR 2 writer migration lagging reader
+  // migration, or a legacy payload still present), fall through to the legacy
+  // seed-meta read so the bundle doesn't over-run during the transition.
   if (section.canonicalKey) {
     const raw = await readRedisKey(section.canonicalKey);
     const { _seed } = unwrapEnvelope(raw);
     if (_seed?.fetchedAt) return { fetchedAt: _seed.fetchedAt };
-    return null;
   }
   if (section.seedMetaKey) {
     const raw = await readRedisKey(`seed-meta:${section.seedMetaKey}`);
@@ -66,7 +69,6 @@ async function readSectionFreshness(section) {
     // level. It has no `_seed` wrapper so unwrapEnvelope returns it as data.
     const meta = unwrapEnvelope(raw).data;
     if (meta?.fetchedAt) return { fetchedAt: meta.fetchedAt };
-    return null;
   }
   return null;
 }

--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -14,6 +14,7 @@ import { execFile } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadEnvFile } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -27,19 +28,47 @@ loadEnvFile(import.meta.url);
 const REDIS_URL = process.env.UPSTASH_REDIS_REST_URL;
 const REDIS_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
 
-async function readSeedMeta(seedMetaKey) {
+async function readRedisKey(key) {
   if (!REDIS_URL || !REDIS_TOKEN) return null;
   try {
-    const resp = await fetch(`${REDIS_URL}/get/${encodeURIComponent(`seed-meta:${seedMetaKey}`)}`, {
+    const resp = await fetch(`${REDIS_URL}/get/${encodeURIComponent(key)}`, {
       headers: { Authorization: `Bearer ${REDIS_TOKEN}` },
       signal: AbortSignal.timeout(5_000),
     });
     if (!resp.ok) return null;
-    const data = await resp.json();
-    return data.result ? JSON.parse(data.result) : null;
+    const body = await resp.json();
+    return body.result ? JSON.parse(body.result) : null;
   } catch {
     return null;
   }
+}
+
+/**
+ * Read section freshness for the interval gate.
+ *
+ * Returns `{ fetchedAt }` or null. Prefers envelope-form data when the section
+ * declares `canonicalKey` (PR 2+); falls back to the legacy `seed-meta:<key>`
+ * read used by every bundle file today. PR 1 keeps legacy as the ONLY live
+ * path — `unwrapEnvelope` here is behavior-preserving because legacy seed-meta
+ * values have no `_seed` field and pass through as `data` unchanged. When PR 2
+ * migrates bundles to `canonicalKey`, this function starts reading envelopes.
+ */
+async function readSectionFreshness(section) {
+  if (section.canonicalKey) {
+    const raw = await readRedisKey(section.canonicalKey);
+    const { _seed } = unwrapEnvelope(raw);
+    if (_seed?.fetchedAt) return { fetchedAt: _seed.fetchedAt };
+    return null;
+  }
+  if (section.seedMetaKey) {
+    const raw = await readRedisKey(`seed-meta:${section.seedMetaKey}`);
+    // Legacy seed-meta is `{ fetchedAt, recordCount, sourceVersion }` at top
+    // level. It has no `_seed` wrapper so unwrapEnvelope returns it as data.
+    const meta = unwrapEnvelope(raw).data;
+    if (meta?.fetchedAt) return { fetchedAt: meta.fetchedAt };
+    return null;
+  }
+  return null;
 }
 
 function spawnSeed(scriptPath, { timeoutMs, label }) {
@@ -76,7 +105,8 @@ function spawnSeed(scriptPath, { timeoutMs, label }) {
  * @param {Array<{
  *   label: string,
  *   script: string,
- *   seedMetaKey: string,
+ *   seedMetaKey?: string,    // legacy (pre-contract); reads `seed-meta:<key>`
+ *   canonicalKey?: string,   // PR 2+: reads envelope from the canonical data key
  *   intervalMs: number,
  *   timeoutMs?: number,
  * }>} sections
@@ -91,9 +121,9 @@ export async function runBundle(label, sections) {
     const scriptPath = join(__dirname, section.script);
     const timeout = section.timeoutMs || 300_000;
 
-    const meta = await readSeedMeta(section.seedMetaKey);
-    if (meta?.fetchedAt) {
-      const elapsed = Date.now() - meta.fetchedAt;
+    const freshness = await readSectionFreshness(section);
+    if (freshness?.fetchedAt) {
+      const elapsed = Date.now() - freshness.fetchedAt;
       if (elapsed < section.intervalMs * 0.8) {
         const agoMin = Math.round(elapsed / 60_000);
         const intervalMin = Math.round(section.intervalMs / 60_000);

--- a/scripts/_seed-contract.mjs
+++ b/scripts/_seed-contract.mjs
@@ -39,7 +39,8 @@ const OPTIONAL_FIELDS = new Set([
   'populationMode',
   'cascadeGroup',
   'groupMembers',
-  'recordCount', // legacy — kept optional through PR 2, removed in PR 3 in favor of declareRecords
+  'recordCount',     // legacy — kept optional through PR 2, removed in PR 3 in favor of declareRecords
+  'metaTtlSeconds',  // legacy — used today by writeSeedMeta / writeExtraKeyWithMeta (e.g. scripts/seed-jodi-gas.mjs); removed in PR 3 when legacy meta writes go away
 ]);
 
 /**

--- a/scripts/_seed-contract.mjs
+++ b/scripts/_seed-contract.mjs
@@ -8,8 +8,11 @@
 // contract is enforced at runtime. PR 3 hard-fails the conformance test.
 
 export class SeedContractError extends Error {
-  constructor(message, { descriptor, field } = {}) {
-    super(message);
+  constructor(message, { descriptor, field, cause } = {}) {
+    // Pass `cause` through the standard Error options bag (Node ≥16.9) so the
+    // usual Error causal-chain tooling works (`err.cause`, Node's default
+    // stack printer, Sentry's chained-cause serializer).
+    super(message, cause !== undefined ? { cause } : undefined);
     this.name = 'SeedContractError';
     this.descriptor = descriptor;
     this.field = field;
@@ -82,14 +85,26 @@ export function validateDescriptor(descriptor) {
     }
   }
 
-  if (descriptor.ttlSeconds <= 0) {
-    throw new SeedContractError('runSeed descriptor ttlSeconds must be > 0', { descriptor, field: 'ttlSeconds' });
+  // Non-empty-string fields. `typeof 'string'` accepts '' which would let a
+  // seeder publish to key '' and write seed-meta under a blank resource.
+  for (const field of ['domain', 'resource', 'canonicalKey', 'sourceVersion']) {
+    if (descriptor[field].trim() === '') {
+      throw new SeedContractError(`runSeed descriptor field "${field}" must be a non-empty string`, { descriptor, field });
+    }
+  }
+
+  // Finite positive numbers. `typeof NaN === 'number'` and `NaN > 0 === false`
+  // means a NaN ttl/age would pass the typeof+<=0 check and then poison
+  // expiry/freshness once enforced at runtime. Number.isFinite rejects NaN and
+  // ±Infinity.
+  if (!Number.isFinite(descriptor.ttlSeconds) || descriptor.ttlSeconds <= 0) {
+    throw new SeedContractError('runSeed descriptor ttlSeconds must be a finite number > 0', { descriptor, field: 'ttlSeconds' });
   }
   if (!Number.isInteger(descriptor.schemaVersion) || descriptor.schemaVersion < 1) {
     throw new SeedContractError('runSeed descriptor schemaVersion must be a positive integer', { descriptor, field: 'schemaVersion' });
   }
-  if (descriptor.maxStaleMin <= 0) {
-    throw new SeedContractError('runSeed descriptor maxStaleMin must be > 0', { descriptor, field: 'maxStaleMin' });
+  if (!Number.isFinite(descriptor.maxStaleMin) || descriptor.maxStaleMin <= 0) {
+    throw new SeedContractError('runSeed descriptor maxStaleMin must be a finite number > 0', { descriptor, field: 'maxStaleMin' });
   }
 
   if (descriptor.populationMode != null && descriptor.populationMode !== 'scheduled' && descriptor.populationMode !== 'on_demand') {
@@ -121,9 +136,10 @@ export function resolveRecordCount(declareRecords, data) {
   try {
     count = declareRecords(data);
   } catch (err) {
-    const wrapped = new SeedContractError(`declareRecords threw: ${err && err.message ? err.message : err}`, { field: 'declareRecords' });
-    wrapped.cause = err;
-    throw wrapped;
+    throw new SeedContractError(
+      `declareRecords threw: ${err && err.message ? err.message : err}`,
+      { field: 'declareRecords', cause: err }
+    );
   }
   if (typeof count !== 'number' || !Number.isInteger(count) || count < 0) {
     throw new SeedContractError(

--- a/scripts/_seed-contract.mjs
+++ b/scripts/_seed-contract.mjs
@@ -1,0 +1,139 @@
+// Seed contract validators.
+//
+// See docs/plans/2026-04-14-002-fix-runseed-zero-record-lockout-plan.md.
+//
+// In PR 1 these validators are imported but not yet invoked by `runSeed` — the
+// conformance test (tests/seed-contract.test.mjs) soft-warns on violations
+// without failing CI. PR 2 wires `validateDescriptor()` into `runSeed()` so the
+// contract is enforced at runtime. PR 3 hard-fails the conformance test.
+
+export class SeedContractError extends Error {
+  constructor(message, { descriptor, field } = {}) {
+    super(message);
+    this.name = 'SeedContractError';
+    this.descriptor = descriptor;
+    this.field = field;
+  }
+}
+
+const REQUIRED_FIELDS = [
+  'domain',
+  'resource',
+  'canonicalKey',
+  'fetchFn',
+  'validateFn',
+  'declareRecords',
+  'ttlSeconds',
+  'sourceVersion',
+  'schemaVersion',
+  'maxStaleMin',
+];
+
+const OPTIONAL_FIELDS = new Set([
+  'lockTtlMs',
+  'extraKeys',
+  'afterPublish',
+  'publishTransform',
+  'emptyDataIsFailure',
+  'zeroIsValid',
+  'populationMode',
+  'cascadeGroup',
+  'groupMembers',
+  'recordCount', // legacy — kept optional through PR 2, removed in PR 3 in favor of declareRecords
+]);
+
+/**
+ * Validate that a descriptor passed to `runSeed()` satisfies the contract.
+ *
+ * Throws `SeedContractError` with a specific `field` on the first violation.
+ * Returns the descriptor unchanged on success.
+ */
+export function validateDescriptor(descriptor) {
+  if (descriptor == null || typeof descriptor !== 'object') {
+    throw new SeedContractError('runSeed descriptor must be an object', { descriptor });
+  }
+
+  for (const field of REQUIRED_FIELDS) {
+    if (descriptor[field] == null) {
+      throw new SeedContractError(`runSeed descriptor missing required field: ${field}`, { descriptor, field });
+    }
+  }
+
+  const checks = [
+    ['domain', 'string'],
+    ['resource', 'string'],
+    ['canonicalKey', 'string'],
+    ['fetchFn', 'function'],
+    ['validateFn', 'function'],
+    ['declareRecords', 'function'],
+    ['ttlSeconds', 'number'],
+    ['sourceVersion', 'string'],
+    ['schemaVersion', 'number'],
+    ['maxStaleMin', 'number'],
+  ];
+  for (const [field, expected] of checks) {
+    const actual = typeof descriptor[field];
+    if (actual !== expected) {
+      throw new SeedContractError(
+        `runSeed descriptor field "${field}" must be ${expected}, got ${actual}`,
+        { descriptor, field }
+      );
+    }
+  }
+
+  if (descriptor.ttlSeconds <= 0) {
+    throw new SeedContractError('runSeed descriptor ttlSeconds must be > 0', { descriptor, field: 'ttlSeconds' });
+  }
+  if (!Number.isInteger(descriptor.schemaVersion) || descriptor.schemaVersion < 1) {
+    throw new SeedContractError('runSeed descriptor schemaVersion must be a positive integer', { descriptor, field: 'schemaVersion' });
+  }
+  if (descriptor.maxStaleMin <= 0) {
+    throw new SeedContractError('runSeed descriptor maxStaleMin must be > 0', { descriptor, field: 'maxStaleMin' });
+  }
+
+  if (descriptor.populationMode != null && descriptor.populationMode !== 'scheduled' && descriptor.populationMode !== 'on_demand') {
+    throw new SeedContractError(
+      `runSeed descriptor populationMode must be 'scheduled' or 'on_demand', got ${descriptor.populationMode}`,
+      { descriptor, field: 'populationMode' }
+    );
+  }
+
+  const known = new Set([...REQUIRED_FIELDS, ...OPTIONAL_FIELDS]);
+  for (const field of Object.keys(descriptor)) {
+    if (!known.has(field)) {
+      throw new SeedContractError(`runSeed descriptor has unknown field: ${field}`, { descriptor, field });
+    }
+  }
+
+  return descriptor;
+}
+
+/**
+ * Apply declareRecords to a payload and return a non-negative integer or throw.
+ * Centralized so runSeed, tests, and any future tooling share the same rules.
+ */
+export function resolveRecordCount(declareRecords, data) {
+  if (typeof declareRecords !== 'function') {
+    throw new SeedContractError('declareRecords must be a function', { field: 'declareRecords' });
+  }
+  let count;
+  try {
+    count = declareRecords(data);
+  } catch (err) {
+    const wrapped = new SeedContractError(`declareRecords threw: ${err && err.message ? err.message : err}`, { field: 'declareRecords' });
+    wrapped.cause = err;
+    throw wrapped;
+  }
+  if (typeof count !== 'number' || !Number.isInteger(count) || count < 0) {
+    throw new SeedContractError(
+      `declareRecords must return a non-negative integer, got ${JSON.stringify(count)}`,
+      { field: 'declareRecords' }
+    );
+  }
+  return count;
+}
+
+// Re-export envelope helpers so seeder code can import "everything contract-y"
+// from one module. The single source of truth for the helpers themselves is
+// scripts/_seed-envelope-source.mjs.
+export { unwrapEnvelope, stripSeedEnvelope, buildEnvelope } from './_seed-envelope-source.mjs';

--- a/scripts/_seed-envelope-source.mjs
+++ b/scripts/_seed-envelope-source.mjs
@@ -1,0 +1,86 @@
+// Single source of truth for the seed-envelope helpers.
+//
+// This file is hand-authored but its PUBLIC SHAPE is mirrored verbatim in:
+//   - server/_shared/seed-envelope.ts  (imported from server/**/*.ts and scripts/**/*.mjs)
+//   - api/_seed-envelope.js            (imported from api/*.js — edge-safe, per AGENTS.md
+//                                       forbidding api/ → server/ imports)
+//
+// Parity is enforced by scripts/verify-seed-envelope-parity.mjs and covered by a
+// test in tests/seed-envelope-parity.test.mjs.
+//
+// The seed envelope is the unified shape for every seeded Redis value once the
+// contract migrates. See docs/plans/2026-04-14-002-fix-runseed-zero-record-lockout-plan.md
+// for the full design.
+//
+//   {
+//     _seed: {
+//       fetchedAt: number,                           // ms since epoch
+//       recordCount: number,                         // integer ≥ 0
+//       sourceVersion: string,                       // seeder-declared
+//       schemaVersion: number,                       // increments when `data` shape changes
+//       state: 'OK' | 'OK_ZERO' | 'ERROR',
+//       failedDatasets?: string[],                   // present when state === 'ERROR'
+//       errorReason?: string,                        // present when state === 'ERROR'
+//       groupId?: string,                            // for multi-key group writes
+//     },
+//     data: <the actual payload>,
+//   }
+//
+// During the rollout, many Redis values are still in the LEGACY shape (no `_seed`
+// wrapper). All helpers below treat legacy values as `{ _seed: null, data: raw }`
+// so callers can adopt envelope-aware reads without breaking behavior. This is
+// what makes PR 1 behavior-preserving.
+
+/**
+ * Parse a raw Redis value (already JSON.parse'd, or a string that needs parsing)
+ * into the canonical `{ _seed, data }` pair.
+ *
+ * - Returns `{ _seed: null, data: null }` when the input is null/undefined.
+ * - Returns `{ _seed, data }` when the input has a well-formed `_seed` block.
+ * - Returns `{ _seed: null, data: raw }` for any other shape (legacy passthrough).
+ *
+ * Intentionally permissive: never throws. A seeder that publishes garbage is a
+ * write-side bug; readers degrade to legacy semantics rather than crashing.
+ */
+export function unwrapEnvelope(raw) {
+  if (raw == null) return { _seed: null, data: null };
+  let value = raw;
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return { _seed: null, data: raw };
+    }
+  }
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    return { _seed: null, data: value };
+  }
+  const seed = value._seed;
+  if (seed && typeof seed === 'object' && typeof seed.fetchedAt === 'number') {
+    return { _seed: seed, data: value.data };
+  }
+  return { _seed: null, data: value };
+}
+
+/**
+ * Strip the envelope and return the inner `data` payload for public callers.
+ * Legacy values pass through unchanged. Use this at any public boundary — RPC
+ * responses, bootstrap payloads, MCP tool outputs — so `_seed` never leaves the
+ * backend.
+ */
+export function stripSeedEnvelope(raw) {
+  return unwrapEnvelope(raw).data;
+}
+
+/**
+ * Build an envelope for a seeder's successful run. Does NOT validate the seed
+ * meta fields beyond what the type expects; `validateDescriptor` in
+ * scripts/_seed-contract.mjs handles pre-publish validation.
+ */
+export function buildEnvelope({ fetchedAt, recordCount, sourceVersion, schemaVersion, state, failedDatasets, errorReason, groupId, data }) {
+  const _seed = { fetchedAt, recordCount, sourceVersion, schemaVersion, state };
+  if (failedDatasets != null) _seed.failedDatasets = failedDatasets;
+  if (errorReason != null) _seed.errorReason = errorReason;
+  if (groupId != null) _seed.groupId = groupId;
+  return { _seed, data };
+}

--- a/scripts/verify-seed-envelope-parity.mjs
+++ b/scripts/verify-seed-envelope-parity.mjs
@@ -38,8 +38,10 @@ const EDGE = resolve(repoRoot, 'api/_seed-envelope.js');
  * Extract bare function bodies from a source file, keyed by name.
  * Returns a Map<name, body> where body is the function's implementation with
  * TypeScript type annotations stripped and whitespace normalized.
+ *
+ * Exported so tests can exercise brace/string edge cases directly.
  */
-function extractFunctions(source) {
+export function extractFunctions(source) {
   const fns = new Map();
   // Match: export function NAME<generics?>(args): returnType? { body }
   // We capture NAME and the brace-balanced body.
@@ -49,26 +51,19 @@ function extractFunctions(source) {
     const name = match[1];
     const afterParen = match.index + match[0].length;
     // Find matching close paren for args
-    let depth = 1;
-    let i = afterParen;
-    while (i < source.length && depth > 0) {
-      if (source[i] === '(') depth++;
-      else if (source[i] === ')') depth--;
-      i++;
-    }
-    // Skip to opening {
+    // Balance the arg-list parens, skipping string / template / comment bodies.
+    // scanBalanced expects `start` to point at (or before) the opening
+    // delimiter; `afterParen` is one past it, so step back.
+    let i = scanBalanced(source, afterParen - 1, '(', ')');
+    // Skip to opening { (may cross return-type annotations that contain `:`).
     while (i < source.length && source[i] !== '{') i++;
     if (i >= source.length) continue;
-    // Brace-balance to find end of function body
+    // Balance the function body's braces using the same string/comment-aware
+    // scanner. Raw `{` inside a string literal like `const marker = '{'` used
+    // to drop `depth` past zero and either truncate or overrun the body.
     const bodyStart = i + 1;
-    depth = 1;
-    i++;
-    while (i < source.length && depth > 0) {
-      const ch = source[i];
-      if (ch === '{') depth++;
-      else if (ch === '}') depth--;
-      i++;
-    }
+    // `i` points at the opening `{`, which is exactly what scanBalanced wants.
+    i = scanBalanced(source, i, '{', '}');
     const bodyEnd = i - 1;
     const body = source.slice(bodyStart, bodyEnd);
     // Bodies must be VERBATIM identical across the three files (parity rule).
@@ -78,6 +73,56 @@ function extractFunctions(source) {
     fns.set(name, normalize(body));
   }
   return fns;
+}
+
+/**
+ * Scan from `start` (which must point AT or just before the opening delimiter),
+ * balancing `open`/`close` while skipping characters inside line comments,
+ * block comments, and string / template literals. Returns the index one past
+ * the matching close delimiter. If input is malformed we return `source.length`
+ * so the caller still produces a (truncated) body rather than an infinite loop.
+ */
+export function scanBalanced(source, start, open, close) {
+  let i = start;
+  // Align `i` to the opening delimiter if it isn't already.
+  while (i < source.length && source[i] !== open) i++;
+  if (i >= source.length) return source.length;
+  let depth = 1;
+  i++;
+  while (i < source.length && depth > 0) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (ch === '/' && next === '/') {
+      const nl = source.indexOf('\n', i);
+      i = nl < 0 ? source.length : nl;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      const c = source.indexOf('*/', i + 2);
+      i = c < 0 ? source.length : c + 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      let j = i + 1;
+      while (j < source.length && source[j] !== ch) {
+        if (source[j] === '\\' && j + 1 < source.length) { j += 2; continue; }
+        // Template-literal interpolation `${ ... }` — recurse to skip matched
+        // braces inside the interpolation so an expression like `${{a:1}}`
+        // doesn't leak a stray `}` into our outer body balance.
+        if (ch === '`' && source[j] === '$' && source[j + 1] === '{') {
+          j = scanBalanced(source, j + 1, '{', '}');
+          continue;
+        }
+        j++;
+      }
+      i = j + 1;
+      continue;
+    }
+    if (ch === open) depth++;
+    else if (ch === close) depth--;
+    i++;
+  }
+  return i;
 }
 
 function normalize(s) {
@@ -129,7 +174,14 @@ async function main() {
   console.log('seed-envelope parity: OK (3 exports verified across source + edge). TS mirror checked by tsc.');
 }
 
-main().catch((err) => {
-  console.error('verify-seed-envelope-parity: unexpected error', err);
-  process.exit(1);
-});
+// isMain guard — only run the verifier when invoked directly as a CLI. Tests
+// import this module to exercise extractFunctions/scanBalanced in isolation,
+// and running main() on import would trigger process.exit from the test
+// process.
+const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^file:\/\//, ''));
+if (isMain) {
+  main().catch((err) => {
+    console.error('verify-seed-envelope-parity: unexpected error', err);
+    process.exit(1);
+  });
+}

--- a/scripts/verify-seed-envelope-parity.mjs
+++ b/scripts/verify-seed-envelope-parity.mjs
@@ -43,7 +43,7 @@ function extractFunctions(source) {
   const fns = new Map();
   // Match: export function NAME<generics?>(args): returnType? { body }
   // We capture NAME and the brace-balanced body.
-  const pattern = /export\s+function\s+(\w+)\s*(?:<[^>]+>)?\s*\(/g;
+  const pattern = /export\s+(?:async\s+)?function\s+(\w+)\s*(?:<[^>]+>)?\s*\(/g;
   let match;
   while ((match = pattern.exec(source)) != null) {
     const name = match[1];

--- a/scripts/verify-seed-envelope-parity.mjs
+++ b/scripts/verify-seed-envelope-parity.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Verify that the three seed-envelope helper files stay in sync.
+//
+// The source of truth is scripts/_seed-envelope-source.mjs. Two mirrored copies
+// live at:
+//   - api/_seed-envelope.js            (edge-safe, for api/*.js)
+//   - server/_shared/seed-envelope.ts  (TypeScript, for server/ and scripts/)
+//
+// The TypeScript copy carries additional type declarations, so the check is
+// function-by-function: every function exported from the source must appear in
+// both copies with identical runtime body (after normalizing TS annotations).
+//
+// Exit 1 with a diff on drift.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+
+// Parity scope.
+//
+// Source of truth: scripts/_seed-envelope-source.mjs (plain JS, hand-authored).
+// Must-match copy:  api/_seed-envelope.js           (plain JS, hand-authored).
+//
+// The TypeScript copy at server/_shared/seed-envelope.ts is type-checked by
+// `tsc` and reviewed manually. It is NOT diffed here because TS-specific casts
+// (`as any`, `as SeedMeta`, etc.) can't be stripped without introducing their
+// own bug class. The drift risk on the TS file is mitigated by (a) this header
+// comment in that file forbidding direct edits, (b) the typecheck guard, and
+// (c) code review. If we ever need stricter enforcement, a separate AST-aware
+// comparator can run over the TS file.
+const SOURCE = resolve(repoRoot, 'scripts/_seed-envelope-source.mjs');
+const EDGE = resolve(repoRoot, 'api/_seed-envelope.js');
+
+/**
+ * Extract bare function bodies from a source file, keyed by name.
+ * Returns a Map<name, body> where body is the function's implementation with
+ * TypeScript type annotations stripped and whitespace normalized.
+ */
+function extractFunctions(source) {
+  const fns = new Map();
+  // Match: export function NAME<generics?>(args): returnType? { body }
+  // We capture NAME and the brace-balanced body.
+  const pattern = /export\s+function\s+(\w+)\s*(?:<[^>]+>)?\s*\(/g;
+  let match;
+  while ((match = pattern.exec(source)) != null) {
+    const name = match[1];
+    const afterParen = match.index + match[0].length;
+    // Find matching close paren for args
+    let depth = 1;
+    let i = afterParen;
+    while (i < source.length && depth > 0) {
+      if (source[i] === '(') depth++;
+      else if (source[i] === ')') depth--;
+      i++;
+    }
+    // Skip to opening {
+    while (i < source.length && source[i] !== '{') i++;
+    if (i >= source.length) continue;
+    // Brace-balance to find end of function body
+    const bodyStart = i + 1;
+    depth = 1;
+    i++;
+    while (i < source.length && depth > 0) {
+      const ch = source[i];
+      if (ch === '{') depth++;
+      else if (ch === '}') depth--;
+      i++;
+    }
+    const bodyEnd = i - 1;
+    const body = source.slice(bodyStart, bodyEnd);
+    // Bodies must be VERBATIM identical across the three files (parity rule).
+    // Type annotations are only permitted OUTSIDE function bodies — signatures,
+    // top-level interfaces, etc. We compare normalized (whitespace/comments
+    // collapsed) bodies but never strip characters from inside them.
+    fns.set(name, normalize(body));
+  }
+  return fns;
+}
+
+function normalize(s) {
+  return s
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const EXPECTED_EXPORTS = ['unwrapEnvelope', 'stripSeedEnvelope', 'buildEnvelope'];
+
+async function main() {
+  const [sourceSrc, edgeSrc] = await Promise.all([
+    readFile(SOURCE, 'utf8'),
+    readFile(EDGE, 'utf8'),
+  ]);
+
+  const sourceFns = extractFunctions(sourceSrc);
+  const edgeFns = extractFunctions(edgeSrc);
+
+  const errors = [];
+
+  for (const name of EXPECTED_EXPORTS) {
+    if (!sourceFns.has(name)) errors.push(`source missing export: ${name}`);
+    if (!edgeFns.has(name)) errors.push(`api/_seed-envelope.js missing export: ${name}`);
+  }
+
+  if (errors.length) {
+    console.error('Missing exports:');
+    for (const e of errors) console.error(`  ${e}`);
+    process.exit(1);
+  }
+
+  for (const name of EXPECTED_EXPORTS) {
+    const src = sourceFns.get(name);
+    const edge = edgeFns.get(name);
+    if (src !== edge) {
+      errors.push(`drift: api/_seed-envelope.js::${name} differs from source.\n  source: ${src}\n  edge:   ${edge}`);
+    }
+  }
+
+  if (errors.length) {
+    console.error('Seed-envelope parity check FAILED:');
+    for (const e of errors) console.error(`\n  ${e}`);
+    process.exit(1);
+  }
+
+  console.log('seed-envelope parity: OK (3 exports verified across source + edge). TS mirror checked by tsc.');
+}
+
+main().catch((err) => {
+  console.error('verify-seed-envelope-parity: unexpected error', err);
+  process.exit(1);
+});

--- a/server/_shared/seed-envelope.ts
+++ b/server/_shared/seed-envelope.ts
@@ -1,0 +1,77 @@
+// Mirror of scripts/_seed-envelope-source.mjs.
+//
+// DO NOT EDIT function behavior here independently — keep implementations in
+// lockstep with the JS source (same control flow, same field access, same
+// return shapes). Runtime parity between this file and
+// scripts/_seed-envelope-source.mjs / api/_seed-envelope.js is the contract.
+// TS-only narrowing/casting is tolerated, but the runtime effect must match.
+//
+// The JS source ↔ edge copy are diffed programmatically by
+// scripts/verify-seed-envelope-parity.mjs. The TS copy is reviewed manually
+// and validated by `tsc --noEmit`.
+
+export type SeedState = 'OK' | 'OK_ZERO' | 'ERROR';
+
+export interface SeedMeta {
+  fetchedAt: number;
+  recordCount: number;
+  sourceVersion: string;
+  schemaVersion: number;
+  state: SeedState;
+  failedDatasets?: string[];
+  errorReason?: string;
+  groupId?: string;
+}
+
+export interface SeedEnvelope<T = unknown> {
+  _seed: SeedMeta;
+  data: T;
+}
+
+export interface UnwrapResult<T = unknown> {
+  _seed: SeedMeta | null;
+  data: T | null;
+}
+
+export function unwrapEnvelope(raw: unknown): UnwrapResult {
+  if (raw == null) return { _seed: null, data: null };
+  let value: any = raw;
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return { _seed: null, data: raw };
+    }
+  }
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    return { _seed: null, data: value };
+  }
+  const seed = value._seed;
+  if (seed && typeof seed === 'object' && typeof seed.fetchedAt === 'number') {
+    return { _seed: seed, data: value.data };
+  }
+  return { _seed: null, data: value };
+}
+
+export function stripSeedEnvelope(raw: unknown): unknown {
+  return unwrapEnvelope(raw).data;
+}
+
+export function buildEnvelope(input: {
+  fetchedAt: number;
+  recordCount: number;
+  sourceVersion: string;
+  schemaVersion: number;
+  state: SeedState;
+  failedDatasets?: string[];
+  errorReason?: string;
+  groupId?: string;
+  data: unknown;
+}): SeedEnvelope {
+  const { fetchedAt, recordCount, sourceVersion, schemaVersion, state, failedDatasets, errorReason, groupId, data } = input;
+  const _seed: SeedMeta = { fetchedAt, recordCount, sourceVersion, schemaVersion, state };
+  if (failedDatasets != null) _seed.failedDatasets = failedDatasets;
+  if (errorReason != null) _seed.errorReason = errorReason;
+  if (groupId != null) _seed.groupId = groupId;
+  return { _seed, data };
+}

--- a/tests/seed-contract.test.mjs
+++ b/tests/seed-contract.test.mjs
@@ -71,6 +71,33 @@ test('validateDescriptor: rejects ttlSeconds <= 0', () => {
   assert.throws(() => validateDescriptor(minimalDescriptor({ ttlSeconds: -5 })), SeedContractError);
 });
 
+test('validateDescriptor: rejects non-finite ttlSeconds (NaN, Infinity)', () => {
+  // `typeof NaN === "number"` and `NaN > 0 === false`, so the old check
+  // silently accepted it; Number.isFinite is what we actually want.
+  assert.throws(() => validateDescriptor(minimalDescriptor({ ttlSeconds: NaN })), SeedContractError);
+  assert.throws(() => validateDescriptor(minimalDescriptor({ ttlSeconds: Infinity })), SeedContractError);
+  assert.throws(() => validateDescriptor(minimalDescriptor({ ttlSeconds: -Infinity })), SeedContractError);
+});
+
+test('validateDescriptor: rejects non-finite maxStaleMin (NaN, Infinity)', () => {
+  assert.throws(() => validateDescriptor(minimalDescriptor({ maxStaleMin: NaN })), SeedContractError);
+  assert.throws(() => validateDescriptor(minimalDescriptor({ maxStaleMin: Infinity })), SeedContractError);
+});
+
+for (const field of ['domain', 'resource', 'canonicalKey', 'sourceVersion']) {
+  test(`validateDescriptor: rejects empty string for "${field}"`, () => {
+    const err = expectThrows(() => validateDescriptor(minimalDescriptor({ [field]: '' })));
+    assert.ok(err instanceof SeedContractError);
+    assert.equal(err.field, field);
+  });
+
+  test(`validateDescriptor: rejects whitespace-only string for "${field}"`, () => {
+    const err = expectThrows(() => validateDescriptor(minimalDescriptor({ [field]: '   ' })));
+    assert.ok(err instanceof SeedContractError);
+    assert.equal(err.field, field);
+  });
+}
+
 test('validateDescriptor: rejects non-integer schemaVersion', () => {
   assert.throws(() => validateDescriptor(minimalDescriptor({ schemaVersion: 1.5 })), SeedContractError);
   assert.throws(() => validateDescriptor(minimalDescriptor({ schemaVersion: 0 })), SeedContractError);
@@ -113,6 +140,13 @@ test('resolveRecordCount: wraps thrown errors with SeedContractError + cause', (
   assert.ok(err instanceof SeedContractError);
   assert.match(err.message, /declareRecords threw: boom/);
   assert.equal(err.cause?.message, 'boom');
+});
+
+test('SeedContractError: accepts cause via options bag (Error v2 spec)', () => {
+  const underlying = new TypeError('inner');
+  const err = new SeedContractError('wrap', { field: 'declareRecords', cause: underlying });
+  assert.equal(err.cause, underlying);
+  assert.equal(err.field, 'declareRecords');
 });
 
 test('resolveRecordCount: rejects non-function declareRecords', () => {

--- a/tests/seed-contract.test.mjs
+++ b/tests/seed-contract.test.mjs
@@ -176,39 +176,112 @@ function hasRunSeedCall(src) {
   return /\brunSeed\s*\(/.test(src);
 }
 
-test('conformance: every scripts/seed-*.mjs that calls runSeed() should export declareRecords', async (t) => {
+// Required opts-based fields a descriptor must carry (positional args
+// `domain, resource, canonicalKey, fetchFn` are handled outside the opts).
+// Must match the REQUIRED_FIELDS set in scripts/_seed-contract.mjs minus the
+// four positional arg names.
+const REQUIRED_OPTS_FIELDS = ['validateFn', 'declareRecords', 'ttlSeconds', 'sourceVersion', 'schemaVersion', 'maxStaleMin'];
+
+/**
+ * Extract the single `runSeed(...)` call site as a raw string, balance-matching
+ * parentheses so embedded function literals and object literals don't throw off
+ * substring checks. Returns null if no runSeed call is found.
+ */
+function extractRunSeedCall(src) {
+  const start = src.search(/\brunSeed\s*\(/);
+  if (start < 0) return null;
+  const open = src.indexOf('(', start);
+  let depth = 1;
+  let i = open + 1;
+  while (i < src.length && depth > 0) {
+    const ch = src[i];
+    if (ch === '(' ) depth++;
+    else if (ch === ')') depth--;
+    else if (ch === '/' && src[i + 1] === '/') {
+      const nl = src.indexOf('\n', i);
+      i = nl < 0 ? src.length : nl;
+      continue;
+    } else if (ch === '/' && src[i + 1] === '*') {
+      const close = src.indexOf('*/', i);
+      i = close < 0 ? src.length : close + 2;
+      continue;
+    } else if (ch === '"' || ch === "'" || ch === '`') {
+      // Skip over string literal — rough but adequate for these seeders.
+      let j = i + 1;
+      while (j < src.length && src[j] !== ch) {
+        if (src[j] === '\\') j += 2;
+        else j++;
+      }
+      i = j + 1;
+      continue;
+    }
+    i++;
+  }
+  return src.slice(open + 1, i - 1);
+}
+
+/**
+ * True when a `runSeed(...)` call-site carries all required opts-based
+ * descriptor fields (checked by presence of the field name as a key).
+ */
+function descriptorFieldsPresent(callSrc) {
+  const missing = [];
+  for (const field of REQUIRED_OPTS_FIELDS) {
+    // Match `field:` or `field ,` (shorthand property) with a word boundary so
+    // `sourceVersion` doesn't accidentally match `sourceVersions:`.
+    const re = new RegExp(`\\b${field}\\b\\s*[:,}]`);
+    if (!re.test(callSrc)) missing.push(field);
+  }
+  return { ok: missing.length === 0, missing };
+}
+
+test('conformance: every scripts/seed-*.mjs that calls runSeed() satisfies the descriptor contract', async (t) => {
   const files = await findSeederFiles();
   assert.ok(files.length > 0, 'expected at least one seeder file');
 
   const runSeedCallers = [];
-  const missing = [];
+  const incomplete = []; // [{ file, missing: string[] }]
   for (const file of files) {
     const src = await readFile(file, 'utf8');
     if (!hasRunSeedCall(src)) continue;
     runSeedCallers.push(file);
-    if (!hasDeclareRecordsExport(src)) {
-      missing.push(file.replace(scriptsDir + '/', ''));
+
+    const missing = [];
+    if (!hasDeclareRecordsExport(src)) missing.push('declareRecords export');
+
+    const callSrc = extractRunSeedCall(src);
+    if (callSrc == null) {
+      missing.push('unparseable runSeed(...) call');
+    } else {
+      const result = descriptorFieldsPresent(callSrc);
+      if (!result.ok) missing.push(...result.missing.map((f) => `opt:${f}`));
+    }
+
+    if (missing.length > 0) {
+      incomplete.push({ file: file.replace(scriptsDir + '/', ''), missing });
     }
   }
 
-  // Surface the summary as a diagnostic so it's visible in `node --test` output
-  // even when the test passes. This is the migration-progress signal.
-  const migrated = runSeedCallers.length - missing.length;
-  t.diagnostic(`seed-contract conformance: ${migrated}/${runSeedCallers.length} seeders export declareRecords`);
+  // Migration-progress signal. Must remain visible in `node --test` even when
+  // the test passes — this is the readiness indicator for PR 2/PR 3.
+  const migrated = runSeedCallers.length - incomplete.length;
+  t.diagnostic(`seed-contract conformance: ${migrated}/${runSeedCallers.length} seeders satisfy the full descriptor`);
 
-  if (missing.length > 0) {
-    // SEED_CONTRACT_STRICT=1 flips this to a hard failure — the mechanism PR 3
-    // will use to block merges once the migration is complete. PR 1 default is
-    // soft-warn so local dev and CI don't red-flag an expected migration state.
+  if (incomplete.length > 0) {
+    // SEED_CONTRACT_STRICT=1 flips this to a hard failure. PR 3 will enable
+    // strict mode by default once the fleet is migrated.
     const strict = process.env.SEED_CONTRACT_STRICT === '1';
-    const head = `[seed-contract] ${missing.length} seeders missing declareRecords (of ${runSeedCallers.length} runSeed callers)`;
+    const head = `[seed-contract] ${incomplete.length}/${runSeedCallers.length} seeders incomplete (missing declareRecords export AND/OR required opts ${REQUIRED_OPTS_FIELDS.join(', ')})`;
     if (strict) {
-      assert.fail(`${head}: ${missing.slice(0, 10).join(', ')}${missing.length > 10 ? ', …' : ''}`);
+      const sample = incomplete.slice(0, 5).map((x) => `${x.file}: ${x.missing.join(', ')}`).join(' | ');
+      assert.fail(`${head}. First offenders: ${sample}${incomplete.length > 5 ? ', …' : ''}`);
     }
     console.warn(head);
-    for (const name of missing) console.warn(`  - ${name}`);
+    for (const { file, missing } of incomplete) {
+      console.warn(`  - ${file}: ${missing.join(', ')}`);
+    }
     console.warn('Soft-warn: expected during PR 1/2. Set SEED_CONTRACT_STRICT=1 to hard-fail. PR 3 will enable strict mode by default.');
-    t.diagnostic(`${missing.length} seeders awaiting declareRecords migration`);
+    t.diagnostic(`${incomplete.length} seeders awaiting full descriptor migration`);
   }
 });
 

--- a/tests/seed-contract.test.mjs
+++ b/tests/seed-contract.test.mjs
@@ -1,0 +1,176 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  SeedContractError,
+  validateDescriptor,
+  resolveRecordCount,
+} from '../scripts/_seed-contract.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scriptsDir = resolve(here, '..', 'scripts');
+
+function minimalDescriptor(overrides = {}) {
+  return {
+    domain: 'test',
+    resource: 'thing',
+    canonicalKey: 'test:thing:v1',
+    fetchFn: async () => ({}),
+    validateFn: () => true,
+    declareRecords: (d) => (d?.items?.length ?? 0),
+    ttlSeconds: 3600,
+    sourceVersion: 'v1',
+    schemaVersion: 1,
+    maxStaleMin: 120,
+    ...overrides,
+  };
+}
+
+// ─── validateDescriptor ────────────────────────────────────────────────────
+
+test('validateDescriptor: accepts a minimal valid descriptor', () => {
+  assert.doesNotThrow(() => validateDescriptor(minimalDescriptor()));
+});
+
+test('validateDescriptor: rejects non-object input', () => {
+  assert.throws(() => validateDescriptor(null), SeedContractError);
+  assert.throws(() => validateDescriptor('string'), SeedContractError);
+});
+
+function expectThrows(fn) {
+  try {
+    fn();
+  } catch (err) {
+    return err;
+  }
+  assert.fail('expected function to throw');
+}
+
+for (const field of [
+  'domain', 'resource', 'canonicalKey', 'fetchFn', 'validateFn',
+  'declareRecords', 'ttlSeconds', 'sourceVersion', 'schemaVersion', 'maxStaleMin',
+]) {
+  test(`validateDescriptor: rejects missing required field "${field}"`, () => {
+    const d = minimalDescriptor();
+    delete d[field];
+    const err = expectThrows(() => validateDescriptor(d));
+    assert.ok(err instanceof SeedContractError, `expected SeedContractError, got ${err?.constructor?.name}`);
+    assert.equal(err.field, field);
+  });
+}
+
+test('validateDescriptor: rejects wrong type on ttlSeconds', () => {
+  assert.throws(() => validateDescriptor(minimalDescriptor({ ttlSeconds: '3600' })), SeedContractError);
+});
+
+test('validateDescriptor: rejects ttlSeconds <= 0', () => {
+  assert.throws(() => validateDescriptor(minimalDescriptor({ ttlSeconds: 0 })), SeedContractError);
+  assert.throws(() => validateDescriptor(minimalDescriptor({ ttlSeconds: -5 })), SeedContractError);
+});
+
+test('validateDescriptor: rejects non-integer schemaVersion', () => {
+  assert.throws(() => validateDescriptor(minimalDescriptor({ schemaVersion: 1.5 })), SeedContractError);
+  assert.throws(() => validateDescriptor(minimalDescriptor({ schemaVersion: 0 })), SeedContractError);
+});
+
+test('validateDescriptor: rejects invalid populationMode', () => {
+  assert.throws(() => validateDescriptor(minimalDescriptor({ populationMode: 'never' })), SeedContractError);
+});
+
+test('validateDescriptor: accepts valid populationMode values', () => {
+  assert.doesNotThrow(() => validateDescriptor(minimalDescriptor({ populationMode: 'scheduled' })));
+  assert.doesNotThrow(() => validateDescriptor(minimalDescriptor({ populationMode: 'on_demand' })));
+});
+
+test('validateDescriptor: rejects unknown fields (prevents silent typos)', () => {
+  const err = expectThrows(() => validateDescriptor(minimalDescriptor({ recordCoount: 5 })));
+  assert.ok(err instanceof SeedContractError);
+  assert.equal(err.field, 'recordCoount');
+});
+
+// ─── resolveRecordCount ────────────────────────────────────────────────────
+
+test('resolveRecordCount: returns non-negative integer', () => {
+  assert.equal(resolveRecordCount((d) => d.length, [1, 2, 3]), 3);
+  assert.equal(resolveRecordCount(() => 0, null), 0);
+});
+
+test('resolveRecordCount: rejects negative returns', () => {
+  assert.throws(() => resolveRecordCount(() => -1, {}), SeedContractError);
+});
+
+test('resolveRecordCount: rejects non-integer returns', () => {
+  assert.throws(() => resolveRecordCount(() => 1.5, {}), SeedContractError);
+  assert.throws(() => resolveRecordCount(() => 'three', {}), SeedContractError);
+  assert.throws(() => resolveRecordCount(() => null, {}), SeedContractError);
+});
+
+test('resolveRecordCount: wraps thrown errors with SeedContractError + cause', () => {
+  const err = expectThrows(() => resolveRecordCount(() => { throw new Error('boom'); }, {}));
+  assert.ok(err instanceof SeedContractError);
+  assert.match(err.message, /declareRecords threw: boom/);
+  assert.equal(err.cause?.message, 'boom');
+});
+
+test('resolveRecordCount: rejects non-function declareRecords', () => {
+  assert.throws(() => resolveRecordCount('not a function', {}), SeedContractError);
+});
+
+// ─── Seeder conformance (static AST-lite parse, no dynamic import) ─────────
+// We do NOT `import()` any scripts/seed-*.mjs file because several of them
+// `process.exit()` at module load (seed-consumer-prices.mjs:31,
+// seed-military-maritime-news.mjs:68, seed-service-statuses.mjs:43). We scan
+// the file text for required patterns. PR 1 soft-warns; PR 3 hard-fails.
+
+async function findSeederFiles() {
+  const entries = await readdir(scriptsDir);
+  return entries
+    .filter((f) => f.startsWith('seed-') && f.endsWith('.mjs'))
+    .filter((f) => !f.startsWith('seed-bundle-')) // bundle orchestrators are not seeders
+    .map((f) => resolve(scriptsDir, f));
+}
+
+function hasDeclareRecordsExport(src) {
+  // Matches `export function declareRecords(` OR `export const declareRecords =`
+  return /export\s+(function\s+declareRecords\s*\(|const\s+declareRecords\s*=)/.test(src);
+}
+
+function hasRunSeedCall(src) {
+  return /\brunSeed\s*\(/.test(src);
+}
+
+test('conformance: every scripts/seed-*.mjs that calls runSeed() should export declareRecords (soft-warn in PR 1)', async (t) => {
+  const files = await findSeederFiles();
+  assert.ok(files.length > 0, 'expected at least one seeder file');
+
+  const missing = [];
+  for (const file of files) {
+    const src = await readFile(file, 'utf8');
+    if (!hasRunSeedCall(src)) continue;
+    if (!hasDeclareRecordsExport(src)) {
+      missing.push(file.replace(scriptsDir + '/', ''));
+    }
+  }
+
+  if (missing.length > 0) {
+    // PR 1: soft-warn. Do NOT fail the test — the plan mandates gradual migration.
+    // PR 3 will flip this to assert.equal(missing.length, 0).
+    console.warn(`[seed-contract soft-warn] ${missing.length} seeders do not yet export declareRecords:`);
+    for (const name of missing) console.warn(`  - ${name}`);
+    console.warn('This is expected during PR 1. PR 2 migrates each seeder; PR 3 will hard-fail this test.');
+    t.diagnostic(`${missing.length} seeders awaiting declareRecords migration`);
+  }
+});
+
+test('conformance: seeders that already export declareRecords have a top-level export (not nested)', async (t) => {
+  const files = await findSeederFiles();
+  let migrated = 0;
+  for (const file of files) {
+    const src = await readFile(file, 'utf8');
+    if (hasDeclareRecordsExport(src)) migrated++;
+  }
+  t.diagnostic(`${migrated}/${files.length} seeders have declareRecords export`);
+});

--- a/tests/seed-contract.test.mjs
+++ b/tests/seed-contract.test.mjs
@@ -142,25 +142,38 @@ function hasRunSeedCall(src) {
   return /\brunSeed\s*\(/.test(src);
 }
 
-test('conformance: every scripts/seed-*.mjs that calls runSeed() should export declareRecords (soft-warn in PR 1)', async (t) => {
+test('conformance: every scripts/seed-*.mjs that calls runSeed() should export declareRecords', async (t) => {
   const files = await findSeederFiles();
   assert.ok(files.length > 0, 'expected at least one seeder file');
 
+  const runSeedCallers = [];
   const missing = [];
   for (const file of files) {
     const src = await readFile(file, 'utf8');
     if (!hasRunSeedCall(src)) continue;
+    runSeedCallers.push(file);
     if (!hasDeclareRecordsExport(src)) {
       missing.push(file.replace(scriptsDir + '/', ''));
     }
   }
 
+  // Surface the summary as a diagnostic so it's visible in `node --test` output
+  // even when the test passes. This is the migration-progress signal.
+  const migrated = runSeedCallers.length - missing.length;
+  t.diagnostic(`seed-contract conformance: ${migrated}/${runSeedCallers.length} seeders export declareRecords`);
+
   if (missing.length > 0) {
-    // PR 1: soft-warn. Do NOT fail the test — the plan mandates gradual migration.
-    // PR 3 will flip this to assert.equal(missing.length, 0).
-    console.warn(`[seed-contract soft-warn] ${missing.length} seeders do not yet export declareRecords:`);
+    // SEED_CONTRACT_STRICT=1 flips this to a hard failure — the mechanism PR 3
+    // will use to block merges once the migration is complete. PR 1 default is
+    // soft-warn so local dev and CI don't red-flag an expected migration state.
+    const strict = process.env.SEED_CONTRACT_STRICT === '1';
+    const head = `[seed-contract] ${missing.length} seeders missing declareRecords (of ${runSeedCallers.length} runSeed callers)`;
+    if (strict) {
+      assert.fail(`${head}: ${missing.slice(0, 10).join(', ')}${missing.length > 10 ? ', …' : ''}`);
+    }
+    console.warn(head);
     for (const name of missing) console.warn(`  - ${name}`);
-    console.warn('This is expected during PR 1. PR 2 migrates each seeder; PR 3 will hard-fail this test.');
+    console.warn('Soft-warn: expected during PR 1/2. Set SEED_CONTRACT_STRICT=1 to hard-fail. PR 3 will enable strict mode by default.');
     t.diagnostic(`${missing.length} seeders awaiting declareRecords migration`);
   }
 });

--- a/tests/seed-contract.test.mjs
+++ b/tests/seed-contract.test.mjs
@@ -172,8 +172,65 @@ function hasDeclareRecordsExport(src) {
   return /export\s+(function\s+declareRecords\s*\(|const\s+declareRecords\s*=)/.test(src);
 }
 
+/**
+ * Return a copy of `src` with single-line comments, block comments, and
+ * string literals replaced by spaces of identical length. Preserves all
+ * indices so we can pattern-match for call sites without confusing
+ * `// runSeed(...)` mentions in comments or docstrings for real calls.
+ * Keeps newlines intact so line numbers in any downstream diagnostics stay
+ * accurate.
+ */
+function stripCommentsAndStrings(src) {
+  const out = src.split('');
+  let i = 0;
+  while (i < src.length) {
+    const ch = src[i];
+    const next = src[i + 1];
+
+    // Block comment
+    if (ch === '/' && next === '*') {
+      const close = src.indexOf('*/', i + 2);
+      const end = close < 0 ? src.length : close + 2;
+      for (let j = i; j < end; j++) out[j] = src[j] === '\n' ? '\n' : ' ';
+      i = end;
+      continue;
+    }
+    // Line comment
+    if (ch === '/' && next === '/') {
+      const nl = src.indexOf('\n', i);
+      const end = nl < 0 ? src.length : nl;
+      for (let j = i; j < end; j++) out[j] = ' ';
+      i = end;
+      continue;
+    }
+    // String / template literal — replace body with spaces, keep delimiters
+    // so the shape of the source is preserved. Template literals can contain
+    // `${expr}` which may itself embed runSeed(...) — but that's unusual and
+    // fine to treat as opaque for our purposes.
+    if (ch === '"' || ch === "'" || ch === '`') {
+      let j = i + 1;
+      while (j < src.length && src[j] !== ch) {
+        if (src[j] === '\\' && j + 1 < src.length) {
+          out[j] = ' ';
+          out[j + 1] = src[j + 1] === '\n' ? '\n' : ' ';
+          j += 2;
+          continue;
+        }
+        out[j] = src[j] === '\n' ? '\n' : ' ';
+        j++;
+      }
+      i = j + 1; // skip past closing quote
+      continue;
+    }
+    i++;
+  }
+  return out.join('');
+}
+
 function hasRunSeedCall(src) {
-  return /\brunSeed\s*\(/.test(src);
+  // Check against the stripped source so a commented-out `runSeed(...)`
+  // mention doesn't mark the file as a runSeed caller when it isn't.
+  return /\brunSeed\s*\(/.test(stripCommentsAndStrings(src));
 }
 
 // Required opts-based fields a descriptor must carry (positional args
@@ -184,56 +241,113 @@ const REQUIRED_OPTS_FIELDS = ['validateFn', 'declareRecords', 'ttlSeconds', 'sou
 
 /**
  * Extract the single `runSeed(...)` call site as a raw string, balance-matching
- * parentheses so embedded function literals and object literals don't throw off
- * substring checks. Returns null if no runSeed call is found.
+ * parentheses against a comment- and string-stripped view of the source.
+ * Returns null if no runSeed call is found.
+ *
+ * We locate the call in the stripped source (so commented-out `runSeed(...)`
+ * mentions don't win) but then slice the corresponding range out of the
+ * ORIGINAL source so descriptor-field checks see the real code. Both strings
+ * share indices because stripCommentsAndStrings preserves them.
  */
 function extractRunSeedCall(src) {
-  const start = src.search(/\brunSeed\s*\(/);
+  const stripped = stripCommentsAndStrings(src);
+  const start = stripped.search(/\brunSeed\s*\(/);
   if (start < 0) return null;
-  const open = src.indexOf('(', start);
+  const open = stripped.indexOf('(', start);
   let depth = 1;
   let i = open + 1;
-  while (i < src.length && depth > 0) {
-    const ch = src[i];
-    if (ch === '(' ) depth++;
+  while (i < stripped.length && depth > 0) {
+    const ch = stripped[i];
+    if (ch === '(') depth++;
     else if (ch === ')') depth--;
-    else if (ch === '/' && src[i + 1] === '/') {
-      const nl = src.indexOf('\n', i);
-      i = nl < 0 ? src.length : nl;
-      continue;
-    } else if (ch === '/' && src[i + 1] === '*') {
-      const close = src.indexOf('*/', i);
-      i = close < 0 ? src.length : close + 2;
-      continue;
-    } else if (ch === '"' || ch === "'" || ch === '`') {
-      // Skip over string literal — rough but adequate for these seeders.
-      let j = i + 1;
-      while (j < src.length && src[j] !== ch) {
-        if (src[j] === '\\') j += 2;
-        else j++;
-      }
-      i = j + 1;
-      continue;
-    }
     i++;
   }
+  if (depth !== 0) return null;
   return src.slice(open + 1, i - 1);
 }
 
 /**
  * True when a `runSeed(...)` call-site carries all required opts-based
  * descriptor fields (checked by presence of the field name as a key).
+ *
+ * Operates on a comment- and string-stripped view so a `// TODO: validateFn`
+ * comment inside the call doesn't trick us into thinking the field is present.
  */
 function descriptorFieldsPresent(callSrc) {
+  const strippedCall = stripCommentsAndStrings(callSrc);
   const missing = [];
   for (const field of REQUIRED_OPTS_FIELDS) {
-    // Match `field:` or `field ,` (shorthand property) with a word boundary so
-    // `sourceVersion` doesn't accidentally match `sourceVersions:`.
+    // Match `field:` or `field ,` (shorthand property) or `field }` with a
+    // word boundary so `sourceVersion` doesn't accidentally match
+    // `sourceVersions:`.
     const re = new RegExp(`\\b${field}\\b\\s*[:,}]`);
-    if (!re.test(callSrc)) missing.push(field);
+    if (!re.test(strippedCall)) missing.push(field);
   }
   return { ok: missing.length === 0, missing };
 }
+
+// ─── Call-site extraction edge cases ────────────────────────────────────
+// The helpers below must never mistake a commented-out `runSeed(...)` mention
+// for the real call. Regression: seed-bis-data.mjs:209 has a comment that
+// reads `// runSeed() calls process.exit(0)` ahead of the real invocation at
+// :220; seed-economy.mjs:788 has a similar header comment ahead of the real
+// call at :891. Before this fix, extractRunSeedCall() sliced the comment's
+// empty parens and descriptorFieldsPresent() reported everything as missing.
+
+test('extractRunSeedCall: ignores runSeed mentions inside line comments', () => {
+  const src = `
+    // runSeed() calls process.exit(0) so whatever follows never runs.
+    runSeed('d', 'r', 'd:r:v1', fetchFn, {
+      validateFn, declareRecords, ttlSeconds: 60,
+      sourceVersion: 'v1', schemaVersion: 1, maxStaleMin: 30,
+    });
+  `;
+  const call = extractRunSeedCall(src);
+  assert.ok(call, 'expected extractRunSeedCall to find the real call');
+  assert.ok(call.includes('validateFn'), 'should slice the real opts object');
+  assert.ok(descriptorFieldsPresent(call).ok, 'real call has all required opts');
+});
+
+test('extractRunSeedCall: ignores runSeed mentions inside block comments', () => {
+  const src = `
+    /*
+     * Migration note: runSeed() writes seed-meta on failure. See issue 123.
+     */
+    runSeed('d', 'r', 'd:r:v1', fetchFn, {
+      validateFn, declareRecords, ttlSeconds: 60,
+      sourceVersion: 'v1', schemaVersion: 1, maxStaleMin: 30,
+    });
+  `;
+  const call = extractRunSeedCall(src);
+  assert.ok(descriptorFieldsPresent(call).ok);
+});
+
+test('extractRunSeedCall: ignores runSeed mentions inside string literals', () => {
+  const src = `
+    const msg = "don't call runSeed() directly";
+    runSeed('d', 'r', 'd:r:v1', fetchFn, {
+      validateFn, declareRecords, ttlSeconds: 60,
+      sourceVersion: 'v1', schemaVersion: 1, maxStaleMin: 30,
+    });
+  `;
+  const call = extractRunSeedCall(src);
+  assert.ok(descriptorFieldsPresent(call).ok);
+});
+
+test('descriptorFieldsPresent: ignores field names inside comments of the call', () => {
+  // If the REAL call is missing a field but a comment names that field, the
+  // checker should still mark it missing.
+  const callSrc = `
+    'd', 'r', 'd:r:v1', fetchFn, {
+      validateFn,
+      // missing: declareRecords, ttlSeconds, sourceVersion, schemaVersion, maxStaleMin
+    }`;
+  const result = descriptorFieldsPresent(callSrc);
+  assert.equal(result.ok, false);
+  for (const f of ['declareRecords', 'ttlSeconds', 'sourceVersion', 'schemaVersion', 'maxStaleMin']) {
+    assert.ok(result.missing.includes(f), `expected ${f} in missing`);
+  }
+});
 
 test('conformance: every scripts/seed-*.mjs that calls runSeed() satisfies the descriptor contract', async (t) => {
   const files = await findSeederFiles();

--- a/tests/seed-envelope-parity.test.mjs
+++ b/tests/seed-envelope-parity.test.mjs
@@ -1,13 +1,15 @@
-// Drift check for the seed-envelope helpers.
+// Drift check for the seed-envelope helpers + unit coverage for the
+// verifier's extractor.
 //
 // `scripts/verify-seed-envelope-parity.mjs` diffs function bodies between:
 //   - scripts/_seed-envelope-source.mjs  (source of truth)
 //   - api/_seed-envelope.js              (edge-safe mirror)
 //
-// This test runs the verifier as a child process during `npm run test:data`
-// so drift between the two JS copies fails CI. Without this, someone could
-// hand-edit api/_seed-envelope.js and the parity guarantee — which is the
-// central invariant PR #3095 introduced — would silently erode.
+// Running the verifier in-process fails on drift so CI catches hand-edits to
+// api/_seed-envelope.js that the source didn't receive. Additional unit tests
+// below cover the extractor's robustness against unbalanced-brace string
+// literals, line/block comments, and template-literal interpolation — all
+// regressions the verifier's older brace-only counter would have hit.
 //
 // The TS mirror at server/_shared/seed-envelope.ts is validated by
 // `npm run typecheck` and reviewed manually (see header comment in that file).
@@ -19,6 +21,8 @@ import { promisify } from 'node:util';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { extractFunctions, scanBalanced } from '../scripts/verify-seed-envelope-parity.mjs';
+
 const execFileP = promisify(execFile);
 const here = dirname(fileURLToPath(import.meta.url));
 const verifier = resolve(here, '..', 'scripts', 'verify-seed-envelope-parity.mjs');
@@ -27,9 +31,84 @@ test('seed-envelope parity: source ↔ edge mirror stay in sync', async () => {
   const { stdout, stderr } = await execFileP(process.execPath, [verifier], {
     timeout: 10_000,
   });
-  // Verifier prints a one-line OK on success. Any drift would exit non-zero,
-  // which execFile surfaces as a thrown error rejecting the promise, so
-  // reaching this line means the verifier succeeded.
   assert.match(stdout, /parity: OK/);
   assert.equal(stderr.trim(), '');
+});
+
+// ─── Body extractor: brace/string/comment robustness ───────────────────────
+
+test('extractFunctions: tolerates unbalanced braces inside string literals', () => {
+  const src = `
+    export function trickyBraces(x) {
+      const open = '{';
+      const close = '}';
+      return open + x + close;
+    }
+  `;
+  const fns = extractFunctions(src);
+  // If the brace counter were raw, the '{' inside the string literal would
+  // have pushed depth to 2 and the first '}' would have closed back to 1 —
+  // body would truncate early. We verify the WHOLE body was captured.
+  const body = fns.get('trickyBraces');
+  assert.ok(body, 'trickyBraces body should be extracted');
+  assert.match(body, /open = '\{'/);
+  assert.match(body, /close = '\}'/);
+  assert.match(body, /return open \+ x \+ close/);
+});
+
+test('extractFunctions: tolerates unbalanced braces inside template literals', () => {
+  const src = `
+    export function tmpl(a) {
+      return \`prefix {\${a}} suffix\`;
+    }
+  `;
+  const fns = extractFunctions(src);
+  const body = fns.get('tmpl');
+  assert.ok(body);
+  assert.match(body, /prefix/);
+  assert.match(body, /suffix/);
+});
+
+test('extractFunctions: tolerates braces inside block comments', () => {
+  const src = `
+    export function withComment(x) {
+      /* example: { a: 1, b: 2 } */
+      return x + 1;
+    }
+  `;
+  const fns = extractFunctions(src);
+  const body = fns.get('withComment');
+  assert.ok(body);
+  assert.match(body, /return x \+ 1/);
+});
+
+test('extractFunctions: tolerates braces inside line comments', () => {
+  const src = `
+    export function withLineComment(x) {
+      // sample map: { k: v }
+      return x;
+    }
+  `;
+  const fns = extractFunctions(src);
+  const body = fns.get('withLineComment');
+  assert.ok(body);
+  assert.match(body, /return x/);
+});
+
+test('scanBalanced: respects escape sequences in strings', () => {
+  // Without escape handling, '\\'' would terminate the string early and the
+  // following ' would reopen a fresh string, leaving braces afterward
+  // miscounted.
+  const src = `{ const s = 'a\\'b{'; const t = 'c'; }`;
+  const end = scanBalanced(src, 0, '{', '}');
+  // end should point just past the final '}'.
+  assert.equal(src.slice(end - 1, end), '}');
+  assert.equal(end, src.length);
+});
+
+test('scanBalanced: template-literal ${} with unbalanced braces inside', () => {
+  const src = `{ const x = \`a\${ {a:1} }b\`; }`;
+  const end = scanBalanced(src, 0, '{', '}');
+  assert.equal(src.slice(end - 1, end), '}');
+  assert.equal(end, src.length);
 });

--- a/tests/seed-envelope-parity.test.mjs
+++ b/tests/seed-envelope-parity.test.mjs
@@ -1,0 +1,35 @@
+// Drift check for the seed-envelope helpers.
+//
+// `scripts/verify-seed-envelope-parity.mjs` diffs function bodies between:
+//   - scripts/_seed-envelope-source.mjs  (source of truth)
+//   - api/_seed-envelope.js              (edge-safe mirror)
+//
+// This test runs the verifier as a child process during `npm run test:data`
+// so drift between the two JS copies fails CI. Without this, someone could
+// hand-edit api/_seed-envelope.js and the parity guarantee — which is the
+// central invariant PR #3095 introduced — would silently erode.
+//
+// The TS mirror at server/_shared/seed-envelope.ts is validated by
+// `npm run typecheck` and reviewed manually (see header comment in that file).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFileP = promisify(execFile);
+const here = dirname(fileURLToPath(import.meta.url));
+const verifier = resolve(here, '..', 'scripts', 'verify-seed-envelope-parity.mjs');
+
+test('seed-envelope parity: source ↔ edge mirror stay in sync', async () => {
+  const { stdout, stderr } = await execFileP(process.execPath, [verifier], {
+    timeout: 10_000,
+  });
+  // Verifier prints a one-line OK on success. Any drift would exit non-zero,
+  // which execFile surfaces as a thrown error rejecting the promise, so
+  // reaching this line means the verifier succeeded.
+  assert.match(stdout, /parity: OK/);
+  assert.equal(stderr.trim(), '');
+});

--- a/tests/seed-envelope.test.mjs
+++ b/tests/seed-envelope.test.mjs
@@ -1,0 +1,118 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  unwrapEnvelope,
+  stripSeedEnvelope,
+  buildEnvelope,
+} from '../scripts/_seed-envelope-source.mjs';
+
+test('unwrapEnvelope: null input → null envelope + null data', () => {
+  assert.deepEqual(unwrapEnvelope(null), { _seed: null, data: null });
+  assert.deepEqual(unwrapEnvelope(undefined), { _seed: null, data: null });
+});
+
+test('unwrapEnvelope: legacy raw value passes through as data', () => {
+  assert.deepEqual(unwrapEnvelope({ events: [1, 2, 3] }), {
+    _seed: null,
+    data: { events: [1, 2, 3] },
+  });
+});
+
+test('unwrapEnvelope: legacy array passes through as data', () => {
+  assert.deepEqual(unwrapEnvelope([1, 2, 3]), { _seed: null, data: [1, 2, 3] });
+});
+
+test('unwrapEnvelope: envelope shape parses _seed + data', () => {
+  const wrapped = {
+    _seed: { fetchedAt: 1_700_000_000_000, recordCount: 5, sourceVersion: 'v1', schemaVersion: 1, state: 'OK' },
+    data: { events: [{ id: 1 }] },
+  };
+  const out = unwrapEnvelope(wrapped);
+  assert.equal(out._seed.fetchedAt, 1_700_000_000_000);
+  assert.equal(out._seed.state, 'OK');
+  assert.deepEqual(out.data, { events: [{ id: 1 }] });
+});
+
+test('unwrapEnvelope: malformed _seed block (missing fetchedAt) → treated as legacy', () => {
+  const bogus = { _seed: { sourceVersion: 'v1' }, data: { x: 1 } };
+  const out = unwrapEnvelope(bogus);
+  assert.equal(out._seed, null);
+  // Falls through the `_seed` branch: whole object becomes `data`.
+  assert.deepEqual(out.data, bogus);
+});
+
+test('unwrapEnvelope: stringified JSON is parsed', () => {
+  const wrapped = JSON.stringify({
+    _seed: { fetchedAt: 123, recordCount: 0, sourceVersion: 'v1', schemaVersion: 1, state: 'OK_ZERO' },
+    data: [],
+  });
+  const out = unwrapEnvelope(wrapped);
+  assert.equal(out._seed.state, 'OK_ZERO');
+  assert.deepEqual(out.data, []);
+});
+
+test('unwrapEnvelope: stringified garbage → legacy passthrough', () => {
+  const out = unwrapEnvelope('not json at all');
+  assert.equal(out._seed, null);
+  assert.equal(out.data, 'not json at all');
+});
+
+test('stripSeedEnvelope: returns data only', () => {
+  const wrapped = {
+    _seed: { fetchedAt: 1, recordCount: 1, sourceVersion: 'v1', schemaVersion: 1, state: 'OK' },
+    data: { hello: 'world' },
+  };
+  assert.deepEqual(stripSeedEnvelope(wrapped), { hello: 'world' });
+});
+
+test('stripSeedEnvelope: legacy value passes through unchanged', () => {
+  const legacy = { events: [1, 2] };
+  assert.deepEqual(stripSeedEnvelope(legacy), legacy);
+});
+
+test('stripSeedEnvelope: null → null', () => {
+  assert.equal(stripSeedEnvelope(null), null);
+});
+
+test('buildEnvelope: minimal OK build', () => {
+  const env = buildEnvelope({
+    fetchedAt: 1, recordCount: 5, sourceVersion: 'v1', schemaVersion: 1, state: 'OK',
+    data: { events: [] },
+  });
+  assert.equal(env._seed.state, 'OK');
+  assert.equal(env._seed.recordCount, 5);
+  assert.deepEqual(env.data, { events: [] });
+  assert.equal(env._seed.failedDatasets, undefined);
+});
+
+test('buildEnvelope: ERROR state carries failedDatasets + errorReason', () => {
+  const env = buildEnvelope({
+    fetchedAt: 1, recordCount: 0, sourceVersion: 'v1', schemaVersion: 1, state: 'ERROR',
+    failedDatasets: ['wgi', 'fao'],
+    errorReason: 'upstream 503',
+    data: null,
+  });
+  assert.equal(env._seed.state, 'ERROR');
+  assert.deepEqual(env._seed.failedDatasets, ['wgi', 'fao']);
+  assert.equal(env._seed.errorReason, 'upstream 503');
+});
+
+test('buildEnvelope: groupId included for multi-key group writes', () => {
+  const env = buildEnvelope({
+    fetchedAt: 1, recordCount: 222, sourceVersion: 'v7', schemaVersion: 1, state: 'OK',
+    groupId: 'resilience-static:2026-04-14',
+    data: { countries: {} },
+  });
+  assert.equal(env._seed.groupId, 'resilience-static:2026-04-14');
+});
+
+test('unwrapEnvelope round-trips buildEnvelope output', () => {
+  const env = buildEnvelope({
+    fetchedAt: 42, recordCount: 3, sourceVersion: 'v9', schemaVersion: 2, state: 'OK',
+    data: { items: [{ a: 1 }, { b: 2 }, { c: 3 }] },
+  });
+  const out = unwrapEnvelope(env);
+  assert.deepEqual(out._seed, env._seed);
+  assert.deepEqual(out.data, env.data);
+});


### PR DESCRIPTION
## Summary

First of three PRs implementing the **unified seed contract** from [`docs/plans/2026-04-14-002-fix-runseed-zero-record-lockout-plan.md`](docs/plans/2026-04-14-002-fix-runseed-zero-record-lockout-plan.md). Foundation only — **behavior-preserving by construction**. No seeder modified, no write path changed, no reader semantics changed.

**What problem this fixes (once all three PRs land):**
- Phantom EMPTY_DATA on custom-shape seeders (zoneNormals, euFsi, bisPolicy today)
- Meta-outlives-data lies (resilienceRanking recordCount:222 vs 0-byte data key)
- Bundle gate null-read misfires (`feed-meta` TTL shorter than data interval)
- Five-registry drift in `api/health.js` (ON_DEMAND_KEYS, EMPTY_DATA_OK_KEYS, STANDALONE_KEYS, BOOTSTRAP_KEYS, CASCADE_GROUPS)
- Non-`runSeed` writers (ais-relay, consumer-prices/publish.ts, handler-side warmers)

This PR is behavior-preserving scaffolding. PR 2 does the semantic cutover; PR 3 removes the legacy path.

## What's in this PR

**Helpers (parity-enforced across three files):**
- `scripts/_seed-envelope-source.mjs` — single source of truth
- `api/_seed-envelope.js` — edge-safe mirror (AGENTS.md:80 forbids `api/*` importing from `server/`)
- `server/_shared/seed-envelope.ts` — TS mirror with `SeedMeta`, `SeedEnvelope`, `UnwrapResult` types
- `scripts/verify-seed-envelope-parity.mjs` — diffs function bodies between the two JS copies; TS copy validated by `tsc --noEmit`

**Contract:**
- `scripts/_seed-contract.mjs` — `SeedContractError`, `validateDescriptor` (10 required fields, unknown-field rejection), `resolveRecordCount` (non-negative integer or throw)

**Conformance test (soft-warn):**
- `tests/seed-contract.test.mjs` — statically parses every `scripts/seed-*.mjs` (no dynamic `import()` — several seeders `process.exit()` at module load: `seed-consumer-prices.mjs:31`, `seed-military-maritime-news.mjs:68`, `seed-service-statuses.mjs:43`). Currently soft-warns that **91 seeders** await `declareRecords` migration. PR 3 flips to hard-fail.

**Wiring (minimal, no-op on legacy):**
- `api/health.js` — imports `unwrapEnvelope`, routes `readSeedMeta` through it. Legacy seed-meta has no `_seed` wrapper → passes through as `.data` unchanged.
- `scripts/_bundle-runner.mjs` — `readSectionFreshness` prefers envelope at `section.canonicalKey` when present, falls back to existing `seed-meta:<key>` read via `section.seedMetaKey`. No bundle defines `canonicalKey` yet, so live behavior is identical to main.

## Testing

- 14 new envelope tests (`tests/seed-envelope.test.mjs`) — null, legacy passthrough, stringified JSON parse, round-trip, malformed `_seed` handling
- 25 new contract tests (`tests/seed-contract.test.mjs`) — validateDescriptor happy path, all 10 missing-field rejections, type checks, schemaVersion integer requirement, unknown-field rejection, resolveRecordCount non-negative integer rule, error-cause propagation
- Soft-warn conformance scan listing the 91 seeders still pending declareRecords
- All 5279 existing `test:data` tests green
- `npm run typecheck` + `npm run typecheck:api` clean
- `node scripts/verify-seed-envelope-parity.mjs` green

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: none expected — this PR adds helpers but nothing invokes them yet on any write path
  - Metrics/Dashboards: `/api/health` response shape should be byte-identical to pre-merge
- **Validation checks (queries/commands)**
  - `curl -s https://api.worldmonitor.app/api/health?compact=1 | jq '.summary'` — counts should match pre-merge snapshot (today: `{total: 177, ok: 169, warn: 0, onDemandWarn: 3, crit: 5}` ± naturally fluctuating stale counts)
  - Railway logs for `seed-bundle-*` services — no new errors; skip/run counts should match historical baseline
- **Expected healthy behavior**
  - Identical health summary counts
  - Identical bundle skip/run/failed counts
  - No new Sentry events
- **Failure signal(s) / rollback trigger**
  - Any new `/api/health` 500s → revert immediately
  - Bundle services reporting `failed++` where they previously reported `skipped++` → revert (shouldn't happen; no bundle defines canonicalKey yet)
- **Validation window & owner**
  - Window: 24h post-deploy
  - Owner: @koala73
- **If no operational impact**
  - Helpers exist but nothing writes envelopes yet; only `api/health.js` and `_bundle-runner.mjs` READ through them on legacy-shape values. The helpers are no-ops on legacy so this PR is effectively a scaffold-only change.

## Follow-up (tracked in plan, NOT this PR)

- **PR 2** — Envelope dual-write across 55+ seeders, 15 `seed-bundle-*.mjs` files with `canonicalKey` section shape, consumer-prices `consumer-prices-core/src/jobs/publish.ts` + `ais-relay.cjs` + handler-side warmers; health/bundle readers preferentially read envelope; registry collapse to one `{ key, maxStaleMin, populationMode, cascadeGroup? }`.
- **PR 3** — Remove legacy `seed-meta:*` writes, delete `writeSeedMeta`/`writeExtraKeyWithMeta`/`writeFreshnessMetadata`, delete `ON_DEMAND_KEYS`/`EMPTY_DATA_OK_KEYS`/`STANDALONE_KEYS`/`BOOTSTRAP_KEYS`/`CASCADE_GROUPS`, hard-fail conformance test, explicit registry-driven cleanup script for orphaned `seed-meta:*` keys.

---

🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.49.0