### PR TITLE
feat(digest): DIGEST_SCORE_MIN absolute score floor for the brief

### DIFF
--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -80,6 +80,19 @@ const AI_SUMMARY_CACHE_TTL = 3600; // 1h
 const AI_DIGEST_ENABLED = process.env.AI_DIGEST_ENABLED !== '0';
 const ENTITLEMENT_CACHE_TTL = 900; // 15 min
 
+// Absolute importance-score floor applied to the digest AFTER dedup.
+// Mirrors the realtime notification-relay gate (IMPORTANCE_SCORE_MIN)
+// but lives on the brief/digest side so operators can tune them
+// independently — e.g. let realtime page at score>=63 while the brief
+// digest drops anything <50. Default 0 = no filtering; ship disabled
+// so this PR is a no-op until Railway flips the env. Setting the var
+// to any positive integer drops every cluster whose representative
+// currentScore is below it.
+function getDigestScoreMin() {
+  const raw = Number.parseInt(process.env.DIGEST_SCORE_MIN ?? '0', 10);
+  return Number.isInteger(raw) && raw >= 0 ? raw : 0;
+}
+
 // ── Brief composer (consolidation of the retired seed-brief-composer) ──────
 
 const BRIEF_URL_SIGNING_SECRET = process.env.BRIEF_URL_SIGNING_SECRET ?? '';
@@ -276,7 +289,21 @@ async function buildDigest(rule, windowStartMs) {
   if (stories.length === 0) return null;
 
   stories.sort((a, b) => b.currentScore - a.currentScore);
-  const deduped = await deduplicateStories(stories);
+  const dedupedAll = await deduplicateStories(stories);
+  // Apply the absolute-score floor AFTER dedup so the floor runs on
+  // the representative's score (mentionCount-sum doesn't change the
+  // score field; the rep is the highest-scoring member of its
+  // cluster). At DIGEST_SCORE_MIN=0 this is a no-op.
+  const scoreFloor = getDigestScoreMin();
+  const deduped = scoreFloor > 0
+    ? dedupedAll.filter((s) => Number(s.currentScore ?? 0) >= scoreFloor)
+    : dedupedAll;
+  if (scoreFloor > 0 && dedupedAll.length !== deduped.length) {
+    console.log(
+      `[digest] score floor dropped ${dedupedAll.length - deduped.length} ` +
+        `of ${dedupedAll.length} clusters (DIGEST_SCORE_MIN=${scoreFloor})`,
+    );
+  }
   const top = deduped.slice(0, DIGEST_MAX_ITEMS);
 
   const allSourceCmds = [];

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -304,6 +304,21 @@ async function buildDigest(rule, windowStartMs) {
         `of ${dedupedAll.length} clusters (DIGEST_SCORE_MIN=${scoreFloor})`,
     );
   }
+  // If the floor drained every cluster, return null with a distinct
+  // log line so operators can tell "floor too high" apart from "no
+  // stories in window" (the caller treats both as a skip but the
+  // root causes are different — without this line the main-loop
+  // "No stories in window" message never fires because [] is truthy
+  // and silences the diagnostic at the caller's guard).
+  if (deduped.length === 0) {
+    if (scoreFloor > 0 && dedupedAll.length > 0) {
+      console.log(
+        `[digest] score floor dropped ALL ${dedupedAll.length} clusters ` +
+          `(DIGEST_SCORE_MIN=${scoreFloor}) — skipping user`,
+      );
+    }
+    return null;
+  }
   const top = deduped.slice(0, DIGEST_MAX_ITEMS);
 
   const allSourceCmds = [];

--- a/tests/digest-score-floor.test.mjs
+++ b/tests/digest-score-floor.test.mjs
@@ -80,4 +80,25 @@ describe('DIGEST_SCORE_MIN env floor', () => {
       'log fragment with the scoreFloor value must be present',
     );
   });
+
+  it('returns null when floor drains every cluster (caller skips cleanly)', () => {
+    // Greptile P2 regression: if buildDigest returned [] rather than
+    // null when the floor emptied the list, the caller's `if (!stories)`
+    // guard (which checks falsiness, so [] slips through) would stop
+    // logging the canonical "No stories in window" line, and the
+    // only skip-signal would be a swallowed formatDigest=>null at the
+    // `!storyListPlain` check. Contract is: empty-after-floor returns
+    // null so the caller takes the same path as pre-dedup-empty.
+    assert.match(src, /if\s*\(\s*deduped\.length\s*===\s*0\s*\)\s*\{/);
+    // A distinct log line fires BEFORE the return so operators can
+    // tell "floor too high" apart from "no news today".
+    assert.ok(
+      src.includes('score floor dropped ALL'),
+      'distinct "dropped ALL" log line must fire when the floor drains everything',
+    );
+    assert.ok(
+      src.includes('skipping user'),
+      'log line must mention the user is being skipped',
+    );
+  });
 });

--- a/tests/digest-score-floor.test.mjs
+++ b/tests/digest-score-floor.test.mjs
@@ -1,0 +1,83 @@
+/**
+ * Regression tests for the DIGEST_SCORE_MIN floor applied after the
+ * dedup step in scripts/seed-digest-notifications.mjs.
+ *
+ * Matches the repo's existing pattern for digest-mode regression
+ * tests (read the source, assert structural invariants) — the cron
+ * has a top-level env-exit block that makes importing it at test
+ * time fragile, so we guard on shape instead.
+ *
+ * Run: node --test tests/digest-score-floor.test.mjs
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(
+  resolve(__dirname, '../scripts/seed-digest-notifications.mjs'),
+  'utf-8',
+);
+
+describe('DIGEST_SCORE_MIN env floor', () => {
+  it('reads DIGEST_SCORE_MIN from process.env at call time', () => {
+    // Function-based read — not a module-level constant — so Railway
+    // env flips take effect on the next cron tick without a redeploy.
+    assert.match(src, /function\s+getDigestScoreMin\s*\(\)\s*\{/);
+    assert.match(src, /process\.env\.DIGEST_SCORE_MIN/);
+  });
+
+  it('default is 0 (no-op) so this PR is a behaviour-neutral ship', () => {
+    assert.match(src, /process\.env\.DIGEST_SCORE_MIN\s*\?\?\s*['"]0['"]/);
+  });
+
+  it('rejects non-integer / negative values', () => {
+    // The parser returns 0 on NaN / negative so a misconfigured env
+    // value degrades to "no floor" rather than blowing up the cron.
+    assert.match(src, /Number\.isInteger\(raw\)\s*&&\s*raw\s*>=\s*0\s*\?\s*raw\s*:\s*0/);
+  });
+
+  it('filter runs AFTER deduplicateStories (score is the rep cluster score)', () => {
+    // The representative's currentScore is the max within its cluster
+    // (materializeCluster sorts by currentScore DESC and takes items[0]),
+    // so filtering after dedup only drops clusters whose HIGHEST-scoring
+    // member is below the floor.
+    const dedupIdx = src.indexOf('await deduplicateStories(stories)');
+    const filterIdx = src.indexOf('dedupedAll.filter');
+    const sliceIdx = src.indexOf('DIGEST_MAX_ITEMS');
+    assert.ok(dedupIdx > 0, 'deduplicateStories call must exist');
+    assert.ok(filterIdx > 0, 'score-floor filter must exist');
+    assert.ok(dedupIdx < filterIdx, 'filter must run after dedup');
+    assert.ok(
+      filterIdx < src.indexOf('.slice(0, DIGEST_MAX_ITEMS)'),
+      'filter must run before the top-30 slice',
+    );
+    void sliceIdx;
+  });
+
+  it('short-circuits when floor is 0 (no wasted filter pass)', () => {
+    assert.match(
+      src,
+      /scoreFloor\s*>\s*0\s*\n?\s*\?\s*dedupedAll\.filter/,
+    );
+  });
+
+  it('logs a "dropped N of M clusters" line when the floor fires', () => {
+    // Operators need to know how aggressive the floor is. Silent
+    // filtering on a per-tick basis would make it impossible to
+    // notice that the floor is dropping too much. The log spans
+    // two template fragments (concatenated with +) so we assert on
+    // the fragments independently rather than a cross-line regex.
+    assert.ok(
+      src.includes('score floor dropped'),
+      'log fragment "score floor dropped" must be present',
+    );
+    assert.ok(
+      src.includes('clusters (DIGEST_SCORE_MIN=${scoreFloor})'),
+      'log fragment with the scoreFloor value must be present',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The digest cron ranks stories by `currentScore` and slices top-30, but has **no absolute score floor** — on slow news days low-importance items bubble up to fill slots. PR #3223 added the realtime-side gate (`IMPORTANCE_SCORE_MIN=63`), but the digest path reads the same `story:track:*.currentScore` without any corresponding threshold.

This PR adds a mirror knob for the digest side. Default 0 = no-op, PR is behaviour-neutral until Railway flips the env.

## Motivation

Sample brief (2026-04-20 08:00) contained 12 stories, 7 of which were duplicates of 4 events, plus low-importance filler (niche commodity, domestic crime). Duplication is tracked separately (dedup cosine threshold); THIS PR addresses the low-importance leak.

## Changes

`scripts/seed-digest-notifications.mjs`:
- `getDigestScoreMin()` reads `DIGEST_SCORE_MIN` from `process.env` at call time (no redeploy for Railway flips).
- Filter applied **after** `deduplicateStories()` so it drops clusters by the representative's score (highest-scoring member of its cluster).
- Short-circuits at `scoreFloor === 0` (no wasted filter pass in the default/no-op case).
- Emits `[digest] score floor dropped N of M clusters (DIGEST_SCORE_MIN=X)` only when the floor actually drops something.

`tests/digest-score-floor.test.mjs` — 6 regressions covering env read, default, negative-value rejection, filter ordering, short-circuit, and log fragment.

## Operator activation

After merge, set on Railway `seed-digest-notifications`:
```
DIGEST_SCORE_MIN=63
```
Matches `notification-relay`'s gate to start. Tune up/down based on the log lines over ~24h. Unset (or 0) = pre-PR behaviour.

## Why not bundle a cosine-threshold bump

`DIGEST_DEDUP_COSINE_THRESHOLD` is already env-gated by the dedup orchestrator. Bundling a default change here would slow rollback. Operator flips that env var on Railway as a separate action.

## Test plan

- [x] `npm run test:data` — 5825/5825 pass
- [x] `tests/digest-score-floor` — 6/6 pass
- [x] `tests/edge-functions` — 171/171 pass
- [x] `npm run typecheck` + `typecheck:api` — clean
- [x] `biome check` on changed files — clean (pre-existing `main()` complexity warning is unchanged)
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK

## Post-Deploy Monitoring & Validation

- **What to monitor** after setting `DIGEST_SCORE_MIN` on Railway:
  - `[digest] score floor dropped` lines
  - `[digest] Cron run complete: N digest(s) sent` stays > 0
- **Expected healthy behaviour**
  - 0-5 clusters dropped on normal ~80-story ticks
  - 50-200 dropped on bulk 700+ story ticks
  - Brief still reports 10-30 stories for PRO users
- **Failure signals / rollback**
  - 0 digests sent for 24h after flipping the var → threshold too high
  - User-visible brief now has < 10 stories → threshold too high
  - **Rollback**: unset `DIGEST_SCORE_MIN` on Railway dashboard (instant, no deploy)
- **Validation window**: 24h
- **Owner**: koala73

## Related

- #3218 LLM prompt upgrade (source of `importanceScore` quality)
- #3221 geopolitical scope for critical
- #3223 notification-relay realtime gate (mirror knob)
- #3200 embedding-based dedup (the other half of brief quality)