### PR TITLE
fix(middleware): allow /api/seed-contract-probe to bypass bot UA filter

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -6,7 +6,15 @@ const SOCIAL_PREVIEW_UA =
 
 const SOCIAL_PREVIEW_PATHS = new Set(['/api/story', '/api/og-story']);
 
-const PUBLIC_API_PATHS = new Set(['/api/version', '/api/health']);
+// Paths that bypass bot/script UA filtering below. Each must carry its own
+// auth (API key, shared secret, or intentionally-public semantics) because
+// this list disables the middleware's generic bot gate.
+// - /api/version, /api/health: intentionally public, monitoring-friendly.
+// - /api/seed-contract-probe: requires RELAY_SHARED_SECRET header; called by
+//   UptimeRobot + ops curl. Was blocked by the curl/bot UA regex before this
+//   exception landed (Vercel log 2026-04-15: "Middleware 403 Forbidden" on
+//   /api/seed-contract-probe).
+const PUBLIC_API_PATHS = new Set(['/api/version', '/api/health', '/api/seed-contract-probe']);
 
 const SOCIAL_IMAGE_UA =
   /Slack-ImgProxy|Slackbot|twitterbot|facebookexternalhit|linkedinbot|telegrambot|whatsapp|discordbot|redditbot/i;


### PR DESCRIPTION
## Summary

Unblocks the seed-contract probe endpoint (shipped in PR #3097) for UptimeRobot monitoring and ops curl calls.

Vercel Inspector logs on `api.worldmonitor.app/api/seed-contract-probe` showed:

```
Firewall:   bypass
Middleware: 403 Forbidden   ← this commit fixes
```

`middleware.ts`'s `BOT_UA` regex matches \`curl/\`, \`bot\`, and many scanner UAs, so both ops curl (`curl/8.x`) and UptimeRobot's UA got 403'd before reaching the handler — even though the probe has its own `RELAY_SHARED_SECRET` auth that makes the UA check redundant.

Fix: add `/api/seed-contract-probe` to `PUBLIC_API_PATHS` (joining `/api/version` and `/api/health`). Safe because:

- The endpoint enforces `x-probe-secret` matches `RELAY_SHARED_SECRET` internally.
- Bypassing the generic bot UA filter does not reduce security for this specific path.

Also added a comment above the allowlist spelling out the invariant: entries must carry their own auth because this list disables the middleware's generic bot gate.

## Test plan

- [x] `npm run typecheck:all` — clean
- [ ] Post-merge, verify from ops machine:
  ```
  curl -i -H "x-probe-secret: $RELAY_SHARED_SECRET" \
    https://api.worldmonitor.app/api/seed-contract-probe
  ```
  Expected: 200 (if seeders have cycled post-#3097) or 503 with failing `checks` list. Not 403.
- [ ] Point UptimeRobot at the endpoint per the monitoring setup in `docs/plans/2026-04-14-002-fix-runseed-zero-record-lockout-plan.md`.