### PR TITLE
fix(health): persist WARNING events + add failure-log timeline

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -677,20 +677,27 @@ export default async function handler(req, ctx) {
 
   const httpStatus = 200;
 
-  if (overall !== 'HEALTHY' && overall !== 'WARNING') {
+  if (overall !== 'HEALTHY') {
     const problemKeys = Object.entries(checks)
-      .filter(([, c]) => c.status === 'EMPTY' || c.status === 'EMPTY_DATA' || c.status === 'STALE_SEED' || c.status === 'SEED_ERROR' || c.status === 'REDIS_PARTIAL')
+      .filter(([, c]) => c.status !== 'OK' && c.status !== 'OK_CASCADE' && c.status !== 'EMPTY_ON_DEMAND')
       .map(([k, c]) => `${k}:${c.status}${c.seedAgeMin != null ? `(${c.seedAgeMin}min)` : ''}`);
-    console.log('[health] %s crits=[%s]', overall, problemKeys.join(', '));
-    // Persist last failure snapshot for post-mortem. Vercel edge isolates can
-    // terminate before a fire-and-forget Promise resolves; ctx.waitUntil keeps
-    // the runtime alive until the write completes.
-    const persist = redisPipeline([['SET', 'health:last-failure', JSON.stringify({
+    console.log('[health] %s problems=[%s]', overall, problemKeys.join(', '));
+    // Persist snapshot for post-mortem. Includes WARNING (STALE_SEED) so
+    // UptimeRobot keyword-check failures ("HEALTHY" not found) leave a trail.
+    // Previous code excluded WARNING, making stale-seed incidents invisible.
+    const snapshot = {
       at: new Date(now).toISOString(),
       status: overall,
       critCount,
-      crits: problemKeys,
-    }), 'EX', 86400]]).catch(() => {});
+      warnCount: realWarnCount,
+      problems: problemKeys,
+    };
+    const persist = redisPipeline([
+      ['SET', 'health:last-failure', JSON.stringify(snapshot), 'EX', 86400],
+      ['LPUSH', 'health:failure-log', JSON.stringify(snapshot)],
+      ['LTRIM', 'health:failure-log', '0', '49'],
+      ['EXPIRE', 'health:failure-log', String(86400 * 7)],
+    ]).catch(() => {});
     if (ctx && typeof ctx.waitUntil === 'function') ctx.waitUntil(persist);
   }
 

--- a/api/health.js
+++ b/api/health.js
@@ -678,13 +678,17 @@ export default async function handler(req, ctx) {
   const httpStatus = 200;
 
   if (overall !== 'HEALTHY') {
+    // problemKeys includes seedAgeMin for the snapshot (useful for post-mortem),
+    // but the dedupe signature uses only key:status (no age) so a long STALE_SEED
+    // window doesn't produce a new log entry on every poll.
     const problemKeys = Object.entries(checks)
       .filter(([, c]) => c.status !== 'OK' && c.status !== 'OK_CASCADE' && c.status !== 'EMPTY_ON_DEMAND')
       .map(([k, c]) => `${k}:${c.status}${c.seedAgeMin != null ? `(${c.seedAgeMin}min)` : ''}`);
+    const sigKeys = Object.entries(checks)
+      .filter(([, c]) => c.status !== 'OK' && c.status !== 'OK_CASCADE' && c.status !== 'EMPTY_ON_DEMAND')
+      .map(([k, c]) => `${k}:${c.status}`)
+      .sort();
     console.log('[health] %s problems=[%s]', overall, problemKeys.join(', '));
-    // Persist snapshot for post-mortem. Includes WARNING (STALE_SEED) so
-    // UptimeRobot keyword-check failures ("HEALTHY" not found) leave a trail.
-    // Previous code excluded WARNING, making stale-seed incidents invisible.
     const snapshot = {
       at: new Date(now).toISOString(),
       status: overall,
@@ -692,14 +696,10 @@ export default async function handler(req, ctx) {
       warnCount: realWarnCount,
       problems: problemKeys,
     };
-    // Dedupe: only LPUSH when the incident signature (status + problem set)
-    // changes. Otherwise repeated polls during one long WARNING window would
-    // fill the 50-entry log with near-identical snapshots, evicting older
-    // distinct incidents.
-    // Uses SET ... GET (Redis 6.2+) to atomically swap the sig and return
-    // the previous value in one round-trip, avoiding a read-then-write race
-    // where concurrent health probes could both see the old sig.
-    const sig = `${overall}|${problemKeys.join(',')}`;
+    // Dedupe: only LPUSH when the incident signature (status + problem set,
+    // excluding seedAgeMin) changes. Uses SET ... GET (Redis 6.2+) to
+    // atomically swap the sig and return the previous value.
+    const sig = `${overall}|${sigKeys.join(',')}`;
     const persistCmds = [
       ['SET', 'health:last-failure', JSON.stringify(snapshot), 'EX', 86400],
       ['SET', 'health:failure-log-sig', sig, 'EX', 86400, 'GET'],
@@ -718,6 +718,12 @@ export default async function handler(req, ctx) {
       ? redisPipeline(logCmds, 4_000).catch(() => {})
       : Promise.resolve();
     if (ctx && typeof ctx.waitUntil === 'function') ctx.waitUntil(persist);
+  } else {
+    // Clear the sig on recovery so a recurrence of the same problem set
+    // after a healthy gap is logged as a new incident, not deduped against
+    // the previous one.
+    const clear = redisPipeline([['DEL', 'health:failure-log-sig']], 4_000).catch(() => {});
+    if (ctx && typeof ctx.waitUntil === 'function') ctx.waitUntil(clear);
   }
 
   const url = new URL(req.url);

--- a/api/health.js
+++ b/api/health.js
@@ -697,26 +697,25 @@ export default async function handler(req, ctx) {
       problems: problemKeys,
     };
     // Dedupe: only LPUSH when the incident signature (status + problem set,
-    // excluding seedAgeMin) changes. Uses SET ... GET (Redis 6.2+) to
-    // atomically swap the sig and return the previous value.
+    // excluding seedAgeMin) changes. Read the previous sig first, then write
+    // everything (last-failure + sig + LPUSH) in one atomic pipeline so the
+    // sig only advances when the LPUSH succeeds. If the pipeline fails, the
+    // sig stays stale and the next poll retries the append.
     const sig = `${overall}|${sigKeys.join(',')}`;
+    const prevSigResult = await redisPipeline([['GET', 'health:failure-log-sig']], 4_000).catch(() => null);
+    const prevSig = prevSigResult?.[0]?.result ?? '';
     const persistCmds = [
       ['SET', 'health:last-failure', JSON.stringify(snapshot), 'EX', 86400],
-      ['SET', 'health:failure-log-sig', sig, 'EX', 86400, 'GET'],
     ];
-    const sigResults = await redisPipeline(persistCmds, 4_000).catch(() => null);
-    const prevSig = sigResults?.[1]?.result ?? '';
-    const logCmds = [];
     if (sig !== prevSig) {
-      logCmds.push(
+      persistCmds.push(
         ['LPUSH', 'health:failure-log', JSON.stringify(snapshot)],
         ['LTRIM', 'health:failure-log', 0, 49],
         ['EXPIRE', 'health:failure-log', 86400 * 7],
+        ['SET', 'health:failure-log-sig', sig, 'EX', 86400],
       );
     }
-    const persist = logCmds.length > 0
-      ? redisPipeline(logCmds, 4_000).catch(() => {})
-      : Promise.resolve();
+    const persist = redisPipeline(persistCmds, 4_000).catch(() => {});
     if (ctx && typeof ctx.waitUntil === 'function') ctx.waitUntil(persist);
   } else {
     // Clear the sig on recovery so a recurrence of the same problem set

--- a/api/health.js
+++ b/api/health.js
@@ -696,16 +696,17 @@ export default async function handler(req, ctx) {
     // changes. Otherwise repeated polls during one long WARNING window would
     // fill the 50-entry log with near-identical snapshots, evicting older
     // distinct incidents.
+    // Uses SET ... GET (Redis 6.2+) to atomically swap the sig and return
+    // the previous value in one round-trip, avoiding a read-then-write race
+    // where concurrent health probes could both see the old sig.
     const sig = `${overall}|${problemKeys.join(',')}`;
     const persistCmds = [
       ['SET', 'health:last-failure', JSON.stringify(snapshot), 'EX', 86400],
-      ['GET', 'health:failure-log-sig'],
+      ['SET', 'health:failure-log-sig', sig, 'EX', 86400, 'GET'],
     ];
     const sigResults = await redisPipeline(persistCmds, 4_000).catch(() => null);
     const prevSig = sigResults?.[1]?.result ?? '';
-    const logCmds = [
-      ['SET', 'health:failure-log-sig', sig, 'EX', 86400],
-    ];
+    const logCmds = [];
     if (sig !== prevSig) {
       logCmds.push(
         ['LPUSH', 'health:failure-log', JSON.stringify(snapshot)],
@@ -713,7 +714,9 @@ export default async function handler(req, ctx) {
         ['EXPIRE', 'health:failure-log', 86400 * 7],
       );
     }
-    const persist = redisPipeline(logCmds, 4_000).catch(() => {});
+    const persist = logCmds.length > 0
+      ? redisPipeline(logCmds, 4_000).catch(() => {})
+      : Promise.resolve();
     if (ctx && typeof ctx.waitUntil === 'function') ctx.waitUntil(persist);
   }
 

--- a/api/health.js
+++ b/api/health.js
@@ -701,7 +701,7 @@ export default async function handler(req, ctx) {
       ['SET', 'health:last-failure', JSON.stringify(snapshot), 'EX', 86400],
       ['GET', 'health:failure-log-sig'],
     ];
-    const sigResults = await redisPipeline(persistCmds).catch(() => null);
+    const sigResults = await redisPipeline(persistCmds, 4_000).catch(() => null);
     const prevSig = sigResults?.[1]?.result ?? '';
     const logCmds = [
       ['SET', 'health:failure-log-sig', sig, 'EX', 86400],
@@ -709,11 +709,11 @@ export default async function handler(req, ctx) {
     if (sig !== prevSig) {
       logCmds.push(
         ['LPUSH', 'health:failure-log', JSON.stringify(snapshot)],
-        ['LTRIM', 'health:failure-log', '0', '49'],
-        ['EXPIRE', 'health:failure-log', String(86400 * 7)],
+        ['LTRIM', 'health:failure-log', 0, 49],
+        ['EXPIRE', 'health:failure-log', 86400 * 7],
       );
     }
-    const persist = redisPipeline(logCmds).catch(() => {});
+    const persist = redisPipeline(logCmds, 4_000).catch(() => {});
     if (ctx && typeof ctx.waitUntil === 'function') ctx.waitUntil(persist);
   }
 

--- a/api/health.js
+++ b/api/health.js
@@ -692,12 +692,28 @@ export default async function handler(req, ctx) {
       warnCount: realWarnCount,
       problems: problemKeys,
     };
-    const persist = redisPipeline([
+    // Dedupe: only LPUSH when the incident signature (status + problem set)
+    // changes. Otherwise repeated polls during one long WARNING window would
+    // fill the 50-entry log with near-identical snapshots, evicting older
+    // distinct incidents.
+    const sig = `${overall}|${problemKeys.join(',')}`;
+    const persistCmds = [
       ['SET', 'health:last-failure', JSON.stringify(snapshot), 'EX', 86400],
-      ['LPUSH', 'health:failure-log', JSON.stringify(snapshot)],
-      ['LTRIM', 'health:failure-log', '0', '49'],
-      ['EXPIRE', 'health:failure-log', String(86400 * 7)],
-    ]).catch(() => {});
+      ['GET', 'health:failure-log-sig'],
+    ];
+    const sigResults = await redisPipeline(persistCmds).catch(() => null);
+    const prevSig = sigResults?.[1]?.result ?? '';
+    const logCmds = [
+      ['SET', 'health:failure-log-sig', sig, 'EX', 86400],
+    ];
+    if (sig !== prevSig) {
+      logCmds.push(
+        ['LPUSH', 'health:failure-log', JSON.stringify(snapshot)],
+        ['LTRIM', 'health:failure-log', '0', '49'],
+        ['EXPIRE', 'health:failure-log', String(86400 * 7)],
+      );
+    }
+    const persist = redisPipeline(logCmds).catch(() => {});
     if (ctx && typeof ctx.waitUntil === 'function') ctx.waitUntil(persist);
   }
 


### PR DESCRIPTION
## Summary
- **Root cause of UptimeRobot false-positives:** UptimeRobot keyword-checks for "HEALTHY" in the `/api/health` response body. When seeds go stale (STALE_SEED), the endpoint returns `{"status":"WARNING",...}` (HTTP 200), but the keyword check fails and UptimeRobot flags DOWN. The `health:last-failure` Redis key was NOT written for WARNING events (line 680 excluded them), leaving zero forensic trail for post-mortem.
- **Fix:** Now writes `health:last-failure` for ANY non-HEALTHY status, including WARNING.
- **New:** `health:failure-log` Redis list (LPUSH, last 50 entries, 7-day TTL) preserves a timeline of incidents so multiple alerts can be correlated against actual seed states.
- **New fields:** `warnCount` (alongside existing `critCount`) and broadened `problems` array that includes all non-OK statuses (STALE_SEED, SEED_ERROR, REDIS_PARTIAL, EMPTY, EMPTY_DATA).

## Post-mortem usage
```bash
# Latest incident snapshot
GET health:last-failure

# Full 7-day timeline (up to 50 entries)
LRANGE health:failure-log 0 -1
```

## Test plan
- [x] `npm run typecheck` / `typecheck:api`
- [x] `npm run lint` (0 errors)
- [x] `npm run test:data` — pass
- [x] `node --test tests/edge-functions.test.mjs` (171/171)
- [x] Edge bundle check, `lint:md`, `version:check`