### PR TITLE
fix(swf): restore 8/8 fund coverage + explicit per-country observability

### DIFF
--- a/scripts/seed-sovereign-wealth.mjs
+++ b/scripts/seed-sovereign-wealth.mjs
@@ -736,13 +736,19 @@ export function buildCoverageSummary(manifest, imports, countries) {
   const expectedCountries = new Set(manifest.funds.map((f) => f.country));
   let matchedFundsTotal = 0;
   for (const entry of Object.values(countries)) matchedFundsTotal += entry.matchedFunds;
+  // Every status carries a `reason` field so downstream consumers that
+  // iterate the persisted countryStatuses can safely dereference `.reason`
+  // without defensive checks. `complete` and `partial` use `null` to make
+  // the shape uniform; `missing` carries a human-readable string naming
+  // which upstream the operator should investigate (WB imports vs
+  // Wikipedia fund match).
   const countryStatuses = [];
   for (const iso2 of expectedCountries) {
     const entry = countries[iso2];
     if (entry && entry.completeness === 1.0) {
-      countryStatuses.push({ country: iso2, status: 'complete', matched: entry.matchedFunds, expected: entry.expectedFunds });
+      countryStatuses.push({ country: iso2, status: 'complete', matched: entry.matchedFunds, expected: entry.expectedFunds, reason: null });
     } else if (entry) {
-      countryStatuses.push({ country: iso2, status: 'partial', matched: entry.matchedFunds, expected: entry.expectedFunds });
+      countryStatuses.push({ country: iso2, status: 'partial', matched: entry.matchedFunds, expected: entry.expectedFunds, reason: null });
     } else {
       const reason = imports[iso2] ? 'no fund AUM matched' : 'missing WB imports';
       countryStatuses.push({

--- a/scripts/seed-sovereign-wealth.mjs
+++ b/scripts/seed-sovereign-wealth.mjs
@@ -135,12 +135,50 @@ const CURRENCY_SYMBOL_TO_ISO = [
 
 // ── World Bank: per-country annual imports (denominator for rawMonths) ──
 
+// MRV lookback used in the bulk fetch. WB's `country/all?mrv=1` returns the
+// SAME year across every country (the most recent year that any country
+// reports) with `value: null` for countries that haven't published yet.
+// KW/QA/AE report NE.IMP.GNFS.CD a year or two behind NO/SA/SG, so mrv=1
+// returned null for them in the 2026-04-23 prod run (PR #3352 root cause).
+// mrv=5 gives 5 years and lets us pick the most recent non-null per
+// country, matching what the per-country endpoint returns naturally.
+// Five years is deliberate — one is clearly insufficient, ten is overkill
+// for a denominator that evolves on a yearly cadence (we also report back
+// the year we picked, so the scorer can flag stale ones if it wants).
+const IMPORTS_LOOKBACK_YEARS = 5;
+
+/**
+ * Collapse a WB multi-year bulk response into a per-country map keyed on
+ * most-recent-non-null value. Exported so the mrv=5 + pick-latest logic
+ * is unit-testable without mocking fetch.
+ *
+ * @param {Array<{ countryiso3code?: string, country?: { id?: string }, value: unknown, date: unknown }>} records
+ * @returns {Record<string, { importsUsd: number, year: number }>}
+ */
+export function pickLatestPerCountry(records) {
+  const imports = {};
+  for (const record of records) {
+    const rawCode = record?.countryiso3code ?? record?.country?.id ?? '';
+    const iso2 = rawCode.length === 3 ? (iso3ToIso2[rawCode] ?? null) : (rawCode.length === 2 ? rawCode : null);
+    if (!iso2) continue;
+    const value = Number(record?.value);
+    if (!Number.isFinite(value) || value <= 0) continue;
+    const year = Number(record?.date);
+    if (!Number.isFinite(year)) continue;
+    const existing = imports[iso2];
+    if (!existing || year > existing.year) {
+      imports[iso2] = { importsUsd: value, year };
+    }
+  }
+  return imports;
+}
+
 async function fetchAnnualImportsUsd() {
   const pages = [];
   let page = 1;
   let totalPages = 1;
   while (page <= totalPages) {
-    const url = `${WB_BASE}/country/all/indicator/${IMPORTS_INDICATOR}?format=json&per_page=500&page=${page}&mrv=1`;
+    const url = `${WB_BASE}/country/all/indicator/${IMPORTS_INDICATOR}?format=json&per_page=2000&page=${page}&mrv=${IMPORTS_LOOKBACK_YEARS}`;
     const resp = await fetch(url, {
       headers: { 'User-Agent': CHROME_UA },
       signal: AbortSignal.timeout(30_000),
@@ -153,17 +191,7 @@ async function fetchAnnualImportsUsd() {
     pages.push(...records);
     page++;
   }
-  const imports = {};
-  for (const record of pages) {
-    const rawCode = record?.countryiso3code ?? record?.country?.id ?? '';
-    const iso2 = rawCode.length === 3 ? (iso3ToIso2[rawCode] ?? null) : (rawCode.length === 2 ? rawCode : null);
-    if (!iso2) continue;
-    const value = Number(record?.value);
-    if (!Number.isFinite(value) || value <= 0) continue;
-    const year = Number(record?.date);
-    imports[iso2] = { importsUsd: value, year: Number.isFinite(year) ? year : null };
-  }
-  return imports;
+  return pickLatestPerCountry(pages);
 }
 
 // ── Tier 1: official disclosure endpoints (per-fund hand-curated) ──
@@ -671,6 +699,14 @@ export async function fetchSovereignWealth() {
     console.warn(`[seed-sovereign-wealth] ${unmatched.length} fund(s) unmatched across all tiers: ${unmatched.join(', ')}`);
   }
 
+  const summary = buildCoverageSummary(manifest, imports, countries);
+  console.log(`[seed-sovereign-wealth] manifest coverage: ${summary.matchedFunds}/${summary.expectedFunds} funds across ${summary.expectedCountries} countries`);
+  for (const row of summary.countryStatuses) {
+    const tag = row.status === 'complete' ? 'OK  ' : row.status === 'partial' ? 'PART' : 'MISS';
+    const extra = row.reason ? ` — ${row.reason}` : '';
+    console.log(`[seed-sovereign-wealth]   ${tag} ${row.country} ${row.matched}/${row.expected}${extra}`);
+  }
+
   const usedWikipedia = sourceMix.wikipedia_list + sourceMix.wikipedia_infobox > 0;
   return {
     countries,
@@ -680,7 +716,58 @@ export async function fetchSovereignWealth() {
     sourceAttribution: {
       wikipedia: usedWikipedia ? WIKIPEDIA_SOURCE_ATTRIBUTION : undefined,
     },
+    summary,
   };
+}
+
+/**
+ * Manifest-vs-seeded coverage summary. Exported so the enumeration logic
+ * is unit-testable — previously, a country that failed (no WB imports +
+ * no Wikipedia match) disappeared silently unless a log line happened to
+ * emit on the specific code path. This function guarantees every
+ * manifest country appears with an explicit status and reason.
+ *
+ * @param {{ funds: Array<{ country: string, fund: string }> }} manifest
+ * @param {Record<string, unknown>} imports Per-country import entries from pickLatestPerCountry
+ * @param {Record<string, { matchedFunds: number, expectedFunds: number, completeness: number }>} countries Seeded country payload
+ */
+export function buildCoverageSummary(manifest, imports, countries) {
+  const expectedFundsTotal = manifest.funds.length;
+  const expectedCountries = new Set(manifest.funds.map((f) => f.country));
+  let matchedFundsTotal = 0;
+  for (const entry of Object.values(countries)) matchedFundsTotal += entry.matchedFunds;
+  const countryStatuses = [];
+  for (const iso2 of expectedCountries) {
+    const entry = countries[iso2];
+    if (entry && entry.completeness === 1.0) {
+      countryStatuses.push({ country: iso2, status: 'complete', matched: entry.matchedFunds, expected: entry.expectedFunds });
+    } else if (entry) {
+      countryStatuses.push({ country: iso2, status: 'partial', matched: entry.matchedFunds, expected: entry.expectedFunds });
+    } else {
+      const reason = imports[iso2] ? 'no fund AUM matched' : 'missing WB imports';
+      countryStatuses.push({
+        country: iso2,
+        status: 'missing',
+        matched: 0,
+        expected: countManifestFundsForCountry(manifest, iso2),
+        reason,
+      });
+    }
+  }
+  countryStatuses.sort((a, b) => a.country.localeCompare(b.country));
+  return {
+    expectedCountries: expectedCountries.size,
+    expectedFunds: expectedFundsTotal,
+    matchedCountries: Object.keys(countries).length,
+    matchedFunds: matchedFundsTotal,
+    countryStatuses,
+  };
+}
+
+function countManifestFundsForCountry(manifest, iso2) {
+  let n = 0;
+  for (const f of manifest.funds) if (f.country === iso2) n++;
+  return n;
 }
 
 export function validate(data) {

--- a/tests/seed-sovereign-wealth.test.mjs
+++ b/tests/seed-sovereign-wealth.test.mjs
@@ -566,11 +566,16 @@ describe('pickLatestPerCountry — WB mrv>1 per-country latest-non-null selectio
   });
 
   it('drops countries with ONLY null values (WB has no data in the lookback window)', () => {
+    // Real ISO-3 code required — a fake one (e.g. 'XYZ') is filtered at the
+    // iso3→iso2 lookup stage, never reaching the null-value guard. A
+    // regression that deleted the null check entirely would still leave
+    // this test green. Using NOR forces the record through the lookup
+    // branch so the null-filter is the actual gate under test.
     const out = pickLatestPerCountry([
-      { countryiso3code: 'XYZ', date: '2024', value: null },
-      { countryiso3code: 'XYZ', date: '2023', value: null },
+      { countryiso3code: 'NOR', date: '2024', value: null },
+      { countryiso3code: 'NOR', date: '2023', value: null },
     ]);
-    assert.equal(out.XY, undefined);
+    assert.equal(out.NO, undefined);
   });
 
   it('drops records with non-positive values (WB sometimes reports 0 for countries with no trade)', () => {
@@ -629,6 +634,16 @@ describe('pickLatestPerCountry — WB mrv>1 per-country latest-non-null selectio
     assert.equal(summary.countryStatuses[1].expected, 1,
       'KW expected field must reflect manifest fund count for this country, even when the country was dropped');
     assert.equal(summary.countryStatuses[2].status, 'complete');
+    // Every status entry must carry a `reason` key for uniform shape —
+    // downstream consumers reading the persisted Redis payload iterate
+    // countryStatuses and dereference `.reason` directly. complete/partial
+    // use null; missing uses a string. Guard against regressions that
+    // drop the key on success paths.
+    for (const row of summary.countryStatuses) {
+      assert.ok('reason' in row, `${row.country} (${row.status}): reason key must be present in persisted shape even when there's no error`);
+    }
+    assert.equal(summary.countryStatuses[0].reason, null, 'partial entries use reason=null');
+    assert.equal(summary.countryStatuses[2].reason, null, 'complete entries use reason=null');
   });
 
   it('labels "no fund AUM matched" distinctly from "missing WB imports" so operators can disambiguate', () => {

--- a/tests/seed-sovereign-wealth.test.mjs
+++ b/tests/seed-sovereign-wealth.test.mjs
@@ -2,12 +2,14 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
+  buildCoverageSummary,
   declareRecords,
   detectCurrency,
   lookupUsdRate,
   matchWikipediaRecord,
   parseWikipediaArticleInfobox,
   parseWikipediaRankingsTable,
+  pickLatestPerCountry,
   validate,
 } from '../scripts/seed-sovereign-wealth.mjs';
 import { SHARED_FX_FALLBACKS } from '../scripts/_seed-utils.mjs';
@@ -527,5 +529,143 @@ describe('matchWikipediaRecord — country-disambiguation on abbrev collisions',
     const fund = { country: 'ZZ', fund: 'pif', wikipedia: { abbrev: 'PIF' } };
     assert.equal(matchWikipediaRecord(fund, cache), null,
       'ambiguous match with no country mapping must return null — silent wrong-country match is the exact bug this test guards against');
+  });
+});
+
+describe('pickLatestPerCountry — WB mrv>1 per-country latest-non-null selection', () => {
+  // Shape mirrors the WB /country/all/indicator/... response's second
+  // array. Year order in prod is newest-first per country, but the
+  // picking logic must be order-agnostic so a silent upstream re-order
+  // doesn't pick a stale year. Regression from the 2026-04-23 prod
+  // crash: mrv=1 returned null for KW/QA/AE because they're a year or
+  // two behind NO/SA/SG; mrv=5 + pick-latest fixes it. (PR #3352.)
+  const NO_2024 = { countryiso3code: 'NOR', date: '2024', value: 163_801_535_479 };
+  const NO_2023 = { countryiso3code: 'NOR', date: '2023', value: 157_000_000_000 };
+  const KW_2023 = { countryiso3code: 'KWT', date: '2023', value: 63_424_320_849 };
+  const KW_2024_NULL = { countryiso3code: 'KWT', date: '2024', value: null };
+  const QA_2022 = { countryiso3code: 'QAT', date: '2022', value: 74_520_054_945 };
+  const QA_2024_NULL = { countryiso3code: 'QAT', date: '2024', value: null };
+
+  it('returns the most recent non-null value per country even when mrv=1 would pick a null year', () => {
+    const out = pickLatestPerCountry([KW_2024_NULL, KW_2023, QA_2024_NULL, QA_2022, NO_2024]);
+    assert.deepEqual(out.KW, { importsUsd: 63_424_320_849, year: 2023 });
+    assert.deepEqual(out.QA, { importsUsd: 74_520_054_945, year: 2022 });
+    assert.deepEqual(out.NO, { importsUsd: 163_801_535_479, year: 2024 });
+  });
+
+  it('picks the NEWER year when the array arrives in ascending year order (upstream re-order must not pick stale)', () => {
+    const out = pickLatestPerCountry([NO_2023, NO_2024]);
+    assert.equal(out.NO.year, 2024);
+    assert.equal(out.NO.importsUsd, 163_801_535_479);
+  });
+
+  it('picks the newer year when the array arrives in descending year order (prod-observed ordering)', () => {
+    const out = pickLatestPerCountry([NO_2024, NO_2023]);
+    assert.equal(out.NO.year, 2024);
+    assert.equal(out.NO.importsUsd, 163_801_535_479);
+  });
+
+  it('drops countries with ONLY null values (WB has no data in the lookback window)', () => {
+    const out = pickLatestPerCountry([
+      { countryiso3code: 'XYZ', date: '2024', value: null },
+      { countryiso3code: 'XYZ', date: '2023', value: null },
+    ]);
+    assert.equal(out.XY, undefined);
+  });
+
+  it('drops records with non-positive values (WB sometimes reports 0 for countries with no trade)', () => {
+    const out = pickLatestPerCountry([
+      { countryiso3code: 'NOR', date: '2024', value: 0 },
+      { countryiso3code: 'NOR', date: '2023', value: -100 },
+    ]);
+    assert.equal(out.NO, undefined);
+  });
+
+  it('handles both iso3 and iso2 country codes (bulk endpoint occasionally uses either)', () => {
+    const out = pickLatestPerCountry([
+      { countryiso3code: 'NOR', date: '2024', value: 100 },
+      { country: { id: 'SA' }, date: '2024', value: 200 },
+    ]);
+    assert.equal(out.NO.importsUsd, 100);
+    assert.equal(out.SA.importsUsd, 200);
+  });
+
+  it('enumerates every manifest country in buildCoverageSummary — no silent drops', () => {
+    // Regression-guard: AE was silently dropped in the 2026-04-23 prod run
+    // with no log line explaining why. The fix requires that every
+    // manifest country appear in the summary with an explicit status and
+    // reason.
+    const manifest = {
+      funds: [
+        { country: 'AE', fund: 'adia' },
+        { country: 'AE', fund: 'mubadala' },
+        { country: 'NO', fund: 'gpfg' },
+        { country: 'KW', fund: 'kia' },
+      ],
+    };
+    // Simulate: NO fully matched, AE partial (1 of 2), KW missing due to
+    // no WB imports.
+    const imports = {
+      NO: { importsUsd: 163_000_000_000, year: 2024 },
+      AE: { importsUsd: 481_000_000_000, year: 2023 },
+      // KW absent → summary should show 'missing WB imports'
+    };
+    const countries = {
+      NO: { matchedFunds: 1, expectedFunds: 1, completeness: 1.0 },
+      AE: { matchedFunds: 1, expectedFunds: 2, completeness: 0.5 },
+      // KW absent
+    };
+    const summary = buildCoverageSummary(manifest, imports, countries);
+    assert.equal(summary.expectedCountries, 3);
+    assert.equal(summary.expectedFunds, 4);
+    assert.equal(summary.matchedCountries, 2);
+    assert.equal(summary.matchedFunds, 2);
+    // Sorted alphabetically
+    assert.deepEqual(summary.countryStatuses.map((s) => s.country), ['AE', 'KW', 'NO']);
+    assert.equal(summary.countryStatuses[0].status, 'partial');
+    assert.equal(summary.countryStatuses[1].status, 'missing');
+    assert.equal(summary.countryStatuses[1].reason, 'missing WB imports',
+      'KW had no imports entry — reason must specifically name the WB import denominator, not a generic "missing"');
+    assert.equal(summary.countryStatuses[1].expected, 1,
+      'KW expected field must reflect manifest fund count for this country, even when the country was dropped');
+    assert.equal(summary.countryStatuses[2].status, 'complete');
+  });
+
+  it('labels "no fund AUM matched" distinctly from "missing WB imports" so operators can disambiguate', () => {
+    // If the import denominator IS present but Wikipedia matching fails
+    // for every fund the country owns, the reason must be different —
+    // operator investigates Wikipedia, not WB.
+    const manifest = { funds: [{ country: 'ZZ', fund: 'zz_fund' }] };
+    const imports = { ZZ: { importsUsd: 1_000_000_000, year: 2024 } };
+    const countries = {}; // country dropped because no fund matched
+    const summary = buildCoverageSummary(manifest, imports, countries);
+    assert.equal(summary.countryStatuses[0].status, 'missing');
+    assert.equal(summary.countryStatuses[0].reason, 'no fund AUM matched');
+  });
+
+  it('mirrors the prod scenario that failed on 2026-04-23 — all 6 manifest countries resolve', () => {
+    // Snapshot of the WB mrv=5 response for the 6 manifest countries as
+    // probed on 2026-04-23. If WB's data shape shifts, this fixture
+    // breaks and the seeder's coverage claim needs re-verification.
+    const input = [
+      { countryiso3code: 'NOR', date: '2024', value: 163_801_535_479 },
+      { countryiso3code: 'SAU', date: '2024', value: 317_011_733_333 },
+      { countryiso3code: 'SGP', date: '2024', value: 786_020_626_642 },
+      { countryiso3code: 'ARE', date: '2024', value: null },
+      { countryiso3code: 'ARE', date: '2023', value: 481_851_599_728 },
+      { countryiso3code: 'KWT', date: '2024', value: null },
+      { countryiso3code: 'KWT', date: '2023', value: 63_424_320_849 },
+      { countryiso3code: 'QAT', date: '2024', value: null },
+      { countryiso3code: 'QAT', date: '2023', value: null },
+      { countryiso3code: 'QAT', date: '2022', value: 74_520_054_945 },
+    ];
+    const out = pickLatestPerCountry(input);
+    for (const iso2 of ['NO', 'SA', 'SG', 'AE', 'KW', 'QA']) {
+      assert.ok(out[iso2], `${iso2} must resolve under mrv=5 pick-latest — this is the 8/8 coverage test`);
+    }
+    // AE was the silent-drop country in prod: no log line, no record.
+    // Lock in that mrv=5 recovers it from the 2023 row.
+    assert.equal(out.AE.year, 2023);
+    assert.equal(out.AE.importsUsd, 481_851_599_728);
   });
 });


### PR DESCRIPTION
## Summary
Post-#3344, the Railway Sovereign-Wealth seeder ran successfully but only wrote **4/8 funds across 3/6 countries**:

| Country | Before | After |
|---------|-------:|------:|
| NO (GPFG) | ✅ | ✅ |
| SA (PIF) | ✅ | ✅ |
| SG (GIC + Temasek) | ✅ 2/2 | ✅ 2/2 |
| **AE (ADIA + Mubadala)** | ❌ silent drop | ✅ 2/2 effMo=3.85 |
| **KW (KIA)** | ❌ "missing WB imports" | ✅ 1/1 effMo=45.43 |
| **QA (QIA)** | ❌ "missing WB imports" | ✅ 1/1 effMo=8.61 |
| **TOTAL** | **4/8** | **8/8** |

## Two root causes

**1. `mrv=1` bulk fetch returns a single year for all countries.** WB's `country/all/indicator/…?mrv=1` picks the most-recent year reported by ANY country (2024) and returns `value: null` for countries that haven't published yet. KW/QA/AE report NE.IMP.GNFS.CD a year or two behind the leaders, so they got dropped with no denominator.

Fix: `mrv=5` + new `pickLatestPerCountry(records)` helper that picks the most-recent non-null per country. Verified via the WB probe:
```
ARE: 2024=null  2023=481B ✓
KWT: 2024=null  2023=63B  ✓
QAT: 2024=null  2023=null  2022=74B ✓
```

**2. Silent drops with no log line.** Prod 14:59Z logged `KW/QA skipped: missing WB imports` but AE dropped with zero log output (different code path — country passed the imports gate but no fund matched). Operator had to cross-reference the manifest to notice.

Fix: new `buildCoverageSummary(manifest, imports, countries)` enumerates every manifest country with explicit status (`complete` | `partial` | `missing`) and reason (`'missing WB imports'` | `'no fund AUM matched'`). Summary is both logged AND embedded in the persisted payload so operators can detect degraded runs from seed-meta alone.

## Validation (multiple times per request)

**6 back-to-back live dry-runs, all 8/8, byte-identical numbers:**
```
Run 1-6: matched 8/8 funds across 6/6 countries
  NO: GPFG          1/1  effMo=93.05   (2024 imports)
  AE: ADIA+Mubadala 2/2  effMo=3.85    (2023 imports)
  SA: PIF           1/1  effMo=1.68    (2024 imports)
  KW: KIA           1/1  effMo=45.43   (2023 imports)
  QA: QIA           1/1  effMo=8.61    (2022 imports)
  SG: GIC+Temasek   2/2  effMo=7.11    (2024 imports; Temasek via infobox)
```

**569/569 tests pass** (48 in the SWF seeder test file, including 9 new cases):
- `pickLatestPerCountry`: 7 cases (prod scenario, ascending/descending upstream order, null-only, non-positive, iso2/iso3 codes, 6-country manifest snapshot)
- `buildCoverageSummary`: 2 cases (silent-drop regression, reason-string disambiguation)

Also: biome clean, syntax check clean, lint:md clean.

## Test plan
- [x] `node --test --import tsx/esm tests/seed-sovereign-wealth.test.mjs` — 48/48
- [x] `node --test --import tsx/esm tests/resilience-*.test.m{t,j}s` — 569/569
- [x] 6 live dry-runs against WB + Wikipedia
- [x] `npx biome lint scripts/seed-sovereign-wealth.mjs tests/seed-sovereign-wealth.test.mjs`
- [x] `npm run lint:md`
- [ ] CI: typecheck + unit + biome + mintlify
- [ ] Post-merge: next Railway tick should log `manifest coverage: 8/8 funds across 6 countries` and all six `OK` status lines. Redis will have countries `{NO, SA, SG, AE, KW, QA}` in the canonical payload.