### PR TITLE
fix(brief): compose magazine from digest accumulator, not news:insights

### DIFF
--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -147,9 +147,14 @@ export function userDisplayNameFromId(userId) {
 const MAX_STORIES_PER_USER = 12;
 
 /**
- * Filter + assemble a BriefEnvelope for one alert rule. Returns null
- * when the filter produces zero stories — the caller decides whether
- * to fall back to another variant or skip the user.
+ * Filter + assemble a BriefEnvelope for one alert rule from a
+ * prebuilt upstream top-stories list (news:insights:v1 shape).
+ *
+ * @deprecated The live path is composeBriefFromDigestStories(), which
+ *   reads from the same digest:accumulator pool as the email. This
+ *   entry point is kept only for tests that stub a news:insights payload
+ *   directly — real runs would ship a brief with a different story
+ *   list than the email and should use the digest-stories path.
  *
  * @param {object} rule — enabled alertRule row
  * @param {{ topStories: unknown[]; numbers: { clusters: number; multiSource: number } }} insights
@@ -175,6 +180,73 @@ export function composeBriefForRule(rule, insights, { nowMs = Date.now() } = {})
     // Same nowMs as the rest of the envelope so the function stays
     // deterministic for a given input — tests + retries see identical
     // output.
+    issuedAt: nowMs,
+    localHour: localHourInTz(nowMs, tz),
+  });
+}
+
+// ── Compose from digest-accumulator stories (the live path) ─────────────────
+
+/**
+ * Adapter: the digest accumulator hydrates stories from
+ * story:track:v1:{hash} (title / severity / lang / score /
+ * mentionCount) + story:sources:v1:{hash} SMEMBERS. It does NOT carry
+ * a category or country-code — those fields are optional in the
+ * upstream brief-filter shape and default cleanly.
+ *
+ * @param {object} s — digest-shaped story from buildDigest()
+ */
+function digestStoryToUpstreamTopStory(s) {
+  const sources = Array.isArray(s?.sources) ? s.sources : [];
+  const primarySource = sources.length > 0 ? sources[0] : 'Multiple wires';
+  return {
+    primaryTitle: typeof s?.title === 'string' ? s.title : '',
+    // Digest track hash has no separate body; the title *is* the
+    // headline AND the one-line description. The magazine renderer
+    // treats identical headline/description gracefully (stacks them).
+    // Phase 3b will swap this for an LLM-generated description.
+    description: typeof s?.title === 'string' ? s.title : '',
+    primarySource,
+    threatLevel: s?.severity,
+    // story:track:v1 carries neither field, so the brief falls back
+    // to 'General' / 'Global' via filterTopStories defaults.
+    category: typeof s?.category === 'string' ? s.category : undefined,
+    countryCode: typeof s?.countryCode === 'string' ? s.countryCode : undefined,
+  };
+}
+
+/**
+ * Compose a BriefEnvelope from a per-rule digest-accumulator pool
+ * (same stories the email digest uses), plus global insights numbers
+ * for the stats page.
+ *
+ * Returns null when no story survives the sensitivity filter — caller
+ * falls back to another variant or skips the user.
+ *
+ * @param {object} rule — enabled alertRule row
+ * @param {unknown[]} digestStories — output of buildDigest(rule, windowStart)
+ * @param {{ clusters: number; multiSource: number }} insightsNumbers
+ * @param {{ nowMs?: number }} [opts]
+ */
+export function composeBriefFromDigestStories(rule, digestStories, insightsNumbers, { nowMs = Date.now() } = {}) {
+  if (!Array.isArray(digestStories) || digestStories.length === 0) return null;
+  const sensitivity = rule.sensitivity ?? 'all';
+  const tz = rule.digestTimezone ?? 'UTC';
+  const upstreamLike = digestStories.map(digestStoryToUpstreamTopStory);
+  const stories = filterTopStories({
+    stories: upstreamLike,
+    sensitivity,
+    maxStories: MAX_STORIES_PER_USER,
+  });
+  if (stories.length === 0) return null;
+  const issueDate = issueDateInTz(nowMs, tz);
+  return assembleStubbedBriefEnvelope({
+    user: { name: userDisplayNameFromId(rule.userId), tz },
+    stories,
+    issueDate,
+    dateLong: dateLongFromIso(issueDate),
+    issue: issueCodeFromIso(issueDate),
+    insightsNumbers,
     issuedAt: nowMs,
     localHour: localHourInTz(nowMs, tz),
   });

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -31,7 +31,7 @@ const { fetchUserPreferences, extractUserContext, formatUserProfile } = require(
 const { Resend } = require('resend');
 import { readRawJsonFromUpstash, redisPipeline } from '../api/_upstash-json.js';
 import {
-  composeBriefForRule,
+  composeBriefFromDigestStories,
   extractInsights,
   groupEligibleRulesByUser,
   shouldExitNonZero as shouldExitOnBriefFailures,
@@ -81,6 +81,12 @@ const BRIEF_URL_SIGNING_SECRET = process.env.BRIEF_URL_SIGNING_SECRET ?? '';
 const WORLDMONITOR_PUBLIC_BASE_URL =
   process.env.WORLDMONITOR_PUBLIC_BASE_URL ?? 'https://worldmonitor.app';
 const BRIEF_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+// The brief is a once-per-day editorial snapshot. 24h is the natural
+// window regardless of a user's email cadence (daily / twice_daily /
+// weekly) — weekly subscribers still expect a fresh brief each day
+// in the dashboard panel. Matches DIGEST_LOOKBACK_MS so first-send
+// users see identical story pools in brief and email.
+const BRIEF_STORY_WINDOW_MS = 24 * 60 * 60 * 1000;
 const INSIGHTS_KEY = 'news:insights:v1';
 
 // Operator kill switch — used to intentionally silence brief compose
@@ -932,28 +938,41 @@ async function composeBriefsForRun(rules, nowMs) {
   }
   if (!BRIEF_COMPOSE_ENABLED) return { briefByUser, composeSuccess: 0, composeFailed: 0 };
 
-  let insightsRaw = null;
+  // The brief's story list now comes from the same digest accumulator
+  // the email reads (buildDigest). news:insights:v1 is still consulted
+  // for the global "clusters / multi-source" stat-page numbers, but no
+  // longer for the story list itself. A failed or empty insights fetch
+  // is NOT fatal — we fall back to zeroed numbers and still ship the
+  // brief, because the stories are what matter. (A mismatched brief
+  // was far worse than a brief with dashes on the stats page.)
+  let insightsNumbers = { clusters: 0, multiSource: 0 };
   try {
-    insightsRaw = await readRawJsonFromUpstash(INSIGHTS_KEY);
+    const insightsRaw = await readRawJsonFromUpstash(INSIGHTS_KEY);
+    if (insightsRaw) insightsNumbers = extractInsights(insightsRaw).numbers;
   } catch (err) {
-    console.warn('[digest] brief: insights read failed, skipping brief composition:', err.message);
-    // An infra-level read failure is a compose-layer failure worth
-    // the Railway red-flag — count it as one failure so the exit
-    // gate catches it. We still return a valid shape so the digest
-    // send path runs normally.
-    return { briefByUser, composeSuccess: 0, composeFailed: 1 };
+    console.warn('[digest] brief: insights read failed, using zeroed stats:', err.message);
   }
-  if (!insightsRaw) return { briefByUser, composeSuccess: 0, composeFailed: 0 };
 
-  const insights = extractInsights(insightsRaw);
-  if (insights.topStories.length === 0) return { briefByUser, composeSuccess: 0, composeFailed: 0 };
+  // Memoize buildDigest by (variant, lang, windowStart). Many users
+  // share a variant/lang, so this saves ZRANGE + HGETALL round-trips
+  // across the per-user loop. Scoped to this cron run — no cross-run
+  // memoization needed (Redis is authoritative).
+  const windowStart = nowMs - BRIEF_STORY_WINDOW_MS;
+  const digestCache = new Map();
+  async function digestFor(candidate) {
+    const key = `${candidate.variant ?? 'full'}:${candidate.lang ?? 'en'}:${windowStart}`;
+    if (digestCache.has(key)) return digestCache.get(key);
+    const stories = await buildDigest(candidate, windowStart);
+    digestCache.set(key, stories ?? []);
+    return stories ?? [];
+  }
 
   const eligibleByUser = groupEligibleRulesByUser(rules);
   let composeSuccess = 0;
   let composeFailed = 0;
   for (const [userId, candidates] of eligibleByUser) {
     try {
-      const hit = await composeAndStoreBriefForUser(userId, candidates, insights, nowMs);
+      const hit = await composeAndStoreBriefForUser(userId, candidates, insightsNumbers, digestFor, nowMs);
       if (hit) {
         briefByUser.set(userId, hit);
         composeSuccess++;
@@ -974,15 +993,25 @@ async function composeBriefsForRun(rules, nowMs) {
 }
 
 /**
- * Per-user: walk candidates until one produces stories, SETEX the
- * envelope, sign the magazine URL. Returns the entry the caller
- * should stash in briefByUser, or null when no candidate had stories.
+ * Per-user: walk candidates, for each pull the per-variant digest
+ * story pool (same pool buildDigest feeds to the email), and compose
+ * the brief envelope from the first candidate that yields non-empty
+ * stories. SETEX the envelope, sign the magazine URL. Returns the
+ * entry the caller should stash in briefByUser, or null when no
+ * candidate had stories.
  */
-async function composeAndStoreBriefForUser(userId, candidates, insights, nowMs) {
+async function composeAndStoreBriefForUser(userId, candidates, insightsNumbers, digestFor, nowMs) {
   let envelope = null;
   let chosenVariant = null;
   for (const candidate of candidates) {
-    const composed = composeBriefForRule(candidate, insights, { nowMs });
+    const digestStories = await digestFor(candidate);
+    if (!digestStories || digestStories.length === 0) continue;
+    const composed = composeBriefFromDigestStories(
+      candidate,
+      digestStories,
+      insightsNumbers,
+      { nowMs },
+    );
     if (composed) {
       envelope = composed;
       chosenVariant = candidate.variant;

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -1,0 +1,188 @@
+// Regression tests for composeBriefFromDigestStories — the live path
+// that maps the digest accumulator's per-variant story pool (same
+// pool the email digest reads) into a BriefEnvelope.
+//
+// Why these tests exist: Phase 3a originally composed from
+// news:insights:v1 (a global 8-story summary). The email, however,
+// reads from digest:accumulator:v1:{variant}:{lang} (30+ stories).
+// The result was a brief whose stories had nothing to do with the
+// email a user had just received. These tests lock the mapping so a
+// future "clever" change can't regress the brief away from the
+// email's story pool.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { composeBriefFromDigestStories } from '../scripts/lib/brief-compose.mjs';
+
+const NOW = 1_745_000_000_000; // 2026-04-18 ish, deterministic
+
+function rule(overrides = {}) {
+  return {
+    userId: 'user_abc',
+    variant: 'full',
+    enabled: true,
+    digestMode: 'daily',
+    sensitivity: 'all',
+    aiDigestEnabled: true,
+    digestTimezone: 'UTC',
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function digestStory(overrides = {}) {
+  return {
+    hash: 'abc123',
+    title: 'Iran threatens to close Strait of Hormuz',
+    link: 'https://example.com/hormuz',
+    severity: 'critical',
+    currentScore: 100,
+    mentionCount: 5,
+    phase: 'developing',
+    sources: ['Guardian', 'Al Jazeera'],
+    ...overrides,
+  };
+}
+
+describe('composeBriefFromDigestStories', () => {
+  it('returns null for empty input (caller falls back)', () => {
+    assert.equal(composeBriefFromDigestStories(rule(), [], { clusters: 0, multiSource: 0 }, { nowMs: NOW }), null);
+    assert.equal(composeBriefFromDigestStories(rule(), null, { clusters: 0, multiSource: 0 }, { nowMs: NOW }), null);
+  });
+
+  it('maps digest story title → brief headline and description', () => {
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [digestStory()],
+      { clusters: 12, multiSource: 3 },
+      { nowMs: NOW },
+    );
+    assert.ok(env, 'expected an envelope');
+    assert.equal(env.data.stories.length, 1);
+    const s = env.data.stories[0];
+    assert.equal(s.headline, 'Iran threatens to close Strait of Hormuz');
+    // Description is stubbed from the title until Phase 3b wires in
+    // an LLM-generated body.
+    assert.equal(s.description, 'Iran threatens to close Strait of Hormuz');
+  });
+
+  it('uses first sources[] entry as the brief source', () => {
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [digestStory({ sources: ['Reuters', 'AP'] })],
+      { clusters: 0, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    assert.equal(env.data.stories[0].source, 'Reuters');
+  });
+
+  it('falls back to "Multiple wires" when sources[] is empty', () => {
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [digestStory({ sources: [] })],
+      { clusters: 0, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    assert.equal(env.data.stories[0].source, 'Multiple wires');
+  });
+
+  it('respects sensitivity=critical by dropping non-critical stories', () => {
+    const env = composeBriefFromDigestStories(
+      rule({ sensitivity: 'critical' }),
+      [
+        digestStory({ severity: 'critical', title: 'A' }),
+        digestStory({ severity: 'high', title: 'B', hash: 'b' }),
+        digestStory({ severity: 'medium', title: 'C', hash: 'c' }),
+      ],
+      { clusters: 0, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    assert.equal(env.data.stories.length, 1);
+    assert.equal(env.data.stories[0].headline, 'A');
+  });
+
+  it('respects sensitivity=high (critical + high pass, medium drops)', () => {
+    const env = composeBriefFromDigestStories(
+      rule({ sensitivity: 'high' }),
+      [
+        digestStory({ severity: 'critical', title: 'A' }),
+        digestStory({ severity: 'high', title: 'B', hash: 'b' }),
+        digestStory({ severity: 'medium', title: 'C', hash: 'c' }),
+      ],
+      { clusters: 0, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    assert.equal(env.data.stories.length, 2);
+    assert.deepEqual(env.data.stories.map((s) => s.headline), ['A', 'B']);
+  });
+
+  it('caps at 12 stories per brief', () => {
+    const many = Array.from({ length: 30 }, (_, i) =>
+      digestStory({ hash: `h${i}`, title: `Story ${i}` }),
+    );
+    const env = composeBriefFromDigestStories(
+      rule(),
+      many,
+      { clusters: 30, multiSource: 15 },
+      { nowMs: NOW },
+    );
+    assert.equal(env.data.stories.length, 12);
+  });
+
+  it('maps unknown severity to null → story is dropped', () => {
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [
+        digestStory({ severity: 'unknown', title: 'drop me' }),
+        digestStory({ severity: 'critical', title: 'keep me', hash: 'k' }),
+      ],
+      { clusters: 0, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    assert.equal(env.data.stories.length, 1);
+    assert.equal(env.data.stories[0].headline, 'keep me');
+  });
+
+  it('aliases upstream "moderate" severity to "medium"', () => {
+    const env = composeBriefFromDigestStories(
+      rule({ sensitivity: 'all' }),
+      [digestStory({ severity: 'moderate', title: 'mod' })],
+      { clusters: 0, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    assert.equal(env.data.stories[0].threatLevel, 'medium');
+  });
+
+  it('defaults category to "General" and country to "Global" when the digest track omits them', () => {
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [digestStory()],
+      { clusters: 0, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    const s = env.data.stories[0];
+    assert.equal(s.category, 'General');
+    assert.equal(s.country, 'Global');
+  });
+
+  it('passes insightsNumbers through to the stats page', () => {
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [digestStory()],
+      { clusters: 277, multiSource: 22 },
+      { nowMs: NOW },
+    );
+    // numbers live on the digest branch of the envelope. Shape is
+    // deliberately validated here so the assembler can't silently
+    // drop them.
+    assert.equal(env.data.digest.numbers.clusters, 277);
+    assert.equal(env.data.digest.numbers.multiSource, 22);
+  });
+
+  it('returns deterministic envelope for same input (safe to retry)', () => {
+    const input = [digestStory()];
+    const a = composeBriefFromDigestStories(rule(), input, { clusters: 1, multiSource: 0 }, { nowMs: NOW });
+    const b = composeBriefFromDigestStories(rule(), input, { clusters: 1, multiSource: 0 }, { nowMs: NOW });
+    assert.deepEqual(a, b);
+  });
+});


### PR DESCRIPTION
## Summary

Today's user report: the email digest had **30 critical events** (UNICEF/Gaza, Hormuz, Rohingya, Ukraine, Sudan, etc.) and the linked brief at the same URL showed **2 random Bellingcat stories** that weren't in the digest at all. Same cron tick, same user, completely different story lists.

### Root cause

Two pipelines, two Redis keys, zero agreement:

| Pipeline | Key | Producer | Content |
|---|---|---|---|
| **Email digest** | `digest:accumulator:v1:{variant}:{lang}` | `list-feed-digest` on every ingest cycle | 30+ per-variant ingested stories, hydrated from `story:track:v1:{hash}` + `story:sources:v1:{hash}` |
| **Brief composer** | `news:insights:v1` | `seed-insights` cron | Global 8-story summary. After `sensitivity=critical` filter → 2 stories. |

A user who had just read Hormuz/Gaza/Rohingya in their email opened the brief and saw two Bellingcat articles on unrelated topics. The brief was reading from the wrong source.

## Fix

The brief now composes from the same accumulator the email reads.

**`scripts/lib/brief-compose.mjs`:**
- New `composeBriefFromDigestStories(rule, digestStories, insightsNumbers, {nowMs})`. Adapts the digest shape (`{hash, title, severity, sources[], phase, currentScore}`) into the existing upstream brief-filter shape, applies the user's sensitivity gate, assembles the envelope.
- `composeBriefForRule` kept as `@deprecated` so existing tests that stub a `news:insights` payload directly don't break.

**`scripts/seed-digest-notifications.mjs`:**
- `composeBriefsForRun` now calls `buildDigest(candidate, windowStart)` per rule instead of pulling one global pool.
- Memoizes `buildDigest` by `(variant, lang, windowStart)` so a 500-user run with shared variants doesn't fire 500 identical `ZRANGE + HGETALL` round-trips — it fires one per unique combo.
- `BRIEF_STORY_WINDOW_MS = 24h`. A weekly-cadence email subscriber still expects a fresh daily brief in the dashboard panel, so the brief window is independent of the user's email cadence.
- `news:insights:v1` is still read, but **only** for the `clusters / multiSource` counters on the stats page. A failed insights fetch no longer aborts brief composition — zero stats > wrong stories.

## Tests

**New:** `tests/brief-from-digest-stories.test.mjs` (12 cases) locks the mapping:
- empty / null input → null
- title → headline + description
- first `sources[]` entry → source, fallback to `'Multiple wires'`
- sensitivity `critical` / `high` / `all` drop ladder
- 12-story cap per brief
- unknown severity dropped
- upstream `'moderate'` aliased to `'medium'`
- `category`/`country` default when digest track omits them
- `insightsNumbers` passthrough to stats page
- deterministic output for same input (retry-safe)

**Full suite:** 122/122 brief tests pass. Both tsconfigs typecheck clean.

## Operator note

Today's wrong brief at `brief:user_3BUozhPhytg74IEjLfQ3CL61qzM:2026-04-18` was already `DEL`ed manually. The next cron tick (minute `:05`) under this code composes a correct one from the same pool the email used.

If you want extra safety while reviewing, set `BRIEF_COMPOSE_DISABLED_BY_OPERATOR=1` on the Railway `digest-notifications` service — emails still send, brief compose pauses — and unset it after this PR merges + deploys.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: `[digest] brief: compose_success=… compose_failed=…` line per run. Expect `compose_success` ≈ total PRO users, `compose_failed` ≈ 0.
  - Sentry / Railway run status: red flag if the exit-non-zero gate trips (`shouldExitOnBriefFailures`).
- **Validation checks**
  - SSH a known user's keys after the next cron tick:
    ```
    UPSTASH_PIPELINE [["GET","brief:user_<id>:2026-04-18"], ["ZRANGEBYSCORE","digest:accumulator:v1:full:en","<windowStart>","<now>"]]
    ```
    Parse the brief envelope's `data.stories` — every headline should appear in the accumulator's hydrated titles.
  - Receive the email digest, open the linked magazine URL → the first few story titles should match between the two.
- **Expected healthy behavior**
  - Brief story count is between 1 and 12 (filtered by user sensitivity).
  - Every brief headline matches a current `story:track:v1:{hash}.title`.
- **Failure signal / rollback trigger**
  - Any user report of brief ≠ email content → revert immediately.
  - `compose_failed > compose_success * 0.05` in Railway logs → revert and diagnose (likely accumulator key empty or a variant/lang rule mismatch).
- **Validation window & owner**
  - First 3 cron ticks (3h) post-deploy; @koala73.