### PR TITLE
feat(seed): BUNDLE_RUN_STARTED_AT_MS env + runSeed SIGTERM cleanup

### DIFF
--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -196,10 +196,33 @@ function spawnSeed(scriptPath, { timeoutMs, label, bundleStartedAtMs }) {
  *   canonicalKey?: string,   // PR 2+: reads envelope from the canonical data key
  *   intervalMs: number,
  *   timeoutMs?: number,
+ *   dependsOn?: string[],    // labels that MUST run earlier in the array
  * }>} sections
  * @param {{ maxBundleMs?: number }} [opts]
  */
 export async function runBundle(label, sections, opts = {}) {
+  // Topological-order assertion. A consumer seeder reading a peer's
+  // Redis output in-bundle depends on the peer running first; if a
+  // future edit (e.g. alphabetizing sections) reorders them, the
+  // consumer reads last-bundle's stale output. The freshness-guard in
+  // the consumer is a safety net; this assertion is the contract.
+  // Throws on violation so misconfiguration surfaces before any cron
+  // tick runs.
+  const labelIndex = new Map(sections.map((s, i) => [s.label, i]));
+  for (let i = 0; i < sections.length; i++) {
+    const deps = sections[i].dependsOn;
+    if (!Array.isArray(deps)) continue;
+    for (const depLabel of deps) {
+      const depIdx = labelIndex.get(depLabel);
+      if (depIdx == null) {
+        throw new Error(`[Bundle:${label}] section '${sections[i].label}' dependsOn unknown label '${depLabel}'`);
+      }
+      if (depIdx >= i) {
+        throw new Error(`[Bundle:${label}] section '${sections[i].label}' dependsOn '${depLabel}' but '${depLabel}' is at index ${depIdx} (must be < ${i})`);
+      }
+    }
+  }
+
   const t0 = Date.now();
   const maxBundleMs = opts.maxBundleMs ?? Infinity;
   const budgetLabel = Number.isFinite(maxBundleMs) ? `, budget ${Math.round(maxBundleMs / 1000)}s` : '';

--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -107,7 +107,7 @@ function streamLines(stream, onLine) {
   stream.on('error', (err) => onLine(`<stdio error: ${err.message}>`));
 }
 
-function spawnSeed(scriptPath, { timeoutMs, label }) {
+function spawnSeed(scriptPath, { timeoutMs, label, bundleStartedAtMs }) {
   return new Promise((resolve) => {
     const t0 = Date.now();
     // Capture the child's structured `seed_complete` event if emitted, so
@@ -118,8 +118,15 @@ function spawnSeed(scriptPath, { timeoutMs, label }) {
     // dropped a different subset of Run ID / Mode / seed_complete lines
     // despite identical code paths). Bundle-level lines survive reliably.
     let lastSeedComplete = null;
+    // BUNDLE_RUN_STARTED_AT_MS lets consumer seeders detect when a cohort
+    // peer's seed-meta predates the current bundle run and fall back to a
+    // hard default instead of reading a stale peer key. See plan
+    // 2026-04-24-003 §"Phase 2 — SWF seeder" bundle-freshness guard.
     const child = spawn(process.execPath, [scriptPath], {
-      env: process.env,
+      env: {
+        ...process.env,
+        BUNDLE_RUN_STARTED_AT_MS: String(bundleStartedAtMs ?? Date.now()),
+      },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
@@ -228,7 +235,7 @@ export async function runBundle(label, sections, opts = {}) {
       continue;
     }
 
-    const result = await spawnSeed(scriptPath, { timeoutMs: timeout, label: section.label });
+    const result = await spawnSeed(scriptPath, { timeoutMs: timeout, label: section.label, bundleStartedAtMs: t0 });
     if (result.ok) {
       console.log(`  [${section.label}] Done (${result.elapsed}s)`);
       // Bundle-level per-section summary — emitted from parent stdout so

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -17,6 +17,30 @@ const __seed_dirname = dirname(fileURLToPath(import.meta.url));
 
 export { CHROME_UA };
 
+/**
+ * Return the bundle-run start timestamp injected by `_bundle-runner.mjs`
+ * as the `BUNDLE_RUN_STARTED_AT_MS` env var before each child spawn.
+ *
+ * All sibling seeders in a single bundle run share ONE value (captured
+ * at `runBundle` start, not at spawn time). Use this when a consumer
+ * seeder reads a peer's output inside the same bundle and must detect
+ * stale data from a previous bundle tick:
+ *
+ *   if (fetchedAt < getBundleRunStartedAtMs()) {
+ *     // peer did NOT run in this bundle — fall back to safe default
+ *   }
+ *
+ * Standalone runs (manual invocation outside the bundle) fall back to
+ * `Math.floor(Date.now()/1000)*1000` so the freshness check degrades
+ * gracefully rather than throwing.
+ *
+ * @returns {number} epoch milliseconds
+ */
+export function getBundleRunStartedAtMs() {
+  return Number(process.env.BUNDLE_RUN_STARTED_AT_MS)
+    || Math.floor(Date.now() / 1000) * 1000;
+}
+
 // Canonical FX fallback rates — used when Yahoo Finance returns null/zero.
 // Single source of truth shared by seed-bigmac, seed-grocery-basket, seed-fx-rates.
 // EGP: 0.0192 is the most recently observed live rate (2026-03-21 seed run).
@@ -821,34 +845,42 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     process.exit(0);
   }
 
-  // SIGTERM handler — _bundle-runner.mjs sends SIGTERM when a section's
-  // timeout fires, then SIGKILL after KILL_GRACE_MS (5s). Without this
-  // handler the `finally` path never runs on SIGKILL, leaving the 30-min
-  // acquireLock() reservation in place until its own TTL expires — the
-  // next cron tick silently skips that resource. Release lock + extend
-  // existing-data TTL on timeout so consumers keep reading the last-good
-  // envelope. Exit 143 = POSIX convention for SIGTERM-terminated process.
+  // SIGTERM handler, SCOPED to the fetch phase only. _bundle-runner.mjs
+  // sends SIGTERM when a section's timeout fires, then SIGKILL after
+  // KILL_GRACE_MS (5s). The fetch phase is the long-running blocking
+  // call where timeout realistically fires; publish/verify is bounded
+  // Redis writes. Narrowing the handler's lifetime prevents it from
+  // racing graceful exit paths that MUST NOT refresh TTL — notably the
+  // `emptyDataIsFailure: true` strict-floor branch (IMF-External,
+  // WB-bulk) which deliberately avoids refreshing seed-meta so the next
+  // cron tick retries. Release lock + extend existing-data TTL in
+  // parallel (disjoint keys; serializing compounds Upstash latency
+  // during the exact failure mode this handler exists to handle).
+  // Exit 143 = POSIX convention for SIGTERM-terminated process.
   const sigTermHandler = async () => {
     console.error(`  [${domain}:${resource}] SIGTERM received — releasing lock runId=${runId}, extending existing TTL`);
     try {
-      await releaseLock(`${domain}:${resource}`, runId);
       const ttl = ttlSeconds || 600;
       const keys = [canonicalKey, `seed-meta:${domain}:${resource}`];
       if (extraKeys) keys.push(...extraKeys.map((ek) => ek.key));
-      await extendExistingTtl(keys, ttl);
+      await Promise.allSettled([
+        releaseLock(`${domain}:${resource}`, runId),
+        extendExistingTtl(keys, ttl),
+      ]);
     } catch (err) {
       console.error(`  [${domain}:${resource}] SIGTERM cleanup error: ${err?.message || err}`);
     } finally {
       process.exit(143);
     }
   };
-  process.once('SIGTERM', sigTermHandler);
 
   // Phase 1: Fetch data (graceful on failure — extend TTL on stale data)
   let data;
   try {
+    process.once('SIGTERM', sigTermHandler);
     data = await withRetry(fetchFn);
   } catch (err) {
+    process.off('SIGTERM', sigTermHandler);
     await releaseLock(`${domain}:${resource}`, runId);
     const durationMs = Date.now() - startMs;
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
@@ -861,6 +893,12 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
 
     console.log(`\n=== Failed gracefully (${Math.round(durationMs)}ms) ===`);
     process.exit(0);
+  } finally {
+    // Remove the SIGTERM handler unconditionally: success path (fall
+    // through to publish), catch path (already removed above), and any
+    // future exit path added inside the try. process.off is a safe
+    // no-op when the listener was never registered or already removed.
+    process.off('SIGTERM', sigTermHandler);
   }
 
   // Phase 2: Publish to Redis (rethrow on failure — data was fetched but not stored)

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -821,6 +821,29 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     process.exit(0);
   }
 
+  // SIGTERM handler — _bundle-runner.mjs sends SIGTERM when a section's
+  // timeout fires, then SIGKILL after KILL_GRACE_MS (5s). Without this
+  // handler the `finally` path never runs on SIGKILL, leaving the 30-min
+  // acquireLock() reservation in place until its own TTL expires — the
+  // next cron tick silently skips that resource. Release lock + extend
+  // existing-data TTL on timeout so consumers keep reading the last-good
+  // envelope. Exit 143 = POSIX convention for SIGTERM-terminated process.
+  const sigTermHandler = async () => {
+    console.error(`  [${domain}:${resource}] SIGTERM received — releasing lock runId=${runId}, extending existing TTL`);
+    try {
+      await releaseLock(`${domain}:${resource}`, runId);
+      const ttl = ttlSeconds || 600;
+      const keys = [canonicalKey, `seed-meta:${domain}:${resource}`];
+      if (extraKeys) keys.push(...extraKeys.map((ek) => ek.key));
+      await extendExistingTtl(keys, ttl);
+    } catch (err) {
+      console.error(`  [${domain}:${resource}] SIGTERM cleanup error: ${err?.message || err}`);
+    } finally {
+      process.exit(143);
+    }
+  };
+  process.once('SIGTERM', sigTermHandler);
+
   // Phase 1: Fetch data (graceful on failure — extend TTL on stale data)
   let data;
   try {

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -19,26 +19,34 @@ export { CHROME_UA };
 
 /**
  * Return the bundle-run start timestamp injected by `_bundle-runner.mjs`
- * as the `BUNDLE_RUN_STARTED_AT_MS` env var before each child spawn.
+ * as the `BUNDLE_RUN_STARTED_AT_MS` env var, or `null` when the seeder
+ * is running STANDALONE (manual invocation outside the bundle).
  *
  * All sibling seeders in a single bundle run share ONE value (captured
  * at `runBundle` start, not at spawn time). Use this when a consumer
  * seeder reads a peer's output inside the same bundle and must detect
  * stale data from a previous bundle tick:
  *
- *   if (fetchedAt < getBundleRunStartedAtMs()) {
- *     // peer did NOT run in this bundle — fall back to safe default
+ *   const bundleStartMs = getBundleRunStartedAtMs();
+ *   if (bundleStartMs != null && fetchedAt < bundleStartMs) {
+ *     // in-bundle context + peer did NOT run in THIS bundle → fallback
  *   }
  *
- * Standalone runs (manual invocation outside the bundle) fall back to
- * `Math.floor(Date.now()/1000)*1000` so the freshness check degrades
- * gracefully rather than throwing.
+ * The null-on-unset contract matters. Earlier designs fell back to
+ * `Date.now()` when the env was absent, which regressed standalone
+ * runs: a sibling seeder invoked manually just before the consumer
+ * wrote `fetchedAt = (process start - 5s)`, and the consumer's own
+ * `bundleStartMs = Date.now()` rejected that perfectly-fresh peer
+ * envelope as "stale". Returning null keeps the gate scoped to its
+ * real purpose: protecting against across-bundle-tick staleness,
+ * which has no analog outside a bundle context.
  *
- * @returns {number} epoch milliseconds
+ * @returns {number | null} epoch milliseconds when spawned by the
+ *   bundle runner; null when running standalone.
  */
 export function getBundleRunStartedAtMs() {
-  return Number(process.env.BUNDLE_RUN_STARTED_AT_MS)
-    || Math.floor(Date.now() / 1000) * 1000;
+  const raw = Number(process.env.BUNDLE_RUN_STARTED_AT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : null;
 }
 
 // Canonical FX fallback rates — used when Yahoo Finance returns null/zero.

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -125,3 +125,56 @@ test('non-zero exit without timeout reports exit code', async () => {
     cleanup();
   }
 });
+
+test('injects BUNDLE_RUN_STARTED_AT_MS env into child; value is within run bounds', async () => {
+  const cleanup = writeFixture(
+    '_bundle-fixture-env.mjs',
+    `console.log('BUNDLE_RUN_STARTED_AT_MS=' + process.env.BUNDLE_RUN_STARTED_AT_MS);\n`,
+  );
+  const before = Date.now();
+  try {
+    const { code, stdout } = await runBundleWith([
+      { label: 'ENV', script: '_bundle-fixture-env.mjs', intervalMs: 1, timeoutMs: 5000 },
+    ]);
+    const after = Date.now();
+    assert.equal(code, 0);
+    const match = stdout.match(/BUNDLE_RUN_STARTED_AT_MS=(\d+)/);
+    assert.ok(match, `expected env var in child stdout; got:\n${stdout}`);
+    const injected = Number(match[1]);
+    assert.ok(Number.isInteger(injected), 'injected value must be an integer');
+    // Parent captured t0 at bundle start (before this test's `before` call) and
+    // child ran before `after`. So: before - tolerance <= injected <= after.
+    assert.ok(injected >= before - 5000 && injected <= after,
+      `injected=${injected} out of bounds [${before - 5000}, ${after}]`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('sibling sections share the same BUNDLE_RUN_STARTED_AT_MS (one-shot per bundle)', async () => {
+  const cleanupA = writeFixture(
+    '_bundle-fixture-env-a.mjs',
+    `console.log('TS_A=' + process.env.BUNDLE_RUN_STARTED_AT_MS);\n`,
+  );
+  const cleanupB = writeFixture(
+    '_bundle-fixture-env-b.mjs',
+    `await new Promise((r) => setTimeout(r, 200));\nconsole.log('TS_B=' + process.env.BUNDLE_RUN_STARTED_AT_MS);\n`,
+  );
+  try {
+    const { code, stdout } = await runBundleWith([
+      { label: 'A', script: '_bundle-fixture-env-a.mjs', intervalMs: 1, timeoutMs: 5000 },
+      { label: 'B', script: '_bundle-fixture-env-b.mjs', intervalMs: 1, timeoutMs: 5000 },
+    ]);
+    assert.equal(code, 0);
+    const tsA = Number(stdout.match(/TS_A=(\d+)/)?.[1]);
+    const tsB = Number(stdout.match(/TS_B=(\d+)/)?.[1]);
+    assert.ok(tsA && tsB, `both timestamps present; stdout:\n${stdout}`);
+    // Both children read the same bundle-level t0, so the injected value is
+    // identical across siblings (NOT spawn time). This is the critical
+    // property Phase 2's bundle-freshness guard relies on.
+    assert.equal(tsA, tsB, 'siblings must share one bundle-level timestamp');
+  } finally {
+    cleanupA();
+    cleanupB();
+  }
+});

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -178,3 +178,52 @@ test('sibling sections share the same BUNDLE_RUN_STARTED_AT_MS (one-shot per bun
     cleanupB();
   }
 });
+
+test('dependsOn: throws when a dep appears later in the sections array', async () => {
+  // Consumer (depends on Producer) is at index 0 — violates the contract.
+  const cleanupC = writeFixture('_bundle-fixture-dep-consumer.mjs', `console.log('consumer');\n`);
+  const cleanupP = writeFixture('_bundle-fixture-dep-producer.mjs', `console.log('producer');\n`);
+  try {
+    const { code, stderr } = await runBundleWith([
+      { label: 'Consumer', script: '_bundle-fixture-dep-consumer.mjs', intervalMs: 1, timeoutMs: 5000, dependsOn: ['Producer'] },
+      { label: 'Producer', script: '_bundle-fixture-dep-producer.mjs', intervalMs: 1, timeoutMs: 5000 },
+    ]);
+    assert.notEqual(code, 0, 'out-of-order dependsOn must cause non-zero exit');
+    assert.match(stderr, /dependsOn 'Producer' but 'Producer' is at index 1/,
+      `expected topological violation error; stderr:\n${stderr}`);
+  } finally {
+    cleanupC();
+    cleanupP();
+  }
+});
+
+test('dependsOn: passes when deps appear earlier in the sections array', async () => {
+  const cleanupP = writeFixture('_bundle-fixture-dep-producer-ok.mjs', `console.log('producer');\n`);
+  const cleanupC = writeFixture('_bundle-fixture-dep-consumer-ok.mjs', `console.log('consumer');\n`);
+  try {
+    const { code, stdout } = await runBundleWith([
+      { label: 'Producer', script: '_bundle-fixture-dep-producer-ok.mjs', intervalMs: 1, timeoutMs: 5000 },
+      { label: 'Consumer', script: '_bundle-fixture-dep-consumer-ok.mjs', intervalMs: 1, timeoutMs: 5000, dependsOn: ['Producer'] },
+    ]);
+    assert.equal(code, 0);
+    assert.match(stdout, /\[Producer\] producer/);
+    assert.match(stdout, /\[Consumer\] consumer/);
+  } finally {
+    cleanupP();
+    cleanupC();
+  }
+});
+
+test('dependsOn: throws on unknown label reference', async () => {
+  const cleanup = writeFixture('_bundle-fixture-dep-orphan.mjs', `console.log('orphan');\n`);
+  try {
+    const { code, stderr } = await runBundleWith([
+      { label: 'Orphan', script: '_bundle-fixture-dep-orphan.mjs', intervalMs: 1, timeoutMs: 5000, dependsOn: ['DoesNotExist'] },
+    ]);
+    assert.notEqual(code, 0);
+    assert.match(stderr, /dependsOn unknown label 'DoesNotExist'/,
+      `expected unknown-label error; stderr:\n${stderr}`);
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/seed-utils-sigterm-cleanup.test.mjs
+++ b/tests/seed-utils-sigterm-cleanup.test.mjs
@@ -148,3 +148,85 @@ test('runSeed SIGTERM handler fires once even if multiple SIGTERMs arrive', asyn
     try { unlinkSync(path); } catch {}
   }
 });
+
+test('SIGTERM handler is removed AFTER fetchFn completes (no race with publish-phase exit)', async () => {
+  // After the fetch phase returns, runSeed's try/finally removes the
+  // SIGTERM listener. Verify by: fetchFn returns synthetic data → runSeed
+  // enters publish phase (which will fail on our empty fetch mock that
+  // doesn't simulate atomicPublish success) → SIGTERM arriving AFTER
+  // fetchFn-resolution must fall through to Node's default handler (fast
+  // exit with signal=SIGTERM, NO "SIGTERM received" cleanup line).
+  //
+  // This pins the narrowed-scope contract: the cleanup handler exists
+  // only during the long-running fetch, and post-fetch SIGTERMs do
+  // NOT trigger runSeed's TTL-extension code path — critical for
+  // strict-floor seeders (emptyDataIsFailure: true) that must NOT
+  // refresh seed-meta on empty data.
+  const body = `
+    import { runSeed } from './_seed-utils.mjs';
+    // Redis stub: lock SET NX → OK, everything else → OK.
+    globalThis.fetch = async (url, opts = {}) => {
+      const body = opts?.body ? (() => { try { return JSON.parse(opts.body); } catch { return opts.body; } })() : null;
+      if (Array.isArray(body) && Array.isArray(body[0])) {
+        return new Response(JSON.stringify(body.map(() => ({ result: 0 }))), { status: 200 });
+      }
+      return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+    };
+    // fetchFn resolves IMMEDIATELY with data, then we signal READY and
+    // hang in the publish phase so the test can send SIGTERM. Using
+    // atomicPublish's Lua-redirect stub response ('OK') will keep the
+    // seeder alive in verify-retry; setInterval ensures event loop stays up.
+    const quickFetch = async () => {
+      const data = { items: [{ k: 1 }] };
+      // Give the SIGTERM handler a microtask to be removed by the
+      // try{ ... } finally{ process.off } after withRetry resolves.
+      // Then signal ready.
+      setInterval(() => {}, 10_000);
+      setImmediate(() => console.log('POST_FETCH_READY'));
+      return data;
+    };
+    await runSeed('test-domain', 'post-fetch', 'data:test:post-fetch:v1', quickFetch, {
+      ttlSeconds: 900,
+      lockTtlMs: 60_000,
+    });
+  `;
+  const path = join(SCRIPTS_DIR, `_sigterm-postfetch-fixture-${Date.now()}.mjs`);
+  writeFileSync(path, body);
+  try {
+    await new Promise((resolve) => {
+      const child = spawn(process.execPath, [path], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: {
+          ...process.env,
+          UPSTASH_REDIS_REST_URL: 'https://fake-upstash.example.com',
+          UPSTASH_REDIS_REST_TOKEN: 'fake-token',
+        },
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (c) => { stdout += c; });
+      child.stderr.on('data', (c) => { stderr += c; });
+      const ready = setInterval(() => {
+        if (stdout.includes('POST_FETCH_READY')) {
+          clearInterval(ready);
+          // Give one extra event-loop tick so the finally{process.off} runs.
+          setTimeout(() => child.kill('SIGTERM'), 50);
+        }
+      }, 25);
+      child.on('close', (code, signal) => {
+        clearInterval(ready);
+        // Post-fetch SIGTERM falls through to Node default: no "SIGTERM
+        // received" cleanup log from our handler. Exit may be signal=SIGTERM
+        // or code (Node varies), but the decisive signal is the ABSENCE of
+        // the cleanup log line.
+        const cleanupFired = /SIGTERM received — releasing lock/.test(stderr);
+        assert.equal(cleanupFired, false,
+          `post-fetch SIGTERM must NOT trigger runSeed cleanup (strict-floor safety). stderr:\n${stderr}`);
+        resolve();
+      });
+      setTimeout(() => { try { child.kill('SIGKILL'); } catch {} }, 10_000);
+    });
+  } finally {
+    try { unlinkSync(path); } catch {}
+  }
+});

--- a/tests/seed-utils-sigterm-cleanup.test.mjs
+++ b/tests/seed-utils-sigterm-cleanup.test.mjs
@@ -54,17 +54,31 @@ function runFixture(bodyJs) {
 }
 
 test('runSeed releases lock and extends existing TTL on SIGTERM', async () => {
+  // Fixture logs every Upstash HTTP call (shape + body) on its own
+  // line so the test can assert that the SIGTERM cleanup actually
+  // emitted (a) an EVAL DEL-on-match for the lock key, and (b) an
+  // EXPIRE pipeline for the canonical + seed-meta keys. Log goes to
+  // stderr so READY-signal on stdout stays uncontended.
   const body = `
     import { runSeed } from './_seed-utils.mjs';
-    const calls = [];
     globalThis.fetch = async (url, opts = {}) => {
       const body = opts?.body ? (() => { try { return JSON.parse(opts.body); } catch { return opts.body; } })() : null;
-      calls.push({ url: String(url), body });
-      // Log each call on its own line so the test can regex the output.
-      console.log('FETCH ' + String(url).split('/').pop() + ' ' + JSON.stringify(body));
+      // Shape signature: EVAL / EXPIRE / pipeline / other — so the test
+      // asserts on the exact op without having to deep-inspect.
+      let shape = 'other';
+      if (Array.isArray(body)) {
+        if (Array.isArray(body[0])) {
+          shape = body[0][0] === 'EXPIRE' ? 'pipeline-EXPIRE' : 'pipeline-other';
+        } else if (body[0] === 'EVAL') {
+          shape = 'EVAL';
+        } else {
+          shape = 'cmd-' + body[0];
+        }
+      }
+      console.error('FETCH_OP shape=' + shape + ' body=' + JSON.stringify(body));
       // Lock SET NX → return result:0 (not already held). Pipeline → array.
       if (Array.isArray(body) && Array.isArray(body[0])) {
-        return new Response(JSON.stringify(body.map(() => ({ result: 0 }))), { status: 200 });
+        return new Response(JSON.stringify(body.map(() => ({ result: 1 }))), { status: 200 });
       }
       return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
     };
@@ -87,6 +101,34 @@ test('runSeed releases lock and extends existing TTL on SIGTERM', async () => {
     `expected exit 143 or SIGTERM; got code=${code} signal=${signal}\nstderr:\n${stderr}`);
   assert.match(stderr, /SIGTERM received — releasing lock/,
     `expected SIGTERM cleanup log; stderr:\n${stderr}`);
+
+  // Verify cleanup actually ISSUED the Redis ops, not just logged intent.
+  // Extract FETCH_OP lines; separate the acquire-time ops from SIGTERM-time.
+  const fetchOps = stderr.split('\n').filter((l) => l.startsWith('FETCH_OP '));
+  const evalOps = fetchOps.filter((l) => l.includes('shape=EVAL'));
+  const pipelineExpireOps = fetchOps.filter((l) => l.includes('shape=pipeline-EXPIRE'));
+  // The SIGTERM handler must emit at least one EVAL (releaseLock Lua
+  // script on the lock key) and at least one pipeline EXPIRE (extend
+  // existing TTL on canonical + seed-meta keys).
+  assert.ok(evalOps.length >= 1,
+    `expected >=1 EVAL (releaseLock) call; saw ${evalOps.length}\nstderr:\n${stderr}`);
+  assert.ok(pipelineExpireOps.length >= 1,
+    `expected >=1 pipeline-EXPIRE (extendExistingTtl) call; saw ${pipelineExpireOps.length}\nstderr:\n${stderr}`);
+  // Specific: the EVAL body must reference our runId (body[4]) so we
+  // know it's the SIGTERM-time release, not a different lock op.
+  // runId format: `${Date.now()}-${Math.random().toString(36).slice(2,8)}`
+  // → e.g. "1777061031282-cmgso6", JSON-quoted inside the EVAL body.
+  const evalHasRunId = evalOps.some((l) => /"\d{10,}-[a-z0-9]{6}"/.test(l));
+  assert.ok(evalHasRunId,
+    `expected EVAL body to carry the runSeed-generated runId; stderr:\n${stderr}`);
+  // Specific: the EXPIRE pipeline must reference both the canonical
+  // key and the seed-meta key (proves keys[] was constructed correctly).
+  const expireTouchesCanonical = pipelineExpireOps.some((l) => l.includes('data:test:sigterm:v1'));
+  const expireTouchesSeedMeta = pipelineExpireOps.some((l) => l.includes('seed-meta:test-domain:sigterm'));
+  assert.ok(expireTouchesCanonical,
+    `EXPIRE pipeline must include canonicalKey; stderr:\n${stderr}`);
+  assert.ok(expireTouchesSeedMeta,
+    `EXPIRE pipeline must include seed-meta key; stderr:\n${stderr}`);
 });
 
 test('runSeed SIGTERM handler fires once even if multiple SIGTERMs arrive', async () => {

--- a/tests/seed-utils-sigterm-cleanup.test.mjs
+++ b/tests/seed-utils-sigterm-cleanup.test.mjs
@@ -1,0 +1,150 @@
+// Regression test: runSeed must release its lock and extend existing-data
+// TTL when it receives SIGTERM from _bundle-runner.mjs. Without this, the
+// 30-min acquireLock reservation leaks to the NEXT cron tick, which then
+// silently skips the resource — long-tail outage window described in
+// memory `bundle-runner-sigkill-leaks-child-lock` (PR #3128).
+//
+// Strategy: spawn a real child that monkey-patches global fetch to capture
+// every Upstash call, invokes runSeed() with a fetchFn that awaits forever,
+// sends SIGTERM, and verifies the child (a) exits 143 (b) prints the
+// "SIGTERM received" line (c) emits the DEL (releaseLock) + EXPIRE pipeline
+// (extendExistingTtl) calls before exit.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SCRIPTS_DIR = new URL('../scripts/', import.meta.url).pathname;
+
+function runFixture(bodyJs) {
+  const path = join(SCRIPTS_DIR, `_sigterm-fixture-${Date.now()}.mjs`);
+  writeFileSync(path, bodyJs);
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [path], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        UPSTASH_REDIS_REST_URL: 'https://fake-upstash.example.com',
+        UPSTASH_REDIS_REST_TOKEN: 'fake-token',
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => { stdout += c; });
+    child.stderr.on('data', (c) => { stderr += c; });
+    child.on('close', (code, signal) => {
+      try { unlinkSync(path); } catch {}
+      resolve({ code, signal, stdout, stderr });
+    });
+    // Let runSeed register the SIGTERM handler and enter fetchFn before we kill.
+    // The fixture logs "READY" once the fetchFn is awaited; we kill then.
+    const readyCheck = setInterval(() => {
+      if (stdout.includes('READY')) {
+        clearInterval(readyCheck);
+        child.kill('SIGTERM');
+      }
+    }, 25);
+    setTimeout(() => {
+      clearInterval(readyCheck);
+      try { child.kill('SIGKILL'); } catch {}
+    }, 10_000);
+  });
+}
+
+test('runSeed releases lock and extends existing TTL on SIGTERM', async () => {
+  const body = `
+    import { runSeed } from './_seed-utils.mjs';
+    const calls = [];
+    globalThis.fetch = async (url, opts = {}) => {
+      const body = opts?.body ? (() => { try { return JSON.parse(opts.body); } catch { return opts.body; } })() : null;
+      calls.push({ url: String(url), body });
+      // Log each call on its own line so the test can regex the output.
+      console.log('FETCH ' + String(url).split('/').pop() + ' ' + JSON.stringify(body));
+      // Lock SET NX → return result:0 (not already held). Pipeline → array.
+      if (Array.isArray(body) && Array.isArray(body[0])) {
+        return new Response(JSON.stringify(body.map(() => ({ result: 0 }))), { status: 200 });
+      }
+      return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+    };
+    // fetchFn that awaits "forever" — we want SIGTERM to interrupt mid-fetch.
+    // setInterval keeps the event loop alive (otherwise Node bails with
+    // "Detected unsettled top-level await" before SIGTERM can be delivered).
+    const foreverFetch = () => new Promise(() => {
+      console.log('READY');
+      setInterval(() => {}, 10_000);
+    });
+    await runSeed('test-domain', 'sigterm', 'data:test:sigterm:v1', foreverFetch, {
+      ttlSeconds: 900,
+      lockTtlMs: 60_000,
+    });
+  `;
+  const { code, signal, stderr } = await runFixture(body);
+  // process.exit(143) should produce code=143; on some platforms Node maps it
+  // back to a signal termination, so accept either code or signal.
+  assert.ok(code === 143 || signal === 'SIGTERM',
+    `expected exit 143 or SIGTERM; got code=${code} signal=${signal}\nstderr:\n${stderr}`);
+  assert.match(stderr, /SIGTERM received — releasing lock/,
+    `expected SIGTERM cleanup log; stderr:\n${stderr}`);
+});
+
+test('runSeed SIGTERM handler fires once even if multiple SIGTERMs arrive', async () => {
+  // Uses process.once under the hood; verify by emitting SIGTERM twice.
+  // A second SIGTERM while the handler is mid-cleanup should not trigger
+  // re-entry. If the handler was registered with process.on instead of
+  // process.once, the second SIGTERM would re-enter and double-release.
+  const body = `
+    import { runSeed } from './_seed-utils.mjs';
+    globalThis.fetch = async (url, opts = {}) => {
+      const body = opts?.body ? (() => { try { return JSON.parse(opts.body); } catch { return opts.body; } })() : null;
+      if (Array.isArray(body) && Array.isArray(body[0])) {
+        return new Response(JSON.stringify(body.map(() => ({ result: 0 }))), { status: 200 });
+      }
+      return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+    };
+    const foreverFetch = () => new Promise(() => { console.log('READY'); setInterval(() => {}, 10_000); });
+    await runSeed('test-domain', 'sigterm-once', 'data:test:sigterm-once:v1', foreverFetch, {
+      ttlSeconds: 900,
+      lockTtlMs: 60_000,
+    });
+  `;
+  const path = join(SCRIPTS_DIR, `_sigterm-once-fixture-${Date.now()}.mjs`);
+  writeFileSync(path, body);
+  try {
+    await new Promise((resolve) => {
+      const child = spawn(process.execPath, [path], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: {
+          ...process.env,
+          UPSTASH_REDIS_REST_URL: 'https://fake-upstash.example.com',
+          UPSTASH_REDIS_REST_TOKEN: 'fake-token',
+        },
+      });
+      let stdout = '';
+      let stderr = '';
+      let sigtermLinesSeen = 0;
+      child.stdout.on('data', (c) => { stdout += c; });
+      child.stderr.on('data', (c) => {
+        stderr += c;
+        sigtermLinesSeen = (stderr.match(/SIGTERM received/g) || []).length;
+      });
+      const ready = setInterval(() => {
+        if (stdout.includes('READY')) {
+          clearInterval(ready);
+          child.kill('SIGTERM');
+          setTimeout(() => { try { child.kill('SIGTERM'); } catch {} }, 50);
+        }
+      }, 25);
+      child.on('close', (code) => {
+        clearInterval(ready);
+        assert.equal(sigtermLinesSeen, 1,
+          `handler must fire once (process.once); saw ${sigtermLinesSeen} SIGTERM lines\nstderr:\n${stderr}`);
+        resolve();
+      });
+      setTimeout(() => { try { child.kill('SIGKILL'); } catch {} }, 10_000);
+    });
+  } finally {
+    try { unlinkSync(path); } catch {}
+  }
+});


### PR DESCRIPTION
## Summary

Two coupled infrastructure changes that prereq the Comtrade re-export-share seeder (plan `2026-04-24-003`). Both are broadly usable by any cohort seeder with a freshness-dependent consumer.

1. **`_bundle-runner.mjs` — inject `BUNDLE_RUN_STARTED_AT_MS` env** into every spawned child. All siblings in a single bundle run share one value (captured at `runBundle` start, not spawn time). Consumers can use this to detect stale peer keys — if a peer's `seed-meta` predates the current bundle run, fall back to a hard default instead of reading a cohort-peer's last-week output.
2. **`_seed-utils.mjs::runSeed` — `process.once('SIGTERM')` cleanup handler**. `_bundle-runner.mjs` sends SIGTERM on section timeout, then SIGKILL after `KILL_GRACE_MS` (5s). Without this handler the existing `finally`-based cleanup never runs on SIGKILL, leaking the 30-min `acquireLock` reservation — the next cron tick silently skips the resource (root cause captured in memory `bundle-runner-sigkill-leaks-child-lock`, PR #3128). Handler releases the lock and extends existing-data TTL before `process.exit(143)`.

## Test plan

- [x] `tests/bundle-runner.test.mjs` — two new tests:
  - env injection (value within run bounds)
  - **sibling sections share the same timestamp** (critical for the consumer freshness guard)
- [x] `tests/seed-utils-sigterm-cleanup.test.mjs` — two new tests:
  - runSeed SIGTERM path exits 143, logs "SIGTERM received — releasing lock"
  - `process.once` contract: second SIGTERM does not re-enter handler
- [x] Full `npm run test:data` passes (6,862 tests)
- [x] `npm run typecheck` clean
- [x] `npm run lint` — no new errors (207 pre-existing warnings unchanged)

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: search Railway for `SIGTERM received — releasing lock` on any bundle seeder. Each occurrence = a section that timed out and cleaned up (expected, desired behavior).
  - Metrics: `api/health.js` — no resource should flip to `STALE_SEED` after a bundle run completes.
- **Validation checks**
  - `curl https://worldmonitor.app/api/health | jq '.bundles.resilienceRecovery'` — after one monthly run, recoverySovereignWealth fetchedAt should be < 24h.
- **Expected healthy behavior**
  - Zero SIGTERM cleanup log lines on timely sections (normal case). SIGTERM lines appear only when a section blows its timeout — same population as before this PR, but cleanup now actually releases locks.
- **Failure signal / rollback trigger**
  - `SIGTERM cleanup error` log line (caught exception in handler) — safe to roll back; existing TTL-based recovery still works.
- **Validation window & owner**
  - Window: next weekly resilience-recovery bundle run (~7 days). Owner: @koala73.

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.49.0