### PR TITLE
feat(energy-atlas): GEM pipeline data import — gas 297, oil 334

### DIFF
--- a/docs/methodology/pipelines.mdx
+++ b/docs/methodology/pipelines.mdx
@@ -69,20 +69,97 @@ The hand-curated subset (operator/regulator/sanctions-bearing rows with classifi
 
 ## Operator runbook — GEM import refresh
 
-GEM publishes new releases of the Oil & Gas Infrastructure Trackers roughly quarterly. The refresh is operator-mediated rather than cron-driven because the GEM download URL changes per release; a hardcoded URL would silently fetch a different version than the one we attribute. Steps:
+### Cadence
 
-1. Visit the [GEM Oil & Gas Infrastructure Trackers](https://globalenergymonitor.org/projects/global-oil-gas-infrastructure-tracker/) page. Registration is required for direct download even though the data itself is CC-BY 4.0.
-2. Download the latest gas + oil tracker Excel workbooks. Record the release date and download URL.
-3. Pre-convert each workbook to JSON externally (Numbers / pandas / csvkit), normalizing column names to the canonical set documented in `scripts/import-gem-pipelines.mjs::REQUIRED_COLUMNS` and country names to ISO 3166-1 alpha-2 codes.
-4. Run a dry pass to inspect the candidate diff:
+**Refresh quarterly** (or whenever a new GEM release lands — check the GGIT/GOIT landing pages below). The refresh is operator-mediated rather than cron-driven because:
+
+- GEM downloads are gated behind a per-request form; the resulting URL is release-specific and rotates each quarter, so a hardcoded URL would silently fetch a different version than the one we attribute.
+- Each release adjusts column names occasionally; the schema-drift sentinel in `scripts/import-gem-pipelines.mjs` catches this loudly, but it requires a human review of the diff before committing.
+
+If a quarter passes without a refresh, set a calendar reminder. Suggested cadence: review every 90 days; refresh whenever a peer reference site (e.g. global-energy-flow.com) advertises a newer release than ours.
+
+### Source datasets
+
+The two files we use are GEM's pipeline-only trackers (NOT the combined "Oil & Gas Extraction Tracker" — that's upstream wells/fields and has a different schema):
+
+| Tracker | Acronym | What it contains | Landing page |
+|---|---|---|---|
+| Global Gas Infrastructure Tracker | **GGIT** | Gas pipelines + LNG terminals | [globalenergymonitor.org/projects/global-gas-infrastructure-tracker](https://globalenergymonitor.org/projects/global-gas-infrastructure-tracker/) |
+| Global Oil Infrastructure Tracker | **GOIT** | Oil + NGL pipelines | [globalenergymonitor.org/projects/global-oil-infrastructure-tracker](https://globalenergymonitor.org/projects/global-oil-infrastructure-tracker/) |
+
+The **GIS .zip download** (containing GeoJSON, GeoPackage, and shapefile) is what we want — NOT the .xlsx. The XLSX has properties but no lat/lon columns; only the GeoJSON has both column properties AND `LineString.coordinates` for endpoint extraction.
+
+#### Last-known-good URLs (rotate per release)
+
+These are the URLs we used for the 2026-04-25 import. GEM rotates them per release, so always re-request via the landing page above for the current release before re-running:
+
+```
+GGIT Gas (2025-11):  https://globalenergymonitor.org/wp-content/uploads/2025/11/GEM-GGIT-Gas-Pipelines-2025-11.zip
+GOIT Oil (2025-03):  https://globalenergymonitor.org/wp-content/uploads/2025/03/GEM-GOIT-Oil-NGL-Pipelines-2025-03.zip
+```
+
+URL pattern is stable: `globalenergymonitor.org/wp-content/uploads/YYYY/MM/GEM-{GGIT,GOIT}-{tracker-name}-YYYY-MM.zip`. If the landing-page download flow changes, this pattern is the fallback for figuring out the new URL given the release date GEM publishes.
+
+### Refresh steps
+
+1. **Request the data** via either landing page above. GEM emails you per-release URLs (one for the .xlsx, one for the GIS .zip). Registration is required even though the data itself is CC-BY 4.0.
+
+2. **Download both GIS .zips** and unzip:
    ```bash
-   GEM_PIPELINES_FILE=/tmp/gem.json node scripts/import-gem-pipelines.mjs --print-candidates | jq '.gas | length, .oil | length'
+   unzip -o ~/Downloads/GEM-GGIT-Gas-Pipelines-YYYY-MM.zip -d /tmp/gem-gis/gas/
+   unzip -o ~/Downloads/GEM-GOIT-Oil-NGL-Pipelines-YYYY-MM.zip -d /tmp/gem-gis/oil/
    ```
-5. Run the merge to write the deduplicated rows into `scripts/data/pipelines-{gas,oil}.json`. Spot-check 5-10 random GEM-sourced rows manually before committing.
-6. Commit the data + bump `MIN_PIPELINES_PER_REGISTRY` in `scripts/_pipeline-registry.mjs` to a sensible new floor (e.g. 200) so future partial imports fail loud. Record the GEM release date, download URL, and SHA256 of the source workbook in the commit message.
-7. Verify `npm run test:data` is green before pushing.
 
-Schema-drift sentinel guards against silent failures when GEM renames columns between releases — the parser throws with a clear message naming the missing column rather than producing zero-data rows.
+3. **Convert GeoJSON → canonical JSON** via the in-repo converter. It reads both GeoJSON files, applies the filter knobs documented in the script header, normalizes country names to ISO 3166-1 alpha-2 via `pycountry`, and emits the operator-shape envelope:
+   ```bash
+   pip3 install pycountry  # one-time
+   GEM_GAS_GEOJSON=/tmp/gem-gis/gas/GEM-GGIT-Gas-Pipelines-YYYY-MM.geojson \
+   GEM_OIL_GEOJSON=/tmp/gem-gis/oil/GEM-GOIT-Oil-NGL-Pipelines-YYYY-MM.geojson \
+   GEM_DOWNLOADED_AT=YYYY-MM-DD \
+   GEM_SOURCE_VERSION="GEM-GGIT-YYYY-MM+GOIT-YYYY-MM" \
+   python3 scripts/_gem-geojson-to-canonical.py > /tmp/gem-pipelines.json 2> /tmp/gem-drops.log
+   cat /tmp/gem-drops.log  # inspect drop counts before merging
+   ```
+
+   Filter knob defaults (in `scripts/_gem-geojson-to-canonical.py`):
+   - `MIN_LENGTH_KM_GAS = 750` (trunk-class only)
+   - `MIN_LENGTH_KM_OIL = 400` (trunk-class only)
+   - `ACCEPTED_STATUS = {operating, construction}`
+   - Capacity unit conversions: bcm/y native; MMcf/d, MMSCMD, mtpa, m3/day, bpd, Mb/d, kbd → bcm/y (gas) or bbl/d (oil)
+
+   These thresholds were tuned empirically against the 2025-11/2025-03 release to land at ~250-300 entries per registry. Adjust if a future release shifts the volume distribution.
+
+4. **Dry-run** to inspect candidate counts before touching the registry:
+   ```bash
+   GEM_PIPELINES_FILE=/tmp/gem-pipelines.json node scripts/import-gem-pipelines.mjs --print-candidates \
+     | jq '{ gas: (.gas | length), oil: (.oil | length) }'
+   ```
+
+5. **Merge** into `scripts/data/pipelines-{gas,oil}.json` (writes both atomically — validates both before either is touched on disk):
+   ```bash
+   GEM_PIPELINES_FILE=/tmp/gem-pipelines.json node scripts/import-gem-pipelines.mjs --merge
+   ```
+   Spot-check 5-10 random GEM-sourced rows in the diff before committing — known major trunks (Druzhba, Nord Stream, Keystone, TAPI, Centro Oeste) are good sanity-check anchors.
+
+6. **Commit** the data + record provenance. Per-release SHA256s go in the commit message so future audits can verify reproducibility:
+   ```bash
+   shasum -a 256 ~/Downloads/GEM-GGIT-Gas-Pipelines-YYYY-MM.xlsx \
+                  ~/Downloads/GEM-GOIT-Oil-NGL-Pipelines-YYYY-MM.xlsx
+   ```
+   If the row count crosses a threshold, also bump `MIN_PIPELINES_PER_REGISTRY` in `scripts/_pipeline-registry.mjs` so future partial re-imports fail loud rather than silently halving the registry.
+
+7. **Verify** `npm run test:data` is green before pushing.
+
+### Failure modes and what to do
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Converter exits with `GEM_GAS_GEOJSON env vars are required` | Env vars not set | Re-run with both `GEM_GAS_GEOJSON` and `GEM_OIL_GEOJSON` pointed at the unzipped `.geojson` files |
+| Many rows dropped on `country:Foo|Bar` | New country name GEM uses isn't in `pycountry` or the alias table | Add the alias to `COUNTRY_ALIASES` in `scripts/_gem-geojson-to-canonical.py` |
+| Many rows dropped on `no_capacity` with a unit we haven't seen | GEM added a capacity unit | Add the conversion factor to `gas_capacity()` or `oil_capacity()` in the converter |
+| Parser throws `schema drift — pipelines[i] missing column "X"` | GEM renamed a column between releases | The parser will name the missing column; map it back in the converter and re-run |
+| `validateRegistry` rejects the merged registry | Almost always: count below `MIN_PIPELINES_PER_REGISTRY`, or an evidence-source not in the whitelist | Inspect the merged JSON; if the row drop is real, lower the floor; if a row's evidence is malformed, fix the converter |
+| Net adds drop precipitously between releases | GEM removed a tracker subset, OR the dedup is over-matching | Run `--print-candidates` and diff against the prior quarter's output; adjust the haversine/Jaccard knobs in `scripts/_pipeline-dedup.mjs` if needed |
 
 ## Corrections
 

--- a/scripts/_gem-geojson-to-canonical.py
+++ b/scripts/_gem-geojson-to-canonical.py
@@ -274,6 +274,12 @@ def convert_one(props, geom, fuel_token):
         return None, "no_geom"
     s_lon, s_lat = pts[0][0], pts[0][1]
     e_lon, e_lat = pts[1][0], pts[1][1]
+    # Drop degenerate geometry (start == end). GEM occasionally publishes
+    # rows with a Point geometry or a single-coord LineString, which we'd
+    # otherwise emit as zero-length routes. PR #3406 review found 9 such
+    # rows (Trans-Alaska, Enbridge Line 3 Replacement, Ichthys, etc.).
+    if s_lat == e_lat and s_lon == e_lon:
+        return None, "zero_length"
 
     length = best_length_km(props)
     threshold = MIN_LENGTH_KM_GAS if fuel_token == "Gas" else MIN_LENGTH_KM_OIL

--- a/scripts/_gem-geojson-to-canonical.py
+++ b/scripts/_gem-geojson-to-canonical.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""
+Pre-convert GEM GeoJSON (GGIT gas + GOIT oil pipelines) → canonical JSON shape
+that scripts/import-gem-pipelines.mjs::REQUIRED_COLUMNS expects.
+
+Why GeoJSON, not XLSX:
+    GEM publishes both XLSX and GIS .zip downloads (with GeoJSON, GeoPackage,
+    shapefile inside). The XLSX has properties but NO lat/lon columns — endpoint
+    geometry only lives in the GIS feed. The GeoJSON `properties` block carries
+    the same column set as the XLSX, AND `geometry.coordinates` gives us the
+    LineString endpoints we need for haversine dedup. So we use GeoJSON only.
+
+Usage:
+    GEM_GAS_GEOJSON=/path/to/GEM-GGIT-Gas-Pipelines-YYYY-MM.geojson \\
+    GEM_OIL_GEOJSON=/path/to/GEM-GOIT-Oil-NGL-Pipelines-YYYY-MM.geojson \\
+    python3 scripts/_gem-geojson-to-canonical.py \\
+        > /tmp/gem-pipelines.json
+
+    # Then feed to the merge step:
+    GEM_PIPELINES_FILE=/tmp/gem-pipelines.json node \\
+        scripts/import-gem-pipelines.mjs --print-candidates  # dry run
+    GEM_PIPELINES_FILE=/tmp/gem-pipelines.json node \\
+        scripts/import-gem-pipelines.mjs --merge
+
+Dependencies:
+    pip3 install pycountry  # ISO 3166-1 alpha-2 mapping for country names
+
+Drop-summary log goes to stderr; canonical JSON goes to stdout.
+"""
+
+import json
+import os
+import sys
+import pycountry
+
+GAS_PATH = os.environ.get("GEM_GAS_GEOJSON")
+OIL_PATH = os.environ.get("GEM_OIL_GEOJSON")
+if not GAS_PATH or not OIL_PATH:
+    sys.exit(
+        "GEM_GAS_GEOJSON and GEM_OIL_GEOJSON env vars are required. "
+        "Point each at the GEM-{GGIT,GOIT}-{Gas,Oil-NGL}-Pipelines-YYYY-MM.geojson "
+        "file unzipped from the GIS download. See script header for details."
+    )
+
+# Filter knobs (per plan: trunk-class only, target 250-300 entries per registry).
+# Asymmetric thresholds: gas has more long-distance trunks worldwide (LNG-feeder
+# corridors, Russia→Europe, Russia→China), oil pipelines tend to be shorter
+# regional collectors. Tuned empirically against the 2025-11 GEM release to
+# yield ~265 gas + ~300 oil after dedup against the 75 hand-curated rows.
+MIN_LENGTH_KM_GAS = 750.0
+MIN_LENGTH_KM_OIL = 400.0
+ACCEPTED_STATUS = {"operating", "construction"}
+
+# GEM (lowercase) → parser STATUS_MAP key (PascalCase)
+STATUS_PASCAL = {
+    "operating": "Operating",
+    "construction": "Construction",
+    "proposed": "Proposed",
+    "cancelled": "Cancelled",
+    "shelved": "Cancelled",  # treat shelved as cancelled per plan U2
+    "mothballed": "Mothballed",
+    "idle": "Idle",
+    "shut-in": "Shut-in",
+    "retired": "Mothballed",
+    "mixed status": "Operating",  # rare; treat as operating
+}
+
+# Country aliases for cases pycountry's fuzzy match fails on
+COUNTRY_ALIASES = {
+    "United States": "US",
+    "United Kingdom": "GB",
+    "Russia": "RU",
+    "South Korea": "KR",
+    "North Korea": "KP",
+    "Iran": "IR",
+    "Syria": "SY",
+    "Venezuela": "VE",
+    "Bolivia": "BO",
+    "Tanzania": "TZ",
+    "Vietnam": "VN",
+    "Laos": "LA",
+    "Czech Republic": "CZ",
+    "Czechia": "CZ",
+    "Slovakia": "SK",
+    "Macedonia": "MK",
+    "North Macedonia": "MK",
+    "Moldova": "MD",
+    "Brunei": "BN",
+    "Cape Verde": "CV",
+    "Ivory Coast": "CI",
+    "Cote d'Ivoire": "CI",
+    "Republic of the Congo": "CG",
+    "Democratic Republic of the Congo": "CD",
+    "DR Congo": "CD",
+    "DRC": "CD",
+    "Congo": "CG",
+    "Burma": "MM",
+    "Myanmar": "MM",
+    "Taiwan": "TW",
+    "Palestine": "PS",
+    "Kosovo": "XK",  # not ISO-2 official; use XK (commonly accepted)
+}
+
+
+def country_to_iso2(name):
+    if not name:
+        return None
+    name = name.strip()
+    if name in COUNTRY_ALIASES:
+        return COUNTRY_ALIASES[name]
+    try:
+        c = pycountry.countries.get(name=name)
+        if c:
+            return c.alpha_2
+        # Try common_name (e.g. "Russia" → "Russian Federation")
+        c = pycountry.countries.get(common_name=name)
+        if c:
+            return c.alpha_2
+        # Fuzzy
+        results = pycountry.countries.search_fuzzy(name)
+        if results:
+            return results[0].alpha_2
+    except (LookupError, KeyError):
+        pass
+    return None
+
+
+def split_countries(s):
+    """Parse 'Russia, Belarus, Ukraine' → ['Russia','Belarus','Ukraine']"""
+    if not s:
+        return []
+    return [x.strip() for x in s.split(",") if x.strip()]
+
+
+def get_endpoints(geom):
+    """Return ((startLon, startLat), (endLon, endLat)) or None."""
+    if not geom:
+        return None
+    t = geom.get("type")
+    coords = geom.get("coordinates")
+    if t == "LineString" and coords and len(coords) >= 2:
+        return coords[0], coords[-1]
+    if t == "MultiLineString" and coords:
+        flat = [pt for line in coords if line for pt in line]
+        if len(flat) >= 2:
+            return flat[0], flat[-1]
+    if t == "GeometryCollection":
+        geoms = geom.get("geometries") or []
+        all_coords = []
+        for g in geoms:
+            if g and g.get("type") == "LineString" and g.get("coordinates"):
+                all_coords.extend(g["coordinates"])
+            elif g and g.get("type") == "MultiLineString" and g.get("coordinates"):
+                for line in g["coordinates"]:
+                    all_coords.extend(line)
+        if len(all_coords) >= 2:
+            return all_coords[0], all_coords[-1]
+    return None
+
+
+def first_year(props):
+    for k in ("StartYear1", "StartYear2", "StartYear3"):
+        v = props.get(k)
+        if v:
+            try:
+                return int(float(v))
+            except (TypeError, ValueError):
+                pass
+    return 0
+
+
+def best_length_km(props):
+    for k in ("LengthMergedKm", "LengthKnownKm", "LengthEstimateKm"):
+        v = props.get(k)
+        if v in (None, "", "NA"):
+            continue
+        try:
+            f = float(v)
+            if f > 0:
+                return f
+        except (TypeError, ValueError):
+            pass
+    return 0.0
+
+
+def _f(v):
+    if v in (None, "", "NA"):
+        return None
+    try:
+        f = float(v)
+        return f if f > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def gas_capacity(props):
+    """Return (capacity, 'bcm/y'). GGIT has CapacityBcm/y derived for many rows."""
+    f = _f(props.get("CapacityBcm/y"))
+    if f is not None:
+        return f, "bcm/y"
+    # Fall back to raw Capacity + CapacityUnits with conversions to bcm/y.
+    cap = _f(props.get("Capacity"))
+    if cap is None:
+        return None, None
+    u = (props.get("CapacityUnits") or "").strip().lower()
+    if u == "bcm/y":
+        return cap, "bcm/y"
+    if u == "mmcf/d":  # million standard cubic feet/day → bcm/y
+        return cap * 0.01034, "bcm/y"
+    if u == "mmscmd":  # million standard cubic metres/day
+        return cap * 365.25 / 1000.0, "bcm/y"
+    if u == "mill.sm3/day":  # million Sm3/day = MMSCMD
+        return cap * 365.25 / 1000.0, "bcm/y"
+    if u == "scm/y":  # standard cubic metres/year
+        return cap / 1e9, "bcm/y"
+    if u == "mtpa":  # million tonnes/annum LNG → bcm/y (1 mtpa ≈ 1.36 bcm/y)
+        return cap * 1.36, "bcm/y"
+    return None, None
+
+
+def oil_capacity(props):
+    """Return (capacity, capacityUnit) for oil. Convert to bbl/d for parser
+    consumption (parser then converts bbl/d / 1e6 → Mbd internally)."""
+    cap = _f(props.get("Capacity"))
+    unit_raw = (props.get("CapacityUnits") or "").strip().lower()
+    if cap is None or not unit_raw:
+        # Fallback: derive from CapacityBOEd if present (already bpd-equivalent).
+        boed = _f(props.get("CapacityBOEd"))
+        if boed is not None:
+            return boed, "bbl/d"
+        return None, None
+    if unit_raw == "bpd":
+        return cap, "bbl/d"
+    if unit_raw in ("mb/d", "mbd"):
+        # GEM "Mb/d" = thousand bbl/day (industry shorthand). Convert to bbl/d.
+        return cap * 1000.0, "bbl/d"
+    if unit_raw in ("kbd", "kb/d"):
+        return cap * 1000.0, "bbl/d"
+    if unit_raw == "mtpa":
+        # Million tonnes/annum crude → bbl/d (avg crude: 7.33 bbl/tonne).
+        return cap * 1e6 * 7.33 / 365.25, "bbl/d"
+    if unit_raw == "m3/day":
+        # 1 m3 = 6.2898 bbl
+        return cap * 6.2898, "bbl/d"
+    if unit_raw == "m3/month":
+        return cap * 6.2898 / 30.4, "bbl/d"
+    if unit_raw == "m3/year":
+        return cap * 6.2898 / 365.25, "bbl/d"
+    if unit_raw == "thousand m3/year":
+        return cap * 1000 * 6.2898 / 365.25, "bbl/d"
+    if unit_raw == "tn/d":  # tonnes/day
+        return cap * 7.33, "bbl/d"
+    # Unknown unit → fall back to BOEd if available.
+    boed = _f(props.get("CapacityBOEd"))
+    if boed is not None:
+        return boed, "bbl/d"
+    return None, None
+
+
+def convert_one(props, geom, fuel_token):
+    name = (props.get("PipelineName") or "").strip()
+    seg = (props.get("SegmentName") or "").strip()
+    if seg and seg.lower() not in ("main line", "mainline", "main"):
+        name = f"{name} - {seg}" if name else seg
+    if not name:
+        return None, "no_name"
+
+    status = (props.get("Status") or "").strip().lower()
+    if status not in ACCEPTED_STATUS:
+        return None, f"status:{status or 'empty'}"
+
+    pts = get_endpoints(geom)
+    if not pts:
+        return None, "no_geom"
+    s_lon, s_lat = pts[0][0], pts[0][1]
+    e_lon, e_lat = pts[1][0], pts[1][1]
+
+    length = best_length_km(props)
+    threshold = MIN_LENGTH_KM_GAS if fuel_token == "Gas" else MIN_LENGTH_KM_OIL
+    if length < threshold:
+        return None, "too_short"
+
+    if fuel_token == "Gas":
+        cap, unit = gas_capacity(props)
+        from_country_name = props.get("StartCountryOrArea")
+        to_country_name = props.get("EndCountryOrArea")
+        all_countries = split_countries(props.get("CountriesOrAreas"))
+    else:
+        cap, unit = oil_capacity(props)
+        from_country_name = props.get("StartCountry")
+        to_country_name = props.get("EndCountry")
+        all_countries = split_countries(props.get("Countries"))
+    if cap is None or unit is None:
+        return None, "no_capacity"
+
+    from_iso = country_to_iso2(from_country_name)
+    to_iso = country_to_iso2(to_country_name)
+    if not from_iso or not to_iso:
+        return None, f"country:{from_country_name}|{to_country_name}"
+
+    transit = []
+    for c in all_countries:
+        iso = country_to_iso2(c)
+        if iso and iso != from_iso and iso != to_iso:
+            transit.append(iso)
+
+    operator = (props.get("Owner") or props.get("Parent") or "").strip()
+    if not operator:
+        operator = "Unknown"
+
+    row = {
+        "name": name,
+        "operator": operator,
+        "fuel": fuel_token,
+        "fromCountry": from_iso,
+        "toCountry": to_iso,
+        "transitCountries": transit,
+        "capacity": cap,
+        "capacityUnit": unit,
+        "lengthKm": length,
+        "status": STATUS_PASCAL.get(status, "Operating"),
+        "startLat": s_lat,
+        "startLon": s_lon,
+        "endLat": e_lat,
+        "endLon": e_lon,
+        "startYear": first_year(props),
+    }
+    return row, None
+
+
+def process(path, fuel_token, drops):
+    with open(path) as f:
+        gj = json.load(f)
+    out = []
+    for ft in gj["features"]:
+        props = ft.get("properties") or {}
+        geom = ft.get("geometry")
+        row, reason = convert_one(props, geom, fuel_token)
+        if row:
+            out.append(row)
+        else:
+            drops[reason] = drops.get(reason, 0) + 1
+    return out
+
+
+def main():
+    drops_gas, drops_oil = {}, {}
+    gas_rows = process(GAS_PATH, "Gas", drops_gas)
+    oil_rows = process(OIL_PATH, "Oil", drops_oil)
+
+    # The operator stamps `downloadedAt` and `sourceVersion` per release so
+    # the parser's deterministic-timestamp logic (resolveEvidenceTimestamp in
+    # scripts/import-gem-pipelines.mjs) produces a stable lastEvidenceUpdate
+    # tied to the actual download date — not "now". Override via env so the
+    # script doesn't drift across re-runs.
+    downloaded_at = os.environ.get("GEM_DOWNLOADED_AT", "1970-01-01")
+    source_version = os.environ.get("GEM_SOURCE_VERSION", "GEM-unspecified-release")
+    envelope = {
+        "downloadedAt": downloaded_at,
+        "sourceVersion": source_version,
+        "pipelines": gas_rows + oil_rows,
+    }
+    json.dump(envelope, sys.stdout, indent=2, ensure_ascii=False)
+
+    print("\n--- DROP SUMMARY (gas) ---", file=sys.stderr)
+    for k, v in sorted(drops_gas.items(), key=lambda x: -x[1]):
+        print(f"  {k}: {v}", file=sys.stderr)
+    print(f"  KEPT: {len(gas_rows)}", file=sys.stderr)
+    print("--- DROP SUMMARY (oil) ---", file=sys.stderr)
+    for k, v in sorted(drops_oil.items(), key=lambda x: -x[1]):
+        print(f"  {k}: {v}", file=sys.stderr)
+    print(f"  KEPT: {len(oil_rows)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/_pipeline-dedup.mjs
+++ b/scripts/_pipeline-dedup.mjs
@@ -24,6 +24,16 @@ const STOPWORDS = new Set([
 
 const MATCH_DISTANCE_KM = 5;
 const MATCH_JACCARD_MIN = 0.6;
+// When the candidate's tokenized name equals the existing row's tokenized
+// name (Jaccard == 1.0 after stopword removal), accept the match if ANY
+// endpoint pairing is within MATCH_NAME_IDENTICAL_DISTANCE_KM. Catches PR
+// #3406 review's Dampier-Bunbury case: GEM digitized only the southern
+// 60% of the line, so the average-endpoint distance was 287km but the
+// shared Bunbury terminus matched within 13.7km. A pure name-only rule
+// would false-positive on coincidental collisions in different oceans
+// (e.g. unrelated "Nord Stream 1" in the Pacific), so we still require
+// SOME geographic anchor.
+const MATCH_NAME_IDENTICAL_DISTANCE_KM = 25;
 const EARTH_RADIUS_KM = 6371;
 
 /**
@@ -56,6 +66,24 @@ function averageEndpointDistanceKm(a, b) {
 }
 
 /**
+ * Minimum of all four cross-pairings between candidate and existing endpoints.
+ * Used by the name-identical short-circuit: if the candidate digitizes a
+ * different segment of the same physical pipeline, only ONE endpoint pair
+ * may match closely (e.g. Dampier-Bunbury: shared Bunbury terminus 13.7 km,
+ * other end 560 km away because GEM stopped at Onslow vs the full Dampier
+ * route). A tight average would miss this; the min of the four pairings
+ * doesn't.
+ */
+function minPairwiseEndpointDistanceKm(a, b) {
+  return Math.min(
+    haversineKm(a.startPoint, b.startPoint),
+    haversineKm(a.startPoint, b.endPoint),
+    haversineKm(a.endPoint, b.startPoint),
+    haversineKm(a.endPoint, b.endPoint),
+  );
+}
+
+/**
  * Tokenize a name: lowercased word tokens, ASCII-only word boundaries,
  * stopwords removed. Stable across invocations.
  */
@@ -85,12 +113,35 @@ function jaccard(a, b) {
 }
 
 /**
- * Decide if a candidate matches an existing row. Both criteria required.
+ * Decide if a candidate matches an existing row.
+ *
+ * Two acceptance paths:
+ *   (a) Token sets are IDENTICAL (Jaccard == 1.0 after stopword removal) —
+ *       the same pipeline regardless of how either source digitized its
+ *       endpoints. Catches the Dampier-Bunbury case (PR #3406 review):
+ *       GEM's GeoJSON terminus was 13.7 km from the curated terminus
+ *       (just over the 5 km distance gate) but both names tokenize to
+ *       {dampier, to, bunbury, natural, gas}, so they are clearly the
+ *       same physical pipeline.
+ *   (b) Distance ≤ 5 km AND Jaccard ≥ 0.6 — the original conjunctive rule
+ *       for slight name-variation cases (e.g. "Druzhba Pipeline" vs
+ *       "Druzhba Oil Pipeline").
  */
 function isDuplicate(candidate, existing) {
+  const sim = jaccard(candidate.name, existing.name);
+  // Path (a): identical token-set + at least one endpoint pair within 25 km.
+  // The geographic anchor distinguishes the Dampier-Bunbury case from a
+  // theoretical name-collision in a different ocean.
+  if (sim >= 1.0) {
+    const minDist = minPairwiseEndpointDistanceKm(candidate, existing);
+    if (minDist <= MATCH_NAME_IDENTICAL_DISTANCE_KM) return true;
+    // Identical names but no endpoint near each other → distinct pipelines
+    // sharing a name (rare but real). Fall through to the conjunctive rule
+    // below, which will return false because Jaccard 1.0 with > 25km min
+    // pair always exceeds 5 km average.
+  }
   const dist = averageEndpointDistanceKm(candidate, existing);
   if (dist > MATCH_DISTANCE_KM) return false;
-  const sim = jaccard(candidate.name, existing.name);
   return sim >= MATCH_JACCARD_MIN;
 }
 
@@ -160,6 +211,7 @@ export function dedupePipelines(existing, candidates) {
 export const _internal = {
   haversineKm,
   averageEndpointDistanceKm,
+  minPairwiseEndpointDistanceKm,
   tokenize,
   jaccard,
   isDuplicate,
@@ -167,4 +219,5 @@ export const _internal = {
   STOPWORDS,
   MATCH_DISTANCE_KM,
   MATCH_JACCARD_MIN,
+  MATCH_NAME_IDENTICAL_DISTANCE_KM,
 };

--- a/scripts/_pipeline-registry.mjs
+++ b/scripts/_pipeline-registry.mjs
@@ -44,9 +44,11 @@ export const VALID_SOURCES = new Set(['operator', 'regulator', 'press', 'satelli
 // inline copy in tests could silently drift when the enum is extended.
 export const VALID_OIL_PRODUCT_CLASSES = new Set(['crude', 'products', 'mixed']);
 
-// Minimum viable registry size. Expansion to ~75 each happens in the follow-up
-// GEM import PR; this seeder doesn't care about exact counts beyond the floor.
-const MIN_PIPELINES_PER_REGISTRY = 8;
+// Minimum viable registry size. Post-GEM-import floor: 200. Live counts after
+// the 2025-11 GGIT + 2025-03 GOIT merge are 297 gas / 334 oil; 200 leaves ~100
+// rows of jitter headroom so a partial GEM re-import or a coverage-narrowing
+// release fails loud rather than silently halving the registry.
+const MIN_PIPELINES_PER_REGISTRY = 200;
 
 function loadRegistry(filename) {
   const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/scripts/_pipeline-registry.mjs
+++ b/scripts/_pipeline-registry.mjs
@@ -98,6 +98,13 @@ export function validateRegistry(data) {
     if (!p.endPoint || typeof p.endPoint.lat !== 'number' || typeof p.endPoint.lon !== 'number') return false;
     if (!isValidLatLon(p.startPoint.lat, p.startPoint.lon)) return false;
     if (!isValidLatLon(p.endPoint.lat, p.endPoint.lon)) return false;
+    // Reject degenerate routes where startPoint == endPoint. PR #3406 review
+    // surfaced 9 GEM rows (incl. Trans-Alaska, Enbridge Line 3, Ichthys)
+    // whose source GeoJSON had a Point geometry or a single-coord LineString,
+    // producing zero-length pipelines that render as map-point artifacts and
+    // skew aggregate-length statistics. Defense in depth — converter also
+    // drops these — but the validator gate makes the contract explicit.
+    if (p.startPoint.lat === p.endPoint.lat && p.startPoint.lon === p.endPoint.lon) return false;
 
     if (!p.evidence || typeof p.evidence !== 'object') return false;
     const ev = p.evidence;

--- a/scripts/data/pipelines-gas.json
+++ b/scripts/data/pipelines-gas.json
@@ -1,5 +1,5 @@
 {
-  "source": "Curated from operator disclosures, regulator filings, ENTSOG, GEM (CC-BY 4.0)",
+  "source": "Curated from operator disclosures, regulator filings, ENTSOG, GEM (CC-BY 4.0) + Global Energy Monitor (CC-BY 4.0)",
   "methodologyUrl": "/docs/methodology/pipelines",
   "version": "v1",
   "referenceYear": 2026,
@@ -16,8 +16,14 @@
       "capacityBcmYr": 55,
       "lengthKm": 1224,
       "inService": 2011,
-      "startPoint": { "lat": 60.08, "lon": 29.05 },
-      "endPoint": { "lat": 54.14, "lon": 13.66 },
+      "startPoint": {
+        "lat": 60.08,
+        "lon": 29.05
+      },
+      "endPoint": {
+        "lat": 54.14,
+        "lon": 13.66
+      },
       "evidence": {
         "physicalState": "offline",
         "physicalStateSource": "operator",
@@ -28,7 +34,12 @@
         },
         "commercialState": "suspended",
         "sanctionRefs": [
-          { "authority": "EU", "listId": "2022/1269 (energy sanctions package 8)", "date": "2022-10-06", "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R1269" }
+          {
+            "authority": "EU",
+            "listId": "2022/1269 (energy sanctions package 8)",
+            "date": "2022-10-06",
+            "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R1269"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -46,8 +57,14 @@
       "capacityBcmYr": 55,
       "lengthKm": 1234,
       "inService": null,
-      "startPoint": { "lat": 60.08, "lon": 29.05 },
-      "endPoint": { "lat": 54.14, "lon": 13.66 },
+      "startPoint": {
+        "lat": 60.08,
+        "lon": 29.05
+      },
+      "endPoint": {
+        "lat": 54.14,
+        "lon": 13.66
+      },
       "evidence": {
         "physicalState": "offline",
         "physicalStateSource": "operator",
@@ -58,7 +75,12 @@
         },
         "commercialState": "suspended",
         "sanctionRefs": [
-          { "authority": "US", "listId": "OFAC (PEESA)", "date": "2022-02-23", "url": "https://home.treasury.gov/news/press-releases/jy0602" }
+          {
+            "authority": "US",
+            "listId": "OFAC (PEESA)",
+            "date": "2022-02-23",
+            "url": "https://home.treasury.gov/news/press-releases/jy0602"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -76,8 +98,14 @@
       "capacityBcmYr": 31.5,
       "lengthKm": 930,
       "inService": 2020,
-      "startPoint": { "lat": 44.95, "lon": 37.32 },
-      "endPoint": { "lat": 41.89, "lon": 28.02 },
+      "startPoint": {
+        "lat": 44.95,
+        "lon": 37.32
+      },
+      "endPoint": {
+        "lat": 41.89,
+        "lon": 28.02
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -96,19 +124,33 @@
       "commodityType": "gas",
       "fromCountry": "RU",
       "toCountry": "DE",
-      "transitCountries": ["BY", "PL"],
+      "transitCountries": [
+        "BY",
+        "PL"
+      ],
       "capacityBcmYr": 33,
       "lengthKm": 4107,
       "inService": 1999,
-      "startPoint": { "lat": 66.52, "lon": 66.60 },
-      "endPoint": { "lat": 52.27, "lon": 14.64 },
+      "startPoint": {
+        "lat": 66.52,
+        "lon": 66.6
+      },
+      "endPoint": {
+        "lat": 52.27,
+        "lon": 14.64
+      },
       "evidence": {
         "physicalState": "offline",
         "physicalStateSource": "press",
         "operatorStatement": null,
         "commercialState": "expired",
         "sanctionRefs": [
-          { "authority": "Poland", "listId": "Retaliatory counter-sanctions on EuRoPol GAZ", "date": "2022-04-26", "url": "https://www.gov.pl/web/aktywa-panstwowe/" }
+          {
+            "authority": "Poland",
+            "listId": "Retaliatory counter-sanctions on EuRoPol GAZ",
+            "date": "2022-04-26",
+            "url": "https://www.gov.pl/web/aktywa-panstwowe/"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -122,12 +164,20 @@
       "commodityType": "gas",
       "fromCountry": "RU",
       "toCountry": "SK",
-      "transitCountries": ["UA"],
+      "transitCountries": [
+        "UA"
+      ],
       "capacityBcmYr": 142,
       "lengthKm": 4451,
       "inService": 1983,
-      "startPoint": { "lat": 58.00, "lon": 56.00 },
-      "endPoint": { "lat": 48.60, "lon": 22.14 },
+      "startPoint": {
+        "lat": 58,
+        "lon": 56
+      },
+      "endPoint": {
+        "lat": 48.6,
+        "lon": 22.14
+      },
       "evidence": {
         "physicalState": "offline",
         "physicalStateSource": "operator",
@@ -154,8 +204,14 @@
       "capacityBcmYr": 38,
       "lengthKm": 3000,
       "inService": 2019,
-      "startPoint": { "lat": 62.45, "lon": 129.73 },
-      "endPoint": { "lat": 49.58, "lon": 127.52 },
+      "startPoint": {
+        "lat": 62.45,
+        "lon": 129.73
+      },
+      "endPoint": {
+        "lat": 49.58,
+        "lon": 127.52
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -178,8 +234,14 @@
       "capacityBcmYr": 20.4,
       "lengthKm": 364,
       "inService": 2007,
-      "startPoint": { "lat": 25.90, "lon": 51.50 },
-      "endPoint": { "lat": 24.47, "lon": 54.37 },
+      "startPoint": {
+        "lat": 25.9,
+        "lon": 51.5
+      },
+      "endPoint": {
+        "lat": 24.47,
+        "lon": 54.37
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -202,8 +264,14 @@
       "capacityBcmYr": 10.5,
       "lengthKm": 757,
       "inService": 2011,
-      "startPoint": { "lat": 35.67, "lon": -0.64 },
-      "endPoint": { "lat": 36.73, "lon": -2.59 },
+      "startPoint": {
+        "lat": 35.67,
+        "lon": -0.64
+      },
+      "endPoint": {
+        "lat": 36.73,
+        "lon": -2.59
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -222,12 +290,21 @@
       "commodityType": "gas",
       "fromCountry": "TR",
       "toCountry": "IT",
-      "transitCountries": ["GR", "AL"],
+      "transitCountries": [
+        "GR",
+        "AL"
+      ],
       "capacityBcmYr": 10,
       "lengthKm": 878,
       "inService": 2020,
-      "startPoint": { "lat": 40.91, "lon": 26.27 },
-      "endPoint": { "lat": 40.53, "lon": 17.85 },
+      "startPoint": {
+        "lat": 40.91,
+        "lon": 26.27
+      },
+      "endPoint": {
+        "lat": 40.53,
+        "lon": 17.85
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -246,12 +323,20 @@
       "commodityType": "gas",
       "fromCountry": "AZ",
       "toCountry": "TR",
-      "transitCountries": ["GE"],
+      "transitCountries": [
+        "GE"
+      ],
       "capacityBcmYr": 16,
       "lengthKm": 1850,
       "inService": 2018,
-      "startPoint": { "lat": 41.17, "lon": 42.85 },
-      "endPoint": { "lat": 40.91, "lon": 26.27 },
+      "startPoint": {
+        "lat": 41.17,
+        "lon": 42.85
+      },
+      "endPoint": {
+        "lat": 40.91,
+        "lon": 26.27
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -270,12 +355,21 @@
       "commodityType": "gas",
       "fromCountry": "TM",
       "toCountry": "CN",
-      "transitCountries": ["UZ", "KZ"],
+      "transitCountries": [
+        "UZ",
+        "KZ"
+      ],
       "capacityBcmYr": 55,
       "lengthKm": 1833,
       "inService": 2009,
-      "startPoint": { "lat": 40.00, "lon": 62.50 },
-      "endPoint": { "lat": 42.88, "lon": 80.20 },
+      "startPoint": {
+        "lat": 40,
+        "lon": 62.5
+      },
+      "endPoint": {
+        "lat": 42.88,
+        "lon": 80.2
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -298,8 +392,14 @@
       "capacityBcmYr": 25.5,
       "lengthKm": 1166,
       "inService": 2006,
-      "startPoint": { "lat": 64.82, "lon": 6.70 },
-      "endPoint": { "lat": 53.71, "lon": -0.31 },
+      "startPoint": {
+        "lat": 64.82,
+        "lon": 6.7
+      },
+      "endPoint": {
+        "lat": 53.71,
+        "lon": -0.31
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -322,8 +422,14 @@
       "capacityBcmYr": 16,
       "lengthKm": 620,
       "inService": 1995,
-      "startPoint": { "lat": 56.55, "lon": 3.22 },
-      "endPoint": { "lat": 53.50, "lon": 7.12 },
+      "startPoint": {
+        "lat": 56.55,
+        "lon": 3.22
+      },
+      "endPoint": {
+        "lat": 53.5,
+        "lon": 7.12
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -346,8 +452,14 @@
       "capacityBcmYr": 24,
       "lengthKm": 658,
       "inService": 1999,
-      "startPoint": { "lat": 58.85, "lon": 2.07 },
-      "endPoint": { "lat": 53.50, "lon": 7.12 },
+      "startPoint": {
+        "lat": 58.85,
+        "lon": 2.07
+      },
+      "endPoint": {
+        "lat": 53.5,
+        "lon": 7.12
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -370,8 +482,14 @@
       "capacityBcmYr": 19.2,
       "lengthKm": 840,
       "inService": 1998,
-      "startPoint": { "lat": 56.54, "lon": 3.22 },
-      "endPoint": { "lat": 51.08, "lon": 2.35 },
+      "startPoint": {
+        "lat": 56.54,
+        "lon": 3.22
+      },
+      "endPoint": {
+        "lat": 51.08,
+        "lon": 2.35
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -394,8 +512,14 @@
       "capacityBcmYr": 15,
       "lengthKm": 814,
       "inService": 1993,
-      "startPoint": { "lat": 60.62, "lon": 3.33 },
-      "endPoint": { "lat": 51.33, "lon": 3.20 },
+      "startPoint": {
+        "lat": 60.62,
+        "lon": 3.33
+      },
+      "endPoint": {
+        "lat": 51.33,
+        "lon": 3.2
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -418,8 +542,14 @@
       "capacityBcmYr": 25.5,
       "lengthKm": 235,
       "inService": 1998,
-      "startPoint": { "lat": 52.08, "lon": 1.67 },
-      "endPoint": { "lat": 51.33, "lon": 3.20 },
+      "startPoint": {
+        "lat": 52.08,
+        "lon": 1.67
+      },
+      "endPoint": {
+        "lat": 51.33,
+        "lon": 3.2
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -442,8 +572,14 @@
       "capacityBcmYr": 19,
       "lengthKm": 235,
       "inService": 2006,
-      "startPoint": { "lat": 52.93, "lon": 4.83 },
-      "endPoint": { "lat": 52.85, "lon": 1.45 },
+      "startPoint": {
+        "lat": 52.93,
+        "lon": 4.83
+      },
+      "endPoint": {
+        "lat": 52.85,
+        "lon": 1.45
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -462,12 +598,20 @@
       "commodityType": "gas",
       "fromCountry": "DZ",
       "toCountry": "IT",
-      "transitCountries": ["TN"],
+      "transitCountries": [
+        "TN"
+      ],
       "capacityBcmYr": 33.5,
       "lengthKm": 2475,
       "inService": 1983,
-      "startPoint": { "lat": 31.67, "lon": 5.02 },
-      "endPoint": { "lat": 37.63, "lon": 12.73 },
+      "startPoint": {
+        "lat": 31.67,
+        "lon": 5.02
+      },
+      "endPoint": {
+        "lat": 37.63,
+        "lon": 12.73
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -490,8 +634,14 @@
       "capacityBcmYr": 8,
       "lengthKm": 520,
       "inService": 2004,
-      "startPoint": { "lat": 32.60, "lon": 12.47 },
-      "endPoint": { "lat": 37.12, "lon": 14.28 },
+      "startPoint": {
+        "lat": 32.6,
+        "lon": 12.47
+      },
+      "endPoint": {
+        "lat": 37.12,
+        "lon": 14.28
+      },
       "evidence": {
         "physicalState": "reduced",
         "physicalStateSource": "press",
@@ -510,12 +660,20 @@
       "commodityType": "gas",
       "fromCountry": "DZ",
       "toCountry": "ES",
-      "transitCountries": ["MA"],
+      "transitCountries": [
+        "MA"
+      ],
       "capacityBcmYr": 12,
       "lengthKm": 1620,
       "inService": 1996,
-      "startPoint": { "lat": 32.13, "lon": -0.67 },
-      "endPoint": { "lat": 36.15, "lon": -5.45 },
+      "startPoint": {
+        "lat": 32.13,
+        "lon": -0.67
+      },
+      "endPoint": {
+        "lat": 36.15,
+        "lon": -5.45
+      },
       "evidence": {
         "physicalState": "offline",
         "physicalStateSource": "regulator",
@@ -542,8 +700,14 @@
       "capacityBcmYr": 3,
       "lengthKm": 182,
       "inService": 2022,
-      "startPoint": { "lat": 40.93, "lon": 25.14 },
-      "endPoint": { "lat": 42.15, "lon": 24.75 },
+      "startPoint": {
+        "lat": 40.93,
+        "lon": 25.14
+      },
+      "endPoint": {
+        "lat": 42.15,
+        "lon": 24.75
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -562,19 +726,33 @@
       "commodityType": "gas",
       "fromCountry": "EG",
       "toCountry": "LB",
-      "transitCountries": ["JO", "SY"],
+      "transitCountries": [
+        "JO",
+        "SY"
+      ],
       "capacityBcmYr": 10.3,
       "lengthKm": 1200,
       "inService": 2003,
-      "startPoint": { "lat": 31.33, "lon": 32.28 },
-      "endPoint": { "lat": 34.27, "lon": 35.67 },
+      "startPoint": {
+        "lat": 31.33,
+        "lon": 32.28
+      },
+      "endPoint": {
+        "lat": 34.27,
+        "lon": 35.67
+      },
       "evidence": {
         "physicalState": "offline",
         "physicalStateSource": "press",
         "operatorStatement": null,
         "commercialState": "suspended",
         "sanctionRefs": [
-          { "authority": "US", "listId": "Caesar Act (Syria)", "date": "2020-06-17", "url": "https://www.congress.gov/bill/116th-congress/house-bill/31" }
+          {
+            "authority": "US",
+            "listId": "Caesar Act (Syria)",
+            "date": "2020-06-17",
+            "url": "https://www.congress.gov/bill/116th-congress/house-bill/31"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -592,15 +770,26 @@
       "capacityBcmYr": 16,
       "lengthKm": 1213,
       "inService": 2003,
-      "startPoint": { "lat": 44.72, "lon": 37.75 },
-      "endPoint": { "lat": 41.05, "lon": 34.58 },
+      "startPoint": {
+        "lat": 44.72,
+        "lon": 37.75
+      },
+      "endPoint": {
+        "lat": 41.05,
+        "lon": 34.58
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
         "operatorStatement": null,
         "commercialState": "under_contract",
         "sanctionRefs": [
-          { "authority": "EU", "listId": "2022/1269 (energy sanctions package 8)", "date": "2022-10-06", "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R1269" }
+          {
+            "authority": "EU",
+            "listId": "2022/1269 (energy sanctions package 8)",
+            "date": "2022-10-06",
+            "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R1269"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -618,8 +807,14 @@
       "capacityBcmYr": 30,
       "lengthKm": 7378,
       "inService": 2014,
-      "startPoint": { "lat": 42.95, "lon": 80.35 },
-      "endPoint": { "lat": 26.08, "lon": 119.30 },
+      "startPoint": {
+        "lat": 42.95,
+        "lon": 80.35
+      },
+      "endPoint": {
+        "lat": 26.08,
+        "lon": 119.3
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -642,8 +837,14 @@
       "capacityBcmYr": 12,
       "lengthKm": 793,
       "inService": 2013,
-      "startPoint": { "lat": 20.15, "lon": 93.53 },
-      "endPoint": { "lat": 24.45, "lon": 98.58 },
+      "startPoint": {
+        "lat": 20.15,
+        "lon": 93.53
+      },
+      "endPoint": {
+        "lat": 24.45,
+        "lon": 98.58
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -662,12 +863,21 @@
       "commodityType": "gas",
       "fromCountry": "NG",
       "toCountry": "GH",
-      "transitCountries": ["BJ", "TG"],
+      "transitCountries": [
+        "BJ",
+        "TG"
+      ],
       "capacityBcmYr": 5,
       "lengthKm": 678,
       "inService": 2010,
-      "startPoint": { "lat": 6.35, "lon": 3.38 },
-      "endPoint": { "lat": 5.10, "lon": -1.27 },
+      "startPoint": {
+        "lat": 6.35,
+        "lon": 3.38
+      },
+      "endPoint": {
+        "lat": 5.1,
+        "lon": -1.27
+      },
       "evidence": {
         "physicalState": "reduced",
         "physicalStateSource": "press",
@@ -690,8 +900,14 @@
       "capacityBcmYr": 11,
       "lengthKm": 3150,
       "inService": 1999,
-      "startPoint": { "lat": -18.85, "lon": -57.85 },
-      "endPoint": { "lat": -29.95, "lon": -51.13 },
+      "startPoint": {
+        "lat": -18.85,
+        "lon": -57.85
+      },
+      "endPoint": {
+        "lat": -29.95,
+        "lon": -51.13
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -714,8 +930,14 @@
       "capacityBcmYr": 13,
       "lengthKm": 363,
       "inService": 2001,
-      "startPoint": { "lat": 59.90, "lon": 1.85 },
-      "endPoint": { "lat": 57.60, "lon": -1.80 },
+      "startPoint": {
+        "lat": 59.9,
+        "lon": 1.85
+      },
+      "endPoint": {
+        "lat": 57.6,
+        "lon": -1.8
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -738,8 +960,14 @@
       "capacityBcmYr": 9.6,
       "lengthKm": 404,
       "inService": 1993,
-      "startPoint": { "lat": 57.83, "lon": 0.90 },
-      "endPoint": { "lat": 54.63, "lon": -1.17 },
+      "startPoint": {
+        "lat": 57.83,
+        "lon": 0.9
+      },
+      "endPoint": {
+        "lat": 54.63,
+        "lon": -1.17
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -762,15 +990,26 @@
       "capacityBcmYr": 14,
       "lengthKm": 2577,
       "inService": 2001,
-      "startPoint": { "lat": 38.08, "lon": 46.30 },
-      "endPoint": { "lat": 39.92, "lon": 32.85 },
+      "startPoint": {
+        "lat": 38.08,
+        "lon": 46.3
+      },
+      "endPoint": {
+        "lat": 39.92,
+        "lon": 32.85
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
         "operatorStatement": null,
         "commercialState": "under_contract",
         "sanctionRefs": [
-          { "authority": "US", "listId": "OFAC Iran energy sanctions framework", "date": "2018-08-07", "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions" }
+          {
+            "authority": "US",
+            "listId": "OFAC Iran energy sanctions framework",
+            "date": "2018-08-07",
+            "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -788,15 +1027,26 @@
       "capacityBcmYr": 2.3,
       "lengthKm": 140,
       "inService": 2007,
-      "startPoint": { "lat": 38.92, "lon": 46.08 },
-      "endPoint": { "lat": 39.33, "lon": 45.35 },
+      "startPoint": {
+        "lat": 38.92,
+        "lon": 46.08
+      },
+      "endPoint": {
+        "lat": 39.33,
+        "lon": 45.35
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
         "operatorStatement": null,
         "commercialState": "under_contract",
         "sanctionRefs": [
-          { "authority": "US", "listId": "OFAC Iran energy sanctions framework", "date": "2018-08-07", "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions" }
+          {
+            "authority": "US",
+            "listId": "OFAC Iran energy sanctions framework",
+            "date": "2018-08-07",
+            "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -814,15 +1064,26 @@
       "capacityBcmYr": 9,
       "lengthKm": 270,
       "inService": 2017,
-      "startPoint": { "lat": 31.35, "lon": 48.67 },
-      "endPoint": { "lat": 30.50, "lon": 47.80 },
+      "startPoint": {
+        "lat": 31.35,
+        "lon": 48.67
+      },
+      "endPoint": {
+        "lat": 30.5,
+        "lon": 47.8
+      },
       "evidence": {
         "physicalState": "reduced",
         "physicalStateSource": "press",
         "operatorStatement": null,
         "commercialState": "under_contract",
         "sanctionRefs": [
-          { "authority": "US", "listId": "OFAC Iran energy sanctions framework (US waivers intermittent)", "date": "2018-08-07", "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions" }
+          {
+            "authority": "US",
+            "listId": "OFAC Iran energy sanctions framework (US waivers intermittent)",
+            "date": "2018-08-07",
+            "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -836,12 +1097,21 @@
       "commodityType": "gas",
       "fromCountry": "TM",
       "toCountry": "RU",
-      "transitCountries": ["UZ", "KZ"],
+      "transitCountries": [
+        "UZ",
+        "KZ"
+      ],
       "capacityBcmYr": 44,
       "lengthKm": 5000,
       "inService": 1967,
-      "startPoint": { "lat": 40.80, "lon": 54.02 },
-      "endPoint": { "lat": 51.53, "lon": 45.72 },
+      "startPoint": {
+        "lat": 40.8,
+        "lon": 54.02
+      },
+      "endPoint": {
+        "lat": 51.53,
+        "lon": 45.72
+      },
       "evidence": {
         "physicalState": "reduced",
         "physicalStateSource": "press",
@@ -860,12 +1130,20 @@
       "commodityType": "gas",
       "fromCountry": "AZ",
       "toCountry": "TR",
-      "transitCountries": ["GE"],
+      "transitCountries": [
+        "GE"
+      ],
       "capacityBcmYr": 22,
       "lengthKm": 692,
       "inService": 2006,
-      "startPoint": { "lat": 40.37, "lon": 50.25 },
-      "endPoint": { "lat": 39.90, "lon": 41.27 },
+      "startPoint": {
+        "lat": 40.37,
+        "lon": 50.25
+      },
+      "endPoint": {
+        "lat": 39.9,
+        "lon": 41.27
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -888,8 +1166,14 @@
       "capacityBcmYr": 17,
       "lengthKm": 4200,
       "inService": 2004,
-      "startPoint": { "lat": 39.47, "lon": 84.98 },
-      "endPoint": { "lat": 31.23, "lon": 121.47 },
+      "startPoint": {
+        "lat": 39.47,
+        "lon": 84.98
+      },
+      "endPoint": {
+        "lat": 31.23,
+        "lon": 121.47
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -912,8 +1196,14 @@
       "capacityBcmYr": 30,
       "lengthKm": 8700,
       "inService": 2011,
-      "startPoint": { "lat": 45.13, "lon": 82.57 },
-      "endPoint": { "lat": 22.95, "lon": 113.40 },
+      "startPoint": {
+        "lat": 45.13,
+        "lon": 82.57
+      },
+      "endPoint": {
+        "lat": 22.95,
+        "lon": 113.4
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -936,8 +1226,14 @@
       "capacityBcmYr": 7.7,
       "lengthKm": 441,
       "inService": 1972,
-      "startPoint": { "lat": -22.02, "lon": -63.67 },
-      "endPoint": { "lat": -24.15, "lon": -65.30 },
+      "startPoint": {
+        "lat": -22.02,
+        "lon": -63.67
+      },
+      "endPoint": {
+        "lat": -24.15,
+        "lon": -65.3
+      },
       "evidence": {
         "physicalState": "reduced",
         "physicalStateSource": "press",
@@ -960,8 +1256,14 @@
       "capacityBcmYr": 5,
       "lengthKm": 224,
       "inService": 2007,
-      "startPoint": { "lat": 11.38, "lon": -72.47 },
-      "endPoint": { "lat": 10.67, "lon": -71.67 },
+      "startPoint": {
+        "lat": 11.38,
+        "lon": -72.47
+      },
+      "endPoint": {
+        "lat": 10.67,
+        "lon": -71.67
+      },
       "evidence": {
         "physicalState": "offline",
         "physicalStateSource": "press",
@@ -972,7 +1274,12 @@
         },
         "commercialState": "suspended",
         "sanctionRefs": [
-          { "authority": "US", "listId": "OFAC Venezuela/PDVSA sanctions", "date": "2019-01-28", "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/venezuela-related-sanctions" }
+          {
+            "authority": "US",
+            "listId": "OFAC Venezuela/PDVSA sanctions",
+            "date": "2019-01-28",
+            "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/venezuela-related-sanctions"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -990,8 +1297,14 @@
       "capacityBcmYr": 95,
       "lengthKm": 2400,
       "inService": 1982,
-      "startPoint": { "lat": 26.10, "lon": 49.87 },
-      "endPoint": { "lat": 22.20, "lon": 39.13 },
+      "startPoint": {
+        "lat": 26.1,
+        "lon": 49.87
+      },
+      "endPoint": {
+        "lat": 22.2,
+        "lon": 39.13
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -1014,8 +1327,14 @@
       "capacityBcmYr": 8,
       "lengthKm": 1470,
       "inService": 0,
-      "startPoint": { "lat": 37.12, "lon": 8.83 },
-      "endPoint": { "lat": 40.55, "lon": 9.73 },
+      "startPoint": {
+        "lat": 37.12,
+        "lon": 8.83
+      },
+      "endPoint": {
+        "lat": 40.55,
+        "lon": 9.73
+      },
       "evidence": {
         "physicalState": "unknown",
         "physicalStateSource": "press",
@@ -1038,12 +1357,20 @@
       "commodityType": "gas",
       "fromCountry": "IL",
       "toCountry": "GR",
-      "transitCountries": ["CY"],
+      "transitCountries": [
+        "CY"
+      ],
       "capacityBcmYr": 10,
       "lengthKm": 1900,
       "inService": 0,
-      "startPoint": { "lat": 32.40, "lon": 34.13 },
-      "endPoint": { "lat": 38.93, "lon": 21.76 },
+      "startPoint": {
+        "lat": 32.4,
+        "lon": 34.13
+      },
+      "endPoint": {
+        "lat": 38.93,
+        "lon": 21.76
+      },
       "evidence": {
         "physicalState": "unknown",
         "physicalStateSource": "press",
@@ -1066,12 +1393,20 @@
       "commodityType": "gas",
       "fromCountry": "NG",
       "toCountry": "DZ",
-      "transitCountries": ["NE"],
+      "transitCountries": [
+        "NE"
+      ],
       "capacityBcmYr": 30,
       "lengthKm": 4128,
       "inService": 0,
-      "startPoint": { "lat": 9.07, "lon": 7.48 },
-      "endPoint": { "lat": 36.75, "lon": 3.05 },
+      "startPoint": {
+        "lat": 9.07,
+        "lon": 7.48
+      },
+      "endPoint": {
+        "lat": 36.75,
+        "lon": 3.05
+      },
       "evidence": {
         "physicalState": "unknown",
         "physicalStateSource": "press",
@@ -1098,8 +1433,14 @@
       "capacityBcmYr": 7,
       "lengthKm": 90,
       "inService": 2020,
-      "startPoint": { "lat": 31.67, "lon": 34.58 },
-      "endPoint": { "lat": 31.13, "lon": 33.80 },
+      "startPoint": {
+        "lat": 31.67,
+        "lon": 34.58
+      },
+      "endPoint": {
+        "lat": 31.13,
+        "lon": 33.8
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -1122,8 +1463,14 @@
       "capacityBcmYr": 8,
       "lengthKm": 200,
       "inService": 1997,
-      "startPoint": { "lat": 39.42, "lon": 54.83 },
-      "endPoint": { "lat": 37.47, "lon": 54.67 },
+      "startPoint": {
+        "lat": 39.42,
+        "lon": 54.83
+      },
+      "endPoint": {
+        "lat": 37.47,
+        "lon": 54.67
+      },
       "evidence": {
         "physicalState": "reduced",
         "physicalStateSource": "press",
@@ -1142,12 +1489,29 @@
       "commodityType": "gas",
       "fromCountry": "NG",
       "toCountry": "MA",
-      "transitCountries": ["BJ", "TG", "GH", "CI", "LR", "SL", "GN", "GW", "SN", "MR"],
+      "transitCountries": [
+        "BJ",
+        "TG",
+        "GH",
+        "CI",
+        "LR",
+        "SL",
+        "GN",
+        "GW",
+        "SN",
+        "MR"
+      ],
       "capacityBcmYr": 30,
       "lengthKm": 6800,
       "inService": 0,
-      "startPoint": { "lat": 6.35, "lon": 3.38 },
-      "endPoint": { "lat": 35.75, "lon": -5.80 },
+      "startPoint": {
+        "lat": 6.35,
+        "lon": 3.38
+      },
+      "endPoint": {
+        "lat": 35.75,
+        "lon": -5.8
+      },
       "evidence": {
         "physicalState": "unknown",
         "physicalStateSource": "press",
@@ -1170,12 +1534,20 @@
       "commodityType": "gas",
       "fromCountry": "RU",
       "toCountry": "CN",
-      "transitCountries": ["MN"],
+      "transitCountries": [
+        "MN"
+      ],
       "capacityBcmYr": 50,
       "lengthKm": 6700,
       "inService": 0,
-      "startPoint": { "lat": 67.50, "lon": 80.57 },
-      "endPoint": { "lat": 43.82, "lon": 125.32 },
+      "startPoint": {
+        "lat": 67.5,
+        "lon": 80.57
+      },
+      "endPoint": {
+        "lat": 43.82,
+        "lon": 125.32
+      },
       "evidence": {
         "physicalState": "unknown",
         "physicalStateSource": "press",
@@ -1186,7 +1558,12 @@
         },
         "commercialState": "unknown",
         "sanctionRefs": [
-          { "authority": "EU", "listId": "2022/1269 (energy sanctions package 8)", "date": "2022-10-06", "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R1269" }
+          {
+            "authority": "EU",
+            "listId": "2022/1269 (energy sanctions package 8)",
+            "date": "2022-10-06",
+            "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R1269"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -1204,8 +1581,14 @@
       "capacityBcmYr": 3.5,
       "lengthKm": 390,
       "inService": 2003,
-      "startPoint": { "lat": 29.93, "lon": 32.57 },
-      "endPoint": { "lat": 29.52, "lon": 35.00 },
+      "startPoint": {
+        "lat": 29.93,
+        "lon": 32.57
+      },
+      "endPoint": {
+        "lat": 29.52,
+        "lon": 35
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -1228,8 +1611,14 @@
       "capacityBcmYr": 14,
       "lengthKm": 170,
       "inService": 2023,
-      "startPoint": { "lat": 42.38, "lon": 31.85 },
-      "endPoint": { "lat": 41.27, "lon": 31.40 },
+      "startPoint": {
+        "lat": 42.38,
+        "lon": 31.85
+      },
+      "endPoint": {
+        "lat": 41.27,
+        "lon": 31.4
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -1252,8 +1641,14 @@
       "capacityBcmYr": 10,
       "lengthKm": 430,
       "inService": 0,
-      "startPoint": { "lat": 35.47, "lon": 44.40 },
-      "endPoint": { "lat": 37.07, "lon": 37.33 },
+      "startPoint": {
+        "lat": 35.47,
+        "lon": 44.4
+      },
+      "endPoint": {
+        "lat": 37.07,
+        "lon": 37.33
+      },
       "evidence": {
         "physicalState": "unknown",
         "physicalStateSource": "press",
@@ -1270,117 +1665,477 @@
       }
     },
     "statpipe": {
-      "id": "statpipe", "name": "Statpipe", "operator": "Gassco", "commodityType": "gas",
-      "fromCountry": "NO", "toCountry": "NO", "transitCountries": [],
-      "capacityBcmYr": 25, "lengthKm": 880, "inService": 1985,
-      "startPoint": { "lat": 61.25, "lon": 1.85 }, "endPoint": { "lat": 59.28, "lon": 5.42 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.9 }
+      "id": "statpipe",
+      "name": "Statpipe",
+      "operator": "Gassco",
+      "commodityType": "gas",
+      "fromCountry": "NO",
+      "toCountry": "NO",
+      "transitCountries": [],
+      "capacityBcmYr": 25,
+      "lengthKm": 880,
+      "inService": 1985,
+      "startPoint": {
+        "lat": 61.25,
+        "lon": 1.85
+      },
+      "endPoint": {
+        "lat": 59.28,
+        "lon": 5.42
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.9
+      }
     },
     "sleipner-karsto": {
-      "id": "sleipner-karsto", "name": "Sleipner–Kårstø", "operator": "Gassco", "commodityType": "gas",
-      "fromCountry": "NO", "toCountry": "NO", "transitCountries": [],
-      "capacityBcmYr": 12, "lengthKm": 245, "inService": 1993,
-      "startPoint": { "lat": 58.37, "lon": 1.90 }, "endPoint": { "lat": 59.28, "lon": 5.42 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.88 }
+      "id": "sleipner-karsto",
+      "name": "Sleipner–Kårstø",
+      "operator": "Gassco",
+      "commodityType": "gas",
+      "fromCountry": "NO",
+      "toCountry": "NO",
+      "transitCountries": [],
+      "capacityBcmYr": 12,
+      "lengthKm": 245,
+      "inService": 1993,
+      "startPoint": {
+        "lat": 58.37,
+        "lon": 1.9
+      },
+      "endPoint": {
+        "lat": 59.28,
+        "lon": 5.42
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.88
+      }
     },
     "troll-a-gas-pipeline": {
-      "id": "troll-a-gas-pipeline", "name": "Troll A – Kollsnes", "operator": "Gassco", "commodityType": "gas",
-      "fromCountry": "NO", "toCountry": "NO", "transitCountries": [],
-      "capacityBcmYr": 30, "lengthKm": 67, "inService": 1996,
-      "startPoint": { "lat": 60.65, "lon": 3.72 }, "endPoint": { "lat": 60.55, "lon": 4.85 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.92 }
+      "id": "troll-a-gas-pipeline",
+      "name": "Troll A – Kollsnes",
+      "operator": "Gassco",
+      "commodityType": "gas",
+      "fromCountry": "NO",
+      "toCountry": "NO",
+      "transitCountries": [],
+      "capacityBcmYr": 30,
+      "lengthKm": 67,
+      "inService": 1996,
+      "startPoint": {
+        "lat": 60.65,
+        "lon": 3.72
+      },
+      "endPoint": {
+        "lat": 60.55,
+        "lon": 4.85
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.92
+      }
     },
     "oseberg-gas-transport": {
-      "id": "oseberg-gas-transport", "name": "Oseberg Gas Transport (OGT)", "operator": "Gassco", "commodityType": "gas",
-      "fromCountry": "NO", "toCountry": "NO", "transitCountries": [],
-      "capacityBcmYr": 9, "lengthKm": 109, "inService": 2000,
-      "startPoint": { "lat": 60.48, "lon": 2.82 }, "endPoint": { "lat": 60.55, "lon": 4.85 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.88 }
+      "id": "oseberg-gas-transport",
+      "name": "Oseberg Gas Transport (OGT)",
+      "operator": "Gassco",
+      "commodityType": "gas",
+      "fromCountry": "NO",
+      "toCountry": "NO",
+      "transitCountries": [],
+      "capacityBcmYr": 9,
+      "lengthKm": 109,
+      "inService": 2000,
+      "startPoint": {
+        "lat": 60.48,
+        "lon": 2.82
+      },
+      "endPoint": {
+        "lat": 60.55,
+        "lon": 4.85
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.88
+      }
     },
     "asgard-transport": {
-      "id": "asgard-transport", "name": "Åsgard Transport", "operator": "Gassco", "commodityType": "gas",
-      "fromCountry": "NO", "toCountry": "NO", "transitCountries": [],
-      "capacityBcmYr": 14, "lengthKm": 707, "inService": 2000,
-      "startPoint": { "lat": 65.05, "lon": 6.78 }, "endPoint": { "lat": 59.28, "lon": 5.42 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.88 }
+      "id": "asgard-transport",
+      "name": "Åsgard Transport",
+      "operator": "Gassco",
+      "commodityType": "gas",
+      "fromCountry": "NO",
+      "toCountry": "NO",
+      "transitCountries": [],
+      "capacityBcmYr": 14,
+      "lengthKm": 707,
+      "inService": 2000,
+      "startPoint": {
+        "lat": 65.05,
+        "lon": 6.78
+      },
+      "endPoint": {
+        "lat": 59.28,
+        "lon": 5.42
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.88
+      }
     },
     "dampier-bunbury": {
-      "id": "dampier-bunbury", "name": "Dampier to Bunbury Natural Gas Pipeline", "operator": "DBNGP WA", "commodityType": "gas",
-      "fromCountry": "AU", "toCountry": "AU", "transitCountries": [],
-      "capacityBcmYr": 8.6, "lengthKm": 1594, "inService": 1984,
-      "startPoint": { "lat": -20.68, "lon": 116.72 }, "endPoint": { "lat": -33.33, "lon": 115.63 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.9 }
+      "id": "dampier-bunbury",
+      "name": "Dampier to Bunbury Natural Gas Pipeline",
+      "operator": "DBNGP WA",
+      "commodityType": "gas",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityBcmYr": 8.6,
+      "lengthKm": 1594,
+      "inService": 1984,
+      "startPoint": {
+        "lat": -20.68,
+        "lon": 116.72
+      },
+      "endPoint": {
+        "lat": -33.33,
+        "lon": 115.63
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.9
+      }
     },
     "moomba-sydney": {
-      "id": "moomba-sydney", "name": "Moomba–Sydney Pipeline", "operator": "APA Group", "commodityType": "gas",
-      "fromCountry": "AU", "toCountry": "AU", "transitCountries": [],
-      "capacityBcmYr": 5.5, "lengthKm": 1299, "inService": 1976,
-      "startPoint": { "lat": -28.12, "lon": 140.20 }, "endPoint": { "lat": -33.87, "lon": 151.20 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.88 }
+      "id": "moomba-sydney",
+      "name": "Moomba–Sydney Pipeline",
+      "operator": "APA Group",
+      "commodityType": "gas",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityBcmYr": 5.5,
+      "lengthKm": 1299,
+      "inService": 1976,
+      "startPoint": {
+        "lat": -28.12,
+        "lon": 140.2
+      },
+      "endPoint": {
+        "lat": -33.87,
+        "lon": 151.2
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.88
+      }
     },
     "mozambique-rompco": {
-      "id": "mozambique-rompco", "name": "ROMPCO (Mozambique–South Africa)", "operator": "Sasol / CEF / Companhia Moçambicana de Gasoduto", "commodityType": "gas",
-      "fromCountry": "MZ", "toCountry": "ZA", "transitCountries": [],
-      "capacityBcmYr": 5.5, "lengthKm": 865, "inService": 2004,
-      "startPoint": { "lat": -22.93, "lon": 31.33 }, "endPoint": { "lat": -26.20, "lon": 28.02 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.85 }
+      "id": "mozambique-rompco",
+      "name": "ROMPCO (Mozambique–South Africa)",
+      "operator": "Sasol / CEF / Companhia Moçambicana de Gasoduto",
+      "commodityType": "gas",
+      "fromCountry": "MZ",
+      "toCountry": "ZA",
+      "transitCountries": [],
+      "capacityBcmYr": 5.5,
+      "lengthKm": 865,
+      "inService": 2004,
+      "startPoint": {
+        "lat": -22.93,
+        "lon": 31.33
+      },
+      "endPoint": {
+        "lat": -26.2,
+        "lon": 28.02
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.85
+      }
     },
     "escravos-lagos-gas": {
-      "id": "escravos-lagos-gas", "name": "Escravos–Lagos Pipeline System", "operator": "NNPC / Chevron Nigeria", "commodityType": "gas",
-      "fromCountry": "NG", "toCountry": "NG", "transitCountries": [],
-      "capacityBcmYr": 9, "lengthKm": 342, "inService": 1989,
-      "startPoint": { "lat": 5.62, "lon": 5.20 }, "endPoint": { "lat": 6.46, "lon": 3.37 },
-      "evidence": { "physicalState": "reduced", "physicalStateSource": "press", "operatorStatement": "Regular pipeline vandalism and NNPC/Chevron force-majeure declarations (2020-2024) per NNPC press releases + Reuters Lagos coverage.", "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.75 }
+      "id": "escravos-lagos-gas",
+      "name": "Escravos–Lagos Pipeline System",
+      "operator": "NNPC / Chevron Nigeria",
+      "commodityType": "gas",
+      "fromCountry": "NG",
+      "toCountry": "NG",
+      "transitCountries": [],
+      "capacityBcmYr": 9,
+      "lengthKm": 342,
+      "inService": 1989,
+      "startPoint": {
+        "lat": 5.62,
+        "lon": 5.2
+      },
+      "endPoint": {
+        "lat": 6.46,
+        "lon": 3.37
+      },
+      "evidence": {
+        "physicalState": "reduced",
+        "physicalStateSource": "press",
+        "operatorStatement": "Regular pipeline vandalism and NNPC/Chevron force-majeure declarations (2020-2024) per NNPC press releases + Reuters Lagos coverage.",
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.75
+      }
     },
     "tanzania-mtwara-dar": {
-      "id": "tanzania-mtwara-dar", "name": "Mtwara–Dar es Salaam Gas Pipeline", "operator": "TPDC / CPI-CPP consortium", "commodityType": "gas",
-      "fromCountry": "TZ", "toCountry": "TZ", "transitCountries": [],
-      "capacityBcmYr": 2, "lengthKm": 542, "inService": 2015,
-      "startPoint": { "lat": -10.27, "lon": 40.18 }, "endPoint": { "lat": -6.80, "lon": 39.28 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.78 }
+      "id": "tanzania-mtwara-dar",
+      "name": "Mtwara–Dar es Salaam Gas Pipeline",
+      "operator": "TPDC / CPI-CPP consortium",
+      "commodityType": "gas",
+      "fromCountry": "TZ",
+      "toCountry": "TZ",
+      "transitCountries": [],
+      "capacityBcmYr": 2,
+      "lengthKm": 542,
+      "inService": 2015,
+      "startPoint": {
+        "lat": -10.27,
+        "lon": 40.18
+      },
+      "endPoint": {
+        "lat": -6.8,
+        "lon": 39.28
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.78
+      }
     },
     "thailand-malaysia-cakerawala": {
-      "id": "thailand-malaysia-cakerawala", "name": "Cakerawala–Pengerang (Thai–Malaysia JDA)", "operator": "Carigali-PTTEPI Operating Company", "commodityType": "gas",
-      "fromCountry": "TH", "toCountry": "MY", "transitCountries": [],
-      "capacityBcmYr": 14, "lengthKm": 270, "inService": 2005,
-      "startPoint": { "lat": 6.78, "lon": 102.75 }, "endPoint": { "lat": 6.43, "lon": 99.67 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.82 }
+      "id": "thailand-malaysia-cakerawala",
+      "name": "Cakerawala–Pengerang (Thai–Malaysia JDA)",
+      "operator": "Carigali-PTTEPI Operating Company",
+      "commodityType": "gas",
+      "fromCountry": "TH",
+      "toCountry": "MY",
+      "transitCountries": [],
+      "capacityBcmYr": 14,
+      "lengthKm": 270,
+      "inService": 2005,
+      "startPoint": {
+        "lat": 6.78,
+        "lon": 102.75
+      },
+      "endPoint": {
+        "lat": 6.43,
+        "lon": 99.67
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.82
+      }
     },
     "indonesia-singapore-west-natuna": {
-      "id": "indonesia-singapore-west-natuna", "name": "West Natuna–Singapore Gas Pipeline", "operator": "ConocoPhillips / SembGas", "commodityType": "gas",
-      "fromCountry": "ID", "toCountry": "SG", "transitCountries": [],
-      "capacityBcmYr": 3.7, "lengthKm": 656, "inService": 2001,
-      "startPoint": { "lat": 3.67, "lon": 108.32 }, "endPoint": { "lat": 1.31, "lon": 103.65 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.82 }
+      "id": "indonesia-singapore-west-natuna",
+      "name": "West Natuna–Singapore Gas Pipeline",
+      "operator": "ConocoPhillips / SembGas",
+      "commodityType": "gas",
+      "fromCountry": "ID",
+      "toCountry": "SG",
+      "transitCountries": [],
+      "capacityBcmYr": 3.7,
+      "lengthKm": 656,
+      "inService": 2001,
+      "startPoint": {
+        "lat": 3.67,
+        "lon": 108.32
+      },
+      "endPoint": {
+        "lat": 1.31,
+        "lon": 103.65
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.82
+      }
     },
     "indonesia-singapore-grissik-sakra": {
-      "id": "indonesia-singapore-grissik-sakra", "name": "Grissik–Sakra Gas Pipeline", "operator": "ConocoPhillips / SembGas", "commodityType": "gas",
-      "fromCountry": "ID", "toCountry": "SG", "transitCountries": [],
-      "capacityBcmYr": 3.5, "lengthKm": 470, "inService": 2003,
-      "startPoint": { "lat": -2.08, "lon": 103.77 }, "endPoint": { "lat": 1.31, "lon": 103.65 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.82 }
+      "id": "indonesia-singapore-grissik-sakra",
+      "name": "Grissik–Sakra Gas Pipeline",
+      "operator": "ConocoPhillips / SembGas",
+      "commodityType": "gas",
+      "fromCountry": "ID",
+      "toCountry": "SG",
+      "transitCountries": [],
+      "capacityBcmYr": 3.5,
+      "lengthKm": 470,
+      "inService": 2003,
+      "startPoint": {
+        "lat": -2.08,
+        "lon": 103.77
+      },
+      "endPoint": {
+        "lat": 1.31,
+        "lon": 103.65
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.82
+      }
     },
     "nel-pipeline-germany": {
-      "id": "nel-pipeline-germany", "name": "NEL Pipeline (Nord Stream continuation)", "operator": "Gasunie Deutschland / Fluxys / WIGA", "commodityType": "gas",
-      "fromCountry": "DE", "toCountry": "DE", "transitCountries": [],
-      "capacityBcmYr": 20, "lengthKm": 440, "inService": 2013,
-      "startPoint": { "lat": 54.14, "lon": 13.66 }, "endPoint": { "lat": 52.52, "lon": 7.77 },
-      "evidence": { "physicalState": "reduced", "physicalStateSource": "press", "operatorStatement": "Direct Nord Stream 1 continuation; flows reduced to zero post-Sep-2022 sabotage per Gasunie Deutschland operator notice + BBC coverage.", "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.8 }
+      "id": "nel-pipeline-germany",
+      "name": "NEL Pipeline (Nord Stream continuation)",
+      "operator": "Gasunie Deutschland / Fluxys / WIGA",
+      "commodityType": "gas",
+      "fromCountry": "DE",
+      "toCountry": "DE",
+      "transitCountries": [],
+      "capacityBcmYr": 20,
+      "lengthKm": 440,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 54.14,
+        "lon": 13.66
+      },
+      "endPoint": {
+        "lat": 52.52,
+        "lon": 7.77
+      },
+      "evidence": {
+        "physicalState": "reduced",
+        "physicalStateSource": "press",
+        "operatorStatement": "Direct Nord Stream 1 continuation; flows reduced to zero post-Sep-2022 sabotage per Gasunie Deutschland operator notice + BBC coverage.",
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.8
+      }
     },
     "opal-pipeline-germany": {
-      "id": "opal-pipeline-germany", "name": "OPAL Pipeline (Nord Stream continuation)", "operator": "OPAL Gastransport (WIGA joint venture)", "commodityType": "gas",
-      "fromCountry": "DE", "toCountry": "CZ", "transitCountries": [],
-      "capacityBcmYr": 36, "lengthKm": 470, "inService": 2011,
-      "startPoint": { "lat": 54.14, "lon": 13.66 }, "endPoint": { "lat": 50.73, "lon": 14.03 },
-      "evidence": { "physicalState": "reduced", "physicalStateSource": "press", "operatorStatement": "Direct Nord Stream 1 continuation; flows reduced to zero post-Sep-2022 sabotage per OPAL operator notice + BBC coverage.", "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.8 }
+      "id": "opal-pipeline-germany",
+      "name": "OPAL Pipeline (Nord Stream continuation)",
+      "operator": "OPAL Gastransport (WIGA joint venture)",
+      "commodityType": "gas",
+      "fromCountry": "DE",
+      "toCountry": "CZ",
+      "transitCountries": [],
+      "capacityBcmYr": 36,
+      "lengthKm": 470,
+      "inService": 2011,
+      "startPoint": {
+        "lat": 54.14,
+        "lon": 13.66
+      },
+      "endPoint": {
+        "lat": 50.73,
+        "lon": 14.03
+      },
+      "evidence": {
+        "physicalState": "reduced",
+        "physicalStateSource": "press",
+        "operatorStatement": "Direct Nord Stream 1 continuation; flows reduced to zero post-Sep-2022 sabotage per OPAL operator notice + BBC coverage.",
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.8
+      }
     },
     "eugal-pipeline-germany": {
-      "id": "eugal-pipeline-germany", "name": "EUGAL Pipeline (Nord Stream 2 continuation)", "operator": "EUGAL Gastransport consortium", "commodityType": "gas",
-      "fromCountry": "DE", "toCountry": "CZ", "transitCountries": [],
-      "capacityBcmYr": 55, "lengthKm": 485, "inService": 2020,
-      "startPoint": { "lat": 54.14, "lon": 13.66 }, "endPoint": { "lat": 50.73, "lon": 14.03 },
+      "id": "eugal-pipeline-germany",
+      "name": "EUGAL Pipeline (Nord Stream 2 continuation)",
+      "operator": "EUGAL Gastransport consortium",
+      "commodityType": "gas",
+      "fromCountry": "DE",
+      "toCountry": "CZ",
+      "transitCountries": [],
+      "capacityBcmYr": 55,
+      "lengthKm": 485,
+      "inService": 2020,
+      "startPoint": {
+        "lat": 54.14,
+        "lon": 13.66
+      },
+      "endPoint": {
+        "lat": 50.73,
+        "lon": 14.03
+      },
       "evidence": {
-        "physicalState": "offline", "physicalStateSource": "press",
+        "physicalState": "offline",
+        "physicalStateSource": "press",
         "operatorStatement": {
           "text": "Built to carry Nord Stream 2 volumes into Central/Southern Europe; never reached commercial operation after NS2 certification was halted (Feb 2022) and NS2 was damaged (Sep 2022). Pipeline physically complete but dormant.",
           "url": "https://www.eugal.de/en/",
@@ -1388,63 +2143,217 @@
         },
         "commercialState": "suspended",
         "sanctionRefs": [
-          { "authority": "EU", "listId": "2022/1269 (energy sanctions package 8)", "date": "2022-10-06", "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R1269" }
+          {
+            "authority": "EU",
+            "listId": "2022/1269 (energy sanctions package 8)",
+            "date": "2022-10-06",
+            "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R1269"
+          }
         ],
-        "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.88
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.88
       }
     },
     "megal-pipeline": {
-      "id": "megal-pipeline", "name": "Mid-European Gas Pipeline (MEGAL)", "operator": "GRTgaz Deutschland / OGE", "commodityType": "gas",
-      "fromCountry": "DE", "toCountry": "FR", "transitCountries": [],
-      "capacityBcmYr": 37, "lengthKm": 1101, "inService": 1980,
-      "startPoint": { "lat": 48.93, "lon": 12.35 }, "endPoint": { "lat": 48.28, "lon": 6.97 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.88 }
+      "id": "megal-pipeline",
+      "name": "Mid-European Gas Pipeline (MEGAL)",
+      "operator": "GRTgaz Deutschland / OGE",
+      "commodityType": "gas",
+      "fromCountry": "DE",
+      "toCountry": "FR",
+      "transitCountries": [],
+      "capacityBcmYr": 37,
+      "lengthKm": 1101,
+      "inService": 1980,
+      "startPoint": {
+        "lat": 48.93,
+        "lon": 12.35
+      },
+      "endPoint": {
+        "lat": 48.28,
+        "lon": 6.97
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.88
+      }
     },
     "trans-austria-gas": {
-      "id": "trans-austria-gas", "name": "Trans Austria Gas Pipeline (TAG)", "operator": "Trans Austria Gasleitung GmbH", "commodityType": "gas",
-      "fromCountry": "AT", "toCountry": "IT", "transitCountries": [],
-      "capacityBcmYr": 45, "lengthKm": 380, "inService": 1974,
-      "startPoint": { "lat": 48.35, "lon": 16.87 }, "endPoint": { "lat": 45.90, "lon": 13.20 },
-      "evidence": { "physicalState": "reduced", "physicalStateSource": "press", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [
-        { "authority": "EU", "listId": "2022/1269 (energy sanctions package 8)", "date": "2022-10-06", "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R1269" }
-      ], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.82 }
+      "id": "trans-austria-gas",
+      "name": "Trans Austria Gas Pipeline (TAG)",
+      "operator": "Trans Austria Gasleitung GmbH",
+      "commodityType": "gas",
+      "fromCountry": "AT",
+      "toCountry": "IT",
+      "transitCountries": [],
+      "capacityBcmYr": 45,
+      "lengthKm": 380,
+      "inService": 1974,
+      "startPoint": {
+        "lat": 48.35,
+        "lon": 16.87
+      },
+      "endPoint": {
+        "lat": 45.9,
+        "lon": 13.2
+      },
+      "evidence": {
+        "physicalState": "reduced",
+        "physicalStateSource": "press",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [
+          {
+            "authority": "EU",
+            "listId": "2022/1269 (energy sanctions package 8)",
+            "date": "2022-10-06",
+            "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R1269"
+          }
+        ],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.82
+      }
     },
     "progress-urengoy-uzhhorod": {
-      "id": "progress-urengoy-uzhhorod", "name": "Urengoy–Pomary–Uzhhorod (Progress)", "operator": "Gazprom / Naftogaz", "commodityType": "gas",
-      "fromCountry": "RU", "toCountry": "SK", "transitCountries": ["UA"],
-      "capacityBcmYr": 32, "lengthKm": 4451, "inService": 1984,
-      "startPoint": { "lat": 65.97, "lon": 76.55 }, "endPoint": { "lat": 48.62, "lon": 22.30 },
-      "evidence": { "physicalState": "offline", "physicalStateSource": "regulator", "operatorStatement": {
-        "text": "Ukraine did not renew the 2019 transit agreement; transit via Sudzha halted 1 Jan 2025. Pipeline physically intact; flow zero.",
-        "url": "https://naftogaz.com/",
-        "date": "2025-01-01"
-      }, "commercialState": "expired", "sanctionRefs": [
-        { "authority": "EU", "listId": "2022/1269 (energy sanctions package 8)", "date": "2022-10-06", "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R1269" }
-      ], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.92 }
+      "id": "progress-urengoy-uzhhorod",
+      "name": "Urengoy–Pomary–Uzhhorod (Progress)",
+      "operator": "Gazprom / Naftogaz",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "SK",
+      "transitCountries": [
+        "UA"
+      ],
+      "capacityBcmYr": 32,
+      "lengthKm": 4451,
+      "inService": 1984,
+      "startPoint": {
+        "lat": 65.97,
+        "lon": 76.55
+      },
+      "endPoint": {
+        "lat": 48.62,
+        "lon": 22.3
+      },
+      "evidence": {
+        "physicalState": "offline",
+        "physicalStateSource": "regulator",
+        "operatorStatement": {
+          "text": "Ukraine did not renew the 2019 transit agreement; transit via Sudzha halted 1 Jan 2025. Pipeline physically intact; flow zero.",
+          "url": "https://naftogaz.com/",
+          "date": "2025-01-01"
+        },
+        "commercialState": "expired",
+        "sanctionRefs": [
+          {
+            "authority": "EU",
+            "listId": "2022/1269 (energy sanctions package 8)",
+            "date": "2022-10-06",
+            "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R1269"
+          }
+        ],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.92
+      }
     },
     "kish-iran-gas": {
-      "id": "kish-iran-gas", "name": "Kish Island–Iran Mainland Gas Pipeline", "operator": "NIGC", "commodityType": "gas",
-      "fromCountry": "IR", "toCountry": "IR", "transitCountries": [],
-      "capacityBcmYr": 2.5, "lengthKm": 42, "inService": 2010,
-      "startPoint": { "lat": 26.53, "lon": 53.95 }, "endPoint": { "lat": 27.20, "lon": 53.57 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [
-        { "authority": "US", "listId": "OFAC Iran energy sanctions framework", "date": "2018-08-07", "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions" }
-      ], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.75 }
+      "id": "kish-iran-gas",
+      "name": "Kish Island–Iran Mainland Gas Pipeline",
+      "operator": "NIGC",
+      "commodityType": "gas",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityBcmYr": 2.5,
+      "lengthKm": 42,
+      "inService": 2010,
+      "startPoint": {
+        "lat": 26.53,
+        "lon": 53.95
+      },
+      "endPoint": {
+        "lat": 27.2,
+        "lon": 53.57
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [
+          {
+            "authority": "US",
+            "listId": "OFAC Iran energy sanctions framework",
+            "date": "2018-08-07",
+            "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions"
+          }
+        ],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.75
+      }
     },
     "ghana-gas": {
-      "id": "ghana-gas", "name": "Ghana Gas Company Pipeline (Atuabo)", "operator": "Ghana National Gas Company", "commodityType": "gas",
-      "fromCountry": "GH", "toCountry": "GH", "transitCountries": [],
-      "capacityBcmYr": 1.5, "lengthKm": 111, "inService": 2015,
-      "startPoint": { "lat": 4.85, "lon": -2.33 }, "endPoint": { "lat": 4.90, "lon": -1.73 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.75 }
+      "id": "ghana-gas",
+      "name": "Ghana Gas Company Pipeline (Atuabo)",
+      "operator": "Ghana National Gas Company",
+      "commodityType": "gas",
+      "fromCountry": "GH",
+      "toCountry": "GH",
+      "transitCountries": [],
+      "capacityBcmYr": 1.5,
+      "lengthKm": 111,
+      "inService": 2015,
+      "startPoint": {
+        "lat": 4.85,
+        "lon": -2.33
+      },
+      "endPoint": {
+        "lat": 4.9,
+        "lon": -1.73
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.75
+      }
     },
     "iran-pakistan-gas-planned": {
-      "id": "iran-pakistan-gas-planned", "name": "Iran–Pakistan Gas Pipeline (Peace, Pakistani segment stalled)", "operator": "NIGC / ISGS Pakistan", "commodityType": "gas",
-      "fromCountry": "IR", "toCountry": "PK", "transitCountries": [],
-      "capacityBcmYr": 11, "lengthKm": 1931, "inService": 0,
-      "startPoint": { "lat": 25.62, "lon": 60.90 }, "endPoint": { "lat": 25.00, "lon": 67.03 },
+      "id": "iran-pakistan-gas-planned",
+      "name": "Iran–Pakistan Gas Pipeline (Peace, Pakistani segment stalled)",
+      "operator": "NIGC / ISGS Pakistan",
+      "commodityType": "gas",
+      "fromCountry": "IR",
+      "toCountry": "PK",
+      "transitCountries": [],
+      "capacityBcmYr": 11,
+      "lengthKm": 1931,
+      "inService": 0,
+      "startPoint": {
+        "lat": 25.62,
+        "lon": 60.9
+      },
+      "endPoint": {
+        "lat": 25,
+        "lon": 67.03
+      },
       "evidence": {
-        "physicalState": "unknown", "physicalStateSource": "press",
+        "physicalState": "unknown",
+        "physicalStateSource": "press",
         "operatorStatement": {
           "text": "Iranian segment completed to border 2013. Pakistani segment stalled since 2014 amid US sanction risk on completion; NIOC served arbitration notice 2023. Pipeline not operational end-to-end.",
           "url": "https://isgs.gov.pk/",
@@ -1452,31 +2361,6796 @@
         },
         "commercialState": "expired",
         "sanctionRefs": [
-          { "authority": "US", "listId": "OFAC Iran energy sanctions framework (applied to Pakistani completion)", "date": "2018-08-07", "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions" }
+          {
+            "authority": "US",
+            "listId": "OFAC Iran energy sanctions framework (applied to Pakistani completion)",
+            "date": "2018-08-07",
+            "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions"
+          }
         ],
-        "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.8
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.8
       }
     },
     "gascade-jagal": {
-      "id": "gascade-jagal", "name": "JAGAL (North German gas link)", "operator": "GASCADE", "commodityType": "gas",
-      "fromCountry": "DE", "toCountry": "DE", "transitCountries": [],
-      "capacityBcmYr": 16, "lengthKm": 340, "inService": 1999,
-      "startPoint": { "lat": 53.87, "lon": 14.27 }, "endPoint": { "lat": 51.87, "lon": 10.57 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.8 }
+      "id": "gascade-jagal",
+      "name": "JAGAL (North German gas link)",
+      "operator": "GASCADE",
+      "commodityType": "gas",
+      "fromCountry": "DE",
+      "toCountry": "DE",
+      "transitCountries": [],
+      "capacityBcmYr": 16,
+      "lengthKm": 340,
+      "inService": 1999,
+      "startPoint": {
+        "lat": 53.87,
+        "lon": 14.27
+      },
+      "endPoint": {
+        "lat": 51.87,
+        "lon": 10.57
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.8
+      }
     },
     "zeelink-germany": {
-      "id": "zeelink-germany", "name": "ZEELINK (H-gas conversion pipeline)", "operator": "OGE / Thyssengas", "commodityType": "gas",
-      "fromCountry": "BE", "toCountry": "DE", "transitCountries": [],
-      "capacityBcmYr": 10, "lengthKm": 216, "inService": 2021,
-      "startPoint": { "lat": 51.33, "lon": 3.20 }, "endPoint": { "lat": 50.33, "lon": 7.57 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.85 }
+      "id": "zeelink-germany",
+      "name": "ZEELINK (H-gas conversion pipeline)",
+      "operator": "OGE / Thyssengas",
+      "commodityType": "gas",
+      "fromCountry": "BE",
+      "toCountry": "DE",
+      "transitCountries": [],
+      "capacityBcmYr": 10,
+      "lengthKm": 216,
+      "inService": 2021,
+      "startPoint": {
+        "lat": 51.33,
+        "lon": 3.2
+      },
+      "endPoint": {
+        "lat": 50.33,
+        "lon": 7.57
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.85
+      }
     },
     "china-hong-kong-gas": {
-      "id": "china-hong-kong-gas", "name": "Mainland–Hong Kong Gas Pipeline", "operator": "CNOOC Gas & Power / Towngas", "commodityType": "gas",
-      "fromCountry": "CN", "toCountry": "HK", "transitCountries": [],
-      "capacityBcmYr": 2.5, "lengthKm": 92, "inService": 2006,
-      "startPoint": { "lat": 22.68, "lon": 113.83 }, "endPoint": { "lat": 22.35, "lon": 114.18 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.8 }
+      "id": "china-hong-kong-gas",
+      "name": "Mainland–Hong Kong Gas Pipeline",
+      "operator": "CNOOC Gas & Power / Towngas",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "HK",
+      "transitCountries": [],
+      "capacityBcmYr": 2.5,
+      "lengthKm": 92,
+      "inService": 2006,
+      "startPoint": {
+        "lat": 22.68,
+        "lon": 113.83
+      },
+      "endPoint": {
+        "lat": 22.35,
+        "lon": 114.18
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.8
+      }
+    },
+    "acadian-gas-pipeline-system-us": {
+      "id": "acadian-gas-pipeline-system-us",
+      "name": "Acadian Gas Pipeline System",
+      "operator": "Enterprise Products Partners [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 10.22,
+      "lengthKm": 1609.34,
+      "inService": 0,
+      "startPoint": {
+        "lat": 32.217872,
+        "lon": -93.715924
+      },
+      "endPoint": {
+        "lat": 30.437255,
+        "lon": -91.179409
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "access-south-gas-pipeline-us": {
+      "id": "access-south-gas-pipeline-us",
+      "name": "Access South Gas Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 3.27,
+      "lengthKm": 1287,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 39.869262,
+        "lon": -80.189121
+      },
+      "endPoint": {
+        "lat": 33.020389,
+        "lon": -89.355913
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "al-ndalus-gas-pipeline-es": {
+      "id": "al-ndalus-gas-pipeline-es",
+      "name": "Al Ándalus Gas Pipeline",
+      "operator": "Enagás [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "ES",
+      "toCountry": "ES",
+      "transitCountries": [],
+      "capacityBcmYr": 12,
+      "lengthKm": 884,
+      "inService": 1996,
+      "startPoint": {
+        "lat": 36.2,
+        "lon": -6.007
+      },
+      "endPoint": {
+        "lat": 36.765,
+        "lon": -3.617
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "algonquin-gas-transmission-pipeline-us": {
+      "id": "algonquin-gas-transmission-pipeline-us",
+      "name": "Algonquin Gas Transmission Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 31.89,
+      "lengthKm": 1820.17,
+      "inService": 1997,
+      "startPoint": {
+        "lat": 40.361664,
+        "lon": -74.940096
+      },
+      "endPoint": {
+        "lat": 42.491592,
+        "lon": -70.829481
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "alliance-gas-pipeline-ca": {
+      "id": "alliance-gas-pipeline-ca",
+      "name": "Alliance Gas Pipeline",
+      "operator": "Alliance USA [50.00%]; Alliance Canada [50.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 16.35,
+      "lengthKm": 3848,
+      "inService": 2000,
+      "startPoint": {
+        "lat": 54.597543,
+        "lon": -118.234573
+      },
+      "endPoint": {
+        "lat": 41.459706,
+        "lon": -88.132283
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "amadeus-gas-pipeline-au": {
+      "id": "amadeus-gas-pipeline-au",
+      "name": "Amadeus Gas Pipeline",
+      "operator": "APA Group [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityBcmYr": 1.66,
+      "lengthKm": 1658,
+      "inService": 1986,
+      "startPoint": {
+        "lat": -23.98548,
+        "lon": 131.551069
+      },
+      "endPoint": {
+        "lat": -12.555919,
+        "lon": 130.879921
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "anaco-barquisimeto-gas-pipeline-ve": {
+      "id": "anaco-barquisimeto-gas-pipeline-ve",
+      "name": "Anaco-Barquisimeto Gas Pipeline",
+      "operator": "PDVSA [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "VE",
+      "toCountry": "VE",
+      "transitCountries": [],
+      "capacityBcmYr": 10,
+      "lengthKm": 2470,
+      "inService": 1950,
+      "startPoint": {
+        "lat": 9.309778,
+        "lon": -64.7002
+      },
+      "endPoint": {
+        "lat": 10.06735,
+        "lon": -69.379
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "anaco-puerto-la-cruz-gas-pipeline-ve": {
+      "id": "anaco-puerto-la-cruz-gas-pipeline-ve",
+      "name": "Anaco-Puerto La Cruz Gas Pipeline",
+      "operator": "PDVSA [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "VE",
+      "toCountry": "VE",
+      "transitCountries": [],
+      "capacityBcmYr": 6.13,
+      "lengthKm": 772,
+      "inService": 1951,
+      "startPoint": {
+        "lat": 9.438541,
+        "lon": -64.472408
+      },
+      "endPoint": {
+        "lat": 10.237455,
+        "lon": -64.627708
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "anaco-puerto-ordaz-gas-pipeline-ve": {
+      "id": "anaco-puerto-ordaz-gas-pipeline-ve",
+      "name": "Anaco-Puerto Ordaz Gas Pipeline",
+      "operator": "PDVSA [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "VE",
+      "toCountry": "VE",
+      "transitCountries": [],
+      "capacityBcmYr": 6.29,
+      "lengthKm": 779,
+      "inService": 1970,
+      "startPoint": {
+        "lat": 8.214898,
+        "lon": -62.9879
+      },
+      "endPoint": {
+        "lat": 9.35787,
+        "lon": -64.7321
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "anr-gas-pipeline-us": {
+      "id": "anr-gas-pipeline-us",
+      "name": "ANR Gas Pipeline",
+      "operator": "ANR Pipeline Co [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 61.32,
+      "lengthKm": 2896.82,
+      "inService": 1949,
+      "startPoint": {
+        "lat": 36.537197,
+        "lon": -99.817135
+      },
+      "endPoint": {
+        "lat": 43.431261,
+        "lon": -85.524911
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "atacama-gas-pipeline-ar": {
+      "id": "atacama-gas-pipeline-ar",
+      "name": "Atacama Gas Pipeline",
+      "operator": "Enel Generación Chile SA [97.40%]; other [2.60%]",
+      "commodityType": "gas",
+      "fromCountry": "AR",
+      "toCountry": "CL",
+      "transitCountries": [],
+      "capacityBcmYr": 1.97,
+      "lengthKm": 1167,
+      "inService": 1999,
+      "startPoint": {
+        "lat": -22.679575,
+        "lon": -68.487256
+      },
+      "endPoint": {
+        "lat": -23.232801,
+        "lon": -67.060657
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "atmos-pipeline-texas-us": {
+      "id": "atmos-pipeline-texas-us",
+      "name": "Atmos Pipeline Texas",
+      "operator": "Atmos Energy Corp [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 1.84,
+      "lengthKm": 9173.26,
+      "inService": 0,
+      "startPoint": {
+        "lat": 31.312,
+        "lon": -103.09
+      },
+      "endPoint": {
+        "lat": 33.61,
+        "lon": -95.624
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "bc-gas-pipeline-westcoast-pipeline-ca": {
+      "id": "bc-gas-pipeline-westcoast-pipeline-ca",
+      "name": "BC Gas Pipeline - Westcoast Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 34.75,
+      "lengthKm": 2953,
+      "inService": 1957,
+      "startPoint": {
+        "lat": 56.0877,
+        "lon": -120.666
+      },
+      "endPoint": {
+        "lat": 55.863701,
+        "lon": -120.197998
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "beineu-bozoy-shymkent-gas-pipeline-i-kz": {
+      "id": "beineu-bozoy-shymkent-gas-pipeline-i-kz",
+      "name": "Beineu-Bozoy-Shymkent Gas Pipeline - I",
+      "operator": "QazaqGaz [50.00%]; Trans-Asia Gas Pipeline Co Ltd [50.00%]",
+      "commodityType": "gas",
+      "fromCountry": "KZ",
+      "toCountry": "KZ",
+      "transitCountries": [],
+      "capacityBcmYr": 15,
+      "lengthKm": 1449,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 45.240584,
+        "lon": 55.235174
+      },
+      "endPoint": {
+        "lat": 42.369174,
+        "lon": 69.918462
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "belogorsk-khabarovsk-gas-pipeline-ru": {
+      "id": "belogorsk-khabarovsk-gas-pipeline-ru",
+      "name": "Belogorsk-Khabarovsk Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 28,
+      "lengthKm": 828,
+      "inService": 2027,
+      "startPoint": {
+        "lat": 51.559226,
+        "lon": 128.203053
+      },
+      "endPoint": {
+        "lat": 48.59364,
+        "lon": 135.599442
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "belousovo-leningrad-gas-pipeline-ru": {
+      "id": "belousovo-leningrad-gas-pipeline-ru",
+      "name": "Belousovo-Leningrad Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 7,
+      "lengthKm": 765,
+      "inService": 1964,
+      "startPoint": {
+        "lat": 55.11288,
+        "lon": 36.684149
+      },
+      "endPoint": {
+        "lat": 60.128929,
+        "lon": 30.339904
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "blue-stream-gas-pipeline-ru": {
+      "id": "blue-stream-gas-pipeline-ru",
+      "name": "Blue Stream Gas Pipeline",
+      "operator": "Gazprom PJSC [50.00%]; Eni SpA; BOTAŞ",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "TR",
+      "transitCountries": [],
+      "capacityBcmYr": 16,
+      "lengthKm": 1213,
+      "inService": 2003,
+      "startPoint": {
+        "lat": 40.573855,
+        "lon": 35.157065
+      },
+      "endPoint": {
+        "lat": 40.814143,
+        "lon": 35.692436
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "bovanenkovo-ukhta-gas-pipeline-pipeline-1-ru": {
+      "id": "bovanenkovo-ukhta-gas-pipeline-pipeline-1-ru",
+      "name": "Bovanenkovo-Ukhta Gas Pipeline - Pipeline 1",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 57.5,
+      "lengthKm": 1200,
+      "inService": 2012,
+      "startPoint": {
+        "lat": 64.926654,
+        "lon": 56.631649
+      },
+      "endPoint": {
+        "lat": 68.015787,
+        "lon": 65.13476
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "bovanenkovo-ukhta-gas-pipeline-pipeline-2-ru": {
+      "id": "bovanenkovo-ukhta-gas-pipeline-pipeline-2-ru",
+      "name": "Bovanenkovo-Ukhta Gas Pipeline - Pipeline 2",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 57.5,
+      "lengthKm": 1200,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 68.81146,
+        "lon": 66.87679
+      },
+      "endPoint": {
+        "lat": 68.004278,
+        "lon": 65.108622
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "bridgeline-gas-pipeline-us": {
+      "id": "bridgeline-gas-pipeline-us",
+      "name": "Bridgeline Gas Pipeline",
+      "operator": "EnLink Midstream [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 9.4,
+      "lengthKm": 1585,
+      "inService": 2000,
+      "startPoint": {
+        "lat": 29.764438,
+        "lon": -93.907285
+      },
+      "endPoint": {
+        "lat": 29.701481,
+        "lon": -91.207021
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "bukhara-tashkent-bishkek-almaty-gas-pipeline-i-uz": {
+      "id": "bukhara-tashkent-bishkek-almaty-gas-pipeline-i-uz",
+      "name": "Bukhara-Tashkent-Bishkek-Almaty Gas Pipeline - I",
+      "operator": "Uztransgaz; QazaqGaz; Gazprom Kyrgyzstan",
+      "commodityType": "gas",
+      "fromCountry": "UZ",
+      "toCountry": "KZ",
+      "transitCountries": [
+        "KG"
+      ],
+      "capacityBcmYr": 12,
+      "lengthKm": 1585,
+      "inService": 1971,
+      "startPoint": {
+        "lat": 39.721974,
+        "lon": 64.534295
+      },
+      "endPoint": {
+        "lat": 42.253233,
+        "lon": 70.032407
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "bukhara-ural-gas-pipeline-i-uz": {
+      "id": "bukhara-ural-gas-pipeline-i-uz",
+      "name": "Bukhara-Ural Gas Pipeline - I",
+      "operator": "--",
+      "commodityType": "gas",
+      "fromCountry": "UZ",
+      "toCountry": "RU",
+      "transitCountries": [
+        "TM",
+        "KZ"
+      ],
+      "capacityBcmYr": 21,
+      "lengthKm": 2200,
+      "inService": 1963,
+      "startPoint": {
+        "lat": 40.153802,
+        "lon": 63.485626
+      },
+      "endPoint": {
+        "lat": 55.154808,
+        "lon": 61.42395
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "bulgaria-national-gas-transmission-network-system-network-in-bg": {
+      "id": "bulgaria-national-gas-transmission-network-system-network-in-bg",
+      "name": "Bulgaria National Gas Transmission Network - SYSTEM/NETWORK INFO",
+      "operator": "Bulgartransgaz [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "BG",
+      "toCountry": "BG",
+      "transitCountries": [],
+      "capacityBcmYr": 25.2,
+      "lengthKm": 3276,
+      "inService": 0,
+      "startPoint": {
+        "lat": 42.4382,
+        "lon": 23.8162
+      },
+      "endPoint": {
+        "lat": 42.614841,
+        "lon": 23.041768
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "canadian-mainline-gas-pipeline-ca": {
+      "id": "canadian-mainline-gas-pipeline-ca",
+      "name": "Canadian Mainline Gas Pipeline",
+      "operator": "TransCanada PipeLines Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityBcmYr": 71.18,
+      "lengthKm": 14082,
+      "inService": 1955,
+      "startPoint": {
+        "lat": 43.085493,
+        "lon": -79.195757
+      },
+      "endPoint": {
+        "lat": 50.606519,
+        "lon": -108.697972
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "carpentaria-gas-pipeline-au": {
+      "id": "carpentaria-gas-pipeline-au",
+      "name": "Carpentaria Gas Pipeline",
+      "operator": "Carpentaria Gas Pipeline Joint Venture [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityBcmYr": 1.19,
+      "lengthKm": 840,
+      "inService": 1998,
+      "startPoint": {
+        "lat": -20.780624,
+        "lon": 139.48417
+      },
+      "endPoint": {
+        "lat": -27.387921,
+        "lon": 141.807398
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "central-asia-center-gas-pipeline-cac-2-tm": {
+      "id": "central-asia-center-gas-pipeline-cac-2-tm",
+      "name": "Central Asia–Center Gas Pipeline - CAC-2",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "TM",
+      "toCountry": "RU",
+      "transitCountries": [
+        "UZ",
+        "KZ"
+      ],
+      "capacityBcmYr": 60.2,
+      "lengthKm": 2662,
+      "inService": 1970,
+      "startPoint": {
+        "lat": 55.239044,
+        "lon": 38.802016
+      },
+      "endPoint": {
+        "lat": 52.265924,
+        "lon": 45.413403
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "central-asia-center-gas-pipeline-cac-3-tm": {
+      "id": "central-asia-center-gas-pipeline-cac-3-tm",
+      "name": "Central Asia–Center Gas Pipeline - CAC-3",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "TM",
+      "toCountry": "RU",
+      "transitCountries": [
+        "UZ",
+        "KZ"
+      ],
+      "capacityBcmYr": 5,
+      "lengthKm": 2600,
+      "inService": 1975,
+      "startPoint": {
+        "lat": 45.313772,
+        "lon": 55.250129
+      },
+      "endPoint": {
+        "lat": 50.129452,
+        "lon": 38.126153
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "central-asia-china-gas-pipeline-line-c-tm": {
+      "id": "central-asia-china-gas-pipeline-line-c-tm",
+      "name": "Central Asia–China Gas Pipeline - Line C",
+      "operator": "China National Petroleum Corp; Turkmengaz; Uztransgaz; QazaqGaz",
+      "commodityType": "gas",
+      "fromCountry": "TM",
+      "toCountry": "CN",
+      "transitCountries": [
+        "UZ",
+        "KZ"
+      ],
+      "capacityBcmYr": 25,
+      "lengthKm": 1833,
+      "inService": 2014,
+      "startPoint": {
+        "lat": 38.612094,
+        "lon": 64.755208
+      },
+      "endPoint": {
+        "lat": 44.068771,
+        "lon": 80.441261
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "centro-oeste-gas-pipeline-ar": {
+      "id": "centro-oeste-gas-pipeline-ar",
+      "name": "Centro Oeste Gas Pipeline",
+      "operator": "GasInvest SA [56.00%]; Southern Cone Energy Holding Co Inc [24.00%]; Bolsas y Mercados Argentinos SA [20.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AR",
+      "toCountry": "AR",
+      "transitCountries": [],
+      "capacityBcmYr": 11.68,
+      "lengthKm": 1121,
+      "inService": 1981,
+      "startPoint": {
+        "lat": -35.10311,
+        "lon": -66.828211
+      },
+      "endPoint": {
+        "lat": -33.477847,
+        "lon": -67.555948
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "chelyabinsk-petrovsk-gas-pipeline-ru": {
+      "id": "chelyabinsk-petrovsk-gas-pipeline-ru",
+      "name": "Chelyabinsk-Petrovsk Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 37.12,
+      "lengthKm": 1285,
+      "inService": 1980,
+      "startPoint": {
+        "lat": 55.178827,
+        "lon": 61.411506
+      },
+      "endPoint": {
+        "lat": 52.316082,
+        "lon": 45.393535
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "china-russia-east-pipeline-phase-i-cn": {
+      "id": "china-russia-east-pipeline-phase-i-cn",
+      "name": "China–Russia East Pipeline - Phase I",
+      "operator": "National Pipe Network Group North Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 38,
+      "lengthKm": 1067,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 51.572642,
+        "lon": 128.193026
+      },
+      "endPoint": {
+        "lat": 43.35972,
+        "lon": 123.644593
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "china-russia-east-pipeline-phase-ii-cn": {
+      "id": "china-russia-east-pipeline-phase-ii-cn",
+      "name": "China–Russia East Pipeline - Phase II",
+      "operator": "National Pipe Network Group North Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 38,
+      "lengthKm": 1110,
+      "inService": 2020,
+      "startPoint": {
+        "lat": 43.35972,
+        "lon": 123.644593
+      },
+      "endPoint": {
+        "lat": 39.297164,
+        "lon": 116.51979
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "china-russia-east-pipeline-phase-iii-cn": {
+      "id": "china-russia-east-pipeline-phase-iii-cn",
+      "name": "China–Russia East Pipeline - Phase III",
+      "operator": "Construction Project Management Branch of China National Petroleum Pipeline Network Group Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 18.9,
+      "lengthKm": 1509,
+      "inService": 2024,
+      "startPoint": {
+        "lat": 39.297164,
+        "lon": 116.51979
+      },
+      "endPoint": {
+        "lat": 31.266851,
+        "lon": 121.131321
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "china-russia-east-pipeline-system-network-info-cn": {
+      "id": "china-russia-east-pipeline-system-network-info-cn",
+      "name": "China–Russia East Pipeline - SYSTEM/NETWORK INFO",
+      "operator": "National Pipe Network Group North Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 38,
+      "lengthKm": 5111,
+      "inService": 2022,
+      "startPoint": {
+        "lat": 39.297164,
+        "lon": 116.51979
+      },
+      "endPoint": {
+        "lat": 39.297164,
+        "lon": 116.51979
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "china-russia-far-east-gas-pipeline-hulin-changchun-trunk-lin-cn": {
+      "id": "china-russia-far-east-gas-pipeline-hulin-changchun-trunk-lin-cn",
+      "name": "China–Russia Far East Gas Pipeline - Hulin–Changchun Trunk Line",
+      "operator": "National Pipe Network Group North Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 10,
+      "lengthKm": 860,
+      "inService": 2025,
+      "startPoint": {
+        "lat": 44.167126,
+        "lon": 125.370384
+      },
+      "endPoint": {
+        "lat": 44.158577,
+        "lon": 125.368198
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "cnpc-sichuan-chongqing-gas-pipeline-network-cn": {
+      "id": "cnpc-sichuan-chongqing-gas-pipeline-network-cn",
+      "name": "CNPC Sichuan & Chongqing Gas Pipeline Network",
+      "operator": "China National Petroleum Corp Southwest Oil and Gas Field Branch [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 30,
+      "lengthKm": 9227,
+      "inService": 1967,
+      "startPoint": {
+        "lat": 31.786699,
+        "lon": 104.892998
+      },
+      "endPoint": {
+        "lat": 29.862301,
+        "lon": 107.081001
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "colorado-interstate-gas-pipeline-us": {
+      "id": "colorado-interstate-gas-pipeline-us",
+      "name": "Colorado Interstate Gas Pipeline",
+      "operator": "Kinder Morgan [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 52.63,
+      "lengthKm": 6920,
+      "inService": 2008,
+      "startPoint": {
+        "lat": 40.95066,
+        "lon": -104.794993
+      },
+      "endPoint": {
+        "lat": 40.193114,
+        "lon": -103.813059
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "columbia-gas-transmission-system-network-info-us": {
+      "id": "columbia-gas-transmission-system-network-info-us",
+      "name": "Columbia Gas Transmission - SYSTEM/NETWORK INFO",
+      "operator": "Columbia Gas Transmission LLC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 30.66,
+      "lengthKm": 19312,
+      "inService": 1996,
+      "startPoint": {
+        "lat": 40.612179,
+        "lon": -81.821721
+      },
+      "endPoint": {
+        "lat": 40.994508,
+        "lon": -83.630923
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "cordillerano-patag-nico-gas-pipeline-cordillerano-north-ar": {
+      "id": "cordillerano-patag-nico-gas-pipeline-cordillerano-north-ar",
+      "name": "Cordillerano-Patagónico Gas Pipeline - Cordillerano (North)",
+      "operator": "CIESA-Compañía de Inversiones de Energía SA [51.00%]; ANSES-Administración Nacional de la Seguridad Social [24.00%]; NYSE-New York Stock Exchange [12.00%]; BYMA-Bolsas y Mercados Argentinos SA [8.00%]; other [5.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AR",
+      "toCountry": "AR",
+      "transitCountries": [],
+      "capacityBcmYr": 0.48,
+      "lengthKm": 940,
+      "inService": 1986,
+      "startPoint": {
+        "lat": -42.930415,
+        "lon": -71.251405
+      },
+      "endPoint": {
+        "lat": -38.910459,
+        "lon": -69.17671
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "dabhol-bangalore-gas-pipeline-in": {
+      "id": "dabhol-bangalore-gas-pipeline-in",
+      "name": "Dabhol-Bangalore Gas Pipeline",
+      "operator": "GAIL (India) Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 5.84,
+      "lengthKm": 1386,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 17.587163,
+        "lon": 73.157882
+      },
+      "endPoint": {
+        "lat": 12.944857,
+        "lon": 77.290154
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "dadri-bawana-nangal-gas-pipeline-in": {
+      "id": "dadri-bawana-nangal-gas-pipeline-in",
+      "name": "Dadri-Bawana-Nangal Gas Pipeline",
+      "operator": "GAIL (India) Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 11.32,
+      "lengthKm": 886,
+      "inService": 2012,
+      "startPoint": {
+        "lat": 28.551572,
+        "lon": 77.537104
+      },
+      "endPoint": {
+        "lat": 31.384701,
+        "lon": 76.3597
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "dahej-uran-panvel-dhabhol-gas-pipeline-in": {
+      "id": "dahej-uran-panvel-dhabhol-gas-pipeline-in",
+      "name": "Dahej-Uran-Panvel-Dhabhol Gas Pipeline",
+      "operator": "GAIL (India) Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 7.26,
+      "lengthKm": 815,
+      "inService": 2007,
+      "startPoint": {
+        "lat": 17.539275,
+        "lon": 73.159589
+      },
+      "endPoint": {
+        "lat": 21.680119,
+        "lon": 72.537816
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "dahej-vijaipur-gas-pipeline-dvpl-i-in": {
+      "id": "dahej-vijaipur-gas-pipeline-dvpl-i-in",
+      "name": "Dahej-Vijaipur Gas Pipeline (DVPL-I)",
+      "operator": "GAIL (India) Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 39.06,
+      "lengthKm": 770,
+      "inService": 2004,
+      "startPoint": {
+        "lat": 21.727732,
+        "lon": 72.554908
+      },
+      "endPoint": {
+        "lat": 24.489186,
+        "lon": 77.137452
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "dampier-to-bunbury-natural-gas-pipeline-au": {
+      "id": "dampier-to-bunbury-natural-gas-pipeline-au",
+      "name": "Dampier to Bunbury Natural Gas Pipeline",
+      "operator": "DUET Group [80.00%]; Alcoa [20.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityBcmYr": 8.67,
+      "lengthKm": 1597,
+      "inService": 1984,
+      "startPoint": {
+        "lat": -33.265797,
+        "lon": 115.755682
+      },
+      "endPoint": {
+        "lat": -24.86854,
+        "lon": 113.674968
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "dashava-kiev-bryansk-moscow-gas-pipeline-ua": {
+      "id": "dashava-kiev-bryansk-moscow-gas-pipeline-ua",
+      "name": "Dashava-Kiev-Bryansk-Moscow Gas Pipeline",
+      "operator": "Gazprom PJSC; Gas Transmission System Operator of Ukraine",
+      "commodityType": "gas",
+      "fromCountry": "UA",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 1.8,
+      "lengthKm": 1301,
+      "inService": 1952,
+      "startPoint": {
+        "lat": 49.26252,
+        "lon": 24.011517
+      },
+      "endPoint": {
+        "lat": 55.724292,
+        "lon": 37.602831
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "dominion-gas-pipeline-us": {
+      "id": "dominion-gas-pipeline-us",
+      "name": "Dominion Gas Pipeline",
+      "operator": "Dominion Energy [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 73.58,
+      "lengthKm": 6059,
+      "inService": 2001,
+      "startPoint": {
+        "lat": 38.388272,
+        "lon": -76.409351
+      },
+      "endPoint": {
+        "lat": 41.66192,
+        "lon": -83.578698
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "east-tennessee-gas-pipeline-us": {
+      "id": "east-tennessee-gas-pipeline-us",
+      "name": "East Tennessee Gas Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 19.01,
+      "lengthKm": 2456,
+      "inService": 1996,
+      "startPoint": {
+        "lat": 36.518166,
+        "lon": -79.656692
+      },
+      "endPoint": {
+        "lat": 36.795513,
+        "lon": -81.793067
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "east-west-gas-pipeline-india-in": {
+      "id": "east-west-gas-pipeline-india-in",
+      "name": "East West Gas Pipeline (India)",
+      "operator": "India Infrastructure Trust [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 31.03,
+      "lengthKm": 1375,
+      "inService": 2008,
+      "startPoint": {
+        "lat": 16.927682,
+        "lon": 82.254747
+      },
+      "endPoint": {
+        "lat": 16.033857,
+        "lon": 80.851841
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "east-west-gas-pipeline-tm": {
+      "id": "east-west-gas-pipeline-tm",
+      "name": "East-West Gas Pipeline",
+      "operator": "Turkmengaz [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "TM",
+      "toCountry": "TM",
+      "transitCountries": [],
+      "capacityBcmYr": 30,
+      "lengthKm": 773,
+      "inService": 2015,
+      "startPoint": {
+        "lat": 39.992063,
+        "lon": 53.6471
+      },
+      "endPoint": {
+        "lat": 37.593518,
+        "lon": 61.380019
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "eastern-gas-pipeline-au": {
+      "id": "eastern-gas-pipeline-au",
+      "name": "Eastern Gas Pipeline",
+      "operator": "Jemena [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityBcmYr": 3.44,
+      "lengthKm": 797,
+      "inService": 2000,
+      "startPoint": {
+        "lat": -38.203,
+        "lon": 147.159
+      },
+      "endPoint": {
+        "lat": -33.832,
+        "lon": 150.864
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "eastern-gas-transmission-and-storage-system-egts-us": {
+      "id": "eastern-gas-transmission-and-storage-system-egts-us",
+      "name": "Eastern Gas Transmission and Storage System (EGTS)",
+      "operator": "Eastern Gas Transmission and Storage Inc [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 97.09,
+      "lengthKm": 6437.38,
+      "inService": 0,
+      "startPoint": {
+        "lat": 42.881063,
+        "lon": -74.667513
+      },
+      "endPoint": {
+        "lat": 42.673342,
+        "lon": -78.064986
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "el-paso-gas-pipeline-us": {
+      "id": "el-paso-gas-pipeline-us",
+      "name": "El Paso Gas Pipeline",
+      "operator": "Kinder Morgan [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 57.23,
+      "lengthKm": 16318.75,
+      "inService": 1997,
+      "startPoint": {
+        "lat": 35.162131,
+        "lon": -107.835606
+      },
+      "endPoint": {
+        "lat": 32.316549,
+        "lon": -109.68817
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "enable-gas-transmission-us": {
+      "id": "enable-gas-transmission-us",
+      "name": "Enable Gas Transmission",
+      "operator": "Enable Gas Transmission LLC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 67.45,
+      "lengthKm": 9495,
+      "inService": 0,
+      "startPoint": {
+        "lat": 35.642008,
+        "lon": -100.239958
+      },
+      "endPoint": {
+        "lat": 33.955054,
+        "lon": -93.150311
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "enable-oklahoma-instrastate-transmission-eoit-us": {
+      "id": "enable-oklahoma-instrastate-transmission-eoit-us",
+      "name": "Enable Oklahoma Instrastate Transmission (EOIT)",
+      "operator": "Enable Midstream Partners LP [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 23.51,
+      "lengthKm": 3540,
+      "inService": 0,
+      "startPoint": {
+        "lat": 36.652182,
+        "lon": -98.764464
+      },
+      "endPoint": {
+        "lat": 34.635376,
+        "lon": -95.807731
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "energia-mayakan-pipeline-mx": {
+      "id": "energia-mayakan-pipeline-mx",
+      "name": "Energia Mayakan Pipeline",
+      "operator": "Engie SA [67.50%]; General Electric Co; Mexico Infrastructure Partners",
+      "commodityType": "gas",
+      "fromCountry": "MX",
+      "toCountry": "MX",
+      "transitCountries": [],
+      "capacityBcmYr": 2.56,
+      "lengthKm": 775,
+      "inService": 1999,
+      "startPoint": {
+        "lat": 20.693056,
+        "lon": -88.267497
+      },
+      "endPoint": {
+        "lat": 17.864064,
+        "lon": -93.119699
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "ennore-tuticorn-bengalaru-gas-pipeline-in": {
+      "id": "ennore-tuticorn-bengalaru-gas-pipeline-in",
+      "name": "Ennore-Tuticorn-Bengalaru Gas Pipeline",
+      "operator": "Indian Oil Corp [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 30.9,
+      "lengthKm": 1431,
+      "inService": 2025,
+      "startPoint": {
+        "lat": 13.215734,
+        "lon": 80.320196
+      },
+      "endPoint": {
+        "lat": 12.712817,
+        "lon": 77.328962
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "florida-gas-transmission-pipeline-system-network-info-us": {
+      "id": "florida-gas-transmission-pipeline-system-network-info-us",
+      "name": "Florida Gas Transmission Pipeline - SYSTEM/NETWORK INFO",
+      "operator": "Florida Gas Transmission Co LLC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 10.83,
+      "lengthKm": 8529.52,
+      "inService": 1998,
+      "startPoint": {
+        "lat": 30.041463,
+        "lon": -82.160287
+      },
+      "endPoint": {
+        "lat": 27.23785,
+        "lon": -81.046694
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "foothills-system-gas-pipeline-ca": {
+      "id": "foothills-system-gas-pipeline-ca",
+      "name": "Foothills System Gas Pipeline",
+      "operator": "TransCanada PipeLines Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityBcmYr": 33.73,
+      "lengthKm": 1237,
+      "inService": 1981,
+      "startPoint": {
+        "lat": 51.945599,
+        "lon": -114.740434
+      },
+      "endPoint": {
+        "lat": 50.338095,
+        "lon": -109.572735
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "franpipe-gas-pipeline-no": {
+      "id": "franpipe-gas-pipeline-no",
+      "name": "Franpipe Gas Pipeline",
+      "operator": "Gassco [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "NO",
+      "toCountry": "FR",
+      "transitCountries": [],
+      "capacityBcmYr": 19.78,
+      "lengthKm": 840,
+      "inService": 1998,
+      "startPoint": {
+        "lat": 58.188694,
+        "lon": 2.466666
+      },
+      "endPoint": {
+        "lat": 51.046406,
+        "lon": 2.252709
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gas-transmission-northwest-ca": {
+      "id": "gas-transmission-northwest-ca",
+      "name": "Gas Transmission Northwest",
+      "operator": "TC Energy [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 29.64,
+      "lengthKm": 2177.44,
+      "inService": 1961,
+      "startPoint": {
+        "lat": 49.001218,
+        "lon": -116.186345
+      },
+      "endPoint": {
+        "lat": 47.277472,
+        "lon": -117.405781
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gasbol-gas-pipeline-bo": {
+      "id": "gasbol-gas-pipeline-bo",
+      "name": "GASBOL Gas Pipeline",
+      "operator": "Petrobras [51.00%]; BBPP Holdings Ltda [29.00%]; YPFB [12.00%]; Corumbá Holding SARL [8.00%]",
+      "commodityType": "gas",
+      "fromCountry": "BO",
+      "toCountry": "BR",
+      "transitCountries": [],
+      "capacityBcmYr": 11,
+      "lengthKm": 3150,
+      "inService": 1999,
+      "startPoint": {
+        "lat": -19.109674,
+        "lon": -57.81924
+      },
+      "endPoint": {
+        "lat": -29.876189,
+        "lon": -51.147325
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gasene-gas-pipeline-gascac-br": {
+      "id": "gasene-gas-pipeline-gascac-br",
+      "name": "Gasene Gas Pipeline - GASCAC",
+      "operator": "CDPQ [50.00%]; Engie SA [32.50%]; Engie Brasil Energia [17.50%]",
+      "commodityType": "gas",
+      "fromCountry": "BR",
+      "toCountry": "BR",
+      "transitCountries": [],
+      "capacityBcmYr": 7.3,
+      "lengthKm": 958.2,
+      "inService": 2010,
+      "startPoint": {
+        "lat": -12.389001,
+        "lon": -38.351933
+      },
+      "endPoint": {
+        "lat": -18.627986,
+        "lon": -39.921665
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gasoducto-al-altiplano-gas-pipeline-bo": {
+      "id": "gasoducto-al-altiplano-gas-pipeline-bo",
+      "name": "Gasoducto al Altiplano Gas Pipeline",
+      "operator": "YPFB [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "BO",
+      "toCountry": "BO",
+      "transitCountries": [],
+      "capacityBcmYr": 0.69,
+      "lengthKm": 1181,
+      "inService": 1988,
+      "startPoint": {
+        "lat": -18.183363,
+        "lon": -62.904743
+      },
+      "endPoint": {
+        "lat": -18.15966,
+        "lon": -63.689464
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gasoducto-contugas-gas-pipeline-pe": {
+      "id": "gasoducto-contugas-gas-pipeline-pe",
+      "name": "Gasoducto Contugas Gas Pipeline",
+      "operator": "Contugas [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "PE",
+      "toCountry": "PE",
+      "transitCountries": [],
+      "capacityBcmYr": 3.58,
+      "lengthKm": 1100,
+      "inService": 2014,
+      "startPoint": {
+        "lat": -14.100685,
+        "lon": -75.843653
+      },
+      "endPoint": {
+        "lat": -13.715032,
+        "lon": -75.969021
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gasoducto-norte-gas-pipeline-ar": {
+      "id": "gasoducto-norte-gas-pipeline-ar",
+      "name": "Gasoducto Norte Gas Pipeline",
+      "operator": "GasInvest SA [56.00%]; Southern Cone Energy Holding Co Inc [24.00%]; Bolsas y Mercados Argentinos SA [20.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AR",
+      "toCountry": "AR",
+      "transitCountries": [],
+      "capacityBcmYr": 10.22,
+      "lengthKm": 1454,
+      "inService": 1960,
+      "startPoint": {
+        "lat": -22.468837,
+        "lon": -63.786356
+      },
+      "endPoint": {
+        "lat": -25.445031,
+        "lon": -64.936717
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gazli-shymkent-gas-pipeline-uz": {
+      "id": "gazli-shymkent-gas-pipeline-uz",
+      "name": "Gazli-Shymkent Gas Pipeline",
+      "operator": "QazaqGaz [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "UZ",
+      "toCountry": "KZ",
+      "transitCountries": [],
+      "capacityBcmYr": 4.3,
+      "lengthKm": 877,
+      "inService": 1988,
+      "startPoint": {
+        "lat": 40.187553,
+        "lon": 63.588123
+      },
+      "endPoint": {
+        "lat": 41.955343,
+        "lon": 69.489436
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "goldfields-gas-pipeline-au": {
+      "id": "goldfields-gas-pipeline-au",
+      "name": "Goldfields Gas Pipeline",
+      "operator": "APA Group [57.00%]; Brookfield Asset Management [11.84%]",
+      "commodityType": "gas",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityBcmYr": 2.03,
+      "lengthKm": 1380,
+      "inService": 1996,
+      "startPoint": {
+        "lat": -21.444989,
+        "lon": 115.955553
+      },
+      "endPoint": {
+        "lat": -23.345146,
+        "lon": 119.709375
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gr-5-gas-pipeline-dz": {
+      "id": "gr-5-gas-pipeline-dz",
+      "name": "GR-5 Gas Pipeline",
+      "operator": "Sonatrach [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "DZ",
+      "toCountry": "DZ",
+      "transitCountries": [],
+      "capacityBcmYr": 8.8,
+      "lengthKm": 770,
+      "inService": 2018,
+      "startPoint": {
+        "lat": 30.857063,
+        "lon": 0.49291
+      },
+      "endPoint": {
+        "lat": 32.9361,
+        "lon": 3.2516
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "great-lakes-gas-transmission-pipeline-ca": {
+      "id": "great-lakes-gas-transmission-pipeline-ca",
+      "name": "Great Lakes Gas Transmission Pipeline",
+      "operator": "TC Energy [53.55%]; TC PipeLines LP [46.45%]",
+      "commodityType": "gas",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 24.53,
+      "lengthKm": 3403.76,
+      "inService": 1967,
+      "startPoint": {
+        "lat": 48.255791,
+        "lon": -96.239502
+      },
+      "endPoint": {
+        "lat": 46.551516,
+        "lon": -90.885168
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gryazovets-volkhov-slavyanskaya-gas-pipeline-ru": {
+      "id": "gryazovets-volkhov-slavyanskaya-gas-pipeline-ru",
+      "name": "Gryazovets-Volkhov-Slavyanskaya Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 84.2,
+      "lengthKm": 880,
+      "inService": 2022,
+      "startPoint": {
+        "lat": 58.787926,
+        "lon": 40.250152
+      },
+      "endPoint": {
+        "lat": 59.451417,
+        "lon": 28.10993
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gryazovets-vyborg-gas-pipeline-i-ru": {
+      "id": "gryazovets-vyborg-gas-pipeline-i-ru",
+      "name": "Gryazovets-Vyborg Gas Pipeline - I",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 55,
+      "lengthKm": 917,
+      "inService": 2011,
+      "startPoint": {
+        "lat": 59.148604,
+        "lon": 38.533592
+      },
+      "endPoint": {
+        "lat": 59.487957,
+        "lon": 34.332103
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gulf-coast-express-pipeline-us": {
+      "id": "gulf-coast-express-pipeline-us",
+      "name": "Gulf Coast Express Pipeline",
+      "operator": "Gulf Coast Express Pipeline LLC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 20.24,
+      "lengthKm": 800.65,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 27.746087,
+        "lon": -97.800026
+      },
+      "endPoint": {
+        "lat": 31.894956,
+        "lon": -101.79858
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gulf-coast-southbound-pipeline-phase-i-us": {
+      "id": "gulf-coast-southbound-pipeline-phase-i-us",
+      "name": "Gulf Coast Southbound Pipeline - Phase I",
+      "operator": "Natural Gas Pipeline Co of America LLC (NGPL) [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 4.7,
+      "lengthKm": 2227.07,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 41.876768,
+        "lon": -87.630028
+      },
+      "endPoint": {
+        "lat": 27.782797,
+        "lon": -97.909973
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gulf-south-gas-pipeline-system-network-info-us": {
+      "id": "gulf-south-gas-pipeline-system-network-info-us",
+      "name": "Gulf South Gas Pipeline - SYSTEM/NETWORK INFO",
+      "operator": "Boardwalk Pipeline Partners [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 27.59,
+      "lengthKm": 12070.08,
+      "inService": 2008,
+      "startPoint": {
+        "lat": 32.594515,
+        "lon": -94.840659
+      },
+      "endPoint": {
+        "lat": 32.923891,
+        "lon": -91.447948
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "gulfstream-natural-gas-pipeline-us": {
+      "id": "gulfstream-natural-gas-pipeline-us",
+      "name": "Gulfstream Natural Gas Pipeline",
+      "operator": "Williams Companies [50.00%]; Enbridge [50.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 13.39,
+      "lengthKm": 1199,
+      "inService": 2002,
+      "startPoint": {
+        "lat": 30.421916,
+        "lon": -88.883977
+      },
+      "endPoint": {
+        "lat": 26.683618,
+        "lon": -80.210593
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "hajiqabul-astara-abadan-gas-pipeline-az": {
+      "id": "hajiqabul-astara-abadan-gas-pipeline-az",
+      "name": "Hajiqabul–Astara–Abadan Gas Pipeline",
+      "operator": "National Iranian Oil Refining and Distribution Co [100.00%]; SOCAR",
+      "commodityType": "gas",
+      "fromCountry": "AZ",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityBcmYr": 10,
+      "lengthKm": 1474.5,
+      "inService": 1970,
+      "startPoint": {
+        "lat": 40.042202,
+        "lon": 48.902911
+      },
+      "endPoint": {
+        "lat": 28.082322,
+        "lon": 51.766742
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "hazira-vijaipur-jagdishpur-hvj-gas-pipeline-in": {
+      "id": "hazira-vijaipur-jagdishpur-hvj-gas-pipeline-in",
+      "name": "Hazira-Vijaipur-Jagdishpur (HVJ) Gas Pipeline",
+      "operator": "GAIL (India) Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 39.06,
+      "lengthKm": 2887,
+      "inService": 1997,
+      "startPoint": {
+        "lat": 21.177933,
+        "lon": 72.645373
+      },
+      "endPoint": {
+        "lat": 26.750347,
+        "lon": 80.542835
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "hebei-nanjing-connecting-gas-pipeline-trunk-line-cn": {
+      "id": "hebei-nanjing-connecting-gas-pipeline-trunk-line-cn",
+      "name": "Hebei-Nanjing Connecting Gas Pipeline - Trunk line",
+      "operator": "--",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 9,
+      "lengthKm": 886,
+      "inService": 2005,
+      "startPoint": {
+        "lat": 32.257451,
+        "lon": 119.087956
+      },
+      "endPoint": {
+        "lat": 38.300838,
+        "lon": 115.42929
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "high-pressure-gujarat-gas-grid-network-in": {
+      "id": "high-pressure-gujarat-gas-grid-network-in",
+      "name": "High Pressure Gujarat Gas Grid Network",
+      "operator": "Gujarat State Petronet [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 11.32,
+      "lengthKm": 2207,
+      "inService": 2016,
+      "startPoint": {
+        "lat": 20.443966,
+        "lon": 72.968384
+      },
+      "endPoint": {
+        "lat": 22.425935,
+        "lon": 71.074938
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "houston-gas-pipeline-hpl-system-us": {
+      "id": "houston-gas-pipeline-hpl-system-us",
+      "name": "Houston Gas Pipeline (HPL) System",
+      "operator": "ETP Legacy [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 54.17,
+      "lengthKm": 6115.51,
+      "inService": 0,
+      "startPoint": {
+        "lat": 33.632786,
+        "lon": -96.772354
+      },
+      "endPoint": {
+        "lat": 30.295604,
+        "lon": -97.747957
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "ichthys-gas-pipeline-au": {
+      "id": "ichthys-gas-pipeline-au",
+      "name": "Ichthys Gas Pipeline",
+      "operator": "INPEX Corp [50.00%]; TotalEnergies SE [30.00%]; Government of Taiwan [2.63%]; Tokyo Gas [1.58%]; Osaka Gas [1.20%]; Kansai Electric Power Co [1.20%]; Nuclear Damage Compensation and Decommissioning Facilitation Corp [0.37%]; Toho Gas [0.42%]; Chubu Electric Power [0.37%]",
+      "commodityType": "gas",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityBcmYr": 16.35,
+      "lengthKm": 889,
+      "inService": 2018,
+      "startPoint": {
+        "lat": -12.519356,
+        "lon": 128.393202
+      },
+      "endPoint": {
+        "lat": -12.519356,
+        "lon": 128.393202
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "igat-11-gas-pipeline-ir": {
+      "id": "igat-11-gas-pipeline-ir",
+      "name": "IGAT 11 Gas Pipeline",
+      "operator": "Iran Ministry of Petroleum [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityBcmYr": 40.15,
+      "lengthKm": 1200,
+      "inService": 2026,
+      "startPoint": {
+        "lat": 27.474,
+        "lon": 52.591
+      },
+      "endPoint": {
+        "lat": 39.304,
+        "lon": 44.432
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "igat-3-gas-pipeline-ir": {
+      "id": "igat-3-gas-pipeline-ir",
+      "name": "IGAT 3 Gas Pipeline",
+      "operator": "Iran Ministry of Petroleum [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityBcmYr": 32.85,
+      "lengthKm": 1195,
+      "inService": 0,
+      "startPoint": {
+        "lat": 27.473853,
+        "lon": 52.590629
+      },
+      "endPoint": {
+        "lat": 37.443898,
+        "lon": 49.560164
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "igat-4-gas-pipeline-ir": {
+      "id": "igat-4-gas-pipeline-ir",
+      "name": "IGAT 4 Gas Pipeline",
+      "operator": "Iran Ministry of Petroleum [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityBcmYr": 40.15,
+      "lengthKm": 1145,
+      "inService": 0,
+      "startPoint": {
+        "lat": 27.4737,
+        "lon": 52.590629
+      },
+      "endPoint": {
+        "lat": 35.12463,
+        "lon": 49.507111
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "igat-7-gas-pipeline-ir": {
+      "id": "igat-7-gas-pipeline-ir",
+      "name": "IGAT 7 Gas Pipeline",
+      "operator": "Iran Ministry of Petroleum [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityBcmYr": 18.4,
+      "lengthKm": 907,
+      "inService": 2010,
+      "startPoint": {
+        "lat": 27.47431,
+        "lon": 52.590114
+      },
+      "endPoint": {
+        "lat": 31.13774,
+        "lon": 59.218119
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "igat-8-gas-pipeline-ir": {
+      "id": "igat-8-gas-pipeline-ir",
+      "name": "IGAT 8 Gas Pipeline",
+      "operator": "Iran Ministry of Petroleum [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityBcmYr": 39.7,
+      "lengthKm": 1000,
+      "inService": 2016,
+      "startPoint": {
+        "lat": 27.47393,
+        "lon": 52.590458
+      },
+      "endPoint": {
+        "lat": 34.737892,
+        "lon": 51.086176
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "igat-9-gas-pipeline-ir": {
+      "id": "igat-9-gas-pipeline-ir",
+      "name": "IGAT 9 Gas Pipeline",
+      "operator": "Iran Ministry of Petroleum [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityBcmYr": 39.7,
+      "lengthKm": 1900,
+      "inService": 2022,
+      "startPoint": {
+        "lat": 39.629501,
+        "lon": 44.7243
+      },
+      "endPoint": {
+        "lat": 27.742201,
+        "lon": 52.758202
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "iran-oman-gas-pipeline-ir": {
+      "id": "iran-oman-gas-pipeline-ir",
+      "name": "Iran-Oman Gas Pipeline",
+      "operator": "Iran Ministry of Petroleum [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IR",
+      "toCountry": "OM",
+      "transitCountries": [],
+      "capacityBcmYr": 10,
+      "lengthKm": 1000,
+      "inService": 0,
+      "startPoint": {
+        "lat": 25.843336,
+        "lon": 57.347288
+      },
+      "endPoint": {
+        "lat": 24.377131,
+        "lon": 56.721953
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "iran-pakistan-pipeline-ir": {
+      "id": "iran-pakistan-pipeline-ir",
+      "name": "Iran-Pakistan Pipeline",
+      "operator": "Iran Ministry of Petroleum [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IR",
+      "toCountry": "PK",
+      "transitCountries": [],
+      "capacityBcmYr": 7.67,
+      "lengthKm": 2775,
+      "inService": 2024,
+      "startPoint": {
+        "lat": 27.474,
+        "lon": 52.591
+      },
+      "endPoint": {
+        "lat": 26.245,
+        "lon": 68.391
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "jagdishpur-haldia-bokaro-dhamra-natural-gas-pipeline-jhbdpl-in": {
+      "id": "jagdishpur-haldia-bokaro-dhamra-natural-gas-pipeline-jhbdpl-in",
+      "name": "Jagdishpur-Haldia-Bokaro-Dhamra Natural Gas Pipeline (JHBDPL)",
+      "operator": "GAIL (India) Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 8.4,
+      "lengthKm": 3546,
+      "inService": 2025,
+      "startPoint": {
+        "lat": 20.793992,
+        "lon": 86.899137
+      },
+      "endPoint": {
+        "lat": 25.518106,
+        "lon": 82.849216
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "kern-river-gas-pipeline-us": {
+      "id": "kern-river-gas-pipeline-us",
+      "name": "Kern River Gas Pipeline",
+      "operator": "Kern River Gas Transmission Co [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 22.18,
+      "lengthKm": 2763.24,
+      "inService": 1991,
+      "startPoint": {
+        "lat": 34.993468,
+        "lon": -117.671106
+      },
+      "endPoint": {
+        "lat": 35.267478,
+        "lon": -116.298416
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "kg-basin-gas-pipeline-in": {
+      "id": "kg-basin-gas-pipeline-in",
+      "name": "KG Basin Gas Pipeline",
+      "operator": "GAIL (India) Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 5.84,
+      "lengthKm": 877.86,
+      "inService": 1991,
+      "startPoint": {
+        "lat": 15.982519,
+        "lon": 82.060898
+      },
+      "endPoint": {
+        "lat": 16.481701,
+        "lon": 81.89159
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "kochi-koottanad-bangalore-mangalore-gas-pipeline-phase-ii-in": {
+      "id": "kochi-koottanad-bangalore-mangalore-gas-pipeline-phase-ii-in",
+      "name": "Kochi-Koottanad-Bangalore-Mangalore Gas Pipeline - Phase II",
+      "operator": "GAIL (India) Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 5.84,
+      "lengthKm": 1060,
+      "inService": 2022,
+      "startPoint": {
+        "lat": 12.783957,
+        "lon": 77.043288
+      },
+      "endPoint": {
+        "lat": 10.838579,
+        "lon": 76.003921
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "kpc-gas-pipeline-us": {
+      "id": "kpc-gas-pipeline-us",
+      "name": "KPC Gas Pipeline",
+      "operator": "KPC Pipeline [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 1.64,
+      "lengthKm": 1817,
+      "inService": 1995,
+      "startPoint": {
+        "lat": 36.709697,
+        "lon": -99.893885
+      },
+      "endPoint": {
+        "lat": 37.670798,
+        "lon": -97.339368
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "langeled-gas-pipeline-no": {
+      "id": "langeled-gas-pipeline-no",
+      "name": "Langeled Gas Pipeline",
+      "operator": "Gassled [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "NO",
+      "toCountry": "GB",
+      "transitCountries": [],
+      "capacityBcmYr": 25.5,
+      "lengthKm": 1166,
+      "inService": 2006,
+      "startPoint": {
+        "lat": 62.851559,
+        "lon": 6.945771
+      },
+      "endPoint": {
+        "lat": 53.659231,
+        "lon": 0.116031
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "libya-coastal-gas-pipeline-ly": {
+      "id": "libya-coastal-gas-pipeline-ly",
+      "name": "Libya Coastal Gas Pipeline",
+      "operator": "Libyan National Oil Corp [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "LY",
+      "toCountry": "LY",
+      "transitCountries": [],
+      "capacityBcmYr": 6.17,
+      "lengthKm": 1164,
+      "inService": 1983,
+      "startPoint": {
+        "lat": 32.8538,
+        "lon": 12.2375
+      },
+      "endPoint": {
+        "lat": 32.1,
+        "lon": 20.09
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "louisiana-intrastate-gas-lig-pipeline-us": {
+      "id": "louisiana-intrastate-gas-lig-pipeline-us",
+      "name": "Louisiana Intrastate Gas (LIG) Pipeline",
+      "operator": "EnLink Midstream [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 7.15,
+      "lengthKm": 3218.69,
+      "inService": 1985,
+      "startPoint": {
+        "lat": 32.819154,
+        "lon": -93.417851
+      },
+      "endPoint": {
+        "lat": 30.970491,
+        "lon": -91.694101
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "maghreb-europe-gas-pipeline-dz": {
+      "id": "maghreb-europe-gas-pipeline-dz",
+      "name": "Maghreb-Europe Gas Pipeline",
+      "operator": "Sonatrach; Government of Morocco; Enagás; SaskEnergy",
+      "commodityType": "gas",
+      "fromCountry": "DZ",
+      "toCountry": "ES",
+      "transitCountries": [
+        "MA",
+        "PT"
+      ],
+      "capacityBcmYr": 12,
+      "lengthKm": 1350,
+      "inService": 1996,
+      "startPoint": {
+        "lat": 32.931267,
+        "lon": 3.247745
+      },
+      "endPoint": {
+        "lat": 36.067881,
+        "lon": -5.706203
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "makat-north-caucasus-pipeline-kz": {
+      "id": "makat-north-caucasus-pipeline-kz",
+      "name": "Makat–North Caucasus Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "KZ",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 21.9,
+      "lengthKm": 944,
+      "inService": 1988,
+      "startPoint": {
+        "lat": 43.580142,
+        "lon": 45.891674
+      },
+      "endPoint": {
+        "lat": 47.355885,
+        "lon": 51.847789
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "mallavaram-bhopal-bhilwara-vijaipur-gas-pipeline-phase-ii-in": {
+      "id": "mallavaram-bhopal-bhilwara-vijaipur-gas-pipeline-phase-ii-in",
+      "name": "Mallavaram-Bhopal-Bhilwara-Vijaipur Gas Pipeline - Phase II",
+      "operator": "Gujarat State Petronet [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 28.56,
+      "lengthKm": 1517,
+      "inService": 2024,
+      "startPoint": {
+        "lat": 16.719706,
+        "lon": 82.258428
+      },
+      "endPoint": {
+        "lat": 24.189908,
+        "lon": 77.18526
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "maritimes-and-northeast-gas-pipeline-ca": {
+      "id": "maritimes-and-northeast-gas-pipeline-ca",
+      "name": "Maritimes and Northeast Gas Pipeline",
+      "operator": "Enbridge [77.53%]; Emera [12.92%]; ExxonMobil [9.55%]",
+      "commodityType": "gas",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 8.48,
+      "lengthKm": 1432,
+      "inService": 1999,
+      "startPoint": {
+        "lat": 42.530439,
+        "lon": -70.908119
+      },
+      "endPoint": {
+        "lat": 42.662765,
+        "lon": -71.257762
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "matterhorn-express-gas-pipeline-us": {
+      "id": "matterhorn-express-gas-pipeline-us",
+      "name": "Matterhorn Express Gas Pipeline",
+      "operator": "WhiteWater Midstream; EnLink Midstream; WPX Energy; MPLX",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 25.55,
+      "lengthKm": 933.42,
+      "inService": 2024,
+      "startPoint": {
+        "lat": 29.69691,
+        "lon": -96.182908
+      },
+      "endPoint": {
+        "lat": 31.337166,
+        "lon": -101.780113
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "megal-gas-pipeline-de": {
+      "id": "megal-gas-pipeline-de",
+      "name": "MEGAL Gas Pipeline",
+      "operator": "Mittel-Europäische-Gasleitungsgesellschaft mbH & Co. KG [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "DE",
+      "toCountry": "DE",
+      "transitCountries": [],
+      "capacityBcmYr": 22,
+      "lengthKm": 1115,
+      "inService": 1980,
+      "startPoint": {
+        "lat": 49.11,
+        "lon": 7.22
+      },
+      "endPoint": {
+        "lat": 48.5738,
+        "lon": 13.7218
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "mehsana-bhatinda-gas-pipeline-phase-i-in": {
+      "id": "mehsana-bhatinda-gas-pipeline-phase-i-in",
+      "name": "Mehsana-Bhatinda Gas Pipeline - Phase I",
+      "operator": "Gujarat State Petronet [52.00%]; Indian Oil Corp [26.00%]; BPCL Group [11.00%]; Hindustan Petroleum [11.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 29.24,
+      "lengthKm": 1177,
+      "inService": 2022,
+      "startPoint": {
+        "lat": 24.140246,
+        "lon": 72.350832
+      },
+      "endPoint": {
+        "lat": 25.641378,
+        "lon": 73.698352
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "midcontinent-express-gas-pipeline-us": {
+      "id": "midcontinent-express-gas-pipeline-us",
+      "name": "Midcontinent Express Gas Pipeline",
+      "operator": "Kinder Morgan [50.00%]; ETP Legacy [50.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 15.67,
+      "lengthKm": 816.42,
+      "inService": 2009,
+      "startPoint": {
+        "lat": 34.004507,
+        "lon": -96.038237
+      },
+      "endPoint": {
+        "lat": 32.089742,
+        "lon": -88.221005
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "mississippi-river-transmission-us": {
+      "id": "mississippi-river-transmission-us",
+      "name": "Mississippi River Transmission",
+      "operator": "Enable Midstream Partners LP [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 19.42,
+      "lengthKm": 2574,
+      "inService": 0,
+      "startPoint": {
+        "lat": 34.672279,
+        "lon": -91.795776
+      },
+      "endPoint": {
+        "lat": 38.668875,
+        "lon": -90.103533
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "mojave-gas-pipeline-us": {
+      "id": "mojave-gas-pipeline-us",
+      "name": "Mojave Gas Pipeline",
+      "operator": "El Paso Corp [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 4.09,
+      "lengthKm": 804.7,
+      "inService": 1991,
+      "startPoint": {
+        "lat": 35.411718,
+        "lon": -118.922603
+      },
+      "endPoint": {
+        "lat": 34.714337,
+        "lon": -114.488486
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "moomba-adelaide-pipeline-system-au": {
+      "id": "moomba-adelaide-pipeline-system-au",
+      "name": "Moomba Adelaide Pipeline System",
+      "operator": "Queensland Investment Corp [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityBcmYr": 2.42,
+      "lengthKm": 1184,
+      "inService": 1969,
+      "startPoint": {
+        "lat": -28.116,
+        "lon": 140.206
+      },
+      "endPoint": {
+        "lat": -34.805,
+        "lon": 138.52
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "moomba-sydney-pipeline-system-au": {
+      "id": "moomba-sydney-pipeline-system-au",
+      "name": "Moomba Sydney Pipeline System",
+      "operator": "APA Group [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityBcmYr": 4.48,
+      "lengthKm": 1300,
+      "inService": 1976,
+      "startPoint": {
+        "lat": -28.115865,
+        "lon": 140.206289
+      },
+      "endPoint": {
+        "lat": -33.96409,
+        "lon": 150.9806
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "mountainwest-gas-pipeline-us": {
+      "id": "mountainwest-gas-pipeline-us",
+      "name": "MountainWest Gas Pipeline",
+      "operator": "Williams Companies [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 26.57,
+      "lengthKm": 3006.25,
+      "inService": 0,
+      "startPoint": {
+        "lat": 41.13483,
+        "lon": -111.933555
+      },
+      "endPoint": {
+        "lat": 39.686978,
+        "lon": -110.623456
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "mozambique-south-africa-gas-pipeline-mz": {
+      "id": "mozambique-south-africa-gas-pipeline-mz",
+      "name": "Mozambique-South Africa Gas Pipeline",
+      "operator": "Sasol [50.00%]; South African Gas Development Ltd Co [25.00%]; Companhia Mocambiçana de Gasoduto [25.00%]",
+      "commodityType": "gas",
+      "fromCountry": "MZ",
+      "toCountry": "ZA",
+      "transitCountries": [],
+      "capacityBcmYr": 5.52,
+      "lengthKm": 865,
+      "inService": 2004,
+      "startPoint": {
+        "lat": -26.562479,
+        "lon": 29.14458
+      },
+      "endPoint": {
+        "lat": -21.802044,
+        "lon": 34.911121
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "mumbai-nagpur-jharsuguda-gas-pipeline-in": {
+      "id": "mumbai-nagpur-jharsuguda-gas-pipeline-in",
+      "name": "Mumbai-Nagpur-Jharsuguda Gas Pipeline",
+      "operator": "GAIL (India) Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 6.02,
+      "lengthKm": 1755,
+      "inService": 2025,
+      "startPoint": {
+        "lat": 19.308792,
+        "lon": 73.263244
+      },
+      "endPoint": {
+        "lat": 23.289176,
+        "lon": 80.005943
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "national-fuel-gas-supply-corporation-gas-pipeline-us": {
+      "id": "national-fuel-gas-supply-corporation-gas-pipeline-us",
+      "name": "National Fuel Gas Supply Corporation Gas Pipeline",
+      "operator": "National Fuel Gas Supply Corp",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 44.97,
+      "lengthKm": 2896.82,
+      "inService": 0,
+      "startPoint": {
+        "lat": 39.900478,
+        "lon": -80.435288
+      },
+      "endPoint": {
+        "lat": 41.899505,
+        "lon": -77.916144
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "natural-gas-pipeline-company-of-america-system-us": {
+      "id": "natural-gas-pipeline-company-of-america-system-us",
+      "name": "Natural Gas Pipeline Company of America System",
+      "operator": "Kinder Morgan [37.50%]; Brookfield Infrastructure Partners [25.00%]; ArcLight Capital Partners [37.50%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 16.35,
+      "lengthKm": 14645.03,
+      "inService": 1931,
+      "startPoint": {
+        "lat": 32.656,
+        "lon": -104.58176
+      },
+      "endPoint": {
+        "lat": 41.707584,
+        "lon": -87.539008
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "neuba-i-gas-pipeline-ar": {
+      "id": "neuba-i-gas-pipeline-ar",
+      "name": "Neuba I Gas Pipeline",
+      "operator": "Compañía de Inversiones de Energía SA (CIESA) [51.00%]; Administración Nacional de la Seguridad Social (ANSES) [24.00%]; New York Stock Exchange (NYSE) [12.00%]; BYMA-Bolsas y Mercados Argentinos SA [8.00%]; other [5.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AR",
+      "toCountry": "AR",
+      "transitCountries": [],
+      "capacityBcmYr": 4.75,
+      "lengthKm": 1267,
+      "inService": 1970,
+      "startPoint": {
+        "lat": -39.026594,
+        "lon": -66.535641
+      },
+      "endPoint": {
+        "lat": -39.026579,
+        "lon": -66.535777
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "neuba-ii-gas-pipeline-ar": {
+      "id": "neuba-ii-gas-pipeline-ar",
+      "name": "Neuba II Gas Pipeline",
+      "operator": "Compañía de Inversiones de Energía SA (CIESA) [51.00%]; Administración Nacional de la Seguridad Social (ANSES) [24.00%]; New York Stock Exchange (NYSE) [12.00%]; BYMA-Bolsas y Mercados Argentinos SA [8.00%]; other [5.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AR",
+      "toCountry": "AR",
+      "transitCountries": [],
+      "capacityBcmYr": 10.95,
+      "lengthKm": 1958,
+      "inService": 1988,
+      "startPoint": {
+        "lat": -38.435441,
+        "lon": -68.57022
+      },
+      "endPoint": {
+        "lat": -34.834635,
+        "lon": -59.014491
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "nizhnevartovsk-parabel-kuzbass-gas-pipeline-i-ru": {
+      "id": "nizhnevartovsk-parabel-kuzbass-gas-pipeline-i-ru",
+      "name": "Nizhnevartovsk-Parabel-Kuzbass Gas Pipeline - I",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 4.1,
+      "lengthKm": 1162,
+      "inService": 1978,
+      "startPoint": {
+        "lat": 56.155811,
+        "lon": 84.341362
+      },
+      "endPoint": {
+        "lat": 53.844127,
+        "lon": 87.076011
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "norandino-gas-pipeline-ar": {
+      "id": "norandino-gas-pipeline-ar",
+      "name": "NorAndino Gas Pipeline",
+      "operator": "Engie Energía Chile (EECL) [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AR",
+      "toCountry": "CL",
+      "transitCountries": [],
+      "capacityBcmYr": 2.92,
+      "lengthKm": 1070,
+      "inService": 1999,
+      "startPoint": {
+        "lat": -23.780383,
+        "lon": -70.434909
+      },
+      "endPoint": {
+        "lat": -23.409028,
+        "lon": -64.33854
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "north-east-natural-gas-pipeline-grid-project-in": {
+      "id": "north-east-natural-gas-pipeline-grid-project-in",
+      "name": "North East Natural Gas Pipeline Grid Project",
+      "operator": "Indradhanush Gas Grid Ltd (IGGL) [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityBcmYr": 1.73,
+      "lengthKm": 1656,
+      "inService": 2026,
+      "startPoint": {
+        "lat": 26.138092,
+        "lon": 91.73278
+      },
+      "endPoint": {
+        "lat": 27.43497,
+        "lon": 88.569707
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "northern-border-gas-pipeline-ca": {
+      "id": "northern-border-gas-pipeline-ca",
+      "name": "Northern Border Gas Pipeline",
+      "operator": "TC Energy [50.00%]; ONEOK Inc [50.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 24.53,
+      "lengthKm": 2272.39,
+      "inService": 1982,
+      "startPoint": {
+        "lat": 46.439499,
+        "lon": -100.575201
+      },
+      "endPoint": {
+        "lat": 48.558444,
+        "lon": -106.313389
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "northern-natural-gas-pipeline-us": {
+      "id": "northern-natural-gas-pipeline-us",
+      "name": "Northern Natural Gas Pipeline",
+      "operator": "Northern Natural Gas [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 64.39,
+      "lengthKm": 23013.62,
+      "inService": 1930,
+      "startPoint": {
+        "lat": 37.06553,
+        "lon": -101.663715
+      },
+      "endPoint": {
+        "lat": 41.0176,
+        "lon": -95.907328
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "northern-tyumen-regions-srto-torzhok-gas-pipeline-ru": {
+      "id": "northern-tyumen-regions-srto-torzhok-gas-pipeline-ru",
+      "name": "Northern Tyumen Regions (SRTO)–Torzhok Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 28.5,
+      "lengthKm": 2200,
+      "inService": 2006,
+      "startPoint": {
+        "lat": 62.908086,
+        "lon": 61.503667
+      },
+      "endPoint": {
+        "lat": 62.524334,
+        "lon": 50.823954
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "northwest-gas-pipeline-system-network-info-us": {
+      "id": "northwest-gas-pipeline-system-network-info-us",
+      "name": "Northwest Gas Pipeline - SYSTEM/NETWORK INFO",
+      "operator": "Williams Companies [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 38.84,
+      "lengthKm": 6276.44,
+      "inService": 1965,
+      "startPoint": {
+        "lat": 42.529724,
+        "lon": -111.403387
+      },
+      "endPoint": {
+        "lat": 37.578062,
+        "lon": -108.711249
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "nova-gas-transmission-ngtl-pipeline-alberta-gas-pipeline-sys-ca": {
+      "id": "nova-gas-transmission-ngtl-pipeline-alberta-gas-pipeline-sys-ca",
+      "name": "Nova Gas Transmission (NGTL) Pipeline - Alberta Gas Pipeline System",
+      "operator": "NOVA Gas Transmission Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityBcmYr": 81.76,
+      "lengthKm": 24500,
+      "inService": 1957,
+      "startPoint": {
+        "lat": 49.306615,
+        "lon": -114.039927
+      },
+      "endPoint": {
+        "lat": 59.058791,
+        "lon": -118.871545
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "oasis-gas-pipeline-us": {
+      "id": "oasis-gas-pipeline-us",
+      "name": "Oasis Gas Pipeline",
+      "operator": "Energy Transfer [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 12.26,
+      "lengthKm": 966,
+      "inService": 0,
+      "startPoint": {
+        "lat": 31.310983,
+        "lon": -103.106007
+      },
+      "endPoint": {
+        "lat": 29.800767,
+        "lon": -95.859284
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "okarem-beyneu-gas-pipeline-tm": {
+      "id": "okarem-beyneu-gas-pipeline-tm",
+      "name": "Okarem-Beyneu Gas Pipeline",
+      "operator": "Turkmengaz; Samruk-Kazyna SWF JSC",
+      "commodityType": "gas",
+      "fromCountry": "TM",
+      "toCountry": "KZ",
+      "transitCountries": [],
+      "capacityBcmYr": 3.78,
+      "lengthKm": 999,
+      "inService": 1974,
+      "startPoint": {
+        "lat": 37.80305,
+        "lon": 53.866901
+      },
+      "endPoint": {
+        "lat": 45.309018,
+        "lon": 55.246059
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "orenburg-novopskov-gas-pipeline-ru": {
+      "id": "orenburg-novopskov-gas-pipeline-ru",
+      "name": "Orenburg-Novopskov Gas Pipeline",
+      "operator": "Gazprom PJSC; QazaqGaz",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "UA",
+      "transitCountries": [
+        "KZ"
+      ],
+      "capacityBcmYr": 14.6,
+      "lengthKm": 1230,
+      "inService": 1975,
+      "startPoint": {
+        "lat": 51.78109,
+        "lon": 55.10983
+      },
+      "endPoint": {
+        "lat": 49.52207,
+        "lon": 39.14875
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "ostrogozhsk-belousovo-gas-pipeline-ru": {
+      "id": "ostrogozhsk-belousovo-gas-pipeline-ru",
+      "name": "Ostrogozhsk-Belousovo Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 8.79,
+      "lengthKm": 810,
+      "inService": 0,
+      "startPoint": {
+        "lat": 50.83566,
+        "lon": 38.99924
+      },
+      "endPoint": {
+        "lat": 55.11288,
+        "lon": 36.68415
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "panhandle-eastern-gas-pipeline-us": {
+      "id": "panhandle-eastern-gas-pipeline-us",
+      "name": "Panhandle Eastern Gas Pipeline",
+      "operator": "Southern Union Panhandle LLC; Energy Transfer",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 28.62,
+      "lengthKm": 1384.04,
+      "inService": 1929,
+      "startPoint": {
+        "lat": 37.942059,
+        "lon": -101.290054
+      },
+      "endPoint": {
+        "lat": 35.789328,
+        "lon": -97.744369
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "peninsular-gas-utilization-pipeline-my": {
+      "id": "peninsular-gas-utilization-pipeline-my",
+      "name": "Peninsular Gas Utilization Pipeline",
+      "operator": "Petronas [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "MY",
+      "toCountry": "MY",
+      "transitCountries": [],
+      "capacityBcmYr": 35.77,
+      "lengthKm": 2623,
+      "inService": 1993,
+      "startPoint": {
+        "lat": 6.341818,
+        "lon": 100.153761
+      },
+      "endPoint": {
+        "lat": 1.582785,
+        "lon": 103.783946
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "pisarevka-anapa-gas-pipeline-ru": {
+      "id": "pisarevka-anapa-gas-pipeline-ru",
+      "name": "Pisarevka-Anapa Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 63,
+      "lengthKm": 880,
+      "inService": 2016,
+      "startPoint": {
+        "lat": 49.91781,
+        "lon": 40.19104
+      },
+      "endPoint": {
+        "lat": 44.82824,
+        "lon": 37.42724
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "pochinki-anapa-gas-pipeline-ru": {
+      "id": "pochinki-anapa-gas-pipeline-ru",
+      "name": "Pochinki-Anapa Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 63,
+      "lengthKm": 1625,
+      "inService": 2023,
+      "startPoint": {
+        "lat": 54.6707,
+        "lon": 44.63861
+      },
+      "endPoint": {
+        "lat": 44.80583,
+        "lon": 37.407667
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "pochinki-izobilnoe-north-stavropol-underground-gas-storage-p-ru": {
+      "id": "pochinki-izobilnoe-north-stavropol-underground-gas-storage-p-ru",
+      "name": "Pochinki-Izobilnoe-North Stavropol Underground Gas Storage Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 30,
+      "lengthKm": 937,
+      "inService": 1998,
+      "startPoint": {
+        "lat": 54.6707,
+        "lon": 44.63861
+      },
+      "endPoint": {
+        "lat": 45.28569,
+        "lon": 41.76145
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "power-of-siberia-gas-pipeline-phase-i-ru": {
+      "id": "power-of-siberia-gas-pipeline-phase-i-ru",
+      "name": "Power of Siberia Gas Pipeline - Phase I",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 38,
+      "lengthKm": 2200,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 57.299473,
+        "lon": 125.250836
+      },
+      "endPoint": {
+        "lat": 60.754906,
+        "lon": 119.156075
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "power-of-siberia-gas-pipeline-phase-ii-kovykta-chayanda-gas--ru": {
+      "id": "power-of-siberia-gas-pipeline-phase-ii-kovykta-chayanda-gas--ru",
+      "name": "Power of Siberia Gas Pipeline - Phase II Kovykta-Chayanda Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 38,
+      "lengthKm": 800,
+      "inService": 2022,
+      "startPoint": {
+        "lat": 60.754906,
+        "lon": 119.156075
+      },
+      "endPoint": {
+        "lat": 55.364967,
+        "lon": 106.14415
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "prince-rupert-gas-transmission-pipeline-ca": {
+      "id": "prince-rupert-gas-transmission-pipeline-ca",
+      "name": "Prince Rupert Gas Transmission Pipeline",
+      "operator": "NW Infrastructure Ltd Partnership [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityBcmYr": 20.44,
+      "lengthKm": 750,
+      "inService": 2029,
+      "startPoint": {
+        "lat": 55.339955,
+        "lon": -126.715557
+      },
+      "endPoint": {
+        "lat": 55.12716,
+        "lon": -122.932258
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "progress-gas-pipeline-ru": {
+      "id": "progress-gas-pipeline-ru",
+      "name": "Progress Gas Pipeline",
+      "operator": "Gazprom PJSC; Gas Transmission System Operator of Ukraine",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "UA",
+      "transitCountries": [],
+      "capacityBcmYr": 26,
+      "lengthKm": 4590.7,
+      "inService": 1988,
+      "startPoint": {
+        "lat": 67.909871,
+        "lon": 74.901217
+      },
+      "endPoint": {
+        "lat": 48.621871,
+        "lon": 22.288048
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "promigas-pipeline-network-co": {
+      "id": "promigas-pipeline-network-co",
+      "name": "Promigas Pipeline Network",
+      "operator": "Promigas [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CO",
+      "toCountry": "CO",
+      "transitCountries": [],
+      "capacityBcmYr": 9.73,
+      "lengthKm": 2537,
+      "inService": 1977,
+      "startPoint": {
+        "lat": 11.695809,
+        "lon": -72.723018
+      },
+      "endPoint": {
+        "lat": 10.271969,
+        "lon": -75.550727
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "punga-ukhta-gryazovets-gas-pipeline-iv-ru": {
+      "id": "punga-ukhta-gryazovets-gas-pipeline-iv-ru",
+      "name": "Punga-Ukhta-Gryazovets Gas Pipeline - IV",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 29.5,
+      "lengthKm": 945.8,
+      "inService": 1981,
+      "startPoint": {
+        "lat": 63.666384,
+        "lon": 53.762311
+      },
+      "endPoint": {
+        "lat": 58.776894,
+        "lon": 40.228024
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "rockies-express-gas-pipeline-us": {
+      "id": "rockies-express-gas-pipeline-us",
+      "name": "Rockies Express Gas Pipeline",
+      "operator": "Tallgrass Energy [75.00%]; Phillips 66 [25.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 41.39,
+      "lengthKm": 2711.74,
+      "inService": 2009,
+      "startPoint": {
+        "lat": 41.532225,
+        "lon": -110.059937
+      },
+      "endPoint": {
+        "lat": 41.680249,
+        "lon": -107.983217
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "rover-pipeline-phase-1-us": {
+      "id": "rover-pipeline-phase-1-us",
+      "name": "Rover Pipeline - Phase 1",
+      "operator": "Energy Transfer [32.57%]; Blackstone [32.44%]; Traverse [35.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 17.37,
+      "lengthKm": 1144.24,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 40.437951,
+        "lon": -81.221438
+      },
+      "endPoint": {
+        "lat": 39.791468,
+        "lon": -81.297212
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "ruby-gas-pipeline-us": {
+      "id": "ruby-gas-pipeline-us",
+      "name": "Ruby Gas Pipeline",
+      "operator": "Ruby Pipeline LLC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 15.33,
+      "lengthKm": 1099.18,
+      "inService": 2011,
+      "startPoint": {
+        "lat": 41.996886,
+        "lon": -121.356893
+      },
+      "endPoint": {
+        "lat": 41.464237,
+        "lon": -111.547098
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "russia-iran-gas-pipeline-ru": {
+      "id": "russia-iran-gas-pipeline-ru",
+      "name": "Russia–Iran Gas Pipeline",
+      "operator": "Iran Ministry of Petroleum; Gazprom PJSC",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityBcmYr": 55,
+      "lengthKm": 1413.38,
+      "inService": 0,
+      "startPoint": {
+        "lat": 37.273875,
+        "lon": 49.603781
+      },
+      "endPoint": {
+        "lat": 47.672514,
+        "lon": 53.316221
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "sabal-trail-gas-transmission-pipeline-project-phase-i-us": {
+      "id": "sabal-trail-gas-transmission-pipeline-project-phase-i-us",
+      "name": "Sabal Trail Gas Transmission Pipeline - Project Phase I",
+      "operator": "Sabal Trail Transmission LLC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 8.48,
+      "lengthKm": 830.42,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 28.963711,
+        "lon": -82.676149
+      },
+      "endPoint": {
+        "lat": 33.001458,
+        "lon": -85.895451
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "sakhalin-khabarovsk-vladivostok-gas-pipeline-ru": {
+      "id": "sakhalin-khabarovsk-vladivostok-gas-pipeline-ru",
+      "name": "Sakhalin-Khabarovsk-Vladivostok Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 20,
+      "lengthKm": 1822,
+      "inService": 2011,
+      "startPoint": {
+        "lat": 52.500729,
+        "lon": 143.182026
+      },
+      "endPoint": {
+        "lat": 43.15261,
+        "lon": 132.00341
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "san-martin-pipeline-ar": {
+      "id": "san-martin-pipeline-ar",
+      "name": "San Martin Pipeline",
+      "operator": "Compañía de Inversiones de Energía SA (CIESA) [51.00%]; Administración Nacional de la Seguridad Social (ANSES) [24.00%]; New York Stock Exchange (NYSE) [12.00%]; BYMA-Bolsas y Mercados Argentinos SA [8.00%]; other [5.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AR",
+      "toCountry": "AR",
+      "transitCountries": [],
+      "capacityBcmYr": 11.24,
+      "lengthKm": 4590,
+      "inService": 1965,
+      "startPoint": {
+        "lat": -38.480217,
+        "lon": -61.608929
+      },
+      "endPoint": {
+        "lat": -52.679759,
+        "lon": -68.591764
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "sarakhs-sari-pipeline-ir": {
+      "id": "sarakhs-sari-pipeline-ir",
+      "name": "Sarakhs-Sari Pipeline",
+      "operator": "Iran Ministry of Petroleum [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityBcmYr": 12,
+      "lengthKm": 795,
+      "inService": 0,
+      "startPoint": {
+        "lat": 36.35569,
+        "lon": 61.181478
+      },
+      "endPoint": {
+        "lat": 36.548507,
+        "lon": 53.049977
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "saryarka-gas-pipeline-phase-i-kyzylorda-zhezkazgan-karaganda-kz": {
+      "id": "saryarka-gas-pipeline-phase-i-kyzylorda-zhezkazgan-karaganda-kz",
+      "name": "Saryarka Gas Pipeline - Phase I (Kyzylorda-Zhezkazgan-Karaganda-Astana Gas Pipeline)",
+      "operator": "AstanaGaz KMG JSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "KZ",
+      "toCountry": "KZ",
+      "transitCountries": [],
+      "capacityBcmYr": 2.2,
+      "lengthKm": 1061,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 45.355172,
+        "lon": 65.045451
+      },
+      "endPoint": {
+        "lat": 51.151735,
+        "lon": 71.439063
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "sawan-lahore-gas-pipeline-pk": {
+      "id": "sawan-lahore-gas-pipeline-pk",
+      "name": "Sawan–Lahore Gas Pipeline",
+      "operator": "Sui Northern Gas Pipelines Ltd (SNGPL) [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "PK",
+      "toCountry": "PK",
+      "transitCountries": [],
+      "capacityBcmYr": 12.26,
+      "lengthKm": 770,
+      "inService": 2025,
+      "startPoint": {
+        "lat": 27.259895,
+        "lon": 69.152198
+      },
+      "endPoint": {
+        "lat": 31.479928,
+        "lon": 74.405686
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "sebei-xining-lanzhou-gas-pipeline-cn": {
+      "id": "sebei-xining-lanzhou-gas-pipeline-cn",
+      "name": "Sebei-Xining-Lanzhou Gas Pipeline",
+      "operator": "China Petroleum West Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 2,
+      "lengthKm": 953,
+      "inService": 2001,
+      "startPoint": {
+        "lat": 37.350374,
+        "lon": 94.165981
+      },
+      "endPoint": {
+        "lat": 36.105148,
+        "lon": 103.583904
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "serpukhov-kalinin-leningrad-pipeline-ru": {
+      "id": "serpukhov-kalinin-leningrad-pipeline-ru",
+      "name": "Serpukhov-Kalinin-Leningrad Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 3.7,
+      "lengthKm": 803,
+      "inService": 1959,
+      "startPoint": {
+        "lat": 59.791653,
+        "lon": 30.157471
+      },
+      "endPoint": {
+        "lat": 54.9684,
+        "lon": 37.50156
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "shaan-jing-gas-pipeline-shaan-jing-gas-pipeline-1-cn": {
+      "id": "shaan-jing-gas-pipeline-shaan-jing-gas-pipeline-1-cn",
+      "name": "Shaan-Jing Gas Pipeline - Shaan-Jing Gas Pipeline 1",
+      "operator": "Petrochina Beijing Gas Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 4,
+      "lengthKm": 918,
+      "inService": 1997,
+      "startPoint": {
+        "lat": 37.655418,
+        "lon": 108.926356
+      },
+      "endPoint": {
+        "lat": 39.884447,
+        "lon": 116.213974
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "shaan-jing-gas-pipeline-shaan-jing-gas-pipeline-2-cn": {
+      "id": "shaan-jing-gas-pipeline-shaan-jing-gas-pipeline-2-cn",
+      "name": "Shaan-Jing Gas Pipeline - Shaan-Jing Gas Pipeline 2",
+      "operator": "Petrochina Beijing Gas Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 12,
+      "lengthKm": 935,
+      "inService": 2005,
+      "startPoint": {
+        "lat": 37.655418,
+        "lon": 108.926356
+      },
+      "endPoint": {
+        "lat": 39.795992,
+        "lon": 116.810907
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "shaan-jing-gas-pipeline-shaan-jing-gas-pipeline-3-cn": {
+      "id": "shaan-jing-gas-pipeline-shaan-jing-gas-pipeline-3-cn",
+      "name": "Shaan-Jing Gas Pipeline - Shaan-Jing Gas Pipeline 3",
+      "operator": "Petrochina Beijing Gas Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 15,
+      "lengthKm": 1011,
+      "inService": 2010,
+      "startPoint": {
+        "lat": 38.276825,
+        "lon": 109.543413
+      },
+      "endPoint": {
+        "lat": 40.174674,
+        "lon": 116.24763
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "shaan-jing-gas-pipeline-shaan-jing-gas-pipeline-4-cn": {
+      "id": "shaan-jing-gas-pipeline-shaan-jing-gas-pipeline-4-cn",
+      "name": "Shaan-Jing Gas Pipeline - Shaan-Jing Gas Pipeline 4",
+      "operator": "Petrochina Beijing Gas Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 25,
+      "lengthKm": 1114,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 37.655418,
+        "lon": 108.926356
+      },
+      "endPoint": {
+        "lat": 40.174674,
+        "lon": 116.24763
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "sichuan-chongqing-grand-loop-line-cn": {
+      "id": "sichuan-chongqing-grand-loop-line-cn",
+      "name": "Sichuan & Chongqing Grand Loop Line",
+      "operator": "--",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 12,
+      "lengthKm": 1756,
+      "inService": 2018,
+      "startPoint": {
+        "lat": 31.531108,
+        "lon": 107.729531
+      },
+      "endPoint": {
+        "lat": 30.467651,
+        "lon": 106.619943
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "sichuan-shanghai-gas-pipeline-trunk-line-cn": {
+      "id": "sichuan-shanghai-gas-pipeline-trunk-line-cn",
+      "name": "Sichuan–Shanghai Gas Pipeline - Trunk line",
+      "operator": "--",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 15,
+      "lengthKm": 1628.64,
+      "inService": 2009,
+      "startPoint": {
+        "lat": 35.762562,
+        "lon": 115.012833
+      },
+      "endPoint": {
+        "lat": 31.267021,
+        "lon": 120.601984
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "sichuan-shanghai-parallel-gas-pipeline-xiantao-wenzhou-trunk-cn": {
+      "id": "sichuan-shanghai-parallel-gas-pipeline-xiantao-wenzhou-trunk-cn",
+      "name": "Sichuan–Shanghai Parallel Gas Pipeline - Xiantao-Wenzhou Trunk Line",
+      "operator": "National Petroleum and Natural Gas Pipeline Network Group Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 27,
+      "lengthKm": 1260,
+      "inService": 0,
+      "startPoint": {
+        "lat": 30.338497,
+        "lon": 113.427828
+      },
+      "endPoint": {
+        "lat": 28.103556,
+        "lon": 120.514058
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "sichuan-shanghai-parallel-gas-pipeline-zaoyang-xuancheng-con-cn": {
+      "id": "sichuan-shanghai-parallel-gas-pipeline-zaoyang-xuancheng-con-cn",
+      "name": "Sichuan–Shanghai Parallel Gas Pipeline - Zaoyang–Xuancheng Connecting Pipeline",
+      "operator": "National Petroleum and Natural Gas Pipeline Network Group Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 9.53,
+      "lengthKm": 787.2,
+      "inService": 0,
+      "startPoint": {
+        "lat": 32.331229,
+        "lon": 112.973379
+      },
+      "endPoint": {
+        "lat": 30.92808,
+        "lon": 118.755919
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "sino-myanmar-gas-pipeline-trunk-line-china-segment-cn": {
+      "id": "sino-myanmar-gas-pipeline-trunk-line-china-segment-cn",
+      "name": "Sino-Myanmar Gas Pipeline - Trunk line (China segment)",
+      "operator": "National Pipe Network Group Southwest Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 12,
+      "lengthKm": 1727,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 24.031343,
+        "lon": 97.980098
+      },
+      "endPoint": {
+        "lat": 22.818347,
+        "lon": 108.361184
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "sino-myanmar-gas-pipeline-trunk-line-myanmar-segment-mm": {
+      "id": "sino-myanmar-gas-pipeline-trunk-line-myanmar-segment-mm",
+      "name": "Sino-Myanmar Gas Pipeline - Trunk line (Myanmar segment)",
+      "operator": "National Pipe Network Group Southwest Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "MM",
+      "toCountry": "MM",
+      "transitCountries": [],
+      "capacityBcmYr": 12,
+      "lengthKm": 793,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 19.39337,
+        "lon": 93.720537
+      },
+      "endPoint": {
+        "lat": 19.593576,
+        "lon": 92.857825
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "sistema-nacional-de-gasoductos-sng-mx": {
+      "id": "sistema-nacional-de-gasoductos-sng-mx",
+      "name": "Sistema Nacional de Gasoductos (SNG)",
+      "operator": "Cenagas [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "MX",
+      "toCountry": "MX",
+      "transitCountries": [],
+      "capacityBcmYr": 51.1,
+      "lengthKm": 8611,
+      "inService": 1999,
+      "startPoint": {
+        "lat": 25.803947,
+        "lon": -103.192347
+      },
+      "endPoint": {
+        "lat": 16.203828,
+        "lon": -95.1824
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "socalgas-pipeline-us": {
+      "id": "socalgas-pipeline-us",
+      "name": "SoCalGas Pipeline",
+      "operator": "--",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 38.07,
+      "lengthKm": 5858.01,
+      "inService": 0,
+      "startPoint": {
+        "lat": 33.924264,
+        "lon": -116.667768
+      },
+      "endPoint": {
+        "lat": 33.916939,
+        "lon": -117.744169
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "south-valley-gas-pipeline-system-network-info-eg": {
+      "id": "south-valley-gas-pipeline-system-network-info-eg",
+      "name": "South Valley Gas Pipeline - SYSTEM/NETWORK INFO",
+      "operator": "Egyptian Natural Gas Holding Co [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "EG",
+      "toCountry": "EG",
+      "transitCountries": [],
+      "capacityBcmYr": 12,
+      "lengthKm": 930,
+      "inService": 2009,
+      "startPoint": {
+        "lat": 29.751158,
+        "lon": 31.242331
+      },
+      "endPoint": {
+        "lat": 24.089411,
+        "lon": 32.89637
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "south-west-queensland-pipeline-au": {
+      "id": "south-west-queensland-pipeline-au",
+      "name": "South West Queensland Pipeline",
+      "operator": "APA Group [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityBcmYr": 4.05,
+      "lengthKm": 937,
+      "inService": 1996,
+      "startPoint": {
+        "lat": -28.122,
+        "lon": 140.204
+      },
+      "endPoint": {
+        "lat": -27.385,
+        "lon": 141.805
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "southern-natural-gas-pipeline-us": {
+      "id": "southern-natural-gas-pipeline-us",
+      "name": "Southern Natural Gas Pipeline",
+      "operator": "Kinder Morgan [50.00%]; Southern Co [50.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 39.86,
+      "lengthKm": 12231,
+      "inService": 1928,
+      "startPoint": {
+        "lat": 32.270577,
+        "lon": -81.282585
+      },
+      "endPoint": {
+        "lat": 31.759251,
+        "lon": -89.87893
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "southern-star-central-gas-pipeline-us": {
+      "id": "southern-star-central-gas-pipeline-us",
+      "name": "Southern Star Central Gas Pipeline",
+      "operator": "Southern Star Central Gas Pipeline Inc [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 24.53,
+      "lengthKm": 9334,
+      "inService": 1904,
+      "startPoint": {
+        "lat": 35.958498,
+        "lon": -99.975493
+      },
+      "endPoint": {
+        "lat": 39.133568,
+        "lon": -98.2176
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "srto-surgut-omsk-gas-pipeline-ru": {
+      "id": "srto-surgut-omsk-gas-pipeline-ru",
+      "name": "SRTO-Surgut-Omsk Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 32.8,
+      "lengthKm": 763,
+      "inService": 1989,
+      "startPoint": {
+        "lat": 63.19162,
+        "lon": 75.549
+      },
+      "endPoint": {
+        "lat": 55.2094,
+        "lon": 73.33994
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "srto-ural-gas-pipeline-i-ru": {
+      "id": "srto-ural-gas-pipeline-i-ru",
+      "name": "SRTO-Ural Gas Pipeline - I",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 16.2,
+      "lengthKm": 1986,
+      "inService": 1974,
+      "startPoint": {
+        "lat": 62.76384,
+        "lon": 64.2772
+      },
+      "endPoint": {
+        "lat": 56.849723,
+        "lon": 60.600586
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "statpipe-gas-pipeline-no": {
+      "id": "statpipe-gas-pipeline-no",
+      "name": "Statpipe Gas Pipeline",
+      "operator": "Petoro AS; Solveig Gas Norway [23.48%]; CapeOmega; Allianz SE; Infragas Norge AS; Equinor; Tallyman AS; ConocoPhillips; Ørsted AS; Engie SA; RWE AG",
+      "commodityType": "gas",
+      "fromCountry": "NO",
+      "toCountry": "NO",
+      "transitCountries": [],
+      "capacityBcmYr": 18.9,
+      "lengthKm": 892,
+      "inService": 1985,
+      "startPoint": {
+        "lat": 60.560875,
+        "lon": 2.896863
+      },
+      "endPoint": {
+        "lat": 61.18583,
+        "lon": 1.845936
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "sur-de-texas-tuxpan-gas-pipeline-us": {
+      "id": "sur-de-texas-tuxpan-gas-pipeline-us",
+      "name": "Sur de Texas-Tuxpan Gas Pipeline",
+      "operator": "TC Energy [60.00%]; IEnova [40.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "MX",
+      "transitCountries": [],
+      "capacityBcmYr": 26.57,
+      "lengthKm": 770,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 21.271997,
+        "lon": -97.465183
+      },
+      "endPoint": {
+        "lat": 22.307103,
+        "lon": -98.103785
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "tallgrass-interstate-gas-transmission-us": {
+      "id": "tallgrass-interstate-gas-transmission-us",
+      "name": "Tallgrass Interstate Gas Transmission",
+      "operator": "Tallgrass Energy [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 8.48,
+      "lengthKm": 7491.5,
+      "inService": 1927,
+      "startPoint": {
+        "lat": 38.473472,
+        "lon": -101.040896
+      },
+      "endPoint": {
+        "lat": 40.09216,
+        "lon": -102.482944
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "taquiperenda-sucre-potos-cochabamba-gas-pipeline-bo": {
+      "id": "taquiperenda-sucre-potos-cochabamba-gas-pipeline-bo",
+      "name": "Taquiperenda-Sucre-Potosí-Cochabamba Gas Pipeline",
+      "operator": "YPFB [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "BO",
+      "toCountry": "BO",
+      "transitCountries": [],
+      "capacityBcmYr": 0.22,
+      "lengthKm": 900.89,
+      "inService": 0,
+      "startPoint": {
+        "lat": -20.000123,
+        "lon": -63.895576
+      },
+      "endPoint": {
+        "lat": -19.535804,
+        "lon": -65.706819
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "tejas-gas-pipeline-us": {
+      "id": "tejas-gas-pipeline-us",
+      "name": "Tejas Gas Pipeline",
+      "operator": "Kinder Morgan [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 1.23,
+      "lengthKm": 5221,
+      "inService": 1953,
+      "startPoint": {
+        "lat": 26.89744,
+        "lon": -99.293676
+      },
+      "endPoint": {
+        "lat": 32.803121,
+        "lon": -95.442771
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "tennessee-gas-pipeline-us": {
+      "id": "tennessee-gas-pipeline-us",
+      "name": "Tennessee Gas Pipeline",
+      "operator": "Kinder Morgan [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 10.22,
+      "lengthKm": 18925.89,
+      "inService": 1943,
+      "startPoint": {
+        "lat": 32.555663,
+        "lon": -92.178086
+      },
+      "endPoint": {
+        "lat": 42.414198,
+        "lon": -77.458042
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "texas-eastern-transmission-tetco-gas-pipeline-us": {
+      "id": "texas-eastern-transmission-tetco-gas-pipeline-us",
+      "name": "Texas Eastern Transmission (TETCO) Gas Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 119.47,
+      "lengthKm": 14202,
+      "inService": 1942,
+      "startPoint": {
+        "lat": 36.136185,
+        "lon": -86.406632
+      },
+      "endPoint": {
+        "lat": 38.229159,
+        "lon": -83.704513
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "texas-gas-transmission-pipeline-us": {
+      "id": "texas-gas-transmission-pipeline-us",
+      "name": "Texas Gas Transmission Pipeline",
+      "operator": "Boardwalk Pipeline Partners [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 62.34,
+      "lengthKm": 9615.83,
+      "inService": 1948,
+      "startPoint": {
+        "lat": 37.022027,
+        "lon": -88.326334
+      },
+      "endPoint": {
+        "lat": 38.844478,
+        "lon": -86.320491
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "texas-intrastate-system-gas-pipeline-us": {
+      "id": "texas-intrastate-system-gas-pipeline-us",
+      "name": "Texas Intrastate System Gas Pipeline",
+      "operator": "Enterprise Products Partners [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 74.89,
+      "lengthKm": 10895.26,
+      "inService": 1960,
+      "startPoint": {
+        "lat": 31.298221,
+        "lon": -103.120599
+      },
+      "endPoint": {
+        "lat": 33.66974,
+        "lon": -96.629386
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "tgi-pipeline-network-ballena-barrancabermeja-co": {
+      "id": "tgi-pipeline-network-ballena-barrancabermeja-co",
+      "name": "TGI Pipeline Network - Ballena-Barrancabermeja",
+      "operator": "TGI SAS E.S.P [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CO",
+      "toCountry": "CO",
+      "transitCountries": [],
+      "capacityBcmYr": 2.66,
+      "lengthKm": 771,
+      "inService": 1996,
+      "startPoint": {
+        "lat": 11.695224,
+        "lon": -72.724988
+      },
+      "endPoint": {
+        "lat": 8.686579,
+        "lon": -73.670202
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "tgi-pipeline-network-centro-oriente-co": {
+      "id": "tgi-pipeline-network-centro-oriente-co",
+      "name": "TGI Pipeline Network - Centro-Oriente",
+      "operator": "TGI SAS E.S.P [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CO",
+      "toCountry": "CO",
+      "transitCountries": [],
+      "capacityBcmYr": 4.46,
+      "lengthKm": 1120,
+      "inService": 1996,
+      "startPoint": {
+        "lat": 7.086065,
+        "lon": -73.862337
+      },
+      "endPoint": {
+        "lat": 4.278358,
+        "lon": -74.818664
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "tgi-pipeline-network-mariquita-cali-co": {
+      "id": "tgi-pipeline-network-mariquita-cali-co",
+      "name": "TGI Pipeline Network - Mariquita-Cali",
+      "operator": "TGI SAS E.S.P [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CO",
+      "toCountry": "CO",
+      "transitCountries": [],
+      "capacityBcmYr": 1.72,
+      "lengthKm": 797,
+      "inService": 1997,
+      "startPoint": {
+        "lat": 5.220846,
+        "lon": -74.870404
+      },
+      "endPoint": {
+        "lat": 4.439967,
+        "lon": -75.782595
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "torzhok-minsk-ivatsevichy-gas-pipeline-i-ru": {
+      "id": "torzhok-minsk-ivatsevichy-gas-pipeline-i-ru",
+      "name": "Torzhok-Minsk-Ivatsevichy Gas Pipeline - I",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "BY",
+      "transitCountries": [],
+      "capacityBcmYr": 40,
+      "lengthKm": 851,
+      "inService": 1974,
+      "startPoint": {
+        "lat": 57.0393,
+        "lon": 34.974
+      },
+      "endPoint": {
+        "lat": 52.708,
+        "lon": 25.335
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "torzhok-smolensk-mazyr-dolyna-gas-pipeline-ru": {
+      "id": "torzhok-smolensk-mazyr-dolyna-gas-pipeline-ru",
+      "name": "Torzhok-Smolensk-Mazyr-Dolyna Gas Pipeline",
+      "operator": "Gas Transmission System Operator of Ukraine; Gazprom PJSC",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "UA",
+      "transitCountries": [
+        "BY"
+      ],
+      "capacityBcmYr": 22,
+      "lengthKm": 1300,
+      "inService": 1996,
+      "startPoint": {
+        "lat": 56.95741,
+        "lon": 35.03115
+      },
+      "endPoint": {
+        "lat": 48.78983,
+        "lon": 24.01413
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "trans-adriatic-gas-pipeline-tr": {
+      "id": "trans-adriatic-gas-pipeline-tr",
+      "name": "Trans-Adriatic Gas Pipeline",
+      "operator": "Trans Adriatic Pipeline AG [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "TR",
+      "toCountry": "IT",
+      "transitCountries": [
+        "GR",
+        "AL"
+      ],
+      "capacityBcmYr": 10,
+      "lengthKm": 878,
+      "inService": 2020,
+      "startPoint": {
+        "lat": 40.50733,
+        "lon": 20.199479
+      },
+      "endPoint": {
+        "lat": 41.016503,
+        "lon": 24.696373
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "trans-anatolian-gas-pipeline-main-line-phase-0-and-1-ge": {
+      "id": "trans-anatolian-gas-pipeline-main-line-phase-0-and-1-ge",
+      "name": "Trans-Anatolian Gas Pipeline - Main Line (Phase 0 and 1)",
+      "operator": "Southern Gas Corridor CJSC [51.00%]; BOTAŞ [30.00%]; BP plc [12.00%]; SOCAR [7.00%]",
+      "commodityType": "gas",
+      "fromCountry": "GE",
+      "toCountry": "TR",
+      "transitCountries": [],
+      "capacityBcmYr": 16,
+      "lengthKm": 1811,
+      "inService": 2018,
+      "startPoint": {
+        "lat": 40.340371,
+        "lon": 42.495929
+      },
+      "endPoint": {
+        "lat": 39.084214,
+        "lon": 35.946544
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "trans-nigeria-gas-pipeline-phase-1-ajaokuta-kaduna-kano-pipe-ng": {
+      "id": "trans-nigeria-gas-pipeline-phase-1-ajaokuta-kaduna-kano-pipe-ng",
+      "name": "Trans Nigeria Gas Pipeline - Phase 1: Ajaokuta–Kaduna–Kano Pipeline (AKK Pipeline)",
+      "operator": "Nigerian National Petroleum Corp [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "NG",
+      "toCountry": "NG",
+      "transitCountries": [],
+      "capacityBcmYr": 35.77,
+      "lengthKm": 1300,
+      "inService": 2025,
+      "startPoint": {
+        "lat": 9.085473,
+        "lon": 7.401924
+      },
+      "endPoint": {
+        "lat": 11.989088,
+        "lon": 8.534712
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "transcontinental-gas-pipeline-system-network-info-main-line-us": {
+      "id": "transcontinental-gas-pipeline-system-network-info-main-line-us",
+      "name": "Transcontinental Gas Pipeline - SYSTEM/NETWORK INFO (Main Line)",
+      "operator": "Transco [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 171.7,
+      "lengthKm": 10200,
+      "inService": 1950,
+      "startPoint": {
+        "lat": 40.229115,
+        "lon": -74.794428
+      },
+      "endPoint": {
+        "lat": 40.441177,
+        "lon": -74.315548
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "transwestern-gas-pipeline-us": {
+      "id": "transwestern-gas-pipeline-us",
+      "name": "Transwestern Gas Pipeline",
+      "operator": "ETP Legacy [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 28.97,
+      "lengthKm": 4345,
+      "inService": 1960,
+      "startPoint": {
+        "lat": 34.955334,
+        "lon": -114.538279
+      },
+      "endPoint": {
+        "lat": 35.537261,
+        "lon": -108.642074
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "trunkline-gas-pipeline-us": {
+      "id": "trunkline-gas-pipeline-us",
+      "name": "Trunkline Gas Pipeline",
+      "operator": "ETP Legacy [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 15.33,
+      "lengthKm": 3932,
+      "inService": 1947,
+      "startPoint": {
+        "lat": 28.372629,
+        "lon": -97.517969
+      },
+      "endPoint": {
+        "lat": 31.599724,
+        "lon": -92.432055
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "turkmenistan-afghanistan-pakistan-india-gas-pipeline-tm": {
+      "id": "turkmenistan-afghanistan-pakistan-india-gas-pipeline-tm",
+      "name": "Turkmenistan-Afghanistan-Pakistan-India Gas Pipeline",
+      "operator": "Turkmengaz [85.00%]; Afghan Gas Enterprise [5.00%]; Interstate Gas Systems [5.00%]; GAIL (India) Ltd [5.00%]",
+      "commodityType": "gas",
+      "fromCountry": "TM",
+      "toCountry": "IN",
+      "transitCountries": [
+        "AF",
+        "PK"
+      ],
+      "capacityBcmYr": 33,
+      "lengthKm": 1814,
+      "inService": 0,
+      "startPoint": {
+        "lat": 37.320475,
+        "lon": 62.326071
+      },
+      "endPoint": {
+        "lat": 31.716949,
+        "lon": 65.715115
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "turkstream-gas-pipeline-1-ru": {
+      "id": "turkstream-gas-pipeline-1-ru",
+      "name": "TurkStream Gas Pipeline - 1",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "TR",
+      "transitCountries": [],
+      "capacityBcmYr": 15.75,
+      "lengthKm": 930,
+      "inService": 2020,
+      "startPoint": {
+        "lat": 41.480007,
+        "lon": 27.328246
+      },
+      "endPoint": {
+        "lat": 41.66008,
+        "lon": 28.089251
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "turkstream-gas-pipeline-2-ru": {
+      "id": "turkstream-gas-pipeline-2-ru",
+      "name": "TurkStream Gas Pipeline - 2",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "TR",
+      "transitCountries": [],
+      "capacityBcmYr": 15.75,
+      "lengthKm": 930,
+      "inService": 2020,
+      "startPoint": {
+        "lat": 44.657833,
+        "lon": 37.488667
+      },
+      "endPoint": {
+        "lat": 42.06039,
+        "lon": 27.028453
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "ukhta-torzhok-yamal-2-gas-pipeline-ru": {
+      "id": "ukhta-torzhok-yamal-2-gas-pipeline-ru",
+      "name": "Ukhta-Torzhok (Yamal) 2 Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 45,
+      "lengthKm": 970,
+      "inService": 2018,
+      "startPoint": {
+        "lat": 63.671248,
+        "lon": 53.723934
+      },
+      "endPoint": {
+        "lat": 58.763426,
+        "lon": 40.22122
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "ukhta-torzhok-yamal-gas-pipeline-ru": {
+      "id": "ukhta-torzhok-yamal-gas-pipeline-ru",
+      "name": "Ukhta-Torzhok (Yamal) Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 45,
+      "lengthKm": 970,
+      "inService": 2012,
+      "startPoint": {
+        "lat": 62.901527,
+        "lon": 52.033842
+      },
+      "endPoint": {
+        "lat": 58.760324,
+        "lon": 40.222181
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "urengoy-center-gas-pipeline-i-ru": {
+      "id": "urengoy-center-gas-pipeline-i-ru",
+      "name": "Urengoy-Center Gas Pipeline - I",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 32.49,
+      "lengthKm": 3211,
+      "inService": 1984,
+      "startPoint": {
+        "lat": 66.48333,
+        "lon": 76.51694
+      },
+      "endPoint": {
+        "lat": 53.242222,
+        "lon": 40.446944
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "urengoy-chelyabinsk-gas-pipeline-ru": {
+      "id": "urengoy-chelyabinsk-gas-pipeline-ru",
+      "name": "Urengoy-Chelyabinsk Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 58,
+      "lengthKm": 1780,
+      "inService": 1979,
+      "startPoint": {
+        "lat": 66.03047,
+        "lon": 76.82846
+      },
+      "endPoint": {
+        "lat": 55.37083,
+        "lon": 61.28747
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "urengoy-novopskov-gas-pipeline-ru": {
+      "id": "urengoy-novopskov-gas-pipeline-ru",
+      "name": "Urengoy-Novopskov Gas Pipeline",
+      "operator": "Gazprom PJSC; Gas Transmission System Operator of Ukraine",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "UA",
+      "transitCountries": [],
+      "capacityBcmYr": 31,
+      "lengthKm": 3609,
+      "inService": 1982,
+      "startPoint": {
+        "lat": 66.071385,
+        "lon": 76.797931
+      },
+      "endPoint": {
+        "lat": 49.526058,
+        "lon": 39.151132
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "urengoy-petrovsk-gas-pipeline-ru": {
+      "id": "urengoy-petrovsk-gas-pipeline-ru",
+      "name": "Urengoy-Petrovsk Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 32,
+      "lengthKm": 2733,
+      "inService": 1983,
+      "startPoint": {
+        "lat": 66.071385,
+        "lon": 76.797931
+      },
+      "endPoint": {
+        "lat": 52.25748,
+        "lon": 45.42233
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "urengoy-pomary-uzhgorod-gas-pipeline-ru": {
+      "id": "urengoy-pomary-uzhgorod-gas-pipeline-ru",
+      "name": "Urengoy-Pomary-Uzhgorod Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]; Gas Transmission System Operator of Ukraine",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "UA",
+      "transitCountries": [],
+      "capacityBcmYr": 32,
+      "lengthKm": 4451,
+      "inService": 1983,
+      "startPoint": {
+        "lat": 48.85557,
+        "lon": 24.045958
+      },
+      "endPoint": {
+        "lat": 61.785336,
+        "lon": 64.561147
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "victorian-transmission-system-au": {
+      "id": "victorian-transmission-system-au",
+      "name": "Victorian Transmission System",
+      "operator": "APA Group [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityBcmYr": 10.34,
+      "lengthKm": 2035,
+      "inService": 1969,
+      "startPoint": {
+        "lat": -35.66077,
+        "lon": 147.01716
+      },
+      "endPoint": {
+        "lat": -37.594066,
+        "lon": 144.183257
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "viking-gas-transmission-ca": {
+      "id": "viking-gas-transmission-ca",
+      "name": "Viking Gas Transmission",
+      "operator": "ONEOK Inc [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 5.11,
+      "lengthKm": 1079.87,
+      "inService": 1996,
+      "startPoint": {
+        "lat": 49.005584,
+        "lon": -97.208086
+      },
+      "endPoint": {
+        "lat": 44.662991,
+        "lon": -90.192536
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "wafa-mellitah-gas-pipeline-pipeline-1-ly": {
+      "id": "wafa-mellitah-gas-pipeline-pipeline-1-ly",
+      "name": "Wafa-Mellitah Gas Pipeline - Pipeline 1",
+      "operator": "Libyan National Oil Corp [50.00%]; Eni SpA [50.00%]",
+      "commodityType": "gas",
+      "fromCountry": "LY",
+      "toCountry": "LY",
+      "transitCountries": [],
+      "capacityBcmYr": 13,
+      "lengthKm": 5246,
+      "inService": 2004,
+      "startPoint": {
+        "lat": 28.8885,
+        "lon": 10.0235
+      },
+      "endPoint": {
+        "lat": 32.8538,
+        "lon": 12.2375
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "west-east-gas-pipeline-1-cn": {
+      "id": "west-east-gas-pipeline-1-cn",
+      "name": "West-East Gas Pipeline 1",
+      "operator": "--",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 17,
+      "lengthKm": 4000,
+      "inService": 2005,
+      "startPoint": {
+        "lat": 41.475422,
+        "lon": 84.2161
+      },
+      "endPoint": {
+        "lat": 31.25252,
+        "lon": 121.139422
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "west-east-gas-pipeline-2-cn": {
+      "id": "west-east-gas-pipeline-2-cn",
+      "name": "West-East Gas Pipeline 2",
+      "operator": "China Petroleum West Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 30,
+      "lengthKm": 9102,
+      "inService": 2012,
+      "startPoint": {
+        "lat": 44.211743,
+        "lon": 80.389959
+      },
+      "endPoint": {
+        "lat": 43.162187,
+        "lon": 88.847569
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "west-east-gas-pipeline-2-nanchang-shanghai-branch-cn": {
+      "id": "west-east-gas-pipeline-2-nanchang-shanghai-branch-cn",
+      "name": "West-East Gas Pipeline 2 - Nanchang-Shanghai Branch",
+      "operator": "West to East Gas Transmission Branch of National Petroleum Pipeline Network Group Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 10,
+      "lengthKm": 822.7,
+      "inService": 2011,
+      "startPoint": {
+        "lat": 28.514698,
+        "lon": 115.500411
+      },
+      "endPoint": {
+        "lat": 31.241703,
+        "lon": 121.144346
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "west-east-gas-pipeline-3-cn": {
+      "id": "west-east-gas-pipeline-3-cn",
+      "name": "West-East Gas Pipeline 3",
+      "operator": "--",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 30,
+      "lengthKm": 7378,
+      "inService": 0,
+      "startPoint": {
+        "lat": 44.211373,
+        "lon": 80.409797
+      },
+      "endPoint": {
+        "lat": 32.053556,
+        "lon": 117.197791
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "west-east-gas-pipeline-3-east-section-ji-an-fuzhou-cn": {
+      "id": "west-east-gas-pipeline-3-east-section-ji-an-fuzhou-cn",
+      "name": "West-East Gas Pipeline 3 - East Section (Ji'an–Fuzhou)",
+      "operator": "National Pipe Network Group United Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 30,
+      "lengthKm": 817,
+      "inService": 2016,
+      "startPoint": {
+        "lat": 27.106776,
+        "lon": 114.970112
+      },
+      "endPoint": {
+        "lat": 26.068932,
+        "lon": 119.436656
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "west-east-gas-pipeline-3-middle-section-zhongwei-ji-an-cn": {
+      "id": "west-east-gas-pipeline-3-middle-section-zhongwei-ji-an-cn",
+      "name": "West-East Gas Pipeline 3 - Middle Section (Zhongwei–Ji'an)",
+      "operator": "National Pipe Network Group United Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 25,
+      "lengthKm": 2090,
+      "inService": 2025,
+      "startPoint": {
+        "lat": 37.459851,
+        "lon": 105.147203
+      },
+      "endPoint": {
+        "lat": 27.106776,
+        "lon": 114.970112
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "west-east-gas-pipeline-3-west-section-khorgos-zhongwei-cn": {
+      "id": "west-east-gas-pipeline-3-west-section-khorgos-zhongwei-cn",
+      "name": "West-East Gas Pipeline 3 - West Section (Khorgos–Zhongwei)",
+      "operator": "National Pipe Network Group United Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 30,
+      "lengthKm": 2445,
+      "inService": 2014,
+      "startPoint": {
+        "lat": 44.211743,
+        "lon": 80.389959
+      },
+      "endPoint": {
+        "lat": 37.459851,
+        "lon": 105.147203
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "west-east-gas-pipeline-4-updated-route-cn": {
+      "id": "west-east-gas-pipeline-4-updated-route-cn",
+      "name": "West-East Gas Pipeline 4 - Updated route",
+      "operator": "National Petroleum and Natural Gas Pipeline Network Group Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 15,
+      "lengthKm": 1745,
+      "inService": 2025,
+      "startPoint": {
+        "lat": 43.970352,
+        "lon": 81.475926
+      },
+      "endPoint": {
+        "lat": 37.459851,
+        "lon": 105.147203
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "whistler-pipeline-us": {
+      "id": "whistler-pipeline-us",
+      "name": "Whistler Pipeline",
+      "operator": "Whistler Pipeline LLC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 20.44,
+      "lengthKm": 764,
+      "inService": 2021,
+      "startPoint": {
+        "lat": 27.745232,
+        "lon": -97.812123
+      },
+      "endPoint": {
+        "lat": 27.752643,
+        "lon": -97.857289
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "williston-basin-gas-pipeline-us": {
+      "id": "williston-basin-gas-pipeline-us",
+      "name": "Williston Basin Gas Pipeline",
+      "operator": "WBI Energy [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 21.46,
+      "lengthKm": 5413.83,
+      "inService": 1920,
+      "startPoint": {
+        "lat": 46.309888,
+        "lon": -106.67776
+      },
+      "endPoint": {
+        "lat": 45.894163,
+        "lon": -106.641564
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "wyoming-interstate-gas-pipeline-us": {
+      "id": "wyoming-interstate-gas-pipeline-us",
+      "name": "Wyoming Interstate Gas Pipeline",
+      "operator": "Kinder Morgan [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityBcmYr": 39.86,
+      "lengthKm": 1287.48,
+      "inService": 1997,
+      "startPoint": {
+        "lat": 41.669933,
+        "lon": -108.035553
+      },
+      "endPoint": {
+        "lat": 41.761401,
+        "lon": -107.31689
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "xinjiang-coal-to-gas-pipeline-cn": {
+      "id": "xinjiang-coal-to-gas-pipeline-cn",
+      "name": "Xinjiang Coal-to-Gas Pipeline",
+      "operator": "State Pipe Network Group Xinjiang Coal To Natural Gas Export Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 30,
+      "lengthKm": 4159,
+      "inService": 2022,
+      "startPoint": {
+        "lat": 44.024475,
+        "lon": 90.149571
+      },
+      "endPoint": {
+        "lat": 24.821935,
+        "lon": 113.667615
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "xinjiang-gas-pipeline-network-cn": {
+      "id": "xinjiang-gas-pipeline-network-cn",
+      "name": "Xinjiang Gas Pipeline Network",
+      "operator": "PetroChina Xinjiang Oilfield Oil and Gas Storage and Transportation Branch [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 12,
+      "lengthKm": 760,
+      "inService": 2008,
+      "startPoint": {
+        "lat": 45.430602,
+        "lon": 86.866238
+      },
+      "endPoint": {
+        "lat": 44.975883,
+        "lon": 88.360835
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "yacheng-hong-kong-gas-pipeline-cn": {
+      "id": "yacheng-hong-kong-gas-pipeline-cn",
+      "name": "Yacheng-Hong Kong Gas Pipeline",
+      "operator": "CNOOC Ltd; Atlantic Richfield Co; Kuwait Petroleum Corp",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [
+        "HK"
+      ],
+      "capacityBcmYr": 3.4,
+      "lengthKm": 778,
+      "inService": 1996,
+      "startPoint": {
+        "lat": 18.381293,
+        "lon": 109.254334
+      },
+      "endPoint": {
+        "lat": 18.01637,
+        "lon": 109.398686
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "yamburg-volga-region-gas-pipeline-ru": {
+      "id": "yamburg-volga-region-gas-pipeline-ru",
+      "name": "Yamburg-Volga Region Gas Pipeline",
+      "operator": "Gazprom PJSC [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityBcmYr": 32.49,
+      "lengthKm": 2755,
+      "inService": 1990,
+      "startPoint": {
+        "lat": 67.85743,
+        "lon": 75.46492
+      },
+      "endPoint": {
+        "lat": 51.553185,
+        "lon": 46.018363
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "yelets-kremenchuk-kryvyi-rih-gas-pipeline-ru": {
+      "id": "yelets-kremenchuk-kryvyi-rih-gas-pipeline-ru",
+      "name": "Yelets-Kremenchuk–Kryvyi Rih Gas Pipeline",
+      "operator": "Gazprom PJSC; Gas Transmission System Operator of Ukraine",
+      "commodityType": "gas",
+      "fromCountry": "RU",
+      "toCountry": "UA",
+      "transitCountries": [],
+      "capacityBcmYr": 34.68,
+      "lengthKm": 771,
+      "inService": 1986,
+      "startPoint": {
+        "lat": 52.618026,
+        "lon": 38.504582
+      },
+      "endPoint": {
+        "lat": 47.913069,
+        "lon": 33.388533
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "yu-ji-pipeline-network-yulin-jinan-gas-pipeline-cn": {
+      "id": "yu-ji-pipeline-network-yulin-jinan-gas-pipeline-cn",
+      "name": "Yu-ji Pipeline Network - Yulin-Jinan Gas Pipeline",
+      "operator": "Sinopec Yu Ji Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 3,
+      "lengthKm": 911,
+      "inService": 2010,
+      "startPoint": {
+        "lat": 38.276825,
+        "lon": 109.543413
+      },
+      "endPoint": {
+        "lat": 36.936466,
+        "lon": 116.82381
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "zeepipe-gas-pipeline-zeepipe-i-no": {
+      "id": "zeepipe-gas-pipeline-zeepipe-i-no",
+      "name": "Zeepipe Gas Pipeline - Zeepipe I",
+      "operator": "Gasled [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "NO",
+      "toCountry": "BE",
+      "transitCountries": [],
+      "capacityBcmYr": 14.97,
+      "lengthKm": 844,
+      "inService": 1993,
+      "startPoint": {
+        "lat": 58.36433,
+        "lon": 1.914243
+      },
+      "endPoint": {
+        "lat": 58.190334,
+        "lon": 2.462768
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "zhongwei-guiyang-connecting-gas-pipeline-trunk-line-cn": {
+      "id": "zhongwei-guiyang-connecting-gas-pipeline-trunk-line-cn",
+      "name": "Zhongwei-Guiyang Connecting Gas Pipeline - Trunk line",
+      "operator": "National Pipe Network Group Southwest Pipeline Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 15,
+      "lengthKm": 1608,
+      "inService": 2012,
+      "startPoint": {
+        "lat": 37.459796,
+        "lon": 105.147714
+      },
+      "endPoint": {
+        "lat": 26.311174,
+        "lon": 106.545545
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
+    },
+    "zhongxian-wuhan-gas-pipeline-cn": {
+      "id": "zhongxian-wuhan-gas-pipeline-cn",
+      "name": "Zhongxian-Wuhan Gas Pipeline",
+      "operator": "National Petroleum and Natural Gas Pipeline Network Group Co Ltd [100.00%]",
+      "commodityType": "gas",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityBcmYr": 3,
+      "lengthKm": 1375,
+      "inService": 2004,
+      "startPoint": {
+        "lat": 30.355944,
+        "lon": 107.897793
+      },
+      "endPoint": {
+        "lat": 32.052539,
+        "lon": 112.167706
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      }
     }
   }
 }

--- a/scripts/data/pipelines-gas.json
+++ b/scripts/data/pipelines-gas.json
@@ -3467,36 +3467,6 @@
         "classifierConfidence": 0.4
       }
     },
-    "china-russia-east-pipeline-system-network-info-cn": {
-      "id": "china-russia-east-pipeline-system-network-info-cn",
-      "name": "China–Russia East Pipeline - SYSTEM/NETWORK INFO",
-      "operator": "National Pipe Network Group North Pipeline Co Ltd [100.00%]",
-      "commodityType": "gas",
-      "fromCountry": "CN",
-      "toCountry": "CN",
-      "transitCountries": [],
-      "capacityBcmYr": 38,
-      "lengthKm": 5111,
-      "inService": 2022,
-      "startPoint": {
-        "lat": 39.297164,
-        "lon": 116.51979
-      },
-      "endPoint": {
-        "lat": 39.297164,
-        "lon": 116.51979
-      },
-      "evidence": {
-        "physicalState": "flowing",
-        "physicalStateSource": "gem",
-        "operatorStatement": null,
-        "commercialState": "unknown",
-        "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
-        "classifierVersion": "gem-import-v1",
-        "classifierConfidence": 0.4
-      }
-    },
     "china-russia-far-east-gas-pipeline-hulin-changchun-trunk-lin-cn": {
       "id": "china-russia-far-east-gas-pipeline-hulin-changchun-trunk-lin-cn",
       "name": "China–Russia Far East Gas Pipeline - Hulin–Changchun Trunk Line",
@@ -3755,36 +3725,6 @@
       "endPoint": {
         "lat": 24.489186,
         "lon": 77.137452
-      },
-      "evidence": {
-        "physicalState": "flowing",
-        "physicalStateSource": "gem",
-        "operatorStatement": null,
-        "commercialState": "unknown",
-        "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
-        "classifierVersion": "gem-import-v1",
-        "classifierConfidence": 0.4
-      }
-    },
-    "dampier-to-bunbury-natural-gas-pipeline-au": {
-      "id": "dampier-to-bunbury-natural-gas-pipeline-au",
-      "name": "Dampier to Bunbury Natural Gas Pipeline",
-      "operator": "DUET Group [80.00%]; Alcoa [20.00%]",
-      "commodityType": "gas",
-      "fromCountry": "AU",
-      "toCountry": "AU",
-      "transitCountries": [],
-      "capacityBcmYr": 8.67,
-      "lengthKm": 1597,
-      "inService": 1984,
-      "startPoint": {
-        "lat": -33.265797,
-        "lon": 115.755682
-      },
-      "endPoint": {
-        "lat": -24.86854,
-        "lon": 113.674968
       },
       "evidence": {
         "physicalState": "flowing",
@@ -4877,36 +4817,6 @@
         "classifierConfidence": 0.4
       }
     },
-    "ichthys-gas-pipeline-au": {
-      "id": "ichthys-gas-pipeline-au",
-      "name": "Ichthys Gas Pipeline",
-      "operator": "INPEX Corp [50.00%]; TotalEnergies SE [30.00%]; Government of Taiwan [2.63%]; Tokyo Gas [1.58%]; Osaka Gas [1.20%]; Kansai Electric Power Co [1.20%]; Nuclear Damage Compensation and Decommissioning Facilitation Corp [0.37%]; Toho Gas [0.42%]; Chubu Electric Power [0.37%]",
-      "commodityType": "gas",
-      "fromCountry": "AU",
-      "toCountry": "AU",
-      "transitCountries": [],
-      "capacityBcmYr": 16.35,
-      "lengthKm": 889,
-      "inService": 2018,
-      "startPoint": {
-        "lat": -12.519356,
-        "lon": 128.393202
-      },
-      "endPoint": {
-        "lat": -12.519356,
-        "lon": 128.393202
-      },
-      "evidence": {
-        "physicalState": "flowing",
-        "physicalStateSource": "gem",
-        "operatorStatement": null,
-        "commercialState": "unknown",
-        "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
-        "classifierVersion": "gem-import-v1",
-        "classifierConfidence": 0.4
-      }
-    },
     "igat-11-gas-pipeline-ir": {
       "id": "igat-11-gas-pipeline-ir",
       "name": "IGAT 11 Gas Pipeline",
@@ -5708,36 +5618,6 @@
       "endPoint": {
         "lat": -34.805,
         "lon": 138.52
-      },
-      "evidence": {
-        "physicalState": "flowing",
-        "physicalStateSource": "gem",
-        "operatorStatement": null,
-        "commercialState": "unknown",
-        "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
-        "classifierVersion": "gem-import-v1",
-        "classifierConfidence": 0.4
-      }
-    },
-    "moomba-sydney-pipeline-system-au": {
-      "id": "moomba-sydney-pipeline-system-au",
-      "name": "Moomba Sydney Pipeline System",
-      "operator": "APA Group [100.00%]",
-      "commodityType": "gas",
-      "fromCountry": "AU",
-      "toCountry": "AU",
-      "transitCountries": [],
-      "capacityBcmYr": 4.48,
-      "lengthKm": 1300,
-      "inService": 1976,
-      "startPoint": {
-        "lat": -28.115865,
-        "lon": 140.206289
-      },
-      "endPoint": {
-        "lat": -33.96409,
-        "lon": 150.9806
       },
       "evidence": {
         "physicalState": "flowing",

--- a/scripts/data/pipelines-oil.json
+++ b/scripts/data/pipelines-oil.json
@@ -1,5 +1,5 @@
 {
-  "source": "Curated from operator disclosures, regulator filings, GEM (CC-BY 4.0)",
+  "source": "Curated from operator disclosures, regulator filings, GEM (CC-BY 4.0) + Global Energy Monitor (CC-BY 4.0)",
   "methodologyUrl": "/docs/methodology/pipelines",
   "version": "v1",
   "referenceYear": 2026,
@@ -13,12 +13,21 @@
       "productClass": "crude",
       "fromCountry": "RU",
       "toCountry": "DE",
-      "transitCountries": ["BY", "PL"],
-      "capacityMbd": 1.0,
+      "transitCountries": [
+        "BY",
+        "PL"
+      ],
+      "capacityMbd": 1,
       "lengthKm": 4000,
       "inService": 1964,
-      "startPoint": { "lat": 52.60, "lon": 49.40 },
-      "endPoint": { "lat": 52.32, "lon": 14.06 },
+      "startPoint": {
+        "lat": 52.6,
+        "lon": 49.4
+      },
+      "endPoint": {
+        "lat": 52.32,
+        "lon": 14.06
+      },
       "evidence": {
         "physicalState": "offline",
         "physicalStateSource": "operator",
@@ -29,7 +38,12 @@
         },
         "commercialState": "suspended",
         "sanctionRefs": [
-          { "authority": "EU", "listId": "Regulation 2022/879 (Russian crude embargo)", "date": "2022-06-03", "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R0879" }
+          {
+            "authority": "EU",
+            "listId": "Regulation 2022/879 (Russian crude embargo)",
+            "date": "2022-06-03",
+            "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R0879"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -44,19 +58,34 @@
       "productClass": "crude",
       "fromCountry": "RU",
       "toCountry": "HU",
-      "transitCountries": ["BY", "UA", "SK"],
+      "transitCountries": [
+        "BY",
+        "UA",
+        "SK"
+      ],
       "capacityMbd": 0.6,
       "lengthKm": 2400,
       "inService": 1964,
-      "startPoint": { "lat": 52.60, "lon": 49.40 },
-      "endPoint": { "lat": 47.50, "lon": 19.04 },
+      "startPoint": {
+        "lat": 52.6,
+        "lon": 49.4
+      },
+      "endPoint": {
+        "lat": 47.5,
+        "lon": 19.04
+      },
       "evidence": {
         "physicalState": "reduced",
         "physicalStateSource": "press",
         "operatorStatement": null,
         "commercialState": "under_contract",
         "sanctionRefs": [
-          { "authority": "EU", "listId": "Regulation 2022/879 (derogation for landlocked HU/SK/CZ)", "date": "2022-06-03", "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R0879" }
+          {
+            "authority": "EU",
+            "listId": "Regulation 2022/879 (derogation for landlocked HU/SK/CZ)",
+            "date": "2022-06-03",
+            "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R0879"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -75,8 +104,14 @@
       "capacityMbd": 1.4,
       "lengthKm": 1511,
       "inService": 2001,
-      "startPoint": { "lat": 46.32, "lon": 53.40 },
-      "endPoint": { "lat": 44.72, "lon": 37.77 },
+      "startPoint": {
+        "lat": 46.32,
+        "lon": 53.4
+      },
+      "endPoint": {
+        "lat": 44.72,
+        "lon": 37.77
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -100,15 +135,26 @@
       "capacityMbd": 1.6,
       "lengthKm": 4857,
       "inService": 2009,
-      "startPoint": { "lat": 56.15, "lon": 101.88 },
-      "endPoint": { "lat": 42.66, "lon": 133.05 },
+      "startPoint": {
+        "lat": 56.15,
+        "lon": 101.88
+      },
+      "endPoint": {
+        "lat": 42.66,
+        "lon": 133.05
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
         "operatorStatement": null,
         "commercialState": "under_contract",
         "sanctionRefs": [
-          { "authority": "G7+EU", "listId": "Russian crude price cap ($60/bbl; $47.60 from 2026-02)", "date": "2022-12-05", "url": "https://home.treasury.gov/news/press-releases/jy1161" }
+          {
+            "authority": "G7+EU",
+            "listId": "Russian crude price cap ($60/bbl; $47.60 from 2026-02)",
+            "date": "2022-12-05",
+            "url": "https://home.treasury.gov/news/press-releases/jy1161"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -123,12 +169,20 @@
       "productClass": "crude",
       "fromCountry": "AZ",
       "toCountry": "TR",
-      "transitCountries": ["GE"],
+      "transitCountries": [
+        "GE"
+      ],
       "capacityMbd": 1.2,
       "lengthKm": 1768,
       "inService": 2006,
-      "startPoint": { "lat": 40.38, "lon": 49.87 },
-      "endPoint": { "lat": 36.87, "lon": 35.93 },
+      "startPoint": {
+        "lat": 40.38,
+        "lon": 49.87
+      },
+      "endPoint": {
+        "lat": 36.87,
+        "lon": 35.93
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -152,8 +206,14 @@
       "capacityMbd": 2.1,
       "lengthKm": 1287,
       "inService": 1977,
-      "startPoint": { "lat": 70.25, "lon": -148.34 },
-      "endPoint": { "lat": 61.13, "lon": -146.35 },
+      "startPoint": {
+        "lat": 70.25,
+        "lon": -148.34
+      },
+      "endPoint": {
+        "lat": 61.13,
+        "lon": -146.35
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -177,8 +237,14 @@
       "capacityMbd": 1.5,
       "lengthKm": 360,
       "inService": 2012,
-      "startPoint": { "lat": 23.75, "lon": 53.72 },
-      "endPoint": { "lat": 25.12, "lon": 56.36 },
+      "startPoint": {
+        "lat": 23.75,
+        "lon": 53.72
+      },
+      "endPoint": {
+        "lat": 25.12,
+        "lon": 56.36
+      },
       "note": "Strategic Hormuz bypass — rerouted volume during Hormuz disruptions.",
       "evidence": {
         "physicalState": "flowing",
@@ -203,8 +269,14 @@
       "capacityMbd": 0.59,
       "lengthKm": 4324,
       "inService": 2010,
-      "startPoint": { "lat": 53.66, "lon": -113.62 },
-      "endPoint": { "lat": 29.38, "lon": -94.90 },
+      "startPoint": {
+        "lat": 53.66,
+        "lon": -113.62
+      },
+      "endPoint": {
+        "lat": 29.38,
+        "lon": -94.9
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -228,8 +300,14 @@
       "capacityMbd": 1.6,
       "lengthKm": 970,
       "inService": 1977,
-      "startPoint": { "lat": 35.47, "lon": 44.39 },
-      "endPoint": { "lat": 36.87, "lon": 35.93 },
+      "startPoint": {
+        "lat": 35.47,
+        "lon": 44.39
+      },
+      "endPoint": {
+        "lat": 36.87,
+        "lon": 35.93
+      },
       "evidence": {
         "physicalState": "offline",
         "physicalStateSource": "press",
@@ -254,8 +332,14 @@
       "capacityMbd": 0.145,
       "lengthKm": 833,
       "inService": 1999,
-      "startPoint": { "lat": 40.38, "lon": 49.87 },
-      "endPoint": { "lat": 41.95, "lon": 41.75 },
+      "startPoint": {
+        "lat": 40.38,
+        "lon": 49.87
+      },
+      "endPoint": {
+        "lat": 41.95,
+        "lon": 41.75
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -279,8 +363,14 @@
       "capacityMbd": 0.89,
       "lengthKm": 1150,
       "inService": 1953,
-      "startPoint": { "lat": 53.55, "lon": -113.49 },
-      "endPoint": { "lat": 49.28, "lon": -122.95 },
+      "startPoint": {
+        "lat": 53.55,
+        "lon": -113.49
+      },
+      "endPoint": {
+        "lat": 49.28,
+        "lon": -122.95
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -308,15 +398,26 @@
       "capacityMbd": 0.6,
       "lengthKm": 1030,
       "inService": 2011,
-      "startPoint": { "lat": 53.37, "lon": 122.44 },
-      "endPoint": { "lat": 46.80, "lon": 125.02 },
+      "startPoint": {
+        "lat": 53.37,
+        "lon": 122.44
+      },
+      "endPoint": {
+        "lat": 46.8,
+        "lon": 125.02
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
         "operatorStatement": null,
         "commercialState": "under_contract",
         "sanctionRefs": [
-          { "authority": "G7+EU", "listId": "Russian crude price cap", "date": "2022-12-05", "url": "https://home.treasury.gov/news/press-releases/jy1161" }
+          {
+            "authority": "G7+EU",
+            "listId": "Russian crude price cap",
+            "date": "2022-12-05",
+            "url": "https://home.treasury.gov/news/press-releases/jy1161"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -335,8 +436,14 @@
       "capacityMbd": 3.15,
       "lengthKm": 4625,
       "inService": 1950,
-      "startPoint": { "lat": 53.55, "lon": -113.50 },
-      "endPoint": { "lat": 46.72, "lon": -92.10 },
+      "startPoint": {
+        "lat": 53.55,
+        "lon": -113.5
+      },
+      "endPoint": {
+        "lat": 46.72,
+        "lon": -92.1
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -360,8 +467,14 @@
       "capacityMbd": 0.76,
       "lengthKm": 1660,
       "inService": 2021,
-      "startPoint": { "lat": 53.31, "lon": -109.07 },
-      "endPoint": { "lat": 46.72, "lon": -92.10 },
+      "startPoint": {
+        "lat": 53.31,
+        "lon": -109.07
+      },
+      "endPoint": {
+        "lat": 46.72,
+        "lon": -92.1
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -385,8 +498,14 @@
       "capacityMbd": 0.6,
       "lengthKm": 950,
       "inService": 2014,
-      "startPoint": { "lat": 40.88, "lon": -88.85 },
-      "endPoint": { "lat": 35.97, "lon": -96.77 },
+      "startPoint": {
+        "lat": 40.88,
+        "lon": -88.85
+      },
+      "endPoint": {
+        "lat": 35.97,
+        "lon": -96.77
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -410,8 +529,14 @@
       "capacityMbd": 0.95,
       "lengthKm": 1060,
       "inService": 1976,
-      "startPoint": { "lat": 35.97, "lon": -96.77 },
-      "endPoint": { "lat": 28.98, "lon": -95.37 },
+      "startPoint": {
+        "lat": 35.97,
+        "lon": -96.77
+      },
+      "endPoint": {
+        "lat": 28.98,
+        "lon": -95.37
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -435,8 +560,14 @@
       "capacityMbd": 0.75,
       "lengthKm": 784,
       "inService": 2014,
-      "startPoint": { "lat": 35.97, "lon": -96.77 },
-      "endPoint": { "lat": 29.73, "lon": -93.87 },
+      "startPoint": {
+        "lat": 35.97,
+        "lon": -96.77
+      },
+      "endPoint": {
+        "lat": 29.73,
+        "lon": -93.87
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -460,8 +591,14 @@
       "capacityMbd": 0.193,
       "lengthKm": 1050,
       "inService": 1977,
-      "startPoint": { "lat": 40.88, "lon": -88.85 },
-      "endPoint": { "lat": 35.97, "lon": -96.77 },
+      "startPoint": {
+        "lat": 40.88,
+        "lon": -88.85
+      },
+      "endPoint": {
+        "lat": 35.97,
+        "lon": -96.77
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -485,8 +622,14 @@
       "capacityMbd": 2.8,
       "lengthKm": 320,
       "inService": 1977,
-      "startPoint": { "lat": 29.60, "lon": 32.35 },
-      "endPoint": { "lat": 30.95, "lon": 29.55 },
+      "startPoint": {
+        "lat": 29.6,
+        "lon": 32.35
+      },
+      "endPoint": {
+        "lat": 30.95,
+        "lon": 29.55
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -507,11 +650,17 @@
       "fromCountry": "SA",
       "toCountry": "SA",
       "transitCountries": [],
-      "capacityMbd": 5.0,
+      "capacityMbd": 5,
       "lengthKm": 1200,
       "inService": 1981,
-      "startPoint": { "lat": 26.43, "lon": 50.10 },
-      "endPoint": { "lat": 22.20, "lon": 39.13 },
+      "startPoint": {
+        "lat": 26.43,
+        "lon": 50.1
+      },
+      "endPoint": {
+        "lat": 22.2,
+        "lon": 39.13
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -535,8 +684,14 @@
       "capacityMbd": 1.65,
       "lengthKm": 1200,
       "inService": 1989,
-      "startPoint": { "lat": 30.95, "lon": 47.70 },
-      "endPoint": { "lat": 24.92, "lon": 38.55 },
+      "startPoint": {
+        "lat": 30.95,
+        "lon": 47.7
+      },
+      "endPoint": {
+        "lat": 24.92,
+        "lon": 38.55
+      },
       "evidence": {
         "physicalState": "offline",
         "physicalStateSource": "regulator",
@@ -564,8 +719,14 @@
       "capacityMbd": 0.4,
       "lengthKm": 2228,
       "inService": 2006,
-      "startPoint": { "lat": 47.11, "lon": 51.92 },
-      "endPoint": { "lat": 45.13, "lon": 82.57 },
+      "startPoint": {
+        "lat": 47.11,
+        "lon": 51.92
+      },
+      "endPoint": {
+        "lat": 45.13,
+        "lon": 82.57
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -589,8 +750,14 @@
       "capacityMbd": 0.25,
       "lengthKm": 1070,
       "inService": 2003,
-      "startPoint": { "lat": 9.20, "lon": 15.97 },
-      "endPoint": { "lat": 2.95, "lon": 9.83 },
+      "startPoint": {
+        "lat": 9.2,
+        "lon": 15.97
+      },
+      "endPoint": {
+        "lat": 2.95,
+        "lon": 9.83
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -614,8 +781,14 @@
       "capacityMbd": 0.45,
       "lengthKm": 485,
       "inService": 2003,
-      "startPoint": { "lat": -0.47, "lon": -76.98 },
-      "endPoint": { "lat": -0.95, "lon": -80.73 },
+      "startPoint": {
+        "lat": -0.47,
+        "lon": -76.98
+      },
+      "endPoint": {
+        "lat": -0.95,
+        "lon": -80.73
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -639,8 +812,14 @@
       "capacityMbd": 0.36,
       "lengthKm": 497,
       "inService": 1972,
-      "startPoint": { "lat": -0.07, "lon": -76.88 },
-      "endPoint": { "lat": -0.95, "lon": -80.73 },
+      "startPoint": {
+        "lat": -0.07,
+        "lon": -76.88
+      },
+      "endPoint": {
+        "lat": -0.95,
+        "lon": -80.73
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -660,12 +839,20 @@
       "productClass": "crude",
       "fromCountry": "IT",
       "toCountry": "DE",
-      "transitCountries": ["AT"],
+      "transitCountries": [
+        "AT"
+      ],
       "capacityMbd": 0.77,
       "lengthKm": 753,
       "inService": 1967,
-      "startPoint": { "lat": 45.67, "lon": 13.76 },
-      "endPoint": { "lat": 48.77, "lon": 11.43 },
+      "startPoint": {
+        "lat": 45.67,
+        "lon": 13.76
+      },
+      "endPoint": {
+        "lat": 48.77,
+        "lon": 11.43
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -685,12 +872,20 @@
       "productClass": "crude",
       "fromCountry": "HR",
       "toCountry": "HU",
-      "transitCountries": ["RS"],
+      "transitCountries": [
+        "RS"
+      ],
       "capacityMbd": 0.28,
       "lengthKm": 750,
       "inService": 1979,
-      "startPoint": { "lat": 45.15, "lon": 14.60 },
-      "endPoint": { "lat": 47.38, "lon": 19.00 },
+      "startPoint": {
+        "lat": 45.15,
+        "lon": 14.6
+      },
+      "endPoint": {
+        "lat": 47.38,
+        "lon": 19
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -714,8 +909,14 @@
       "capacityMbd": 0.9,
       "lengthKm": 354,
       "inService": 1975,
-      "startPoint": { "lat": 56.55, "lon": 3.22 },
-      "endPoint": { "lat": 54.15, "lon": 8.87 },
+      "startPoint": {
+        "lat": 56.55,
+        "lon": 3.22
+      },
+      "endPoint": {
+        "lat": 54.15,
+        "lon": 8.87
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -739,15 +940,26 @@
       "capacityMbd": 1.3,
       "lengthKm": 2700,
       "inService": 2001,
-      "startPoint": { "lat": 56.93, "lon": 52.92 },
-      "endPoint": { "lat": 60.37, "lon": 28.62 },
+      "startPoint": {
+        "lat": 56.93,
+        "lon": 52.92
+      },
+      "endPoint": {
+        "lat": 60.37,
+        "lon": 28.62
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
         "operatorStatement": null,
         "commercialState": "under_contract",
         "sanctionRefs": [
-          { "authority": "G7+EU", "listId": "Russian crude price cap", "date": "2022-12-05", "url": "https://home.treasury.gov/news/press-releases/jy1161" }
+          {
+            "authority": "G7+EU",
+            "listId": "Russian crude price cap",
+            "date": "2022-12-05",
+            "url": "https://home.treasury.gov/news/press-releases/jy1161"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -766,15 +978,26 @@
       "capacityMbd": 0.75,
       "lengthKm": 1170,
       "inService": 2012,
-      "startPoint": { "lat": 53.38, "lon": 34.33 },
-      "endPoint": { "lat": 59.67, "lon": 28.42 },
+      "startPoint": {
+        "lat": 53.38,
+        "lon": 34.33
+      },
+      "endPoint": {
+        "lat": 59.67,
+        "lon": 28.42
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
         "operatorStatement": null,
         "commercialState": "under_contract",
         "sanctionRefs": [
-          { "authority": "G7+EU", "listId": "Russian crude price cap", "date": "2022-12-05", "url": "https://home.treasury.gov/news/press-releases/jy1161" }
+          {
+            "authority": "G7+EU",
+            "listId": "Russian crude price cap",
+            "date": "2022-12-05",
+            "url": "https://home.treasury.gov/news/press-releases/jy1161"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -789,12 +1012,20 @@
       "productClass": "crude",
       "fromCountry": "CA",
       "toCountry": "CA",
-      "transitCountries": ["US"],
+      "transitCountries": [
+        "US"
+      ],
       "capacityMbd": 0.54,
       "lengthKm": 1038,
       "inService": 1953,
-      "startPoint": { "lat": 46.75, "lon": -92.10 },
-      "endPoint": { "lat": 42.95, "lon": -83.00 },
+      "startPoint": {
+        "lat": 46.75,
+        "lon": -92.1
+      },
+      "endPoint": {
+        "lat": 42.95,
+        "lon": -83
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -822,8 +1053,14 @@
       "capacityMbd": 0.83,
       "lengthKm": 1897,
       "inService": 0,
-      "startPoint": { "lat": 52.28, "lon": -110.83 },
-      "endPoint": { "lat": 40.03, "lon": -97.72 },
+      "startPoint": {
+        "lat": 52.28,
+        "lon": -110.83
+      },
+      "endPoint": {
+        "lat": 40.03,
+        "lon": -97.72
+      },
       "evidence": {
         "physicalState": "unknown",
         "physicalStateSource": "regulator",
@@ -851,8 +1088,14 @@
       "capacityMbd": 0.9,
       "lengthKm": 131,
       "inService": 1982,
-      "startPoint": { "lat": 9.33, "lon": -82.23 },
-      "endPoint": { "lat": 8.27, "lon": -82.80 },
+      "startPoint": {
+        "lat": 9.33,
+        "lon": -82.23
+      },
+      "endPoint": {
+        "lat": 8.27,
+        "lon": -82.8
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -876,8 +1119,14 @@
       "capacityMbd": 0.5,
       "lengthKm": 275,
       "inService": 1960,
-      "startPoint": { "lat": 51.90, "lon": 4.15 },
-      "endPoint": { "lat": 50.13, "lon": 8.78 },
+      "startPoint": {
+        "lat": 51.9,
+        "lon": 4.15
+      },
+      "endPoint": {
+        "lat": 50.13,
+        "lon": 8.78
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -901,8 +1150,14 @@
       "capacityMbd": 0.49,
       "lengthKm": 769,
       "inService": 1962,
-      "startPoint": { "lat": 43.45, "lon": 4.95 },
-      "endPoint": { "lat": 49.01, "lon": 8.40 },
+      "startPoint": {
+        "lat": 43.45,
+        "lon": 4.95
+      },
+      "endPoint": {
+        "lat": 49.01,
+        "lon": 8.4
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -926,8 +1181,14 @@
       "capacityMbd": 0.6,
       "lengthKm": 169,
       "inService": 1975,
-      "startPoint": { "lat": 57.75, "lon": 0.97 },
-      "endPoint": { "lat": 56.95, "lon": -2.23 },
+      "startPoint": {
+        "lat": 57.75,
+        "lon": 0.97
+      },
+      "endPoint": {
+        "lat": 56.95,
+        "lon": -2.23
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -951,8 +1212,14 @@
       "capacityMbd": 0.5,
       "lengthKm": 150,
       "inService": 1978,
-      "startPoint": { "lat": 61.08, "lon": 1.72 },
-      "endPoint": { "lat": 60.48, "lon": -1.30 },
+      "startPoint": {
+        "lat": 61.08,
+        "lon": 1.72
+      },
+      "endPoint": {
+        "lat": 60.48,
+        "lon": -1.3
+      },
       "evidence": {
         "physicalState": "reduced",
         "physicalStateSource": "operator",
@@ -980,8 +1247,14 @@
       "capacityMbd": 0.31,
       "lengthKm": 120,
       "inService": 1960,
-      "startPoint": { "lat": 28.43, "lon": 48.50 },
-      "endPoint": { "lat": 29.08, "lon": 48.13 },
+      "startPoint": {
+        "lat": 28.43,
+        "lon": 48.5
+      },
+      "endPoint": {
+        "lat": 29.08,
+        "lon": 48.13
+      },
       "evidence": {
         "physicalState": "reduced",
         "physicalStateSource": "press",
@@ -1005,8 +1278,14 @@
       "capacityMbd": 0.27,
       "lengthKm": 1610,
       "inService": 1999,
-      "startPoint": { "lat": 9.55, "lon": 30.08 },
-      "endPoint": { "lat": 19.57, "lon": 37.18 },
+      "startPoint": {
+        "lat": 9.55,
+        "lon": 30.08
+      },
+      "endPoint": {
+        "lat": 19.57,
+        "lon": 37.18
+      },
       "evidence": {
         "physicalState": "reduced",
         "physicalStateSource": "press",
@@ -1030,8 +1309,14 @@
       "capacityMbd": 0.11,
       "lengthKm": 427,
       "inService": 1994,
-      "startPoint": { "lat": -37.72, "lon": -69.10 },
-      "endPoint": { "lat": -36.77, "lon": -73.05 },
+      "startPoint": {
+        "lat": -37.72,
+        "lon": -69.1
+      },
+      "endPoint": {
+        "lat": -36.77,
+        "lon": -73.05
+      },
       "evidence": {
         "physicalState": "offline",
         "physicalStateSource": "press",
@@ -1059,15 +1344,26 @@
       "capacityMbd": 0.18,
       "lengthKm": 674,
       "inService": 2001,
-      "startPoint": { "lat": 46.48, "lon": 30.73 },
-      "endPoint": { "lat": 50.08, "lon": 25.15 },
+      "startPoint": {
+        "lat": 46.48,
+        "lon": 30.73
+      },
+      "endPoint": {
+        "lat": 50.08,
+        "lon": 25.15
+      },
       "evidence": {
         "physicalState": "offline",
         "physicalStateSource": "press",
         "operatorStatement": null,
         "commercialState": "expired",
         "sanctionRefs": [
-          { "authority": "EU", "listId": "2022/879 (Russian oil embargo, 6th sanctions package)", "date": "2022-06-03", "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R0879" }
+          {
+            "authority": "EU",
+            "listId": "2022/879 (Russian oil embargo, 6th sanctions package)",
+            "date": "2022-06-03",
+            "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32022R0879"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -1086,8 +1382,14 @@
       "capacityMbd": 0.35,
       "lengthKm": 115,
       "inService": 2018,
-      "startPoint": { "lat": 25.57, "lon": 49.80 },
-      "endPoint": { "lat": 26.18, "lon": 50.63 },
+      "startPoint": {
+        "lat": 25.57,
+        "lon": 49.8
+      },
+      "endPoint": {
+        "lat": 26.18,
+        "lon": 50.63
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -1111,8 +1413,14 @@
       "capacityMbd": 0.44,
       "lengthKm": 155,
       "inService": 1980,
-      "startPoint": { "lat": 18.03, "lon": -93.15 },
-      "endPoint": { "lat": 17.58, "lon": -93.32 },
+      "startPoint": {
+        "lat": 18.03,
+        "lon": -93.15
+      },
+      "endPoint": {
+        "lat": 17.58,
+        "lon": -93.32
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -1136,8 +1444,14 @@
       "capacityMbd": 0.4,
       "lengthKm": 92,
       "inService": 1971,
-      "startPoint": { "lat": 5.55, "lon": 5.72 },
-      "endPoint": { "lat": 5.35, "lon": 5.35 },
+      "startPoint": {
+        "lat": 5.55,
+        "lon": 5.72
+      },
+      "endPoint": {
+        "lat": 5.35,
+        "lon": 5.35
+      },
       "evidence": {
         "physicalState": "reduced",
         "physicalStateSource": "press",
@@ -1165,8 +1479,14 @@
       "capacityMbd": 0.45,
       "lengthKm": 180,
       "inService": 1965,
-      "startPoint": { "lat": 4.72, "lon": 7.28 },
-      "endPoint": { "lat": 4.43, "lon": 7.17 },
+      "startPoint": {
+        "lat": 4.72,
+        "lon": 7.28
+      },
+      "endPoint": {
+        "lat": 4.43,
+        "lon": 7.17
+      },
       "evidence": {
         "physicalState": "reduced",
         "physicalStateSource": "press",
@@ -1190,12 +1510,20 @@
       "productClass": "crude",
       "fromCountry": "IQ",
       "toCountry": "IL",
-      "transitCountries": ["JO"],
+      "transitCountries": [
+        "JO"
+      ],
       "capacityMbd": 0.08,
       "lengthKm": 942,
       "inService": 1934,
-      "startPoint": { "lat": 35.47, "lon": 44.40 },
-      "endPoint": { "lat": 32.82, "lon": 35.00 },
+      "startPoint": {
+        "lat": 35.47,
+        "lon": 44.4
+      },
+      "endPoint": {
+        "lat": 32.82,
+        "lon": 35
+      },
       "evidence": {
         "physicalState": "offline",
         "physicalStateSource": "regulator",
@@ -1223,8 +1551,14 @@
       "capacityMbd": 0.27,
       "lengthKm": 175,
       "inService": 1981,
-      "startPoint": { "lat": -4.12, "lon": 11.85 },
-      "endPoint": { "lat": -4.77, "lon": 11.85 },
+      "startPoint": {
+        "lat": -4.12,
+        "lon": 11.85
+      },
+      "endPoint": {
+        "lat": -4.77,
+        "lon": 11.85
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -1248,8 +1582,14 @@
       "capacityMbd": 0.216,
       "lengthKm": 1443,
       "inService": 0,
-      "startPoint": { "lat": 2.27, "lon": 31.50 },
-      "endPoint": { "lat": -5.08, "lon": 39.05 },
+      "startPoint": {
+        "lat": 2.27,
+        "lon": 31.5
+      },
+      "endPoint": {
+        "lat": -5.08,
+        "lon": 39.05
+      },
       "evidence": {
         "physicalState": "unknown",
         "physicalStateSource": "operator",
@@ -1277,8 +1617,14 @@
       "capacityMbd": 0.44,
       "lengthKm": 771,
       "inService": 2017,
-      "startPoint": { "lat": 20.15, "lon": 93.53 },
-      "endPoint": { "lat": 24.45, "lon": 98.58 },
+      "startPoint": {
+        "lat": 20.15,
+        "lon": 93.53
+      },
+      "endPoint": {
+        "lat": 24.45,
+        "lon": 98.58
+      },
       "evidence": {
         "physicalState": "flowing",
         "physicalStateSource": "operator",
@@ -1302,15 +1648,26 @@
       "capacityMbd": 0.1,
       "lengthKm": 1330,
       "inService": 1996,
-      "startPoint": { "lat": 40.37, "lon": 50.25 },
-      "endPoint": { "lat": 44.72, "lon": 37.75 },
+      "startPoint": {
+        "lat": 40.37,
+        "lon": 50.25
+      },
+      "endPoint": {
+        "lat": 44.72,
+        "lon": 37.75
+      },
       "evidence": {
         "physicalState": "reduced",
         "physicalStateSource": "press",
         "operatorStatement": null,
         "commercialState": "under_contract",
         "sanctionRefs": [
-          { "authority": "G7+EU", "listId": "Russian crude price cap", "date": "2022-12-05", "url": "https://home.treasury.gov/news/press-releases/jy1161" }
+          {
+            "authority": "G7+EU",
+            "listId": "Russian crude price cap",
+            "date": "2022-12-05",
+            "url": "https://home.treasury.gov/news/press-releases/jy1161"
+          }
         ],
         "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
         "classifierVersion": "v1",
@@ -1318,205 +1675,8874 @@
       }
     },
     "colombia-cano-limon-covenas": {
-      "id": "colombia-cano-limon-covenas", "name": "Caño Limón–Coveñas Pipeline", "operator": "Ecopetrol / Occidental",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "CO", "toCountry": "CO", "transitCountries": [],
-      "capacityMbd": 0.22, "lengthKm": 785, "inService": 1986,
-      "startPoint": { "lat": 6.95, "lon": -71.33 }, "endPoint": { "lat": 9.40, "lon": -75.68 },
-      "evidence": { "physicalState": "reduced", "physicalStateSource": "press", "operatorStatement": {
-        "text": "Chronic ELN insurgent sabotage attacks interrupt throughput multiple times annually; 2024 attacks again forced force-majeure declarations.",
-        "url": "https://www.ecopetrol.com.co/", "date": "2024-11-01"
-      }, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.8 }
+      "id": "colombia-cano-limon-covenas",
+      "name": "Caño Limón–Coveñas Pipeline",
+      "operator": "Ecopetrol / Occidental",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "CO",
+      "toCountry": "CO",
+      "transitCountries": [],
+      "capacityMbd": 0.22,
+      "lengthKm": 785,
+      "inService": 1986,
+      "startPoint": {
+        "lat": 6.95,
+        "lon": -71.33
+      },
+      "endPoint": {
+        "lat": 9.4,
+        "lon": -75.68
+      },
+      "evidence": {
+        "physicalState": "reduced",
+        "physicalStateSource": "press",
+        "operatorStatement": {
+          "text": "Chronic ELN insurgent sabotage attacks interrupt throughput multiple times annually; 2024 attacks again forced force-majeure declarations.",
+          "url": "https://www.ecopetrol.com.co/",
+          "date": "2024-11-01"
+        },
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.8
+      }
     },
     "colombia-ocensa": {
-      "id": "colombia-ocensa", "name": "Oleoducto Central (OCENSA)", "operator": "OCENSA (Ecopetrol-led)",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "CO", "toCountry": "CO", "transitCountries": [],
-      "capacityMbd": 0.65, "lengthKm": 836, "inService": 1997,
-      "startPoint": { "lat": 4.13, "lon": -72.58 }, "endPoint": { "lat": 9.40, "lon": -75.68 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.88 }
+      "id": "colombia-ocensa",
+      "name": "Oleoducto Central (OCENSA)",
+      "operator": "OCENSA (Ecopetrol-led)",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "CO",
+      "toCountry": "CO",
+      "transitCountries": [],
+      "capacityMbd": 0.65,
+      "lengthKm": 836,
+      "inService": 1997,
+      "startPoint": {
+        "lat": 4.13,
+        "lon": -72.58
+      },
+      "endPoint": {
+        "lat": 9.4,
+        "lon": -75.68
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.88
+      }
     },
     "peru-norperuano": {
-      "id": "peru-norperuano", "name": "Oleoducto Norperuano", "operator": "Petroperú",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "PE", "toCountry": "PE", "transitCountries": [],
-      "capacityMbd": 0.2, "lengthKm": 854, "inService": 1977,
-      "startPoint": { "lat": -4.48, "lon": -76.65 }, "endPoint": { "lat": -4.82, "lon": -81.10 },
-      "evidence": { "physicalState": "reduced", "physicalStateSource": "press", "operatorStatement": {
-        "text": "Recurring spill incidents + indigenous community protests have forced intermittent shutdowns across the jungle sections since 2016.",
-        "url": "https://www.petroperu.com.pe/", "date": "2024-06-01"
-      }, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.78 }
+      "id": "peru-norperuano",
+      "name": "Oleoducto Norperuano",
+      "operator": "Petroperú",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "PE",
+      "toCountry": "PE",
+      "transitCountries": [],
+      "capacityMbd": 0.2,
+      "lengthKm": 854,
+      "inService": 1977,
+      "startPoint": {
+        "lat": -4.48,
+        "lon": -76.65
+      },
+      "endPoint": {
+        "lat": -4.82,
+        "lon": -81.1
+      },
+      "evidence": {
+        "physicalState": "reduced",
+        "physicalStateSource": "press",
+        "operatorStatement": {
+          "text": "Recurring spill incidents + indigenous community protests have forced intermittent shutdowns across the jungle sections since 2016.",
+          "url": "https://www.petroperu.com.pe/",
+          "date": "2024-06-01"
+        },
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.78
+      }
     },
     "ecuador-lago-agrio-orellana": {
-      "id": "ecuador-lago-agrio-orellana", "name": "Lago Agrio–Orellana Feeder", "operator": "Petroecuador",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "EC", "toCountry": "EC", "transitCountries": [],
-      "capacityMbd": 0.08, "lengthKm": 105, "inService": 1975,
-      "startPoint": { "lat": -0.07, "lon": -76.88 }, "endPoint": { "lat": -0.47, "lon": -76.98 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.72 }
+      "id": "ecuador-lago-agrio-orellana",
+      "name": "Lago Agrio–Orellana Feeder",
+      "operator": "Petroecuador",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "EC",
+      "toCountry": "EC",
+      "transitCountries": [],
+      "capacityMbd": 0.08,
+      "lengthKm": 105,
+      "inService": 1975,
+      "startPoint": {
+        "lat": -0.07,
+        "lon": -76.88
+      },
+      "endPoint": {
+        "lat": -0.47,
+        "lon": -76.98
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.72
+      }
     },
     "venezuela-anzoategui-puerto-la-cruz": {
-      "id": "venezuela-anzoategui-puerto-la-cruz", "name": "Anzoátegui–Puerto La Cruz Crude Trunk", "operator": "PDVSA",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "VE", "toCountry": "VE", "transitCountries": [],
-      "capacityMbd": 0.35, "lengthKm": 220, "inService": 1960,
-      "startPoint": { "lat": 9.80, "lon": -63.20 }, "endPoint": { "lat": 10.20, "lon": -64.62 },
-      "evidence": { "physicalState": "reduced", "physicalStateSource": "press", "operatorStatement": "PDVSA infrastructure degraded post-2017; throughput reported well below nameplate per S&P Global Platts + Bloomberg PDVSA coverage.", "commercialState": "under_contract", "sanctionRefs": [
-        { "authority": "US", "listId": "OFAC Venezuela/PDVSA sanctions", "date": "2019-01-28", "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/venezuela-related-sanctions" }
-      ], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.72 }
+      "id": "venezuela-anzoategui-puerto-la-cruz",
+      "name": "Anzoátegui–Puerto La Cruz Crude Trunk",
+      "operator": "PDVSA",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "VE",
+      "toCountry": "VE",
+      "transitCountries": [],
+      "capacityMbd": 0.35,
+      "lengthKm": 220,
+      "inService": 1960,
+      "startPoint": {
+        "lat": 9.8,
+        "lon": -63.2
+      },
+      "endPoint": {
+        "lat": 10.2,
+        "lon": -64.62
+      },
+      "evidence": {
+        "physicalState": "reduced",
+        "physicalStateSource": "press",
+        "operatorStatement": "PDVSA infrastructure degraded post-2017; throughput reported well below nameplate per S&P Global Platts + Bloomberg PDVSA coverage.",
+        "commercialState": "under_contract",
+        "sanctionRefs": [
+          {
+            "authority": "US",
+            "listId": "OFAC Venezuela/PDVSA sanctions",
+            "date": "2019-01-28",
+            "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/venezuela-related-sanctions"
+          }
+        ],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.72
+      }
     },
     "angola-cabinda-offshore": {
-      "id": "angola-cabinda-offshore", "name": "Cabinda Offshore Export System", "operator": "Sonangol / Chevron",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "AO", "toCountry": "AO", "transitCountries": [],
-      "capacityMbd": 0.55, "lengthKm": 185, "inService": 1968,
-      "startPoint": { "lat": -5.72, "lon": 12.08 }, "endPoint": { "lat": -5.55, "lon": 12.20 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.82 }
+      "id": "angola-cabinda-offshore",
+      "name": "Cabinda Offshore Export System",
+      "operator": "Sonangol / Chevron",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "AO",
+      "toCountry": "AO",
+      "transitCountries": [],
+      "capacityMbd": 0.55,
+      "lengthKm": 185,
+      "inService": 1968,
+      "startPoint": {
+        "lat": -5.72,
+        "lon": 12.08
+      },
+      "endPoint": {
+        "lat": -5.55,
+        "lon": 12.2
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.82
+      }
     },
     "russia-sakhalin-2-crude": {
-      "id": "russia-sakhalin-2-crude", "name": "Sakhalin-2 Crude Export Pipeline", "operator": "Sakhalin Energy (Gazprom-led, post-2022)",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "RU", "toCountry": "RU", "transitCountries": [],
-      "capacityMbd": 0.18, "lengthKm": 800, "inService": 2008,
-      "startPoint": { "lat": 53.17, "lon": 143.18 }, "endPoint": { "lat": 46.10, "lon": 142.70 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [
-        { "authority": "G7+EU", "listId": "Russian crude price cap", "date": "2022-12-05", "url": "https://home.treasury.gov/news/press-releases/jy1161" }
-      ], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.82 }
+      "id": "russia-sakhalin-2-crude",
+      "name": "Sakhalin-2 Crude Export Pipeline",
+      "operator": "Sakhalin Energy (Gazprom-led, post-2022)",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.18,
+      "lengthKm": 800,
+      "inService": 2008,
+      "startPoint": {
+        "lat": 53.17,
+        "lon": 143.18
+      },
+      "endPoint": {
+        "lat": 46.1,
+        "lon": 142.7
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [
+          {
+            "authority": "G7+EU",
+            "listId": "Russian crude price cap",
+            "date": "2022-12-05",
+            "url": "https://home.treasury.gov/news/press-releases/jy1161"
+          }
+        ],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.82
+      }
     },
     "russia-omsk-pavlodar": {
-      "id": "russia-omsk-pavlodar", "name": "Omsk–Pavlodar Crude Pipeline", "operator": "Transneft / KazTransOil",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "RU", "toCountry": "KZ", "transitCountries": [],
-      "capacityMbd": 0.5, "lengthKm": 1500, "inService": 1977,
-      "startPoint": { "lat": 54.99, "lon": 73.37 }, "endPoint": { "lat": 52.28, "lon": 76.95 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [
-        { "authority": "G7+EU", "listId": "Russian crude price cap", "date": "2022-12-05", "url": "https://home.treasury.gov/news/press-releases/jy1161" }
-      ], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.8 }
+      "id": "russia-omsk-pavlodar",
+      "name": "Omsk–Pavlodar Crude Pipeline",
+      "operator": "Transneft / KazTransOil",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "RU",
+      "toCountry": "KZ",
+      "transitCountries": [],
+      "capacityMbd": 0.5,
+      "lengthKm": 1500,
+      "inService": 1977,
+      "startPoint": {
+        "lat": 54.99,
+        "lon": 73.37
+      },
+      "endPoint": {
+        "lat": 52.28,
+        "lon": 76.95
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [
+          {
+            "authority": "G7+EU",
+            "listId": "Russian crude price cap",
+            "date": "2022-12-05",
+            "url": "https://home.treasury.gov/news/press-releases/jy1161"
+          }
+        ],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.8
+      }
     },
     "iran-abadan-isfahan": {
-      "id": "iran-abadan-isfahan", "name": "Abadan–Isfahan Crude Pipeline", "operator": "NIOC",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "IR", "toCountry": "IR", "transitCountries": [],
-      "capacityMbd": 0.34, "lengthKm": 770, "inService": 1969,
-      "startPoint": { "lat": 30.35, "lon": 48.30 }, "endPoint": { "lat": 32.65, "lon": 51.67 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [
-        { "authority": "US", "listId": "OFAC Iran energy sanctions framework", "date": "2018-08-07", "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions" }
-      ], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.75 }
+      "id": "iran-abadan-isfahan",
+      "name": "Abadan–Isfahan Crude Pipeline",
+      "operator": "NIOC",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityMbd": 0.34,
+      "lengthKm": 770,
+      "inService": 1969,
+      "startPoint": {
+        "lat": 30.35,
+        "lon": 48.3
+      },
+      "endPoint": {
+        "lat": 32.65,
+        "lon": 51.67
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [
+          {
+            "authority": "US",
+            "listId": "OFAC Iran energy sanctions framework",
+            "date": "2018-08-07",
+            "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions"
+          }
+        ],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.75
+      }
     },
     "iran-neka-tehran": {
-      "id": "iran-neka-tehran", "name": "Neka–Tehran Crude Trunk", "operator": "NIOC",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "IR", "toCountry": "IR", "transitCountries": [],
-      "capacityMbd": 0.37, "lengthKm": 325, "inService": 2003,
-      "startPoint": { "lat": 36.65, "lon": 53.30 }, "endPoint": { "lat": 35.70, "lon": 51.42 },
-      "evidence": { "physicalState": "reduced", "physicalStateSource": "press", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [
-        { "authority": "US", "listId": "OFAC Iran energy sanctions framework", "date": "2018-08-07", "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions" }
-      ], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.72 }
+      "id": "iran-neka-tehran",
+      "name": "Neka–Tehran Crude Trunk",
+      "operator": "NIOC",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityMbd": 0.37,
+      "lengthKm": 325,
+      "inService": 2003,
+      "startPoint": {
+        "lat": 36.65,
+        "lon": 53.3
+      },
+      "endPoint": {
+        "lat": 35.7,
+        "lon": 51.42
+      },
+      "evidence": {
+        "physicalState": "reduced",
+        "physicalStateSource": "press",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [
+          {
+            "authority": "US",
+            "listId": "OFAC Iran energy sanctions framework",
+            "date": "2018-08-07",
+            "url": "https://home.treasury.gov/policy-issues/financial-sanctions/sanctions-programs-and-country-information/iran-sanctions"
+          }
+        ],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.72
+      }
     },
     "saudi-abqaiq-yanbu-products": {
-      "id": "saudi-abqaiq-yanbu-products", "name": "Abqaiq–Yanbu Products Line", "operator": "Saudi Aramco",
-      "commodityType": "oil", "productClass": "products", "fromCountry": "SA", "toCountry": "SA", "transitCountries": [],
-      "capacityMbd": 0.55, "lengthKm": 1170, "inService": 1981,
-      "startPoint": { "lat": 25.93, "lon": 49.67 }, "endPoint": { "lat": 24.08, "lon": 38.08 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.88 }
+      "id": "saudi-abqaiq-yanbu-products",
+      "name": "Abqaiq–Yanbu Products Line",
+      "operator": "Saudi Aramco",
+      "commodityType": "oil",
+      "productClass": "products",
+      "fromCountry": "SA",
+      "toCountry": "SA",
+      "transitCountries": [],
+      "capacityMbd": 0.55,
+      "lengthKm": 1170,
+      "inService": 1981,
+      "startPoint": {
+        "lat": 25.93,
+        "lon": 49.67
+      },
+      "endPoint": {
+        "lat": 24.08,
+        "lon": 38.08
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.88
+      }
     },
     "iraq-strategic-pipeline": {
-      "id": "iraq-strategic-pipeline", "name": "Iraq Strategic Pipeline (North–South)", "operator": "Iraq State Oil Marketing Organization (SOMO)",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "IQ", "toCountry": "IQ", "transitCountries": [],
-      "capacityMbd": 1.4, "lengthKm": 1000, "inService": 1975,
-      "startPoint": { "lat": 35.47, "lon": 44.40 }, "endPoint": { "lat": 30.04, "lon": 47.96 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.8 }
+      "id": "iraq-strategic-pipeline",
+      "name": "Iraq Strategic Pipeline (North–South)",
+      "operator": "Iraq State Oil Marketing Organization (SOMO)",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "IQ",
+      "toCountry": "IQ",
+      "transitCountries": [],
+      "capacityMbd": 1.4,
+      "lengthKm": 1000,
+      "inService": 1975,
+      "startPoint": {
+        "lat": 35.47,
+        "lon": 44.4
+      },
+      "endPoint": {
+        "lat": 30.04,
+        "lon": 47.96
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.8
+      }
     },
     "oman-muscat-export": {
-      "id": "oman-muscat-export", "name": "Oman Main Oil Pipeline (Fahud–Mina al-Fahal)", "operator": "Petroleum Development Oman",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "OM", "toCountry": "OM", "transitCountries": [],
-      "capacityMbd": 1.0, "lengthKm": 320, "inService": 1967,
-      "startPoint": { "lat": 22.38, "lon": 56.50 }, "endPoint": { "lat": 23.55, "lon": 58.57 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.85 }
+      "id": "oman-muscat-export",
+      "name": "Oman Main Oil Pipeline (Fahud–Mina al-Fahal)",
+      "operator": "Petroleum Development Oman",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "OM",
+      "toCountry": "OM",
+      "transitCountries": [],
+      "capacityMbd": 1,
+      "lengthKm": 320,
+      "inService": 1967,
+      "startPoint": {
+        "lat": 22.38,
+        "lon": 56.5
+      },
+      "endPoint": {
+        "lat": 23.55,
+        "lon": 58.57
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.85
+      }
     },
     "uae-habshan-ruwais": {
-      "id": "uae-habshan-ruwais", "name": "Habshan–Ruwais Crude Trunk", "operator": "ADNOC",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "AE", "toCountry": "AE", "transitCountries": [],
-      "capacityMbd": 1.1, "lengthKm": 130, "inService": 1982,
-      "startPoint": { "lat": 23.82, "lon": 53.73 }, "endPoint": { "lat": 24.08, "lon": 52.75 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.88 }
+      "id": "uae-habshan-ruwais",
+      "name": "Habshan–Ruwais Crude Trunk",
+      "operator": "ADNOC",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "AE",
+      "toCountry": "AE",
+      "transitCountries": [],
+      "capacityMbd": 1.1,
+      "lengthKm": 130,
+      "inService": 1982,
+      "startPoint": {
+        "lat": 23.82,
+        "lon": 53.73
+      },
+      "endPoint": {
+        "lat": 24.08,
+        "lon": 52.75
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.88
+      }
     },
     "mexico-salina-cruz-minatitlan": {
-      "id": "mexico-salina-cruz-minatitlan", "name": "Salina Cruz–Minatitlán Products/Crude Bridge", "operator": "Pemex",
-      "commodityType": "oil", "productClass": "mixed", "fromCountry": "MX", "toCountry": "MX", "transitCountries": [],
-      "capacityMbd": 0.28, "lengthKm": 304, "inService": 1977,
-      "startPoint": { "lat": 16.17, "lon": -95.20 }, "endPoint": { "lat": 17.98, "lon": -94.55 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.75 }
+      "id": "mexico-salina-cruz-minatitlan",
+      "name": "Salina Cruz–Minatitlán Products/Crude Bridge",
+      "operator": "Pemex",
+      "commodityType": "oil",
+      "productClass": "mixed",
+      "fromCountry": "MX",
+      "toCountry": "MX",
+      "transitCountries": [],
+      "capacityMbd": 0.28,
+      "lengthKm": 304,
+      "inService": 1977,
+      "startPoint": {
+        "lat": 16.17,
+        "lon": -95.2
+      },
+      "endPoint": {
+        "lat": 17.98,
+        "lon": -94.55
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.75
+      }
     },
     "mexico-madero-cadereyta": {
-      "id": "mexico-madero-cadereyta", "name": "Madero–Cadereyta Crude Feed", "operator": "Pemex",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "MX", "toCountry": "MX", "transitCountries": [],
-      "capacityMbd": 0.235, "lengthKm": 530, "inService": 1979,
-      "startPoint": { "lat": 22.28, "lon": -97.85 }, "endPoint": { "lat": 25.72, "lon": -99.97 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.78 }
+      "id": "mexico-madero-cadereyta",
+      "name": "Madero–Cadereyta Crude Feed",
+      "operator": "Pemex",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "MX",
+      "toCountry": "MX",
+      "transitCountries": [],
+      "capacityMbd": 0.235,
+      "lengthKm": 530,
+      "inService": 1979,
+      "startPoint": {
+        "lat": 22.28,
+        "lon": -97.85
+      },
+      "endPoint": {
+        "lat": 25.72,
+        "lon": -99.97
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.78
+      }
     },
     "india-salaya-mathura": {
-      "id": "india-salaya-mathura", "name": "Salaya–Mathura Crude Pipeline", "operator": "Indian Oil Corporation",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "IN", "toCountry": "IN", "transitCountries": [],
-      "capacityMbd": 0.5, "lengthKm": 1770, "inService": 1996,
-      "startPoint": { "lat": 22.30, "lon": 69.70 }, "endPoint": { "lat": 27.50, "lon": 77.70 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.85 }
+      "id": "india-salaya-mathura",
+      "name": "Salaya–Mathura Crude Pipeline",
+      "operator": "Indian Oil Corporation",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.5,
+      "lengthKm": 1770,
+      "inService": 1996,
+      "startPoint": {
+        "lat": 22.3,
+        "lon": 69.7
+      },
+      "endPoint": {
+        "lat": 27.5,
+        "lon": 77.7
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.85
+      }
     },
     "india-vadinar-kandla": {
-      "id": "india-vadinar-kandla", "name": "Vadinar–Kandla Products Pipeline", "operator": "Indian Oil Corporation",
-      "commodityType": "oil", "productClass": "products", "fromCountry": "IN", "toCountry": "IN", "transitCountries": [],
-      "capacityMbd": 0.18, "lengthKm": 116, "inService": 1994,
-      "startPoint": { "lat": 22.45, "lon": 69.73 }, "endPoint": { "lat": 23.03, "lon": 70.22 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.78 }
+      "id": "india-vadinar-kandla",
+      "name": "Vadinar–Kandla Products Pipeline",
+      "operator": "Indian Oil Corporation",
+      "commodityType": "oil",
+      "productClass": "products",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.18,
+      "lengthKm": 116,
+      "inService": 1994,
+      "startPoint": {
+        "lat": 22.45,
+        "lon": 69.73
+      },
+      "endPoint": {
+        "lat": 23.03,
+        "lon": 70.22
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.78
+      }
     },
     "india-mundra-bhatinda": {
-      "id": "india-mundra-bhatinda", "name": "Mundra–Bhatinda Crude Pipeline", "operator": "HPCL-Mittal Energy (HMEL)",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "IN", "toCountry": "IN", "transitCountries": [],
-      "capacityMbd": 0.45, "lengthKm": 1014, "inService": 2011,
-      "startPoint": { "lat": 22.83, "lon": 69.72 }, "endPoint": { "lat": 30.21, "lon": 74.95 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.85 }
+      "id": "india-mundra-bhatinda",
+      "name": "Mundra–Bhatinda Crude Pipeline",
+      "operator": "HPCL-Mittal Energy (HMEL)",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.45,
+      "lengthKm": 1014,
+      "inService": 2011,
+      "startPoint": {
+        "lat": 22.83,
+        "lon": 69.72
+      },
+      "endPoint": {
+        "lat": 30.21,
+        "lon": 74.95
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.85
+      }
     },
     "china-qinhuangdao-tianjin-huabei": {
-      "id": "china-qinhuangdao-tianjin-huabei", "name": "Qinhuangdao–Tianjin–Huabei Trunk", "operator": "PetroChina",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "CN", "toCountry": "CN", "transitCountries": [],
-      "capacityMbd": 0.4, "lengthKm": 418, "inService": 1996,
-      "startPoint": { "lat": 39.93, "lon": 119.60 }, "endPoint": { "lat": 39.08, "lon": 117.20 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.8 }
+      "id": "china-qinhuangdao-tianjin-huabei",
+      "name": "Qinhuangdao–Tianjin–Huabei Trunk",
+      "operator": "PetroChina",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.4,
+      "lengthKm": 418,
+      "inService": 1996,
+      "startPoint": {
+        "lat": 39.93,
+        "lon": 119.6
+      },
+      "endPoint": {
+        "lat": 39.08,
+        "lon": 117.2
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.8
+      }
     },
     "china-yangzi-hefei-hangzhou": {
-      "id": "china-yangzi-hefei-hangzhou", "name": "Yangzi–Hefei–Hangzhou Products Pipeline", "operator": "Sinopec",
-      "commodityType": "oil", "productClass": "products", "fromCountry": "CN", "toCountry": "CN", "transitCountries": [],
-      "capacityMbd": 0.2, "lengthKm": 600, "inService": 2005,
-      "startPoint": { "lat": 32.07, "lon": 118.78 }, "endPoint": { "lat": 30.27, "lon": 120.15 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.75 }
+      "id": "china-yangzi-hefei-hangzhou",
+      "name": "Yangzi–Hefei–Hangzhou Products Pipeline",
+      "operator": "Sinopec",
+      "commodityType": "oil",
+      "productClass": "products",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.2,
+      "lengthKm": 600,
+      "inService": 2005,
+      "startPoint": {
+        "lat": 32.07,
+        "lon": 118.78
+      },
+      "endPoint": {
+        "lat": 30.27,
+        "lon": 120.15
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.75
+      }
     },
     "russia-komsomolsk-perevoznaya": {
-      "id": "russia-komsomolsk-perevoznaya", "name": "Komsomolsk–Perevoznaya Crude Pipeline (Khabarovsk Krai)", "operator": "Transneft",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "RU", "toCountry": "RU", "transitCountries": [],
-      "capacityMbd": 0.4, "lengthKm": 1163, "inService": 2009,
-      "startPoint": { "lat": 50.55, "lon": 137.02 }, "endPoint": { "lat": 42.75, "lon": 132.82 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [
-        { "authority": "G7+EU", "listId": "Russian crude price cap", "date": "2022-12-05", "url": "https://home.treasury.gov/news/press-releases/jy1161" }
-      ], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.78 }
+      "id": "russia-komsomolsk-perevoznaya",
+      "name": "Komsomolsk–Perevoznaya Crude Pipeline (Khabarovsk Krai)",
+      "operator": "Transneft",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.4,
+      "lengthKm": 1163,
+      "inService": 2009,
+      "startPoint": {
+        "lat": 50.55,
+        "lon": 137.02
+      },
+      "endPoint": {
+        "lat": 42.75,
+        "lon": 132.82
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [
+          {
+            "authority": "G7+EU",
+            "listId": "Russian crude price cap",
+            "date": "2022-12-05",
+            "url": "https://home.treasury.gov/news/press-releases/jy1161"
+          }
+        ],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.78
+      }
     },
     "south-sudan-kenya-lamu-planned": {
-      "id": "south-sudan-kenya-lamu-planned", "name": "South Sudan–Kenya Lamu Crude Pipeline (LAPSSET, planned)", "operator": "South Sudan Ministry of Petroleum / LAPSSET Corridor Development Authority",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "SS", "toCountry": "KE", "transitCountries": [],
-      "capacityMbd": 0.45, "lengthKm": 2240, "inService": 0,
-      "startPoint": { "lat": 9.55, "lon": 30.08 }, "endPoint": { "lat": -2.27, "lon": 40.90 },
+      "id": "south-sudan-kenya-lamu-planned",
+      "name": "South Sudan–Kenya Lamu Crude Pipeline (LAPSSET, planned)",
+      "operator": "South Sudan Ministry of Petroleum / LAPSSET Corridor Development Authority",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "SS",
+      "toCountry": "KE",
+      "transitCountries": [],
+      "capacityMbd": 0.45,
+      "lengthKm": 2240,
+      "inService": 0,
+      "startPoint": {
+        "lat": 9.55,
+        "lon": 30.08
+      },
+      "endPoint": {
+        "lat": -2.27,
+        "lon": 40.9
+      },
       "evidence": {
-        "physicalState": "unknown", "physicalStateSource": "press",
+        "physicalState": "unknown",
+        "physicalStateSource": "press",
         "operatorStatement": {
           "text": "LAPSSET programme (Lamu Port South-Sudan Ethiopia Transport) includes a crude pipeline to reduce South Sudan dependence on Sudan transit. Financing + alignment remain unresolved. Construction not commenced on main trunk.",
-          "url": "https://www.lapsset.go.ke/", "date": "2024-05-01"
+          "url": "https://www.lapsset.go.ke/",
+          "date": "2024-05-01"
         },
-        "commercialState": "unknown", "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.68
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.68
       }
     },
     "mexico-gulf-coast-pipeline": {
-      "id": "mexico-gulf-coast-pipeline", "name": "Tuxpan–Mexico City Products Pipeline", "operator": "Pemex Logística",
-      "commodityType": "oil", "productClass": "products", "fromCountry": "MX", "toCountry": "MX", "transitCountries": [],
-      "capacityMbd": 0.12, "lengthKm": 298, "inService": 1974,
-      "startPoint": { "lat": 20.95, "lon": -97.40 }, "endPoint": { "lat": 19.43, "lon": -99.13 },
-      "evidence": { "physicalState": "reduced", "physicalStateSource": "press", "operatorStatement": "Pemex Gulf pipelines face recurring leaks and clandestine tap theft (huachicol); throughput reduced since 2017 per Pemex annual reports + Reuters Mexico coverage.", "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.68 }
+      "id": "mexico-gulf-coast-pipeline",
+      "name": "Tuxpan–Mexico City Products Pipeline",
+      "operator": "Pemex Logística",
+      "commodityType": "oil",
+      "productClass": "products",
+      "fromCountry": "MX",
+      "toCountry": "MX",
+      "transitCountries": [],
+      "capacityMbd": 0.12,
+      "lengthKm": 298,
+      "inService": 1974,
+      "startPoint": {
+        "lat": 20.95,
+        "lon": -97.4
+      },
+      "endPoint": {
+        "lat": 19.43,
+        "lon": -99.13
+      },
+      "evidence": {
+        "physicalState": "reduced",
+        "physicalStateSource": "press",
+        "operatorStatement": "Pemex Gulf pipelines face recurring leaks and clandestine tap theft (huachicol); throughput reduced since 2017 per Pemex annual reports + Reuters Mexico coverage.",
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.68
+      }
     },
     "iraq-bai-hassan": {
-      "id": "iraq-bai-hassan", "name": "Bai Hassan Crude Gathering Line", "operator": "North Oil Company (Iraq)",
-      "commodityType": "oil", "productClass": "crude", "fromCountry": "IQ", "toCountry": "IQ", "transitCountries": [],
-      "capacityMbd": 0.25, "lengthKm": 65, "inService": 1975,
-      "startPoint": { "lat": 35.42, "lon": 43.93 }, "endPoint": { "lat": 35.47, "lon": 44.40 },
-      "evidence": { "physicalState": "flowing", "physicalStateSource": "operator", "operatorStatement": null, "commercialState": "under_contract", "sanctionRefs": [], "lastEvidenceUpdate": "2026-04-22T00:00:00Z", "classifierVersion": "v1", "classifierConfidence": 0.72 }
+      "id": "iraq-bai-hassan",
+      "name": "Bai Hassan Crude Gathering Line",
+      "operator": "North Oil Company (Iraq)",
+      "commodityType": "oil",
+      "productClass": "crude",
+      "fromCountry": "IQ",
+      "toCountry": "IQ",
+      "transitCountries": [],
+      "capacityMbd": 0.25,
+      "lengthKm": 65,
+      "inService": 1975,
+      "startPoint": {
+        "lat": 35.42,
+        "lon": 43.93
+      },
+      "endPoint": {
+        "lat": 35.47,
+        "lon": 44.4
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "operator",
+        "operatorStatement": null,
+        "commercialState": "under_contract",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-22T00:00:00Z",
+        "classifierVersion": "v1",
+        "classifierConfidence": 0.72
+      }
+    },
+    "abadan-ahvaz-arak-tehran-pipeline-ir": {
+      "id": "abadan-ahvaz-arak-tehran-pipeline-ir",
+      "name": "Abadan-Ahvaz-Arak-Tehran Pipeline",
+      "operator": "Iran Ministry of Petroleum [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityMbd": 0.3,
+      "lengthKm": 650,
+      "inService": 0,
+      "startPoint": {
+        "lat": 30.345826,
+        "lon": 48.294856
+      },
+      "endPoint": {
+        "lat": 35.691516,
+        "lon": 51.423976
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "abqaiq-yanbu-ngl-pipeline-sa": {
+      "id": "abqaiq-yanbu-ngl-pipeline-sa",
+      "name": "Abqaiq-Yanbu NGL pipeline",
+      "operator": "Saudi Aramco [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "SA",
+      "toCountry": "SA",
+      "transitCountries": [],
+      "capacityMbd": 0.29,
+      "lengthKm": 1193,
+      "inService": 1982,
+      "startPoint": {
+        "lat": 25.924365,
+        "lon": 49.67728
+      },
+      "endPoint": {
+        "lat": 23.965193,
+        "lon": 38.245263
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "adria-oil-pipeline-hr": {
+      "id": "adria-oil-pipeline-hr",
+      "name": "Adria Oil Pipeline",
+      "operator": "Jadranski Naftovod [100.00%]; Gazprom [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "HR",
+      "toCountry": "BA",
+      "transitCountries": [
+        "HU",
+        "RS",
+        "SI"
+      ],
+      "capacityMbd": 0.401368925393566,
+      "lengthKm": 622,
+      "inService": 1990,
+      "startPoint": {
+        "lat": 45.215153,
+        "lon": 14.569801
+      },
+      "endPoint": {
+        "lat": 45.349398,
+        "lon": 14.360894
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "adria-wien-oil-pipeline-at": {
+      "id": "adria-wien-oil-pipeline-at",
+      "name": "Adria-Wien Oil Pipeline",
+      "operator": "Adria-Wien Pipeline GmbH [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "AT",
+      "toCountry": "AT",
+      "transitCountries": [],
+      "capacityMbd": 0.16,
+      "lengthKm": 420,
+      "inService": 1970,
+      "startPoint": {
+        "lat": 46.659156,
+        "lon": 13.014137
+      },
+      "endPoint": {
+        "lat": 46.954056,
+        "lon": 15.340772
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "aegis-pipeline-system-us": {
+      "id": "aegis-pipeline-system-us",
+      "name": "Aegis Pipeline System",
+      "operator": "Enterprise Products Partners [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.4,
+      "lengthKm": 434.52,
+      "inService": 2015,
+      "startPoint": {
+        "lat": 30.22047,
+        "lon": -91.766889
+      },
+      "endPoint": {
+        "lat": 30.251465,
+        "lon": -91.180888
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "ahwaz-ray-oil-pipeline-ir": {
+      "id": "ahwaz-ray-oil-pipeline-ir",
+      "name": "Ahwaz–Ray Oil Pipeline",
+      "operator": "National Iranian Oil Company [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityMbd": 0.094,
+      "lengthKm": 934,
+      "inService": 0,
+      "startPoint": {
+        "lat": 31.318707,
+        "lon": 48.670699
+      },
+      "endPoint": {
+        "lat": 35.606671,
+        "lon": 51.438649
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "alberta-clipper-oil-pipeline-ca": {
+      "id": "alberta-clipper-oil-pipeline-ca",
+      "name": "Alberta Clipper Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.45,
+      "lengthKm": 1790,
+      "inService": 2010,
+      "startPoint": {
+        "lat": 52.66972,
+        "lon": -111.31072
+      },
+      "endPoint": {
+        "lat": 46.690572,
+        "lon": -92.067312
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "alberta-ethane-gathering-system-aegs-ca": {
+      "id": "alberta-ethane-gathering-system-aegs-ca",
+      "name": "Alberta Ethane Gathering System (AEGS)",
+      "operator": "unknown [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.33,
+      "lengthKm": 1330,
+      "inService": 0,
+      "startPoint": {
+        "lat": 53.79385,
+        "lon": -113.100657
+      },
+      "endPoint": {
+        "lat": 51.130012,
+        "lon": -114.552637
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "alexandrovskoe-anzhero-sudzhensk-oil-pipeline-ru": {
+      "id": "alexandrovskoe-anzhero-sudzhensk-oil-pipeline-ru",
+      "name": "Alexandrovskoe-Anzhero-Sudzhensk Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 1.1639698836413415,
+      "lengthKm": 818,
+      "inService": 1973,
+      "startPoint": {
+        "lat": 60.83682,
+        "lon": 77.14303
+      },
+      "endPoint": {
+        "lat": 56.15516,
+        "lon": 86.05329
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "algerian-tunisian-border-skhira-oil-pipeline-tn": {
+      "id": "algerian-tunisian-border-skhira-oil-pipeline-tn",
+      "name": "Algerian-Tunisian Border-Skhira Oil Pipeline",
+      "operator": "Entreprise Tunisienne d'Activités Pétrolières [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "TN",
+      "toCountry": "TN",
+      "transitCountries": [],
+      "capacityMbd": 0.200684462696783,
+      "lengthKm": 512,
+      "inService": 1960,
+      "startPoint": {
+        "lat": 30.314267,
+        "lon": 9.531806
+      },
+      "endPoint": {
+        "lat": 34.235,
+        "lon": 10.133
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "almetyevsk-gorky-oil-pipeline-ii-ru": {
+      "id": "almetyevsk-gorky-oil-pipeline-ii-ru",
+      "name": "Almetyevsk-Gorky Oil Pipeline - II",
+      "operator": "Transneft [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.9974017796030117,
+      "lengthKm": 580,
+      "inService": 0,
+      "startPoint": {
+        "lat": 54.9263,
+        "lon": 52.2153
+      },
+      "endPoint": {
+        "lat": 56.12591,
+        "lon": 44.10207
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "anzhero-sudzhensk-krasnoyarsk-oil-pipeline-ru": {
+      "id": "anzhero-sudzhensk-krasnoyarsk-oil-pipeline-ru",
+      "name": "Anzhero-Sudzhensk-Krasnoyarsk Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.899066392881588,
+      "lengthKm": 602,
+      "inService": 1974,
+      "startPoint": {
+        "lat": 56.15516,
+        "lon": 86.05329
+      },
+      "endPoint": {
+        "lat": 55.79291,
+        "lon": 94.79794
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "arbuckle-ii-y-grade-pipeline-us": {
+      "id": "arbuckle-ii-y-grade-pipeline-us",
+      "name": "Arbuckle II Y-Grade Pipeline",
+      "operator": "ONEOK Inc [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.4,
+      "lengthKm": 852.95,
+      "inService": 2020,
+      "startPoint": {
+        "lat": 29.865103,
+        "lon": -94.890414
+      },
+      "endPoint": {
+        "lat": 36.774726,
+        "lon": -97.761905
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "arbuckle-pipeline-us": {
+      "id": "arbuckle-pipeline-us",
+      "name": "Arbuckle Pipeline",
+      "operator": "unknown [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.24,
+      "lengthKm": 708.11,
+      "inService": 0,
+      "startPoint": {
+        "lat": 33.19045,
+        "lon": -97.794682
+      },
+      "endPoint": {
+        "lat": 29.852535,
+        "lon": -94.914414
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "athabasca-oil-pipeline-ca": {
+      "id": "athabasca-oil-pipeline-ca",
+      "name": "Athabasca Oil Pipeline",
+      "operator": "Enbridge [88.43%]; Athabasca Indigenous Investments [11.57%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.57,
+      "lengthKm": 542.35,
+      "inService": 1999,
+      "startPoint": {
+        "lat": 57.033603,
+        "lon": -111.606597
+      },
+      "endPoint": {
+        "lat": 52.675254,
+        "lon": -111.304163
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "bab-habshan-fujairah-oil-pipeline-ae": {
+      "id": "bab-habshan-fujairah-oil-pipeline-ae",
+      "name": "Bab-Habshan–Fujairah Oil Pipeline",
+      "operator": "Abu Dhabi Crude Oil Pipeline LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "AE",
+      "toCountry": "AE",
+      "transitCountries": [],
+      "capacityMbd": 1.8,
+      "lengthKm": 406,
+      "inService": 2012,
+      "startPoint": {
+        "lat": 23.8279,
+        "lon": 53.6176
+      },
+      "endPoint": {
+        "lat": 25.2128,
+        "lon": 56.3413
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "baghein-ps-isfahan-oil-pipelines-pipeline-2-ir": {
+      "id": "baghein-ps-isfahan-oil-pipelines-pipeline-2-ir",
+      "name": "Baghein PS-Isfahan Oil Pipelines - Pipeline 2",
+      "operator": "National Iranian Oil Refining and Distribution Company [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityMbd": 0.2,
+      "lengthKm": 597.01,
+      "inService": 0,
+      "startPoint": {
+        "lat": 30.182158,
+        "lon": 56.803648
+      },
+      "endPoint": {
+        "lat": 32.653862,
+        "lon": 51.66635
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "bakken-ngl-pipeline-us": {
+      "id": "bakken-ngl-pipeline-us",
+      "name": "Bakken NGL Pipeline",
+      "operator": "ONEOK Inc [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.14,
+      "lengthKm": 965.61,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 48.406516,
+        "lon": -102.914691
+      },
+      "endPoint": {
+        "lat": 48.22589,
+        "lon": -103.952924
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "baku-novorossiysk-oil-pipeline-az": {
+      "id": "baku-novorossiysk-oil-pipeline-az",
+      "name": "Baku-Novorossiysk Oil Pipeline",
+      "operator": "SOCAR [100.00%]; Transneft [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "AZ",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.15051334702258726,
+      "lengthKm": 1330,
+      "inService": 1983,
+      "startPoint": {
+        "lat": 40.44692,
+        "lon": 49.7006
+      },
+      "endPoint": {
+        "lat": 44.70349,
+        "lon": 37.84597
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "baku-tbilisi-ceyhan-pipeline-az": {
+      "id": "baku-tbilisi-ceyhan-pipeline-az",
+      "name": "Baku-Tbilisi-Ceyhan Pipeline",
+      "operator": "Baku-Tbilisi-Ceyhan Pipeline Company [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "AZ",
+      "toCountry": "TR",
+      "transitCountries": [
+        "GE"
+      ],
+      "capacityMbd": 1.2,
+      "lengthKm": 1768,
+      "inService": 2006,
+      "startPoint": {
+        "lat": 40.16285,
+        "lon": 49.20759
+      },
+      "endPoint": {
+        "lat": 36.87574,
+        "lon": 35.90124
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "baltic-pipeline-system-1-palkino-primorsk-oil-pipeline-ru": {
+      "id": "baltic-pipeline-system-1-palkino-primorsk-oil-pipeline-ru",
+      "name": "Baltic Pipeline System 1 - Palkino-Primorsk oil pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 1.2442436687200547,
+      "lengthKm": 712.9,
+      "inService": 2003,
+      "startPoint": {
+        "lat": 57.736119,
+        "lon": 38.39315
+      },
+      "endPoint": {
+        "lat": 60.34071,
+        "lon": 28.71197
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "baltic-pipeline-system-1-yaroslavl-kirishi-1-oil-pipeline-ru": {
+      "id": "baltic-pipeline-system-1-yaroslavl-kirishi-1-oil-pipeline-ru",
+      "name": "Baltic Pipeline System 1 - Yaroslavl-Kirishi 1 oil pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.2809582477754962,
+      "lengthKm": 539.9,
+      "inService": 2001,
+      "startPoint": {
+        "lat": 57.54401,
+        "lon": 39.83705
+      },
+      "endPoint": {
+        "lat": 59.53751,
+        "lon": 32.04454
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "baltic-pipeline-system-2-ru": {
+      "id": "baltic-pipeline-system-2-ru",
+      "name": "Baltic Pipeline System 2",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.7224640657084188,
+      "lengthKm": 1000,
+      "inService": 2012,
+      "startPoint": {
+        "lat": 52.76664,
+        "lon": 32.93646
+      },
+      "endPoint": {
+        "lat": 59.68556,
+        "lon": 28.43964
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "bandar-abbas-rafsanjan-oil-pipeline-ir": {
+      "id": "bandar-abbas-rafsanjan-oil-pipeline-ir",
+      "name": "Bandar Abbas–Rafsanjan Oil Pipeline",
+      "operator": "National Iranian Oil Company [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityMbd": 0.3,
+      "lengthKm": 450,
+      "inService": 1988,
+      "startPoint": {
+        "lat": 27.178766,
+        "lon": 56.077256
+      },
+      "endPoint": {
+        "lat": 30.404329,
+        "lon": 55.988852
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "bangl-pipeline-us": {
+      "id": "bangl-pipeline-us",
+      "name": "BANGL Pipeline",
+      "operator": "BANGL LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.125,
+      "lengthKm": 844.91,
+      "inService": 2021,
+      "startPoint": {
+        "lat": 31.983726,
+        "lon": -103.701716
+      },
+      "endPoint": {
+        "lat": 31.367103,
+        "lon": -101.779232
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "basin-oil-pipeline-us": {
+      "id": "basin-oil-pipeline-us",
+      "name": "Basin Oil Pipeline",
+      "operator": "Plains All American Pipeline [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.45,
+      "lengthKm": 835.25,
+      "inService": 0,
+      "startPoint": {
+        "lat": 33.923516,
+        "lon": -98.428999
+      },
+      "endPoint": {
+        "lat": 35.866558,
+        "lon": -96.800982
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "basra-aqaba-oil-pipeline-pipeline-2-iq": {
+      "id": "basra-aqaba-oil-pipeline-pipeline-2-iq",
+      "name": "Basra-Aqaba Oil Pipeline - Pipeline 2",
+      "operator": "Iraq Ministry of Oil [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IQ",
+      "toCountry": "JO",
+      "transitCountries": [],
+      "capacityMbd": 1,
+      "lengthKm": 1154,
+      "inService": 0,
+      "startPoint": {
+        "lat": 29.529646,
+        "lon": 35.005821
+      },
+      "endPoint": {
+        "lat": 30.497093,
+        "lon": 47.718414
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "batman-dortyol-crude-oil-pipeline-tr": {
+      "id": "batman-dortyol-crude-oil-pipeline-tr",
+      "name": "Batman-Dortyol Crude Oil Pipeline",
+      "operator": "BOTAŞ [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "TR",
+      "toCountry": "TR",
+      "transitCountries": [],
+      "capacityMbd": 0.09030800821355235,
+      "lengthKm": 511,
+      "inService": 1976,
+      "startPoint": {
+        "lat": 37.6684,
+        "lon": 40.809898
+      },
+      "endPoint": {
+        "lat": 37.5928,
+        "lon": 40.793999
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "bin-omar-baiji-k2-oil-pipeline-iq": {
+      "id": "bin-omar-baiji-k2-oil-pipeline-iq",
+      "name": "Bin Omar-Baiji K2 Oil Pipeline",
+      "operator": "unknown [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "IQ",
+      "toCountry": "IQ",
+      "transitCountries": [],
+      "capacityMbd": 1.5,
+      "lengthKm": 750,
+      "inService": 0,
+      "startPoint": {
+        "lat": 35.024654,
+        "lon": 43.456507
+      },
+      "endPoint": {
+        "lat": 30.58,
+        "lon": 47.531
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "black-lake-pipeline-us": {
+      "id": "black-lake-pipeline-us",
+      "name": "Black Lake Pipeline",
+      "operator": "Black Lake Pipeline Company [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.04,
+      "lengthKm": 510.16,
+      "inService": 1967,
+      "startPoint": {
+        "lat": 31.941054,
+        "lon": -92.960143
+      },
+      "endPoint": {
+        "lat": 30.933028,
+        "lon": -93.215861
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "bridgetex-oil-pipeline-us": {
+      "id": "bridgetex-oil-pipeline-us",
+      "name": "BridgeTex Oil Pipeline",
+      "operator": "OMERS [50.00%]; Magellan Midstream Partners [30.00%]; Plains All American Pipeline [20.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.3,
+      "lengthKm": 643.74,
+      "inService": 2014,
+      "startPoint": {
+        "lat": 32.52008,
+        "lon": -100.859
+      },
+      "endPoint": {
+        "lat": 29.37244,
+        "lon": -94.9195
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "ca-o-lim-n-cove-as-oil-pipeline-co": {
+      "id": "ca-o-lim-n-cove-as-oil-pipeline-co",
+      "name": "Caño Limón–Coveñas Oil Pipeline",
+      "operator": "Cenit SAS [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CO",
+      "toCountry": "CO",
+      "transitCountries": [],
+      "capacityMbd": 0.251,
+      "lengthKm": 774,
+      "inService": 1986,
+      "startPoint": {
+        "lat": 6.93262,
+        "lon": -71.167153
+      },
+      "endPoint": {
+        "lat": 9.410435,
+        "lon": -75.692114
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "cactus-ii-oil-pipeline-us": {
+      "id": "cactus-ii-oil-pipeline-us",
+      "name": "Cactus II Oil Pipeline",
+      "operator": "Cactus II Pipeline LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.67,
+      "lengthKm": 925.37,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 27.824583,
+        "lon": -97.181567
+      },
+      "endPoint": {
+        "lat": 31.748277,
+        "lon": -103.149131
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "cactus-oil-pipeline-us": {
+      "id": "cactus-oil-pipeline-us",
+      "name": "Cactus Oil Pipeline",
+      "operator": "Plains GP Holdings LP [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.25,
+      "lengthKm": 498.9,
+      "inService": 2015,
+      "startPoint": {
+        "lat": 27.841744,
+        "lon": -97.416527
+      },
+      "endPoint": {
+        "lat": 31.745919,
+        "lon": -103.149131
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "cameron-highway-oil-pipeline-system-chops-us": {
+      "id": "cameron-highway-oil-pipeline-system-chops-us",
+      "name": "Cameron Highway Oil Pipeline System (CHOPS)",
+      "operator": "Cameron Highway Oil Pipeline Company [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.6,
+      "lengthKm": 611.55,
+      "inService": 2003,
+      "startPoint": {
+        "lat": 29.1354,
+        "lon": -93.9991
+      },
+      "endPoint": {
+        "lat": 29.1354,
+        "lon": -93.9987
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "camisea-ngl-pipeline-pe": {
+      "id": "camisea-ngl-pipeline-pe",
+      "name": "Camisea NGL Pipeline",
+      "operator": "TGP (Transportadora de Gas del Perú) [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "PE",
+      "toCountry": "PE",
+      "transitCountries": [],
+      "capacityMbd": 0.13,
+      "lengthKm": 560,
+      "inService": 2004,
+      "startPoint": {
+        "lat": -11.840021,
+        "lon": -72.945592
+      },
+      "endPoint": {
+        "lat": -13.768781,
+        "lon": -76.229567
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "cantarell-field-oil-pipeline-network-mx": {
+      "id": "cantarell-field-oil-pipeline-network-mx",
+      "name": "Cantarell Field Oil Pipeline Network",
+      "operator": "Pemex [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "MX",
+      "toCountry": "MX",
+      "transitCountries": [],
+      "capacityMbd": 0.4,
+      "lengthKm": 425,
+      "inService": 1979,
+      "startPoint": {
+        "lat": 19.431915,
+        "lon": -92.09
+      },
+      "endPoint": {
+        "lat": 19.53,
+        "lon": -92.72
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "capline-oil-pipeline-patoka-to-catlettsburg-expansion-us": {
+      "id": "capline-oil-pipeline-patoka-to-catlettsburg-expansion-us",
+      "name": "Capline Oil Pipeline - Patoka-to-Catlettsburg Expansion",
+      "operator": "Capline Pipeline Company LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.014,
+      "lengthKm": 653.39,
+      "inService": 2012,
+      "startPoint": {
+        "lat": 38.901504,
+        "lon": -89.026654
+      },
+      "endPoint": {
+        "lat": 38.424419,
+        "lon": -82.640471
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "capline-oil-pipeline-us": {
+      "id": "capline-oil-pipeline-us",
+      "name": "Capline Oil Pipeline",
+      "operator": "Capline Pipeline Company LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.3,
+      "lengthKm": 1017.11,
+      "inService": 2005,
+      "startPoint": {
+        "lat": 30.01008,
+        "lon": -90.8598
+      },
+      "endPoint": {
+        "lat": 38.79399,
+        "lon": -89.0698
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "caspian-pipeline-kz": {
+      "id": "caspian-pipeline-kz",
+      "name": "Caspian Pipeline",
+      "operator": "Transneft [24.00%]; KazMunayGas JSC [19.00%]; Chevron Caspian Pipeline Consortium Company [15.00%]; LukArco B.V. [12.50%]; Mobil Caspian Pipeline Company [7.50%]; Rosneft-Shell Caspian Ventures Limited [7.50%]; CPC Company [7.00%]; BG Overseas Holdings Limited [2.00%]; Eni International (N.A.) N.V. S.ar.l. [2.00%]; Kazakhstan Pipeline Ventures LLC [1.75%]; Oryx Caspian Pipeline LLC [1.75%]",
+      "commodityType": "oil",
+      "fromCountry": "KZ",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 1.34,
+      "lengthKm": 1511,
+      "inService": 2001,
+      "startPoint": {
+        "lat": 46.176391,
+        "lon": 53.420055
+      },
+      "endPoint": {
+        "lat": 44.954974,
+        "lon": 37.954475
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "centurion-oil-pipeline-us": {
+      "id": "centurion-oil-pipeline-us",
+      "name": "Centurion Oil Pipeline",
+      "operator": "Centurion Pipeline LP [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.35,
+      "lengthKm": 4828.03,
+      "inService": 2004,
+      "startPoint": {
+        "lat": 35.93967,
+        "lon": -96.7575
+      },
+      "endPoint": {
+        "lat": 33.86342,
+        "lon": -102.025
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "ceyhan-k-r-kkale-oil-pipeline-tr": {
+      "id": "ceyhan-k-r-kkale-oil-pipeline-tr",
+      "name": "Ceyhan-Kırıkkale Oil Pipeline",
+      "operator": "BOTAŞ [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "TR",
+      "toCountry": "TR",
+      "transitCountries": [],
+      "capacityMbd": 0.096986,
+      "lengthKm": 457,
+      "inService": 1986,
+      "startPoint": {
+        "lat": 36.868023,
+        "lon": 35.917069
+      },
+      "endPoint": {
+        "lat": 39.839645,
+        "lon": 33.481228
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "chad-cameroon-oil-pipeline-td": {
+      "id": "chad-cameroon-oil-pipeline-td",
+      "name": "Chad–Cameroon Oil Pipeline",
+      "operator": "Savannah Energy PLC [40.00%]; Petronas [35.00%]; Government of Chad [25.00%]",
+      "commodityType": "oil",
+      "fromCountry": "TD",
+      "toCountry": "CM",
+      "transitCountries": [],
+      "capacityMbd": 0.225,
+      "lengthKm": 1070,
+      "inService": 2003,
+      "startPoint": {
+        "lat": 8.689639,
+        "lon": 17.072754
+      },
+      "endPoint": {
+        "lat": 2.952641,
+        "lon": 9.908981
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "co-ed-system-ngl-pipeline-ca": {
+      "id": "co-ed-system-ngl-pipeline-ca",
+      "name": "Co-Ed System NGL pipeline",
+      "operator": "Plains All American Pipeline [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.072,
+      "lengthKm": 1200,
+      "inService": 1984,
+      "startPoint": {
+        "lat": 51.216345,
+        "lon": -114.48646
+      },
+      "endPoint": {
+        "lat": 53.686133,
+        "lon": -113.190073
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "cochabamba-arica-oil-pipeline-bo": {
+      "id": "cochabamba-arica-oil-pipeline-bo",
+      "name": "Cochabamba-Arica Oil Pipeline",
+      "operator": "YPFB Transporte [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "BO",
+      "toCountry": "CL",
+      "transitCountries": [],
+      "capacityMbd": 0.024,
+      "lengthKm": 577,
+      "inService": 1966,
+      "startPoint": {
+        "lat": -17.452532,
+        "lon": -66.122037
+      },
+      "endPoint": {
+        "lat": -18.4815,
+        "lon": -70.2791
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "cochin-pipeline-system-ca": {
+      "id": "cochin-pipeline-system-ca",
+      "name": "Cochin Pipeline System",
+      "operator": "PKM Cochin ULC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.095,
+      "lengthKm": 3057,
+      "inService": 1979,
+      "startPoint": {
+        "lat": 53.711746,
+        "lon": -113.20655
+      },
+      "endPoint": {
+        "lat": 42.220382,
+        "lon": -83.020935
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "cold-lake-pipeline-system-ca": {
+      "id": "cold-lake-pipeline-system-ca",
+      "name": "Cold Lake Pipeline System",
+      "operator": "Cold Lake Pipeline LP [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 1.9,
+      "lengthKm": 1400,
+      "inService": 0,
+      "startPoint": {
+        "lat": 54.467305,
+        "lon": -110.17256
+      },
+      "endPoint": {
+        "lat": 52.675254,
+        "lon": -111.304163
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "colombia-oil-pipeline-co": {
+      "id": "colombia-oil-pipeline-co",
+      "name": "Colombia Oil Pipeline",
+      "operator": "Cenit SAS [51.28%]; Hocol SA [21.72%]; Emerald Energy [unknown %]; Frontera Energy [unknown %]; Perenco [unknown %]; Repsol [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "CO",
+      "toCountry": "CO",
+      "transitCountries": [],
+      "capacityMbd": 0.236,
+      "lengthKm": 483,
+      "inService": 1990,
+      "startPoint": {
+        "lat": 6.06589,
+        "lon": -74.558448
+      },
+      "endPoint": {
+        "lat": 9.410435,
+        "lon": -75.692114
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "corridor-oil-pipeline-ca": {
+      "id": "corridor-oil-pipeline-ca",
+      "name": "Corridor Oil Pipeline",
+      "operator": "Inter Pipeline [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.465,
+      "lengthKm": 1046,
+      "inService": 2003,
+      "startPoint": {
+        "lat": 56.720334,
+        "lon": -111.38145
+      },
+      "endPoint": {
+        "lat": 53.533778,
+        "lon": -113.50387
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "dakota-access-oil-pipeline-dapl-us": {
+      "id": "dakota-access-oil-pipeline-dapl-us",
+      "name": "Dakota Access Oil Pipeline (DAPL)",
+      "operator": "Dakota Access [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.57,
+      "lengthKm": 1886,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 48.304257,
+        "lon": -102.460191
+      },
+      "endPoint": {
+        "lat": 38.766678,
+        "lon": -89.041695
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "daqing-jinxi-oil-pipeline-tieling-jinxi-oil-pipeline-cn": {
+      "id": "daqing-jinxi-oil-pipeline-tieling-jinxi-oil-pipeline-cn",
+      "name": "Daqing-Jinxi Oil Pipeline - Tieling-Jinxi Oil Pipeline",
+      "operator": "National Pipe Network Group North Pipeline Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.200684462696783,
+      "lengthKm": 406.3,
+      "inService": 2015,
+      "startPoint": {
+        "lat": 42.30425,
+        "lon": 123.812383
+      },
+      "endPoint": {
+        "lat": 40.734555,
+        "lon": 120.808716
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "daqing-tieling-oil-pipeline-pipeline-4-cn": {
+      "id": "daqing-tieling-oil-pipeline-pipeline-4-cn",
+      "name": "Daqing–Tieling Oil Pipeline - Pipeline 4",
+      "operator": "National Pipe Network Group North Pipeline Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.401368925393566,
+      "lengthKm": 568.68,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 46.341355,
+        "lon": 124.74045
+      },
+      "endPoint": {
+        "lat": 42.30425,
+        "lon": 123.812383
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "daytona-ngl-pipeline-us": {
+      "id": "daytona-ngl-pipeline-us",
+      "name": "Daytona NGL Pipeline",
+      "operator": "Grand Prix Pipeline LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.55,
+      "lengthKm": 643.74,
+      "inService": 2024,
+      "startPoint": {
+        "lat": 32.279095,
+        "lon": -99.141996
+      },
+      "endPoint": {
+        "lat": 32.241238,
+        "lon": -99.671447
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "diamond-oil-pipeline-us": {
+      "id": "diamond-oil-pipeline-us",
+      "name": "Diamond Oil Pipeline",
+      "operator": "Diamond Pipeline LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.2,
+      "lengthKm": 708.11,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 35.914786,
+        "lon": -96.524093
+      },
+      "endPoint": {
+        "lat": 35.146227,
+        "lon": -90.31632
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "dingbian-huhhot-oil-pipeline-cn": {
+      "id": "dingbian-huhhot-oil-pipeline-cn",
+      "name": "Dingbian-Huhhot Oil Pipeline",
+      "operator": "National Pipe Network Group North Pipeline Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.1003422313483915,
+      "lengthKm": 563.23,
+      "inService": 2012,
+      "startPoint": {
+        "lat": 37.459723,
+        "lon": 107.816366
+      },
+      "endPoint": {
+        "lat": 40.733302,
+        "lon": 111.751047
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "dongjiakou-weifang-luzhong-lubei-oil-pipeline-phase-i-dongji-cn": {
+      "id": "dongjiakou-weifang-luzhong-lubei-oil-pipeline-phase-i-dongji-cn",
+      "name": "Dongjiakou–Weifang–Luzhong Lubei Oil Pipeline - Phase I Dongjiakou–Binhai District",
+      "operator": "Shandong Ganglianhua Pipeline Oil Transportation Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.4415058179329227,
+      "lengthKm": 532,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 35.594047,
+        "lon": 119.758164
+      },
+      "endPoint": {
+        "lat": 37.050025,
+        "lon": 119.113632
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "double-h-pipeline-us": {
+      "id": "double-h-pipeline-us",
+      "name": "Double H Pipeline",
+      "operator": "Hiland Crude LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.084,
+      "lengthKm": 822.37,
+      "inService": 2015,
+      "startPoint": {
+        "lat": 47.933832,
+        "lon": -104.021937
+      },
+      "endPoint": {
+        "lat": 42.298623,
+        "lon": -104.687679
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "druzhba-oil-pipeline-kuibyshev-unecha-2-oil-pipeline-ru": {
+      "id": "druzhba-oil-pipeline-kuibyshev-unecha-2-oil-pipeline-ru",
+      "name": "Druzhba Oil Pipeline - Kuibyshev-Unecha 2 oil pipeline",
+      "operator": "Transneft-Druzhba JSC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 1.4850650239561942,
+      "lengthKm": 1228,
+      "inService": 1973,
+      "startPoint": {
+        "lat": 53.080869,
+        "lon": 50.254431
+      },
+      "endPoint": {
+        "lat": 52.76664,
+        "lon": 32.93646
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "druzhba-oil-pipeline-kuibyshev-unecha-mozyr-1-ru": {
+      "id": "druzhba-oil-pipeline-kuibyshev-unecha-mozyr-1-ru",
+      "name": "Druzhba Oil Pipeline - Kuibyshev-Unecha-Mozyr-1",
+      "operator": "Gomeltransneft Druzhba JSC [unknown %]; Transneft-Druzhba JSC [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "BY",
+      "transitCountries": [],
+      "capacityMbd": 0.7385188227241616,
+      "lengthKm": 1792,
+      "inService": 1964,
+      "startPoint": {
+        "lat": 52.90072,
+        "lon": 50.262446
+      },
+      "endPoint": {
+        "lat": 51.884611,
+        "lon": 28.841304
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "druzhba-oil-pipeline-mozyr-brest-oil-pipeline-by": {
+      "id": "druzhba-oil-pipeline-mozyr-brest-oil-pipeline-by",
+      "name": "Druzhba Oil Pipeline - Mozyr-Brest oil pipeline",
+      "operator": "PERN Przyjasn SA [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "BY",
+      "toCountry": "BY",
+      "transitCountries": [],
+      "capacityMbd": 0.45756057494866526,
+      "lengthKm": 441,
+      "inService": 1963,
+      "startPoint": {
+        "lat": 51.924788,
+        "lon": 29.259649
+      },
+      "endPoint": {
+        "lat": 52.380084,
+        "lon": 23.262225
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "druzhba-oil-pipeline-mozyr-uzhgorod-oil-pipeline-i-by": {
+      "id": "druzhba-oil-pipeline-mozyr-uzhgorod-oil-pipeline-i-by",
+      "name": "Druzhba Oil Pipeline - Mozyr-Uzhgorod Oil Pipeline I",
+      "operator": "Gomeltransneft Druzhba JSC [unknown %]; UkrTransNafta [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "BY",
+      "toCountry": "UA",
+      "transitCountries": [],
+      "capacityMbd": 0.35119780971937026,
+      "lengthKm": 684,
+      "inService": 1963,
+      "startPoint": {
+        "lat": 52.038601,
+        "lon": 29.225921
+      },
+      "endPoint": {
+        "lat": 48.57503,
+        "lon": 22.22743
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "druzhba-oil-pipeline-sahy-bucany-litvinov-oil-pipeline-sk": {
+      "id": "druzhba-oil-pipeline-sahy-bucany-litvinov-oil-pipeline-sk",
+      "name": "Druzhba Oil Pipeline - Sahy-Bucany-Litvinov oil pipeline",
+      "operator": "MERO A.S [unknown %]; Transpetrol AS [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "SK",
+      "toCountry": "CZ",
+      "transitCountries": [],
+      "capacityMbd": 0.1806160164271047,
+      "lengthKm": 529,
+      "inService": 1962,
+      "startPoint": {
+        "lat": 48.07129,
+        "lon": 18.95041
+      },
+      "endPoint": {
+        "lat": 50.33601,
+        "lon": 14.039747
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "druzhba-oil-pipeline-unecha-polotsk-1-oil-pipeline-ru": {
+      "id": "druzhba-oil-pipeline-unecha-polotsk-1-oil-pipeline-ru",
+      "name": "Druzhba Oil Pipeline - Unecha-Polotsk 1 Oil Pipeline",
+      "operator": "Gomeltransneft Druzhba JSC [unknown %]; Transneft-Druzhba JSC [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "BY",
+      "transitCountries": [],
+      "capacityMbd": 0.12041067761806983,
+      "lengthKm": 450,
+      "inService": 1964,
+      "startPoint": {
+        "lat": 55.489454,
+        "lon": 28.784732
+      },
+      "endPoint": {
+        "lat": 52.837701,
+        "lon": 32.662042
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "durban-sasolburg-oil-pipeline-za": {
+      "id": "durban-sasolburg-oil-pipeline-za",
+      "name": "Durban–Sasolburg Oil Pipeline",
+      "operator": "Transnet [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "ZA",
+      "toCountry": "ZA",
+      "transitCountries": [],
+      "capacityMbd": 0.125,
+      "lengthKm": 580,
+      "inService": 1971,
+      "startPoint": {
+        "lat": -29.890965,
+        "lon": 31.03086
+      },
+      "endPoint": {
+        "lat": -26.809005,
+        "lon": 27.854889
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "eagle-ford-jv-pipeline-system-us": {
+      "id": "eagle-ford-jv-pipeline-system-us",
+      "name": "Eagle Ford JV Pipeline System",
+      "operator": "Enterprise Products Partners [50.00%]; Plains All American Pipeline [50.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.3,
+      "lengthKm": 1062.17,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 29.753029,
+        "lon": -96.154397
+      },
+      "endPoint": {
+        "lat": 28.922162,
+        "lon": -98.123845
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "eaglebine-express-crude-oil-pipeline-us": {
+      "id": "eaglebine-express-crude-oil-pipeline-us",
+      "name": "Eaglebine Express Crude Oil Pipeline",
+      "operator": "Energy Transfer [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.06,
+      "lengthKm": 450,
+      "inService": 2014,
+      "startPoint": {
+        "lat": 30.878881,
+        "lon": -96.592833
+      },
+      "endPoint": {
+        "lat": 29.974019,
+        "lon": -93.992842
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "east-west-crude-oil-pipeline-sa": {
+      "id": "east-west-crude-oil-pipeline-sa",
+      "name": "East-West Crude Oil Pipeline",
+      "operator": "Saudi Aramco [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "SA",
+      "toCountry": "SA",
+      "transitCountries": [],
+      "capacityMbd": 5,
+      "lengthKm": 1200,
+      "inService": 1982,
+      "startPoint": {
+        "lat": 25.924365,
+        "lon": 49.67728
+      },
+      "endPoint": {
+        "lat": 23.965193,
+        "lon": 38.245263
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "eastern-siberia-pacific-ocean-oil-pipeline-phase-i-espo-1-ru": {
+      "id": "eastern-siberia-pacific-ocean-oil-pipeline-phase-i-espo-1-ru",
+      "name": "Eastern Siberia–Pacific Ocean Oil Pipeline - Phase I (ESPO 1)",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 1.605475701574264,
+      "lengthKm": 2694,
+      "inService": 2009,
+      "startPoint": {
+        "lat": 55.88687,
+        "lon": 98.03255
+      },
+      "endPoint": {
+        "lat": 53.95038,
+        "lon": 124.25202
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "eastern-siberia-pacific-ocean-oil-pipeline-phase-ii-espo-2-ru": {
+      "id": "eastern-siberia-pacific-ocean-oil-pipeline-phase-ii-espo-2-ru",
+      "name": "Eastern Siberia–Pacific Ocean Oil Pipeline - Phase II (ESPO 2)",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 1.003422313483915,
+      "lengthKm": 2046,
+      "inService": 2012,
+      "startPoint": {
+        "lat": 42.82226,
+        "lon": 133.0809
+      },
+      "endPoint": {
+        "lat": 53.96826,
+        "lon": 124.2459
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "eastern-siberia-pacific-ocean-oil-pipeline-russia-china-crud-cn": {
+      "id": "eastern-siberia-pacific-ocean-oil-pipeline-russia-china-crud-cn",
+      "name": "Eastern Siberia–Pacific Ocean Oil Pipeline - Russia–China Crude Oil Pipeline 2",
+      "operator": "National Pipe Network Group North Pipeline Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.3010266940451745,
+      "lengthKm": 942,
+      "inService": 2018,
+      "startPoint": {
+        "lat": 53.413253,
+        "lon": 123.951329
+      },
+      "endPoint": {
+        "lat": 46.608395,
+        "lon": 125.085219
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "el-feel-mellitah-oil-pipeline-ly": {
+      "id": "el-feel-mellitah-oil-pipeline-ly",
+      "name": "El Feel-Mellitah Oil Pipeline",
+      "operator": "Libyan National Oil Corporation [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "LY",
+      "toCountry": "LY",
+      "transitCountries": [],
+      "capacityMbd": 0.04,
+      "lengthKm": 726,
+      "inService": 0,
+      "startPoint": {
+        "lat": 26.051346,
+        "lon": 11.973287
+      },
+      "endPoint": {
+        "lat": 32.855794,
+        "lon": 12.24166
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "el-sharara-mellitah-oil-pipeline-ly": {
+      "id": "el-sharara-mellitah-oil-pipeline-ly",
+      "name": "El Sharara-Mellitah Oil Pipeline",
+      "operator": "Eni S.p.A. [50.00%]; Libyan National Oil Corporation [50.00%]",
+      "commodityType": "oil",
+      "fromCountry": "LY",
+      "toCountry": "LY",
+      "transitCountries": [],
+      "capacityMbd": 0.1998817248459959,
+      "lengthKm": 723,
+      "inService": 0,
+      "startPoint": {
+        "lat": 26.5946,
+        "lon": 12.3636
+      },
+      "endPoint": {
+        "lat": 32.8518,
+        "lon": 12.2361
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "el-sharara-zawiya-oil-pipeline-ly": {
+      "id": "el-sharara-zawiya-oil-pipeline-ly",
+      "name": "El Sharara-Zawiya Oil Pipeline",
+      "operator": "Libyan National Oil Corporation [88.00%]; Equinor [unknown %]; OMV [unknown %]; Repsol [unknown %]; TotalEnergies SE [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "LY",
+      "toCountry": "LY",
+      "transitCountries": [],
+      "capacityMbd": 0.1998817248459959,
+      "lengthKm": 725.4,
+      "inService": 1998,
+      "startPoint": {
+        "lat": 26.5946,
+        "lon": 12.3636
+      },
+      "endPoint": {
+        "lat": 32.7873,
+        "lon": 12.6973
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "elk-creek-ngl-pipeline-us": {
+      "id": "elk-creek-ngl-pipeline-us",
+      "name": "Elk Creek NGL Pipeline",
+      "operator": "ONEOK Inc [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.24,
+      "lengthKm": 1448.41,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 47.408868,
+        "lon": -104.041124
+      },
+      "endPoint": {
+        "lat": 38.568747,
+        "lon": -98.314957
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "enbridge-line-1-oil-pipeline-ca": {
+      "id": "enbridge-line-1-oil-pipeline-ca",
+      "name": "Enbridge Line 1 Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.237,
+      "lengthKm": 1767.06,
+      "inService": 1950,
+      "startPoint": {
+        "lat": 53.55355,
+        "lon": -113.350719
+      },
+      "endPoint": {
+        "lat": 46.690572,
+        "lon": -92.067312
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "enbridge-line-14-64-oil-pipeline-us": {
+      "id": "enbridge-line-14-64-oil-pipeline-us",
+      "name": "Enbridge Line 14/64 Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.343,
+      "lengthKm": 783.75,
+      "inService": 1998,
+      "startPoint": {
+        "lat": 46.690572,
+        "lon": -92.067312
+      },
+      "endPoint": {
+        "lat": 41.522899,
+        "lon": -87.541928
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "enbridge-line-2-oil-pipeline-ca": {
+      "id": "enbridge-line-2-oil-pipeline-ca",
+      "name": "Enbridge Line 2 Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.442,
+      "lengthKm": 1773.5,
+      "inService": 1957,
+      "startPoint": {
+        "lat": 53.55355,
+        "lon": -113.350719
+      },
+      "endPoint": {
+        "lat": 46.690572,
+        "lon": -92.067312
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "enbridge-line-3-oil-pipeline-line-3-replacement-project-ca": {
+      "id": "enbridge-line-3-oil-pipeline-line-3-replacement-project-ca",
+      "name": "Enbridge Line 3 Oil Pipeline - Line 3 Replacement Project",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.844,
+      "lengthKm": 1889.37,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 47.68948,
+        "lon": -95.4207
+      },
+      "endPoint": {
+        "lat": 47.68948,
+        "lon": -95.4207
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "enbridge-line-4-oil-pipeline-ca": {
+      "id": "enbridge-line-4-oil-pipeline-ca",
+      "name": "Enbridge Line 4 Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.796,
+      "lengthKm": 1770.28,
+      "inService": 2002,
+      "startPoint": {
+        "lat": 53.55355,
+        "lon": -113.350719
+      },
+      "endPoint": {
+        "lat": 46.690572,
+        "lon": -92.067312
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "enbridge-line-5-pipeline-us": {
+      "id": "enbridge-line-5-pipeline-us",
+      "name": "Enbridge Line 5 Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.54,
+      "lengthKm": 1038.03,
+      "inService": 1953,
+      "startPoint": {
+        "lat": 46.690572,
+        "lon": -92.067312
+      },
+      "endPoint": {
+        "lat": 42.95186,
+        "lon": -82.416
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "enbridge-line-6-oil-pipeline-us": {
+      "id": "enbridge-line-6-oil-pipeline-us",
+      "name": "Enbridge Line 6 Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.667,
+      "lengthKm": 1212,
+      "inService": 1969,
+      "startPoint": {
+        "lat": 46.690572,
+        "lon": -92.067312
+      },
+      "endPoint": {
+        "lat": 41.520501,
+        "lon": -87.473886
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "enbridge-line-61-oil-pipeline-us": {
+      "id": "enbridge-line-61-oil-pipeline-us",
+      "name": "Enbridge Line 61 Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.4,
+      "lengthKm": 743.52,
+      "inService": 2009,
+      "startPoint": {
+        "lat": 40.942105,
+        "lon": -88.64816
+      },
+      "endPoint": {
+        "lat": 46.690572,
+        "lon": -92.067312
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "enbridge-line-65-oil-pipeline-ca": {
+      "id": "enbridge-line-65-oil-pipeline-ca",
+      "name": "Enbridge Line 65 Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.186,
+      "lengthKm": 503.72,
+      "inService": 2010,
+      "startPoint": {
+        "lat": 47.690625,
+        "lon": -95.410998
+      },
+      "endPoint": {
+        "lat": 49.742221,
+        "lon": -101.243284
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "enbridge-line-78-oil-pipeline-us": {
+      "id": "enbridge-line-78-oil-pipeline-us",
+      "name": "Enbridge Line 78 Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.57,
+      "lengthKm": 601.89,
+      "inService": 2015,
+      "startPoint": {
+        "lat": 41.046003,
+        "lon": -88.450744
+      },
+      "endPoint": {
+        "lat": 42.897796,
+        "lon": -82.501734
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "enbridge-line-9-oil-pipeline-ca": {
+      "id": "enbridge-line-9-oil-pipeline-ca",
+      "name": "Enbridge Line 9 Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.3,
+      "lengthKm": 832,
+      "inService": 1976,
+      "startPoint": {
+        "lat": 42.95186,
+        "lon": -82.416
+      },
+      "endPoint": {
+        "lat": 45.643067,
+        "lon": -73.523613
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "enbridge-line-93-oil-pipeline-ca": {
+      "id": "enbridge-line-93-oil-pipeline-ca",
+      "name": "Enbridge Line 93 Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.844,
+      "lengthKm": 1070.21,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 52.66972,
+        "lon": -111.31072
+      },
+      "endPoint": {
+        "lat": 46.690572,
+        "lon": -92.067312
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "energy-transfer-crude-oil-pipeline-etcop-us": {
+      "id": "energy-transfer-crude-oil-pipeline-etcop-us",
+      "name": "Energy Transfer Crude Oil Pipeline (ETCOP)",
+      "operator": "Energy Transfer [38.25%]; Enbridge [27.56%]; Phillips 66 [25.00%]; Marathon Petroleum [9.19%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.47,
+      "lengthKm": 1213.45,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 38.774868,
+        "lon": -89.091387
+      },
+      "endPoint": {
+        "lat": 29.930239,
+        "lon": -94.018739
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "epic-ngl-pipeline-us": {
+      "id": "epic-ngl-pipeline-us",
+      "name": "EPIC NGL Pipeline",
+      "operator": "EPIC Midstream Holdings [45.00%]; Chevron [15.00%]; Salt Creek Midstream, LLC [10.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.3,
+      "lengthKm": 1126.54,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 28.563898,
+        "lon": -97.848174
+      },
+      "endPoint": {
+        "lat": 28.647565,
+        "lon": -100.063759
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "epic-oil-pipeline-us": {
+      "id": "epic-oil-pipeline-us",
+      "name": "EPIC Oil Pipeline",
+      "operator": "EPIC Midstream Holdings [45.00%]; Diamondback Energy [27.50%]; Kinetik Holdings [27.50%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.6,
+      "lengthKm": 1175,
+      "inService": 2020,
+      "startPoint": {
+        "lat": 27.75004,
+        "lon": -97.5448
+      },
+      "endPoint": {
+        "lat": 27.76749,
+        "lon": -97.6733
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "express-oil-pipeline-system-ca": {
+      "id": "express-oil-pipeline-system-ca",
+      "name": "Express Oil Pipeline System",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.28,
+      "lengthKm": 1263.34,
+      "inService": 1997,
+      "startPoint": {
+        "lat": 42.865337,
+        "lon": -106.409763
+      },
+      "endPoint": {
+        "lat": 52.614117,
+        "lon": -111.266634
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "ez-line-us": {
+      "id": "ez-line-us",
+      "name": "EZ Line",
+      "operator": "Chevron Phillips Chemical [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.1,
+      "lengthKm": 778.11,
+      "inService": 0,
+      "startPoint": {
+        "lat": 30.508048,
+        "lon": -100.589982
+      },
+      "endPoint": {
+        "lat": 30.989405,
+        "lon": -101.078621
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "flanagan-south-oil-pipeline-us": {
+      "id": "flanagan-south-oil-pipeline-us",
+      "name": "Flanagan South Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.585,
+      "lengthKm": 954.34,
+      "inService": 2014,
+      "startPoint": {
+        "lat": 40.948503,
+        "lon": -88.827937
+      },
+      "endPoint": {
+        "lat": 36.010716,
+        "lon": -96.824538
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "frontier-oil-pipeline-us": {
+      "id": "frontier-oil-pipeline-us",
+      "name": "Frontier Oil Pipeline",
+      "operator": "Frontier Aspen LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.072,
+      "lengthKm": 465.1,
+      "inService": 0,
+      "startPoint": {
+        "lat": 40.83273,
+        "lon": -111.921
+      },
+      "endPoint": {
+        "lat": 42.86215,
+        "lon": -106.372
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "goureh-jask-crude-oil-pipeline-ir": {
+      "id": "goureh-jask-crude-oil-pipeline-ir",
+      "name": "Goureh-Jask Crude Oil Pipeline",
+      "operator": "Petroleum Engineering and Development Company (PEDEC) [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityMbd": 1,
+      "lengthKm": 1100,
+      "inService": 2021,
+      "startPoint": {
+        "lat": 29.932592,
+        "lon": 50.50997
+      },
+      "endPoint": {
+        "lat": 25.648838,
+        "lon": 57.780652
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "grand-mesa-oil-pipeline-us": {
+      "id": "grand-mesa-oil-pipeline-us",
+      "name": "Grand Mesa Oil Pipeline",
+      "operator": "Grand Mesa Pipeline, LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.15,
+      "lengthKm": 885.14,
+      "inService": 2016,
+      "startPoint": {
+        "lat": 40.215735,
+        "lon": -104.84241
+      },
+      "endPoint": {
+        "lat": 35.986089,
+        "lon": -96.82429
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "grand-prix-y-grade-pipeline-north-texas-mont-belvieu-us": {
+      "id": "grand-prix-y-grade-pipeline-north-texas-mont-belvieu-us",
+      "name": "Grand Prix Y-Grade Pipeline - North Texas–Mont Belvieu",
+      "operator": "Grand Prix Pipeline LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.45,
+      "lengthKm": 514.99,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 31.938263,
+        "lon": -104.318915
+      },
+      "endPoint": {
+        "lat": 29.847276,
+        "lon": -94.824451
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "grand-rapids-oil-pipeline-ca": {
+      "id": "grand-rapids-oil-pipeline-ca",
+      "name": "Grand Rapids Oil Pipeline",
+      "operator": "Phoenix Energy Holdings [50.00%]; TC Energy [50.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.9,
+      "lengthKm": 460,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 56.768475,
+        "lon": -112.136369
+      },
+      "endPoint": {
+        "lat": 53.537095,
+        "lon": -113.327915
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "gray-oak-oil-pipeline-us": {
+      "id": "gray-oak-oil-pipeline-us",
+      "name": "Gray Oak Oil Pipeline",
+      "operator": "Gray Oak Pipeline LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.9,
+      "lengthKm": 1367.94,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 31.704959,
+        "lon": -103.92813
+      },
+      "endPoint": {
+        "lat": 27.907806,
+        "lon": -97.424238
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "greater-nile-oil-pipeline-ss": {
+      "id": "greater-nile-oil-pipeline-ss",
+      "name": "Greater Nile Oil Pipeline",
+      "operator": "Greater Nile Petroleum Operating Company [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "SS",
+      "toCountry": "SD",
+      "transitCountries": [],
+      "capacityMbd": 0.25,
+      "lengthKm": 1600,
+      "inService": 1999,
+      "startPoint": {
+        "lat": 19.617728,
+        "lon": 37.211981
+      },
+      "endPoint": {
+        "lat": 10.462069,
+        "lon": 32.540131
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "haoudh-el-hamra-arzew-oil-pipeline-ii-dz": {
+      "id": "haoudh-el-hamra-arzew-oil-pipeline-ii-dz",
+      "name": "Haoudh El Hamra-Arzew Oil Pipeline - II",
+      "operator": "Sonatrach [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "DZ",
+      "toCountry": "DZ",
+      "transitCountries": [],
+      "capacityMbd": 0.6823271731690622,
+      "lengthKm": 821,
+      "inService": 2005,
+      "startPoint": {
+        "lat": 31.8835,
+        "lon": 5.9799
+      },
+      "endPoint": {
+        "lat": 35.808904,
+        "lon": -0.318603
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "haoudh-el-hamra-bejaia-oil-pipeline-dz": {
+      "id": "haoudh-el-hamra-bejaia-oil-pipeline-dz",
+      "name": "Haoudh El Hamra-Bejaia Oil Pipeline",
+      "operator": "Sonatrach [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "DZ",
+      "toCountry": "DZ",
+      "transitCountries": [],
+      "capacityMbd": 0.22878028747433263,
+      "lengthKm": 668,
+      "inService": 1959,
+      "startPoint": {
+        "lat": 31.8835,
+        "lon": 5.9799
+      },
+      "endPoint": {
+        "lat": 36.7368,
+        "lon": 5.0682
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "haoudh-el-hamra-skikda-oil-pipeline-dz": {
+      "id": "haoudh-el-hamra-skikda-oil-pipeline-dz",
+      "name": "Haoudh El Hamra-Skikda Oil Pipeline",
+      "operator": "Sonatrach [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "DZ",
+      "toCountry": "DZ",
+      "transitCountries": [],
+      "capacityMbd": 0.602053388090349,
+      "lengthKm": 646,
+      "inService": 1972,
+      "startPoint": {
+        "lat": 31.8835,
+        "lon": 5.9799
+      },
+      "endPoint": {
+        "lat": 36.868635,
+        "lon": 6.896667
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "hassan-cherlapalli-lpg-pipeline-capacity-expansion-in": {
+      "id": "hassan-cherlapalli-lpg-pipeline-capacity-expansion-in",
+      "name": "Hassan-Cherlapalli LPG Pipeline - Capacity Expansion",
+      "operator": "Hindustan Petroleum [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.044150581793292266,
+      "lengthKm": 650,
+      "inService": 2023,
+      "startPoint": {
+        "lat": 13.009563,
+        "lon": 76.08394
+      },
+      "endPoint": {
+        "lat": 17.17719,
+        "lon": 79.291948
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "heavy-louisiana-sweet-crude-oil-pipeline-system-us": {
+      "id": "heavy-louisiana-sweet-crude-oil-pipeline-system-us",
+      "name": "Heavy Louisiana Sweet Crude Oil Pipeline System",
+      "operator": "ExxonMobil [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.044,
+      "lengthKm": 411.34,
+      "inService": 0,
+      "startPoint": {
+        "lat": 28.325308,
+        "lon": -88.34876
+      },
+      "endPoint": {
+        "lat": 30.536604,
+        "lon": -91.753679
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "high-plains-crude-oil-pipeline-us": {
+      "id": "high-plains-crude-oil-pipeline-us",
+      "name": "High Plains Crude Oil Pipeline",
+      "operator": "Tesoro High Plains Pipeline Company LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.09,
+      "lengthKm": 1126.54,
+      "inService": 0,
+      "startPoint": {
+        "lat": 48.880093,
+        "lon": -102.565137
+      },
+      "endPoint": {
+        "lat": 47.643832,
+        "lon": -105.068311
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "hobbs-east-gathering-system-rio-grande-pipeline-us": {
+      "id": "hobbs-east-gathering-system-rio-grande-pipeline-us",
+      "name": "Hobbs East Gathering System - Rio Grande Pipeline",
+      "operator": "Enterprise Products Partners [70.00%]; BP [30.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [
+        "MX"
+      ],
+      "capacityMbd": 0.025,
+      "lengthKm": 426.48,
+      "inService": 0,
+      "startPoint": {
+        "lat": 31.899603,
+        "lon": -102.638805
+      },
+      "endPoint": {
+        "lat": 31.550165,
+        "lon": -106.262528
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "horizon-crude-oil-pipeline-ca": {
+      "id": "horizon-crude-oil-pipeline-ca",
+      "name": "Horizon Crude Oil Pipeline",
+      "operator": "Pembina Pipeline Corporation [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.25,
+      "lengthKm": 513,
+      "inService": 2008,
+      "startPoint": {
+        "lat": 57.371222,
+        "lon": -111.75785
+      },
+      "endPoint": {
+        "lat": 53.5978,
+        "lon": -113.32573
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "huatugou-golmud-pipeline-cn": {
+      "id": "huatugou-golmud-pipeline-cn",
+      "name": "Huatugou-Golmud Pipeline",
+      "operator": "National Pipe Network Group North Pipeline Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.06020533880903491,
+      "lengthKm": 438,
+      "inService": 2004,
+      "startPoint": {
+        "lat": 38.248424,
+        "lon": 90.856135
+      },
+      "endPoint": {
+        "lat": 36.396412,
+        "lon": 94.915583
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "hydrocarbons-stationary-transport-system-gt": {
+      "id": "hydrocarbons-stationary-transport-system-gt",
+      "name": "Hydrocarbons Stationary Transport System",
+      "operator": "Perenco [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "GT",
+      "toCountry": "GT",
+      "transitCountries": [],
+      "capacityMbd": 0.03,
+      "lengthKm": 475,
+      "inService": 1992,
+      "startPoint": {
+        "lat": 17.529743,
+        "lon": -90.784979
+      },
+      "endPoint": {
+        "lat": 15.983147,
+        "lon": -90.449946
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "in-amenas-haoudh-el-hamra-oil-pipeline-dz": {
+      "id": "in-amenas-haoudh-el-hamra-oil-pipeline-dz",
+      "name": "In Amenas-Haoudh el Hamra Oil Pipeline",
+      "operator": "Sonatrach [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "DZ",
+      "toCountry": "DZ",
+      "transitCountries": [],
+      "capacityMbd": 0.17860917180013688,
+      "lengthKm": 630,
+      "inService": 1982,
+      "startPoint": {
+        "lat": 28.0392,
+        "lon": 9.5464
+      },
+      "endPoint": {
+        "lat": 31.8835,
+        "lon": 5.9799
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "iraq-strategic-pipeline-pipeline-1-iq": {
+      "id": "iraq-strategic-pipeline-pipeline-1-iq",
+      "name": "Iraq Strategic Pipeline - Pipeline 1",
+      "operator": "Iraq Ministry of Oil [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IQ",
+      "toCountry": "IQ",
+      "transitCountries": [],
+      "capacityMbd": 1.4,
+      "lengthKm": 669,
+      "inService": 1975,
+      "startPoint": {
+        "lat": 34.0796,
+        "lon": 42.3754
+      },
+      "endPoint": {
+        "lat": 29.9696,
+        "lon": 48.4515
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "iraq-strategic-pipeline-pipeline-3-iq": {
+      "id": "iraq-strategic-pipeline-pipeline-3-iq",
+      "name": "Iraq Strategic Pipeline - Pipeline 3",
+      "operator": "Iraq Ministry of Oil [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IQ",
+      "toCountry": "IQ",
+      "transitCountries": [],
+      "capacityMbd": 0.8,
+      "lengthKm": 669,
+      "inService": 2014,
+      "startPoint": {
+        "lat": 34.0796,
+        "lon": 42.3754
+      },
+      "endPoint": {
+        "lat": 29.9696,
+        "lon": 48.4515
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "jamnagar-loni-lpg-pipeline-in": {
+      "id": "jamnagar-loni-lpg-pipeline-in",
+      "name": "Jamnagar-Loni LPG Pipeline",
+      "operator": "GAIL (India) Limited [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.05017111567419575,
+      "lengthKm": 1414,
+      "inService": 2001,
+      "startPoint": {
+        "lat": 22.485018,
+        "lon": 70.087904
+      },
+      "endPoint": {
+        "lat": 27.657129,
+        "lon": 80.019545
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "jayhawk-oil-pipeline-us": {
+      "id": "jayhawk-oil-pipeline-us",
+      "name": "Jayhawk Oil Pipeline",
+      "operator": "CHS Inc [unknown %]; Southwest Pipeline Holding Company LLC [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.14,
+      "lengthKm": 1609.34,
+      "inService": 1957,
+      "startPoint": {
+        "lat": 38.33994,
+        "lon": -98.3101
+      },
+      "endPoint": {
+        "lat": 38.33994,
+        "lon": -98.3101
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "jing-an-xianyang-oil-pipeline-cn": {
+      "id": "jing-an-xianyang-oil-pipeline-cn",
+      "name": "Jing'an-Xianyang Oil Pipeline",
+      "operator": "National Pipe Network Group North Pipeline Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.07023956194387405,
+      "lengthKm": 456.5,
+      "inService": 2001,
+      "startPoint": {
+        "lat": 36.981632,
+        "lon": 108.609378
+      },
+      "endPoint": {
+        "lat": 34.363952,
+        "lon": 108.773554
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "kaltasy-samara-oil-pipeline-ru": {
+      "id": "kaltasy-samara-oil-pipeline-ru",
+      "name": "Kaltasy-Samara Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.37728678986995207,
+      "lengthKm": 499.05,
+      "inService": 0,
+      "startPoint": {
+        "lat": 56.00576,
+        "lon": 54.53558
+      },
+      "endPoint": {
+        "lat": 53.00774,
+        "lon": 50.53054
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "kaltasy-yazykovo-salavat-oil-pipeline-ru": {
+      "id": "kaltasy-yazykovo-salavat-oil-pipeline-ru",
+      "name": "Kaltasy-Yazykovo-Salavat Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.1003422313483915,
+      "lengthKm": 450,
+      "inService": 1974,
+      "startPoint": {
+        "lat": 56.00279,
+        "lon": 54.52967
+      },
+      "endPoint": {
+        "lat": 53.4431,
+        "lon": 55.87191
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "karachaganak-atyrau-oil-pipeline-kz": {
+      "id": "karachaganak-atyrau-oil-pipeline-kz",
+      "name": "Karachaganak-Atyrau Oil Pipeline",
+      "operator": "Karachaganak Petroleum Operating B.V. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "KZ",
+      "toCountry": "KZ",
+      "transitCountries": [],
+      "capacityMbd": 0.2024906228610541,
+      "lengthKm": 635,
+      "inService": 2003,
+      "startPoint": {
+        "lat": 51.362344,
+        "lon": 53.20683
+      },
+      "endPoint": {
+        "lat": 47.09712,
+        "lon": 51.96205
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "karachi-mahmoodkot-kmk-pipeline-pk": {
+      "id": "karachi-mahmoodkot-kmk-pipeline-pk",
+      "name": "Karachi-Mahmoodkot (KMK) Pipeline",
+      "operator": "Pak-Arab Pipeline Company Limited (PAPCO) [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "PK",
+      "toCountry": "PK",
+      "transitCountries": [],
+      "capacityMbd": 0.12041067761806983,
+      "lengthKm": 870,
+      "inService": 1981,
+      "startPoint": {
+        "lat": 24.908489,
+        "lon": 66.941023
+      },
+      "endPoint": {
+        "lat": 30.203289,
+        "lon": 71.009494
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "karamay-dushanzi-r-mqi-oil-pipeline-cn": {
+      "id": "karamay-dushanzi-r-mqi-oil-pipeline-cn",
+      "name": "Karamay–Dushanzi/Ürümqi Oil Pipeline",
+      "operator": "China Petroleum West Pipeline Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.06823271731690624,
+      "lengthKm": 442.2,
+      "inService": 1959,
+      "startPoint": {
+        "lat": 45.62948,
+        "lon": 85.064874
+      },
+      "endPoint": {
+        "lat": 43.867591,
+        "lon": 87.369162
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "kaw-oil-pipeline-us": {
+      "id": "kaw-oil-pipeline-us",
+      "name": "Kaw Oil Pipeline",
+      "operator": "CHS Inc [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.14,
+      "lengthKm": 434.52,
+      "inService": 1957,
+      "startPoint": {
+        "lat": 38.33994,
+        "lon": -98.3101
+      },
+      "endPoint": {
+        "lat": 39.36898,
+        "lon": -99.8106
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "kazakhstan-china-oil-pipeline-atasu-alashankou-kz": {
+      "id": "kazakhstan-china-oil-pipeline-atasu-alashankou-kz",
+      "name": "Kazakhstan-China Oil Pipeline - Atasu-Alashankou",
+      "operator": "Kazakhstan-China Pipeline LLP [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "KZ",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.401368925393566,
+      "lengthKm": 965,
+      "inService": 2006,
+      "startPoint": {
+        "lat": 48.652028,
+        "lon": 71.615357
+      },
+      "endPoint": {
+        "lat": 45.187108,
+        "lon": 82.557755
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "kazakhstan-china-oil-pipeline-kenkiyak-kumkol-i-kz": {
+      "id": "kazakhstan-china-oil-pipeline-kenkiyak-kumkol-i-kz",
+      "name": "Kazakhstan-China Oil Pipeline - Kenkiyak-Kumkol I",
+      "operator": "Kazakhstan-China Pipeline LLP [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "KZ",
+      "toCountry": "KZ",
+      "transitCountries": [],
+      "capacityMbd": 0.200684462696783,
+      "lengthKm": 794,
+      "inService": 2009,
+      "startPoint": {
+        "lat": 48.584035,
+        "lon": 57.118515
+      },
+      "endPoint": {
+        "lat": 46.422425,
+        "lon": 65.721759
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "kenkiyak-atyrau-oil-pipeline-i-kz": {
+      "id": "kenkiyak-atyrau-oil-pipeline-i-kz",
+      "name": "Kenkiyak-Atyrau Oil Pipeline - I",
+      "operator": "MunayTas North-West Pipeline Company LLP [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "KZ",
+      "toCountry": "KZ",
+      "transitCountries": [],
+      "capacityMbd": 0.12041067761806983,
+      "lengthKm": 455,
+      "inService": 2004,
+      "startPoint": {
+        "lat": 47.11296,
+        "lon": 51.89013
+      },
+      "endPoint": {
+        "lat": 48.58961,
+        "lon": 57.15635
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "keystone-oil-pipeline-mainline-phase-1-ca": {
+      "id": "keystone-oil-pipeline-mainline-phase-1-ca",
+      "name": "Keystone Oil Pipeline - Mainline (Phase 1)",
+      "operator": "TC Energy [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.7,
+      "lengthKm": 3455.26,
+      "inService": 2010,
+      "startPoint": {
+        "lat": 52.646266,
+        "lon": -111.265433
+      },
+      "endPoint": {
+        "lat": 38.795087,
+        "lon": -89.076253
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "keystone-oil-pipeline-phase-2-us": {
+      "id": "keystone-oil-pipeline-phase-2-us",
+      "name": "Keystone Oil Pipeline - Phase 2",
+      "operator": "TC Energy [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.156,
+      "lengthKm": 479.58,
+      "inService": 2011,
+      "startPoint": {
+        "lat": 40.037862,
+        "lon": -96.999863
+      },
+      "endPoint": {
+        "lat": 35.963835,
+        "lon": -96.762665
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "kholmogory-klin-oil-pipeline-ru": {
+      "id": "kholmogory-klin-oil-pipeline-ru",
+      "name": "Kholmogory-Klin Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 1.5051334702258727,
+      "lengthKm": 2456,
+      "inService": 1984,
+      "startPoint": {
+        "lat": 53.13904,
+        "lon": 47.55678
+      },
+      "endPoint": {
+        "lat": 63.15056,
+        "lon": 74.60202
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "kirkuk-ceyhan-oil-pipeline-iq": {
+      "id": "kirkuk-ceyhan-oil-pipeline-iq",
+      "name": "Kirkuk-Ceyhan Oil Pipeline",
+      "operator": "BOTAŞ [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IQ",
+      "toCountry": "TR",
+      "transitCountries": [],
+      "capacityMbd": 1.4,
+      "lengthKm": 970,
+      "inService": 1976,
+      "startPoint": {
+        "lat": 35.5173,
+        "lon": 44.3099
+      },
+      "endPoint": {
+        "lat": 37.028528,
+        "lon": 35.813335
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "korla-shanshan-oil-pipeline-cn": {
+      "id": "korla-shanshan-oil-pipeline-cn",
+      "name": "Korla-Shanshan Oil Pipeline",
+      "operator": "China Petroleum West Pipeline Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.1003422313483915,
+      "lengthKm": 476,
+      "inService": 1997,
+      "startPoint": {
+        "lat": 41.681222,
+        "lon": 86.192201
+      },
+      "endPoint": {
+        "lat": 43.084557,
+        "lon": 90.419404
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "krasnoyarsk-irkutsk-oil-pipeline-ru": {
+      "id": "krasnoyarsk-irkutsk-oil-pipeline-ru",
+      "name": "Krasnoyarsk-Irkutsk Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.8067515400410677,
+      "lengthKm": 660,
+      "inService": 1984,
+      "startPoint": {
+        "lat": 55.97819,
+        "lon": 93.2731
+      },
+      "endPoint": {
+        "lat": 52.328625,
+        "lon": 104.236908
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "kuibyshev-lysychansk-oil-pipeline-ru": {
+      "id": "kuibyshev-lysychansk-oil-pipeline-ru",
+      "name": "Kuibyshev-Lysychansk Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "UA",
+      "transitCountries": [],
+      "capacityMbd": 1.6456125941136206,
+      "lengthKm": 1111,
+      "inService": 1977,
+      "startPoint": {
+        "lat": 52.99433,
+        "lon": 50.55136
+      },
+      "endPoint": {
+        "lat": 48.80505,
+        "lon": 38.35786
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "kuibyshev-tikhoretsk-oil-pipeline-capacity-expansion-i-ru": {
+      "id": "kuibyshev-tikhoretsk-oil-pipeline-capacity-expansion-i-ru",
+      "name": "Kuibyshev-Tikhoretsk Oil Pipeline - Capacity expansion I",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.1003422313483915,
+      "lengthKm": 613.08,
+      "inService": 2022,
+      "startPoint": {
+        "lat": 53.11084,
+        "lon": 50.55722
+      },
+      "endPoint": {
+        "lat": 49.73022,
+        "lon": 44.58688
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "kuibyshev-tikhoretsk-oil-pipeline-ru": {
+      "id": "kuibyshev-tikhoretsk-oil-pipeline-ru",
+      "name": "Kuibyshev-Tikhoretsk Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.7023956194387405,
+      "lengthKm": 1474,
+      "inService": 1974,
+      "startPoint": {
+        "lat": 53.11084,
+        "lon": 50.55722
+      },
+      "endPoint": {
+        "lat": 45.90598,
+        "lon": 40.16679
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "kurdistan-oil-pipeline-iq": {
+      "id": "kurdistan-oil-pipeline-iq",
+      "name": "Kurdistan Oil Pipeline",
+      "operator": "Kurdistan Regional Government [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IQ",
+      "toCountry": "TR",
+      "transitCountries": [],
+      "capacityMbd": 0.7,
+      "lengthKm": 896,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 35.886613,
+        "lon": 44.592991
+      },
+      "endPoint": {
+        "lat": 37.028326,
+        "lon": 35.812263
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "kuyumba-taishet-oil-pipeline-phase-1-ru": {
+      "id": "kuyumba-taishet-oil-pipeline-phase-1-ru",
+      "name": "Kuyumba-Taishet Oil Pipeline - Phase 1",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.1725886379192334,
+      "lengthKm": 703,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 60.82801,
+        "lon": 97.36324
+      },
+      "endPoint": {
+        "lat": 55.886865,
+        "lon": 98.032551
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "lanzhou-chengdu-oil-pipeline-cn": {
+      "id": "lanzhou-chengdu-oil-pipeline-cn",
+      "name": "Lanzhou-Chengdu Oil Pipeline",
+      "operator": "National Pipe Network Group Southwest Pipeline Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.200684,
+      "lengthKm": 880,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 35.422898,
+        "lon": 103.85538
+      },
+      "endPoint": {
+        "lat": 30.675715,
+        "lon": 104.018554
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "linyi-yizheng-pipeline-cn": {
+      "id": "linyi-yizheng-pipeline-cn",
+      "name": "Linyi-Yizheng Pipeline",
+      "operator": "China Sinopec Pipeline Storage and Transportation Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.22075290896646135,
+      "lengthKm": 665,
+      "inService": 1978,
+      "startPoint": {
+        "lat": 37.212971,
+        "lon": 116.900607
+      },
+      "endPoint": {
+        "lat": 32.274054,
+        "lon": 119.191302
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "loma-la-lata-bah-a-blanca-pipeline-ar": {
+      "id": "loma-la-lata-bah-a-blanca-pipeline-ar",
+      "name": "Loma La Lata - Bahía Blanca Pipeline",
+      "operator": "MEGA S.A. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "AR",
+      "toCountry": "AR",
+      "transitCountries": [],
+      "capacityMbd": 0.033424800000000005,
+      "lengthKm": 600,
+      "inService": 2001,
+      "startPoint": {
+        "lat": -38.692348,
+        "lon": -62.427343
+      },
+      "endPoint": {
+        "lat": -38.692348,
+        "lon": -62.427343
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "lone-star-express-y-grade-pipeline-expansion-us": {
+      "id": "lone-star-express-y-grade-pipeline-expansion-us",
+      "name": "Lone Star Express Y-Grade Pipeline - Expansion",
+      "operator": "Energy Transfer [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.4,
+      "lengthKm": 566.49,
+      "inService": 2020,
+      "startPoint": {
+        "lat": 32.049801,
+        "lon": -101.823897
+      },
+      "endPoint": {
+        "lat": 31.605232,
+        "lon": -96.173316
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "lone-star-express-y-grade-pipeline-us": {
+      "id": "lone-star-express-y-grade-pipeline-us",
+      "name": "Lone Star Express Y-Grade Pipeline",
+      "operator": "Energy Transfer [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.507,
+      "lengthKm": 861,
+      "inService": 0,
+      "startPoint": {
+        "lat": 32.049801,
+        "lon": -101.823897
+      },
+      "endPoint": {
+        "lat": 29.74301,
+        "lon": -94.986685
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "longhorn-oil-pipeline-crude-oil-system-us": {
+      "id": "longhorn-oil-pipeline-crude-oil-system-us",
+      "name": "Longhorn Oil Pipeline - Crude oil system",
+      "operator": "ONEOK Inc [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.275,
+      "lengthKm": 724.2,
+      "inService": 1950,
+      "startPoint": {
+        "lat": 31.397326,
+        "lon": -102.350149
+      },
+      "endPoint": {
+        "lat": 31.843291,
+        "lon": -102.371718
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "luyu-oil-pipeline-rizhao-puyang-luoyang-oil-pipeline-cn": {
+      "id": "luyu-oil-pipeline-rizhao-puyang-luoyang-oil-pipeline-cn",
+      "name": "Luyu Oil Pipeline - Rizhao–Puyang–Luoyang Oil Pipeline",
+      "operator": "China Sinopec Pipeline Storage and Transportation Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.3612320328542094,
+      "lengthKm": 796,
+      "inService": 2021,
+      "startPoint": {
+        "lat": 35.376488,
+        "lon": 119.556965
+      },
+      "endPoint": {
+        "lat": 34.667716,
+        "lon": 112.499053
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "lysychansk-tikhoretsk-oil-pipeline-pipeline-1-ua": {
+      "id": "lysychansk-tikhoretsk-oil-pipeline-pipeline-1-ua",
+      "name": "Lysychansk-Tikhoretsk Oil Pipeline - Pipeline 1",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "UA",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.4214373716632443,
+      "lengthKm": 475,
+      "inService": 1975,
+      "startPoint": {
+        "lat": 48.82468,
+        "lon": 38.34236
+      },
+      "endPoint": {
+        "lat": 45.85183,
+        "lon": 40.1767
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "madero-cadereyta-oil-pipeline-line-1-mx": {
+      "id": "madero-cadereyta-oil-pipeline-line-1-mx",
+      "name": "Madero-Cadereyta Oil Pipeline - Line 1",
+      "operator": "Pemex [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "MX",
+      "toCountry": "MX",
+      "transitCountries": [],
+      "capacityMbd": 0.115,
+      "lengthKm": 472,
+      "inService": 1975,
+      "startPoint": {
+        "lat": 22.27427,
+        "lon": -97.816536
+      },
+      "endPoint": {
+        "lat": 25.586649,
+        "lon": -99.943797
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "madero-cadereyta-pipeline-line-2-mx": {
+      "id": "madero-cadereyta-pipeline-line-2-mx",
+      "name": "Madero-Cadereyta Pipeline - Line 2",
+      "operator": "Pemex [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "MX",
+      "toCountry": "MX",
+      "transitCountries": [],
+      "capacityMbd": 0.16,
+      "lengthKm": 504,
+      "inService": 2000,
+      "startPoint": {
+        "lat": 22.27427,
+        "lon": -97.816536
+      },
+      "endPoint": {
+        "lat": 25.586649,
+        "lon": -99.943797
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "malgobek-tikhoretsk-oil-pipeline-ru": {
+      "id": "malgobek-tikhoretsk-oil-pipeline-ru",
+      "name": "Malgobek-Tikhoretsk Oil Pipeline",
+      "operator": "Chernomortransneft JSC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.17660232717316907,
+      "lengthKm": 469,
+      "inService": 0,
+      "startPoint": {
+        "lat": 45.828184,
+        "lon": 40.135634
+      },
+      "endPoint": {
+        "lat": 43.508743,
+        "lon": 44.587558
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "mangala-development-pipeline-in": {
+      "id": "mangala-development-pipeline-in",
+      "name": "Mangala Development Pipeline",
+      "operator": "Vedanta Resources [70.00%]; Oil and Natural Gas Corporation Limited [30.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.17479616700889802,
+      "lengthKm": 660,
+      "inService": 2010,
+      "startPoint": {
+        "lat": 25.730632,
+        "lon": 71.400146
+      },
+      "endPoint": {
+        "lat": 21.966927,
+        "lon": 69.209919
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "marib-ras-isa-oil-pipeline-ye": {
+      "id": "marib-ras-isa-oil-pipeline-ye",
+      "name": "Marib-Ras Isa Oil Pipeline",
+      "operator": "SAFER Exploration & Production Operations Company [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "YE",
+      "toCountry": "YE",
+      "transitCountries": [],
+      "capacityMbd": 0.3,
+      "lengthKm": 438,
+      "inService": 1987,
+      "startPoint": {
+        "lat": 15.469871,
+        "lon": 45.324042
+      },
+      "endPoint": {
+        "lat": 15.218422,
+        "lon": 42.621982
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "mariner-east-2-ngl-pipeline-us": {
+      "id": "mariner-east-2-ngl-pipeline-us",
+      "name": "Mariner East 2 NGL Pipeline",
+      "operator": "Energy Transfer [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.125,
+      "lengthKm": 563.27,
+      "inService": 2022,
+      "startPoint": {
+        "lat": 40.401234,
+        "lon": -81.105988
+      },
+      "endPoint": {
+        "lat": 39.844502,
+        "lon": -75.41787
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "mariner-west-pipeline-us": {
+      "id": "mariner-west-pipeline-us",
+      "name": "Mariner West Pipeline",
+      "operator": "Sunoco Pipeline LP [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.05,
+      "lengthKm": 724.2,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 40.264562,
+        "lon": -80.260642
+      },
+      "endPoint": {
+        "lat": 41.67421,
+        "lon": -83.448597
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "mehraran-shiraz-oil-pipeline-ir": {
+      "id": "mehraran-shiraz-oil-pipeline-ir",
+      "name": "Mehraran-Shiraz Oil Pipeline",
+      "operator": "unknown [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityMbd": 0.075,
+      "lengthKm": 400,
+      "inService": 0,
+      "startPoint": {
+        "lat": 28.60526,
+        "lon": 55.809078
+      },
+      "endPoint": {
+        "lat": 29.592152,
+        "lon": 52.589606
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "mid-valley-oil-pipeline-us": {
+      "id": "mid-valley-oil-pipeline-us",
+      "name": "Mid-Valley Oil Pipeline",
+      "operator": "Energy Transfer [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.24,
+      "lengthKm": 1570,
+      "inService": 1950,
+      "startPoint": {
+        "lat": 32.48461,
+        "lon": -94.8242
+      },
+      "endPoint": {
+        "lat": 32.45579,
+        "lon": -91.5117
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "midland-to-echo-pipeline-system-midland-to-echo-1-oil-pipeli-us": {
+      "id": "midland-to-echo-pipeline-system-midland-to-echo-1-oil-pipeli-us",
+      "name": "Midland-to-ECHO Pipeline System - Midland-to-ECHO 1 Oil Pipeline",
+      "operator": "Enterprise Products Partners [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.575,
+      "lengthKm": 672.7,
+      "inService": 2018,
+      "startPoint": {
+        "lat": 31.970612,
+        "lon": -102.151999
+      },
+      "endPoint": {
+        "lat": 29.711237,
+        "lon": -96.185777
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "midland-to-echo-pipeline-system-pipeline-3-us": {
+      "id": "midland-to-echo-pipeline-system-pipeline-3-us",
+      "name": "Midland-to-ECHO Pipeline System - Pipeline 3",
+      "operator": "Enterprise Products Partners [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.45,
+      "lengthKm": 708.11,
+      "inService": 2020,
+      "startPoint": {
+        "lat": 31.952843,
+        "lon": -102.121722
+      },
+      "endPoint": {
+        "lat": 29.797411,
+        "lon": -96.175932
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "minnesota-pipeline-system-lines-1-3-us": {
+      "id": "minnesota-pipeline-system-lines-1-3-us",
+      "name": "Minnesota Pipeline System - Lines 1–3",
+      "operator": "Minnesota Pipe Line Company LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.3,
+      "lengthKm": 1235.98,
+      "inService": 1954,
+      "startPoint": {
+        "lat": 47.6919,
+        "lon": -95.431004
+      },
+      "endPoint": {
+        "lat": 44.694109,
+        "lon": -92.984845
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "moomba-to-port-bonython-oil-pipeline-au": {
+      "id": "moomba-to-port-bonython-oil-pipeline-au",
+      "name": "Moomba to Port Bonython Oil Pipeline",
+      "operator": "Santos Limited [66.60%]; Beach Energy Limited [20.20%]; Origin Energy Limited [13.20%]",
+      "commodityType": "oil",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityMbd": 0.04,
+      "lengthKm": 659,
+      "inService": 1984,
+      "startPoint": {
+        "lat": -32.9602,
+        "lon": 137.7126
+      },
+      "endPoint": {
+        "lat": -32.9602,
+        "lon": 137.7126
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "moomba-to-sydney-ethane-pipeline-au": {
+      "id": "moomba-to-sydney-ethane-pipeline-au",
+      "name": "Moomba to Sydney Ethane Pipeline",
+      "operator": "Ethane Pipeline Income Fund [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "AU",
+      "toCountry": "AU",
+      "transitCountries": [],
+      "capacityMbd": 0.005619164955509925,
+      "lengthKm": 1375,
+      "inService": 1996,
+      "startPoint": {
+        "lat": -28.121067,
+        "lon": 140.209673
+      },
+      "endPoint": {
+        "lat": -33.96409,
+        "lon": 150.9806
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "mundra-bhatinda-pipeline-in": {
+      "id": "mundra-bhatinda-pipeline-in",
+      "name": "Mundra Bhatinda Pipeline",
+      "operator": "HPCL-Mittal Energy Limited [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.22577002053388093,
+      "lengthKm": 1017,
+      "inService": 2010,
+      "startPoint": {
+        "lat": 23.135148,
+        "lon": 69.617262
+      },
+      "endPoint": {
+        "lat": 30.443787,
+        "lon": 74.956617
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "mundra-panipat-oil-pipeline-in": {
+      "id": "mundra-panipat-oil-pipeline-in",
+      "name": "Mundra-Panipat Oil Pipeline",
+      "operator": "Indian Oil Corporation [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.16857494866529774,
+      "lengthKm": 1194,
+      "inService": 2007,
+      "startPoint": {
+        "lat": 22.835045,
+        "lon": 69.728117
+      },
+      "endPoint": {
+        "lat": 29.379621,
+        "lon": 76.96914
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "naharkatiya-barauni-crude-oil-pipeline-in": {
+      "id": "naharkatiya-barauni-crude-oil-pipeline-in",
+      "name": "Naharkatiya-Barauni Crude Oil Pipeline",
+      "operator": "Oil India Limited [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.17961259411362082,
+      "lengthKm": 1157,
+      "inService": 1962,
+      "startPoint": {
+        "lat": 27.287236,
+        "lon": 95.247908
+      },
+      "endPoint": {
+        "lat": 25.471908,
+        "lon": 85.975774
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "nato-pipeline-system-south-european-oil-pipeline-marseille-b-fr": {
+      "id": "nato-pipeline-system-south-european-oil-pipeline-marseille-b-fr",
+      "name": "NATO Pipeline System - South European Oil Pipeline: Marseille-Besancon-Cressier",
+      "operator": "Société du pipeline sud-européen [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "FR",
+      "toCountry": "DE",
+      "transitCountries": [
+        "CH"
+      ],
+      "capacityMbd": 0.45,
+      "lengthKm": 1831,
+      "inService": 1962,
+      "startPoint": {
+        "lat": 43.430705,
+        "lon": 4.923411
+      },
+      "endPoint": {
+        "lat": 47.057955,
+        "lon": 7.113157
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "neka-ray-oil-pipelines-pipeline-1-ir": {
+      "id": "neka-ray-oil-pipelines-pipeline-1-ir",
+      "name": "Neka–Ray Oil Pipelines - Pipeline 1",
+      "operator": "National Iranian Oil Company [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityMbd": 0.5,
+      "lengthKm": 515,
+      "inService": 0,
+      "startPoint": {
+        "lat": 36.649844,
+        "lon": 53.297247
+      },
+      "endPoint": {
+        "lat": 31.318707,
+        "lon": 48.670699
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "niger-benin-oil-pipeline-ne": {
+      "id": "niger-benin-oil-pipeline-ne",
+      "name": "Niger–Benin Oil Pipeline",
+      "operator": "China National Petroleum Corp [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "NE",
+      "toCountry": "BJ",
+      "transitCountries": [],
+      "capacityMbd": 0.09,
+      "lengthKm": 1950,
+      "inService": 2024,
+      "startPoint": {
+        "lat": 6.36495,
+        "lon": 2.62407
+      },
+      "endPoint": {
+        "lat": 13.9403,
+        "lon": 8.70168
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "ningbo-shanghai-nanjing-oil-pipeline-cn": {
+      "id": "ningbo-shanghai-nanjing-oil-pipeline-cn",
+      "name": "Ningbo-Shanghai-Nanjing Oil Pipeline",
+      "operator": "China Sinopec Pipeline Storage and Transportation Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.9432169746748803,
+      "lengthKm": 849.5,
+      "inService": 2004,
+      "startPoint": {
+        "lat": 29.914085,
+        "lon": 121.974736
+      },
+      "endPoint": {
+        "lat": 32.101487,
+        "lon": 118.905661
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "nizhnevartovsk-kurgan-kuibyshev-oil-pipeline-ru": {
+      "id": "nizhnevartovsk-kurgan-kuibyshev-oil-pipeline-ru",
+      "name": "Nizhnevartovsk-Kurgan-Kuibyshev Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 1.8061601642710474,
+      "lengthKm": 2150,
+      "inService": 1975,
+      "startPoint": {
+        "lat": 60.98423,
+        "lon": 76.43799
+      },
+      "endPoint": {
+        "lat": 52.99226,
+        "lon": 50.53428
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "norman-wells-oil-pipeline-ca": {
+      "id": "norman-wells-oil-pipeline-ca",
+      "name": "Norman Wells Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.045,
+      "lengthKm": 869.05,
+      "inService": 1985,
+      "startPoint": {
+        "lat": 65.293978,
+        "lon": -126.764
+      },
+      "endPoint": {
+        "lat": 59.15371,
+        "lon": -118.69294
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "north-dakota-pipeline-system-us": {
+      "id": "north-dakota-pipeline-system-us",
+      "name": "North Dakota Pipeline System",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.165,
+      "lengthKm": 1530,
+      "inService": 0,
+      "startPoint": {
+        "lat": 48.2393,
+        "lon": -101.261
+      },
+      "endPoint": {
+        "lat": 48.7161,
+        "lon": -100.915
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "north-system-pipeline-us": {
+      "id": "north-system-pipeline-us",
+      "name": "North System Pipeline",
+      "operator": "unknown [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.134,
+      "lengthKm": 2550.81,
+      "inService": 0,
+      "startPoint": {
+        "lat": 38.009744,
+        "lon": -97.958586
+      },
+      "endPoint": {
+        "lat": 38.406935,
+        "lon": -97.924249
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "northern-peruvian-oil-pipeline-tramo-ii-pe": {
+      "id": "northern-peruvian-oil-pipeline-tramo-ii-pe",
+      "name": "Northern Peruvian Oil Pipeline - Tramo II",
+      "operator": "Petroperú [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "PE",
+      "toCountry": "PE",
+      "transitCountries": [],
+      "capacityMbd": 0.2,
+      "lengthKm": 548,
+      "inService": 1977,
+      "startPoint": {
+        "lat": -4.649176,
+        "lon": -77.505285
+      },
+      "endPoint": {
+        "lat": -5.82348,
+        "lon": -81.032277
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "nuevo-teapa-madero-oil-pipeline-mx": {
+      "id": "nuevo-teapa-madero-oil-pipeline-mx",
+      "name": "Nuevo Teapa-Madero Oil Pipeline",
+      "operator": "Pemex [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "MX",
+      "toCountry": "MX",
+      "transitCountries": [],
+      "capacityMbd": 0.16,
+      "lengthKm": 736,
+      "inService": 2005,
+      "startPoint": {
+        "lat": 18.076597,
+        "lon": -94.327403
+      },
+      "endPoint": {
+        "lat": 22.27427,
+        "lon": -97.816536
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "nuevo-teapa-poza-rica-oil-pipeline-mx": {
+      "id": "nuevo-teapa-poza-rica-oil-pipeline-mx",
+      "name": "Nuevo Teapa-Poza Rica Oil Pipeline",
+      "operator": "Pemex [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "MX",
+      "toCountry": "MX",
+      "transitCountries": [],
+      "capacityMbd": 0.24,
+      "lengthKm": 486,
+      "inService": 1975,
+      "startPoint": {
+        "lat": 18.076597,
+        "lon": -94.327403
+      },
+      "endPoint": {
+        "lat": 20.509984,
+        "lon": -97.47763
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "nuevo-teapa-tula-oil-pipeline-line-1-mx": {
+      "id": "nuevo-teapa-tula-oil-pipeline-line-1-mx",
+      "name": "Nuevo Teapa-Tula Oil Pipeline - Line 1",
+      "operator": "Pemex [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "MX",
+      "toCountry": "MX",
+      "transitCountries": [],
+      "capacityMbd": 0.5,
+      "lengthKm": 629,
+      "inService": 1980,
+      "startPoint": {
+        "lat": 18.076597,
+        "lon": -94.327403
+      },
+      "endPoint": {
+        "lat": 20.04956,
+        "lon": -99.272552
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "ocensa-oil-pipeline-co": {
+      "id": "ocensa-oil-pipeline-co",
+      "name": "Ocensa Oil Pipeline",
+      "operator": "Cenit SAS [72.65%]; AI Candelaria Spain SA [27.35%]",
+      "commodityType": "oil",
+      "fromCountry": "CO",
+      "toCountry": "CO",
+      "transitCountries": [],
+      "capacityMbd": 0.745,
+      "lengthKm": 848,
+      "inService": 1997,
+      "startPoint": {
+        "lat": 5.2127,
+        "lon": -72.610583
+      },
+      "endPoint": {
+        "lat": 9.410435,
+        "lon": -75.692114
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "oldelval-oil-pipeline-allen-puerto-rosales-ar": {
+      "id": "oldelval-oil-pipeline-allen-puerto-rosales-ar",
+      "name": "Oldelval Oil Pipeline - Allen-Puerto Rosales",
+      "operator": "Oleoductos del Valle SA [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "AR",
+      "toCountry": "AR",
+      "transitCountries": [],
+      "capacityMbd": 0.223917,
+      "lengthKm": 513,
+      "inService": 1993,
+      "startPoint": {
+        "lat": -38.934084,
+        "lon": -67.671492
+      },
+      "endPoint": {
+        "lat": -38.923906,
+        "lon": -62.052878
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "oldelval-oil-pipeline-proyecto-duplicar-ar": {
+      "id": "oldelval-oil-pipeline-proyecto-duplicar-ar",
+      "name": "Oldelval Oil Pipeline - Proyecto Duplicar",
+      "operator": "Oleoductos del Valle SA [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "AR",
+      "toCountry": "AR",
+      "transitCountries": [],
+      "capacityMbd": 0.315,
+      "lengthKm": 525,
+      "inService": 2025,
+      "startPoint": {
+        "lat": -38.934084,
+        "lon": -67.671492
+      },
+      "endPoint": {
+        "lat": -38.923906,
+        "lon": -62.052878
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "omsk-irkutsk-oil-pipeline-ru": {
+      "id": "omsk-irkutsk-oil-pipeline-ru",
+      "name": "Omsk-Irkutsk Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.4816427104722793,
+      "lengthKm": 1870,
+      "inService": 1967,
+      "startPoint": {
+        "lat": 55.08879,
+        "lon": 73.23503
+      },
+      "endPoint": {
+        "lat": 52.328625,
+        "lon": 104.236908
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "omsk-pavlodar-oil-pipeline-ru": {
+      "id": "omsk-pavlodar-oil-pipeline-ru",
+      "name": "Omsk-Pavlodar Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "KZ",
+      "transitCountries": [],
+      "capacityMbd": 0.9030800821355237,
+      "lengthKm": 438,
+      "inService": 1977,
+      "startPoint": {
+        "lat": 55.08991,
+        "lon": 73.23845
+      },
+      "endPoint": {
+        "lat": 52.39864,
+        "lon": 76.88163
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "orenburg-kazan-ethane-pipeline-orenburg-minnibaevo-ethane-pi-ru": {
+      "id": "orenburg-kazan-ethane-pipeline-orenburg-minnibaevo-ethane-pi-ru",
+      "name": "Orenburg-Kazan Ethane Pipeline - Orenburg-Minnibaevo Ethane Pipeline",
+      "operator": "Gazprom [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.015051334702258728,
+      "lengthKm": 434.6,
+      "inService": 1982,
+      "startPoint": {
+        "lat": 51.957254,
+        "lon": 54.67939
+      },
+      "endPoint": {
+        "lat": 54.931583,
+        "lon": 51.910518
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "osbra-pipeline-br": {
+      "id": "osbra-pipeline-br",
+      "name": "OSBRA Pipeline",
+      "operator": "Petrobras [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "BR",
+      "toCountry": "BR",
+      "transitCountries": [],
+      "capacityMbd": 0.10339397,
+      "lengthKm": 964,
+      "inService": 1996,
+      "startPoint": {
+        "lat": -16.692967,
+        "lon": -49.106089
+      },
+      "endPoint": {
+        "lat": -16.692967,
+        "lon": -49.106089
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "overland-pass-ngl-pipeline-us": {
+      "id": "overland-pass-ngl-pipeline-us",
+      "name": "Overland Pass NGL Pipeline",
+      "operator": "Overland Pass Pipeline Company LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.245,
+      "lengthKm": 1223.1,
+      "inService": 2008,
+      "startPoint": {
+        "lat": 40.363169,
+        "lon": -104.398612
+      },
+      "endPoint": {
+        "lat": 38.376578,
+        "lon": -97.831819
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "ozark-crude-oil-pipeline-patoka-to-lima-expansion-us": {
+      "id": "ozark-crude-oil-pipeline-patoka-to-lima-expansion-us",
+      "name": "Ozark Crude Oil Pipeline - Patoka-to-Lima Expansion",
+      "operator": "MPLX [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.018,
+      "lengthKm": 486.02,
+      "inService": 2016,
+      "startPoint": {
+        "lat": 38.753157,
+        "lon": -89.099153
+      },
+      "endPoint": {
+        "lat": 40.708861,
+        "lon": -84.143663
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "ozark-crude-oil-pipeline-us": {
+      "id": "ozark-crude-oil-pipeline-us",
+      "name": "Ozark Crude Oil Pipeline",
+      "operator": "MPLX [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.23,
+      "lengthKm": 700.06,
+      "inService": 0,
+      "startPoint": {
+        "lat": 38.81875,
+        "lon": -90.0293
+      },
+      "endPoint": {
+        "lat": 35.94303,
+        "lon": -96.673
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "panola-pipeline-us": {
+      "id": "panola-pipeline-us",
+      "name": "Panola Pipeline",
+      "operator": "Panola Pipeline Company LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.05,
+      "lengthKm": 407.16,
+      "inService": 0,
+      "startPoint": {
+        "lat": 32.187549,
+        "lon": -94.260255
+      },
+      "endPoint": {
+        "lat": 29.85982,
+        "lon": -94.912207
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "paradip-haldia-barauni-oil-pipeline-phbpl-in": {
+      "id": "paradip-haldia-barauni-oil-pipeline-phbpl-in",
+      "name": "Paradip-Haldia-Barauni Oil Pipeline (PHBPL)",
+      "operator": "Indian Oil Corporation [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.3052055,
+      "lengthKm": 1447,
+      "inService": 2009,
+      "startPoint": {
+        "lat": 20.220966,
+        "lon": 86.550293
+      },
+      "endPoint": {
+        "lat": 25.442267,
+        "lon": 86.058826
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "paradip-haldia-durgapur-lpg-pipeline-in": {
+      "id": "paradip-haldia-durgapur-lpg-pipeline-in",
+      "name": "Paradip Haldia Durgapur LPG Pipeline",
+      "operator": "unknown [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.02548692676249144,
+      "lengthKm": 873,
+      "inService": 0,
+      "startPoint": {
+        "lat": 20.329393,
+        "lon": 86.632906
+      },
+      "endPoint": {
+        "lat": 23.532306,
+        "lon": 87.321958
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "pavlodar-shymkent-oil-pipeline-kz": {
+      "id": "pavlodar-shymkent-oil-pipeline-kz",
+      "name": "Pavlodar-Shymkent Oil Pipeline",
+      "operator": "KazTransOil JSC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "KZ",
+      "toCountry": "KZ",
+      "transitCountries": [],
+      "capacityMbd": 0.4415058179329227,
+      "lengthKm": 1652,
+      "inService": 1983,
+      "startPoint": {
+        "lat": 52.40964,
+        "lon": 76.87728
+      },
+      "endPoint": {
+        "lat": 42.32508,
+        "lon": 69.36017
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "permian-express-oil-pipeline-phase-i-us": {
+      "id": "permian-express-oil-pipeline-phase-i-us",
+      "name": "Permian Express Oil Pipeline - Phase I",
+      "operator": "Permian Express Partners LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.2,
+      "lengthKm": 482.8,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 29.98286,
+        "lon": -94.04219
+      },
+      "endPoint": {
+        "lat": 33.923516,
+        "lon": -98.428999
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "permian-express-oil-pipeline-phase-ii-us": {
+      "id": "permian-express-oil-pipeline-phase-ii-us",
+      "name": "Permian Express Oil Pipeline - Phase II",
+      "operator": "Permian Express Partners LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.23,
+      "lengthKm": 537.52,
+      "inService": 2015,
+      "startPoint": {
+        "lat": 31.946085,
+        "lon": -101.926475
+      },
+      "endPoint": {
+        "lat": 29.98286,
+        "lon": -94.04219
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "permian-express-oil-pipeline-phase-iv-us": {
+      "id": "permian-express-oil-pipeline-phase-iv-us",
+      "name": "Permian Express Oil Pipeline - Phase IV",
+      "operator": "Permian Express Partners LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.12,
+      "lengthKm": 643.74,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 32.52008,
+        "lon": -100.859005
+      },
+      "endPoint": {
+        "lat": 29.986868,
+        "lon": -94.075275
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "permian-longview-and-louisiana-extension-pela-oil-pipeline-us": {
+      "id": "permian-longview-and-louisiana-extension-pela-oil-pipeline-us",
+      "name": "Permian Longview and Louisiana Extension (PELA) Oil Pipeline",
+      "operator": "Energy Transfer [unknown %]; ExxonMobil [unknown %]; SunVit Pipeline LLC [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.1,
+      "lengthKm": 1207.01,
+      "inService": 2016,
+      "startPoint": {
+        "lat": 32.521123,
+        "lon": -100.838587
+      },
+      "endPoint": {
+        "lat": 32.521123,
+        "lon": -100.838587
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "plains-west-coast-pipeline-us": {
+      "id": "plains-west-coast-pipeline-us",
+      "name": "Plains West Coast Pipeline",
+      "operator": "Pacific Pipeline System LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.235,
+      "lengthKm": 571.13,
+      "inService": 1999,
+      "startPoint": {
+        "lat": 35.151872,
+        "lon": -119.338244
+      },
+      "endPoint": {
+        "lat": 35.019585,
+        "lon": -119.065185
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "platte-crude-oil-pipeline-us": {
+      "id": "platte-crude-oil-pipeline-us",
+      "name": "Platte Crude Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.164,
+      "lengthKm": 1511.17,
+      "inService": 0,
+      "startPoint": {
+        "lat": 42.864456,
+        "lon": -106.408789
+      },
+      "endPoint": {
+        "lat": 38.827431,
+        "lon": -90.088331
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "pony-express-oil-pipeline-us": {
+      "id": "pony-express-oil-pipeline-us",
+      "name": "Pony Express Oil Pipeline",
+      "operator": "Tallgrass Pony Express Pipeline LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.4,
+      "lengthKm": 1223.1,
+      "inService": 2014,
+      "startPoint": {
+        "lat": 42.264699,
+        "lon": -104.752892
+      },
+      "endPoint": {
+        "lat": 35.986089,
+        "lon": -96.82429
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "poseidon-oil-pipeline-us": {
+      "id": "poseidon-oil-pipeline-us",
+      "name": "Poseidon Oil Pipeline",
+      "operator": "Enterprise Products Partners [36.00%]; Shell [36.00%]; Genesis Energy [28.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.4,
+      "lengthKm": 590,
+      "inService": 1996,
+      "startPoint": {
+        "lat": 27.92279,
+        "lon": -92.5541
+      },
+      "endPoint": {
+        "lat": 29.11181,
+        "lon": -90.483
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "poza-rica-salamanca-oil-pipeline-mx": {
+      "id": "poza-rica-salamanca-oil-pipeline-mx",
+      "name": "Poza Rica-Salamanca Oil Pipeline",
+      "operator": "Pemex [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "MX",
+      "toCountry": "MX",
+      "transitCountries": [],
+      "capacityMbd": 0.081,
+      "lengthKm": 443,
+      "inService": 1975,
+      "startPoint": {
+        "lat": 20.509984,
+        "lon": -97.47763
+      },
+      "endPoint": {
+        "lat": 20.573348,
+        "lon": -101.183499
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "puerto-rosales-la-plata-oil-pipeline-ar": {
+      "id": "puerto-rosales-la-plata-oil-pipeline-ar",
+      "name": "Puerto Rosales-La Plata Oil Pipeline",
+      "operator": "YPF [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "AR",
+      "toCountry": "AR",
+      "transitCountries": [],
+      "capacityMbd": 0.326541,
+      "lengthKm": 585,
+      "inService": 0,
+      "startPoint": {
+        "lat": -38.923906,
+        "lon": -62.052878
+      },
+      "endPoint": {
+        "lat": -34.885565,
+        "lon": -57.913351
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "puesto-hern-ndez-luj-n-de-cuyo-oil-pipeline-ar": {
+      "id": "puesto-hern-ndez-luj-n-de-cuyo-oil-pipeline-ar",
+      "name": "Puesto Hernández-Luján de Cuyo Oil Pipeline",
+      "operator": "YPF [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "AR",
+      "toCountry": "AR",
+      "transitCountries": [],
+      "capacityMbd": 0.093509,
+      "lengthKm": 528,
+      "inService": 0,
+      "startPoint": {
+        "lat": -37.29611,
+        "lon": -69.066683
+      },
+      "endPoint": {
+        "lat": -33.064998,
+        "lon": -68.96724
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "purovsk-yuzhny-balyk-tobolsk-product-pipeline-purovsk-yuzhny-ru": {
+      "id": "purovsk-yuzhny-balyk-tobolsk-product-pipeline-purovsk-yuzhny-ru",
+      "name": "Purovsk-Yuzhny Balyk-Tobolsk Product Pipeline - Purovsk-Yuzhny Balyk Product Pipeline",
+      "operator": "Sibur Holding PJSC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.0802737850787132,
+      "lengthKm": 686,
+      "inService": 2014,
+      "startPoint": {
+        "lat": 64.915176,
+        "lon": 77.749906
+      },
+      "endPoint": {
+        "lat": 60.687678,
+        "lon": 72.864469
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "purovsk-yuzhny-balyk-tobolsk-product-pipeline-yuzhny-balyk-t-ru": {
+      "id": "purovsk-yuzhny-balyk-tobolsk-product-pipeline-yuzhny-balyk-t-ru",
+      "name": "Purovsk-Yuzhny Balyk-Tobolsk Product Pipeline - Yuzhny Balyk-Tobolsk Product Pipeline",
+      "operator": "Sibur Holding PJSC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.1605475701574264,
+      "lengthKm": 410,
+      "inService": 2014,
+      "startPoint": {
+        "lat": 60.687678,
+        "lon": 72.864469
+      },
+      "endPoint": {
+        "lat": 58.262636,
+        "lon": 68.437988
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "purpe-samotlor-oil-pipeline-ru": {
+      "id": "purpe-samotlor-oil-pipeline-ru",
+      "name": "Purpe-Samotlor Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.9030800821355237,
+      "lengthKm": 430,
+      "inService": 2011,
+      "startPoint": {
+        "lat": 64.533682,
+        "lon": 76.725769
+      },
+      "endPoint": {
+        "lat": 61.2581,
+        "lon": 77.0433
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "ray-tabriz-oil-pipeline-ir": {
+      "id": "ray-tabriz-oil-pipeline-ir",
+      "name": "Ray–Tabriz Oil Pipeline",
+      "operator": "National Iranian Oil Company [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityMbd": 0.117,
+      "lengthKm": 1721,
+      "inService": 1995,
+      "startPoint": {
+        "lat": 31.318707,
+        "lon": 48.670699
+      },
+      "endPoint": {
+        "lat": 38.079241,
+        "lon": 46.288689
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "red-river-oil-pipeline-us": {
+      "id": "red-river-oil-pipeline-us",
+      "name": "Red River Oil Pipeline",
+      "operator": "Plains All American Pipeline [unknown %]; Valero Energy [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.15,
+      "lengthKm": 563.27,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 35.986089,
+        "lon": -96.82429
+      },
+      "endPoint": {
+        "lat": 32.506702,
+        "lon": -94.825353
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "rizhao-dongming-oil-pipeline-cn": {
+      "id": "rizhao-dongming-oil-pipeline-cn",
+      "name": "Rizhao-Dongming Oil Pipeline",
+      "operator": "China Sinopec Pipeline Storage and Transportation Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.200684462696783,
+      "lengthKm": 447.02,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 35.105195,
+        "lon": 119.371814
+      },
+      "endPoint": {
+        "lat": 35.304604,
+        "lon": 115.122863
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "rizhao-yizheng-parallel-oil-pipeline-network-system-route-cn": {
+      "id": "rizhao-yizheng-parallel-oil-pipeline-network-system-route-cn",
+      "name": "Rizhao–Yizheng Parallel Oil Pipeline - NETWORK/SYSTEM ROUTE",
+      "operator": "China Sinopec Pipeline Storage and Transportation Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.401368925393566,
+      "lengthKm": 400,
+      "inService": 0,
+      "startPoint": {
+        "lat": 34.591618,
+        "lon": 119.232853
+      },
+      "endPoint": {
+        "lat": 32.244403,
+        "lon": 119.177921
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "rizhao-zhanhua-oil-pipeline-rizhao-port-jingbo-oil-pipeline-cn": {
+      "id": "rizhao-zhanhua-oil-pipeline-rizhao-port-jingbo-oil-pipeline-cn",
+      "name": "Rizhao–Zhanhua Oil Pipeline - Rizhao Port–Jingbo Oil Pipeline",
+      "operator": "Rizhao Gangda Pipeline Transportation Co.,Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.3010266940451745,
+      "lengthKm": 428,
+      "inService": 2021,
+      "startPoint": {
+        "lat": 35.371251,
+        "lon": 119.557049
+      },
+      "endPoint": {
+        "lat": 37.154003,
+        "lon": 118.131875
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "rizhao-zhanhua-oil-pipeline-rizhao-zhonghai-fine-chemical-oi-cn": {
+      "id": "rizhao-zhanhua-oil-pipeline-rizhao-zhonghai-fine-chemical-oi-cn",
+      "name": "Rizhao–Zhanhua Oil Pipeline - Rizhao-Zhonghai Fine Chemical Oil Pipeline",
+      "operator": "Rizhao Gangda Pipeline Transportation Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.3010266940451745,
+      "lengthKm": 485,
+      "inService": 0,
+      "startPoint": {
+        "lat": 40.782057,
+        "lon": 122.095132
+      },
+      "endPoint": {
+        "lat": 40.720033,
+        "lon": 122.170445
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "saddlehorn-oil-pipeline-expansion-us": {
+      "id": "saddlehorn-oil-pipeline-expansion-us",
+      "name": "Saddlehorn Oil Pipeline - Expansion",
+      "operator": "Saddlehorn Pipeline Company LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.1,
+      "lengthKm": 865.8,
+      "inService": 2020,
+      "startPoint": {
+        "lat": 40.461744,
+        "lon": -104.7647
+      },
+      "endPoint": {
+        "lat": 35.947974,
+        "lon": -96.776086
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "salaya-mathura-oil-pipeline-in": {
+      "id": "salaya-mathura-oil-pipeline-in",
+      "name": "Salaya–Mathura Oil Pipeline",
+      "operator": "Indian Oil Corporation [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.5017111567419575,
+      "lengthKm": 2660,
+      "inService": 1978,
+      "startPoint": {
+        "lat": 22.30869,
+        "lon": 69.600571
+      },
+      "endPoint": {
+        "lat": 29.399932,
+        "lon": 76.969954
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "sand-hills-ngl-pipeline-us": {
+      "id": "sand-hills-ngl-pipeline-us",
+      "name": "Sand Hills NGL Pipeline",
+      "operator": "DCP Midstream LLC [66.67%]; Phillips 66 Partners [33.33%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.2,
+      "lengthKm": 1158.73,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 29.827795,
+        "lon": -94.939661
+      },
+      "endPoint": {
+        "lat": 31.832239,
+        "lon": -104.247009
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "santa-cruz-cochabamba-oil-pipeline-bo": {
+      "id": "santa-cruz-cochabamba-oil-pipeline-bo",
+      "name": "Santa Cruz-Cochabamba Oil Pipeline",
+      "operator": "YPFB Transporte [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "BO",
+      "toCountry": "BO",
+      "transitCountries": [],
+      "capacityMbd": 0.035,
+      "lengthKm": 531,
+      "inService": 1966,
+      "startPoint": {
+        "lat": -17.452532,
+        "lon": -66.122037
+      },
+      "endPoint": {
+        "lat": -17.879678,
+        "lon": -63.195752
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "sarir-tobruk-oil-pipeline-ly": {
+      "id": "sarir-tobruk-oil-pipeline-ly",
+      "name": "Sarir-Tobruk Oil Pipeline",
+      "operator": "Libyan National Oil Corporation [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "LY",
+      "toCountry": "LY",
+      "transitCountries": [],
+      "capacityMbd": 0.4997043121149897,
+      "lengthKm": 511.87,
+      "inService": 1969,
+      "startPoint": {
+        "lat": 27.6468,
+        "lon": 22.4986
+      },
+      "endPoint": {
+        "lat": 32.0448,
+        "lon": 23.9768
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "saskatchewan-oil-pipeline-ca": {
+      "id": "saskatchewan-oil-pipeline-ca",
+      "name": "Saskatchewan Oil Pipeline",
+      "operator": "Kingston Midstream Westspur Limited [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.175,
+      "lengthKm": 547,
+      "inService": 0,
+      "startPoint": {
+        "lat": 49.671583,
+        "lon": -103.847377
+      },
+      "endPoint": {
+        "lat": 49.731683,
+        "lon": -101.23528
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "seaway-oil-pipeline-system-us": {
+      "id": "seaway-oil-pipeline-system-us",
+      "name": "Seaway Oil Pipeline System",
+      "operator": "Seaway Crude Pipeline Company LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.35,
+      "lengthKm": 846.51,
+      "inService": 1976,
+      "startPoint": {
+        "lat": 35.986089,
+        "lon": -96.82429
+      },
+      "endPoint": {
+        "lat": 28.942909,
+        "lon": -95.438198
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "seminole-red-pipeline-us": {
+      "id": "seminole-red-pipeline-us",
+      "name": "Seminole Red Pipeline",
+      "operator": "Enterprise Products Partners [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.28,
+      "lengthKm": 708.1,
+      "inService": 1980,
+      "startPoint": {
+        "lat": 29.854457,
+        "lon": -94.906794
+      },
+      "endPoint": {
+        "lat": 30.37688,
+        "lon": -96.521214
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "shaim-tyumen-oil-pipeline-ru": {
+      "id": "shaim-tyumen-oil-pipeline-ru",
+      "name": "Shaim-Tyumen Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.14449281314168377,
+      "lengthKm": 440,
+      "inService": 1965,
+      "startPoint": {
+        "lat": 60.08086,
+        "lon": 64.69428
+      },
+      "endPoint": {
+        "lat": 57.10169,
+        "lon": 65.7394
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "shaybah-abqaiq-ngl-pipeline-sa": {
+      "id": "shaybah-abqaiq-ngl-pipeline-sa",
+      "name": "Shaybah-Abqaiq NGL Pipeline",
+      "operator": "Saudi Aramco [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "SA",
+      "toCountry": "SA",
+      "transitCountries": [],
+      "capacityMbd": 0.228,
+      "lengthKm": 633,
+      "inService": 2016,
+      "startPoint": {
+        "lat": 22.516833,
+        "lon": 54.005162
+      },
+      "endPoint": {
+        "lat": 25.934821,
+        "lon": 49.688328
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "shaybah-abqaiq-oil-pipeline-sa": {
+      "id": "shaybah-abqaiq-oil-pipeline-sa",
+      "name": "Shaybah-Abqaiq Oil Pipeline",
+      "operator": "Saudi Aramco [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "SA",
+      "toCountry": "SA",
+      "transitCountries": [],
+      "capacityMbd": 0.75,
+      "lengthKm": 645,
+      "inService": 1998,
+      "startPoint": {
+        "lat": 22.516833,
+        "lon": 54.005162
+      },
+      "endPoint": {
+        "lat": 25.934821,
+        "lon": 49.688328
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "sino-myanmar-oil-pipeline-sino-myanmar-oil-pipeline-myanmar--mm": {
+      "id": "sino-myanmar-oil-pipeline-sino-myanmar-oil-pipeline-myanmar--mm",
+      "name": "Sino-Myanmar Oil Pipeline - Sino-Myanmar Oil Pipeline(Myanmar section)",
+      "operator": "National Pipe Network Group Southwest Oil and Gas Pipeline Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "MM",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.442,
+      "lengthKm": 771,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 19.39337,
+        "lon": 93.720537
+      },
+      "endPoint": {
+        "lat": 29.599141,
+        "lon": 106.568303
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "skelly-belvieu-pipeline-us": {
+      "id": "skelly-belvieu-pipeline-us",
+      "name": "Skelly–Belvieu Pipeline",
+      "operator": "Skelly Belvieu Pipeline Company LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.044,
+      "lengthKm": 914.11,
+      "inService": 0,
+      "startPoint": {
+        "lat": 35.570407,
+        "lon": -101.124676
+      },
+      "endPoint": {
+        "lat": 29.838621,
+        "lon": -94.89191
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "sote-oil-pipeline-ec": {
+      "id": "sote-oil-pipeline-ec",
+      "name": "SOTE Oil Pipeline",
+      "operator": "EP Petroecuador [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "EC",
+      "toCountry": "EC",
+      "transitCountries": [],
+      "capacityMbd": 0.36,
+      "lengthKm": 497.7,
+      "inService": 1972,
+      "startPoint": {
+        "lat": 0.402234,
+        "lon": -79.524562
+      },
+      "endPoint": {
+        "lat": -0.113192,
+        "lon": -77.599933
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "south-texas-crude-oil-pipeline-system-enterprise-us": {
+      "id": "south-texas-crude-oil-pipeline-system-enterprise-us",
+      "name": "South Texas Crude Oil Pipeline System (Enterprise)",
+      "operator": "Enterprise Products Partners [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.35,
+      "lengthKm": 901.23,
+      "inService": 2012,
+      "startPoint": {
+        "lat": 28.92436,
+        "lon": -98.14
+      },
+      "endPoint": {
+        "lat": 29.60725,
+        "lon": -95.1848
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "southern-lights-pipeline-us": {
+      "id": "southern-lights-pipeline-us",
+      "name": "Southern Lights Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.18,
+      "lengthKm": 2556,
+      "inService": 2010,
+      "startPoint": {
+        "lat": 41.41471,
+        "lon": -88.183309
+      },
+      "endPoint": {
+        "lat": 53.55355,
+        "lon": -113.350719
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "spearhead-oil-pipeline-us": {
+      "id": "spearhead-oil-pipeline-us",
+      "name": "Spearhead Oil Pipeline",
+      "operator": "Enbridge [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.193,
+      "lengthKm": 938.25,
+      "inService": 2006,
+      "startPoint": {
+        "lat": 38.800523,
+        "lon": -90.067628
+      },
+      "endPoint": {
+        "lat": 35.925766,
+        "lon": -96.786264
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "sterling-ngl-pipelines-lines-i-ii-and-iii-us": {
+      "id": "sterling-ngl-pipelines-lines-i-ii-and-iii-us",
+      "name": "Sterling NGL Pipelines - Lines I, II, and III",
+      "operator": "unknown [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.000386,
+      "lengthKm": 2613.93,
+      "inService": 0,
+      "startPoint": {
+        "lat": 36.774621,
+        "lon": -97.755208
+      },
+      "endPoint": {
+        "lat": 29.853438,
+        "lon": -94.892658
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "sunrise-pipeline-system-us": {
+      "id": "sunrise-pipeline-system-us",
+      "name": "Sunrise Pipeline System",
+      "operator": "Plains All American Pipeline [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.35,
+      "lengthKm": 408.77,
+      "inService": 0,
+      "startPoint": {
+        "lat": 33.884605,
+        "lon": -98.44326
+      },
+      "endPoint": {
+        "lat": 32.021294,
+        "lon": -101.983769
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "surgut-gorky-polotsk-oil-pipeline-ru": {
+      "id": "surgut-gorky-polotsk-oil-pipeline-ru",
+      "name": "Surgut-Gorky-Polotsk Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "BY",
+      "transitCountries": [],
+      "capacityMbd": 1.204106776180698,
+      "lengthKm": 3250,
+      "inService": 1981,
+      "startPoint": {
+        "lat": 61.32499,
+        "lon": 73.01672
+      },
+      "endPoint": {
+        "lat": 55.49733,
+        "lon": 28.53836
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "tarim-oilfield-lanzhou-petrochemical-condensate-pipeline-cn": {
+      "id": "tarim-oilfield-lanzhou-petrochemical-condensate-pipeline-cn",
+      "name": "Tarim Oilfield-Lanzhou Petrochemical Condensate Pipeline",
+      "operator": "PetroChina Company Limited [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.012442436687200548,
+      "lengthKm": 1806.72,
+      "inService": 2019,
+      "startPoint": {
+        "lat": 41.840899,
+        "lon": 84.068443
+      },
+      "endPoint": {
+        "lat": 36.108027,
+        "lon": 103.643222
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "tazama-oil-pipeline-tz": {
+      "id": "tazama-oil-pipeline-tz",
+      "name": "Tazama Oil Pipeline",
+      "operator": "Government of Zambia [66.70%]; Government of Tanzania [33.30%]",
+      "commodityType": "oil",
+      "fromCountry": "TZ",
+      "toCountry": "ZM",
+      "transitCountries": [],
+      "capacityMbd": 0.022,
+      "lengthKm": 1710,
+      "inService": 1968,
+      "startPoint": {
+        "lat": -6.638323,
+        "lon": 38.750936
+      },
+      "endPoint": {
+        "lat": -13.533688,
+        "lon": 28.406867
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "tehran-tabriz-crude-oil-pipeline-2nd-section-ir": {
+      "id": "tehran-tabriz-crude-oil-pipeline-2nd-section-ir",
+      "name": "Tehran-Tabriz Crude Oil Pipeline - 2nd Section",
+      "operator": "National Iranian Oil Refining and Distribution Company [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IR",
+      "toCountry": "IR",
+      "transitCountries": [],
+      "capacityMbd": 0.11,
+      "lengthKm": 539,
+      "inService": 0,
+      "startPoint": {
+        "lat": 38.056774,
+        "lon": 46.159577
+      },
+      "endPoint": {
+        "lat": 35.539311,
+        "lon": 51.42526
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "teppco-pipeline-us": {
+      "id": "teppco-pipeline-us",
+      "name": "TEPPCO Pipeline",
+      "operator": "unknown [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.23,
+      "lengthKm": 5508.78,
+      "inService": 1958,
+      "startPoint": {
+        "lat": 30.242804,
+        "lon": -93.885077
+      },
+      "endPoint": {
+        "lat": 29.791771,
+        "lon": -94.920249
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "texas-express-y-grade-pipeline-us": {
+      "id": "texas-express-y-grade-pipeline-us",
+      "name": "Texas Express Y-Grade Pipeline",
+      "operator": "Texas Express Pipeline LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.28,
+      "lengthKm": 933.42,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 35.571257,
+        "lon": -101.123239
+      },
+      "endPoint": {
+        "lat": 29.861631,
+        "lon": -94.902583
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "tieling-dalian-oil-pipeline-original-line-cn": {
+      "id": "tieling-dalian-oil-pipeline-original-line-cn",
+      "name": "Tieling–Dalian Oil Pipeline - Original Line",
+      "operator": "National Pipe Network Group North Pipeline Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.4415058179329227,
+      "lengthKm": 568.39,
+      "inService": 2014,
+      "startPoint": {
+        "lat": 42.30425,
+        "lon": 123.812383
+      },
+      "endPoint": {
+        "lat": 39.075042,
+        "lon": 121.797759
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "trans-alaska-oil-pipeline-system-us": {
+      "id": "trans-alaska-oil-pipeline-system-us",
+      "name": "Trans-Alaska Oil Pipeline System",
+      "operator": "Harvest Alaska LLC [49.11%]; ConocoPhillips Transportation Alaska Inc [29.61%]; ExxonMobil Pipeline Company LLC [21.28%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 2.136,
+      "lengthKm": 1288,
+      "inService": 1977,
+      "startPoint": {
+        "lat": 68.172417,
+        "lon": -149.426171
+      },
+      "endPoint": {
+        "lat": 68.172417,
+        "lon": -149.426171
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "trans-andean-oil-pipeline-ar": {
+      "id": "trans-andean-oil-pipeline-ar",
+      "name": "Trans-Andean Oil Pipeline",
+      "operator": "Enap [36.25%]; YPF [36.00%]; Unocal Argentina [27.75%]",
+      "commodityType": "oil",
+      "fromCountry": "AR",
+      "toCountry": "CL",
+      "transitCountries": [],
+      "capacityMbd": 0.115,
+      "lengthKm": 425,
+      "inService": 1994,
+      "startPoint": {
+        "lat": -37.296398,
+        "lon": -69.066463
+      },
+      "endPoint": {
+        "lat": -36.780621,
+        "lon": -73.126
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "trans-mountain-oil-pipeline-ca": {
+      "id": "trans-mountain-oil-pipeline-ca",
+      "name": "Trans Mountain Oil Pipeline",
+      "operator": "Trans Mountain Corporation [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.3,
+      "lengthKm": 1150,
+      "inService": 1953,
+      "startPoint": {
+        "lat": 49.270491,
+        "lon": -122.978471
+      },
+      "endPoint": {
+        "lat": 53.502473,
+        "lon": -113.547766
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "transalpine-oil-pipeline-it": {
+      "id": "transalpine-oil-pipeline-it",
+      "name": "Transalpine Oil Pipeline",
+      "operator": "Transalpine Pipeline Group [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IT",
+      "toCountry": "DE",
+      "transitCountries": [
+        "AT"
+      ],
+      "capacityMbd": 0.85,
+      "lengthKm": 752,
+      "inService": 1967,
+      "startPoint": {
+        "lat": 45.601487,
+        "lon": 13.8543
+      },
+      "endPoint": {
+        "lat": 49.05316,
+        "lon": 8.336582
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "tuymazy-omsk-novosibirsk-2-oil-pipeline-ru": {
+      "id": "tuymazy-omsk-novosibirsk-2-oil-pipeline-ru",
+      "name": "Tuymazy-Omsk-Novosibirsk 2 Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "KZ",
+      "transitCountries": [],
+      "capacityMbd": 0.22075290896646135,
+      "lengthKm": 3600,
+      "inService": 1959,
+      "startPoint": {
+        "lat": 55.08879,
+        "lon": 73.23503
+      },
+      "endPoint": {
+        "lat": 54.5474,
+        "lon": 53.83957
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "ukhta-yaroslavl-oil-pipeline-ru": {
+      "id": "ukhta-yaroslavl-oil-pipeline-ru",
+      "name": "Ukhta-Yaroslavl Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.4696016427104723,
+      "lengthKm": 1135,
+      "inService": 1975,
+      "startPoint": {
+        "lat": 63.64953,
+        "lon": 53.82842
+      },
+      "endPoint": {
+        "lat": 57.54111,
+        "lon": 39.83981
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "urengoy-surgut-condensate-pipeline-i-ru": {
+      "id": "urengoy-surgut-condensate-pipeline-i-ru",
+      "name": "Urengoy-Surgut Condensate Pipeline - I",
+      "operator": "Gazprom [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.12041067761806983,
+      "lengthKm": 703,
+      "inService": 1985,
+      "startPoint": {
+        "lat": 66.108186,
+        "lon": 76.850945
+      },
+      "endPoint": {
+        "lat": 61.253035,
+        "lon": 73.430807
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "usa-ukhta-oil-pipeline-ru": {
+      "id": "usa-ukhta-oil-pipeline-ru",
+      "name": "Usa-Ukhta Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.48766324435318276,
+      "lengthKm": 409,
+      "inService": 1975,
+      "startPoint": {
+        "lat": 66.14443,
+        "lon": 57.34134
+      },
+      "endPoint": {
+        "lat": 63.64104,
+        "lon": 53.82779
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "ust-balyk-kurgan-ufa-almetyevsk-oil-pipeline-ru": {
+      "id": "ust-balyk-kurgan-ufa-almetyevsk-oil-pipeline-ru",
+      "name": "Ust-Balyk-Kurgan-Ufa-Almetyevsk Oil Pipeline",
+      "operator": "Transneft-Prikamye JSC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 1.8061601642710474,
+      "lengthKm": 2119,
+      "inService": 1973,
+      "startPoint": {
+        "lat": 60.964527,
+        "lon": 72.426639
+      },
+      "endPoint": {
+        "lat": 54.924577,
+        "lon": 52.214241
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "ust-balyk-omsk-oil-pipeline-ru": {
+      "id": "ust-balyk-omsk-oil-pipeline-ru",
+      "name": "Ust-Balyk-Omsk Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.032109514031485285,
+      "lengthKm": 970,
+      "inService": 1967,
+      "startPoint": {
+        "lat": 60.49233,
+        "lon": 72.19837
+      },
+      "endPoint": {
+        "lat": 55.08991,
+        "lon": 73.23845
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "utopia-ethane-pipeline-us": {
+      "id": "utopia-ethane-pipeline-us",
+      "name": "Utopia Ethane Pipeline",
+      "operator": "Kinder Morgan [50.00%]; Energy Income Partners [12.50%]; KDB Infrastructure Investments Asset Management [12.50%]; ST International [12.50%]; Shinhan Financial Group [12.50%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.05,
+      "lengthKm": 431,
+      "inService": 2018,
+      "startPoint": {
+        "lat": 40.251312,
+        "lon": -81.017176
+      },
+      "endPoint": {
+        "lat": 42.087704,
+        "lon": -83.296971
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "uzen-atyrau-samara-uas-pipeline-kz": {
+      "id": "uzen-atyrau-samara-uas-pipeline-kz",
+      "name": "Uzen-Atyrau-Samara (UAS) Pipeline",
+      "operator": "KazTransOil JSC [24.00%]; Transneft [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "KZ",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.602053388090349,
+      "lengthKm": 1380,
+      "inService": 1968,
+      "startPoint": {
+        "lat": 52.992264,
+        "lon": 50.534277
+      },
+      "endPoint": {
+        "lat": 43.363056,
+        "lon": 52.825278
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "vadinar-bina-crude-oil-pipeline-in": {
+      "id": "vadinar-bina-crude-oil-pipeline-in",
+      "name": "Vadinar-Bina Crude Oil Pipeline",
+      "operator": "BPCL Group [74.00%]; Oman Oil Company SAOC [26.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.15653388090349077,
+      "lengthKm": 937,
+      "inService": 2010,
+      "startPoint": {
+        "lat": 22.398292,
+        "lon": 69.7194
+      },
+      "endPoint": {
+        "lat": 24.177644,
+        "lon": 78.196092
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "vankor-purpe-pipeline-ru": {
+      "id": "vankor-purpe-pipeline-ru",
+      "name": "Vankor-Purpe Pipeline",
+      "operator": "Rosneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.5017111567419575,
+      "lengthKm": 556,
+      "inService": 2009,
+      "startPoint": {
+        "lat": 67.85105,
+        "lon": 83.57615
+      },
+      "endPoint": {
+        "lat": 64.55181,
+        "lon": 76.60439
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "vizag-secunderabad-lpg-pipeline-in": {
+      "id": "vizag-secunderabad-lpg-pipeline-in",
+      "name": "Vizag-Secunderabad LPG Pipeline",
+      "operator": "GAIL (India) Limited [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "IN",
+      "toCountry": "IN",
+      "transitCountries": [],
+      "capacityMbd": 0.02669103353867214,
+      "lengthKm": 610,
+      "inService": 2003,
+      "startPoint": {
+        "lat": 17.715502,
+        "lon": 83.236949
+      },
+      "endPoint": {
+        "lat": 17.401268,
+        "lon": 78.479869
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "vostok-oil-pipeline-vankor-payakha-sever-bay-i-oil-pipeline-ru": {
+      "id": "vostok-oil-pipeline-vankor-payakha-sever-bay-i-oil-pipeline-ru",
+      "name": "Vostok Oil Pipeline - Vankor-Payakha-Sever Bay I Oil Pipeline",
+      "operator": "Vostok Oil LLC [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.25085557837097877,
+      "lengthKm": 770,
+      "inService": 2026,
+      "startPoint": {
+        "lat": 68.315013,
+        "lon": 83.664308
+      },
+      "endPoint": {
+        "lat": 73.509934,
+        "lon": 80.601676
+      },
+      "evidence": {
+        "physicalState": "unknown",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "wafa-mellitah-ngl-pipeline-ly": {
+      "id": "wafa-mellitah-ngl-pipeline-ly",
+      "name": "Wafa-Mellitah NGL Pipeline",
+      "operator": "Libyan National Oil Corporation [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "LY",
+      "toCountry": "LY",
+      "transitCountries": [],
+      "capacityMbd": 0.022503,
+      "lengthKm": 487.98,
+      "inService": 2004,
+      "startPoint": {
+        "lat": 28.887696,
+        "lon": 10.030287
+      },
+      "endPoint": {
+        "lat": 32.854692,
+        "lon": 12.241871
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "wafa-mellitah-oil-pipeline-ly": {
+      "id": "wafa-mellitah-oil-pipeline-ly",
+      "name": "Wafa-Mellitah Oil Pipeline",
+      "operator": "Eni S.p.A. [50.00%]; Libyan National Oil Corporation [50.00%]",
+      "commodityType": "oil",
+      "fromCountry": "LY",
+      "toCountry": "LY",
+      "transitCountries": [],
+      "capacityMbd": 0.12,
+      "lengthKm": 525,
+      "inService": 2004,
+      "startPoint": {
+        "lat": 28.8885,
+        "lon": 10.0235
+      },
+      "endPoint": {
+        "lat": 32.8538,
+        "lon": 12.2375
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "western-corridor-oil-pipeline-system-glacier-pipeline-bearto-us": {
+      "id": "western-corridor-oil-pipeline-system-glacier-pipeline-bearto-us",
+      "name": "Western Corridor Oil Pipeline System - Glacier Pipeline, Beartooth Pipeline, Big Horn Pipeline",
+      "operator": "Plains GP Holdings LP [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.025,
+      "lengthKm": 1628.66,
+      "inService": 1944,
+      "startPoint": {
+        "lat": 48.987044,
+        "lon": -113.306837
+      },
+      "endPoint": {
+        "lat": 42.224765,
+        "lon": -104.732592
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "western-crude-oil-pipeline-shanshan-lanzhou-oil-pipeline-cn": {
+      "id": "western-crude-oil-pipeline-shanshan-lanzhou-oil-pipeline-cn",
+      "name": "Western Crude Oil Pipeline - Shanshan–Lanzhou Oil Pipeline",
+      "operator": "China Petroleum West Pipeline Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.401368925393566,
+      "lengthKm": 1652,
+      "inService": 2007,
+      "startPoint": {
+        "lat": 44.637391,
+        "lon": 83.342285
+      },
+      "endPoint": {
+        "lat": 36.099901,
+        "lon": 103.64879
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "westpur-oil-pipeline-ca": {
+      "id": "westpur-oil-pipeline-ca",
+      "name": "Westpur Oil Pipeline",
+      "operator": "Kingston Midstream Westspur Limited [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CA",
+      "toCountry": "CA",
+      "transitCountries": [],
+      "capacityMbd": 0.247444,
+      "lengthKm": 511,
+      "inService": 1957,
+      "startPoint": {
+        "lat": 49.473909,
+        "lon": -103.274503
+      },
+      "endPoint": {
+        "lat": 49.30194,
+        "lon": -101.752279
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "white-cliffs-oil-pipeline-us": {
+      "id": "white-cliffs-oil-pipeline-us",
+      "name": "White Cliffs Oil Pipeline",
+      "operator": "Energy Transfer [51.00%]; Plains All American Pipeline [36.00%]; Occidental Petroleum [5.64%]; other [4.36%]; Chevron [3.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.029,
+      "lengthKm": 848,
+      "inService": 2009,
+      "startPoint": {
+        "lat": 40.241446,
+        "lon": -104.939453
+      },
+      "endPoint": {
+        "lat": 36.146535,
+        "lon": -96.066582
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "wink-to-webster-pipeline-us": {
+      "id": "wink-to-webster-pipeline-us",
+      "name": "Wink to Webster Pipeline",
+      "operator": "Delek US [unknown %]; ExxonMobil [unknown %]; Lotus Midstream LLC [unknown %]; MPLX [unknown %]; Plains All American Pipeline [unknown %]; Rattler Midstream LP [unknown %]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 1.5,
+      "lengthKm": 1046.07,
+      "inService": 2020,
+      "startPoint": {
+        "lat": 31.795983,
+        "lon": -103.140623
+      },
+      "endPoint": {
+        "lat": 29.354931,
+        "lon": -94.943123
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "yizheng-changling-oil-pipeline-cn": {
+      "id": "yizheng-changling-oil-pipeline-cn",
+      "name": "Yizheng-Changling Oil Pipeline",
+      "operator": "China Sinopec Pipeline Storage and Transportation Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.5418480492813141,
+      "lengthKm": 979,
+      "inService": 2006,
+      "startPoint": {
+        "lat": 32.29367,
+        "lon": 119.091004
+      },
+      "endPoint": {
+        "lat": 29.550168,
+        "lon": 113.35273
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "yizheng-changling-parallel-oil-pipeline-cn": {
+      "id": "yizheng-changling-parallel-oil-pipeline-cn",
+      "name": "Yizheng–Changling Parallel Oil Pipeline",
+      "operator": "China Sinopec Pipeline Storage and Transportation Co., Ltd. [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "CN",
+      "toCountry": "CN",
+      "transitCountries": [],
+      "capacityMbd": 0.401368925393566,
+      "lengthKm": 560,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 32.387489,
+        "lon": 119.197534
+      },
+      "endPoint": {
+        "lat": 29.698015,
+        "lon": 116.00086
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "zapolyarye-purpe-oil-pipeline-ru": {
+      "id": "zapolyarye-purpe-oil-pipeline-ru",
+      "name": "Zapolyarye-Purpe Oil Pipeline",
+      "operator": "Transneft [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "RU",
+      "toCountry": "RU",
+      "transitCountries": [],
+      "capacityMbd": 0.9030800821355237,
+      "lengthKm": 488,
+      "inService": 2017,
+      "startPoint": {
+        "lat": 67.84358,
+        "lon": 80.06218
+      },
+      "endPoint": {
+        "lat": 64.52091,
+        "lon": 76.621785
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
+    },
+    "zydeco-oil-pipeline-us": {
+      "id": "zydeco-oil-pipeline-us",
+      "name": "Zydeco Oil Pipeline",
+      "operator": "Shell Midstream Partners LP [100.00%]",
+      "commodityType": "oil",
+      "fromCountry": "US",
+      "toCountry": "US",
+      "transitCountries": [],
+      "capacityMbd": 0.36,
+      "lengthKm": 563.27,
+      "inService": 2013,
+      "startPoint": {
+        "lat": 29.994538,
+        "lon": -93.980807
+      },
+      "endPoint": {
+        "lat": 29.990396,
+        "lon": -93.987619
+      },
+      "evidence": {
+        "physicalState": "flowing",
+        "physicalStateSource": "gem",
+        "operatorStatement": null,
+        "commercialState": "unknown",
+        "sanctionRefs": [],
+        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
+        "classifierVersion": "gem-import-v1",
+        "classifierConfidence": 0.4
+      },
+      "productClass": "crude"
     }
   }
 }

--- a/scripts/data/pipelines-oil.json
+++ b/scripts/data/pipelines-oil.json
@@ -4896,37 +4896,6 @@
       },
       "productClass": "crude"
     },
-    "enbridge-line-3-oil-pipeline-line-3-replacement-project-ca": {
-      "id": "enbridge-line-3-oil-pipeline-line-3-replacement-project-ca",
-      "name": "Enbridge Line 3 Oil Pipeline - Line 3 Replacement Project",
-      "operator": "Enbridge [100.00%]",
-      "commodityType": "oil",
-      "fromCountry": "CA",
-      "toCountry": "US",
-      "transitCountries": [],
-      "capacityMbd": 0.844,
-      "lengthKm": 1889.37,
-      "inService": 2019,
-      "startPoint": {
-        "lat": 47.68948,
-        "lon": -95.4207
-      },
-      "endPoint": {
-        "lat": 47.68948,
-        "lon": -95.4207
-      },
-      "evidence": {
-        "physicalState": "flowing",
-        "physicalStateSource": "gem",
-        "operatorStatement": null,
-        "commercialState": "unknown",
-        "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
-        "classifierVersion": "gem-import-v1",
-        "classifierConfidence": 0.4
-      },
-      "productClass": "crude"
-    },
     "enbridge-line-4-oil-pipeline-ca": {
       "id": "enbridge-line-4-oil-pipeline-ca",
       "name": "Enbridge Line 4 Oil Pipeline",
@@ -4945,37 +4914,6 @@
       "endPoint": {
         "lat": 46.690572,
         "lon": -92.067312
-      },
-      "evidence": {
-        "physicalState": "flowing",
-        "physicalStateSource": "gem",
-        "operatorStatement": null,
-        "commercialState": "unknown",
-        "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
-        "classifierVersion": "gem-import-v1",
-        "classifierConfidence": 0.4
-      },
-      "productClass": "crude"
-    },
-    "enbridge-line-5-pipeline-us": {
-      "id": "enbridge-line-5-pipeline-us",
-      "name": "Enbridge Line 5 Pipeline",
-      "operator": "Enbridge [100.00%]",
-      "commodityType": "oil",
-      "fromCountry": "US",
-      "toCountry": "CA",
-      "transitCountries": [],
-      "capacityMbd": 0.54,
-      "lengthKm": 1038.03,
-      "inService": 1953,
-      "startPoint": {
-        "lat": 46.690572,
-        "lon": -92.067312
-      },
-      "endPoint": {
-        "lat": 42.95186,
-        "lon": -82.416
       },
       "evidence": {
         "physicalState": "flowing",
@@ -6014,37 +5952,6 @@
       },
       "productClass": "crude"
     },
-    "jayhawk-oil-pipeline-us": {
-      "id": "jayhawk-oil-pipeline-us",
-      "name": "Jayhawk Oil Pipeline",
-      "operator": "CHS Inc [unknown %]; Southwest Pipeline Holding Company LLC [unknown %]",
-      "commodityType": "oil",
-      "fromCountry": "US",
-      "toCountry": "US",
-      "transitCountries": [],
-      "capacityMbd": 0.14,
-      "lengthKm": 1609.34,
-      "inService": 1957,
-      "startPoint": {
-        "lat": 38.33994,
-        "lon": -98.3101
-      },
-      "endPoint": {
-        "lat": 38.33994,
-        "lon": -98.3101
-      },
-      "evidence": {
-        "physicalState": "flowing",
-        "physicalStateSource": "gem",
-        "operatorStatement": null,
-        "commercialState": "unknown",
-        "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
-        "classifierVersion": "gem-import-v1",
-        "classifierConfidence": 0.4
-      },
-      "productClass": "crude"
-    },
     "jing-an-xianyang-oil-pipeline-cn": {
       "id": "jing-an-xianyang-oil-pipeline-cn",
       "name": "Jing'an-Xianyang Oil Pipeline",
@@ -6758,37 +6665,6 @@
       },
       "productClass": "crude"
     },
-    "loma-la-lata-bah-a-blanca-pipeline-ar": {
-      "id": "loma-la-lata-bah-a-blanca-pipeline-ar",
-      "name": "Loma La Lata - Bahía Blanca Pipeline",
-      "operator": "MEGA S.A. [100.00%]",
-      "commodityType": "oil",
-      "fromCountry": "AR",
-      "toCountry": "AR",
-      "transitCountries": [],
-      "capacityMbd": 0.033424800000000005,
-      "lengthKm": 600,
-      "inService": 2001,
-      "startPoint": {
-        "lat": -38.692348,
-        "lon": -62.427343
-      },
-      "endPoint": {
-        "lat": -38.692348,
-        "lon": -62.427343
-      },
-      "evidence": {
-        "physicalState": "flowing",
-        "physicalStateSource": "gem",
-        "operatorStatement": null,
-        "commercialState": "unknown",
-        "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
-        "classifierVersion": "gem-import-v1",
-        "classifierConfidence": 0.4
-      },
-      "productClass": "crude"
-    },
     "lone-star-express-y-grade-pipeline-expansion-us": {
       "id": "lone-star-express-y-grade-pipeline-expansion-us",
       "name": "Lone Star Express Y-Grade Pipeline - Expansion",
@@ -7303,37 +7179,6 @@
       "endPoint": {
         "lat": 44.694109,
         "lon": -92.984845
-      },
-      "evidence": {
-        "physicalState": "flowing",
-        "physicalStateSource": "gem",
-        "operatorStatement": null,
-        "commercialState": "unknown",
-        "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
-        "classifierVersion": "gem-import-v1",
-        "classifierConfidence": 0.4
-      },
-      "productClass": "crude"
-    },
-    "moomba-to-port-bonython-oil-pipeline-au": {
-      "id": "moomba-to-port-bonython-oil-pipeline-au",
-      "name": "Moomba to Port Bonython Oil Pipeline",
-      "operator": "Santos Limited [66.60%]; Beach Energy Limited [20.20%]; Origin Energy Limited [13.20%]",
-      "commodityType": "oil",
-      "fromCountry": "AU",
-      "toCountry": "AU",
-      "transitCountries": [],
-      "capacityMbd": 0.04,
-      "lengthKm": 659,
-      "inService": 1984,
-      "startPoint": {
-        "lat": -32.9602,
-        "lon": 137.7126
-      },
-      "endPoint": {
-        "lat": -32.9602,
-        "lon": 137.7126
       },
       "evidence": {
         "physicalState": "flowing",
@@ -8031,37 +7876,6 @@
       },
       "productClass": "crude"
     },
-    "osbra-pipeline-br": {
-      "id": "osbra-pipeline-br",
-      "name": "OSBRA Pipeline",
-      "operator": "Petrobras [unknown %]",
-      "commodityType": "oil",
-      "fromCountry": "BR",
-      "toCountry": "BR",
-      "transitCountries": [],
-      "capacityMbd": 0.10339397,
-      "lengthKm": 964,
-      "inService": 1996,
-      "startPoint": {
-        "lat": -16.692967,
-        "lon": -49.106089
-      },
-      "endPoint": {
-        "lat": -16.692967,
-        "lon": -49.106089
-      },
-      "evidence": {
-        "physicalState": "flowing",
-        "physicalStateSource": "gem",
-        "operatorStatement": null,
-        "commercialState": "unknown",
-        "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
-        "classifierVersion": "gem-import-v1",
-        "classifierConfidence": 0.4
-      },
-      "productClass": "crude"
-    },
     "overland-pass-ngl-pipeline-us": {
       "id": "overland-pass-ngl-pipeline-us",
       "name": "Overland Pass NGL Pipeline",
@@ -8372,37 +8186,6 @@
       },
       "productClass": "crude"
     },
-    "permian-longview-and-louisiana-extension-pela-oil-pipeline-us": {
-      "id": "permian-longview-and-louisiana-extension-pela-oil-pipeline-us",
-      "name": "Permian Longview and Louisiana Extension (PELA) Oil Pipeline",
-      "operator": "Energy Transfer [unknown %]; ExxonMobil [unknown %]; SunVit Pipeline LLC [unknown %]",
-      "commodityType": "oil",
-      "fromCountry": "US",
-      "toCountry": "US",
-      "transitCountries": [],
-      "capacityMbd": 0.1,
-      "lengthKm": 1207.01,
-      "inService": 2016,
-      "startPoint": {
-        "lat": 32.521123,
-        "lon": -100.838587
-      },
-      "endPoint": {
-        "lat": 32.521123,
-        "lon": -100.838587
-      },
-      "evidence": {
-        "physicalState": "flowing",
-        "physicalStateSource": "gem",
-        "operatorStatement": null,
-        "commercialState": "unknown",
-        "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
-        "classifierVersion": "gem-import-v1",
-        "classifierConfidence": 0.4
-      },
-      "productClass": "crude"
-    },
     "plains-west-coast-pipeline-us": {
       "id": "plains-west-coast-pipeline-us",
       "name": "Plains West Coast Pipeline",
@@ -8638,37 +8421,6 @@
       "endPoint": {
         "lat": 60.687678,
         "lon": 72.864469
-      },
-      "evidence": {
-        "physicalState": "flowing",
-        "physicalStateSource": "gem",
-        "operatorStatement": null,
-        "commercialState": "unknown",
-        "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
-        "classifierVersion": "gem-import-v1",
-        "classifierConfidence": 0.4
-      },
-      "productClass": "crude"
-    },
-    "purovsk-yuzhny-balyk-tobolsk-product-pipeline-yuzhny-balyk-t-ru": {
-      "id": "purovsk-yuzhny-balyk-tobolsk-product-pipeline-yuzhny-balyk-t-ru",
-      "name": "Purovsk-Yuzhny Balyk-Tobolsk Product Pipeline - Yuzhny Balyk-Tobolsk Product Pipeline",
-      "operator": "Sibur Holding PJSC [100.00%]",
-      "commodityType": "oil",
-      "fromCountry": "RU",
-      "toCountry": "RU",
-      "transitCountries": [],
-      "capacityMbd": 0.1605475701574264,
-      "lengthKm": 410,
-      "inService": 2014,
-      "startPoint": {
-        "lat": 60.687678,
-        "lon": 72.864469
-      },
-      "endPoint": {
-        "lat": 58.262636,
-        "lon": 68.437988
       },
       "evidence": {
         "physicalState": "flowing",
@@ -9692,37 +9444,6 @@
       "endPoint": {
         "lat": 39.075042,
         "lon": 121.797759
-      },
-      "evidence": {
-        "physicalState": "flowing",
-        "physicalStateSource": "gem",
-        "operatorStatement": null,
-        "commercialState": "unknown",
-        "sanctionRefs": [],
-        "lastEvidenceUpdate": "2026-04-25T00:00:00Z",
-        "classifierVersion": "gem-import-v1",
-        "classifierConfidence": 0.4
-      },
-      "productClass": "crude"
-    },
-    "trans-alaska-oil-pipeline-system-us": {
-      "id": "trans-alaska-oil-pipeline-system-us",
-      "name": "Trans-Alaska Oil Pipeline System",
-      "operator": "Harvest Alaska LLC [49.11%]; ConocoPhillips Transportation Alaska Inc [29.61%]; ExxonMobil Pipeline Company LLC [21.28%]",
-      "commodityType": "oil",
-      "fromCountry": "US",
-      "toCountry": "US",
-      "transitCountries": [],
-      "capacityMbd": 2.136,
-      "lengthKm": 1288,
-      "inService": 1977,
-      "startPoint": {
-        "lat": 68.172417,
-        "lon": -149.426171
-      },
-      "endPoint": {
-        "lat": 68.172417,
-        "lon": -149.426171
       },
       "evidence": {
         "physicalState": "flowing",

--- a/tests/import-gem-pipelines.test.mjs
+++ b/tests/import-gem-pipelines.test.mjs
@@ -182,13 +182,17 @@ describe('import-gem-pipelines — minimum-viable evidence', () => {
 });
 
 describe('import-gem-pipelines — registry-shape conformance', () => {
+  // Compute the repeat count from the floor + the fixture row count so this
+  // test stays correct if the fixture is trimmed or the floor is raised. The
+  // hardcoded `for (let i = 0; i < 70; i++)` was fragile — Greptile P2 on PR
+  // #3406. +5 over the floor leaves a safety margin without inflating the test.
+  const REGISTRY_FLOOR = 200;
+
   test('emitted gas registry passes validateRegistry', () => {
-    // Build a synthetic registry of just the GEM-emitted gas rows; meets the
-    // validator's MIN_PIPELINES_PER_REGISTRY=200 floor by repeating the 3
-    // fixture rows so we exercise the schema, not the count.
     const { gas } = parseGemPipelines(fixture);
+    const reps = Math.ceil(REGISTRY_FLOOR / gas.length) + 5;
     const repeated = [];
-    for (let i = 0; i < 70; i++) {
+    for (let i = 0; i < reps; i++) {
       for (const p of gas) repeated.push({ ...p, id: `${p.id}-rep${i}` });
     }
     const reg = {
@@ -199,8 +203,9 @@ describe('import-gem-pipelines — registry-shape conformance', () => {
 
   test('emitted oil registry passes validateRegistry', () => {
     const { oil } = parseGemPipelines(fixture);
+    const reps = Math.ceil(REGISTRY_FLOOR / oil.length) + 5;
     const repeated = [];
-    for (let i = 0; i < 70; i++) {
+    for (let i = 0; i < reps; i++) {
       for (const p of oil) repeated.push({ ...p, id: `${p.id}-rep${i}` });
     }
     const reg = {

--- a/tests/import-gem-pipelines.test.mjs
+++ b/tests/import-gem-pipelines.test.mjs
@@ -184,11 +184,11 @@ describe('import-gem-pipelines — minimum-viable evidence', () => {
 describe('import-gem-pipelines — registry-shape conformance', () => {
   test('emitted gas registry passes validateRegistry', () => {
     // Build a synthetic registry of just the GEM-emitted gas rows; meets the
-    // validator's MIN_PIPELINES_PER_REGISTRY=8 floor by repeating the 3 fixture
-    // rows so we exercise the schema, not the count.
+    // validator's MIN_PIPELINES_PER_REGISTRY=200 floor by repeating the 3
+    // fixture rows so we exercise the schema, not the count.
     const { gas } = parseGemPipelines(fixture);
     const repeated = [];
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < 70; i++) {
       for (const p of gas) repeated.push({ ...p, id: `${p.id}-rep${i}` });
     }
     const reg = {
@@ -200,7 +200,7 @@ describe('import-gem-pipelines — registry-shape conformance', () => {
   test('emitted oil registry passes validateRegistry', () => {
     const { oil } = parseGemPipelines(fixture);
     const repeated = [];
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < 70; i++) {
       for (const p of oil) repeated.push({ ...p, id: `${p.id}-rep${i}` });
     }
     const reg = {

--- a/tests/pipeline-dedup.test.mjs
+++ b/tests/pipeline-dedup.test.mjs
@@ -86,6 +86,22 @@ describe('pipeline-dedup — match logic', () => {
     assert.equal(skippedDuplicates[0].matchedExistingId, 'druzhba-north');
   });
 
+  test('identical names + one shared terminus (≤25 km) → deduped (PR #3406 Dampier-Bunbury regression)', () => {
+    // Real-world case from PR #3406 review: GEM digitized only the southern
+    // 60% of the line, so the shared Bunbury terminus matched at 13.7 km
+    // but the average-endpoint distance was 287 km (over the 5 km gate).
+    // Identical token sets + ≥1 close pairing = same physical pipeline.
+    const existing = [makePipeline('dampier-bunbury', 'Dampier to Bunbury Natural Gas Pipeline',
+      -20.68, 116.72, -33.33, 115.63)];
+    const candidates = [makePipeline('dampier-to-bunbury-natural-gas-pipeline-au',
+      'Dampier to Bunbury Natural Gas Pipeline',
+      -33.265797, 115.755682, -24.86854, 113.674968)];
+    const { toAdd, skippedDuplicates } = dedupePipelines(existing, candidates);
+    assert.equal(toAdd.length, 0);
+    assert.equal(skippedDuplicates.length, 1);
+    assert.equal(skippedDuplicates[0].matchedExistingId, 'dampier-bunbury');
+  });
+
   test('name-match only (endpoints in different ocean) → added', () => {
     const existing = [makePipeline('nord-stream-1', 'Nord Stream 1',
       60.08, 29.05, 54.14, 13.66)];

--- a/tests/pipelines-registry.test.mts
+++ b/tests/pipelines-registry.test.mts
@@ -88,7 +88,7 @@ describe('pipeline registries — evidence', () => {
       const hasEvidence =
         p.evidence.operatorStatement != null ||
         p.evidence.sanctionRefs.length > 0 ||
-        ['ais-relay', 'satellite', 'press'].includes(p.evidence.physicalStateSource);
+        ['ais-relay', 'satellite', 'press', 'gem'].includes(p.evidence.physicalStateSource);
       assert.ok(hasEvidence, `${p.id} has no supporting evidence for state=${p.evidence.physicalState}`);
     }
   });
@@ -157,7 +157,7 @@ describe('pipeline registries — productClass', () => {
     const { productClass: _drop, ...stripped } = oilSample;
     const bad = {
       pipelines: Object.fromEntries(
-        Array.from({ length: 8 }, (_, i) => [`p${i}`, { ...stripped, id: `p${i}` }]),
+        Array.from({ length: 210 }, (_, i) => [`p${i}`, { ...stripped, id: `p${i}` }]),
       ),
     };
     assert.equal(validateRegistry(bad), false);
@@ -167,7 +167,7 @@ describe('pipeline registries — productClass', () => {
     const oilSample = oil.pipelines[Object.keys(oil.pipelines)[0]!];
     const bad = {
       pipelines: Object.fromEntries(
-        Array.from({ length: 8 }, (_, i) => [
+        Array.from({ length: 210 }, (_, i) => [
           `p${i}`,
           { ...oilSample, id: `p${i}`, productClass: 'diesel-only' },
         ]),
@@ -180,7 +180,7 @@ describe('pipeline registries — productClass', () => {
     const gasSample = gas.pipelines[Object.keys(gas.pipelines)[0]!];
     const bad = {
       pipelines: Object.fromEntries(
-        Array.from({ length: 8 }, (_, i) => [
+        Array.from({ length: 210 }, (_, i) => [
           `p${i}`,
           { ...gasSample, id: `p${i}`, productClass: 'crude' },
         ]),
@@ -202,7 +202,7 @@ describe('pipeline registries — validateRegistry rejects bad input', () => {
   test('rejects a pipeline with no evidence', () => {
     const bad = {
       pipelines: Object.fromEntries(
-        Array.from({ length: 8 }, (_, i) => [`p${i}`, {
+        Array.from({ length: 210 }, (_, i) => [`p${i}`, {
           id: `p${i}`, name: 'x', operator: 'y', commodityType: 'gas',
           fromCountry: 'US', toCountry: 'CA', transitCountries: [],
           capacityBcmYr: 1, startPoint: { lat: 0, lon: 0 }, endPoint: { lat: 1, lon: 1 },
@@ -236,7 +236,7 @@ describe('pipeline registries — GEM source enum', () => {
     const gasSample = gas.pipelines[Object.keys(gas.pipelines)[0]!];
     const good = {
       pipelines: Object.fromEntries(
-        Array.from({ length: 8 }, (_, i) => [`p${i}`, {
+        Array.from({ length: 210 }, (_, i) => [`p${i}`, {
           ...gasSample,
           id: `p${i}`,
           evidence: {
@@ -264,7 +264,7 @@ describe('pipeline registries — GEM source enum', () => {
     const gasSample = gas.pipelines[Object.keys(gas.pipelines)[0]!];
     const good = {
       pipelines: Object.fromEntries(
-        Array.from({ length: 8 }, (_, i) => [`p${i}`, {
+        Array.from({ length: 210 }, (_, i) => [`p${i}`, {
           ...gasSample,
           id: `p${i}`,
           evidence: {
@@ -288,7 +288,7 @@ describe('pipeline registries — GEM source enum', () => {
     const gasSample = gas.pipelines[Object.keys(gas.pipelines)[0]!];
     const bad = {
       pipelines: Object.fromEntries(
-        Array.from({ length: 8 }, (_, i) => [`p${i}`, {
+        Array.from({ length: 210 }, (_, i) => [`p${i}`, {
           ...gasSample,
           id: `p${i}`,
           evidence: {


### PR DESCRIPTION
## Summary

Closes the ~3.6× pipeline-scale gap by running the GEM import infrastructure that landed in #3397. The data PR that #3397's commit message said was "intentionally OUT OF SCOPE for this agent-authored PR" because GEM downloads are registration-gated.

| | Pre | Post | + Added | Dedupe |
|---|---|---|---|---|
| Gas | 75 | **297** | 222 GEM | 15 skipped |
| Oil | 75 | **334** | 259 GEM | 16 skipped |

vs peer reference (281 gas + 265 oil): gas at parity, oil ahead.

## Provenance

CC-BY 4.0, attribution preserved in registry envelope `source` field.

| File | SHA256 | Source |
|---|---|---|
| `GEM-GGIT-Gas-Pipelines-2025-11.xlsx` | `f56d8b14400e558f06e53a4205034d3d506fc38c5ae6bf58000252f87b1845e6` | https://globalenergymonitor.org/wp-content/uploads/2025/11/GEM-GGIT-Gas-Pipelines-2025-11.xlsx |
| `GEM-GOIT-Oil-NGL-Pipelines-2025-03.xlsx` | `d1648d28aed99cfd2264047f1e944ddfccf50ce9feeac7de5db233c601dc3bb2` | https://globalenergymonitor.org/wp-content/uploads/2025/03/GEM-GOIT-Oil-NGL-Pipelines-2025-03.xlsx |

## Filter knobs

- `status ∈ {operating, construction}` (drops cancelled / shelved / mothballed / proposed)
- Length: gas ≥ 750 km, oil ≥ 400 km (asymmetric per-fuel trunk-class)
- Capacity unit conversions: bcm/y native; MMcf/d, MMSCMD, mtpa, m3/day, bpd, Mb/d, kbd → bcm/y (gas) or bbl/d (oil)
- Country names → ISO 3166-1 alpha-2 via pycountry + alias table

## Floor bump

`MIN_PIPELINES_PER_REGISTRY` 8 → 200. Live counts (297/334) leave ~100 rows of jitter headroom.

## Test plan

- [x] `node --import tsx/esm --test tests/pipelines-registry.test.mts tests/import-gem-pipelines.test.mjs` — 51/51 pass
- [x] `npx tsc --noEmit` clean
- [x] Spot-checked 5 random GEM-sourced rows per registry (TAPI, Druzhba Kuibyshev-Unecha 2, Keystone Phase 2, Centro Oeste, Gryazovets-Vyborg)
- [x] Hand-curated 75+75 preserved with full evidence; dedup matched 31 overlap rows correctly
- [ ] Deploy preview rendering 297/334 rows in `PipelineStatusPanel` table (verify pagination/perf)
- [ ] Health endpoint `pipelinesGas` / `pipelinesOil` reports OK after seed-cron run
