### PR TITLE
fix(resilience-ranking): return warmed scores from memory, skip lossy re-read

### DIFF
--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -25,6 +25,13 @@ function prefixKey(key: string): string {
   return `${cachedPrefix}${key}`;
 }
 
+// Test-only: invalidate the memoized key prefix so a test that mutates
+// process.env.VERCEL_ENV / VERCEL_GIT_COMMIT_SHA sees the new value on the
+// next read. No production caller should ever invoke this.
+export function __resetKeyPrefixCacheForTests(): void {
+  cachedPrefix = undefined;
+}
+
 /**
  * Like getCachedJson but throws on Redis/network failures instead of returning null.
  * Always uses the raw (unprefixed) key — callers that write via seed scripts (which bypass

--- a/server/worldmonitor/resilience/v1/_shared.ts
+++ b/server/worldmonitor/resilience/v1/_shared.ts
@@ -473,6 +473,12 @@ export async function warmMissingResilienceScores(
   }
   if (scores.length === 0) return warmed;
 
+  // Default `raw=false` so runRedisPipeline applies the env-based key prefix
+  // (`preview:<sha>:` on preview/dev, empty in production). The normal score
+  // reads (`getCachedResilienceScores`, `ensureResilienceScoreCached`) look in
+  // the prefixed namespace via setCachedJson/cachedFetchJson; writing raw here
+  // would (a) make preview warms invisible to subsequent preview reads and
+  // (b) leak preview writes into the production-visible unprefixed namespace.
   const setCommands = scores.map(({ cc, score }) => [
     'SET',
     scoreCacheKey(cc),
@@ -480,7 +486,7 @@ export async function warmMissingResilienceScores(
     'EX',
     String(RESILIENCE_SCORE_CACHE_TTL_SECONDS),
   ]);
-  const persistResults = await runRedisPipeline(setCommands, true);
+  const persistResults = await runRedisPipeline(setCommands);
   // runRedisPipeline returns [] on transport/HTTP failure. Without a
   // per-command OK signal we have no proof anything persisted — return an
   // empty map so the ranking coverage gate can't false-positive on a broken

--- a/server/worldmonitor/resilience/v1/_shared.ts
+++ b/server/worldmonitor/resilience/v1/_shared.ts
@@ -208,6 +208,68 @@ async function appendHistory(countryCode: string, overallScore: number): Promise
   ]);
 }
 
+// Pure compute: no caching, no Redis side-effects (except appendHistory, which
+// is part of the score semantics). Kept separate from `ensureResilienceScoreCached`
+// so the ranking warm path can persist with explicit write-verification via a
+// pipeline (see `warmMissingResilienceScores`) rather than trusting
+// `cachedFetchJson`'s log-and-swallow write semantics.
+async function buildResilienceScore(
+  normalizedCountryCode: string,
+  reader?: ResilienceSeedReader,
+): Promise<GetResilienceScoreResponse> {
+  const staticMeta = await getCachedJson(RESILIENCE_STATIC_META_KEY, true) as { fetchedAt?: number } | null;
+  const dataVersion = staticMeta?.fetchedAt
+    ? new Date(staticMeta.fetchedAt).toISOString().slice(0, 10)
+    : todayIsoDate();
+
+  const scoreMap = await scoreAllDimensions(normalizedCountryCode, reader);
+  const dimensions = buildDimensionList(scoreMap);
+  const domains = buildDomainList(dimensions);
+  const pillars = buildPillarList(domains, true);
+
+  const baselineDims: ResilienceDimension[] = [];
+  const stressDims: ResilienceDimension[] = [];
+  for (const dim of dimensions) {
+    const dimType = RESILIENCE_DIMENSION_TYPES[dim.id as ResilienceDimensionId];
+    if (dimType === 'baseline' || dimType === 'mixed') baselineDims.push(dim);
+    if (dimType === 'stress' || dimType === 'mixed') stressDims.push(dim);
+  }
+  const baselineScore = round(coverageWeightedMean(baselineDims));
+  const stressScore = round(coverageWeightedMean(stressDims));
+  const stressFactor = round(Math.max(0, Math.min(1 - stressScore / 100, 0.5)), 4);
+  const overallScore = round(domains.reduce((sum, d) => sum + d.score * d.weight, 0));
+
+  const totalImputed = dimensions.reduce((sum, d) => sum + (d.imputedWeight ?? 0), 0);
+  const totalObserved = dimensions.reduce((sum, d) => sum + (d.observedWeight ?? 0), 0);
+  const imputationShare = (totalImputed + totalObserved) > 0
+    ? round(totalImputed / (totalImputed + totalObserved), 4)
+    : 0;
+
+  const history = (await readHistory(normalizedCountryCode))
+    .filter((point) => point.date !== todayIsoDate());
+  const scoreSeries = [...history.map((point) => point.score), overallScore];
+  const oldestScore = history[0]?.score;
+
+  await appendHistory(normalizedCountryCode, overallScore);
+
+  return {
+    countryCode: normalizedCountryCode,
+    overallScore,
+    baselineScore,
+    stressScore,
+    stressFactor,
+    level: classifyResilienceLevel(overallScore),
+    domains,
+    trend: detectTrend(scoreSeries),
+    change30d: oldestScore == null ? 0 : round(overallScore - oldestScore),
+    lowConfidence: computeLowConfidence(dimensions, imputationShare),
+    imputationShare,
+    dataVersion,
+    pillars,
+    schemaVersion: '2.0',
+  };
+}
+
 export async function ensureResilienceScoreCached(countryCode: string, reader?: ResilienceSeedReader): Promise<GetResilienceScoreResponse> {
   const normalizedCountryCode = normalizeCountryCode(countryCode);
   if (!normalizedCountryCode) {
@@ -235,59 +297,7 @@ export async function ensureResilienceScoreCached(countryCode: string, reader?: 
   let cached = await cachedFetchJson<GetResilienceScoreResponse>(
     scoreCacheKey(normalizedCountryCode),
     RESILIENCE_SCORE_CACHE_TTL_SECONDS,
-    async () => {
-      const staticMeta = await getCachedJson(RESILIENCE_STATIC_META_KEY, true) as { fetchedAt?: number } | null;
-      const dataVersion = staticMeta?.fetchedAt
-        ? new Date(staticMeta.fetchedAt).toISOString().slice(0, 10)
-        : todayIsoDate();
-
-      const scoreMap = await scoreAllDimensions(normalizedCountryCode, reader);
-      const dimensions = buildDimensionList(scoreMap);
-      const domains = buildDomainList(dimensions);
-      const pillars = buildPillarList(domains, true);
-
-      const baselineDims: ResilienceDimension[] = [];
-      const stressDims: ResilienceDimension[] = [];
-      for (const dim of dimensions) {
-        const dimType = RESILIENCE_DIMENSION_TYPES[dim.id as ResilienceDimensionId];
-        if (dimType === 'baseline' || dimType === 'mixed') baselineDims.push(dim);
-        if (dimType === 'stress' || dimType === 'mixed') stressDims.push(dim);
-      }
-      const baselineScore = round(coverageWeightedMean(baselineDims));
-      const stressScore = round(coverageWeightedMean(stressDims));
-      const stressFactor = round(Math.max(0, Math.min(1 - stressScore / 100, 0.5)), 4);
-      const overallScore = round(domains.reduce((sum, d) => sum + d.score * d.weight, 0));
-
-      const totalImputed = dimensions.reduce((sum, d) => sum + (d.imputedWeight ?? 0), 0);
-      const totalObserved = dimensions.reduce((sum, d) => sum + (d.observedWeight ?? 0), 0);
-      const imputationShare = (totalImputed + totalObserved) > 0
-        ? round(totalImputed / (totalImputed + totalObserved), 4)
-        : 0;
-
-      const history = (await readHistory(normalizedCountryCode))
-        .filter((point) => point.date !== todayIsoDate());
-      const scoreSeries = [...history.map((point) => point.score), overallScore];
-      const oldestScore = history[0]?.score;
-
-      await appendHistory(normalizedCountryCode, overallScore);
-
-      return {
-        countryCode: normalizedCountryCode,
-        overallScore,
-        baselineScore,
-        stressScore,
-        stressFactor,
-        level: classifyResilienceLevel(overallScore),
-        domains,
-        trend: detectTrend(scoreSeries),
-        change30d: oldestScore == null ? 0 : round(overallScore - oldestScore),
-        lowConfidence: computeLowConfidence(dimensions, imputationShare),
-        imputationShare,
-        dataVersion,
-        pillars,
-        schemaVersion: '2.0',
-      };
-    },
+    () => buildResilienceScore(normalizedCountryCode, reader),
     300,
   ) ?? {
     countryCode: normalizedCountryCode,
@@ -410,40 +420,87 @@ export function sortRankingItems(items: ResilienceRankingItem[]): ResilienceRank
   });
 }
 
-// Returns the in-memory map of successfully warmed scores keyed by normalized
-// country code. Callers should merge this into their local cachedScores rather
-// than re-reading from Redis: Upstash REST has visible write→read lag within a
-// single Vercel invocation, so an immediate pipeline GET of freshly-written
-// keys can return 0 results even when every SET succeeded, which collapses the
-// ranking coverage gate and silently drops the ranking publish (PR that added
-// this note — see `feedback_upstash_write_reread_race_in_handler.md`).
+// Warms the resilience score cache for the given countries and returns a map
+// of country-code → score for ONLY the scores whose writes actually landed in
+// Redis. Two subtle requirements:
+//
+//   1. Avoid the Upstash REST write→re-read visibility lag. A /pipeline GET of
+//      freshly-SET keys in the same Vercel invocation can return null even
+//      when every SET succeeded — the pre-existing post-warm re-read tripped
+//      this and silently dropped the ranking publish. See
+//      `feedback_upstash_write_reread_race_in_handler.md`.
+//   2. Still detect actual write failures. `cachedFetchJson`'s underlying
+//      `setCachedJson` only logs and swallows on error, which would make a
+//      transient /set failure look like a successful warm and publish a
+//      ranking aggregate over missing per-country keys.
+//
+// The pipeline SET response is the authoritative persistence signal: it's
+// synchronous with the write, so "result: OK" per command means the key is
+// actually stored. We compute scores in memory (no caching), persist in one
+// pipeline, and only include countries whose SET returned OK in the returned
+// map. Callers should merge the map directly into their local `cachedScores`
+// — no post-warm Redis re-read.
 export async function warmMissingResilienceScores(
   countryCodes: string[],
 ): Promise<Map<string, GetResilienceScoreResponse>> {
   const uniqueCodes = [...new Set(countryCodes.map((countryCode) => normalizeCountryCode(countryCode)).filter(Boolean))];
+  const warmed = new Map<string, GetResilienceScoreResponse>();
+  if (uniqueCodes.length === 0) return warmed;
+
   // Share one memoized reader across all countries so global Redis keys (conflict events,
   // sanctions, unrest, etc.) are fetched only once instead of once per country.
   const sharedReader = createMemoizedSeedReader();
-  const results = await Promise.allSettled(
-    uniqueCodes.map((countryCode) => ensureResilienceScoreCached(countryCode, sharedReader)),
+  const computed = await Promise.allSettled(
+    uniqueCodes.map(async (cc) => ({ cc, score: await buildResilienceScore(cc, sharedReader) })),
   );
-  const warmed = new Map<string, GetResilienceScoreResponse>();
-  const failures: Array<{ countryCode: string; reason: string }> = [];
-  for (let i = 0; i < results.length; i++) {
-    const result = results[i];
-    const countryCode = uniqueCodes[i]!;
-    if (result?.status === 'fulfilled' && result.value) {
-      warmed.set(countryCode, result.value);
-    } else if (result?.status === 'rejected') {
-      failures.push({
-        countryCode,
+
+  const scores: Array<{ cc: string; score: GetResilienceScoreResponse }> = [];
+  const computeFailures: Array<{ countryCode: string; reason: string }> = [];
+  for (let i = 0; i < computed.length; i++) {
+    const result = computed[i]!;
+    if (result.status === 'fulfilled') {
+      scores.push(result.value);
+    } else {
+      computeFailures.push({
+        countryCode: uniqueCodes[i]!,
         reason: result.reason instanceof Error ? result.reason.message : String(result.reason),
       });
     }
   }
-  if (failures.length > 0) {
-    const sample = failures.slice(0, 10).map((f) => `${f.countryCode}(${f.reason})`).join(', ');
-    console.warn(`[resilience] warm failed for ${failures.length}/${uniqueCodes.length} countries: ${sample}${failures.length > 10 ? '...' : ''}`);
+  if (computeFailures.length > 0) {
+    const sample = computeFailures.slice(0, 10).map((f) => `${f.countryCode}(${f.reason})`).join(', ');
+    console.warn(`[resilience] warm compute failed for ${computeFailures.length}/${uniqueCodes.length} countries: ${sample}${computeFailures.length > 10 ? '...' : ''}`);
+  }
+  if (scores.length === 0) return warmed;
+
+  const setCommands = scores.map(({ cc, score }) => [
+    'SET',
+    scoreCacheKey(cc),
+    JSON.stringify(score),
+    'EX',
+    String(RESILIENCE_SCORE_CACHE_TTL_SECONDS),
+  ]);
+  const persistResults = await runRedisPipeline(setCommands, true);
+  // runRedisPipeline returns [] on transport/HTTP failure. Without a
+  // per-command OK signal we have no proof anything persisted — return an
+  // empty map so the ranking coverage gate can't false-positive on a broken
+  // write path.
+  if (persistResults.length !== scores.length) {
+    console.warn(`[resilience] warm pipeline returned ${persistResults.length}/${scores.length} results — treating all as unpersisted`);
+    return warmed;
+  }
+
+  let persistFailures = 0;
+  for (let i = 0; i < scores.length; i++) {
+    const { cc, score } = scores[i]!;
+    if (persistResults[i]?.result === 'OK') {
+      warmed.set(cc, score);
+    } else {
+      persistFailures++;
+    }
+  }
+  if (persistFailures > 0) {
+    console.warn(`[resilience] warm persisted ${warmed.size}/${scores.length} scores (${persistFailures} SETs did not return OK)`);
   }
   return warmed;
 }

--- a/server/worldmonitor/resilience/v1/_shared.ts
+++ b/server/worldmonitor/resilience/v1/_shared.ts
@@ -410,7 +410,16 @@ export function sortRankingItems(items: ResilienceRankingItem[]): ResilienceRank
   });
 }
 
-export async function warmMissingResilienceScores(countryCodes: string[]): Promise<void> {
+// Returns the in-memory map of successfully warmed scores keyed by normalized
+// country code. Callers should merge this into their local cachedScores rather
+// than re-reading from Redis: Upstash REST has visible write→read lag within a
+// single Vercel invocation, so an immediate pipeline GET of freshly-written
+// keys can return 0 results even when every SET succeeded, which collapses the
+// ranking coverage gate and silently drops the ranking publish (PR that added
+// this note — see `feedback_upstash_write_reread_race_in_handler.md`).
+export async function warmMissingResilienceScores(
+  countryCodes: string[],
+): Promise<Map<string, GetResilienceScoreResponse>> {
   const uniqueCodes = [...new Set(countryCodes.map((countryCode) => normalizeCountryCode(countryCode)).filter(Boolean))];
   // Share one memoized reader across all countries so global Redis keys (conflict events,
   // sanctions, unrest, etc.) are fetched only once instead of once per country.
@@ -418,12 +427,16 @@ export async function warmMissingResilienceScores(countryCodes: string[]): Promi
   const results = await Promise.allSettled(
     uniqueCodes.map((countryCode) => ensureResilienceScoreCached(countryCode, sharedReader)),
   );
+  const warmed = new Map<string, GetResilienceScoreResponse>();
   const failures: Array<{ countryCode: string; reason: string }> = [];
   for (let i = 0; i < results.length; i++) {
     const result = results[i];
-    if (result?.status === 'rejected') {
+    const countryCode = uniqueCodes[i]!;
+    if (result?.status === 'fulfilled' && result.value) {
+      warmed.set(countryCode, result.value);
+    } else if (result?.status === 'rejected') {
       failures.push({
-        countryCode: uniqueCodes[i]!,
+        countryCode,
         reason: result.reason instanceof Error ? result.reason.message : String(result.reason),
       });
     }
@@ -432,4 +445,5 @@ export async function warmMissingResilienceScores(countryCodes: string[]): Promi
     const sample = failures.slice(0, 10).map((f) => `${f.countryCode}(${f.reason})`).join(', ');
     console.warn(`[resilience] warm failed for ${failures.length}/${uniqueCodes.length} countries: ${sample}${failures.length > 10 ? '...' : ''}`);
   }
+  return warmed;
 }

--- a/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
@@ -69,12 +69,18 @@ export const getResilienceRanking: ResilienceServiceHandler['getResilienceRankin
   const countryCodes = await listScorableCountries();
   if (countryCodes.length === 0) return { items: [], greyedOut: [] };
 
-  let cachedScores = await getCachedResilienceScores(countryCodes);
+  const cachedScores = await getCachedResilienceScores(countryCodes);
   const missing = countryCodes.filter((countryCode) => !cachedScores.has(countryCode));
   if (missing.length > 0) {
     try {
-      await warmMissingResilienceScores(missing.slice(0, SYNC_WARM_LIMIT));
-      cachedScores = await getCachedResilienceScores(countryCodes);
+      // Merge warm results into cachedScores directly rather than re-reading
+      // from Redis. Upstash REST writes (/set) aren't always visible to an
+      // immediately-following /pipeline GET in the same Vercel invocation,
+      // which collapsed coverage to 0/N and silently dropped the ranking
+      // publish. The warmer already holds every score in memory — trust it.
+      // See `feedback_upstash_write_reread_race_in_handler.md`.
+      const warmed = await warmMissingResilienceScores(missing.slice(0, SYNC_WARM_LIMIT));
+      for (const [countryCode, score] of warmed) cachedScores.set(countryCode, score);
     } catch (err) {
       console.warn('[resilience] ranking warmup failed:', err);
     }

--- a/tests/helpers/fake-upstash-redis.mts
+++ b/tests/helpers/fake-upstash-redis.mts
@@ -124,10 +124,10 @@ export function createRedisFetch(fixtures: Record<string, unknown>): FakeRedisSt
   return { fetchImpl, redis, sortedSets, expires };
 }
 
-export function installRedis(fixtures: Record<string, unknown>): FakeRedisState {
+export function installRedis(fixtures: Record<string, unknown>, opts: { keepVercelEnv?: boolean } = {}): FakeRedisState {
   process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
   process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
-  delete process.env.VERCEL_ENV;
+  if (!opts.keepVercelEnv) delete process.env.VERCEL_ENV;
   const state = createRedisFetch(fixtures);
   globalThis.fetch = state.fetchImpl;
   return state;

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -207,6 +207,58 @@ describe('resilience ranking contracts', () => {
     assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written despite pipeline-GET race');
   });
 
+  it('pipeline SETs apply env prefix so preview warms do not leak into production namespace', async () => {
+    // Reviewer regression: passing `raw=true` to runRedisPipeline bypasses the
+    // env-based key prefix (preview: / dev:) that isolates preview deploys
+    // from production. The symptom is asymmetric: preview reads hit
+    // `preview:<sha>:resilience:score:v9:XX` while preview writes landed at
+    // raw `resilience:score:v9:XX`, simultaneously (a) missing the preview
+    // cache forever and (b) poisoning production's shared cache. Simulate a
+    // preview deploy and assert the pipeline SET keys carry the prefix.
+    process.env.VERCEL_ENV = 'preview';
+    process.env.VERCEL_GIT_COMMIT_SHA = 'abcdef12ffff';
+    const { __resetKeyPrefixCacheForTests } = await import('../server/_shared/redis.ts');
+    __resetKeyPrefixCacheForTests();
+
+    try {
+      const { redis, fetchImpl } = installRedis({ ...RESILIENCE_FIXTURES }, { keepVercelEnv: true });
+      redis.set('resilience:static:index:v1', JSON.stringify({
+        countries: ['NO', 'US'],
+        recordCount: 2,
+        failedDatasets: [],
+        seedYear: 2026,
+      }));
+
+      const pipelineBodies: Array<Array<Array<unknown>>> = [];
+      const capturing = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+        if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
+          pipelineBodies.push(JSON.parse(init.body) as Array<Array<unknown>>);
+        }
+        return fetchImpl(input, init);
+      }) as typeof fetch;
+      globalThis.fetch = capturing;
+
+      await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
+
+      const scoreSetKeys = pipelineBodies
+        .flat()
+        .filter((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v9:'))
+        .map((cmd) => cmd[1] as string);
+      assert.ok(scoreSetKeys.length >= 2, `expected at least 2 score SETs, got ${scoreSetKeys.length}`);
+      for (const key of scoreSetKeys) {
+        assert.ok(
+          key.startsWith('preview:abcdef12:'),
+          `score SET key must carry preview prefix; got ${key} — writes would poison the production namespace`,
+        );
+      }
+    } finally {
+      delete process.env.VERCEL_ENV;
+      delete process.env.VERCEL_GIT_COMMIT_SHA;
+      __resetKeyPrefixCacheForTests();
+    }
+  });
+
   it('does NOT publish ranking when score-key /set writes silently fail (persistence guard)', async () => {
     // Reviewer regression: trusting in-memory warm results without verifying
     // persistence turned a read-lag fix into a write-failure false positive.

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -207,6 +207,46 @@ describe('resilience ranking contracts', () => {
     assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written despite pipeline-GET race');
   });
 
+  it('does NOT publish ranking when score-key /set writes silently fail (persistence guard)', async () => {
+    // Reviewer regression: trusting in-memory warm results without verifying
+    // persistence turned a read-lag fix into a write-failure false positive.
+    // With writes broken at the Upstash layer, coverage should NOT pass the
+    // gate and neither the ranking nor its meta should be published.
+    const { redis, fetchImpl } = installRedis({ ...RESILIENCE_FIXTURES });
+    redis.set('resilience:static:index:v1', JSON.stringify({
+      countries: ['NO', 'US'],
+      recordCount: 2,
+      failedDatasets: [],
+      seedYear: 2026,
+    }));
+
+    // Intercept any pipeline SET to resilience:score:v9:* and reply with
+    // non-OK results (persisted but authoritative signal says no). /set and
+    // other paths pass through normally so history/interval writes succeed.
+    const blockedScoreWrites = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
+        const commands = JSON.parse(init.body) as Array<Array<string>>;
+        const allScoreSets = commands.length > 0 && commands.every(
+          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v9:'),
+        );
+        if (allScoreSets) {
+          return new Response(
+            JSON.stringify(commands.map(() => ({ error: 'simulated write failure' }))),
+            { status: 200 },
+          );
+        }
+      }
+      return fetchImpl(input, init);
+    }) as typeof fetch;
+    globalThis.fetch = blockedScoreWrites;
+
+    await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
+
+    assert.ok(!redis.has('resilience:ranking:v9'), 'ranking must NOT be published when score writes failed');
+    assert.ok(!redis.has('seed-meta:resilience:ranking'), 'seed-meta must NOT be written when score writes failed');
+  });
+
   it('defaults rankStable=false when no interval data exists', () => {
     const item = buildRankingItem('ZZ', {
       countryCode: 'ZZ', overallScore: 50, level: 'medium',

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -160,6 +160,53 @@ describe('resilience ranking contracts', () => {
     assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written alongside the ranking');
   });
 
+  it('publishes ranking via in-memory warm results even when Upstash pipeline-GET lags after /set writes (race regression)', async () => {
+    // Simulates the documented Upstash REST write→re-read lag inside a single
+    // Vercel invocation: /set calls succeed, but a pipeline GET immediately
+    // afterwards can return null for the same keys. Pre-fix, this collapsed
+    // coverage to 0 and silently dropped the ranking publish. Post-fix, the
+    // handler merges warm results from memory, so coverage reflects reality.
+    const { redis, fetchImpl } = installRedis({ ...RESILIENCE_FIXTURES });
+    // Override the static index: 2 countries, neither pre-cached — both must
+    // be warmed by the handler. Pre-fix, both pipeline-GETs post-warm would
+    // return null, coverage = 0% < 75%, handler skips the write. Post-fix,
+    // the in-memory merge carries both scores, coverage = 100%, write
+    // proceeds.
+    redis.set('resilience:static:index:v1', JSON.stringify({
+      countries: ['NO', 'US'],
+      recordCount: 2,
+      failedDatasets: [],
+      seedYear: 2026,
+    }));
+
+    // Stale pipeline-GETs for score keys: pretend Redis hasn't caught up with
+    // the /set writes yet. /set calls still mutate the underlying map so the
+    // final assertion on ranking presence can verify the SET happened.
+    const lagged = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
+        const commands = JSON.parse(init.body) as Array<Array<string>>;
+        const allScoreReads = commands.length > 0 && commands.every(
+          (cmd) => cmd[0] === 'GET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v9:'),
+        );
+        if (allScoreReads) {
+          // Simulate visibility lag: pretend no scores are cached yet.
+          return new Response(
+            JSON.stringify(commands.map(() => ({ result: null }))),
+            { status: 200 },
+          );
+        }
+      }
+      return fetchImpl(input, init);
+    }) as typeof fetch;
+    globalThis.fetch = lagged;
+
+    await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
+
+    assert.ok(redis.has('resilience:ranking:v9'), 'ranking must be published despite pipeline-GET race');
+    assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written despite pipeline-GET race');
+  });
+
   it('defaults rankStable=false when no interval data exists', () => {
     const item = buildRankingItem('ZZ', {
       countryCode: 'ZZ', overallScore: 50, level: 'medium',

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -3,6 +3,7 @@ import { afterEach, describe, it } from 'node:test';
 
 import { getResilienceRanking } from '../server/worldmonitor/resilience/v1/get-resilience-ranking.ts';
 import { buildRankingItem, sortRankingItems } from '../server/worldmonitor/resilience/v1/_shared.ts';
+import { __resetKeyPrefixCacheForTests } from '../server/_shared/redis.ts';
 import { installRedis } from './helpers/fake-upstash-redis.mts';
 import { RESILIENCE_FIXTURES } from './helpers/resilience-fixtures.mts';
 
@@ -10,6 +11,7 @@ const originalFetch = globalThis.fetch;
 const originalRedisUrl = process.env.UPSTASH_REDIS_REST_URL;
 const originalRedisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
 const originalVercelEnv = process.env.VERCEL_ENV;
+const originalVercelSha = process.env.VERCEL_GIT_COMMIT_SHA;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
@@ -19,6 +21,12 @@ afterEach(() => {
   else process.env.UPSTASH_REDIS_REST_TOKEN = originalRedisToken;
   if (originalVercelEnv == null) delete process.env.VERCEL_ENV;
   else process.env.VERCEL_ENV = originalVercelEnv;
+  if (originalVercelSha == null) delete process.env.VERCEL_GIT_COMMIT_SHA;
+  else process.env.VERCEL_GIT_COMMIT_SHA = originalVercelSha;
+  // Any test that touched VERCEL_ENV / VERCEL_GIT_COMMIT_SHA must invalidate
+  // the memoized key prefix so the next test recomputes it against the
+  // restored env — otherwise preview/dev tests would leak a stale prefix.
+  __resetKeyPrefixCacheForTests();
 });
 
 describe('resilience ranking contracts', () => {
@@ -215,47 +223,43 @@ describe('resilience ranking contracts', () => {
     // raw `resilience:score:v9:XX`, simultaneously (a) missing the preview
     // cache forever and (b) poisoning production's shared cache. Simulate a
     // preview deploy and assert the pipeline SET keys carry the prefix.
+    // Shared afterEach snapshots/restores VERCEL_ENV + VERCEL_GIT_COMMIT_SHA
+    // and invalidates the memoized key prefix, so this test just mutates them
+    // freely without a finally block.
     process.env.VERCEL_ENV = 'preview';
     process.env.VERCEL_GIT_COMMIT_SHA = 'abcdef12ffff';
-    const { __resetKeyPrefixCacheForTests } = await import('../server/_shared/redis.ts');
     __resetKeyPrefixCacheForTests();
 
-    try {
-      const { redis, fetchImpl } = installRedis({ ...RESILIENCE_FIXTURES }, { keepVercelEnv: true });
-      redis.set('resilience:static:index:v1', JSON.stringify({
-        countries: ['NO', 'US'],
-        recordCount: 2,
-        failedDatasets: [],
-        seedYear: 2026,
-      }));
+    const { redis, fetchImpl } = installRedis({ ...RESILIENCE_FIXTURES }, { keepVercelEnv: true });
+    redis.set('resilience:static:index:v1', JSON.stringify({
+      countries: ['NO', 'US'],
+      recordCount: 2,
+      failedDatasets: [],
+      seedYear: 2026,
+    }));
 
-      const pipelineBodies: Array<Array<Array<unknown>>> = [];
-      const capturing = (async (input: RequestInfo | URL, init?: RequestInit) => {
-        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
-        if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
-          pipelineBodies.push(JSON.parse(init.body) as Array<Array<unknown>>);
-        }
-        return fetchImpl(input, init);
-      }) as typeof fetch;
-      globalThis.fetch = capturing;
-
-      await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
-
-      const scoreSetKeys = pipelineBodies
-        .flat()
-        .filter((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v9:'))
-        .map((cmd) => cmd[1] as string);
-      assert.ok(scoreSetKeys.length >= 2, `expected at least 2 score SETs, got ${scoreSetKeys.length}`);
-      for (const key of scoreSetKeys) {
-        assert.ok(
-          key.startsWith('preview:abcdef12:'),
-          `score SET key must carry preview prefix; got ${key} — writes would poison the production namespace`,
-        );
+    const pipelineBodies: Array<Array<Array<unknown>>> = [];
+    const capturing = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
+        pipelineBodies.push(JSON.parse(init.body) as Array<Array<unknown>>);
       }
-    } finally {
-      delete process.env.VERCEL_ENV;
-      delete process.env.VERCEL_GIT_COMMIT_SHA;
-      __resetKeyPrefixCacheForTests();
+      return fetchImpl(input, init);
+    }) as typeof fetch;
+    globalThis.fetch = capturing;
+
+    await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
+
+    const scoreSetKeys = pipelineBodies
+      .flat()
+      .filter((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v9:'))
+      .map((cmd) => cmd[1] as string);
+    assert.ok(scoreSetKeys.length >= 2, `expected at least 2 score SETs, got ${scoreSetKeys.length}`);
+    for (const key of scoreSetKeys) {
+      assert.ok(
+        key.startsWith('preview:abcdef12:'),
+        `score SET key must carry preview prefix; got ${key} — writes would poison the production namespace`,
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

Fixes the silent ranking publish failure that leaves `resilience:ranking:v9` absent while the seeder keeps writing a "fresh" `seed-meta:resilience:ranking`, producing `resilienceRanking: { status: EMPTY_ON_DEMAND, records: 0, seedAgeMin: 277 }` in `/api/health` even when the cron is firing normally.

## Root cause

`server/worldmonitor/resilience/v1/get-resilience-ranking.ts` warmed ~222 country scores, then immediately re-read them via `getCachedResilienceScores` (a `/pipeline` GET) to compute coverage. Upstash REST has documented write→re-read visibility lag within a single Vercel invocation (PR #3057, `feedback_upstash_write_reread_race_in_handler.md`). The pipeline GET could return 0 results despite every SET succeeding — coverage collapsed to 0% < 75% threshold, handler logged `[resilience] ranking not cached …` and skipped both the ranking SET and the meta SET. Seeder then wrote its own meta anyway (based on its own pipeline GET, which by then had propagated), leaving the aggregate permanently absent.

## Fix

- `warmMissingResilienceScores` now returns `Map<countryCode, GetResilienceScoreResponse>` with every successfully computed score.
- Handler merges warm results into `cachedScores` directly and drops the post-warm re-read — coverage reflects what was actually computed in-memory in this invocation.

No API changes, no schema changes, ~20 lines across 2 files.

## Test plan
- [x] `npx tsx --test tests/resilience-ranking.test.mts` — 9/9 pass (8 existing + 1 new race regression).
- [x] Full resilience suite: 369/369 pass.
- [x] New test `publishes ranking via in-memory warm results even when Upstash pipeline-GET lags after /set writes (race regression)` simulates the exact Upstash lag: pipeline-GET of score keys returns null after `/set` writes. Fails against old code, passes with the fix.
- [ ] After deploy, probe Redis: `TTL resilience:ranking:v9` should be positive; `/api/health` should show `resilienceRanking: { status: OK, records: ~150+, seedAgeMin: <360 }`.
- [ ] Seeder's `[resilience] ranking not cached — coverage X/222 below 75% threshold` warnings should stop appearing.

## Follow-up (not in this PR)

Slice B: make `seed-resilience-scores.mjs` write `seed-meta:resilience:ranking` only when the ranking key is actually present (currently it lies about freshness based on per-country score count).