### PR TITLE
fix(emails): transactional copy — '22 services' → '30+ services' (follow-up to #3202)

### DIFF
--- a/api/register-interest.js
+++ b/api/register-interest.js
@@ -87,7 +87,7 @@ async function sendConfirmationEmail(email, referralCode) {
                   <td style="width: 50%; padding: 12px; vertical-align: top;">
                     <div style="background: #111; border: 1px solid #1a1a1a; padding: 16px; height: 100%;">
                       <div style="font-size: 20px; margin-bottom: 8px;">&#128273;</div>
-                      <div style="font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 4px;">22 Services, 1 Key</div>
+                      <div style="font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 4px;">30+ Services, 1 Key</div>
                       <div style="font-size: 12px; color: #888; line-height: 1.4;">ACLED, NASA FIRMS, OpenSky, Finnhub, and more</div>
                     </div>
                   </td>

--- a/convex/payments/subscriptionEmails.ts
+++ b/convex/payments/subscriptionEmails.ts
@@ -54,7 +54,7 @@ function featureCardsHtml(planKey: string): string {
           <div style="background: #111; border: 1px solid #1a1a1a; padding: 16px; height: 100%;">
             <div style="font-size: 20px; margin-bottom: 8px;">&#128273;</div>
             <div style="font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 4px;">Full API Access</div>
-            <div style="font-size: 12px; color: #888; line-height: 1.4;">22 services, one API key</div>
+            <div style="font-size: 12px; color: #888; line-height: 1.4;">30+ services, one API key</div>
           </div>
         </td>
         <td style="width: 50%; padding: 12px; vertical-align: top;">


### PR DESCRIPTION
## Summary

[Greptile flagged on PR #3202](https://github.com/koala73/worldmonitor/pull/3202) that two transactional email templates still said **\"22 services\"** while the `/pro` marketing page now says **\"30+ services\"**. A user signing up via `/pro` would read \"30+ services\" on the page and then receive a welcome email saying \"22\". Self-inconsistent.

## Fix

Two one-line changes:

| File | Line | Before | After |
|---|---|---|---|
| `api/register-interest.js` | 90 | `22 Services, 1 Key` | `30+ Services, 1 Key` |
| `convex/payments/subscriptionEmails.ts` | 57 | `22 services, one API key` | `30+ services, one API key` |

Same '30+' phrasing as `/pro` (rationale in PR #3202: real count is 31 in `server/worldmonitor/*` + 32nd at `api/scenario/v1/`, and '30+' is self-maintaining as new domains ship).

## Testing

- Templates render identically (HTML structure untouched; only the copy inside one `<div>` per file)
- No runtime logic, no schema

## Post-Deploy Monitoring & Validation

- **What to monitor:** next interest-registration confirmation email sent through `api/register-interest` and next API subscription confirmation sent via `convex/payments/subscriptionEmails` — spot-check the rendered email reads "30+ services".
- **Rollback:** revert single commit (2-line change, trivial).
- **Owner:** Elie. Window: 24h after next send.