### PR TITLE
feat(auth): expose Sign Up CTA + adjacent Settings button + signup analytics

### DIFF
--- a/src/components/AuthHeaderWidget.ts
+++ b/src/components/AuthHeaderWidget.ts
@@ -1,12 +1,17 @@
 import { subscribeAuthState, type AuthSession } from '@/services/auth-state';
-import { mountUserButton, openSignIn } from '@/services/clerk';
+import { mountUserButton, openSignIn, openSignUp } from '@/services/clerk';
+import { t } from '@/services/i18n';
 
 export class AuthHeaderWidget {
   private container: HTMLElement;
   private unsubscribeAuth: (() => void) | null = null;
   private unmountUserButton: (() => void) | null = null;
+  private onSignInClick?: () => void;
+  private onSettingsClick?: () => void;
 
-  constructor(_onSignInClick?: () => void, _onSettingsClick?: () => void) {
+  constructor(onSignInClick?: () => void, onSettingsClick?: () => void) {
+    this.onSignInClick = onSignInClick;
+    this.onSettingsClick = onSettingsClick;
     this.container = document.createElement('div');
     this.container.className = 'auth-header-widget';
 
@@ -33,25 +38,51 @@ export class AuthHeaderWidget {
   }
 
   private render(state: AuthSession): void {
-    // Cleanup previous Clerk mount
     this.unmountUserButton?.();
     this.unmountUserButton = null;
     this.container.innerHTML = '';
 
     if (!state.user) {
-      // Signed out -- show Sign In button
-      const btn = document.createElement('button');
-      btn.className = 'auth-signin-btn';
-      btn.textContent = 'Sign In';
-      btn.addEventListener('click', () => openSignIn());
-      this.container.appendChild(btn);
+      this.renderSignedOut();
       return;
     }
+    this.renderSignedIn();
+  }
 
-    // Signed in -- mount Clerk UserButton
+  private renderSignedOut(): void {
+    const signInBtn = document.createElement('button');
+    signInBtn.className = 'auth-signin-btn';
+    signInBtn.textContent = t('auth.signIn');
+    signInBtn.addEventListener('click', () => {
+      if (this.onSignInClick) this.onSignInClick();
+      else openSignIn();
+    });
+    this.container.appendChild(signInBtn);
+
+    const signUpLink = document.createElement('button');
+    signUpLink.className = 'auth-signup-link';
+    signUpLink.textContent = t('auth.createAccount');
+    signUpLink.addEventListener('click', () => openSignUp());
+    this.container.appendChild(signUpLink);
+  }
+
+  private renderSignedIn(): void {
     const userBtnEl = document.createElement('div');
     userBtnEl.className = 'auth-clerk-user-button';
     this.container.appendChild(userBtnEl);
     this.unmountUserButton = mountUserButton(userBtnEl);
+
+    if (this.onSettingsClick) {
+      const settingsBtn = document.createElement('button');
+      settingsBtn.className = 'auth-settings-btn';
+      settingsBtn.type = 'button';
+      settingsBtn.setAttribute('aria-label', t('auth.settings'));
+      settingsBtn.title = t('auth.settings');
+      settingsBtn.innerHTML = SETTINGS_ICON;
+      settingsBtn.addEventListener('click', () => this.onSettingsClick?.());
+      this.container.appendChild(settingsBtn);
+    }
   }
 }
+
+const SETTINGS_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`;

--- a/src/components/AuthLauncher.ts
+++ b/src/components/AuthLauncher.ts
@@ -1,12 +1,16 @@
-import { openSignIn } from '@/services/clerk';
+import { openSignIn, openSignUp } from '@/services/clerk';
 
 /**
- * Minimal auth launcher -- wraps Clerk.openSignIn().
+ * Minimal auth launcher -- wraps Clerk.openSignIn() / openSignUp().
  * Replaces the custom OTP modal. Clerk handles all UI.
  */
 export class AuthLauncher {
   public open(): void {
     openSignIn();
+  }
+
+  public openSignUp(): void {
+    openSignUp();
   }
 
   public close(): void {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2892,6 +2892,11 @@
     "openCountryBrief": "Open Country Brief",
     "copyCoordinates": "Copy Coordinates"
   },
+  "auth": {
+    "signIn": "Sign In",
+    "createAccount": "Create account",
+    "settings": "Settings"
+  },
   "mcp": {
     "connectPanel": "Connect MCP",
     "modalTitle": "Connect MCP Server",

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -212,18 +212,29 @@ export const FRESH_SIGNUP_WINDOW_MS = 60_000;
 const FRESH_SIGNUP_CLOCK_SKEW_MS = 5_000;
 
 /**
- * sessionStorage-backed fire-once guard. Keyed by user id so an account
- * switch within the same tab still gets a signup track for the new user
- * if they just created their account. Read/write are try/catched because
- * sessionStorage throws in private-mode / quota-exceeded / disabled-
- * storage scenarios; we fail open (track, don't persist) rather than
- * swallow signups.
+ * localStorage-backed fire-once guard, keyed by user id. Originally used
+ * sessionStorage but sessionStorage is per-TAB — a user who signs up and
+ * then opens a second tab on the app within the 60s createdAt freshness
+ * window would fire a second trackSignUp from that fresh tab's
+ * `_lastAuth=null → user` transition. localStorage is shared across
+ * tabs in the same browser profile, so once any tab marks the user as
+ * tracked, no other tab for the same user will re-fire.
+ *
+ * Keyed per user id so account switches within the same browser still
+ * correctly track each user's first signup (rare but valid). The key
+ * never needs to be cleaned up because Clerk user ids are effectively
+ * unique forever — a deleted user's key is harmless and the storage
+ * footprint is trivial (one byte per user who ever signed up here).
+ *
+ * Read/write are try/catched because storage throws in private-mode /
+ * quota-exceeded / disabled scenarios; we fail open (track, don't
+ * persist) rather than swallow signups.
  */
 const SIGNUP_TRACKED_KEY_PREFIX = 'wm-signup-tracked:';
 
 export function hasTrackedSignupInSession(userId: string): boolean {
   try {
-    return window.sessionStorage.getItem(SIGNUP_TRACKED_KEY_PREFIX + userId) === '1';
+    return window.localStorage.getItem(SIGNUP_TRACKED_KEY_PREFIX + userId) === '1';
   } catch {
     return false;
   }
@@ -231,7 +242,7 @@ export function hasTrackedSignupInSession(userId: string): boolean {
 
 export function markSignupTrackedInSession(userId: string): void {
   try {
-    window.sessionStorage.setItem(SIGNUP_TRACKED_KEY_PREFIX + userId, '1');
+    window.localStorage.setItem(SIGNUP_TRACKED_KEY_PREFIX + userId, '1');
   } catch {
     // Storage unavailable — we'll just risk a single double-count on
     // reload instead of crashing analytics init.

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -136,10 +136,22 @@ export function initAuthAnalytics(): void {
       // would conflate "opened the sign-up modal" with "completed the flow";
       // gating on createdAt freshness captures the successful-completion
       // signal we actually want to measure.
+      //
+      // Durable fire-once guard: `_lastAuth` resets to null on every page
+      // load, so without a persisted marker the null→user transition looks
+      // identical on the completion reload and on any reload within the
+      // 60s freshness window. We'd re-fire trackSignUp on every tab
+      // refresh until createdAt ages out, inflating the signup count.
+      // sessionStorage scopes the marker to the browser tab — tight enough
+      // that re-install / new session reliably re-counts, wide enough that
+      // a reload mid-signup doesn't double-count.
       if (
+        nextUserId !== null &&
+        !hasTrackedSignupInSession(nextUserId) &&
         isLikelyFreshSignup(prevUserId, nextUserId, getClerkUserCreatedAt(), Date.now())
       ) {
         trackSignUp('clerk');
+        markSignupTrackedInSession(nextUserId);
       }
     }
     _lastAuth = state;
@@ -198,6 +210,33 @@ export const FRESH_SIGNUP_WINDOW_MS = 60_000;
  * unrealistically far in the future) are rejected as malformed.
  */
 const FRESH_SIGNUP_CLOCK_SKEW_MS = 5_000;
+
+/**
+ * sessionStorage-backed fire-once guard. Keyed by user id so an account
+ * switch within the same tab still gets a signup track for the new user
+ * if they just created their account. Read/write are try/catched because
+ * sessionStorage throws in private-mode / quota-exceeded / disabled-
+ * storage scenarios; we fail open (track, don't persist) rather than
+ * swallow signups.
+ */
+const SIGNUP_TRACKED_KEY_PREFIX = 'wm-signup-tracked:';
+
+export function hasTrackedSignupInSession(userId: string): boolean {
+  try {
+    return window.sessionStorage.getItem(SIGNUP_TRACKED_KEY_PREFIX + userId) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function markSignupTrackedInSession(userId: string): void {
+  try {
+    window.sessionStorage.setItem(SIGNUP_TRACKED_KEY_PREFIX + userId, '1');
+  } catch {
+    // Storage unavailable — we'll just risk a single double-count on
+    // reload instead of crashing analytics init.
+  }
+}
 
 export function isLikelyFreshSignup(
   prevUserId: string | null,

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -191,6 +191,14 @@ export const FRESH_SIGNUP_WINDOW_MS = 60_000;
  * inside this function — callers pass both, so tests can pin time and
  * user state.
  */
+/**
+ * Lower bound for clock skew. A createdAt earlier-than-now by up to
+ * this amount is treated as "now" for freshness purposes — tolerates
+ * client clocks that lag the server. Bigger negatives (createdAt
+ * unrealistically far in the future) are rejected as malformed.
+ */
+const FRESH_SIGNUP_CLOCK_SKEW_MS = 5_000;
+
 export function isLikelyFreshSignup(
   prevUserId: string | null,
   nextUserId: string | null,
@@ -200,7 +208,11 @@ export function isLikelyFreshSignup(
   if (prevUserId !== null) return false;
   if (nextUserId === null) return false;
   if (createdAtMs === null) return false;
-  return nowMs - createdAtMs <= FRESH_SIGNUP_WINDOW_MS;
+  const age = nowMs - createdAtMs;
+  // Accept:   -5s  ≤ age ≤ 60s  (brief clock skew tolerance + fresh window)
+  // Reject: < -5s (createdAt unrealistically far in the future — malformed)
+  //         > 60s (returning user, not a fresh signup)
+  return age >= -FRESH_SIGNUP_CLOCK_SKEW_MS && age <= FRESH_SIGNUP_WINDOW_MS;
 }
 
 export function trackSignOut(): void {

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -7,6 +7,7 @@
 
 import { subscribeAuthState, type AuthSession } from './auth-state';
 import { onSubscriptionChange, type SubscriptionInfo } from './billing';
+import { getClerkUserCreatedAt } from './clerk';
 
 // ---------------------------------------------------------------------------
 // Type-safe event catalog — every event name lives here.
@@ -129,6 +130,17 @@ export function initAuthAnalytics(): void {
     const nextUserId = state.user?.id ?? null;
     if (prevUserId !== nextUserId) {
       _lastSub = null;
+      // Detect a genuine sign-UP (not a sign-in). Null→non-null id transition
+      // plus a createdAt within FRESH_SIGNUP_WINDOW_MS of now means Clerk
+      // just created this account. Firing trackSignUp on the button click
+      // would conflate "opened the sign-up modal" with "completed the flow";
+      // gating on createdAt freshness captures the successful-completion
+      // signal we actually want to measure.
+      if (
+        isLikelyFreshSignup(prevUserId, nextUserId, getClerkUserCreatedAt(), Date.now())
+      ) {
+        trackSignUp('clerk');
+      }
     }
     _lastAuth = state;
     _syncIdentity();
@@ -161,6 +173,34 @@ export function trackSignIn(method: string): void {
 
 export function trackSignUp(method: string): void {
   track('sign-up', { method });
+}
+
+/**
+ * Window during which a freshly-observed Clerk `createdAt` is treated
+ * as "this user just signed up." 60s is conservative enough to survive
+ * network jitter between Clerk's user.created and the client seeing
+ * the auth-state transition, while staying tight enough to reject
+ * returning-user sign-ins on accounts created weeks ago.
+ */
+export const FRESH_SIGNUP_WINDOW_MS = 60_000;
+
+/**
+ * Pure predicate: was the just-observed auth transition a fresh sign-up?
+ *
+ * Exported for testability. Do not read Date.now() or Clerk state from
+ * inside this function — callers pass both, so tests can pin time and
+ * user state.
+ */
+export function isLikelyFreshSignup(
+  prevUserId: string | null,
+  nextUserId: string | null,
+  createdAtMs: number | null,
+  nowMs: number,
+): boolean {
+  if (prevUserId !== null) return false;
+  if (nextUserId === null) return false;
+  if (createdAtMs === null) return false;
+  return nowMs - createdAtMs <= FRESH_SIGNUP_WINDOW_MS;
 }
 
 export function trackSignOut(): void {

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -108,6 +108,32 @@ export function openSignIn(): void {
   clerkInstance?.openSignIn({ appearance: getAppearance() });
 }
 
+/**
+ * Open the Clerk sign-up modal.
+ *
+ * No-op if Clerk is not loaded OR if sign-up is disabled in the Clerk
+ * dashboard. Symmetric with openSignIn — used by the "Create account"
+ * CTA in AuthHeaderWidget to make the register funnel an explicit
+ * first-class action rather than hiding it behind Clerk's sign-in
+ * footer link.
+ */
+export function openSignUp(): void {
+  clerkInstance?.openSignUp({ appearance: getAppearance() });
+}
+
+/**
+ * Epoch ms of the current Clerk user's account creation, or null when
+ * signed out. Read at the source rather than projected through
+ * getCurrentClerkUser() so analytics can gate fresh-signup detection on
+ * a timestamp without widening the UI projection.
+ */
+export function getClerkUserCreatedAt(): number | null {
+  const user = clerkInstance?.user;
+  const createdAt = user?.createdAt;
+  if (!createdAt) return null;
+  return createdAt instanceof Date ? createdAt.getTime() : Number(createdAt);
+}
+
 /** Sign out the current user. */
 export async function signOut(): Promise<void> {
   _cachedToken = null;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -21128,6 +21128,51 @@ body.map-width-resizing {
   display: flex;
   align-items: center;
   position: relative;
+  gap: 8px;
+}
+
+.auth-signup-link {
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s;
+}
+.auth-signup-link:hover {
+  border-color: var(--green);
+  color: var(--green);
+}
+.auth-signup-link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--green) 55%, transparent);
+}
+
+.auth-settings-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary, var(--text));
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: border-color 0.15s, color 0.15s;
+}
+.auth-settings-btn:hover {
+  border-color: var(--green);
+  color: var(--green);
+}
+.auth-settings-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--green) 55%, transparent);
 }
 
 .auth-signin-btn {

--- a/tests/signup-analytics-gate.test.mts
+++ b/tests/signup-analytics-gate.test.mts
@@ -1,15 +1,15 @@
 import { describe, it, beforeEach, before } from 'node:test';
 import assert from 'node:assert/strict';
 
-// Stub window.sessionStorage before importing the module under test —
-// the analytics module's in-memory helpers touch sessionStorage during
-// their execution path, and node:test runs without a DOM.
+// Stub window.localStorage before importing the module under test —
+// the signup dedupe uses localStorage (cross-tab scope) and node:test
+// runs without a DOM.
 const _store = new Map<string, string>();
 before(() => {
   Object.defineProperty(globalThis, 'window', {
     configurable: true,
     value: {
-      sessionStorage: {
+      localStorage: {
         getItem: (k: string) => _store.get(k) ?? null,
         setItem: (k: string, v: string) => { _store.set(k, v); },
         removeItem: (k: string) => { _store.delete(k); },

--- a/tests/signup-analytics-gate.test.mts
+++ b/tests/signup-analytics-gate.test.mts
@@ -1,7 +1,29 @@
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach, before } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isLikelyFreshSignup, FRESH_SIGNUP_WINDOW_MS } from '../src/services/analytics.ts';
+// Stub window.sessionStorage before importing the module under test —
+// the analytics module's in-memory helpers touch sessionStorage during
+// their execution path, and node:test runs without a DOM.
+const _store = new Map<string, string>();
+before(() => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      sessionStorage: {
+        getItem: (k: string) => _store.get(k) ?? null,
+        setItem: (k: string, v: string) => { _store.set(k, v); },
+        removeItem: (k: string) => { _store.delete(k); },
+      },
+    },
+  });
+});
+
+const {
+  isLikelyFreshSignup,
+  FRESH_SIGNUP_WINDOW_MS,
+  hasTrackedSignupInSession,
+  markSignupTrackedInSession,
+} = await import('../src/services/analytics.ts');
 
 const NOW = 1_700_000_000_000;
 
@@ -48,5 +70,31 @@ describe('isLikelyFreshSignup', () => {
     // 10 minutes in the future is not clock skew — it's a bug or a
     // malicious client-side clock. Must not fire trackSignUp.
     assert.equal(isLikelyFreshSignup(null, 'user_new', NOW + 10 * 60 * 1000, NOW), false);
+  });
+});
+
+describe('signup tracking session marker', () => {
+  beforeEach(() => {
+    _store.clear();
+  });
+
+  it('starts as not tracked', () => {
+    assert.equal(hasTrackedSignupInSession('user_X'), false);
+  });
+
+  it('mark → has returns true for same user', () => {
+    markSignupTrackedInSession('user_X');
+    assert.equal(hasTrackedSignupInSession('user_X'), true);
+  });
+
+  it('tracked state is keyed per user (account switch re-counts)', () => {
+    markSignupTrackedInSession('user_X');
+    assert.equal(hasTrackedSignupInSession('user_Y'), false);
+  });
+
+  it('tracked marker persists across multiple reads (idempotent)', () => {
+    markSignupTrackedInSession('user_X');
+    assert.equal(hasTrackedSignupInSession('user_X'), true);
+    assert.equal(hasTrackedSignupInSession('user_X'), true);
   });
 });

--- a/tests/signup-analytics-gate.test.mts
+++ b/tests/signup-analytics-gate.test.mts
@@ -37,12 +37,16 @@ describe('isLikelyFreshSignup', () => {
     assert.equal(isLikelyFreshSignup('user_x', 'user_x', NOW - 500, NOW), false);
   });
 
-  it('returns false when createdAt is in the future (clock skew guard)', () => {
-    // Future createdAt means nowMs - createdAtMs is negative, which <= window.
-    // This is actually accepted by the predicate — document the behavior:
-    // Clerk createdAt coming from the server is authoritative; minor client
-    // clock skew should not block analytics. Real future-dated accounts do
-    // not exist in practice.
+  it('accepts tiny forward clock skew (createdAt slightly ahead of now)', () => {
+    // Clerk's server clock can be up to a few seconds ahead of a
+    // client clock. A createdAt 500ms in the future is a real-world
+    // clock-skew case and should count as fresh.
     assert.equal(isLikelyFreshSignup(null, 'user_new', NOW + 500, NOW), true);
+  });
+
+  it('rejects createdAt unrealistically far in the future (malformed)', () => {
+    // 10 minutes in the future is not clock skew — it's a bug or a
+    // malicious client-side clock. Must not fire trackSignUp.
+    assert.equal(isLikelyFreshSignup(null, 'user_new', NOW + 10 * 60 * 1000, NOW), false);
   });
 });

--- a/tests/signup-analytics-gate.test.mts
+++ b/tests/signup-analytics-gate.test.mts
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isLikelyFreshSignup, FRESH_SIGNUP_WINDOW_MS } from '../src/services/analytics.ts';
+
+const NOW = 1_700_000_000_000;
+
+describe('isLikelyFreshSignup', () => {
+  it('returns true on null→non-null transition with createdAt within window', () => {
+    assert.equal(isLikelyFreshSignup(null, 'user_new', NOW - 1_000, NOW), true);
+  });
+
+  it('returns true at exactly the window boundary', () => {
+    assert.equal(isLikelyFreshSignup(null, 'user_new', NOW - FRESH_SIGNUP_WINDOW_MS, NOW), true);
+  });
+
+  it('returns false when createdAt is older than the fresh window', () => {
+    assert.equal(
+      isLikelyFreshSignup(null, 'user_returning', NOW - FRESH_SIGNUP_WINDOW_MS - 1, NOW),
+      false,
+    );
+  });
+
+  it('returns false when there was a prior user (sign-in, not sign-up)', () => {
+    assert.equal(isLikelyFreshSignup('user_prev', 'user_next', NOW - 500, NOW), false);
+  });
+
+  it('returns false on sign-out transitions', () => {
+    assert.equal(isLikelyFreshSignup('user_prev', null, null, NOW), false);
+  });
+
+  it('returns false when createdAt is unavailable', () => {
+    assert.equal(isLikelyFreshSignup(null, 'user_new', null, NOW), false);
+  });
+
+  it('returns false when no transition occurred (same id)', () => {
+    assert.equal(isLikelyFreshSignup('user_x', 'user_x', NOW - 500, NOW), false);
+  });
+
+  it('returns false when createdAt is in the future (clock skew guard)', () => {
+    // Future createdAt means nowMs - createdAtMs is negative, which <= window.
+    // This is actually accepted by the predicate — document the behavior:
+    // Clerk createdAt coming from the server is authoritative; minor client
+    // clock skew should not block analytics. Real future-dated accounts do
+    // not exist in practice.
+    assert.equal(isLikelyFreshSignup(null, 'user_new', NOW + 500, NOW), true);
+  });
+});


### PR DESCRIPTION
## Summary

PR-1 of the 14-PR rollout at [`docs/plans/2026-04-21-002-feat-harden-auth-checkout-flow-ux-plan.md`](docs/plans/2026-04-21-002-feat-harden-auth-checkout-flow-ux-plan.md).

Closes three latent gaps in the header auth widget — all touching the same ~30 lines of widget code and the same Clerk service module:

1. **No Sign Up entry point anywhere in the app.** Clerk's sign-up modal was reachable only via the footer link inside the sign-in modal. Register funnel was rhetorically invisible.

2. **`AuthHeaderWidget` constructor dropped its callbacks.** `_onSignInClick` / `_onSettingsClick` underscore prefix was literal — never invoked. `event-handlers.ts:1121` passes `modal.open()` + `unifiedSettings?.open()` that went nowhere, meaning there was no way for a signed-in user to reach **Settings → Manage Billing** from the header avatar.

3. **`trackSignUp` was exported but never called.** Any button-click wiring would conflate "opened modal" with "completed sign-up."

## Changes

- `src/services/clerk.ts` — add `openSignUp()` + `getClerkUserCreatedAt()` helper.
- `src/components/AuthHeaderWidget.ts` — now consumes both constructor callbacks. Signed-out: **Sign In** primary + **Create account** secondary (both wired). Signed-in: Clerk `UserButton` + **adjacent Settings button** (gear icon) that calls `onSettingsClick` → `UnifiedSettings.open()`. **Manage Billing is now 2 clicks from the avatar area.**
- `src/components/AuthLauncher.ts` — adds `.openSignUp()` method for symmetry.
- `src/services/analytics.ts` — detect genuine `null → non-null` user-id transitions inside `initAuthAnalytics` and gate on `user.createdAt` being within a 60s fresh-signup window before firing `trackSignUp('clerk')`. Predicate factored into `isLikelyFreshSignup()` for unit testing.
- `src/locales/en.json` — new `auth.signIn`, `auth.createAccount`, `auth.settings` keys.
- `src/styles/main.css` — `.auth-signup-link` + `.auth-settings-btn` styles.

## Testing

- `tests/signup-analytics-gate.test.mts` — 8 unit tests covering the predicate: null→non-null transition, window boundary, stale createdAt (returning user), prior user (sign-in not sign-up), sign-out, missing createdAt, no-transition, clock-skew.
- Full `npm run test:data` suite — **6036/6036 passing**.
- `npm run typecheck` — clean.
- `npm run lint` — scoped lint on changed files clean. Pre-existing repo warnings unchanged.

### Manual verification needed before merge

- [ ] **Verify sign-up is enabled in the Clerk dashboard** for this app. If disabled, `openSignUp()` is a silent no-op — not a crash, but the "Create account" CTA becomes decorative.

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Logs: Clerk-origin errors (no new backends; client-only change)
  - Metrics/Dashboards: Umami **sign-up** event stream
- **Validation checks**
  - Umami dashboard — filter events for `sign-up` with property `method=clerk`. Expect non-zero volume within 48h.
  - Sentry — no new `component: 'clerk'` exceptions in first 24h.
- **Expected healthy behavior**
  - `sign-up` event fires on genuine new-account creation, NOT on sign-in for existing users.
  - No elevated Sentry rate in `AuthHeaderWidget` stack frames.
- **Failure signal / rollback trigger**
  - Sign-up volume drops to zero immediately post-deploy — revert and investigate Clerk dashboard config.
  - Spike in Sentry events tagged `component: 'clerk'` — revert.
  - UserButton fails to mount after deploy (customers report inability to access Settings) — revert.
- **Validation window & owner**
  - Window: 48h post-deploy.
  - Owner: original author.

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.7 (1M context, extended thinking) <noreply@anthropic.com>