### PR TITLE
feat(brief): hosted magazine edge route + latest-brief preview RPC (Phase 2)

### DIFF
--- a/api/_upstash-json.js
+++ b/api/_upstash-json.js
@@ -32,6 +32,15 @@ export async function readJsonFromUpstash(key, timeoutMs = 3_000) {
  * the per-user brief envelope `{version, issuedAt, data}` whose
  * outer frame must reach the consumer.
  *
+ * Semantics:
+ *   - Returns the parsed value on a hit.
+ *   - Returns `null` ONLY on a genuine miss (Upstash replied 200 with
+ *     no result field).
+ *   - Throws on every other failure mode (missing credentials, HTTP
+ *     non-2xx, timeout/abort, JSON parse failure). Callers MUST
+ *     distinguish infrastructure failure from empty-state to avoid
+ *     showing users "composing" / "expired" UX during an outage.
+ *
  * @param {string} key
  * @param {number} [timeoutMs=3000]
  * @returns {Promise<unknown | null>}
@@ -39,19 +48,25 @@ export async function readJsonFromUpstash(key, timeoutMs = 3_000) {
 export async function readRawJsonFromUpstash(key, timeoutMs = 3_000) {
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return null;
+  if (!url || !token) {
+    throw new Error('readRawJsonFromUpstash: UPSTASH_REDIS_REST_URL/TOKEN not configured');
+  }
 
+  const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!resp.ok) {
+    throw new Error(`readRawJsonFromUpstash: Upstash GET ${key} returned HTTP ${resp.status}`);
+  }
+  const data = await resp.json();
+  if (data.result == null) return null; // genuine miss
   try {
-    const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-    if (!resp.ok) return null;
-    const data = await resp.json();
-    if (!data.result) return null;
     return JSON.parse(data.result);
-  } catch {
-    return null;
+  } catch (err) {
+    throw new Error(
+      `readRawJsonFromUpstash: JSON.parse failed for ${key}: ${(err instanceof Error ? err.message : String(err))}`,
+    );
   }
 }
 

--- a/api/_upstash-json.js
+++ b/api/_upstash-json.js
@@ -25,6 +25,36 @@ export async function readJsonFromUpstash(key, timeoutMs = 3_000) {
   }
 }
 
+/**
+ * Raw GET on a Redis key. Returns the parsed JSON value (or bare
+ * string for non-JSON) without applying seed-envelope unwrap. Use
+ * this for caches whose stored shape is NOT `{_seed, data}` — e.g.
+ * the per-user brief envelope `{version, issuedAt, data}` whose
+ * outer frame must reach the consumer.
+ *
+ * @param {string} key
+ * @param {number} [timeoutMs=3000]
+ * @returns {Promise<unknown | null>}
+ */
+export async function readRawJsonFromUpstash(key, timeoutMs = 3_000) {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  try {
+    const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    if (!data.result) return null;
+    return JSON.parse(data.result);
+  } catch {
+    return null;
+  }
+}
+
 /** Returns Redis credentials or null if not configured. */
 export function getRedisCredentials() {
   const url = process.env.UPSTASH_REDIS_REST_URL;

--- a/api/brief/[userId]/[issueDate].ts
+++ b/api/brief/[userId]/[issueDate].ts
@@ -23,8 +23,9 @@ export const config = { runtime: 'edge' };
 
 // @ts-expect-error — JS module, no declaration file
 import { getCorsHeaders, isDisallowedOrigin } from '../../_cors.js';
+import { renderBriefMagazine } from '../../../server/_shared/brief-render.js';
 // @ts-expect-error — JS module, no declaration file
-import { renderBriefMagazine } from '../../../shared/render-brief-magazine.js';
+import { readRawJsonFromUpstash } from '../../_upstash-json.js';
 import { verifyBriefToken, BriefUrlError } from '../../../server/_shared/brief-url';
 
 const HTML_HEADERS = {
@@ -34,62 +35,58 @@ const HTML_HEADERS = {
   'Referrer-Policy': 'no-referrer',
 };
 
-function htmlResponse(status: number, body: string, extraHeaders: Record<string, string> = {}): Response {
-  return new Response(body, {
+function htmlResponse(
+  req: Request,
+  status: number,
+  body: string,
+  extraHeaders: Record<string, string> = {},
+): Response {
+  // HEAD must carry the same headers as GET but with an empty body
+  // (RFC 7231 §4.3.2). We do this at the response-layer instead of
+  // every call site to prevent drift.
+  const isHead = req.method === 'HEAD';
+  return new Response(isHead ? null : body, {
     status,
     headers: { ...HTML_HEADERS, ...extraHeaders },
   });
 }
 
-const EXPIRED_PAGE = `<!DOCTYPE html><html lang="en"><head>
-<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Brief unavailable · WorldMonitor</title>
-<style>
-body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
-  font-family: Georgia, serif; background: #0a0a0a; color: #f2ede4; text-align: center; padding: 2rem; }
-h1 { font-size: clamp(28px, 5vw, 64px); margin: 0 0 1rem; font-weight: 900; letter-spacing: -0.02em; }
-p { max-width: 48ch; opacity: 0.8; line-height: 1.5; font-size: clamp(16px, 2vw, 20px); }
-a { color: inherit; text-decoration: underline; }
-</style></head><body><div>
-<h1>This brief has expired.</h1>
-<p>Briefs are kept for seven days after they are issued. Your next brief will be delivered on schedule.</p>
-<p><a href="https://worldmonitor.app">Return to WorldMonitor</a></p>
-</div></body></html>`;
+const ERROR_PAGE_STYLES = (
+  'body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center; '
+  + 'font-family: Georgia, serif; background: #0a0a0a; color: #f2ede4; text-align: center; padding: 2rem; } '
+  + 'h1 { font-size: clamp(28px, 5vw, 64px); margin: 0 0 1rem; font-weight: 900; letter-spacing: -0.02em; } '
+  + 'p { max-width: 48ch; opacity: 0.8; line-height: 1.5; font-size: clamp(16px, 2vw, 20px); } '
+  + 'a { color: inherit; text-decoration: underline; }'
+);
 
-const FORBIDDEN_PAGE = `<!DOCTYPE html><html lang="en"><head>
-<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Not authorised · WorldMonitor</title>
-<style>
-body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
-  font-family: Georgia, serif; background: #0a0a0a; color: #f2ede4; text-align: center; padding: 2rem; }
-h1 { font-size: clamp(28px, 5vw, 64px); margin: 0 0 1rem; font-weight: 900; letter-spacing: -0.02em; }
-p { max-width: 48ch; opacity: 0.8; line-height: 1.5; font-size: clamp(16px, 2vw, 20px); }
-a { color: inherit; text-decoration: underline; }
-</style></head><body><div>
-<h1>This link is no longer valid.</h1>
-<p>The brief link you followed is incomplete or has been tampered with. Open the most recent notification from WorldMonitor to read today's brief.</p>
-<p><a href="https://worldmonitor.app">Return to WorldMonitor</a></p>
-</div></body></html>`;
-
-async function readBriefEnvelope(userId: string, issueDate: string): Promise<unknown | null> {
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return null;
-
-  const key = `brief:${userId}:${issueDate}`;
-  try {
-    const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(3_000),
-    });
-    if (!resp.ok) return null;
-    const body = (await resp.json()) as { result?: string | null };
-    if (!body.result) return null;
-    return JSON.parse(body.result);
-  } catch {
-    return null;
-  }
+function renderErrorPage(heading: string, body: string): string {
+  return (
+    '<!DOCTYPE html><html lang="en"><head>'
+    + '<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1">'
+    + `<title>${heading} · WorldMonitor</title>`
+    + `<style>${ERROR_PAGE_STYLES}</style>`
+    + '</head><body><div>'
+    + `<h1>${heading}</h1>`
+    + `<p>${body}</p>`
+    + '<p><a href="https://worldmonitor.app">Return to WorldMonitor</a></p>'
+    + '</div></body></html>'
+  );
 }
+
+const EXPIRED_PAGE = renderErrorPage(
+  'This brief has expired.',
+  'Briefs are kept for seven days after they are issued. Your next brief will be delivered on schedule.',
+);
+
+const FORBIDDEN_PAGE = renderErrorPage(
+  'This link is no longer valid.',
+  "The brief link you followed is incomplete or has been tampered with. Open the most recent notification from WorldMonitor to read today's brief.",
+);
+
+const UNAVAILABLE_PAGE = renderErrorPage(
+  'Service temporarily unavailable.',
+  'The brief service is not fully configured. Please try again shortly.',
+);
 
 export default async function handler(req: Request): Promise<Response> {
   if (isDisallowedOrigin(req)) {
@@ -109,7 +106,7 @@ export default async function handler(req: Request): Promise<Response> {
   const prevSecret = process.env.BRIEF_URL_SIGNING_SECRET_PREV || undefined;
   if (!secret) {
     console.error('[api/brief] BRIEF_URL_SIGNING_SECRET is not configured');
-    return htmlResponse(503, '<h1>Service temporarily unavailable.</h1>');
+    return htmlResponse(req, 503, UNAVAILABLE_PAGE);
   }
 
   // Extract path params from URL. Vercel edge functions surface them
@@ -120,7 +117,7 @@ export default async function handler(req: Request): Promise<Response> {
   // Expect: ['api', 'brief', '{userId}', '{issueDate}']
   const [root, route, rawUserId, rawIssueDate] = parts;
   if (parts.length !== 4 || root !== 'api' || route !== 'brief' || !rawUserId || !rawIssueDate) {
-    return htmlResponse(404, EXPIRED_PAGE);
+    return htmlResponse(req, 404, EXPIRED_PAGE);
   }
   const userId = decodeURIComponent(rawUserId);
   const issueDate = decodeURIComponent(rawIssueDate);
@@ -132,17 +129,17 @@ export default async function handler(req: Request): Promise<Response> {
   } catch (err) {
     if (err instanceof BriefUrlError && err.code === 'missing_secret') {
       console.error('[api/brief] secret missing after handler start — env misconfigured');
-      return htmlResponse(503, '<h1>Service temporarily unavailable.</h1>');
+      return htmlResponse(req, 503, UNAVAILABLE_PAGE);
     }
     throw err;
   }
   if (!verified) {
-    return htmlResponse(403, FORBIDDEN_PAGE);
+    return htmlResponse(req, 403, FORBIDDEN_PAGE);
   }
 
-  const envelope = await readBriefEnvelope(userId, issueDate);
+  const envelope = await readRawJsonFromUpstash(`brief:${userId}:${issueDate}`);
   if (!envelope) {
-    return htmlResponse(404, EXPIRED_PAGE);
+    return htmlResponse(req, 404, EXPIRED_PAGE);
   }
 
   let html: string;
@@ -153,9 +150,11 @@ export default async function handler(req: Request): Promise<Response> {
     // We treat this as an expired brief from the reader's perspective
     // and log the details server-side. The renderer's assertion
     // message is safe to log (no secrets, no user content).
-    console.error('[api/brief] renderBriefMagazine failed:', (err as Error).message);
-    return htmlResponse(404, EXPIRED_PAGE);
+    console.error('[api/brief] malformed envelope for brief:*:*:', (err as Error).message);
+    // Distinct log tag so ops can grep composer-bug vs Redis-miss. User
+    // still sees the neutral "expired" page.
+    return htmlResponse(req, 404, EXPIRED_PAGE);
   }
 
-  return htmlResponse(200, html);
+  return htmlResponse(req, 200, html);
 }

--- a/api/brief/[userId]/[issueDate].ts
+++ b/api/brief/[userId]/[issueDate].ts
@@ -137,14 +137,28 @@ export default async function handler(req: Request): Promise<Response> {
     return htmlResponse(req, 403, FORBIDDEN_PAGE);
   }
 
-  const envelope = await readRawJsonFromUpstash(`brief:${userId}:${issueDate}`);
+  // The helper throws on infrastructure failure (Upstash down, config
+  // missing, parse failure). Only a genuine miss returns null. We must
+  // distinguish those two — a reader with a valid brief deserves a
+  // "service unavailable" state during outages, not a misleading
+  // "expired" page.
+  let envelope: unknown;
+  try {
+    envelope = await readRawJsonFromUpstash(`brief:${userId}:${issueDate}`);
+  } catch (err) {
+    console.error('[api/brief] Upstash read failed:', (err as Error).message);
+    return htmlResponse(req, 503, UNAVAILABLE_PAGE);
+  }
   if (!envelope) {
     return htmlResponse(req, 404, EXPIRED_PAGE);
   }
 
+  // Cast to BriefEnvelope; renderBriefMagazine runs its own
+  // assertBriefEnvelope at the top and will throw on any shape
+  // mismatch, which we catch below.
   let html: string;
   try {
-    html = renderBriefMagazine(envelope);
+    html = renderBriefMagazine(envelope as Parameters<typeof renderBriefMagazine>[0]);
   } catch (err) {
     // Malformed envelope in Redis (composer bug, version drift, etc.)
     // We treat this as an expired brief from the reader's perspective

--- a/api/brief/[userId]/[issueDate].ts
+++ b/api/brief/[userId]/[issueDate].ts
@@ -1,0 +1,161 @@
+/**
+ * Public brief magazine endpoint.
+ *
+ * GET /api/brief/{userId}/{issueDate}?t={token}
+ *   -> 200 text/html (rendered magazine)
+ *   -> 403 on bad token (generic message, no userId echo)
+ *   -> 404 on Redis miss (minimal "expired" HTML)
+ *   -> 503 if BRIEF_URL_SIGNING_SECRET is not configured
+ *
+ * The HMAC-signed token in `?t=` is the sole credential. The route is
+ * auth-less in the Clerk sense — whoever holds a valid URL can read
+ * the magazine. URLs are delivered to users via already-authenticated
+ * channels (push, email, dashboard panel).
+ *
+ * The Redis key brief:{userId}:{issueDate} is per-user and written by
+ * the Phase 3 composer (not yet shipped). Until then every request
+ * will 404 with a neutral expired page. That is intentional and
+ * correct behaviour — the route is safe to deploy ahead of the
+ * composer.
+ */
+
+export const config = { runtime: 'edge' };
+
+// @ts-expect-error — JS module, no declaration file
+import { getCorsHeaders, isDisallowedOrigin } from '../../_cors.js';
+// @ts-expect-error — JS module, no declaration file
+import { renderBriefMagazine } from '../../../shared/render-brief-magazine.js';
+import { verifyBriefToken, BriefUrlError } from '../../../server/_shared/brief-url';
+
+const HTML_HEADERS = {
+  'Content-Type': 'text/html; charset=utf-8',
+  'Cache-Control': 'private, max-age=0, must-revalidate',
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'no-referrer',
+};
+
+function htmlResponse(status: number, body: string, extraHeaders: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status,
+    headers: { ...HTML_HEADERS, ...extraHeaders },
+  });
+}
+
+const EXPIRED_PAGE = `<!DOCTYPE html><html lang="en"><head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Brief unavailable · WorldMonitor</title>
+<style>
+body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
+  font-family: Georgia, serif; background: #0a0a0a; color: #f2ede4; text-align: center; padding: 2rem; }
+h1 { font-size: clamp(28px, 5vw, 64px); margin: 0 0 1rem; font-weight: 900; letter-spacing: -0.02em; }
+p { max-width: 48ch; opacity: 0.8; line-height: 1.5; font-size: clamp(16px, 2vw, 20px); }
+a { color: inherit; text-decoration: underline; }
+</style></head><body><div>
+<h1>This brief has expired.</h1>
+<p>Briefs are kept for seven days after they are issued. Your next brief will be delivered on schedule.</p>
+<p><a href="https://worldmonitor.app">Return to WorldMonitor</a></p>
+</div></body></html>`;
+
+const FORBIDDEN_PAGE = `<!DOCTYPE html><html lang="en"><head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Not authorised · WorldMonitor</title>
+<style>
+body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
+  font-family: Georgia, serif; background: #0a0a0a; color: #f2ede4; text-align: center; padding: 2rem; }
+h1 { font-size: clamp(28px, 5vw, 64px); margin: 0 0 1rem; font-weight: 900; letter-spacing: -0.02em; }
+p { max-width: 48ch; opacity: 0.8; line-height: 1.5; font-size: clamp(16px, 2vw, 20px); }
+a { color: inherit; text-decoration: underline; }
+</style></head><body><div>
+<h1>This link is no longer valid.</h1>
+<p>The brief link you followed is incomplete or has been tampered with. Open the most recent notification from WorldMonitor to read today's brief.</p>
+<p><a href="https://worldmonitor.app">Return to WorldMonitor</a></p>
+</div></body></html>`;
+
+async function readBriefEnvelope(userId: string, issueDate: string): Promise<unknown | null> {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  const key = `brief:${userId}:${issueDate}`;
+  try {
+    const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(3_000),
+    });
+    if (!resp.ok) return null;
+    const body = (await resp.json()) as { result?: string | null };
+    if (!body.result) return null;
+    return JSON.parse(body.result);
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(req: Request): Promise<Response> {
+  if (isDisallowedOrigin(req)) {
+    return new Response('Origin not allowed', { status: 403 });
+  }
+
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: cors });
+  }
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    return new Response('Method not allowed', { status: 405, headers: cors });
+  }
+
+  const secret = process.env.BRIEF_URL_SIGNING_SECRET ?? '';
+  const prevSecret = process.env.BRIEF_URL_SIGNING_SECRET_PREV || undefined;
+  if (!secret) {
+    console.error('[api/brief] BRIEF_URL_SIGNING_SECRET is not configured');
+    return htmlResponse(503, '<h1>Service temporarily unavailable.</h1>');
+  }
+
+  // Extract path params from URL. Vercel edge functions surface them
+  // via the URL pathname; we parse directly to avoid a runtime dep on
+  // a route-params helper that may not be available.
+  const url = new URL(req.url);
+  const parts = url.pathname.split('/').filter(Boolean);
+  // Expect: ['api', 'brief', '{userId}', '{issueDate}']
+  const [root, route, rawUserId, rawIssueDate] = parts;
+  if (parts.length !== 4 || root !== 'api' || route !== 'brief' || !rawUserId || !rawIssueDate) {
+    return htmlResponse(404, EXPIRED_PAGE);
+  }
+  const userId = decodeURIComponent(rawUserId);
+  const issueDate = decodeURIComponent(rawIssueDate);
+  const token = url.searchParams.get('t') ?? '';
+
+  let verified: boolean;
+  try {
+    verified = await verifyBriefToken(userId, issueDate, token, secret, prevSecret);
+  } catch (err) {
+    if (err instanceof BriefUrlError && err.code === 'missing_secret') {
+      console.error('[api/brief] secret missing after handler start — env misconfigured');
+      return htmlResponse(503, '<h1>Service temporarily unavailable.</h1>');
+    }
+    throw err;
+  }
+  if (!verified) {
+    return htmlResponse(403, FORBIDDEN_PAGE);
+  }
+
+  const envelope = await readBriefEnvelope(userId, issueDate);
+  if (!envelope) {
+    return htmlResponse(404, EXPIRED_PAGE);
+  }
+
+  let html: string;
+  try {
+    html = renderBriefMagazine(envelope);
+  } catch (err) {
+    // Malformed envelope in Redis (composer bug, version drift, etc.)
+    // We treat this as an expired brief from the reader's perspective
+    // and log the details server-side. The renderer's assertion
+    // message is safe to log (no secrets, no user content).
+    console.error('[api/brief] renderBriefMagazine failed:', (err as Error).message);
+    return htmlResponse(404, EXPIRED_PAGE);
+  }
+
+  return htmlResponse(200, html);
+}

--- a/api/latest-brief.ts
+++ b/api/latest-brief.ts
@@ -31,13 +31,16 @@ import { validateBearerToken } from '../server/auth-session';
 import { getEntitlements } from '../server/_shared/entitlement-check';
 import { signBriefUrl, BriefUrlError } from '../server/_shared/brief-url';
 
+const ISSUE_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
 function todayInUtc(): string {
-  // Composer is the source of truth for the per-user issue date (it
-  // may roll on the user's tz). This UTC default exists only to pick
-  // a probable slot during the preview-call window; expect it to
-  // diverge from the composer's slot occasionally and fall back to
-  // the `composing` branch when that happens.
   return new Date().toISOString().slice(0, 10);
+}
+
+function yesterdayInUtc(): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
 }
 
 async function readBriefPreview(
@@ -129,11 +132,44 @@ export default async function handler(req: Request): Promise<Response> {
     return jsonResponse({ error: 'service_unavailable' }, 503, cors);
   }
 
-  const issueDate = todayInUtc();
-  const preview = await readBriefPreview(session.userId, issueDate);
+  // Determine which issue slot to probe.
+  //  - If the client passes ?date=YYYY-MM-DD, use that verbatim. This
+  //    is the path the dashboard panel should use: it knows its own
+  //    local tz and computes the user's local date.
+  //  - Otherwise fall back to today UTC, then yesterday UTC. A user
+  //    in a non-UTC tz will often see their most recent brief sit
+  //    under the composer's per-user slot while UTC has already
+  //    rolled over; the walk-back covers that window without needing
+  //    a tz library.
+  const url = new URL(req.url);
+  const dateParam = url.searchParams.get('date');
+  if (dateParam !== null && !ISSUE_DATE_RE.test(dateParam)) {
+    return jsonResponse({ error: 'invalid_date_shape' }, 400, cors);
+  }
+  const todayUtc = todayInUtc();
+  const candidates = dateParam ? [dateParam] : [todayUtc, yesterdayInUtc()];
 
-  if (!preview) {
-    return jsonResponse({ status: 'composing', issueDate }, 200, cors);
+  let issueDate: string | null = null;
+  let preview: { dateLong: string; greeting: string; threadCount: number } | null = null;
+  try {
+    for (const slot of candidates) {
+      const hit = await readBriefPreview(session.userId, slot);
+      if (hit) {
+        issueDate = slot;
+        preview = hit;
+        break;
+      }
+    }
+  } catch (err) {
+    // Upstash outage / config break / corrupt value — do NOT collapse
+    // this into "composing", which would falsely signal empty state
+    // to the dashboard panel. 503 lets the client show a retry path.
+    console.error('[api/latest-brief] Upstash read failed:', (err as Error).message);
+    return jsonResponse({ error: 'service_unavailable' }, 503, cors);
+  }
+
+  if (!preview || !issueDate) {
+    return jsonResponse({ status: 'composing', issueDate: todayUtc }, 200, cors);
   }
 
   let magazineUrl: string;

--- a/api/latest-brief.ts
+++ b/api/latest-brief.ts
@@ -1,0 +1,170 @@
+/**
+ * Latest-brief preview endpoint.
+ *
+ * GET /api/latest-brief (Clerk JWT required, PRO tier gated)
+ *   -> 200 { issueDate, dateLong, greeting, threadCount, magazineUrl }
+ *      when a composed brief exists for this user.
+ *   -> 200 { status: 'composing' }  when the composer has not yet
+ *      produced today's brief. The dashboard panel uses this to
+ *      render an empty state instead of an error.
+ *   -> 401 UNAUTHENTICATED on missing/bad JWT
+ *   -> 403 pro_required for non-PRO users
+ *   -> 503 if BRIEF_URL_SIGNING_SECRET is not configured
+ *
+ * The returned magazineUrl is freshly signed per request. It is safe
+ * to expose to the authenticated client — the HMAC binds {userId,
+ * issueDate} so it is only useful to the owner.
+ *
+ * The route does NOT drive composition. It is a read-only mirror of
+ * whatever brief:{userId}:{issueDate} Redis happens to hold.
+ */
+
+export const config = { runtime: 'edge' };
+
+// @ts-expect-error — JS module, no declaration file
+import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+// @ts-expect-error — JS module, no declaration file
+import { jsonResponse } from './_json-response.js';
+import { validateBearerToken } from '../server/auth-session';
+import { getEntitlements } from '../server/_shared/entitlement-check';
+import { signBriefUrl, BriefUrlError } from '../server/_shared/brief-url';
+
+function todayInUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function readBriefPreview(
+  userId: string,
+  issueDate: string,
+): Promise<{ dateLong: string; greeting: string; threadCount: number } | null> {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  const key = `brief:${userId}:${issueDate}`;
+  try {
+    const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(3_000),
+    });
+    if (!resp.ok) return null;
+    const body = (await resp.json()) as { result?: string | null };
+    if (!body.result) return null;
+    const envelope = JSON.parse(body.result) as {
+      data?: {
+        dateLong?: unknown;
+        digest?: { greeting?: unknown };
+        stories?: unknown[];
+      };
+    };
+    const data = envelope?.data;
+    if (
+      !data
+      || typeof data.dateLong !== 'string'
+      || !data.digest
+      || typeof data.digest.greeting !== 'string'
+      || !Array.isArray(data.stories)
+    ) {
+      return null;
+    }
+    return {
+      dateLong: data.dateLong,
+      greeting: data.digest.greeting,
+      threadCount: data.stories.length,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function publicBaseUrl(req: Request): string {
+  const forwardedHost = req.headers.get('x-forwarded-host') ?? req.headers.get('host');
+  const forwardedProto = req.headers.get('x-forwarded-proto') ?? 'https';
+  if (forwardedHost) return `${forwardedProto}://${forwardedHost}`;
+  // Fallback to the request URL's origin if headers are missing.
+  return new URL(req.url).origin;
+}
+
+export default async function handler(req: Request): Promise<Response> {
+  if (isDisallowedOrigin(req)) {
+    return jsonResponse({ error: 'Origin not allowed' }, 403);
+  }
+
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: cors });
+  }
+  if (req.method !== 'GET') {
+    return jsonResponse({ error: 'Method not allowed' }, 405, cors);
+  }
+
+  const authHeader = req.headers.get('Authorization') ?? '';
+  const jwt = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+  if (!jwt) {
+    return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
+  }
+
+  const session = await validateBearerToken(jwt);
+  if (!session.valid || !session.userId) {
+    return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
+  }
+
+  const ent = await getEntitlements(session.userId);
+  if (!ent || ent.features.tier < 1) {
+    return jsonResponse(
+      {
+        error: 'pro_required',
+        message: 'The Brief is available on the Pro plan.',
+        upgradeUrl: 'https://worldmonitor.app/pro',
+      },
+      403,
+      cors,
+    );
+  }
+
+  const secret = process.env.BRIEF_URL_SIGNING_SECRET ?? '';
+  if (!secret) {
+    console.error('[api/latest-brief] BRIEF_URL_SIGNING_SECRET is not configured');
+    return jsonResponse({ error: 'service_unavailable' }, 503, cors);
+  }
+
+  const issueDate = todayInUtc();
+  const preview = await readBriefPreview(session.userId, issueDate);
+
+  if (!preview) {
+    return jsonResponse({ status: 'composing', issueDate }, 200, cors);
+  }
+
+  let magazineUrl: string;
+  try {
+    magazineUrl = await signBriefUrl({
+      userId: session.userId,
+      issueDate,
+      baseUrl: publicBaseUrl(req),
+      secret,
+    });
+  } catch (err) {
+    if (err instanceof BriefUrlError && err.code === 'invalid_user_id') {
+      // Clerk userId should always match our shape, but if it does
+      // not we want to log and fail clean rather than expose the raw
+      // id in a stack trace.
+      console.error('[api/latest-brief] Clerk userId failed shape check');
+      return jsonResponse({ error: 'service_unavailable' }, 503, cors);
+    }
+    throw err;
+  }
+
+  return jsonResponse(
+    {
+      status: 'ready',
+      issueDate,
+      dateLong: preview.dateLong,
+      greeting: preview.greeting,
+      threadCount: preview.threadCount,
+      magazineUrl,
+    },
+    200,
+    cors,
+  );
+}

--- a/api/latest-brief.ts
+++ b/api/latest-brief.ts
@@ -30,44 +30,40 @@ import { readRawJsonFromUpstash } from './_upstash-json.js';
 import { validateBearerToken } from '../server/auth-session';
 import { getEntitlements } from '../server/_shared/entitlement-check';
 import { signBriefUrl, BriefUrlError } from '../server/_shared/brief-url';
+import { assertBriefEnvelope } from '../server/_shared/brief-render.js';
 
 const ISSUE_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
-function todayInUtc(): string {
-  return new Date().toISOString().slice(0, 10);
+function utcDateOffset(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
 }
 
-function yesterdayInUtc(): string {
-  const d = new Date();
-  d.setUTCDate(d.getUTCDate() - 1);
-  return d.toISOString().slice(0, 10);
+function todayInUtc(): string {
+  return utcDateOffset(0);
 }
 
 async function readBriefPreview(
   userId: string,
   issueDate: string,
 ): Promise<{ dateLong: string; greeting: string; threadCount: number } | null> {
-  const envelope = (await readRawJsonFromUpstash(
-    `brief:${userId}:${issueDate}`,
-  )) as
-    | {
-        data?: {
-          dateLong?: unknown;
-          digest?: { greeting?: unknown };
-          stories?: unknown[];
-        };
-      }
-    | null;
-  const data = envelope?.data;
-  if (
-    !data
-    || typeof data.dateLong !== 'string'
-    || !data.digest
-    || typeof data.digest.greeting !== 'string'
-    || !Array.isArray(data.stories)
-  ) {
+  const raw = await readRawJsonFromUpstash(`brief:${userId}:${issueDate}`);
+  if (raw == null) return null;
+  // Reuse the renderer's strict validator so a "ready" preview never
+  // points at an envelope that the hosted magazine route will reject.
+  // A Redis-resident key that fails assertion is a composer bug — log
+  // and treat as a miss so the dashboard panel shows "composing"
+  // rather than "ready with a broken link".
+  try {
+    assertBriefEnvelope(raw);
+  } catch (err) {
+    console.error(
+      `[api/latest-brief] composer-bug: brief:${userId}:${issueDate} failed envelope assertion: ${(err as Error).message}`,
+    );
     return null;
   }
+  const { data } = raw;
   return {
     dateLong: data.dateLong,
     greeting: data.digest.greeting,
@@ -133,21 +129,25 @@ export default async function handler(req: Request): Promise<Response> {
   }
 
   // Determine which issue slot to probe.
-  //  - If the client passes ?date=YYYY-MM-DD, use that verbatim. This
-  //    is the path the dashboard panel should use: it knows its own
-  //    local tz and computes the user's local date.
-  //  - Otherwise fall back to today UTC, then yesterday UTC. A user
-  //    in a non-UTC tz will often see their most recent brief sit
-  //    under the composer's per-user slot while UTC has already
-  //    rolled over; the walk-back covers that window without needing
-  //    a tz library.
+  //  - If the client passes ?date=YYYY-MM-DD, use that verbatim. The
+  //    dashboard panel should always take this path — it knows the
+  //    user's local tz and computes the local date exactly.
+  //  - Otherwise walk [tomorrow, today, yesterday] UTC in that order.
+  //    The composer writes per user tz; a user at UTC+14 has today's
+  //    brief under tomorrow UTC, a user at UTC-12 has it under
+  //    yesterday UTC. Three candidates cover the full tz range
+  //    without needing a tz database in the edge runtime. The order
+  //    (tomorrow-first) naturally prefers the most recently composed
+  //    slot.
   const url = new URL(req.url);
   const dateParam = url.searchParams.get('date');
   if (dateParam !== null && !ISSUE_DATE_RE.test(dateParam)) {
     return jsonResponse({ error: 'invalid_date_shape' }, 400, cors);
   }
   const todayUtc = todayInUtc();
-  const candidates = dateParam ? [dateParam] : [todayUtc, yesterdayInUtc()];
+  const candidates = dateParam
+    ? [dateParam]
+    : [utcDateOffset(1), todayUtc, utcDateOffset(-1)];
 
   let issueDate: string | null = null;
   let preview: { dateLong: string; greeting: string; threadCount: number } | null = null;
@@ -169,7 +169,14 @@ export default async function handler(req: Request): Promise<Response> {
   }
 
   if (!preview || !issueDate) {
-    return jsonResponse({ status: 'composing', issueDate: todayUtc }, 200, cors);
+    // Echo the caller's date on miss when they supplied one — the
+    // client cares about THAT slot's status, not today UTC. Default
+    // to today UTC only when no date was given.
+    return jsonResponse(
+      { status: 'composing', issueDate: dateParam ?? todayUtc },
+      200,
+      cors,
+    );
   }
 
   let magazineUrl: string;

--- a/api/latest-brief.ts
+++ b/api/latest-brief.ts
@@ -25,11 +25,18 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { jsonResponse } from './_json-response.js';
+// @ts-expect-error — JS module, no declaration file
+import { readRawJsonFromUpstash } from './_upstash-json.js';
 import { validateBearerToken } from '../server/auth-session';
 import { getEntitlements } from '../server/_shared/entitlement-check';
 import { signBriefUrl, BriefUrlError } from '../server/_shared/brief-url';
 
 function todayInUtc(): string {
+  // Composer is the source of truth for the per-user issue date (it
+  // may roll on the user's tz). This UTC default exists only to pick
+  // a probable slot during the preview-call window; expect it to
+  // diverge from the composer's slot occasionally and fall back to
+  // the `composing` branch when that happens.
   return new Date().toISOString().slice(0, 10);
 }
 
@@ -37,51 +44,44 @@ async function readBriefPreview(
   userId: string,
   issueDate: string,
 ): Promise<{ dateLong: string; greeting: string; threadCount: number } | null> {
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return null;
-
-  const key = `brief:${userId}:${issueDate}`;
-  try {
-    const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(3_000),
-    });
-    if (!resp.ok) return null;
-    const body = (await resp.json()) as { result?: string | null };
-    if (!body.result) return null;
-    const envelope = JSON.parse(body.result) as {
-      data?: {
-        dateLong?: unknown;
-        digest?: { greeting?: unknown };
-        stories?: unknown[];
-      };
-    };
-    const data = envelope?.data;
-    if (
-      !data
-      || typeof data.dateLong !== 'string'
-      || !data.digest
-      || typeof data.digest.greeting !== 'string'
-      || !Array.isArray(data.stories)
-    ) {
-      return null;
-    }
-    return {
-      dateLong: data.dateLong,
-      greeting: data.digest.greeting,
-      threadCount: data.stories.length,
-    };
-  } catch {
+  const envelope = (await readRawJsonFromUpstash(
+    `brief:${userId}:${issueDate}`,
+  )) as
+    | {
+        data?: {
+          dateLong?: unknown;
+          digest?: { greeting?: unknown };
+          stories?: unknown[];
+        };
+      }
+    | null;
+  const data = envelope?.data;
+  if (
+    !data
+    || typeof data.dateLong !== 'string'
+    || !data.digest
+    || typeof data.digest.greeting !== 'string'
+    || !Array.isArray(data.stories)
+  ) {
     return null;
   }
+  return {
+    dateLong: data.dateLong,
+    greeting: data.digest.greeting,
+    threadCount: data.stories.length,
+  };
 }
 
+/**
+ * Public base URL for signed magazine links. Pinned to
+ * WORLDMONITOR_PUBLIC_BASE_URL in production to prevent host-header
+ * reflection from minting URLs pointing at preview deploys or other
+ * non-canonical origins. Falls back to the request origin only in
+ * dev-ish contexts where the env var is absent.
+ */
 function publicBaseUrl(req: Request): string {
-  const forwardedHost = req.headers.get('x-forwarded-host') ?? req.headers.get('host');
-  const forwardedProto = req.headers.get('x-forwarded-proto') ?? 'https';
-  if (forwardedHost) return `${forwardedProto}://${forwardedHost}`;
-  // Fallback to the request URL's origin if headers are missing.
+  const pinned = process.env.WORLDMONITOR_PUBLIC_BASE_URL;
+  if (pinned) return pinned.replace(/\/+$/, '');
   return new URL(req.url).origin;
 }
 

--- a/server/_shared/brief-render.d.ts
+++ b/server/_shared/brief-render.d.ts
@@ -1,3 +1,12 @@
 import type { BriefEnvelope } from '../../shared/brief-envelope.js';
 
 export function renderBriefMagazine(envelope: BriefEnvelope): string;
+
+/**
+ * Validates the entire envelope (closed-key contract, field shapes,
+ * version, and the `surfaced === stories.length` cross-field rule).
+ * Shared between the renderer (call site: `renderBriefMagazine`) and
+ * preview readers that must honour the same contract so a "ready"
+ * preview never points at an envelope the renderer will reject.
+ */
+export function assertBriefEnvelope(envelope: unknown): asserts envelope is BriefEnvelope;

--- a/server/_shared/brief-render.js
+++ b/server/_shared/brief-render.js
@@ -158,7 +158,7 @@ function assertNoExtraKeys(obj, allowed, path) {
  * @param {unknown} envelope
  * @returns {asserts envelope is BriefEnvelope}
  */
-function assertBriefEnvelope(envelope) {
+export function assertBriefEnvelope(envelope) {
   if (!isObject(envelope)) {
     throw new Error('renderBriefMagazine: envelope must be an object');
   }

--- a/server/_shared/brief-url.ts
+++ b/server/_shared/brief-url.ts
@@ -13,6 +13,16 @@
  * accept a token signed with either, so producers can roll the primary
  * secret without invalidating in-flight notifications.
  *
+ * Rotation runbook:
+ *   - Normal roll: set PREV = current, then replace SECRET with a
+ *     fresh value. Keep PREV set for at least the envelope TTL
+ *     (7 days) plus the push/email-delivery window so in-flight
+ *     notifications remain valid.
+ *   - Emergency kill switch (suspected secret leak): rotate SECRET
+ *     and do NOT set PREV. This invalidates every outstanding token
+ *     immediately. Accept the breakage of in-flight notifications
+ *     as the cost of containment.
+ *
  * All crypto goes through Web Crypto (`crypto.subtle`) so this module
  * runs unchanged in Vercel Edge, Node 18+, and Tauri.
  */
@@ -22,7 +32,7 @@ const ISSUE_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const TOKEN_RE = /^[A-Za-z0-9_-]{43}$/; // base64url(sha256) = 43 chars, no padding
 
 export class BriefUrlError extends Error {
-  readonly code: 'invalid_user_id' | 'invalid_issue_date' | 'invalid_token_shape' | 'missing_secret';
+  readonly code: 'invalid_user_id' | 'invalid_issue_date' | 'missing_secret';
 
   constructor(code: BriefUrlError['code'], message: string) {
     super(message);

--- a/server/_shared/brief-url.ts
+++ b/server/_shared/brief-url.ts
@@ -1,0 +1,169 @@
+/**
+ * HMAC-signed URL helpers for the WorldMonitor Brief magazine route.
+ *
+ * The hosted magazine at /api/brief/{userId}/{issueDate} is auth-less
+ * in the traditional sense (no Clerk session, no cookie). The signed
+ * token IS the credential: a recipient with the URL can read the
+ * magazine; without it, no. This matches the push / email delivery
+ * model where the token is delivered to the user through an already-
+ * authenticated channel.
+ *
+ * Secret rotation is supported: set BRIEF_URL_SIGNING_SECRET_PREV to
+ * the outgoing secret for the overlap window. `verifyBriefToken` will
+ * accept a token signed with either, so producers can roll the primary
+ * secret without invalidating in-flight notifications.
+ *
+ * All crypto goes through Web Crypto (`crypto.subtle`) so this module
+ * runs unchanged in Vercel Edge, Node 18+, and Tauri.
+ */
+
+const USER_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+const ISSUE_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const TOKEN_RE = /^[A-Za-z0-9_-]{43}$/; // base64url(sha256) = 43 chars, no padding
+
+export class BriefUrlError extends Error {
+  readonly code: 'invalid_user_id' | 'invalid_issue_date' | 'invalid_token_shape' | 'missing_secret';
+
+  constructor(code: BriefUrlError['code'], message: string) {
+    super(message);
+    this.code = code;
+    this.name = 'BriefUrlError';
+  }
+}
+
+function assertShape(userId: string, issueDate: string): void {
+  if (!USER_ID_RE.test(userId)) {
+    throw new BriefUrlError('invalid_user_id', 'userId must match [A-Za-z0-9_-]{1,128}');
+  }
+  if (!ISSUE_DATE_RE.test(issueDate)) {
+    throw new BriefUrlError('invalid_issue_date', 'issueDate must match YYYY-MM-DD');
+  }
+}
+
+function base64url(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function hmacSha256(secret: string, message: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(message));
+  return new Uint8Array(sig);
+}
+
+/** Constant-time byte comparison. Returns false on length mismatch. */
+function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= (a[i] ?? 0) ^ (b[i] ?? 0);
+  return diff === 0;
+}
+
+/**
+ * Deterministically sign `${userId}:${issueDate}` and return a
+ * base64url-encoded token. Throws BriefUrlError on malformed inputs or
+ * missing secret.
+ */
+export async function signBriefToken(
+  userId: string,
+  issueDate: string,
+  secret: string,
+): Promise<string> {
+  assertShape(userId, issueDate);
+  if (!secret) {
+    throw new BriefUrlError('missing_secret', 'BRIEF_URL_SIGNING_SECRET is not configured');
+  }
+  const sig = await hmacSha256(secret, `${userId}:${issueDate}`);
+  return base64url(sig);
+}
+
+/**
+ * Verify a token against userId + issueDate. Accepts the primary
+ * secret and (if provided) a previous secret during rotation. Returns
+ * `true` only on a byte-for-byte match under either secret.
+ *
+ * The token is rejected without ever touching crypto if its shape is
+ * invalid (wrong length, illegal chars). userId and issueDate are
+ * shape-validated before any HMAC computation to prevent probing.
+ */
+export async function verifyBriefToken(
+  userId: string,
+  issueDate: string,
+  token: string,
+  secret: string,
+  prevSecret?: string,
+): Promise<boolean> {
+  if (typeof token !== 'string' || !TOKEN_RE.test(token)) return false;
+  try {
+    assertShape(userId, issueDate);
+  } catch {
+    return false;
+  }
+  if (!secret) {
+    throw new BriefUrlError('missing_secret', 'BRIEF_URL_SIGNING_SECRET is not configured');
+  }
+
+  const tokenBytes = base64urlDecode(token);
+  if (!tokenBytes) return false;
+
+  const message = `${userId}:${issueDate}`;
+  const primary = await hmacSha256(secret, message);
+  if (constantTimeEqual(primary, tokenBytes)) return true;
+
+  if (prevSecret) {
+    const legacy = await hmacSha256(prevSecret, message);
+    if (constantTimeEqual(legacy, tokenBytes)) return true;
+  }
+  return false;
+}
+
+function base64urlDecode(token: string): Uint8Array | null {
+  try {
+    const b64 = token.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64 + '==='.slice((b64.length + 3) % 4);
+    const bin = atob(padded);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compose the full magazine URL with signed token.
+ *
+ * Producers should always go through this helper rather than string-
+ * concatenating URLs by hand. Example:
+ *
+ *   const url = await signBriefUrl({
+ *     userId: 'user_abc',
+ *     issueDate: '2026-04-17',
+ *     baseUrl: 'https://worldmonitor.app',
+ *     secret: process.env.BRIEF_URL_SIGNING_SECRET!,
+ *   });
+ */
+export async function signBriefUrl({
+  userId,
+  issueDate,
+  baseUrl,
+  secret,
+}: {
+  userId: string;
+  issueDate: string;
+  baseUrl: string;
+  secret: string;
+}): Promise<string> {
+  const token = await signBriefToken(userId, issueDate, secret);
+  const encodedUser = encodeURIComponent(userId);
+  const encodedDate = encodeURIComponent(issueDate);
+  const trimmedBase = baseUrl.replace(/\/+$/, '');
+  return `${trimmedBase}/api/brief/${encodedUser}/${encodedDate}?t=${token}`;
+}

--- a/tests/brief-edge-route-smoke.test.mjs
+++ b/tests/brief-edge-route-smoke.test.mjs
@@ -160,3 +160,52 @@ describe('infrastructure-error vs miss (both routes must not collapse)', () => {
     // wiring is covered by the 403/404 smoke tests.
   });
 });
+
+describe('assertBriefEnvelope is shared between renderer and preview', () => {
+  // Regression guard against the "ready preview → 404 on click"
+  // contradiction. The preview RPC must use the same validator the
+  // renderer uses so no partial envelope escapes as a "ready" status.
+
+  it('exports assertBriefEnvelope from server/_shared/brief-render.js', async () => {
+    const mod = await import('../server/_shared/brief-render.js');
+    assert.equal(typeof mod.assertBriefEnvelope, 'function');
+    assert.equal(typeof mod.renderBriefMagazine, 'function');
+  });
+
+  it('assertBriefEnvelope throws on partial envelope missing digest.numbers', async () => {
+    const { assertBriefEnvelope } = await import('../server/_shared/brief-render.js');
+    // Weak preview would have passed this envelope: dateLong string,
+    // digest.greeting string, stories array. But it's missing
+    // digest.numbers entirely — the renderer must reject it so the
+    // preview RPC rejects it too.
+    const partial = {
+      version: 1,
+      issuedAt: Date.now(),
+      data: {
+        user: { name: 'Elie', tz: 'UTC' },
+        issue: '18.04',
+        date: '2026-04-18',
+        dateLong: '18 April 2026',
+        digest: {
+          greeting: 'Good morning.',
+          lead: 'Lead paragraph.',
+          threads: [],
+          signals: [],
+          // numbers intentionally absent
+        },
+        stories: [
+          {
+            category: 'Energy',
+            country: 'US',
+            threatLevel: 'medium',
+            headline: 'Headline',
+            description: 'Description',
+            source: 'Wires',
+            whyMatters: 'Why',
+          },
+        ],
+      },
+    };
+    assert.throws(() => assertBriefEnvelope(partial), /digest\.numbers/);
+  });
+});

--- a/tests/brief-edge-route-smoke.test.mjs
+++ b/tests/brief-edge-route-smoke.test.mjs
@@ -76,3 +76,87 @@ describe('api/brief handler behaviour (no secrets / no Redis)', () => {
     assert.equal(res.headers.get('Content-Type'), 'text/html; charset=utf-8');
   });
 });
+
+describe('infrastructure-error vs miss (both routes must not collapse)', () => {
+  it('readRawJsonFromUpstash throws when Upstash credentials are missing', async () => {
+    const { readRawJsonFromUpstash } = await import('../api/_upstash-json.js');
+    const saved = {
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      tok: process.env.UPSTASH_REDIS_REST_TOKEN,
+    };
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    try {
+      await assert.rejects(
+        () => readRawJsonFromUpstash('brief:user_x:2026-04-17'),
+        /not configured/,
+      );
+    } finally {
+      if (saved.url) process.env.UPSTASH_REDIS_REST_URL = saved.url;
+      if (saved.tok) process.env.UPSTASH_REDIS_REST_TOKEN = saved.tok;
+    }
+  });
+
+  it('readRawJsonFromUpstash throws on Upstash HTTP error', async () => {
+    const { readRawJsonFromUpstash } = await import('../api/_upstash-json.js');
+    const realFetch = globalThis.fetch;
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.invalid';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'tok';
+    globalThis.fetch = async () => new Response('internal error', { status: 500 });
+    try {
+      await assert.rejects(
+        () => readRawJsonFromUpstash('brief:user_x:2026-04-17'),
+        /HTTP 500/,
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it('readRawJsonFromUpstash returns null only on genuine miss', async () => {
+    const { readRawJsonFromUpstash } = await import('../api/_upstash-json.js');
+    const realFetch = globalThis.fetch;
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.invalid';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'tok';
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ result: null }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    try {
+      const out = await readRawJsonFromUpstash('brief:user_x:2026-04-17');
+      assert.equal(out, null);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it('api/brief returns 503 when Upstash fails (not 404 "expired")', async () => {
+    process.env.BRIEF_URL_SIGNING_SECRET ??= 'test-secret-infra-err-path';
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.invalid';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'tok';
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response('oops', { status: 500 });
+    try {
+      const { default: handler } = await import('../api/brief/[userId]/[issueDate].ts');
+      const { signBriefToken } = await import('../server/_shared/brief-url.ts');
+      const userId = 'user_test';
+      const issueDate = '2026-04-17';
+      const token = await signBriefToken(userId, issueDate, process.env.BRIEF_URL_SIGNING_SECRET);
+      const req = new Request(
+        `https://worldmonitor.app/api/brief/${userId}/${issueDate}?t=${token}`,
+        { method: 'GET', headers: { origin: 'https://worldmonitor.app' } },
+      );
+      const res = await handler(req);
+      assert.equal(res.status, 503, 'Upstash outage must surface as 503, not 404');
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  it('api/latest-brief returns 503 when Upstash fails (not 200 "composing")', async () => {
+    // Skipped when Clerk is not mockable in unit tests. We exercise
+    // the infra-error branch at the helper level above; the route
+    // wiring is covered by the 403/404 smoke tests.
+  });
+});

--- a/tests/brief-edge-route-smoke.test.mjs
+++ b/tests/brief-edge-route-smoke.test.mjs
@@ -1,0 +1,78 @@
+// Smoke test for the brief edge routes.
+//
+// Purpose: force actual module resolution (imports + dependency graph)
+// so a broken import path cannot slip past `tsc`. `@ts-expect-error`
+// directives silence the missing-module error at compile time, but
+// the runtime loader still fails on first request in Vercel edge —
+// which we only discover on deploy. Importing the handler in a test
+// catches it here.
+//
+// Phase 1 review (todo #210) moved the renderer from shared/ to
+// server/_shared/; Phase 2's first cut imported the old path with
+// `@ts-expect-error` and green-lit in CI. This test makes that
+// regression impossible to repeat.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+describe('api/brief/[userId]/[issueDate] module resolution', () => {
+  it('loads the handler and its renderer dependency without error', async () => {
+    const mod = await import('../api/brief/[userId]/[issueDate].ts');
+    assert.equal(typeof mod.default, 'function', 'handler must be a function');
+    assert.equal(mod.config?.runtime, 'edge', 'route must declare edge runtime');
+  });
+});
+
+describe('api/latest-brief module resolution', () => {
+  it('loads the preview RPC handler without error', async () => {
+    const mod = await import('../api/latest-brief.ts');
+    assert.equal(typeof mod.default, 'function', 'handler must be a function');
+    assert.equal(mod.config?.runtime, 'edge', 'route must declare edge runtime');
+  });
+});
+
+describe('api/brief handler behaviour (no secrets / no Redis)', () => {
+  // Rejects obviously-bad requests without any env dependencies. More
+  // exhaustive tests belong in brief-url.test.mjs (HMAC) and a future
+  // integration suite with mocked Redis. These confirm the handler
+  // composes responses correctly from the inputs that do NOT require
+  // env config.
+
+  it('returns 204 on OPTIONS preflight', async () => {
+    const { default: handler } = await import('../api/brief/[userId]/[issueDate].ts');
+    const req = new Request('https://worldmonitor.app/api/brief/user_x/2026-04-17', {
+      method: 'OPTIONS',
+      headers: { origin: 'https://worldmonitor.app' },
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 204);
+  });
+
+  it('returns 405 on disallowed methods', async () => {
+    process.env.BRIEF_URL_SIGNING_SECRET ??= 'test-secret-used-only-for-method-gate';
+    const { default: handler } = await import('../api/brief/[userId]/[issueDate].ts');
+    const req = new Request('https://worldmonitor.app/api/brief/user_x/2026-04-17', {
+      method: 'POST',
+      headers: { origin: 'https://worldmonitor.app' },
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 405);
+  });
+
+  it('returns empty body on HEAD (RFC 7231)', async () => {
+    process.env.BRIEF_URL_SIGNING_SECRET ??= 'test-secret-used-only-for-head-body-check';
+    const { default: handler } = await import('../api/brief/[userId]/[issueDate].ts');
+    // HEAD with a bad token → 403 path; body should still be empty.
+    const req = new Request(
+      'https://worldmonitor.app/api/brief/user_x/2026-04-17?t=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      {
+        method: 'HEAD',
+        headers: { origin: 'https://worldmonitor.app' },
+      },
+    );
+    const res = await handler(req);
+    const body = await res.text();
+    assert.equal(body, '', 'HEAD must not carry a body');
+    assert.equal(res.headers.get('Content-Type'), 'text/html; charset=utf-8');
+  });
+});

--- a/tests/brief-url.test.mjs
+++ b/tests/brief-url.test.mjs
@@ -1,0 +1,187 @@
+// HMAC-signed brief URL helpers.
+//
+// The signed token is the credential for the hosted magazine route —
+// a recipient with the URL can read the brief, no other auth. These
+// tests lock down the invariants that matter: deterministic signing,
+// rejection of tampered inputs, and graceful rotation via a second
+// accepted secret during overlap windows.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  BriefUrlError,
+  signBriefToken,
+  signBriefUrl,
+  verifyBriefToken,
+} from '../server/_shared/brief-url.ts';
+
+const SECRET = 'primary-secret-for-tests-0123456789';
+const PREV_SECRET = 'rotated-out-legacy-secret-abcdefghij';
+const USER_ID = 'user_abc123';
+const ISSUE_DATE = '2026-04-17';
+
+describe('signBriefToken + verifyBriefToken', () => {
+  it('round-trips: verify(sign) is true for matching inputs', async () => {
+    const token = await signBriefToken(USER_ID, ISSUE_DATE, SECRET);
+    assert.equal(await verifyBriefToken(USER_ID, ISSUE_DATE, token, SECRET), true);
+  });
+
+  it('produces a 43-char base64url token (SHA-256 without padding)', async () => {
+    const token = await signBriefToken(USER_ID, ISSUE_DATE, SECRET);
+    assert.match(token, /^[A-Za-z0-9_-]{43}$/);
+  });
+
+  it('is deterministic for the same input', async () => {
+    const a = await signBriefToken(USER_ID, ISSUE_DATE, SECRET);
+    const b = await signBriefToken(USER_ID, ISSUE_DATE, SECRET);
+    assert.equal(a, b);
+  });
+
+  it('rejects a tampered token', async () => {
+    const token = await signBriefToken(USER_ID, ISSUE_DATE, SECRET);
+    // Flip one base64url char without changing shape.
+    const tampered = token.startsWith('A')
+      ? `B${token.slice(1)}`
+      : `A${token.slice(1)}`;
+    assert.equal(await verifyBriefToken(USER_ID, ISSUE_DATE, tampered, SECRET), false);
+  });
+
+  it('rejects a token bound to a different userId', async () => {
+    const token = await signBriefToken(USER_ID, ISSUE_DATE, SECRET);
+    assert.equal(await verifyBriefToken('user_xyz', ISSUE_DATE, token, SECRET), false);
+  });
+
+  it('rejects a token bound to a different issueDate', async () => {
+    const token = await signBriefToken(USER_ID, ISSUE_DATE, SECRET);
+    assert.equal(await verifyBriefToken(USER_ID, '2026-04-18', token, SECRET), false);
+  });
+
+  it('rejects a token signed with a different secret', async () => {
+    const token = await signBriefToken(USER_ID, ISSUE_DATE, 'other-secret');
+    assert.equal(await verifyBriefToken(USER_ID, ISSUE_DATE, token, SECRET), false);
+  });
+
+  it('rejects a malformed token shape without touching crypto', async () => {
+    // Tokens of the wrong length short-circuit.
+    assert.equal(await verifyBriefToken(USER_ID, ISSUE_DATE, 'too-short', SECRET), false);
+    assert.equal(
+      await verifyBriefToken(USER_ID, ISSUE_DATE, 'a'.repeat(44), SECRET),
+      false,
+    );
+    // Non-string token.
+    assert.equal(
+      await verifyBriefToken(USER_ID, ISSUE_DATE, /** @type {any} */ (null), SECRET),
+      false,
+    );
+  });
+
+  it('rejects a malformed userId or issueDate on verify without throwing', async () => {
+    const token = await signBriefToken(USER_ID, ISSUE_DATE, SECRET);
+    assert.equal(await verifyBriefToken('', ISSUE_DATE, token, SECRET), false);
+    assert.equal(await verifyBriefToken('user with spaces', ISSUE_DATE, token, SECRET), false);
+    assert.equal(await verifyBriefToken(USER_ID, '04/17/2026', token, SECRET), false);
+  });
+
+  it('throws BriefUrlError when signing with an empty secret', async () => {
+    await assert.rejects(
+      () => signBriefToken(USER_ID, ISSUE_DATE, ''),
+      (err) => err instanceof BriefUrlError && err.code === 'missing_secret',
+    );
+  });
+
+  it('throws BriefUrlError when verifying with an empty secret', async () => {
+    const token = await signBriefToken(USER_ID, ISSUE_DATE, SECRET);
+    await assert.rejects(
+      () => verifyBriefToken(USER_ID, ISSUE_DATE, token, ''),
+      (err) => err instanceof BriefUrlError && err.code === 'missing_secret',
+    );
+  });
+
+  it('throws BriefUrlError on malformed userId at sign time', async () => {
+    await assert.rejects(
+      () => signBriefToken('user with spaces', ISSUE_DATE, SECRET),
+      (err) => err instanceof BriefUrlError && err.code === 'invalid_user_id',
+    );
+  });
+
+  it('throws BriefUrlError on malformed issueDate at sign time', async () => {
+    await assert.rejects(
+      () => signBriefToken(USER_ID, '2026/04/17', SECRET),
+      (err) => err instanceof BriefUrlError && err.code === 'invalid_issue_date',
+    );
+  });
+});
+
+describe('secret rotation', () => {
+  it('accepts tokens signed with the previous secret during rotation', async () => {
+    const legacyToken = await signBriefToken(USER_ID, ISSUE_DATE, PREV_SECRET);
+    // Primary is rotated; prev is still accepted during the overlap.
+    assert.equal(
+      await verifyBriefToken(USER_ID, ISSUE_DATE, legacyToken, SECRET, PREV_SECRET),
+      true,
+    );
+  });
+
+  it('still accepts tokens signed with the new primary after rotation', async () => {
+    const freshToken = await signBriefToken(USER_ID, ISSUE_DATE, SECRET);
+    assert.equal(
+      await verifyBriefToken(USER_ID, ISSUE_DATE, freshToken, SECRET, PREV_SECRET),
+      true,
+    );
+  });
+
+  it('rejects a token signed with a third, unknown secret even when prev is set', async () => {
+    const strayToken = await signBriefToken(USER_ID, ISSUE_DATE, 'unknown-secret');
+    assert.equal(
+      await verifyBriefToken(USER_ID, ISSUE_DATE, strayToken, SECRET, PREV_SECRET),
+      false,
+    );
+  });
+
+  it('rejects previous-secret tokens once prev is removed', async () => {
+    const legacyToken = await signBriefToken(USER_ID, ISSUE_DATE, PREV_SECRET);
+    assert.equal(
+      await verifyBriefToken(USER_ID, ISSUE_DATE, legacyToken, SECRET),
+      false,
+    );
+  });
+});
+
+describe('signBriefUrl', () => {
+  it('composes a URL with the expected path and token', async () => {
+    const url = await signBriefUrl({
+      userId: USER_ID,
+      issueDate: ISSUE_DATE,
+      baseUrl: 'https://worldmonitor.app',
+      secret: SECRET,
+    });
+    assert.match(
+      url,
+      new RegExp(`^https://worldmonitor\\.app/api/brief/${USER_ID}/${ISSUE_DATE}\\?t=[A-Za-z0-9_-]{43}$`),
+    );
+  });
+
+  it('trims trailing slash on baseUrl', async () => {
+    const url = await signBriefUrl({
+      userId: USER_ID,
+      issueDate: ISSUE_DATE,
+      baseUrl: 'https://worldmonitor.app/',
+      secret: SECRET,
+    });
+    assert.ok(url.startsWith('https://worldmonitor.app/api/brief/'));
+    assert.ok(!url.includes('.app//api/'));
+  });
+
+  it('URL-encodes the path components', async () => {
+    // Underscore + dash are legal userId chars; they must NOT be
+    // percent-encoded by the helper (encodeURIComponent preserves
+    // them), which keeps the URL readable in email clients.
+    const url = await signBriefUrl({
+      userId: 'user_abc-123',
+      issueDate: ISSUE_DATE,
+      baseUrl: 'https://worldmonitor.app',
+      secret: SECRET,
+    });
+    assert.ok(url.includes('/brief/user_abc-123/'));
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the WorldMonitor Brief plan ([docs/plans/2026-04-17-003-feat-worldmonitor-brief-magazine-plan.md](docs/plans/2026-04-17-003-feat-worldmonitor-brief-magazine-plan.md)). Adds the read-path surfaces every downstream delivery channel binds to (push, email, dashboard panel, Tauri reader, carousel).

Phase 1 (PR #3150) shipped the renderer + envelope contract. Phase 3 (composer) will populate Redis. Until Phase 3 merges, this route returns a neutral "expired" page for every request — intentional, safe to deploy ahead of the composer.

## Files

| File | Purpose |
|---|---|
| `server/_shared/brief-url.ts` | HMAC-SHA256 sign + verify helpers via Web Crypto. Rotation (`prev` secret) + strict userId/YYYY-MM-DD shape validation + constant-time comparison. Typed `BriefUrlError` with code enum. |
| `api/brief/[userId]/[issueDate].ts` | Public edge route. HMAC-signed `?t=` is the credential; no Clerk session. Verify → Redis GET → renderBriefMagazine → HTML. 403 on bad token, 404 on miss, 503 on missing secret. Never echoes userId in error pages. |
| `api/latest-brief.ts` | Clerk-JWT + PRO-gated preview RPC for the dashboard panel. Returns `{ issueDate, dateLong, greeting, threadCount, magazineUrl }` or `{ status: 'composing', issueDate }` when Redis is cold. Mirrors `api/notify.ts:22-51` auth pattern. |
| `tests/brief-url.test.mjs` | 20 tests: round-trip, tampering (token/user/date/secret), malformed shape, rotation (accept prev, reject after removal), URL composition. |

## Why signed-URL, not Clerk-gated, on the public route

- The magazine URL is delivered through push, email, webhook, Tauri — channels where the recipient is already authenticated. Adding a second auth layer at click time produces friction without adding security (the URL already identifies the intended reader).
- Signed URLs work in email clients that strip cookies, in Telegram/Slack previews, and in external readers — all planned delivery surfaces.
- The HMAC binds `{userId, issueDate}` so a leaked URL is only useful to the intended recipient.

## 🚨 Pre-merge blocker (not a code change)

**`BRIEF_URL_SIGNING_SECRET` must be set in Vercel before this merges.**

- Generate with `openssl rand -base64 48` (avoid `$` chars — `feedback_vercel_env_shell_interpolation`).
- Set in Vercel production + preview environments.
- When the Phase 3 composer ships it will also need this secret in Railway.
- The route returns 503 (not 500) with a server-side log when the secret is missing, so a mis-configured deploy is survivable but unusable.
- For rotation later: set `BRIEF_URL_SIGNING_SECRET_PREV` during the overlap window; `verifyBriefToken` accepts either.

## Testing

- `npx tsx --test tests/brief-url.test.mjs tests/brief-magazine-render.test.mjs` — 50/50 pass.
- `npm run typecheck` + `npm run typecheck:api` — clean.
- `npx biome lint` on all four new files — clean.

Manual verification: sanity render still works end-to-end — Phase 1 renderer's test fixtures pass the stricter envelope contract unchanged.

## What this does NOT do

- No Redis writes (Phase 3 composer).
- No notifications (Phases 5–8).
- No dashboard panel UI (Phase 4).
- No Tauri in-app webview (Phase 7).

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: `[api/brief]` and `[api/latest-brief]` prefixes — expect only 503 messages until Phase 3 ships. Any 5xx with a different shape is a regression.
  - Dashboards: Vercel edge function error rate on `/api/brief/*` and `/api/latest-brief`.
- **Validation checks (after Vercel env is set, before Phase 3)**
  - `curl -s -o /dev/null -w "%{http_code}\n" https://worldmonitor.app/api/brief/invalid/2026-04-17?t=abc` → expect `403` (bad token).
  - `curl -s -o /dev/null -w "%{http_code}\n" 'https://worldmonitor.app/api/brief/abc/2026-04-17?t=$(node -e "require(\"./server/_shared/brief-url\").signBriefToken(\"abc\",\"2026-04-17\",\"${BRIEF_URL_SIGNING_SECRET}\").then(console.log)")'` → expect `404` (no composer yet).
  - `GET /api/latest-brief` with a PRO user's Clerk JWT → expect `{ status: "composing", issueDate: "<today>" }`.
- **Expected healthy behaviour (pre-Phase-3)**
  - `api/brief`: 403 for bad token, 404 for valid token + missing Redis key, 200 only if someone manually seeds the key.
  - `api/latest-brief`: 200 `{ status: "composing" }` for PRO users, 401 for anonymous, 403 `pro_required` for free tier.
- **Failure signal / rollback trigger**
  - Any 500 from either route → revert the PR (the edge functions are the only new runtime surface; reverting fully disables the feature).
  - 503 from either route after deploy → check `BRIEF_URL_SIGNING_SECRET` is set in Vercel env.
- **Validation window & owner**
  - Window: 24h after deploy.
  - Owner: Elie.

## Related

- Plan: `docs/plans/2026-04-17-003-feat-worldmonitor-brief-magazine-plan.md`
- Brainstorm: `docs/brainstorms/2026-04-17-worldmonitor-brief-magazine-requirements.md`
- Phase 1: #3150 (merged).