### PR TITLE
fix(map+sentry): radar setTiles race + iOS OrbitControls noise filter

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -572,6 +572,12 @@ export class DeckGLMap {
   private radarRefreshIntervalId: ReturnType<typeof setInterval> | null = null;
   private radarActive = false;
   private radarTileUrl = '';
+  // Drop duplicate `once('idle', applyRadarLayer)` registrations when
+  // the source isn't loaded yet. Without this, both the style.load
+  // callback and the 5-minute refresh can register listeners in the
+  // same load window — they'd all fire on the next idle and call
+  // setTiles back-to-back. Idempotent today but wasteful.
+  private radarIdlePending = false;
   private readonly startupTime = Date.now();
   private lastCableHighlightSignature = '';
   private lastCableHealthSignature = '';
@@ -727,7 +733,13 @@ export class DeckGLMap {
         // isSourceLoaded(id) is MapLibre's official "tiles fetched +
         // applied to GL state" check; defer to the next idle if false.
         if (!this.maplibreMap.isSourceLoaded('weather-radar')) {
-          this.maplibreMap.once('idle', () => this.applyRadarLayer());
+          if (!this.radarIdlePending) {
+            this.radarIdlePending = true;
+            this.maplibreMap.once('idle', () => {
+              this.radarIdlePending = false;
+              this.applyRadarLayer();
+            });
+          }
           return;
         }
         existing.setTiles([this.radarTileUrl]);

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -719,6 +719,17 @@ export class DeckGLMap {
     try {
       const existing = this.maplibreMap.getSource('weather-radar') as (maplibregl.RasterTileSource & { setTiles: (tiles: string[]) => void }) | undefined;
       if (existing) {
+        // Guard against the source existing in the style registry while
+        // its underlying texture is mid-load or being torn down. Calling
+        // setTiles in that window triggers a render-frame crash inside
+        // MapLibre at fa() / texture.bind() (Sentry WORLDMONITOR-P6:
+        // Firefox 149, hit on the 5-minute radar refresh interval).
+        // isSourceLoaded(id) is MapLibre's official "tiles fetched +
+        // applied to GL state" check; defer to the next idle if false.
+        if (!this.maplibreMap.isSourceLoaded('weather-radar')) {
+          this.maplibreMap.once('idle', () => this.applyRadarLayer());
+          return;
+        }
         existing.setTiles([this.radarTileUrl]);
         return;
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -346,7 +346,7 @@ Sentry.init({
     if (/undefined is not an object \(evaluating 't\.x'\)|Cannot read properties of undefined \(reading 'x'\)/.test(msg)) {
       if (!hasFirstParty || frames.some(f => /\b_handleTouch\w*Dolly|OrbitControls/.test(f.function ?? ''))) return null;
       const osName = ((event.contexts as any)?.os?.name as string) ?? '';
-      const isTouchOs = /^iOS|iPadOS$/.test(osName);
+      const isTouchOs = /^(iOS|iPadOS)$/.test(osName);
       const mainBundleFrames = nonInfraFrames.filter(f => /\/(main|index)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''));
       if (isTouchOs && mainBundleFrames.length === 1 && nonInfraFrames.length === mainBundleFrames.length) return null;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -334,8 +334,21 @@ Sentry.init({
     // Suppress Three.js OrbitControls touch crashes (finger lifted during pinch-zoom).
     // OrbitControls is bundled into the main chunk, so hasFirstParty is true.
     // Match by function name pattern (_handleTouch*Dolly*) or suppress when no first-party frames.
+    //
+    // Symbolicated case: function name regex hits (_handleTouchDolly*, OrbitControls).
+    // Unsymbolicated case (Sentry WORLDMONITOR-P7): single minified frame in the main
+    // bundle (e.g. `Yge`) on iOS/iPadOS Safari. iOS is the only platform where a
+    // touch-driven `t.x` crash is plausible AND the production build can lose source
+    // maps for OrbitControls' touch handlers. Gate on:
+    //   - exactly one main-bundle frame in the trace (no other first-party functions)
+    //   - device.family/os indicates iOS/iPadOS
+    // so a real `t.x` regression elsewhere on desktop still surfaces.
     if (/undefined is not an object \(evaluating 't\.x'\)|Cannot read properties of undefined \(reading 'x'\)/.test(msg)) {
       if (!hasFirstParty || frames.some(f => /\b_handleTouch\w*Dolly|OrbitControls/.test(f.function ?? ''))) return null;
+      const osName = ((event.contexts as any)?.os?.name as string) ?? '';
+      const isTouchOs = /^iOS|iPadOS$/.test(osName);
+      const mainBundleFrames = nonInfraFrames.filter(f => /\/(main|index)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''));
+      if (isTouchOs && mainBundleFrames.length === 1 && nonInfraFrames.length === mainBundleFrames.length) return null;
     }
     // Suppress Three.js OrbitControls pointer-capture race: pointerdown handler calls
     // setPointerCapture but the browser has already released the pointer (focus change,


### PR DESCRIPTION
## Summary

Two production Sentry issues triaged and fixed on 2026-04-26.

### WORLDMONITOR-P6 — `TypeError: ne.texture is undefined` (Firefox 149, MapLibre)

ACTIONABLE bug in our weather-radar refresh loop. The 5-minute `setInterval` calls `applyRadarLayer()` which invokes `existing.setTiles([url])` on the `weather-radar` source. If the source's underlying GL texture is mid-load or being torn down at that moment, MapLibre's render-frame crashes at `fa()` / `texture.bind()`.

**Fix:** guard `setTiles` behind `isSourceLoaded('weather-radar')`. When not ready, defer to the next `idle` event. The MapLibre `idle` event only fires when the map has stopped rendering, so the deferred retry won't loop.

**Discovery note:** the top 8 frames of the stack were 100% MapLibre internals — looked like pure vendor noise. The full 30-frame stack revealed 4 first-party frames (`startWeatherRadar` → `fetchAndApplyRadar` → `applyRadarLayer`) buried after the vendor frames. Captured this triage trap in `skill_truncated_stack_trace_misses_first_party_call_origin.md`.

### WORLDMONITOR-P7 — `TypeError: undefined is not an object (evaluating 't.x')` (iPad/Chrome iOS)

NOISE-filter strengthening for the existing OrbitControls touch-crash filter. The filter requires either `!hasFirstParty` or a function-name match (`_handleTouchDolly*` / `OrbitControls`). Production iOS builds lose source maps for the minified touch handlers, leaving a single unsymbolicated main-bundle frame (e.g. `Yge`) that matches neither gate.

**Fix:** extended the filter to ALSO suppress when `device.os` is `iOS`/`iPadOS` AND the trace has exactly one main-bundle frame. iOS is the only platform where touch-driven `t.x` is plausible AND symbolication is fragile. Desktop `t.x` regressions still surface (gated on touch-OS check).

## Test plan

- [x] `npm run typecheck` + `npm run typecheck:api`: PASS
- [x] `npm run lint`: PASS (8 pre-existing warnings unchanged)
- [x] `npm run test:data`: **7202/7202** (including 115 sentry-beforesend regression tests)
- [x] `npm run lint:md`: 0 errors
- [x] `npm run version:check`: OK
- [x] Edge function bundle + tests: PASS
- [x] Both Sentry issues marked Resolved (`inNextRelease: true`) on the project — will auto-reopen if the signatures recur after deploy

## Post-Deploy Monitoring & Validation

**Sentry signals to watch (first 7 days post-deploy):**

| Signature | Expected | If reopened |
|---|---|---|
| `WORLDMONITOR-P6` (`ne.texture is undefined` from `applyRadarLayer`) | 0 events | radar refresh has another race path; investigate `removeRadarLayer` and the post-`removeSource` window |
| `WORLDMONITOR-P7` (`t.x` evaluating) on iOS/iPadOS device tag | 0 events | minified function name moved or device tag changed; widen the filter or add another OS gate |
| Generic `t.x` on non-iOS desktop | unchanged | regression elsewhere (real bug, not OrbitControls) — investigate |

**Validation window:** 7 days. Owner: @eliehabib. Both issues had only 2 events / 1 user pre-fix, so confirmation may take a few days of normal traffic.

**Rollback:** revert the commit; both fixes are isolated. The radar guard is a one-line `if`, the Sentry filter extension is a 4-line block — neither has any cross-cutting blast radius.