### PR TITLE
fix(resilience): PR 1 — widen Comtrade period to 4y + surface picked year

### DIFF
--- a/scripts/seed-recovery-import-hhi.mjs
+++ b/scripts/seed-recovery-import-hhi.mjs
@@ -52,11 +52,23 @@ for (const [iso2, code] of Object.entries(COMTRADE_REPORTER_OVERRIDES)) {
 
 const ALL_REPORTERS = Object.values(UN_TO_ISO2).filter(c => c.length === 2);
 
-function parseRecords(data) {
+// Parse Comtrade imports into partner-value rows for HHI. Picks the
+// "best" year per reporter using a freshness-weighted rule:
+//   (a) prefer years with more partner rows (proxy for data completeness);
+//   (b) on ties, prefer the most recent year (newer data wins).
+//
+// PR 1 of plan 2026-04-24-002: period window is 4y (Y-1..Y-4). Late-
+// reporters like UAE, Oman, Bahrain publish Comtrade 1-2y behind; with
+// the original Y-1..Y-2 window their per-reporter query returned an
+// empty set and they fell through to IMPUTED on importConcentration.
+// The 4y window gives us a chance to pick a reporter's latest
+// non-empty year without degrading the result for on-time reporters
+// (they still get their newest year on the completeness tiebreak).
+export function parseRecords(data) {
   const records = data?.data ?? [];
-  if (!Array.isArray(records)) return [];
+  if (!Array.isArray(records)) return { rows: [], year: null };
   const valid = records.filter(r => r && Number(r.primaryValue ?? 0) > 0);
-  if (valid.length === 0) return [];
+  if (valid.length === 0) return { rows: [], year: null };
   const byPeriod = new Map();
   for (const r of valid) {
     const p = String(r.period ?? r.refPeriodId ?? '0');
@@ -75,10 +87,12 @@ function parseRecords(data) {
       bestPeriod = p;
     }
   }
-  return byPeriod.get(bestPeriod).map(r => ({
+  const rows = byPeriod.get(bestPeriod).map(r => ({
     partnerCode: String(r.partnerCode ?? r.partner2Code ?? '000'),
     primaryValue: Number(r.primaryValue ?? 0),
   }));
+  const yearNum = Number(bestPeriod);
+  return { rows, year: Number.isFinite(yearNum) ? yearNum : null };
 }
 
 // Comtrade transient 5xx (500/502/503/504) must be retried or the reporter
@@ -94,12 +108,24 @@ export function isTransientComtrade(status) {
 let _retrySleep = sleep;
 export function __setSleepForTests(fn) { _retrySleep = typeof fn === 'function' ? fn : sleep; }
 
+// 4-year period window. Plan 2026-04-24-002 §PR 1: late-reporters
+// (UAE, Oman, Bahrain and others) publish Comtrade 1-2y behind G7, so
+// a Y-1..Y-2 window silently drops them. Y-1..Y-4 keeps on-time
+// reporters' latest-year data AND picks up late reporters' most
+// recent published year.
+const PERIOD_WINDOW_YEARS = 4;
+export function buildPeriodParam(nowYear = new Date().getFullYear()) {
+  const years = [];
+  for (let i = 1; i <= PERIOD_WINDOW_YEARS; i++) years.push(nowYear - i);
+  return years.join(',');
+}
+
 export async function fetchImportsForReporter(reporterCode, apiKey) {
   const url = new URL(COMTRADE_URL);
   url.searchParams.set('reporterCode', reporterCode);
   url.searchParams.set('flowCode', 'M');
   url.searchParams.set('cmdCode', 'TOTAL');
-  url.searchParams.set('period', `${new Date().getFullYear() - 1},${new Date().getFullYear() - 2}`);
+  url.searchParams.set('period', buildPeriodParam());
   url.searchParams.set('subscription-key', apiKey);
 
   async function once() {
@@ -135,8 +161,9 @@ export async function fetchImportsForReporter(reporterCode, apiKey) {
     break;
   }
 
-  if (!resp.ok) return { records: [], status: resp.status };
-  return { records: parseRecords(await resp.json()), status: resp.status };
+  if (!resp.ok) return { records: [], year: null, status: resp.status };
+  const { rows, year } = parseRecords(await resp.json());
+  return { records: rows, year, status: resp.status };
 }
 
 export function computeHhi(records) {
@@ -184,7 +211,7 @@ async function runWorker(apiKey, queue, countries, progressRef) {
     if (!unCode) { progressRef.skipped++; continue; }
 
     try {
-      const { records, status } = await fetchImportsForReporter(unCode, apiKey);
+      const { records, year, status } = await fetchImportsForReporter(unCode, apiKey);
       if (records.length === 0) {
         if (status && status !== 200) progressRef.errors++;
         progressRef.skipped++;
@@ -197,6 +224,11 @@ async function runWorker(apiKey, queue, countries, progressRef) {
             hhi: result.hhi,
             concentrated: result.hhi > 0.25,
             partnerCount: result.partnerCount,
+            // `year` is the reporter's latest non-empty Comtrade year inside
+            // the 4y window. Publication-lag auditors (operators + the
+            // cohort-sanity audit at scripts/audit-resilience-cohorts.mjs)
+            // read this to see which reporters are 2-3y stale vs current.
+            year,
             fetchedAt: new Date().toISOString(),
           };
           progressRef.fetched++;

--- a/tests/seed-recovery-import-hhi.test.mjs
+++ b/tests/seed-recovery-import-hhi.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { computeHhi } from '../scripts/seed-recovery-import-hhi.mjs';
+import { computeHhi, buildPeriodParam, parseRecords } from '../scripts/seed-recovery-import-hhi.mjs';
 
 describe('seed-recovery-import-hhi', () => {
   it('computes HHI=1 for single-partner imports', () => {
@@ -105,5 +105,105 @@ describe('seed-recovery-import-hhi', () => {
     // HHI = 0.667^2 + 0.333^2 ≈ 0.5556
     assert.ok(Math.abs(result.hhi - 0.5556) < 0.01, `HHI ${result.hhi} should be ~0.5556`);
     assert.equal(result.partnerCount, 2);
+  });
+});
+
+// PR 1 of plan 2026-04-24-002: 4-year period window + pick-latest-per-reporter
+// to unblock late-reporters (UAE, OM, BH) who publish Comtrade 1-2y behind.
+describe('seed-recovery-import-hhi — period window + pick-latest', () => {
+  describe('buildPeriodParam', () => {
+    it('emits a 4-year window descending from Y-1 to Y-4', () => {
+      assert.equal(buildPeriodParam(2026), '2025,2024,2023,2022');
+    });
+
+    it('defaults to the current system year when no arg passed', () => {
+      const nowYear = new Date().getFullYear();
+      const produced = buildPeriodParam();
+      const parts = produced.split(',').map(Number);
+      assert.equal(parts.length, 4, 'must always produce exactly 4 years');
+      assert.equal(parts[0], nowYear - 1, 'first year is Y-1 relative to system clock');
+      assert.equal(parts[3], nowYear - 4, 'last year is Y-4');
+    });
+
+    it('never emits the current year (Comtrade is always behind by at least 1y)', () => {
+      const produced = buildPeriodParam(2026).split(',').map(Number);
+      assert.ok(!produced.includes(2026), `${produced} must not include the current year`);
+    });
+  });
+
+  describe('parseRecords — picks year with most partners', () => {
+    it('picks the year with the most partner rows (completeness tiebreak)', () => {
+      const data = { data: [
+        // 2023 has 3 partners → fewer than 2024
+        { period: 2023, partnerCode: '156', primaryValue: 100 },
+        { period: 2023, partnerCode: '842', primaryValue: 100 },
+        { period: 2023, partnerCode: '276', primaryValue: 100 },
+        // 2024 has 5 partners → winner on completeness
+        { period: 2024, partnerCode: '156', primaryValue: 100 },
+        { period: 2024, partnerCode: '842', primaryValue: 100 },
+        { period: 2024, partnerCode: '276', primaryValue: 100 },
+        { period: 2024, partnerCode: '392', primaryValue: 100 },
+        { period: 2024, partnerCode: '410', primaryValue: 100 },
+      ]};
+      const { rows, year } = parseRecords(data);
+      assert.equal(year, 2024, 'should pick 2024 (more partners)');
+      assert.equal(rows.length, 5, 'should return the 2024 rows only');
+    });
+
+    it('picks the most recent year when partner counts tie', () => {
+      const data = { data: [
+        { period: 2022, partnerCode: '156', primaryValue: 100 },
+        { period: 2022, partnerCode: '842', primaryValue: 100 },
+        { period: 2023, partnerCode: '156', primaryValue: 100 },
+        { period: 2023, partnerCode: '842', primaryValue: 100 },
+      ]};
+      const { rows, year } = parseRecords(data);
+      assert.equal(year, 2023, 'should pick the newer year on ties');
+      assert.equal(rows.length, 2);
+    });
+
+    it('picks the only populated year for late-reporters (the UAE/OM/BH scenario)', () => {
+      // UAE pattern: Comtrade has 2023 data but 2024/2025 rows are empty.
+      const data = { data: [
+        { period: 2023, partnerCode: '156', primaryValue: 500 },
+        { period: 2023, partnerCode: '842', primaryValue: 500 },
+        { period: 2023, partnerCode: '276', primaryValue: 500 },
+        // No 2024/2025 rows — this is what the API returns for a late reporter.
+      ]};
+      const { rows, year } = parseRecords(data);
+      assert.equal(year, 2023, 'must surface 2023 as the latest non-empty year');
+      assert.equal(rows.length, 3, 'must return all 2023 rows intact');
+    });
+
+    it('returns { rows: [], year: null } on empty input (no IMPUTE surface)', () => {
+      assert.deepEqual(parseRecords({ data: [] }), { rows: [], year: null });
+      assert.deepEqual(parseRecords({}), { rows: [], year: null });
+      assert.deepEqual(parseRecords(null), { rows: [], year: null });
+    });
+
+    it('ignores rows with primaryValue <= 0', () => {
+      const data = { data: [
+        { period: 2024, partnerCode: '156', primaryValue: 0 },
+        { period: 2024, partnerCode: '842', primaryValue: -100 },
+        { period: 2023, partnerCode: '156', primaryValue: 500 },
+      ]};
+      const { rows, year } = parseRecords(data);
+      assert.equal(year, 2023, 'only 2023 has a positive-value row');
+      assert.equal(rows.length, 1);
+    });
+
+    it('ignores world-aggregate partner codes (0, 000) in the completeness count', () => {
+      // 2024 has one real partner + two world-aggregate rows (4 total rows,
+      // but only 1 "usable"); 2023 has two real partners (2 usable). 2023 wins.
+      const data = { data: [
+        { period: 2024, partnerCode: '0',   primaryValue: 1000 },
+        { period: 2024, partnerCode: '000', primaryValue: 1000 },
+        { period: 2024, partnerCode: '156', primaryValue: 500 },
+        { period: 2023, partnerCode: '156', primaryValue: 500 },
+        { period: 2023, partnerCode: '842', primaryValue: 500 },
+      ]};
+      const { year } = parseRecords(data);
+      assert.equal(year, 2023, 'completeness count must exclude world-aggregates');
+    });
   });
 });


### PR DESCRIPTION
## Summary

**PR 1 of the cohort-audit workstream** (plan: `docs/plans/2026-04-24-002-fix-resilience-cohort-ranking-structural-audit-plan.md`). Unblocks UAE, Oman, Bahrain (and any other late-reporter) on the `importConcentration` dimension.

Follows PR #3369 (cohort-sanity release-gate harness).

## Problem

`scripts/seed-recovery-import-hhi.mjs` queries Comtrade with `period=Y-1,Y-2` — currently `2025,2024`. Several reporters (UAE, Oman, Bahrain, and others) publish Comtrade 1-2y behind G7 — their 2024/2025 rows are empty while 2023 is populated. With no data in the queried window:

1. `parseRecords()` returned `[]` for the reporter,
2. seeder counted a "skip",
3. scorer fell through to `IMPUTE` (`score=50, coverage=0.3, imputationClass='unmonitored'`),
4. the cohort-sanity audit in PR #3369 correctly flagged AE as a coverage-outlier inside the GCC.

This is a clean *seed-level* fix — same family as `wb-bulk-mrv1-null-coverage-trap`.

## Fix

1. **4-year period window** via a new `buildPeriodParam(nowYear)` helper. Query becomes `period=Y-1,Y-2,Y-3,Y-4`. On-time reporters still pick their newest year via the existing completeness tiebreak; late reporters pick up whatever year they actually published.
2. **`parseRecords()` now returns `{ rows, year }`** — the picked year surfaces in the per-country payload as `year: number | null` for operator freshness audit. The scorer's `RecoveryImportHhiCountry` type at `_dimension-scorers.ts:1524` already expects this field; PR 1 actually populates it.
3. **Exports** — `buildPeriodParam` and `parseRecords` are now exported so unit tests can pin year-selection behaviour without hitting Comtrade.

No cache-prefix bump: the payload shape only ADDS an optional field; old snapshots remain valid readers.

## Note on PR 2 of the plan

The plan calls out **"PR 2 — externalDebtCoverage re-goalpost to Greenspan-Guidotti"** as unshipped. It **IS** shipped: commit `7f78a7561` (`feat(resilience): PR 3 §3.5 point 3 — re-goalpost externalDebtCoverage (0..5 → 0..2)`) landed under the prior workstream plan `2026-04-22-001`. My new construct invariants in `tests/resilience-construct-invariants.test.mts` (PR #3369) confirm `score(ratio=0)=100`, `score(1)=50`, `score(2)=0` against current main. PR 2 of the cohort-audit plan is a no-op — flagging this here rather than bundling a plan edit into PR 1.

## Testing

- `npx tsx --test tests/seed-recovery-import-hhi.test.mjs` — **19 pass** (10 existing + 9 new):
  - `buildPeriodParam` shape: 4y window, Y-1..Y-4, never the current year
  - `parseRecords` picks: completeness-tiebreak winner, newer-year on ties, late-reporter fallback (the UAE/OM/BH scenario)
  - Empty / negative-value / world-aggregate handling
- `npx tsx --test tests/seed-comtrade-5xx-retry.test.mjs` — green (the caller's `{ records, status }` destructure still works; the new `year` field is purely additive)
- `npm run test:data` — **6703 pass / 0 fail**
- `npm run typecheck` / `typecheck:api` — green
- `npm run lint` / `lint:md` — no new warnings
- Pre-push: typecheck + `build:full` + version sync — all green

Acceptance per plan:

- Construct invariant `score(HHI=0.05) > score(HHI=0.20)` — already covered in `tests/resilience-construct-invariants.test.mts` (#3369)
- Monotonicity pin — covered in `tests/resilience-dimension-monotonicity.test.mts`

## Post-Deploy Monitoring & Validation

**What to monitor/search**
- Logs: Railway cron `seed-bundle-resilience-recovery` — specifically the `[seed] import-hhi: N fetched, M skipped, E errors, T total` line
- Keys: `resilience:recovery:import-hhi:v1` payload

**Validation checks (queries/commands)**
```bash
# After the next bundle cron tick (weekly — `0 6 * * 1`):
redis-cli --url $UPSTASH_REDIS_REST_URL GET resilience:recovery:import-hhi:v1 | \
  jq '.countries | to_entries | map(select(.value.hhi != null)) | length'
# Expected: higher than pre-fix count (late-reporters newly populated)

# Spot-check UAE/OM/BH specifically:
redis-cli --url $UPSTASH_REDIS_REST_URL GET resilience:recovery:import-hhi:v1 | \
  jq '.countries | {AE: .AE, OM: .OM, BH: .BH}'
# Expected: non-null hhi + `year` field surfaces the picked year (likely 2023 for AE/OM/BH)

# Re-run the cohort-sanity audit (PR #3369):
WORLDMONITOR_API_KEY=wm_xxx API_BASE=https://api.worldmonitor.app \
  node scripts/audit-resilience-cohorts.mjs | grep -A5 "Flagged patterns"
# Expected: GCC coverage-outlier flag on AE.importConcentration disappears
```

**Expected healthy behavior**
- `seed-bundle-resilience-recovery` still ≤ 30min budget; total `fetched` count INCREASES (late reporters now land data instead of skipping)
- `resilience:recovery:import-hhi:v1` has a `year` field on every populated country entry (range 2022..2025 depending on reporter)
- `/api/health` remains HEALTHY on `resilience.recovery.import-hhi`
- Scorer's `scoreImportConcentration` returns real scores (not IMPUTE) for UAE/OM/BH

**Failure signal(s) / rollback trigger**
- Comtrade rate-limit errors spike (if the wider query pushes per-key usage over a threshold) — mitigation: drop `PERIOD_WINDOW_YEARS` from 4 → 3 and redeploy
- `fetched` count DROPS (indicates wider window caused per-reporter parse failures) — rollback: revert this PR
- New NullPointer / undefined-field errors surface in scorer logs mentioning `year` — unlikely (the type was already optional) but rollback if seen

**Validation window & owner**
- Window: first 2 Railway cron cycles after merge (~2 weeks)
- Owner: Elie (@eliehabib)

## Related

- Plan: `docs/plans/2026-04-24-002-fix-resilience-cohort-ranking-structural-audit-plan.md`
- Predecessor: #3369 (PR 0 — cohort-sanity release-gate harness)
- Related skill: `wb-bulk-mrv1-null-coverage-trap` (same family of silent late-reporter drops in bulk-query APIs)

---

🤖 Generated with Claude Opus 4.7 (1M context) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.49.0

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>