### PR TITLE
fix(relay): harden Telegram session lifecycle + add health monitoring

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -197,6 +197,7 @@ const STANDALONE_KEYS = {
   // and alarms earlier than the underlying seed-meta staleness window.
   chokepointFlowsRelayHeartbeat: 'relay:heartbeat:chokepoint-flows',
   climateNewsRelayHeartbeat:     'relay:heartbeat:climate-news',
+  telegramFeed:                  'intelligence:telegram-feed:v1',
 };
 
 const SEED_META = {
@@ -258,6 +259,7 @@ const SEED_META = {
   spending:         { key: 'seed-meta:economic:spending',          maxStaleMin: 120 },
   techEvents:       { key: 'seed-meta:research:tech-events',       maxStaleMin: 480 },
   gdeltIntel:       { key: 'seed-meta:intelligence:gdelt-intel',   maxStaleMin: 420 }, // 6h cron + 1h grace; CACHE_TTL is 24h so per-topic merge always has a prior snapshot
+  telegramFeed:     { key: 'seed-meta:intelligence:telegram-feed:v1', maxStaleMin: 10 }, // 60s poll interval; 10min grace catches poll failures before they go stale in the panel
   forecasts:        { key: 'seed-meta:forecast:predictions',       maxStaleMin: 90 },
   sectors:          { key: 'seed-meta:market:sectors',             maxStaleMin: 30 },
   techReadiness:    { key: 'seed-meta:economic:worldbank-techreadiness:v1', maxStaleMin: 10080 },

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -640,6 +640,23 @@ function normalizeTelegramMessage(msg, channel) {
 
 let telegramPermanentlyDisabled = false;
 
+function destroyTelegramClient() {
+  const client = telegramState.client;
+  telegramState.client = null;
+  if (!client) return;
+  try { client.disconnect(); } catch {}
+  try {
+    if (client._sender) {
+      client._sender._reconnecting = false;
+      client._sender._autoReconnect = false;
+      if (client._sender._connection) {
+        try { client._sender._connection.socket?.destroy?.(); } catch {}
+        try { client._sender._connection.close?.(); } catch {}
+      }
+    }
+  } catch {}
+}
+
 async function initTelegramClientIfNeeded() {
   if (!TELEGRAM_ENABLED) return false;
   if (telegramState.client) return true;
@@ -676,6 +693,7 @@ async function initTelegramClientIfNeeded() {
       telegramPermanentlyDisabled = true;
       telegramState.lastError = 'session invalidated (AUTH_KEY_DUPLICATED) — generate a new TELEGRAM_SESSION';
       console.error('[Relay] Telegram session permanently invalidated (AUTH_KEY_DUPLICATED). Generate a new session with: node scripts/telegram/session-auth.mjs');
+      destroyTelegramClient();
       return false;
     }
     telegramState.lastError = `telegram init failed: ${em}`;
@@ -752,8 +770,7 @@ async function pollTelegramOnce() {
         telegramPermanentlyDisabled = true;
         telegramState.lastError = 'session invalidated (AUTH_KEY_DUPLICATED) — generate a new TELEGRAM_SESSION';
         console.error('[Relay] Telegram session permanently invalidated (AUTH_KEY_DUPLICATED). Generate a new session with: node scripts/telegram/session-auth.mjs');
-        try { telegramState.client?.disconnect(); } catch {}
-        telegramState.client = null;
+        destroyTelegramClient();
         break;
       }
       if (/FLOOD_WAIT/.test(em)) {
@@ -779,6 +796,19 @@ async function pollTelegramOnce() {
   telegramState.lastPollAt = Date.now();
   const elapsed = ((Date.now() - pollStart) / 1000).toFixed(1);
   console.log(`[Relay] Telegram poll: ${channelsPolled}/${channels.length} channels, ${newItems.length} new msgs, ${telegramState.items.length} total, ${channelsFailed} errors, ${mediaSkipped} media-only skipped (${elapsed}s)`);
+
+  if (channelsPolled > 0) {
+    const rc = telegramState.items.length;
+    upstashSet('intelligence:telegram-feed:v1', {
+      count: rc,
+      updatedAt: new Date().toISOString(),
+      enabled: true,
+    }, 600).catch(() => {});
+    upstashSet('seed-meta:intelligence:telegram-feed:v1', {
+      fetchedAt: Date.now(),
+      recordCount: rc,
+    }, 600).catch(() => {});
+  }
 }
 
 let telegramPollInFlight = false;
@@ -801,7 +831,7 @@ function guardedTelegramPoll() {
     .finally(() => { telegramPollInFlight = false; });
 }
 
-const TELEGRAM_STARTUP_DELAY_MS = Math.max(0, Number(process.env.TELEGRAM_STARTUP_DELAY_MS || 60_000));
+const TELEGRAM_STARTUP_DELAY_MS = Math.max(0, Number(process.env.TELEGRAM_STARTUP_DELAY_MS || 120_000));
 
 function startTelegramPollLoop() {
   if (!TELEGRAM_ENABLED) return;
@@ -10986,16 +11016,19 @@ async function gracefulShutdown(signal) {
     try {
       await Promise.race([
         telegramState.client.disconnect(),
-        new Promise(r => setTimeout(r, 3000)),
+        new Promise(r => setTimeout(r, 10_000)),
       ]);
-    } catch {}
-    telegramState.client = null;
+      console.log('[Relay] Telegram client disconnected cleanly');
+    } catch (e) {
+      console.warn('[Relay] Telegram disconnect error (non-fatal):', e?.message || e);
+    }
+    destroyTelegramClient();
   }
   if (upstreamSocket) {
     try { upstreamSocket.close(); } catch {}
   }
   server.close(() => process.exit(0));
-  setTimeout(() => process.exit(0), 5000);
+  setTimeout(() => process.exit(0), 12_000);
 }
 process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
 process.on('SIGINT', () => gracefulShutdown('SIGINT'));

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -668,11 +668,12 @@ async function initTelegramClientIfNeeded() {
 
   if (!apiId || !apiHash || !sessionStr) return false;
 
+  let client;
   try {
     const { TelegramClient } = await import('telegram');
     const { StringSession } = await import('telegram/sessions/index.js');
 
-    const client = new TelegramClient(new StringSession(sessionStr), apiId, apiHash, {
+    client = new TelegramClient(new StringSession(sessionStr), apiId, apiHash, {
       connectionRetries: 3,
     });
 
@@ -689,11 +690,17 @@ async function initTelegramClientIfNeeded() {
       console.warn('[Relay] Telegram package not installed — disabling permanently for this session');
       return false;
     }
+    // Destroy the locally-created client directly — telegramState.client
+    // is still null because connect() failed before the assignment. Without
+    // this, the MTProto sender's autonomous reconnect loop keeps running.
+    if (client) {
+      telegramState.client = client;
+      destroyTelegramClient();
+    }
     if (/AUTH_KEY_DUPLICATED/.test(em)) {
       telegramPermanentlyDisabled = true;
       telegramState.lastError = 'session invalidated (AUTH_KEY_DUPLICATED) — generate a new TELEGRAM_SESSION';
       console.error('[Relay] Telegram session permanently invalidated (AUTH_KEY_DUPLICATED). Generate a new session with: node scripts/telegram/session-auth.mjs');
-      destroyTelegramClient();
       return false;
     }
     telegramState.lastError = `telegram init failed: ${em}`;

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -799,15 +799,20 @@ async function pollTelegramOnce() {
 
   if (channelsPolled > 0) {
     const rc = telegramState.items.length;
+    // Data key TTL must outlive maxStaleMin (10 min = 600s) by enough
+    // buffer so health sees hasData=true + stale seed-meta → STALE_SEED.
+    // If both keys expire together, health jumps straight to EMPTY and
+    // the stale window is never visible. 1800s (30 min) data vs 900s
+    // (15 min) meta gives a 15-min STALE_SEED window before EMPTY.
     upstashSet('intelligence:telegram-feed:v1', {
       count: rc,
       updatedAt: new Date().toISOString(),
       enabled: true,
-    }, 600).catch(() => {});
+    }, 1800).catch(() => {});
     upstashSet('seed-meta:intelligence:telegram-feed:v1', {
       fetchedAt: Date.now(),
       recordCount: rc,
-    }, 600).catch(() => {});
+    }, 900).catch(() => {});
   }
 }
 


### PR DESCRIPTION
## Summary

Addresses the AUTH_KEY_DUPLICATED outage that silently emptied the Telegram Intel panel with zero health signal.

- **Disconnect timeout 3s → 10s**: the MTProto disconnect handshake was timing out, leaving the old session alive past the new container's startup delay. Startup delay also increased 60s → 120s.
- **Health registration**: `telegramFeed` added to STANDALONE_KEYS + SEED_META (maxStaleMin=10). Relay writes `intelligence:telegram-feed:v1` + `seed-meta:intelligence:telegram-feed:v1` on each successful poll. When the poll stops, health surfaces STALE_SEED within 10 minutes.
- **Zombie recv loop cleanup**: new `destroyTelegramClient()` tears down the MTProto sender's internal reconnect loop and socket, stopping the 90s crash/reconnect log spam after AUTH_KEY_DUPLICATED.

## Test plan

- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `node -c scripts/ais-relay.cjs`
- [x] `node --test tests/edge-functions.test.mjs` (169 pass)
- [x] `npm run test:data` (0 fail)
- [ ] After merge + deploy: verify `curl <RELAY_URL>/health | jq .telegram` shows `enabled: true`, `items: > 0`, `lastPollAt` recent. Verify `/api/health` shows `telegramFeed: OK`.
- [ ] On next redeploy: verify no AUTH_KEY_DUPLICATED in logs (old container disconnects cleanly within 10s, new container waits 120s).

## Post-Deploy Monitoring & Validation

- **What to monitor**: `api/health` for `telegramFeed` status. Railway logs for `[Relay] Telegram poll:` lines.
- **Expected healthy behavior**: `telegramFeed: OK` in health, non-zero items count, poll lines every 60s.
- **Failure signal**: `telegramFeed: STALE_SEED` after 10 minutes of no polls. `AUTH_KEY_DUPLICATED` in logs = session needs regen.
- **Validation window**: 24h post-deploy, one redeploy cycle.