### PR TITLE
chore(bundle-runner): emit reliable per-section summary line on parent stdout

### DIFF
--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -110,12 +110,28 @@ function streamLines(stream, onLine) {
 function spawnSeed(scriptPath, { timeoutMs, label }) {
   return new Promise((resolve) => {
     const t0 = Date.now();
+    // Capture the child's structured `seed_complete` event if emitted, so
+    // the parent can re-emit the key fields on a single bundle-level line.
+    // Railway log ingestion drops child-stdout lines when many seeders log
+    // at similar timestamps (observed across Storage-Facilities /
+    // Energy-Disruptions / Pipelines-Gas in PR #3294 launch run: each
+    // dropped a different subset of Run ID / Mode / seed_complete lines
+    // despite identical code paths). Bundle-level lines survive reliably.
+    let lastSeedComplete = null;
     const child = spawn(process.execPath, [scriptPath], {
       env: process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
-    streamLines(child.stdout, (line) => console.log(`  [${label}] ${line}`));
+    streamLines(child.stdout, (line) => {
+      console.log(`  [${label}] ${line}`);
+      const idx = line.indexOf('{"event":"seed_complete"');
+      if (idx >= 0) {
+        try {
+          lastSeedComplete = JSON.parse(line.slice(idx));
+        } catch { /* malformed JSON — keep previous */ }
+      }
+    });
     streamLines(child.stderr, (line) => console.warn(`  [${label}] ${line}`));
 
     let settled = false;
@@ -156,7 +172,7 @@ function spawnSeed(scriptPath, { timeoutMs, label }) {
         // Terminal reason already logged by softKill — just record the outcome.
         settle({ elapsed, ok: false, reason: `timeout after ${Math.round(timeoutMs / 1000)}s (signal ${signal || 'SIGTERM'})`, alreadyLogged: true });
       } else if (code === 0) {
-        settle({ elapsed, ok: true });
+        settle({ elapsed, ok: true, seedComplete: lastSeedComplete });
       } else {
         settle({ elapsed, ok: false, reason: `exit ${code ?? 'null'}${signal ? ` (signal ${signal})` : ''}` });
       }
@@ -215,11 +231,24 @@ export async function runBundle(label, sections, opts = {}) {
     const result = await spawnSeed(scriptPath, { timeoutMs: timeout, label: section.label });
     if (result.ok) {
       console.log(`  [${section.label}] Done (${result.elapsed}s)`);
+      // Bundle-level per-section summary — emitted from parent stdout so
+      // Railway log ingestion captures it reliably even when child lines
+      // drop. Observability tools should key off this line, not per-section
+      // Run ID / Mode / seed_complete lines which are best-effort only.
+      const sc = result.seedComplete;
+      if (sc && typeof sc === 'object') {
+        console.log(`[Bundle:${label}] section=${section.label} status=OK durationMs=${sc.durationMs ?? ''} records=${sc.recordCount ?? ''} state=${sc.state || 'OK'}`);
+      } else {
+        // Seeder didn't emit seed_complete (legacy non-contract seeders, or
+        // the child's event line was dropped before parsing).
+        console.log(`[Bundle:${label}] section=${section.label} status=OK elapsed=${result.elapsed}s`);
+      }
       ran++;
     } else {
       if (!result.alreadyLogged) {
         console.error(`  [${section.label}] Failed after ${result.elapsed}s: ${result.reason}`);
       }
+      console.log(`[Bundle:${label}] section=${section.label} status=FAILED elapsed=${result.elapsed}s reason=${(result.reason || 'unknown').replace(/\s+/g, ' ')}`);
       failed++;
     }
   }

--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -248,7 +248,13 @@ export async function runBundle(label, sections, opts = {}) {
       if (!result.alreadyLogged) {
         console.error(`  [${section.label}] Failed after ${result.elapsed}s: ${result.reason}`);
       }
-      console.log(`[Bundle:${label}] section=${section.label} status=FAILED elapsed=${result.elapsed}s reason=${(result.reason || 'unknown').replace(/\s+/g, ' ')}`);
+      // Emit the FAILED summary to stderr (same stream as the Failed line
+      // and SIGKILL escalation log) so chronological ordering in combined
+      // output is preserved. If we went to stdout here, the line would
+      // appear before those stderr lines when consumers concatenate
+      // stdout+stderr, breaking tests (and log readers) that rely on
+      // signal-escalation ordering.
+      console.error(`[Bundle:${label}] section=${section.label} status=FAILED elapsed=${result.elapsed}s reason=${(result.reason || 'unknown').replace(/\s+/g, ' ')}`);
       failed++;
     }
   }


### PR DESCRIPTION
## Summary

Fixes observability asymmetry in Railway bundle-service logs where some seeders appeared to skip \`Run ID\` / \`Mode\` / \`seed_complete\` lines. Root cause is Railway's log ingestion dropping child-stdout lines when many seeders emit at similar timestamps — not a code bug.

**Evidence** (PR #3294 launch run, \`seed-bundle-energy-sources\` 04:04:19Z):

| Section | Banner | Run ID | Mode | seed_complete |
|---|---|---|---|---|
| Pipelines-Gas | ❌ missing | ✅ | ❌ | ✅ |
| Pipelines-Oil | ✅ (out of order) | ✅ | ❌ | ✅ |
| Storage-Facilities | ✅ | ❌ | ❌ | ❌ |
| Fuel-Shortages | ✅ | ❌ | ✅ | ✅ |
| Energy-Disruptions | ❌ | ❌ | ❌ | ❌ |

All five have identical code paths (same \`runSeed\` with \`declareRecords\`). Different lines dropped from each — classic log-aggregation flake. Health check shows correct record counts for all five keys, so data path is fine.

## Fix

Bundle runner now emits a single structured summary line per section **from the parent process's stdout** (which survives Railway's ingestion reliably — bundle-level lines like \`[Bundle:X] Starting\` and \`Finished\` made it through every run).

\`\`\`
[Bundle:energy-sources] section=Pipelines-Gas status=OK durationMs=1277 records=12 state=OK
[Bundle:energy-sources] section=Storage-Facilities status=OK durationMs=1239 records=21 state=OK
[Bundle:energy-sources] section=Pipelines-Oil status=FAILED elapsed=60.0s reason=timeout after 60s
\`\`\`

Observability consumers should key off this line rather than per-section child lines. Per-section child lines stay as-is for interactive debugging; they're just best-effort for log scrapers.

### Mechanism

1. \`spawnSeed\` now scans stdout lines for \`{"event":"seed_complete",...}\` and parses the JSON into a result-bag field.
2. After child exit, the main loop emits one bundle-level line per section using the parsed fields (falls back to elapsed-only if \`seed_complete\` was dropped or the seeder is legacy non-contract).
3. Failed sections always emit a \`status=FAILED\` summary with reason — guarantees monitors see the failure even if the child's error output was dropped.

## Test plan

- [x] Node syntax check (\`node --check scripts/_bundle-runner.mjs\`) clean
- [x] Typecheck clean
- [x] Parse-logic sanity check against actual \`seed_complete\` line from PR #3294 run — captures \`recordCount: 21, state: OK, durationMs: 1239\` correctly
- [ ] Deploy to Railway; confirm \`[Bundle:energy-sources] section=X\` lines appear for all 8 energy-sources sections on next cron tick
- [ ] Verify same reliability in \`seed-bundle-portwatch\` (other bundle service using the same runner)