### PR TITLE
fix(convex): use ConvexError for AUTH_REQUIRED so Sentry treats it as expected

### DIFF
--- a/convex/lib/auth.ts
+++ b/convex/lib/auth.ts
@@ -1,3 +1,4 @@
+import { ConvexError } from "convex/values";
 import { QueryCtx, MutationCtx, ActionCtx } from "../_generated/server";
 
 export const DEV_USER_ID = "test-user-001";
@@ -55,7 +56,11 @@ export async function requireUserId(
 ): Promise<string> {
   const userId = await resolveUserId(ctx);
   if (!userId) {
-    throw new Error("Authentication required");
+    // Throw as ConvexError so Convex's server-side Sentry integration treats it
+    // as an expected business error (WebSocket/auth races on query fire) rather
+    // than reporting every unauthed query fire as an unhandled exception
+    // (WORLDMONITOR-N3).
+    throw new ConvexError("AUTH_REQUIRED");
   }
   return userId;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -248,6 +248,7 @@ Sentry.init({
     /Possible side-effect in debug-evaluate/, // Chrome DevTools internal EvalError
     /ConvexError: CONFLICT/, // Expected OCC rejection on concurrent preference saves
     /ConvexError: API_ACCESS_REQUIRED/, // Expected business error: free user opens API Keys tab; client handles gracefully (UnifiedSettings.ts:731-738) — WORLDMONITOR-NA
+    /ConvexError: AUTH_REQUIRED/, // Expected business error: query fires before Convex WS auth handshake completes; subscription error handler recovers — WORLDMONITOR-N3
     /\[CONVEX [AQM]\(.+?\)\] Connection lost while action was in flight/, // Convex SDK transient WS disconnect
     /Response did not contain `success` or `data`/, // DuckDuckGo browser internal tracker/content-block response — never emitted by our code
     /Cannot set properties of undefined \(setting 'bodyTouched'\)/, // Quark browser (Alibaba mobile) touch-tracking script injection (WORLDMONITOR-N1)

--- a/src/main.ts
+++ b/src/main.ts
@@ -248,7 +248,6 @@ Sentry.init({
     /Possible side-effect in debug-evaluate/, // Chrome DevTools internal EvalError
     /ConvexError: CONFLICT/, // Expected OCC rejection on concurrent preference saves
     /ConvexError: API_ACCESS_REQUIRED/, // Expected business error: free user opens API Keys tab; client handles gracefully (UnifiedSettings.ts:731-738) — WORLDMONITOR-NA
-    /ConvexError: AUTH_REQUIRED/, // Expected business error: query fires before Convex WS auth handshake completes; subscription error handler recovers — WORLDMONITOR-N3
     /\[CONVEX [AQM]\(.+?\)\] Connection lost while action was in flight/, // Convex SDK transient WS disconnect
     /Response did not contain `success` or `data`/, // DuckDuckGo browser internal tracker/content-block response — never emitted by our code
     /Cannot set properties of undefined \(setting 'bodyTouched'\)/, // Quark browser (Alibaba mobile) touch-tracking script injection (WORLDMONITOR-N1)


### PR DESCRIPTION
## Summary
- WORLDMONITOR-N3: server-side Convex was reporting `Uncaught Error: Authentication required` (8 events / 2 users) every time a query fired before the WebSocket auth handshake completed.
- `convex/lib/auth.ts::requireUserId` was throwing a plain `Error` — Convex's server-side Sentry integration treats those as unhandled. Every other business error in this repo uses `ConvexError("CODE")` (see checkout.ts, notificationChannels.ts, apiKeys.ts), which Convex treats as expected.
- Migrated to `ConvexError("AUTH_REQUIRED")`. Verified no consumer parses the message string (the one `src/App.ts:879` reference is a code comment).
- Added a matching client-side `ignoreErrors` entry in `src/main.ts` next to the existing `API_ACCESS_REQUIRED` precedent — defense-in-depth against the rare case the error propagates to the browser SDK as an unhandled rejection.

## Test plan
- [x] `npm run typecheck` + `typecheck:api` green
- [x] `npm run test:data` passes (5772 tests)
- [x] `node --test tests/edge-functions.test.mjs` passes (171 tests)
- [x] `npm run lint` / `lint:md` / `version:check` clean
- [ ] Next unauthed-query event in Sentry should no longer be reported from Convex backend

Resolves WORLDMONITOR-N3.