### PR TITLE
fix(bundle-runner): stream child stdio + SIGKILL escalation on timeout

### DIFF
--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -121,9 +121,15 @@ function spawnSeed(scriptPath, { timeoutMs, label }) {
     let settled = false;
     let timedOut = false;
     let killTimer = null;
+    // Fire the terminal "Failed ... timeout" log the moment we decide to kill,
+    // BEFORE the SIGTERM→SIGKILL grace window. This guarantees the reason
+    // reaches the log stream even if the container itself is killed during
+    // the grace period (Railway's ~10min cap can land inside the grace for
+    // sections whose timeoutMs is close to 10min).
     const softKill = setTimeout(() => {
       timedOut = true;
-      console.warn(`  [${label}] Timeout at ${Math.round(timeoutMs / 1000)}s — sending SIGTERM`);
+      const elapsedAtTimeout = ((Date.now() - t0) / 1000).toFixed(1);
+      console.error(`  [${label}] Failed after ${elapsedAtTimeout}s: timeout after ${Math.round(timeoutMs / 1000)}s — sending SIGTERM`);
       child.kill('SIGTERM');
       killTimer = setTimeout(() => {
         console.warn(`  [${label}] Did not exit on SIGTERM within ${KILL_GRACE_MS / 1000}s — sending SIGKILL`);
@@ -140,13 +146,15 @@ function spawnSeed(scriptPath, { timeoutMs, label }) {
 
     child.on('error', (err) => {
       const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
-      settle({ elapsed, ok: false, reason: `spawn error: ${err.message}` });
+      console.error(`  [${label}] Failed after ${elapsed}s: spawn error: ${err.message}`);
+      settle({ elapsed, ok: false, reason: `spawn error: ${err.message}`, alreadyLogged: true });
     });
 
     child.on('close', (code, signal) => {
       const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
       if (timedOut) {
-        settle({ elapsed, ok: false, reason: `timeout after ${Math.round(timeoutMs / 1000)}s (signal ${signal || 'SIGTERM'})` });
+        // Terminal reason already logged by softKill — just record the outcome.
+        settle({ elapsed, ok: false, reason: `timeout after ${Math.round(timeoutMs / 1000)}s (signal ${signal || 'SIGTERM'})`, alreadyLogged: true });
       } else if (code === 0) {
         settle({ elapsed, ok: true });
       } else {
@@ -193,10 +201,13 @@ export async function runBundle(label, sections, opts = {}) {
     }
 
     const elapsedBundle = Date.now() - t0;
-    if (elapsedBundle + timeout > maxBundleMs) {
+    // Worst-case runtime is timeoutMs + KILL_GRACE_MS (child may ignore SIGTERM
+    // and need SIGKILL after grace). Admit only when the full worst-case fits.
+    const worstCase = timeout + KILL_GRACE_MS;
+    if (elapsedBundle + worstCase > maxBundleMs) {
       const remainingSec = Math.max(0, Math.round((maxBundleMs - elapsedBundle) / 1000));
-      const timeoutSec = Math.round(timeout / 1000);
-      console.log(`  [${section.label}] Deferred, needs ${timeoutSec}s but only ${remainingSec}s left in bundle budget`);
+      const needSec = Math.round(worstCase / 1000);
+      console.log(`  [${section.label}] Deferred, needs ${needSec}s (timeout+grace) but only ${remainingSec}s left in bundle budget`);
       deferred++;
       continue;
     }
@@ -206,7 +217,9 @@ export async function runBundle(label, sections, opts = {}) {
       console.log(`  [${section.label}] Done (${result.elapsed}s)`);
       ran++;
     } else {
-      console.error(`  [${section.label}] Failed after ${result.elapsed}s: ${result.reason}`);
+      if (!result.alreadyLogged) {
+        console.error(`  [${section.label}] Failed after ${result.elapsed}s: ${result.reason}`);
+      }
       failed++;
     }
   }

--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 /**
- * Bundle orchestrator: spawns multiple seed scripts sequentially
- * via child_process.execFile, with freshness-gated skipping.
- *
- * Pattern matches ais-relay.cjs:5645-5695 (ClimateNews/ChokepointFlows spawns).
+ * Bundle orchestrator: spawns multiple seed scripts sequentially via
+ * child_process.spawn, with line-streamed stdio, SIGTERM→SIGKILL escalation on
+ * timeout, and freshness-gated skipping. Streaming matters because a hanging
+ * section would otherwise buffer its logs until exit and look like a silent
+ * container crash (see PR that replaced execFile).
  *
  * Usage from a bundle script:
  *   import { runBundle } from './_bundle-runner.mjs';
@@ -114,8 +115,16 @@ function spawnSeed(scriptPath, { timeoutMs, label }) {
     streamLines(child.stdout, (line) => console.log(`  [${label}] ${line}`));
     streamLines(child.stderr, (line) => console.warn(`  [${label}] ${line}`));
 
+    let settled = false;
     let timedOut = false;
     let killTimer = null;
+    const settle = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(softKill);
+      if (killTimer) clearTimeout(killTimer);
+      resolve(value);
+    };
     const softKill = setTimeout(() => {
       timedOut = true;
       console.warn(`  [${label}] Timeout at ${Math.round(timeoutMs / 1000)}s — sending SIGTERM`);
@@ -127,22 +136,18 @@ function spawnSeed(scriptPath, { timeoutMs, label }) {
     }, timeoutMs);
 
     child.on('error', (err) => {
-      clearTimeout(softKill);
-      if (killTimer) clearTimeout(killTimer);
       const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
-      resolve({ elapsed, ok: false, reason: `spawn error: ${err.message}` });
+      settle({ elapsed, ok: false, reason: `spawn error: ${err.message}` });
     });
 
     child.on('close', (code, signal) => {
-      clearTimeout(softKill);
-      if (killTimer) clearTimeout(killTimer);
       const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
       if (timedOut) {
-        resolve({ elapsed, ok: false, reason: `timeout after ${Math.round(timeoutMs / 1000)}s (signal ${signal || 'SIGTERM'})` });
+        settle({ elapsed, ok: false, reason: `timeout after ${Math.round(timeoutMs / 1000)}s (signal ${signal || 'SIGTERM'})` });
       } else if (code === 0) {
-        resolve({ elapsed, ok: true });
+        settle({ elapsed, ok: true });
       } else {
-        resolve({ elapsed, ok: false, reason: `exit ${code ?? 'null'}${signal ? ` (signal ${signal})` : ''}` });
+        settle({ elapsed, ok: false, reason: `exit ${code ?? 'null'}${signal ? ` (signal ${signal})` : ''}` });
       }
     });
   });

--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -102,6 +102,9 @@ function streamLines(stream, onLine) {
     }
   });
   stream.on('end', () => { if (buf) onLine(buf); });
+  // Child-stdio `error` is rare (SIGKILL emits `end`), but Node throws on an
+  // unhandled `error` event. Log it instead of crashing the runner.
+  stream.on('error', (err) => onLine(`<stdio error: ${err.message}>`));
 }
 
 function spawnSeed(scriptPath, { timeoutMs, label }) {
@@ -118,13 +121,6 @@ function spawnSeed(scriptPath, { timeoutMs, label }) {
     let settled = false;
     let timedOut = false;
     let killTimer = null;
-    const settle = (value) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(softKill);
-      if (killTimer) clearTimeout(killTimer);
-      resolve(value);
-    };
     const softKill = setTimeout(() => {
       timedOut = true;
       console.warn(`  [${label}] Timeout at ${Math.round(timeoutMs / 1000)}s — sending SIGTERM`);
@@ -134,6 +130,13 @@ function spawnSeed(scriptPath, { timeoutMs, label }) {
         child.kill('SIGKILL');
       }, KILL_GRACE_MS);
     }, timeoutMs);
+    const settle = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(softKill);
+      if (killTimer) clearTimeout(killTimer);
+      resolve(value);
+    };
 
     child.on('error', (err) => {
       const elapsed = ((Date.now() - t0) / 1000).toFixed(1);

--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -20,7 +20,7 @@
  * broken by adopting the runner.
  */
 
-import { execFile } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadEnvFile } from './_seed-utils.mjs';
@@ -83,30 +83,66 @@ async function readSectionFreshness(section) {
   return null;
 }
 
+// Stream child stdio line-by-line so hung sections surface progress instead of
+// looking like a silent crash. Escalate SIGTERM → SIGKILL on timeout so child
+// processes with in-flight HTTPS sockets can't outlive the deadline.
+const KILL_GRACE_MS = 10_000;
+
+function streamLines(stream, onLine) {
+  let buf = '';
+  stream.setEncoding('utf8');
+  stream.on('data', (chunk) => {
+    buf += chunk;
+    let idx;
+    while ((idx = buf.indexOf('\n')) !== -1) {
+      const line = buf.slice(0, idx);
+      buf = buf.slice(idx + 1);
+      if (line) onLine(line);
+    }
+  });
+  stream.on('end', () => { if (buf) onLine(buf); });
+}
+
 function spawnSeed(scriptPath, { timeoutMs, label }) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     const t0 = Date.now();
-    execFile(process.execPath, [scriptPath], {
+    const child = spawn(process.execPath, [scriptPath], {
       env: process.env,
-      timeout: timeoutMs,
-      maxBuffer: 2 * 1024 * 1024,
-    }, (err, stdout, stderr) => {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    streamLines(child.stdout, (line) => console.log(`  [${label}] ${line}`));
+    streamLines(child.stderr, (line) => console.warn(`  [${label}] ${line}`));
+
+    let timedOut = false;
+    let killTimer = null;
+    const softKill = setTimeout(() => {
+      timedOut = true;
+      console.warn(`  [${label}] Timeout at ${Math.round(timeoutMs / 1000)}s — sending SIGTERM`);
+      child.kill('SIGTERM');
+      killTimer = setTimeout(() => {
+        console.warn(`  [${label}] Did not exit on SIGTERM within ${KILL_GRACE_MS / 1000}s — sending SIGKILL`);
+        child.kill('SIGKILL');
+      }, KILL_GRACE_MS);
+    }, timeoutMs);
+
+    child.on('error', (err) => {
+      clearTimeout(softKill);
+      if (killTimer) clearTimeout(killTimer);
       const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
-      if (stdout) {
-        for (const line of String(stdout).trim().split('\n')) {
-          if (line) console.log(`  [${label}] ${line}`);
-        }
-      }
-      if (stderr) {
-        for (const line of String(stderr).trim().split('\n')) {
-          if (line) console.warn(`  [${label}] ${line}`);
-        }
-      }
-      if (err) {
-        const reason = err.killed ? 'timeout' : (err.code || err.message);
-        reject(new Error(`${label} failed after ${elapsed}s: ${reason}`));
+      resolve({ elapsed, ok: false, reason: `spawn error: ${err.message}` });
+    });
+
+    child.on('close', (code, signal) => {
+      clearTimeout(softKill);
+      if (killTimer) clearTimeout(killTimer);
+      const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+      if (timedOut) {
+        resolve({ elapsed, ok: false, reason: `timeout after ${Math.round(timeoutMs / 1000)}s (signal ${signal || 'SIGTERM'})` });
+      } else if (code === 0) {
+        resolve({ elapsed, ok: true });
       } else {
-        resolve({ elapsed });
+        resolve({ elapsed, ok: false, reason: `exit ${code ?? 'null'}${signal ? ` (signal ${signal})` : ''}` });
       }
     });
   });
@@ -157,12 +193,12 @@ export async function runBundle(label, sections, opts = {}) {
       continue;
     }
 
-    try {
-      const result = await spawnSeed(scriptPath, { timeoutMs: timeout, label: section.label });
+    const result = await spawnSeed(scriptPath, { timeoutMs: timeout, label: section.label });
+    if (result.ok) {
       console.log(`  [${section.label}] Done (${result.elapsed}s)`);
       ran++;
-    } catch (err) {
-      console.error(`  [${section.label}] ${err.message}`);
+    } else {
+      console.error(`  [${section.label}] Failed after ${result.elapsed}s: ${result.reason}`);
       failed++;
     }
   }

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -58,7 +58,7 @@ test('streams child stdout live and reports Done on success', async () => {
   }
 });
 
-test('timeout escalates to SIGKILL when child ignores SIGTERM and logs reason', async () => {
+test('timeout emits terminal reason BEFORE SIGTERM/SIGKILL grace (survives container kill)', async () => {
   const cleanup = writeFixture(
     '_bundle-fixture-hang.mjs',
     // Ignore SIGTERM so the runner must SIGKILL.
@@ -73,11 +73,36 @@ test('timeout escalates to SIGKILL when child ignores SIGTERM and logs reason', 
     assert.equal(code, 1, 'bundle must exit non-zero on failure');
     const combined = stdout + stderr;
     assert.match(combined, /\[HANG\] hung/, 'child stdout should stream before kill');
-    assert.match(combined, /Timeout at 1s — sending SIGTERM/);
+    // Critical: terminal "Failed ... timeout" line must appear in-line with the
+    // SIGTERM send, not after SIGKILL — this is what survives a container kill
+    // landing inside the 10s grace window.
+    const failIdx = combined.indexOf('Failed after');
+    const sigkillIdx = combined.indexOf('SIGKILL');
+    assert.ok(failIdx >= 0, 'must emit Failed line');
+    assert.ok(sigkillIdx > failIdx, 'Failed line must precede SIGKILL escalation');
+    assert.match(combined, /Failed after .*s: timeout after 1s — sending SIGTERM/);
     assert.match(combined, /Did not exit on SIGTERM.*SIGKILL/);
-    assert.match(combined, /Failed after .*s: timeout after 1s/);
     // 1s timeout + 10s SIGTERM grace + overhead; cap well above that to avoid flake.
     assert.ok(elapsedMs < 20_000, `timeout escalation took ${elapsedMs}ms — too slow`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('budget check accounts for SIGKILL grace when deferring', async () => {
+  const cleanup = writeFixture(
+    '_bundle-fixture-sleep.mjs',
+    `console.log('ok');\n`,
+  );
+  try {
+    // timeoutMs (15s) + grace (10s) = 25s worst-case. Budget 20s must defer.
+    const { code, stdout } = await runBundleWith(
+      [{ label: 'GATED', script: '_bundle-fixture-sleep.mjs', intervalMs: 1, timeoutMs: 15_000 }],
+      { maxBundleMs: 20_000 },
+    );
+    assert.equal(code, 0, 'deferred sections are not failures');
+    assert.match(stdout, /\[GATED\] Deferred, needs 25s \(timeout\+grace\)/);
+    assert.match(stdout, /deferred:1/);
   } finally {
     cleanup();
   }

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -1,0 +1,102 @@
+// Verifies _bundle-runner.mjs streams child stdio live, reports timeout with
+// a clear reason, and escalates SIGTERM → SIGKILL when a child ignores SIGTERM.
+//
+// Uses a real spawn of a small bundle against ephemeral scripts under scripts/
+// because the runner joins __dirname with section.script.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SCRIPTS_DIR = new URL('../scripts/', import.meta.url).pathname;
+
+function runBundleWith(sections, opts = {}) {
+  const runPath = join(SCRIPTS_DIR, '_bundle-runner-test-run.mjs');
+  writeFileSync(
+    runPath,
+    `import { runBundle } from './_bundle-runner.mjs';\nawait runBundle('test', ${JSON.stringify(
+      sections,
+    )}, ${JSON.stringify(opts)});\n`,
+  );
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [runPath], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => { stdout += c; });
+    child.stderr.on('data', (c) => { stderr += c; });
+    child.on('close', (code) => {
+      try { unlinkSync(runPath); } catch {}
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+function writeFixture(name, body) {
+  const path = join(SCRIPTS_DIR, name);
+  writeFileSync(path, body);
+  return () => { try { unlinkSync(path); } catch {} };
+}
+
+test('streams child stdout live and reports Done on success', async () => {
+  const cleanup = writeFixture(
+    '_bundle-fixture-fast.mjs',
+    `console.log('line-one'); console.log('line-two');\n`,
+  );
+  try {
+    const { code, stdout } = await runBundleWith([
+      { label: 'FAST', script: '_bundle-fixture-fast.mjs', intervalMs: 1, timeoutMs: 5000 },
+    ]);
+    assert.equal(code, 0);
+    assert.match(stdout, /\[FAST\] line-one/);
+    assert.match(stdout, /\[FAST\] line-two/);
+    assert.match(stdout, /\[FAST\] Done \(/);
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:1/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('timeout escalates to SIGKILL when child ignores SIGTERM and logs reason', async () => {
+  const cleanup = writeFixture(
+    '_bundle-fixture-hang.mjs',
+    // Ignore SIGTERM so the runner must SIGKILL.
+    `process.on('SIGTERM', () => {}); console.log('hung'); setInterval(() => {}, 1000);\n`,
+  );
+  try {
+    const t0 = Date.now();
+    const { code, stdout, stderr } = await runBundleWith([
+      { label: 'HANG', script: '_bundle-fixture-hang.mjs', intervalMs: 1, timeoutMs: 1000 },
+    ]);
+    const elapsedMs = Date.now() - t0;
+    assert.equal(code, 1, 'bundle must exit non-zero on failure');
+    const combined = stdout + stderr;
+    assert.match(combined, /\[HANG\] hung/, 'child stdout should stream before kill');
+    assert.match(combined, /Timeout at 1s — sending SIGTERM/);
+    assert.match(combined, /Did not exit on SIGTERM.*SIGKILL/);
+    assert.match(combined, /Failed after .*s: timeout after 1s/);
+    // 1s timeout + 10s SIGTERM grace + overhead; cap well above that to avoid flake.
+    assert.ok(elapsedMs < 20_000, `timeout escalation took ${elapsedMs}ms — too slow`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('non-zero exit without timeout reports exit code', async () => {
+  const cleanup = writeFixture(
+    '_bundle-fixture-fail.mjs',
+    `console.error('boom'); process.exit(2);\n`,
+  );
+  try {
+    const { code, stdout, stderr } = await runBundleWith([
+      { label: 'FAIL', script: '_bundle-fixture-fail.mjs', intervalMs: 1, timeoutMs: 5000 },
+    ]);
+    assert.equal(code, 1);
+    const combined = stdout + stderr;
+    assert.match(combined, /\[FAIL\] boom/);
+    assert.match(combined, /Failed after .*s: exit 2/);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

seed-bundle-portwatch (and any of the 15 bundles using `_bundle-runner.mjs`) can silently crash on Railway with zero logs from the hung section. Root cause is the runner, not the seeder: `execFile` buffers child stdout until the callback fires, and its default SIGTERM never escalates, so a child holding in-flight HTTPS sockets can outlive the timeout and be killed by the container limit before any diagnostic is emitted.

This PR:
- Switches to `spawn` with line-prefixed live streaming on `stdout`/`stderr`.
- On `timeoutMs`, sends SIGTERM, then SIGKILL after a 10s grace.
- Always emits a terminal reason (`timeout`, `exit N`, `signal X`) on the `[Label] Failed after …` line.
- Idempotent `settle()` guard so `error`+`close` can't double-resolve.
- Adds `tests/bundle-runner.test.mjs` covering live streaming, SIGKILL escalation when the child ignores SIGTERM, and non-zero exit reporting (picked up by `npm run test:data`).

Why portwatch was invisible: after PW-Main completed, PW-Port-Activity (not migrated in PR 2a; unchanged for weeks) hangs on ArcGIS for 7min with buffered logs, SIGTERM gets ignored by the Node process holding open sockets, and Railway kills the container before anyone sees a line. With this change, the next failure surfaces the hung section in real time and always logs a terminal reason.

## Test plan
- [x] `node --test tests/bundle-runner.test.mjs` — 3/3 pass (12s; SIGKILL test takes 11s by design).
- [x] Smoke-ran a fake bundle with a hanging child: `tick` lines stream live; timeout logs SIGTERM then `Failed after 2.0s: timeout after 2s`.
- [ ] After merge, watch next `seed-bundle-portwatch` cron run — should now show live Port-Activity output or a clear `Failed after Ns: timeout …` line, not a silent container crash.
- [ ] Follow-up (Slice B): add an internal wall-clock deadline to `seed-portwatch-port-activity.mjs` so slow ArcGIS degrades gracefully through the existing `DEGRADATION GUARD` instead of relying on SIGTERM.

Applies to all 15 `seed-bundle-*.mjs` services (same runner).