### PR TITLE
chore(railway): force rebuild of seed bundles after infra-error build failure

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// rebuild-trigger: 2026-04-23
 
 import { readFileSync, existsSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';


### PR DESCRIPTION
## Summary

Four Railway seed-bundle services failed their last deploy with a Railway orchestrator / Temporal infrastructure error:

```
dial tcp 10.10.10.50:7233: cannot assign requested address
```

Affected services:

- `seed-bundle-macro`
- `seed-bundle-derived-signals`
- `seed-bundle-static-ref`
- `seed-fear-greed`

Redeploy on a failed Railway service replays the last **successful** image, not the failed one, so a fresh commit on `main` is needed to trigger a new build off current source.

This PR adds a single-line comment to `scripts/_seed-utils.mjs` (imported by every seeder) as a no-op rebuild trigger. No logic changes.

```diff
 #!/usr/bin/env node
+// rebuild-trigger: 2026-04-23
 
 import { readFileSync, existsSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
```

## Test plan

- [ ] Verify the four Railway seed-bundle services rebuild and deploy cleanly after merge