### PR TITLE
fix(brief): unify compose+send window, fall through filter-rejection

### DIFF
--- a/scripts/lib/digest-orchestration-helpers.mjs
+++ b/scripts/lib/digest-orchestration-helpers.mjs
@@ -32,32 +32,68 @@ export function subjectForBrief({ briefLead, synthesisLevel, shortDate }) {
 }
 
 /**
+ * Single source of truth for the digest's story window. Used by BOTH
+ * the compose path (digestFor closure in the cron) and the send loop.
+ * Without this, the brief lead can be synthesized from a 24h pool
+ * while the channel body ships 7d / 12h of stories — reintroducing
+ * the cross-surface divergence the canonical-brain refactor is meant
+ * to eliminate, just in a different shape.
+ *
+ * `lastSentAt` is the rule's previous successful send timestamp (ms
+ * since epoch) or null on first send. `defaultLookbackMs` is the
+ * first-send fallback (today: 24h).
+ *
+ * @param {number | null | undefined} lastSentAt
+ * @param {number} nowMs
+ * @param {number} defaultLookbackMs
+ * @returns {number}
+ */
+export function digestWindowStartMs(lastSentAt, nowMs, defaultLookbackMs) {
+  return lastSentAt ?? (nowMs - defaultLookbackMs);
+}
+
+/**
  * Walk an annotated rule list and return the winning candidate +
  * its non-empty story pool. Two-pass: due rules first (so the
  * synthesis comes from a rule that's actually sending), then ALL
  * eligible rules (compose-only tick — keeps the dashboard brief
  * fresh for weekly/twice_daily users). Within each pass, walk by
  * compareRules priority and pick the FIRST candidate whose pool is
- * non-empty.
+ * non-empty AND survives `tryCompose` (when provided).
  *
- * Returns null when every candidate has an empty pool — caller
- * skips the user (same as today's behavior).
+ * Returns null when every candidate is rejected — caller skips the
+ * user (same as today's behavior on empty-pool exhaustion).
  *
  * Plan acceptance criteria A6.l (compose-only tick still works for
  * weekly user) + A6.m (winner walks past empty-pool top-priority
  * candidate). Codex Round-3 High #1 + Round-4 High #1 + Round-4
  * Medium #2.
  *
- * `log` is the per-empty-pool log emitter — passed in so tests can
- * capture lines without reaching for console.log.
+ * `tryCompose` (optional): called with `(cand, stories)` after a
+ * non-empty pool is found. Returning a truthy value claims the
+ * candidate as winner and the value is forwarded as `composeResult`.
+ * Returning a falsy value (e.g. composeBriefFromDigestStories
+ * dropped every story via its URL/headline/shape filters) walks to
+ * the next candidate. Without this callback, the helper preserves
+ * the original "first non-empty pool wins" semantics, which let a
+ * filter-rejected top-priority candidate suppress the brief for the
+ * user even when a lower-priority candidate would have shipped one.
+ *
+ * `digestFor` receives the full annotated candidate (not just the
+ * rule) so callers can derive a per-candidate story window from
+ * `cand.lastSentAt` — see `digestWindowStartMs`.
+ *
+ * `log` is the per-rejected-candidate log emitter — passed in so
+ * tests can capture lines without reaching for console.log.
  *
  * @param {Array<{ rule: object; lastSentAt: number | null; due: boolean }>} annotated
- * @param {(rule: object) => Promise<unknown[] | null | undefined>} digestFor
+ * @param {(cand: { rule: object; lastSentAt: number | null; due: boolean }) => Promise<unknown[] | null | undefined>} digestFor
  * @param {(line: string) => void} log
  * @param {string} userId
- * @returns {Promise<{ winner: { rule: object; lastSentAt: number | null; due: boolean }; stories: unknown[] } | null>}
+ * @param {((cand: { rule: object; lastSentAt: number | null; due: boolean }, stories: unknown[]) => Promise<unknown> | unknown)} [tryCompose]
+ * @returns {Promise<{ winner: { rule: object; lastSentAt: number | null; due: boolean }; stories: unknown[]; composeResult?: unknown } | null>}
  */
-export async function pickWinningCandidateWithPool(annotated, digestFor, log, userId) {
+export async function pickWinningCandidateWithPool(annotated, digestFor, log, userId, tryCompose) {
   if (!Array.isArray(annotated) || annotated.length === 0) return null;
   const sortedDue = annotated.filter((a) => a.due).sort((a, b) => compareRules(a.rule, b.rule));
   const sortedAll = [...annotated].sort((a, b) => compareRules(a.rule, b.rule));
@@ -72,7 +108,7 @@ export async function pickWinningCandidateWithPool(annotated, digestFor, log, us
     walkOrder.push(cand);
   }
   for (const cand of walkOrder) {
-    const stories = await digestFor(cand.rule);
+    const stories = await digestFor(cand);
     if (!stories || stories.length === 0) {
       log(
         `[digest] brief filter drops user=${userId} ` +
@@ -83,6 +119,21 @@ export async function pickWinningCandidateWithPool(annotated, digestFor, log, us
           `in=0 dropped_severity=0 dropped_url=0 dropped_headline=0 dropped_shape=0 dropped_cap=0 out=0`,
       );
       continue;
+    }
+    if (typeof tryCompose === 'function') {
+      const composeResult = await tryCompose(cand, stories);
+      if (!composeResult) {
+        log(
+          `[digest] brief filter drops user=${userId} ` +
+            `sensitivity=${cand.rule.sensitivity ?? 'high'} ` +
+            `variant=${cand.rule.variant ?? 'full'} ` +
+            `due=${cand.due} ` +
+            `outcome=filter-rejected ` +
+            `in=${stories.length} out=0`,
+        );
+        continue;
+      }
+      return { winner: cand, stories, composeResult };
     }
     return { winner: cand, stories };
   }

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -40,6 +40,7 @@ import {
   shouldExitNonZero as shouldExitOnBriefFailures,
 } from './lib/brief-compose.mjs';
 import {
+  digestWindowStartMs,
   pickWinningCandidateWithPool,
   runSynthesisWithFallback,
   subjectForBrief,
@@ -127,12 +128,13 @@ const BRIEF_URL_SIGNING_SECRET = process.env.BRIEF_URL_SIGNING_SECRET ?? '';
 const WORLDMONITOR_PUBLIC_BASE_URL =
   process.env.WORLDMONITOR_PUBLIC_BASE_URL ?? 'https://worldmonitor.app';
 const BRIEF_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
-// The brief is a once-per-day editorial snapshot. 24h is the natural
-// window regardless of a user's email cadence (daily / twice_daily /
-// weekly) — weekly subscribers still expect a fresh brief each day
-// in the dashboard panel. Matches DIGEST_LOOKBACK_MS so first-send
-// users see identical story pools in brief and email.
-const BRIEF_STORY_WINDOW_MS = 24 * 60 * 60 * 1000;
+// Brief story window: derived per-rule from the rule's lastSentAt via
+// digestWindowStartMs, identical to the send-loop window. The previous
+// fixed-24h constant decoupled the canonical brief lead from the
+// stories the email/Slack body actually shipped, reintroducing the
+// cross-surface divergence the canonical-brain refactor is designed to
+// eliminate (especially severe for weekly users — 7d email body vs 24h
+// lead).
 const INSIGHTS_KEY = 'news:insights:v1';
 
 // Operator kill switch — used to intentionally silence brief compose
@@ -1253,12 +1255,20 @@ async function composeBriefsForRun(rules, nowMs) {
   // inherits a looser populator's pool (the earlier populator "wins"
   // and decides which severity tiers enter the pool, so stricter
   // users get a pool that contains severities they never wanted).
-  const windowStart = nowMs - BRIEF_STORY_WINDOW_MS;
+  //
+  // windowStart is derived per-candidate from `lastSentAt`, matching
+  // the send loop's formula exactly (digestWindowStartMs). Without
+  // this, the canonical brief lead would be synthesized from a fixed
+  // 24h pool while the email/Slack body ships the actual cadence's
+  // window (7d for weekly, 12h for twice_daily) — a different flavor
+  // of the cross-surface divergence the canonical-brain refactor is
+  // designed to eliminate.
   const digestCache = new Map();
-  async function digestFor(candidate) {
-    const key = `${candidate.variant ?? 'full'}:${candidate.lang ?? 'en'}:${candidate.sensitivity ?? 'high'}:${windowStart}`;
+  async function digestFor(cand) {
+    const windowStart = digestWindowStartMs(cand.lastSentAt, nowMs, DIGEST_LOOKBACK_MS);
+    const key = `${cand.rule.variant ?? 'full'}:${cand.rule.lang ?? 'en'}:${cand.rule.sensitivity ?? 'high'}:${windowStart}`;
     if (digestCache.has(key)) return digestCache.get(key);
-    const stories = await buildDigest(candidate, windowStart);
+    const stories = await buildDigest(cand.rule, windowStart);
     digestCache.set(key, stories ?? []);
     return stories ?? [];
   }
@@ -1328,9 +1338,36 @@ async function composeBriefsForRun(rules, nowMs) {
  */
 async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, digestFor, nowMs) {
   // Two-pass walk extracted to a pure helper so it can be unit-tested
-  // (A6.l + A6.m). When no candidate has a non-empty pool, returns
-  // null — same outcome as today's behavior.
-  const winnerResult = await pickWinningCandidateWithPool(annotated, digestFor, (line) => console.log(line), userId);
+  // (A6.l + A6.m). When no candidate has a non-empty pool — OR when
+  // every non-empty candidate has its stories filtered out by the
+  // composer (URL/headline/shape filters) — returns null.
+  //
+  // The `tryCompose` callback is the filter-rejection fall-through:
+  // before the original PR, the legacy loop kept trying lower-priority
+  // candidates whenever compose returned null. Without this hook the
+  // helper would claim the first non-empty pool as winner and the
+  // caller would bail on filter-drop, suppressing briefs that a
+  // lower-priority candidate would have produced.
+  //
+  // We compose WITHOUT synthesis here (cheap — pure JS, no I/O) just
+  // to check filter survival; the real composition with synthesis
+  // splice-in happens once below, after the winner is locked in.
+  const log = (line) => console.log(line);
+  const winnerResult = await pickWinningCandidateWithPool(
+    annotated,
+    digestFor,
+    log,
+    userId,
+    (cand, stories) => {
+      const test = composeBriefFromDigestStories(
+        cand.rule,
+        stories,
+        insightsNumbers,
+        { nowMs },
+      );
+      return test ?? null;
+    },
+  );
   if (!winnerResult) return null;
   const { winner, stories: winnerStories } = winnerResult;
 
@@ -1598,7 +1635,7 @@ async function main() {
       continue;
     }
 
-    const windowStart = lastSentAt ?? (nowMs - DIGEST_LOOKBACK_MS);
+    const windowStart = digestWindowStartMs(lastSentAt, nowMs, DIGEST_LOOKBACK_MS);
     const stories = await buildDigest(rule, windowStart);
     if (!stories) {
       console.log(`[digest] No stories in window for ${rule.userId} (${rule.variant})`);

--- a/tests/digest-cache-key-sensitivity.test.mjs
+++ b/tests/digest-cache-key-sensitivity.test.mjs
@@ -32,13 +32,16 @@ const src = readFileSync(
 );
 
 describe('digestFor cache key includes sensitivity', () => {
-  it('memoization key interpolates candidate.sensitivity', () => {
+  it('memoization key interpolates cand.rule.sensitivity', () => {
     // The key must include sensitivity alongside variant+lang+windowStart
     // so stricter users do not inherit a looser populator's pool.
+    // Post-canonical-window-fix: digestFor receives the annotated candidate
+    // (`cand`) instead of just the rule, and reaches sensitivity via
+    // cand.rule.sensitivity.
     assert.match(
       src,
-      /const\s+key\s*=\s*`\$\{candidate\.variant[^`]*?\$\{candidate\.sensitivity[^`]*?\$\{windowStart\}`/,
-      'digestFor cache key must interpolate candidate.sensitivity',
+      /const\s+key\s*=\s*`\$\{cand\.rule\.variant[^`]*?\$\{cand\.rule\.sensitivity[^`]*?\$\{windowStart\}`/,
+      'digestFor cache key must interpolate cand.rule.sensitivity',
     );
   });
 
@@ -50,11 +53,11 @@ describe('digestFor cache key includes sensitivity', () => {
     // something else).
     //
     // Anchor the match to the cache-key template-literal context so it
-    // cannot be satisfied by an unrelated `chosenCandidate.sensitivity
-    // ?? 'high'` elsewhere in the file (e.g. the new operator log line).
+    // cannot be satisfied by an unrelated `cand.rule.sensitivity ?? 'high'`
+    // elsewhere in the file (e.g. the new operator log line).
     assert.match(
       src,
-      /\$\{candidate\.sensitivity\s*\?\?\s*'high'\}\s*:\s*\$\{windowStart\}/,
+      /\$\{cand\.rule\.sensitivity\s*\?\?\s*'high'\}\s*:\s*\$\{windowStart\}/,
       'cache key default for sensitivity must be "high" to align with buildDigest default, anchored inside the cache-key template literal',
     );
   });
@@ -63,12 +66,12 @@ describe('digestFor cache key includes sensitivity', () => {
     // Sanity: ensure the key construction is not pulled out into a
     // separate helper whose shape this test can no longer see.
     const digestForBlock = src.match(
-      /async\s+function\s+digestFor\s*\(candidate\)\s*\{[\s\S]*?\n\s*\}/,
+      /async\s+function\s+digestFor\s*\(cand\)\s*\{[\s\S]*?\n\s*\}/,
     );
     assert.ok(digestForBlock, 'digestFor function block should exist');
     assert.match(
       digestForBlock[0],
-      /candidate\.sensitivity/,
+      /cand\.rule\.sensitivity/,
       'sensitivity must be referenced inside digestFor',
     );
   });

--- a/tests/digest-orchestration-helpers.test.mjs
+++ b/tests/digest-orchestration-helpers.test.mjs
@@ -16,6 +16,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  digestWindowStartMs,
   pickWinningCandidateWithPool,
   runSynthesisWithFallback,
   subjectForBrief,
@@ -106,9 +107,9 @@ describe('pickWinningCandidateWithPool — winner walk', () => {
     const regionalHigh = rule({ variant: 'regional', sensitivity: 'high', updatedAt: 50 });
     const annotatedList = [annotated(fullCritical, true), annotated(regionalHigh, true)];
 
-    const digestFor = async (r) => {
-      if (r === fullCritical) return [];  // empty pool
-      if (r === regionalHigh) return [{ hash: 'h2', title: 'Story from regional' }];
+    const digestFor = async (c) => {
+      if (c.rule === fullCritical) return [];  // empty pool
+      if (c.rule === regionalHigh) return [{ hash: 'h2', title: 'Story from regional' }];
       return [];
     };
     const lines = [];
@@ -173,6 +174,156 @@ describe('pickWinningCandidateWithPool — winner walk', () => {
     const digestFor = async () => { calls++; return [{ hash: 'h' }]; };
     await pickWinningCandidateWithPool(annotatedList, digestFor, () => {}, 'u1');
     assert.equal(calls, 1, 'same rule must not be tried twice');
+  });
+
+  it('passes the FULL annotated candidate to digestFor (not just the rule) so callers can derive a per-candidate window from cand.lastSentAt', async () => {
+    // Regression guard for the canonical-vs-send window divergence.
+    // digestFor needs lastSentAt to compute its windowStart via
+    // digestWindowStartMs; passing only the rule strips that signal
+    // and forces a fixed-24h fallback that the email/Slack body
+    // doesn't honour.
+    const dueRule = rule({ variant: 'full' });
+    const passedArgs = [];
+    const digestFor = async (cand) => { passedArgs.push(cand); return [{ hash: 'h' }]; };
+    await pickWinningCandidateWithPool(
+      [annotated(dueRule, true, 1_700_000_000_000)],
+      digestFor,
+      () => {},
+      'u1',
+    );
+    assert.equal(passedArgs.length, 1);
+    assert.equal(passedArgs[0].rule, dueRule);
+    assert.equal(passedArgs[0].lastSentAt, 1_700_000_000_000);
+    assert.equal(passedArgs[0].due, true);
+  });
+
+  it('walks past a filter-rejected top-priority candidate to a lower-priority candidate that composes successfully (Risk 2 regression guard)', async () => {
+    // Pre-fix behaviour: helper returned the first NON-EMPTY pool as
+    // winner. If composer then dropped every story (URL/headline/shape
+    // filters), the caller bailed without trying lower-priority rules.
+    // Fix: tryCompose callback lets the helper continue walking when
+    // a candidate's pool survives buildDigest but compose returns null.
+    const fullCritical = rule({ variant: 'full', sensitivity: 'critical', updatedAt: 100 });
+    const regionalHigh = rule({ variant: 'regional', sensitivity: 'high', updatedAt: 50 });
+    const annotatedList = [annotated(fullCritical, true), annotated(regionalHigh, true)];
+    const digestFor = async () => [{ hash: 'h', title: 'pool member' }];
+    // tryCompose: top candidate gets filtered to nothing (returns null);
+    // lower-priority survives.
+    const tryCompose = (cand) => {
+      if (cand.rule === fullCritical) return null;        // simulate URL/headline filter dropping all
+      if (cand.rule === regionalHigh) return { envelope: 'ok' };
+      return null;
+    };
+    const lines = [];
+    const result = await pickWinningCandidateWithPool(
+      annotatedList,
+      digestFor,
+      (l) => lines.push(l),
+      'u1',
+      tryCompose,
+    );
+    assert.ok(result, 'lower-priority candidate must still win after top-priority filter-rejection');
+    assert.equal(result.winner.rule, regionalHigh);
+    assert.deepEqual(result.composeResult, { envelope: 'ok' });
+    assert.ok(
+      lines.some((l) => l.includes('outcome=filter-rejected') && l.includes('variant=full')),
+      'filter-rejected line must be logged for the skipped top candidate',
+    );
+  });
+
+  it('returns null when EVERY candidate is rejected by tryCompose (no fallthrough has a survivor)', async () => {
+    const a = rule({ variant: 'a' });
+    const b = rule({ variant: 'b' });
+    const annotatedList = [annotated(a, true), annotated(b, true)];
+    const digestFor = async () => [{ hash: 'h' }];
+    const tryCompose = () => null;  // nothing ever composes
+    const result = await pickWinningCandidateWithPool(
+      annotatedList,
+      digestFor,
+      () => {},
+      'u1',
+      tryCompose,
+    );
+    assert.equal(result, null);
+  });
+
+  it('forwards tryCompose return value as composeResult on success (lets caller skip a redundant compose call)', async () => {
+    const r = rule({ variant: 'full' });
+    const composedEnvelope = { data: { stories: [{ hash: 'h' }] } };
+    const result = await pickWinningCandidateWithPool(
+      [annotated(r, true)],
+      async () => [{ hash: 'h' }],
+      () => {},
+      'u1',
+      () => composedEnvelope,
+    );
+    assert.ok(result);
+    assert.equal(result.composeResult, composedEnvelope);
+  });
+
+  it('without tryCompose, preserves legacy "first non-empty pool wins" semantics (existing callers/tests unaffected)', async () => {
+    const r = rule({ variant: 'full' });
+    const result = await pickWinningCandidateWithPool(
+      [annotated(r, true)],
+      async () => [{ hash: 'h' }],
+      () => {},
+      'u1',
+      // no tryCompose
+    );
+    assert.ok(result);
+    assert.equal(result.winner.rule, r);
+    assert.equal(result.composeResult, undefined);
+  });
+});
+
+// ── digestWindowStartMs — Risk 1 (canonical vs send window parity) ────────
+
+describe('digestWindowStartMs — single source of truth for compose + send window', () => {
+  it('returns lastSentAt verbatim when present (rule has shipped before)', () => {
+    const lastSentAt = 1_700_000_000_000;
+    assert.equal(digestWindowStartMs(lastSentAt, 1_700_086_400_000, 24 * 60 * 60 * 1000), lastSentAt);
+  });
+
+  it('falls back to nowMs - defaultLookbackMs when lastSentAt is null (first send)', () => {
+    const nowMs = 1_700_086_400_000;
+    const lookback = 24 * 60 * 60 * 1000;
+    assert.equal(digestWindowStartMs(null, nowMs, lookback), nowMs - lookback);
+  });
+
+  it('falls back when lastSentAt is undefined', () => {
+    const nowMs = 1_700_086_400_000;
+    const lookback = 24 * 60 * 60 * 1000;
+    assert.equal(digestWindowStartMs(undefined, nowMs, lookback), nowMs - lookback);
+  });
+
+  it('weekly user (lastSentAt = 7d ago) → window covers exactly the prior 7d', () => {
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+    const nowMs = 2_000_000_000_000;
+    const lastSentAt = nowMs - sevenDaysMs;
+    const windowStart = digestWindowStartMs(lastSentAt, nowMs, 24 * 60 * 60 * 1000);
+    // The compose-path brief lead and the send-loop email body both
+    // call buildDigest(rule, windowStart) with this same value, so a
+    // weekly user's lead now summarizes the same 7-day pool that
+    // ships in the email body. Pre-fix, the lead came from a 24h pool
+    // while the email shipped 7d.
+    assert.equal(windowStart, lastSentAt);
+    assert.equal(nowMs - windowStart, sevenDaysMs);
+  });
+
+  it('twice-daily user (lastSentAt = 12h ago) → 12h window matches what ships', () => {
+    const twelveHoursMs = 12 * 60 * 60 * 1000;
+    const nowMs = 2_000_000_000_000;
+    const lastSentAt = nowMs - twelveHoursMs;
+    const windowStart = digestWindowStartMs(lastSentAt, nowMs, 24 * 60 * 60 * 1000);
+    assert.equal(windowStart, lastSentAt);
+    assert.equal(nowMs - windowStart, twelveHoursMs);
+  });
+
+  it('zero is a valid lastSentAt (epoch — exotic but legal); does not fall through to default', () => {
+    // ?? operator is explicit about this; guards against regressions
+    // toward `||` which would treat 0 as missing.
+    const nowMs = 1_700_000_000_000;
+    assert.equal(digestWindowStartMs(0, nowMs, 24 * 60 * 60 * 1000), 0);
   });
 });
 


### PR DESCRIPTION
Stacked on #3396 — targets `feat/brief-two-brain-divergence`. Addresses two residual risks called out in review.

## Risk 1 — canonical lead vs send-channel window divergence

**Pre-fix:** `scripts/seed-digest-notifications.mjs:1256` built the brief pool from a fixed 24h window (`nowMs - BRIEF_STORY_WINDOW_MS`). The send loop at `:1601` builds the channel body from `lastSentAt ?? (nowMs - DIGEST_LOOKBACK_MS)`. For weekly users that meant a 24h-pool lead bolted onto a 7d email body — the same cross-surface divergence the canonical-brain refactor was designed to eliminate, just in a different shape. Twice-daily users hit a 12h-vs-24h variant.

**Fix:** extracted the window formula to `digestWindowStartMs(lastSentAt, nowMs, defaultLookbackMs)` in `digest-orchestration-helpers.mjs`. Both the compose-path `digestFor` closure AND the send loop call it. Removed the now-unused `BRIEF_STORY_WINDOW_MS` constant.

Side-effect: `digestFor` now receives the full annotated candidate (`cand`) instead of just the rule, so it can reach `cand.lastSentAt`. `pickWinningCandidateWithPool` forwards `cand` instead of `cand.rule`. Existing helper tests updated for the new arg shape; one static-shape test in `digest-cache-key-sensitivity.test.mjs` updated to grep for `cand.rule.sensitivity` (intent unchanged: cache key MUST include sensitivity).

Cache memo hit rate drops since `lastSentAt` varies per-rule, but correctness > a few extra Upstash GETs. The dedup logic inside `pickWinningCandidateWithPool` still prevents per-user duplicate calls.

## Risk 2 — filter-rejected top-priority candidate suppresses brief

**Pre-fix:** `pickWinningCandidateWithPool` returned the first candidate with a non-empty raw pool as winner. If `composeBriefFromDigestStories` then dropped every story (URL/headline/shape filters), the caller bailed without trying lower-priority candidates. Pre-PR-#3396 behaviour was to keep walking.

**Fix:** optional `tryCompose(cand, stories)` callback on `pickWinningCandidateWithPool`. When provided, the helper calls it after the non-empty-pool check; falsy return → log `outcome=filter-rejected` and walk to the next candidate; truthy → returns `{winner, stories, composeResult}`. Without the callback, legacy "first non-empty pool wins" semantics preserved (existing tests + callers unaffected).

`composeAndStoreBriefForUser` passes a no-synthesis compose call as `tryCompose` — cheap pure-JS, no I/O. Synthesis still runs **once** after the winner is locked in, so the perf cost is one extra compose call per filter-rejected candidate (no extra LLM round-trips).

## Tests (+10 new, 31 total in `digest-orchestration-helpers.test.mjs`)

| Suite | Coverage |
|---|---|
| `pickWinningCandidateWithPool` | digestFor receives full candidate; tryCompose fall-through to lower-priority; all-rejected returns null; composeResult forwarded; legacy semantics without tryCompose |
| `digestWindowStartMs` | lastSentAt-vs-default branches; weekly + twice-daily window parity; epoch-zero `??` guard |

`tests/digest-cache-key-sensitivity.test.mjs` regexes updated for the `cand.rule.sensitivity` shape — intent (cache MUST key on sensitivity) preserved.

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] CJS syntax check
- [x] `npm run lint` (no errors)
- [x] `npm run test:data` (6999 pass; was 6944)
- [x] Edge bundle check for `api/*.js`
- [x] `node --test tests/edge-functions.test.mjs` (177 pass)
- [x] `npm run lint:md`
- [x] `npm run version:check`
- [ ] After merge into PR #3396 + production rollout, monitor `[digest] brief filter drops ... outcome=filter-rejected` log line — non-zero counts confirm the fall-through is engaging for real multi-rule users.
- [ ] Spot-check a weekly user's brief lead in production to confirm it cites events from the full prior 7d (not just the last 24h).