### PR TITLE
feat(checkout): unify reload ownership + extended "still unlocking" banner

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -193,7 +193,13 @@ export class PanelLayoutManager implements AppModule {
       // of the attempt record here catches the success path where the
       // overlay handler never ran (direct Dodo redirect).
       clearCheckoutAttempt('success');
-      showCheckoutSuccess();
+      // waitForEntitlement: true keeps the banner mounted across the
+      // entitlement-watcher reload (post-PR-4 the watcher is the single
+      // reload source). If the user is already entitled on mount the
+      // banner goes straight to the "active" state; otherwise it waits
+      // up to 30s for the transition before surfacing a manual-refresh
+      // CTA.
+      showCheckoutSuccess({ waitForEntitlement: true });
     } else if (returnResult.kind === 'failed') {
       showCheckoutFailureBanner(returnResult.rawStatus);
     }
@@ -205,7 +211,11 @@ export class PanelLayoutManager implements AppModule {
       this.unsubscribePaymentFailureBanner = initPaymentFailureBanner();
     }
 
-    initCheckoutOverlay(() => showCheckoutSuccess());
+    // Overlay success fires BEFORE the entitlement-watcher reload. The
+    // banner stays mounted through the reload via waitForEntitlement so
+    // the user sees visual continuity from "Payment received!" through
+    // "Premium activated" without a blank intermediate state.
+    initCheckoutOverlay(() => showCheckoutSuccess({ waitForEntitlement: true }));
 
     // Reload only on a free→pro transition. Legacy-pro users whose first
     // snapshot is already pro (lastEntitled === null) must not trigger a

--- a/src/services/checkout-banner-state.ts
+++ b/src/services/checkout-banner-state.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure helpers for the checkout-success banner's extended-unlock state
+ * machine. Lives in its own module so tests (and any future consumer)
+ * can exercise the decision logic without pulling in `dodopayments-
+ * checkout` through `checkout.ts`.
+ */
+
+export type CheckoutSuccessBannerState = 'pending' | 'active' | 'timeout';
+
+/**
+ * How long to wait for the post-checkout entitlement transition before
+ * switching into the `timeout` state. Median webhook-to-entitlement
+ * latency observed in prod is <5s (per 2026-04-18 incident analysis);
+ * 30s covers the long tail without letting a genuinely stuck
+ * activation hide behind a "still loading" banner.
+ */
+export const EXTENDED_UNLOCK_TIMEOUT_MS = 30_000;
+
+/**
+ * Auto-dismiss window for the classic (non-waitForEntitlement) banner.
+ * Informational-only usage where the panel unlock is already guaranteed.
+ */
+export const CLASSIC_AUTO_DISMISS_MS = 5_000;
+
+/**
+ * Decide the initial banner state at mount time.
+ *
+ * If the user already has pro entitlement when the banner fires
+ * (e.g., the post-reload `consumePostCheckoutFlag` path where the
+ * entitlement watcher already flipped true), skip "pending" and go
+ * straight to "active" so the banner doesn't falsely suggest the
+ * webhook is still in flight.
+ */
+export function computeInitialBannerState(entitledNow: boolean): CheckoutSuccessBannerState {
+  return entitledNow ? 'active' : 'pending';
+}

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -28,6 +28,19 @@ import {
 } from './checkout-errors';
 import { showCheckoutErrorToast } from './checkout-error-toast';
 import { decideNoUserPathOutcome } from './checkout-no-user-policy';
+import { isEntitled, onEntitlementChange } from './entitlements';
+import {
+  CLASSIC_AUTO_DISMISS_MS,
+  EXTENDED_UNLOCK_TIMEOUT_MS,
+  computeInitialBannerState,
+  type CheckoutSuccessBannerState,
+} from './checkout-banner-state';
+
+export {
+  EXTENDED_UNLOCK_TIMEOUT_MS,
+  computeInitialBannerState,
+  type CheckoutSuccessBannerState,
+} from './checkout-banner-state';
 
 export {
   saveCheckoutAttempt,
@@ -132,15 +145,20 @@ export function initCheckoutOverlay(onSuccess?: () => void): void {
             // cleared to avoid auto-opening the overlay on the reload.
             clearCheckoutAttempt('success');
             clearPendingCheckoutIntent();
-            // Belt-and-braces: reload after the webhook is likely to have
-            // landed (median <5s). Mark a session flag so the reloaded page
-            // can seed the entitlement transition detector as post-checkout
-            // — the overlay uses manualRedirect:true so the reload lands at
-            // the original URL without subscription_id params, and the
-            // detector would otherwise treat the first pro snapshot as the
-            // legacy-pro baseline and swallow it.
+            // Mark a session flag so the reloaded page seeds the entitlement
+            // transition detector as post-checkout — without this, the
+            // detector would treat the first pro snapshot as "legacy-pro
+            // baseline" and swallow the activation.
+            //
+            // Reload ownership: as of PR-4, the entitlement watcher in
+            // panel-layout.ts is the SINGLE reload source (fires on
+            // free→pro transition). We no longer schedule a 3s setTimeout
+            // reload here — that competed with the entitlement watcher's
+            // reload and made "still unlocking" UX impossible because the
+            // banner was guaranteed to be wiped at 3s regardless of
+            // webhook latency. The watcher's reload depends on the
+            // 2026-04-18-001 fix landing first (#3163, merged).
             markPostCheckout();
-            setTimeout(() => window.location.reload(), 3_000);
           }
           break;
         }
@@ -628,10 +646,29 @@ function renderCheckoutErrorSurface(
 }
 
 /**
- * Show a transient success banner at the top of the viewport.
- * Auto-dismisses after 5 seconds.
+ * Show the post-checkout success banner.
+ *
+ * Classic mode (no `waitForEntitlement`): renders "Payment received! ..."
+ * and auto-dismisses after 5s. Used when entitlement unlock is a
+ * synchronous consequence of the current page load (e.g., the overlay
+ * handler firing pre-reload) or when the caller does not own the
+ * entitlement lifecycle.
+ *
+ * Extended-unlock mode (`waitForEntitlement: true`): stays mounted and
+ * transitions through three states that are observable via the
+ * `data-entitlement-state` attribute:
+ *   - `pending` (initial): "Payment received! Unlocking..."
+ *   - `active`: "Premium activated — reloading..." (set either on
+ *               mount when already entitled, or when the entitlement
+ *               watcher fires free→pro). Lets the watcher trigger the
+ *               actual reload so the banner persists across it.
+ *   - `timeout`: after 30s with no transition, swap to an explicit
+ *               "Refresh if features haven't unlocked" CTA + Sentry
+ *               warning. Never silently disappears.
  */
-export function showCheckoutSuccess(): void {
+export function showCheckoutSuccess(
+  options?: { waitForEntitlement?: boolean },
+): void {
   const existing = document.getElementById('checkout-success-banner');
   if (existing) existing.remove();
 
@@ -653,9 +690,13 @@ export function showCheckoutSuccess(): void {
     transition: 'opacity 0.4s ease, transform 0.4s ease',
     transform: 'translateY(-100%)',
     opacity: '0',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '12px',
   });
-  banner.textContent = 'Payment received! Unlocking your premium features...';
 
+  setBannerText(banner, 'pending');
   document.body.appendChild(banner);
 
   requestAnimationFrame(() => {
@@ -663,9 +704,75 @@ export function showCheckoutSuccess(): void {
     banner.style.opacity = '1';
   });
 
-  setTimeout(() => {
-    banner.style.transform = 'translateY(-100%)';
-    banner.style.opacity = '0';
-    setTimeout(() => banner.remove(), 400);
-  }, 5000);
+  if (!options?.waitForEntitlement) {
+    setTimeout(() => dismissBanner(banner), CLASSIC_AUTO_DISMISS_MS);
+    return;
+  }
+
+  const initial = computeInitialBannerState(isEntitled());
+  if (initial === 'active') {
+    setBannerText(banner, 'active');
+    // No auto-dismiss: the entitlement watcher's reload navigates away.
+    return;
+  }
+
+  let resolved = false;
+  const timeoutHandle = setTimeout(() => {
+    if (resolved) return;
+    resolved = true;
+    unsubscribe();
+    setBannerText(banner, 'timeout');
+    Sentry.captureMessage('Checkout entitlement-activation timeout', {
+      level: 'warning',
+      tags: { component: 'dodo-checkout', action: 'entitlement-timeout' },
+    });
+  }, EXTENDED_UNLOCK_TIMEOUT_MS);
+
+  const unsubscribe = onEntitlementChange(() => {
+    if (resolved) return;
+    if (!isEntitled()) return;
+    resolved = true;
+    clearTimeout(timeoutHandle);
+    setBannerText(banner, 'active');
+    unsubscribe();
+  });
+}
+
+function setBannerText(banner: HTMLElement, state: CheckoutSuccessBannerState): void {
+  banner.setAttribute('data-entitlement-state', state);
+  if (state === 'pending') {
+    banner.textContent = 'Payment received! Unlocking your premium features…';
+    return;
+  }
+  if (state === 'active') {
+    banner.textContent = 'Premium activated — reloading…';
+    return;
+  }
+  // timeout
+  banner.innerHTML = '';
+  const text = document.createElement('span');
+  text.textContent = "Payment received. If features haven't unlocked, refresh the page.";
+  const refreshBtn = document.createElement('button');
+  refreshBtn.type = 'button';
+  refreshBtn.textContent = 'Refresh';
+  Object.assign(refreshBtn.style, {
+    background: '#fff',
+    color: '#16a34a',
+    border: 'none',
+    borderRadius: '4px',
+    padding: '4px 12px',
+    fontWeight: '600',
+    fontSize: '12px',
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+  });
+  refreshBtn.addEventListener('click', () => window.location.reload());
+  banner.appendChild(text);
+  banner.appendChild(refreshBtn);
+}
+
+function dismissBanner(banner: HTMLElement): void {
+  banner.style.transform = 'translateY(-100%)';
+  banner.style.opacity = '0';
+  setTimeout(() => banner.remove(), 400);
 }

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -711,8 +711,19 @@ export function showCheckoutSuccess(
 
   const initial = computeInitialBannerState(isEntitled());
   if (initial === 'active') {
+    // Already entitled at mount (e.g., returned to the page after the
+    // watcher-reload already flipped lock state, or Convex cache hit
+    // before any transition could fire). The 'active' branch previously
+    // sat forever with "Premium activated — reloading…" because:
+    //   - onEntitlementChange listener below only fires on transitions,
+    //     and we're already in steady pro state — no transition to
+    //     observe.
+    //   - No auto-dismiss / timeout existed for the fast-path.
+    // Treat this like a classic confirmation: show active text and
+    // auto-dismiss on the CLASSIC_AUTO_DISMISS_MS window so the user
+    // gets closure instead of a banner that hangs until a hard refresh.
     setBannerText(banner, 'active');
-    // No auto-dismiss: the entitlement watcher's reload navigates away.
+    setTimeout(() => dismissBanner(banner), CLASSIC_AUTO_DISMISS_MS);
     return;
   }
 

--- a/tests/checkout-banner-initial-state.test.mts
+++ b/tests/checkout-banner-initial-state.test.mts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for the banner state helpers. DOM-level transitions
+ * (pending → active → timeout) are async + event-driven and are
+ * covered by manual verification per the plan; this locks the pure
+ * decision we CAN exercise in plain TS so future refactors don't
+ * silently flip the mount-time behavior.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  computeInitialBannerState,
+  EXTENDED_UNLOCK_TIMEOUT_MS,
+  CLASSIC_AUTO_DISMISS_MS,
+} from '../src/services/checkout-banner-state.ts';
+
+describe('computeInitialBannerState', () => {
+  it('returns "pending" when the user is not yet entitled', () => {
+    assert.equal(computeInitialBannerState(false), 'pending');
+  });
+
+  it('returns "active" when the user is already entitled at mount time', () => {
+    assert.equal(computeInitialBannerState(true), 'active');
+  });
+});
+
+describe('banner timing constants', () => {
+  it('EXTENDED_UNLOCK_TIMEOUT_MS is 30s — covers webhook/propagation long tail', () => {
+    assert.equal(EXTENDED_UNLOCK_TIMEOUT_MS, 30_000);
+  });
+
+  it('CLASSIC_AUTO_DISMISS_MS is 5s — fast fade when unlock is already guaranteed', () => {
+    assert.equal(CLASSIC_AUTO_DISMISS_MS, 5_000);
+  });
+
+  it('classic auto-dismiss is strictly shorter than extended timeout', () => {
+    // If this ever flips, the non-extended flow would outlive the
+    // entitlement-wait flow, which defeats the "fast fade" intent.
+    assert.ok(CLASSIC_AUTO_DISMISS_MS < EXTENDED_UNLOCK_TIMEOUT_MS);
+  });
+});


### PR DESCRIPTION
## Summary

PR-4 of the 14-PR rollout at [`docs/plans/2026-04-21-002-feat-harden-auth-checkout-flow-ux-plan.md`](docs/plans/2026-04-21-002-feat-harden-auth-checkout-flow-ux-plan.md).

**⚠️ Stacked on #3259 (PR-2)** — do not merge until PR-2 lands. Base branch is `feat/checkout-attempt-lifecycle`, not `main`.

### The fight between two reloads

Before this PR, two independent sources raced to reload the page after a successful Dodo checkout:

1. `setTimeout(reload, 3000)` in the overlay `checkout.status=succeeded` handler (checkout.ts).
2. `window.location.reload()` in the entitlement watcher on a free→pro transition (panel-layout.ts).

The 3s timer fired unconditionally, guaranteeing the success banner was wiped at 3s regardless of webhook latency. This made a "still unlocking…" UX impossible — if the webhook was slower than 3s, the user saw locked panels until the watcher's second reload eventually landed.

### Fix — single reload source (Primitive C) + three-state banner

The entitlement watcher is now the **single** reload owner. The banner stays mounted across it via a state machine driven by `onEntitlementChange`:

| State | Copy | Trigger |
|---|---|---|
| `pending` | "Payment received! Unlocking your premium features…" | Mount, no entitlement yet |
| `active` | "Premium activated — reloading…" | Already entitled at mount OR watcher fires free→pro |
| `timeout` | "Payment received. If features haven't unlocked, refresh the page." + Refresh button | 30s elapsed with no transition + Sentry warning |

`data-entitlement-state` is exposed on the banner for e2e selectors. The banner never silently disappears — it either transitions to active (entitlement watcher then reloads) or to an actionable timeout.

### Release gate

**Hard-dep on #3163** (fix(pro): reliable post-payment activation) — merged 2026-04-18. That PR fixed the `skipInitialSnapshot` guard that used to swallow the post-payment activation snapshot. Without it, removing the 3s reload would leave users stranded in pending.

## Changes

- **`src/services/checkout.ts`**:
  - Remove 3s `setTimeout(reload)` from the overlay `succeeded` handler. Keep `markPostCheckout()` + `onSuccessCallback()` so the post-reload consume path still seeds the transition detector.
  - Rewrite `showCheckoutSuccess()` to accept `{ waitForEntitlement }`. Classic path keeps 5s auto-dismiss. Extended path subscribes to `onEntitlementChange`, walks three states, exposes `data-entitlement-state`.
  - If already entitled at mount (fast webhook post-reload), skip straight to `active` — banner doesn't lie about a webhook still in flight.
- **`src/services/checkout-banner-state.ts`** (new): pure helpers (`computeInitialBannerState`, `EXTENDED_UNLOCK_TIMEOUT_MS`, `CLASSIC_AUTO_DISMISS_MS`) extracted so they're testable without pulling in the Dodo SDK through checkout.ts (same pattern as PR-2's `checkout-attempt.ts`).
- **`src/app/panel-layout.ts`**: both success-banner call sites pass `{ waitForEntitlement: true }` — the checkout-return-discriminant path and the `initCheckoutOverlay` onSuccess callback.

## Testing

- **`tests/checkout-banner-initial-state.test.mts`** — 5 cases: both initial-state branches + timing-constant invariants (30s > 5s ordering, exact values).
- Full `npm run test:data` — **6078/6078 passing**.
- `npm run typecheck` — clean.
- `npm run lint:boundaries` — clean.
- Scoped lint — clean (1 pre-existing complexity warning unrelated).

### Acceptance criteria (from plan)
- [x] Grep `window.location.reload` in `src/services/checkout.ts` = 1 hit (the user-initiated manual Refresh button in the timeout-state banner). Automatic reload removed.
- [x] Banner remains until entitlement transition OR 30s timeout.
- [x] Timeout branch shows retry CTA, never silently disappears.
- [x] No double-reload: entitlement watcher is the single source.
- [x] `markPostCheckout` flag still consumed post-reload; success banner still appears on next load.

### Manual verification (before merge)
- [ ] Happy path: successful Dodo test card → banner appears as "pending" → entitlement webhook lands → banner transitions to "active" → watcher reloads → banner reappears post-reload (already "active") → fades.
- [ ] Slow-webhook path: throttle network during Dodo callback → banner stays in "pending" for up to 30s → swaps to "timeout" state with Refresh button.
- [ ] Post-reload path: `markPostCheckout` consume on next load still shows banner (now in "active" state immediately since entitlement is already pro).
- [ ] No race: trigger success three times in rapid succession — no stacked banners, no double-reload.

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Sentry — new message `"Checkout entitlement-activation timeout"` (`tags.action=entitlement-timeout`). Expected volume: very low (<1% of successful purchases per 2026-04-18 analysis).
  - Sentry — overall volume on `component: dodo-checkout` (should be stable or drop; the 3s reload was sometimes swallowing fast webhooks).
- **Validation checks**
  - Sentry query — `tags.component:dodo-checkout AND tags.action:entitlement-timeout`. Expected non-zero but small; any sudden spike indicates webhook pipeline regression.
  - Sentry — no regression in `tags.component:dodo-billing` volume.
- **Expected healthy behavior**
  - Successful purchases land on the reloaded page with the banner briefly visible in `active` state, then fade.
  - Slow webhooks keep the banner mounted in `pending` for up to 30s, then transition to `timeout` (not into an unlabeled void).
- **Failure signal / rollback trigger**
  - Spike in `entitlement-timeout` events — indicates entitlement watcher isn't firing. Revert to restore the 3s belt-and-braces reload.
  - Users report stuck "Unlocking…" banners on otherwise-successful checkouts — revert.
  - Regression in `test:data` or E2E suites — block.
- **Validation window & owner**
  - Window: 72h post-deploy (longer than usual to capture the tail of webhook-lag scenarios).
  - Owner: original author.

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.7 (1M context, extended thinking) <noreply@anthropic.com>