### PR TITLE
fix(sentry): suppress 6 noise patterns from triage

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -306,7 +306,7 @@ Sentry.init({
     // Suppress Sentry SDK DOM breadcrumb null-access on document.activeElement/contains
     if (/Cannot read properties of null \(reading 'contains'\)|null is not an object \(evaluating '\w+\.contains'\)/.test(msg) && frames.some(f => /\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     // Suppress Convex WS onmessage JSON.parse truncation (intermittent WS frame splits on Ping/Updated control messages)
-    if (excType === 'SyntaxError' && /is not valid JSON/.test(msg) && frames.some(f => /onmessage/.test(f.function ?? ''))) return null;
+    if (excType === 'SyntaxError' && /is not valid JSON/.test(msg) && !hasFirstParty && frames.some(f => /onmessage/.test(f.function ?? ''))) return null;
     // Suppress errors originating from UV proxy (Ultraviolet service worker)
     if (frames.some(f => /\/uv\/service\//.test(f.filename ?? '') || /uv\.handler/.test(f.filename ?? ''))) return null;
     // Suppress Greasemonkey/Tampermonkey userscript errors (x-plugin-script)

--- a/src/main.ts
+++ b/src/main.ts
@@ -246,6 +246,7 @@ Sentry.init({
     /doesn't provide an export named/, // stale cached chunk after deploy references removed export
     /Possible side-effect in debug-evaluate/, // Chrome DevTools internal EvalError
     /ConvexError: CONFLICT/, // Expected OCC rejection on concurrent preference saves
+    /\[CONVEX [AQM]\(.+?\)\] Connection lost while action was in flight/, // Convex SDK transient WS disconnect
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';
@@ -300,6 +301,12 @@ Sentry.init({
     if (/evaluating '(?:element|e)\.offset(?:Width|Height)'/.test(msg) && frames.some(f => /\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     // Suppress errors originating entirely from blob: URLs (browser extensions)
     if (frames.length > 0 && frames.every(f => /^blob:/.test(f.filename ?? ''))) return null;
+    // Suppress errors where any frame is a chrome/moz/safari extension intercepting fetch/XHR
+    if (frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? ''))) return null;
+    // Suppress Sentry SDK DOM breadcrumb null-access on document.activeElement/contains
+    if (/Cannot read properties of null \(reading 'contains'\)|null is not an object \(evaluating '\w+\.contains'\)/.test(msg) && frames.some(f => /\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
+    // Suppress Convex WS onmessage JSON.parse truncation (intermittent WS frame splits on Ping/Updated control messages)
+    if (excType === 'SyntaxError' && /is not valid JSON/.test(msg) && frames.some(f => /onmessage/.test(f.function ?? ''))) return null;
     // Suppress errors originating from UV proxy (Ultraviolet service worker)
     if (frames.some(f => /\/uv\/service\//.test(f.filename ?? '') || /uv\.handler/.test(f.filename ?? ''))) return null;
     // Suppress Greasemonkey/Tampermonkey userscript errors (x-plugin-script)
@@ -347,7 +354,7 @@ Sentry.init({
       || /NotSupportedError/.test(msg)
       || /^Key not found$/.test(msg)
       || /^Element not found$/.test(msg)
-      || /^TypeError: Failed to fetch/.test(msg)
+      || /^(?:TypeError: )?Failed to fetch$/.test(msg)
       || /^TypeError: NetworkError/.test(msg)
       || /Could not connect to the server/.test(msg)
       || /(?:Failed to fetch|Importing a module script failed|error loading) dynamically imported module/i.test(msg)

--- a/src/main.ts
+++ b/src/main.ts
@@ -301,10 +301,14 @@ Sentry.init({
     if (/evaluating '(?:element|e)\.offset(?:Width|Height)'/.test(msg) && frames.some(f => /\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     // Suppress errors originating entirely from blob: URLs (browser extensions)
     if (frames.length > 0 && frames.every(f => /^blob:/.test(f.filename ?? ''))) return null;
-    // Suppress errors where any frame is a chrome/moz/safari extension intercepting fetch/XHR
-    if (frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? ''))) return null;
-    // Suppress Sentry SDK DOM breadcrumb null-access on document.activeElement/contains
-    if (/Cannot read properties of null \(reading 'contains'\)|null is not an object \(evaluating '\w+\.contains'\)/.test(msg) && frames.some(f => /\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
+    // Suppress errors where any frame is a chrome/moz/safari extension, ONLY when stack has no first-party frames.
+    // A first-party frame elsewhere in the stack means the error likely originated in our code; surface it even if
+    // an extension wrapped the call.
+    if (!hasFirstParty && frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? ''))) return null;
+    // Suppress Sentry SDK DOM breadcrumb null-access on document.activeElement/contains.
+    // Gated on !hasFirstParty because Sentry wraps first-party handlers, so a genuine app `el.contains(...)` bug
+    // can produce a stack containing both main-*.js and sentry-*.js frames.
+    if (!hasFirstParty && /Cannot read properties of null \(reading 'contains'\)|null is not an object \(evaluating '\w+\.contains'\)/.test(msg) && frames.some(f => /\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     // Suppress Convex WS onmessage JSON.parse truncation (intermittent WS frame splits on Ping/Updated control messages)
     if (excType === 'SyntaxError' && /is not valid JSON/.test(msg) && !hasFirstParty && frames.some(f => /onmessage/.test(f.function ?? ''))) return null;
     // Suppress errors originating from UV proxy (Ultraviolet service worker)

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -324,4 +324,58 @@ describe('existing beforeSend filters', () => {
     );
     assert.ok(beforeSend(event) !== null, 'first-party runtime regression must still surface');
   });
+
+  // WORLDMONITOR-MP: Chrome extension intercepting maplibre fetch.
+  it('suppresses any error with a chrome-extension:// frame in the stack', () => {
+    const event = makeEvent('Failed to fetch (pub-x.r2.dev)', 'TypeError', [
+      firstPartyFrame('/assets/maplibre-WH5fAPRo.js', 'FetchSource.load'),
+      { filename: 'chrome-extension://abc/frame_ant.js', lineno: 1, function: 'window.fetch' },
+    ]);
+    assert.equal(beforeSend(event), null);
+  });
+
+  it('suppresses errors with moz-extension and safari-web-extension frames', () => {
+    for (const url of ['moz-extension://abc/inj.js', 'safari-web-extension://abc/inj.js']) {
+      const event = makeEvent('whatever', 'TypeError', [
+        { filename: url, lineno: 1, function: 'inject' },
+      ]);
+      assert.equal(beforeSend(event), null, `should suppress for ${url}`);
+    }
+  });
+
+  // WORLDMONITOR-MQ: Sentry SDK DOM breadcrumb null.contains crash.
+  it("suppresses null 'contains' read when a sentry-*.js frame is in the stack", () => {
+    const event = makeEvent("Cannot read properties of null (reading 'contains')", 'TypeError', [
+      { filename: '/assets/sentry-C2sjIlLb.js', lineno: 1, function: 'HTMLDocument.r' },
+      { filename: '/assets/main-MURvZ_wC.js', lineno: 1, function: 'HTMLDocument.x' },
+    ]);
+    assert.equal(beforeSend(event), null);
+  });
+
+  it("does NOT suppress null 'contains' read when no sentry-*.js frame is present", () => {
+    const event = makeEvent("Cannot read properties of null (reading 'contains')", 'TypeError', [
+      firstPartyFrame('src/components/SomePanel.ts', 'handleClick'),
+    ]);
+    assert.ok(beforeSend(event) !== null, 'first-party null.contains must still surface');
+  });
+
+  // WORLDMONITOR-MV: Convex WS onmessage JSON.parse truncation — suppress only when stack has no first-party frames.
+  it('suppresses SyntaxError "is not valid JSON" with onmessage frame and no first-party frames', () => {
+    const event = makeEvent(
+      'Unexpected token \'p\', "pdated","Ping"}" is not valid JSON',
+      'SyntaxError',
+      [
+        { filename: '<anonymous>', lineno: 1, function: 'e.onmessage' },
+        { filename: '<anonymous>', lineno: 1, function: 'JSON.parse' },
+      ],
+    );
+    assert.equal(beforeSend(event), null);
+  });
+
+  it('does NOT suppress SyntaxError "is not valid JSON" when a first-party onmessage handler is present', () => {
+    const event = makeEvent('Unexpected token in JSON at position 0 is not valid JSON', 'SyntaxError', [
+      firstPartyFrame('src/services/stream.ts', 'onmessage'),
+    ]);
+    assert.ok(beforeSend(event) !== null, 'first-party onmessage regression must surface');
+  });
 });

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -325,16 +325,16 @@ describe('existing beforeSend filters', () => {
     assert.ok(beforeSend(event) !== null, 'first-party runtime regression must still surface');
   });
 
-  // WORLDMONITOR-MP: Chrome extension intercepting maplibre fetch.
-  it('suppresses any error with a chrome-extension:// frame in the stack', () => {
+  // WORLDMONITOR-MP: Chrome extension intercepting maplibre fetch — suppress only when no first-party frames.
+  it('suppresses chrome-extension-frame errors when no first-party frames are present', () => {
     const event = makeEvent('Failed to fetch (pub-x.r2.dev)', 'TypeError', [
-      firstPartyFrame('/assets/maplibre-WH5fAPRo.js', 'FetchSource.load'),
+      { filename: '/assets/maplibre-WH5fAPRo.js', lineno: 1, function: 'FetchSource.load' }, // vendor chunk → not first-party
       { filename: 'chrome-extension://abc/frame_ant.js', lineno: 1, function: 'window.fetch' },
     ]);
     assert.equal(beforeSend(event), null);
   });
 
-  it('suppresses errors with moz-extension and safari-web-extension frames', () => {
+  it('suppresses moz/safari-extension-frame errors when no first-party frames are present', () => {
     for (const url of ['moz-extension://abc/inj.js', 'safari-web-extension://abc/inj.js']) {
       const event = makeEvent('whatever', 'TypeError', [
         { filename: url, lineno: 1, function: 'inject' },
@@ -343,13 +343,28 @@ describe('existing beforeSend filters', () => {
     }
   });
 
-  // WORLDMONITOR-MQ: Sentry SDK DOM breadcrumb null.contains crash.
-  it("suppresses null 'contains' read when a sentry-*.js frame is in the stack", () => {
+  it('does NOT suppress extension-frame errors when a first-party frame is also present', () => {
+    const event = makeEvent('x is not defined', 'ReferenceError', [
+      firstPartyFrame('/assets/panels-DzUv7BBV.js', 'loadTab'),
+      { filename: 'chrome-extension://abc/inj.js', lineno: 1, function: 'inject' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'first-party bug must surface even if an extension frame is on the stack');
+  });
+
+  // WORLDMONITOR-MQ: Sentry SDK DOM breadcrumb null.contains crash — suppress only when no first-party frames.
+  it("suppresses null 'contains' read on a sentry-*.js frame with no first-party frames", () => {
     const event = makeEvent("Cannot read properties of null (reading 'contains')", 'TypeError', [
       { filename: '/assets/sentry-C2sjIlLb.js', lineno: 1, function: 'HTMLDocument.r' },
-      { filename: '/assets/main-MURvZ_wC.js', lineno: 1, function: 'HTMLDocument.x' },
     ]);
     assert.equal(beforeSend(event), null);
+  });
+
+  it("does NOT suppress null 'contains' read when a first-party frame is also present (Sentry wraps handlers)", () => {
+    const event = makeEvent("Cannot read properties of null (reading 'contains')", 'TypeError', [
+      { filename: '/assets/sentry-C2sjIlLb.js', lineno: 1, function: 'HTMLDocument.r' },
+      firstPartyFrame('/assets/main-MURvZ_wC.js', 'handleClick'),
+    ]);
+    assert.ok(beforeSend(event) !== null, 'first-party el.contains bug must surface even with sentry frame on stack');
   });
 
   it("does NOT suppress null 'contains' read when no sentry-*.js frame is present", () => {


### PR DESCRIPTION
## Summary
Sentry triage of 9 unresolved issues → 6 classified as noise. Adding filters so they don't re-fire:

- **WORLDMONITOR-MW** — Convex \`Connection lost while action was in flight\` → \`ignoreErrors\` (Convex-specific phrasing)
- **WORLDMONITOR-MV** — Convex WS \`onmessage\` JSON.parse truncation on Ping/Updated frames → \`beforeSend\` gated on \`onmessage\` frame
- **WORLDMONITOR-MP** — Chrome extension intercepting maplibre fetch → \`beforeSend\` drops any \`chrome/moz/safari-extension://\` frame
- **WORLDMONITOR-MQ** — Sentry SDK DOM breadcrumb \`null.contains\` → \`beforeSend\` gated on sentry chunk
- **WORLDMONITOR-KY** — Bare \`Failed to fetch\` (msg lacks \`TypeError:\` prefix) → fixed regex to match both forms
- **WORLDMONITOR-MT** — already covered by existing \`/appendChild.*Unexpected token/\`

Unresolved (first-party frames, ambiguous): MR, MG, MS.

## Test plan
- [x] \`npm run typecheck\` / \`typecheck:api\`
- [x] \`npm run lint\`
- [x] \`node --test tests/sentry-beforesend.test.mjs\` — 84/84 pass
- [x] \`node --test tests/edge-functions.test.mjs\`
- [x] \`npm run test:data\` — only pre-existing dividend test fails on main
- [x] \`npm run lint:md\` / \`version:check\`