### PR TITLE
fix(brief): cover greeting was hardcoded "Good evening" regardless of issue time

### DIFF
--- a/server/_shared/brief-render.js
+++ b/server/_shared/brief-render.js
@@ -377,9 +377,6 @@ function digestRunningHead(dateShort, label) {
 // ── Page renderers ───────────────────────────────────────────────────────────
 
 /**
- * @param {{ dateLong: string; issue: string; storyCount: number; pageIndex: number; totalPages: number }} opts
- */
-/**
  * Strip the trailing period from envelope.data.digest.greeting
  * ("Good afternoon." → "Good afternoon") so the cover's mono-cased
  * salutation stays consistent with the historical no-period style.
@@ -391,6 +388,9 @@ function coverGreeting(greeting) {
   return greeting.replace(/\.+$/, '').trim() || 'Hello';
 }
 
+/**
+ * @param {{ dateLong: string; issue: string; storyCount: number; pageIndex: number; totalPages: number; greeting: string }} opts
+ */
 function renderCover({ dateLong, issue, storyCount, pageIndex, totalPages, greeting }) {
   const blurb =
     storyCount === 1

--- a/server/_shared/brief-render.js
+++ b/server/_shared/brief-render.js
@@ -379,7 +379,19 @@ function digestRunningHead(dateShort, label) {
 /**
  * @param {{ dateLong: string; issue: string; storyCount: number; pageIndex: number; totalPages: number }} opts
  */
-function renderCover({ dateLong, issue, storyCount, pageIndex, totalPages }) {
+/**
+ * Strip the trailing period from envelope.data.digest.greeting
+ * ("Good afternoon." → "Good afternoon") so the cover's mono-cased
+ * salutation stays consistent with the historical no-period style.
+ * Defensive: if the envelope ever produces an unexpected value, fall
+ * back to a generic "Hello" rather than hardcoding a wrong time-of-day.
+ */
+function coverGreeting(greeting) {
+  if (typeof greeting !== 'string' || greeting.length === 0) return 'Hello';
+  return greeting.replace(/\.+$/, '').trim() || 'Hello';
+}
+
+function renderCover({ dateLong, issue, storyCount, pageIndex, totalPages, greeting }) {
   const blurb =
     storyCount === 1
       ? 'One thread that shaped the world today.'
@@ -399,7 +411,7 @@ function renderCover({ dateLong, issue, storyCount, pageIndex, totalPages }) {
     `<p class="blurb">${escapeHtml(blurb)}</p>` +
     '</div>' +
     '<div class="meta-bottom">' +
-    '<span class="mono">Good evening</span>' +
+    `<span class="mono">${escapeHtml(coverGreeting(greeting))}</span>` +
     '<span class="mono">Swipe / ↔ to begin</span>' +
     '</div>' +
     `<div class="page-number mono">${pad2(pageIndex)} / ${pad2(totalPages)}</div>` +
@@ -1200,6 +1212,7 @@ export function renderBriefMagazine(envelope, options = {}) {
       storyCount: stories.length,
       pageIndex: ++p,
       totalPages,
+      greeting: digest.greeting,
     }),
   );
 

--- a/tests/brief-magazine-render.test.mjs
+++ b/tests/brief-magazine-render.test.mjs
@@ -700,3 +700,67 @@ describe('renderBriefMagazine — publicMode', () => {
     assert.equal(a, b);
   });
 });
+
+// ── Regression: cover greeting follows envelope.data.digest.greeting ─────────
+// Previously the cover hardcoded "Good evening" regardless of issue time, so
+// a brief composed at 13:02 local (envelope greeting = "Good afternoon.")
+// rendered "Good evening" on the cover and "Good afternoon." on slide 2 —
+// visibly inconsistent. Fix wires digest.greeting into the cover (period
+// stripped for the mono-cased slot).
+describe('cover greeting ↔ digest.greeting parity', () => {
+  /**
+   * Extract the cover <section> so we can assert on it in isolation without
+   * matching the identical greeting that appears on slide 2.
+   */
+  function extractCover(html) {
+    const match = html.match(/<section class="page cover">[\s\S]*?<\/section>/);
+    assert.ok(match, 'cover section must be present');
+    return match[0];
+  }
+
+  it('renders "Good afternoon" on the cover when digest.greeting is "Good afternoon."', () => {
+    const env = envelope({
+      digest: { ...envelope().data.digest, greeting: 'Good afternoon.' },
+    });
+    const cover = extractCover(renderBriefMagazine(env));
+    assert.ok(cover.includes('>Good afternoon<'), `cover should contain "Good afternoon" without period, got: ${cover}`);
+    assert.ok(!cover.includes('Good evening'), 'cover must NOT say "Good evening" when digest.greeting is afternoon');
+  });
+
+  it('renders "Good morning" on the cover when digest.greeting is "Good morning."', () => {
+    const env = envelope({
+      digest: { ...envelope().data.digest, greeting: 'Good morning.' },
+    });
+    const cover = extractCover(renderBriefMagazine(env));
+    assert.ok(cover.includes('>Good morning<'));
+    assert.ok(!cover.includes('Good evening'));
+    assert.ok(!cover.includes('Good afternoon'));
+  });
+
+  it('renders "Good evening" on the cover when digest.greeting is "Good evening."', () => {
+    const env = envelope({
+      digest: { ...envelope().data.digest, greeting: 'Good evening.' },
+    });
+    const cover = extractCover(renderBriefMagazine(env));
+    assert.ok(cover.includes('>Good evening<'));
+  });
+
+  it('strips trailing period(s) — cover is mono-cased, no punctuation', () => {
+    const env = envelope({
+      digest: { ...envelope().data.digest, greeting: 'Good afternoon...' },
+    });
+    const cover = extractCover(renderBriefMagazine(env));
+    // Envelope can send any trailing dot count; cover strips all of them.
+    assert.ok(cover.includes('>Good afternoon<'));
+    assert.ok(!cover.includes('Good afternoon.'));
+  });
+
+  it('HTML-escapes the greeting (defense-in-depth, even though envelope values are controlled)', () => {
+    const env = envelope({
+      digest: { ...envelope().data.digest, greeting: '<script>alert(1)</script>.' },
+    });
+    const cover = extractCover(renderBriefMagazine(env));
+    assert.ok(!cover.includes('<script>alert'));
+    assert.ok(cover.includes('&lt;script&gt;'));
+  });
+});


### PR DESCRIPTION
## Summary

Brief cover (slide 1) was hardcoded to `'Good evening'` regardless of the issue's local time. The digest greeting page (slide 2) uses the correct time-of-day value from `envelope.data.digest.greeting` — so any brief composed outside the literal evening showed an inconsistent pair.

**Reported example:** a brief viewed at **13:02 local** showed:
- Slide 1 cover → `Good evening` ❌
- Slide 2 digest greeting → `Good afternoon.` ✓

## Root cause

`server/_shared/brief-render.js:402` had a literal string in the cover's meta-bottom mono slot — no time-of-day logic, no envelope lookup.

## Fix

- `renderCover` now accepts `greeting` and uses a `coverGreeting()` helper that strips the trailing period (cover is mono-cased, no punctuation — historical style preserved).
- Call site in `renderBriefMagazine` passes `digest.greeting` through.
- Defensive fallback: if the envelope ever sends an unexpected value, cover shows generic `Hello` rather than silently picking a specific (possibly wrong) time of day.

## Testing

5 new regression tests in `tests/brief-magazine-render.test.mjs`:

| Case | Asserts |
|---|---|
| `digest.greeting = "Good afternoon."` | cover shows `>Good afternoon<`, NO `Good evening` |
| `digest.greeting = "Good morning."` | cover shows `>Good morning<`, NO evening/afternoon |
| `digest.greeting = "Good evening."` | cover shows `>Good evening<` (no regression) |
| `digest.greeting = "Good afternoon..."` | trailing dots stripped |
| `digest.greeting = "<script>alert(1)</script>."` | HTML-escaped (defense-in-depth) |

- 60/60 in the magazine render suite pass.
- 5921/5921 in `npm run test:data`.
- `typecheck`, `typecheck:api`, biome clean.

## Scope

**Standalone hotfix branch off `main`**, NOT bundled into open feature PRs (#3247 merged; #3248 open — unrelated to this). Per `feedback_no_pr_pollution`.

## Post-Deploy Monitoring & Validation

- **What to check:** fetch a brief at any non-evening hour and confirm slide 1 greeting matches slide 2 greeting.
  - Example: `curl -s "https://worldmonitor.app/api/brief/<user>/<slot>?t=<token>" | grep -oE '>Good (morning|afternoon|evening)<' | head -3` — all matches should be the same time-of-day.
- **Expected healthy behavior:** cover + digest greeting always agree.
- **Failure signal:** any mismatch, OR the literal fallback `Hello` appearing in production (would indicate the envelope is sending a malformed greeting — upstream bug).
- **Rollback:** revert the PR (single commit, low risk).
- **Validation window:** next brief cron tick after deploy (~30 min).
- **Owner:** koala73.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)