### PR TITLE
fix(pro): switch Clerk to no-rhc bundle so sign-in modal mounts on /pro

### DIFF
--- a/pro-test/src/App.tsx
+++ b/pro-test/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import * as Sentry from '@sentry/react';
 import { motion } from 'motion/react';
 import {
   Globe, Activity, ShieldAlert, Zap, Terminal, Database,
@@ -57,6 +58,7 @@ function getRefCode(): string | undefined {
 function openSignIn(): void {
   ensureClerk().then(c => c.openSignIn()).catch((err) => {
     console.error('[auth] Failed to open sign in:', err);
+    Sentry.captureException(err, { tags: { surface: 'pro-marketing', action: 'open-sign-in' } });
   });
 }
 

--- a/pro-test/src/services/checkout.ts
+++ b/pro-test/src/services/checkout.ts
@@ -35,8 +35,8 @@ async function _loadClerk(): Promise<InstanceType<typeof Clerk>> {
   const { Clerk: C } = await import('@clerk/clerk-js/no-rhc');
   const key = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
   if (!key) throw new Error('VITE_CLERK_PUBLISHABLE_KEY not set');
-  clerk = new C(key);
-  await clerk.load({
+  const instance = new C(key);
+  await instance.load({
     appearance: {
       variables: {
         colorBackground: '#0f0f0f',
@@ -59,6 +59,11 @@ async function _loadClerk(): Promise<InstanceType<typeof Clerk>> {
       },
     },
   });
+
+  // Only publish the instance after load() succeeds, so a failed load
+  // doesn't wedge ensureClerk()'s `if (clerk) return clerk;` short-circuit
+  // and bypass the retry path.
+  clerk = instance;
 
   // Auto-resume checkout after sign-in
   clerk.addListener(() => {

--- a/pro-test/src/services/checkout.ts
+++ b/pro-test/src/services/checkout.ts
@@ -5,6 +5,7 @@
  * No Convex client needed — the edge endpoint handles relay.
  */
 
+import * as Sentry from '@sentry/react';
 import type { Clerk } from '@clerk/clerk-js';
 import type { CheckoutEvent } from 'dodopayments-checkout';
 
@@ -28,7 +29,7 @@ export async function ensureClerk(): Promise<InstanceType<typeof Clerk>> {
 }
 
 async function _loadClerk(): Promise<InstanceType<typeof Clerk>> {
-  const { Clerk: C } = await import('@clerk/clerk-js');
+  const { Clerk: C } = await import('@clerk/clerk-js/no-rhc');
   const key = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
   if (!key) throw new Error('VITE_CLERK_PUBLISHABLE_KEY not set');
   clerk = new C(key);
@@ -101,7 +102,14 @@ export async function startCheckout(
   if (!c.user) {
     pendingProductId = productId;
     pendingOptions = options ?? null;
-    c.openSignIn();
+    try {
+      c.openSignIn();
+    } catch (err) {
+      console.error('[checkout] Failed to open sign in:', err);
+      Sentry.captureException(err, { tags: { surface: 'pro-marketing', action: 'checkout-sign-in' } });
+      pendingProductId = null;
+      pendingOptions = null;
+    }
     return false;
   }
 

--- a/pro-test/src/services/checkout.ts
+++ b/pro-test/src/services/checkout.ts
@@ -24,7 +24,10 @@ let clerkLoadPromise: Promise<InstanceType<typeof Clerk>> | null = null;
 export async function ensureClerk(): Promise<InstanceType<typeof Clerk>> {
   if (clerk) return clerk;
   if (clerkLoadPromise) return clerkLoadPromise;
-  clerkLoadPromise = _loadClerk();
+  clerkLoadPromise = _loadClerk().catch((err) => {
+    clerkLoadPromise = null;
+    throw err;
+  });
   return clerkLoadPromise;
 }
 
@@ -98,7 +101,15 @@ export async function startCheckout(
 ): Promise<boolean> {
   if (checkoutInFlight) return false;
 
-  const c = await ensureClerk();
+  let c: InstanceType<typeof Clerk>;
+  try {
+    c = await ensureClerk();
+  } catch (err) {
+    console.error('[checkout] Failed to load Clerk:', err);
+    Sentry.captureException(err, { tags: { surface: 'pro-marketing', action: 'load-clerk' } });
+    return false;
+  }
+
   if (!c.user) {
     pendingProductId = productId;
     pendingOptions = options ?? null;


### PR DESCRIPTION
## Summary

The /pro marketing page was throwing **"Clerk was not loaded with Ui components"** the moment an unauthenticated user clicked **Sign In** or **GET STARTED** on a pricing tier — blocking every paid conversion. The error was also silent in Sentry, so we had no visibility.

**Root cause**: `@clerk/clerk-js@^6` main export (`dist/clerk.mjs`) is the **headless** build — no UI controller. `clerk.load()` resolves fine, but the next call into any UI surface (`openSignIn`, `openSignUp`, `mountSignIn`, `openUserProfile`, …) hits an internal `assertComponentsReady` and throws. The bundled-with-UI variant is exposed at `@clerk/clerk-js/no-rhc` (same `Clerk` named export, drop-in).

This works fine when Clerk is loaded via `<script>` (the UMD bundle includes UI), which is why the bug only surfaces once you bundle through Vite.

**Why Sentry was blind**:
- `App.tsx` swallowed the rejection with `.catch(err => console.error(err))` — never reported.
- `checkout.ts:104` called `c.openSignIn()` unwrapped inside an async function; its synchronous throw rejected the outer promise, but the calling site never `.catch()`'d it.

## Changes

- \`pro-test/src/services/checkout.ts\` — switched dynamic import to \`@clerk/clerk-js/no-rhc\`; wrapped \`c.openSignIn()\` in try/catch with explicit \`Sentry.captureException\`.
- \`pro-test/src/App.tsx\` — added \`Sentry.captureException\` in the openSignIn \`.catch\` handler.

Tagged with \`surface: 'pro-marketing'\` so future regressions alarm immediately.

Skill extracted: \`clerk-js-bundler-headless-ui\`.

## Test plan

- [ ] Build pro-test (\`cd pro-test && npm run build\`) and load /pro as an anonymous user
- [ ] Click header **SIGN IN** → Clerk modal opens (no console error)
- [ ] Click pricing **GET STARTED** on Pro tier → Clerk modal opens (no console error)
- [ ] Sign in → checkout auto-resumes via \`pendingProductId\` listener and opens Dodo overlay
- [ ] Verify the bundled chunk for \`/pro\` includes both \`assertComponentsReady\` AND UI controller code (proves no-rhc was picked up, not the headless build)
- [ ] Force a sign-in failure (e.g., disconnect network mid-load) and confirm the error now surfaces in Sentry under tag \`surface: pro-marketing\`