### PR TITLE
fix(deps): promote `yaml` to top-level dep to unblock SWF seeder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "topojson-client": "^3.1.0",
         "uqr": "^0.1.2",
         "ws": "^8.19.0",
+        "yaml": "^2.8.3",
         "youtubei.js": "^16.0.1"
       },
       "devDependencies": {
@@ -24022,7 +24023,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "topojson-client": "^3.1.0",
     "uqr": "^0.1.2",
     "ws": "^8.19.0",
+    "yaml": "^2.8.3",
     "youtubei.js": "^16.0.1"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- Railway `seed-bundle-resilience-recovery` failed at 06:36:18 UTC on its first post-#3328 tick with `ERR_MODULE_NOT_FOUND: Cannot find package 'yaml' imported from /app/shared/swf-manifest-loader.mjs`.
- `scripts/shared/swf-manifest-loader.mjs` (landed in #3319) imports `parse` from `yaml` to read `docs/methodology/swf-classification-manifest.yaml`.
- `yaml` was only present locally as a transitive peer of other deps; Railway's production install doesn't land peer-only packages in `/app/node_modules`.
- Promoting `yaml ^2.8.3` (the already-resolved version in package-lock) from transitive peer to a direct `dependencies` entry.

## Why this is the right fix
- Alternatives considered and rejected:
  - **Convert manifest to JSON**: loses YAML comments that document the classification rationale — the whole point of the manifest being human-auditable.
  - **Hand-parse YAML**: a real library is 200 lines vs dozens of edge cases (multiline rationale strings, anchors, etc.) we'd silently get wrong.
- `yaml` is an ISC-licensed 30KB dep already present in our tree as a peer of `prettier` et al; promoting it is a no-op for local dev and a one-line fix for Railway.

## Test plan
- [x] `node --test --import tsx/esm tests/swf-classification-manifest.test.mjs tests/seed-sovereign-wealth.test.mjs` — 53/53 pass
- [ ] CI: typecheck + unit + biome + mintlify
- [ ] Post-merge: next Railway `seed-bundle-resilience-recovery` tick should publish `resilience:recovery:sovereign-wealth:v1` per-country keys + `seed-meta:resilience:recovery:sovereign-wealth`