### PR TITLE
chore(sentry): filter NS_ERROR_UNEXPECTED + ConvexError API_ACCESS_REQUIRED

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,7 @@ Sentry.init({
     /userScripts is not defined/,
     /NS_ERROR_ABORT/,
     /NS_ERROR_OUT_OF_MEMORY/,
+    /NS_ERROR_UNEXPECTED/, // Firefox XPCOM: Worker init failure on privacy-hardened Firefox/Ubuntu — WORLDMONITOR-N6/N7/N8/N9
     /DataCloneError.*could not be cloned/,
     /cannot decode message/,
     /WKWebView was deallocated/,
@@ -246,6 +247,7 @@ Sentry.init({
     /doesn't provide an export named/, // stale cached chunk after deploy references removed export
     /Possible side-effect in debug-evaluate/, // Chrome DevTools internal EvalError
     /ConvexError: CONFLICT/, // Expected OCC rejection on concurrent preference saves
+    /ConvexError: API_ACCESS_REQUIRED/, // Expected business error: free user opens API Keys tab; client handles gracefully (UnifiedSettings.ts:731-738) — WORLDMONITOR-NA
     /\[CONVEX [AQM]\(.+?\)\] Connection lost while action was in flight/, // Convex SDK transient WS disconnect
     /Response did not contain `success` or `data`/, // DuckDuckGo browser internal tracker/content-block response — never emitted by our code
     /Cannot set properties of undefined \(setting 'bodyTouched'\)/, // Quark browser (Alibaba mobile) touch-tracking script injection (WORLDMONITOR-N1)


### PR DESCRIPTION
## Summary
- **NS_ERROR_UNEXPECTED** (WORLDMONITOR-N6/N7/N8/N9, Firefox 149/Ubuntu, 6 events/1 user): Firefox XPCOM Worker init failure. Joins existing `NS_ERROR_ABORT` and `NS_ERROR_OUT_OF_MEMORY` in `ignoreErrors`. 0 repo matches. Breadcrumbs confirm the Worker fallback path works (`"[NewsPanel] Failed to cluster news, keeping flat list"`).
- **ConvexError: API_ACCESS_REQUIRED** (WORLDMONITOR-NA, 15 events/5 users, prod): Expected business error from merged PR #3125 (API key management). Free users click the API Keys tab, server correctly denies access, client try/catch at `UnifiedSettings.ts:731-738` handles gracefully and shows a user-facing error message. Sentry sees it because the Convex WS transport fires an unhandled rejection before the client-side Promise chain catches it. Joins existing `ConvexError: CONFLICT` pattern.

## Follow-up (not in this PR)
The API Keys tab should show a PRO upgrade CTA for free users instead of triggering a server error and catching it client-side. That would eliminate the noise at the source and improve the growth funnel.

## Test plan
- [x] `npm run typecheck` / `typecheck:api`
- [x] `npm run lint` (0 errors)
- [x] `npm run test:data` — pass
- [x] `node --test tests/edge-functions.test.mjs` — pass (includes `sentry-beforesend.test.mjs`, 92/92)
- [x] Edge bundle check, `lint:md`, `version:check`