### PR TITLE
fix(clerk): pin afterSignOutUrl to origin root, not window.location.href

### DIFF
--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -230,8 +230,15 @@ export function subscribeClerk(callback: () => void): () => void {
  */
 export function mountUserButton(el: HTMLDivElement): () => void {
   if (!clerkInstance) return () => {};
+  // Pin the after-sign-out destination to the origin root rather than
+  // `window.location.href`. The current page URL may carry stale
+  // checkout params (e.g., a subscription_id/status query that
+  // handleCheckoutReturn hasn't cleaned yet at sign-out time) or
+  // transient session fragments that shouldn't persist into a
+  // signed-out state. Origin-root is unambiguous and identical on
+  // Tauri desktop (same absolute URL resolves correctly in WKWebView).
   clerkInstance.mountUserButton(el, {
-    afterSignOutUrl: window.location.href,
+    afterSignOutUrl: new URL('/', window.location.origin).toString(),
     appearance: getAppearance(),
   });
   return () => clerkInstance?.unmountUserButton(el);


### PR DESCRIPTION
## Summary

PR-12 of the 14-PR rollout at [`docs/plans/2026-04-21-002-feat-harden-auth-checkout-flow-ux-plan.md`](docs/plans/2026-04-21-002-feat-harden-auth-checkout-flow-ux-plan.md).

### Problem

`mountUserButton` in `src/services/clerk.ts:234` was passing `window.location.href` as Clerk's `afterSignOutUrl`. The current page URL can carry stale checkout params (`subscription_id`, `status`, `payment_id`) that `handleCheckoutReturn` hasn't cleaned yet at sign-out time, or session fragments that shouldn't persist into a signed-out state. A user who signed out from a post-purchase URL would land on a signed-out page with their purchase identifiers still in the query string — low-risk, but unnecessary leakage and weird UX.

### Solution

One-line change: `new URL('/', window.location.origin).toString()`. Origin-root, unambiguous, parameter-free. Identical behavior on Tauri desktop — WKWebView resolves the absolute URL correctly.

## Changes

- **`src/services/clerk.ts`** — `afterSignOutUrl` now pinned to origin root.

## Testing

- `npm run typecheck` — clean
- `npm run test:data` — **6049/6049 passing** (no test additions; trivial one-line change)
- Scoped lint — clean

### Manual verification (before merge)

- [ ] Sign out from `/?subscription_id=sub_X&status=active` → lands on `/`, not `/?subscription_id=sub_X`.
- [ ] Sign out from `/some/deep/path` → lands on origin root.
- [ ] Tauri desktop shell: sign out still works, lands on the app root (no external browser spawn).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: one-line UX hardening on a Clerk config option. No new API surface, no new Sentry paths, no data sent anywhere new. Sign-out flow continues to route through Clerk's normal machinery.

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.7 (1M context, extended thinking) <noreply@anthropic.com>