### PR TITLE
fix(pro): consult Convex entitlement in hasPremiumAccess + isProUser

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -203,7 +203,15 @@ export class PanelLayoutManager implements AppModule {
       if (reload) {
         console.log('[entitlements] Subscription activated — reloading to unlock panels');
         window.location.reload();
+        return;
       }
+      // Re-run panel gating on every entitlement snapshot. hasPremiumAccess()
+      // now consults isEntitled(), so a legacy-pro user whose first snapshot
+      // is already pro (null→true — intentionally not reloaded to avoid a
+      // loop) still needs the paywall overlay lifted; likewise on WS reconnect
+      // or entitlement revocation, the lock state must follow the current
+      // snapshot synchronously rather than waiting for the next auth event.
+      this.updatePanelGating(getAuthState());
     });
   }
 

--- a/src/services/panel-gating.ts
+++ b/src/services/panel-gating.ts
@@ -1,6 +1,7 @@
 import type { AuthSession } from './auth-state';
 import { getSecretState } from './runtime-config';
 import { isProUser } from './widget-store';
+import { isEntitled } from './entitlements';
 
 export enum PanelGateReason {
   NONE = 'none',           // show content (pro user, or desktop with API key, or non-premium panel)
@@ -10,12 +11,22 @@ export enum PanelGateReason {
 
 /**
  * Single source of truth for premium access.
- * Covers all access paths: desktop API key, tester keys (wm-pro-key / wm-widget-key), Clerk Pro.
+ * Covers all access paths: desktop API key, tester keys (wm-pro-key / wm-widget-key),
+ * Clerk Pro role, and Convex Dodo entitlement.
+ *
+ * The Convex entitlement check is the authoritative signal for paying
+ * customers — Clerk `publicMetadata.plan` is NOT written by our webhook
+ * pipeline, so a user with a valid Dodo subscription would otherwise show
+ * as free here even though isPanelEntitled() already allowed them past
+ * the panel-rendering gate. That split caused paying users to see the
+ * "Upgrade to Pro" paywall overlay on top of panels they were entitled to,
+ * reproducing the 2026-04-17/18 duplicate-subscription incident.
  */
 export function hasPremiumAccess(authState?: AuthSession): boolean {
   if (getSecretState('WORLDMONITOR_API_KEY').present) return true;
   if (isProUser()) return true;
   if (authState?.user?.role === 'pro') return true;
+  if (isEntitled()) return true;
   return false;
 }
 

--- a/src/services/panel-gating.ts
+++ b/src/services/panel-gating.ts
@@ -1,7 +1,6 @@
 import type { AuthSession } from './auth-state';
 import { getSecretState } from './runtime-config';
 import { isProUser } from './widget-store';
-import { isEntitled } from './entitlements';
 
 export enum PanelGateReason {
   NONE = 'none',           // show content (pro user, or desktop with API key, or non-premium panel)
@@ -12,7 +11,7 @@ export enum PanelGateReason {
 /**
  * Single source of truth for premium access.
  * Covers all access paths: desktop API key, tester keys (wm-pro-key / wm-widget-key),
- * Clerk Pro role, and Convex Dodo entitlement.
+ * Clerk Pro role, and Convex Dodo entitlement (the latter two via isProUser).
  *
  * The Convex entitlement check is the authoritative signal for paying
  * customers — Clerk `publicMetadata.plan` is NOT written by our webhook
@@ -21,12 +20,16 @@ export enum PanelGateReason {
  * the panel-rendering gate. That split caused paying users to see the
  * "Upgrade to Pro" paywall overlay on top of panels they were entitled to,
  * reproducing the 2026-04-17/18 duplicate-subscription incident.
+ *
+ * isEntitled() is folded into isProUser() (see widget-store.ts) so every
+ * call site that checks isProUser — widgets, search, event handlers —
+ * agrees with panel gating. That keeps this function a thin union of
+ * signals that aren't already covered by isProUser.
  */
 export function hasPremiumAccess(authState?: AuthSession): boolean {
   if (getSecretState('WORLDMONITOR_API_KEY').present) return true;
   if (isProUser()) return true;
   if (authState?.user?.role === 'pro') return true;
-  if (isEntitled()) return true;
   return false;
 }
 

--- a/src/services/widget-store.ts
+++ b/src/services/widget-store.ts
@@ -1,6 +1,7 @@
 import { loadFromStorage, saveToStorage } from '@/utils';
 import { sanitizeWidgetHtml } from '@/utils/widget-sanitizer';
 import { getAuthState } from '@/services/auth-state';
+import { isEntitled } from '@/services/entitlements';
 
 const STORAGE_KEY = 'wm-custom-widgets';
 const PANEL_SPANS_KEY = 'worldmonitor-panel-spans';
@@ -168,7 +169,12 @@ export function isProWidgetEnabled(): boolean {
 }
 
 export function isProUser(): boolean {
-  return isWidgetFeatureEnabled() || isProWidgetEnabled() || getAuthState().user?.role === 'pro';
+  return (
+    isWidgetFeatureEnabled() ||
+    isProWidgetEnabled() ||
+    getAuthState().user?.role === 'pro' ||
+    isEntitled()
+  );
 }
 
 export function getProWidgetKey(): string {


### PR DESCRIPTION
## Why this PR?

Follow-up to the merged #3163. Kevin Rosa (customer `cus_0NcmwcAWw0jhVBHVOK58C`) reports he is **still seeing the "Upgrade to Pro" paywall overlay** on premium panels even after PR #3163's reload and wait-for-auth fixes landed. Screenshot confirms: `PRO` badges render next to panel titles (so `isPanelEntitled()` honours his Convex entitlement), but the panel bodies are still the paywall ("Upgrade to Pro for full access to premium analytics").

## Root cause

`hasPremiumAccess` and `isProUser` never consulted the Convex entitlement. They only check:
- Desktop `WORLDMONITOR_API_KEY`
- Tester keys (`wm-pro-key`, `wm-widget-key`)
- Clerk `authState.user.role === 'pro'`

Our Dodo webhook writes to Convex `entitlements` but **never** updates Clerk `publicMetadata.plan`. So for every paying Dodo customer, the role check stays `'free'`, `hasPremiumAccess()` returns false, and `getPanelGateReason()` returns `FREE_TIER` → paywall overlay covers the panel.

PR #3163's reload strategy only helps if `hasPremiumAccess` flips true on the next load. It never did. That's why #3163 wasn't enough on its own.

## Changes

- **`src/services/panel-gating.ts`** — `hasPremiumAccess` now checks `isEntitled()` after the Clerk role check. Convex entitlement is now the authoritative paying-customer signal.
- **`src/services/widget-store.ts`** — same fix in `isProUser` so widget, search, and event-handler gates agree with panel gating.
- **`src/app/panel-layout.ts`** — after the existing free→pro reload branch in the entitlement listener, re-run `updatePanelGating(getAuthState())` on every snapshot. Without this, a legacy-pro user's `null → true` first snapshot (intentionally not reloaded to avoid a loop) would leave the paywall overlay covering unlocked panels until the next auth event. Also handles WS reconnect and entitlement revocation cleanly.

Import graph stays acyclic: `panel-gating → entitlements → convex-client → clerk`; `widget-store → entitlements` likewise.

## Testing

- `npm run typecheck:all` — clean.
- Existing 10 `shouldReloadOnEntitlementChange` unit tests still pass (contract unchanged).

Manual test for a reviewer (quickest repro):
1. With a signed-in Dodo-paying test account (or by direct Convex seeding of an `entitlements` row with `planKey: "pro_monthly"` and `validUntil` in the future).
2. Load the dashboard. Expect:
   - PRO badge next to premium panel titles (unchanged).
   - **Panel bodies show real content, not the "Upgrade to Pro" overlay** (this is the fix).
3. Simulate revocation by setting `validUntil` to a past timestamp. Expect overlay comes back without a reload.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Support inbox / Intercom for "paid but still free" complaints — rate should drop to zero.
  - Convex query on paying users (`entitlements.planKey != 'free'`): cross-reference against Sentry `isProUser()` usage to ensure no unexpected free→pro flips.
- **Validation checks (queries/commands)**
  - Ad-hoc: `npx convex run 'entitlements:getEntitlementsByUserId' '{"userId":"<kevin>"}'` already returns `pro_monthly` for Kevin. After deploy, his dashboard should show unlocked panels on a single reload.
- **Expected healthy signals**
  - Paying customers see unlocked panels immediately on load or via the existing WS snapshot → `updatePanelGating` refresh path.
  - Free users see paywall, exactly as before.
- **Failure signal / rollback trigger**
  - Reports of free users somehow getting premium content (would indicate `isEntitled()` returning true for a user without a valid entitlement — unlikely but worth watching).
  - Reports of legacy-pro users in a reload loop. Revert with `git revert <merge>`.
- **Validation window & owner**
  - 24h post-merge. Owner: @koala73.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>