### PR TITLE
feat(checkout): checkout attempt lifecycle + failed-return banner

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -76,7 +76,12 @@ import { install as installCloudPrefsSync, onSignIn as cloudPrefsSignIn, onSignO
 import { getConvexClient, getConvexApi, waitForConvexAuth } from '@/services/convex-client';
 import { initEntitlementSubscription, destroyEntitlementSubscription, resetEntitlementState } from '@/services/entitlements';
 import { initSubscriptionWatch, destroySubscriptionWatch } from '@/services/billing';
-import { capturePendingCheckoutIntentFromUrl, resumePendingCheckout } from '@/services/checkout';
+import {
+  capturePendingCheckoutIntentFromUrl,
+  initCheckoutWatchers,
+  resumePendingCheckout,
+  sweepAbandonedCheckoutAttempt,
+} from '@/services/checkout';
 import {
   CorrelationEngine,
   militaryAdapter,
@@ -976,6 +981,18 @@ export class App {
     this.state.correlationEngine = correlationEngine;
     this.eventHandlers.setupUnifiedSettings();
     this.eventHandlers.setupAuthWidget();
+    // Wire checkout-attempt lifecycle watchers (sign-out clear) before
+    // any capture/resume path runs, so a stale session from a prior
+    // user can't bleed into the current one.
+    initCheckoutWatchers();
+    // Abandonment sweep: clear long-stale attempt records when the
+    // current page load carries no Dodo return params. Runs before
+    // capture (which repopulates the record for /pro handoff intent).
+    const hasCheckoutReturnParams = (() => {
+      const p = new URL(window.location.href).searchParams;
+      return !!(p.get('subscription_id') || p.get('payment_id'));
+    })();
+    sweepAbandonedCheckoutAttempt(hasCheckoutReturnParams);
     const pendingCheckout = capturePendingCheckoutIntentFromUrl();
     if (pendingCheckout) {
       // Checkout intent from /pro page redirect. Resume immediately if

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -105,7 +105,8 @@ import { initSubscriptionWatch, destroySubscriptionWatch } from '@/services/bill
 import { getUserId } from '@/services/user-identity';
 import { initPaymentFailureBanner } from '@/components/payment-failure-banner';
 import { handleCheckoutReturn } from '@/services/checkout-return';
-import { initCheckoutOverlay, destroyCheckoutOverlay, showCheckoutSuccess, consumePostCheckoutFlag } from '@/services/checkout';
+import { initCheckoutOverlay, destroyCheckoutOverlay, showCheckoutSuccess, consumePostCheckoutFlag, clearCheckoutAttempt } from '@/services/checkout';
+import { showCheckoutFailureBanner } from '@/components/checkout-failure-banner';
 import { McpDataPanel } from '@/components/McpDataPanel';
 import { openMcpConnectModal } from '@/components/McpConnectModal';
 import { loadMcpPanels, saveMcpPanel } from '@/services/mcp-store';
@@ -184,11 +185,17 @@ export class PanelLayoutManager implements AppModule {
     //      subscription_id/status URL params and cleans them.
     //   2. Dodo overlay success — setTimeout(reload) with no URL params;
     //      we stash a session flag before the reload and consume it here.
-    const returnedFromCheckoutUrl = handleCheckoutReturn();
+    const returnResult = handleCheckoutReturn();
     const returnedFromOverlay = consumePostCheckoutFlag();
-    const returnedFromCheckout = returnedFromCheckoutUrl || returnedFromOverlay;
+    const returnedFromCheckout = returnResult.kind === 'success' || returnedFromOverlay;
     if (returnedFromCheckout) {
+      // Full-page return cleared its URL params; belt-and-braces clear
+      // of the attempt record here catches the success path where the
+      // overlay handler never ran (direct Dodo redirect).
+      clearCheckoutAttempt('success');
       showCheckoutSuccess();
+    } else if (returnResult.kind === 'failed') {
+      showCheckoutFailureBanner(returnResult.rawStatus);
     }
 
     const userId = getUserId();

--- a/src/components/checkout-failure-banner.ts
+++ b/src/components/checkout-failure-banner.ts
@@ -77,17 +77,38 @@ export function showCheckoutFailureBanner(rawStatus: string): void {
   document.body.appendChild(banner);
 
   if (hasRetryTarget && attempt) {
-    const retryBtn = document.getElementById('cf-retry-btn');
-    retryBtn?.addEventListener('click', () => {
-      banner.remove();
-      void startCheckout(
-        attempt.productId,
-        {
-          referralCode: attempt.referralCode,
-          discountCode: attempt.discountCode,
-        },
-        { fallbackToPricingPage: false },
-      );
+    const retryBtn = document.getElementById('cf-retry-btn') as HTMLButtonElement | null;
+    retryBtn?.addEventListener('click', async () => {
+      // Do NOT remove the banner yet — keep it mounted so the user has
+      // somewhere to land if retry fails (bad network, Clerk unavailable,
+      // edge endpoint 5xx). Swap retry into a "retrying…" state so the
+      // user sees progress, then only remove on confirmed success. On
+      // failure, re-enable so they can try again or dismiss.
+      if (retryBtn) {
+        retryBtn.disabled = true;
+        retryBtn.setAttribute('aria-busy', 'true');
+        retryBtn.textContent = 'Retrying…';
+      }
+      let succeeded = false;
+      try {
+        succeeded = await startCheckout(
+          attempt.productId,
+          {
+            referralCode: attempt.referralCode,
+            discountCode: attempt.discountCode,
+          },
+          { fallbackToPricingPage: false },
+        );
+      } catch {
+        succeeded = false;
+      }
+      if (succeeded) {
+        banner.remove();
+      } else if (retryBtn) {
+        retryBtn.disabled = false;
+        retryBtn.removeAttribute('aria-busy');
+        retryBtn.textContent = 'Retry';
+      }
     });
   }
 

--- a/src/components/checkout-failure-banner.ts
+++ b/src/components/checkout-failure-banner.ts
@@ -1,0 +1,99 @@
+/**
+ * Transient red banner shown when a Dodo checkout return carries
+ * ?status=failed|declined|cancelled. Offers a single-click retry that
+ * reopens the overlay with the exact product the user just tried to
+ * buy (read from LAST_CHECKOUT_ATTEMPT_KEY).
+ *
+ * Styling mirrors payment-failure-banner.ts so the two red banners
+ * feel like one visual family. They never co-fire — payment-failure
+ * watches on_hold subscriptions, this one fires on return-URL status.
+ */
+
+import * as Sentry from '@sentry/browser';
+import {
+  clearCheckoutAttempt,
+  loadCheckoutAttempt,
+  startCheckout,
+} from '@/services/checkout';
+
+const BANNER_ID = 'checkout-failure-banner';
+
+/**
+ * Show the checkout-failure banner. Idempotent: a second call while
+ * a banner is already mounted is a no-op.
+ *
+ * Caller provides the raw Dodo status string so the Sentry event
+ * carries diagnostic context. We never render the raw status to the
+ * user — PR-3 will introduce a typed taxonomy for that.
+ */
+export function showCheckoutFailureBanner(rawStatus: string): void {
+  if (document.getElementById(BANNER_ID)) return;
+
+  Sentry.captureMessage('Dodo checkout declined', {
+    level: 'warning',
+    tags: { component: 'dodo-checkout', status: rawStatus },
+  });
+
+  const banner = document.createElement('div');
+  banner.id = BANNER_ID;
+  Object.assign(banner.style, {
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    right: '0',
+    zIndex: '99998',
+    padding: '10px 20px',
+    background: '#dc2626',
+    color: '#fff',
+    fontSize: '13px',
+    textAlign: 'center',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '12px',
+    boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
+  });
+
+  const attempt = loadCheckoutAttempt();
+  const hasRetryTarget = !!attempt?.productId;
+  // Retry button is omitted when we have no product context (stale
+  // attempt cleared, private-browsing storage, cross-device flow).
+  // User can still dismiss and use the /pro pricing page normally.
+  const retryButton = hasRetryTarget
+    ? `<button id="cf-retry-btn" style="background:#fff;color:#dc2626;border:none;border-radius:4px;padding:4px 12px;font-weight:600;font-size:12px;cursor:pointer;white-space:nowrap;">Try again</button>`
+    : '';
+
+  banner.innerHTML = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0;" aria-hidden="true">
+      <circle cx="12" cy="12" r="10"/>
+      <line x1="12" y1="8" x2="12" y2="12"/>
+      <line x1="12" y1="16" x2="12.01" y2="16"/>
+    </svg>
+    <span>Payment couldn't be completed. No charge was made.</span>
+    ${retryButton}
+    <button id="cf-dismiss-btn" aria-label="Dismiss" style="background:transparent;color:#fff;border:none;cursor:pointer;font-size:18px;padding:0 4px;line-height:1;">&times;</button>
+  `;
+
+  document.body.appendChild(banner);
+
+  if (hasRetryTarget && attempt) {
+    const retryBtn = document.getElementById('cf-retry-btn');
+    retryBtn?.addEventListener('click', () => {
+      banner.remove();
+      void startCheckout(
+        attempt.productId,
+        {
+          referralCode: attempt.referralCode,
+          discountCode: attempt.discountCode,
+        },
+        { fallbackToPricingPage: false },
+      );
+    });
+  }
+
+  const dismissBtn = document.getElementById('cf-dismiss-btn');
+  dismissBtn?.addEventListener('click', () => {
+    clearCheckoutAttempt('dismissed');
+    banner.remove();
+  });
+}

--- a/src/services/checkout-attempt.ts
+++ b/src/services/checkout-attempt.ts
@@ -1,0 +1,106 @@
+/**
+ * Primitive A — checkout attempt lifecycle (retry context store).
+ *
+ * Separate from `PENDING_CHECKOUT_KEY` in checkout.ts because the two
+ * keys have different terminal-clear rules:
+ *
+ *   PENDING_CHECKOUT_KEY      — "should we auto-open the overlay on
+ *                                next mount?" Cleared on overlay close
+ *                                to avoid silent auto-retries.
+ *
+ *   LAST_CHECKOUT_ATTEMPT_KEY — "what product should the failure-retry
+ *                                banner re-open?" MUST survive Dodo
+ *                                emitting `checkout.closed` before the
+ *                                browser navigates to ?status=failed,
+ *                                so the retry button has context.
+ *
+ * Living in its own file so unit tests can exercise the helpers
+ * without pulling in `dodopayments-checkout` (which is browser-only
+ * and breaks Node test runners on import).
+ */
+
+export const LAST_CHECKOUT_ATTEMPT_KEY = 'wm-last-checkout-attempt';
+
+export interface CheckoutAttempt {
+  productId: string;
+  referralCode?: string;
+  discountCode?: string;
+  startedAt: number;
+  origin: 'dashboard' | 'pro';
+}
+
+export type CheckoutAttemptClearReason =
+  | 'success'
+  | 'duplicate'
+  | 'signout'
+  | 'dismissed'
+  | 'abandoned';
+
+/**
+ * Maximum age of a saved attempt before we treat it as stale and
+ * ignore on read. Generous (24h) so a user declined this morning can
+ * return this afternoon and retry the exact product they picked.
+ */
+export const CHECKOUT_ATTEMPT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Silent-abandon cutoff for the mount-time sweep. Older than this AND
+ * no Dodo return params on the current URL → treat as abandoned and
+ * clear so a much-later visit doesn't resurface a stale retry banner.
+ */
+export const CHECKOUT_ATTEMPT_ABANDONED_MS = 30 * 60 * 1000;
+
+export function saveCheckoutAttempt(attempt: CheckoutAttempt): void {
+  try {
+    sessionStorage.setItem(LAST_CHECKOUT_ATTEMPT_KEY, JSON.stringify(attempt));
+  } catch {
+    // Storage disabled (private browsing); retry banner will degrade
+    // gracefully to omitting the "Try again" button.
+  }
+}
+
+export function loadCheckoutAttempt(): CheckoutAttempt | null {
+  try {
+    const raw = sessionStorage.getItem(LAST_CHECKOUT_ATTEMPT_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CheckoutAttempt;
+    if (!parsed || typeof parsed.productId !== 'string' || typeof parsed.startedAt !== 'number') {
+      return null;
+    }
+    if (Date.now() - parsed.startedAt > CHECKOUT_ATTEMPT_MAX_AGE_MS) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearCheckoutAttempt(_reason: CheckoutAttemptClearReason): void {
+  try {
+    sessionStorage.removeItem(LAST_CHECKOUT_ATTEMPT_KEY);
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+/**
+ * Mount-time defensive cleanup. Caller passes `hasReturnParams` so we
+ * never clear an attempt that a freshly-loaded ?status=failed URL is
+ * about to consume (the failed-redirect race).
+ */
+export function sweepAbandonedCheckoutAttempt(hasReturnParams: boolean): void {
+  if (hasReturnParams) return;
+  try {
+    const raw = sessionStorage.getItem(LAST_CHECKOUT_ATTEMPT_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as CheckoutAttempt;
+    const age = Date.now() - (parsed?.startedAt ?? 0);
+    if (age > CHECKOUT_ATTEMPT_ABANDONED_MS) {
+      sessionStorage.removeItem(LAST_CHECKOUT_ATTEMPT_KEY);
+    }
+  } catch {
+    // Malformed record — clear defensively.
+    try { sessionStorage.removeItem(LAST_CHECKOUT_ATTEMPT_KEY); } catch { /* noop */ }
+  }
+}

--- a/src/services/checkout-return.ts
+++ b/src/services/checkout-return.ts
@@ -2,38 +2,60 @@
  * Post-checkout redirect detection and URL cleanup.
  *
  * When Dodo redirects the user back to the dashboard after payment,
- * it appends query params like ?subscription_id=sub_xxx&status=active.
- * This module detects those params, cleans the URL, and returns
- * whether a successful checkout was detected.
+ * it appends query params like ?subscription_id=sub_xxx&status=active
+ * or ?subscription_id=...&status=failed for declined cards.
+ *
+ * This module inspects those params, cleans them from the URL, and
+ * returns a discriminated union so callers can branch on success vs
+ * failure vs "not a checkout return at all" without sentinel-boolean
+ * ambiguity. The prior boolean return silently swallowed declined
+ * payments — a Dodo return with status=failed looked identical to "no
+ * checkout here, render normal dashboard."
  */
 
+export type CheckoutReturnResult =
+  | { kind: 'none' }
+  | { kind: 'success' }
+  | { kind: 'failed'; rawStatus: string };
+
+const SUCCESS_STATUSES = new Set(['active', 'succeeded']);
+const FAILED_STATUSES = new Set(['failed', 'declined', 'cancelled', 'canceled']);
+
 /**
- * Check the current URL for Dodo checkout return params.
- * If found, cleans them from the URL and returns true when payment succeeded.
- * Returns false if no checkout params are present.
+ * Inspect current URL for Dodo return params. If found, cleans them
+ * and returns the outcome discriminant. Callers:
+ *  - `kind: 'success'` → show success banner, trigger entitlement unlock
+ *  - `kind: 'failed'`  → show failure banner with retry CTA
+ *  - `kind: 'none'`    → no-op, this is a normal page load
  */
-export function handleCheckoutReturn(): boolean {
+export function handleCheckoutReturn(): CheckoutReturnResult {
   const url = new URL(window.location.href);
   const params = url.searchParams;
 
   const subscriptionId = params.get('subscription_id');
   const paymentId = params.get('payment_id');
-  const status = params.get('status');
+  const status = params.get('status') ?? '';
 
-  // No checkout params -- not a return from checkout
   if (!subscriptionId && !paymentId) {
-    return false;
+    return { kind: 'none' };
   }
 
-  // Clean checkout-related params from URL immediately
+  // Clean checkout-related params from URL immediately. Do this before
+  // returning the discriminant so history replacement is not conditional
+  // on the caller — a URL with these params should never survive to a
+  // second call of handleCheckoutReturn().
   const paramsToRemove = ['subscription_id', 'payment_id', 'status', 'email', 'license_key'];
   for (const key of paramsToRemove) {
     params.delete(key);
   }
-
   const cleanUrl = url.pathname + (params.toString() ? `?${params.toString()}` : '') + url.hash;
   window.history.replaceState({}, '', cleanUrl);
 
-  // Return true if payment was successful
-  return status === 'active' || status === 'succeeded';
+  if (SUCCESS_STATUSES.has(status)) return { kind: 'success' };
+  if (FAILED_STATUSES.has(status)) return { kind: 'failed', rawStatus: status };
+  // Unknown status (e.g. Dodo introduces a new value) — prefer the
+  // failure branch so the user sees an actionable banner rather than
+  // silent degradation. Log the unexpected status for investigation.
+  if (status) return { kind: 'failed', rawStatus: status };
+  return { kind: 'none' };
 }

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -69,6 +69,18 @@ interface PendingCheckoutIntent {
   productId: string;
   referralCode?: string;
   discountCode?: string;
+  /**
+   * User id who saved this intent, or null if saved anonymously (the
+   * common "click Buy, get sign-in modal" path). On resume, we only
+   * fire the auto-checkout if:
+   *   - savedByUserId === current user id (mid-flow redirect return), OR
+   *   - savedByUserId === null AND current user is authenticated
+   *     (anonymous intent → user just signed up/in — THIS IS the
+   *     auto-resume case)
+   * Anything else (A saved, B is now signed in) is a cross-user leak
+   * and the intent is discarded.
+   */
+  savedByUserId?: string | null;
 }
 
 let initialized = false;
@@ -270,6 +282,11 @@ export function capturePendingCheckoutIntentFromUrl(): PendingCheckoutIntent | n
     productId,
     referralCode: url.searchParams.get(CHECKOUT_REFERRAL_PARAM) ?? undefined,
     discountCode: url.searchParams.get(CHECKOUT_DISCOUNT_PARAM) ?? undefined,
+    // Stamp the owning user id at save time so a later load in the
+    // same tab by a different user can discard this intent instead of
+    // auto-resuming it. null = saved anonymously (the click-sign-in
+    // flow), which is fair game for the first signed-in user.
+    savedByUserId: getCurrentClerkUser()?.id ?? null,
   };
   savePendingCheckoutIntent(intent);
   // /pro-origin intent captured here also populates the failure-retry
@@ -301,11 +318,22 @@ export async function resumePendingCheckout(options?: {
   }
 
   const clerkUser = getCurrentClerkUser();
-  console.log(`[checkout] resumePendingCheckout: intent=${intent.productId}, clerkUser=${clerkUser?.id ?? 'null'}, hasOpenAuth=${!!options?.openAuth}`);
+  console.log(`[checkout] resumePendingCheckout: intent=${intent.productId}, clerkUser=${clerkUser?.id ?? 'null'}, savedBy=${intent.savedByUserId ?? 'anon'}, hasOpenAuth=${!!options?.openAuth}`);
 
   if (!clerkUser?.id) {
     console.log('[checkout] resumePendingCheckout: no Clerk user, opening auth');
     options?.openAuth?.();
+    return false;
+  }
+
+  // Cross-user leak guard: drop the intent if it was saved by a
+  // different signed-in user. Anonymous saves (savedByUserId === null
+  // OR missing for legacy intents pre-fix) are fair game for the
+  // now-signed-in user — that's the auto-resume case.
+  const savedBy = intent.savedByUserId;
+  if (savedBy != null && savedBy !== clerkUser.id) {
+    console.log('[checkout] resumePendingCheckout: intent belongs to different user, discarding');
+    clearPendingCheckoutIntent();
     return false;
   }
 

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -94,8 +94,16 @@ export function initCheckoutOverlay(onSuccess?: () => void): void {
     displayType: 'overlay',
     onEvent: (event: CheckoutEvent) => {
       switch (event.event_type) {
-        case 'checkout.status':
-          if (event.data?.status === 'succeeded') {
+        case 'checkout.status': {
+          // Dodo SDK has emitted `event.data.status` in some versions and
+          // `event.data.message.status` in others (the /pro build reads both
+          // already; main app was only reading the first, so successes went
+          // unnoticed whenever the SDK used the nested shape). Read both.
+          const rawData = event.data as Record<string, unknown> | undefined;
+          const status = typeof rawData?.status === 'string'
+            ? rawData.status
+            : (rawData?.message as Record<string, unknown> | undefined)?.status;
+          if (status === 'succeeded') {
             _successFired = true;
             onSuccessCallback?.();
             // Terminal success: clear both keys. LAST_CHECKOUT_ATTEMPT_KEY
@@ -114,6 +122,7 @@ export function initCheckoutOverlay(onSuccess?: () => void): void {
             setTimeout(() => window.location.reload(), 3_000);
           }
           break;
+        }
         case 'checkout.closed':
           // Only clear the auto-resume intent. Do NOT clear
           // LAST_CHECKOUT_ATTEMPT_KEY here — Dodo can emit `closed` BEFORE
@@ -175,21 +184,34 @@ function clearPendingCheckoutIntent(): void {
  * Wire lifecycle watchers that need to fire outside the direct
  * startCheckout() call path. Idempotent.
  *
- * Currently: clears both state keys on sign-out so the next signed-in
- * user never inherits the previous user's checkout intent. The
- * `auth-state` subscription fires immediately with the current session
- * on subscribe, so we gate on a null→null transition by tracking the
- * previously-observed user id.
+ * Clears per-session checkout state on ANY user-id change:
+ *   - null → user (sign-in): nothing to clear, but initialize baseline.
+ *   - user → null (sign-out): wipe state so the next user doesn't
+ *     inherit it.
+ *   - userA → userB (account switch, Clerk session swap, SSO
+ *     re-attribution): also wipe — accidentally showing user B a retry
+ *     button for user A's failed Pro checkout is worse than losing
+ *     retry context.
+ *
+ * The `auth-state` subscription fires immediately with the current
+ * session on subscribe, so we track the previously-observed id to
+ * distinguish real transitions from the initial snapshot.
  */
 export function initCheckoutWatchers(): void {
   if (_watchersInitialized) return;
   _watchersInitialized = true;
 
   let _lastUserId: string | null = null;
+  let _initialized = false;
   subscribeAuthState((state) => {
     const nextId = state.user?.id ?? null;
-    if (_lastUserId !== null && nextId === null) {
-      // Real sign-out transition.
+    if (!_initialized) {
+      _initialized = true;
+      _lastUserId = nextId;
+      return;
+    }
+    if (nextId !== _lastUserId) {
+      // Any user-id change — sign-out, account switch, session rotation.
       clearCheckoutAttempt('signout');
       clearPendingCheckoutIntent();
     }

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -208,12 +208,27 @@ export function initCheckoutWatchers(): void {
     if (!_initialized) {
       _initialized = true;
       _lastUserId = nextId;
+      // Defensive sweep on first snapshot: if the tab loads signed-out,
+      // there's no legitimate owner for any prior checkout state — wipe
+      // pending/post-checkout/attempt so a stale marker from a previous
+      // user (closed tab, session expiry, account switch before reload)
+      // can't leak into the next signed-in user's session. Signed-in
+      // loads preserve state because that user may be returning from a
+      // Dodo redirect mid-flow.
+      if (nextId === null) {
+        clearCheckoutAttempt('signout');
+        clearPendingCheckoutIntent();
+        try { sessionStorage.removeItem(POST_CHECKOUT_FLAG_KEY); } catch { /* ignore */ }
+      }
       return;
     }
     if (nextId !== _lastUserId) {
       // Any user-id change — sign-out, account switch, session rotation.
+      // Must also clear POST_CHECKOUT_FLAG_KEY so a success banner from
+      // the previous user can't fire for the next one on the same tab.
       clearCheckoutAttempt('signout');
       clearPendingCheckoutIntent();
+      try { sessionStorage.removeItem(POST_CHECKOUT_FLAG_KEY); } catch { /* ignore */ }
     }
     _lastUserId = nextId;
   });

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -16,6 +16,17 @@ import { DodoPayments } from 'dodopayments-checkout';
 import type { CheckoutEvent } from 'dodopayments-checkout';
 import { openBillingPortal } from './billing';
 import { getCurrentClerkUser, getClerkToken } from './clerk';
+import { subscribeAuthState } from './auth-state';
+import { saveCheckoutAttempt, clearCheckoutAttempt } from './checkout-attempt';
+
+export {
+  saveCheckoutAttempt,
+  loadCheckoutAttempt,
+  clearCheckoutAttempt,
+  sweepAbandonedCheckoutAttempt,
+  type CheckoutAttempt,
+  type CheckoutAttemptClearReason,
+} from './checkout-attempt';
 
 const CHECKOUT_PRODUCT_PARAM = 'checkoutProduct';
 const CHECKOUT_REFERRAL_PARAM = 'checkoutReferral';
@@ -62,6 +73,8 @@ interface PendingCheckoutIntent {
 
 let initialized = false;
 let onSuccessCallback: (() => void) | null = null;
+let _successFired = false;
+let _watchersInitialized = false;
 
 /**
  * Initialize the Dodo overlay SDK. Idempotent -- second+ calls are no-ops.
@@ -83,7 +96,13 @@ export function initCheckoutOverlay(onSuccess?: () => void): void {
       switch (event.event_type) {
         case 'checkout.status':
           if (event.data?.status === 'succeeded') {
+            _successFired = true;
             onSuccessCallback?.();
+            // Terminal success: clear both keys. LAST_CHECKOUT_ATTEMPT_KEY
+            // is no longer needed (no retry context required); PENDING is
+            // cleared to avoid auto-opening the overlay on the reload.
+            clearCheckoutAttempt('success');
+            clearPendingCheckoutIntent();
             // Belt-and-braces: reload after the webhook is likely to have
             // landed (median <5s). Mark a session flag so the reloaded page
             // can seed the entitlement transition detector as post-checkout
@@ -96,6 +115,16 @@ export function initCheckoutOverlay(onSuccess?: () => void): void {
           }
           break;
         case 'checkout.closed':
+          // Only clear the auto-resume intent. Do NOT clear
+          // LAST_CHECKOUT_ATTEMPT_KEY here — Dodo can emit `closed` BEFORE
+          // the browser navigates to ?status=failed, and the failure
+          // banner on the next page needs the attempt record to populate
+          // the retry CTA. The attempt record will be cleared later by
+          // the terminal path that actually resolves (success, dismissed,
+          // duplicate, or the mount-time abandonment sweep).
+          if (!_successFired) {
+            clearPendingCheckoutIntent();
+          }
           break;
         case 'checkout.error':
           console.error('[checkout] Overlay error:', event.data?.message);
@@ -142,6 +171,32 @@ function clearPendingCheckoutIntent(): void {
   }
 }
 
+/**
+ * Wire lifecycle watchers that need to fire outside the direct
+ * startCheckout() call path. Idempotent.
+ *
+ * Currently: clears both state keys on sign-out so the next signed-in
+ * user never inherits the previous user's checkout intent. The
+ * `auth-state` subscription fires immediately with the current session
+ * on subscribe, so we gate on a null→null transition by tracking the
+ * previously-observed user id.
+ */
+export function initCheckoutWatchers(): void {
+  if (_watchersInitialized) return;
+  _watchersInitialized = true;
+
+  let _lastUserId: string | null = null;
+  subscribeAuthState((state) => {
+    const nextId = state.user?.id ?? null;
+    if (_lastUserId !== null && nextId === null) {
+      // Real sign-out transition.
+      clearCheckoutAttempt('signout');
+      clearPendingCheckoutIntent();
+    }
+    _lastUserId = nextId;
+  });
+}
+
 export function buildCheckoutLaunchUrl(
   productId: string,
   options?: { referralCode?: string; discountCode?: string },
@@ -170,6 +225,15 @@ export function capturePendingCheckoutIntentFromUrl(): PendingCheckoutIntent | n
     discountCode: url.searchParams.get(CHECKOUT_DISCOUNT_PARAM) ?? undefined,
   };
   savePendingCheckoutIntent(intent);
+  // /pro-origin intent captured here also populates the failure-retry
+  // record so a decline on this session's checkout can retry cross-origin.
+  saveCheckoutAttempt({
+    productId,
+    referralCode: intent.referralCode,
+    discountCode: intent.discountCode,
+    startedAt: Date.now(),
+    origin: 'pro',
+  });
 
   url.searchParams.delete(CHECKOUT_PRODUCT_PARAM);
   url.searchParams.delete(CHECKOUT_REFERRAL_PARAM);
@@ -273,6 +337,17 @@ export async function startCheckout(
   }
 
   _checkoutInFlight = true;
+  _successFired = false;
+  // Record the attempt BEFORE the network call so the failure-retry
+  // banner has context even if every subsequent step fails (timeout,
+  // user closes tab before Dodo redirects, SDK crashes, etc.).
+  saveCheckoutAttempt({
+    productId,
+    referralCode: options?.referralCode,
+    discountCode: options?.discountCode,
+    startedAt: Date.now(),
+    origin: 'dashboard',
+  });
   try {
     let token = await getClerkToken();
     if (!token) {
@@ -301,6 +376,7 @@ export async function startCheckout(
       console.error('[checkout] Edge endpoint error:', resp.status, err);
       if (resp.status === 409 && err?.error === ACTIVE_SUBSCRIPTION_EXISTS) {
         clearPendingCheckoutIntent();
+        clearCheckoutAttempt('duplicate');
         await openBillingPortal();
         return false;
       }

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -223,12 +223,22 @@ export function initCheckoutWatchers(): void {
       return;
     }
     if (nextId !== _lastUserId) {
-      // Any user-id change — sign-out, account switch, session rotation.
-      // Must also clear POST_CHECKOUT_FLAG_KEY so a success banner from
-      // the previous user can't fire for the next one on the same tab.
-      clearCheckoutAttempt('signout');
-      clearPendingCheckoutIntent();
-      try { sessionStorage.removeItem(POST_CHECKOUT_FLAG_KEY); } catch { /* ignore */ }
+      const isSignIn = _lastUserId === null && nextId !== null;
+      if (isSignIn) {
+        // null→user transition is a sign-IN, NOT a sign-OUT. The whole
+        // point of pending/attempt state is to survive a sign-in so the
+        // post-auth auto-resume listener can fire the deferred checkout.
+        // Clearing here would race the resume listener and kill the
+        // flow — reviewer flagged this as a subscriber-order bug.
+        // Do NOT clear pending / post-checkout on sign-in.
+      } else {
+        // Everything else — sign-out, account switch (A→B), session
+        // rotation — must wipe all checkout state so the next user
+        // never inherits the previous user's intent/flag/attempt.
+        clearCheckoutAttempt('signout');
+        clearPendingCheckoutIntent();
+        try { sessionStorage.removeItem(POST_CHECKOUT_FLAG_KEY); } catch { /* ignore */ }
+      }
     }
     _lastUserId = nextId;
   });

--- a/tests/checkout-attempt-lifecycle.test.mts
+++ b/tests/checkout-attempt-lifecycle.test.mts
@@ -1,0 +1,190 @@
+/**
+ * Exercises the save/load/clear primitives for LAST_CHECKOUT_ATTEMPT_KEY
+ * and the abandonment sweep. The key invariant under test is the two-key
+ * separation: Primitive A's PENDING_CHECKOUT_KEY and LAST_CHECKOUT_ATTEMPT_KEY
+ * have different terminal-clear triggers (see the plan's Primitive A section).
+ *
+ * Only pure storage helpers are exercised here — startCheckout() and the
+ * Dodo overlay event handlers require a browser/SDK environment and are
+ * covered by manual + E2E paths per the PR plan.
+ */
+
+import { describe, it, beforeEach, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+class MemoryStorage {
+  private readonly store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) as string) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const LAST_CHECKOUT_ATTEMPT_KEY = 'wm-last-checkout-attempt';
+
+let _sessionStorage: MemoryStorage;
+
+before(() => {
+  _sessionStorage = new MemoryStorage();
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    value: _sessionStorage,
+  });
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      location: { href: 'https://worldmonitor.app/', pathname: '/', search: '', hash: '' },
+      history: { replaceState: () => {} },
+    },
+  });
+});
+
+after(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (globalThis as any).sessionStorage;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (globalThis as any).window;
+});
+
+beforeEach(() => {
+  _sessionStorage.clear();
+});
+
+const {
+  saveCheckoutAttempt,
+  loadCheckoutAttempt,
+  clearCheckoutAttempt,
+  sweepAbandonedCheckoutAttempt,
+} = await import('../src/services/checkout-attempt.ts');
+
+describe('saveCheckoutAttempt / loadCheckoutAttempt', () => {
+  it('round-trips a fresh attempt', () => {
+    saveCheckoutAttempt({
+      productId: 'pdt_X',
+      referralCode: 'abc',
+      startedAt: Date.now(),
+      origin: 'dashboard',
+    });
+    const loaded = loadCheckoutAttempt();
+    assert.equal(loaded?.productId, 'pdt_X');
+    assert.equal(loaded?.referralCode, 'abc');
+    assert.equal(loaded?.origin, 'dashboard');
+  });
+
+  it('returns null when nothing stored', () => {
+    assert.equal(loadCheckoutAttempt(), null);
+  });
+
+  it('returns null for malformed JSON', () => {
+    _sessionStorage.setItem(LAST_CHECKOUT_ATTEMPT_KEY, '{not json');
+    assert.equal(loadCheckoutAttempt(), null);
+  });
+
+  it('returns null for stored records missing productId', () => {
+    _sessionStorage.setItem(
+      LAST_CHECKOUT_ATTEMPT_KEY,
+      JSON.stringify({ startedAt: Date.now(), origin: 'dashboard' }),
+    );
+    assert.equal(loadCheckoutAttempt(), null);
+  });
+
+  it('returns null for records older than 24h', () => {
+    const twentyFiveHoursAgo = Date.now() - 25 * 60 * 60 * 1000;
+    saveCheckoutAttempt({
+      productId: 'pdt_X',
+      startedAt: twentyFiveHoursAgo,
+      origin: 'dashboard',
+    });
+    assert.equal(loadCheckoutAttempt(), null);
+  });
+
+  it('returns record just under 24h', () => {
+    const twentyThreeHoursAgo = Date.now() - 23 * 60 * 60 * 1000;
+    saveCheckoutAttempt({
+      productId: 'pdt_X',
+      startedAt: twentyThreeHoursAgo,
+      origin: 'pro',
+    });
+    assert.equal(loadCheckoutAttempt()?.productId, 'pdt_X');
+  });
+});
+
+describe('clearCheckoutAttempt', () => {
+  it('clears the stored record regardless of reason', () => {
+    const reasons: Array<'success' | 'duplicate' | 'signout' | 'dismissed' | 'abandoned'> = [
+      'success',
+      'duplicate',
+      'signout',
+      'dismissed',
+      'abandoned',
+    ];
+    for (const reason of reasons) {
+      saveCheckoutAttempt({
+        productId: 'pdt_X',
+        startedAt: Date.now(),
+        origin: 'dashboard',
+      });
+      clearCheckoutAttempt(reason);
+      assert.equal(loadCheckoutAttempt(), null, `reason=${reason} should clear the record`);
+    }
+  });
+
+  it('is safe to call with no record present', () => {
+    assert.doesNotThrow(() => clearCheckoutAttempt('success'));
+  });
+});
+
+describe('sweepAbandonedCheckoutAttempt', () => {
+  it('does not clear when return params are present (failed-redirect race guard)', () => {
+    const oldAttempt = {
+      productId: 'pdt_X',
+      startedAt: Date.now() - 40 * 60 * 1000, // 40min old, past abandon cutoff
+      origin: 'dashboard' as const,
+    };
+    saveCheckoutAttempt(oldAttempt);
+    // hasReturnParams = true means the page carries ?status=failed (or
+    // similar) — we must NOT clear because the failure banner is about
+    // to consume the attempt record to populate retry.
+    sweepAbandonedCheckoutAttempt(true);
+    assert.equal(loadCheckoutAttempt()?.productId, 'pdt_X');
+  });
+
+  it('clears records older than 30min when no return params', () => {
+    saveCheckoutAttempt({
+      productId: 'pdt_X',
+      startedAt: Date.now() - 45 * 60 * 1000,
+      origin: 'dashboard',
+    });
+    sweepAbandonedCheckoutAttempt(false);
+    assert.equal(loadCheckoutAttempt(), null);
+  });
+
+  it('preserves records younger than 30min when no return params', () => {
+    saveCheckoutAttempt({
+      productId: 'pdt_X',
+      startedAt: Date.now() - 5 * 60 * 1000,
+      origin: 'dashboard',
+    });
+    sweepAbandonedCheckoutAttempt(false);
+    assert.equal(loadCheckoutAttempt()?.productId, 'pdt_X');
+  });
+
+  it('clears malformed records defensively', () => {
+    _sessionStorage.setItem(LAST_CHECKOUT_ATTEMPT_KEY, '{not json');
+    sweepAbandonedCheckoutAttempt(false);
+    assert.equal(_sessionStorage.getItem(LAST_CHECKOUT_ATTEMPT_KEY), null);
+  });
+
+  it('is a no-op when nothing is stored', () => {
+    sweepAbandonedCheckoutAttempt(false);
+    assert.equal(loadCheckoutAttempt(), null);
+  });
+});

--- a/tests/checkout-return-discriminant.test.mts
+++ b/tests/checkout-return-discriminant.test.mts
@@ -1,0 +1,111 @@
+import { describe, it, before, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+const BASE_URL = 'https://worldmonitor.app/';
+
+interface MutableLocation {
+  href: string;
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+interface MutableHistory {
+  replaceState: (state: unknown, unused: string, url?: string | URL | null) => void;
+}
+
+let _loc: MutableLocation;
+let _history: MutableHistory;
+
+function setUrl(href: string): void {
+  const url = new URL(href);
+  _loc.href = url.toString();
+  _loc.pathname = url.pathname;
+  _loc.search = url.search;
+  _loc.hash = url.hash;
+}
+
+before(() => {
+  _loc = { href: BASE_URL, pathname: '/', search: '', hash: '' };
+  _history = {
+    replaceState: (_state, _unused, url) => {
+      if (url !== undefined && url !== null) setUrl(new URL(String(url), _loc.href).toString());
+    },
+  };
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { location: _loc, history: _history },
+  });
+});
+
+after(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (globalThis as any).window;
+});
+
+beforeEach(() => {
+  setUrl(BASE_URL);
+});
+
+const { handleCheckoutReturn } = await import('../src/services/checkout-return.ts');
+
+describe('handleCheckoutReturn', () => {
+  it('returns { kind: "none" } when no checkout params present', () => {
+    setUrl(`${BASE_URL}?foo=bar`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'none' });
+    assert.equal(_loc.href, `${BASE_URL}?foo=bar`, 'URL is not modified when no checkout params');
+  });
+
+  it('returns { kind: "success" } for status=active', () => {
+    setUrl(`${BASE_URL}?subscription_id=sub_X&status=active`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'success' });
+  });
+
+  it('returns { kind: "success" } for status=succeeded', () => {
+    setUrl(`${BASE_URL}?subscription_id=sub_X&status=succeeded`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'success' });
+  });
+
+  it('returns { kind: "failed" } for status=failed with raw status preserved', () => {
+    setUrl(`${BASE_URL}?subscription_id=sub_X&status=failed`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'failed', rawStatus: 'failed' });
+  });
+
+  it('returns { kind: "failed" } for status=declined', () => {
+    setUrl(`${BASE_URL}?payment_id=pay_X&status=declined`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'failed', rawStatus: 'declined' });
+  });
+
+  it('returns { kind: "failed" } for status=cancelled', () => {
+    setUrl(`${BASE_URL}?subscription_id=sub_X&status=cancelled`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'failed', rawStatus: 'cancelled' });
+  });
+
+  it('treats unknown status as failed (prefer surfacing over silent success)', () => {
+    setUrl(`${BASE_URL}?subscription_id=sub_X&status=bogus_new_value`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'failed', rawStatus: 'bogus_new_value' });
+  });
+
+  it('returns { kind: "none" } when checkout params present but status missing', () => {
+    setUrl(`${BASE_URL}?subscription_id=sub_X`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'none' });
+  });
+
+  it('cleans checkout params from URL on success', () => {
+    setUrl(`${BASE_URL}?subscription_id=sub_X&status=active&foo=bar`);
+    handleCheckoutReturn();
+    assert.equal(_loc.href, `${BASE_URL}?foo=bar`);
+  });
+
+  it('cleans checkout params from URL on failure too', () => {
+    setUrl(`${BASE_URL}?subscription_id=sub_X&status=failed&foo=bar`);
+    handleCheckoutReturn();
+    assert.equal(_loc.href, `${BASE_URL}?foo=bar`);
+  });
+
+  it('strips email and license_key alongside status params', () => {
+    setUrl(`${BASE_URL}?subscription_id=sub_X&status=active&email=u@x&license_key=k`);
+    handleCheckoutReturn();
+    assert.equal(_loc.href, BASE_URL);
+  });
+});


### PR DESCRIPTION
## Summary

PR-2 of the 14-PR rollout at [`docs/plans/2026-04-21-002-feat-harden-auth-checkout-flow-ux-plan.md`](docs/plans/2026-04-21-002-feat-harden-auth-checkout-flow-ux-plan.md).

Closes two related gaps that depend on a shared state primitive:

1. **`handleCheckoutReturn()` silently swallowed `?status=failed`.** Declined payments returned `false` → dashboard rendered normally → no banner, no retry, no Sentry surface.
2. **Closing the Dodo overlay without paying left a stale `PENDING_CHECKOUT_KEY`** → silently auto-reopened the overlay on next mount via `resumePendingCheckout` (original PR-10 concern).

**Merged into one PR** because both touch the same state machine (Codex review round 2 finding #7). Splitting them would force two passes over the same ~60 lines of cleanup logic and risk a close-before-failed-redirect race.

### Two-key state model (Primitive A)

| Key | Lifecycle | Purpose |
|---|---|---|
| `PENDING_CHECKOUT_KEY` (existing) | Clears on: **close**, success, duplicate, signout | \"Auto-open the overlay on next mount?\" |
| `LAST_CHECKOUT_ATTEMPT_KEY` (new) | Clears on: success, duplicate, signout, **dismissed**, 30-min abandon sweep. NOT on close. | \"What product should the failure-retry banner re-open?\" |

The two-key split is the fix for the Codex-round-2 race: Dodo can emit `checkout.closed` *before* the browser navigates to `?status=failed`, so the retry banner on the subsequent failure page needs the attempt record to survive close.

### Changes

- **`src/services/checkout-attempt.ts` (new)** — Primitive A save/load/clear/sweep helpers in a pure module (no SDK dependency) so they can be unit-tested without a browser env.
- **`src/services/checkout-return.ts`** — boolean → discriminated union `{ kind: 'none' | 'success' | 'failed'; rawStatus }`. Unknown statuses bias toward `failed` (prefer surfacing over silent degradation).
- **`src/services/checkout.ts`** — saves attempt at top of `startCheckout` AND inside `capturePendingCheckoutIntentFromUrl` (covers both dashboard + /pro origins). Clears at every terminal path: `checkout.status=succeeded`, `ACTIVE_SUBSCRIPTION_EXISTS`, sign-out. Crucially does NOT clear the attempt on `checkout.closed` — only clears the pending-auto-resume key there. Adds `initCheckoutWatchers()` with auth-state sign-out subscription.
- **`src/components/checkout-failure-banner.ts` (new)** — red persistent banner mirroring `payment-failure-banner` styling. \"Try again\" CTA reopens the overlay for the exact product the user last tried. Gracefully omits the retry button when no attempt record exists (stale sweep, private browsing, cross-device).
- **`src/app/panel-layout.ts`** — switches on the new discriminant; success banner for `success|overlay-reload`, failure banner for `failed`.
- **`src/App.ts`** — mount-time abandonment sweep (30min) + `initCheckoutWatchers()` before `capturePendingCheckoutIntentFromUrl()` runs so sign-out clears don't race with capture.

## Testing

- **`tests/checkout-return-discriminant.test.mts`** — 11 cases covering all 6 status branches + URL param cleanup edge cases.
- **`tests/checkout-attempt-lifecycle.test.mts`** — 13 cases: save/load round-trip, malformed JSON guard, missing-field guard, 24h staleness cutoff (both boundaries), all 5 clear-reasons, 30-min abandonment sweep, **and the failed-redirect race guard** (`hasReturnParams=true` ⇒ do NOT clear).
- **Full `npm run test:data`** — 6073/6073 passing (24 new tests + pre-existing 6049).
- **`npm run typecheck`** — clean.
- **Scoped lint on changed files** — clean (4 pre-existing complexity warnings in unrelated parts of App.ts / panel-layout.ts).

### Manual verification (before merge)

- [ ] Dodo test decline card → observe red failure banner with \"Try again\" that reopens the overlay for the same product.
- [ ] Open overlay → close without paying → reload → no auto-retry overlay.
- [ ] Sign in as user A, start checkout, sign out, sign in as user B → user B inherits no state.
- [ ] **Race check**: simulate close-before-failed-redirect. Confirm retry context survives.

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Logs: new Sentry message `\"Dodo checkout declined\"` with `tags.status=<raw>`.
  - Metrics: Sentry event rate for `component: 'dodo-checkout'`.
- **Validation checks**
  - Sentry — filter `message: \"Dodo checkout declined\"`. Non-zero volume within 48h is expected (declined cards do happen); sanity-check the rate is not anomalous vs baseline.
  - Umami — no existing event, just verify no regression in `sign-up` / `sign-in` funnels.
- **Expected healthy behavior**
  - Declined payments now emit a banner + a Sentry warning, instead of silently rendering a normal dashboard.
  - Successful payments continue to trigger the existing post-checkout reload + entitlement unlock (no regression).
- **Failure signal / rollback trigger**
  - Spike in `component: 'dodo-checkout'` errors after deploy → revert.
  - Users reporting auto-reopened overlays on unrelated page loads → revert (abandonment sweep or two-key split is misbehaving).
  - `test:data` suite regressions in CI → block merge.
- **Validation window & owner**
  - Window: 48h post-deploy.
  - Owner: original author.

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.7 (1M context, extended thinking) <noreply@anthropic.com>