### PR TITLE
fix(brief): unblock whyMatters analyst endpoint (middleware 403) + DIGEST_ONLY_USER filter

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -14,7 +14,18 @@ const SOCIAL_PREVIEW_PATHS = new Set(['/api/story', '/api/og-story']);
 //   UptimeRobot + ops curl. Was blocked by the curl/bot UA regex before this
 //   exception landed (Vercel log 2026-04-15: "Middleware 403 Forbidden" on
 //   /api/seed-contract-probe).
-const PUBLIC_API_PATHS = new Set(['/api/version', '/api/health', '/api/seed-contract-probe']);
+// - /api/internal/brief-why-matters: requires RELAY_SHARED_SECRET Bearer
+//   (subtle-crypto HMAC timing-safe compare in server/_shared/internal-auth.ts).
+//   Called from the Railway digest-notifications cron whose fetch() uses the
+//   Node undici default UA, which is short enough to trip the "no UA or
+//   suspiciously short" 403 below (Railway log 2026-04-21 post-#3248 merge:
+//   every cron call returned 403 and silently fell back to legacy Gemini).
+const PUBLIC_API_PATHS = new Set([
+  '/api/version',
+  '/api/health',
+  '/api/seed-contract-probe',
+  '/api/internal/brief-why-matters',
+]);
 
 const SOCIAL_IMAGE_UA =
   /Slack-ImgProxy|Slackbot|twitterbot|facebookexternalhit|linkedinbot|telegrambot|whatsapp|discordbot|redditbot/i;

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -156,6 +156,13 @@ async function callAnalystWhyMatters(story) {
       headers: {
         Authorization: `Bearer ${RELAY_SECRET}`,
         'Content-Type': 'application/json',
+        // Explicit UA — Node undici's default is short/empty enough to
+        // trip middleware.ts's "No user-agent or suspiciously short"
+        // 403 path. Defense-in-depth alongside the PUBLIC_API_PATHS
+        // allowlist. Distinct from ops curl / UptimeRobot so log grep
+        // disambiguates cron traffic from operator traffic.
+        'User-Agent': 'worldmonitor-digest-notifications/1.0',
+        Accept: 'application/json',
       },
       body: JSON.stringify({ story }),
       signal: AbortSignal.timeout(15_000),
@@ -1297,6 +1304,25 @@ async function main() {
   if (!Array.isArray(rules) || rules.length === 0) {
     console.log('[digest] No digest rules found — nothing to do');
     return;
+  }
+
+  // Operator single-user test filter. Set DIGEST_ONLY_USER=user_xxx on
+  // the Railway service to run the compose + send paths for exactly
+  // one user on the next cron tick, then unset. Intended for
+  // validating new features (brief enrichment, rendering, email
+  // template changes) end-to-end without fanning out to every PRO user.
+  // Empty string / unset = normal fan-out (production default).
+  const onlyUser = (process.env.DIGEST_ONLY_USER ?? '').trim();
+  if (onlyUser) {
+    const before = rules.length;
+    rules = rules.filter((r) => r && r.userId === onlyUser);
+    console.log(
+      `[digest] DIGEST_ONLY_USER=${onlyUser} — filtered ${before} rules → ${rules.length}`,
+    );
+    if (rules.length === 0) {
+      console.log(`[digest] No rules matched userId=${onlyUser} — nothing to do`);
+      return;
+    }
   }
 
   // Compose per-user brief envelopes once per run (extracted so main's

--- a/tests/middleware-bot-gate.test.mts
+++ b/tests/middleware-bot-gate.test.mts
@@ -175,8 +175,10 @@ describe('middleware PUBLIC_API_PATHS — secret-authed internal endpoints bypas
   }
 
   // Negative case: a sibling path that is NOT in the allowlist must still 403
-  // under the same triggers. This catches a future prefix-match refactor that
-  // would accidentally unblock /api/internal/*.
+  // under EACH of the 3 triggers. This catches a future refactor that moves
+  // the PUBLIC_API_PATHS check later in the chain (e.g. behind a broadened
+  // prefix-match) and might let one of the trigger UAs slip through on a
+  // sibling path without this suite failing. Pin all three guard paths.
   const SIBLING_PATHS = [
     '/api/internal/brief-why-matters-v2',     // near-miss suffix
     '/api/internal/',                          // directory only
@@ -184,10 +186,12 @@ describe('middleware PUBLIC_API_PATHS — secret-authed internal endpoints bypas
   ];
 
   for (const path of SIBLING_PATHS) {
-    it(`${path} does NOT bypass the UA gate (exact-match allowlist)`, () => {
-      const res = call(path, EMPTY_UA);
-      assert.ok(res instanceof Response, `${path} must still hit the 403 guard`);
-      assert.equal(res.status, 403);
-    });
+    for (const { label, ua } of TRIGGERS) {
+      it(`${path} does NOT bypass the UA gate — ${label}`, () => {
+        const res = call(path, ua);
+        assert.ok(res instanceof Response, `${path} must still hit the 403 guard under ${label}`);
+        assert.equal(res.status, 403);
+      });
+    }
   }
 });

--- a/tests/middleware-bot-gate.test.mts
+++ b/tests/middleware-bot-gate.test.mts
@@ -129,3 +129,65 @@ describe('middleware bot gate / carousel allowlist', () => {
     assert.equal(res.status, 403);
   });
 });
+
+// ── PUBLIC_API_PATHS allowlist (secret-authed internal endpoints) ────────────
+// The middleware's "no UA or suspiciously short" 403 guard (middleware.ts:
+// ~L183) blocks Node/undici default-UA callers. Internal endpoints that carry
+// their own Bearer-auth must be in PUBLIC_API_PATHS to bypass the gate.
+//
+// History:
+//   - /api/seed-contract-probe hit this 2026-04-15 (UptimeRobot + ops curl).
+//   - /api/internal/brief-why-matters hit this 2026-04-21 immediately after
+//     PR #3248 merge — every Railway cron call returned 403 and silently
+//     fell back to legacy Gemini. No functional breakage (3-layer fallback
+//     absorbed it) but the new feature never ran in prod.
+//
+// These tests pin the allowlist so a future middleware refactor (e.g. the
+// BOT_UA regex being narrowed, or PUBLIC_API_PATHS being reorganized) can't
+// silently drop an entry.
+
+describe('middleware PUBLIC_API_PATHS — secret-authed internal endpoints bypass UA gate', () => {
+  // UAs that would normally 403 on any other API route.
+  const EMPTY_UA = '';
+  const UNDICI_UA = 'undici';          // Too short (<10 chars) — triggers short-UA 403.
+  const CURL_UA = GENERIC_CURL_UA;     // Matches curl/ in BOT_UA regex.
+
+  const TRIGGERS = [
+    { label: 'empty UA (middleware short-UA gate)', ua: EMPTY_UA },
+    { label: 'short UA (Node undici default-ish)', ua: UNDICI_UA },
+    { label: 'curl UA (BOT_UA regex hit)', ua: CURL_UA },
+  ];
+
+  const ALLOWED_PATHS = [
+    '/api/version',
+    '/api/health',
+    '/api/seed-contract-probe',
+    '/api/internal/brief-why-matters',
+  ];
+
+  for (const path of ALLOWED_PATHS) {
+    for (const { label, ua } of TRIGGERS) {
+      it(`${path} bypasses the UA gate (${label})`, () => {
+        const res = call(path, ua);
+        assert.equal(res, undefined, `${path} must pass through the middleware (no 403); its own auth gate handles access`);
+      });
+    }
+  }
+
+  // Negative case: a sibling path that is NOT in the allowlist must still 403
+  // under the same triggers. This catches a future prefix-match refactor that
+  // would accidentally unblock /api/internal/*.
+  const SIBLING_PATHS = [
+    '/api/internal/brief-why-matters-v2',     // near-miss suffix
+    '/api/internal/',                          // directory only
+    '/api/internal/other',                     // different leaf
+  ];
+
+  for (const path of SIBLING_PATHS) {
+    it(`${path} does NOT bypass the UA gate (exact-match allowlist)`, () => {
+      const res = call(path, EMPTY_UA);
+      assert.ok(res instanceof Response, `${path} must still hit the 403 guard`);
+      assert.equal(res.status, 403);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Three operational changes for the brief whyMatters feature shipped in #3248. All scoped to unblocking and validating that one rollout.

## 🚨 P0: middleware 403 blocking the feature

Railway logs post-#3248 merge showed **every** cron call to \`/api/internal/brief-why-matters\` returning 403:

\`\`\`
[digest] brief-why-matters endpoint HTTP 403
[digest] brief-why-matters endpoint HTTP 403
[digest] brief-why-matters endpoint HTTP 403
... (repeated ~200x per tick)
\`\`\`

**Root cause:** middleware.ts's \"No user-agent or suspiciously short — likely a script\" guard (~L183) rejects Node undici's default UA. The endpoint's own Bearer-auth (\`server/_shared/internal-auth.ts\`) never runs. The feature shipped but **never executed in prod**; the three-layer fallback absorbed it silently and the cron kept producing legacy Gemini output.

Same class as \`/api/seed-contract-probe\` 2026-04-15 (see the existing comment in \`PUBLIC_API_PATHS\`).

## Changes

### 1. \`middleware.ts\` — add to \`PUBLIC_API_PATHS\` allowlist
Endpoint carries its own subtle-crypto HMAC Bearer-auth, so bypassing the generic UA gate is safe. Comment documents the 2026-04-21 incident so the next person understands why it's there.

### 2. \`scripts/seed-digest-notifications.mjs\` — explicit UA on fetch
Defense-in-depth. Sets \`User-Agent: worldmonitor-digest-notifications/1.0\` + \`Accept: application/json\` so:
- A future middleware refactor can't re-break the feature by tightening the allowlist.
- Log grep distinguishes cron traffic from ops curl / UptimeRobot.

### 3. \`DIGEST_ONLY_USER=user_xxx\` filter (feature request)
Operator single-user test flag. Set on the Railway digest-notifications service → next cron tick runs compose + send for exactly that user only → unset. Intended for validating new features end-to-end without fanning out to every PRO user. Empty/unset = normal fan-out (production default).

Applied immediately after \`rules\` is fetched from Convex, so **both** the compose and dispatch paths respect the filter. Structured log line \`[digest] DIGEST_ONLY_USER=user_xxx — filtered N rules → M\` makes it visible in Railway output.

## Testing

### New middleware tests (\`tests/middleware-bot-gate.test.mts\`)

15 new cases pin every entry of \`PUBLIC_API_PATHS\` against 3 UA triggers that would normally 403 (empty, short/undici, curl), plus a negative sibling-path suite:

- \`/api/internal/brief-why-matters-v2\` → 403 (near-miss suffix)
- \`/api/internal/\` → 403 (directory only)
- \`/api/internal/other\` → 403 (different leaf)

Catches any future prefix-match refactor that would silently unblock the whole \`/api/internal/\` subtree.

### Gates

- \`npm run test:data\` → **6043 pass** (was 6022 + 15 new + a few count tweaks).
- \`typecheck\` + \`typecheck:api\` → clean.
- \`biome\` on changed files → only the pre-existing \`main()\` complexity warning (74 → 78 from the filter block; same character as pre-PR).

## Deploy + Validation

### Immediate (P0 fix)
Merge → Vercel deploys → next digest cron tick (~30 min) runs the analyst path for real. Confirm with Railway logs:
\`\`\`bash
railway logs --service digest-notifications --lines 400 | grep -E \"whyMatters source=|endpoint HTTP\"
\`\`\`
**Expected:** \`whyMatters source=analyst producedBy=analyst hash=...\` lines, zero \`endpoint HTTP 403\`.

### Single-user test (validation feature)
Set \`DIGEST_ONLY_USER=user_xxx\` on Railway → wait for next cron tick → inspect that user's brief at \`/api/brief/<user>/<slot>\`. Unset when done.

## Post-Deploy Monitoring & Validation

- **What to monitor:** Railway \`digest-notifications\` logs for \`endpoint HTTP 403\` (should drop to zero) and the new \`whyMatters source=\` / \`producedBy=\` lines (should appear on every cron tick).
- **Cache warmup:** \`SCAN 0 MATCH brief:llm:whymatters:v3:* COUNT 500\` count should start growing after the first successful cron tick post-deploy.
- **Shadow records:** \`SCAN 0 MATCH brief:llm:whymatters:shadow:v1:* COUNT 500\` should start populating (default \`BRIEF_WHY_MATTERS_SHADOW=1\`, \`SAMPLE_PCT=100\`).
- **Failure signal:** \`endpoint HTTP 403\` persists after deploy → revert; \`parse_reject\` rate > 30% → \`BRIEF_WHY_MATTERS_PRIMARY=gemini\` kill switch.
- **Rollback:** revert PR (single commit) OR flip \`BRIEF_WHY_MATTERS_PRIMARY=gemini\` on Vercel for instant kill without redeploy.
- **Validation window:** 2h post-deploy. Owner: koala73.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)