### PR TITLE
feat(brief): make MAX_STORIES_PER_USER env-tunable (default 12, evidence kept it at 12)

### DIFF
--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -151,7 +151,18 @@ export function userDisplayNameFromId(userId) {
 
 // ── Compose a full brief for a single rule ──────────────────────────────────
 
-const MAX_STORIES_PER_USER = 12;
+// Bumped 12 → 16 based on production telemetry from PR #3387: 73% of
+// `sensitivity=all` users had `dropped_cap=18` per tick (30 qualified
+// stories truncated to 12). Multi-member topics straddling the cap
+// boundary lost members to truncation. Bumping to 16 lets larger
+// leading topics fit fully and reduces dropped_cap from ~18 to ~14
+// without affecting `sensitivity=critical` users (their pools cap at
+// 7-10 stories — well below either threshold).
+//
+// "Are we getting better" signal: watch the [digest] brief filter
+// drops log line on Railway — `dropped_cap=` should drop by ~4 per
+// tick after deploy.
+const MAX_STORIES_PER_USER = 16;
 
 /**
  * Filter + assemble a BriefEnvelope for one alert rule from a

--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -151,18 +151,30 @@ export function userDisplayNameFromId(userId) {
 
 // ── Compose a full brief for a single rule ──────────────────────────────────
 
-// Bumped 12 → 16 based on production telemetry from PR #3387: 73% of
-// `sensitivity=all` users had `dropped_cap=18` per tick (30 qualified
-// stories truncated to 12). Multi-member topics straddling the cap
-// boundary lost members to truncation. Bumping to 16 lets larger
-// leading topics fit fully and reduces dropped_cap from ~18 to ~14
-// without affecting `sensitivity=critical` users (their pools cap at
-// 7-10 stories — well below either threshold).
+// Cap on stories shown per user per brief.
 //
-// "Are we getting better" signal: watch the [digest] brief filter
-// drops log line on Railway — `dropped_cap=` should drop by ~4 per
-// tick after deploy.
-const MAX_STORIES_PER_USER = 16;
+// Default 12 — kept at the historical value because the offline sweep
+// harness (scripts/sweep-topic-thresholds.mjs) showed bumping the cap
+// to 16 against 2026-04-24 production replay data DROPPED visible
+// quality at the active 0.45 threshold (visible_quality 0.916 → 0.716;
+// positions 13-16 are mostly singletons or members of "should-separate"
+// clusters at this threshold, so they dilute without helping adjacency).
+//
+// Env-tunable via DIGEST_MAX_STORIES_PER_USER so future sweep evidence
+// (different threshold, different label set, different pool composition)
+// can be acted on with a Railway env flip without a redeploy. Any
+// invalid / non-positive value falls back to the 12 default.
+//
+// "Are we getting better" signal: re-run scripts/sweep-topic-thresholds.mjs
+// with --cap N before flipping the env, and the daily
+// scripts/brief-quality-report.mjs after.
+function readMaxStoriesPerUser() {
+  const raw = process.env.DIGEST_MAX_STORIES_PER_USER;
+  if (raw == null || raw === '') return 12;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 12;
+}
+const MAX_STORIES_PER_USER = readMaxStoriesPerUser();
 
 /**
  * Filter + assemble a BriefEnvelope for one alert rule from a

--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -174,7 +174,13 @@ function readMaxStoriesPerUser() {
   const n = Number.parseInt(raw, 10);
   return Number.isFinite(n) && n > 0 ? n : 12;
 }
-const MAX_STORIES_PER_USER = readMaxStoriesPerUser();
+// Exported so brief-llm.mjs (buildDigestPrompt + hashDigestInput) can
+// slice to the same cap. Hard-coding `slice(0, 12)` there would mean
+// the LLM prose only references the first 12 stories even when the
+// brief envelope carries more — a quiet mismatch between what the
+// reader sees as story cards vs the AI summary above them. Reviewer
+// P1 on PR #3389.
+export const MAX_STORIES_PER_USER = readMaxStoriesPerUser();
 
 /**
  * Filter + assemble a BriefEnvelope for one alert rule from a

--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -34,6 +34,10 @@ import {
   parseWhyMatters,
 } from '../../shared/brief-llm-core.js';
 import { sanitizeForPrompt } from '../../server/_shared/llm-sanitize.js';
+// Single source of truth for the brief story cap. Both buildDigestPrompt
+// and hashDigestInput must slice to this value or the LLM prose drifts
+// from the rendered story cards (PR #3389 reviewer P1).
+import { MAX_STORIES_PER_USER } from './brief-compose.mjs';
 
 /**
  * Sanitize the story fields that flow into buildWhyMattersUserPrompt and
@@ -323,7 +327,7 @@ const DIGEST_PROSE_SYSTEM =
  * @returns {{ system: string; user: string }}
  */
 export function buildDigestPrompt(stories, sensitivity) {
-  const lines = stories.slice(0, 12).map((s, i) => {
+  const lines = stories.slice(0, MAX_STORIES_PER_USER).map((s, i) => {
     const n = String(i + 1).padStart(2, '0');
     return `${n}. [${s.threatLevel}] ${s.headline} — ${s.category} · ${s.country} · ${s.source}`;
   });
@@ -422,10 +426,11 @@ function hashDigestInput(userId, stories, sensitivity) {
   // Canonicalise as JSON of the fields the prompt actually references,
   // in the prompt's ranked order. Stable stringification via an array
   // of tuples keeps field ordering deterministic without relying on
-  // JS object-key iteration order.
+  // JS object-key iteration order. Slice MUST match buildDigestPrompt's
+  // slice or the cache key drifts from the prompt content.
   const material = JSON.stringify([
     sensitivity ?? '',
-    ...stories.slice(0, 12).map((s) => [
+    ...stories.slice(0, MAX_STORIES_PER_USER).map((s) => [
       s.headline ?? '',
       s.threatLevel ?? '',
       s.category ?? '',

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -192,11 +192,14 @@ describe('composeBriefFromDigestStories — continued', () => {
     assert.deepEqual(env.data.stories.map((s) => s.headline), ['A', 'B']);
   });
 
-  it('caps at 16 stories per brief (post production-evidence bump)', () => {
-    // Bumped 12 → 16 in PR following #3387: production logs showed
-    // dropped_cap=18 for 73% of all-sensitivity users every tick.
-    // Larger cap admits more multi-member topic members before
-    // truncating, reducing topic-straddle losses.
+  it('caps at 12 stories per brief by default (env-tunable via DIGEST_MAX_STORIES_PER_USER)', () => {
+    // Default kept at 12. Offline sweep harness against 2026-04-24
+    // production replay showed cap=16 dropped visible_quality from
+    // 0.916 → 0.716 at the active 0.45 threshold (positions 13-16
+    // are mostly singletons or "should-separate" members at this
+    // threshold, so they dilute without helping adjacency). The
+    // constant is env-tunable so a Railway flip can experiment with
+    // cap values once new sweep evidence justifies them.
     const many = Array.from({ length: 30 }, (_, i) =>
       digestStory({ hash: `h${i}`, title: `Story ${i}` }),
     );
@@ -206,7 +209,7 @@ describe('composeBriefFromDigestStories — continued', () => {
       { clusters: 30, multiSource: 15 },
       { nowMs: NOW },
     );
-    assert.equal(env.data.stories.length, 16);
+    assert.equal(env.data.stories.length, 12);
   });
 
   it('maps unknown severity to null → story is dropped', () => {

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -192,7 +192,11 @@ describe('composeBriefFromDigestStories — continued', () => {
     assert.deepEqual(env.data.stories.map((s) => s.headline), ['A', 'B']);
   });
 
-  it('caps at 12 stories per brief', () => {
+  it('caps at 16 stories per brief (post production-evidence bump)', () => {
+    // Bumped 12 → 16 in PR following #3387: production logs showed
+    // dropped_cap=18 for 73% of all-sensitivity users every tick.
+    // Larger cap admits more multi-member topic members before
+    // truncating, reducing topic-straddle losses.
     const many = Array.from({ length: 30 }, (_, i) =>
       digestStory({ hash: `h${i}`, title: `Story ${i}` }),
     );
@@ -202,7 +206,7 @@ describe('composeBriefFromDigestStories — continued', () => {
       { clusters: 30, multiSource: 15 },
       { nowMs: NOW },
     );
-    assert.equal(env.data.stories.length, 12);
+    assert.equal(env.data.stories.length, 16);
   });
 
   it('maps unknown severity to null → story is dropped', () => {


### PR DESCRIPTION
## Summary

**Originally proposed bumping the cap 12 → 16 based on `dropped_cap=18` from PR #3387's instrumentation.** Reviewer correctly pushed back: "the logs prove dropped_cap exists, they don't prove positions 13-16 belong to multi-member topics whose other members survived." Fair.

**The sweep harness (PR #3390) was built to answer that exact question, and the data went the other way.** Against 2026-04-24 production replay:

| threshold | cap=12 visible_quality | cap=16 visible_quality |
|---|---|---|
| 0.45 (current) | **0.916** | 0.716 ← cap bump HURTS |
| 0.42 (proposed) | 0.845 | 0.845 ← neutral |

Positions 13-16 are mostly singletons or members of "should-separate" clusters at the current 0.45 threshold. Bumping the cap dilutes the visible brief without improving topic adjacency.

**Revised PR scope:** keep the default at 12, add env-tunability via `DIGEST_MAX_STORIES_PER_USER`. Future sweep evidence (different threshold, different label corpus, different pool composition) can be acted on with a Railway env flip — no redeploy required.

## Changes

- `scripts/lib/brief-compose.mjs`: `MAX_STORIES_PER_USER` reads from `process.env.DIGEST_MAX_STORIES_PER_USER` with a default of 12 and graceful fallback on invalid values.
- `tests/brief-from-digest-stories.test.mjs`: updated test name + comment to capture the evidence-driven decision.
- Plan doc (local-only, gitignored): updated to reflect the cap finding and mark Sol-3 cancelled with production evidence.

## Companion PR

[#3390](https://github.com/koala73/worldmonitor/pull/3390) — the sweep harness whose data drove this revision. After both PRs land, the actual adjacency fix is **`DIGEST_DEDUP_TOPIC_THRESHOLD=0.42`** as a Railway env flip on the `scripts-cron-digest-notifications` service. Sweep recommends 0.42 with visible_quality 0.845 vs current 0.45's 0.611 — substantial recall lift without false-adjacency cost.

## Test plan

- [x] `npm run test:data`: 6914/6914 passing
- [x] Lint clean
- [x] Sweep validation (cap=12 vs cap=16 at multiple thresholds, against live Upstash replay records)

## Post-Deploy Monitoring & Validation

No production runtime impact at deploy time — the constant is now read from env, defaults to the historical value (12), so production behaviour is byte-identical.

**Future use:** to experiment with cap values, set `DIGEST_MAX_STORIES_PER_USER=N` on the `scripts-cron-digest-notifications` Railway service, watch the next tick's `[digest] brief filter drops` log line for `out=N`, and re-run `scripts/brief-quality-report.mjs` to compare quality_score vs the prior tick.