### PR TITLE
fix(relay): COPY missing _seed-envelope-source + _seed-contract — chokepointFlows stale 32h

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -22,6 +22,15 @@ RUN npm ci --prefix scripts --omit=dev
 COPY scripts/ais-relay.cjs ./scripts/ais-relay.cjs
 COPY scripts/_proxy-utils.cjs ./scripts/_proxy-utils.cjs
 COPY scripts/_seed-utils.mjs ./scripts/_seed-utils.mjs
+# _seed-envelope-source.mjs and _seed-contract.mjs are transitively imported
+# by _seed-utils.mjs (lines 9-10) and by seed-chokepoint-flows.mjs /
+# seed-ember-electricity.mjs directly. Missing them here = silent
+# ERR_MODULE_NOT_FOUND on every execFile invocation, which looks like a hung
+# Railway cron (the initial-seed path throws, the 6h setInterval keeps firing
+# but each child dies on import). tests/dockerfile-relay-imports.test.mjs
+# guards this COPY list against future regressions.
+COPY scripts/_seed-envelope-source.mjs ./scripts/_seed-envelope-source.mjs
+COPY scripts/_seed-contract.mjs ./scripts/_seed-contract.mjs
 COPY scripts/_country-resolver.mjs ./scripts/_country-resolver.mjs
 COPY scripts/seed-climate-news.mjs ./scripts/seed-climate-news.mjs
 COPY scripts/seed-chokepoint-flows.mjs ./scripts/seed-chokepoint-flows.mjs

--- a/tests/dockerfile-relay-imports.test.mjs
+++ b/tests/dockerfile-relay-imports.test.mjs
@@ -31,8 +31,16 @@ function collectRelativeImports(filePath) {
   const src = readFileSync(filePath, 'utf-8');
   const imports = new Set();
   // ESM: import ... from './x.mjs'   |  export ... from './x.mjs'
-  const re = /(?:^|\s|;)(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?['"](\.[^'"]+)['"]/g;
-  for (const m of src.matchAll(re)) imports.add(m[1]);
+  const esmRe = /(?:^|\s|;)(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?['"](\.[^'"]+)['"]/g;
+  for (const m of src.matchAll(esmRe)) imports.add(m[1]);
+  // CJS direct: require('./x.cjs')
+  const cjsRe = /(?:^|[^a-zA-Z0-9_$])require\s*\(\s*['"](\.[^'"]+)['"]/g;
+  for (const m of src.matchAll(cjsRe)) imports.add(m[1]);
+  // CJS chained: createRequire(import.meta.url)('./x.cjs')
+  //  — the final `('./x')` argument is applied to createRequire's return,
+  //    not to a `require(` token, so the cjsRe above misses it.
+  const createRequireRe = /createRequire\s*\([^)]*\)\s*\(\s*['"](\.[^'"]+)['"]/g;
+  for (const m of src.matchAll(createRequireRe)) imports.add(m[1]);
   return imports;
 }
 
@@ -52,6 +60,23 @@ describe('Dockerfile.relay — transitive-import closure', () => {
 
   it('COPY list is non-empty (sanity)', () => {
     assert.ok(copied.size > 0, 'Dockerfile.relay has no COPY scripts/*.mjs|cjs lines');
+  });
+
+  it('scanner catches both ESM imports and CJS require/createRequire', () => {
+    // Regression guard for the scanner itself: _seed-utils.mjs has both
+    // `import { ... } from './_seed-envelope-source.mjs'` (ESM) AND
+    // `createRequire(import.meta.url)('./_proxy-utils.cjs')` (CJS). If
+    // collectRelativeImports ever stops picking up either, a future
+    // createRequire/require pointing at a new uncopied helper would slip
+    // past the BFS test below without anyone noticing.
+    const seedUtils = resolve(root, 'scripts/_seed-utils.mjs');
+    const imports = collectRelativeImports(seedUtils);
+    assert.ok(imports.has('./_seed-envelope-source.mjs'), 'ESM import not detected');
+    assert.ok(imports.has('./_proxy-utils.cjs'), 'CJS createRequire not detected');
+
+    const relayCjs = resolve(root, 'scripts/ais-relay.cjs');
+    const relayImports = collectRelativeImports(relayCjs);
+    assert.ok(relayImports.has('./_proxy-utils.cjs'), 'CJS require not detected');
   });
 
   // BFS the import graph from each COPY'd entrypoint. Every .mjs/.cjs reached

--- a/tests/dockerfile-relay-imports.test.mjs
+++ b/tests/dockerfile-relay-imports.test.mjs
@@ -1,0 +1,86 @@
+// Static guard: every scripts/*.mjs COPY'd into the relay container must
+// have ALL its relative-path imports ALSO COPY'd. A missing transitive
+// import looks like a silent Railway cron hang — the child process dies
+// on ERR_MODULE_NOT_FOUND with output only on the parent's stderr, which
+// is easy to miss when the relay handles many other messages.
+//
+// Historical failures this test would have caught:
+// - 2026-04-14 to 2026-04-16: _seed-envelope-source.mjs added to
+//   _seed-utils.mjs but not COPY'd, breaking chokepoint-flows for 32h
+//   (fixed alongside PR #3128 port-activity work).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+function readCopyList(dockerfilePath) {
+  const src = readFileSync(dockerfilePath, 'utf-8');
+  const copied = new Set();
+  // Matches: COPY scripts/foo.mjs ./scripts/foo.mjs
+  const re = /^COPY\s+(scripts\/[^\s]+\.(mjs|cjs))\s+/gm;
+  for (const m of src.matchAll(re)) copied.add(m[1]);
+  return copied;
+}
+
+function collectRelativeImports(filePath) {
+  const src = readFileSync(filePath, 'utf-8');
+  const imports = new Set();
+  // ESM: import ... from './x.mjs'   |  export ... from './x.mjs'
+  const re = /(?:^|\s|;)(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?['"](\.[^'"]+)['"]/g;
+  for (const m of src.matchAll(re)) imports.add(m[1]);
+  return imports;
+}
+
+function resolveImport(fromFile, relImport) {
+  const abs = resolve(dirname(fromFile), relImport);
+  if (existsSync(abs)) return abs;
+  for (const ext of ['.mjs', '.cjs', '.js']) {
+    if (existsSync(abs + ext)) return abs + ext;
+  }
+  return null;
+}
+
+describe('Dockerfile.relay — transitive-import closure', () => {
+  const dockerfile = resolve(root, 'Dockerfile.relay');
+  const copied = readCopyList(dockerfile);
+  const entrypoints = [...copied].filter(p => p.endsWith('.mjs') || p.endsWith('.cjs'));
+
+  it('COPY list is non-empty (sanity)', () => {
+    assert.ok(copied.size > 0, 'Dockerfile.relay has no COPY scripts/*.mjs|cjs lines');
+  });
+
+  // BFS the import graph from each COPY'd entrypoint. Every .mjs/.cjs reached
+  // via a relative import must itself be COPY'd.
+  it('every transitively-imported scripts/*.mjs|cjs is also COPY\'d', () => {
+    const missing = [];
+    const visited = new Set();
+    const queue = entrypoints.map(p => resolve(root, p));
+    while (queue.length) {
+      const file = queue.shift();
+      if (visited.has(file)) continue;
+      visited.add(file);
+      if (!existsSync(file)) continue;
+      for (const rel of collectRelativeImports(file)) {
+        const resolved = resolveImport(file, rel);
+        if (!resolved) continue;
+        const relToRoot = resolved.startsWith(root + '/') ? resolved.slice(root.length + 1) : null;
+        if (!relToRoot || !relToRoot.startsWith('scripts/')) continue;
+        if (!copied.has(relToRoot)) {
+          missing.push(`${relToRoot} (imported by ${file.slice(root.length + 1)})`);
+        }
+        queue.push(resolved);
+      }
+    }
+    assert.deepEqual(
+      missing,
+      [],
+      `Dockerfile.relay is missing COPY lines for:\n  ${missing.join('\n  ')}\n` +
+      `Add a 'COPY <path> ./<path>' line per missing file.`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

**Diagnosis confirmed by Railway logs.** `chokepointFlows` was STALE_SEED for 32h (1911min, maxStaleMin=720). The live ais-relay container was crashing the seeder at import with `ERR_MODULE_NOT_FOUND` on every 6h cycle.

Direct log evidence from the relay service:

```
2026-04-16T04:02:04Z [err] [ChokepointFlows] Error [ERR_MODULE_NOT_FOUND]:
  Cannot find module '/app/scripts/_seed-envelope-source.mjs'
  imported from /app/scripts/seed-chokepoint-flows.mjs

2026-04-16T04:02:05Z [err] [ChokepointFlows] Seed error:
  Command failed: /usr/local/bin/node /app/scripts/seed-chokepoint-flows.mjs

2026-04-16T04:02:06Z [err] [ClimateNewsSeed] Error [ERR_MODULE_NOT_FOUND]:
  Cannot find module '/app/scripts/_seed-envelope-source.mjs'
  imported from /app/scripts/_seed-utils.mjs

2026-04-16T04:22:02Z [err] [ChokepointFlows] Error [ERR_MODULE_NOT_FOUND]:
  ... (20-min retry loop, every restart)
```

`seed-climate-news.mjs` was hitting the same error because `_seed-utils.mjs:9` imports the missing file, which blows up every execFile'd seeder the relay spawns.

## Timeline

- **2026-04-14 22:11 UTC** — PR #3095 added `_seed-envelope-source.mjs` to the repo
- **2026-04-15 09:16 UTC** — PR #3097 added `import { unwrapEnvelope } from './_seed-envelope-source.mjs'` to `seed-chokepoint-flows.mjs` / `seed-climate-news.mjs` and to `_seed-utils.mjs:9`
- **Dockerfile.relay was not updated** in either PR — COPY list still missing the new file
- **2026-04-14 09:31 UTC** (pre-merge): log shows `[ChokepointFlows] Completed in 3.2s` — works
- **2026-04-16 04:02 UTC** (post-merge): log shows `ERR_MODULE_NOT_FOUND` — broken
- **2026-04-16 13:32 UTC**: unrelated relay restart happened to run on a rebuild that included the file (Railway builder flip or cache-invalidation); initial-seed path cleared the staleness

## Fix

1. **`Dockerfile.relay`**: add COPY lines for
   - `scripts/_seed-envelope-source.mjs` — imported by `_seed-utils.mjs:9` + by `seed-chokepoint-flows.mjs` + `seed-ember-electricity.mjs` directly
   - `scripts/_seed-contract.mjs` — imported by `_seed-utils.mjs:10`
2. **`tests/dockerfile-relay-imports.test.mjs`** — static guard that BFS's the transitive-import graph from every `COPY scripts/*.mjs|cjs` entrypoint and fails if any reached file isn't COPY'd. Handles both ESM (`import`) and CJS (`require`, `createRequire(...)(...)`) syntax. Would have caught the original regression at PR #3097 time.

Matches memory `feedback_dockerfile_relay_explicit_copy.md` — now enforced by CI.

## Test plan

- [x] `node --test tests/dockerfile-relay-imports.test.mjs` — PASS (3/3)
- [x] Log evidence above confirms the exact symptom and module path
- [x] Local repro: `node scripts/seed-chokepoint-flows.mjs` writes 7 records in ~3s; same failure mode reproducible by removing `_seed-envelope-source.mjs` before running
- [ ] After merge + deploy: confirm Railway relay logs show `[ChokepointFlows] Completed in Xs` on every 6h tick, not `ERR_MODULE_NOT_FOUND`
- [ ] Health: `chokepointFlows` returns to OK within one 6h cycle and stays there