### PR TITLE
fix(insights): trust cluster rank, stop LLM from re-picking top story

### DIFF
--- a/scripts/_insights-brief.mjs
+++ b/scripts/_insights-brief.mjs
@@ -1,0 +1,43 @@
+// Pure helpers for the WORLD BRIEF pipeline. Split out from seed-insights.mjs
+// so tests can import without triggering the top-level runSeed() call.
+
+/**
+ * Choose which clustered story to summarize for the WORLD BRIEF.
+ *
+ * Returns the first entry in `topStories` with sourceCount >= 2, or null if
+ * no such entry exists. Callers should treat null as "publish status=degraded,
+ * no brief" — the top-stories list itself is still published; only the brief
+ * paragraph is suppressed.
+ *
+ * Why not just topStories[0]? scoreImportance() in _clustering.mjs is
+ * keyword-heavy (violence +100+25/match, flashpoint +60+15/match, ×1.5 when
+ * both hit) and can rank a single-source sensational rumor ahead of a
+ * 2-source lead. The brief should only ever publish claims that at least two
+ * outlets have independently reported — corroboration as a hard requirement,
+ * not a tiebreaker.
+ */
+export function pickBriefCluster(topStories) {
+  if (!Array.isArray(topStories)) return null;
+  return topStories.find((s) => (s?.sourceCount || 1) >= 2) ?? null;
+}
+
+/**
+ * System prompt for the WORLD BRIEF LLM call. Kept as a pure function so tests
+ * can assert its invariants (no "pick the most important" language, no
+ * unconditional WHERE instruction, explicit no-invention rules).
+ */
+export function briefSystemPrompt(dateISO) {
+  return `Current date: ${dateISO}.
+
+Rewrite the provided headline as 2 concise sentences MAX (under 60 words total).
+Rules:
+- Use ONLY facts present in the headline text. Do not add names, places, dates, or context that are not explicitly in the headline.
+- Do not invent proper nouns (people, organizations, countries) that are not in the headline.
+- Include a location, person, or organization ONLY if it appears in the headline. If the headline has no location, do not add one.
+- NEVER start with "Breaking news", "Good evening", "Tonight", or TV-style openings.
+- No bullet points, no meta-commentary, no speculation beyond the headline.`;
+}
+
+export function briefUserPrompt(headline) {
+  return `Headline: ${headline}\n\nRewrite as 2 sentences using only facts from this headline.`;
+}

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -26,7 +26,9 @@ function normalizeThreat(threat) {
   return { ...threat, level };
 }
 
-const CACHE_TTL = 1800; // 30m — matches cron interval; bad briefs age out in one cycle instead of persisting 3h
+const CACHE_TTL = 10800; // 3h — 6x the 30 min cron interval. Shorter = key expires on any missed cron tick
+                         // and /api/bootstrap loses insights entirely. Bad content is gated upstream (corroboration
+                         // requirement on topStories + grounded prompt), not by aging out fast.
 const MAX_HEADLINE_LEN = 500;
 const GROQ_MODEL = 'llama-3.1-8b-instant';
 
@@ -118,7 +120,7 @@ Rewrite the provided headline as 2 concise sentences MAX (under 60 words total).
 Rules:
 - Use ONLY facts present in the headline text. Do not add names, places, dates, or context that are not explicitly in the headline.
 - Do not invent proper nouns (people, organizations, countries) that are not in the headline.
-- Lead with WHAT happened and WHERE — be specific but grounded.
+- Include a location, person, or organization ONLY if it appears in the headline. If the headline has no location, do not add one.
 - NEVER start with "Breaking news", "Good evening", "Tonight", or TV-style openings.
 - No bullet points, no meta-commentary, no speculation beyond the headline.`;
 
@@ -272,26 +274,35 @@ async function fetchInsights() {
 
   if (topStories.length === 0) throw new Error('No top stories after scoring');
 
-  // Clustering already ranks by sourceCount + velocity + isAlert. Trust the rank:
-  // summarize only the top story. Previously we sent all 10 and asked the LLM to
-  // "pick the most important" — small/medium models biased toward sensational
-  // single-source rumors over multi-sourced objective leaders.
-  const topHeadline = sanitizeTitle(topStories[0].primaryTitle);
+  // Corroboration gate: only brief a story at least two outlets have reported.
+  // scoreImportance() in _clustering.mjs is keyword-heavy (violence +125, flashpoint
+  // +75, multiplier x1.5) and can rank a single-source sensational rumor ahead of a
+  // 2-source lead. Walking for sourceCount >= 2 makes corroboration a hard requirement,
+  // not a tiebreaker. Previously we compounded this by asking the LLM to "pick the
+  // most important" from 10 headlines — small/medium models further biased toward
+  // sensational single-source rumors over multi-sourced leaders.
+  const briefCluster = topStories.find(s => (s.sourceCount || 1) >= 2);
+  const topHeadline = briefCluster ? sanitizeTitle(briefCluster.primaryTitle) : '';
 
   let worldBrief = '';
   let briefProvider = '';
   let briefModel = '';
   let status = 'ok';
 
-  const llmResult = await callLLM(topHeadline);
-  if (llmResult) {
-    worldBrief = llmResult.text;
-    briefProvider = llmResult.provider;
-    briefModel = llmResult.model;
-    console.log(`  Brief generated via ${briefProvider} (${briefModel})`);
-  } else {
+  if (!topHeadline) {
     status = 'degraded';
-    console.warn('  No LLM available — publishing degraded (stories without brief)');
+    console.warn('  No multi-source cluster available — publishing degraded (stories without brief)');
+  } else {
+    const llmResult = await callLLM(topHeadline);
+    if (llmResult) {
+      worldBrief = llmResult.text;
+      briefProvider = llmResult.provider;
+      briefModel = llmResult.model;
+      console.log(`  Brief generated via ${briefProvider} (${briefModel})`);
+    } else {
+      status = 'degraded';
+      console.warn('  No LLM available — publishing degraded (stories without brief)');
+    }
   }
 
   const multiSourceCount = clusters.filter(c => c.sourceCount >= 2).length;

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -4,6 +4,7 @@ import { loadEnvFile, CHROME_UA, getRedisCredentials, runSeed } from './_seed-ut
 import { clusterItems, selectTopStories } from './_clustering.mjs';
 import { extractCountryCode } from './shared/geo-extract.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
+import { pickBriefCluster, briefSystemPrompt, briefUserPrompt } from './_insights-brief.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -26,9 +27,10 @@ function normalizeThreat(threat) {
   return { ...threat, level };
 }
 
-const CACHE_TTL = 10800; // 3h — 6x the 30 min cron interval. Shorter = key expires on any missed cron tick
-                         // and /api/bootstrap loses insights entirely. Bad content is gated upstream (corroboration
-                         // requirement on topStories + grounded prompt), not by aging out fast.
+const CACHE_TTL = 10800; // 3h — 6x the 30 min cron interval. Shorter = key expires on any missed
+                         // cron tick and /api/bootstrap loses insights entirely. Bad brief content
+                         // is gated at brief-selection time (see pickBriefCluster + briefSystemPrompt
+                         // in _insights-brief.mjs), not by aging out fast.
 const MAX_HEADLINE_LEN = 500;
 const GROQ_MODEL = 'llama-3.1-8b-instant';
 
@@ -112,19 +114,8 @@ const LLM_PROVIDERS = [
 ];
 
 async function callLLM(headline) {
-  const dateContext = `Current date: ${new Date().toISOString().split('T')[0]}.`;
-
-  const systemPrompt = `${dateContext}
-
-Rewrite the provided headline as 2 concise sentences MAX (under 60 words total).
-Rules:
-- Use ONLY facts present in the headline text. Do not add names, places, dates, or context that are not explicitly in the headline.
-- Do not invent proper nouns (people, organizations, countries) that are not in the headline.
-- Include a location, person, or organization ONLY if it appears in the headline. If the headline has no location, do not add one.
-- NEVER start with "Breaking news", "Good evening", "Tonight", or TV-style openings.
-- No bullet points, no meta-commentary, no speculation beyond the headline.`;
-
-  const userPrompt = `Headline: ${headline}\n\nRewrite as 2 sentences using only facts from this headline.`;
+  const systemPrompt = briefSystemPrompt(new Date().toISOString().split('T')[0]);
+  const userPrompt = briefUserPrompt(headline);
 
   for (const provider of LLM_PROVIDERS) {
     const envVal = process.env[provider.envKey];
@@ -275,13 +266,12 @@ async function fetchInsights() {
   if (topStories.length === 0) throw new Error('No top stories after scoring');
 
   // Corroboration gate: only brief a story at least two outlets have reported.
-  // scoreImportance() in _clustering.mjs is keyword-heavy (violence +125, flashpoint
-  // +75, multiplier x1.5) and can rank a single-source sensational rumor ahead of a
-  // 2-source lead. Walking for sourceCount >= 2 makes corroboration a hard requirement,
-  // not a tiebreaker. Previously we compounded this by asking the LLM to "pick the
-  // most important" from 10 headlines — small/medium models further biased toward
-  // sensational single-source rumors over multi-sourced leaders.
-  const briefCluster = topStories.find(s => (s.sourceCount || 1) >= 2);
+  // See pickBriefCluster() in _insights-brief.mjs for rationale + unit tests.
+  // Note: this gates ONLY brief generation — the topStories payload itself
+  // continues to include single-source clusters, rendered as the headline list
+  // under the brief. The brief paragraph is the one surface where corroboration
+  // matters; the list is already visually marked with per-story sourceCount.
+  const briefCluster = pickBriefCluster(topStories);
   const topHeadline = briefCluster ? sanitizeTitle(briefCluster.primaryTitle) : '';
 
   let worldBrief = '';

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -26,8 +26,7 @@ function normalizeThreat(threat) {
   return { ...threat, level };
 }
 
-const CACHE_TTL = 10800; // 3h — 6x the 30 min cron interval (was 1x = key expired on any missed run)
-const MAX_HEADLINES = 10;
+const CACHE_TTL = 1800; // 30m — matches cron interval; bad briefs age out in one cycle instead of persisting 3h
 const MAX_HEADLINE_LEN = 500;
 const GROQ_MODEL = 'llama-3.1-8b-instant';
 
@@ -110,23 +109,20 @@ const LLM_PROVIDERS = [
   },
 ];
 
-async function callLLM(headlines) {
-  const headlineText = headlines.map((h, i) => `${i + 1}. ${h}`).join('\n');
-  const dateContext = `Current date: ${new Date().toISOString().split('T')[0]}. Provide geopolitical context appropriate for the current date.`;
+async function callLLM(headline) {
+  const dateContext = `Current date: ${new Date().toISOString().split('T')[0]}.`;
 
   const systemPrompt = `${dateContext}
 
-Summarize the single most important headline in 2 concise sentences MAX (under 60 words total).
+Rewrite the provided headline as 2 concise sentences MAX (under 60 words total).
 Rules:
-- Each numbered headline below is a SEPARATE, UNRELATED story
-- Pick the ONE most significant headline and summarize ONLY that story
-- NEVER combine or merge people, places, or facts from different headlines into one sentence
-- Lead with WHAT happened and WHERE - be specific
-- NEVER start with "Breaking news", "Good evening", "Tonight", or TV-style openings
-- Start directly with the subject of the chosen headline
-- No bullet points, no meta-commentary, no elaboration beyond the core facts`;
+- Use ONLY facts present in the headline text. Do not add names, places, dates, or context that are not explicitly in the headline.
+- Do not invent proper nouns (people, organizations, countries) that are not in the headline.
+- Lead with WHAT happened and WHERE — be specific but grounded.
+- NEVER start with "Breaking news", "Good evening", "Tonight", or TV-style openings.
+- No bullet points, no meta-commentary, no speculation beyond the headline.`;
 
-  const userPrompt = `Each headline below is a separate story. Pick the most important ONE and summarize only that story:\n${headlineText}`;
+  const userPrompt = `Headline: ${headline}\n\nRewrite as 2 sentences using only facts from this headline.`;
 
   for (const provider of LLM_PROVIDERS) {
     const envVal = process.env[provider.envKey];
@@ -146,7 +142,7 @@ Rules:
             { role: 'user', content: userPrompt },
           ],
           max_tokens: 300,
-          temperature: 0.3,
+          temperature: 0.1,
           ...provider.extraBody,
         }),
         signal: AbortSignal.timeout(provider.timeout),
@@ -276,16 +272,18 @@ async function fetchInsights() {
 
   if (topStories.length === 0) throw new Error('No top stories after scoring');
 
-  const headlines = topStories
-    .slice(0, MAX_HEADLINES)
-    .map(s => sanitizeTitle(s.primaryTitle));
+  // Clustering already ranks by sourceCount + velocity + isAlert. Trust the rank:
+  // summarize only the top story. Previously we sent all 10 and asked the LLM to
+  // "pick the most important" — small/medium models biased toward sensational
+  // single-source rumors over multi-sourced objective leaders.
+  const topHeadline = sanitizeTitle(topStories[0].primaryTitle);
 
   let worldBrief = '';
   let briefProvider = '';
   let briefModel = '';
   let status = 'ok';
 
-  const llmResult = await callLLM(headlines);
+  const llmResult = await callLLM(topHeadline);
   if (llmResult) {
     worldBrief = llmResult.text;
     briefProvider = llmResult.provider;

--- a/tests/seed-insights-brief.test.mjs
+++ b/tests/seed-insights-brief.test.mjs
@@ -1,0 +1,104 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  pickBriefCluster,
+  briefSystemPrompt,
+  briefUserPrompt,
+} from '../scripts/_insights-brief.mjs';
+
+describe('pickBriefCluster', () => {
+  it('returns null for empty/non-array input', () => {
+    assert.equal(pickBriefCluster([]), null);
+    assert.equal(pickBriefCluster(null), null);
+    assert.equal(pickBriefCluster(undefined), null);
+  });
+
+  it('returns null when every cluster is single-source', () => {
+    const top = [
+      { sourceCount: 1, primaryTitle: 'A' },
+      { sourceCount: 1, primaryTitle: 'B' },
+    ];
+    assert.equal(pickBriefCluster(top), null);
+  });
+
+  it('returns the first cluster with sourceCount >= 2', () => {
+    const top = [
+      { sourceCount: 1, primaryTitle: 'A' },
+      { sourceCount: 3, primaryTitle: 'B' },
+      { sourceCount: 2, primaryTitle: 'C' },
+    ];
+    assert.equal(pickBriefCluster(top).primaryTitle, 'B');
+  });
+
+  it('skips a higher-ranked single-source rumor for a lower-ranked multi-sourced lead (regression: News24 Iran supreme leader 2026-04-23)', () => {
+    const top = [
+      {
+        sourceCount: 1,
+        primaryTitle: 'Iran new supreme leader seriously wounded, delegates power to Revolutionary Guards',
+        importanceScore: 350,
+      },
+      {
+        sourceCount: 2,
+        primaryTitle: 'Lebanon leaders accuse Israel of war crime after journalist killed',
+        importanceScore: 300,
+      },
+    ];
+    const picked = pickBriefCluster(top);
+    assert.ok(picked, 'expected a multi-source cluster to be picked');
+    assert.match(picked.primaryTitle, /Lebanon/);
+    assert.doesNotMatch(picked.primaryTitle, /supreme leader/);
+  });
+
+  it('treats a missing sourceCount as 1 (safe default — do not brief on unknown corroboration)', () => {
+    const top = [
+      { primaryTitle: 'A' }, // no sourceCount field
+      { sourceCount: 2, primaryTitle: 'B' },
+    ];
+    assert.equal(pickBriefCluster(top).primaryTitle, 'B');
+  });
+
+  it('tolerates a null/undefined entry without throwing', () => {
+    const top = [null, undefined, { sourceCount: 2, primaryTitle: 'A' }];
+    assert.equal(pickBriefCluster(top).primaryTitle, 'A');
+  });
+});
+
+describe('briefSystemPrompt', () => {
+  const prompt = briefSystemPrompt('2026-04-24');
+
+  it('includes the injected date', () => {
+    assert.match(prompt, /2026-04-24/);
+  });
+
+  it('forbids inventing facts absent from the headline', () => {
+    assert.match(prompt, /Use ONLY facts present/);
+    assert.match(prompt, /Do not invent proper nouns/);
+  });
+
+  it('makes location conditional — no unconditional "WHERE" directive', () => {
+    // Regression: P2 review finding. "Lead with WHAT happened and WHERE" + "use ONLY facts"
+    // conflicted for headlines with no location, pushing the model to confabulate one.
+    assert.doesNotMatch(prompt, /Lead with WHAT happened and WHERE/);
+    assert.match(prompt, /ONLY if it appears in the headline/);
+  });
+
+  it('does not ask the LLM to rank/pick from multiple headlines', () => {
+    // Regression: the original prompt said "Pick the ONE most significant headline".
+    // Ranking is now done by pickBriefCluster upstream.
+    assert.doesNotMatch(prompt, /Pick the ONE most significant/);
+    assert.doesNotMatch(prompt, /Each numbered headline/i);
+    assert.doesNotMatch(prompt, /summarize ONLY that story/i);
+  });
+});
+
+describe('briefUserPrompt', () => {
+  it('passes the headline verbatim', () => {
+    const headline = 'Iran launches missile strikes on targets in Syria';
+    const out = briefUserPrompt(headline);
+    assert.ok(out.includes(headline));
+  });
+
+  it('instructs using only facts from the provided headline', () => {
+    assert.match(briefUserPrompt('X'), /only facts from this headline/i);
+  });
+});


### PR DESCRIPTION
## Summary

Two compounding issues produced a user-visible hallucination in the WORLD BRIEF panel. This PR fixes both, with a corroboration gate as the safety backstop — and locks both behaviors with regression tests.

**1. The LLM was double-ranking.** `scripts/seed-insights.mjs` sent all 10 clustered headlines to gemini-2.5-flash with "pick the ONE most significant and summarize." Shrink that to phrasing-only — pass a single chosen headline and instruct the model to rewrite using only facts present in it.

**2. The upstream cluster ranker is keyword-heavy, not objective.** `scoreImportance()` in `scripts/_clustering.mjs` awards `sourceCount * 10` but `+100+25` per violence keyword, `+60+75` for flashpoint/military, and a `x1.5` multiplier when both hit — a single-source sensational rumor routinely outranks a 2-source lead. So blindly trusting `topStories[0]` still produces bad briefs. Add a corroboration gate: walk `topStories` for the first cluster with `sourceCount >= 2`; if none qualifies, publish `status: 'degraded'` with no brief. This gate only affects the brief paragraph — the topStories list itself continues to render single-source clusters.

**3. Prompt contradiction.** "Use ONLY facts present in the headline" conflicted with "Lead with WHAT happened and WHERE" for headlines with no explicit location — pushing the model toward inferred-place hallucination. Replaced with "Include a location, person, or organization ONLY if it appears in the headline."

**4. Regression tests.** Selection logic + prompt invariants extracted into `scripts/_insights-brief.mjs` (pure module, no side effects at import time) and locked by `tests/seed-insights-brief.test.mjs` — 12 cases including an explicit News24-Iran-scenario test that fails if future code ever briefs a single-source cluster over a multi-sourced lead.

Also: `temperature 0.3 -> 0.1` (factual summary), dead `MAX_HEADLINES` const removed. **CACHE_TTL unchanged at 10800 (3h)** — a one-cron-cadence TTL would reintroduce the cache-drop outage the old comment warned against (`/api/bootstrap` reads the key directly). Bad content is gated at brief-selection time now, so the LKG window does not need to be sacrificed.

Payload shape unchanged; frontend untouched.

### Why (user-visible bug)

WORLD BRIEF panel published for ~3h on 2026-04-23:
> "Iran's new supreme leader was seriously wounded, leading him to delegate power to the Revolutionary Guards. This development comes amid an ongoing war with Israel."

Payload receipt: `briefProvider: openrouter`, `briefModel: google/gemini-2.5-flash`. An earlier generation also confabulated the name "Ayatollah Ali Khamenei" (not in any input headline — gemini filled it in from its training prior).

Input top stories (cluster rank):
1. Lebanon leaders accuse Israel of war crime after journalist killed (2 sources)
2. Lebanon accuses Israel of targeting journalist killed in air strike (same cluster)
3. News24 | Iran's new supreme leader seriously wounded, delegates power to Revolutionary Guards (1 source)
4. Navy Secretary John Phelan fired amid tensions with Pete Hegseth as Iran war rages
5. A well-known secret: inside Toronto's violent tow truck wars

Old prompt told gemini to pick the most significant and summarize it. Gemini picked #3 (single-source rumor) over #1 (multi-sourced lead) and embellished with the "ongoing war with Israel" frame pulled from #4. After this PR: #3 is never eligible for the brief (sourceCount < 2); #1 is briefed using only its own headline text.

## Test plan

- [x] `npm run typecheck` — PASS (22s)
- [x] `npm run typecheck:api` — PASS (8s)
- [x] `npm run lint` — PASS (no new warnings beyond 202-warning / 23-info baseline)
- [x] `npm run test:data` — PASS (6657/6657 — +12 new regression tests)
- [x] `node --test tests/seed-insights-brief.test.mjs` — 12/12 PASS including the News24-Iran regression scenario
- [x] `node --test tests/edge-functions.test.mjs` — PASS
- [x] Edge bundle check across `api/*.js` — PASS
- [x] `npm run lint:md` — PASS (0 errors)
- [x] `npm run version:check` — PASS
- [x] CJS syntax across `scripts/*.cjs` — PASS
- [x] `node --check scripts/seed-insights.mjs` + `node --check scripts/_insights-brief.mjs`
- [ ] After merge: `DEL news:insights:v1` in Upstash so the next cron tick regenerates immediately (current bad brief otherwise persists until its existing TTL expires)
- [ ] Verify next `/api/bootstrap` payload: `insights.worldBrief` summarizes a `sourceCount >= 2` cluster and contains no proper noun absent from that cluster's `primaryTitle`; or `insights.status === 'degraded'` with empty `worldBrief`