### PR TITLE
fix(relay): add _retryCount guard to sendTelegram to prevent unbounded recursion on 429

### DIFF
--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -256,7 +256,7 @@ async function processFlushQuietHeld(event) {
 
 // ── Delivery: Telegram ────────────────────────────────────────────────────────
 
-async function sendTelegram(userId, chatId, text) {
+async function sendTelegram(userId, chatId, text, _retryCount = 0) {
   if (!TELEGRAM_BOT_TOKEN) {
     console.warn('[relay] Telegram: TELEGRAM_BOT_TOKEN not set — skipping');
     return false;
@@ -276,11 +276,15 @@ async function sendTelegram(userId, chatId, text) {
     }
     return false;
   }
+  if (_retryCount >= 1) {
+    console.warn(`[relay] Telegram rate-limited twice — giving up for ${userId}`);
+    return false;
+  }
   if (res.status === 429) {
     const body = await res.json().catch(() => ({}));
     const wait = ((body.parameters?.retry_after ?? 5) + 1) * 1000;
     await new Promise(r => setTimeout(r, wait));
-    return sendTelegram(userId, chatId, text); // single retry
+    return sendTelegram(userId, chatId, text, _retryCount + 1); // single retry
   }
   if (res.status === 401) {
     console.error('[relay] Telegram 401 Unauthorized — TELEGRAM_BOT_TOKEN is invalid or belongs to a different bot; correct the Railway env var to restore Telegram delivery');

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -276,11 +276,11 @@ async function sendTelegram(userId, chatId, text, _retryCount = 0) {
     }
     return false;
   }
-  if (_retryCount >= 1) {
-    console.warn(`[relay] Telegram rate-limited twice — giving up for ${userId}`);
-    return false;
-  }
   if (res.status === 429) {
+    if (_retryCount >= 1) {
+      console.warn(`[relay] Telegram rate-limited twice — giving up for ${userId}`);
+      return false;
+    }
     const body = await res.json().catch(() => ({}));
     const wait = ((body.parameters?.retry_after ?? 5) + 1) * 1000;
     await new Promise(r => setTimeout(r, wait));


### PR DESCRIPTION
## Fix

In `scripts/notification-relay.cjs:259`, `sendTelegram` calls itself on HTTP 429 with no retry counter. The comment says "single retry" but there's no depth/counter parameter to enforce it. If Telegram keeps returning 429 (sustained rate limiting during alert bursts), this recurses indefinitely.

**Changes:**
- Add `_retryCount` parameter (default 0) to `sendTelegram`
- Bail with `console.warn` log if `_retryCount >= 1` before attempting 429 retry
- Pass `_retryCount + 1` on the recursive 429 retry call

This prevents stack overflow under sustained Telegram rate limiting.

## Verification Steps

- [x] `sendTelegram` signature has `_retryCount` parameter defaulting to 0
- [x] Recursive call passes `_retryCount + 1`
- [x] Guard bails (returns false + logs) when `_retryCount >= 1`
- [x] Non-429 paths are unaffected (no behavioral change for 200, 400, 403, 401)

Fixes #3060