### PR TITLE
fix(auth): remove login gate for all visitors

### DIFF
--- a/pro-test/src/App.tsx
+++ b/pro-test/src/App.tsx
@@ -1244,13 +1244,8 @@ export default function App() {
         <ProShowcase />
         <ApiSection />
         <EnterpriseShowcase />
-        {/* TODO: isProUser gate should be removed when we are ready to get new users signing up */}
-        {(localStorage.getItem('wm-widget-key') || localStorage.getItem('wm-pro-key')) && (
-          <>
-            <PricingSection refCode={getRefCode()} />
-            <PricingTable />
-          </>
-        )}
+        <PricingSection refCode={getRefCode()} />
+        <PricingTable />
         <FAQ />
       </main>
       <Footer />

--- a/src/App.ts
+++ b/src/App.ts
@@ -970,8 +970,7 @@ export class App {
     correlationEngine.registerAdapter(disasterAdapter);
     this.state.correlationEngine = correlationEngine;
     this.eventHandlers.setupUnifiedSettings();
-    // TODO: isProUser() gate should be removed when we are ready to get new users signing up
-    if (isProUser()) this.eventHandlers.setupAuthWidget();
+    this.eventHandlers.setupAuthWidget();
     const pendingCheckout = capturePendingCheckoutIntentFromUrl();
     if (pendingCheckout) {
       // Checkout intent from /pro page redirect. Resume immediately if

--- a/todos/034-pending-p1-auth-init-gated-behind-isProUser-deadlock.md
+++ b/todos/034-pending-p1-auth-init-gated-behind-isProUser-deadlock.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: done
 priority: p1
 issue_id: "034"
 tags: [code-review, bug, auth, clerk]


### PR DESCRIPTION
## Summary
- Removes the `isProUser()` guard around `setupAuthWidget()` in `src/App.ts` so the Sign In button is visible to all visitors, not just users with legacy API keys
- Removes the matching localStorage gate around the pricing section in `pro-test/src/App.tsx`
- Resolves the bootstrapping deadlock documented in todo #034

Per @koala73's request — time to remove the blocker and let everyone sign in.

## Test plan
- [ ] Open the app in a fresh browser (no localStorage keys) — Sign In button should appear in the header
- [ ] Clicking Sign In opens the Clerk auth modal
- [ ] After signing in, pro features work as expected
- [ ] Visit the /pro landing page — pricing section is visible without legacy keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)