### PR TITLE
feat(consumer-prices): strict search-hit validator (shadow mode)

### DIFF
--- a/consumer-prices-core/configs/baskets/essentials_ae.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_ae.yaml
@@ -102,7 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
-      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "powdered"]
 
     - id: cheese_processed_200g
       category: dairy

--- a/consumer-prices-core/configs/baskets/essentials_ae.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_ae.yaml
@@ -72,6 +72,7 @@ basket:
       substitutionGroup: tomatoes
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["chopped", "peeled", "sauce", "paste", "canned", "puree", "sundried"]
 
     - id: onions_1kg
       category: onions
@@ -81,6 +82,7 @@ basket:
       substitutionGroup: onions
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["powder", "flakes", "rings", "pickled", "seeds", "sets"]
 
     - id: water_1_5l
       category: water
@@ -90,6 +92,7 @@ basket:
       substitutionGroup: water_still
       minBaseQty: 1400
       maxBaseQty: 1600
+      negativeTokens: ["sparkling", "flavored", "flavoured"]
 
     - id: sugar_1kg
       category: sugar
@@ -99,6 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
 
     - id: cheese_processed_200g
       category: dairy
@@ -108,6 +112,7 @@ basket:
       substitutionGroup: cheese_processed
       minBaseQty: 150
       maxBaseQty: 250
+      negativeTokens: ["vegan", "gouda", "cheddar", "parmesan", "mozzarella", "feta"]
 
     - id: yogurt_500g
       category: dairy
@@ -117,3 +122,4 @@ basket:
       substitutionGroup: yogurt_plain
       minBaseQty: 450
       maxBaseQty: 550
+      negativeTokens: ["drink", "drinking", "plant-based", "vegan", "greek", "fruit"]

--- a/consumer-prices-core/configs/baskets/essentials_au.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_au.yaml
@@ -72,6 +72,7 @@ basket:
       substitutionGroup: tomatoes
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["chopped", "peeled", "sauce", "paste", "canned", "puree", "sundried"]
 
     - id: onions_1kg
       category: onions
@@ -81,6 +82,7 @@ basket:
       substitutionGroup: onions
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["powder", "flakes", "rings", "pickled", "seeds", "sets"]
 
     - id: water_1_5l
       category: water
@@ -90,6 +92,7 @@ basket:
       substitutionGroup: water_still
       minBaseQty: 1300
       maxBaseQty: 1700
+      negativeTokens: ["sparkling", "flavored", "flavoured"]
 
     - id: sugar_1kg
       category: sugar
@@ -99,6 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
 
     - id: cheese_cheddar_500g
       category: dairy
@@ -117,3 +121,4 @@ basket:
       substitutionGroup: yogurt_plain
       minBaseQty: 450
       maxBaseQty: 550
+      negativeTokens: ["drink", "drinking", "plant-based", "vegan", "greek", "fruit"]

--- a/consumer-prices-core/configs/baskets/essentials_au.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_au.yaml
@@ -102,7 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
-      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "powdered"]
 
     - id: cheese_cheddar_500g
       category: dairy

--- a/consumer-prices-core/configs/baskets/essentials_br.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_br.yaml
@@ -102,7 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
-      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "powdered"]
 
     - id: yogurt_500g
       category: dairy

--- a/consumer-prices-core/configs/baskets/essentials_br.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_br.yaml
@@ -72,6 +72,7 @@ basket:
       substitutionGroup: tomatoes
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["chopped", "peeled", "sauce", "paste", "canned", "puree", "sundried"]
 
     - id: onions_1kg
       category: onions
@@ -81,6 +82,7 @@ basket:
       substitutionGroup: onions
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["powder", "flakes", "rings", "pickled", "seeds", "sets"]
 
     - id: water_1_5l
       category: water
@@ -90,6 +92,7 @@ basket:
       substitutionGroup: water_still
       minBaseQty: 1300
       maxBaseQty: 1700
+      negativeTokens: ["sparkling", "flavored", "flavoured"]
 
     - id: sugar_1kg
       category: sugar
@@ -99,6 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
 
     - id: yogurt_500g
       category: dairy
@@ -108,3 +112,4 @@ basket:
       substitutionGroup: yogurt_plain
       minBaseQty: 450
       maxBaseQty: 550
+      negativeTokens: ["drink", "drinking", "plant-based", "vegan", "greek", "fruit"]

--- a/consumer-prices-core/configs/baskets/essentials_ch.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_ch.yaml
@@ -72,6 +72,7 @@ basket:
       substitutionGroup: tomatoes
       minBaseQty: 400
       maxBaseQty: 600
+      negativeTokens: ["chopped", "peeled", "sauce", "paste", "canned", "puree", "sundried"]
 
     - id: onions_1kg
       category: onions
@@ -81,6 +82,7 @@ basket:
       substitutionGroup: onions
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["powder", "flakes", "rings", "pickled", "seeds", "sets"]
 
     - id: water_1_5l
       category: water
@@ -90,6 +92,7 @@ basket:
       substitutionGroup: water_still
       minBaseQty: 1300
       maxBaseQty: 1700
+      negativeTokens: ["sparkling", "flavored", "flavoured"]
 
     - id: sugar_1kg
       category: sugar
@@ -99,6 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
 
     - id: cheese_200g
       category: dairy
@@ -117,3 +121,4 @@ basket:
       substitutionGroup: yogurt_plain
       minBaseQty: 450
       maxBaseQty: 550
+      negativeTokens: ["drink", "drinking", "plant-based", "vegan", "greek", "fruit"]

--- a/consumer-prices-core/configs/baskets/essentials_ch.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_ch.yaml
@@ -102,7 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
-      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "powdered"]
 
     - id: cheese_200g
       category: dairy

--- a/consumer-prices-core/configs/baskets/essentials_gb.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_gb.yaml
@@ -102,7 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
-      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "powdered"]
 
     - id: cheese_cheddar_400g
       category: dairy

--- a/consumer-prices-core/configs/baskets/essentials_gb.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_gb.yaml
@@ -72,6 +72,7 @@ basket:
       substitutionGroup: tomatoes
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["chopped", "peeled", "sauce", "paste", "canned", "puree", "sundried"]
 
     - id: onions_1kg
       category: onions
@@ -81,6 +82,7 @@ basket:
       substitutionGroup: onions
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["powder", "flakes", "rings", "pickled", "seeds", "sets"]
 
     - id: water_1_5l
       category: water
@@ -90,6 +92,7 @@ basket:
       substitutionGroup: water_still
       minBaseQty: 7000
       maxBaseQty: 10000
+      negativeTokens: ["sparkling", "flavored", "flavoured"]
 
     - id: sugar_1kg
       category: sugar
@@ -99,6 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
 
     - id: cheese_cheddar_400g
       category: dairy
@@ -117,3 +121,4 @@ basket:
       substitutionGroup: yogurt_plain
       minBaseQty: 450
       maxBaseQty: 550
+      negativeTokens: ["drink", "drinking", "plant-based", "vegan", "greek", "fruit"]

--- a/consumer-prices-core/configs/baskets/essentials_in.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_in.yaml
@@ -72,6 +72,7 @@ basket:
       substitutionGroup: tomatoes
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["chopped", "peeled", "sauce", "paste", "canned", "puree", "sundried"]
 
     - id: onions_1kg
       category: onions
@@ -81,6 +82,7 @@ basket:
       substitutionGroup: onions
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["powder", "flakes", "rings", "pickled", "seeds", "sets"]
 
     - id: water_1l
       category: water
@@ -90,6 +92,7 @@ basket:
       substitutionGroup: water_still
       minBaseQty: 900
       maxBaseQty: 1100
+      negativeTokens: ["sparkling", "flavored", "flavoured"]
 
     - id: sugar_1kg
       category: sugar
@@ -99,6 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
 
     - id: paneer_200g
       category: dairy
@@ -117,3 +121,4 @@ basket:
       substitutionGroup: yogurt_plain
       minBaseQty: 350
       maxBaseQty: 450
+      negativeTokens: ["drink", "drinking", "plant-based", "vegan", "greek", "fruit"]

--- a/consumer-prices-core/configs/baskets/essentials_in.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_in.yaml
@@ -102,7 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
-      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "powdered"]
 
     - id: paneer_200g
       category: dairy

--- a/consumer-prices-core/configs/baskets/essentials_ke.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_ke.yaml
@@ -102,7 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
-      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "powdered"]
 
     - id: cheese_processed_200g
       category: dairy

--- a/consumer-prices-core/configs/baskets/essentials_ke.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_ke.yaml
@@ -72,6 +72,7 @@ basket:
       substitutionGroup: tomatoes
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["chopped", "peeled", "sauce", "paste", "canned", "puree", "sundried"]
 
     - id: onions_1kg
       category: onions
@@ -81,6 +82,7 @@ basket:
       substitutionGroup: onions
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["powder", "flakes", "rings", "pickled", "seeds", "sets"]
 
     - id: water_1_5l
       category: water
@@ -90,6 +92,7 @@ basket:
       substitutionGroup: water_still
       minBaseQty: 1300
       maxBaseQty: 1700
+      negativeTokens: ["sparkling", "flavored", "flavoured"]
 
     - id: sugar_1kg
       category: sugar
@@ -99,6 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
 
     - id: cheese_processed_200g
       category: dairy
@@ -108,6 +112,7 @@ basket:
       substitutionGroup: cheese_processed
       minBaseQty: 150
       maxBaseQty: 250
+      negativeTokens: ["vegan", "gouda", "cheddar", "parmesan", "mozzarella", "feta"]
 
     - id: yogurt_500g
       category: dairy
@@ -117,3 +122,4 @@ basket:
       substitutionGroup: yogurt_plain
       minBaseQty: 450
       maxBaseQty: 550
+      negativeTokens: ["drink", "drinking", "plant-based", "vegan", "greek", "fruit"]

--- a/consumer-prices-core/configs/baskets/essentials_sa.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_sa.yaml
@@ -102,7 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
-      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "powdered"]
 
     - id: cheese_processed_200g
       category: dairy

--- a/consumer-prices-core/configs/baskets/essentials_sa.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_sa.yaml
@@ -72,6 +72,7 @@ basket:
       substitutionGroup: tomatoes
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["chopped", "peeled", "sauce", "paste", "canned", "puree", "sundried"]
 
     - id: onions_1kg
       category: onions
@@ -81,6 +82,7 @@ basket:
       substitutionGroup: onions
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["powder", "flakes", "rings", "pickled", "seeds", "sets"]
 
     - id: water_1_5l
       category: water
@@ -90,6 +92,7 @@ basket:
       substitutionGroup: water_still
       minBaseQty: 1400
       maxBaseQty: 1600
+      negativeTokens: ["sparkling", "flavored", "flavoured"]
 
     - id: sugar_1kg
       category: sugar
@@ -99,6 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
 
     - id: cheese_processed_200g
       category: dairy
@@ -108,6 +112,7 @@ basket:
       substitutionGroup: cheese_processed
       minBaseQty: 150
       maxBaseQty: 250
+      negativeTokens: ["vegan", "gouda", "cheddar", "parmesan", "mozzarella", "feta"]
 
     - id: yogurt_500g
       category: dairy
@@ -117,3 +122,4 @@ basket:
       substitutionGroup: yogurt_plain
       minBaseQty: 450
       maxBaseQty: 550
+      negativeTokens: ["drink", "drinking", "plant-based", "vegan", "greek", "fruit"]

--- a/consumer-prices-core/configs/baskets/essentials_sg.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_sg.yaml
@@ -72,6 +72,7 @@ basket:
       substitutionGroup: tomatoes
       minBaseQty: 400
       maxBaseQty: 600
+      negativeTokens: ["chopped", "peeled", "sauce", "paste", "canned", "puree", "sundried"]
 
     - id: onions_500g
       category: onions
@@ -81,6 +82,7 @@ basket:
       substitutionGroup: onions
       minBaseQty: 400
       maxBaseQty: 600
+      negativeTokens: ["powder", "flakes", "rings", "pickled", "seeds", "sets"]
 
     - id: water_1_5l
       category: water
@@ -90,6 +92,7 @@ basket:
       substitutionGroup: water_still
       minBaseQty: 1300
       maxBaseQty: 1700
+      negativeTokens: ["sparkling", "flavored", "flavoured"]
 
     - id: sugar_1kg
       category: sugar
@@ -99,6 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
 
     - id: cheese_200g
       category: dairy
@@ -108,6 +112,7 @@ basket:
       substitutionGroup: cheese_processed
       minBaseQty: 150
       maxBaseQty: 250
+      negativeTokens: ["vegan", "gouda", "cheddar", "parmesan", "mozzarella", "feta"]
 
     - id: yogurt_500g
       category: dairy
@@ -117,3 +122,4 @@ basket:
       substitutionGroup: yogurt_plain
       minBaseQty: 450
       maxBaseQty: 550
+      negativeTokens: ["drink", "drinking", "plant-based", "vegan", "greek", "fruit"]

--- a/consumer-prices-core/configs/baskets/essentials_sg.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_sg.yaml
@@ -102,7 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 900
       maxBaseQty: 1100
-      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "powdered"]
 
     - id: cheese_200g
       category: dairy

--- a/consumer-prices-core/configs/baskets/essentials_us.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_us.yaml
@@ -72,6 +72,7 @@ basket:
       substitutionGroup: tomatoes
       minBaseQty: 800
       maxBaseQty: 1200
+      negativeTokens: ["chopped", "peeled", "sauce", "paste", "canned", "puree", "sundried"]
 
     - id: onions_1kg
       category: onions
@@ -81,6 +82,7 @@ basket:
       substitutionGroup: onions
       minBaseQty: 1000
       maxBaseQty: 1600
+      negativeTokens: ["powder", "flakes", "rings", "pickled", "seeds", "sets"]
 
     - id: water_1_5l
       category: water
@@ -90,6 +92,7 @@ basket:
       substitutionGroup: water_still
       minBaseQty: 6000
       maxBaseQty: 10000
+      negativeTokens: ["sparkling", "flavored", "flavoured"]
 
     - id: sugar_1kg
       category: sugar
@@ -99,6 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 1600
       maxBaseQty: 2000
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
 
     - id: cheese_cheddar_200g
       category: dairy
@@ -117,3 +121,4 @@ basket:
       substitutionGroup: yogurt_plain
       minBaseQty: 800
       maxBaseQty: 1000
+      negativeTokens: ["drink", "drinking", "plant-based", "vegan", "greek", "fruit"]

--- a/consumer-prices-core/configs/baskets/essentials_us.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_us.yaml
@@ -102,7 +102,7 @@ basket:
       substitutionGroup: sugar_white
       minBaseQty: 1600
       maxBaseQty: 2000
-      negativeTokens: ["brown", "baby", "mascavo", "sachets", "cane", "powdered"]
+      negativeTokens: ["brown", "baby", "mascavo", "sachets", "powdered"]
 
     - id: cheese_cheddar_200g
       category: dairy

--- a/consumer-prices-core/migrations/008_candidate_match_status.sql
+++ b/consumer-prices-core/migrations/008_candidate_match_status.sql
@@ -1,0 +1,10 @@
+-- Widen product_matches.match_status to include 'candidate' — the state written
+-- for weak search hits that must not enter aggregates but whose evidence we
+-- still want to keep so the next scrape doesn't re-pay the same Exa/Firecrawl
+-- cost. Readers that filter on ('auto','approved') naturally exclude candidates.
+
+ALTER TABLE product_matches DROP CONSTRAINT IF EXISTS product_matches_match_status_check;
+
+ALTER TABLE product_matches
+  ADD CONSTRAINT product_matches_match_status_check
+  CHECK (match_status IN ('auto','review','approved','rejected','candidate'));

--- a/consumer-prices-core/src/adapters/search.ts
+++ b/consumer-prices-core/src/adapters/search.ts
@@ -20,6 +20,8 @@ import type { RetailerConfig } from '../config/types.js';
 import type { AdapterContext, FetchResult, ParsedProduct, RetailerAdapter, Target } from './types.js';
 import { MARKET_NAMES } from './market-names.js';
 import { parseSize } from '../normalizers/size.js';
+import { validateSearchHit, type ValidatorResult } from './validator.js';
+import type { BasketItem } from '../config/types.js';
 
 /** Packaging/container words that are not product identity tokens. */
 const PACKAGING_WORDS = new Set(['pack', 'box', 'bag', 'container', 'bottle', 'can', 'jar', 'tin', 'set', 'kit', 'bundle']);
@@ -93,12 +95,16 @@ interface ExtractedProduct {
   sizeText?: string;
 }
 
+type ItemConstraints = Pick<BasketItem, 'baseUnit' | 'minBaseQty' | 'maxBaseQty' | 'negativeTokens' | 'substitutionGroup'>;
+
 interface SearchPayload {
   extracted: ExtractedProduct;
   productUrl: string;
   canonicalName: string;
   basketSlug: string;
   itemCategory: string;
+  itemConstraints: ItemConstraints;
+  validator?: ValidatorResult;
   direct?: boolean;
   pinnedProductId?: string;
   matchId?: string;
@@ -127,6 +133,13 @@ export class SearchAdapter implements RetailerAdapter {
       for (const item of basket.items) {
         const pinKey = `${basket.slug}:${item.canonicalName}`;
         const pinned = ctx.pinnedUrls?.get(pinKey);
+        const itemConstraints: ItemConstraints = {
+          baseUnit: item.baseUnit,
+          minBaseQty: item.minBaseQty,
+          maxBaseQty: item.maxBaseQty,
+          negativeTokens: item.negativeTokens,
+          substitutionGroup: item.substitutionGroup,
+        };
 
         if (pinned && isAllowedHost(pinned.sourceUrl, domain)) {
           targets.push({
@@ -138,6 +151,7 @@ export class SearchAdapter implements RetailerAdapter {
               domain,
               basketSlug: basket.slug,
               currency: ctx.config.currencyCode,
+              itemConstraints,
               direct: true,
               pinnedProductId: pinned.productId,
               matchId: pinned.matchId,
@@ -156,6 +170,7 @@ export class SearchAdapter implements RetailerAdapter {
               domain,
               basketSlug: basket.slug,
               currency: ctx.config.currencyCode,
+              itemConstraints,
               direct: false,
             },
           });
@@ -171,7 +186,8 @@ export class SearchAdapter implements RetailerAdapter {
     url: string,
     canonicalName: string,
     currency: string,
-  ): Promise<ExtractedProduct | null> {
+    itemConstraints?: ItemConstraints,
+  ): Promise<{ extracted: ExtractedProduct; validator: ValidatorResult } | null> {
     const sizeHint = extractSizeHint(canonicalName);
     const sizeClause = sizeHint
       ? ` You are looking for "${canonicalName}". The product MUST be ${sizeHint}. If the page shows a different size, pack count, or bulk case, return null for price.`
@@ -195,7 +211,25 @@ export class SearchAdapter implements RetailerAdapter {
     if (typeof price !== 'number' || !Number.isFinite(price) || price <= 0) {
       return null;
     }
-    if (!isTitlePlausible(canonicalName, data.productName)) {
+    const legacyPass = isTitlePlausible(canonicalName, data.productName);
+    const validator = validateSearchHit({
+      canonicalName,
+      productName: data.productName,
+      sizeText: data.sizeText,
+      item: itemConstraints ?? { baseUnit: '' },
+    });
+
+    // Shadow-mode: the strict validator runs alongside the legacy boolean gate
+    // but does NOT block a hit on its own yet. When validator.ok=false and
+    // legacy would have accepted, log a wouldReject with reasons so the diff
+    // report can inform the rollout decision to flip the hard gate.
+    if (legacyPass && !validator.ok) {
+      ctx.logger.warn(
+        `  [search:shadow-reject] "${canonicalName}" would reject productName="${data.productName}" reasons=${validator.reasons.join(',')} score=${validator.score.toFixed(2)}`,
+      );
+    }
+
+    if (!legacyPass) {
       return null;
     }
 
@@ -206,15 +240,16 @@ export class SearchAdapter implements RetailerAdapter {
       data.inStock = true;
     }
 
-    return data;
+    return { extracted: data, validator };
   }
 
   async fetchTarget(ctx: AdapterContext, target: Target): Promise<FetchResult> {
-    const { canonicalName, domain, currency, basketSlug, direct, pinnedProductId, matchId } = target.metadata as {
+    const { canonicalName, domain, currency, basketSlug, itemConstraints, direct, pinnedProductId, matchId } = target.metadata as {
       canonicalName: string;
       domain: string;
       currency: string;
       basketSlug: string;
+      itemConstraints: ItemConstraints;
       direct: boolean;
       pinnedProductId?: string;
       matchId?: string;
@@ -223,19 +258,21 @@ export class SearchAdapter implements RetailerAdapter {
     // Direct path: skip Exa, call Firecrawl on pinned URL
     if (direct) {
       try {
-        const extracted = await this._extractFromUrl(ctx, target.url, canonicalName, currency);
-        if (extracted) {
+        const result = await this._extractFromUrl(ctx, target.url, canonicalName, currency, itemConstraints);
+        if (result) {
           ctx.logger.info(
-            `  [search:pin] ${canonicalName}: price=${extracted.price} ${extracted.currency} from ${target.url}`,
+            `  [search:pin] ${canonicalName}: price=${result.extracted.price} ${result.extracted.currency} from ${target.url}`,
           );
           return {
             url: target.url,
             html: JSON.stringify({
-              extracted,
+              extracted: result.extracted,
               productUrl: target.url,
               canonicalName,
               basketSlug,
               itemCategory: target.category,
+              itemConstraints,
+              validator: result.validator,
               direct: true,
               pinnedProductId,
               matchId,
@@ -286,15 +323,15 @@ export class SearchAdapter implements RetailerAdapter {
     }
 
     // Stage 2: Firecrawl structured extraction — iterate safe URLs until one yields a valid price
-    let extracted: ExtractedProduct | null = null;
+    let picked: { extracted: ExtractedProduct; validator: ValidatorResult } | null = null;
     let usedUrl = safeUrls[0];
     const lastErrors: string[] = [];
 
     for (const url of safeUrls) {
       try {
-        const result = await this._extractFromUrl(ctx, url, canonicalName, currency);
+        const result = await this._extractFromUrl(ctx, url, canonicalName, currency, itemConstraints);
         if (result) {
-          extracted = result;
+          picked = result;
           usedUrl = url;
           break;
         }
@@ -306,24 +343,26 @@ export class SearchAdapter implements RetailerAdapter {
       }
     }
 
-    if (extracted === null) {
+    if (picked === null) {
       throw new Error(
         `All ${safeUrls.length} URLs failed extraction for "${canonicalName}".${lastErrors.length ? ` Last: ${lastErrors.at(-1)}` : ''}`,
       );
     }
 
     ctx.logger.info(
-      `  [search:extract] ${canonicalName}: price=${extracted.price} ${extracted.currency} from ${usedUrl}`,
+      `  [search:extract] ${canonicalName}: price=${picked.extracted.price} ${picked.extracted.currency} from ${usedUrl}`,
     );
 
     return {
       url: usedUrl,
       html: JSON.stringify({
-        extracted,
+        extracted: picked.extracted,
         productUrl: usedUrl,
         canonicalName,
         basketSlug,
         itemCategory: target.category,
+        itemConstraints,
+        validator: picked.validator,
         direct: false,
       } satisfies SearchPayload),
       statusCode: 200,
@@ -332,7 +371,7 @@ export class SearchAdapter implements RetailerAdapter {
   }
 
   async parseListing(ctx: AdapterContext, result: FetchResult): Promise<ParsedProduct[]> {
-    const { extracted, productUrl, canonicalName, basketSlug, itemCategory, direct, pinnedProductId, matchId } =
+    const { extracted, productUrl, canonicalName, basketSlug, itemCategory, itemConstraints, validator, direct, pinnedProductId, matchId } =
       JSON.parse(result.html) as SearchPayload;
 
     const priceResult = z.number().positive().finite().safeParse(extracted?.price);
@@ -371,7 +410,7 @@ export class SearchAdapter implements RetailerAdapter {
         // inStock defaults to true when Firecrawl does not return the field.
         // This is a conservative assumption — monitor for out-of-stock false positives.
         inStock: extracted.inStock ?? true,
-        rawPayload: { extracted, basketSlug, itemCategory, canonicalName, direct, pinnedProductId, matchId },
+        rawPayload: { extracted, basketSlug, itemCategory, canonicalName, itemConstraints, validator, direct, pinnedProductId, matchId },
       },
     ];
   }

--- a/consumer-prices-core/src/adapters/validator.test.ts
+++ b/consumer-prices-core/src/adapters/validator.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from 'vitest';
+import { validateSearchHit, AUTO_MATCH_THRESHOLD } from './validator.js';
+import type { BasketItem } from '../config/types.js';
+
+const item = (over: Partial<BasketItem> = {}): BasketItem => ({
+  id: 'x',
+  category: 'x',
+  canonicalName: 'x',
+  weight: 0.1,
+  baseUnit: 'g',
+  ...over,
+});
+
+describe('validateSearchHit — known bad log examples', () => {
+  it('rejects mango sugar baby for White Sugar 1kg', () => {
+    const r = validateSearchHit({
+      canonicalName: 'White Sugar 1kg',
+      productName: 'mango sugar baby india 1 kg',
+      sizeText: '1 kg',
+      item: item({
+        baseUnit: 'g', minBaseQty: 900, maxBaseQty: 1100,
+        negativeTokens: ['baby', 'brown', 'mascavo', 'sachets'],
+      }),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.some((s) => s.startsWith('negative-token:baby'))).toBe(true);
+  });
+
+  it('rejects vegan gouda for Processed Cheese Slices', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Processed Cheese Slices 200g',
+      productName: 'vegan gouda slices 200g',
+      sizeText: '200 g',
+      item: item({
+        baseUnit: 'g', minBaseQty: 180, maxBaseQty: 220,
+        negativeTokens: ['vegan', 'gouda', 'cheddar'],
+      }),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.some((s) => s.startsWith('negative-token:vegan'))).toBe(true);
+  });
+
+  it('rejects onion powder for Onions 1kg', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Onions 1kg',
+      productName: 'Onion Powder 100g',
+      sizeText: '100 g',
+      item: item({
+        baseUnit: 'g', minBaseQty: 900, maxBaseQty: 1100,
+        negativeTokens: ['powder', 'flakes'],
+      }),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.some((s) => s.startsWith('negative-token:powder'))).toBe(true);
+  });
+
+  it('rejects chopped canned tomatoes for Tomatoes Fresh 1kg', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Tomatoes Fresh 1kg',
+      productName: 'Chopped Tomatoes 400g canned',
+      sizeText: '400 g',
+      item: item({
+        baseUnit: 'g', minBaseQty: 900, maxBaseQty: 1100,
+        negativeTokens: ['chopped', 'peeled', 'sauce', 'paste', 'canned'],
+      }),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.some((s) => s.startsWith('negative-token:'))).toBe(true);
+  });
+
+  it('rejects plant-based yogurt for Plain Yogurt 500g', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Plain Yogurt 500g',
+      productName: 'Plant-Based Almond Yogurt 500g',
+      sizeText: '500 g',
+      item: item({
+        baseUnit: 'g', minBaseQty: 450, maxBaseQty: 550,
+        negativeTokens: ['drink', 'drinking', 'plant-based', 'vegan'],
+      }),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.some((s) => s.startsWith('negative-token:plant-based'))).toBe(true);
+  });
+
+  it('rejects drinking yogurt for Plain Yogurt 500g', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Plain Yogurt 500g',
+      productName: 'Dairy Drinking Yogurt 500g',
+      sizeText: '500 g',
+      item: item({
+        baseUnit: 'g', minBaseQty: 450, maxBaseQty: 550,
+        negativeTokens: ['drink', 'drinking', 'plant-based', 'vegan'],
+      }),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.some((s) => s.startsWith('negative-token:drinking'))).toBe(true);
+  });
+});
+
+describe('validateSearchHit — positive counterparts must still pass', () => {
+  it('accepts normal white sugar 1kg', () => {
+    const r = validateSearchHit({
+      canonicalName: 'White Sugar 1kg',
+      productName: 'Al Khaleej White Sugar 1 kg',
+      sizeText: '1 kg',
+      item: item({
+        baseUnit: 'g', minBaseQty: 900, maxBaseQty: 1100,
+        negativeTokens: ['brown', 'baby', 'mascavo', 'sachets'],
+      }),
+    });
+    expect(r.ok).toBe(true);
+    expect(r.signals.sizeWindow).toBe('pass');
+    expect(r.score).toBeGreaterThanOrEqual(AUTO_MATCH_THRESHOLD);
+  });
+
+  it('accepts fresh whole onions 1kg', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Onions 1kg',
+      productName: 'Fresh Red Onions 1kg',
+      sizeText: '1kg',
+      item: item({
+        baseUnit: 'g', minBaseQty: 900, maxBaseQty: 1100,
+        negativeTokens: ['powder', 'flakes'],
+      }),
+    });
+    expect(r.ok).toBe(true);
+    expect(r.score).toBeGreaterThanOrEqual(AUTO_MATCH_THRESHOLD);
+  });
+
+  it('accepts fresh tomatoes 1kg', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Tomatoes Fresh 1kg',
+      productName: 'Fresh Tomatoes 1kg',
+      sizeText: '1 kg',
+      item: item({
+        baseUnit: 'g', minBaseQty: 900, maxBaseQty: 1100,
+        negativeTokens: ['chopped', 'peeled', 'sauce', 'paste', 'canned'],
+      }),
+    });
+    expect(r.ok).toBe(true);
+    expect(r.score).toBeGreaterThanOrEqual(AUTO_MATCH_THRESHOLD);
+  });
+
+  it('accepts normal plain yogurt 500g', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Plain Yogurt 500g',
+      productName: 'Al Ain Plain Yogurt 500g',
+      sizeText: '500 g',
+      item: item({
+        baseUnit: 'g', minBaseQty: 450, maxBaseQty: 550,
+        negativeTokens: ['drink', 'drinking', 'plant-based', 'vegan'],
+      }),
+    });
+    expect(r.ok).toBe(true);
+    expect(r.score).toBeGreaterThanOrEqual(AUTO_MATCH_THRESHOLD);
+  });
+
+  it('accepts processed cheese slices 200g', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Processed Cheese Slices 200g',
+      productName: 'Kraft Processed Cheese Slices 200g',
+      sizeText: '200g',
+      item: item({
+        baseUnit: 'g', minBaseQty: 180, maxBaseQty: 220,
+        negativeTokens: ['vegan', 'gouda', 'cheddar'],
+      }),
+    });
+    expect(r.ok).toBe(true);
+    expect(r.score).toBeGreaterThanOrEqual(AUTO_MATCH_THRESHOLD);
+  });
+});
+
+describe('validateSearchHit — quantity window', () => {
+  it('rejects 400g for a 500g target outside the allowed window', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Plain Yogurt 500g',
+      productName: 'Plain Yogurt 400g',
+      sizeText: '400g',
+      item: item({ baseUnit: 'g', minBaseQty: 450, maxBaseQty: 550 }),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.signals.sizeWindow).toBe('fail');
+    expect(r.reasons.some((s) => s.startsWith('size-window-fail'))).toBe(true);
+  });
+
+  it('rejects 2.5kg for a 1kg target', () => {
+    const r = validateSearchHit({
+      canonicalName: 'White Sugar 1kg',
+      productName: 'White Sugar 2.5 kg',
+      sizeText: '2.5 kg',
+      item: item({ baseUnit: 'g', minBaseQty: 900, maxBaseQty: 1100 }),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.signals.sizeWindow).toBe('fail');
+  });
+
+  it('accepts 505g for a 500g target inside the window', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Plain Yogurt 500g',
+      productName: 'Plain Yogurt 505g',
+      sizeText: '505g',
+      item: item({ baseUnit: 'g', minBaseQty: 450, maxBaseQty: 550 }),
+    });
+    expect(r.ok).toBe(true);
+    expect(r.signals.sizeWindow).toBe('pass');
+  });
+
+  it('treats unknown size as neutral (does not hard-fail)', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Plain Yogurt 500g',
+      productName: 'Plain Yogurt',
+      sizeText: undefined,
+      item: item({ baseUnit: 'g', minBaseQty: 450, maxBaseQty: 550 }),
+    });
+    expect(r.signals.sizeWindow).toBe('unknown');
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('validateSearchHit — non-food and token overlap', () => {
+  it('rejects seeds for a vegetable basket item', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Tomatoes Fresh 1kg',
+      productName: 'GGOOT Tomato Seeds 100 pcs Vegetable Garden',
+      sizeText: undefined,
+      item: item({ baseUnit: 'g' }),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.signals.nonFoodIndicatorHit).toBe('seeds');
+  });
+
+  it('rejects low token overlap', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Basmati Rice 1kg',
+      productName: 'Olive Oil 500ml',
+      sizeText: '500ml',
+      item: item({ baseUnit: 'g' }),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.some((s) => s.startsWith('low-token-overlap'))).toBe(true);
+  });
+
+  it('returns empty-product-name reason for missing productName', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Milk 1L',
+      productName: undefined,
+      sizeText: undefined,
+      item: item(),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons).toContain('empty-product-name');
+    expect(r.score).toBe(0);
+  });
+});

--- a/consumer-prices-core/src/adapters/validator.test.ts
+++ b/consumer-prices-core/src/adapters/validator.test.ts
@@ -145,6 +145,28 @@ describe('validateSearchHit — positive counterparts must still pass', () => {
     expect(r.score).toBeGreaterThanOrEqual(AUTO_MATCH_THRESHOLD);
   });
 
+  // Regression: compact size tokens like "1kg" used to be kept as identity
+  // tokens, but Firecrawl often emits "1 kg" (spaced) which tokenises to
+  // ["1","kg"] — both below the length>2 floor — so "1kg" could never
+  // match. For short canonical names like "Onions 1kg", that dropped the
+  // token overlap from 1.0 to 0.5 and pushed valid hits below the
+  // AUTO_MATCH_THRESHOLD. Size fidelity is already enforced by the
+  // quantity-window check; identity tokens should ignore size.
+  it('overlap ignores compact size token so spaced-size extractions pass', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Onions 1kg',
+      productName: 'Fresh Red Onions 1 kg',
+      sizeText: '1 kg',
+      item: item({
+        baseUnit: 'g', minBaseQty: 900, maxBaseQty: 1100,
+        negativeTokens: ['powder', 'flakes'],
+      }),
+    });
+    expect(r.ok).toBe(true);
+    expect(r.signals.tokenOverlap).toBe(1);
+    expect(r.score).toBeGreaterThanOrEqual(AUTO_MATCH_THRESHOLD);
+  });
+
   it('accepts fresh tomatoes 1kg', () => {
     const r = validateSearchHit({
       canonicalName: 'Tomatoes Fresh 1kg',

--- a/consumer-prices-core/src/adapters/validator.test.ts
+++ b/consumer-prices-core/src/adapters/validator.test.ts
@@ -105,11 +105,29 @@ describe('validateSearchHit — positive counterparts must still pass', () => {
       sizeText: '1 kg',
       item: item({
         baseUnit: 'g', minBaseQty: 900, maxBaseQty: 1100,
-        negativeTokens: ['brown', 'baby', 'mascavo', 'sachets'],
+        negativeTokens: ['brown', 'baby', 'mascavo', 'sachets', 'powdered'],
       }),
     });
     expect(r.ok).toBe(true);
     expect(r.signals.sizeWindow).toBe('pass');
+    expect(r.score).toBeGreaterThanOrEqual(AUTO_MATCH_THRESHOLD);
+  });
+
+  // Regression: "cane" is a legitimate descriptor for white cane sugar.
+  // An earlier iteration of negativeTokens included "cane" and would have
+  // downgraded real SKUs to candidate. Guard against any future edit that
+  // re-adds "cane" without considering this positive case.
+  it('accepts white cane sugar 1kg — cane is not a class error', () => {
+    const r = validateSearchHit({
+      canonicalName: 'White Sugar 1kg',
+      productName: 'Silver Spoon White Cane Sugar 1kg',
+      sizeText: '1 kg',
+      item: item({
+        baseUnit: 'g', minBaseQty: 900, maxBaseQty: 1100,
+        negativeTokens: ['brown', 'baby', 'mascavo', 'sachets', 'powdered'],
+      }),
+    });
+    expect(r.ok).toBe(true);
     expect(r.score).toBeGreaterThanOrEqual(AUTO_MATCH_THRESHOLD);
   });
 

--- a/consumer-prices-core/src/adapters/validator.ts
+++ b/consumer-prices-core/src/adapters/validator.ts
@@ -1,0 +1,158 @@
+/**
+ * Structured search-hit validator — deterministic post-extraction gate that
+ * replaces the boolean `isTitlePlausible` check for scoring and candidate
+ * triage. Evaluates:
+ *   1. class-error rejects (basket item's negativeTokens present in title)
+ *   2. non-food indicator rejects (shared with legacy gate)
+ *   3. token-overlap score (identity tokens from canonicalName vs productName)
+ *   4. quantity-window conformance (minBaseQty <= extractedBase <= maxBaseQty)
+ *
+ * Score is a 0..1 float combining the three positive signals so callers can
+ * make graduated decisions (auto vs candidate) instead of the legacy 1.0 shortcut.
+ * Reasons are returned so shadow mode and evidence_json can be human-readable.
+ */
+import { parseSize } from '../normalizers/size.js';
+import type { BasketItem } from '../config/types.js';
+
+export interface ValidatorInput {
+  canonicalName: string;
+  productName: string | undefined;
+  sizeText: string | undefined;
+  item: Pick<BasketItem, 'baseUnit' | 'minBaseQty' | 'maxBaseQty' | 'negativeTokens'>;
+}
+
+export interface ValidatorResult {
+  ok: boolean;
+  score: number;
+  reasons: string[];
+  signals: {
+    tokenOverlap: number;
+    negativeTokenHit: string | null;
+    nonFoodIndicatorHit: string | null;
+    sizeWindow: 'pass' | 'fail' | 'unknown';
+    extractedBaseQty: number | null;
+  };
+}
+
+const PACKAGING_WORDS = new Set([
+  'pack', 'box', 'bag', 'container', 'bottle', 'can', 'jar', 'tin', 'set', 'kit', 'bundle',
+]);
+
+const NON_FOOD_INDICATORS = new Set([
+  'seeds', 'seed', 'seedling', 'seedlings', 'planting', 'fertilizer', 'fertiliser',
+]);
+
+function stem(w: string): string {
+  return w.replace(/ies$/, 'y').replace(/es$/, '').replace(/s$/, '');
+}
+
+function tokens(s: string): string[] {
+  return s.toLowerCase().split(/\W+/).filter(Boolean);
+}
+
+function identityTokens(canonicalName: string): string[] {
+  return tokens(canonicalName).filter((w) => w.length > 2 && !PACKAGING_WORDS.has(w));
+}
+
+function computeTokenOverlap(canonicalName: string, productName: string): number {
+  const ids = identityTokens(canonicalName);
+  if (ids.length === 0) return 1;
+  const haystack = productName.toLowerCase();
+  const hits = ids.filter((w) => {
+    if (haystack.includes(w)) return true;
+    const s = stem(w);
+    return s.length >= 4 && s !== w && haystack.includes(s);
+  });
+  return hits.length / ids.length;
+}
+
+function findNegativeToken(productName: string, negativeTokens: readonly string[] | undefined): string | null {
+  if (!negativeTokens || negativeTokens.length === 0) return null;
+  const titleTokens = new Set(tokens(productName));
+  const lowered = productName.toLowerCase();
+  for (const raw of negativeTokens) {
+    const t = raw.toLowerCase().trim();
+    if (!t) continue;
+    // Multi-word entries (e.g. "plant-based") are substring-matched; single
+    // words use whole-token match so "pastelaria" never matches "past".
+    if (t.includes(' ') || t.includes('-')) {
+      if (lowered.includes(t)) return raw;
+    } else if (titleTokens.has(t)) {
+      return raw;
+    }
+  }
+  return null;
+}
+
+function findNonFoodIndicator(productName: string): string | null {
+  for (const w of tokens(productName)) {
+    if (NON_FOOD_INDICATORS.has(w)) return w;
+  }
+  return null;
+}
+
+function evaluateSizeWindow(
+  sizeText: string | undefined,
+  item: ValidatorInput['item'],
+): { status: 'pass' | 'fail' | 'unknown'; baseQty: number | null } {
+  if (item.minBaseQty == null && item.maxBaseQty == null) return { status: 'unknown', baseQty: null };
+  if (!sizeText) return { status: 'unknown', baseQty: null };
+  const parsed = parseSize(sizeText);
+  if (!parsed) return { status: 'unknown', baseQty: null };
+  if (parsed.baseUnit !== item.baseUnit) return { status: 'unknown', baseQty: parsed.baseQuantity };
+  const min = item.minBaseQty ?? 0;
+  const max = item.maxBaseQty ?? Number.POSITIVE_INFINITY;
+  const q = parsed.baseQuantity;
+  return { status: q >= min && q <= max ? 'pass' : 'fail', baseQty: q };
+}
+
+export function validateSearchHit(input: ValidatorInput): ValidatorResult {
+  const reasons: string[] = [];
+  const signals: ValidatorResult['signals'] = {
+    tokenOverlap: 0,
+    negativeTokenHit: null,
+    nonFoodIndicatorHit: null,
+    sizeWindow: 'unknown',
+    extractedBaseQty: null,
+  };
+
+  if (!input.productName) {
+    reasons.push('empty-product-name');
+    return { ok: false, score: 0, reasons, signals };
+  }
+
+  const nonFood = findNonFoodIndicator(input.productName);
+  signals.nonFoodIndicatorHit = nonFood;
+  if (nonFood) reasons.push(`non-food-indicator:${nonFood}`);
+
+  const negHit = findNegativeToken(input.productName, input.item.negativeTokens);
+  signals.negativeTokenHit = negHit;
+  if (negHit) reasons.push(`negative-token:${negHit}`);
+
+  const overlap = computeTokenOverlap(input.canonicalName, input.productName);
+  signals.tokenOverlap = overlap;
+  const overlapFloor = 0.4;
+  if (overlap < overlapFloor) reasons.push(`low-token-overlap:${overlap.toFixed(2)}`);
+
+  const sizeEval = evaluateSizeWindow(input.sizeText, input.item);
+  signals.sizeWindow = sizeEval.status;
+  signals.extractedBaseQty = sizeEval.baseQty;
+  if (sizeEval.status === 'fail') {
+    reasons.push(`size-window-fail:${sizeEval.baseQty}${input.item.baseUnit ?? ''}`);
+  }
+
+  // Hard-reject conditions (any single one fails the hit):
+  const hardFail = Boolean(nonFood) || Boolean(negHit) || overlap < overlapFloor || sizeEval.status === 'fail';
+
+  // Score combines positive signals even when hard-failing, so candidate rows
+  // retain their relative quality for later review.
+  // Weights: token overlap 0.55, size 0.35 (or 0.2 neutral when unknown), class-clean 0.10.
+  const sizeComponent = sizeEval.status === 'pass' ? 0.35 : sizeEval.status === 'unknown' ? 0.2 : 0;
+  const classClean = nonFood || negHit ? 0 : 0.1;
+  const score = Math.min(1, Math.max(0, overlap * 0.55 + sizeComponent + classClean));
+
+  return { ok: !hardFail, score, reasons, signals };
+}
+
+/** Exported for tests + metrics bucketing. */
+export const AUTO_MATCH_THRESHOLD = 0.75;

--- a/consumer-prices-core/src/adapters/validator.ts
+++ b/consumer-prices-core/src/adapters/validator.ts
@@ -50,8 +50,19 @@ function tokens(s: string): string[] {
   return s.toLowerCase().split(/\W+/).filter(Boolean);
 }
 
+// Compact size tokens (e.g. "1kg", "500g", "250ml", "12pk") must be stripped
+// from identity tokens. The quantity-window check already handles size
+// fidelity. Carrying them here creates systematic false misses because
+// Firecrawl usually emits size spaced ("1 kg"), which tokenises to
+// ["1","kg"] — both below the length>2 floor — so the "1kg" token can
+// never match. For short canonical names like "Onions 1kg" that drops
+// overlap from 1.0 to 0.5 and pushes valid hits below AUTO_MATCH_THRESHOLD.
+const SIZE_LIKE = /^\d+(?:\.\d+)?[a-z]+$/;
+
 function identityTokens(canonicalName: string): string[] {
-  return tokens(canonicalName).filter((w) => w.length > 2 && !PACKAGING_WORDS.has(w));
+  return tokens(canonicalName).filter(
+    (w) => w.length > 2 && !PACKAGING_WORDS.has(w) && !SIZE_LIKE.test(w),
+  );
 }
 
 function computeTokenOverlap(canonicalName: string, productName: string): number {

--- a/consumer-prices-core/src/config/types.ts
+++ b/consumer-prices-core/src/config/types.ts
@@ -100,6 +100,11 @@ export const BasketItemSchema = z.object({
   substitutionGroup: z.string().optional(),
   minBaseQty: z.number().optional(),
   maxBaseQty: z.number().optional(),
+  // Lowercase tokens that, if present in an extracted productName, mark the hit
+  // as a class mismatch (e.g. "canned" for fresh tomatoes). Intended for obvious
+  // class errors; product-taxonomy distinctions like plain vs greek yogurt
+  // belong in separate substitutionGroup values, not here.
+  negativeTokens: z.array(z.string()).optional(),
   qualificationRules: z.record(z.string(), z.unknown()).optional(),
 });
 

--- a/consumer-prices-core/src/db/queries/matches.ts
+++ b/consumer-prices-core/src/db/queries/matches.ts
@@ -16,16 +16,32 @@ export async function upsertProductMatch(input: {
      DO UPDATE SET
        basket_item_id  = EXCLUDED.basket_item_id,
        match_score     = EXCLUDED.match_score,
-       -- Human-curated 'approved' rows are immutable via this path. Without
-       -- the CASE guard, a re-scrape whose validator scored the same URL
-       -- below AUTO_MATCH_THRESHOLD would demote an approved match to
-       -- 'candidate' and silently drop it from aggregate queries.
+       -- Curated states are immutable via the scrape upsert:
+       --   'approved' — human accepted the match
+       --   'review'   — validate-job quarantined on price outlier, or
+       --                human sent it back for review (see jobs/validate.ts)
+       --   'rejected' — human explicitly blocked this URL
+       -- Conflict key is (retailer_product_id, canonical_product_id), so
+       -- rediscovery is the normal path for these rows. Without this
+       -- guard a re-scrape writes 'auto' or 'candidate' and silently
+       -- re-enables a previously quarantined URL in aggregate queries
+       -- (aggregate.ts / snapshots filter on ('auto','approved')).
+       -- Only machine-written states ('auto', 'candidate') are allowed
+       -- to move to the fresh validator verdict.
        match_status    = CASE
-         WHEN product_matches.match_status = 'approved' THEN 'approved'
+         WHEN product_matches.match_status IN ('approved', 'review', 'rejected')
+           THEN product_matches.match_status
          ELSE EXCLUDED.match_status
        END,
        evidence_json   = EXCLUDED.evidence_json,
-       pin_disabled_at = NULL`,
+       -- Only clear pin_disabled_at when the row is actually moving back
+       -- to a machine-writable state. A 'review'/'rejected' row keeps
+       -- its disabled flag until the review workflow resolves it.
+       pin_disabled_at = CASE
+         WHEN product_matches.match_status IN ('review', 'rejected')
+           THEN product_matches.pin_disabled_at
+         ELSE NULL
+       END`,
     [
       input.retailerProductId,
       input.canonicalProductId,

--- a/consumer-prices-core/src/db/queries/matches.ts
+++ b/consumer-prices-core/src/db/queries/matches.ts
@@ -16,7 +16,14 @@ export async function upsertProductMatch(input: {
      DO UPDATE SET
        basket_item_id  = EXCLUDED.basket_item_id,
        match_score     = EXCLUDED.match_score,
-       match_status    = EXCLUDED.match_status,
+       -- Human-curated 'approved' rows are immutable via this path. Without
+       -- the CASE guard, a re-scrape whose validator scored the same URL
+       -- below AUTO_MATCH_THRESHOLD would demote an approved match to
+       -- 'candidate' and silently drop it from aggregate queries.
+       match_status    = CASE
+         WHEN product_matches.match_status = 'approved' THEN 'approved'
+         ELSE EXCLUDED.match_status
+       END,
        evidence_json   = EXCLUDED.evidence_json,
        pin_disabled_at = NULL`,
     [

--- a/consumer-prices-core/src/db/queries/matches.ts
+++ b/consumer-prices-core/src/db/queries/matches.ts
@@ -5,17 +5,19 @@ export async function upsertProductMatch(input: {
   canonicalProductId: string;
   basketItemId: string;
   matchScore: number;
-  matchStatus: 'auto' | 'approved';
+  matchStatus: 'auto' | 'approved' | 'candidate';
+  evidence?: Record<string, unknown>;
 }): Promise<void> {
   await query(
     `INSERT INTO product_matches
        (retailer_product_id, canonical_product_id, basket_item_id, match_score, match_status, evidence_json)
-     VALUES ($1,$2,$3,$4,$5,'{}')
+     VALUES ($1,$2,$3,$4,$5,$6)
      ON CONFLICT (retailer_product_id, canonical_product_id)
      DO UPDATE SET
        basket_item_id  = EXCLUDED.basket_item_id,
        match_score     = EXCLUDED.match_score,
        match_status    = EXCLUDED.match_status,
+       evidence_json   = EXCLUDED.evidence_json,
        pin_disabled_at = NULL`,
     [
       input.retailerProductId,
@@ -23,6 +25,7 @@ export async function upsertProductMatch(input: {
       input.basketItemId,
       input.matchScore,
       input.matchStatus,
+      JSON.stringify(input.evidence ?? {}),
     ],
   );
   // Reset stale counters when Exa re-discovers a product — fresh match means the URL works.

--- a/consumer-prices-core/src/jobs/scrape.ts
+++ b/consumer-prices-core/src/jobs/scrape.ts
@@ -145,6 +145,29 @@ export async function scrapeRetailer(slug: string) {
         // so this correctly distinguishes "pin worked" from "pin failed, Exa used instead".
         const wasDirectHit = isDirect && product.rawPayload.direct === true;
 
+        // Direct-hit validator enforcement — the pin path's common steady
+        // state. The legacy isTitlePlausible gate inside _extractFromUrl
+        // already let this hit through, so the strict validator here acts
+        // as a second opinion that specifically catches pins that have
+        // drifted onto the wrong product (e.g. "White Sugar 1kg" now
+        // resolving to "mango sugar baby india"). If the validator
+        // disagrees, skip the observation entirely and route this target
+        // through the existing pin-error counter so the pin soft-disables
+        // after repeated failures. Aggregates never see the bad price.
+        if (wasDirectHit) {
+          const v = product.rawPayload.validator as ValidatorResult | undefined;
+          if (v && !v.ok) {
+            logger.warn(
+              `  [${target.id}] pin validator reject — skipping observation, counting as pin error. reasons=${v.reasons.join(',')} score=${v.score.toFixed(2)} title="${product.rawTitle}"`,
+            );
+            errorsCount++;
+            if (pinnedProductId && pinnedMatchId) {
+              await handlePinError(pinnedProductId, pinnedMatchId, target.id);
+            }
+            continue;
+          }
+        }
+
         const productId = await upsertRetailerProduct({
           retailerId,
           retailerSku: product.retailerSku,

--- a/consumer-prices-core/src/jobs/scrape.ts
+++ b/consumer-prices-core/src/jobs/scrape.ts
@@ -16,6 +16,7 @@ import { FirecrawlProvider } from '../acquisition/firecrawl.js';
 import type { AdapterContext } from '../adapters/types.js';
 import { upsertCanonicalProduct } from '../db/queries/products.js';
 import { getBasketItemId, getPinnedUrlsForRetailer, upsertProductMatch } from '../db/queries/matches.js';
+import { AUTO_MATCH_THRESHOLD, type ValidatorResult } from '../adapters/validator.js';
 
 const logger = {
   info: (msg: string, ...args: unknown[]) => console.log(`[scrape] ${msg}`, ...args),
@@ -220,12 +221,31 @@ export async function scrapeRetailer(slug: string) {
               product.rawPayload.canonicalName as string,
             );
             if (basketItemId) {
+              // Use the validator result threaded through the adapter payload
+              // to pick the match state. No validator = legacy fallback at
+              // score 1.0 / auto (keeps the pre-validator adapters working
+              // unchanged). The strict path scores real hits and downgrades
+              // weak ones to 'candidate' so they never enter aggregates.
+              const validator = product.rawPayload.validator as ValidatorResult | undefined;
+              const hasValidator = validator != null;
+              const score = hasValidator ? validator.score : 1.0;
+              const status: 'auto' | 'candidate' =
+                !hasValidator || (validator.ok && score >= AUTO_MATCH_THRESHOLD) ? 'auto' : 'candidate';
+              const evidence = hasValidator
+                ? { validator: { reasons: validator.reasons, signals: validator.signals } }
+                : {};
+              if (status === 'candidate') {
+                logger.warn(
+                  `  [${target.id}] downgraded to candidate score=${score.toFixed(2)} reasons=${validator?.reasons.join(',')}`,
+                );
+              }
               await upsertProductMatch({
                 retailerProductId: productId,
                 canonicalProductId: canonicalId,
                 basketItemId,
-                matchScore: 1.0,
-                matchStatus: 'auto',
+                matchScore: score,
+                matchStatus: status,
+                evidence,
               });
             }
           } catch (matchErr) {

--- a/consumer-prices-core/vitest.config.ts
+++ b/consumer-prices-core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**', 'src/adapters/search.smoke.ts'],
+  },
+});

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -311,11 +311,18 @@ export async function fetchDividendProfile(symbol: string, currentPrice: number)
     //                           prior-year Q1 fell outside the 365d window)
     let paymentsPerYear = 0;
     if (recentDivs.length >= 3) {
-      const byInterval = paymentsPerYearFromInterval(entries);
+      // Use the trailing-year window directly. Scoping the median to
+      // ≥3 trailing-year entries (= 2+ gaps) reflects the CURRENT cadence,
+      // so regime changes like monthly → quarterly (whose 2-year median
+      // would still skew to monthly from prior-year history) are caught.
+      const byInterval = paymentsPerYearFromInterval(recentDivs);
       paymentsPerYear = byInterval > 0
         ? byInterval
         : (recentDivs.length || (entries.length / Math.max(1, annualTotals.size)));
     } else if (recentDivs.length > 0) {
+      // 1..2 recent payments: reach into the 2-year history to decide
+      // between calendar drift and regime slowdown. Most-recent gap
+      // > 180d means a real slowdown → trust the count.
       const lastTwo = entries.slice(-2);
       const mostRecentGapDays =
         lastTwo.length === 2

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -233,7 +233,12 @@ function paymentsPerYearFromInterval(
   }
   if (gaps.length === 0) return 0;
   gaps.sort((a, b) => a - b);
-  const medianGapDays = gaps[Math.floor(gaps.length / 2)]!;
+  // True median (average of two middles for even-length arrays) — avoids
+  // upper-bias at thresholds when the trailing-year sample is small.
+  const mid = Math.floor(gaps.length / 2);
+  const medianGapDays = gaps.length % 2 === 1
+    ? gaps[mid]!
+    : (gaps[mid - 1]! + gaps[mid]!) / 2;
   if (medianGapDays <= 0) return 0;
   return 365.25 / medianGapDays;
 }

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -208,13 +208,25 @@ function inferDividendFrequency(paymentsPerYear: number): string {
  * robust than counting payments inside a 365.25-day window: quarterly
  * payers whose last-year-Q1 payment falls just outside the window (common
  * after mid-April each year) were misclassified as Semi-annual.
+ *
+ * Scopes gaps to the most recent `windowSec` seconds so a cadence change
+ * (e.g. quarterly → annual) is reflected within one window rather than
+ * being averaged over 5 years of history. Falls back to the full series
+ * when the recent window has fewer than 2 usable entries.
  */
-function paymentsPerYearFromInterval(sortedEntries: ReadonlyArray<{ date?: number }>): number {
+function paymentsPerYearFromInterval(
+  sortedEntries: ReadonlyArray<{ date?: number }>,
+  nowSec: number = Math.floor(Date.now() / 1000),
+  windowSec: number = 2 * 365.25 * 24 * 3600,
+): number {
   if (sortedEntries.length < 2) return 0;
+  const cutoff = nowSec - windowSec;
+  const recent = sortedEntries.filter((e) => typeof e.date === 'number' && e.date >= cutoff);
+  const series = recent.length >= 2 ? recent : sortedEntries;
   const gaps: number[] = [];
-  for (let i = 1; i < sortedEntries.length; i++) {
-    const prev = sortedEntries[i - 1]!.date;
-    const curr = sortedEntries[i]!.date;
+  for (let i = 1; i < series.length; i++) {
+    const prev = series[i - 1]!.date;
+    const curr = series[i]!.date;
     if (typeof prev !== 'number' || typeof curr !== 'number') continue;
     const gapDays = (curr - prev) / (24 * 3600);
     if (gapDays > 0) gaps.push(gapDays);
@@ -284,12 +296,38 @@ export async function fetchDividendProfile(symbol: string, currentPrice: number)
     const recentDivs = entries.filter((d) => (d.date ?? 0) * 1000 >= oneYearAgo);
     const trailingAnnual = recentDivs.reduce((sum, d) => sum + (d.amount ?? 0), 0);
     const dividendYield = currentPrice > 0 ? (trailingAnnual / currentPrice) * 100 : 0;
-    // Prefer inter-payment-interval classification (robust to calendar drift);
-    // fall back to recentDivs count if entries are too sparse to compute gaps.
-    const byInterval = paymentsPerYearFromInterval(entries);
-    const paymentsPerYear = byInterval > 0
-      ? byInterval
-      : (recentDivs.length || (entries.length / Math.max(1, annualTotals.size)));
+    // Suppress frequency entirely when there is no active dividend program:
+    // no payment in the trailing year means dividendYield/trailingAnnualRate
+    // are both 0, and emitting a 'Quarterly' badge derived from suspended
+    // history would contradict the accompanying zeros in the UI.
+    // Frequency reconciliation:
+    //   recent=0          → program suspended, leave frequency empty
+    //   recent >= 3       → trust interval (robust to calendar-boundary drift)
+    //   recent 1..2       → ambiguous. Use the most recent gap to decide:
+    //                         large recent gap (> 180d) = regime slowdown →
+    //                           trust the count (quarterly → annual shift)
+    //                         small recent gap (<= 180d) = calendar drift →
+    //                           trust the interval (steady quarterly whose
+    //                           prior-year Q1 fell outside the 365d window)
+    let paymentsPerYear = 0;
+    if (recentDivs.length >= 3) {
+      const byInterval = paymentsPerYearFromInterval(entries);
+      paymentsPerYear = byInterval > 0
+        ? byInterval
+        : (recentDivs.length || (entries.length / Math.max(1, annualTotals.size)));
+    } else if (recentDivs.length > 0) {
+      const lastTwo = entries.slice(-2);
+      const mostRecentGapDays =
+        lastTwo.length === 2
+          ? ((lastTwo[1]!.date ?? 0) - (lastTwo[0]!.date ?? 0)) / (24 * 3600)
+          : Number.POSITIVE_INFINITY;
+      if (mostRecentGapDays > 180) {
+        paymentsPerYear = recentDivs.length;
+      } else {
+        const byInterval = paymentsPerYearFromInterval(entries);
+        paymentsPerYear = byInterval > 0 ? byInterval : recentDivs.length;
+      }
+    }
 
     const latestEntry = entries[entries.length - 1]!;
     const exDividendDate = (latestEntry.date ?? 0) * 1000;

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -203,6 +203,29 @@ function inferDividendFrequency(paymentsPerYear: number): string {
   return '';
 }
 
+/**
+ * Implied payments-per-year from the median gap between dividends. More
+ * robust than counting payments inside a 365.25-day window: quarterly
+ * payers whose last-year-Q1 payment falls just outside the window (common
+ * after mid-April each year) were misclassified as Semi-annual.
+ */
+function paymentsPerYearFromInterval(sortedEntries: ReadonlyArray<{ date?: number }>): number {
+  if (sortedEntries.length < 2) return 0;
+  const gaps: number[] = [];
+  for (let i = 1; i < sortedEntries.length; i++) {
+    const prev = sortedEntries[i - 1]!.date;
+    const curr = sortedEntries[i]!.date;
+    if (typeof prev !== 'number' || typeof curr !== 'number') continue;
+    const gapDays = (curr - prev) / (24 * 3600);
+    if (gapDays > 0) gaps.push(gapDays);
+  }
+  if (gaps.length === 0) return 0;
+  gaps.sort((a, b) => a - b);
+  const medianGapDays = gaps[Math.floor(gaps.length / 2)]!;
+  if (medianGapDays <= 0) return 0;
+  return 365.25 / medianGapDays;
+}
+
 function computeDividendCagr(annualTotals: Map<number, number>): number {
   if (annualTotals.size < 2) return 0;
   const years = [...annualTotals.keys()].sort((a, b) => a - b);
@@ -261,7 +284,12 @@ export async function fetchDividendProfile(symbol: string, currentPrice: number)
     const recentDivs = entries.filter((d) => (d.date ?? 0) * 1000 >= oneYearAgo);
     const trailingAnnual = recentDivs.reduce((sum, d) => sum + (d.amount ?? 0), 0);
     const dividendYield = currentPrice > 0 ? (trailingAnnual / currentPrice) * 100 : 0;
-    const paymentsPerYear = recentDivs.length || (entries.length / Math.max(1, annualTotals.size));
+    // Prefer inter-payment-interval classification (robust to calendar drift);
+    // fall back to recentDivs count if entries are too sparse to compute gaps.
+    const byInterval = paymentsPerYearFromInterval(entries);
+    const paymentsPerYear = byInterval > 0
+      ? byInterval
+      : (recentDivs.length || (entries.length / Math.max(1, annualTotals.size)));
 
     const latestEntry = entries[entries.length - 1]!;
     const exDividendDate = (latestEntry.date ?? 0) * 1000;

--- a/tests/stock-dividend-profile.test.mts
+++ b/tests/stock-dividend-profile.test.mts
@@ -190,6 +190,32 @@ describe('fetchDividendProfile', () => {
     assert.equal(profile.dividendFrequency, '');
   });
 
+  it('detects a recent monthly → quarterly cadence change', async () => {
+    // 12 monthly payments in year -2..-1 (all outside trailing 12 months)
+    // plus 4 quarterly payments inside the trailing year. A 2-year median
+    // gap is ~30d (Monthly dominates the history), but current cadence
+    // is clearly quarterly. The classifier must look at trailing-year
+    // gaps only when there are enough of them.
+    const now = Math.floor(Date.now() / 1000);
+    const day = 24 * 3600;
+    const divs: Record<string, { amount: number; date: number }> = {};
+    // Monthly leg: 12 payments from month -24 to month -13.
+    for (let m = 13; m <= 24; m++) {
+      const ts = now - m * 30 * day;
+      divs[String(ts)] = { amount: 0.10, date: ts };
+    }
+    // Quarterly leg: 4 payments in the last year at ~ -30, -120, -210, -300 days.
+    for (let q = 0; q < 4; q++) {
+      const ts = now - (30 + q * 90) * day;
+      divs[String(ts)] = { amount: 0.30, date: ts };
+    }
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify(makeDividendChartPayload(divs)), { status: 200 });
+    }) as typeof fetch;
+    const profile = await fetchDividendProfile('SHIFT', 100);
+    assert.equal(profile.dividendFrequency, 'Quarterly');
+  });
+
   it('detects a recent quarterly → annual cadence change', async () => {
     // 3 years of quarterly history (12 entries, ~91d gap) followed by
     // a single annual payment in the last year. Whole-series median

--- a/tests/stock-dividend-profile.test.mts
+++ b/tests/stock-dividend-profile.test.mts
@@ -169,6 +169,51 @@ describe('fetchDividendProfile', () => {
     assert.equal(profile.dividendFrequency, 'Annual');
   });
 
+  it('emits empty frequency when the dividend program has been suspended', async () => {
+    // 3 years of quarterly history, then silence for the last 18 months.
+    // dividendYield and trailingAnnualDividendRate are both 0; emitting
+    // 'Quarterly' from the historical median gap would contradict them.
+    const now = Math.floor(Date.now() / 1000);
+    const quarterSec = Math.floor((365.25 / 4) * 24 * 3600);
+    const silenceSec = 18 * 30 * 24 * 3600;
+    const divs: Record<string, { amount: number; date: number }> = {};
+    for (let q = 0; q < 12; q++) {
+      const ts = now - silenceSec - q * quarterSec;
+      divs[String(ts)] = { amount: 0.50, date: ts };
+    }
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify(makeDividendChartPayload(divs)), { status: 200 });
+    }) as typeof fetch;
+    const profile = await fetchDividendProfile('SUSP', 100);
+    assert.equal(profile.dividendYield, 0);
+    assert.equal(profile.trailingAnnualDividendRate, 0);
+    assert.equal(profile.dividendFrequency, '');
+  });
+
+  it('detects a recent quarterly → annual cadence change', async () => {
+    // 3 years of quarterly history (12 entries, ~91d gap) followed by
+    // a single annual payment in the last year. Whole-series median
+    // would still report ~91d (Quarterly); the recent-window median
+    // correctly reports ~365d (Annual).
+    const now = Math.floor(Date.now() / 1000);
+    const quarterSec = Math.floor((365.25 / 4) * 24 * 3600);
+    const divs: Record<string, { amount: number; date: number }> = {};
+    // Historical quarterly payments, 2..5 years ago (all ≥ 1 year ago).
+    for (let q = 0; q < 12; q++) {
+      const ts = now - (365.25 * 24 * 3600) - q * quarterSec;
+      divs[String(ts)] = { amount: 0.50, date: Math.floor(ts) };
+    }
+    // One payment inside the trailing year at roughly T-60d.
+    const recentTs = now - 60 * 24 * 3600;
+    divs[String(recentTs)] = { amount: 0.50, date: recentTs };
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify(makeDividendChartPayload(divs)), { status: 200 });
+    }) as typeof fetch;
+    const profile = await fetchDividendProfile('SLOW', 100);
+    // Exactly one payment in trailing 12 months → paymentsPerYear ≈ 1 → Annual.
+    assert.equal(profile.dividendFrequency, 'Annual');
+  });
+
   it('filters out zero-amount dividends', async () => {
     const now = Math.floor(Date.now() / 1000);
     const divs: Record<string, { amount: number; date: number }> = {

--- a/tests/stock-dividend-profile.test.mts
+++ b/tests/stock-dividend-profile.test.mts
@@ -90,6 +90,8 @@ describe('fetchDividendProfile', () => {
     const currentYear = new Date().getFullYear();
     const divs: Record<string, { amount: number; date: number }> = {};
     // Four fully completed prior calendar years, growing 0.50 -> 0.65.
+    // CAGR is computed only on years < currentYear (see computeDividendCagr),
+    // so the prior-year block is the sole source of CAGR signal.
     const startYear = currentYear - 4;
     for (let yearIndex = 0; yearIndex < 4; yearIndex++) {
       const year = startYear + yearIndex;


### PR DESCRIPTION
## Summary

Smallest-safe-first PR from `docs/internal/consumerPricesImprovement.md`. Lands the strict validator, its taxonomy config, and the `candidate` match state — all behind a **shadow gate** so live behavior for existing retailers is unchanged while we collect a reject-diff baseline.

### What this PR does

1. **Migration 008** widens `product_matches.match_status` CHECK to include `'candidate'`. Aggregate queries and snapshot SQL filter on `('auto','approved')`, so candidates are excluded from user-visible data automatically.
2. **`BasketItem.negativeTokens`** — new optional `string[]` on the zod schema. Config-driven class-error reject tokens so the taxonomy can evolve without a deploy.
3. **`validateSearchHit()`** — pure deterministic helper (`consumer-prices-core/src/adapters/validator.ts`). Returns `{ok, score, reasons, signals}` from four signals:
   - class-error rejects via `BasketItem.negativeTokens` (whole-token match; substring for hyphenated entries like `plant-based`)
   - non-food indicators (`seeds`, `fertilizer`, `planting`) — shared with the legacy gate
   - token-overlap ratio over identity tokens (>2 chars, non-packaging)
   - quantity-window conformance against `minBaseQty`/`maxBaseQty`
   - Score = overlap·0.55 + size(0.35 pass / 0.2 unknown / 0 fail) + class-clean·0.10. `AUTO_MATCH_THRESHOLD = 0.75`.
4. **Shadow wiring in `search.ts`** — runs the validator alongside `isTitlePlausible`; legacy remains the hard gate. When they disagree (legacy accepts, validator rejects), logs `[search:shadow-reject]` with reasons + score so the rollout diff can inform flipping the gate in a follow-up PR. No live behavior change for currently-passing hits.
5. **`scrape.ts` match upsert** — replaces unconditional `matchScore: 1.0 / status: 'auto'` with validator-driven scoring. `ok && score ≥ 0.75` → `auto`; everything else → `candidate` with `evidence_json` carrying reasons + signals. Adapters without a validator (exa-search, generic) fall back to legacy `1.0/auto` so this PR is a no-op for non-search paths.
6. **`negativeTokens` populated** across all 10 essentials baskets for the six substitution groups that produced wrong matches in the failure log (`tomatoes`, `onions`, `water_still`, `sugar_white`, `cheese_processed`, `yogurt_plain`).

### What this PR explicitly does NOT do (deferred)

- Flip shadow → hard gate. That happens in a follow-up after the diff report shows `wouldReject < 2%` for 3 cycles with zero known-good products rejected.
- Threshold calibration against live score distribution (§3 of the plan). Starting value `0.75` is conservative; tune after observing p10 of known-good.
- Legacy `matchScore = 1.0` backfill (§8 of the plan). Existing poisoned rows survive until natural churn for this PR.
- Host alias config / Carrefour BR diagnosis (§4) and rolling-window pin disable (§5).
- Observability counters (§7) — follow-up, needs metrics-backend decision.

### Why shadow mode first

Tightening validation will reject previously-accepted products. Shadow-mode emits `wouldReject` diagnostics without changing behavior, so we can read a diff before committing to the harder gate. The `candidate` plumbing lands now so the follow-up that flips the gate doesn't also introduce a new persisted state.

### Schema impact

Migration 008 is additive — drops and re-adds the CHECK constraint with a wider set. Safe under concurrent writes (Postgres holds an `ACCESS EXCLUSIVE` lock during ALTER but no row rewrite). Run `npm run migrate` inside `consumer-prices-core` after merge.

## Testing

- **29/29 pass** in `consumer-prices-core` (`npm test`): 18 new validator cases + 11 existing search cases.
- New regression tests lock in all five bad log examples (`mango sugar baby`, `vegan gouda`, `onion powder`, `chopped tomatoes`, `plant-based yogurt`, `drinking yogurt`) AND matching positive cases (correct fresh onions, fresh tomatoes, plain yogurt, processed cheese, white sugar) — the tests prove both sides of the boundary.
- Quantity-window tests cover outside-window rejects (400g for 500g target, 2.5kg for 1kg) and in-window accepts (505g for 500g target).
- `npm run typecheck`, `npm run typecheck:api`, `npm run lint:md`, `node --test tests/edge-functions.test.mjs` — all pass.
- `npm run test:data` — 5339/5340 (pre-existing dividend-CAGR flake, unrelated).

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: grep `[search:shadow-reject]` in Railway `consumer-prices-core` service output. Also grep `downgraded to candidate` in the scrape logs for retailers using the `search` adapter.
- **Validation checks**
  - `SELECT match_status, COUNT(*) FROM product_matches WHERE created_at > NOW() - INTERVAL '24 hours' GROUP BY 1;` — should show a non-zero `candidate` bucket only for retailers using the `search` adapter, and `auto` should still dominate for those.
  - `SELECT match_status, AVG(match_score) FROM product_matches WHERE match_status IN ('auto','candidate') AND created_at > NOW() - INTERVAL '24 hours' GROUP BY 1;` — auto mean should land >0.8, candidate mean <0.75 by definition.
  - `SELECT COUNT(*) FROM product_matches WHERE match_status = 'candidate';` — track the aging curve. If it climbs >10% of total matches week-over-week, the threshold is too tight.
- **Expected healthy behavior**
  - Shadow-reject log lines produce a stable reject-reason distribution.
  - `auto` insert rate stays within ±5% of the previous baseline (the behavior change is tiny because `search` is one adapter among several).
  - No new errors from aggregate or publish jobs (candidates filtered by existing WHERE clauses).
- **Failure signal(s) / rollback trigger**
  - Aggregate row count drops by >10% → revert (means the adapter is writing `candidate` too aggressively and aggregate lost signal it previously had).
  - Shadow-reject rate > 20% of accepted hits → pause rollout (implies the new tokens are mis-tuned).
  - Rollback: revert the four commits; migration 008 is idempotent — the CHECK widening is safe to leave in place since no row can be in a state the prior constraint disallowed.
- **Validation window & owner**
  - Window: 3 aggregate cycles (≈72h given daily cadence).
  - Owner: consumer-prices feature lead.

---

🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)