### PR TITLE
chore(sentry): filter Firefox Mobile HTML5 media codec-rejection noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -248,6 +248,7 @@ Sentry.init({
     /ConvexError: CONFLICT/, // Expected OCC rejection on concurrent preference saves
     /\[CONVEX [AQM]\(.+?\)\] Connection lost while action was in flight/, // Convex SDK transient WS disconnect
     /Response did not contain `success` or `data`/, // DuckDuckGo browser internal tracker/content-block response — never emitted by our code
+    /The media resource indicated by the src attribute or assigned media provider object was not suitable/, // Browser-native HTML5 video/audio codec rejection (Firefox Mobile unsupported formats) — WORLDMONITOR-N2
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary
- Adds one `ignoreErrors` pattern in `src/main.ts` for Firefox Mobile 149 / Android 16 emitting the verbatim HTML5-spec error `"The media resource indicated by the src attribute or assigned media provider object was not suitable."` (WORLDMONITOR-N2).
- Zero matches for the string in our codebase — it's emitted by the browser's own `<video>`/`<audio>` element when the src format isn't decodable, so it cannot originate from our bundle.
- Consistent with existing filters for browser-native media errors (`/The fetching process for the media resource was aborted/`, `/NotAllowedError/`, `/The play\(\) request was interrupted/`).

## Test plan
- [x] `npm run typecheck` / `typecheck:api`
- [x] `npm run lint` (0 errors)
- [x] `npm run test:data` — pass
- [x] `node --test tests/edge-functions.test.mjs` — pass (includes `sentry-beforesend.test.mjs` policy tests)
- [x] Edge bundle check, `lint:md`, `version:check`