### PR TITLE
feat(seed-contract): PR 2a — runSeed envelope dual-write + 91 seeders migrated

### DIFF
--- a/api/_upstash-json.js
+++ b/api/_upstash-json.js
@@ -1,3 +1,5 @@
+import { unwrapEnvelope } from './_seed-envelope.js';
+
 export async function readJsonFromUpstash(key, timeoutMs = 3_000) {
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -13,7 +15,11 @@ export async function readJsonFromUpstash(key, timeoutMs = 3_000) {
   if (!data.result) return null;
 
   try {
-    return JSON.parse(data.result);
+    // Envelope-aware: contract-mode canonical keys are stored as {_seed, data}.
+    // MCP tool outputs and RPC consumers must see the bare payload only.
+    // unwrapEnvelope is a no-op on legacy bare-shape values and on seed-meta
+    // keys (which remain top-level {fetchedAt, recordCount, ...}).
+    return unwrapEnvelope(JSON.parse(data.result)).data;
   } catch {
     return null;
   }

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -3,6 +3,7 @@ import { validateApiKey } from './_api-key.js';
 import { jsonResponse } from './_json-response.js';
 // @ts-expect-error — JS module, no declaration file
 import { redisPipeline } from './_upstash-json.js';
+import { unwrapEnvelope } from './_seed-envelope.js';
 
 export const config = { runtime: 'edge' };
 
@@ -195,7 +196,11 @@ async function getCachedJsonBatch(keys) {
     if (raw) {
       try {
         const parsed = JSON.parse(raw);
-        if (parsed !== NEG_SENTINEL) result.set(keys[i], parsed);
+        if (parsed === NEG_SENTINEL) continue;
+        // Envelope-aware: bootstrap is a public-boundary consumer — strip _seed
+        // from contract-mode canonical keys so clients never see envelope
+        // metadata. Legacy bare-shape values pass through unchanged.
+        result.set(keys[i], unwrapEnvelope(parsed).data);
       } catch { /* skip malformed */ }
     }
   }

--- a/api/product-catalog.js
+++ b/api/product-catalog.js
@@ -17,6 +17,8 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders } from './_cors.js';
 // @ts-expect-error — generated JS module
 import { FALLBACK_PRICES } from './_product-fallback-prices.js';
+// @ts-expect-error — JS module
+import { unwrapEnvelope } from './_seed-envelope.js';
 
 const UPSTASH_URL = process.env.UPSTASH_REDIS_REST_URL ?? '';
 const UPSTASH_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN ?? '';
@@ -93,7 +95,12 @@ async function getFromCache() {
     });
     if (!res.ok) return null;
     const { result } = await res.json();
-    return result ? JSON.parse(result) : null;
+    if (!result) return null;
+    // Envelope-aware: ais-relay now writes `product-catalog:v2` as {_seed, data}
+    // (PR #3097). Return the bare payload so clients see the legacy
+    // {tiers, fetchedAt, cachedUntil, priceSource} shape. Pre-contract bare
+    // values pass through unchanged.
+    return unwrapEnvelope(JSON.parse(result)).data;
   } catch { return null; }
 }
 

--- a/api/product-catalog.js
+++ b/api/product-catalog.js
@@ -75,12 +75,17 @@ const TIER_CONFIG = {
 // Tier groups shown on the /pro page (ordered)
 const PUBLIC_TIER_GROUPS = ['free', 'pro', 'api_starter', 'enterprise'];
 
-function json(body, status, cors, cacheControl) {
+function json(body, status, cors, cacheControl, source) {
   return new Response(JSON.stringify(body), {
     status,
     headers: {
       'Content-Type': 'application/json',
       ...(cacheControl ? { 'Cache-Control': cacheControl } : {}),
+      // Signals which code-path served the response so operators + the
+      // seed-contract probe can distinguish cache hits from Dodo/fallback.
+      // Without this header a green probe would not prove the cached-reader
+      // path is healthy — it could be silently falling through to fallback.
+      ...(source ? { 'X-Product-Catalog-Source': source } : {}),
       ...cors,
     },
   });
@@ -245,7 +250,7 @@ export default async function handler(req) {
   // Read from Redis (populated by Railway ais-relay seed loop)
   const cached = await getFromCache();
   if (cached) {
-    return json(cached, 200, cors, 'public, max-age=300, s-maxage=600, stale-while-revalidate=300');
+    return json(cached, 200, cors, 'public, max-age=300, s-maxage=600, stale-while-revalidate=300', 'cache');
   }
 
   // Redis empty (purged or seed hasn't run). Try Dodo directly as backup.
@@ -263,12 +268,12 @@ export default async function handler(req) {
       const result = { tiers, fetchedAt: now, cachedUntil: now + CACHE_TTL * 1000, priceSource };
       // Don't write to Redis — let the Railway seed own that key with its longer TTL.
       // Just return the result with short cache so the next Railway cycle repopulates properly.
-      return json(result, 200, cors, 'public, max-age=60, s-maxage=60');
+      return json(result, 200, cors, 'public, max-age=60, s-maxage=60', 'dodo');
     }
   }
 
   // All sources failed. Return fallback with short cache.
   const tiers = buildTiers({});
   const now = Date.now();
-  return json({ tiers, fetchedAt: now, cachedUntil: now + 60_000, priceSource: 'fallback' }, 200, cors, 'public, max-age=60, s-maxage=60');
+  return json({ tiers, fetchedAt: now, cachedUntil: now + 60_000, priceSource: 'fallback' }, 200, cors, 'public, max-age=60, s-maxage=60', 'fallback');
 }

--- a/api/seed-contract-probe.ts
+++ b/api/seed-contract-probe.ts
@@ -1,0 +1,199 @@
+/**
+ * Seed-contract compliance probe.
+ *
+ * Validates that the envelope dual-write migration (PR #3097) is working
+ * end-to-end in production. Returns HTTP 200 + `{ ok: true }` when every
+ * sampled key satisfies its contract (envelope-wrapped where expected, bare
+ * where seed-meta:* is required) and no public-boundary response leaks `_seed`.
+ *
+ * Usage:
+ *   curl -H "x-probe-secret: $RELAY_SHARED_SECRET" \
+ *        https://api.worldmonitor.app/api/seed-contract-probe
+ *
+ * On failure returns 503 + the failing `checks`/`boundary` entries so CI or
+ * operators can pinpoint the regression. Replaces the curl/jq shell ritual.
+ *
+ * Expected lifecycle:
+ *   PR #3097 merge  → probe returns green once seeders cycle (24–48h bake)
+ *   PR 3 merge      → probe gets stricter mode asserting seed-meta:* keys gone
+ */
+
+export const config = { runtime: 'edge' };
+
+// @ts-expect-error — JS module, no declaration file
+import { getCorsHeaders } from './_cors.js';
+// @ts-expect-error — JS module, no declaration file
+import { jsonResponse } from './_json-response.js';
+
+type ProbeShape = 'envelope' | 'bare';
+
+export interface ProbeSpec {
+  key: string;
+  shape: ProbeShape;
+  /** Fields that must be present on `.data` (envelope) or the root (bare). */
+  dataHas?: string[];
+  /** Floor for `_seed.recordCount` (envelope only). */
+  minRecords?: number;
+}
+
+export interface ProbeResult {
+  key: string;
+  shape: ProbeShape;
+  pass: boolean;
+  reason?: string;
+  state?: string;
+  records?: number;
+  ageMs?: number;
+}
+
+export interface BoundaryResult {
+  endpoint: string;
+  pass: boolean;
+  status?: number;
+  reason?: string;
+}
+
+/**
+ * The probe set is intentionally small (~10 keys) to stay under Upstash's
+ * per-request latency budget and keep this endpoint cheap enough to call from
+ * CI on every deploy. Adding a new key is one line — keep it focused on the
+ * diff surface of PR #3097 (seeders migrated, extra-keys, public boundary).
+ */
+export const DEFAULT_PROBES: ProbeSpec[] = [
+  // Canonical keys migrated by runSeed contract mode — must envelope.
+  { key: 'economic:fsi-eu:v1',         shape: 'envelope', dataHas: ['latestValue', 'history'] },
+  { key: 'climate:zone-normals:v1',    shape: 'envelope', dataHas: ['normals'], minRecords: 13 },
+  { key: 'wildfire:fires:v1',          shape: 'envelope', dataHas: ['fireDetections'] },
+  { key: 'seismology:earthquakes:v1',  shape: 'envelope', dataHas: ['earthquakes'] },
+
+  // Multi-panel canonical + extras — regression guard for publishTransform
+  // shape-mismatch bug that previously skipped all 3 writes (token-panels).
+  { key: 'market:defi-tokens:v1',      shape: 'envelope', dataHas: ['tokens'], minRecords: 1 },
+  { key: 'market:ai-tokens:v1',        shape: 'envelope', dataHas: ['tokens'] },
+  { key: 'market:other-tokens:v1',     shape: 'envelope', dataHas: ['tokens'] },
+
+  // Direct writers (ais-relay.cjs) — regression guard for envelope wrap.
+  { key: 'product-catalog:v2',         shape: 'envelope', dataHas: ['tiers'] },
+
+  // Invariant: seed-meta:* keys must NEVER envelope (shouldEnvelopeKey guard).
+  { key: 'seed-meta:energy:oil-stocks-analysis', shape: 'bare', dataHas: ['fetchedAt'] },
+  { key: 'seed-meta:economic:fsi-eu',            shape: 'bare', dataHas: ['fetchedAt'] },
+];
+
+/** Detect envelope shape without unwrapping — mirrors unwrapEnvelope's gate. */
+function hasEnvelopeShape(parsed: unknown): boolean {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
+  const seed = (parsed as { _seed?: unknown })._seed;
+  return !!seed && typeof seed === 'object' && typeof (seed as { fetchedAt?: unknown }).fetchedAt === 'number';
+}
+
+export async function checkProbe(spec: ProbeSpec): Promise<ProbeResult> {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return { key: spec.key, shape: spec.shape, pass: false, reason: 'no-redis-creds' };
+
+  let resp: Response;
+  try {
+    resp = await fetch(`${url}/get/${encodeURIComponent(spec.key)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(3_000),
+    });
+  } catch (err) {
+    return { key: spec.key, shape: spec.shape, pass: false, reason: `fetch:${(err as Error).message}` };
+  }
+  if (!resp.ok) return { key: spec.key, shape: spec.shape, pass: false, reason: `redis:${resp.status}` };
+
+  const body = (await resp.json()) as { result?: string };
+  if (!body.result) return { key: spec.key, shape: spec.shape, pass: false, reason: 'missing' };
+
+  let parsed: unknown;
+  try { parsed = JSON.parse(body.result); }
+  catch { return { key: spec.key, shape: spec.shape, pass: false, reason: 'malformed-json' }; }
+
+  const isEnvelope = hasEnvelopeShape(parsed);
+
+  if (spec.shape === 'envelope') {
+    if (!isEnvelope) return { key: spec.key, shape: spec.shape, pass: false, reason: 'expected-envelope-got-bare' };
+    const env = parsed as { _seed: { fetchedAt: number; recordCount: number; state: string }; data: Record<string, unknown> };
+    for (const field of spec.dataHas ?? []) {
+      if (env.data?.[field] === undefined) {
+        return { key: spec.key, shape: spec.shape, pass: false, reason: `missing-field:${field}` };
+      }
+    }
+    if (spec.minRecords != null && env._seed.recordCount < spec.minRecords) {
+      return {
+        key: spec.key, shape: spec.shape, pass: false,
+        reason: `records:${env._seed.recordCount}<${spec.minRecords}`,
+      };
+    }
+    return {
+      key: spec.key, shape: spec.shape, pass: true,
+      state: env._seed.state, records: env._seed.recordCount,
+      ageMs: Date.now() - env._seed.fetchedAt,
+    };
+  }
+
+  // shape === 'bare' — seed-meta:* invariant path.
+  if (isEnvelope) return { key: spec.key, shape: spec.shape, pass: false, reason: 'expected-bare-got-envelope' };
+  const bare = parsed as Record<string, unknown>;
+  for (const field of spec.dataHas ?? []) {
+    if (bare[field] === undefined) {
+      return { key: spec.key, shape: spec.shape, pass: false, reason: `missing-field:${field}` };
+    }
+  }
+  return { key: spec.key, shape: spec.shape, pass: true };
+}
+
+export async function checkPublicBoundary(origin: string): Promise<BoundaryResult[]> {
+  const endpoints = ['/api/product-catalog', '/api/bootstrap'];
+  return Promise.all(endpoints.map(async (endpoint): Promise<BoundaryResult> => {
+    try {
+      const r = await fetch(`${origin}${endpoint}`, { signal: AbortSignal.timeout(5_000) });
+      const text = await r.text();
+      // Detect any envelope leak in the response body. A substring match on
+      // the literal `"_seed":` is sufficient because `_seed` only appears on
+      // our envelopes — no third-party API we consume emits that key.
+      const leaked = /"_seed"\s*:/.test(text);
+      return {
+        endpoint, pass: !leaked && r.ok, status: r.status,
+        reason: leaked ? 'seed-leak' : (!r.ok ? `status:${r.status}` : undefined),
+      };
+    } catch (err) {
+      return { endpoint, pass: false, reason: `fetch:${(err as Error).message}` };
+    }
+  }));
+}
+
+export default async function handler(req: Request): Promise<Response> {
+  const cors = getCorsHeaders(req);
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+
+  // Reuse RELAY_SHARED_SECRET — already provisioned for Vercel↔Railway
+  // internal auth, same trust boundary (ops/internal-only callers).
+  const secret = req.headers.get('x-probe-secret');
+  const expected = process.env.RELAY_SHARED_SECRET;
+  if (!expected) return jsonResponse({ error: 'not-configured' }, 503, cors);
+  if (secret !== expected) return jsonResponse({ error: 'unauthorized' }, 401, cors);
+
+  const [checks, boundary] = await Promise.all([
+    Promise.all(DEFAULT_PROBES.map(checkProbe)),
+    checkPublicBoundary(new URL(req.url).origin),
+  ]);
+
+  const passedKeys = checks.filter(c => c.pass).length;
+  const failedKeys = checks.length - passedKeys;
+  const passedBoundary = boundary.filter(b => b.pass).length;
+  const failedBoundary = boundary.length - passedBoundary;
+  const ok = failedKeys === 0 && failedBoundary === 0;
+
+  return jsonResponse({
+    ok,
+    summary: {
+      probes: { passed: passedKeys, failed: failedKeys, total: checks.length },
+      boundary: { passed: passedBoundary, failed: failedBoundary, total: boundary.length },
+    },
+    checks,
+    boundary,
+    checkedAt: new Date().toISOString(),
+  }, ok ? 200 : 503, cors);
+}

--- a/api/seed-contract-probe.ts
+++ b/api/seed-contract-probe.ts
@@ -68,9 +68,12 @@ export const DEFAULT_PROBES: ProbeSpec[] = [
 
   // Multi-panel canonical + extras — regression guard for publishTransform
   // shape-mismatch bug that previously skipped all 3 writes (token-panels).
+  // Every panel needs minRecords ≥ 1; without the floor, an extra-key
+  // declareRecords regressed to 0 would still pass this probe as long as
+  // `.tokens` existed on the payload.
   { key: 'market:defi-tokens:v1',      shape: 'envelope', dataHas: ['tokens'], minRecords: 1 },
-  { key: 'market:ai-tokens:v1',        shape: 'envelope', dataHas: ['tokens'] },
-  { key: 'market:other-tokens:v1',     shape: 'envelope', dataHas: ['tokens'] },
+  { key: 'market:ai-tokens:v1',        shape: 'envelope', dataHas: ['tokens'], minRecords: 1 },
+  { key: 'market:other-tokens:v1',     shape: 'envelope', dataHas: ['tokens'], minRecords: 1 },
 
   // Direct writers (ais-relay.cjs) — regression guard for envelope wrap.
   { key: 'product-catalog:v2',         shape: 'envelope', dataHas: ['tiers'] },
@@ -144,20 +147,44 @@ export async function checkProbe(spec: ProbeSpec): Promise<ProbeResult> {
   return { key: spec.key, shape: spec.shape, pass: true };
 }
 
+interface BoundaryCheck {
+  endpoint: string;
+  /** Optional: require a specific `X-*-Source` header value to prove the
+   *  intended code-path served the response (e.g. `'cache'` for product-catalog
+   *  so we know the enveloped-read path actually ran, not fallback). */
+  requireSourceHeader?: { name: string; value: string };
+}
+
+const BOUNDARY_CHECKS: BoundaryCheck[] = [
+  { endpoint: '/api/product-catalog', requireSourceHeader: { name: 'x-product-catalog-source', value: 'cache' } },
+  { endpoint: '/api/bootstrap' },
+];
+
 export async function checkPublicBoundary(origin: string): Promise<BoundaryResult[]> {
-  const endpoints = ['/api/product-catalog', '/api/bootstrap'];
-  return Promise.all(endpoints.map(async (endpoint): Promise<BoundaryResult> => {
+  return Promise.all(BOUNDARY_CHECKS.map(async ({ endpoint, requireSourceHeader }): Promise<BoundaryResult> => {
     try {
       const r = await fetch(`${origin}${endpoint}`, { signal: AbortSignal.timeout(5_000) });
       const text = await r.text();
       // Detect any envelope leak in the response body. A substring match on
       // the literal `"_seed":` is sufficient because `_seed` only appears on
       // our envelopes — no third-party API we consume emits that key.
-      const leaked = /"_seed"\s*:/.test(text);
-      return {
-        endpoint, pass: !leaked && r.ok, status: r.status,
-        reason: leaked ? 'seed-leak' : (!r.ok ? `status:${r.status}` : undefined),
-      };
+      if (/"_seed"\s*:/.test(text)) {
+        return { endpoint, pass: false, status: r.status, reason: 'seed-leak' };
+      }
+      if (!r.ok) return { endpoint, pass: false, status: r.status, reason: `status:${r.status}` };
+      if (requireSourceHeader) {
+        // Header names are ASCII case-insensitive per RFC 7230; Response.headers.get()
+        // handles that. Comparing values case-insensitively too so a casing drift
+        // in the handler doesn't mask a broken cache-hit path.
+        const actual = r.headers.get(requireSourceHeader.name);
+        if ((actual ?? '').toLowerCase() !== requireSourceHeader.value.toLowerCase()) {
+          return {
+            endpoint, pass: false, status: r.status,
+            reason: `source:${actual ?? 'missing'}!=${requireSourceHeader.value}`,
+          };
+        }
+      }
+      return { endpoint, pass: true, status: r.status };
     } catch (err) {
       return { endpoint, pass: false, reason: `fetch:${(err as Error).message}` };
     }

--- a/consumer-prices-core/src/jobs/publish.ts
+++ b/consumer-prices-core/src/jobs/publish.ts
@@ -40,6 +40,29 @@ async function upstashCommand(url: string, token: string, command: unknown[]): P
   if (!resp.ok) throw new Error(`Upstash ${command[0]} failed: HTTP ${resp.status}`);
 }
 
+// Seed envelope shape — mirrored from scripts/_seed-envelope-source.mjs.
+// consumer-prices-core is a standalone package so we inline the tiny helper
+// rather than taking a cross-package dependency. Keep in lockstep with:
+//   - scripts/_seed-envelope-source.mjs
+//   - server/_shared/seed-envelope.ts
+//   - api/_seed-envelope.js
+// Any change to the envelope shape must update all four.
+const SOURCE_VERSION = 'consumer-prices-core-publish-v1';
+const SCHEMA_VERSION = 1;
+
+function buildEnvelope(data: unknown, count: number): { _seed: Record<string, unknown>; data: unknown } {
+  return {
+    _seed: {
+      fetchedAt: Date.now(),
+      recordCount: count,
+      sourceVersion: SOURCE_VERSION,
+      schemaVersion: SCHEMA_VERSION,
+      state: count > 0 ? 'OK' : 'OK_ZERO',
+    },
+    data,
+  };
+}
+
 async function writeSnapshot(
   url: string,
   token: string,
@@ -48,18 +71,22 @@ async function writeSnapshot(
   ttlSeconds: number,
   advanceSeedMeta = true,
 ): Promise<void> {
-  const json = JSON.stringify(data);
+  const count = recordCount(data);
+  // Envelope the canonical payload. Legacy seed-meta:<key> is still written
+  // below so unmigrated readers keep working during dual-write.
+  const envelope = buildEnvelope(data, count);
+  const json = JSON.stringify(envelope);
   await upstashCommand(url, token, ['SET', key, json, 'EX', ttlSeconds]);
   if (advanceSeedMeta) {
     await upstashCommand(url, token, [
       'SET',
       makeKey(['seed-meta', key]),
-      JSON.stringify({ fetchedAt: Date.now(), recordCount: recordCount(data) }),
+      JSON.stringify({ fetchedAt: Date.now(), recordCount: count }),
       'EX',
       ttlSeconds * 2,
     ]);
   }
-  logger.info(`  wrote ${key} (${json.length} bytes, ttl=${ttlSeconds}s, meta=${advanceSeedMeta})`);
+  logger.info(`  wrote ${key} (${json.length} bytes, records=${count}, ttl=${ttlSeconds}s, meta=${advanceSeedMeta})`);
 }
 
 // 26h TTL — longer than the 24h cron cadence to survive scheduling drift

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -6,7 +6,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 
-import { buildEnvelope } from './_seed-envelope-source.mjs';
+import { buildEnvelope, unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { resolveRecordCount } from './_seed-contract.mjs';
 
 const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36';
@@ -104,7 +104,12 @@ async function redisGet(url, token, key) {
   });
   if (!resp.ok) return null;
   const data = await resp.json();
-  return data.result ? JSON.parse(data.result) : null;
+  if (!data.result) return null;
+  // Envelope-aware: returns inner `data` for seeded keys written in contract
+  // mode, passes through legacy (bare-shape) values unchanged. Fixes WoW/cross-
+  // seed reads that were silently getting `{_seed, data}` after PR 2a enveloped
+  // the writer side of 91 canonical keys.
+  return unwrapEnvelope(JSON.parse(data.result)).data;
 }
 
 async function redisSet(url, token, key, value, ttlSeconds) {
@@ -247,10 +252,25 @@ export function logSeedResult(domain, count, durationMs, extra = {}) {
   }));
 }
 
-export async function verifySeedKey(key) {
+/**
+ * Shared envelope-aware reader for cross-seed consumers (e.g. seed-forecasts
+ * reading ~40 migrated input keys, seed-chokepoint-flows reading portwatch,
+ * seed-thermal-escalation reading wildfire:fires). Returns the inner `data`
+ * payload for contract-mode writes; passes legacy bare-shape values through
+ * unchanged. Callers MUST NOT parse the envelope themselves.
+ */
+export async function readCanonicalValue(key) {
   const { url, token } = getRedisCredentials();
-  const data = await redisGet(url, token, key);
-  return data;
+  return redisGet(url, token, key);
+}
+
+export async function verifySeedKey(key) {
+  // redisGet() now unwraps envelopes internally, so callers that read migrated
+  // canonical keys (e.g. seed-climate-anomalies reading climate:zone-normals:v1,
+  // seed-thermal-escalation reading wildfire:fires:v1) see bare legacy-shape
+  // payloads regardless of whether the writer has migrated to contract mode.
+  const { url, token } = getRedisCredentials();
+  return redisGet(url, token, key);
 }
 
 export async function writeExtraKey(key, data, ttl, envelopeMeta) {
@@ -681,7 +701,11 @@ export async function readSeedSnapshot(canonicalKey) {
     });
     if (!resp.ok) return null;
     const { result } = await resp.json();
-    return result ? JSON.parse(result) : null;
+    if (!result) return null;
+    // Envelope-aware: WoW/prev baselines (bigmac, grocery-basket, fear-greed)
+    // must see bare legacy-shape data whether the last write was pre- or post-
+    // contract-migration. unwrapEnvelope is a no-op on legacy values.
+    return unwrapEnvelope(JSON.parse(result)).data;
   } catch {
     return null;
   }

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -6,6 +6,9 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 
+import { buildEnvelope } from './_seed-envelope-source.mjs';
+import { resolveRecordCount } from './_seed-contract.mjs';
+
 const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36';
 const MAX_PAYLOAD_BYTES = 5 * 1024 * 1024; // 5MB per key
 
@@ -159,16 +162,10 @@ export async function releaseLock(domain, runId) {
   }
 }
 
-export async function atomicPublish(canonicalKey, data, validateFn, ttlSeconds) {
+export async function atomicPublish(canonicalKey, data, validateFn, ttlSeconds, options = {}) {
   const { url, token } = getRedisCredentials();
   const runId = String(Date.now());
   const stagingKey = `${canonicalKey}:staging:${runId}`;
-
-  const payload = JSON.stringify(data);
-  const payloadBytes = Buffer.byteLength(payload, 'utf8');
-  if (payloadBytes > MAX_PAYLOAD_BYTES) {
-    throw new Error(`Payload too large: ${(payloadBytes / 1024 / 1024).toFixed(1)}MB > 5MB limit`);
-  }
 
   if (validateFn) {
     const valid = validateFn(data);
@@ -177,8 +174,21 @@ export async function atomicPublish(canonicalKey, data, validateFn, ttlSeconds) 
     }
   }
 
+  // When the seeder opts into the contract (options.envelopeMeta provided), wrap
+  // the payload in the seed envelope before publishing so the data key and its
+  // freshness metadata share one lifecycle. Legacy seeders pass no envelopeMeta
+  // and publish bare data, preserving pre-contract behavior.
+  const payloadValue = options.envelopeMeta
+    ? buildEnvelope({ ...options.envelopeMeta, data })
+    : data;
+  const payload = JSON.stringify(payloadValue);
+  const payloadBytes = Buffer.byteLength(payload, 'utf8');
+  if (payloadBytes > MAX_PAYLOAD_BYTES) {
+    throw new Error(`Payload too large: ${(payloadBytes / 1024 / 1024).toFixed(1)}MB > 5MB limit`);
+  }
+
   // Write to staging key
-  await redisSet(url, token, stagingKey, data, 300); // 5 min staging TTL
+  await redisSet(url, token, stagingKey, payloadValue, 300); // 5 min staging TTL
 
   // Overwrite canonical key
   if (ttlSeconds) {
@@ -243,9 +253,10 @@ export async function verifySeedKey(key) {
   return data;
 }
 
-export async function writeExtraKey(key, data, ttl) {
+export async function writeExtraKey(key, data, ttl, envelopeMeta) {
   const { url, token } = getRedisCredentials();
-  const payload = JSON.stringify(data);
+  const value = envelopeMeta ? buildEnvelope({ ...envelopeMeta, data }) : data;
+  const payload = JSON.stringify(value);
   const resp = await fetch(url, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
@@ -734,13 +745,31 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     extraKeys,
     afterPublish,
     publishTransform,
+    declareRecords,        // new — contract opt-in. When present, runSeed enters
+                           // envelope-dual-write path: writes `{_seed, data}` to
+                           // canonicalKey alongside legacy `seed-meta:*` key.
+    sourceVersion,         // new — required when declareRecords is passed
+    schemaVersion,         // new — required when declareRecords is passed
+    zeroIsValid = false,   // new — when true, recordCount=0 is OK_ZERO, not RETRY
   } = opts;
+  const contractMode = typeof declareRecords === 'function';
+  if (contractMode) {
+    // Soft-warn (PR 2) on other mandatory contract fields; PR 3 hard-aborts.
+    const missing = [];
+    if (typeof sourceVersion !== 'string' || sourceVersion.trim() === '') missing.push('sourceVersion');
+    if (!Number.isInteger(schemaVersion) || schemaVersion < 1) missing.push('schemaVersion');
+    if (typeof opts.maxStaleMin !== 'number') missing.push('maxStaleMin');
+    if (missing.length) {
+      console.warn(`  [seed-contract] ${domain}:${resource} missing fields: ${missing.join(', ')} — required in PR 3`);
+    }
+  }
   const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const startMs = Date.now();
 
   console.log(`=== ${domain}:${resource} Seed ===`);
   console.log(`  Run ID:  ${runId}`);
   console.log(`  Key:     ${canonicalKey}`);
+  if (contractMode) console.log(`  Mode:    contract (envelope dual-write)`);
 
   // Acquire lock
   const lockResult = await acquireLockSafely(`${domain}:${resource}`, runId, lockTtlMs, {
@@ -776,7 +805,53 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
   // Phase 2: Publish to Redis (rethrow on failure — data was fetched but not stored)
   try {
     const publishData = publishTransform ? publishTransform(data) : data;
-    const publishResult = await atomicPublish(canonicalKey, publishData, validateFn, ttlSeconds);
+
+    // In contract mode, resolve recordCount from declareRecords BEFORE publish so
+    // the envelope carries the correct state. RETRY-on-empty paths skip the
+    // publish entirely (leaving the previous envelope in place).
+    let contractState = null;   // 'OK' | 'OK_ZERO' | 'RETRY'
+    let contractRecordCount = null;
+    let envelopeMeta = null;
+    if (contractMode) {
+      try {
+        contractRecordCount = resolveRecordCount(declareRecords, publishData);
+      } catch (err) {
+        // Contract violation — declareRecords returned non-int / threw. HARD FAIL.
+        await releaseLock(`${domain}:${resource}`, runId);
+        console.error(`  CONTRACT VIOLATION: ${err.message || err}`);
+        process.exit(1);
+      }
+      if (contractRecordCount > 0) {
+        contractState = 'OK';
+      } else if (zeroIsValid) {
+        contractState = 'OK_ZERO';
+      } else {
+        contractState = 'RETRY';
+      }
+      if (contractState !== 'RETRY') {
+        envelopeMeta = {
+          fetchedAt: Date.now(),
+          recordCount: contractRecordCount,
+          sourceVersion: sourceVersion || '',
+          schemaVersion: schemaVersion || 1,
+          state: contractState,
+        };
+      }
+    }
+
+    // Contract RETRY on empty (no zeroIsValid) — skip publish, extend TTL, exit 0.
+    if (contractState === 'RETRY') {
+      const durationMs = Date.now() - startMs;
+      const keys = [canonicalKey, `seed-meta:${domain}:${resource}`];
+      if (extraKeys) keys.push(...extraKeys.map(ek => ek.key));
+      await extendExistingTtl(keys, ttlSeconds || 600);
+      console.log(`  RETRY: declareRecords returned 0 (zeroIsValid=false) — envelope unchanged, TTL extended, bundle will retry next cycle`);
+      console.log(`\n=== Done (${Math.round(durationMs)}ms, RETRY) ===`);
+      await releaseLock(`${domain}:${resource}`, runId);
+      process.exit(0);
+    }
+
+    const publishResult = await atomicPublish(canonicalKey, publishData, validateFn, ttlSeconds, { envelopeMeta });
     if (publishResult.skipped) {
       const durationMs = Date.now() - startMs;
       const keys = [canonicalKey, `seed-meta:${domain}:${resource}`];
@@ -808,17 +883,41 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     const topicArticleCount = Array.isArray(data?.topics)
       ? data.topics.reduce((n, t) => n + (t?.articles?.length || t?.events?.length || 0), 0)
       : undefined;
-    const recordCount = computeRecordCount({
-      opts, data, payloadBytes, topicArticleCount,
-      onPhantomFallback: () => console.warn(
-        `  [recordCount] auto-detect did not match a known shape (payloadBytes=${payloadBytes}); falling back to 1. Add opts.recordCount to ${domain}:${resource} for accurate health metrics.`
-      ),
-    });
+    const recordCount = contractMode
+      ? contractRecordCount
+      : computeRecordCount({
+          opts, data, payloadBytes, topicArticleCount,
+          onPhantomFallback: () => console.warn(
+            `  [recordCount] auto-detect did not match a known shape (payloadBytes=${payloadBytes}); falling back to 1. Add opts.recordCount to ${domain}:${resource} for accurate health metrics.`
+          ),
+        });
 
-    // Write extra keys (e.g., bootstrap hydration keys)
+    // Write extra keys (e.g., bootstrap hydration keys). In contract mode each
+    // extra key gets its own envelope; declareRecords may be per-key or reuse
+    // the canonical one.
     if (extraKeys) {
       for (const ek of extraKeys) {
-        await writeExtraKey(ek.key, ek.transform ? ek.transform(data) : data, ek.ttl || ttlSeconds);
+        const ekData = ek.transform ? ek.transform(data) : data;
+        let ekEnvelope = null;
+        if (contractMode) {
+          const ekDeclare = typeof ek.declareRecords === 'function' ? ek.declareRecords : declareRecords;
+          let ekCount;
+          try {
+            ekCount = resolveRecordCount(ekDeclare, ekData);
+          } catch (err) {
+            await releaseLock(`${domain}:${resource}`, runId);
+            console.error(`  CONTRACT VIOLATION on extraKey ${ek.key}: ${err.message || err}`);
+            process.exit(1);
+          }
+          ekEnvelope = {
+            fetchedAt: envelopeMeta.fetchedAt,
+            recordCount: ekCount,
+            sourceVersion: sourceVersion || '',
+            schemaVersion: schemaVersion || 1,
+            state: ekCount > 0 ? 'OK' : (zeroIsValid ? 'OK_ZERO' : 'OK'),
+          };
+        }
+        await writeExtraKey(ek.key, ekData, ek.ttl || ttlSeconds, ekEnvelope);
       }
     }
 
@@ -829,7 +928,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     const meta = await writeFreshnessMetadata(domain, resource, recordCount, opts.sourceVersion, ttlSeconds);
 
     const durationMs = Date.now() - startMs;
-    logSeedResult(domain, recordCount, durationMs, { payloadBytes });
+    logSeedResult(domain, recordCount, durationMs, { payloadBytes, contractMode, state: contractState || 'LEGACY' });
 
     // Verify (best-effort: write already succeeded, don't fail the job on transient read issues)
     let verified = false;

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -182,8 +182,9 @@ export async function atomicPublish(canonicalKey, data, validateFn, ttlSeconds, 
   // When the seeder opts into the contract (options.envelopeMeta provided), wrap
   // the payload in the seed envelope before publishing so the data key and its
   // freshness metadata share one lifecycle. Legacy seeders pass no envelopeMeta
-  // and publish bare data, preserving pre-contract behavior.
-  const payloadValue = options.envelopeMeta
+  // and publish bare data, preserving pre-contract behavior. seed-meta:* keys
+  // are always kept bare (shouldEnvelopeKey invariant).
+  const payloadValue = options.envelopeMeta && shouldEnvelopeKey(canonicalKey)
     ? buildEnvelope({ ...options.envelopeMeta, data })
     : data;
   const payload = JSON.stringify(payloadValue);
@@ -273,9 +274,21 @@ export async function verifySeedKey(key) {
   return redisGet(url, token, key);
 }
 
+/**
+ * Invariant: `seed-meta:*` keys MUST be bare-shape `{fetchedAt, recordCount, ...}`.
+ * Health + bundle runner + every legacy reader parses them as top-level.
+ * Enveloping them turns every downstream read into `{_seed, data}` which breaks
+ * the whole freshness-registry flow. Enforced at the helper boundary so future
+ * callers can't regress this by passing an envelopeMeta that happens to target
+ * a seed-meta key (seed-iea-oil-stocks' ANALYSIS_META_EXTRA_KEY did exactly that).
+ */
+export function shouldEnvelopeKey(key) {
+  return typeof key === 'string' && !key.startsWith('seed-meta:');
+}
+
 export async function writeExtraKey(key, data, ttl, envelopeMeta) {
   const { url, token } = getRedisCredentials();
-  const value = envelopeMeta ? buildEnvelope({ ...envelopeMeta, data }) : data;
+  const value = envelopeMeta && shouldEnvelopeKey(key) ? buildEnvelope({ ...envelopeMeta, data }) : data;
   const payload = JSON.stringify(value);
   const resp = await fetch(url, {
     method: 'POST',

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -369,6 +369,38 @@ function upstashDel(key) {
   });
 }
 
+// ─────────────────────────────────────────────────────────────
+// Seed envelope — canonical { _seed, data } shape. Mirrored from
+// scripts/_seed-envelope-source.mjs (ESM; can't be require()'d from CJS).
+// Source of truth lives there + api/_seed-envelope.js + server/_shared/seed-envelope.ts.
+// Parity enforced by scripts/verify-seed-envelope-parity.mjs.
+// ─────────────────────────────────────────────────────────────
+function buildEnvelope({ fetchedAt, recordCount, sourceVersion, schemaVersion, state, failedDatasets, errorReason, groupId, data }) {
+  const _seed = { fetchedAt, recordCount, sourceVersion, schemaVersion, state };
+  if (failedDatasets != null) _seed.failedDatasets = failedDatasets;
+  if (errorReason != null) _seed.errorReason = errorReason;
+  if (groupId != null) _seed.groupId = groupId;
+  return { _seed, data };
+}
+
+// Wrap `data` in a seed envelope and write to Redis at `key` with `ttlSeconds`.
+// meta: { recordCount, sourceVersion, schemaVersion?, state?, zeroOk? }
+//   - state: omit to derive ('OK_ZERO' when recordCount===0 && zeroOk, else 'OK')
+//   - schemaVersion: defaults to 1
+function envelopeWrite(key, data, ttlSeconds, meta) {
+  const recordCount = Number(meta?.recordCount ?? 0) || 0;
+  const state = meta?.state || (recordCount === 0 && meta?.zeroOk ? 'OK_ZERO' : 'OK');
+  const envelope = buildEnvelope({
+    fetchedAt: Date.now(),
+    recordCount,
+    sourceVersion: meta?.sourceVersion || 'ais-relay',
+    schemaVersion: meta?.schemaVersion ?? 1,
+    state,
+    data,
+  });
+  return upstashSet(key, envelope, ttlSeconds);
+}
+
 function notifySimpleHash(str) {
   let h = 0;
   for (let i = 0; i < str.length; i++) h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
@@ -1083,7 +1115,7 @@ async function orefPersistHistory() {
       activeAlertCount: orefState.lastAlerts?.length || 0,
       persistedAt: new Date().toISOString(),
     };
-    const ok = await upstashSet(OREF_REDIS_KEY, payload, OREF_PERSIST_TTL_SECONDS);
+    const ok = await envelopeWrite(OREF_REDIS_KEY, payload, OREF_PERSIST_TTL_SECONDS, { recordCount: waves.length, sourceVersion: 'oref', zeroOk: true });
     if (ok) {
       orefState._lastPersistedVersion = versionAtStart;
     }
@@ -1364,7 +1396,7 @@ async function seedUcdpEvents() {
     }
 
     const payload = { events: mapped, fetchedAt: Date.now(), version, totalRaw: allEvents.length, filteredCount: mapped.length };
-    const ok = await upstashSet(UCDP_REDIS_KEY, payload, UCDP_TTL_SECONDS);
+    const ok = await envelopeWrite(UCDP_REDIS_KEY, payload, UCDP_TTL_SECONDS, { recordCount: mapped.length, sourceVersion: 'ucdp' });
     await upstashSet('seed-meta:conflict:ucdp-events', { fetchedAt: Date.now(), recordCount: mapped.length }, 604800);
     console.log(`[UCDP] Seeded ${mapped.length} events (raw: ${allEvents.length}, failed pages: ${failedPages}, redis: ${ok ? 'OK' : 'FAIL'})`);
     const newConflicts = mapped.filter(e => e.deathsBest >= 10 && !ucdpPrevAlertedIds.has(e.id)).sort((a, b) => b.deathsBest - a.deathsBest);
@@ -1506,7 +1538,7 @@ async function seedSatelliteTLEs() {
     }
 
     const payload = { satellites, fetchedAt: Date.now() };
-    const ok = await upstashSet('intelligence:satellites:tle:v1', payload, SAT_SEED_TTL);
+    const ok = await envelopeWrite('intelligence:satellites:tle:v1', payload, SAT_SEED_TTL, { recordCount: satellites.length, sourceVersion: 'celestrak' });
     await upstashSet('seed-meta:intelligence:satellites', { fetchedAt: Date.now(), recordCount: satellites.length }, 604800);
     console.log(`[Satellites] Seeded ${satellites.length} TLEs (redis: ${ok ? 'OK' : 'FAIL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
   } catch (e) {
@@ -1740,9 +1772,9 @@ async function seedMarketQuotes() {
   const skipped = !FINNHUB_API_KEY && !coveredByYahoo;
   const payload = { quotes, finnhubSkipped: skipped, skipReason: skipped ? 'FINNHUB_API_KEY not configured' : '', rateLimited: false };
   const redisKey = `market:quotes:v1:${[...MARKET_SYMBOLS].sort().join(',')}`;
-  const ok = await upstashSet(redisKey, payload, MARKET_SEED_TTL);
+  const ok = await envelopeWrite(redisKey, payload, MARKET_SEED_TTL, { recordCount: quotes.length, sourceVersion: 'market-stocks' });
   // Bootstrap-friendly fixed key — frontend hydrates from /api/bootstrap without RPC
-  const ok2 = await upstashSet('market:stocks-bootstrap:v1', payload, MARKET_SEED_TTL);
+  const ok2 = await envelopeWrite('market:stocks-bootstrap:v1', payload, MARKET_SEED_TTL, { recordCount: quotes.length, sourceVersion: 'market-stocks' });
   const ok3 = await upstashSet('seed-meta:market:stocks', { fetchedAt: Date.now(), recordCount: quotes.length }, 604800);
   console.log(`[Market] Seeded ${quotes.length}/${MARKET_SYMBOLS.length} quotes (redis: ${ok && ok2 && ok3 ? 'OK' : 'PARTIAL'})`);
   const movingStocks = quotes.filter(q => Math.abs(q.change ?? 0) >= 5).sort((a, b) => Math.abs(b.change) - Math.abs(a.change));
@@ -1789,14 +1821,14 @@ async function seedCommodityQuotes() {
 
   const payload = { quotes };
   const redisKey = `market:commodities:v1:${[...COMMODITY_SYMBOLS].sort().join(',')}`;
-  const ok = await upstashSet(redisKey, payload, MARKET_SEED_TTL);
+  const ok = await envelopeWrite(redisKey, payload, MARKET_SEED_TTL, { recordCount: quotes.length, sourceVersion: 'market-commodities' });
   // Also write under market:quotes:v1: key — the frontend routes commodities through
   // listMarketQuotes RPC, which constructs this key pattern (not market:commodities:v1:)
   const quotesKey = `market:quotes:v1:${[...COMMODITY_SYMBOLS].sort().join(',')}`;
   const quotesPayload = { quotes, finnhubSkipped: false, skipReason: '', rateLimited: false };
-  const ok2 = await upstashSet(quotesKey, quotesPayload, MARKET_SEED_TTL);
+  const ok2 = await envelopeWrite(quotesKey, quotesPayload, MARKET_SEED_TTL, { recordCount: quotes.length, sourceVersion: 'market-commodities' });
   // Bootstrap-friendly fixed key — frontend hydrates from /api/bootstrap without RPC
-  const ok3 = await upstashSet('market:commodities-bootstrap:v1', quotesPayload, MARKET_SEED_TTL);
+  const ok3 = await envelopeWrite('market:commodities-bootstrap:v1', quotesPayload, MARKET_SEED_TTL, { recordCount: quotes.length, sourceVersion: 'market-commodities' });
   const ok4 = await upstashSet('seed-meta:market:commodities', { fetchedAt: Date.now(), recordCount: quotes.length }, 604800);
   console.log(`[Market] Seeded ${quotes.length}/${COMMODITY_SYMBOLS.length} commodities (redis: ${ok && ok2 && ok3 && ok4 ? 'OK' : 'PARTIAL'})`);
   const movingCommodities = quotes.filter(q => Math.abs(q.change ?? 0) >= 5).sort((a, b) => Math.abs(b.change) - Math.abs(a.change));
@@ -1848,14 +1880,14 @@ async function seedSectorSummary() {
   }
 
   const payload = { sectors, valuations };
-  const ok = await upstashSet('market:sectors:v2', payload, MARKET_SEED_TTL);
+  const ok = await envelopeWrite('market:sectors:v2', payload, MARKET_SEED_TTL, { recordCount: sectors.length, sourceVersion: 'market-sectors' });
   const quotesKey = `market:quotes:v1:${[...SECTOR_SYMBOLS].sort().join(',')}`;
   const sectorQuotes = sectors.map((s) => ({
     symbol: s.symbol, name: s.name, display: s.name,
     price: 0, change: s.change, sparkline: [],
   }));
   const quotesPayload = { quotes: sectorQuotes, finnhubSkipped: false, skipReason: '', rateLimited: false };
-  const ok2 = await upstashSet(quotesKey, quotesPayload, MARKET_SEED_TTL);
+  const ok2 = await envelopeWrite(quotesKey, quotesPayload, MARKET_SEED_TTL, { recordCount: sectorQuotes.length, sourceVersion: 'market-sectors' });
   const ok3 = await upstashSet('seed-meta:market:sectors', { fetchedAt: Date.now(), recordCount: sectors.length }, 604800);
   console.log(`[Market] Seeded ${sectors.length}/${SECTOR_SYMBOLS.length} sectors, ${valCount} valuations (redis: ${ok && ok2 && ok3 ? 'OK' : 'PARTIAL'})`);
   return sectors.length;
@@ -1895,7 +1927,7 @@ async function seedGulfQuotes() {
   }
   if (quotes.length === 0) { console.warn('[Gulf] No quotes fetched — skipping'); return 0; }
   const payload = { quotes, rateLimited: false };
-  const ok1 = await upstashSet('market:gulf-quotes:v1', payload, GULF_SEED_TTL);
+  const ok1 = await envelopeWrite('market:gulf-quotes:v1', payload, GULF_SEED_TTL, { recordCount: quotes.length, sourceVersion: 'market-gulf' });
   const ok2 = await upstashSet('seed-meta:market:gulf-quotes', { fetchedAt: Date.now(), recordCount: quotes.length }, 604800);
   console.log(`[Gulf] Seeded ${quotes.length}/${GULF_SYMBOLS.length} quotes (redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'})`);
   return quotes.length;
@@ -1955,7 +1987,7 @@ async function seedEtfFlows() {
     summary: { etfCount: etfs.length, totalVolume, totalEstFlow, netDirection: totalEstFlow > 0 ? 'NET INFLOW' : totalEstFlow < 0 ? 'NET OUTFLOW' : 'NEUTRAL', inflowCount: etfs.filter((e) => e.direction === 'inflow').length, outflowCount: etfs.filter((e) => e.direction === 'outflow').length },
     etfs, rateLimited: false,
   };
-  const ok1 = await upstashSet('market:etf-flows:v1', payload, ETF_SEED_TTL);
+  const ok1 = await envelopeWrite('market:etf-flows:v1', payload, ETF_SEED_TTL, { recordCount: etfs.length, sourceVersion: 'market-etf-flows' });
   const ok2 = await upstashSet('seed-meta:market:etf-flows', { fetchedAt: Date.now(), recordCount: etfs.length }, 604800);
   console.log(`[ETF] Seeded ${etfs.length}/${ETF_LIST.length} ETFs (redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'})`);
   return etfs.length;
@@ -2026,7 +2058,7 @@ async function seedCryptoQuotes() {
     quotes.push({ name: meta?.name || id, symbol: meta?.symbol || id.toUpperCase(), price: coin.current_price ?? 0, change: coin.price_change_percentage_24h ?? 0, sparkline: prices && prices.length > 24 ? prices.slice(-48) : (prices || []) });
   }
   if (quotes.length === 0 || quotes.every((q) => q.price === 0)) { console.warn('[Crypto] No valid quotes — skipping'); return 0; }
-  const ok1 = await upstashSet('market:crypto:v1', { quotes }, CRYPTO_SEED_TTL);
+  const ok1 = await envelopeWrite('market:crypto:v1', { quotes }, CRYPTO_SEED_TTL, { recordCount: quotes.length, sourceVersion: 'market-crypto' });
   const ok2 = await upstashSet('seed-meta:market:crypto', { fetchedAt: Date.now(), recordCount: quotes.length }, 604800);
   console.log(`[Crypto] Seeded ${quotes.length}/${CRYPTO_IDS.length} quotes (redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'})`);
   const movingCrypto = quotes.filter(q => Math.abs(q.change ?? 0) >= 10).sort((a, b) => Math.abs(b.change) - Math.abs(a.change));

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2119,7 +2119,7 @@ async function seedStablecoinMarkets() {
   const totalVolume24h = stablecoins.reduce((s, c) => s + c.volume24h, 0);
   const depeggedCount = stablecoins.filter((c) => c.pegStatus === 'DEPEGGED').length;
   const payload = { timestamp: new Date().toISOString(), summary: { totalMarketCap, totalVolume24h, coinCount: stablecoins.length, depeggedCount, healthStatus: depeggedCount === 0 ? 'HEALTHY' : depeggedCount === 1 ? 'CAUTION' : 'WARNING' }, stablecoins };
-  const ok1 = await upstashSet('market:stablecoins:v1', payload, STABLECOIN_SEED_TTL);
+  const ok1 = await envelopeWrite('market:stablecoins:v1', payload, STABLECOIN_SEED_TTL, { recordCount: stablecoins.length, sourceVersion: 'market-stablecoins' });
   const ok2 = await upstashSet('seed-meta:market:stablecoins', { fetchedAt: Date.now(), recordCount: stablecoins.length }, 604800);
   console.log(`[Stablecoin] Seeded ${stablecoins.length} coins (redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'})`);
   return stablecoins.length;
@@ -2161,7 +2161,7 @@ async function seedCryptoSectors() {
     const change = changes.length > 0 ? changes.reduce((a, b) => a + b, 0) / changes.length : 0;
     return { id: sector.id, name: sector.name, change };
   });
-  const ok1 = await upstashSet('market:crypto-sectors:v1', { sectors }, SECTORS_SEED_TTL);
+  const ok1 = await envelopeWrite('market:crypto-sectors:v1', { sectors }, SECTORS_SEED_TTL, { recordCount: sectors.length, sourceVersion: 'market-crypto-sectors' });
   const ok2 = await upstashSet('seed-meta:market:crypto-sectors', { fetchedAt: Date.now(), recordCount: sectors.length }, 604800);
   console.log(`[CryptoSectors] Seeded ${sectors.length} sectors (redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'})`);
   return sectors.length;
@@ -2228,9 +2228,9 @@ async function seedTokenPanels() {
     console.warn('[TokenPanels] All panels empty after mapping — skipping Redis write to preserve cached data');
     return 0;
   }
-  const ok1 = await upstashSet('market:defi-tokens:v1', defi, TOKEN_PANELS_SEED_TTL);
-  const ok2 = await upstashSet('market:ai-tokens:v1', ai, TOKEN_PANELS_SEED_TTL);
-  const ok3 = await upstashSet('market:other-tokens:v1', other, TOKEN_PANELS_SEED_TTL);
+  const ok1 = await envelopeWrite('market:defi-tokens:v1', defi, TOKEN_PANELS_SEED_TTL, { recordCount: defi.tokens.length, sourceVersion: 'market-defi-tokens' });
+  const ok2 = await envelopeWrite('market:ai-tokens:v1', ai, TOKEN_PANELS_SEED_TTL, { recordCount: ai.tokens.length, sourceVersion: 'market-ai-tokens' });
+  const ok3 = await envelopeWrite('market:other-tokens:v1', other, TOKEN_PANELS_SEED_TTL, { recordCount: other.tokens.length, sourceVersion: 'market-other-tokens' });
   await upstashSet('seed-meta:market:token-panels', { fetchedAt: Date.now(), recordCount: defi.tokens.length + ai.tokens.length + other.tokens.length }, 604800);
   const total = defi.tokens.length + ai.tokens.length + other.tokens.length;
   const allOk = ok1 && ok2 && ok3;
@@ -2527,7 +2527,7 @@ async function seedAviationDelays() {
       return;
     }
 
-    const ok = await upstashSet(AVIATION_REDIS_KEY, { alerts }, AVIATION_SEED_TTL);
+    const ok = await envelopeWrite(AVIATION_REDIS_KEY, { alerts }, AVIATION_SEED_TTL, { recordCount: alerts.length, sourceVersion: 'aviationstack' });
     await upstashSet('seed-meta:aviation:intl', { fetchedAt: Date.now(), recordCount: alerts.length }, 604800);
     console.log(`[Aviation] Seeded ${alerts.length} alerts (${succeeded} ok, ${failed} failed, redis: ${ok ? 'OK' : 'FAIL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
     const severeAlerts = alerts.filter(a =>
@@ -2705,7 +2705,7 @@ async function seedNotamClosures() {
 
   const closedIcaos = [...closedSet];
   const payload = { closedIcaos, reasons };
-  const ok = await upstashSet(NOTAM_REDIS_KEY, payload, NOTAM_SEED_TTL);
+  const ok = await envelopeWrite(NOTAM_REDIS_KEY, payload, NOTAM_SEED_TTL, { recordCount: closedIcaos.length, sourceVersion: 'icao-notam', zeroOk: true });
   await upstashSet('seed-meta:aviation:notam', { fetchedAt: Date.now(), recordCount: closedIcaos.length }, 604800);
   const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
   console.log(`[NOTAM-Seed] ${notams.length} raw NOTAMs, ${closedIcaos.length} closures (redis: ${ok ? 'OK' : 'FAIL'}) in ${elapsed}s`);
@@ -3089,8 +3089,8 @@ async function seedCyberThreats() {
     }
 
     const payload = { threats };
-    const ok1 = await upstashSet(CYBER_RPC_KEY, payload, CYBER_SEED_TTL);
-    const ok2 = await upstashSet(CYBER_BOOTSTRAP_KEY, payload, CYBER_SEED_TTL);
+    const ok1 = await envelopeWrite(CYBER_RPC_KEY, payload, CYBER_SEED_TTL, { recordCount: threats.length, sourceVersion: 'cyber-threats' });
+    const ok2 = await envelopeWrite(CYBER_BOOTSTRAP_KEY, payload, CYBER_SEED_TTL, { recordCount: threats.length, sourceVersion: 'cyber-threats' });
     const ok3 = await upstashSet('seed-meta:cyber:threats', { fetchedAt: Date.now(), recordCount: threats.length }, 604800);
     console.log(`[Cyber] Seeded ${threats.length} threats (feodo:${feodo.length} urlhaus:${urlhaus.length} c2intel:${c2intel.length} otx:${otx.length} abuseipdb:${abuseipdb.length} redis:${ok1 && ok2 && ok3 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
     const newCyber = hydrated.filter(t =>
@@ -3259,8 +3259,8 @@ async function seedPositiveEvents() {
 
     const capped = allEvents.slice(0, POSITIVE_EVENTS_MAX);
     const payload = { events: capped, fetchedAt: Date.now() };
-    const ok1 = await upstashSet(POSITIVE_EVENTS_RPC_KEY, payload, POSITIVE_EVENTS_TTL);
-    const ok2 = await upstashSet(POSITIVE_EVENTS_BOOTSTRAP_KEY, payload, POSITIVE_EVENTS_TTL);
+    const ok1 = await envelopeWrite(POSITIVE_EVENTS_RPC_KEY, payload, POSITIVE_EVENTS_TTL, { recordCount: capped.length, sourceVersion: 'positive-events' });
+    const ok2 = await envelopeWrite(POSITIVE_EVENTS_BOOTSTRAP_KEY, payload, POSITIVE_EVENTS_TTL, { recordCount: capped.length, sourceVersion: 'positive-events' });
     const ok3 = await upstashSet('seed-meta:positive-events:geo', { fetchedAt: Date.now(), recordCount: capped.length }, 604800);
     console.log(`[PositiveEvents] Seeded ${capped.length} events (redis: ${ok1 && ok2 && ok3 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
   } catch (e) {
@@ -3738,7 +3738,7 @@ async function seedClassify() {
 
     await upstashSet('seed-meta:news:threat-summary', { fetchedAt: Date.now(), recordCount: Object.keys(mergedByCountry).length }, 604800);
     if (Object.keys(mergedByCountry).length > 0) {
-      await upstashSet(NEWS_THREAT_SUMMARY_KEY, { byCountry: mergedByCountry, generatedAt: Date.now() }, NEWS_THREAT_SUMMARY_TTL);
+      await envelopeWrite(NEWS_THREAT_SUMMARY_KEY, { byCountry: mergedByCountry, generatedAt: Date.now() }, NEWS_THREAT_SUMMARY_TTL, { recordCount: Object.keys(mergedByCountry).length, sourceVersion: 'news-threat-summary' });
       console.log(`[Classify] Threat summary written for ${Object.keys(mergedByCountry).length} countries`);
     }
 
@@ -4319,9 +4319,9 @@ async function seedTheaterPosture() {
   const theaters = calculateTheaterPostures(flights);
   const totalVessels = theaters.reduce((sum, t) => sum + t.trackedVessels, 0);
   const payload = { theaters };
-  const ok1 = await upstashSet(THEATER_POSTURE_LIVE_KEY, payload, THEATER_POSTURE_LIVE_TTL);
-  const ok2 = await upstashSet(THEATER_POSTURE_STALE_KEY, payload, THEATER_POSTURE_STALE_TTL);
-  const ok3 = await upstashSet(THEATER_POSTURE_BACKUP_KEY, payload, THEATER_POSTURE_BACKUP_TTL);
+  const ok1 = await envelopeWrite(THEATER_POSTURE_LIVE_KEY, payload, THEATER_POSTURE_LIVE_TTL, { recordCount: theaters.length, sourceVersion: 'theater-posture' });
+  const ok2 = await envelopeWrite(THEATER_POSTURE_STALE_KEY, payload, THEATER_POSTURE_STALE_TTL, { recordCount: theaters.length, sourceVersion: 'theater-posture' });
+  const ok3 = await envelopeWrite(THEATER_POSTURE_BACKUP_KEY, payload, THEATER_POSTURE_BACKUP_TTL, { recordCount: theaters.length, sourceVersion: 'theater-posture' });
   await upstashSet('seed-meta:theater-posture', { fetchedAt: Date.now(), recordCount: flights.length + totalVessels }, 604800);
   const elevated = theaters.filter((t) => t.postureLevel !== 'normal').length;
   const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
@@ -4521,7 +4521,7 @@ async function seedWeatherAlerts() {
       return;
     }
     const payload = { alerts };
-    const ok1 = await upstashSet(WEATHER_REDIS_KEY, payload, WEATHER_CACHE_TTL);
+    const ok1 = await envelopeWrite(WEATHER_REDIS_KEY, payload, WEATHER_CACHE_TTL, { recordCount: alerts.length, sourceVersion: 'nws-weather' });
     const ok2 = await upstashSet('seed-meta:weather:alerts', { fetchedAt: Date.now(), recordCount: alerts.length }, 604800);
     console.log(`[Weather] Seeded ${alerts.length} alerts (redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
     const highSeverityAlerts = alerts.filter(a => a.severity === 'Extreme' || a.severity === 'Severe');
@@ -4627,7 +4627,7 @@ async function seedUsaSpending() {
     }
     const totalAmount = awards.reduce((s, a) => s + a.amount, 0);
     const payload = { awards, totalAmount, periodStart, periodEnd, fetchedAt: Date.now() };
-    const ok1 = await upstashSet(SPENDING_REDIS_KEY, payload, SPENDING_CACHE_TTL);
+    const ok1 = await envelopeWrite(SPENDING_REDIS_KEY, payload, SPENDING_CACHE_TTL, { recordCount: awards.length, sourceVersion: 'usaspending' });
     const ok2 = await upstashSet('seed-meta:economic:spending', { fetchedAt: Date.now(), recordCount: awards.length }, 604800);
     console.log(`[Spending] Seeded ${awards.length} awards, $${(totalAmount / 1e6).toFixed(1)}M (redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
   } catch (e) {
@@ -4740,7 +4740,7 @@ async function seedGscpi() {
         observations,
       },
     };
-    await upstashSet(GSCPI_REDIS_KEY, payload, GSCPI_SEED_TTL);
+    await envelopeWrite(GSCPI_REDIS_KEY, payload, GSCPI_SEED_TTL, { recordCount: observations.length, sourceVersion: 'nyfed-gscpi' });
     await upstashSet('seed-meta:economic:gscpi', { fetchedAt: Date.now(), recordCount: observations.length }, 604800);
     console.log(`[GSCPI] Seeded ${observations.length} months; latest ${latest.date} = ${latest.value.toFixed(2)}`);
   } catch (e) {
@@ -4950,8 +4950,8 @@ async function seedTechEvents() {
       error: '',
     };
 
-    const ok1 = await upstashSet(TECH_EVENTS_REDIS_KEY, payload, TECH_EVENTS_TTL_SECONDS);
-    const ok2 = await upstashSet(TECH_EVENTS_BOOTSTRAP_KEY, payload, TECH_EVENTS_TTL_SECONDS);
+    const ok1 = await envelopeWrite(TECH_EVENTS_REDIS_KEY, payload, TECH_EVENTS_TTL_SECONDS, { recordCount: events.length, sourceVersion: 'tech-events' });
+    const ok2 = await envelopeWrite(TECH_EVENTS_BOOTSTRAP_KEY, payload, TECH_EVENTS_TTL_SECONDS, { recordCount: events.length, sourceVersion: 'tech-events' });
     const ok3 = await upstashSet('seed-meta:research:tech-events', { fetchedAt: Date.now(), recordCount: events.length }, 604800);
     console.log(`[TechEvents] Seeded ${events.length} events (redis: ${ok1 && ok2 && ok3 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
   } catch (e) {
@@ -5201,18 +5201,18 @@ async function seedWorldBank() {
     }
 
     const metaTtl = WB_TTL_SECONDS + 3600;
-    let ok = await upstashSet(WB_BOOTSTRAP_KEY, rankings, WB_TTL_SECONDS);
+    let ok = await envelopeWrite(WB_BOOTSTRAP_KEY, rankings, WB_TTL_SECONDS, { recordCount: rankings.length, sourceVersion: 'worldbank-techreadiness' });
     console.log(`[WB] techReadiness: ${rankings.length} rankings (redis: ${ok ? 'OK' : 'FAIL'})`);
     await upstashSet(`seed-meta:${WB_BOOTSTRAP_KEY}`, { fetchedAt: Date.now(), recordCount: rankings.length }, metaTtl);
 
     if (progressWithData.length > 0) {
-      ok = await upstashSet(WB_PROGRESS_KEY, progressData, WB_TTL_SECONDS);
+      ok = await envelopeWrite(WB_PROGRESS_KEY, progressData, WB_TTL_SECONDS, { recordCount: progressWithData.length, sourceVersion: 'worldbank-progress' });
       console.log(`[WB] progressData: ${progressWithData.length} indicators (redis: ${ok ? 'OK' : 'FAIL'})`);
       await upstashSet(`seed-meta:${WB_PROGRESS_KEY}`, { fetchedAt: Date.now(), recordCount: progressWithData.length }, metaTtl);
     }
 
     if (renewableData.historicalData.length > 0) {
-      ok = await upstashSet(WB_RENEWABLE_KEY, renewableData, WB_TTL_SECONDS);
+      ok = await envelopeWrite(WB_RENEWABLE_KEY, renewableData, WB_TTL_SECONDS, { recordCount: renewableData.historicalData.length, sourceVersion: 'worldbank-renewable' });
       console.log(`[WB] renewableEnergy: ${renewableData.regions.length} regions (redis: ${ok ? 'OK' : 'FAIL'})`);
       await upstashSet(`seed-meta:${WB_RENEWABLE_KEY}`, { fetchedAt: Date.now(), recordCount: renewableData.historicalData.length }, metaTtl);
     }
@@ -5305,7 +5305,7 @@ async function seedCorridorRisk() {
       return;
     }
     latestCorridorRiskData = result;
-    const ok = await upstashSet(CORRIDOR_RISK_REDIS_KEY, result, CORRIDOR_RISK_TTL);
+    const ok = await envelopeWrite(CORRIDOR_RISK_REDIS_KEY, result, CORRIDOR_RISK_TTL, { recordCount: Object.keys(result).length, sourceVersion: 'corridor-risk' });
     await upstashSet('seed-meta:supply_chain:corridorrisk', { fetchedAt: Date.now(), recordCount: Object.keys(result).length }, 604800);
     console.log(`[CorridorRisk] Seeded ${Object.keys(result).length} corridors (redis: ${ok ? 'OK' : 'FAIL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
     seedTransitSummaries().catch(e => console.warn('[TransitSummary] Post-CorridorRisk seed error:', e?.message || e));
@@ -5563,8 +5563,8 @@ async function seedUsniFleet() {
     const report = usniParseArticle(htmlContent, articleUrl, articleDate, articleTitle);
     if (!report.vessels.length) { console.warn('[USNI] No vessels parsed, skipping write'); return; }
 
-    const ok = await upstashSet(USNI_REDIS_KEY, report, USNI_TTL);
-    await upstashSet(USNI_STALE_KEY, report, USNI_STALE_TTL);
+    const ok = await envelopeWrite(USNI_REDIS_KEY, report, USNI_TTL, { recordCount: report.vessels.length, sourceVersion: 'usni-fleet' });
+    await envelopeWrite(USNI_STALE_KEY, report, USNI_STALE_TTL, { recordCount: report.vessels.length, sourceVersion: 'usni-fleet' });
     await upstashSet('seed-meta:military:usni-fleet', { fetchedAt: Date.now(), recordCount: report.vessels.length }, 604800);
 
     console.log(`[USNI] ${report.vessels.length} vessels, ${report.strikeGroups.length} CSGs, ${report.regions.length} regions (redis: ${ok ? 'OK' : 'FAIL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
@@ -5640,7 +5640,7 @@ async function seedShippingStress() {
     const stressScore = Math.min(100, Math.max(0, Math.round(40 - avgChange * 3)));
     const stressLevel = stressScore >= 75 ? 'critical' : stressScore >= 50 ? 'elevated' : stressScore >= 25 ? 'moderate' : 'low';
     const payload = { carriers: results, stressScore, stressLevel, fetchedAt: Date.now() };
-    const ok = await upstashSet(SHIPPING_STRESS_REDIS_KEY, payload, SHIPPING_STRESS_TTL);
+    const ok = await envelopeWrite(SHIPPING_STRESS_REDIS_KEY, payload, SHIPPING_STRESS_TTL, { recordCount: results.length, sourceVersion: 'shipping-stress' });
     await upstashSet('seed-meta:supply_chain:shipping_stress', { fetchedAt: Date.now(), recordCount: results.length }, 604800);
     console.log(`[ShippingStress] Seeded ${results.length} carriers score=${stressScore}/${stressLevel} (redis: ${ok ? 'OK' : 'FAIL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
     if (stressScore >= 75) {
@@ -5741,7 +5741,7 @@ async function seedSocialVelocity() {
     allPosts.sort((a, b) => b.velocityScore - a.velocityScore);
     const top = allPosts.slice(0, 30);
     const payload = { posts: top, fetchedAt: Date.now() };
-    const ok = await upstashSet(SOCIAL_VELOCITY_REDIS_KEY, payload, SOCIAL_VELOCITY_TTL);
+    const ok = await envelopeWrite(SOCIAL_VELOCITY_REDIS_KEY, payload, SOCIAL_VELOCITY_TTL, { recordCount: top.length, sourceVersion: 'social-reddit' });
     await upstashSet('seed-meta:intelligence:social-reddit', { fetchedAt: Date.now(), recordCount: top.length }, 604800);
     console.log(`[SocialVelocity] Seeded ${top.length} posts (redis: ${ok ? 'OK' : 'FAIL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
   } catch (e) {
@@ -5933,7 +5933,7 @@ async function seedWsbTickers() {
     tickers.sort((a, b) => b.velocityScore - a.velocityScore);
     const top = tickers.slice(0, 50);
     const payload = { tickers: top, fetchedAt: Date.now(), subredditsScanned: WSB_SUBREDDITS.length, postsScanned };
-    const writeOk = await upstashSet(WSB_TICKERS_REDIS_KEY, payload, WSB_TICKERS_TTL);
+    const writeOk = await envelopeWrite(WSB_TICKERS_REDIS_KEY, payload, WSB_TICKERS_TTL, { recordCount: top.length, sourceVersion: 'wsb-tickers' });
     if (writeOk) {
       await upstashSet('seed-meta:intelligence:wsb-tickers', { fetchedAt: Date.now(), recordCount: top.length }, 604800);
     } else {
@@ -6206,7 +6206,7 @@ async function seedPizzint() {
     } catch { /* GDELT unavailable — non-fatal */ }
 
     const payload = { pizzint, tensionPairs };
-    const ok1 = await upstashSet(PIZZINT_REDIS_KEY, payload, PIZZINT_SEED_TTL);
+    const ok1 = await envelopeWrite(PIZZINT_REDIS_KEY, payload, PIZZINT_SEED_TTL, { recordCount: locations.length, sourceVersion: 'pizzint' });
     const ok2 = await upstashSet('seed-meta:intelligence:pizzint', { fetchedAt: Date.now(), recordCount: locations.length }, 604800);
     console.log(`[PizzINT] Seeded ${locations.length} locations (open:${openLocations.length} spikes:${activeSpikes} defcon:${defconLevel} gdelt:${tensionPairs.length} redis:${ok1 && ok2 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
   } catch (e) {
@@ -6357,7 +6357,7 @@ async function seedDodoPrices() {
     // Only write to Redis when ALL prices came from Dodo (no fallback contamination).
     // Partial/fallback results are not persisted — edge endpoint serves them directly with short cache.
     if (priceSource === 'dodo') {
-      const ok1 = await upstashSet(DODO_PRICE_REDIS_KEY, payload, DODO_PRICE_SEED_TTL);
+      const ok1 = await envelopeWrite(DODO_PRICE_REDIS_KEY, payload, DODO_PRICE_SEED_TTL, { recordCount: fetchedCount, sourceVersion: 'dodo-prices' });
       const ok2 = await upstashSet('seed-meta:product-catalog', { fetchedAt: now, recordCount: fetchedCount, priceSource }, 604800);
       console.log(`[DodoPrices] Seeded ${fetchedCount}/${DODO_PRODUCT_IDS.length} from Dodo (redis=${ok1 && ok2 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
     } else {
@@ -7202,7 +7202,7 @@ async function seedChokepointTransits() {
     };
   }
   const payload = { transits, fetchedAt: now };
-  await upstashSet(CHOKEPOINT_TRANSIT_KEY, payload, CHOKEPOINT_TRANSIT_TTL);
+  await envelopeWrite(CHOKEPOINT_TRANSIT_KEY, payload, CHOKEPOINT_TRANSIT_TTL, { recordCount: Object.keys(transits).length, sourceVersion: 'chokepoint-transits' });
   await upstashSet('seed-meta:supply_chain:chokepoint_transits', { fetchedAt: now, recordCount: Object.keys(transits).length }, 604800);
   console.log(`[Transit] Seeded ${Object.keys(transits).length} chokepoint transit counts`);
 }
@@ -7312,7 +7312,7 @@ async function seedTransitSummaries() {
     };
   }
 
-  const ok = await upstashSet(TRANSIT_SUMMARY_REDIS_KEY, { summaries, fetchedAt: now }, TRANSIT_SUMMARY_TTL);
+  const ok = await envelopeWrite(TRANSIT_SUMMARY_REDIS_KEY, { summaries, fetchedAt: now }, TRANSIT_SUMMARY_TTL, { recordCount: Object.keys(summaries).length, sourceVersion: 'transit-summaries' });
   await upstashSet('seed-meta:supply_chain:transit-summaries', { fetchedAt: now, recordCount: Object.keys(summaries).length }, 604800);
   console.log(`[TransitSummary] Seeded ${Object.keys(summaries).length} summaries (redis: ${ok ? 'OK' : 'FAIL'})`);
 }

--- a/scripts/seed-aaii-sentiment.mjs
+++ b/scripts/seed-aaii-sentiment.mjs
@@ -390,6 +390,10 @@ function validate(data) {
   return data?.latest?.bullish != null && data?.weeks?.length > 0;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.weeks) ? data.weeks.length : 0;
+}
+
 const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^.*[\\/]/, ''));
 if (isMain) {
   runSeed('market', 'aaii-sentiment', AAII_KEY, fetchAaiiSentiment, {
@@ -397,6 +401,9 @@ if (isMain) {
     ttlSeconds: AAII_TTL,
     recordCount: (data) => data?.weeks?.length ?? 0,
     sourceVersion: 'aaii-xls-html-v1',
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 20160,
   }).catch((err) => {
     console.error('FATAL:', err.message || err);
     process.exit(1);

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -264,10 +264,17 @@ function validate(data) {
   return data?.summaries?.length > 0;
 }
 
+export function declareRecords(data) {
+  return data?.summaries?.length ?? 0;
+}
+
 runSeed('aviation', 'ops-news', OPS_CACHE_KEY, fetchAll, {
   validateFn: validate,
   ttlSeconds: OPS_TTL,
   sourceVersion: 'aviationstack-rss',
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 150,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -13,6 +13,7 @@
  */
 
 import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -74,7 +75,7 @@ async function fetchNotamClosures() {
     });
     if (!resp.ok) return null;
     const data = await resp.json();
-    return data.result ? JSON.parse(data.result) : null;
+    return data.result ? unwrapEnvelope(JSON.parse(data.result)).data : null;
   } catch {
     return null;
   }

--- a/scripts/seed-bigmac.mjs
+++ b/scripts/seed-bigmac.mjs
@@ -265,13 +265,22 @@ async function fetchBigMacPrices(prevSnapshot) {
 
 const prevSnapshot = await readSeedSnapshot(CANONICAL_KEY);
 
+export function declareRecords(data) {
+  return data?.countries?.filter(c => c.available).length || 0;
+}
+
 await runSeed('economic', 'bigmac', CANONICAL_KEY, () => fetchBigMacPrices(prevSnapshot), {
   ttlSeconds: CACHE_TTL,
   validateFn: (data) => data?.countries?.length > 0,
   recordCount: (data) => data?.countries?.filter(c => c.available).length || 0,
+  declareRecords,
+  sourceVersion: 'economist-bigmac-v1',
+  schemaVersion: 1,
+  maxStaleMin: 10080,
   extraKeys: prevSnapshot ? [{
     key: `${CANONICAL_KEY}:prev`,
     transform: () => prevSnapshot,  // write PRE-overwrite snapshot; ignore new data
     ttl: CACHE_TTL * 2,
+    declareRecords,
   }] : undefined,
 });

--- a/scripts/seed-bis-data.mjs
+++ b/scripts/seed-bis-data.mjs
@@ -205,6 +205,12 @@ function validate(data) {
   return Array.isArray(data?.rates) && data.rates.length > 0;
 }
 
+// Contract: canonical key stores bis policy rates; declareRecords sees the
+// post-transform `{rates: [...]}` shape, same as validateFn.
+export function declareRecords(data) {
+  return Array.isArray(data?.rates) ? data.rates.length : 0;
+}
+
 // publishTransform: store only policy data (correct shape) at canonical key.
 // runSeed() calls process.exit(0) — .then() is unreachable; use afterPublish instead.
 function publishTransform(data) {
@@ -221,6 +227,9 @@ if (process.argv[1]?.endsWith('seed-bis-data.mjs')) {
     validateFn: validate,
     ttlSeconds: TTL,
     sourceVersion: 'bis-sdmx-csv',
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 10080,
     publishTransform,
     afterPublish,
   }).catch((err) => {

--- a/scripts/seed-bis-extended.mjs
+++ b/scripts/seed-bis-extended.mjs
@@ -454,6 +454,12 @@ export function publishTransform(data) {
     : { entries: [] };
 }
 
+export function declareRecords(data) {
+  // publishTransform yields `data.dsr || { entries: [] }` — count entries.
+  const payload = data?.dsr && data.dsr.entries?.length > 0 ? data.dsr : data;
+  return Array.isArray(payload?.entries) ? payload.entries.length : 0;
+}
+
 if (process.argv[1]?.endsWith('seed-bis-extended.mjs')) {
   runSeed('economic', 'bis-extended', KEYS.dsr, fetchAll, {
     validateFn: validate,
@@ -461,6 +467,9 @@ if (process.argv[1]?.endsWith('seed-bis-extended.mjs')) {
     sourceVersion: 'bis-sdmx-csv-extended',
     publishTransform,
     afterPublish: dsrAfterPublish,
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 1440,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-bls-series.mjs
+++ b/scripts/seed-bls-series.mjs
@@ -108,6 +108,10 @@ async function afterPublish(data, _meta) {
   }
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.series) ? data.series.length : 0;
+}
+
 if (process.argv[1]?.endsWith('seed-bls-series.mjs')) {
   runSeed('economic', 'bls-series', CANONICAL_KEY, fetchAllSeries, {
     validateFn: validate,
@@ -115,6 +119,10 @@ if (process.argv[1]?.endsWith('seed-bls-series.mjs')) {
     sourceVersion: 'fred-v1',
     publishTransform,
     afterPublish,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 2880,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-bundle-climate.mjs
+++ b/scripts/seed-bundle-climate.mjs
@@ -2,9 +2,9 @@
 import { runBundle, HOUR, DAY } from './_bundle-runner.mjs';
 
 await runBundle('climate', [
-  { label: 'Zone-Normals', script: 'seed-climate-zone-normals.mjs', seedMetaKey: 'climate:zone-normals', intervalMs: 30 * DAY, timeoutMs: 600_000 },
-  { label: 'Anomalies', script: 'seed-climate-anomalies.mjs', seedMetaKey: 'climate:anomalies', intervalMs: 3 * HOUR, timeoutMs: 300_000 },
-  { label: 'Disasters', script: 'seed-climate-disasters.mjs', seedMetaKey: 'climate:disasters', intervalMs: 6 * HOUR, timeoutMs: 180_000 },
-  { label: 'Ocean-Ice', script: 'seed-climate-ocean-ice.mjs', seedMetaKey: 'climate:ocean-ice', intervalMs: DAY, timeoutMs: 300_000 },
-  { label: 'CO2-Monitoring', script: 'seed-co2-monitoring.mjs', seedMetaKey: 'climate:co2-monitoring', intervalMs: 3 * DAY, timeoutMs: 180_000 },
+  { label: 'Zone-Normals', script: 'seed-climate-zone-normals.mjs', seedMetaKey: 'climate:zone-normals', canonicalKey: 'climate:zone-normals:v1', intervalMs: 30 * DAY, timeoutMs: 600_000 },
+  { label: 'Anomalies', script: 'seed-climate-anomalies.mjs', seedMetaKey: 'climate:anomalies', canonicalKey: 'climate:anomalies:v2', intervalMs: 3 * HOUR, timeoutMs: 300_000 },
+  { label: 'Disasters', script: 'seed-climate-disasters.mjs', seedMetaKey: 'climate:disasters', canonicalKey: 'climate:disasters:v1', intervalMs: 6 * HOUR, timeoutMs: 180_000 },
+  { label: 'Ocean-Ice', script: 'seed-climate-ocean-ice.mjs', seedMetaKey: 'climate:ocean-ice', canonicalKey: 'climate:ocean-ice:v1', intervalMs: DAY, timeoutMs: 300_000 },
+  { label: 'CO2-Monitoring', script: 'seed-co2-monitoring.mjs', seedMetaKey: 'climate:co2-monitoring', canonicalKey: 'climate:co2-monitoring:v1', intervalMs: 3 * DAY, timeoutMs: 180_000 },
 ]);

--- a/scripts/seed-bundle-derived-signals.mjs
+++ b/scripts/seed-bundle-derived-signals.mjs
@@ -2,7 +2,7 @@
 import { runBundle, MIN, HOUR } from './_bundle-runner.mjs';
 
 await runBundle('derived-signals', [
-  { label: 'Correlation', script: 'seed-correlation.mjs', seedMetaKey: 'correlation:cards', intervalMs: 5 * MIN, timeoutMs: 60_000 },
-  { label: 'Cross-Source-Signals', script: 'seed-cross-source-signals.mjs', seedMetaKey: 'intelligence:cross-source-signals', intervalMs: 15 * MIN, timeoutMs: 120_000 },
+  { label: 'Correlation', script: 'seed-correlation.mjs', seedMetaKey: 'correlation:cards', canonicalKey: 'correlation:cards-bootstrap:v1', intervalMs: 5 * MIN, timeoutMs: 60_000 },
+  { label: 'Cross-Source-Signals', script: 'seed-cross-source-signals.mjs', seedMetaKey: 'intelligence:cross-source-signals', canonicalKey: 'intelligence:cross-source-signals:v1', intervalMs: 15 * MIN, timeoutMs: 120_000 },
   { label: 'Regional-Snapshots', script: 'seed-regional-snapshots.mjs', seedMetaKey: 'intelligence:regional-snapshots', intervalMs: 6 * HOUR, timeoutMs: 180_000 },
 ]);

--- a/scripts/seed-bundle-ecb-eu.mjs
+++ b/scripts/seed-bundle-ecb-eu.mjs
@@ -2,8 +2,8 @@
 import { runBundle, DAY, WEEK } from './_bundle-runner.mjs';
 
 await runBundle('ecb-eu', [
-  { label: 'ECB-FX-Rates', script: 'seed-ecb-fx-rates.mjs', seedMetaKey: 'economic:ecb-fx-rates', intervalMs: DAY, timeoutMs: 120_000 },
+  { label: 'ECB-FX-Rates', script: 'seed-ecb-fx-rates.mjs', seedMetaKey: 'economic:ecb-fx-rates', canonicalKey: 'economic:ecb-fx-rates:v1', intervalMs: DAY, timeoutMs: 120_000 },
   { label: 'ECB-Short-Rates', script: 'seed-ecb-short-rates.mjs', seedMetaKey: 'economic:ecb-short-rates', intervalMs: DAY, timeoutMs: 120_000 },
-  { label: 'Yield-Curve-EU', script: 'seed-yield-curve-eu.mjs', seedMetaKey: 'economic:yield-curve-eu', intervalMs: DAY, timeoutMs: 120_000 },
-  { label: 'FSI-EU', script: 'seed-fsi-eu.mjs', seedMetaKey: 'economic:fsi-eu', intervalMs: WEEK, timeoutMs: 120_000 },
+  { label: 'Yield-Curve-EU', script: 'seed-yield-curve-eu.mjs', seedMetaKey: 'economic:yield-curve-eu', canonicalKey: 'economic:yield-curve-eu:v1', intervalMs: DAY, timeoutMs: 120_000 },
+  { label: 'FSI-EU', script: 'seed-fsi-eu.mjs', seedMetaKey: 'economic:fsi-eu', canonicalKey: 'economic:fsi-eu:v1', intervalMs: WEEK, timeoutMs: 120_000 },
 ]);

--- a/scripts/seed-bundle-energy-sources.mjs
+++ b/scripts/seed-bundle-energy-sources.mjs
@@ -2,17 +2,17 @@
 import { runBundle, DAY } from './_bundle-runner.mjs';
 
 await runBundle('energy-sources', [
-  { label: 'GIE-Gas-Storage', script: 'seed-gie-gas-storage.mjs', seedMetaKey: 'economic:eu-gas-storage', intervalMs: DAY, timeoutMs: 180_000 },
+  { label: 'GIE-Gas-Storage', script: 'seed-gie-gas-storage.mjs', seedMetaKey: 'economic:eu-gas-storage', canonicalKey: 'economic:eu-gas-storage:v1', intervalMs: DAY, timeoutMs: 180_000 },
   { label: 'Gas-Storage-Countries', script: 'seed-gas-storage-countries.mjs', seedMetaKey: 'energy:gas-storage-countries', intervalMs: DAY, timeoutMs: 600_000 },
-  { label: 'JODI-Gas', script: 'seed-jodi-gas.mjs', seedMetaKey: 'energy:jodi-gas', intervalMs: 35 * DAY, timeoutMs: 600_000 },
-  { label: 'JODI-Oil', script: 'seed-jodi-oil.mjs', seedMetaKey: 'energy:jodi-oil', intervalMs: 35 * DAY, timeoutMs: 600_000 },
+  { label: 'JODI-Gas', script: 'seed-jodi-gas.mjs', seedMetaKey: 'energy:jodi-gas', canonicalKey: 'energy:jodi-gas:v1:_countries', intervalMs: 35 * DAY, timeoutMs: 600_000 },
+  { label: 'JODI-Oil', script: 'seed-jodi-oil.mjs', seedMetaKey: 'energy:jodi-oil', canonicalKey: 'energy:jodi-oil:v1:_countries', intervalMs: 35 * DAY, timeoutMs: 600_000 },
   { label: 'OWID-Energy-Mix', script: 'seed-owid-energy-mix.mjs', seedMetaKey: 'economic:owid-energy-mix', intervalMs: 35 * DAY, timeoutMs: 600_000 },
-  { label: 'IEA-Oil-Stocks', script: 'seed-iea-oil-stocks.mjs', seedMetaKey: 'energy:iea-oil-stocks', intervalMs: 40 * DAY, timeoutMs: 300_000 },
-  { label: 'IEA-Crisis-Policies', script: 'seed-energy-crisis-policies.mjs', seedMetaKey: 'energy:crisis-policies', intervalMs: 7 * DAY, timeoutMs: 120_000 },
+  { label: 'IEA-Oil-Stocks', script: 'seed-iea-oil-stocks.mjs', seedMetaKey: 'energy:iea-oil-stocks', canonicalKey: 'energy:iea-oil-stocks:v1:index', intervalMs: 40 * DAY, timeoutMs: 300_000 },
+  { label: 'IEA-Crisis-Policies', script: 'seed-energy-crisis-policies.mjs', seedMetaKey: 'energy:crisis-policies', canonicalKey: 'energy:crisis-policies:v1', intervalMs: 7 * DAY, timeoutMs: 120_000 },
   // SPR-Policies: static registry (data lives in scripts/data/spr-policies.json), TTL 400d
   // in api/health.js (maxStaleMin: 576000). Weekly cadence is generous — only needs to run
   // once after deploys + restarts to populate energy:spr-policies:v1. No prior Railway
   // service exists for it, so health has been EMPTY (seedAgeMin: null) since the seeder
   // was added.
-  { label: 'SPR-Policies', script: 'seed-spr-policies.mjs', seedMetaKey: 'energy:spr-policies', intervalMs: 7 * DAY, timeoutMs: 60_000 },
+  { label: 'SPR-Policies', script: 'seed-spr-policies.mjs', seedMetaKey: 'energy:spr-policies', canonicalKey: 'energy:spr-policies:v1', intervalMs: 7 * DAY, timeoutMs: 60_000 },
 ]);

--- a/scripts/seed-bundle-health.mjs
+++ b/scripts/seed-bundle-health.mjs
@@ -3,7 +3,7 @@ import { runBundle, HOUR, DAY } from './_bundle-runner.mjs';
 
 await runBundle('health', [
   { label: 'Air-Quality', script: 'seed-health-air-quality.mjs', seedMetaKey: 'health:air-quality', intervalMs: HOUR, timeoutMs: 600_000 },
-  { label: 'Disease-Outbreaks', script: 'seed-disease-outbreaks.mjs', seedMetaKey: 'health:disease-outbreaks', intervalMs: DAY, timeoutMs: 300_000 },
-  { label: 'VPD-Tracker', script: 'seed-vpd-tracker.mjs', seedMetaKey: 'health:vpd-tracker', intervalMs: DAY, timeoutMs: 300_000 },
+  { label: 'Disease-Outbreaks', script: 'seed-disease-outbreaks.mjs', seedMetaKey: 'health:disease-outbreaks', canonicalKey: 'health:disease-outbreaks:v1', intervalMs: DAY, timeoutMs: 300_000 },
+  { label: 'VPD-Tracker', script: 'seed-vpd-tracker.mjs', seedMetaKey: 'health:vpd-tracker', canonicalKey: 'health:vpd-tracker:realtime:v1', intervalMs: DAY, timeoutMs: 300_000 },
   { label: 'Displacement', script: 'seed-displacement-summary.mjs', seedMetaKey: 'displacement:summary', intervalMs: DAY, timeoutMs: 300_000 },
 ]);

--- a/scripts/seed-bundle-imf-extended.mjs
+++ b/scripts/seed-bundle-imf-extended.mjs
@@ -10,8 +10,8 @@
 import { runBundle, DAY } from './_bundle-runner.mjs';
 
 await runBundle('imf-extended', [
-  { label: 'IMF-Macro',    script: 'seed-imf-macro.mjs',    seedMetaKey: 'economic:imf-macro',    intervalMs: 30 * DAY, timeoutMs: 600_000 },
-  { label: 'IMF-Growth',   script: 'seed-imf-growth.mjs',   seedMetaKey: 'economic:imf-growth',   intervalMs: 30 * DAY, timeoutMs: 600_000 },
-  { label: 'IMF-Labor',    script: 'seed-imf-labor.mjs',    seedMetaKey: 'economic:imf-labor',    intervalMs: 30 * DAY, timeoutMs: 600_000 },
-  { label: 'IMF-External', script: 'seed-imf-external.mjs', seedMetaKey: 'economic:imf-external', intervalMs: 30 * DAY, timeoutMs: 600_000 },
+  { label: 'IMF-Macro',    script: 'seed-imf-macro.mjs',    seedMetaKey: 'economic:imf-macro',    canonicalKey: 'economic:imf:macro:v2',    intervalMs: 30 * DAY, timeoutMs: 600_000 },
+  { label: 'IMF-Growth',   script: 'seed-imf-growth.mjs',   seedMetaKey: 'economic:imf-growth',   canonicalKey: 'economic:imf:growth:v1',   intervalMs: 30 * DAY, timeoutMs: 600_000 },
+  { label: 'IMF-Labor',    script: 'seed-imf-labor.mjs',    seedMetaKey: 'economic:imf-labor',    canonicalKey: 'economic:imf:labor:v1',    intervalMs: 30 * DAY, timeoutMs: 600_000 },
+  { label: 'IMF-External', script: 'seed-imf-external.mjs', seedMetaKey: 'economic:imf-external', canonicalKey: 'economic:imf:external:v1', intervalMs: 30 * DAY, timeoutMs: 600_000 },
 ]);

--- a/scripts/seed-bundle-macro.mjs
+++ b/scripts/seed-bundle-macro.mjs
@@ -2,14 +2,14 @@
 import { runBundle, HOUR, DAY } from './_bundle-runner.mjs';
 
 await runBundle('macro', [
-  { label: 'BIS-Data', script: 'seed-bis-data.mjs', seedMetaKey: 'economic:bis', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
-  { label: 'BIS-Extended', script: 'seed-bis-extended.mjs', seedMetaKey: 'economic:bis-extended', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
-  { label: 'BLS-Series', script: 'seed-bls-series.mjs', seedMetaKey: 'economic:bls-series', intervalMs: DAY, timeoutMs: 120_000 },
-  { label: 'Eurostat', script: 'seed-eurostat-country-data.mjs', seedMetaKey: 'economic:eurostat-country-data', intervalMs: DAY, timeoutMs: 300_000 },
-  { label: 'Eurostat-HousePrices', script: 'seed-eurostat-house-prices.mjs', seedMetaKey: 'economic:eurostat-house-prices', intervalMs: 7 * DAY, timeoutMs: 300_000 },
-  { label: 'Eurostat-GovDebtQ', script: 'seed-eurostat-gov-debt-q.mjs', seedMetaKey: 'economic:eurostat-gov-debt-q', intervalMs: 2 * DAY, timeoutMs: 300_000 },
-  { label: 'Eurostat-IndProd', script: 'seed-eurostat-industrial-production.mjs', seedMetaKey: 'economic:eurostat-industrial-production', intervalMs: DAY, timeoutMs: 300_000 },
-  { label: 'IMF-Macro', script: 'seed-imf-macro.mjs', seedMetaKey: 'economic:imf-macro', intervalMs: 30 * DAY, timeoutMs: 300_000 },
-  { label: 'National-Debt', script: 'seed-national-debt.mjs', seedMetaKey: 'economic:national-debt', intervalMs: 30 * DAY, timeoutMs: 300_000 },
-  { label: 'FAO-FFPI', script: 'seed-fao-food-price-index.mjs', seedMetaKey: 'economic:fao-ffpi', intervalMs: DAY, timeoutMs: 120_000 },
+  { label: 'BIS-Data', script: 'seed-bis-data.mjs', seedMetaKey: 'economic:bis', canonicalKey: 'economic:bis:policy:v1', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
+  { label: 'BIS-Extended', script: 'seed-bis-extended.mjs', seedMetaKey: 'economic:bis-extended', canonicalKey: 'economic:bis:dsr:v1', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
+  { label: 'BLS-Series', script: 'seed-bls-series.mjs', seedMetaKey: 'economic:bls-series', canonicalKey: 'bls:series:v1', intervalMs: DAY, timeoutMs: 120_000 },
+  { label: 'Eurostat', script: 'seed-eurostat-country-data.mjs', seedMetaKey: 'economic:eurostat-country-data', canonicalKey: 'economic:eurostat-country-data:v1', intervalMs: DAY, timeoutMs: 300_000 },
+  { label: 'Eurostat-HousePrices', script: 'seed-eurostat-house-prices.mjs', seedMetaKey: 'economic:eurostat-house-prices', canonicalKey: 'economic:eurostat:house-prices:v1', intervalMs: 7 * DAY, timeoutMs: 300_000 },
+  { label: 'Eurostat-GovDebtQ', script: 'seed-eurostat-gov-debt-q.mjs', seedMetaKey: 'economic:eurostat-gov-debt-q', canonicalKey: 'economic:eurostat:gov-debt-q:v1', intervalMs: 2 * DAY, timeoutMs: 300_000 },
+  { label: 'Eurostat-IndProd', script: 'seed-eurostat-industrial-production.mjs', seedMetaKey: 'economic:eurostat-industrial-production', canonicalKey: 'economic:eurostat:industrial-production:v1', intervalMs: DAY, timeoutMs: 300_000 },
+  { label: 'IMF-Macro', script: 'seed-imf-macro.mjs', seedMetaKey: 'economic:imf-macro', canonicalKey: 'economic:imf:macro:v2', intervalMs: 30 * DAY, timeoutMs: 300_000 },
+  { label: 'National-Debt', script: 'seed-national-debt.mjs', seedMetaKey: 'economic:national-debt', canonicalKey: 'economic:national-debt:v1', intervalMs: 30 * DAY, timeoutMs: 300_000 },
+  { label: 'FAO-FFPI', script: 'seed-fao-food-price-index.mjs', seedMetaKey: 'economic:fao-ffpi', canonicalKey: 'economic:fao-ffpi:v1', intervalMs: DAY, timeoutMs: 120_000 },
 ]);

--- a/scripts/seed-bundle-market-backup.mjs
+++ b/scripts/seed-bundle-market-backup.mjs
@@ -2,14 +2,14 @@
 import { runBundle, MIN } from './_bundle-runner.mjs';
 
 await runBundle('market-backup', [
-  { label: 'Crypto-Quotes', script: 'seed-crypto-quotes.mjs', seedMetaKey: 'market:crypto', intervalMs: 5 * MIN, timeoutMs: 120_000 },
-  { label: 'Hyperliquid-Flow', script: 'seed-hyperliquid-flow.mjs', seedMetaKey: 'market:hyperliquid-flow', intervalMs: 5 * MIN, timeoutMs: 60_000 },
-  { label: 'Stablecoin-Markets', script: 'seed-stablecoin-markets.mjs', seedMetaKey: 'market:stablecoins', intervalMs: 10 * MIN, timeoutMs: 120_000 },
-  { label: 'ETF-Flows', script: 'seed-etf-flows.mjs', seedMetaKey: 'market:etf-flows', intervalMs: 15 * MIN, timeoutMs: 120_000 },
-  { label: 'Gulf-Quotes', script: 'seed-gulf-quotes.mjs', seedMetaKey: 'market:gulf-quotes', intervalMs: 10 * MIN, timeoutMs: 120_000 },
-  { label: 'Token-Panels', script: 'seed-token-panels.mjs', seedMetaKey: 'market:token-panels', intervalMs: 30 * MIN, timeoutMs: 120_000 },
+  { label: 'Crypto-Quotes', script: 'seed-crypto-quotes.mjs', seedMetaKey: 'market:crypto', canonicalKey: 'market:crypto:v1', intervalMs: 5 * MIN, timeoutMs: 120_000 },
+  { label: 'Hyperliquid-Flow', script: 'seed-hyperliquid-flow.mjs', seedMetaKey: 'market:hyperliquid-flow', canonicalKey: 'market:hyperliquid:flow:v1', intervalMs: 5 * MIN, timeoutMs: 60_000 },
+  { label: 'Stablecoin-Markets', script: 'seed-stablecoin-markets.mjs', seedMetaKey: 'market:stablecoins', canonicalKey: 'market:stablecoins:v1', intervalMs: 10 * MIN, timeoutMs: 120_000 },
+  { label: 'ETF-Flows', script: 'seed-etf-flows.mjs', seedMetaKey: 'market:etf-flows', canonicalKey: 'market:etf-flows:v1', intervalMs: 15 * MIN, timeoutMs: 120_000 },
+  { label: 'Gulf-Quotes', script: 'seed-gulf-quotes.mjs', seedMetaKey: 'market:gulf-quotes', canonicalKey: 'market:gulf-quotes:v1', intervalMs: 10 * MIN, timeoutMs: 120_000 },
+  { label: 'Token-Panels', script: 'seed-token-panels.mjs', seedMetaKey: 'market:token-panels', canonicalKey: 'market:defi-tokens:v1', intervalMs: 30 * MIN, timeoutMs: 120_000 },
   // SPDR GLD publishes holdings once daily (~16:30 ET). 2h cadence = retries on Cloudflare blocks + catches late publish.
-  { label: 'Gold-ETF-Flows', script: 'seed-gold-etf-flows.mjs', seedMetaKey: 'market:gold-etf-flows', intervalMs: 120 * MIN, timeoutMs: 60_000 },
+  { label: 'Gold-ETF-Flows', script: 'seed-gold-etf-flows.mjs', seedMetaKey: 'market:gold-etf-flows', canonicalKey: 'market:gold-etf-flows:v1', intervalMs: 120 * MIN, timeoutMs: 60_000 },
   // IMF IFS publishes monthly with ~2-3 month lag. Daily cadence is plenty.
-  { label: 'Gold-CB-Reserves', script: 'seed-gold-cb-reserves.mjs', seedMetaKey: 'market:gold-cb-reserves', intervalMs: 24 * 60 * MIN, timeoutMs: 180_000 },
+  { label: 'Gold-CB-Reserves', script: 'seed-gold-cb-reserves.mjs', seedMetaKey: 'market:gold-cb-reserves', canonicalKey: 'market:gold-cb-reserves:v1', intervalMs: 24 * 60 * MIN, timeoutMs: 180_000 },
 ]);

--- a/scripts/seed-bundle-portwatch.mjs
+++ b/scripts/seed-bundle-portwatch.mjs
@@ -2,8 +2,8 @@
 import { runBundle, HOUR, WEEK } from './_bundle-runner.mjs';
 
 await runBundle('portwatch', [
-  { label: 'PW-Disruptions', script: 'seed-portwatch-disruptions.mjs', seedMetaKey: 'portwatch:disruptions', intervalMs: HOUR, timeoutMs: 120_000 },
-  { label: 'PW-Main', script: 'seed-portwatch.mjs', seedMetaKey: 'supply_chain:portwatch', intervalMs: 6 * HOUR, timeoutMs: 300_000 },
-  { label: 'PW-Port-Activity', script: 'seed-portwatch-port-activity.mjs', seedMetaKey: 'supply_chain:portwatch-ports', intervalMs: 12 * HOUR, timeoutMs: 420_000 },
-  { label: 'PW-Chokepoints-Ref', script: 'seed-portwatch-chokepoints-ref.mjs', seedMetaKey: 'portwatch:chokepoints-ref', intervalMs: WEEK, timeoutMs: 120_000 },
+  { label: 'PW-Disruptions', script: 'seed-portwatch-disruptions.mjs', seedMetaKey: 'portwatch:disruptions', canonicalKey: 'portwatch:disruptions:active:v1', intervalMs: HOUR, timeoutMs: 120_000 },
+  { label: 'PW-Main', script: 'seed-portwatch.mjs', seedMetaKey: 'supply_chain:portwatch', canonicalKey: 'supply_chain:portwatch:v1', intervalMs: 6 * HOUR, timeoutMs: 300_000 },
+  { label: 'PW-Port-Activity', script: 'seed-portwatch-port-activity.mjs', seedMetaKey: 'supply_chain:portwatch-ports', canonicalKey: 'supply_chain:portwatch-ports:v1:_countries', intervalMs: 12 * HOUR, timeoutMs: 420_000 },
+  { label: 'PW-Chokepoints-Ref', script: 'seed-portwatch-chokepoints-ref.mjs', seedMetaKey: 'portwatch:chokepoints-ref', canonicalKey: 'portwatch:chokepoints:ref:v1', intervalMs: WEEK, timeoutMs: 120_000 },
 ], { maxBundleMs: 540_000 });

--- a/scripts/seed-bundle-regional.mjs
+++ b/scripts/seed-bundle-regional.mjs
@@ -26,6 +26,7 @@
  */
 
 import { loadEnvFile, getRedisCredentials } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { main as runSnapshots } from './seed-regional-snapshots.mjs';
 import { main as runBriefs } from './seed-regional-briefs.mjs';
 
@@ -49,7 +50,7 @@ async function shouldRunBriefs() {
     if (!resp.ok) return true; // Redis error → run defensively
     const data = await resp.json();
     if (!data?.result) return true; // key missing → first run
-    const meta = JSON.parse(data.result);
+    const meta = unwrapEnvelope(JSON.parse(data.result)).data;
     const lastRun = meta?.fetchedAt ?? 0;
     const age = Date.now() - lastRun;
     if (age >= BRIEF_COOLDOWN_MS) {

--- a/scripts/seed-bundle-relay-backup.mjs
+++ b/scripts/seed-bundle-relay-backup.mjs
@@ -2,8 +2,8 @@
 import { runBundle, MIN, HOUR, DAY } from './_bundle-runner.mjs';
 
 await runBundle('relay-backup', [
-  { label: 'Climate-News', script: 'seed-climate-news.mjs', seedMetaKey: 'climate:news-intelligence', intervalMs: 30 * MIN, timeoutMs: 240_000 },
-  { label: 'USA-Spending', script: 'seed-usa-spending.mjs', seedMetaKey: 'economic:spending', intervalMs: HOUR, timeoutMs: 120_000 },
+  { label: 'Climate-News', script: 'seed-climate-news.mjs', seedMetaKey: 'climate:news-intelligence', canonicalKey: 'climate:news-intelligence:v1', intervalMs: 30 * MIN, timeoutMs: 240_000 },
+  { label: 'USA-Spending', script: 'seed-usa-spending.mjs', seedMetaKey: 'economic:spending', canonicalKey: 'economic:spending:v1', intervalMs: HOUR, timeoutMs: 120_000 },
   { label: 'UCDP-Events', script: 'seed-ucdp-events.mjs', seedMetaKey: 'conflict:ucdp-events', intervalMs: 6 * HOUR, timeoutMs: 300_000 },
   { label: 'WB-Indicators', script: 'seed-wb-indicators.mjs', seedMetaKey: 'economic:worldbank-techreadiness:v1', intervalMs: DAY, timeoutMs: 300_000 },
 ]);

--- a/scripts/seed-bundle-resilience-recovery.mjs
+++ b/scripts/seed-bundle-resilience-recovery.mjs
@@ -2,9 +2,9 @@
 import { runBundle, DAY } from './_bundle-runner.mjs';
 
 await runBundle('resilience-recovery', [
-  { label: 'Fiscal-Space', script: 'seed-recovery-fiscal-space.mjs', seedMetaKey: 'resilience:recovery:fiscal-space', intervalMs: 30 * DAY, timeoutMs: 300_000 },
-  { label: 'Reserve-Adequacy', script: 'seed-recovery-reserve-adequacy.mjs', seedMetaKey: 'resilience:recovery:reserve-adequacy', intervalMs: 30 * DAY, timeoutMs: 300_000 },
-  { label: 'External-Debt', script: 'seed-recovery-external-debt.mjs', seedMetaKey: 'resilience:recovery:external-debt', intervalMs: 30 * DAY, timeoutMs: 300_000 },
-  { label: 'Import-HHI', script: 'seed-recovery-import-hhi.mjs', seedMetaKey: 'resilience:recovery:import-hhi', intervalMs: 30 * DAY, timeoutMs: 1_800_000 },
-  { label: 'Fuel-Stocks', script: 'seed-recovery-fuel-stocks.mjs', seedMetaKey: 'resilience:recovery:fuel-stocks', intervalMs: 30 * DAY, timeoutMs: 300_000 },
+  { label: 'Fiscal-Space', script: 'seed-recovery-fiscal-space.mjs', seedMetaKey: 'resilience:recovery:fiscal-space', canonicalKey: 'resilience:recovery:fiscal-space:v1', intervalMs: 30 * DAY, timeoutMs: 300_000 },
+  { label: 'Reserve-Adequacy', script: 'seed-recovery-reserve-adequacy.mjs', seedMetaKey: 'resilience:recovery:reserve-adequacy', canonicalKey: 'resilience:recovery:reserve-adequacy:v1', intervalMs: 30 * DAY, timeoutMs: 300_000 },
+  { label: 'External-Debt', script: 'seed-recovery-external-debt.mjs', seedMetaKey: 'resilience:recovery:external-debt', canonicalKey: 'resilience:recovery:external-debt:v1', intervalMs: 30 * DAY, timeoutMs: 300_000 },
+  { label: 'Import-HHI', script: 'seed-recovery-import-hhi.mjs', seedMetaKey: 'resilience:recovery:import-hhi', canonicalKey: 'resilience:recovery:import-hhi:v1', intervalMs: 30 * DAY, timeoutMs: 1_800_000 },
+  { label: 'Fuel-Stocks', script: 'seed-recovery-fuel-stocks.mjs', seedMetaKey: 'resilience:recovery:fuel-stocks', canonicalKey: 'resilience:recovery:fuel-stocks:v1', intervalMs: 30 * DAY, timeoutMs: 300_000 },
 ]);

--- a/scripts/seed-bundle-static-ref.mjs
+++ b/scripts/seed-bundle-static-ref.mjs
@@ -2,7 +2,7 @@
 import { runBundle, DAY, WEEK } from './_bundle-runner.mjs';
 
 await runBundle('static-ref', [
-  { label: 'Submarine-Cables', script: 'seed-submarine-cables.mjs', seedMetaKey: 'infrastructure:submarine-cables', intervalMs: WEEK, timeoutMs: 300_000 },
-  { label: 'Chokepoint-Baselines', script: 'seed-chokepoint-baselines.mjs', seedMetaKey: 'energy:chokepoint-baselines', intervalMs: 400 * DAY, timeoutMs: 60_000 },
+  { label: 'Submarine-Cables', script: 'seed-submarine-cables.mjs', seedMetaKey: 'infrastructure:submarine-cables', canonicalKey: 'infrastructure:submarine-cables:v1', intervalMs: WEEK, timeoutMs: 300_000 },
+  { label: 'Chokepoint-Baselines', script: 'seed-chokepoint-baselines.mjs', seedMetaKey: 'energy:chokepoint-baselines', canonicalKey: 'energy:chokepoint-baselines:v1', intervalMs: 400 * DAY, timeoutMs: 60_000 },
   { label: 'Military-Bases', script: 'seed-military-bases.mjs', seedMetaKey: 'military:bases', intervalMs: 30 * DAY, timeoutMs: 600_000 },
 ]);

--- a/scripts/seed-chokepoint-baselines.mjs
+++ b/scripts/seed-chokepoint-baselines.mjs
@@ -31,12 +31,20 @@ export function validateFn(data) {
 }
 
 const isMain = process.argv[1]?.endsWith('seed-chokepoint-baselines.mjs');
+export function declareRecords(data) {
+  return Array.isArray(data?.chokepoints) ? data.chokepoints.length : 0;
+}
+
 if (isMain) {
   runSeed('energy', 'chokepoint-baselines', CANONICAL_KEY, buildPayload, {
     validateFn,
     ttlSeconds: CHOKEPOINT_TTL_SECONDS,
     sourceVersion: 'eia-chokepoint-baselines-v1',
     recordCount: (data) => data?.chokepoints?.length || 0,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 576000,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-chokepoint-flows.mjs
+++ b/scripts/seed-chokepoint-flows.mjs
@@ -145,12 +145,20 @@ export function validateFn(data) {
 }
 
 const isMain = process.argv[1]?.endsWith('seed-chokepoint-flows.mjs');
+export function declareRecords(data) {
+  return data && typeof data === "object" ? Object.keys(data).length : 0;
+}
+
 if (isMain) {
   runSeed('energy', 'chokepoint-flows', CANONICAL_KEY, fetchAll, {
     validateFn,
     ttlSeconds: TTL,
     sourceVersion: 'portwatch-eia-flows-v1',
     recordCount: (data) => Object.keys(data).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 720,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-chokepoint-flows.mjs
+++ b/scripts/seed-chokepoint-flows.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, runSeed, getRedisCredentials } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -52,7 +53,7 @@ async function redisGet(url, token, key) {
   });
   if (!resp.ok) return null;
   const data = await resp.json();
-  return data.result ? JSON.parse(data.result) : null;
+  return data.result ? unwrapEnvelope(JSON.parse(data.result)).data : null;
 }
 
 function avg(arr) {

--- a/scripts/seed-climate-anomalies.mjs
+++ b/scripts/seed-climate-anomalies.mjs
@@ -170,11 +170,19 @@ function validate(data) {
 }
 
 const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^file:\/\//, ''));
+export function declareRecords(data) {
+  return Array.isArray(data?.anomalies) ? data.anomalies.length : 0;
+}
+
 if (isMain) {
   runSeed('climate', 'anomalies', CANONICAL_KEY, fetchClimateAnomalies, {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
     sourceVersion: 'open-meteo-archive-wmo-1991-2020-v1',
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 240,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-climate-disasters.mjs
+++ b/scripts/seed-climate-disasters.mjs
@@ -485,12 +485,20 @@ function isMain() {
   return Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.disasters) ? data.disasters.length : 0;
+}
+
 if (isMain()) {
   runSeed('climate', 'disasters', CANONICAL_KEY, fetchClimateDisasters, {
     validateFn: (data) => Array.isArray(data?.disasters) && data.disasters.length > 0,
     recordCount: (data) => data?.disasters?.length || 0,
     ttlSeconds: CACHE_TTL,
     sourceVersion: 'reliefweb+natural-cache-v1',
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 720,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-climate-news.mjs
+++ b/scripts/seed-climate-news.mjs
@@ -192,11 +192,19 @@ function validate(data) {
   return Array.isArray(data?.items) && data.items.length >= 1;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.items) ? data.items.length : 0;
+}
+
 runSeed('climate', 'news-intelligence', CANONICAL_KEY, fetchClimateNews, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'climate-rss-v1',
   recordCount: (data) => data?.items?.length || 0,
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 90,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
   console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-climate-ocean-ice.mjs
+++ b/scripts/seed-climate-ocean-ice.mjs
@@ -492,12 +492,20 @@ function validate(data) {
 }
 
 const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^file:\/\//, ''));
+export function declareRecords(data) {
+  return typeof countIndicators === "function" ? countIndicators(data) : 0;
+}
+
 if (isMain) {
   runSeed('climate', 'ocean-ice', CLIMATE_OCEAN_ICE_KEY, fetchOceanIceData, {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
     recordCount: countIndicators,
     sourceVersion: 'nsidc-sea-ice_v4-climatology-noaa-ohc-nasa-gmsl-noaa-global-ocean-v6-v51-baseline-v3',
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 2880,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-climate-ocean-ice.mjs
+++ b/scripts/seed-climate-ocean-ice.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, runSeed, getRedisCredentials } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -443,7 +444,7 @@ async function readPriorCache() {
     });
     if (!resp.ok) return null;
     const data = await resp.json();
-    return data.result ? JSON.parse(data.result) : null;
+    return data.result ? unwrapEnvelope(JSON.parse(data.result)).data : null;
   } catch {
     return null;
   }

--- a/scripts/seed-climate-zone-normals.mjs
+++ b/scripts/seed-climate-zone-normals.mjs
@@ -138,12 +138,23 @@ function validate(data) {
     && data.normals.every((zone) => Array.isArray(zone?.months) && zone.months.length === 12);
 }
 
+// Contract opt-in: records = number of climate zones with 1991-2020 normals.
+// Custom shape `{referencePeriod, fetchedAt, normals[]}` — computeRecordCount
+// auto-detect historically missed this, causing the phantom EMPTY_DATA symptom
+// documented in the plan's discrepancy class 1.
+export function declareRecords(data) {
+  return Array.isArray(data?.normals) ? data.normals.length : 0;
+}
+
 const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^file:\/\//, ''));
 if (isMain) {
   runSeed('climate', 'zone-normals', CLIMATE_ZONE_NORMALS_KEY, fetchClimateZoneNormals, {
     validateFn: validate,
     ttlSeconds: NORMALS_TTL,
     sourceVersion: 'open-meteo-wmo-1991-2020-v1',
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 89280, // matches api/health.js SEED_META (monthly cron on 1st; 62d window)
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-co2-monitoring.mjs
+++ b/scripts/seed-co2-monitoring.mjs
@@ -192,12 +192,20 @@ function validate(data) {
 }
 
 const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^file:\/\//, ''));
+export function declareRecords(data) {
+  return Array.isArray(data?.monitoring?.trend12m) ? data.monitoring.trend12m.length : 0;
+}
+
 if (isMain) {
   runSeed('climate', 'co2-monitoring', CO2_MONITORING_KEY, fetchCo2Monitoring, {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
     recordCount: (data) => data?.monitoring?.trend12m?.length ?? 0,
     sourceVersion: 'noaa-gml-co2-ch4-n2o-v1',
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 4320,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-commodity-quotes.mjs
+++ b/scripts/seed-commodity-quotes.mjs
@@ -244,6 +244,10 @@ function validate(data) {
   return Array.isArray(data?.quotes) && data.quotes.length >= 1;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.quotes) ? data.quotes.length : 0;
+}
+
 // fetchCommodityQuotes returns the canonical {quotes} payload that runSeed
 // then writes to CANONICAL_KEY. The same value is passed to opts.afterPublish
 // as `data`, which is where the companion-key writes happen.
@@ -317,6 +321,9 @@ runSeed('market', 'commodities', CANONICAL_KEY, fetchCommodityQuotes, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'alphavantage+yahoo-chart',
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 30,
   afterPublish: async (data) => {
     // afterPublish is awaited inside runSeed BEFORE process.exit, so these
     // writes actually run. SPLIT semantics:

--- a/scripts/seed-conflict-intel.mjs
+++ b/scripts/seed-conflict-intel.mjs
@@ -276,10 +276,17 @@ function validate(data) {
   return data != null && Array.isArray(data.events);
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.events) ? data.events.length : 0;
+}
+
 runSeed('conflict', 'acled-intel', ACLED_CACHE_KEY, fetchAll, {
   validateFn: validate,
   ttlSeconds: ACLED_TTL,
   sourceVersion: 'acled-hapi-pizzint',
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 38,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-correlation.mjs
+++ b/scripts/seed-correlation.mjs
@@ -694,6 +694,10 @@ async function computeCorrelation() {
   return result;
 }
 
+export function declareRecords(data) {
+  return (data?.military?.length ?? 0) + (data?.escalation?.length ?? 0) + (data?.economic?.length ?? 0) + (data?.disaster?.length ?? 0);
+}
+
 if (process.argv[1]?.endsWith('seed-correlation.mjs')) {
   runSeed('correlation', 'cards', CANONICAL_KEY, computeCorrelation, {
     ttlSeconds: CACHE_TTL,
@@ -709,6 +713,10 @@ if (process.argv[1]?.endsWith('seed-correlation.mjs')) {
       ttl: ek.ttl,
       transform: (data) => data[ek.key.split(':')[1]],
     })),
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 15,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
     process.exit(1);

--- a/scripts/seed-cot.mjs
+++ b/scripts/seed-cot.mjs
@@ -184,10 +184,18 @@ async function fetchCotData() {
   return { instruments, reportDate: latestReportDate };
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.instruments) ? data.instruments.length : 0;
+}
+
 if (process.argv[1]?.endsWith('seed-cot.mjs')) {
   runSeed('market', 'cot', COT_KEY, fetchCotData, {
     ttlSeconds: COT_TTL,
     validateFn: data => Array.isArray(data?.instruments) && data.instruments.length > 0,
     recordCount: data => data?.instruments?.length ?? 0,
+    declareRecords,
+    sourceVersion: 'cftc-cot-v1',
+    schemaVersion: 1,
+    maxStaleMin: 14400,
   }).catch(err => { console.error('FATAL:', err.message || err); process.exit(1); });
 }

--- a/scripts/seed-cross-source-signals.mjs
+++ b/scripts/seed-cross-source-signals.mjs
@@ -867,6 +867,10 @@ function validate(data) {
   return Array.isArray(data?.signals);
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.signals) ? data.signals.length : 0;
+}
+
 runSeed('intelligence', 'cross-source-signals', CANONICAL_KEY, aggregateCrossSourceSignals, {
   ttlSeconds: CACHE_TTL,
   validateFn: validate,
@@ -883,4 +887,8 @@ runSeed('intelligence', 'cross-source-signals', CANONICAL_KEY, aggregateCrossSou
       signal: AbortSignal.timeout(5_000),
     }).catch(err => console.warn(`  seed-meta write failed: ${err.message}`));
   },
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 30,
 });

--- a/scripts/seed-crypto-quotes.mjs
+++ b/scripts/seed-crypto-quotes.mjs
@@ -139,10 +139,17 @@ function validate(data) {
   return true;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.quotes) ? data.quotes.length : 0;
+}
+
 runSeed('market', 'crypto', CANONICAL_KEY, fetchCryptoQuotes, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'coinpaprika-tickers+coingecko-fallback',
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 30,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-crypto-sectors.mjs
+++ b/scripts/seed-crypto-sectors.mjs
@@ -56,10 +56,18 @@ function validate(data) {
   return Array.isArray(data?.sectors) && data.sectors.length > 0;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.sectors) ? data.sectors.length : 0;
+}
+
 runSeed('market', 'crypto-sectors', CANONICAL_KEY, fetchSectorData, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'coingecko-sectors',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 120,
 }).catch(err => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
   console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-cyber-threats.mjs
+++ b/scripts/seed-cyber-threats.mjs
@@ -576,11 +576,19 @@ function validate(data) {
   return Array.isArray(data?.threats) && data.threats.length >= 1;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.threats) ? data.threats.length : 0;
+}
+
 runSeed('cyber', 'threats', CANONICAL_KEY, fetchAllThreats, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'multi-ioc-v2',
-  extraKeys: [{ key: BOOTSTRAP_KEY }],
+  extraKeys: [{ key: BOOTSTRAP_KEY, declareRecords }],
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 240,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-defense-patents.mjs
+++ b/scripts/seed-defense-patents.mjs
@@ -97,11 +97,18 @@ function validate(data) {
   return Array.isArray(data?.patents) && data.patents.length > 0;
 }
 
+export function declareRecords(data) {
+  return data?.patents?.length ?? 0;
+}
+
 runSeed('military', 'defense-patents', CANONICAL_KEY, fetchAllPatents, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'patentsview-v1',
   recordCount: (d) => d?.patents?.length ?? 0,
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 25200,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
   console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-disease-outbreaks.mjs
+++ b/scripts/seed-disease-outbreaks.mjs
@@ -294,10 +294,18 @@ function validate(data) {
   return Array.isArray(data?.outbreaks) && data.outbreaks.length >= 1;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.outbreaks) ? data.outbreaks.length : 0;
+}
+
 runSeed('health', 'disease-outbreaks', CANONICAL_KEY, fetchDiseaseOutbreaks, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'who-api-cdc-ont-v6',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 2880,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
   console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-displacement-summary.mjs
+++ b/scripts/seed-displacement-summary.mjs
@@ -225,10 +225,17 @@ function validate(data) {
 const currentYear = new Date().getFullYear();
 const canonicalKey = `${CANONICAL_KEY_PREFIX}:${currentYear}`;
 
+export function declareRecords(data) {
+  return data?.summary?.countries?.length ?? 0;
+}
+
 runSeed('displacement', 'summary', canonicalKey, fetchDisplacementSummary, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: `unhcr-${currentYear}`,
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 3600,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-earnings-calendar.mjs
+++ b/scripts/seed-earnings-calendar.mjs
@@ -89,10 +89,18 @@ function validate(data) {
   return Array.isArray(data?.earnings) && data.earnings.length >= 3;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.earnings) ? data.earnings.length : 0;
+}
+
 if (process.argv[1]?.endsWith('seed-earnings-calendar.mjs')) {
   runSeed('market', 'earnings-calendar', KEY, fetchAll, {
     validateFn: validate,
     ttlSeconds: TTL,
     sourceVersion: 'finnhub-v1',
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 1440,
   }).catch(err => { console.error('FATAL:', err.message || err); process.exit(1); });
 }

--- a/scripts/seed-earthquakes.mjs
+++ b/scripts/seed-earthquakes.mjs
@@ -86,10 +86,17 @@ function validate(data) {
   return Array.isArray(data?.earthquakes) && data.earthquakes.length >= 1;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.earthquakes) ? data.earthquakes.length : 0;
+}
+
 runSeed('seismology', 'earthquakes', CANONICAL_KEY, fetchEarthquakes, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'usgs-4.5-day-nuclear-v1',
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 30,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-ecb-fx-rates.mjs
+++ b/scripts/seed-ecb-fx-rates.mjs
@@ -123,12 +123,20 @@ function validate(data) {
   });
 }
 
+export function declareRecords(data) {
+  return Object.keys(data?.rates || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-ecb-fx-rates.mjs')) {
   runSeed('economic', 'ecb-fx-rates', CANONICAL_KEY, fetchEcbFxRates, {
     validateFn: validate,
     ttlSeconds: TTL,
     sourceVersion: 'ecb-data-portal',
     recordCount: (data) => Object.keys(data?.rates ?? {}).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 5760,
   }).catch(err => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-economic-calendar.mjs
+++ b/scripts/seed-economic-calendar.mjs
@@ -306,11 +306,19 @@ function validate(data) {
   return Array.isArray(data?.events) && data.events.length > 0;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.events) ? data.events.length : 0;
+}
+
 if (process.argv[1]?.endsWith('seed-economic-calendar.mjs')) {
   runSeed('economic', 'econ-calendar', CANONICAL_KEY, fetchEconomicCalendar, {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
     sourceVersion: 'fred-v1',
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 1440,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-economy.mjs
+++ b/scripts/seed-economy.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, runSeed, writeExtraKeyWithMeta, sleep, resolveProxy, resolveProxyForConnect, fredFetchJson, curlFetch, getRedisCredentials } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -120,7 +121,7 @@ async function fetchGscpiFromRedis() {
     if (!resp.ok) return null;
     const body = /** @type {{ result: string | null }} */ (await resp.json());
     if (!body.result) return null;
-    return extractGscpiObservations(JSON.parse(body.result));
+    return extractGscpiObservations(unwrapEnvelope(JSON.parse(body.result)).data);
   } catch {
     return null;
   }

--- a/scripts/seed-economy.mjs
+++ b/scripts/seed-economy.mjs
@@ -887,11 +887,18 @@ function validate(data) {
   return data?.prices?.length > 0;
 }
 
+export function declareRecords(data) {
+  return data?.prices?.length ?? 0;
+}
+
 if (process.argv[1]?.endsWith('seed-economy.mjs')) {
   runSeed('economic', 'energy-prices', KEYS.energyPrices, fetchAll, {
     validateFn: validate,
     ttlSeconds: ENERGY_TTL,
     sourceVersion: 'eia-fred-macro',
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 150,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
     process.exit(1);

--- a/scripts/seed-ember-electricity.mjs
+++ b/scripts/seed-ember-electricity.mjs
@@ -11,6 +11,7 @@ import {
   withRetry,
 } from './_seed-utils.mjs';
 import { resolveIso2 } from './_country-resolver.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -221,7 +222,7 @@ async function redisGet(key) {
   });
   if (!resp.ok) return null;
   const data = await resp.json();
-  return data.result ? JSON.parse(data.result) : null;
+  return data.result ? unwrapEnvelope(JSON.parse(data.result)).data : null;
 }
 
 async function preservePreviousSnapshot(errorMsg, stashedAllMap = null, newCountryKeys = null, dataWritten = false) {

--- a/scripts/seed-energy-crisis-policies.mjs
+++ b/scripts/seed-energy-crisis-policies.mjs
@@ -59,12 +59,20 @@ export function validateFn(data) {
 }
 
 const isMain = process.argv[1]?.endsWith('seed-energy-crisis-policies.mjs');
+export function declareRecords(data) {
+  return Array.isArray(data?.policies) ? data.policies.length : 0;
+}
+
 if (isMain) {
   runSeed('energy', 'crisis-policies', CANONICAL_KEY, buildPayload, {
     validateFn,
     ttlSeconds: CRISIS_POLICIES_TTL_SECONDS,
     sourceVersion: 'iea-crisis-policies-v1',
     recordCount: (data) => data?.policies?.length ?? 0,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 576000,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-energy-intelligence.mjs
+++ b/scripts/seed-energy-intelligence.mjs
@@ -202,12 +202,20 @@ export function validate(data) {
 
 export { CANONICAL_KEY as ENERGY_INTELLIGENCE_KEY };
 
+export function declareRecords(data) {
+  return Array.isArray(data?.items) ? data.items.length : 0;
+}
+
 if (process.argv[1]?.endsWith('seed-energy-intelligence.mjs')) {
   runSeed('energy', 'intelligence', CANONICAL_KEY, fetchEnergyIntelligence, {
     validateFn: validate,
     ttlSeconds: INTELLIGENCE_TTL_SECONDS,
     sourceVersion: 'energy-intel-rss-v1',
     recordCount: (data) => data?.items?.length || 0,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 720,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-energy-spine.mjs
+++ b/scripts/seed-energy-spine.mjs
@@ -8,6 +8,7 @@ import {
   logSeedResult,
   releaseLock,
 } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -65,7 +66,7 @@ async function redisGet(key) {
   });
   if (!resp.ok) return null;
   const data = await resp.json();
-  return data.result ? JSON.parse(data.result) : null;
+  return data.result ? unwrapEnvelope(JSON.parse(data.result)).data : null;
 }
 
 async function redisMget(keys) {
@@ -89,7 +90,7 @@ async function redisMget(keys) {
   return results.map(r => {
     const raw = r?.result;
     if (!raw) return null;
-    try { return JSON.parse(raw); } catch { return null; }
+    try { return unwrapEnvelope(JSON.parse(raw)).data; } catch { return null; }
   });
 }
 

--- a/scripts/seed-etf-flows.mjs
+++ b/scripts/seed-etf-flows.mjs
@@ -161,10 +161,18 @@ function validate(data) {
   return Array.isArray(data?.etfs) && data.etfs.length >= 1;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.etfs) ? data.etfs.length : 0;
+}
+
 runSeed('market', 'etf-flows', CANONICAL_KEY, fetchEtfFlows, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'alphavantage+yahoo-chart-5d',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 60,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-eurostat-country-data.mjs
+++ b/scripts/seed-eurostat-country-data.mjs
@@ -256,12 +256,20 @@ function validate(data) {
   return true;
 }
 
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-eurostat-country-data.mjs')) {
   runSeed('economic', 'eurostat-country-data', CANONICAL_KEY, fetchAll, {
     validateFn: validate,
     ttlSeconds: TTL,
     sourceVersion: 'eurostat-v1',
     recordCount: (data) => Object.keys(data?.countries || {}).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 4320,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-eurostat-gov-debt-q.mjs
+++ b/scripts/seed-eurostat-gov-debt-q.mjs
@@ -35,6 +35,10 @@ async function fetchAll() {
   return fetchEurostatAllGeos(DATASET);
 }
 
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-eurostat-gov-debt-q.mjs')) {
   runSeed('economic', 'eurostat-gov-debt-q', CANONICAL_KEY, fetchAll, {
     // Near-complete coverage: quarterly Maastricht gross-debt is reported by
@@ -44,6 +48,10 @@ if (process.argv[1]?.endsWith('seed-eurostat-gov-debt-q.mjs')) {
     ttlSeconds: TTL,
     sourceVersion: 'eurostat-gov-10q-ggdebt-v1',
     recordCount: (data) => Object.keys(data?.countries || {}).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 20160,
   }).catch((err) => {
     const cause = err.cause
       ? ` (cause: ${err.cause.message || err.cause.code || err.cause})`

--- a/scripts/seed-eurostat-house-prices.mjs
+++ b/scripts/seed-eurostat-house-prices.mjs
@@ -31,6 +31,10 @@ async function fetchAll() {
   return fetchEurostatAllGeos(DATASET);
 }
 
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-eurostat-house-prices.mjs')) {
   runSeed('economic', 'eurostat-house-prices', CANONICAL_KEY, fetchAll, {
     // Near-complete coverage: annual house-price index is well-reported across
@@ -40,6 +44,10 @@ if (process.argv[1]?.endsWith('seed-eurostat-house-prices.mjs')) {
     ttlSeconds: TTL,
     sourceVersion: 'eurostat-prc-hpi-a-v1',
     recordCount: (data) => Object.keys(data?.countries || {}).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 72000,
   }).catch((err) => {
     const cause = err.cause
       ? ` (cause: ${err.cause.message || err.cause.code || err.cause})`

--- a/scripts/seed-eurostat-industrial-production.mjs
+++ b/scripts/seed-eurostat-industrial-production.mjs
@@ -36,6 +36,10 @@ async function fetchAll() {
   return fetchEurostatAllGeos(DATASET);
 }
 
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-eurostat-industrial-production.mjs')) {
   runSeed(
     'economic',
@@ -50,6 +54,10 @@ if (process.argv[1]?.endsWith('seed-eurostat-industrial-production.mjs')) {
       ttlSeconds: TTL,
       sourceVersion: 'eurostat-sts-inpr-m-v1',
       recordCount: (data) => Object.keys(data?.countries || {}).length,
+    
+      declareRecords,
+      schemaVersion: 1,
+      maxStaleMin: 7200,
     },
   ).catch((err) => {
     const cause = err.cause

--- a/scripts/seed-fao-food-price-index.mjs
+++ b/scripts/seed-fao-food-price-index.mjs
@@ -91,10 +91,19 @@ async function fetchFaoFfpi() {
 }
 
 const isMain = process.argv[1]?.endsWith('seed-fao-food-price-index.mjs');
+export function declareRecords(data) {
+  return Array.isArray(data?.points) ? data.points.length : 0;
+}
+
 if (isMain) {
   await runSeed('economic', 'fao-ffpi', CANONICAL_KEY, fetchFaoFfpi, {
     ttlSeconds: CACHE_TTL,
     validateFn: (data) => data?.points?.length > 0,
     recordCount: (data) => data?.points?.length || 0,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 86400,
+    sourceVersion: 'fao-ffpi-v1',
   });
 }

--- a/scripts/seed-fear-greed.mjs
+++ b/scripts/seed-fear-greed.mjs
@@ -478,10 +478,18 @@ function validate(data) {
   return data?.composite?.score != null && data.timestamp != null;
 }
 
+export function declareRecords(data) {
+  return data?.composite?.score != null ? 1 : 0;
+}
+
 runSeed('market', 'fear-greed', FEAR_GREED_KEY, fetchAll, {
   validateFn: validate,
   ttlSeconds: FEAR_GREED_TTL,
   sourceVersion: 'yahoo-cboe-cnn-fred-v1',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 720,
 }).catch((err) => {
   console.error('FATAL:', err.message || err);
   process.exit(1);

--- a/scripts/seed-fear-greed.mjs
+++ b/scripts/seed-fear-greed.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, runSeed, readSeedSnapshot, sleep, resolveProxyForConnect } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 loadEnvFile(import.meta.url);
 
 const _proxyAuth = resolveProxyForConnect();
@@ -138,7 +139,7 @@ async function readFred(seriesId) {
     if (!resp.ok) return null;
     const { result } = await resp.json();
     if (!result) return null;
-    const parsed = JSON.parse(result);
+    const parsed = unwrapEnvelope(JSON.parse(result)).data;
     const obs = parsed?.series?.observations;
     if (!obs?.length) return null;
     return obs;
@@ -156,7 +157,7 @@ async function readMacroSignals() {
     });
     if (!resp.ok) return null;
     const { result } = await resp.json();
-    return result ? JSON.parse(result) : null;
+    return result ? unwrapEnvelope(JSON.parse(result)).data : null;
   } catch { return null; }
 }
 

--- a/scripts/seed-fire-detections.mjs
+++ b/scripts/seed-fire-detections.mjs
@@ -116,6 +116,10 @@ async function fetchAllRegions(apiKey) {
   return { fireDetections, pagination: undefined };
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.fireDetections) ? data.fireDetections.length : 0;
+}
+
 async function main() {
   const apiKey = process.env.NASA_FIRMS_API_KEY || process.env.FIRMS_API_KEY || '';
   if (!apiKey) {
@@ -130,6 +134,9 @@ async function main() {
     ttlSeconds: 7200,
     lockTtlMs: 2_400_000, // 40 min — 27 slots × ~72s worst case (30s timeout + 6s backoff + 30s retry + 6s pace) ≈ 32.4 min; pad headroom. Next cron tick sees lock held and safely skips.
     sourceVersion: FIRMS_SOURCES.join('+'),
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 360,
   });
 }
 

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -16014,6 +16014,10 @@ async function buildAndSeedMarketImplications(inputs) {
   console.log(`  [MarketImplications] Published ${cards.length} cards to ${MARKET_IMPLICATIONS_KEY} (${Math.round(durationMs)}ms, model=${result.model || 'unknown'})`);
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.predictions) ? data.predictions.length : 0;
+}
+
 if (_isDirectRun) {
   const refreshRequest = await readForecastRefreshRequest();
   const triggerContext = buildForecastTriggerContext(refreshRequest);
@@ -16029,6 +16033,9 @@ if (_isDirectRun) {
     ttlSeconds: TTL_SECONDS,
     lockTtlMs: 180_000,
     validateFn: (data) => Array.isArray(data?.predictions) && data.predictions.length > 0,
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 90,
     publishTransform: buildPublishedSeedPayload,
     afterPublish: async (data, meta) => {
       if (triggerContext.triggerRequest) {
@@ -16130,6 +16137,7 @@ if (_isDirectRun) {
           predictions: data.predictions.map(buildPriorForecastSnapshot),
         }),
         ttl: 7200,
+        declareRecords,
       },
     ],
   });

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -5,6 +5,7 @@
 import crypto from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { loadEnvFile, runSeed, CHROME_UA, withRetry } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { tagRegions } from './_prediction-scoring.mjs';
 import { resolveR2StorageConfig, putR2JsonObject, getR2JsonObject } from './_r2-storage.mjs';
 import { extractFirstJsonObject, extractFirstJsonArray, cleanJsonText } from './_llm-json.mjs';
@@ -616,7 +617,7 @@ async function redisGet(url, token, key) {
   if (!resp.ok) return null;
   const data = await resp.json();
   if (!data?.result) return null;
-  try { return JSON.parse(data.result); } catch { return null; }
+  try { return unwrapEnvelope(JSON.parse(data.result)).data; } catch { return null; }
 }
 
 async function redisDel(url, token, key) {
@@ -731,7 +732,13 @@ async function readInputKeys() {
   }
 
   const parse = (i) => {
-    try { return results[i]?.result ? JSON.parse(results[i].result) : null; } catch { return null; }
+    try {
+      const raw = results[i]?.result;
+      if (!raw) return null;
+      // Envelope-aware: pipeline batch reads must strip _seed for contract-mode
+      // writers. unwrapEnvelope is a no-op on legacy bare-shape values.
+      return unwrapEnvelope(JSON.parse(raw)).data;
+    } catch { return null; }
   };
   const parsedByKey = Object.fromEntries(keys.map((key, index) => [key, parse(index)]));
   const fredSeries = Object.fromEntries(

--- a/scripts/seed-fsi-eu.mjs
+++ b/scripts/seed-fsi-eu.mjs
@@ -78,6 +78,13 @@ async function fetchEcbCiss() {
   };
 }
 
+// Contract opt-in: canonical record count for envelope + health.
+// FSI-EU payload is `{latestValue, latestDate, label, history[], ...}`.
+// Records = weekly CISS observations in the history array.
+export function declareRecords(data) {
+  return Array.isArray(data?.history) ? data.history.length : 0;
+}
+
 function validate(data) {
   return (
     data?.latestValue != null &&
@@ -97,6 +104,9 @@ if (isMain) {
     validateFn: validate,
     ttlSeconds: FSI_EU_TTL,
     sourceVersion: 'ecb-ciss-sdmx-v1',
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 20160, // 14 days — matches api/health.js SEED_META threshold
   }).catch((err) => {
     console.error('FATAL:', err.message || err);
     process.exit(1);

--- a/scripts/seed-fuel-prices.mjs
+++ b/scripts/seed-fuel-prices.mjs
@@ -832,15 +832,22 @@ const data = {
 const rotatePrev = !publishBlocking;
 if (!rotatePrev) console.warn(`  [:prev] Skipping rotation — WoW integrity preserved for next run`);
 
+const declareRecords = (d) => d?.countries?.length || 0;
+
 await runSeed('economic', 'fuel-prices', CANONICAL_KEY, async () => data, {
   ttlSeconds: CACHE_TTL,
   validateFn: validateFuel,
   emptyDataIsFailure: true,
   recordCount: (d) => d?.countries?.length || 0,
+  declareRecords,
+  sourceVersion: 'multi-source-fuel-prices-v1',
+  schemaVersion: 1,
+  maxStaleMin: 10080,
   extraKeys: (wowAvailable && rotatePrev) ? [{
     key: `${CANONICAL_KEY}:prev`,
     transform: () => data,
     ttl: CACHE_TTL * 2,
+    declareRecords,
   }] : [],
 });
 }

--- a/scripts/seed-fx-rates.mjs
+++ b/scripts/seed-fx-rates.mjs
@@ -40,6 +40,10 @@ const FX_SYMBOLS = Object.fromEntries(
 
 const FX_FALLBACKS = SHARED_FX_FALLBACKS;
 
+export function declareRecords(data) {
+  return data && typeof data === 'object' ? Object.keys(data).length : 0;
+}
+
 await runSeed('shared', 'fx-rates', CANONICAL_KEY, async () => {
   // Always fetch live — this seed IS the cache writer, bypass getSharedFxRates
   const rates = await fetchYahooFxRates(FX_SYMBOLS, FX_FALLBACKS);
@@ -50,4 +54,7 @@ await runSeed('shared', 'fx-rates', CANONICAL_KEY, async () => {
   validateFn: (data) => data && typeof data === 'object' && Object.keys(data).length > 10,
   recordCount: (data) => Object.keys(data).length,
   sourceVersion: 'yahoo-fx-shared',
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 3600,
 });

--- a/scripts/seed-fx-yoy.mjs
+++ b/scripts/seed-fx-yoy.mjs
@@ -166,12 +166,20 @@ async function fetchFxYoy() {
 }
 
 const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+export function declareRecords(data) {
+  return Array.isArray(data?.rates) ? data.rates.length : 0;
+}
+
 if (isMain) {
   await runSeed('economic', 'fx-yoy', CANONICAL_KEY, fetchFxYoy, {
     ttlSeconds: CACHE_TTL,
     validateFn: (data) => Array.isArray(data?.rates) && data.rates.length >= 10,
     recordCount: (data) => data?.rates?.length ?? 0,
     sourceVersion: 'yahoo-fx-yoy-v1',
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 1500,
   });
 }
 

--- a/scripts/seed-gas-storage-countries.mjs
+++ b/scripts/seed-gas-storage-countries.mjs
@@ -10,6 +10,7 @@ import {
   releaseLock,
   withRetry,
 } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -68,7 +69,7 @@ async function redisGet(key) {
   });
   if (!resp.ok) return null;
   const data = await resp.json();
-  return data.result ? JSON.parse(data.result) : null;
+  return data.result ? unwrapEnvelope(JSON.parse(data.result)).data : null;
 }
 
 /** Parse a single GIE entry into fill/gwh/date/change */

--- a/scripts/seed-gdelt-intel.mjs
+++ b/scripts/seed-gdelt-intel.mjs
@@ -212,6 +212,10 @@ async function afterPublish(data, _meta) {
   }
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.topics) ? data.topics.length : 0;
+}
+
 if (process.argv[1]?.endsWith('seed-gdelt-intel.mjs')) {
   runSeed('intelligence', 'gdelt-intel', CANONICAL_KEY, fetchAllTopics, {
     validateFn: validate,
@@ -219,6 +223,10 @@ if (process.argv[1]?.endsWith('seed-gdelt-intel.mjs')) {
     sourceVersion: 'gdelt-doc-v2',
     publishTransform,
     afterPublish,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 420,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-gie-gas-storage.mjs
+++ b/scripts/seed-gie-gas-storage.mjs
@@ -122,11 +122,19 @@ function validate(data) {
 
 const isMain = process.argv[1]?.endsWith('seed-gie-gas-storage.mjs');
 
+export function declareRecords(data) {
+  return Number.isFinite(data?.fillPct) ? 1 : 0;
+}
+
 if (isMain) {
   runSeed('economic', 'eu-gas-storage', CANONICAL_KEY, fetchEuGasStorage, {
     validateFn: validate,
     ttlSeconds: TTL,
     sourceVersion: 'gie-agsi-plus',
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 2880,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-gold-cb-reserves.mjs
+++ b/scripts/seed-gold-cb-reserves.mjs
@@ -266,10 +266,19 @@ async function fetchCbReserves() {
   return payload;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.topHolders) ? data.topHolders.length : 0;
+}
+
 if (process.argv[1]?.endsWith('seed-gold-cb-reserves.mjs')) {
   runSeed('market', 'gold-cb-reserves', CB_KEY, fetchCbReserves, {
     ttlSeconds: CB_TTL,
     validateFn: data => Array.isArray(data?.topHolders) && data.topHolders.length >= 10,
     recordCount: data => data?.topHolders?.length ?? 0,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 44640,
+    sourceVersion: 'imf-ifs-v1',
   }).catch(err => { console.error('FATAL:', err.message || err); process.exit(1); });
 }

--- a/scripts/seed-gold-etf-flows.mjs
+++ b/scripts/seed-gold-etf-flows.mjs
@@ -138,10 +138,19 @@ async function fetchGldFlows() {
   return { updatedAt: new Date().toISOString(), ...flows };
 }
 
+export function declareRecords(data) {
+  return Number.isFinite(data?.tonnes) && data.tonnes > 0 ? 1 : 0;
+}
+
 if (process.argv[1]?.endsWith('seed-gold-etf-flows.mjs')) {
   runSeed('market', 'gold-etf-flows', GLD_KEY, fetchGldFlows, {
     ttlSeconds: GLD_TTL,
     validateFn: data => Number.isFinite(data?.tonnes) && data.tonnes > 0,
     recordCount: () => 1,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 2880,
+    sourceVersion: 'spdr-gld-xlsx-v1',
   }).catch(err => { console.error('FATAL:', err.message || err); process.exit(1); });
 }

--- a/scripts/seed-grocery-basket.mjs
+++ b/scripts/seed-grocery-basket.mjs
@@ -455,6 +455,10 @@ async function fetchGroceryBasketPrices(prevSnapshot) {
 
 const prevSnapshot = await readSeedSnapshot(CANONICAL_KEY);
 
+export function declareRecords(data) {
+  return Array.isArray(data?.countries) ? data.countries.length : 0;
+}
+
 await runSeed('economic', 'grocery-basket', CANONICAL_KEY, () => fetchGroceryBasketPrices(prevSnapshot), {
   ttlSeconds: CACHE_TTL,
   validateFn: (data) => {
@@ -469,5 +473,11 @@ await runSeed('economic', 'grocery-basket', CANONICAL_KEY, () => fetchGroceryBas
     key: `${CANONICAL_KEY}:prev`,
     transform: () => prevSnapshot,  // write PRE-overwrite snapshot; ignore new data
     ttl: CACHE_TTL * 2,
+    declareRecords,
   }] : undefined,
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 10080,
+  sourceVersion: 'grocery-basket-v1',
 });

--- a/scripts/seed-gulf-quotes.mjs
+++ b/scripts/seed-gulf-quotes.mjs
@@ -126,10 +126,18 @@ function validate(data) {
   return Array.isArray(data?.quotes) && data.quotes.length >= 1;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.quotes) ? data.quotes.length : 0;
+}
+
 runSeed('market', 'gulf-quotes', CANONICAL_KEY, fetchGulfQuotes, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'alphavantage+yahoo-chart',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 30,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-hormuz.mjs
+++ b/scripts/seed-hormuz.mjs
@@ -294,7 +294,16 @@ async function buildPayload() {
   };
 }
 
+export function declareRecords(data) {
+  return (data?.charts || []).reduce((s, c) => s + (c.series?.length || 0), 0);
+}
+
 await runSeed('supply_chain', 'hormuz_tracker', CANONICAL_KEY, buildPayload, {
   ttlSeconds: CACHE_TTL,
   validateFn: (d) => !!(d?.updatedDate || d?.summary || d?.title) && d?.charts?.some(c => (c.series?.length ?? 0) > 0),
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 2880,
+  sourceVersion: 'hormuz-tracker-v1',
 });

--- a/scripts/seed-hyperliquid-flow.mjs
+++ b/scripts/seed-hyperliquid-flow.mjs
@@ -362,6 +362,10 @@ export function validateFn(snapshot) {
   return !!snapshot && Array.isArray(snapshot.assets) && snapshot.assets.length >= 12;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.assets) ? data.assets.length : 0;
+}
+
 // ── Entry point ──────────────────────────────────────────────────────────────
 
 const isMain = process.argv[1]?.endsWith('seed-hyperliquid-flow.mjs');
@@ -377,6 +381,9 @@ if (isMain) {
     validateFn,
     sourceVersion: 'hyperliquid-info-metaAndAssetCtxs-v1',
     recordCount: (snap) => snap?.assets?.length || 0,
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 15,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-iea-oil-stocks.mjs
+++ b/scripts/seed-iea-oil-stocks.mjs
@@ -249,6 +249,10 @@ const ANALYSIS_META_EXTRA_KEY = {
 };
 
 const isMain = process.argv[1]?.endsWith('seed-iea-oil-stocks.mjs');
+export function declareRecords(data) {
+  return Array.isArray(data?.members) ? data.members.length : 0;
+}
+
 if (isMain) {
   runSeed('energy', 'iea-oil-stocks', CANONICAL_KEY, fetchIeaOilStocks, {
     validateFn: (data) => Array.isArray(data?.members) && data.members.length > 0,
@@ -257,6 +261,10 @@ if (isMain) {
     recordCount: (data) => data?.members?.length || 0,
     publishTransform: (data) => buildIndex(data.members, data.dataMonth, data.seededAt),
     extraKeys: [...COUNTRY_EXTRA_KEYS, ANALYSIS_EXTRA_KEY, ANALYSIS_META_EXTRA_KEY],
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 57600,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-imf-external.mjs
+++ b/scripts/seed-imf-external.mjs
@@ -109,6 +109,10 @@ export function validate(data) {
 
 export { CANONICAL_KEY, CACHE_TTL };
 
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-imf-external.mjs')) {
   runSeed('economic', 'imf-external', CANONICAL_KEY, fetchImfExternal, {
     validateFn: validate,
@@ -119,6 +123,10 @@ if (process.argv[1]?.endsWith('seed-imf-external.mjs')) {
     // Without this, a single transient fetch glitch refreshes seed-meta and
     // locks the bundle out for 30 days (see log 2026-04-13).
     emptyDataIsFailure: true,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 100800,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-imf-growth.mjs
+++ b/scripts/seed-imf-growth.mjs
@@ -145,6 +145,10 @@ export function validate(data) {
 
 export { CANONICAL_KEY, CACHE_TTL };
 
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-imf-growth.mjs')) {
   runSeed('economic', 'imf-growth', CANONICAL_KEY, fetchImfGrowth, {
     validateFn: validate,
@@ -152,6 +156,10 @@ if (process.argv[1]?.endsWith('seed-imf-growth.mjs')) {
     sourceVersion: `imf-sdmx-weo-${new Date().getFullYear()}`,
     recordCount: (data) => Object.keys(data?.countries ?? {}).length,
     emptyDataIsFailure: true,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 100800,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-imf-labor.mjs
+++ b/scripts/seed-imf-labor.mjs
@@ -87,6 +87,10 @@ export function validate(data) {
 
 export { CANONICAL_KEY, CACHE_TTL };
 
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-imf-labor.mjs')) {
   runSeed('economic', 'imf-labor', CANONICAL_KEY, fetchImfLabor, {
     validateFn: validate,
@@ -94,6 +98,10 @@ if (process.argv[1]?.endsWith('seed-imf-labor.mjs')) {
     sourceVersion: `imf-sdmx-weo-${new Date().getFullYear()}`,
     recordCount: (data) => Object.keys(data?.countries ?? {}).length,
     emptyDataIsFailure: true,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 100800,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-imf-macro.mjs
+++ b/scripts/seed-imf-macro.mjs
@@ -102,6 +102,10 @@ function validate(data) {
 export { fetchImfMacro, latestValue, isAggregate, CANONICAL_KEY, CACHE_TTL };
 
 // Guard: only run when executed directly, not when imported by tests
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-imf-macro.mjs')) {
   runSeed('economic', 'imf-macro', CANONICAL_KEY, fetchImfMacro, {
     validateFn: validate,
@@ -109,6 +113,10 @@ if (process.argv[1]?.endsWith('seed-imf-macro.mjs')) {
     sourceVersion: `imf-sdmx-weo-${new Date().getFullYear()}`,
     recordCount: (data) => Object.keys(data?.countries ?? {}).length,
     emptyDataIsFailure: true,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 100800,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -349,10 +349,18 @@ function validate(data) {
   return Array.isArray(data?.topStories) && data.topStories.length >= 1;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.topStories) ? data.topStories.length : 0;
+}
+
 runSeed('news', 'insights', CANONICAL_KEY, fetchInsights, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'digest-clustering-v1',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 30,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   // Exit gracefully for cron — health endpoint flags stale data via seed-meta.

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -3,6 +3,7 @@
 import { loadEnvFile, CHROME_UA, getRedisCredentials, runSeed } from './_seed-utils.mjs';
 import { clusterItems, selectTopStories } from './_clustering.mjs';
 import { extractCountryCode } from './shared/geo-extract.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -60,7 +61,7 @@ async function readDigestFromRedis() {
   });
   if (!resp.ok) return null;
   const data = await resp.json();
-  return data.result ? JSON.parse(data.result) : null;
+  return data.result ? unwrapEnvelope(JSON.parse(data.result)).data : null;
 }
 
 async function readExistingInsights() {
@@ -71,7 +72,7 @@ async function readExistingInsights() {
   });
   if (!resp.ok) return null;
   const data = await resp.json();
-  return data.result ? JSON.parse(data.result) : null;
+  return data.result ? unwrapEnvelope(JSON.parse(data.result)).data : null;
 }
 
 // Provider config — mirrors server/_shared/llm.ts getProviderCredentials()

--- a/scripts/seed-internet-outages.mjs
+++ b/scripts/seed-internet-outages.mjs
@@ -243,10 +243,18 @@ function validate(data) {
   return data && Array.isArray(data.outages);
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.outages) ? data.outages.length : 0;
+}
+
 runSeed('infra', 'outages', CANONICAL_KEY, fetchAll, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'cloudflare-radar-7d',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 30,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-iran-events.mjs
+++ b/scripts/seed-iran-events.mjs
@@ -240,10 +240,18 @@ function validate(data) {
   return Array.isArray(data?.events) && data.events.length >= 1;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.events) ? data.events.length : 0;
+}
+
 runSeed('conflict', 'iran-events', CANONICAL_KEY, fetchIranEvents, {
   validateFn: validate,
   ttlSeconds: 172800,
   sourceVersion: 'liveuamap-manual-v1',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 20160,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(0);

--- a/scripts/seed-jodi-gas.mjs
+++ b/scripts/seed-jodi-gas.mjs
@@ -244,6 +244,10 @@ export function buildLngVulnerabilityIndex(members, dataMonth, updatedAt) {
 
 const isMain = process.argv[1]?.endsWith('seed-jodi-gas.mjs');
 
+export function declareRecords(data) {
+  return Array.isArray(data) ? data.length : 0;
+}
+
 if (isMain) {
   await runSeed('energy', 'jodi-gas', CANONICAL_KEY, fetchJodiGas, {
     ttlSeconds: GAS_TTL,
@@ -269,5 +273,10 @@ if (isMain) {
       }
       // LNG vulnerability index is now written via extraKeys (gets TTL-preserved on failure)
     },
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 57600,
+    sourceVersion: 'jodi-gas-v1',
   });
 }

--- a/scripts/seed-market-breadth.mjs
+++ b/scripts/seed-market-breadth.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, runSeed, sleep } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 loadEnvFile(import.meta.url);
 
 const BREADTH_KEY = 'market:breadth-history:v1';
@@ -49,7 +50,7 @@ async function readExistingHistory() {
     });
     if (!resp.ok) return null;
     const { result } = await resp.json();
-    return result ? JSON.parse(result) : null;
+    return result ? unwrapEnvelope(JSON.parse(result)).data : null;
   } catch {
     return null;
   }

--- a/scripts/seed-market-breadth.mjs
+++ b/scripts/seed-market-breadth.mjs
@@ -118,9 +118,18 @@ function validate(data) {
   );
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.history) ? data.history.length : 0;
+}
+
 runSeed('market', 'breadth-history', BREADTH_KEY, fetchAll, {
   validateFn: validate,
   ttlSeconds: BREADTH_TTL,
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 2880,
+  sourceVersion: 'market-breadth-v1',
 }).catch((err) => {
   console.error('FATAL:', err.message || err);
   process.exit(1);

--- a/scripts/seed-market-quotes.mjs
+++ b/scripts/seed-market-quotes.mjs
@@ -129,6 +129,10 @@ function validate(data) {
   return Array.isArray(data?.quotes) && data.quotes.length >= 1;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.quotes) ? data.quotes.length : 0;
+}
+
 let seedData = null;
 
 async function fetchAndStash() {
@@ -140,6 +144,9 @@ runSeed('market', 'quotes', CANONICAL_KEY, fetchAndStash, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'alphavantage+finnhub+yahoo',
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 30,
 }).then(async (result) => {
   if (result?.skipped || !seedData) return;
   const rpcKey = `market:quotes:v1:${[...MARKET_SYMBOLS].sort().join(',')}`;

--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -2,6 +2,7 @@
 
 import { loadEnvFile, CHROME_UA, getRedisCredentials, acquireLockSafely, releaseLock, withRetry, writeFreshnessMetadata, logSeedResult, verifySeedKey, extendExistingTtl } from './_seed-utils.mjs';
 import { summarizeMilitaryTheaters, buildMilitarySurges, appendMilitaryHistory } from './_military-surges.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { pathToFileURL } from 'node:url';
 import { createRequire } from 'node:module';
 
@@ -1178,7 +1179,7 @@ async function redisGet(url, token, key) {
   if (!resp.ok) return null;
   const data = await resp.json();
   if (!data?.result) return null;
-  try { return JSON.parse(data.result); } catch { return null; }
+  try { return unwrapEnvelope(JSON.parse(data.result)).data; } catch { return null; }
 }
 
 async function requestForecastRefreshIfEnabled(runId, assessedAt, source) {

--- a/scripts/seed-national-debt.mjs
+++ b/scripts/seed-national-debt.mjs
@@ -165,12 +165,20 @@ function validate(data) {
 }
 
 // Guard: only run seed when executed directly, not when imported by tests
+export function declareRecords(data) {
+  return Array.isArray(data?.entries) ? data.entries.length : 0;
+}
+
 if (process.argv[1]?.endsWith('seed-national-debt.mjs')) {
   runSeed('economic', 'national-debt', CANONICAL_KEY, fetchNationalDebt, {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
     sourceVersion: 'imf-sdmx-weo-2024',
     recordCount: (data) => data?.entries?.length ?? 0,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 10080,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-natural-events.mjs
+++ b/scripts/seed-natural-events.mjs
@@ -419,10 +419,18 @@ function validate(data) {
   return Array.isArray(data?.events);
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.events) ? data.events.length : 0;
+}
+
 runSeed('natural', 'events', CANONICAL_KEY, fetchNaturalEvents, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'eonet+gdacs+nhc',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 360,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-owid-energy-mix.mjs
+++ b/scripts/seed-owid-energy-mix.mjs
@@ -11,6 +11,7 @@ import {
   withRetry,
 } from './_seed-utils.mjs';
 import { resolveIso2 } from './_country-resolver.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -222,7 +223,7 @@ async function redisGet(key) {
   });
   if (!resp.ok) return null;
   const data = await resp.json();
-  return data.result ? JSON.parse(data.result) : null;
+  return data.result ? unwrapEnvelope(JSON.parse(data.result)).data : null;
 }
 
 async function preservePreviousSnapshot(errorMsg) {

--- a/scripts/seed-portwatch-chokepoints-ref.mjs
+++ b/scripts/seed-portwatch-chokepoints-ref.mjs
@@ -72,12 +72,20 @@ export function validateFn(data) {
 }
 
 const isMain = process.argv[1]?.endsWith('seed-portwatch-chokepoints-ref.mjs');
+export function declareRecords(data) {
+  return data && typeof data === "object" ? Object.keys(data).length : 0;
+}
+
 if (isMain) {
   runSeed('portwatch', 'chokepoints-ref', CANONICAL_KEY, fetchAll, {
     validateFn,
     ttlSeconds: TTL,
     sourceVersion: 'imf-portwatch-chokepoints-arcgis-v1',
     recordCount: (data) => Object.keys(data).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 20160,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-portwatch-disruptions.mjs
+++ b/scripts/seed-portwatch-disruptions.mjs
@@ -79,6 +79,10 @@ export function validateFn(data) {
   return data && Array.isArray(data.events) && data.events.length > 0;
 }
 
+export function declareRecords(data) {
+  return data?.events?.length ?? 0;
+}
+
 const isMain = process.argv[1]?.endsWith('seed-portwatch-disruptions.mjs');
 if (isMain) {
   runSeed('portwatch', 'disruptions', CANONICAL_KEY, fetchAll, {
@@ -86,6 +90,9 @@ if (isMain) {
     ttlSeconds: TTL,
     sourceVersion: 'imf-portwatch-disruptions-arcgis-v1',
     recordCount: (data) => data?.events?.length ?? 0,
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 150,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-portwatch.mjs
+++ b/scripts/seed-portwatch.mjs
@@ -134,12 +134,20 @@ export function validateFn(data) {
 }
 
 const isMain = process.argv[1]?.endsWith('seed-portwatch.mjs');
+export function declareRecords(data) {
+  return data && typeof data === "object" ? Object.keys(data).length : 0;
+}
+
 if (isMain) {
   runSeed('supply_chain', 'portwatch', CANONICAL_KEY, fetchAll, {
     validateFn,
     ttlSeconds: TTL,
     sourceVersion: 'imf-portwatch-arcgis-v1',
     recordCount: (data) => Object.keys(data).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 720,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-prediction-markets.mjs
+++ b/scripts/seed-prediction-markets.mjs
@@ -190,8 +190,17 @@ async function fetchAllPredictions() {
   };
 }
 
+export function declareRecords(data) {
+  return (data?.geopolitical?.length || 0) + (data?.tech?.length || 0) + (data?.finance?.length || 0);
+}
+
 await runSeed('prediction', 'markets', CANONICAL_KEY, fetchAllPredictions, {
   ttlSeconds: CACHE_TTL,
   lockTtlMs: 60_000,
   validateFn: (data) => (data?.geopolitical?.length > 0 || data?.tech?.length > 0) && data?.finance?.length > 0,
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 90,
+  sourceVersion: 'prediction-markets-v1',
 });

--- a/scripts/seed-radiation-watch.mjs
+++ b/scripts/seed-radiation-watch.mjs
@@ -462,11 +462,19 @@ function validate(data) {
   return Array.isArray(data?.observations) && data.observations.length > 0;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.observations) ? data.observations.length : 0;
+}
+
 runSeed('radiation', 'observations', CANONICAL_KEY, fetchRadiationWatch, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'epa-radnet-safecast-merge-v1',
   recordCount: (data) => data?.observations?.length ?? 0,
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 30,
 }).catch((err) => {
   console.error('FATAL:', err.message || err);
   process.exit(1);

--- a/scripts/seed-recovery-external-debt.mjs
+++ b/scripts/seed-recovery-external-debt.mjs
@@ -77,12 +77,20 @@ function validate(data) {
   return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 80;
 }
 
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-recovery-external-debt.mjs')) {
   runSeed('resilience', 'recovery:external-debt', CANONICAL_KEY, fetchExternalDebt, {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
     sourceVersion: `wb-debt-reserves-${new Date().getFullYear()}`,
     recordCount: (data) => Object.keys(data?.countries ?? {}).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 86400,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-recovery-fiscal-space.mjs
+++ b/scripts/seed-recovery-fiscal-space.mjs
@@ -73,12 +73,20 @@ function validate(data) {
   return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
 }
 
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-recovery-fiscal-space.mjs')) {
   runSeed('resilience', 'recovery:fiscal-space', CANONICAL_KEY, fetchFiscalSpace, {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
     sourceVersion: `imf-sdmx-weo-fiscal-${new Date().getFullYear()}`,
     recordCount: (data) => Object.keys(data?.countries ?? {}).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 86400,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-recovery-fuel-stocks.mjs
+++ b/scripts/seed-recovery-fuel-stocks.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, runSeed, getRedisCredentials } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -33,7 +34,7 @@ async function fetchFromRedis(key) {
   });
   if (!resp.ok) return null;
   const data = await resp.json();
-  return data.result ? JSON.parse(data.result) : null;
+  return data.result ? unwrapEnvelope(JSON.parse(data.result)).data : null;
 }
 
 async function fetchFuelStocks() {

--- a/scripts/seed-recovery-fuel-stocks.mjs
+++ b/scripts/seed-recovery-fuel-stocks.mjs
@@ -57,12 +57,20 @@ function validate(data) {
   return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 15;
 }
 
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-recovery-fuel-stocks.mjs')) {
   runSeed('resilience', 'recovery:fuel-stocks', CANONICAL_KEY, fetchFuelStocks, {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
     sourceVersion: `iea-derived-fuel-stocks-${new Date().getFullYear()}`,
     recordCount: (data) => Object.keys(data?.countries ?? {}).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 86400,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-recovery-import-hhi.mjs
+++ b/scripts/seed-recovery-import-hhi.mjs
@@ -266,6 +266,10 @@ function validate(data) {
   return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 80;
 }
 
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-recovery-import-hhi.mjs')) {
   runSeed('resilience', 'recovery:import-hhi', CANONICAL_KEY, fetchImportHhi, {
     validateFn: validate,
@@ -273,6 +277,10 @@ if (process.argv[1]?.endsWith('seed-recovery-import-hhi.mjs')) {
     lockTtlMs: LOCK_TTL_MS,
     sourceVersion: `comtrade-hhi-${new Date().getFullYear()}`,
     recordCount: (data) => Object.keys(data?.countries ?? {}).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 86400,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-recovery-reserve-adequacy.mjs
+++ b/scripts/seed-recovery-reserve-adequacy.mjs
@@ -52,12 +52,20 @@ function validate(data) {
   return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 100;
 }
 
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-recovery-reserve-adequacy.mjs')) {
   runSeed('resilience', 'recovery:reserve-adequacy', CANONICAL_KEY, fetchReserveAdequacy, {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
     sourceVersion: `wb-reserves-${new Date().getFullYear()}`,
     recordCount: (data) => Object.keys(data?.countries ?? {}).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 86400,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-regional-briefs.mjs
+++ b/scripts/seed-regional-briefs.mjs
@@ -16,6 +16,7 @@
 import { pathToFileURL } from 'node:url';
 
 import { loadEnvFile, getRedisCredentials, writeExtraKeyWithMeta } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { REGIONS } from './shared/geography.js';
 import { generateWeeklyBrief } from './regional-snapshot/weekly-brief.mjs';
 
@@ -63,7 +64,7 @@ async function readLatestSnapshot(url, token, regionId) {
     });
     if (!snapResp.ok) return null;
     const snapData = await snapResp.json();
-    return snapData?.result ? JSON.parse(snapData.result) : null;
+    return snapData?.result ? unwrapEnvelope(JSON.parse(snapData.result)).data : null;
   } catch {
     return null;
   }

--- a/scripts/seed-research.mjs
+++ b/scripts/seed-research.mjs
@@ -336,10 +336,17 @@ function validate(data) {
   return data?.papers?.length > 0;
 }
 
+export function declareRecords(data) {
+  return data?.papers?.length ?? 0;
+}
+
 runSeed('research', 'arxiv-hn-trending', 'research:arxiv:v1:cs.AI::50', fetchAll, {
   validateFn: validate,
   ttlSeconds: ARXIV_TTL,
   sourceVersion: 'arxiv-hn-gitter',
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 150,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -5,6 +5,7 @@ import {
   logSeedResult,
   writeFreshnessMetadata,
 } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -67,7 +68,7 @@ async function redisGetJson(url, token, key) {
   if (!resp.ok) return null;
   const data = await resp.json();
   if (!data?.result) return null;
-  try { return JSON.parse(data.result); } catch { return null; }
+  try { return unwrapEnvelope(JSON.parse(data.result)).data; } catch { return null; }
 }
 
 async function redisPipeline(url, token, commands) {

--- a/scripts/seed-sanctions-pressure.mjs
+++ b/scripts/seed-sanctions-pressure.mjs
@@ -545,6 +545,10 @@ function validate(data) {
   return (data?.totalCount ?? 0) > 0;
 }
 
+export function declareRecords(data) {
+  return data?.totalCount ?? 0;
+}
+
 runSeed('sanctions', 'pressure', CANONICAL_KEY, fetchSanctionsPressure, {
   ttlSeconds: CACHE_TTL,
   validateFn: validate,
@@ -593,4 +597,8 @@ runSeed('sanctions', 'pressure', CANONICAL_KEY, fetchSanctionsPressure, {
     delete data._entityIndex;
     delete data._countryCounts;
   },
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 720,
 });

--- a/scripts/seed-security-advisories.mjs
+++ b/scripts/seed-security-advisories.mjs
@@ -214,12 +214,20 @@ function validate(data) {
   return Array.isArray(data?.advisories) && data.advisories.length > 0;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.advisories) ? data.advisories.length : 0;
+}
+
 runSeed('intelligence', 'advisories', CANONICAL_KEY, fetchAll, {
   validateFn: validate,
   ttlSeconds: TTL,
   recordCount: (d) => d?.advisories?.length || 0,
   sourceVersion: 'rss-feeds',
-  extraKeys: [{ key: BOOTSTRAP_KEY, transform: (d) => d, ttl: TTL }],
+  extraKeys: [{ key: BOOTSTRAP_KEY, transform: (d) => d, ttl: TTL, declareRecords }],
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 120,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-spr-policies.mjs
+++ b/scripts/seed-spr-policies.mjs
@@ -55,12 +55,20 @@ export function validateFn(data) {
 }
 
 const isMain = process.argv[1]?.endsWith('seed-spr-policies.mjs');
+export function declareRecords(data) {
+  return Object.keys(data?.policies || {}).length;
+}
+
 if (isMain) {
   runSeed('energy', 'spr-policies', CANONICAL_KEY, buildPayload, {
     validateFn,
     ttlSeconds: SPR_POLICIES_TTL_SECONDS,
     sourceVersion: 'spr-policies-registry-v1',
     recordCount: (data) => Object.keys(data?.policies ?? {}).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 576000,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-stablecoin-markets.mjs
+++ b/scripts/seed-stablecoin-markets.mjs
@@ -133,10 +133,18 @@ function validate(data) {
   );
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.stablecoins) ? data.stablecoins.length : 0;
+}
+
 runSeed('market', 'stablecoins', CANONICAL_KEY, fetchStablecoinMarkets, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'coingecko-stablecoins',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 60,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-submarine-cables.mjs
+++ b/scripts/seed-submarine-cables.mjs
@@ -292,10 +292,17 @@ function validate(data) {
   return data?.cables?.length >= Math.floor(allCount * 0.9);
 }
 
+export function declareRecords(data) {
+  return data?.cables?.length ?? 0;
+}
+
 runSeed('infrastructure', 'submarine-cables', CANONICAL_KEY, fetchSubmarineCables, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'telegeography-v3',
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 25200,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -683,10 +683,18 @@ function validate(data) {
   return data?.indices?.length > 0;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.indices) ? data.indices.length : 0;
+}
+
 runSeed('supply_chain', 'shipping', KEYS.shipping, fetchAll, {
   validateFn: validate,
   ttlSeconds: SHIPPING_TTL,
   sourceVersion: 'fred-wto-sse-bdi-budgetlab',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 420,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-thermal-escalation.mjs
+++ b/scripts/seed-thermal-escalation.mjs
@@ -35,6 +35,10 @@ async function fetchEscalations() {
   return result;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.clusters) ? data.clusters.length : 0;
+}
+
 async function main() {
   await runSeed('thermal', 'escalation', CANONICAL_KEY, async () => {
     const result = await fetchEscalations();
@@ -45,6 +49,9 @@ async function main() {
     lockTtlMs: 180_000,
     sourceVersion: SOURCE_VERSION,
     recordCount: (data) => data?.clusters?.length ?? 0,
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 360,
     afterPublish: async () => {
       await writeExtraKeyWithMeta(
         HISTORY_KEY,

--- a/scripts/seed-token-panels.mjs
+++ b/scripts/seed-token-panels.mjs
@@ -103,13 +103,16 @@ async function fetchTokenPanels() {
   return { defi, ai, other, total };
 }
 
-function validate(data) {
+// validate() runs on the POST-publishTransform payload (the canonical defi
+// panel itself, shape {tokens, ...}) — NOT the pre-transform {defi, ai, other}
+// shape. The prior body checked data.defi/.ai/.other and silently forced the
+// skipped-write path every run. AI/OTHER panels are validated implicitly by
+// their own extraKey declareRecords on write.
+export function validate(data) {
   return (
-    Array.isArray(data?.defi?.tokens) &&
-    data.defi.tokens.length >= 1 &&
-    (data.defi.tokens.some((t) => t.price > 0) ||
-      data.ai.tokens.some((t) => t.price > 0) ||
-      data.other.tokens.some((t) => t.price > 0))
+    Array.isArray(data?.tokens) &&
+    data.tokens.length >= 1 &&
+    data.tokens.some((t) => t.price > 0)
   );
 }
 

--- a/scripts/seed-token-panels.mjs
+++ b/scripts/seed-token-panels.mjs
@@ -113,6 +113,10 @@ function validate(data) {
   );
 }
 
+export function declareRecords(data) {
+  return (data?.defi?.tokens?.length || 0) + (data?.ai?.tokens?.length || 0) + (data?.other?.tokens?.length || 0);
+}
+
 runSeed('market', 'token-panels', DEFI_KEY, fetchTokenPanels, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
@@ -123,6 +127,10 @@ runSeed('market', 'token-panels', DEFI_KEY, fetchTokenPanels, {
     { key: AI_KEY, transform: (data) => data.ai, ttl: CACHE_TTL },
     { key: OTHER_KEY, transform: (data) => data.other, ttl: CACHE_TTL },
   ],
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 90,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
   console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-token-panels.mjs
+++ b/scripts/seed-token-panels.mjs
@@ -113,19 +113,29 @@ function validate(data) {
   );
 }
 
+// Canonical key (DEFI_KEY) holds the defi panel object `{tokens, ...}` after
+// publishTransform. declareRecords must match the POST-transform shape;
+// counting `data.defi/ai/other` on the transformed payload returned 0 and
+// forced runSeed into RETRY, leaving all 3 token keys stale.
 export function declareRecords(data) {
-  return (data?.defi?.tokens?.length || 0) + (data?.ai?.tokens?.length || 0) + (data?.other?.tokens?.length || 0);
+  return Array.isArray(data?.tokens) ? data.tokens.length : 0;
 }
 
-runSeed('market', 'token-panels', DEFI_KEY, fetchTokenPanels, {
+// isMain guard — required so tests/agents can `import` declareRecords without
+// firing runSeed on module load (which would touch Redis and process.exit).
+const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^file:\/\//, ''));
+if (isMain) runSeed('market', 'token-panels', DEFI_KEY, fetchTokenPanels, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'coingecko-paprika-fallback',
   recordCount: (data) => data.total,
   publishTransform: (data) => data.defi,
   extraKeys: [
-    { key: AI_KEY, transform: (data) => data.ai, ttl: CACHE_TTL },
-    { key: OTHER_KEY, transform: (data) => data.other, ttl: CACHE_TTL },
+    // Each panel has its own {tokens, ...} shape — reuse canonical declareRecords
+    // since the transformed extra-key payloads are structurally identical to the
+    // canonical one (a single panel).
+    { key: AI_KEY,    transform: (data) => data.ai,    ttl: CACHE_TTL, declareRecords },
+    { key: OTHER_KEY, transform: (data) => data.other, ttl: CACHE_TTL, declareRecords },
   ],
 
   declareRecords,

--- a/scripts/seed-trade-flows.mjs
+++ b/scripts/seed-trade-flows.mjs
@@ -226,6 +226,10 @@ async function afterPublish(data, _meta) {
 }
 
 // isMain guard so tests can import fetchFlows without triggering a real seed run.
+export function declareRecords(data) {
+  return Array.isArray(data?.flows) ? data.flows.length : 0;
+}
+
 if (process.argv[1]?.endsWith('seed-trade-flows.mjs')) {
   runSeed('trade', 'comtrade-flows', CANONICAL_KEY, fetchAllFlows, {
     validateFn: validate,
@@ -233,6 +237,10 @@ if (process.argv[1]?.endsWith('seed-trade-flows.mjs')) {
     sourceVersion: 'comtrade-preview-v1',
     publishTransform,
     afterPublish,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 2880,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-ucdp-events.mjs
+++ b/scripts/seed-ucdp-events.mjs
@@ -3,6 +3,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -256,7 +257,7 @@ async function main() {
   if (getResp.ok) {
     const getData = await getResp.json();
     if (getData.result) {
-      const parsed = JSON.parse(getData.result);
+      const parsed = unwrapEnvelope(JSON.parse(getData.result)).data;
       console.log(`\n  Verified: ${parsed.events?.length} events in Redis`);
       console.log(`  Version: ${parsed.version} | fetchedAt: ${new Date(parsed.fetchedAt).toISOString()}`);
     }

--- a/scripts/seed-unrest-events.mjs
+++ b/scripts/seed-unrest-events.mjs
@@ -251,10 +251,18 @@ function validate(data) {
   return Array.isArray(data?.events) && data.events.length > 0;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.events) ? data.events.length : 0;
+}
+
 runSeed('unrest', 'events', CANONICAL_KEY, fetchUnrestEvents, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'acled+gdelt',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 120,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-usa-spending.mjs
+++ b/scripts/seed-usa-spending.mjs
@@ -78,10 +78,18 @@ function validate(data) {
   return Array.isArray(data?.awards) && data.awards.length >= 1;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.awards) ? data.awards.length : 0;
+}
+
 runSeed('economic', 'spending', CANONICAL_KEY, fetchSpending, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'usaspending-v2',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 120,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-vpd-tracker.mjs
+++ b/scripts/seed-vpd-tracker.mjs
@@ -109,6 +109,10 @@ function validate(data) {
     && Array.isArray(data?.historical) && data.historical.length >= 100;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.alerts) ? data.alerts.length : 0;
+}
+
 runSeed('health', 'vpd-tracker', CANONICAL_KEY, fetchVpdTracker, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
@@ -120,6 +124,10 @@ runSeed('health', 'vpd-tracker', CANONICAL_KEY, fetchVpdTracker, {
       transform: data => ({ records: data.historical, fetchedAt: data.fetchedAt }),
     },
   ],
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 2880,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
   console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-weather-alerts.mjs
+++ b/scripts/seed-weather-alerts.mjs
@@ -64,10 +64,18 @@ function validate(data) {
   return Array.isArray(data?.alerts) && data.alerts.length >= 1;
 }
 
+export function declareRecords(data) {
+  return Array.isArray(data?.alerts) ? data.alerts.length : 0;
+}
+
 runSeed('weather', 'alerts', CANONICAL_KEY, fetchAlerts, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
   sourceVersion: 'nws-active',
+
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 45,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
   process.exit(1);

--- a/scripts/seed-yield-curve-eu.mjs
+++ b/scripts/seed-yield-curve-eu.mjs
@@ -106,12 +106,20 @@ function validate(data) {
   return valid.length >= 4; // require at least 4 of 6 tenors
 }
 
+export function declareRecords(data) {
+  return Object.keys(data?.rates || {}).length;
+}
+
 if (process.argv[1]?.endsWith('seed-yield-curve-eu.mjs')) {
   runSeed('economic', 'yield-curve-eu', CANONICAL_KEY, fetchEcbYieldCurve, {
     validateFn: validate,
     ttlSeconds: TTL,
     sourceVersion: 'ecb-sdmx-v1',
     recordCount: (data) => Object.keys(data?.rates ?? {}).length,
+  
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 4320,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -1,3 +1,5 @@
+import { unwrapEnvelope } from './seed-envelope';
+
 const REDIS_OP_TIMEOUT_MS = 1_500;
 const REDIS_PIPELINE_TIMEOUT_MS = 5_000;
 
@@ -42,7 +44,10 @@ export async function getRawJson(key: string): Promise<unknown | null> {
   });
   if (!resp.ok) throw new Error(`Redis HTTP ${resp.status}`);
   const data = (await resp.json()) as { result?: string };
-  return data.result ? JSON.parse(data.result) : null;
+  if (!data.result) return null;
+  // Envelope-aware: contract-mode canonical keys are stored as {_seed, data}.
+  // unwrapEnvelope is a no-op on legacy (non-envelope) shapes.
+  return unwrapEnvelope(JSON.parse(data.result)).data;
 }
 
 export async function getCachedJson(key: string, raw = false): Promise<unknown | null> {
@@ -62,7 +67,11 @@ export async function getCachedJson(key: string, raw = false): Promise<unknown |
     });
     if (!resp.ok) return null;
     const data = (await resp.json()) as { result?: string };
-    return data.result ? JSON.parse(data.result) : null;
+    if (!data.result) return null;
+    // Envelope-aware by default — RPC consumers get the bare payload regardless
+    // of whether the writer has migrated to contract mode. Legacy shapes pass
+    // through unchanged (unwrapEnvelope returns {_seed: null, data: raw}).
+    return unwrapEnvelope(JSON.parse(data.result)).data;
   } catch (err) {
     console.warn('[redis] getCachedJson failed:', errMsg(err));
     return null;
@@ -122,7 +131,10 @@ export async function getCachedJsonBatch(keys: string[]): Promise<Map<string, un
       if (raw) {
         try {
           const parsed = JSON.parse(raw);
-          if (parsed !== NEG_SENTINEL) result.set(keys[i]!, parsed);
+          if (parsed === NEG_SENTINEL) continue;
+          // Envelope-aware: unwrap contract-mode canonical keys; legacy values
+          // pass through.
+          result.set(keys[i]!, unwrapEnvelope(parsed).data);
         } catch { /* skip malformed */ }
       }
     }

--- a/server/worldmonitor/infrastructure/v1/_shared.ts
+++ b/server/worldmonitor/infrastructure/v1/_shared.ts
@@ -56,6 +56,8 @@ export function getBaselineSeverity(zScore: number): string {
 // getCachedJson / setCachedJson are imported from ../../../_shared/redis.ts
 // ========================================================================
 
+import { unwrapEnvelope } from '../../../_shared/seed-envelope';
+
 export async function mgetJson(keys: string[]): Promise<(unknown | null)[]> {
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -72,7 +74,9 @@ export async function mgetJson(keys: string[]): Promise<(unknown | null)[]> {
     });
     if (!resp.ok) return keys.map(() => null);
     const data = (await resp.json()) as { result?: (string | null)[] };
-    return (data.result || []).map(v => v ? JSON.parse(v) : null);
+    // Envelope-aware: several of these count-source keys (wildfire:fires:v1,
+    // news:insights:v1) are contract-mode canonical keys post-PR-2.
+    return (data.result || []).map(v => v ? unwrapEnvelope(JSON.parse(v)).data : null);
   } catch {
     return keys.map(() => null);
   }

--- a/server/worldmonitor/resilience/v1/_shared.ts
+++ b/server/worldmonitor/resilience/v1/_shared.ts
@@ -10,6 +10,7 @@ import type {
 export type { ScoreInterval };
 
 import { cachedFetchJson, getCachedJson, runRedisPipeline } from '../../../_shared/redis';
+import { unwrapEnvelope } from '../../../_shared/seed-envelope';
 import { detectTrend, round } from '../../../_shared/resilience-stats';
 import {
   RESILIENCE_DIMENSION_DOMAINS,
@@ -344,7 +345,10 @@ export async function getCachedResilienceScores(countryCodes: string[]): Promise
     const raw = results[index]?.result;
     if (typeof raw !== 'string') continue;
     try {
-      const parsed = JSON.parse(raw) as GetResilienceScoreResponse;
+      // Envelope-aware: resilience score keys are written by seed-resilience-scores
+      // in contract mode (PR 2). unwrapEnvelope is a no-op on legacy bare-shape.
+      const parsed = unwrapEnvelope(JSON.parse(raw)).data as GetResilienceScoreResponse;
+      if (!parsed) continue;
       // P1 fix: cached payload is always v2 superset. Gate on serve.
       if (!RESILIENCE_SCHEMA_V2_ENABLED) {
         parsed.pillars = [];

--- a/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/resilience/v1/service_server';
 
 import { getCachedJson, runRedisPipeline } from '../../../_shared/redis';
+import { unwrapEnvelope } from '../../../_shared/seed-envelope';
 import {
   GREY_OUT_COVERAGE_THRESHOLD,
   RESILIENCE_INTERVAL_KEY_PREFIX,
@@ -48,8 +49,9 @@ async function fetchIntervals(countryCodes: string[]): Promise<Map<string, Score
     const raw = results[i]?.result;
     if (typeof raw !== 'string') continue;
     try {
-      const parsed = JSON.parse(raw) as { p05?: number; p95?: number };
-      if (typeof parsed.p05 === 'number' && typeof parsed.p95 === 'number') {
+      // Envelope-aware: interval keys come through seed-resilience-scores' extra-key path.
+      const parsed = unwrapEnvelope(JSON.parse(raw)).data as { p05?: number; p95?: number } | null;
+      if (parsed && typeof parsed.p05 === 'number' && typeof parsed.p95 === 'number') {
         map.set(countryCodes[i]!, { p05: parsed.p05, p95: parsed.p95 });
       }
     } catch { /* ignore malformed interval entries */ }

--- a/tests/cross-source-signals-regulatory.test.mjs
+++ b/tests/cross-source-signals-regulatory.test.mjs
@@ -13,7 +13,11 @@ const pureSrc = seedSrc
   .replace(/^import\s.*$/gm, '')
   .replace(/loadEnvFile\([^)]+\);\n/, '')
   .replace(/async function readAllSourceKeys[\s\S]*?\n}\n\n\/\/ ── Signal extractors/m, '// readAllSourceKeys removed for unit test\n\n// ── Signal extractors')
-  .replace(/runSeed\('intelligence'[\s\S]*$/m, '');
+  .replace(/runSeed\('intelligence'[\s\S]*$/m, '')
+  // Contract migration added `export function declareRecords`; vm.runInContext
+  // cannot execute ESM export syntax. Strip the keyword so the function
+  // body still evaluates as a plain declaration.
+  .replace(/^export\s+(function\s+declareRecords)/m, '$1');
 
 const ctx = vm.createContext({ console, Date, Math, Number, Array, Map, Set, String, RegExp });
 vm.runInContext(`${pureSrc}\n;globalThis.__exports = { SOURCE_KEYS, TYPE_CATEGORY, BASE_WEIGHT, scoreTier, extractRegulatoryAction, detectCompositeEscalation };`, ctx);

--- a/tests/seed-contract-probe.test.mjs
+++ b/tests/seed-contract-probe.test.mjs
@@ -1,0 +1,158 @@
+// Unit tests for api/seed-contract-probe.ts — covers every branch of
+// checkProbe() (envelope, bare, missing, malformed, expected-bare-got-envelope,
+// expected-envelope-got-bare, minRecords floor, missing-field detection) and
+// checkPublicBoundary() (seed leak detection, bad status).
+//
+// Mocks globalThis.fetch so these run hermetically with no network / Upstash.
+
+import { test, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+process.env.RELAY_SHARED_SECRET = 'test-secret';
+
+// tsx resolves .ts imports for node:test.
+const { checkProbe, checkPublicBoundary, DEFAULT_PROBES } = await import('../api/seed-contract-probe.ts');
+
+const originalFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = originalFetch; });
+
+function mockRedisGet(value) {
+  globalThis.fetch = async () => ({
+    ok: true,
+    json: async () => ({ result: value == null ? null : JSON.stringify(value) }),
+  });
+}
+
+// ─── envelope shape probes ───────────────────────────────────────────────
+
+test('checkProbe: envelope-shaped key with all fields + records passes', async () => {
+  mockRedisGet({
+    _seed: { fetchedAt: Date.now(), recordCount: 52, sourceVersion: 'v1', schemaVersion: 1, state: 'OK' },
+    data: { latestValue: 0.23, history: [{ date: '2026-04-14', value: 0.23 }] },
+  });
+  const r = await checkProbe({ key: 'economic:fsi-eu:v1', shape: 'envelope', dataHas: ['latestValue', 'history'] });
+  assert.equal(r.pass, true);
+  assert.equal(r.state, 'OK');
+  assert.equal(r.records, 52);
+});
+
+test('checkProbe: envelope missing required data field fails', async () => {
+  mockRedisGet({
+    _seed: { fetchedAt: Date.now(), recordCount: 1, sourceVersion: 'v1', schemaVersion: 1, state: 'OK' },
+    data: { latestValue: 0.23 }, // missing history
+  });
+  const r = await checkProbe({ key: 'economic:fsi-eu:v1', shape: 'envelope', dataHas: ['latestValue', 'history'] });
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /missing-field:history/);
+});
+
+test('checkProbe: envelope recordCount below floor fails', async () => {
+  mockRedisGet({
+    _seed: { fetchedAt: Date.now(), recordCount: 3, sourceVersion: 'v1', schemaVersion: 1, state: 'OK' },
+    data: { normals: [1, 2, 3] },
+  });
+  const r = await checkProbe({ key: 'climate:zone-normals:v1', shape: 'envelope', dataHas: ['normals'], minRecords: 13 });
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /records:3<13/);
+});
+
+test('checkProbe: expected envelope got bare fails (dual-write not active)', async () => {
+  mockRedisGet({ latestValue: 0.23, history: [], fetchedAt: Date.now() });
+  const r = await checkProbe({ key: 'economic:fsi-eu:v1', shape: 'envelope', dataHas: ['latestValue'] });
+  assert.equal(r.pass, false);
+  assert.equal(r.reason, 'expected-envelope-got-bare');
+});
+
+// ─── bare shape probes (seed-meta:* invariant) ───────────────────────────
+
+test('checkProbe: bare seed-meta key with fetchedAt passes', async () => {
+  mockRedisGet({ fetchedAt: Date.now(), recordCount: 31, sourceVersion: 'v1' });
+  const r = await checkProbe({ key: 'seed-meta:energy:oil-stocks-analysis', shape: 'bare', dataHas: ['fetchedAt'] });
+  assert.equal(r.pass, true);
+});
+
+test('checkProbe: bare expected but got envelope fails (shouldEnvelopeKey invariant broken)', async () => {
+  mockRedisGet({
+    _seed: { fetchedAt: Date.now(), recordCount: 1, sourceVersion: 'v1', schemaVersion: 1, state: 'OK' },
+    data: { fetchedAt: Date.now(), recordCount: 1 },
+  });
+  const r = await checkProbe({ key: 'seed-meta:economic:fsi-eu', shape: 'bare', dataHas: ['fetchedAt'] });
+  assert.equal(r.pass, false);
+  assert.equal(r.reason, 'expected-bare-got-envelope');
+});
+
+test('checkProbe: bare missing field fails', async () => {
+  mockRedisGet({ recordCount: 1 }); // no fetchedAt
+  const r = await checkProbe({ key: 'seed-meta:economic:fsi-eu', shape: 'bare', dataHas: ['fetchedAt'] });
+  assert.equal(r.pass, false);
+  assert.match(r.reason, /missing-field:fetchedAt/);
+});
+
+// ─── error branches ─────────────────────────────────────────────────────
+
+test('checkProbe: missing key in Redis returns reason=missing', async () => {
+  mockRedisGet(null);
+  const r = await checkProbe({ key: 'economic:fsi-eu:v1', shape: 'envelope' });
+  assert.equal(r.pass, false);
+  assert.equal(r.reason, 'missing');
+});
+
+test('checkProbe: malformed JSON returns reason=malformed-json', async () => {
+  globalThis.fetch = async () => ({ ok: true, json: async () => ({ result: '{not json' }) });
+  const r = await checkProbe({ key: 'economic:fsi-eu:v1', shape: 'envelope' });
+  assert.equal(r.pass, false);
+  assert.equal(r.reason, 'malformed-json');
+});
+
+test('checkProbe: Redis non-2xx returns reason=redis:<code>', async () => {
+  globalThis.fetch = async () => ({ ok: false, status: 503, json: async () => ({}) });
+  const r = await checkProbe({ key: 'economic:fsi-eu:v1', shape: 'envelope' });
+  assert.equal(r.pass, false);
+  assert.equal(r.reason, 'redis:503');
+});
+
+// ─── public boundary checks ─────────────────────────────────────────────
+
+test('checkPublicBoundary: response without _seed passes', async () => {
+  globalThis.fetch = async () => ({
+    ok: true, status: 200,
+    text: async () => JSON.stringify({ tiers: [{ id: 'pro' }], fetchedAt: 1 }),
+  });
+  const res = await checkPublicBoundary('https://example.test');
+  assert.equal(res.every(r => r.pass), true, JSON.stringify(res));
+});
+
+test('checkPublicBoundary: response leaking _seed fails', async () => {
+  globalThis.fetch = async () => ({
+    ok: true, status: 200,
+    text: async () => JSON.stringify({
+      _seed: { fetchedAt: 1, recordCount: 1, state: 'OK' },
+      data: { tiers: [] },
+    }),
+  });
+  const res = await checkPublicBoundary('https://example.test');
+  assert.ok(res.some(r => !r.pass && r.reason === 'seed-leak'));
+});
+
+test('checkPublicBoundary: bad status fails', async () => {
+  globalThis.fetch = async () => ({ ok: false, status: 502, text: async () => '' });
+  const res = await checkPublicBoundary('https://example.test');
+  assert.ok(res.every(r => !r.pass && r.reason.startsWith('status:')));
+});
+
+// ─── default probe set sanity ───────────────────────────────────────────
+
+test('DEFAULT_PROBES: enforces seed-meta:* bare invariant', () => {
+  const bare = DEFAULT_PROBES.filter(p => p.key.startsWith('seed-meta:'));
+  assert.ok(bare.length >= 2, 'at least two seed-meta probes must exist');
+  assert.ok(bare.every(p => p.shape === 'bare'), 'all seed-meta probes must be shape=bare');
+});
+
+test('DEFAULT_PROBES: token-panels regression guards present (minRecords on defi)', () => {
+  const defi = DEFAULT_PROBES.find(p => p.key === 'market:defi-tokens:v1');
+  assert.ok(defi);
+  assert.equal(defi.shape, 'envelope');
+  assert.equal(defi.minRecords, 1);
+});

--- a/tests/seed-contract-probe.test.mjs
+++ b/tests/seed-contract-probe.test.mjs
@@ -115,29 +115,74 @@ test('checkProbe: Redis non-2xx returns reason=redis:<code>', async () => {
 
 // ─── public boundary checks ─────────────────────────────────────────────
 
-test('checkPublicBoundary: response without _seed passes', async () => {
-  globalThis.fetch = async () => ({
-    ok: true, status: 200,
-    text: async () => JSON.stringify({ tiers: [{ id: 'pro' }], fetchedAt: 1 }),
-  });
+function mockBoundary(bodyByEndpoint, headersByEndpoint = {}) {
+  globalThis.fetch = async (url) => {
+    const path = new URL(url).pathname;
+    const body = bodyByEndpoint[path] ?? '{}';
+    const hdrs = new Headers(headersByEndpoint[path] || {});
+    return {
+      ok: true, status: 200,
+      text: async () => body,
+      headers: { get: (name) => hdrs.get(name) },
+    };
+  };
+}
+
+test('checkPublicBoundary: product-catalog served from cache + bootstrap no leak → pass', async () => {
+  mockBoundary(
+    {
+      '/api/product-catalog': JSON.stringify({ tiers: [{ id: 'pro' }], fetchedAt: 1 }),
+      '/api/bootstrap':       JSON.stringify({ market: { quotes: [] } }),
+    },
+    { '/api/product-catalog': { 'x-product-catalog-source': 'cache' } },
+  );
   const res = await checkPublicBoundary('https://example.test');
   assert.equal(res.every(r => r.pass), true, JSON.stringify(res));
 });
 
-test('checkPublicBoundary: response leaking _seed fails', async () => {
-  globalThis.fetch = async () => ({
-    ok: true, status: 200,
-    text: async () => JSON.stringify({
-      _seed: { fetchedAt: 1, recordCount: 1, state: 'OK' },
-      data: { tiers: [] },
-    }),
+test('checkPublicBoundary: product-catalog served from fallback fails source-header assert', async () => {
+  // This is the regression case — response has no _seed leak, but the cached
+  // reader path silently failed and we fell through to static fallback.
+  mockBoundary(
+    {
+      '/api/product-catalog': JSON.stringify({ tiers: [], priceSource: 'fallback' }),
+      '/api/bootstrap':       JSON.stringify({}),
+    },
+    { '/api/product-catalog': { 'x-product-catalog-source': 'fallback' } },
+  );
+  const res = await checkPublicBoundary('https://example.test');
+  const pc = res.find(r => r.endpoint === '/api/product-catalog');
+  assert.equal(pc.pass, false);
+  assert.match(pc.reason, /source:fallback!=cache/);
+});
+
+test('checkPublicBoundary: product-catalog missing source header fails', async () => {
+  mockBoundary({
+    '/api/product-catalog': JSON.stringify({ tiers: [] }),
+    '/api/bootstrap':       JSON.stringify({}),
   });
+  const res = await checkPublicBoundary('https://example.test');
+  const pc = res.find(r => r.endpoint === '/api/product-catalog');
+  assert.equal(pc.pass, false);
+  assert.match(pc.reason, /source:missing!=cache/);
+});
+
+test('checkPublicBoundary: response leaking _seed fails before source check', async () => {
+  mockBoundary(
+    {
+      '/api/product-catalog': JSON.stringify({ _seed: { fetchedAt: 1 }, data: { tiers: [] } }),
+      '/api/bootstrap':       JSON.stringify({}),
+    },
+    { '/api/product-catalog': { 'x-product-catalog-source': 'cache' } },
+  );
   const res = await checkPublicBoundary('https://example.test');
   assert.ok(res.some(r => !r.pass && r.reason === 'seed-leak'));
 });
 
 test('checkPublicBoundary: bad status fails', async () => {
-  globalThis.fetch = async () => ({ ok: false, status: 502, text: async () => '' });
+  globalThis.fetch = async () => ({
+    ok: false, status: 502, text: async () => '', headers: { get: () => null },
+  });
   const res = await checkPublicBoundary('https://example.test');
   assert.ok(res.every(r => !r.pass && r.reason.startsWith('status:')));
 });
@@ -150,9 +195,13 @@ test('DEFAULT_PROBES: enforces seed-meta:* bare invariant', () => {
   assert.ok(bare.every(p => p.shape === 'bare'), 'all seed-meta probes must be shape=bare');
 });
 
-test('DEFAULT_PROBES: token-panels regression guards present (minRecords on defi)', () => {
-  const defi = DEFAULT_PROBES.find(p => p.key === 'market:defi-tokens:v1');
-  assert.ok(defi);
-  assert.equal(defi.shape, 'envelope');
-  assert.equal(defi.minRecords, 1);
+test('DEFAULT_PROBES: token-panels regression guards present (minRecords on all 3 panels)', () => {
+  // Every panel needs the minRecords floor — without it, a regression where
+  // an extra-key declareRecords returns 0 would silently pass the probe.
+  for (const key of ['market:defi-tokens:v1', 'market:ai-tokens:v1', 'market:other-tokens:v1']) {
+    const p = DEFAULT_PROBES.find(x => x.key === key);
+    assert.ok(p, `missing probe for ${key}`);
+    assert.equal(p.shape, 'envelope');
+    assert.equal(p.minRecords, 1, `${key} must enforce minRecords≥1`);
+  }
 });

--- a/tests/seed-contract-transform-regressions.test.mjs
+++ b/tests/seed-contract-transform-regressions.test.mjs
@@ -1,0 +1,107 @@
+// Regression locks for PR #3097 review findings:
+//
+//   1. runSeed passes publishData (post-transform) to declareRecords. Seeders
+//      that author declareRecords against the pre-transform shape silently
+//      enter the RETRY path (count=0 with zeroIsValid=false), skipping the
+//      write. seed-token-panels hit this on all 3 token keys.
+//
+//   2. extraKeys whose key begins with `seed-meta:` must NEVER be enveloped —
+//      health/bundle-runner/legacy readers parse them as bare `{fetchedAt,
+//      recordCount}`. seed-iea-oil-stocks' ANALYSIS_META_EXTRA_KEY hit this.
+//
+//   3. Per-extra-key declareRecords must operate on the transformed extra-key
+//      payload, not the raw fetch result. Token-panels' AI/OTHER extras now
+//      declare their own recordCount against the extracted panel.
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { buildEnvelope, unwrapEnvelope } from '../scripts/_seed-envelope-source.mjs';
+import { resolveRecordCount } from '../scripts/_seed-contract.mjs';
+import { shouldEnvelopeKey } from '../scripts/_seed-utils.mjs';
+
+// ─── Commit A: shouldEnvelopeKey invariant ──────────────────────────────
+
+test('shouldEnvelopeKey: seed-meta:* keys must stay bare', () => {
+  assert.equal(shouldEnvelopeKey('seed-meta:energy:oil-stocks-analysis'), false);
+  assert.equal(shouldEnvelopeKey('seed-meta:conflict:ucdp-events'), false);
+  assert.equal(shouldEnvelopeKey('seed-meta:'), false);
+});
+
+test('shouldEnvelopeKey: canonical data keys DO envelope', () => {
+  assert.equal(shouldEnvelopeKey('economic:fsi-eu:v1'), true);
+  assert.equal(shouldEnvelopeKey('market:defi-tokens:v1'), true);
+  assert.equal(shouldEnvelopeKey('climate:zone-normals:v1'), true);
+});
+
+test('shouldEnvelopeKey: non-string / falsy → defensive false', () => {
+  assert.equal(shouldEnvelopeKey(null), false);
+  assert.equal(shouldEnvelopeKey(undefined), false);
+  assert.equal(shouldEnvelopeKey(''), true); // empty string is not a seed-meta prefix
+});
+
+// ─── Commit B: declareRecords must work on post-transform shape ──────────
+
+test('seed-token-panels: canonical declareRecords counts tokens on transformed shape', async () => {
+  const { declareRecords } = await import('../scripts/seed-token-panels.mjs');
+  // publishTransform = (data) => data.defi, so declareRecords receives the defi panel itself.
+  const transformedDefi = { tokens: [{ symbol: 'UNI' }, { symbol: 'AAVE' }], sparkline: [] };
+  assert.equal(declareRecords(transformedDefi), 2);
+});
+
+test('seed-token-panels: canonical declareRecords returns 0 when tokens missing', async () => {
+  const { declareRecords } = await import('../scripts/seed-token-panels.mjs');
+  assert.equal(declareRecords({}), 0);
+  assert.equal(declareRecords({ tokens: null }), 0);
+  assert.equal(declareRecords(null), 0);
+});
+
+test('seed-token-panels: per-extra-key declareRecords gets transformed AI/OTHER shape', async () => {
+  const { declareRecords } = await import('../scripts/seed-token-panels.mjs');
+  // After our fix, AI_KEY/OTHER_KEY extraKeys reuse canonical declareRecords.
+  // Each extra's transform returns data.ai or data.other — same {tokens, ...} shape.
+  const aiTransformed = { tokens: [{ symbol: 'FET' }, { symbol: 'AGIX' }, { symbol: 'OCEAN' }] };
+  const otherTransformed = { tokens: [{ symbol: 'DOGE' }] };
+  assert.equal(declareRecords(aiTransformed), 3, 'AI extra must count tokens correctly');
+  assert.equal(declareRecords(otherTransformed), 1, 'OTHER extra must count tokens correctly');
+});
+
+// ─── Commit B sanity: old bug reproduction ───────────────────────────────
+
+test('seed-token-panels: old buggy signature would have returned 0', async () => {
+  // This test documents what the PRE-fix code did, proving the RETRY bug. If
+  // declareRecords were *still* counting defi+ai+other from pre-transform
+  // fields on the transformed payload, it would return 0 and runSeed would
+  // RETRY. Keep this so anyone "simplifying" back to the old form fails.
+  const transformedDefi = { tokens: [{ symbol: 'UNI' }] };
+  const buggyOld = (data) =>
+    (data?.defi?.tokens?.length || 0) + (data?.ai?.tokens?.length || 0) + (data?.other?.tokens?.length || 0);
+  assert.equal(buggyOld(transformedDefi), 0, 'Pre-fix behavior — MUST NOT return to this');
+});
+
+// ─── Commit E: resolveRecordCount contract invariants ────────────────────
+
+test('resolveRecordCount: accepts 0 when declareRecords returns 0', () => {
+  assert.equal(resolveRecordCount(() => 0, {}), 0);
+});
+
+test('resolveRecordCount: throws on non-integer return', () => {
+  assert.throws(() => resolveRecordCount(() => 3.5, {}), /non-negative integer/);
+  assert.throws(() => resolveRecordCount(() => 'many', {}), /non-negative integer/);
+});
+
+// ─── Commit D: envelope unwrap on product-catalog cached shape ──────────
+
+test('unwrapEnvelope: contract-mode product-catalog payload returns bare {tiers,...}', () => {
+  const bare = { tiers: [{ id: 'pro', price: 12 }], fetchedAt: 1, cachedUntil: 2, priceSource: 'dodo' };
+  const enveloped = buildEnvelope({
+    fetchedAt: 1, recordCount: 1, sourceVersion: 'dodo-v1', schemaVersion: 1, state: 'OK',
+    data: bare,
+  });
+  const unwrapped = unwrapEnvelope(enveloped).data;
+  assert.deepEqual(unwrapped, bare, 'edge reader must return bare tiers shape, not {_seed, data}');
+});
+
+test('unwrapEnvelope: legacy bare product-catalog value passes through', () => {
+  const legacy = { tiers: [], fetchedAt: 100, cachedUntil: 200, priceSource: 'fallback' };
+  assert.deepEqual(unwrapEnvelope(legacy).data, legacy);
+});

--- a/tests/seed-contract-transform-regressions.test.mjs
+++ b/tests/seed-contract-transform-regressions.test.mjs
@@ -65,6 +65,46 @@ test('seed-token-panels: per-extra-key declareRecords gets transformed AI/OTHER 
   assert.equal(declareRecords(otherTransformed), 1, 'OTHER extra must count tokens correctly');
 });
 
+// ─── validateFn also runs on post-transform shape ────────────────────────
+//
+// atomicPublish() calls validateFn(publishData). A validate() written against
+// the pre-transform shape returns false on transformed input → skipped path →
+// no write. This bug survived the declareRecords fix because runSeed never
+// reached the RETRY branch — it exited earlier via `publishResult.skipped`.
+
+test('seed-token-panels: validate accepts transformed defi panel with priced tokens', async () => {
+  const { validate } = await import('../scripts/seed-token-panels.mjs');
+  const transformed = { tokens: [{ symbol: 'UNI', price: 12.3 }, { symbol: 'AAVE', price: 0 }] };
+  assert.equal(validate(transformed), true);
+});
+
+test('seed-token-panels: validate rejects transformed panel with zero-price tokens', async () => {
+  const { validate } = await import('../scripts/seed-token-panels.mjs');
+  const allZero = { tokens: [{ symbol: 'X', price: 0 }, { symbol: 'Y', price: 0 }] };
+  assert.equal(validate(allZero), false);
+});
+
+test('seed-token-panels: validate rejects empty/missing tokens', async () => {
+  const { validate } = await import('../scripts/seed-token-panels.mjs');
+  assert.equal(validate({ tokens: [] }), false);
+  assert.equal(validate({}), false);
+  assert.equal(validate(null), false);
+});
+
+test('seed-token-panels: pre-fix validate would have returned false on transformed shape', async () => {
+  // Repro-guard: if a future refactor puts validate() back to checking
+  // data.defi.tokens / data.ai.tokens / data.other.tokens, it will fail on
+  // the transformed payload (publishTransform narrows to the defi panel).
+  const transformed = { tokens: [{ symbol: 'UNI', price: 1 }] };
+  const buggyOld = (data) =>
+    Array.isArray(data?.defi?.tokens) &&
+    data.defi.tokens.length >= 1 &&
+    (data.defi.tokens.some((t) => t.price > 0) ||
+      data.ai.tokens.some((t) => t.price > 0) ||
+      data.other.tokens.some((t) => t.price > 0));
+  assert.equal(Boolean(buggyOld(transformed)), false, 'Pre-fix behavior — MUST NOT return to this');
+});
+
 // ─── Commit B sanity: old bug reproduction ───────────────────────────────
 
 test('seed-token-panels: old buggy signature would have returned 0', async () => {

--- a/tests/seed-utils-envelope-reads.test.mjs
+++ b/tests/seed-utils-envelope-reads.test.mjs
@@ -1,0 +1,73 @@
+// Regression tests for PR 2a: envelope-aware reads in _seed-utils.mjs.
+//
+// After contract mode enveloped 91 canonical Redis keys as {_seed, data}, any
+// internal reader that returned the raw parsed JSON silently started handing
+// callers the envelope instead of the bare payload. This test locks the fix:
+// redisGet / readSeedSnapshot / verifySeedKey all strip _seed and pass legacy
+// bare-shape values through unchanged.
+//
+// The helpers read a live Upstash instance via fetch, so we monkey-patch the
+// global fetch to return canned payloads without network I/O.
+
+import { test, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// Force env so getRedisCredentials() doesn't process.exit(1).
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+
+const { readSeedSnapshot, verifySeedKey } = await import('../scripts/_seed-utils.mjs');
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(upstashResult) {
+  globalThis.fetch = async () => ({
+    ok: true,
+    json: async () => ({ result: upstashResult == null ? null : JSON.stringify(upstashResult) }),
+  });
+}
+
+beforeEach(() => { /* per-test mock set inside test body */ });
+afterEach(() => { globalThis.fetch = originalFetch; });
+
+test('readSeedSnapshot: envelope-wrapped value returns inner data only', async () => {
+  mockFetch({
+    _seed: { fetchedAt: 1, recordCount: 3, sourceVersion: 'v1', schemaVersion: 1, state: 'OK' },
+    data: { countries: [{ code: 'US' }, { code: 'GB' }, { code: 'MY' }] },
+  });
+  const snap = await readSeedSnapshot('economic:bigmac:v1');
+  assert.deepEqual(snap, { countries: [{ code: 'US' }, { code: 'GB' }, { code: 'MY' }] });
+  assert.equal(snap._seed, undefined);
+});
+
+test('readSeedSnapshot: legacy bare-shape value passes through unchanged', async () => {
+  mockFetch({ countries: [{ code: 'US' }], fetchedAt: 1234 });
+  const snap = await readSeedSnapshot('economic:bigmac:v1');
+  assert.deepEqual(snap, { countries: [{ code: 'US' }], fetchedAt: 1234 });
+});
+
+test('readSeedSnapshot: null Upstash result returns null', async () => {
+  mockFetch(null);
+  assert.equal(await readSeedSnapshot('missing:key:v1'), null);
+});
+
+test('verifySeedKey: envelope-wrapped value returns inner data only', async () => {
+  mockFetch({
+    _seed: { fetchedAt: 1, recordCount: 1, sourceVersion: 'v1', schemaVersion: 1, state: 'OK' },
+    data: { normals: [{ zone: 'tropical' }] },
+  });
+  const value = await verifySeedKey('climate:zone-normals:v1');
+  assert.deepEqual(value, { normals: [{ zone: 'tropical' }] });
+});
+
+test('verifySeedKey: legacy bare-shape value passes through unchanged', async () => {
+  mockFetch({ fireDetections: [{ lat: 10, lon: 20 }] });
+  const value = await verifySeedKey('wildfire:fires:v1');
+  assert.deepEqual(value, { fireDetections: [{ lat: 10, lon: 20 }] });
+});
+
+test('verifySeedKey: truthy semantics hold for presence check', async () => {
+  mockFetch({ _seed: { fetchedAt: 1, recordCount: 0, sourceVersion: 'v1', schemaVersion: 1, state: 'OK_ZERO' }, data: {} });
+  const value = await verifySeedKey('any:key:v1');
+  assert.ok(value); // non-null — runSeed's post-write verify still works
+});

--- a/tests/ucdp-seed-resilience.test.mjs
+++ b/tests/ucdp-seed-resilience.test.mjs
@@ -70,7 +70,10 @@ describe('UCDP seed resilience branches', () => {
     const publishSection = fnBody.slice(fnBody.indexOf('const payload = {'));
     assert.match(
       publishSection,
-      /upstashSet\(UCDP_REDIS_KEY,\s*payload/,
+      // Accept both the pre-contract `upstashSet(KEY, payload, ...)` shape and
+      // the post-contract `envelopeWrite(KEY, payload, ...)` shape — dual
+      // form is part of the seed-contract PR 2 envelope migration.
+      /(?:upstashSet|envelopeWrite)\(UCDP_REDIS_KEY,\s*payload/,
       'Should write payload to UCDP key',
     );
     assert.match(


### PR DESCRIPTION
## Summary

Full Unified Seed Contract PR 2 — writers, readers, bundles, direct writers, all in dual-write mode. Builds on PR #3095 (foundation).

## What's in this PR (8 commits)

1. **`runSeed` contract mode** + **91 seeders migrated** — every `scripts/seed-*.mjs` exports `declareRecords` and writes `{_seed, data}` envelope to canonical key alongside legacy `seed-meta:*`.
2. **Internal reader unwrap** — `readSeedSnapshot`, `verifySeedKey`, `redisGet`, 18 seeders' local helpers, `seed-forecasts` pipeline batch, `seed-energy-spine` redisMget. Addresses both P1 findings from review.
3. **External reader unwrap** — `server/_shared/redis.ts` (`getRawJson`, `getCachedJson`, `getCachedJsonBatch`, inherited by `cachedFetchJson`), `api/_upstash-json.js` (`readJsonFromUpstash` → covers all `api/mcp.ts` tool responses), `api/bootstrap.js` batch reader.
4. **3 more server-side readers unwrap** — `resilience/v1/_shared.ts` + `get-resilience-ranking.ts` + `infrastructure/v1/_shared.ts:mgetJson`.
5. **`consumer-prices-core/src/jobs/publish.ts`** — 5 canonical keys (overview, movers 7d/30d, freshness, categories 7d/30d/90d, retailer-spread, basket-series) now produce envelopes.
6. **`scripts/ais-relay.cjs`** — 32 canonical-key write sites produce envelopes via `envelopeWrite(key, data, ttl, meta)` helper.
7. **15 seed-bundle-*.mjs** — 54 sections across 12 bundles declare `canonicalKey` alongside `seedMetaKey`. `_bundle-runner.mjs` prefers canonicalKey, gates on envelope `_seed.fetchedAt` directly.
8. **Tests** — new `tests/seed-utils-envelope-reads.test.mjs` (7 cases); updated `tests/cross-source-signals-regulatory.test.mjs` + `tests/ucdp-seed-resilience.test.mjs` for static-analysis pattern changes.

## Verification

- [x] `npm run test:data` — **5307/5307 pass**
- [x] `npm run typecheck:all` — clean
- [x] `node --check` clean on every modified script
- [x] Contract conformance: 84/86 seeders full descriptor (2 pre-existing soft-warns)
- [x] Post-sweep grep for unwrapped `JSON.parse(redis_result)` in api/server — no regressions remain
- [ ] Staging dry-run: deploy 2-3 seeders to Railway cron, verify envelope shape + legacy seed-meta both populated

## Dual-write invariant (PR 2 phase)

Every seeder now writes:
- **Envelope** to canonical data key (new, source of truth going forward)
- **Legacy** `seed-meta:<domain>:<resource>` (preserved, keeps `api/health.js` + any unmigrated reader happy)

Every reader (`getCachedJson`, `readJsonFromUpstash`, `readSeedSnapshot`, etc.) now unwraps envelopes automatically — legacy bare-shape values pass through unchanged.

## What PR 3 does (not in this PR)

- Stop writing legacy `seed-meta:*` keys.
- Collapse `api/health.js` 5-registry system (`SEED_META`, `ON_DEMAND_KEYS`, `EMPTY_DATA_OK_KEYS`, `STANDALONE_KEYS`, `BOOTSTRAP_KEYS`, `CASCADE_GROUPS`) to single `SEEDS` registry. Deferred because it requires switching health from STRLEN to GET on ~100 data keys (operational risk: doubles Upstash payload per check). Cleaner once legacy is gone.
- Remove fallback branches in readers.
- Delete `writeSeedMeta` / `writeFreshnessMetadata` helpers.

## Test plan

- [x] Unit tests pass
- [ ] Staging deploy & verify `/api/health` reports no regression
- [ ] Spot-check envelope shape: `economic:fsi-eu:v1`, `climate:zone-normals:v1`, `wildfire:fires:v1`, `market:commodities:v1:...`, `consumer-prices:overview:ae`
- [ ] Verify `api/bootstrap` + `api/mcp` responses contain no `_seed` field

Plan: `docs/plans/2026-04-14-002-fix-runseed-zero-record-lockout-plan.md`