### PR TITLE
feat(scoring): set data-driven score gate thresholds (82/69/63)

### DIFF
--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -626,10 +626,11 @@ function shouldNotify(rule, event) {
 
   if (process.env.IMPORTANCE_SCORE_LIVE === '1' && event.payload?.importanceScore != null) {
     // Calibrated from v5 shadow-log recalibration (2026-04-20).
-    // Adjustable via env: IMPORTANCE_SCORE_MIN overrides the 'all' floor.
+    // IMPORTANCE_SCORE_MIN env var controls the 'all' floor at both the
+    // relay ingress gate AND per-rule sensitivity — single tuning surface.
     const threshold = rule.sensitivity === 'critical' ? 82
                     : rule.sensitivity === 'high' ? 69
-                    : 63; // 'all'
+                    : IMPORTANCE_SCORE_MIN;
     return event.payload.importanceScore >= threshold;
   }
 

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -625,9 +625,11 @@ function shouldNotify(rule, event) {
   if (!passesLegacy) return false;
 
   if (process.env.IMPORTANCE_SCORE_LIVE === '1' && event.payload?.importanceScore != null) {
-    const threshold = rule.sensitivity === 'critical' ? 85
-                    : rule.sensitivity === 'high' ? 65
-                    : 40; // 'all'
+    // Calibrated from v5 shadow-log recalibration (2026-04-20).
+    // Adjustable via env: IMPORTANCE_SCORE_MIN overrides the 'all' floor.
+    const threshold = rule.sensitivity === 'critical' ? 82
+                    : rule.sensitivity === 'high' ? 69
+                    : 63; // 'all'
     return event.payload.importanceScore >= threshold;
   }
 


### PR DESCRIPTION
## Summary

Final step in the scoring pipeline activation. Sets the threshold constants in `shouldNotify()` to data-driven values calibrated from v5 shadow-log recalibration.

## Changes

One file: `scripts/notification-relay.cjs:628-630`

```
critical sensitivity: 85 → 82  (Hormuz closures, ship seizures, ceasefire collapses)
high sensitivity:     65 → 69  (mass shootings, blockade enforcement, major diplomatic)
all/default MIN:      40 → 63  (drops tutorials, domestic crime, niche commodity)
```

## Activation

After this PR merges, set on Railway `notification-relay` service:

```
IMPORTANCE_SCORE_LIVE=1
IMPORTANCE_SCORE_MIN=63
```

Both env vars can be adjusted without a code deploy if thresholds need tuning.

## Scoring pipeline journey

| PR | What | Pearson |
|---|---|---|
| #3069 | Fixed stale relay score + shadow-log v2 | 0.31 → 0.41 |
| #3143 | Closed /api/notify bypass | — |
| #3144 | Weight rebalance (severity 55%) | 0.41 → 0.67 |
| #3218 | LLM prompt upgrade + cache v2 | — |
| #3221 | Geopolitical scope for critical | — |
| **This PR** | **Threshold constants** | — |

## Testing

- `node -c scripts/notification-relay.cjs` passes
- No test changes needed (thresholds are runtime constants, not structure)

## Post-Deploy Monitoring & Validation

- **What to monitor after setting IMPORTANCE_SCORE_LIVE=1**
  - Logs: `[relay] Score gate: dropped` lines — should appear for ~20-35% of rss_alert events (the noise floor)
  - Logs: ensure critical/high events still generate `[relay] Processing event` lines after the gate
  - Telegram/Slack: spot-check that real geopolitical alerts still deliver
- **Failure signals**
  - Zero alerts in 24h → threshold too high, lower IMPORTANCE_SCORE_MIN
  - Domestic crime/tutorial alerts still firing → LLM not classifying correctly, check classify:sebuf:v3 cache
- **Rollback**: unset `IMPORTANCE_SCORE_LIVE` on Railway dashboard (instant, no deploy)
- **Validation window**: 24h
- **Owner**: koala73

🤖 Generated with Claude Opus 4.6 via [Claude Code](https://claude.com/claude-code)