### PR TITLE
chore: 301 redirect /security.txt → /.well-known/security.txt (RFC 9116)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,8 @@
   "ignoreCommand": "bash scripts/vercel-ignore.sh",
   "crons": [],
   "redirects": [
-    { "source": "/docs", "destination": "/docs/documentation", "permanent": false }
+    { "source": "/docs", "destination": "/docs/documentation", "permanent": false },
+    { "source": "/security.txt", "destination": "/.well-known/security.txt", "permanent": true }
   ],
   "rewrites": [
     { "source": "/docs/:match*", "destination": "https://worldmonitor.mintlify.dev/docs/:match*" },


### PR DESCRIPTION
## Summary
- Legacy `/security.txt` was returning the SPA shell (`text/html` 200) because it falls through to the catch-all rewrite that points unmatched paths at `/index.html`.
- RFC 9116 §3 says the legacy path should 301 to `/.well-known/security.txt`.
- Adds a single `permanent: true` redirect entry to `vercel.json`.

## Why now
Follow-up from blocker #3322 (apex-redirect fix). Surfaced while verifying `curl -sI https://worldmonitor.app/security.txt` returned `text/html` instead of the expected `text/plain`.

## Test plan
- [ ] Deploy preview: `curl -sI <preview>/security.txt` returns `HTTP/2 301` with `location: /.well-known/security.txt`.
- [ ] `curl -sI <preview>/.well-known/security.txt` still returns `200 text/plain` (unchanged).
- [ ] Post-merge prod: same two checks against `https://worldmonitor.app` and `https://www.worldmonitor.app`.

Refs #3306, #3322.