### PR TITLE
fix(api): unblock Pro API clients at edge + accept x-api-key alias

### DIFF
--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -33,7 +33,7 @@ function extractOriginFromReferer(referer) {
 
 export function validateApiKey(req, options = {}) {
   const forceKey = options.forceKey === true;
-  const key = req.headers.get('X-WorldMonitor-Key');
+  const key = req.headers.get('X-WorldMonitor-Key') || req.headers.get('X-Api-Key');
   // Same-origin browser requests don't send Origin (per CORS spec).
   // Fall back to Referer to identify trusted same-origin callers.
   const origin = req.headers.get('Origin') || extractOriginFromReferer(req.headers.get('Referer')) || '';

--- a/api/_cors.js
+++ b/api/_cors.js
@@ -22,7 +22,7 @@ export function getCorsHeaders(req, methods = 'GET, OPTIONS') {
   return {
     'Access-Control-Allow-Origin': allowOrigin,
     'Access-Control-Allow-Methods': methods,
-    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Widget-Key, X-Pro-Key',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Api-Key, X-Widget-Key, X-Pro-Key',
     'Access-Control-Max-Age': '3600',
     'Vary': 'Origin',
   };
@@ -40,7 +40,7 @@ export function getPublicCorsHeaders(methods = 'GET, OPTIONS') {
   return {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': methods,
-    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Widget-Key, X-Pro-Key',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Api-Key, X-Widget-Key, X-Pro-Key',
     'Access-Control-Max-Age': '3600',
   };
 }

--- a/api/chat-analyst.ts
+++ b/api/chat-analyst.ts
@@ -76,7 +76,7 @@ export default async function handler(req: Request): Promise<Response> {
       headers: {
         ...corsHeaders,
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Api-Key',
       },
     });
   }

--- a/api/v2/shipping/route-intelligence.ts
+++ b/api/v2/shipping/route-intelligence.ts
@@ -51,7 +51,10 @@ export default async function handler(req: Request): Promise<Response> {
 
   let apiKeyResult = validateApiKey(req, { forceKey: true });
   // Fallback: wm_ user keys are validated async via Convex, not in the static key list
-  const wmKey = req.headers.get('X-WorldMonitor-Key') ?? '';
+  const wmKey =
+    req.headers.get('X-WorldMonitor-Key') ??
+    req.headers.get('X-Api-Key') ??
+    '';
   if (apiKeyResult.required && !apiKeyResult.valid && wmKey.startsWith('wm_')) {
     const { validateUserApiKey } = await import('../../../server/_shared/user-api-key');
     const userKeyResult = await validateUserApiKey(wmKey);

--- a/api/v2/shipping/webhooks.ts
+++ b/api/v2/shipping/webhooks.ts
@@ -111,7 +111,10 @@ function ownerIndexKey(ownerHash: string): string {
 
 /** SHA-256 hash of the caller's API key — used as ownerTag and owner index key. Never secret. */
 async function callerFingerprint(req: Request): Promise<string> {
-  const key = req.headers.get('X-WorldMonitor-Key') ?? '';
+  const key =
+    req.headers.get('X-WorldMonitor-Key') ??
+    req.headers.get('X-Api-Key') ??
+    '';
   if (!key) return 'anon';
   const encoded = new TextEncoder().encode(key);
   const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);

--- a/api/widget-agent.ts
+++ b/api/widget-agent.ts
@@ -51,7 +51,7 @@ export default async function handler(req: Request): Promise<Response> {
       headers: {
         ...corsHeaders,
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Widget-Key, X-Pro-Key',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Api-Key, X-Widget-Key, X-Pro-Key',
       },
     });
   }
@@ -59,7 +59,10 @@ export default async function handler(req: Request): Promise<Response> {
   // ── Auth ──────────────────────────────────────────────────────────────────
   let isPro = false;
 
-  const worldMonitorKey = req.headers.get('X-WorldMonitor-Key') ?? '';
+  const worldMonitorKey =
+    req.headers.get('X-WorldMonitor-Key') ??
+    req.headers.get('X-Api-Key') ??
+    '';
   if (hasValidWorldMonitorKey(worldMonitorKey)) {
     isPro = true;
   } else {

--- a/middleware.ts
+++ b/middleware.ts
@@ -126,6 +126,18 @@ export default function middleware(request: Request) {
     return;
   }
 
+  // Authenticated Pro API clients bypass UA filtering. Real key validation
+  // still runs downstream in server/gateway.ts (Convex userApiKeys hash
+  // lookup); invalid keys still get 401. Accept both header names so clients
+  // using the common `x-api-key` convention aren't blocked at the edge.
+  const apiKey =
+    request.headers.get('x-worldmonitor-key') ??
+    request.headers.get('x-api-key') ??
+    '';
+  if (apiKey.startsWith('wm_')) {
+    return;
+  }
+
   // Block bots from all API routes
   if (BOT_UA.test(ua)) {
     return new Response('{"error":"Forbidden"}', {

--- a/middleware.ts
+++ b/middleware.ts
@@ -126,15 +126,19 @@ export default function middleware(request: Request) {
     return;
   }
 
-  // Authenticated Pro API clients bypass UA filtering. Real key validation
-  // still runs downstream in server/gateway.ts (Convex userApiKeys hash
-  // lookup); invalid keys still get 401. Accept both header names so clients
-  // using the common `x-api-key` convention aren't blocked at the edge.
+  // Authenticated Pro API clients bypass UA filtering. This is a cheap
+  // edge heuristic, not auth — real validation (SHA-256 hash vs Convex
+  // userApiKeys + entitlement) happens in server/gateway.ts. To keep the
+  // bot-UA shield meaningful, require the exact key shape emitted by
+  // src/services/api-keys.ts:generateKey: `wm_` + 40 lowercase hex chars.
+  // A random scraper would have to guess a specific 43-char format, and
+  // spoofed-but-well-shaped keys still 401 at the gateway.
+  const WM_KEY_SHAPE = /^wm_[a-f0-9]{40}$/;
   const apiKey =
     request.headers.get('x-worldmonitor-key') ??
     request.headers.get('x-api-key') ??
     '';
-  if (apiKey.startsWith('wm_')) {
+  if (WM_KEY_SHAPE.test(apiKey)) {
     return;
   }
 

--- a/server/_shared/premium-check.ts
+++ b/server/_shared/premium-check.ts
@@ -12,7 +12,10 @@ import { validateUserApiKey } from './user-api-key';
 export async function isCallerPremium(request: Request): Promise<boolean> {
   // Browser tester keys — validateApiKey returns required:false for trusted origins
   // even when a valid key is present, so we check the header directly first.
-  const wmKey = request.headers.get('X-WorldMonitor-Key') ?? '';
+  const wmKey =
+    request.headers.get('X-WorldMonitor-Key') ??
+    request.headers.get('X-Api-Key') ??
+    '';
   if (wmKey) {
     const validKeys = (process.env.WORLDMONITOR_VALID_KEYS ?? '')
       .split(',').map((k) => k.trim()).filter(Boolean);

--- a/server/cors.ts
+++ b/server/cors.ts
@@ -34,7 +34,7 @@ export function getCorsHeaders(req: Request): Record<string, string> {
   return {
     'Access-Control-Allow-Origin': allowOrigin,
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Widget-Key, X-Pro-Key',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-WorldMonitor-Key, X-Api-Key, X-Widget-Key, X-Pro-Key',
     'Access-Control-Max-Age': '3600',
     'Vary': 'Origin',
   };

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -312,7 +312,10 @@ export function createDomainGateway(
     // User-owned API keys (wm_ prefix): when the static WORLDMONITOR_VALID_KEYS
     // check fails, try async Convex-backed validation for user-issued keys.
     let isUserApiKey = false;
-    const wmKey = request.headers.get('X-WorldMonitor-Key') ?? '';
+    const wmKey =
+      request.headers.get('X-WorldMonitor-Key') ??
+      request.headers.get('X-Api-Key') ??
+      '';
     if (keyCheck.required && !keyCheck.valid && wmKey.startsWith('wm_')) {
       const { validateUserApiKey } = await import('./_shared/user-api-key');
       const userKeyResult = await validateUserApiKey(wmKey);


### PR DESCRIPTION
## Summary

Closes #3146.

Pro subscriber `Laurentldk` reported all API calls from his Railway-hosted server returning `403` with a Cloudflare HTML block page. Tracing both edge layers revealed two independent blockers that together made every legitimate server-to-server Pro API client unusable:

1. **Vercel Edge Middleware** (`middleware.ts`) returns `403 {"error":"Forbidden"}` when the User-Agent matches `/bot|curl\/|python-requests|go-http|java\//`. Curl, Python `requests`, Go `net/http`, Java clients — the exact stacks Pro subscribers use — all hit this gate before the gateway ever runs. The bot filter was intended for scraper defense on HTML/OG routes, but it applies to every `/api/*` path except a three-path public allowlist.
2. **Header name mismatch.** Docs and gateway only accepted `X-WorldMonitor-Key`, but the overwhelming default in API tooling is `x-api-key`. Cloudflare's Managed Ruleset also flags the literal `x-api-key` header name as a scraper signature (verified by live repro: identical curl from residential Mac is blocked at CF on `x-api-key`, passes through on `X-WorldMonitor-Key`).

### Fix

**Middleware bypass for authenticated API clients.** If the incoming request carries `x-worldmonitor-key` or `x-api-key` starting with `wm_`, skip the UA heuristic. The prefix is a client-side signal only — downstream `server/gateway.ts` still hashes the key (SHA-256) and validates it against the Convex `userApiKeys` table plus the owner's entitlement. Invalid keys still get a 401 from the gateway.

**Accept `X-Api-Key` as an alias** in:
- `api/_api-key.js` — legacy static-key allowlist (`WORLDMONITOR_VALID_KEYS`)
- `server/gateway.ts` — user-issued Convex-backed keys
- `server/_shared/premium-check.ts` — `isCallerPremium`

Add `X-Api-Key` to `Access-Control-Allow-Headers` in `server/cors.ts` and `api/_cors.js` so browser preflights succeed for clients using the common name.

### Follow-up (Cloudflare dashboard, not in repo)

1. Extend the existing "Allow api access with WM" custom WAF rule to also skip when `x-api-key` is present:
   ```
   (http.request.uri.path contains "/api/" and (starts_with(http.request.headers["x-worldmonitor-key"][0], "wm_") or starts_with(http.request.headers["x-api-key"][0], "wm_")))
   ```
2. Update the `api-cors-preflight` CF Worker's `corsHeaders` to include `X-Api-Key` (the Worker overrides repo CORS on `api.worldmonitor.app` per the cors-cloudflare-worker runbook).

### Reproduction (before this PR)

From any server-side environment (Railway, local curl, etc.):

```
$ curl -H "X-WorldMonitor-Key: wm_..." https://api.worldmonitor.app/api/v2/worldmonitor/resilience/v1/get-country-risk?country=US
HTTP/2 403
{"error":"Forbidden"}   # Vercel middleware bot filter
```

After the PR: reaches the gateway, key is hash-validated against Convex, returns data (200).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx tsc --noEmit -p tsconfig.api.json` — clean
- [x] `npx tsx --test api/_cors.test.mjs tests/edge-functions.test.mjs tests/deploy-config.test.mjs` — 190/190 pass
- [x] `npx biome lint` on the six changed files — no new warnings (two pre-existing `?.` suggestions on adjacent lines)
- [ ] After merge, re-run the reporter's curl from a Railway container with a valid Pro key to confirm end-to-end 200 response
- [ ] Apply the two Cloudflare dashboard follow-ups before closing #3146

🤖 Generated with [Claude Code](https://claude.com/claude-code)