### PR TITLE
fix(unrest): Decodo proxy fallback for GDELT + surface err.cause

### DIFF
--- a/scripts/seed-unrest-events.mjs
+++ b/scripts/seed-unrest-events.mjs
@@ -162,7 +162,7 @@ async function fetchAcledProtests() {
 function describeErr(err) {
   if (!err) return 'unknown';
   const cause = err.cause;
-  const causeCode = cause?.code || cause?.errno || cause?.message;
+  const causeCode = cause?.code || cause?.errno || cause?.message || (typeof cause === 'string' ? cause : null);
   return causeCode ? `${err.message} (cause: ${causeCode})` : (err.message || String(err));
 }
 
@@ -171,7 +171,7 @@ async function fetchGdeltDirect(url) {
     headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
     signal: AbortSignal.timeout(30_000),
   });
-  if (!resp.ok) throw new Error(`GDELT API error: ${resp.status}`);
+  if (!resp.ok) throw Object.assign(new Error(`GDELT API error: ${resp.status}`), { httpStatus: resp.status });
   return resp.json();
 }
 
@@ -194,6 +194,9 @@ async function fetchGdeltEvents() {
   try {
     data = await fetchGdeltDirect(url);
   } catch (directErr) {
+    // Upstream HTTP error (4xx/5xx) — proxy routes to the same GDELT endpoint so
+    // it won't change the response. Save the 20s proxy timeout and bubble up.
+    if (directErr.httpStatus) throw directErr;
     const proxyAuth = resolveProxyForConnect();
     if (!proxyAuth) {
       throw Object.assign(new Error(`GDELT direct failed (no proxy configured): ${describeErr(directErr)}`), { cause: directErr });

--- a/scripts/seed-unrest-events.mjs
+++ b/scripts/seed-unrest-events.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, httpsProxyFetchRaw, resolveProxyForConnect } from './_seed-utils.mjs';
 import { getAcledToken } from './shared/acled-oauth.mjs';
 
 loadEnvFile(import.meta.url);
@@ -159,20 +159,56 @@ async function fetchAcledProtests() {
 
 // ---------- GDELT Fetch ----------
 
+function describeErr(err) {
+  if (!err) return 'unknown';
+  const cause = err.cause;
+  const causeCode = cause?.code || cause?.errno || cause?.message;
+  return causeCode ? `${err.message} (cause: ${causeCode})` : (err.message || String(err));
+}
+
+async function fetchGdeltDirect(url) {
+  const resp = await fetch(url, {
+    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!resp.ok) throw new Error(`GDELT API error: ${resp.status}`);
+  return resp.json();
+}
+
+async function fetchGdeltViaProxy(url, proxyAuth) {
+  const { buffer } = await httpsProxyFetchRaw(url, proxyAuth, {
+    accept: 'application/json',
+    timeoutMs: 20_000,
+  });
+  return JSON.parse(buffer.toString('utf8'));
+}
+
 async function fetchGdeltEvents() {
   const params = new URLSearchParams({
     query: 'protest OR riot OR demonstration OR strike',
     maxrows: '2500',
   });
+  const url = `${GDELT_GKG_URL}?${params}`;
 
-  const resp = await fetch(`${GDELT_GKG_URL}?${params}`, {
-    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(30_000),
-  });
+  let data;
+  try {
+    data = await fetchGdeltDirect(url);
+  } catch (directErr) {
+    const proxyAuth = resolveProxyForConnect();
+    if (!proxyAuth) {
+      throw Object.assign(new Error(`GDELT direct failed (no proxy configured): ${describeErr(directErr)}`), { cause: directErr });
+    }
+    console.warn(`  [GDELT] direct failed (${describeErr(directErr)}); retrying via proxy`);
+    try {
+      data = await fetchGdeltViaProxy(url, proxyAuth);
+    } catch (proxyErr) {
+      throw Object.assign(
+        new Error(`GDELT both paths failed — direct: ${describeErr(directErr)}; proxy: ${describeErr(proxyErr)}`),
+        { cause: proxyErr },
+      );
+    }
+  }
 
-  if (!resp.ok) throw new Error(`GDELT API error: ${resp.status}`);
-
-  const data = await resp.json();
   const features = data?.features || [];
 
   // Aggregate by location (v1 GKG returns individual mentions, not aggregated counts)
@@ -236,8 +272,8 @@ async function fetchUnrestEvents() {
   const acledEvents = results[0].status === 'fulfilled' ? results[0].value : [];
   const gdeltEvents = results[1].status === 'fulfilled' ? results[1].value : [];
 
-  if (results[0].status === 'rejected') console.log(`  ACLED failed: ${results[0].reason?.message || results[0].reason}`);
-  if (results[1].status === 'rejected') console.log(`  GDELT failed: ${results[1].reason?.message || results[1].reason}`);
+  if (results[0].status === 'rejected') console.log(`  ACLED failed: ${describeErr(results[0].reason)}`);
+  if (results[1].status === 'rejected') console.log(`  GDELT failed: ${describeErr(results[1].reason)}`);
 
   const merged = deduplicateEvents([...acledEvents, ...gdeltEvents]);
   const sorted = sortBySeverityAndRecency(merged);


### PR DESCRIPTION
## Summary
- `unrestEvents` went **STALE_SEED** (records 107, seedAgeMin 126) because every tick logged a bare `GDELT failed: fetch failed`. ACLED is currently disabled (no creds), so GDELT is the only live source — when it fails, the seed freezes and health flips to WARN.
- The generic \"fetch failed\" string hid the actual cause (DNS / TCP / TLS / connect timeout). The outage looked like a code bug but was a transport error against a Railway datacenter IP.

## Changes
- `fetchGdeltEvents`: direct-first, Decodo proxy fallback via `httpsProxyFetchRaw` when `PROXY_URL` is configured. Mirrors the `imfFetchJson` / `_yahoo-fetch.mjs` direct→proxy pattern already used for other sources that flap against Railway IPs.
- Error messages now include `err.cause.code` (e.g. `UND_ERR_CONNECT_TIMEOUT`, `ENOTFOUND`, `ECONNRESET`) so the next outage surfaces the underlying transport error in Railway logs instead of \"fetch failed\".
- Both-paths-failed error carries direct + proxy message in one line for faster triage.

No behavior change on the happy path — direct fetch still runs first with the existing 30s AbortSignal timeout.

## Testing
- `npm run test:data` — 6028 passed, 0 failed
- `node --check scripts/seed-unrest-events.mjs` — OK

## Post-Deploy Monitoring & Validation
- **What to monitor/search**
  - Logs: Railway \`ais-relay\` container — grep for \`[GDELT]\` and \`GDELT failed\`
  - Health: \`/api/health\` → \`unrestEvents\` status
- **Validation checks**
  - \`curl https://worldmonitor.app/api/health | jq '.services.unrestEvents'\` — expect \`status: OK\` within ~45 min of deploy
  - Railway logs: either \`GDELT: N mentions → K aggregated events\` (direct works) or \`[GDELT] direct failed (... cause: CODE); retrying via proxy\` followed by success
- **Expected healthy signal**
  - \`unrestEvents\` returns to \`OK\`, recordCount > 107 (proves a fresh fetch landed)
- **Failure signal / rollback trigger**
  - Both paths fail → error log now shows actual cause code; if it's \`ENOTFOUND\` or \`EAI_AGAIN\`, check Decodo/Railway DNS
  - If status stays STALE_SEED past 2 cron ticks (~90 min), investigate the logged cause code
- **Validation window & owner**
  - 1 hour post-deploy, Elie

## Related
- Precedent: \`feedback_decodo_denies_gov_tlds.md\`, \`yahoo-decodo-curl-not-connect\`
- Out of scope (noted for follow-up): restore ACLED credentials in Railway env

---
[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code)