### PR TITLE
fix(brief-ingest): READ-time freshness + direct-RSS migration + U6 age mode

### DIFF
--- a/scripts/audit-static-page-contamination.mjs
+++ b/scripts/audit-static-page-contamination.mjs
@@ -19,16 +19,20 @@
 //
 //   --mode=residue : match rows where track.publishedAt is missing/unparseable
 //                    AND track.lastSeen is older than --residue-min-stale-hours
-//                    (default 24). The lastSeen guard is the safety constraint:
-//                    a row that was re-mentioned recently MUST have publishedAt
-//                    (this PR's HSET always writes it), so a row missing the
-//                    field BUT with fresh lastSeen is anomalous and NOT touched.
-//                    Only rows that are both missing publishedAt AND haven't
-//                    been touched in N hours are treated as residue. This
-//                    prevents deleting legitimate recent stories that simply
-//                    didn't re-surface in the first post-deploy cron cycle.
-//                    Operator runbook: wait ≥24h post-deploy, then run with
-//                    default --residue-min-stale-hours=24.
+//                    (default 192 = 7d + 24h buffer = the maximum supported
+//                    digest window per digest-orchestration-helpers.mjs's
+//                    weekly-user readTimeAgeCutoffMs). The lastSeen guard is
+//                    the safety constraint: a row that was re-mentioned within
+//                    any user's digest window — including weekly users at 7d —
+//                    is still legitimately ship-able, so deleting it would
+//                    drop real stories from a user's brief. Only rows that
+//                    are both missing publishedAt AND haven't been touched
+//                    in N hours (default 8d) are treated as residue.
+//                    Operator runbook: wait ≥24h post-deploy (so still-active
+//                    rows have had publishedAt added via HSET re-mention),
+//                    then run with default --residue-min-stale-hours=192.
+//                    Operators with confidence the fleet is daily-only can
+//                    drop to --residue-min-stale-hours=48 for faster cleanup.
 //
 //   --mode=both    : run url + age. Does NOT include residue (use --mode=residue
 //                    explicitly so the operator opts into the destructive scan).
@@ -52,7 +56,12 @@ import { getRedisCredentials } from './_seed-utils.mjs';
 const VALID_MODES = ['url', 'age', 'residue', 'both'];
 
 export function parseArgs(argv) {
-  const args = { mode: 'url', maxAgeHours: 48, residueMinStaleHours: 24, apply: false };
+  // Default residueMinStaleHours = 192h = 7d + 24h buffer. Aligns with
+  // the maximum supported digest window (weekly users) so residue mode
+  // can never delete a row still legitimately ship-able for ANY user.
+  // See P2 review on PR #3422 — earlier 24h default would have deleted
+  // weekly users' 5d-old stories.
+  const args = { mode: 'url', maxAgeHours: 48, residueMinStaleHours: 192, apply: false };
   const unknown = [];
   for (const arg of argv) {
     if (arg === '--apply') args.apply = true;
@@ -238,16 +247,19 @@ export function classifyTrack(track, { mode, maxAgeMs, nowMs, residueMinStaleMs 
     // SAFETY-CRITICAL: residue is the only mode that deletes by absence-of-
     // evidence (no publishedAt) rather than evidence-of-staleness. Without
     // a guard, this would delete EVERY pre-PR-3422 row including legitimate
-    // recent stories that happen not to have been re-mentioned yet.
+    // weekly-user stories whose 5-7-day-old lastSeen is still well within
+    // their digest window.
     //
     // Two conditions required:
     //   1. publishedAt is missing/unparseable (legacy row, never had the
     //      field, OR future write race that left the field empty).
-    //   2. lastSeen is older than residueMinStaleMs (default 24h). Active
-    //      stories get HSET-touched on every re-mention; if a row hasn't
-    //      been touched in 24h it's not actively in any feed's results,
-    //      meaning the new ingest gate (when:1d) is correctly excluding
-    //      it. Safe to evict.
+    //   2. lastSeen is older than residueMinStaleMs (default 192h = 7d
+    //      buffer = max supported digest window). Aligns with the
+    //      readTimeAgeCutoffMs formula in digest-orchestration-helpers.mjs
+    //      so residue mode can never delete a row that's still
+    //      legitimately ship-able for ANY user (daily, twice-daily,
+    //      weekly). Active stories get HSET-touched on every re-mention,
+    //      so a row not touched in 8 days is unambiguously abandoned.
     //
     // Defensive fall-throughs: if lastSeen is missing/unparseable, treat
     // the row as if it were touched at epoch (i.e., consider it stale).
@@ -257,7 +269,8 @@ export function classifyTrack(track, { mode, maxAgeMs, nowMs, residueMinStaleMs 
     const pubMs = Number.parseInt(track?.publishedAt ?? '', 10);
     if (Number.isInteger(pubMs) && pubMs > 0) return reasons; // has publishedAt → not residue
 
-    const minStaleMs = residueMinStaleMs ?? 24 * 60 * 60 * 1000;
+    const DEFAULT_RESIDUE_MIN_STALE_MS = 192 * 60 * 60 * 1000; // 8d
+    const minStaleMs = residueMinStaleMs ?? DEFAULT_RESIDUE_MIN_STALE_MS;
     const lastSeenMs = Number.parseInt(track?.lastSeen ?? '', 10);
     const lastSeenAge = Number.isInteger(lastSeenMs) && lastSeenMs > 0
       ? nowMs - lastSeenMs

--- a/scripts/audit-static-page-contamination.mjs
+++ b/scripts/audit-static-page-contamination.mjs
@@ -1,26 +1,61 @@
 #!/usr/bin/env node
-// Ops audit + cleanup for residual static-institutional-page contamination
-// in story:track:v1:* (U6 of docs/plans/2026-04-26-001-fix-brief-static-
-// page-contamination-plan.md).
+// Ops audit + cleanup for residual contamination in story:track:v1:* and the
+// digest accumulator (U6 of docs/plans/2026-04-26-001-fix-brief-static-page-
+// contamination-plan.md).
+//
+// Two cleanup modes:
+//
+//   --mode=url    (default): match by institutional-static-page URL pattern.
+//                            Catches direct-RSS pre-ingest entries where
+//                            track.link is a real defense.gov / .mil / .int
+//                            URL.
+//
+//   --mode=age    : match by track.publishedAt being older than --max-age-hours
+//                   (default 48). Catches Google-News-routed entries whose
+//                   `link` is an opaque news.google.com redirect (so the URL
+//                   classifier can't see the destination), AND any other
+//                   stale residue regardless of source. This is the primary
+//                   eviction mode after ingest-gate tightening (PR #3417's
+//                   when:1d), where pre-deploy ingests carry real but stale
+//                   publishedAt timestamps.
+//
+//   --mode=both   : run both classifiers and union the matches.
 //
 // Usage:
-//   node scripts/audit-static-page-contamination.mjs           # dry run, prints stats
-//   node scripts/audit-static-page-contamination.mjs --apply   # also DELs matched keys
-//
-// Run AFTER PR-1 (ingest gates) and PR-2 (LLM cache prefix bump) reach
-// production. The dry-run output drives whether U7's URL-classifier
-// regex needs widening (separate follow-up PR) and confirms the upstream
-// gates are catching new arrivals (matched count should fall over time).
+//   node scripts/audit-static-page-contamination.mjs                       # dry run, URL mode
+//   node scripts/audit-static-page-contamination.mjs --mode=age            # dry run, age mode (48h)
+//   node scripts/audit-static-page-contamination.mjs --mode=age --max-age-hours=24
+//   node scripts/audit-static-page-contamination.mjs --mode=both --apply   # delete by either signal
 //
 // Pure-helper coverage lives in tests/url-classifier.test.mjs. The Redis
 // scan is mechanical and exercised by manual dry runs — there is no unit
-// test for the side-effecting --apply path (would require a Redis
-// double; out of scope for this one-shot script).
+// test for the side-effecting --apply path (would require a Redis double;
+// out of scope for this one-shot script).
 
 import { isInstitutionalStaticPage } from './shared/url-classifier.js';
 import { getRedisCredentials } from './_seed-utils.mjs';
 
-const APPLY = process.argv.includes('--apply');
+function parseArgs(argv) {
+  const args = { mode: 'url', maxAgeHours: 48, apply: false };
+  for (const arg of argv) {
+    if (arg === '--apply') args.apply = true;
+    else if (arg.startsWith('--mode=')) args.mode = arg.slice('--mode='.length);
+    else if (arg.startsWith('--max-age-hours=')) {
+      const n = Number.parseInt(arg.slice('--max-age-hours='.length), 10);
+      if (Number.isInteger(n) && n > 0) args.maxAgeHours = n;
+    }
+  }
+  if (!['url', 'age', 'both'].includes(args.mode)) {
+    console.error(`Unknown --mode=${args.mode}; expected url|age|both`);
+    process.exit(2);
+  }
+  return args;
+}
+
+const ARGS = parseArgs(process.argv.slice(2));
+const APPLY = ARGS.apply;
+const MODE = ARGS.mode;
+const MAX_AGE_MS = ARGS.maxAgeHours * 60 * 60 * 1000;
 const SCAN_PATTERN = 'story:track:v1:*';
 const SCAN_BATCH = 100;
 const SCAN_TIMEOUT_MS = 15_000;
@@ -143,11 +178,33 @@ function summarizePerHostPath(matches) {
   return { byHost: fmt(hostCounts), byPathPattern: fmt(pathPatternCounts) };
 }
 
+function classifyTrack(track, nowMs) {
+  const reasons = [];
+  const link = typeof track.link === 'string' ? track.link : '';
+
+  if ((MODE === 'url' || MODE === 'both') && link && isInstitutionalStaticPage(link)) {
+    reasons.push('url');
+  }
+
+  if (MODE === 'age' || MODE === 'both') {
+    const pubMs = Number.parseInt(track.publishedAt ?? '', 10);
+    if (Number.isInteger(pubMs) && pubMs > 0 && nowMs - pubMs > MAX_AGE_MS) {
+      reasons.push('age');
+    }
+  }
+
+  return reasons;
+}
+
 async function main() {
   const { url, token } = getRedisCredentials();
-  console.log(`[audit] mode=${APPLY ? 'APPLY (will DELETE)' : 'DRY RUN'}`);
+  console.log(
+    `[audit] mode=${MODE} ${APPLY ? 'APPLY (will DELETE)' : 'DRY RUN'}` +
+      (MODE === 'age' || MODE === 'both' ? ` max-age-hours=${ARGS.maxAgeHours}` : ''),
+  );
   console.log(`[audit] scanning ${SCAN_PATTERN}…`);
 
+  const nowMs = Date.now();
   const matches = [];
   let scanned = 0;
 
@@ -160,17 +217,21 @@ async function main() {
         const key = slice[j];
         const t = tracks[j];
         if (!t || typeof t !== 'object') continue;
-        const link = t.link;
-        if (typeof link !== 'string' || link.length === 0) continue;
-        if (isInstitutionalStaticPage(link)) {
-          matches.push({
-            key,
-            link,
-            severity: t.severity ?? '?',
-            source: t.source ?? '?',
-            title: (t.title ?? '').slice(0, 80),
-          });
-        }
+        const reasons = classifyTrack(t, nowMs);
+        if (reasons.length === 0) continue;
+        const pubMs = Number.parseInt(t.publishedAt ?? '', 10);
+        const ageH = Number.isInteger(pubMs) && pubMs > 0
+          ? Math.round((nowMs - pubMs) / (60 * 60 * 1000))
+          : null;
+        matches.push({
+          key,
+          link: t.link ?? '',
+          severity: t.severity ?? '?',
+          source: t.source ?? '?',
+          title: (t.title ?? '').slice(0, 80),
+          reasons,
+          ageH,
+        });
       }
     }
     process.stderr.write(`\r[audit] scanned=${scanned} matched=${matches.length}`);
@@ -185,17 +246,34 @@ async function main() {
   console.log('');
   console.log(`[audit] matched ${matches.length} contaminated story:track:v1 entries:`);
   for (const m of matches) {
+    const reasons = m.reasons.join(',');
+    const ageStr = m.ageH != null ? ` age=${m.ageH}h` : '';
     console.log(
-      `  [${m.key}] severity=${m.severity} source="${m.source}" url=${m.link}`,
+      `  [${m.key}] reasons=${reasons}${ageStr} severity=${m.severity} source="${m.source}" url=${m.link}`,
     );
   }
 
   console.log('');
-  const summary = summarizePerHostPath(matches);
-  console.log('[audit] by host:');
-  for (const [host, n] of summary.byHost) console.log(`  ${host.padEnd(40)} ${n}`);
-  console.log('[audit] by path pattern:');
-  for (const [pattern, n] of summary.byPathPattern) console.log(`  ${pattern.padEnd(40)} ${n}`);
+  // Per-reason rollup so operators can tell URL hits from age hits at a glance.
+  const reasonCounts = new Map();
+  for (const m of matches) {
+    for (const r of m.reasons) reasonCounts.set(r, (reasonCounts.get(r) ?? 0) + 1);
+  }
+  console.log('[audit] by reason:');
+  for (const [r, n] of reasonCounts) console.log(`  ${r.padEnd(8)} ${n}`);
+
+  // Host/path rollup is only meaningful for matches with a parseable URL.
+  // Age-only matches with Google News redirect URLs would clutter it
+  // (every entry maps to news.google.com), so skip when MODE === 'age'.
+  if (MODE !== 'age') {
+    const summary = summarizePerHostPath(matches.filter((m) => m.reasons.includes('url')));
+    if (summary.byHost.length > 0) {
+      console.log('[audit] by host (url-mode matches only):');
+      for (const [host, n] of summary.byHost) console.log(`  ${host.padEnd(40)} ${n}`);
+      console.log('[audit] by path pattern (url-mode matches only):');
+      for (const [pattern, n] of summary.byPathPattern) console.log(`  ${pattern.padEnd(40)} ${n}`);
+    }
+  }
 
   if (!APPLY) {
     console.log('');

--- a/scripts/audit-static-page-contamination.mjs
+++ b/scripts/audit-static-page-contamination.mjs
@@ -3,29 +3,40 @@
 // digest accumulator (U6 of docs/plans/2026-04-26-001-fix-brief-static-page-
 // contamination-plan.md).
 //
-// Two cleanup modes:
+// Cleanup modes:
 //
-//   --mode=url    (default): match by institutional-static-page URL pattern.
-//                            Catches direct-RSS pre-ingest entries where
-//                            track.link is a real defense.gov / .mil / .int
-//                            URL.
+//   --mode=url     (default): match by institutional-static-page URL pattern.
+//                             Catches direct-RSS pre-ingest entries where
+//                             track.link is a real defense.gov / .mil / .int
+//                             URL.
 //
-//   --mode=age    : match by track.publishedAt being older than --max-age-hours
-//                   (default 48). Catches Google-News-routed entries whose
-//                   `link` is an opaque news.google.com redirect (so the URL
-//                   classifier can't see the destination), AND any other
-//                   stale residue regardless of source. This is the primary
-//                   eviction mode after ingest-gate tightening (PR #3417's
-//                   when:1d), where pre-deploy ingests carry real but stale
-//                   publishedAt timestamps.
+//   --mode=age     : match by track.publishedAt being older than --max-age-hours
+//                    (default 48). Catches entries with a parseable publishedAt
+//                    that's stale — works for Google-News-routed entries (whose
+//                    track.link is an opaque news.google.com redirect) AND any
+//                    other source where the publisher's pubDate is honest.
+//                    REQUIRES rows to have publishedAt persisted (PR #3422+).
 //
-//   --mode=both   : run both classifiers and union the matches.
+//   --mode=residue : match rows where track.publishedAt is missing/unparseable.
+//                    This is the one-shot eviction mode for the immediate
+//                    PR-3422 deploy: pre-PR-3422 ingests never persisted
+//                    publishedAt, so neither --mode=age NOR the read-time
+//                    freshness floor can see them. Run AFTER waiting ≥1 cron
+//                    cycle so still-active stories have been re-mentioned and
+//                    had publishedAt added via HSET. Anything still missing
+//                    the field at that point is residue that won't be re-
+//                    mentioned (typically because the new ingest gate now
+//                    filters it out).
+//
+//   --mode=both    : run url + age. Does NOT include residue (use --mode=residue
+//                    explicitly so the operator opts into the destructive scan).
 //
 // Usage:
-//   node scripts/audit-static-page-contamination.mjs                       # dry run, URL mode
-//   node scripts/audit-static-page-contamination.mjs --mode=age            # dry run, age mode (48h)
+//   node scripts/audit-static-page-contamination.mjs                          # dry run, URL mode
+//   node scripts/audit-static-page-contamination.mjs --mode=age               # dry run, age mode (48h)
 //   node scripts/audit-static-page-contamination.mjs --mode=age --max-age-hours=24
-//   node scripts/audit-static-page-contamination.mjs --mode=both --apply   # delete by either signal
+//   node scripts/audit-static-page-contamination.mjs --mode=residue --apply   # one-shot post-PR-3422 cleanup
+//   node scripts/audit-static-page-contamination.mjs --mode=both --apply      # delete by URL OR age signal
 //
 // Pure-helper coverage lives in tests/url-classifier.test.mjs. The Redis
 // scan is mechanical and exercised by manual dry runs — there is no unit
@@ -35,27 +46,38 @@
 import { isInstitutionalStaticPage } from './shared/url-classifier.js';
 import { getRedisCredentials } from './_seed-utils.mjs';
 
-function parseArgs(argv) {
+const VALID_MODES = ['url', 'age', 'residue', 'both'];
+
+export function parseArgs(argv) {
   const args = { mode: 'url', maxAgeHours: 48, apply: false };
+  const unknown = [];
   for (const arg of argv) {
     if (arg === '--apply') args.apply = true;
     else if (arg.startsWith('--mode=')) args.mode = arg.slice('--mode='.length);
     else if (arg.startsWith('--max-age-hours=')) {
       const n = Number.parseInt(arg.slice('--max-age-hours='.length), 10);
       if (Number.isInteger(n) && n > 0) args.maxAgeHours = n;
+    } else {
+      // Catch typos like `--mode age` (space instead of equals) or
+      // misspelled flags before they silently use the default mode.
+      unknown.push(arg);
     }
   }
-  if (!['url', 'age', 'both'].includes(args.mode)) {
-    console.error(`Unknown --mode=${args.mode}; expected url|age|both`);
+  if (unknown.length > 0) {
+    console.error(`Unknown args: ${unknown.join(' ')}`);
+    console.error(`Expected: --mode=${VALID_MODES.join('|')} [--max-age-hours=N] [--apply]`);
+    process.exit(2);
+  }
+  if (!VALID_MODES.includes(args.mode)) {
+    console.error(`Unknown --mode=${args.mode}; expected ${VALID_MODES.join('|')}`);
     process.exit(2);
   }
   return args;
 }
 
-const ARGS = parseArgs(process.argv.slice(2));
-const APPLY = ARGS.apply;
-const MODE = ARGS.mode;
-const MAX_AGE_MS = ARGS.maxAgeHours * 60 * 60 * 1000;
+// Argv-derived state (APPLY, MODE, MAX_AGE_MS) is resolved inside main()
+// instead of at module load so unit tests can `import` this file
+// without parseArgs running against the test-runner's argv.
 const SCAN_PATTERN = 'story:track:v1:*';
 const SCAN_BATCH = 100;
 const SCAN_TIMEOUT_MS = 15_000;
@@ -178,18 +200,39 @@ function summarizePerHostPath(matches) {
   return { byHost: fmt(hostCounts), byPathPattern: fmt(pathPatternCounts) };
 }
 
-function classifyTrack(track, nowMs) {
+/**
+ * Pure classifier — exported so tests can exercise the matrix without
+ * spinning up the script (which has top-level argv side effects).
+ *
+ * @param {Record<string, string>} track — flatArrayToObject of HGETALL result
+ * @param {{ mode: 'url'|'age'|'residue'|'both', maxAgeMs: number, nowMs: number }} opts
+ * @returns {string[]} reasons (subset of ['url', 'age', 'residue']) — empty = no match
+ */
+export function classifyTrack(track, { mode, maxAgeMs, nowMs }) {
   const reasons = [];
-  const link = typeof track.link === 'string' ? track.link : '';
+  const link = typeof track?.link === 'string' ? track.link : '';
 
-  if ((MODE === 'url' || MODE === 'both') && link && isInstitutionalStaticPage(link)) {
+  if ((mode === 'url' || mode === 'both') && link && isInstitutionalStaticPage(link)) {
     reasons.push('url');
   }
 
-  if (MODE === 'age' || MODE === 'both') {
-    const pubMs = Number.parseInt(track.publishedAt ?? '', 10);
-    if (Number.isInteger(pubMs) && pubMs > 0 && nowMs - pubMs > MAX_AGE_MS) {
+  if (mode === 'age' || mode === 'both') {
+    const pubMs = Number.parseInt(track?.publishedAt ?? '', 10);
+    if (Number.isInteger(pubMs) && pubMs > 0 && nowMs - pubMs > maxAgeMs) {
       reasons.push('age');
+    }
+  }
+
+  if (mode === 'residue') {
+    // Match rows where publishedAt is missing or unparseable. This is the
+    // one-shot post-deploy cleanup signal for ingests that pre-date the
+    // PR-3422 HSET write of publishedAt. NOT included in --mode=both
+    // because it deletes by absence-of-evidence, not evidence-of-staleness;
+    // the operator opts in explicitly after waiting ≥1 cron cycle so
+    // active stories have had publishedAt populated by re-mention.
+    const pubMs = Number.parseInt(track?.publishedAt ?? '', 10);
+    if (!Number.isInteger(pubMs) || pubMs <= 0) {
+      reasons.push('residue');
     }
   }
 
@@ -197,6 +240,11 @@ function classifyTrack(track, nowMs) {
 }
 
 async function main() {
+  const ARGS = parseArgs(process.argv.slice(2));
+  const APPLY = ARGS.apply;
+  const MODE = ARGS.mode;
+  const MAX_AGE_MS = ARGS.maxAgeHours * 60 * 60 * 1000;
+
   const { url, token } = getRedisCredentials();
   console.log(
     `[audit] mode=${MODE} ${APPLY ? 'APPLY (will DELETE)' : 'DRY RUN'}` +
@@ -217,7 +265,7 @@ async function main() {
         const key = slice[j];
         const t = tracks[j];
         if (!t || typeof t !== 'object') continue;
-        const reasons = classifyTrack(t, nowMs);
+        const reasons = classifyTrack(t, { mode: MODE, maxAgeMs: MAX_AGE_MS, nowMs });
         if (reasons.length === 0) continue;
         const pubMs = Number.parseInt(t.publishedAt ?? '', 10);
         const ageH = Number.isInteger(pubMs) && pubMs > 0
@@ -291,7 +339,17 @@ async function main() {
   console.log(`[audit] deleted ${matches.length} contaminated entries.`);
 }
 
-main().catch((err) => {
-  console.error('[audit] failed:', err);
-  process.exit(1);
-});
+// Only run main() when this file is invoked directly (not when imported
+// by a unit test). Standard ESM idiom: compare import.meta.url against
+// the resolved CLI entry-point.
+const isDirectInvocation =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  import.meta.url === `file://${process.argv[1]}`;
+
+if (isDirectInvocation) {
+  main().catch((err) => {
+    console.error('[audit] failed:', err);
+    process.exit(1);
+  });
+}

--- a/scripts/audit-static-page-contamination.mjs
+++ b/scripts/audit-static-page-contamination.mjs
@@ -17,16 +17,18 @@
 //                    other source where the publisher's pubDate is honest.
 //                    REQUIRES rows to have publishedAt persisted (PR #3422+).
 //
-//   --mode=residue : match rows where track.publishedAt is missing/unparseable.
-//                    This is the one-shot eviction mode for the immediate
-//                    PR-3422 deploy: pre-PR-3422 ingests never persisted
-//                    publishedAt, so neither --mode=age NOR the read-time
-//                    freshness floor can see them. Run AFTER waiting ≥1 cron
-//                    cycle so still-active stories have been re-mentioned and
-//                    had publishedAt added via HSET. Anything still missing
-//                    the field at that point is residue that won't be re-
-//                    mentioned (typically because the new ingest gate now
-//                    filters it out).
+//   --mode=residue : match rows where track.publishedAt is missing/unparseable
+//                    AND track.lastSeen is older than --residue-min-stale-hours
+//                    (default 24). The lastSeen guard is the safety constraint:
+//                    a row that was re-mentioned recently MUST have publishedAt
+//                    (this PR's HSET always writes it), so a row missing the
+//                    field BUT with fresh lastSeen is anomalous and NOT touched.
+//                    Only rows that are both missing publishedAt AND haven't
+//                    been touched in N hours are treated as residue. This
+//                    prevents deleting legitimate recent stories that simply
+//                    didn't re-surface in the first post-deploy cron cycle.
+//                    Operator runbook: wait ≥24h post-deploy, then run with
+//                    default --residue-min-stale-hours=24.
 //
 //   --mode=both    : run url + age. Does NOT include residue (use --mode=residue
 //                    explicitly so the operator opts into the destructive scan).
@@ -35,7 +37,8 @@
 //   node scripts/audit-static-page-contamination.mjs                          # dry run, URL mode
 //   node scripts/audit-static-page-contamination.mjs --mode=age               # dry run, age mode (48h)
 //   node scripts/audit-static-page-contamination.mjs --mode=age --max-age-hours=24
-//   node scripts/audit-static-page-contamination.mjs --mode=residue --apply   # one-shot post-PR-3422 cleanup
+//   node scripts/audit-static-page-contamination.mjs --mode=residue --apply              # one-shot, default 24h staleness gate
+//   node scripts/audit-static-page-contamination.mjs --mode=residue --residue-min-stale-hours=48 --apply
 //   node scripts/audit-static-page-contamination.mjs --mode=both --apply      # delete by URL OR age signal
 //
 // Pure-helper coverage lives in tests/url-classifier.test.mjs. The Redis
@@ -49,7 +52,7 @@ import { getRedisCredentials } from './_seed-utils.mjs';
 const VALID_MODES = ['url', 'age', 'residue', 'both'];
 
 export function parseArgs(argv) {
-  const args = { mode: 'url', maxAgeHours: 48, apply: false };
+  const args = { mode: 'url', maxAgeHours: 48, residueMinStaleHours: 24, apply: false };
   const unknown = [];
   for (const arg of argv) {
     if (arg === '--apply') args.apply = true;
@@ -57,6 +60,9 @@ export function parseArgs(argv) {
     else if (arg.startsWith('--max-age-hours=')) {
       const n = Number.parseInt(arg.slice('--max-age-hours='.length), 10);
       if (Number.isInteger(n) && n > 0) args.maxAgeHours = n;
+    } else if (arg.startsWith('--residue-min-stale-hours=')) {
+      const n = Number.parseInt(arg.slice('--residue-min-stale-hours='.length), 10);
+      if (Number.isInteger(n) && n > 0) args.residueMinStaleHours = n;
     } else {
       // Catch typos like `--mode age` (space instead of equals) or
       // misspelled flags before they silently use the default mode.
@@ -65,7 +71,7 @@ export function parseArgs(argv) {
   }
   if (unknown.length > 0) {
     console.error(`Unknown args: ${unknown.join(' ')}`);
-    console.error(`Expected: --mode=${VALID_MODES.join('|')} [--max-age-hours=N] [--apply]`);
+    console.error(`Expected: --mode=${VALID_MODES.join('|')} [--max-age-hours=N] [--residue-min-stale-hours=N] [--apply]`);
     process.exit(2);
   }
   if (!VALID_MODES.includes(args.mode)) {
@@ -205,10 +211,15 @@ function summarizePerHostPath(matches) {
  * spinning up the script (which has top-level argv side effects).
  *
  * @param {Record<string, string>} track — flatArrayToObject of HGETALL result
- * @param {{ mode: 'url'|'age'|'residue'|'both', maxAgeMs: number, nowMs: number }} opts
+ * @param {{
+ *   mode: 'url'|'age'|'residue'|'both',
+ *   maxAgeMs: number,
+ *   nowMs: number,
+ *   residueMinStaleMs?: number,
+ * }} opts
  * @returns {string[]} reasons (subset of ['url', 'age', 'residue']) — empty = no match
  */
-export function classifyTrack(track, { mode, maxAgeMs, nowMs }) {
+export function classifyTrack(track, { mode, maxAgeMs, nowMs, residueMinStaleMs }) {
   const reasons = [];
   const link = typeof track?.link === 'string' ? track.link : '';
 
@@ -224,14 +235,34 @@ export function classifyTrack(track, { mode, maxAgeMs, nowMs }) {
   }
 
   if (mode === 'residue') {
-    // Match rows where publishedAt is missing or unparseable. This is the
-    // one-shot post-deploy cleanup signal for ingests that pre-date the
-    // PR-3422 HSET write of publishedAt. NOT included in --mode=both
-    // because it deletes by absence-of-evidence, not evidence-of-staleness;
-    // the operator opts in explicitly after waiting ≥1 cron cycle so
-    // active stories have had publishedAt populated by re-mention.
+    // SAFETY-CRITICAL: residue is the only mode that deletes by absence-of-
+    // evidence (no publishedAt) rather than evidence-of-staleness. Without
+    // a guard, this would delete EVERY pre-PR-3422 row including legitimate
+    // recent stories that happen not to have been re-mentioned yet.
+    //
+    // Two conditions required:
+    //   1. publishedAt is missing/unparseable (legacy row, never had the
+    //      field, OR future write race that left the field empty).
+    //   2. lastSeen is older than residueMinStaleMs (default 24h). Active
+    //      stories get HSET-touched on every re-mention; if a row hasn't
+    //      been touched in 24h it's not actively in any feed's results,
+    //      meaning the new ingest gate (when:1d) is correctly excluding
+    //      it. Safe to evict.
+    //
+    // Defensive fall-throughs: if lastSeen is missing/unparseable, treat
+    // the row as if it were touched at epoch (i.e., consider it stale).
+    // That's the safer default for residue mode — we're already in an
+    // operator-opt-in destructive path; data without lastSeen is anomalous
+    // enough that erring toward "evict" is acceptable.
     const pubMs = Number.parseInt(track?.publishedAt ?? '', 10);
-    if (!Number.isInteger(pubMs) || pubMs <= 0) {
+    if (Number.isInteger(pubMs) && pubMs > 0) return reasons; // has publishedAt → not residue
+
+    const minStaleMs = residueMinStaleMs ?? 24 * 60 * 60 * 1000;
+    const lastSeenMs = Number.parseInt(track?.lastSeen ?? '', 10);
+    const lastSeenAge = Number.isInteger(lastSeenMs) && lastSeenMs > 0
+      ? nowMs - lastSeenMs
+      : Number.POSITIVE_INFINITY; // missing lastSeen → treat as ancient
+    if (lastSeenAge >= minStaleMs) {
       reasons.push('residue');
     }
   }
@@ -244,11 +275,17 @@ async function main() {
   const APPLY = ARGS.apply;
   const MODE = ARGS.mode;
   const MAX_AGE_MS = ARGS.maxAgeHours * 60 * 60 * 1000;
+  const RESIDUE_MIN_STALE_MS = ARGS.residueMinStaleHours * 60 * 60 * 1000;
 
   const { url, token } = getRedisCredentials();
+  const modeAnnotation =
+    MODE === 'age' || MODE === 'both'
+      ? ` max-age-hours=${ARGS.maxAgeHours}`
+      : MODE === 'residue'
+        ? ` residue-min-stale-hours=${ARGS.residueMinStaleHours}`
+        : '';
   console.log(
-    `[audit] mode=${MODE} ${APPLY ? 'APPLY (will DELETE)' : 'DRY RUN'}` +
-      (MODE === 'age' || MODE === 'both' ? ` max-age-hours=${ARGS.maxAgeHours}` : ''),
+    `[audit] mode=${MODE} ${APPLY ? 'APPLY (will DELETE)' : 'DRY RUN'}${modeAnnotation}`,
   );
   console.log(`[audit] scanning ${SCAN_PATTERN}…`);
 
@@ -265,7 +302,12 @@ async function main() {
         const key = slice[j];
         const t = tracks[j];
         if (!t || typeof t !== 'object') continue;
-        const reasons = classifyTrack(t, { mode: MODE, maxAgeMs: MAX_AGE_MS, nowMs });
+        const reasons = classifyTrack(t, {
+          mode: MODE,
+          maxAgeMs: MAX_AGE_MS,
+          nowMs,
+          residueMinStaleMs: RESIDUE_MIN_STALE_MS,
+        });
         if (reasons.length === 0) continue;
         const pubMs = Number.parseInt(t.publishedAt ?? '', 10);
         const ageH = Number.isInteger(pubMs) && pubMs > 0

--- a/scripts/lib/digest-orchestration-helpers.mjs
+++ b/scripts/lib/digest-orchestration-helpers.mjs
@@ -199,3 +199,51 @@ export async function runSynthesisWithFallback(userId, stories, sensitivity, ctx
   noteTrace(3, 'success');
   return { synthesis: null, level: 3 };
 }
+
+/**
+ * READ-time freshness predicate. Returns true if the story:track:v1 row
+ * should be dropped because its source `publishedAt` is older than the
+ * cutoff. Used by buildDigest to keep pre-deploy residue (whose ingest
+ * gate has since been tightened) from shipping in briefs.
+ *
+ * Behaviour matrix:
+ *   - publishedAt is a positive integer epoch-ms AND < cutoff → drop (true).
+ *   - publishedAt is a positive integer epoch-ms AND ≥ cutoff → keep (false).
+ *   - publishedAt is missing/unparseable/zero/negative → keep (false).
+ *
+ * The "missing → keep" branch is back-compat for legacy story:track:v1
+ * rows written before publishedAt was persisted. Pre-deploy residue
+ * with no publishedAt is NOT caught here — handle it via the audit
+ * script's `--mode=residue` (one-shot eviction). Once that has run AND
+ * ≥1 cron cycle has refreshed publishedAt on still-active rows, any
+ * row reaching this predicate without publishedAt is anomalous, not
+ * residue.
+ *
+ * See: skill ingest-gate-tightening-leaves-residue-in-read-path.
+ *
+ * @param {Record<string, string> | null | undefined} track
+ * @param {number} ageCutoffMs — drop rows with publishedAt strictly less than this
+ * @returns {boolean}
+ */
+export function shouldDropTrackByAge(track, ageCutoffMs) {
+  const pubMs = Number.parseInt(track?.publishedAt ?? '', 10);
+  if (!Number.isInteger(pubMs) || pubMs <= 0) return false;
+  return pubMs < ageCutoffMs;
+}
+
+/**
+ * Compute the READ-time freshness cutoff for a given digest window.
+ * Cutoff is anchored to `windowStartMs` (from `digestWindowStartMs`)
+ * minus a 24h buffer that accommodates sustained stories whose first
+ * mention sits just before the window edge.
+ *
+ * Daily user (24h window) → 48h-ago cutoff.
+ * Weekly user (7d window) → 8d-ago cutoff.
+ *
+ * @param {number} windowStartMs
+ * @returns {number}
+ */
+export function readTimeAgeCutoffMs(windowStartMs) {
+  const STALE_BUFFER_MS = 24 * 60 * 60 * 1000;
+  return windowStartMs - STALE_BUFFER_MS;
+}

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -453,12 +453,40 @@ async function buildDigest(rule, windowStartMs) {
     hashes.map((h) => ['HGETALL', `story:track:v1:${h}`]),
   );
 
+  // READ-time freshness floor: drop story:track:v1 rows whose source
+  // publishedAt is older than DIGEST_READ_MAX_AGE_HOURS (default 48h).
+  // This complements PR #3417's INGEST-time floor by closing the residue
+  // window: when an ingest-side gate is tightened (e.g. when:1d added to a
+  // gn() query), pre-deploy entries persist in the accumulator + track
+  // table until natural TTL drainage. Without this READ-time check, those
+  // residual entries continue to ship in briefs even though their source
+  // pubDate is months old. See:
+  //   skill: ingest-gate-tightening-leaves-residue-in-read-path
+  // Set DIGEST_READ_MAX_AGE_HOURS=999 to disable (operator kill switch).
+  const readMaxAgeHoursRaw = Number.parseInt(process.env.DIGEST_READ_MAX_AGE_HOURS ?? '', 10);
+  const readMaxAgeHours = Number.isInteger(readMaxAgeHoursRaw) && readMaxAgeHoursRaw > 0
+    ? readMaxAgeHoursRaw
+    : 48;
+  const readMaxAgeMs = readMaxAgeHours * 60 * 60 * 1000;
+  const nowMs = Date.now();
+
   const stories = [];
+  let droppedStaleAtRead = 0;
   for (let i = 0; i < hashes.length; i++) {
     const raw = trackResults[i]?.result;
     if (!Array.isArray(raw) || raw.length === 0) continue;
     const track = flatArrayToObject(raw);
     if (!track.title || !track.severity) continue;
+
+    // Source publishedAt freshness check. Track rows missing publishedAt
+    // (legacy entries from before the field was persisted) are NOT dropped
+    // here — fall through to the existing gates so the change is back-
+    // compat for any pre-existing rows without the field.
+    const pubMs = Number.parseInt(track.publishedAt ?? '', 10);
+    if (Number.isInteger(pubMs) && pubMs > 0 && nowMs - pubMs > readMaxAgeMs) {
+      droppedStaleAtRead++;
+      continue;
+    }
 
     const phase = derivePhase(track);
     if (phase === 'fading') continue;
@@ -478,6 +506,13 @@ async function buildDigest(rule, windowStartMs) {
       // description. Downstream adapter falls back to the cleaned headline.
       description: typeof track.description === 'string' ? track.description : '',
     });
+  }
+
+  if (droppedStaleAtRead > 0) {
+    console.warn(
+      `[digest] buildDigest read-time freshness floor dropped ${droppedStaleAtRead} ` +
+        `stale items (max age: ${readMaxAgeHours}h) — likely pre-deploy residue`,
+    );
   }
 
   if (stories.length === 0) return null;

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -41,7 +41,9 @@ import {
 import {
   digestWindowStartMs,
   pickWinningCandidateWithPool,
+  readTimeAgeCutoffMs,
   runSynthesisWithFallback,
+  shouldDropTrackByAge,
   subjectForBrief,
 } from './lib/digest-orchestration-helpers.mjs';
 import { injectEmailSummary } from './lib/email-summary-html.mjs';
@@ -453,22 +455,13 @@ async function buildDigest(rule, windowStartMs) {
     hashes.map((h) => ['HGETALL', `story:track:v1:${h}`]),
   );
 
-  // READ-time freshness floor: drop story:track:v1 rows whose source
-  // publishedAt is older than DIGEST_READ_MAX_AGE_HOURS (default 48h).
-  // This complements PR #3417's INGEST-time floor by closing the residue
-  // window: when an ingest-side gate is tightened (e.g. when:1d added to a
-  // gn() query), pre-deploy entries persist in the accumulator + track
-  // table until natural TTL drainage. Without this READ-time check, those
-  // residual entries continue to ship in briefs even though their source
-  // pubDate is months old. See:
-  //   skill: ingest-gate-tightening-leaves-residue-in-read-path
-  // Set DIGEST_READ_MAX_AGE_HOURS=999 to disable (operator kill switch).
-  const readMaxAgeHoursRaw = Number.parseInt(process.env.DIGEST_READ_MAX_AGE_HOURS ?? '', 10);
-  const readMaxAgeHours = Number.isInteger(readMaxAgeHoursRaw) && readMaxAgeHoursRaw > 0
-    ? readMaxAgeHoursRaw
-    : 48;
-  const readMaxAgeMs = readMaxAgeHours * 60 * 60 * 1000;
-  const nowMs = Date.now();
+  // READ-time freshness cutoff is anchored to the rule's own digest
+  // window. Daily user (24h window) → 48h cutoff; weekly user (7d
+  // window) → 8d cutoff. See: skill ingest-gate-tightening-leaves-
+  // residue-in-read-path. Legacy rows without publishedAt fall through
+  // (back-compat); pre-deploy residue with no publishedAt is handled
+  // by audit --mode=residue (one-shot).
+  const ageCutoffMs = readTimeAgeCutoffMs(windowStartMs);
 
   const stories = [];
   let droppedStaleAtRead = 0;
@@ -478,12 +471,7 @@ async function buildDigest(rule, windowStartMs) {
     const track = flatArrayToObject(raw);
     if (!track.title || !track.severity) continue;
 
-    // Source publishedAt freshness check. Track rows missing publishedAt
-    // (legacy entries from before the field was persisted) are NOT dropped
-    // here — fall through to the existing gates so the change is back-
-    // compat for any pre-existing rows without the field.
-    const pubMs = Number.parseInt(track.publishedAt ?? '', 10);
-    if (Number.isInteger(pubMs) && pubMs > 0 && nowMs - pubMs > readMaxAgeMs) {
+    if (shouldDropTrackByAge(track, ageCutoffMs)) {
       droppedStaleAtRead++;
       continue;
     }
@@ -509,9 +497,10 @@ async function buildDigest(rule, windowStartMs) {
   }
 
   if (droppedStaleAtRead > 0) {
+    const cutoffH = Math.round((Date.now() - ageCutoffMs) / (60 * 60 * 1000));
     console.warn(
       `[digest] buildDigest read-time freshness floor dropped ${droppedStaleAtRead} ` +
-        `stale items (max age: ${readMaxAgeHours}h) — likely pre-deploy residue`,
+        `stale items (window cutoff: ${cutoffH}h ago) — likely pre-deploy residue`,
     );
   }
 

--- a/scripts/shared/source-tiers.json
+++ b/scripts/shared/source-tiers.json
@@ -7,6 +7,7 @@
   "AFP": 1,
   "Bloomberg": 1,
   "White House": 1,
+  "White House Actions": 1,
   "State Dept": 1,
   "Pentagon": 1,
   "UN News": 1,

--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -67,9 +67,27 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'Reuters Business', url: gn('site:reuters.com business markets when:1d') },
     ],
     gov: [
-      { name: 'White House', url: gn('site:whitehouse.gov when:1d') },
+      // White House: two direct WordPress RSS feeds. Replaces
+      // gn('site:whitehouse.gov ...') so the publisher's pubDate is
+      // authoritative and old re-indexed pages can't slip through.
+      // briefings-statements covers daily press releases; presidential-actions
+      // covers EOs / proclamations / nominations.
+      { name: 'White House', url: 'https://www.whitehouse.gov/briefings-statements/feed/' },
+      { name: 'White House Actions', url: 'https://www.whitehouse.gov/presidential-actions/feed/' },
+      // State Dept, Treasury, DOJ: no working public RSS feed at any
+      // verified path (probed 2026-04-26). Federal Register fallback is
+      // bot-blocked. Stuck on Google News until a per-agency HTML scraper
+      // or destination-pubDate cross-check ships. The READ-time freshness
+      // floor in seed-digest-notifications.mjs::buildDigest mitigates the
+      // residue gap; PR-3417's when:1d gates new ingests by Google's
+      // honest-relayed source pubDate. See:
+      //   skill: ingest-gate-tightening-leaves-residue-in-read-path
       { name: 'State Dept', url: gn('(site:state.gov OR "State Department") when:1d') },
-      { name: 'Pentagon', url: gn('(site:defense.gov OR Pentagon) when:1d') },
+      // Pentagon: direct war.gov RSS (post-rebrand). Replaces
+      // gn('(site:defense.gov OR Pentagon) when:1d') for the same reason
+      // as White House — the publisher's pubDate is authoritative, no
+      // re-indexing surprises.
+      { name: 'Pentagon', url: 'https://www.war.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=945' },
       { name: 'Federal Reserve', url: 'https://www.federalreserve.gov/feeds/press_all.xml' },
       { name: 'SEC', url: 'https://www.sec.gov/news/pressreleases.rss' },
       { name: 'UN News', url: 'https://news.un.org/feed/subscribe/en/news/all/rss.xml' },

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -709,7 +709,12 @@ function buildStoryTrackHsetFields(
     // age-mode — can drop residual stale entries that pre-date an
     // ingest-side gate tightening. See:
     //   skill: ingest-gate-tightening-leaves-residue-in-read-path.
-    'publishedAt', String(item.publishedAt),
+    // Defensive cast: write '' when publishedAt isn't a finite number so
+    // the field never holds the literal "undefined"/"NaN" string. Read-side
+    // parseInt('') yields NaN → falls through the missing-field branch
+    // (treats as legacy row) instead of being mis-classified as a stale
+    // row with a bogus timestamp.
+    'publishedAt', Number.isFinite(item.publishedAt) ? String(item.publishedAt) : '',
   ];
 }
 

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -703,6 +703,13 @@ function buildStoryTrackHsetFields(
     'severity', item.level,
     'lang', item.lang,
     'description', item.description ?? '',
+    // Source publishedAt (the article's actual publication time as parsed
+    // from the RSS pubDate or Dublin Core fallback). Persisted so READ-time
+    // consumers — buildDigest's freshness floor and the U6 audit's
+    // age-mode — can drop residual stale entries that pre-date an
+    // ingest-side gate tightening. See:
+    //   skill: ingest-gate-tightening-leaves-residue-in-read-path.
+    'publishedAt', String(item.publishedAt),
   ];
 }
 

--- a/shared/source-tiers.json
+++ b/shared/source-tiers.json
@@ -7,6 +7,7 @@
   "AFP": 1,
   "Bloomberg": 1,
   "White House": 1,
+  "White House Actions": 1,
   "State Dept": 1,
   "Pentagon": 1,
   "UN News": 1,

--- a/tests/audit-static-page-contamination.test.mjs
+++ b/tests/audit-static-page-contamination.test.mjs
@@ -1,0 +1,218 @@
+// Pure-function tests for the audit script's classifier + arg parser.
+// The Redis side (scanKeys, batchHgetAll, batchDel, main) is covered
+// only by manual dry-run invocation per the runbook in the script header.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyTrack,
+  parseArgs,
+} from '../scripts/audit-static-page-contamination.mjs';
+
+const HOUR = 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 3, 26, 8, 0, 0);
+
+describe('classifyTrack — url mode', () => {
+  it('matches institutional static page URL', () => {
+    const t = { link: 'https://www.defense.gov/About/Section-508/' };
+    const r = classifyTrack(t, { mode: 'url', maxAgeMs: 48 * HOUR, nowMs: NOW });
+    assert.deepEqual(r, ['url']);
+  });
+
+  it('does not match a real news article on the same host', () => {
+    const t = { link: 'https://www.defense.gov/News/Releases/Release/Article/4123456/x/' };
+    const r = classifyTrack(t, { mode: 'url', maxAgeMs: 48 * HOUR, nowMs: NOW });
+    assert.deepEqual(r, []);
+  });
+
+  it('does not match Google News redirect URLs (the structural blind spot)', () => {
+    const t = { link: 'https://news.google.com/rss/articles/CBMi.../?oc=5' };
+    const r = classifyTrack(t, { mode: 'url', maxAgeMs: 48 * HOUR, nowMs: NOW });
+    assert.deepEqual(r, []);
+  });
+
+  it('handles missing link defensively', () => {
+    const r = classifyTrack({}, { mode: 'url', maxAgeMs: 48 * HOUR, nowMs: NOW });
+    assert.deepEqual(r, []);
+  });
+});
+
+describe('classifyTrack — age mode', () => {
+  it('matches a row whose publishedAt is older than the cutoff', () => {
+    const t = { publishedAt: String(NOW - 60 * HOUR) }; // 60h old
+    const r = classifyTrack(t, { mode: 'age', maxAgeMs: 48 * HOUR, nowMs: NOW });
+    assert.deepEqual(r, ['age']);
+  });
+
+  it('does NOT match a fresh row', () => {
+    const t = { publishedAt: String(NOW - 12 * HOUR) }; // 12h old
+    const r = classifyTrack(t, { mode: 'age', maxAgeMs: 48 * HOUR, nowMs: NOW });
+    assert.deepEqual(r, []);
+  });
+
+  it('does NOT match rows missing publishedAt (legacy back-compat — use --mode=residue)', () => {
+    const t = { link: 'https://news.google.com/x' };
+    const r = classifyTrack(t, { mode: 'age', maxAgeMs: 48 * HOUR, nowMs: NOW });
+    assert.deepEqual(r, []);
+  });
+
+  it('does NOT match rows with unparseable publishedAt', () => {
+    const t = { publishedAt: 'undefined' };
+    const r = classifyTrack(t, { mode: 'age', maxAgeMs: 48 * HOUR, nowMs: NOW });
+    assert.deepEqual(r, []);
+  });
+});
+
+describe('classifyTrack — residue mode (the P1 reviewer fix)', () => {
+  it('matches rows missing publishedAt entirely (the actual pre-PR-3422 residue)', () => {
+    const t = { title: 'Stale Pentagon item', link: 'https://news.google.com/x' };
+    const r = classifyTrack(t, { mode: 'residue', maxAgeMs: 0, nowMs: NOW });
+    assert.deepEqual(r, ['residue']);
+  });
+
+  it('matches rows with empty-string publishedAt (defensive write)', () => {
+    const r = classifyTrack({ publishedAt: '' }, { mode: 'residue', maxAgeMs: 0, nowMs: NOW });
+    assert.deepEqual(r, ['residue']);
+  });
+
+  it('matches rows with literal "undefined"/"NaN" publishedAt', () => {
+    assert.deepEqual(
+      classifyTrack({ publishedAt: 'undefined' }, { mode: 'residue', maxAgeMs: 0, nowMs: NOW }),
+      ['residue'],
+    );
+    assert.deepEqual(
+      classifyTrack({ publishedAt: 'NaN' }, { mode: 'residue', maxAgeMs: 0, nowMs: NOW }),
+      ['residue'],
+    );
+  });
+
+  it('does NOT match rows with a parseable publishedAt (residue is absence-of-evidence)', () => {
+    const t = { publishedAt: String(NOW - 100 * 24 * HOUR) }; // 100 days old
+    const r = classifyTrack(t, { mode: 'residue', maxAgeMs: 0, nowMs: NOW });
+    assert.deepEqual(r, [], 'old-but-known should be caught by --mode=age, not --mode=residue');
+  });
+
+  it('does NOT include url match in residue mode (operator opts in explicitly)', () => {
+    const t = {
+      link: 'https://www.defense.gov/About/Section-508/',
+      // No publishedAt
+    };
+    const r = classifyTrack(t, { mode: 'residue', maxAgeMs: 0, nowMs: NOW });
+    // residue matches because publishedAt is missing; url is NOT additionally
+    // included because residue mode is single-classifier by design.
+    assert.deepEqual(r, ['residue']);
+  });
+});
+
+describe('classifyTrack — both mode (url ∪ age)', () => {
+  it('matches when both signals fire (institutional URL AND stale)', () => {
+    const t = {
+      link: 'https://www.defense.gov/About/Section-508/',
+      publishedAt: String(NOW - 60 * HOUR),
+    };
+    const r = classifyTrack(t, { mode: 'both', maxAgeMs: 48 * HOUR, nowMs: NOW });
+    assert.deepEqual(r.sort(), ['age', 'url']);
+  });
+
+  it('matches on URL alone when publishedAt is fresh', () => {
+    const t = {
+      link: 'https://www.defense.gov/About/Section-508/',
+      publishedAt: String(NOW - 1 * HOUR),
+    };
+    const r = classifyTrack(t, { mode: 'both', maxAgeMs: 48 * HOUR, nowMs: NOW });
+    assert.deepEqual(r, ['url']);
+  });
+
+  it('matches on age alone when URL is non-institutional', () => {
+    const t = {
+      link: 'https://news.google.com/x',
+      publishedAt: String(NOW - 60 * HOUR),
+    };
+    const r = classifyTrack(t, { mode: 'both', maxAgeMs: 48 * HOUR, nowMs: NOW });
+    assert.deepEqual(r, ['age']);
+  });
+
+  it('does NOT include residue (residue is opt-in via --mode=residue only)', () => {
+    const t = {
+      link: 'https://www.defense.gov/About/Section-508/',
+      // No publishedAt
+    };
+    const r = classifyTrack(t, { mode: 'both', maxAgeMs: 48 * HOUR, nowMs: NOW });
+    assert.deepEqual(r, ['url'], 'residue must NOT be included unless mode=residue');
+  });
+});
+
+describe('parseArgs — flag handling', () => {
+  it('defaults to mode=url, maxAgeHours=48, apply=false', () => {
+    const a = parseArgs([]);
+    assert.equal(a.mode, 'url');
+    assert.equal(a.maxAgeHours, 48);
+    assert.equal(a.apply, false);
+  });
+
+  it('--apply flips to true', () => {
+    assert.equal(parseArgs(['--apply']).apply, true);
+  });
+
+  it('--mode=age | --mode=both | --mode=residue all accepted', () => {
+    assert.equal(parseArgs(['--mode=age']).mode, 'age');
+    assert.equal(parseArgs(['--mode=both']).mode, 'both');
+    assert.equal(parseArgs(['--mode=residue']).mode, 'residue');
+  });
+
+  it('--max-age-hours=N accepts positive integer', () => {
+    assert.equal(parseArgs(['--max-age-hours=24']).maxAgeHours, 24);
+  });
+
+  it('--max-age-hours=foo silently ignores (default kept)', () => {
+    assert.equal(parseArgs(['--max-age-hours=foo']).maxAgeHours, 48);
+  });
+
+  it('--max-age-hours=0 ignored (positive-only)', () => {
+    assert.equal(parseArgs(['--max-age-hours=0']).maxAgeHours, 48);
+  });
+
+  it('rejects unknown args by exiting (the P3 footgun fix)', () => {
+    // parseArgs calls process.exit(2) on unknown args. Capture by spawning
+    // a subprocess instead of letting it kill the test process.
+    // Inline subprocess spawn via Node's worker_threads is overkill; a
+    // simpler way is to monkey-patch process.exit + console.error and
+    // restore. Keep the assertion shape simple: invocation throws via
+    // the patched exit.
+    const origExit = process.exit;
+    const origErr = console.error;
+    let exitCode = null;
+    let errMsg = '';
+    process.exit = ((code) => {
+      exitCode = code;
+      throw new Error('__patched_exit__');
+    });
+    console.error = (...args) => { errMsg += args.join(' ') + '\n'; };
+    try {
+      assert.throws(() => parseArgs(['--mode', 'age']), /__patched_exit__/);
+      assert.equal(exitCode, 2);
+      assert.match(errMsg, /Unknown args/);
+    } finally {
+      process.exit = origExit;
+      console.error = origErr;
+    }
+  });
+
+  it('rejects --mode=invalid (out-of-set value)', () => {
+    const origExit = process.exit;
+    const origErr = console.error;
+    let exitCode = null;
+    process.exit = ((code) => {
+      exitCode = code;
+      throw new Error('__patched_exit__');
+    });
+    console.error = () => {};
+    try {
+      assert.throws(() => parseArgs(['--mode=invalid']), /__patched_exit__/);
+      assert.equal(exitCode, 2);
+    } finally {
+      process.exit = origExit;
+      console.error = origErr;
+    }
+  });
+});

--- a/tests/audit-static-page-contamination.test.mjs
+++ b/tests/audit-static-page-contamination.test.mjs
@@ -63,43 +63,124 @@ describe('classifyTrack — age mode', () => {
   });
 });
 
-describe('classifyTrack — residue mode (the P1 reviewer fix)', () => {
-  it('matches rows missing publishedAt entirely (the actual pre-PR-3422 residue)', () => {
-    const t = { title: 'Stale Pentagon item', link: 'https://news.google.com/x' };
-    const r = classifyTrack(t, { mode: 'residue', maxAgeMs: 0, nowMs: NOW });
+describe('classifyTrack — residue mode (the P1 reviewer fix + safety guard)', () => {
+  // Default test setup: lastSeen 48h ago (well past the 24h default
+  // staleness gate), so missing publishedAt → residue.
+  const STALE_LAST_SEEN = String(NOW - 48 * HOUR);
+
+  it('matches rows missing publishedAt AND lastSeen older than min-stale (the actual residue)', () => {
+    const t = {
+      title: 'Stale Pentagon item',
+      link: 'https://news.google.com/x',
+      lastSeen: STALE_LAST_SEEN,
+    };
+    const r = classifyTrack(t, {
+      mode: 'residue',
+      maxAgeMs: 0,
+      nowMs: NOW,
+      residueMinStaleMs: 24 * HOUR,
+    });
     assert.deepEqual(r, ['residue']);
   });
 
-  it('matches rows with empty-string publishedAt (defensive write)', () => {
-    const r = classifyTrack({ publishedAt: '' }, { mode: 'residue', maxAgeMs: 0, nowMs: NOW });
+  it('SAFETY: does NOT match rows missing publishedAt if lastSeen is fresh (P2 reviewer fix)', () => {
+    // The reviewer-flagged risk: a legitimate recent story that just
+    // hasn't had publishedAt populated yet (write race, or first cron
+    // tick after deploy hasn't re-mentioned it but it WAS touched
+    // recently). Must NOT be deleted.
+    const t = {
+      title: 'Recent legitimate story',
+      lastSeen: String(NOW - 2 * HOUR), // 2h ago — well within fresh window
+    };
+    const r = classifyTrack(t, {
+      mode: 'residue',
+      maxAgeMs: 0,
+      nowMs: NOW,
+      residueMinStaleMs: 24 * HOUR,
+    });
+    assert.deepEqual(r, [], 'fresh lastSeen must protect the row');
+  });
+
+  it('boundary: lastSeen exactly at min-stale threshold matches (>= boundary)', () => {
+    const t = {
+      lastSeen: String(NOW - 24 * HOUR),
+    };
+    const r = classifyTrack(t, {
+      mode: 'residue',
+      maxAgeMs: 0,
+      nowMs: NOW,
+      residueMinStaleMs: 24 * HOUR,
+    });
     assert.deepEqual(r, ['residue']);
   });
 
-  it('matches rows with literal "undefined"/"NaN" publishedAt', () => {
-    assert.deepEqual(
-      classifyTrack({ publishedAt: 'undefined' }, { mode: 'residue', maxAgeMs: 0, nowMs: NOW }),
-      ['residue'],
+  it('boundary: lastSeen 1ms newer than threshold does NOT match', () => {
+    const t = {
+      lastSeen: String(NOW - 24 * HOUR + 1),
+    };
+    const r = classifyTrack(t, {
+      mode: 'residue',
+      maxAgeMs: 0,
+      nowMs: NOW,
+      residueMinStaleMs: 24 * HOUR,
+    });
+    assert.deepEqual(r, []);
+  });
+
+  it('matches rows with empty-string publishedAt + stale lastSeen', () => {
+    const r = classifyTrack(
+      { publishedAt: '', lastSeen: STALE_LAST_SEEN },
+      { mode: 'residue', maxAgeMs: 0, nowMs: NOW, residueMinStaleMs: 24 * HOUR },
     );
+    assert.deepEqual(r, ['residue']);
+  });
+
+  it('matches rows with literal "undefined"/"NaN" publishedAt + stale lastSeen', () => {
     assert.deepEqual(
-      classifyTrack({ publishedAt: 'NaN' }, { mode: 'residue', maxAgeMs: 0, nowMs: NOW }),
+      classifyTrack(
+        { publishedAt: 'undefined', lastSeen: STALE_LAST_SEEN },
+        { mode: 'residue', maxAgeMs: 0, nowMs: NOW, residueMinStaleMs: 24 * HOUR },
+      ),
       ['residue'],
     );
   });
 
   it('does NOT match rows with a parseable publishedAt (residue is absence-of-evidence)', () => {
-    const t = { publishedAt: String(NOW - 100 * 24 * HOUR) }; // 100 days old
-    const r = classifyTrack(t, { mode: 'residue', maxAgeMs: 0, nowMs: NOW });
+    const t = {
+      publishedAt: String(NOW - 100 * 24 * HOUR), // 100 days old
+      lastSeen: STALE_LAST_SEEN,
+    };
+    const r = classifyTrack(t, {
+      mode: 'residue',
+      maxAgeMs: 0,
+      nowMs: NOW,
+      residueMinStaleMs: 24 * HOUR,
+    });
     assert.deepEqual(r, [], 'old-but-known should be caught by --mode=age, not --mode=residue');
+  });
+
+  it('treats missing lastSeen as ancient (errs toward eviction in opt-in destructive mode)', () => {
+    const r = classifyTrack(
+      { title: 'Anomalous row, no lastSeen' },
+      { mode: 'residue', maxAgeMs: 0, nowMs: NOW, residueMinStaleMs: 24 * HOUR },
+    );
+    assert.deepEqual(r, ['residue']);
   });
 
   it('does NOT include url match in residue mode (operator opts in explicitly)', () => {
     const t = {
       link: 'https://www.defense.gov/About/Section-508/',
-      // No publishedAt
+      lastSeen: STALE_LAST_SEEN,
     };
-    const r = classifyTrack(t, { mode: 'residue', maxAgeMs: 0, nowMs: NOW });
-    // residue matches because publishedAt is missing; url is NOT additionally
-    // included because residue mode is single-classifier by design.
+    const r = classifyTrack(t, {
+      mode: 'residue',
+      maxAgeMs: 0,
+      nowMs: NOW,
+      residueMinStaleMs: 24 * HOUR,
+    });
+    // residue matches because publishedAt is missing AND lastSeen is stale;
+    // url is NOT additionally included because residue mode is
+    // single-classifier by design.
     assert.deepEqual(r, ['residue']);
   });
 });
@@ -143,11 +224,24 @@ describe('classifyTrack — both mode (url ∪ age)', () => {
 });
 
 describe('parseArgs — flag handling', () => {
-  it('defaults to mode=url, maxAgeHours=48, apply=false', () => {
+  it('defaults to mode=url, maxAgeHours=48, residueMinStaleHours=24, apply=false', () => {
     const a = parseArgs([]);
     assert.equal(a.mode, 'url');
     assert.equal(a.maxAgeHours, 48);
+    assert.equal(a.residueMinStaleHours, 24);
     assert.equal(a.apply, false);
+  });
+
+  it('--residue-min-stale-hours=N overrides default', () => {
+    assert.equal(parseArgs(['--residue-min-stale-hours=48']).residueMinStaleHours, 48);
+  });
+
+  it('--residue-min-stale-hours=foo silently ignores (default kept)', () => {
+    assert.equal(parseArgs(['--residue-min-stale-hours=foo']).residueMinStaleHours, 24);
+  });
+
+  it('--residue-min-stale-hours=0 ignored (positive-only)', () => {
+    assert.equal(parseArgs(['--residue-min-stale-hours=0']).residueMinStaleHours, 24);
   });
 
   it('--apply flips to true', () => {

--- a/tests/audit-static-page-contamination.test.mjs
+++ b/tests/audit-static-page-contamination.test.mjs
@@ -63,83 +63,109 @@ describe('classifyTrack — age mode', () => {
   });
 });
 
-describe('classifyTrack — residue mode (the P1 reviewer fix + safety guard)', () => {
-  // Default test setup: lastSeen 48h ago (well past the 24h default
-  // staleness gate), so missing publishedAt → residue.
-  const STALE_LAST_SEEN = String(NOW - 48 * HOUR);
+describe('classifyTrack — residue mode (P1 + weekly-user safety guard)', () => {
+  // Default residueMinStaleMs is 192h (8d = 7d max digest window + 24h
+  // buffer). Aligns with the readTimeAgeCutoffMs formula in
+  // digest-orchestration-helpers.mjs so residue mode never deletes a row
+  // still legitimately ship-able for ANY user (daily, twice-daily,
+  // weekly).
+  const RESIDUE_DEFAULT_MS = 192 * HOUR;
+  const ANCIENT_LAST_SEEN = String(NOW - 200 * HOUR); // 200h > 192h default
 
-  it('matches rows missing publishedAt AND lastSeen older than min-stale (the actual residue)', () => {
+  it('matches rows missing publishedAt AND lastSeen older than min-stale', () => {
     const t = {
       title: 'Stale Pentagon item',
       link: 'https://news.google.com/x',
-      lastSeen: STALE_LAST_SEEN,
+      lastSeen: ANCIENT_LAST_SEEN,
     };
     const r = classifyTrack(t, {
       mode: 'residue',
       maxAgeMs: 0,
       nowMs: NOW,
-      residueMinStaleMs: 24 * HOUR,
+      residueMinStaleMs: RESIDUE_DEFAULT_MS,
     });
     assert.deepEqual(r, ['residue']);
   });
 
-  it('SAFETY: does NOT match rows missing publishedAt if lastSeen is fresh (P2 reviewer fix)', () => {
-    // The reviewer-flagged risk: a legitimate recent story that just
-    // hasn't had publishedAt populated yet (write race, or first cron
-    // tick after deploy hasn't re-mentioned it but it WAS touched
-    // recently). Must NOT be deleted.
+  it('SAFETY: does NOT match weekly-user 5d-old story (P2 round-2 reviewer fix)', () => {
+    // The reviewer-flagged regression: a pre-PR-3422 row with no
+    // publishedAt but lastSeen 5 days ago is still legitimately
+    // ship-able for a weekly user (whose readTimeAgeCutoffMs is
+    // windowStart - 24h = 8d ago). Earlier 24h default would have
+    // deleted it. Default 192h aligns with weekly-user window and
+    // protects it.
     const t = {
-      title: 'Recent legitimate story',
-      lastSeen: String(NOW - 2 * HOUR), // 2h ago — well within fresh window
+      title: 'Weekly-user legitimate story',
+      lastSeen: String(NOW - 5 * 24 * HOUR), // 5d ago, within weekly window
     };
     const r = classifyTrack(t, {
       mode: 'residue',
       maxAgeMs: 0,
       nowMs: NOW,
-      residueMinStaleMs: 24 * HOUR,
+      residueMinStaleMs: RESIDUE_DEFAULT_MS,
+    });
+    assert.deepEqual(
+      r,
+      [],
+      '5d-old lastSeen must be PROTECTED — weekly users still need this row',
+    );
+  });
+
+  it('SAFETY: does NOT match recent (2h) lastSeen even when publishedAt is missing', () => {
+    // Original P2 review case: row touched recently, publishedAt missing
+    // due to write race. Must NOT be deleted.
+    const t = {
+      title: 'Just-touched row',
+      lastSeen: String(NOW - 2 * HOUR),
+    };
+    const r = classifyTrack(t, {
+      mode: 'residue',
+      maxAgeMs: 0,
+      nowMs: NOW,
+      residueMinStaleMs: RESIDUE_DEFAULT_MS,
     });
     assert.deepEqual(r, [], 'fresh lastSeen must protect the row');
   });
 
   it('boundary: lastSeen exactly at min-stale threshold matches (>= boundary)', () => {
     const t = {
-      lastSeen: String(NOW - 24 * HOUR),
+      lastSeen: String(NOW - RESIDUE_DEFAULT_MS),
     };
     const r = classifyTrack(t, {
       mode: 'residue',
       maxAgeMs: 0,
       nowMs: NOW,
-      residueMinStaleMs: 24 * HOUR,
+      residueMinStaleMs: RESIDUE_DEFAULT_MS,
     });
     assert.deepEqual(r, ['residue']);
   });
 
   it('boundary: lastSeen 1ms newer than threshold does NOT match', () => {
     const t = {
-      lastSeen: String(NOW - 24 * HOUR + 1),
+      lastSeen: String(NOW - RESIDUE_DEFAULT_MS + 1),
     };
     const r = classifyTrack(t, {
       mode: 'residue',
       maxAgeMs: 0,
       nowMs: NOW,
-      residueMinStaleMs: 24 * HOUR,
+      residueMinStaleMs: RESIDUE_DEFAULT_MS,
     });
     assert.deepEqual(r, []);
   });
 
-  it('matches rows with empty-string publishedAt + stale lastSeen', () => {
+  it('matches rows with empty-string publishedAt + ancient lastSeen', () => {
     const r = classifyTrack(
-      { publishedAt: '', lastSeen: STALE_LAST_SEEN },
-      { mode: 'residue', maxAgeMs: 0, nowMs: NOW, residueMinStaleMs: 24 * HOUR },
+      { publishedAt: '', lastSeen: ANCIENT_LAST_SEEN },
+      { mode: 'residue', maxAgeMs: 0, nowMs: NOW, residueMinStaleMs: RESIDUE_DEFAULT_MS },
     );
     assert.deepEqual(r, ['residue']);
   });
 
-  it('matches rows with literal "undefined"/"NaN" publishedAt + stale lastSeen', () => {
+  it('matches rows with literal "undefined"/"NaN" publishedAt + ancient lastSeen', () => {
     assert.deepEqual(
       classifyTrack(
-        { publishedAt: 'undefined', lastSeen: STALE_LAST_SEEN },
-        { mode: 'residue', maxAgeMs: 0, nowMs: NOW, residueMinStaleMs: 24 * HOUR },
+        { publishedAt: 'undefined', lastSeen: ANCIENT_LAST_SEEN },
+        { mode: 'residue', maxAgeMs: 0, nowMs: NOW, residueMinStaleMs: RESIDUE_DEFAULT_MS },
       ),
       ['residue'],
     );
@@ -148,13 +174,13 @@ describe('classifyTrack — residue mode (the P1 reviewer fix + safety guard)', 
   it('does NOT match rows with a parseable publishedAt (residue is absence-of-evidence)', () => {
     const t = {
       publishedAt: String(NOW - 100 * 24 * HOUR), // 100 days old
-      lastSeen: STALE_LAST_SEEN,
+      lastSeen: ANCIENT_LAST_SEEN,
     };
     const r = classifyTrack(t, {
       mode: 'residue',
       maxAgeMs: 0,
       nowMs: NOW,
-      residueMinStaleMs: 24 * HOUR,
+      residueMinStaleMs: RESIDUE_DEFAULT_MS,
     });
     assert.deepEqual(r, [], 'old-but-known should be caught by --mode=age, not --mode=residue');
   });
@@ -162,7 +188,7 @@ describe('classifyTrack — residue mode (the P1 reviewer fix + safety guard)', 
   it('treats missing lastSeen as ancient (errs toward eviction in opt-in destructive mode)', () => {
     const r = classifyTrack(
       { title: 'Anomalous row, no lastSeen' },
-      { mode: 'residue', maxAgeMs: 0, nowMs: NOW, residueMinStaleMs: 24 * HOUR },
+      { mode: 'residue', maxAgeMs: 0, nowMs: NOW, residueMinStaleMs: RESIDUE_DEFAULT_MS },
     );
     assert.deepEqual(r, ['residue']);
   });
@@ -170,17 +196,30 @@ describe('classifyTrack — residue mode (the P1 reviewer fix + safety guard)', 
   it('does NOT include url match in residue mode (operator opts in explicitly)', () => {
     const t = {
       link: 'https://www.defense.gov/About/Section-508/',
-      lastSeen: STALE_LAST_SEEN,
+      lastSeen: ANCIENT_LAST_SEEN,
     };
     const r = classifyTrack(t, {
       mode: 'residue',
       maxAgeMs: 0,
       nowMs: NOW,
-      residueMinStaleMs: 24 * HOUR,
+      residueMinStaleMs: RESIDUE_DEFAULT_MS,
     });
-    // residue matches because publishedAt is missing AND lastSeen is stale;
-    // url is NOT additionally included because residue mode is
-    // single-classifier by design.
+    assert.deepEqual(r, ['residue']);
+  });
+
+  it('operator can override to 48h for daily-only fleet (--residue-min-stale-hours=48)', () => {
+    // Documented escape hatch in the script header: operators with
+    // confidence the fleet is daily-only can drop to 48h for faster
+    // cleanup. Verify the override works.
+    const t = {
+      lastSeen: String(NOW - 60 * HOUR), // 60h — past 48h, within 192h default
+    };
+    const r = classifyTrack(t, {
+      mode: 'residue',
+      maxAgeMs: 0,
+      nowMs: NOW,
+      residueMinStaleMs: 48 * HOUR,
+    });
     assert.deepEqual(r, ['residue']);
   });
 });
@@ -224,24 +263,28 @@ describe('classifyTrack — both mode (url ∪ age)', () => {
 });
 
 describe('parseArgs — flag handling', () => {
-  it('defaults to mode=url, maxAgeHours=48, residueMinStaleHours=24, apply=false', () => {
+  it('defaults to mode=url, maxAgeHours=48, residueMinStaleHours=192, apply=false', () => {
+    // residueMinStaleHours = 192h = 7d max digest window + 24h buffer.
+    // Aligns with the readTimeAgeCutoffMs formula in
+    // digest-orchestration-helpers.mjs so residue mode never deletes a
+    // row still legitimately ship-able for any user (incl. weekly).
     const a = parseArgs([]);
     assert.equal(a.mode, 'url');
     assert.equal(a.maxAgeHours, 48);
-    assert.equal(a.residueMinStaleHours, 24);
+    assert.equal(a.residueMinStaleHours, 192);
     assert.equal(a.apply, false);
   });
 
-  it('--residue-min-stale-hours=N overrides default', () => {
+  it('--residue-min-stale-hours=N overrides default (e.g. 48 for daily-only fleet)', () => {
     assert.equal(parseArgs(['--residue-min-stale-hours=48']).residueMinStaleHours, 48);
   });
 
   it('--residue-min-stale-hours=foo silently ignores (default kept)', () => {
-    assert.equal(parseArgs(['--residue-min-stale-hours=foo']).residueMinStaleHours, 24);
+    assert.equal(parseArgs(['--residue-min-stale-hours=foo']).residueMinStaleHours, 192);
   });
 
   it('--residue-min-stale-hours=0 ignored (positive-only)', () => {
-    assert.equal(parseArgs(['--residue-min-stale-hours=0']).residueMinStaleHours, 24);
+    assert.equal(parseArgs(['--residue-min-stale-hours=0']).residueMinStaleHours, 192);
   });
 
   it('--apply flips to true', () => {

--- a/tests/digest-orchestration-helpers.test.mjs
+++ b/tests/digest-orchestration-helpers.test.mjs
@@ -569,4 +569,3 @@ describe('shouldDropTrackByAge — predicate matrix', () => {
     );
   });
 });
-

--- a/tests/digest-orchestration-helpers.test.mjs
+++ b/tests/digest-orchestration-helpers.test.mjs
@@ -18,7 +18,9 @@ import assert from 'node:assert/strict';
 import {
   digestWindowStartMs,
   pickWinningCandidateWithPool,
+  readTimeAgeCutoffMs,
   runSynthesisWithFallback,
+  shouldDropTrackByAge,
   subjectForBrief,
 } from '../scripts/lib/digest-orchestration-helpers.mjs';
 
@@ -464,3 +466,107 @@ describe('runSynthesisWithFallback — three-level chain', () => {
     assert.ok(result.synthesis);
   });
 });
+
+// ── readTimeAgeCutoffMs / shouldDropTrackByAge — buildDigest READ-time floor ──
+
+describe('readTimeAgeCutoffMs — window-aware cutoff', () => {
+  const HOUR = 60 * 60 * 1000;
+  const DAY = 24 * HOUR;
+
+  it('daily user (24h window) → 48h-ago cutoff', () => {
+    const now = Date.UTC(2026, 3, 26, 8, 0, 0);
+    const windowStart = now - 1 * DAY;
+    const cutoff = readTimeAgeCutoffMs(windowStart);
+    // Cutoff = windowStart - 24h buffer = now - 48h
+    assert.equal(now - cutoff, 2 * DAY);
+  });
+
+  it('weekly user (7d window) → 8d-ago cutoff', () => {
+    const now = Date.UTC(2026, 3, 26, 8, 0, 0);
+    const windowStart = now - 7 * DAY;
+    const cutoff = readTimeAgeCutoffMs(windowStart);
+    assert.equal(now - cutoff, 8 * DAY);
+  });
+
+  it('twice-daily user (12h window) → 36h-ago cutoff', () => {
+    const now = Date.UTC(2026, 3, 26, 8, 0, 0);
+    const windowStart = now - 12 * HOUR;
+    const cutoff = readTimeAgeCutoffMs(windowStart);
+    assert.equal(now - cutoff, 36 * HOUR);
+  });
+});
+
+describe('shouldDropTrackByAge — predicate matrix', () => {
+  const cutoff = Date.UTC(2026, 3, 24, 0, 0, 0); // arbitrary fixed cutoff
+
+  it('drops row with publishedAt strictly before cutoff', () => {
+    assert.equal(
+      shouldDropTrackByAge({ publishedAt: String(cutoff - 1) }, cutoff),
+      true,
+    );
+  });
+
+  it('keeps row with publishedAt exactly at cutoff (>= boundary)', () => {
+    assert.equal(
+      shouldDropTrackByAge({ publishedAt: String(cutoff) }, cutoff),
+      false,
+    );
+  });
+
+  it('keeps row with publishedAt after cutoff', () => {
+    assert.equal(
+      shouldDropTrackByAge({ publishedAt: String(cutoff + 1) }, cutoff),
+      false,
+    );
+  });
+
+  it('keeps row with missing publishedAt (legacy back-compat)', () => {
+    assert.equal(shouldDropTrackByAge({}, cutoff), false);
+  });
+
+  it('keeps row with empty-string publishedAt (defensive write from non-finite item)', () => {
+    assert.equal(shouldDropTrackByAge({ publishedAt: '' }, cutoff), false);
+  });
+
+  it('keeps row with unparseable publishedAt (e.g. literal "undefined")', () => {
+    assert.equal(shouldDropTrackByAge({ publishedAt: 'undefined' }, cutoff), false);
+  });
+
+  it('keeps row with zero or negative publishedAt (sentinel guard)', () => {
+    assert.equal(shouldDropTrackByAge({ publishedAt: '0' }, cutoff), false);
+    assert.equal(shouldDropTrackByAge({ publishedAt: '-1' }, cutoff), false);
+  });
+
+  it('handles null/undefined track defensively', () => {
+    assert.equal(shouldDropTrackByAge(null, cutoff), false);
+    assert.equal(shouldDropTrackByAge(undefined, cutoff), false);
+  });
+
+  it('integration: weekly user with 5d-old story is KEPT (window-aware vs naive 48h)', () => {
+    // Regression guard against the pre-fix behavior where the floor was a
+    // hardcoded 48h. A weekly user's 5-day-old story SHOULD survive because
+    // it's well within their 7d digest window.
+    const now = Date.UTC(2026, 3, 26, 8, 0, 0);
+    const weeklyWindowStart = now - 7 * 24 * 60 * 60 * 1000;
+    const weeklyCutoff = readTimeAgeCutoffMs(weeklyWindowStart); // = now - 8d
+    const fiveDaysAgo = now - 5 * 24 * 60 * 60 * 1000;
+    assert.equal(
+      shouldDropTrackByAge({ publishedAt: String(fiveDaysAgo) }, weeklyCutoff),
+      false,
+      '5d-old story must survive a weekly user\'s window — naive 48h would have dropped it',
+    );
+  });
+
+  it('integration: residue case (4-month-old Pentagon item) is dropped for daily user', () => {
+    const now = Date.UTC(2026, 3, 26, 8, 0, 0);
+    const dailyWindowStart = now - 24 * 60 * 60 * 1000;
+    const dailyCutoff = readTimeAgeCutoffMs(dailyWindowStart); // = now - 48h
+    const fourMonthsAgo = Date.UTC(2026, 0, 9, 0, 0, 0); // 2026-01-09
+    assert.equal(
+      shouldDropTrackByAge({ publishedAt: String(fourMonthsAgo) }, dailyCutoff),
+      true,
+      'Months-old residue with a real publishedAt must be dropped',
+    );
+  });
+});
+

--- a/tests/news-story-track-description-persistence.test.mts
+++ b/tests/news-story-track-description-persistence.test.mts
@@ -115,6 +115,19 @@ describe('buildStoryTrackHsetFields — story:track:v1 HSET contract', () => {
     assert.strictEqual((m.get('description') as string).length, 400);
   });
 
+  it('persists publishedAt as a stringified epoch ms (READ-time freshness contract)', () => {
+    // The READ-time freshness floor in scripts/seed-digest-notifications.mjs
+    // (buildDigest) parses track.publishedAt as int and drops rows older
+    // than DIGEST_READ_MAX_AGE_HOURS. The HSET helper MUST emit it as a
+    // numeric string for that parse to succeed. Skipping this would make
+    // the read-time gate silently inert.
+    const item = baseItem({ publishedAt: 1_745_000_000_000 });
+    const fields = buildStoryTrackHsetFields(item, '1745000000000', 42);
+    const m = fieldsToMap(fields);
+    assert.strictEqual(m.get('publishedAt'), '1745000000000');
+    assert.strictEqual(Number.parseInt(m.get('publishedAt') as string, 10), 1_745_000_000_000);
+  });
+
   it('stale-body overwrite: sequence of mentions for the same titleHash always reflects the CURRENT mention', () => {
     // Simulates the Codex-flagged scenario: Feed A at T0 has body, Feed B
     // at T1 body-less, Feed C at T2 has different body. All collapse to the


### PR DESCRIPTION
## Why this matters

Brief 2026-04-26-0802 surfaced two months-old Pentagon items to a paying user **despite PR #3417's `when:1d` ingest gate working perfectly** (verified live: the gated query returns zero Pentagon items in the last 24h). The cause was post-deploy residue: pre-PR-3417 cron ticks wrote those items to story:track:v1 + the digest accumulator with their real Jan/Sep pubDates, and `buildDigest`'s read path had no `publishedAt`-based freshness check. Pre-deploy entries stayed visible for up to ~48h until accumulator TTL drainage.

This PR closes the residue gap structurally + reduces dependence on Google News for the gov sources where direct RSS exists.

## What changed

### 1. READ-time freshness floor in `buildDigest` (`scripts/seed-digest-notifications.mjs`)
Drops `story:track:v1` rows whose `publishedAt` is older than `DIGEST_READ_MAX_AGE_HOURS` (default 48h). Closes the residue gap for any future ingest-side change. Rows missing `publishedAt` (legacy entries) fall through — back-compat. Operator kill switch: `DIGEST_READ_MAX_AGE_HOURS=999`.

### 2. Persist `publishedAt` in `story:track:v1` HSET (`server/worldmonitor/news/v1/list-feed-digest.ts`)
Adds `'publishedAt', String(item.publishedAt)` to `buildStoryTrackHsetFields`. Required for #1 AND for U6's age-mode (#3). Pre-existing rows pick it up on next mention.

### 3. U6 audit gains `--mode=age|url|both` (`scripts/audit-static-page-contamination.mjs`)
Original URL classifier was BLIND to Google-News-routed entries (`track.link` is a `news.google.com/rss/articles/CBMi…` opaque redirect). `--mode=age` matches by `track.publishedAt > max-age-hours`, the right primary signal for evicting post-deploy residue. Per-reason rollup, operator runbook in script header.

### 4. Feed swap: Pentagon + White House → direct RSS (`server/worldmonitor/news/v1/_feeds.ts`)
Verified via live `curl` + end-to-end `parseRssXml` smoke test:
| Feed | URL | Verified |
|---|---|---|
| Pentagon (war.gov) | `https://www.war.gov/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=945` | 5/5 items, ages 33-54h |
| White House (briefings) | `https://www.whitehouse.gov/briefings-statements/feed/` | 5/5 items, ages 13-59h |
| White House Actions (NEW) | `https://www.whitehouse.gov/presidential-actions/feed/` | 5/5 items, ages 107-129h |

Direct RSS = publisher's pubDate is authoritative. State Dept, Treasury, DOJ retain `gn(...)` with explanatory comment — no working public RSS at any verified path; the READ-time freshness floor (#1) mitigates the residue gap for those.

### 5. `source-tiers.json` adds `White House Actions: 1` (+ scripts/shared mirror)
Without this the new feed would default to tier-4 (no source boost).

## Tests

250/250 pass across the touched + parity-coupled surface. New test asserts `publishedAt` is emitted as a numeric string round-tripping through `parseInt`.

## Operator runbook for the immediate residue

1. Merge this PR → Vercel deploy + Railway redeploy.
2. Wait ~1h for cron tick to start writing `publishedAt` on existing entries via HSET re-mention.
3. Dry run: `node scripts/audit-static-page-contamination.mjs --mode=age`
4. Inspect output — matched titles should look stale (months-old).
5. Apply: `node scripts/audit-static-page-contamination.mjs --mode=age --apply`
6. Random spot-check 3 user briefs over the next 24h — confirm no months-old items.

## Test plan

- [ ] CI green
- [ ] After deploy: Railway logs show `[digest] buildDigest read-time freshness floor dropped N stale items` lines (= the READ-time gate is firing on residue)
- [ ] After deploy: `story:track:v1:*` rows updated by recent cron ticks contain a `publishedAt` field
- [ ] U6 audit `--mode=age` dry-run captured in this PR's review thread before `--apply`
- [ ] 24h post-deploy + audit-apply: random spot-check on 3 user briefs — no items with `publishedAt` more than 48h old