### PR TITLE
hotfix(docker): COPY shared/url-classifier.js into digest-notifications container

### DIFF
--- a/Dockerfile.digest-notifications
+++ b/Dockerfile.digest-notifications
@@ -56,6 +56,12 @@ COPY scripts/lib/ ./scripts/lib/
 # unrelated shared/* files expands the rebuild watch surface.
 COPY shared/brief-envelope.js shared/brief-envelope.d.ts ./shared/
 COPY shared/brief-filter.js shared/brief-filter.d.ts ./shared/
+# brief-filter.js imports url-classifier.js for the U7 institutional-static-
+# page denylist. Added in PR #3419 — without this COPY, the cron crashes at
+# startup with ERR_MODULE_NOT_FOUND on /app/shared/url-classifier.js.
+# See feedback_validation_docker_ship_full_scripts_dir.md — the tight COPY
+# list keeps biting whenever a shared/*.js file gets a new cross-file import.
+COPY shared/url-classifier.js ./shared/
 COPY shared/brief-llm-core.js shared/brief-llm-core.d.ts ./shared/
 COPY server/_shared/brief-render.js server/_shared/brief-render.d.ts ./server/_shared/
 # llm-sanitize is imported by scripts/lib/brief-llm.mjs on the fallback


### PR DESCRIPTION
## 🚨 Production hotfix — digest-notifications cron is down

Railway logs show repeated startup crashes since PR #3419 deployed:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/shared/url-classifier.js'
imported from /app/shared/brief-filter.js
```

Every container restart attempt fails on the same import; cron is not running.

## Why

PR #3419 added `import { isInstitutionalStaticPage } from './url-classifier.js'` to `shared/brief-filter.js` (the U7 brief-side denylist). The file exists in the repo at `shared/url-classifier.js` and the Vercel side picks it up automatically (whole-tree deploy). But `Dockerfile.digest-notifications` uses a deliberately tight per-file COPY list for `shared/*`:

```dockerfile
# Keep this COPY list tight — adding unrelated shared/* files expands
# the rebuild watch surface.
COPY shared/brief-envelope.js shared/brief-envelope.d.ts ./shared/
COPY shared/brief-filter.js shared/brief-filter.d.ts ./shared/
COPY shared/brief-llm-core.js shared/brief-llm-core.d.ts ./shared/
```

PR #3419 didn't update this list, so the Railway container ships `brief-filter.js` without its new dependency.

## Fix

Single-line `COPY shared/url-classifier.js ./shared/` adjacent to its consumer, with an explanatory comment citing PR #3419 + the recurring tight-COPY-list pattern.

Other Railway services (`Dockerfile.relay`, `Dockerfile.seed-bundle-*`) use whole-dir `COPY shared/ ./shared/` and were not affected.

## Test plan

- [ ] CI green (no test changes; URL classifier itself has 24 unit-test cases that already pass)
- [ ] Merge → Railway rebuilds the digest-notifications service
- [ ] Railway logs show "Starting Container" → digest-cron init lines, NOT `ERR_MODULE_NOT_FOUND`
- [ ] Next scheduled cron tick succeeds (digest sends)

## Side note: PR #3422 has follow-on work

PR #3422 (open, READ-time freshness floor + direct-RSS migration + audit residue mode) is unrelated to this Docker fix but rebases cleanly on top of this hotfix once it merges.