### PR TITLE
feat(brief): Phase 3b — LLM whyMatters + editorial digest prose via Gemini

### DIFF
--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -218,11 +218,22 @@ export function validateDigestProseShape(obj) {
     .slice(0, 6);
   if (threads.length < 1) return null;
 
+  // The prompt instructs the model to produce signals of "<=14 words,
+  // forward-looking imperative phrase". Enforce both a word cap (with
+  // a small margin of 4 words for model drift and compound phrases)
+  // and a byte cap — a 30-word "signal" would render as a second
+  // paragraph on the signals page, breaking visual rhythm. Previously
+  // only the byte cap was enforced, allowing ~40-word signals to
+  // sneak through when the model ignored the word count.
   const rawSignals = Array.isArray(obj.signals) ? obj.signals : [];
   const signals = rawSignals
     .filter((x) => typeof x === 'string')
     .map((x) => x.trim())
-    .filter((x) => x.length > 0 && x.length < 220)
+    .filter((x) => {
+      if (x.length === 0 || x.length >= 220) return false;
+      const words = x.split(/\s+/).filter(Boolean).length;
+      return words <= 18;
+    })
     .slice(0, 6);
 
   return { lead, threads, signals };

--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -1,0 +1,335 @@
+// Phase 3b: LLM enrichment for the WorldMonitor Brief envelope.
+//
+// Substitutes the stubbed `whyMatters` per story and the stubbed
+// executive summary (`digest.lead` / `digest.threads` / `digest.signals`)
+// with Gemini 2.5 Flash output via the existing OpenRouter-backed
+// callLLM chain. The LLM provider is pinned to openrouter by
+// skipProviders:['ollama','groq'] so the brief's editorial voice
+// stays on one model across environments.
+//
+// Deliberately:
+//   - Pure parse/build helpers are exported for testing without IO.
+//   - Cache layer is parameterised (cacheGet / cacheSet) so tests use
+//     an in-memory stub and production uses Upstash.
+//   - Any failure (null LLM result, parse error, cache hiccup) falls
+//     through to the original stub — the brief must always ship.
+//
+// Cache semantics:
+//   - brief:llm:whymatters:v1:{storyHash}   — 24h, shared across users.
+//     whyMatters is editorial global-stakes commentary, not user
+//     personalisation, so per-story caching collapses N×U LLM calls
+//     to N.
+//   - brief:llm:digest:v1:{userId}:{poolHash} — 4h, per user.
+//     The executive summary IS personalised to a user's sensitivity
+//     and surfaced story pool, so cache keys include a hash of both.
+//     4h balances cost vs freshness — hourly cron pays at most once
+//     per 4 ticks per user.
+
+import { createHash } from 'node:crypto';
+
+// ── Tunables ───────────────────────────────────────────────────────────────
+
+const WHY_MATTERS_TTL_SEC = 24 * 60 * 60;
+const DIGEST_PROSE_TTL_SEC = 4 * 60 * 60;
+const WHY_MATTERS_CONCURRENCY = 5;
+
+// Pin to openrouter (google/gemini-2.5-flash). Ollama isn't deployed
+// in Railway and groq (llama-3.1-8b) produces noticeably less
+// editorial prose than Gemini Flash.
+const BRIEF_LLM_SKIP_PROVIDERS = ['ollama', 'groq'];
+
+// ── whyMatters (per story) ─────────────────────────────────────────────────
+
+const WHY_MATTERS_SYSTEM =
+  'You are the editor of WorldMonitor Brief, a geopolitical intelligence magazine. ' +
+  'For each story below, write ONE concise sentence (18–30 words) explaining the ' +
+  'regional or global stakes. Editorial, impersonal, serious. No preamble ' +
+  '("This matters because…"), no questions, no calls to action, no markdown, ' +
+  'no quotes. One sentence only.';
+
+/**
+ * Deterministic hash of the story identity used as cache key.
+ * Same headline + source + severity from two users gets one LLM call.
+ * @param {{ headline: string; source: string; threatLevel: string }} story
+ */
+function hashStory(story) {
+  const material = `${story.headline}||${story.source}||${story.threatLevel}`;
+  return createHash('sha256').update(material).digest('hex').slice(0, 16);
+}
+
+/**
+ * @param {{ headline: string; source: string; threatLevel: string; category: string; country: string }} story
+ * @returns {{ system: string; user: string }}
+ */
+export function buildWhyMattersPrompt(story) {
+  const user = [
+    `Headline: ${story.headline}`,
+    `Source: ${story.source}`,
+    `Severity: ${story.threatLevel}`,
+    `Category: ${story.category}`,
+    `Country: ${story.country}`,
+    '',
+    'One editorial sentence on why this matters:',
+  ].join('\n');
+  return { system: WHY_MATTERS_SYSTEM, user };
+}
+
+/**
+ * Parse + validate the LLM response into a single editorial sentence.
+ * Returns null when the output is obviously wrong (empty, boilerplate
+ * preamble that survived stripReasoningPreamble, too short / too long).
+ *
+ * @param {unknown} text
+ * @returns {string | null}
+ */
+export function parseWhyMatters(text) {
+  if (typeof text !== 'string') return null;
+  let s = text.trim();
+  if (!s) return null;
+  // Drop surrounding quotes if the model insisted.
+  s = s.replace(/^[\u201C"']+/, '').replace(/[\u201D"']+$/, '').trim();
+  // Take the first sentence only. Keep terminal punctuation.
+  const match = s.match(/^[^.!?]+[.!?]/);
+  const sentence = match ? match[0].trim() : s;
+  if (sentence.length < 30 || sentence.length > 400) return null;
+  // Reject the stub itself — if the LLM echoed it back verbatim we
+  // don't want to cache that as "enrichment".
+  if (/^story flagged by your sensitivity/i.test(sentence)) return null;
+  return sentence;
+}
+
+/**
+ * Resolve a `whyMatters` sentence for one story via cache → LLM.
+ * Returns null on any failure; caller falls back to the stub.
+ *
+ * @param {object} story
+ * @param {{
+ *   callLLM: (system: string, user: string, opts: object) => Promise<string|null>;
+ *   cacheGet: (key: string) => Promise<unknown>;
+ *   cacheSet: (key: string, value: unknown, ttlSec: number) => Promise<void>;
+ * }} deps
+ */
+export async function generateWhyMatters(story, deps) {
+  const key = `brief:llm:whymatters:v1:${hashStory(story)}`;
+  try {
+    const hit = await deps.cacheGet(key);
+    if (typeof hit === 'string' && hit.length > 0) return hit;
+  } catch { /* cache miss is fine */ }
+  const { system, user } = buildWhyMattersPrompt(story);
+  let text = null;
+  try {
+    text = await deps.callLLM(system, user, {
+      maxTokens: 120,
+      temperature: 0.4,
+      timeoutMs: 10_000,
+      skipProviders: BRIEF_LLM_SKIP_PROVIDERS,
+    });
+  } catch {
+    return null;
+  }
+  const parsed = parseWhyMatters(text);
+  if (!parsed) return null;
+  try {
+    await deps.cacheSet(key, parsed, WHY_MATTERS_TTL_SEC);
+  } catch { /* cache write failures don't matter here */ }
+  return parsed;
+}
+
+// ── Digest prose (per user) ────────────────────────────────────────────────
+
+const DIGEST_PROSE_SYSTEM =
+  'You are the chief editor of WorldMonitor Brief. Given a ranked list of ' +
+  "today's top stories for a reader, produce EXACTLY this JSON and nothing " +
+  'else (no markdown, no code fences, no preamble):\n' +
+  '{\n' +
+  '  "lead": "<2–3 sentence executive summary, editorial tone, references ' +
+  'the most important 1–2 threads, addresses the reader in the third person>",\n' +
+  '  "threads": [\n' +
+  '    { "tag": "<one-word editorial category e.g. Energy, Diplomacy, Climate>", ' +
+  '"teaser": "<one sentence describing what is developing>" }\n' +
+  '  ],\n' +
+  '  "signals": ["<forward-looking imperative phrase, <=14 words>"]\n' +
+  '}\n' +
+  'Threads: 3–6 items reflecting actual clusters in the stories. ' +
+  'Signals: 2–4 items, forward-looking.';
+
+/**
+ * @param {Array<{ headline: string; threatLevel: string; category: string; country: string; source: string }>} stories
+ * @param {string} sensitivity
+ * @returns {{ system: string; user: string }}
+ */
+export function buildDigestPrompt(stories, sensitivity) {
+  const lines = stories.slice(0, 12).map((s, i) => {
+    const n = String(i + 1).padStart(2, '0');
+    return `${n}. [${s.threatLevel}] ${s.headline} — ${s.category} · ${s.country} · ${s.source}`;
+  });
+  const user = [
+    `Reader sensitivity level: ${sensitivity}`,
+    '',
+    "Today's surfaced stories (ranked):",
+    ...lines,
+  ].join('\n');
+  return { system: DIGEST_PROSE_SYSTEM, user };
+}
+
+/**
+ * @param {unknown} text
+ * @returns {{ lead: string; threads: Array<{tag:string;teaser:string}>; signals: string[] } | null}
+ */
+export function parseDigestProse(text) {
+  if (typeof text !== 'string') return null;
+  let s = text.trim();
+  if (!s) return null;
+  // Defensive: strip common wrappings the model sometimes inserts
+  // despite the explicit system instruction.
+  s = s.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+  let obj;
+  try {
+    obj = JSON.parse(s);
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
+
+  const lead = typeof obj.lead === 'string' ? obj.lead.trim() : '';
+  if (lead.length < 40 || lead.length > 800) return null;
+
+  const rawThreads = Array.isArray(obj.threads) ? obj.threads : [];
+  const threads = rawThreads
+    .filter((t) => t && typeof t.tag === 'string' && typeof t.teaser === 'string')
+    .map((t) => ({
+      tag: t.tag.trim().slice(0, 40),
+      teaser: t.teaser.trim().slice(0, 220),
+    }))
+    .filter((t) => t.tag.length > 0 && t.teaser.length > 0)
+    .slice(0, 6);
+  if (threads.length < 1) return null;
+
+  const rawSignals = Array.isArray(obj.signals) ? obj.signals : [];
+  const signals = rawSignals
+    .filter((x) => typeof x === 'string')
+    .map((x) => x.trim())
+    .filter((x) => x.length > 0 && x.length < 220)
+    .slice(0, 6);
+
+  return { lead, threads, signals };
+}
+
+/**
+ * Cache key for digest prose — scoped to (userId, sensitivity) and to
+ * the actual story pool, so an LLM call is re-used only when the pool
+ * has not changed. Pool hash intentionally uses headline + severity
+ * only; re-ordering by score between runs must re-use the same prose.
+ */
+function hashDigestInput(userId, stories, sensitivity) {
+  const material = stories
+    .map((s) => `${s.headline}|${s.threatLevel}`)
+    .sort()
+    .join('\n') + `|${sensitivity}`;
+  const h = createHash('sha256').update(material).digest('hex').slice(0, 16);
+  return `${userId}:${sensitivity}:${h}`;
+}
+
+/**
+ * Resolve the digest prose object via cache → LLM.
+ * @param {string} userId
+ * @param {Array} stories
+ * @param {string} sensitivity
+ * @param {object} deps — { callLLM, cacheGet, cacheSet }
+ */
+export async function generateDigestProse(userId, stories, sensitivity, deps) {
+  const key = `brief:llm:digest:v1:${hashDigestInput(userId, stories, sensitivity)}`;
+  try {
+    const hit = await deps.cacheGet(key);
+    if (hit && typeof hit === 'object' && typeof hit.lead === 'string') return hit;
+  } catch { /* cache miss fine */ }
+  const { system, user } = buildDigestPrompt(stories, sensitivity);
+  let text = null;
+  try {
+    text = await deps.callLLM(system, user, {
+      maxTokens: 700,
+      temperature: 0.4,
+      timeoutMs: 15_000,
+      skipProviders: BRIEF_LLM_SKIP_PROVIDERS,
+    });
+  } catch {
+    return null;
+  }
+  const parsed = parseDigestProse(text);
+  if (!parsed) return null;
+  try {
+    await deps.cacheSet(key, parsed, DIGEST_PROSE_TTL_SEC);
+  } catch { /* ignore */ }
+  return parsed;
+}
+
+// ── Envelope enrichment ────────────────────────────────────────────────────
+
+/**
+ * Bounded-concurrency map. Preserves input order. Doesn't short-circuit
+ * on individual failures — fn is expected to return a sentinel (null)
+ * on error and the caller decides.
+ */
+async function mapLimit(items, limit, fn) {
+  if (!Array.isArray(items) || items.length === 0) return [];
+  const n = Math.min(Math.max(1, limit), items.length);
+  const out = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      try {
+        out[idx] = await fn(items[idx], idx);
+      } catch {
+        out[idx] = items[idx];
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: n }, worker));
+  return out;
+}
+
+/**
+ * Take a baseline BriefEnvelope (stubbed whyMatters + stubbed lead /
+ * threads / signals) and enrich it with LLM output. All failures fall
+ * through cleanly — the envelope that comes out is always a valid
+ * BriefEnvelope (structure unchanged; only string/array field
+ * contents are substituted).
+ *
+ * @param {object} envelope
+ * @param {{ userId: string; sensitivity?: string }} rule
+ * @param {{ callLLM: Function; cacheGet: Function; cacheSet: Function }} deps
+ */
+export async function enrichBriefEnvelopeWithLLM(envelope, rule, deps) {
+  if (!envelope?.data || !Array.isArray(envelope.data.stories)) return envelope;
+  const stories = envelope.data.stories;
+  const sensitivity = rule?.sensitivity ?? 'all';
+
+  // Per-story whyMatters — parallel but bounded.
+  const enrichedStories = await mapLimit(stories, WHY_MATTERS_CONCURRENCY, async (story) => {
+    const why = await generateWhyMatters(story, deps);
+    if (!why) return story;
+    return { ...story, whyMatters: why };
+  });
+
+  // Per-user digest prose — one call.
+  const prose = await generateDigestProse(rule.userId, stories, sensitivity, deps);
+  const digest = prose
+    ? {
+        ...envelope.data.digest,
+        lead: prose.lead,
+        threads: prose.threads,
+        signals: prose.signals,
+      }
+    : envelope.data.digest;
+
+  return {
+    ...envelope,
+    data: {
+      ...envelope.data,
+      digest,
+      stories: enrichedStories,
+    },
+  };
+}

--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -48,12 +48,27 @@ const WHY_MATTERS_SYSTEM =
   'no quotes. One sentence only.';
 
 /**
- * Deterministic hash of the story identity used as cache key.
- * Same headline + source + severity from two users gets one LLM call.
- * @param {{ headline: string; source: string; threatLevel: string }} story
+ * Deterministic hash of every field that flows into buildWhyMattersPrompt.
+ *
+ * Keying only on headline/source/severity (as an earlier draft did)
+ * leaves `category` and `country` out of the cache identity, which is
+ * wrong: those fields appear in the user prompt, and if a story's
+ * classification or geocoding is corrected upstream we must re-LLM
+ * rather than serve the pre-correction prose. Bumped key version to
+ * v2 so any pre-fix cached entries (on the v1 hash) are ignored
+ * rather than reused — a one-off recompute is cheaper than serving
+ * stale editorial content.
+ *
+ * @param {{ headline: string; source: string; threatLevel: string; category: string; country: string }} story
  */
 function hashStory(story) {
-  const material = `${story.headline}||${story.source}||${story.threatLevel}`;
+  const material = [
+    story.headline ?? '',
+    story.source ?? '',
+    story.threatLevel ?? '',
+    story.category ?? '',
+    story.country ?? '',
+  ].join('||');
   return createHash('sha256').update(material).digest('hex').slice(0, 16);
 }
 
@@ -110,7 +125,9 @@ export function parseWhyMatters(text) {
  * }} deps
  */
 export async function generateWhyMatters(story, deps) {
-  const key = `brief:llm:whymatters:v1:${hashStory(story)}`;
+  // v2: hash now covers the full prompt (headline/source/severity/
+  // category/country) — see hashStory() comment.
+  const key = `brief:llm:whymatters:v2:${hashStory(story)}`;
   try {
     const hit = await deps.cacheGet(key);
     if (typeof hit === 'string' && hit.length > 0) return hit;
@@ -173,22 +190,18 @@ export function buildDigestPrompt(stories, sensitivity) {
 }
 
 /**
- * @param {unknown} text
+ * Strict shape check for a parsed digest-prose object. Used by BOTH
+ * parseDigestProse (fresh LLM output) AND generateDigestProse's
+ * cache-hit path, so a bad row written under an older/buggy version
+ * can't poison the envelope at SETEX time. Returns a **normalised**
+ * copy of the object on success, null on any shape failure — never
+ * returns the caller's object by reference so downstream writes
+ * can't observe internal state.
+ *
+ * @param {unknown} obj
  * @returns {{ lead: string; threads: Array<{tag:string;teaser:string}>; signals: string[] } | null}
  */
-export function parseDigestProse(text) {
-  if (typeof text !== 'string') return null;
-  let s = text.trim();
-  if (!s) return null;
-  // Defensive: strip common wrappings the model sometimes inserts
-  // despite the explicit system instruction.
-  s = s.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
-  let obj;
-  try {
-    obj = JSON.parse(s);
-  } catch {
-    return null;
-  }
+export function validateDigestProseShape(obj) {
   if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
 
   const lead = typeof obj.lead === 'string' ? obj.lead.trim() : '';
@@ -216,16 +229,52 @@ export function parseDigestProse(text) {
 }
 
 /**
- * Cache key for digest prose — scoped to (userId, sensitivity) and to
- * the actual story pool, so an LLM call is re-used only when the pool
- * has not changed. Pool hash intentionally uses headline + severity
- * only; re-ordering by score between runs must re-use the same prose.
+ * @param {unknown} text
+ * @returns {{ lead: string; threads: Array<{tag:string;teaser:string}>; signals: string[] } | null}
+ */
+export function parseDigestProse(text) {
+  if (typeof text !== 'string') return null;
+  let s = text.trim();
+  if (!s) return null;
+  // Defensive: strip common wrappings the model sometimes inserts
+  // despite the explicit system instruction.
+  s = s.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+  let obj;
+  try {
+    obj = JSON.parse(s);
+  } catch {
+    return null;
+  }
+  return validateDigestProseShape(obj);
+}
+
+/**
+ * Cache key for digest prose. MUST cover every field the LLM sees,
+ * in the order it sees them — anything less and we risk returning
+ * pre-computed prose for a materially different prompt (e.g. the
+ * same stories re-ranked, or with corrected category/country
+ * metadata). The old "sort + headline|severity" hash was explicitly
+ * about cache-hit rate; that optimisation is the wrong tradeoff for
+ * an editorial product whose correctness bar is "matches the email".
+ *
+ * v2 key space so pre-fix cache rows (under the looser key) are
+ * ignored on rollout — a one-tick cost to pay for clean semantics.
  */
 function hashDigestInput(userId, stories, sensitivity) {
-  const material = stories
-    .map((s) => `${s.headline}|${s.threatLevel}`)
-    .sort()
-    .join('\n') + `|${sensitivity}`;
+  // Canonicalise as JSON of the fields the prompt actually references,
+  // in the prompt's ranked order. Stable stringification via an array
+  // of tuples keeps field ordering deterministic without relying on
+  // JS object-key iteration order.
+  const material = JSON.stringify([
+    sensitivity ?? '',
+    ...stories.slice(0, 12).map((s) => [
+      s.headline ?? '',
+      s.threatLevel ?? '',
+      s.category ?? '',
+      s.country ?? '',
+      s.source ?? '',
+    ]),
+  ]);
   const h = createHash('sha256').update(material).digest('hex').slice(0, 16);
   return `${userId}:${sensitivity}:${h}`;
 }
@@ -238,10 +287,22 @@ function hashDigestInput(userId, stories, sensitivity) {
  * @param {object} deps — { callLLM, cacheGet, cacheSet }
  */
 export async function generateDigestProse(userId, stories, sensitivity, deps) {
-  const key = `brief:llm:digest:v1:${hashDigestInput(userId, stories, sensitivity)}`;
+  // v2 key: see hashDigestInput() comment. Full-prompt hash + strict
+  // shape validation on every cache hit.
+  const key = `brief:llm:digest:v2:${hashDigestInput(userId, stories, sensitivity)}`;
   try {
     const hit = await deps.cacheGet(key);
-    if (hit && typeof hit === 'object' && typeof hit.lead === 'string') return hit;
+    // CRITICAL: re-run the shape validator on cache hits. Without
+    // this, a bad row (written under an older buggy code path, or
+    // partial write, or tampered Redis) flows straight into
+    // envelope.data.digest and the envelope later fails
+    // assertBriefEnvelope() at the /api/brief render boundary. The
+    // user's brief URL then 404s / expired-pages. Treat a
+    // shape-failed hit the same as a miss — re-LLM and overwrite.
+    if (hit) {
+      const validated = validateDigestProseShape(hit);
+      if (validated) return validated;
+    }
   } catch { /* cache miss fine */ }
   const { system, user } = buildDigestPrompt(stories, sensitivity);
   let text = null;

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -36,6 +36,7 @@ import {
   groupEligibleRulesByUser,
   shouldExitNonZero as shouldExitOnBriefFailures,
 } from './lib/brief-compose.mjs';
+import { enrichBriefEnvelopeWithLLM } from './lib/brief-llm.mjs';
 import { signBriefUrl, BriefUrlError } from './lib/brief-url-sign.mjs';
 
 // ── Config ────────────────────────────────────────────────────────────────────
@@ -97,6 +98,27 @@ const BRIEF_COMPOSE_ENABLED =
   !BRIEF_COMPOSE_DISABLED_BY_OPERATOR && BRIEF_URL_SIGNING_SECRET !== '';
 const BRIEF_SIGNING_SECRET_MISSING =
   !BRIEF_COMPOSE_DISABLED_BY_OPERATOR && BRIEF_URL_SIGNING_SECRET === '';
+
+// Phase 3b LLM enrichment. Kept separate from AI_DIGEST_ENABLED so
+// the email-digest AI summary and the brief editorial prose can be
+// toggled independently (e.g. kill the brief LLM without silencing
+// the email's AI summary during a provider outage).
+const BRIEF_LLM_ENABLED = process.env.BRIEF_LLM_ENABLED !== '0';
+
+// Dependencies injected into brief-llm.mjs. Defined near the top so
+// the upstashRest helper below is in scope when this closure runs
+// inside composeAndStoreBriefForUser().
+const briefLlmDeps = {
+  callLLM,
+  async cacheGet(key) {
+    const raw = await upstashRest('GET', key);
+    if (typeof raw !== 'string' || raw.length === 0) return null;
+    try { return JSON.parse(raw); } catch { return null; }
+  },
+  async cacheSet(key, value, ttlSec) {
+    await upstashRest('SETEX', key, String(ttlSec), JSON.stringify(value));
+  },
+};
 
 // ── Redis helpers ──────────────────────────────────────────────────────────────
 
@@ -1003,6 +1025,7 @@ async function composeBriefsForRun(rules, nowMs) {
 async function composeAndStoreBriefForUser(userId, candidates, insightsNumbers, digestFor, nowMs) {
   let envelope = null;
   let chosenVariant = null;
+  let chosenCandidate = null;
   for (const candidate of candidates) {
     const digestStories = await digestFor(candidate);
     if (!digestStories || digestStories.length === 0) continue;
@@ -1015,10 +1038,25 @@ async function composeAndStoreBriefForUser(userId, candidates, insightsNumbers, 
     if (composed) {
       envelope = composed;
       chosenVariant = candidate.variant;
+      chosenCandidate = candidate;
       break;
     }
   }
   if (!envelope) return null;
+
+  // Phase 3b — LLM enrichment. Substitutes the stubbed whyMatters /
+  // lead / threads / signals fields with Gemini 2.5 Flash output.
+  // Pure passthrough on any failure: the baseline envelope has
+  // already passed validation and is safe to ship as-is. Do NOT
+  // abort composition if the LLM is down; the stub is better than
+  // no brief.
+  if (BRIEF_LLM_ENABLED && chosenCandidate) {
+    try {
+      envelope = await enrichBriefEnvelopeWithLLM(envelope, chosenCandidate, briefLlmDeps);
+    } catch (err) {
+      console.warn(`[digest] brief: LLM enrichment threw for ${userId} — shipping stubbed envelope:`, err?.message);
+    }
+  }
 
   const issueDate = envelope.data.date;
   const key = `brief:${userId}:${issueDate}`;

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -37,6 +37,7 @@ import {
   shouldExitNonZero as shouldExitOnBriefFailures,
 } from './lib/brief-compose.mjs';
 import { enrichBriefEnvelopeWithLLM } from './lib/brief-llm.mjs';
+import { assertBriefEnvelope } from '../server/_shared/brief-render.js';
 import { signBriefUrl, BriefUrlError } from './lib/brief-url-sign.mjs';
 
 // ── Config ────────────────────────────────────────────────────────────────────
@@ -1051,10 +1052,27 @@ async function composeAndStoreBriefForUser(userId, candidates, insightsNumbers, 
   // abort composition if the LLM is down; the stub is better than
   // no brief.
   if (BRIEF_LLM_ENABLED && chosenCandidate) {
+    const baseline = envelope;
     try {
-      envelope = await enrichBriefEnvelopeWithLLM(envelope, chosenCandidate, briefLlmDeps);
+      const enriched = await enrichBriefEnvelopeWithLLM(envelope, chosenCandidate, briefLlmDeps);
+      // Defence in depth: re-validate the enriched envelope against
+      // the renderer's strict contract before we SETEX it. If
+      // enrichment produced a structurally broken shape (bad cache
+      // row, code bug, upstream type drift) we'd otherwise SETEX it
+      // and /api/brief would 404 the user's brief at read time. Fall
+      // back to the unenriched baseline — which is already known to
+      // pass assertBriefEnvelope() because composeBriefFromDigestStories
+      // asserted on construction.
+      try {
+        assertBriefEnvelope(enriched);
+        envelope = enriched;
+      } catch (assertErr) {
+        console.warn(`[digest] brief: enriched envelope failed assertion for ${userId} — shipping stubbed:`, assertErr?.message);
+        envelope = baseline;
+      }
     } catch (err) {
       console.warn(`[digest] brief: LLM enrichment threw for ${userId} — shipping stubbed envelope:`, err?.message);
+      envelope = baseline;
     }
   }
 

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -283,6 +283,22 @@ describe('parseDigestProse', () => {
     assert.equal(out.signals.length, 6);
   });
 
+  it('drops signals that exceed the prompt\'s 14-word cap (with small margin)', () => {
+    // REGRESSION: previously the validator only capped by byte length
+    // (< 220 chars), so a 30+ word signal paragraph could slip through
+    // despite the prompt explicitly saying "<=14 words, forward-looking
+    // imperative phrase". Validator now checks word count too.
+    const obj = JSON.parse(good);
+    obj.signals = [
+      'Watch for US naval redeployment.',                        // 5 words — keep
+      Array.from({ length: 22 }, (_, i) => `w${i}`).join(' '),    // 22 words — drop
+      Array.from({ length: 30 }, (_, i) => `w${i}`).join(' '),    // 30 words — drop
+    ];
+    const out = parseDigestProse(JSON.stringify(obj));
+    assert.equal(out.signals.length, 1);
+    assert.match(out.signals[0], /naval redeployment/);
+  });
+
   it('filters out malformed thread entries without rejecting the whole payload', () => {
     const obj = JSON.parse(good);
     obj.threads = [
@@ -327,11 +343,16 @@ describe('generateDigestProse', () => {
     assert.equal(cache.store.size, 0);
   });
 
-  it('different users share the cache when the story pool is identical', async () => {
+  it('different users do NOT share the digest cache even when the story pool is identical', async () => {
+    // The cache key is {userId}:{sensitivity}:{poolHash} — userId is
+    // part of the key precisely because the digest prose addresses
+    // the reader directly ("your brief surfaces ...") and we never
+    // want one user's prose showing up in another user's envelope.
+    // Assertion: user_a's fresh fetch doesn't prevent user_b from
+    // hitting the LLM.
     const cache = makeCache();
     const llm1 = makeLLM(validJson);
     await generateDigestProse('user_a', stories, 'all', { ...cache, callLLM: llm1.callLLM });
-    // user_b with same stories+sensitivity — different cache key (user is part of key)
     const llm2 = makeLLM(validJson);
     await generateDigestProse('user_b', stories, 'all', { ...cache, callLLM: llm2.callLLM });
     assert.equal(llm1.calls.length, 1);

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -18,6 +18,7 @@ import {
   generateWhyMatters,
   buildDigestPrompt,
   parseDigestProse,
+  validateDigestProseShape,
   generateDigestProse,
   enrichBriefEnvelopeWithLLM,
 } from '../scripts/lib/brief-llm.mjs';
@@ -156,8 +157,8 @@ describe('generateWhyMatters', () => {
     const real = makeLLM('Closure would freeze a fifth of seaborne crude within days.');
     const first = await generateWhyMatters(story(), { ...cache, callLLM: real.callLLM });
     assert.ok(first);
-    const cachedKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:whymatters:v1:'));
-    assert.ok(cachedKey, 'expected a whymatters cache entry');
+    const cachedKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:whymatters:v2:'));
+    assert.ok(cachedKey, 'expected a whymatters cache entry under the v2 key');
 
     // Second call: responder throws — cache must prevent the call
     llm.calls.length = 0;
@@ -337,13 +338,119 @@ describe('generateDigestProse', () => {
     assert.equal(llm2.calls.length, 1, 'digest prose cache is per-user, not per-story-pool');
   });
 
-  it('story pool reordering reuses the cache (hash is order-insensitive)', async () => {
+  // REGRESSION: pre-v2 the digest hash was order-insensitive (sort +
+  // headline|severity only) as a cache-hit-rate optimisation. The
+  // review on PR #3172 called that out as a correctness bug: the
+  // LLM prompt includes ranked order AND category/country/source,
+  // so serving pre-computed prose for a different ranking = serving
+  // stale editorial for a different input. The v2 hash now covers
+  // the full prompt, so reordering MUST miss the cache.
+  it('story pool reordering invalidates the cache (hash covers ranked order)', async () => {
     const cache = makeCache();
     const llm1 = makeLLM(validJson);
     await generateDigestProse('user_a', [stories[0], stories[1]], 'all', { ...cache, callLLM: llm1.callLLM });
-    const llm2 = makeLLM(() => { throw new Error('would not be called'); });
+    const llm2 = makeLLM(validJson);
     await generateDigestProse('user_a', [stories[1], stories[0]], 'all', { ...cache, callLLM: llm2.callLLM });
-    assert.equal(llm2.calls.length, 0, 'reordered pool should hit the same cache entry');
+    assert.equal(llm2.calls.length, 1, 'reordered pool is a different prompt — must re-LLM');
+  });
+
+  it('changing a story category invalidates the cache (hash covers all prompt fields)', async () => {
+    const cache = makeCache();
+    const llm1 = makeLLM(validJson);
+    await generateDigestProse('user_a', stories, 'all', { ...cache, callLLM: llm1.callLLM });
+    const reclassified = [
+      { ...stories[0], category: 'Energy' }, // was 'Diplomacy'
+      stories[1],
+    ];
+    const llm2 = makeLLM(validJson);
+    await generateDigestProse('user_a', reclassified, 'all', { ...cache, callLLM: llm2.callLLM });
+    assert.equal(llm2.calls.length, 1, 'category change re-keys the cache');
+  });
+
+  it('malformed cached row is rejected on hit and re-LLM is called', async () => {
+    const cache = makeCache();
+    // Seed a bad cached row that would poison the envelope: missing
+    // `threads`, which the renderer's assertBriefEnvelope requires.
+    const llm1 = makeLLM(validJson);
+    await generateDigestProse('user_a', stories, 'all', { ...cache, callLLM: llm1.callLLM });
+    // Corrupt the stored row in place
+    const badKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:digest:v2:'));
+    assert.ok(badKey, 'expected a digest prose cache entry');
+    cache.store.set(badKey, { lead: 'short', /* missing threads + signals */ });
+    const llm2 = makeLLM(validJson);
+    const out = await generateDigestProse('user_a', stories, 'all', { ...cache, callLLM: llm2.callLLM });
+    assert.ok(out, 'shape-failed hit must fall through to LLM');
+    assert.equal(llm2.calls.length, 1, 'bad cache row treated as miss');
+  });
+});
+
+describe('validateDigestProseShape', () => {
+  // Extracted helper — the same strictness runs on fresh LLM output
+  // AND on cache hits, so a bad row written under older buggy code
+  // can't sneak past.
+  const good = {
+    lead: 'A long-enough executive lead about Hormuz and the Gaza humanitarian crisis, written in editorial tone.',
+    threads: [{ tag: 'Energy', teaser: 'Hormuz closure threats resurface.' }],
+    signals: ['Watch for US naval redeployment.'],
+  };
+
+  it('accepts a well-formed object and returns a normalised copy', () => {
+    const out = validateDigestProseShape(good);
+    assert.ok(out);
+    assert.notEqual(out, good, 'must not return the caller object by reference');
+    assert.equal(out.threads.length, 1);
+  });
+
+  it('rejects missing threads', () => {
+    assert.equal(validateDigestProseShape({ ...good, threads: [] }), null);
+    assert.equal(validateDigestProseShape({ lead: good.lead }), null);
+  });
+
+  it('rejects short lead', () => {
+    assert.equal(validateDigestProseShape({ ...good, lead: 'too short' }), null);
+  });
+
+  it('rejects non-object / array / null input', () => {
+    assert.equal(validateDigestProseShape(null), null);
+    assert.equal(validateDigestProseShape(undefined), null);
+    assert.equal(validateDigestProseShape([good]), null);
+    assert.equal(validateDigestProseShape('string'), null);
+  });
+});
+
+describe('generateWhyMatters — cache key covers all prompt fields', () => {
+  // REGRESSION: pre-v2 whyMatters keyed only on (headline, source,
+  // severity), leaving category + country unhashed. If upstream
+  // classification or geocoding changed while those three fields
+  // stayed the same, cached prose was served for a materially
+  // different prompt.
+  it('category change busts the cache', async () => {
+    const llm1 = {
+      calls: 0,
+      async callLLM(_s, _u, _opts) {
+        this.calls += 1;
+        return 'Closure of the Strait of Hormuz would force a coordinated naval response within days.';
+      },
+    };
+    const cache = makeCache();
+    const s1 = { category: 'Diplomacy', country: 'IR', threatLevel: 'critical', headline: 'Hormuz closure threat', description: '', source: 'Reuters', whyMatters: '' };
+    await generateWhyMatters(s1, { ...cache, callLLM: (sys, u, o) => llm1.callLLM(sys, u, o) });
+    const s2 = { ...s1, category: 'Energy' }; // reclassified
+    await generateWhyMatters(s2, { ...cache, callLLM: (sys, u, o) => llm1.callLLM(sys, u, o) });
+    assert.equal(llm1.calls, 2, 'category change must re-LLM');
+  });
+
+  it('country change busts the cache', async () => {
+    const llm1 = {
+      calls: 0,
+      async callLLM() { this.calls += 1; return 'Closure of the Strait of Hormuz would spike oil prices across global markets.'; },
+    };
+    const cache = makeCache();
+    const s1 = { category: 'Diplomacy', country: 'IR', threatLevel: 'critical', headline: 'Hormuz', description: '', source: 'Reuters', whyMatters: '' };
+    await generateWhyMatters(s1, { ...cache, callLLM: (sys, u, o) => llm1.callLLM(sys, u, o) });
+    const s2 = { ...s1, country: 'OM' }; // re-geocoded
+    await generateWhyMatters(s2, { ...cache, callLLM: (sys, u, o) => llm1.callLLM(sys, u, o) });
+    assert.equal(llm1.calls, 2, 'country change must re-LLM');
   });
 });
 

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -1,0 +1,496 @@
+// Phase 3b: unit tests for brief-llm.mjs.
+//
+// Covers:
+//   - Pure build/parse helpers (no IO)
+//   - Cached generate* functions with an in-memory cache stub
+//   - Full enrichBriefEnvelopeWithLLM envelope pass-through
+//
+// Every LLM call is stubbed; there is no network. The cache is a plain
+// Map and the deps object is fabricated per-test. Tests assert both
+// the happy path (LLM output adopted) and every failure mode the
+// production code tolerates (null LLM, parse error, cache throw).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildWhyMattersPrompt,
+  parseWhyMatters,
+  generateWhyMatters,
+  buildDigestPrompt,
+  parseDigestProse,
+  generateDigestProse,
+  enrichBriefEnvelopeWithLLM,
+} from '../scripts/lib/brief-llm.mjs';
+import { assertBriefEnvelope } from '../server/_shared/brief-render.js';
+import { composeBriefFromDigestStories } from '../scripts/lib/brief-compose.mjs';
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+function story(overrides = {}) {
+  return {
+    category: 'Diplomacy',
+    country: 'IR',
+    threatLevel: 'critical',
+    headline: 'Iran threatens to close Strait of Hormuz if US blockade continues',
+    description: 'Iran threatens to close Strait of Hormuz if US blockade continues',
+    source: 'Guardian',
+    whyMatters: 'Story flagged by your sensitivity settings. Open for context.',
+    ...overrides,
+  };
+}
+
+function envelope(overrides = {}) {
+  return {
+    version: 1,
+    issuedAt: 1_745_000_000_000,
+    data: {
+      user: { name: 'Reader', tz: 'UTC' },
+      issue: '18.04',
+      date: '2026-04-18',
+      dateLong: '18 April 2026',
+      digest: {
+        greeting: 'Good afternoon.',
+        lead: 'Today\'s brief surfaces 2 threads flagged by your sensitivity settings. Open any page to read the full editorial.',
+        numbers: { clusters: 277, multiSource: 22, surfaced: 2 },
+        threads: [{ tag: 'Diplomacy', teaser: '2 threads on the desk today.' }],
+        signals: [],
+      },
+      stories: [story(), story({ headline: 'UNICEF outraged by Gaza water truck killings', country: 'PS', source: 'UN News' })],
+    },
+    ...overrides,
+  };
+}
+
+function makeCache() {
+  const store = new Map();
+  return {
+    store,
+    async cacheGet(key) { return store.has(key) ? store.get(key) : null; },
+    async cacheSet(key, value) { store.set(key, value); },
+  };
+}
+
+function makeLLM(responder) {
+  const calls = [];
+  return {
+    calls,
+    async callLLM(system, user, opts) {
+      calls.push({ system, user, opts });
+      return typeof responder === 'function' ? responder(system, user, opts) : responder;
+    },
+  };
+}
+
+// ── buildWhyMattersPrompt ──────────────────────────────────────────────────
+
+describe('buildWhyMattersPrompt', () => {
+  it('includes all story fields in the user prompt', () => {
+    const { system, user } = buildWhyMattersPrompt(story());
+    assert.match(system, /WorldMonitor Brief/);
+    assert.match(system, /One sentence only/);
+    assert.match(user, /Headline: Iran threatens/);
+    assert.match(user, /Source: Guardian/);
+    assert.match(user, /Severity: critical/);
+    assert.match(user, /Category: Diplomacy/);
+    assert.match(user, /Country: IR/);
+  });
+});
+
+// ── parseWhyMatters ────────────────────────────────────────────────────────
+
+describe('parseWhyMatters', () => {
+  it('returns null for non-string / empty input', () => {
+    assert.equal(parseWhyMatters(null), null);
+    assert.equal(parseWhyMatters(undefined), null);
+    assert.equal(parseWhyMatters(''), null);
+    assert.equal(parseWhyMatters('   '), null);
+    assert.equal(parseWhyMatters(42), null);
+  });
+
+  it('returns null when the sentence is too short', () => {
+    assert.equal(parseWhyMatters('Too brief.'), null);
+  });
+
+  it('returns null when the sentence is too long (likely reasoning)', () => {
+    const long = 'A '.repeat(250) + '.';
+    assert.equal(parseWhyMatters(long), null);
+  });
+
+  it('takes the first sentence only when the model returns multiple', () => {
+    const text = 'Closure would spike oil markets and force a naval response. A second sentence here.';
+    const out = parseWhyMatters(text);
+    assert.equal(out, 'Closure would spike oil markets and force a naval response.');
+  });
+
+  it('strips surrounding quotes (smart and straight)', () => {
+    const out = parseWhyMatters('\u201CClosure would spike oil markets and force a naval response.\u201D');
+    assert.equal(out, 'Closure would spike oil markets and force a naval response.');
+  });
+
+  it('rejects the stub sentence itself so we never cache it', () => {
+    assert.equal(parseWhyMatters('Story flagged by your sensitivity settings. Open for context.'), null);
+  });
+
+  it('accepts a single clean editorial sentence', () => {
+    const out = parseWhyMatters('Closure of the Strait of Hormuz would spike global oil prices and force a US naval response.');
+    assert.match(out, /^Closure of the Strait/);
+    assert.ok(out.endsWith('.'));
+  });
+});
+
+// ── generateWhyMatters ─────────────────────────────────────────────────────
+
+describe('generateWhyMatters', () => {
+  it('returns the cached value without calling the LLM when cache hits', async () => {
+    const cache = makeCache();
+    const llm = makeLLM(() => 'should not be called');
+    cache.store.set(
+      // Hash matches hashStory(story()) deterministically via same inputs.
+      // We just pre-populate via the real key by calling once and peeking.
+      // Easier: call generate first to populate, then flip responder.
+      'placeholder', null,
+    );
+
+    // First call: real responder populates cache
+    llm.calls.length = 0;
+    const real = makeLLM('Closure would freeze a fifth of seaborne crude within days.');
+    const first = await generateWhyMatters(story(), { ...cache, callLLM: real.callLLM });
+    assert.ok(first);
+    const cachedKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:whymatters:v1:'));
+    assert.ok(cachedKey, 'expected a whymatters cache entry');
+
+    // Second call: responder throws — cache must prevent the call
+    llm.calls.length = 0;
+    const throwing = makeLLM(() => { throw new Error('should not be called'); });
+    const second = await generateWhyMatters(story(), { ...cache, callLLM: throwing.callLLM });
+    assert.equal(second, first);
+    assert.equal(throwing.calls.length, 0);
+  });
+
+  it('returns null when the LLM returns null', async () => {
+    const cache = makeCache();
+    const llm = makeLLM(null);
+    const out = await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
+    assert.equal(out, null);
+    assert.equal(cache.store.size, 0, 'nothing should be cached on a null LLM response');
+  });
+
+  it('returns null when the LLM throws', async () => {
+    const cache = makeCache();
+    const llm = makeLLM(() => { throw new Error('provider down'); });
+    const out = await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
+    assert.equal(out, null);
+  });
+
+  it('returns null when the LLM output fails parse validation', async () => {
+    const cache = makeCache();
+    const llm = makeLLM('too short');
+    const out = await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
+    assert.equal(out, null);
+  });
+
+  it('pins the provider chain to openrouter (skipProviders=ollama,groq)', async () => {
+    const cache = makeCache();
+    const llm = makeLLM('Closure of the Strait of Hormuz would spike oil prices globally.');
+    await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
+    assert.ok(llm.calls[0]);
+    assert.deepEqual(llm.calls[0].opts.skipProviders, ['ollama', 'groq']);
+  });
+
+  it('caches shared story-hash across users (no per-user key)', async () => {
+    const cache = makeCache();
+    const llm = makeLLM('Closure of the Strait of Hormuz would spike oil prices globally.');
+    await generateWhyMatters(story(), { ...cache, callLLM: llm.callLLM });
+    // Different user requesting same story — cache should hit, LLM not called again
+    const llm2 = makeLLM(() => { throw new Error('would not be called'); });
+    const out = await generateWhyMatters(story(), { ...cache, callLLM: llm2.callLLM });
+    assert.ok(out);
+    assert.equal(llm2.calls.length, 0);
+  });
+});
+
+// ── buildDigestPrompt ──────────────────────────────────────────────────────
+
+describe('buildDigestPrompt', () => {
+  it('includes reader sensitivity and ranked story lines', () => {
+    const { system, user } = buildDigestPrompt([story(), story({ headline: 'Second', country: 'PS' })], 'critical');
+    assert.match(system, /chief editor of WorldMonitor Brief/);
+    assert.match(user, /Reader sensitivity level: critical/);
+    assert.match(user, /01\. \[critical\] Iran threatens/);
+    assert.match(user, /02\. \[critical\] Second/);
+  });
+
+  it('caps at 12 stories', () => {
+    const many = Array.from({ length: 30 }, (_, i) => story({ headline: `H${i}` }));
+    const { user } = buildDigestPrompt(many, 'all');
+    const lines = user.split('\n').filter((l) => /^\d{2}\. /.test(l));
+    assert.equal(lines.length, 12);
+  });
+});
+
+// ── parseDigestProse ───────────────────────────────────────────────────────
+
+describe('parseDigestProse', () => {
+  const good = JSON.stringify({
+    lead: 'The most impactful development today is Iran\'s repeated threats to close the Strait of Hormuz, a move with significant global economic repercussions.',
+    threads: [
+      { tag: 'Energy', teaser: 'Hormuz closure threats have reopened global oil volatility.' },
+      { tag: 'Humanitarian', teaser: 'Gaza water truck killings drew UNICEF condemnation.' },
+    ],
+    signals: ['Watch for US naval redeployment in the Gulf.'],
+  });
+
+  it('parses a valid JSON payload', () => {
+    const out = parseDigestProse(good);
+    assert.ok(out);
+    assert.match(out.lead, /Strait of Hormuz/);
+    assert.equal(out.threads.length, 2);
+    assert.equal(out.signals.length, 1);
+  });
+
+  it('strips ```json fences the model occasionally emits', () => {
+    const fenced = '```json\n' + good + '\n```';
+    const out = parseDigestProse(fenced);
+    assert.ok(out);
+    assert.match(out.lead, /Strait of Hormuz/);
+  });
+
+  it('returns null on malformed JSON', () => {
+    assert.equal(parseDigestProse('not json {'), null);
+    assert.equal(parseDigestProse('[]'), null);
+    assert.equal(parseDigestProse(''), null);
+    assert.equal(parseDigestProse(null), null);
+  });
+
+  it('returns null when lead is too short or missing', () => {
+    assert.equal(parseDigestProse(JSON.stringify({ lead: 'too short', threads: [{ tag: 'A', teaser: 'b' }], signals: [] })), null);
+    assert.equal(parseDigestProse(JSON.stringify({ threads: [{ tag: 'A', teaser: 'b' }] })), null);
+  });
+
+  it('returns null when threads are empty — renderer needs at least one', () => {
+    const obj = JSON.parse(good);
+    obj.threads = [];
+    assert.equal(parseDigestProse(JSON.stringify(obj)), null);
+  });
+
+  it('caps threads at 6 and signals at 6', () => {
+    const obj = JSON.parse(good);
+    obj.threads = Array.from({ length: 12 }, (_, i) => ({ tag: `T${i}`, teaser: `teaser ${i}` }));
+    obj.signals = Array.from({ length: 12 }, (_, i) => `signal ${i}`);
+    const out = parseDigestProse(JSON.stringify(obj));
+    assert.equal(out.threads.length, 6);
+    assert.equal(out.signals.length, 6);
+  });
+
+  it('filters out malformed thread entries without rejecting the whole payload', () => {
+    const obj = JSON.parse(good);
+    obj.threads = [
+      { tag: 'Energy', teaser: 'Hormuz closure threats.' },
+      { tag: '' /* empty, drop */, teaser: 'should not appear' },
+      { teaser: 'no tag, drop' },
+      null,
+      'not-an-object',
+    ];
+    const out = parseDigestProse(JSON.stringify(obj));
+    assert.equal(out.threads.length, 1);
+    assert.equal(out.threads[0].tag, 'Energy');
+  });
+});
+
+// ── generateDigestProse ────────────────────────────────────────────────────
+
+describe('generateDigestProse', () => {
+  const stories = [story(), story({ headline: 'Second story on Gaza', country: 'PS' })];
+  const validJson = JSON.stringify({
+    lead: 'The most impactful development today is Iran\'s threats to close the Strait of Hormuz, with significant global oil-market implications.',
+    threads: [{ tag: 'Energy', teaser: 'Hormuz closure threats.' }],
+    signals: ['Watch for US naval redeployment.'],
+  });
+
+  it('cache hit skips the LLM', async () => {
+    const cache = makeCache();
+    const llm1 = makeLLM(validJson);
+    await generateDigestProse('user_abc', stories, 'critical', { ...cache, callLLM: llm1.callLLM });
+
+    const llm2 = makeLLM(() => { throw new Error('would not be called'); });
+    const out = await generateDigestProse('user_abc', stories, 'critical', { ...cache, callLLM: llm2.callLLM });
+    assert.ok(out);
+    assert.equal(llm2.calls.length, 0);
+  });
+
+  it('returns null when the LLM output fails parse validation', async () => {
+    const cache = makeCache();
+    const llm = makeLLM('not json');
+    const out = await generateDigestProse('user_abc', stories, 'all', { ...cache, callLLM: llm.callLLM });
+    assert.equal(out, null);
+    assert.equal(cache.store.size, 0);
+  });
+
+  it('different users share the cache when the story pool is identical', async () => {
+    const cache = makeCache();
+    const llm1 = makeLLM(validJson);
+    await generateDigestProse('user_a', stories, 'all', { ...cache, callLLM: llm1.callLLM });
+    // user_b with same stories+sensitivity — different cache key (user is part of key)
+    const llm2 = makeLLM(validJson);
+    await generateDigestProse('user_b', stories, 'all', { ...cache, callLLM: llm2.callLLM });
+    assert.equal(llm1.calls.length, 1);
+    assert.equal(llm2.calls.length, 1, 'digest prose cache is per-user, not per-story-pool');
+  });
+
+  it('story pool reordering reuses the cache (hash is order-insensitive)', async () => {
+    const cache = makeCache();
+    const llm1 = makeLLM(validJson);
+    await generateDigestProse('user_a', [stories[0], stories[1]], 'all', { ...cache, callLLM: llm1.callLLM });
+    const llm2 = makeLLM(() => { throw new Error('would not be called'); });
+    await generateDigestProse('user_a', [stories[1], stories[0]], 'all', { ...cache, callLLM: llm2.callLLM });
+    assert.equal(llm2.calls.length, 0, 'reordered pool should hit the same cache entry');
+  });
+});
+
+// ── enrichBriefEnvelopeWithLLM ─────────────────────────────────────────────
+
+describe('enrichBriefEnvelopeWithLLM', () => {
+  const goodWhy = 'Closure of the Strait of Hormuz would spike global oil prices and force a US naval response within 72 hours.';
+  const goodProse = JSON.stringify({
+    lead: 'Iran\'s threats over the Strait of Hormuz dominate today, alongside the widening Gaza humanitarian crisis and South Sudan famine warnings.',
+    threads: [
+      { tag: 'Energy', teaser: 'Hormuz closure would disrupt a fifth of seaborne crude.' },
+      { tag: 'Humanitarian', teaser: 'UNICEF condemns Gaza water truck killings.' },
+    ],
+    signals: ['Watch for US naval redeployment in the Gulf.'],
+  });
+
+  it('happy path: whyMatters per story + lead/threads/signals substituted', async () => {
+    const cache = makeCache();
+    let call = 0;
+    const llm = makeLLM((_sys, user) => {
+      call++;
+      if (user.includes('Reader sensitivity level')) return goodProse;
+      return goodWhy;
+    });
+    const env = envelope();
+    const out = await enrichBriefEnvelopeWithLLM(env, { userId: 'user_a', sensitivity: 'critical' }, {
+      ...cache, callLLM: llm.callLLM,
+    });
+    for (const s of out.data.stories) {
+      assert.equal(s.whyMatters, goodWhy, 'every story gets enriched whyMatters');
+    }
+    assert.match(out.data.digest.lead, /Strait of Hormuz/);
+    assert.equal(out.data.digest.threads.length, 2);
+    assert.equal(out.data.digest.signals.length, 1);
+    // Numbers / stories count must NOT be touched
+    assert.equal(out.data.digest.numbers.surfaced, env.data.digest.numbers.surfaced);
+    assert.equal(out.data.stories.length, env.data.stories.length);
+  });
+
+  it('LLM down everywhere: envelope returns unchanged stubs', async () => {
+    const cache = makeCache();
+    const llm = makeLLM(() => { throw new Error('provider down'); });
+    const env = envelope();
+    const out = await enrichBriefEnvelopeWithLLM(env, { userId: 'user_a', sensitivity: 'all' }, {
+      ...cache, callLLM: llm.callLLM,
+    });
+    // Stories keep their stubbed whyMatters
+    assert.equal(out.data.stories[0].whyMatters, env.data.stories[0].whyMatters);
+    // Digest prose stays as the stub lead/threads/signals
+    assert.equal(out.data.digest.lead, env.data.digest.lead);
+    assert.deepEqual(out.data.digest.threads, env.data.digest.threads);
+    assert.deepEqual(out.data.digest.signals, env.data.digest.signals);
+  });
+
+  it('partial failure: whyMatters OK, digest prose fails — per-story still enriched', async () => {
+    const cache = makeCache();
+    const llm = makeLLM((_sys, user) => {
+      if (user.includes('Reader sensitivity level')) return 'not valid json';
+      return goodWhy;
+    });
+    const env = envelope();
+    const out = await enrichBriefEnvelopeWithLLM(env, { userId: 'user_a', sensitivity: 'all' }, {
+      ...cache, callLLM: llm.callLLM,
+    });
+    for (const s of out.data.stories) {
+      assert.equal(s.whyMatters, goodWhy);
+    }
+    // Digest falls back to the stub
+    assert.equal(out.data.digest.lead, env.data.digest.lead);
+  });
+
+  it('preserves envelope shape: version, issuedAt, user, date unchanged', async () => {
+    const cache = makeCache();
+    const llm = makeLLM(goodWhy);
+    const env = envelope();
+    const out = await enrichBriefEnvelopeWithLLM(env, { userId: 'user_a', sensitivity: 'all' }, {
+      ...cache, callLLM: llm.callLLM,
+    });
+    assert.equal(out.version, env.version);
+    assert.equal(out.issuedAt, env.issuedAt);
+    assert.deepEqual(out.data.user, env.data.user);
+    assert.equal(out.data.date, env.data.date);
+    assert.equal(out.data.dateLong, env.data.dateLong);
+    assert.equal(out.data.issue, env.data.issue);
+  });
+
+  it('returns envelope untouched if data or stories are missing', async () => {
+    const cache = makeCache();
+    const llm = makeLLM(goodWhy);
+    const out = await enrichBriefEnvelopeWithLLM({ version: 1, issuedAt: 0 }, { userId: 'user_a' }, {
+      ...cache, callLLM: llm.callLLM,
+    });
+    assert.deepEqual(out, { version: 1, issuedAt: 0 });
+    assert.equal(llm.calls.length, 0);
+  });
+
+  it('integration: composed + enriched envelope still passes assertBriefEnvelope', async () => {
+    // Mirrors the production path: compose from digest stories, then
+    // enrich. The output MUST validate — otherwise the SETEX would
+    // land a key the api/brief route refuses to render.
+    const rule = { userId: 'user_abc', variant: 'full', sensitivity: 'all', digestTimezone: 'UTC' };
+    const digestStories = [
+      {
+        hash: 'a1', title: 'Iran threatens Strait of Hormuz closure', link: 'https://x/1',
+        severity: 'critical', currentScore: 100, mentionCount: 5, phase: 'developing',
+        sources: ['Guardian'],
+      },
+      {
+        hash: 'a2', title: 'UNICEF outraged by Gaza water truck killings', link: 'https://x/2',
+        severity: 'critical', currentScore: 90, mentionCount: 3, phase: 'developing',
+        sources: ['UN News'],
+      },
+    ];
+    const composed = composeBriefFromDigestStories(rule, digestStories, { clusters: 277, multiSource: 22 }, { nowMs: 1_745_000_000_000 });
+    assert.ok(composed);
+    const llm = makeLLM((_sys, user) => {
+      if (user.includes('Reader sensitivity level')) {
+        return JSON.stringify({
+          lead: 'Iran\'s Hormuz threats dominate the wire today, with the Gaza humanitarian crisis deepening on a parallel axis.',
+          threads: [
+            { tag: 'Energy', teaser: 'Hormuz closure threats resurface.' },
+            { tag: 'Humanitarian', teaser: 'Gaza water infrastructure under attack.' },
+          ],
+          signals: ['Watch for US naval redeployment.'],
+        });
+      }
+      return 'The stakes here extend far beyond the immediate actors and reshape the week ahead.';
+    });
+    const enriched = await enrichBriefEnvelopeWithLLM(composed, rule, { ...makeCache(), callLLM: llm.callLLM });
+    // Must not throw — the renderer's strict validator is the live
+    // gate between composer and api/brief.
+    assertBriefEnvelope(enriched);
+  });
+
+  it('cache write failure does not break enrichment', async () => {
+    const llm = makeLLM(goodWhy);
+    const env = envelope();
+    const brokenCache = {
+      async cacheGet() { return null; },
+      async cacheSet() { throw new Error('upstash down'); },
+    };
+    const out = await enrichBriefEnvelopeWithLLM(env, { userId: 'user_a', sensitivity: 'all' }, {
+      ...brokenCache, callLLM: llm.callLLM,
+    });
+    // whyMatters still enriched even though the cache write threw
+    for (const s of out.data.stories) {
+      assert.equal(s.whyMatters, goodWhy);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3b of the WorldMonitor Brief plan (`docs/plans/2026-04-17-003`). Replaces the Phase 3a stubs with real editorial output from **Gemini 2.5 Flash** via the existing OpenRouter-backed `callLLM` chain.

Before this PR, every story in the magazine read "Story flagged by your sensitivity settings. Open for context." and the digest lead was a templated "Today's brief surfaces N threads…". The brief looked like an editorial magazine but had the editorial content of a placeholder.

## How it works

Two LLM pathways, different caching semantics:

| Pathway | Shape | Cache key | TTL | Scope |
|---------|-------|-----------|-----|-------|
| `whyMatters` (per story) | 1 editorial sentence, 18–30 words | `brief:llm:whymatters:v1:{sha256(headline\|source\|severity)}` | 24h | **Shared across users** — `whyMatters` is global stakes commentary, not personalised |
| `digest.{lead,threads,signals}` (per user) | JSON `{ lead, threads[], signals[] }` | `brief:llm:digest:v1:{userId}:{sensitivity}:{poolHash}` | 4h | **Per user** — prose references the user's own story pool |

Pool hash sorts titles before hashing so story rank shuffling between cron ticks doesn't invalidate cache needlessly.

Concurrency cap of 5 parallel `whyMatters` calls per brief — a 12-story brief opens 3 sockets in sequence rather than slamming 12 into OpenRouter at once.

## Provider pinning

Explicit user direction: Gemini 2.5 Flash only. Implemented via `skipProviders: ['ollama', 'groq']` on every `callLLM` invocation — Ollama is dev-only and Groq's 8B model produced visibly thinner editorial prose in a spike.

## Failure model

**The brief always ships.** Every LLM call, every parse, every cache hit/write is wrapped with try/catch and null-safe fall-through. If OpenRouter is down, parse validation fails, or Upstash hiccups, `enrichBriefEnvelopeWithLLM` returns the baseline envelope unchanged — its Phase 3a stubs stay in place and `assertBriefEnvelope` still passes.

Kill switch: `BRIEF_LLM_ENABLED` (default `1`). Distinct from `AI_DIGEST_ENABLED` so the brief's editorial prose and the email digest's AI summary can be toggled independently during a provider outage.

## Files changed

| File | Change |
|------|--------|
| `scripts/lib/brief-llm.mjs` | NEW — pure prompt/parse helpers + IO `generateWhyMatters` / `generateDigestProse` + `enrichBriefEnvelopeWithLLM` |
| `scripts/seed-digest-notifications.mjs` | `BRIEF_LLM_ENABLED` env flag, `briefLlmDeps` closure (`callLLM` + Upstash GET/SETEX adapter), enrichment inserted between compose + SETEX |
| `tests/brief-llm.test.mjs` | NEW — 34 cases |

## Tests

- **Pure parsers**: too-short / too-long / echoed stub / smart-quote wrapping / multi-sentence truncation / code-fence stripping / malformed JSON / empty threads / oversized caps
- **Cached generators**: cache hit avoids LLM; cache miss + LLM failure returns null; shared `whyMatters` cache across users for the same story hash; per-user digest prose cache; order-insensitive pool hash
- **End-to-end**: `composeBriefFromDigestStories` → `enrichBriefEnvelopeWithLLM` → `assertBriefEnvelope()` passes. The renderer's strict validator is the live gate between composer and `api/brief`, so we prove the enriched envelope still validates.

**156/156 brief tests pass. Both tsconfigs typecheck clean.**

## Env / operator notes

- **`BRIEF_LLM_ENABLED=0`** on the Railway `digest-notifications` service → brief ships with Phase 3a stubs, as if this PR never landed. Use during OpenRouter outage if you want to skip enrichment attempts instead of burning the 10s timeout per story.
- **`OPENROUTER_API_KEY`** must be set on the service (already is — the email digest AI summary uses the same provider chain).
- No new env vars required.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: `[digest] brief: compose_success=… compose_failed=…` stays healthy (enrichment wraps in try/catch so it shouldn't affect these counters).
  - New log to watch for enrichment throws: `[digest] brief: LLM enrichment threw for {userId}` — expected near-zero.
  - OpenRouter usage: cost per cron tick should scale roughly linearly with **unique** stories across all users plus one call per user.
- **Validation checks**
  ```
  UPSTASH_PIPELINE [
    ["GET", "brief:user_<id>:2026-04-18"],
    ["SCAN", "0", "MATCH", "brief:llm:whymatters:v1:*", "COUNT", "100"],
    ["SCAN", "0", "MATCH", "brief:llm:digest:v1:*", "COUNT", "100"]
  ]
  ```
  - Parse the brief: `data.stories[*].whyMatters` should be varied, editorial, not the stub string.
  - `data.digest.lead` should read as 2–3 sentences of editorial prose, not the templated "Today's brief surfaces N threads…"
- **Expected healthy behavior**
  - whyMatters strings are 18–30 words each, sentence-case, no JSON wrappers
  - digest.lead is 2–3 sentences; threads have 3–6 entries with editorial tags; signals has 2–4 forward-looking imperatives
- **Failure signal / rollback trigger**
  - User reports "brief just says 'Story flagged by your sensitivity settings' on every story" → enrichment is silently no-op; check OpenRouter credits + `OPENROUTER_API_KEY`
  - Parse rejection rate visible in Sentry breadcrumbs → either Gemini format drift or our parser too strict; in both cases the stub stays so no user-facing damage, but triage
  - Any user-visible brokenness → set `BRIEF_LLM_ENABLED=0` on Railway, redeploy digest-notifications; reverts to Phase 3a stubs with zero code change
- **Validation window & owner**
  - First 2 cron ticks (2h) post-deploy; @koala73

Next up in the sequence: Phase 6 (web-push), Phase 8 (carousel renderer), Todo #218 (token-in-URL), Todo #223 (share button + referral).