### PR TITLE
feat(auth): user-facing API key management (create / list / revoke)

### DIFF
--- a/api/invalidate-user-api-key-cache.ts
+++ b/api/invalidate-user-api-key-cache.ts
@@ -58,29 +58,40 @@ export default async function handler(req: Request): Promise<Response> {
   }
 
   // Verify the keyHash belongs to the calling user (tenancy boundary).
+  // Fail-closed: if ownership cannot be verified, reject the request.
   const convexSiteUrl = process.env.CONVEX_SITE_URL;
   const convexSharedSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
-  if (convexSiteUrl && convexSharedSecret) {
-    try {
-      const ownerResp = await fetch(`${convexSiteUrl}/api/internal-get-key-owner`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-convex-shared-secret': convexSharedSecret,
-        },
-        body: JSON.stringify({ keyHash }),
-        signal: AbortSignal.timeout(3_000),
-      });
-      if (ownerResp.ok) {
-        const ownerData = await ownerResp.json() as { userId?: string } | null;
-        if (ownerData && ownerData.userId !== session.userId) {
-          return jsonResponse({ error: 'FORBIDDEN' }, 403, cors);
-        }
-      }
-    } catch {
-      // Fail-open: if ownership check fails, still allow invalidation.
-      // Worst case is an evicted cache entry forcing one Convex refetch.
+  if (!convexSiteUrl || !convexSharedSecret) {
+    console.warn('[invalidate-cache] Missing CONVEX_SITE_URL or CONVEX_SERVER_SHARED_SECRET');
+    return jsonResponse({ error: 'Service unavailable' }, 503, cors);
+  }
+
+  try {
+    const ownerResp = await fetch(`${convexSiteUrl}/api/internal-get-key-owner`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-convex-shared-secret': convexSharedSecret,
+      },
+      body: JSON.stringify({ keyHash }),
+      signal: AbortSignal.timeout(3_000),
+    });
+    if (!ownerResp.ok) {
+      console.warn(`[invalidate-cache] Convex ownership check HTTP ${ownerResp.status}`);
+      return jsonResponse({ error: 'Service unavailable' }, 503, cors);
     }
+    const ownerData = await ownerResp.json() as { userId?: string } | null;
+    if (!ownerData) {
+      // Hash not in DB — nothing to invalidate, but not an error
+      return jsonResponse({ ok: true }, 200, cors);
+    }
+    if (ownerData.userId !== session.userId) {
+      return jsonResponse({ error: 'FORBIDDEN' }, 403, cors);
+    }
+  } catch (err) {
+    // Fail-closed: ownership check failed — reject to surface the issue
+    console.warn('[invalidate-cache] Ownership check failed:', err instanceof Error ? err.message : String(err));
+    return jsonResponse({ error: 'Service unavailable' }, 503, cors);
   }
 
   await invalidateApiKeyCache(keyHash);

--- a/api/invalidate-user-api-key-cache.ts
+++ b/api/invalidate-user-api-key-cache.ts
@@ -6,6 +6,8 @@
  *
  * Authentication: Clerk Bearer token (any signed-in user).
  * Body: { keyHash: string }
+ *
+ * Ownership is verified via Convex — the keyHash must belong to the caller.
  */
 
 export const config = { runtime: 'edge' };
@@ -53,6 +55,32 @@ export default async function handler(req: Request): Promise<Response> {
   const { keyHash } = body;
   if (typeof keyHash !== 'string' || !/^[a-f0-9]{64}$/.test(keyHash)) {
     return jsonResponse({ error: 'Invalid keyHash' }, 422, cors);
+  }
+
+  // Verify the keyHash belongs to the calling user (tenancy boundary).
+  const convexSiteUrl = process.env.CONVEX_SITE_URL;
+  const convexSharedSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
+  if (convexSiteUrl && convexSharedSecret) {
+    try {
+      const ownerResp = await fetch(`${convexSiteUrl}/api/internal-get-key-owner`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-convex-shared-secret': convexSharedSecret,
+        },
+        body: JSON.stringify({ keyHash }),
+        signal: AbortSignal.timeout(3_000),
+      });
+      if (ownerResp.ok) {
+        const ownerData = await ownerResp.json() as { userId?: string } | null;
+        if (ownerData && ownerData.userId !== session.userId) {
+          return jsonResponse({ error: 'FORBIDDEN' }, 403, cors);
+        }
+      }
+    } catch {
+      // Fail-open: if ownership check fails, still allow invalidation.
+      // Worst case is an evicted cache entry forcing one Convex refetch.
+    }
   }
 
   await invalidateApiKeyCache(keyHash);

--- a/api/invalidate-user-api-key-cache.ts
+++ b/api/invalidate-user-api-key-cache.ts
@@ -1,0 +1,61 @@
+/**
+ * POST /api/invalidate-user-api-key-cache
+ *
+ * Deletes the Redis cache entry for a revoked user API key so the gateway
+ * stops accepting it immediately instead of waiting for TTL expiry.
+ *
+ * Authentication: Clerk Bearer token (any signed-in user).
+ * Body: { keyHash: string }
+ */
+
+export const config = { runtime: 'edge' };
+
+// @ts-expect-error — JS module, no declaration file
+import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+// @ts-expect-error — JS module, no declaration file
+import { jsonResponse } from './_json-response.js';
+import { validateBearerToken } from '../server/auth-session';
+import { invalidateApiKeyCache } from '../server/_shared/user-api-key';
+
+export default async function handler(req: Request): Promise<Response> {
+  if (isDisallowedOrigin(req)) {
+    return jsonResponse({ error: 'Origin not allowed' }, 403);
+  }
+
+  const cors = getCorsHeaders(req, 'POST, OPTIONS');
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: cors });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405, cors);
+  }
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+  if (!token) {
+    return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
+  }
+
+  const session = await validateBearerToken(token);
+  if (!session.valid || !session.userId) {
+    return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
+  }
+
+  let body: { keyHash?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON body' }, 422, cors);
+  }
+
+  const { keyHash } = body;
+  if (typeof keyHash !== 'string' || !/^[a-f0-9]{64}$/.test(keyHash)) {
+    return jsonResponse({ error: 'Invalid keyHash' }, 422, cors);
+  }
+
+  await invalidateApiKeyCache(keyHash);
+
+  return jsonResponse({ ok: true }, 200, cors);
+}

--- a/api/v2/shipping/route-intelligence.ts
+++ b/api/v2/shipping/route-intelligence.ts
@@ -49,7 +49,16 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: { ...cors, 'Content-Type': 'application/json' } });
   }
 
-  const apiKeyResult = validateApiKey(req, { forceKey: true });
+  let apiKeyResult = validateApiKey(req, { forceKey: true });
+  // Fallback: wm_ user keys are validated async via Convex, not in the static key list
+  const wmKey = req.headers.get('X-WorldMonitor-Key') ?? '';
+  if (apiKeyResult.required && !apiKeyResult.valid && wmKey.startsWith('wm_')) {
+    const { validateUserApiKey } = await import('../../../server/_shared/user-api-key');
+    const userKeyResult = await validateUserApiKey(wmKey);
+    if (userKeyResult) {
+      apiKeyResult = { valid: true, required: true };
+    }
+  }
   if (apiKeyResult.required && !apiKeyResult.valid) {
     return new Response(JSON.stringify({ error: apiKeyResult.error ?? 'API key required' }), {
       status: 401,

--- a/api/v2/shipping/webhooks.ts
+++ b/api/v2/shipping/webhooks.ts
@@ -138,16 +138,7 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response(null, { status: 204, headers: cors });
   }
 
-  let apiKeyResult = validateApiKey(req, { forceKey: true });
-  // Fallback: wm_ user keys are validated async via Convex, not in the static key list
-  const wmKey = req.headers.get('X-WorldMonitor-Key') ?? '';
-  if (apiKeyResult.required && !apiKeyResult.valid && wmKey.startsWith('wm_')) {
-    const { validateUserApiKey } = await import('../../../server/_shared/user-api-key');
-    const userKeyResult = await validateUserApiKey(wmKey);
-    if (userKeyResult) {
-      apiKeyResult = { valid: true, required: true };
-    }
-  }
+  const apiKeyResult = validateApiKey(req, { forceKey: true });
   if (apiKeyResult.required && !apiKeyResult.valid) {
     return new Response(JSON.stringify({ error: apiKeyResult.error ?? 'API key required' }), {
       status: 401,

--- a/api/v2/shipping/webhooks.ts
+++ b/api/v2/shipping/webhooks.ts
@@ -138,7 +138,16 @@ export default async function handler(req: Request): Promise<Response> {
     return new Response(null, { status: 204, headers: cors });
   }
 
-  const apiKeyResult = validateApiKey(req, { forceKey: true });
+  let apiKeyResult = validateApiKey(req, { forceKey: true });
+  // Fallback: wm_ user keys are validated async via Convex, not in the static key list
+  const wmKey = req.headers.get('X-WorldMonitor-Key') ?? '';
+  if (apiKeyResult.required && !apiKeyResult.valid && wmKey.startsWith('wm_')) {
+    const { validateUserApiKey } = await import('../../../server/_shared/user-api-key');
+    const userKeyResult = await validateUserApiKey(wmKey);
+    if (userKeyResult) {
+      apiKeyResult = { valid: true, required: true };
+    }
+  }
   if (apiKeyResult.required && !apiKeyResult.valid) {
     return new Response(JSON.stringify({ error: apiKeyResult.error ?? 'API key required' }), {
       status: 401,

--- a/convex/__tests__/apiKeys.test.ts
+++ b/convex/__tests__/apiKeys.test.ts
@@ -14,6 +14,7 @@ const NOW = Date.now();
 const FUTURE = NOW + 86400000 * 30; // 30 days
 const PAST = NOW - 86400000; // 1 day ago
 
+const API_USER = { subject: "user-api", tokenIdentifier: "clerk|user-api" };
 const PRO_USER = { subject: "user-pro", tokenIdentifier: "clerk|user-pro" };
 const FREE_USER = { subject: "user-free", tokenIdentifier: "clerk|user-free" };
 const OTHER_USER = { subject: "user-other", tokenIdentifier: "clerk|user-other" };
@@ -28,6 +29,24 @@ function makeKeyArgs(n: number) {
   };
 }
 
+/** Seed entitlement with apiAccess=true (API_STARTER plan, tier 2). */
+async function seedApiEntitlement(
+  t: ReturnType<typeof convexTest>,
+  userId: string,
+  opts: { validUntil?: number } = {},
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("entitlements", {
+      userId,
+      planKey: "api_starter",
+      features: getFeaturesForPlan("api_starter"),
+      validUntil: opts.validUntil ?? FUTURE,
+      updatedAt: NOW,
+    });
+  });
+}
+
+/** Seed entitlement with apiAccess=false (Pro plan, tier 1). */
 async function seedProEntitlement(
   t: ReturnType<typeof convexTest>,
   userId: string,
@@ -49,28 +68,38 @@ async function seedProEntitlement(
 // ---------------------------------------------------------------------------
 
 describe("createApiKey", () => {
-  test("rejects free-tier users (PRO_REQUIRED)", async () => {
+  test("rejects free-tier users (API_ACCESS_REQUIRED)", async () => {
     const t = convexTest(schema, modules);
 
     await expect(
       t.withIdentity(FREE_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1)),
-    ).rejects.toThrow(/PRO_REQUIRED/);
+    ).rejects.toThrow(/API_ACCESS_REQUIRED/);
+  });
+
+  test("rejects pro-tier users without apiAccess", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    // Pro plan has apiAccess=false — should be rejected
+    await expect(
+      t.withIdentity(PRO_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1)),
+    ).rejects.toThrow(/API_ACCESS_REQUIRED/);
   });
 
   test("rejects users with expired entitlement", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro", { validUntil: PAST });
+    await seedApiEntitlement(t, "user-api", { validUntil: PAST });
 
     await expect(
-      t.withIdentity(PRO_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1)),
-    ).rejects.toThrow(/PRO_REQUIRED/);
+      t.withIdentity(API_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1)),
+    ).rejects.toThrow(/API_ACCESS_REQUIRED/);
   });
 
-  test("succeeds for pro user", async () => {
+  test("succeeds for API-tier user", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    const result = await t.withIdentity(PRO_USER).mutation(
+    const result = await t.withIdentity(API_USER).mutation(
       api.apiKeys.createApiKey,
       makeKeyArgs(1),
     );
@@ -84,45 +113,45 @@ describe("createApiKey", () => {
 
   test("enforces per-user limit of 5 active keys", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    const asProUser = t.withIdentity(PRO_USER);
+    const asApiUser = t.withIdentity(API_USER);
     for (let i = 1; i <= 5; i++) {
-      await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(i));
+      await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(i));
     }
 
     await expect(
-      asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(6)),
+      asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(6)),
     ).rejects.toThrow(/KEY_LIMIT_REACHED/);
   });
 
   test("revoked keys do not count toward the limit", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    const asProUser = t.withIdentity(PRO_USER);
-    const first = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    const asApiUser = t.withIdentity(API_USER);
+    const first = await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
     for (let i = 2; i <= 5; i++) {
-      await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(i));
+      await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(i));
     }
 
     // Revoke the first key
-    await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: first.id });
+    await asApiUser.mutation(api.apiKeys.revokeApiKey, { keyId: first.id });
 
     // Should succeed since only 4 active keys remain
-    const sixth = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(6));
+    const sixth = await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(6));
     expect(sixth.name).toBe("test-key-6");
   });
 
   test("rejects duplicate key hash", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    const asProUser = t.withIdentity(PRO_USER);
-    await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    const asApiUser = t.withIdentity(API_USER);
+    await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
 
     await expect(
-      asProUser.mutation(api.apiKeys.createApiKey, {
+      asApiUser.mutation(api.apiKeys.createApiKey, {
         ...makeKeyArgs(1),
         name: "different-name",
       }),
@@ -131,10 +160,10 @@ describe("createApiKey", () => {
 
   test("rejects invalid keyPrefix format", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
     await expect(
-      t.withIdentity(PRO_USER).mutation(api.apiKeys.createApiKey, {
+      t.withIdentity(API_USER).mutation(api.apiKeys.createApiKey, {
         name: "test",
         keyPrefix: "wm_toolong00",
         keyHash: "a".repeat(64),
@@ -144,10 +173,10 @@ describe("createApiKey", () => {
 
   test("rejects invalid keyHash format", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
     await expect(
-      t.withIdentity(PRO_USER).mutation(api.apiKeys.createApiKey, {
+      t.withIdentity(API_USER).mutation(api.apiKeys.createApiKey, {
         name: "test",
         keyPrefix: "wm_abcde",
         keyHash: "not-a-valid-hash",
@@ -157,10 +186,10 @@ describe("createApiKey", () => {
 
   test("rejects empty name", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
     await expect(
-      t.withIdentity(PRO_USER).mutation(api.apiKeys.createApiKey, {
+      t.withIdentity(API_USER).mutation(api.apiKeys.createApiKey, {
         name: "   ",
         keyPrefix: "wm_abcde",
         keyHash: "a".repeat(64),
@@ -176,21 +205,21 @@ describe("createApiKey", () => {
 describe("revokeApiKey", () => {
   test("revokes own key and returns keyHash", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    const asProUser = t.withIdentity(PRO_USER);
-    const created = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    const asApiUser = t.withIdentity(API_USER);
+    const created = await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
 
-    const result = await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
+    const result = await asApiUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
     expect(result.ok).toBe(true);
     expect(result.keyHash).toBe(makeKeyArgs(1).keyHash);
   });
 
   test("rejects non-owner revoke attempt", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    const created = await t.withIdentity(PRO_USER).mutation(
+    const created = await t.withIdentity(API_USER).mutation(
       api.apiKeys.createApiKey,
       makeKeyArgs(1),
     );
@@ -202,14 +231,14 @@ describe("revokeApiKey", () => {
 
   test("rejects double revocation", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    const asProUser = t.withIdentity(PRO_USER);
-    const created = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
-    await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
+    const asApiUser = t.withIdentity(API_USER);
+    const created = await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    await asApiUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
 
     await expect(
-      asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id }),
+      asApiUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id }),
     ).rejects.toThrow(/ALREADY_REVOKED/);
   });
 });
@@ -222,20 +251,20 @@ describe("listApiKeys", () => {
   test("returns empty list when no keys", async () => {
     const t = convexTest(schema, modules);
 
-    const keys = await t.withIdentity(PRO_USER).query(api.apiKeys.listApiKeys, {});
+    const keys = await t.withIdentity(API_USER).query(api.apiKeys.listApiKeys, {});
     expect(keys).toEqual([]);
   });
 
   test("returns both active and revoked keys", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    const asProUser = t.withIdentity(PRO_USER);
-    const k1 = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
-    await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(2));
-    await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: k1.id });
+    const asApiUser = t.withIdentity(API_USER);
+    const k1 = await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(2));
+    await asApiUser.mutation(api.apiKeys.revokeApiKey, { keyId: k1.id });
 
-    const keys = await asProUser.query(api.apiKeys.listApiKeys, {});
+    const keys = await asApiUser.query(api.apiKeys.listApiKeys, {});
     expect(keys).toHaveLength(2);
 
     const active = keys.filter((k: any) => !k.revokedAt);
@@ -246,9 +275,9 @@ describe("listApiKeys", () => {
 
   test("does not return other users' keys", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    await t.withIdentity(PRO_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    await t.withIdentity(API_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
 
     const otherKeys = await t.withIdentity(OTHER_USER).query(api.apiKeys.listApiKeys, {});
     expect(otherKeys).toEqual([]);
@@ -262,26 +291,26 @@ describe("listApiKeys", () => {
 describe("validateKeyByHash", () => {
   test("returns key info for valid active key", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    await t.withIdentity(PRO_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    await t.withIdentity(API_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
 
     const result = await t.query(internal.apiKeys.validateKeyByHash, {
       keyHash: makeKeyArgs(1).keyHash,
     });
     expect(result).toMatchObject({
-      userId: "user-pro",
+      userId: "user-api",
       name: "test-key-1",
     });
   });
 
   test("returns null for revoked key", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    const asProUser = t.withIdentity(PRO_USER);
-    const created = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
-    await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
+    const asApiUser = t.withIdentity(API_USER);
+    const created = await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    await asApiUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
 
     const result = await t.query(internal.apiKeys.validateKeyByHash, {
       keyHash: makeKeyArgs(1).keyHash,
@@ -306,16 +335,16 @@ describe("validateKeyByHash", () => {
 describe("getKeyOwner", () => {
   test("returns owner regardless of revoked status", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    const asProUser = t.withIdentity(PRO_USER);
-    const created = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
-    await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
+    const asApiUser = t.withIdentity(API_USER);
+    const created = await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    await asApiUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
 
     const result = await t.query(internal.apiKeys.getKeyOwner, {
       keyHash: makeKeyArgs(1).keyHash,
     });
-    expect(result).toEqual({ userId: "user-pro" });
+    expect(result).toEqual({ userId: "user-api" });
   });
 
   test("returns null for nonexistent hash", async () => {
@@ -335,27 +364,27 @@ describe("getKeyOwner", () => {
 describe("touchKeyLastUsed", () => {
   test("sets lastUsedAt on first call", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    const created = await t.withIdentity(PRO_USER).mutation(
+    const created = await t.withIdentity(API_USER).mutation(
       api.apiKeys.createApiKey,
       makeKeyArgs(1),
     );
 
     await t.mutation(internal.apiKeys.touchKeyLastUsed, { keyId: created.id });
 
-    const keys = await t.withIdentity(PRO_USER).query(api.apiKeys.listApiKeys, {});
+    const keys = await t.withIdentity(API_USER).query(api.apiKeys.listApiKeys, {});
     const key = keys.find((k: any) => k.id === created.id);
     expect(key?.lastUsedAt).toBeGreaterThan(0);
   });
 
   test("skips write for revoked key", async () => {
     const t = convexTest(schema, modules);
-    await seedProEntitlement(t, "user-pro");
+    await seedApiEntitlement(t, "user-api");
 
-    const asProUser = t.withIdentity(PRO_USER);
-    const created = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
-    await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
+    const asApiUser = t.withIdentity(API_USER);
+    const created = await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    await asApiUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
 
     // Should not throw
     await t.mutation(internal.apiKeys.touchKeyLastUsed, { keyId: created.id });

--- a/convex/__tests__/apiKeys.test.ts
+++ b/convex/__tests__/apiKeys.test.ts
@@ -1,0 +1,363 @@
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import { getFeaturesForPlan } from "../lib/entitlements";
+
+const modules = import.meta.glob("../**/*.ts");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NOW = Date.now();
+const FUTURE = NOW + 86400000 * 30; // 30 days
+const PAST = NOW - 86400000; // 1 day ago
+
+const PRO_USER = { subject: "user-pro", tokenIdentifier: "clerk|user-pro" };
+const FREE_USER = { subject: "user-free", tokenIdentifier: "clerk|user-free" };
+const OTHER_USER = { subject: "user-other", tokenIdentifier: "clerk|user-other" };
+
+function makeKeyArgs(n: number) {
+  const hex = n.toString(16).padStart(5, "0");
+  const hash = hex.repeat(13).slice(0, 64); // 64-char hex
+  return {
+    name: `test-key-${n}`,
+    keyPrefix: `wm_${hex}`,
+    keyHash: hash,
+  };
+}
+
+async function seedProEntitlement(
+  t: ReturnType<typeof convexTest>,
+  userId: string,
+  opts: { validUntil?: number } = {},
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("entitlements", {
+      userId,
+      planKey: "pro_monthly",
+      features: getFeaturesForPlan("pro_monthly"),
+      validUntil: opts.validUntil ?? FUTURE,
+      updatedAt: NOW,
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// createApiKey
+// ---------------------------------------------------------------------------
+
+describe("createApiKey", () => {
+  test("rejects free-tier users (PRO_REQUIRED)", async () => {
+    const t = convexTest(schema, modules);
+
+    await expect(
+      t.withIdentity(FREE_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1)),
+    ).rejects.toThrow(/PRO_REQUIRED/);
+  });
+
+  test("rejects users with expired entitlement", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro", { validUntil: PAST });
+
+    await expect(
+      t.withIdentity(PRO_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1)),
+    ).rejects.toThrow(/PRO_REQUIRED/);
+  });
+
+  test("succeeds for pro user", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    const result = await t.withIdentity(PRO_USER).mutation(
+      api.apiKeys.createApiKey,
+      makeKeyArgs(1),
+    );
+
+    expect(result).toMatchObject({
+      name: "test-key-1",
+      keyPrefix: "wm_00001",
+    });
+    expect(result.id).toBeTruthy();
+  });
+
+  test("enforces per-user limit of 5 active keys", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    const asProUser = t.withIdentity(PRO_USER);
+    for (let i = 1; i <= 5; i++) {
+      await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(i));
+    }
+
+    await expect(
+      asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(6)),
+    ).rejects.toThrow(/KEY_LIMIT_REACHED/);
+  });
+
+  test("revoked keys do not count toward the limit", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    const asProUser = t.withIdentity(PRO_USER);
+    const first = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    for (let i = 2; i <= 5; i++) {
+      await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(i));
+    }
+
+    // Revoke the first key
+    await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: first.id });
+
+    // Should succeed since only 4 active keys remain
+    const sixth = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(6));
+    expect(sixth.name).toBe("test-key-6");
+  });
+
+  test("rejects duplicate key hash", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    const asProUser = t.withIdentity(PRO_USER);
+    await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+
+    await expect(
+      asProUser.mutation(api.apiKeys.createApiKey, {
+        ...makeKeyArgs(1),
+        name: "different-name",
+      }),
+    ).rejects.toThrow(/DUPLICATE_KEY/);
+  });
+
+  test("rejects invalid keyPrefix format", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    await expect(
+      t.withIdentity(PRO_USER).mutation(api.apiKeys.createApiKey, {
+        name: "test",
+        keyPrefix: "wm_toolong00",
+        keyHash: "a".repeat(64),
+      }),
+    ).rejects.toThrow(/INVALID_PREFIX/);
+  });
+
+  test("rejects invalid keyHash format", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    await expect(
+      t.withIdentity(PRO_USER).mutation(api.apiKeys.createApiKey, {
+        name: "test",
+        keyPrefix: "wm_abcde",
+        keyHash: "not-a-valid-hash",
+      }),
+    ).rejects.toThrow(/INVALID_HASH/);
+  });
+
+  test("rejects empty name", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    await expect(
+      t.withIdentity(PRO_USER).mutation(api.apiKeys.createApiKey, {
+        name: "   ",
+        keyPrefix: "wm_abcde",
+        keyHash: "a".repeat(64),
+      }),
+    ).rejects.toThrow(/INVALID_NAME/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// revokeApiKey
+// ---------------------------------------------------------------------------
+
+describe("revokeApiKey", () => {
+  test("revokes own key and returns keyHash", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    const asProUser = t.withIdentity(PRO_USER);
+    const created = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+
+    const result = await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
+    expect(result.ok).toBe(true);
+    expect(result.keyHash).toBe(makeKeyArgs(1).keyHash);
+  });
+
+  test("rejects non-owner revoke attempt", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    const created = await t.withIdentity(PRO_USER).mutation(
+      api.apiKeys.createApiKey,
+      makeKeyArgs(1),
+    );
+
+    await expect(
+      t.withIdentity(OTHER_USER).mutation(api.apiKeys.revokeApiKey, { keyId: created.id }),
+    ).rejects.toThrow(/NOT_FOUND/);
+  });
+
+  test("rejects double revocation", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    const asProUser = t.withIdentity(PRO_USER);
+    const created = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
+
+    await expect(
+      asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id }),
+    ).rejects.toThrow(/ALREADY_REVOKED/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listApiKeys
+// ---------------------------------------------------------------------------
+
+describe("listApiKeys", () => {
+  test("returns empty list when no keys", async () => {
+    const t = convexTest(schema, modules);
+
+    const keys = await t.withIdentity(PRO_USER).query(api.apiKeys.listApiKeys, {});
+    expect(keys).toEqual([]);
+  });
+
+  test("returns both active and revoked keys", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    const asProUser = t.withIdentity(PRO_USER);
+    const k1 = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(2));
+    await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: k1.id });
+
+    const keys = await asProUser.query(api.apiKeys.listApiKeys, {});
+    expect(keys).toHaveLength(2);
+
+    const active = keys.filter((k: any) => !k.revokedAt);
+    const revoked = keys.filter((k: any) => k.revokedAt);
+    expect(active).toHaveLength(1);
+    expect(revoked).toHaveLength(1);
+  });
+
+  test("does not return other users' keys", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    await t.withIdentity(PRO_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+
+    const otherKeys = await t.withIdentity(OTHER_USER).query(api.apiKeys.listApiKeys, {});
+    expect(otherKeys).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateKeyByHash (internal)
+// ---------------------------------------------------------------------------
+
+describe("validateKeyByHash", () => {
+  test("returns key info for valid active key", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    await t.withIdentity(PRO_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+
+    const result = await t.query(internal.apiKeys.validateKeyByHash, {
+      keyHash: makeKeyArgs(1).keyHash,
+    });
+    expect(result).toMatchObject({
+      userId: "user-pro",
+      name: "test-key-1",
+    });
+  });
+
+  test("returns null for revoked key", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    const asProUser = t.withIdentity(PRO_USER);
+    const created = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
+
+    const result = await t.query(internal.apiKeys.validateKeyByHash, {
+      keyHash: makeKeyArgs(1).keyHash,
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns null for nonexistent hash", async () => {
+    const t = convexTest(schema, modules);
+
+    const result = await t.query(internal.apiKeys.validateKeyByHash, {
+      keyHash: "f".repeat(64),
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getKeyOwner (internal)
+// ---------------------------------------------------------------------------
+
+describe("getKeyOwner", () => {
+  test("returns owner regardless of revoked status", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    const asProUser = t.withIdentity(PRO_USER);
+    const created = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
+
+    const result = await t.query(internal.apiKeys.getKeyOwner, {
+      keyHash: makeKeyArgs(1).keyHash,
+    });
+    expect(result).toEqual({ userId: "user-pro" });
+  });
+
+  test("returns null for nonexistent hash", async () => {
+    const t = convexTest(schema, modules);
+
+    const result = await t.query(internal.apiKeys.getKeyOwner, {
+      keyHash: "f".repeat(64),
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// touchKeyLastUsed (internal) — debounce
+// ---------------------------------------------------------------------------
+
+describe("touchKeyLastUsed", () => {
+  test("sets lastUsedAt on first call", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    const created = await t.withIdentity(PRO_USER).mutation(
+      api.apiKeys.createApiKey,
+      makeKeyArgs(1),
+    );
+
+    await t.mutation(internal.apiKeys.touchKeyLastUsed, { keyId: created.id });
+
+    const keys = await t.withIdentity(PRO_USER).query(api.apiKeys.listApiKeys, {});
+    const key = keys.find((k: any) => k.id === created.id);
+    expect(key?.lastUsedAt).toBeGreaterThan(0);
+  });
+
+  test("skips write for revoked key", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+
+    const asProUser = t.withIdentity(PRO_USER);
+    const created = await asProUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    await asProUser.mutation(api.apiKeys.revokeApiKey, { keyId: created.id });
+
+    // Should not throw
+    await t.mutation(internal.apiKeys.touchKeyLastUsed, { keyId: created.id });
+  });
+});

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as alertRules from "../alertRules.js";
+import type * as apiKeys from "../apiKeys.js";
 import type * as config_productCatalog from "../config/productCatalog.js";
 import type * as constants from "../constants.js";
 import type * as contactMessages from "../contactMessages.js";
@@ -43,6 +44,7 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   alertRules: typeof alertRules;
+  apiKeys: typeof apiKeys;
   "config/productCatalog": typeof config_productCatalog;
   constants: typeof constants;
   contactMessages: typeof contactMessages;

--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -1,0 +1,147 @@
+import { ConvexError, v } from "convex/values";
+import { internalMutation, internalQuery, mutation, query } from "./_generated/server";
+import { requireUserId } from "./lib/auth";
+
+/** Maximum number of active (non-revoked) API keys per user. */
+const MAX_KEYS_PER_USER = 5;
+
+// ---------------------------------------------------------------------------
+// Public mutations & queries (require Clerk JWT via ctx.auth)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new API key.
+ *
+ * The caller must generate the random key client-side (or in the HTTP action)
+ * and pass the SHA-256 hex hash + the first 8 chars (prefix) here.
+ * The plaintext key is NEVER stored in Convex.
+ */
+export const createApiKey = mutation({
+  args: {
+    name: v.string(),
+    keyPrefix: v.string(),
+    keyHash: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const userId = await requireUserId(ctx);
+
+    if (!args.name.trim()) {
+      throw new ConvexError("INVALID_NAME");
+    }
+    if (args.keyPrefix.length < 4 || args.keyPrefix.length > 12) {
+      throw new ConvexError("INVALID_PREFIX");
+    }
+    if (!/^[a-f0-9]{64}$/.test(args.keyHash)) {
+      throw new ConvexError("INVALID_HASH");
+    }
+
+    // Enforce per-user key limit (count only non-revoked keys)
+    const existing = await ctx.db
+      .query("userApiKeys")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .collect();
+    const activeCount = existing.filter((k) => !k.revokedAt).length;
+    if (activeCount >= MAX_KEYS_PER_USER) {
+      throw new ConvexError("KEY_LIMIT_REACHED");
+    }
+
+    // Guard against duplicate hash (astronomically unlikely, but belt-and-suspenders)
+    const dup = await ctx.db
+      .query("userApiKeys")
+      .withIndex("by_keyHash", (q) => q.eq("keyHash", args.keyHash))
+      .first();
+    if (dup) {
+      throw new ConvexError("DUPLICATE_KEY");
+    }
+
+    const id = await ctx.db.insert("userApiKeys", {
+      userId,
+      name: args.name.trim(),
+      keyPrefix: args.keyPrefix,
+      keyHash: args.keyHash,
+      createdAt: Date.now(),
+    });
+
+    return { id, name: args.name.trim(), keyPrefix: args.keyPrefix };
+  },
+});
+
+/** List all API keys for the current user (active + revoked). */
+export const listApiKeys = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireUserId(ctx);
+    const keys = await ctx.db
+      .query("userApiKeys")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .collect();
+
+    return keys.map((k) => ({
+      id: k._id,
+      name: k.name,
+      keyPrefix: k.keyPrefix,
+      createdAt: k.createdAt,
+      lastUsedAt: k.lastUsedAt,
+      revokedAt: k.revokedAt,
+    }));
+  },
+});
+
+/** Revoke a key owned by the current user. */
+export const revokeApiKey = mutation({
+  args: { keyId: v.id("userApiKeys") },
+  handler: async (ctx, args) => {
+    const userId = await requireUserId(ctx);
+    const key = await ctx.db.get(args.keyId);
+
+    if (!key || key.userId !== userId) {
+      throw new ConvexError("NOT_FOUND");
+    }
+    if (key.revokedAt) {
+      throw new ConvexError("ALREADY_REVOKED");
+    }
+
+    await ctx.db.patch(args.keyId, { revokedAt: Date.now() });
+    return { ok: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Internal (service-to-service) — called from HTTP actions / middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up an API key by its SHA-256 hash.
+ * Returns the key row (with userId) if found and not revoked, else null.
+ * Used by the edge gateway to validate incoming API keys.
+ */
+export const validateKeyByHash = internalQuery({
+  args: { keyHash: v.string() },
+  handler: async (ctx, args) => {
+    const key = await ctx.db
+      .query("userApiKeys")
+      .withIndex("by_keyHash", (q) => q.eq("keyHash", args.keyHash))
+      .first();
+
+    if (!key || key.revokedAt) return null;
+
+    return {
+      id: key._id,
+      userId: key.userId,
+      name: key.name,
+    };
+  },
+});
+
+/**
+ * Bump lastUsedAt for a key (fire-and-forget from the gateway).
+ */
+export const touchKeyLastUsed = internalMutation({
+  args: { keyId: v.id("userApiKeys") },
+  handler: async (ctx, args) => {
+    const key = await ctx.db.get(args.keyId);
+    if (key) {
+      await ctx.db.patch(args.keyId, { lastUsedAt: Date.now() });
+    }
+  },
+});

--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -28,7 +28,7 @@ export const createApiKey = mutation({
     if (!args.name.trim()) {
       throw new ConvexError("INVALID_NAME");
     }
-    if (args.keyPrefix.length < 4 || args.keyPrefix.length > 12) {
+    if (!/^wm_[a-f0-9]{5,9}$/.test(args.keyPrefix)) {
       throw new ConvexError("INVALID_PREFIX");
     }
     if (!/^[a-f0-9]{64}$/.test(args.keyHash)) {
@@ -102,7 +102,7 @@ export const revokeApiKey = mutation({
     }
 
     await ctx.db.patch(args.keyId, { revokedAt: Date.now() });
-    return { ok: true };
+    return { ok: true, keyHash: key.keyHash };
   },
 });
 
@@ -140,7 +140,7 @@ export const touchKeyLastUsed = internalMutation({
   args: { keyId: v.id("userApiKeys") },
   handler: async (ctx, args) => {
     const key = await ctx.db.get(args.keyId);
-    if (key) {
+    if (key && !key.revokedAt) {
       await ctx.db.patch(args.keyId, { lastUsedAt: Date.now() });
     }
   },

--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -5,6 +5,9 @@ import { requireUserId } from "./lib/auth";
 /** Maximum number of active (non-revoked) API keys per user. */
 const MAX_KEYS_PER_USER = 5;
 
+/** Minimum entitlement tier required to create API keys (1 = pro). */
+const REQUIRED_TIER = 1;
+
 // ---------------------------------------------------------------------------
 // Public mutations & queries (require Clerk JWT via ctx.auth)
 // ---------------------------------------------------------------------------
@@ -15,6 +18,8 @@ const MAX_KEYS_PER_USER = 5;
  * The caller must generate the random key client-side (or in the HTTP action)
  * and pass the SHA-256 hex hash + the first 8 chars (prefix) here.
  * The plaintext key is NEVER stored in Convex.
+ *
+ * Requires an active pro (tier >= 1) entitlement. Free-tier users are blocked.
  */
 export const createApiKey = mutation({
   args: {
@@ -25,10 +30,22 @@ export const createApiKey = mutation({
   handler: async (ctx, args) => {
     const userId = await requireUserId(ctx);
 
+    // Entitlement gate: only pro+ users may create API keys
+    const entitlement = await ctx.db
+      .query("entitlements")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .first();
+    const tier = (entitlement && entitlement.validUntil >= Date.now())
+      ? entitlement.features.tier
+      : 0;
+    if (tier < REQUIRED_TIER) {
+      throw new ConvexError("PRO_REQUIRED");
+    }
+
     if (!args.name.trim()) {
       throw new ConvexError("INVALID_NAME");
     }
-    if (!/^wm_[a-f0-9]{5,9}$/.test(args.keyPrefix)) {
+    if (!/^wm_[a-f0-9]{5}$/.test(args.keyPrefix)) {
       throw new ConvexError("INVALID_PREFIX");
     }
     if (!/^[a-f0-9]{64}$/.test(args.keyHash)) {
@@ -134,14 +151,33 @@ export const validateKeyByHash = internalQuery({
 });
 
 /**
- * Bump lastUsedAt for a key (fire-and-forget from the gateway).
+ * Look up the owner of a key by its hash, regardless of revoked status.
+ * Used by the cache-invalidation endpoint to verify tenancy.
  */
+export const getKeyOwner = internalQuery({
+  args: { keyHash: v.string() },
+  handler: async (ctx, args) => {
+    const key = await ctx.db
+      .query("userApiKeys")
+      .withIndex("by_keyHash", (q) => q.eq("keyHash", args.keyHash))
+      .first();
+    return key ? { userId: key.userId } : null;
+  },
+});
+
+/**
+ * Bump lastUsedAt for a key (fire-and-forget from the gateway).
+ * Skips the write if lastUsedAt was updated within the last 5 minutes
+ * to reduce Convex write load for hot keys.
+ */
+const TOUCH_DEBOUNCE_MS = 5 * 60 * 1000;
+
 export const touchKeyLastUsed = internalMutation({
   args: { keyId: v.id("userApiKeys") },
   handler: async (ctx, args) => {
     const key = await ctx.db.get(args.keyId);
-    if (key && !key.revokedAt) {
-      await ctx.db.patch(args.keyId, { lastUsedAt: Date.now() });
-    }
+    if (!key || key.revokedAt) return;
+    if (key.lastUsedAt && key.lastUsedAt > Date.now() - TOUCH_DEBOUNCE_MS) return;
+    await ctx.db.patch(args.keyId, { lastUsedAt: Date.now() });
   },
 });

--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -5,9 +5,6 @@ import { requireUserId } from "./lib/auth";
 /** Maximum number of active (non-revoked) API keys per user. */
 const MAX_KEYS_PER_USER = 5;
 
-/** Minimum entitlement tier required to create API keys (1 = pro). */
-const REQUIRED_TIER = 1;
-
 // ---------------------------------------------------------------------------
 // Public mutations & queries (require Clerk JWT via ctx.auth)
 // ---------------------------------------------------------------------------
@@ -19,7 +16,8 @@ const REQUIRED_TIER = 1;
  * and pass the SHA-256 hex hash + the first 8 chars (prefix) here.
  * The plaintext key is NEVER stored in Convex.
  *
- * Requires an active pro (tier >= 1) entitlement. Free-tier users are blocked.
+ * Requires an active entitlement with apiAccess=true (API_STARTER+ plans).
+ * Pro plans (tier 1) have apiAccess=false and cannot create keys.
  */
 export const createApiKey = mutation({
   args: {
@@ -30,16 +28,19 @@ export const createApiKey = mutation({
   handler: async (ctx, args) => {
     const userId = await requireUserId(ctx);
 
-    // Entitlement gate: only pro+ users may create API keys
+    // Entitlement gate: only users with apiAccess may create API keys.
+    // This is catalog-driven — Pro (tier 1) has apiAccess=false;
+    // API_STARTER+ (tier 2+) have apiAccess=true.
     const entitlement = await ctx.db
       .query("entitlements")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
       .first();
-    const tier = (entitlement && entitlement.validUntil >= Date.now())
-      ? entitlement.features.tier
-      : 0;
-    if (tier < REQUIRED_TIER) {
-      throw new ConvexError("PRO_REQUIRED");
+    if (
+      !entitlement ||
+      entitlement.validUntil < Date.now() ||
+      !entitlement.features.apiAccess
+    ) {
+      throw new ConvexError("API_ACCESS_REQUIRED");
     }
 
     if (!args.name.trim()) {

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -635,122 +635,8 @@ http.route({
 });
 
 // ---------------------------------------------------------------------------
-// User API key management (Clerk JWT required)
+// User API key validation (service-to-service only)
 // ---------------------------------------------------------------------------
-
-http.route({
-  path: "/api/api-keys",
-  method: "OPTIONS",
-  handler: httpAction(async (_ctx, request) => {
-    const headers = corsHeaders(request.headers.get("Origin"));
-    return new Response(null, { status: 204, headers });
-  }),
-});
-
-http.route({
-  path: "/api/api-keys",
-  method: "POST",
-  handler: httpAction(async (ctx, request) => {
-    const headers = corsHeaders(request.headers.get("Origin"));
-    headers.set("Content-Type", "application/json");
-
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) {
-      return new Response(JSON.stringify({ error: "UNAUTHENTICATED" }), {
-        status: 401,
-        headers,
-      });
-    }
-
-    let body: { action?: string; name?: string; keyId?: string };
-    try {
-      body = (await request.json()) as typeof body;
-    } catch {
-      return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
-        status: 400,
-        headers,
-      });
-    }
-
-    const action = body.action ?? "create";
-
-    try {
-      // --- CREATE ---
-      if (action === "create") {
-        if (typeof body.name !== "string" || !body.name.trim()) {
-          return new Response(
-            JSON.stringify({ error: "MISSING_FIELDS", required: ["name"] }),
-            { status: 400, headers },
-          );
-        }
-
-        // Generate a cryptographically random key in the HTTP action layer.
-        // Format: wm_<40 hex chars>  (20 random bytes → 160 bits of entropy)
-        const raw = new Uint8Array(20);
-        crypto.getRandomValues(raw);
-        const hex = Array.from(raw, (b) => b.toString(16).padStart(2, "0")).join("");
-        const plaintext = `wm_${hex}`;
-        const keyPrefix = plaintext.slice(0, 8); // "wm_XXXXX"
-
-        // Hash for storage (SHA-256, hex-encoded)
-        const hashBuf = await crypto.subtle.digest(
-          "SHA-256",
-          new TextEncoder().encode(plaintext),
-        );
-        const keyHash = Array.from(new Uint8Array(hashBuf), (b) =>
-          b.toString(16).padStart(2, "0"),
-        ).join("");
-
-        const result = await ctx.runMutation(
-          anyApi.apiKeys!.createApiKey as any,
-          { name: body.name.trim(), keyPrefix, keyHash },
-        );
-
-        // Return the plaintext key ONCE — it can never be retrieved again.
-        return new Response(
-          JSON.stringify({ ...result, key: plaintext }),
-          { status: 201, headers },
-        );
-      }
-
-      // --- LIST ---
-      if (action === "list") {
-        const keys = await ctx.runQuery(
-          anyApi.apiKeys!.listApiKeys as any,
-          {},
-        );
-        return new Response(JSON.stringify({ keys }), { status: 200, headers });
-      }
-
-      // --- REVOKE ---
-      if (action === "revoke") {
-        if (typeof body.keyId !== "string" || !body.keyId) {
-          return new Response(
-            JSON.stringify({ error: "MISSING_FIELDS", required: ["keyId"] }),
-            { status: 400, headers },
-          );
-        }
-        const result = await ctx.runMutation(
-          anyApi.apiKeys!.revokeApiKey as any,
-          { keyId: body.keyId },
-        );
-        return new Response(JSON.stringify(result), { status: 200, headers });
-      }
-
-      return new Response(
-        JSON.stringify({ error: "UNKNOWN_ACTION" }),
-        { status: 400, headers },
-      );
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      const status = msg.includes("KEY_LIMIT_REACHED") ? 429
-        : msg.includes("NOT_FOUND") ? 404
-        : msg.includes("ALREADY_REVOKED") ? 409
-        : 500;
-      return new Response(JSON.stringify({ error: msg }), { status, headers });
-    }
-  }),
-});
 
 // Service-to-service: validate a user API key by its SHA-256 hash.
 // Called by the Vercel edge gateway to look up user-owned keys.
@@ -793,6 +679,50 @@ http.route({
       // Fire-and-forget: update lastUsedAt (don't await, don't block response)
       void ctx.runMutation((internal as any).apiKeys.touchKeyLastUsed, { keyId: result.id });
     }
+
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }),
+});
+
+// Service-to-service: look up the owner of a key by hash (regardless of revoked status).
+// Used by the cache-invalidation endpoint to verify tenancy boundaries.
+http.route({
+  path: "/api/internal-get-key-owner",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const providedSecret = request.headers.get("x-convex-shared-secret") ?? "";
+    const expectedSecret = process.env.CONVEX_SERVER_SHARED_SECRET ?? "";
+    if (!expectedSecret || !(await timingSafeEqualStrings(providedSecret, expectedSecret))) {
+      return new Response(JSON.stringify({ error: "UNAUTHORIZED" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    let body: { keyHash?: unknown };
+    try {
+      body = await request.json() as { keyHash?: unknown };
+    } catch {
+      return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (typeof body.keyHash !== "string" || !/^[a-f0-9]{64}$/.test(body.keyHash)) {
+      return new Response(JSON.stringify({ error: "INVALID_KEY_HASH" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const result = await ctx.runQuery(
+      (internal as any).apiKeys.getKeyOwner,
+      { keyHash: body.keyHash },
+    );
 
     return new Response(JSON.stringify(result), {
       status: 200,

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -634,6 +634,173 @@ http.route({
   }),
 });
 
+// ---------------------------------------------------------------------------
+// User API key management (Clerk JWT required)
+// ---------------------------------------------------------------------------
+
+http.route({
+  path: "/api/api-keys",
+  method: "OPTIONS",
+  handler: httpAction(async (_ctx, request) => {
+    const headers = corsHeaders(request.headers.get("Origin"));
+    return new Response(null, { status: 204, headers });
+  }),
+});
+
+http.route({
+  path: "/api/api-keys",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const headers = corsHeaders(request.headers.get("Origin"));
+    headers.set("Content-Type", "application/json");
+
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      return new Response(JSON.stringify({ error: "UNAUTHENTICATED" }), {
+        status: 401,
+        headers,
+      });
+    }
+
+    let body: { action?: string; name?: string; keyId?: string };
+    try {
+      body = (await request.json()) as typeof body;
+    } catch {
+      return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
+        status: 400,
+        headers,
+      });
+    }
+
+    const action = body.action ?? "create";
+
+    try {
+      // --- CREATE ---
+      if (action === "create") {
+        if (typeof body.name !== "string" || !body.name.trim()) {
+          return new Response(
+            JSON.stringify({ error: "MISSING_FIELDS", required: ["name"] }),
+            { status: 400, headers },
+          );
+        }
+
+        // Generate a cryptographically random key in the HTTP action layer.
+        // Format: wm_<40 hex chars>  (20 random bytes → 160 bits of entropy)
+        const raw = new Uint8Array(20);
+        crypto.getRandomValues(raw);
+        const hex = Array.from(raw, (b) => b.toString(16).padStart(2, "0")).join("");
+        const plaintext = `wm_${hex}`;
+        const keyPrefix = plaintext.slice(0, 8); // "wm_XXXXX"
+
+        // Hash for storage (SHA-256, hex-encoded)
+        const hashBuf = await crypto.subtle.digest(
+          "SHA-256",
+          new TextEncoder().encode(plaintext),
+        );
+        const keyHash = Array.from(new Uint8Array(hashBuf), (b) =>
+          b.toString(16).padStart(2, "0"),
+        ).join("");
+
+        const result = await ctx.runMutation(
+          anyApi.apiKeys!.createApiKey as any,
+          { name: body.name.trim(), keyPrefix, keyHash },
+        );
+
+        // Return the plaintext key ONCE — it can never be retrieved again.
+        return new Response(
+          JSON.stringify({ ...result, key: plaintext }),
+          { status: 201, headers },
+        );
+      }
+
+      // --- LIST ---
+      if (action === "list") {
+        const keys = await ctx.runQuery(
+          anyApi.apiKeys!.listApiKeys as any,
+          {},
+        );
+        return new Response(JSON.stringify({ keys }), { status: 200, headers });
+      }
+
+      // --- REVOKE ---
+      if (action === "revoke") {
+        if (typeof body.keyId !== "string" || !body.keyId) {
+          return new Response(
+            JSON.stringify({ error: "MISSING_FIELDS", required: ["keyId"] }),
+            { status: 400, headers },
+          );
+        }
+        const result = await ctx.runMutation(
+          anyApi.apiKeys!.revokeApiKey as any,
+          { keyId: body.keyId },
+        );
+        return new Response(JSON.stringify(result), { status: 200, headers });
+      }
+
+      return new Response(
+        JSON.stringify({ error: "UNKNOWN_ACTION" }),
+        { status: 400, headers },
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const status = msg.includes("KEY_LIMIT_REACHED") ? 429
+        : msg.includes("NOT_FOUND") ? 404
+        : msg.includes("ALREADY_REVOKED") ? 409
+        : 500;
+      return new Response(JSON.stringify({ error: msg }), { status, headers });
+    }
+  }),
+});
+
+// Service-to-service: validate a user API key by its SHA-256 hash.
+// Called by the Vercel edge gateway to look up user-owned keys.
+http.route({
+  path: "/api/internal-validate-api-key",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    const providedSecret = request.headers.get("x-convex-shared-secret") ?? "";
+    const expectedSecret = process.env.CONVEX_SERVER_SHARED_SECRET ?? "";
+    if (!expectedSecret || !(await timingSafeEqualStrings(providedSecret, expectedSecret))) {
+      return new Response(JSON.stringify({ error: "UNAUTHORIZED" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    let body: { keyHash?: unknown };
+    try {
+      body = await request.json() as { keyHash?: unknown };
+    } catch {
+      return new Response(JSON.stringify({ error: "INVALID_JSON" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (typeof body.keyHash !== "string" || body.keyHash.length === 0) {
+      return new Response(JSON.stringify({ error: "MISSING_KEY_HASH" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const result = await ctx.runQuery(
+      (internal as any).apiKeys.validateKeyByHash,
+      { keyHash: body.keyHash },
+    );
+
+    if (result) {
+      // Fire-and-forget: update lastUsedAt (don't await, don't block response)
+      void ctx.runMutation((internal as any).apiKeys.touchKeyLastUsed, { keyId: result.id });
+    }
+
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }),
+});
+
 http.route({
   path: "/dodopayments-webhook",
   method: "POST",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -215,6 +215,18 @@ export default defineSchema({
     .index("by_dodoProductId", ["dodoProductId"])
     .index("by_planKey", ["planKey"]),
 
+  userApiKeys: defineTable({
+    userId: v.string(),
+    name: v.string(),
+    keyPrefix: v.string(),        // first 8 chars of plaintext key, for display
+    keyHash: v.string(),          // SHA-256 hex digest — never store plaintext
+    createdAt: v.number(),
+    lastUsedAt: v.optional(v.number()),
+    revokedAt: v.optional(v.number()),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_keyHash", ["keyHash"]),
+
   emailSuppressions: defineTable({
     normalizedEmail: v.string(),
     reason: v.union(v.literal("bounce"), v.literal("complaint"), v.literal("manual")),

--- a/server/_shared/premium-check.ts
+++ b/server/_shared/premium-check.ts
@@ -18,9 +18,14 @@ export async function isCallerPremium(request: Request): Promise<boolean> {
       .split(',').map((k) => k.trim()).filter(Boolean);
     if (validKeys.length > 0 && validKeys.includes(wmKey)) return true;
 
-    // Check user-owned API keys (wm_ prefix) via Convex lookup
+    // Check user-owned API keys (wm_ prefix) via Convex lookup.
+    // Key existence alone is not sufficient — verify the owner's entitlement.
     const userKey = await validateUserApiKey(wmKey);
-    if (userKey) return true;
+    if (userKey) {
+      const ent = await getEntitlements(userKey.userId);
+      if (ent && ent.features.tier >= 1) return true;
+      return false;
+    }
   }
 
   const keyCheck = validateApiKey(request, {}) as { valid: boolean; required: boolean };

--- a/server/_shared/premium-check.ts
+++ b/server/_shared/premium-check.ts
@@ -23,7 +23,7 @@ export async function isCallerPremium(request: Request): Promise<boolean> {
     const userKey = await validateUserApiKey(wmKey);
     if (userKey) {
       const ent = await getEntitlements(userKey.userId);
-      if (ent && ent.features.tier >= 1) return true;
+      if (ent && ent.features.apiAccess === true) return true;
       return false;
     }
   }

--- a/server/_shared/premium-check.ts
+++ b/server/_shared/premium-check.ts
@@ -2,6 +2,7 @@
 import { validateApiKey } from '../../api/_api-key.js';
 import { validateBearerToken } from '../auth-session';
 import { getEntitlements } from './entitlement-check';
+import { validateUserApiKey } from './user-api-key';
 
 /**
  * Returns true when the caller has a valid API key OR a PRO bearer token.
@@ -16,6 +17,10 @@ export async function isCallerPremium(request: Request): Promise<boolean> {
     const validKeys = (process.env.WORLDMONITOR_VALID_KEYS ?? '')
       .split(',').map((k) => k.trim()).filter(Boolean);
     if (validKeys.length > 0 && validKeys.includes(wmKey)) return true;
+
+    // Check user-owned API keys (wm_ prefix) via Convex lookup
+    const userKey = await validateUserApiKey(wmKey);
+    if (userKey) return true;
   }
 
   const keyCheck = validateApiKey(request, {}) as { valid: boolean; required: boolean };

--- a/server/_shared/user-api-key.ts
+++ b/server/_shared/user-api-key.ts
@@ -6,7 +6,7 @@
  * Cache entries are keyed by the SHA-256 hash of the API key (never the plaintext).
  */
 
-import { getCachedJson, setCachedJson } from './redis';
+import { getCachedJson, setCachedJson, deleteRedisKey } from './redis';
 
 interface UserKeyResult {
   userId: string;
@@ -15,6 +15,7 @@ interface UserKeyResult {
 }
 
 const CACHE_TTL_SECONDS = 300; // 5 min
+const CACHE_KEY_PREFIX = 'user-api-key:';
 
 /** SHA-256 hex digest (Web Crypto API — works in Edge Runtime). */
 async function sha256Hex(input: string): Promise<string> {
@@ -32,7 +33,7 @@ export async function validateUserApiKey(key: string): Promise<UserKeyResult | n
   if (!key || !key.startsWith('wm_')) return null;
 
   const keyHash = await sha256Hex(key);
-  const cacheKey = `user-api-key:${keyHash}`;
+  const cacheKey = `${CACHE_KEY_PREFIX}${keyHash}`;
 
   // Check Redis cache
   const cached = await getCachedJson(cacheKey, true);
@@ -72,4 +73,12 @@ export async function validateUserApiKey(key: string): Promise<UserKeyResult | n
     console.warn('[user-api-key] validation failed:', err instanceof Error ? err.message : String(err));
     return null;
   }
+}
+
+/**
+ * Delete the Redis cache entry for a specific API key hash.
+ * Called after revocation to ensure the key cannot be used during the TTL window.
+ */
+export async function invalidateApiKeyCache(keyHash: string): Promise<void> {
+  await deleteRedisKey(`${CACHE_KEY_PREFIX}${keyHash}`, true);
 }

--- a/server/_shared/user-api-key.ts
+++ b/server/_shared/user-api-key.ts
@@ -2,11 +2,11 @@
  * Validates user-owned API keys by hashing the provided key and looking up
  * the hash in Convex via the internal HTTP action.
  *
- * Uses Redis as a short-lived cache to avoid hitting Convex on every request.
- * Cache entries are keyed by the SHA-256 hash of the API key (never the plaintext).
+ * Uses cachedFetchJson for Redis caching with in-flight coalescing and
+ * environment-partitioned keys (no raw=true — keys are prefixed by deploy).
  */
 
-import { getCachedJson, setCachedJson, deleteRedisKey } from './redis';
+import { cachedFetchJson, deleteRedisKey } from './redis';
 
 interface UserKeyResult {
   userId: string;
@@ -14,7 +14,8 @@ interface UserKeyResult {
   name: string;
 }
 
-const CACHE_TTL_SECONDS = 300; // 5 min
+const CACHE_TTL_SECONDS = 60; // 1 min — short to limit staleness on revocation
+const NEG_TTL_SECONDS = 60;   // negative cache: avoid hammering Convex with invalid keys
 const CACHE_KEY_PREFIX = 'user-api-key:';
 
 /** SHA-256 hex digest (Web Crypto API — works in Edge Runtime). */
@@ -27,7 +28,8 @@ async function sha256Hex(input: string): Promise<string> {
  * Validate a user-owned API key.
  *
  * Returns the userId and key metadata if valid, or null if invalid/revoked.
- * Checks Redis cache first, then falls back to Convex internal endpoint.
+ * Uses cachedFetchJson for Redis caching with request coalescing and
+ * standard NEG_SENTINEL for negative results.
  */
 export async function validateUserApiKey(key: string): Promise<UserKeyResult | null> {
   if (!key || !key.startsWith('wm_')) return null;
@@ -35,50 +37,40 @@ export async function validateUserApiKey(key: string): Promise<UserKeyResult | n
   const keyHash = await sha256Hex(key);
   const cacheKey = `${CACHE_KEY_PREFIX}${keyHash}`;
 
-  // Check Redis cache
-  const cached = await getCachedJson(cacheKey, true);
-  if (cached === '__INVALID__') return null;
-  if (cached && typeof cached === 'object') return cached as UserKeyResult;
+  return cachedFetchJson<UserKeyResult>(
+    cacheKey,
+    CACHE_TTL_SECONDS,
+    () => fetchFromConvex(keyHash),
+    NEG_TTL_SECONDS,
+  );
+}
 
-  // Convex fallback
+/** Fetch key validation from Convex internal endpoint. */
+async function fetchFromConvex(keyHash: string): Promise<UserKeyResult | null> {
   const convexSiteUrl = process.env.CONVEX_SITE_URL;
   const convexSharedSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
   if (!convexSiteUrl || !convexSharedSecret) return null;
 
-  try {
-    const resp = await fetch(`${convexSiteUrl}/api/internal-validate-api-key`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': 'worldmonitor-gateway/1.0',
-        'x-convex-shared-secret': convexSharedSecret,
-      },
-      body: JSON.stringify({ keyHash }),
-      signal: AbortSignal.timeout(3_000),
-    });
+  const resp = await fetch(`${convexSiteUrl}/api/internal-validate-api-key`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'User-Agent': 'worldmonitor-gateway/1.0',
+      'x-convex-shared-secret': convexSharedSecret,
+    },
+    body: JSON.stringify({ keyHash }),
+    signal: AbortSignal.timeout(3_000),
+  });
 
-    if (!resp.ok) return null;
-
-    const result = await resp.json() as UserKeyResult | null;
-
-    if (result) {
-      await setCachedJson(cacheKey, result, CACHE_TTL_SECONDS, true);
-      return result;
-    }
-
-    // Cache negative result briefly to avoid hammering Convex with invalid keys
-    await setCachedJson(cacheKey, '__INVALID__', 60, true);
-    return null;
-  } catch (err) {
-    console.warn('[user-api-key] validation failed:', err instanceof Error ? err.message : String(err));
-    return null;
-  }
+  if (!resp.ok) return null;
+  return resp.json() as Promise<UserKeyResult | null>;
 }
 
 /**
  * Delete the Redis cache entry for a specific API key hash.
  * Called after revocation to ensure the key cannot be used during the TTL window.
+ * Uses prefixed keys (no raw=true) matching the cache writes above.
  */
 export async function invalidateApiKeyCache(keyHash: string): Promise<void> {
-  await deleteRedisKey(`${CACHE_KEY_PREFIX}${keyHash}`, true);
+  await deleteRedisKey(`${CACHE_KEY_PREFIX}${keyHash}`);
 }

--- a/server/_shared/user-api-key.ts
+++ b/server/_shared/user-api-key.ts
@@ -37,12 +37,19 @@ export async function validateUserApiKey(key: string): Promise<UserKeyResult | n
   const keyHash = await sha256Hex(key);
   const cacheKey = `${CACHE_KEY_PREFIX}${keyHash}`;
 
-  return cachedFetchJson<UserKeyResult>(
-    cacheKey,
-    CACHE_TTL_SECONDS,
-    () => fetchFromConvex(keyHash),
-    NEG_TTL_SECONDS,
-  );
+  try {
+    return await cachedFetchJson<UserKeyResult>(
+      cacheKey,
+      CACHE_TTL_SECONDS,
+      () => fetchFromConvex(keyHash),
+      NEG_TTL_SECONDS,
+    );
+  } catch (err) {
+    // Fail-soft: transient Convex/network errors degrade to unauthorized
+    // rather than bubbling a 500 through the gateway or isCallerPremium.
+    console.warn('[user-api-key] validateUserApiKey failed:', err instanceof Error ? err.message : String(err));
+    return null;
+  }
 }
 
 /** Fetch key validation from Convex internal endpoint. */

--- a/server/_shared/user-api-key.ts
+++ b/server/_shared/user-api-key.ts
@@ -1,0 +1,75 @@
+/**
+ * Validates user-owned API keys by hashing the provided key and looking up
+ * the hash in Convex via the internal HTTP action.
+ *
+ * Uses Redis as a short-lived cache to avoid hitting Convex on every request.
+ * Cache entries are keyed by the SHA-256 hash of the API key (never the plaintext).
+ */
+
+import { getCachedJson, setCachedJson } from './redis';
+
+interface UserKeyResult {
+  userId: string;
+  keyId: string;
+  name: string;
+}
+
+const CACHE_TTL_SECONDS = 300; // 5 min
+
+/** SHA-256 hex digest (Web Crypto API — works in Edge Runtime). */
+async function sha256Hex(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(buf), (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Validate a user-owned API key.
+ *
+ * Returns the userId and key metadata if valid, or null if invalid/revoked.
+ * Checks Redis cache first, then falls back to Convex internal endpoint.
+ */
+export async function validateUserApiKey(key: string): Promise<UserKeyResult | null> {
+  if (!key || !key.startsWith('wm_')) return null;
+
+  const keyHash = await sha256Hex(key);
+  const cacheKey = `user-api-key:${keyHash}`;
+
+  // Check Redis cache
+  const cached = await getCachedJson(cacheKey, true);
+  if (cached === '__INVALID__') return null;
+  if (cached && typeof cached === 'object') return cached as UserKeyResult;
+
+  // Convex fallback
+  const convexSiteUrl = process.env.CONVEX_SITE_URL;
+  const convexSharedSecret = process.env.CONVEX_SERVER_SHARED_SECRET;
+  if (!convexSiteUrl || !convexSharedSecret) return null;
+
+  try {
+    const resp = await fetch(`${convexSiteUrl}/api/internal-validate-api-key`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': 'worldmonitor-gateway/1.0',
+        'x-convex-shared-secret': convexSharedSecret,
+      },
+      body: JSON.stringify({ keyHash }),
+      signal: AbortSignal.timeout(3_000),
+    });
+
+    if (!resp.ok) return null;
+
+    const result = await resp.json() as UserKeyResult | null;
+
+    if (result) {
+      await setCachedJson(cacheKey, result, CACHE_TTL_SECONDS, true);
+      return result;
+    }
+
+    // Cache negative result briefly to avoid hammering Convex with invalid keys
+    await setCachedJson(cacheKey, '__INVALID__', 60, true);
+    return null;
+  } catch (err) {
+    console.warn('[user-api-key] validation failed:', err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -340,8 +340,8 @@ export function createDomainGateway(
     if (isUserApiKey && needsLegacyProBearerGate && sessionUserId) {
       const { getEntitlements } = await import('./_shared/entitlement-check');
       const ent = await getEntitlements(sessionUserId);
-      if (!ent || ent.features.tier < 1) {
-        return new Response(JSON.stringify({ error: 'Pro subscription required' }), {
+      if (!ent || !ent.features.apiAccess) {
+        return new Response(JSON.stringify({ error: 'API access subscription required' }), {
           status: 403,
           headers: { 'Content-Type': 'application/json', ...corsHeaders },
         });

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -305,9 +305,49 @@ export function createDomainGateway(
 
     // API key validation — tier-gated endpoints require EITHER an API key OR a valid bearer token.
     // Authenticated users (sessionUserId present) bypass the API key requirement.
-    const keyCheck = validateApiKey(request, {
+    let keyCheck = validateApiKey(request, {
       forceKey: (isTierGated && !sessionUserId) || needsLegacyProBearerGate,
-    });
+    }) as { valid: boolean; required: boolean; error?: string };
+
+    // User-owned API keys (wm_ prefix): when the static WORLDMONITOR_VALID_KEYS
+    // check fails, try async Convex-backed validation for user-issued keys.
+    let isUserApiKey = false;
+    const wmKey = request.headers.get('X-WorldMonitor-Key') ?? '';
+    if (keyCheck.required && !keyCheck.valid && wmKey.startsWith('wm_')) {
+      const { validateUserApiKey } = await import('./_shared/user-api-key');
+      const userKeyResult = await validateUserApiKey(wmKey);
+      if (userKeyResult) {
+        isUserApiKey = true;
+        keyCheck = { valid: true, required: true };
+        // Inject x-user-id for downstream entitlement checks
+        if (!sessionUserId) {
+          sessionUserId = userKeyResult.userId;
+          request = new Request(request.url, {
+            method: request.method,
+            headers: (() => {
+              const h = new Headers(request.headers);
+              h.set('x-user-id', sessionUserId);
+              return h;
+            })(),
+            body: request.body,
+          });
+        }
+      }
+    }
+
+    // User API keys on PREMIUM_RPC_PATHS need verified pro-tier entitlement.
+    // Admin keys (WORLDMONITOR_VALID_KEYS) bypass this since they are operator-issued.
+    if (isUserApiKey && needsLegacyProBearerGate && sessionUserId) {
+      const { getEntitlements } = await import('./_shared/entitlement-check');
+      const ent = await getEntitlements(sessionUserId);
+      if (!ent || ent.features.tier < 1) {
+        return new Response(JSON.stringify({ error: 'Pro subscription required' }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json', ...corsHeaders },
+        });
+      }
+    }
+
     if (keyCheck.required && !keyCheck.valid) {
       if (needsLegacyProBearerGate) {
         const authHeader = request.headers.get('Authorization');
@@ -358,9 +398,9 @@ export function createDomainGateway(
     }
 
     // Entitlement check — blocks tier-gated endpoints for users below required tier.
-    // Valid API-key holders bypass entitlement checks (they have full access by virtue
-    // of possessing a key). Only bearer-token users go through the tier gate.
-    if (!(keyCheck.valid && request.headers.get('X-WorldMonitor-Key'))) {
+    // Admin API-key holders (WORLDMONITOR_VALID_KEYS) bypass entitlement checks.
+    // User API keys do NOT bypass — the key owner's tier is checked normally.
+    if (!(keyCheck.valid && wmKey && !isUserApiKey)) {
       const entitlementResponse = await checkEntitlement(request, pathname, corsHeaders);
       if (entitlementResponse) return entitlementResponse;
     }

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -719,6 +719,8 @@ export class UnifiedSettings {
       const msg = err instanceof Error ? err.message : 'Failed to create key';
       this.apiKeysError = msg.includes('KEY_LIMIT_REACHED')
         ? 'Maximum of 5 active keys reached. Revoke an existing key first.'
+        : msg.includes('PRO_REQUIRED')
+        ? 'API keys require a Pro subscription.'
         : msg;
       this.renderApiKeysError();
     } finally {

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -12,6 +12,7 @@ import { getAuthState } from '@/services/auth-state';
 import { track } from '@/services/analytics';
 import { isEntitled } from '@/services/entitlements';
 import { getSubscription, openBillingPortal } from '@/services/billing';
+import { createApiKey, listApiKeys, revokeApiKey, type ApiKeyInfo } from '@/services/api-keys';
 
 function showToast(msg: string): void {
   document.querySelector('.toast-notification')?.remove();
@@ -38,7 +39,7 @@ export interface UnifiedSettingsConfig {
   onMapProviderChange?: (provider: MapProvider) => void;
 }
 
-type TabId = 'settings' | 'panels' | 'sources';
+type TabId = 'settings' | 'panels' | 'sources' | 'api-keys';
 
 export class UnifiedSettings {
   private overlay: HTMLElement;
@@ -53,6 +54,10 @@ export class UnifiedSettings {
   private draftPanelSettings: Record<string, PanelConfig> = {};
   private panelsJustSaved = false;
   private savedTimeout: ReturnType<typeof setTimeout> | null = null;
+  private apiKeys: ApiKeyInfo[] = [];
+  private apiKeysLoading = false;
+  private apiKeysError = '';
+  private newlyCreatedKey: string | null = null;
 
   constructor(config: UnifiedSettingsConfig) {
     this.config = config;
@@ -164,6 +169,28 @@ export class UnifiedSettings {
         this.updateSourcesCounter();
         return;
       }
+
+      if (target.closest('.api-keys-create-btn')) {
+        void this.handleCreateApiKey();
+        return;
+      }
+
+      const revokeBtn = target.closest<HTMLElement>('.api-keys-revoke-btn');
+      if (revokeBtn?.dataset.keyId) {
+        void this.handleRevokeApiKey(revokeBtn.dataset.keyId);
+        return;
+      }
+
+      if (target.closest('.api-keys-copy-btn')) {
+        const key = this.newlyCreatedKey;
+        if (key) {
+          void navigator.clipboard.writeText(key).then(() => {
+            const btn = this.overlay.querySelector<HTMLElement>('.api-keys-copy-btn');
+            if (btn) { btn.textContent = 'Copied!'; setTimeout(() => { btn.textContent = 'Copy'; }, 1500); }
+          });
+        }
+        return;
+      }
     });
 
     this.overlay.addEventListener('input', (e) => {
@@ -246,6 +273,7 @@ export class UnifiedSettings {
           <button class="${tabClass('settings')}" data-tab="settings" role="tab" aria-selected="${this.activeTab === 'settings'}" id="us-tab-settings" aria-controls="us-tab-panel-settings">${t('header.tabSettings')}</button>
           <button class="${tabClass('panels')}" data-tab="panels" role="tab" aria-selected="${this.activeTab === 'panels'}" id="us-tab-panels" aria-controls="us-tab-panel-panels">${t('header.tabPanels')}</button>
           <button class="${tabClass('sources')}" data-tab="sources" role="tab" aria-selected="${this.activeTab === 'sources'}" id="us-tab-sources" aria-controls="us-tab-panel-sources">${t('header.tabSources')}</button>
+          ${getAuthState().user ? `<button class="${tabClass('api-keys')}" data-tab="api-keys" role="tab" aria-selected="${this.activeTab === 'api-keys'}" id="us-tab-api-keys" aria-controls="us-tab-panel-api-keys">API Keys</button>` : ''}
         </div>
         <div class="unified-settings-tab-panel${this.activeTab === 'settings' ? ' active' : ''}" data-panel-id="settings" id="us-tab-panel-settings" role="tabpanel" aria-labelledby="us-tab-settings">
           ${prefs.html}
@@ -279,6 +307,24 @@ export class UnifiedSettings {
             <button class="sources-select-none">${t('common.selectNone')}</button>
           </div>
         </div>
+        ${getAuthState().user ? `
+        <div class="unified-settings-tab-panel${this.activeTab === 'api-keys' ? ' active' : ''}" data-panel-id="api-keys" id="us-tab-panel-api-keys" role="tabpanel" aria-labelledby="us-tab-api-keys">
+          <div class="api-keys-section">
+            <div class="api-keys-header">
+              <p class="api-keys-desc">Create API keys to access WorldMonitor data programmatically. Keys are shown once on creation — store them securely.</p>
+            </div>
+            <div class="api-keys-create-form">
+              <input type="text" class="api-keys-name-input" placeholder="Key name (e.g. my-app)" maxlength="64" />
+              <button class="btn btn-primary api-keys-create-btn">Create Key</button>
+            </div>
+            <div class="api-keys-created-banner" id="usApiKeysBanner" style="display:none;"></div>
+            <div class="api-keys-error" id="usApiKeysError" style="display:none;"></div>
+            <div class="api-keys-list" id="usApiKeysList">
+              <div class="api-keys-loading">Loading...</div>
+            </div>
+          </div>
+        </div>
+        ` : ''}
       </div>
     `;
 
@@ -300,6 +346,18 @@ export class UnifiedSettings {
     this.renderRegionPills();
     this.renderSourcesGrid();
     this.updateSourcesCounter();
+
+    // API keys: Enter to submit
+    const apiKeyInput = this.overlay.querySelector<HTMLInputElement>('.api-keys-name-input');
+    if (apiKeyInput) {
+      apiKeyInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') void this.handleCreateApiKey();
+      });
+    }
+
+    if (this.activeTab === 'api-keys') {
+      void this.loadApiKeys();
+    }
   }
 
   private switchTab(tab: TabId): void {
@@ -314,6 +372,10 @@ export class UnifiedSettings {
     this.overlay.querySelectorAll('.unified-settings-tab-panel').forEach(el => {
       el.classList.toggle('active', (el as HTMLElement).dataset.panelId === tab);
     });
+
+    if (tab === 'api-keys') {
+      void this.loadApiKeys();
+    }
   }
 
   private renderUpgradeSection(): string {
@@ -614,5 +676,145 @@ export class UnifiedSettings {
     const enabledTotal = allSources.length - disabled.size;
 
     counter.textContent = t('header.sourcesEnabled', { enabled: String(enabledTotal), total: String(allSources.length) });
+  }
+
+  // ---------------------------------------------------------------------------
+  // API Keys tab
+  // ---------------------------------------------------------------------------
+
+  private async loadApiKeys(): Promise<void> {
+    this.apiKeysLoading = true;
+    this.apiKeysError = '';
+    this.renderApiKeysList();
+
+    try {
+      this.apiKeys = await listApiKeys();
+    } catch (err) {
+      this.apiKeysError = err instanceof Error ? err.message : 'Failed to load keys';
+    } finally {
+      this.apiKeysLoading = false;
+      this.renderApiKeysList();
+    }
+  }
+
+  private async handleCreateApiKey(): Promise<void> {
+    const input = this.overlay.querySelector<HTMLInputElement>('.api-keys-name-input');
+    const btn = this.overlay.querySelector<HTMLButtonElement>('.api-keys-create-btn');
+    const name = input?.value.trim();
+    if (!name || !input || !btn) return;
+
+    btn.disabled = true;
+    btn.textContent = 'Creating...';
+    this.apiKeysError = '';
+    this.newlyCreatedKey = null;
+    this.hideBanner();
+
+    try {
+      const result = await createApiKey(name);
+      this.newlyCreatedKey = result.key;
+      input.value = '';
+      this.showCreatedBanner(result.key);
+      await this.loadApiKeys();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to create key';
+      this.apiKeysError = msg.includes('KEY_LIMIT_REACHED')
+        ? 'Maximum of 5 active keys reached. Revoke an existing key first.'
+        : msg;
+      this.renderApiKeysError();
+    } finally {
+      btn.disabled = false;
+      btn.textContent = 'Create Key';
+    }
+  }
+
+  private async handleRevokeApiKey(keyId: string): Promise<void> {
+    const keyInfo = this.apiKeys.find(k => k.id === keyId);
+    const keyName = keyInfo?.name ?? 'this key';
+    if (!confirm(`Revoke "${keyName}"? This cannot be undone. Any applications using this key will stop working.`)) return;
+
+    try {
+      await revokeApiKey(keyId);
+      await this.loadApiKeys();
+    } catch (err) {
+      this.apiKeysError = err instanceof Error ? err.message : 'Failed to revoke key';
+      this.renderApiKeysError();
+    }
+  }
+
+  private showCreatedBanner(key: string): void {
+    const banner = this.overlay.querySelector<HTMLElement>('#usApiKeysBanner');
+    if (!banner) return;
+
+    banner.style.display = 'block';
+    banner.innerHTML = `
+      <div class="api-keys-banner-title">Key created — copy it now, it won't be shown again</div>
+      <div class="api-keys-banner-key">
+        <code class="api-keys-key-value">${escapeHtml(key)}</code>
+        <button class="btn btn-secondary api-keys-copy-btn">Copy</button>
+      </div>
+    `;
+  }
+
+  private hideBanner(): void {
+    const banner = this.overlay.querySelector<HTMLElement>('#usApiKeysBanner');
+    if (banner) {
+      banner.style.display = 'none';
+      banner.innerHTML = '';
+    }
+  }
+
+  private renderApiKeysError(): void {
+    const el = this.overlay.querySelector<HTMLElement>('#usApiKeysError');
+    if (!el) return;
+    if (this.apiKeysError) {
+      el.style.display = 'block';
+      el.textContent = this.apiKeysError;
+    } else {
+      el.style.display = 'none';
+      el.textContent = '';
+    }
+  }
+
+  private renderApiKeysList(): void {
+    const container = this.overlay.querySelector('#usApiKeysList');
+    if (!container) return;
+
+    if (this.apiKeysLoading && this.apiKeys.length === 0) {
+      container.innerHTML = '<div class="api-keys-loading">Loading...</div>';
+      return;
+    }
+
+    this.renderApiKeysError();
+
+    const active = this.apiKeys.filter(k => !k.revokedAt);
+    const revoked = this.apiKeys.filter(k => k.revokedAt);
+
+    if (active.length === 0 && revoked.length === 0) {
+      container.innerHTML = '<div class="api-keys-empty">No API keys yet. Create one above to get started.</div>';
+      return;
+    }
+
+    const formatDate = (ts: number) => new Date(ts).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+
+    const renderKey = (k: ApiKeyInfo) => {
+      const isRevoked = !!k.revokedAt;
+      return `
+        <div class="api-keys-item${isRevoked ? ' revoked' : ''}">
+          <div class="api-keys-item-main">
+            <span class="api-keys-item-name">${escapeHtml(k.name)}</span>
+            <code class="api-keys-item-prefix">${escapeHtml(k.keyPrefix)}${'*'.repeat(8)}</code>
+          </div>
+          <div class="api-keys-item-meta">
+            <span>Created ${formatDate(k.createdAt)}</span>
+            ${k.lastUsedAt ? `<span>Last used ${formatDate(k.lastUsedAt)}</span>` : ''}
+            ${isRevoked ? `<span class="api-keys-item-revoked-badge">Revoked ${formatDate(k.revokedAt!)}</span>` : ''}
+          </div>
+          ${!isRevoked ? `<button class="btn btn-ghost api-keys-revoke-btn" data-key-id="${escapeHtml(k.id)}">Revoke</button>` : ''}
+        </div>
+      `;
+    };
+
+    container.innerHTML = active.map(renderKey).join('')
+      + (revoked.length > 0 ? `<div class="api-keys-revoked-section"><div class="api-keys-revoked-label">Revoked</div>${revoked.map(renderKey).join('')}</div>` : '');
   }
 }

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -719,8 +719,8 @@ export class UnifiedSettings {
       const msg = err instanceof Error ? err.message : 'Failed to create key';
       this.apiKeysError = msg.includes('KEY_LIMIT_REACHED')
         ? 'Maximum of 5 active keys reached. Revoke an existing key first.'
-        : msg.includes('PRO_REQUIRED')
-        ? 'API keys require a Pro subscription.'
+        : msg.includes('API_ACCESS_REQUIRED')
+        ? 'API keys require an API access subscription (API Starter or higher).'
         : msg;
       this.renderApiKeysError();
     } finally {

--- a/src/services/api-keys.ts
+++ b/src/services/api-keys.ts
@@ -1,0 +1,86 @@
+/**
+ * Frontend service for managing user API keys.
+ *
+ * Uses the shared ConvexClient (WebSocket) to call mutations/queries in
+ * convex/apiKeys.ts. Key generation + hashing happens client-side so the
+ * plaintext key is shown to the user exactly once without a round-trip
+ * that could log it.
+ */
+
+import { getConvexClient, getConvexApi, waitForConvexAuth } from './convex-client';
+
+export interface ApiKeyInfo {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  createdAt: number;
+  lastUsedAt?: number;
+  revokedAt?: number;
+}
+
+export interface CreateApiKeyResult {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  /** Plaintext key — shown to the user ONCE. */
+  key: string;
+}
+
+/** Generate a random key: wm_<40 hex chars> (20 bytes = 160 bits). */
+function generateKey(): string {
+  const raw = new Uint8Array(20);
+  crypto.getRandomValues(raw);
+  const hex = Array.from(raw, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `wm_${hex}`;
+}
+
+/** SHA-256 hex digest of a string. */
+async function sha256Hex(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(buf), (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Create a new API key for the current user.
+ * Returns the full plaintext key (shown once) and metadata.
+ */
+export async function createApiKey(name: string): Promise<CreateApiKeyResult> {
+  const client = await getConvexClient();
+  const api = await getConvexApi();
+  if (!client || !api) throw new Error('Convex unavailable');
+
+  await waitForConvexAuth();
+
+  const plaintext = generateKey();
+  const keyPrefix = plaintext.slice(0, 8);
+  const keyHash = await sha256Hex(plaintext);
+
+  const result = await client.mutation(
+    (api as any).apiKeys.createApiKey,
+    { name: name.trim(), keyPrefix, keyHash },
+  );
+
+  return { id: result.id, name: result.name, keyPrefix: result.keyPrefix, key: plaintext };
+}
+
+/** List all API keys for the current user. */
+export async function listApiKeys(): Promise<ApiKeyInfo[]> {
+  const client = await getConvexClient();
+  const api = await getConvexApi();
+  if (!client || !api) return [];
+
+  await waitForConvexAuth();
+
+  return client.query((api as any).apiKeys.listApiKeys, {});
+}
+
+/** Revoke an API key by its Convex document ID. */
+export async function revokeApiKey(keyId: string): Promise<void> {
+  const client = await getConvexClient();
+  const api = await getConvexApi();
+  if (!client || !api) throw new Error('Convex unavailable');
+
+  await waitForConvexAuth();
+
+  await client.mutation((api as any).apiKeys.revokeApiKey, { keyId });
+}

--- a/src/services/api-keys.ts
+++ b/src/services/api-keys.ts
@@ -85,15 +85,19 @@ export async function revokeApiKey(keyId: string): Promise<void> {
 
   const result = await client.mutation((api as any).apiKeys.revokeApiKey, { keyId });
 
-  // Best-effort cache bust so the gateway stops accepting the revoked key immediately.
+  // Await cache bust so the gateway stops accepting the revoked key immediately.
+  // If this fails, the 60s cache TTL limits the staleness window.
   if (result?.keyHash) {
     const token = await getClerkToken();
     if (token) {
-      fetch('/api/invalidate-user-api-key-cache', {
+      const resp = await fetch('/api/invalidate-user-api-key-cache', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ keyHash: result.keyHash }),
-      }).catch(() => { /* fire-and-forget */ });
+      });
+      if (!resp.ok) {
+        console.warn('[api-keys] cache invalidation failed:', resp.status);
+      }
     }
   }
 }

--- a/src/services/api-keys.ts
+++ b/src/services/api-keys.ts
@@ -8,6 +8,7 @@
  */
 
 import { getConvexClient, getConvexApi, waitForConvexAuth } from './convex-client';
+import { getClerkToken } from './clerk';
 
 export interface ApiKeyInfo {
   id: string;
@@ -82,5 +83,17 @@ export async function revokeApiKey(keyId: string): Promise<void> {
 
   await waitForConvexAuth();
 
-  await client.mutation((api as any).apiKeys.revokeApiKey, { keyId });
+  const result = await client.mutation((api as any).apiKeys.revokeApiKey, { keyId });
+
+  // Best-effort cache bust so the gateway stops accepting the revoked key immediately.
+  if (result?.keyHash) {
+    const token = await getClerkToken();
+    if (token) {
+      fetch('/api/invalidate-user-api-key-cache', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ keyHash: result.keyHash }),
+      }).catch(() => { /* fire-and-forget */ });
+    }
+  }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -22727,6 +22727,167 @@ body.map-width-resizing {
 
 .manage-billing-btn:hover { color: var(--text); }
 
+/* ---- API Keys Settings Tab ---- */
+
+.api-keys-section {
+  padding: 16px 0;
+}
+
+.api-keys-desc {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+.api-keys-create-form {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.api-keys-name-input {
+  flex: 1;
+  padding: 8px 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+}
+
+.api-keys-name-input:focus {
+  border-color: var(--accent);
+}
+
+.api-keys-name-input::placeholder {
+  color: var(--text-dim);
+}
+
+.api-keys-created-banner {
+  padding: 12px;
+  background: color-mix(in srgb, #22c55e 8%, transparent);
+  border: 1px solid color-mix(in srgb, #22c55e 25%, transparent);
+  border-radius: 6px;
+  margin-bottom: 12px;
+}
+
+.api-keys-banner-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #22c55e;
+  margin-bottom: 8px;
+}
+
+.api-keys-banner-key {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.api-keys-key-value {
+  flex: 1;
+  font-family: 'SF Mono', 'Monaco', 'Cascadia Code', monospace;
+  font-size: 12px;
+  color: var(--text);
+  background: var(--surface);
+  padding: 6px 10px;
+  border-radius: 4px;
+  word-break: break-all;
+  user-select: all;
+}
+
+.api-keys-error {
+  font-size: 12px;
+  color: var(--semantic-critical);
+  margin-bottom: 8px;
+}
+
+.api-keys-loading,
+.api-keys-empty {
+  font-size: 12px;
+  color: var(--text-dim);
+  padding: 16px 0;
+  text-align: center;
+}
+
+.api-keys-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-bottom: 6px;
+}
+
+.api-keys-item.revoked {
+  opacity: 0.5;
+}
+
+.api-keys-item-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.api-keys-item-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.api-keys-item-prefix {
+  font-family: 'SF Mono', 'Monaco', 'Cascadia Code', monospace;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.api-keys-item-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 11px;
+  color: var(--text-dim);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.api-keys-item-revoked-badge {
+  color: var(--semantic-critical);
+  font-weight: 600;
+}
+
+.api-keys-revoke-btn {
+  font-size: 12px;
+  padding: 4px 10px;
+  color: var(--semantic-critical);
+  flex-shrink: 0;
+}
+
+.api-keys-revoke-btn:hover {
+  background: color-mix(in srgb, var(--semantic-critical) 10%, transparent);
+}
+
+.api-keys-revoked-section {
+  margin-top: 16px;
+}
+
+.api-keys-revoked-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 6px;
+}
+
 /* ---- Energy Crisis Panel ---- */
 
 .ecp-container {


### PR DESCRIPTION
## Summary
- Full-stack API key management: users can create, list, and revoke API keys from the Settings UI
- Keys are generated client-side, SHA-256 hashed, and only the hash is stored in Convex — plaintext shown once on creation
- Gateway middleware validates user-owned keys via Convex lookup with Redis cache
- Max 5 active keys per user, `wm_` prefix format

### Backend
- New `userApiKeys` Convex table with indexes on `userId` and `keyHash`
- Public mutations: `createApiKey`, `listApiKeys`, `revokeApiKey`
- Internal: `validateKeyByHash`, `touchKeyLastUsed` for gateway validation
- HTTP endpoints: `/api/api-keys` (authenticated CRUD) + `/api/internal-validate-api-key` (service-to-service)
- `premium-check.ts` updated to validate user-owned keys before static key list

### Frontend
- New "API Keys" tab in UnifiedSettings (only visible when signed in)
- Create form, copy-on-creation banner, key list with prefix + timestamps, revoke with confirmation

Closes #3116
Depends on #3115 (login gate removal)

## Test plan
- [ ] Sign in, open Settings, see "API Keys" tab
- [ ] Create a key — banner shows full key with copy button
- [ ] Key appears in the list with `wm_XXXXX********` prefix
- [ ] Copy button works, key is valid `wm_` format
- [ ] Revoke a key — confirmation prompt, key moves to "Revoked" section
- [ ] Try creating 6th key — error message about limit
- [ ] Use a created key in `X-WorldMonitor-Key` header against a premium endpoint — should authenticate
- [ ] Revoked key returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)