### PR TITLE
feat(portwatch): globalise EP3 — one paginated fetch, in-memory groupBy

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -118,22 +118,36 @@ async function fetchAllPortRefs() {
   return byIso3;
 }
 
-// Fetch ALL activity rows globally in one paginated pass, grouped by ISO3.
+// Stream-aggregate ALL activity rows into per-port running counters.
 // Replaces 174× per-country WHERE=ISO3 round-trips (which hit ~90s each at
 // concurrency 12, far exceeding the 420s section budget even when none of
 // them hung) with a single sequential loop of ~150-200 pages that completes
 // comfortably inside the section budget. Also eliminates the `Invalid query
 // parameters` errors we saw in prod for BRA/IDN/NGA on the per-country
-// filter: the global WHERE does not involve an ISO3 equality on the feature
-// server, so those failure modes disappear.
+// filter: the global WHERE has no ISO3 equality, so those failure modes
+// disappear.
 //
-// Returns Map<iso3, Feature[]>. Aborts between pages when signal.aborted.
-async function fetchAllActivityRows(since, { signal, progress } = {}) {
-  const byIso3 = new Map();
+// Memory: each page's features are folded into Map<iso3, Map<portId, Accum>>
+// and discarded. We never materialise the full 180k+ rows at once; only
+// ~2000 accumulators (≈100 bytes each = ~200KB) live across pages. Review
+// feedback on PR #3225 flagged the prior shape (Map<iso3, Feature[]>) as an
+// OOM risk on the 1GB Railway container — this addresses it.
+//
+// Returns Map<iso3, Map<portId, PortAccum>>. Aborts between pages when
+// signal.aborted is set.
+async function fetchAndAggregateActivity(since, { signal, progress } = {}) {
+  const now = Date.now();
+  const cutoff30 = now - 30 * 86400000;
+  const cutoff60 = now - 60 * 86400000;
+  const cutoff7 = now - 7 * 86400000;
+
+  const accumByIso3 = new Map();
   let offset = 0;
   let body;
   let page = 0;
   const t0 = Date.now();
+  let totalRows = 0;
+
   do {
     if (signal?.aborted) throw signal.reason ?? new Error('aborted');
     const params = new URLSearchParams({
@@ -148,88 +162,89 @@ async function fetchAllActivityRows(since, { signal, progress } = {}) {
     body = await fetchWithTimeout(`${EP3_BASE}?${params}`, { signal });
     const features = body.features ?? [];
     for (const f of features) {
-      const iso3 = f.attributes?.ISO3;
-      if (!iso3) continue;
-      const key = String(iso3);
-      let list = byIso3.get(key);
-      if (!list) { list = []; byIso3.set(key, list); }
-      list.push(f);
+      const a = f.attributes;
+      if (!a || a.portid == null || !a.ISO3 || a.date == null) continue;
+      const iso3 = String(a.ISO3);
+      const portId = String(a.portid);
+      // ArcGIS changed date field to esriFieldTypeDateOnly — returns ISO
+      // string "YYYY-MM-DD", not epoch ms. Same parse as the prior per-row
+      // code, just done inline here so we can fold without keeping the row.
+      const date = typeof a.date === 'number' ? a.date : Date.parse(a.date + 'T12:00:00Z');
+      const calls = Number(a.portcalls_tanker ?? 0);
+      const imports = Number(a.import_tanker ?? 0);
+      const exports_ = Number(a.export_tanker ?? 0);
+
+      let countryMap = accumByIso3.get(iso3);
+      if (!countryMap) { countryMap = new Map(); accumByIso3.set(iso3, countryMap); }
+
+      let acc = countryMap.get(portId);
+      if (!acc) {
+        // First time we see this port — capture its name. Rows arrive in
+        // (portid ASC, date ASC) order, so this matches the old behaviour
+        // where `rows[0].portname` was the earliest row's portname.
+        acc = {
+          portname: String(a.portname || ''),
+          last30_calls: 0, last30_count: 0, last30_import: 0, last30_export: 0,
+          prev30_calls: 0,
+          last7_calls: 0, last7_count: 0,
+        };
+        countryMap.set(portId, acc);
+      }
+
+      if (date >= cutoff30) {
+        acc.last30_calls += calls;
+        acc.last30_count += 1;
+        acc.last30_import += imports;
+        acc.last30_export += exports_;
+        if (date >= cutoff7) {
+          acc.last7_calls += calls;
+          acc.last7_count += 1;
+        }
+      } else if (date >= cutoff60) {
+        acc.prev30_calls += calls;
+      }
     }
     page++;
+    totalRows += features.length;
     if (progress) {
       progress.pages = page;
-      progress.countries = byIso3.size;
+      progress.countries = accumByIso3.size;
     }
     if (page === 1 || page % ACTIVITY_LOG_EVERY === 0) {
       const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
-      console.log(`  [port-activity]   activity page ${page}: +${features.length} rows (${byIso3.size} countries, ${elapsed}s)`);
+      console.log(`  [port-activity]   activity page ${page}: +${features.length} rows (${accumByIso3.size} countries, ${totalRows} total rows, ${elapsed}s)`);
     }
     if (features.length === 0) break;
     offset += features.length;
   } while (body.exceededTransferLimit);
-  console.log(`  [port-activity] Activity rows loaded: ${page} pages across ${byIso3.size} countries (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
-  return byIso3;
+  console.log(`  [port-activity] Activity folded: ${page} pages, ${totalRows} rows, ${accumByIso3.size} countries (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
+  return accumByIso3;
 }
 
-function computeCountryPorts(rawRows, refMap) {
-  const now = Date.now();
-  const cutoff30 = now - 30 * 86400000;
-  const cutoff60 = now - 60 * 86400000;
-  const cutoff7 = now - 7 * 86400000;
-
-  const portGroups = new Map();
-  for (const f of rawRows) {
-    const a = f.attributes;
-    if (a?.portid == null || a?.date == null) continue;
-    const portId = String(a.portid);
-    if (!portGroups.has(portId)) portGroups.set(portId, []);
-    portGroups.get(portId).push({
-      // ArcGIS changed date field to esriFieldTypeDateOnly — returns ISO string "YYYY-MM-DD", not epoch ms
-      date: typeof a.date === 'number' ? a.date : Date.parse(a.date + 'T12:00:00Z'),
-      portname: String(a.portname || ''),
-      portcalls_tanker: Number(a.portcalls_tanker ?? 0),
-      import_tanker: Number(a.import_tanker ?? 0),
-      export_tanker: Number(a.export_tanker ?? 0),
-    });
-  }
-
+export function finalisePortsForCountry(portAccumMap, refMap) {
   const ports = [];
-  for (const [portId, rows] of portGroups) {
-    const last30 = rows.filter(r => r.date >= cutoff30);
-    const prev30 = rows.filter(r => r.date >= cutoff60 && r.date < cutoff30);
-    const last7 = rows.filter(r => r.date >= cutoff7);
-
-    const tankerCalls30d = last30.reduce((s, r) => s + r.portcalls_tanker, 0);
-    const tankerCalls30dPrev = prev30.reduce((s, r) => s + r.portcalls_tanker, 0);
-    const importTankerDwt30d = last30.reduce((s, r) => s + r.import_tanker, 0);
-    const exportTankerDwt30d = last30.reduce((s, r) => s + r.export_tanker, 0);
-
-    const avg30d = last30.length > 0 ? tankerCalls30d / last30.length : 0;
-    const avg7d = last7.length > 0 ? last7.reduce((s, r) => s + r.portcalls_tanker, 0) / last7.length : 0;
+  for (const [portId, a] of portAccumMap) {
+    const avg30d = a.last30_count > 0 ? a.last30_calls / a.last30_count : 0;
+    const avg7d = a.last7_count > 0 ? a.last7_calls / a.last7_count : 0;
     const anomalySignal = avg30d > 0 && avg7d < avg30d * 0.5;
-
-    const trendDelta = tankerCalls30dPrev > 0
-      ? Math.round(((tankerCalls30d - tankerCalls30dPrev) / tankerCalls30dPrev) * 1000) / 10
+    const trendDelta = a.prev30_calls > 0
+      ? Math.round(((a.last30_calls - a.prev30_calls) / a.prev30_calls) * 1000) / 10
       : 0;
-
-    const portName = rows[0].portname;
     const coords = refMap.get(portId) || { lat: 0, lon: 0 };
-
     ports.push({
       portId,
-      portName,
+      portName: a.portname,
       lat: coords.lat,
       lon: coords.lon,
-      tankerCalls30d,
+      tankerCalls30d: a.last30_calls,
       trendDelta,
-      importTankerDwt30d,
-      exportTankerDwt30d,
+      importTankerDwt30d: a.last30_import,
+      exportTankerDwt30d: a.last30_export,
       anomalySignal,
     });
   }
-
   return ports
-    .sort((a, b) => b.tankerCalls30d - a.tankerCalls30d)
+    .sort((x, y) => y.tankerCalls30d - x.tankerCalls30d)
     .slice(0, MAX_PORTS_PER_COUNTRY);
 }
 
@@ -264,20 +279,20 @@ export async function fetchAll(progress, { signal } = {}) {
   console.log(`  [port-activity] Refs loaded: ${refsByIso3.size} countries with ports (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
 
   if (progress) progress.stage = 'activity';
-  console.log(`  [port-activity] Fetching global activity rows (${HISTORY_DAYS}d history, EP3)...`);
-  const activityByIso3 = await fetchAllActivityRows(since, { signal, progress });
+  console.log(`  [port-activity] Fetching + aggregating global activity (${HISTORY_DAYS}d history, EP3)...`);
+  const accumByIso3 = await fetchAndAggregateActivity(since, { signal, progress });
 
   if (progress) progress.stage = 'compute';
   const eligibleIso3 = [...refsByIso3.keys()].filter(iso3 => iso3ToIso2.has(iso3));
   const skipped = refsByIso3.size - eligibleIso3.length;
-  console.log(`  [port-activity] Computing ports for ${eligibleIso3.length} eligible countries (skipping ${skipped} unmapped iso3)`);
+  console.log(`  [port-activity] Finalising ports for ${eligibleIso3.length} eligible countries (skipping ${skipped} unmapped iso3)`);
 
   const countryData = new Map();
   let missingActivity = 0;
   for (const iso3 of eligibleIso3) {
-    const rawRows = activityByIso3.get(iso3);
-    if (!rawRows || rawRows.length === 0) { missingActivity++; continue; }
-    const ports = computeCountryPorts(rawRows, refsByIso3.get(iso3));
+    const accum = accumByIso3.get(iso3);
+    if (!accum || accum.size === 0) { missingActivity++; continue; }
+    const ports = finalisePortsForCountry(accum, refsByIso3.get(iso3));
     if (!ports.length) continue;
     const iso2 = iso3ToIso2.get(iso3);
     countryData.set(iso2, { iso2, ports, fetchedAt: new Date().toISOString() });

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -83,12 +83,13 @@ async function fetchWithTimeout(url, { signal } = {}) {
 // resultRecordCount (PortWatch_ports_database caps at 1000 despite
 // PAGE_SIZE=2000). Advancing by PAGE_SIZE silently skips the rows between
 // the server cap and PAGE_SIZE. Advance by the actual features.length.
-async function fetchAllPortRefs() {
+async function fetchAllPortRefs({ signal } = {}) {
   const byIso3 = new Map();
   let offset = 0;
   let body;
   let page = 0;
   do {
+    if (signal?.aborted) throw signal.reason ?? new Error('aborted');
     page++;
     const params = new URLSearchParams({
       where: '1=1',
@@ -100,7 +101,7 @@ async function fetchAllPortRefs() {
       outSR: '4326',
       f: 'json',
     });
-    body = await fetchWithTimeout(`${EP4_BASE}?${params}`);
+    body = await fetchWithTimeout(`${EP4_BASE}?${params}`, { signal });
     const features = body.features ?? [];
     for (const f of features) {
       const a = f.attributes;
@@ -153,6 +154,10 @@ async function fetchAndAggregateActivity(since, { signal, progress } = {}) {
     const params = new URLSearchParams({
       where: `date > ${epochToTimestamp(since)}`,
       outFields: 'portid,portname,ISO3,date,portcalls_tanker,import_tanker,export_tanker',
+      // ArcGIS returns geometry by default (~100-200KB per page). We only
+      // need attributes — skip geometry to shave tens of MB off the wire
+      // across ~150-200 pages on the perf-critical path (PR #3225 review).
+      returnGeometry: 'false',
       orderByFields: 'portid ASC,date ASC',
       resultRecordCount: String(PAGE_SIZE),
       resultOffset: String(offset),
@@ -275,7 +280,7 @@ export async function fetchAll(progress, { signal } = {}) {
   if (progress) progress.stage = 'refs';
   console.log('  [port-activity] Fetching global port reference (EP4)...');
   const t0 = Date.now();
-  const refsByIso3 = await fetchAllPortRefs();
+  const refsByIso3 = await fetchAllPortRefs({ signal });
   console.log(`  [port-activity] Refs loaded: ${refsByIso3.size} countries with ports (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
 
   if (progress) progress.stage = 'activity';

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -33,14 +33,7 @@ const PAGE_SIZE = 2000;
 const FETCH_TIMEOUT = 45_000;
 const HISTORY_DAYS = 90;
 const MAX_PORTS_PER_COUNTRY = 50;
-const CONCURRENCY = 12;
-const BATCH_LOG_EVERY = 5;
-// Per-country budget. Promise.allSettled waits for the slowest member of the
-// batch, so one runaway country (e.g. USA: many ports × many pages when EP3
-// is slow) can stall the whole batch and cascade to the section timeout,
-// leaving batches 2..N unattempted. This caps a single country without
-// aborting the whole section.
-const PER_COUNTRY_TIMEOUT_MS = 90_000;
+const ACTIVITY_LOG_EVERY = 20;
 
 function epochToTimestamp(epochMs) {
   const d = new Date(epochMs);
@@ -125,17 +118,26 @@ async function fetchAllPortRefs() {
   return byIso3;
 }
 
-async function fetchActivityRows(iso3, since, { signal } = {}) {
+// Fetch ALL activity rows globally in one paginated pass, grouped by ISO3.
+// Replaces 174× per-country WHERE=ISO3 round-trips (which hit ~90s each at
+// concurrency 12, far exceeding the 420s section budget even when none of
+// them hung) with a single sequential loop of ~150-200 pages that completes
+// comfortably inside the section budget. Also eliminates the `Invalid query
+// parameters` errors we saw in prod for BRA/IDN/NGA on the per-country
+// filter: the global WHERE does not involve an ISO3 equality on the feature
+// server, so those failure modes disappear.
+//
+// Returns Map<iso3, Feature[]>. Aborts between pages when signal.aborted.
+async function fetchAllActivityRows(since, { signal, progress } = {}) {
+  const byIso3 = new Map();
   let offset = 0;
-  const allRows = [];
   let body;
+  let page = 0;
+  const t0 = Date.now();
   do {
-    // Abort between pages so a cancelled per-country timer stops the
-    // paginator on the next iteration boundary even if the current fetch
-    // has already resolved.
     if (signal?.aborted) throw signal.reason ?? new Error('aborted');
     const params = new URLSearchParams({
-      where: `ISO3='${iso3}' AND date > ${epochToTimestamp(since)}`,
+      where: `date > ${epochToTimestamp(since)}`,
       outFields: 'portid,portname,ISO3,date,portcalls_tanker,import_tanker,export_tanker',
       orderByFields: 'portid ASC,date ASC',
       resultRecordCount: String(PAGE_SIZE),
@@ -145,13 +147,28 @@ async function fetchActivityRows(iso3, since, { signal } = {}) {
     });
     body = await fetchWithTimeout(`${EP3_BASE}?${params}`, { signal });
     const features = body.features ?? [];
-    if (features.length) allRows.push(...features);
-    // Advance by actual returned count, not PAGE_SIZE. ArcGIS can cap below
-    // the requested size (see fetchAllPortRefs for the same issue on EP4).
+    for (const f of features) {
+      const iso3 = f.attributes?.ISO3;
+      if (!iso3) continue;
+      const key = String(iso3);
+      let list = byIso3.get(key);
+      if (!list) { list = []; byIso3.set(key, list); }
+      list.push(f);
+    }
+    page++;
+    if (progress) {
+      progress.pages = page;
+      progress.countries = byIso3.size;
+    }
+    if (page === 1 || page % ACTIVITY_LOG_EVERY === 0) {
+      const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+      console.log(`  [port-activity]   activity page ${page}: +${features.length} rows (${byIso3.size} countries, ${elapsed}s)`);
+    }
     if (features.length === 0) break;
     offset += features.length;
   } while (body.exceededTransferLimit);
-  return allRows;
+  console.log(`  [port-activity] Activity rows loaded: ${page} pages across ${byIso3.size} countries (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
+  return byIso3;
 }
 
 function computeCountryPorts(rawRows, refMap) {
@@ -231,96 +248,43 @@ async function redisPipeline(commands) {
   return resp.json();
 }
 
-async function processCountry(iso3, iso2, since, refMap, { signal } = {}) {
-  const rawRows = await fetchActivityRows(iso3, since, { signal });
-  if (!rawRows.length) return null;
-  const ports = computeCountryPorts(rawRows, refMap);
-  if (!ports.length) return null;
-  return { iso2, ports, fetchedAt: new Date().toISOString() };
-}
-
-// Runs `doWork(signal)` but rejects if the per-country timer fires first,
-// aborting the controller so the in-flight fetch (and its pagination loop)
-// actually stops instead of orphaning. Keeps the CONCURRENCY=12 cap real:
-// the next batch cannot pile new requests on top of still-running earlier
-// work. Exported with an injectable timeoutMs so runtime tests can exercise
-// the abort path at 50ms instead of the production 90s.
-export function withPerCountryTimeout(doWork, iso3, timeoutMs = PER_COUNTRY_TIMEOUT_MS) {
-  const controller = new AbortController();
-  let timer;
-  const guard = new Promise((_, reject) => {
-    timer = setTimeout(() => {
-      const err = new Error(`per-country timeout after ${timeoutMs / 1000}s (${iso3})`);
-      try { controller.abort(err); } catch {}
-      reject(err);
-    }, timeoutMs);
-  });
-  const work = doWork(controller.signal);
-  return Promise.race([work, guard]).finally(() => clearTimeout(timer));
-}
-
 // fetchAll() — pure data collection, no Redis writes.
 // Returns { countries: string[], countryData: Map<iso2, payload>, fetchedAt: string }.
 //
 // `progress` (optional) is mutated in-place so a SIGTERM handler in main()
-// can read the last batch index, seeded count, and error list at kill time.
-export async function fetchAll(progress) {
+// can report which stage was running and how far into it we got.
+export async function fetchAll(progress, { signal } = {}) {
   const { iso3ToIso2 } = createCountryResolvers();
   const since = Date.now() - HISTORY_DAYS * 86400000;
 
+  if (progress) progress.stage = 'refs';
   console.log('  [port-activity] Fetching global port reference (EP4)...');
   const t0 = Date.now();
   const refsByIso3 = await fetchAllPortRefs();
   console.log(`  [port-activity] Refs loaded: ${refsByIso3.size} countries with ports (${((Date.now() - t0) / 1000).toFixed(1)}s)`);
 
-  // Only fetch activity for ISO3s that have at least one port AND exist in our iso3→iso2 map.
+  if (progress) progress.stage = 'activity';
+  console.log(`  [port-activity] Fetching global activity rows (${HISTORY_DAYS}d history, EP3)...`);
+  const activityByIso3 = await fetchAllActivityRows(since, { signal, progress });
+
+  if (progress) progress.stage = 'compute';
   const eligibleIso3 = [...refsByIso3.keys()].filter(iso3 => iso3ToIso2.has(iso3));
   const skipped = refsByIso3.size - eligibleIso3.length;
-  console.log(`  [port-activity] Activity queue: ${eligibleIso3.length} countries (skipping ${skipped} unmapped iso3, concurrency ${CONCURRENCY}, per-country cap ${PER_COUNTRY_TIMEOUT_MS / 1000}s)`);
+  console.log(`  [port-activity] Computing ports for ${eligibleIso3.length} eligible countries (skipping ${skipped} unmapped iso3)`);
 
   const countryData = new Map();
-  const errors = progress?.errors ?? [];
-  const batches = Math.ceil(eligibleIso3.length / CONCURRENCY);
-  const activityStart = Date.now();
-  if (progress) progress.totalBatches = batches;
-
-  for (let i = 0; i < eligibleIso3.length; i += CONCURRENCY) {
-    const batch = eligibleIso3.slice(i, i + CONCURRENCY);
-    const batchIdx = Math.floor(i / CONCURRENCY) + 1;
-    if (progress) progress.batchIdx = batchIdx;
-    const promises = batch.map(iso3 => {
-      const iso2 = iso3ToIso2.get(iso3);
-      const p = withPerCountryTimeout(
-        (signal) => processCountry(iso3, iso2, since, refsByIso3.get(iso3), { signal }),
-        iso3,
-      );
-      // Eager error flush (review feedback P2 on PR #3222). Push into the
-      // shared errors array the moment each promise rejects, so a SIGTERM
-      // that arrives MID-batch (while Promise.allSettled is still pending)
-      // sees the rejections that have already fired. The settled-loop
-      // below skips rejected outcomes to avoid double-counting.
-      p.catch(err => {
-        errors.push(`${iso3}: ${err?.message || err}`);
-      });
-      return p;
-    });
-    const settled = await Promise.allSettled(promises);
-    for (let j = 0; j < batch.length; j++) {
-      const outcome = settled[j];
-      if (outcome.status === 'rejected') continue; // already recorded via .catch above
-      if (!outcome.value) continue;
-      const { iso2, ports, fetchedAt } = outcome.value;
-      countryData.set(iso2, { iso2, ports, fetchedAt });
-    }
-    if (progress) progress.seeded = countryData.size;
-    if (batchIdx === 1 || batchIdx % BATCH_LOG_EVERY === 0 || batchIdx === batches) {
-      const elapsed = ((Date.now() - activityStart) / 1000).toFixed(1);
-      console.log(`  [port-activity]   batch ${batchIdx}/${batches}: ${countryData.size} countries seeded, ${errors.length} errors (${elapsed}s)`);
-    }
+  let missingActivity = 0;
+  for (const iso3 of eligibleIso3) {
+    const rawRows = activityByIso3.get(iso3);
+    if (!rawRows || rawRows.length === 0) { missingActivity++; continue; }
+    const ports = computeCountryPorts(rawRows, refsByIso3.get(iso3));
+    if (!ports.length) continue;
+    const iso2 = iso3ToIso2.get(iso3);
+    countryData.set(iso2, { iso2, ports, fetchedAt: new Date().toISOString() });
   }
 
-  if (errors.length) {
-    console.warn(`  [port-activity] ${errors.length} country errors: ${errors.slice(0, 5).join('; ')}${errors.length > 5 ? ' ...' : ''}`);
+  if (missingActivity > 0) {
+    console.log(`  [port-activity] ${missingActivity} eligible countries had no activity rows in the global dataset`);
   }
 
   if (countryData.size === 0) throw new Error('No country port data returned from ArcGIS');
@@ -350,11 +314,15 @@ async function main() {
   let prevCountryKeys = [];
   let prevCount = 0;
 
-  // Mutated in-place by fetchAll() so the SIGTERM handler can log which batch
-  // we died in and what the per-country errors looked like. Without this, a
-  // timeout kill flushes nothing from the errors array — past regressions
-  // have been undiagnosable for exactly this reason.
-  const progress = { batchIdx: 0, totalBatches: 0, seeded: 0, errors: [] };
+  // Mutated in-place by fetchAll() so the SIGTERM handler can report which
+  // stage was running and how far into the global paginator we got.
+  const progress = { stage: 'starting', pages: 0, countries: 0 };
+
+  // AbortController plumbed through fetchAll → fetchAllActivityRows →
+  // fetchWithTimeout → _proxy-utils so a SIGTERM kill (or bundle-runner
+  // grace-window escalation) actually stops any in-flight HTTP work
+  // instead of leaving orphan requests running into the SIGKILL.
+  const shutdownController = new AbortController();
 
   // Bundle-runner SIGKILLs via SIGTERM → SIGKILL on timeout. Release the lock
   // and extend existing TTLs synchronously(ish) so the next cron tick isn't
@@ -363,12 +331,10 @@ async function main() {
   const onSigterm = async () => {
     if (sigHandled) return;
     sigHandled = true;
+    try { shutdownController.abort(new Error('SIGTERM')); } catch {}
     console.error(
-      `  [port-activity] SIGTERM at batch ${progress.batchIdx}/${progress.totalBatches} — ${progress.seeded} seeded, ${progress.errors.length} errors`,
+      `  [port-activity] SIGTERM during stage=${progress.stage} (pages=${progress.pages}, countries=${progress.countries})`,
     );
-    if (progress.errors.length) {
-      console.error(`  [port-activity] First errors: ${progress.errors.slice(0, 10).join('; ')}`);
-    }
     console.error('  [port-activity] Releasing lock + extending TTLs');
     try {
       await extendExistingTtl([CANONICAL_KEY, META_KEY, ...prevCountryKeys], TTL);
@@ -386,7 +352,7 @@ async function main() {
     prevCount = Array.isArray(prevIso2List) ? prevIso2List.length : 0;
 
     console.log(`  Fetching port activity data (${HISTORY_DAYS}d history)...`);
-    const { countries, countryData } = await fetchAll(progress);
+    const { countries, countryData } = await fetchAll(progress, { signal: shutdownController.signal });
 
     console.log(`  Fetched ${countryData.size} countries`);
 

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -5,8 +5,6 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 
-import { withPerCountryTimeout } from '../scripts/seed-portwatch-port-activity.mjs';
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 
@@ -55,48 +53,58 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /outFields:\s*'portid,ISO3,lat,lon'/);
   });
 
-  it('Endpoint 3 activity query still filters per-country ISO3', () => {
-    assert.match(src, /where:\s*`ISO3='\$\{iso3\}'\s+AND\s+date\s*>/);
+  it('Endpoint 3 activity query is globalised — no per-country ISO3 filter', () => {
+    // The per-country `WHERE ISO3='XX' AND date > ...` shape is gone; the
+    // globalised paginator uses a single date filter and groups by ISO3 in
+    // memory. This eliminates the 174-per-country round-trip cost that
+    // blew the 420s section budget even when every country was fast, and
+    // also removes the `Invalid query parameters` errors that hit
+    // BRA/IDN/NGA under the per-country shape.
+    assert.doesNotMatch(src, /where:\s*`ISO3=/);
+    assert.match(src, /where:\s*`date\s*>\s*\$\{epochToTimestamp\(since\)\}`/);
   });
 
-  it('concurrency is bumped to 12', () => {
-    assert.match(src, /CONCURRENCY\s*=\s*12/);
+  it('defines fetchAllActivityRows that groups rows by ISO3 in memory', () => {
+    assert.match(src, /async function fetchAllActivityRows/);
+    assert.match(src, /byIso3\.set\(key,\s*list\)/);
   });
 
   it('registers SIGTERM handler for graceful shutdown', () => {
     assert.match(src, /process\.on\('SIGTERM'/);
   });
 
-  it('defines a per-country timeout to cap Promise.allSettled stalls', () => {
-    // Without this cap, one slow country (USA: many ports × many pages when
-    // ArcGIS is throttled) blocks the whole batch via Promise.allSettled and
-    // cascades to the 420s section timeout, leaving batches 2..N unattempted.
-    assert.match(src, /PER_COUNTRY_TIMEOUT_MS\s*=\s*\d/);
+  it('SIGTERM handler aborts shutdownController + logs stage/pages/countries', () => {
+    // Per-country batching is gone, but the SIGTERM path still must (a)
+    // abort the in-flight global paginator via the shared controller, and
+    // (b) emit a forensic line identifying which stage we died in.
+    assert.match(src, /shutdownController\.abort\(new Error\('SIGTERM'\)\)/);
+    assert.match(src, /SIGTERM during stage=\$\{progress\.stage\}/);
+    assert.match(src, /pages=\$\{progress\.pages\},\s*countries=\$\{progress\.countries\}/);
   });
 
-  it('wraps processCountry with the per-country timeout in the batch loop', () => {
-    // Must pass a factory (signal) => processCountry(...) so the timer can
-    // abort the in-flight fetch (PR #3222 review P1), not just race a
-    // detached promise.
-    assert.match(src, /withPerCountryTimeout\s*\(\s*\n?\s*\(signal\)\s*=>\s*processCountry/);
+  it('fetchAll accepts progress + { signal } and mutates progress.stage', () => {
+    assert.match(src, /export async function fetchAll\(progress,\s*\{\s*signal\s*\}\s*=\s*\{\}\)/);
+    assert.match(src, /progress\.stage\s*=\s*'refs'/);
+    assert.match(src, /progress\.stage\s*=\s*'activity'/);
+    assert.match(src, /progress\.stage\s*=\s*'compute'/);
+  });
+
+  it('fetchAllActivityRows updates progress.pages + progress.countries', () => {
+    assert.match(src, /progress\.pages\s*=\s*page/);
+    assert.match(src, /progress\.countries\s*=\s*byIso3\.size/);
   });
 
   it('fetchWithTimeout combines caller signal with FETCH_TIMEOUT via AbortSignal.any', () => {
-    // Otherwise the per-country abort cannot propagate into the in-flight
-    // fetch; orphan pagination would continue with fresh 45s budgets each
-    // page (PR #3222 review P1).
+    // Still needed so a shutdown-controller abort propagates into the
+    // in-flight fetch instead of orphaning it for up to 45s.
     assert.match(src, /AbortSignal\.any\(\[signal,\s*AbortSignal\.timeout\(FETCH_TIMEOUT\)\]\)/);
   });
 
-  it('fetchActivityRows checks signal.aborted between pages', () => {
+  it('fetchAllActivityRows checks signal.aborted between pages', () => {
     assert.match(src, /signal\?\.aborted\)\s*throw\s+signal\.reason/);
   });
 
   it('429 proxy fallback threads caller signal into httpsProxyFetchRaw', () => {
-    // Review feedback: without this, a timed-out country can leak a
-    // proxy CONNECT tunnel for up to FETCH_TIMEOUT (45s) after the
-    // batch moved on, defeating the concurrency cap under the exact
-    // throttling scenario this PR addresses.
     assert.match(src, /httpsProxyFetchRaw\(url,\s*proxyAuth,\s*\{[^}]*signal\s*\}/s);
   });
 
@@ -110,27 +118,6 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(proxyUtilsSrc, /function proxyConnectTunnel\([\s\S]*?\bsignal\s*\}\s*=\s*\{\}/);
     assert.match(proxyUtilsSrc, /signal && signal\.aborted/);
     assert.match(proxyUtilsSrc, /signal\.addEventListener\('abort'/);
-  });
-
-  it('eager error flush attaches p.catch before Promise.allSettled', () => {
-    // Review P2: without this, errors collected only AFTER allSettled
-    // returns. A mid-batch SIGTERM would flush zero errors even though
-    // several promises had already rejected.
-    assert.match(src, /p\.catch\(err\s*=>\s*\{[^}]*errors\.push/);
-  });
-
-  it('SIGTERM handler flushes batch progress + first errors', () => {
-    // Past regressions were undiagnosable because the errors array was only
-    // logged after all batches completed — a SIGTERM kill discarded it.
-    assert.match(src, /SIGTERM at batch \$\{progress\.batchIdx\}/);
-    assert.match(src, /progress\.errors\.slice\(0,\s*10\)/);
-  });
-
-  it('fetchAll accepts a progress object and mutates it', () => {
-    assert.match(src, /export async function fetchAll\(progress\)/);
-    assert.match(src, /progress\.totalBatches\s*=\s*batches/);
-    assert.match(src, /progress\.batchIdx\s*=\s*batchIdx/);
-    assert.match(src, /progress\.seeded\s*=\s*countryData\.size/);
   });
 
   it('pagination advances by actual features.length, not PAGE_SIZE', () => {
@@ -289,58 +276,14 @@ describe('top-N port truncation', () => {
   });
 });
 
-describe('withPerCountryTimeout (runtime)', () => {
-  it('aborts the per-country signal when the timer fires', async () => {
-    let observedSignal;
-    const p = withPerCountryTimeout(
-      (signal) => {
-        observedSignal = signal;
-        // Never resolves on its own; can only reject via abort.
-        return new Promise((_, reject) => {
-          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
-        });
-      },
-      'TST',
-      40, // 40ms — keeps the test fast
-    );
-
-    await assert.rejects(p, /per-country timeout after 0\.04s \(TST\)/);
-    assert.equal(observedSignal.aborted, true, 'underlying work received the abort');
-  });
-
-  it('resolves with the work result when work completes before the timer', async () => {
-    const result = await withPerCountryTimeout(
-      (_signal) => Promise.resolve({ ok: true }),
-      'TST',
-      500,
-    );
-    assert.deepEqual(result, { ok: true });
-  });
-
-  it('does not invoke the timer path when work rejects first', async () => {
-    // Rejecting with a non-timeout error should surface as-is, not as the
-    // per-country timeout message.
-    await assert.rejects(
-      withPerCountryTimeout(
-        (_signal) => Promise.reject(new Error('ArcGIS HTTP 500')),
-        'TST',
-        1_000,
-      ),
-      /ArcGIS HTTP 500/,
-    );
-  });
-});
-
 describe('proxyFetch signal propagation (runtime)', () => {
   const require_ = createRequire(import.meta.url);
   const { proxyFetch } = require_('../scripts/_proxy-utils.cjs');
 
   it('rejects synchronously when called with an already-aborted signal', async () => {
-    // Review feedback: the per-country AbortController must kill the proxy
-    // fallback too. Pre-aborted signals must short-circuit BEFORE any
-    // CONNECT tunnel opens; otherwise a timed-out country's proxy call
-    // continues in the background. No network reached in this test — the
-    // synchronous aborted check is the guard.
+    // A shutdown-controller abort must short-circuit BEFORE any CONNECT
+    // tunnel opens; otherwise a killed run's proxy call continues in the
+    // background past SIGKILL. No network reached in this test.
     const controller = new AbortController();
     controller.abort(new Error('test-cancel'));
     await assert.rejects(
@@ -350,42 +293,6 @@ describe('proxyFetch signal propagation (runtime)', () => {
       }),
       /test-cancel|aborted/,
     );
-  });
-});
-
-describe('eager error flush (runtime)', () => {
-  it('populates shared errors via p.catch before Promise.allSettled resolves', async () => {
-    // Mirrors the wiring in fetchAll(): attach p.catch to each promise so
-    // rejections land in the errors array at the moment they fire, not
-    // only after allSettled. A SIGTERM that hits during allSettled still
-    // sees the already-pushed errors.
-    const errors = [];
-    let stuckResolve;
-
-    const rejecting = Promise.reject(new Error('boom A'));
-    rejecting.catch(err => errors.push(`A: ${err.message}`));
-
-    const stuck = new Promise(resolve => { stuckResolve = resolve; });
-    stuck.catch(err => errors.push(`B: ${err.message}`));
-
-    // Yield microtasks so `rejecting.catch` fires.
-    await Promise.resolve();
-    await Promise.resolve();
-
-    assert.deepEqual(errors, ['A: boom A'], 'rejected promise pushed BEFORE allSettled is even awaited');
-
-    // Sanity: the hung promise still blocks allSettled, proving the
-    // behavior we rely on: errors from resolved-rejected members are
-    // visible to a SIGTERM handler even while the batch itself is stuck.
-    const allSettledPromise = Promise.allSettled([rejecting, stuck]);
-    let settledEarly = false;
-    allSettledPromise.then(() => { settledEarly = true; });
-    await new Promise(r => setTimeout(r, 10));
-    assert.equal(settledEarly, false, 'allSettled still pending while one member is stuck');
-    assert.equal(errors.length, 1, 'error list observable despite pending batch');
-
-    stuckResolve();
-    await allSettledPromise;
   });
 });
 

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -53,6 +53,25 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /outFields:\s*'portid,ISO3,lat,lon'/);
   });
 
+  it('both paginators set returnGeometry:false to avoid wasted wire bandwidth', () => {
+    // ArcGIS returns geometry by default (~100-200KB per page). Omitting
+    // this in the EP3 paginator across ~150-200 pages adds tens of MB to
+    // the perf-critical path. Review feedback on PR #3225.
+    const matches = src.match(/returnGeometry:\s*'false'/g) ?? [];
+    assert.ok(matches.length >= 2, `expected returnGeometry:'false' in both EP3 and EP4 paginators, found ${matches.length}`);
+  });
+
+  it('fetchAllPortRefs accepts + forwards signal for SIGTERM cancellation', () => {
+    // Review feedback on PR #3225: during the 'refs' stage a SIGTERM must
+    // cancel in-flight EP4 fetches, not let them run up to FETCH_TIMEOUT
+    // after the handler fires. The signal must thread through the
+    // paginator into fetchWithTimeout.
+    assert.match(src, /async function fetchAllPortRefs\(\{\s*signal\s*\}\s*=\s*\{\}\)/);
+    assert.match(src, /fetchWithTimeout\(`\$\{EP4_BASE\}\?\$\{params\}`,\s*\{\s*signal\s*\}\)/);
+    // fetchAll must pass the signal when calling it.
+    assert.match(src, /fetchAllPortRefs\(\{\s*signal\s*\}\)/);
+  });
+
   it('Endpoint 3 activity query is globalised — no per-country ISO3 filter', () => {
     // The per-country `WHERE ISO3='XX' AND date > ...` shape is gone; the
     // globalised paginator uses a single date filter and groups by ISO3 in

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
@@ -64,9 +64,28 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /where:\s*`date\s*>\s*\$\{epochToTimestamp\(since\)\}`/);
   });
 
-  it('defines fetchAllActivityRows that groups rows by ISO3 in memory', () => {
-    assert.match(src, /async function fetchAllActivityRows/);
-    assert.match(src, /byIso3\.set\(key,\s*list\)/);
+  it('streams EP3 into per-port accumulators, not a flat rows array', () => {
+    // Review feedback on PR #3225: materialising the full 90d activity
+    // dataset as Map<iso3, Feature[]> holds ~180k feature objects at once
+    // (~70MB) on a 1GB Railway container. The aggregator now folds each
+    // page into Map<iso3, Map<portId, PortAccum>> (~200KB) and discards
+    // the rows. Assert both the rename and the accumulator shape.
+    assert.match(src, /async function fetchAndAggregateActivity/);
+    assert.doesNotMatch(src, /async function fetchAllActivityRows/);
+    // Accumulator fields (at least the key ones we rely on downstream).
+    assert.match(src, /last30_calls:\s*0/);
+    assert.match(src, /last30_count:\s*0/);
+    assert.match(src, /prev30_calls:\s*0/);
+    assert.match(src, /last7_calls:\s*0/);
+    // No more flat rows array collected per country.
+    assert.doesNotMatch(src, /byIso3\.set\(key,\s*list\)/);
+  });
+
+  it('finalisePortsForCountry emits top-N ports from accumulators', () => {
+    assert.match(src, /function finalisePortsForCountry\(portAccumMap,\s*refMap\)/);
+    assert.match(src, /MAX_PORTS_PER_COUNTRY/);
+    // Same anomaly/trend formula as the old per-row code.
+    assert.match(src, /avg7d\s*<\s*avg30d\s*\*\s*0\.5/);
   });
 
   it('registers SIGTERM handler for graceful shutdown', () => {
@@ -89,9 +108,9 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /progress\.stage\s*=\s*'compute'/);
   });
 
-  it('fetchAllActivityRows updates progress.pages + progress.countries', () => {
+  it('fetchAndAggregateActivity updates progress.pages + progress.countries', () => {
     assert.match(src, /progress\.pages\s*=\s*page/);
-    assert.match(src, /progress\.countries\s*=\s*byIso3\.size/);
+    assert.match(src, /progress\.countries\s*=\s*accumByIso3\.size/);
   });
 
   it('fetchWithTimeout combines caller signal with FETCH_TIMEOUT via AbortSignal.any', () => {
@@ -100,7 +119,7 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /AbortSignal\.any\(\[signal,\s*AbortSignal\.timeout\(FETCH_TIMEOUT\)\]\)/);
   });
 
-  it('fetchAllActivityRows checks signal.aborted between pages', () => {
+  it('fetchAndAggregateActivity checks signal.aborted between pages', () => {
     assert.match(src, /signal\?\.aborted\)\s*throw\s+signal\.reason/);
   });
 
@@ -273,6 +292,90 @@ describe('top-N port truncation', () => {
     assert.equal(result[0].portId, 'b');
     assert.equal(result[1].portId, 'c');
     assert.equal(result[2].portId, 'a');
+  });
+});
+
+describe('finalisePortsForCountry (runtime, semantic equivalence)', () => {
+  // eslint-disable-next-line import/first
+  let finalisePortsForCountry;
+  before(async () => {
+    ({ finalisePortsForCountry } = await import('../scripts/seed-portwatch-port-activity.mjs'));
+  });
+
+  it('emits tankerCalls30d / trendDelta / anomalySignal that match the old per-row formula', () => {
+    // Accum equivalent of: last30 has 30 rows × 60 calls, prev30 has 30 × 40,
+    // last7 has 7 rows × 20 calls (subset of last30 — but note that the
+    // streaming aggregator increments last30 AND last7 on the same row for
+    // dates ≤ 7d, so last7_calls should be <= last30_calls).
+    const portAccumMap = new Map([
+      ['42', {
+        portname: 'Test Port',
+        last30_calls: 60 * 23 + 20 * 7, // 23 rows in 8-30d window + 7 rows in 0-7d window
+        last30_count: 30,
+        last30_import: 1000,
+        last30_export: 500,
+        prev30_calls: 40 * 30,
+        last7_calls: 20 * 7,
+        last7_count: 7,
+      }],
+    ]);
+    const refMap = new Map([['42', { lat: 10, lon: 20 }]]);
+    const [port] = finalisePortsForCountry(portAccumMap, refMap);
+
+    assert.equal(port.portId, '42');
+    assert.equal(port.portName, 'Test Port');
+    assert.equal(port.lat, 10);
+    assert.equal(port.lon, 20);
+    assert.equal(port.tankerCalls30d, 60 * 23 + 20 * 7);
+    assert.equal(port.importTankerDwt30d, 1000);
+    assert.equal(port.exportTankerDwt30d, 500);
+    // trendDelta = ((last30 - prev30) / prev30) * 100, rounded to 1 decimal
+    const expectedTrend = Math.round(((60 * 23 + 20 * 7 - 40 * 30) / (40 * 30)) * 1000) / 10;
+    assert.equal(port.trendDelta, expectedTrend);
+    // avg30d = last30_calls / last30_count; avg7d = last7_calls / last7_count
+    // (60*23 + 20*7) / 30 = (1380+140)/30 = 50.67; last7 avg = 140/7 = 20
+    // 20 < 50.67 * 0.5 = 25.33 → anomaly = true
+    assert.equal(port.anomalySignal, true);
+  });
+
+  it('returns trendDelta=0 when prev30_calls is zero (no baseline)', () => {
+    const portAccumMap = new Map([
+      ['1', {
+        portname: 'P', last30_calls: 100, last30_count: 30,
+        last30_import: 0, last30_export: 0,
+        prev30_calls: 0, // no prior-period baseline
+        // last7 matches last30 rate → no anomaly
+        last7_calls: Math.round((100 / 30) * 7),
+        last7_count: 7,
+      }],
+    ]);
+    const [port] = finalisePortsForCountry(portAccumMap, new Map());
+    assert.equal(port.trendDelta, 0);
+    assert.equal(port.anomalySignal, false);
+  });
+
+  it('sorts by tankerCalls30d desc and truncates to MAX_PORTS_PER_COUNTRY=50', () => {
+    const portAccumMap = new Map();
+    for (let i = 0; i < 60; i++) {
+      portAccumMap.set(String(i), {
+        portname: `P${i}`, last30_calls: 60 - i, last30_count: 1,
+        last30_import: 0, last30_export: 0, prev30_calls: 0,
+        last7_calls: 0, last7_count: 0,
+      });
+    }
+    const out = finalisePortsForCountry(portAccumMap, new Map());
+    assert.equal(out.length, 50);
+    assert.equal(out[0].tankerCalls30d, 60);
+    assert.equal(out[49].tankerCalls30d, 11);
+  });
+
+  it('falls back to lat/lon=0 when a portId is missing from refMap', () => {
+    const portAccumMap = new Map([
+      ['999', { portname: 'Orphan', last30_calls: 1, last30_count: 1, last30_import: 0, last30_export: 0, prev30_calls: 0, last7_calls: 0, last7_count: 0 }],
+    ]);
+    const [port] = finalisePortsForCountry(portAccumMap, new Map());
+    assert.equal(port.lat, 0);
+    assert.equal(port.lon, 0);
   });
 });
 


### PR DESCRIPTION
## Why this PR?

Follow-up to #3222 (stabiliser). Production log at 2026-04-20T06:48-06:55 confirmed the stabilisers worked — per-country cap enforced cleanly at 90.0s, SIGTERM handler printed stage + errors, abort propagated through fetch + proxy paths. But the log also proved the **per-country shape itself is the bug**:

\`\`\`
batch 1/15: 7 seeded, 5 errors (90.0s)    ← per-country cap hit cleanly
batch 5/15: 40 seeded, 20 errors (371.3s) ← 4 batches / ~70s avg
SIGTERM at batch 6/15 after 420s
\`\`\`

15 batches × ~70s = ~1050s. Section budget is 420s. Per-country can't fit even with a perfectly-behaving ArcGIS. Three countries (BRA, IDN, NGA) also returned \`Invalid query parameters\` on the ISO3-filtered WHERE — a failure mode unique to the per-country shape.

## What this PR does

Replace 174 per-country EP3 round-trips with a **single paginated pass** over \`WHERE date > <ts>\`, grouped by ISO3 in memory. Mirrors \`fetchAllPortRefs\` (EP4), which has used this shape since #3128. ~150-200 sequential pages × ~1s each ≈ 2-4 min total wall time inside the 420s section budget. Eliminates the per-country failure modes by construction.

### New / changed
- \`fetchAllActivityRows(since, { signal, progress })\` — single paginated EP3 fetch, groups by \`attributes.ISO3\` into \`Map<iso3, rows[]>\`. Advances offset by actual \`features.length\` (server-cap defence). Checks \`signal.aborted\` between pages.
- \`fetchAll()\` now reads the global map and calls \`computeCountryPorts\` per eligible ISO3. No concurrency primitives, no batch loop, no \`Promise.allSettled\`.
- \`progress\` simplified to \`{ stage, pages, countries }\`. SIGTERM handler logs \`SIGTERM during stage=<x> (pages=N, countries=M)\`.
- Shutdown \`AbortController\` in \`main()\` threads its signal through \`fetchAll → fetchAllActivityRows → fetchWithTimeout → _proxy-utils\`. SIGTERM calls \`abort()\` so in-flight HTTP stops cleanly.

### Removed (dead under global pattern)
\`processCountry\`, \`withPerCountryTimeout\`, per-country \`fetchActivityRows\`, \`CONCURRENCY\`, \`PER_COUNTRY_TIMEOUT_MS\`, \`BATCH_LOG_EVERY\`.

### Preserved (still needed)
Degradation guard (>20% drop rejects), TTL extension on failure, lock release in \`finally\`, 429 proxy fallback with signal propagation, page-level abort checks. Signal-threading plumbing from #3222 is reused by the global paginator.

## Expected behaviour

- Total wall time: 1-2 min refs + 2-4 min activity + <1s compute = well inside 420s.
- No \`Invalid query parameters\` errors (global WHERE has no per-country ISO3 clause).
- Degradation guard still protects against partial data: if the global paginator bails early with only 30% of countries, publish is refused.
- SIGTERM path still informative via \`{stage, pages, countries}\`.

## Test plan

- [x] \`node --test tests/portwatch-port-activity-seed.test.mjs\` — 43 pass
- [x] \`npm run test:data\` — 5865 pass
- [x] \`npm run typecheck:all\` — clean
- [x] Biome lint on changed files — clean
- [ ] Watch next Railway cron: expect a successful publish with full country count, not a SIGTERM
- [ ] Verify degradation guard behaviour by comparing \`countries.length\` to prev snapshot