### PR TITLE
fix(ci): vercel-ignore prefers merge-base over VERCEL_GIT_PREVIOUS_SHA on previews

### DIFF
--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -17,11 +17,25 @@ fi
 # Skip preview deploys that aren't tied to a pull request
 [ -z "$VERCEL_GIT_PULL_REQUEST_ID" ] && exit 0
 
-# Resolve comparison base: prefer VERCEL_GIT_PREVIOUS_SHA, fall back to merge-base with main
-# (empty/invalid PREVIOUS_SHA caused false "build" on PRs that only touch scripts/)
-COMPARE_SHA="$VERCEL_GIT_PREVIOUS_SHA"
-if [ -z "$COMPARE_SHA" ] || ! git cat-file -e "$COMPARE_SHA" 2>/dev/null; then
-  COMPARE_SHA=$(git merge-base HEAD origin/main 2>/dev/null)
+# Resolve comparison base: prefer `merge-base HEAD origin/main` (the SHA
+# where this PR branched off main), fall back to VERCEL_GIT_PREVIOUS_SHA.
+#
+# Why this ordering: on a PR branch's FIRST push, Vercel has historically
+# set VERCEL_GIT_PREVIOUS_SHA to values that make the path-diff come back
+# empty (the same SHA as HEAD, or a parent that sees no net change),
+# causing "Canceled by Ignored Build Step" on PRs that genuinely touch
+# web paths (PR #3346 incident: four web-relevant files changed, skipped
+# anyway). merge-base is the stable truth: "everything on this PR since
+# it left main", which is always a superset of any single push and is
+# what the reviewer actually needs a preview for.
+#
+# PREVIOUS_SHA stays as the fallback for the rare shallow-clone edge case
+# where `origin/main` isn't in Vercel's clone and merge-base returns
+# empty. This is the opposite priority from the main-branch branch above
+# (line 6), which correctly wants PREVIOUS_SHA = the last deployed commit.
+COMPARE_SHA=$(git merge-base HEAD origin/main 2>/dev/null)
+if [ -z "$COMPARE_SHA" ] && [ -n "$VERCEL_GIT_PREVIOUS_SHA" ]; then
+  git cat-file -e "$VERCEL_GIT_PREVIOUS_SHA" 2>/dev/null && COMPARE_SHA="$VERCEL_GIT_PREVIOUS_SHA"
 fi
 [ -z "$COMPARE_SHA" ] && exit 1
 


### PR DESCRIPTION
## Summary

- PR #3346 was "Canceled by Ignored Build Step" despite its diff touching `src/`, `pro-test/`, and `public/`.
- Root cause: on a PR branch's FIRST push, Vercel populates `VERCEL_GIT_PREVIOUS_SHA` in ways that make `git diff "$PREVIOUS_SHA" HEAD -- <allowlist>` collapse to empty (same SHA as HEAD, or a parent commit that sees no net change in the allowed paths).
- The script preferred `PREVIOUS_SHA` and only fell back to `git merge-base HEAD origin/main` when PREVIOUS_SHA was literally empty or unresolvable — missing the "PREVIOUS_SHA resolves but gives the wrong answer" case.

## Fix

Flip the priority for **preview** deploys. `merge-base` first (the stable truth: "everything on this PR since it left main"), fall back to `PREVIOUS_SHA` only for the rare shallow-clone scenario where `origin/main` isn't in Vercel's clone.

The **main-branch** branch (line 6) is intentionally unchanged — it correctly wants `PREVIOUS_SHA = last deployed commit`, not merge-base (which would be HEAD itself on main and incorrectly skip every push).

## Test plan

Covered by local simulation before push:

- [x] PR branch + web-path change + `PREVIOUS_SHA=HEAD` (worst-case Vercel quirk) → exit 1 (build)
- [x] PR branch + scripts-only change + `PREVIOUS_SHA=HEAD` → exit 0 (skip) — preserved
- [x] `main` + `PREVIOUS_SHA=valid previous deploy with web change` → exit 1 (build) — preserved

On Vercel:
- [ ] This PR's first-push preview deploys without the empty-commit workaround that #3346 needed.
- [ ] Next future PR with scripts/ only change still gets skipped (check Vercel shows "Canceled by Ignored Build Step" on such a PR after this merges).

## Rollback

Single-file revert of `scripts/vercel-ignore.sh`.

## Related

- PR #3346 (fix(checkout): implement `checkout.redirect_requested`) — the incident that surfaced this bug; the empty commit there served as a manual retrigger.