### PR TITLE
fix(brief): sign-in-required state + composing auto-refresh

### DIFF
--- a/src/components/LatestBriefPanel.ts
+++ b/src/components/LatestBriefPanel.ts
@@ -22,7 +22,7 @@
 import { Panel } from './Panel';
 import { premiumFetch } from '@/services/premium-fetch';
 import { PanelGateReason, hasPremiumAccess } from '@/services/panel-gating';
-import { getAuthState } from '@/services/auth-state';
+import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { h, rawHtml, replaceChildren, clearChildren } from '@/utils/dom-utils';
 
 interface LatestBriefReady {
@@ -57,6 +57,11 @@ const WM_LOGO_SVG = (
   + '</svg>'
 );
 
+// Composing-state poll interval. 60s balances "responsive when the
+// composer finishes between digest ticks" against "don't hammer
+// Upstash with 401-path checks from backgrounded tabs".
+const COMPOSING_POLL_MS = 60_000;
+
 export class LatestBriefPanel extends Panel {
   private refreshing = false;
   private refreshQueued = false;
@@ -69,6 +74,11 @@ export class LatestBriefPanel extends Panel {
    */
   private gateLocked = false;
   private inflightAbort: AbortController | null = null;
+  private composingPollId: ReturnType<typeof setTimeout> | null = null;
+  private unsubscribeAuth: (() => void) | null = null;
+  private onVisibility: (() => void) | null = null;
+  /** Last Clerk user-id seen. Used to detect sign-in / sign-out transitions. */
+  private lastUserId: string | null = null;
 
   constructor() {
     super({
@@ -86,13 +96,24 @@ export class LatestBriefPanel extends Panel {
     });
 
     this.renderLoading();
-    // Defer the self-fetch until updatePanelGating() (called on mount
-    // + on auth state changes) has either unlocked us or rendered
-    // the gated CTA. If we fetch first, anonymous/free users would
-    // hit 401/403 and see raw error UI for a moment before the gate
-    // repaints over us. refresh() also short-circuits when the user
-    // has no premium access, so a mid-session downgrade stops
-    // hitting the endpoint immediately.
+    this.lastUserId = getAuthState().user?.id ?? null;
+    // Refresh on auth transitions (sign in → load brief; sign out →
+    // stop polling). updatePanelGating handles the locked CTA; we
+    // handle data fetches that are keyed to the Clerk identity.
+    this.unsubscribeAuth = subscribeAuthState((state) => {
+      const nextId = state.user?.id ?? null;
+      if (nextId !== this.lastUserId) {
+        this.lastUserId = nextId;
+        if (nextId) void this.refresh();
+      }
+    });
+    // visibilitychange drives a refresh when the user returns to
+    // the tab. Addresses the "composing → stays composing forever"
+    // case where the composer completed while the tab was hidden.
+    this.onVisibility = () => {
+      if (document.visibilityState === 'visible') void this.refresh();
+    };
+    document.addEventListener('visibilitychange', this.onVisibility);
     void this.refresh();
   }
 
@@ -113,8 +134,19 @@ export class LatestBriefPanel extends Panel {
       this.refreshQueued = true;
       return;
     }
+    this.clearComposingPoll();
     // Check #1: gate before starting.
-    if (this.gateLocked || !hasPremiumAccess(getAuthState())) return;
+    const authState = getAuthState();
+    if (this.gateLocked || !hasPremiumAccess(authState)) return;
+    // Per-user endpoint needs a Clerk userId. Desktop API key +
+    // browser tester keys satisfy hasPremiumAccess but don't bind
+    // to a Clerk user, so /api/latest-brief returns 401. Render a
+    // specific "Sign in" CTA inline instead of hammering the
+    // endpoint or showing a retry-loop error.
+    if (!authState.user?.id) {
+      this.renderSignInRequired();
+      return;
+    }
     this.refreshing = true;
     const controller = new AbortController();
     this.inflightAbort = controller;
@@ -155,6 +187,7 @@ export class LatestBriefPanel extends Panel {
     this.gateLocked = true;
     this.inflightAbort?.abort();
     this.inflightAbort = null;
+    this.clearComposingPoll();
     super.showGatedCta(reason, onAction);
   }
 
@@ -205,8 +238,48 @@ export class LatestBriefPanel extends Panel {
     );
   }
 
+  /**
+   * Desktop / tester-key auth can satisfy hasPremiumAccess without a
+   * Clerk userId. /api/latest-brief is user-scoped, so there's
+   * nothing to fetch. Render a specific CTA rather than pretending
+   * this is an error state.
+   */
+  private renderSignInRequired(): void {
+    clearChildren(this.content);
+    const logo = h('div', { className: 'latest-brief-logo' });
+    logo.appendChild(rawHtml(WM_LOGO_SVG));
+    this.content.appendChild(
+      h('div', { className: 'latest-brief-card latest-brief-card--composing' },
+        logo,
+        h('div', { className: 'latest-brief-empty-title' }, 'Sign in to view your brief.'),
+        h('div', { className: 'latest-brief-empty-body' },
+          'Your personalised brief is tied to your WorldMonitor account. Sign in to see today\u2019s issue.',
+        ),
+      ),
+    );
+  }
+
+  private scheduleComposingPoll(): void {
+    this.clearComposingPoll();
+    this.composingPollId = setTimeout(() => {
+      this.composingPollId = null;
+      void this.refresh();
+    }, COMPOSING_POLL_MS);
+  }
+
+  private clearComposingPoll(): void {
+    if (this.composingPollId !== null) {
+      clearTimeout(this.composingPollId);
+      this.composingPollId = null;
+    }
+  }
+
   private renderComposing(data: LatestBriefComposing): void {
     clearChildren(this.content);
+    // While we're stuck on composing, re-poll every minute so the
+    // panel transitions to ready on the next cron tick without
+    // requiring a full page reload.
+    this.scheduleComposingPoll();
     // h()'s applyProps has no special-case for innerHTML — passing
     // it as a prop sets a literal DOM attribute named "innerHTML"
     // rather than parsing HTML. Use rawHtml() which returns a
@@ -251,5 +324,18 @@ export class LatestBriefPanel extends Panel {
     );
 
     replaceChildren(this.content, coverCard);
+  }
+
+  public override destroy(): void {
+    this.clearComposingPoll();
+    this.inflightAbort?.abort();
+    this.inflightAbort = null;
+    if (this.onVisibility) {
+      document.removeEventListener('visibilitychange', this.onVisibility);
+      this.onVisibility = null;
+    }
+    this.unsubscribeAuth?.();
+    this.unsubscribeAuth = null;
+    super.destroy();
   }
 }

--- a/src/components/LatestBriefPanel.ts
+++ b/src/components/LatestBriefPanel.ts
@@ -20,7 +20,7 @@
  */
 
 import { Panel } from './Panel';
-import { getClerkToken } from '@/services/clerk';
+import { getClerkToken, clearClerkTokenCache } from '@/services/clerk';
 import { PanelGateReason, hasPremiumAccess } from '@/services/panel-gating';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { h, rawHtml, replaceChildren, clearChildren } from '@/utils/dom-utils';
@@ -112,6 +112,12 @@ export class LatestBriefPanel extends Panel {
       this.inflightAbort?.abort();
       this.inflightAbort = null;
       this.clearComposingPoll();
+      // The Clerk token cache is keyed by time, not user. On every
+      // id transition we MUST drop it so the next fetch reflects
+      // the new session. Without this, /api/latest-brief derives
+      // userId from the stale token's sub claim and paints the
+      // previous user's brief in the new session for up to 50s.
+      clearClerkTokenCache();
       if (nextId) {
         void this.refresh();
       } else {

--- a/src/components/LatestBriefPanel.ts
+++ b/src/components/LatestBriefPanel.ts
@@ -41,6 +41,20 @@ interface LatestBriefComposing {
 
 type LatestBriefResponse = LatestBriefReady | LatestBriefComposing;
 
+/**
+ * Typed access-failure surface. Lets the refresh loop branch on the
+ * specific condition (sign-in / upgrade) instead of retrying as if
+ * the error were transient.
+ */
+class BriefAccessError extends Error {
+  readonly code: 'sign_in_required' | 'upgrade_required';
+  constructor(code: BriefAccessError['code']) {
+    super(code);
+    this.code = code;
+    this.name = 'BriefAccessError';
+  }
+}
+
 const LATEST_BRIEF_ENDPOINT = '/api/latest-brief';
 
 const WM_LOGO_SVG = (
@@ -165,6 +179,15 @@ export class LatestBriefPanel extends Panel {
       this.renderSignInRequired();
       return;
     }
+    // Mixed-auth edge case: desktop/tester keys open the panel even
+    // when the signed-in Clerk account is FREE. /api/latest-brief
+    // verifies entitlement from the JWT's userId and returns 403
+    // for free accounts. Render the upgrade CTA locally instead of
+    // bouncing through a doomed fetch.
+    if (authState.user?.role !== 'pro') {
+      this.renderUpgradeRequired();
+      return;
+    }
     this.refreshing = true;
     const controller = new AbortController();
     this.inflightAbort = controller;
@@ -187,6 +210,13 @@ export class LatestBriefPanel extends Panel {
       if ((err as { name?: string } | null)?.name === 'AbortError') return;
       if (this.gateLocked || !hasPremiumAccess(getAuthState())) return;
       if ((getAuthState().user?.id ?? null) !== requestUserId) return;
+      // Structured access errors render a terminal CTA, not a retry
+      // error — retrying a 401 or 403 can't flip the outcome.
+      if (err instanceof BriefAccessError) {
+        if (err.code === 'sign_in_required') this.renderSignInRequired();
+        else this.renderUpgradeRequired();
+        return;
+      }
       const message = err instanceof Error ? err.message : 'Brief unavailable — try again shortly.';
       this.showError(message, () => { void this.refresh(); });
     } finally {
@@ -246,13 +276,15 @@ export class LatestBriefPanel extends Panel {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (res.status === 401) {
-      throw new Error('Sign in to view your brief.');
+      throw new BriefAccessError('sign_in_required');
     }
     if (res.status === 403) {
-      // PRO gate — base panel handles the visual. Keep the throw so
-      // the caller's error branch is a no-op; locked-state overlay
-      // already covers the content area.
-      throw new Error('PRO required');
+      // Server says the Clerk userId is not Pro. This can happen
+      // when the client's authState says role=pro but the server's
+      // entitlement source (Convex) disagrees, or when the Clerk
+      // plan claim goes stale. Surface as upgrade CTA — not a
+      // retryable error, since retrying won't flip entitlement.
+      throw new BriefAccessError('upgrade_required');
     }
     if (!res.ok) {
       throw new Error(`Brief service unavailable (${res.status})`);
@@ -289,6 +321,26 @@ export class LatestBriefPanel extends Panel {
         h('div', { className: 'latest-brief-empty-title' }, 'Sign in to view your brief.'),
         h('div', { className: 'latest-brief-empty-body' },
           'Your personalised brief is tied to your WorldMonitor account. Sign in to see today\u2019s issue.',
+        ),
+      ),
+    );
+  }
+
+  /**
+   * Free Clerk account (either via local authState or via a 403
+   * from the server). Render an upgrade CTA instead of retrying —
+   * the user needs a plan change, not a fresh fetch.
+   */
+  private renderUpgradeRequired(): void {
+    clearChildren(this.content);
+    const logo = h('div', { className: 'latest-brief-logo' });
+    logo.appendChild(rawHtml(WM_LOGO_SVG));
+    this.content.appendChild(
+      h('div', { className: 'latest-brief-card latest-brief-card--composing' },
+        logo,
+        h('div', { className: 'latest-brief-empty-title' }, 'Pro required.'),
+        h('div', { className: 'latest-brief-empty-body' },
+          'The WorldMonitor Brief is included with the Pro plan. Upgrade to unlock today\u2019s issue.',
         ),
       ),
     );

--- a/src/components/LatestBriefPanel.ts
+++ b/src/components/LatestBriefPanel.ts
@@ -20,7 +20,7 @@
  */
 
 import { Panel } from './Panel';
-import { premiumFetch } from '@/services/premium-fetch';
+import { getClerkToken } from '@/services/clerk';
 import { PanelGateReason, hasPremiumAccess } from '@/services/panel-gating';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { h, rawHtml, replaceChildren, clearChildren } from '@/utils/dom-utils';
@@ -97,14 +97,27 @@ export class LatestBriefPanel extends Panel {
 
     this.renderLoading();
     this.lastUserId = getAuthState().user?.id ?? null;
-    // Refresh on auth transitions (sign in → load brief; sign out →
-    // stop polling). updatePanelGating handles the locked CTA; we
-    // handle data fetches that are keyed to the Clerk identity.
+    // Refresh on ANY auth-id transition:
+    //   null → id      : sign-in, load brief
+    //   idA → idB      : account switch, load new user's brief
+    //   id → null      : sign-out, abort + render sign-in CTA
+    //                    (hasPremiumAccess may still be true via
+    //                    desktop/tester key, so the layout-level
+    //                    updatePanelGating won't re-lock us — we
+    //                    must clear state ourselves)
     this.unsubscribeAuth = subscribeAuthState((state) => {
       const nextId = state.user?.id ?? null;
-      if (nextId !== this.lastUserId) {
-        this.lastUserId = nextId;
-        if (nextId) void this.refresh();
+      if (nextId === this.lastUserId) return;
+      this.lastUserId = nextId;
+      this.inflightAbort?.abort();
+      this.inflightAbort = null;
+      this.clearComposingPoll();
+      if (nextId) {
+        void this.refresh();
+      } else {
+        // Sign-out. Don't leave the previous user's content on
+        // screen even when premium keys keep the panel unlocked.
+        this.renderSignInRequired();
       }
     });
     // visibilitychange drives a refresh when the user returns to
@@ -140,10 +153,9 @@ export class LatestBriefPanel extends Panel {
     if (this.gateLocked || !hasPremiumAccess(authState)) return;
     // Per-user endpoint needs a Clerk userId. Desktop API key +
     // browser tester keys satisfy hasPremiumAccess but don't bind
-    // to a Clerk user, so /api/latest-brief returns 401. Render a
-    // specific "Sign in" CTA inline instead of hammering the
-    // endpoint or showing a retry-loop error.
-    if (!authState.user?.id) {
+    // to a Clerk user, so there's nothing to fetch.
+    const requestUserId = authState.user?.id ?? null;
+    if (!requestUserId) {
       this.renderSignInRequired();
       return;
     }
@@ -152,11 +164,13 @@ export class LatestBriefPanel extends Panel {
     this.inflightAbort = controller;
     try {
       const data = await this.fetchLatest(controller.signal);
-      // Check #3 (post-response): auth may have flipped during the
-      // await. If the gate was flipped by updatePanelGating, it has
-      // already replaced `this.content` with the locked CTA — we
-      // must NOT overwrite that with brief content.
+      // Check #3 (post-response): verify we're still on the SAME
+      // user AND still unlocked. A Clerk account switch during the
+      // await (A→B) would otherwise paint user A's brief into user
+      // B's session because getClerkToken caches for up to 50s
+      // across account changes.
       if (this.gateLocked || !hasPremiumAccess(getAuthState())) return;
+      if ((getAuthState().user?.id ?? null) !== requestUserId) return;
       if (data.status === 'ready') {
         this.renderReady(data);
       } else {
@@ -166,6 +180,7 @@ export class LatestBriefPanel extends Panel {
       // AbortError comes from showGatedCta's abort() → render nothing.
       if ((err as { name?: string } | null)?.name === 'AbortError') return;
       if (this.gateLocked || !hasPremiumAccess(getAuthState())) return;
+      if ((getAuthState().user?.id ?? null) !== requestUserId) return;
       const message = err instanceof Error ? err.message : 'Brief unavailable — try again shortly.';
       this.showError(message, () => { void this.refresh(); });
     } finally {
@@ -209,7 +224,21 @@ export class LatestBriefPanel extends Panel {
   }
 
   private async fetchLatest(signal: AbortSignal): Promise<LatestBriefResponse> {
-    const res = await premiumFetch(LATEST_BRIEF_ENDPOINT, { signal });
+    // /api/latest-brief is user-scoped and Bearer-only. premiumFetch
+    // short-circuits on desktop WORLDMONITOR_API_KEY / tester keys
+    // and never sends Clerk, producing a 401 we can't recover from.
+    // Always mint a fresh Bearer here — the refresh() pre-check
+    // guaranteed authState.user exists.
+    const token = await getClerkToken();
+    if (!token) {
+      // Clerk token evicted between the pre-check and now (logout,
+      // cache expiry + Clerk session gone). Surface as sign-in.
+      throw new Error('Sign in to view your brief.');
+    }
+    const res = await fetch(LATEST_BRIEF_ENDPOINT, {
+      signal,
+      headers: { Authorization: `Bearer ${token}` },
+    });
     if (res.status === 401) {
       throw new Error('Sign in to view your brief.');
     }

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -115,10 +115,20 @@ export async function signOut(): Promise<void> {
   await clerkInstance?.signOut();
 }
 
-/** Clear the cached Clerk token (call when Convex signals a 401 via forceRefreshToken). */
+/**
+ * Clear the cached Clerk token. Call when:
+ *   - Convex signals a 401 via forceRefreshToken
+ *   - The observed Clerk user changes (account switch / sign-out)
+ *
+ * Also drops the inflight promise so an A→B switch while a token
+ * fetch is mid-air doesn't let the next caller reuse A's promise.
+ * The old promise still resolves to its closure but nothing
+ * downstream references it once this runs.
+ */
 export function clearClerkTokenCache(): void {
   _cachedToken = null;
   _cachedTokenAt = 0;
+  _tokenInflight = null;
 }
 
 /**
@@ -168,6 +178,7 @@ export async function getClerkToken(): Promise<string | null> {
   })();
   return _tokenInflight;
 }
+
 
 /** Get current Clerk user metadata. Returns null if signed out. */
 export function getCurrentClerkUser(): { id: string; name: string; email: string; image: string | null; plan: 'free' | 'pro' } | null {


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #3159 (Phase 4 dashboard panel). Two review P1s:

### Finding 1 — API-key/tester-key users see a broken unlocked panel
`hasPremiumAccess` returns true for three paths: desktop `WORLDMONITOR_API_KEY`, browser tester keys (`wm-pro-key` / `wm-widget-key`), and Clerk Pro. `/api/latest-brief` is user-scoped and needs a Clerk userId — it returns 401 for API-key-only callers. Before this fix the panel unlocked, self-fetched, 401'd, and showed a retry-loop error forever.

**Fix:** panel now checks `authState.user?.id` alongside `hasPremiumAccess`. When premium but no Clerk user, renders a dedicated "Sign in to view your brief" CTA inline — no endpoint hit. `subscribeAuthState` fires `refresh()` automatically on sign-in.

### Finding 2 — Composing state never auto-refreshed
The panel rendered "Your brief is composing" and stayed there until page reload or auth transition. No poll, no visibilitychange hook, no scheduler.

**Fix:**
- `renderComposing` schedules a 60s `setTimeout` re-poll. Cleared on `ready` / `error` / `showGatedCta` / `destroy`.
- `document.visibilitychange` listener: when the tab returns to focus, refresh fires. Covers "composer finished while tab backgrounded" without requiring manual reload.

## Files

| File | Change |
|---|---|
| `src/components/LatestBriefPanel.ts` | Auth subscribe + `renderSignInRequired()` + `scheduleComposingPoll()` + `visibilitychange` handler + `destroy()` override for cleanup |

## Testing

- `npm run typecheck` — clean
- `npx biome lint src/components/LatestBriefPanel.ts` — clean

## Post-Deploy Monitoring

- **Healthy signals:** PRO user with Clerk signs in → panel transitions from "composing" to "ready" within 60s of composer run. Tab switch → refresh within 1s.
- **Regression signals:** retry loops on the browser console, or composing state that never resolves despite Redis having the key.
- **Rollback:** revert this PR; prior behaviour (retry-loop on API-key-only, composing-forever) returns.

## Related

- Phase 4 panel: #3159 (merged)
- Plan: `docs/plans/2026-04-17-003-feat-worldmonitor-brief-magazine-plan.md`