### PR TITLE
fix(sentry): filter MapLibre AJAXError tile-fetch transients

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -276,6 +276,14 @@ Sentry.init({
     if ((excType === 'TypeError' || excType === 'RangeError' || /^(?:TypeError|RangeError):/.test(msg)) && frames.length > 0) {
       if (nonInfraFrames.length > 0 && nonInfraFrames.every(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     }
+    // Suppress MapLibre AJAXError for raster tile fetches: maplibre wraps transient network
+    // errors as `Failed to fetch (<hostname>)` and rethrows in a Generator-backed Promise
+    // that leaks to onunhandledrejection even though DeckGLMap's map-error handler already
+    // logs it as a warning. Our own fetch code throws plain `Failed to fetch` (no paren
+    // suffix); the `(hostname)` format is maplibre-specific, and requiring a maplibre
+    // vendor frame guards against hiding first-party regressions (WORLDMONITOR-NE/NF).
+    if (excType === 'TypeError' && /^Failed to fetch \([^)]+\)$/.test(msg)
+        && frames.some(f => /\/maplibre-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     // Suppress Three.js/globe.gl TypeError crashes in main bundle (reading 'type'/'pathType'/'count'/'__globeObjType' on undefined during WebGL traversal/raycast).
     // __globeObjType is exclusively set by three-globe on its own objects and we have no user onClick/onHover handler, so it is always globe.gl internal even when the stack shows the bundled main chunk (WORLDMONITOR-ME).
     if (/reading '__globeObjType'|__globeObjType/.test(msg)) return null;

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -303,6 +303,30 @@ describe('existing beforeSend filters', () => {
     assert.ok(beforeSend(event) !== null, 'First-party setPointerCapture regression must reach Sentry even when unsymbolicated');
   });
 
+  it('suppresses MapLibre AJAXError "Failed to fetch (<hostname>)" with a maplibre vendor frame', () => {
+    const event = makeEvent('Failed to fetch (tilecache.rainviewer.com)', 'TypeError', [
+      { filename: '/assets/maplibre-A8Ca0ysS.js', lineno: 4, function: 'ajaxFetch' },
+      { filename: '/assets/panels-wF5GXf0N.js', lineno: 24, function: 'window.fetch' },
+    ]);
+    assert.equal(beforeSend(event), null, 'MapLibre tile AJAX failure should be suppressed');
+  });
+
+  it('does NOT suppress plain "Failed to fetch" from first-party code without maplibre frames', () => {
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: '/assets/panels-wF5GXf0N.js', lineno: 100, function: 'MyApiCall' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'Plain first-party fetch failure should surface');
+  });
+
+  it('does NOT suppress "Failed to fetch (<hostname>)" when no maplibre frame is present', () => {
+    // Guards against broad message-only suppression hiding a real first-party fetch
+    // regression that happens to wrap host into the message.
+    const event = makeEvent('Failed to fetch (api.worldmonitor.app)', 'TypeError', [
+      { filename: '/assets/panels-wF5GXf0N.js', lineno: 100, function: 'MyApiCall' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'Non-maplibre Failed-to-fetch must reach Sentry');
+  });
+
   it('does NOT suppress setPointerCapture NotFoundError when no frame context is present', () => {
     // Defensive: if Sentry strips context, we err on the side of surfacing.
     const event = makeEvent(


### PR DESCRIPTION
## Summary
- WORLDMONITOR-NE / WORLDMONITOR-NF (8 events, 1 user, Chrome 147/Windows): MapLibre wraps `tilecache.rainviewer.com` tile-fetch failures as `TypeError: Failed to fetch (<hostname>)` and rethrows inside a Generator-backed Promise. That leaks to `onunhandledrejection` even though DeckGLMap's map-error handler already logs them as a warning. Triggered mostly by adblockers / extensions / flaky mobile networks (one stack even passed through `chrome-extension://hoklmmgfnpapgjgcpechhaamimifchmp/frame_ant` wrapping fetch).
- Existing `!hasFirstParty` fetch filter only matches exact `Failed to fetch` (no hostname suffix) and fails because `panels-*.js:window.fetch` counts as first-party.
- New filter in `beforeSend` gated on two positive signals: (a) the maplibre-specific paren message format `Failed to fetch (hostname)` (our own fetch code throws plain `Failed to fetch` without hostname), and (b) a `/maplibre-*.js/` frame in the stack. Keeps a first-party `Failed to fetch (api.worldmonitor.app)` regression surfaced.

## Test plan
- [x] `npm run typecheck` + `typecheck:api` green
- [x] `npm run test:data` passes (5772 tests)
- [x] `node --test tests/sentry-beforesend.test.mjs` passes (98 tests, +3 new)
  - positive: maplibre frame → suppressed
  - negative: plain `Failed to fetch` from first-party → surfaces
  - negative: `Failed to fetch (api.worldmonitor.app)` without maplibre frame → surfaces
- [x] `npm run lint` / `lint:md` / `version:check` clean
- [ ] After next deploy, WORLDMONITOR-NE/NF should stay closed

Resolves WORLDMONITOR-NE, WORLDMONITOR-NF.