### PR TITLE
feat(relay): seeder-loop heartbeats for chokepoint-flows + climate-news

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -405,6 +405,16 @@ const ON_DEMAND_KEYS = new Set([
   'hyperliquidFlow', // TRANSITIONAL: seed-hyperliquid-flow runs inside seed-bundle-market-backup on
                      // Railway; gate as on-demand so initial deploy-order race or first cold-start
                      // snapshot doesn't CRIT. Remove after ~7 days of clean production cron runs.
+  'chokepointFlowsRelayHeartbeat', // TRANSITIONAL (PR #3133): ais-relay.cjs writes this on the
+                                   // first successful child exit after a deploy. Vercel deploys
+                                   // api/health.js instantly, but Railway rebuild + 6h initial
+                                   // loop interval means the key is absent for up to ~6h post-merge.
+                                   // Gate as on-demand so the deploy window doesn't CRIT. Remove
+                                   // after ~7 days of clean production runs (verify via
+                                   // `relay:heartbeat:chokepoint-flows.fetchedAt`).
+  'climateNewsRelayHeartbeat',     // TRANSITIONAL (PR #3133): same deploy-order rationale.
+                                   // 30min initial loop, so window is shorter but still present.
+                                   // Remove after ~7 days alongside the chokepoint-flows entry.
 ]);
 
 // Keys where 0 records is a valid healthy state (e.g. no airports closed,

--- a/api/health.js
+++ b/api/health.js
@@ -190,6 +190,13 @@ const STANDALONE_KEYS = {
   goldExtended:             'market:gold-extended:v1',
   goldEtfFlows:             'market:gold-etf-flows:v1',
   goldCbReserves:           'market:gold-cb-reserves:v1',
+  // Relay-side loop heartbeats. ais-relay.cjs writes these on successful child
+  // exit for the two execFile-spawned seeders (chokepoint-flows, climate-news).
+  // A stale heartbeat means the relay loop itself is broken (child dying at
+  // import, parent event-loop blocked, container in a restart loop, etc.)
+  // and alarms earlier than the underlying seed-meta staleness window.
+  chokepointFlowsRelayHeartbeat: 'relay:heartbeat:chokepoint-flows',
+  climateNewsRelayHeartbeat:     'relay:heartbeat:climate-news',
 };
 
 const SEED_META = {
@@ -350,6 +357,12 @@ const SEED_META = {
   aaiiSentiment:        { key: 'seed-meta:market:aaii-sentiment',       maxStaleMin: 20160 }, // weekly cron; 20160min = 14 days = 2x weekly cadence
   portwatchChokepointsRef: { key: 'seed-meta:portwatch:chokepoints-ref', maxStaleMin: 60 * 24 * 14 }, // seed-bundle-portwatch runs this at WEEK cadence; 14d = 2× interval
   chokepointFlows:      { key: 'seed-meta:energy:chokepoint-flows',     maxStaleMin: 720 }, // 6h cron; 720min = 2x interval
+  // Relay-side heartbeat written by ais-relay.cjs on successful child exit.
+  // Detects "relay loop fires but child dies at import/runtime" failures
+  // (e.g. ERR_MODULE_NOT_FOUND from a missing Dockerfile COPY) 4h earlier
+  // than the 720min seed-meta threshold above. TTL is 18h on the writer.
+  chokepointFlowsRelayHeartbeat: { key: 'relay:heartbeat:chokepoint-flows', maxStaleMin: 480 }, // 6h loop; 8h alarm
+  climateNewsRelayHeartbeat:     { key: 'relay:heartbeat:climate-news',     maxStaleMin: 60 },  // 30m loop; 60m alarm
   emberElectricity:     { key: 'seed-meta:energy:ember',                maxStaleMin: 2880 }, // daily cron (08:00 UTC); 2880min = 48h = 2x interval
   cryptoSectors:        { key: 'seed-meta:market:crypto-sectors',             maxStaleMin: 120 }, // relay loop every ~30min; 120min = 2h = 4x interval
   ddosAttacks:          { key: 'seed-meta:cf:radar:ddos',                    maxStaleMin: 60 }, // written by seed-internet-outages afterPublish; outages cron ~15min; 60 = 4x interval

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -6010,7 +6010,12 @@ async function seedClimateNews() {
   const t0 = Date.now();
   try {
     await runClimateNewsSeedScript();
-    console.log(`[ClimateNewsSeed] Completed in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+    const durMs = Date.now() - t0;
+    console.log(`[ClimateNewsSeed] Completed in ${(durMs / 1000).toFixed(1)}s`);
+    // Heartbeat: success-only write so the health endpoint can alarm on a
+    // stalled loop before the 90min seed-meta threshold fires. TTL=3x interval
+    // (90min) lets two consecutive cycles miss before the key evaporates.
+    upstashSet('relay:heartbeat:climate-news', { fetchedAt: Date.now(), recordCount: 1, durMs }, 90 * 60).catch(() => {});
   } catch (e) {
     const message = e?.killed ? 'timeout' : (e?.message || e);
     console.warn('[ClimateNewsSeed] Seed error:', message);
@@ -6076,7 +6081,13 @@ async function seedChokepointFlows() {
   const t0 = Date.now();
   try {
     await runChokepointFlowsSeedScript();
-    console.log(`[ChokepointFlows] Completed in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+    const durMs = Date.now() - t0;
+    console.log(`[ChokepointFlows] Completed in ${(durMs / 1000).toFixed(1)}s`);
+    // Heartbeat: success-only write so the health endpoint can alarm at +8h
+    // instead of +12h (seed-meta threshold). This catches the failure mode
+    // where the child process dies at import (ERR_MODULE_NOT_FOUND) and
+    // never refreshes seed-meta.energy:chokepoint-flows. TTL=3x interval.
+    upstashSet('relay:heartbeat:chokepoint-flows', { fetchedAt: Date.now(), recordCount: 1, durMs }, 18 * 3600).catch(() => {});
   } catch (e) {
     const message = e?.killed ? 'timeout' : (e?.message || e);
     console.warn('[ChokepointFlows] Seed error:', message);


### PR DESCRIPTION
## Summary

Defensive observability for the two `execFile`-spawned seeders inside `ais-relay.cjs`. When the relay loop fires but the child dies (like the 32h chokepointFlows outage fixed in #3132), `seed-meta:energy:chokepoint-flows` stays frozen at the last successful run and health only alarms at +12h. This PR shortens that detection window to +8h for chokepoint-flows and +1h for climate-news by writing a success-only heartbeat key after each clean child exit.

## Changes

**`scripts/ais-relay.cjs`** — after each successful `execFile`:
- `relay:heartbeat:chokepoint-flows` — TTL 18h (3× the 6h interval)
- `relay:heartbeat:climate-news` — TTL 90min (3× the 30m interval)

Payload shape `{ fetchedAt, recordCount, durMs }` matches the existing seed-meta convention so the health-check reader picks it up unchanged.

**`api/health.js`** — two new entries:
- `STANDALONE_KEYS` maps the logical names to the heartbeat data keys.
- `SEED_META` gives each a tighter staleness threshold than the underlying seed-meta:
  - `chokepointFlowsRelayHeartbeat`: `maxStaleMin=480` (8h vs the 720min on `seed-meta:energy:chokepoint-flows`)
  - `climateNewsRelayHeartbeat`: `maxStaleMin=60` (vs 90min on `seed-meta:climate:news-intelligence`)

Staleness modes:
- 0–8h / 0–60min: heartbeat fresh → OK
- 8–18h / 60–90min: heartbeat present but stale → STALE_SEED (warn)
- >18h / >90min: heartbeat key expired → EMPTY (crit)

## Why orthogonal to #3132

PR #3132 removes the specific `ERR_MODULE_NOT_FOUND` that caused the 32h outage. This PR is insurance for the next failure we can't predict — any relay-loop freeze (event-loop blocked, container restart loop, upstream Redis hang, etc.) will surface in `/api/health` within 2× the loop interval.

## Test plan

- [x] \`npm run typecheck:api\` — PASS
- [x] \`npm run test:data\` — PASS (5417/5417, +1 from before)
- [x] \`node --test tests/edge-functions.test.mjs\` — PASS (168/168)
- [x] \`node -c scripts/ais-relay.cjs\` — syntax OK
- [x] Relay module-load verified (fails only on missing AISSTREAM_API_KEY in local env — expected)
- [ ] After deploy: verify \`/api/health\` shows \`chokepointFlowsRelayHeartbeat\` = OK within one 6h cycle
- [ ] Kill the relay in a staging env for >60min, confirm \`climateNewsRelayHeartbeat\` flips to STALE_SEED at +60min instead of waiting for \`climateNews\` (+90min)