### PR TITLE
fix(open-meteo): curl proxy as second-choice when CONNECT proxy fails

### DIFF
--- a/scripts/_open-meteo-archive.mjs
+++ b/scripts/_open-meteo-archive.mjs
@@ -1,4 +1,4 @@
-import { CHROME_UA, sleep, resolveProxy, httpsProxyFetchRaw } from './_seed-utils.mjs';
+import { CHROME_UA, sleep, resolveProxy, httpsProxyFetchRaw, curlFetch } from './_seed-utils.mjs';
 
 const MAX_RETRY_AFTER_MS = 60_000;
 const RETRYABLE_STATUSES = new Set([429, 503]);
@@ -42,12 +42,13 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
     retryBaseMs = 2_000,
     label = zones.map((zone) => zone.name).join(', '),
     // Test hooks. Production callers leave these unset; the helper uses the
-    // real proxy resolver + fetcher from _seed-utils.mjs. Tests inject mocks
-    // here to exercise the proxy fallback path without spinning up a real
+    // real proxy resolver + fetchers from _seed-utils.mjs. Tests inject mocks
+    // here to exercise the proxy fallback paths without spinning up a real
     // Decodo tunnel. Keep these undocumented in PR descriptions — they are
     // implementation-only seams, not a public API surface.
     _proxyResolver = resolveProxy,
     _proxyFetcher = httpsProxyFetchRaw,
+    _proxyCurlFetcher = curlFetch,
   } = opts;
 
   const params = new URLSearchParams({
@@ -118,10 +119,21 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
   // _seed-utils.mjs. Decodo gateway gets a different egress IP that is not
   // (yet) on Open-Meteo's per-IP throttle. Skip silently if no proxy is
   // configured (preserves existing behavior in non-Railway envs).
+  //
+  // Two-attempt cascade: CONNECT path first (pure-Node, faster, no curl
+  // dependency), curl fallback second. Decodo's CONNECT and curl egress
+  // reach DIFFERENT IP pools (per scripts/_proxy-utils.cjs:67), and some
+  // hosts only accept one path — Yahoo Finance returns 404 to Decodo's
+  // CONNECT egress but 200 to the curl egress (probed 2026-04-16). For
+  // Open-Meteo both paths work today, but pinning the helper to one would
+  // be a single point of failure if Decodo rebalances pools. The curl
+  // attempt costs an exec only when CONNECT also failed, so steady-state
+  // overhead is zero.
   const proxyAuth = _proxyResolver();
+  let lastProxyError = null;
   if (proxyAuth) {
     try {
-      console.log(`  [OPEN_METEO] direct exhausted on ${label} (${lastDirectError?.message ?? 'unknown'}); trying proxy`);
+      console.log(`  [OPEN_METEO] direct exhausted on ${label} (${lastDirectError?.message ?? 'unknown'}); trying proxy (CONNECT)`);
       const { buffer } = await _proxyFetcher(url, proxyAuth, {
         accept: 'application/json',
         timeoutMs,
@@ -130,15 +142,35 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
       if (data.length !== zones.length) {
         throw new Error(`Open-Meteo proxy batch size mismatch for ${label}: expected ${zones.length}, got ${data.length}`);
       }
-      console.log(`  [OPEN_METEO] proxy succeeded for ${label}`);
+      console.log(`  [OPEN_METEO] proxy (CONNECT) succeeded for ${label}`);
       return data;
     } catch (proxyErr) {
-      console.warn(`  [OPEN_METEO] proxy fallback failed for ${label}: ${proxyErr?.message ?? proxyErr}`);
+      lastProxyError = proxyErr;
+      console.warn(`  [OPEN_METEO] proxy (CONNECT) failed for ${label}: ${proxyErr?.message ?? proxyErr}; trying proxy (curl)`);
+    }
+
+    // Second-choice proxy attempt via curl. Different egress pool —
+    // succeeds against hosts that 404 the CONNECT path.
+    try {
+      const text = _proxyCurlFetcher(url, proxyAuth, { 'User-Agent': CHROME_UA, Accept: 'application/json' });
+      const data = normalizeArchiveBatchResponse(JSON.parse(text));
+      if (data.length !== zones.length) {
+        throw new Error(`Open-Meteo proxy (curl) batch size mismatch for ${label}: expected ${zones.length}, got ${data.length}`);
+      }
+      console.log(`  [OPEN_METEO] proxy (curl) succeeded for ${label}`);
+      return data;
+    } catch (curlErr) {
+      lastProxyError = curlErr;
+      console.warn(`  [OPEN_METEO] proxy (curl) failed for ${label}: ${curlErr?.message ?? curlErr}`);
     }
   }
 
-  throw new Error(
-    `Open-Meteo retries exhausted for ${label}${lastDirectError ? ` (last direct: ${lastDirectError.message})` : ''}`,
+  // Surface the most relevant upstream signal. Direct error usually wins
+  // (it's why we tried the proxy in the first place). Proxy error is in
+  // cause-chain for deeper inspection.
+  const finalErr = new Error(
+    `Open-Meteo retries exhausted for ${label}${lastDirectError ? ` (last direct: ${lastDirectError.message})` : ''}${lastProxyError ? ` (last proxy: ${lastProxyError.message})` : ''}`,
     lastDirectError ? { cause: lastDirectError } : undefined,
   );
+  throw finalErr;
 }

--- a/scripts/_open-meteo-archive.mjs
+++ b/scripts/_open-meteo-archive.mjs
@@ -1,4 +1,24 @@
-import { CHROME_UA, sleep, resolveProxy, httpsProxyFetchRaw, curlFetch } from './_seed-utils.mjs';
+import { CHROME_UA, sleep, resolveProxy, resolveProxyForConnect, httpsProxyFetchRaw, curlFetch } from './_seed-utils.mjs';
+
+// Production defaults for the proxy cascade. Exported so tests can assert
+// the wiring is correct without re-importing the underlying functions.
+//
+// CRITICAL invariant: the CONNECT leg MUST resolve via resolveProxyForConnect()
+// (preserves gate.decodo.com, the host Decodo routes via its CONNECT egress
+// pool), and the curl leg MUST resolve via resolveProxy() (rewrites to
+// us.decodo.com, the host Decodo routes via its curl egress pool — a
+// DIFFERENT IP pool). Mixing them collapses the two-leg cascade into one
+// pool and defeats the redundancy this helper exists to provide.
+//
+// See scripts/_proxy-utils.cjs:67-88 and the established usage at
+// scripts/seed-portwatch-chokepoints-ref.mjs:33-37 +
+// scripts/seed-recovery-external-debt.mjs:31-35.
+export const _PROXY_DEFAULTS = Object.freeze({
+  connectProxyResolver: resolveProxyForConnect,
+  curlProxyResolver: resolveProxy,
+  connectFetcher: httpsProxyFetchRaw,
+  curlFetcher: curlFetch,
+});
 
 const MAX_RETRY_AFTER_MS = 60_000;
 const RETRYABLE_STATUSES = new Set([429, 503]);
@@ -42,13 +62,19 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
     retryBaseMs = 2_000,
     label = zones.map((zone) => zone.name).join(', '),
     // Test hooks. Production callers leave these unset; the helper uses the
-    // real proxy resolver + fetchers from _seed-utils.mjs. Tests inject mocks
-    // here to exercise the proxy fallback paths without spinning up a real
-    // Decodo tunnel. Keep these undocumented in PR descriptions — they are
+    // real proxy resolvers + fetchers from _seed-utils.mjs (see _PROXY_DEFAULTS).
+    // Tests inject mocks to exercise the cascade without spinning up real
+    // Decodo tunnels. Keep these undocumented in PR descriptions — they are
     // implementation-only seams, not a public API surface.
-    _proxyResolver = resolveProxy,
-    _proxyFetcher = httpsProxyFetchRaw,
-    _proxyCurlFetcher = curlFetch,
+    //
+    // INVARIANT: connect/curl legs use DIFFERENT resolvers because Decodo
+    // routes CONNECT (gate.decodo.com) and curl-x (us.decodo.com) through
+    // different egress IP pools. Reusing one resolver for both legs collapses
+    // the redundancy.
+    _connectProxyResolver = _PROXY_DEFAULTS.connectProxyResolver,
+    _curlProxyResolver = _PROXY_DEFAULTS.curlProxyResolver,
+    _proxyFetcher = _PROXY_DEFAULTS.connectFetcher,
+    _proxyCurlFetcher = _PROXY_DEFAULTS.curlFetcher,
   } = opts;
 
   const params = new URLSearchParams({
@@ -129,12 +155,15 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
   // be a single point of failure if Decodo rebalances pools. The curl
   // attempt costs an exec only when CONNECT also failed, so steady-state
   // overhead is zero.
-  const proxyAuth = _proxyResolver();
+  const connectProxyAuth = _connectProxyResolver();
+  const curlProxyAuth = _curlProxyResolver();
   let lastProxyError = null;
-  if (proxyAuth) {
+
+  // CONNECT leg via gate.decodo.com pool.
+  if (connectProxyAuth) {
     try {
       console.log(`  [OPEN_METEO] direct exhausted on ${label} (${lastDirectError?.message ?? 'unknown'}); trying proxy (CONNECT)`);
-      const { buffer } = await _proxyFetcher(url, proxyAuth, {
+      const { buffer } = await _proxyFetcher(url, connectProxyAuth, {
         accept: 'application/json',
         timeoutMs,
       });
@@ -146,13 +175,16 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
       return data;
     } catch (proxyErr) {
       lastProxyError = proxyErr;
-      console.warn(`  [OPEN_METEO] proxy (CONNECT) failed for ${label}: ${proxyErr?.message ?? proxyErr}; trying proxy (curl)`);
+      console.warn(`  [OPEN_METEO] proxy (CONNECT) failed for ${label}: ${proxyErr?.message ?? proxyErr}${curlProxyAuth ? '; trying proxy (curl)' : ''}`);
     }
+  }
 
-    // Second-choice proxy attempt via curl. Different egress pool —
-    // succeeds against hosts that 404 the CONNECT path.
+  // Second-choice curl leg via us.decodo.com pool — DIFFERENT egress IPs
+  // than the CONNECT pool above. Some hosts (Yahoo Finance) only accept
+  // this path. Only runs when CONNECT also failed.
+  if (curlProxyAuth) {
     try {
-      const text = _proxyCurlFetcher(url, proxyAuth, { 'User-Agent': CHROME_UA, Accept: 'application/json' });
+      const text = _proxyCurlFetcher(url, curlProxyAuth, { 'User-Agent': CHROME_UA, Accept: 'application/json' });
       const data = normalizeArchiveBatchResponse(JSON.parse(text));
       if (data.length !== zones.length) {
         throw new Error(`Open-Meteo proxy (curl) batch size mismatch for ${label}: expected ${zones.length}, got ${data.length}`);

--- a/scripts/_open-meteo-archive.mjs
+++ b/scripts/_open-meteo-archive.mjs
@@ -184,7 +184,12 @@ export async function fetchOpenMeteoArchiveBatch(zones, opts) {
   // this path. Only runs when CONNECT also failed.
   if (curlProxyAuth) {
     try {
-      const text = _proxyCurlFetcher(url, curlProxyAuth, { 'User-Agent': CHROME_UA, Accept: 'application/json' });
+      // _proxyCurlFetcher (curlFetch / execFileSync) is intentionally
+      // synchronous today, so plain invocation works. Wrapping with
+      // Promise.resolve + await keeps the call future-safe: if curlFetch is
+      // ever refactored to async, this line silently keeps working instead
+      // of returning an unhandled Promise to JSON.parse.
+      const text = await Promise.resolve(_proxyCurlFetcher(url, curlProxyAuth, { 'User-Agent': CHROME_UA, Accept: 'application/json' }));
       const data = normalizeArchiveBatchResponse(JSON.parse(text));
       if (data.length !== zones.length) {
         throw new Error(`Open-Meteo proxy (curl) batch size mismatch for ${label}: expected ${zones.length}, got ${data.length}`);

--- a/tests/open-meteo-proxy-fallback.test.mjs
+++ b/tests/open-meteo-proxy-fallback.test.mjs
@@ -47,10 +47,16 @@ afterEach(() => {
   delete process.env.SEED_PROXY_AUTH;
 });
 
-// The helper accepts `_proxyResolver` and `_proxyFetcher` opt overrides
-// specifically for tests — production callers leave them unset and get the
-// real Decodo path from _seed-utils.mjs. This lets us exercise the proxy
-// branch without spinning up a real CONNECT tunnel.
+// The helper accepts `_connectProxyResolver` / `_curlProxyResolver` /
+// `_proxyFetcher` / `_proxyCurlFetcher` opt overrides specifically for tests
+// — production callers leave them unset and get the real Decodo paths from
+// _seed-utils.mjs. This lets us exercise the cascade without spinning up
+// real CONNECT tunnels or curl execs.
+//
+// IMPORTANT: every test that exercises the proxy cascade injects BOTH
+// resolvers, because production defaults route the two legs through
+// DIFFERENT Decodo endpoints (gate.decodo.com vs us.decodo.com). The
+// "production defaults" test below locks that wiring at the helper level.
 
 test('429 with no proxy configured: throws after exhausting retries (preserves pre-fix behavior)', async () => {
   // Re-import per-test so module-level state (none currently) is fresh.
@@ -139,7 +145,8 @@ test('429 + proxy configured + proxy succeeds: returns proxy data, never throws'
   let receivedProxyAuth = null;
   const result = await fetchOpenMeteoArchiveBatch(ZONES, {
     ...ARCHIVE_OPTS,
-    _proxyResolver: () => 'user:pass@gate.decodo.com:7000',
+    _connectProxyResolver: () => 'user:pass@gate.decodo.com:7000',
+    _curlProxyResolver:    () => 'user:pass@us.decodo.com:10001',
     _proxyFetcher: async (url, proxyAuth, _opts) => {
       proxyCalls += 1;
       receivedProxyAuth = proxyAuth;
@@ -170,7 +177,8 @@ test('thrown fetch error (timeout/ECONNRESET) on final direct attempt → proxy 
   let proxyCalls = 0;
   const result = await fetchOpenMeteoArchiveBatch(ZONES, {
     ...ARCHIVE_OPTS,
-    _proxyResolver: () => 'user:pass@proxy.test:8000',
+    _connectProxyResolver: () => 'user:pass@proxy.test:8000',
+    _curlProxyResolver:    () => 'user:pass@proxy-curl.test:8000',
     _proxyFetcher: async () => {
       proxyCalls += 1;
       return { buffer: Buffer.from(JSON.stringify(VALID_PAYLOAD), 'utf8'), contentType: 'application/json' };
@@ -196,7 +204,8 @@ test('429 + proxy configured + proxy ALSO fails: throws exhausted with last dire
   await assert.rejects(
     () => fetchOpenMeteoArchiveBatch(ZONES, {
       ...ARCHIVE_OPTS,
-      _proxyResolver: () => 'user:pass@proxy.test:8000',
+      _connectProxyResolver: () => 'user:pass@proxy.test:8000',
+    _curlProxyResolver:    () => 'user:pass@proxy-curl.test:8000',
       _proxyFetcher: async () => {
         connectCalls += 1;
         throw new Error('proxy 502');
@@ -217,6 +226,38 @@ test('429 + proxy configured + proxy ALSO fails: throws exhausted with last dire
   );
   assert.equal(connectCalls, 1);
   assert.equal(curlCalls, 1);
+});
+
+// ─── Production defaults: lock the resolver wiring ──────────────────────
+//
+// Without this test, the proxy-cascade tests would all pass even if the
+// helper accidentally routed BOTH legs through the same resolver
+// (collapsing the gate.decodo.com vs us.decodo.com pool redundancy this
+// helper exists to provide). The defaults are exported via _PROXY_DEFAULTS
+// for exactly this lock.
+
+test('production defaults: CONNECT leg uses resolveProxyForConnect, curl leg uses resolveProxy', async () => {
+  // No `?t=` cache-buster on these two imports — reference equality across
+  // modules requires both imports to resolve to the SAME module instance.
+  // Cache-busting forces re-evaluation and breaks the reference comparison.
+  const { _PROXY_DEFAULTS } = await import('../scripts/_open-meteo-archive.mjs');
+  const { resolveProxy, resolveProxyForConnect, httpsProxyFetchRaw, curlFetch } = await import('../scripts/_seed-utils.mjs');
+
+  // Reference equality: the helper must wire the EXACT functions from
+  // _seed-utils.mjs. Anything else (a wrapper, a different resolver, the
+  // wrong direction) means the cascade is misconfigured.
+  assert.equal(_PROXY_DEFAULTS.connectProxyResolver, resolveProxyForConnect, 'CONNECT leg MUST use resolveProxyForConnect (gate.decodo.com pool)');
+  assert.equal(_PROXY_DEFAULTS.curlProxyResolver,    resolveProxy,            'curl leg MUST use resolveProxy (us.decodo.com pool)');
+  assert.equal(_PROXY_DEFAULTS.connectFetcher,       httpsProxyFetchRaw,      'CONNECT leg MUST use httpsProxyFetchRaw');
+  assert.equal(_PROXY_DEFAULTS.curlFetcher,          curlFetch,               'curl leg MUST use curlFetch');
+});
+
+test('production defaults: connect/curl resolvers are different functions (no single point of failure)', async () => {
+  const { _PROXY_DEFAULTS } = await import('../scripts/_open-meteo-archive.mjs');
+  assert.notEqual(_PROXY_DEFAULTS.connectProxyResolver, _PROXY_DEFAULTS.curlProxyResolver,
+    'Same resolver for both legs would collapse the cascade into one Decodo egress pool');
+  assert.notEqual(_PROXY_DEFAULTS.connectFetcher, _PROXY_DEFAULTS.curlFetcher,
+    'Same fetcher for both legs is incoherent (CONNECT vs curl-x are different transport mechanisms)');
 });
 
 // ─── Second-choice curl proxy fallback ──────────────────────────────────
@@ -241,7 +282,8 @@ test('CONNECT proxy fails → curl proxy succeeds: returns curl data, never thro
   let curlCalls = 0;
   const result = await fetchOpenMeteoArchiveBatch(ZONES, {
     ...ARCHIVE_OPTS,
-    _proxyResolver: () => 'user:pass@gate.decodo.com:7000',
+    _connectProxyResolver: () => 'user:pass@gate.decodo.com:7000',
+    _curlProxyResolver:    () => 'user:pass@us.decodo.com:10001',
     _proxyFetcher: async () => { connectCalls += 1; throw new Error('HTTP 404'); },
     _proxyCurlFetcher: (url, _proxyAuth, _headers) => {
       curlCalls += 1;
@@ -267,7 +309,8 @@ test('CONNECT succeeds: curl never invoked', async () => {
   let curlCalls = 0;
   const result = await fetchOpenMeteoArchiveBatch(ZONES, {
     ...ARCHIVE_OPTS,
-    _proxyResolver: () => 'user:pass@gate.decodo.com:7000',
+    _connectProxyResolver: () => 'user:pass@gate.decodo.com:7000',
+    _curlProxyResolver:    () => 'user:pass@us.decodo.com:10001',
     _proxyFetcher: async () => ({
       buffer: Buffer.from(JSON.stringify(VALID_PAYLOAD), 'utf8'),
       contentType: 'application/json',
@@ -291,7 +334,8 @@ test('CONNECT fails AND curl fails: throws exhausted with both errors visible', 
   await assert.rejects(
     () => fetchOpenMeteoArchiveBatch(ZONES, {
       ...ARCHIVE_OPTS,
-      _proxyResolver: () => 'user:pass@gate.decodo.com:7000',
+      _connectProxyResolver: () => 'user:pass@gate.decodo.com:7000',
+    _curlProxyResolver:    () => 'user:pass@us.decodo.com:10001',
       _proxyFetcher: async () => { throw new Error('CONNECT 404'); },
       _proxyCurlFetcher: () => { throw new Error('curl 502'); },
     }),
@@ -316,7 +360,8 @@ test('curl returns malformed JSON: caught + warns, throws exhausted', async () =
   await assert.rejects(
     () => fetchOpenMeteoArchiveBatch(ZONES, {
       ...ARCHIVE_OPTS,
-      _proxyResolver: () => 'user:pass@gate.decodo.com:7000',
+      _connectProxyResolver: () => 'user:pass@gate.decodo.com:7000',
+    _curlProxyResolver:    () => 'user:pass@us.decodo.com:10001',
       _proxyFetcher: async () => { throw new Error('CONNECT failed'); },
       _proxyCurlFetcher: () => 'not-valid-json',
     }),
@@ -336,7 +381,8 @@ test('proxy fallback returns wrong batch size: caught + warns, throws exhausted'
   await assert.rejects(
     () => fetchOpenMeteoArchiveBatch(ZONES, {
       ...ARCHIVE_OPTS,
-      _proxyResolver: () => 'user:pass@proxy.test:8000',
+      _connectProxyResolver: () => 'user:pass@proxy.test:8000',
+    _curlProxyResolver:    () => 'user:pass@proxy-curl.test:8000',
       _proxyFetcher: async () => ({
         buffer: Buffer.from(JSON.stringify([VALID_PAYLOAD[0]]), 'utf8'),  // 1 instead of 2
         contentType: 'application/json',

--- a/tests/open-meteo-proxy-fallback.test.mjs
+++ b/tests/open-meteo-proxy-fallback.test.mjs
@@ -191,14 +191,22 @@ test('429 + proxy configured + proxy ALSO fails: throws exhausted with last dire
     json: async () => ({}),
   });
 
-  let proxyCalls = 0;
+  let connectCalls = 0;
+  let curlCalls = 0;
   await assert.rejects(
     () => fetchOpenMeteoArchiveBatch(ZONES, {
       ...ARCHIVE_OPTS,
       _proxyResolver: () => 'user:pass@proxy.test:8000',
       _proxyFetcher: async () => {
-        proxyCalls += 1;
+        connectCalls += 1;
         throw new Error('proxy 502');
+      },
+      // Stub curl path too (CONNECT failure now cascades to curl). Without
+      // this stub the test would shell out to real curl since the helper's
+      // default is the production curlFetch.
+      _proxyCurlFetcher: () => {
+        curlCalls += 1;
+        throw new Error('proxy curl 502');
       },
     }),
     (err) => {
@@ -207,7 +215,113 @@ test('429 + proxy configured + proxy ALSO fails: throws exhausted with last dire
       return true;
     },
   );
-  assert.equal(proxyCalls, 1);
+  assert.equal(connectCalls, 1);
+  assert.equal(curlCalls, 1);
+});
+
+// ─── Second-choice curl proxy fallback ──────────────────────────────────
+//
+// Decodo's CONNECT and curl egress reach DIFFERENT IP pools (per
+// scripts/_proxy-utils.cjs:67). Some hosts only accept one path — Yahoo
+// Finance returns 404 to Decodo's CONNECT egress but 200 to curl. Probed
+// 2026-04-16: Open-Meteo works through both today, but pinning to one path
+// is a single point of failure if Decodo rebalances pools. The helper
+// tries CONNECT first, falls through to curl only when CONNECT errors.
+
+test('CONNECT proxy fails → curl proxy succeeds: returns curl data, never throws', async () => {
+  const { fetchOpenMeteoArchiveBatch } = await import(`../scripts/_open-meteo-archive.mjs?t=${Date.now()}`);
+
+  globalThis.fetch = async () => ({
+    ok: false, status: 429,
+    headers: { get: () => null },
+    json: async () => ({}),
+  });
+
+  let connectCalls = 0;
+  let curlCalls = 0;
+  const result = await fetchOpenMeteoArchiveBatch(ZONES, {
+    ...ARCHIVE_OPTS,
+    _proxyResolver: () => 'user:pass@gate.decodo.com:7000',
+    _proxyFetcher: async () => { connectCalls += 1; throw new Error('HTTP 404'); },
+    _proxyCurlFetcher: (url, _proxyAuth, _headers) => {
+      curlCalls += 1;
+      assert.match(url, /open-meteo/);
+      return JSON.stringify(VALID_PAYLOAD);
+    },
+  });
+
+  assert.equal(connectCalls, 1, 'CONNECT path attempted exactly once');
+  assert.equal(curlCalls, 1, 'curl path attempted as second choice');
+  assert.equal(result.length, 2);
+});
+
+test('CONNECT succeeds: curl never invoked', async () => {
+  const { fetchOpenMeteoArchiveBatch } = await import(`../scripts/_open-meteo-archive.mjs?t=${Date.now()}`);
+
+  globalThis.fetch = async () => ({
+    ok: false, status: 429,
+    headers: { get: () => null },
+    json: async () => ({}),
+  });
+
+  let curlCalls = 0;
+  const result = await fetchOpenMeteoArchiveBatch(ZONES, {
+    ...ARCHIVE_OPTS,
+    _proxyResolver: () => 'user:pass@gate.decodo.com:7000',
+    _proxyFetcher: async () => ({
+      buffer: Buffer.from(JSON.stringify(VALID_PAYLOAD), 'utf8'),
+      contentType: 'application/json',
+    }),
+    _proxyCurlFetcher: () => { curlCalls += 1; throw new Error('should not be called'); },
+  });
+
+  assert.equal(curlCalls, 0, 'CONNECT succeeded — curl path must be skipped');
+  assert.equal(result.length, 2);
+});
+
+test('CONNECT fails AND curl fails: throws exhausted with both errors visible', async () => {
+  const { fetchOpenMeteoArchiveBatch } = await import(`../scripts/_open-meteo-archive.mjs?t=${Date.now()}`);
+
+  globalThis.fetch = async () => ({
+    ok: false, status: 429,
+    headers: { get: () => null },
+    json: async () => ({}),
+  });
+
+  await assert.rejects(
+    () => fetchOpenMeteoArchiveBatch(ZONES, {
+      ...ARCHIVE_OPTS,
+      _proxyResolver: () => 'user:pass@gate.decodo.com:7000',
+      _proxyFetcher: async () => { throw new Error('CONNECT 404'); },
+      _proxyCurlFetcher: () => { throw new Error('curl 502'); },
+    }),
+    (err) => {
+      assert.match(err.message, /Open-Meteo retries exhausted/);
+      assert.match(err.message, /HTTP 429/);     // direct error in cause-chain
+      assert.match(err.message, /curl 502/);     // last proxy error appended
+      return true;
+    },
+  );
+});
+
+test('curl returns malformed JSON: caught + warns, throws exhausted', async () => {
+  const { fetchOpenMeteoArchiveBatch } = await import(`../scripts/_open-meteo-archive.mjs?t=${Date.now()}`);
+
+  globalThis.fetch = async () => ({
+    ok: false, status: 429,
+    headers: { get: () => null },
+    json: async () => ({}),
+  });
+
+  await assert.rejects(
+    () => fetchOpenMeteoArchiveBatch(ZONES, {
+      ...ARCHIVE_OPTS,
+      _proxyResolver: () => 'user:pass@gate.decodo.com:7000',
+      _proxyFetcher: async () => { throw new Error('CONNECT failed'); },
+      _proxyCurlFetcher: () => 'not-valid-json',
+    }),
+    /Open-Meteo retries exhausted/,
+  );
 });
 
 test('proxy fallback returns wrong batch size: caught + warns, throws exhausted', async () => {
@@ -227,6 +341,10 @@ test('proxy fallback returns wrong batch size: caught + warns, throws exhausted'
         buffer: Buffer.from(JSON.stringify([VALID_PAYLOAD[0]]), 'utf8'),  // 1 instead of 2
         contentType: 'application/json',
       }),
+      // CONNECT fails with mismatched batch size → cascades to curl;
+      // stub curl so it also fails so the test deterministically hits the
+      // final exhausted-throw branch.
+      _proxyCurlFetcher: () => JSON.stringify([VALID_PAYLOAD[0]]),
     }),
     /Open-Meteo retries exhausted/,
   );


### PR DESCRIPTION
## Why

Decodo's CONNECT egress and curl egress reach **different IP pools** (per `scripts/_proxy-utils.cjs:67`). Surfaced today (2026-04-16) while probing Yahoo Finance for an upcoming PR:

| Host | Direct | CONNECT proxy | curl proxy |
|---|---|---|---|
| Yahoo Finance | 200 | **404** | 200 |
| Open-Meteo | 200 | 200 | 200 |
| GDELT | 200 | 429 | partial (40%) |

PR #3118 wired only the CONNECT path (`httpsProxyFetchRaw`). For Open-Meteo both paths happen to work today, but pinning the helper to one path is a single point of failure if Decodo rebalances pools, or if Open-Meteo starts behaving like Yahoo.

## What

Cascade after direct exhausts: `CONNECT proxy → curl proxy → throw`. Steady-state cost is **zero** because the curl exec only runs when CONNECT also failed.

Final exhausted-throw now appends the last *proxy* error too, so on-call sees both signals (direct + proxy) instead of just direct.

## Test plan

- [x] `tests/open-meteo-proxy-fallback.test.mjs` → 12/12 (was 8, +4 new)
  - CONNECT fails → curl succeeds: returns curl data
  - CONNECT succeeds: curl never invoked (cost gate)
  - CONNECT AND curl both fail: exhausted-throw shows both errors
  - curl returns malformed JSON: caught, warned, throws exhausted
- [x] Updated 2 existing tests to stub `_proxyCurlFetcher` so they don't shell out to real curl when CONNECT is mocked-failed
- [x] `npm run test:data` → 5367/5367 pass (+4)
- [x] `npm run typecheck:all` → clean
- [ ] Post-deploy: trigger `seed-bundle-climate` once. Look for `[OPEN_METEO] proxy (CONNECT) succeeded` (steady state) — `proxy (curl) succeeded` line should only appear if CONNECT degrades.

## Followup PRs

This commit also unblocks the upcoming Yahoo Finance helper PR — Yahoo MUST use the curl path. Future helper (`_yahoo-fetch.mjs`) will use the same DI seam pattern but skip the CONNECT attempt entirely.