### PR TITLE
fix(brief): unblock Telegram carousel fetch in middleware bot gate

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -109,8 +109,18 @@ export default function middleware(request: Request) {
     return;
   }
 
-  // Allow social preview/image bots on OG image assets
-  if (path.startsWith('/favico/') || path.endsWith('.png')) {
+  // Allow social preview/image bots on OG image assets.
+  // Image-returning API routes that don't end in `.png` (e.g. the
+  // brief carousel at /api/brief/carousel/<userId>/<date>/<page>)
+  // need an explicit prefix here — otherwise Telegram's sendMediaGroup
+  // fetch trips the BOT_UA gate below and surfaces as Telegram
+  // error 400 "WEBPAGE_CURL_FAILED". HMAC token in the URL is the
+  // real auth; the UA allowlist is defence-in-depth.
+  if (
+    path.startsWith('/favico/') ||
+    path.endsWith('.png') ||
+    path.startsWith('/api/brief/carousel/')
+  ) {
     if (SOCIAL_IMAGE_UA.test(ua)) {
       return;
     }

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,6 +19,14 @@ const PUBLIC_API_PATHS = new Set(['/api/version', '/api/health', '/api/seed-cont
 const SOCIAL_IMAGE_UA =
   /Slack-ImgProxy|Slackbot|twitterbot|facebookexternalhit|linkedinbot|telegrambot|whatsapp|discordbot|redditbot/i;
 
+// Must match the exact route shape enforced by
+// api/brief/carousel/[userId]/[issueDate]/[page].ts:
+//   /api/brief/carousel/<userId>/YYYY-MM-DD/<0|1|2>
+// pageFromIndex() in brief-carousel-render.ts accepts only 0/1/2, so
+// the trailing segment is tightly bounded.
+const BRIEF_CAROUSEL_PATH_RE =
+  /^\/api\/brief\/carousel\/[^/]+\/\d{4}-\d{2}-\d{2}\/[0-2]\/?$/;
+
 const VARIANT_HOST_MAP: Record<string, string> = {
   'tech.worldmonitor.app': 'tech',
   'finance.worldmonitor.app': 'finance',
@@ -110,16 +118,24 @@ export default function middleware(request: Request) {
   }
 
   // Allow social preview/image bots on OG image assets.
-  // Image-returning API routes that don't end in `.png` (e.g. the
-  // brief carousel at /api/brief/carousel/<userId>/<date>/<page>)
-  // need an explicit prefix here — otherwise Telegram's sendMediaGroup
-  // fetch trips the BOT_UA gate below and surfaces as Telegram
-  // error 400 "WEBPAGE_CURL_FAILED". HMAC token in the URL is the
-  // real auth; the UA allowlist is defence-in-depth.
+  //
+  // Image-returning API routes that don't end in `.png` also need
+  // an explicit carve-out — otherwise server-side fetches from
+  // Slack / Telegram / Discord / LinkedIn / WhatsApp / Facebook /
+  // Twitter / Reddit all trip the BOT_UA gate below. Telegram
+  // surfaces it as error 400 "WEBPAGE_CURL_FAILED" on sendMediaGroup;
+  // the others silently drop the preview image.
+  //
+  // Only the brief carousel route shape is allowlisted — a strict
+  // regex (same shape enforced by the handler) prevents a future
+  // /api/brief/carousel/admin or similar sibling from accidentally
+  // inheriting this bypass. HMAC token in the URL is the real auth;
+  // this allowlist is defence-in-depth for any well-shaped request
+  // whose UA happens to be in SOCIAL_IMAGE_UA.
   if (
     path.startsWith('/favico/') ||
     path.endsWith('.png') ||
-    path.startsWith('/api/brief/carousel/')
+    BRIEF_CAROUSEL_PATH_RE.test(path)
   ) {
     if (SOCIAL_IMAGE_UA.test(ua)) {
       return;

--- a/tests/middleware-bot-gate.test.mts
+++ b/tests/middleware-bot-gate.test.mts
@@ -1,0 +1,116 @@
+// Regression tests for middleware.ts's bot-UA gate.
+//
+// Pins the contract around the `/api/brief/carousel/` carve-out
+// shipped in PR #3196: social-platform image fetchers
+// (Slack/Telegram/Discord/LinkedIn/etc.) must be able to download
+// the carousel PNGs even though their UAs contain "bot" and thus
+// match BOT_UA, while the generic bot gate must still 403 plain
+// scrapers on every other API path.
+//
+// Without this test the allowlist is the kind of policy that
+// silently regresses on future middleware edits — Telegram's
+// sendMediaGroup failure mode ("WEBPAGE_CURL_FAILED") does not
+// surface as a CI failure anywhere else.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import middleware from '../middleware';
+
+const TELEGRAM_BOT_UA = 'TelegramBot (like TwitterBot)';
+const SLACKBOT_UA = 'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)';
+const DISCORDBOT_UA = 'Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)';
+const LINKEDINBOT_UA = 'LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)';
+const GENERIC_CURL_UA = 'curl/8.1.2';
+const GENERIC_SCRAPER_UA = 'Mozilla/5.0 (compatible; SomeRandomBot/1.2)';
+const CHROME_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+
+const CAROUSEL_PATH = '/api/brief/carousel/user_abc/2026-04-19/0';
+const OTHER_API_PATH = '/api/notifications';
+const MALFORMED_CAROUSEL_PATH = '/api/brief/carousel/admin/dashboard';
+
+function call(pathOrUrl: string, ua: string): Response | void {
+  const url = pathOrUrl.startsWith('http')
+    ? pathOrUrl
+    : `https://www.worldmonitor.app${pathOrUrl}`;
+  const req = new Request(url, {
+    headers: ua ? { 'user-agent': ua } : {},
+  });
+  return middleware(req) as Response | void;
+}
+
+describe('middleware bot gate / carousel allowlist', () => {
+  it('passes TelegramBot through on the carousel route (the PR #3196 fix)', () => {
+    const res = call(CAROUSEL_PATH, TELEGRAM_BOT_UA);
+    assert.equal(res, undefined, 'Telegram must be able to fetch carousel images');
+  });
+
+  it('passes Slackbot through on the carousel route', () => {
+    const res = call(CAROUSEL_PATH, SLACKBOT_UA);
+    assert.equal(res, undefined);
+  });
+
+  it('passes Discordbot through on the carousel route', () => {
+    const res = call(CAROUSEL_PATH, DISCORDBOT_UA);
+    assert.equal(res, undefined);
+  });
+
+  it('passes LinkedInBot through on the carousel route', () => {
+    const res = call(CAROUSEL_PATH, LINKEDINBOT_UA);
+    assert.equal(res, undefined);
+  });
+
+  it('still 403s curl on the carousel route (bot gate protects from non-social UAs)', () => {
+    const res = call(CAROUSEL_PATH, GENERIC_CURL_UA);
+    assert.ok(res instanceof Response, 'should return a Response, not pass through');
+    assert.equal(res.status, 403);
+  });
+
+  it('still 403s a generic "bot" UA on the carousel route', () => {
+    const res = call(CAROUSEL_PATH, GENERIC_SCRAPER_UA);
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, 403);
+  });
+
+  it('still 403s TelegramBot on non-carousel API routes (allowlist is scoped, not global)', () => {
+    const res = call(OTHER_API_PATH, TELEGRAM_BOT_UA);
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, 403);
+  });
+
+  it('still 403s TelegramBot on malformed carousel paths (regex enforces route shape)', () => {
+    const res = call(MALFORMED_CAROUSEL_PATH, TELEGRAM_BOT_UA);
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, 403);
+  });
+
+  it('still 403s missing UA on the carousel route (short-UA guard)', () => {
+    const res = call(CAROUSEL_PATH, '');
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, 403);
+  });
+
+  it('passes normal browsers through on the carousel route', () => {
+    const res = call(CAROUSEL_PATH, CHROME_UA);
+    assert.equal(res, undefined);
+  });
+
+  it('passes normal browsers through on any API route', () => {
+    const res = call(OTHER_API_PATH, CHROME_UA);
+    assert.equal(res, undefined);
+  });
+
+  it('does not accept page 3+ on the carousel route (pageFromIndex only has 0/1/2)', () => {
+    const res = call('/api/brief/carousel/user_abc/2026-04-19/3', TELEGRAM_BOT_UA);
+    assert.ok(res instanceof Response, 'out-of-range page must hit the bot gate');
+    assert.equal(res.status, 403);
+  });
+
+  it('does not accept non-ISO-date segments on the carousel route', () => {
+    const res = call('/api/brief/carousel/user_abc/today/0', TELEGRAM_BOT_UA);
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, 403);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the root cause behind PR #3174's silent Telegram brief carousel failure.

`middleware.ts`'s `BOT_UA = /bot|.../i` regex was 403'ing Telegram's server-side `sendMediaGroup` fetch of `/api/brief/carousel/<userId>/<date>/<page>`. Telegram's fetcher sends `User-Agent: TelegramBot (like TwitterBot)` — matches `bot` → blocked.

The existing `SOCIAL_IMAGE_UA` allowlist (which DOES include `telegrambot`) was only consulted inside a guard scoped to `/favico/*` or paths ending in `.png`:

```ts
if (path.startsWith('/favico/') || path.endsWith('.png')) {
  if (SOCIAL_IMAGE_UA.test(ua)) return;
}
```

The carousel route returns `image/png` but its URL has no extension, so the exemption never fires. Execution falls through to the generic bot gate → 403 → Telegram logs `Bad Request: failed to send message #N with the error message "WEBPAGE_CURL_FAILED"` and the whole album drops (sendMediaGroup is atomic).

## Evidence

Railway digest log, 2026-04-19T04:03:05Z:

```
[digest] Telegram carousel 400 for user_3BovQ1tYlaz2YIGYAdDPXGFBgKy:
{"ok":false,"error_code":400,"description":"Bad Request: failed to send message #2 with the error message \"WEBPAGE_CURL_FAILED\""}
```

Manual probe with the exact UA Telegram uses (pre-fix) returns 403 from middleware. Post-fix it returns 200 + `image/png`.

## Fix

Add `/api/brief/carousel/` to the prefix list that opens the `SOCIAL_IMAGE_UA` allowlist. HMAC token verification in `api/brief/carousel/[userId]/[issueDate]/[page].ts` is the real auth boundary; the UA allowlist is defence-in-depth. No other API route is affected — they all still hit the bot gate exactly as before.

Smallest possible diff: +10 / -2 on `middleware.ts`.

## Files

| File | Change |
|------|--------|
| `middleware.ts` | Extend existing `/favico/` + `.png` guard to also include `/api/brief/carousel/` prefix |

## Tests

- `npm run typecheck` clean
- `npm run typecheck:api` clean
- `npm run test:data` — 5759/5759 pass
- Pre-push lint:boundaries + version:check clean

## Post-deploy validation

Once deployed, validate with Telegram's UA:

\`\`\`bash
curl -I -H "User-Agent: TelegramBot (like TwitterBot)" \\
  "https://www.worldmonitor.app/api/brief/carousel/<userId>/<date>/0?t=<token>"
# Expect: HTTP/2 200, content-type: image/png
# Before fix: HTTP/2 403
\`\`\`

Then wait for the next digest cron tick and confirm Railway log line `[digest] Telegram carousel 400` does NOT appear. On the recipient side, the 3-image album should now land above the text message.

## Out of scope (separate follow-up)

The brief footer link (`📖 Open your WorldMonitor Brief magazine`) is still sometimes cut by Telegram's 4096-char message truncation because `buildChannelBodies` in `scripts/seed-digest-notifications.mjs` appends it at the very end of `telegramText`. That's a separate presentation fix — either move the footer to the top of the message, or rely on the carousel caption as the primary magazine CTA. Not bundled here to keep this PR focused on the silent 403.

## Test plan

- [x] Typechecks pass
- [x] Full test suite passes (5759 tests)
- [ ] Post-merge: smoke-test with curl + Telegram UA
- [ ] Post-merge: confirm next digest cron delivers 3-image carousel end-to-end