### PR TITLE
feat(agent-readiness): Content-Signal directive in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,9 @@
 # World Monitor - protect API routes from crawlers
+
+# AI content-usage preferences (contentsignals.org draft RFC).
+# Origin-wide directive, NOT scoped under User-agent per the spec.
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+
 User-agent: *
 Allow: /
 Allow: /api/story


### PR DESCRIPTION
## Summary
Adds a `Content-Signal:` directive to `public/robots.txt` per the [contentsignals.org](https://contentsignals.org/) draft RFC, declaring AI content-usage preferences at the origin level.

```
Content-Signal: ai-train=no, search=yes, ai-input=yes
```

## Rationale per value
- **`ai-train=no`** — we don't consent to having our curated panels ingested into foundation-model training corpora without a commercial agreement.
- **`search=yes`** — we want search engines to index us for discovery and referral traffic.
- **`ai-input=yes`** — we want live agent retrieval (Perplexity, ChatGPT browsing, Claude web) because that's the exact posture of the broader agent-readiness epic.

## Spec notes
The directive is origin-wide — intentionally NOT scoped under `User-agent: *`, per the draft spec. The leading comments explain this for future editors.

## Test plan
- [ ] Deploy preview: `curl -s <preview>/robots.txt` includes the `Content-Signal:` line.
- [ ] Post-merge prod: `curl -s https://worldmonitor.app/robots.txt` and `https://www.worldmonitor.app/robots.txt` both include it (apex is now served directly post-#3322).
- [ ] Re-run isitagentready.com scan — Content Signals check flips green.

Closes #3307. Refs #3306, #3322.