### PR TITLE
fix(live-webcams): refresh Iran-Attacks multicam + Mideast Mecca video IDs

### DIFF
--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -26,12 +26,12 @@ const WEBCAM_FEEDS: WebcamFeed[] = [
   { id: 'iran-tehran', city: 'Tehran', country: 'Iran', region: 'iran', channelHandle: '@IranHDCams', fallbackVideoId: '-zGuR1qVKrU' },
   { id: 'iran-telaviv', city: 'Tel Aviv', country: 'Israel', region: 'iran', channelHandle: '@IsraelLiveCam', fallbackVideoId: 'gmtlJ_m2r5A' },
   { id: 'iran-jerusalem', city: 'Jerusalem', country: 'Israel', region: 'iran', channelHandle: '@JerusalemLive', fallbackVideoId: 'fIurYTprwzg' },
-  { id: 'iran-multicam', city: 'Middle East', country: 'Multi', region: 'iran', channelHandle: '@MiddleEastCams', fallbackVideoId: 'FGUKbzulB_Y' },
+  { id: 'iran-multicam', city: 'Middle East', country: 'Multi', region: 'iran', channelHandle: '@MiddleEastCams', fallbackVideoId: 'KSwPNkzEgxg' },
   // Middle East — Jerusalem & Tehran adjacent (conflict hotspots)
   { id: 'jerusalem', city: 'Jerusalem', country: 'Israel', region: 'middle-east', channelHandle: '@TheWesternWall', fallbackVideoId: 'e34xb-Fbl0U' },
   { id: 'tehran', city: 'Tehran', country: 'Iran', region: 'middle-east', channelHandle: '@IranHDCams', fallbackVideoId: '-zGuR1qVKrU' },
   { id: 'tel-aviv', city: 'Tel Aviv', country: 'Israel', region: 'middle-east', channelHandle: '@IsraelLiveCam', fallbackVideoId: 'gmtlJ_m2r5A' },
-  { id: 'mecca', city: 'Mecca', country: 'Saudi Arabia', region: 'middle-east', channelHandle: '@MakkahLive', fallbackVideoId: 'Cm1v4bteXbI' },
+  { id: 'mecca', city: 'Mecca', country: 'Saudi Arabia', region: 'middle-east', channelHandle: '@MakkahLive', fallbackVideoId: 'kJwEsQTegxk' },
   { id: 'beirut-mtv', city: 'Beirut', country: 'Lebanon', region: 'middle-east', channelHandle: '@MTVLebanonNews', fallbackVideoId: 'djF-Lkgfp6k' },
   // Europe
   { id: 'kyiv', city: 'Kyiv', country: 'Ukraine', region: 'europe', channelHandle: '@DWNews', fallbackVideoId: '-Q7FuPINDjA' },


### PR DESCRIPTION
## Summary

User reported two Live Webcams tiles showing "This live stream recording is not available" — the pinned fallback video IDs had gone dark. Refreshing both with working URLs.

- **Iran Attacks → Middle East slot** (`iran-multicam`): `FGUKbzulB_Y` → `KSwPNkzEgxg`
- **Mideast → Mecca slot** (`mecca`): `Cm1v4bteXbI` → `kJwEsQTegxk`

## Context

Only `fallbackVideoId` is actually read by the runtime (embed URL at line 303, open-in-YouTube link at line 422). `channelHandle` is metadata left untouched.

## Testing

- `npm run typecheck` ✓

Manually verifiable after deploy by opening the Live Webcams panel → Iran Attacks / Mideast tabs and confirming the bottom-right / Mecca cells play.