### PR TITLE
feat(digest-dedup): single-link clustering (F1 0.73 vs 0.53 complete-link)

### DIFF
--- a/scripts/lib/brief-dedup-embed.mjs
+++ b/scripts/lib/brief-dedup-embed.mjs
@@ -219,3 +219,96 @@ export function completeLinkCluster(items, { cosineThreshold, vetoFn = null }) {
   return { clusters, vetoFires };
 }
 
+// ── Single-link clustering ─────────────────────────────────────────────
+
+/**
+ * Single-link agglomerative clustering via union-find.
+ *
+ * Admission rule: two items end up in the same cluster iff there
+ * EXISTS a path of pairwise merges, where every step has
+ *   1. cosine(a.embedding, b.embedding) >= cosineThreshold
+ *   2. vetoFn(a, b) === false  (if vetoFn provided)
+ *
+ * This lets wire stories chain through a strong intermediate
+ * headline: ship-1 ↔ ship-5 (0.63) and ship-5 ↔ ship-8 (0.69) both
+ * clear, so all three merge even when ship-1 ↔ ship-8 is only 0.50.
+ * Complete-link would block this whole cluster because of the one
+ * weak pair.
+ *
+ * The original plan rejected single-link to avoid "bridge pollution"
+ * (topically-unrelated stories chaining through a mixed-topic
+ * headline). With embeddings at threshold ≥ 0.60 the bridge has to
+ * be semantically real, so the empirical win on the 2026-04-20
+ * story set (F1 0.73 vs complete-link 0.53) outweighed the
+ * theoretical concern.
+ *
+ * Output cluster membership is independent of iteration order — the
+ * union-find shape is determined purely by the set of admissible
+ * pairs, so single-link is permutation-invariant by construction.
+ *
+ * @param {Array<{title:string, embedding:number[]}>} items
+ * @param {object} opts
+ * @param {number} opts.cosineThreshold
+ * @param {((a: {title:string}, b: {title:string}) => boolean) | null} [opts.vetoFn]
+ * @returns {{ clusters: number[][], vetoFires: number }}
+ */
+export function singleLinkCluster(items, { cosineThreshold, vetoFn = null }) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return { clusters: [], vetoFires: 0 };
+  }
+
+  const n = items.length;
+  const parent = new Array(n);
+  const rank = new Array(n).fill(0);
+  for (let i = 0; i < n; i++) parent[i] = i;
+
+  const find = (x) => {
+    while (parent[x] !== x) {
+      parent[x] = parent[parent[x]];
+      x = parent[x];
+    }
+    return x;
+  };
+  const union = (a, b) => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra === rb) return;
+    if (rank[ra] < rank[rb]) parent[ra] = rb;
+    else if (rank[ra] > rank[rb]) parent[rb] = ra;
+    else { parent[rb] = ra; rank[ra]++; }
+  };
+
+  let vetoFires = 0;
+  for (let i = 0; i < n; i++) {
+    const a = items[i];
+    if (!a || !Array.isArray(a.embedding)) continue;
+    for (let j = i + 1; j < n; j++) {
+      const b = items[j];
+      if (!b || !Array.isArray(b.embedding)) continue;
+      // Already in the same cluster via a prior union — skip both
+      // the cosine and veto checks. Union-find makes this cheap.
+      if (find(i) === find(j)) continue;
+      const cos = cosineSimilarity(a.embedding, b.embedding);
+      if (cos < cosineThreshold) continue;
+      if (vetoFn?.(a, b)) {
+        vetoFires += 1;
+        continue;
+      }
+      union(i, j);
+    }
+  }
+
+  // Build clusters preserving the caller's input order: iterate
+  // items in order, group by their union-find root, and drop into
+  // a Map whose insertion order reflects first-appearance. Keeps
+  // downstream representative selection deterministic alongside
+  // the caller's pre-sort contract.
+  const byRoot = new Map();
+  for (let i = 0; i < n; i++) {
+    const r = find(i);
+    if (!byRoot.has(r)) byRoot.set(r, []);
+    byRoot.get(r).push(i);
+  }
+  return { clusters: [...byRoot.values()], vetoFires };
+}
+

--- a/scripts/lib/brief-dedup.mjs
+++ b/scripts/lib/brief-dedup.mjs
@@ -35,6 +35,7 @@ import {
 import {
   completeLinkCluster,
   shouldVeto,
+  singleLinkCluster,
 } from './brief-dedup-embed.mjs';
 import {
   embedBatch,
@@ -48,6 +49,7 @@ import { defaultRedisPipeline } from './_upstash-pipeline.mjs';
  * @param {Record<string, string | undefined>} [env]
  * @returns {{
  *   mode: 'jaccard' | 'embed',
+ *   clustering: 'single' | 'complete',
  *   entityVetoEnabled: boolean,
  *   cosineThreshold: number,
  *   wallClockMs: number,
@@ -69,6 +71,17 @@ export function readOrchestratorConfig(env = process.env) {
     invalidModeRaw = modeRaw;
   }
 
+  // DIGEST_DEDUP_CLUSTERING = 'single' (default) | 'complete'.
+  // Single-link chains wire variants that share a strong
+  // intermediate headline (calibrated F1 0.73 vs complete-link 0.53
+  // on real brief output). Flip to 'complete' for instant kill
+  // switch if single-link ever over-merges in production.
+  const clusteringRaw = (env.DIGEST_DEDUP_CLUSTERING ?? '').toLowerCase();
+  const clustering =
+    clusteringRaw === 'complete' ? 'complete'
+    : clusteringRaw === 'single' || clusteringRaw === '' ? 'single'
+    : 'single';
+
   const cosineRaw = Number.parseFloat(env.DIGEST_DEDUP_COSINE_THRESHOLD ?? '');
   const cosineThreshold =
     Number.isFinite(cosineRaw) && cosineRaw > 0 && cosineRaw <= 1 ? cosineRaw : 0.60;
@@ -79,6 +92,7 @@ export function readOrchestratorConfig(env = process.env) {
 
   return {
     mode,
+    clustering,
     entityVetoEnabled: env.DIGEST_DEDUP_ENTITY_VETO_ENABLED !== '0',
     cosineThreshold,
     wallClockMs,
@@ -175,7 +189,8 @@ export async function deduplicateStories(stories, deps = {}) {
     const vetoFn = cfg.entityVetoEnabled
       ? (a, b) => shouldVeto(a.title, b.title)
       : null;
-    const clusterResult = completeLinkCluster(items, {
+    const clusterFn = cfg.clustering === 'complete' ? completeLinkCluster : singleLinkCluster;
+    const clusterResult = clusterFn(items, {
       cosineThreshold: cfg.cosineThreshold,
       vetoFn,
     });
@@ -186,7 +201,7 @@ export async function deduplicateStories(stories, deps = {}) {
     );
 
     log(
-      `[digest] dedup mode=embed stories=${items.length} clusters=${embedClusters.length} ` +
+      `[digest] dedup mode=embed clustering=${cfg.clustering} stories=${items.length} clusters=${embedClusters.length} ` +
         `veto_fires=${clusterResult.vetoFires} ms=${nowImpl() - started} ` +
         `threshold=${cfg.cosineThreshold} fallback=false`,
     );

--- a/tests/brief-dedup-embedding.test.mjs
+++ b/tests/brief-dedup-embedding.test.mjs
@@ -35,6 +35,7 @@ import {
   completeLinkCluster,
   extractEntities,
   shouldVeto,
+  singleLinkCluster,
 } from '../scripts/lib/brief-dedup-embed.mjs';
 
 // ── Fixture helpers ───────────────────────────────────────────────────────────
@@ -538,6 +539,141 @@ describe('extractEntities', () => {
       shouldVeto('Houthis strike ship in Red Sea', 'US escorts convoy in Red Sea'),
       true,
     );
+  });
+});
+
+// ── Single-link clustering ───────────────────────────────────────────────────
+
+describe('singleLinkCluster', () => {
+  // Derived from a real production case (2026-04-20-1532 brief, US
+  // Navy ship-seizure coverage): 4 wire stories about the same event
+  // where pairwise cosines chain through a strong intermediate (story
+  // 5 with cos ≥ 0.63 to every other) but one outlier pair (1↔8) is
+  // 0.500. Complete-link refuses to merge all 4 because of the outlier;
+  // single-link chains them via the bridge.
+  it('chains 4 items through a strong intermediate when one pair is weak', () => {
+    // Construct 4 unit vectors so cosines are exact:
+    //   5 = [1, 0, 0]
+    //   1 ≈ strong link to 5 (~0.65), weak to 8
+    //   8 ≈ strong link to 5 (~0.70), weak to 1
+    //   10 ≈ strong link to 5 (~0.66), weak to 8
+    // Constructing this in 3D isn't straightforward; easier to just
+    // hand-craft vectors that give the required pairwise matrix.
+    const v5 = [1, 0, 0, 0];
+    const v1 = [0.65, Math.sqrt(1 - 0.65 * 0.65), 0, 0];
+    const v8 = [0.70, 0.0, Math.sqrt(1 - 0.70 * 0.70), 0];
+    const v10 = [0.66, Math.sqrt(1 - 0.66 * 0.66) * 0.3, 0, Math.sqrt(1 - 0.66 * 0.66 - (Math.sqrt(1 - 0.66 * 0.66) * 0.3) ** 2)];
+    const items = [
+      { title: 's1', embedding: v1 },
+      { title: 's5', embedding: v5 },
+      { title: 's8', embedding: v8 },
+      { title: 's10', embedding: v10 },
+    ];
+
+    // Complete-link at 0.55 splits at least one story out because the
+    // weak 1↔8 / 8↔10 pairs fail the "every pair" rule.
+    const complete = completeLinkCluster(items, { cosineThreshold: 0.55 });
+    assert.ok(complete.clusters.length >= 2, 'complete-link fails to merge all 4');
+
+    // Single-link at 0.55 chains them through story 5 (strong link
+    // to each of 1, 8, 10).
+    const single = singleLinkCluster(items, { cosineThreshold: 0.55 });
+    assert.equal(single.clusters.length, 1, 'single-link unions all 4 via the bridge');
+    assert.deepEqual([...single.clusters[0]].sort(), [0, 1, 2, 3]);
+  });
+
+  it('respects veto: pairs that satisfy cosine but fail shouldVeto do NOT union', () => {
+    // Two items with high cosine but the veto fires on the pair
+    // shape (shared location, disagreeing actors).
+    const items = [
+      { title: 'Biden meets Xi in Tokyo', embedding: [1, 0, 0] },
+      { title: 'Biden meets Putin in Tokyo', embedding: [0.99, Math.sqrt(1 - 0.99 * 0.99), 0] },
+    ];
+    const vetoFn = (a, b) => shouldVeto(a.title, b.title);
+    const out = singleLinkCluster(items, { cosineThreshold: 0.5, vetoFn });
+    assert.equal(out.clusters.length, 2, 'veto keeps the two titles separate');
+    assert.equal(out.vetoFires, 1);
+  });
+
+  it('permutation-invariant: random input orders yield the same cluster set', () => {
+    // Single-link is order-independent by construction (union-find
+    // doesn't care which pair is visited first). Property test.
+    const N = 12;
+    const items = [];
+    for (let c = 0; c < 3; c++) {
+      const basis = Array.from({ length: 3 }, (_, i) => (i === c ? 1 : 0));
+      for (let k = 0; k < 4; k++) {
+        const jitter = basis.map((v, i) => (i === c ? v - k * 0.002 : v));
+        items.push({ title: `c${c}-k${k}`, embedding: jitter, _hash: `c${c}k${k}` });
+      }
+    }
+    const baseline = singleLinkCluster(items, { cosineThreshold: 0.9 }).clusters;
+    const baselineSig = baseline
+      .map((c) => c.map((i) => items[i]._hash).sort().join(','))
+      .sort()
+      .join('|');
+
+    let seed = 17;
+    const rand = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+    for (let r = 0; r < 5; r++) {
+      const shuffled = [...items];
+      for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(rand() * (i + 1));
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+      }
+      const run = singleLinkCluster(shuffled, { cosineThreshold: 0.9 }).clusters;
+      const sig = run
+        .map((c) => c.map((i) => shuffled[i]._hash).sort().join(','))
+        .sort()
+        .join('|');
+      assert.equal(sig, baselineSig, `shuffle ${r} produced a different cluster set`);
+    }
+  });
+
+  it('empty input returns empty clusters without exploding', () => {
+    const out = singleLinkCluster([], { cosineThreshold: 0.5 });
+    assert.deepEqual(out.clusters, []);
+    assert.equal(out.vetoFires, 0);
+  });
+});
+
+// ── Orchestrator clustering-algorithm dispatch ────────────────────────────────
+
+describe('readOrchestratorConfig — DIGEST_DEDUP_CLUSTERING', () => {
+  it('defaults to single-link when DIGEST_DEDUP_CLUSTERING is unset', async () => {
+    const { readOrchestratorConfig } = await import('../scripts/lib/brief-dedup.mjs');
+    const cfg = readOrchestratorConfig({});
+    assert.equal(cfg.clustering, 'single');
+  });
+  it('honours DIGEST_DEDUP_CLUSTERING=complete (kill switch)', async () => {
+    const { readOrchestratorConfig } = await import('../scripts/lib/brief-dedup.mjs');
+    const cfg = readOrchestratorConfig({ DIGEST_DEDUP_CLUSTERING: 'complete' });
+    assert.equal(cfg.clustering, 'complete');
+  });
+  it('unrecognised values fall back to single (default, safe)', async () => {
+    const { readOrchestratorConfig } = await import('../scripts/lib/brief-dedup.mjs');
+    const cfg = readOrchestratorConfig({ DIGEST_DEDUP_CLUSTERING: 'average' });
+    assert.equal(cfg.clustering, 'single');
+  });
+  it('structured log line includes clustering=<algo>', async () => {
+    const { deduplicateStories } = await import('../scripts/lib/brief-dedup.mjs');
+    const stories = [story('x', 10, 1, 'x1'), story('y', 10, 1, 'y1')];
+    const vec = new Map([
+      [normalizeForEmbedding('x'), [1, 0, 0]],
+      [normalizeForEmbedding('y'), [0.99, Math.sqrt(1 - 0.99 * 0.99), 0]],
+    ]);
+    const { embedBatch } = stubEmbedder(vec);
+    const lines = [];
+    await deduplicateStories(stories, {
+      env: { DIGEST_DEDUP_MODE: 'embed', DIGEST_DEDUP_COSINE_THRESHOLD: '0.5' },
+      embedBatch,
+      redisPipeline: async () => [],
+      log: (l) => lines.push(l),
+    });
+    assert.ok(lines.some((l) => /clustering=(single|complete)/.test(l)), 'log line must mention clustering algorithm');
   });
 });
 


### PR DESCRIPTION
## Summary

`DIGEST_DEDUP_COSINE_THRESHOLD=0.55` set on Railway this morning still produced a brief with 4 copies of "US seizes Iranian ship", 3 copies of the Hormuz closure, and 2 copies of the oil story.

Root cause: **complete-link is too strict for wire-headline clustering.** On the 4-way ship-seizure cluster from today's 15:32 brief:

```
1↔5: 0.632   5↔8: 0.692
1↔8: 0.500   5↔10: 0.656
1↔10: 0.554  8↔10: 0.510
```

Complete-link requires every pair to clear threshold. Pair `1↔8` at `0.500` fails → 4-way cluster can't form → 4 separate reps eat 4 brief slots.

## The fix

Add `singleLinkCluster` (union-find, O(N² α(N)), respects veto). At threshold 0.60:

| Algorithm | Clusters | F1 | P | R |
|---|---|---|---|---|
| complete-link @ 0.55 (current) | 7 | 0.526 | 0.56 | 0.50 |
| complete-link @ 0.50 | 6 | 0.435 | 0.38 | 0.50 |
| single-link @ 0.55 | 4 | 0.435 | 0.28 | 1.00 (over-merge) |
| **single-link @ 0.60** | **6** | **0.727** | **0.67** | **0.80** |

F1 up **37%**, no FP increase. Single-link chains the ship-seizure 4 through the strong intermediate (story 5, cosines 0.63–0.69 to all others) even though `1↔8` is weak.

## Bridge-pollution risk

The original plan rejected single-link to avoid the Jaccard-era bridge-chaining failure mode (A~B=0.6, B~C=0.6 → chain, even if A~C=0.3 is unrelated). With `text-embedding-3-small` at cosine ≥ 0.60 the bridge has to be semantically real. Empirical probe shows zero new FPs on the production story set.

Kill switch: `DIGEST_DEDUP_CLUSTERING=complete` on Railway (instant rollback, no deploy).

## Changes

- `scripts/lib/brief-dedup-embed.mjs` — new `singleLinkCluster` via union-find, permutation-invariant by construction
- `scripts/lib/brief-dedup.mjs` — new `DIGEST_DEDUP_CLUSTERING` env (default `single`), dispatch at call site, log line includes `clustering=<algo>`
- `tests/brief-dedup-embedding.test.mjs` — +8 regressions: 4-way bridge chain, veto blocks unions, permutation-invariance, empty input, env dispatch, kill switch, unrecognised fallback, log line

## Operator activation

After merge, one env flip on `seed-digest-notifications`:

```
DIGEST_DEDUP_COSINE_THRESHOLD=0.60
```

(Revert from 0.55 back to 0.60 — single-link wants the higher threshold.)

Rollback: `DIGEST_DEDUP_CLUSTERING=complete`.

## Test plan

- [x] `npm run test:data` — 5825/5825 pass
- [x] `tests/brief-dedup-embedding` — 53/53 pass (45 existing + 8 new)
- [x] typecheck + typecheck:api — clean
- [x] biome check on changed files — clean

## Post-Deploy Monitoring & Validation

- **Grep** `[digest] dedup mode=embed clustering=single` in Railway logs → confirms new algo is live
- **Expected behaviour**: `clusters=` drops further on bulk ticks (current ~23 on 84 stories → expected ~15-18)
- **Visual**: open next brief after merge, verify ship / Hormuz / oil no longer duplicate
- **Rollback trigger**: if a brief shows an unrelated story merged into a cluster (bridge pollution), set `DIGEST_DEDUP_CLUSTERING=complete` on Railway — takes effect next tick
- **Validation window**: 24h
- **Owner**: koala73

## Related

- #3200 embedding-based dedup (introduced complete-link)
- #3224 `DIGEST_SCORE_MIN` floor