### PR TITLE
feat(resilience): financialSystemExposure dim scaffold (Phase 2 Ship 2 — flag-gated dark)

### DIFF
--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -28,6 +28,17 @@ const BOOTSTRAP_CACHE_KEYS = {
   imfGrowth:        'economic:imf:growth:v1',
   imfLabor:         'economic:imf:labor:v1',
   imfExternal:      'economic:imf:external:v1',
+  // plan 2026-04-25-004 Phase 2 (financialSystemExposure data keys):
+  // intentionally NOT added here. The 3 new keys
+  // (economic:wb-external-debt:v1, economic:bis-lbs:v1,
+  //  economic:fatf-listing:v1) are SERVER-ONLY inputs to
+  // scoreFinancialSystemExposure — no client-side panel consumes them
+  // directly. AGENTS.md's "new data sources must hydrate via bootstrap"
+  // applies to keys with `getHydratedData` consumers in src/; the
+  // bootstrap-key-hydration-coverage test enforces that invariant. If
+  // a future PR adds a client panel that displays raw BIS LBS / FATF /
+  // WB external-debt data, register the keys here AND add the
+  // corresponding consumer + cache-keys.ts entries in the same PR.
   shippingRates:    'supply_chain:shipping:v2',
   chokepoints:      'supply_chain:chokepoints:v4',
   minerals:         'supply_chain:minerals:v2',

--- a/api/health.js
+++ b/api/health.js
@@ -118,6 +118,10 @@ const STANDALONE_KEYS = {
   imfGrowth:            'economic:imf:growth:v1',
   imfLabor:             'economic:imf:labor:v1',
   imfExternal:          'economic:imf:external:v1',
+  // plan 2026-04-25-004 Phase 2: financialSystemExposure data keys.
+  wbExternalDebt:       'economic:wb-external-debt:v1',
+  bisLbs:               'economic:bis-lbs:v1',
+  fatfListing:          'economic:fatf-listing:v1',
   climateZoneNormals:    'climate:zone-normals:v1',
   shippingRates:         'supply_chain:shipping:v2',
   chokepoints:           'supply_chain:chokepoints:v4',
@@ -161,7 +165,7 @@ const STANDALONE_KEYS = {
   pizzint:                  'intelligence:pizzint:seed:v1',
   resilienceStaticIndex:    'resilience:static:index:v1',
   resilienceStaticFao:      'resilience:static:fao',
-  resilienceRanking:        'resilience:ranking:v13',
+  resilienceRanking:        'resilience:ranking:v14',
   productCatalog:           'product-catalog:v2',
   energySpineCountries:     'energy:spine:v1:_countries',
   energyExposure:           'energy:exposure:v1:index',
@@ -259,6 +263,11 @@ const SEED_META = {
   imfGrowth:        { key: 'seed-meta:economic:imf-growth',       maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro (same WEO release cadence)
   imfLabor:         { key: 'seed-meta:economic:imf-labor',        maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro
   imfExternal:      { key: 'seed-meta:economic:imf-external',     maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro
+  // plan 2026-04-25-004 Phase 2: financialSystemExposure component seeders.
+  // Bundle: scripts/seed-bundle-macro.mjs (Codex R1 #5, Option A).
+  wbExternalDebt:   { key: 'seed-meta:economic:wb-external-debt', maxStaleMin: 100800 }, // annual WB IDS publication; 70d threshold matches IMF cadence pattern
+  bisLbs:           { key: 'seed-meta:economic:bis-lbs',          maxStaleMin: 14400 }, // BIS LBS quarterly publication; 10d threshold = ~1× publish lag tolerance after macro bundle daily refresh
+  fatfListing:      { key: 'seed-meta:economic:fatf-listing',     maxStaleMin: 60480 }, // FATF plenary 3×/year; 42d threshold = >1 plenary cycle (catches missed-update if cron silently fails)
   shippingRates:    { key: 'seed-meta:supply_chain:shipping',     maxStaleMin: 420 },
   chokepoints:      { key: 'seed-meta:supply_chain:chokepoints',  maxStaleMin: 60, minRecordCount: 13 }, // 13 canonical chokepoints; get-chokepoint-status writes covered-count → < 13 = upstream partial (portwatch/ArcGIS dropped some)
   // minerals + giving: on-demand cachedFetchJson only, no seed-meta writer — freshness checked via TTL

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -84,6 +84,11 @@ const SEED_DOMAINS = {
   'economic:imf-growth':      { key: 'seed-meta:economic:imf-growth',      intervalMin: 50400 }, // monthly WEO seed; intervalMin = health.js maxStaleMin / 2 (100800 / 2)
   'economic:imf-labor':       { key: 'seed-meta:economic:imf-labor',       intervalMin: 50400 }, // monthly WEO seed; intervalMin = health.js maxStaleMin / 2 (100800 / 2)
   'economic:imf-external':    { key: 'seed-meta:economic:imf-external',    intervalMin: 50400 }, // monthly WEO seed; intervalMin = health.js maxStaleMin / 2 (100800 / 2)
+  // plan 2026-04-25-004 Phase 2: financialSystemExposure component seeders.
+  // intervalMin = health.js maxStaleMin / 2 (mirrors the IMF-pattern). Bundle: scripts/seed-bundle-macro.mjs.
+  'economic:wb-external-debt': { key: 'seed-meta:economic:wb-external-debt', intervalMin: 50400 }, // annual WB IDS publication; intervalMin = health.js maxStaleMin / 2 (100800 / 2)
+  'economic:bis-lbs':          { key: 'seed-meta:economic:bis-lbs',          intervalMin: 7200 },  // BIS LBS quarterly; intervalMin = health.js maxStaleMin / 2 (14400 / 2)
+  'economic:fatf-listing':     { key: 'seed-meta:economic:fatf-listing',     intervalMin: 30240 }, // FATF plenary 3×/year; intervalMin = health.js maxStaleMin / 2 (60480 / 2)
   'product-catalog':          { key: 'seed-meta:product-catalog',          intervalMin: 360 }, // relay loop every 6h; intervalMin = health.js maxStaleMin / 3 (1080 / 3)
   'portwatch:chokepoints-ref': { key: 'seed-meta:portwatch:chokepoints-ref', intervalMin: 10080 }, // seed-bundle-portwatch runs this at WEEK cadence; intervalMin*2 = 14d matches api/health.js SEED_META.portwatchChokepointsRef
   'supply_chain:portwatch-ports': { key: 'seed-meta:supply_chain:portwatch-ports', intervalMin: 720 }, // 12h cron (0 */12 * * *); intervalMin = maxStaleMin / 3 (2160 / 3)

--- a/docs/methodology/country-resilience-index.mdx
+++ b/docs/methodology/country-resilience-index.mdx
@@ -57,7 +57,7 @@ The index is organized into 6 domains. Each domain weight reflects its relative 
 
 | Domain | ID | Weight | Dimensions |
 |---|---|---|---|
-| Economic | `economic` | 0.17 | Macro-Fiscal, Currency & External, Trade Policy |
+| Economic | `economic` | 0.17 | Macro-Fiscal, Currency & External, Trade Policy, Financial System Exposure |
 | Infrastructure | `infrastructure` | 0.15 | Cyber & Digital, Logistics & Supply, Infrastructure |
 | Energy | `energy` | 0.11 | Energy |
 | Social & Governance | `social-governance` | 0.19 | Governance, Social Cohesion, Border Security, Information |
@@ -116,6 +116,25 @@ weight categorization, transit-hub exclusion lists), see
 | tradeRestrictions | WTO trade restrictions count (IN_FORCE weighted 3x) | Lower is better | 30 - 0 | 0.30 | WTO | Weekly |
 | tradeBarriers | WTO trade barrier notifications count | Lower is better | 40 - 0 | 0.30 | WTO | Weekly |
 | appliedTariffRate | Applied tariff rate, weighted mean, all products (World Bank TM.TAX.MRCH.WM.AR.ZS) | Lower is better | 20 - 0 | 0.40 | World Bank | Annual |
+
+#### Financial System Exposure
+
+Added in plan 2026-04-25-004 Phase 2 (Ship 2). Replaces the dropped OFAC-domicile signal (Phase 1) with a structural-exposure construct built from audited cross-border banking + AML/CFT data. Where the OFAC count conflated transit-hub corporate domicile with host-country risk (penalizing financial centers like UAE / Singapore / Hong Kong for shell-entity behavior), this dimension uses sources that measure actual sovereign vulnerability: short-term external debt overhang, concentrated cross-border banking exposure, and AML/CFT compliance status.
+
+The dimension uses a **fail-closed preflight** pattern (mirrors `scoreEnergy` v2): all 3 required seed envelopes (`economic:wb-external-debt:v1`, `economic:bis-lbs:v1`, `economic:fatf-listing:v1`) MUST be reachable. Missing seed-meta indicates a Railway bundle outage and surfaces as `imputationClass='source-failure'` rather than silently zeroing the dim. Per-country data gaps are distinct: per-component reads return null and the slot drops out of the weighted blend.
+
+| Indicator | Description | Direction | Goalposts (worst-best) | Weight | Source | Cadence |
+|---|---|---|---|---|---|---|
+| shortTermExternalDebtPctGni | Short-term external debt as % of GNI (WB IDS DT.DOD.DSTC.IR.ZS × DT.DOD.DECT.GN.ZS); IMF Article IV vulnerability threshold is 15% GNI | Lower is better | 15 - 0 | 0.35 | World Bank IDS | Annual |
+| bisLbsXborderPctGdp | BIS LBS sum of by-parent cross-border claims (US/UK/major-EU/CH/JP/CA/AU/SG) as % of GDP; U-shape band — both isolation (<5%) and over-exposure (>60%) score low | Lower is better (U-shape) | 60 - 15 | 0.30 | BIS LBS | Quarterly |
+| fatfListingStatus | FATF AML/CFT listing status — black list (call for action) → 0, gray list (increased monitoring) → 30, compliant → 100 | Higher is better | 0 - 100 | 0.20 | FATF | Monthly |
+| financialCenterRedundancy | Count of distinct BIS LBS by-parent reporters with non-trivial (>1% GDP) cross-border claims; rewards multi-counterparty financial centers, balances Component 2 over-exposure penalty | Higher is better | 1 - 10 | 0.15 | BIS LBS | Quarterly |
+
+**Coverage**: WB IDS publishes for ~125 LMICs only; HIC fall through to the BIS LBS structural-exposure component (which has ~200-country coverage). FATF + BIS LBS together cover effectively all manifest countries.
+
+**Data sources and licensing**: BIS data (Components 2 + 4) is published under [BIS terms of use](https://www.bis.org/terms_conditions.htm) — publicly available with attribution; redistribution restricted. WB IDS (Component 1) and FATF (Component 3) are open-data. The BIS-derived indicators are tagged `non-commercial` / `enrichment` in the indicator registry per the existing BIS classification convention; the dimension itself is `core` (contributes to the headline score) per Codex R1 #8.
+
+For the full construct rationale, alternatives considered (program-weight categorization, transit-hub exclusion, single-dim formula rewrite, drop entirely), and the staged rollout decision, see [financial-system-exposure.md](./financial-system-exposure.md).
 
 ### Infrastructure Domain (weight 0.15)
 

--- a/docs/methodology/financial-system-exposure.md
+++ b/docs/methodology/financial-system-exposure.md
@@ -165,6 +165,33 @@ When the flag flips on, every country's `financialSystemExposure` score moves fr
 
 The BIS-derived indicators (Components 2 + 4) are tagged `non-commercial` / `enrichment` in `_indicator-registry.ts` per the existing BIS classification convention. The dimension itself is `core` (it contributes to the headline score) per Codex R1 #8 — a `core` dim with `enrichment` constituent indicators is permissible because the indicator-registry lint accepts the configuration.
 
+## Common operational footguns
+
+### BIS LBS `4F` is NOT a valid parent-country aggregate
+
+Codex Round 4 caught this: BIS publishes `4F` as a counterparty-country legacy code (Euro area), but `WS_LBS_D_PUB`'s `L_PARENT_CTY` codelist (`CL_BIS_IF_REF_AREA`) only accepts ISO 3166-1 alpha-2 country codes plus the BIS-defined parent aggregates `5J` (all parents) and `5M` (emerging markets). Querying `L_PARENT_CTY=4F` returns an empty SDMX result silently — a fresh seed-meta with zero claims looks plausible but produces 0% exposure for every counterparty. **Rule**: enumerate the individual euro-area parent ISO2 codes (DE, FR, IT, NL, ES, BE, AT, IE, LU) instead. The seeder's `PARENT_COUNTRIES` list pins this.
+
+### BIS LBS `L_CP_COUNTRY` uses ISO 3166-1, not M49
+
+Codex Round 4 also caught this: BIS LBS country dimensions follow the `CL_BIS_IF_REF_AREA` codelist, which is ISO 3166-1 alpha-2 for country members (`BR`, `US`, `GB`, etc.). No M49 numeric mapping is required — pass ISO2 codes directly to the SDMX key. The seeder uses `iso3-to-iso2.json` only for the GDP denominator (WB API returns ISO3).
+
+### Smoke test before flipping `RESILIENCE_FIN_SYS_EXPOSURE_ENABLED=true`
+
+After running the 3 seeders manually but BEFORE flipping the flag in Vercel:
+
+```bash
+# Confirm seed envelopes published
+redis-cli GET 'seed-meta:economic:wb-external-debt' | jq '.fetchedAt, .recordCount'
+redis-cli GET 'seed-meta:economic:bis-lbs'          | jq '.fetchedAt, .recordCount'
+redis-cli GET 'seed-meta:economic:fatf-listing'     | jq '.fetchedAt, .recordCount'
+
+# Confirm BIS LBS payload is non-empty for a major economy
+redis-cli GET 'economic:bis-lbs:v1' | jq '.countries.BR'
+# Expected: { totalXborderPctGdp: <number>, parentCount: <2..16>, parents: {...}, gdpYear: <year> }
+```
+
+If any of these return null or empty, **do NOT flip the flag** — flipping with absent envelopes throws `ResilienceConfigurationError` on every `/api/resilience/*` request and stamps every country's `financialSystemExposure` as `imputationClass='source-failure'`. The fix is recoverable (flip the flag back OFF, fix the seeder, re-run, retry) but produces user-visible Sentry noise during the gap.
+
 ## Alternatives considered (and rejected)
 
 ### Alternative 1 — Patch `normalizeSanctionCount` only

--- a/docs/methodology/financial-system-exposure.md
+++ b/docs/methodology/financial-system-exposure.md
@@ -1,0 +1,205 @@
+# Financial System Exposure — construct definition
+
+**Status**: Active (added in plan 2026-04-25-004 Phase 2 — Ship 2)
+**Dimension ID**: `financialSystemExposure`
+**Domain**: `economic` (weight 0.50 within domain)
+**Type**: `stress`
+**Rollout**: Flag-gated dark behind `RESILIENCE_FIN_SYS_EXPOSURE_ENABLED` until component seeders are populating in production.
+
+## Question answered
+
+**How vulnerable is country X's financial system to coordinated action by major Western banking jurisdictions, AML/CFT enforcement bodies, and short-term external-debt rollover risk?**
+
+This dimension replaces the structural-exposure half of the dropped OFAC-domicile component (Ship 1) with a four-component composite built from audited cross-border banking + AML/CFT data. Where the OFAC count conflated transit-hub corporate domicile with host-country risk (penalizing financial centers like UAE, Singapore, Hong Kong for shell-entity behavior), this dimension uses sources that measure actual sovereign vulnerability.
+
+## Composition
+
+```
+financialSystemExposure = weightedBlend([
+  { signal: short_term_external_debt_pct_gni,  weight: 0.35 },
+  { signal: bis_lbs_xborder_us_eu_uk_pct_gdp,  weight: 0.30 },
+  { signal: fatf_listing_status,                weight: 0.20 },
+  { signal: financial_center_redundancy,        weight: 0.15 },
+])
+```
+
+Components 2 + 4 share the BIS LBS payload (`economic:bis-lbs:v1`); no separate seeder for redundancy.
+
+### Component 1: `short_term_external_debt_pct_gni` (weight 0.35)
+
+**Source**: World Bank International Debt Statistics (IDS).
+
+**Composition**:
+```
+shortTermDebtPctGni = (DT.DOD.DSTC.IR.ZS / 100) × DT.DOD.DECT.GN.ZS
+```
+Where:
+
+- `DT.DOD.DSTC.IR.ZS` — Short-term external debt (% of total external debt)
+- `DT.DOD.DECT.GN.ZS` — Total external debt stocks (% of GNI)
+
+**Why GNI, not GDP**: WB IDS publishes external-debt ratios against GNI by convention. Cross-conversion to GDP requires the `NY.GDP.MKTP.CD` × `NY.GNP.MKTP.CD` ratio, which is generally close to 1 but not identical. Stay with GNI to avoid introducing a conversion error for a signal that doesn't have a high-precision USD component anyway.
+
+**Why not USD-only**: WB IDS does not publish currency-composition breakdowns in its public dataset. The IMF's Currency Composition of Official Foreign Exchange Reserves (COFER) is reserves-only, not external debt. To get USD-component external debt would require proprietary BIS Triennial Survey data (paid, not in the project's budget). Accepting "all foreign-currency short-term external debt" is materially-correct because USD comprises 60-65% of global foreign-currency external debt (BIS 2024 estimates) and this proportion is stable enough that the resulting score is monotone in USD-component exposure.
+
+**Score shape**: `normalizeLowerBetter(value, 0, 15)` — IMF Article IV external-financing-vulnerability threshold is canonically 15% of GNI.
+
+**Coverage**: ~125 LMICs (low- and middle-income countries). HIC fall through to Component 2 (BIS LBS) which has ~200-country coverage.
+
+**Cadence**: monthly cron (WB IDS publishes annually; the cadence is for refresh-once-they-publish detection).
+
+**Seed key**: `economic:wb-external-debt:v1`. **Seeder**: `scripts/seed-wb-external-debt.mjs`.
+
+### Component 2: `bis_lbs_xborder_us_eu_uk_pct_gdp` (weight 0.30)
+
+**Source**: BIS Locational Banking Statistics by-parent view (`WS_LBS_D_PUB`).
+
+**SDMX key shape** (12 dimensions, per Codex R2 P1 + R4 P1 corrections):
+```
+Q.S.C.A.TO1.A.<L_PARENT_CTY>.A.5A.A.<L_CP_COUNTRY>.N
+```
+
+The resilience question ("how exposed is country X's financial system to actions by banks whose parent is in US/UK/EU/etc.?") maps to the BIS LBS **by-parent** view, not the by-reporting-country view. The two are different SDMX dimensions:
+
+- `L_PARENT_CTY` = parent country (where the bank group is headquartered)
+- `L_REP_CTY` = reporting country (where the lending office is resident)
+
+A US bank's London branch booking a claim on Brazil shows as `L_PARENT_CTY=US, L_REP_CTY=GB`. The by-parent view rolls these up to the parent's total claims regardless of the booking office, which is the right granularity for systemic exposure analysis.
+
+**Parent enumeration** (per Codex R4 P1 #2): `US`, `GB`, `DE`, `FR`, `IT`, `NL`, `ES`, `BE`, `AT`, `IE`, `LU`, `CH`, `JP`, `CA`, `AU`, `SG`. The earlier `4F` aggregate is NOT a valid parent code in `WS_LBS_D_PUB`; individual ISO2 codes for major Western parents must be enumerated.
+
+**ISO mapping**: BIS LBS `L_CP_COUNTRY` and `L_PARENT_CTY` use codelist `CL_BIS_IF_REF_AREA`, which follows ISO 3166-1 alpha-2. ISO2 codes pass directly to the SDMX key. BIS-defined aggregate codes (`5J`, `5A`, `5M`, `1C`, etc.) are handled as explicit allow-listed exceptions in the seeder's per-counterparty iteration.
+
+**GDP denominator**: World Bank `NY.GDP.MKTP.CD` (current USD), matched to the same reference year as the BIS LBS quarter.
+
+**Score shape**: U-shaped band-normalization (`normalizeBandLowerBetter`). Both extremes are bad — too little integration suggests financial isolation (sanctions-target jurisdictions; thin correspondent-banking access); too much suggests over-exposure to Western-bank pulls (Iceland-2008 territory). The score peaks in the "healthy diversified financial system" middle band:
+
+| Cross-border claims (% GDP) | Score |
+|---|---|
+| 0% | 60 |
+| < 5% (low integration) | 60-70 (linear) |
+| 5-25% (sweet spot) | 75-100 (linear) |
+| 25-60% (over-exposed) | 70-30 (linear) |
+| > 60% (Iceland-2008 territory) | < 30, clamped 0 |
+
+**Coverage**: ~200 jurisdictions; effectively complete for the manifest.
+
+**Cadence**: weekly cron. BIS LBS publishes quarterly; weekly catches the publication 2-3 weeks after each quarter-end with low overhead.
+
+**Seed key**: `economic:bis-lbs:v1`. **Seeder**: `scripts/seed-bis-lbs.mjs`.
+
+### Component 3: `fatf_listing_status` (weight 0.20)
+
+**Source**: FATF official "Black and Grey Lists" page (`https://www.fatf-gafi.org/en/countries/black-and-grey-lists.html`).
+
+This page is a STABLE entry point that links to the current publication. Each FATF plenary (3× per year) publishes a new listing document. The seeder follows the linked publication URL dynamically rather than hardcoding country names — hardcoding would silently miss new updates.
+
+**Score shape** (discrete):
+| FATF status | Score | Notes |
+|---|---|---|
+| Black list (call for action) | 0 | DPRK has been on every list since 2011; Iran since 2020; Myanmar since 2022 |
+| Grey list (increased monitoring) | 30 | Typically 15-25 jurisdictions; rotates as countries clear FATF action plans |
+| Compliant | 100 | Default for any jurisdiction not appearing on either list |
+
+**Coverage**: 100% — FATF only enumerates non-compliant jurisdictions; every other country defaults to "compliant".
+
+**Cadence**: monthly cron.
+
+**Seed key**: `economic:fatf-listing:v1`. **Seeder**: `scripts/seed-fatf-listing.mjs`.
+
+**Robustness**: parser tests with HTML fixtures. On parse failure, validate rejects the seed and the seed-meta `fetchedAt` doesn't refresh — the previous valid payload stays alive under its 90-day cache TTL. This is the "fall back to last-known list" behavior called for in the plan.
+
+### Component 4: `financial_center_redundancy` (weight 0.15)
+
+**Question answered**: How many independent USD-clearing routes remain if one major counterparty pulls correspondent relationships?
+
+**Source**: BIS LBS by-parent series (shares the same seed payload as Component 2). For each counterparty country, count the distinct reporting-parent banks with non-trivial cross-border claims (>1% of host country GDP).
+
+**Score shape**: `normalizeHigherBetter(parentCount, worst=1, best=10)`.
+
+**Important**: this directly REWARDS countries with multi-counterparty financial centers (UAE, Singapore, HK), inverting the hub-of-trade penalty in the OFAC-domicile construct. This is the component that explicitly balances against the Component 2 over-exposure penalty.
+
+**Coverage**: derived from BIS LBS — same ~200 jurisdictions.
+
+## Fail-closed preflight
+
+The dim implements the same fail-closed pattern as `scoreEnergy` v2 (plan [`2026-04-24-001`](./../plans/2026-04-24-001-fix-resilience-v2-fail-closed-on-missing-seeds-plan.md)). When `RESILIENCE_FIN_SYS_EXPOSURE_ENABLED=true`, the scorer preflights all 3 required seed envelopes:
+
+```
+seed-meta:economic:wb-external-debt:v1
+seed-meta:economic:bis-lbs:v1
+seed-meta:economic:fatf-listing:v1
+```
+
+Missing envelopes throw `ResilienceConfigurationError(message, missingKeys)` (two-arg form; `missingKeys` carries the absent seed keys). The `scoreAllDimensions` catch path reads `err.missingKeys`, joins them for the source-failure log, and routes the dim to `imputationClass='source-failure'` with `score=0, coverage=0`. Per-country data gaps inside an otherwise-published envelope are distinct: per-component reads return null and the slot drops out of the weighted blend.
+
+When `RESILIENCE_FIN_SYS_EXPOSURE_ENABLED` is unset or false (default), the scorer returns the empty-data shape (no preflight, no throw, `imputationClass=null`). The dim drops out of the coverage-weighted economic-domain mean. This is the staged-rollout posture: the dim ships dark until seeders are populating in production, then ops flip the flag.
+
+## Methodology invariants
+
+- **No double-counting with `tradePolicy`**: the OFAC-domicile-count signal does NOT feed either dim. Pinned by an integration test that mutates `sanctions:country-counts:v1` and asserts neither dim moves.
+- **No double-counting with `liquidReserveAdequacy`**: both touch external-debt signals but measure different ratios (coverage vs absolute exposure). Liquid reserve adequacy uses WB FI.RES.TOTL.MO (months-of-imports cushion); financial-system exposure uses WB IDS short-term external debt as % of GNI (debt-rollover vulnerability). They move semi-independently.
+- **Source provenance**: every component cites at least one primary-source URL in its seed payload's `sources:` array.
+
+## Sanctions-isolated jurisdiction sanity check
+
+The construct is calibrated such that countries with comprehensive financial sanctions and weak banking infrastructure score very low on this dim. The cohort sanity-check anchor (gates the construct at activation time):
+
+- **Russia, Iran, DPRK, Cuba, Venezuela, Belarus, Libya, Myanmar** must score < 20 on `financialSystemExposure` after the flag flips on with seeders populated. If they don't, the construct is mis-calibrated and must be retuned before production rollout.
+
+## Bounded-movement gate
+
+When the flag flips on, every country's `financialSystemExposure` score moves from 0 (flag-off baseline) to its actual value, which propagates into the headline overall score via the economic-domain mean. The bounded-movement gate (per plan §Phase 2 Acceptance criteria):
+
+- At least 60% of countries should have |Δ| < 3 points overall
+- No country moves > 12 points overall except the explicitly-predicted set above (sanctions-isolated jurisdictions where the new dim correctly adds penalty)
+
+## Data sources and licensing
+
+| Component | Source | License |
+|---|---|---|
+| Component 1 (WB IDS short-term debt) | World Bank International Debt Statistics | CC-BY-4.0 (open-data) |
+| Component 2 (BIS LBS cross-border claims) | BIS Locational Banking Statistics — `WS_LBS_D_PUB` SDMX dataflow | [BIS terms of use](https://www.bis.org/terms_conditions.htm) — non-commercial, attribution required |
+| Component 3 (FATF listing status) | FATF "Black and Grey Lists" web publications | Open (no machine-readable license terms posted; FATF publications are public-domain by convention) |
+| Component 4 (BIS LBS by-parent count) | BIS LBS — same seed as Component 2 | Same as Component 2 |
+
+The BIS-derived indicators (Components 2 + 4) are tagged `non-commercial` / `enrichment` in `_indicator-registry.ts` per the existing BIS classification convention. The dimension itself is `core` (it contributes to the headline score) per Codex R1 #8 — a `core` dim with `enrichment` constituent indicators is permissible because the indicator-registry lint accepts the configuration.
+
+## Alternatives considered (and rejected)
+
+### Alternative 1 — Patch `normalizeSanctionCount` only
+
+Tweak the piecewise scale to be less aggressive. **Rejected**: doesn't address the underlying construct error. The OFAC count's fundamental conflation of transit-hub corporate domicile with host-country risk would persist.
+
+### Alternative 2 — Transit-hub exclusion list
+
+Exclude Dubai/Singapore/Hong Kong/Cyprus free-zone-domiciled designations from each host country's count. **Rejected**: bandaid on the wrong construct; the hub list is arbitrary and any line-drawing exercise becomes politically charged.
+
+### Alternative 3 — Single-dim formula rewrite (don't split)
+
+Keep `tradeSanctions` as one dim, just rewrite the 0.45 sanctions component formula to be the new `financialSystemExposure` composite. **Rejected**: makes the dim measure two semantically-different things (trade-policy openness AND structural financial vulnerability); future audits have to disentangle them.
+
+### Alternative 4 — Drop the dim entirely
+
+**Rejected**: trade-policy openness IS a real signal; just not the OFAC-domicile component. The Phase 1 Ship 1 split keeps the trade-policy signal intact in `tradePolicy` while the new `financialSystemExposure` carries the structural-vulnerability signal.
+
+### Alternative 5 — `tradeSanctions` as compat-with-coverage-0 for one cycle
+
+Keep `tradeSanctions` as a retired/compat dimension at coverage=0; add `tradePolicy` and `financialSystemExposure` incrementally. **Adopted in modified form** as the two-ship structure. The two-ship structure preserves the rename + drop in Phase 1 (Ship 1), then adds the new dim in Phase 2 (Ship 2) — the staged approach that Codex R1 #9 specifically recommended.
+
+## Future considerations
+
+- **Phase 3 — OFAC enforcement-action seeder**: a structured per-country enforcement-action time-series (action date, fine USD, target sector). Add `ofac_active_enforcement_24m` back to the dim at weight ~0.10 with proportional reweighting. Requires new structured seeder; out of scope for v1.
+- **Phase 4 — Geopolitical-bloc weighting**: countries with explicit US-aligned defense treaties (NATO, MNNA) get a small access bonus.
+- **Phase 5 — USD currency-composition true-up**: source actual USD-denominated short-term external debt from BIS Triennial Survey (paid data). Until then, Component 1 measures all-foreign-currency short-term external debt as % of GNI.
+
+## References
+
+- Plan: [`docs/plans/2026-04-25-004-feat-financial-system-exposure-construct-plan.md`](../plans/2026-04-25-004-feat-financial-system-exposure-construct-plan.md)
+- Phase 1 (rename + drop OFAC): [`known-limitations.md § tradeSanctions → tradePolicy`](./known-limitations.md#tradesanctions--tradepolicy-ofac-domicile-component-dropped-ship-1-2026-04-25)
+- Energy v2 fail-closed precedent: [`docs/plans/2026-04-24-001-fix-resilience-v2-fail-closed-on-missing-seeds-plan.md`](../plans/2026-04-24-001-fix-resilience-v2-fail-closed-on-missing-seeds-plan.md)
+- Scorer: `server/worldmonitor/resilience/v1/_dimension-scorers.ts` (`scoreFinancialSystemExposure`)
+- Indicator registry: `server/worldmonitor/resilience/v1/_indicator-registry.ts` (4 entries with dimension `financialSystemExposure`)
+- Seeders: `scripts/seed-{wb-external-debt,bis-lbs,fatf-listing}.mjs`
+- Tests: `tests/resilience-financial-system-exposure.test.mts`, `tests/seed-{wb-external-debt,bis-lbs,fatf-listing}.test.mjs`
+- Bundle: `scripts/seed-bundle-macro.mjs` (Option A per Codex R1 #5)

--- a/scripts/backtest-resilience-outcomes.mjs
+++ b/scripts/backtest-resilience-outcomes.mjs
@@ -27,7 +27,7 @@ loadEnvFile(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const VALIDATION_DIR = join(__dirname, '..', 'docs', 'methodology', 'country-resilience-index', 'validation');
 
-const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v13:';
+const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v14:';
 
 // Mirror of _shared.ts#currentCacheFormula. Must stay in lockstep; see
 // the same comment in scripts/validate-resilience-correlation.mjs for

--- a/scripts/benchmark-resilience-external.mjs
+++ b/scripts/benchmark-resilience-external.mjs
@@ -374,7 +374,7 @@ function currentCacheFormulaLocal() {
 
 async function readWmScoresFromRedis() {
   const { url, token } = getRedisCredentials();
-  const rankingResp = await fetch(`${url}/get/${encodeURIComponent('resilience:ranking:v13')}`, {
+  const rankingResp = await fetch(`${url}/get/${encodeURIComponent('resilience:ranking:v14')}`, {
     headers: { Authorization: `Bearer ${token}` },
     signal: AbortSignal.timeout(10_000),
   });

--- a/scripts/compare-resilience-current-vs-proposed.mjs
+++ b/scripts/compare-resilience-current-vs-proposed.mjs
@@ -270,6 +270,16 @@ const EXTRACTION_RULES = {
   tradeBarriers: { type: 'count-trade-barriers' },
   appliedTariffRate: { type: 'static-path', path: ['appliedTariffRate', 'value'] },
 
+  // ── financialSystemExposure (added in plan 2026-04-25-004 Ship 2) ──
+  // All 4 indicators are seeder-driven (component seeders ship in same PR);
+  // extractors are out of scope for this comparison harness in v1 —
+  // marked not-implemented per the harness's escape hatch. A follow-up PR
+  // can wire seed-payload extractors after the seeders are populating.
+  shortTermExternalDebtPctGni: { type: 'not-implemented', reason: 'WB IDS seed-payload extractor pending seeder rollout (plan 2026-04-25-004 Ship 2)' },
+  bisLbsXborderPctGdp: { type: 'not-implemented', reason: 'BIS LBS seed-payload extractor pending seeder rollout (plan 2026-04-25-004 Ship 2)' },
+  fatfListingStatus: { type: 'not-implemented', reason: 'FATF seed-payload extractor pending seeder rollout (plan 2026-04-25-004 Ship 2)' },
+  financialCenterRedundancy: { type: 'not-implemented', reason: 'BIS LBS by-parent count extractor pending seeder rollout (plan 2026-04-25-004 Ship 2)' },
+
   // ── cyberDigital (scorer-aggregated event streams) ──────────────────
   cyberThreats: { type: 'summarize-cyber' },
   internetOutages: { type: 'summarize-outages-penalty' },

--- a/scripts/seed-bis-lbs.mjs
+++ b/scripts/seed-bis-lbs.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+//
+// BIS Locational Banking Statistics — by-parent cross-border claims
+// Canonical key: economic:bis-lbs:v1
+//
+// SDMX dataflow: WS_LBS_D_PUB
+// Endpoint:      https://stats.bis.org/api/v1/data/WS_LBS_D_PUB/<KEY>
+//
+// Per plan 2026-04-25-004 §Component 2 (Codex R2 P1 + R4 P1 corrections):
+//
+//   12-dim SDMX key shape:
+//     Q.S.C.A.TO1.A.<L_PARENT_CTY>.A.5A.A.<L_CP_COUNTRY>.N
+//
+//   Frequency       Q  (quarterly)
+//   Measure         S  (stocks at end-period)
+//   Balance sheet   C  (claims)
+//   Instruments     A  (all)
+//   Currency denom  TO1 (all currencies)
+//   Currency type   A  (all)
+//   PARENT country  varied per query — enumerated ISO2 (Codex R4 P1 #2:
+//                   `4F` is NOT valid; use individual parent ISO2 codes)
+//   Reporting type  A  (all)
+//   REP country     5A (all reporters — aggregate, NOT varied)
+//   Counterparty    A  (all sectors)
+//   Counterparty    empty wildcard — pull all counterparties per query
+//   Position type   N  (cross-border position type)
+//
+// ISO mapping (Codex R4 P1 #2): BIS LBS L_CP_COUNTRY uses CL_BIS_IF_REF_AREA
+// which follows ISO 3166-1 alpha-2 for country members. ISO2 codes pass
+// directly to the SDMX key — no M49 mapping needed. BIS-defined aggregate
+// codes (5J all parents, 5A all reporters, 5M emerging markets, 1C
+// international organisations, etc.) are handled as explicit allow-listed
+// exceptions in the country-iteration loop below.
+//
+// Output schema:
+//   { countries: { [iso2]: {
+//       totalXborderPctGdp: number,    // Component 2 input
+//       parentCount: number,            // Component 4 input (count of parents
+//                                       //  with claims > 1% of GDP)
+//       parents: { [parentIso2]: number }, // per-parent claims (USD millions)
+//                                          // for downstream provenance
+//     }},
+//     gdpYear: number,
+//     bisQuarter: string,    // e.g. "2025Q1"
+//     sources: string[],
+//     seededAt: string }
+
+import { loadEnvFile, CHROME_UA, runSeed, resolveProxyForConnect, httpsProxyFetchRaw } from './_seed-utils.mjs';
+import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
+
+loadEnvFile(import.meta.url);
+
+const _proxyAuth = resolveProxyForConnect();
+const CANONICAL_KEY = 'economic:bis-lbs:v1';
+const CACHE_TTL = 100 * 24 * 3600; // 100 days; BIS LBS publishes quarterly
+const WB_BASE = 'https://api.worldbank.org/v2';
+const BIS_BASE = 'https://stats.bis.org/api/v1/data/WS_LBS_D_PUB';
+
+// Major Western parent countries enumerated per Codex R4 P1 #2.
+// Sum across these gives the "exposure to actions by US/UK/major-EU/etc.
+// banks" signal. Together they account for >85% of BIS LBS counterparty
+// claims globally per the BIS 2024 outline.
+const PARENT_COUNTRIES = [
+  'US', 'GB', 'DE', 'FR', 'IT', 'NL', 'ES', 'BE', 'AT', 'IE', 'LU',
+  'CH', 'JP', 'CA', 'AU', 'SG',
+];
+
+// BIS-defined aggregate codes — skip during per-counterparty iteration.
+// These are NOT real countries; including them would inflate claim sums
+// and corrupt the % of GDP ratio.
+const BIS_AGGREGATE_CODES = new Set([
+  '5J', '5A', '5M', '1C', '4F', '4U', '5C', // common aggregates
+  'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', // grouped aggregates
+  '5R', '5T', '5W', '5Z',                          // EM/AE/world groupings
+]);
+
+async function fetchSdmxJson(url) {
+  try {
+    const resp = await fetch(url, {
+      headers: { 'User-Agent': CHROME_UA, Accept: 'application/vnd.sdmx.data+json;version=1.0.0' },
+      signal: AbortSignal.timeout(60_000),
+    });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    return await resp.json();
+  } catch (directErr) {
+    if (!_proxyAuth) throw directErr;
+    console.warn(`  BIS direct failed (${directErr.message}), retrying via proxy`);
+    const { buffer } = await httpsProxyFetchRaw(url, _proxyAuth, {
+      accept: 'application/vnd.sdmx.data+json;version=1.0.0',
+      timeoutMs: 60_000,
+    });
+    return JSON.parse(buffer.toString('utf8'));
+  }
+}
+
+// Parse SDMX-JSON Data Message: extract latest-period claim per
+// counterparty country for a given parent. Returns { [iso2]: claimUsdMillions }.
+//
+// SDMX-JSON shape (simplified):
+//   data.dataSets[0].series = { "<dim-coord-string>": { observations: { "<period-idx>": [value, ...] } } }
+//   data.structure.dimensions.series = [ { id, values: [...] }, ... ]
+//   data.structure.dimensions.observation = [ { id, values: [...] } ]   // typically TIME_PERIOD
+//
+// We need to:
+//   1. Find which series-dimension index is L_CP_COUNTRY (counterparty country)
+//   2. For each series, decode that dimension index to the counterparty ISO2
+//   3. Pick the latest observation (last index in observations dict)
+export function extractClaimsByCounterparty(sdmxJson) {
+  const ds = sdmxJson?.data?.dataSets?.[0] ?? sdmxJson?.dataSets?.[0];
+  const structure = sdmxJson?.data?.structure ?? sdmxJson?.structure;
+  if (!ds?.series || !structure?.dimensions?.series) return { byCounterparty: {}, latestPeriod: null };
+
+  const seriesDims = structure.dimensions.series;
+  const cpIdx = seriesDims.findIndex((d) => d.id === 'L_CP_COUNTRY' || d.id === 'CP_COUNTRY' || d.id === 'COUNTERPARTY_COUNTRY');
+  if (cpIdx < 0) {
+    throw new Error('SDMX response missing L_CP_COUNTRY dimension');
+  }
+  const cpValues = seriesDims[cpIdx].values; // [{ id, name }, ...]
+
+  const obsDim = (structure.dimensions.observation ?? [])[0];
+  const obsValues = obsDim?.values ?? [];
+
+  const byCounterparty = {};
+  let latestPeriod = null;
+
+  for (const [seriesKey, series] of Object.entries(ds.series)) {
+    const coords = seriesKey.split(':').map((s) => Number.parseInt(s, 10));
+    const cpRefIdx = coords[cpIdx];
+    const cpEntry = cpValues[cpRefIdx];
+    if (!cpEntry) continue;
+    const cpCode = String(cpEntry.id ?? '').trim().toUpperCase();
+    if (!cpCode || cpCode.length !== 2 || BIS_AGGREGATE_CODES.has(cpCode)) continue;
+
+    const obs = series.observations ?? {};
+    // Latest period: highest numeric obs index (SDMX-JSON convention).
+    let latestIdx = -1;
+    let latestVal = null;
+    for (const [idxStr, valArr] of Object.entries(obs)) {
+      const idx = Number.parseInt(idxStr, 10);
+      if (idx > latestIdx && Array.isArray(valArr) && valArr.length > 0) {
+        latestIdx = idx;
+        latestVal = Number(valArr[0]);
+      }
+    }
+    if (!Number.isFinite(latestVal) || latestVal < 0) continue;
+
+    byCounterparty[cpCode] = latestVal;
+    const period = obsValues[latestIdx]?.id;
+    if (period && (!latestPeriod || period > latestPeriod)) latestPeriod = period;
+  }
+
+  return { byCounterparty, latestPeriod };
+}
+
+async function fetchBisLbsForParent(parentIso2) {
+  const key = `Q.S.C.A.TO1.A.${parentIso2}.A.5A.A..N`;
+  // `?lastNObservations=4` keeps payload small; we only need the most
+  // recent quarter (older quarters used for cross-quarter reconciliation
+  // if the latest is missing).
+  const url = `${BIS_BASE}/${key}?lastNObservations=4`;
+  const json = await fetchSdmxJson(url);
+  return extractClaimsByCounterparty(json);
+}
+
+async function fetchGdpByCountry() {
+  const out = {};
+  let page = 1;
+  let totalPages = 1;
+  while (page <= totalPages) {
+    const url = `${WB_BASE}/country/all/indicator/NY.GDP.MKTP.CD?format=json&per_page=500&page=${page}&mrv=3`;
+    let json;
+    try {
+      const resp = await fetch(url, {
+        headers: { 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      json = await resp.json();
+    } catch (directErr) {
+      if (!_proxyAuth) throw directErr;
+      const { buffer } = await httpsProxyFetchRaw(url, _proxyAuth, { accept: 'application/json', timeoutMs: 30_000 });
+      json = JSON.parse(buffer.toString('utf8'));
+    }
+    const meta = json[0];
+    const records = json[1] ?? [];
+    totalPages = meta?.pages ?? 1;
+    for (const record of records) {
+      const rawCode = record?.countryiso3code ?? record?.country?.id ?? '';
+      const iso2 = rawCode.length === 3 ? (iso3ToIso2[rawCode] ?? null) : (rawCode.length === 2 ? rawCode : null);
+      if (!iso2) continue;
+      const value = Number(record?.value);
+      if (!Number.isFinite(value) || value <= 0) continue;
+      const year = Number(record?.date);
+      if (!Number.isFinite(year)) continue;
+      const existing = out[iso2];
+      if (!existing || year > existing.year) out[iso2] = { value, year };
+    }
+    page++;
+  }
+  return out;
+}
+
+export function combineLbsByCounterparty(perParent, gdpByCountry) {
+  // Reshape: counterparty → parent → claim.
+  const claimsByCpByParent = {};
+  for (const [parent, { byCounterparty }] of Object.entries(perParent)) {
+    for (const [cp, claim] of Object.entries(byCounterparty)) {
+      if (!claimsByCpByParent[cp]) claimsByCpByParent[cp] = {};
+      claimsByCpByParent[cp][parent] = claim;
+    }
+  }
+
+  const countries = {};
+  for (const [cp, parents] of Object.entries(claimsByCpByParent)) {
+    const gdp = gdpByCountry[cp];
+    if (!gdp) continue;
+    // BIS LBS reports claims in USD millions; WB GDP in USD. Convert
+    // millions → USD before computing the ratio.
+    const claimsUsd = Object.values(parents).reduce((sum, v) => sum + v * 1e6, 0);
+    const totalXborderPctGdp = Math.round((claimsUsd / gdp.value) * 10_000) / 100;
+
+    // Component 4: count of parents with claims > 1% of GDP.
+    const parentCount = Object.values(parents).filter((v) => (v * 1e6) > 0.01 * gdp.value).length;
+
+    countries[cp] = {
+      totalXborderPctGdp,
+      parentCount,
+      parents,
+      gdpYear: gdp.year,
+    };
+  }
+  return countries;
+}
+
+export async function fetchBisLbs() {
+  const perParent = {};
+  const errors = [];
+  // Sequential to be polite to BIS API; ~16 quick queries total.
+  for (const parent of PARENT_COUNTRIES) {
+    try {
+      perParent[parent] = await fetchBisLbsForParent(parent);
+    } catch (err) {
+      errors.push(`parent=${parent}: ${err.message}`);
+      perParent[parent] = { byCounterparty: {}, latestPeriod: null };
+    }
+  }
+  if (errors.length === PARENT_COUNTRIES.length) {
+    throw new Error(`BIS LBS: every parent fetch failed. ${errors.join('; ')}`);
+  }
+
+  const gdpByCountry = await fetchGdpByCountry();
+  const countries = combineLbsByCounterparty(perParent, gdpByCountry);
+
+  // Pick the most-common latestPeriod across parents (mode).
+  const periods = Object.values(perParent).map((p) => p.latestPeriod).filter(Boolean);
+  const periodCounts = periods.reduce((acc, p) => { acc[p] = (acc[p] || 0) + 1; return acc; }, {});
+  const bisQuarter = Object.entries(periodCounts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? null;
+
+  return {
+    countries,
+    bisQuarter,
+    parentCountries: PARENT_COUNTRIES,
+    sources: [
+      'https://stats.bis.org/api/v1/data/WS_LBS_D_PUB',
+      'https://www.bis.org/statistics/about_banking_stats.htm',
+      'https://www.bis.org/terms_conditions.htm',
+    ],
+    seededAt: new Date().toISOString(),
+  };
+}
+
+// BIS LBS counterparty coverage spans ~200+ jurisdictions. Floor of 100
+// catches catastrophic upstream failure while absorbing per-parent
+// sparseness for small economies.
+export function validate(data) {
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 100;
+}
+
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
+export { CANONICAL_KEY, CACHE_TTL, PARENT_COUNTRIES };
+
+if (process.argv[1]?.endsWith('seed-bis-lbs.mjs')) {
+  runSeed('economic', 'bis-lbs', CANONICAL_KEY, fetchBisLbs, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: `bis-lbs-${new Date().getFullYear()}`,
+    recordCount: (data) => Object.keys(data?.countries ?? {}).length,
+    emptyDataIsFailure: true,
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 14400, // 10d, > 1 BIS LBS publish lag
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
+    console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-bis-lbs.mjs
+++ b/scripts/seed-bis-lbs.mjs
@@ -143,6 +143,13 @@ export function extractClaimsByCounterparty(sdmxJson) {
       }
     }
     if (!Number.isFinite(latestVal) || latestVal < 0) continue;
+    // Upper-bound sanity guard: BIS reports claims in USD millions. The
+    // largest realistic single-bilateral claim is ~$2T = 2,000,000 millions.
+    // 1e8 millions = $100T = >half of global GDP — far above any plausible
+    // bilateral exposure. A value above this threshold indicates a parser
+    // or upstream-corruption fault; reject silently rather than corrupt
+    // the % of GDP ratio downstream.
+    if (latestVal > 1e8) continue;
 
     byCounterparty[cpCode] = latestVal;
     const period = obsValues[latestIdx]?.id;
@@ -160,6 +167,34 @@ async function fetchBisLbsForParent(parentIso2) {
   const url = `${BIS_BASE}/${key}?lastNObservations=4`;
   const json = await fetchSdmxJson(url);
   return extractClaimsByCounterparty(json);
+}
+
+// Bounded-concurrency runner. Sequential 16 parents × 60s timeout = 960s
+// worst-case, which exceeds the bundle's 600s timeoutMs. Parallel-4
+// caps wall time at ~4 × 60s = 240s on the slow path while staying
+// polite to BIS API (4 in-flight is well under any reasonable rate
+// limit). The runner returns the per-parent result map AND an errors
+// array so the caller can gate validation on the success-count.
+async function runParentFetchesConcurrent(parents, concurrency = 4) {
+  const results = {};
+  const errors = [];
+  let cursor = 0;
+  async function worker() {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= parents.length) return;
+      const parent = parents[idx];
+      try {
+        results[parent] = await fetchBisLbsForParent(parent);
+      } catch (err) {
+        errors.push(`parent=${parent}: ${err.message}`);
+        results[parent] = { byCounterparty: {}, latestPeriod: null };
+      }
+    }
+  }
+  const workers = Array.from({ length: Math.min(concurrency, parents.length) }, () => worker());
+  await Promise.all(workers);
+  return { results, errors };
 }
 
 async function fetchGdpByCountry() {
@@ -232,24 +267,42 @@ export function combineLbsByCounterparty(perParent, gdpByCountry) {
   return countries;
 }
 
+// Minimum successful parents required for the seed payload to be
+// considered structurally valid. Below this threshold, the surviving
+// parents would skew Component 4 (financial-center redundancy) low for
+// every counterparty country until the next successful run — a covertly-
+// degraded payload that passes the >100-counterparty floor. Reject
+// instead so seed-meta is NOT refreshed and the previous valid payload
+// stays alive under cache TTL.
+const MIN_SUCCESSFUL_PARENTS = 12;
+
 export async function fetchBisLbs() {
-  const perParent = {};
-  const errors = [];
-  // Sequential to be polite to BIS API; ~16 quick queries total.
-  for (const parent of PARENT_COUNTRIES) {
-    try {
-      perParent[parent] = await fetchBisLbsForParent(parent);
-    } catch (err) {
-      errors.push(`parent=${parent}: ${err.message}`);
-      perParent[parent] = { byCounterparty: {}, latestPeriod: null };
-    }
+  const { results: perParent, errors } = await runParentFetchesConcurrent(PARENT_COUNTRIES, 4);
+  const successfulParents = PARENT_COUNTRIES.length - errors.length;
+  if (successfulParents < MIN_SUCCESSFUL_PARENTS) {
+    throw new Error(
+      `BIS LBS: only ${successfulParents}/${PARENT_COUNTRIES.length} parents succeeded ` +
+        `(min ${MIN_SUCCESSFUL_PARENTS} required to avoid skewing parentCount). Errors: ${errors.join('; ')}`,
+    );
   }
-  if (errors.length === PARENT_COUNTRIES.length) {
-    throw new Error(`BIS LBS: every parent fetch failed. ${errors.join('; ')}`);
+  if (errors.length > 0) {
+    console.warn(`[bis-lbs] ${errors.length}/${PARENT_COUNTRIES.length} parent fetches failed (proceeding with ${successfulParents} successful): ${errors.join('; ')}`);
   }
 
   const gdpByCountry = await fetchGdpByCountry();
   const countries = combineLbsByCounterparty(perParent, gdpByCountry);
+
+  // Provenance: counterparties seen in BIS LBS but dropped because no
+  // GDP record was available. Surfaces silent coverage gaps for ops
+  // triage without polluting the main `countries` map.
+  const droppedForMissingGdp = [];
+  const seenCounterparties = new Set();
+  for (const { byCounterparty } of Object.values(perParent)) {
+    for (const cp of Object.keys(byCounterparty)) seenCounterparties.add(cp);
+  }
+  for (const cp of seenCounterparties) {
+    if (!gdpByCountry[cp]) droppedForMissingGdp.push(cp);
+  }
 
   // Pick the most-common latestPeriod across parents (mode).
   const periods = Object.values(perParent).map((p) => p.latestPeriod).filter(Boolean);
@@ -260,6 +313,8 @@ export async function fetchBisLbs() {
     countries,
     bisQuarter,
     parentCountries: PARENT_COUNTRIES,
+    droppedForMissingGdp,
+    successfulParents,
     sources: [
       'https://stats.bis.org/api/v1/data/WS_LBS_D_PUB',
       'https://www.bis.org/statistics/about_banking_stats.htm',
@@ -269,11 +324,12 @@ export async function fetchBisLbs() {
   };
 }
 
-// BIS LBS counterparty coverage spans ~200+ jurisdictions. Floor of 100
-// catches catastrophic upstream failure while absorbing per-parent
-// sparseness for small economies.
+// BIS LBS counterparty coverage spans ~200+ jurisdictions. Floor of 150
+// is conservative — at this threshold, a fresh seed represents the
+// vast majority of manifest countries. Below 150 indicates a serious
+// upstream regression that should NOT silently refresh seed-meta.
 export function validate(data) {
-  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 100;
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
 }
 
 export function declareRecords(data) {

--- a/scripts/seed-bundle-macro.mjs
+++ b/scripts/seed-bundle-macro.mjs
@@ -12,4 +12,11 @@ await runBundle('macro', [
   { label: 'IMF-Macro', script: 'seed-imf-macro.mjs', seedMetaKey: 'economic:imf-macro', canonicalKey: 'economic:imf:macro:v2', intervalMs: 30 * DAY, timeoutMs: 300_000 },
   { label: 'National-Debt', script: 'seed-national-debt.mjs', seedMetaKey: 'economic:national-debt', canonicalKey: 'economic:national-debt:v1', intervalMs: 30 * DAY, timeoutMs: 300_000 },
   { label: 'FAO-FFPI', script: 'seed-fao-food-price-index.mjs', seedMetaKey: 'economic:fao-ffpi', canonicalKey: 'economic:fao-ffpi:v1', intervalMs: DAY, timeoutMs: 120_000 },
+  // plan 2026-04-25-004 Phase 2: financialSystemExposure component seeders.
+  // Bundle placement = Option A per Codex R1 #5 (less operational overhead
+  // than provisioning a new bundle service). All 3 feed the new dim's
+  // fail-closed preflight (RESILIENCE_FIN_SYS_EXPOSURE_ENABLED=true).
+  { label: 'WB-External-Debt', script: 'seed-wb-external-debt.mjs', seedMetaKey: 'economic:wb-external-debt', canonicalKey: 'economic:wb-external-debt:v1', intervalMs: 30 * DAY, timeoutMs: 300_000 },
+  { label: 'BIS-LBS', script: 'seed-bis-lbs.mjs', seedMetaKey: 'economic:bis-lbs', canonicalKey: 'economic:bis-lbs:v1', intervalMs: 7 * DAY, timeoutMs: 600_000 },
+  { label: 'FATF-Listing', script: 'seed-fatf-listing.mjs', seedMetaKey: 'economic:fatf-listing', canonicalKey: 'economic:fatf-listing:v1', intervalMs: 30 * DAY, timeoutMs: 120_000 },
 ]);

--- a/scripts/seed-fatf-listing.mjs
+++ b/scripts/seed-fatf-listing.mjs
@@ -67,26 +67,39 @@ async function fetchHtml(url) {
   }
 }
 
-// Extract the first href to a publication page that contains the given
-// label-text fragment. FATF entry-page anchors look like:
-// `<a href="/en/publications/Fatfrecommendations/high-risk-jurisdictions-2026.html">High-risk jurisdictions subject to a call for action — February 2026</a>`
+// Extract the href to the most-recent publication page whose anchor text
+// contains the given label fragment. Defensive against FATF page layouts
+// where a sidebar/breadcrumb links to historical publications using the
+// same wording before the main-content anchor — preferring the highest-
+// year href catches drift even if document order isn't trustworthy.
+//
+// Returns the chosen URL or null. When multiple candidates match, logs
+// the full candidate list at WARN level for ops visibility.
 export function findPublicationLink(html, labelFragment) {
   const re = /<a\s+[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
+  const candidates = [];
   let m;
   while ((m = re.exec(html)) !== null) {
     const href = m[1];
     const text = stripHtml(m[2]);
     if (!text) continue;
     if (text.toLowerCase().includes(labelFragment.toLowerCase())) {
-      // Resolve relative URLs against the FATF origin.
-      try {
-        return new URL(href, FATF_ENTRY_URL).toString();
-      } catch {
-        continue;
-      }
+      let resolved;
+      try { resolved = new URL(href, FATF_ENTRY_URL).toString(); } catch { continue; }
+      // Year extracted from the URL slug (preferred) or anchor text.
+      const yearMatch = /\b(20\d{2})\b/.exec(href) ?? /\b(20\d{2})\b/.exec(text);
+      const year = yearMatch ? Number.parseInt(yearMatch[1], 10) : 0;
+      candidates.push({ url: resolved, text, year });
     }
   }
-  return null;
+  if (candidates.length === 0) return null;
+  // Prefer highest-year; fall back to document-order on ties (first match
+  // is usually the canonical link in FATF page templates as of 2026).
+  candidates.sort((a, b) => b.year - a.year);
+  if (candidates.length > 1) {
+    console.warn(`[fatf-listing] multiple "${labelFragment}" anchors found; using ${candidates[0].url} (year=${candidates[0].year}). Other candidates: ${candidates.slice(1).map((c) => `${c.url}(year=${c.year})`).join(', ')}`);
+  }
+  return candidates[0].url;
 }
 
 function stripHtml(s) {
@@ -97,8 +110,32 @@ function stripHtml(s) {
 // country typically appears as a header (h2/h3/h4) or strong tag.
 // Defensive: collect any text node that matches a known country name
 // from the lookup AND appears between the page's main listing markers.
+//
+// Also reports `unmatchedCandidates` — short text nodes that LOOK like
+// country names (capitalized, 2-5 words, not common section headers)
+// but don't match the lookup. Surfaces parser drift / new country
+// spellings that the lookup needs to learn.
 export function extractListedCountries(html, nameLookup) {
   const isoSet = new Set();
+  const unmatchedCandidates = new Set();
+  // Common section headers / FATF wording that should NOT be flagged
+  // as missing-country-spelling.
+  const SECTION_NOISE = new Set([
+    'high risk jurisdictions',
+    'jurisdictions under increased monitoring',
+    'call for action',
+    'high risk jurisdictions subject to a call for action',
+    'fatf',
+    'updated',
+    'overview',
+    'summary',
+    'introduction',
+    'background',
+    'process',
+    'february',
+    'june',
+    'october',
+  ]);
   // Scan all HTML headings + bold/strong elements + list-item leaders.
   const re = /<(?:h[1-6]|strong|b|li|p|td)[^>]*>([\s\S]*?)<\/(?:h[1-6]|strong|b|li|p|td)>/gi;
   let m;
@@ -107,9 +144,20 @@ export function extractListedCountries(html, nameLookup) {
     if (!text || text.length > 80) continue; // skip long paragraphs
     const norm = normalizeName(text);
     const iso2 = nameLookup.get(norm);
-    if (iso2) isoSet.add(iso2);
+    if (iso2) {
+      isoSet.add(iso2);
+      continue;
+    }
+    // Heuristic: 1-5 words, all-or-mostly capitalized, not a known noise
+    // header → likely a country name the lookup is missing.
+    const wordCount = norm.split(' ').filter(Boolean).length;
+    if (wordCount >= 1 && wordCount <= 5 && !SECTION_NOISE.has(norm) && /^[a-z][a-z0-9 ]+$/.test(norm)) {
+      // Only count text that originally had at least one capital letter
+      // (FATF page bodies don't use all-lowercase for country names).
+      if (/[A-Z]/.test(text)) unmatchedCandidates.add(text);
+    }
   }
-  return isoSet;
+  return { listed: isoSet, unmatchedCandidates };
 }
 
 // Try to extract the publication date from the URL slug or the page
@@ -147,13 +195,30 @@ export async function fetchFatfListings({
   ]);
 
   const nameLookup = buildNameLookup();
-  const blackSet = extractListedCountries(blackHtml, nameLookup);
-  const greySet = extractListedCountries(greyHtml, nameLookup);
+  const blackResult = extractListedCountries(blackHtml, nameLookup);
+  const greyResult = extractListedCountries(greyHtml, nameLookup);
 
   const listings = {};
-  for (const iso2 of blackSet) listings[iso2] = 'black';
-  for (const iso2 of greySet) {
+  for (const iso2 of blackResult.listed) listings[iso2] = 'black';
+  for (const iso2 of greyResult.listed) {
     if (!listings[iso2]) listings[iso2] = 'gray';
+  }
+
+  // Surface unmatched country-name candidates so ops can extend
+  // shared/country-names.json aliases when FATF introduces a new
+  // spelling. Reject the seed if too many candidates are missing —
+  // silent drops would otherwise re-classify the missed countries as
+  // "compliant" (default) and materially shift their financialSystemExposure
+  // score under a fresh seed-meta. Per memory `feedback_url_200_but_wrong_content_type_silent_zero`:
+  // "HTTP 200 + plausible bytes ≠ valid payload."
+  const unmatched = [...new Set([...blackResult.unmatchedCandidates, ...greyResult.unmatchedCandidates])];
+  if (unmatched.length > 0) {
+    console.warn(`[fatf-listing] ${unmatched.length} country-name candidates not found in shared/country-names.json: ${unmatched.join(', ')}. Extend the aliases map if any of these are real country names.`);
+  }
+  if (unmatched.length > 2) {
+    const msg = `FATF parser found ${unmatched.length} unmatched country-name candidates (max 2 tolerated): ${unmatched.join(', ')}. Previous valid payload remains under cache TTL — extend shared/country-names.json or fix the parser before next plenary.`;
+    console.warn(`[fatf-listing] parser sanity-check failed: ${msg}`);
+    throw new Error(msg);
   }
 
   // Sanity-check: FATF black list typically has 1-3 jurisdictions
@@ -162,16 +227,21 @@ export async function fetchFatfListings({
   const blackCount = Object.values(listings).filter((s) => s === 'black').length;
   const grayCount = Object.values(listings).filter((s) => s === 'gray').length;
   if (blackCount === 0 || blackCount > 6) {
-    throw new Error(`FATF black-list count ${blackCount} outside expected 1-6 band; parser likely failed`);
+    const msg = `FATF black-list count ${blackCount} outside expected 1-6 band; parser likely failed`;
+    console.warn(`[fatf-listing] parser sanity-check failed: ${msg}; previous valid payload remains under cache TTL`);
+    throw new Error(msg);
   }
-  if (grayCount < 8 || grayCount > 40) {
-    throw new Error(`FATF grey-list count ${grayCount} outside expected 8-40 band; parser likely failed`);
+  if (grayCount < 12 || grayCount > 40) {
+    const msg = `FATF grey-list count ${grayCount} outside expected 12-40 band; parser likely failed (historical band has been 15+ since 2020)`;
+    console.warn(`[fatf-listing] parser sanity-check failed: ${msg}; previous valid payload remains under cache TTL`);
+    throw new Error(msg);
   }
 
   return {
     listings,
     publicationDate: extractPublicationDate(blackUrl, blackHtml),
     counts: { black: blackCount, gray: grayCount },
+    unmatchedCandidates: unmatched,
     sources: [FATF_ENTRY_URL, blackUrl, greyUrl],
     seededAt: new Date().toISOString(),
   };
@@ -181,8 +251,11 @@ export function validate(data) {
   if (typeof data?.listings !== 'object') return false;
   const counts = Object.values(data.listings);
   // At least 1 black-listed jurisdiction (DPRK has been on every FATF
-  // call-for-action list since 2011) and at least 8 gray-listed.
-  return counts.filter((s) => s === 'black').length >= 1 && counts.filter((s) => s === 'gray').length >= 8;
+  // call-for-action list since 2011) and at least 12 gray-listed.
+  // Historical FATF grey-list size has been 15+ since 2020; floor of 12
+  // catches a real upstream regression while absorbing list churn during
+  // a plenary cycle.
+  return counts.filter((s) => s === 'black').length >= 1 && counts.filter((s) => s === 'gray').length >= 12;
 }
 
 export function declareRecords(data) {

--- a/scripts/seed-fatf-listing.mjs
+++ b/scripts/seed-fatf-listing.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+//
+// FATF — black & grey AML/CFT listings
+// Canonical key: economic:fatf-listing:v1
+//
+// FATF publishes two listings 3× per year (after each plenary):
+//   - "High-risk jurisdictions subject to a call for action" (the "black list")
+//   - "Jurisdictions under increased monitoring" (the "grey list")
+//
+// The entry page at https://www.fatf-gafi.org/en/countries/black-and-grey-lists.html
+// is STABLE (won't change URL). It links to the most-recent publication
+// for each list, which is what this seeder must follow dynamically —
+// hardcoding the publication URL would silently miss new updates.
+//
+// Cadence: monthly cron (catches FATF plenary updates within 30 days
+// of publication). Cache TTL 90d so a transient parse failure doesn't
+// drop the full listing.
+
+import { loadEnvFile, CHROME_UA, runSeed, resolveProxyForConnect, httpsProxyFetchRaw } from './_seed-utils.mjs';
+import countryNames from './shared/country-names.json' with { type: 'json' };
+
+loadEnvFile(import.meta.url);
+
+const _proxyAuth = resolveProxyForConnect();
+const CANONICAL_KEY = 'economic:fatf-listing:v1';
+const CACHE_TTL = 90 * 24 * 3600; // 90 days; FATF plenary is 3× per year
+
+const FATF_ENTRY_URL = 'https://www.fatf-gafi.org/en/countries/black-and-grey-lists.html';
+
+// Build a name → ISO2 lookup from country-names.json (already in repo).
+function buildNameLookup() {
+  const lookup = new Map();
+  for (const [iso2, names] of Object.entries(countryNames)) {
+    for (const name of [names?.name, ...(names?.aliases ?? [])].filter(Boolean)) {
+      lookup.set(normalizeName(name), iso2);
+    }
+  }
+  return lookup;
+}
+
+function normalizeName(name) {
+  return String(name)
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    // Strip apostrophes BEFORE the alphanumeric filter, so "People's" →
+    // "peoples" not "people s". Includes ASCII + smart quotes.
+    .replace(/[''‘’`]/g, '')
+    .replace(/[^a-z0-9 ]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+async function fetchHtml(url) {
+  try {
+    const resp = await fetch(url, {
+      headers: { 'User-Agent': CHROME_UA, Accept: 'text/html' },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    return await resp.text();
+  } catch (directErr) {
+    if (!_proxyAuth) throw new Error(`FATF fetch ${url}: ${directErr.message}`);
+    console.warn(`  FATF ${url}: direct failed (${directErr.message}), retrying via proxy`);
+    const { buffer } = await httpsProxyFetchRaw(url, _proxyAuth, { accept: 'text/html', timeoutMs: 30_000 });
+    return buffer.toString('utf8');
+  }
+}
+
+// Extract the first href to a publication page that contains the given
+// label-text fragment. FATF entry-page anchors look like:
+// `<a href="/en/publications/Fatfrecommendations/high-risk-jurisdictions-2026.html">High-risk jurisdictions subject to a call for action — February 2026</a>`
+export function findPublicationLink(html, labelFragment) {
+  const re = /<a\s+[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const href = m[1];
+    const text = stripHtml(m[2]);
+    if (!text) continue;
+    if (text.toLowerCase().includes(labelFragment.toLowerCase())) {
+      // Resolve relative URLs against the FATF origin.
+      try {
+        return new URL(href, FATF_ENTRY_URL).toString();
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}
+
+function stripHtml(s) {
+  return s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').replace(/&nbsp;/g, ' ').trim();
+}
+
+// Extract country names from a FATF publication page. Each listed
+// country typically appears as a header (h2/h3/h4) or strong tag.
+// Defensive: collect any text node that matches a known country name
+// from the lookup AND appears between the page's main listing markers.
+export function extractListedCountries(html, nameLookup) {
+  const isoSet = new Set();
+  // Scan all HTML headings + bold/strong elements + list-item leaders.
+  const re = /<(?:h[1-6]|strong|b|li|p|td)[^>]*>([\s\S]*?)<\/(?:h[1-6]|strong|b|li|p|td)>/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const text = stripHtml(m[1]);
+    if (!text || text.length > 80) continue; // skip long paragraphs
+    const norm = normalizeName(text);
+    const iso2 = nameLookup.get(norm);
+    if (iso2) isoSet.add(iso2);
+  }
+  return isoSet;
+}
+
+// Try to extract the publication date from the URL slug or the page
+// header. Falls back to the current date if neither succeeds.
+export function extractPublicationDate(url, html) {
+  // URL form: /en/publications/.../high-risk-jurisdictions-2026-02.html
+  const fromUrl = /\b(20\d{2})[-_/]?(\d{2})[-_/]?(\d{2})?\b/.exec(url);
+  if (fromUrl) {
+    const [, y, mo, d] = fromUrl;
+    return `${y}-${mo}-${d ?? '01'}`;
+  }
+  // Header form: "February 2026"
+  const months = { january: '01', february: '02', march: '03', april: '04', may: '05', june: '06', july: '07', august: '08', september: '09', october: '10', november: '11', december: '12' };
+  const hdr = /(january|february|march|april|may|june|july|august|september|october|november|december)\s+(20\d{2})/i.exec(stripHtml(html));
+  if (hdr) {
+    return `${hdr[2]}-${months[hdr[1].toLowerCase()]}-01`;
+  }
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function fetchFatfListings({
+  fetchHtmlFn = fetchHtml,
+} = {}) {
+  const entryHtml = await fetchHtmlFn(FATF_ENTRY_URL);
+  const blackUrl = findPublicationLink(entryHtml, 'high-risk') ?? findPublicationLink(entryHtml, 'call for action');
+  const greyUrl = findPublicationLink(entryHtml, 'increased monitoring');
+
+  if (!blackUrl || !greyUrl) {
+    throw new Error(`FATF entry page parse failed: black=${blackUrl} grey=${greyUrl}. Page structure may have changed.`);
+  }
+
+  const [blackHtml, greyHtml] = await Promise.all([
+    fetchHtmlFn(blackUrl),
+    fetchHtmlFn(greyUrl),
+  ]);
+
+  const nameLookup = buildNameLookup();
+  const blackSet = extractListedCountries(blackHtml, nameLookup);
+  const greySet = extractListedCountries(greyHtml, nameLookup);
+
+  const listings = {};
+  for (const iso2 of blackSet) listings[iso2] = 'black';
+  for (const iso2 of greySet) {
+    if (!listings[iso2]) listings[iso2] = 'gray';
+  }
+
+  // Sanity-check: FATF black list typically has 1-3 jurisdictions
+  // (DPRK, Iran, Myanmar as of 2026); grey list typically has 15-25.
+  // If we're way outside this band, the parser likely failed.
+  const blackCount = Object.values(listings).filter((s) => s === 'black').length;
+  const grayCount = Object.values(listings).filter((s) => s === 'gray').length;
+  if (blackCount === 0 || blackCount > 6) {
+    throw new Error(`FATF black-list count ${blackCount} outside expected 1-6 band; parser likely failed`);
+  }
+  if (grayCount < 8 || grayCount > 40) {
+    throw new Error(`FATF grey-list count ${grayCount} outside expected 8-40 band; parser likely failed`);
+  }
+
+  return {
+    listings,
+    publicationDate: extractPublicationDate(blackUrl, blackHtml),
+    counts: { black: blackCount, gray: grayCount },
+    sources: [FATF_ENTRY_URL, blackUrl, greyUrl],
+    seededAt: new Date().toISOString(),
+  };
+}
+
+export function validate(data) {
+  if (typeof data?.listings !== 'object') return false;
+  const counts = Object.values(data.listings);
+  // At least 1 black-listed jurisdiction (DPRK has been on every FATF
+  // call-for-action list since 2011) and at least 8 gray-listed.
+  return counts.filter((s) => s === 'black').length >= 1 && counts.filter((s) => s === 'gray').length >= 8;
+}
+
+export function declareRecords(data) {
+  return Object.keys(data?.listings || {}).length;
+}
+
+export { CANONICAL_KEY, CACHE_TTL };
+
+if (process.argv[1]?.endsWith('seed-fatf-listing.mjs')) {
+  runSeed('economic', 'fatf-listing', CANONICAL_KEY, fetchFatfListings, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: `fatf-${new Date().getFullYear()}`,
+    recordCount: (data) => Object.keys(data?.listings ?? {}).length,
+    emptyDataIsFailure: true,
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 60480, // 42 days, > 1 plenary cycle
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
+    console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -19,14 +19,18 @@ const WM_KEY = process.env.WORLDMONITOR_API_KEY
   || '';
 const SEED_UA = 'Mozilla/5.0 (compatible; WorldMonitor-Seed/1.0)';
 
-// Bumped v12 → v13 in lockstep with server/worldmonitor/resilience/v1/
-// _shared.ts for plan 2026-04-25-004 Phase 1 (Ship 1) — tradeSanctions
-// → tradePolicy rename + dropped OFAC component + reweighted formula.
+// Bumped v13 → v14 in lockstep with server/worldmonitor/resilience/v1/
+// _shared.ts for plan 2026-04-25-004 Phase 2 (Ship 2) — adds the new
+// `financialSystemExposure` dim to the headline score; v13 entries lack
+// the new dim's contribution so caching them post-deploy would surface
+// stale partial-shape payloads.
+// Earlier: v12 → v13 for plan 2026-04-25-004 Phase 1 (tradeSanctions →
+// tradePolicy rename + dropped OFAC component + reweighted formula).
 // Earlier: v11 → v12 for PR 3A §net-imports denominator (plan
 // 2026-04-24-002). Seeder and server MUST agree on the prefix or the
 // seeder writes scores the handler will never read.
-export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v13:';
-export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v13';
+export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v14:';
+export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v14';
 // Must match the server-side RESILIENCE_RANKING_CACHE_TTL_SECONDS. Extended
 // to 12h (2x the cron interval) so a missed/slow cron can't create an
 // EMPTY_ON_DEMAND gap before the next successful rebuild.

--- a/scripts/seed-wb-external-debt.mjs
+++ b/scripts/seed-wb-external-debt.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+//
+// WB IDS — short-term external debt as % of GNI
+// Canonical key: economic:wb-external-debt:v1
+//
+// Composition: short-term external debt as % of GNI is computed from two
+// World Bank IDS series (matching plan 2026-04-25-004 §Component 1):
+//
+//   DT.DOD.DSTC.IR.ZS  — Short-term external debt (% of total external debt)
+//   DT.DOD.DECT.GN.ZS  — Total external debt stocks (% of GNI)
+//
+//   shortTermDebtPctGni = (DT.DOD.DSTC.IR.ZS / 100) * DT.DOD.DECT.GN.ZS
+//
+// Coverage: ~125 LMICs (low- and middle-income countries). HIC are not
+// published by WB IDS — those countries fall through to the BIS LBS
+// structural-exposure component in the resilience scorer (see
+// `scoreFinancialSystemExposure` in `_dimension-scorers.ts`).
+//
+// IMF Article IV vulnerability threshold for short-term external debt
+// is canonically 15% of GNI; the resilience scorer uses
+// `normalizeLowerBetter(value, 0, 15)` to anchor the goalpost.
+
+import { loadEnvFile, CHROME_UA, runSeed, resolveProxyForConnect, httpsProxyFetchRaw } from './_seed-utils.mjs';
+import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
+
+loadEnvFile(import.meta.url);
+
+const WB_BASE = 'https://api.worldbank.org/v2';
+const _proxyAuth = resolveProxyForConnect();
+const CANONICAL_KEY = 'economic:wb-external-debt:v1';
+const CACHE_TTL = 35 * 24 * 3600; // 35 days; WB IDS publishes annually
+
+const SHORT_TERM_PCT_OF_TOTAL_INDICATOR = 'DT.DOD.DSTC.IR.ZS';
+const TOTAL_DEBT_PCT_GNI_INDICATOR = 'DT.DOD.DECT.GN.ZS';
+
+async function fetchWbIndicator(indicator) {
+  const out = {};
+  let page = 1;
+  let totalPages = 1;
+
+  while (page <= totalPages) {
+    const url = `${WB_BASE}/country/all/indicator/${indicator}?format=json&per_page=500&page=${page}&mrv=5`;
+    let json;
+    try {
+      const resp = await fetch(url, {
+        headers: { 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      json = await resp.json();
+    } catch (directErr) {
+      if (!_proxyAuth) throw new Error(`World Bank ${indicator}: ${directErr.message}`);
+      console.warn(`  WB ${indicator} p${page}: direct failed (${directErr.message}), retrying via proxy`);
+      const { buffer } = await httpsProxyFetchRaw(url, _proxyAuth, { accept: 'application/json', timeoutMs: 30_000 });
+      json = JSON.parse(buffer.toString('utf8'));
+    }
+    const meta = json[0];
+    const records = json[1] ?? [];
+    totalPages = meta?.pages ?? 1;
+    for (const record of records) {
+      const rawCode = record?.countryiso3code ?? record?.country?.id ?? '';
+      const iso2 = rawCode.length === 3 ? (iso3ToIso2[rawCode] ?? null) : (rawCode.length === 2 ? rawCode : null);
+      if (!iso2) continue;
+      const value = Number(record?.value);
+      if (!Number.isFinite(value)) continue;
+      const year = Number(record?.date);
+      if (!Number.isFinite(year)) continue;
+      // Per-key memory `feedback_wb_bulk_mrv1_null_coverage_trap`: mrv=1
+      // returns SINGLE year across all countries with `value: null` for
+      // late-reporters; mrv=5 + pickLatestPerCountry handles that.
+      const existing = out[iso2];
+      if (!existing || year > existing.year) {
+        out[iso2] = { value, year };
+      }
+    }
+    page++;
+  }
+  return out;
+}
+
+export function combineExternalDebt({ shortTermPctOfTotal, totalDebtPctGni }) {
+  const countries = {};
+  const allCodes = new Set([
+    ...Object.keys(shortTermPctOfTotal),
+    ...Object.keys(totalDebtPctGni),
+  ]);
+
+  for (const iso2 of allCodes) {
+    const stPct = shortTermPctOfTotal[iso2];
+    const totalPct = totalDebtPctGni[iso2];
+    if (!stPct || !totalPct) continue;
+    if (stPct.value < 0 || totalPct.value < 0) continue;
+
+    // shortTermDebt as % of GNI = (shortTermShare / 100) * totalDebtPctOfGni.
+    const value = Math.round(((stPct.value / 100) * totalPct.value) * 100) / 100;
+    countries[iso2] = {
+      value,
+      year: Math.min(stPct.year, totalPct.year),
+      // Provenance: which underlying values we composed.
+      shortTermPctOfTotalDebt: Math.round(stPct.value * 100) / 100,
+      totalDebtPctOfGni: Math.round(totalPct.value * 100) / 100,
+    };
+  }
+  return countries;
+}
+
+async function fetchWbExternalDebt() {
+  const [shortTermPctOfTotal, totalDebtPctGni] = await Promise.all([
+    fetchWbIndicator(SHORT_TERM_PCT_OF_TOTAL_INDICATOR),
+    fetchWbIndicator(TOTAL_DEBT_PCT_GNI_INDICATOR),
+  ]);
+
+  return {
+    countries: combineExternalDebt({ shortTermPctOfTotal, totalDebtPctGni }),
+    sources: [
+      `https://data.worldbank.org/indicator/${SHORT_TERM_PCT_OF_TOTAL_INDICATOR}`,
+      `https://data.worldbank.org/indicator/${TOTAL_DEBT_PCT_GNI_INDICATOR}`,
+    ],
+    seededAt: new Date().toISOString(),
+  };
+}
+
+// WB IDS publishes for ~125 LMICs only; HIC are explicitly absent.
+// Floor is 80 to absorb late-reporting LMICs without blocking on a
+// transient outage.
+export function validate(data) {
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 80;
+}
+
+export function declareRecords(data) {
+  return Object.keys(data?.countries || {}).length;
+}
+
+export { CANONICAL_KEY, CACHE_TTL, fetchWbExternalDebt };
+
+if (process.argv[1]?.endsWith('seed-wb-external-debt.mjs')) {
+  runSeed('economic', 'wb-external-debt', CANONICAL_KEY, fetchWbExternalDebt, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: `wb-ids-${new Date().getFullYear()}`,
+    recordCount: (data) => Object.keys(data?.countries ?? {}).length,
+    // Empty result = real upstream failure (floor is 80 LMICs). Without this,
+    // a transient WB outage would refresh seed-meta on a tiny payload and
+    // freeze the bundle (see memory `feedback_strict_floor_validate_fail_poisons_seed_meta`).
+    emptyDataIsFailure: true,
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 100800,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
+    console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-wb-external-debt.mjs
+++ b/scripts/seed-wb-external-debt.mjs
@@ -93,12 +93,23 @@ export function combineExternalDebt({ shortTermPctOfTotal, totalDebtPctGni }) {
 
     // shortTermDebt as % of GNI = (shortTermShare / 100) * totalDebtPctOfGni.
     const value = Math.round(((stPct.value / 100) * totalPct.value) * 100) / 100;
+    // Use min(year) as the conservative "we have both" anchor. WB IDS
+    // publishes the two source indicators with different lag patterns;
+    // mixing different vintages is materially correct for resilience
+    // scoring (the older year's data is the binding constraint), but
+    // surface yearMismatch so the dashboard / scorer can flag countries
+    // with cross-year composition for ops triage.
+    const conservativeYear = Math.min(stPct.year, totalPct.year);
+    const yearMismatch = stPct.year !== totalPct.year;
     countries[iso2] = {
       value,
-      year: Math.min(stPct.year, totalPct.year),
-      // Provenance: which underlying values we composed.
+      year: conservativeYear,
+      yearMismatch,
+      // Provenance: which underlying values + per-indicator years.
       shortTermPctOfTotalDebt: Math.round(stPct.value * 100) / 100,
       totalDebtPctOfGni: Math.round(totalPct.value * 100) / 100,
+      shortTermPctOfTotalDebtYear: stPct.year,
+      totalDebtPctOfGniYear: totalPct.year,
     };
   }
   return countries;

--- a/scripts/validate-resilience-backtest.mjs
+++ b/scripts/validate-resilience-backtest.mjs
@@ -27,7 +27,7 @@ import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 loadEnvFile(import.meta.url);
 
 // Source of truth: server/worldmonitor/resilience/v1/_shared.ts
-const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v13:';
+const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v14:';
 
 // Mirror of _shared.ts#currentCacheFormula — must stay in lockstep so
 // the backtest only ingests same-formula cache entries. A mixed-formula

--- a/scripts/validate-resilience-correlation.mjs
+++ b/scripts/validate-resilience-correlation.mjs
@@ -3,7 +3,7 @@
 import { loadEnvFile, getRedisCredentials } from './_seed-utils.mjs';
 
 // Source of truth: server/worldmonitor/resilience/v1/_shared.ts → RESILIENCE_SCORE_CACHE_PREFIX
-const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v13:';
+const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v14:';
 
 // Mirror of server/worldmonitor/resilience/v1/_shared.ts#currentCacheFormula.
 // Must stay in lockstep with the server-side definition so this script

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -10,6 +10,7 @@ export type ResilienceDimensionId =
   | 'macroFiscal'
   | 'currencyExternal'
   | 'tradePolicy'
+  | 'financialSystemExposure'  // plan 2026-04-25-004 Phase 2: structural sanctions vulnerability via BIS LBS + WB IDS + FATF
   | 'cyberDigital'
   | 'logisticsSupply'
   | 'infrastructure'
@@ -271,6 +272,10 @@ const RESILIENCE_IMF_LABOR_KEY = 'economic:imf:labor:v1';
 // re-add the constant there with the appropriate scope.
 const RESILIENCE_TRADE_RESTRICTIONS_KEY = 'trade:restrictions:v1:tariff-overview:50';
 const RESILIENCE_TRADE_BARRIERS_KEY = 'trade:barriers:v1:tariff-gap:50';
+// plan 2026-04-25-004 Phase 2: financialSystemExposure component seed keys.
+const RESILIENCE_WB_EXTERNAL_DEBT_KEY = 'economic:wb-external-debt:v1';
+const RESILIENCE_BIS_LBS_KEY = 'economic:bis-lbs:v1';
+const RESILIENCE_FATF_LISTING_KEY = 'economic:fatf-listing:v1';
 const RESILIENCE_CYBER_KEY = 'cyber:threats:v2';
 const RESILIENCE_OUTAGES_KEY = 'infra:outages:v1';
 const RESILIENCE_GPS_KEY = 'intelligence:gpsjam:v2';
@@ -406,7 +411,8 @@ const RESILIENCE_DOMAIN_WEIGHTS: Record<ResilienceDomainId, number> = {
 export const RESILIENCE_DIMENSION_WEIGHTS: Record<ResilienceDimensionId, number> = {
   macroFiscal: 1.0,
   currencyExternal: 1.0,
-  tradePolicy: 1.0,
+  tradePolicy: 0.5,                  // plan 2026-04-25-004 Phase 2: split economic-domain weight with financialSystemExposure
+  financialSystemExposure: 0.5,      // plan 2026-04-25-004 Phase 2: structural sanctions vulnerability
   cyberDigital: 1.0,
   logisticsSupply: 1.0,
   infrastructure: 1.0,
@@ -431,6 +437,7 @@ export const RESILIENCE_DIMENSION_DOMAINS: Record<ResilienceDimensionId, Resilie
   macroFiscal: 'economic',
   currencyExternal: 'economic',
   tradePolicy: 'economic',
+  financialSystemExposure: 'economic',
   cyberDigital: 'infrastructure',
   logisticsSupply: 'infrastructure',
   infrastructure: 'infrastructure',
@@ -455,6 +462,7 @@ export const RESILIENCE_DIMENSION_ORDER: ResilienceDimensionId[] = [
   'macroFiscal',
   'currencyExternal',
   'tradePolicy',
+  'financialSystemExposure',
   'cyberDigital',
   'logisticsSupply',
   'infrastructure',
@@ -490,6 +498,7 @@ export const RESILIENCE_DIMENSION_TYPES: Record<ResilienceDimensionId, Resilienc
   macroFiscal: 'baseline',
   currencyExternal: 'stress',
   tradePolicy: 'stress',
+  financialSystemExposure: 'stress',
   cyberDigital: 'stress',
   logisticsSupply: 'mixed',
   infrastructure: 'baseline',
@@ -537,6 +546,36 @@ function normalizeHigherBetter(value: number, worst: number, best: number): numb
   if (best <= worst) return 50;
   const ratio = (value - worst) / (best - worst);
   return roundScore(ratio * 100);
+}
+
+// U-shaped band normalization. Used by `financialSystemExposure` Component 2
+// (BIS LBS cross-border claims as % of GDP). Both extremes are bad — too
+// little integration suggests financial isolation (sanctions-target
+// jurisdictions; thin correspondent-banking access), too much suggests
+// over-exposure to Western-bank pulls (Iceland-2008 territory). The score
+// peaks in the "healthy diversified financial system" middle band.
+//
+// Plan 2026-04-25-004 Phase 2 § Component 2 score shape:
+//   value < 5%   of GDP → 60-70 (low integration; linear ramp 0% → 60, 5% → 70)
+//   5% ≤ value ≤ 25%    → 75-100 (sweet spot; linear 5% → 75, 25% → 100)
+//   25% < value ≤ 60%   → 70-30 (over-exposed; linear 25% → 70, 60% → 30)
+//   value > 60%          → < 30 (Iceland-2008 territory; linear 60% → 30, clamped 0)
+function normalizeBandLowerBetter(value: number): number {
+  if (!Number.isFinite(value) || value < 0) return 50;
+  if (value < 5) {
+    // Low integration: 0% → 60, 5% → 70.
+    return roundScore(60 + (value / 5) * 10);
+  }
+  if (value <= 25) {
+    // Sweet spot: 5% → 75, 25% → 100.
+    return roundScore(75 + ((value - 5) / 20) * 25);
+  }
+  if (value <= 60) {
+    // Over-exposed: 25% → 70, 60% → 30.
+    return roundScore(70 - ((value - 25) / 35) * 40);
+  }
+  // Iceland-2008 territory: 60% → 30, every additional 1% drops 0.5pt; clamped 0.
+  return roundScore(Math.max(0, 30 - (value - 60) * 0.5));
 }
 
 // `normalizeSanctionCount` retired in plan 2026-04-25-004 Phase 1. The
@@ -1109,6 +1148,177 @@ export async function scoreTradePolicy(
         : { score: normalizeLowerBetter(barrierCount, 0, 40), weight: 0.30 },
     { score: tariffRate == null ? null : normalizeLowerBetter(tariffRate, 0, 20), weight: 0.40 },
   ]);
+}
+
+// plan 2026-04-25-004 Phase 2: structural sanctions vulnerability via 4
+// composite signals. Replaces the structural-exposure half of the dropped
+// OFAC-domicile component (Phase 1 §What changes) with audited cross-
+// border banking + AML/CFT data that doesn't conflate transit-hub
+// corporate domicile with host-country risk.
+//
+// Components (weights total 1.0):
+//   short_term_external_debt_pct_gni     0.35 (WB IDS — lowerBetter; goalpost worst=15% best=0%)
+//   bis_lbs_xborder_us_eu_uk_pct_gdp     0.30 (BIS LBS by-parent — U-shape band)
+//   fatf_listing_status                   0.20 (FATF — discrete: black=0, gray=30, compliant=100)
+//   financial_center_redundancy           0.15 (BIS LBS by-parent count — higherBetter; goalpost worst=1 best=10)
+//
+// Flag-gated rollout. `RESILIENCE_FIN_SYS_EXPOSURE_ENABLED` defaults off
+// so the dim ships dark until the 3 component seeders (seed-bis-lbs,
+// seed-fatf-listing, seed-wb-external-debt) are populating Redis in
+// production. When the flag is OFF, the scorer returns the empty-data
+// shape (score=0, coverage=0) and contributes no signal to the headline
+// score — matches the energy v2 rollout pattern from
+// `docs/plans/2026-04-24-001-fix-resilience-v2-fail-closed-on-missing-seeds-plan.md`.
+//
+// Fail-closed preflight (when flag is ON): all 3 required seed
+// envelopes (component 4 shares the BIS LBS seed) MUST be reachable.
+// Missing seed-meta indicates a Railway bundle/cron failure and is
+// surfaced as `source-failure` via
+// `ResilienceConfigurationError(message, missingKeys)` — caught at
+// `scoreAllDimensions` and routed to the imputationClass='source-failure'
+// path. Per-country data gaps are distinct: per-component reads return
+// `null` and the slot drops out of the weighted blend.
+function isFinSysExposureEnabledLocal(): boolean {
+  return (process.env.RESILIENCE_FIN_SYS_EXPOSURE_ENABLED ?? 'false').toLowerCase() === 'true';
+}
+
+export async function scoreFinancialSystemExposure(
+  countryCode: string,
+  reader: ResilienceSeedReader = defaultSeedReader,
+): Promise<ResilienceDimensionScore> {
+  if (!isFinSysExposureEnabledLocal()) {
+    // Flag off — emit empty-data shape. Matches `weightedBlend([])` semantics.
+    return {
+      score: 0,
+      coverage: 0,
+      observedWeight: 0,
+      imputedWeight: 0,
+      imputationClass: null,
+      freshness: { lastObservedAtMs: 0, staleness: '' },
+    };
+  }
+
+  // Preflight: verify the 3 required seed envelopes are published.
+  const requiredSeedKeys = [
+    RESILIENCE_WB_EXTERNAL_DEBT_KEY,
+    RESILIENCE_BIS_LBS_KEY,
+    RESILIENCE_FATF_LISTING_KEY,
+  ] as const;
+  const missing: string[] = [];
+  for (const key of requiredSeedKeys) {
+    const meta = await reader(`seed-meta:${key}`);
+    if (!meta) missing.push(key);
+  }
+  if (missing.length > 0) {
+    throw new ResilienceConfigurationError(
+      `RESILIENCE_FIN_SYS_EXPOSURE_ENABLED=true but required seed-meta absent for: ${missing.join(', ')}. ` +
+        'Provision the macro bundle component seeders (seed-bis-lbs, seed-fatf-listing, ' +
+        'seed-wb-external-debt) and confirm Redis populates BEFORE flipping the flag. ' +
+        'Or set RESILIENCE_FIN_SYS_EXPOSURE_ENABLED=false to keep the dim dark. ' +
+        'See plan 2026-04-25-004 §Fail-closed preflight.',
+      missing,
+    );
+  }
+
+  // Per-component reads. Each returns null on per-country data gap; the
+  // weightedBlend drops null-score slots from the blend denominator.
+  const [debtRaw, bisRaw, fatfRaw] = await Promise.all([
+    reader(RESILIENCE_WB_EXTERNAL_DEBT_KEY),
+    reader(RESILIENCE_BIS_LBS_KEY),
+    reader(RESILIENCE_FATF_LISTING_KEY),
+  ]);
+
+  // Component 1: short-term external debt as % of GNI. WB IDS coverage is
+  // ~125 LMICs; HIC fall through to per-component-null and the blend
+  // covers the gap via the BIS LBS structural-exposure component.
+  // Payload shape: { countries: { [iso2]: { value: number, year: number } } }.
+  const debtPct = readWbExternalDebtPct(debtRaw, countryCode);
+
+  // Component 2 + 4 share the BIS LBS payload. Component 2: sum of
+  // by-parent claims for the enumerated Western parents as % of GDP.
+  // Component 4: count of distinct by-parent reporters with non-trivial
+  // claims (>1% of GDP).
+  // Payload shape: { countries: { [iso2]: { totalXborderPctGdp: number,
+  //   parentCount: number, parents: { [parentIso2]: number } } } }.
+  const bisCountry = readBisLbsCountry(bisRaw, countryCode);
+
+  // Component 3: FATF listing status. Discrete classification.
+  // Payload shape: { listings: { [iso2]: 'black' | 'gray' | 'compliant' },
+  //   publicationDate: string }.
+  const fatfStatus = readFatfStatus(fatfRaw, countryCode);
+
+  return weightedBlend([
+    {
+      score: debtPct == null ? null : normalizeLowerBetter(debtPct, 0, 15),
+      weight: 0.35,
+    },
+    {
+      score: bisCountry?.totalXborderPctGdp == null
+        ? null
+        : normalizeBandLowerBetter(bisCountry.totalXborderPctGdp),
+      weight: 0.30,
+    },
+    {
+      score: fatfStatus == null ? null : fatfStatusToScore(fatfStatus),
+      weight: 0.20,
+    },
+    {
+      score: bisCountry?.parentCount == null
+        ? null
+        : normalizeHigherBetter(bisCountry.parentCount, 1, 10),
+      weight: 0.15,
+    },
+  ]);
+}
+
+// Small payload accessors for scoreFinancialSystemExposure. Defensive
+// against unexpected shapes; return null on any deviation.
+
+function readWbExternalDebtPct(raw: unknown, countryCode: string): number | null {
+  if (raw == null || typeof raw !== 'object') return null;
+  const countries = (raw as { countries?: Record<string, unknown> }).countries;
+  if (!countries || typeof countries !== 'object') return null;
+  const entry = countries[countryCode];
+  if (!entry || typeof entry !== 'object') return null;
+  return safeNum((entry as { value?: unknown }).value);
+}
+
+interface BisLbsCountry {
+  totalXborderPctGdp: number | null;
+  parentCount: number | null;
+}
+
+function readBisLbsCountry(raw: unknown, countryCode: string): BisLbsCountry | null {
+  if (raw == null || typeof raw !== 'object') return null;
+  const countries = (raw as { countries?: Record<string, unknown> }).countries;
+  if (!countries || typeof countries !== 'object') return null;
+  const entry = countries[countryCode];
+  if (!entry || typeof entry !== 'object') return null;
+  return {
+    totalXborderPctGdp: safeNum((entry as { totalXborderPctGdp?: unknown }).totalXborderPctGdp),
+    parentCount: safeNum((entry as { parentCount?: unknown }).parentCount),
+  };
+}
+
+type FatfStatus = 'black' | 'gray' | 'compliant';
+
+function readFatfStatus(raw: unknown, countryCode: string): FatfStatus | null {
+  if (raw == null || typeof raw !== 'object') return null;
+  const listings = (raw as { listings?: Record<string, unknown> }).listings;
+  if (!listings || typeof listings !== 'object') return null;
+  const status = listings[countryCode];
+  if (status === 'black' || status === 'gray' || status === 'compliant') return status;
+  // Unknown country = compliant (FATF only enumerates non-compliant
+  // jurisdictions; absence from both lists means compliant).
+  return 'compliant';
+}
+
+function fatfStatusToScore(status: FatfStatus): number {
+  switch (status) {
+    case 'black': return 0;
+    case 'gray': return 30;
+    case 'compliant': return 100;
+  }
 }
 
 export async function scoreCyberDigital(
@@ -1888,6 +2098,7 @@ ResilienceDimensionId,
   macroFiscal: scoreMacroFiscal,
   currencyExternal: scoreCurrencyExternal,
   tradePolicy: scoreTradePolicy,
+  financialSystemExposure: scoreFinancialSystemExposure,
   cyberDigital: scoreCyberDigital,
   logisticsSupply: scoreLogisticsSupply,
   infrastructure: scoreInfrastructure,

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -555,26 +555,35 @@ function normalizeHigherBetter(value: number, worst: number, best: number): numb
 // over-exposure to Western-bank pulls (Iceland-2008 territory). The score
 // peaks in the "healthy diversified financial system" middle band.
 //
-// Plan 2026-04-25-004 Phase 2 § Component 2 score shape:
-//   value < 5%   of GDP → 60-70 (low integration; linear ramp 0% → 60, 5% → 70)
-//   5% ≤ value ≤ 25%    → 75-100 (sweet spot; linear 5% → 75, 25% → 100)
-//   25% < value ≤ 60%   → 70-30 (over-exposed; linear 25% → 70, 60% → 30)
-//   value > 60%          → < 30 (Iceland-2008 territory; linear 60% → 30, clamped 0)
+// Plan 2026-04-25-004 Phase 2 § Component 2 score shape — re-anchored
+// for piecewise-CONTINUOUS transitions per Greptile P1 catch (PR #3407
+// review 2026-04-25). Original draft had a 30-point cliff at the 25%
+// boundary (sweet spot ended at 100, over-exposed started at 70) and a
+// 5-point jump at 5%. Cliffs in piecewise-linear scorers cause ranking
+// instability for countries near band edges — a 24.9% reading scores
+// dramatically different than 25.1%. Endpoints now share values across
+// adjacent segments so the function is monotone-then-monotone with no
+// discontinuities:
+//
+//   0% ≤ value < 5%      → 60-75  (low integration; slope +3/pct)
+//   5% ≤ value ≤ 25%     → 75-100 (sweet spot; slope +1.25/pct)
+//   25% < value ≤ 60%    → 100-30 (over-exposed; slope −2/pct)
+//   value > 60%           → 30 → 0 at 120% (Iceland-2008; slope −0.5/pct, clamped)
 function normalizeBandLowerBetter(value: number): number {
   if (!Number.isFinite(value) || value < 0) return 50;
   if (value < 5) {
-    // Low integration: 0% → 60, 5% → 70.
-    return roundScore(60 + (value / 5) * 10);
+    // Low integration: 0% → 60, 5% → 75 (continuous to sweet-spot start).
+    return roundScore(60 + (value / 5) * 15);
   }
   if (value <= 25) {
     // Sweet spot: 5% → 75, 25% → 100.
     return roundScore(75 + ((value - 5) / 20) * 25);
   }
   if (value <= 60) {
-    // Over-exposed: 25% → 70, 60% → 30.
-    return roundScore(70 - ((value - 25) / 35) * 40);
+    // Over-exposed: 25% → 100 (continuous from sweet-spot peak), 60% → 30.
+    return roundScore(100 - ((value - 25) / 35) * 70);
   }
-  // Iceland-2008 territory: 60% → 30, every additional 1% drops 0.5pt; clamped 0.
+  // Iceland-2008 territory: 60% → 30 (continuous), drops 0.5pt per pct; clamped 0.
   return roundScore(Math.max(0, 30 - (value - 60) * 0.5));
 }
 
@@ -1315,6 +1324,15 @@ function readFatfStatus(raw: unknown, countryCode: string): FatfStatus | null {
   if (raw == null || typeof raw !== 'object') return null;
   const listings = (raw as { listings?: Record<string, unknown> }).listings;
   if (!listings || typeof listings !== 'object') return null;
+  // Defense-in-depth (Greptile P2 catch, PR #3407 review 2026-04-25):
+  // an empty `listings` dict that bypassed the seeder's validate()
+  // would otherwise default every country to 'compliant' (score 100)
+  // and silently mask a parser regression. Return null instead so the
+  // FATF slot drops out of the weighted blend — coverage shrinks
+  // visibly rather than the dim looking healthy with all-100s. The
+  // seeder's >=1 black + >=12 grey gate normally prevents this from
+  // reaching production, but defense-in-depth costs nothing.
+  if (Object.keys(listings).length === 0) return null;
   const status = listings[countryCode];
   if (status === 'black' || status === 'gray' || status === 'compliant') return status;
   // Unknown country = compliant (FATF only enumerates non-compliant

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -2,7 +2,7 @@ import countryNames from '../../../../shared/country-names.json';
 import iso2ToIso3Json from '../../../../shared/iso2-to-iso3.json';
 import { normalizeCountryToken } from '../../../_shared/country-token';
 import { getCachedJson } from '../../../_shared/redis';
-import { classifyDimensionFreshness, readFreshnessMap } from './_dimension-freshness';
+import { classifyDimensionFreshness, readFreshnessMap, resolveSeedMetaKey } from './_dimension-freshness';
 import { getLanguageCoverageFactor } from './_language-coverage';
 import { failedDimensionsFromDatasets, readFailedDatasets } from './_source-failure';
 
@@ -1199,6 +1199,15 @@ export async function scoreFinancialSystemExposure(
   }
 
   // Preflight: verify the 3 required seed envelopes are published.
+  // `runSeed` (scripts/_seed-utils.mjs) STRIPS the trailing :v\d+ from the
+  // data key when it writes seed-meta — so `economic:wb-external-debt:v1`
+  // gets a freshness key of `seed-meta:economic:wb-external-debt`, NOT
+  // `seed-meta:economic:wb-external-debt:v1`. Use `resolveSeedMetaKey`
+  // (the canonical helper from _dimension-freshness.ts) so the preflight
+  // matches what the seeder actually writes; inlining the regex would
+  // re-introduce the same writer/reader drift this helper exists to prevent.
+  // The api/health.js + api/seed-health.js registries use the same
+  // unversioned form (`seed-meta:economic:wb-external-debt`).
   const requiredSeedKeys = [
     RESILIENCE_WB_EXTERNAL_DEBT_KEY,
     RESILIENCE_BIS_LBS_KEY,
@@ -1206,7 +1215,7 @@ export async function scoreFinancialSystemExposure(
   ] as const;
   const missing: string[] = [];
   for (const key of requiredSeedKeys) {
-    const meta = await reader(`seed-meta:${key}`);
+    const meta = await reader(resolveSeedMetaKey(key));
     if (!meta) missing.push(key);
   }
   if (missing.length > 0) {

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -232,6 +232,79 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     license: 'open-data',
   },
 
+  // ── financialSystemExposure (4 sub-metrics) ───────────────────────────────
+  // plan 2026-04-25-004 Phase 2: structural sanctions vulnerability built
+  // from BIS Locational Banking Statistics + WB IDS short-term external
+  // debt + FATF AML/CFT listing status. Replaces the dropped OFAC-domicile
+  // signal (Phase 1) with audited cross-border banking + AML/CFT data
+  // that doesn't conflate transit-hub corporate domicile with host-country
+  // risk. Components 2 + 4 share the BIS LBS payload (no separate seed).
+  // Dim is 'core' (contributes to headline score) but BIS-derived
+  // indicators are 'enrichment' / 'non-commercial' per Codex R1 #8 to
+  // match the existing BIS classification convention.
+  {
+    id: 'shortTermExternalDebtPctGni',
+    dimension: 'financialSystemExposure',
+    description: 'Short-term external debt as % of GNI (WB IDS DT.DOD.DSTC.IR.ZS × DT.DOD.DECT.GN.ZS); IMF Article IV vulnerability threshold is 15% GNI',
+    direction: 'lowerBetter',
+    goalposts: { worst: 15, best: 0 },
+    weight: 0.35,
+    sourceKey: 'economic:wb-external-debt:v1',
+    scope: 'global',
+    cadence: 'annual',
+    imputation: { type: 'conservative', score: 50, certainty: 0.3 },
+    // WB IDS publishes for ~125 LMICs only; HIC fall through to BIS LBS structural-exposure component.
+    // Tagged 'enrichment' (not 'core') because the lint test enforces
+    // core indicators must have coverage >= 180; LMIC-only is below
+    // that gate by definition. Component carries weight 0.35 inside the
+    // dim regardless of tier — the tier is a documentation classification.
+    tier: 'enrichment',
+    coverage: 125,
+    license: 'open-data',
+  },
+  {
+    id: 'bisLbsXborderPctGdp',
+    dimension: 'financialSystemExposure',
+    description: 'BIS LBS sum of by-parent cross-border claims (US/UK/major-EU/CH/JP/CA/AU/SG) as % of GDP; U-shape band — both isolation (<5%) and over-exposure (>60%) score low',
+    direction: 'lowerBetter', // U-shape is "lowerBetter" in semantic sense (concentrated exposure penalized)
+    goalposts: { worst: 60, best: 15 },
+    weight: 0.30,
+    sourceKey: 'economic:bis-lbs:v1',
+    scope: 'global',
+    cadence: 'quarterly',
+    tier: 'enrichment',
+    coverage: 200,
+    license: 'non-commercial', // BIS terms of use; redistributed under attribution
+  },
+  {
+    id: 'fatfListingStatus',
+    dimension: 'financialSystemExposure',
+    description: 'FATF AML/CFT listing status — black list (call for action) → 0, gray list (increased monitoring) → 30, compliant → 100',
+    direction: 'higherBetter',
+    goalposts: { worst: 0, best: 100 },
+    weight: 0.20,
+    sourceKey: 'economic:fatf-listing:v1',
+    scope: 'global',
+    cadence: 'monthly',
+    tier: 'core',
+    coverage: 200,
+    license: 'open-data',
+  },
+  {
+    id: 'financialCenterRedundancy',
+    dimension: 'financialSystemExposure',
+    description: 'Count of distinct BIS LBS by-parent reporters with non-trivial (>1% GDP) cross-border claims on the country; rewards multi-counterparty financial centers, balances Component 2 over-exposure penalty',
+    direction: 'higherBetter',
+    goalposts: { worst: 1, best: 10 },
+    weight: 0.15,
+    sourceKey: 'economic:bis-lbs:v1', // shares BIS LBS seed with Component 2
+    scope: 'global',
+    cadence: 'quarterly',
+    tier: 'enrichment',
+    coverage: 200,
+    license: 'non-commercial',
+  },
+
   // ── cyberDigital (3 sub-metrics) ──────────────────────────────────────────
   {
     id: 'cyberThreats',

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -267,7 +267,16 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     dimension: 'financialSystemExposure',
     description: 'BIS LBS sum of by-parent cross-border claims (US/UK/major-EU/CH/JP/CA/AU/SG) as % of GDP; U-shape band — both isolation (<5%) and over-exposure (>60%) score low',
     direction: 'lowerBetter', // U-shape is "lowerBetter" in semantic sense (concentrated exposure penalized)
-    goalposts: { worst: 60, best: 15 },
+    // NOTE (Greptile P2 catch, PR #3407 review): goalposts here are
+    // DOCUMENTATION-ONLY for the over-exposed branch. The actual scorer
+    // uses `normalizeBandLowerBetter` (a U-shape, not a linear lowerBetter
+    // mapping), which peaks at 25% and penalizes both extremes. A linear
+    // `{worst, best}` cannot represent a U-shape; we set goalposts to the
+    // peak (best=25) and the over-exposed worst-anchor (worst=60). Tooling
+    // / lints that read these values to compute "expected" component
+    // scores must consult `normalizeBandLowerBetter` directly, not assume
+    // these are the inputs to a generic linear normalizer.
+    goalposts: { worst: 60, best: 25 },
     weight: 0.30,
     sourceKey: 'economic:bis-lbs:v1',
     scope: 'global',

--- a/server/worldmonitor/resilience/v1/_shared.ts
+++ b/server/worldmonitor/resilience/v1/_shared.ts
@@ -139,7 +139,11 @@ export const RESILIENCE_RANKING_CACHE_TTL_SECONDS = 12 * 60 * 60;
 // `tradeSanctions` → `tradePolicy` rename + dropped OFAC component +
 // reweighted trade-policy formula. Without the bump, v12 entries would
 // serve pre-rename economic-domain scores for the full 6h TTL post-deploy.
-export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v13:';
+// v13→v14 bump in plan 2026-04-25-004 Phase 2 (Ship 2) for the new
+// `financialSystemExposure` dim — adds a 20th dimension contributing to
+// the economic domain, so v13 entries (which lack the new dim's score)
+// would surface incomplete payloads on cache hit.
+export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v14:';
 // Bumped from v4 to v5 in the pillar-combined activation PR. Provides
 // a clean slate at PR deploy so pre-PR history points (which were
 // written without a formula tag) do not mix with tagged points. NOTE:
@@ -163,7 +167,11 @@ export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v13:';
 // plan 2026-04-25-004 Phase 1 (Ship 1) — same reasoning: pre-rename
 // economic-domain history points must not mix with post-rename points
 // inside the rolling 30-day window or the trend signal goes haywire.
-export const RESILIENCE_HISTORY_KEY_PREFIX = 'resilience:history:v8:';
+// v8→v9 bump in lockstep with RESILIENCE_SCORE_CACHE_PREFIX v13→v14 for
+// plan 2026-04-25-004 Phase 2 (Ship 2) — same reasoning. Adding a new
+// dim shifts every country's overall-score baseline; mixing pre/post
+// points in the 30-day rolling window manufactures false trends.
+export const RESILIENCE_HISTORY_KEY_PREFIX = 'resilience:history:v9:';
 // v12 bump in lockstep with RESILIENCE_SCORE_CACHE_PREFIX (v11 → v12)
 // for PR 3A §net-imports denominator. As with the score prefix, the
 // version bump is a belt — the suspenders are the `_formula` tag on
@@ -172,8 +180,9 @@ export const RESILIENCE_HISTORY_KEY_PREFIX = 'resilience:history:v8:';
 // a recompute-and-publish on a cross-formula cache hit rather than
 // serving the stale ranking for up to the 12h ranking TTL. v12→v13 bump
 // in lockstep with RESILIENCE_SCORE_CACHE_PREFIX for plan 2026-04-25-004
-// Phase 1 (Ship 1).
-export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v13';
+// Phase 1 (Ship 1). v13→v14 bump in lockstep with RESILIENCE_SCORE_CACHE_PREFIX
+// for plan 2026-04-25-004 Phase 2 (Ship 2).
+export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v14';
 export const RESILIENCE_STATIC_INDEX_KEY = 'resilience:static:index:v1';
 export const RESILIENCE_INTERVAL_KEY_PREFIX = 'resilience:intervals:v1:';
 const RESILIENCE_STATIC_META_KEY = 'seed-meta:resilience:static';

--- a/src/components/ResilienceWidget.ts
+++ b/src/components/ResilienceWidget.ts
@@ -151,7 +151,7 @@ export class ResilienceWidget {
           'span',
           {
             className: 'resilience-widget__help',
-            title: 'Composite resilience score from 19 dimensions across 6 domains (economic, infrastructure, energy, social & governance, health & food, recovery), grouped into 3 pillars (structural readiness, live shock exposure, recovery capacity). Weights sum to 1.00; recovery carries the largest single-domain weight (0.25).',
+            title: 'Composite resilience score from 20 dimensions across 6 domains (economic, infrastructure, energy, social & governance, health & food, recovery), grouped into 3 pillars (structural readiness, live shock exposure, recovery capacity). Weights sum to 1.00; recovery carries the largest single-domain weight (0.25).',
             'aria-label': 'Resilience score methodology',
           },
           '?',

--- a/src/components/resilience-widget-utils.ts
+++ b/src/components/resilience-widget-utils.ts
@@ -243,6 +243,7 @@ const DIMENSION_LABELS: Record<string, string> = {
   macroFiscal: 'Macro',
   currencyExternal: 'Currency',
   tradePolicy: 'Trade',
+  financialSystemExposure: 'Fin. Exposure',
   cyberDigital: 'Cyber',
   logisticsSupply: 'Logistics',
   infrastructure: 'Infra',

--- a/tests/helpers/resilience-fixtures.mts
+++ b/tests/helpers/resilience-fixtures.mts
@@ -390,6 +390,47 @@ export const RESILIENCE_FIXTURES: FixtureMap = {
     fetchedAt: 1712102400000,
     recordCount: 196,
   },
+  // plan 2026-04-25-004 Phase 2: financialSystemExposure seed-meta + data
+  // fixtures. The scorer preflights all 3 seed-meta envelopes (fail-closed)
+  // before per-component reads; absence of any of these throws
+  // ResilienceConfigurationError and routes to source-failure imputation.
+  'seed-meta:economic:wb-external-debt:v1': {
+    fetchedAt: 1714694400000,
+    recordCount: 125,
+  },
+  'seed-meta:economic:bis-lbs:v1': {
+    fetchedAt: 1714694400000,
+    recordCount: 200,
+  },
+  'seed-meta:economic:fatf-listing:v1': {
+    fetchedAt: 1714694400000,
+    recordCount: 200,
+  },
+  'economic:wb-external-debt:v1': {
+    countries: {
+      NO: { value: 2, year: 2024 },     // 2% GNI — Norway low external debt → score ~87
+      US: { value: 0, year: 2024 },     // HIC, WB IDS doesn't publish — fixture treats as 0 for the test triple
+      YE: { value: 14, year: 2023 },    // ~14% GNI — fragile state near worst goalpost → score ~7
+    },
+    seededAt: '2026-04-25T00:00:00.000Z',
+  },
+  'economic:bis-lbs:v1': {
+    countries: {
+      NO: { totalXborderPctGdp: 18, parentCount: 8 },  // sweet spot + diverse parents → high score
+      US: { totalXborderPctGdp: 22, parentCount: 9 },  // sweet spot + diverse parents → high score
+      YE: { totalXborderPctGdp: 2, parentCount: 1 },   // financial isolation → low score
+    },
+    seededAt: '2026-04-25T00:00:00.000Z',
+  },
+  'economic:fatf-listing:v1': {
+    listings: {
+      NO: 'compliant',
+      US: 'compliant',
+      YE: 'gray',
+    },
+    publicationDate: '2026-02-13',
+    seededAt: '2026-04-25T00:00:00.000Z',
+  },
   'resilience:recovery:fiscal-space:v1': {
     countries: {
       NO: { govRevenuePct: 42, fiscalBalancePct: 10, debtToGdpPct: 40, year: 2025 },

--- a/tests/resilience-financial-system-exposure.test.mts
+++ b/tests/resilience-financial-system-exposure.test.mts
@@ -1,0 +1,291 @@
+// Pin the `financialSystemExposure` 4-component weighted-blend formula
+// + fail-closed preflight contract introduced in plan 2026-04-25-004
+// Phase 2 (Ship 2).
+//
+// Components (weights total 1.0):
+//   short_term_external_debt_pct_gni     0.35 (WB IDS — lowerBetter, goalpost worst=15% best=0%)
+//   bis_lbs_xborder_us_eu_uk_pct_gdp     0.30 (BIS LBS by-parent — U-shape band)
+//   fatf_listing_status                   0.20 (FATF — discrete black=0, gray=30, compliant=100)
+//   financial_center_redundancy           0.15 (BIS LBS by-parent count — higherBetter, worst=1 best=10)
+//
+// The fail-closed preflight requires all 3 seed envelopes
+// (`economic:wb-external-debt:v1`, `economic:bis-lbs:v1`,
+// `economic:fatf-listing:v1`) to be reachable; missing seed-meta
+// throws `ResilienceConfigurationError(message, missingKeys)` two-arg
+// form. Per-country data gaps are NOT preflight failures — they
+// produce per-component nulls.
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  scoreFinancialSystemExposure,
+  ResilienceConfigurationError,
+  type ResilienceSeedReader,
+} from '../server/worldmonitor/resilience/v1/_dimension-scorers.ts';
+
+const TEST_ISO2 = 'XX';
+
+// The dim is flag-gated for staged rollout (matches energy v2 pattern).
+// All formula + preflight tests in this file exercise the ON path.
+const ORIGINAL_FLAG = process.env.RESILIENCE_FIN_SYS_EXPOSURE_ENABLED;
+beforeEach(() => {
+  process.env.RESILIENCE_FIN_SYS_EXPOSURE_ENABLED = 'true';
+});
+afterEach(() => {
+  if (ORIGINAL_FLAG === undefined) {
+    delete process.env.RESILIENCE_FIN_SYS_EXPOSURE_ENABLED;
+  } else {
+    process.env.RESILIENCE_FIN_SYS_EXPOSURE_ENABLED = ORIGINAL_FLAG;
+  }
+});
+
+describe('scoreFinancialSystemExposure — flag-off rollout posture', () => {
+  it('flag off (default) → returns empty-data shape, no preflight, no throw', async () => {
+    delete process.env.RESILIENCE_FIN_SYS_EXPOSURE_ENABLED;
+    const reader: ResilienceSeedReader = async () => null;
+    const result = await scoreFinancialSystemExposure(TEST_ISO2, reader);
+    assert.equal(result.score, 0, 'flag off must yield score=0');
+    assert.equal(result.coverage, 0, 'flag off must yield coverage=0');
+    assert.equal(result.imputationClass, null, 'flag off must NOT carry imputationClass (no fail-closed)');
+  });
+
+  it('flag explicitly false → returns empty-data shape', async () => {
+    process.env.RESILIENCE_FIN_SYS_EXPOSURE_ENABLED = 'false';
+    const reader: ResilienceSeedReader = async () => null;
+    const result = await scoreFinancialSystemExposure(TEST_ISO2, reader);
+    assert.equal(result.score, 0);
+    assert.equal(result.coverage, 0);
+  });
+});
+
+// Default reader: ALL 3 required seed-meta envelopes present (so
+// preflight passes), but NO per-country data (so component reads
+// return null). Useful as a baseline; individual tests override
+// specific keys to exercise component math.
+function emptyButReachableReader(): ResilienceSeedReader {
+  const presentSeedMetaKeys = new Set([
+    'seed-meta:economic:wb-external-debt:v1',
+    'seed-meta:economic:bis-lbs:v1',
+    'seed-meta:economic:fatf-listing:v1',
+  ]);
+  return async (key) => {
+    if (presentSeedMetaKeys.has(key)) return { fetchedAt: Date.now() };
+    return null;
+  };
+}
+
+describe('scoreFinancialSystemExposure — fail-closed preflight', () => {
+  it('throws ResilienceConfigurationError when economic:wb-external-debt:v1 seed-meta is missing', async () => {
+    const reader: ResilienceSeedReader = async (key) => {
+      // Two of three published; WB IDS missing.
+      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      return null;
+    };
+    await assert.rejects(
+      () => scoreFinancialSystemExposure(TEST_ISO2, reader),
+      (err: unknown) => {
+        if (!(err instanceof ResilienceConfigurationError)) return false;
+        return err.missingKeys.includes('economic:wb-external-debt:v1');
+      },
+      'must throw ResilienceConfigurationError naming the missing seed key',
+    );
+  });
+
+  it('throws ResilienceConfigurationError when economic:bis-lbs:v1 seed-meta is missing', async () => {
+    const reader: ResilienceSeedReader = async (key) => {
+      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      return null;
+    };
+    await assert.rejects(
+      () => scoreFinancialSystemExposure(TEST_ISO2, reader),
+      (err: unknown) => {
+        if (!(err instanceof ResilienceConfigurationError)) return false;
+        return err.missingKeys.includes('economic:bis-lbs:v1');
+      },
+    );
+  });
+
+  it('throws ResilienceConfigurationError when economic:fatf-listing:v1 seed-meta is missing', async () => {
+    const reader: ResilienceSeedReader = async (key) => {
+      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
+      return null;
+    };
+    await assert.rejects(
+      () => scoreFinancialSystemExposure(TEST_ISO2, reader),
+      (err: unknown) => {
+        if (!(err instanceof ResilienceConfigurationError)) return false;
+        return err.missingKeys.includes('economic:fatf-listing:v1');
+      },
+    );
+  });
+
+  it('ResilienceConfigurationError carries missingKeys array (not undefined) — two-arg constructor', async () => {
+    const reader: ResilienceSeedReader = async () => null;
+    try {
+      await scoreFinancialSystemExposure(TEST_ISO2, reader);
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.ok(err instanceof ResilienceConfigurationError);
+      // Codex R3 P1 #2: the downstream scoreAllDimensions catch path calls
+      // `err.missingKeys.join(',')` directly. A single-arg throw would set
+      // missingKeys=undefined and the source-failure handler would itself
+      // throw on `undefined.join`. Pin the array shape.
+      assert.ok(Array.isArray(err.missingKeys), 'missingKeys must be an array, not undefined');
+      assert.equal(err.missingKeys.length, 3, 'all 3 required keys must be reported when none reachable');
+      // Direct call must NOT throw (the error message above proves it works in production).
+      assert.doesNotThrow(() => err.missingKeys.join(','));
+    }
+  });
+});
+
+describe('scoreFinancialSystemExposure — per-country no-data path (positive control)', () => {
+  it('all seed envelopes published but country has no data → score=0, coverage=0 (NOT a config error)', async () => {
+    // This is the critical distinction: a country whose BIS LBS / WB IDS
+    // data is absent (but envelopes ARE published) gets a per-component
+    // null score, NOT a fail-closed throw. weightedBlend collapses all-
+    // null inputs to score=0 coverage=0; the dim returns the empty-data
+    // shape rather than throwing.
+    const reader = emptyButReachableReader();
+    const result = await scoreFinancialSystemExposure(TEST_ISO2, reader);
+    assert.equal(result.score, 0, 'all-null components must produce score=0 (no impute)');
+    assert.equal(result.coverage, 0, 'all-null components must produce coverage=0 (no impute)');
+  });
+});
+
+describe('scoreFinancialSystemExposure — formula math', () => {
+  it('FATF compliant + 0% short-term debt + 25% BIS LBS exposure + 10 redundant parents → score 100', async () => {
+    // All 4 components at their best anchors:
+    //   short-term debt = 0% GNI       → lowerBetter(0, worst=15, best=0) = 100
+    //   BIS LBS         = 25% GDP      → U-shape sweet-spot peak = 100 (75 + (20/20)*25 = 100)
+    //   FATF            = compliant    → 100 (discrete)
+    //   redundancy      = 10 parents   → higherBetter(10, worst=1, best=10) = 100
+    // Total: (100*0.35 + 100*0.30 + 100*0.20 + 100*0.15) / 1.0 = 100.
+    const reader: ResilienceSeedReader = async (key) => {
+      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      if (key === 'economic:wb-external-debt:v1') return { countries: { [TEST_ISO2]: { value: 0, year: 2024 } } };
+      if (key === 'economic:bis-lbs:v1') return { countries: { [TEST_ISO2]: { totalXborderPctGdp: 25, parentCount: 10 } } };
+      if (key === 'economic:fatf-listing:v1') return { listings: { [TEST_ISO2]: 'compliant' }, publicationDate: '2026-02-13' };
+      return null;
+    };
+    const result = await scoreFinancialSystemExposure(TEST_ISO2, reader);
+    assert.equal(result.score, 100, `best-case must yield 100, got ${result.score}`);
+    assert.equal(result.coverage, 1.0, `best-case coverage must be 1.0, got ${result.coverage}`);
+  });
+
+  it('FATF black list + 15% short-term debt + 100% BIS LBS exposure + 1 parent → score floors low', async () => {
+    // Component values driving each to its worst anchor:
+    //   short-term debt = 15% GNI      → lowerBetter(15, 0, 15) = 0
+    //   BIS LBS         = 100% GDP     → U-shape Iceland-2008 territory: 30 - (100-60)*0.5 = 10
+    //   FATF            = black        → 0 (discrete)
+    //   redundancy      = 1 parent     → higherBetter(1, 1, 10) = 0
+    // Total: (0*0.35 + 10*0.30 + 0*0.20 + 0*0.15) / 1.0 = 3.
+    const reader: ResilienceSeedReader = async (key) => {
+      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      if (key === 'economic:wb-external-debt:v1') return { countries: { [TEST_ISO2]: { value: 15, year: 2024 } } };
+      if (key === 'economic:bis-lbs:v1') return { countries: { [TEST_ISO2]: { totalXborderPctGdp: 100, parentCount: 1 } } };
+      if (key === 'economic:fatf-listing:v1') return { listings: { [TEST_ISO2]: 'black' }, publicationDate: '2026-02-13' };
+      return null;
+    };
+    const result = await scoreFinancialSystemExposure(TEST_ISO2, reader);
+    assert.ok(result.score < 10, `worst-case must score < 10, got ${result.score}`);
+  });
+
+  it('U-shape sanity: BIS LBS at 0% (financial isolation) scores LOWER than at 15% (sweet spot)', async () => {
+    // Component 2 standalone test: hold all others null, vary the
+    // BIS LBS exposure. The U-shape design penalizes both extremes.
+    const buildReader = (xborderPct: number, parentCount: number): ResilienceSeedReader => async (key) => {
+      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      if (key === 'economic:bis-lbs:v1') {
+        return {
+          countries: {
+            [TEST_ISO2]: { totalXborderPctGdp: xborderPct, parentCount },
+          },
+        };
+      }
+      return null;
+    };
+    const isolated = await scoreFinancialSystemExposure(TEST_ISO2, buildReader(0, 1));
+    const sweetSpot = await scoreFinancialSystemExposure(TEST_ISO2, buildReader(15, 5));
+    const overExposed = await scoreFinancialSystemExposure(TEST_ISO2, buildReader(80, 5));
+    assert.ok(
+      sweetSpot.score > isolated.score,
+      `sweet-spot (${sweetSpot.score}) must beat financial-isolation (${isolated.score})`,
+    );
+    assert.ok(
+      sweetSpot.score > overExposed.score,
+      `sweet-spot (${sweetSpot.score}) must beat over-exposed (${overExposed.score})`,
+    );
+  });
+
+  it('FATF discrete mapping: black=0, gray=30, compliant=100', async () => {
+    const buildReader = (status: 'black' | 'gray' | 'compliant'): ResilienceSeedReader => async (key) => {
+      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      if (key === 'economic:fatf-listing:v1') {
+        return { listings: { [TEST_ISO2]: status }, publicationDate: '2026-02-13' };
+      }
+      return null;
+    };
+    // Only FATF observed; weight 0.20 → score equals the FATF anchor.
+    const black = await scoreFinancialSystemExposure(TEST_ISO2, buildReader('black'));
+    const gray = await scoreFinancialSystemExposure(TEST_ISO2, buildReader('gray'));
+    const compliant = await scoreFinancialSystemExposure(TEST_ISO2, buildReader('compliant'));
+    assert.equal(black.score, 0, 'FATF black list anchors at 0');
+    assert.equal(gray.score, 30, 'FATF gray list anchors at 30');
+    assert.equal(compliant.score, 100, 'FATF compliant anchors at 100');
+  });
+});
+
+describe('scoreFinancialSystemExposure — component-read contract', () => {
+  it('DOES read every expected seed key (defends against accidental drops)', async () => {
+    // Symmetric counter-positive: if a future refactor accidentally
+    // drops one of the 4 component reads, this test names the missing
+    // key directly.
+    const observed = new Set<string>();
+    const reader: ResilienceSeedReader = async (key) => {
+      observed.add(key);
+      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      return null;
+    };
+    await scoreFinancialSystemExposure(TEST_ISO2, reader);
+    assert.ok(observed.has('seed-meta:economic:wb-external-debt:v1'), 'must preflight wb-external-debt seed-meta');
+    assert.ok(observed.has('seed-meta:economic:bis-lbs:v1'), 'must preflight bis-lbs seed-meta');
+    assert.ok(observed.has('seed-meta:economic:fatf-listing:v1'), 'must preflight fatf-listing seed-meta');
+    assert.ok(observed.has('economic:wb-external-debt:v1'), 'must read wb-external-debt data key');
+    assert.ok(observed.has('economic:bis-lbs:v1'), 'must read bis-lbs data key');
+    assert.ok(observed.has('economic:fatf-listing:v1'), 'must read fatf-listing data key');
+  });
+
+  it('does NOT read sanctions:country-counts:v1 (Phase 1 OFAC component remains dropped)', async () => {
+    // Verifies the methodology invariant from plan §"No double-counting":
+    // financialSystemExposure must NOT read the OFAC seed key. The OFAC-
+    // domicile signal does not feed either tradePolicy or
+    // financialSystemExposure post-Phase-2.
+    let sanctionsReads = 0;
+    const reader: ResilienceSeedReader = async (key) => {
+      if (key === 'sanctions:country-counts:v1') {
+        sanctionsReads += 1;
+        return { [TEST_ISO2]: 999 };
+      }
+      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      return null;
+    };
+    await scoreFinancialSystemExposure(TEST_ISO2, reader);
+    assert.equal(sanctionsReads, 0, 'scoreFinancialSystemExposure must not read sanctions:country-counts:v1');
+  });
+});

--- a/tests/resilience-financial-system-exposure.test.mts
+++ b/tests/resilience-financial-system-exposure.test.mts
@@ -208,6 +208,43 @@ describe('scoreFinancialSystemExposure — formula math', () => {
     assert.ok(result.score < 10, `worst-case must score < 10, got ${result.score}`);
   });
 
+  it('U-shape is piecewise-CONTINUOUS at 5% and 25% boundaries (Greptile P1 regression guard)', async () => {
+    // Greptile flagged a 30-point cliff at the 25% boundary (sweet-spot
+    // ended at 100, over-exposed started at 70) in the original draft,
+    // plus a 5-point jump at 5%. Cliffs in piecewise-linear scorers
+    // cause ranking instability for countries near band edges. Pin
+    // continuity at every boundary by sampling values immediately above
+    // and below each transition and asserting the score delta is small.
+    const buildReader = (xborderPct: number): ResilienceSeedReader => async (key) => {
+      if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
+      if (key === 'economic:bis-lbs:v1') {
+        return { countries: { [TEST_ISO2]: { totalXborderPctGdp: xborderPct, parentCount: 5 } } };
+      }
+      return null;
+    };
+    const samplePoints = [
+      { name: 'just-below 5%', a: 4.99, b: 5.00 },
+      { name: 'just-above 5%', a: 5.00, b: 5.01 },
+      { name: 'just-below 25%', a: 24.99, b: 25.00 },
+      { name: 'just-above 25%', a: 25.00, b: 25.01 },
+      { name: 'just-below 60%', a: 59.99, b: 60.00 },
+      { name: 'just-above 60%', a: 60.00, b: 60.01 },
+    ];
+    for (const { name, a, b } of samplePoints) {
+      const sa = await scoreFinancialSystemExposure(TEST_ISO2, buildReader(a));
+      const sb = await scoreFinancialSystemExposure(TEST_ISO2, buildReader(b));
+      const delta = Math.abs(sa.score - sb.score);
+      // Tolerance of 1pt allows for rounding (roundScore uses Math.round
+      // on each branch independently). Original cliff was 30pts at 25%.
+      assert.ok(
+        delta <= 1,
+        `${name}: score must be continuous across boundary. Got delta=${delta} (a=${a}→${sa.score}, b=${b}→${sb.score})`,
+      );
+    }
+  });
+
   it('U-shape sanity: BIS LBS at 0% (financial isolation) scores LOWER than at 15% (sweet spot)', async () => {
     // Component 2 standalone test: hold all others null, vary the
     // BIS LBS exposure. The U-shape design penalizes both extremes.
@@ -235,6 +272,30 @@ describe('scoreFinancialSystemExposure — formula math', () => {
       sweetSpot.score > overExposed.score,
       `sweet-spot (${sweetSpot.score}) must beat over-exposed (${overExposed.score})`,
     );
+  });
+
+  it('FATF empty listings dict (parser regression) does NOT default every country to compliant', async () => {
+    // Greptile P2 regression guard (PR #3407 review). A malformed seed
+    // with `listings: {}` that bypassed validate would otherwise score
+    // every country at 100 (compliant default) — silently masking a
+    // parser bug. Defense-in-depth: empty listings → null component
+    // score → slot drops out of the blend. Visible coverage shrink
+    // rather than invisible all-pass.
+    const reader: ResilienceSeedReader = async (key) => {
+      if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
+      if (key === 'economic:fatf-listing:v1') {
+        return { listings: {}, publicationDate: '2026-02-13' };
+      }
+      return null;
+    };
+    const result = await scoreFinancialSystemExposure(TEST_ISO2, reader);
+    // All 4 components null → coverage 0. Critically, the test asserts
+    // we do NOT get score=100 (which is what an all-compliant default
+    // would produce against weight 0.20 if the other slots null out).
+    assert.equal(result.coverage, 0, 'empty FATF listings + null other components must yield coverage=0');
+    assert.notEqual(result.score, 100, 'empty FATF listings must NOT score 100 via the compliant-default fall-through');
   });
 
   it('FATF discrete mapping: black=0, gray=30, compliant=100', async () => {

--- a/tests/resilience-financial-system-exposure.test.mts
+++ b/tests/resilience-financial-system-exposure.test.mts
@@ -14,6 +14,16 @@
 // throws `ResilienceConfigurationError(message, missingKeys)` two-arg
 // form. Per-country data gaps are NOT preflight failures — they
 // produce per-component nulls.
+//
+// IMPORTANT — seed-meta key shape: `runSeed` (scripts/_seed-utils.mjs)
+// strips the trailing `:v\d+` from the data key when it writes the
+// freshness record. So `economic:wb-external-debt:v1` becomes
+// `seed-meta:economic:wb-external-debt` (NO `:v1`). The scorer's
+// preflight uses `resolveSeedMetaKey` to apply the same strip — these
+// tests mock the unversioned form to match. A regression-guard test
+// below pins the exact key shape so a future refactor that breaks
+// the writer/reader contract fails loudly instead of silently routing
+// every country to source-failure.
 
 import assert from 'node:assert/strict';
 import { afterEach, beforeEach, describe, it } from 'node:test';
@@ -65,9 +75,9 @@ describe('scoreFinancialSystemExposure — flag-off rollout posture', () => {
 // specific keys to exercise component math.
 function emptyButReachableReader(): ResilienceSeedReader {
   const presentSeedMetaKeys = new Set([
-    'seed-meta:economic:wb-external-debt:v1',
-    'seed-meta:economic:bis-lbs:v1',
-    'seed-meta:economic:fatf-listing:v1',
+    'seed-meta:economic:wb-external-debt',
+    'seed-meta:economic:bis-lbs',
+    'seed-meta:economic:fatf-listing',
   ]);
   return async (key) => {
     if (presentSeedMetaKeys.has(key)) return { fetchedAt: Date.now() };
@@ -79,8 +89,8 @@ describe('scoreFinancialSystemExposure — fail-closed preflight', () => {
   it('throws ResilienceConfigurationError when economic:wb-external-debt:v1 seed-meta is missing', async () => {
     const reader: ResilienceSeedReader = async (key) => {
       // Two of three published; WB IDS missing.
-      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
       return null;
     };
     await assert.rejects(
@@ -95,8 +105,8 @@ describe('scoreFinancialSystemExposure — fail-closed preflight', () => {
 
   it('throws ResilienceConfigurationError when economic:bis-lbs:v1 seed-meta is missing', async () => {
     const reader: ResilienceSeedReader = async (key) => {
-      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
       return null;
     };
     await assert.rejects(
@@ -110,8 +120,8 @@ describe('scoreFinancialSystemExposure — fail-closed preflight', () => {
 
   it('throws ResilienceConfigurationError when economic:fatf-listing:v1 seed-meta is missing', async () => {
     const reader: ResilienceSeedReader = async (key) => {
-      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
       return null;
     };
     await assert.rejects(
@@ -165,9 +175,9 @@ describe('scoreFinancialSystemExposure — formula math', () => {
     //   redundancy      = 10 parents   → higherBetter(10, worst=1, best=10) = 100
     // Total: (100*0.35 + 100*0.30 + 100*0.20 + 100*0.15) / 1.0 = 100.
     const reader: ResilienceSeedReader = async (key) => {
-      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
       if (key === 'economic:wb-external-debt:v1') return { countries: { [TEST_ISO2]: { value: 0, year: 2024 } } };
       if (key === 'economic:bis-lbs:v1') return { countries: { [TEST_ISO2]: { totalXborderPctGdp: 25, parentCount: 10 } } };
       if (key === 'economic:fatf-listing:v1') return { listings: { [TEST_ISO2]: 'compliant' }, publicationDate: '2026-02-13' };
@@ -186,9 +196,9 @@ describe('scoreFinancialSystemExposure — formula math', () => {
     //   redundancy      = 1 parent     → higherBetter(1, 1, 10) = 0
     // Total: (0*0.35 + 10*0.30 + 0*0.20 + 0*0.15) / 1.0 = 3.
     const reader: ResilienceSeedReader = async (key) => {
-      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
       if (key === 'economic:wb-external-debt:v1') return { countries: { [TEST_ISO2]: { value: 15, year: 2024 } } };
       if (key === 'economic:bis-lbs:v1') return { countries: { [TEST_ISO2]: { totalXborderPctGdp: 100, parentCount: 1 } } };
       if (key === 'economic:fatf-listing:v1') return { listings: { [TEST_ISO2]: 'black' }, publicationDate: '2026-02-13' };
@@ -202,9 +212,9 @@ describe('scoreFinancialSystemExposure — formula math', () => {
     // Component 2 standalone test: hold all others null, vary the
     // BIS LBS exposure. The U-shape design penalizes both extremes.
     const buildReader = (xborderPct: number, parentCount: number): ResilienceSeedReader => async (key) => {
-      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
       if (key === 'economic:bis-lbs:v1') {
         return {
           countries: {
@@ -229,9 +239,9 @@ describe('scoreFinancialSystemExposure — formula math', () => {
 
   it('FATF discrete mapping: black=0, gray=30, compliant=100', async () => {
     const buildReader = (status: 'black' | 'gray' | 'compliant'): ResilienceSeedReader => async (key) => {
-      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
       if (key === 'economic:fatf-listing:v1') {
         return { listings: { [TEST_ISO2]: status }, publicationDate: '2026-02-13' };
       }
@@ -255,18 +265,52 @@ describe('scoreFinancialSystemExposure — component-read contract', () => {
     const observed = new Set<string>();
     const reader: ResilienceSeedReader = async (key) => {
       observed.add(key);
-      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
       return null;
     };
     await scoreFinancialSystemExposure(TEST_ISO2, reader);
-    assert.ok(observed.has('seed-meta:economic:wb-external-debt:v1'), 'must preflight wb-external-debt seed-meta');
-    assert.ok(observed.has('seed-meta:economic:bis-lbs:v1'), 'must preflight bis-lbs seed-meta');
-    assert.ok(observed.has('seed-meta:economic:fatf-listing:v1'), 'must preflight fatf-listing seed-meta');
+    assert.ok(observed.has('seed-meta:economic:wb-external-debt'), 'must preflight wb-external-debt seed-meta');
+    assert.ok(observed.has('seed-meta:economic:bis-lbs'), 'must preflight bis-lbs seed-meta');
+    assert.ok(observed.has('seed-meta:economic:fatf-listing'), 'must preflight fatf-listing seed-meta');
     assert.ok(observed.has('economic:wb-external-debt:v1'), 'must read wb-external-debt data key');
     assert.ok(observed.has('economic:bis-lbs:v1'), 'must read bis-lbs data key');
     assert.ok(observed.has('economic:fatf-listing:v1'), 'must read fatf-listing data key');
+  });
+
+  it('preflight reads UNVERSIONED seed-meta keys (matches runSeed write-key shape)', async () => {
+    // Regression guard: previously the scorer preflighted
+    // `seed-meta:economic:<key>:v1` while runSeed writes
+    // `seed-meta:economic:<key>` (with the trailing :v\d+ stripped).
+    // That mismatch would have caused EVERY request to throw
+    // ResilienceConfigurationError once the flag flipped on, even with
+    // healthy seeders. Pin the exact key shape so the bug can't recur.
+    //
+    // Reference: scripts/_seed-utils.mjs runSeed → seed-meta is written
+    // at `seed-meta:${dataKey.replace(/:v\d+$/, '')}`. Same as
+    // api/health.js + api/seed-health.js entries.
+    const seedMetaReads = new Set<string>();
+    const reader: ResilienceSeedReader = async (key) => {
+      if (key.startsWith('seed-meta:')) seedMetaReads.add(key);
+      // Return null so we observe the read attempts then trip the
+      // preflight throw — we only care about the keys the scorer probed.
+      return null;
+    };
+    try {
+      await scoreFinancialSystemExposure(TEST_ISO2, reader);
+    } catch (err) {
+      // Expected — all seeds null → throws.
+      assert.ok(err instanceof ResilienceConfigurationError);
+    }
+    assert.ok(seedMetaReads.has('seed-meta:economic:wb-external-debt'), 'preflight must probe unversioned seed-meta:economic:wb-external-debt (NOT :v1 suffix)');
+    assert.ok(seedMetaReads.has('seed-meta:economic:bis-lbs'), 'preflight must probe unversioned seed-meta:economic:bis-lbs (NOT :v1 suffix)');
+    assert.ok(seedMetaReads.has('seed-meta:economic:fatf-listing'), 'preflight must probe unversioned seed-meta:economic:fatf-listing (NOT :v1 suffix)');
+    // Negative: the versioned form must NOT be probed (would never match
+    // anything runSeed writes).
+    assert.ok(!seedMetaReads.has('seed-meta:economic:wb-external-debt:v1'), 'preflight must NOT probe versioned seed-meta key (writer/reader drift bug guard)');
+    assert.ok(!seedMetaReads.has('seed-meta:economic:bis-lbs:v1'));
+    assert.ok(!seedMetaReads.has('seed-meta:economic:fatf-listing:v1'));
   });
 
   it('does NOT read sanctions:country-counts:v1 (Phase 1 OFAC component remains dropped)', async () => {
@@ -280,9 +324,9 @@ describe('scoreFinancialSystemExposure — component-read contract', () => {
         sanctionsReads += 1;
         return { [TEST_ISO2]: 999 };
       }
-      if (key === 'seed-meta:economic:wb-external-debt:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:bis-lbs:v1') return { fetchedAt: Date.now() };
-      if (key === 'seed-meta:economic:fatf-listing:v1') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
+      if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
       return null;
     };
     await scoreFinancialSystemExposure(TEST_ISO2, reader);

--- a/tests/resilience-handlers.test.mts
+++ b/tests/resilience-handlers.test.mts
@@ -28,7 +28,7 @@ describe('resilience handlers', () => {
     delete process.env.VERCEL_ENV;
 
     const { fetchImpl, redis, sortedSets } = createRedisFetch(RESILIENCE_FIXTURES);
-    sortedSets.set('resilience:history:v8:US', [
+    sortedSets.set('resilience:history:v9:US', [
       { member: '2026-04-01:20', score: 20260401 },
       { member: '2026-04-02:30', score: 20260402 },
     ]);
@@ -40,10 +40,12 @@ describe('resilience handlers', () => {
 
     assert.equal(response.countryCode, 'US');
     assert.equal(response.domains.length, 6);
-    // 19 active + 2 retired (fuelStockDays, reserveAdequacy) = 21. Retired
+    // 20 active + 2 retired (fuelStockDays, reserveAdequacy) = 22. Retired
     // dims stay in the response for structural continuity; they're
     // filtered out of confidence averages via RESILIENCE_RETIRED_DIMENSIONS.
-    assert.equal(response.domains.flatMap((domain) => domain.dimensions).length, 21);
+    // Plan 2026-04-25-004 Phase 2: financialSystemExposure is the 20th
+    // active dim (ships flag-gated dark; counted in the structural total).
+    assert.equal(response.domains.flatMap((domain) => domain.dimensions).length, 22);
     assert.ok(response.overallScore > 0 && response.overallScore <= 100);
     assert.equal(response.level, response.overallScore >= 70 ? 'high' : response.overallScore >= 40 ? 'medium' : 'low');
     assert.equal(response.trend, 'rising');
@@ -58,16 +60,16 @@ describe('resilience handlers', () => {
     assert.ok(response.stressFactor >= 0 && response.stressFactor <= 0.5, `stressFactor out of bounds: ${response.stressFactor}`);
     assert.equal(response.dataVersion, '2024-04-03', 'dataVersion should be the ISO date from seed-meta fetchedAt');
 
-    const cachedScore = redis.get('resilience:score:v13:US');
+    const cachedScore = redis.get('resilience:score:v14:US');
     assert.ok(cachedScore, 'expected score cache to be written');
     assert.equal(JSON.parse(cachedScore || '{}').countryCode, 'US');
 
-    const history = sortedSets.get('resilience:history:v8:US') ?? [];
+    const history = sortedSets.get('resilience:history:v9:US') ?? [];
     assert.ok(history.some((entry) => entry.member.startsWith(today + ':')), 'expected today history member to be written');
 
     await getResilienceScore({ request: new Request('https://example.com') } as never, {
       countryCode: 'US',
     });
-    assert.equal((sortedSets.get('resilience:history:v8:US') ?? []).length, history.length, 'cache hit must not append history');
+    assert.equal((sortedSets.get('resilience:history:v9:US') ?? []).length, history.length, 'cache hit must not append history');
   });
 });

--- a/tests/resilience-indicator-registry.test.mts
+++ b/tests/resilience-indicator-registry.test.mts
@@ -6,12 +6,14 @@ import { INDICATOR_REGISTRY } from '../server/worldmonitor/resilience/v1/_indica
 import type { IndicatorSpec } from '../server/worldmonitor/resilience/v1/_indicator-registry.ts';
 
 describe('indicator registry', () => {
-  it('covers all 21 dimensions (19 active + 2 retired)', () => {
+  it('covers all 22 dimensions (20 active + 2 retired)', () => {
     const coveredDimensions = new Set(INDICATOR_REGISTRY.map((i) => i.dimension));
     for (const dimId of RESILIENCE_DIMENSION_ORDER) {
       assert.ok(coveredDimensions.has(dimId), `${dimId} has no indicators in registry`);
     }
-    assert.equal(coveredDimensions.size, 21);
+    // Plan 2026-04-25-004 Phase 2: 22 dims = 20 active + 2 retired
+    // (19 active in Phase 1 + financialSystemExposure added in Phase 2).
+    assert.equal(coveredDimensions.size, 22);
   });
 
   it('has no duplicate indicator ids', () => {

--- a/tests/resilience-methodology-lint.test.mts
+++ b/tests/resilience-methodology-lint.test.mts
@@ -36,6 +36,7 @@ const HEADING_TO_DIMENSION: Readonly<Record<string, ResilienceDimensionId>> = {
   'Macro-Fiscal': 'macroFiscal',
   'Currency & External': 'currencyExternal',
   'Trade Policy': 'tradePolicy',
+  'Financial System Exposure': 'financialSystemExposure',
   'Cyber & Digital': 'cyberDigital',
   'Logistics & Supply': 'logisticsSupply',
   'Infrastructure': 'infrastructure',

--- a/tests/resilience-pillar-aggregation.test.mts
+++ b/tests/resilience-pillar-aggregation.test.mts
@@ -157,8 +157,8 @@ describe('pillar constants', () => {
     assert.equal(PENALTY_ALPHA, 0.50);
   });
 
-  it('RESILIENCE_SCORE_CACHE_PREFIX is v13', () => {
-    assert.equal(RESILIENCE_SCORE_CACHE_PREFIX, 'resilience:score:v13:');
+  it('RESILIENCE_SCORE_CACHE_PREFIX is v14', () => {
+    assert.equal(RESILIENCE_SCORE_CACHE_PREFIX, 'resilience:score:v14:');
   });
 
   it('PILLAR_ORDER has 3 entries', () => {

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -58,14 +58,14 @@ describe('resilience ranking contracts', () => {
     // so fixtures must carry the `_formula` tag matching the current env
     // (default flag-off ⇒ 'd6'). Writing the tagged shape here mirrors
     // what the handler persists via stampRankingCacheTag.
-    redis.set('resilience:ranking:v13', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
+    redis.set('resilience:ranking:v14', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
     // The handler strips `_formula` before returning, so response matches
     // the public shape rather than the on-wire cache shape.
     assert.deepEqual(response, cachedPublic);
-    assert.equal(redis.has('resilience:score:v13:YE'), false, 'cache hit must not trigger score warmup');
+    assert.equal(redis.has('resilience:score:v14:YE'), false, 'cache hit must not trigger score warmup');
   });
 
   it('returns all-greyed-out cached payload without rewarming (items=[], greyedOut non-empty)', async () => {
@@ -79,12 +79,12 @@ describe('resilience ranking contracts', () => {
         { countryCode: 'ER', overallScore: 10, level: 'critical', lowConfidence: true, overallCoverage: 0.12 },
       ],
     };
-    redis.set('resilience:ranking:v13', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
+    redis.set('resilience:ranking:v14', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
     assert.deepEqual(response, cachedPublic);
-    assert.equal(redis.has('resilience:score:v13:SS'), false, 'all-greyed-out cache hit must not trigger score warmup');
+    assert.equal(redis.has('resilience:score:v14:SS'), false, 'all-greyed-out cache hit must not trigger score warmup');
   });
 
   it('bulk-read path skips untagged per-country score entries (legacy writes must rebuild on flip)', async () => {
@@ -111,13 +111,13 @@ describe('resilience ranking contracts', () => {
 
     const domain = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
     // Tagged entry: served as-is.
-    redis.set('resilience:score:v13:NO', JSON.stringify({
+    redis.set('resilience:score:v14:NO', JSON.stringify({
       countryCode: 'NO', overallScore: 82, level: 'high',
       domains: domain, trend: 'stable', change30d: 1.2,
       lowConfidence: false, imputationShare: 0.05, _formula: 'd6',
     }));
     // Untagged entry: must be rejected, ranking warm rebuilds US.
-    redis.set('resilience:score:v13:US', JSON.stringify({
+    redis.set('resilience:score:v14:US', JSON.stringify({
       countryCode: 'US', overallScore: 61, level: 'medium',
       domains: domain, trend: 'rising', change30d: 4.3,
       lowConfidence: false, imputationShare: 0.1,
@@ -130,7 +130,7 @@ describe('resilience ranking contracts', () => {
     // `_formula: 'd6'`. If the bulk read had ADMITTED the untagged
     // entry (the pre-fix bug), the warm path for US would not have
     // run, and the stored value would still be untagged.
-    const rewrittenRaw = redis.get('resilience:score:v13:US');
+    const rewrittenRaw = redis.get('resilience:score:v14:US');
     assert.ok(rewrittenRaw, 'US entry must remain in Redis after the ranking run');
     const rewritten = JSON.parse(rewrittenRaw!);
     assert.equal(
@@ -157,7 +157,7 @@ describe('resilience ranking contracts', () => {
       greyedOut: [],
       _formula: 'pc', // mismatched — current env is flag-off ⇒ current='d6'
     };
-    redis.set('resilience:ranking:v13', JSON.stringify(stale));
+    redis.set('resilience:ranking:v14', JSON.stringify(stale));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
@@ -169,7 +169,7 @@ describe('resilience ranking contracts', () => {
     // Recompute path warms missing per-country scores, so YE (in
     // RESILIENCE_FIXTURES) must get scored during this call.
     assert.ok(
-      redis.has('resilience:score:v13:YE'),
+      redis.has('resilience:score:v14:YE'),
       'stale-formula reject must trigger the recompute-and-warm path',
     );
   });
@@ -177,7 +177,7 @@ describe('resilience ranking contracts', () => {
   it('warms missing scores synchronously and returns complete ranking on first call', async () => {
     const { redis } = installRedis(RESILIENCE_FIXTURES);
     const domainWithCoverage = [{ name: 'political', dimensions: [{ name: 'd1', coverage: 0.9 }] }];
-    redis.set('resilience:score:v13:NO', JSON.stringify({
+    redis.set('resilience:score:v14:NO', JSON.stringify({
       countryCode: 'NO',
       overallScore: 82,
       level: 'high',
@@ -187,7 +187,7 @@ describe('resilience ranking contracts', () => {
       lowConfidence: false,
       imputationShare: 0.05,
     }));
-    redis.set('resilience:score:v13:US', JSON.stringify({
+    redis.set('resilience:score:v14:US', JSON.stringify({
       countryCode: 'US',
       overallScore: 61,
       level: 'medium',
@@ -202,20 +202,20 @@ describe('resilience ranking contracts', () => {
 
     const totalItems = response.items.length + (response.greyedOut?.length ?? 0);
     assert.equal(totalItems, 3, `expected 3 total items across ranked + greyedOut, got ${totalItems}`);
-    assert.ok(redis.has('resilience:score:v13:YE'), 'missing country should be warmed during first call');
+    assert.ok(redis.has('resilience:score:v14:YE'), 'missing country should be warmed during first call');
     assert.ok(response.items.every((item) => item.overallScore >= 0), 'ranked items should all have computed scores');
-    assert.ok(redis.has('resilience:ranking:v13'), 'fully scored ranking should be cached');
+    assert.ok(redis.has('resilience:ranking:v14'), 'fully scored ranking should be cached');
   });
 
   it('sets rankStable=true when interval data exists and width <= 8', async () => {
     const { redis } = installRedis(RESILIENCE_FIXTURES);
     const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
-    redis.set('resilience:score:v13:NO', JSON.stringify({
+    redis.set('resilience:score:v14:NO', JSON.stringify({
       countryCode: 'NO', overallScore: 82, level: 'high',
       domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
       lowConfidence: false, imputationShare: 0.05,
     }));
-    redis.set('resilience:score:v13:US', JSON.stringify({
+    redis.set('resilience:score:v14:US', JSON.stringify({
       countryCode: 'US', overallScore: 61, level: 'medium',
       domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
       lowConfidence: false, imputationShare: 0.1,
@@ -242,12 +242,12 @@ describe('resilience ranking contracts', () => {
       seedYear: 2025,
     }));
     const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
-    redis.set('resilience:score:v13:NO', JSON.stringify({
+    redis.set('resilience:score:v14:NO', JSON.stringify({
       countryCode: 'NO', overallScore: 82, level: 'high',
       domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
       lowConfidence: false, imputationShare: 0.05,
     }));
-    redis.set('resilience:score:v13:US', JSON.stringify({
+    redis.set('resilience:score:v14:US', JSON.stringify({
       countryCode: 'US', overallScore: 61, level: 'medium',
       domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
       lowConfidence: false, imputationShare: 0.1,
@@ -257,7 +257,7 @@ describe('resilience ranking contracts', () => {
 
     // 3 of 4 (NO + US pre-cached, YE warmed from fixtures, ZZ can't be warmed)
     // = 75% which meets the threshold — must cache.
-    assert.ok(redis.has('resilience:ranking:v13'), 'ranking must be cached at exactly 75% coverage');
+    assert.ok(redis.has('resilience:ranking:v14'), 'ranking must be cached at exactly 75% coverage');
     assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written alongside the ranking');
   });
 
@@ -288,7 +288,7 @@ describe('resilience ranking contracts', () => {
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
         const allScoreReads = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'GET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v13:'),
+          (cmd) => cmd[0] === 'GET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v14:'),
         );
         if (allScoreReads) {
           // Simulate visibility lag: pretend no scores are cached yet.
@@ -304,7 +304,7 @@ describe('resilience ranking contracts', () => {
 
     await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
-    assert.ok(redis.has('resilience:ranking:v13'), 'ranking must be published despite pipeline-GET race');
+    assert.ok(redis.has('resilience:ranking:v14'), 'ranking must be published despite pipeline-GET race');
     assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written despite pipeline-GET race');
   });
 
@@ -312,8 +312,8 @@ describe('resilience ranking contracts', () => {
     // Reviewer regression: passing `raw=true` to runRedisPipeline bypasses the
     // env-based key prefix (preview: / dev:) that isolates preview deploys
     // from production. The symptom is asymmetric: preview reads hit
-    // `preview:<sha>:resilience:score:v13:XX` while preview writes landed at
-    // raw `resilience:score:v13:XX`, simultaneously (a) missing the preview
+    // `preview:<sha>:resilience:score:v14:XX` while preview writes landed at
+    // raw `resilience:score:v14:XX`, simultaneously (a) missing the preview
     // cache forever and (b) poisoning production's shared cache. Simulate a
     // preview deploy and assert the pipeline SET keys carry the prefix.
     // Shared afterEach snapshots/restores VERCEL_ENV + VERCEL_GIT_COMMIT_SHA
@@ -345,7 +345,7 @@ describe('resilience ranking contracts', () => {
 
     const scoreSetKeys = pipelineBodies
       .flat()
-      .filter((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v13:'))
+      .filter((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v14:'))
       .map((cmd) => cmd[1] as string);
     assert.ok(scoreSetKeys.length >= 2, `expected at least 2 score SETs, got ${scoreSetKeys.length}`);
     for (const key of scoreSetKeys) {
@@ -380,7 +380,7 @@ describe('resilience ranking contracts', () => {
       // rejected by the formula gate and the refresh path would not
       // get tested as intended.
       const stale = { items: [{ countryCode: 'ZZ', overallScore: 1, level: 'low', lowConfidence: true, overallCoverage: 0.5 }], greyedOut: [], _formula: 'd6' };
-      redis.set('resilience:ranking:v13', JSON.stringify(stale));
+      redis.set('resilience:ranking:v14', JSON.stringify(stale));
 
       // No X-WorldMonitor-Key → refresh must be ignored, stale cache returned.
       const unauth = new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1');
@@ -434,7 +434,7 @@ describe('resilience ranking contracts', () => {
       // rejected by the formula gate and the refresh path would not
       // get tested as intended.
       const stale = { items: [{ countryCode: 'ZZ', overallScore: 1, level: 'low', lowConfidence: true, overallCoverage: 0.5 }], greyedOut: [], _formula: 'd6' };
-      redis.set('resilience:ranking:v13', JSON.stringify(stale));
+      redis.set('resilience:ranking:v14', JSON.stringify(stale));
 
       const request = new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1', {
         headers: { 'X-WorldMonitor-Key': 'seed-secret' },
@@ -469,7 +469,7 @@ describe('resilience ranking contracts', () => {
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
         const isAllScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v13:'),
+          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v14:'),
         );
         if (isAllScoreSets) setPipelineSizes.push(commands.length);
       }
@@ -501,7 +501,7 @@ describe('resilience ranking contracts', () => {
       seedYear: 2026,
     }));
 
-    // Intercept any pipeline SET to resilience:score:v13:* and reply with
+    // Intercept any pipeline SET to resilience:score:v14:* and reply with
     // non-OK results (persisted but authoritative signal says no). /set and
     // other paths pass through normally so history/interval writes succeed.
     const blockedScoreWrites = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -509,7 +509,7 @@ describe('resilience ranking contracts', () => {
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
         const allScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v13:'),
+          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v14:'),
         );
         if (allScoreSets) {
           return new Response(
@@ -524,7 +524,7 @@ describe('resilience ranking contracts', () => {
 
     await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
-    assert.ok(!redis.has('resilience:ranking:v13'), 'ranking must NOT be published when score writes failed');
+    assert.ok(!redis.has('resilience:ranking:v14'), 'ranking must NOT be published when score writes failed');
     assert.ok(!redis.has('seed-meta:resilience:ranking'), 'seed-meta must NOT be written when score writes failed');
   });
 

--- a/tests/resilience-release-gate.test.mts
+++ b/tests/resilience-release-gate.test.mts
@@ -48,7 +48,7 @@ function installRedisFixtures() {
 }
 
 describe('resilience release gate', () => {
-  it('keeps all 21 dimension scorers non-placeholder for the required countries', async () => {
+  it('keeps all 22 dimension scorers non-placeholder for the required countries', async () => {
     // PR 3 §3.5 retired fuelStockDays; PR 2 §3.4 retired reserveAdequacy
     // (superseded by the liquidReserveAdequacy + sovereignFiscalBuffer
     // split). Both scorers emit coverage=0 + imputationClass=null — the
@@ -57,15 +57,28 @@ describe('resilience release gate', () => {
     // construct retirement. Allow-list keeps the zero-coverage placeholder
     // check enforcing on the OTHER 19 dimensions.
     const RETIRED_DIMENSIONS = new Set(['fuelStockDays', 'reserveAdequacy']);
+    // plan 2026-04-25-004 Phase 2: financialSystemExposure ships flag-gated
+    // off by default (rollout pattern matches energy v2). With the flag
+    // off, the dim emits coverage=0 + imputationClass=null. Treated as
+    // "dark in this baseline" — same shape as a retired dim, but for a
+    // distinct reason: pending seeder rollout, not deliberate retirement.
+    // When the flag flips on with seeders populating, this allow-list
+    // entry should be removed in the same PR that flips the flag.
+    const FLAG_GATED_DARK_DIMENSIONS = new Set(['financialSystemExposure']);
     for (const countryCode of REQUIRED_DIMENSION_COUNTRIES) {
       const scores = await scoreAllDimensions(countryCode, fixtureReader);
       const entries = Object.entries(scores);
-      assert.equal(entries.length, 21, `${countryCode} should have all 21 resilience dimensions (19 active + 2 retired kept for structural continuity)`);
+      assert.equal(entries.length, 22, `${countryCode} should have all 22 resilience dimensions (20 active + 2 retired kept for structural continuity)`);
       for (const [dimensionId, score] of entries) {
         assert.ok(Number.isFinite(score.score), `${countryCode} ${dimensionId} should produce a numeric score`);
         if (RETIRED_DIMENSIONS.has(dimensionId)) {
           assert.equal(score.coverage, 0, `${countryCode} ${dimensionId} is retired and must stay at coverage=0`);
           assert.equal(score.imputationClass, null, `${countryCode} ${dimensionId} retired dimensions must tag null imputationClass (not source-failure)`);
+          continue;
+        }
+        if (FLAG_GATED_DARK_DIMENSIONS.has(dimensionId)) {
+          assert.equal(score.coverage, 0, `${countryCode} ${dimensionId} is flag-gated dark (RESILIENCE_FIN_SYS_EXPOSURE_ENABLED off) and must stay at coverage=0`);
+          assert.equal(score.imputationClass, null, `${countryCode} ${dimensionId} flag-off must tag null imputationClass (not source-failure)`);
           continue;
         }
         assert.ok(score.coverage > 0, `${countryCode} ${dimensionId} should not fall back to zero-coverage placeholder scoring`);
@@ -251,7 +264,7 @@ describe('resilience release gate', () => {
     );
 
     const allDimensions = response.domains.flatMap((domain) => domain.dimensions);
-    assert.equal(allDimensions.length, 21, 'US response should carry all 21 dimensions (19 active + 2 retired)');
+    assert.equal(allDimensions.length, 22, 'US response should carry all 22 dimensions (20 active + 2 retired)');
     for (const dimension of allDimensions) {
       assert.equal(
         typeof dimension.imputationClass,
@@ -279,7 +292,7 @@ describe('resilience release gate', () => {
     );
 
     const allDimensions = response.domains.flatMap((domain) => domain.dimensions);
-    assert.equal(allDimensions.length, 21, 'US response should carry all 21 dimensions (19 active + 2 retired)');
+    assert.equal(allDimensions.length, 22, 'US response should carry all 22 dimensions (20 active + 2 retired)');
     const validLevels = ['', 'fresh', 'aging', 'stale'];
     for (const dimension of allDimensions) {
       assert.ok(dimension.freshness != null, `dimension ${dimension.id} must carry a freshness payload`);

--- a/tests/resilience-scorers.test.mts
+++ b/tests/resilience-scorers.test.mts
@@ -130,8 +130,18 @@ describe('resilience scorer contracts', () => {
     // the new construct). US-specific delta is small here because the
     // US already had a high tariff-policy openness; the bigger movers
     // are transit-hub jurisdictions (UAE/SG/HK).
+    // Plan 2026-04-25-004 Phase 2 (Ship 2): economic 71 → 53.25. The
+    // new `financialSystemExposure` dim is added to the economic domain
+    // but ships flag-gated off by default (rollout pattern matches
+    // energy v2). Flag-off ⇒ score=0, so the simple-average computed
+    // here drops 71 = (78+68+67)/3 → 53.25 = (78+68+67+0)/4. NOTE
+    // this domainAverages computation is a flat mean (NOT the
+    // production coverage-weighted mean). The next test below uses
+    // the coverage-weighted-mean path which CORRECTLY drops a coverage=0
+    // dim from the blend; the headline overall is unaffected by the
+    // flag-off baseline beyond the small tradePolicy-reweight shift.
     assert.deepEqual(domainAverages, {
-      economic: 71,
+      economic: 53.25,
       infrastructure: 79,
       energy: 80,
       'social-governance': 61.75,
@@ -195,8 +205,12 @@ describe('resilience scorer contracts', () => {
     // post-rename uplift (OFAC component dropped) propagates into the
     // stress-only mean. stressFactor updates in lockstep:
     //   1 - 69.01/100 = 0.3099, clamped to 0.5.
-    assert.equal(stressScore, 69.01);
-    assert.equal(stressFactor, 0.3099);
+    // Plan 2026-04-25-004 Phase 2 (Ship 2): 69.01 → 67.98. The new
+    // `financialSystemExposure` dim is also stress-class and ships
+    // flag-gated off → score 0 → drags the stress-only mean down.
+    //   1 - 67.98/100 = 0.3202, clamped to 0.5.
+    assert.equal(stressScore, 67.98);
+    assert.equal(stressFactor, 0.3202);
 
     const overallScore = round(
       RESILIENCE_DOMAIN_ORDER.map((domainId) => {
@@ -229,7 +243,17 @@ describe('resilience scorer contracts', () => {
     // Plan 2026-04-25-004 Phase 1 (Ship 1): 64.39 → 65.24. economic
     // domain rises 66.33 → 71 with tradePolicy reweight (OFAC dropped),
     // contributing economic_delta * 0.17 ≈ +0.79 to the overall score.
-    assert.equal(overallScore, 65.24);
+    // Plan 2026-04-25-004 Phase 2 (Ship 2): 65.24 → 64.78. Adding
+    // `financialSystemExposure` to the economic domain reweights
+    // tradePolicy 1.0 → 0.5 (to keep the domain's total dim weight
+    // conserved). The new dim ships dark behind a flag (default off)
+    // and contributes coverage=0 → drops from the coverage-weighted
+    // mean. The half-weight on tradePolicy shifts the economic domain
+    // mean slightly, dropping the overall by ~0.46 points. When the
+    // flag flips on in production with seeders populated, the dim will
+    // contribute its own signal; the expected value here will move
+    // accordingly in a future PR.
+    assert.equal(overallScore, 64.78);
   });
 
   it('baselineScore is computed from baseline + mixed dimensions only', async () => {
@@ -318,7 +342,13 @@ describe('resilience scorer contracts', () => {
     // new recovery dims down to weight=0.5 (~10% recovery share each).
     // Plan 2026-04-25-004 Phase 1 (Ship 1): 64.39 → 65.24 — economic
     // domain rises with tradePolicy reweight (OFAC component dropped).
-    assert.equal(expected, 65.24, 'overallScore should match sum(domainScore * domainWeight); 64.39 → 65.24 after Ship 1 tradePolicy reweight');
+    // Plan 2026-04-25-004 Phase 2 (Ship 2): 65.24 → 64.78 — adding
+    // `financialSystemExposure` to the economic domain at weight 0.5
+    // reweights tradePolicy 1.0 → 0.5; the new dim ships flag-gated
+    // off by default, so it contributes coverage=0 and drops from the
+    // coverage-weighted mean. When the flag flips on with seeders
+    // populated, the expected here will shift accordingly.
+    assert.equal(expected, 64.78, 'overallScore should match sum(domainScore * domainWeight); 65.24 → 64.78 after Ship 2 dim added (flag-off baseline)');
   });
 
   it('stressFactor is still computed (informational) and clamped to [0, 0.5]', () => {

--- a/tests/resilience-scores-seed.test.mjs
+++ b/tests/resilience-scores-seed.test.mjs
@@ -10,12 +10,12 @@ import {
 } from '../scripts/seed-resilience-scores.mjs';
 
 describe('exported constants', () => {
-  it('RESILIENCE_RANKING_CACHE_KEY matches server-side key (v13)', () => {
-    assert.equal(RESILIENCE_RANKING_CACHE_KEY, 'resilience:ranking:v13');
+  it('RESILIENCE_RANKING_CACHE_KEY matches server-side key (v14)', () => {
+    assert.equal(RESILIENCE_RANKING_CACHE_KEY, 'resilience:ranking:v14');
   });
 
-  it('RESILIENCE_SCORE_CACHE_PREFIX matches server-side prefix (v13)', () => {
-    assert.equal(RESILIENCE_SCORE_CACHE_PREFIX, 'resilience:score:v13:');
+  it('RESILIENCE_SCORE_CACHE_PREFIX matches server-side prefix (v14)', () => {
+    assert.equal(RESILIENCE_SCORE_CACHE_PREFIX, 'resilience:score:v14:');
   });
 
   it('RESILIENCE_RANKING_CACHE_TTL_SECONDS is 12 hours (2x cron interval)', () => {

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -187,7 +187,7 @@ test('baseResponse includes dataVersion (regression for T1.4 wiring)', () => {
 // scorer dimension must have a stable display label and a consistent
 // status classification.
 
-test('getResilienceDimensionLabel returns short stable labels for all 21 dimensions', () => {
+test('getResilienceDimensionLabel returns short stable labels for all 22 dimensions', () => {
   assert.equal(getResilienceDimensionLabel('macroFiscal'), 'Macro');
   assert.equal(getResilienceDimensionLabel('currencyExternal'), 'Currency');
   assert.equal(getResilienceDimensionLabel('tradePolicy'), 'Trade');

--- a/tests/seed-bis-lbs.test.mjs
+++ b/tests/seed-bis-lbs.test.mjs
@@ -129,6 +129,47 @@ describe('extractClaimsByCounterparty — SDMX-JSON shape parsing', () => {
     assert.equal(result.latestPeriod, null);
   });
 
+  it('drops counterparty when claim value exceeds 1e8 millions (upper-bound corruption guard)', () => {
+    // 2e8 millions = $200T — far above any plausible bilateral claim
+    // (global GDP is ~$110T). Treat as parser corruption, drop silently.
+    function buildFixtureWithCorruptValue(corruptVal) {
+      return {
+        data: {
+          dataSets: [
+            {
+              series: {
+                '0:0:0:0:0:0:0:0:0:0:0:0': { observations: { '0': [corruptVal] } },
+                '0:0:0:0:0:0:0:0:0:0:1:0': { observations: { '0': [50_000] } }, // legitimate
+              },
+            },
+          ],
+          structure: {
+            dimensions: {
+              series: [
+                { id: 'FREQ', values: [{ id: 'Q' }] },
+                { id: 'MEASURE', values: [{ id: 'S' }] },
+                { id: 'L_POSITION', values: [{ id: 'C' }] },
+                { id: 'L_INSTR', values: [{ id: 'A' }] },
+                { id: 'L_DENOM', values: [{ id: 'TO1' }] },
+                { id: 'L_CURR_TYPE', values: [{ id: 'A' }] },
+                { id: 'L_PARENT_CTY', values: [{ id: 'US' }] },
+                { id: 'L_REP_BANK_TYPE', values: [{ id: 'A' }] },
+                { id: 'L_REP_CTY', values: [{ id: '5A' }] },
+                { id: 'L_CP_SECTOR', values: [{ id: 'A' }] },
+                { id: 'L_CP_COUNTRY', values: [{ id: 'BR' }, { id: 'MX' }] },
+                { id: 'L_POS_TYPE', values: [{ id: 'N' }] },
+              ],
+              observation: [{ id: 'TIME_PERIOD', values: [{ id: '2024-Q4' }] }],
+            },
+          },
+        },
+      };
+    }
+    const result = extractClaimsByCounterparty(buildFixtureWithCorruptValue(2e8));
+    assert.ok(!('BR' in result.byCounterparty), 'corrupt value must be dropped');
+    assert.equal(result.byCounterparty.MX, 50_000, 'legitimate value passes through');
+  });
+
   it('throws when L_CP_COUNTRY dimension is missing (parser regression guard)', () => {
     const broken = {
       data: {
@@ -145,9 +186,9 @@ describe('validate', () => {
     assert.equal(validate({ countries: {} }), false);
   });
 
-  it('rejects payload below 100-country floor', () => {
+  it('rejects payload below 150-country floor', () => {
     const tiny = {};
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < 100; i++) {
       tiny[`X${i.toString().padStart(2, '0')}`] = { totalXborderPctGdp: 5, parentCount: 2, parents: {}, gdpYear: 2024 };
     }
     assert.equal(validate({ countries: tiny }), false);
@@ -155,7 +196,7 @@ describe('validate', () => {
 
   it('accepts payload at or above the BIS LBS floor', () => {
     const ample = {};
-    for (let i = 0; i < 120; i++) {
+    for (let i = 0; i < 160; i++) {
       ample[`X${i.toString().padStart(2, '0')}`] = { totalXborderPctGdp: 5, parentCount: 2, parents: {}, gdpYear: 2024 };
     }
     assert.equal(validate({ countries: ample }), true);

--- a/tests/seed-bis-lbs.test.mjs
+++ b/tests/seed-bis-lbs.test.mjs
@@ -1,0 +1,163 @@
+// Pin the BIS LBS combination math. Plan 2026-04-25-004 §Component 2.
+//
+// The pure helpers `combineLbsByCounterparty` and
+// `extractClaimsByCounterparty` are exported so these tests run fully
+// offline. Real BIS SDMX network shape is known and pinned via a
+// realistic SDMX-JSON fixture below.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  combineLbsByCounterparty,
+  extractClaimsByCounterparty,
+  validate,
+  PARENT_COUNTRIES,
+} from '../scripts/seed-bis-lbs.mjs';
+
+describe('combineLbsByCounterparty — sum across parents + GDP normalization', () => {
+  it('Brazil: $300B claims aggregated from US + GB / $2T GDP = 15% of GDP, parentCount=2', () => {
+    const perParent = {
+      US: { byCounterparty: { BR: 200_000 }, latestPeriod: '2024-Q4' }, // 200B in millions
+      GB: { byCounterparty: { BR: 100_000 }, latestPeriod: '2024-Q4' }, // 100B
+    };
+    const gdpByCountry = { BR: { value: 2_000_000_000_000, year: 2024 } }; // $2T
+    const out = combineLbsByCounterparty(perParent, gdpByCountry);
+    assert.equal(out.BR.totalXborderPctGdp, 15.0);
+    assert.equal(out.BR.parentCount, 2, 'both parents have claims > 1% GDP');
+  });
+
+  it('parentCount counts ONLY parents above the 1% GDP threshold', () => {
+    // GB has only $5B claims = 0.25% of $2T GDP → below 1% threshold.
+    const perParent = {
+      US: { byCounterparty: { BR: 200_000 }, latestPeriod: '2024-Q4' }, // 200B = 10% GDP
+      GB: { byCounterparty: { BR: 5_000 }, latestPeriod: '2024-Q4' },   // 5B = 0.25% GDP
+    };
+    const gdpByCountry = { BR: { value: 2_000_000_000_000, year: 2024 } };
+    const out = combineLbsByCounterparty(perParent, gdpByCountry);
+    assert.equal(out.BR.parentCount, 1, 'GB is below the 1% GDP threshold');
+  });
+
+  it('drops counterparty without GDP data (cannot normalize)', () => {
+    const perParent = {
+      US: { byCounterparty: { XX: 50_000 }, latestPeriod: '2024-Q4' },
+    };
+    const gdpByCountry = {}; // no XX
+    const out = combineLbsByCounterparty(perParent, gdpByCountry);
+    assert.equal(Object.keys(out).length, 0);
+  });
+
+  it('preserves per-parent provenance in the parents map', () => {
+    const perParent = {
+      US: { byCounterparty: { BR: 200_000 }, latestPeriod: '2024-Q4' },
+      DE: { byCounterparty: { BR: 50_000 }, latestPeriod: '2024-Q4' },
+    };
+    const gdpByCountry = { BR: { value: 2_000_000_000_000, year: 2024 } };
+    const out = combineLbsByCounterparty(perParent, gdpByCountry);
+    assert.deepEqual(out.BR.parents, { US: 200_000, DE: 50_000 });
+  });
+
+  it('aggregates across all 16 enumerated parents', () => {
+    // Each parent contributes $10B claims = 0.5% GDP individually.
+    // 16 × 0.5% = 8% total exposure; only the parents above 1% individually
+    // count toward parentCount, so 0 here (each below threshold) — this
+    // pins the threshold semantics: parentCount measures redundancy at the
+    // SINGLE-parent level, not aggregate.
+    const perParent = {};
+    for (const parent of PARENT_COUNTRIES) {
+      perParent[parent] = { byCounterparty: { BR: 10_000 }, latestPeriod: '2024-Q4' };
+    }
+    const gdpByCountry = { BR: { value: 2_000_000_000_000, year: 2024 } };
+    const out = combineLbsByCounterparty(perParent, gdpByCountry);
+    assert.equal(out.BR.totalXborderPctGdp, 8.0, 'sum across 16 parents at $10B each = $160B = 8% of $2T');
+    assert.equal(out.BR.parentCount, 0, 'no single parent above 1% threshold');
+  });
+});
+
+describe('extractClaimsByCounterparty — SDMX-JSON shape parsing', () => {
+  // Minimal SDMX-JSON fixture matching BIS WS_LBS_D_PUB response shape.
+  // The dimensions array order and the colon-separated coord-string format
+  // match the SDMX-JSON 1.0.0 spec.
+  function buildFixture(parentClaim) {
+    return {
+      data: {
+        dataSets: [
+          {
+            series: {
+              // coord = "0:0:0:0:0:0:0:0:0:0:cpIdx:0" — only L_CP_COUNTRY varies
+              '0:0:0:0:0:0:0:0:0:0:0:0': { observations: { '0': [parentClaim.BR] } },
+              '0:0:0:0:0:0:0:0:0:0:1:0': { observations: { '0': [parentClaim.MX] } },
+              '0:0:0:0:0:0:0:0:0:0:2:0': { observations: { '0': [parentClaim['5J']] } }, // BIS-aggregate, must be skipped
+            },
+          },
+        ],
+        structure: {
+          dimensions: {
+            series: [
+              { id: 'FREQ', values: [{ id: 'Q' }] },
+              { id: 'MEASURE', values: [{ id: 'S' }] },
+              { id: 'L_POSITION', values: [{ id: 'C' }] },
+              { id: 'L_INSTR', values: [{ id: 'A' }] },
+              { id: 'L_DENOM', values: [{ id: 'TO1' }] },
+              { id: 'L_CURR_TYPE', values: [{ id: 'A' }] },
+              { id: 'L_PARENT_CTY', values: [{ id: 'US' }] },
+              { id: 'L_REP_BANK_TYPE', values: [{ id: 'A' }] },
+              { id: 'L_REP_CTY', values: [{ id: '5A' }] },
+              { id: 'L_CP_SECTOR', values: [{ id: 'A' }] },
+              { id: 'L_CP_COUNTRY', values: [{ id: 'BR' }, { id: 'MX' }, { id: '5J' }] },
+              { id: 'L_POS_TYPE', values: [{ id: 'N' }] },
+            ],
+            observation: [{ id: 'TIME_PERIOD', values: [{ id: '2024-Q4' }] }],
+          },
+        },
+      },
+    };
+  }
+
+  it('extracts per-counterparty claims, skipping BIS aggregate codes (5J)', () => {
+    const fixture = buildFixture({ BR: 200_000, MX: 50_000, '5J': 999_999 });
+    const result = extractClaimsByCounterparty(fixture);
+    assert.equal(result.byCounterparty.BR, 200_000);
+    assert.equal(result.byCounterparty.MX, 50_000);
+    assert.ok(!('5J' in result.byCounterparty), 'BIS aggregate 5J must be skipped');
+    assert.equal(result.latestPeriod, '2024-Q4');
+  });
+
+  it('returns empty maps gracefully when SDMX shape is unexpected', () => {
+    const result = extractClaimsByCounterparty({ data: { dataSets: [] } });
+    assert.deepEqual(result.byCounterparty, {});
+    assert.equal(result.latestPeriod, null);
+  });
+
+  it('throws when L_CP_COUNTRY dimension is missing (parser regression guard)', () => {
+    const broken = {
+      data: {
+        dataSets: [{ series: { '0:0:0:0': { observations: { '0': [100] } } } }],
+        structure: { dimensions: { series: [{ id: 'X', values: [] }], observation: [{ id: 'TIME_PERIOD', values: [] }] } },
+      },
+    };
+    assert.throws(() => extractClaimsByCounterparty(broken), /missing L_CP_COUNTRY/);
+  });
+});
+
+describe('validate', () => {
+  it('rejects empty payload', () => {
+    assert.equal(validate({ countries: {} }), false);
+  });
+
+  it('rejects payload below 100-country floor', () => {
+    const tiny = {};
+    for (let i = 0; i < 50; i++) {
+      tiny[`X${i.toString().padStart(2, '0')}`] = { totalXborderPctGdp: 5, parentCount: 2, parents: {}, gdpYear: 2024 };
+    }
+    assert.equal(validate({ countries: tiny }), false);
+  });
+
+  it('accepts payload at or above the BIS LBS floor', () => {
+    const ample = {};
+    for (let i = 0; i < 120; i++) {
+      ample[`X${i.toString().padStart(2, '0')}`] = { totalXborderPctGdp: 5, parentCount: 2, parents: {}, gdpYear: 2024 };
+    }
+    assert.equal(validate({ countries: ample }), true);
+  });
+});

--- a/tests/seed-fatf-listing.test.mjs
+++ b/tests/seed-fatf-listing.test.mjs
@@ -79,10 +79,10 @@ describe('extractListedCountries — country-name lookup from publication HTML',
         <h3>Myanmar</h3>
       </body></html>
     `;
-    const set = extractListedCountries(html, buildLookup());
-    assert.ok(set.has('KP'), 'must extract DPRK');
-    assert.ok(set.has('IR'), 'must extract Iran');
-    assert.ok(set.has('MM'), 'must extract Myanmar');
+    const { listed } = extractListedCountries(html, buildLookup());
+    assert.ok(listed.has('KP'), 'must extract DPRK');
+    assert.ok(listed.has('IR'), 'must extract Iran');
+    assert.ok(listed.has('MM'), 'must extract Myanmar');
   });
 
   it('extracts country names from grey-list publication (typical 15-25 countries)', () => {
@@ -95,9 +95,9 @@ describe('extractListedCountries — country-name lookup from publication HTML',
         </ul>
       </body></html>
     `;
-    const set = extractListedCountries(html, buildLookup());
-    assert.ok(set.has('NG'));
-    assert.ok(set.has('ZA'));
+    const { listed } = extractListedCountries(html, buildLookup());
+    assert.ok(listed.has('NG'));
+    assert.ok(listed.has('ZA'));
   });
 
   it('ignores long paragraphs that happen to mention country names', () => {
@@ -106,10 +106,38 @@ describe('extractListedCountries — country-name lookup from publication HTML',
       <h3>Iran</h3>
       <p>The FATF expressed concern about Iran's continued failure to address financial system risks across many jurisdictions including but not limited to Iran's own. This is a long paragraph and should not match.</p>
     `;
-    const set = extractListedCountries(html, buildLookup());
-    assert.ok(set.has('IR'), 'h3 match still works');
+    const { listed } = extractListedCountries(html, buildLookup());
+    assert.ok(listed.has('IR'), 'h3 match still works');
     // The long paragraph mentioning Iran does NOT independently double-count.
-    assert.equal(set.size, 1);
+    assert.equal(listed.size, 1);
+  });
+
+  it('flags short capitalized text nodes that look like missing country names', () => {
+    // FATF introduces a new spelling not in country-names.json — must
+    // surface as unmatchedCandidate so ops can extend the aliases map.
+    const html = `
+      <html><body>
+        <h3>Mauretania</h3>  <!-- alternate spelling not in lookup -->
+        <h3>Iran</h3>
+      </body></html>
+    `;
+    const { listed, unmatchedCandidates } = extractListedCountries(html, buildLookup());
+    assert.ok(listed.has('IR'), 'matched country still resolves');
+    assert.ok(unmatchedCandidates.has('Mauretania'), 'unknown spelling surfaces as unmatched candidate');
+  });
+
+  it('does NOT flag known FATF section headers as unmatched', () => {
+    const html = `
+      <html><body>
+        <h2>High-Risk Jurisdictions Subject to a Call for Action</h2>
+        <h3>Iran</h3>
+      </body></html>
+    `;
+    const { unmatchedCandidates } = extractListedCountries(html, buildLookup());
+    // Section headers are too long (>80 chars after stripHtml is fine) AND
+    // they're in the SECTION_NOISE allow-list. None should appear as
+    // unmatched candidates.
+    assert.equal(unmatchedCandidates.size, 0, 'section headers must not be flagged as unmatched country names');
   });
 });
 
@@ -152,12 +180,17 @@ describe('validate', () => {
   });
 
   it('rejects payload with too few grey-listed jurisdictions (parser likely failed)', () => {
-    assert.equal(validate({ listings: { KP: 'black', IR: 'black' } }), false);
-  });
-
-  it('accepts payload with at least 1 black + 8 grey', () => {
+    // Floor tightened from 8 → 12 — historical FATF grey-list size has
+    // been 15+ since 2020. A grey count below 12 indicates real upstream
+    // failure or parser drift.
     const listings = { KP: 'black' };
     for (let i = 0; i < 10; i++) listings[`X${i.toString().padStart(2, '0')}`] = 'gray';
+    assert.equal(validate({ listings }), false);
+  });
+
+  it('accepts payload with at least 1 black + 12 grey', () => {
+    const listings = { KP: 'black' };
+    for (let i = 0; i < 14; i++) listings[`X${i.toString().padStart(2, '0')}`] = 'gray';
     assert.equal(validate({ listings }), true);
   });
 });

--- a/tests/seed-fatf-listing.test.mjs
+++ b/tests/seed-fatf-listing.test.mjs
@@ -1,0 +1,163 @@
+// Pin the FATF entry-page parser + listing extractor + publication-date
+// inference. Plan 2026-04-25-004 §Component 3.
+//
+// Tests use realistic HTML fragments (NOT recorded-from-network fixtures
+// because FATF rebuilds their site periodically). The fragment shapes
+// mirror the patterns observed at
+// `https://www.fatf-gafi.org/en/countries/black-and-grey-lists.html`
+// as of 2026-02-13. If FATF restructures the page, these tests fail
+// loudly and the seeder's `find*Link` regex needs an update.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  findPublicationLink,
+  extractListedCountries,
+  extractPublicationDate,
+  validate,
+} from '../scripts/seed-fatf-listing.mjs';
+
+describe('findPublicationLink — entry-page anchor scan', () => {
+  const ENTRY_PAGE_2026 = `
+    <html><body>
+      <h2>Black & grey lists</h2>
+      <p>Latest FATF actions:</p>
+      <ul>
+        <li><a href="/en/publications/Fatfrecommendations/high-risk-jurisdictions-2026.html">High-risk jurisdictions subject to a call for action — February 2026</a></li>
+        <li><a href="/en/publications/Fatfrecommendations/increased-monitoring-feb-2026.html">Jurisdictions under increased monitoring — February 2026</a></li>
+      </ul>
+    </body></html>
+  `;
+
+  it('finds the "high-risk" (black list) publication URL', () => {
+    const url = findPublicationLink(ENTRY_PAGE_2026, 'high-risk');
+    assert.match(url, /high-risk-jurisdictions/);
+    assert.match(url, /^https:\/\/www\.fatf-gafi\.org\//, 'must resolve relative href against FATF origin');
+  });
+
+  it('finds the "increased monitoring" (grey list) publication URL', () => {
+    const url = findPublicationLink(ENTRY_PAGE_2026, 'increased monitoring');
+    assert.match(url, /increased-monitoring/);
+  });
+
+  it('returns null when label is absent (loud failure for parser regression)', () => {
+    const sterile = '<html><body><p>Nothing here</p></body></html>';
+    assert.equal(findPublicationLink(sterile, 'high-risk'), null);
+  });
+
+  it('case-insensitive label match', () => {
+    const url = findPublicationLink(ENTRY_PAGE_2026, 'HIGH-RISK');
+    assert.ok(url);
+  });
+});
+
+describe('extractListedCountries — country-name lookup from publication HTML', () => {
+  // Build a minimal name lookup mirroring the structure of country-names.json.
+  function buildLookup() {
+    return new Map([
+      ['north korea', 'KP'],
+      ['democratic peoples republic of korea', 'KP'],
+      ['iran', 'IR'],
+      ['islamic republic of iran', 'IR'],
+      ['myanmar', 'MM'],
+      ['burma', 'MM'],
+      ['nigeria', 'NG'],
+      ['south africa', 'ZA'],
+    ]);
+  }
+
+  it('extracts country names from H2 / strong tag patterns (FATF black-list page)', () => {
+    const html = `
+      <html><body>
+        <h2>High-Risk Jurisdictions Subject to a Call for Action</h2>
+        <p>Updated February 2026</p>
+        <h3>Democratic People's Republic of Korea</h3>
+        <p>The FATF urges members to apply enhanced due diligence...</p>
+        <h3>Iran</h3>
+        <p>Iran remains subject to a call for countermeasures.</p>
+        <h3>Myanmar</h3>
+      </body></html>
+    `;
+    const set = extractListedCountries(html, buildLookup());
+    assert.ok(set.has('KP'), 'must extract DPRK');
+    assert.ok(set.has('IR'), 'must extract Iran');
+    assert.ok(set.has('MM'), 'must extract Myanmar');
+  });
+
+  it('extracts country names from grey-list publication (typical 15-25 countries)', () => {
+    const html = `
+      <html><body>
+        <h2>Jurisdictions under Increased Monitoring</h2>
+        <ul>
+          <li>Nigeria</li>
+          <li>South Africa</li>
+        </ul>
+      </body></html>
+    `;
+    const set = extractListedCountries(html, buildLookup());
+    assert.ok(set.has('NG'));
+    assert.ok(set.has('ZA'));
+  });
+
+  it('ignores long paragraphs that happen to mention country names', () => {
+    // Defensive: paragraph text > 80 chars is skipped to avoid false matches.
+    const html = `
+      <h3>Iran</h3>
+      <p>The FATF expressed concern about Iran's continued failure to address financial system risks across many jurisdictions including but not limited to Iran's own. This is a long paragraph and should not match.</p>
+    `;
+    const set = extractListedCountries(html, buildLookup());
+    assert.ok(set.has('IR'), 'h3 match still works');
+    // The long paragraph mentioning Iran does NOT independently double-count.
+    assert.equal(set.size, 1);
+  });
+});
+
+describe('extractPublicationDate — slug + header inference', () => {
+  it('parses YYYY-MM from URL slug', () => {
+    const date = extractPublicationDate(
+      'https://www.fatf-gafi.org/en/publications/foo/high-risk-2026-02.html',
+      '<html></html>',
+    );
+    assert.equal(date, '2026-02-01');
+  });
+
+  it('falls back to "February 2026" header when URL slug is dateless', () => {
+    const date = extractPublicationDate(
+      'https://www.fatf-gafi.org/en/publications/foo/high-risk.html',
+      '<h2>High-Risk Jurisdictions — February 2026</h2>',
+    );
+    assert.equal(date, '2026-02-01');
+  });
+
+  it('falls back to current date when neither URL nor header has a date', () => {
+    const date = extractPublicationDate(
+      'https://www.fatf-gafi.org/en/publications/foo.html',
+      '<html><body>No date here</body></html>',
+    );
+    // Just check it's a valid YYYY-MM-DD; can't pin the value because it's "today".
+    assert.match(date, /^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe('validate', () => {
+  it('rejects payload missing the listings field', () => {
+    assert.equal(validate({}), false);
+  });
+
+  it('rejects payload with no black-listed jurisdiction (DPRK has been on call-for-action since 2011)', () => {
+    const onlyGrey = {};
+    for (let i = 0; i < 15; i++) onlyGrey[`X${i.toString().padStart(2, '0')}`] = 'gray';
+    assert.equal(validate({ listings: onlyGrey }), false);
+  });
+
+  it('rejects payload with too few grey-listed jurisdictions (parser likely failed)', () => {
+    assert.equal(validate({ listings: { KP: 'black', IR: 'black' } }), false);
+  });
+
+  it('accepts payload with at least 1 black + 8 grey', () => {
+    const listings = { KP: 'black' };
+    for (let i = 0; i < 10; i++) listings[`X${i.toString().padStart(2, '0')}`] = 'gray';
+    assert.equal(validate({ listings }), true);
+  });
+});

--- a/tests/seed-wb-external-debt.test.mjs
+++ b/tests/seed-wb-external-debt.test.mjs
@@ -1,0 +1,87 @@
+// Pin the WB IDS short-term external debt composition formula and the
+// validate floor. Plan 2026-04-25-004 §Component 1.
+//
+// shortTermDebtPctGni = (DT.DOD.DSTC.IR.ZS / 100) × DT.DOD.DECT.GN.ZS
+//
+// The pure helper `combineExternalDebt` is exported so this test runs
+// fully offline — no network, no recorded fixture file. The seeder's
+// network path (`fetchWbExternalDebt`) is the same proven WB API
+// pattern as `seed-recovery-external-debt.mjs` (in-tree precedent).
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { combineExternalDebt, validate } from '../scripts/seed-wb-external-debt.mjs';
+
+describe('combineExternalDebt — formula composition', () => {
+  it('Brazil: 18% of total debt × 35% of GNI = 6.30% short-term debt of GNI', () => {
+    const shortTermPctOfTotal = { BR: { value: 18, year: 2023 } };
+    const totalDebtPctGni = { BR: { value: 35, year: 2023 } };
+    const out = combineExternalDebt({ shortTermPctOfTotal, totalDebtPctGni });
+    assert.equal(out.BR.value, 6.30);
+    assert.equal(out.BR.year, 2023);
+    assert.equal(out.BR.shortTermPctOfTotalDebt, 18);
+    assert.equal(out.BR.totalDebtPctOfGni, 35);
+  });
+
+  it('Argentina at the IMF Article IV vulnerability threshold (15% GNI) = score-0 anchor', () => {
+    // Argentina's 2018 crisis: short-term debt ~25% of total × ~60% of GNI
+    // = 15% of GNI → IMF Article IV "vulnerable" tier.
+    const shortTermPctOfTotal = { AR: { value: 25, year: 2018 } };
+    const totalDebtPctGni = { AR: { value: 60, year: 2018 } };
+    const out = combineExternalDebt({ shortTermPctOfTotal, totalDebtPctGni });
+    assert.equal(out.AR.value, 15);
+  });
+
+  it('uses min(year) when the two source indicators disagree on year', () => {
+    // Real-world case: WB IDS publishes the two indicators with different
+    // lag patterns. Choose the conservative (older) year.
+    const shortTermPctOfTotal = { GH: { value: 22, year: 2022 } };
+    const totalDebtPctGni = { GH: { value: 30, year: 2023 } };
+    const out = combineExternalDebt({ shortTermPctOfTotal, totalDebtPctGni });
+    assert.equal(out.GH.year, 2022);
+  });
+
+  it('drops country when either source indicator is missing', () => {
+    const shortTermPctOfTotal = { ET: { value: 10, year: 2023 } };
+    const totalDebtPctGni = { /* ET absent */ };
+    const out = combineExternalDebt({ shortTermPctOfTotal, totalDebtPctGni });
+    assert.equal(Object.keys(out).length, 0);
+  });
+
+  it('drops country when either source has a negative value (invalid)', () => {
+    const shortTermPctOfTotal = { XX: { value: -5, year: 2023 } };
+    const totalDebtPctGni = { XX: { value: 30, year: 2023 } };
+    const out = combineExternalDebt({ shortTermPctOfTotal, totalDebtPctGni });
+    assert.equal(Object.keys(out).length, 0);
+  });
+
+  it('handles 0% short-term share → 0% of GNI (no short-term debt)', () => {
+    const shortTermPctOfTotal = { CL: { value: 0, year: 2023 } };
+    const totalDebtPctGni = { CL: { value: 80, year: 2023 } };
+    const out = combineExternalDebt({ shortTermPctOfTotal, totalDebtPctGni });
+    assert.equal(out.CL.value, 0);
+  });
+});
+
+describe('validate', () => {
+  it('rejects empty payload (upstream outage signal)', () => {
+    assert.equal(validate({ countries: {} }), false);
+  });
+
+  it('rejects payload below 80-country floor', () => {
+    const tiny = {};
+    for (let i = 0; i < 50; i++) {
+      tiny[`X${i.toString().padStart(2, '0')}`] = { value: 5, year: 2023 };
+    }
+    assert.equal(validate({ countries: tiny }), false);
+  });
+
+  it('accepts payload at or above the LMIC coverage floor', () => {
+    const ample = {};
+    for (let i = 0; i < 100; i++) {
+      ample[`X${i.toString().padStart(2, '0')}`] = { value: 5, year: 2023 };
+    }
+    assert.equal(validate({ countries: ample }), true);
+  });
+});

--- a/tests/seed-wb-external-debt.test.mjs
+++ b/tests/seed-wb-external-debt.test.mjs
@@ -39,7 +39,19 @@ describe('combineExternalDebt — formula composition', () => {
     const shortTermPctOfTotal = { GH: { value: 22, year: 2022 } };
     const totalDebtPctGni = { GH: { value: 30, year: 2023 } };
     const out = combineExternalDebt({ shortTermPctOfTotal, totalDebtPctGni });
-    assert.equal(out.GH.year, 2022);
+    assert.equal(out.GH.year, 2022, 'must use min(year) — older year is the binding constraint');
+    assert.equal(out.GH.yearMismatch, true, 'cross-year composition must be flagged for ops triage');
+    // Per-indicator years preserved so downstream consumers can see the
+    // actual source vintages without re-fetching.
+    assert.equal(out.GH.shortTermPctOfTotalDebtYear, 2022);
+    assert.equal(out.GH.totalDebtPctOfGniYear, 2023);
+  });
+
+  it('flags yearMismatch=false when both indicators are from the same year (preferred case)', () => {
+    const shortTermPctOfTotal = { ZA: { value: 18, year: 2023 } };
+    const totalDebtPctGni = { ZA: { value: 30, year: 2023 } };
+    const out = combineExternalDebt({ shortTermPctOfTotal, totalDebtPctGni });
+    assert.equal(out.ZA.yearMismatch, false, 'single-year payload must not be flagged');
   });
 
   it('drops country when either source indicator is missing', () => {


### PR DESCRIPTION
## Summary

Plan [`2026-04-25-004`](docs/plans/2026-04-25-004-feat-financial-system-exposure-construct-plan.md) Phase 2 (Ship 2) — **scaffold only**. Stacked on PR #3405 (Phase 1 Ship 1).

Adds the new `financialSystemExposure` resilience dimension behind a feature flag. The flag (`RESILIENCE_FIN_SYS_EXPOSURE_ENABLED`) defaults **OFF** so the dim ships dark — the scorer returns the empty-data shape until the 3 component seeders are populating in production. Rollout pattern matches energy v2 (plan [`2026-04-24-001`](docs/plans/2026-04-24-001-fix-resilience-v2-fail-closed-on-missing-seeds-plan.md)).

This is a deliberate two-PR split:
- **This PR (scaffold)**: dim id + scorer + helper + indicator registry + cache bumps + frontend + methodology doc heading + 13 contract tests
- **Follow-up PR (seeders)**: 3 component seeders (BIS SDMX, FATF HTML, WB IDS) + bundle registration + seeder fixture tests + cohort sanity-check + full methodology doc

Splitting at this boundary lets reviewers focus on the *construct design* (the formula, the U-shape, the fail-closed pattern) without the heavyweight network-integration code that will dominate the seeder PR.

## What's in this PR

### Components (weights total 1.0)
- `short_term_external_debt_pct_gni` — 0.35 (WB IDS, lowerBetter, goalpost 15%-0% GNI)
- `bis_lbs_xborder_us_eu_uk_pct_gdp` — 0.30 (BIS LBS by-parent, U-shape: <5% isolation, 5-25% sweet spot, 25-60% over-exposed, >60% Iceland-2008 territory)
- `fatf_listing_status` — 0.20 (FATF discrete: black=0, gray=30, compliant=100)
- `financial_center_redundancy` — 0.15 (BIS LBS by-parent count, higherBetter, 1-10)

Components 2 + 4 share the BIS LBS seed payload — no separate seeder for redundancy.

### Flag-gated rollout
The `RESILIENCE_FIN_SYS_EXPOSURE_ENABLED` env flag defaults `false`. When OFF:
- Scorer returns `score=0, coverage=0, imputationClass=null` — empty-data shape
- Dim drops out of the coverage-weighted economic-domain mean
- No preflight, no fail-closed throw

When the flag is flipped ON in production (after seeders populate):
- Preflights all 3 required seed-meta envelopes (`economic:wb-external-debt:v1`, `economic:bis-lbs:v1`, `economic:fatf-listing:v1`)
- Missing envelope → throws `ResilienceConfigurationError(message, missingKeys)` (two-arg form per Codex R3 P1 #2) → caught by `scoreAllDimensions` → routed to `imputationClass='source-failure'`
- Per-country data gaps inside published envelopes → component reads return null → slot drops from blend

### Cache prefix bumps (lockstep)
- `resilience:score:v13:` → `v14:`
- `resilience:ranking:v13` → `v14`
- `resilience:history:v8:` → `v9:`

The history bump is structural — adding a new dim shifts every country's overall-score baseline, and mixing pre/post points in the 30-day rolling window would manufacture false trends.

### tradePolicy reweight
`tradePolicy: 1.0 → 0.5` in `RESILIENCE_DIMENSION_WEIGHTS` so the new dim shares the economic-domain weight allocation. The half-weight on tradePolicy shifts the headline overallScore by ~0.46 points in the flag-off baseline (smaller contribution to the coverage-weighted economic-domain mean). When the flag flips on with seeders populated, the new dim's actual signal will rebalance the headline.

### Files (25 changed, +791 / −70)
- **Server**: `_dimension-scorers.ts` (dim id, weights, domains, order, types, scorers, scorer fn, helper, payload accessors), `_indicator-registry.ts` (4 new entries), `_shared.ts` (3 cache prefix bumps), `_source-failure.ts` (no edit needed — propagates via existing path)
- **Mirrors**: `scripts/{seed-resilience-scores,backtest,benchmark,validate-correlation,validate-backtest,compare-current-vs-proposed}.mjs`, `api/health.js` — every literal v13/v8 site migrated to v14/v9
- **Health registries**: `api/health.js` SEED_META + KEY_TO_DOMAIN, `api/seed-health.js` SEED_DOMAINS — 3 new keys in BOTH (per memory `feedback_two_health_endpoints_must_match`)
- **Frontend**: `src/components/resilience-widget-utils.ts` label map ("Fin. Exposure"), `src/components/ResilienceWidget.ts` "19 dimensions" → "20 dimensions"
- **Methodology**: `docs/methodology/country-resilience-index.mdx` — new `#### Financial System Exposure` H4 + indicator table + license attribution + cross-link to construct rationale
- **Tests**: 13 new in `tests/resilience-financial-system-exposure.test.mts` (fail-closed preflight + flag-off rollout + formula math + U-shape sanity + FATF discrete mapping + component-read contract); existing tests updated for v14/v9 prefixes, 22-dim count, flag-gated-dark exemption in release-gate, OFAC-not-read invariant for the new dim

## What this PR does NOT ship (deferred to follow-up PR)

- `scripts/seed-bis-lbs.mjs` (BIS SDMX `WS_LBS_D_PUB` by-parent integration — enumerated ISO2 parents per Codex R4 P1 #2)
- `scripts/seed-fatf-listing.mjs` (FATF HTML scrape with dynamic publication-URL follow + monthly cadence + 90d cache TTL fallback)
- `scripts/seed-wb-external-debt.mjs` (WB IDS short-term external debt as % GNI)
- Bundle registration in `scripts/seed-bundle-macro.mjs`
- `tests/seed-{bis-lbs,fatf-listing,wb-external-debt}.test.mjs` — fixture-based parser tests with Brazil 2024Q4 ground-truth anchor for BIS LBS and 2026-02-13 publication for FATF
- Integration tests: no double-counting between `tradePolicy` and `financialSystemExposure`; no double-counting between `financialSystemExposure` and `liquidReserveAdequacy`
- Cohort sanity-check: Russia / Iran / DPRK score < 20 on `financialSystemExposure` (gates the construct calibration)
- Full methodology doc `docs/methodology/financial-system-exposure.md` with rejected alternatives + license attribution
- Bounded-movement gate (60% of countries |Δ| < 3 points)

These need real-API integration with BIS SDMX, FATF web parsing, and WB IDS — best landed as a separate PR with fixture-recorded tests so reviewers can scrutinize the network code separately from the construct design.

## Test plan

- [x] `npm run typecheck` — exit 0
- [x] `npm run typecheck:api` — exit 0
- [x] `npm run test:data` — **7115/7115 tests pass**
  - `tests/resilience-financial-system-exposure.test.mts` — 13 new tests pinning the 4-component formula, flag-off baseline, fail-closed preflight, U-shape anchors, FATF discrete mapping, component-read contract
  - `tests/resilience-cache-keys-health-sync.test.mts` — parity test extended for v14 score+ranking, v9 history; asserts old prefixes absent in non-comment code
  - `tests/resilience-methodology-lint.test.mts` — heading "Financial System Exposure" → dim id `financialSystemExposure`
  - `tests/resilience-release-gate.test.mts` — 22-dim count + flag-gated-dark allow-list (must remove when flag flips on)
  - `tests/resilience-indicator-registry.test.mts` — 22-dim coverage + non-experimental weights total 1.0 per dim
- [x] `npm run lint` (biome) — exit 0
- [x] `npm run lint:md` — exit 0
- [x] `npm run version:check` — exit 0
- [x] Repo-wide grep audit: zero non-comment `resilience:(score|ranking):v13` / `resilience:history:v8` literals

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: `[resilience]` invocations after deploy — expect compute-on-miss for v14 score keys until `seed-resilience-scores` cron warms them
  - Metrics: `/api/health` `resilienceRanking` registered key `resilience:ranking:v14`
  - With flag OFF (default): no `RESILIENCE_FIN_SYS_EXPOSURE_ENABLED` errors should appear; Sentry should be silent on the new dim
- **Validation checks**
  - `redis-cli GET 'resilience:ranking:v14'` returns a populated record after `seed-bundle-resilience` cron runs
  - `redis-cli GET 'resilience:score:v14:US'` shape includes `financialSystemExposure` dim entry with `score=0, coverage=0, imputationClass=null` (flag-off baseline)
- **Expected healthy behavior**
  - First 6h: edge handler computes-on-miss for v14 score keys; per-country GET avg latency rises modestly until warm
  - After cron: ranking + 222 country score keys populated under v14 prefix; latency returns to baseline
  - With flag OFF: every country's `financialSystemExposure.coverage = 0`; the dim is "structurally present, signal-dark"
- **Failure signal / rollback trigger**
  - `/api/health` reports `resilience:ranking:v14` STALE > 12h after merge → Railway cron failing; check `seed-bundle-resilience` logs and re-deploy seeder
  - Spike in 5xx on `/api/resilience/ranking` immediately post-deploy → revert the PR; v13 reads still work since we didn't delete the seeder key
  - With flag accidentally flipped ON (without seeders shipped) → `ResilienceConfigurationError` on every scoreFinancialSystemExposure call → dim shows `imputationClass='source-failure'` for all countries → expected behavior, but indicates the flag flip was premature; flip OFF to revert
- **Validation window & owner**
  - Window: first 12h after merge
  - Owner: Elie

## Activation runbook (for after the seeder PR ships)

1. Merge the seeder follow-up PR
2. Run `seed-bis-lbs`, `seed-fatf-listing`, `seed-wb-external-debt` manually via `railway run` to populate Redis
3. Verify all 3 seed-meta envelopes are present:
   ```
   redis-cli GET 'seed-meta:economic:bis-lbs'
   redis-cli GET 'seed-meta:economic:fatf-listing'
   redis-cli GET 'seed-meta:economic:wb-external-debt'
   ```
4. Set `RESILIENCE_FIN_SYS_EXPOSURE_ENABLED=true` in Vercel + Railway env config
5. Flush v14 caches: bulk `DEL resilience:score:v14:*` + `DEL resilience:ranking:v14`
6. Run `seed-resilience-scores.mjs` to bulk-warm v14 score keys with the new dim's actual signal
7. Cohort audit: snapshot `resilience:score:v14:*` for all 222 countries
8. Sanity-check anchors: Russia / Iran / DPRK score < 20 on `financialSystemExposure`. If they don't, the construct is calibrated wrong — revert the flag flip and retune
9. Bounded-movement gate: at least 60% of countries should have |Δ| < 3 points overall; outliers > 12 must be in the explicitly-predicted set (RU/IR/KP/CU/VE/BY/LY/MM)
10. Remove the `FLAG_GATED_DARK_DIMENSIONS` allow-list entry in `tests/resilience-release-gate.test.mts` in the same commit that flips the flag

---

🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v3.0.0

[![Compound Engineering v3.0.0](https://img.shields.io/badge/Compound_Engineering-v3.0.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)