### PR TITLE
fix(consumer-prices): count risers+fallers in movers recordCount

### DIFF
--- a/consumer-prices-core/src/jobs/publish.ts
+++ b/consumer-prices-core/src/jobs/publish.ts
@@ -27,7 +27,12 @@ function makeKey(parts: string[]): string {
 function recordCount(data: unknown): number {
   if (!data || typeof data !== 'object') return 1;
   const d = data as Record<string, unknown>;
-  const arr = d.retailers ?? d.risers ?? d.essentialsSeries ?? d.categories;
+  if (Array.isArray(d.risers) || Array.isArray(d.fallers)) {
+    const risers = Array.isArray(d.risers) ? d.risers.length : 0;
+    const fallers = Array.isArray(d.fallers) ? d.fallers.length : 0;
+    return risers + fallers;
+  }
+  const arr = d.retailers ?? d.essentialsSeries ?? d.categories;
   return Array.isArray(arr) ? arr.length : 1;
 }
 

--- a/consumer-prices-core/src/jobs/publish.ts
+++ b/consumer-prices-core/src/jobs/publish.ts
@@ -30,7 +30,10 @@ function recordCount(data: unknown): number {
   if (Array.isArray(d.risers) || Array.isArray(d.fallers)) {
     const risers = Array.isArray(d.risers) ? d.risers.length : 0;
     const fallers = Array.isArray(d.fallers) ? d.fallers.length : 0;
-    return risers + fallers;
+    // Movers is bipolar and a fully-flat window (risers=0, fallers=0) is still a
+    // valid snapshot. advanceSeedMeta already gates writes on upstream freshness,
+    // so floor at 1 here to prevent health from flagging EMPTY_DATA on quiet markets.
+    return Math.max(1, risers + fallers);
   }
   const arr = d.retailers ?? d.essentialsSeries ?? d.categories;
   return Array.isArray(arr) ? arr.length : 1;

--- a/scripts/seed-consumer-prices.mjs
+++ b/scripts/seed-consumer-prices.mjs
@@ -198,7 +198,11 @@ async function run() {
   for (const { key, data, ttl, metaKey } of writes) {
     try {
       let recordCount;
-      if (Array.isArray(data.risers) || Array.isArray(data.fallers)) {
+      if (data.upstreamUnavailable === true) {
+        // Synthetic placeholder written when upstream fetch failed — keep
+        // recordCount=0 so health.js surfaces EMPTY_DATA instead of going green.
+        recordCount = 0;
+      } else if (Array.isArray(data.risers) || Array.isArray(data.fallers)) {
         const sum = (data.risers?.length ?? 0) + (data.fallers?.length ?? 0);
         recordCount = Math.max(1, sum);
       } else if (Array.isArray(data.retailers ?? data.essentialsSeries ?? data.categories)) {

--- a/scripts/seed-consumer-prices.mjs
+++ b/scripts/seed-consumer-prices.mjs
@@ -197,9 +197,14 @@ async function run() {
   let failed = 0;
   for (const { key, data, ttl, metaKey } of writes) {
     try {
-      const recordCount = Array.isArray(data.retailers ?? data.categories ?? data.risers)
-        ? (data.retailers ?? data.categories ?? data.risers ?? []).length
-        : 1;
+      let recordCount;
+      if (Array.isArray(data.risers) || Array.isArray(data.fallers)) {
+        recordCount = (data.risers?.length ?? 0) + (data.fallers?.length ?? 0);
+      } else if (Array.isArray(data.retailers ?? data.categories)) {
+        recordCount = (data.retailers ?? data.categories).length;
+      } else {
+        recordCount = 1;
+      }
       await writeExtraKeyWithMeta(key, data, ttl, recordCount, metaKey);
       console.log(`  [consumer-prices] wrote ${key} (${recordCount} records)`);
     } catch (err) {

--- a/scripts/seed-consumer-prices.mjs
+++ b/scripts/seed-consumer-prices.mjs
@@ -199,9 +199,10 @@ async function run() {
     try {
       let recordCount;
       if (Array.isArray(data.risers) || Array.isArray(data.fallers)) {
-        recordCount = (data.risers?.length ?? 0) + (data.fallers?.length ?? 0);
-      } else if (Array.isArray(data.retailers ?? data.categories)) {
-        recordCount = (data.retailers ?? data.categories).length;
+        const sum = (data.risers?.length ?? 0) + (data.fallers?.length ?? 0);
+        recordCount = Math.max(1, sum);
+      } else if (Array.isArray(data.retailers ?? data.essentialsSeries ?? data.categories)) {
+        recordCount = (data.retailers ?? data.essentialsSeries ?? data.categories).length;
       } else {
         recordCount = 1;
       }


### PR DESCRIPTION
## Summary
- Health endpoint reported `consumerPricesMovers` as `EMPTY_DATA` whenever the 30d window had zero risers, because `recordCount()` in `publish.ts` used `d.retailers ?? d.risers ?? d.essentialsSeries ?? d.categories` — a `??` chain that picks only one sibling array.
- Movers payloads are bipolar (`risers[]` + `fallers[]`). A valid all-fallers market registered as 0 records and tripped a false staleness alarm.
- Fix both the authoritative publish job (`consumer-prices-core/src/jobs/publish.ts`) and the manual fallback seed script (`scripts/seed-consumer-prices.mjs`) to sum `risers.length + fallers.length` when either array is present.

## Test plan
- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `npm run lint` (0 errors)
- [x] `npm run test:data` (5301 pass)
- [x] `node --test tests/edge-functions.test.mjs` (167 pass)
- [x] Edge bundle check across `api/*.js`
- [x] `npm run lint:md` + `npm run version:check`
- [ ] Verify post-merge: after next publish.ts cron (02:30 UTC daily), `seed-meta:consumer-prices:movers:ae:30d` shows non-zero `recordCount` and health status flips OK.