### PR TITLE
fix(gateway): accept Dodo entitlement as pro, not just Clerk role — unblocks paying users

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -16,7 +16,7 @@ import { validateApiKey } from '../api/_api-key.js';
 import { mapErrorToResponse } from './error-mapper';
 import { checkRateLimit, checkEndpointRateLimit, hasEndpointRatePolicy } from './_shared/rate-limit';
 import { drainResponseHeaders } from './_shared/response-headers';
-import { checkEntitlement, getRequiredTier } from './_shared/entitlement-check';
+import { checkEntitlement, getRequiredTier, getEntitlements } from './_shared/entitlement-check';
 import { resolveSessionUserId } from './_shared/auth-session';
 import type { ServerOptions } from '../src/generated/server/worldmonitor/seismology/v1/service_server';
 
@@ -386,13 +386,29 @@ export function createDomainGateway(
     }
 
     // Bearer role check — authenticated users who bypassed the API key gate still
-    // need a pro role for PREMIUM_RPC_PATHS (entitlement check below handles tier-gated).
+    // need pro access for PREMIUM_RPC_PATHS (entitlement check below handles tier-gated).
+    //
+    // Accept EITHER a Clerk 'pro' role OR a Convex Dodo entitlement with tier >= 1.
+    // Rationale: the Dodo webhook pipeline writes Convex entitlements but does NOT
+    // sync Clerk publicMetadata.role. A paying user whose subscription is active in
+    // Convex will have session.role === 'free' until Clerk is separately updated,
+    // which would otherwise block them on every legacy premium path even though
+    // they've paid. This mirrors the logic in server/_shared/premium-check.ts
+    // (isCallerPremium) so the gateway gate and the per-handler gate agree on who
+    // is premium — a split the 2026-04-17/18 duplicate-subscription incident also
+    // surfaced at the frontend layer (see src/services/panel-gating.ts:11-27).
     if (sessionUserId && !keyCheck.valid && needsLegacyProBearerGate) {
       const authHeader = request.headers.get('Authorization');
       if (authHeader?.startsWith('Bearer ')) {
         const { validateBearerToken } = await import('./auth-session');
         const session = await validateBearerToken(authHeader.slice(7));
-        if (!session.valid || session.role !== 'pro') {
+        let allowed = session.valid && session.role === 'pro';
+        if (!allowed && session.valid && session.userId) {
+          // Fall through to Convex entitlement as the authoritative signal.
+          const ent = await getEntitlements(session.userId);
+          allowed = !!ent && ent.features.tier >= 1 && ent.validUntil >= Date.now();
+        }
+        if (!allowed) {
           return new Response(JSON.stringify({ error: 'Pro subscription required' }), {
             status: 403,
             headers: { 'Content-Type': 'application/json', ...corsHeaders },

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -342,7 +342,6 @@ export function createDomainGateway(
     // User API keys on PREMIUM_RPC_PATHS need verified pro-tier entitlement.
     // Admin keys (WORLDMONITOR_VALID_KEYS) bypass this since they are operator-issued.
     if (isUserApiKey && needsLegacyProBearerGate && sessionUserId) {
-      const { getEntitlements } = await import('./_shared/entitlement-check');
       const ent = await getEntitlements(sessionUserId);
       if (!ent || !ent.features.apiAccess) {
         return new Response(JSON.stringify({ error: 'API access subscription required' }), {

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -364,13 +364,34 @@ export function createDomainGateway(
               headers: { 'Content-Type': 'application/json', ...corsHeaders },
             });
           }
-          if (session.role !== 'pro') {
+          // Accept EITHER a Clerk 'pro' role OR a Convex Dodo entitlement with
+          // tier >= 1. The Dodo webhook pipeline writes Convex entitlements but
+          // does NOT sync Clerk publicMetadata.role, so a paying subscriber's
+          // session.role stays 'free' indefinitely. A Clerk-role-only check
+          // would block every paying user on legacy premium endpoints despite
+          // a valid Dodo subscription. This mirrors the two-signal logic in
+          // server/_shared/premium-check.ts::isCallerPremium so the gateway
+          // gate and the per-handler gate agree on who is premium — same split
+          // already documented at the frontend layer (panel-gating.ts:11-27).
+          //
+          // Note: validateBearerToken returns session.userId directly, so we
+          // use it without needing to resolveSessionUserId() — sessionUserId
+          // is intentionally only resolved for ENDPOINT_ENTITLEMENTS-tier-gated
+          // endpoints earlier (line 292) to avoid a JWKS lookup on every
+          // legacy premium request. validateBearerToken already does its own
+          // verification here (line 360) and exposes userId on the result.
+          let allowed = session.role === 'pro';
+          if (!allowed && session.userId) {
+            const ent = await getEntitlements(session.userId);
+            allowed = !!ent && ent.features.tier >= 1 && ent.validUntil >= Date.now();
+          }
+          if (!allowed) {
             return new Response(JSON.stringify({ error: 'Pro subscription required' }), {
               status: 403,
               headers: { 'Content-Type': 'application/json', ...corsHeaders },
             });
           }
-          // Valid pro session — fall through to route handling
+          // Valid pro session (Clerk role OR Dodo entitlement) — fall through to route handling.
         } else {
           return new Response(JSON.stringify({ error: keyCheck.error, _debug: (keyCheck as any)._debug }), {
             status: 401,
@@ -382,38 +403,6 @@ export function createDomainGateway(
           status: 401,
           headers: { 'Content-Type': 'application/json', ...corsHeaders },
         });
-      }
-    }
-
-    // Bearer role check — authenticated users who bypassed the API key gate still
-    // need pro access for PREMIUM_RPC_PATHS (entitlement check below handles tier-gated).
-    //
-    // Accept EITHER a Clerk 'pro' role OR a Convex Dodo entitlement with tier >= 1.
-    // Rationale: the Dodo webhook pipeline writes Convex entitlements but does NOT
-    // sync Clerk publicMetadata.role. A paying user whose subscription is active in
-    // Convex will have session.role === 'free' until Clerk is separately updated,
-    // which would otherwise block them on every legacy premium path even though
-    // they've paid. This mirrors the logic in server/_shared/premium-check.ts
-    // (isCallerPremium) so the gateway gate and the per-handler gate agree on who
-    // is premium — a split the 2026-04-17/18 duplicate-subscription incident also
-    // surfaced at the frontend layer (see src/services/panel-gating.ts:11-27).
-    if (sessionUserId && !keyCheck.valid && needsLegacyProBearerGate) {
-      const authHeader = request.headers.get('Authorization');
-      if (authHeader?.startsWith('Bearer ')) {
-        const { validateBearerToken } = await import('./auth-session');
-        const session = await validateBearerToken(authHeader.slice(7));
-        let allowed = session.valid && session.role === 'pro';
-        if (!allowed && session.valid && session.userId) {
-          // Fall through to Convex entitlement as the authoritative signal.
-          const ent = await getEntitlements(session.userId);
-          allowed = !!ent && ent.features.tier >= 1 && ent.validUntil >= Date.now();
-        }
-        if (!allowed) {
-          return new Response(JSON.stringify({ error: 'Pro subscription required' }), {
-            status: 403,
-            headers: { 'Content-Type': 'application/json', ...corsHeaders },
-          });
-        }
       }
     }
 


### PR DESCRIPTION
## Problem — paying Dodo subscribers get 403 on every premium endpoint

Live report 2026-04-21 after a successful purchase:

\`\`\`
GET /api/intelligence/v1/get-regional-snapshot?region_id=mena       403 (Forbidden)
GET /api/trade/v1/get-tariff-trends?reporting_country=840&...       403 (Forbidden)
GET /api/trade/v1/list-comtrade-flows                               403 (Forbidden)
GET /api/economic/v1/get-national-debt                              403 (Forbidden)
POST /api/intelligence/v1/deduct-situation                          403 (Forbidden)
\`\`\`

Root cause: gateway-level split-brain between Clerk and Convex entitlement.

\`server/gateway.ts:388-401\` (the legacy \`PREMIUM_RPC_PATHS\` Bearer gate):

\`\`\`ts
if (!session.valid || session.role !== 'pro') {
  return new Response(JSON.stringify({ error: 'Pro subscription required' }), { status: 403 });
}
\`\`\`

That \`session.role\` comes from Clerk. But the **Dodo webhook pipeline writes Convex entitlements, NOT Clerk \`publicMetadata.role\`** — a gap already documented for the frontend at \`src/services/panel-gating.ts:11-27\`:

> "The Convex entitlement check is the authoritative signal for paying customers — Clerk \`publicMetadata.plan\` is NOT written by our webhook pipeline"

Frontend was fixed (\`hasPremiumAccess()\` falls through to \`isEntitled()\`). The backend gateway still only consulted Clerk role, so every paying Dodo subscriber whose Clerk role is \`'free'\` got 403'd on legacy-premium endpoints — which is essentially every new Pro purchase.

## Fix

Align the gateway's Bearer gate with the two-signal logic already present in \`server/_shared/premium-check.ts::isCallerPremium\`:

\`\`\`diff
+ let allowed = session.valid && session.role === 'pro';
+ if (!allowed && session.valid && session.userId) {
+   // Fall through to Convex entitlement as the authoritative signal.
+   const ent = await getEntitlements(session.userId);
+   allowed = !!ent && ent.features.tier >= 1 && ent.validUntil >= Date.now();
+ }
+ if (!allowed) {
    return new Response(JSON.stringify({ error: 'Pro subscription required' }), { status: 403 });
- }
+ }
\`\`\`

1. **Fast path**: Clerk role === 'pro' → allow with no Redis/Convex I/O.
2. **Fallback**: look up Convex entitlement; allow if \`tier >= 1 AND validUntil >= Date.now()\` (the \`validUntil\` gate naturally denies lapsed subscriptions).
3. Else → 403.

\`getEntitlements\` was already being dynamically imported at line 345 in a different branch; promoted to top-level since the new site is in a hotter path.

## Impact

Unblocks all Dodo subscribers whose Clerk role is still \`'free'\` (i.e. everyone, since webhook-based Clerk role sync was never wired up). Gateway and per-handler \`isCallerPremium\` now agree on who is premium, closing a split that's been silently causing support tickets since the Dodo migration.

## Related

- Frontend analog fix: \`src/services/panel-gating.ts\` docstring lines 11-27 (already merged)
- Matches \`isCallerPremium\` logic at \`server/_shared/premium-check.ts:39-50\`
- Doesn't affect the \`checkEntitlement\` path (lines 404-409) which is only used for tier-gated endpoints in \`ENDPOINT_ENTITLEMENTS\` — it already reads Convex directly.

## Test plan

- [ ] Merge + Vercel deploy.
- [ ] As pro user whose Clerk role is 'free' but Convex entitlement tier=1: load /, confirm Regional Intelligence / Tariffs / Comtrade / National Debt panels populate (currently show empty after 403).
- [ ] As pro user whose Clerk role is 'pro' (if any such users exist): confirm no regression — fast path still allows before touching Redis/Convex.
- [ ] As free signed-in user (no Dodo sub): confirm 403 still fires on premium paths (both signals false).
- [ ] As user whose Dodo subscription lapsed (\`validUntil < Date.now()\`): confirm 403 fires (allowed to decay to free).
- [ ] As anonymous visitor: confirm 401 still fires (no Bearer at all).