### PR TITLE
fix(portwatch): unblock port-activity seeder (global EP4 refs, conc 12, progress logs, SIGTERM)

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -33,7 +33,8 @@ const PAGE_SIZE = 2000;
 const FETCH_TIMEOUT = 45_000;
 const HISTORY_DAYS = 90;
 const MAX_PORTS_PER_COUNTRY = 50;
-const CONCURRENCY = 4;
+const CONCURRENCY = 12;
+const BATCH_LOG_EVERY = 5;
 
 function epochToTimestamp(epochMs) {
   const d = new Date(epochMs);
@@ -61,14 +62,19 @@ async function fetchWithTimeout(url) {
   return body;
 }
 
-async function fetchPortRef(iso3) {
+// Fetch ALL ports globally in one paginated pass, grouped by ISO3.
+// Replaces 240× per-country queries with ~5 pages of 2000. Returns
+// Map<iso3, Map<portId, { lat, lon }>>.
+async function fetchAllPortRefs() {
+  const byIso3 = new Map();
   let offset = 0;
-  const refMap = new Map();
   let body;
+  let page = 0;
   do {
+    page++;
     const params = new URLSearchParams({
-      where: `ISO3='${iso3}'`,
-      outFields: 'portid,lat,lon',
+      where: '1=1',
+      outFields: 'portid,ISO3,lat,lon',
       returnGeometry: 'false',
       orderByFields: 'portid ASC',
       resultRecordCount: String(PAGE_SIZE),
@@ -77,15 +83,20 @@ async function fetchPortRef(iso3) {
       f: 'json',
     });
     body = await fetchWithTimeout(`${EP4_BASE}?${params}`);
-    for (const f of body.features ?? []) {
+    const features = body.features ?? [];
+    for (const f of features) {
       const a = f.attributes;
-      if (a?.portid != null) {
-        refMap.set(String(a.portid), { lat: Number(a.lat ?? 0), lon: Number(a.lon ?? 0) });
-      }
+      if (a?.portid == null || !a?.ISO3) continue;
+      const iso3 = String(a.ISO3);
+      const portId = String(a.portid);
+      let ports = byIso3.get(iso3);
+      if (!ports) { ports = new Map(); byIso3.set(iso3, ports); }
+      ports.set(portId, { lat: Number(a.lat ?? 0), lon: Number(a.lon ?? 0) });
     }
+    console.log(`  [port-activity]   ref page ${page}: +${features.length} ports (${byIso3.size} countries so far)`);
     offset += PAGE_SIZE;
   } while (body.exceededTransferLimit);
-  return refMap;
+  return byIso3;
 }
 
 async function fetchActivityRows(iso3, since) {
@@ -186,11 +197,8 @@ async function redisPipeline(commands) {
   return resp.json();
 }
 
-async function processCountry(iso3, iso2, since) {
-  const [refMap, rawRows] = await Promise.all([
-    fetchPortRef(iso3),
-    fetchActivityRows(iso3, since),
-  ]);
+async function processCountry(iso3, iso2, since, refMap) {
+  const rawRows = await fetchActivityRows(iso3, since);
   if (!rawRows.length) return null;
   const ports = computeCountryPorts(rawRows, refMap);
   if (!ports.length) return null;
@@ -201,18 +209,30 @@ async function processCountry(iso3, iso2, since) {
 // Returns { countries: string[], countryData: Map<iso2, payload>, fetchedAt: string }.
 export async function fetchAll() {
   const { iso3ToIso2 } = createCountryResolvers();
-  const ISO3_LIST = [...iso3ToIso2.keys()];
   const since = Date.now() - HISTORY_DAYS * 86400000;
+
+  console.log('  [port-activity] Fetching global port reference (EP4)...');
+  const t0 = Date.now();
+  const refsByIso3 = await fetchAllPortRefs();
+  console.log(`  [port-activity] Refs loaded: ${refsByIso3.size} countries with ports (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
+
+  // Only fetch activity for ISO3s that have at least one port AND exist in our iso3→iso2 map.
+  const eligibleIso3 = [...refsByIso3.keys()].filter(iso3 => iso3ToIso2.has(iso3));
+  const skipped = refsByIso3.size - eligibleIso3.length;
+  console.log(`  [port-activity] Activity queue: ${eligibleIso3.length} countries (skipping ${skipped} unmapped iso3, concurrency ${CONCURRENCY})`);
 
   const countryData = new Map();
   const errors = [];
+  const batches = Math.ceil(eligibleIso3.length / CONCURRENCY);
+  const activityStart = Date.now();
 
-  for (let i = 0; i < ISO3_LIST.length; i += CONCURRENCY) {
-    const batch = ISO3_LIST.slice(i, i + CONCURRENCY);
+  for (let i = 0; i < eligibleIso3.length; i += CONCURRENCY) {
+    const batch = eligibleIso3.slice(i, i + CONCURRENCY);
+    const batchIdx = Math.floor(i / CONCURRENCY) + 1;
     const settled = await Promise.allSettled(
       batch.map(iso3 => {
         const iso2 = iso3ToIso2.get(iso3);
-        return processCountry(iso3, iso2, since);
+        return processCountry(iso3, iso2, since, refsByIso3.get(iso3));
       })
     );
     for (let j = 0; j < batch.length; j++) {
@@ -225,6 +245,10 @@ export async function fetchAll() {
       if (!outcome.value) continue;
       const { iso2, ports, fetchedAt } = outcome.value;
       countryData.set(iso2, { iso2, ports, fetchedAt });
+    }
+    if (batchIdx === 1 || batchIdx % BATCH_LOG_EVERY === 0 || batchIdx === batches) {
+      const elapsed = ((Date.now() - activityStart) / 1000).toFixed(1);
+      console.log(`  [port-activity]   batch ${batchIdx}/${batches}: ${countryData.size} countries seeded, ${errors.length} errors (${elapsed}s)`);
     }
   }
 
@@ -258,6 +282,23 @@ async function main() {
   // Hoist so the catch block can extend TTLs even when the error occurs before these are resolved.
   let prevCountryKeys = [];
   let prevCount = 0;
+
+  // Bundle-runner SIGKILLs via SIGTERM → SIGKILL on timeout. Release the lock
+  // and extend existing TTLs synchronously(ish) so the next cron tick isn't
+  // blocked for up to 30 min and the Redis snapshot doesn't evaporate.
+  let sigHandled = false;
+  const onSigterm = async () => {
+    if (sigHandled) return;
+    sigHandled = true;
+    console.error('  [port-activity] SIGTERM received — releasing lock + extending TTLs');
+    try {
+      await extendExistingTtl([CANONICAL_KEY, META_KEY, ...prevCountryKeys], TTL);
+    } catch {}
+    try { await releaseLock(LOCK_DOMAIN, runId); } catch {}
+    process.exit(1);
+  };
+  process.on('SIGTERM', onSigterm);
+  process.on('SIGINT', onSigterm);
 
   try {
     // Read previous snapshot first — needed for both degradation guard and error TTL extension.

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -63,8 +63,13 @@ async function fetchWithTimeout(url) {
 }
 
 // Fetch ALL ports globally in one paginated pass, grouped by ISO3.
-// Replaces 240× per-country queries with ~5 pages of 2000. Returns
+// Replaces 240× per-country queries with a handful of pages. Returns
 // Map<iso3, Map<portId, { lat, lon }>>.
+//
+// IMPORTANT: ArcGIS FeatureServer can cap responses below the requested
+// resultRecordCount (PortWatch_ports_database caps at 1000 despite
+// PAGE_SIZE=2000). Advancing by PAGE_SIZE silently skips the rows between
+// the server cap and PAGE_SIZE. Advance by the actual features.length.
 async function fetchAllPortRefs() {
   const byIso3 = new Map();
   let offset = 0;
@@ -94,7 +99,8 @@ async function fetchAllPortRefs() {
       ports.set(portId, { lat: Number(a.lat ?? 0), lon: Number(a.lon ?? 0) });
     }
     console.log(`  [port-activity]   ref page ${page}: +${features.length} ports (${byIso3.size} countries so far)`);
-    offset += PAGE_SIZE;
+    if (features.length === 0) break; // defensive: ETL=true + 0 features would infinite-loop
+    offset += features.length;
   } while (body.exceededTransferLimit);
   return byIso3;
 }
@@ -114,8 +120,12 @@ async function fetchActivityRows(iso3, since) {
       f: 'json',
     });
     body = await fetchWithTimeout(`${EP3_BASE}?${params}`);
-    if (body.features?.length) allRows.push(...body.features);
-    offset += PAGE_SIZE;
+    const features = body.features ?? [];
+    if (features.length) allRows.push(...features);
+    // Advance by actual returned count, not PAGE_SIZE. ArcGIS can cap below
+    // the requested size (see fetchAllPortRefs for the same issue on EP4).
+    if (features.length === 0) break;
+    offset += features.length;
   } while (body.exceededTransferLimit);
   return allRows;
 }

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -44,9 +44,22 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /body\.exceededTransferLimit/);
   });
 
-  it('Endpoint 4 query uses per-country ISO3 filter', () => {
+  it('Endpoint 4 query fetches all ports globally with where=1=1', () => {
     assert.match(src, /PortWatch_ports_database/);
-    assert.match(src, /ISO3=/);
+    assert.match(src, /where:\s*'1=1'/);
+    assert.match(src, /outFields:\s*'portid,ISO3,lat,lon'/);
+  });
+
+  it('Endpoint 3 activity query still filters per-country ISO3', () => {
+    assert.match(src, /where:\s*`ISO3='\$\{iso3\}'\s+AND\s+date\s*>/);
+  });
+
+  it('concurrency is bumped to 12', () => {
+    assert.match(src, /CONCURRENCY\s*=\s*12/);
+  });
+
+  it('registers SIGTERM handler for graceful shutdown', () => {
+    assert.match(src, /process\.on\('SIGTERM'/);
   });
 
   it('anomalySignal computation is present', () => {

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -62,6 +62,16 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /process\.on\('SIGTERM'/);
   });
 
+  it('pagination advances by actual features.length, not PAGE_SIZE', () => {
+    // ArcGIS PortWatch_ports_database caps responses at 1000 rows even when
+    // resultRecordCount=2000. Advancing by PAGE_SIZE skips rows 1000-1999.
+    // Guard: no 'offset += PAGE_SIZE' anywhere in the file, both loops use
+    // 'offset += features.length'.
+    assert.doesNotMatch(src, /offset\s*\+=\s*PAGE_SIZE/);
+    const matches = src.match(/offset\s*\+=\s*features\.length/g) ?? [];
+    assert.ok(matches.length >= 2, `expected both paginators to advance by features.length, found ${matches.length}`);
+  });
+
   it('anomalySignal computation is present', () => {
     assert.match(src, /anomalySignal/);
   });


### PR DESCRIPTION
## Summary

`seed-portwatch-port-activity` has been SIGKILL'd at the Railway 10-min container ceiling on every run since 2026-04-14 (`recordCount=174`, `seedAgeMin=3096 = 51.6h`), leaving `portwatchPortActivity` STALE_SEED and the 30-min lock leaking between cron ticks.

**Root cause:** ~240 ISO3s × 2 per-country ArcGIS queries at `CONCURRENCY=4` with no per-batch logging — slow enough to miss the 420s `timeoutMs` and silent enough that the timeout line was the only log on failure (see earlier run `logs.1776183642501.log` line 73: `failed after 600.1s: timeout`).

**Four fixes applied:**

- `fetchAllPortRefs()` — one paginated EP4 query (`where=1=1`, `outFields=portid,ISO3,lat,lon`) grouped by ISO3 locally. Collapses ~240 ref calls into ~5 pages.
- `CONCURRENCY 4 → 12` and only queue activity fetches for ISO3s that (a) have a port in `refsByIso3` and (b) are in the `iso3→iso2` map. Skips ~66 unmapped/empty iso3s.
- Per-page ref logs + per-batch activity logs every 5 batches (`BATCH_LOG_EVERY=5`). The next failure will show exactly where it stalls instead of a silent 10-min hang.
- `SIGTERM`/`SIGINT` handler releases the 30-min lock and extends prev-snapshot TTLs before exiting with code 1, so the next cron tick isn't blocked by a lingering lock and Redis data doesn't evaporate when the bundle-runner kills the child.

Tests updated to match (EP4 now uses `where=1=1`, concurrency 12 assertion, SIGTERM handler assertion).

## Test plan

- [x] `npm run typecheck` — PASS (16.4s)
- [x] `npm run typecheck:api` — PASS (11.2s)
- [x] CJS syntax check on `scripts/*.cjs` — PASS
- [x] `npm run lint` — PASS (0 errors, warnings only)
- [x] `npm run test:data` — PASS (5415/5415)
- [x] esbuild bundle check on `api/*.js` — PASS
- [x] `tests/edge-functions.test.mjs` — PASS (168/168)
- [x] `npm run lint:md` — PASS (0 errors)
- [x] `npm run version:check` — PASS
- [ ] Watch next Railway `seed-bundle-portwatch` run: confirm ref-page logs appear, batch progress logs every 5, bundle finishes under 540s, `portwatchPortActivity` seedAgeMin drops back under 720
- [ ] Confirm lock is released on timeout (no "another seed run in progress" SKIPPED on subsequent tick)