### PR TITLE
chore(relay): socialVelocity + wsbTickers to hourly fetch (6x Reddit traffic reduction)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -329,8 +329,8 @@ const SEED_META = {
   shippingStress:    { key: 'seed-meta:supply_chain:shipping_stress',  maxStaleMin: 45 }, // relay loop every 15min; 45 = 3x interval (was 30 = 2×, too tight on relay hiccup)
   diseaseOutbreaks:  { key: 'seed-meta:health:disease-outbreaks',      maxStaleMin: 2880 }, // daily seed; 2880 = 48h = 2x interval
   healthAirQuality:  { key: 'seed-meta:health:air-quality',            maxStaleMin: 180 }, // hourly cron; 180 = 3x interval for shared health/climate seed
-  socialVelocity:    { key: 'seed-meta:intelligence:social-reddit',    maxStaleMin: 30 }, // relay loop every 10min; 30 = 3x interval (was 20 = equals retry window, too tight)
-  wsbTickers:        { key: 'seed-meta:intelligence:wsb-tickers',      maxStaleMin: 30 }, // relay loop every 10min; 30 = 3x interval
+  socialVelocity:    { key: 'seed-meta:intelligence:social-reddit',    maxStaleMin: 180 }, // relay loop every 60min (hourly, bumped from 10min to reduce Reddit IP blocking); 180 = 3x interval
+  wsbTickers:        { key: 'seed-meta:intelligence:wsb-tickers',      maxStaleMin: 180 }, // relay loop every 60min; 180 = 3x interval
   pizzint:           { key: 'seed-meta:intelligence:pizzint',          maxStaleMin: 30 }, // relay loop every 10min; 30 = 3x interval
   productCatalog:    { key: 'seed-meta:product-catalog',               maxStaleMin: 1080 }, // relay loop every 6h; 1080 = 18h = 3x interval
   vpdTrackerRealtime:   { key: 'seed-meta:health:vpd-tracker',         maxStaleMin: 2880 }, // daily seed (0 2 * * *); 2880min = 48h = 2x interval

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -67,7 +67,7 @@ const SEED_DOMAINS = {
   'intelligence:gdelt-intel': { key: 'seed-meta:intelligence:gdelt-intel', intervalMin: 210 }, // 420min maxStaleMin / 2 — aligned with health.js (6h cron + 1h grace)
   'correlation:cards':        { key: 'seed-meta:correlation:cards',        intervalMin: 5 },
   'intelligence:advisories':  { key: 'seed-meta:intelligence:advisories',  intervalMin: 60 },
-  'intelligence:wsb-tickers': { key: 'seed-meta:intelligence:wsb-tickers', intervalMin: 15 }, // 10min relay loop; intervalMin = maxStaleMin / 2 (30 / 2)
+  'intelligence:wsb-tickers': { key: 'seed-meta:intelligence:wsb-tickers', intervalMin: 90 }, // 60min relay loop (hourly, bumped from 10min); intervalMin = maxStaleMin / 2 (180 / 2)
   'trade:customs-revenue':    { key: 'seed-meta:trade:customs-revenue',    intervalMin: 720 },
   'thermal:escalation':       { key: 'seed-meta:thermal:escalation',       intervalMin: 180 },
   'radiation:observations':   { key: 'seed-meta:radiation:observations',   intervalMin: 15 },

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -67,6 +67,7 @@ const SEED_DOMAINS = {
   'intelligence:gdelt-intel': { key: 'seed-meta:intelligence:gdelt-intel', intervalMin: 210 }, // 420min maxStaleMin / 2 — aligned with health.js (6h cron + 1h grace)
   'correlation:cards':        { key: 'seed-meta:correlation:cards',        intervalMin: 5 },
   'intelligence:advisories':  { key: 'seed-meta:intelligence:advisories',  intervalMin: 60 },
+  'intelligence:social-reddit': { key: 'seed-meta:intelligence:social-reddit', intervalMin: 90 }, // 60min relay loop (hourly, bumped from 10min to reduce Reddit IP blocking); intervalMin = maxStaleMin / 2 (180 / 2)
   'intelligence:wsb-tickers': { key: 'seed-meta:intelligence:wsb-tickers', intervalMin: 90 }, // 60min relay loop (hourly, bumped from 10min); intervalMin = maxStaleMin / 2 (180 / 2)
   'trade:customs-revenue':    { key: 'seed-meta:trade:customs-revenue',    intervalMin: 720 },
   'thermal:escalation':       { key: 'seed-meta:thermal:escalation',       intervalMin: 180 },

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -5678,8 +5678,12 @@ async function startShippingStressSeedLoop() {
 // ─────────────────────────────────────────────────────────────
 
 const SOCIAL_VELOCITY_REDIS_KEY = 'intelligence:social:reddit:v1';
-const SOCIAL_VELOCITY_TTL = 1800; // 30min — seed runs every 10min (3× safety margin)
-const SOCIAL_VELOCITY_INTERVAL_MS = 10 * 60 * 1000;
+// Hourly cadence (bumped from 10min). Reddit rate-limits Railway datacenter IPs
+// after ~50min of 10-min polling (empirically observed 2026-04-16: both subs
+// returned HTTP 403 on every cycle after 16:26 UTC). Dropping the success-path
+// frequency to 1/hour reduces the traffic Reddit's behavioral heuristic flags on.
+const SOCIAL_VELOCITY_TTL = 10800; // 3h — 3× the 60min interval
+const SOCIAL_VELOCITY_INTERVAL_MS = 60 * 60 * 1000;
 const REDDIT_SUBREDDITS = ['worldnews', 'geopolitics'];
 
 let socialVelocityInFlight = false;
@@ -5770,8 +5774,10 @@ async function startSocialVelocitySeedLoop() {
 // ─────────────────────────────────────────────────────────────
 
 const WSB_TICKERS_REDIS_KEY = 'intelligence:wsb-tickers:v1';
-const WSB_TICKERS_TTL = 1800; // 30min — seed runs every 10min (3× safety margin)
-const WSB_TICKERS_INTERVAL_MS = 10 * 60 * 1000;
+// Hourly cadence (bumped from 10min). Same Reddit-datacenter-IP blocking
+// rationale as SocialVelocity — see comment above.
+const WSB_TICKERS_TTL = 10800; // 3h — 3× the 60min interval
+const WSB_TICKERS_INTERVAL_MS = 60 * 60 * 1000;
 const WSB_TICKERS_RETRY_MS = 20 * 60 * 1000;
 const WSB_SUBREDDITS = ['wallstreetbets', 'stocks', 'investing'];
 


### PR DESCRIPTION
## Summary

Reduce Reddit rate-limiting blast radius for the two relay-side subreddit seeders. Bump cadence from every 10 min to once per hour.

## Why

Reddit's behavioral heuristic for datacenter IPs consistently flags the Railway relay IP after ~50 min of 10-min polling. Direct evidence from 2026-04-16 ais-relay logs:

| Time | SocialVelocity | WsbTickers |
|---|---|---|
| 13:32–14:22 UTC | ✓ 6 successful cycles | ✓ 6 successful cycles |
| 16:06–16:16 UTC | ✓ 2 cycles post-restart | ✓ 2 cycles post-restart |
| **16:26 UTC onward** | **✗ 403 r/worldnews, r/geopolitics** | **✗ 403 r/wallstreetbets, r/stocks, r/investing** |

Each 10-min cycle sends 5 Reddit requests (2 subs × SV + 3 subs × WSB). Even at `5 req / 10min = 30 req/hour` — well below Reddit's stated 60-req/min ceiling — the IP still gets flagged.

Dropping to hourly success-path fetches = 6× fewer requests. Won't eliminate blocking entirely, but gives Reddit's heuristic less volume to flag on, and successful windows should last longer between blocks.

## Changes

| Constant | Before | After |
|---|---|---|
| `SOCIAL_VELOCITY_INTERVAL_MS` | 10 min | 60 min |
| `SOCIAL_VELOCITY_TTL` | 30 min | 3 h (3× interval) |
| `WSB_TICKERS_INTERVAL_MS` | 10 min | 60 min |
| `WSB_TICKERS_TTL` | 30 min | 3 h |
| `api/health.js` maxStaleMin (both) | 30 | 180 |
| `api/seed-health.js` intervalMin (wsb) | 15 | 90 |

Retry window stays at 20 min — during an active block we're already flagged, so extra retries don't worsen the situation. `upstashExpire` on the failure path keeps the last snapshot alive for the full 3h TTL.

## What this does NOT fix

Reddit blocking itself. When the IP is flagged the 1/hour tick still fails. Proper fix is proxy fallback (`httpsProxyFetchRaw` like yahoo/cftc) or Reddit OAuth — deferred. This PR is the cheap probability-reduction.

## Test plan

- [x] \`node --test tests/edge-functions.test.mjs\` — PASS (168/168)
- [x] \`npm run test:data\` — PASS (5420/5420)
- [x] \`npm run typecheck:api\` — PASS
- [x] \`node -c scripts/ais-relay.cjs\` — syntax OK
- [ ] After deploy: watch relay logs for 2-3 successful hourly cycles, confirm health \`socialVelocity\` / \`wsbTickers\` settle at seedAgeMin under 180min