### PR TITLE
fix(settings): prevent paying users hitting 409 on stale Upgrade CTA

### DIFF
--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -332,6 +332,15 @@ export class UnifiedSettings {
     this.pendingNotifs = null;
     this.unsubscribeEntitlement?.();
     this.unsubscribeEntitlement = null;
+    // Mirror close() — without this, a destroy() during the 12s fallback
+    // window leaves the timer live; it fires after teardown and calls
+    // replaceUpgradeSection() against a detached overlay (no-op via the
+    // querySelector early return, but a stray async callback + DOM
+    // reference alive longer than intended).
+    if (this.entitlementReadyTimer) {
+      clearTimeout(this.entitlementReadyTimer);
+      this.entitlementReadyTimer = null;
+    }
     document.removeEventListener('keydown', this.escapeHandler);
     this.overlay.remove();
   }
@@ -530,6 +539,27 @@ export class UnifiedSettings {
           </div>
           ${statusLine ? `<div class="upgrade-pro-status-line">${escapeHtml(statusLine)}</div>` : ''}
           <button class="manage-billing-btn">Manage Billing</button>
+        </div>
+      `;
+    }
+
+    // Fallback branch: 12s timer fired but Convex never delivered a
+    // snapshot. entitlementReady===true does NOT prove the user is free —
+    // it just means we've given up waiting. A paying user whose auth/query
+    // is simply very slow (beyond the 10s waitForConvexAuth timeout) would
+    // otherwise race into in-modal startCheckout here and reproduce the
+    // 409 duplicate_subscription cascade this PR exists to eliminate.
+    // Render the card with a plain anchor to /pro instead: /pro has its
+    // own entitlement gating on fresh page load, and navigating away is a
+    // no-op for backend subscription state. The `upgrade-pro-cta-link`
+    // class does NOT match the `.upgrade-pro-cta` delegated click handler
+    // (line ~95), so the browser handles the navigation natively.
+    if (getAuthState().user && getEntitlementState() === null) {
+      return `
+        <div class="upgrade-pro-section upgrade-pro-fallback">
+          <div class="upgrade-pro-title">Upgrade to Pro</div>
+          <div class="upgrade-pro-desc">Unlock all panels, AI analysis, and priority data refresh.</div>
+          <a class="upgrade-pro-cta-link" href="/pro" target="_blank" rel="noopener">View plans →</a>
         </div>
       `;
     }

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -454,7 +454,14 @@ export class UnifiedSettings {
     // onEntitlementChange listener in open() swaps it in place once the
     // snapshot arrives.
     if (getAuthState().user && getEntitlementState() === null) {
-      return '<div class="upgrade-pro-section upgrade-pro-loading" aria-hidden="true"></div>';
+      // `hidden` so the browser's default `[hidden] { display: none }`
+      // suppresses the empty card — without it, the base `.upgrade-pro-
+      // section` styles (margin + padding + border + surface background
+      // in main.css:22833) paint a visibly empty bordered box during the
+      // Convex cold-load window, which is exactly the state we're trying
+      // to clean up. Element stays queryable for the replaceWith swap in
+      // open().
+      return '<div class="upgrade-pro-section upgrade-pro-loading" hidden aria-hidden="true"></div>';
     }
     if (isEntitled()) {
       const sub = getSubscription();

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -11,7 +11,8 @@ import { renderPreferences } from '@/services/preferences-content';
 import { renderNotificationsSettings, type NotificationsSettingsResult } from '@/services/notifications-settings';
 import { getAuthState } from '@/services/auth-state';
 import { track } from '@/services/analytics';
-import { isEntitled, hasFeature, onEntitlementChange } from '@/services/entitlements';
+import { isEntitled, hasFeature, onEntitlementChange, getEntitlementState } from '@/services/entitlements';
+import { hasPremiumAccess } from '@/services/panel-gating';
 import { getSubscription, openBillingPortal, prereserveBillingPortalTab } from '@/services/billing';
 import { createApiKey, listApiKeys, revokeApiKey, type ApiKeyInfo } from '@/services/api-keys';
 
@@ -241,6 +242,19 @@ export class UnifiedSettings {
           void this.loadApiKeys();
         }
       }
+      // Replace the upgrade/billing section in place so a paying user who
+      // opened settings before the Convex snapshot arrived sees "Manage
+      // Billing" instead of the stale "Upgrade to Pro" CTA (which, if
+      // clicked, triggers 409 duplicate_subscription). Click handlers are
+      // delegated at overlay level (line ~94), so replacing innerHTML is
+      // sufficient — no rebind needed.
+      const upgradeSection = this.overlay.querySelector('.upgrade-pro-section');
+      if (upgradeSection) {
+        const fresh = document.createElement('template');
+        fresh.innerHTML = this.renderUpgradeSection().trim();
+        const next = fresh.content.firstElementChild;
+        if (next) upgradeSection.replaceWith(next);
+      }
     });
   }
 
@@ -424,6 +438,24 @@ export class UnifiedSettings {
   }
 
   private renderUpgradeSection(): string {
+    // Non-Dodo premium (API key / tester key / Clerk pro role without a
+    // Convex subscription): neither "Upgrade" nor "Manage Billing" is
+    // actionable. Checked FIRST so these users don't get stuck on the
+    // loading placeholder below — their Convex entitlement snapshot may
+    // never arrive at all.
+    if (!isEntitled() && hasPremiumAccess()) {
+      return '<div class="upgrade-pro-section upgrade-pro-hidden" hidden></div>';
+    }
+    // Signed-in user whose Convex entitlement snapshot has not arrived yet.
+    // Rendering "Upgrade to Pro" in this window is how paying users click
+    // through to /api/create-checkout and hit 409 duplicate_subscription —
+    // same race as the 2026-04-17/18 panel-overlay incident fixed in
+    // panel-gating.ts, different surface. Render a placeholder; the
+    // onEntitlementChange listener in open() swaps it in place once the
+    // snapshot arrives.
+    if (getAuthState().user && getEntitlementState() === null) {
+      return '<div class="upgrade-pro-section upgrade-pro-loading" aria-hidden="true"></div>';
+    }
     if (isEntitled()) {
       const sub = getSubscription();
       const planName = sub?.displayName ?? 'Pro';

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -63,6 +63,14 @@ export class UnifiedSettings {
   private apiKeysError = '';
   private newlyCreatedKey: string | null = null;
   private unsubscribeEntitlement: (() => void) | null = null;
+  // Bounded "entitlement snapshot might still arrive" window. Starts false
+  // on open() when currentState is null, flips true on first snapshot OR
+  // after a fallback timeout so signed-in free users aren't stranded on an
+  // empty placeholder when Convex is disabled / auth times out / init
+  // silently fails (all of which leave currentState === null forever — see
+  // src/services/entitlements.ts:41,47,58,78).
+  private entitlementReady = false;
+  private entitlementReadyTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(config: UnifiedSettingsConfig) {
     this.config = config;
@@ -222,6 +230,10 @@ export class UnifiedSettings {
   public open(tab?: TabId): void {
     if (tab) this.activeTab = tab;
     this.resetPanelDraft();
+    // Seed entitlementReady BEFORE render() so the first paint of
+    // renderUpgradeSection branches on the current snapshot state, not the
+    // stale value left over from a previous open/close cycle.
+    this.entitlementReady = getEntitlementState() !== null;
     this.render();
     this.overlay.classList.add('active');
     localStorage.setItem('wm-settings-open', '1');
@@ -233,6 +245,7 @@ export class UnifiedSettings {
     // delivers data, so a paid API Starter user sees the upgrade CTA briefly).
     this.unsubscribeEntitlement?.();
     this.unsubscribeEntitlement = onEntitlementChange(() => {
+      this.entitlementReady = true;
       const panel = this.overlay.querySelector<HTMLElement>('[data-panel-id="api-keys"]');
       if (panel) {
         panel.innerHTML = this.renderApiKeysContent();
@@ -242,20 +255,38 @@ export class UnifiedSettings {
           void this.loadApiKeys();
         }
       }
-      // Replace the upgrade/billing section in place so a paying user who
-      // opened settings before the Convex snapshot arrived sees "Manage
-      // Billing" instead of the stale "Upgrade to Pro" CTA (which, if
-      // clicked, triggers 409 duplicate_subscription). Click handlers are
-      // delegated at overlay level (line ~94), so replacing innerHTML is
-      // sufficient — no rebind needed.
-      const upgradeSection = this.overlay.querySelector('.upgrade-pro-section');
-      if (upgradeSection) {
-        const fresh = document.createElement('template');
-        fresh.innerHTML = this.renderUpgradeSection().trim();
-        const next = fresh.content.firstElementChild;
-        if (next) upgradeSection.replaceWith(next);
-      }
+      this.replaceUpgradeSection();
     });
+    // Bounded fallback: the entitlement listener can legitimately never
+    // fire (no VITE_CONVEX_URL, Convex API fails to load, waitForConvexAuth
+    // times out at 10s, or init throws — see entitlements.ts:41,47,58,78).
+    // Without this timer, the signed-in-free branch of renderUpgradeSection
+    // would show a blank placeholder for the entire session. 12s > the 10s
+    // auth timeout so the healthy-but-slow path lands on the real state;
+    // any later path falls back to "Upgrade to Pro" with handleUpgradeClick
+    // defensively re-checking isEntitled() at click time.
+    if (this.entitlementReadyTimer) clearTimeout(this.entitlementReadyTimer);
+    if (!this.entitlementReady) {
+      this.entitlementReadyTimer = setTimeout(() => {
+        this.entitlementReadyTimer = null;
+        if (this.entitlementReady) return;
+        this.entitlementReady = true;
+        this.replaceUpgradeSection();
+      }, 12_000);
+    }
+  }
+
+  /**
+   * Swap the .upgrade-pro-section wrapper in place. Click handlers are
+   * delegated at overlay level, so replacing the node needs no rebind.
+   */
+  private replaceUpgradeSection(): void {
+    const upgradeSection = this.overlay.querySelector('.upgrade-pro-section');
+    if (!upgradeSection) return;
+    const fresh = document.createElement('template');
+    fresh.innerHTML = this.renderUpgradeSection().trim();
+    const next = fresh.content.firstElementChild;
+    if (next) upgradeSection.replaceWith(next);
   }
 
   public close(): void {
@@ -268,6 +299,10 @@ export class UnifiedSettings {
     this.pendingNotifs = null;
     this.unsubscribeEntitlement?.();
     this.unsubscribeEntitlement = null;
+    if (this.entitlementReadyTimer) {
+      clearTimeout(this.entitlementReadyTimer);
+      this.entitlementReadyTimer = null;
+    }
     this.resetPanelDraft();
     localStorage.removeItem('wm-settings-open');
     document.removeEventListener('keydown', this.escapeHandler);
@@ -446,14 +481,17 @@ export class UnifiedSettings {
     if (!isEntitled() && hasPremiumAccess()) {
       return '<div class="upgrade-pro-section upgrade-pro-hidden" hidden></div>';
     }
-    // Signed-in user whose Convex entitlement snapshot has not arrived yet.
-    // Rendering "Upgrade to Pro" in this window is how paying users click
-    // through to /api/create-checkout and hit 409 duplicate_subscription —
-    // same race as the 2026-04-17/18 panel-overlay incident fixed in
-    // panel-gating.ts, different surface. Render a placeholder; the
-    // onEntitlementChange listener in open() swaps it in place once the
-    // snapshot arrives.
-    if (getAuthState().user && getEntitlementState() === null) {
+    // Signed-in user whose Convex entitlement snapshot has not arrived yet
+    // AND whose bounded-wait window has not expired. Rendering "Upgrade to
+    // Pro" in this window is how paying users click through to
+    // /api/create-checkout and hit 409 duplicate_subscription — same race
+    // as the 2026-04-17/18 panel-overlay incident fixed in panel-gating.ts,
+    // different surface. The entitlementReady flag is flipped either by
+    // the onEntitlementChange listener (healthy path) or by a 12s fallback
+    // timer in open() (Convex-disabled / auth-timeout / init-fail paths
+    // where currentState would otherwise stay null forever and strand a
+    // signed-in free user on an empty placeholder).
+    if (!this.entitlementReady && getAuthState().user && getEntitlementState() === null) {
       // `hidden` so the browser's default `[hidden] { display: none }`
       // suppresses the empty card — without it, the base `.upgrade-pro-
       // section` styles (margin + padding + border + surface background
@@ -506,6 +544,20 @@ export class UnifiedSettings {
   }
 
   private handleUpgradeClick(): void {
+    // Defense in depth: the upgrade CTA can only be clicked when either (a)
+    // the user is genuinely free-tier, or (b) the 12s fallback timer fired
+    // before the Convex snapshot arrived. In (b), the snapshot might land
+    // AFTER the timer but BEFORE the click — re-check isEntitled() here so
+    // a late-arriving "you're a paying user" state routes to the billing
+    // portal instead of triggering /api/create-checkout against an active
+    // subscription (which would 409 and re-enter the duplicate_subscription
+    // → getCustomerPortalUrl cascade this PR is trying to eliminate).
+    if (isEntitled()) {
+      this.close();
+      const reservedWin = prereserveBillingPortalTab();
+      void openBillingPortal(reservedWin);
+      return;
+    }
     this.close();
     if (this.config.isDesktopApp) {
       window.open('https://worldmonitor.app/pro', '_blank');


### PR DESCRIPTION
## Summary

- Paying users opening the Settings gear during a cold Convex WebSocket load saw a stale **"Upgrade to Pro"** CTA; clicking it hit `/api/create-checkout`, got 409 `duplicate_subscription`, then cascaded into the billing-portal error path (which itself can dead-end on a generic Dodo login).
- Root cause: `UnifiedSettings.renderUpgradeSection()` branched on `isEntitled()` (false while `currentState === null`), and the modal's `onEntitlementChange` listener only re-rendered the `api-keys` tab — the Settings tab's upgrade section was never refreshed once the snapshot arrived.
- Same class of bug as the 2026-04-17/18 panel-overlay duplicate-subscription incident called out in `panel-gating.ts:20-22` — different surface, same race.

## What changed (`src/components/UnifiedSettings.ts`)

1. `renderUpgradeSection()` now returns a hidden wrapper for non-Dodo premium (API key / tester key / Clerk pro role) **first**, so those users don't get stuck on the loading placeholder indefinitely (their Convex snapshot may never arrive).
2. For a signed-in user whose Convex entitlement snapshot is still null, it returns a neutral loading placeholder instead of "Upgrade to Pro" — a fast click can no longer submit before Convex hydrates.
3. `open()`'s `onEntitlementChange` handler now swaps the `.upgrade-pro-section` element in place once the snapshot arrives. Click handlers are delegated at overlay level, so replacing the node needs no rebind.

## Observed signal behind this fix

| Sentry ID | Date | Title |
|---|---|---|
| WORLDMONITOR-NY | 2026-04-23 | `Checkout error: duplicate_subscription` |
| WORLDMONITOR-NZ | 2026-04-23 | `[CONVEX A(payments/billing:getCustomerPortalUrl)] Server Error` (same user, 4s after NY) |

Broader 14-day context for the billing-portal cascade that NY triggered: ~6 distinct paying users hit `getCustomerPortalUrl` errors (mix of `Connection lost while action was in flight` and opaque `Server Error`). Those are NOT fixed by this PR — they're Layer B/C concerns that warrant a separate retry + toast-fallback change. This PR fixes Layer A (the entry-point bug that made the cascade reachable at all).

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS
- [x] CJS `node -c scripts/*.cjs` — PASS
- [x] `npm run lint` + targeted `biome lint src/components/UnifiedSettings.ts` — PASS
- [x] `npm run test:data` — 6618 / 6618 PASS
- [x] `esbuild --bundle` over `api/*.js` — PASS
- [x] `node --test tests/edge-functions.test.mjs` — 176 / 176 PASS
- [x] `npm run lint:md` — PASS
- [x] `npm run version:check` — PASS
- [ ] Manual regression — open settings in a fresh incognito while signed in as a paying user; confirm no flash of "Upgrade to Pro" before "Manage Billing" appears
- [ ] Manual regression — API-key-only user: confirm settings no longer shows any upgrade/billing section (was showing "Upgrade to Pro" before)
- [ ] Monitor WORLDMONITOR-NY / NZ event volume in Sentry for 48h post-deploy