### PR TITLE
fix(email): route Intelligence Brief off the alerts@ mailbox

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -368,8 +368,19 @@ NOTIFICATION_ENCRYPTION_KEY=
 # Get from: resend.com/api-keys
 RESEND_API_KEY=
 
-# "From" address for email notifications (must be a verified Resend sender domain)
-RESEND_FROM_EMAIL=WorldMonitor <alerts@worldmonitor.app>
+# "From" address for email notifications (must be a verified Resend sender domain).
+# ALWAYS include a display name in "Name <addr@domain>" form — without it, Gmail
+# and Outlook render the local-part ("alerts") as the sender name, which reads
+# like a scary alarm even for editorial content.
+# RESEND_FROM_EMAIL is used by notification-relay.cjs for realtime push alerts.
+RESEND_FROM_EMAIL=WorldMonitor Alerts <alerts@worldmonitor.app>
+
+# "From" address for the daily Intelligence Brief / digest email. Kept
+# separate from RESEND_FROM_EMAIL so editorial mail doesn't ship from the
+# `alerts@` mailbox (which reads like an incident alarm). Used by
+# scripts/seed-digest-notifications.mjs. Falls back to RESEND_FROM_EMAIL
+# if unset, so existing deploys keep working during rollout.
+RESEND_FROM_BRIEF=WorldMonitor Brief <brief@worldmonitor.app>
 
 # Vite-exposed Convex URL for frontend entitlement service (VITE_ prefix required for client-side access)
 VITE_CONVEX_URL=

--- a/.env.example
+++ b/.env.example
@@ -370,16 +370,23 @@ RESEND_API_KEY=
 
 # "From" address for email notifications (must be a verified Resend sender domain).
 # ALWAYS include a display name in "Name <addr@domain>" form — without it, Gmail
-# and Outlook render the local-part ("alerts") as the sender name, which reads
-# like a scary alarm even for editorial content.
+# and Outlook fall back to rendering the local-part ("alerts") as the sender
+# name, which reads like a scary alarm even for editorial content. The digest
+# path (see RESEND_FROM_BRIEF below) enforces this at runtime via
+# scripts/lib/resend-from.cjs; set this var with the wrapper anyway so the
+# realtime-alert path (notification-relay.cjs) gets the same protection once
+# the relay-side normalizer lands.
 # RESEND_FROM_EMAIL is used by notification-relay.cjs for realtime push alerts.
-RESEND_FROM_EMAIL=WorldMonitor Alerts <alerts@worldmonitor.app>
+RESEND_FROM_EMAIL=WorldMonitor <alerts@worldmonitor.app>
 
 # "From" address for the daily Intelligence Brief / digest email. Kept
 # separate from RESEND_FROM_EMAIL so editorial mail doesn't ship from the
 # `alerts@` mailbox (which reads like an incident alarm). Used by
-# scripts/seed-digest-notifications.mjs. Falls back to RESEND_FROM_EMAIL
-# if unset, so existing deploys keep working during rollout.
+# scripts/seed-digest-notifications.mjs, which normalizes the value via
+# scripts/lib/resend-from.cjs — a bare address is coerced to
+# "WorldMonitor Brief <addr>" at runtime with a loud warning, so a
+# misconfigured env cannot silently re-introduce the bare-local-part bug.
+# Falls back to RESEND_FROM_EMAIL if unset, so existing deploys keep working.
 RESEND_FROM_BRIEF=WorldMonitor Brief <brief@worldmonitor.app>
 
 # Vite-exposed Convex URL for frontend entitlement service (VITE_ prefix required for client-side access)

--- a/scripts/lib/resend-from.cjs
+++ b/scripts/lib/resend-from.cjs
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * Coerce a Resend `from:` value into a form that renders a friendly
+ * display name in Gmail / Outlook / Apple Mail. When the value is a
+ * bare email address (no "Name <addr@domain>" wrapper), clients fall
+ * back to the local-part as the sender name — so `alerts@worldmonitor.app`
+ * shows up as "alerts" in the inbox, which reads like an incident
+ * alarm when the mail is actually a curated editorial brief.
+ *
+ * We coerce (rather than fail-closed) so a misconfigured Railway env
+ * does NOT take the cron down; the coercion emits a loud warning so
+ * operators can see and fix the misconfiguration in logs.
+ *
+ * @param {string | null | undefined} raw - env value (possibly empty).
+ * @param {string} defaultDisplayName - friendly name to wrap bare addresses with.
+ * @param {(msg: string) => void} [warn] - warning sink (default: console.warn).
+ * @returns {string | null} normalized sender, or null when raw is empty.
+ */
+function normalizeResendSender(raw, defaultDisplayName, warn) {
+  const warnFn = typeof warn === 'function' ? warn : (m) => console.warn(m);
+  const value = typeof raw === 'string' ? raw.trim() : '';
+  if (!value) return null;
+  if (value.includes('<') && value.includes('>')) return value;
+  warnFn(
+    `[resend] sender "${value}" lacks display name — coercing to "${defaultDisplayName} <${value}>". ` +
+      `Set the env var in "Name <addr@domain>" form to silence this.`,
+  );
+  return `${defaultDisplayName} <${value}>`;
+}
+
+module.exports = { normalizeResendSender };

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -29,6 +29,7 @@ const { decrypt } = require('./lib/crypto.cjs');
 const { callLLM } = require('./lib/llm-chain.cjs');
 const { fetchUserPreferences, extractUserContext, formatUserProfile } = require('./lib/user-context.cjs');
 const { Resend } = require('resend');
+const { normalizeResendSender } = require('./lib/resend-from.cjs');
 import { readRawJsonFromUpstash, redisPipeline } from '../api/_upstash-json.js';
 import {
   composeBriefFromDigestStories,
@@ -60,11 +61,15 @@ const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN ?? '';
 const RESEND_API_KEY = process.env.RESEND_API_KEY ?? '';
 // Brief/digest is an editorial daily read, not an incident alarm — route it
 // off the `alerts@` mailbox so recipients don't see a scary "alert" from-name
-// in their inbox when an env override drops the display component.
+// in their inbox. normalizeResendSender coerces a bare email address into a
+// "Name <addr>" wrapper at runtime (with a loud warning), so a Railway env
+// like `RESEND_FROM_BRIEF=brief@worldmonitor.app` can't re-introduce the bug
+// that `.env.example` documents.
 const RESEND_FROM =
-  process.env.RESEND_FROM_BRIEF ??
-  process.env.RESEND_FROM_EMAIL ??
-  'WorldMonitor Brief <brief@worldmonitor.app>';
+  normalizeResendSender(
+    process.env.RESEND_FROM_BRIEF ?? process.env.RESEND_FROM_EMAIL,
+    'WorldMonitor Brief',
+  ) ?? 'WorldMonitor Brief <brief@worldmonitor.app>';
 
 if (process.env.DIGEST_CRON_ENABLED === '0') {
   console.log('[digest] DIGEST_CRON_ENABLED=0 — skipping run');

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -58,7 +58,13 @@ const CONVEX_SITE_URL =
 const RELAY_SECRET = process.env.RELAY_SHARED_SECRET ?? '';
 const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN ?? '';
 const RESEND_API_KEY = process.env.RESEND_API_KEY ?? '';
-const RESEND_FROM = process.env.RESEND_FROM_EMAIL ?? 'WorldMonitor <alerts@worldmonitor.app>';
+// Brief/digest is an editorial daily read, not an incident alarm — route it
+// off the `alerts@` mailbox so recipients don't see a scary "alert" from-name
+// in their inbox when an env override drops the display component.
+const RESEND_FROM =
+  process.env.RESEND_FROM_BRIEF ??
+  process.env.RESEND_FROM_EMAIL ??
+  'WorldMonitor Brief <brief@worldmonitor.app>';
 
 if (process.env.DIGEST_CRON_ENABLED === '0') {
   console.log('[digest] DIGEST_CRON_ENABLED=0 — skipping run');

--- a/tests/resend-sender-normalize.test.mjs
+++ b/tests/resend-sender-normalize.test.mjs
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { normalizeResendSender } = require('../scripts/lib/resend-from.cjs');
+
+const silent = () => {};
+
+test('returns null for empty, null, undefined, or whitespace-only input', () => {
+  assert.equal(normalizeResendSender(null, 'WorldMonitor', silent), null);
+  assert.equal(normalizeResendSender(undefined, 'WorldMonitor', silent), null);
+  assert.equal(normalizeResendSender('', 'WorldMonitor', silent), null);
+  assert.equal(normalizeResendSender('   ', 'WorldMonitor', silent), null);
+});
+
+test('passes a properly wrapped sender through unchanged', () => {
+  assert.equal(
+    normalizeResendSender('WorldMonitor <alerts@worldmonitor.app>', 'Default', silent),
+    'WorldMonitor <alerts@worldmonitor.app>',
+  );
+  assert.equal(
+    normalizeResendSender('WorldMonitor Brief <brief@worldmonitor.app>', 'Default', silent),
+    'WorldMonitor Brief <brief@worldmonitor.app>',
+  );
+});
+
+test('trims surrounding whitespace before returning a wrapped sender', () => {
+  assert.equal(
+    normalizeResendSender('  WorldMonitor Brief <brief@worldmonitor.app>  ', 'Default', silent),
+    'WorldMonitor Brief <brief@worldmonitor.app>',
+  );
+});
+
+test('wraps a bare email address with the supplied default display name', () => {
+  assert.equal(
+    normalizeResendSender('brief@worldmonitor.app', 'WorldMonitor Brief', silent),
+    'WorldMonitor Brief <brief@worldmonitor.app>',
+  );
+  assert.equal(
+    normalizeResendSender('alerts@worldmonitor.app', 'WorldMonitor Alerts', silent),
+    'WorldMonitor Alerts <alerts@worldmonitor.app>',
+  );
+});
+
+test('emits exactly one warning when coercing a bare address', () => {
+  const warnings = [];
+  normalizeResendSender('brief@worldmonitor.app', 'WorldMonitor Brief', (m) => warnings.push(m));
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /lacks display name/);
+  assert.match(warnings[0], /WorldMonitor Brief <brief@worldmonitor\.app>/);
+});
+
+test('does not warn when the value already has a display-name wrapper', () => {
+  const warnings = [];
+  normalizeResendSender(
+    'WorldMonitor Brief <brief@worldmonitor.app>',
+    'Default',
+    (m) => warnings.push(m),
+  );
+  assert.equal(warnings.length, 0);
+});
+
+test('defaults to console.warn when no warning sink is supplied', () => {
+  const original = console.warn;
+  const captured = [];
+  console.warn = (m) => captured.push(m);
+  try {
+    normalizeResendSender('bare@example.com', 'Name');
+    assert.equal(captured.length, 1);
+    assert.match(captured[0], /lacks display name/);
+  } finally {
+    console.warn = original;
+  }
+});


### PR DESCRIPTION
## Why this PR?

The daily **WorldMonitor Intelligence Brief** email shipped from `alerts@worldmonitor.app`. In recipients' inboxes it rendered as if it were from **\"alert\"** — because Gmail/Outlook fall back to the local-part of the sender address when the \`Name <addr>\` display-name component is missing or malformed. A curated editorial read is arriving looking like an incident alarm, which is scary and bad-feeling for end users.

## Root cause

Two compounding problems:

1. **Wrong mailbox for editorial mail.** The brief/digest and the realtime incident push shared the same \`RESEND_FROM_EMAIL\` env var → same \`alerts@\` mailbox. That's accurate for real alerts from \`notification-relay.cjs\`, but wrong for the daily editorial brief.
2. **Bare-address trap.** The in-repo default is \`WorldMonitor <alerts@worldmonitor.app>\`, but the Railway env override appears to have been set to a bare address (no \`Name <...>\` wrapper). Gmail/Outlook then display the local-part as the friendly name — \"alerts\" (or \"alert\" after a client-side truncation).

## What this changes

- **New env var \`RESEND_FROM_BRIEF\`** (default \`WorldMonitor Brief <brief@worldmonitor.app>\`), consumed only by \`scripts/seed-digest-notifications.mjs\`.
- **Three-tier fallback**: \`RESEND_FROM_BRIEF\` → \`RESEND_FROM_EMAIL\` → built-in default. Existing deploys keep working with zero behavior change until Railway flips the flag.
- **\`notification-relay.cjs\` is untouched** — realtime push alerts correctly keep \`alerts@\`.
- **\`.env.example\` documents the display-name rule** so the bare-address trap can't re-introduce the bug on a future sender.

## Rollout

After merge, on the \`seed-digest-notifications\` Railway service:

\`\`\`
RESEND_FROM_BRIEF=WorldMonitor Brief <brief@worldmonitor.app>
\`\`\`

Domain-level Resend verification already covers any local-part on \`@worldmonitor.app\`, so **no DNS change is needed**. The next digest run after the env flip will send with the new sender.

Recommend also sanity-checking \`RESEND_FROM_EMAIL\` on the \`notification-relay\` service — if it's a bare address there too, alerts will keep showing as \"alert\" in-inbox.

## Out of scope (followup)

\`scripts/proactive-intelligence.mjs\` has the same \`RESEND_FROM_EMAIL\` pattern but is **dormant** — PR #2889 merged the code in 2026-04 but no Railway service was provisioned. It's superseded by the daily digest. Will be removed in a separate cleanup PR.

## Test plan

- [x] \`node --check scripts/seed-digest-notifications.mjs\` passes
- [ ] After Railway env flip, one digest run lands in Gmail/Outlook with friendly name rendered as **\"WorldMonitor Brief\"** (not \"brief\" / \"alert\")
- [ ] \`notification-relay\` still delivers realtime alerts with its existing \`alerts@\` sender (behavior unchanged)