### PR TITLE
chore(sentry): add Chrome/Firefox variant of UTItemActionController filter

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -116,7 +116,7 @@ Sentry.init({
     /(?:AbortError: )?The user aborted a request/,
     /\w+ is not a function.*\/uv\/service\//,
     /__isInQueue__/,
-    /^(?:LIDNotify(?:Id)?|onWebViewAppeared|onGetWiFiBSSID|onHide|onShow|onReady|tapAt|removeHighlight) is not defined$/,
+    /^(?:LIDNotify(?:Id)?|onWebViewAppeared|onGetWiFiBSSID|onHide|onShow|onReady|tapAt|removeHighlight|UTItemActionController) is not defined$/,
     /Se requiere plan premium/,
     /hybridExecute is not defined/,
     /reading 'postMessage'/,


### PR DESCRIPTION
## Summary
- `UTItemActionController is not defined` (WORLDMONITOR-NB) was slipping through because the existing `ignoreErrors` at line 53 only covers Safari's format (`Can't find variable: UTItemActionController`).
- Chrome/Firefox uses the `X is not defined` format instead. Added `UTItemActionController` to the existing `is not defined` group at line 119.
- `UTItemActionController` is an iOS/Apple private API variable (UITableViewCell action controller), never emitted by our code.

## Test plan
- [x] `npm run typecheck` / `typecheck:api`
- [x] `npm run lint` (0 errors)
- [x] `npm run test:data` — pass
- [x] `node --test tests/edge-functions.test.mjs` — pass (92/92 sentry-beforesend policy tests)
- [x] Edge bundle, `lint:md`, `version:check`