### PR TITLE
fix(fatf-listing): Wayback Machine fallback for Cloudflare-blocked fetches

### DIFF
--- a/scripts/seed-fatf-listing.mjs
+++ b/scripts/seed-fatf-listing.mjs
@@ -90,7 +90,10 @@ export async function fetchViaWayback(url, { fetchFn = fetch, lookbackDays = WAY
   // is exactly what we want and also avoids fetching ~20× more rows than
   // we need.
   const cdxUrl = `${WAYBACK_CDX_URL}?url=${encodeURIComponent(url)}&filter=statuscode:200&output=json&from=${fromDate}&limit=-1`;
-  const cdxResp = await fetchFn(cdxUrl, { signal: AbortSignal.timeout(20_000) });
+  const cdxResp = await fetchFn(cdxUrl, {
+    headers: { 'User-Agent': CHROME_UA },
+    signal: AbortSignal.timeout(20_000),
+  });
   if (!cdxResp.ok) throw new Error(`Wayback CDX HTTP ${cdxResp.status} for ${url}`);
   const rows = await cdxResp.json();
   // CDX returns: [headerRow, snapshotRow]. Each snapshot row =
@@ -105,7 +108,10 @@ export async function fetchViaWayback(url, { fetchFn = fetch, lookbackDays = WAY
     throw new Error(`Wayback CDX returned malformed timestamp "${timestamp}" for ${url}`);
   }
   const snapshotUrl = `https://web.archive.org/web/${timestamp}id_/${url}`;
-  const snapResp = await fetchFn(snapshotUrl, { signal: AbortSignal.timeout(30_000) });
+  const snapResp = await fetchFn(snapshotUrl, {
+    headers: { 'User-Agent': CHROME_UA },
+    signal: AbortSignal.timeout(30_000),
+  });
   if (!snapResp.ok) throw new Error(`Wayback snapshot ${timestamp} HTTP ${snapResp.status} for ${url}`);
   return snapResp.text();
 }

--- a/scripts/seed-fatf-listing.mjs
+++ b/scripts/seed-fatf-listing.mjs
@@ -51,7 +51,60 @@ function normalizeName(name) {
     .trim();
 }
 
+// Wayback fallback config. FATF plenary publishes 3×/year (Feb / Jun / Oct);
+// 180 days covers >1 plenary cycle so we won't miss the most recent list
+// even if Cloudflare blocked Wayback's own crawler for a few weeks.
+const WAYBACK_CDX_URL = 'https://web.archive.org/cdx/search/cdx';
+const WAYBACK_LOOKBACK_DAYS = 180;
+
+/**
+ * Fetch a URL via Wayback Machine's most recent successful (statuscode:200)
+ * snapshot. Used when both direct and CONNECT-proxy fetches are blocked at
+ * the URL level (e.g. FATF's Cloudflare "Just a moment…" JS challenge —
+ * neither browser headers nor residential proxy IPs pass without JS exec).
+ *
+ * Wayback's `id_` URL modifier returns the captured HTML byte-for-byte
+ * without Wayback's banner injection or href/src rewriting — critical for
+ * keeping the parser working against the same DOM it sees from FATF
+ * directly.
+ *
+ * Tradeoff: 1–3 day staleness vs FATF's live page. For FATF specifically
+ * this is fine because plenary outputs change ~3×/year and the seeder's
+ * bundle interval is 30d; for any caller with a tighter freshness budget,
+ * tune `WAYBACK_LOOKBACK_DAYS` accordingly.
+ *
+ * Test seam: `fetchFn` defaults to global `fetch` so production wiring is
+ * untouched; tests pass a mocked fetch.
+ */
+export async function fetchViaWayback(url, { fetchFn = fetch, lookbackDays = WAYBACK_LOOKBACK_DAYS } = {}) {
+  const fromDate = new Date(Date.now() - lookbackDays * 86_400_000)
+    .toISOString()
+    .slice(0, 10)
+    .replace(/-/g, '');
+  const cdxUrl = `${WAYBACK_CDX_URL}?url=${encodeURIComponent(url)}&filter=statuscode:200&output=json&from=${fromDate}&limit=20`;
+  const cdxResp = await fetchFn(cdxUrl, { signal: AbortSignal.timeout(20_000) });
+  if (!cdxResp.ok) throw new Error(`Wayback CDX HTTP ${cdxResp.status} for ${url}`);
+  const rows = await cdxResp.json();
+  // CDX returns: [headerRow, ...snapshotRows]. Each snapshot row =
+  // [urlkey, timestamp, original, mimetype, statuscode, digest, length].
+  // Snapshots are timestamp-ascending, so the LAST row is most recent.
+  if (!Array.isArray(rows) || rows.length < 2) {
+    throw new Error(`Wayback has no status-200 snapshots for ${url} since ${fromDate}`);
+  }
+  const latest = rows[rows.length - 1];
+  const timestamp = latest[1];
+  if (!/^\d{14}$/.test(timestamp)) {
+    throw new Error(`Wayback CDX returned malformed timestamp "${timestamp}" for ${url}`);
+  }
+  const snapshotUrl = `https://web.archive.org/web/${timestamp}id_/${url}`;
+  const snapResp = await fetchFn(snapshotUrl, { signal: AbortSignal.timeout(30_000) });
+  if (!snapResp.ok) throw new Error(`Wayback snapshot ${timestamp} HTTP ${snapResp.status} for ${url}`);
+  return snapResp.text();
+}
+
 async function fetchHtml(url) {
+  // Tier 1: direct fetch.
+  let directErr;
   try {
     const resp = await fetch(url, {
       headers: { 'User-Agent': CHROME_UA, Accept: 'text/html' },
@@ -59,11 +112,29 @@ async function fetchHtml(url) {
     });
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     return await resp.text();
-  } catch (directErr) {
-    if (!_proxyAuth) throw new Error(`FATF fetch ${url}: ${directErr.message}`);
-    console.warn(`  FATF ${url}: direct failed (${directErr.message}), retrying via proxy`);
-    const { buffer } = await httpsProxyFetchRaw(url, _proxyAuth, { accept: 'text/html', timeoutMs: 30_000 });
-    return buffer.toString('utf8');
+  } catch (err) {
+    directErr = err;
+    console.warn(`  FATF ${url}: direct failed (${err.message})`);
+  }
+  // Tier 2: CONNECT proxy (if configured).
+  let proxyErr;
+  if (_proxyAuth) {
+    try {
+      const { buffer } = await httpsProxyFetchRaw(url, _proxyAuth, { accept: 'text/html', timeoutMs: 30_000 });
+      return buffer.toString('utf8');
+    } catch (err) {
+      proxyErr = err;
+      console.warn(`  FATF ${url}: proxy failed (${err.message}), falling back to Wayback`);
+    }
+  } else {
+    console.warn(`  FATF ${url}: no proxy configured, falling back to Wayback`);
+  }
+  // Tier 3: Wayback Machine (bypasses Cloudflare JS challenge).
+  try {
+    return await fetchViaWayback(url);
+  } catch (wbErr) {
+    const proxyMsg = proxyErr ? ` proxy=${proxyErr.message};` : '';
+    throw new Error(`FATF fetch ${url}: direct=${directErr.message};${proxyMsg} wayback=${wbErr.message}`);
   }
 }
 

--- a/scripts/seed-fatf-listing.mjs
+++ b/scripts/seed-fatf-listing.mjs
@@ -81,13 +81,21 @@ export async function fetchViaWayback(url, { fetchFn = fetch, lookbackDays = WAY
     .toISOString()
     .slice(0, 10)
     .replace(/-/g, '');
-  const cdxUrl = `${WAYBACK_CDX_URL}?url=${encodeURIComponent(url)}&filter=statuscode:200&output=json&from=${fromDate}&limit=20`;
+  // CDX default sort is timestamp-ASCENDING. With a positive `limit=N` the
+  // server returns the FIRST N captures within the window (i.e. the OLDEST
+  // N), not the newest. FATF accumulates well over 20 captures per 180-day
+  // window, so a positive limit would silently serve a stale snapshot when
+  // a newer one exists. CDX accepts a NEGATIVE `limit` to mean "last N
+  // captures" — `limit=-1` returns just the most-recent snapshot, which
+  // is exactly what we want and also avoids fetching ~20× more rows than
+  // we need.
+  const cdxUrl = `${WAYBACK_CDX_URL}?url=${encodeURIComponent(url)}&filter=statuscode:200&output=json&from=${fromDate}&limit=-1`;
   const cdxResp = await fetchFn(cdxUrl, { signal: AbortSignal.timeout(20_000) });
   if (!cdxResp.ok) throw new Error(`Wayback CDX HTTP ${cdxResp.status} for ${url}`);
   const rows = await cdxResp.json();
-  // CDX returns: [headerRow, ...snapshotRows]. Each snapshot row =
+  // CDX returns: [headerRow, snapshotRow]. Each snapshot row =
   // [urlkey, timestamp, original, mimetype, statuscode, digest, length].
-  // Snapshots are timestamp-ascending, so the LAST row is most recent.
+  // With `limit=-1` we expect exactly one snapshot row.
   if (!Array.isArray(rows) || rows.length < 2) {
     throw new Error(`Wayback has no status-200 snapshots for ${url} since ${fromDate}`);
   }

--- a/tests/seed-fatf-listing.test.mjs
+++ b/tests/seed-fatf-listing.test.mjs
@@ -16,6 +16,7 @@ import {
   extractListedCountries,
   extractPublicationDate,
   validate,
+  fetchViaWayback,
 } from '../scripts/seed-fatf-listing.mjs';
 
 describe('findPublicationLink — entry-page anchor scan', () => {
@@ -192,5 +193,133 @@ describe('validate', () => {
     const listings = { KP: 'black' };
     for (let i = 0; i < 14; i++) listings[`X${i.toString().padStart(2, '0')}`] = 'gray';
     assert.equal(validate({ listings }), true);
+  });
+});
+
+// ── fetchViaWayback — Cloudflare-bypass fallback ─────────────────────────
+
+describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
+  const FATF_URL = 'https://www.fatf-gafi.org/en/countries/black-and-grey-lists.html';
+  // CDX response shape: [headerRow, ...snapshotRows]. Each snapshot row
+  // is [urlkey, timestamp, original, mimetype, statuscode, digest, length].
+  // Ordered timestamp-ascending — last row is most recent.
+  function cdxResponse(...timestamps) {
+    return {
+      ok: true,
+      json: async () => [
+        ['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode', 'digest', 'length'],
+        ...timestamps.map((ts) => [
+          'org,fatf-gafi)/en/countries/black-and-grey-lists.html',
+          ts,
+          FATF_URL,
+          'text/html',
+          '200',
+          'DIGEST',
+          '18000',
+        ]),
+      ],
+    };
+  }
+
+  it('happy path: queries CDX for latest 200 snapshot, fetches it via id_ modifier, returns HTML', async () => {
+    const calls = [];
+    const fetchFn = async (url) => {
+      calls.push(url);
+      if (url.startsWith('https://web.archive.org/cdx/')) {
+        return cdxResponse('20260224230921', '20260331230909', '20260403144947');
+      }
+      // Snapshot fetch — must use the LATEST timestamp + id_ modifier
+      assert.match(url, /web\/20260403144947id_\//, 'must request the latest CDX timestamp with id_ modifier');
+      return { ok: true, text: async () => '<html><body><h2>Black & grey lists</h2></body></html>' };
+    };
+    const html = await fetchViaWayback(FATF_URL, { fetchFn });
+    assert.match(html, /Black & grey lists/);
+    assert.equal(calls.length, 2, 'one CDX call + one snapshot call');
+  });
+
+  it('CDX URL is built with statuscode:200 filter and a from-date — does NOT return 4xx-cached snapshots', async () => {
+    let cdxUrl;
+    const fetchFn = async (url) => {
+      if (url.startsWith('https://web.archive.org/cdx/')) {
+        cdxUrl = url;
+        return cdxResponse('20260403144947');
+      }
+      return { ok: true, text: async () => '<html></html>' };
+    };
+    await fetchViaWayback(FATF_URL, { fetchFn, lookbackDays: 90 });
+    assert.match(cdxUrl, /filter=statuscode%3A200|filter=statuscode:200/, 'CDX query must filter to status 200');
+    assert.match(cdxUrl, /from=\d{8}/, 'CDX query must include a from-date floor');
+    assert.match(cdxUrl, /output=json/);
+  });
+
+  it('throws clear error when Wayback has NO status-200 snapshots in window', async () => {
+    const fetchFn = async (url) => {
+      if (url.startsWith('https://web.archive.org/cdx/')) {
+        // Only the header row, no actual snapshots.
+        return { ok: true, json: async () => [['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode', 'digest', 'length']] };
+      }
+      throw new Error('snapshot fetch should not be reached when CDX is empty');
+    };
+    await assert.rejects(
+      fetchViaWayback(FATF_URL, { fetchFn }),
+      /no status-200 snapshots/,
+    );
+  });
+
+  it('throws when CDX itself is unreachable (HTTP 5xx)', async () => {
+    const fetchFn = async () => ({ ok: false, status: 503 });
+    await assert.rejects(
+      fetchViaWayback(FATF_URL, { fetchFn }),
+      /Wayback CDX HTTP 503/,
+    );
+  });
+
+  it('throws when the snapshot itself returns non-200 (e.g. Wayback re-fetched a Cloudflare 403)', async () => {
+    const fetchFn = async (url) => {
+      if (url.startsWith('https://web.archive.org/cdx/')) {
+        return cdxResponse('20260403144947');
+      }
+      return { ok: false, status: 403 };
+    };
+    await assert.rejects(
+      fetchViaWayback(FATF_URL, { fetchFn }),
+      /Wayback snapshot 20260403144947 HTTP 403/,
+    );
+  });
+
+  it('rejects malformed CDX timestamps (defends against CDX schema drift)', async () => {
+    const fetchFn = async (url) => {
+      if (url.startsWith('https://web.archive.org/cdx/')) {
+        return {
+          ok: true,
+          json: async () => [
+            ['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode', 'digest', 'length'],
+            ['org,fatf-gafi)/x', 'NOT-A-TIMESTAMP', FATF_URL, 'text/html', '200', 'D', '1'],
+          ],
+        };
+      }
+      throw new Error('snapshot fetch should not run with malformed timestamp');
+    };
+    await assert.rejects(
+      fetchViaWayback(FATF_URL, { fetchFn }),
+      /malformed timestamp/,
+    );
+  });
+
+  it('uses id_ modifier (NOT the bare /web/timestamp/url path) — keeps the parser DOM byte-for-byte identical to direct FATF', async () => {
+    // Without `id_`, Wayback prepends a ~3KB toolbar banner and rewrites
+    // every href/src to /web/.../ paths. Both would break the existing
+    // parser. This test pins the modifier so a future "cleanup" can't
+    // silently regress to the broken bare form.
+    let snapshotUrl;
+    const fetchFn = async (url) => {
+      if (url.startsWith('https://web.archive.org/cdx/')) {
+        return cdxResponse('20260403144947');
+      }
+      snapshotUrl = url;
+      return { ok: true, text: async () => '<html></html>' };
+    };
+    await fetchViaWayback(FATF_URL, { fetchFn });
+    assert.match(snapshotUrl, /\/web\/\d{14}id_\//, 'snapshot URL MUST use the id_ modifier');
   });
 });

--- a/tests/seed-fatf-listing.test.mjs
+++ b/tests/seed-fatf-listing.test.mjs
@@ -314,6 +314,32 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
     );
   });
 
+  it('sends a User-Agent header on BOTH the CDX query and the snapshot fetch (AGENTS.md convention)', async () => {
+    // AGENTS.md mandates "Always include `User-Agent` header in
+    // server-side fetch calls". The direct FATF fetch sends CHROME_UA;
+    // the Wayback path must match. archive.org doesn't usually block
+    // header-less requests, but house-style consistency is the point —
+    // and a future Wayback rate-limiter could reasonably enforce UA.
+    const seenHeaders = [];
+    const fetchFn = async (url, opts) => {
+      seenHeaders.push({ url, ua: opts?.headers?.['User-Agent'] });
+      if (url.startsWith('https://web.archive.org/cdx/')) {
+        return cdxResponse('20260403144947');
+      }
+      return { ok: true, text: async () => '<html></html>' };
+    };
+    await fetchViaWayback(FATF_URL, { fetchFn });
+    assert.equal(seenHeaders.length, 2, 'expected one CDX + one snapshot fetch');
+    for (const { url, ua } of seenHeaders) {
+      assert.ok(typeof ua === 'string' && ua.length > 0,
+        `User-Agent must be set on ${url} (got: ${ua})`);
+      // Pin that we're not sending some empty/sentinel value — it should
+      // be the real CHROME_UA the rest of the seeder uses.
+      assert.match(ua, /Mozilla\/5\.0/,
+        `User-Agent on ${url} should be the canonical CHROME_UA, not a placeholder; got: ${ua}`);
+    }
+  });
+
   it('uses id_ modifier (NOT the bare /web/timestamp/url path) — keeps the parser DOM byte-for-byte identical to direct FATF', async () => {
     // Without `id_`, Wayback prepends a ~3KB toolbar banner and rewrites
     // every href/src to /web/.../ paths. Both would break the existing

--- a/tests/seed-fatf-listing.test.mjs
+++ b/tests/seed-fatf-listing.test.mjs
@@ -237,7 +237,7 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
     assert.equal(calls.length, 2, 'one CDX call + one snapshot call');
   });
 
-  it('CDX URL is built with statuscode:200 filter and a from-date — does NOT return 4xx-cached snapshots', async () => {
+  it('CDX URL is built with statuscode:200 filter, a from-date, AND limit=-1 (negative limit returns the most-recent capture)', async () => {
     let cdxUrl;
     const fetchFn = async (url) => {
       if (url.startsWith('https://web.archive.org/cdx/')) {
@@ -250,6 +250,14 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
     assert.match(cdxUrl, /filter=statuscode%3A200|filter=statuscode:200/, 'CDX query must filter to status 200');
     assert.match(cdxUrl, /from=\d{8}/, 'CDX query must include a from-date floor');
     assert.match(cdxUrl, /output=json/);
+    // Critical: CDX default ordering is timestamp-ASCENDING. A positive
+    // `limit=N` returns the OLDEST N captures within the window — not the
+    // newest. FATF accumulates well over 20 captures per 180-day window,
+    // so a positive limit would silently serve a stale archived snapshot
+    // even when a newer one exists. `limit=-1` = "last 1 capture" =
+    // most-recent. Pin this so a future cleanup can't regress it.
+    assert.match(cdxUrl, /[?&]limit=-1(&|$)/, 'CDX query MUST use negative limit (limit=-1) to get the most-recent snapshot, not the oldest within the window');
+    assert.doesNotMatch(cdxUrl, /[?&]limit=(?!-)\d+/, 'CDX query must NOT use a positive limit — that returns the oldest captures and serves stale data');
   });
 
   it('throws clear error when Wayback has NO status-200 snapshots in window', async () => {


### PR DESCRIPTION
## Problem

PR #3407's FATF seeder writes nothing on every Railway tick — `economic:fatf-listing:v1` shows `status=EMPTY` in `/api/health` because the canonical key has never been published.

Root cause: `www.fatf-gafi.org` enforces a **Cloudflare "Just a moment…" JS challenge** that returns HTTP 403 to any client that doesn't execute JavaScript. Both direct Node `fetch` and the existing `httpsProxyFetchRaw` CONNECT-proxy (Decodo) leg fail this check. From production logs (2026-04-25T19:01 UTC, run id `1777143709725-d2wtr1`):

```
[FATF-Listing] FATF https://...: direct failed (HTTP 403), retrying via proxy
[FATF-Listing] Retry 1/3 in 1000ms: HTTP 403   ← proxy ALSO 403
[FATF-Listing] Retry 2/3 in 2000ms: HTTP 403
[FATF-Listing] Retry 3/3 in 4000ms: HTTP 403
[FATF-Listing] FETCH FAILED: HTTP 403
```

I confirmed today (2026-04-25) that even with full Chrome browser headers (Accept-Language, Referer, Sec-Fetch-Dest/Mode/Site, Upgrade-Insecure-Requests) the request still returns the Cloudflare challenge HTML (`<title>Just a moment...</title>`). Header tweaks won't help.

## Fix

Add a third tier to `fetchHtml`: **direct → CONNECT proxy → Wayback Machine**. The first two tiers are unchanged; Wayback runs only when both fail.

### Why Wayback works

- Different infrastructure: Wayback's crawler captures via paths Cloudflare doesn't gate the same way.
- I confirmed the CDX API has multiple `statuscode:200` snapshots in 2026 (most recent **2026-04-03 14:49 UTC**, with current Feb-2026-plenary content — i.e. today's actual real-world FATF state).
- Capture lag (1–3 days) is irrelevant given FATF publishes 3×/year and the seeder's bundle interval is 30 days, with a 42-day STALE_SEED threshold.

### Why the `id_` modifier

The implementation fetches `https://web.archive.org/web/<timestamp>id_/<url>`. The `id_` modifier returns the original captured HTML byte-for-byte without Wayback's banner injection or href/src rewriting — keeping the existing parser (`findPublicationLink`, `extractListedCountries`) unchanged. A regression test pins the modifier so a future "cleanup" can't silently switch to the bare `/web/timestamp/url` form (which would prepend ~3KB of Wayback toolbar HTML and rewrite every link, breaking the parser).

### Self-healing direct path

The order is `direct → proxy → Wayback`, **not** Wayback-first. The moment FATF rotates off Cloudflare or Decodo egress IPs get whitelisted, the seeder transparently goes back to live data with no code change.

## Tests

`+7` cases on `fetchViaWayback` in `tests/seed-fatf-listing.test.mjs`:

- Happy path: queries CDX, fetches latest 200 snapshot via `id_`
- CDX URL shape: `filter=statuscode:200`, `from=YYYYMMDD`, `output=json`
- No-200-snapshots window → throws clear error
- CDX HTTP 5xx → throws
- Snapshot 4xx (Wayback re-fetched a Cloudflare challenge) → throws
- Malformed CDX timestamp → throws (defends against schema drift)
- `id_` modifier pin (regression guard against parser-breaking cleanup)

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] CJS syntax check
- [x] `npm run lint` (no errors)
- [x] `npm run test:data` (7194 pass)
- [x] Edge bundle check
- [x] `node --test tests/edge-functions.test.mjs` (177 pass)
- [x] `npm run lint:md`
- [x] `npm run version:check`
- [ ] After merge + Railway redeploy, watch for `[FATF-Listing]` log line that does NOT end in `FETCH FAILED: HTTP 403`. Wayback fallback kicks in after the proxy 403, parses the snapshot HTML, and `runSeed` writes `economic:fatf-listing:v1`.
- [ ] Confirm `/api/health` `fatfListing.status` flips from `EMPTY` to `OK` (or `STALE_SEED` clearing once seed-meta is written).

## Out of scope

- BIS-LBS `EMPTY` status (separate root cause: lock contention / validate floor / bundle timeout). Will be a separate PR adding a SIGTERM lock-release handler defensively.