### PR TITLE
chore(railway): wire seed-sovereign-wealth into resilience-recovery bundle

### DIFF
--- a/scripts/seed-bundle-resilience-recovery.mjs
+++ b/scripts/seed-bundle-resilience-recovery.mjs
@@ -7,4 +7,10 @@ await runBundle('resilience-recovery', [
   { label: 'External-Debt', script: 'seed-recovery-external-debt.mjs', seedMetaKey: 'resilience:recovery:external-debt', canonicalKey: 'resilience:recovery:external-debt:v1', intervalMs: 30 * DAY, timeoutMs: 300_000 },
   { label: 'Import-HHI', script: 'seed-recovery-import-hhi.mjs', seedMetaKey: 'resilience:recovery:import-hhi', canonicalKey: 'resilience:recovery:import-hhi:v1', intervalMs: 30 * DAY, timeoutMs: 1_800_000 },
   { label: 'Fuel-Stocks', script: 'seed-recovery-fuel-stocks.mjs', seedMetaKey: 'resilience:recovery:fuel-stocks', canonicalKey: 'resilience:recovery:fuel-stocks:v1', intervalMs: 30 * DAY, timeoutMs: 300_000 },
+  // PR 2 §3.4 — feeds the forthcoming `sovereignFiscalBuffer` dimension.
+  // 30-day interval matches the CACHE_TTL_SECONDS (35 days) in the seeder
+  // and the quarterly revision cadence documented in the manifest. Longer
+  // timeout than peers because Tier 3b (per-fund Wikipedia infobox) is N
+  // network round-trips per manifest fund the list article misses.
+  { label: 'Sovereign-Wealth', script: 'seed-sovereign-wealth.mjs', seedMetaKey: 'resilience:recovery:sovereign-wealth', canonicalKey: 'resilience:recovery:sovereign-wealth:v1', intervalMs: 30 * DAY, timeoutMs: 600_000 },
 ]);

--- a/tests/seed-bundle-resilience-recovery.test.mjs
+++ b/tests/seed-bundle-resilience-recovery.test.mjs
@@ -15,12 +15,15 @@ const EXPECTED_ENTRIES = [
   { label: 'External-Debt', script: 'seed-recovery-external-debt.mjs', seedMetaKey: 'resilience:recovery:external-debt' },
   { label: 'Import-HHI', script: 'seed-recovery-import-hhi.mjs', seedMetaKey: 'resilience:recovery:import-hhi' },
   { label: 'Fuel-Stocks', script: 'seed-recovery-fuel-stocks.mjs', seedMetaKey: 'resilience:recovery:fuel-stocks' },
+  { label: 'Sovereign-Wealth', script: 'seed-sovereign-wealth.mjs', seedMetaKey: 'resilience:recovery:sovereign-wealth' },
 ];
 
 describe('seed-bundle-resilience-recovery', () => {
-  it('has exactly 5 entries', () => {
+  it(`has exactly ${EXPECTED_ENTRIES.length} entries`, () => {
     const labelMatches = bundleSource.match(/label:\s*'[^']+'/g) ?? [];
-    assert.equal(labelMatches.length, 5, `Expected 5 entries, found ${labelMatches.length}`);
+    assert.equal(labelMatches.length, EXPECTED_ENTRIES.length,
+      `Expected ${EXPECTED_ENTRIES.length} entries, found ${labelMatches.length}. ` +
+      `If you added a new seeder, update EXPECTED_ENTRIES above.`);
   });
 
   for (const entry of EXPECTED_ENTRIES) {
@@ -38,7 +41,8 @@ describe('seed-bundle-resilience-recovery', () => {
 
   it('all entries use 30 * DAY interval', () => {
     const intervalMatches = bundleSource.match(/intervalMs:\s*30\s*\*\s*DAY/g) ?? [];
-    assert.equal(intervalMatches.length, 5, `Expected all 5 entries to use 30 * DAY interval`);
+    assert.equal(intervalMatches.length, EXPECTED_ENTRIES.length,
+      `Expected all ${EXPECTED_ENTRIES.length} entries to use 30 * DAY interval`);
   });
 
   it('imports runBundle and DAY from _bundle-runner.mjs', () => {


### PR DESCRIPTION
One-line bundle wiring to get the SWF seeder (landed in #3305) running
on Railway cron. The `seed-bundle-resilience-recovery` service already
exists — this just adds `seed-sovereign-wealth.mjs` to its entry list.

## Summary

- Adds one entry to `scripts/seed-bundle-resilience-recovery.mjs`:
  ```
  { label: 'Sovereign-Wealth', script: 'seed-sovereign-wealth.mjs',
    seedMetaKey: 'resilience:recovery:sovereign-wealth',
    canonicalKey: 'resilience:recovery:sovereign-wealth:v1',
    intervalMs: 30 * DAY, timeoutMs: 600_000 }
  ```
- Settings rationale inline in the comment: 30-day interval matches
  the seeder's `CACHE_TTL_SECONDS = 35 * DAY` and the quarterly
  manifest revision cadence; `timeoutMs: 600_000` is 2× the peers
  because Tier 3b (per-fund Wikipedia article infobox) is N extra
  round-trips for any fund the list article omits (currently Temasek
  is the only such case, leaving headroom).

## Why this is safe

- No new Railway service — same bundle, same Dockerfile, same image.
  Railway will auto-redeploy `seed-bundle-resilience-recovery` on
  merge to main.
- The seeder has `emptyDataIsFailure: false` so a transient Wikipedia
  outage on the first cron tick does not poison seed-meta for 30 days
  (see `feedback_strict_floor_validate_fail_poisons_seed_meta.md`).
- Health wiring is still deliberately absent — the key stays
  `ON_DEMAND_KEYS` equivalent (no `api/health.js` entry) until ~7
  days of clean cron runs confirm the seeder is stable, then the
  scorer PR graduates it. Same pattern as `bisDsr`, `bisPolicy`, etc.
- No RPC consumer yet, so even if the payload is empty on the first
  cron tick, no user-facing surface breaks.

## Test plan

- [x] `node -c scripts/seed-bundle-resilience-recovery.mjs` — syntax OK
- [x] All 6 referenced seed scripts exist in `scripts/`
- [x] `seed-sovereign-wealth.mjs` module imports cleanly (exports
      intact)
- [ ] After merge: Railway redeploys `seed-bundle-resilience-recovery`
      automatically (connected to main branch)
- [ ] Next cron tick populates
      `resilience:recovery:sovereign-wealth:v1` with 8/8 matched
      countries (live scrape against Wikipedia list + Temasek infobox)
- [ ] Verify via
      `redis-cli GET resilience:recovery:sovereign-wealth:v1 | jq .sourceMix`
      — should show `wikipedia_list: 7, wikipedia_infobox: 1`

## Follow-up (separate PR, after bake-in)

Once the seeder has ~7 days of clean Railway cron runs:

- Graduate the key from on-demand to registered in `api/health.js`
  (SEED_META + recordCount threshold) + optional bootstrap hydration
  once the scorer reads it.
- Land scorer + dimension wiring: `liquidReserveAdequacy` +
  `sovereignFiscalBuffer` in `RESILIENCE_DIMENSION_ORDER` + registry +
  recovery-domain weight rebalance.