### PR TITLE
fix(security): strip importanceScore from /api/notify payload + scope fan-out by userId

### DIFF
--- a/api/notify.ts
+++ b/api/notify.ts
@@ -58,6 +58,15 @@ export default async function handler(req: Request): Promise<Response> {
     return jsonResponse({ error: 'eventType required (string, max 64 chars)' }, 400, cors);
   }
 
+  // Reject internal relay control events. These are dispatched by Railway
+  // cron scripts (seed-digest-notifications, quiet-hours) and must never be
+  // user-submittable. flush_quiet_held would let a Pro user force-drain their
+  // held queue on demand, bypassing batch_on_wake behaviour.
+  const INTERNAL_EVENT_TYPES = new Set(['flush_quiet_held', 'channel_welcome']);
+  if (INTERNAL_EVENT_TYPES.has(body.eventType)) {
+    return jsonResponse({ error: 'Reserved event type' }, 403, cors);
+  }
+
   if (typeof body.payload !== 'object' || body.payload === null || Array.isArray(body.payload)) {
     return jsonResponse({ error: 'payload must be an object' }, 400, cors);
   }

--- a/api/notify.ts
+++ b/api/notify.ts
@@ -16,6 +16,9 @@ import { jsonResponse } from './_json-response.js';
 import { validateBearerToken } from '../server/auth-session';
 import { getEntitlements } from '../server/_shared/entitlement-check';
 
+const VALID_SEVERITIES = new Set(['critical', 'high', 'medium', 'low', 'info']);
+const INTERNAL_EVENT_TYPES = new Set(['flush_quiet_held', 'channel_welcome']);
+
 export default async function handler(req: Request): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return jsonResponse({ error: 'Origin not allowed' }, 403);
@@ -62,7 +65,6 @@ export default async function handler(req: Request): Promise<Response> {
   // cron scripts (seed-digest-notifications, quiet-hours) and must never be
   // user-submittable. flush_quiet_held would let a Pro user force-drain their
   // held queue on demand, bypassing batch_on_wake behaviour.
-  const INTERNAL_EVENT_TYPES = new Set(['flush_quiet_held', 'channel_welcome']);
   if (INTERNAL_EVENT_TYPES.has(body.eventType)) {
     return jsonResponse({ error: 'Reserved event type' }, 403, cors);
   }
@@ -88,7 +90,6 @@ export default async function handler(req: Request): Promise<Response> {
   delete payload.importanceScore;
   delete payload.corroborationCount;
 
-  const VALID_SEVERITIES = new Set(['critical', 'high', 'medium', 'low', 'info']);
   const rawSeverity = typeof body.severity === 'string' ? body.severity : 'high';
   const severity = VALID_SEVERITIES.has(rawSeverity) ? rawSeverity : 'high';
   const variant = typeof body.variant === 'string' ? body.variant : undefined;

--- a/api/notify.ts
+++ b/api/notify.ts
@@ -69,8 +69,19 @@ export default async function handler(req: Request): Promise<Response> {
     return jsonResponse({ error: 'Service unavailable' }, 503, cors);
   }
 
-  const { eventType, payload } = body;
-  const severity = typeof body.severity === 'string' ? body.severity : 'high';
+  const { eventType } = body;
+
+  // Strip relay-internal scoring fields from user-supplied payload. These are
+  // computed server-side by the relay's importanceScore pipeline; allowing
+  // user-supplied values would let a Pro user bypass the IMPORTANCE_SCORE_MIN
+  // gate and fan out arbitrary alerts to every subscriber.
+  const payload = { ...(body.payload as Record<string, unknown>) };
+  delete payload.importanceScore;
+  delete payload.corroborationCount;
+
+  const VALID_SEVERITIES = new Set(['critical', 'high', 'medium', 'low', 'info']);
+  const rawSeverity = typeof body.severity === 'string' ? body.severity : 'high';
+  const severity = VALID_SEVERITIES.has(rawSeverity) ? rawSeverity : 'high';
   const variant = typeof body.variant === 'string' ? body.variant : undefined;
 
   const msg = JSON.stringify({

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -705,11 +705,17 @@ async function processEvent(event) {
     return;
   }
 
+  // If the event carries a userId (browser-submitted via /api/notify), scope
+  // delivery to ONLY that user's own rules. Relay-emitted events (ais-relay,
+  // regional-snapshot) have no userId and fan out to all matching Pro users.
+  // Without this guard, a Pro user can POST arbitrary rss_alert events that
+  // fan out to every other Pro subscriber — see todo #196.
   const matching = enabledRules.filter(r =>
-    (!r.digestMode || r.digestMode === 'realtime') &&   // skip digest-mode rules — handled by seed-digest-notifications cron
+    (!r.digestMode || r.digestMode === 'realtime') &&
     (r.eventTypes.length === 0 || r.eventTypes.includes(event.eventType)) &&
     shouldNotify(r, event) &&
-    (!event.variant || !r.variant || r.variant === event.variant)
+    (!event.variant || !r.variant || r.variant === event.variant) &&
+    (!event.userId || r.userId === event.userId)
   );
 
   if (matching.length === 0) return;

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -687,9 +687,12 @@ async function processEvent(event) {
   // short-circuit, but we still pay the promise/microtask cost unless gated here.
   if (event.eventType === 'rss_alert') shadowLogScore(event).catch(() => {});
 
-  // Score gate — only for rss_alert; other event types (oref_siren, conflict_escalation,
-  // notam_closure, etc.) never attach importanceScore so they must never be gated here.
-  if (IMPORTANCE_SCORE_LIVE && event.eventType === 'rss_alert') {
+  // Score gate — only for relay-emitted rss_alert (no userId). Browser-submitted
+  // events (with userId) have importanceScore stripped at ingestion and no server-
+  // computed score; gating them would drop every browser notification once
+  // IMPORTANCE_SCORE_LIVE=1 is activated. Other event types (oref_siren,
+  // conflict_escalation, notam_closure) never attach importanceScore.
+  if (IMPORTANCE_SCORE_LIVE && event.eventType === 'rss_alert' && !event.userId) {
     const score = event.payload?.importanceScore ?? 0;
     if (score < IMPORTANCE_SCORE_MIN) {
       console.log(`[relay] Score gate: dropped ${event.eventType} score=${score} < ${IMPORTANCE_SCORE_MIN}`);


### PR DESCRIPTION
## Summary

Closes todo #196 (activation blocker for `IMPORTANCE_SCORE_LIVE=1`).

Pre-existing vulnerability surfaced during the scoring pipeline work (PR #3069): any authenticated Pro user could POST to `/api/notify` with `payload.importanceScore: 100` and `severity: 'critical'`, bypassing the relay's `IMPORTANCE_SCORE_MIN` gate. Fan-out would hit every Pro user with matching rules because the relay matched rules by eventType/severity/variant only, not by userId.

## Changes

- **`api/notify.ts`** — strips `importanceScore` and `corroborationCount` from the user-submitted payload before publishing to `wm:events:queue` (these are relay-internal fields computed by ais-relay's scoring pipeline). Validates `severity` against the known allowlist (`critical`, `high`, `medium`, `low`, `info`) instead of accepting any string.

- **`scripts/notification-relay.cjs`** — adds a userId-scoped fan-out guard: if the event carries `event.userId` (browser-submitted via `/api/notify`), only rules where `rule.userId === event.userId` match. Relay-emitted events (from ais-relay, regional-snapshot) have no userId and continue to fan out to all matching Pro users as before.

## Testing

- `npm run typecheck:api` passes
- `node -c scripts/notification-relay.cjs` passes
- All 27 regression tests pass (including importance-score-parity, relay-importance-recompute, notification-relay-shadow-log)

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Logs: `[relay] Processing event` lines for browser-submitted events (those with `userId` set) should only generate deliveries to one user, not N
  - No change to relay-emitted event delivery volume (those without userId)
- **Validation checks**
  - POST to `/api/notify` with `{ payload: { importanceScore: 100 } }` — confirm the delivered event in the relay has no `importanceScore` on the payload
  - Confirm existing rss_alert relay events (no userId) still deliver to all matching Pro users
- **Expected healthy behavior**
  - Browser-submitted events reach only the submitting user's channels
  - No change to relay-emitted event delivery (ais-relay, regional-snapshot)
- **Failure signal / rollback trigger**
  - If a legitimate user's browser-submitted notification stops reaching their own channels, the userId matching may be wrong
- **Validation window**: 24h
- **Owner**: koala73

## Unblocks

This PR is a prerequisite for activating `IMPORTANCE_SCORE_LIVE=1` on the notification relay (see PR #3069 activation sequence).