### PR TITLE
fix(health): macroSignals maxStaleMin 20 → 150

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -231,7 +231,7 @@ const SEED_META = {
   // RPC/warm-ping keys — seed-meta written by relay loops or handlers
   // serviceStatuses: moved to ON_DEMAND — RPC-populated, no dedicated seed, goes stale when no users visit
   cableHealth:      { key: 'seed-meta:cable-health',              maxStaleMin: 90 }, // ais-relay warm-ping runs every 30min; 90min = 3× interval catches missed pings without false positives
-  macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 20 },
+  macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 150 }, // seed-economy cron; primary key energy-prices has same 150min threshold
   bisPolicy:        { key: 'seed-meta:economic:bis',              maxStaleMin: 10080 }, // runSeed('economic','bis',...) writes seed-meta:economic:bis
   // seed-bis-extended.mjs writes per-dataset seed-meta keys ONLY when that
   // specific dataset published fresh entries — so a single-dataset BIS outage


### PR DESCRIPTION
## Summary

`macroSignals` had `maxStaleMin: 20` in health.js, but it's a secondary key written by `seed-economy.mjs` whose cron runs on a ~1-2h cadence (primary key `energy-prices` has `maxStaleMin: 150`). A 20-min threshold guaranteed STALE_SEED between every cron run.

Fix: align to 150min, matching the cron's primary key threshold.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: single config value change, health will self-clear on next cron run.