### PR TITLE
fix(relay): envelope-aware Redis reads restore chokepoint transit chart

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -403,6 +403,19 @@ function envelopeWrite(key, data, ttlSeconds, meta) {
   return upstashSet(key, envelope, ttlSeconds);
 }
 
+// Envelope-aware read. Mirrors server/_shared/redis.ts::getCachedJson semantics:
+// returns the bare payload for contract-mode canonical keys ({_seed, data}) and
+// passes legacy shapes through unchanged. MUST be used for any seeded canonical
+// key — reading raw via upstashGet() on an enveloped key iterates {_seed, data}
+// as payload keys and silently corrupts downstream consumers.
+async function envelopeRead(key) {
+  const raw = await upstashGet(key);
+  if (raw && typeof raw === 'object' && !Array.isArray(raw) && '_seed' in raw && 'data' in raw) {
+    return raw.data;
+  }
+  return raw;
+}
+
 function notifySimpleHash(str) {
   let h = 0;
   for (let i = 0; i < str.length; i++) h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
@@ -5879,7 +5892,7 @@ const WSB_TICKER_SET_CACHE_TTL_MS = 30 * 60 * 1000; // refresh known ticker set 
 async function loadWsbTickerSet() {
   if (wsbTickerSetCache && (Date.now() - wsbTickerSetCacheTs < WSB_TICKER_SET_CACHE_TTL_MS)) return wsbTickerSetCache;
   try {
-    const data = await upstashGet('market:stocks-bootstrap:v1');
+    const data = await envelopeRead('market:stocks-bootstrap:v1');
     if (data && Array.isArray(data.quotes)) {
       wsbTickerSetCache = new Set(data.quotes.map(s => s.symbol?.toUpperCase()).filter(Boolean));
       wsbTickerSetCacheTs = Date.now();
@@ -7353,11 +7366,11 @@ function detectTrafficAnomalyRelay(history, threatLevel) {
 }
 
 async function seedTransitSummaries() {
-  const pw = await upstashGet(PORTWATCH_REDIS_KEY);
+  const pw = await envelopeRead(PORTWATCH_REDIS_KEY);
   if (!pw || typeof pw !== 'object' || Object.keys(pw).length === 0) return;
 
   if (!latestCorridorRiskData) {
-    const persisted = await upstashGet(CORRIDOR_RISK_REDIS_KEY);
+    const persisted = await envelopeRead(CORRIDOR_RISK_REDIS_KEY);
     if (persisted && typeof persisted === 'object' && Object.keys(persisted).length > 0) {
       latestCorridorRiskData = persisted;
       console.log(`[TransitSummary] Hydrated CorridorRisk from Redis (${Object.keys(persisted).length} corridors)`);

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1211,7 +1211,10 @@ async function orefBootstrapHistoryWithRetry() {
 
   // Phase 1: try Redis first
   try {
-    const cached = await upstashGet(OREF_REDIS_KEY);
+    // envelopeRead unwraps the {_seed, data} shape written by orefPersistHistory()
+    // at line 1133. Reading raw left cached.history undefined, so OREF state was
+    // never restored across relay restarts (reported in PR #3139 review).
+    const cached = await envelopeRead(OREF_REDIS_KEY);
     if (cached && Array.isArray(cached.history) && cached.history.length > 0) {
       const valid = cached.history.every(
         h => Array.isArray(h.alerts) && typeof h.timestamp === 'string'

--- a/scripts/backtest-resilience-outcomes.mjs
+++ b/scripts/backtest-resilience-outcomes.mjs
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveIso2 } from './_country-resolver.mjs';
 import { getRedisCredentials, loadEnvFile } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 // Normalize any country identifier the upstream seeders emit (ISO2, ISO3, or
 // full English name) to canonical uppercase ISO2, or null when unrecognized.
@@ -157,7 +158,9 @@ async function redisGetJson(url, token, key) {
   const data = await resp.json();
   if (!data?.result) return null;
   try {
-    return JSON.parse(data.result);
+    // Envelope-aware: unwrapEnvelope returns bare payload for contract-mode
+    // {_seed, data} shapes (PR #3097) and passes legacy raw payloads through.
+    return unwrapEnvelope(JSON.parse(data.result)).data;
   } catch {
     return typeof data.result === 'string' ? data.result : null;
   }

--- a/scripts/validate-resilience-backtest.mjs
+++ b/scripts/validate-resilience-backtest.mjs
@@ -22,6 +22,7 @@
  */
 
 import { getRedisCredentials, loadEnvFile } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -111,7 +112,11 @@ async function redisGetJson(url, token, key) {
   if (!resp.ok) return null;
   const data = await resp.json();
   if (!data?.result) return null;
-  try { return JSON.parse(data.result); } catch { return null; }
+  try {
+    // Envelope-aware: unwrapEnvelope returns bare payload for contract-mode
+    // {_seed, data} shapes (PR #3097) and passes legacy raw payloads through.
+    return unwrapEnvelope(JSON.parse(data.result)).data;
+  } catch { return null; }
 }
 
 async function redisPipeline(url, token, commands) {

--- a/tests/transit-summaries.test.mjs
+++ b/tests/transit-summaries.test.mjs
@@ -522,6 +522,23 @@ describe('seedTransitSummaries Redis reads', () => {
     assert.doesNotMatch(relaySrc, /const persisted = await upstashGet\(CORRIDOR_RISK_REDIS_KEY\)/);
   });
 
+  it('loadWsbTickerSet reads market:stocks-bootstrap:v1 via envelopeRead', () => {
+    // Regression guard (Greptile review PR #3139): market:stocks-bootstrap:v1 is
+    // written via envelopeWrite at lines 1867 + dual-write elsewhere. Reading raw
+    // left data.quotes undefined, silently disabling WSB ticker matching.
+    assert.match(relaySrc, /envelopeRead\('market:stocks-bootstrap:v1'\)/);
+    assert.doesNotMatch(relaySrc, /upstashGet\('market:stocks-bootstrap:v1'\)/);
+  });
+
+  it('OREF bootstrap reads OREF_REDIS_KEY via envelopeRead (parity with orefPersistHistory)', () => {
+    // Regression guard (Greptile review PR #3139): orefPersistHistory() writes via
+    // envelopeWrite. Reading raw left cached.history undefined, so OREF history
+    // was never restored across relay restarts — every cold start hit the
+    // upstream API unnecessarily.
+    assert.match(relaySrc, /const cached = await envelopeRead\(OREF_REDIS_KEY\)/);
+    assert.doesNotMatch(relaySrc, /const cached = await upstashGet\(OREF_REDIS_KEY\)/);
+  });
+
   it('PortWatch Redis read is the first statement (before early return)', () => {
     const fnBody = relaySrc.match(/async function seedTransitSummaries\(\)\s*\{([\s\S]*?)\n\}/)?.[1] || '';
     const readPos = fnBody.indexOf('envelopeRead(PORTWATCH_REDIS_KEY)');

--- a/tests/transit-summaries.test.mjs
+++ b/tests/transit-summaries.test.mjs
@@ -78,8 +78,9 @@ describe('seedTransitSummaries (relay)', () => {
     assert.match(relaySrc, /\{\s*summaries,\s*fetchedAt:\s*now\s*\}/);
   });
 
-  it('PortWatch data is read directly from Redis each cycle', () => {
-    assert.match(relaySrc, /const pw = await upstashGet\(PORTWATCH_REDIS_KEY\)/);
+  it('PortWatch data is read via envelopeRead (unwraps {_seed, data} contract-mode shape)', () => {
+    assert.match(relaySrc, /const pw = await envelopeRead\(PORTWATCH_REDIS_KEY\)/);
+    assert.doesNotMatch(relaySrc, /const pw = await upstashGet\(PORTWATCH_REDIS_KEY\)/);
   });
 
   it('is triggered after CorridorRisk seed completes', () => {
@@ -504,31 +505,82 @@ describe('handler transit data strategy', () => {
 describe('seedTransitSummaries Redis reads', () => {
   it('always reads PortWatch fresh from Redis (no in-memory cache guard)', () => {
     assert.doesNotMatch(relaySrc, /if\s*\(\s*!latestPortwatchData\s*\)/);
-    assert.match(relaySrc, /upstashGet\(PORTWATCH_REDIS_KEY\)/);
+    assert.match(relaySrc, /envelopeRead\(PORTWATCH_REDIS_KEY\)/);
   });
 
   it('reads CorridorRisk from Redis when latestCorridorRiskData is null', () => {
     assert.match(relaySrc, /if\s*\(\s*!latestCorridorRiskData\s*\)/);
-    assert.match(relaySrc, /upstashGet\(CORRIDOR_RISK_REDIS_KEY\)/);
+    assert.match(relaySrc, /envelopeRead\(CORRIDOR_RISK_REDIS_KEY\)/);
     assert.match(relaySrc, /Hydrated CorridorRisk from Redis/);
+  });
+
+  it('PortWatch Redis read unwraps contract-mode envelope (reader parity with producer)', () => {
+    // Regression guard: PR #3097 migrated producers to {_seed, data}. A raw
+    // upstashGet iterates those wrapper keys as chokepoint IDs and silently
+    // zeroes the transit chart for every chokepoint.
+    assert.doesNotMatch(relaySrc, /const pw = await upstashGet\(PORTWATCH_REDIS_KEY\)/);
+    assert.doesNotMatch(relaySrc, /const persisted = await upstashGet\(CORRIDOR_RISK_REDIS_KEY\)/);
   });
 
   it('PortWatch Redis read is the first statement (before early return)', () => {
     const fnBody = relaySrc.match(/async function seedTransitSummaries\(\)\s*\{([\s\S]*?)\n\}/)?.[1] || '';
-    const readPos = fnBody.indexOf('upstashGet(PORTWATCH_REDIS_KEY)');
+    const readPos = fnBody.indexOf('envelopeRead(PORTWATCH_REDIS_KEY)');
     const earlyReturnPos = fnBody.indexOf('if (!pw ||');
-    assert.ok(readPos > 0, 'upstashGet(PORTWATCH_REDIS_KEY) not found in function body');
+    assert.ok(readPos > 0, 'envelopeRead(PORTWATCH_REDIS_KEY) not found in function body');
     assert.ok(earlyReturnPos > 0, 'pw early return not found');
     assert.ok(readPos < earlyReturnPos, 'Redis read must come before the early return');
   });
 
   it('PortWatch data is assigned directly from Redis (no stale in-memory cache)', () => {
     const fnBody = relaySrc.match(/async function seedTransitSummaries\(\)\s*\{([\s\S]*?)\n\}/)?.[1] || '';
-    assert.match(fnBody, /const pw = await upstashGet\(PORTWATCH_REDIS_KEY\)/);
+    assert.match(fnBody, /const pw = await envelopeRead\(PORTWATCH_REDIS_KEY\)/);
   });
 
   it('assigns hydrated data back to latestCorridorRiskData', () => {
     const fnBody = relaySrc.match(/async function seedTransitSummaries\(\)\s*\{([\s\S]*?)\n\}/)?.[1] || '';
     assert.match(fnBody, /latestCorridorRiskData\s*=\s*persisted/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// envelopeRead helper — runtime behavior (regression guard for PR #3097 drift)
+// ---------------------------------------------------------------------------
+describe('envelopeRead helper', () => {
+  // Extract and eval the helper — it is pure aside from upstashGet, which we stub.
+  const helperSrc = relaySrc.match(/async function envelopeRead\([\s\S]*?\n\}/)?.[0];
+
+  it('is defined in ais-relay.cjs next to envelopeWrite', () => {
+    assert.ok(helperSrc, 'envelopeRead not found in ais-relay.cjs');
+  });
+
+  function buildEnvelopeRead(stub) {
+    // eslint-disable-next-line no-new-func
+    return new Function('upstashGet', `${helperSrc}\nreturn envelopeRead;`)(stub);
+  }
+
+  it('unwraps contract-mode envelope {_seed, data} -> data', async () => {
+    const stub = async () => ({ _seed: { fetchedAt: 1 }, data: { hormuz_strait: { history: [1, 2, 3] } } });
+    const read = buildEnvelopeRead(stub);
+    const out = await read('supply_chain:portwatch:v1');
+    assert.deepEqual(out, { hormuz_strait: { history: [1, 2, 3] } });
+  });
+
+  it('passes legacy raw shape through unchanged', async () => {
+    const stub = async () => ({ hormuz_strait: { history: [1] }, suez: { history: [] } });
+    const read = buildEnvelopeRead(stub);
+    const out = await read('legacy:key');
+    assert.deepEqual(out, { hormuz_strait: { history: [1] }, suez: { history: [] } });
+  });
+
+  it('returns null when Redis returns null', async () => {
+    const stub = async () => null;
+    const read = buildEnvelopeRead(stub);
+    assert.equal(await read('missing:key'), null);
+  });
+
+  it('does NOT unwrap arrays that happen to have _seed/data indices', async () => {
+    const stub = async () => [1, 2, 3];
+    const read = buildEnvelopeRead(stub);
+    assert.deepEqual(await read('array:key'), [1, 2, 3]);
   });
 });


### PR DESCRIPTION
## Why this PR?

PR #3097 migrated 91 seed producers to the contract-mode envelope shape `{_seed, data}`, but `scripts/ais-relay.cjs` still uses its private `upstashGet()` which returns raw JSON without unwrapping. Three consumer callsites in the relay were reading envelope metadata as the payload and silently corrupting downstream data. User-visible symptom: clicking a chokepoint card in the Supply Chain panel (or opening the map waterway popup) no longer renders the transit-history chart for Strait of Hormuz or any other chokepoint.

## What's broken

Verified against live Upstash at time of writing:

| Callsite | Key | Shape | Visible effect |
|---|---|---|---|
| `ais-relay.cjs:7356` `seedTransitSummaries()` | `supply_chain:portwatch:v1` | ENVELOPE | `summaries` map keyed by `_seed` / `data` (not chokepoint IDs); every `history: []`; panel + map popup chart hidden |
| `ais-relay.cjs:7360` `seedTransitSummaries()` | `supply_chain:corridorrisk:v1` | ENVELOPE | corridor risk level / incident count / risk report action all empty |
| `ais-relay.cjs:5882` `loadWsbTickerSet()` | `market:stocks-bootstrap:v1` | ENVELOPE | `data.quotes === undefined` → WSB ticker matching silently disabled |

Live snapshot of the corrupted output key (`supply_chain:transit-summaries:v1`) shows `summaries: {_seed: {...empty...}, data: {...empty...}}` instead of the expected chokepoint-ID-keyed map.

## Fix

Add `envelopeRead(key)` next to `envelopeWrite` in `ais-relay.cjs`. Mirrors `server/_shared/redis.ts::getCachedJson` semantics: envelope-aware by default, legacy raw shapes pass through unchanged. Swap the three `upstashGet` calls that target contract-mode canonical keys.

## Test plan

- [x] `npm run test:data` — 5426/5426 pass
- [x] 4 new unit tests cover `envelopeRead`: contract-mode unwrap, legacy passthrough, `null`, and the array-with-numeric-indices edge case
- [x] Existing static-source assertions updated to guard regression to raw `upstashGet` on these keys
- [x] `tsc --noEmit` + `tsc --noEmit -p tsconfig.api.json` both clean
- [ ] After Railway redeploys the relay, verify (10 min after rollout): `GET supply_chain:transit-summaries:v1` → `data.summaries` is a map of 13 chokepoint IDs, `summaries.hormuz_strait.history.length > 0`
- [ ] UI check: Supply Chain panel → click Strait of Hormuz card → transit chart renders; map popup on Hormuz waterway → transit chart renders

## Follow-up (tracked, not in this PR)

4 broken sites audited — 3 in relay (fixed here), 1 in `scripts/backtest-resilience-outcomes.mjs` (offline job reading `economic:fx:yoy:v1`, `infra:outages:v1`, `conflict:ucdp-events:v1` — all envelope). PR B will consolidate the 11 per-script `redisGet`/`upstashGet` helpers into a single typed `readSeedJson` + a CI grep guard so the next envelope migration cannot silently break a consumer.