### PR TITLE
fix(supply-chain): don't CDN-cache empty chokepoint-history responses

### DIFF
--- a/server/worldmonitor/supply-chain/v1/get-chokepoint-history.ts
+++ b/server/worldmonitor/supply-chain/v1/get-chokepoint-history.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/supply_chain/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { CANONICAL_CHOKEPOINTS } from './_chokepoint-ids';
 
 const HISTORY_KEY_PREFIX = 'supply_chain:transit-summaries:history:v1:';
@@ -18,17 +19,28 @@ interface HistoryPayload {
 }
 
 export async function getChokepointHistory(
-  _ctx: ServerContext,
+  ctx: ServerContext,
   req: GetChokepointHistoryRequest,
 ): Promise<GetChokepointHistoryResponse> {
   const id = String(req.chokepointId || '').trim();
   if (!id || !VALID_IDS.has(id)) {
+    // Invalid ID: mark no-cache so junk IDs don't pin a 30-min empty on CF.
+    markNoCacheResponse(ctx.request);
     return { chokepointId: '', history: [], fetchedAt: '0' };
   }
 
   try {
     const payload = await getCachedJson(`${HISTORY_KEY_PREFIX}${id}`, true) as HistoryPayload | null;
-    if (!payload || !Array.isArray(payload.history)) {
+    if (!payload || !Array.isArray(payload.history) || payload.history.length === 0) {
+      // CRITICAL: do NOT let an empty response get CDN-cached. During the
+      // deploy window (Vercel deploys instantly; Railway ais-relay takes
+      // ~10 min to redeploy and another 10 min for the first transit-summary
+      // cron tick), per-id history keys are absent. If we cached empty
+      // responses at the 'slow' tier (30-min CDN), users would see "Transit
+      // history unavailable" for 30 min AFTER the key got populated, because
+      // CF serves stale empty bodies. Mark no-cache so every call re-checks
+      // Redis. Cheap — fetch is ~35 KB and edge→Upstash is <1.5s.
+      markNoCacheResponse(ctx.request);
       return { chokepointId: id, history: [], fetchedAt: '0' };
     }
     return {
@@ -37,6 +49,7 @@ export async function getChokepointHistory(
       fetchedAt: String(payload.fetchedAt ?? 0),
     };
   } catch {
+    markNoCacheResponse(ctx.request);
     return { chokepointId: id, history: [], fetchedAt: '0' };
   }
 }


### PR DESCRIPTION
## Summary

User reported "Transit history unavailable" persisting for Hormuz chokepoint even though the backend had full data.

**Direct evidence:**
- Redis: `supply_chain:transit-summaries:history:v1:hormuz_strait` has **174 entries**
- Server-side curl to `/api/supply-chain/v1/get-chokepoint-history?chokepointId=hormuz_strait` → **174 entries**
- User's browser response to the same URL → **`{"history":[],"fetchedAt":"0"}`** (empty)

## Root cause

Gateway cache tier `slow` pins 200 responses for 30 min at Cloudflare edge (`s-maxage=1800`). During the gap between Vercel instant deploy and Railway ais-relay redeploy + first transit-summary cron tick (~20 min), per-id history keys were absent in Redis, so the handler returned empty. Those empty bodies got **CF-cached for 30 min** and kept serving even after the Redis keys got populated.

Bab-el-Mandeb (which renders for the user) got a fresh non-empty cache entry; Hormuz got stuck with the empty one because the first user to hit Hormuz did so before the key was populated.

## Fix

When the handler returns empty (missing key, invalid id, or thrown error), call `markNoCacheResponse(ctx.request)` — this sets the gateway's `X-No-Cache` side-channel, which flips `Cache-Control` to `no-store`. Every request on an empty state re-checks Redis. Once data is present, the normal tier cache applies on the non-empty response.

Mechanism uses the existing gateway escape hatch at `server/gateway.ts:488`:
```ts
if (mergedHeaders.get('X-No-Cache') || isUpstreamUnavailable) {
  mergedHeaders.set('Cache-Control', 'no-store');
}
```

Same pattern as other handlers that return upstream-unavailable bodies.

Also no-caches invalid chokepoint IDs so scanners / junk IDs don't pin 30-min empties.

## Cost

Per-id history keys are ~35 KB, edge→Upstash round-trip <1.5 s. Slight bump in Redis traffic for as long as keys are empty; negligible in practice (only the deploy window and any prolonged upstream outage).

## Testing

- `npm run typecheck:api` ✓

## Post-deploy

User should see Hormuz (and any other chokepoint that got stuck with empty cache) render correctly within ~1 min of merge (CF TTL rolls over). No Railway action needed.

## Unrelated issue flagged

User also reports Simulate Closure button stuck at "Computing…" despite the `/api/scenario/v1/status` endpoint returning a valid `{status:'done', result:{topImpactCountries:[...]}}`. Client is receiving the correct response but `onScenarioActivate` is not visibly firing. Most likely a stale client bundle (service worker serving pre-PR-#3187 JS). Asked user to hard-refresh; if still broken, will investigate separately.

One cosmetic bug also spotted for future cleanup: `showScenarioSummary` does `(c.impactPct * 100).toFixed(0)` but the worker returns `impactPct` already as a 0–100 integer — banner would show "10000%" instead of "100%". Not why UI shows nothing; separate PR.

---

🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.49.0

Co-Authored-By: Claude <noreply@anthropic.com>