### PR TITLE
fix(sentry): filter Three.js OrbitControls setPointerCapture NotFoundError

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -294,9 +294,13 @@ Sentry.init({
     }
     // Suppress Three.js OrbitControls pointer-capture race: pointerdown handler calls
     // setPointerCapture but the browser has already released the pointer (focus change,
-    // rapid re-tap). Message is unique to setPointerCapture; no first-party code uses it
-    // (WORLDMONITOR-NC).
-    if (excType === 'NotFoundError' && /setPointerCapture.*No active pointer with the given id/.test(msg)) return null;
+    // rapid re-tap). OrbitControls is bundled into main-*.js, so the generic hasFirstParty
+    // gate below would miss it; instead require absence of any source-mapped .ts/.tsx frame
+    // so a future first-party setPointerCapture regression still surfaces (WORLDMONITOR-NC).
+    if (excType === 'NotFoundError' && /setPointerCapture.*No active pointer with the given id/.test(msg)) {
+      const hasSourceMappedFrame = frames.some(f => /\.(ts|tsx)$/.test(f.filename ?? '') || /^src\//.test(f.filename ?? ''));
+      if (!hasSourceMappedFrame) return null;
+    }
     // Suppress deck.gl/maplibre null-access crashes with no usable stack trace (requestAnimationFrame wrapping)
     if (/null is not an object \(evaluating '\w{1,3}\.(id|type|style)'\)/.test(msg) && frames.length === 0) return null;
     // Suppress Safari sortedTrackListForMenu native crash (value is generic "Type error", function name in stack)

--- a/src/main.ts
+++ b/src/main.ts
@@ -294,12 +294,22 @@ Sentry.init({
     }
     // Suppress Three.js OrbitControls pointer-capture race: pointerdown handler calls
     // setPointerCapture but the browser has already released the pointer (focus change,
-    // rapid re-tap). OrbitControls is bundled into main-*.js, so the generic hasFirstParty
-    // gate below would miss it; instead require absence of any source-mapped .ts/.tsx frame
-    // so a future first-party setPointerCapture regression still surfaces (WORLDMONITOR-NC).
+    // rapid re-tap). OrbitControls is bundled into main-*.js, so hasFirstParty=true and
+    // production stacks are often unsymbolicated — require a positive three.js signature
+    // in the frame context (the literal `this._pointers … setPointerCapture` code slice)
+    // so an unrelated first-party setPointerCapture regression still surfaces (WORLDMONITOR-NC).
     if (excType === 'NotFoundError' && /setPointerCapture.*No active pointer with the given id/.test(msg)) {
-      const hasSourceMappedFrame = frames.some(f => /\.(ts|tsx)$/.test(f.filename ?? '') || /^src\//.test(f.filename ?? ''));
-      if (!hasSourceMappedFrame) return null;
+      // Sentry wire format includes `context: [[lineno, text], ...]` per frame, but the
+      // SDK's StackFrame type omits it — cast to any to read it.
+      const hasOrbitControlsContext = frames.some(f => {
+        const ctx = (f as any).context;
+        if (!Array.isArray(ctx)) return false;
+        return ctx.some(row =>
+          Array.isArray(row) && typeof row[1] === 'string'
+          && /_pointers[^\n]*setPointerCapture|setPointerCapture[^\n]*_pointers/.test(row[1]),
+        );
+      });
+      if (hasOrbitControlsContext) return null;
     }
     // Suppress deck.gl/maplibre null-access crashes with no usable stack trace (requestAnimationFrame wrapping)
     if (/null is not an object \(evaluating '\w{1,3}\.(id|type|style)'\)/.test(msg) && frames.length === 0) return null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -292,6 +292,11 @@ Sentry.init({
     if (/undefined is not an object \(evaluating 't\.x'\)|Cannot read properties of undefined \(reading 'x'\)/.test(msg)) {
       if (!hasFirstParty || frames.some(f => /\b_handleTouch\w*Dolly|OrbitControls/.test(f.function ?? ''))) return null;
     }
+    // Suppress Three.js OrbitControls pointer-capture race: pointerdown handler calls
+    // setPointerCapture but the browser has already released the pointer (focus change,
+    // rapid re-tap). Message is unique to setPointerCapture; no first-party code uses it
+    // (WORLDMONITOR-NC).
+    if (excType === 'NotFoundError' && /setPointerCapture.*No active pointer with the given id/.test(msg)) return null;
     // Suppress deck.gl/maplibre null-access crashes with no usable stack trace (requestAnimationFrame wrapping)
     if (/null is not an object \(evaluating '\w{1,3}\.(id|type|style)'\)/.test(msg) && frames.length === 0) return null;
     // Suppress Safari sortedTrackListForMenu native crash (value is generic "Type error", function name in stack)

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -260,6 +260,29 @@ describe('existing beforeSend filters', () => {
     assert.ok(beforeSend(event) !== null, 'First-party non-OrbitControls touch error should reach Sentry');
   });
 
+  it('suppresses OrbitControls setPointerCapture NotFoundError when stack is bundle-only', () => {
+    const event = makeEvent(
+      "Failed to execute 'setPointerCapture' on 'Element': No active pointer with the given id is found.",
+      'NotFoundError',
+      [
+        { filename: '/assets/sentry-CRhtdLad.js', lineno: 15, function: 'HTMLCanvasElement.r' },
+        { filename: '/assets/main-rDi7PwxJ.js', lineno: 6757, function: 'xge._ge' },
+      ],
+    );
+    assert.equal(beforeSend(event), null, 'Bundle-only setPointerCapture race should be suppressed');
+  });
+
+  it('does NOT suppress setPointerCapture NotFoundError from source-mapped first-party frames', () => {
+    const event = makeEvent(
+      "Failed to execute 'setPointerCapture' on 'Element': No active pointer with the given id is found.",
+      'NotFoundError',
+      [
+        { filename: 'src/components/MyCanvas.ts', lineno: 42, function: 'MyCanvas.onPointerDown' },
+      ],
+    );
+    assert.ok(beforeSend(event) !== null, 'First-party setPointerCapture regression must reach Sentry');
+  });
+
   it('suppresses maplibre TypeError when all frames are maplibre', () => {
     const event = makeEvent('Cannot read properties of null', 'TypeError', [
       { filename: '/assets/maplibre-AbC123.js', lineno: 100, function: 'paint' },

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -260,27 +260,59 @@ describe('existing beforeSend filters', () => {
     assert.ok(beforeSend(event) !== null, 'First-party non-OrbitControls touch error should reach Sentry');
   });
 
-  it('suppresses OrbitControls setPointerCapture NotFoundError when stack is bundle-only', () => {
+  it('suppresses OrbitControls setPointerCapture NotFoundError when frame context matches three.js signature', () => {
+    // Verbatim frame context slice from WORLDMONITOR-NC: minified three.js OrbitControls
+    // onPointerDown body. The `_pointers` + `setPointerCapture` adjacency is a three.js-only
+    // pattern (our own code doesn't use `_pointers` naming).
     const event = makeEvent(
       "Failed to execute 'setPointerCapture' on 'Element': No active pointer with the given id is found.",
       'NotFoundError',
       [
         { filename: '/assets/sentry-CRhtdLad.js', lineno: 15, function: 'HTMLCanvasElement.r' },
-        { filename: '/assets/main-rDi7PwxJ.js', lineno: 6757, function: 'xge._ge' },
+        {
+          filename: '/assets/main-rDi7PwxJ.js',
+          lineno: 6757,
+          function: 'xge._ge',
+          context: [
+            [6757, '.enabled!==!1&&(this._pointers.length===0&&(this.domElement.setPointerCapture(i.pointerId),this.domElement.ownerDocument.addEventListener("p'],
+          ],
+        },
       ],
     );
-    assert.equal(beforeSend(event), null, 'Bundle-only setPointerCapture race should be suppressed');
+    assert.equal(beforeSend(event), null, 'OrbitControls setPointerCapture race should be suppressed');
   });
 
-  it('does NOT suppress setPointerCapture NotFoundError from source-mapped first-party frames', () => {
+  it('does NOT suppress setPointerCapture NotFoundError from unsymbolicated first-party bundle frames (no three.js signature)', () => {
+    // Production-realistic regression: first-party code calling setPointerCapture, stack
+    // lands in /assets/main-*.js (unsymbolicated), but frame context does NOT carry the
+    // three.js `_pointers` adjacency. Must reach Sentry.
     const event = makeEvent(
       "Failed to execute 'setPointerCapture' on 'Element': No active pointer with the given id is found.",
       'NotFoundError',
       [
-        { filename: 'src/components/MyCanvas.ts', lineno: 42, function: 'MyCanvas.onPointerDown' },
+        {
+          filename: '/assets/main-rDi7PwxJ.js',
+          lineno: 1200,
+          function: 'MyCanvas.onPointerDown',
+          context: [
+            [1200, 'this.activePointerId=e.pointerId;this.el.setPointerCapture(e.pointerId);this.emit("pointerdown",e)'],
+          ],
+        },
       ],
     );
-    assert.ok(beforeSend(event) !== null, 'First-party setPointerCapture regression must reach Sentry');
+    assert.ok(beforeSend(event) !== null, 'First-party setPointerCapture regression must reach Sentry even when unsymbolicated');
+  });
+
+  it('does NOT suppress setPointerCapture NotFoundError when no frame context is present', () => {
+    // Defensive: if Sentry strips context, we err on the side of surfacing.
+    const event = makeEvent(
+      "Failed to execute 'setPointerCapture' on 'Element': No active pointer with the given id is found.",
+      'NotFoundError',
+      [
+        { filename: '/assets/main-rDi7PwxJ.js', lineno: 6757, function: 'xge._ge' },
+      ],
+    );
+    assert.ok(beforeSend(event) !== null, 'Context-less stacks must not be silently suppressed');
   });
 
   it('suppresses maplibre TypeError when all frames are maplibre', () => {


### PR DESCRIPTION
## Summary
- Three.js OrbitControls' `pointerdown` handler calls `setPointerCapture` after the browser has already released the pointer (focus change, rapid re-tap), throwing `NotFoundError`. OrbitControls is bundled into `main-*.js` so `hasFirstParty` is true; matched by the unique `setPointerCapture` + "No active pointer with the given id" message.
- Grep confirms no first-party code calls `setPointerCapture`, so the message is unambiguous.
- Resolves Sentry WORLDMONITOR-NC.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run test:data` passes (5772 tests)
- [x] `node --test tests/edge-functions.test.mjs` passes (171 tests)
- [x] `npm run lint` / `lint:md` / `version:check` clean
- [ ] Filter verified in next release (Sentry auto-reopens if the error recurs)