### PR TITLE
fix(fatf-listing): broaden CMS-class discriminator + decompress wayback bodies

### DIFF
--- a/scripts/seed-fatf-listing.mjs
+++ b/scripts/seed-fatf-listing.mjs
@@ -16,6 +16,7 @@
 // of publication). Cache TTL 90d so a transient parse failure doesn't
 // drop the full listing.
 
+import { gunzipSync, inflateSync, brotliDecompressSync } from 'node:zlib';
 import { loadEnvFile, CHROME_UA, runSeed, resolveProxyForConnect, httpsProxyFetchRaw, describeErr } from './_seed-utils.mjs';
 import countryNames from './shared/country-names.json' with { type: 'json' };
 
@@ -133,6 +134,46 @@ export async function fetchViaWayback(url, opts = {}) {
   return await fetchWaybackText(snapshotUrl, timestamp, { fetchFn, proxyFetcher, proxyAuth });
 }
 
+// Wayback's `id_` modifier returns the captured response body BYTE-FOR-BYTE
+// from the original origin. When that origin sent `Content-Encoding: gzip`
+// (FATF AEM does, behind Cloudflare), the captured bytes are gzip-encoded.
+//
+// Native `fetch` auto-decompresses based on the response `Content-Encoding`
+// header, so the direct path is fine. Our CONNECT proxy path
+// (`httpsProxyFetchRaw`) returns raw bytes from the tunnel and does NOT
+// auto-decompress. Calling `.toString('utf8')` on gzipped bytes yields
+// binary garbage that the regex parser pattern-matches as ~100 false-
+// positive country candidates, tripping the sanity-check gate.
+//
+// This helper sniffs the standard magic bytes and decompresses when needed.
+// Safe to call on already-decompressed bodies — they'll fall through to the
+// utf8 cast.
+//
+// Magic bytes:
+//   gzip:    1f 8b
+//   zlib:    78 (followed by 01 / 9c / da)
+//   brotli:  no magic bytes; only attempted as last resort if upstream
+//            advertises `br` and the gzip/deflate paths failed.
+export function decodeMaybeCompressed(buffer, contentEncoding) {
+  if (!Buffer.isBuffer(buffer)) buffer = Buffer.from(buffer);
+  // Gzip magic: 1f 8b
+  if (buffer.length >= 2 && buffer[0] === 0x1f && buffer[1] === 0x8b) {
+    return gunzipSync(buffer).toString('utf8');
+  }
+  // Zlib/deflate magic: 78 01, 78 9c, 78 da
+  if (buffer.length >= 2 && buffer[0] === 0x78 && (buffer[1] === 0x01 || buffer[1] === 0x9c || buffer[1] === 0xda)) {
+    return inflateSync(buffer).toString('utf8');
+  }
+  // Brotli has no magic bytes — only try it if explicitly advertised AND
+  // the body is clearly not utf8 text. We treat ASCII-printable starts
+  // (`<`, `{`, `[`, `"`, whitespace) as already-decoded text.
+  if (contentEncoding === 'br' && buffer.length > 0 && buffer[0] >= 0x80) {
+    try { return brotliDecompressSync(buffer).toString('utf8'); }
+    catch { /* fall through to utf8 cast */ }
+  }
+  return buffer.toString('utf8');
+}
+
 async function fetchWaybackJson(cdxUrl, { fetchFn, proxyFetcher, proxyAuth }) {
   let directErr;
   try {
@@ -141,7 +182,12 @@ async function fetchWaybackJson(cdxUrl, { fetchFn, proxyFetcher, proxyAuth }) {
       signal: AbortSignal.timeout(WAYBACK_TIMEOUT_MS),
     });
     if (!cdxResp.ok) throw new Error(`Wayback CDX HTTP ${cdxResp.status}`);
-    return await cdxResp.json();
+    // Defensive decompression: if Wayback omits Content-Encoding on this
+    // route, Node's fetch won't auto-inflate. Use raw bytes + magic-byte
+    // detection. If the body is already-decoded (the common case), the
+    // helper falls through to a plain utf8 cast.
+    const buf = Buffer.from(await cdxResp.arrayBuffer());
+    return JSON.parse(decodeMaybeCompressed(buf, cdxResp.headers.get?.('content-encoding')));
   } catch (err) {
     directErr = err;
   }
@@ -152,11 +198,11 @@ async function fetchWaybackJson(cdxUrl, { fetchFn, proxyFetcher, proxyAuth }) {
     // Note: httpsProxyFetchRaw injects User-Agent: CHROME_UA internally
     // (see scripts/_seed-utils.mjs:httpsProxyFetchRaw) — we don't need to
     // pass headers here. AGENTS.md UA convention is satisfied on both legs.
-    const { buffer } = await proxyFetcher(cdxUrl, proxyAuth, {
+    const { buffer, headers } = await proxyFetcher(cdxUrl, proxyAuth, {
       accept: 'application/json',
       timeoutMs: WAYBACK_TIMEOUT_MS,
     });
-    return JSON.parse(buffer.toString('utf8'));
+    return JSON.parse(decodeMaybeCompressed(buffer, headers?.['content-encoding']));
   } catch (proxyErr) {
     throw new Error(`Wayback CDX direct=${describeErr(directErr)}; proxy=${describeErr(proxyErr)}`);
   }
@@ -170,7 +216,9 @@ async function fetchWaybackText(snapshotUrl, timestamp, { fetchFn, proxyFetcher,
       signal: AbortSignal.timeout(WAYBACK_TIMEOUT_MS),
     });
     if (!snapResp.ok) throw new Error(`Wayback snapshot ${timestamp} HTTP ${snapResp.status}`);
-    return await snapResp.text();
+    // Defensive decompression — see fetchWaybackJson for rationale.
+    const buf = Buffer.from(await snapResp.arrayBuffer());
+    return decodeMaybeCompressed(buf, snapResp.headers.get?.('content-encoding'));
   } catch (err) {
     directErr = err;
   }
@@ -181,11 +229,11 @@ async function fetchWaybackText(snapshotUrl, timestamp, { fetchFn, proxyFetcher,
     // Note: httpsProxyFetchRaw injects User-Agent: CHROME_UA internally
     // (see scripts/_seed-utils.mjs:httpsProxyFetchRaw) — UA is sent on
     // the proxy snapshot fetch even though it's not in the opts here.
-    const { buffer } = await proxyFetcher(snapshotUrl, proxyAuth, {
+    const { buffer, headers } = await proxyFetcher(snapshotUrl, proxyAuth, {
       accept: 'text/html',
       timeoutMs: WAYBACK_TIMEOUT_MS,
     });
-    return buffer.toString('utf8');
+    return decodeMaybeCompressed(buffer, headers?.['content-encoding']);
   } catch (proxyErr) {
     throw new Error(`Wayback snapshot ${timestamp} direct=${describeErr(directErr)}; proxy=${describeErr(proxyErr)}`);
   }
@@ -317,10 +365,14 @@ export function extractListedCountries(html, nameLookup) {
     const slug = m[2];
     const attrsAfter = m[3];
     const innerHtml = m[4];
-    // Skip FATF Member Countries nav anchors. They use the AEM list
-    // component which always tags the anchor with `cmp-list__item-link`.
-    // Real publication-body anchors are plain `<a href="...">`.
-    if (/cmp-list__item-link/.test(attrsBefore + attrsAfter)) continue;
+    // Skip ALL AEM CMS-component anchors (Member Countries side nav,
+    // top nav, breadcrumbs, footer, related-content boxes). FATF's
+    // publication body uses plain `<a href="...">name</a>`; every nav
+    // surface uses `class="cmp-..."`. The previous narrower filter
+    // (`cmp-list__item-link` only) missed snapshots where Wayback served
+    // a slightly different DOM that hit other nav classes — surfaced as
+    // 111 unmatched candidates in production 2026-04-25.
+    if (/\bcmp-/.test(attrsBefore + attrsAfter)) continue;
     // Strip HTML tags BEFORE decoding entities. If a malformed snapshot
     // contained `&lt;note&gt;` inside the anchor, decoding first would
     // produce `<note>` which stripHtml would then erase. Stripping first
@@ -383,6 +435,28 @@ export function extractPublicationDate(url, html) {
   return new Date().toISOString().slice(0, 10);
 }
 
+// On parser-sanity-check failure, surface enough about the HTML body that
+// ops can tell at a glance whether the fetch returned the real publication,
+// a Cloudflare challenge, a 404 redirect, or compressed bytes mistakenly
+// treated as utf8. Bounded to a few hundred chars so log lines stay
+// readable.
+function previewHtmlForDiagnostic(html) {
+  if (!html) return '<empty>';
+  const len = html.length;
+  const detailHrefs = (html.match(/\/en\/countries\/detail\//gi) || []).length;
+  const cmpListItem = (html.match(/cmp-list__item-link/g) || []).length;
+  // Detect leading control bytes / non-printable ASCII as a strong hint
+  // that the body is compressed/binary (gzip starts with 0x1f 0x8b, brotli
+  // is high-bit, etc.). Bypasses html.toString detection issues.
+  const head = html.slice(0, 32);
+  const printable = [...head].filter((c) => {
+    const code = c.charCodeAt(0);
+    return (code >= 0x20 && code < 0x7f) || code === 0x09 || code === 0x0a || code === 0x0d;
+  }).length;
+  const looksBinary = printable < 24;
+  return `len=${len} detailHrefs=${detailHrefs} cmpListItem=${cmpListItem} binaryHead=${looksBinary} firstChars=${JSON.stringify(html.slice(0, 120))}`;
+}
+
 export async function fetchFatfListings({
   fetchHtmlFn = fetchHtml,
 } = {}) {
@@ -421,6 +495,14 @@ export async function fetchFatfListings({
     console.warn(`[fatf-listing] ${unmatched.length} country-name candidates not found in shared/country-names.json: ${unmatched.join(', ')}. Extend the aliases map if any of these are real country names.`);
   }
   if (unmatched.length > 2) {
+    // Diagnostic preview: when this gate trips, ops needs to know whether
+    // the HTML actually arrived (real publication body), arrived garbled
+    // (binary / wrong page / Cloudflare challenge), or arrived empty.
+    // Without this preview the unmatched-text dump is ambiguous — we
+    // can't tell from logs whether to fix the parser or retry the fetch.
+    const blackPreview = previewHtmlForDiagnostic(blackHtml);
+    const greyPreview = previewHtmlForDiagnostic(greyHtml);
+    console.warn(`[fatf-listing] diagnostic: black=${blackPreview} grey=${greyPreview}`);
     const msg = `FATF parser found ${unmatched.length} unmatched country-name candidates (max 2 tolerated): ${unmatched.join(', ')}. Previous valid payload remains under cache TTL — extend shared/country-names.json or fix the parser before next plenary.`;
     console.warn(`[fatf-listing] parser sanity-check failed: ${msg}`);
     throw new Error(msg);

--- a/scripts/seed-fatf-listing.mjs
+++ b/scripts/seed-fatf-listing.mjs
@@ -444,7 +444,12 @@ function previewHtmlForDiagnostic(html) {
   if (!html) return '<empty>';
   const len = html.length;
   const detailHrefs = (html.match(/\/en\/countries\/detail\//gi) || []).length;
-  const cmpListItem = (html.match(/cmp-list__item-link/g) || []).length;
+  // Counts every `cmp-*` AEM class — must mirror the live discriminator
+  // in extractListedCountries (line ~323). The previous narrower count
+  // of `cmp-list__item-link` would report 0 even when the page was full
+  // of `cmp-navigation`/`cmp-breadcrumb`/etc. anchors that the new
+  // discriminator correctly filters, masking the exact diagnostic signal.
+  const cmpAnchors = (html.match(/\bcmp-/g) || []).length;
   // Detect leading control bytes / non-printable ASCII as a strong hint
   // that the body is compressed/binary (gzip starts with 0x1f 0x8b, brotli
   // is high-bit, etc.). Bypasses html.toString detection issues.
@@ -454,7 +459,7 @@ function previewHtmlForDiagnostic(html) {
     return (code >= 0x20 && code < 0x7f) || code === 0x09 || code === 0x0a || code === 0x0d;
   }).length;
   const looksBinary = printable < 24;
-  return `len=${len} detailHrefs=${detailHrefs} cmpListItem=${cmpListItem} binaryHead=${looksBinary} firstChars=${JSON.stringify(html.slice(0, 120))}`;
+  return `len=${len} detailHrefs=${detailHrefs} cmpAnchors=${cmpAnchors} binaryHead=${looksBinary} firstChars=${JSON.stringify(html.slice(0, 120))}`;
 }
 
 export async function fetchFatfListings({

--- a/tests/seed-fatf-listing.test.mjs
+++ b/tests/seed-fatf-listing.test.mjs
@@ -285,20 +285,31 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
   // is [urlkey, timestamp, original, mimetype, statuscode, digest, length].
   // Ordered timestamp-ascending — last row is most recent.
   function cdxResponse(...timestamps) {
+    const rows = [
+      ['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode', 'digest', 'length'],
+      ...timestamps.map((ts) => [
+        'org,fatf-gafi)/en/countries/black-and-grey-lists.html',
+        ts,
+        FATF_URL,
+        'text/html',
+        '200',
+        'DIGEST',
+        '18000',
+      ]),
+    ];
     return {
       ok: true,
-      json: async () => [
-        ['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode', 'digest', 'length'],
-        ...timestamps.map((ts) => [
-          'org,fatf-gafi)/en/countries/black-and-grey-lists.html',
-          ts,
-          FATF_URL,
-          'text/html',
-          '200',
-          'DIGEST',
-          '18000',
-        ]),
-      ],
+      headers: new Map(),
+      arrayBuffer: async () => Buffer.from(JSON.stringify(rows)),
+    };
+  }
+  // Snapshot mock helper. Tests previously used `{ ok: true, text: async () => '...' }`
+  // before the seeder switched to raw `arrayBuffer()` + magic-byte gzip detection.
+  function snapshotResponse(html) {
+    return {
+      ok: true,
+      headers: new Map(),
+      arrayBuffer: async () => Buffer.from(html, 'utf8'),
     };
   }
 
@@ -311,7 +322,7 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
       }
       // Snapshot fetch — must use the LATEST timestamp + id_ modifier
       assert.match(url, /web\/20260403144947id_\//, 'must request the latest CDX timestamp with id_ modifier');
-      return { ok: true, text: async () => '<html><body><h2>Black & grey lists</h2></body></html>' };
+      return snapshotResponse('<html><body><h2>Black & grey lists</h2></body></html>');
     };
     const html = await fetchViaWayback(FATF_URL, { fetchFn });
     assert.match(html, /Black & grey lists/);
@@ -325,7 +336,7 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
         cdxUrl = url;
         return cdxResponse('20260403144947');
       }
-      return { ok: true, text: async () => '<html></html>' };
+      return snapshotResponse('<html></html>');
     };
     await fetchViaWayback(FATF_URL, { fetchFn, lookbackDays: 90 });
     assert.match(cdxUrl, /filter=statuscode%3A200|filter=statuscode:200/, 'CDX query must filter to status 200');
@@ -345,7 +356,11 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
     const fetchFn = async (url) => {
       if (url.startsWith('https://web.archive.org/cdx/')) {
         // Only the header row, no actual snapshots.
-        return { ok: true, json: async () => [['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode', 'digest', 'length']] };
+        return {
+          ok: true,
+          headers: new Map(),
+          arrayBuffer: async () => Buffer.from(JSON.stringify([['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode', 'digest', 'length']])),
+        };
       }
       throw new Error('snapshot fetch should not be reached when CDX is empty');
     };
@@ -384,10 +399,11 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
       if (url.startsWith('https://web.archive.org/cdx/')) {
         return {
           ok: true,
-          json: async () => [
+          headers: new Map(),
+          arrayBuffer: async () => Buffer.from(JSON.stringify([
             ['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode', 'digest', 'length'],
             ['org,fatf-gafi)/x', 'NOT-A-TIMESTAMP', FATF_URL, 'text/html', '200', 'D', '1'],
-          ],
+          ])),
         };
       }
       throw new Error('snapshot fetch should not run with malformed timestamp');
@@ -410,7 +426,7 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
       if (url.startsWith('https://web.archive.org/cdx/')) {
         return cdxResponse('20260403144947');
       }
-      return { ok: true, text: async () => '<html></html>' };
+      return snapshotResponse('<html></html>');
     };
     await fetchViaWayback(FATF_URL, { fetchFn });
     assert.equal(seenHeaders.length, 2, 'expected one CDX + one snapshot fetch');
@@ -516,6 +532,43 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
     );
   });
 
+  it('PROXY path: decompresses gzip-encoded snapshot bodies (Wayback `id_` returns FATF-origin gzipped bytes when CONNECT-proxy strips Content-Encoding header)', async () => {
+    // Production observation 2026-04-25 (run 1777155637881-7uafzc):
+    // FATF AEM origin gzips its HTML responses. Wayback's `id_` modifier
+    // preserves the byte-identical capture INCLUDING the gzipped body.
+    // The CONNECT-tunnel proxy code in scripts/_proxy-utils.cjs reads
+    // `Content-Encoding` to decide whether to inflate, but Wayback's
+    // re-served headers don't always include `content-encoding: gzip`
+    // (intermediate Cloudflare/CDN strips it on some routes). When that
+    // header is missing, raw gzip bytes were being treated as utf8 text,
+    // surfacing ~111 false-positive country candidates from chance
+    // ASCII patterns inside the compressed stream.
+    //
+    // Fix: detect gzip magic bytes (1f 8b) on the response body and
+    // decompress unconditionally on the proxy path.
+    const { gzipSync } = await import('node:zlib');
+    const realHtml = '<a href="/en/countries/detail/iran.html">Iran</a><a href="/en/countries/detail/Myanmar.html">Myanmar</a>';
+    const gzippedBody = gzipSync(Buffer.from(realHtml, 'utf8'));
+    const fetchFn = async () => { throw new Error('direct disabled to force proxy'); };
+    const proxyFetcher = async (url) => {
+      if (url.startsWith('https://web.archive.org/cdx/')) {
+        return { buffer: Buffer.from(JSON.stringify([
+          ['urlkey', 'timestamp', 'original', 'mimetype', 'statuscode', 'digest', 'length'],
+          ['org,fatf-gafi)/x', '20260403144947', FATF_URL, 'text/html', '200', 'D', '1'],
+        ])) };
+      }
+      // Snapshot returned with gzipped body and NO content-encoding header
+      // (the missing-header case that broke production).
+      return { buffer: gzippedBody, headers: {} };
+    };
+    const html = await fetchViaWayback(FATF_URL, {
+      fetchFn,
+      proxyFetcher,
+      proxyAuth: 'test:test@proxy.example:7000',
+    });
+    assert.equal(html, realHtml, 'gzip body must be decompressed before being returned as text');
+  });
+
   it('uses id_ modifier (NOT the bare /web/timestamp/url path) — keeps the parser DOM byte-for-byte identical to direct FATF', async () => {
     // Without `id_`, Wayback prepends a ~3KB toolbar banner and rewrites
     // every href/src to /web/.../ paths. Both would break the existing
@@ -527,7 +580,7 @@ describe('fetchViaWayback — Cloudflare-bypass via Wayback Machine', () => {
         return cdxResponse('20260403144947');
       }
       snapshotUrl = url;
-      return { ok: true, text: async () => '<html></html>' };
+      return snapshotResponse('<html></html>');
     };
     await fetchViaWayback(FATF_URL, { fetchFn });
     assert.match(snapshotUrl, /\/web\/\d{14}id_\//, 'snapshot URL MUST use the id_ modifier');


### PR DESCRIPTION
## Summary

Production seeder hit 111 unmatched-country-name candidates after PR #3416 merged (run `1777155637881-7uafzc`, 2026-04-25T22:20). The previous narrow `cmp-list__item-link` discriminator missed AEM nav surfaces that Wayback's `id_` modifier occasionally exposes; the proxy fallback path didn't magic-byte-detect gzip when Wayback strips `Content-Encoding`.

- **Broader CMS discriminator**: `\bcmp-` catches every AEM nav component (Member Countries side nav, top nav, breadcrumbs, footer, related-content boxes), not just `cmp-list__item-link`. Plain `<a href>` publication-body anchors still pass through.
- **Defensive decompression**: `fetchWayback{Json,Text}` now magic-byte-detect gzip (1f 8b) and zlib (78 01/9c/da) on the response body; already-decoded bodies fall through unchanged. Both direct + proxy paths.
- **Diagnostic preview on parse failure**: when the unmatched-candidates gate trips, log length, detail-href count, cmp-class count, binary-head heuristic, and first 120 chars of body. Without this preview, the unmatched-text dump alone couldn't distinguish "wrong page" from "binary body" from "real HTML with new FATF spellings."

## Test plan

- [x] 33/33 existing tests pass
- [x] New regression test: `PROXY path: decompresses gzip-encoded snapshot bodies (Wayback id_ returns FATF-origin gzipped bytes when CONNECT-proxy strips Content-Encoding header)`
- [x] End-to-end against three real Wayback snapshots (entry-page, blacklist, greylist): `[IR,KP,MM]` + 22 grey ISOs + zero unmatched on all three
- [ ] Production canary: next FATF cron tick (hourly) parses without 111-unmatched failure