### PR TITLE
fix(agent-readiness): align OAuth resource with public MCP origin

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -853,7 +853,7 @@ export default async function handler(req: Request): Promise<Response> {
       // Bearer token present but unresolvable — expired or invalid UUID
       return new Response(
         JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Invalid or expired OAuth token. Re-authenticate via /oauth/token.' } }),
-        { status: 401, headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer realm="worldmonitor", error="invalid_token", resource_metadata="https://api.worldmonitor.app/.well-known/oauth-protected-resource"', ...corsHeaders } }
+        { status: 401, headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer realm="worldmonitor", error="invalid_token", resource_metadata="https://worldmonitor.app/.well-known/oauth-protected-resource"', ...corsHeaders } }
       );
     }
   } else {
@@ -861,7 +861,7 @@ export default async function handler(req: Request): Promise<Response> {
     if (!candidateKey) {
       return new Response(
         JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Authentication required. Use OAuth (/oauth/token) or pass your API key via X-WorldMonitor-Key header.' } }),
-        { status: 401, headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer realm="worldmonitor", resource_metadata="https://api.worldmonitor.app/.well-known/oauth-protected-resource"', ...corsHeaders } }
+        { status: 401, headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': 'Bearer realm="worldmonitor", resource_metadata="https://worldmonitor.app/.well-known/oauth-protected-resource"', ...corsHeaders } }
       );
     }
     const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);

--- a/docs/mcp.mdx
+++ b/docs/mcp.mdx
@@ -13,12 +13,12 @@ The MCP server is gated behind **PRO**. Free-tier users see a 401 at the OAuth s
 
 | Endpoint | Purpose |
 |----------|---------|
-| `https://api.worldmonitor.app/api/mcp` | JSON-RPC server (Streamable HTTP transport, protocol `2025-03-26`) |
+| `https://worldmonitor.app/mcp` | JSON-RPC server (Streamable HTTP transport, protocol `2025-03-26`) |
 | `https://api.worldmonitor.app/api/oauth/register` | Dynamic Client Registration (RFC 7591) |
 | `https://api.worldmonitor.app/api/oauth/authorize` | OAuth 2.1 authorization endpoint (PKCE required) |
 | `https://api.worldmonitor.app/api/oauth/token` | Token endpoint (authorization_code + refresh_token) |
 | `https://api.worldmonitor.app/.well-known/oauth-authorization-server` | AS metadata (RFC 8414) |
-| `https://api.worldmonitor.app/.well-known/oauth-protected-resource` | Resource server metadata (RFC 9728) |
+| `https://worldmonitor.app/.well-known/oauth-protected-resource` | Resource server metadata (RFC 9728) |
 
 Protocol version: `2025-03-26`. Server identifier: `worldmonitor` v1.0.
 
@@ -69,7 +69,7 @@ Exceeding returns `429` with a `Retry-After` header.
 {
   "mcpServers": {
     "worldmonitor": {
-      "url": "https://api.worldmonitor.app/api/mcp"
+      "url": "https://worldmonitor.app/mcp"
     }
   }
 }
@@ -82,7 +82,7 @@ Claude Desktop handles the OAuth flow automatically on first connection.
 Add via **Settings → Connectors → Add custom connector**:
 
 - Name: `WorldMonitor`
-- URL: `https://api.worldmonitor.app/api/mcp`
+- URL: `https://worldmonitor.app/mcp`
 
 ### Cursor
 
@@ -92,7 +92,7 @@ Add via **Settings → Connectors → Add custom connector**:
 {
   "mcpServers": {
     "worldmonitor": {
-      "url": "https://api.worldmonitor.app/api/mcp"
+      "url": "https://worldmonitor.app/mcp"
     }
   }
 }
@@ -101,7 +101,7 @@ Add via **Settings → Connectors → Add custom connector**:
 ### MCP Inspector (debugging)
 
 ```bash
-npx @modelcontextprotocol/inspector https://api.worldmonitor.app/api/mcp
+npx @modelcontextprotocol/inspector https://worldmonitor.app/mcp
 ```
 
 ## Tool catalog
@@ -173,13 +173,13 @@ Server-side with a direct API key — send it as `X-WorldMonitor-Key`, **not** a
 WM_KEY="wm_live_..."
 
 # 1. List tools
-curl -s https://api.worldmonitor.app/api/mcp \
+curl -s https://worldmonitor.app/mcp \
   -H "X-WorldMonitor-Key: $WM_KEY" \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 
 # 2. Call a cache tool
-curl -s https://api.worldmonitor.app/api/mcp \
+curl -s https://worldmonitor.app/mcp \
   -H "X-WorldMonitor-Key: $WM_KEY" \
   -H 'Content-Type: application/json' \
   -d '{

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -15,7 +15,7 @@
   "authentication": {
     "type": "oauth2",
     "authorization_servers": ["https://api.worldmonitor.app"],
-    "resource": "https://api.worldmonitor.app",
+    "resource": "https://worldmonitor.app",
     "scopes": ["mcp"]
   }
 }

--- a/public/.well-known/oauth-protected-resource
+++ b/public/.well-known/oauth-protected-resource
@@ -1,5 +1,5 @@
 {
-  "resource": "https://api.worldmonitor.app",
+  "resource": "https://worldmonitor.app",
   "authorization_servers": ["https://api.worldmonitor.app"],
   "bearer_methods_supported": ["header"],
   "scopes_supported": ["mcp"]

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -376,6 +376,75 @@ describe('agent readiness: api-catalog + openapi build', () => {
   });
 });
 
+// The MCP endpoint and OAuth protected-resource metadata must share an
+// origin — a scanner or client that enters from a mismatched host sees
+// "this server says its resource lives on a different origin", which
+// violates RFC 9728 and breaks the PRM discovery flow in strict clients.
+// The resource/authorization-server split is intentional: apex serves
+// the MCP transport + resource metadata, api.worldmonitor.app serves
+// the OAuth endpoints. Keep them in lockstep — all resource-side
+// pointers (MCP server-card transport.endpoint, MCP server-card
+// authentication.resource, oauth-protected-resource.resource, and every
+// WWW-Authenticate resource_metadata pointer emitted from api/mcp.ts)
+// must agree, while authorization_servers stays on the api host.
+describe('agent readiness: MCP/OAuth origin alignment', () => {
+  const mcpCard = JSON.parse(
+    readFileSync(resolve(__dirname, '../public/.well-known/mcp/server-card.json'), 'utf-8')
+  );
+  const oauthMeta = JSON.parse(
+    readFileSync(resolve(__dirname, '../public/.well-known/oauth-protected-resource'), 'utf-8')
+  );
+
+  const mcpEndpointOrigin = new URL(mcpCard.transport.endpoint).origin;
+  const resourceOrigin = new URL(oauthMeta.resource).origin;
+
+  it('MCP transport.endpoint origin matches OAuth metadata resource origin', () => {
+    assert.equal(
+      mcpEndpointOrigin,
+      resourceOrigin,
+      'MCP transport.endpoint and OAuth resource must share the same origin'
+    );
+  });
+
+  it('MCP card authentication.resource equals OAuth metadata resource exactly', () => {
+    assert.equal(
+      mcpCard.authentication.resource,
+      oauthMeta.resource,
+      'MCP card authentication.resource must equal OAuth metadata resource'
+    );
+  });
+
+  it('authorization_servers stay on api.worldmonitor.app (intentional resource/AS split)', () => {
+    assert.ok(
+      Array.isArray(oauthMeta.authorization_servers) && oauthMeta.authorization_servers.length > 0,
+      'oauth-protected-resource.authorization_servers must be a non-empty array'
+    );
+    for (const s of oauthMeta.authorization_servers) {
+      assert.equal(
+        new URL(s).origin,
+        'https://api.worldmonitor.app',
+        `authorization_servers entry must stay on api.worldmonitor.app, got: ${s}`
+      );
+    }
+  });
+
+  it('api/mcp.ts WWW-Authenticate resource_metadata pointers share origin with oauth-protected-resource', () => {
+    const mcpSource = readFileSync(resolve(__dirname, '../api/mcp.ts'), 'utf-8');
+    const matches = [...mcpSource.matchAll(/resource_metadata="([^"]+)"/g)];
+    assert.ok(
+      matches.length > 0,
+      'api/mcp.ts should emit resource_metadata pointers in its 401 WWW-Authenticate headers'
+    );
+    for (const [, url] of matches) {
+      assert.equal(
+        new URL(url).origin,
+        resourceOrigin,
+        `api/mcp.ts resource_metadata pointer ${url} must share origin with oauth-protected-resource`
+      );
+    }
+  });
+});
+
 // PR history: #3204 / #3206 forced the resvg linux-x64-gnu native
 // binding into the carousel function via vercel.json
 // `functions.includeFiles`. That entire workaround became unnecessary

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -5,7 +5,7 @@ const originalFetch = globalThis.fetch;
 const originalEnv = { ...process.env };
 
 const VALID_KEY = 'wm_test_key_123';
-const BASE_URL = 'https://api.worldmonitor.app/mcp';
+const BASE_URL = 'https://worldmonitor.app/mcp';
 
 function makeReq(method = 'POST', body = null, headers = {}) {
   return new Request(BASE_URL, {


### PR DESCRIPTION
## Summary
Fixes the isitagentready.com OAuth Protected Resource check, which was failing with "JSON missing or invalid 'resource' field, or origin mismatch". The scanner probes `https://worldmonitor.app/.well-known/oauth-protected-resource` and enforces that the declared `resource` matches the scanned origin (per the spirit of RFC 9728 §3 — the metadata document should be retrievable from the resource's own well-known path).

## Root cause
Our metadata declared `resource: "https://api.worldmonitor.app"` while the MCP endpoint is actually publicly served at `https://worldmonitor.app/mcp` (vercel.json rewrites `/mcp → /api/mcp` on every attached domain; the MCP card's `transport.endpoint` already points at apex).

Scanned origin (`worldmonitor.app`) ≠ declared resource (`api.worldmonitor.app`) → rejection.

## Fix
Flip `resource` to `https://worldmonitor.app` in three places:
- `public/.well-known/oauth-protected-resource`
- `public/.well-known/mcp/server-card.json` (`authentication.resource`)
- `api/mcp.ts` (two `WWW-Authenticate: ... resource_metadata="..."` strings)

`authorization_servers` intentionally stays `https://api.worldmonitor.app` — that subdomain hosts `/oauth/{authorize,token,register}` and `/.well-known/oauth-authorization-server`. RFC 9728 explicitly permits AS and resource at different origins.

## No-risk analysis
Verified that no server-side code validates tokens against the old `resource` value:
- `api/oauth/token.js`, `api/oauth/authorize.js` — no `resource` / `aud` references.
- `api/mcp.ts` — only uses the resource_metadata pointer to direct clients; no aud enforcement.

Existing MCP clients that cached the old value will re-discover on next connection attempt (per standard OAuth discovery flow) and pick up the new value.

## Test plan
- [ ] Preview deploy: `curl -s https://<preview>/.well-known/oauth-protected-resource | jq .resource` returns `"https://worldmonitor.app"`.
- [ ] Preview deploy: `curl -s https://<preview>/.well-known/mcp/server-card.json | jq .authentication.resource` returns `"https://worldmonitor.app"`.
- [ ] Preview deploy: `curl -sI -X POST https://<preview>/mcp | grep -i www-authenticate` shows the new resource_metadata URL.
- [ ] Post-merge prod: same three checks at `https://worldmonitor.app`.
- [ ] Re-run isitagentready.com scan — OAuth Protected Resource check flips green.

Refs epic #3306.