### PR TITLE
fix(health): treat empty intlDelays as OK, matching faaDelays

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -462,7 +462,7 @@ const ON_DEMAND_KEYS = new Set([
 // no earnings events this week, econ calendar quiet between seasons).
 // The key must still exist in Redis; only the record count can be 0.
 const EMPTY_DATA_OK_KEYS = new Set([
-  'notamClosures', 'faaDelays', 'gpsjam', 'positiveGeoEvents', 'weatherAlerts',
+  'notamClosures', 'faaDelays', 'intlDelays', 'gpsjam', 'positiveGeoEvents', 'weatherAlerts',
   'earningsCalendar', 'econCalendar', 'cotPositioning',
   'usniFleet', // usniFleetStale covers the fallback; relay outages → WARN not CRIT
   'newsThreatSummary', // only written when classify produces country matches; quiet news periods = 0 countries, no write


### PR DESCRIPTION
## Summary
- `intlDelays` was alarming `EMPTY_DATA` (CRIT) during calm aviation windows (seedAge 25min, records 0) even though the seeder successfully wrote the valid-but-empty `{ alerts: [] }` payload.
- Its sibling `faaDelays` — produced by the same aviation seeder — is already in `EMPTY_DATA_OK_KEYS`. Both legitimately have quiet periods with 0 alerts.
- The seeder declares `zeroIsValid: true` at `scripts/seed-aviation.mjs:1171`. Adding `intlDelays` to `EMPTY_DATA_OK_KEYS` in `api/health.js:465` aligns the health classifier with the seeder contract.
- Stale-seed degradation still triggers if the seeder stops running (seedAge > 90min).

## Test plan
- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` (no errors)
- [x] `npm run test:data` (6654 pass)
- [x] `node --test tests/edge-functions.test.mjs` (177 pass)
- [x] Edge bundle check for all `api/*.js`
- [x] `npm run lint:md`
- [x] `npm run version:check`
- [ ] After merge, confirm the next health poll reports `intlDelays: { status: "OK", records: 0 }` instead of `EMPTY_DATA` during a quiet window.
- [ ] Inject a simulated stale scenario (seedAge > 90min) and verify classifier still degrades to `STALE_SEED`.