### PR TITLE
fix(portwatch): HISTORY_DAYS 90 → 60 to fit standalone cron budget

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -32,7 +32,15 @@ const EP4_BASE =
 
 const PAGE_SIZE = 2000;
 const FETCH_TIMEOUT = 45_000;
-const HISTORY_DAYS = 90;
+// 60 days. Enough to cover both window aggregates used by the UI
+// (last30 for current metrics + prev30 = days 30-60 for trendDelta),
+// without the extra 30d of tail data that we never actually look at.
+// Cutting from 90→60 days drops each per-country query by ~33% in row
+// count and page count — prod log on 2026-04-21 00:02Z showed 90d
+// per-country pagination averaging ~75s/batch at concurrency 12, which
+// mathematically cannot fit 15 batches into the 540s section budget.
+// 60 days should bring avg batch time down enough for a full publish.
+const HISTORY_DAYS = 60;
 const MAX_PORTS_PER_COUNTRY = 50;
 
 // Per-country budget. ArcGIS's ISO3 index makes per-country fetches O(rows-in-country),
@@ -133,7 +141,7 @@ async function fetchAllPortRefs({ signal } = {}) {
 
 // Fetch ONE country's activity rows, streaming into per-port accumulators.
 // ArcGIS's ISO3 index makes this cheap for most countries (~3-9s typical).
-// Heavy countries (USA/CHN/etc.) can be 30-60s because 90 days × their many
+// Heavy countries (USA/CHN/etc.) can still be 30-60s because 60 days × their many
 // ports = thousands of rows across multiple pages. Hence the per-country
 // timeout + single retry.
 //

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -142,6 +142,14 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /MAX_PORTS_PER_COUNTRY\s*=\s*50/);
   });
 
+  it('HISTORY_DAYS is 60 (enough for last30 + prev30/trendDelta, no more)', () => {
+    // 90d was the prior default but prod log 2026-04-21 00:02Z showed
+    // per-country pagination at 90d cannot fit 174 countries in the 540s
+    // section budget even in a standalone Railway cron. 60d is the minimum
+    // that still covers the UI's trendDelta window (prev30 = days 30-60).
+    assert.match(src, /const\s+HISTORY_DAYS\s*=\s*60\b/);
+  });
+
   it('TTL is 259200 (3 days)', () => {
     assert.match(src, /259[_\s]*200/);
   });


### PR DESCRIPTION
## Why this PR?

Follow-up to #3231 (split port-activity into its own Railway cron). Production log 2026-04-21T00:02Z shows the standalone service STILL can't fit 174 countries into its 540s budget at 90 days of history:

\`\`\`
batch 1/15: 7 seeded, 5 errors (90.0s)
batch 5/15: 42 seeded, 18 errors (392.6s)
[SIGTERM at 540s — only ~50 countries seeded]
\`\`\`

**Math**: avg ~75s/batch × 15 batches = **~1,125s needed** vs **540s available**. Degradation guard then rejects the partial publish because it has <80% of the prior country count.

## What this PR does

Cuts \`HISTORY_DAYS\` from **90 → 60**. That's the minimum window still covering both aggregates the UI computes:
- \`last30\` (days 0-30 → \`tankerCalls30d\`, \`importTankerDwt30d\`, \`exportTankerDwt30d\`)
- \`prev30\` (days 30-60 → \`trendDelta\`)

~33% fewer rows per country, ~33% fewer ArcGIS pagination pages. Expected avg batch time drops from ~75s → ~50s. 15 × 50s = **~750s worst case, still over 540s but much more of the queue publishes before SIGTERM**, and the degradation guard should accept the result.

If 60d still doesn't fit after this ships, we fall back to 30d + client-side partial-trend computation as a follow-up.

## No feature regression

\`anomalySignal\` / \`last7\` aggregation has been a no-op for 10+ days anyway because ArcGIS's \`Daily_Ports_Data\` max date lags ~10 days behind wall-clock. The last-7-day window always returns 0 rows, so \`avg7d = 0\` and \`anomalySignal = false\` universally. 60d doesn't make that worse.

All other metrics (\`tankerCalls30d\`, \`trendDelta\`, \`importTankerDwt30d\`, \`exportTankerDwt30d\`) use data inside the 60d window.

## Test plan

- [x] \`node --test tests/portwatch-port-activity-seed.test.mjs\` — 55 pass (+1 new guard for HISTORY_DAYS=60)
- [x] \`npm run typecheck:all\` — clean
- [x] Biome lint on changed files — clean
- [ ] After merge: next cron tick (00:00 UTC tomorrow) OR manual redeploy. Expect batches 1-15 to finish under 540s and the degradation guard to accept.
- [ ] Health endpoint on \`supply_chain:portwatch-ports\` moves from STALE_SEED → HEALTHY