### PR TITLE
fix(a11y): resolve WCAG AA contrast, label, and touch-target failures (Phase 23, #3112)

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -380,7 +380,7 @@ export class PanelLayoutManager implements AppModule {
             <span>${t('header.live')}</span>
           </div>
           <div class="region-selector">
-            <select id="regionSelect" class="region-select">
+            <select id="regionSelect" class="region-select" aria-label="${t('header.selectRegion')}">
               <option value="global">${t('components.deckgl.views.global')}</option>
               <option value="america">${t('components.deckgl.views.americas')}</option>
               <option value="mena">${t('components.deckgl.views.mena')}</option>

--- a/src/components/CascadePanel.ts
+++ b/src/components/CascadePanel.ts
@@ -115,7 +115,7 @@ export class CascadePanel extends Panel {
     return `
       <div class="cascade-selector">
         <div class="panel-tabs" role="radiogroup" aria-label="Infrastructure type filter">${filterButtons}</div>
-        <select class="cascade-select" ${nodes.length === 0 ? 'disabled' : ''}>
+        <select class="cascade-select" aria-label="${t('components.cascade.selectPrompt', { type: selectedType })}" ${nodes.length === 0 ? 'disabled' : ''}>
           <option value="">${t('components.cascade.selectPrompt', { type: selectedType })}</option>
           ${nodeOptions}
         </select>

--- a/src/components/PizzIntIndicator.ts
+++ b/src/components/PizzIntIndicator.ts
@@ -79,7 +79,9 @@ export class PizzIntIndicator {
     const color = DEFCON_COLORS[this.status.defconLevel] || '#888';
     defconEl.textContent = t('components.pizzint.defcon', { level: String(this.status.defconLevel) });
     defconEl.style.background = color;
-    defconEl.style.color = this.status.defconLevel <= 3 ? '#000' : '#fff';
+    // Use black text on all DEFCON colors — verified WCAG AA contrast (≥4.5:1) for all levels (#3112):
+    // L1 #ff0040: 5.3:1, L2 #ff4400: 6.1:1, L3 #ffaa00: 11.1:1, L4 #00aaff: 8.3:1, L5 #2d8a6e: 5.0:1
+    defconEl.style.color = '#000';
 
     scoreEl.textContent = `${this.status.aggregateActivity}%`;
     labelEl.textContent = this.getDefconLabel(this.status.defconLevel);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -781,7 +781,7 @@ canvas,
 .github-stars {
   font-size: 11px;
   margin-left: 4px;
-  opacity: 0.7;
+  /* Removed opacity: 0.7 — dim inherited text color failed WCAG AA contrast (#3112) */
 }
 
 /* Medium-width desktop: keep header utility actions reachable when OS scaling
@@ -1976,7 +1976,8 @@ body.panel-resize-active iframe {
 }
 
 .live-channel-btn.offline {
-  opacity: 0.5;
+  /* Removed opacity: 0.5 — dropped contrast below WCAG AA threshold (#3112).
+     Dashed border already signals offline state without opacity. */
   border-style: dashed;
 }
 
@@ -4397,6 +4398,8 @@ body.playback-mode .status-dot {
 
 .time-btn {
   padding: 3px 6px;
+  min-height: 44px;
+  min-width: 44px;
   background: transparent;
   border: 1px solid var(--border);
   color: var(--text-dim);
@@ -4482,6 +4485,7 @@ body.playback-mode .status-dot {
 }
 
 .layer-help-btn {
+  position: relative;
   width: 20px;
   height: 20px;
   padding: 0;
@@ -4497,6 +4501,13 @@ body.playback-mode .status-dot {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+/* Extend touch target to 48×48 px without changing visual size (#3112) */
+.layer-help-btn::before {
+  content: '';
+  position: absolute;
+  inset: -14px;
 }
 
 .layer-help-btn:hover {


### PR DESCRIPTION
Fixes #3112

## Problem

Phase 23 accessibility audit identified six WCAG AA failures across three categories.

## Solution

### Contrast failures (A11Y-01)

| Element | Before | After |
|---------|--------|-------|
| `.github-stars` | `opacity: 0.7` on `--text-dim` → ~2.9:1 on header surface | Removed opacity; inherits `--text-dim` → ≥5.1:1 |
| `.live-channel-btn.offline` | `opacity: 0.5` → contrast drops below threshold | Replaced with `border-style: dashed`; dashed border is sufficient visual cue |
| `.pizzint-defcon` DEFCON 4 (`#00aaff`) | `#fff` text → 2.5:1 ❌ | `#000` text → 8.3:1 ✅ |
| `.pizzint-defcon` DEFCON 5 (`#2d8a6e`) | `#fff` text → 4.2:1 ❌ | `#000` text → 5.0:1 ✅ |

All other DEFCON levels already passed with black text (L1: 5.3:1, L2: 6.1:1, L3: 11.1:1).

### Missing labels (A11Y-02)

- `#regionSelect`: added `aria-label` using the existing `header.selectRegion` i18n key
- `.cascade-select`: added `aria-label` using the existing `components.cascade.selectPrompt` i18n key (already populated with the selected infrastructure type)

### Touch targets (A11Y-03)

- `.time-btn`: added `min-height: 44px; min-width: 44px` to meet WCAG 2.5.5 minimum
- `.layer-help-btn`: extended touch target to 48×48 px via `::before { inset: -14px }` — visual size (20×20 circle) is unchanged

## Testing

- Verified contrast ratios manually against WCAG 2.1 AA thresholds (4.5:1 normal, 3:1 large text)
- All colour combinations confirmed with relative luminance formula
- No functional behaviour changed