### PR TITLE
fix(checkout): block duplicate subscriptions at the checkout entry point

### DIFF
--- a/api/create-checkout.ts
+++ b/api/create-checkout.ts
@@ -102,6 +102,12 @@ export default async function handler(req: Request): Promise<Response> {
 
     const data = await resp.json();
     if (!resp.ok) {
+      // Propagate the structured already_subscribed payload with 409 so the
+      // client can route the user to billing portal instead of silently
+      // opening another Dodo checkout.
+      if (resp.status === 409 && data?.error && typeof data.error === 'object') {
+        return json(data, 409, cors);
+      }
       console.error('[create-checkout] Relay error:', resp.status, data);
       return json({ error: data?.error || 'Checkout creation failed' }, 502, cors);
     }

--- a/convex/__tests__/duplicate-subscription-guard.test.ts
+++ b/convex/__tests__/duplicate-subscription-guard.test.ts
@@ -1,0 +1,197 @@
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../schema";
+import { api, internal } from "../_generated/api";
+import { ConvexError } from "convex/values";
+
+const modules = import.meta.glob("../**/*.ts");
+
+const USER_ID = "user_guard_test_001";
+const NOW = Date.now();
+const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+
+const PRO_MONTHLY_PRODUCT = "pdt_0Nbtt71uObulf7fGXhQup";
+const PRO_ANNUAL_PRODUCT = "pdt_0NbttMIfjLWC10jHQWYgJ";
+const API_STARTER_PRODUCT = "pdt_0NbttVmG1SERrxhygbbUq";
+
+async function seedSub(
+  t: ReturnType<typeof convexTest>,
+  opts: {
+    status: "active" | "on_hold" | "cancelled" | "expired";
+    planKey: string;
+    dodoProductId: string;
+    periodEnd?: number;
+  },
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("subscriptions", {
+      userId: USER_ID,
+      dodoSubscriptionId: `sub_guard_${opts.planKey}_${opts.status}`,
+      dodoProductId: opts.dodoProductId,
+      planKey: opts.planKey,
+      status: opts.status,
+      currentPeriodStart: NOW,
+      currentPeriodEnd: opts.periodEnd ?? NOW + MONTH_MS,
+      rawPayload: {},
+      updatedAt: NOW,
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// getBlockingSubscription
+// ---------------------------------------------------------------------------
+
+describe("getBlockingSubscription", () => {
+  test("returns null when user has no subscriptions", async () => {
+    const t = convexTest(schema, modules);
+    const sub = await t.query(
+      internal.payments.billing.getBlockingSubscription,
+      { userId: USER_ID },
+    );
+    expect(sub).toBeNull();
+  });
+
+  test("returns the active subscription", async () => {
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "active", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    const sub = await t.query(
+      internal.payments.billing.getBlockingSubscription,
+      { userId: USER_ID },
+    );
+    expect(sub?.status).toBe("active");
+    expect(sub?.planKey).toBe("pro_monthly");
+  });
+
+  test("returns on_hold when no active subscription exists", async () => {
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "on_hold", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    await seedSub(t, { status: "cancelled", planKey: "pro_annual", dodoProductId: PRO_ANNUAL_PRODUCT });
+    const sub = await t.query(
+      internal.payments.billing.getBlockingSubscription,
+      { userId: USER_ID },
+    );
+    expect(sub?.status).toBe("on_hold");
+  });
+
+  test("prefers active over on_hold when both exist", async () => {
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "on_hold", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    await seedSub(t, { status: "active", planKey: "pro_annual", dodoProductId: PRO_ANNUAL_PRODUCT });
+    const sub = await t.query(
+      internal.payments.billing.getBlockingSubscription,
+      { userId: USER_ID },
+    );
+    expect(sub?.status).toBe("active");
+    expect(sub?.planKey).toBe("pro_annual");
+  });
+
+  test("ignores cancelled and expired subscriptions", async () => {
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "cancelled", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    await seedSub(t, { status: "expired", planKey: "pro_annual", dodoProductId: PRO_ANNUAL_PRODUCT });
+    const sub = await t.query(
+      internal.payments.billing.getBlockingSubscription,
+      { userId: USER_ID },
+    );
+    expect(sub).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// internalCreateCheckout guard
+// ---------------------------------------------------------------------------
+//
+// We can't let the guard pass without hitting the Dodo SDK (which requires
+// live credentials), so the "allow" cases assert the error is NOT
+// already_subscribed — some other Dodo/env error is expected and acceptable
+// for our purposes. The block cases assert the specific ConvexError payload.
+
+async function runCheckoutAndCaptureError(
+  t: ReturnType<typeof convexTest>,
+  productId: string,
+): Promise<unknown> {
+  try {
+    await t.action(internal.payments.checkout.internalCreateCheckout, {
+      userId: USER_ID,
+      productId,
+    });
+    return null;
+  } catch (err) {
+    return err;
+  }
+}
+
+function parseErrorData(err: unknown): Record<string, unknown> | null {
+  const raw = (err as { data?: unknown })?.data;
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+  if (raw && typeof raw === "object") {
+    return raw as Record<string, unknown>;
+  }
+  return null;
+}
+
+function isAlreadySubscribedError(err: unknown): boolean {
+  const data = parseErrorData(err);
+  return !!data && data.code === "already_subscribed";
+}
+
+describe("internalCreateCheckout duplicate-subscription guard", () => {
+  test("blocks a second pro_monthly when user already has active pro_monthly", async () => {
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "active", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    const err = await runCheckoutAndCaptureError(t, PRO_MONTHLY_PRODUCT);
+    expect(err).not.toBeNull();
+    expect(isAlreadySubscribedError(err)).toBe(true);
+    const data = parseErrorData(err)!;
+    expect(data.existingStatus).toBe("active");
+    expect(data.existingPlanKey).toBe("pro_monthly");
+    expect(typeof data.currentPeriodEnd).toBe("number");
+    expect(typeof data.message).toBe("string");
+  });
+
+  test("blocks pro_annual when user already has active pro_monthly (same tier group)", async () => {
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "active", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    const err = await runCheckoutAndCaptureError(t, PRO_ANNUAL_PRODUCT);
+    expect(isAlreadySubscribedError(err)).toBe(true);
+  });
+
+  test("blocks any new checkout when user has an on_hold subscription", async () => {
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "on_hold", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    const err = await runCheckoutAndCaptureError(t, PRO_MONTHLY_PRODUCT);
+    expect(isAlreadySubscribedError(err)).toBe(true);
+    const data = parseErrorData(err)!;
+    expect(data.existingStatus).toBe("on_hold");
+    expect(String(data.message).toLowerCase()).toContain("payment");
+  });
+
+  test("allows api_starter when user has active pro_monthly (tier upgrade)", async () => {
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "active", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    // pro_monthly = tier 1; api_starter = tier 2. Upgrade path must not be blocked.
+    const err = await runCheckoutAndCaptureError(t, API_STARTER_PRODUCT);
+    expect(isAlreadySubscribedError(err)).toBe(false);
+  });
+
+  test("allows a new checkout when the only prior sub is cancelled", async () => {
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "cancelled", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    const err = await runCheckoutAndCaptureError(t, PRO_MONTHLY_PRODUCT);
+    expect(isAlreadySubscribedError(err)).toBe(false);
+  });
+
+  test("allows a new checkout when the only prior sub is expired", async () => {
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "expired", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    const err = await runCheckoutAndCaptureError(t, PRO_MONTHLY_PRODUCT);
+    expect(isAlreadySubscribedError(err)).toBe(false);
+  });
+});

--- a/convex/__tests__/duplicate-subscription-guard.test.ts
+++ b/convex/__tests__/duplicate-subscription-guard.test.ts
@@ -13,6 +13,8 @@ const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
 const PRO_MONTHLY_PRODUCT = "pdt_0Nbtt71uObulf7fGXhQup";
 const PRO_ANNUAL_PRODUCT = "pdt_0NbttMIfjLWC10jHQWYgJ";
 const API_STARTER_PRODUCT = "pdt_0NbttVmG1SERrxhygbbUq";
+const API_STARTER_ANNUAL_PRODUCT = "pdt_0Nbu2lawHYE3dv2THgSEV";
+const ENTERPRISE_PRODUCT = "pdt_0Nbttnqrfh51cRqhMdVLx";
 
 async function seedSub(
   t: ReturnType<typeof convexTest>,
@@ -39,62 +41,81 @@ async function seedSub(
 }
 
 // ---------------------------------------------------------------------------
-// getBlockingSubscription
+// getBlockingSubscriptions
 // ---------------------------------------------------------------------------
 
-describe("getBlockingSubscription", () => {
-  test("returns null when user has no subscriptions", async () => {
+describe("getBlockingSubscriptions", () => {
+  test("returns [] when user has no subscriptions", async () => {
     const t = convexTest(schema, modules);
-    const sub = await t.query(
-      internal.payments.billing.getBlockingSubscription,
+    const subs = await t.query(
+      internal.payments.billing.getBlockingSubscriptions,
       { userId: USER_ID },
     );
-    expect(sub).toBeNull();
+    expect(subs).toEqual([]);
   });
 
   test("returns the active subscription", async () => {
     const t = convexTest(schema, modules);
     await seedSub(t, { status: "active", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
-    const sub = await t.query(
-      internal.payments.billing.getBlockingSubscription,
+    const subs = await t.query(
+      internal.payments.billing.getBlockingSubscriptions,
       { userId: USER_ID },
     );
-    expect(sub?.status).toBe("active");
-    expect(sub?.planKey).toBe("pro_monthly");
+    expect(subs.length).toBe(1);
+    expect(subs[0]?.status).toBe("active");
+    expect(subs[0]?.planKey).toBe("pro_monthly");
   });
 
-  test("returns on_hold when no active subscription exists", async () => {
+  test("returns on_hold plus cancelled-filtered-out", async () => {
     const t = convexTest(schema, modules);
     await seedSub(t, { status: "on_hold", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
     await seedSub(t, { status: "cancelled", planKey: "pro_annual", dodoProductId: PRO_ANNUAL_PRODUCT });
-    const sub = await t.query(
-      internal.payments.billing.getBlockingSubscription,
+    const subs = await t.query(
+      internal.payments.billing.getBlockingSubscriptions,
       { userId: USER_ID },
     );
-    expect(sub?.status).toBe("on_hold");
+    expect(subs.length).toBe(1);
+    expect(subs[0]?.status).toBe("on_hold");
   });
 
-  test("prefers active over on_hold when both exist", async () => {
+  test("returns both active and on_hold when both exist", async () => {
     const t = convexTest(schema, modules);
     await seedSub(t, { status: "on_hold", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
     await seedSub(t, { status: "active", planKey: "pro_annual", dodoProductId: PRO_ANNUAL_PRODUCT });
-    const sub = await t.query(
-      internal.payments.billing.getBlockingSubscription,
+    const subs = await t.query(
+      internal.payments.billing.getBlockingSubscriptions,
       { userId: USER_ID },
     );
-    expect(sub?.status).toBe("active");
-    expect(sub?.planKey).toBe("pro_annual");
+    expect(subs.length).toBe(2);
+    const statuses = subs.map((s) => s.status).sort();
+    expect(statuses).toEqual(["active", "on_hold"]);
   });
 
   test("ignores cancelled and expired subscriptions", async () => {
     const t = convexTest(schema, modules);
     await seedSub(t, { status: "cancelled", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
     await seedSub(t, { status: "expired", planKey: "pro_annual", dodoProductId: PRO_ANNUAL_PRODUCT });
-    const sub = await t.query(
-      internal.payments.billing.getBlockingSubscription,
+    const subs = await t.query(
+      internal.payments.billing.getBlockingSubscriptions,
       { userId: USER_ID },
     );
-    expect(sub).toBeNull();
+    expect(subs).toEqual([]);
+  });
+
+  test("returns every active row when multiple exist (stale + current)", async () => {
+    // Real-world case: a user with a historical active pro_monthly that
+    // never cancelled, plus a current active api_starter. The caller must
+    // see both so tier comparison evaluates against the highest.
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "active", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    await seedSub(t, { status: "active", planKey: "api_starter", dodoProductId: API_STARTER_PRODUCT });
+    const subs = await t.query(
+      internal.payments.billing.getBlockingSubscriptions,
+      { userId: USER_ID },
+    );
+    expect(subs.length).toBe(2);
+    const planKeys = subs.map((s) => s.planKey).sort();
+    expect(planKeys).toEqual(["api_starter", "pro_monthly"]);
   });
 });
 
@@ -193,5 +214,43 @@ describe("internalCreateCheckout duplicate-subscription guard", () => {
     await seedSub(t, { status: "expired", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
     const err = await runCheckoutAndCaptureError(t, PRO_MONTHLY_PRODUCT);
     expect(isAlreadySubscribedError(err)).toBe(false);
+  });
+
+  test("regression: stale pro_monthly + current api_starter blocks api_starter_annual (same tier)", async () => {
+    // Before the multi-row fix, the guard picked the first active row it
+    // saw. If the stale pro_monthly (tier 1) came back first, requestedTier
+    // (api_starter_annual = 2) > existingTier (1), so it was mis-classified
+    // as an upgrade and a duplicate API Starter checkout was allowed.
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "active", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    await seedSub(t, { status: "active", planKey: "api_starter", dodoProductId: API_STARTER_PRODUCT });
+    const err = await runCheckoutAndCaptureError(t, API_STARTER_ANNUAL_PRODUCT);
+    expect(isAlreadySubscribedError(err)).toBe(true);
+    const data = parseErrorData(err)!;
+    // The error should reference the highest-tier active row, not the stale one.
+    expect(data.existingPlanKey).toBe("api_starter");
+  });
+
+  test("allows genuine upgrade above all active rows (pro_monthly + api_starter → enterprise)", async () => {
+    // Enterprise is tier 3, strictly higher than both active rows (tier 1 + 2).
+    // This must still flow through as an upgrade.
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "active", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    await seedSub(t, { status: "active", planKey: "api_starter", dodoProductId: API_STARTER_PRODUCT });
+    const err = await runCheckoutAndCaptureError(t, ENTERPRISE_PRODUCT);
+    expect(isAlreadySubscribedError(err)).toBe(false);
+  });
+
+  test("on_hold takes priority even when a higher-tier active row exists", async () => {
+    // If ANY sub is on_hold we block regardless of tier, because the user
+    // must fix the failed-payment sub before starting a parallel one.
+    const t = convexTest(schema, modules);
+    await seedSub(t, { status: "on_hold", planKey: "pro_monthly", dodoProductId: PRO_MONTHLY_PRODUCT });
+    await seedSub(t, { status: "active", planKey: "api_starter", dodoProductId: API_STARTER_PRODUCT });
+    const err = await runCheckoutAndCaptureError(t, ENTERPRISE_PRODUCT);
+    expect(isAlreadySubscribedError(err)).toBe(true);
+    const data = parseErrorData(err)!;
+    expect(data.existingStatus).toBe("on_hold");
+    expect(data.existingPlanKey).toBe("pro_monthly");
   });
 });

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -799,6 +799,28 @@ http.route({
         headers: { "Content-Type": "application/json" },
       });
     } catch (err) {
+      // Structured ConvexError payload (e.g. already_subscribed) propagates to
+      // the edge so the browser can render a "manage subscription" UX instead
+      // of opening a second Dodo checkout. ConvexError.data is serialized as
+      // a JSON string when it crosses the action boundary — parse before
+      // matching on the code field.
+      const rawData = (err as { data?: unknown })?.data;
+      let parsed: Record<string, unknown> | null = null;
+      if (typeof rawData === "string") {
+        try {
+          parsed = JSON.parse(rawData);
+        } catch {
+          parsed = null;
+        }
+      } else if (rawData && typeof rawData === "object") {
+        parsed = rawData as Record<string, unknown>;
+      }
+      if (parsed && parsed.code === "already_subscribed") {
+        return new Response(JSON.stringify({ error: parsed }), {
+          status: 409,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
       const msg = err instanceof Error ? err.message : "Checkout creation failed";
       return new Response(JSON.stringify({ error: msg }), {
         status: 500,

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -133,6 +133,34 @@ export const getActiveSubscription = internalQuery({
   },
 });
 
+/**
+ * Internal query used by checkout to decide whether a new purchase should
+ * be blocked. Returns the strongest existing subscription that makes a new
+ * checkout a duplicate or conflicting purchase:
+ *
+ *   - "active"  → user is already paying; caller decides by tier comparison
+ *   - "on_hold" → payment failed; block new checkouts and surface the
+ *                 billing portal instead of creating parallel subscriptions
+ *
+ * Cancelled/expired subs are ignored — the user is allowed to resubscribe.
+ * Prefers active over on_hold so the caller sees the representative record.
+ */
+export const getBlockingSubscription = internalQuery({
+  args: { userId: v.string() },
+  handler: async (ctx, args) => {
+    const allSubs = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .take(50);
+
+    return (
+      allSubs.find((s) => s.status === "active") ??
+      allSubs.find((s) => s.status === "on_hold") ??
+      null
+    );
+  },
+});
+
 // ---------------------------------------------------------------------------
 // Actions
 // ---------------------------------------------------------------------------

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -134,29 +134,25 @@ export const getActiveSubscription = internalQuery({
 });
 
 /**
- * Internal query used by checkout to decide whether a new purchase should
- * be blocked. Returns the strongest existing subscription that makes a new
- * checkout a duplicate or conflicting purchase:
+ * Internal query returning every subscription that would block or constrain
+ * a new checkout: all active + on_hold rows for the user. Cancelled and
+ * expired rows are filtered out (the user may freely resubscribe).
  *
- *   - "active"  → user is already paying; caller decides by tier comparison
- *   - "on_hold" → payment failed; block new checkouts and surface the
- *                 billing portal instead of creating parallel subscriptions
- *
- * Cancelled/expired subs are ignored — the user is allowed to resubscribe.
- * Prefers active over on_hold so the caller sees the representative record.
+ * Callers must evaluate the full list — there is no "winning" row. Picking
+ * one row and comparing tiers against it is unsafe because a user can have
+ * multiple active rows at different tiers (e.g. a stale pro_monthly that
+ * was never cancelled plus a current api_starter), and comparing against
+ * the wrong one allows a same-tier duplicate to slip through.
  */
-export const getBlockingSubscription = internalQuery({
+export const getBlockingSubscriptions = internalQuery({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
     const allSubs = await ctx.db
       .query("subscriptions")
       .withIndex("by_userId", (q) => q.eq("userId", args.userId))
-      .take(50);
-
-    return (
-      allSubs.find((s) => s.status === "active") ??
-      allSubs.find((s) => s.status === "on_hold") ??
-      null
+      .take(100);
+    return allSubs.filter(
+      (s) => s.status === "active" || s.status === "on_hold",
     );
   },
 });

--- a/convex/payments/checkout.ts
+++ b/convex/payments/checkout.ts
@@ -77,13 +77,17 @@ async function _createCheckoutSession(
   // customer cus_0NcmwcAWw0jhVBHVOK58C paid Pro Monthly twice within 32 min).
   //
   // Block:
-  //   - Same tier already active (duplicate — nothing to buy)
-  //   - Higher tier already active (downgrade — must use billing portal)
-  //   - on_hold (payment failed — must update payment method in portal)
+  //   - Any on_hold row (payment failed — must update payment method)
+  //   - Any active row at the same or higher tier as the requested product
+  //     (duplicate same-tier purchase, or attempted downgrade)
   //
   // Allow:
-  //   - No subscription, or only cancelled/expired subs (resubscribe)
-  //   - Upgrade: existing tier strictly lower than requested
+  //   - No subscription, or only cancelled/expired rows (resubscribe)
+  //   - Upgrade: every active row is strictly lower tier than requested
+  //
+  // We must evaluate ALL active rows, not just one: a user may have a stale
+  // active sub at one tier and a current active sub at another, and picking
+  // the wrong row as the baseline lets a same-tier duplicate slip through.
   const requestedPlanKey = resolveProductToPlan(args.productId);
   if (!requestedPlanKey) {
     throw new ConvexError(
@@ -96,28 +100,47 @@ async function _createCheckoutSession(
       `Resolved plan ${requestedPlanKey} is not in PRODUCT_CATALOG.`,
     );
   }
-  const existing = await ctx.runQuery(
-    internal.payments.billing.getBlockingSubscription,
+  const requestedTier = requestedCatalog.features.tier;
+  const existingSubs = await ctx.runQuery(
+    internal.payments.billing.getBlockingSubscriptions,
     { userId: user.userId },
   );
-  if (existing) {
-    const existingCatalog = PRODUCT_CATALOG[existing.planKey];
-    const existingTier = existingCatalog?.features.tier ?? 0;
-    const requestedTier = requestedCatalog.features.tier;
-    const isUpgrade =
-      existing.status === "active" && existingTier < requestedTier;
-    if (!isUpgrade) {
-      throw new ConvexError({
-        code: "already_subscribed",
-        existingStatus: existing.status,
-        existingPlanKey: existing.planKey,
-        currentPeriodEnd: existing.currentPeriodEnd,
-        message:
-          existing.status === "on_hold"
-            ? "Your subscription is on hold due to a payment issue. Update your payment method in the billing portal instead of starting a new subscription."
-            : "You already have an active subscription. Manage it in the billing portal.",
-      });
+
+  // on_hold takes priority — no new checkouts while a payment is unresolved.
+  const onHold = existingSubs.find((s) => s.status === "on_hold");
+  if (onHold) {
+    throw new ConvexError({
+      code: "already_subscribed",
+      existingStatus: "on_hold",
+      existingPlanKey: onHold.planKey,
+      currentPeriodEnd: onHold.currentPeriodEnd,
+      message:
+        "Your subscription is on hold due to a payment issue. Update your payment method in the billing portal instead of starting a new subscription.",
+    });
+  }
+
+  // Find the highest-tier active row across all active subs. Block if any
+  // active row has tier >= requested — only true upgrades (every active row
+  // strictly lower) are allowed through.
+  let highestActive: (typeof existingSubs)[number] | null = null;
+  let highestActiveTier = -1;
+  for (const sub of existingSubs) {
+    if (sub.status !== "active") continue;
+    const tier = PRODUCT_CATALOG[sub.planKey]?.features.tier ?? 0;
+    if (tier > highestActiveTier) {
+      highestActiveTier = tier;
+      highestActive = sub;
     }
+  }
+  if (highestActive && highestActiveTier >= requestedTier) {
+    throw new ConvexError({
+      code: "already_subscribed",
+      existingStatus: "active",
+      existingPlanKey: highestActive.planKey,
+      currentPeriodEnd: highestActive.currentPeriodEnd,
+      message:
+        "You already have an active subscription. Manage it in the billing portal.",
+    });
   }
 
   // Build metadata: HMAC-signed userId for the webhook identity bridge.

--- a/convex/payments/checkout.ts
+++ b/convex/payments/checkout.ts
@@ -11,9 +11,14 @@
 
 import { v, ConvexError } from "convex/values";
 import { action, internalAction, type ActionCtx } from "../_generated/server";
+import { internal } from "../_generated/api";
 import { checkout } from "../lib/dodo";
 import { requireUserId, resolveUserIdentity } from "../lib/auth";
 import { signUserId } from "../lib/identitySigning";
+import {
+  PRODUCT_CATALOG,
+  resolveProductToPlan,
+} from "../config/productCatalog";
 
 // ---------------------------------------------------------------------------
 // Shared checkout session creation logic
@@ -64,6 +69,55 @@ async function _createCheckoutSession(
       );
     }
     returnUrl = parsedReturnUrl.toString();
+  }
+
+  // Duplicate-subscription guard. Prevents the case where a user clicks
+  // "Subscribe" twice during a slow webhook activation and ends up with two
+  // parallel Dodo subscriptions + two charges (incident 2026-04-17/18:
+  // customer cus_0NcmwcAWw0jhVBHVOK58C paid Pro Monthly twice within 32 min).
+  //
+  // Block:
+  //   - Same tier already active (duplicate — nothing to buy)
+  //   - Higher tier already active (downgrade — must use billing portal)
+  //   - on_hold (payment failed — must update payment method in portal)
+  //
+  // Allow:
+  //   - No subscription, or only cancelled/expired subs (resubscribe)
+  //   - Upgrade: existing tier strictly lower than requested
+  const requestedPlanKey = resolveProductToPlan(args.productId);
+  if (!requestedPlanKey) {
+    throw new ConvexError(
+      `Unknown productId ${args.productId}. Add it to PRODUCT_CATALOG or seed the alias.`,
+    );
+  }
+  const requestedCatalog = PRODUCT_CATALOG[requestedPlanKey];
+  if (!requestedCatalog) {
+    throw new ConvexError(
+      `Resolved plan ${requestedPlanKey} is not in PRODUCT_CATALOG.`,
+    );
+  }
+  const existing = await ctx.runQuery(
+    internal.payments.billing.getBlockingSubscription,
+    { userId: user.userId },
+  );
+  if (existing) {
+    const existingCatalog = PRODUCT_CATALOG[existing.planKey];
+    const existingTier = existingCatalog?.features.tier ?? 0;
+    const requestedTier = requestedCatalog.features.tier;
+    const isUpgrade =
+      existing.status === "active" && existingTier < requestedTier;
+    if (!isUpgrade) {
+      throw new ConvexError({
+        code: "already_subscribed",
+        existingStatus: existing.status,
+        existingPlanKey: existing.planKey,
+        currentPeriodEnd: existing.currentPeriodEnd,
+        message:
+          existing.status === "on_hold"
+            ? "Your subscription is on hold due to a payment issue. Update your payment method in the billing portal instead of starting a new subscription."
+            : "You already have an active subscription. Manage it in the billing portal.",
+      });
+    }
   }
 
   // Build metadata: HMAC-signed userId for the webhook identity bridge.

--- a/pro-test/src/services/checkout.ts
+++ b/pro-test/src/services/checkout.ts
@@ -144,6 +144,17 @@ async function doCheckout(
 
     if (!resp.ok) {
       const err = await resp.json().catch(() => ({}));
+      if (resp.status === 409 && err?.error?.code === 'already_subscribed') {
+        // Already subscribed — point the user at their active subscription
+        // on the dashboard instead of starting a duplicate checkout.
+        const endStr = new Date(err.error.currentPeriodEnd ?? Date.now())
+          .toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+        alert(
+          `${err.error.message ?? 'You already have an active subscription.'}\n\nCurrent period ends ${endStr}.`,
+        );
+        window.location.href = 'https://worldmonitor.app';
+        return false;
+      }
       console.error('[checkout] Edge error:', resp.status, err);
       return false;
     }

--- a/src/services/checkout-errors.ts
+++ b/src/services/checkout-errors.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure types and discriminators for the checkout error surface.
+ *
+ * Split out of src/services/checkout.ts because that module imports
+ * browser-only SDKs (`dodopayments-checkout`, Clerk) that can't be loaded in
+ * node:test. Mirrors the repo convention of sibling `-errors`/`-utils` files
+ * used where panels or services need pure helpers testable from node.
+ */
+
+export interface AlreadySubscribedError {
+  code: 'already_subscribed';
+  existingStatus: 'active' | 'on_hold';
+  existingPlanKey: string;
+  currentPeriodEnd: number;
+  message: string;
+}
+
+/**
+ * Discriminator for the structured 409 payload produced by
+ * convex/payments/checkout.ts. A true return routes the caller to the
+ * "Manage subscription" modal; false falls through to generic error handling.
+ */
+export function isAlreadySubscribedError(
+  value: unknown,
+): value is AlreadySubscribedError {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    (value as { code?: unknown }).code === 'already_subscribed'
+  );
+}

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -16,6 +16,10 @@ import { DodoPayments } from 'dodopayments-checkout';
 import type { CheckoutEvent } from 'dodopayments-checkout';
 import { getCurrentClerkUser, getClerkToken } from './clerk';
 import { openBillingPortal } from './billing';
+import {
+  type AlreadySubscribedError,
+  isAlreadySubscribedError,
+} from './checkout-errors';
 
 const CHECKOUT_PRODUCT_PARAM = 'checkoutProduct';
 const CHECKOUT_REFERRAL_PARAM = 'checkoutReferral';
@@ -286,21 +290,6 @@ export async function startCheckout(
   }
 }
 
-interface AlreadySubscribedError {
-  code: 'already_subscribed';
-  existingStatus: 'active' | 'on_hold';
-  existingPlanKey: string;
-  currentPeriodEnd: number;
-  message: string;
-}
-
-function isAlreadySubscribedError(value: unknown): value is AlreadySubscribedError {
-  return (
-    !!value &&
-    typeof value === 'object' &&
-    (value as { code?: unknown }).code === 'already_subscribed'
-  );
-}
 
 /**
  * Blocking modal that tells the user they already have a subscription and

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -15,6 +15,7 @@ import * as Sentry from '@sentry/browser';
 import { DodoPayments } from 'dodopayments-checkout';
 import type { CheckoutEvent } from 'dodopayments-checkout';
 import { getCurrentClerkUser, getClerkToken } from './clerk';
+import { openBillingPortal } from './billing';
 
 const CHECKOUT_PRODUCT_PARAM = 'checkoutProduct';
 const CHECKOUT_REFERRAL_PARAM = 'checkoutReferral';
@@ -257,6 +258,13 @@ export async function startCheckout(
 
     if (!resp.ok) {
       const err = await resp.json().catch(() => ({}));
+      if (resp.status === 409 && isAlreadySubscribedError(err?.error)) {
+        // User already has an active/on_hold subscription. Route to billing
+        // portal instead of opening another Dodo checkout — prevents the
+        // double-charge that hit cus_0NcmwcAWw0jhVBHVOK58C on 2026-04-17/18.
+        await showAlreadySubscribedDialog(err.error);
+        return false;
+      }
       console.error('[checkout] Edge endpoint error:', resp.status, err);
       if (fallbackToPricingPage) window.open('https://worldmonitor.app/pro', '_blank');
       return false;
@@ -276,6 +284,156 @@ export async function startCheckout(
   } finally {
     _checkoutInFlight = false;
   }
+}
+
+interface AlreadySubscribedError {
+  code: 'already_subscribed';
+  existingStatus: 'active' | 'on_hold';
+  existingPlanKey: string;
+  currentPeriodEnd: number;
+  message: string;
+}
+
+function isAlreadySubscribedError(value: unknown): value is AlreadySubscribedError {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    (value as { code?: unknown }).code === 'already_subscribed'
+  );
+}
+
+/**
+ * Blocking modal that tells the user they already have a subscription and
+ * offers to open the billing portal. Returns once the user dismisses.
+ * Intentionally vanilla DOM — the main app is not a framework, and every
+ * other dialog-style surface in this file uses the same pattern.
+ */
+function showAlreadySubscribedDialog(err: AlreadySubscribedError): Promise<void> {
+  return new Promise((resolve) => {
+    const existing = document.getElementById('already-subscribed-dialog');
+    if (existing) existing.remove();
+
+    const dateLabel = Number.isFinite(err.currentPeriodEnd)
+      ? new Date(err.currentPeriodEnd).toLocaleDateString(undefined, {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        })
+      : null;
+
+    const overlay = document.createElement('div');
+    overlay.id = 'already-subscribed-dialog';
+    Object.assign(overlay.style, {
+      position: 'fixed',
+      inset: '0',
+      background: 'rgba(0,0,0,0.72)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: '99999',
+      padding: '20px',
+    });
+
+    const card = document.createElement('div');
+    Object.assign(card.style, {
+      background: '#111',
+      border: '1px solid #2a2a2a',
+      borderRadius: '8px',
+      padding: '24px',
+      maxWidth: '440px',
+      color: '#e8e8e8',
+      fontFamily: "'SF Mono', Monaco, 'Cascadia Code', monospace",
+      fontSize: '14px',
+      lineHeight: '1.5',
+      boxShadow: '0 20px 60px rgba(0,0,0,0.6)',
+    });
+
+    const title = document.createElement('div');
+    title.textContent =
+      err.existingStatus === 'on_hold'
+        ? 'Your subscription needs attention'
+        : 'You already have Pro';
+    Object.assign(title.style, {
+      fontSize: '16px',
+      fontWeight: '600',
+      marginBottom: '12px',
+      color: '#fff',
+    });
+
+    const body = document.createElement('div');
+    body.textContent = err.message;
+    body.style.marginBottom = '16px';
+
+    const details = document.createElement('div');
+    details.textContent = dateLabel
+      ? `Current period ends ${dateLabel}.`
+      : '';
+    Object.assign(details.style, {
+      color: '#909090',
+      fontSize: '12px',
+      marginBottom: '20px',
+    });
+
+    const buttonRow = document.createElement('div');
+    Object.assign(buttonRow.style, {
+      display: 'flex',
+      gap: '8px',
+      justifyContent: 'flex-end',
+    });
+
+    const close = (): void => {
+      overlay.remove();
+      resolve();
+    };
+
+    const dismiss = document.createElement('button');
+    dismiss.type = 'button';
+    dismiss.textContent = 'Close';
+    Object.assign(dismiss.style, {
+      background: 'transparent',
+      border: '1px solid #323232',
+      color: '#e8e8e8',
+      padding: '8px 16px',
+      borderRadius: '4px',
+      cursor: 'pointer',
+      fontFamily: 'inherit',
+      fontSize: '13px',
+    });
+    dismiss.addEventListener('click', close);
+
+    const openPortal = document.createElement('button');
+    openPortal.type = 'button';
+    openPortal.textContent =
+      err.existingStatus === 'on_hold' ? 'Update payment method' : 'Manage subscription';
+    Object.assign(openPortal.style, {
+      background: '#22c55e',
+      border: 'none',
+      color: '#0d0d0d',
+      padding: '8px 16px',
+      borderRadius: '4px',
+      cursor: 'pointer',
+      fontWeight: '600',
+      fontFamily: 'inherit',
+      fontSize: '13px',
+    });
+    openPortal.addEventListener('click', () => {
+      void openBillingPortal();
+      close();
+    });
+
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) close();
+    });
+
+    buttonRow.appendChild(dismiss);
+    buttonRow.appendChild(openPortal);
+    card.appendChild(title);
+    card.appendChild(body);
+    if (dateLabel) card.appendChild(details);
+    card.appendChild(buttonRow);
+    overlay.appendChild(card);
+    document.body.appendChild(overlay);
+  });
 }
 
 /**

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -266,6 +266,14 @@ export async function startCheckout(
         // User already has an active/on_hold subscription. Route to billing
         // portal instead of opening another Dodo checkout — prevents the
         // double-charge that hit cus_0NcmwcAWw0jhVBHVOK58C on 2026-04-17/18.
+        //
+        // Consume any pending checkout intent stored in sessionStorage. The
+        // intent exists only to replay a /pro handoff once the user has
+        // signed in; a 409 "already subscribed" means the intent is fully
+        // resolved, and leaving it behind would re-trigger this same modal
+        // on every subsequent app startup until the sub is cancelled or the
+        // session ends.
+        clearPendingCheckoutIntent();
         await showAlreadySubscribedDialog(err.error);
         return false;
       }

--- a/tests/already-subscribed-error.test.mts
+++ b/tests/already-subscribed-error.test.mts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for isAlreadySubscribedError.
+ *
+ * This discriminator decides whether a 409 response from /api/create-checkout
+ * should open the "Manage subscription" modal or fall through to the generic
+ * error path. Getting it wrong means either (a) silently letting the user
+ * open a duplicate Dodo checkout (what hit cus_0NcmwcAWw0jhVBHVOK58C on
+ * 2026-04-17/18) or (b) showing the modal on unrelated errors.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { isAlreadySubscribedError } from '@/services/checkout-errors';
+
+describe('isAlreadySubscribedError', () => {
+  it('accepts the exact structured payload produced by the Convex guard', () => {
+    const payload = {
+      code: 'already_subscribed',
+      existingStatus: 'active',
+      existingPlanKey: 'pro_monthly',
+      currentPeriodEnd: 1779061911916,
+      message: 'You already have an active subscription. Manage it in the billing portal.',
+    };
+    assert.equal(isAlreadySubscribedError(payload), true);
+  });
+
+  it('accepts the on_hold variant', () => {
+    const payload = {
+      code: 'already_subscribed',
+      existingStatus: 'on_hold',
+      existingPlanKey: 'pro_monthly',
+      currentPeriodEnd: 1779061911916,
+      message: 'Your subscription is on hold due to a payment issue.',
+    };
+    assert.equal(isAlreadySubscribedError(payload), true);
+  });
+
+  it('rejects null and undefined', () => {
+    assert.equal(isAlreadySubscribedError(null), false);
+    assert.equal(isAlreadySubscribedError(undefined), false);
+  });
+
+  it('rejects primitives', () => {
+    assert.equal(isAlreadySubscribedError('already_subscribed'), false);
+    assert.equal(isAlreadySubscribedError(409), false);
+    assert.equal(isAlreadySubscribedError(true), false);
+  });
+
+  it('rejects objects with the wrong code', () => {
+    assert.equal(isAlreadySubscribedError({ code: 'not_found' }), false);
+    assert.equal(isAlreadySubscribedError({ code: 'internal_error' }), false);
+  });
+
+  it('rejects objects missing the code field', () => {
+    assert.equal(isAlreadySubscribedError({}), false);
+    assert.equal(isAlreadySubscribedError({ message: 'something' }), false);
+  });
+
+  it('rejects objects where code is not the string "already_subscribed"', () => {
+    assert.equal(isAlreadySubscribedError({ code: 1 }), false);
+    assert.equal(isAlreadySubscribedError({ code: true }), false);
+    assert.equal(isAlreadySubscribedError({ code: {} }), false);
+  });
+
+  it('accepts extra fields (forward-compatible)', () => {
+    const payload = {
+      code: 'already_subscribed',
+      existingStatus: 'active',
+      existingPlanKey: 'pro_monthly',
+      currentPeriodEnd: 1779061911916,
+      message: 'x',
+      newFutureField: 'ignore me',
+    };
+    assert.equal(isAlreadySubscribedError(payload), true);
+  });
+});


### PR DESCRIPTION
## Summary

Prevents the exact double-charge from incident 2026-04-17/18 by rejecting new Dodo checkouts for users who already have an active or on_hold subscription at the same (or lower) tier. Works in tandem with #3163 (PR1 activation-race fix) but is independently correct and shippable.

### Guard semantics

| Existing subscription | Requested product | Result |
|---|---|---|
| _(none)_ | _any_ | Allow |
| `cancelled` / `expired` | _any_ | Allow (resubscribe) |
| `active`, same tier group | same or sibling (e.g. monthly vs annual) | **Block** `already_subscribed` |
| `active`, lower tier | higher tier | Allow (upgrade path) |
| `active`, higher tier | lower tier | **Block** (downgrade → billing portal) |
| `on_hold` | _any_ | **Block** with "update payment method" hint |

### Error plumbing

- Convex: `_createCheckoutSession` throws `new ConvexError({ code: "already_subscribed", existingStatus, existingPlanKey, currentPeriodEnd, message })` before the Dodo SDK call.
- `/relay/create-checkout`: parses `ConvexError.data` (serialized as a JSON string across the action boundary), returns HTTP **409** with the structured payload.
- `api/create-checkout.ts` (edge): forwards the 409 unchanged.
- Browser (`src/services/checkout.ts`): modal offering `Manage subscription` / `Update payment method` that opens the Dodo customer portal. `/pro` page uses a simpler `alert` + redirect to dashboard.

### New internal query

- `getBlockingSubscription(userId)` in `convex/payments/billing.ts` — prefers `active` over `on_hold`, ignores `cancelled`/`expired`. Kept separate from the existing `getActiveSubscription` so plan-change validation semantics are unchanged.

## Testing

- **79/79** existing convex tests pass.
- **11 new** tests in `convex/__tests__/duplicate-subscription-guard.test.ts`:
  - `getBlockingSubscription` — all 5 status combinations.
  - `internalCreateCheckout` guard — blocks same-tier, blocks cross-product same-tier (monthly vs annual), blocks `on_hold`, allows tier upgrade, allows resubscribe after cancelled, allows resubscribe after expired.
- `npm run typecheck:all` — clean.
- `npm run lint` on changed files — no new warnings.

Manual test checklist for a reviewer:
- Seed an `active` `pro_monthly` row for a test user via `t.run`, call `/api/create-checkout` with `pro_monthly` product → expect HTTP 409 + modal.
- Same with `api_starter` product → expect 200 (upgrade) + Dodo checkout opens.
- Seed an `on_hold` row → expect 409 with "update payment method" text.
- Full E2E in test mode: pay once, try to pay again → modal blocks, "Manage subscription" opens portal.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Sentry: filter `component:dodo-checkout` for any new 409 error spikes. Expected: small volume proportional to "already subscribed" click-throughs.
  - Dodo dashboard: refund count with reason `"Duplicate transaction"` should drop to ~0 for newly-created subs.
  - Vercel edge logs for `[create-checkout] Relay error: 409` — confirms the new path is firing.
- **Validation checks**
  - After deploy, in a test-mode account: subscribe once, then click subscribe again. Expect modal not a second Dodo overlay.
  - `gh pr view` + deploy green.
- **Expected healthy signals**
  - Active subscribers clicking any Pro/API CTA see the "Manage subscription" modal rather than a second checkout.
  - Upgrades (monthly → annual is still blocked as same-tier; Pro → API Starter allowed) proceed normally.
- **Failure signal / rollback trigger**
  - Any report of a legitimate upgrade or resubscribe being blocked. Revert via `git revert <merge commit>`.
  - Unexpected 500s in `/relay/create-checkout` due to missed error-parsing path.
- **Validation window & owner**
  - 72h post-merge. Owner: @koala73.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>