### PR TITLE
fix(energy): strict validation — emptyDataIsFailure on Atlas seeders

### DIFF
--- a/scripts/seed-energy-disruptions.mjs
+++ b/scripts/seed-energy-disruptions.mjs
@@ -25,6 +25,9 @@ if (isMain) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: MAX_STALE_MIN,
+    // See seed-pipelines-gas.mjs for rationale — strict validation failure
+    // must leave seed-meta stale so the bundle retries every tick.
+    emptyDataIsFailure: true,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-fuel-shortages.mjs
+++ b/scripts/seed-fuel-shortages.mjs
@@ -28,6 +28,9 @@ if (isMain) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: MAX_STALE_MIN,
+    // See seed-pipelines-gas.mjs for rationale — strict validation failure
+    // must leave seed-meta stale so the bundle retries every tick.
+    emptyDataIsFailure: true,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-pipelines-gas.mjs
+++ b/scripts/seed-pipelines-gas.mjs
@@ -31,6 +31,12 @@ if (isMain) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: MAX_STALE_MIN,
+    // File-read-and-validate seeder: if the container can't load/validate the
+    // registry (stale image, missing data file, shape regression), fail LOUDLY
+    // rather than refreshing seed-meta with recordCount=0. Without this, the
+    // bundle's interval gate silently locks the seeder out for ~7 days after
+    // a single transient validation failure.
+    emptyDataIsFailure: true,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-pipelines-oil.mjs
+++ b/scripts/seed-pipelines-oil.mjs
@@ -30,6 +30,9 @@ if (isMain) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: MAX_STALE_MIN,
+    // See seed-pipelines-gas.mjs for rationale — strict validation failure
+    // must leave seed-meta stale so the bundle retries every tick.
+    emptyDataIsFailure: true,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-storage-facilities.mjs
+++ b/scripts/seed-storage-facilities.mjs
@@ -29,6 +29,12 @@ if (isMain) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: MAX_STALE_MIN,
+    // File-read-and-validate seeder: if the container can't load/validate the
+    // registry (stale image, missing data file, shape regression), fail LOUDLY
+    // rather than refreshing seed-meta with recordCount=0. Without this, the
+    // bundle gate silently locks the seeder out for ~5.5 days after a single
+    // validation hiccup. See seed-pipelines-gas.mjs for the canonical incident.
+    emptyDataIsFailure: true,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);


### PR DESCRIPTION
## Summary

- Adds `emptyDataIsFailure: true` to all 5 Atlas curated-registry seeders (pipelines-gas, pipelines-oil, storage-facilities, fuel-shortages, energy-disruptions).
- Converts the silent "validation failed → seed-meta refreshed with recordCount:0 → bundle gate locks seeder out for ~5.5 days → canonical never written" failure mode into a LOUD failure: seed-meta stays stale, bundle fails the section, health flips STALE_SEED, next cron tick retries.
- 21-line change across 5 files. No new tests, no behavior change in the healthy path.

## Background — observed incident (2026-04-23)

Post PR #3337 merge, a subset of Atlas seeders got into a broken state that was invisible to the bundle runner:

1. Seeder invoked (via Railway cron or local `railway run`)
2. `validateRegistry(data)` returned false — because the container or working-tree state was inconsistent at the moment of invocation
3. `atomicPublish` at `_seed-utils.mjs:175-180` returned `{skipped: true}` without writing canonical
4. `runSeed` at `_seed-utils.mjs:906-911` wrote `seed-meta:energy:<X>` with `fetchedAt: now, recordCount: 0`
5. Bundle runner's interval gate at `_bundle-runner.mjs:210` read `fetchedAt`, saw it was fresh, and **skipped the section every subsequent tick** for 0.8 × intervalMs = **5.5 days**

During that 5.5 days: canonical key stays empty, `/api/health` reports EMPTY, `/atlas` renders nothing, and the bundle has no way to self-heal because the gate believes the seeder is healthy.

Observed in production: `pipelinesOil` and `storageFacilities` sat at `records: 0, status: EMPTY` despite the bundle logs showing "Skipped, last seeded 216min ago" — textbook symptoms of the poisoned-seed-meta pattern.

## How this PR fixes it

`_seed-utils.mjs:897-905` already has a strict branch for this case:

```js
if (strictFailure) {
  console.error(`FAILURE: validation failed (empty data) — seed-meta NOT refreshed; bundle will retry next cycle`);
}
```

Triggered by `emptyDataIsFailure: true` in `runSeed` opts. With the flag set:
- seed-meta is NOT refreshed on validation failure
- the seed script exits non-zero
- `_bundle-runner.mjs` counts it as `failed++`
- next cron tick sees stale seed-meta (unchanged `fetchedAt`), fires the seeder again
- as soon as the underlying issue is resolved (deploy lands, shape fixes, etc.) the next tick auto-repairs
- `/api/health` flips STALE_SEED, which propagates to any uptime monitor watching health status

No impact in the healthy path — when `validateRegistry` passes, the code path is identical to before.

## Related context

- Same pattern already applied to strict-floor upstream-fetching seeders (IMF/WEO 180+ countries) per `feedback_strict_floor_validate_fail_poisons_seed_meta.md` in project memory.
- This PR extends the discipline to file-read curated registries where the invariant is "if we can't read+validate the committed JSON, something is wrong — do not stamp fresh meta as if it succeeded."

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test:data` — **6618/6618 pass** (35 more tests than pre-Atlas baseline; all existing seed-util tests still green)
- [ ] Post-merge: watch the next `seed-bundle-energy-sources` cron tick after any future data-PR — expect normal `state: OK` in the seed-complete event, and no change in observable behavior.
- [ ] Post-merge (eventual): next time a Railway container goes stale or a JSON shape regresses, observe the loud-failure behavior kick in — health flips STALE_SEED within `maxStaleMin` instead of silently holding EMPTY for 5.5 days.
