### PR TITLE
chore(ci): enforce pro-test bundle freshness — local hook + CI backstop

### DIFF
--- a/.github/workflows/pro-bundle-freshness.yml
+++ b/.github/workflows/pro-bundle-freshness.yml
@@ -1,0 +1,52 @@
+name: Pro bundle freshness
+
+# Rebuilds pro-test on any PR that touches pro-test/** or public/pro/**
+# and fails if the committed public/pro/ doesn't match the build output.
+#
+# Why: public/pro/ is committed to the repo and served verbatim by Vercel.
+# The root build script does NOT run pro-test's vite build, so if a PR
+# changes pro-test/src/** but forgets to commit the regenerated bundle,
+# the deploy silently ships stale JS. Happened with PR #3227 → #3228.
+
+on:
+  pull_request:
+    paths:
+      - 'pro-test/**'
+      - 'public/pro/**'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: pro-test/package-lock.json
+
+      - name: Install pro-test deps
+        run: cd pro-test && npm ci
+
+      - name: Build pro-test
+        run: cd pro-test && npm run build
+
+      - name: Verify public/pro/ matches build output
+        run: |
+          if ! git diff --exit-code public/pro/; then
+            echo "::error::pro-test sources changed but public/pro/ is stale."
+            echo "Vercel ships whatever is committed under public/pro/ — it does NOT rebuild pro-test on deploy."
+            echo "Run 'cd pro-test && npm run build' locally and commit the regenerated bundle."
+            exit 1
+          fi
+          UNTRACKED=$(git ls-files --others --exclude-standard public/pro/)
+          if [ -n "$UNTRACKED" ]; then
+            echo "::error::Untracked files in public/pro/ after rebuild:"
+            echo "$UNTRACKED"
+            echo "Run 'git add public/pro/' and commit the regenerated bundle."
+            exit 1
+          fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -190,7 +190,12 @@ echo "Running pro-test bundle freshness check..."
 # pro-test/ scratch edits don't trigger a slow rebuild on unrelated
 # branches. RUN_ALL forces the check when the branch delta couldn't be
 # computed (matches the safety fallback used by the test runners above).
-if [ "$RUN_ALL" = true ] || echo "$CHANGED_FILES" | grep -q "^pro-test/"; then
+#
+# Trigger on EITHER pro-test/ OR public/pro/ to match the CI workflow's
+# path filter — a bundle-only PR that edits public/pro/ without touching
+# pro-test/ (e.g. a fix-forward rebuild, or a hand-edit) is exactly the
+# class of change this guard is meant to validate.
+if [ "$RUN_ALL" = true ] || echo "$CHANGED_FILES" | grep -qE "^(pro-test|public/pro)/"; then
   if [ ! -d pro-test/node_modules ]; then
     echo "  Installing pro-test deps..."
     (cd pro-test && npm install --prefer-offline) || exit 1
@@ -223,7 +228,7 @@ if [ "$RUN_ALL" = true ] || echo "$CHANGED_FILES" | grep -q "^pro-test/"; then
   fi
   echo "  pro-test bundle is up to date."
 else
-  echo "  Skipped (no pro-test/ changes in branch)."
+  echo "  Skipped (no pro-test/ or public/pro/ changes in branch)."
 fi
 
 echo "Running version sync check..."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -184,7 +184,13 @@ echo "Running pro-test bundle freshness check..."
 # changes ship without the rebuild, production /pro serves the old bundle
 # (see PR #3227 → #3228: source fix merged but deploy still broken because
 # public/pro/ was stale).
-if git diff --name-only origin/main -- pro-test/ | grep -q .; then
+#
+# Scope to the BRANCH delta ($CHANGED_FILES, computed earlier from
+# `git diff origin/main...HEAD`), not the worktree, so unstaged local
+# pro-test/ scratch edits don't trigger a slow rebuild on unrelated
+# branches. RUN_ALL forces the check when the branch delta couldn't be
+# computed (matches the safety fallback used by the test runners above).
+if [ "$RUN_ALL" = true ] || echo "$CHANGED_FILES" | grep -q "^pro-test/"; then
   if [ ! -d pro-test/node_modules ]; then
     echo "  Installing pro-test deps..."
     (cd pro-test && npm install --prefer-offline) || exit 1
@@ -217,7 +223,7 @@ if git diff --name-only origin/main -- pro-test/ | grep -q .; then
   fi
   echo "  pro-test bundle is up to date."
 else
-  echo "  Skipped (no pro-test/ changes)."
+  echo "  Skipped (no pro-test/ changes in branch)."
 fi
 
 echo "Running version sync check..."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -177,5 +177,48 @@ else
   echo "No proto-related changes, skipping."
 fi
 
+echo "Running pro-test bundle freshness check..."
+# public/pro/ is NOT built by Vercel — the root build script only runs the
+# main app's vite build. The /pro marketing app under pro-test/ must be
+# rebuilt manually and its output committed to public/pro/. If source
+# changes ship without the rebuild, production /pro serves the old bundle
+# (see PR #3227 → #3228: source fix merged but deploy still broken because
+# public/pro/ was stale).
+if git diff --name-only origin/main -- pro-test/ | grep -q .; then
+  if [ ! -d pro-test/node_modules ]; then
+    echo "  Installing pro-test deps..."
+    (cd pro-test && npm install --prefer-offline) || exit 1
+  fi
+  (cd pro-test && npm run build >/dev/null) || {
+    echo "ERROR: pro-test build failed"
+    exit 1
+  }
+  if ! git diff --exit-code public/pro/; then
+    echo ""
+    echo "============================================================"
+    echo "ERROR: pro-test sources changed but public/pro/ is stale."
+    echo "Vercel ships whatever is committed under public/pro/ —"
+    echo "it does NOT rebuild pro-test on deploy."
+    echo "Fix:"
+    echo "  cd pro-test && npm run build && cd .."
+    echo "  git add public/pro/ && git commit --amend --no-edit"
+    echo "============================================================"
+    exit 1
+  fi
+  UNTRACKED=$(git ls-files --others --exclude-standard public/pro/)
+  if [ -n "$UNTRACKED" ]; then
+    echo ""
+    echo "============================================================"
+    echo "ERROR: Untracked files in public/pro/ after rebuild:"
+    echo "$UNTRACKED"
+    echo "Run: git add public/pro/ && git commit --amend --no-edit"
+    echo "============================================================"
+    exit 1
+  fi
+  echo "  pro-test bundle is up to date."
+else
+  echo "  Skipped (no pro-test/ changes)."
+fi
+
 echo "Running version sync check..."
 npm run version:check || exit 1


### PR DESCRIPTION
## Why

\`public/pro/\` is **committed to the repo** and served verbatim by Vercel. The root build script only runs the main app's vite build — it does NOT run \`pro-test/\`'s build. So any PR that changes \`pro-test/src/**\` without manually running \`cd pro-test && npm run build\` and committing the regenerated chunks ships to production with a stale bundle.

This footgun just cost us:

- PR #3227 fixed the Clerk "Clerk was not loaded with Ui components" sign-in bug in source, merged, deployed.
- Live site still threw the error because the committed \`public/pro/assets/clerk-C6kUTNKl.js\` was the pre-fix build.
- PR #3228 fix-forwarded by rebuilding.

Without enforcement, this happens again the next time someone touches the pricing page, checkout, or any other pro-test surface.

## What

Two-layer guard, mirroring the proto-freshness pattern that already exists in the same hook (\`.husky/pre-push:146-178\`):

### 1. \`.husky/pre-push\` (local fast feedback)
If \`pro-test/\` changed vs \`origin/main\`:

1. Install \`pro-test\` deps if missing.
2. \`cd pro-test && npm run build\`
3. \`git diff --exit-code public/pro/\` — block push if dirty.
4. Fail loudly on untracked files in \`public/pro/\`.

### 2. \`.github/workflows/pro-bundle-freshness.yml\` (CI backstop)
On any PR touching \`pro-test/**\` or \`public/pro/**\`:

1. Checkout, setup-node 22 with pro-test/package-lock.json cache.
2. \`cd pro-test && npm ci && npm run build\`
3. \`git diff --exit-code public/pro/\` + untracked-files check.

This catches PRs even if the author bypassed the local hook (\`--no-verify\`, different machine, etc).

## Test plan

- [ ] Merge → on next PR that edits \`pro-test/src/\` without rebuilding, the new CI check should fail with a clear message.
- [ ] Local: in a branch with a pro-test/src edit but no \`public/pro/\` rebuild, \`git push\` should be blocked by the hook.
- [ ] Local: the same branch after \`cd pro-test && npm run build && git add public/pro/ && git commit --amend --no-edit\` should push cleanly.
- [ ] PRs that don't touch pro-test/ at all should not trigger either check (path filters).

## Notes

- The hook's "diff against origin/main" gate means a fix-forward branch that only touches \`public/pro/\` (like #3228) skips the local build step. CI covers that case via the \`public/pro/**\` path filter on the workflow trigger.
- I considered making the hook auto-stage the rebuilt files, but mirroring the existing proto-freshness pattern (block + tell the user the exact commands to run) keeps the diff to one obvious commit and avoids amending behind the dev's back.