### PR TITLE
fix(supply-chain, news): scenario % double-multiply + entity null-type TypeError

### DIFF
--- a/src/components/SupplyChainPanel.ts
+++ b/src/components/SupplyChainPanel.ts
@@ -679,8 +679,11 @@ export class SupplyChainPanel extends Panel {
     this.activeScenarioState = { scenarioId, result };
     this.content.querySelector('.sc-scenario-banner')?.remove();
     const top5 = result.topImpactCountries.slice(0, 5);
+    // impactPct is already a 0–100 integer from the scenario-worker
+    // (scripts/scenario-worker.mjs: `Math.min(Math.round((totalImpact / maxImpact) * 100), 100)`).
+    // Prior code multiplied by 100 again → banner showed "10000%" instead of "100%".
     const countriesHtml = top5.map(c =>
-      `<span class="sc-scenario-country">${escapeHtml(c.iso2)} <em>${(c.impactPct * 100).toFixed(0)}%</em></span>`
+      `<span class="sc-scenario-country">${escapeHtml(c.iso2)} <em>${c.impactPct.toFixed(0)}%</em></span>`
     ).join(' \u00B7 ');
     const banner = document.createElement('div');
     banner.className = 'sc-scenario-banner';

--- a/src/services/parallel-analysis.ts
+++ b/src/services/parallel-analysis.ts
@@ -243,9 +243,16 @@ class ParallelAnalysisService {
   }
 
   private scoreByEntities(entities: NEREntity[]): PerspectiveScore {
-    const locations = entities.filter(e => e.type.includes('LOC'));
-    const people = entities.filter(e => e.type.includes('PER'));
-    const orgs = entities.filter(e => e.type.includes('ORG'));
+    // Defensive: ML worker occasionally returns entities with missing
+    // `type`/`text` fields (observed in prod as TypeError: Cannot read
+    // properties of undefined reading 'includes' on the .filter below).
+    // Narrow to well-formed entries before any string access.
+    const safeEntities = entities.filter((e): e is NEREntity =>
+      typeof e?.type === 'string' && typeof e?.text === 'string'
+    );
+    const locations = safeEntities.filter(e => e.type.includes('LOC'));
+    const people = safeEntities.filter(e => e.type.includes('PER'));
+    const orgs = safeEntities.filter(e => e.type.includes('ORG'));
 
     const geopoliticalLocations = locations.filter(e =>
       FLASHPOINT_KEYWORDS.some(fp => e.text.toLowerCase().includes(fp))
@@ -272,7 +279,7 @@ class ParallelAnalysisService {
       reasons.push(`orgs(${orgs.map(e => e.text).join(',')})`);
     }
 
-    const entityDensity = entities.length;
+    const entityDensity = safeEntities.length;
     if (entityDensity > 3) {
       score += 0.15;
       reasons.push(`high-density(${entityDensity})`);
@@ -281,7 +288,7 @@ class ParallelAnalysisService {
     return {
       name: 'entities',
       score: Math.min(1, score),
-      confidence: entities.length > 0 ? 0.7 : 0.3,
+      confidence: safeEntities.length > 0 ? 0.7 : 0.3,
       reasoning: reasons.length > 0 ? reasons.join(' + ') : 'no significant entities',
     };
   }


### PR DESCRIPTION
## Summary

Two unrelated issues caught during live session testing of Simulate Closure:

### 1. Scenario banner percentages inflated 100×

Screenshot showed `⚠ Hormuz Strait Tanker Blockade CN 10000% · IN 8400% · TW 8200% · IR 8000% · US 3900%`.

`showScenarioSummary` was doing `(c.impactPct * 100).toFixed(0)`, but the scenario-worker (`scripts/scenario-worker.mjs:295`) already ships `impactPct` as a 0–100 integer:
```js
impactPct: Math.min(Math.round((totalImpact / maxImpact) * 100), 100)
```
Multiplying by 100 again inflated every percentage 100×.

**Fix:** drop the extra `* 100`. Now renders `CN 100% · IN 84% · TW 82% · IR 80% · US 39%` — matches the worker's intent.

### 2. TypeError in `scoreByEntities`

Console showed:
```
[ParallelAnalysis] Error: TypeError: Cannot read properties of undefined (reading 'includes')
    at scoreByEntities (parallel-analysis.ts)
```

ML worker occasionally returns entities with `type` or `text` undefined. The filter `entities.filter(e => e.type.includes('LOC'))` NPEs on the first such entry.

**Fix:** narrow to well-formed entries via a type guard before any string access:
```ts
const safeEntities = entities.filter((e): e is NEREntity =>
  typeof e?.type === 'string' && typeof e?.text === 'string'
);
```
`safeEntities` is used everywhere downstream (locations/people/orgs filters, density, confidence) so the guard is the single source of truth — no latent paths accessing the raw array.

## Testing

- `npm run typecheck` ✓

## Deploy

Client-only changes; Vercel auto-deploys on merge.

---

🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.49.0

Co-Authored-By: Claude <noreply@anthropic.com>