### PR TITLE
fix(brief): bundle resvg linux-x64-gnu native binding with carousel fn

### DIFF
--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -280,3 +280,41 @@ describe('brief magazine CSP override', () => {
     }
   });
 });
+
+// PR #3204: `vercel.json` is strict JSON (no comments allowed), so the
+// arch-assumption reasoning that would otherwise sit next to the
+// `includeFiles` entry lives here instead.
+//
+// Vercel Node serverless currently runs on Amazon Linux 2, x86_64,
+// glibc — so `@resvg/resvg-js/js-binding.js` resolves to
+// `@resvg/resvg-js-linux-x64-gnu` at cold start. Vercel's nft tracer
+// does NOT follow that conditional require, so the subpackage has to
+// be force-included via `functions.includeFiles`. If Vercel ever
+// migrates its Node pool to Graviton/arm64 (AWS Lambda supports it),
+// the correct subpackage becomes `@resvg/resvg-js-linux-arm64-gnu`
+// and the cold-start `MODULE_NOT_FOUND` crash silently returns with
+// no other signal. This block guards against both (a) the rule being
+// accidentally removed and (b) the glob drifting off the binding the
+// runtime actually loads.
+describe('brief carousel function native-binding bundling', () => {
+  const CAROUSEL_ROUTE = 'api/brief/carousel/[userId]/[issueDate]/[page].ts';
+  const EXPECTED_BINDING_GLOB = 'node_modules/@resvg/resvg-js-linux-x64-gnu/**';
+
+  it('forces the resvg linux-x64-gnu native binding into the carousel function bundle', () => {
+    const carouselFn = vercelConfig.functions?.[CAROUSEL_ROUTE];
+    assert.ok(
+      carouselFn,
+      `vercel.json functions.${CAROUSEL_ROUTE} entry is missing — without it, ` +
+        "Vercel nft doesn't trace @resvg/resvg-js's conditional require() and " +
+        'the function crashes at cold start with FUNCTION_INVOCATION_FAILED. ' +
+        'See PR #3204.',
+    );
+    assert.equal(
+      carouselFn.includeFiles,
+      EXPECTED_BINDING_GLOB,
+      'includeFiles must point at the Amazon Linux 2 x86_64 glibc binding that ' +
+        'Vercel Lambda actually requires at runtime. If Vercel migrates to ' +
+        'Graviton/arm64, update this glob to linux-arm64-gnu.',
+    );
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,11 @@
 {
   "ignoreCommand": "bash scripts/vercel-ignore.sh",
   "crons": [],
+  "functions": {
+    "api/brief/carousel/[userId]/[issueDate]/[page].ts": {
+      "includeFiles": "node_modules/@resvg/resvg-js-linux-x64-gnu/**"
+    }
+  },
   "redirects": [
     { "source": "/docs", "destination": "/docs/documentation", "permanent": false }
   ],


### PR DESCRIPTION
## The real root cause

Every single Telegram brief carousel attempt since PR #3174 merged has failed in production. PR #3196 (my middleware fix) addressed a theoretical UA-block path but the observed failure was actually deeper: the Vercel function itself crashes hard on cold start with `HTTP 500 FUNCTION_INVOCATION_FAILED` on every request — even `OPTIONS` — meaning the isolate cannot initialise.

Reproduced just now, ~4h after PR #3196 merged:

```bash
curl -I -H "User-Agent: TelegramBot (like TwitterBot)" \
  "https://www.worldmonitor.app/api/brief/carousel/user_test/2026-04-19/0"
HTTP/2 500
x-vercel-error: FUNCTION_INVOCATION_FAILED
```

OPTIONS / GET / HEAD — all 500. This is isolate boot failure, not a render error (which would 503 from our handler) and not middleware (which would 403 JSON).

## Why it crashes

`api/brief/carousel/[userId]/[issueDate]/[page].ts` imports `server/_shared/brief-carousel-render.ts`, which lazy-imports `@resvg/resvg-js`. That package's `js-binding.js` does:

```js
// node_modules/@resvg/resvg-js/js-binding.js
// ...
case "linux":
  switch (arch) {
    case "x64":
      // ...
      nativeBinding = require("@resvg/resvg-js-linux-x64-gnu");
```

A conditional `require` of a peer-optional package picked at runtime from `process.platform` + `process.arch` + `isMusl()`. On Vercel Lambda (Amazon Linux 2 glibc) that resolves to `@resvg/resvg-js-linux-x64-gnu`.

Vercel's `@vercel/build` node-file-trace does NOT follow this pattern — the optional peer is declared in `package.json`'s `optionalDependencies` but isn't pulled into the function's output bundle. At cold start the `require()` throws `MODULE_NOT_FOUND`, the isolate crashes during module evaluation, Vercel returns the generic `FUNCTION_INVOCATION_FAILED` page, and Telegram's `sendMediaGroup` reports it as `WEBPAGE_CURL_FAILED` (same failure mode we've been chasing since the feature shipped).

## Fix

Force the binding into the function's deploy bundle via `vercel.json` `functions.includeFiles`. Only the carousel route needs this — every other `api/*` route is unaffected.

```json
"functions": {
  "api/brief/carousel/[userId]/[issueDate]/[page].ts": {
    "includeFiles": "node_modules/@resvg/resvg-js-linux-x64-gnu/**"
  }
}
```

## Files

| File | Change |
|------|--------|
| `vercel.json` | Add `functions.includeFiles` rule scoping the linux-x64-gnu native binding to the carousel function only |

## Tests

- `npm run typecheck` clean (no TS change)
- `tests/deploy-config.test.mjs` 21/21 pass
- `node -e` validates the JSON shape
- Reproduced the 500 locally via `curl -I` across all methods and UAs
- Cross-referenced `node_modules/@resvg/resvg-js/js-binding.js` to confirm `linux-x64-gnu` is the exact subpackage Amazon Linux 2 will require at runtime

## Post-deploy validation

```bash
curl -I -H "User-Agent: TelegramBot (like TwitterBot)" \\
  "https://www.worldmonitor.app/api/brief/carousel/<userId>/<date>/0?t=<token>"
# Expect: HTTP/2 200, content-type: image/png
# Before this PR: HTTP/2 500 FUNCTION_INVOCATION_FAILED
```

Then wait for the next digest cron tick (30-min cadence) and confirm Railway log line `[digest] Telegram carousel 400` does NOT reappear. On the Telegram recipient side the 3-image album should finally land above the text.

## Why the previous fix matters too

PR #3196 (middleware carousel UA bypass) is still valid defence-in-depth. Without it, once the function itself starts returning 200 image/png, Telegram's fetcher would then be 403'd by `BOT_UA`. So both PRs together are what actually unblock the feature end-to-end. Merge order doesn't matter (both changes are independent and safe).

## Follow-ups (not in this PR)

- The font fetch from jsdelivr is still a runtime dep; if it ever flakes the render 503s. Worth bundling the TTF inline as a follow-up. Out of scope for this hotfix.
- The brief footer link in Telegram digests is still truncated off the 4096-char message. Separate issue — move footer to top of `telegramText` in `buildChannelBodies`.

## Test plan

- [x] deploy-config tests pass
- [x] JSON valid
- [ ] Post-merge: `curl -I` with TelegramBot UA returns 200
- [ ] Post-merge: next cron tick confirms carousel lands in Telegram