### PR TITLE
chore(sentry): silence Opera extension injection noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -262,6 +262,9 @@ Sentry.init({
     /\[CONVEX [AQM]\(.+?\)\] Connection lost while action was in flight/, // Convex SDK transient WS disconnect
     /Response did not contain `success` or `data`/, // DuckDuckGo browser internal tracker/content-block response — never emitted by our code
     /Cannot set properties of undefined \(setting 'bodyTouched'\)/, // Quark browser (Alibaba mobile) touch-tracking script injection (WORLDMONITOR-N1)
+    /Cannot read properties of \w+ \(reading '[^']*[^\x00-\x7F][^']*'\)/, // Non-ASCII property name in message = mojibake/corrupted identifier from injected extension; our bundle emits ASCII-only identifiers (WORLDMONITOR-NS)
+    /Octal literals are not allowed in strict mode/, // Runtime SyntaxError from injected extension script; our TS bundle never emits octal literals and doesn't eval (WORLDMONITOR-NV)
+    /Unexpected identifier 'm'/, // Foreign script injection on Opera; pre-compiled bundle can't parse-fail at runtime (WORLDMONITOR-NT)
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';


### PR DESCRIPTION
## Summary
Three cascading errors fired within ~40 ms from a single Opera 130 / Windows 10 session (WORLDMONITOR-NS/NT/NV) — all signatures of an extension injecting broken JS:

- `TypeError: reading 'oîUpdateObj'` — property name contains non-ASCII `î` (U+00EE). Our minifier only emits ASCII identifiers, so a mojibake property name in the message is unambiguously from a foreign object.
- `SyntaxError: Octal literals are not allowed in strict mode` — our TS bundle never emits octals and has no `eval` / `Function()` call path, so a runtime parse error of this shape can only come from an injected `<script>`.
- `SyntaxError: Unexpected identifier 'm'` — a pre-compiled bundle can't parse-fail at runtime. Same injection class as the two above.

Filters added to `src/main.ts` `ignoreErrors`:
- `/Cannot read properties of \w+ \(reading '[^']*[^\x00-\x7F][^']*'\)/` — any property access with a non-ASCII name in the message
- `/Octal literals are not allowed in strict mode/`
- `/Unexpected identifier 'm'/` (matches existing `'https'` / `'does'` precedent)

Sentry issues already marked resolved with `inNextRelease: true` so they auto-reopen if they recur against a new release.

## Test plan
- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `npm run lint` (biome, exit 0)
- [x] `npm run test:data` (6369 pass / 0 fail)
- [x] `node --test tests/edge-functions.test.mjs` (176 pass)
- [x] CJS syntax check, edge-function esbuild bundles, markdownlint, version:check
- [ ] After merge: confirm no new `WORLDMONITOR-N{S,T,V}`-style events against `worldmonitor@2.6.7+` in Sentry
