### PR TITLE
fix(seed-contract-probe): send Origin header so /api/bootstrap boundary check doesn't 401

### DIFF
--- a/api/seed-contract-probe.ts
+++ b/api/seed-contract-probe.ts
@@ -163,7 +163,15 @@ const BOUNDARY_CHECKS: BoundaryCheck[] = [
 export async function checkPublicBoundary(origin: string): Promise<BoundaryResult[]> {
   return Promise.all(BOUNDARY_CHECKS.map(async ({ endpoint, requireSourceHeader }): Promise<BoundaryResult> => {
     try {
-      const r = await fetch(`${origin}${endpoint}`, { signal: AbortSignal.timeout(5_000) });
+      // Send Origin of the canonical public host so endpoints that gate
+      // behind validateApiKey() (e.g. /api/bootstrap) take the trusted-browser
+      // branch instead of demanding an API key. The probe runs edge-side with
+      // internal auth; we intentionally emulate a trusted browser for boundary
+      // verification only.
+      const r = await fetch(`${origin}${endpoint}`, {
+        signal: AbortSignal.timeout(5_000),
+        headers: { Origin: 'https://worldmonitor.app' },
+      });
       const text = await r.text();
       // Detect any envelope leak in the response body. A substring match on
       // the literal `"_seed":` is sufficient because `_seed` only appears on

--- a/api/seed-contract-probe.ts
+++ b/api/seed-contract-probe.ts
@@ -170,7 +170,10 @@ export async function checkPublicBoundary(origin: string): Promise<BoundaryResul
       // verification only.
       const r = await fetch(`${origin}${endpoint}`, {
         signal: AbortSignal.timeout(5_000),
-        headers: { Origin: 'https://worldmonitor.app' },
+        headers: {
+          Origin: 'https://worldmonitor.app',
+          'User-Agent': 'WorldMonitor-SeedContractProbe/1.0',
+        },
       });
       const text = await r.text();
       // Detect any envelope leak in the response body. A substring match on


### PR DESCRIPTION
## Summary

Production probe output:
\`\`\`
"boundary": [
  { "endpoint": "/api/product-catalog", "pass": true, "status": 200 },
  { "endpoint": "/api/bootstrap",       "pass": false, "status": 401, "reason": "status:401" }
]
\`\`\`

Root cause: `checkPublicBoundary` self-fetch sent no `Origin` header, so `/api/bootstrap`'s `validateApiKey()` treated it as a non-browser caller and required an API key.

Fix: send `Origin: https://worldmonitor.app` on the boundary self-fetch. Takes the trusted-browser path without needing to embed an API key in the probe.

The probe still runs edge-side with `x-probe-secret` internal auth; emulating a trusted browser is only for boundary response-shape verification (envelope-leak detection + cache-header check on product-catalog).

## Test plan

- [x] `npx tsx --test tests/seed-contract-probe.test.mjs` → 17/17
- [x] `npm run typecheck:api` — clean
- [ ] Post-deploy, probe's boundary `/api/bootstrap` returns `pass: true, status: 200`.