### PR TITLE
fix(digest): DIGEST_ONLY_USER self-expiring (mandatory until= suffix, 48h cap)

### DIFF
--- a/scripts/lib/digest-only-user.mjs
+++ b/scripts/lib/digest-only-user.mjs
@@ -27,9 +27,16 @@ export function parseDigestOnlyUser(raw, nowMs) {
 
   const parts = raw.split('|');
   if (parts.length !== 2) {
+    // Distinguish "no separator" from "too many" so the operator's
+    // next action is clear. Without this, a double-`|until=` typo got
+    // told "missing suffix" even though a suffix was present — the
+    // operator's instinct would be to add a second suffix, looping.
     return {
       kind: 'reject',
-      reason: 'missing mandatory "|until=<ISO8601>" suffix',
+      reason:
+        parts.length === 1
+          ? 'missing mandatory "|until=<ISO8601>" suffix'
+          : `expected exactly one "|" separator, got ${parts.length - 1}`,
     };
   }
   const userId = parts[0].trim();
@@ -42,6 +49,17 @@ export function parseDigestOnlyUser(raw, nowMs) {
     };
   }
   const untilRaw = suffix.slice('until='.length).trim();
+  // `Date.parse` is intentionally lenient in V8 (accepts RFC 2822,
+  // locale-formatted dates, etc.). The documented contract is strict
+  // ISO 8601 — gate with a rough regex so non-ISO values are rejected
+  // by shape, not just by the 48h cap catching a random valid date.
+  // Accept YYYY-MM-DD with optional time / fractional / timezone.
+  if (!/^\d{4}-\d{2}-\d{2}(?:[T\s]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+\-]\d{2}:?\d{2})?)?$/.test(untilRaw)) {
+    return {
+      kind: 'reject',
+      reason: `expiry "${untilRaw}" is not a parseable ISO8601 timestamp`,
+    };
+  }
   const untilMs = Date.parse(untilRaw);
   if (!Number.isFinite(untilMs)) {
     return {

--- a/scripts/lib/digest-only-user.mjs
+++ b/scripts/lib/digest-only-user.mjs
@@ -1,0 +1,65 @@
+// Pure parser for the DIGEST_ONLY_USER env flag. Lives here (not inline
+// in seed-digest-notifications.mjs) because the seed script has no
+// isMain guard — importing it executes main() + env-assert exits. This
+// module is pure and test-friendly.
+
+// Hard cap: an operator cannot set an expiry more than 48h in the future.
+// Prevents "forever test" misconfig even if the format is otherwise valid.
+// 48h covers every realistic same-day + next-day validation window.
+export const DIGEST_ONLY_USER_MAX_HORIZON_MS = 48 * 60 * 60 * 1000;
+
+/**
+ * Parse the DIGEST_ONLY_USER env value.
+ *
+ * The value MUST be in the form `<userId>|until=<ISO8601>` where the
+ * expiry is in the future and within the 48h horizon. Legacy bare-
+ * userId format is REJECTED to prevent sticky test flags from producing
+ * silent partial outages indefinitely if the operator forgets to unset.
+ *
+ * @param {string} raw - The trimmed env var value. Pass '' for unset.
+ * @param {number} nowMs - Current ms (injected for deterministic tests).
+ * @returns {{ kind: 'active', userId: string, untilMs: number }
+ *   | { kind: 'reject', reason: string }
+ *   | { kind: 'unset' }}
+ */
+export function parseDigestOnlyUser(raw, nowMs) {
+  if (typeof raw !== 'string' || raw.length === 0) return { kind: 'unset' };
+
+  const parts = raw.split('|');
+  if (parts.length !== 2) {
+    return {
+      kind: 'reject',
+      reason: 'missing mandatory "|until=<ISO8601>" suffix',
+    };
+  }
+  const userId = parts[0].trim();
+  const suffix = parts[1].trim();
+  if (!userId) return { kind: 'reject', reason: 'empty userId before "|"' };
+  if (!suffix.startsWith('until=')) {
+    return {
+      kind: 'reject',
+      reason: `suffix must be "until=<ISO8601>" (got "${suffix}")`,
+    };
+  }
+  const untilRaw = suffix.slice('until='.length).trim();
+  const untilMs = Date.parse(untilRaw);
+  if (!Number.isFinite(untilMs)) {
+    return {
+      kind: 'reject',
+      reason: `expiry "${untilRaw}" is not a parseable ISO8601 timestamp`,
+    };
+  }
+  if (untilMs <= nowMs) {
+    return {
+      kind: 'reject',
+      reason: `expiry ${new Date(untilMs).toISOString()} is in the past (now=${new Date(nowMs).toISOString()}) — auto-disabled`,
+    };
+  }
+  if (untilMs > nowMs + DIGEST_ONLY_USER_MAX_HORIZON_MS) {
+    return {
+      kind: 'reject',
+      reason: `expiry ${new Date(untilMs).toISOString()} exceeds the 48h hard cap — set a closer expiry`,
+    };
+  }
+  return { kind: 'active', userId, untilMs };
+}

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -38,6 +38,7 @@ import {
 } from './lib/brief-compose.mjs';
 import { issueSlotInTz } from '../shared/brief-filter.js';
 import { enrichBriefEnvelopeWithLLM } from './lib/brief-llm.mjs';
+import { parseDigestOnlyUser } from './lib/digest-only-user.mjs';
 import { assertBriefEnvelope } from '../server/_shared/brief-render.js';
 import { signBriefUrl, BriefUrlError } from './lib/brief-url-sign.mjs';
 import {
@@ -1306,24 +1307,52 @@ async function main() {
     return;
   }
 
-  // Operator single-user test filter. Set DIGEST_ONLY_USER=user_xxx on
-  // the Railway service to run the compose + send paths for exactly
-  // one user on the next cron tick, then unset. Intended for
-  // validating new features (brief enrichment, rendering, email
-  // template changes) end-to-end without fanning out to every PRO user.
-  // Empty string / unset = normal fan-out (production default).
-  const onlyUser = (process.env.DIGEST_ONLY_USER ?? '').trim();
-  if (onlyUser) {
+  // Operator single-user test filter. Self-expiring by design: the env
+  // var MUST carry an `|until=<ISO8601>` suffix within 48h, or it's
+  // IGNORED. Rationale: the naive `DIGEST_ONLY_USER=user_xxx` format
+  // from PR #3255 was a sticky footgun — if an operator set it for a
+  // one-off validation and forgot to unset it, the cron would silently
+  // filter out every other user indefinitely while still completing
+  // normally and exiting 0, creating a prolonged partial outage with
+  // "green" runs. Mandatory expiry + hard 48h cap + loud warn at run
+  // start makes the test surface self-cleanup even if the operator
+  // walks away.
+  //
+  // Format: DIGEST_ONLY_USER=user_xxxxxxxxxxxxxxxxxxxxxx|until=2026-04-22T18:00Z
+  // Legacy bare-userId format is rejected (fall-through to normal
+  // fan-out) with a loud warn explaining the new syntax.
+  const onlyUserFilter = parseDigestOnlyUser(
+    (process.env.DIGEST_ONLY_USER ?? '').trim(),
+    nowMs,
+  );
+  if (onlyUserFilter.kind === 'active') {
+    const remainingMin = Math.round((onlyUserFilter.untilMs - nowMs) / 60_000);
+    console.warn(
+      `⚠️  [digest] DIGEST_ONLY_USER ACTIVE — filtering to userId=${onlyUserFilter.userId}. ` +
+        `Expires in ${remainingMin} min (${new Date(onlyUserFilter.untilMs).toISOString()}). ` +
+        `All other users are EXCLUDED from this run. Unset DIGEST_ONLY_USER after testing.`,
+    );
     const before = rules.length;
-    rules = rules.filter((r) => r && r.userId === onlyUser);
+    rules = rules.filter((r) => r && r.userId === onlyUserFilter.userId);
     console.log(
-      `[digest] DIGEST_ONLY_USER=${onlyUser} — filtered ${before} rules → ${rules.length}`,
+      `[digest] DIGEST_ONLY_USER — filtered ${before} rules → ${rules.length}`,
     );
     if (rules.length === 0) {
-      console.log(`[digest] No rules matched userId=${onlyUser} — nothing to do`);
+      console.warn(
+        `[digest] No rules matched userId=${onlyUserFilter.userId} — nothing to do (exiting green).`,
+      );
       return;
     }
+  } else if (onlyUserFilter.kind === 'reject') {
+    // Malformed / expired / cap-exceeded — log LOUDLY and fan out normally
+    // so a forgotten flag cannot produce a silent partial outage.
+    console.warn(
+      `[digest] DIGEST_ONLY_USER present but IGNORED: ${onlyUserFilter.reason}. ` +
+        `Proceeding with normal fan-out. Format: ` +
+        `DIGEST_ONLY_USER=user_xxx|until=<ISO8601 within 48h>.`,
+    );
   }
+  // kind === 'unset' → normal fan-out, no log (production default)
 
   // Compose per-user brief envelopes once per run (extracted so main's
   // complexity score stays in the biome budget). Failures MUST NOT

--- a/tests/digest-only-user.test.mjs
+++ b/tests/digest-only-user.test.mjs
@@ -1,0 +1,147 @@
+/**
+ * Regression tests for `scripts/lib/digest-only-user.mjs`.
+ *
+ * The DIGEST_ONLY_USER flag was flagged in review as a sticky
+ * production footgun: if an operator set it for a one-off validation
+ * and forgot to unset, the cron would silently filter every other user
+ * out indefinitely while still completing normally (exit 0), creating
+ * a prolonged partial outage with "green" runs.
+ *
+ * The mitigation is a mandatory `|until=<ISO8601>` suffix within a 48h
+ * hard cap. These tests pin the parser's accept/reject boundary so a
+ * future "helpful" refactor that reverses any of these rules fails
+ * loudly in CI rather than silently in prod.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DIGEST_ONLY_USER_MAX_HORIZON_MS,
+  parseDigestOnlyUser,
+} from '../scripts/lib/digest-only-user.mjs';
+
+// Fixed "now" for deterministic tests. 2026-04-21 18:00Z is a realistic
+// Railway-set clock during a test session.
+const NOW = Date.parse('2026-04-21T18:00:00Z');
+
+describe('parseDigestOnlyUser — kind:unset', () => {
+  it('empty string → unset', () => {
+    assert.deepEqual(parseDigestOnlyUser('', NOW), { kind: 'unset' });
+  });
+  it('non-string → unset', () => {
+    assert.deepEqual(parseDigestOnlyUser(undefined, NOW), { kind: 'unset' });
+    assert.deepEqual(parseDigestOnlyUser(null, NOW), { kind: 'unset' });
+    assert.deepEqual(parseDigestOnlyUser(123, NOW), { kind: 'unset' });
+  });
+});
+
+describe('parseDigestOnlyUser — kind:reject (prevents sticky footgun)', () => {
+  it('rejects the legacy bare-userId format from PR #3255', () => {
+    const out = parseDigestOnlyUser('user_3BovQ1tYlaz2YIGYAdDPXGFBgKy', NOW);
+    assert.equal(out.kind, 'reject');
+    assert.match(out.reason, /missing mandatory "\|until=<ISO8601>" suffix/);
+  });
+
+  it('rejects pipe with no suffix', () => {
+    const out = parseDigestOnlyUser('user_xxx|', NOW);
+    assert.equal(out.kind, 'reject');
+    assert.match(out.reason, /suffix must be "until=<ISO8601>"/);
+  });
+
+  it('rejects suffix that is not "until="', () => {
+    const out = parseDigestOnlyUser('user_xxx|expires=2026-04-22T18:00Z', NOW);
+    assert.equal(out.kind, 'reject');
+    assert.match(out.reason, /suffix must be "until=<ISO8601>"/);
+  });
+
+  it('rejects garbage in the ISO8601 slot', () => {
+    const out = parseDigestOnlyUser('user_xxx|until=NOT-A-DATE', NOW);
+    assert.equal(out.kind, 'reject');
+    assert.match(out.reason, /not a parseable ISO8601/);
+  });
+
+  it('rejects empty userId before pipe', () => {
+    const out = parseDigestOnlyUser('|until=2026-04-22T18:00Z', NOW);
+    assert.equal(out.kind, 'reject');
+    assert.match(out.reason, /empty userId before "\|"/);
+  });
+
+  it('rejects expiry in the past (auto-disable)', () => {
+    const out = parseDigestOnlyUser('user_xxx|until=2026-04-20T18:00Z', NOW);
+    assert.equal(out.kind, 'reject');
+    assert.match(out.reason, /is in the past/);
+  });
+
+  it('rejects expiry exactly equal to now (strict future requirement)', () => {
+    const out = parseDigestOnlyUser(`user_xxx|until=${new Date(NOW).toISOString()}`, NOW);
+    assert.equal(out.kind, 'reject');
+    assert.match(out.reason, /is in the past/);
+  });
+
+  it('rejects expiry more than 48h in the future (hard cap)', () => {
+    const beyondHorizon = new Date(NOW + DIGEST_ONLY_USER_MAX_HORIZON_MS + 60_000).toISOString();
+    const out = parseDigestOnlyUser(`user_xxx|until=${beyondHorizon}`, NOW);
+    assert.equal(out.kind, 'reject');
+    assert.match(out.reason, /exceeds the 48h hard cap/);
+  });
+
+  it('rejects expiry a year out (the classic forever-test mistake)', () => {
+    const out = parseDigestOnlyUser('user_xxx|until=2027-04-21T18:00Z', NOW);
+    assert.equal(out.kind, 'reject');
+    assert.match(out.reason, /exceeds the 48h hard cap/);
+  });
+
+  it('rejects multiple pipes (ambiguous format)', () => {
+    const out = parseDigestOnlyUser('user_xxx|until=2026-04-22T18:00Z|extra', NOW);
+    assert.equal(out.kind, 'reject');
+  });
+});
+
+describe('parseDigestOnlyUser — kind:active (valid path)', () => {
+  it('accepts an expiry 30 min in the future', () => {
+    const until = new Date(NOW + 30 * 60_000).toISOString();
+    const out = parseDigestOnlyUser(`user_3Bo|until=${until}`, NOW);
+    assert.equal(out.kind, 'active');
+    if (out.kind === 'active') {
+      assert.equal(out.userId, 'user_3Bo');
+      assert.equal(out.untilMs, Date.parse(until));
+    }
+  });
+
+  it('accepts an expiry at the 48h boundary (inclusive)', () => {
+    const until = new Date(NOW + DIGEST_ONLY_USER_MAX_HORIZON_MS).toISOString();
+    const out = parseDigestOnlyUser(`user_xxx|until=${until}`, NOW);
+    assert.equal(out.kind, 'active');
+  });
+
+  it('accepts all three ISO8601 flavors the spec permits', () => {
+    const expires = NOW + 60 * 60_000; // +1h
+    // Node's Date.parse is lenient; cover the Railway-friendly variants
+    // operators are likely to type.
+    const variants = [
+      new Date(expires).toISOString(),                 // 2026-04-21T19:00:00.000Z
+      new Date(expires).toISOString().replace('.000', ''), // 2026-04-21T19:00:00Z
+      new Date(expires).toISOString().slice(0, 16) + 'Z',  // 2026-04-21T19:00Z
+    ];
+    for (const v of variants) {
+      const out = parseDigestOnlyUser(`user_xxx|until=${v}`, NOW);
+      assert.equal(out.kind, 'active', `should parse ISO variant: ${v}`);
+    }
+  });
+
+  it('tolerates surrounding whitespace inside the pipe-split parts', () => {
+    const until = new Date(NOW + 60 * 60_000).toISOString();
+    const out = parseDigestOnlyUser(`  user_xxx | until=${until}  `, NOW);
+    // Note: the outer trim is done by the caller; we test post-trim semantics.
+    // Parser still splits on '|' and trims each part, so inner whitespace tolerates.
+    assert.equal(out.kind, 'active');
+    if (out.kind === 'active') assert.equal(out.userId, 'user_xxx');
+  });
+});
+
+describe('DIGEST_ONLY_USER_MAX_HORIZON_MS', () => {
+  it('is exactly 48 hours', () => {
+    assert.equal(DIGEST_ONLY_USER_MAX_HORIZON_MS, 48 * 60 * 60 * 1000);
+  });
+});

--- a/tests/digest-only-user.test.mjs
+++ b/tests/digest-only-user.test.mjs
@@ -92,9 +92,32 @@ describe('parseDigestOnlyUser — kind:reject (prevents sticky footgun)', () => 
     assert.match(out.reason, /exceeds the 48h hard cap/);
   });
 
-  it('rejects multiple pipes (ambiguous format)', () => {
+  it('rejects multiple pipes with a SPECIFIC reason (not the misleading "missing suffix")', () => {
+    // Regression pin: earlier the reason incorrectly pointed the
+    // operator toward adding a suffix that was already present.
     const out = parseDigestOnlyUser('user_xxx|until=2026-04-22T18:00Z|extra', NOW);
     assert.equal(out.kind, 'reject');
+    assert.match(out.reason, /expected exactly one "\|" separator, got 2/);
+    assert.doesNotMatch(out.reason, /missing mandatory/);
+  });
+
+  it('rejects non-ISO8601 formats that V8 Date.parse would accept', () => {
+    // V8's Date.parse is lenient (RFC 2822, locale-formatted, etc.).
+    // The documented contract is strict ISO 8601 — enforce by shape,
+    // not just by the 48h cap catching a random valid date.
+    const cases = [
+      'April 22, 2026 18:00',
+      '22 Apr 2026 18:00:00 GMT',
+      '04/22/2026',
+      '2026/04/22 18:00',
+      'tomorrow',
+      '1717200000',           // numeric epoch, accepted by some parsers
+    ];
+    for (const c of cases) {
+      const out = parseDigestOnlyUser(`user_xxx|until=${c}`, NOW);
+      assert.equal(out.kind, 'reject', `should reject non-ISO "${c}"`);
+      assert.match(out.reason, /not a parseable ISO8601 timestamp/);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses a P2 review finding on #3255: \`DIGEST_ONLY_USER\` as shipped was a **sticky production footgun**. If an operator set it for a one-off validation and forgot to unset it, the cron silently filtered out every other user indefinitely while still completing normally and exiting 0 — a prolonged partial outage with "green" runs.

## Fix

Mandatory expiry. The env var MUST now be in the form:

\`\`\`
DIGEST_ONLY_USER=user_xxx|until=2026-04-22T18:00Z
\`\`\`

**Rules:**
- Expiry must be a parseable ISO8601 timestamp.
- Expiry must be in the future.
- Expiry must be within **48 hours of now** (hard cap prevents the "forever test" mistake).
- Anything that doesn't match → IGNORED with a loud \`console.warn\` explaining the new format. Cron proceeds with normal fan-out.
- When active: loud \`console.warn\` at run start listing \`userId\`, expiry, and remaining minutes.

This means a test flag cannot sit in Railway env forever — it expires on its own, and even a misconfigured value fails safe (fan out, don't silently exclude).

**Breaking change** to the flag format, but the flag shipped ~2h before this finding with no prod usage — cheaper to tighten now than after an incident.

## Changes

- **NEW** \`scripts/lib/digest-only-user.mjs\` — pure parser returning \`{kind: 'unset'} | {kind: 'active', ...} | {kind: 'reject', reason}\`. Extracted so it's testable without importing \`seed-digest-notifications.mjs\` (no isMain guard there).
- **MODIFY** \`scripts/seed-digest-notifications.mjs\` — use the parser; loud warn on all branches.
- **NEW** \`tests/digest-only-user.test.mjs\` — 17 cases pinning the accept/reject boundary.

## Testing

**6066 tests pass** (was 6049 + 17 new). typecheck + typecheck:api clean.

Coverage:
- unset (empty / non-string / undefined)
- reject: missing suffix, legacy bare userId (the PR #3255 footgun), empty userId, malformed \`until=\`, unparseable ISO, past expiry, expiry-equals-now, >48h (beyond horizon), 1-year-out (forever-test mistake), multiple pipes
- active: 30 min future, 48h boundary inclusive, three ISO8601 variants, whitespace-tolerant
- \`DIGEST_ONLY_USER_MAX_HORIZON_MS\` pin

## Post-Deploy Monitoring & Validation

- **When you next want to test single-user delivery**, set:
  \`\`\`bash
  railway variables --set DIGEST_ONLY_USER=user_3BovQ1tYlaz2YIGYAdDPXGFBgKy\\|until=\$(date -u -v+2H +%Y-%m-%dT%H:%MZ)
  \`\`\`
  (2h from now). Next cron tick runs for you only; 2h later auto-disables.
- **What to see in Railway logs:** the \`⚠️  [digest] DIGEST_ONLY_USER ACTIVE — filtering to userId=...\` warn line at each tick.
- **Failure mode test:** set any invalid value (e.g. \`DIGEST_ONLY_USER=foo\`) and the next tick logs \`[digest] DIGEST_ONLY_USER present but IGNORED: ...\` and fans out normally. No partial outage possible.

---

[![Compound Engineering v2.49.0](https://img.shields.io/badge/Compound_Engineering-v2.49.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)