### PR TITLE
fix(auth): subscribe to Convex entitlement for Pro-gated UI (locked map layers + stuck Trade Policy)

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -80,7 +80,7 @@ import { showProBanner } from '@/components/ProBanner';
 import { initAuthState, subscribeAuthState } from '@/services/auth-state';
 import { install as installCloudPrefsSync, onSignIn as cloudPrefsSignIn, onSignOut as cloudPrefsSignOut } from '@/utils/cloud-prefs-sync';
 import { getConvexClient, getConvexApi, waitForConvexAuth } from '@/services/convex-client';
-import { initEntitlementSubscription, destroyEntitlementSubscription, resetEntitlementState } from '@/services/entitlements';
+import { initEntitlementSubscription, destroyEntitlementSubscription, resetEntitlementState, onEntitlementChange } from '@/services/entitlements';
 import { initSubscriptionWatch, destroySubscriptionWatch } from '@/services/billing';
 import {
   capturePendingCheckoutIntentFromUrl,
@@ -118,6 +118,7 @@ export class App {
   private modules: { destroy(): void }[] = [];
   private unsubAiFlow: (() => void) | null = null;
   private unsubFreeTier: (() => void) | null = null;
+  private unsubEntitlementPremiumLoaders: (() => void) | null = null;
   // Resolves once Phase-4 UI modules (searchManager, countryIntel) have
   // initialised so WebMCP bindings can await readiness before touching
   // the nullable UI targets. Avoids the startup race where an agent
@@ -946,7 +947,14 @@ export class App {
     // loadTradePolicy) would sit empty until the next scheduled refresh — for
     // trade-policy that's a 10-minute wait post-sign-in. See PR #3295 review.
     let _prevHadPremium = hasPremiumAccess();
-    this.unsubFreeTier = subscribeAuthState((session) => {
+    // Pro-loader fan-out runs on EITHER Clerk auth changes OR Convex
+    // entitlement changes — Pro can come from either signal (Clerk
+    // user.role === 'pro' OR Convex tier >= 1 via Dodo). User-reported
+    // on commodity.worldmonitor.app: Trade Policy panel stuck at "Loading…"
+    // for a Pro Monthly subscriber because the original listener only
+    // watched subscribeAuthState (Clerk-only); Convex Free→Pro transitions
+    // never re-fired loadTradePolicy. Same root cause as PR #3409 layer-unlock.
+    const firePremiumLoaders = (): void => {
       this.enforceFreeTierLimits();
       const hadPremium = _prevHadPremium;
       const nowPremium = hasPremiumAccess();
@@ -960,6 +968,10 @@ export class App {
         void this.dataLoader.loadTradePolicy();
       }
       _prevHadPremium = nowPremium;
+    };
+    this.unsubEntitlementPremiumLoaders = onEntitlementChange(() => firePremiumLoaders());
+    this.unsubFreeTier = subscribeAuthState((session) => {
+      firePremiumLoaders();
 
       const userId = session.user?.id ?? null;
       if (userId !== null && userId !== _prevUserId) {
@@ -1256,6 +1268,7 @@ export class App {
     // Clean up subscriptions, map, AIS, and breaking news
     this.unsubAiFlow?.();
     this.unsubFreeTier?.();
+    this.unsubEntitlementPremiumLoaders?.();
     this.state.breakingBanner?.destroy();
     destroyBreakingNewsAlerts();
     this.cachedModeBannerEl?.remove();

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -114,6 +114,7 @@ import { resolveTradeRouteSegments, TRADE_ROUTES as TRADE_ROUTES_LIST, type Trad
 import type { ScenarioVisualState } from '@/config/scenario-templates';
 import { getLayersForVariant, resolveLayerLabel, bindLayerSearch, type MapVariant } from '@/config/map-layer-definitions';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
+import { onEntitlementChange } from '@/services/entitlements';
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { trackGateHit } from '@/services/analytics';
 import { MapPopup, type PopupType } from './MapPopup';
@@ -428,6 +429,7 @@ export class DeckGLMap {
   private aptGroups: import('@/types').APTGroup[] = [];
   private aptGroupsLoaded = false;
   private _unsubscribeAuthState: (() => void) | null = null;
+  private _unsubscribeEntitlement: (() => void) | null = null;
   private aptGroupsLayerFailed = false;
   private satelliteImageryLayerFailed = false;
   private iranEvents: IranEvent[] = [];
@@ -5005,6 +5007,33 @@ export class DeckGLMap {
       queueMicrotask(() => {
         this._unsubscribeAuthState?.();
         this._unsubscribeAuthState = null;
+        this._unsubscribeEntitlement?.();
+        this._unsubscribeEntitlement = null;
+      });
+    });
+    // Pro can come from Convex (Dodo subscription) — subscribeAuthState above
+    // only listens to Clerk changes. A Dodo subscriber whose Pro arrives via
+    // Convex (tier>=1) NOT via Clerk role would never get the unlock fired.
+    // User-reported on energy.worldmonitor.app: "Pro Monthly" in settings UI
+    // but the Resilience layer still showed the lock. Mirror the auth-state
+    // subscription with an entitlement-change subscription that re-runs the
+    // same unlock logic. Whichever fires first with Pro performs the unlock;
+    // the other becomes a no-op via the early-return + already-unsubscribed
+    // queueMicrotask cleanup.
+    this._unsubscribeEntitlement = onEntitlementChange(() => {
+      if (!hasPremiumAccess(getAuthState())) return;
+      toggles.querySelectorAll('.layer-toggle-locked').forEach(label => {
+        label.classList.remove('layer-toggle-locked');
+        const input = label.querySelector('input') as HTMLInputElement | null;
+        if (input) input.disabled = false;
+        const labelSpan = label.querySelector('.toggle-label');
+        if (labelSpan) labelSpan.textContent = labelSpan.textContent!.replace(' 🔒', '');
+      });
+      queueMicrotask(() => {
+        this._unsubscribeAuthState?.();
+        this._unsubscribeAuthState = null;
+        this._unsubscribeEntitlement?.();
+        this._unsubscribeEntitlement = null;
       });
     });
 
@@ -7094,6 +7123,8 @@ export class DeckGLMap {
     this.clearTrailsBtn = null;
     this._unsubscribeAuthState?.();
     this._unsubscribeAuthState = null;
+    this._unsubscribeEntitlement?.();
+    this._unsubscribeEntitlement = null;
     window.removeEventListener('theme-changed', this.handleThemeChange);
     window.removeEventListener('map-theme-changed', this.handleMapThemeChange);
     this.debouncedRebuildLayers.cancel();

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -4992,11 +4992,21 @@ export class DeckGLMap {
 
     this.container.appendChild(toggles);
 
-    // Unlock premium layers when auth state resolves (e.g., Clerk JWT arrives after map init).
-    // subscribeAuthState fires the callback synchronously if state is already available,
-    // so we defer the self-unsubscribe with queueMicrotask to ensure the assignment completes.
-    this._unsubscribeAuthState = subscribeAuthState((state) => {
-      if (!hasPremiumAccess(state)) return;
+    // Unlock premium layers when Pro status resolves. Pro can come from EITHER:
+    //   1. Clerk role === 'pro' (subscribeAuthState fires on Clerk changes)
+    //   2. Convex entitlement tier >= 1 (onEntitlementChange fires on Convex changes)
+    // Subscribing to BOTH covers Dodo subscribers whose Pro flag arrives via
+    // Convex (NOT via Clerk role). User-reported on energy.worldmonitor.app:
+    // "Pro Monthly" in settings UI but Resilience layer still showed the lock
+    // because subscribeAuthState alone never fires on Convex transitions.
+    //
+    // Whichever signal resolves Pro first does the unlock; the other becomes
+    // a no-op (early-return when not Pro; no-op .remove on already-removed
+    // class). queueMicrotask defers self-unsubscribe so both _unsubscribe*
+    // assignments complete before the unsubscribe runs. Greptile P2 fix:
+    // single helper instead of duplicated callback bodies.
+    const unlockIfPro = (): void => {
+      if (!hasPremiumAccess(getAuthState())) return;
       toggles.querySelectorAll('.layer-toggle-locked').forEach(label => {
         label.classList.remove('layer-toggle-locked');
         const input = label.querySelector('input') as HTMLInputElement | null;
@@ -5010,32 +5020,9 @@ export class DeckGLMap {
         this._unsubscribeEntitlement?.();
         this._unsubscribeEntitlement = null;
       });
-    });
-    // Pro can come from Convex (Dodo subscription) — subscribeAuthState above
-    // only listens to Clerk changes. A Dodo subscriber whose Pro arrives via
-    // Convex (tier>=1) NOT via Clerk role would never get the unlock fired.
-    // User-reported on energy.worldmonitor.app: "Pro Monthly" in settings UI
-    // but the Resilience layer still showed the lock. Mirror the auth-state
-    // subscription with an entitlement-change subscription that re-runs the
-    // same unlock logic. Whichever fires first with Pro performs the unlock;
-    // the other becomes a no-op via the early-return + already-unsubscribed
-    // queueMicrotask cleanup.
-    this._unsubscribeEntitlement = onEntitlementChange(() => {
-      if (!hasPremiumAccess(getAuthState())) return;
-      toggles.querySelectorAll('.layer-toggle-locked').forEach(label => {
-        label.classList.remove('layer-toggle-locked');
-        const input = label.querySelector('input') as HTMLInputElement | null;
-        if (input) input.disabled = false;
-        const labelSpan = label.querySelector('.toggle-label');
-        if (labelSpan) labelSpan.textContent = labelSpan.textContent!.replace(' 🔒', '');
-      });
-      queueMicrotask(() => {
-        this._unsubscribeAuthState?.();
-        this._unsubscribeAuthState = null;
-        this._unsubscribeEntitlement?.();
-        this._unsubscribeEntitlement = null;
-      });
-    });
+    };
+    this._unsubscribeAuthState = subscribeAuthState(() => unlockIfPro());
+    this._unsubscribeEntitlement = onEntitlementChange(() => unlockIfPro());
 
     // Bind toggle events
     toggles.querySelectorAll('.layer-toggle input').forEach(input => {


### PR DESCRIPTION
## Summary

User-reported across two subdomains:

1. **energy.worldmonitor.app** — Pro Monthly subscriber sees the 🔒 padlock on the Resilience map layer despite settings UI showing "Pro Monthly · Renews 5/7/2026 · Manage Billing".
2. **commodity.worldmonitor.app** — Trade Policy panel stuck at "Loading…" forever for the same user.

## Single root cause, two call sites

`hasPremiumAccess()` reads BOTH signals — Clerk `user.role === 'pro'` **OR** Convex entitlement `tier >= 1` (via `isProUser()`). But two long-lived subscriptions in this codebase only watched `subscribeAuthState` (Clerk-only):

| File | Site | Symptom for Convex-only Pro |
|---|---|---|
| `src/components/DeckGLMap.ts` | layer-toggle unlock listener | locked layer stays locked |
| `src/App.ts` | Pro-loader boot fan-out | `loadTradePolicy` never re-fires after Convex resolves Pro → 10-min scheduler-tick wait |

For Dodo subscribers whose Pro flag arrives via Convex (NOT via Clerk role), neither subscriber re-runs after Free→Pro because the source they listen to (Clerk) never fires.

## Fix (both call sites)

Add a parallel `onEntitlementChange` subscription that runs the same handler body. Whichever signal resolves Pro first does the work; the other becomes a no-op via the existing gate (`!hasPremiumAccess(getAuthState())` early-return on the unlock listener; `_prevHadPremium → nowPremium` flag on the loader fan-out). `destroy()` tears down both subscriptions.

## Out of scope

- `GlobeMap.createLayerToggles` (line 1826) has a different latent bug — checks only `_wmKey` (= API key presence), ignoring Pro entirely. Energy variant is flat-only / DeckGL, so user's reported bug fully addressed by DeckGLMap fix here. GlobeMap fix tracked as follow-up.
- The Live Tankers layer rendering empty on energy.worldmonitor.app is a separate issue (relay deployment / AISStream subscription scope), not auth-related.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Repro on deploy preview: Pro user (Dodo subscription, no Clerk role override) on:
  - energy.worldmonitor.app → Resilience map layer renders without 🔒
  - commodity.worldmonitor.app → Trade Policy panel renders content (not stuck Loading…)
- [ ] Sanity: API-key dev path still unlocks both
- [ ] Sanity: Free user still sees lock and Trade Policy gated