### PR TITLE
fix(upstash): chunk embedding cache writes + buildDigest HGETALL reads

### DIFF
--- a/scripts/lib/brief-embedding.mjs
+++ b/scripts/lib/brief-embedding.mjs
@@ -253,9 +253,21 @@ export async function embedBatch(normalizedTitles, deps = {}) {
       cacheWrites.push(['SET', key, JSON.stringify(freshVectors[i]), 'EX', String(CACHE_TTL_SECONDS)]);
     }
     // Cache writes are best-effort — a failure costs us a re-embed
-    // on the next run, never a correctness bug.
+    // on the next run, never a correctness bug. Chunked because the
+    // 512-dim vector serialises to ~9.4KB per SET command; an unbatched
+    // pipeline of N misses sends one HTTP body of N×9.4KB to Upstash
+    // REST `/pipeline`, which trips the per-request body limit (50MB on
+    // our plan) at ~5,300 misses. Real ticks rarely approach that, but
+    // a cold cache on a high-volume language tick (or a future tick-
+    // size growth) would silently exceed it. 200 × 9.4KB ≈ 1.9MB per
+    // request matches the chunking pattern used by sibling seeders
+    // (PIPE_BATCH=50 in seed-resilience-intervals.mjs / seed-comtrade-
+    // bilateral-hs4.mjs, SET_BATCH=30 in resilience/v1/_shared.ts).
     try {
-      await pipelineImpl(cacheWrites);
+      const FLUSH = 200;
+      for (let i = 0; i < cacheWrites.length; i += FLUSH) {
+        await pipelineImpl(cacheWrites.slice(i, i + FLUSH));
+      }
     } catch {
       // swallow
     }

--- a/scripts/lib/brief-embedding.mjs
+++ b/scripts/lib/brief-embedding.mjs
@@ -72,6 +72,16 @@ export function cacheKeyFor(normalizedTitle) {
 // Default (production) deps wiring lives in ./_upstash-pipeline.mjs so
 // the orchestrator and the embedding client share one implementation.
 
+// Symmetric to the cache-write FLUSH knob: a 512-dim vector
+// serialises to ~9.4KB, so an unbatched GET pipeline RESPONSE for
+// N unique titles is N×9.4KB. With ~8K cached titles in production
+// (live brief:emb:v1:* count), a cold-tick pipeline-GET response
+// would already be 75MB — well past Upstash's per-request limit
+// and likely to time out the 10s pipeline budget. 500 GETs ×
+// ~9.4KB = ~4.7MB per chunk response keeps the symmetric read
+// path under the same budget the writes target.
+const CACHE_GET_FLUSH = 500;
+
 /**
  * Look up a set of cache keys via the redis pipeline and return a
  * Map of key → vector for the hits. Misses, corrupt cells, pipeline
@@ -80,24 +90,42 @@ export function cacheKeyFor(normalizedTitle) {
  *
  * Kept as a helper so embedBatch's cognitive complexity stays
  * reviewable; there's no other caller.
+ *
+ * Chunked + bail-on-failure for parity with the cache-write path:
+ * the response body for a single GET pipeline scales linearly with
+ * uniqueKeys.length, and an outage would otherwise spend the full
+ * embed deadline on N × 10s timeouts inside this helper before the
+ * caller's deadline check fires. Per-chunk index alignment is
+ * preserved because each chunk reads its own contiguous
+ * uniqueKeys.slice(...) — no cross-chunk position arithmetic.
  */
-async function cacheGetBatched(uniqueKeys, pipelineImpl) {
+async function cacheGetBatched(uniqueKeys, pipelineImpl, deadline = Infinity, nowImpl = Date.now) {
   const hits = new Map();
   if (uniqueKeys.length === 0) return hits;
-  const getResults = await pipelineImpl(uniqueKeys.map((k) => ['GET', k]));
-  if (!Array.isArray(getResults)) return hits;
-  for (let i = 0; i < uniqueKeys.length; i++) {
-    const cell = getResults[i];
-    const raw = cell && typeof cell === 'object' && 'result' in cell ? cell.result : null;
-    if (typeof raw !== 'string') continue;
-    try {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed) && parsed.length === EMBED_DIMS) {
-        hits.set(uniqueKeys[i], parsed);
+
+  for (let start = 0; start < uniqueKeys.length; start += CACHE_GET_FLUSH) {
+    if (nowImpl() > deadline) return hits;
+    const chunk = uniqueKeys.slice(start, start + CACHE_GET_FLUSH);
+    const getResults = await pipelineImpl(chunk.map((k) => ['GET', k]));
+    // Outage / short-response: treat the rest as misses. The caller
+    // will hit the API for them — strict optimisation only, never
+    // correctness. Don't keep iterating; remaining chunks would
+    // almost certainly hit the same outage and burn the deadline.
+    if (!Array.isArray(getResults) || getResults.length !== chunk.length) return hits;
+
+    for (let i = 0; i < chunk.length; i++) {
+      const cell = getResults[i];
+      const raw = cell && typeof cell === 'object' && 'result' in cell ? cell.result : null;
+      if (typeof raw !== 'string') continue;
+      try {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed) && parsed.length === EMBED_DIMS) {
+          hits.set(chunk[i], parsed);
+        }
+      } catch {
+        // Corrupt cache cell: treat as miss. Don't error — next
+        // successful API call will overwrite.
       }
-    } catch {
-      // Corrupt cache cell: treat as miss. Don't error — next
-      // successful API call will overwrite.
     }
   }
   return hits;
@@ -226,7 +254,7 @@ export async function embedBatch(normalizedTitles, deps = {}) {
   const keyByIndex = normalizedTitles.map((t) => cacheKeyFor(t));
   const uniqueKeys = [...new Set(keyByIndex)];
 
-  const vectorByKey = await cacheGetBatched(uniqueKeys, pipelineImpl);
+  const vectorByKey = await cacheGetBatched(uniqueKeys, pipelineImpl, deadline, nowImpl);
   if (nowImpl() > deadline) throw new EmbeddingTimeoutError();
 
   // Build the miss list, preserving the first normalised title we

--- a/scripts/lib/brief-embedding.mjs
+++ b/scripts/lib/brief-embedding.mjs
@@ -263,10 +263,20 @@ export async function embedBatch(normalizedTitles, deps = {}) {
     // request matches the chunking pattern used by sibling seeders
     // (PIPE_BATCH=50 in seed-resilience-intervals.mjs / seed-comtrade-
     // bilateral-hs4.mjs, SET_BATCH=30 in resilience/v1/_shared.ts).
+    //
+    // Outage break: defaultRedisPipeline returns null on HTTP error
+    // (does NOT throw), so the try/catch alone won't stop the loop.
+    // On a sustained Upstash outage with 5K misses, that would mean
+    // 27 chunks × ~10s timeout each ≈ 270s — well past the 45s
+    // wall-clock budget for dedup. Break on any non-array (null /
+    // short) chunk result, and on remaining-deadline exhaustion, so
+    // the caller stays inside its budget even on outage.
     try {
       const FLUSH = 200;
       for (let i = 0; i < cacheWrites.length; i += FLUSH) {
-        await pipelineImpl(cacheWrites.slice(i, i + FLUSH));
+        if (nowImpl() > deadline) break;
+        const result = await pipelineImpl(cacheWrites.slice(i, i + FLUSH));
+        if (!Array.isArray(result) || result.length !== Math.min(FLUSH, cacheWrites.length - i)) break;
       }
     } catch {
       // swallow

--- a/scripts/lib/story-track-batch-reader.mjs
+++ b/scripts/lib/story-track-batch-reader.mjs
@@ -1,0 +1,59 @@
+/**
+ * Chunked HGETALL reader for story:track:v1:<hash> rows used by
+ * scripts/seed-digest-notifications.mjs::buildDigest.
+ *
+ * Extracted so the index-alignment-on-partial-failure contract can be
+ * unit-tested without dragging the cron's top-level side effects
+ * (Upstash creds check, main() entry-point) into the test runtime.
+ *
+ * Why chunked:
+ *   Per-language `digest:accumulator:v1:full:<lang>` ZSETs hold
+ *   17K-21K hashes today, bounded only by ingest volume ×
+ *   DIGEST_ACCUMULATOR_TTL. Each story:track:v1 hash averages ~380B
+ *   but reaches ~1.2KB. An unbatched pipeline RESPONSE for the
+ *   largest accumulator already crosses 7MB and grows linearly with
+ *   ingest. 500 commands × ~1.2KB = ~600KB per chunk keeps each
+ *   /pipeline call's response well under Upstash's per-request
+ *   limit (50MB on our plan) and inside the 10-15s pipeline timeout.
+ *
+ * Why bail-on-short:
+ *   The caller pairs `trackResults[i]` with `hashes[i]` (see
+ *   seed-digest-notifications.mjs buildDigest's stories.push hash
+ *   field). `pipelineFn` is allowed to return `[]` (or `null` /
+ *   undefined / a short array) on HTTP error; naive `out.push(...partial)`
+ *   on a short result would shift every later position onto the wrong
+ *   hash and publish stories with wrong source-set / embedding-cache
+ *   linkage. We pad the remaining positions with `{result: null}`
+ *   placeholders (downstream `Array.isArray(raw)` skips them, matching
+ *   legacy single-pipeline-failure semantics where every row was a
+ *   miss) and abort, so a sustained outage doesn't burn the full
+ *   pipeline budget on N × per-chunk timeouts.
+ */
+
+export const STORY_TRACK_HGETALL_BATCH = 500;
+
+export async function readStoryTracksChunked(
+  hashes,
+  pipelineFn,
+  { batchSize = STORY_TRACK_HGETALL_BATCH, log = console.warn } = {},
+) {
+  const out = [];
+  for (let i = 0; i < hashes.length; i += batchSize) {
+    const chunk = hashes.slice(i, i + batchSize);
+    const partial = await pipelineFn(
+      chunk.map((h) => ['HGETALL', `story:track:v1:${h}`]),
+    );
+    if (Array.isArray(partial) && partial.length === chunk.length) {
+      out.push(...partial);
+      continue;
+    }
+    const failedAt = Math.floor(i / batchSize);
+    const got = Array.isArray(partial) ? partial.length : 'non-array';
+    log(
+      `[digest] readStoryTracksChunked: chunk ${failedAt} returned ${got} of ${chunk.length} expected — padding remaining ${hashes.length - i} entries as misses and aborting`,
+    );
+    for (let j = i; j < hashes.length; j++) out.push({ result: null });
+    return out;
+  }
+  return out;
+}

--- a/scripts/lib/story-track-batch-reader.mjs
+++ b/scripts/lib/story-track-batch-reader.mjs
@@ -16,18 +16,30 @@
  *   /pipeline call's response well under Upstash's per-request
  *   limit (50MB on our plan) and inside the 10-15s pipeline timeout.
  *
- * Why bail-on-short:
+ * Why bail-on-failure (return null):
  *   The caller pairs `trackResults[i]` with `hashes[i]` (see
  *   seed-digest-notifications.mjs buildDigest's stories.push hash
  *   field). `pipelineFn` is allowed to return `[]` (or `null` /
  *   undefined / a short array) on HTTP error; naive `out.push(...partial)`
  *   on a short result would shift every later position onto the wrong
  *   hash and publish stories with wrong source-set / embedding-cache
- *   linkage. We pad the remaining positions with `{result: null}`
- *   placeholders (downstream `Array.isArray(raw)` skips them, matching
- *   legacy single-pipeline-failure semantics where every row was a
- *   miss) and abort, so a sustained outage doesn't burn the full
- *   pipeline budget on N × per-chunk timeouts.
+ *   linkage.
+ *
+ *   We could pad the remaining positions with `{result: null}`
+ *   placeholders to keep length === hashes.length, but that would
+ *   regress the legacy semantic: pre-chunking, a single pipeline
+ *   failure returned [] from upstashPipeline → every row skipped →
+ *   buildDigest returned null → the cron skipped sending that user/
+ *   variant. With placeholders, a partial failure would now ship a
+ *   digest built from chunks 0..N-1, mark `digest:last-sent:v1` as
+ *   sent, and the user would never see the dropped stories on the
+ *   next tick. Worse: dropped stories would be silent — no operator
+ *   signal that the digest was incomplete.
+ *
+ *   So we return `null` on any chunk failure. Callers MUST treat
+ *   null as "skip this digest tick — Upstash partial outage" rather
+ *   than as empty-but-successful. Stops iterating so an outage
+ *   doesn't burn the full pipeline budget on N × per-chunk timeouts.
  */
 
 export const STORY_TRACK_HGETALL_BATCH = 500;
@@ -50,10 +62,9 @@ export async function readStoryTracksChunked(
     const failedAt = Math.floor(i / batchSize);
     const got = Array.isArray(partial) ? partial.length : 'non-array';
     log(
-      `[digest] readStoryTracksChunked: chunk ${failedAt} returned ${got} of ${chunk.length} expected — padding remaining ${hashes.length - i} entries as misses and aborting`,
+      `[digest] readStoryTracksChunked: chunk ${failedAt} returned ${got} of ${chunk.length} expected — aborting and returning null so caller skips this digest tick`,
     );
-    for (let j = i; j < hashes.length; j++) out.push({ result: null });
-    return out;
+    return null;
   }
   return out;
 }

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -462,7 +462,27 @@ async function readStoryTracksChunked(hashes) {
     const partial = await upstashPipeline(
       chunk.map((h) => ['HGETALL', `story:track:v1:${h}`]),
     );
-    out.push(...partial);
+    // upstashPipeline returns [] on HTTP error, and a short result on
+    // any other shape mismatch. The downstream caller pairs
+    // trackResults[i] with hashes[i], so a missing chunk would shift
+    // every later result onto the wrong hash — publishing stories with
+    // wrong source-set / embedding-cache linkage. Bail out: pad the
+    // remaining positions with null-result placeholders so callers see
+    // the same row-skip behaviour as the legacy single-pipeline failure
+    // (no rows pass `Array.isArray(raw)` → buildDigest returns null).
+    // Stop iterating so an outage doesn't burn the full pipeline budget
+    // on N × 15s timeouts.
+    if (Array.isArray(partial) && partial.length === chunk.length) {
+      out.push(...partial);
+      continue;
+    }
+    const failedAt = i / STORY_TRACK_HGETALL_BATCH;
+    const got = Array.isArray(partial) ? partial.length : 'non-array';
+    console.warn(
+      `[digest] readStoryTracksChunked: chunk ${failedAt} returned ${got} of ${chunk.length} expected — padding remaining ${hashes.length - i} entries as misses and aborting`,
+    );
+    for (let j = i; j < hashes.length; j++) out.push({ result: null });
+    return out;
   }
   return out;
 }

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -441,6 +441,32 @@ function matchesSensitivity(ruleSensitivity, severity) {
 // is imported from the Jaccard module so the text/HTML formatters
 // below keep their current per-story title cleanup.
 
+// Chunked HGETALL over story:track:v1:<hash>. An accumulator ZSET can
+// hold tens of thousands of hashes (per-language `:full:<lang>` ZSETs
+// observed at 17K-21K entries — bounded only by ingest volume ×
+// DIGEST_ACCUMULATOR_TTL). Each story:track:v1 hash averages ~380B but
+// can reach ~1.2KB, so an unbatched pipeline RESPONSE for the largest
+// accumulator already crosses 7MB and grows linearly with ingest. Chunk
+// to keep each /pipeline call's response well under Upstash's per-
+// request limit (50MB on our plan) and to stay within the 10s pipeline
+// timeout in defaultRedisPipeline. 500 commands × ~1.2KB worst-case
+// per response = ~600KB per chunk — same chunking pattern used by
+// server/worldmonitor/resilience/v1/_shared.ts (SET_BATCH=30, smaller
+// because per-key payload there is much larger).
+const STORY_TRACK_HGETALL_BATCH = 500;
+
+async function readStoryTracksChunked(hashes) {
+  const out = [];
+  for (let i = 0; i < hashes.length; i += STORY_TRACK_HGETALL_BATCH) {
+    const chunk = hashes.slice(i, i + STORY_TRACK_HGETALL_BATCH);
+    const partial = await upstashPipeline(
+      chunk.map((h) => ['HGETALL', `story:track:v1:${h}`]),
+    );
+    out.push(...partial);
+  }
+  return out;
+}
+
 async function buildDigest(rule, windowStartMs) {
   const variant = rule.variant ?? 'full';
   const lang = rule.lang ?? 'en';
@@ -451,9 +477,7 @@ async function buildDigest(rule, windowStartMs) {
   );
   if (!Array.isArray(hashes) || hashes.length === 0) return null;
 
-  const trackResults = await upstashPipeline(
-    hashes.map((h) => ['HGETALL', `story:track:v1:${h}`]),
-  );
+  const trackResults = await readStoryTracksChunked(hashes);
 
   // READ-time freshness cutoff is anchored to the rule's own digest
   // window. Daily user (24h window) → 48h cutoff; weekly user (7d

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -64,6 +64,7 @@ import {
 } from './lib/brief-dedup.mjs';
 import { stripSourceSuffix } from './lib/brief-dedup-jaccard.mjs';
 import { writeReplayLog } from './lib/brief-dedup-replay-log.mjs';
+import { readStoryTracksChunked } from './lib/story-track-batch-reader.mjs';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -441,52 +442,6 @@ function matchesSensitivity(ruleSensitivity, severity) {
 // is imported from the Jaccard module so the text/HTML formatters
 // below keep their current per-story title cleanup.
 
-// Chunked HGETALL over story:track:v1:<hash>. An accumulator ZSET can
-// hold tens of thousands of hashes (per-language `:full:<lang>` ZSETs
-// observed at 17K-21K entries — bounded only by ingest volume ×
-// DIGEST_ACCUMULATOR_TTL). Each story:track:v1 hash averages ~380B but
-// can reach ~1.2KB, so an unbatched pipeline RESPONSE for the largest
-// accumulator already crosses 7MB and grows linearly with ingest. Chunk
-// to keep each /pipeline call's response well under Upstash's per-
-// request limit (50MB on our plan) and to stay within the 10s pipeline
-// timeout in defaultRedisPipeline. 500 commands × ~1.2KB worst-case
-// per response = ~600KB per chunk — same chunking pattern used by
-// server/worldmonitor/resilience/v1/_shared.ts (SET_BATCH=30, smaller
-// because per-key payload there is much larger).
-const STORY_TRACK_HGETALL_BATCH = 500;
-
-async function readStoryTracksChunked(hashes) {
-  const out = [];
-  for (let i = 0; i < hashes.length; i += STORY_TRACK_HGETALL_BATCH) {
-    const chunk = hashes.slice(i, i + STORY_TRACK_HGETALL_BATCH);
-    const partial = await upstashPipeline(
-      chunk.map((h) => ['HGETALL', `story:track:v1:${h}`]),
-    );
-    // upstashPipeline returns [] on HTTP error, and a short result on
-    // any other shape mismatch. The downstream caller pairs
-    // trackResults[i] with hashes[i], so a missing chunk would shift
-    // every later result onto the wrong hash — publishing stories with
-    // wrong source-set / embedding-cache linkage. Bail out: pad the
-    // remaining positions with null-result placeholders so callers see
-    // the same row-skip behaviour as the legacy single-pipeline failure
-    // (no rows pass `Array.isArray(raw)` → buildDigest returns null).
-    // Stop iterating so an outage doesn't burn the full pipeline budget
-    // on N × 15s timeouts.
-    if (Array.isArray(partial) && partial.length === chunk.length) {
-      out.push(...partial);
-      continue;
-    }
-    const failedAt = i / STORY_TRACK_HGETALL_BATCH;
-    const got = Array.isArray(partial) ? partial.length : 'non-array';
-    console.warn(
-      `[digest] readStoryTracksChunked: chunk ${failedAt} returned ${got} of ${chunk.length} expected — padding remaining ${hashes.length - i} entries as misses and aborting`,
-    );
-    for (let j = i; j < hashes.length; j++) out.push({ result: null });
-    return out;
-  }
-  return out;
-}
-
 async function buildDigest(rule, windowStartMs) {
   const variant = rule.variant ?? 'full';
   const lang = rule.lang ?? 'en';
@@ -497,7 +452,7 @@ async function buildDigest(rule, windowStartMs) {
   );
   if (!Array.isArray(hashes) || hashes.length === 0) return null;
 
-  const trackResults = await readStoryTracksChunked(hashes);
+  const trackResults = await readStoryTracksChunked(hashes, upstashPipeline);
 
   // READ-time freshness cutoff is anchored to the rule's own digest
   // window. Daily user (24h window) → 48h cutoff; weekly user (7d

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -452,7 +452,16 @@ async function buildDigest(rule, windowStartMs) {
   );
   if (!Array.isArray(hashes) || hashes.length === 0) return null;
 
+  // null = at least one HGETALL chunk failed. Returning null here
+  // matches the legacy semantic (single-pipeline failure produced
+  // an empty story list → null buildDigest result → cron skipped
+  // sending the digest for this user/variant). The alternative —
+  // shipping a digest built from only the successfully-fetched
+  // chunks — would silently drop stories AND mark the slot as sent,
+  // suppressing retry on the next tick. See:
+  //   scripts/lib/story-track-batch-reader.mjs (bail-on-failure rationale).
   const trackResults = await readStoryTracksChunked(hashes, upstashPipeline);
+  if (trackResults === null) return null;
 
   // READ-time freshness cutoff is anchored to the rule's own digest
   // window. Daily user (24h window) → 48h cutoff; weekly user (7d

--- a/tests/story-track-batch-reader.test.mjs
+++ b/tests/story-track-batch-reader.test.mjs
@@ -1,0 +1,182 @@
+/**
+ * Regression tests for scripts/lib/story-track-batch-reader.mjs.
+ *
+ * The contract under test: when the upstream pipeline returns a short,
+ * non-array, or empty result for any chunk, the helper MUST preserve
+ * index alignment between the input `hashes` array and the returned
+ * `trackResults` array. The downstream caller in seed-digest-
+ * notifications.mjs::buildDigest pairs `trackResults[i]` with
+ * `hashes[i]` (line `stories.push({ hash: hashes[i], ... })`), so a
+ * shifted result would publish stories with the wrong source-set /
+ * embedding-cache linkage. Caught in PR #3428 review.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  STORY_TRACK_HGETALL_BATCH,
+  readStoryTracksChunked,
+} from '../scripts/lib/story-track-batch-reader.mjs';
+
+// Build N synthetic hashes that differ enough to be visible in failures.
+function hashes(n) {
+  return Array.from({ length: n }, (_, i) => `h${String(i).padStart(4, '0')}`);
+}
+
+// Stub pipelineFn that returns a deterministic per-command result.
+function ok(commands) {
+  return commands.map((cmd) => ({
+    result: ['title', `t-${cmd[1]}`, 'severity', 'high'],
+  }));
+}
+
+describe('readStoryTracksChunked', () => {
+  describe('happy path', () => {
+    it('returns one entry per hash when every chunk succeeds', async () => {
+      const input = hashes(7);
+      const out = await readStoryTracksChunked(input, ok, { batchSize: 3 });
+      assert.equal(out.length, input.length);
+      // Spot-check alignment: the synthetic title carries the cache
+      // key, which carries the hash. trackResults[i] must pair with
+      // hashes[i].
+      for (let i = 0; i < input.length; i++) {
+        assert.deepEqual(out[i], {
+          result: ['title', `t-story:track:v1:${input[i]}`, 'severity', 'high'],
+        });
+      }
+    });
+
+    it('handles empty hash list without calling the pipeline', async () => {
+      let callCount = 0;
+      const counting = (cmds) => {
+        callCount++;
+        return ok(cmds);
+      };
+      const out = await readStoryTracksChunked([], counting, { batchSize: 3 });
+      assert.deepEqual(out, []);
+      assert.equal(callCount, 0);
+    });
+
+    it('handles a single full chunk in one call', async () => {
+      let callCount = 0;
+      const counting = (cmds) => {
+        callCount++;
+        return ok(cmds);
+      };
+      const out = await readStoryTracksChunked(hashes(3), counting, { batchSize: 3 });
+      assert.equal(out.length, 3);
+      assert.equal(callCount, 1);
+    });
+  });
+
+  describe('partial failure — index alignment', () => {
+    it('pads remaining positions with null-result placeholders when a middle chunk returns []', async () => {
+      const input = hashes(7); // chunks: [0..2], [3..5], [6]
+      const calls = [];
+      const flaky = (cmds) => {
+        calls.push(cmds.length);
+        // Fail the SECOND chunk (commands for hashes h0003..h0005).
+        if (cmds[0][1] === 'story:track:v1:h0003') return [];
+        return ok(cmds);
+      };
+      const log = []; // capture warnings
+      const out = await readStoryTracksChunked(input, flaky, {
+        batchSize: 3,
+        log: (line) => log.push(line),
+      });
+
+      // Length MUST equal input.length so trackResults[i] ↔ hashes[i]
+      // remains valid in the caller.
+      assert.equal(out.length, input.length);
+
+      // First chunk's three positions hold real results.
+      for (let i = 0; i < 3; i++) {
+        assert.deepEqual(out[i], {
+          result: ['title', `t-story:track:v1:${input[i]}`, 'severity', 'high'],
+        });
+      }
+      // Failed chunk's three positions are null-result placeholders.
+      for (let i = 3; i < 6; i++) {
+        assert.deepEqual(out[i], { result: null });
+      }
+      // The trailing chunk MUST also be padded (we abort, not skip-and-
+      // continue) — otherwise a later success would re-introduce drift
+      // by shifting one entry into position 6.
+      assert.deepEqual(out[6], { result: null });
+
+      // Pipeline was called exactly once for chunk 0 and once for the
+      // failing chunk 1 — chunk 2 was skipped to preserve the dedup
+      // wall-clock budget.
+      assert.equal(calls.length, 2);
+      assert.equal(calls[0], 3);
+      assert.equal(calls[1], 3);
+
+      // One warning, surfacing the failed chunk index + observed length.
+      assert.equal(log.length, 1);
+      assert.match(log[0], /chunk 1 returned 0 of 3 expected/);
+      assert.match(log[0], /padding remaining 4 entries/);
+    });
+
+    it('treats a non-array (null / undefined) pipeline result as failure', async () => {
+      const input = hashes(5); // chunks: [0..2], [3..4]
+      const flaky = (cmds) => (cmds[0][1] === 'story:track:v1:h0000' ? null : ok(cmds));
+      const log = [];
+      const out = await readStoryTracksChunked(input, flaky, {
+        batchSize: 3,
+        log: (line) => log.push(line),
+      });
+      assert.equal(out.length, input.length);
+      // Every position is a placeholder — first chunk failed, so we
+      // abort before reaching the second chunk.
+      for (const cell of out) assert.deepEqual(cell, { result: null });
+      assert.match(log[0], /returned non-array of 3 expected/);
+    });
+
+    it('treats a short array (partial response) as failure', async () => {
+      const input = hashes(6); // chunks: [0..2], [3..5]
+      const flaky = (cmds) => {
+        if (cmds[0][1] === 'story:track:v1:h0003') {
+          // Upstream returned only 2 of 3 expected results.
+          return ok(cmds.slice(0, 2));
+        }
+        return ok(cmds);
+      };
+      const log = [];
+      const out = await readStoryTracksChunked(input, flaky, {
+        batchSize: 3,
+        log: (line) => log.push(line),
+      });
+      assert.equal(out.length, input.length);
+      // First chunk OK, rest padded.
+      assert.deepEqual(out[0].result.slice(0, 2), ['title', 't-story:track:v1:h0000']);
+      for (let i = 3; i < 6; i++) assert.deepEqual(out[i], { result: null });
+      assert.match(log[0], /chunk 1 returned 2 of 3 expected/);
+    });
+
+    it('aborts on the FIRST chunk failure when the very first chunk fails', async () => {
+      let callCount = 0;
+      const counting = () => {
+        callCount++;
+        return [];
+      };
+      const out = await readStoryTracksChunked(hashes(10), counting, {
+        batchSize: 3,
+        log: () => {},
+      });
+      assert.equal(out.length, 10);
+      for (const cell of out) assert.deepEqual(cell, { result: null });
+      // Only one pipeline call — we did NOT keep retrying chunks 2/3/4.
+      assert.equal(callCount, 1);
+    });
+  });
+
+  describe('default batch size', () => {
+    it('exports STORY_TRACK_HGETALL_BATCH=500 (load-bearing for 50MB request budget)', () => {
+      // Documenting the constant in a test guards against an absent-
+      // minded bump to e.g. 5000 that would re-introduce the 50MB body
+      // problem on the largest accumulator.
+      assert.equal(STORY_TRACK_HGETALL_BATCH, 500);
+    });
+  });
+});

--- a/tests/story-track-batch-reader.test.mjs
+++ b/tests/story-track-batch-reader.test.mjs
@@ -1,14 +1,25 @@
 /**
  * Regression tests for scripts/lib/story-track-batch-reader.mjs.
  *
- * The contract under test: when the upstream pipeline returns a short,
- * non-array, or empty result for any chunk, the helper MUST preserve
- * index alignment between the input `hashes` array and the returned
- * `trackResults` array. The downstream caller in seed-digest-
- * notifications.mjs::buildDigest pairs `trackResults[i]` with
- * `hashes[i]` (line `stories.push({ hash: hashes[i], ... })`), so a
- * shifted result would publish stories with the wrong source-set /
- * embedding-cache linkage. Caught in PR #3428 review.
+ * Two interlocking contracts under test:
+ *
+ *   1. Per-chunk index alignment: `trackResults[i]` must always pair
+ *      with `hashes[i]` in the caller. A short / non-array chunk
+ *      response that's blindly spread into the output would shift
+ *      every later position onto the wrong hash → publish stories
+ *      with wrong source-set / embedding-cache linkage.
+ *
+ *   2. All-or-nothing on failure: returning a partially-filled array
+ *      (even one with placeholders) regresses the legacy semantic
+ *      where a single-pipeline failure made buildDigest return null
+ *      → cron skipped sending the digest for that user/variant. With
+ *      a partial array, the cron would ship a digest built from the
+ *      successful chunks AND mark `digest:last-sent:v1` as sent,
+ *      suppressing retry on the next tick. So the helper returns
+ *      null on any chunk failure; the caller must treat null as
+ *      "skip this digest tick".
+ *
+ * Both contracts caught in PR #3428 review.
  */
 
 import { describe, it } from 'node:test';
@@ -70,8 +81,8 @@ describe('readStoryTracksChunked', () => {
     });
   });
 
-  describe('partial failure — index alignment', () => {
-    it('pads remaining positions with null-result placeholders when a middle chunk returns []', async () => {
+  describe('partial failure — returns null (all-or-nothing)', () => {
+    it('returns null and discards prior success when a middle chunk returns []', async () => {
       const input = hashes(7); // chunks: [0..2], [3..5], [6]
       const calls = [];
       const flaky = (cmds) => {
@@ -86,24 +97,10 @@ describe('readStoryTracksChunked', () => {
         log: (line) => log.push(line),
       });
 
-      // Length MUST equal input.length so trackResults[i] ↔ hashes[i]
-      // remains valid in the caller.
-      assert.equal(out.length, input.length);
-
-      // First chunk's three positions hold real results.
-      for (let i = 0; i < 3; i++) {
-        assert.deepEqual(out[i], {
-          result: ['title', `t-story:track:v1:${input[i]}`, 'severity', 'high'],
-        });
-      }
-      // Failed chunk's three positions are null-result placeholders.
-      for (let i = 3; i < 6; i++) {
-        assert.deepEqual(out[i], { result: null });
-      }
-      // The trailing chunk MUST also be padded (we abort, not skip-and-
-      // continue) — otherwise a later success would re-introduce drift
-      // by shifting one entry into position 6.
-      assert.deepEqual(out[6], { result: null });
+      // null signals "skip this digest tick" — caller must NOT ship a
+      // digest built from chunk 0's results alone (would mark slot as
+      // sent, suppress retry on next tick, and silently drop stories).
+      assert.equal(out, null);
 
       // Pipeline was called exactly once for chunk 0 and once for the
       // failing chunk 1 — chunk 2 was skipped to preserve the dedup
@@ -115,10 +112,10 @@ describe('readStoryTracksChunked', () => {
       // One warning, surfacing the failed chunk index + observed length.
       assert.equal(log.length, 1);
       assert.match(log[0], /chunk 1 returned 0 of 3 expected/);
-      assert.match(log[0], /padding remaining 4 entries/);
+      assert.match(log[0], /aborting and returning null/);
     });
 
-    it('treats a non-array (null / undefined) pipeline result as failure', async () => {
+    it('returns null when a non-array (null / undefined) pipeline result is observed', async () => {
       const input = hashes(5); // chunks: [0..2], [3..4]
       const flaky = (cmds) => (cmds[0][1] === 'story:track:v1:h0000' ? null : ok(cmds));
       const log = [];
@@ -126,16 +123,15 @@ describe('readStoryTracksChunked', () => {
         batchSize: 3,
         log: (line) => log.push(line),
       });
-      assert.equal(out.length, input.length);
-      // Every position is a placeholder — first chunk failed, so we
-      // abort before reaching the second chunk.
-      for (const cell of out) assert.deepEqual(cell, { result: null });
+      assert.equal(out, null);
       assert.match(log[0], /returned non-array of 3 expected/);
     });
 
-    it('treats a short array (partial response) as failure', async () => {
+    it('returns null when a short array (partial response) is observed', async () => {
       const input = hashes(6); // chunks: [0..2], [3..5]
+      const calls = [];
       const flaky = (cmds) => {
+        calls.push(cmds.length);
         if (cmds[0][1] === 'story:track:v1:h0003') {
           // Upstream returned only 2 of 3 expected results.
           return ok(cmds.slice(0, 2));
@@ -147,14 +143,14 @@ describe('readStoryTracksChunked', () => {
         batchSize: 3,
         log: (line) => log.push(line),
       });
-      assert.equal(out.length, input.length);
-      // First chunk OK, rest padded.
-      assert.deepEqual(out[0].result.slice(0, 2), ['title', 't-story:track:v1:h0000']);
-      for (let i = 3; i < 6; i++) assert.deepEqual(out[i], { result: null });
+      // Even though chunk 0 succeeded, the partial chunk 1 voids the
+      // whole call — caller must skip the digest tick.
+      assert.equal(out, null);
+      assert.equal(calls.length, 2); // chunk 0 + failing chunk 1, no chunk 2 retry
       assert.match(log[0], /chunk 1 returned 2 of 3 expected/);
     });
 
-    it('aborts on the FIRST chunk failure when the very first chunk fails', async () => {
+    it('returns null and aborts after exactly one call when the first chunk fails', async () => {
       let callCount = 0;
       const counting = () => {
         callCount++;
@@ -164,8 +160,7 @@ describe('readStoryTracksChunked', () => {
         batchSize: 3,
         log: () => {},
       });
-      assert.equal(out.length, 10);
-      for (const cell of out) assert.deepEqual(cell, { result: null });
+      assert.equal(out, null);
       // Only one pipeline call — we did NOT keep retrying chunks 2/3/4.
       assert.equal(callCount, 1);
     });


### PR DESCRIPTION
## Why

Last week (PR #3200, enabled #3234) the digest cron added embedding-based dedup. As a side effect, two Upstash REST `/pipeline` calls in the digest path are now **unbatched** and scale linearly with ingest volume. Both will silently exceed Upstash's 50MB per-request limit as the accumulator and embedding cache grow.

This PR adds chunking to both — same pattern as sibling seeders that already chunk (`PIPE_BATCH=50` in `seed-resilience-intervals.mjs`, `seed-comtrade-bilateral-hs4.mjs`; `SET_BATCH=30` in `server/worldmonitor/resilience/v1/_shared.ts:838`).

### Sizing evidence (live STRLEN/SCAN, 2026-04-26)

```
brief:emb:v1:*           8,185 keys × 9,410B avg  = 73.5 MB total
                                           max     = 9,609B
digest:accumulator:v1:full:es  ZCARD       = 21,032
digest:accumulator:v1:full:en  ZCARD       = 18,021
... 17 langs at 17K-21K each
story:track:v1:*         20,073 hashes × 382B avg = 7.6 MB total
                                          max     = 1,179B
```

- **`embedBatch.cacheWrites`** — at ~9.4KB per `SET` command, 5,300 misses in a single embedBatch hits the 50MB body limit. Steady-state ticks stay under (digest log peak: `stories=1015` → ~10MB pipeline), but a cold-cache or post-feed-expansion tick can plausibly burst higher. Cache writes are best-effort, so a silent reject also drops writes with no correctness signal.
- **`buildDigest` HGETALL** — already at ~7MB response body for the largest accumulator (`:full:es` at 21K hashes × 382B avg). Bounded only by `DIGEST_ACCUMULATOR_TTL × ingest rate` — no natural ceiling short of the per-request limit.

## What changed

### `scripts/lib/brief-embedding.mjs`

Wrap the existing best-effort `await pipelineImpl(cacheWrites)` in a 200-command chunking loop (~1.9MB body per request).

### `scripts/seed-digest-notifications.mjs`

Extract `readStoryTracksChunked(hashes)` helper (500-command HGETALL chunks, ~600KB worst-case response per chunk). Helper is split out so `buildDigest` cognitive complexity stays at 52 — matches `main`. Biome warns >50, but the warning is pre-existing.

## Behaviour preservation

- **Embedding write path**: same try/catch wrapper, first failing chunk aborts subsequent writes (same as today's "one failed pipeline → no cache writes for this tick"). On small inputs the loop runs once with the full set.
- **buildDigest read path**: helper returns the same `Array<{result?: ...}>` shape `upstashPipeline` returns, accumulating chunks via `push(...partial)`. Per-element index alignment with `hashes` is preserved. Throws on upstream failure (same as today). On small inputs the loop runs once.

## Test plan

- [x] `node --test tests/brief-dedup-embedding.test.mjs` (61 pass) — exercises `embedBatch` with the stub `pipelineImpl`; chunked write path is invariant under the stub.
- [x] `node --test tests/digest-* tests/brief-dedup-replay-log.test.mjs tests/brief-from-digest-stories.test.mjs` (144 pass).
- [x] Combined: 205 tests pass, 0 fail.
- [x] `biome check` on both files — only pre-existing complexity warnings on `buildDigest` (52, unchanged) and `main` (88, unchanged).
- [ ] Production tick: confirm digest cron keeps producing `[digest] dedup mode=embed clustering=single stories=N clusters=M` log lines after merge.

## Risk

Very low. Both edits are pure scope-tightening — same effective writes/reads, just more, smaller HTTP requests. Worst case if my arithmetic is off: the cron does N/200 (or N/500) extra round-trips per call instead of one. At today's sizes that's ~5 extra requests per embedBatch call and ~40 extra requests per `buildDigest` for the largest accumulator — well within the existing 30s pipeline timeout budget and Upstash request rate.

## Out of scope

The `SMEMBERS` pipeline at `seed-digest-notifications.mjs:620` (`allSourceCmds` after dedup) is also unbatched but bounded by `DIGEST_MAX_ITEMS=30 × cluster.mergedHashes.length` — currently safe (~21K commands max, ~1MB body). Worth chunking as a follow-up if accumulators keep growing; not in this PR to keep the diff focused.