### PR TITLE
docs(referral): explain affonso_referral is a vendor contract, DO NOT RENAME

### DIFF
--- a/convex/payments/checkout.ts
+++ b/convex/payments/checkout.ts
@@ -128,6 +128,14 @@ async function _createCheckoutSession(
   metadata.wm_user_id = user.userId;
   metadata.wm_user_id_sig = await signUserId(user.userId);
   if (args.referralCode) {
+    // `affonso_referral` is the Dodo ↔ Affonso vendor-contracted metadata
+    // key — Dodo forwards values on this exact key to Affonso's referral-
+    // tracking webhook. DO NOT RENAME (to `wm_referral`, `referral`,
+    // `ref`, or anything else) without coordinating with Dodo + Affonso;
+    // a rename silently breaks sharer attribution because Affonso stops
+    // receiving the signal and `userReferralCredits` rows are never
+    // created on this conversion path. Mirror read in
+    // `convex/payments/subscriptionHelpers.ts`.
     metadata.affonso_referral = args.referralCode;
   }
 

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -296,6 +296,11 @@ export async function handleSubscriptionActive(
     // insert a userReferralCredits row crediting the sharer. The
     // `else` branch guards against double-crediting on webhook
     // replays — existing subscription rows skip this path.
+    //
+    // `affonso_referral` is the Dodo ↔ Affonso vendor contract key —
+    // DO NOT RENAME here or on the write side in checkout.ts. A
+    // rename desyncs writer/reader and silently breaks every
+    // conversion-path credit.
     const referralCode = data.metadata?.affonso_referral;
     if (typeof referralCode === "string" && referralCode.length > 0) {
       const referrer = await ctx.db

--- a/docs/api-commerce.mdx
+++ b/docs/api-commerce.mdx
@@ -110,6 +110,8 @@ Errors:
 
 No `referrals` count or `rewardMonths` is returned today — Dodo's `affonso_referral` attribution doesn't yet flow into Convex, and exposing only the waitlist-side count would mislead.
 
+`affonso_referral` is the vendor-contracted metadata key Dodo forwards to Affonso's referral-tracking webhook. The key name is load-bearing — renaming it (to `wm_referral`, `ref`, etc.) silently breaks Dodo→Affonso attribution. See `convex/payments/checkout.ts` and `convex/payments/subscriptionHelpers.ts` for the writer/reader call sites.
+
 ## Waitlist
 
 ### `POST /api/register-interest`


### PR DESCRIPTION
## Summary

PR-15 of the 14-PR rollout at [`docs/plans/2026-04-21-002-feat-harden-auth-checkout-flow-ux-plan.md`](docs/plans/2026-04-21-002-feat-harden-auth-checkout-flow-ux-plan.md).

### The problem

`affonso_referral` reads like leftover prototype naming to anyone who doesn't know the Dodo ↔ Affonso integration. Three PR reviews in a row flagged it with some variant of _"this should be `wm_referral`"_. Each time the correct answer was "leave it alone — it's a load-bearing vendor contract key."

### The reality

Dodo Payments forwards values under that exact metadata key to Affonso's referral-tracking webhook. Renaming desyncs the write path from Affonso's attribution pipeline and **silently breaks sharer credit with no exception raised**. The downstream failure mode is "share links stop counting," which is almost impossible to correlate back to a rename weeks later.

### The fix

Comments. Lots of them. Specifically:

- **`convex/payments/checkout.ts:131`** — block comment at the write site explaining the vendor contract and the failure mode of a rename, with a pointer to the reader.
- **`convex/payments/subscriptionHelpers.ts:299`** — mirror comment at the read site pointing back to the writer.
- **`docs/api-commerce.mdx:111`** — one-sentence explanation for anyone reading the commerce docs who wonders about the unusual key.

No runtime behavior change; comments only.

## Testing

- `npm run typecheck` — clean
- `npm run lint:md` — clean
- `npm run test:data` — **6049/6049 passing** (no code change; sanity check)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: comments-only change with no runtime, build, or deployment impact.

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.7 (1M context, extended thinking) <noreply@anthropic.com>