### PR TITLE
fix(idb-cleanup): swallow TransactionInactiveError in idempotent cursor loops

### DIFF
--- a/src/services/persistent-cache.ts
+++ b/src/services/persistent-cache.ts
@@ -82,9 +82,13 @@ async function deleteFromIndexedDbByPrefix(prefix: string): Promise<void> {
     request.onsuccess = () => {
       const cursor = request.result;
       if (!cursor) return;
-
-      store.delete(cursor.primaryKey);
-      cursor.continue();
+      // iOS Safari kills in-flight IDB transactions when the tab backgrounds;
+      // prefix-invalidation is idempotent so swallow TransactionInactiveError
+      // and let the next invalidation call resume.
+      try {
+        store.delete(cursor.primaryKey);
+        cursor.continue();
+      } catch { /* tx died mid-iteration */ }
     };
     request.onerror = () => reject(request.error);
   });

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -214,7 +214,10 @@ export async function cleanOldSnapshots(): Promise<void> {
       const request = store.index('by_time').openCursor(IDBKeyRange.upperBound(cutoff));
       request.onsuccess = () => {
         const cursor = request.result;
-        if (cursor) { cursor.delete(); cursor.continue(); }
+        if (!cursor) return;
+        // iOS Safari kills in-flight IDB transactions when the tab backgrounds;
+        // cleanup is idempotent so swallow TransactionInactiveError and resume next run.
+        try { cursor.delete(); cursor.continue(); } catch { /* tx died mid-cleanup */ }
       };
       void tx;
     },


### PR DESCRIPTION
## Why this PR?

Closes Sentry [WORLDMONITOR-NX](https://elie-habib.sentry.io/issues/7435755260/). iOS Safari kills in-flight IDB transactions when the tab backgrounds, and our idle detector (`[App] User idle - pausing animations to save resources`) fires right before the browser suspends. Any `cursor.delete()` / `cursor.continue()` mid-iteration then throws `TransactionInactiveError` synchronously inside the `onsuccess` handler.

## Summary

- Wrap cursor iteration in `src/services/storage.ts:cleanOldSnapshots` with try/catch — cleanup is idempotent, so failing silently resumes on the next run.
- Same treatment for `src/services/persistent-cache.ts:deleteFromIndexedDbByPrefix` — prefix-invalidation is idempotent by design.
- No filter change: `main.ts` `beforeSend` intentionally keeps first-party `TransactionInactiveError` surfaced (see line 415 comment re: `storage.ts` / `persistent-cache.ts` / `vector-db.ts`). Source-level swallow is the correct layer — we still want the signal if a non-cleanup caller hits it.

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` (exit 0, warnings-only pre-existing)
- [x] `npm run test:data` (6594/6594 pass)
- [x] `node --test tests/edge-functions.test.mjs` (176/176 pass)
- [x] `npm run lint:md`, `npm run version:check`
- [ ] Ship & verify WORLDMONITOR-NX does not reopen in `inNextRelease`