### PR TITLE
fix(unrest): proxy-only fetch + 3-attempt retry for GDELT

### DIFF
--- a/scripts/seed-unrest-events.mjs
+++ b/scripts/seed-unrest-events.mjs
@@ -171,42 +171,60 @@ function describeErr(err) {
 // Decodo→Cloudflare→GDELT occasionally returns 522 or RSTs the TLS handshake
 // (~80% per single attempt in production); retry-with-jitter recovers most of
 // it without touching the cron interval.
-async function fetchGdeltViaProxy(url, proxyAuth) {
-  const MAX_ATTEMPTS = 3;
+//
+// Test seams:
+//   _proxyFetcher  — replaces httpsProxyFetchRaw (default production wiring).
+//   _sleep         — replaces the inter-attempt jitter delay.
+//   _maxAttempts   — replaces the default 3 (lets tests bound iterations).
+//   _jitter        — replaces Math.random()-based jitter (deterministic in tests).
+export async function fetchGdeltViaProxy(url, proxyAuth, opts = {}) {
+  const {
+    _proxyFetcher = httpsProxyFetchRaw,
+    _sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+    _maxAttempts = 3,
+    _jitter = () => 1500 + Math.random() * 1500,
+  } = opts;
   let lastErr;
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+  for (let attempt = 1; attempt <= _maxAttempts; attempt++) {
     try {
-      const { buffer } = await httpsProxyFetchRaw(url, proxyAuth, {
+      const { buffer } = await _proxyFetcher(url, proxyAuth, {
         accept: 'application/json',
         timeoutMs: 45_000,
       });
       return JSON.parse(buffer.toString('utf8'));
     } catch (err) {
       lastErr = err;
-      if (attempt < MAX_ATTEMPTS) {
-        console.warn(`  [GDELT] proxy attempt ${attempt}/${MAX_ATTEMPTS} failed (${describeErr(err)}); retrying`);
-        await new Promise((r) => setTimeout(r, 1500 + Math.random() * 1500));
+      // JSON.parse on a successfully fetched body is deterministic — retrying
+      // can't recover. Bail immediately so we don't burn three attempts on
+      // a malformed-but-cached upstream response.
+      if (err instanceof SyntaxError) throw err;
+      if (attempt < _maxAttempts) {
+        console.warn(`  [GDELT] proxy attempt ${attempt}/${_maxAttempts} failed (${describeErr(err)}); retrying`);
+        await _sleep(_jitter());
       }
     }
   }
   throw lastErr;
 }
 
-async function fetchGdeltEvents() {
+export async function fetchGdeltEvents(opts = {}) {
+  const { _resolveProxyForConnect = resolveProxyForConnect, ..._proxyOpts } = opts;
   const params = new URLSearchParams({
     query: 'protest OR riot OR demonstration OR strike',
     maxrows: '2500',
   });
   const url = `${GDELT_GKG_URL}?${params}`;
 
-  const proxyAuth = resolveProxyForConnect();
+  const proxyAuth = _resolveProxyForConnect();
   if (!proxyAuth) {
-    throw new Error('GDELT requires proxy: no proxy credentials configured');
+    // Direct fetch hasn't worked from Railway since PR #3256; this seeder
+    // hard-requires a CONNECT proxy. Surface the env var ops needs to set.
+    throw new Error('GDELT requires CONNECT proxy: PROXY_URL env var is not set on this Railway service');
   }
 
   let data;
   try {
-    data = await fetchGdeltViaProxy(url, proxyAuth);
+    data = await fetchGdeltViaProxy(url, proxyAuth, _proxyOpts);
   } catch (proxyErr) {
     throw Object.assign(
       new Error(`GDELT proxy failed (3 attempts): ${describeErr(proxyErr)}`),
@@ -296,15 +314,22 @@ export function declareRecords(data) {
   return Array.isArray(data?.events) ? data.events.length : 0;
 }
 
-runSeed('unrest', 'events', CANONICAL_KEY, fetchUnrestEvents, {
-  validateFn: validate,
-  ttlSeconds: CACHE_TTL,
-  sourceVersion: 'acled+gdelt',
+// Gate the runSeed entry-point so this module is importable from tests
+// without triggering a real seed run. process.argv[1] is set when this file
+// is invoked as a script (`node scripts/seed-unrest-events.mjs`); under
+// `node --test`, argv[1] is the test runner, not this file.
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  runSeed('unrest', 'events', CANONICAL_KEY, fetchUnrestEvents, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: 'acled+gdelt',
 
-  declareRecords,
-  schemaVersion: 1,
-  maxStaleMin: 120,
-}).catch((err) => {
-  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
-  process.exit(1);
-});
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 120,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-unrest-events.mjs
+++ b/scripts/seed-unrest-events.mjs
@@ -166,25 +166,30 @@ function describeErr(err) {
   return causeCode ? `${err.message} (cause: ${causeCode})` : (err.message || String(err));
 }
 
-async function fetchGdeltDirect(url) {
-  const resp = await fetch(url, {
-    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!resp.ok) throw Object.assign(new Error(`GDELT API error: ${resp.status}`), { httpStatus: resp.status });
-  return resp.json();
-}
-
+// Direct fetch from Railway has 0% success — every attempt errors with
+// UND_ERR_CONNECT_TIMEOUT or ECONNRESET. Path is always proxy-only here.
+// Decodo→Cloudflare→GDELT occasionally returns 522 or RSTs the TLS handshake
+// (~80% per single attempt in production); retry-with-jitter recovers most of
+// it without touching the cron interval.
 async function fetchGdeltViaProxy(url, proxyAuth) {
-  // GDELT v1 gkg_geojson responds in ~19s when degraded; 20s timeout caused
-  // chronic "HTTP 522" / "CONNECT tunnel timeout" from Decodo, freezing
-  // seed-meta and firing STALE_SEED across health. 45s absorbs that variance
-  // with headroom.
-  const { buffer } = await httpsProxyFetchRaw(url, proxyAuth, {
-    accept: 'application/json',
-    timeoutMs: 45_000,
-  });
-  return JSON.parse(buffer.toString('utf8'));
+  const MAX_ATTEMPTS = 3;
+  let lastErr;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const { buffer } = await httpsProxyFetchRaw(url, proxyAuth, {
+        accept: 'application/json',
+        timeoutMs: 45_000,
+      });
+      return JSON.parse(buffer.toString('utf8'));
+    } catch (err) {
+      lastErr = err;
+      if (attempt < MAX_ATTEMPTS) {
+        console.warn(`  [GDELT] proxy attempt ${attempt}/${MAX_ATTEMPTS} failed (${describeErr(err)}); retrying`);
+        await new Promise((r) => setTimeout(r, 1500 + Math.random() * 1500));
+      }
+    }
+  }
+  throw lastErr;
 }
 
 async function fetchGdeltEvents() {
@@ -194,26 +199,19 @@ async function fetchGdeltEvents() {
   });
   const url = `${GDELT_GKG_URL}?${params}`;
 
+  const proxyAuth = resolveProxyForConnect();
+  if (!proxyAuth) {
+    throw new Error('GDELT requires proxy: no proxy credentials configured');
+  }
+
   let data;
   try {
-    data = await fetchGdeltDirect(url);
-  } catch (directErr) {
-    // Upstream HTTP error (4xx/5xx) — proxy routes to the same GDELT endpoint so
-    // it won't change the response. Save the 20s proxy timeout and bubble up.
-    if (directErr.httpStatus) throw directErr;
-    const proxyAuth = resolveProxyForConnect();
-    if (!proxyAuth) {
-      throw Object.assign(new Error(`GDELT direct failed (no proxy configured): ${describeErr(directErr)}`), { cause: directErr });
-    }
-    console.warn(`  [GDELT] direct failed (${describeErr(directErr)}); retrying via proxy`);
-    try {
-      data = await fetchGdeltViaProxy(url, proxyAuth);
-    } catch (proxyErr) {
-      throw Object.assign(
-        new Error(`GDELT both paths failed — direct: ${describeErr(directErr)}; proxy: ${describeErr(proxyErr)}`),
-        { cause: proxyErr },
-      );
-    }
+    data = await fetchGdeltViaProxy(url, proxyAuth);
+  } catch (proxyErr) {
+    throw Object.assign(
+      new Error(`GDELT proxy failed (3 attempts): ${describeErr(proxyErr)}`),
+      { cause: proxyErr },
+    );
   }
 
   const features = data?.features || [];

--- a/tests/seed-unrest-gdelt-fetch.test.mjs
+++ b/tests/seed-unrest-gdelt-fetch.test.mjs
@@ -1,0 +1,163 @@
+// Tests for the GDELT proxy retry path in scripts/seed-unrest-events.mjs.
+//
+// Locks the behavioural contract introduced in PR #3395:
+//
+//   1. Single attempt success — happy path, no retries fire.
+//   2. Transient proxy failure recoverable by retry — first attempt(s)
+//      fail, a later attempt succeeds, returns parsed JSON.
+//   3. All attempts fail — throws the LAST error so ops sees the most
+//      recent failure mode (Cloudflare 522 vs ECONNRESET drift).
+//   4. Malformed proxy body — JSON.parse throws SyntaxError; the helper
+//      bails immediately rather than burning attempts on a deterministic
+//      parse failure.
+//   5. Missing CONNECT proxy creds — fetchGdeltEvents throws with a
+//      clear "PROXY_URL env var is not set" pointer for ops, with NO
+//      proxy fetcher invocation (no wasted network).
+//
+// Pre-PR-#3395 behaviour to AVOID regressing into:
+//   - Direct fetch was tried first and failed UND_ERR_CONNECT_TIMEOUT
+//     on every Railway tick (0% success). Re-introducing a "soft"
+//     direct fallback would just add latency and log noise.
+
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+
+const { fetchGdeltViaProxy, fetchGdeltEvents } = await import('../scripts/seed-unrest-events.mjs');
+
+const URL = 'https://api.gdeltproject.org/api/v1/gkg_geojson?query=test';
+const PROXY_AUTH = 'user:pass@gate.decodo.com:7000';
+
+function jsonBuffer(obj) {
+  return { buffer: Buffer.from(JSON.stringify(obj), 'utf8') };
+}
+
+const noSleep = async () => {};
+const noJitter = () => 0;
+
+// ─── 1. happy path: first attempt succeeds ─────────────────────────────
+
+test('proxy success on first attempt → returns parsed JSON, no retries', async () => {
+  let calls = 0;
+  const _proxyFetcher = async () => {
+    calls++;
+    return jsonBuffer({ features: [{ name: 'A' }] });
+  };
+  const result = await fetchGdeltViaProxy(URL, PROXY_AUTH, {
+    _proxyFetcher,
+    _sleep: noSleep,
+    _jitter: noJitter,
+  });
+  assert.deepEqual(result, { features: [{ name: 'A' }] });
+  assert.equal(calls, 1, 'should NOT retry on success');
+});
+
+// ─── 2. transient flake: 2 failures + 1 success ────────────────────────
+
+test('two proxy failures, third attempt succeeds → returns parsed JSON', async () => {
+  let calls = 0;
+  const _proxyFetcher = async () => {
+    calls++;
+    if (calls < 3) throw new Error(`Proxy CONNECT: HTTP/1.1 522 Server Error`);
+    return jsonBuffer({ features: [{ name: 'B' }] });
+  };
+  let sleepCount = 0;
+  const _sleep = async () => { sleepCount++; };
+  const result = await fetchGdeltViaProxy(URL, PROXY_AUTH, {
+    _proxyFetcher,
+    _sleep,
+    _jitter: noJitter,
+    _maxAttempts: 3,
+  });
+  assert.deepEqual(result, { features: [{ name: 'B' }] });
+  assert.equal(calls, 3, 'should retry until success');
+  assert.equal(sleepCount, 2, 'should sleep between attempts only (not after final)');
+});
+
+// ─── 3. all attempts fail ──────────────────────────────────────────────
+
+test('all attempts fail → throws LAST error', async () => {
+  let calls = 0;
+  const errors = [
+    new Error('Proxy CONNECT: HTTP/1.1 522 Server Error'),
+    new Error('CONNECT tunnel timeout'),
+    new Error('Client network socket disconnected'),
+  ];
+  const _proxyFetcher = async () => {
+    throw errors[calls++];
+  };
+  await assert.rejects(
+    fetchGdeltViaProxy(URL, PROXY_AUTH, {
+      _proxyFetcher,
+      _sleep: noSleep,
+      _jitter: noJitter,
+      _maxAttempts: 3,
+    }),
+    /Client network socket disconnected/,
+  );
+  assert.equal(calls, 3);
+});
+
+// ─── 4. parse failure short-circuits retry ─────────────────────────────
+
+test('malformed proxy body → throws SyntaxError immediately, no retry', async () => {
+  let calls = 0;
+  const _proxyFetcher = async () => {
+    calls++;
+    return { buffer: Buffer.from('<html>this is not json</html>', 'utf8') };
+  };
+  await assert.rejects(
+    fetchGdeltViaProxy(URL, PROXY_AUTH, {
+      _proxyFetcher,
+      _sleep: noSleep,
+      _jitter: noJitter,
+      _maxAttempts: 3,
+    }),
+    SyntaxError,
+  );
+  assert.equal(calls, 1, 'parse error must not trigger retries');
+});
+
+// ─── 5. fetchGdeltEvents: missing proxy creds ──────────────────────────
+
+test('fetchGdeltEvents with no proxy creds → throws clear ops-actionable error, no fetcher call', async () => {
+  let fetcherCalled = false;
+  await assert.rejects(
+    fetchGdeltEvents({
+      _resolveProxyForConnect: () => null,
+      _proxyFetcher: async () => { fetcherCalled = true; return jsonBuffer({}); },
+      _sleep: noSleep,
+      _jitter: noJitter,
+    }),
+    /PROXY_URL env var is not set/,
+  );
+  assert.equal(fetcherCalled, false, 'must not attempt proxy fetch when creds missing');
+});
+
+// ─── 6. fetchGdeltEvents: end-to-end with retry path ───────────────────
+
+test('fetchGdeltEvents with one transient proxy failure → recovers and aggregates events', async () => {
+  let calls = 0;
+  const _proxyFetcher = async () => {
+    calls++;
+    if (calls === 1) throw new Error('Proxy CONNECT: HTTP/1.1 522 Server Error');
+    // Five mentions at the same lat/lon — passes the count >= 5 floor in the aggregator.
+    const features = Array.from({ length: 5 }, () => ({
+      properties: { name: 'Cairo, Egypt', urltone: -3 },
+      geometry: { type: 'Point', coordinates: [31.2, 30.0] },
+    }));
+    return jsonBuffer({ features });
+  };
+  const events = await fetchGdeltEvents({
+    _resolveProxyForConnect: () => PROXY_AUTH,
+    _proxyFetcher,
+    _sleep: noSleep,
+    _jitter: noJitter,
+    _maxAttempts: 3,
+  });
+  assert.equal(calls, 2, 'should retry exactly once after the 522');
+  assert.equal(events.length, 1, 'five mentions at one location → one aggregated event');
+  assert.equal(events[0].country, 'Egypt');
+});


### PR DESCRIPTION
## Summary

PR #3362 (45s proxy timeout) deployed correctly but didn't fix the dominant failure mode. Fresh production log analysis from 2026-04-24T20:30 → 2026-04-25T10:16 UTC shows:

- **18% per-tick success rate**, 9 consecutive failures observed in the most recent 2.25h window — exactly matches the user-reported `unrestEvents: STALE_SEED, records: 106, seedAgeMin: 133`.
- Most failures complete in **3–14 seconds**, well below the 45s timeout. They're not timing out — Decodo's proxy is **fast-failing** with two errors:
  - `Proxy CONNECT: HTTP/1.1 522 Server Error` — Cloudflare-to-origin gateway error
  - `Client network socket disconnected before secure TLS connection was established (cause: ECONNRESET)` — Decodo TLS handshake yanked
- Every tick (success and failure) logs `[GDELT] direct failed (cause: UND_ERR_CONNECT_TIMEOUT|ECONNRESET)` — the direct path has **0% success** since PR #3256 added the proxy fallback. We waste ~8–30s per tick on it.

## Changes

1. **Drop the direct fetch entirely.** It can't succeed and just adds latency + log noise.
2. **Wrap the proxy call in a 3-attempt retry with 1.5–3s jitter.** With per-attempt success ~18% at the moment, three attempts lift per-tick success to ~1 - (1 - 0.18)^3 ≈ 45%. Under more typical Decodo↔Cloudflare flake (~50% per attempt) the same retry takes us to ~87%, comfortably under the 120m STALE_SEED threshold.

## Deeper fix (deliberately separate)

ACLED credentials remain unconfigured on the Railway unrest service — every run still logs `ACLED: no credentials configured, skipping`. Wiring those env vars gives the seeder a genuine second upstream and is the structural fix; this PR is the immediate-relief layer.

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] CJS syntax check
- [x] `npm run lint` (no errors; warnings/infos only)
- [x] `npm run test:data` (6944 pass)
- [x] Edge bundle check for `api/*.js`
- [x] `node --test tests/edge-functions.test.mjs` (177 pass)
- [x] `npm run lint:md`
- [x] `npm run version:check`
- [x] `node --check scripts/seed-unrest-events.mjs`
- [ ] After merge + Railway redeploy, watch the next ~1h of unrest cron logs for `[GDELT] proxy attempt N/3 failed ... retrying` lines (proves retry is engaging) followed by successful `Merged: 0 ACLED + N GDELT = N deduplicated` lines.
- [ ] Confirm `/api/health` `unrestEvents.status` settles back to `OK` within ~60m.