### PR TITLE
fix: isolate Travelpayouts cache keys by request variant

### DIFF
--- a/server/worldmonitor/aviation/v1/_providers/travelpayouts_data.ts
+++ b/server/worldmonitor/aviation/v1/_providers/travelpayouts_data.ts
@@ -231,7 +231,7 @@ export async function searchPricesTravelpayouts(opts: {
         if (nonstopOnly) params.set('direct', 'true');
         if (market_) params.set('market', market_);
 
-        const cacheKey = `tp:v3:${origin}:${destination}:${departureDate}:${returnDate}:${cabin}:${currency_}:v1`;
+        const cacheKey = `tp:v3:${origin}:${destination}:${departureDate}:${returnDate}:${cabin}:${currency_}:${market_}:${nonstopOnly}:${Math.min(maxResults, 30)}:v2`;
         const data = await cachedFetchJson<TpV3Ticket[]>(cacheKey, 3600, () =>
             fetchTp<TpV3Ticket[]>(`${BASE_V3}/prices_for_dates?${params}`, token)
                 .then(d => d ?? [])
@@ -272,7 +272,7 @@ export async function searchPricesTravelpayouts(opts: {
             show_to_affiliates: 'true',
         });
 
-        const cacheKey = `tp:latest:${origin}:${destination}:${cabin}:${currency_}:v1`;
+        const cacheKey = `tp:latest:${origin}:${destination}:${cabin}:${currency_}:${returnDate ? 'roundtrip' : 'oneway'}:${Math.min(maxResults, 30)}:v2`;
         const data = await cachedFetchJson<TpLatestTicket[]>(cacheKey, 3600, () =>
             fetchTp<TpLatestTicket[]>(`${BASE_V2}/latest?${params}`, token)
                 .then(d => d ?? [])

--- a/server/worldmonitor/aviation/v1/_providers/travelpayouts_data.ts
+++ b/server/worldmonitor/aviation/v1/_providers/travelpayouts_data.ts
@@ -246,7 +246,7 @@ export async function searchPricesTravelpayouts(opts: {
         if (nonstopOnly) params.set('direct', 'true');
         if (market_) params.set('market', market_);
 
-        const cacheKey = `tp:v3:${origin}:${destination}:${departureDate}:${returnDate}:${cabin}:${currency_}:v1`;
+        const cacheKey = `tp:v3:${origin}:${destination}:${departureDate}:${returnDate}:${cabin}:${currency_}:${market_}:${nonstopOnly}:${Math.min(maxResults, 30)}:v2`;
         const data = await cachedFetchJson<TpV3Ticket[]>(cacheKey, 3600, () =>
             fetchTp<TpV3Ticket[]>(`${BASE_V3}/prices_for_dates?${params}`, token)
         );
@@ -289,7 +289,7 @@ export async function searchPricesTravelpayouts(opts: {
             show_to_affiliates: 'true',
         });
 
-        const cacheKey = `tp:latest:${origin}:${destination}:${cabin}:${currency_}:v1`;
+        const cacheKey = `tp:latest:${origin}:${destination}:${cabin}:${currency_}:${returnDate ? 'roundtrip' : 'oneway'}:${Math.min(maxResults, 30)}:v2`;
         const data = await cachedFetchJson<TpLatestTicket[]>(cacheKey, 3600, () =>
             fetchTp<TpLatestTicket[]>(`${BASE_V2}/latest?${params}`, token)
         );

--- a/tests/travelpayouts-cache-key-contract.test.mjs
+++ b/tests/travelpayouts-cache-key-contract.test.mjs
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const src = readFileSync(
+  new URL('../server/worldmonitor/aviation/v1/_providers/travelpayouts_data.ts', import.meta.url),
+  'utf8',
+);
+
+function blockBetween(start, end) {
+  const startIndex = src.indexOf(start);
+  assert.notEqual(startIndex, -1, `missing start marker: ${start}`);
+  const endIndex = src.indexOf(end, startIndex);
+  assert.notEqual(endIndex, -1, `missing end marker after ${start}: ${end}`);
+  return src.slice(startIndex, endIndex);
+}
+
+describe('Travelpayouts cache-key contract', () => {
+  it('keys v3 day-precision cache by every upstream-varying request option', () => {
+    const block = blockBetween('// v3: prices_for_dates', '} else if (isMonthPrecision)');
+
+    assert.match(block, /if \(nonstopOnly\) params\.set\('direct', 'true'\)/);
+    assert.match(block, /if \(market_\) params\.set\('market', market_\)/);
+    assert.match(block, /limit: String\(Math\.min\(maxResults, 30\)\)/);
+    assert.match(
+      block,
+      /const cacheKey = `tp:v3:\$\{origin\}:\$\{destination\}:\$\{departureDate\}:\$\{returnDate\}:\$\{cabin\}:\$\{currency_\}:\$\{market_\}:\$\{nonstopOnly\}:\$\{Math\.min\(maxResults, 30\)\}:v2`/,
+    );
+  });
+
+  it('keeps month-matrix cache keyed only by upstream-varying options', () => {
+    const block = blockBetween('// v2: month-matrix', '// v2: latest');
+
+    assert.doesNotMatch(block, /params\.set\('direct'/);
+    assert.doesNotMatch(block, /limit: String\(Math\.min\(maxResults, 30\)\)/);
+    assert.match(block, /const cacheKey = `tp:month:\$\{origin\}:\$\{destination\}:\$\{departureDate\}:\$\{cabin\}:\$\{currency_\}:v1`/);
+    assert.match(block, /nonstopOnly \? data\.filter\(r => \(r\.number_of_changes \?\? 0\) === 0\) : data/);
+    assert.match(block, /rows\.slice\(0, maxResults\)/);
+  });
+
+  it('keys latest cache by upstream-varying trip shape and capped limit', () => {
+    const block = blockBetween('// v2: latest', '// Save 7-day price snapshot');
+
+    assert.match(block, /one_way: returnDate \? 'false' : 'true'/);
+    assert.match(block, /limit: String\(Math\.min\(maxResults, 30\)\)/);
+    assert.match(
+      block,
+      /const cacheKey = `tp:latest:\$\{origin\}:\$\{destination\}:\$\{cabin\}:\$\{currency_\}:\$\{returnDate \? 'roundtrip' : 'oneway'\}:\$\{Math\.min\(maxResults, 30\)\}:v2`/,
+    );
+    assert.match(block, /nonstopOnly \? data\.filter\(r => \(r\.number_of_changes \?\? 0\) === 0\) : data/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes incorrect Travelpayouts flight-price cache reuse across request variants. Exact-date searches now isolate cache entries for direct-vs-any flights and market-specific pricing, and latest-price searches isolate one-way vs round-trip responses and different upstream result limits. Adds regression tests for the affected cache-key paths.

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)
- [x] Other: Aviation flight pricing provider and regression tests

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
