### PR TITLE
fix(billing): wrap non-Error throws before Sentry.captureException

### DIFF
--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -67,8 +67,13 @@ export async function initSubscriptionWatch(_userId?: string): Promise<void> {
     initialized = true;
   } catch (err) {
     console.error('[billing] Failed to initialize subscription watch:', err);
-    // Do not rethrow -- billing service failure must not break the dashboard
-    Sentry.captureException(err, { tags: { component: 'dodo-billing', action: 'initSubscriptionWatch' } });
+    // Do not rethrow -- billing service failure must not break the dashboard.
+    // Convex/Clerk bootstrap rarely rejects with a non-Error value; wrap so Sentry
+    // gets a useful stack + message instead of synthetic `Error: undefined` (WORLDMONITOR-ND).
+    const normalized = err instanceof Error
+      ? err
+      : new Error(`[billing] initSubscriptionWatch threw non-Error: ${err === undefined ? 'undefined' : String(err)}`);
+    Sentry.captureException(normalized, { tags: { component: 'dodo-billing', action: 'initSubscriptionWatch' } });
   }
 }
 

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -28,12 +28,17 @@ let unsubscribeConvex: (() => void) | null = null;
 
 // Convex/Clerk bootstrap rarely rejects with a non-Error value (undefined, null, string).
 // Sentry serializes those as synthetic `Error: undefined` with zero frames — uninvestigable.
-// Normalize to a real Error carrying the offending value so events remain debuggable
-// (WORLDMONITOR-ND).
+// Normalize to a real Error carrying the offending value both in the message (for log/search)
+// and as `cause` (for Sentry's structured display) so events remain debuggable (WORLDMONITOR-ND).
 function normalizeCaughtError(action: string, err: unknown): Error {
-  return err instanceof Error
-    ? err
-    : new Error(`[billing] ${action} threw non-Error: ${err === undefined ? 'undefined' : String(err)}`);
+  if (err instanceof Error) return err;
+  const rendered = err === undefined ? 'undefined' : String(err);
+  const wrapped = new Error(`[billing] ${action} threw non-Error: ${rendered}`);
+  // Attach the original thrown value as `cause` so Sentry shows it as structured data.
+  // Assigned post-construction because tsconfig target=ES2020 lacks ErrorOptions typing;
+  // Sentry and modern browsers read the property either way.
+  (wrapped as Error & { cause?: unknown }).cause = err;
+  return wrapped;
 }
 
 /**

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -26,6 +26,16 @@ const listeners = new Set<(sub: SubscriptionInfo | null) => void>();
 let initialized = false;
 let unsubscribeConvex: (() => void) | null = null;
 
+// Convex/Clerk bootstrap rarely rejects with a non-Error value (undefined, null, string).
+// Sentry serializes those as synthetic `Error: undefined` with zero frames — uninvestigable.
+// Normalize to a real Error carrying the offending value so events remain debuggable
+// (WORLDMONITOR-ND).
+function normalizeCaughtError(action: string, err: unknown): Error {
+  return err instanceof Error
+    ? err
+    : new Error(`[billing] ${action} threw non-Error: ${err === undefined ? 'undefined' : String(err)}`);
+}
+
 /**
  * Initialize the subscription watch for the authenticated user.
  * Idempotent -- calling multiple times is a no-op after the first.
@@ -67,13 +77,11 @@ export async function initSubscriptionWatch(_userId?: string): Promise<void> {
     initialized = true;
   } catch (err) {
     console.error('[billing] Failed to initialize subscription watch:', err);
-    // Do not rethrow -- billing service failure must not break the dashboard.
-    // Convex/Clerk bootstrap rarely rejects with a non-Error value; wrap so Sentry
-    // gets a useful stack + message instead of synthetic `Error: undefined` (WORLDMONITOR-ND).
-    const normalized = err instanceof Error
-      ? err
-      : new Error(`[billing] initSubscriptionWatch threw non-Error: ${err === undefined ? 'undefined' : String(err)}`);
-    Sentry.captureException(normalized, { tags: { component: 'dodo-billing', action: 'initSubscriptionWatch' } });
+    // Do not rethrow -- billing service failure must not break the dashboard
+    Sentry.captureException(
+      normalizeCaughtError('initSubscriptionWatch', err),
+      { tags: { component: 'dodo-billing', action: 'initSubscriptionWatch' } },
+    );
   }
 }
 
@@ -148,7 +156,10 @@ export async function openBillingPortal(): Promise<string | null> {
     return url;
   } catch (err) {
     console.warn('[billing] Failed to get customer portal URL, falling back:', err);
-    Sentry.captureException(err, { tags: { component: 'dodo-billing', action: 'openBillingPortal' } });
+    Sentry.captureException(
+      normalizeCaughtError('openBillingPortal', err),
+      { tags: { component: 'dodo-billing', action: 'openBillingPortal' } },
+    );
     window.open(DODO_PORTAL_FALLBACK_URL, '_blank');
     return DODO_PORTAL_FALLBACK_URL;
   }


### PR DESCRIPTION
## Summary
- Convex/Clerk bootstrap occasionally rejects with `undefined`. `billing.ts` was passing the raw falsy `err` to `Sentry.captureException`, which serialized it as a synthetic `Error: undefined` with zero stack frames (see WORLDMONITOR-ND).
- Normalize `err` to a real `Error` carrying the non-Error value in its message, so the next occurrence produces a usable, debuggable Sentry event.
- Resolves WORLDMONITOR-ND.

## Test plan
- [x] `npm run typecheck` + `typecheck:api` green
- [x] `npm run test:data` passes (5772 tests)
- [x] `node --test tests/edge-functions.test.mjs` passes (171 tests)
- [x] `npm run lint` / `lint:md` / `version:check` clean
- [ ] Next occurrence in Sentry should carry a real stack + message rather than synthetic `Error: undefined`