### PR TITLE
fix(liquidity-shifts): wire missing primeTask so fetchData() is called

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -50,6 +50,7 @@ import type { YieldCurvePanel } from '@/components/YieldCurvePanel';
 import type { EarningsCalendarPanel } from '@/components/EarningsCalendarPanel';
 import type { EconomicCalendarPanel } from '@/components/EconomicCalendarPanel';
 import type { CotPositioningPanel } from '@/components/CotPositioningPanel';
+import type { LiquidityShiftsPanel } from '@/components/LiquidityShiftsPanel';
 import type { GoldIntelligencePanel } from '@/components/GoldIntelligencePanel';
 import { isDesktopRuntime, waitForSidecarReady } from '@/services/runtime';
 import { hasPremiumAccess } from '@/services/panel-gating';
@@ -344,6 +345,10 @@ export class App {
     if (shouldPrime('cot-positioning')) {
       const panel = this.state.panels['cot-positioning'] as CotPositioningPanel | undefined;
       if (panel) primeTask('cot-positioning', () => panel.fetchData());
+    }
+    if (shouldPrime('liquidity-shifts')) {
+      const panel = this.state.panels['liquidity-shifts'] as LiquidityShiftsPanel | undefined;
+      if (panel) primeTask('liquidity-shifts', () => panel.fetchData());
     }
     if (shouldPrime('gold-intelligence')) {
       const panel = this.state.panels['gold-intelligence'] as GoldIntelligencePanel | undefined;


### PR DESCRIPTION
## Why this PR?

The Liquidity Shifts panel is permanently stuck on "Loading..." with the radar spinner. Seeders are healthy, Redis has data, RPC handler works. The panel simply never fetches.

## Root cause

`LiquidityShiftsPanel` was created in `panel-layout.ts:1115` but no `primeTask('liquidity-shifts', ...)` was added to `App.ts`. Every other self-fetching panel in the same tier (cot-positioning, gold-intelligence, fear-greed, etf-flows, etc.) has its `primeTask` call. This one was missed when the panel was added.

The panel constructor calls `showLoading()` via the base class, then waits for `fetchData()` to be called externally. Nobody calls it.

## Fix

Add `primeTask('liquidity-shifts', () => panel.fetchData())` in `App.ts` right after the `cot-positioning` block, matching the pattern of every other panel.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Post-deploy: Liquidity Shifts panel should show COT positioning data + top stock movers instead of "Loading..."