### PR TITLE
docs(brief-quality): correct cap_truncation help text drift (PR #3390 follow-up)

### DIFF
--- a/scripts/brief-quality-report.mjs
+++ b/scripts/brief-quality-report.mjs
@@ -17,9 +17,11 @@
 //   - false_adjacency — % of "should-separate" labeled pairs that end
 //     up adjacent (false positive)
 //   - cap_truncation_rate — % of qualified stories truncated by the
-//     MAX_STORIES_PER_USER cap (computed from production drop logs if
-//     supplied via stdin, else estimated as max(0, in - 16)/in from
-//     replay record counts)
+//     MAX_STORIES_PER_USER cap. ONLY reported when production drop logs
+//     are piped in via --drop-lines-stdin. Without that input, this
+//     metric is omitted entirely (no fallback estimate — replay records
+//     don't capture the post-cap output count, so any estimate would be
+//     misleading).
 //   - multi_member_topic_share — % of topics with size > 1
 //   - quality_score — composite (recall × 0.6 + (1-false-adj) × 0.3 +
 //     multi-member × 0.1)


### PR DESCRIPTION
## Summary

Greptile P3 follow-up on the merged PR #3390. The help comment in \`scripts/brief-quality-report.mjs\` (lines 19-22) described \`cap_truncation_rate\` as having a fallback estimate from replay record counts, but:

1. The "16" in the formula was stale (post PR #3389, cap default is 12).
2. The fallback estimate was never implemented. \`cap_truncation\` is only reported when \`--drop-lines-stdin\` is passed.

Operators reading \`--help\` would expect the metric without piping stdin and not see it. Doc fix only — code behaviour unchanged.

## Why no fallback implementation

Replay records don't capture the post-cap \`out\` count (that's a per-user product of \`composeAndStoreBriefForUser\`). Estimating cap-truncation from replay alone would compare the seeder-side \`reps[]\` length against an assumed cap, which would over-report (replay reps are pre-floor, pre-slice) and mislead operators about the actual user-visible truncation. The honest answer is "we need the production drop logs to know," and the code already reflects that — the doc just didn't.

## Test plan

- [x] \`node --import tsx/esm scripts/brief-quality-report.mjs --help\` prints the corrected text
- [x] \`node --import tsx/esm scripts/brief-quality-report.mjs --date 2026-04-24\` still works (no code-path change)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — comment-only doc fix in an operator-side script.