### PR TITLE
fix(analyze-stock): classify dividend frequency by median gap

### DIFF
--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -311,11 +311,18 @@ export async function fetchDividendProfile(symbol: string, currentPrice: number)
     //                           prior-year Q1 fell outside the 365d window)
     let paymentsPerYear = 0;
     if (recentDivs.length >= 3) {
-      const byInterval = paymentsPerYearFromInterval(entries);
+      // Use the trailing-year window directly. Scoping the median to
+      // ≥3 trailing-year entries (= 2+ gaps) reflects the CURRENT cadence,
+      // so regime changes like monthly → quarterly (whose 2-year median
+      // would still skew to monthly from prior-year history) are caught.
+      const byInterval = paymentsPerYearFromInterval(recentDivs);
       paymentsPerYear = byInterval > 0
         ? byInterval
         : (recentDivs.length || (entries.length / Math.max(1, annualTotals.size)));
     } else if (recentDivs.length > 0) {
+      // 1..2 recent payments: reach into the 2-year history to decide
+      // between calendar drift and regime slowdown. Most-recent gap
+      // > 180d means a real slowdown → trust the count.
       const lastTwo = entries.slice(-2);
       const mostRecentGapDays =
         lastTwo.length === 2

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -233,7 +233,12 @@ function paymentsPerYearFromInterval(
   }
   if (gaps.length === 0) return 0;
   gaps.sort((a, b) => a - b);
-  const medianGapDays = gaps[Math.floor(gaps.length / 2)]!;
+  // True median (average of two middles for even-length arrays) — avoids
+  // upper-bias at thresholds when the trailing-year sample is small.
+  const mid = Math.floor(gaps.length / 2);
+  const medianGapDays = gaps.length % 2 === 1
+    ? gaps[mid]!
+    : (gaps[mid - 1]! + gaps[mid]!) / 2;
   if (medianGapDays <= 0) return 0;
   return 365.25 / medianGapDays;
 }

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -208,13 +208,25 @@ function inferDividendFrequency(paymentsPerYear: number): string {
  * robust than counting payments inside a 365.25-day window: quarterly
  * payers whose last-year-Q1 payment falls just outside the window (common
  * after mid-April each year) were misclassified as Semi-annual.
+ *
+ * Scopes gaps to the most recent `windowSec` seconds so a cadence change
+ * (e.g. quarterly → annual) is reflected within one window rather than
+ * being averaged over 5 years of history. Falls back to the full series
+ * when the recent window has fewer than 2 usable entries.
  */
-function paymentsPerYearFromInterval(sortedEntries: ReadonlyArray<{ date?: number }>): number {
+function paymentsPerYearFromInterval(
+  sortedEntries: ReadonlyArray<{ date?: number }>,
+  nowSec: number = Math.floor(Date.now() / 1000),
+  windowSec: number = 2 * 365.25 * 24 * 3600,
+): number {
   if (sortedEntries.length < 2) return 0;
+  const cutoff = nowSec - windowSec;
+  const recent = sortedEntries.filter((e) => typeof e.date === 'number' && e.date >= cutoff);
+  const series = recent.length >= 2 ? recent : sortedEntries;
   const gaps: number[] = [];
-  for (let i = 1; i < sortedEntries.length; i++) {
-    const prev = sortedEntries[i - 1]!.date;
-    const curr = sortedEntries[i]!.date;
+  for (let i = 1; i < series.length; i++) {
+    const prev = series[i - 1]!.date;
+    const curr = series[i]!.date;
     if (typeof prev !== 'number' || typeof curr !== 'number') continue;
     const gapDays = (curr - prev) / (24 * 3600);
     if (gapDays > 0) gaps.push(gapDays);
@@ -284,12 +296,38 @@ export async function fetchDividendProfile(symbol: string, currentPrice: number)
     const recentDivs = entries.filter((d) => (d.date ?? 0) * 1000 >= oneYearAgo);
     const trailingAnnual = recentDivs.reduce((sum, d) => sum + (d.amount ?? 0), 0);
     const dividendYield = currentPrice > 0 ? (trailingAnnual / currentPrice) * 100 : 0;
-    // Prefer inter-payment-interval classification (robust to calendar drift);
-    // fall back to recentDivs count if entries are too sparse to compute gaps.
-    const byInterval = paymentsPerYearFromInterval(entries);
-    const paymentsPerYear = byInterval > 0
-      ? byInterval
-      : (recentDivs.length || (entries.length / Math.max(1, annualTotals.size)));
+    // Suppress frequency entirely when there is no active dividend program:
+    // no payment in the trailing year means dividendYield/trailingAnnualRate
+    // are both 0, and emitting a 'Quarterly' badge derived from suspended
+    // history would contradict the accompanying zeros in the UI.
+    // Frequency reconciliation:
+    //   recent=0          → program suspended, leave frequency empty
+    //   recent >= 3       → trust interval (robust to calendar-boundary drift)
+    //   recent 1..2       → ambiguous. Use the most recent gap to decide:
+    //                         large recent gap (> 180d) = regime slowdown →
+    //                           trust the count (quarterly → annual shift)
+    //                         small recent gap (<= 180d) = calendar drift →
+    //                           trust the interval (steady quarterly whose
+    //                           prior-year Q1 fell outside the 365d window)
+    let paymentsPerYear = 0;
+    if (recentDivs.length >= 3) {
+      const byInterval = paymentsPerYearFromInterval(entries);
+      paymentsPerYear = byInterval > 0
+        ? byInterval
+        : (recentDivs.length || (entries.length / Math.max(1, annualTotals.size)));
+    } else if (recentDivs.length > 0) {
+      const lastTwo = entries.slice(-2);
+      const mostRecentGapDays =
+        lastTwo.length === 2
+          ? ((lastTwo[1]!.date ?? 0) - (lastTwo[0]!.date ?? 0)) / (24 * 3600)
+          : Number.POSITIVE_INFINITY;
+      if (mostRecentGapDays > 180) {
+        paymentsPerYear = recentDivs.length;
+      } else {
+        const byInterval = paymentsPerYearFromInterval(entries);
+        paymentsPerYear = byInterval > 0 ? byInterval : recentDivs.length;
+      }
+    }
 
     const latestEntry = entries[entries.length - 1]!;
     const exDividendDate = (latestEntry.date ?? 0) * 1000;

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -203,6 +203,29 @@ function inferDividendFrequency(paymentsPerYear: number): string {
   return '';
 }
 
+/**
+ * Implied payments-per-year from the median gap between dividends. More
+ * robust than counting payments inside a 365.25-day window: quarterly
+ * payers whose last-year-Q1 payment falls just outside the window (common
+ * after mid-April each year) were misclassified as Semi-annual.
+ */
+function paymentsPerYearFromInterval(sortedEntries: ReadonlyArray<{ date?: number }>): number {
+  if (sortedEntries.length < 2) return 0;
+  const gaps: number[] = [];
+  for (let i = 1; i < sortedEntries.length; i++) {
+    const prev = sortedEntries[i - 1]!.date;
+    const curr = sortedEntries[i]!.date;
+    if (typeof prev !== 'number' || typeof curr !== 'number') continue;
+    const gapDays = (curr - prev) / (24 * 3600);
+    if (gapDays > 0) gaps.push(gapDays);
+  }
+  if (gaps.length === 0) return 0;
+  gaps.sort((a, b) => a - b);
+  const medianGapDays = gaps[Math.floor(gaps.length / 2)]!;
+  if (medianGapDays <= 0) return 0;
+  return 365.25 / medianGapDays;
+}
+
 function computeDividendCagr(annualTotals: Map<number, number>): number {
   if (annualTotals.size < 2) return 0;
   const years = [...annualTotals.keys()].sort((a, b) => a - b);
@@ -261,7 +284,12 @@ export async function fetchDividendProfile(symbol: string, currentPrice: number)
     const recentDivs = entries.filter((d) => (d.date ?? 0) * 1000 >= oneYearAgo);
     const trailingAnnual = recentDivs.reduce((sum, d) => sum + (d.amount ?? 0), 0);
     const dividendYield = currentPrice > 0 ? (trailingAnnual / currentPrice) * 100 : 0;
-    const paymentsPerYear = recentDivs.length || (entries.length / Math.max(1, annualTotals.size));
+    // Prefer inter-payment-interval classification (robust to calendar drift);
+    // fall back to recentDivs count if entries are too sparse to compute gaps.
+    const byInterval = paymentsPerYearFromInterval(entries);
+    const paymentsPerYear = byInterval > 0
+      ? byInterval
+      : (recentDivs.length || (entries.length / Math.max(1, annualTotals.size)));
 
     const latestEntry = entries[entries.length - 1]!;
     const exDividendDate = (latestEntry.date ?? 0) * 1000;

--- a/tests/stock-dividend-profile.test.mts
+++ b/tests/stock-dividend-profile.test.mts
@@ -190,6 +190,32 @@ describe('fetchDividendProfile', () => {
     assert.equal(profile.dividendFrequency, '');
   });
 
+  it('detects a recent monthly → quarterly cadence change', async () => {
+    // 12 monthly payments in year -2..-1 (all outside trailing 12 months)
+    // plus 4 quarterly payments inside the trailing year. A 2-year median
+    // gap is ~30d (Monthly dominates the history), but current cadence
+    // is clearly quarterly. The classifier must look at trailing-year
+    // gaps only when there are enough of them.
+    const now = Math.floor(Date.now() / 1000);
+    const day = 24 * 3600;
+    const divs: Record<string, { amount: number; date: number }> = {};
+    // Monthly leg: 12 payments from month -24 to month -13.
+    for (let m = 13; m <= 24; m++) {
+      const ts = now - m * 30 * day;
+      divs[String(ts)] = { amount: 0.10, date: ts };
+    }
+    // Quarterly leg: 4 payments in the last year at ~ -30, -120, -210, -300 days.
+    for (let q = 0; q < 4; q++) {
+      const ts = now - (30 + q * 90) * day;
+      divs[String(ts)] = { amount: 0.30, date: ts };
+    }
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify(makeDividendChartPayload(divs)), { status: 200 });
+    }) as typeof fetch;
+    const profile = await fetchDividendProfile('SHIFT', 100);
+    assert.equal(profile.dividendFrequency, 'Quarterly');
+  });
+
   it('detects a recent quarterly → annual cadence change', async () => {
     // 3 years of quarterly history (12 entries, ~91d gap) followed by
     // a single annual payment in the last year. Whole-series median

--- a/tests/stock-dividend-profile.test.mts
+++ b/tests/stock-dividend-profile.test.mts
@@ -169,6 +169,51 @@ describe('fetchDividendProfile', () => {
     assert.equal(profile.dividendFrequency, 'Annual');
   });
 
+  it('emits empty frequency when the dividend program has been suspended', async () => {
+    // 3 years of quarterly history, then silence for the last 18 months.
+    // dividendYield and trailingAnnualDividendRate are both 0; emitting
+    // 'Quarterly' from the historical median gap would contradict them.
+    const now = Math.floor(Date.now() / 1000);
+    const quarterSec = Math.floor((365.25 / 4) * 24 * 3600);
+    const silenceSec = 18 * 30 * 24 * 3600;
+    const divs: Record<string, { amount: number; date: number }> = {};
+    for (let q = 0; q < 12; q++) {
+      const ts = now - silenceSec - q * quarterSec;
+      divs[String(ts)] = { amount: 0.50, date: ts };
+    }
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify(makeDividendChartPayload(divs)), { status: 200 });
+    }) as typeof fetch;
+    const profile = await fetchDividendProfile('SUSP', 100);
+    assert.equal(profile.dividendYield, 0);
+    assert.equal(profile.trailingAnnualDividendRate, 0);
+    assert.equal(profile.dividendFrequency, '');
+  });
+
+  it('detects a recent quarterly → annual cadence change', async () => {
+    // 3 years of quarterly history (12 entries, ~91d gap) followed by
+    // a single annual payment in the last year. Whole-series median
+    // would still report ~91d (Quarterly); the recent-window median
+    // correctly reports ~365d (Annual).
+    const now = Math.floor(Date.now() / 1000);
+    const quarterSec = Math.floor((365.25 / 4) * 24 * 3600);
+    const divs: Record<string, { amount: number; date: number }> = {};
+    // Historical quarterly payments, 2..5 years ago (all ≥ 1 year ago).
+    for (let q = 0; q < 12; q++) {
+      const ts = now - (365.25 * 24 * 3600) - q * quarterSec;
+      divs[String(ts)] = { amount: 0.50, date: Math.floor(ts) };
+    }
+    // One payment inside the trailing year at roughly T-60d.
+    const recentTs = now - 60 * 24 * 3600;
+    divs[String(recentTs)] = { amount: 0.50, date: recentTs };
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify(makeDividendChartPayload(divs)), { status: 200 });
+    }) as typeof fetch;
+    const profile = await fetchDividendProfile('SLOW', 100);
+    // Exactly one payment in trailing 12 months → paymentsPerYear ≈ 1 → Annual.
+    assert.equal(profile.dividendFrequency, 'Annual');
+  });
+
   it('filters out zero-amount dividends', async () => {
     const now = Math.floor(Date.now() / 1000);
     const divs: Record<string, { amount: number; date: number }> = {

--- a/tests/stock-dividend-profile.test.mts
+++ b/tests/stock-dividend-profile.test.mts
@@ -90,6 +90,8 @@ describe('fetchDividendProfile', () => {
     const currentYear = new Date().getFullYear();
     const divs: Record<string, { amount: number; date: number }> = {};
     // Four fully completed prior calendar years, growing 0.50 -> 0.65.
+    // CAGR is computed only on years < currentYear (see computeDividendCagr),
+    // so the prior-year block is the sole source of CAGR signal.
     const startYear = currentYear - 4;
     for (let yearIndex = 0; yearIndex < 4; yearIndex++) {
       const year = startYear + yearIndex;


### PR DESCRIPTION
## Summary

The dividend-frequency classifier counted payments inside a trailing 365.25-day window. Quarterly payers whose prior-year Q1 payment sat just outside that window — common after mid-April each year, when \`Date.now() - 365.25d\` lands past Jan's payment timestamp — got misclassified as Semi-annual.

The 'non-zero CAGR for a quarterly payer with several full calendar years' test flaked on exactly this date boundary: Apr 15 2025 dividend at 00:00 UTC versus \`oneYearAgo ≈ Apr 15 2025 01:00 UTC\` excluded it, leaving 2 payments in the window instead of 3 → Semi-annual → assertion fail.

Fix: classify by median inter-payment interval. Quarterly payers have ~91d median gap regardless of where the trailing window bisects the series. Falls back to the old count when fewer than 2 entries exist.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: test-only flake plus a narrow classifier change on a Vercel edge endpoint that already has robust fallback paths. Watch Sentry for any new \`analyze-stock\` errors in the 24h after deploy.

---

🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)