### PR TITLE
fix(railway): tolerate Ubuntu apt mirror failures in NIXPACKS builds

### DIFF
--- a/consumer-prices-core/Dockerfile
+++ b/consumer-prices-core/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:20-slim AS base
 WORKDIR /app
 
-# Install Playwright dependencies
-RUN apt-get update && apt-get install -y \
+# Install Playwright dependencies. Tolerate transient Ubuntu mirror failures
+# (2026-04-17: noble-security CDN hash-sum mismatch blocked all Railway builds).
+RUN (apt-get update || true) && apt-get install -y --fix-missing \
     chromium \
     fonts-liberation \
     libatk-bridge2.0-0 \

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -5,7 +5,13 @@
 # available at runtime when node scripts/ais-relay.cjs is started.
 
 [phases.setup]
-aptPkgs = ["curl"]
+# aptPkgs = ["curl"]  — disabled; NIXPACKS' apt wrapper runs
+# `apt-get update && apt-get install` which fails hard when Ubuntu's
+# package-index CDN returns a hash mismatch (2026-04-17: noble-security
+# mirror globally broken, blocking ALL Railway NIXPACKS builds). The
+# manual cmds below tolerate transient mirror failures by adding
+# --fix-missing and allowing partial index updates to succeed.
+cmds = ["sudo apt-get update -o Acquire::AllowInsecureRepositories=false || true", "sudo apt-get install -y --no-install-recommends --fix-missing curl || echo 'apt curl install failed; curl may already be present'"]
 
 [variables]
 NODE_OPTIONS = "--dns-result-order=ipv4first"

--- a/scripts/nixpacks.toml
+++ b/scripts/nixpacks.toml
@@ -1,5 +1,6 @@
 [phases.setup]
-aptPkgs = ["curl"]
+# aptPkgs = ["curl"]  — same workaround as root nixpacks.toml; see comment there.
+cmds = ["sudo apt-get update -o Acquire::AllowInsecureRepositories=false || true", "sudo apt-get install -y --no-install-recommends --fix-missing curl || echo 'apt curl install failed; curl may already be present'"]
 
 [variables]
 NODE_OPTIONS = "--dns-result-order=ipv4first"


### PR DESCRIPTION
## Hotfix — multiple Railway services are red

Ubuntu's \`noble-security\` package-index CDN is returning hash-sum mismatches (2026-04-17). **All Railway services that build via NIXPACKS fail** at the \`apt-get update && apt-get install curl\` layer with exit code 100.

```
E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/noble-security/main/binary-amd64/Packages.gz  Hash Sum mismatch
ERROR: failed to build: process "apt-get update && apt-get install -y --no-install-recommends curl" did not complete successfully: exit code: 100
```

Retries don't help — same CDN error. Affects every NIXPACKS service that has \`aptPkgs = ["curl"]\` in its nixpacks.toml.

## Fix

Replace \`aptPkgs = ["curl"]\` with manual \`cmds\` that tolerate partial mirror failures:

\`\`\`toml
[phases.setup]
cmds = ["sudo apt-get update ... || true", "sudo apt-get install -y --fix-missing curl || echo '...'"]
\`\`\`

Same treatment for \`consumer-prices-core/Dockerfile\` (\`apt-get update && apt-get install\` → \`(apt-get update || true) && apt-get install --fix-missing\`).

## Safety

- \`|| true\` on \`apt-get update\` is safe: curl is the only package, and it's often already present in the NIXPACKS base image via nix-env.
- If curl genuinely isn't available, the seeder fails at runtime with \`curl: not found\` — not silent degradation.
- \`--fix-missing\` lets apt install packages from healthy mirrors even when one mirror is broken.

## Test plan

- [ ] After merge, Railway redeploys ALL affected services automatically (watch paths cover \`nixpacks.toml\`).
- [ ] Verify build logs show \`apt-get update\` warning (not error) + \`apt-get install\` succeeds.
- [ ] goldExtended flips from EMPTY to OK in \`/api/health?compact=1\` once seed-commodity-quotes rebuilds + crons with the Yahoo proxy fallback (PR #3120, already merged).