### PR TITLE
fix(brief): mobile layout — stack story callout, floor digest typography

### DIFF
--- a/server/_shared/brief-render.js
+++ b/server/_shared/brief-render.js
@@ -779,6 +779,40 @@ const STYLE_BLOCK = `<style>
     font-size: max(11px, 0.85vw);
     letter-spacing: 0.2em; opacity: 0.55;
   }
+  @media (max-width: 640px) {
+    .page { padding: 5vh 6vw 8vh; }
+    .digest .running-head {
+      flex-direction: column; align-items: flex-start;
+      gap: 1vh; padding-right: 18vw;
+    }
+    .page-number { top: 4vh; right: 5vw; opacity: 0.6; }
+    .digest h2 { font-size: 10vw; max-width: 22ch; margin-bottom: 4vh; }
+    .digest blockquote {
+      font-size: max(17px, 4.6vw); line-height: 1.35;
+      max-width: 40ch; padding-left: 4vw;
+    }
+    .digest .rule { width: 14vw; margin-top: 4vh; }
+    .digest .stat-row { grid-template-columns: 1fr; gap: 1.5vh; }
+    .digest .stat-num { font-size: 18vw; }
+    .digest .stat-label { font-size: max(15px, 4vw); }
+    .digest .thread { font-size: max(15px, 4vw); line-height: 1.5; }
+    .digest .signal { font-size: max(15px, 4vw); padding-left: 4vw; }
+    .story { display: flex; flex-direction: column; gap: 4vh; }
+    .story .left { padding-right: 0; }
+    .story .rank-ghost { font-size: 62vw; left: -4vw; top: 30%; }
+    .story h3 { font-size: 9.5vw; max-width: none; margin-bottom: 3vh; }
+    .story .desc {
+      font-size: max(16px, 4.4vw); max-width: none;
+      margin-bottom: 3vh; line-height: 1.5;
+    }
+    .story .tag-row { gap: 2vw; margin-bottom: 3vh; }
+    .story .tag { font-size: 11px; padding: 0.4em 0.8em; }
+    .story .source { font-size: 11px; }
+    .story .right { justify-content: flex-start; }
+    .story .callout { padding: 3vh 4vw; border-left-width: 3px; }
+    .story .callout .label { font-size: 11px; margin-bottom: 1.5vh; opacity: 0.7; }
+    .story .callout .note { font-size: max(16px, 4.2vw); line-height: 1.5; }
+  }
 </style>`;
 
 const NAV_SCRIPT = `<script>

--- a/server/_shared/brief-render.js
+++ b/server/_shared/brief-render.js
@@ -781,9 +781,15 @@ const STYLE_BLOCK = `<style>
   }
   @media (max-width: 640px) {
     .page { padding: 5vh 6vw 8vh; }
+    /* padding-right must clear the absolute .page-number block on the
+       right. "09 / 12" in IBM Plex Mono at 11px is ~65-70px wide and
+       .page-number sits at right:5vw; on a 360px Android ~19px + 70px
+       = ~89px of occupied space. 22vw ≈ 79px at 360px AND ≈ 86px at
+       393px — enough headroom with a one-vw safety margin. 18vw left
+       ~0 clearance on iPhone SE (Greptile P2). */
     .digest .running-head {
       flex-direction: column; align-items: flex-start;
-      gap: 1vh; padding-right: 18vw;
+      gap: 1vh; padding-right: 22vw;
     }
     .page-number { top: 4vh; right: 5vw; opacity: 0.6; }
     .digest h2 { font-size: 10vw; max-width: 22ch; margin-bottom: 4vh; }
@@ -794,9 +800,13 @@ const STYLE_BLOCK = `<style>
     .digest .rule { width: 14vw; margin-top: 4vh; }
     .digest .stat-row { grid-template-columns: 1fr; gap: 1.5vh; }
     .digest .stat-num { font-size: 18vw; }
-    .digest .stat-label { font-size: max(15px, 4vw); }
-    .digest .thread { font-size: max(15px, 4vw); line-height: 1.5; }
-    .digest .signal { font-size: max(15px, 4vw); padding-left: 4vw; }
+    /* Keep px floors at or above the base-rule floors (17px / 18px)
+       so very narrow viewports (<375px) never render smaller than
+       desktop. vw term still scales up on typical phones (4vw ≈ 15.7px
+       at 393px so the max() picks the px floor). Greptile P2. */
+    .digest .stat-label { font-size: max(17px, 4vw); }
+    .digest .thread { font-size: max(17px, 4vw); line-height: 1.5; }
+    .digest .signal { font-size: max(18px, 4vw); padding-left: 4vw; }
     .story { display: flex; flex-direction: column; gap: 4vh; }
     .story .left { padding-right: 0; }
     .story .rank-ghost { font-size: 62vw; left: -4vw; top: 30%; }


### PR DESCRIPTION
## Summary

On mobile viewports (<=640px) two things were off in the brief magazine:

1. **Story pages** used a `grid-template-columns: 55fr 45fr` layout that kept the "Why this is important" callout pinned at ~45% of the phone width beside the headline — both columns ended up cramped, nothing could breathe.
2. **Digest pages** used raw `vw` units with no floor (`blockquote { font-size: 2vw }`, `.digest .thread { ... 1.55vw }`), which on a 393px iPhone frame collapsed to ~6–8px before the browser min-clamped them to a barely-legible size.

Fix is CSS-only: one `@media (max-width: 640px)` block appended to `STYLE_BLOCK` in `server/_shared/brief-render.js`.

- `.story` becomes `flex-direction: column` — callout stacks **under** the headline + description with its own breathing room.
- Story headline scales to `9.5vw` full-width; description gets `max(16px, 4.4vw)`; callout note gets `max(16px, 4.2vw)`.
- Digest `blockquote`, `h2`, stat rows, threads, signals all get viewport floors (`max(17px, 4.6vw)` etc.) so they never collapse.
- Digest running-head stacks vertically, and `.page-number` gets clearance so it stops colliding with the right-hand meta.
- Tags and source labels pinned to 11px (they were scaling down with `vw`).

No envelope changes, no HTML structural changes, no new classes — purely an additive `@media` block. Preview was validated via `brief-mobile-playground.html` (not shipped) with iPhone 14 Pro (393×852) before/after frames.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run typecheck:api` — passes
- [x] `npm run lint` — 0 errors
- [x] `npm run test:data` — 5673/5673 pass
- [x] `node --test tests/brief-magazine-render.test.mjs` — 30/30 pass (chrome invariants, envelope validation, sentinel-poisoning)
- [x] `node --test tests/edge-functions.test.mjs` — 171/171 pass
- [x] Edge bundle check across all `api/*.js` — OK
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK
- [ ] Visual check on production: open `/api/brief/...` on an iPhone-width viewport after merge; confirm digest intro is legible and story callouts stack under headline

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: no new entries expected — renderer is pure & output is HTML only
  - Metrics/Dashboards: Vercel `renderBriefMagazine` cold-start latency (should be unchanged; only ~34 CSS lines added)
- **Validation checks (queries/commands)**
  - `curl -sL https://<prod>/api/brief/<user>/<date> | grep -c "@media (max-width: 640px)"` → expect 1
- **Expected healthy behavior**
  - Desktop rendering unchanged (no rules inside the media query affect >640px viewports)
  - Mobile safari/chrome on the shared brief link shows stacked callout + floored typography
- **Failure signal(s) / rollback trigger**
  - Any new Sentry error referencing `brief-render.js` or `renderBriefMagazine` — revert the commit
  - Visible layout regression on desktop (shouldn't happen; overrides are all inside the media query)
- **Validation window & owner**
  - Window: 24h after merge
  - Owner: @koala73