### PR TITLE
fix(sentry): guard ConvexClient on Firefox 149/Linux + filter Quark noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -248,6 +248,7 @@ Sentry.init({
     /ConvexError: CONFLICT/, // Expected OCC rejection on concurrent preference saves
     /\[CONVEX [AQM]\(.+?\)\] Connection lost while action was in flight/, // Convex SDK transient WS disconnect
     /Response did not contain `success` or `data`/, // DuckDuckGo browser internal tracker/content-block response — never emitted by our code
+    /Cannot set properties of undefined \(setting 'bodyTouched'\)/, // Quark browser (Alibaba mobile) touch-tracking script injection (WORLDMONITOR-N1)
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';

--- a/src/services/convex-client.ts
+++ b/src/services/convex-client.ts
@@ -40,7 +40,12 @@ export async function getConvexClient(): Promise<ConvexClient | null> {
     // "t is not a constructor" (WORLDMONITOR-N0/MX). Degrade to the null-client
     // path instead of letting init error-bubble into Sentry — subscription features
     // silently no-op, which matches the behavior when VITE_CONVEX_URL is unset.
+    // Also reset authReadyPromise: it was just created at the top of this function
+    // and would otherwise leave waitForConvexAuth() blocking for the full timeout
+    // for any future caller that doesn't pre-check the client is non-null.
     console.warn('[convex-client] ConvexClient constructor rejected:', (err as Error).message);
+    authReadyPromise = null;
+    authReadyResolve = null;
     return null;
   }
   client.setAuth(

--- a/src/services/convex-client.ts
+++ b/src/services/convex-client.ts
@@ -33,7 +33,16 @@ export async function getConvexClient(): Promise<ConvexClient | null> {
   authReadyPromise = new Promise<void>((resolve) => { authReadyResolve = resolve; });
 
   const { ConvexClient: CC } = await import('convex/browser');
-  client = new CC(convexUrl);
+  try {
+    client = new CC(convexUrl);
+  } catch (err) {
+    // Firefox 149/Linux has been observed to reject the Convex constructor with
+    // "t is not a constructor" (WORLDMONITOR-N0/MX). Degrade to the null-client
+    // path instead of letting init error-bubble into Sentry — subscription features
+    // silently no-op, which matches the behavior when VITE_CONVEX_URL is unset.
+    console.warn('[convex-client] ConvexClient constructor rejected:', (err as Error).message);
+    return null;
+  }
   client.setAuth(
     async ({ forceRefreshToken }: { forceRefreshToken?: boolean } = {}) => {
       if (forceRefreshToken) {


### PR DESCRIPTION
## Summary
- **WORLDMONITOR-N0 + MX (Firefox 149/Linux, 5 events / 2 users).** `new CC(convexUrl)` inside `getConvexClient()` throws `TypeError: t is not a constructor`. Breadcrumbs confirmed the source (console logs: `[entitlements] Failed to initialize Convex subscription` + `[billing] Failed to initialize subscription watch`). Wrapped the constructor in try/catch so `getConvexClient()` returns `null` on failure; both callers (`src/services/entitlements.ts:40`, `src/services/billing.ts:38`) already have the null path wired for the no-`VITE_CONVEX_URL` case. Net effect: subscription features silently no-op instead of bubbling into Sentry via the explicit `Sentry.captureException(err, ...)` at `billing.ts:71`.
- **WORLDMONITOR-N1 (Quark 7.4.6 / Android 13, 3 events / 1 user).** Alibaba's Quark mobile browser injects touch-tracking into the page (`setting 'bodyTouched'` with obfuscated `_0x520c7b` stack frame). Property name `bodyTouched` has 0 matches in repo — safe to add to `ignoreErrors`.

## Context
- WORLDMONITOR-MY (Chrome extension `frame_ant` wrapping `window.fetch` → `Failed to fetch`) intentionally left unresolved: the policy codified in `tests/sentry-beforesend.test.mjs` forbids suppression when a first-party frame is present.

## Test plan
- [x] `npm run typecheck` / `typecheck:api`
- [x] `npm run lint` (0 errors)
- [x] `npm run test:data` (5417/5417)
- [x] `node --test tests/edge-functions.test.mjs` (168/168) — includes sentry-beforesend policy tests
- [x] Edge bundle check (`esbuild` over `api/*.js`)
- [x] `npm run lint:md` + `npm run version:check`
- [ ] Post-merge: verify WORLDMONITOR-N0 + N1 stay resolved against release > 2.6.7 (auto-reopen if recurring)