### PR TITLE
fix(unrest): bump GDELT proxy timeout 20s → 45s

### DIFF
--- a/scripts/seed-unrest-events.mjs
+++ b/scripts/seed-unrest-events.mjs
@@ -176,9 +176,13 @@ async function fetchGdeltDirect(url) {
 }
 
 async function fetchGdeltViaProxy(url, proxyAuth) {
+  // GDELT v1 gkg_geojson responds in ~19s when degraded; 20s timeout caused
+  // chronic "HTTP 522" / "CONNECT tunnel timeout" from Decodo, freezing
+  // seed-meta and firing STALE_SEED across health. 45s absorbs that variance
+  // with headroom.
   const { buffer } = await httpsProxyFetchRaw(url, proxyAuth, {
     accept: 'application/json',
-    timeoutMs: 20_000,
+    timeoutMs: 45_000,
   });
   return JSON.parse(buffer.toString('utf8'));
 }


### PR DESCRIPTION
## Summary

- GDELT v1 `gkg_geojson` endpoint is currently degraded — direct `curl` to the endpoint returns HTTP 200 at **t=19.4s** right now.
- With the old 20s proxy timeout the Decodo leg hits Cloudflare origin timeout and returns **HTTP 522** on nearly every tick, so `fetchGdeltEvents` throws "both paths failed — proxy: HTTP/1.1 522 Server Error".
- When both paths fail, `runSeed` extends the data TTL but **does not advance `seed-meta:unrest:events.fetchedAt`**, so `/api/health` reports `unrestEvents: STALE_SEED` (seedAgeMin climbing past 120) even though the cron is firing every 45 min and Redis still holds the last-good payload.
- **4.5+ consecutive hours** of "both paths failed" observed in production logs overnight (2026-04-24 00:00 → 04:30 UTC), matching the user-reported `seedAgeMin: 132, records: 106` health alert.
- Direct path has been chronically broken with `UND_ERR_CONNECT_TIMEOUT` since PR #3256 added the proxy fallback, so the proxy is the real fetch path. 45s gives comfortable headroom for GDELT's current ~19s responses.

## Follow-ups (out of scope for this PR)

- ACLED credentials are unconfigured in the Railway unrest service — every run logs `ACLED: no credentials configured, skipping`, so GDELT is effectively the single upstream. Wiring `ACLED_USERNAME`/`ACLED_PASSWORD` env vars would give the seeder a genuine second source.
- Consider flipping the fetch order (proxy-first, direct as fallback) since the direct leg has zero success rate in production logs — it currently burns ~30s per tick on a path that can't succeed.

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] CJS syntax check
- [x] `npm run lint` (no errors)
- [x] `npm run test:data` (6692 pass)
- [x] Edge bundle check for all `api/*.js`
- [x] `node --test tests/edge-functions.test.mjs` (177 pass)
- [x] `npm run lint:md`
- [x] `npm run version:check`
- [ ] After merge, monitor the next 3 unrest cron runs in Railway logs — expect at least one `GDELT: NNNN mentions → N aggregated events` success within 15–30 min.
- [ ] Confirm `/api/health` returns `unrestEvents: { status: "OK" }` within ~50 min of first successful run.