### PR TITLE
feat(agent-readiness): publish MCP Server Card (SEP-1649) at /.well-known/mcp/server-card.json

### DIFF
--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,0 +1,21 @@
+{
+  "serverInfo": {
+    "name": "worldmonitor",
+    "version": "1.0"
+  },
+  "transport": {
+    "type": "streamableHttp",
+    "endpoint": "https://worldmonitor.app/mcp"
+  },
+  "capabilities": {
+    "tools": true,
+    "resources": false,
+    "prompts": false
+  },
+  "authentication": {
+    "type": "oauth2",
+    "authorization_servers": ["https://api.worldmonitor.app"],
+    "resource": "https://api.worldmonitor.app",
+    "scopes": ["mcp"]
+  }
+}


### PR DESCRIPTION
## Summary
Publishes the static MCP Server Card at `public/.well-known/mcp/server-card.json`, pointing at the existing MCP server (`api/mcp.ts`, public endpoint `https://worldmonitor.app/mcp`, protocol `2025-03-26`).

## What's in the card
- `serverInfo`: `worldmonitor` v1.0 (matches `api/mcp.ts`)
- `transport`: `streamableHttp` at `https://worldmonitor.app/mcp`
- `capabilities`: `tools=true`, `resources=false`, `prompts=false` (matches the current tool-only registry)
- `authentication`: mirrors `/.well-known/oauth-protected-resource` — `oauth2`, `authorization_servers=["https://api.worldmonitor.app"]`, `resource="https://api.worldmonitor.app"`, `scopes=["mcp"]`

## Deliberately omitted
No `$schema` field. SEP-1649 is still in draft ([modelcontextprotocol/modelcontextprotocol#2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127)) — adding a schema URL now would advertise a non-existent location. Add on a follow-up PR once the spec merges.

## Drift invariant
`authentication.resource`, `authorization_servers`, and `scopes` in this file MUST stay in lockstep with `public/.well-known/oauth-protected-resource`. Any edit to one should touch both in the same commit.

## Test plan
- [ ] Deploy preview: `curl -s <preview>/.well-known/mcp/server-card.json | jq .` returns valid JSON with the expected shape.
- [ ] Content-Type is `application/json` (Vercel auto-detects from extension; generic `/.well-known/(.*)` CORS/cache headers apply).
- [ ] Values match `/.well-known/oauth-protected-resource` on the three shared fields.
- [ ] Post-merge prod: same checks at `https://worldmonitor.app/.well-known/mcp/server-card.json`.
- [ ] Re-run isitagentready.com scan — MCP Server Card check flips green.

Closes #3311. Refs #3306.