### PR TITLE
fix(vercel): drop fragile VERCEL_GIT_PULL_REQUEST_ID guard in ignore step

### DIFF
--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -14,25 +14,36 @@ if [ "$VERCEL_GIT_COMMIT_REF" = "main" ] && [ -n "$VERCEL_GIT_PREVIOUS_SHA" ]; t
   exit 1
 fi
 
-# Skip preview deploys that aren't tied to a pull request
-[ -z "$VERCEL_GIT_PULL_REQUEST_ID" ] && exit 0
-
 # Resolve comparison base: prefer `merge-base HEAD origin/main` (the SHA
-# where this PR branched off main), fall back to VERCEL_GIT_PREVIOUS_SHA.
+# where this branch left main), fall back to VERCEL_GIT_PREVIOUS_SHA.
 #
-# Why this ordering: on a PR branch's FIRST push, Vercel has historically
-# set VERCEL_GIT_PREVIOUS_SHA to values that make the path-diff come back
-# empty (the same SHA as HEAD, or a parent that sees no net change),
-# causing "Canceled by Ignored Build Step" on PRs that genuinely touch
-# web paths (PR #3346 incident: four web-relevant files changed, skipped
-# anyway). merge-base is the stable truth: "everything on this PR since
-# it left main", which is always a superset of any single push and is
-# what the reviewer actually needs a preview for.
+# We deliberately do NOT gate on VERCEL_GIT_PULL_REQUEST_ID. Vercel only
+# populates that var when the deploy is triggered by a fresh PR-aware
+# webhook event; manual "Redeploy" / "Redeploy without cache" actions
+# from the dashboard, and some integration edge cases, leave it empty
+# even on commits that are clearly attached to an open PR. Gating on it
+# silently cancels legitimate previews (PR #3403 incident: 24d511e on
+# feat/usage-telemetry, all 5 api/ + server/ files skipped).
 #
-# PREVIOUS_SHA stays as the fallback for the rare shallow-clone edge case
-# where `origin/main` isn't in Vercel's clone and merge-base returns
-# empty. This is the opposite priority from the main-branch branch above
-# (line 6), which correctly wants PREVIOUS_SHA = the last deployed commit.
+# The merge-base diff below is the authoritative "did this branch touch
+# anything web-relevant" check, and it's strictly stronger than the
+# PR-ID guard: branches with no web changes still skip via that diff,
+# branches with web changes build whether or not Vercel happens to know
+# about a PR association at deploy time.
+#
+# Why merge-base is preferred over PREVIOUS_SHA: on a branch's FIRST
+# push, Vercel has historically set VERCEL_GIT_PREVIOUS_SHA to values
+# that make the path-diff come back empty (the same SHA as HEAD, or a
+# parent that sees no net change), causing "Canceled by Ignored Build
+# Step" on commits that genuinely touch web paths (PR #3346 incident).
+# merge-base is the stable truth: "everything on this branch since it
+# left main", which is always a superset of any single push.
+#
+# PREVIOUS_SHA stays as the fallback for the rare shallow-clone edge
+# case where `origin/main` isn't in Vercel's clone and merge-base
+# returns empty. This is the opposite priority from the main-branch
+# block above (line 6), which correctly wants PREVIOUS_SHA = the last
+# deployed commit.
 COMPARE_SHA=$(git merge-base HEAD origin/main 2>/dev/null)
 if [ -z "$COMPARE_SHA" ] && [ -n "$VERCEL_GIT_PREVIOUS_SHA" ]; then
   git cat-file -e "$VERCEL_GIT_PREVIOUS_SHA" 2>/dev/null && COMPARE_SHA="$VERCEL_GIT_PREVIOUS_SHA"


### PR DESCRIPTION
## Summary
- `scripts/vercel-ignore.sh` skipped any preview where `VERCEL_GIT_PULL_REQUEST_ID` was empty. Vercel leaves that var unset on manual "Redeploy" / "Redeploy without cache" actions and some integration edge cases — even when the commit is clearly attached to an open PR — so legitimate previews silently canceled.
- The merge-base diff against `origin/main` immediately below the deleted guard is already the authoritative "did this branch touch anything web-relevant" check and is strictly stronger: branches with no web changes still skip via that diff; branches with web changes build whether or not Vercel happens to know about a PR association at deploy time.
- Comment block expanded to record the failure mode so the guard isn't reintroduced.

## Repro
PR #3403 (`feat/usage-telemetry`) commit `24d511e29` modified five `api/` + `server/` files. Vercel canceled at the ignore step:

```
Running "bash scripts/vercel-ignore.sh"
The Deployment has been canceled as a result of running the command defined in the "Ignored Build Step" setting.
```

Local replay with `VERCEL_GIT_PULL_REQUEST_ID` and `VERCEL_GIT_PREVIOUS_SHA` unset and `VERCEL_GIT_COMMIT_REF=feat/usage-telemetry`:

- Before this PR: `exit 0` (skip — wrong)
- After this PR: `exit 1` (build — correct)

## Test plan
- [x] `bash -n scripts/vercel-ignore.sh` (syntax)
- [x] Local replay against `24d511e29` with PR_ID unset → exits 1
- [ ] After merge: `feat/usage-telemetry` next push (or rebase) deploys preview
- [ ] Negative: a docs-only branch with no `api/`/`server/`/`src/` changes still gets skipped