### PR TITLE
fix(energy-atlas): wire 4 panels into App.ts primeTask (panels stuck on 'Loading…')

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -40,6 +40,10 @@ import type { BigMacPanel } from '@/components/BigMacPanel';
 import type { FuelPricesPanel } from '@/components/FuelPricesPanel';
 import type { FaoFoodPriceIndexPanel } from '@/components/FaoFoodPriceIndexPanel';
 import type { OilInventoriesPanel } from '@/components/OilInventoriesPanel';
+import type { PipelineStatusPanel } from '@/components/PipelineStatusPanel';
+import type { StorageFacilityMapPanel } from '@/components/StorageFacilityMapPanel';
+import type { FuelShortagePanel } from '@/components/FuelShortagePanel';
+import type { EnergyDisruptionsPanel } from '@/components/EnergyDisruptionsPanel';
 import type { ClimateNewsPanel } from '@/components/ClimateNewsPanel';
 import type { ConsumerPricesPanel } from '@/components/ConsumerPricesPanel';
 import type { DefensePatentsPanel } from '@/components/DefensePatentsPanel';
@@ -323,6 +327,29 @@ export class App {
     if (shouldPrime('oil-inventories')) {
       const panel = this.state.panels['oil-inventories'] as OilInventoriesPanel | undefined;
       if (panel) primeTask('oil-inventories', () => panel.fetchData());
+    }
+    // Energy Atlas panels — each self-fetches via bootstrap cache + RPC fallback
+    // (scripts/seed-pipelines-{gas,oil}.mjs, seed-storage-facilities.mjs,
+    // seed-fuel-shortages.mjs, seed-energy-disruptions.mjs). Without these
+    // primeTask wires the panels sit at showLoading() forever because
+    // Panel's constructor calls showLoading() but nothing else triggers
+    // fetchData() on attach — App.ts's primeTask table is the sole
+    // near-viewport kickoff path.
+    if (shouldPrime('pipeline-status')) {
+      const panel = this.state.panels['pipeline-status'] as PipelineStatusPanel | undefined;
+      if (panel) primeTask('pipeline-status', () => panel.fetchData());
+    }
+    if (shouldPrime('storage-facility-map')) {
+      const panel = this.state.panels['storage-facility-map'] as StorageFacilityMapPanel | undefined;
+      if (panel) primeTask('storage-facility-map', () => panel.fetchData());
+    }
+    if (shouldPrime('fuel-shortages')) {
+      const panel = this.state.panels['fuel-shortages'] as FuelShortagePanel | undefined;
+      if (panel) primeTask('fuel-shortages', () => panel.fetchData());
+    }
+    if (shouldPrime('energy-disruptions')) {
+      const panel = this.state.panels['energy-disruptions'] as EnergyDisruptionsPanel | undefined;
+      if (panel) primeTask('energy-disruptions', () => panel.fetchData());
     }
     if (shouldPrime('climate-news')) {
       const panel = this.state.panels['climate-news'] as ClimateNewsPanel | undefined;


### PR DESCRIPTION
## Summary
- All 4 Energy Atlas panels (\`pipeline-status\`, \`storage-facility-map\`, \`fuel-shortages\`, \`energy-disruptions\`) ship rendering their headers and the spinner but never leave \`showLoading()\` — their \`fetchData()\` is never called.
- Root cause: \`App.ts::primeDataForVisiblePanels\` is the sole near-viewport kickoff for panel fetches; all 4 entries were missing from it.
- Fix adds the 4 missing \`if (shouldPrime(...)) primeTask(...)\` entries, mirroring the pattern already used for \`energy-crisis\`, \`hormuz-tracker\`, \`oil-inventories\`, etc.

## Evidence the data is fine; it's pure wiring

All 5 backing Redis keys report OK via \`/api/health\` with expected record counts:
\`\`\`
pipelinesGas        OK 75
pipelinesOil        OK 75
storageFacilities   OK 200
fuelShortages       OK 29
energyDisruptions   OK 52
\`\`\`

All 4 RPCs return real payloads (probed directly):
\`\`\`
GET /api/supply-chain/v1/list-pipelines?commodityType=  → 200 (100 KB)
GET /api/supply-chain/v1/list-storage-facilities        → 200 (115 KB)
GET /api/supply-chain/v1/list-fuel-shortages            → 200 (21 KB)
GET /api/supply-chain/v1/list-energy-disruptions        → 200 (36 KB)
\`\`\`

## Why the panels self-fetch already

Each panel already implements the full data path: bootstrap-cache-first lookup, RPC fallback, \`setCached…\` back-propagation into the shared store so map layers pick up the same data, and error states. The panels are not missing any logic; they were simply never triggered because App.ts doesn't know about them.

## Test plan
- [x] \`npm run typecheck\` passes.
- [ ] Visual check: pull the branch, load a variant that includes the panels (FULL / ENERGY / FINANCE / COMMODITY), confirm all 4 leave \"Loading…\" and render data.