### PR TITLE
fix(premium): route RPC clients through premiumFetch — stop 401s for pro users

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -1,5 +1,6 @@
 import type { AppContext, AppModule, CountryBriefSignals } from '@/app/app-context';
 import { getRpcBaseUrl } from '@/services/rpc-client';
+import { premiumFetch } from '@/services/premium-fetch';
 import type { TimelineEvent } from '@/components/CountryTimeline';
 import { CountryTimeline } from '@/components/CountryTimeline';
 import type {
@@ -581,10 +582,12 @@ export class CountryIntelManager implements AppModule {
 
   private fetchProSections(code: string): void {
     const rpcBase = getRpcBaseUrl();
-    const fetchFn = (...args: Parameters<typeof globalThis.fetch>) => globalThis.fetch(...args);
-    const economicClient = new EconomicServiceClient(rpcBase, { fetch: fetchFn });
-    const intelClientPro = new IntelligenceServiceClient(rpcBase, { fetch: fetchFn });
-    const tradeClient = new TradeServiceClient(rpcBase, { fetch: fetchFn });
+    // Pro-section endpoints (national-debt, regional briefs, comtrade flows)
+    // are premium-gated — premiumFetch injects the Clerk bearer / API key so
+    // signed-in pro users actually get data instead of 401.
+    const economicClient = new EconomicServiceClient(rpcBase, { fetch: premiumFetch });
+    const intelClientPro = new IntelligenceServiceClient(rpcBase, { fetch: premiumFetch });
+    const tradeClient = new TradeServiceClient(rpcBase, { fetch: premiumFetch });
     const iso3 = iso2ToIso3(code);
 
     economicClient.getNationalDebt({}).then(resp => {

--- a/src/components/DeductionPanel.ts
+++ b/src/components/DeductionPanel.ts
@@ -1,5 +1,6 @@
 import { Panel } from './Panel';
 import { getRpcBaseUrl } from '@/services/rpc-client';
+import { premiumFetch } from '@/services/premium-fetch';
 import { IntelligenceServiceClient } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 import { h, replaceChildren } from '@/utils/dom-utils';
 import { marked } from 'marked';
@@ -10,7 +11,8 @@ import { getActiveFrameworkForPanel } from '@/services/analysis-framework-store'
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { FrameworkSelector } from './FrameworkSelector';
 
-const client = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
+// deduct-situation + list-market-implications are premium-gated.
+const client = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: premiumFetch });
 
 const COOLDOWN_MS = 5_000;
 

--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -1,14 +1,16 @@
 import { Panel } from './Panel';
 import { getRpcBaseUrl } from '@/services/rpc-client';
+import { premiumFetch } from '@/services/premium-fetch';
 import { IntelligenceServiceClient } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 import type { RegionalSnapshot, RegimeTransition, RegionalBrief } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 import { h, replaceChildren } from '@/utils/dom-utils';
 import { escapeHtml } from '@/utils/sanitize';
 import { BOARD_REGIONS, DEFAULT_REGION_ID, buildBoardHtml, buildRegimeHistoryBlock, buildWeeklyBriefBlock, isLatestSequence } from './regional-intelligence-board-utils';
 
-const client = new IntelligenceServiceClient(getRpcBaseUrl(), {
-  fetch: (...args) => globalThis.fetch(...args),
-});
+// get-regional-snapshot + get-regime-history + get-regional-brief are
+// premium-gated. Plain globalThis.fetch skips Clerk/tester/api-key injection
+// and returns 401 for pro users — premiumFetch is the correct fetcher here.
+const client = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: premiumFetch });
 
 /**
  * RegionalIntelligenceBoard — premium panel rendering a canonical

--- a/src/services/trade/index.ts
+++ b/src/services/trade/index.ts
@@ -4,6 +4,7 @@
  */
 
 import { getRpcBaseUrl } from '@/services/rpc-client';
+import { premiumFetch } from '@/services/premium-fetch';
 import {
   TradeServiceClient,
   type GetTradeRestrictionsResponse,
@@ -35,7 +36,9 @@ export type {
   ListComtradeFlowsResponse,
 };
 
-const client = new TradeServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
+// get-tariff-trends + list-comtrade-flows are premium-gated; the rest fall
+// through premiumFetch unauthenticated without penalty.
+const client = new TradeServiceClient(getRpcBaseUrl(), { fetch: premiumFetch });
 
 const restrictionsBreaker = createCircuitBreaker<GetTradeRestrictionsResponse>({ name: 'WTO Restrictions', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
 const tariffsBreaker = createCircuitBreaker<GetTariffTrendsResponse>({ name: 'WTO Tariffs', cacheTtlMs: 30 * 60 * 1000, persistCache: true });

--- a/src/services/trade/index.ts
+++ b/src/services/trade/index.ts
@@ -6,6 +6,8 @@
 import { getRpcBaseUrl } from '@/services/rpc-client';
 import { premiumFetch } from '@/services/premium-fetch';
 import { getCurrentClerkUser } from '@/services/clerk';
+import { hasPremiumAccess } from '@/services/panel-gating';
+import { onEntitlementChange } from '@/services/entitlements';
 import {
   TradeServiceClient,
   type GetTradeRestrictionsResponse,
@@ -67,31 +69,36 @@ const barriersBreaker = createCircuitBreaker<GetTradeBarriersResponse>({ name: '
 const revenueBreaker = createCircuitBreaker<GetCustomsRevenueResponse>({ name: 'Treasury Revenue', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
 const comtradeBreaker = createCircuitBreaker<ListComtradeFlowsResponse>({ name: 'Comtrade Flows', cacheTtlMs: 6 * 60 * 60 * 1000, persistCache: false });
 
-// Track the Clerk identity + entitlement that last populated the in-memory
-// premium breaker caches. On any change — sign-out, user switch, OR
-// entitlement downgrade/upgrade for the same user — wipe the premium
+// Track the identity + entitlement fingerprint that last populated the
+// in-memory premium breaker caches. On any change — sign-out, user switch,
+// OR entitlement downgrade/upgrade for the same user — wipe the premium
 // breakers so the new session doesn't see the previous session's premium
 // response. persistCache:false already closes the cross-browser-reload
 // path; this closes the in-tab SPA transition path.
 //
-// The fingerprint must include `plan`: a user who cancels Pro mid-session
-// keeps the same Clerk user id, so a pure-id key would let their cached
-// tariff/comtrade response persist for up to the breaker TTL even though
-// the gateway would now refuse a fresh fetch.
+// ENTITLEMENT SIGNAL: hasPremiumAccess() is the repo's single source of
+// truth (src/services/panel-gating.ts). It unions API key, tester key,
+// Clerk pro role, and Convex Dodo entitlement via isProUser/isEntitled.
+// The earlier version of this fingerprint used Clerk publicMetadata.plan,
+// which is NOT written by the webhook pipeline — a paying user with a
+// valid Dodo entitlement would still fingerprint as 'free', and a user
+// whose Dodo subscription lapsed would still fingerprint as 'pro' until
+// the next Clerk session refresh. Swap to hasPremiumAccess() so the
+// fingerprint tracks authoritative entitlement state directly.
 //
-// Shape: `${userId}:${plan}` | `anon` | null-not-yet-observed
+// Shape: `${userId}:${entitled ? 'pro' : 'free'}` | `anon:<state>` | undefined-not-yet-observed
 let lastPremiumFingerprint: string | null | undefined; // undefined = never observed
 
 function currentPremiumFingerprint(): string {
+  let userId = 'anon';
   try {
-    const u = getCurrentClerkUser();
-    if (!u) return 'anon';
-    return `${u.id}:${u.plan}`;
-  } catch {
-    // Clerk not loaded yet — treat as anon; first real call after load
-    // will trigger an invalidation because the fingerprint will differ.
-    return 'anon';
-  }
+    userId = getCurrentClerkUser()?.id ?? 'anon';
+  } catch { /* Clerk not loaded yet */ }
+  let entitled = false;
+  try {
+    entitled = hasPremiumAccess();
+  } catch { /* entitlement/panel-gating not ready */ }
+  return `${userId}:${entitled ? 'pro' : 'free'}`;
 }
 
 function invalidatePremiumBreakersIfIdentityChanged(): void {
@@ -102,6 +109,20 @@ function invalidatePremiumBreakersIfIdentityChanged(): void {
   }
   lastPremiumFingerprint = fp;
 }
+
+// Reactive path: when Convex publishes an entitlement change, wipe the
+// premium breakers immediately rather than waiting for the next premium
+// fetcher call. A user whose subscription lapses after they've opened
+// the tariff panel shouldn't keep seeing premium data until they click
+// something else.
+onEntitlementChange(() => {
+  const fp = currentPremiumFingerprint();
+  if (lastPremiumFingerprint !== undefined && fp !== lastPremiumFingerprint) {
+    tariffsBreaker.clearMemoryCache();
+    comtradeBreaker.clearMemoryCache();
+    lastPremiumFingerprint = fp;
+  }
+});
 
 const emptyRestrictions: GetTradeRestrictionsResponse = { restrictions: [], fetchedAt: '', upstreamUnavailable: false };
 const emptyTariffs: GetTariffTrendsResponse = { datapoints: [], fetchedAt: '', upstreamUnavailable: false };

--- a/src/services/trade/index.ts
+++ b/src/services/trade/index.ts
@@ -36,16 +36,35 @@ export type {
   ListComtradeFlowsResponse,
 };
 
-// get-tariff-trends + list-comtrade-flows are premium-gated; the rest fall
-// through premiumFetch unauthenticated without penalty.
-const client = new TradeServiceClient(getRpcBaseUrl(), { fetch: premiumFetch });
+// Two clients to prevent cross-entitlement cache leakage.
+//
+// The breakers below use `persistCache: true` and auth-invariant cache
+// keys — once a response lands in the cache it's served to any future
+// session on the same browser without re-authenticating. Routing
+// premium-backed calls through the same client as non-premium calls
+// would let a pro user's tariff/comtrade response populate the cache
+// and leak to the next free / signed-out session. Keep them split:
+//
+//   - publicClient  (globalThis.fetch)  — feeds restrictionsBreaker,
+//     flowsBreaker, barriersBreaker, revenueBreaker. Unauthenticated,
+//     shareable response bodies, safe to cache across auth states.
+//
+//   - premiumClient (premiumFetch)      — ONLY used for get-tariff-trends
+//     and list-comtrade-flows. Injects the caller's Clerk bearer /
+//     tester-key / WORLDMONITOR_API_KEY, so pro users get real data
+//     instead of 401.
+const publicClient = new TradeServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
+const premiumClient = new TradeServiceClient(getRpcBaseUrl(), { fetch: premiumFetch });
 
 const restrictionsBreaker = createCircuitBreaker<GetTradeRestrictionsResponse>({ name: 'WTO Restrictions', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
-const tariffsBreaker = createCircuitBreaker<GetTariffTrendsResponse>({ name: 'WTO Tariffs', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
+// Premium endpoints: persistCache:false so a pro user's response is NOT
+// written to localStorage/IndexedDB where a later free / signed-out session
+// on the same browser would read it back without re-authenticating.
+const tariffsBreaker = createCircuitBreaker<GetTariffTrendsResponse>({ name: 'WTO Tariffs', cacheTtlMs: 30 * 60 * 1000, persistCache: false });
 const flowsBreaker = createCircuitBreaker<GetTradeFlowsResponse>({ name: 'WTO Flows', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
 const barriersBreaker = createCircuitBreaker<GetTradeBarriersResponse>({ name: 'WTO Barriers', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
 const revenueBreaker = createCircuitBreaker<GetCustomsRevenueResponse>({ name: 'Treasury Revenue', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
-const comtradeBreaker = createCircuitBreaker<ListComtradeFlowsResponse>({ name: 'Comtrade Flows', cacheTtlMs: 6 * 60 * 60 * 1000, persistCache: true });
+const comtradeBreaker = createCircuitBreaker<ListComtradeFlowsResponse>({ name: 'Comtrade Flows', cacheTtlMs: 6 * 60 * 60 * 1000, persistCache: false });
 
 const emptyRestrictions: GetTradeRestrictionsResponse = { restrictions: [], fetchedAt: '', upstreamUnavailable: false };
 const emptyTariffs: GetTariffTrendsResponse = { datapoints: [], fetchedAt: '', upstreamUnavailable: false };
@@ -58,7 +77,7 @@ export async function fetchTradeRestrictions(countries: string[] = [], limit = 5
   if (!isFeatureAvailable('wtoTrade')) return emptyRestrictions;
   try {
     return await restrictionsBreaker.execute(async () => {
-      return client.getTradeRestrictions({ countries, limit });
+      return publicClient.getTradeRestrictions({ countries, limit });
     }, emptyRestrictions, { shouldCache: r => (r.restrictions?.length ?? 0) > 0 });
   } catch {
     return emptyRestrictions;
@@ -69,7 +88,7 @@ export async function fetchTariffTrends(reportingCountry: string, partnerCountry
   if (!isFeatureAvailable('wtoTrade')) return emptyTariffs;
   try {
     return await tariffsBreaker.execute(async () => {
-      return client.getTariffTrends({ reportingCountry, partnerCountry, productSector, years });
+      return premiumClient.getTariffTrends({ reportingCountry, partnerCountry, productSector, years });
     }, emptyTariffs, { shouldCache: r => (r.datapoints?.length ?? 0) > 0 });
   } catch {
     return emptyTariffs;
@@ -80,7 +99,7 @@ export async function fetchTradeFlows(reportingCountry: string, partnerCountry: 
   if (!isFeatureAvailable('wtoTrade')) return emptyFlows;
   try {
     return await flowsBreaker.execute(async () => {
-      return client.getTradeFlows({ reportingCountry, partnerCountry, years });
+      return publicClient.getTradeFlows({ reportingCountry, partnerCountry, years });
     }, emptyFlows, { shouldCache: r => (r.flows?.length ?? 0) > 0 });
   } catch {
     return emptyFlows;
@@ -91,7 +110,7 @@ export async function fetchTradeBarriers(countries: string[] = [], measureType =
   if (!isFeatureAvailable('wtoTrade')) return emptyBarriers;
   try {
     return await barriersBreaker.execute(async () => {
-      return client.getTradeBarriers({ countries, measureType, limit });
+      return publicClient.getTradeBarriers({ countries, measureType, limit });
     }, emptyBarriers, { shouldCache: r => (r.barriers?.length ?? 0) > 0 });
   } catch {
     return emptyBarriers;
@@ -103,7 +122,7 @@ export async function fetchCustomsRevenue(): Promise<GetCustomsRevenueResponse> 
   if (hydrated?.months?.length) return hydrated;
   try {
     return await revenueBreaker.execute(async () => {
-      return client.getCustomsRevenue({});
+      return publicClient.getCustomsRevenue({});
     }, emptyRevenue, { shouldCache: r => (r.months?.length ?? 0) > 0 });
   } catch {
     return emptyRevenue;
@@ -113,7 +132,7 @@ export async function fetchCustomsRevenue(): Promise<GetCustomsRevenueResponse> 
 export async function fetchComtradeFlows(): Promise<ListComtradeFlowsResponse> {
   try {
     return await comtradeBreaker.execute(async () => {
-      return client.listComtradeFlows({ reporterCode: '', cmdCode: '', anomaliesOnly: false });
+      return premiumClient.listComtradeFlows({ reporterCode: '', cmdCode: '', anomaliesOnly: false });
     }, emptyComtrade, { shouldCache: r => (r.flows?.length ?? 0) > 0 });
   } catch {
     return emptyComtrade;

--- a/src/services/trade/index.ts
+++ b/src/services/trade/index.ts
@@ -5,6 +5,7 @@
 
 import { getRpcBaseUrl } from '@/services/rpc-client';
 import { premiumFetch } from '@/services/premium-fetch';
+import { getCurrentClerkUser } from '@/services/clerk';
 import {
   TradeServiceClient,
   type GetTradeRestrictionsResponse,
@@ -66,6 +67,26 @@ const barriersBreaker = createCircuitBreaker<GetTradeBarriersResponse>({ name: '
 const revenueBreaker = createCircuitBreaker<GetCustomsRevenueResponse>({ name: 'Treasury Revenue', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
 const comtradeBreaker = createCircuitBreaker<ListComtradeFlowsResponse>({ name: 'Comtrade Flows', cacheTtlMs: 6 * 60 * 60 * 1000, persistCache: false });
 
+// Track the Clerk user identity that last populated the in-memory premium
+// breaker caches. On identity change (sign-out, user switch, free→pro
+// upgrade, pro→free downgrade), wipe the premium breakers' in-memory cache
+// so the new session doesn't see the previous session's premium response.
+// persistCache:false already closes the cross-browser-reload path; this
+// closes the in-tab SPA auth-transition path.
+let lastPremiumUserId: string | null | undefined; // undefined = never observed
+
+function invalidatePremiumBreakersIfIdentityChanged(): void {
+  let currentUserId: string | null = null;
+  try {
+    currentUserId = getCurrentClerkUser()?.id ?? null;
+  } catch { /* clerk not loaded yet */ }
+  if (lastPremiumUserId !== undefined && currentUserId !== lastPremiumUserId) {
+    tariffsBreaker.clearMemoryCache();
+    comtradeBreaker.clearMemoryCache();
+  }
+  lastPremiumUserId = currentUserId;
+}
+
 const emptyRestrictions: GetTradeRestrictionsResponse = { restrictions: [], fetchedAt: '', upstreamUnavailable: false };
 const emptyTariffs: GetTariffTrendsResponse = { datapoints: [], fetchedAt: '', upstreamUnavailable: false };
 const emptyFlows: GetTradeFlowsResponse = { flows: [], fetchedAt: '', upstreamUnavailable: false };
@@ -86,6 +107,7 @@ export async function fetchTradeRestrictions(countries: string[] = [], limit = 5
 
 export async function fetchTariffTrends(reportingCountry: string, partnerCountry: string, productSector = '', years = 10): Promise<GetTariffTrendsResponse> {
   if (!isFeatureAvailable('wtoTrade')) return emptyTariffs;
+  invalidatePremiumBreakersIfIdentityChanged();
   try {
     return await tariffsBreaker.execute(async () => {
       return premiumClient.getTariffTrends({ reportingCountry, partnerCountry, productSector, years });
@@ -130,6 +152,7 @@ export async function fetchCustomsRevenue(): Promise<GetCustomsRevenueResponse> 
 }
 
 export async function fetchComtradeFlows(): Promise<ListComtradeFlowsResponse> {
+  invalidatePremiumBreakersIfIdentityChanged();
   try {
     return await comtradeBreaker.execute(async () => {
       return premiumClient.listComtradeFlows({ reporterCode: '', cmdCode: '', anomaliesOnly: false });

--- a/src/services/trade/index.ts
+++ b/src/services/trade/index.ts
@@ -67,24 +67,40 @@ const barriersBreaker = createCircuitBreaker<GetTradeBarriersResponse>({ name: '
 const revenueBreaker = createCircuitBreaker<GetCustomsRevenueResponse>({ name: 'Treasury Revenue', cacheTtlMs: 30 * 60 * 1000, persistCache: true });
 const comtradeBreaker = createCircuitBreaker<ListComtradeFlowsResponse>({ name: 'Comtrade Flows', cacheTtlMs: 6 * 60 * 60 * 1000, persistCache: false });
 
-// Track the Clerk user identity that last populated the in-memory premium
-// breaker caches. On identity change (sign-out, user switch, free→pro
-// upgrade, pro→free downgrade), wipe the premium breakers' in-memory cache
-// so the new session doesn't see the previous session's premium response.
-// persistCache:false already closes the cross-browser-reload path; this
-// closes the in-tab SPA auth-transition path.
-let lastPremiumUserId: string | null | undefined; // undefined = never observed
+// Track the Clerk identity + entitlement that last populated the in-memory
+// premium breaker caches. On any change — sign-out, user switch, OR
+// entitlement downgrade/upgrade for the same user — wipe the premium
+// breakers so the new session doesn't see the previous session's premium
+// response. persistCache:false already closes the cross-browser-reload
+// path; this closes the in-tab SPA transition path.
+//
+// The fingerprint must include `plan`: a user who cancels Pro mid-session
+// keeps the same Clerk user id, so a pure-id key would let their cached
+// tariff/comtrade response persist for up to the breaker TTL even though
+// the gateway would now refuse a fresh fetch.
+//
+// Shape: `${userId}:${plan}` | `anon` | null-not-yet-observed
+let lastPremiumFingerprint: string | null | undefined; // undefined = never observed
+
+function currentPremiumFingerprint(): string {
+  try {
+    const u = getCurrentClerkUser();
+    if (!u) return 'anon';
+    return `${u.id}:${u.plan}`;
+  } catch {
+    // Clerk not loaded yet — treat as anon; first real call after load
+    // will trigger an invalidation because the fingerprint will differ.
+    return 'anon';
+  }
+}
 
 function invalidatePremiumBreakersIfIdentityChanged(): void {
-  let currentUserId: string | null = null;
-  try {
-    currentUserId = getCurrentClerkUser()?.id ?? null;
-  } catch { /* clerk not loaded yet */ }
-  if (lastPremiumUserId !== undefined && currentUserId !== lastPremiumUserId) {
+  const fp = currentPremiumFingerprint();
+  if (lastPremiumFingerprint !== undefined && fp !== lastPremiumFingerprint) {
     tariffsBreaker.clearMemoryCache();
     comtradeBreaker.clearMemoryCache();
   }
-  lastPremiumUserId = currentUserId;
+  lastPremiumFingerprint = fp;
 }
 
 const emptyRestrictions: GetTradeRestrictionsResponse = { restrictions: [], fetchedAt: '', upstreamUnavailable: false };


### PR DESCRIPTION
## Why

Four generated-client instantiations in the main app were using plain \`globalThis.fetch\`, bypassing the auth-injection chain in \`src/services/premium-fetch.ts\` (Clerk bearer token → tester key → \`WORLDMONITOR_API_KEY\`). For endpoints listed in \`src/shared/premium-paths.ts\`, signed-in pro users hit 401 instead of getting data.

Surfaced after fixing /pro sign-in (PR #3232) — user landed on \`/\` post-auth and saw 401 on \`get-regional-snapshot\` and \`get-tariff-trends\`.

## Fix

Swap \`fetch: (...args) => globalThis.fetch(...args)\` → \`fetch: premiumFetch\` in the four offender files:

| File | Premium endpoint(s) it calls |
|---|---|
| \`src/components/RegionalIntelligenceBoard.ts\` | get-regional-snapshot, get-regime-history, get-regional-brief |
| \`src/components/DeductionPanel.ts\` | deduct-situation, list-market-implications |
| \`src/services/trade/index.ts\` | get-tariff-trends, list-comtrade-flows (+ non-premium siblings) |
| \`src/app/country-intel.ts::fetchProSections\` | get-national-debt, regional briefs, list-comtrade-flows |

\`premiumFetch\` falls through to a plain fetch when no auth is available, so routing non-premium endpoints through it is identical to \`globalThis.fetch\` — no regression surface for anonymous / free users.

## Left untouched

Three other files construct \`IntelligenceServiceClient\` with \`globalThis.fetch\` but **only call non-premium endpoints**. Not currently broken; worth swapping when convenient but not blocking:

- \`src/services/gdelt-intel.ts\` → \`searchGdeltDocuments\` (not in \`PREMIUM_RPC_PATHS\`)
- \`src/services/social-velocity.ts\` → \`getSocialVelocity\`
- \`src/services/pizzint.ts\` → \`getPizzintStatus\`

If any of those endpoints later move into \`PREMIUM_RPC_PATHS\`, swap them too. Logged as memory + pattern so future PRs catch it.

## Test plan

- [ ] typecheck passes locally ✓
- [ ] As anonymous user → load /, free panels still render (no auth header added by \`premiumFetch\` fallthrough, identical behavior)
- [ ] As signed-in **pro** user → load /, Regional Intelligence board populates (was 401)
- [ ] As signed-in **pro** user → open a country deep-dive → pro sections (national debt, trade flows) populate (was 401)
- [ ] As signed-in **pro** user → open DeductionPanel, run a deduction (was 401 before hitting the LLM)
- [ ] As signed-in **free** user → confirm the existing paywall UI still triggers correctly (the 401 will now be replaced by the server's explicit 403/plan-required response, which the panels should handle)

## Related

Follows PR #3232 (/pro Clerk v5 downgrade — sign-in modal now opens). Together they close the end-to-end pro flow: sign in from /pro → land on / → premium panels actually render.