### PR TITLE
chore(lint): exclude docs/brainstorms and docs/ideation from lint:md

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:rate-limit-policies": "node scripts/enforce-rate-limit-policies.mjs",
     "lint:unicode": "node scripts/check-unicode-safety.mjs",
     "lint:unicode:staged": "node scripts/check-unicode-safety.mjs --staged",
-    "lint:md": "markdownlint-cli2 '**/*.md' '!**/node_modules/**' '!.agent/**' '!.agents/**' '!.claude/**' '!.factory/**' '!.windsurf/**' '!skills/**' '!docs/internal/**' '!docs/Docs_To_Review/**' '!todos/**' '!docs/plans/**'",
+    "lint:md": "markdownlint-cli2 '**/*.md' '!**/node_modules/**' '!.agent/**' '!.agents/**' '!.claude/**' '!.factory/**' '!.windsurf/**' '!skills/**' '!docs/internal/**' '!docs/Docs_To_Review/**' '!todos/**' '!docs/plans/**' '!docs/brainstorms/**' '!docs/ideation/**'",
     "version:sync": "node scripts/sync-desktop-version.mjs",
     "version:check": "node scripts/sync-desktop-version.mjs --check",
     "dev": "vite",


### PR DESCRIPTION
## Why this PR?

`lint:md` already excludes `docs/plans/**` (gitignored). It was missing the parallel exclusions for `docs/brainstorms/**` and `docs/ideation/**`, which are also gitignored. Result: any developer writing a local brainstorm or ideation doc during a session has that doc flagged by the pre-push markdown linter on unrelated feature branches, blocking pushes until the untracked doc is either deleted or scrubbed to markdownlint's satisfaction.

Observed this session when shipping #3330: had to delete a local brainstorm doc from the worktree to unblock the push even though it was never going to be committed.

## Change

One-line edit to `package.json`'s `lint:md` script:

```
+ '!docs/brainstorms/**' '!docs/ideation/**'
```

## What this does NOT change

- Nothing in the repo's shipping code
- No markdown files currently tracked are affected (they're not in the newly excluded dirs)
- `docs/internal/**`, `docs/Docs_To_Review/**`, `todos/**`, `docs/plans/**` stay excluded as before
- Gitignore unchanged

## Verification

```
$ npm run lint:md
Finding: **/*.md ... !docs/brainstorms/** !docs/ideation/**
Linting: 46 file(s)
Summary: 0 error(s)
```

Before: 49 files. After: 46 files (3 untracked local-only docs correctly skipped). Zero errors in both cases, no tracked file changes its lint outcome.

## Test plan

- [x] `npm run lint:md` — 46 files, 0 errors
- [x] Exclusion list now matches the `docs/*` entries in `.gitignore`