### PR TITLE
fix(brief): use wildcard glob in vercel.json functions key (PR #3204 follow-up)

### DIFF
--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -281,9 +281,9 @@ describe('brief magazine CSP override', () => {
   });
 });
 
-// PR #3204: `vercel.json` is strict JSON (no comments allowed), so the
-// arch-assumption reasoning that would otherwise sit next to the
-// `includeFiles` entry lives here instead.
+// PR #3204 / #follow-up: `vercel.json` is strict JSON (no comments
+// allowed), so the arch-assumption reasoning that would otherwise sit
+// next to the `includeFiles` entry lives here instead.
 //
 // Vercel Node serverless currently runs on Amazon Linux 2, x86_64,
 // glibc — so `@resvg/resvg-js/js-binding.js` resolves to
@@ -293,28 +293,53 @@ describe('brief magazine CSP override', () => {
 // migrates its Node pool to Graviton/arm64 (AWS Lambda supports it),
 // the correct subpackage becomes `@resvg/resvg-js-linux-arm64-gnu`
 // and the cold-start `MODULE_NOT_FOUND` crash silently returns with
-// no other signal. This block guards against both (a) the rule being
-// accidentally removed and (b) the glob drifting off the binding the
-// runtime actually loads.
+// no other signal.
+//
+// GOTCHA — discovered the hard way post-PR #3204: Vercel's
+// `functions` config keys use micromatch glob patterns, NOT literal
+// paths. So `"api/brief/carousel/[userId]/[issueDate]/[page].ts"`
+// is interpreted as a character-class expression (`[userId]` =
+// match any ONE character from {u,s,e,r,I,d}), the rule matches
+// zero files, and `includeFiles` is silently ignored. Use wildcard
+// path segments (`api/brief/carousel/**`) to actually catch files
+// under dynamic-segment routes. This block guards against the rule
+// being accidentally removed AND against the key reverting to a
+// literal-looking-but-glob-parsed path that matches nothing.
 describe('brief carousel function native-binding bundling', () => {
-  const CAROUSEL_ROUTE = 'api/brief/carousel/[userId]/[issueDate]/[page].ts';
+  const CAROUSEL_ROUTE_PATTERN = 'api/brief/carousel/**';
   const EXPECTED_BINDING_GLOB = 'node_modules/@resvg/resvg-js-linux-x64-gnu/**';
+  // Paranoia: make sure any key that uses dynamic-segment brackets
+  // literally (which Vercel reads as a glob character class, matching
+  // nothing) fails the test loudly instead of silently shipping.
+  const BRACKET_LITERAL_RE = /\[[A-Za-z]+\]/;
 
   it('forces the resvg linux-x64-gnu native binding into the carousel function bundle', () => {
-    const carouselFn = vercelConfig.functions?.[CAROUSEL_ROUTE];
+    const carouselFn = vercelConfig.functions?.[CAROUSEL_ROUTE_PATTERN];
     assert.ok(
       carouselFn,
-      `vercel.json functions.${CAROUSEL_ROUTE} entry is missing — without it, ` +
-        "Vercel nft doesn't trace @resvg/resvg-js's conditional require() and " +
-        'the function crashes at cold start with FUNCTION_INVOCATION_FAILED. ' +
-        'See PR #3204.',
+      `vercel.json functions.${CAROUSEL_ROUTE_PATTERN} entry is missing — ` +
+        "without it, Vercel nft doesn't trace @resvg/resvg-js's conditional " +
+        'require() and the function crashes at cold start with ' +
+        'FUNCTION_INVOCATION_FAILED. See PR #3204.',
     );
     assert.equal(
       carouselFn.includeFiles,
       EXPECTED_BINDING_GLOB,
-      'includeFiles must point at the Amazon Linux 2 x86_64 glibc binding that ' +
-        'Vercel Lambda actually requires at runtime. If Vercel migrates to ' +
-        'Graviton/arm64, update this glob to linux-arm64-gnu.',
+      'includeFiles must point at the Amazon Linux 2 x86_64 glibc binding ' +
+        'that Vercel Lambda actually requires at runtime. If Vercel migrates ' +
+        'to Graviton/arm64, update this glob to linux-arm64-gnu.',
     );
+  });
+
+  it('does not use literal dynamic-segment brackets (Vercel reads them as glob char classes)', () => {
+    for (const key of Object.keys(vercelConfig.functions ?? {})) {
+      assert.ok(
+        !BRACKET_LITERAL_RE.test(key),
+        `functions key "${key}" contains a bracketed segment — Vercel's ` +
+          'micromatch will interpret it as a character class and the rule ' +
+          'will match nothing. Use wildcard path segments (e.g. `**`) to ' +
+          'cover dynamic-segment routes.',
+      );
+    }
   });
 });

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -311,7 +311,11 @@ describe('brief carousel function native-binding bundling', () => {
   // Paranoia: make sure any key that uses dynamic-segment brackets
   // literally (which Vercel reads as a glob character class, matching
   // nothing) fails the test loudly instead of silently shipping.
-  const BRACKET_LITERAL_RE = /\[[A-Za-z]+\]/;
+  // Covers all common Next.js-style segment name shapes:
+  // [userId], [user_id], [issue_date], [page1], [slug2024], etc.
+  // A leading letter is required so legitimate glob char classes like
+  // [0-9] or [!abc] don't false-positive.
+  const BRACKET_LITERAL_RE = /\[[A-Za-z][A-Za-z0-9_]*\]/;
 
   it('forces the resvg linux-x64-gnu native binding into the carousel function bundle', () => {
     const carouselFn = vercelConfig.functions?.[CAROUSEL_ROUTE_PATTERN];
@@ -339,6 +343,36 @@ describe('brief carousel function native-binding bundling', () => {
           'micromatch will interpret it as a character class and the rule ' +
           'will match nothing. Use wildcard path segments (e.g. `**`) to ' +
           'cover dynamic-segment routes.',
+      );
+    }
+  });
+
+  // Self-test for the guard regex itself. Catches drift where someone
+  // narrows it and breaks the only thing standing between us and a
+  // silent re-regression of PR #3206.
+  it('bracket-literal regex catches common dynamic-segment shapes', () => {
+    for (const shape of [
+      'api/brief/carousel/[userId]/a.ts',
+      'api/brief/carousel/[user_id]/a.ts',
+      'api/brief/carousel/[issue_date]/a.ts',
+      'api/brief/carousel/[page1]/a.ts',
+      'api/foo/[slug2024]/a.ts',
+    ]) {
+      assert.ok(
+        BRACKET_LITERAL_RE.test(shape),
+        `regex should flag literal dynamic segment in "${shape}"`,
+      );
+    }
+    // Negative cases — legitimate glob syntax that should NOT trip.
+    for (const shape of [
+      'api/brief/carousel/**',
+      'api/brief/carousel/**/*.ts',
+      'api/foo/[0-9].ts',
+      'api/foo/[!abc].ts',
+    ]) {
+      assert.ok(
+        !BRACKET_LITERAL_RE.test(shape),
+        `regex should NOT flag valid glob "${shape}"`,
       );
     }
   });

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "ignoreCommand": "bash scripts/vercel-ignore.sh",
   "crons": [],
   "functions": {
-    "api/brief/carousel/[userId]/[issueDate]/[page].ts": {
+    "api/brief/carousel/**": {
       "includeFiles": "node_modules/@resvg/resvg-js-linux-x64-gnu/**"
     }
   },


### PR DESCRIPTION
## What I got wrong in PR #3204

Right diagnosis, right `includeFiles` value, **wrong key syntax**. I used the literal file path:

```json
"api/brief/carousel/[userId]/[issueDate]/[page].ts": { ... }
```

Vercel's `functions` config keys are **micromatch globs**, not literal paths. Bracketed segments like `[userId]` are parsed as **character classes** — `[userId]` matches any ONE character from `{u, s, e, r, I, d}`. So my rule matched zero files and `includeFiles` was silently dropped.

Post-PR-#3204-merge probe, ~20 min after deploy:

```bash
curl -I -H "User-Agent: TelegramBot (like TwitterBot)" \
  "https://www.worldmonitor.app/api/brief/carousel/user_3BovQ1tYlaz2YIGYAdDPXGFBgKy/2026-04-19/0"
HTTP/2 500
x-vercel-error: FUNCTION_INVOCATION_FAILED
```

Pulled the build log via the Vercel events API for `dpl_3gmAzLfvxdPTRwXjqz4GNTsmzfm8`: **zero** mentions of `carousel`, `resvg`, or `linux-x64-gnu`. Corroborates the `functions` rule never applied.

## Fix

Replace the bracketed-literal key with a wildcard:

```json
"api/brief/carousel/**": {
  "includeFiles": "node_modules/@resvg/resvg-js-linux-x64-gnu/**"
}
```

`api/brief/carousel/**` matches every file under the carousel route dir. Since the only deployed file there is the dynamic-segment handler, the effective scope is identical to my original intent — but Vercel can now actually see it.

## New regression guard

Added a second test in `tests/deploy-config.test.mjs` that walks every `functions` key and fails loudly if any bracketed segment slips back in:

```js
it('does not use literal dynamic-segment brackets (Vercel reads them as glob char classes)', () => {
  for (const key of Object.keys(vercelConfig.functions ?? {})) {
    assert.ok(!BRACKET_LITERAL_RE.test(key), ...);
  }
});
```

Without this, anyone looking at the old config format or copy-pasting the Vercel route path ("hey `[userId]/[issueDate]/[page].ts`, that's what's in my file tree") could silently revert the fix.

## Files

| File | Change |
|------|--------|
| `vercel.json` | `"api/brief/carousel/[userId]/[issueDate]/[page].ts"` → `"api/brief/carousel/**"` |
| `tests/deploy-config.test.mjs` | Updated existing test for the new key; added bracket-literal guard; expanded block comment with the gotcha |

## Tests

- `tsx --test tests/deploy-config.test.mjs` → 23/23 pass (was 22, +1 new guard)
- JSON valid
- Pre-push lint + version:check clean

## Post-deploy validation

Same probe as before — should now flip from 500 to a different status code:

```bash
curl -I -H "User-Agent: TelegramBot (like TwitterBot)" \\
  "https://www.worldmonitor.app/api/brief/carousel/<userId>/<date>/0?t=<token>"
# Expect: HTTP/2 200 image/png (with valid token)
# Or:     HTTP/2 403 forbidden JSON (no/invalid token — proves the isolate loaded fine)
# NOT:    HTTP/2 500 FUNCTION_INVOCATION_FAILED (what we had before)
```

A 403 (even without a valid token) is sufficient proof — it means the handler ran, parsed the URL, reached the token-verify step, and rejected cleanly. A 500 means the isolate still can't initialise.

After that confirms, wait for the next Railway digest cron tick (30-min cadence) and grep for `[digest] Telegram carousel 400` — should not reappear.

## Test plan

- [x] deploy-config tests 23/23 pass
- [x] Bracket-literal guard fires on the old (broken) key shape
- [ ] Post-merge: curl probe with TelegramBot UA returns != 500
- [ ] Post-merge: Railway log no longer emits `Telegram carousel 400`
- [ ] Post-merge: 3-image album actually lands in Telegram

## Skill update pending

Updating the `vercel-native-binding-peer-dep-missing` skill with this gotcha — anyone hitting the same pattern would step on the same rake.