### PR TITLE
fix(ais-relay): subscribe to ShipStaticData so tanker layer actually populates

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -6372,6 +6372,18 @@ const candidateReports = new Map();
 // consumer's contract is unchanged.
 const tankerReports = new Map();
 
+// MMSI → { shipType, shipName, lastSeen } cache populated from
+// ShipStaticData messages. AISStream's PositionReport message does NOT
+// carry ShipType in MetaData (per their schema), so a relay that filters
+// to PositionReport-only never gets the type signal — tanker classification
+// (which needs shipType ∈ 80..89) is impossible on PositionReport alone.
+// Static data arrives every ~6 minutes per MMSI so the cache hits steady
+// state quickly. Without this, tankerReports stays permanently empty and
+// the live-tanker layer renders zero vessels — root cause identified
+// 2026-04-25 when the layer shipped (#3402) but rendered empty.
+const vesselMeta = new Map();
+const VESSEL_META_TTL_MS = 24 * 60 * 60 * 1000; // 24h — well over the 6-min broadcast cycle
+
 let snapshotSequence = 0;
 let lastSnapshot = null;
 let lastSnapshotAt = 0;
@@ -6567,6 +6579,12 @@ function processRawUpstreamMessage(raw) {
     const parsed = JSON.parse(raw);
     if (parsed?.MessageType === 'PositionReport') {
       processPositionReportForSnapshot(parsed);
+    } else if (parsed?.MessageType === 'ShipStaticData') {
+      // Cache ShipType + ShipName by MMSI so subsequent PositionReports
+      // can classify the vessel as a tanker. AISStream broadcasts static
+      // data ~every 6 min per vessel; in steady state the cache covers
+      // most active MMSIs within minutes of relay startup.
+      processShipStaticDataForMeta(parsed);
     }
   } catch {
     // Ignore malformed upstream payloads
@@ -6585,6 +6603,24 @@ function processRawUpstreamMessage(raw) {
       }
     }
   }
+}
+
+function processShipStaticDataForMeta(data) {
+  // AISStream Type 5 (ShipStaticData). Carries ShipType, ShipName, IMO,
+  // CallSign, dimensions. We only need ShipType + ShipName for classification.
+  const meta = data?.MetaData;
+  const sd = data?.Message?.ShipStaticData;
+  if (!meta || !sd) return;
+  const mmsi = String(meta.MMSI || '');
+  if (!mmsi) return;
+  // ShipType lives in the message body, not MetaData, on Type 5 frames.
+  const shipType = Number(sd.Type);
+  if (!Number.isFinite(shipType)) return;
+  vesselMeta.set(mmsi, {
+    shipType,
+    shipName: (sd.Name || meta.ShipName || '').trim(),
+    lastSeen: Date.now(),
+  });
 }
 
 function processPositionReportForSnapshot(data) {
@@ -6655,11 +6691,20 @@ function processPositionReportForSnapshot(data) {
   // hazardous cargo classes A-D, and other tanker variants). Stored in a
   // SEPARATE Map from candidateReports so the existing military-detection
   // consumer never sees tankers (their contract is unchanged).
-  const shipType = Number(meta.ShipType);
+  //
+  // ShipType is NOT in PositionReport MetaData per AISStream's schema —
+  // it arrives in ShipStaticData (Type 5) frames, cached in vesselMeta
+  // by processShipStaticDataForMeta. Pre-fix, this predicate always
+  // failed (NaN) and tankerReports stayed empty; rendering empty layer
+  // on energy.worldmonitor.app despite PR #3402 wiring being correct.
+  const cachedMeta = vesselMeta.get(mmsi);
+  const shipType = Number.isFinite(Number(meta.ShipType))
+    ? Number(meta.ShipType)
+    : (cachedMeta ? cachedMeta.shipType : NaN);
   if (Number.isFinite(shipType) && shipType >= 80 && shipType <= 89) {
     tankerReports.set(mmsi, {
       mmsi,
-      name: meta.ShipName || '',
+      name: (cachedMeta && cachedMeta.shipName) || meta.ShipName || '',
       lat,
       lon,
       shipType,
@@ -6738,6 +6783,16 @@ function cleanupAggregates() {
     }
   }
   evictMapByTimestamp(tankerReports, MAX_TANKER_REPORTS_PER_RESPONSE * 10, (report) => report.timestamp || 0);
+
+  // vesselMeta TTL eviction: drop entries older than VESSEL_META_TTL_MS so
+  // long-running relays don't accumulate metadata for vessels that have
+  // sailed out of any tracked region. ShipStaticData is rebroadcast every
+  // ~6 min, so a 24h TTL covers vessels with intermittent visibility.
+  for (const [mmsi, entry] of vesselMeta) {
+    if (entry.lastSeen < now - VESSEL_META_TTL_MS) {
+      vesselMeta.delete(mmsi);
+    }
+  }
 
   // Clean chokepoint buckets: remove stale vessels
   for (const [cpName, bucket] of chokepointBuckets) {
@@ -10598,7 +10653,13 @@ function connectUpstream() {
     socket.send(JSON.stringify({
       APIKey: API_KEY,
       BoundingBoxes: [[[-90, -180], [90, 180]]],
-      FilterMessageTypes: ['PositionReport'],
+      // ShipStaticData (AIS Type 5) carries ShipType, which PositionReport
+      // does not. Required for tanker classification on the Energy Atlas
+      // live-tanker layer — without it, vesselMeta cache stays empty and
+      // tankerReports never populates. Static data is broadcast every ~6
+      // min per vessel (ITU-R M.1371), so the volume add is small relative
+      // to PositionReport (which broadcasts every 2-10s underway).
+      FilterMessageTypes: ['PositionReport', 'ShipStaticData'],
     }));
   });
 

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -6442,9 +6442,15 @@ function getGridKey(lat, lon) {
   return `${gridLat},${gridLon}`;
 }
 
-function isLikelyMilitaryCandidate(meta) {
+function isLikelyMilitaryCandidate(meta, resolvedShipType) {
   const mmsi = String(meta?.MMSI || '');
-  const shipType = Number(meta?.ShipType);
+  // Prefer caller-resolved shipType (typically from vesselMeta cache) so
+  // PositionReport callers — where MetaData lacks ShipType — still hit the
+  // type-based military arm (35/55/50-59) instead of relying purely on
+  // NAVAL_PREFIX_RE + MMSI-suffix fallbacks.
+  const shipType = Number.isFinite(Number(resolvedShipType))
+    ? Number(resolvedShipType)
+    : Number(meta?.ShipType);
   const name = (meta?.ShipName || '').trim().toUpperCase();
 
   if (Number.isFinite(shipType) && (shipType === 35 || shipType === 55 || (shipType >= 50 && shipType <= 59))) {
@@ -6642,13 +6648,29 @@ function processPositionReportForSnapshot(data) {
 
   const now = Date.now();
 
+  // Resolve ShipType ONCE per position report and feed it to every consumer
+  // below (vessels record, military classifier, tanker capture). Pre-fix,
+  // each consumer read meta.ShipType directly — but AISStream's PositionReport
+  // MetaData does NOT carry that field; ShipType only arrives via Type 5
+  // ShipStaticData frames cached in vesselMeta. The consequence wasn't just
+  // an empty tanker layer (PR #3410 original scope) — `vessels[mmsi].shipType`
+  // was also undefined, so classifyVesselType(vessel?.shipType) used by
+  // chokepoint transit logging at line ~6555 always returned 'other'. That
+  // silently broke per-type transit counts in /seedChokepointTransits and
+  // every downstream consumer of transit-by-type breakdowns. PR3410 review
+  // catch — same root cause, same vesselMeta cache fixes all three sites.
+  const cachedMeta = vesselMeta.get(mmsi);
+  const effectiveShipType = Number.isFinite(Number(meta.ShipType))
+    ? Number(meta.ShipType)
+    : (cachedMeta ? cachedMeta.shipType : undefined);
+
   vessels.set(mmsi, {
     mmsi,
-    name: meta.ShipName || '',
+    name: meta.ShipName || (cachedMeta && cachedMeta.shipName) || '',
     lat,
     lon,
     timestamp: now,
-    shipType: meta.ShipType,
+    shipType: effectiveShipType,
     heading: pos.TrueHeading,
     speed: pos.Sog,
     course: pos.Cog,
@@ -6677,13 +6699,13 @@ function processPositionReportForSnapshot(data) {
   // Maintain exact chokepoint membership so moving vessels don't get "stuck" in old buckets.
   updateVesselChokepoints(mmsi, lat, lon);
 
-  if (isLikelyMilitaryCandidate(meta)) {
+  if (isLikelyMilitaryCandidate(meta, effectiveShipType)) {
     candidateReports.set(mmsi, {
       mmsi,
-      name: meta.ShipName || '',
+      name: meta.ShipName || (cachedMeta && cachedMeta.shipName) || '',
       lat,
       lon,
-      shipType: meta.ShipType,
+      shipType: effectiveShipType,
       heading: pos.TrueHeading,
       speed: pos.Sog,
       course: pos.Cog,
@@ -6696,16 +6718,7 @@ function processPositionReportForSnapshot(data) {
   // hazardous cargo classes A-D, and other tanker variants). Stored in a
   // SEPARATE Map from candidateReports so the existing military-detection
   // consumer never sees tankers (their contract is unchanged).
-  //
-  // ShipType is NOT in PositionReport MetaData per AISStream's schema —
-  // it arrives in ShipStaticData (Type 5) frames, cached in vesselMeta
-  // by processShipStaticDataForMeta. Pre-fix, this predicate always
-  // failed (NaN) and tankerReports stayed empty; rendering empty layer
-  // on energy.worldmonitor.app despite PR #3402 wiring being correct.
-  const cachedMeta = vesselMeta.get(mmsi);
-  const shipType = Number.isFinite(Number(meta.ShipType))
-    ? Number(meta.ShipType)
-    : (cachedMeta ? cachedMeta.shipType : NaN);
+  const shipType = Number.isFinite(Number(effectiveShipType)) ? Number(effectiveShipType) : NaN;
   if (Number.isFinite(shipType) && shipType >= 80 && shipType <= 89) {
     tankerReports.set(mmsi, {
       mmsi,

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -6611,7 +6611,12 @@ function processShipStaticDataForMeta(data) {
   const meta = data?.MetaData;
   const sd = data?.Message?.ShipStaticData;
   if (!meta || !sd) return;
-  const mmsi = String(meta.MMSI || '');
+  // MMSI fallback: AISStream's PositionReport wrapper puts MMSI under
+  // MetaData.MMSI, but the ShipStaticData payload sample shows MMSI mirrored
+  // as `UserID` on the message body itself. Read MetaData.MMSI first (the
+  // documented wrapper field), then fall back to the message-body field so
+  // a wrapper schema variant doesn't silently re-empty vesselMeta.
+  const mmsi = String(meta.MMSI || sd.UserID || '');
   if (!mmsi) return;
   // ShipType lives in the message body, not MetaData, on Type 5 frames.
   const shipType = Number(sd.Type);

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -6360,6 +6360,14 @@ const SNAPSHOT_INTERVAL_MS = Math.max(2000, Number(process.env.AIS_SNAPSHOT_INTE
 const CANDIDATE_RETENTION_MS = 2 * 60 * 60 * 1000; // 2 hours
 const MAX_DENSITY_ZONES = 200;
 const MAX_CANDIDATE_REPORTS = 1500;
+// Hard size cap for vesselMeta. Active global AIS fleet is ~50-70k unique
+// MMSIs at any given time (UNCTAD/MarineTraffic estimates). 50k headroom
+// covers steady state with the 24h TTL; a hostile or buggy upstream that
+// floods unique MMSIs gets bounded after this cap. Pairs with the TTL
+// loop in cleanupAggregates so eviction has both age-based and size-based
+// gates, matching the pattern used by tankerReports / candidateReports /
+// densityGrid / vesselHistory.
+const MAX_VESSEL_META = 50000;
 
 const vessels = new Map();
 const vesselHistory = new Map();
@@ -6625,8 +6633,13 @@ function processShipStaticDataForMeta(data) {
   const mmsi = String(meta.MMSI || sd.UserID || '');
   if (!mmsi) return;
   // ShipType lives in the message body, not MetaData, on Type 5 frames.
+  // Gate on `> 0` (not just `Number.isFinite`) so that Number(null) === 0
+  // and AIS code 0 ("Not available" per ITU-R M.1371) don't overwrite a
+  // previously-cached valid type. Otherwise a vessel that broadcasts
+  // {Type: 85} then later {Type: null} would be downgraded to non-tanker
+  // because the second write replaces the first with shipType=0.
   const shipType = Number(sd.Type);
-  if (!Number.isFinite(shipType)) return;
+  if (!Number.isFinite(shipType) || shipType <= 0) return;
   vesselMeta.set(mmsi, {
     shipType,
     shipName: (sd.Name || meta.ShipName || '').trim(),
@@ -6811,6 +6824,10 @@ function cleanupAggregates() {
       vesselMeta.delete(mmsi);
     }
   }
+  // Hard size cap as defense-in-depth against a hostile/buggy upstream
+  // flooding unique MMSIs faster than the TTL eviction can drain them.
+  // Matches the pattern used by every peer Map in this function.
+  evictMapByTimestamp(vesselMeta, MAX_VESSEL_META, (entry) => entry.lastSeen || 0);
 
   // Clean chokepoint buckets: remove stale vessels
   for (const [cpName, bucket] of chokepointBuckets) {

--- a/tests/relay-tanker-shipstatic.test.mjs
+++ b/tests/relay-tanker-shipstatic.test.mjs
@@ -112,12 +112,35 @@ describe('ais-relay — tanker classification depends on ShipStaticData', () => 
     );
   });
 
-  test('vesselMeta has TTL eviction so it cannot grow unbounded', () => {
+  test('vesselMeta has TTL eviction AND hard size cap so it cannot grow unbounded', () => {
     assert.match(RELAY, /VESSEL_META_TTL_MS/);
     assert.match(
       RELAY,
       /vesselMeta\.delete\(/,
       'cleanup must delete stale vesselMeta entries',
+    );
+    // PR #3410 review (Greptile P1): every peer Map in cleanupAggregates
+    // (tankerReports, candidateReports, densityGrid, vesselHistory) follows
+    // its TTL loop with an evictMapByTimestamp hard cap. vesselMeta must
+    // match that pattern — TTL alone is insufficient against a hostile or
+    // buggy upstream flooding unique MMSIs faster than the TTL drains them.
+    assert.match(RELAY, /MAX_VESSEL_META/);
+    assert.match(
+      RELAY,
+      /evictMapByTimestamp\(\s*vesselMeta\s*,/,
+      'vesselMeta must have a hard size cap via evictMapByTimestamp',
+    );
+  });
+
+  test('processShipStaticDataForMeta rejects shipType <= 0 (AIS code 0 = "Not available")', () => {
+    // Number(null) === 0, which is finite. Without the > 0 gate, a Type 5
+    // frame with Type=null after a valid Type=85 would overwrite the
+    // cached tanker as shipType=0, downgrading classification on the next
+    // PositionReport. Pin the gate so a refactor can't accidentally drop it.
+    assert.match(
+      RELAY,
+      /!Number\.isFinite\(shipType\)\s*\|\|\s*shipType\s*<=\s*0/,
+      'shipType must be guarded against <= 0 in processShipStaticDataForMeta',
     );
   });
 

--- a/tests/relay-tanker-shipstatic.test.mjs
+++ b/tests/relay-tanker-shipstatic.test.mjs
@@ -120,4 +120,61 @@ describe('ais-relay — tanker classification depends on ShipStaticData', () => 
       'cleanup must delete stale vesselMeta entries',
     );
   });
+
+  test('vessels record uses effectiveShipType (NOT raw meta.ShipType)', () => {
+    // Without this, classifyVesselType(vessel?.shipType) at the chokepoint
+    // transit logging site always returns 'other' because meta.ShipType
+    // is permanently undefined on PositionReport. Same root cause as the
+    // tanker layer being empty — needs the same vesselMeta fallback.
+    const fnStart = RELAY.indexOf('function processPositionReportForSnapshot');
+    const nextFnRel = RELAY.slice(fnStart + 1).search(/\nfunction\s/);
+    const fnEnd = nextFnRel > -1 ? fnStart + 1 + nextFnRel : RELAY.length;
+    const fnBody = RELAY.slice(fnStart, fnEnd);
+    // The vessels.set call must reference effectiveShipType, not meta.ShipType
+    const vesselsSetMatch = fnBody.match(/vessels\.set\(\s*mmsi\s*,\s*\{[^}]*shipType:\s*([^,\n}]+)/);
+    assert.ok(vesselsSetMatch, 'vessels.set must include a shipType field');
+    assert.match(
+      vesselsSetMatch[1].trim(),
+      /^effectiveShipType\b/,
+      `vessels.set shipType must be effectiveShipType (was: ${vesselsSetMatch[1].trim()})`,
+    );
+  });
+
+  test('isLikelyMilitaryCandidate accepts a resolved-shipType override', () => {
+    // PositionReport callers must pass effectiveShipType so the type-based
+    // military arms (35/55/50-59) actually fire. Without the override, the
+    // classifier falls back to NAVAL_PREFIX_RE + MMSI suffix only.
+    assert.match(
+      RELAY,
+      /function\s+isLikelyMilitaryCandidate\s*\(\s*meta\s*,\s*resolvedShipType\s*\)/,
+      'isLikelyMilitaryCandidate must accept a resolvedShipType parameter',
+    );
+    // The PositionReport call site must pass it through
+    const fnStart = RELAY.indexOf('function processPositionReportForSnapshot');
+    const nextFnRel = RELAY.slice(fnStart + 1).search(/\nfunction\s/);
+    const fnEnd = nextFnRel > -1 ? fnStart + 1 + nextFnRel : RELAY.length;
+    const fnBody = RELAY.slice(fnStart, fnEnd);
+    assert.match(
+      fnBody,
+      /isLikelyMilitaryCandidate\(\s*meta\s*,\s*effectiveShipType\s*\)/,
+      'PositionReport must invoke isLikelyMilitaryCandidate with effectiveShipType',
+    );
+  });
+
+  test('candidateReports record uses effectiveShipType', () => {
+    // Same fix as vessels.set — military candidate snapshots had shipType
+    // permanently undefined, so any downstream consumer that filtered
+    // candidates by ship type was broken too.
+    const fnStart = RELAY.indexOf('function processPositionReportForSnapshot');
+    const nextFnRel = RELAY.slice(fnStart + 1).search(/\nfunction\s/);
+    const fnEnd = nextFnRel > -1 ? fnStart + 1 + nextFnRel : RELAY.length;
+    const fnBody = RELAY.slice(fnStart, fnEnd);
+    const candSetMatch = fnBody.match(/candidateReports\.set\(\s*mmsi\s*,\s*\{[^}]*shipType:\s*([^,\n}]+)/);
+    assert.ok(candSetMatch, 'candidateReports.set must include a shipType field');
+    assert.match(
+      candSetMatch[1].trim(),
+      /^effectiveShipType\b/,
+      `candidateReports.set shipType must be effectiveShipType (was: ${candSetMatch[1].trim()})`,
+    );
+  });
 });

--- a/tests/relay-tanker-shipstatic.test.mjs
+++ b/tests/relay-tanker-shipstatic.test.mjs
@@ -59,12 +59,53 @@ describe('ais-relay — tanker classification depends on ShipStaticData', () => 
     );
   });
 
+  test('processShipStaticDataForMeta reads ShipType from sd.Type (NOT meta.ShipType)', () => {
+    // Pre-fix root cause was reading from meta.ShipType which AISStream
+    // never populates on PositionReport. ShipStaticData puts ShipType under
+    // the message body as `Type` (capital T), not the wrapper MetaData. A
+    // typo regression (e.g., `Number(sd.Typ)`, `Number(sd.shipType)`,
+    // `Number(meta.ShipType)`) would re-empty the tanker layer silently —
+    // the tests in this file depend on the FIELD NAME being correct, so
+    // pin it explicitly.
+    assert.match(
+      RELAY,
+      /Number\(sd\.Type\)/,
+      'shipType must be parsed from sd.Type (the message-body field)',
+    );
+    assert.match(
+      RELAY,
+      /sd\.Name/,
+      'shipName should fall back to sd.Name from the message body',
+    );
+  });
+
+  test('processShipStaticDataForMeta accepts MMSI from meta.MMSI OR sd.UserID', () => {
+    // AISStream's ShipStaticData payload mirrors MMSI as UserID on the
+    // message body. Defense in depth against a wrapper-schema variant
+    // that omits MetaData.MMSI on Type 5 frames — without the fallback,
+    // such a frame would early-return and silently re-empty vesselMeta.
+    assert.match(
+      RELAY,
+      /String\(\s*meta\.MMSI\s*\|\|\s*sd\.UserID\s*\|\|\s*['"]['"]?\s*\)/,
+      'MMSI extraction must fall back to sd.UserID',
+    );
+  });
+
   test('tanker capture falls back to vesselMeta when position-report meta lacks ShipType', () => {
-    // Order matters: cachedMeta lookup must precede tanker classification.
-    const cacheLookupIdx = RELAY.indexOf('vesselMeta.get(mmsi)');
-    const tankerSetIdx = RELAY.indexOf('tankerReports.set(mmsi');
-    assert.ok(cacheLookupIdx > -1, 'vesselMeta.get(mmsi) must appear in tanker capture path');
-    assert.ok(tankerSetIdx > -1, 'tankerReports.set(mmsi) must appear');
+    // Scope the order assertion to the body of processPositionReportForSnapshot
+    // so a future change adding an earlier vesselMeta.get(...) elsewhere in
+    // the file can't satisfy the order check while removing the in-tanker-path
+    // lookup. The body extends until the next top-level function declaration.
+    const fnStart = RELAY.indexOf('function processPositionReportForSnapshot');
+    assert.ok(fnStart > -1, 'processPositionReportForSnapshot must exist');
+    // Find next top-level `function ` after the start (matches column-0 `function`)
+    const nextFnRel = RELAY.slice(fnStart + 1).search(/\nfunction\s/);
+    const fnEnd = nextFnRel > -1 ? fnStart + 1 + nextFnRel : RELAY.length;
+    const fnBody = RELAY.slice(fnStart, fnEnd);
+    const cacheLookupIdx = fnBody.indexOf('vesselMeta.get(mmsi)');
+    const tankerSetIdx = fnBody.indexOf('tankerReports.set(mmsi');
+    assert.ok(cacheLookupIdx > -1, 'vesselMeta.get(mmsi) must appear inside processPositionReportForSnapshot');
+    assert.ok(tankerSetIdx > -1, 'tankerReports.set(mmsi) must appear inside processPositionReportForSnapshot');
     assert.ok(
       cacheLookupIdx < tankerSetIdx,
       'vesselMeta lookup must precede tanker insertion so the fallback informs the predicate',

--- a/tests/relay-tanker-shipstatic.test.mjs
+++ b/tests/relay-tanker-shipstatic.test.mjs
@@ -1,0 +1,82 @@
+// Static-analysis regression tests for the relay's tanker-classification
+// dependency on ShipStaticData (AIS Type 5).
+//
+// Background: AISStream's PositionReport messages do NOT carry ShipType in
+// MetaData. PR #3402 shipped tanker capture predicated on `meta.ShipType`,
+// which evaluated to NaN on every PositionReport, so tankerReports stayed
+// permanently empty and the live-tanker layer rendered zero vessels on
+// energy.worldmonitor.app.
+//
+// These tests pin the fix shape so a regression can't flip the relay back
+// to PositionReport-only and silently re-empty the tanker layer:
+//   1. AISStream subscription includes ShipStaticData in FilterMessageTypes.
+//   2. Relay dispatches ShipStaticData → processShipStaticDataForMeta.
+//   3. Tanker capture predicate falls back to vesselMeta cache when the
+//      position-report meta lacks ShipType.
+
+import { strict as assert } from 'node:assert';
+import { describe, test } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const RELAY = readFileSync(
+  resolve(__dirname, '..', 'scripts', 'ais-relay.cjs'),
+  'utf-8',
+);
+
+describe('ais-relay — tanker classification depends on ShipStaticData', () => {
+  test('AISStream subscription requests both PositionReport AND ShipStaticData', () => {
+    // Without ShipStaticData, ShipType is never populated and tanker capture
+    // fails on every position report.
+    assert.match(
+      RELAY,
+      /FilterMessageTypes:\s*\[\s*['"]PositionReport['"]\s*,\s*['"]ShipStaticData['"]\s*\]/,
+      'AISStream subscription must request both PositionReport and ShipStaticData',
+    );
+  });
+
+  test('relay dispatches ShipStaticData → processShipStaticDataForMeta', () => {
+    assert.match(
+      RELAY,
+      /MessageType\s*===\s*['"]ShipStaticData['"]/,
+      'relay must branch on MessageType === ShipStaticData',
+    );
+    assert.match(
+      RELAY,
+      /processShipStaticDataForMeta\s*\(/,
+      'relay must invoke processShipStaticDataForMeta on Type 5 frames',
+    );
+  });
+
+  test('vesselMeta cache is declared and populated by ShipStaticData handler', () => {
+    assert.match(RELAY, /const\s+vesselMeta\s*=\s*new Map\(\)/);
+    assert.match(
+      RELAY,
+      /vesselMeta\.set\([^)]+,\s*\{[^}]*shipType/,
+      'processShipStaticDataForMeta must write shipType into vesselMeta',
+    );
+  });
+
+  test('tanker capture falls back to vesselMeta when position-report meta lacks ShipType', () => {
+    // Order matters: cachedMeta lookup must precede tanker classification.
+    const cacheLookupIdx = RELAY.indexOf('vesselMeta.get(mmsi)');
+    const tankerSetIdx = RELAY.indexOf('tankerReports.set(mmsi');
+    assert.ok(cacheLookupIdx > -1, 'vesselMeta.get(mmsi) must appear in tanker capture path');
+    assert.ok(tankerSetIdx > -1, 'tankerReports.set(mmsi) must appear');
+    assert.ok(
+      cacheLookupIdx < tankerSetIdx,
+      'vesselMeta lookup must precede tanker insertion so the fallback informs the predicate',
+    );
+  });
+
+  test('vesselMeta has TTL eviction so it cannot grow unbounded', () => {
+    assert.match(RELAY, /VESSEL_META_TTL_MS/);
+    assert.match(
+      RELAY,
+      /vesselMeta\.delete\(/,
+      'cleanup must delete stale vesselMeta entries',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

User-reported on energy.worldmonitor.app: **Live Tanker Positions layer renders zero vessels** despite PR #3402's wiring being correct end-to-end.

## Root cause (full debug trace)

AISStream's `PositionReport.MetaData` does **NOT** carry `ShipType` per their schema — that field only arrives in `ShipStaticData` (Type 5) frames. PR #3402 shipped tanker capture predicated on `meta.ShipType`:

```js
const shipType = Number(meta.ShipType);  // always NaN
if (Number.isFinite(shipType) && shipType >= 80 && shipType <= 89) {
  tankerReports.set(mmsi, ...);  // never executes
}
```

The relay subscribed to AISStream with `FilterMessageTypes: ['PositionReport']` only — `ShipStaticData` never reached the relay, so the predicate always failed (NaN), `tankerReports` Map stayed permanently empty, and `getVesselSnapshot` returned `tankerReports: []` to every caller. The frontend layer correctly rendered zero vessels.

Military detection (`isLikelyMilitaryCandidate`) survived because it has fallback paths (`NAVAL_PREFIX_RE` on ShipName + MMSI-suffix `00`/`99`). Tanker detection had zero fallback because tanker MMSIs and names don't follow a single regex pattern.

## Fix

| Change | Purpose |
|---|---|
| `FilterMessageTypes` ← `['PositionReport', 'ShipStaticData']` | Receive Type 5 frames |
| New `processShipStaticDataForMeta` handler | Cache `{shipType, shipName, lastSeen}` by MMSI in a `vesselMeta` Map |
| Tanker-capture predicate in `processPositionReportForSnapshot` falls back to `vesselMeta.get(mmsi).shipType` when `meta.ShipType` is missing | The actual classification logic |
| TTL eviction in `cleanupAggregates` (24h) for `vesselMeta` | Bound memory growth on long-running relay |

## Volume impact

ShipStaticData is broadcast every ~6 min per vessel (vs every 2-10s for PositionReport while underway). Negligible volume increase relative to the existing PositionReport firehose.

## Test plan

- [x] `node -c scripts/ais-relay.cjs` syntax clean
- [x] `tests/relay-tanker-shipstatic.test.mjs` (new, 5/5 pass) — static-analysis regression that pins the fix shape so a future change can't flip `FilterMessageTypes` back to `PositionReport`-only and silently re-empty the layer
- [ ] **Deploy**: Railway redeploy of the AIS-relay service required to pick up the new subscription
- [ ] **Soak ~5-10 min** post-deploy for vesselMeta to populate from ShipStaticData broadcasts
- [ ] **Verify on energy.worldmonitor.app**: Live Tanker Positions layer should render vessels in the 6 chokepoint bboxes (Hormuz, Suez, Bab el-Mandeb, Malacca, Panama, Turkish Straits)
- [ ] **Network tab check**: `GetVesselSnapshot` response should include `snapshot.tankerReports[]` with entries for the bbox query