### PR TITLE
chore(exa): add x-exa-integration header and category:news filter

### DIFF
--- a/consumer-prices-core/src/acquisition/exa.ts
+++ b/consumer-prices-core/src/acquisition/exa.ts
@@ -8,6 +8,8 @@ export class ExaProvider implements AcquisitionProvider {
 
   constructor(apiKey: string) {
     this.client = new Exa(apiKey);
+    (this.client as unknown as { headers: { set: (k: string, v: string) => void } })
+      .headers.set('x-exa-integration', 'worldmonitor');
   }
 
   async fetch(url: string, _opts: FetchOptions = {}): Promise<FetchResult> {

--- a/consumer-prices-core/src/adapters/exa-search.ts
+++ b/consumer-prices-core/src/adapters/exa-search.ts
@@ -167,6 +167,7 @@ export class ExaSearchAdapter implements RetailerAdapter {
         'x-api-key': this.apiKey,
         'Content-Type': 'application/json',
         'User-Agent': CHROME_UA,
+        'x-exa-integration': 'worldmonitor',
       },
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(15_000),

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -10359,7 +10359,7 @@ async function performWidgetWebSearch(query) {
     try {
       const res = await fetch('https://api.exa.ai/search', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'x-api-key': WIDGET_EXA_KEY },
+        headers: { 'Content-Type': 'application/json', 'x-api-key': WIDGET_EXA_KEY, 'x-exa-integration': 'worldmonitor' },
         body: JSON.stringify({
           query,
           numResults: 8,

--- a/scripts/seed-bigmac.mjs
+++ b/scripts/seed-bigmac.mjs
@@ -116,7 +116,12 @@ async function searchExa(query, includeDomains = null) {
 
   const resp = await fetch('https://api.exa.ai/search', {
     method: 'POST',
-    headers: { 'x-api-key': apiKey, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
+    headers: {
+      'x-api-key': apiKey,
+      'Content-Type': 'application/json',
+      'User-Agent': CHROME_UA,
+      'x-exa-integration': 'worldmonitor',
+    },
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(15_000),
   });

--- a/scripts/seed-grocery-basket.mjs
+++ b/scripts/seed-grocery-basket.mjs
@@ -44,6 +44,7 @@ async function searchExa(query, sites, locationCode) {
       'x-api-key': apiKey,
       'Content-Type': 'application/json',
       'User-Agent': CHROME_UA,
+      'x-exa-integration': 'worldmonitor',
     },
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(15_000),

--- a/server/worldmonitor/market/v1/stock-news-search.ts
+++ b/server/worldmonitor/market/v1/stock-news-search.ts
@@ -172,6 +172,7 @@ async function searchWithExa(query: string, maxResults: number, days: number, ap
       'Content-Type': 'application/json',
       'x-api-key': apiKey,
       'User-Agent': CHROME_UA,
+      'x-exa-integration': 'worldmonitor',
     },
     body: JSON.stringify({
       query,
@@ -179,6 +180,7 @@ async function searchWithExa(query: string, maxResults: number, days: number, ap
       type: 'neural',
       useAutoprompt: false,
       startPublishedDate: startDate,
+      category: 'news',
     }),
     signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
   });


### PR DESCRIPTION
## Summary

- Adds an `x-exa-integration: worldmonitor` header to every outbound call to `https://api.exa.ai/search` and to the `exa-js` SDK client so Exa-side usage telemetry can attribute requests to this project. No functional change from this header.
- Adds `category: 'news'` to the stock news Exa request so results are constrained to the news category (the surrounding provider chain is a news-only fallback: Exa → Brave → SerpAPI → Google News RSS).

## Files changed

- `consumer-prices-core/src/acquisition/exa.ts` — set the header on the `exa-js` SDK client after construction.
- `consumer-prices-core/src/adapters/exa-search.ts` — header on the basket price-discovery search.
- `server/worldmonitor/market/v1/stock-news-search.ts` — header + `category: 'news'` on the stock news search.
- `scripts/ais-relay.cjs` — header on the widget web-search path.
- `scripts/seed-bigmac.mjs` — header on the Big Mac price seed script.
- `scripts/seed-grocery-basket.mjs` — header on the grocery basket seed script.

## Example

```ts
// stock-news-search.ts (diff excerpt)
headers: {
  'Content-Type': 'application/json',
  'x-api-key': apiKey,
  'User-Agent': CHROME_UA,
  'x-exa-integration': 'worldmonitor',
},
body: JSON.stringify({
  query,
  numResults: Math.min(maxResults, 10),
  type: 'neural',
  useAutoprompt: false,
  startPublishedDate: startDate,
  category: 'news',
}),
```

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `(consumer-prices-core) npx tsc --noEmit` — clean
- [x] `npx tsx --test tests/stock-news-search.test.mts` — 5/5 pass (Exa-first, Exa→Brave fallback, RSS fallback, SerpAPI)
- [x] `biome lint` on changed files — no new diagnostics introduced