### PR TITLE
fix(sentry): triage 4 inbox issues — silence no-user checkout + deck.gl/Safari noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -310,6 +310,19 @@ Sentry.init({
     if (/reading '(?:type|pathType|count)'|can't access property "(?:type|pathType|count|__globeObjType)",? \w+ is (?:undefined|null)|undefined is not an object \(evaluating '\w+\.(?:pathType|count)'\)/.test(msg)) {
       if (!hasFirstParty) return null;
     }
+    // deck.gl/maplibre internal null-access on Layer.isHidden during render (Safari 26.4 beta,
+    // empty stacks, preceded by DeckGLMap map-error breadcrumbs). Our first-party `isHidden`
+    // lives on SmartPollContext in runtime.ts — any access there would produce frames, so gate
+    // on !hasFirstParty to preserve signal on a real poller regression (WORLDMONITOR-NR).
+    if (/undefined is not an object \(evaluating '\w{1,3}\.isHidden'\)|Cannot read properties of undefined \(reading 'isHidden'\)/.test(msg)) {
+      if (!hasFirstParty) return null;
+    }
+    // Short minified ReferenceError from Safari ("Can't find variable: ss"). With an empty stack
+    // and no first-party frames, this is userscript/extension injection. Our own minified bundle
+    // would keep frames via the source-mapped assets/*.js chunks; if the SDK strips them, the
+    // stack is non-empty. Bound var length to 1–2 to avoid masking a real "foo is not defined"
+    // that happens to hit the unhandledrejection path (WORLDMONITOR-NQ).
+    if (!hasFirstParty && frames.length === 0 && /^Can't find variable: \w{1,2}$/.test(msg)) return null;
     // Suppress minified Three.js/globe.gl crashes (e.g. "l is undefined" in raycast, "b is undefined" in update/initGlobe)
     if (/^\w{1,2} is (?:undefined|not an object)$/.test(msg) && frames.length > 0) {
       if (frames.some(f => /\/(main|index)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? '') && /(raycast|update|initGlobe|traverse|render)/.test(f.function ?? ''))) return null;

--- a/src/services/checkout-sentry-policy.ts
+++ b/src/services/checkout-sentry-policy.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure policy helper: which `action` tags on reportCheckoutError skip the
+ * Sentry emit?
+ *
+ * Lives in its own file so tests can import the policy without pulling the
+ * Dodo SDK + Clerk + storage transitively from checkout.ts (mirrors
+ * checkout-no-user-policy.ts). Never import from checkout.ts here.
+ *
+ * Contract: `no-user` is a pre-auth redirect UX (user clicked upgrade before
+ * signing up and is routed to signup/pricing). Clerk conversion analytics
+ * already tracks that funnel, so reporting it at info level just floods the
+ * Sentry inbox. Every other action — `no-token`, `http-error`,
+ * `missing-checkout-url`, `exception`, `entitlement-timeout` — MUST still
+ * emit so mid-flight auth drops and real failures stay visible.
+ *
+ * Regression-tested in tests/checkout-report-error.test.mts.
+ */
+export const SENTRY_SKIP_ACTIONS: ReadonlySet<string> = new Set(['no-user']);
+
+export function shouldSkipSentryForAction(action: string): boolean {
+  return SENTRY_SKIP_ACTIONS.has(action);
+}

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -694,10 +694,18 @@ function reportCheckoutError(
       serverMessage: error.serverMessage,
     },
   };
-  if (caught) {
-    Sentry.captureException(caught, payload);
-  } else {
-    Sentry.captureMessage(`Checkout error: ${error.code}`, payload);
+  // 'no-user' is a pre-auth redirect flow, not an error — user clicked upgrade
+  // before signing up and is routed to signup/pricing. Reporting it to Sentry
+  // adds inbox noise without signal (Clerk conversion analytics already tracks
+  // this funnel). session_expired / other codes still emit so mid-flight auth
+  // drops remain visible.
+  const skipSentry = context.action === 'no-user';
+  if (!skipSentry) {
+    if (caught) {
+      Sentry.captureException(caught, payload);
+    } else {
+      Sentry.captureMessage(`Checkout error: ${error.code}`, payload);
+    }
   }
   const logger = level === 'info' ? console.info : console.error;
   logger(

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -28,6 +28,7 @@ import {
 } from './checkout-errors';
 import { showCheckoutErrorToast } from './checkout-error-toast';
 import { decideNoUserPathOutcome } from './checkout-no-user-policy';
+import { shouldSkipSentryForAction } from './checkout-sentry-policy';
 import { isEntitled, onEntitlementChange } from './entitlements';
 import {
   CLASSIC_AUTO_DISMISS_MS,
@@ -694,13 +695,7 @@ function reportCheckoutError(
       serverMessage: error.serverMessage,
     },
   };
-  // 'no-user' is a pre-auth redirect flow, not an error — user clicked upgrade
-  // before signing up and is routed to signup/pricing. Reporting it to Sentry
-  // adds inbox noise without signal (Clerk conversion analytics already tracks
-  // this funnel). session_expired / other codes still emit so mid-flight auth
-  // drops remain visible.
-  const skipSentry = context.action === 'no-user';
-  if (!skipSentry) {
+  if (!shouldSkipSentryForAction(context.action)) {
     if (caught) {
       Sentry.captureException(caught, payload);
     } else {

--- a/tests/checkout-report-error.test.mts
+++ b/tests/checkout-report-error.test.mts
@@ -1,0 +1,105 @@
+/**
+ * Regression tests for the Sentry-emit contract in `reportCheckoutError`.
+ *
+ * The `no-user` checkout path is a pre-auth redirect UX (user clicks upgrade
+ * before signing up), not an engineering failure. Clerk conversion analytics
+ * already tracks that funnel, so `reportCheckoutError` deliberately skips
+ * Sentry capture for `action: 'no-user'`. Every other action MUST still emit,
+ * or mid-flight auth drops / missing tokens / server errors would be invisible
+ * — exactly the class of regression a future refactor could introduce by
+ * renaming or collapsing action strings.
+ *
+ * Tests the exported `shouldSkipSentryForAction` predicate (the pure policy)
+ * and asserts the contract against every action string actually used in
+ * src/services/checkout.ts so a silent drift gets caught.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { shouldSkipSentryForAction, SENTRY_SKIP_ACTIONS } from '../src/services/checkout-sentry-policy.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('shouldSkipSentryForAction', () => {
+  it('skips Sentry for the no-user pre-auth redirect', () => {
+    assert.equal(shouldSkipSentryForAction('no-user'), true);
+  });
+
+  it('does NOT skip Sentry for session_expired / no-token (mid-flight auth drop)', () => {
+    // no-token fires when Clerk returns null token mid-flight after a valid
+    // session — a real auth-bridge regression we MUST see.
+    assert.equal(shouldSkipSentryForAction('no-token'), false);
+  });
+
+  it('does NOT skip Sentry for http-error (server / network failures)', () => {
+    assert.equal(shouldSkipSentryForAction('http-error'), false);
+  });
+
+  it('does NOT skip Sentry for missing-checkout-url (malformed Convex response)', () => {
+    assert.equal(shouldSkipSentryForAction('missing-checkout-url'), false);
+  });
+
+  it('does NOT skip Sentry for exception (unhandled throw inside startCheckout)', () => {
+    assert.equal(shouldSkipSentryForAction('exception'), false);
+  });
+
+  it('does NOT skip Sentry for entitlement-timeout (post-success activation failure)', () => {
+    assert.equal(shouldSkipSentryForAction('entitlement-timeout'), false);
+  });
+
+  it('does NOT skip Sentry for an unknown / future action string', () => {
+    // Fail-safe: default must be "emit to Sentry" so adding a new error site
+    // never silently blinds the funnel.
+    assert.equal(shouldSkipSentryForAction('something-we-havent-written-yet'), false);
+  });
+
+  it('has exactly one skip action (guards against scope drift)', () => {
+    // If this grows, the PR that expands it must update this assertion AND
+    // the docstring on SENTRY_SKIP_ACTIONS. Keeping the set tiny limits the
+    // blast radius for future refactors that might rename `action` tags.
+    assert.equal(SENTRY_SKIP_ACTIONS.size, 1);
+    assert.ok(SENTRY_SKIP_ACTIONS.has('no-user'));
+  });
+});
+
+describe('reportCheckoutError call sites in src/services/checkout.ts', () => {
+  // Static guard: every `reportCheckoutError(... action: 'X' ...)` call site
+  // in the implementation corresponds to a known skip / no-skip decision.
+  // If someone adds a new action string without adding a matching assertion
+  // in shouldSkipSentryForAction tests above, this test fails — forcing the
+  // author to explicitly declare the Sentry-emit policy for the new action.
+  const src = readFileSync(resolve(__dirname, '../src/services/checkout.ts'), 'utf-8');
+  // Non-greedy multi-line match: `reportCheckoutError(` ... up to 300 chars
+  // ... `action: '<tag>'`. Handles call sites where the first arg is itself
+  // a function call (classifySyntheticCheckoutError('unauthorized')) so the
+  // `action` tag can live on a later line.
+  const actionRegex = /reportCheckoutError\([\s\S]{0,300}?action:\s*'([^']+)'/g;
+  const knownActions = new Set<string>();
+  let m: RegExpExecArray | null;
+  while ((m = actionRegex.exec(src)) !== null) {
+    knownActions.add(m[1]);
+  }
+
+  it('finds the expected reportCheckoutError call sites', () => {
+    // Pins actual usage at the time of writing. If a new error site is added,
+    // this assertion forces an accompanying policy decision.
+    assert.deepEqual(
+      [...knownActions].sort(),
+      ['exception', 'http-error', 'missing-checkout-url', 'no-token', 'no-user'].sort(),
+    );
+  });
+
+  it('no-user is the only call site marked for skip', () => {
+    for (const action of knownActions) {
+      const expected = action === 'no-user';
+      assert.equal(
+        shouldSkipSentryForAction(action),
+        expected,
+        `action='${action}' must ${expected ? 'skip' : 'emit'} Sentry`,
+      );
+    }
+  });
+});

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -554,4 +554,68 @@ describe('existing beforeSend filters', () => {
     ]);
     assert.ok(beforeSend(event) !== null, 'first-party onmessage regression must surface');
   });
+
+  // WORLDMONITOR-NR: deck.gl/maplibre internal null-access on Layer.isHidden
+  // during render (Safari 26.4 beta, empty stacks preceded by DeckGLMap map-error
+  // breadcrumbs). `\w{1,3}\.isHidden` is gated on !hasFirstParty so a genuine
+  // SmartPollContext.isHidden regression in runtime.ts still surfaces.
+  it('suppresses "evaluating \'Ue.isHidden\'" with empty stack (deck.gl/Safari internal)', () => {
+    const event = makeEvent("undefined is not an object (evaluating 'Ue.isHidden')", 'TypeError', []);
+    assert.equal(beforeSend(event), null, 'deck.gl isHidden null-access with empty stack should be suppressed');
+  });
+
+  it('suppresses Cannot-read-isHidden with only vendor frames', () => {
+    const event = makeEvent("Cannot read properties of undefined (reading 'isHidden')", 'TypeError', [
+      { filename: '/assets/deck-stack-x1y2z3.js', lineno: 1, function: 'Layer.render' },
+    ]);
+    assert.equal(beforeSend(event), null, 'deck.gl vendor-only isHidden crash should be suppressed');
+  });
+
+  it('does NOT suppress ".isHidden" crashes with first-party frames (SmartPollContext regression)', () => {
+    // src/services/runtime.ts owns SmartPollContext.isHidden. A real regression
+    // there would carry a first-party frame — must surface.
+    const event = makeEvent("Cannot read properties of undefined (reading 'isHidden')", 'TypeError', [
+      firstPartyFrame('src/services/runtime.ts', 'SmartPoller.tick'),
+    ]);
+    assert.ok(beforeSend(event) !== null, 'first-party SmartPollContext.isHidden regression must reach Sentry');
+  });
+
+  it('does NOT suppress ".isHidden" errors on longer-name symbols (bounded char class)', () => {
+    // Filter is scoped to `\w{1,3}` to match minified short names. A 4+ char
+    // symbol like `myLayer.isHidden` should NOT match this filter (it'd hit
+    // the broader !hasFirstParty network/runtime gate instead, which requires
+    // specific shapes — isHidden isn't on that list).
+    const event = makeEvent("undefined is not an object (evaluating 'myLayer.isHidden')", 'TypeError', []);
+    assert.ok(beforeSend(event) !== null, '4+ char symbol accessing .isHidden must still surface');
+  });
+
+  // WORLDMONITOR-NQ: Safari short-var ReferenceError ("Can't find variable: ss")
+  // from userscript/extension injection. Gated on empty stack + !hasFirstParty +
+  // 1–2 char var name so a real "foo is not defined" from our code still surfaces.
+  it("suppresses \"Can't find variable: ss\" with empty stack", () => {
+    const event = makeEvent("Can't find variable: ss", 'Error', []);
+    assert.equal(beforeSend(event), null, 'Short-var Safari ReferenceError with empty stack should be suppressed');
+  });
+
+  it("suppresses \"Can't find variable: x\" (single char)", () => {
+    const event = makeEvent("Can't find variable: x", 'Error', []);
+    assert.equal(beforeSend(event), null);
+  });
+
+  it("does NOT suppress \"Can't find variable: ss\" when first-party frames are present", () => {
+    // A real minified first-party ReferenceError would carry frames. We never
+    // want to silently drop that.
+    const event = makeEvent("Can't find variable: ss", 'Error', [
+      firstPartyFrame('/assets/panels-DzUv7BBV.js', 'loadTab'),
+    ]);
+    assert.ok(beforeSend(event) !== null, 'first-party short-var ReferenceError must surface');
+  });
+
+  it("does NOT suppress longer variable names (3+ chars) — shape outside char class", () => {
+    // Only `\w{1,2}` matches. `foo` is 3 chars, falls through — meaningful
+    // first-party misses (e.g. helper name typo) still surface.
+    const event = makeEvent("Can't find variable: foo", 'Error', []);
+    assert.ok(beforeSend(event) !== null, '3+ char variable names must surface');
+  });
+
 });


### PR DESCRIPTION
## Why this PR?
Sentry inbox had 4 unresolved issues. All 4 are now classified, fixed-or-filtered, and marked resolved (`inNextRelease: true`) so recurrence auto-reopens with real signal.

## Summary
- **WORLDMONITOR-NN** — `Checkout error: unauthorized` (info, 7 users). Pre-auth redirect UX, not an error. `reportCheckoutError` now skips Sentry emit when `action === 'no-user'`; Clerk analytics already tracks this funnel. `session_expired` / other codes keep emitting so mid-flight auth drops stay visible.
- **WORLDMONITOR-NQ** — `Can't find variable: ss` (Safari, empty stack, tech.worldmonitor.app). `beforeSend` gate: `!hasFirstParty && frames.length === 0 && /^Can't find variable: \w{1,2}$/`. Classic userscript/extension injection; bounded to 1–2 char vars so a real `foo is not defined` still surfaces.
- **WORLDMONITOR-NR** — `undefined is not an object (evaluating 'Ue.isHidden')` (Safari 26.4 beta, empty stack, preceded by `[DeckGLMap] familiesBySource` breadcrumbs). Extended existing deck.gl `beforeSend` block to cover `\w{1,3}\.isHidden` when `!hasFirstParty`. First-party `SmartPollContext.isHidden` (runtime.ts) regressions still surface.
- **WORLDMONITOR-NP** — `Couldn't acquire a permit on this funrun` (Convex server-side, 1 event, `POST /api/internal-entitlements`). Emitted by the Convex→Sentry SDK, not our bundle — no source-side filter possible. Resolved; recurrence would signal a real concurrency problem worth investigating.

## Test plan
- [x] `npm run typecheck` + `typecheck:api` — PASS
- [x] `npm run test:data` — PASS (6340 tests)
- [x] `node --test tests/edge-functions.test.mjs` — PASS (175 tests)
- [x] `npx esbuild api/*.js --bundle` — PASS (all edge functions bundle)
- [x] `npm run lint` / `lint:md` / `version:check` — PASS
- [ ] After deploy: confirm NN/NQ/NR do not reappear within 48h; confirm `session_expired` and `no-token` checkout errors still emit
- [ ] Spot-check real `Ue.isHidden` / `ss`-named identifier regressions would still surface (they'd carry first-party frames → filter skipped)