### PR TITLE
fix(brief): clerk-pro-only gate + generation-guarded Clerk token cache

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -127,6 +127,23 @@ const WEB_PREMIUM_PANELS = new Set([
   'latest-brief',
 ]);
 
+/**
+ * Panels that require a Clerk-authenticated PRO account specifically.
+ * Desktop API key / browser tester keys do NOT satisfy the gate because
+ * these panels are bound to a Clerk userId server-side (e.g. the Brief
+ * is stored at brief:{clerkUserId}:{date} in Redis — no Clerk user, no
+ * brief to fetch).
+ *
+ * Without this extra gate, API-key + free-Clerk users would see the
+ * panel "unlocked" by hasPremiumAccess() and then hit a 403 when the
+ * server re-checks entitlement from the JWT. This set promotes the
+ * inconsistency to the layout gating layer so the user sees the
+ * correct "Upgrade to Pro" CTA instead of a doomed fetch.
+ */
+const WEB_CLERK_PRO_ONLY_PANELS = new Set([
+  'latest-brief',
+]);
+
 export interface PanelLayoutManagerCallbacks {
   openCountryStory: (code: string, name: string) => void;
   openCountryBrief: (code: string) => void;
@@ -266,7 +283,20 @@ export class PanelLayoutManager implements AppModule {
   private updatePanelGating(state: AuthSession): void {
     for (const [key, panel] of Object.entries(this.ctx.panels)) {
       const isPremium = WEB_PREMIUM_PANELS.has(key);
-      const reason = getPanelGateReason(state, isPremium);
+      let reason = getPanelGateReason(state, isPremium);
+
+      // Clerk-pro-only panels: even when hasPremiumAccess() returns true
+      // via API/tester key, these panels cannot function without a Clerk
+      // userId bound to a PRO plan. Downgrade the gate reason so the user
+      // sees the correct CTA (sign-in or upgrade) instead of an unlocked
+      // panel that then fails to fetch.
+      if (
+        reason === PanelGateReason.NONE &&
+        WEB_CLERK_PRO_ONLY_PANELS.has(key) &&
+        state.user?.role !== 'pro'
+      ) {
+        reason = state.user ? PanelGateReason.FREE_TIER : PanelGateReason.ANONYMOUS;
+      }
 
       if (reason === PanelGateReason.NONE) {
         // User has access -- unlock if previously locked

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -112,6 +112,8 @@ export function openSignIn(): void {
 export async function signOut(): Promise<void> {
   _cachedToken = null;
   _cachedTokenAt = 0;
+  _tokenInflight = null;
+  _tokenGen++;
   await clerkInstance?.signOut();
 }
 
@@ -120,15 +122,19 @@ export async function signOut(): Promise<void> {
  *   - Convex signals a 401 via forceRefreshToken
  *   - The observed Clerk user changes (account switch / sign-out)
  *
- * Also drops the inflight promise so an A→B switch while a token
- * fetch is mid-air doesn't let the next caller reuse A's promise.
- * The old promise still resolves to its closure but nothing
- * downstream references it once this runs.
+ * Bumping _tokenGen invalidates any promise that was already awaiting
+ * session.getToken() before the clear. When that promise resolves, its
+ * closure compares its captured generation to the current one and
+ * refuses to write the stale token into the cache or return it to its
+ * (now detached) callers. Without the generation check, an A→B switch
+ * mid-fetch would let the old promise land A's JWT as B's cache entry
+ * and poison the next 50 seconds of requests.
  */
 export function clearClerkTokenCache(): void {
   _cachedToken = null;
   _cachedTokenAt = 0;
   _tokenInflight = null;
+  _tokenGen++;
 }
 
 /**
@@ -138,10 +144,14 @@ export function clearClerkTokenCache(): void {
  *
  * Tokens are cached for 50s (Clerk tokens expire at 60s) with in-flight
  * deduplication to prevent concurrent panels from racing against Clerk.
+ * A monotonic _tokenGen counter lets clearClerkTokenCache() invalidate
+ * any mid-flight fetch whose result would otherwise paint the previous
+ * user's JWT into the new session.
  */
 let _cachedToken: string | null = null;
 let _cachedTokenAt = 0;
 let _tokenInflight: Promise<string | null> | null = null;
+let _tokenGen = 0;
 const TOKEN_CACHE_TTL_MS = 50_000;
 
 export async function getClerkToken(): Promise<string | null> {
@@ -150,14 +160,16 @@ export async function getClerkToken(): Promise<string | null> {
   }
   if (_tokenInflight) return _tokenInflight;
 
-  _tokenInflight = (async () => {
+  const myGen = _tokenGen;
+  const promise: Promise<string | null> = (async () => {
     if (!clerkInstance && PUBLISHABLE_KEY) {
       try { await initClerk(); } catch { /* Clerk load failed, proceed with null */ }
     }
+    // If a session invalidation fired during initClerk(), abandon.
+    if (myGen !== _tokenGen) return null;
     const session = clerkInstance?.session;
     if (!session) {
       console.warn(`[clerk] getClerkToken: no session (clerkInstance=${!!clerkInstance}, user=${!!clerkInstance?.user})`);
-      _tokenInflight = null;
       return null;
     }
     try {
@@ -165,6 +177,10 @@ export async function getClerkToken(): Promise<string | null> {
       // Fall back to the standard session token if the template isn't configured in Clerk.
       const token = (await session.getToken({ template: 'convex' }).catch(() => null))
         ?? await session.getToken().catch(() => null);
+      // If the session generation advanced while getToken() was in
+      // flight, this JWT belongs to the previous user. Drop it on the
+      // floor — do not cache, do not return.
+      if (myGen !== _tokenGen) return null;
       if (token) {
         _cachedToken = token;
         _cachedTokenAt = Date.now();
@@ -173,10 +189,15 @@ export async function getClerkToken(): Promise<string | null> {
     } catch {
       return null;
     } finally {
-      _tokenInflight = null;
+      // Only clear _tokenInflight if we are still the current generation.
+      // If clearClerkTokenCache() fired during our await it has already
+      // nulled _tokenInflight AND bumped _tokenGen; a newer caller may
+      // have assigned a fresh promise that we must not clobber.
+      if (myGen === _tokenGen) _tokenInflight = null;
     }
   })();
-  return _tokenInflight;
+  _tokenInflight = promise;
+  return promise;
 }
 
 


### PR DESCRIPTION
## Summary

Two P1 race/gate findings from post-merge review of #3160. Both are real against `main` today.

### Finding 1 — mixed-auth path (`LatestBriefPanel.ts:158-166`, `panel-gating.ts:15-19`, `widget-store.ts:170-171`, `api/latest-brief.ts:101-123`)

`hasPremiumAccess()` unlocks any panel that has *some* premium access: desktop API key, browser tester key, OR Clerk Pro. The Brief panel is bound to a Clerk `userId` in Redis (`brief:{userId}:{date}`) — there is no Redis key an API-key-only user could read, and the server's entitlement re-check returns 403.

Today the panel "unlocks" for those users and then paints an upgrade CTA inside an unlocked body — inconsistent UX, and one more doomed server round-trip per refresh.

**Fix**: `WEB_CLERK_PRO_ONLY_PANELS` set in `panel-layout.ts`. When a panel is in this set AND `state.user?.role !== 'pro'`, the layout promotes the gate reason from `NONE` to `FREE_TIER` (or `ANONYMOUS` when no Clerk user at all). The panel now renders the same locked overlay an actual free user sees.

### Finding 2 — account-switch token leak (`src/services/clerk.ts:119-169`)

Before this PR:

```ts
export function clearClerkTokenCache(): void {
  _cachedToken = null;
  _cachedTokenAt = 0;
  _tokenInflight = null;   // ← doesn't cancel the already-running promise
}
```

If user A's token fetch is already awaiting `session.getToken()` when the app switches to user B, the old promise **keeps running**. When it resolves it unconditionally writes `_cachedToken = tokenA` and returns `tokenA` to whatever callers were already awaiting it. The cache is now poisoned with A's JWT for up to 50s. A fresh `getClerkToken()` after the switch returns A's token, the server happily validates it as A, and the panel's post-response `requestUserId` guard can't tell the difference because `requestUserId` was captured as B.

**Fix**: monotonic `_tokenGen` counter. Incremented by both `clearClerkTokenCache()` and `signOut()`. Each `getClerkToken()` call captures `myGen` on entry; if `_tokenGen` has advanced by the time the JWT arrives, the closure drops it on the floor — no cache write, no return value. The `finally` block also guards `_tokenInflight = null` so a newer generation's inflight promise isn't clobbered by the old generation's cleanup.

## Files

| File | Change |
|------|--------|
| `src/app/panel-layout.ts` | `WEB_CLERK_PRO_ONLY_PANELS` set + gate promotion in `updatePanelGating()` |
| `src/services/clerk.ts` | `_tokenGen` counter; `signOut()` + `clearClerkTokenCache()` bump it; `getClerkToken()` checks it on every boundary |

## Why the layout-level fix over a stricter `hasPremiumAccess()`

`hasPremiumAccess()` is the app-wide "any premium path" check — tightening it to require Clerk Pro would break every other premium panel (stock-analysis, daily-market-brief, etc.) that legitimately works via API key. The Brief is the outlier: its server-side contract is Clerk-keyed. Scoping the restriction to a per-panel set keeps the general case correct.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx tsc --noEmit -p tsconfig.api.json` — clean
- [x] `node --test tests/brief-*.test.mjs tests/deploy-config.test.mjs` — 94/94 pass
- [ ] Manual: browser tester key + free Clerk account → Brief panel shows "Upgrade to Pro" locked overlay (not inline CTA). Upgrade to Pro → panel unlocks and loads.
- [ ] Manual: sign in as A, fire a refresh, within 50s sign out and in as B, refresh again → B's brief renders, never A's. No stale-cache 50s window.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: Sentry issues `BriefAccessError` with code `upgrade_required` — expect a small drop in 403s from `/api/latest-brief` (those requests won't fire any more).
  - Metrics/Dashboards: none; this is a client-side fix.
- **Validation checks**
  - Sign in with a free Clerk account that has a tester key → Brief panel shows locked overlay
  - Switch between two Clerk accounts within 50s → inspect Network: JWT `sub` in `Authorization` header matches the currently-signed-in user on every `/api/latest-brief` call
- **Expected healthy behavior**
  - No `403 pro_required` responses from `/api/latest-brief` for API-key-only sessions (requests are gated client-side before firing)
  - No cross-user brief rendering after an account switch
- **Failure signal / rollback trigger**
  - Any Sentry report of a free-Clerk user seeing *another* user's brief content → revert immediately
  - Sign-in flow on desktop (API key present) regresses → revert
- **Validation window & owner**
  - 24h post-deploy; @koala73