### PR TITLE
fix(checkout): escape hatch for Dodo overlay deadlock on close

### DIFF
--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -131,6 +131,28 @@ let initialized = false;
 let onSuccessCallback: (() => void) | null = null;
 let _resetOverlaySession: (() => void) | null = null;
 let _watchersInitialized = false;
+let _escapeHandler: ((e: KeyboardEvent) => void) | null = null;
+
+/**
+ * Dodo's hosted overlay has been observed to deadlock: the in-iframe X
+ * button hits `GET /api/checkout/sessions/{id}/payment-link` → 404 →
+ * unhandled rejection in their React code → Maximum-update-depth render
+ * loop. When that happens, the `checkout.closed` postMessage never
+ * escapes their iframe, so our onEvent handler can't clean up and the
+ * user is trapped on the overlay. `DodoPayments.Checkout.close()`
+ * removes the iframe at the merchant-SDK level and works even when the
+ * inner overlay is frozen — it's the only safety net available since
+ * CheckoutOptions has no onCancel/dismissBehavior hook (SDK 1.8.0).
+ */
+function safeCloseOverlay(): void {
+  try {
+    if (DodoPayments.Checkout.isOpen?.()) {
+      DodoPayments.Checkout.close();
+    }
+  } catch {
+    // Swallow — the overlay is already gone or the SDK is mid-teardown.
+  }
+}
 
 /**
  * Initialize the Dodo overlay SDK. Idempotent -- second+ calls are no-ops.
@@ -229,10 +251,22 @@ export function initCheckoutOverlay(onSuccess?: () => void): void {
         case 'checkout.error':
           console.error('[checkout] Overlay error:', event.data?.message);
           Sentry.captureMessage(`Dodo checkout overlay error: ${event.data?.message || 'unknown'}`, { level: 'error', tags: { component: 'dodo-checkout' } });
+          // Release the user if their overlay surfaces an error. The
+          // deadlock bug (payment-link 404 + render loop) never reaches
+          // this branch — it traps inside their iframe — but any error
+          // that DOES escape should not leave a broken overlay mounted.
+          safeCloseOverlay();
           break;
       }
     },
   });
+
+  _escapeHandler = (e: KeyboardEvent) => {
+    if (e.key === 'Escape' && DodoPayments.Checkout.isOpen?.()) {
+      safeCloseOverlay();
+    }
+  };
+  window.addEventListener('keydown', _escapeHandler);
 
   initialized = true;
 }
@@ -244,6 +278,10 @@ export function initCheckoutOverlay(onSuccess?: () => void): void {
 export function destroyCheckoutOverlay(): void {
   initialized = false;
   onSuccessCallback = null;
+  if (_escapeHandler) {
+    window.removeEventListener('keydown', _escapeHandler);
+    _escapeHandler = null;
+  }
 }
 
 function loadPendingCheckoutIntent(): PendingCheckoutIntent | null {


### PR DESCRIPTION
## Summary

- Dodo's hosted overlay can deadlock: X-button click fires `GET /api/checkout/sessions/{id}/payment-link`, the 404 goes unhandled inside their React, and the resulting Maximum-update-depth render loop traps the `checkout.closed` postMessage inside the iframe. Our `onEvent` handler never runs, the user is stuck on the overlay.
- Adds a merchant-side safety net in `src/services/checkout.ts`: window-level Escape-key listener → `DodoPayments.Checkout.close()` via a small `safeCloseOverlay()` helper. `close()` operates on the iframe node we mounted, so it works even when the inner React is frozen.
- Also auto-closes from the `checkout.error` branch so any surfaced error doesn't leave a zombie overlay behind. Cleanup wired into `destroyCheckoutOverlay`.
- SDK `dodopayments-checkout@1.8.0` (latest) has no `onCancel` / `cancel_url` / `dismissBehavior` option — `close()` + `isOpen()` are the only escape hatch the SDK exposes.

Observed session: `cks_0NdL3CalSpBDR6vrMFIS3`, reproduced from the `?embed=pro-preview` iframe-in-iframe landing flow. The underlying 404 + render loop is a Dodo-side bug and should be filed with their support separately.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run typecheck:api` clean
- [x] `npm run lint` clean (0 errors; pre-existing warnings unrelated to this change)
- [x] `npm run test:data` — 6633/6633 pass
- [x] `node --test tests/edge-functions.test.mjs` — 177/177 pass
- [x] CJS syntax check on `scripts/*.cjs`
- [x] Edge function bundle check (`esbuild --bundle` on all `api/*.js`)
- [x] `npm run lint:md` clean
- [x] `npm run version:check` clean
- [ ] Manual: open the Dodo overlay, click X, verify Escape dismisses it when X is broken (reproduce via the embedded `?embed=pro-preview` landing)
- [ ] Manual: happy-path checkout — Escape listener does not interfere with normal flow; X still closes when working

## Follow-up

- File with Dodo support: session `cks_0NdL3CalSpBDR6vrMFIS3`, `/api/checkout/sessions/{id}/payment-link` 404 + unhandled rejection → render loop; seems correlated with iframe-embedded contexts.
- Learning captured at `.claude/skills/dodo-overlay-deadlock-merchant-close/SKILL.md`.