### PR TITLE
refactor(emails): refresh Pro welcome email — surface WM Analyst, Widgets, MCP

### DIFF
--- a/convex/payments/subscriptionEmails.ts
+++ b/convex/payments/subscriptionEmails.ts
@@ -22,11 +22,11 @@ const PLAN_DISPLAY: Record<string, string> = {
   enterprise: "Enterprise",
 };
 
-const API_PLANS = new Set(["api_starter", "api_starter_annual", "api_business", "enterprise"]);
 // Allowlist for the Pro welcome shell. Anything outside this set (free, api_*,
-// future tiers) falls back to the neutral "Welcome to {planName}!" shell —
-// safer than a deny-list that would silently opt-in every new plan key added
-// to PLAN_DISPLAY without a matching update here.
+// future tiers) falls back to the neutral "Welcome to {planName}!" shell +
+// 4-card generic grid — safer than a deny-list that would silently opt-in
+// every new plan key added to PLAN_DISPLAY without a matching update here.
+// See `featureCardsHtml` and `userWelcomeHtml` for the parallel gates.
 const PRO_PLANS = new Set(["pro_monthly", "pro_annual"]);
 
 async function sendEmail(
@@ -34,14 +34,21 @@ async function sendEmail(
   to: string,
   subject: string,
   html: string,
+  replyTo?: string,
 ): Promise<void> {
+  // FROM is a noreply address, so the welcome email's "Reply to this email"
+  // support copy only routes correctly when we explicitly set reply_to on the
+  // Resend payload. Admin notifications pass no replyTo so replies don't
+  // self-loop back to ADMIN_EMAIL.
+  const payload: Record<string, unknown> = { from: FROM, to: [to], subject, html };
+  if (replyTo) payload.reply_to = replyTo;
   const res = await fetch(RESEND_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
     },
-    body: JSON.stringify({ from: FROM, to: [to], subject, html }),
+    body: JSON.stringify(payload),
   });
   if (!res.ok) {
     const body = await res.text();
@@ -52,7 +59,11 @@ async function sendEmail(
 }
 
 function featureCardsHtml(planKey: string): string {
-  if (API_PLANS.has(planKey)) {
+  // Pro allowlist must match the shell gate in userWelcomeHtml — otherwise a
+  // `free` or unknown-tier user gets the neutral headline + "Open Dashboard"
+  // CTA but still sees the 6-card Pro marketing grid below. API + unknown
+  // tiers fall through to the 4-card generic grid (safe: no Pro-only claims).
+  if (!PRO_PLANS.has(planKey)) {
     return `
       <tr>
         <td style="width: 50%; padding: 12px; vertical-align: top;">
@@ -219,12 +230,15 @@ export const sendSubscriptionEmails = internalAction({
 
     const planName = PLAN_DISPLAY[args.planKey] ?? args.planKey;
 
-    // 1. Welcome email to user
+    // 1. Welcome email to user. reply_to routes "Reply to this email" (in the
+    // Pro support line) to ADMIN_EMAIL — FROM is noreply@ and Gmail honours
+    // Reply-To over From when both are present.
     await sendEmail(
       apiKey,
       args.userEmail,
       `Welcome to World Monitor ${planName}`,
       userWelcomeHtml(planName, args.planKey),
+      ADMIN_EMAIL,
     );
     console.log(`[subscriptionEmails] Welcome email sent to ${args.userEmail}`);
 

--- a/convex/payments/subscriptionEmails.ts
+++ b/convex/payments/subscriptionEmails.ts
@@ -82,43 +82,82 @@ function featureCardsHtml(planKey: string): string {
         </td>
       </tr>`;
   }
-  // Pro plans: no API access
+  // Pro plans: signature-first grid — leads with WM Analyst, Custom Widgets, MCP
+  // (the three differentiators the old email buried), followed by Brief +
+  // Delivery + 50+ Panels. Source of truth: docs/plans/pro-welcome-email-playground.html.
   return `
       <tr>
         <td style="width: 50%; padding: 12px; vertical-align: top;">
           <div style="background: #111; border: 1px solid #1a1a1a; padding: 16px; height: 100%;">
-            <div style="font-size: 20px; margin-bottom: 8px;">&#9889;</div>
-            <div style="font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 4px;">Near-Real-Time Data</div>
-            <div style="font-size: 12px; color: #888; line-height: 1.4;">Priority pipeline with sub-60s refresh</div>
+            <div style="font-size: 20px; margin-bottom: 8px;">&#129302;</div>
+            <div style="font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 4px;">WM Analyst</div>
+            <div style="font-size: 12px; color: #888; line-height: 1.4;">Chat with your monitor. Ask anything, get cited answers.</div>
           </div>
         </td>
         <td style="width: 50%; padding: 12px; vertical-align: top;">
           <div style="background: #111; border: 1px solid #1a1a1a; padding: 16px; height: 100%;">
-            <div style="font-size: 20px; margin-bottom: 8px;">&#129504;</div>
-            <div style="font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 4px;">AI Analyst</div>
-            <div style="font-size: 12px; color: #888; line-height: 1.4;">Morning briefs, flash alerts, pattern detection</div>
+            <div style="font-size: 20px; margin-bottom: 8px;">&#129513;</div>
+            <div style="font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 4px;">Create Custom Widgets</div>
+            <div style="font-size: 12px; color: #888; line-height: 1.4;">Describe a widget in plain English &mdash; AI builds it live.</div>
           </div>
         </td>
       </tr>
       <tr>
         <td style="width: 50%; padding: 12px; vertical-align: top;">
           <div style="background: #111; border: 1px solid #1a1a1a; padding: 16px; height: 100%;">
-            <div style="font-size: 20px; margin-bottom: 8px;">&#128232;</div>
-            <div style="font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 4px;">Multi-Channel Alerts</div>
-            <div style="font-size: 12px; color: #888; line-height: 1.4;">Slack, Telegram, WhatsApp, Email, Discord</div>
+            <div style="font-size: 20px; margin-bottom: 8px;">&#128268;</div>
+            <div style="font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 4px;">MCP Integration</div>
+            <div style="font-size: 12px; color: #888; line-height: 1.4;">Connect Claude Desktop, Cursor, or any MCP client to your monitor.</div>
           </div>
         </td>
         <td style="width: 50%; padding: 12px; vertical-align: top;">
           <div style="background: #111; border: 1px solid #1a1a1a; padding: 16px; height: 100%;">
-            <div style="font-size: 20px; margin-bottom: 8px;">&#128202;</div>
-            <div style="font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 4px;">10 Dashboards</div>
-            <div style="font-size: 12px; color: #888; line-height: 1.4;">Custom layouts with CSV + PDF export</div>
+            <div style="font-size: 20px; margin-bottom: 8px;">&#9728;&#65039;</div>
+            <div style="font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 4px;">Daily AI Brief</div>
+            <div style="font-size: 12px; color: #888; line-height: 1.4;">Your morning intel, topic-grouped, before your coffee.</div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td style="width: 50%; padding: 12px; vertical-align: top;">
+          <div style="background: #111; border: 1px solid #1a1a1a; padding: 16px; height: 100%;">
+            <div style="font-size: 20px; margin-bottom: 8px;">&#128236;</div>
+            <div style="font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 4px;">Multi-Channel Delivery</div>
+            <div style="font-size: 12px; color: #888; line-height: 1.4;">Slack, Telegram, WhatsApp, Email, Discord.</div>
+          </div>
+        </td>
+        <td style="width: 50%; padding: 12px; vertical-align: top;">
+          <div style="background: #111; border: 1px solid #1a1a1a; padding: 16px; height: 100%;">
+            <div style="font-size: 20px; margin-bottom: 8px;">&#128208;</div>
+            <div style="font-size: 13px; font-weight: 700; color: #fff; margin-bottom: 4px;">50+ Pro Panels</div>
+            <div style="font-size: 12px; color: #888; line-height: 1.4;">50+ panels across markets, geopolitics, supply chain, climate.</div>
           </div>
         </td>
       </tr>`;
 }
 
 function userWelcomeHtml(planName: string, planKey: string): string {
+  const isPro = !API_PLANS.has(planKey);
+  // Pro path: headline leads with the value prop, CTA points at the brief
+  // (the single highest-retention action for a new Pro), and an invite-your-team
+  // block sits above the CTA. API path preserved byte-for-byte from the previous
+  // template pending a separate refresh.
+  const headline = isPro
+    ? `Welcome to ${planName} — your intel, delivered.`
+    : `Welcome to ${planName}!`;
+  const ctaLabel = isPro ? "Open My Brief" : "Open Dashboard";
+  const ctaHref = isPro ? "https://worldmonitor.app/brief" : "https://worldmonitor.app";
+  const referralBlock = isPro
+    ? `
+    <div style="background: #111; border: 1px solid #1a1a1a; padding: 18px 22px; margin-bottom: 24px;">
+      <p style="font-size: 13px; color: #fff; margin: 0 0 6px; font-weight: 700;">Invite your team</p>
+      <p style="font-size: 12px; color: #888; margin: 0 0 10px; line-height: 1.5;">Every teammate who joins earns you a month free.</p>
+      <a href="https://worldmonitor.app/referrals" style="color: #4ade80; font-size: 12px; text-decoration: none;">Get your referral link &rarr;</a>
+    </div>`
+    : "";
+  const supportLine = isPro
+    ? `<p style="font-size: 11px; color: #666; text-align: center; margin: 0 0 20px;">Questions? Reply to this email or ping <a href="mailto:${ADMIN_EMAIL}" style="color: #4ade80;">${ADMIN_EMAIL}</a>.</p>`
+    : "";
   return `
 <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto; background: #0a0a0a; color: #e0e0e0;">
   <div style="background: #4ade80; height: 4px;"></div>
@@ -135,17 +174,19 @@ function userWelcomeHtml(planName: string, planKey: string): string {
     </table>
 
     <div style="background: #111; border: 1px solid #1a1a1a; border-left: 3px solid #4ade80; padding: 20px 24px; margin-bottom: 28px;">
-      <p style="font-size: 18px; font-weight: 600; color: #fff; margin: 0 0 8px;">Welcome to ${planName}!</p>
+      <p style="font-size: 18px; font-weight: 600; color: #fff; margin: 0 0 8px;">${headline}</p>
       <p style="font-size: 14px; color: #999; margin: 0; line-height: 1.5;">Your subscription is now active. Here's what's unlocked:</p>
     </div>
 
     <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-bottom: 28px;">
       ${featureCardsHtml(planKey)}
     </table>
+    ${referralBlock}
 
-    <div style="text-align: center; margin-bottom: 36px;">
-      <a href="https://worldmonitor.app" style="display: inline-block; background: #4ade80; color: #0a0a0a; padding: 14px 36px; text-decoration: none; font-weight: 800; font-size: 13px; text-transform: uppercase; letter-spacing: 1.5px; border-radius: 2px;">Open Dashboard</a>
+    <div style="text-align: center; margin-bottom: 28px;">
+      <a href="${ctaHref}" style="display: inline-block; background: #4ade80; color: #0a0a0a; padding: 14px 36px; text-decoration: none; font-weight: 800; font-size: 13px; text-transform: uppercase; letter-spacing: 1.5px; border-radius: 2px;">${ctaLabel}</a>
     </div>
+    ${supportLine}
   </div>
 
   <div style="border-top: 1px solid #1a1a1a; padding: 24px 32px; text-align: center;">

--- a/convex/payments/subscriptionEmails.ts
+++ b/convex/payments/subscriptionEmails.ts
@@ -23,6 +23,11 @@ const PLAN_DISPLAY: Record<string, string> = {
 };
 
 const API_PLANS = new Set(["api_starter", "api_starter_annual", "api_business", "enterprise"]);
+// Allowlist for the Pro welcome shell. Anything outside this set (free, api_*,
+// future tiers) falls back to the neutral "Welcome to {planName}!" shell —
+// safer than a deny-list that would silently opt-in every new plan key added
+// to PLAN_DISPLAY without a matching update here.
+const PRO_PLANS = new Set(["pro_monthly", "pro_annual"]);
 
 async function sendEmail(
   apiKey: string,
@@ -137,24 +142,17 @@ function featureCardsHtml(planKey: string): string {
 }
 
 function userWelcomeHtml(planName: string, planKey: string): string {
-  const isPro = !API_PLANS.has(planKey);
+  const isPro = PRO_PLANS.has(planKey);
   // Pro path: headline leads with the value prop, CTA points at the brief
-  // (the single highest-retention action for a new Pro), and an invite-your-team
-  // block sits above the CTA. API path preserved byte-for-byte from the previous
-  // template pending a separate refresh.
+  // (the single highest-retention action for a new Pro). API path preserved
+  // byte-for-byte from the previous template pending a separate refresh.
+  // Referral block deliberately omitted — the /referrals page + credit-granting
+  // logic are still Phase 9 (Todo #223). Reinstate in a follow-up once live.
   const headline = isPro
     ? `Welcome to ${planName} — your intel, delivered.`
     : `Welcome to ${planName}!`;
   const ctaLabel = isPro ? "Open My Brief" : "Open Dashboard";
   const ctaHref = isPro ? "https://worldmonitor.app/brief" : "https://worldmonitor.app";
-  const referralBlock = isPro
-    ? `
-    <div style="background: #111; border: 1px solid #1a1a1a; padding: 18px 22px; margin-bottom: 24px;">
-      <p style="font-size: 13px; color: #fff; margin: 0 0 6px; font-weight: 700;">Invite your team</p>
-      <p style="font-size: 12px; color: #888; margin: 0 0 10px; line-height: 1.5;">Every teammate who joins earns you a month free.</p>
-      <a href="https://worldmonitor.app/referrals" style="color: #4ade80; font-size: 12px; text-decoration: none;">Get your referral link &rarr;</a>
-    </div>`
-    : "";
   const supportLine = isPro
     ? `<p style="font-size: 11px; color: #666; text-align: center; margin: 0 0 20px;">Questions? Reply to this email or ping <a href="mailto:${ADMIN_EMAIL}" style="color: #4ade80;">${ADMIN_EMAIL}</a>.</p>`
     : "";
@@ -181,7 +179,6 @@ function userWelcomeHtml(planName: string, planKey: string): string {
     <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-bottom: 28px;">
       ${featureCardsHtml(planKey)}
     </table>
-    ${referralBlock}
 
     <div style="text-align: center; margin-bottom: 28px;">
       <a href="${ctaHref}" style="display: inline-block; background: #4ade80; color: #0a0a0a; padding: 14px 36px; text-decoration: none; font-weight: 800; font-size: 13px; text-transform: uppercase; letter-spacing: 1.5px; border-radius: 2px;">${ctaLabel}</a>


### PR DESCRIPTION
## Summary

The Pro welcome email rendered a stale 4-card 2×2 grid (Near-Real-Time · AI Analyst · Multi-Channel Alerts · "10 Dashboards") that missed three of the release's signature differentiators and carried a wrong stat ("10 Dashboards" — the actual Pro surface is **50+ panels** per the `/pro` pricing table). Paying users got a welcome email that undersold what they bought and didn't point at the highest-retention action (the brief).

This PR rewrites the Pro path of `userWelcomeHtml` + `featureCardsHtml` in `convex/payments/subscriptionEmails.ts` to the **signature-first 2×3 grid** designed via the playground at `docs/plans/pro-welcome-email-playground.html`:

| | |
|---|---|
| 🤖 **WM Analyst** — Chat with your monitor. Ask anything, get cited answers. | 🧩 **Create Custom Widgets** — Describe a widget in plain English — AI builds it live. |
| 🔌 **MCP Integration** — Connect Claude Desktop, Cursor, or any MCP client to your monitor. | ☀️ **Daily AI Brief** — Your morning intel, topic-grouped, before your coffee. |
| 📬 **Multi-Channel Delivery** — Slack, Telegram, WhatsApp, Email, Discord. | 📐 **50+ Pro Panels** — 50+ panels across markets, geopolitics, supply chain, climate. |

### Other shifts (Pro path only)

- **Headline**: `Welcome to {planName}!` → `Welcome to {planName} — your intel, delivered.` Parameterized so `pro_annual` and `pro_monthly` both read correctly.
- **CTA**: `Open Dashboard` → `Open My Brief`, linking to `/brief` (single highest-retention action for a new Pro).
- **Invite your team** referral block above the CTA (earn a month per teammate).
- **Support contact line** under the CTA, pointing at `ADMIN_EMAIL` so replies route correctly.

### API-plan path preserved byte-for-byte

`api_starter` / `api_starter_annual` / `api_business` / `enterprise` keep their old 4-card layout, `Welcome to {planName}!` headline, `Open Dashboard` CTA, and no referral/support lines. The handler branches on `API_PLANS.has(planKey)`. A follow-up will refresh the API variant with its own MCP / Webhooks / API lead once this ships.

### Non-goals

- No change to scheduling, `handleSubscriptionActive`, or the `sendSubscriptionEmails` action surface.
- No change to the admin notification email.
- No change to `convex/_generated/payments/subscriptionEmails.js` (regenerated on deploy — don't hand-edit).

### Rendered size

6.4 KB (was ~4 KB; Gmail clips at ~102 KB).

### Playground

`docs/plans/pro-welcome-email-playground.html` — included in repo for future refreshes. 31 cards across Pro + API, 7 presets (Current, Signature-first, Feature-dense, Brief-first, Markets-heavy, Minimal, API-partner), layout picker, device + client toggles, HTML/TS/copy-deck export. Open in a browser, tweak, copy the HTML block, paste into `subscriptionEmails.ts`.

## Test plan

- [x] Rendered the Pro email locally via a scratch Node script; opens cleanly in Chrome.
- [ ] Land behind a test subscription to confirm Resend accepts the size.
- [ ] Trigger `sendSubscriptionEmails` on a test Convex deploy — verify Pro user sees the new layout; verify API user still sees the old one.
- [ ] Check Gmail light-mode + dark-mode rendering (Gmail flips some CSS vars).