### PR TITLE
fix(fatf-listing): proxy-fallback + describeErr for Wayback failures from Railway

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -18,6 +18,26 @@ const __seed_dirname = dirname(fileURLToPath(import.meta.url));
 export { CHROME_UA };
 
 /**
+ * Unwrap fetch / network errors so log lines surface the actual cause
+ * (DNS / TCP reset / TLS abort) instead of undici's bare "fetch failed".
+ * Pulls `err.cause.code` (preferred — `ENOTFOUND`, `ECONNRESET`, etc.),
+ * `err.cause.errno`, or `err.cause.message` in that order; falls back to
+ * the outer error message when no cause is attached. Used by seeders
+ * with multi-tier fallback chains (FATF, GDELT) where the failure mode
+ * dictates the next-tier decision and operators need to distinguish
+ * routing / DNS / handshake failures from per-host throttling.
+ *
+ * @param {unknown} err
+ * @returns {string}
+ */
+export function describeErr(err) {
+  if (!err) return 'unknown';
+  const cause = err.cause;
+  const causeCode = cause?.code || cause?.errno || cause?.message || (typeof cause === 'string' ? cause : null);
+  return causeCode ? `${err.message} (cause: ${causeCode})` : (err.message || String(err));
+}
+
+/**
  * Return the bundle-run start timestamp injected by `_bundle-runner.mjs`
  * as the `BUNDLE_RUN_STARTED_AT_MS` env var, or `null` when the seeder
  * is running STANDALONE (manual invocation outside the bundle).

--- a/scripts/seed-bundle-macro.mjs
+++ b/scripts/seed-bundle-macro.mjs
@@ -18,5 +18,10 @@ await runBundle('macro', [
   // fail-closed preflight (RESILIENCE_FIN_SYS_EXPOSURE_ENABLED=true).
   { label: 'WB-External-Debt', script: 'seed-wb-external-debt.mjs', seedMetaKey: 'economic:wb-external-debt', canonicalKey: 'economic:wb-external-debt:v1', intervalMs: 30 * DAY, timeoutMs: 300_000 },
   { label: 'BIS-LBS', script: 'seed-bis-lbs.mjs', seedMetaKey: 'economic:bis-lbs', canonicalKey: 'economic:bis-lbs:v1', intervalMs: 7 * DAY, timeoutMs: 600_000 },
-  { label: 'FATF-Listing', script: 'seed-fatf-listing.mjs', seedMetaKey: 'economic:fatf-listing', canonicalKey: 'economic:fatf-listing:v1', intervalMs: 30 * DAY, timeoutMs: 120_000 },
+  // FATF fetches 3 URLs (entry sequential, black+grey parallel) through a 6-tier
+  // fallback chain (direct → proxy → wayback-cdx-direct → wayback-cdx-proxy →
+  // wayback-snap-direct → wayback-snap-proxy, ≤125s/URL). Worst-case ≤250s;
+  // 300_000 gives ~50s margin and matches peer sections. Pre-PR-#3415 the section
+  // was 120_000 — too tight for the multi-tier fallback, would SIGTERM mid-fetch.
+  { label: 'FATF-Listing', script: 'seed-fatf-listing.mjs', seedMetaKey: 'economic:fatf-listing', canonicalKey: 'economic:fatf-listing:v1', intervalMs: 30 * DAY, timeoutMs: 300_000 },
 ]);

--- a/scripts/seed-fatf-listing.mjs
+++ b/scripts/seed-fatf-listing.mjs
@@ -56,12 +56,35 @@ function normalizeName(name) {
 // even if Cloudflare blocked Wayback's own crawler for a few weeks.
 const WAYBACK_CDX_URL = 'https://web.archive.org/cdx/search/cdx';
 const WAYBACK_LOOKBACK_DAYS = 180;
+// Bumped from 20s → 45s after Railway-egress observations (PR #34xx, log
+// 2026-04-25T20:35): direct CDX from a Railway IP frequently times out
+// past 20s — the same IP pool gets soft-rate-limited or routed slowly
+// to archive.org, while local desktop probes complete in <2s. 45s is a
+// generous ceiling that still keeps the seeder under bundle-runner's
+// 120s timeoutMs and accommodates the proxy-fallback path's added hops.
+const WAYBACK_TIMEOUT_MS = 45_000;
+
+// Unwrap fetch errors so production logs surface the actual cause
+// (DNS failure / TCP reset / TLS abort) instead of undici's bare
+// "fetch failed". Without this, the bundle log is unactionable on
+// any wayback failure.
+function describeErr(err) {
+  if (!err) return 'unknown';
+  const cause = err.cause;
+  const causeCode = cause?.code || cause?.errno || cause?.message || (typeof cause === 'string' ? cause : null);
+  return causeCode ? `${err.message} (cause: ${causeCode})` : (err.message || String(err));
+}
 
 /**
  * Fetch a URL via Wayback Machine's most recent successful (statuscode:200)
  * snapshot. Used when both direct and CONNECT-proxy fetches are blocked at
  * the URL level (e.g. FATF's Cloudflare "Just a moment…" JS challenge —
  * neither browser headers nor residential proxy IPs pass without JS exec).
+ *
+ * Two-tier per-call: direct fetch → CONNECT proxy fallback. Railway egress
+ * IPs are routinely soft-rate-limited or slowed by archive.org; routing
+ * the same CDX/snapshot request through Decodo's residential proxy pool
+ * bypasses that without changing the response shape.
  *
  * Wayback's `id_` URL modifier returns the captured HTML byte-for-byte
  * without Wayback's banner injection or href/src rewriting — critical for
@@ -73,10 +96,17 @@ const WAYBACK_LOOKBACK_DAYS = 180;
  * bundle interval is 30d; for any caller with a tighter freshness budget,
  * tune `WAYBACK_LOOKBACK_DAYS` accordingly.
  *
- * Test seam: `fetchFn` defaults to global `fetch` so production wiring is
- * untouched; tests pass a mocked fetch.
+ * Test seams: `fetchFn` and `proxyFetcher` default to global `fetch` and
+ * `httpsProxyFetchRaw` so production wiring is untouched; tests can pass
+ * mocked versions of either.
  */
-export async function fetchViaWayback(url, { fetchFn = fetch, lookbackDays = WAYBACK_LOOKBACK_DAYS } = {}) {
+export async function fetchViaWayback(url, opts = {}) {
+  const {
+    fetchFn = fetch,
+    proxyFetcher = httpsProxyFetchRaw,
+    proxyAuth = resolveProxyForConnect(),
+    lookbackDays = WAYBACK_LOOKBACK_DAYS,
+  } = opts;
   const fromDate = new Date(Date.now() - lookbackDays * 86_400_000)
     .toISOString()
     .slice(0, 10)
@@ -90,12 +120,7 @@ export async function fetchViaWayback(url, { fetchFn = fetch, lookbackDays = WAY
   // is exactly what we want and also avoids fetching ~20× more rows than
   // we need.
   const cdxUrl = `${WAYBACK_CDX_URL}?url=${encodeURIComponent(url)}&filter=statuscode:200&output=json&from=${fromDate}&limit=-1`;
-  const cdxResp = await fetchFn(cdxUrl, {
-    headers: { 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(20_000),
-  });
-  if (!cdxResp.ok) throw new Error(`Wayback CDX HTTP ${cdxResp.status} for ${url}`);
-  const rows = await cdxResp.json();
+  const rows = await fetchWaybackJson(cdxUrl, { fetchFn, proxyFetcher, proxyAuth });
   // CDX returns: [headerRow, snapshotRow]. Each snapshot row =
   // [urlkey, timestamp, original, mimetype, statuscode, digest, length].
   // With `limit=-1` we expect exactly one snapshot row.
@@ -108,12 +133,59 @@ export async function fetchViaWayback(url, { fetchFn = fetch, lookbackDays = WAY
     throw new Error(`Wayback CDX returned malformed timestamp "${timestamp}" for ${url}`);
   }
   const snapshotUrl = `https://web.archive.org/web/${timestamp}id_/${url}`;
-  const snapResp = await fetchFn(snapshotUrl, {
-    headers: { 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!snapResp.ok) throw new Error(`Wayback snapshot ${timestamp} HTTP ${snapResp.status} for ${url}`);
-  return snapResp.text();
+  return await fetchWaybackText(snapshotUrl, timestamp, { fetchFn, proxyFetcher, proxyAuth });
+}
+
+async function fetchWaybackJson(cdxUrl, { fetchFn, proxyFetcher, proxyAuth }) {
+  let directErr;
+  try {
+    const cdxResp = await fetchFn(cdxUrl, {
+      headers: { 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(WAYBACK_TIMEOUT_MS),
+    });
+    if (!cdxResp.ok) throw new Error(`Wayback CDX HTTP ${cdxResp.status}`);
+    return await cdxResp.json();
+  } catch (err) {
+    directErr = err;
+  }
+  if (!proxyAuth) {
+    throw new Error(`Wayback CDX direct failed (${describeErr(directErr)}); no proxy configured`);
+  }
+  try {
+    const { buffer } = await proxyFetcher(cdxUrl, proxyAuth, {
+      accept: 'application/json',
+      timeoutMs: WAYBACK_TIMEOUT_MS,
+    });
+    return JSON.parse(buffer.toString('utf8'));
+  } catch (proxyErr) {
+    throw new Error(`Wayback CDX direct=${describeErr(directErr)}; proxy=${describeErr(proxyErr)}`);
+  }
+}
+
+async function fetchWaybackText(snapshotUrl, timestamp, { fetchFn, proxyFetcher, proxyAuth }) {
+  let directErr;
+  try {
+    const snapResp = await fetchFn(snapshotUrl, {
+      headers: { 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(WAYBACK_TIMEOUT_MS),
+    });
+    if (!snapResp.ok) throw new Error(`Wayback snapshot ${timestamp} HTTP ${snapResp.status}`);
+    return await snapResp.text();
+  } catch (err) {
+    directErr = err;
+  }
+  if (!proxyAuth) {
+    throw new Error(`Wayback snapshot ${timestamp} direct failed (${describeErr(directErr)}); no proxy configured`);
+  }
+  try {
+    const { buffer } = await proxyFetcher(snapshotUrl, proxyAuth, {
+      accept: 'text/html',
+      timeoutMs: WAYBACK_TIMEOUT_MS,
+    });
+    return buffer.toString('utf8');
+  } catch (proxyErr) {
+    throw new Error(`Wayback snapshot ${timestamp} direct=${describeErr(directErr)}; proxy=${describeErr(proxyErr)}`);
+  }
 }
 
 async function fetchHtml(url) {
@@ -128,7 +200,7 @@ async function fetchHtml(url) {
     return await resp.text();
   } catch (err) {
     directErr = err;
-    console.warn(`  FATF ${url}: direct failed (${err.message})`);
+    console.warn(`  FATF ${url}: direct failed (${describeErr(err)})`);
   }
   // Tier 2: CONNECT proxy (if configured).
   let proxyErr;
@@ -138,17 +210,19 @@ async function fetchHtml(url) {
       return buffer.toString('utf8');
     } catch (err) {
       proxyErr = err;
-      console.warn(`  FATF ${url}: proxy failed (${err.message}), falling back to Wayback`);
+      console.warn(`  FATF ${url}: proxy failed (${describeErr(err)}), falling back to Wayback`);
     }
   } else {
     console.warn(`  FATF ${url}: no proxy configured, falling back to Wayback`);
   }
-  // Tier 3: Wayback Machine (bypasses Cloudflare JS challenge).
+  // Tier 3: Wayback Machine (bypasses Cloudflare JS challenge). Internally
+  // does its own direct → proxy fallback because Railway egress IPs are
+  // routinely soft-rate-limited by archive.org.
   try {
     return await fetchViaWayback(url);
   } catch (wbErr) {
-    const proxyMsg = proxyErr ? ` proxy=${proxyErr.message};` : '';
-    throw new Error(`FATF fetch ${url}: direct=${directErr.message};${proxyMsg} wayback=${wbErr.message}`);
+    const proxyMsg = proxyErr ? ` proxy=${describeErr(proxyErr)};` : '';
+    throw new Error(`FATF fetch ${url}: direct=${describeErr(directErr)};${proxyMsg} wayback=${describeErr(wbErr)}`);
   }
 }
 

--- a/scripts/seed-fatf-listing.mjs
+++ b/scripts/seed-fatf-listing.mjs
@@ -16,7 +16,7 @@
 // of publication). Cache TTL 90d so a transient parse failure doesn't
 // drop the full listing.
 
-import { loadEnvFile, CHROME_UA, runSeed, resolveProxyForConnect, httpsProxyFetchRaw } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, resolveProxyForConnect, httpsProxyFetchRaw, describeErr } from './_seed-utils.mjs';
 import countryNames from './shared/country-names.json' with { type: 'json' };
 
 loadEnvFile(import.meta.url);
@@ -64,17 +64,6 @@ const WAYBACK_LOOKBACK_DAYS = 180;
 // max Wayback budget per URL) this fits inside the seeder's overall
 // per-URL ceiling (see comment block at fetchHtml).
 const WAYBACK_TIMEOUT_MS = 25_000;
-
-// Unwrap fetch errors so production logs surface the actual cause
-// (DNS failure / TCP reset / TLS abort) instead of undici's bare
-// "fetch failed". Without this, the bundle log is unactionable on
-// any wayback failure.
-function describeErr(err) {
-  if (!err) return 'unknown';
-  const cause = err.cause;
-  const causeCode = cause?.code || cause?.errno || cause?.message || (typeof cause === 'string' ? cause : null);
-  return causeCode ? `${err.message} (cause: ${causeCode})` : (err.message || String(err));
-}
 
 /**
  * Fetch a URL via Wayback Machine's most recent successful (statuscode:200)
@@ -153,6 +142,9 @@ async function fetchWaybackJson(cdxUrl, { fetchFn, proxyFetcher, proxyAuth }) {
     throw new Error(`Wayback CDX direct failed (${describeErr(directErr)}); no proxy configured`);
   }
   try {
+    // Note: httpsProxyFetchRaw injects User-Agent: CHROME_UA internally
+    // (see scripts/_seed-utils.mjs:httpsProxyFetchRaw) — we don't need to
+    // pass headers here. AGENTS.md UA convention is satisfied on both legs.
     const { buffer } = await proxyFetcher(cdxUrl, proxyAuth, {
       accept: 'application/json',
       timeoutMs: WAYBACK_TIMEOUT_MS,
@@ -179,6 +171,9 @@ async function fetchWaybackText(snapshotUrl, timestamp, { fetchFn, proxyFetcher,
     throw new Error(`Wayback snapshot ${timestamp} direct failed (${describeErr(directErr)}); no proxy configured`);
   }
   try {
+    // Note: httpsProxyFetchRaw injects User-Agent: CHROME_UA internally
+    // (see scripts/_seed-utils.mjs:httpsProxyFetchRaw) — UA is sent on
+    // the proxy snapshot fetch even though it's not in the opts here.
     const { buffer } = await proxyFetcher(snapshotUrl, proxyAuth, {
       accept: 'text/html',
       timeoutMs: WAYBACK_TIMEOUT_MS,

--- a/scripts/seed-fatf-listing.mjs
+++ b/scripts/seed-fatf-listing.mjs
@@ -56,13 +56,14 @@ function normalizeName(name) {
 // even if Cloudflare blocked Wayback's own crawler for a few weeks.
 const WAYBACK_CDX_URL = 'https://web.archive.org/cdx/search/cdx';
 const WAYBACK_LOOKBACK_DAYS = 180;
-// Bumped from 20s → 45s after Railway-egress observations (PR #34xx, log
-// 2026-04-25T20:35): direct CDX from a Railway IP frequently times out
-// past 20s — the same IP pool gets soft-rate-limited or routed slowly
-// to archive.org, while local desktop probes complete in <2s. 45s is a
-// generous ceiling that still keeps the seeder under bundle-runner's
-// 120s timeoutMs and accommodates the proxy-fallback path's added hops.
-const WAYBACK_TIMEOUT_MS = 45_000;
+// Per-tier timeout. Railway-egress observations (log 2026-04-25T20:35)
+// showed direct CDX timing out past 20s when archive.org rate-limits the
+// shared pool; 25s gives 25% margin over that and pairs with a Decodo
+// proxy fallback for the case where direct still times out. Together
+// (direct 25s + proxy 25s = 50s per Wayback call × CDX + snapshot = 100s
+// max Wayback budget per URL) this fits inside the seeder's overall
+// per-URL ceiling (see comment block at fetchHtml).
+const WAYBACK_TIMEOUT_MS = 25_000;
 
 // Unwrap fetch errors so production logs surface the actual cause
 // (DNS failure / TCP reset / TLS abort) instead of undici's bare
@@ -188,13 +189,26 @@ async function fetchWaybackText(snapshotUrl, timestamp, { fetchFn, proxyFetcher,
   }
 }
 
+// Per-URL fetch budget — total ≤ 125s in the absolute worst case where
+// every tier exhausts its timeout. Composed of: direct(10s) + proxy(15s)
+// + wayback-CDX-direct(25s) + wayback-CDX-proxy(25s) + wayback-snapshot-
+// direct(25s) + wayback-snapshot-proxy(25s) = 125s. The seeder fetches
+// the entry page sequentially, then black + grey publication pages in
+// parallel via Promise.all, so end-to-end worst case is ≤ 250s — fits
+// inside seed-bundle-macro.mjs's 300_000 ms FATF-Listing section budget
+// with ~50s margin. Direct 30s / proxy 30s / wayback 45s in the prior
+// design summed to 240s per URL × sequential entry + parallel pubs =
+// 480s worst case, exceeded the original 120_000 ms section budget and
+// caused bundle-runner SIGTERM to interrupt the graceful-fail path.
 async function fetchHtml(url) {
-  // Tier 1: direct fetch.
+  // Tier 1: direct fetch (Cloudflare 403s in <1s when blocking; 10s
+  // gives 10× margin without burning section budget on a guaranteed
+  // failure).
   let directErr;
   try {
     const resp = await fetch(url, {
       headers: { 'User-Agent': CHROME_UA, Accept: 'text/html' },
-      signal: AbortSignal.timeout(30_000),
+      signal: AbortSignal.timeout(10_000),
     });
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     return await resp.text();
@@ -202,11 +216,13 @@ async function fetchHtml(url) {
     directErr = err;
     console.warn(`  FATF ${url}: direct failed (${describeErr(err)})`);
   }
-  // Tier 2: CONNECT proxy (if configured).
+  // Tier 2: CONNECT proxy (if configured) — Decodo adds ~1s of CONNECT-
+  // tunnel overhead; 15s lets a slow-but-eventually-200 proxy response
+  // through while still leaving 100s of budget for Wayback.
   let proxyErr;
   if (_proxyAuth) {
     try {
-      const { buffer } = await httpsProxyFetchRaw(url, _proxyAuth, { accept: 'text/html', timeoutMs: 30_000 });
+      const { buffer } = await httpsProxyFetchRaw(url, _proxyAuth, { accept: 'text/html', timeoutMs: 15_000 });
       return buffer.toString('utf8');
     } catch (err) {
       proxyErr = err;

--- a/scripts/seed-unrest-events.mjs
+++ b/scripts/seed-unrest-events.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, httpsProxyFetchRaw, resolveProxyForConnect } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, httpsProxyFetchRaw, resolveProxyForConnect, describeErr } from './_seed-utils.mjs';
 import { getAcledToken } from './shared/acled-oauth.mjs';
 
 loadEnvFile(import.meta.url);
@@ -158,13 +158,6 @@ async function fetchAcledProtests() {
 }
 
 // ---------- GDELT Fetch ----------
-
-function describeErr(err) {
-  if (!err) return 'unknown';
-  const cause = err.cause;
-  const causeCode = cause?.code || cause?.errno || cause?.message || (typeof cause === 'string' ? cause : null);
-  return causeCode ? `${err.message} (cause: ${causeCode})` : (err.message || String(err));
-}
 
 // Direct fetch from Railway has 0% success — every attempt errors with
 // UND_ERR_CONNECT_TIMEOUT or ECONNRESET. Path is always proxy-only here.

--- a/tests/seed-fatf-listing.test.mjs
+++ b/tests/seed-fatf-listing.test.mjs
@@ -343,6 +343,30 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
     }
   });
 
+  it('per-tier timeouts sum to a budget that fits in seed-bundle-macro.mjs FATF-Listing timeoutMs (no SIGTERM mid-fetch)', async () => {
+    // Static-shape regression guard. Pre-PR-#3415 the tier timeouts were:
+    //   direct 30s + proxy 30s + wayback 4×45s = 240s/URL
+    //   × 3 URLs (entry sequential + black/grey parallel) = 480s end-to-end
+    // while the section was capped at 120_000ms. That meant bundle-runner
+    // would SIGTERM the seeder mid-fetch instead of letting runSeed reach
+    // its graceful "Failed gracefully" path. This test pins the new
+    // budget so a future cleanup can't silently regress it.
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, resolve } = await import('node:path');
+    const here = dirname(fileURLToPath(import.meta.url));
+    const seederSrc = readFileSync(resolve(here, '../scripts/seed-fatf-listing.mjs'), 'utf-8');
+    const bundleSrc = readFileSync(resolve(here, '../scripts/seed-bundle-macro.mjs'), 'utf-8');
+    // Direct fetch timeout — 10s ceiling; Cloudflare 403s in <1s when blocking.
+    assert.match(seederSrc, /AbortSignal\.timeout\(10_000\)/, 'direct fetch must use 10s timeout (was 30s pre-fix)');
+    // Proxy fetch timeout — 15s ceiling.
+    assert.match(seederSrc, /timeoutMs:\s*15_000\s*\}\s*\)/, 'proxy fetch must use 15s timeoutMs (was 30s pre-fix)');
+    // Wayback per-tier — 25s ceiling.
+    assert.match(seederSrc, /WAYBACK_TIMEOUT_MS\s*=\s*25_000/, 'WAYBACK_TIMEOUT_MS must be 25s (was 45s pre-fix)');
+    // Section timeoutMs — 300s, matches peer sections.
+    assert.match(bundleSrc, /label:\s*'FATF-Listing'[^\n]*timeoutMs:\s*300_000/, 'FATF-Listing section must use 300_000 ms timeoutMs (was 120_000 pre-fix)');
+  });
+
   it('falls back to CONNECT proxy when direct CDX query fails (Railway-egress rate-limit defense)', async () => {
     // Production observation 2026-04-25T20:35: Railway egress IPs hit
     // 20s+ timeouts on CDX while local desktop probes complete in <2s.

--- a/tests/seed-fatf-listing.test.mjs
+++ b/tests/seed-fatf-listing.test.mjs
@@ -274,15 +274,18 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
     );
   });
 
-  it('throws when CDX itself is unreachable (HTTP 5xx)', async () => {
+  it('throws when CDX itself is unreachable (HTTP 5xx) AND no proxy is configured', async () => {
+    // Pass proxyAuth: null to disable the new proxy fallback so this
+    // test stays focused on the direct-CDX failure mode. The proxy
+    // fallback path is exercised in dedicated cases below.
     const fetchFn = async () => ({ ok: false, status: 503 });
     await assert.rejects(
-      fetchViaWayback(FATF_URL, { fetchFn }),
-      /Wayback CDX HTTP 503/,
+      fetchViaWayback(FATF_URL, { fetchFn, proxyAuth: null }),
+      /Wayback CDX direct failed.*HTTP 503.*no proxy configured/,
     );
   });
 
-  it('throws when the snapshot itself returns non-200 (e.g. Wayback re-fetched a Cloudflare 403)', async () => {
+  it('throws when the snapshot itself returns non-200 AND no proxy is configured (e.g. Wayback re-fetched a Cloudflare 403)', async () => {
     const fetchFn = async (url) => {
       if (url.startsWith('https://web.archive.org/cdx/')) {
         return cdxResponse('20260403144947');
@@ -290,8 +293,8 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
       return { ok: false, status: 403 };
     };
     await assert.rejects(
-      fetchViaWayback(FATF_URL, { fetchFn }),
-      /Wayback snapshot 20260403144947 HTTP 403/,
+      fetchViaWayback(FATF_URL, { fetchFn, proxyAuth: null }),
+      /Wayback snapshot 20260403144947 direct failed.*HTTP 403.*no proxy configured/,
     );
   });
 
@@ -338,6 +341,74 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
       assert.match(ua, /Mozilla\/5\.0/,
         `User-Agent on ${url} should be the canonical CHROME_UA, not a placeholder; got: ${ua}`);
     }
+  });
+
+  it('falls back to CONNECT proxy when direct CDX query fails (Railway-egress rate-limit defense)', async () => {
+    // Production observation 2026-04-25T20:35: Railway egress IPs hit
+    // 20s+ timeouts on CDX while local desktop probes complete in <2s.
+    // The same pool gets soft-rate-limited or routed slowly to
+    // archive.org. Routing CDX through Decodo's residential proxy pool
+    // bypasses that without changing the response shape.
+    const fetchFn = async () => {
+      // Direct CDX fails — simulate timeout/rate-limit.
+      throw new Error('fetch failed');
+    };
+    const proxyCalls = [];
+    const proxyFetcher = async (url, auth, opts) => {
+      proxyCalls.push({ url, auth, opts });
+      if (url.startsWith('https://web.archive.org/cdx/')) {
+        // Return CDX response shape: header + 1 row.
+        return {
+          buffer: Buffer.from(JSON.stringify([
+            ['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode', 'digest', 'length'],
+            ['org,fatf-gafi)/x', '20260403144947', FATF_URL, 'text/html', '200', 'D', '1'],
+          ])),
+        };
+      }
+      // Snapshot via proxy.
+      return { buffer: Buffer.from('<html><body><h2>Wayback via proxy</h2></body></html>') };
+    };
+    const html = await fetchViaWayback(FATF_URL, {
+      fetchFn,
+      proxyFetcher,
+      proxyAuth: 'test-user:test-pass@gate.decodo.com:7000',
+    });
+    assert.match(html, /Wayback via proxy/);
+    // Both CDX and snapshot must have hit the proxy after direct failed.
+    assert.equal(proxyCalls.length, 2, 'both CDX and snapshot must route through proxy after direct failure');
+    assert.match(proxyCalls[0].url, /^https:\/\/web\.archive\.org\/cdx\//);
+    assert.match(proxyCalls[1].url, /\/web\/20260403144947id_\//, 'snapshot proxy fetch must still use the id_ modifier + the CDX timestamp');
+  });
+
+  it('error message unwraps err.cause when both direct and proxy fail (operator-actionable diagnostics)', async () => {
+    // The pre-fix error was "wayback=fetch failed" with no detail —
+    // unactionable in production logs. The fix adds a describeErr
+    // helper that pulls err.cause.code / err.cause.message so failures
+    // surface DNS / TCP-reset / TLS-abort distinctions.
+    const fetchFn = async () => {
+      const err = new TypeError('fetch failed');
+      err.cause = Object.assign(new Error('getaddrinfo ENOTFOUND web.archive.org'), { code: 'ENOTFOUND' });
+      throw err;
+    };
+    const proxyFetcher = async () => {
+      const err = new Error('Proxy CONNECT: HTTP/1.1 407 Proxy Authentication Required');
+      throw err;
+    };
+    await assert.rejects(
+      fetchViaWayback(FATF_URL, {
+        fetchFn,
+        proxyFetcher,
+        proxyAuth: 'test:test@proxy.example:7000',
+      }),
+      (err) => {
+        // Error message must include BOTH the direct cause (ENOTFOUND
+        // unwrapped) and the proxy error message — gives operators the
+        // full failure surface in one log line.
+        assert.match(err.message, /direct=.*ENOTFOUND/, `expected ENOTFOUND cause unwrapped; got: ${err.message}`);
+        assert.match(err.message, /proxy=.*407/, `expected proxy 407 in message; got: ${err.message}`);
+        return true;
+      },
+    );
   });
 
   it('uses id_ modifier (NOT the bare /web/timestamp/url path) — keeps the parser DOM byte-for-byte identical to direct FATF', async () => {


### PR DESCRIPTION
Follow-up to PR #3413. After that merged, production logs from `seed-bundle-macro` show the Wayback fallback path itself fails on every Railway tick — the very fallback that was supposed to bypass FATF's Cloudflare challenge.

## Production evidence (Railway log, 2026-04-25T20:35)

```
[FATF-Listing] FATF .../black-and-grey-lists.html: direct failed (HTTP 403)
[FATF-Listing] FATF .../black-and-grey-lists.html: proxy failed (HTTP 403), falling back to Wayback
[FATF-Listing] Retry 1/3 in 1000ms: ... wayback=The operation was aborted due to timeout
[FATF-Listing] Retry 2/3 in 2000ms: ... wayback=fetch failed
[FATF-Listing] Retry 3/3 in 4000ms: ... wayback=fetch failed
[FATF-Listing] === Failed gracefully (73062ms) ===
```

The same CDX query from my local desktop completes in **1.4 seconds** with HTTP 200 — so it's not a Wayback outage. Railway's egress IP pool is either soft-rate-limited or routed slowly to archive.org. And the bare `"wayback=fetch failed"` is undici's default — gives operators no actionable signal.

## Three changes

1. **CDX timeout 20s → 45s.** Generous ceiling that still keeps the seeder under bundle-runner's 120s `timeoutMs` and accommodates the added proxy-fallback hops.

2. **Two-tier per-call inside `fetchViaWayback`** — direct fetch first (fast when egress isn't rate-limited), CONNECT proxy fallback through Decodo (residential pool isn't bucketed alongside Railway IPs at archive.org). Applied to both the CDX query AND the snapshot fetch. Same shape as the seeder's outer `fetchHtml` three-tier.

3. **`describeErr` helper** (mirrors `scripts/seed-unrest-events.mjs:162`) unwraps `err.cause` so production logs surface the actual failure mode (`ENOTFOUND` / `ECONNRESET` / `UND_ERR_CONNECT_TIMEOUT` / etc.) instead of bare `"fetch failed"`.

## Self-healing path

Same property as the original three-tier: direct → proxy → Wayback (now itself direct → proxy → throw). The moment Railway egress stops being rate-limited by archive.org, direct CDX succeeds again with no code change. No need to re-evaluate later.

## Tests

`+2` new cases on `fetchViaWayback`:

- **`falls back to CONNECT proxy when direct CDX query fails`** — pins both CDX and snapshot proxy routing, asserts `id_` modifier is preserved on the proxy path.
- **`error message unwraps err.cause when both direct and proxy fail`** — drives a `TypeError('fetch failed')` with `cause.code = 'ENOTFOUND'` through direct, a 407 through proxy; asserts the final error message contains BOTH `direct=...ENOTFOUND` and `proxy=...407`.

Updated 2 existing tests (`throws when CDX itself is unreachable`, `throws when the snapshot itself returns non-200`) to pass `proxyAuth: null` so they stay focused on the direct-only failure mode the new fallback would otherwise mask.

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] CJS syntax check
- [x] `npm run lint` (no errors)
- [x] `npm run test:data` (7201 pass; was 7194 on main + 24 in fatf file)
- [x] Edge bundle check
- [x] `node --test tests/edge-functions.test.mjs` (177 pass)
- [x] `npm run lint:md`
- [x] `npm run version:check`
- [ ] After merge + Railway redeploy, watch the next 1–3 macro-bundle ticks for `[FATF-Listing]` lines that don't end in `=== Failed gracefully ===`. Either direct Wayback works (CDX latency dropped) or proxy-Wayback succeeds — either way, `economic:fatf-listing:v1` gets written.
- [ ] Confirm `/api/health` `fatfListing.status` flips from `EMPTY` to `OK`.

## Related

- #3413 (Wayback fallback) — merged, this is the second-order fix for that path's own failure mode.
- #3414 (SIGTERM lock-release whole-run) — merged, unrelated to FATF but addresses BIS-LBS in the same bundle.