### PR TITLE
fix(digest): semantic story clustering — collapse same-event wire duplicates

### DIFF
--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -294,24 +294,21 @@ const JACCARD_MERGE_THRESHOLD = 0.35;
 // "hormuz" being the distinctive entity) and correctly collapse
 // into one event.
 const CLUSTER_JOIN_MIN_SHARED_WORDS = 2;
+const CLUSTER_JOIN_MIN_DISTINCTIVE_SHARED = 2;
 const CLUSTER_JOIN_DISTINCTIVE_LEN = 5;
-// When merging into a cluster that already has ≥2 items, 1 distinctive
-// shared word is enough evidence (the cluster itself is the prior).
-// Singleton-to-singleton merges need stronger signal — a single entity
-// overlap like "hormuz" is not enough: two unrelated Iran-tagged
-// stories often share "iran" + another 4-char generic. Require ≥2
-// distinctive shared words AND Jaccard above a floor so two stories
-// sharing just {french, lebanon} (different Lebanon events) don't
-// collapse.
-const CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_BOTH_SINGLETON = 2;
-const CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_HAS_EVIDENCE = 1;
-// Jaccard floor applied in addition to distinctive-word count when both
-// sides are singletons. Prevents the classic false-positive of two
-// genuinely different events that happen to share two named entities
-// (e.g. two separate Lebanon incidents both mentioning "French" and
-// "Lebanon"). The events will have different verbs / objects around
-// those entities, pulling the Jaccard below this floor.
-const SINGLETON_MERGE_MIN_JACCARD = 0.25;
+// Jaccard floor for the SECONDARY merge rule (Jaccard in this range
+// still merges if distinctive + total shared meet thresholds). Below
+// this, no amount of entity overlap is enough — the surrounding
+// vocabulary has diverged too far for us to claim the stories cover
+// the same event. Catches the classic false positives where two
+// different events share two named entities but nothing else:
+//   - Two Lebanon incidents both mentioning "French" + "Lebanon"
+//   - Two Russia events both mentioning "Russia" + "attack"
+//   - Iran-talks vs oil-price-reaction both mentioning "Iran" +
+//     "nuclear" + "talks"
+// All of those have Jaccard between 0.14 and 0.24 — below 0.25
+// they won't merge regardless of distinctive-word overlap.
+const SECONDARY_MERGE_MIN_JACCARD = 0.25;
 
 /**
  * Count words that appear in BOTH sets where the word is distinctive
@@ -373,34 +370,36 @@ function deduplicateStories(stories) {
     const words = extractTitleWords(story.title);
     let merged = false;
     for (const cluster of clusters) {
+      // Unified merge rule. Jaccard is the honest signal —
+      // naturally penalises divergence via the union denominator.
+      // Distinctive-shared is NOT sufficient on its own because
+      // "distinctive" (length ≥5) is a weak proxy for named
+      // entities: "attack"/"nuclear"/"missile"/"talks"/"rally" all
+      // clear the length bar and are generic event vocabulary.
+      // Proper nouns like "Kyiv"/"Oman" don't even correlate with
+      // length. So every merge — singleton or established cluster
+      // — goes through the same gate:
+      //
+      //   PRIMARY: Jaccard ≥ 0.35 (covers near-duplicates)
+      //   SECONDARY: Jaccard ≥ 0.25 AND distinctive-shared ≥ 2
+      //     AND total-shared ≥ 2 (covers close misses with strong
+      //     entity overlap, e.g. "Iran says closed Strait of
+      //     Hormuz" variants that use mixed vocabulary)
+      //
+      // Distinctive-shared is measured against cluster.CORE (the
+      // intersection of all cluster items' words). Bridge-headline
+      // pollution in cluster.words (union) can't leak into core
+      // because core only contains words every item has. Total-
+      // shared is against union, just to confirm some real overlap
+      // exists beyond the distinctive entities alone.
       const jaccard = jaccardSimilarity(words, cluster.words);
-      let shouldMerge = false;
-      if (jaccard >= JACCARD_MERGE_THRESHOLD) {
-        // Primary: high lexical overlap always merges.
-        shouldMerge = true;
-      } else if (cluster.items.length >= 2) {
-        // Established cluster: 1 distinctive shared word with CORE
-        // is enough evidence (the cluster's repeated vocabulary IS
-        // the topic signal). Still require ≥2 total shared words
-        // with the UNION so e.g. "iran" alone can't pull in anything
-        // tangentially Iran-related.
+      let shouldMerge = jaccard >= JACCARD_MERGE_THRESHOLD;
+      if (!shouldMerge && jaccard >= SECONDARY_MERGE_MIN_JACCARD) {
         const distinct = countDistinctiveShared(words, cluster.core);
         const total = countShared(words, cluster.words);
         shouldMerge =
-          distinct >= CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_HAS_EVIDENCE &&
+          distinct >= CLUSTER_JOIN_MIN_DISTINCTIVE_SHARED &&
           total >= CLUSTER_JOIN_MIN_SHARED_WORDS;
-      } else {
-        // Singleton-to-singleton: no prior evidence of a topic yet,
-        // so require STRONGER signal — ≥2 distinctive shared words
-        // (NOT the bridge-polluted union; for size-1 cluster, core
-        // == seed words anyway) AND Jaccard ≥ the singleton floor.
-        // Two unrelated Lebanon stories sharing just {french,
-        // lebanon} hit the distinctive count (both ≥5 chars) but
-        // have low Jaccard → blocked by the floor.
-        const distinct = countDistinctiveShared(words, cluster.core);
-        shouldMerge =
-          distinct >= CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_BOTH_SINGLETON &&
-          jaccard >= SINGLETON_MERGE_MIN_JACCARD;
       }
       if (shouldMerge) {
         cluster.items.push(story);
@@ -433,19 +432,20 @@ function deduplicateStories(stories) {
     for (let j = i + 1; j < clusters.length; ) {
       const a = clusters[i];
       const b = clusters[j];
+      // Post-pass applies the SAME unified rule as the initial pass,
+      // just between two existing clusters: Jaccard on unions, with
+      // distinctive/total measured against CORE intersections (so
+      // bridge-injected vocabulary in either cluster's union cannot
+      // drive a false-positive merge).
+      const jaccardUnion = jaccardSimilarity(a.words, b.words);
       const distinctiveCore = countDistinctiveShared(a.core, b.core);
       const totalCore = countShared(a.core, b.core);
-      // Jaccard is computed on the UNION (cluster.words) — same
-      // penalty-for-divergence signal as the initial pass. Two
-      // singletons sharing {french, lebanon} hit the distinctive /
-      // total thresholds but their Jaccard stays low (few other
-      // words overlap) and the floor blocks them.
-      const jaccardUnion = jaccardSimilarity(a.words, b.words);
-      if (
-        distinctiveCore >= CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_BOTH_SINGLETON &&
-        totalCore >= CLUSTER_JOIN_MIN_SHARED_WORDS &&
-        jaccardUnion >= SINGLETON_MERGE_MIN_JACCARD
-      ) {
+      const postMerge =
+        jaccardUnion >= JACCARD_MERGE_THRESHOLD ||
+        (jaccardUnion >= SECONDARY_MERGE_MIN_JACCARD &&
+          distinctiveCore >= CLUSTER_JOIN_MIN_DISTINCTIVE_SHARED &&
+          totalCore >= CLUSTER_JOIN_MIN_SHARED_WORDS);
+      if (postMerge) {
         for (const item of b.items) a.items.push(item);
         for (const w of b.words) a.words.add(w);
         a.core = intersectSets(a.core, b.core);

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -297,103 +297,158 @@ const CLUSTER_JOIN_MIN_SHARED_WORDS = 2;
 const CLUSTER_JOIN_DISTINCTIVE_LEN = 5;
 // When merging into a cluster that already has ≥2 items, 1 distinctive
 // shared word is enough evidence (the cluster itself is the prior).
-// When the other side is a singleton, require ≥2 distinctive shared
-// words — without the cluster-as-prior, a single entity overlap like
-// "hormuz" or "airman" isn't strong enough: two unrelated Iran stories
-// can share "iran" + "airman" as a generic vocabulary coincidence.
-// Two DISTINCTIVE words pin the topic.
+// Singleton-to-singleton merges need stronger signal — a single entity
+// overlap like "hormuz" is not enough: two unrelated Iran-tagged
+// stories often share "iran" + another 4-char generic. Require ≥2
+// distinctive shared words AND Jaccard above a floor so two stories
+// sharing just {french, lebanon} (different Lebanon events) don't
+// collapse.
 const CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_BOTH_SINGLETON = 2;
 const CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_HAS_EVIDENCE = 1;
+// Jaccard floor applied in addition to distinctive-word count when both
+// sides are singletons. Prevents the classic false-positive of two
+// genuinely different events that happen to share two named entities
+// (e.g. two separate Lebanon incidents both mentioning "French" and
+// "Lebanon"). The events will have different verbs / objects around
+// those entities, pulling the Jaccard below this floor.
+const SINGLETON_MERGE_MIN_JACCARD = 0.25;
 
 /**
- * Does `words` share enough distinctive content with `clusterPool` to
- * be considered the same topic? The `minDistinctive` threshold reflects
- * how much independent evidence already exists:
- *   - 1 when the target cluster has ≥2 items (cluster IS the evidence)
- *   - 2 when both sides are singletons (need stronger signal)
+ * Count words that appear in BOTH sets where the word is distinctive
+ * (length ≥ CLUSTER_JOIN_DISTINCTIVE_LEN). Distinctive length is a
+ * proxy for "named entity / place / event name" rather than a generic
+ * short content word.
  *
- * Always requires ≥ CLUSTER_JOIN_MIN_SHARED_WORDS total shared words
- * as a basic floor.
- *
- * @param {Set<string>} words
- * @param {Set<string>} clusterPool
- * @param {number} minDistinctive
+ * @param {Set<string>} a
+ * @param {Set<string>} b
  */
-function sharesDistinctiveContent(words, clusterPool, minDistinctive) {
-  let shared = 0;
-  let distinctive = 0;
-  for (const w of words) {
-    if (clusterPool.has(w)) {
-      shared++;
-      if (w.length >= CLUSTER_JOIN_DISTINCTIVE_LEN) distinctive++;
-    }
+function countDistinctiveShared(a, b) {
+  let count = 0;
+  for (const w of a) {
+    if (w.length >= CLUSTER_JOIN_DISTINCTIVE_LEN && b.has(w)) count++;
   }
-  return shared >= CLUSTER_JOIN_MIN_SHARED_WORDS && distinctive >= minDistinctive;
+  return count;
 }
 
+/** Count words that appear in both sets, any length. */
+function countShared(a, b) {
+  let count = 0;
+  for (const w of a) if (b.has(w)) count++;
+  return count;
+}
+
+/** Intersection of two sets as a new Set. */
+function intersectSets(a, b) {
+  const out = new Set();
+  for (const w of a) if (b.has(w)) out.add(w);
+  return out;
+}
+
+/**
+ * Each cluster tracks TWO sets of words:
+ *
+ *  - `words` = UNION of all items' vocabulary. Used for Jaccard
+ *    because Jaccard's denominator (union) naturally penalises
+ *    cluster pollution — as bridge / mixed headlines get absorbed,
+ *    Jaccard to new unrelated candidates stays low.
+ *
+ *  - `core`  = INTERSECTION of all items' vocabulary (words present
+ *    in every item of the cluster). Used for distinctive-content
+ *    checks. Robust against bridge-headline pollution: a mixed
+ *    headline like "… Hormuz … French soldier killed in Lebanon"
+ *    injects french+lebanon into `words` (union) but they never land
+ *    in `core` because the other items in the Hormuz cluster don't
+ *    mention them. Post-pass and secondary merge therefore use core
+ *    and avoid the transitive false-positive the reviewer flagged on
+ *    PR #3195 (Hormuz cluster absorbing a separate Lebanon cluster
+ *    via bridge-injected vocabulary).
+ *
+ *  For a 1-item cluster, `core === words` (intersection of a single
+ *  set is the set itself), so the asymmetry only matters once a
+ *  cluster has grown.
+ */
 function deduplicateStories(stories) {
   const clusters = [];
   for (const story of stories) {
     const words = extractTitleWords(story.title);
     let merged = false;
     for (const cluster of clusters) {
-      // Primary: Jaccard overlap on the union of cluster words.
-      // Secondary (only for non-singleton clusters): distinctive
-      // content-word overlap. The asymmetry is deliberate — an
-      // isolated story joining a 1-item cluster still needs strong
-      // lexical overlap (Jaccard) because there's no independent
-      // evidence of a topic yet. A cluster of 2+ items IS the
-      // evidence, so a matching entity pair is enough to join.
       const jaccard = jaccardSimilarity(words, cluster.words);
-      const minDistinctive =
-        cluster.items.length >= 2
-          ? CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_HAS_EVIDENCE
-          : CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_BOTH_SINGLETON;
-      if (
-        jaccard >= JACCARD_MERGE_THRESHOLD ||
-        sharesDistinctiveContent(words, cluster.words, minDistinctive)
-      ) {
+      let shouldMerge = false;
+      if (jaccard >= JACCARD_MERGE_THRESHOLD) {
+        // Primary: high lexical overlap always merges.
+        shouldMerge = true;
+      } else if (cluster.items.length >= 2) {
+        // Established cluster: 1 distinctive shared word with CORE
+        // is enough evidence (the cluster's repeated vocabulary IS
+        // the topic signal). Still require ≥2 total shared words
+        // with the UNION so e.g. "iran" alone can't pull in anything
+        // tangentially Iran-related.
+        const distinct = countDistinctiveShared(words, cluster.core);
+        const total = countShared(words, cluster.words);
+        shouldMerge =
+          distinct >= CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_HAS_EVIDENCE &&
+          total >= CLUSTER_JOIN_MIN_SHARED_WORDS;
+      } else {
+        // Singleton-to-singleton: no prior evidence of a topic yet,
+        // so require STRONGER signal — ≥2 distinctive shared words
+        // (NOT the bridge-polluted union; for size-1 cluster, core
+        // == seed words anyway) AND Jaccard ≥ the singleton floor.
+        // Two unrelated Lebanon stories sharing just {french,
+        // lebanon} hit the distinctive count (both ≥5 chars) but
+        // have low Jaccard → blocked by the floor.
+        const distinct = countDistinctiveShared(words, cluster.core);
+        shouldMerge =
+          distinct >= CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_BOTH_SINGLETON &&
+          jaccard >= SINGLETON_MERGE_MIN_JACCARD;
+      }
+      if (shouldMerge) {
         cluster.items.push(story);
-        // CRITICAL: grow the cluster's word pool as it absorbs new
-        // stories. Previously `cluster.words` stayed frozen at the
-        // seed story's vocabulary, so later Jaccard comparisons
-        // always used the original headline rather than the
-        // accumulated topic signature. That hid obvious merges
-        // whenever a later story used vocabulary introduced by a
-        // sibling already in the cluster.
-        for (const w of words) cluster.words.add(w);
+        for (const w of words) cluster.words.add(w); // union grows
+        cluster.core = intersectSets(cluster.core, words); // core narrows
         merged = true;
         break;
       }
     }
-    if (!merged) clusters.push({ words: new Set(words), items: [story] });
+    if (!merged) {
+      // New cluster: seed core = words. Both are the same set object
+      // is fine — only reads happen in the inner loop. We copy via
+      // new Set so subsequent mutations stay independent.
+      clusters.push({
+        words: new Set(words),
+        core: new Set(words),
+        items: [story],
+      });
+    }
   }
-  // Post-pass: merge cluster-to-cluster when both have size ≥2 and
-  // share distinctive content. Protects against processing-order
-  // asymmetry where the highest-scored story of a topic happens to
-  // use unusual vocabulary and seeds a sibling cluster of
-  // near-duplicates, while the second-highest seeds the "main"
-  // cluster with typical vocabulary. Without this pass, both
-  // clusters would survive even though they cover the same event.
+  // Post-pass: catch processing-order misses (two clusters that
+  // cover the same event but neither seeded in a way that let the
+  // other join in the first pass). Uses CORE for the distinctive
+  // check — critical for avoiding bridge-pollution false positives.
+  // A mixed headline inside the Hormuz cluster adds french+lebanon
+  // to that cluster's UNION but never to its CORE (since sibling
+  // Hormuz stories don't mention Lebanon), so a separate Lebanon
+  // cluster no longer matches here.
   for (let i = 0; i < clusters.length; i++) {
     for (let j = i + 1; j < clusters.length; ) {
       const a = clusters[i];
       const b = clusters[j];
-      // Post-pass uses the stronger (singleton) threshold regardless
-      // of cluster sizes — we're looking for clusters that SHOULD
-      // have merged during the initial pass but didn't because of
-      // processing-order asymmetry. Requiring 2+ distinctive shared
-      // words avoids collapsing unrelated regional coverage that
-      // happens to share a single entity.
+      const distinctiveCore = countDistinctiveShared(a.core, b.core);
+      const totalCore = countShared(a.core, b.core);
+      // Jaccard is computed on the UNION (cluster.words) — same
+      // penalty-for-divergence signal as the initial pass. Two
+      // singletons sharing {french, lebanon} hit the distinctive /
+      // total thresholds but their Jaccard stays low (few other
+      // words overlap) and the floor blocks them.
+      const jaccardUnion = jaccardSimilarity(a.words, b.words);
       if (
-        sharesDistinctiveContent(
-          a.words,
-          b.words,
-          CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_BOTH_SINGLETON,
-        )
+        distinctiveCore >= CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_BOTH_SINGLETON &&
+        totalCore >= CLUSTER_JOIN_MIN_SHARED_WORDS &&
+        jaccardUnion >= SINGLETON_MERGE_MIN_JACCARD
       ) {
         for (const item of b.items) a.items.push(item);
         for (const w of b.words) a.words.add(w);
+        a.core = intersectSets(a.core, b.core);
         clusters.splice(j, 1);
       } else {
         j++;

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -232,6 +232,17 @@ const STOP_WORDS = new Set([
   'says','say','said','according','reports','report','officials','official',
   'us','new','will','can','could','would','may','also','who','that','this',
   'after','about','over','more','up','out','into','than','some','other',
+  // News framing / liveblog boilerplate — these appear in a huge
+  // fraction of wire headlines and were causing the Jaccard signal
+  // to drown in framing noise rather than converge on event words.
+  // Added after the 2026-04-19 Hormuz-cluster incident (6 stories
+  // about the same Strait closure ended up as 6 separate brief
+  // pages because shared headline vocabulary was dominated by
+  // "middle east crisis live" framing rather than the actual event
+  // nouns).
+  'live','crisis','update','updates','breaking','today','yesterday','latest',
+  'middle','east','west','north','south','news','briefing','watch',
+  'amid','and','if','but','or','so','when','while','still','now','then',
 ]);
 
 function stripSourceSuffix(title) {
@@ -257,19 +268,137 @@ function jaccardSimilarity(setA, setB) {
   return intersection / (setA.size + setB.size - intersection);
 }
 
+// Jaccard threshold for the primary merge signal. Lowered from 0.55
+// to 0.35 — 0.55 required near-identical headlines and missed wire
+// duplicates that phrase the same event slightly differently
+// ("closed" vs "closes", "strait of hormuz" vs "strait hormuz",
+// "again over US blockade" vs "and fires on ships"). 0.35 catches
+// those near-misses while still rejecting unrelated stories sharing
+// a single generic word.
+const JACCARD_MERGE_THRESHOLD = 0.35;
+
+// Secondary merge signal (kicks in only once a cluster already has
+// ≥2 items, so isolated stories still need strong Jaccard before
+// being absorbed — this prevents merging two unrelated one-off
+// stories that happen to share a single named entity).
+//
+// When the cluster has already grown, a new story joins it if it
+// shares at least this many content words with the cluster's pooled
+// word set AND at least one shared word is distinctively long
+// (≥ DISTINCTIVE_LEN chars — proxy for named entities like
+// "hormuz"/"lebanon"/"kyiv"/"trump" rather than generic short
+// content words like "iran"/"news"). This is what catches the
+// 2026-04-19 Hormuz cluster: stories phrased "Iran says Hormuz
+// closed", "Defiant message from Iran … cross Hormuz", "Tanker
+// attacked as Iran closes Hormuz" all share {iran, hormuz} (with
+// "hormuz" being the distinctive entity) and correctly collapse
+// into one event.
+const CLUSTER_JOIN_MIN_SHARED_WORDS = 2;
+const CLUSTER_JOIN_DISTINCTIVE_LEN = 5;
+// When merging into a cluster that already has ≥2 items, 1 distinctive
+// shared word is enough evidence (the cluster itself is the prior).
+// When the other side is a singleton, require ≥2 distinctive shared
+// words — without the cluster-as-prior, a single entity overlap like
+// "hormuz" or "airman" isn't strong enough: two unrelated Iran stories
+// can share "iran" + "airman" as a generic vocabulary coincidence.
+// Two DISTINCTIVE words pin the topic.
+const CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_BOTH_SINGLETON = 2;
+const CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_HAS_EVIDENCE = 1;
+
+/**
+ * Does `words` share enough distinctive content with `clusterPool` to
+ * be considered the same topic? The `minDistinctive` threshold reflects
+ * how much independent evidence already exists:
+ *   - 1 when the target cluster has ≥2 items (cluster IS the evidence)
+ *   - 2 when both sides are singletons (need stronger signal)
+ *
+ * Always requires ≥ CLUSTER_JOIN_MIN_SHARED_WORDS total shared words
+ * as a basic floor.
+ *
+ * @param {Set<string>} words
+ * @param {Set<string>} clusterPool
+ * @param {number} minDistinctive
+ */
+function sharesDistinctiveContent(words, clusterPool, minDistinctive) {
+  let shared = 0;
+  let distinctive = 0;
+  for (const w of words) {
+    if (clusterPool.has(w)) {
+      shared++;
+      if (w.length >= CLUSTER_JOIN_DISTINCTIVE_LEN) distinctive++;
+    }
+  }
+  return shared >= CLUSTER_JOIN_MIN_SHARED_WORDS && distinctive >= minDistinctive;
+}
+
 function deduplicateStories(stories) {
   const clusters = [];
   for (const story of stories) {
     const words = extractTitleWords(story.title);
     let merged = false;
     for (const cluster of clusters) {
-      if (jaccardSimilarity(words, cluster.words) > 0.55) {
+      // Primary: Jaccard overlap on the union of cluster words.
+      // Secondary (only for non-singleton clusters): distinctive
+      // content-word overlap. The asymmetry is deliberate — an
+      // isolated story joining a 1-item cluster still needs strong
+      // lexical overlap (Jaccard) because there's no independent
+      // evidence of a topic yet. A cluster of 2+ items IS the
+      // evidence, so a matching entity pair is enough to join.
+      const jaccard = jaccardSimilarity(words, cluster.words);
+      const minDistinctive =
+        cluster.items.length >= 2
+          ? CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_HAS_EVIDENCE
+          : CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_BOTH_SINGLETON;
+      if (
+        jaccard >= JACCARD_MERGE_THRESHOLD ||
+        sharesDistinctiveContent(words, cluster.words, minDistinctive)
+      ) {
         cluster.items.push(story);
+        // CRITICAL: grow the cluster's word pool as it absorbs new
+        // stories. Previously `cluster.words` stayed frozen at the
+        // seed story's vocabulary, so later Jaccard comparisons
+        // always used the original headline rather than the
+        // accumulated topic signature. That hid obvious merges
+        // whenever a later story used vocabulary introduced by a
+        // sibling already in the cluster.
+        for (const w of words) cluster.words.add(w);
         merged = true;
         break;
       }
     }
-    if (!merged) clusters.push({ words, items: [story] });
+    if (!merged) clusters.push({ words: new Set(words), items: [story] });
+  }
+  // Post-pass: merge cluster-to-cluster when both have size ≥2 and
+  // share distinctive content. Protects against processing-order
+  // asymmetry where the highest-scored story of a topic happens to
+  // use unusual vocabulary and seeds a sibling cluster of
+  // near-duplicates, while the second-highest seeds the "main"
+  // cluster with typical vocabulary. Without this pass, both
+  // clusters would survive even though they cover the same event.
+  for (let i = 0; i < clusters.length; i++) {
+    for (let j = i + 1; j < clusters.length; ) {
+      const a = clusters[i];
+      const b = clusters[j];
+      // Post-pass uses the stronger (singleton) threshold regardless
+      // of cluster sizes — we're looking for clusters that SHOULD
+      // have merged during the initial pass but didn't because of
+      // processing-order asymmetry. Requiring 2+ distinctive shared
+      // words avoids collapsing unrelated regional coverage that
+      // happens to share a single entity.
+      if (
+        sharesDistinctiveContent(
+          a.words,
+          b.words,
+          CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_BOTH_SINGLETON,
+        )
+      ) {
+        for (const item of b.items) a.items.push(item);
+        for (const w of b.words) a.words.add(w);
+        clusters.splice(j, 1);
+      } else {
+        j++;
+      }
+    }
   }
   return clusters.map(({ items }) => {
     items.sort((a, b) => b.currentScore - a.currentScore || b.mentionCount - a.mentionCount);

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -320,6 +320,16 @@ const CLUSTER_JOIN_DISTINCTIVE_LEN = 5;
 //     "nuclear" + "talks"
 // All of those have Jaccard between 0.14 and 0.24 — below 0.25
 // they won't merge regardless of distinctive-word overlap.
+//
+// IMPORTANT: the secondary rule compares with STRICT inequality
+// (jaccard > SECONDARY_MERGE_MIN_JACCARD), not ≥. A short
+// downstream-reaction headline like "Oil prices rise on Iran
+// nuclear talks optimism" vs an Iran-talks cluster can land
+// EXACTLY on 0.25 (3 shared words in a 12-word union), and with
+// ≥ it would scrape through merge despite being a different
+// event. Strict > excludes that boundary case without moving
+// the constant — which would risk breaking legitimate close-
+// miss Hormuz merges (P10 joining at J=0.267, P02↔P08 at 0.308).
 const SECONDARY_MERGE_MIN_JACCARD = 0.25;
 
 /**
@@ -406,7 +416,7 @@ function deduplicateStories(stories) {
       // exists beyond the distinctive entities alone.
       const jaccard = jaccardSimilarity(words, cluster.words);
       let shouldMerge = jaccard >= JACCARD_MERGE_THRESHOLD;
-      if (!shouldMerge && jaccard >= SECONDARY_MERGE_MIN_JACCARD) {
+      if (!shouldMerge && jaccard > SECONDARY_MERGE_MIN_JACCARD) {
         const distinct = countDistinctiveShared(words, cluster.core);
         const total = countShared(words, cluster.words);
         shouldMerge =
@@ -454,7 +464,7 @@ function deduplicateStories(stories) {
       const totalCore = countShared(a.core, b.core);
       const postMerge =
         jaccardUnion >= JACCARD_MERGE_THRESHOLD ||
-        (jaccardUnion >= SECONDARY_MERGE_MIN_JACCARD &&
+        (jaccardUnion > SECONDARY_MERGE_MIN_JACCARD &&
           distinctiveCore >= CLUSTER_JOIN_MIN_DISTINCTIVE_SHARED &&
           totalCore >= CLUSTER_JOIN_MIN_SHARED_WORDS);
       if (postMerge) {

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -268,31 +268,43 @@ function jaccardSimilarity(setA, setB) {
   return intersection / (setA.size + setB.size - intersection);
 }
 
-// Jaccard threshold for the primary merge signal. Lowered from 0.55
-// to 0.35 — 0.55 required near-identical headlines and missed wire
+// Jaccard threshold for the PRIMARY merge signal. 0.35 catches wire
 // duplicates that phrase the same event slightly differently
-// ("closed" vs "closes", "strait of hormuz" vs "strait hormuz",
-// "again over US blockade" vs "and fires on ships"). 0.35 catches
-// those near-misses while still rejecting unrelated stories sharing
-// a single generic word.
+// ("closed" vs "closes", "strait of hormuz" vs "strait hormuz") but
+// rejects unrelated stories sharing a single generic word.
+//
+// NOTE for future tuners: in practice this threshold is ONLY reached
+// by singleton-to-singleton comparisons and very-close pairs joining
+// a small cluster. Once a cluster absorbs 3+ stories its word UNION
+// expands to 15–30+ terms; a new 7-word candidate sharing 2 words
+// gets Jaccard ≈ 2/(7+25-2) = 0.067 — nowhere near 0.35 regardless of
+// how related it is. Multi-story cluster merges therefore flow
+// through the SECONDARY rule below. That's intentional: the
+// secondary rule checks distinctive overlap against cluster.CORE
+// (intersection of all items), which narrows sharply as the cluster
+// grows and is the right signal for "does this new story belong to
+// the topic this cluster has converged on?". If you're tempted to
+// raise JACCARD_MERGE_THRESHOLD because "it seems loose", remember
+// it barely affects established clusters — tune the secondary
+// floor (SECONDARY_MERGE_MIN_JACCARD) and
+// CLUSTER_JOIN_MIN_DISTINCTIVE_SHARED instead.
 const JACCARD_MERGE_THRESHOLD = 0.35;
 
-// Secondary merge signal (kicks in only once a cluster already has
-// ≥2 items, so isolated stories still need strong Jaccard before
-// being absorbed — this prevents merging two unrelated one-off
-// stories that happen to share a single named entity).
+// Secondary merge signal: catches close-Jaccard-miss candidates that
+// nonetheless share strong distinctive-entity overlap with a
+// cluster's core (intersection of all items). Threshold values below
+// are the triple gate applied in deduplicateStories:
+//   - Jaccard ≥ SECONDARY_MERGE_MIN_JACCARD (defined further down)
+//   - countDistinctiveShared(story, cluster.core) ≥ MIN_DISTINCTIVE_SHARED
+//   - countShared(story, cluster.words) ≥ MIN_SHARED_WORDS
 //
-// When the cluster has already grown, a new story joins it if it
-// shares at least this many content words with the cluster's pooled
-// word set AND at least one shared word is distinctively long
-// (≥ DISTINCTIVE_LEN chars — proxy for named entities like
-// "hormuz"/"lebanon"/"kyiv"/"trump" rather than generic short
-// content words like "iran"/"news"). This is what catches the
-// 2026-04-19 Hormuz cluster: stories phrased "Iran says Hormuz
-// closed", "Defiant message from Iran … cross Hormuz", "Tanker
-// attacked as Iran closes Hormuz" all share {iran, hormuz} (with
-// "hormuz" being the distinctive entity) and correctly collapse
-// into one event.
+// "Distinctive" is a length ≥ DISTINCTIVE_LEN proxy for named
+// entities. It's imperfect — generic event vocabulary like
+// "attack"/"missile"/"talks" also clears the bar — which is why the
+// Jaccard floor is required as a second independent signal. Two
+// unrelated events sharing only "attack"+"missile" would hit the
+// distinctive count but their surrounding vocabulary diverges enough
+// to push Jaccard below the floor.
 const CLUSTER_JOIN_MIN_SHARED_WORDS = 2;
 const CLUSTER_JOIN_MIN_DISTINCTIVE_SHARED = 2;
 const CLUSTER_JOIN_DISTINCTIVE_LEN = 5;

--- a/tests/digest-dedup.test.mjs
+++ b/tests/digest-dedup.test.mjs
@@ -57,7 +57,36 @@ new Function('mod', `
   mod.countShared = countShared;
   mod.intersectSets = intersectSets;
   mod.deduplicateStories = deduplicateStories;
+  // Post-eval: expose every tuning constant the implementation
+  // references so the extractor regex can't silently drop a newly-
+  // added constant. If a future author adds e.g.
+  // CLUSTER_JOIN_MIN_EVIDENCE_SCALE below the current last constant
+  // and forgets to update the regex, this line throws a loud
+  // ReferenceError at test bootstrap — much easier to diagnose than
+  // deduplicateStories itself throwing from the eval body.
+  mod.__constants = {
+    JACCARD_MERGE_THRESHOLD,
+    SECONDARY_MERGE_MIN_JACCARD,
+    CLUSTER_JOIN_MIN_SHARED_WORDS,
+    CLUSTER_JOIN_MIN_DISTINCTIVE_SHARED,
+    CLUSTER_JOIN_DISTINCTIVE_LEN,
+  };
 `)(mod);
+
+// Guard: every tuning constant the dedup rule reads must be reachable
+// from the test-extractor's regex. A mismatch means the regex silently
+// stopped short of capturing a new constant — the eval above would
+// still succeed (function hoisting), but `deduplicateStories` would
+// throw ReferenceError the first time the test invokes it. This
+// assertion surfaces the break at bootstrap instead.
+assert.ok(mod.__constants, 'threshold constants must be exposed on mod');
+for (const [name, value] of Object.entries(mod.__constants)) {
+  assert.equal(
+    typeof value,
+    'number',
+    `constant ${name} must be captured by thresholdConsts regex and injected as a number`,
+  );
+}
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -390,5 +419,44 @@ describe('deduplicateStories — P1 false-positive regressions (from PR #3195 re
     );
     const sizes = result.map((r) => r.mergedHashes.length).sort((a, b) => b - a);
     assert.deepEqual(sizes, [2, 1], 'larger cluster has both talks stories');
+  });
+
+  // REGRESSION (directional-word stop-words concern): north/south/
+  // east/west were added to STOP_WORDS to strip news-framing
+  // boilerplate ("Middle East crisis live"). That also strips them
+  // from "South Sudan" / "South Korea" / "North Korea" / etc. —
+  // lowering the differentiating signal between stories that share
+  // a geographic direction. In practice the attached proper noun
+  // (sudan/korea/etc.) still differentiates, but this test locks
+  // that assumption: two unrelated "South ___" stories stay
+  // separate.
+  it('South Sudan famine and South Korea election stay separate despite stripped "south"', () => {
+    const stories = [
+      story('South Sudan famine worsens as refugees flood border', 90, 'ss1'),
+      story('South Korea election results surprise observers', 85, 'sk1'),
+    ];
+    const result = mod.deduplicateStories(stories);
+    assert.equal(
+      result.length,
+      2,
+      `expected 2 clusters (sudan vs korea differentiate even without "south"), got ${result.length}: ${result.map((r) => r.title).join(' | ')}`,
+    );
+  });
+
+  // Positive counterpart: two stories about the SAME South Sudan
+  // event must still merge, proving the "south" stop-word doesn't
+  // also damage legitimate clustering. Shared {sudan, famine} +
+  // high Jaccard.
+  it('two South Sudan famine stories still merge into one cluster', () => {
+    const stories = [
+      story('South Sudan famine worsens as refugees flood border', 90, 'ss1'),
+      story('South Sudan famine deepens amid civil war and border collapse', 85, 'ss2'),
+    ];
+    const result = mod.deduplicateStories(stories);
+    assert.equal(
+      result.length,
+      1,
+      `expected 1 cluster for the same South Sudan event, got ${result.length}: ${result.map((r) => r.title).join(' | ')}`,
+    );
   });
 });

--- a/tests/digest-dedup.test.mjs
+++ b/tests/digest-dedup.test.mjs
@@ -20,19 +20,23 @@ const src = readFileSync(
 // We extract the pure functions (no side-effects, no imports) to test them.
 
 const STOP_WORDS_BLOCK = src.match(/const STOP_WORDS = new Set\(\[[\s\S]*?\]\);/)?.[0];
-const thresholdConsts = src.match(/const JACCARD_MERGE_THRESHOLD[\s\S]*?const CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_HAS_EVIDENCE\s*=\s*\d+;/)?.[0];
+const thresholdConsts = src.match(/const JACCARD_MERGE_THRESHOLD[\s\S]*?const SINGLETON_MERGE_MIN_JACCARD\s*=\s*[0-9.]+;/)?.[0];
 const stripSourceSuffix = src.match(/function stripSourceSuffix\(title\) \{[\s\S]*?\n\}/)?.[0];
 const extractTitleWords = src.match(/function extractTitleWords\(title\) \{[\s\S]*?\n\}/)?.[0];
 const jaccardSimilarity = src.match(/function jaccardSimilarity\(setA, setB\) \{[\s\S]*?\n\}/)?.[0];
-const sharesDistinctiveContent = src.match(/function sharesDistinctiveContent\([^)]+\) \{[\s\S]*?\n\}/)?.[0];
-const deduplicateStories = src.match(/function deduplicateStories\(stories\) \{[\s\S]*?\n\}/)?.[0];
+const countDistinctiveShared = src.match(/function countDistinctiveShared\([^)]+\) \{[\s\S]*?\n\}/)?.[0];
+const countShared = src.match(/function countShared\([^)]+\) \{[\s\S]*?\n\}/)?.[0];
+const intersectSets = src.match(/function intersectSets\([^)]+\) \{[\s\S]*?\n\}/)?.[0];
+const deduplicateStories = src.match(/function deduplicateStories\(stories\) \{[\s\S]*?^\}/m)?.[0];
 
 assert.ok(STOP_WORDS_BLOCK, 'STOP_WORDS not found in source');
 assert.ok(thresholdConsts, 'merge threshold constants not found in source');
 assert.ok(stripSourceSuffix, 'stripSourceSuffix not found in source');
 assert.ok(extractTitleWords, 'extractTitleWords not found in source');
 assert.ok(jaccardSimilarity, 'jaccardSimilarity not found in source');
-assert.ok(sharesDistinctiveContent, 'sharesDistinctiveContent not found in source');
+assert.ok(countDistinctiveShared, 'countDistinctiveShared not found in source');
+assert.ok(countShared, 'countShared not found in source');
+assert.ok(intersectSets, 'intersectSets not found in source');
 assert.ok(deduplicateStories, 'deduplicateStories not found in source');
 
 const mod = {};
@@ -42,12 +46,16 @@ new Function('mod', `
   ${stripSourceSuffix}
   ${extractTitleWords}
   ${jaccardSimilarity}
-  ${sharesDistinctiveContent}
+  ${countDistinctiveShared}
+  ${countShared}
+  ${intersectSets}
   ${deduplicateStories}
   mod.stripSourceSuffix = stripSourceSuffix;
   mod.extractTitleWords = extractTitleWords;
   mod.jaccardSimilarity = jaccardSimilarity;
-  mod.sharesDistinctiveContent = sharesDistinctiveContent;
+  mod.countDistinctiveShared = countDistinctiveShared;
+  mod.countShared = countShared;
+  mod.intersectSets = intersectSets;
   mod.deduplicateStories = deduplicateStories;
 `)(mod);
 
@@ -222,42 +230,105 @@ describe('deduplicateStories', () => {
   // different-angle coverage of the same incident.
 });
 
-describe('sharesDistinctiveContent (new secondary merge signal)', () => {
-  // The third arg is the "min distinctive shared" threshold.
-  // Call sites pass 1 for has-evidence clusters, 2 for singletons /
-  // post-pass.
-  it('requires ≥2 total shared words regardless of threshold', () => {
+describe('countDistinctiveShared / countShared (merge-rule primitives)', () => {
+  it('countShared counts words present in both sets regardless of length', () => {
     const a = new Set(['iran', 'hormuz', 'blockade']);
-    const b = new Set(['iran', 'nuclear', 'enrichment']);
-    assert.equal(mod.sharesDistinctiveContent(a, b, 1), false, 'only 1 shared word is not enough');
+    const b = new Set(['iran', 'gaza', 'attack']);
+    assert.equal(mod.countShared(a, b), 1);
   });
 
-  it('min=1 merges when 2+ shared AND ≥1 is length ≥5', () => {
-    const a = new Set(['iran', 'hormuz', 'closed']);
-    const b = new Set(['iran', 'hormuz', 'tanker', 'attack']);
-    assert.equal(mod.sharesDistinctiveContent(a, b, 1), true);
-  });
-
-  it('min=1 rejects when both shared words are short (<5 chars)', () => {
-    const a = new Set(['iran', 'gaza', 'attack']);
+  it('countDistinctiveShared counts ONLY shared words of length ≥5', () => {
+    // iran(4) + gaza(4) are shared but short. blockade is not shared.
+    const a = new Set(['iran', 'gaza', 'blockade']);
     const b = new Set(['iran', 'gaza', 'relief']);
-    assert.equal(mod.sharesDistinctiveContent(a, b, 1), false);
+    assert.equal(mod.countDistinctiveShared(a, b), 0, 'both shared words are short');
+    const c = new Set(['iran', 'hormuz', 'strait']);
+    const d = new Set(['iran', 'hormuz', 'tanker']);
+    assert.equal(mod.countDistinctiveShared(c, d), 1, 'only hormuz(6) is distinctive');
   });
 
-  it('min=2 rejects when only one distinctive word is shared (singleton guard)', () => {
-    // {iran, airman} — airman is 6 chars (distinctive), iran is 4.
-    // Under the singleton rule (need ≥2 distinctive), this fails —
-    // prevents unrelated Iran stories from collapsing just because
-    // both happen to mention "airman" once.
-    const a = new Set(['iran', 'airman', 'rescues']);
-    const b = new Set(['iran', 'airman', 'missing']);
-    assert.equal(mod.sharesDistinctiveContent(a, b, 2), false);
+  it('intersectSets returns only words present in both', () => {
+    const a = new Set(['a', 'b', 'c', 'd']);
+    const b = new Set(['c', 'd', 'e', 'f']);
+    const out = mod.intersectSets(a, b);
+    assert.deepEqual([...out].sort(), ['c', 'd']);
+  });
+});
+
+describe('deduplicateStories — P1 false-positive regressions (from PR #3195 review)', () => {
+  function story(title, score = 10, hash = undefined) {
+    return {
+      title,
+      currentScore: score,
+      mentionCount: 1,
+      sources: [],
+      severity: 'critical',
+      hash: hash ?? title.slice(0, 8),
+    };
+  }
+
+  // REGRESSION P1-1: two genuinely different Lebanon-French events
+  // must NOT collapse just because they share {french, lebanon} —
+  // both 5+ chars, but the events differ. The added Jaccard floor
+  // for singleton-to-singleton merge rejects this pair.
+  it('distinct Lebanon stories sharing only {french, lebanon} stay separate', () => {
+    const stories = [
+      story('French soldier killed in Lebanon after border fire', 90, 'leb1'),
+      story('French envoy arrives in Lebanon for emergency talks', 85, 'leb2'),
+    ];
+    const result = mod.deduplicateStories(stories);
+    assert.equal(
+      result.length,
+      2,
+      `expected 2 clusters, got ${result.length}: ${result.map((r) => r.title).join(' | ')}`,
+    );
   });
 
-  it('min=2 accepts when 2+ distinctive words are shared', () => {
-    // strait + hormuz + tanker all distinctive ≥5
-    const a = new Set(['iran', 'strait', 'hormuz', 'tanker']);
-    const b = new Set(['iran', 'strait', 'hormuz', 'blockade']);
-    assert.equal(mod.sharesDistinctiveContent(a, b, 2), true);
+  // REGRESSION P1-2: a bridge headline that merges into the Hormuz
+  // cluster must NOT pollute the cluster's distinctive-content
+  // signature. A separate Lebanon cluster must stay separate —
+  // previously the post-pass absorbed it via bridge-injected
+  // french/lebanon words in the UNION.
+  it('bridge headline does not let Hormuz cluster absorb a Lebanon cluster (core vs union)', () => {
+    const stories = [
+      // Two pure Hormuz stories so the cluster has ≥2 items.
+      story('Iran closes Strait of Hormuz again over US blockade', 95, 'h1'),
+      story('Iran says it has closed Strait of Hormuz again over US blockade', 90, 'h2'),
+      // Bridge headline — legitimately joins the Hormuz cluster but
+      // also mentions a Lebanon sub-topic.
+      story('Tanker attacked as Iran closes strait of Hormuz; French soldier killed in Lebanon', 85, 'bridge'),
+      // Pure Lebanon story — must stay separate despite the bridge
+      // injecting "french" and "lebanon" into the Hormuz UNION.
+      story('French envoy arrives in Lebanon for emergency talks', 70, 'leb'),
+    ];
+    const result = mod.deduplicateStories(stories);
+    // Expect 2 clusters: Hormuz (+ bridge) and Lebanon.
+    assert.equal(
+      result.length,
+      2,
+      `expected 2 clusters, got ${result.length}: ${result.map((r) => r.title).join(' | ')}`,
+    );
+    // The Lebanon story must survive as its own cluster — not
+    // absorbed into the Hormuz cluster.
+    const lebanonCluster = result.find((r) => r.title.includes('envoy'));
+    assert.ok(lebanonCluster, 'Lebanon cluster must still exist after post-pass');
+  });
+
+  // REGRESSION P1-2 (reverse-order): three-story reproducer the
+  // reviewer cited — Hormuz + Lebanon + mixed. The mixed headline
+  // is a legitimate bridge and joins one side; the OTHER side must
+  // stay separate. Previous buggy head collapsed all three into 1.
+  it('three stories Hormuz + Lebanon + mixed resolve to 2 clusters, not 1', () => {
+    const stories = [
+      story('Iran closes Strait of Hormuz again over US blockade', 90, 'h'),
+      story('French soldier killed in Lebanon after border fire', 85, 'leb'),
+      story('Tanker attacked as Iran closes strait of Hormuz; French soldier killed in Lebanon', 80, 'mixed'),
+    ];
+    const result = mod.deduplicateStories(stories);
+    assert.equal(
+      result.length,
+      2,
+      `expected 2 clusters (NOT the buggy 1), got ${result.length}: ${result.map((r) => r.title).join(' | ')}`,
+    );
   });
 });

--- a/tests/digest-dedup.test.mjs
+++ b/tests/digest-dedup.test.mjs
@@ -20,7 +20,7 @@ const src = readFileSync(
 // We extract the pure functions (no side-effects, no imports) to test them.
 
 const STOP_WORDS_BLOCK = src.match(/const STOP_WORDS = new Set\(\[[\s\S]*?\]\);/)?.[0];
-const thresholdConsts = src.match(/const JACCARD_MERGE_THRESHOLD[\s\S]*?const SINGLETON_MERGE_MIN_JACCARD\s*=\s*[0-9.]+;/)?.[0];
+const thresholdConsts = src.match(/const JACCARD_MERGE_THRESHOLD[\s\S]*?const SECONDARY_MERGE_MIN_JACCARD\s*=\s*[0-9.]+;/)?.[0];
 const stripSourceSuffix = src.match(/function stripSourceSuffix\(title\) \{[\s\S]*?\n\}/)?.[0];
 const extractTitleWords = src.match(/function extractTitleWords\(title\) \{[\s\S]*?\n\}/)?.[0];
 const jaccardSimilarity = src.match(/function jaccardSimilarity\(setA, setB\) \{[\s\S]*?\n\}/)?.[0];
@@ -168,13 +168,17 @@ describe('deduplicateStories', () => {
   });
 
   // REGRESSION (2026-04-19): a real brief surfaced 6 separate stories
-  // about the Strait-of-Hormuz closure with wildly different phrasing
-  // (one said "closed", another "defiant message ... cross Hormuz",
-  // another framed as "Middle East crisis live"). At Jaccard ≥ 0.55
-  // with frozen cluster words, all 6 passed through as distinct.
-  // With the new rules (threshold 0.35 + distinctive-content second
-  // pass + growing cluster pool) they collapse to a single cluster.
-  it('merges 6 wire variants of the same Hormuz closure event into one cluster', () => {
+  // about the Strait-of-Hormuz closure with wildly different phrasing.
+  // At the original Jaccard ≥ 0.55 with frozen cluster words, all 6
+  // passed through as distinct. The new rules collapse the high-
+  // overlap variants into one cluster. One outlier (the "Defiant
+  // message from Iran as vessels attempting to cross Hormuz"
+  // headline) has Jaccard 0.13 with the rest and only shares
+  // {iran, hormuz} — we intentionally leave that outlier as its own
+  // cluster rather than relax the rule further, because relaxing
+  // would over-merge genuinely distinct events (see the Russia/
+  // Odesa and Iran/oil-price regressions below).
+  it('collapses at least 5 of 6 Hormuz wire variants into one cluster', () => {
     const stories = [
       story('Iran says it has closed Strait of Hormuz again over US blockade', 95, 1, 'h02'),
       story('Iran closes Strait of Hormuz again over US blockade and fires on ships', 90, 1, 'h05'),
@@ -184,21 +188,26 @@ describe('deduplicateStories', () => {
       story('Middle East crisis live: tanker reports attack as Iran closes strait of Hormuz; French soldier killed in Lebanon', 70, 1, 'h11'),
     ];
     const result = mod.deduplicateStories(stories);
-    assert.equal(result.length, 1, `expected 1 Hormuz cluster, got ${result.length}: ${result.map((r) => r.title).join(' | ')}`);
-    // All six hashes carried through so source-lookup still works.
-    assert.equal(result[0].mergedHashes.length, 6);
-    // The highest-scored variant wins as the display title.
-    assert.ok(result[0].title.includes('Iran says it has closed Strait'));
-    // Mention-count is the sum across the cluster.
-    assert.equal(result[0].mentionCount, 6);
+    const largestClusterSize = Math.max(...result.map((r) => r.mergedHashes.length));
+    assert.ok(
+      largestClusterSize >= 5,
+      `expected main Hormuz cluster to absorb ≥5 of 6 variants, got max size ${largestClusterSize}. Clusters: ${result.map((r) => `${r.mergedHashes.length}:${r.title.slice(0, 40)}`).join(' | ')}`,
+    );
+    // At most 2 clusters survive — the main one plus (possibly) the
+    // low-overlap "defiant message" outlier.
+    assert.ok(
+      result.length <= 2,
+      `expected ≤2 clusters, got ${result.length}`,
+    );
   });
 
-  // Asymmetry check: the 6-Hormuz merge must survive any processing
-  // order. The greedy clusterer could in principle pick a "sibling"
-  // first story whose low Jaccard with the dominant variant seeds
-  // two clusters instead of one; the post-pass cluster-cluster
-  // merge is what guards against that.
-  it('Hormuz merge survives reversed processing order (score equalised)', () => {
+  // Asymmetry check: low-overlap Hormuz variants must still cluster
+  // usefully under reverse processing order. We assert that the
+  // majority of the 6 stories end up in the SAME cluster, not that
+  // all 6 do (the low-vocab-overlap outlier may still float free
+  // depending on order — acceptable given the false-positive
+  // trade-off).
+  it('Hormuz merge under reverse processing order still collapses a majority into one cluster', () => {
     const titles = [
       'Middle East crisis live: tanker reports attack as Iran closes strait of Hormuz; French soldier killed in Lebanon',
       'Middle East crisis live: Iran says it has closed the strait of Hormuz; tanker reports being attacked',
@@ -209,7 +218,11 @@ describe('deduplicateStories', () => {
     ];
     const stories = titles.map((t, i) => story(t, 70 - i, 1, `r${i}`));
     const result = mod.deduplicateStories(stories);
-    assert.equal(result.length, 1, `expected 1 cluster under reverse order, got ${result.length}: ${result.map((r) => r.title).join(' | ')}`);
+    const largestClusterSize = Math.max(...result.map((r) => r.mergedHashes.length));
+    assert.ok(
+      largestClusterSize >= 4,
+      `expected majority of 6 Hormuz stories in one cluster under reverse order, got max size ${largestClusterSize}`,
+    );
   });
 
   // FALSE-POSITIVE GUARD: a single shared entity ("Iran") must NOT
@@ -330,5 +343,52 @@ describe('deduplicateStories — P1 false-positive regressions (from PR #3195 re
       2,
       `expected 2 clusters (NOT the buggy 1), got ${result.length}: ${result.map((r) => r.title).join(' | ')}`,
     );
+  });
+
+  // REGRESSION (second round of P1 review): three Russia-Kyiv-Odesa
+  // stories where the first two ARE the same attack and the third
+  // is a separate event. Previous rule ("established cluster merges
+  // on 1 distinctive + 2 total shared") collapsed all three via
+  // {russia, attack} — both length ≥5 but generic event vocabulary.
+  // The new rule applies a Jaccard floor of 0.25, and the Odesa
+  // story's Jaccard against the Russia-Kyiv cluster (0.143) is
+  // below the floor → stays separate.
+  it('Russia Kyiv missile attacks stay separate from Russia Odesa grain attack (generic "attack" not enough)', () => {
+    const stories = [
+      story('Russia missile attack hits Kyiv apartment block', 95, 'rk1'),
+      story('Russia missile attack kills civilians in Kyiv', 90, 'rk2'),
+      story('Russia attack disrupts grain exports from Odesa port', 85, 'ro1'),
+    ];
+    const result = mod.deduplicateStories(stories);
+    assert.equal(
+      result.length,
+      2,
+      `expected 2 clusters (the two Kyiv stories merge, Odesa stays separate), got ${result.length}: ${result.map((r) => r.title).join(' | ')}`,
+    );
+    // The larger cluster is the Kyiv one.
+    const sizes = result.map((r) => r.mergedHashes.length).sort((a, b) => b - a);
+    assert.deepEqual(sizes, [2, 1], 'larger cluster has both Kyiv stories');
+  });
+
+  // REGRESSION (second round): Iran-nuclear-talks coverage vs an
+  // oil-price reaction story sharing {iran, nuclear, talks}. All
+  // three words clear the 5-char "distinctive" bar but they're
+  // generic diplomatic-event vocabulary. Secondary merge requires
+  // Jaccard ≥ 0.25 — the oil-price story's Jaccard against the
+  // talks cluster is 0.231, just below the floor.
+  it('Iran nuclear talks coverage does not absorb an oil-price-reaction story sharing {iran, nuclear, talks}', () => {
+    const stories = [
+      story('US Iran nuclear talks resume in Oman', 95, 'nt1'),
+      story('US Iran nuclear talks enter second day in Oman', 90, 'nt2'),
+      story('Oil price rally accelerates on Iran nuclear talks optimism', 85, 'op1'),
+    ];
+    const result = mod.deduplicateStories(stories);
+    assert.equal(
+      result.length,
+      2,
+      `expected 2 clusters (two talks stories merge, oil-price stays separate), got ${result.length}: ${result.map((r) => r.title).join(' | ')}`,
+    );
+    const sizes = result.map((r) => r.mergedHashes.length).sort((a, b) => b - a);
+    assert.deepEqual(sizes, [2, 1], 'larger cluster has both talks stories');
   });
 });

--- a/tests/digest-dedup.test.mjs
+++ b/tests/digest-dedup.test.mjs
@@ -200,14 +200,25 @@ describe('deduplicateStories', () => {
   // about the Strait-of-Hormuz closure with wildly different phrasing.
   // At the original Jaccard ≥ 0.55 with frozen cluster words, all 6
   // passed through as distinct. The new rules collapse the high-
-  // overlap variants into one cluster. One outlier (the "Defiant
-  // message from Iran as vessels attempting to cross Hormuz"
-  // headline) has Jaccard 0.13 with the rest and only shares
-  // {iran, hormuz} — we intentionally leave that outlier as its own
-  // cluster rather than relax the rule further, because relaxing
-  // would over-merge genuinely distinct events (see the Russia/
-  // Odesa and Iran/oil-price regressions below).
-  it('collapses at least 5 of 6 Hormuz wire variants into one cluster', () => {
+  // overlap core variants into one cluster. Two outliers intentionally
+  // stay separate:
+  //
+  //   - "Defiant message from Iran as vessels attempting to cross
+  //     Hormuz report gunfire" — shares only {iran, hormuz} (J≈0.13)
+  //     with the rest; below the Jaccard floor.
+  //
+  //   - "Middle East crisis live: tanker reports attack as Iran
+  //     closes strait of Hormuz; French soldier killed in Lebanon" —
+  //     a bridge headline whose French/Lebanon content dilutes its
+  //     Jaccard against the 4-story Hormuz cluster to exactly 0.25,
+  //     which our strict > floor rejects (same boundary value that
+  //     blocks the reviewer's oil-price reaction false positive, so
+  //     we cannot admit one without the other).
+  //
+  // Accepting these two outliers — a 6→3 reduction — is the deliberate
+  // trade-off for blocking the structural false positives in the
+  // regressions below (Russia/Odesa, Iran/oil-price, Lebanon-pair).
+  it('collapses at least 4 of 6 Hormuz wire variants into one cluster', () => {
     const stories = [
       story('Iran says it has closed Strait of Hormuz again over US blockade', 95, 1, 'h02'),
       story('Iran closes Strait of Hormuz again over US blockade and fires on ships', 90, 1, 'h05'),
@@ -219,14 +230,14 @@ describe('deduplicateStories', () => {
     const result = mod.deduplicateStories(stories);
     const largestClusterSize = Math.max(...result.map((r) => r.mergedHashes.length));
     assert.ok(
-      largestClusterSize >= 5,
-      `expected main Hormuz cluster to absorb ≥5 of 6 variants, got max size ${largestClusterSize}. Clusters: ${result.map((r) => `${r.mergedHashes.length}:${r.title.slice(0, 40)}`).join(' | ')}`,
+      largestClusterSize >= 4,
+      `expected main Hormuz cluster to absorb ≥4 of 6 variants, got max size ${largestClusterSize}. Clusters: ${result.map((r) => `${r.mergedHashes.length}:${r.title.slice(0, 40)}`).join(' | ')}`,
     );
-    // At most 2 clusters survive — the main one plus (possibly) the
-    // low-overlap "defiant message" outlier.
+    // At most 3 clusters survive — the main one plus up to 2
+    // documented outliers (P07 defiant-message + P11 bridge-headline).
     assert.ok(
-      result.length <= 2,
-      `expected ≤2 clusters, got ${result.length}`,
+      result.length <= 3,
+      `expected ≤3 clusters, got ${result.length}`,
     );
   });
 
@@ -403,8 +414,8 @@ describe('deduplicateStories — P1 false-positive regressions (from PR #3195 re
   // oil-price reaction story sharing {iran, nuclear, talks}. All
   // three words clear the 5-char "distinctive" bar but they're
   // generic diplomatic-event vocabulary. Secondary merge requires
-  // Jaccard ≥ 0.25 — the oil-price story's Jaccard against the
-  // talks cluster is 0.231, just below the floor.
+  // Jaccard > 0.25 — the oil-price story's Jaccard against the
+  // talks cluster is 0.231, below the floor.
   it('Iran nuclear talks coverage does not absorb an oil-price-reaction story sharing {iran, nuclear, talks}', () => {
     const stories = [
       story('US Iran nuclear talks resume in Oman', 95, 'nt1'),
@@ -419,6 +430,33 @@ describe('deduplicateStories — P1 false-positive regressions (from PR #3195 re
     );
     const sizes = result.map((r) => r.mergedHashes.length).sort((a, b) => b - a);
     assert.deepEqual(sizes, [2, 1], 'larger cluster has both talks stories');
+  });
+
+  // REGRESSION (third round / Jaccard boundary): a SHORTER oil-
+  // price variant landed EXACTLY on Jaccard = 0.25 against the
+  // talks cluster (3 shared words in a 12-word union), and with
+  // an inclusive ≥ comparison it scraped through and collapsed
+  // the three stories into 1. The fix is strict > SECONDARY_
+  // MERGE_MIN_JACCARD so the exact-boundary case falls out
+  // without bumping the constant (which would break legitimate
+  // close-miss Hormuz merges at J ≈ 0.267).
+  it('shorter oil-price variant at Jaccard exactly 0.25 still does NOT merge into talks cluster', () => {
+    const stories = [
+      story('US Iran nuclear talks resume in Oman', 95, 'nt1'),
+      story('US Iran nuclear talks enter second day in Oman', 90, 'nt2'),
+      // This variant is shorter than the one above (7 words vs 8
+      // after stop-filter). Against the 8-word cluster union, the
+      // 3 shared words give Jaccard = 3/(7+8-3) = 0.25 exactly.
+      story('Oil prices rise on Iran nuclear talks optimism', 85, 'op2'),
+    ];
+    const result = mod.deduplicateStories(stories);
+    assert.equal(
+      result.length,
+      2,
+      `expected 2 clusters (oil-price variant stays separate even at J=0.25 boundary), got ${result.length}: ${result.map((r) => r.title).join(' | ')}`,
+    );
+    const sizes = result.map((r) => r.mergedHashes.length).sort((a, b) => b - a);
+    assert.deepEqual(sizes, [2, 1], 'talks cluster has the two talks stories; oil-price is alone');
   });
 
   // REGRESSION (directional-word stop-words concern): north/south/

--- a/tests/digest-dedup.test.mjs
+++ b/tests/digest-dedup.test.mjs
@@ -20,27 +20,34 @@ const src = readFileSync(
 // We extract the pure functions (no side-effects, no imports) to test them.
 
 const STOP_WORDS_BLOCK = src.match(/const STOP_WORDS = new Set\(\[[\s\S]*?\]\);/)?.[0];
+const thresholdConsts = src.match(/const JACCARD_MERGE_THRESHOLD[\s\S]*?const CLUSTER_JOIN_MIN_DISTINCTIVE_WHEN_HAS_EVIDENCE\s*=\s*\d+;/)?.[0];
 const stripSourceSuffix = src.match(/function stripSourceSuffix\(title\) \{[\s\S]*?\n\}/)?.[0];
 const extractTitleWords = src.match(/function extractTitleWords\(title\) \{[\s\S]*?\n\}/)?.[0];
 const jaccardSimilarity = src.match(/function jaccardSimilarity\(setA, setB\) \{[\s\S]*?\n\}/)?.[0];
+const sharesDistinctiveContent = src.match(/function sharesDistinctiveContent\([^)]+\) \{[\s\S]*?\n\}/)?.[0];
 const deduplicateStories = src.match(/function deduplicateStories\(stories\) \{[\s\S]*?\n\}/)?.[0];
 
 assert.ok(STOP_WORDS_BLOCK, 'STOP_WORDS not found in source');
+assert.ok(thresholdConsts, 'merge threshold constants not found in source');
 assert.ok(stripSourceSuffix, 'stripSourceSuffix not found in source');
 assert.ok(extractTitleWords, 'extractTitleWords not found in source');
 assert.ok(jaccardSimilarity, 'jaccardSimilarity not found in source');
+assert.ok(sharesDistinctiveContent, 'sharesDistinctiveContent not found in source');
 assert.ok(deduplicateStories, 'deduplicateStories not found in source');
 
 const mod = {};
 new Function('mod', `
   ${STOP_WORDS_BLOCK}
+  ${thresholdConsts}
   ${stripSourceSuffix}
   ${extractTitleWords}
   ${jaccardSimilarity}
+  ${sharesDistinctiveContent}
   ${deduplicateStories}
   mod.stripSourceSuffix = stripSourceSuffix;
   mod.extractTitleWords = extractTitleWords;
   mod.jaccardSimilarity = jaccardSimilarity;
+  mod.sharesDistinctiveContent = sharesDistinctiveContent;
   mod.deduplicateStories = deduplicateStories;
 `)(mod);
 
@@ -150,5 +157,107 @@ describe('deduplicateStories', () => {
     assert.equal(result.length, 1);
     assert.equal(result[0].mentionCount, 3);
     assert.deepEqual(result[0].mergedHashes, [stories[0].hash]);
+  });
+
+  // REGRESSION (2026-04-19): a real brief surfaced 6 separate stories
+  // about the Strait-of-Hormuz closure with wildly different phrasing
+  // (one said "closed", another "defiant message ... cross Hormuz",
+  // another framed as "Middle East crisis live"). At Jaccard ≥ 0.55
+  // with frozen cluster words, all 6 passed through as distinct.
+  // With the new rules (threshold 0.35 + distinctive-content second
+  // pass + growing cluster pool) they collapse to a single cluster.
+  it('merges 6 wire variants of the same Hormuz closure event into one cluster', () => {
+    const stories = [
+      story('Iran says it has closed Strait of Hormuz again over US blockade', 95, 1, 'h02'),
+      story('Iran closes Strait of Hormuz again over US blockade and fires on ships', 90, 1, 'h05'),
+      story('Defiant message from Iran as vessels attempting to cross Hormuz report gunfire - Reuters', 85, 1, 'h07'),
+      story('Middle East crisis live: Iran warns it will close strait of Hormuz if US blockade continues', 80, 1, 'h08'),
+      story('Middle East crisis live: Iran says it has closed the strait of Hormuz; tanker reports being attacked', 75, 1, 'h10'),
+      story('Middle East crisis live: tanker reports attack as Iran closes strait of Hormuz; French soldier killed in Lebanon', 70, 1, 'h11'),
+    ];
+    const result = mod.deduplicateStories(stories);
+    assert.equal(result.length, 1, `expected 1 Hormuz cluster, got ${result.length}: ${result.map((r) => r.title).join(' | ')}`);
+    // All six hashes carried through so source-lookup still works.
+    assert.equal(result[0].mergedHashes.length, 6);
+    // The highest-scored variant wins as the display title.
+    assert.ok(result[0].title.includes('Iran says it has closed Strait'));
+    // Mention-count is the sum across the cluster.
+    assert.equal(result[0].mentionCount, 6);
+  });
+
+  // Asymmetry check: the 6-Hormuz merge must survive any processing
+  // order. The greedy clusterer could in principle pick a "sibling"
+  // first story whose low Jaccard with the dominant variant seeds
+  // two clusters instead of one; the post-pass cluster-cluster
+  // merge is what guards against that.
+  it('Hormuz merge survives reversed processing order (score equalised)', () => {
+    const titles = [
+      'Middle East crisis live: tanker reports attack as Iran closes strait of Hormuz; French soldier killed in Lebanon',
+      'Middle East crisis live: Iran says it has closed the strait of Hormuz; tanker reports being attacked',
+      'Middle East crisis live: Iran warns it will close strait of Hormuz if US blockade continues',
+      'Defiant message from Iran as vessels attempting to cross Hormuz report gunfire - Reuters',
+      'Iran closes Strait of Hormuz again over US blockade and fires on ships',
+      'Iran says it has closed Strait of Hormuz again over US blockade',
+    ];
+    const stories = titles.map((t, i) => story(t, 70 - i, 1, `r${i}`));
+    const result = mod.deduplicateStories(stories);
+    assert.equal(result.length, 1, `expected 1 cluster under reverse order, got ${result.length}: ${result.map((r) => r.title).join(' | ')}`);
+  });
+
+  // FALSE-POSITIVE GUARD: a single shared entity ("Iran") must NOT
+  // be enough to merge two genuinely different stories — the
+  // distinctive-content rule requires ≥2 shared words. Protects
+  // against collapsing unrelated regional coverage into one bucket.
+  it('does not merge two stories that share only one entity word', () => {
+    const stories = [
+      story('Iran announces new nuclear enrichment facility in Natanz', 90, 1, 'n1'),
+      story('Saudi Arabia and Iran resume diplomatic relations', 85, 1, 'n2'),
+    ];
+    const result = mod.deduplicateStories(stories);
+    assert.equal(result.length, 2, 'unrelated stories sharing only "iran" must stay separate');
+  });
+
+  // The existing "US rescues airman" trio (see below) must still
+  // stay as ≥2 clusters — the new rules must not over-merge
+  // different-angle coverage of the same incident.
+});
+
+describe('sharesDistinctiveContent (new secondary merge signal)', () => {
+  // The third arg is the "min distinctive shared" threshold.
+  // Call sites pass 1 for has-evidence clusters, 2 for singletons /
+  // post-pass.
+  it('requires ≥2 total shared words regardless of threshold', () => {
+    const a = new Set(['iran', 'hormuz', 'blockade']);
+    const b = new Set(['iran', 'nuclear', 'enrichment']);
+    assert.equal(mod.sharesDistinctiveContent(a, b, 1), false, 'only 1 shared word is not enough');
+  });
+
+  it('min=1 merges when 2+ shared AND ≥1 is length ≥5', () => {
+    const a = new Set(['iran', 'hormuz', 'closed']);
+    const b = new Set(['iran', 'hormuz', 'tanker', 'attack']);
+    assert.equal(mod.sharesDistinctiveContent(a, b, 1), true);
+  });
+
+  it('min=1 rejects when both shared words are short (<5 chars)', () => {
+    const a = new Set(['iran', 'gaza', 'attack']);
+    const b = new Set(['iran', 'gaza', 'relief']);
+    assert.equal(mod.sharesDistinctiveContent(a, b, 1), false);
+  });
+
+  it('min=2 rejects when only one distinctive word is shared (singleton guard)', () => {
+    // {iran, airman} — airman is 6 chars (distinctive), iran is 4.
+    // Under the singleton rule (need ≥2 distinctive), this fails —
+    // prevents unrelated Iran stories from collapsing just because
+    // both happen to mention "airman" once.
+    const a = new Set(['iran', 'airman', 'rescues']);
+    const b = new Set(['iran', 'airman', 'missing']);
+    assert.equal(mod.sharesDistinctiveContent(a, b, 2), false);
+  });
+
+  it('min=2 accepts when 2+ distinctive words are shared', () => {
+    // strait + hormuz + tanker all distinctive ≥5
+    const a = new Set(['iran', 'strait', 'hormuz', 'tanker']);
+    const b = new Set(['iran', 'strait', 'hormuz', 'blockade']);
+    assert.equal(mod.sharesDistinctiveContent(a, b, 2), true);
   });
 });


### PR DESCRIPTION
## Summary

Live prod bug reported 2026-04-19: a real brief had **6 of 12 stories** all about the Strait of Hormuz closure, just phrased differently across wires:

| # | Headline (paraphrased) |
|---|---|
| P02 | *Iran says it has closed Strait of Hormuz again over US blockade* |
| P05 | *Iran closes Strait of Hormuz again over US blockade and fires on ships* |
| P07 | *Defiant message from Iran as vessels attempting to cross Hormuz report gunfire* |
| P08 | *Middle East crisis live: Iran warns it will close strait of Hormuz if US blockade continues* |
| P10 | *Middle East crisis live: Iran says it has closed the strait of Hormuz; tanker reports being attacked* |
| P11 | *Middle East crisis live: tanker reports attack as Iran closes strait of Hormuz; French soldier killed in Lebanon* |

All the same real-world event. All surfaced as separate brief pages.

## Root cause

`deduplicateStories()` in `scripts/seed-digest-notifications.mjs` required Jaccard similarity `> 0.55` on bag-of-words overlap. That's far too strict for news headlines covering the same event with different vocabulary. Measured on the actual headlines:

```
P02↔P05: 0.500      P02↔P07: 0.167      P02↔P08: 0.308
P02↔P10: 0.308      P02↔P11: 0.176      P07↔P10: 0.118
P08↔P10: 0.467      P08↔P11: 0.389      P10↔P11: 0.471
```

**Zero pairs merged** at the 0.55 threshold.

Also: `cluster.words` was frozen at the seed story's vocabulary, so later candidates couldn't benefit from vocabulary introduced by siblings already in the cluster.

## Fix (four coordinated changes)

1. **Lower Jaccard threshold: 0.55 → 0.35.** Catches near-duplicates like *"Iran closes Hormuz"* ≈ *"Iran has closed the Strait of Hormuz"* that previously slipped through.

2. **Add secondary distinctive-content signal.** Merge when the new story shares `≥2` content words with the cluster pool AND at least one shared word is `≥5` chars (proxy for a named entity like "hormuz"/"lebanon"/"kyiv" rather than a generic short word like "iran"/"news"). The threshold scales with cluster evidence:
   - **Cluster size ≥ 2**: `1` distinctive shared word suffices (the cluster IS the prior)
   - **Both singletons**: need `≥2` distinctive shared words (no prior, need stronger signal)

3. **Grow `cluster.words` on merge.** Previously vocabulary was frozen at seed extraction; now each merged story expands the pool, so later Jaccards see the union.

4. **Post-pass cluster-to-cluster merge** using the stricter singleton rule. Guards against processing-order asymmetry where the highest-scored story of a topic uses unusual vocabulary, seeds a sibling cluster, and the "main" cluster never absorbs it.

### Additional: expanded STOP_WORDS

Added common news-framing boilerplate that was drowning the event signal: `live`, `crisis`, `update`, `breaking`, `latest`, `middle`, `east`, `west`, `north`, `south`, `news`, `briefing`, `watch`, `amid`, `and`, `if`, `but`, `or`, `so`, `when`, `while`, `still`, `now`, `then`. Shared vocabulary now converges on event nouns rather than framing.

## Validation against the actual bug data

- Forward order (score-descending P02→P11): **6 stories → 1 cluster** ✓
- Reverse order (adversarial): **6 stories → 1 cluster** (post-pass kicks in) ✓

## Non-regression

The existing test at `tests/digest-dedup.test.mjs:125` asserted that three genuinely-different-angle stories ("US rescues airman", "Iran says aircraft destroyed", "Trump/Israel pressure Iran") must stay as **≥2 clusters**. Under the new rules they still resolve to 3 clusters — the singleton-to-singleton rule's `≥2 distinctive shared` requirement rejects them (shared = `{iran, airman}`, only 1 distinctive).

Single-entity pairs stay separate: *"Iran announces new nuclear facility"* and *"Saudi Arabia and Iran resume diplomatic relations"* share only `{iran}` — not merged. Locked by a new test.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — 0 errors
- [x] `node --test tests/digest-dedup.test.mjs` — 19/19 pass (was 11, +4 new: real-world Hormuz forward, Hormuz reverse, single-entity false-positive guard, new sharesDistinctiveContent helper suite)
- [x] `npm run test:data` — 5767/5767 pass
- [ ] Post-deploy: tomorrow's brief should have materially fewer same-event duplicates. Sample a composed brief from the hourly cron and eyeball it; spot-check against that day's dominant news cluster (expect ≤2 stories per cluster vs. yesterday's 6).

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Railway logs (`seed-digest-notifications`): look for `[digest] brief: compose_success=N compose_failed=M` lines — volume shouldn't change materially; `compose_success` per user should stay near current baseline
  - Briefs themselves: sample a composed `brief:<userId>:<date>` from Redis for a few PRO users; count stories mentioning top-topic words (Hormuz, Gaza, etc.). Expect sharper reduction in repeats
- **Validation check**
  - Spot-test a composed brief end-to-end in the next cron cycle (hourly) — open in the dashboard panel and confirm stories feel distinct, not 6-variants-of-one
- **Expected healthy behavior**
  - Brief surfaces 8–12 distinct events per issue (vs. the 12-pages-with-6-duplicates seen today)
  - Mention-counts on surviving cluster winners are higher (since merged siblings roll up into the count)
- **Failure signal(s) / rollback trigger**
  - If `compose_success` drops by >20%, or if briefs suddenly surface fewer than 5 unique events (over-merging), revert
  - If a brief shows obvious false merges (e.g. two unrelated "Iran" stories collapsed), revert and add the counter-example to the test suite
- **Validation window & owner**
  - Window: 24h (2 cron cycles + next-day brief)
  - Owner: @koala73