### PR TITLE
fix(pro): reliable post-payment activation

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -161,7 +161,8 @@ export class PanelLayoutManager implements AppModule {
     // Free users need the subscription active so they receive real-time
     // entitlement updates after purchasing (P1: newly upgraded users must
     // see their premium access without a manual page reload).
-    if (handleCheckoutReturn()) {
+    const returnedFromCheckout = handleCheckoutReturn();
+    if (returnedFromCheckout) {
       showCheckoutSuccess();
     }
 
@@ -177,10 +178,16 @@ export class PanelLayoutManager implements AppModule {
     // Reload only on a free→pro transition. Legacy-pro users whose first
     // snapshot is already pro (lastEntitled === null) must not trigger a
     // reload loop, but a user who pays mid-session (false → true) must see
-    // their panels unlock without manual refresh. The prior `skipInitialSnapshot`
-    // guard collapsed these cases and silently swallowed post-payment activations
-    // when the first authenticated snapshot carried the new entitlement.
-    let lastEntitled: boolean | null = null;
+    // their panels unlock without manual refresh.
+    //
+    // When we just returned from a Dodo full-page redirect checkout, seed
+    // lastEntitled = false instead of null. The webhook may have already
+    // landed by the time the user's browser comes back, so the first
+    // entitlement snapshot can arrive as pro. Without this seed the
+    // transition detector would swallow that snapshot as "legacy-pro" and
+    // the user would see locked panels until a manual refresh — exactly the
+    // symptom that caused the 2026-04-17/18 duplicate-subscription incident.
+    let lastEntitled: boolean | null = returnedFromCheckout ? false : null;
     this.unsubscribeEntitlementChange = onEntitlementChange(() => {
       const entitled = isEntitled();
       const reload = shouldReloadOnEntitlementChange(lastEntitled, entitled);

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -100,7 +100,7 @@ import { CustomWidgetPanel } from '@/components/CustomWidgetPanel';
 import { openWidgetChatModal } from '@/components/WidgetChatModal';
 import { loadWidgets, saveWidget } from '@/services/widget-store';
 import type { CustomWidgetSpec } from '@/services/widget-store';
-import { initEntitlementSubscription, destroyEntitlementSubscription, isEntitled, onEntitlementChange } from '@/services/entitlements';
+import { initEntitlementSubscription, destroyEntitlementSubscription, isEntitled, onEntitlementChange, shouldReloadOnEntitlementChange } from '@/services/entitlements';
 import { initSubscriptionWatch, destroySubscriptionWatch } from '@/services/billing';
 import { getUserId } from '@/services/user-identity';
 import { initPaymentFailureBanner } from '@/components/payment-failure-banner';
@@ -174,16 +174,18 @@ export class PanelLayoutManager implements AppModule {
 
     initCheckoutOverlay(() => showCheckoutSuccess());
 
-    // Listen for entitlement changes — reload panels to pick up new gating state.
-    // Skip the initial snapshot to avoid a reload loop for users who already have
-    // premium via legacy signals (API key / wm-pro-key).
-    let skipInitialSnapshot = true;
+    // Reload only on a free→pro transition. Legacy-pro users whose first
+    // snapshot is already pro (lastEntitled === null) must not trigger a
+    // reload loop, but a user who pays mid-session (false → true) must see
+    // their panels unlock without manual refresh. The prior `skipInitialSnapshot`
+    // guard collapsed these cases and silently swallowed post-payment activations
+    // when the first authenticated snapshot carried the new entitlement.
+    let lastEntitled: boolean | null = null;
     this.unsubscribeEntitlementChange = onEntitlementChange(() => {
-      if (skipInitialSnapshot) {
-        skipInitialSnapshot = false;
-        return;
-      }
-      if (isEntitled()) {
+      const entitled = isEntitled();
+      const reload = shouldReloadOnEntitlementChange(lastEntitled, entitled);
+      lastEntitled = entitled;
+      if (reload) {
         console.log('[entitlements] Subscription activated — reloading to unlock panels');
         window.location.reload();
       }

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -105,7 +105,7 @@ import { initSubscriptionWatch, destroySubscriptionWatch } from '@/services/bill
 import { getUserId } from '@/services/user-identity';
 import { initPaymentFailureBanner } from '@/components/payment-failure-banner';
 import { handleCheckoutReturn } from '@/services/checkout-return';
-import { initCheckoutOverlay, destroyCheckoutOverlay, showCheckoutSuccess } from '@/services/checkout';
+import { initCheckoutOverlay, destroyCheckoutOverlay, showCheckoutSuccess, consumePostCheckoutFlag } from '@/services/checkout';
 import { McpDataPanel } from '@/components/McpDataPanel';
 import { openMcpConnectModal } from '@/components/McpConnectModal';
 import { loadMcpPanels, saveMcpPanel } from '@/services/mcp-store';
@@ -161,7 +161,15 @@ export class PanelLayoutManager implements AppModule {
     // Free users need the subscription active so they receive real-time
     // entitlement updates after purchasing (P1: newly upgraded users must
     // see their premium access without a manual page reload).
-    const returnedFromCheckout = handleCheckoutReturn();
+    //
+    // Two return paths need to seed the transition detector as post-checkout:
+    //   1. Full-page Dodo redirect — handleCheckoutReturn() reads
+    //      subscription_id/status URL params and cleans them.
+    //   2. Dodo overlay success — setTimeout(reload) with no URL params;
+    //      we stash a session flag before the reload and consume it here.
+    const returnedFromCheckoutUrl = handleCheckoutReturn();
+    const returnedFromOverlay = consumePostCheckoutFlag();
+    const returnedFromCheckout = returnedFromCheckoutUrl || returnedFromOverlay;
     if (returnedFromCheckout) {
       showCheckoutSuccess();
     }

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -20,7 +20,37 @@ const CHECKOUT_PRODUCT_PARAM = 'checkoutProduct';
 const CHECKOUT_REFERRAL_PARAM = 'checkoutReferral';
 const CHECKOUT_DISCOUNT_PARAM = 'checkoutDiscount';
 const PENDING_CHECKOUT_KEY = 'wm-pending-checkout';
+const POST_CHECKOUT_FLAG_KEY = 'wm-post-checkout';
 const APP_CHECKOUT_BASE_URL = 'https://worldmonitor.app/';
+
+/**
+ * Session flag set just before the post-overlay reload. Lets panel-layout
+ * detect "we just returned from an overlay checkout" on the reloaded page —
+ * the overlay uses manualRedirect:true so there are no subscription_id URL
+ * params to key off, unlike the full-page redirect return handled by
+ * handleCheckoutReturn. Exported as a pair (consume+mark) to keep the key
+ * centralized with the rest of the checkout storage constants.
+ */
+export function consumePostCheckoutFlag(): boolean {
+  try {
+    if (sessionStorage.getItem(POST_CHECKOUT_FLAG_KEY) === '1') {
+      sessionStorage.removeItem(POST_CHECKOUT_FLAG_KEY);
+      return true;
+    }
+  } catch {
+    // Private browsing / storage disabled — fall through to false.
+  }
+  return false;
+}
+
+function markPostCheckout(): void {
+  try {
+    sessionStorage.setItem(POST_CHECKOUT_FLAG_KEY, '1');
+  } catch {
+    // Storage denied — the reload will still run; transition detector will
+    // fall back to its null baseline, matching the pre-flag behavior.
+  }
+}
 
 interface PendingCheckoutIntent {
   productId: string;
@@ -53,9 +83,13 @@ export function initCheckoutOverlay(onSuccess?: () => void): void {
           if (event.data?.status === 'succeeded') {
             onSuccessCallback?.();
             // Belt-and-braces: reload after the webhook is likely to have
-            // landed (median <5s). This guarantees the post-payment state is
-            // fresh even if the Convex WS subscription was slow to deliver the
-            // pro snapshot or the free→pro transition detector missed it.
+            // landed (median <5s). Mark a session flag so the reloaded page
+            // can seed the entitlement transition detector as post-checkout
+            // — the overlay uses manualRedirect:true so the reload lands at
+            // the original URL without subscription_id params, and the
+            // detector would otherwise treat the first pro snapshot as the
+            // legacy-pro baseline and swallow it.
+            markPostCheckout();
             setTimeout(() => window.location.reload(), 3_000);
           }
           break;

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -52,6 +52,11 @@ export function initCheckoutOverlay(onSuccess?: () => void): void {
         case 'checkout.status':
           if (event.data?.status === 'succeeded') {
             onSuccessCallback?.();
+            // Belt-and-braces: reload after the webhook is likely to have
+            // landed (median <5s). This guarantees the post-payment state is
+            // fresh even if the Convex WS subscription was slow to deliver the
+            // pro snapshot or the free→pro transition detector missed it.
+            setTimeout(() => window.location.reload(), 3_000);
           }
           break;
         case 'checkout.closed':

--- a/src/services/entitlements.ts
+++ b/src/services/entitlements.ts
@@ -7,7 +7,7 @@
  * is not configured or ConvexClient is unavailable.
  */
 
-import { getConvexClient, getConvexApi } from './convex-client';
+import { getConvexClient, getConvexApi, waitForConvexAuth } from './convex-client';
 
 export interface EntitlementState {
   planKey: string;
@@ -46,6 +46,18 @@ export async function initEntitlementSubscription(_userId?: string): Promise<voi
     const api = await getConvexApi();
     if (!api) {
       console.log('[entitlements] Could not load Convex API — skipping subscription');
+      return;
+    }
+
+    // Wait for Convex to confirm auth before subscribing. Otherwise the first
+    // getEntitlementsForUser snapshot runs unauthenticated and returns
+    // FREE_TIER_DEFAULTS, which can race with the post-payment panel gating
+    // decision (the UI renders as free before the auth-ready pro snapshot
+    // arrives). Unauthenticated visitors time out after 10s and we skip the
+    // subscription entirely — they don't need entitlement updates.
+    const authed = await waitForConvexAuth(10_000);
+    if (!authed) {
+      console.log('[entitlements] Convex auth not established — skipping subscription');
       return;
     }
 
@@ -148,4 +160,23 @@ export function isEntitled(): boolean {
     currentState.planKey !== 'free' &&
     currentState.validUntil >= Date.now()
   );
+}
+
+/**
+ * Decides whether to reload the page when an entitlement snapshot arrives.
+ *
+ * Rules:
+ *   - First snapshot ever (last === null): never reload. A legacy-pro user
+ *     whose first snapshot is already `true` must not trigger a reload loop
+ *     on every page load.
+ *   - Free → pro transition (last === false, next === true): reload. This is
+ *     the post-payment activation case — panels rendered against free-tier
+ *     gating need to re-render to pick up the new entitlement.
+ *   - Everything else (free→free, pro→pro, pro→free): no reload.
+ */
+export function shouldReloadOnEntitlementChange(
+  last: boolean | null,
+  next: boolean,
+): boolean {
+  return last === false && next === true;
 }

--- a/tests/entitlement-transition.test.mts
+++ b/tests/entitlement-transition.test.mts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for shouldReloadOnEntitlementChange.
+ *
+ * This helper drives the post-payment reload in src/app/panel-layout.ts.
+ * A bug here is exactly what caused duplicate subscriptions in the
+ * 2026-04-18 incident (customer cus_0NcmwcAWw0jhVBHVOK58C): the prior
+ * skipInitialSnapshot guard swallowed the first pro snapshot unconditionally,
+ * even when it arrived mid-session after a successful Dodo webhook.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { shouldReloadOnEntitlementChange } from '@/services/entitlements';
+
+describe('shouldReloadOnEntitlementChange', () => {
+  it('does not reload on the first snapshot when user is free', () => {
+    assert.equal(shouldReloadOnEntitlementChange(null, false), false);
+  });
+
+  it('does not reload on the first snapshot when user is already pro', () => {
+    // Legacy-pro user on page load — avoid reload loop.
+    assert.equal(shouldReloadOnEntitlementChange(null, true), false);
+  });
+
+  it('does not reload free → free (idempotent free-tier update)', () => {
+    assert.equal(shouldReloadOnEntitlementChange(false, false), false);
+  });
+
+  it('does not reload pro → pro (renewal, metadata refresh)', () => {
+    assert.equal(shouldReloadOnEntitlementChange(true, true), false);
+  });
+
+  it('does not reload pro → free (expiration, revocation) — handled elsewhere', () => {
+    // Revocation paths are handled by re-rendering; no forced reload.
+    assert.equal(shouldReloadOnEntitlementChange(true, false), false);
+  });
+
+  it('reloads on free → pro (post-payment activation — the incident case)', () => {
+    assert.equal(shouldReloadOnEntitlementChange(false, true), true);
+  });
+
+  it('simulates the incident sequence: free-tier default snapshot followed by authed pro snapshot → reload exactly once', () => {
+    // Before PR 1, this sequence produced no reload because skipInitialSnapshot
+    // swallowed the first snapshot. After the fix, the transition triggers a
+    // reload and the user's panels unlock without manual intervention.
+    let last: boolean | null = null;
+    let reloadCount = 0;
+
+    const snapshots = [false, true, true];
+    for (const entitled of snapshots) {
+      if (shouldReloadOnEntitlementChange(last, entitled)) reloadCount += 1;
+      last = entitled;
+    }
+
+    assert.equal(reloadCount, 1);
+  });
+
+  it('legacy-pro user reconnecting WS: pro, pro, pro → zero reloads', () => {
+    let last: boolean | null = null;
+    let reloadCount = 0;
+
+    for (const entitled of [true, true, true]) {
+      if (shouldReloadOnEntitlementChange(last, entitled)) reloadCount += 1;
+      last = entitled;
+    }
+
+    assert.equal(reloadCount, 0);
+  });
+});

--- a/tests/entitlement-transition.test.mts
+++ b/tests/entitlement-transition.test.mts
@@ -66,4 +66,33 @@ describe('shouldReloadOnEntitlementChange', () => {
 
     assert.equal(reloadCount, 0);
   });
+
+  it('redirect-return from checkout with webhook already landed: seeded as free → first pro snapshot reloads', () => {
+    // When handleCheckoutReturn() fires, panel-layout seeds lastEntitled=false
+    // instead of null. Otherwise a fast webhook (pro snapshot arrives as the
+    // first snapshot after reload) would be swallowed as "legacy-pro".
+    let last: boolean | null = false; // seeded because returnedFromCheckout=true
+    let reloadCount = 0;
+
+    if (shouldReloadOnEntitlementChange(last, true)) reloadCount += 1;
+    last = true;
+    // WS reconnects and re-emits pro — no further reload.
+    if (shouldReloadOnEntitlementChange(last, true)) reloadCount += 1;
+
+    assert.equal(reloadCount, 1);
+  });
+
+  it('redirect-return when webhook is still pending: seeded false → free → pro sequence reloads exactly once', () => {
+    let last: boolean | null = false;
+    let reloadCount = 0;
+
+    // First snapshot comes back as free (webhook not landed yet).
+    if (shouldReloadOnEntitlementChange(last, false)) reloadCount += 1;
+    last = false;
+    // Webhook lands, pro snapshot arrives.
+    if (shouldReloadOnEntitlementChange(last, true)) reloadCount += 1;
+    last = true;
+
+    assert.equal(reloadCount, 1);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes a client-side race that silently dropped post-payment Pro activations and caused at least one confirmed duplicate subscription on 2026-04-17/18. Server side (Dodo webhook → Convex `entitlements`) is verified correct end-to-end; the UI just never surfaced the change.

Three coordinated fixes:

1. **`src/app/panel-layout.ts`** — replace the `skipInitialSnapshot` guard with a free → pro *transition* detector (`shouldReloadOnEntitlementChange`). The prior guard collapsed two distinct cases (legacy-pro on load vs. post-payment activation) and always swallowed the first pro snapshot.
2. **`src/services/entitlements.ts`** — `await waitForConvexAuth(10_000)` before `client.onUpdate`. Mirrors the pattern already used in `api-keys.ts` and `App.ts`. Eliminates the spurious `FREE_TIER_DEFAULTS` first snapshot that the transition detector would otherwise treat as baseline.
3. **`src/services/checkout.ts`** — belt-and-braces: on Dodo overlay `checkout.status=succeeded`, schedule `window.location.reload()` after 3s (observed median webhook latency < 5s).

### Incident evidence

- Customer `cus_0NcmwcAWw0jhVBHVOK58C` (Clerk `user_3CLjKhHDrUQD1OEg6HDoCYrLa6v`): 2 Pro Monthly purchases within 32 min; first charge `pay_0Ncvhw6XhO6lcGQRJ336c` refunded by Dodo with reason "Duplicate transaction" (`ref_0NcwML9RQ4QuQQdHwj4u5`).
- Prod Convex (`tacit-curlew-777`): all 9 webhook events for both subscriptions processed; `entitlements` row exists with `planKey: "pro_monthly"`, `tier: 1`, `validUntil: 2026-05-17`.
- Detailed trace: `docs/plans/2026-04-18-001-fix-pro-activation-race-and-duplicate-checkout-guard-plan.md`.

## Testing

- `tests/entitlement-transition.test.mts` — 8 unit tests covering all six `(last, next)` combinations plus the full incident-simulation sequence and the legacy-pro reconnect sequence. All pass.
- `npm run typecheck:all` — clean.
- `npm run lint` on changed files — no new warnings.

Manual test plan for a reviewer:
- Sign in, open dashboard, confirm pro panels remain locked (free tier baseline).
- Pay via Dodo test mode. Expect: success banner, 3s delay, page reloads, panels unlocked.
- Legacy-pro reload flow: sign in as existing pro user, reload. Expect: no reload loop, panels stay unlocked.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Sentry: filter `component:dodo-checkout` and `[entitlements]` warnings. Spike in overlay errors or subscription errors would indicate regression.
  - Convex logs: `[entitlements] Convex auth not established` frequency — expected only for unauthenticated visitors.
  - Dashboard reloads: no change expected in reload volume for signed-in free users; a small uptick for users completing checkouts.
- **Validation checks**
  - `gh pr view <this>` — assert deploys green.
  - Convex CLI query for a test user's entitlement after a test-mode checkout: `npx convex run 'entitlements:getEntitlementsByUserId' '{"userId":"<test>"}'` — should show `pro_monthly` within 10s of checkout success.
  - Watch for "Duplicate transaction" refund reason in Dodo dashboard — rate should drop to 0 for newly-created subscriptions.
- **Expected healthy signals**
  - Paying users see `Payment received! Unlocking your premium features…` banner → 3s → full panel unlock without manual refresh.
  - No change for legacy-pro users on normal page loads (no reload loop).
- **Failure signal / rollback trigger**
  - Sentry spike in `dodo-checkout` errors, OR repeated `[entitlements] Convex auth not established` for authed users, OR reports of infinite reload loops. Revert via `git revert <this merge commit>`.
- **Validation window & owner**
  - 48h post-merge. Owner: @koala73.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>