### PR TITLE
fix(energy-atlas): wire chokepoint-strip primeTask — unstick "Loading…" forever

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -45,6 +45,7 @@ import type { StorageFacilityMapPanel } from '@/components/StorageFacilityMapPan
 import type { FuelShortagePanel } from '@/components/FuelShortagePanel';
 import type { EnergyDisruptionsPanel } from '@/components/EnergyDisruptionsPanel';
 import type { EnergyRiskOverviewPanel } from '@/components/EnergyRiskOverviewPanel';
+import type { ChokepointStripPanel } from '@/components/ChokepointStripPanel';
 import type { ClimateNewsPanel } from '@/components/ClimateNewsPanel';
 import type { ConsumerPricesPanel } from '@/components/ConsumerPricesPanel';
 import type { DefensePatentsPanel } from '@/components/DefensePatentsPanel';
@@ -355,6 +356,14 @@ export class App {
     if (shouldPrime('energy-risk-overview')) {
       const panel = this.state.panels['energy-risk-overview'] as EnergyRiskOverviewPanel | undefined;
       if (panel) primeTask('energy-risk-overview', () => panel.fetchData());
+    }
+    if (shouldPrime('chokepoint-strip')) {
+      // Without this primeTask entry the panel mounts via panel-layout.ts and
+      // ENERGY_PANELS but its constructor only calls showLoading() — fetchData()
+      // never fires, so the panel sits at "Loading..." forever. Hard-learned in
+      // PR #3386; tracked as skill panel-stuck-loading-means-missing-primetask.
+      const panel = this.state.panels['chokepoint-strip'] as ChokepointStripPanel | undefined;
+      if (panel) primeTask('chokepoint-strip', () => panel.fetchData());
     }
     if (shouldPrime('climate-news')) {
       const panel = this.state.panels['climate-news'] as ClimateNewsPanel | undefined;


### PR DESCRIPTION
## Summary

User-reported on energy.worldmonitor.app: **Chokepoint Status panel stuck at "Loading…" forever**. Classic three-site wiring bug — only two of the three required sites for an energy panel are currently wired:

| Site | Status |
|---|---|
| `src/app/panel-layout.ts:890` (createPanel) | ✓ already there |
| `src/config/panels.ts:934` (ENERGY_PANELS) | ✓ already there |
| `src/App.ts` primeTask branch | ❌ **MISSING — this fix** |

The panel base-class constructor only calls `showLoading()`. `primeTask` is the sole kickoff path; without it `fetchData()` never fires.

This exactly matches skill [`panel-stuck-loading-means-missing-primetask`](https://github.com/koala73/worldmonitor/issues?q=panel-stuck-loading-means-missing-primetask) (hard-learned in PR #3386, regression-blocked since).

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Deploy preview: load `energy.worldmonitor.app`, confirm Chokepoint Status renders 7-tile strip (Hormuz / Malacca / Suez / Bab el-Mandeb / Turkish Straits / Danish Straits / Panama) instead of spinner