### PR TITLE
fix(resilience): repair externalDebtCoverage broken-data-source (mrv=1 + HIC=0)

### DIFF
--- a/scripts/post-pr3427-force-refresh.mjs
+++ b/scripts/post-pr3427-force-refresh.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+//
+// Post-PR-#3427 ONE-SHOT: force-refresh the two recovery seeders
+// affected by the mrv=5/null-skip/HIC=0 fix.
+//
+// Why this script exists: the recovery bundle runs weekly with a 30d
+// freshness gate (`scripts/_bundle-runner.mjs:240` skips when elapsed
+// < intervalMs * 0.8). After PR #3427 merges, the new seeder code
+// will not RUN on Railway until either (a) the canonical envelope
+// ages past 24 days, OR (b) the canonical key is deleted, OR (c) the
+// seeder runs out-of-band. This script is option (c) — invokes both
+// seeders directly, bypassing the bundle runner and its freshness gate.
+//
+// Run AFTER PR #3427 merges, BEFORE the next `seed-resilience-scores`
+// cron tick, so score warmup picks up the corrected debt seed
+// immediately rather than waiting up to ~24 days for the bundle gate
+// to time out.
+//
+// Usage: node scripts/post-pr3427-force-refresh.mjs
+
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const SEEDERS = [
+  'seed-recovery-external-debt.mjs',
+  'seed-recovery-reserve-adequacy.mjs',
+];
+
+console.log('[post-pr3427] Force-refreshing recovery seeders affected by mrv=1 trap fix.');
+console.log('[post-pr3427] Bypasses scripts/_bundle-runner.mjs freshness gate.');
+console.log('');
+
+let failed = 0;
+for (const seeder of SEEDERS) {
+  const path = resolve(here, seeder);
+  console.log(`[post-pr3427] Running: ${seeder}`);
+  const result = spawnSync('node', [path], {
+    stdio: 'inherit',
+    env: { ...process.env, FORCE_RESEED: 'true' },
+  });
+  if (result.status !== 0) {
+    console.error(`[post-pr3427] FAILED: ${seeder} (exit ${result.status})`);
+    failed++;
+  } else {
+    console.log(`[post-pr3427] OK: ${seeder}`);
+  }
+  console.log('');
+}
+
+if (failed > 0) {
+  console.error(`[post-pr3427] ${failed}/${SEEDERS.length} seeders failed. Investigate before triggering seed-resilience-scores.`);
+  process.exit(1);
+}
+
+console.log('[post-pr3427] All seeders refreshed. Now run:');
+console.log('  WORLDMONITOR_API_KEY=<key> node scripts/seed-resilience-scores.mjs');
+console.log('to bulk-warm the v15 score cache against the corrected seed data.');

--- a/scripts/seed-recovery-external-debt.mjs
+++ b/scripts/seed-recovery-external-debt.mjs
@@ -47,7 +47,15 @@ async function fetchWbIndicator(indicator) {
       const rawCode = record?.countryiso3code ?? record?.country?.id ?? '';
       const iso2 = rawCode.length === 3 ? (iso3ToIso2[rawCode] ?? null) : (rawCode.length === 2 ? rawCode : null);
       if (!iso2) continue;
-      const value = Number(record?.value);
+      // CRITICAL: skip null records BEFORE Number() coercion.
+      // Number(null) === 0 (not NaN), which would pass Number.isFinite()
+      // and let a `value: null` record overwrite an older non-null
+      // record in the latest-picker below — silently defeating the
+      // mrv=5 + pickLatest fix. WB returns null for late-reporters
+      // and out-of-scope countries; both should be skipped, not
+      // coerced to 0. Spotted by reviewer post-PR-#3427-initial-push.
+      if (record?.value == null) continue;
+      const value = Number(record.value);
       if (!Number.isFinite(value)) continue;
       const year = Number(record?.date);
       if (!Number.isFinite(year)) continue;

--- a/scripts/seed-recovery-external-debt.mjs
+++ b/scripts/seed-recovery-external-debt.mjs
@@ -19,7 +19,13 @@ async function fetchWbIndicator(indicator) {
   let totalPages = 1;
 
   while (page <= totalPages) {
-    const url = `${WB_BASE}/country/all/indicator/${indicator}?format=json&per_page=500&page=${page}&mrv=1`;
+    // mrv=5 (NOT mrv=1) per memory `feedback_wb_bulk_mrv1_null_coverage_trap`:
+    // mrv=1 returns a SINGLE year across all countries with `value: null`
+    // for late-reporters (KW/QA/AE/etc. publish 1-2y behind G7), silently
+    // dropping them from the dataset. mrv=5 + per-country pickLatest gives
+    // a true latest-available-non-null per country. Same pattern used by
+    // `seed-wb-external-debt.mjs` for the financialSystemExposure dim.
+    const url = `${WB_BASE}/country/all/indicator/${indicator}?format=json&per_page=500&page=${page}&mrv=5`;
     let json;
     try {
       const resp = await fetch(url, {
@@ -43,7 +49,14 @@ async function fetchWbIndicator(indicator) {
       if (!iso2) continue;
       const value = Number(record?.value);
       if (!Number.isFinite(value)) continue;
-      out[iso2] = { value, year: Number(record?.date) || null };
+      const year = Number(record?.date);
+      if (!Number.isFinite(year)) continue;
+      // Per-country latest-non-null. Order-agnostic (mrv=5 returns up
+      // to 5 records per country, possibly across pages).
+      const existing = out[iso2];
+      if (!existing || year > existing.year) {
+        out[iso2] = { value, year };
+      }
     }
     page++;
   }
@@ -57,6 +70,7 @@ async function fetchExternalDebt() {
   ]);
 
   const countries = {};
+  let droppedHicZeroDebt = 0;
   const allCodes = new Set([...Object.keys(debtMap), ...Object.keys(reservesMap)]);
 
   for (const code of allCodes) {
@@ -64,10 +78,25 @@ async function fetchExternalDebt() {
     const reserves = reservesMap[code];
     if (!debt || !reserves || reserves.value <= 0) continue;
 
+    // Plan 2026-04-26 audit finding #7: WB IDS dataset (DT.DOD.DSTC.CD)
+    // is LMIC-scoped. High-income countries get value=0 from this series
+    // (not null — actually the literal zero), which under the previous
+    // code translated to debtToReservesRatio=0 → score 100. 72/164
+    // countries (44%) of the v15 ranking had this false-perfect signal,
+    // including NO/CH/DK/SE/FI/IS/KW/AE/SG/LU. Filter those out: a real
+    // LMIC-scoped IDS reading must have positive short-term debt. The
+    // construct semantically applies to LMICs only, so dropping HIC is
+    // correct (they get the dim's IMPUTE fallback score 50 / cov 0.3).
+    if (debt.value <= 0) { droppedHicZeroDebt++; continue; }
+
     countries[code] = {
       debtToReservesRatio: Math.round((debt.value / reserves.value) * 1000) / 1000,
       year: debt.year ?? reserves.year ?? null,
     };
+  }
+
+  if (droppedHicZeroDebt > 0) {
+    console.warn(`[recovery:external-debt] Dropped ${droppedHicZeroDebt} countries with debt=0 (HIC out-of-IDS-scope; would have falsely scored 100 on debtToReservesRatio).`);
   }
 
   return { countries, seededAt: new Date().toISOString() };

--- a/scripts/seed-recovery-reserve-adequacy.mjs
+++ b/scripts/seed-recovery-reserve-adequacy.mjs
@@ -16,7 +16,12 @@ async function fetchReserveAdequacy() {
   let totalPages = 1;
 
   while (page <= totalPages) {
-    const url = `${WB_BASE}/country/all/indicator/${INDICATOR}?format=json&per_page=500&page=${page}&mrv=1`;
+    // mrv=5 (NOT mrv=1) per memory `feedback_wb_bulk_mrv1_null_coverage_trap`:
+    // mrv=1 returns a SINGLE year across all countries with `value: null`
+    // for late-reporters (KW/QA/AE/etc. publish 1-2y behind G7), silently
+    // dropping them from the dataset. mrv=5 + per-country pickLatest gives
+    // a true latest-available-non-null per country.
+    const url = `${WB_BASE}/country/all/indicator/${INDICATOR}?format=json&per_page=500&page=${page}&mrv=5`;
     const resp = await fetch(url, {
       headers: { 'User-Agent': CHROME_UA },
       signal: AbortSignal.timeout(30_000),
@@ -38,11 +43,16 @@ async function fetchReserveAdequacy() {
     const value = Number(record?.value);
     if (!Number.isFinite(value)) continue;
     const year = Number(record?.date);
+    if (!Number.isFinite(year)) continue;
 
-    countries[iso2] = {
-      reserveMonths: value,
-      year: Number.isFinite(year) ? year : null,
-    };
+    // Per-country latest-non-null (mrv=5 returns up to 5 records per country).
+    const existing = countries[iso2];
+    if (!existing || year > existing.year) {
+      countries[iso2] = {
+        reserveMonths: value,
+        year,
+      };
+    }
   }
 
   return { countries, seededAt: new Date().toISOString() };

--- a/scripts/seed-recovery-reserve-adequacy.mjs
+++ b/scripts/seed-recovery-reserve-adequacy.mjs
@@ -40,7 +40,14 @@ async function fetchReserveAdequacy() {
     const rawCode = record?.countryiso3code ?? record?.country?.id ?? '';
     const iso2 = rawCode.length === 3 ? (iso3ToIso2[rawCode] ?? null) : (rawCode.length === 2 ? rawCode : null);
     if (!iso2) continue;
-    const value = Number(record?.value);
+    // CRITICAL: skip null records BEFORE Number() coercion.
+    // Number(null) === 0 (not NaN), which would pass Number.isFinite()
+    // and let a `value: null` record overwrite an older non-null record
+    // in the latest-picker below — silently defeating the mrv=5 +
+    // pickLatest fix. WB returns null for late-reporters; those must
+    // not be coerced to 0 reserveMonths. Spotted by reviewer post-PR-#3427.
+    if (record?.value == null) continue;
+    const value = Number(record.value);
     if (!Number.isFinite(value)) continue;
     const year = Number(record?.date);
     if (!Number.isFinite(year)) continue;


### PR DESCRIPTION
## Summary

PR #3425's post-merge dry-run surfaced that `externalDebtCoverage` (0.25-weight recovery dimension) awards `debtToReservesRatio: 0` → **score 100 to 72/164 countries (44%)** including NO/CH/DK/SE/FI/IS/KW/AE/SG/LU. A 25%-weighted dim scoring nearly half the universe at 100 is not discriminating.

## Root cause (three layers)

1. **WB `mrv=1` trap** (memory `feedback_wb_bulk_mrv1_null_coverage_trap`) — silently drops late-reporters. Fixed via `mrv=5` + per-country pickLatest, matching the pattern already used by `seed-wb-external-debt.mjs`.
2. **`Number(null) === 0` defeats the latest-picker** — caught by reviewer post-initial-push (commit `b44e74bff`). Without an explicit `if (record?.value == null) continue` BEFORE coercion, a late-arriving null overwrites an older non-null, defeating the entire mrv=5 fix. Now skips nulls upfront.
3. **WB IDS is LMIC-scoped** — HICs return `value: 0` (not null) for short-term external debt. Old code accepted 0 as legitimate, divided by reserves, scored 100. Fix: drop `debt.value <= 0`. HICs fall to the existing `IMPUTE.recoveryExternalDebt` fallback (50/0.3/unmonitored).

Same `mrv=1` + null-skip fix also applied to `seed-recovery-reserve-adequacy.mjs` for the `FI.RES.TOTL.MO` indicator.

## Propagation — manual ops required (do NOT skip)

The recovery seeders ship inside `seed-bundle-resilience-recovery.mjs` which uses a 30-day freshness gate (`scripts/_bundle-runner.mjs:240` skips when `elapsed < intervalMs * 0.8` ≈ 24 days). After merge, the new seeder code WILL NOT RUN on Railway for ~24 days because the bundle runner sees the prior canonical envelope as fresh. Meanwhile `seed-resilience-scores` keeps recomputing scores against stale recovery data — fix appears not to land.

**Release checklist (run in order, post-merge, with prod env):**

```bash
# 1. Force-refresh the two affected canonical keys (bypasses bundle runner gate)
node scripts/post-pr3427-force-refresh.mjs

# 2. Bulk-warm the v15 score cache against the corrected seed data
WORLDMONITOR_API_KEY=<key> node scripts/seed-resilience-scores.mjs

# 3. Re-run the cohort dry-run to capture empirical impact
PRE_RANKING_KEY=resilience:ranking:v14 npm run dryrun:resilience
```

The 72 false-100 countries should drop to IMPUTE 50 in step 2; rank movements (BS/SE/FI/NO/CH/etc. dropping) should appear in step 3's CSV.

## Test plan

- [ ] Run `node scripts/post-pr3427-force-refresh.mjs` — confirm both seeders run, see "Dropped N countries with debt=0" warning
- [ ] Run `WORLDMONITOR_API_KEY=<key> node scripts/seed-resilience-scores.mjs` — confirm 222/222 cached
- [ ] Re-run `npm run dryrun:resilience` — inspect rank deltas for sane reorderings
- [ ] Verify `/api/health.resilienceRanking` stays `OK`

## Lineage

Plan 2026-04-26-001 cohort dry-run → user audit findings #6+#7+#8 → this PR. Second seeder migrated to the `mrv=5 + pickLatest` recipe (first was `seed-wb-external-debt.mjs` in PR #3412).

## Reviewer findings addressed in commit b44e74bff

- **P1 — `Number(null) === 0` defeats the picker** — explicit null-skip before coercion in both seeders
- **P2 — bundle freshness gate delays propagation ~24 days** — added `scripts/post-pr3427-force-refresh.mjs` one-shot + release checklist above