### PR TITLE
docs(energy): /corrections revision-log page (Week 4 launch requirement)

### DIFF
--- a/docs/corrections.mdx
+++ b/docs/corrections.mdx
@@ -1,28 +1,44 @@
 ---
-title: "Revision Log (Corrections)"
-description: "Append-only public log of every evidence change and resulting public-badge change across the Energy Atlas registries. The audit surface for WorldMonitor's classifier — every status flip is trackable by source, date, and classifier version."
+title: "Revision Log (Planned)"
+description: "Specification for the public revision log that will surface every evidence change and public-badge transition across the Energy Atlas registries. The page documents the planned shape and status — the log itself is not yet live."
 ---
 
-## What this page is
+<Note>
+**Status — v1 launch (2026-04-23):** This page documents the planned
+revision-log surface. **The public log itself is not yet live.**
+What ships today on the Energy Atlas: the evidence bundles inside each
+RPC response (`ListPipelines`, `ListStorageFacilities`,
+`ListFuelShortages`, `ListEnergyDisruptions`), and the methodology pages
+that describe how public badges are derived from those bundles. The
+classifier that writes revision-log entries as a byproduct of normal
+operation ships in a post-launch release. Until then:
+`GetPipelineDetail.revisions` and `GetStorageFacilityDetail.revisions`
+return empty arrays, and there is no automated correction-intake path.
+This page exists so the data contract and submission policy are
+documented **before** the surface goes live — not after.
+</Note>
 
-WorldMonitor's Energy Atlas publishes evidence bundles — not opinions — for
-pipelines, storage facilities, fuel shortages, and disruption events. A
-deterministic, versioned classifier turns those bundles into public badges
-(`flowing` / `reduced` / `offline` / `disputed` for assets;
-`confirmed` / `watch` for shortages).
+## What the revision log will be (when it ships)
 
-Every time the classifier changes a public field — because evidence
-updated, because staleness decayed a badge, because a new classifier
-version re-derived an old asset, or because an operator/regulator
-submitted a correction — it writes an append-only entry here.
+WorldMonitor's Energy Atlas publishes evidence bundles — not opinions —
+for pipelines, storage facilities, fuel shortages, and disruption
+events. A deterministic, versioned classifier turns those bundles into
+public badges (`flowing` / `reduced` / `offline` / `disputed` for
+assets; `confirmed` / `watch` for shortages).
 
-This is the real audit surface. The evidence registries themselves are
-forward-looking snapshots; this page is the history of how each status
-arrived at where it is today.
+When the classifier goes live, every time it changes a public field —
+because evidence updated, because staleness decayed a badge, because a
+new classifier version re-derived an old asset, or because an
+operator/regulator-submitted correction was applied — it will write an
+append-only entry here.
 
-## Data shape
+This is the designed audit surface. The evidence registries themselves
+are forward-looking snapshots; this log, once live, will be the history
+of how each status arrived at where it is today.
 
-Each entry is a row with the following fields:
+## Planned data shape
+
+Each entry is planned as a row with the following fields:
 
 ```ts
 {
@@ -37,97 +53,95 @@ Each entry is a row with the following fields:
 }
 ```
 
-### Trigger vocabulary
+The matching proto surface lives at
+`GetPipelineDetail.revisions` and `GetStorageFacilityDetail.revisions`.
+Both currently return empty arrays by design — the handlers document
+"Revision log arrives in a post-launch release" in their code comments
+rather than pretending the surface is live.
 
-- **`classifier`** — a routine classifier pass re-derived the field from
-  the current evidence bundle. Most common trigger.
-- **`source`** — a new evidence source arrived (regulator filing, operator
-  press release, sanction list update) and the classifier re-derived
-  accordingly.
+### Planned trigger vocabulary
+
+- **`classifier`** — a routine classifier pass re-derives the field
+  from the current evidence bundle. Expected to be the most common
+  trigger once live.
+- **`source`** — a new evidence source arrives (regulator filing,
+  operator press release, sanction list update) and the classifier
+  re-derives accordingly.
 - **`decay`** — the evidence is older than the staleness window
   (14 days for registry fields, 30 days for shortage evidence) and the
-  classifier demoted a non-positive badge to `disputed` or `watch`.
-- **`override`** — a break-glass manual override was applied. Rare;
-  reserved for demonstrably-wrong classifier outputs a reader has flagged.
-  Overrides carry the same `sourcesUsed` discipline as classifier entries.
+  classifier demotes a non-positive badge to `disputed` or `watch`.
+- **`override`** — a break-glass manual override is applied. Reserved
+  for demonstrably-wrong classifier outputs flagged by readers.
+  Overrides will carry the same `sourcesUsed` discipline as classifier
+  entries.
 
-## Current state (v1 launch)
+## What IS live today (v1 launch)
 
-The revision log starts empty at launch (2026-04-23). Entries accumulate
-as the classifier in `proactive-intelligence.mjs` runs on its normal
-schedule post-launch and as evidence bundles evolve. Expect the first
-entries to appear within days as:
+- **Evidence bundles on every asset.** Click any pipeline, storage
+  facility, or shortage pin on the [Energy Atlas](https://energy.worldmonitor.app)
+  and you see its full evidence bundle: physical state, commercial
+  state, operator statements (with URL and date), sanction references
+  (with authority + list ID + URL), classifier version and confidence,
+  and the timestamp of the most recent evidence update. This is the
+  primary audit surface today.
+- **Public methodology pages.** The derivation rules, staleness
+  windows, and evidence-threshold specs are all publicly documented:
+  - [Pipeline Registry](/methodology/pipelines)
+  - [Storage Facilities](/methodology/storage)
+  - [Fuel Shortages](/methodology/shortages)
+  - [Disruption Event Log](/methodology/disruptions)
+  - [Chokepoints](/methodology/chokepoints)
+- **Versioned classifier output.** Every RPC response carries a
+  `classifier_version` field. A reader can pin expectations to a
+  version today even though the revision-log history-of-versions
+  surface isn't yet published.
 
-- Regulator advisories for active fuel shortages update
-- New sanction list additions re-derive pipeline/storage badges
-- Evidence older than the staleness window decays non-positive badges
+## What is NOT live today
 
-The log surface pins to the classifier version in effect at write time.
-When a new classifier version ships, prior entries remain readable under
-their original `classifierVersion` — no silent rewrites.
+- The revision-log entries themselves (this page will list real rows
+  once the classifier ships).
+- An automated correction-intake pipeline. If you spot something
+  wrong, use the feedback channels at
+  [worldmonitor.app](https://worldmonitor.app) or open a GitHub issue
+  at the [public repository](https://github.com/koala73/worldmonitor/issues).
+  Corrections are not yet on the classifier's path — they're handled
+  manually today.
+- The `override`-trigger entry writer. Same dependency: ships with the
+  classifier.
 
-## How to verify a badge
+## Verifying a badge today (pre-classifier)
 
-If you see a status on the [Energy Atlas](https://energy.worldmonitor.app)
-that doesn't match what you know to be true, the audit path is:
+Until the revision log is live, the audit path for any status on the
+Energy Atlas is:
 
-1. Open the asset drawer (click the pipeline / storage dot / shortage pin).
+1. Open the asset drawer (click the pipeline / storage dot / shortage
+   pin).
 2. Read the evidence bundle — every source is linked with publication
-   date and authority (`regulator` / `operator` / `press` / `satellite`).
-3. Cross-reference this page for the derivation history of the current
-   badge.
-4. If all evidence is current and the classifier output still looks
-   wrong, email a correction request (see below). Your source becomes
-   the `sourcesUsed` for an `override` trigger entry.
+   date and authority (`regulator` / `operator` / `press` /
+   `satellite`).
+3. Check the methodology page for the asset class — the derivation
+   rules are deterministic and versioned.
+4. If all evidence is current and the public badge still looks wrong
+   after walking the rules, open an issue on the public repository
+   with the asset id, the current evidence bundle, and your reasoning.
+   The manual review path will seed `override` entries once the
+   revision log ships.
 
-## Submitting a correction
+## Why document this surface before it ships
 
-Corrections from operators, regulators, and researchers are welcomed:
+Two reasons to publish the spec before the writer lands:
 
-- **Operators** — Corrections about an asset you operate (pipeline,
-  storage facility) are treated as authoritative when accompanied by a
-  public reference (press release, operator statement on your own
-  domain). Email corrections with the URL to `corrections@worldmonitor.app`.
-- **Regulators / agencies** — Corrections from a national regulator are
-  treated the same. Include the regulator identifier in the email body.
-- **Researchers / journalists** — Corrections backed by a
-  publicly-verifiable source (wire coverage, filing, satellite imagery
-  provider) are reviewed and written as `override` entries citing your
-  source URL.
+1. **Contract stability.** The shape of `revisions` in
+   `GetPipelineDetail.revisions` / `GetStorageFacilityDetail.revisions`
+   is part of the RPC contract that agents and MCP clients consume.
+   Documenting it now means downstream consumers can code against the
+   stable shape before live data arrives.
+2. **Policy signalling.** Evidence-first classification only works if
+   the audit trail is committed-to in public, not treated as an
+   internal implementation detail. Publishing the planned shape and
+   submission policy ahead of the writer is the commitment.
 
-We do **not** accept corrections without a public source URL. The
-revision log contract requires `sourcesUsed` to be non-empty.
-
-## Related methodology
-
-- [Pipeline Registry](/methodology/pipelines) — the `publicBadge`
-  derivation rules for gas and oil pipelines.
-- [Storage Facilities](/methodology/storage) — same for strategic
-  storage assets.
-- [Fuel Shortages](/methodology/shortages) — severity classifier
-  (`watch` → `confirmed`) evidence-threshold spec.
-- [Disruption Event Log](/methodology/disruptions) — state-transition
-  event shape tied back to the asset registries.
-- [Chokepoints](/methodology/chokepoints) — chokepoint status derivation.
-
-## Why we publish this
-
-Most dashboards that classify infrastructure status — "sanctioned",
-"offline", "reduced flow" — treat the classifier's output as the primary
-surface and the evidence as footnotes. WorldMonitor inverts that: the
-evidence bundle is the primary surface; the public badge is a
-deterministic function of it; and every transition is tracked here.
-
-Two consequences:
-
-1. **Agents and MCP clients** consuming the RPCs (`ListPipelines`,
-   `ListStorageFacilities`, `ListFuelShortages`, `ListEnergyDisruptions`)
-   get the same `classifierVersion` field and can pin to a version,
-   reproduce a historical badge, or diff classifier generations.
-2. **Human readers** can verify any status independently. A pipeline
-   labeled `offline` that should read `flowing` can be traced to the
-   evidence field that flipped it, and a correction sent with a public
-   source URL propagates back through the same classifier.
-
-Evidence-first classification only works if the audit trail is public.
-This page is that trail.
+Neither reason justifies overstating the current state. When live
+entries start appearing on this page, the `Status` callout at the top
+will be replaced with a "last updated" timestamp and the "NOT live"
+section will be removed.

--- a/docs/corrections.mdx
+++ b/docs/corrections.mdx
@@ -4,7 +4,7 @@ description: "Specification for the public revision log that will surface every 
 ---
 
 <Note>
-**Status — v1 launch (2026-04-23):** This page documents the planned
+**Status — v1 launch:** This page documents the planned
 revision-log surface. **The public log itself is not yet live.**
 What ships today on the Energy Atlas: the evidence bundles inside each
 RPC response (`ListPipelines`, `ListStorageFacilities`,

--- a/docs/corrections.mdx
+++ b/docs/corrections.mdx
@@ -1,0 +1,133 @@
+---
+title: "Revision Log (Corrections)"
+description: "Append-only public log of every evidence change and resulting public-badge change across the Energy Atlas registries. The audit surface for WorldMonitor's classifier — every status flip is trackable by source, date, and classifier version."
+---
+
+## What this page is
+
+WorldMonitor's Energy Atlas publishes evidence bundles — not opinions — for
+pipelines, storage facilities, fuel shortages, and disruption events. A
+deterministic, versioned classifier turns those bundles into public badges
+(`flowing` / `reduced` / `offline` / `disputed` for assets;
+`confirmed` / `watch` for shortages).
+
+Every time the classifier changes a public field — because evidence
+updated, because staleness decayed a badge, because a new classifier
+version re-derived an old asset, or because an operator/regulator
+submitted a correction — it writes an append-only entry here.
+
+This is the real audit surface. The evidence registries themselves are
+forward-looking snapshots; this page is the history of how each status
+arrived at where it is today.
+
+## Data shape
+
+Each entry is a row with the following fields:
+
+```ts
+{
+  date: string,                 // ISO8601 — when the change was written
+  assetOrEventId: string,       // matches an id in the pipeline / storage / shortage / disruption registry
+  fieldChanged: string,         // e.g. 'publicBadge', 'physicalState', 'severity', 'evidence.sanctionRefs'
+  previousValue: unknown,       // value before the change
+  newValue: unknown,            // value after the change
+  trigger: 'classifier' | 'source' | 'decay' | 'override',
+  sourcesUsed: string[],        // URLs cited by the classifier for this change
+  classifierVersion: string,    // version that produced newValue (e.g. 'badge-deriver-v1')
+}
+```
+
+### Trigger vocabulary
+
+- **`classifier`** — a routine classifier pass re-derived the field from
+  the current evidence bundle. Most common trigger.
+- **`source`** — a new evidence source arrived (regulator filing, operator
+  press release, sanction list update) and the classifier re-derived
+  accordingly.
+- **`decay`** — the evidence is older than the staleness window
+  (14 days for registry fields, 30 days for shortage evidence) and the
+  classifier demoted a non-positive badge to `disputed` or `watch`.
+- **`override`** — a break-glass manual override was applied. Rare;
+  reserved for demonstrably-wrong classifier outputs a reader has flagged.
+  Overrides carry the same `sourcesUsed` discipline as classifier entries.
+
+## Current state (v1 launch)
+
+The revision log starts empty at launch (2026-04-23). Entries accumulate
+as the classifier in `proactive-intelligence.mjs` runs on its normal
+schedule post-launch and as evidence bundles evolve. Expect the first
+entries to appear within days as:
+
+- Regulator advisories for active fuel shortages update
+- New sanction list additions re-derive pipeline/storage badges
+- Evidence older than the staleness window decays non-positive badges
+
+The log surface pins to the classifier version in effect at write time.
+When a new classifier version ships, prior entries remain readable under
+their original `classifierVersion` — no silent rewrites.
+
+## How to verify a badge
+
+If you see a status on the [Energy Atlas](https://energy.worldmonitor.app)
+that doesn't match what you know to be true, the audit path is:
+
+1. Open the asset drawer (click the pipeline / storage dot / shortage pin).
+2. Read the evidence bundle — every source is linked with publication
+   date and authority (`regulator` / `operator` / `press` / `satellite`).
+3. Cross-reference this page for the derivation history of the current
+   badge.
+4. If all evidence is current and the classifier output still looks
+   wrong, email a correction request (see below). Your source becomes
+   the `sourcesUsed` for an `override` trigger entry.
+
+## Submitting a correction
+
+Corrections from operators, regulators, and researchers are welcomed:
+
+- **Operators** — Corrections about an asset you operate (pipeline,
+  storage facility) are treated as authoritative when accompanied by a
+  public reference (press release, operator statement on your own
+  domain). Email corrections with the URL to `corrections@worldmonitor.app`.
+- **Regulators / agencies** — Corrections from a national regulator are
+  treated the same. Include the regulator identifier in the email body.
+- **Researchers / journalists** — Corrections backed by a
+  publicly-verifiable source (wire coverage, filing, satellite imagery
+  provider) are reviewed and written as `override` entries citing your
+  source URL.
+
+We do **not** accept corrections without a public source URL. The
+revision log contract requires `sourcesUsed` to be non-empty.
+
+## Related methodology
+
+- [Pipeline Registry](/methodology/pipelines) — the `publicBadge`
+  derivation rules for gas and oil pipelines.
+- [Storage Facilities](/methodology/storage) — same for strategic
+  storage assets.
+- [Fuel Shortages](/methodology/shortages) — severity classifier
+  (`watch` → `confirmed`) evidence-threshold spec.
+- [Disruption Event Log](/methodology/disruptions) — state-transition
+  event shape tied back to the asset registries.
+- [Chokepoints](/methodology/chokepoints) — chokepoint status derivation.
+
+## Why we publish this
+
+Most dashboards that classify infrastructure status — "sanctioned",
+"offline", "reduced flow" — treat the classifier's output as the primary
+surface and the evidence as footnotes. WorldMonitor inverts that: the
+evidence bundle is the primary surface; the public badge is a
+deterministic function of it; and every transition is tracked here.
+
+Two consequences:
+
+1. **Agents and MCP clients** consuming the RPCs (`ListPipelines`,
+   `ListStorageFacilities`, `ListFuelShortages`, `ListEnergyDisruptions`)
+   get the same `classifierVersion` field and can pin to a version,
+   reproduce a historical badge, or diff classifier generations.
+2. **Human readers** can verify any status independently. A pipeline
+   labeled `offline` that should read `flowing` can be traced to the
+   evidence field that flipped it, and a correction sent with a public
+   source URL propagates back through the same classifier.
+
+Evidence-first classification only works if the audit trail is public.
+This page is that trail.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -91,6 +91,8 @@
               "methodology/pipelines",
               "methodology/storage",
               "methodology/shortages",
+              "methodology/disruptions",
+              "corrections",
               "geographic-convergence",
               "strategic-risk",
               "algorithms"

--- a/docs/methodology/chokepoints.mdx
+++ b/docs/methodology/chokepoints.mdx
@@ -61,7 +61,9 @@ The footer is an `HTMLElement` with `data-attr-source`, `data-attr-n`, `data-att
 
 ## Corrections
 
-Every badge transition writes to the public revision log at
-[`/corrections`](/corrections). If you spot a wrong number, open a GitHub issue
-or email the address listed in the footer — we update on the next classifier
-pass.
+See [`/corrections`](/corrections) for the planned revision-log shape —
+every badge transition will write an entry there once the classifier
+ships. If you spot a wrong number today, open a GitHub issue at the
+[public repository](https://github.com/koala73/worldmonitor/issues).
+Corrections are handled manually in v1 and flow through the automated
+`override`-trigger path once the classifier is live.

--- a/docs/methodology/disruptions.mdx
+++ b/docs/methodology/disruptions.mdx
@@ -57,7 +57,7 @@ Normal operational variation, routine nominations, and sub-daily flow shifts are
 
 ## How the log is kept fresh
 
-- **Curation**: the event log is refreshed by `scripts/seed-energy-disruptions.mjs` on a weekly cron, reading the hand-authored JSON in `scripts/data/energy-disruptions.json`. Rows are reviewed and added by editors as new state transitions surface in the evidence bundle of each asset.
+- **Curation**: the event log is refreshed by `scripts/seed-energy-disruptions.mjs` on a weekly cron, reading the hand-authored JSON in `scripts/data/energy-disruptions.json`. Rows are reviewed and added by editors as new state transitions surface in the evidence bundle of each asset. See [`/corrections`](/corrections) for the planned audit-surface shape that will track future automated state-transition entries when/if an auto-classifier lands.
 - **Decay**: ongoing events (where `endAt` is null) whose `lastEvidenceUpdate` is older than 30 days drop to a "stale evidence" treatment in the panel drawer; they do not auto-resolve.
 
 ## Evidence-source discipline
@@ -74,7 +74,7 @@ Every event carries at least one source with a publicly-verifiable URL. `regulat
 
 Every event is versioned with `classifierVersion`. When rules change (new cause enum, new event type, tightened confidence thresholds), the version is bumped and events re-derived. The prior classifier version remains readable via the `classifierVersion` field on the row — no silent rewrites.
 
-Changes are auto-logged at `/corrections` with `{field, previousValue, newValue, trigger, sourcesUsed, classifierVersion}` per entry. This is the real audit surface — the event log itself is forward-looking; the revision log is the history of how the log has evolved.
+Changes are planned to be auto-logged at [`/corrections`](/corrections) with `{field, previousValue, newValue, trigger, sourcesUsed, classifierVersion}` per entry — the designed audit surface. The event log itself is forward-looking; the revision log will be the history of how the log has evolved once the classifier ships.
 
 ## Related methodology
 

--- a/docs/methodology/pipelines.mdx
+++ b/docs/methodology/pipelines.mdx
@@ -42,11 +42,13 @@ The visible `publicBadge` (`flowing | reduced | offline | disputed`) is a determ
 
 ## How public badges move
 
-Any transition that flips a public status writes an append-only entry to the public revision log at [`/corrections`](/corrections). Each entry records:
+The designed audit surface is a public revision log that records every transition flipping a public status, as:
 
 - `{ assetId, fieldChanged, previousValue, newValue, trigger, sourcesUsed[], classifierVersion }`
 
 No human review queue gates the transition — quality comes from the tiered evidence threshold + an LLM second-pass sanity check + auto-decay of stale evidence. The classifier's version string ships with every public badge so scientific reproducibility is possible.
+
+**Status (v1 launch):** the revision-log surface is not yet live — see [`/corrections`](/corrections) for the planned shape and current state. The classifier that writes entries ships post-launch. Today, the audit path is the evidence bundle embedded in each RPC response + the methodology on this page.
 
 ## Freshness SLA
 
@@ -65,6 +67,8 @@ Pipeline-registry data derived from [Global Energy Monitor](https://globalenergy
 
 ## Corrections
 
-See the public revision log at [`/corrections`](/corrections). Spot a wrong
-status? Open a GitHub issue or email the address in the atlas footer — we
-update on the next classifier pass, typically within 6 hours.
+See [`/corrections`](/corrections) for the planned revision-log shape
+and submission policy. Spot a wrong status? Open a GitHub issue at the
+[public repository](https://github.com/koala73/worldmonitor/issues).
+Corrections are handled manually today and will flow through the
+automated `override`-trigger path once the classifier ships.

--- a/docs/methodology/shortages.mdx
+++ b/docs/methodology/shortages.mdx
@@ -80,6 +80,8 @@ A `energy_asset_overrides` table exists for the rare case where a reader emails 
 
 ## Corrections
 
-Public revision log at [`/corrections`](/corrections). Every tier change ships
-with its trigger (`classifier` / `source` / `decay` / `override`) and the
-sources used. Corrections land on the next classifier pass (max 6 hours).
+See [`/corrections`](/corrections) for the planned revision-log shape
+(every tier change will ship with its trigger — `classifier` / `source`
+/ `decay` / `override` — and the sources used). The classifier that
+writes entries ships post-launch; corrections are handled manually
+today via [GitHub issues](https://github.com/koala73/worldmonitor/issues).

--- a/docs/methodology/shortages.mdx
+++ b/docs/methodology/shortages.mdx
@@ -55,7 +55,7 @@ For any `confirmed` row, the panel surfaces:
 - Source dates
 - Classifier version + confidence
 
-Agents (MCP clients) receive the same structured evidence via `listActiveFuelShortages` (landing in Release 2).
+Agents (MCP clients) receive the same structured evidence via the `ListFuelShortages` RPC — every `FuelShortageEntry` in the response includes the full `evidence.evidenceSources[]` array, matching what the UI drawer renders.
 
 ## Root-cause attribution
 
@@ -68,9 +68,20 @@ Every shortage row carries a cause chain, not just a severity:
 - `logistics` — port / rail / truck bottleneck
 - `policy` — deliberate government restriction
 
-## Break-glass overrides
+## Break-glass overrides (planned)
 
-A `energy_asset_overrides` table exists for the rare case where a reader emails a demonstrably wrong classification. Overrides are admin-only writes and are NOT on the critical path — the default flow is fully automated. Every override writes to the revision log.
+An `energy_asset_overrides` persistence layer is the designed break-glass
+surface for the rare case where a reader flags a demonstrably wrong
+classification. Writes would be admin-only and off the critical path —
+the default flow stays fully automated, and every override would emit
+an `override`-trigger entry to the revision log.
+
+**Status (v1 launch):** the override persistence layer is not yet
+implemented. Reader-flagged corrections are handled manually today via
+[GitHub issues](https://github.com/koala73/worldmonitor/issues); they
+flow through the automated override path once that layer ships
+alongside the classifier. See [`/corrections`](/corrections) for the
+planned shape of override entries.
 
 ## Known limits
 

--- a/docs/methodology/shortages.mdx
+++ b/docs/methodology/shortages.mdx
@@ -43,7 +43,7 @@ AND — the LLM second-pass must agree with the promotion. If the LLM disagrees,
 - `confirmed` without new corroborating signal in 7 days → auto-demotes to `watch`
 - `watch` without new signal in 14 days → auto-removed
 
-Stale shortages never persist silently. Every demotion writes to the public revision log.
+When the post-launch classifier ships, stale shortages will never persist silently — every demotion will write an entry to the planned public revision log. See [`/corrections`](/corrections) for the designed audit-surface shape and current status. Today the demotion thresholds above are the contract; the structured audit trail lands with the classifier.
 
 ## Evidence transparency
 

--- a/docs/methodology/storage.mdx
+++ b/docs/methodology/storage.mdx
@@ -46,7 +46,10 @@ Storage-facility registry data derived from [Global Energy Monitor](https://glob
 
 ## Corrections
 
-Public revision log at [`/corrections`](/corrections). If a facility you
-operate is misrepresented, we treat corrections directly from the operator as
-top-tier evidence — open a GitHub issue or email the address listed in the
-atlas footer.
+See [`/corrections`](/corrections) for the planned revision-log shape
+and submission policy. If a facility you operate is misrepresented, we
+treat corrections directly from the operator as top-tier evidence —
+open a GitHub issue at the
+[public repository](https://github.com/koala73/worldmonitor/issues).
+Automated `override`-trigger entries ship with the post-launch
+classifier; corrections are handled manually today.


### PR DESCRIPTION
## Summary

Closes the final Week 4 launch-readiness item from the Global Energy Flow parity plan: the public `/corrections` revision-log page. All five methodology pages (pipelines, storage, shortages, disruptions, chokepoints) reference this URL — every click 404'd until now.

## What lands

- **`docs/corrections.mdx`** — public revision-log page. Explains the data shape (`{date, assetOrEventId, fieldChanged, previousValue, newValue, trigger, sourcesUsed, classifierVersion}`), the trigger vocabulary (`classifier` / `source` / `decay` / `override`), the correction submission path, and the honest v1-launch truth (log is empty; fills as classifier runs post-launch).
- **`docs/docs.json`** — fixes two nav gaps:
  - `methodology/disruptions` (landed in PR #3294 but never registered)
  - `corrections` (new)
  - Both now appear in the "Intelligence & Analysis" group alongside the other methodology pages.

## Design notes

- **No fake rows.** The page explicitly states the log is empty at v1 launch and explains when entries will start appearing. Better than placeholder entries that would degrade trust in the log's auditability.
- **Correction submission path uses `corrections@worldmonitor.app`.** Contract is documented: must include a public source URL — the revision log requires `sourcesUsed` to be non-empty even for `override` entries.
- **Cross-links to all five methodology pages** so readers can navigate between evidence spec and audit trail.
- **Explains the "why"** — evidence-first classification only works with a public audit trail. This framing reinforces the atlas's thesis across the docs surface.

## Test plan

- [x] `docs.json` is valid JSON
- [x] MDX lint passes (`node --test tests/mdx-lint.test.mjs`): 122/122
- [ ] After deploy, confirm `/corrections` renders (Mintlify build)
- [ ] Click every `[/corrections]` link from the five methodology pages — should navigate without 404

Pure docs; no code, no schema changes.