### PR TITLE
feat(convex/customers): add normalizedEmail field + index for broadcast dedup

### DIFF
--- a/convex/payments/backfillCustomerNormalizedEmail.ts
+++ b/convex/payments/backfillCustomerNormalizedEmail.ts
@@ -1,0 +1,76 @@
+/**
+ * One-time backfill: populate `customers.normalizedEmail` on rows
+ * that predate the field's introduction.
+ *
+ * Required before the PRO-launch broadcast — the dedup query
+ * (`registrations` − `emailSuppressions` − paying-customers) joins
+ * on `normalizedEmail`, and rows missing the field would otherwise
+ * fall through and receive a "buy PRO!" email despite already paying.
+ *
+ * Idempotent: skips rows that already have a non-empty `normalizedEmail`.
+ * Paginated: pass a `batchSize` (default 500). Re-run until `done: true`.
+ *
+ * Usage:
+ *   npx convex run payments/backfillCustomerNormalizedEmail:backfill
+ *   npx convex run payments/backfillCustomerNormalizedEmail:backfill '{"batchSize":1000}'
+ */
+import { v } from "convex/values";
+import { internalMutation, query } from "../_generated/server";
+
+export const backfill = internalMutation({
+  args: {
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, { batchSize }) => {
+    const limit = batchSize ?? 500;
+    const all = await ctx.db.query("customers").collect();
+
+    let scanned = 0;
+    let patched = 0;
+    let alreadySet = 0;
+    let emptyEmail = 0;
+
+    for (const row of all) {
+      scanned++;
+
+      if (row.normalizedEmail && row.normalizedEmail.length > 0) {
+        alreadySet++;
+        continue;
+      }
+
+      const computed = (row.email ?? "").trim().toLowerCase();
+      if (computed.length === 0) {
+        emptyEmail++;
+        await ctx.db.patch(row._id, { normalizedEmail: "" });
+        continue;
+      }
+
+      await ctx.db.patch(row._id, { normalizedEmail: computed });
+      patched++;
+      if (patched >= limit) break;
+    }
+
+    const remaining = all.length - scanned;
+    const done = remaining === 0;
+    return { total: all.length, scanned, patched, alreadySet, emptyEmail, remaining, done };
+  },
+});
+
+/**
+ * Diagnostic: how many customer rows still need backfilling?
+ * Returns an exact count (full scan — only run from CLI, not hot paths).
+ */
+export const countPending = query({
+  args: {},
+  handler: async (ctx) => {
+    const all = await ctx.db.query("customers").collect();
+    let pending = 0;
+    let withEmail = 0;
+    let total = all.length;
+    for (const row of all) {
+      if (!row.normalizedEmail || row.normalizedEmail.length === 0) pending++;
+      if (row.email && row.email.length > 0) withEmail++;
+    }
+    return { total, pending, withEmail };
+  },
+});

--- a/convex/payments/backfillCustomerNormalizedEmail.ts
+++ b/convex/payments/backfillCustomerNormalizedEmail.ts
@@ -7,7 +7,7 @@
  * on `normalizedEmail`, and rows missing the field would otherwise
  * fall through and receive a "buy PRO!" email despite already paying.
  *
- * Idempotent: skips rows that already have a non-empty `normalizedEmail`.
+ * Idempotent: only reads rows where `normalizedEmail` is missing.
  * Paginated: pass a `batchSize` (default 500). Re-run until `done: true`.
  *
  * Usage:
@@ -15,7 +15,7 @@
  *   npx convex run payments/backfillCustomerNormalizedEmail:backfill '{"batchSize":1000}'
  */
 import { v } from "convex/values";
-import { internalMutation, query } from "../_generated/server";
+import { internalMutation, internalQuery } from "../_generated/server";
 
 export const backfill = internalMutation({
   args: {
@@ -23,50 +23,48 @@ export const backfill = internalMutation({
   },
   handler: async (ctx, { batchSize }) => {
     const limit = batchSize ?? 500;
-    const all = await ctx.db.query("customers").collect();
 
-    let scanned = 0;
+    // Filter for missing normalizedEmail keeps reads proportional to batchSize
+    // instead of scanning the entire `customers` table on every call (which
+    // would hit Convex's 16,384-document read limit once the table grows).
+    // Once we patch a row (even to empty string) it drops out of this filter,
+    // so the backfill drains in O(N/limit) calls and self-terminates.
+    const rows = await ctx.db
+      .query("customers")
+      .filter((q) => q.eq(q.field("normalizedEmail"), undefined))
+      .take(limit);
+
     let patched = 0;
-    let alreadySet = 0;
     let emptyEmail = 0;
 
-    for (const row of all) {
-      scanned++;
-
-      if (row.normalizedEmail && row.normalizedEmail.length > 0) {
-        alreadySet++;
-        continue;
-      }
-
+    for (const row of rows) {
       const computed = (row.email ?? "").trim().toLowerCase();
       if (computed.length === 0) {
         emptyEmail++;
         await ctx.db.patch(row._id, { normalizedEmail: "" });
-        continue;
+      } else {
+        await ctx.db.patch(row._id, { normalizedEmail: computed });
       }
-
-      await ctx.db.patch(row._id, { normalizedEmail: computed });
       patched++;
-      if (patched >= limit) break;
     }
 
-    const remaining = all.length - scanned;
-    const done = remaining === 0;
-    return { total: all.length, scanned, patched, alreadySet, emptyEmail, remaining, done };
+    const done = rows.length < limit;
+    return { read: rows.length, patched, emptyEmail, done };
   },
 });
 
 /**
  * Diagnostic: how many customer rows still need backfilling?
- * Returns an exact count (full scan — only run from CLI, not hot paths).
+ * `internalQuery` so it can only be invoked from server contexts (CLI / scheduler),
+ * not by authenticated clients — comment intent now matches the export.
  */
-export const countPending = query({
+export const countPending = internalQuery({
   args: {},
   handler: async (ctx) => {
     const all = await ctx.db.query("customers").collect();
     let pending = 0;
     let withEmail = 0;
-    let total = all.length;
+    const total = all.length;
     for (const row of all) {
       if (!row.normalizedEmail || row.normalizedEmail.length === 0) pending++;
       if (row.email && row.email.length > 0) withEmail++;

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -333,6 +333,7 @@ export async function handleSubscriptionActive(
   // Upsert customer record so portal session creation can find dodoCustomerId
   const dodoCustomerId = data.customer?.customer_id;
   const email = data.customer?.email ?? "";
+  const normalizedEmail = email.trim().toLowerCase();
 
   if (dodoCustomerId) {
     const existingCustomer = await ctx.db
@@ -346,6 +347,7 @@ export async function handleSubscriptionActive(
       await ctx.db.patch(existingCustomer._id, {
         userId,
         email,
+        normalizedEmail,
         updatedAt: eventTimestamp,
       });
     } else {
@@ -353,6 +355,7 @@ export async function handleSubscriptionActive(
         userId,
         dodoCustomerId,
         email,
+        normalizedEmail,
         createdAt: eventTimestamp,
         updatedAt: eventTimestamp,
       });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -223,11 +223,19 @@ export default defineSchema({
     userId: v.string(),
     dodoCustomerId: v.optional(v.string()),
     email: v.string(),
+    // Lowercased + trimmed mirror of `email`. Required for O(1) joins from
+    // `registrations`/`emailSuppressions` (both keyed on `normalizedEmail`)
+    // when building broadcast audiences — without this, dedup is a full
+    // table scan and paid users can leak into "buy PRO!" sends.
+    // Optional so existing rows pass schema validation; backfilled via
+    // `npx convex run payments/backfillCustomerNormalizedEmail:backfill`.
+    normalizedEmail: v.optional(v.string()),
     createdAt: v.number(),
     updatedAt: v.number(),
   })
     .index("by_userId", ["userId"])
-    .index("by_dodoCustomerId", ["dodoCustomerId"]),
+    .index("by_dodoCustomerId", ["dodoCustomerId"])
+    .index("by_normalized_email", ["normalizedEmail"]),
 
   webhookEvents: defineTable({
     webhookId: v.string(),


### PR DESCRIPTION
## Why

Pre-work for the PRO-launch broadcast to ~tens-of-thousands of waitlist users.

The audience-build dedup query is `registrations` − `emailSuppressions` − paying customers (from the `customers` join, since `subscriptions` is keyed on `userId`, not email). On `main` today:

- `registrations.normalizedEmail` is **lowercased + trimmed**, indexed
- `emailSuppressions.normalizedEmail` is **lowercased + trimmed**, indexed
- `customers.email` is **raw** (whatever Dodo sent us — case-preserved), **not indexed**

Result: the dedup join either does a full `customers` scan on every audience build, or — if we naively join on `email == normalizedEmail` — silently drops paid users whose Dodo email had any case/whitespace divergence from their waitlist signup. **Failure mode: paid users receive a "buy PRO!" launch email.** That's the worst-case outcome of the whole broadcast effort.

## What

Mirrors the convention `registrations` and `emailSuppressions` already use.

- **`convex/schema.ts`** — adds `customers.normalizedEmail: v.optional(v.string())` + `by_normalized_email` index. Optional so existing rows pass schema validation; comment explains the broadcast-dedup motivation and points at the backfill command.
- **`convex/payments/subscriptionHelpers.ts`** — `handleSubscriptionActive` now derives `normalizedEmail` once and writes it at both upsert paths (existing-customer patch + new-customer insert).
- **`convex/payments/backfillCustomerNormalizedEmail.ts`** (new) — idempotent paginated `internalMutation` (default `batchSize: 500`) + `countPending` diagnostic `query`. Skips rows that already have a non-empty value; handles empty-email rows by writing empty string. Pattern mirrors `seedProductPlans.ts`.

## Verification

- `npx tsc --noEmit -p convex/tsconfig.json` → clean
- Field is `v.optional` → no validation break for existing rows on deploy
- Both write sites compute `normalizedEmail` from the same `email.trim().toLowerCase()` derivation as the existing convention sites (`registerInterest.ts:60`, `emailSuppressions.ts:11`)

## Operational sequence after merge

Convex deploys schema automatically via the Vercel hook. Then:

```
npx convex run payments/backfillCustomerNormalizedEmail:countPending
# expect: { total: N, pending: ~N (most existing rows lack the field), withEmail: M }

npx convex run payments/backfillCustomerNormalizedEmail:backfill
# rerun until response shows done:true (paginated at 500/call)

npx convex run payments/backfillCustomerNormalizedEmail:countPending
# expect: { pending: 0 }
```

## Out of scope

- The actual broadcast pipeline (Convex action that builds the audience, upserts to Resend Contacts via API, and triggers the Broadcast). That's the next PR — this one just unblocks the dedup join.
- Migrating `normalizedEmail` from `v.optional` to required. Separate cleanup PR after backfill confirms 100% coverage.