### PR TITLE
fix(classify-cache + brief-filter): cap LLM upgrades + brief-side guards (PR 2/2)

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3125,9 +3125,17 @@ function matchCountryNamesInText(text) {
   return [];
 }
 
+// v4 (2026-04-26): bumped from v3 in lockstep with
+// server/worldmonitor/intelligence/v1/_shared.ts and
+// server/worldmonitor/news/v1/list-feed-digest.ts to evict cache entries
+// that previously promoted static-page titles to high/critical via the
+// LLM classifier. The relay maintains its own inline helper because
+// .cjs cannot import from .ts; the prefix-audit static-analysis test
+// (tests/news-classify-cache-prefix-audit.test.mjs) cross-checks all
+// three sites. See U4 of the plan.
 function classifyCacheKey(title) {
   const hash = crypto.createHash('sha256').update(title.toLowerCase()).digest('hex').slice(0, 16);
-  return `classify:sebuf:v3:${hash}`;
+  return `classify:sebuf:v4:${hash}`;
 }
 
 // LLM provider fallback chain — mirrors seed-insights.mjs LLM_PROVIDERS

--- a/scripts/audit-static-page-contamination.mjs
+++ b/scripts/audit-static-page-contamination.mjs
@@ -83,14 +83,23 @@ async function batchHgetAll(url, token, keys) {
   const commands = keys.map((k) => ['HGETALL', k]);
   const responses = await redisPipeline(url, token, commands);
   return responses.map((r) => {
-    const arr = r?.result;
-    if (!Array.isArray(arr) || arr.length === 0) return null;
-    // Upstash HGETALL returns ['k1', 'v1', 'k2', 'v2', ...] OR an object.
-    // Normalize to object.
-    if (typeof arr === 'object' && !Array.isArray(arr)) return arr;
+    const result = r?.result;
+    if (result == null) return null;
+    // Upstash HGETALL response shape varies by client/version:
+    //   - Object: { k1: 'v1', k2: 'v2' } — direct.
+    //   - Flat array: ['k1', 'v1', 'k2', 'v2', ...] — pair-wise normalize.
+    //   - Empty array / empty object: missing key.
+    // Object check MUST come before the array check (typeof []  === 'object'
+    // too, but Array.isArray distinguishes them); the previous order
+    // returned null for object-shape responses before the object branch
+    // could ever match, silently missing every contaminated row.
+    if (typeof result === 'object' && !Array.isArray(result)) {
+      return Object.keys(result).length === 0 ? null : result;
+    }
+    if (!Array.isArray(result) || result.length === 0) return null;
     const obj = {};
-    for (let i = 0; i < arr.length - 1; i += 2) {
-      obj[arr[i]] = arr[i + 1];
+    for (let i = 0; i < result.length - 1; i += 2) {
+      obj[result[i]] = result[i + 1];
     }
     return obj;
   });

--- a/scripts/audit-static-page-contamination.mjs
+++ b/scripts/audit-static-page-contamination.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+// Ops audit + cleanup for residual static-institutional-page contamination
+// in story:track:v1:* (U6 of docs/plans/2026-04-26-001-fix-brief-static-
+// page-contamination-plan.md).
+//
+// Usage:
+//   node scripts/audit-static-page-contamination.mjs           # dry run, prints stats
+//   node scripts/audit-static-page-contamination.mjs --apply   # also DELs matched keys
+//
+// Run AFTER PR-1 (ingest gates) and PR-2 (LLM cache prefix bump) reach
+// production. The dry-run output drives whether U7's URL-classifier
+// regex needs widening (separate follow-up PR) and confirms the upstream
+// gates are catching new arrivals (matched count should fall over time).
+//
+// Pure-helper coverage lives in tests/url-classifier.test.mjs. The Redis
+// scan is mechanical and exercised by manual dry runs — there is no unit
+// test for the side-effecting --apply path (would require a Redis
+// double; out of scope for this one-shot script).
+
+import { isInstitutionalStaticPage } from './shared/url-classifier.js';
+import { getRedisCredentials } from './_seed-utils.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const SCAN_PATTERN = 'story:track:v1:*';
+const SCAN_BATCH = 100;
+const SCAN_TIMEOUT_MS = 15_000;
+const HGETALL_BATCH = 25; // pipeline width
+
+async function redisCommand(url, token, command) {
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(command),
+    signal: AbortSignal.timeout(SCAN_TIMEOUT_MS),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    throw new Error(`Redis command failed: HTTP ${resp.status} — ${text.slice(0, 200)}`);
+  }
+  return resp.json();
+}
+
+async function redisPipeline(url, token, commands) {
+  const resp = await fetch(`${url}/pipeline`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(commands),
+    signal: AbortSignal.timeout(SCAN_TIMEOUT_MS),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    throw new Error(`Redis pipeline failed: HTTP ${resp.status} — ${text.slice(0, 200)}`);
+  }
+  return resp.json();
+}
+
+/**
+ * Cursor-based SCAN. Yields batches of matching keys. The 'cursor === 0'
+ * termination follows Redis SCAN semantics (returns to 0 when done).
+ */
+async function* scanKeys(url, token, pattern) {
+  let cursor = '0';
+  do {
+    const resp = await redisCommand(url, token, [
+      'SCAN', cursor, 'MATCH', pattern, 'COUNT', String(SCAN_BATCH),
+    ]);
+    const result = resp.result;
+    if (!Array.isArray(result) || result.length < 2) {
+      throw new Error(`Unexpected SCAN response shape: ${JSON.stringify(resp)}`);
+    }
+    cursor = String(result[0]);
+    const keys = Array.isArray(result[1]) ? result[1] : [];
+    if (keys.length > 0) yield keys;
+  } while (cursor !== '0');
+}
+
+/**
+ * Pipelined HGETALL for a batch of keys. Returns an array aligned with
+ * `keys`: each entry is the parsed hash (object) or null on miss.
+ */
+async function batchHgetAll(url, token, keys) {
+  if (keys.length === 0) return [];
+  const commands = keys.map((k) => ['HGETALL', k]);
+  const responses = await redisPipeline(url, token, commands);
+  return responses.map((r) => {
+    const arr = r?.result;
+    if (!Array.isArray(arr) || arr.length === 0) return null;
+    // Upstash HGETALL returns ['k1', 'v1', 'k2', 'v2', ...] OR an object.
+    // Normalize to object.
+    if (typeof arr === 'object' && !Array.isArray(arr)) return arr;
+    const obj = {};
+    for (let i = 0; i < arr.length - 1; i += 2) {
+      obj[arr[i]] = arr[i + 1];
+    }
+    return obj;
+  });
+}
+
+async function batchDel(url, token, keys) {
+  if (keys.length === 0) return 0;
+  // SREM corresponding story:sources:v1:{hash} for each — the audit
+  // deletes both halves of the contamination pair so a future
+  // republish won't be blocked by an orphaned sources set.
+  const commands = [];
+  for (const k of keys) {
+    commands.push(['DEL', k]);
+    const hash = k.replace(/^story:track:v1:/, '');
+    if (hash && hash !== k) {
+      commands.push(['DEL', `story:sources:v1:${hash}`]);
+    }
+  }
+  await redisPipeline(url, token, commands);
+  return keys.length;
+}
+
+function summarizePerHostPath(matches) {
+  const hostCounts = new Map();
+  const pathPatternCounts = new Map();
+  for (const m of matches) {
+    try {
+      const u = new URL(m.link);
+      hostCounts.set(u.hostname, (hostCounts.get(u.hostname) ?? 0) + 1);
+      // First two path segments give a useful pattern bucket without
+      // exploding cardinality (e.g., '/About' vs '/About/Section-508').
+      const segs = u.pathname.split('/').filter(Boolean);
+      const bucket = '/' + segs.slice(0, 2).join('/');
+      pathPatternCounts.set(bucket, (pathPatternCounts.get(bucket) ?? 0) + 1);
+    } catch {
+      // Already filtered by isInstitutionalStaticPage; reaching here
+      // would be a regression in the classifier.
+    }
+  }
+  const fmt = (m) => [...m.entries()].sort((a, b) => b[1] - a[1]);
+  return { byHost: fmt(hostCounts), byPathPattern: fmt(pathPatternCounts) };
+}
+
+async function main() {
+  const { url, token } = getRedisCredentials();
+  console.log(`[audit] mode=${APPLY ? 'APPLY (will DELETE)' : 'DRY RUN'}`);
+  console.log(`[audit] scanning ${SCAN_PATTERN}…`);
+
+  const matches = [];
+  let scanned = 0;
+
+  for await (const keyBatch of scanKeys(url, token, SCAN_PATTERN)) {
+    scanned += keyBatch.length;
+    for (let i = 0; i < keyBatch.length; i += HGETALL_BATCH) {
+      const slice = keyBatch.slice(i, i + HGETALL_BATCH);
+      const tracks = await batchHgetAll(url, token, slice);
+      for (let j = 0; j < slice.length; j++) {
+        const key = slice[j];
+        const t = tracks[j];
+        if (!t || typeof t !== 'object') continue;
+        const link = t.link;
+        if (typeof link !== 'string' || link.length === 0) continue;
+        if (isInstitutionalStaticPage(link)) {
+          matches.push({
+            key,
+            link,
+            severity: t.severity ?? '?',
+            source: t.source ?? '?',
+            title: (t.title ?? '').slice(0, 80),
+          });
+        }
+      }
+    }
+    process.stderr.write(`\r[audit] scanned=${scanned} matched=${matches.length}`);
+  }
+  process.stderr.write('\n');
+
+  if (matches.length === 0) {
+    console.log('[audit] zero contaminated entries — upstream gates working ✓');
+    return;
+  }
+
+  console.log('');
+  console.log(`[audit] matched ${matches.length} contaminated story:track:v1 entries:`);
+  for (const m of matches) {
+    console.log(
+      `  [${m.key}] severity=${m.severity} source="${m.source}" url=${m.link}`,
+    );
+  }
+
+  console.log('');
+  const summary = summarizePerHostPath(matches);
+  console.log('[audit] by host:');
+  for (const [host, n] of summary.byHost) console.log(`  ${host.padEnd(40)} ${n}`);
+  console.log('[audit] by path pattern:');
+  for (const [pattern, n] of summary.byPathPattern) console.log(`  ${pattern.padEnd(40)} ${n}`);
+
+  if (!APPLY) {
+    console.log('');
+    console.log('[audit] DRY RUN — pass --apply to delete these keys.');
+    return;
+  }
+
+  console.log('');
+  console.log(`[audit] APPLY: deleting ${matches.length} keys + their story:sources:v1 siblings…`);
+  const keysToDelete = matches.map((m) => m.key);
+  for (let i = 0; i < keysToDelete.length; i += HGETALL_BATCH) {
+    const slice = keysToDelete.slice(i, i + HGETALL_BATCH);
+    await batchDel(url, token, slice);
+  }
+  console.log(`[audit] deleted ${matches.length} contaminated entries.`);
+}
+
+main().catch((err) => {
+  console.error('[audit] failed:', err);
+  process.exit(1);
+});

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -1420,7 +1420,16 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
   // Compose envelope with synthesis pre-baked. The composer applies
   // rankedStoryHashes-aware ordering BEFORE the cap, so the model's
   // editorial judgment of importance survives MAX_STORIES_PER_USER.
-  const dropStats = { severity: 0, headline: 0, url: 0, shape: 0, cap: 0, in: winnerStories.length };
+  const dropStats = {
+    severity: 0,
+    headline: 0,
+    url: 0,
+    shape: 0,
+    cap: 0,
+    source_topic_cap: 0,
+    institutional_static_page: 0,
+    in: winnerStories.length,
+  };
   const envelope = composeBriefFromDigestStories(
     winner.rule,
     winnerStories,
@@ -1456,6 +1465,8 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
       `dropped_headline=${dropStats.headline} ` +
       `dropped_shape=${dropStats.shape} ` +
       `dropped_cap=${dropStats.cap} ` +
+      `dropped_source_topic_cap=${dropStats.source_topic_cap} ` +
+      `dropped_institutional_static_page=${dropStats.institutional_static_page} ` +
       `out=${out}`,
   );
 

--- a/scripts/shared/url-classifier.js
+++ b/scripts/shared/url-classifier.js
@@ -1,0 +1,76 @@
+// Pure URL classifier for static institutional pages on .gov / .mil / .int
+// domains. Used by:
+//   - U7: brief-filter denylist guard (last-line defense before a story
+//     reaches a user-facing brief).
+//   - U6: scripts/audit-static-page-contamination.mjs (one-shot Redis
+//     scanner that evicts story:track:v1 entries from sources that
+//     pre-date the U1+U2+U3 ingest gates).
+//
+// Conservative by design: must match BOTH a .gov/.mil/.int host AND a
+// curated path prefix. Single-condition matches (e.g., any .gov URL or
+// any /About/ path) would over-trigger.
+//
+// See R7 in docs/plans/2026-04-26-001-fix-brief-static-page-contamination-plan.md.
+
+/**
+ * Hosts whose static institutional pages we treat as the contamination
+ * class. Match is case-insensitive and supports the bare domain plus any
+ * subdomain.
+ */
+const INSTITUTIONAL_HOST_SUFFIXES = ['.gov', '.mil', '.int'];
+
+/**
+ * Path-prefix patterns that identify a static landing/policy/strategy
+ * page rather than a dated news article. Match is case-insensitive on
+ * the URL pathname and applied as a starts-with check.
+ *
+ * Curated from the known Pentagon contamination cases that motivated
+ * the plan (About/Section-508, Acquisition-Transformation-Strategy,
+ * 5G Ecosystem report) plus extrapolated patterns common across .gov
+ * sites. Post-deploy U6 audit will confirm coverage and inform any
+ * widening in a follow-up PR.
+ */
+const STATIC_PATH_PREFIXES = [
+  '/About/',
+  '/Section-',
+  '/Acquisition-Transformation-Strategy',
+  '/Strategy/',
+  '/Strategies/',
+  '/Policy/',
+  '/Policies/',
+  '/Resources/',
+  '/Programs/',
+];
+
+/**
+ * Returns true if the URL is a static institutional landing page that
+ * should never be treated as news. Returns false for malformed URLs,
+ * non-institutional hosts, and institutional URLs whose path matches
+ * the news-article pattern (e.g., /News/Releases/...).
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function isInstitutionalStaticPage(url) {
+  if (typeof url !== 'string' || url.length === 0) return false;
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false;
+
+  const host = parsed.hostname.toLowerCase();
+  const hostMatch = INSTITUTIONAL_HOST_SUFFIXES.some(
+    (suffix) => host === suffix.slice(1) || host.endsWith(suffix),
+  );
+  if (!hostMatch) return false;
+
+  // Lowercase pathname so 'defense.gov/ABOUT/...' (rare but observed in
+  // some redirect chains) classifies the same as the canonical case.
+  const path = parsed.pathname.toLowerCase();
+  return STATIC_PATH_PREFIXES.some((prefix) => path.startsWith(prefix.toLowerCase()));
+}

--- a/scripts/shared/url-classifier.js
+++ b/scripts/shared/url-classifier.js
@@ -20,9 +20,20 @@
 const INSTITUTIONAL_HOST_SUFFIXES = ['.gov', '.mil', '.int'];
 
 /**
- * Path-prefix patterns that identify a static landing/policy/strategy
- * page rather than a dated news article. Match is case-insensitive on
- * the URL pathname and applied as a starts-with check.
+ * Path patterns that identify a static landing/policy/strategy page
+ * rather than a dated news article. Two pattern families:
+ *
+ *   - Segment buckets (entries ending with `/`): match the bare segment
+ *     OR the segment as a path prefix. `/About/` matches `/about` AND
+ *     `/about/section-508` but NOT `/aboutface` (segment boundary
+ *     enforced). Using plain `startsWith('/about/')` would have missed
+ *     the bare `/about` form on canonical landing pages — that's the
+ *     P2 finding from PR #3419 review.
+ *
+ *   - Wildcard prefixes (entries NOT ending with `/`): match any path
+ *     starting with the literal prefix. `/Section-` intentionally
+ *     matches `/section-508`, `/section-504`, etc., where the value
+ *     after the dash is part of the bucket name, not a sub-segment.
  *
  * Curated from the known Pentagon contamination cases that motivated
  * the plan (About/Section-508, Acquisition-Transformation-Strategy,
@@ -41,6 +52,28 @@ const STATIC_PATH_PREFIXES = [
   '/Resources/',
   '/Programs/',
 ];
+
+/**
+ * Returns true when `path` (already lowercased) matches `prefix` as
+ * either an exact segment, a segment-prefix, or a wildcard prefix per
+ * the rules above.
+ *
+ * @param {string} path
+ * @param {string} prefix
+ */
+function pathMatchesPrefix(path, prefix) {
+  const lower = prefix.toLowerCase();
+  if (lower.endsWith('/')) {
+    // Segment-bucket rule: drop the trailing slash, match exactly OR
+    // require an explicit segment boundary. `/aboutface` !== `/about`
+    // and !startsWith(`/about/`), so over-match is avoided.
+    const stem = lower.slice(0, -1);
+    return path === stem || path.startsWith(`${stem}/`);
+  }
+  // Wildcard-prefix rule: literal startsWith. `/Section-` matches
+  // `/section-508` because the dash is part of the bucket name.
+  return path.startsWith(lower);
+}
 
 /**
  * Returns true if the URL is a static institutional landing page that
@@ -72,5 +105,5 @@ export function isInstitutionalStaticPage(url) {
   // Lowercase pathname so 'defense.gov/ABOUT/...' (rare but observed in
   // some redirect chains) classifies the same as the canonical case.
   const path = parsed.pathname.toLowerCase();
-  return STATIC_PATH_PREFIXES.some((prefix) => path.startsWith(prefix.toLowerCase()));
+  return STATIC_PATH_PREFIXES.some((prefix) => pathMatchesPrefix(path, prefix));
 }

--- a/server/worldmonitor/intelligence/v1/_shared.ts
+++ b/server/worldmonitor/intelligence/v1/_shared.ts
@@ -9,7 +9,15 @@ import { hashString, sha256Hex } from '../../../_shared/hash';
 // ========================================================================
 
 export const UPSTREAM_TIMEOUT_MS = 25_000;
-const CLASSIFY_CACHE_PREFIX = 'classify:sebuf:v3:';
+// v4 (2026-04-26): bumped from v3 to evict entries poisoned by static
+// institutional pages that previously promoted info-keyword titles to
+// high/critical via the LLM classifier. See PR for U4 of
+// docs/plans/2026-04-26-001-fix-brief-static-page-contamination-plan.md.
+// Three sites read/write this prefix: this canonical writer, the digest
+// reader at server/worldmonitor/news/v1/list-feed-digest.ts (now uses
+// buildClassifyCacheKey), and scripts/ais-relay.cjs (independent inline
+// helper — cannot import from .ts). All three were updated atomically.
+const CLASSIFY_CACHE_PREFIX = 'classify:sebuf:v4:';
 
 // ========================================================================
 // Tier-1 country definitions (used by risk-scores + country-intel-brief)

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -14,6 +14,7 @@ import { sha256Hex } from '../../../_shared/hash';
 import { CHROME_UA } from '../../../_shared/constants';
 import { VARIANT_FEEDS, INTEL_SOURCES, type ServerFeed } from './_feeds';
 import { classifyByKeyword, type ThreatLevel } from './_classifier';
+import { buildClassifyCacheKey } from '../../intelligence/v1/_shared';
 import { getSourceTier } from '../../../_shared/source-tiers';
 import {
   STORY_TRACK_KEY,
@@ -64,6 +65,38 @@ const SEVERITY_SCORES: Record<ThreatLevel, number> = {
   low: 25,
   info: 0,
 };
+
+/**
+ * Ordinal rank of each threat level, used by the LLM classify-cache
+ * upgrade cap (U4). Cap = +2 tiers above the keyword classification.
+ * Rationale: keyword=info (no-match fallback at confidence 0.3) jumping
+ * straight to high/critical is the static-institutional-page contamination
+ * path; capping at info+2=medium blocks it. Legitimate keyword=low →
+ * LLM=critical upgrades (e.g., "Markets crash" headline) are preserved
+ * because low+2=critical. See R4 in the plan.
+ */
+const LEVEL_RANK: Record<ThreatLevel, number> = {
+  info: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+const RANK_TO_LEVEL: ThreatLevel[] = ['info', 'low', 'medium', 'high', 'critical'];
+
+/**
+ * Cap an LLM-classified level to at most +2 tiers above the keyword level.
+ * Returns the original `llmLevel` when within the cap, otherwise the
+ * level at rank `keywordRank + 2`. Falls back to the keyword level when
+ * the LLM level is unrecognized (defensive).
+ */
+function capLlmUpgrade(keywordLevel: ThreatLevel, llmLevel: string): ThreatLevel {
+  const keywordRank = LEVEL_RANK[keywordLevel];
+  const rawLlmRank = LEVEL_RANK[llmLevel as ThreatLevel];
+  if (rawLlmRank == null) return keywordLevel;
+  const cappedRank = Math.min(rawLlmRank, keywordRank + 2);
+  return RANK_TO_LEVEL[cappedRank] ?? keywordLevel;
+}
 
 /**
  * Importance score component weights (must sum to 1.0).
@@ -460,10 +493,13 @@ async function enrichWithAiCache(items: ParsedItem[]): Promise<void> {
   const candidates = items.filter(i => i.classSource === 'keyword');
   if (candidates.length === 0) return;
 
+  // Use the canonical buildClassifyCacheKey from intelligence/v1/_shared
+  // so the cache prefix (currently classify:sebuf:v4:) lives in exactly
+  // one place — bumping it again only requires touching _shared.ts and
+  // the relay's independent .cjs helper. See U4 of the plan.
   const keyMap = new Map<string, ParsedItem[]>();
   for (const item of candidates) {
-    const hash = (await sha256Hex(item.title.toLowerCase())).slice(0, 16);
-    const key = `classify:sebuf:v3:${hash}`;
+    const key = await buildClassifyCacheKey(item.title);
     const existing = keyMap.get(key) ?? [];
     existing.push(item);
     keyMap.set(key, existing);
@@ -478,11 +514,22 @@ async function enrichWithAiCache(items: ParsedItem[]): Promise<void> {
 
     for (const item of relatedItems) {
       if (0.9 <= item.confidence) continue;
-      item.level = hit.level as typeof item.level;
+      // Cap the LLM upgrade at +2 tiers above the keyword classification
+      // so a poisoned cache entry (e.g., "About Section 508" → high) can't
+      // promote an info-keyword item past medium. Legitimate low→critical
+      // upgrades (low+2 = critical) remain reachable. R4.
+      const cappedLevel = capLlmUpgrade(item.level, hit.level);
+      if (cappedLevel !== hit.level) {
+        console.warn(
+          `[classify] LLM upgrade capped: keyword=${item.level} ` +
+            `llm=${hit.level} applied=${cappedLevel} title="${item.title.slice(0, 60)}"`,
+        );
+      }
+      item.level = cappedLevel;
       item.category = hit.category;
       item.confidence = 0.9;
       item.classSource = 'llm';
-      item.isAlert = hit.level === 'critical' || hit.level === 'high';
+      item.isAlert = cappedLevel === 'critical' || cappedLevel === 'high';
     }
   }
 }
@@ -882,6 +929,7 @@ export const __testing__ = {
   extractFirstDateTag,
   buildStoryTrackHsetFields,
   resolveMaxAgeMs,
+  capLlmUpgrade,
   MAX_DESCRIPTION_LEN,
   MIN_DESCRIPTION_LEN,
   FUTURE_DATE_TOLERANCE_MS,

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -524,8 +524,11 @@ async function enrichWithAiCache(items: ParsedItem[]): Promise<void> {
       if (0.9 <= item.confidence) continue;
       // Cap the LLM upgrade at +2 tiers above the keyword classification
       // so a poisoned cache entry (e.g., "About Section 508" → high) can't
-      // promote an info-keyword item past medium. Legitimate low→critical
-      // upgrades (low+2 = critical) remain reachable. R4.
+      // promote an info-keyword item past medium (info+2=medium). Legitimate
+      // medium→critical upgrades (medium+2=critical) remain reachable; the
+      // bounded loss is keyword=low → LLM=critical, which caps at high
+      // (low+2=high) and is logged below. See LEVEL_RANK doc + R4 for the
+      // full per-keyword cap table.
       const cappedLevel = capLlmUpgrade(item.level, hit.level);
       if (cappedLevel !== hit.level) {
         console.warn(

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -69,11 +69,19 @@ const SEVERITY_SCORES: Record<ThreatLevel, number> = {
 /**
  * Ordinal rank of each threat level, used by the LLM classify-cache
  * upgrade cap (U4). Cap = +2 tiers above the keyword classification.
+ *
  * Rationale: keyword=info (no-match fallback at confidence 0.3) jumping
  * straight to high/critical is the static-institutional-page contamination
- * path; capping at info+2=medium blocks it. Legitimate keyword=low →
- * LLM=critical upgrades (e.g., "Markets crash" headline) are preserved
- * because low+2=critical. See R4 in the plan.
+ * path; capping at info+2=medium blocks it. Cap behavior by keyword:
+ *   info(0)+2=medium    — blocks info→{high,critical} (the contamination class)
+ *   low(1)+2=high       — preserves low→{medium,high}; caps low→critical at high
+ *   medium(2)+2=critical — preserves medium→{high,critical} (e.g. "Markets crash" → critical)
+ *   high(3)+2=critical  — passes through (existing 0.9-confidence guard at
+ *                         enrichWithAiCache also skips cache for keyword=critical)
+ *
+ * The keyword=low → LLM=critical case (capped at high) is the bounded
+ * loss; logged on every cap-fire so operators can audit if any are real.
+ * See R4 in the plan.
  */
 const LEVEL_RANK: Record<ThreatLevel, number> = {
   info: 0,

--- a/shared/brief-filter.d.ts
+++ b/shared/brief-filter.d.ts
@@ -31,9 +31,26 @@ export type AlertSensitivity = 'all' | 'high' | 'critical';
  * `cap` fires once per story skipped after `maxStories` has been
  * reached — neither severity nor field metadata is included since
  * the loop short-circuits without parsing the remaining stories.
+ *
+ * `source_topic_cap` (U5) fires when a story is dropped because the
+ * `(source, category)` pair already has `maxPerSourceTopic` survivors
+ * earlier in the in-flight `out` array. Both `severity` and `sourceUrl`
+ * are populated.
+ *
+ * `institutional_static_page` (U7) fires when a story's `sourceUrl`
+ * matches the static-institutional-page denylist (e.g.
+ * `defense.gov/About/Section-508/`). Both `severity` and `sourceUrl`
+ * are populated.
  */
 export type DropMetricsFn = (event: {
-  reason: 'severity' | 'headline' | 'url' | 'shape' | 'cap';
+  reason:
+    | 'severity'
+    | 'headline'
+    | 'url'
+    | 'shape'
+    | 'cap'
+    | 'source_topic_cap'
+    | 'institutional_static_page';
   severity?: string;
   sourceUrl?: string;
 }) => void;
@@ -55,11 +72,18 @@ export type DropMetricsFn = (event: {
  * stories not in the ranking come after in their original relative
  * order. Lets the canonical synthesis brain's editorial judgment of
  * importance survive the `maxStories` cut.
+ *
+ * `maxPerSourceTopic` (U5, default 2) caps how many stories sharing
+ * the same `(source, category)` pair can survive into a single brief.
+ * Pass `Infinity` to disable. The cap runs AFTER `applyRankedOrder`
+ * so the highest-ranked sibling of any pair survives. Stories beyond
+ * the cap are dropped with `onDrop({ reason: 'source_topic_cap' })`.
  */
 export function filterTopStories(input: {
   stories: UpstreamTopStory[];
   sensitivity: AlertSensitivity;
   maxStories?: number;
+  maxPerSourceTopic?: number;
   onDrop?: DropMetricsFn;
   rankedStoryHashes?: string[];
 }): BriefStory[];

--- a/shared/brief-filter.js
+++ b/shared/brief-filter.js
@@ -7,6 +7,7 @@
 
 import { BRIEF_ENVELOPE_VERSION } from './brief-envelope.js';
 import { assertBriefEnvelope } from '../server/_shared/brief-render.js';
+import { isInstitutionalStaticPage } from './url-classifier.js';
 
 /**
  * @typedef {import('./brief-envelope.js').BriefEnvelope} BriefEnvelope
@@ -94,7 +95,7 @@ function clip(v, cap) {
 }
 
 /**
- * @typedef {(event: { reason: 'severity'|'headline'|'url'|'shape'|'cap', severity?: string, sourceUrl?: string }) => void} DropMetricsFn
+ * @typedef {(event: { reason: 'severity'|'headline'|'url'|'shape'|'cap'|'source_topic_cap'|'institutional_static_page', severity?: string, sourceUrl?: string }) => void} DropMetricsFn
  */
 
 /**
@@ -148,10 +149,10 @@ function applyRankedOrder(stories, rankedStoryHashes) {
 }
 
 /**
- * @param {{ stories: UpstreamTopStory[]; sensitivity: AlertSensitivity; maxStories?: number; onDrop?: DropMetricsFn; rankedStoryHashes?: string[] }} input
+ * @param {{ stories: UpstreamTopStory[]; sensitivity: AlertSensitivity; maxStories?: number; maxPerSourceTopic?: number; onDrop?: DropMetricsFn; rankedStoryHashes?: string[] }} input
  * @returns {BriefStory[]}
  */
-export function filterTopStories({ stories, sensitivity, maxStories = 12, onDrop, rankedStoryHashes }) {
+export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPerSourceTopic = 2, onDrop, rankedStoryHashes }) {
   if (!Array.isArray(stories)) return [];
   const allowed = ALLOWED_LEVELS_BY_SENSITIVITY[sensitivity];
   if (!allowed) return [];
@@ -218,6 +219,16 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, onDrop
       continue;
     }
 
+    // U7: defense-in-depth URL/path denylist for static institutional
+    // pages on .gov/.mil/.int. The upstream ingest gates (U1+U2+U3)
+    // should keep these out, but a regression in the feed registry or
+    // a new dialect bypassing U2 could let one through — this gate
+    // ensures the brief surface stays clean even then. R7.
+    if (isInstitutionalStaticPage(sourceUrl)) {
+      if (emit) emit({ reason: 'institutional_static_page', severity: threatLevel, sourceUrl });
+      continue;
+    }
+
     const description = clip(
       asTrimmedString(raw.description) || headline,
       MAX_DESCRIPTION_LEN,
@@ -228,6 +239,23 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, onDrop
     );
     const category = asTrimmedString(raw.category) || 'General';
     const country = asTrimmedString(raw.countryCode) || 'Global';
+
+    // Source-topic cap (R6, U5): prevent more than maxPerSourceTopic
+    // (default 2) stories sharing the same (source, category) pair from
+    // reaching a single brief. Surgical fix for editorial-clutter cases
+    // like the 2026-04-25 brief shipping both "Millions under tornado
+    // threat" and "Watch tornadoes swirl through Oklahoma" from CBS News
+    // — distinct stories the dedup correctly kept separate, but redundant
+    // for a 12-story brief. Ranked-order rule above ensures the
+    // highest-importance member of each pair survives.
+    let existingForPair = 0;
+    for (const s of out) {
+      if (s.source === source && s.category === category) existingForPair++;
+    }
+    if (existingForPair >= maxPerSourceTopic) {
+      if (emit) emit({ reason: 'source_topic_cap', severity: threatLevel, sourceUrl });
+      continue;
+    }
 
     out.push({
       category,

--- a/shared/brief-filter.js
+++ b/shared/brief-filter.js
@@ -175,6 +175,18 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPer
 
   /** @type {BriefStory[]} */
   const out = [];
+  // Per-(source, category) survivor count. Updated atomically with each
+  // out.push() below so the U5 source-topic cap check is O(1) instead of
+  // O(n) per candidate. Key format: source + KEY_DELIM + category. The
+  // ASCII Unit Separator (0x1F) prevents collisions when source or
+  // category itself contains spaces (e.g. (source='Reuters',
+  // category='World Politics') vs (source='Reuters World',
+  // category='Politics') would both produce the same key under a space
+  // delimiter). Sources/categories never legitimately contain control
+  // characters so 0x1F is a safe sentinel.
+  const KEY_DELIM = String.fromCharCode(31);
+  /** @type {Map<string, number>} */
+  const pairCounts = new Map();
   for (let i = 0; i < orderedStories.length; i++) {
     const raw = orderedStories[i];
     if (out.length >= maxStories) {
@@ -248,11 +260,8 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPer
     // — distinct stories the dedup correctly kept separate, but redundant
     // for a 12-story brief. Ranked-order rule above ensures the
     // highest-importance member of each pair survives.
-    let existingForPair = 0;
-    for (const s of out) {
-      if (s.source === source && s.category === category) existingForPair++;
-    }
-    if (existingForPair >= maxPerSourceTopic) {
+    const pairKey = source + KEY_DELIM + category;
+    if ((pairCounts.get(pairKey) ?? 0) >= maxPerSourceTopic) {
       if (emit) emit({ reason: 'source_topic_cap', severity: threatLevel, sourceUrl });
       continue;
     }
@@ -272,6 +281,7 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPer
       whyMatters:
         'Story flagged by your sensitivity settings. Open for context.',
     });
+    pairCounts.set(pairKey, (pairCounts.get(pairKey) ?? 0) + 1);
   }
   return out;
 }

--- a/shared/url-classifier.js
+++ b/shared/url-classifier.js
@@ -1,0 +1,76 @@
+// Pure URL classifier for static institutional pages on .gov / .mil / .int
+// domains. Used by:
+//   - U7: brief-filter denylist guard (last-line defense before a story
+//     reaches a user-facing brief).
+//   - U6: scripts/audit-static-page-contamination.mjs (one-shot Redis
+//     scanner that evicts story:track:v1 entries from sources that
+//     pre-date the U1+U2+U3 ingest gates).
+//
+// Conservative by design: must match BOTH a .gov/.mil/.int host AND a
+// curated path prefix. Single-condition matches (e.g., any .gov URL or
+// any /About/ path) would over-trigger.
+//
+// See R7 in docs/plans/2026-04-26-001-fix-brief-static-page-contamination-plan.md.
+
+/**
+ * Hosts whose static institutional pages we treat as the contamination
+ * class. Match is case-insensitive and supports the bare domain plus any
+ * subdomain.
+ */
+const INSTITUTIONAL_HOST_SUFFIXES = ['.gov', '.mil', '.int'];
+
+/**
+ * Path-prefix patterns that identify a static landing/policy/strategy
+ * page rather than a dated news article. Match is case-insensitive on
+ * the URL pathname and applied as a starts-with check.
+ *
+ * Curated from the known Pentagon contamination cases that motivated
+ * the plan (About/Section-508, Acquisition-Transformation-Strategy,
+ * 5G Ecosystem report) plus extrapolated patterns common across .gov
+ * sites. Post-deploy U6 audit will confirm coverage and inform any
+ * widening in a follow-up PR.
+ */
+const STATIC_PATH_PREFIXES = [
+  '/About/',
+  '/Section-',
+  '/Acquisition-Transformation-Strategy',
+  '/Strategy/',
+  '/Strategies/',
+  '/Policy/',
+  '/Policies/',
+  '/Resources/',
+  '/Programs/',
+];
+
+/**
+ * Returns true if the URL is a static institutional landing page that
+ * should never be treated as news. Returns false for malformed URLs,
+ * non-institutional hosts, and institutional URLs whose path matches
+ * the news-article pattern (e.g., /News/Releases/...).
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function isInstitutionalStaticPage(url) {
+  if (typeof url !== 'string' || url.length === 0) return false;
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false;
+
+  const host = parsed.hostname.toLowerCase();
+  const hostMatch = INSTITUTIONAL_HOST_SUFFIXES.some(
+    (suffix) => host === suffix.slice(1) || host.endsWith(suffix),
+  );
+  if (!hostMatch) return false;
+
+  // Lowercase pathname so 'defense.gov/ABOUT/...' (rare but observed in
+  // some redirect chains) classifies the same as the canonical case.
+  const path = parsed.pathname.toLowerCase();
+  return STATIC_PATH_PREFIXES.some((prefix) => path.startsWith(prefix.toLowerCase()));
+}

--- a/shared/url-classifier.js
+++ b/shared/url-classifier.js
@@ -20,9 +20,20 @@
 const INSTITUTIONAL_HOST_SUFFIXES = ['.gov', '.mil', '.int'];
 
 /**
- * Path-prefix patterns that identify a static landing/policy/strategy
- * page rather than a dated news article. Match is case-insensitive on
- * the URL pathname and applied as a starts-with check.
+ * Path patterns that identify a static landing/policy/strategy page
+ * rather than a dated news article. Two pattern families:
+ *
+ *   - Segment buckets (entries ending with `/`): match the bare segment
+ *     OR the segment as a path prefix. `/About/` matches `/about` AND
+ *     `/about/section-508` but NOT `/aboutface` (segment boundary
+ *     enforced). Using plain `startsWith('/about/')` would have missed
+ *     the bare `/about` form on canonical landing pages — that's the
+ *     P2 finding from PR #3419 review.
+ *
+ *   - Wildcard prefixes (entries NOT ending with `/`): match any path
+ *     starting with the literal prefix. `/Section-` intentionally
+ *     matches `/section-508`, `/section-504`, etc., where the value
+ *     after the dash is part of the bucket name, not a sub-segment.
  *
  * Curated from the known Pentagon contamination cases that motivated
  * the plan (About/Section-508, Acquisition-Transformation-Strategy,
@@ -41,6 +52,28 @@ const STATIC_PATH_PREFIXES = [
   '/Resources/',
   '/Programs/',
 ];
+
+/**
+ * Returns true when `path` (already lowercased) matches `prefix` as
+ * either an exact segment, a segment-prefix, or a wildcard prefix per
+ * the rules above.
+ *
+ * @param {string} path
+ * @param {string} prefix
+ */
+function pathMatchesPrefix(path, prefix) {
+  const lower = prefix.toLowerCase();
+  if (lower.endsWith('/')) {
+    // Segment-bucket rule: drop the trailing slash, match exactly OR
+    // require an explicit segment boundary. `/aboutface` !== `/about`
+    // and !startsWith(`/about/`), so over-match is avoided.
+    const stem = lower.slice(0, -1);
+    return path === stem || path.startsWith(`${stem}/`);
+  }
+  // Wildcard-prefix rule: literal startsWith. `/Section-` matches
+  // `/section-508` because the dash is part of the bucket name.
+  return path.startsWith(lower);
+}
 
 /**
  * Returns true if the URL is a static institutional landing page that
@@ -72,5 +105,5 @@ export function isInstitutionalStaticPage(url) {
   // Lowercase pathname so 'defense.gov/ABOUT/...' (rare but observed in
   // some redirect chains) classifies the same as the canonical case.
   const path = parsed.pathname.toLowerCase();
-  return STATIC_PATH_PREFIXES.some((prefix) => path.startsWith(prefix.toLowerCase()));
+  return STATIC_PATH_PREFIXES.some((prefix) => pathMatchesPrefix(path, prefix));
 }

--- a/tests/brief-filter.test.mjs
+++ b/tests/brief-filter.test.mjs
@@ -533,6 +533,44 @@ describe('filterTopStories — source-topic cap (U5/R6)', () => {
     assert.equal(out.length, 2, 'CBS News + General caps at 2');
   });
 
+  it('source-topic cap key uses non-space delimiter (collision-safe with embedded spaces)', () => {
+    // Regression guard: a naive `${source} ${category}` delimiter would
+    // collide ('Reuters', 'World Politics') with ('Reuters World',
+    // 'Politics'), causing the second pair to inherit the first's
+    // count and either over-drop or under-drop. The Map key uses
+    // ASCII Unit Separator (0x1F) so these stay distinct.
+    const out = filterTopStories({
+      stories: [
+        story({
+          primaryTitle: 'A',
+          primarySource: 'Reuters',
+          category: 'World Politics',
+        }),
+        story({
+          primaryTitle: 'B',
+          primarySource: 'Reuters',
+          category: 'World Politics',
+        }),
+        // Pair shares the naive-concatenation collision key with the
+        // Reuters+World Politics pair above; with the 0x1F delimiter
+        // it's a different pair and gets its own count.
+        story({
+          primaryTitle: 'C',
+          primarySource: 'Reuters World',
+          category: 'Politics',
+        }),
+        story({
+          primaryTitle: 'D',
+          primarySource: 'Reuters World',
+          category: 'Politics',
+        }),
+      ],
+      sensitivity: 'all',
+    });
+    // All 4 should survive (2 per pair, 2 distinct pairs).
+    assert.equal(out.length, 4);
+  });
+
   it('institutional-static-page URLs are dropped (U7/R7)', () => {
     const drops = [];
     const out = filterTopStories({

--- a/tests/brief-filter.test.mjs
+++ b/tests/brief-filter.test.mjs
@@ -88,6 +88,9 @@ describe('filterTopStories', () => {
         upstreamStory({ threatLevel: 'unknown' }),
       ],
       sensitivity: 'all',
+      // Disable U5's source-topic cap — these fixtures share source/category
+      // by design (they test the severity gate, not the per-pair cap).
+      maxPerSourceTopic: Infinity,
     });
     assert.equal(out.length, 4);
   });
@@ -96,7 +99,14 @@ describe('filterTopStories', () => {
     const stories = Array.from({ length: 20 }, (_, i) =>
       upstreamStory({ primaryTitle: `Story ${i}` }),
     );
-    const out = filterTopStories({ stories, sensitivity: 'all', maxStories: 5 });
+    const out = filterTopStories({
+      stories,
+      sensitivity: 'all',
+      maxStories: 5,
+      // Disable U5's source-topic cap — these fixtures share source/category
+      // by design (they test the maxStories cap, not the per-pair cap).
+      maxPerSourceTopic: Infinity,
+    });
     assert.equal(out.length, 5);
   });
 
@@ -369,7 +379,7 @@ describe('filterTopStories — onDrop metrics', () => {
 
   it('reconciliation invariant: in === out + sum(dropped_*) across all reasons', () => {
     // Locks in the operator-facing invariant that motivated adding `cap`.
-    const tally = { severity: 0, headline: 0, url: 0, shape: 0, cap: 0 };
+    const tally = { severity: 0, headline: 0, url: 0, shape: 0, cap: 0, source_topic_cap: 0, institutional_static_page: 0 };
     const stories = [
       upstreamStory({ primaryTitle: 'A' }),
       upstreamStory({ primaryTitle: 'B' }),
@@ -385,9 +395,14 @@ describe('filterTopStories — onDrop metrics', () => {
       stories,
       sensitivity,
       maxStories: 3,
+      // Disable U5's source-topic cap — fixtures share source/category by
+      // design; this test verifies the in===out+dropped invariant for the
+      // existing severity/headline/url/shape/cap reasons. U5's own tests
+      // cover the source_topic_cap reason in isolation.
+      maxPerSourceTopic: Infinity,
       onDrop: (ev) => { tally[ev.reason]++; },
     });
-    const totalDrops = tally.severity + tally.headline + tally.url + tally.shape + tally.cap;
+    const totalDrops = tally.severity + tally.headline + tally.url + tally.shape + tally.cap + tally.source_topic_cap + tally.institutional_static_page;
     assert.equal(stories.length, out.length + totalDrops);
   });
 });
@@ -411,5 +426,157 @@ describe('issueDateInTz', () => {
 
   it('malformed timezone falls back to UTC', () => {
     assert.equal(issueDateInTz(midnightUtc, 'Not/A_Zone'), '2026-04-18');
+  });
+});
+
+// ─── U5: source-topic cap (R6) ───────────────────────────────────────────────
+
+describe('filterTopStories — source-topic cap (U5/R6)', () => {
+  function story(overrides = {}) {
+    return upstreamStory({
+      threatLevel: 'high',
+      primarySource: 'CBS News',
+      category: 'weather',
+      ...overrides,
+    });
+  }
+
+  it('keeps 2 stories from the same (source, category) pair (within default cap)', () => {
+    const out = filterTopStories({
+      stories: [
+        story({ primaryTitle: 'Tornadoes rip through Midwest' }),
+        story({ primaryTitle: 'Watch tornadoes swirl through Oklahoma' }),
+      ],
+      sensitivity: 'all',
+    });
+    assert.equal(out.length, 2);
+  });
+
+  it('drops the 3rd story from the same (source, category) pair with reason source_topic_cap', () => {
+    const drops = [];
+    const out = filterTopStories({
+      stories: [
+        story({ primaryTitle: 'Tornadoes rip through Midwest' }),
+        story({ primaryTitle: 'Watch tornadoes swirl through Oklahoma' }),
+        story({ primaryTitle: 'Storm system batters Kansas' }),
+      ],
+      sensitivity: 'all',
+      onDrop: (e) => drops.push(e),
+    });
+    assert.equal(out.length, 2);
+    assert.equal(drops.length, 1);
+    assert.equal(drops[0].reason, 'source_topic_cap');
+    assert.equal(drops[0].severity, 'high');
+  });
+
+  it('stories from same source but different category both pass', () => {
+    const out = filterTopStories({
+      stories: [
+        story({ primaryTitle: 'Tornado A', category: 'weather' }),
+        story({ primaryTitle: 'Tornado B', category: 'weather' }),
+        story({ primaryTitle: 'Election update', category: 'politics' }),
+      ],
+      sensitivity: 'all',
+    });
+    assert.equal(out.length, 3);
+  });
+
+  it('stories from different sources but same category both pass', () => {
+    const out = filterTopStories({
+      stories: [
+        story({ primaryTitle: 'Tornado A', primarySource: 'CBS News' }),
+        story({ primaryTitle: 'Tornado B', primarySource: 'CBS News' }),
+        story({ primaryTitle: 'Tornado C', primarySource: 'Reuters' }),
+      ],
+      sensitivity: 'all',
+    });
+    assert.equal(out.length, 3);
+  });
+
+  it('honors maxPerSourceTopic override', () => {
+    const drops = [];
+    const out = filterTopStories({
+      stories: [
+        story({ primaryTitle: 'A' }),
+        story({ primaryTitle: 'B' }),
+        story({ primaryTitle: 'C' }),
+      ],
+      sensitivity: 'all',
+      maxPerSourceTopic: 1,
+      onDrop: (e) => drops.push(e),
+    });
+    assert.equal(out.length, 1);
+    assert.equal(drops.filter((d) => d.reason === 'source_topic_cap').length, 2);
+  });
+
+  it('default missing source falls back to "Multiple wires" — cap still applies', () => {
+    const out = filterTopStories({
+      stories: [
+        story({ primaryTitle: 'A', primarySource: undefined }),
+        story({ primaryTitle: 'B', primarySource: undefined }),
+        story({ primaryTitle: 'C', primarySource: undefined }),
+      ],
+      sensitivity: 'all',
+    });
+    assert.equal(out.length, 2, 'Multiple wires + same category caps at 2');
+  });
+
+  it('default missing category falls back to "General" — cap still applies', () => {
+    const out = filterTopStories({
+      stories: [
+        story({ primaryTitle: 'A', category: undefined }),
+        story({ primaryTitle: 'B', category: undefined }),
+        story({ primaryTitle: 'C', category: undefined }),
+      ],
+      sensitivity: 'all',
+    });
+    assert.equal(out.length, 2, 'CBS News + General caps at 2');
+  });
+
+  it('institutional-static-page URLs are dropped (U7/R7)', () => {
+    const drops = [];
+    const out = filterTopStories({
+      stories: [
+        upstreamStory({
+          primaryTitle: 'About Section 508',
+          primaryLink: 'https://www.defense.gov/About/Section-508/',
+          primarySource: 'Pentagon',
+          category: 'gov',
+        }),
+        upstreamStory({
+          primaryTitle: 'Real news',
+          primaryLink: 'https://example.com/real-article',
+          primarySource: 'Pentagon',
+          category: 'gov',
+        }),
+      ],
+      sensitivity: 'all',
+      onDrop: (e) => drops.push(e),
+    });
+    assert.equal(out.length, 1);
+    assert.equal(out[0].headline, 'Real news');
+    assert.equal(drops.length, 1);
+    assert.equal(drops[0].reason, 'institutional_static_page');
+    assert.equal(drops[0].sourceUrl, 'https://www.defense.gov/About/Section-508/');
+  });
+
+  it('ranked order survives the cap: highest-ranked sibling wins', () => {
+    const drops = [];
+    const out = filterTopStories({
+      stories: [
+        story({ primaryTitle: 'C low', hash: 'aaaaaaaaaaaaaaaa' }),
+        story({ primaryTitle: 'B mid', hash: 'bbbbbbbbbbbbbbbb' }),
+        story({ primaryTitle: 'A top', hash: 'cccccccccccccccc' }),
+      ],
+      sensitivity: 'all',
+      maxPerSourceTopic: 2,
+      // Rank C and A first, B last — so C+A survive, B is dropped.
+      rankedStoryHashes: ['cccccccc', 'aaaaaaaa', 'bbbbbbbb'],
+      onDrop: (e) => drops.push(e),
+    });
+    assert.equal(out.length, 2);
+    assert.equal(out[0].headline, 'A top');
+    assert.equal(out[1].headline, 'C low');
+    assert.equal(drops.filter((d) => d.reason === 'source_topic_cap').length, 1);
   });
 });

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -200,8 +200,10 @@ describe('composeBriefFromDigestStories — continued', () => {
     // threshold, so they dilute without helping adjacency). The
     // constant is env-tunable so a Railway flip can experiment with
     // cap values once new sweep evidence justifies them.
+    // Vary sources so U5's source-topic cap (default 2 per source+category)
+    // doesn't dominate the maxStories cap we're testing here.
     const many = Array.from({ length: 30 }, (_, i) =>
-      digestStory({ hash: `h${i}`, title: `Story ${i}` }),
+      digestStory({ hash: `h${i}`, title: `Story ${i}`, sources: [`Source${i}`] }),
     );
     const env = composeBriefFromDigestStories(
       rule(),
@@ -442,10 +444,12 @@ describe('composeBriefFromDigestStories — synthesis splice', () => {
   });
 
   it('rankedStoryHashes re-orders the surfaced pool BEFORE the cap is applied', () => {
+    // Vary sources so U5's source-topic cap (default 2) doesn't drop the
+    // 3rd story — this test verifies ranking, not the per-pair cap.
     const stories = [
-      digestStory({ hash: 'aaaa1111', title: 'First by digest order' }),
-      digestStory({ hash: 'bbbb2222', title: 'Second by digest order' }),
-      digestStory({ hash: 'cccc3333', title: 'Third by digest order' }),
+      digestStory({ hash: 'aaaa1111', title: 'First by digest order', sources: ['SrcA'] }),
+      digestStory({ hash: 'bbbb2222', title: 'Second by digest order', sources: ['SrcB'] }),
+      digestStory({ hash: 'cccc3333', title: 'Third by digest order', sources: ['SrcC'] }),
     ];
     const env = composeBriefFromDigestStories(
       rule(),
@@ -491,10 +495,13 @@ describe('composeBriefFromDigestStories — synthesis splice', () => {
   });
 
   it('stories not present in rankedStoryHashes go after, in original order', () => {
+    // Vary sources so U5's source-topic cap (default 2) doesn't drop the
+    // 3rd story — this test verifies ranking-then-original-order, not the
+    // per-pair cap.
     const stories = [
-      digestStory({ hash: 'unranked-A', title: 'Unranked A' }),
-      digestStory({ hash: 'ranked-B', title: 'Ranked B' }),
-      digestStory({ hash: 'unranked-C', title: 'Unranked C' }),
+      digestStory({ hash: 'unranked-A', title: 'Unranked A', sources: ['SrcA'] }),
+      digestStory({ hash: 'ranked-B', title: 'Ranked B', sources: ['SrcB'] }),
+      digestStory({ hash: 'unranked-C', title: 'Unranked C', sources: ['SrcC'] }),
     ];
     const env = composeBriefFromDigestStories(
       rule(),

--- a/tests/edge-functions.test.mjs
+++ b/tests/edge-functions.test.mjs
@@ -54,6 +54,9 @@ describe('scripts/shared/ stays in sync with shared/', () => {
   const explicitMirroredFiles = new Set([
     'brief-llm-core.js',
     'brief-llm-core.d.ts',
+    // U6/U7: pure URL classifier consumed by the brief filter (edge) AND
+    // by the audit script under scripts/. Must stay byte-identical.
+    'url-classifier.js',
   ]);
   const sharedFiles = readdirSync(sharedDir).filter(
     (f) => f.endsWith('.json') || f.endsWith('.cjs') || explicitMirroredFiles.has(f),

--- a/tests/news-classify-cache-prefix-audit.test.mjs
+++ b/tests/news-classify-cache-prefix-audit.test.mjs
@@ -1,0 +1,93 @@
+// U4 prefix-bump audit (per cache-prefix-bump-propagation-scope learning).
+//
+// The classify cache prefix lives in three independent sites:
+//   1. server/worldmonitor/intelligence/v1/_shared.ts — canonical writer
+//      (CLASSIFY_CACHE_PREFIX constant + buildClassifyCacheKey helper)
+//   2. server/worldmonitor/news/v1/list-feed-digest.ts — digest reader
+//      (now imports buildClassifyCacheKey from the shared module above)
+//   3. scripts/ais-relay.cjs — relay reader+writer (independent inline
+//      helper, cannot import from .ts)
+//
+// When the prefix is bumped (v3 → v4 → v5 …), all three sites MUST update
+// in lockstep. This static-analysis test fails if any literal `classify:
+// sebuf:vN:` string in the repo doesn't match the current canonical
+// version — preventing the relay from getting silently left behind on
+// the previous prefix (which would mean it keeps writing+reading poisoned
+// entries at the old key while the digest reads from the new one).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+// Read canonical version from _shared.ts. Single source of truth.
+const sharedSrc = readFileSync(
+  resolve(repoRoot, 'server/worldmonitor/intelligence/v1/_shared.ts'),
+  'utf-8',
+);
+
+const PREFIX_RE = /CLASSIFY_CACHE_PREFIX\s*=\s*'classify:sebuf:(v\d+):'/;
+const sharedMatch = sharedSrc.match(PREFIX_RE);
+
+describe('classify cache prefix audit (U4)', () => {
+  it('canonical prefix is defined in _shared.ts', () => {
+    assert.ok(sharedMatch, 'CLASSIFY_CACHE_PREFIX not found in _shared.ts');
+  });
+
+  it('every literal classify:sebuf:vN in the repo matches the canonical version', () => {
+    if (!sharedMatch) {
+      assert.fail('canonical prefix not found — earlier test should have caught this');
+    }
+    const canonical = sharedMatch[1]; // e.g., 'v4'
+
+    // Grep across .ts/.mjs/.cjs/.js/.json — same extensions the
+    // cache-prefix-bump-propagation-scope learning calls out. Excludes
+    // node_modules, .git, dist/build outputs.
+    let grepOut = '';
+    try {
+      grepOut = execSync(
+        `grep -rnE "classify:sebuf:v[0-9]+" \
+          --include="*.ts" --include="*.mjs" --include="*.cjs" \
+          --include="*.js" --include="*.json" \
+          --exclude-dir=node_modules --exclude-dir=.git \
+          --exclude-dir=dist --exclude-dir=build \
+          --exclude-dir=coverage \
+          ${repoRoot}`,
+        { encoding: 'utf-8' },
+      );
+    } catch (err) {
+      // grep exits non-zero when no matches; that's a different failure
+      // (audit infrastructure broken, not a prefix mismatch).
+      if (err && err.status !== 1) throw err;
+      grepOut = (err && err.stdout) ?? '';
+    }
+
+    const lines = grepOut.split('\n').filter((l) => l.length > 0);
+    const offenders = [];
+    for (const line of lines) {
+      // Skip the test file itself — its grep regex literal would
+      // false-match. Identified by its filename rather than path so the
+      // exclusion stays robust across worktrees / CI checkout layouts.
+      if (line.includes('news-classify-cache-prefix-audit.test.mjs')) continue;
+      const m = line.match(/classify:sebuf:(v\d+)/);
+      if (!m) continue;
+      if (m[1] !== canonical) {
+        offenders.push(line);
+      }
+    }
+
+    assert.deepEqual(
+      offenders,
+      [],
+      `Found ${offenders.length} site(s) referencing a non-canonical ` +
+        `classify cache prefix (canonical = ${canonical}). All sites must ` +
+        `update in lockstep when bumping the prefix. Offenders:\n  ` +
+        offenders.join('\n  '),
+    );
+  });
+});

--- a/tests/news-classify-cache-tier-cap.test.mts
+++ b/tests/news-classify-cache-tier-cap.test.mts
@@ -2,9 +2,11 @@
 //
 // LLM classify-cache upgrade cap. Caps the cache-driven `level` upgrade at
 // +2 tiers above the keyword classification so a poisoned cache entry can't
-// promote info-keyword static-page titles past medium. Legitimate
-// keyword=low → LLM=critical upgrades (e.g., "Markets crash") remain
-// reachable because low+2 = critical.
+// promote info-keyword static-page titles past medium (info+2=medium).
+// Legitimate keyword=medium → LLM=critical upgrades (e.g., "Markets crash"
+// in MEDIUM_KEYWORDS) remain reachable because medium+2=critical. The
+// bounded loss is keyword=low → LLM=critical, which caps at high
+// (low+2=high) and is logged on every cap-fire.
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';

--- a/tests/news-classify-cache-tier-cap.test.mts
+++ b/tests/news-classify-cache-tier-cap.test.mts
@@ -1,0 +1,103 @@
+// U4 from docs/plans/2026-04-26-001-fix-brief-static-page-contamination-plan.md
+//
+// LLM classify-cache upgrade cap. Caps the cache-driven `level` upgrade at
+// +2 tiers above the keyword classification so a poisoned cache entry can't
+// promote info-keyword static-page titles past medium. Legitimate
+// keyword=low → LLM=critical upgrades (e.g., "Markets crash") remain
+// reachable because low+2 = critical.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { __testing__ } from '../server/worldmonitor/news/v1/list-feed-digest';
+
+const { capLlmUpgrade } = __testing__;
+
+describe('capLlmUpgrade — within cap (no change)', () => {
+  it('keyword=high + LLM=high → applies high (no cap fired)', () => {
+    assert.equal(capLlmUpgrade('high', 'high'), 'high');
+  });
+
+  it('keyword=medium + LLM=critical → applies critical (medium+2 = critical, allowed)', () => {
+    // Real-world case: keyword=medium covers "market crash", "sanctions",
+    // "earthquake" etc. (MEDIUM_KEYWORDS in _classifier.ts). LLM correctly
+    // upgrading these to critical after fuller context must survive.
+    assert.equal(capLlmUpgrade('medium', 'critical'), 'critical');
+  });
+
+  it('keyword=low + LLM=high → applies high (low+2 = high, within cap)', () => {
+    // Most legitimate keyword=low → LLM upgrade cases. low covers "election",
+    // "treaty", "summit", "agreement" — LLM picking up urgency context that
+    // promotes to high (e.g., "Treaty signed amid escalating tensions").
+    assert.equal(capLlmUpgrade('low', 'high'), 'high');
+  });
+});
+
+describe('capLlmUpgrade — cap fires on > +2 jumps', () => {
+  it('keyword=low + LLM=critical → caps at high (low+2 = high, NOT critical)', () => {
+    // Keyword=low → LLM=critical implies the keyword set is missing
+    // taxonomy terms; the cap forces that conversation rather than
+    // letting the cache silently paper over the gap. Loss is bounded
+    // because keyword=low is rare in practice (most upgrade-worthy
+    // headlines hit LOW_KEYWORDS only when the LLM has additional context
+    // the keyword set genuinely doesn't capture).
+    assert.equal(capLlmUpgrade('low', 'critical'), 'high');
+  });
+});
+
+describe('capLlmUpgrade — Pentagon static-page contamination case (cap fires)', () => {
+  it('keyword=info + LLM=critical → caps at medium (info+2 = medium)', () => {
+    // The exact failure shape that put "About Section 508" on the brief.
+    // Keyword classifier returns info (no-match fallback at confidence 0.3).
+    // Cache hit said critical or high. Cap forces medium.
+    assert.equal(capLlmUpgrade('info', 'critical'), 'medium');
+  });
+
+  it('keyword=info + LLM=high → caps at medium (info+2 = medium)', () => {
+    assert.equal(capLlmUpgrade('info', 'high'), 'medium');
+  });
+
+  it('keyword=info + LLM=medium → applies medium (within cap, no fire)', () => {
+    assert.equal(capLlmUpgrade('info', 'medium'), 'medium');
+  });
+
+  it('keyword=info + LLM=low → applies low (LLM downgrade preserved)', () => {
+    assert.equal(capLlmUpgrade('info', 'low'), 'low');
+  });
+
+  it('keyword=info + LLM=info → applies info (no change)', () => {
+    assert.equal(capLlmUpgrade('info', 'info'), 'info');
+  });
+});
+
+describe('capLlmUpgrade — keyword=critical edge case', () => {
+  it('keyword=critical + LLM=high → applies high (downgrade allowed; cap not relevant)', () => {
+    // The 0.9-confidence guard at line 480 of list-feed-digest.ts already
+    // skips the cache for keyword=critical (confidence=0.9), so this case
+    // doesn't fire in practice. Test exists to lock behavior if the guard
+    // is ever loosened.
+    assert.equal(capLlmUpgrade('critical', 'high'), 'high');
+  });
+
+  it('keyword=critical + LLM=critical → applies critical', () => {
+    assert.equal(capLlmUpgrade('critical', 'critical'), 'critical');
+  });
+});
+
+describe('capLlmUpgrade — defensive on malformed LLM levels', () => {
+  it('falls back to keyword level when LLM level is unknown string', () => {
+    // The cache's hit.level should always be one of the canonical 5, but
+    // defensive: an unrecognized value (older schema, fuzzed input)
+    // must not throw — falls back to the keyword level.
+    assert.equal(capLlmUpgrade('low', 'unknown'), 'low');
+  });
+
+  it('falls back to keyword level on empty string', () => {
+    assert.equal(capLlmUpgrade('medium', ''), 'medium');
+  });
+
+  it('falls back to keyword level on case-mismatched LLM value', () => {
+    // RANK_TO_LEVEL is lowercase canonical; the cache writer in classify-event
+    // also writes lowercase, so this is defense against a regression.
+    assert.equal(capLlmUpgrade('low', 'CRITICAL'), 'low');
+  });
+});

--- a/tests/url-classifier.test.mjs
+++ b/tests/url-classifier.test.mjs
@@ -31,6 +31,48 @@ describe('isInstitutionalStaticPage — known contamination cases (true)', () =>
     );
   });
 
+  it('Pentagon /About bare segment (no trailing slash) — segment-boundary rule', () => {
+    // P2 from PR #3419 review: under naive `startsWith('/About/')` this
+    // would have returned false, missing the canonical landing-page form.
+    // The pathMatchesPrefix segment rule treats '/About/' as a bucket
+    // and matches both '/about' and '/about/anything'.
+    assert.equal(
+      isInstitutionalStaticPage('https://www.defense.gov/About'),
+      true,
+    );
+  });
+
+  it('Air Force /Strategy bare segment (no trailing slash)', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.af.mil/Strategy'),
+      true,
+    );
+  });
+
+  it('State Dept /Policy bare segment (no trailing slash)', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.state.gov/Policy'),
+      true,
+    );
+  });
+
+  it('does NOT over-match /aboutface (segment boundary enforced)', () => {
+    // The segment rule rejects /aboutface even though /aboutface starts
+    // with /about. Without the boundary check, every path that happens
+    // to begin with the prefix letters would over-trigger.
+    assert.equal(
+      isInstitutionalStaticPage('https://www.defense.gov/aboutface'),
+      false,
+    );
+  });
+
+  it('does NOT over-match /strategist (segment boundary enforced)', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.af.mil/strategist'),
+      false,
+    );
+  });
+
   it('Section-508 page on a different .gov host', () => {
     assert.equal(
       isInstitutionalStaticPage('https://www.state.gov/Section-508/'),

--- a/tests/url-classifier.test.mjs
+++ b/tests/url-classifier.test.mjs
@@ -1,0 +1,174 @@
+// Pure-function tests for shared/url-classifier.js (U6).
+//
+// The classifier identifies static institutional landing pages on
+// .gov/.mil/.int domains so the brief-filter denylist (U7) can drop them
+// as a last line of defense, and the audit script (U6) can evict residual
+// poisoned story:track:v1 entries.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isInstitutionalStaticPage } from '../shared/url-classifier.js';
+
+describe('isInstitutionalStaticPage — known contamination cases (true)', () => {
+  it('Pentagon About/Section-508 (the original brief contamination)', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.defense.gov/About/Section-508/'),
+      true,
+    );
+  });
+
+  it('Pentagon Acquisition-Transformation-Strategy (no trailing slash)', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.defense.gov/Acquisition-Transformation-Strategy'),
+      true,
+    );
+  });
+
+  it('Pentagon About/ landing page', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.defense.gov/About/'),
+      true,
+    );
+  });
+
+  it('Section-508 page on a different .gov host', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.state.gov/Section-508/'),
+      true,
+    );
+  });
+
+  it('Strategy page on .mil', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.af.mil/Strategy/Some-Page/'),
+      true,
+    );
+  });
+
+  it('case-insensitive path matching', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.defense.gov/ABOUT/something'),
+      true,
+    );
+  });
+
+  it('case-insensitive host matching', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.DEFENSE.GOV/About/x'),
+      true,
+    );
+  });
+});
+
+describe('isInstitutionalStaticPage — legitimate news on institutional domains (false)', () => {
+  it('Pentagon news article under /News/Releases/', () => {
+    assert.equal(
+      isInstitutionalStaticPage(
+        'https://www.defense.gov/News/Releases/Release/Article/4123456/some-news/',
+      ),
+      false,
+    );
+  });
+
+  it('whitehouse.gov press release path', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.whitehouse.gov/briefing-room/press-briefings/'),
+      false,
+    );
+  });
+
+  it('state.gov news page', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.state.gov/press-release-2026/'),
+      false,
+    );
+  });
+});
+
+describe('isInstitutionalStaticPage — non-institutional hosts (false)', () => {
+  it('CBS News tornado article', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.cbsnews.com/news/tornadoes-midwest/'),
+      false,
+    );
+  });
+
+  it('.com host with About path (path matches but host does not)', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://example.com/About/team'),
+      false,
+    );
+  });
+
+  it('Google News redirect URL (has news.google.com host, not .gov)', () => {
+    assert.equal(
+      isInstitutionalStaticPage(
+        'https://news.google.com/articles/CBMiSWh0dHBzOi8v...',
+      ),
+      false,
+    );
+  });
+
+  it('.org host (not in institutional set)', () => {
+    assert.equal(
+      isInstitutionalStaticPage('https://www.aclu.org/About/'),
+      false,
+    );
+  });
+});
+
+describe('isInstitutionalStaticPage — defensive on bad input (false, no throw)', () => {
+  it('empty string', () => {
+    assert.equal(isInstitutionalStaticPage(''), false);
+  });
+
+  it('null', () => {
+    assert.equal(isInstitutionalStaticPage(null), false);
+  });
+
+  it('undefined', () => {
+    assert.equal(isInstitutionalStaticPage(undefined), false);
+  });
+
+  it('non-string (number)', () => {
+    assert.equal(isInstitutionalStaticPage(42), false);
+  });
+
+  it('malformed URL', () => {
+    assert.equal(isInstitutionalStaticPage('not a url'), false);
+  });
+
+  it('javascript: URL (non-http protocol)', () => {
+    assert.equal(
+      isInstitutionalStaticPage('javascript:alert(1)'),
+      false,
+    );
+  });
+
+  it('data: URL', () => {
+    assert.equal(
+      isInstitutionalStaticPage('data:text/html,<h1>hi</h1>'),
+      false,
+    );
+  });
+});
+
+describe('isInstitutionalStaticPage — edge cases', () => {
+  it('http (not https) institutional URL still classifies', () => {
+    // Some legacy government sites still serve http; don't lose the
+    // signal just because the protocol is unencrypted.
+    assert.equal(
+      isInstitutionalStaticPage('http://www.defense.gov/About/x'),
+      true,
+    );
+  });
+
+  it('institutional URL with no recognized path prefix passes through (false)', () => {
+    // Conservative-by-design: must match BOTH host AND path. A bare
+    // /News/ article on defense.gov is not flagged.
+    assert.equal(
+      isInstitutionalStaticPage('https://www.defense.gov/News/Article/123/'),
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Why this matters

Follow-up to #3417 (merged). Closes the remaining four units of `docs/plans/2026-04-26-001-fix-brief-static-page-contamination-plan.md`:

| Unit | What |
|---|---|
| U4 | LLM classify-cache `+2 tier` upgrade cap + atomic 3-site `v3 → v4` prefix bump |
| U5 | Brief composer source-topic cap (default 2 per source+category) |
| U6 | Shared URL classifier helper + ops audit script |
| U7 | Brief-filter URL/path denylist (last-line defense) |

User impact: even if a regression in the feed registry, RSS parser, or LLM cache lets a static page through, the brief surface stays clean. Plus the editorial-clutter case (CBS shipping both Midwest-tornado and Oklahoma-tornado in the same brief) is fixed via the source-topic cap.

## Commits

| SHA | Scope |
|---|---|
| `51dc927ee` | U4: LLM cache `+2` tier cap + atomic 3-site prefix bump (`_shared.ts`, `list-feed-digest.ts`, `ais-relay.cjs`) + 16 new tests |
| `c3a8b6392` | U5+U6+U7: brief-filter source-topic cap + URL denylist + shared URL classifier (with `scripts/shared/` mirror) + ops audit script + test updates |

## Notable design choices

- **U4 cap is `+2 tiers`, not `+1`.** Initial draft was `+1` but reviewer flagged that as too aggressive — `keyword=medium + LLM=critical` (real "Markets crash"-style upgrades) would have regressed. `+2` blocks the contamination class (`info → high/critical` capped at medium) while preserving `medium → critical` and `low → high`. The tradeoff (`low → critical` capped at `high`) is logged on every cap-fire so the loss is measurable, not silent.
- **U4 imports the shared key helper.** `list-feed-digest.ts` no longer has its own `classify:sebuf:v3:` literal — it uses `buildClassifyCacheKey` from `_shared.ts`. Future bumps only require touching `_shared.ts` + the relay's `.cjs` (which can't import from `.ts`). Static-analysis test grep-asserts zero non-canonical literals across `.ts/.mjs/.cjs/.js/.json`.
- **U5 cap default is 2.** Existing tests using identical fixtures opt out via `maxPerSourceTopic: Infinity` since their intent is unrelated (severity gate, max-stories cap, ranking). Production callers (`composeBriefFromDigestStories`) get the default-2 behavior automatically.
- **U6 URL classifier is conservative-by-design.** Must match BOTH a `.gov`/`.mil`/`.int` host AND a curated path prefix. A bare `.gov` URL or a bare `/About/` path on a `.com` doesn't trigger.
- **U6 audit script ships in this PR but `--apply` runs post-deploy.** Script lands here so reviewers can validate the classifier matches expectations; actual `--apply` deletion happens as a one-shot ops invocation after deploy + 48h soak.
- **U7 lives at the brief layer, not ingest.** Ingest has wider blast radius (email, Slack, push). Putting the URL denylist in `filterTopStories` isolates the brief-surface fix from those side-effect channels.

## Tests

| File | Cases | Locks down |
|---|---|---|
| `tests/news-classify-cache-tier-cap.test.mts` | 13 | Cap math: within-cap, contamination case (`info → high`/`critical` clamps to `medium`), legitimate upgrades preserved, malformed LLM levels, `keyword=critical` edge |
| `tests/news-classify-cache-prefix-audit.test.mjs` | 2 | Static-analysis grep-assert across all 5 file extensions |
| `tests/url-classifier.test.mjs` | 24 | Known contamination URLs classify true; legitimate `/News/` paths on same hosts classify false; non-institutional hosts classify false; defensive on bad input |
| `tests/brief-filter.test.mjs` (+9) | 9 new | U5 within/over cap, source/category isolation, ranked-order survival, fallbacks, U7 institutional-static-page drop, `maxPerSourceTopic` override |
| `tests/edge-functions.test.mjs` (+1) | 1 entry added | `url-classifier.js` now in explicit-mirrored-files set |
| `tests/brief-from-digest-stories.test.mjs` (3 fixture updates) | unchanged | Vary sources so U5 cap doesn't dominate tests of other behaviors |

**278/278 tests pass** across the touched + parity-coupled surface (rebased onto current `main`). `tests/importance-score-parity.test.mjs` continues to pass — formula untouched.

## Operational notes

**Rollback:**
- U4's cap can be reverted by changing `keywordRank + 2` → `keywordRank + 99` (no cap fires).
- U4's prefix can be reverted to v3 only AFTER the v4 cache TTL-expires (24h); otherwise both digest paths read poisoned entries again.
- U5's cap can be effectively disabled by passing `maxPerSourceTopic: Infinity` from `composeBriefFromDigestStories` (env wiring is a follow-up if needed).

**Cost-spike monitoring:**
- Classify cache cold-start after v4 bump. The digest only READS the cache; the WRITER is `classify-event.ts` (analyzer RPC) and `ais-relay.cjs`. Warm-up is driven by analyzer + relay traffic, not digest volume — practically slower than the 24h TTL implies. Acceptable: digest behavior degrades gracefully to keyword-only classification during the warm window (no LLM cost spike from the digest path itself).

**Deploy ordering:**
1. Merge this PR. Both Vercel (digest, brief) and Railway (relay) need to redeploy — the relay's `.cjs` change won't take effect until the relay container restarts.
2. Verify in Railway logs: `classify:sebuf:v4:` appears in cache key lines (proves the relay picked up the bump).
3. Run U6 audit dry-run: `node scripts/audit-static-page-contamination.mjs`. Capture the output in this PR thread.
4. After 48h of clean cron: `node scripts/audit-static-page-contamination.mjs --apply` to evict residual contamination. Document remaining count.

## Test plan

- [ ] CI green (typecheck, lint, all suites)
- [ ] After Vercel + Railway deploys: `[classify] LLM upgrade capped:` log lines appear ONLY for keyword=info upgrades (not legitimate medium→critical cases)
- [ ] After deploys: `classify:sebuf:v4:` keys present in Upstash; v3 keys still present but TTL-expiring
- [ ] U6 audit dry-run output captured in this PR's review thread before `--apply` is run
- [ ] 48h post-deploy: re-run U6 audit; matched count should be near-zero (upstream gates working)
- [ ] Random spot-check on 5 user briefs: no `defense.gov/About/`, `defense.gov/Strategy/`, etc. URLs; no >2-story bursts from same `(source, category)` pair