### PR TITLE
fix(gating): silence anonymous 401s on trade-policy + regional-intelligence

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -864,8 +864,27 @@ export class App {
     this.enforceFreeTierLimits();
 
     let _prevUserId: string | null = null;
+    // Track the last-seen PRO entitlement so we can re-fire PRO-gated loaders
+    // ONCE on a false→true transition (user signs in / purchase lands mid-session).
+    // Without this, loaders gated behind hasPremiumAccess() at init time (e.g.
+    // loadTradePolicy) would sit empty until the next scheduled refresh — for
+    // trade-policy that's a 10-minute wait post-sign-in. See PR #3295 review.
+    let _prevHadPremium = hasPremiumAccess();
     this.unsubFreeTier = subscribeAuthState((session) => {
       this.enforceFreeTierLimits();
+      const hadPremium = _prevHadPremium;
+      const nowPremium = hasPremiumAccess();
+      if (nowPremium && !hadPremium) {
+        // Entitlement just resolved → fire PRO-gated initial loads that were
+        // skipped at boot. Each loader early-returns if the panel isn't
+        // mounted and re-checks hasPremiumAccess() internally, so these
+        // calls are safe and idempotent. Without this, trade-policy would
+        // sit empty for up to REFRESH_INTERVALS.tradePolicy (~10 min) after
+        // sign-in because the scheduler's viewport gate is the only retry.
+        void this.dataLoader.loadTradePolicy();
+      }
+      _prevHadPremium = nowPremium;
+
       const userId = session.user?.id ?? null;
       if (userId !== null && userId !== _prevUserId) {
         void cloudPrefsSignIn(userId, SITE_VARIANT);

--- a/src/App.ts
+++ b/src/App.ts
@@ -379,9 +379,9 @@ export class App {
     if (shouldPrime('energy-complex')) {
       primeTask('oil', () => this.dataLoader.loadOilAnalytics());
     }
-    if (shouldPrime('trade-policy')) {
-      primeTask('tradePolicy', () => this.dataLoader.loadTradePolicy());
-    }
+    // trade-policy moved into the _wmAccess block below — see fix for
+    // anonymous 401 bug where loadTradePolicy fired 6 PRO-gated RPCs
+    // unconditionally on every page load.
     if (shouldPrime('supply-chain')) {
       primeTask('supplyChain', () => this.dataLoader.loadSupplyChain());
     }
@@ -391,6 +391,9 @@ export class App {
 
     const _wmAccess = hasPremiumAccess();
     if (_wmAccess) {
+      if (shouldPrime('trade-policy')) {
+        primeTask('tradePolicy', () => this.dataLoader.loadTradePolicy());
+      }
       if (shouldPrime('stock-analysis')) {
         primeTask('stockAnalysis', () => this.dataLoader.loadStockAnalysis());
       }
@@ -1356,9 +1359,12 @@ export class App {
       this.refreshScheduler.scheduleRefresh('temporalBaseline', () => this.dataLoader.refreshTemporalBaseline(), REFRESH_INTERVALS.temporalBaseline, () => this.shouldRefreshIntelligence());
     }
 
-    // WTO trade policy data — annual data, poll every 10 min to avoid hammering upstream
+    // WTO trade policy data — annual data, poll every 10 min to avoid hammering upstream.
+    // PRO-gated: the isNearViewport check is a visibility gate, not an entitlement gate,
+    // so without hasPremiumAccess() here we'd still hit the 6 WTO RPCs every poll for
+    // free users once the panel scrolled into view.
     if (SITE_VARIANT === 'full' || SITE_VARIANT === 'finance' || SITE_VARIANT === 'commodity' || SITE_VARIANT === 'energy') {
-      this.refreshScheduler.scheduleRefresh('tradePolicy', () => this.dataLoader.loadTradePolicy(), REFRESH_INTERVALS.tradePolicy, () => this.isPanelNearViewport('trade-policy'));
+      this.refreshScheduler.scheduleRefresh('tradePolicy', () => this.dataLoader.loadTradePolicy(), REFRESH_INTERVALS.tradePolicy, () => hasPremiumAccess() && this.isPanelNearViewport('trade-policy'));
       this.refreshScheduler.scheduleRefresh('supplyChain', () => this.dataLoader.loadSupplyChain(), REFRESH_INTERVALS.supplyChain, () => this.isPanelNearViewport('supply-chain'));
     }
 

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -620,7 +620,12 @@ export class CountryIntelManager implements AppModule {
     });
 
     const unCode = iso2ToComtradeReporterCode(code);
-    if (unCode) {
+    // Trade RPCs (listComtradeFlows + getTariffTrends) are PRO-gated and
+    // 401 for anonymous/free users. Mirror the hasPremiumAccess() guard
+    // already used above for the other premium country-brief cards so we
+    // don't spray the console with 401s on every country click.
+    const hasPremium = hasPremiumAccess(getAuthState());
+    if (unCode && hasPremium) {
       tradeClient.listComtradeFlows({ reporterCode: unCode, cmdCode: '', anomaliesOnly: false }).then(resp => {
         if (this.ctx.countryBriefPage?.getCode() !== code) return;
         const topFlows = (resp.flows || [])

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -33,7 +33,7 @@ import { IntelligenceServiceClient } from '@/generated/client/worldmonitor/intel
 import { TradeServiceClient } from '@/generated/client/worldmonitor/trade/v1/service_client';
 import { EconomicServiceClient } from '@/generated/client/worldmonitor/economic/v1/service_client';
 import { hasPremiumAccess } from '@/services/panel-gating';
-import { getAuthState } from '@/services/auth-state';
+import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { showMapContextMenu } from '@/components/MapContextMenu';
 import { BETA_MODE } from '@/config/beta';
 import { MILITARY_BASES } from '@/config';
@@ -72,6 +72,14 @@ export class CountryIntelManager implements AppModule {
   private briefRequestToken = 0;
   private frameworkUnsubscribe: (() => void) | null = null;
   private _fwDebounce: ReturnType<typeof setTimeout> | null = null;
+  // Re-fire PRO-gated country sections on false→true entitlement transition.
+  // Without this, a user who opens a country brief before Clerk resolves
+  // keeps seeing empty national-debt / sanctions / comtrade / tariff cards
+  // until they reselect the country or reload. Tracks the last-seen
+  // entitlement so unrelated auth events (session refresh, prefs sync)
+  // don't re-hammer fetchProSections.
+  private authUnsubscribe: (() => void) | null = null;
+  private lastHadPremium = false;
 
   constructor(ctx: AppContext) {
     this.ctx = ctx;
@@ -88,6 +96,20 @@ export class CountryIntelManager implements AppModule {
       if (this._fwDebounce) clearTimeout(this._fwDebounce);
       this._fwDebounce = setTimeout(() => void this.openCountryBriefByCode(code, name), 400);
     });
+
+    this.lastHadPremium = hasPremiumAccess(getAuthState());
+    this.authUnsubscribe = subscribeAuthState(() => {
+      const nowPremium = hasPremiumAccess(getAuthState());
+      if (nowPremium && !this.lastHadPremium) {
+        // Entitlement just resolved — refetch PRO sections for whatever
+        // country the user is currently viewing. No current country =
+        // nothing to retry; the next country open will pick up the new
+        // entitlement naturally.
+        const openCode = this.ctx.countryBriefPage?.getCode();
+        if (openCode) this.fetchProSections(openCode);
+      }
+      this.lastHadPremium = nowPremium;
+    });
   }
 
   destroy(): void {
@@ -97,6 +119,8 @@ export class CountryIntelManager implements AppModule {
     this.ctx.countryBriefPage = null;
     this.frameworkUnsubscribe?.();
     this.frameworkUnsubscribe = null;
+    this.authUnsubscribe?.();
+    this.authUnsubscribe = null;
   }
 
   private setupCountryIntel(): void {

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2793,6 +2793,10 @@ export class DataLoaderManager implements AppModule {
   }
 
   async loadTradePolicy(): Promise<void> {
+    // Trade-policy is PRO-gated. Short-circuit for anonymous/free users so
+    // we don't fire 6 RPCs that all 401 on every page load — fixes the
+    // console-noise + Sentry-noise bug from the 2026-04-22 trace.
+    if (!hasPremiumAccess()) return;
     const tradePanel = this.ctx.panels['trade-policy'] as TradePolicyPanel | undefined;
     if (!tradePanel) return;
 

--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -2,6 +2,7 @@ import { Panel } from './Panel';
 import { getRpcBaseUrl } from '@/services/rpc-client';
 import { premiumFetch } from '@/services/premium-fetch';
 import { IS_EMBEDDED_PREVIEW } from '@/utils/embedded-preview';
+import { hasPremiumAccess } from '@/services/panel-gating';
 import { IntelligenceServiceClient } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 import type { RegionalSnapshot, RegimeTransition, RegionalBrief } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 import { h, replaceChildren } from '@/utils/dom-utils';
@@ -97,6 +98,17 @@ export class RegionalIntelligenceBoard extends Panel {
     // already handles "no data" cases visually; short-circuiting here keeps
     // the /pro console and Sentry quiet from these expected failures.
     if (IS_EMBEDDED_PREVIEW) {
+      this.renderEmpty();
+      return;
+    }
+
+    // Skip premium RPCs for anonymous/free users. Without this the panel
+    // fires get-regional-snapshot on every page load for every visitor and
+    // gets a 401 in the browser console. The panel's `premium: 'locked'`
+    // config + apiKeyPanels entry already keeps it visually hidden until
+    // the user is PRO — this just stops the RPC from firing during the
+    // constructor's `void this.loadCurrent()` before Clerk auth resolves.
+    if (!hasPremiumAccess()) {
       this.renderEmpty();
       return;
     }

--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -54,11 +54,20 @@ export class RegionalIntelligenceBoard extends Panel {
   /**
    * Tracks the last-seen entitlement so the auth subscription re-fires the
    * RPC only on a false→true transition, not on every unrelated auth state
-   * update (session refresh, unrelated user prefs). The subscription teardown
-   * handle is intentionally discarded — this panel lives for the app's
-   * lifetime and Panel has no destroy hook.
+   * update (session refresh, unrelated user prefs).
    */
   private lastHadPremium = false;
+  /**
+   * Handle for the `subscribeAuthState` listener, so `destroy()` can
+   * unsubscribe. Without this, recreating the panel (e.g. on framework
+   * swap or layout teardown → re-init) would leak listeners that still
+   * hold a reference to the destroyed instance's `this` — every old
+   * subscriber would call `loadCurrent()` / `renderEmpty()` on a stale
+   * DOM tree on every future auth event. Panel.destroy IS called from
+   * panel-layout teardown (panel-layout.ts:293, App.ts:1156); the
+   * previous "Panel has no destroy hook" comment was wrong.
+   */
+  private authUnsubscribe: (() => void) | null = null;
 
   constructor() {
     super({
@@ -99,7 +108,7 @@ export class RegionalIntelligenceBoard extends Panel {
     // session hasn't resolved at panel-construction time would see
     // renderEmpty() and then stay empty forever even after sign-in, because
     // nothing else triggers loadCurrent for the current region.
-    subscribeAuthState(() => {
+    this.authUnsubscribe = subscribeAuthState(() => {
       const hasPremium = hasPremiumAccess();
       if (hasPremium && !this.lastHadPremium) {
         this.lastHadPremium = true;
@@ -120,6 +129,18 @@ export class RegionalIntelligenceBoard extends Panel {
     this.currentRegion = regionId;
     this.selector.value = regionId;
     await this.loadCurrent();
+  }
+
+  override destroy(): void {
+    this.authUnsubscribe?.();
+    this.authUnsubscribe = null;
+    // Invalidate any in-flight loadCurrent: the existing sequence guard
+    // (see `isLatestSequence` checks) drops responses whose sequence no
+    // longer matches `latestSequence`. Bumping it here ensures a pending
+    // getRegionalSnapshot that resolves after destroy doesn't try to
+    // render into a detached DOM tree.
+    this.latestSequence += 1;
+    super.destroy();
   }
 
   private async loadCurrent(): Promise<void> {

--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -3,6 +3,7 @@ import { getRpcBaseUrl } from '@/services/rpc-client';
 import { premiumFetch } from '@/services/premium-fetch';
 import { IS_EMBEDDED_PREVIEW } from '@/utils/embedded-preview';
 import { hasPremiumAccess } from '@/services/panel-gating';
+import { subscribeAuthState } from '@/services/auth-state';
 import { IntelligenceServiceClient } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 import type { RegionalSnapshot, RegimeTransition, RegionalBrief } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 import { h, replaceChildren } from '@/utils/dom-utils';
@@ -50,6 +51,15 @@ export class RegionalIntelligenceBoard extends Panel {
    */
   private latestSequence = 0;
 
+  /**
+   * Tracks the last-seen entitlement so the auth subscription re-fires the
+   * RPC only on a false→true transition, not on every unrelated auth state
+   * update (session refresh, unrelated user prefs). The subscription teardown
+   * handle is intentionally discarded — this panel lives for the app's
+   * lifetime and Panel has no destroy hook.
+   */
+  private lastHadPremium = false;
+
   constructor() {
     super({
       id: 'regional-intelligence',
@@ -81,7 +91,28 @@ export class RegionalIntelligenceBoard extends Panel {
     replaceChildren(this.content, h('div', { className: 'rib-shell' }, controls, this.body));
 
     this.renderLoading();
+    this.lastHadPremium = hasPremiumAccess();
     void this.loadCurrent();
+
+    // Re-fire loadCurrent on false→true entitlement transitions (user signs
+    // in / purchases PRO mid-session). Without this, a user whose Clerk
+    // session hasn't resolved at panel-construction time would see
+    // renderEmpty() and then stay empty forever even after sign-in, because
+    // nothing else triggers loadCurrent for the current region.
+    subscribeAuthState(() => {
+      const hasPremium = hasPremiumAccess();
+      if (hasPremium && !this.lastHadPremium) {
+        this.lastHadPremium = true;
+        void this.loadCurrent();
+      } else if (!hasPremium && this.lastHadPremium) {
+        // Entitlement was revoked (sign-out, subscription ended) — blank
+        // the panel so stale data doesn't linger for a user who can no
+        // longer see it. Panel locking separately re-applies via
+        // panel-layout's auth subscription.
+        this.lastHadPremium = false;
+        this.renderEmpty();
+      }
+    });
   }
 
   /** Public API for tests and agent tools: force-load a region directly. */

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -51,7 +51,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'daily-market-brief': { name: 'Daily Market Brief', enabled: true, priority: 1, premium: 'locked' as const },
   'chat-analyst': { name: 'WM Analyst', enabled: true, priority: 1, premium: 'locked' as const },
   economic: { name: 'Macro Stress', enabled: true, priority: 1 },
-  'trade-policy': { name: 'Trade Policy', enabled: true, priority: 1 },
+  'trade-policy': { name: 'Trade Policy', enabled: true, priority: 1, premium: 'locked' as const },
   'supply-chain': { name: 'Supply Chain', enabled: true, priority: 1, ...(_desktop && { premium: 'enhanced' as const }) },
   finance: { name: 'Financial', enabled: true, priority: 1 },
   tech: { name: 'Technology', enabled: true, priority: 2 },
@@ -436,7 +436,7 @@ const FINANCE_PANELS: Record<string, PanelConfig> = {
   'other-tokens': { name: 'Alt Tokens', enabled: true, priority: 2 },
   centralbanks: { name: 'Central Bank Watch', enabled: true, priority: 1 },
   economic: { name: 'Macro Stress', enabled: true, priority: 1 },
-  'trade-policy': { name: 'Trade Policy', enabled: true, priority: 1 },
+  'trade-policy': { name: 'Trade Policy', enabled: true, priority: 1, premium: 'locked' as const },
   'sanctions-pressure': { name: 'Sanctions Pressure', enabled: true, priority: 1 },
   'supply-chain': { name: 'Supply Chain', enabled: true, priority: 1 },
   'economic-news': { name: 'Economic News', enabled: true, priority: 2 },
@@ -763,7 +763,7 @@ const COMMODITY_PANELS: Record<string, PanelConfig> = {
   'gold-intelligence': { name: 'Gold Intelligence', enabled: true, priority: 60 },
   heatmap: { name: 'Sector Heatmap', enabled: true, priority: 1 },
   'macro-signals': { name: 'Market Regime', enabled: true, priority: 1 },
-  'trade-policy': { name: 'Trade Policy', enabled: true, priority: 1 },
+  'trade-policy': { name: 'Trade Policy', enabled: true, priority: 1, premium: 'locked' as const },
   'sanctions-pressure': { name: 'Sanctions Pressure', enabled: true, priority: 1 },
   economic: { name: 'Macro Stress', enabled: true, priority: 1 },
   'gulf-economies': { name: 'Gulf & OPEC Economies', enabled: true, priority: 1 },
@@ -1126,7 +1126,7 @@ export function isPanelEntitled(key: string, config: PanelConfig, isPro = false)
   if (!config.premium) return true;
   // Dodo entitlements unlock all premium panels
   if (isEntitled()) return true;
-  const apiKeyPanels = ['stock-analysis', 'stock-backtest', 'daily-market-brief', 'market-implications', 'regional-intelligence', 'deduction', 'chat-analyst', 'wsb-ticker-scanner'];
+  const apiKeyPanels = ['stock-analysis', 'stock-backtest', 'daily-market-brief', 'market-implications', 'regional-intelligence', 'deduction', 'chat-analyst', 'wsb-ticker-scanner', 'trade-policy'];
   if (apiKeyPanels.includes(key)) {
     return getSecretState('WORLDMONITOR_API_KEY').present || isPro;
   }


### PR DESCRIPTION
## Why this PR?

New-user trace on worldmonitor.app (2026-04-22) showed three PRO-gated RPCs firing on every page load for anonymous visitors, producing red 401s in the console and Sentry noise:

\`\`\`
GET /api/intelligence/v1/get-regional-snapshot?region_id=mena  401
GET /api/trade/v1/get-tariff-trends?...                        401
GET /api/trade/v1/list-comtrade-flows                          401
\`\`\`

All three are PRO-gated by the backend but the frontend fires them unconditionally during init. Before the user has even clicked anything.

## Root cause

**trade-policy panel** was missing all 4 layers of the canonical PRO-panel-gating pattern:

| Layer | Before | After |
|---|---|---|
| 1. \`premium: 'locked'\` in config | ❌ not set in any of 3 variants | ✓ added |
| 2. In \`apiKeyPanels\` list | ❌ | ✓ added |
| 3. \`loadTradePolicy\` guard | ❌ fires 6 WTO RPCs unconditionally | ✓ \`if (!hasPremiumAccess()) return\` |
| 4. Priming + refresh in \`App.ts\` | ❌ primed for everyone | ✓ moved into \`_wmAccess\` block + scheduleRefresh gated |

**regional-intelligence** had layers 1-2 but was missing the component-level guard: \`RegionalIntelligenceBoard.loadCurrent()\` fired \`getRegionalSnapshot\` on construction before any entitlement check. Fixed by mirroring the existing \`IS_EMBEDDED_PREVIEW\` short-circuit with a \`!hasPremiumAccess()\` check.

**country-intel** (per-country drill-down) was firing \`listComtradeFlows\` + \`getTariffTrends\` on every country click for all users. Now gated by \`hasPremiumAccess(getAuthState())\` — mirrors the guard pattern already in use a few lines above for the multi-sector cost shock card.

## Files touched (5)

- \`src/config/panels.ts\` — Layer 1 + 2
- \`src/app/data-loader.ts\` — Layer 3 guard on \`loadTradePolicy\`
- \`src/App.ts\` — Layer 4: move \`primeTask('tradePolicy')\` into \`_wmAccess\` block, add \`hasPremiumAccess()\` to scheduleRefresh viewport gate
- \`src/components/RegionalIntelligenceBoard.ts\` — per-component guard on \`loadCurrent\`
- \`src/app/country-intel.ts\` — wrap per-country trade RPCs in \`hasPremiumAccess\`

## What anonymous / free users see after this

- **No 401s in console.** Zero PRO-gated RPCs fire.
- The \`trade-policy\` and \`regional-intelligence\` panels render a locked state with a PRO upgrade CTA (existing \`showLocked\` machinery handles this via the \`premium: 'locked'\` config).
- Country drill-downs show the non-PRO cards as before; the two gated trade cards are hidden (\`null\` update).
- Zero wasted backend compute, zero Sentry noise.

## What authenticated PRO users see

Identical to before. All 4 layers include the standard PRO unlock path (\`hasPremiumAccess()\` returns true → all RPCs fire normally).

## Out of scope

YouTube iframe's \`compute-pressure\` Permissions-Policy violation (also in the trace) — third-party, not our code. Can silence in a follow-up with a Sentry filter or Permissions-Policy allowlist for the youtube.com iframe.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npx biome lint\` on changed files — clean
- [x] \`npm run test:data\` — **6326 pass** (includes the bootstrap/cache-keys sync test that guards against PRO leaks into the bootstrap payload)
- [ ] Manual: open worldmonitor.app incognito, check DevTools console — expect no 401s on init
- [ ] Manual: sign in as PRO, verify trade-policy + regional-intelligence panels light up and load data