### PR TITLE
fix(relay): bounded recursion in sendTelegram on 429 rate limit

### DIFF
--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -256,7 +256,7 @@ async function processFlushQuietHeld(event) {
 
 // ── Delivery: Telegram ────────────────────────────────────────────────────────
 
-async function sendTelegram(userId, chatId, text) {
+async function sendTelegram(userId, chatId, text, _retryCount = 0) {
   if (!TELEGRAM_BOT_TOKEN) {
     console.warn('[relay] Telegram: TELEGRAM_BOT_TOKEN not set — skipping');
     return false;
@@ -277,10 +277,14 @@ async function sendTelegram(userId, chatId, text) {
     return false;
   }
   if (res.status === 429) {
+    if (_retryCount >= 1) {
+      console.warn(`[relay] Telegram 429 retry limit reached for ${userId} — bailing`);
+      return false;
+    }
     const body = await res.json().catch(() => ({}));
     const wait = ((body.parameters?.retry_after ?? 5) + 1) * 1000;
     await new Promise(r => setTimeout(r, wait));
-    return sendTelegram(userId, chatId, text); // single retry
+    return sendTelegram(userId, chatId, text, _retryCount + 1); // single retry with counter
   }
   if (res.status === 401) {
     console.error('[relay] Telegram 401 Unauthorized — TELEGRAM_BOT_TOKEN is invalid or belongs to a different bot; correct the Railway env var to restore Telegram delivery');


### PR DESCRIPTION
## Bug

In `scripts/notification-relay.cjs:304-308`, `sendTelegram` calls itself on HTTP 429 with no retry counter:

```js
if (res.status === 429) {
  const body = await res.json().catch(() => ({}));
  const wait = ((body.parameters?.retry_after ?? 5) + 1) * 1000;
  await new Promise(r => setTimeout(r, wait));
  return sendTelegram(userId, chatId, text); // "single retry" — but no guard
}
```

The comment says "single retry" but there's no depth/counter parameter to enforce it. If Telegram keeps returning 429 (sustained rate limiting during alert bursts), this recurses indefinitely.

## Impact

Under sustained Telegram rate limiting, the relay could hit a stack overflow and crash on Railway. In practice this is rare since `retry_after` usually resolves it, but it's not guaranteed.

## Fix

Add a `_retryCount` parameter (default 0), pass `_retryCount + 1` on recursion, bail if `_retryCount >= 1`.

## Verification Steps

- [ ] Read `sendTelegram` signature — confirm it has a `_retryCount` parameter defaulting to 0
- [ ] Confirm the recursive call passes `_retryCount + 1`
- [ ] Confirm a guard bails (returns false + logs) when `_retryCount >= 1`
- [ ] Confirm non-429 paths are unaffected (no behavioral change for 200, 400, 403, 401)

Fixes #3060