### PR TITLE
chore(sentry): filter DuckDuckGo browser internal noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -247,6 +247,7 @@ Sentry.init({
     /Possible side-effect in debug-evaluate/, // Chrome DevTools internal EvalError
     /ConvexError: CONFLICT/, // Expected OCC rejection on concurrent preference saves
     /\[CONVEX [AQM]\(.+?\)\] Connection lost while action was in flight/, // Convex SDK transient WS disconnect
+    /Response did not contain `success` or `data`/, // DuckDuckGo browser internal tracker/content-block response — never emitted by our code
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary
- Adds one `ignoreErrors` pattern to `src/main.ts` for the distinctive DuckDuckGo browser internal error `"unreachable. Response did not contain \`success\` or \`data\`"` (WORLDMONITOR-MZ).
- Message is never emitted by our own code (grep across repo confirms zero matches), arrives with an empty stack from DuckDuckGo 26.3 / macOS, and uses backtick-quoted field names that are not in our codebase's vocabulary.

## Context — other Sentry issues triaged this round
- **WORLDMONITOR-MZ** — filtered here (this PR).
- **WORLDMONITOR-MX** (`TypeError: t is not a constructor` in panels chunk, Firefox 149/Linux, 1 user / 2 events) — left unresolved. `hasFirstParty=true` so no safe filter; insufficient signal for a blind fix.
- **WORLDMONITOR-MY** (`TypeError: Failed to fetch (pub-*.r2.dev)` with `chrome-extension://.../frame_ant.js` wrapping `window.fetch`) — left unresolved. A filter keying off "extension frame + Failed to fetch" would violate the policy codified in `tests/sentry-beforesend.test.mjs` (first-party frame present = never suppress).
- **WORLDMONITOR-MS** (`SyntaxError: Invalid or unexpected token`, Edge 142, 0 frames) — left unresolved. Same test-suite policy rejects empty-stack suppression (could still come from our code).

## Test plan
- [x] `npm run typecheck` / `typecheck:api`
- [x] `npm run lint` (0 errors)
- [x] `npm run test:data` (5382/5382)
- [x] `node --test tests/edge-functions.test.mjs` (168/168) — includes `tests/sentry-beforesend.test.mjs` policy tests
- [x] Edge bundle check (`esbuild` over all `api/*.js`)
- [x] `npm run lint:md` + `npm run version:check`