### PR TITLE
chore(tests): add chokepoint-baselines fixture + parity guard (§L #8)

### DIFF
--- a/tests/chokepoint-baselines-seed.test.mjs
+++ b/tests/chokepoint-baselines-seed.test.mjs
@@ -1,5 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   CHOKEPOINTS,
   CANONICAL_KEY,
@@ -7,6 +10,10 @@ import {
   buildPayload,
   validateFn,
 } from '../scripts/seed-chokepoint-baselines.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturePath = resolve(__dirname, 'fixtures/chokepoint-baselines-sample.json');
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf-8'));
 
 describe('buildPayload', () => {
   it('returns all 7 chokepoints', () => {
@@ -99,5 +106,36 @@ describe('validateFn', () => {
   it('returns true for correct shape with 7 chokepoints', () => {
     const payload = buildPayload();
     assert.equal(validateFn(payload), true);
+  });
+});
+
+// Fixture-parity guard (plan §L #8 / V5-7 golden fixtures). The fixture at
+// tests/fixtures/chokepoint-baselines-sample.json snapshots the expected
+// buildPayload output shape (excluding the volatile updatedAt). Any change
+// to CHOKEPOINTS that drifts from the fixture is now a deliberate action
+// requiring a fixture update — not a silent schema shift.
+describe('fixture parity (tests/fixtures/chokepoint-baselines-sample.json)', () => {
+  it('fixture has the same top-level shape (source, referenceYear, chokepoints[])', () => {
+    const payload = buildPayload();
+    assert.equal(fixture.source, payload.source);
+    assert.equal(fixture.referenceYear, payload.referenceYear);
+    assert.ok(Array.isArray(fixture.chokepoints));
+    assert.equal(fixture.chokepoints.length, payload.chokepoints.length);
+  });
+
+  it('fixture chokepoints match seeded CHOKEPOINTS position-by-position (id, relayId, mbd)', () => {
+    for (let i = 0; i < CHOKEPOINTS.length; i++) {
+      const seed = CHOKEPOINTS[i];
+      const fix = fixture.chokepoints[i];
+      assert.equal(fix.id, seed.id, `position ${i}: id drift (seed=${seed.id} fixture=${fix.id})`);
+      assert.equal(fix.relayId, seed.relayId, `${seed.id}: relayId drift`);
+      assert.equal(fix.mbd, seed.mbd, `${seed.id}: mbd drift (seed=${seed.mbd} fixture=${fix.mbd})`);
+    }
+  });
+
+  it('fixture carries a non-empty updatedAt placeholder (format only, not value)', () => {
+    assert.ok(typeof fixture.updatedAt === 'string');
+    assert.ok(Number.isFinite(Date.parse(fixture.updatedAt)),
+      `fixture updatedAt must be ISO-parseable, got "${fixture.updatedAt}"`);
   });
 });

--- a/tests/chokepoint-baselines-seed.test.mjs
+++ b/tests/chokepoint-baselines-seed.test.mjs
@@ -123,14 +123,38 @@ describe('fixture parity (tests/fixtures/chokepoint-baselines-sample.json)', () 
     assert.equal(fixture.chokepoints.length, payload.chokepoints.length);
   });
 
-  it('fixture chokepoints match seeded CHOKEPOINTS position-by-position (id, relayId, mbd)', () => {
-    for (let i = 0; i < CHOKEPOINTS.length; i++) {
-      const seed = CHOKEPOINTS[i];
+  it('fixture chokepoints match buildPayload().chokepoints on every contracted field', () => {
+    // Validate against the seeded PAYLOAD (the actual wire-level contract
+    // the cron writes to Redis), not against the raw CHOKEPOINTS constant.
+    // This matters because buildPayload could transform entries in a
+    // future refactor (coercion, ordering, normalization) — we want the
+    // fixture to track the emitted shape, not the internal source array.
+    //
+    // Validates every field the fixture carries: id, relayId, name, mbd,
+    // lat, lon. Previously only id/relayId/mbd were checked, leaving
+    // lat/lon/name drifts invisible despite being in the fixture.
+    const payload = buildPayload();
+    for (let i = 0; i < payload.chokepoints.length; i++) {
+      const seed = payload.chokepoints[i];
       const fix = fixture.chokepoints[i];
-      assert.equal(fix.id, seed.id, `position ${i}: id drift (seed=${seed.id} fixture=${fix.id})`);
-      assert.equal(fix.relayId, seed.relayId, `${seed.id}: relayId drift`);
-      assert.equal(fix.mbd, seed.mbd, `${seed.id}: mbd drift (seed=${seed.mbd} fixture=${fix.mbd})`);
+      assert.equal(fix.id,       seed.id,       `position ${i}: id drift (seed=${seed.id} fixture=${fix.id})`);
+      assert.equal(fix.relayId,  seed.relayId,  `${seed.id}: relayId drift`);
+      assert.equal(fix.name,     seed.name,     `${seed.id}: name drift (seed="${seed.name}" fixture="${fix.name}")`);
+      assert.equal(fix.mbd,      seed.mbd,      `${seed.id}: mbd drift (seed=${seed.mbd} fixture=${fix.mbd})`);
+      assert.equal(fix.lat,      seed.lat,      `${seed.id}: lat drift (seed=${seed.lat} fixture=${fix.lat})`);
+      assert.equal(fix.lon,      seed.lon,      `${seed.id}: lon drift (seed=${seed.lon} fixture=${fix.lon})`);
     }
+  });
+
+  it('fixture entry key set matches buildPayload entry key set exactly', () => {
+    // Catches the case where a future buildPayload adds a new field
+    // (e.g. mbd_source, last_reviewed) without updating the fixture —
+    // or vice versa. Keeps schema evolution deliberate and reviewed.
+    const payload = buildPayload();
+    const seedKeys  = Object.keys(payload.chokepoints[0]).sort();
+    const fixKeys   = Object.keys(fixture.chokepoints[0]).sort();
+    assert.deepEqual(fixKeys, seedKeys,
+      `entry key set drift — seed keys: [${seedKeys.join(', ')}], fixture keys: [${fixKeys.join(', ')}]`);
   });
 
   it('fixture carries a non-empty updatedAt placeholder (format only, not value)', () => {

--- a/tests/fixtures/chokepoint-baselines-sample.json
+++ b/tests/fixtures/chokepoint-baselines-sample.json
@@ -1,0 +1,14 @@
+{
+  "source": "EIA World Oil Transit Chokepoints",
+  "referenceYear": 2023,
+  "updatedAt": "2026-04-24T00:00:00.000Z",
+  "chokepoints": [
+    { "id": "hormuz",  "relayId": "hormuz_strait",  "name": "Strait of Hormuz",   "mbd": 21.0, "lat": 26.6, "lon": 56.3  },
+    { "id": "malacca", "relayId": "malacca_strait", "name": "Strait of Malacca",  "mbd": 17.2, "lat": 1.3,  "lon": 103.8 },
+    { "id": "suez",    "relayId": "suez",           "name": "Suez Canal / SUMED", "mbd": 7.6,  "lat": 30.7, "lon": 32.3  },
+    { "id": "babelm",  "relayId": "bab_el_mandeb",  "name": "Bab el-Mandeb",      "mbd": 6.2,  "lat": 12.6, "lon": 43.4  },
+    { "id": "danish",  "relayId": "dover_strait",   "name": "Danish Straits",     "mbd": 3.0,  "lat": 57.5, "lon": 10.5  },
+    { "id": "turkish", "relayId": "bosphorus",      "name": "Turkish Straits",    "mbd": 2.9,  "lat": 41.1, "lon": 29.0  },
+    { "id": "panama",  "relayId": "panama",         "name": "Panama Canal",       "mbd": 0.9,  "lat": 9.1,  "lon": -79.7 }
+  ]
+}


### PR DESCRIPTION
## Summary
Closes gap **#8** from \`docs/internal/energy-atlas-registry-expansion.md\` §L — the last missing V5-7 golden fixture. Brings parity with the other seed fixtures already under \`tests/fixtures/\` (\`ember-monthly-sample.csv\`, \`portwatch-arcgis-sample.json\`, …).

## Changes
- **New: \`tests/fixtures/chokepoint-baselines-sample.json\`** — snapshot of the expected \`buildPayload()\` output shape: 7 EIA chokepoints, top-level \`source\` / \`referenceYear\` / \`chokepoints\` array.
- **Extend: \`tests/chokepoint-baselines-seed.test.mjs\`** — add a 3-test fixture-parity \`describe\` block:
  - Top-level key set matches buildPayload (source, referenceYear, chokepoints array length)
  - Position-by-position entries match (id, relayId, mbd)
  - \`updatedAt\` ISO-parseability (format only — value is volatile, not byte-matched)

The existing 14 tests on main are untouched.

## Why schema-stable fields only (no byte-match on updatedAt)
\`updatedAt\` is a per-run timestamp. Asserting an exact value would break every run. Parity is scoped to the downstream-consumer contract instead: \`CountryDeepDivePanel\` transit-chokepoint scoring, the shock RPC \`CHOKEPOINT_EXPOSURE\` lookup, and chokepoint-flows calibration all depend on the stable fields (id / relayId / mbd / lat / lon) — those are the regression surface this guard protects.

If a future change adds/removes an entry or renames a field, the suite now fails until the fixture is updated alongside.

## Test plan
- [x] \`npx tsx --test tests/chokepoint-baselines-seed.test.mjs\` — 17/17 pass (14 pre-existing + 3 new)
- [x] \`npm run typecheck\` — clean
- [x] \`npm run test:data\` — 6697/6697 pass

## Context
This was the only remaining item in the plan's §L gap list. With this merged, the plan doc's §N announcement gate is substantively complete except for product decisions that were already resolved (§S=A subdomain-deferred path keeps #9/10/11/12 out of scope).