### PR TITLE
feat(agent-readiness): RFC 8288 Link headers on homepage

### DIFF
--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -482,3 +482,60 @@ describe('vercel.json functions config (none expected after carousel moved to ed
     );
   });
 });
+
+// Agent readiness: RFC 8288 Link response headers on the homepage.
+// Scanners like isitagentready.com fetch GET / and expect a Link
+// header advertising every well-known resource. Each rel is either
+// an IANA-registered token (api-catalog, service-desc, service-doc,
+// status) or the full IANA URI form (RFC 9728 OAuth rels). The MCP
+// card rel carries anchor="/mcp" because the server card describes
+// the /mcp endpoint, not the homepage.
+describe('agent readiness: homepage Link headers', () => {
+  const vercel = JSON.parse(readFileSync(resolve(__dirname, '../vercel.json'), 'utf-8'));
+
+  for (const source of ['/', '/index.html']) {
+    it(`${source} emits a Link header`, () => {
+      const entry = vercel.headers.find((h) => h.source === source);
+      assert.ok(entry, `expected a headers entry for ${source}`);
+      const linkHeader = entry.headers.find((h) => h.key === 'Link');
+      assert.ok(linkHeader, `expected a Link header on ${source}`);
+
+      // Must advertise each required rel at least once
+      const requiredRels = [
+        'rel="api-catalog"',
+        'rel="service-desc"',
+        'rel="service-doc"',
+        'rel="status"',
+        'rel="http://www.iana.org/assignments/relation/oauth-protected-resource"',
+        'rel="http://www.iana.org/assignments/relation/oauth-authorization-server"',
+        'rel="mcp-server-card"',
+      ];
+      for (const rel of requiredRels) {
+        assert.ok(
+          linkHeader.value.includes(rel),
+          `Link header missing ${rel}`
+        );
+      }
+
+      // MCP card rel must carry anchor="/mcp" (server card describes /mcp, not homepage)
+      assert.match(
+        linkHeader.value,
+        /<\/\.well-known\/mcp\/server-card\.json>[^,]*anchor="\/mcp"/,
+        'mcp-server-card rel must carry anchor="/mcp"'
+      );
+
+      // Target URIs must be root-relative (start with /, not http://)
+      const targetMatches = [...linkHeader.value.matchAll(/<([^>]+)>/g)];
+      assert.ok(
+        targetMatches.length >= 7,
+        `expected >=7 link targets, got ${targetMatches.length}`
+      );
+      for (const [, target] of targetMatches) {
+        assert.ok(
+          target.startsWith('/'),
+          `link target must be root-relative, got ${target}`
+        );
+      }
+    });
+  }
+});

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -526,9 +526,10 @@ describe('agent readiness: homepage Link headers', () => {
 
       // Target URIs must be root-relative (start with /, not http://)
       const targetMatches = [...linkHeader.value.matchAll(/<([^>]+)>/g)];
-      assert.ok(
-        targetMatches.length >= 7,
-        `expected >=7 link targets, got ${targetMatches.length}`
+      assert.strictEqual(
+        targetMatches.length,
+        requiredRels.length,
+        `expected exactly ${requiredRels.length} link targets, got ${targetMatches.length}`
       );
       for (const [, target] of targetMatches) {
         assert.ok(
@@ -538,4 +539,13 @@ describe('agent readiness: homepage Link headers', () => {
       }
     });
   }
+
+  // / and /index.html serve the same document; their Link headers must
+  // stay in lockstep. Hardcoded duplication in vercel.json otherwise
+  // silently drifts — this guard catches the drift at CI time.
+  it('/ and /index.html Link headers are identical', () => {
+    const slash = vercel.headers.find((h) => h.source === '/').headers.find((h) => h.key === 'Link');
+    const index = vercel.headers.find((h) => h.source === '/index.html').headers.find((h) => h.key === 'Link');
+    assert.strictEqual(slash.value, index.value);
+  });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -111,13 +111,15 @@
     {
       "source": "/",
       "headers": [
-        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" },
+        { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\"" }
       ]
     },
     {
       "source": "/index.html",
       "headers": [
-        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" },
+        { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\"" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
Closes #3308 (Link response headers). Emits `Link` on `/` and `/index.html` advertising every live agent-discoverable target per RFC 8288.

## What's advertised
| Target | rel | type |
|---|---|---|
| `/.well-known/api-catalog` | `api-catalog` | `application/linkset+json` |
| `/openapi.yaml` | `service-desc` | `application/vnd.oai.openapi` |
| `/docs/documentation` | `service-doc` | `text/html` |
| `/api/health` | `status` | `application/json` |
| `/.well-known/oauth-protected-resource` | `http://www.iana.org/assignments/relation/oauth-protected-resource` | — |
| `/.well-known/oauth-authorization-server` | `http://www.iana.org/assignments/relation/oauth-authorization-server` | — |
| `/.well-known/mcp/server-card.json` | `mcp-server-card` (anchor `/mcp`) | — |

## Why anchor="/mcp" on the MCP card link
The MCP card describes the `/mcp` endpoint, not the homepage. Per RFC 8288 the `anchor` parameter rescopes the link's context from the request URL to the given anchor, so agents correctly associate the card with `/mcp` rather than the origin root.

## Why IANA URI form for OAuth rels
RFC 9728 and the IANA Link Relations registry use the full URI form (`http://www.iana.org/assignments/relation/oauth-protected-resource`) rather than a short token — agent scanners that index by exact URI match this way.

## Test plan
- [ ] Preview: `curl -sI https://<preview>/` includes `Link: </.well-known/api-catalog>; rel="api-catalog"...` with all 7 targets.
- [ ] Preview: `curl -sI https://<preview>/index.html` same.
- [ ] Post-merge prod: same 2 checks at `https://worldmonitor.app` and `https://www.worldmonitor.app`.
- [ ] Re-run isitagentready.com scan — Link Headers check flips green.

Refs epic #3306, PRs #3343 (API catalog + openapi.yaml), #3351 (dynamic oauth-protected-resource).