### PR TITLE
fix(leads): replace string Convex mutation names with typed api.* handles

### DIFF
--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -15,6 +15,7 @@ import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { jsonResponse } from './_json-response.js';
 import { ConvexHttpClient } from 'convex/browser';
+import { api } from '../convex/_generated/api';
 import { validateBearerToken } from '../server/auth-session';
 
 export default async function handler(req: Request): Promise<Response> {
@@ -56,8 +57,7 @@ export default async function handler(req: Request): Promise<Response> {
     const variant = url.searchParams.get('variant') ?? 'full';
 
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const prefs = await client.query('userPreferences:getPreferences' as any, { variant });
+      const prefs = await client.query(api.userPreferences.getPreferences, { variant });
       return jsonResponse(prefs ?? null, 200, cors);
     } catch (err) {
       console.error('[user-prefs] GET error:', err);
@@ -82,8 +82,7 @@ export default async function handler(req: Request): Promise<Response> {
   }
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = await client.mutation('userPreferences:setPreferences' as any, {
+    const result = await client.mutation(api.userPreferences.setPreferences, {
       variant: body.variant,
       data: body.data,
       expectedSyncVersion: body.expectedSyncVersion,

--- a/server/worldmonitor/leads/v1/register-interest.ts
+++ b/server/worldmonitor/leads/v1/register-interest.ts
@@ -5,6 +5,7 @@
  */
 
 import { ConvexHttpClient } from 'convex/browser';
+import { api } from '../../../../convex/_generated/api';
 import type {
   ServerContext,
   RegisterInterestRequest,
@@ -247,7 +248,7 @@ export async function registerInterest(
   }
 
   const client = new ConvexHttpClient(convexUrl);
-  const result = (await client.mutation('registerInterest:register' as any, {
+  const result = (await client.mutation(api.registerInterest.register, {
     email,
     source: safeSource,
     appVersion: safeAppVersion,

--- a/server/worldmonitor/leads/v1/submit-contact.ts
+++ b/server/worldmonitor/leads/v1/submit-contact.ts
@@ -5,6 +5,7 @@
  */
 
 import { ConvexHttpClient } from 'convex/browser';
+import { api } from '../../../../convex/_generated/api';
 import type {
   ServerContext,
   SubmitContactRequest,
@@ -154,7 +155,7 @@ export async function submitContact(
   }
 
   const client = new ConvexHttpClient(convexUrl);
-  await client.mutation('contactMessages:submit' as any, {
+  await client.mutation(api.contactMessages.submit, {
     name: safeName,
     email: email.trim(),
     organization: safeOrg,


### PR DESCRIPTION
Fixes #3253

## Problem

Three files called Convex mutations/queries using string-based names cast as `any`:

- `server/worldmonitor/leads/v1/submit-contact.ts`: `'contactMessages:submit' as any`
- `server/worldmonitor/leads/v1/register-interest.ts`: `'registerInterest:register' as any`
- `api/user-prefs.ts`: `'userPreferences:getPreferences' as any` and `'userPreferences:setPreferences' as any`

String-based mutation names bypass TypeScript type checking and break silently when mutations are renamed.

## Solution

Import the generated `api` object from `convex/_generated/api` and replace each string name with its typed `api.*` handle:

- `'contactMessages:submit' as any` → `api.contactMessages.submit`
- `'registerInterest:register' as any` → `api.registerInterest.register`
- `'userPreferences:getPreferences' as any` → `api.userPreferences.getPreferences`
- `'userPreferences:setPreferences' as any` → `api.userPreferences.setPreferences`

Also removes the `// eslint-disable-next-line @typescript-eslint/no-explicit-any` comments in `user-prefs.ts` that were suppressing the linter warnings.

## Testing

- All four Convex function names verified to exist in their respective modules (`convex/contactMessages.ts`, `convex/registerInterest.ts`, `convex/userPreferences.ts`)
- Generated `convex/_generated/api.js` exports `api = anyApi` which correctly resolves typed handles at runtime
- No behavioral change — typed handles produce identical wire calls as string names