### PR TITLE
fix(sentry): filter iOS WKWebView UnknownError + Convex re-auth race

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -401,6 +401,21 @@ Sentry.init({
     // origin. Empty stacks are NOT suppressed because we cannot confirm the error didn't
     // come from our own code (OOM, stack overflow, network failures all commonly arrive
     // without frames even when our code triggered them).
+    // iOS Safari WKWebView throws `UnknownError: Cannot inject key into script value`
+    // at the native bridge when a non-structurally-cloneable value is passed to a
+    // bridge API (history.pushState, IndexedDB, etc.). The throw is native; a first-
+    // party caller is always on the stack, so the generic `!hasFirstParty` gate below
+    // misses it. Scope to excType==='UnknownError' — that type name is WebKit-only and
+    // cannot originate from our TypeScript (WORLDMONITOR-NM).
+    if (excType === 'UnknownError' && /Cannot inject key into script value/.test(msg)) return null;
+    // Convex SDK re-auth race: during a WebSocket reconnect, `BaseConvexClient.
+    // tryToReauthenticate` can read `this.authState.config.fetchToken` while
+    // authState is transitioning out of `authenticated` state. Known Convex
+    // internal; we use the SDK as-is. Gate by the exact function name so we
+    // don't mask a genuine first-party `fetchToken` regression
+    // (WORLDMONITOR-NJ).
+    if (/Cannot read properties of undefined \(reading 'fetchToken'\)/.test(msg)
+        && frames.some(f => /tryToReauthenticate/.test(f.function ?? ''))) return null;
     if (hasAnyStack && !hasFirstParty && (
       /\.(?:toLowerCase|trim|indexOf|findIndex) is not a function/.test(msg)
       || /Maximum call stack size exceeded/.test(msg)

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -363,6 +363,52 @@ describe('existing beforeSend filters', () => {
     assert.ok(beforeSend(event) !== null, 'All-maplibre first-party tile fetch failure must still reach Sentry');
   });
 
+  it('suppresses iOS Safari WKWebView "Cannot inject key into script value" regardless of first-party frame', () => {
+    // The native throw always lands in a first-party caller; the existing
+    // !hasFirstParty gate missed it. `UnknownError` type name is WebKit-only
+    // so scoping on excType is safe (WORLDMONITOR-NM).
+    const event = makeEvent('Cannot inject key into script value', 'UnknownError', [
+      { filename: '/assets/panels-Dt68xLlT.js', lineno: 20, function: 'bootstrap' },
+    ]);
+    assert.equal(beforeSend(event), null, 'iOS Safari WKWebView native bridge error should be suppressed');
+  });
+
+  it('does NOT suppress "Cannot inject key into script value" from non-UnknownError exc types', () => {
+    // Guards against a future first-party TypeError happening to share the
+    // message text — the UnknownError type is the only WebKit-native proof.
+    const event = makeEvent('Cannot inject key into script value', 'TypeError', [
+      { filename: '/assets/panels-Dt68xLlT.js', lineno: 20, function: 'bootstrap' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'Non-UnknownError must still reach Sentry');
+  });
+
+  it('suppresses Convex re-auth race on fetchToken (stack has tryToReauthenticate)', () => {
+    // Convex SDK BaseConvexClient.tryToReauthenticate reads authState.config.fetchToken
+    // during WebSocket reconnect when authState.config is still undefined. Known SDK
+    // internal, not actionable in our code (WORLDMONITOR-NJ).
+    const event = makeEvent(
+      "Cannot read properties of undefined (reading 'fetchToken')",
+      'TypeError',
+      [
+        { filename: '/assets/index-DSkSc57y.js', lineno: 2, function: 'ze.tryToReauthenticate' },
+      ],
+    );
+    assert.equal(beforeSend(event), null, 'Convex re-auth race should be suppressed');
+  });
+
+  it('does NOT suppress "reading fetchToken" undefined when no tryToReauthenticate frame is present', () => {
+    // A real first-party regression that happens to read a `.fetchToken` property
+    // must still reach Sentry — only the Convex internal path is suppressed.
+    const event = makeEvent(
+      "Cannot read properties of undefined (reading 'fetchToken')",
+      'TypeError',
+      [
+        { filename: '/assets/panels-DogeMxo_.js', lineno: 25, function: 'MyAuthBridge.load' },
+      ],
+    );
+    assert.ok(beforeSend(event) !== null, 'First-party fetchToken regression must reach Sentry');
+  });
+
   it('does NOT suppress setPointerCapture NotFoundError when no frame context is present', () => {
     // Defensive: if Sentry strips context, we err on the side of surfacing.
     const event = makeEvent(


### PR DESCRIPTION
## Summary

Two `beforeSend` filters for Sentry issues that slip past the existing `!hasFirstParty` ambiguous-error block. Both errors throw at a native/SDK layer but a first-party frame is always on the stack, so the generic gate misses them. Each new filter uses a **positive provenance signal** narrow enough not to hide real first-party regressions.

**WORLDMONITOR-NM** — iOS Safari WKWebView
- `UnknownError: Cannot inject key into script value` — WebKit native bridge throw when a non-structurally-cloneable value is passed to IndexedDB / `history.pushState` / similar.
- Gate: `excType === 'UnknownError'`. The `UnknownError` type name is WebKit-only; our TypeScript never throws it.

**WORLDMONITOR-NJ** — Convex SDK auth race
- `TypeError: Cannot read properties of undefined (reading 'fetchToken')` thrown by `BaseConvexClient.tryToReauthenticate` during WebSocket reconnect, when `this.authState.config` is still undefined.
- Gate: stack frame function name matches `/tryToReauthenticate/`. A first-party `.fetchToken` regression (different call site / function name) still reaches Sentry.

## Test plan
- [x] `npm run typecheck` + `typecheck:api` green
- [x] `npm run test:data` passes (5772 tests)
- [x] `node --test tests/sentry-beforesend.test.mjs` passes (**105/105**, +4 new)
  - Positive: UnknownError + inject-key → suppressed
  - Negative: TypeError + same message → surfaces
  - Positive: fetchToken with `ze.tryToReauthenticate` frame → suppressed
  - Negative: fetchToken with first-party `MyAuthBridge.load` frame → surfaces
- [x] `npm run lint` / `lint:md` / `version:check` clean
- [x] Edge bundle check + edge-functions tests pass

Resolves WORLDMONITOR-NM, WORLDMONITOR-NJ.