### PR TITLE
fix(brief): restore email multi-section format + de-vapidify lead prompt

### DIFF
--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -20,7 +20,7 @@
 //     SHA-256 of the resolved digest lead so per-story rationales
 //     re-generate when the lead changes (rationales must align with
 //     the headline frame). v2 rows were lead-blind and could drift.
-//   - brief:llm:digest:v3:{userId|public}:{sensitivity}:{poolHash}
+//   - brief:llm:digest:v4:{userId|public}:{sensitivity}:{poolHash}
 //     — 4h. The canonical synthesis is now ALWAYS produced through
 //     this path (formerly split with `generateAISummary` in the
 //     digest cron). Material includes profile-SHA, greeting bucket,
@@ -322,21 +322,34 @@ const DIGEST_PROSE_SYSTEM_BASE =
   "today's top stories for a reader, produce EXACTLY this JSON and nothing " +
   'else (no markdown, no code fences, no preamble):\n' +
   '{\n' +
-  '  "lead": "<2–3 sentence executive summary, editorial tone, references ' +
-  'the most important 1–2 threads, addresses the reader directly>",\n' +
+  '  "lead": "<2–3 sentences. The FIRST sentence MUST name the single most ' +
+  "impactful development by its specific actor and event (e.g. \"Pentagon " +
+  "chief Hegseth declared the US blockade on Iran is going global\"), NOT " +
+  'an editorial framing about "geopolitical tensions" or "shifting ' +
+  'landscapes". Subsequent sentences may give brief context. Reference at ' +
+  'most 1–2 threads. No vapid hedging.>",\n' +
   '  "threads": [\n' +
   '    { "tag": "<one-word editorial category e.g. Energy, Diplomacy, Climate>", ' +
-  '"teaser": "<one sentence describing what is developing>" }\n' +
+  '"teaser": "<one sentence naming a SPECIFIC event or actor — e.g. ' +
+  '\\"Hegseth fired Navy Secretary Phelan amid Iran-policy rift\\" — NOT ' +
+  'generic phrasing like \\"tensions continue to develop\\".>" }\n' +
   '  ],\n' +
-  '  "signals": ["<forward-looking imperative phrase, <=14 words>"],\n' +
+  '  "signals": ["<forward-looking imperative phrase, <=14 words, naming a ' +
+  'specific watch-item — e.g. \\"Watch for direct US-Iran naval engagement ' +
+  'in the Strait of Hormuz\\".>"],\n' +
   '  "rankedStoryHashes": ["<short hash from the [h:XXXX] prefix of the most ' +
   'important story>", "..."]\n' +
   '}\n' +
+  'BANNED phrasing (do NOT use any of these — they are vapid editorial ' +
+  'filler that hides which events actually matter): "the global stage", ' +
+  '"buzzing with developments", "intricate shifts", "evolving landscape", ' +
+  '"navigating", "discerning reader", "continues to simmer", "shape the ' +
+  'coming months", "strategic importance".\n' +
   'Threads: 3–6 items reflecting actual clusters in the stories. ' +
   'Signals: 2–4 items, forward-looking. ' +
   'rankedStoryHashes: at least the top 3 stories by editorial importance, ' +
   'using the short hash from each story line (the value inside [h:...]). ' +
-  'Lead with the single most impactful development. Lead under 250 words.';
+  'Lead with the single most impactful development NAMED. Lead under 250 words.';
 
 /**
  * Compute a coarse greeting bucket for cache-key stability.
@@ -582,9 +595,14 @@ function hashDigestInput(userId, stories, sensitivity, ctx = {}) {
  * @param {DigestPromptCtx} [ctx]
  */
 export async function generateDigestProse(userId, stories, sensitivity, deps, ctx = {}) {
-  // v3 key: see hashDigestInput() comment. Full-prompt hash + strict
-  // shape validation on every cache hit.
-  const key = `brief:llm:digest:v3:${hashDigestInput(userId, stories, sensitivity, ctx)}`;
+  // v4 key (2026-04-25 evening): bumped from v3 when the prompt
+  // gained a BANNED-phrasing list + "name the specific actor and
+  // event" lead instructions, after a regression where evening
+  // briefs shipped vapid editorial filler ("the global stage is
+  // buzzing", "navigating the evolving landscape"). v3 cache rows
+  // still in TTL would otherwise serve stale vapid leads for 4h
+  // post-deploy.
+  const key = `brief:llm:digest:v4:${hashDigestInput(userId, stories, sensitivity, ctx)}`;
   try {
     const hit = await deps.cacheGet(key);
     // CRITICAL: re-run the shape validator on cache hits. Without

--- a/scripts/lib/email-summary-html.mjs
+++ b/scripts/lib/email-summary-html.mjs
@@ -77,13 +77,20 @@ export function injectEmailSummary(html, summary) {
 
   // Signals: rendered as a "Signals to watch:" trailer matching the
   // pre-refactor convention. Each signal on its own line.
-  const signalsHtml = payload.signals.length > 0
+  // Defensive: filter the bullets FIRST and only emit the "Signals to
+  // watch:" header when at least one bullet survived. Otherwise an
+  // all-malformed signals array (e.g. [null, 42, '']) renders as an
+  // orphan header with no bullets beneath. Greptile P2 on PR #3411.
+  const signalBullets = payload.signals
+    .map((s) => {
+      const text = htmlEscape(typeof s === 'string' ? s : '');
+      if (!text) return '';
+      return `<div style="font-size:13px;line-height:1.7;color:#ccc;margin:4px 0 0 0;">• ${text}</div>`;
+    })
+    .filter(Boolean);
+  const signalsHtml = signalBullets.length > 0
     ? `<div style="font-size:13px;line-height:1.7;color:#ccc;margin:14px 0 0 0;"><b style="color:#f2ede4;">Signals to watch:</b></div>` +
-      payload.signals.map((s) => {
-        const text = htmlEscape(typeof s === 'string' ? s : '');
-        if (!text) return '';
-        return `<div style="font-size:13px;line-height:1.7;color:#ccc;margin:4px 0 0 0;">• ${text}</div>`;
-      }).filter(Boolean).join('')
+      signalBullets.join('')
     : '';
 
   const summaryHtml = `<div style="background:#161616;border:1px solid #222;border-left:3px solid #4ade80;padding:18px 22px;margin:0 0 24px 0;">

--- a/scripts/lib/email-summary-html.mjs
+++ b/scripts/lib/email-summary-html.mjs
@@ -1,0 +1,96 @@
+// Email summary block builder.
+//
+// Extracted from scripts/seed-digest-notifications.mjs so the
+// HTML assembly can be unit-tested without the cron's
+// env-checking side effects (DIGEST_CRON_ENABLED check, Upstash
+// REST helper, Convex relay auth).
+//
+// The pre-canonical-brain email shipped a 5-paragraph editorial
+// blob from the legacy generateAISummary call. After the
+// single-canonical-synthesis refactor (PR #3396), the synthesis
+// returns structured fields ({lead, threads, signals}) and
+// the magazine renders each as its own page. This builder maps
+// the structured output back into a multi-section HTML block so
+// the email matches the old richness — a single pull-quote-only
+// lead is too thin for an email body.
+
+import { markdownToEmailHtml } from '../_digest-markdown.mjs';
+
+/**
+ * Inject the canonical synthesis (lead + threads + signals) into
+ * the HTML email template's `<div data-ai-summary-slot></div>`
+ * placeholder.
+ *
+ * `summary` may be:
+ *   - null/undefined/empty-object → slot is stripped (no editorial
+ *     block in the email at all). Used for the L3 stub or AI-digest
+ *     opt-out paths.
+ *   - a string → rendered as the lead block only, no threads/
+ *     signals. Used for the L3 stub-string path and for legacy
+ *     callers passing a flat string.
+ *   - an object {lead, threads, signals} → rendered with all three
+ *     sections, matching the magazine's editorial structure (and
+ *     the pre-refactor email's 5-paragraph richness).
+ *
+ * @param {string} html
+ * @param {string | { lead?: string; threads?: Array<{tag?: string; teaser?: string}>; signals?: string[] } | null | undefined} summary
+ * @returns {string}
+ */
+export function injectEmailSummary(html, summary) {
+  if (!html) return html;
+  if (!summary || (typeof summary === 'object' && !summary.lead)) {
+    return html.replace('<div data-ai-summary-slot></div>', '');
+  }
+
+  // Normalise to {lead, threads, signals}. String input (legacy /
+  // stub) → just a lead, no extras.
+  const payload = typeof summary === 'string'
+    ? { lead: summary, threads: [], signals: [] }
+    : {
+        lead: typeof summary.lead === 'string' ? summary.lead : '',
+        threads: Array.isArray(summary.threads) ? summary.threads : [],
+        signals: Array.isArray(summary.signals) ? summary.signals : [],
+      };
+  if (!payload.lead) {
+    return html.replace('<div data-ai-summary-slot></div>', '');
+  }
+
+  const escape = (s) => String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+  const leadHtml = markdownToEmailHtml(payload.lead);
+
+  // Threads: each rendered as "<b>Tag</b> — teaser" on its own line.
+  // Mirrors the old "3-5 bullet points" section visually without
+  // forcing an unordered list (cleaner in Gmail / Outlook clients).
+  const threadsHtml = payload.threads.length > 0
+    ? payload.threads.map((t) => {
+        const tag = escape(t?.tag ?? '');
+        const teaser = escape(t?.teaser ?? '');
+        if (!tag || !teaser) return '';
+        return `<div style="font-size:13px;line-height:1.7;color:#ccc;margin:0 0 8px 0;"><b style="color:#f2ede4;">${tag}</b> — ${teaser}</div>`;
+      }).filter(Boolean).join('')
+    : '';
+
+  // Signals: rendered as a "Signals to watch:" trailer matching the
+  // pre-refactor convention. Each signal on its own line.
+  const signalsHtml = payload.signals.length > 0
+    ? `<div style="font-size:13px;line-height:1.7;color:#ccc;margin:14px 0 0 0;"><b style="color:#f2ede4;">Signals to watch:</b></div>` +
+      payload.signals.map((s) => {
+        const text = escape(typeof s === 'string' ? s : '');
+        if (!text) return '';
+        return `<div style="font-size:13px;line-height:1.7;color:#ccc;margin:4px 0 0 0;">• ${text}</div>`;
+      }).filter(Boolean).join('')
+    : '';
+
+  const summaryHtml = `<div style="background:#161616;border:1px solid #222;border-left:3px solid #4ade80;padding:18px 22px;margin:0 0 24px 0;">
+<div style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:1.5px;color:#4ade80;margin-bottom:10px;">Executive Summary</div>
+<div style="font-size:13px;line-height:1.7;color:#ccc;margin-bottom:${threadsHtml || signalsHtml ? '14px' : '0'};">${leadHtml}</div>
+${threadsHtml}
+${signalsHtml}
+</div>`;
+  return html.replace('<div data-ai-summary-slot></div>', summaryHtml);
+}

--- a/scripts/lib/email-summary-html.mjs
+++ b/scripts/lib/email-summary-html.mjs
@@ -55,7 +55,7 @@ export function injectEmailSummary(html, summary) {
     return html.replace('<div data-ai-summary-slot></div>', '');
   }
 
-  const escape = (s) => String(s)
+  const htmlEscape = (s) => String(s)
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
@@ -68,8 +68,8 @@ export function injectEmailSummary(html, summary) {
   // forcing an unordered list (cleaner in Gmail / Outlook clients).
   const threadsHtml = payload.threads.length > 0
     ? payload.threads.map((t) => {
-        const tag = escape(t?.tag ?? '');
-        const teaser = escape(t?.teaser ?? '');
+        const tag = htmlEscape(t?.tag ?? '');
+        const teaser = htmlEscape(t?.teaser ?? '');
         if (!tag || !teaser) return '';
         return `<div style="font-size:13px;line-height:1.7;color:#ccc;margin:0 0 8px 0;"><b style="color:#f2ede4;">${tag}</b> — ${teaser}</div>`;
       }).filter(Boolean).join('')
@@ -80,7 +80,7 @@ export function injectEmailSummary(html, summary) {
   const signalsHtml = payload.signals.length > 0
     ? `<div style="font-size:13px;line-height:1.7;color:#ccc;margin:14px 0 0 0;"><b style="color:#f2ede4;">Signals to watch:</b></div>` +
       payload.signals.map((s) => {
-        const text = escape(typeof s === 'string' ? s : '');
+        const text = htmlEscape(typeof s === 'string' ? s : '');
         if (!text) return '';
         return `<div style="font-size:13px;line-height:1.7;color:#ccc;margin:4px 0 0 0;">• ${text}</div>`;
       }).filter(Boolean).join('')

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -18,7 +18,6 @@ import {
   escapeHtml,
   escapeTelegramHtml,
   escapeSlackMrkdwn,
-  markdownToEmailHtml,
   markdownToTelegramHtml,
   markdownToSlackMrkdwn,
   markdownToDiscord,
@@ -45,6 +44,7 @@ import {
   runSynthesisWithFallback,
   subjectForBrief,
 } from './lib/digest-orchestration-helpers.mjs';
+import { injectEmailSummary } from './lib/email-summary-html.mjs';
 import { issueSlotInTz } from '../shared/brief-filter.js';
 import {
   enrichBriefEnvelopeWithLLM,
@@ -1160,20 +1160,10 @@ function buildChannelBodies(storyListPlain, aiSummary, magazineUrl) {
   };
 }
 
-/**
- * Inject the formatted AI summary into the HTML email template's slot,
- * or strip the slot placeholder when there is no summary.
- */
-function injectEmailSummary(html, aiSummary) {
-  if (!html) return html;
-  if (!aiSummary) return html.replace('<div data-ai-summary-slot></div>', '');
-  const formattedSummary = markdownToEmailHtml(aiSummary);
-  const summaryHtml = `<div style="background:#161616;border:1px solid #222;border-left:3px solid #4ade80;padding:18px 22px;margin:0 0 24px 0;">
-<div style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:1.5px;color:#4ade80;margin-bottom:10px;">Executive Summary</div>
-<div style="font-size:13px;line-height:1.7;color:#ccc;">${formattedSummary}</div>
-</div>`;
-  return html.replace('<div data-ai-summary-slot></div>', summaryHtml);
-}
+// injectEmailSummary lives in scripts/lib/email-summary-html.mjs so
+// the multi-section HTML assembly can be unit-tested without
+// dragging the cron's env-checking side effects into the test
+// runtime. Imported at the top alongside the other lib helpers.
 
 /**
  * Inject the "Open your brief" CTA into the email HTML. Placed near
@@ -1698,7 +1688,8 @@ async function main() {
     // can't represent multiple per-rule briefs without an
     // architectural change to the URL signer + Redis key.
     const brief = briefByUser.get(rule.userId);
-    let briefLead = null;
+    let briefSynthesis = null;  // full {lead, threads, signals} when synthesis succeeded
+    let briefLead = null;       // string projection for non-email channels + parity log
     let synthesisLevel = 3;
     if (AI_DIGEST_ENABLED && rule.aiDigestEnabled !== false) {
       const ruleCtx = await buildSynthesisCtx(rule, nowMs);
@@ -1709,6 +1700,7 @@ async function main() {
         ruleCtx,
         briefLlmDeps,
       );
+      briefSynthesis = ruleResult.synthesis;
       briefLead = ruleResult.synthesis?.lead ?? null;
       synthesisLevel = ruleResult.level;
     }
@@ -1723,7 +1715,14 @@ async function main() {
       briefLead,
       magazineUrl,
     );
-    const htmlWithSummary = injectEmailSummary(htmlRaw, briefLead);
+    // Email gets the FULL structured synthesis (lead + threads +
+    // signals) so the editorial block matches the old Brain B
+    // multi-paragraph richness — not just the magazine pull-quote.
+    // Non-email channels (Telegram/Slack/Discord/webhook) keep the
+    // single-string lead since their formats favour brevity. The
+    // canonical-synthesis contract still holds: every channel reads
+    // from the same generateDigestProse output for this rule.
+    const htmlWithSummary = injectEmailSummary(htmlRaw, briefSynthesis);
     const html = injectBriefCta(htmlWithSummary, magazineUrl);
 
     const shortDate = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' }).format(new Date(nowMs));

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -471,7 +471,7 @@ describe('generateDigestProse', () => {
     // (2026-04-25) when the digest hash gained ctx (profile, greeting,
     // isPublic) and per-story `hash` fields. v2 rows are ignored on
     // rollout; v3 is the active prefix.
-    const badKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:digest:v3:'));
+    const badKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:digest:v4:'));
     assert.ok(badKey, 'expected a digest prose cache entry');
     cache.store.set(badKey, { lead: 'short', /* missing threads + signals */ });
     const llm2 = makeLLM(validJson);
@@ -631,12 +631,13 @@ describe('generateDigestProsePublic — public cache shared across users', () =>
     assert.equal(llm2.calls.length, 1, 'profile change re-keys the cache');
   });
 
-  it('writes to cache under brief:llm:digest:v3 prefix (not v2)', async () => {
+  it('writes to cache under brief:llm:digest:v4 prefix (not v3)', async () => {
     const cache = makeCache();
     const llm = makeLLM(validJson);
     await generateDigestProse('user_a', stories, 'all', { ...cache, callLLM: llm.callLLM });
     const keys = [...cache.store.keys()];
-    assert.ok(keys.some((k) => k.startsWith('brief:llm:digest:v3:')), 'v3 prefix used');
+    assert.ok(keys.some((k) => k.startsWith('brief:llm:digest:v4:')), 'v4 prefix used');
+    assert.ok(!keys.some((k) => k.startsWith('brief:llm:digest:v3:')), 'no v3 writes');
     assert.ok(!keys.some((k) => k.startsWith('brief:llm:digest:v2:')), 'no v2 writes');
   });
 });

--- a/tests/email-summary-html.test.mjs
+++ b/tests/email-summary-html.test.mjs
@@ -151,4 +151,23 @@ describe('injectEmailSummary — structured synthesis (the email regression fix)
     const bullets = (out.match(/• /g) ?? []).length;
     assert.equal(bullets, 1);
   });
+
+  it('emits no signals block when all signal entries are non-string or empty', () => {
+    // Greptile P2 regression guard: a non-empty signals array where
+    // EVERY entry fails the htmlEscape filter (null / number / empty
+    // string) must NOT render an orphan "Signals to watch:" header
+    // with no bullets beneath it. Pre-fix behaviour: header rendered
+    // alone. Post-fix: filter bullets first, omit header when no
+    // bullets survive.
+    const out = injectEmailSummary(TEMPLATE, {
+      lead: 'A long-enough lead text for the validator floor.',
+      threads: [],
+      signals: [null, 42, ''],
+    });
+    assert.ok(!out.includes('Signals to watch:'), 'header must not appear when all bullets dropped');
+    assert.ok(!out.includes('• '), 'no bullets when all signal entries malformed');
+    // Lead block still rendered — only the signals trailer is omitted.
+    assert.ok(out.includes('Executive Summary'));
+    assert.ok(out.includes('A long-enough lead'));
+  });
 });

--- a/tests/email-summary-html.test.mjs
+++ b/tests/email-summary-html.test.mjs
@@ -1,0 +1,154 @@
+// Pure-function tests for the email Executive Summary builder.
+//
+// Regression guard for the 2026-04-25 evening incident where the
+// canonical-synthesis refactor (PR #3396) shipped emails containing
+// only the magazine pull-quote (one paragraph) instead of the
+// pre-refactor 5-paragraph editorial blob. This builder restores
+// the rich format by mapping the structured synthesis (lead +
+// threads + signals) into a multi-section HTML block.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { injectEmailSummary } from '../scripts/lib/email-summary-html.mjs';
+
+const SLOT = '<div data-ai-summary-slot></div>';
+const TEMPLATE = `<html><body>BEFORE${SLOT}AFTER</body></html>`;
+
+describe('injectEmailSummary — null/empty handling', () => {
+  it('strips slot when summary is null', () => {
+    const out = injectEmailSummary(TEMPLATE, null);
+    assert.ok(!out.includes(SLOT));
+    assert.ok(!out.includes('Executive Summary'));
+    assert.ok(out.includes('BEFOREAFTER'));
+  });
+
+  it('strips slot when summary is undefined', () => {
+    const out = injectEmailSummary(TEMPLATE, undefined);
+    assert.ok(!out.includes(SLOT));
+  });
+
+  it('strips slot when summary is empty string', () => {
+    const out = injectEmailSummary(TEMPLATE, '');
+    assert.ok(!out.includes(SLOT));
+  });
+
+  it('strips slot when synthesis object has empty lead', () => {
+    const out = injectEmailSummary(TEMPLATE, { lead: '', threads: [], signals: [] });
+    assert.ok(!out.includes(SLOT));
+    assert.ok(!out.includes('Executive Summary'));
+  });
+
+  it('returns html unchanged when html is empty', () => {
+    assert.equal(injectEmailSummary('', { lead: 'x' }), '');
+    assert.equal(injectEmailSummary(null, { lead: 'x' }), null);
+  });
+});
+
+describe('injectEmailSummary — string input (legacy / L3 stub path)', () => {
+  it('renders a string summary as the lead block only', () => {
+    const out = injectEmailSummary(TEMPLATE, 'A simple stub lead.');
+    assert.ok(out.includes('Executive Summary'));
+    assert.ok(out.includes('A simple stub lead.'));
+    // No threads/signals when summary is a flat string.
+    assert.ok(!out.includes('Signals to watch'));
+  });
+});
+
+describe('injectEmailSummary — structured synthesis (the email regression fix)', () => {
+  const richSynthesis = {
+    lead: 'Pentagon chief Hegseth declared the US blockade on Iran is going global. The escalation raises the risk of direct military confrontation in the Persian Gulf, a critical chokepoint for global energy markets.',
+    threads: [
+      { tag: 'Energy', teaser: 'Hegseth fired Navy Secretary Phelan amid Iran-policy rift.' },
+      { tag: 'Diplomacy', teaser: 'Rising nuclear risks dominate UN headquarters debate.' },
+      { tag: 'Africa', teaser: '36 Nigerian military officers face arraignment for alleged coup plot.' },
+    ],
+    signals: [
+      'Watch for direct US-Iran naval engagement in the Strait of Hormuz.',
+      'Watch for further details on the Nigerian coup plot.',
+    ],
+  };
+
+  it('renders lead + threads + signals (matches pre-refactor multi-section richness)', () => {
+    const out = injectEmailSummary(TEMPLATE, richSynthesis);
+    // Lead present
+    assert.ok(out.includes('Pentagon chief Hegseth'));
+    // Each thread tag + teaser present
+    assert.ok(out.includes('<b style="color:#f2ede4;">Energy</b> — Hegseth fired'));
+    assert.ok(out.includes('<b style="color:#f2ede4;">Diplomacy</b> — Rising nuclear'));
+    assert.ok(out.includes('<b style="color:#f2ede4;">Africa</b> — 36 Nigerian'));
+    // Signals header + each signal present
+    assert.ok(out.includes('Signals to watch:'));
+    assert.ok(out.includes('• Watch for direct US-Iran naval engagement'));
+    assert.ok(out.includes('• Watch for further details on the Nigerian'));
+  });
+
+  it('renders lead-only when threads + signals are both empty (graceful degradation)', () => {
+    const out = injectEmailSummary(TEMPLATE, {
+      lead: 'A long-enough lead about Hormuz tensions that exceeds the validator floor.',
+      threads: [],
+      signals: [],
+    });
+    assert.ok(out.includes('Executive Summary'));
+    assert.ok(out.includes('A long-enough lead'));
+    assert.ok(!out.includes('Signals to watch'));
+    // No threads block emitted when threads is empty.
+    assert.ok(!out.includes('— '));
+  });
+
+  it('renders lead + threads (no signals) when signals is empty', () => {
+    const out = injectEmailSummary(TEMPLATE, {
+      lead: 'A long-enough lead about Hormuz tensions.',
+      threads: [{ tag: 'Energy', teaser: 'Tensions resurface today.' }],
+      signals: [],
+    });
+    assert.ok(out.includes('Energy</b> — Tensions resurface'));
+    assert.ok(!out.includes('Signals to watch'));
+  });
+
+  it('skips malformed thread entries without rejecting the whole block', () => {
+    const out = injectEmailSummary(TEMPLATE, {
+      lead: 'A long-enough lead about Hormuz tensions.',
+      threads: [
+        { tag: 'Energy', teaser: 'Valid teaser.' },
+        { tag: '', teaser: 'no tag — drop' },
+        { tag: 'Climate' /* missing teaser */ },
+        null,
+      ],
+      signals: [],
+    });
+    assert.ok(out.includes('Energy</b> — Valid teaser'));
+    assert.ok(!out.includes('no tag'));
+    assert.ok(!out.includes('Climate</b>'));
+  });
+
+  it('HTML-escapes hostile thread tags / teasers / signals', () => {
+    const out = injectEmailSummary(TEMPLATE, {
+      lead: 'A long-enough lead text for the validator floor.',
+      threads: [
+        { tag: 'Energy<script>1', teaser: 'Teaser with "quotes" and <em>tags</em>.' },
+      ],
+      signals: ['<img src=x onerror=alert(1)>'],
+    });
+    // Raw script/img must NOT appear; entities should be escaped.
+    assert.ok(!out.includes('<script>1'));
+    assert.ok(!out.includes('<img src=x'));
+    assert.ok(out.includes('Energy&lt;script&gt;1'));
+    assert.ok(out.includes('&lt;em&gt;tags&lt;/em&gt;'));
+    assert.ok(out.includes('&quot;quotes&quot;'));
+    assert.ok(out.includes('&lt;img src=x onerror=alert(1)&gt;'));
+  });
+
+  it('skips empty / non-string signal entries', () => {
+    const out = injectEmailSummary(TEMPLATE, {
+      lead: 'A long-enough lead text for the validator floor.',
+      threads: [],
+      signals: ['Valid signal.', '', 42, null],
+    });
+    assert.ok(out.includes('• Valid signal'));
+    // Header still emitted because at least one signal is valid.
+    assert.ok(out.includes('Signals to watch:'));
+    // Only one bullet — the malformed entries are skipped.
+    const bullets = (out.match(/• /g) ?? []).length;
+    assert.equal(bullets, 1);
+  });
+});


### PR DESCRIPTION
## Summary

Two regressions from the canonical-synthesis refactor (PR #3396) shipped in the 2026-04-25 evening tick. Reader noticed the change immediately:

> *"It's just concerning cause it feels a different structure"*

Old (afternoon, pre-refactor):
> Good afternoon. The most impactful development today is the escalating rhetoric and actions surrounding Iran, with **Pentagon chief Hegseth** declaring a "global" US blockade and former President Trump ordering the Navy to shoot Iranian boats…
> - The US blockade on Iran, now described as "going global"…
> - The firing of **Navy Secretary John Phelan** amid tensions…
> - 36 military officers facing arraignment for an alleged coup plot…
> Signals to watch: Any direct engagement between US and Iranian forces; further details on the Nigerian coup plot.

New (evening, post-refactor):
> Good evening. The global stage is buzzing with significant developments tonight, as geopolitical tensions continue to simmer and economic strategies shift. We're seeing a renewed focus on regional stability and diplomatic maneuvering, which could reshape alliances and trade flows in the coming months. For you, as a discerning reader, understanding these intricate shifts is key to navigating the evolving international landscape.

Two distinct problems shipping together:
1. **Email body shape regressed from 5 paragraphs to 1.** `injectEmailSummary` only consumed `.lead` from the structured synthesis. Threads + signals existed in the envelope but never made it to email.
2. **Lead prompt produced editorial filler instead of named events.** "Addresses the reader directly" invited the model toward "buzzing" / "navigating" / "discerning reader" instead of "Pentagon chief Hegseth declared…".

## Fixes

### `scripts/lib/email-summary-html.mjs` (new)
- Extracted from `seed-digest-notifications.mjs` so the HTML assembly can be unit-tested without the cron's env-checking side effects.
- Accepts a structured `{lead, threads, signals}` object (or a string for legacy / L3 stub).
- Renders all three sections in the email body — restoring the pre-refactor multi-paragraph richness:
  - Lead paragraph at top
  - Threads as `<b>Tag</b> — teaser` lines
  - "Signals to watch:" header + bulleted signals
- All thread/signal text HTML-escaped (defense-in-depth on hostile or quoted phrasing).

### `scripts/seed-digest-notifications.mjs`
- Imports `injectEmailSummary` from the new lib module; removed inline definition.
- Send loop captures the FULL synthesis (`briefSynthesis`) in addition to the string projection (`briefLead`). Email gets the full structured object; non-email channels (Telegram/Slack/Discord/webhook) keep the single-string lead since their formats favour brevity.
- Removed unused `markdownToEmailHtml` import (now in the helper).

### `scripts/lib/brief-llm.mjs` — prompt rewrite
- **Lead instruction**: *"FIRST sentence MUST name the single most impactful development by its specific actor and event"* with positive example *"Pentagon chief Hegseth declared the US blockade on Iran is going global"*. Concrete naming is now load-bearing.
- **Threads + signals** each carry a "name SPECIFIC event/actor" instruction with positive examples.
- **BANNED phrasing list** — the literal phrases the model produced last evening:
  > "the global stage", "buzzing with developments", "intricate shifts", "evolving landscape", "navigating", "discerning reader", "continues to simmer", "shape the coming months", "strategic importance"
- **Cache key bumped `brief:llm:digest:v3` → `v4`.** v3 rows still in TTL would otherwise serve stale vapid leads for 4h post-deploy. Same precedent as the v2→v3 bump.

## Test plan

- [x] `tests/email-summary-html.test.mjs`: **12/12** new (null/empty handling, string fallback, structured rendering, malformed-thread skip, HTML-escape, malformed-signal skip)
- [x] `tests/brief-llm.test.mjs`: 77/77 (cache prefix references updated to v4)
- [x] `npm run test:data`: **7121/7121**
- [x] `npm run typecheck` + `npm run typecheck:api`: clean
- [x] `node -c scripts/seed-digest-notifications.mjs`: parses

## Post-deploy validation

**Tomorrow morning's brief (first tick after deploy + cache TTL expires within 4h):**
- Email exec block should contain 3 sections: lead paragraph + threads + "Signals to watch" bullets (5 paragraphs total, matching the old format)
- Lead's first sentence should name a specific actor + event (e.g. "Pentagon chief…", "Navy Secretary…"), NOT abstract framing
- Magazine `digest.lead` is unchanged (still the pull-quote)

**Failure signals:**
- If lead still uses any banned phrase → prompt instruction not landing; investigate Gemini's adherence
- If threads/signals missing from email → check `briefSynthesis` is being passed (not `briefLead`) to `injectEmailSummary`

**Rollback:** revert this PR. Branch is one commit; revert is mechanical. Cache key v4 means v3 rows will resurface on revert — acceptable cost (4h TTL for stale-on-revert rows).

## Companion

Parent: PR #3396 (canonical synthesis brain), PR #3401 (Greptile P1+P4). This is the third follow-up — the user-visible regression patch.