### PR TITLE
fix(health): align breadthHistory maxStaleMin with actual Tue-Sat cron schedule

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -310,7 +310,7 @@ const SEED_META = {
   ecbEuribor1y:      { key: 'seed-meta:economic:ecb-short-rates',   maxStaleMin: 4320 }, // shared meta key with ecbEstr
   gscpi:             { key: 'seed-meta:economic:gscpi',               maxStaleMin: 2880 }, // 24h interval; 2880min = 48h = 2x interval
   fearGreedIndex:    { key: 'seed-meta:market:fear-greed',            maxStaleMin: 720 }, // 6h cron; 720min = 12h = 2x interval
-  breadthHistory:    { key: 'seed-meta:market:breadth-history',       maxStaleMin: 2880 }, // daily cron at 21:00 ET; 2880min = 48h = 2x interval
+  breadthHistory:    { key: 'seed-meta:market:breadth-history',       maxStaleMin: 5760 }, // cron at 02:00 UTC, Tue-Sat (captures Mon-Fri market close); max gap Sat→Tue = 72h + 24h miss buffer = 96h = 5760min. 48h was wrong — alarmed every Monday morning when Sun+Mon are intentionally skipped.
   hormuzTracker:     { key: 'seed-meta:supply_chain:hormuz_tracker',  maxStaleMin: 2880 }, // daily cron; 2880min = 48h = 2x interval
   earningsCalendar:  { key: 'seed-meta:market:earnings-calendar',     maxStaleMin: 1440 }, // 12h cron; 1440min = 24h = 2x interval
   econCalendar:      { key: 'seed-meta:economic:econ-calendar',       maxStaleMin: 1440 }, // 12h cron; 1440min = 24h = 2x interval


### PR DESCRIPTION
## Summary

Fixes a false-positive `STALE_SEED` alarm on `breadthHistory` that fires every Monday morning UTC — not a seeder bug, a **schedule/threshold mismatch**.

## Evidence

Railway logs for `seed-market-breadth`:
\`\`\`
Apr 16 02:01 UTC  Done (6527ms)  3/3 readings, appended 2026-04-15
Apr 17 02:00 UTC  Done (5996ms)  3/3 readings, appended 2026-04-16
Apr 18 02:01 UTC  Done (5942ms)  3/3 readings, appended 2026-04-17
Apr 18 03:06 UTC  Stopping Container       ← normal Railway cron teardown
(nothing Apr 19 / Apr 20 — Sun/Mon not in schedule)
\`\`\`

Actual cron schedule: `02:00 UTC, Tuesday through Saturday` (captures Mon–Fri market close → following-day UTC).

Old threshold: `maxStaleMin: 2880` (48h) assumed daily cadence.

Real max gap: **Sat 02:00 UTC → Tue 02:00 UTC = 72h**. Every Monday morning, the 48h threshold tripped. Seeder was working perfectly the entire time.

## Fix

| | Old | New |
|---|---|---|
| `maxStaleMin` | 2880 (48h) | **5760 (96h)** |
| Comment | `"daily cron at 21:00 ET"` (wrong — not daily, not ET) | accurate Tue–Sat UTC schedule + reasoning |

96h = weekend gap (72h) + 24h tolerance for one missed Tue tick. Still alarms on a real outage (two consecutive missed Tue+Wed ticks = ~120h).

## No other changes needed

- Seeder code is fine — verified scrapes 3/3 Barchart symbols every run.
- Railway service is running on schedule — not a cron-freeze.
- `api/seed-health.js` has no entry for `market:breadth-history`, so no second registry to sync.

## Deploy / rollback

Single config line. Vercel auto-deploys. Revert is trivial.

---

🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.49.0

Co-Authored-By: Claude <noreply@anthropic.com>