### PR TITLE
perf(aviation): cache searchGoogleFlights + getYoutubeLiveStreamInfo

### DIFF
--- a/server/worldmonitor/aviation/v1/get-youtube-live-stream-info.ts
+++ b/server/worldmonitor/aviation/v1/get-youtube-live-stream-info.ts
@@ -182,7 +182,12 @@ export const getYoutubeLiveStreamInfo: AviationServiceHandler['getYoutubeLiveStr
     return emptyResult('Missing channel or videoId');
   }
 
-  const cacheKey = `aviation:yt-live:${videoId || channel}:v1`;
+  // Distinct request shapes (videoId-only, channel-only, both) MUST get distinct
+  // cache keys — a negative sentinel for one shape must not suppress the others.
+  // Channel handles normalized by stripping leading '@' so `foo` and `@foo` (which
+  // hit the same upstream via tryChannelScrape) share a cache entry.
+  const normalizedChannel = channel.replace(/^@/, '');
+  const cacheKey = `aviation:yt-live:vid:${videoId}:ch:${normalizedChannel}:v1`;
 
   try {
     const cached = await cachedFetchJson<GetYoutubeLiveStreamInfoResponse>(

--- a/server/worldmonitor/aviation/v1/get-youtube-live-stream-info.ts
+++ b/server/worldmonitor/aviation/v1/get-youtube-live-stream-info.ts
@@ -189,17 +189,13 @@ export const getYoutubeLiveStreamInfo: AviationServiceHandler['getYoutubeLiveStr
   const normalizedChannel = channel.replace(/^@/, '');
   const cacheKey = `aviation:yt-live:vid:${videoId}:ch:${normalizedChannel}:v1`;
 
-  try {
-    const cached = await cachedFetchJson<GetYoutubeLiveStreamInfoResponse>(
-      cacheKey,
-      POSITIVE_TTL,
-      () => fetchLiveStreamInfo(channel, videoId, params.toString()),
-      NEGATIVE_TTL,
-    );
-    if (cached) return cached;
-  } catch {
-    // Redis unavailable — fall through to live response.
-  }
+  const cached = await cachedFetchJson<GetYoutubeLiveStreamInfoResponse>(
+    cacheKey,
+    POSITIVE_TTL,
+    () => fetchLiveStreamInfo(channel, videoId, params.toString()),
+    NEGATIVE_TTL,
+  );
+  if (cached) return cached;
 
   return emptyResult('Failed to detect live status', Boolean(channel));
 };

--- a/server/worldmonitor/aviation/v1/get-youtube-live-stream-info.ts
+++ b/server/worldmonitor/aviation/v1/get-youtube-live-stream-info.ts
@@ -6,6 +6,10 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { getRelayBaseUrl, getRelayHeaders } from './_shared';
 import { CHROME_UA } from '../../../_shared/constants';
+import { cachedFetchJson } from '../../../_shared/redis';
+
+const POSITIVE_TTL = 60;
+const NEGATIVE_TTL = 30;
 
 interface YoutubeRelayPayload {
   videoId?: string;
@@ -46,6 +50,122 @@ function parseRelayPayload(payload: YoutubeRelayPayload): GetYoutubeLiveStreamIn
   };
 }
 
+async function tryRelay(query: string): Promise<GetYoutubeLiveStreamInfoResponse | null> {
+  const relayBaseUrl = getRelayBaseUrl();
+  if (!relayBaseUrl) return null;
+  try {
+    const relayResponse = await fetch(`${relayBaseUrl}/youtube-live?${query}`, {
+      headers: getRelayHeaders({ 'User-Agent': 'WorldMonitor-Server/1.0' }),
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (!relayResponse.ok) return null;
+    const relayPayload = (await relayResponse.json()) as YoutubeRelayPayload;
+    return parseRelayPayload(relayPayload);
+  } catch {
+    return null;
+  }
+}
+
+async function tryOEmbed(videoId: string): Promise<GetYoutubeLiveStreamInfoResponse | null> {
+  if (!/^[A-Za-z0-9_-]{11}$/.test(videoId)) return null;
+  try {
+    const oembedResponse = await fetch(
+      `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoId}&format=json`,
+      { headers: { 'User-Agent': CHROME_UA }, signal: AbortSignal.timeout(5_000) },
+    );
+    if (!oembedResponse.ok) return null;
+    const payload = (await oembedResponse.json()) as YoutubeOEmbedPayload;
+    return {
+      videoId,
+      // OEmbed confirms video/channel existence, not live status.
+      isLive: false,
+      channelExists: true,
+      channelName: payload.author_name || '',
+      hlsUrl: '',
+      title: payload.title || '',
+      error: '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parseChannelHtml(html: string): GetYoutubeLiveStreamInfoResponse {
+  const channelExists = html.includes('"channelId"') || html.includes('og:url');
+
+  let channelName = '';
+  const ownerMatch = html.match(/"ownerChannelName"\s*:\s*"([^"]+)"/);
+  if (ownerMatch?.[1]) {
+    channelName = ownerMatch[1];
+  } else {
+    const authorMatch = html.match(/"author"\s*:\s*"([^"]+)"/);
+    if (authorMatch?.[1]) channelName = authorMatch[1];
+  }
+
+  let detectedVideoId = '';
+  const detailsIndex = html.indexOf('"videoDetails"');
+  if (detailsIndex !== -1) {
+    const detailsBlock = html.substring(detailsIndex, detailsIndex + 5_000);
+    const videoIdMatch = detailsBlock.match(/"videoId":"([a-zA-Z0-9_-]{11})"/);
+    const isLiveMatch = detailsBlock.match(/"isLive"\s*:\s*true/);
+    if (videoIdMatch?.[1] && isLiveMatch) {
+      detectedVideoId = videoIdMatch[1];
+    }
+  }
+
+  let hlsUrl = '';
+  const hlsMatch = html.match(/"hlsManifestUrl"\s*:\s*"([^"]+)"/);
+  if (hlsMatch?.[1] && detectedVideoId) {
+    hlsUrl = hlsMatch[1].replace(/\\u0026/g, '&');
+  }
+
+  return {
+    videoId: detectedVideoId,
+    isLive: Boolean(detectedVideoId),
+    channelExists,
+    channelName,
+    hlsUrl,
+    title: '',
+    error: '',
+  };
+}
+
+async function tryChannelScrape(channel: string): Promise<GetYoutubeLiveStreamInfoResponse | null> {
+  try {
+    const channelHandle = channel.startsWith('@') ? channel : `@${channel}`;
+    const response = await fetch(`https://www.youtube.com/${channelHandle}/live`, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36' },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) return null;
+    return parseChannelHtml(await response.text());
+  } catch {
+    return null;
+  }
+}
+
+async function fetchLiveStreamInfo(
+  channel: string,
+  videoId: string,
+  query: string,
+): Promise<GetYoutubeLiveStreamInfoResponse | null> {
+  const relayResult = await tryRelay(query);
+  if (relayResult) return relayResult;
+
+  if (videoId) {
+    const oembedResult = await tryOEmbed(videoId);
+    if (oembedResult) return oembedResult;
+  }
+
+  if (channel) {
+    const scrapeResult = await tryChannelScrape(channel);
+    if (scrapeResult) return scrapeResult;
+  }
+
+  return null;
+}
+
 /**
  * GetYoutubeLiveStreamInfo detects if a YouTube channel is live, with relay and direct fallback.
  */
@@ -62,104 +182,18 @@ export const getYoutubeLiveStreamInfo: AviationServiceHandler['getYoutubeLiveStr
     return emptyResult('Missing channel or videoId');
   }
 
-  const relayBaseUrl = getRelayBaseUrl();
-  if (relayBaseUrl) {
-    try {
-      const relayResponse = await fetch(`${relayBaseUrl}/youtube-live?${params.toString()}`, {
-        headers: getRelayHeaders({ 'User-Agent': 'WorldMonitor-Server/1.0' }),
-        signal: AbortSignal.timeout(8_000),
-      });
-      if (relayResponse.ok) {
-        const relayPayload = (await relayResponse.json()) as YoutubeRelayPayload;
-        return parseRelayPayload(relayPayload);
-      }
-    } catch {
-      // Fall through to direct checks.
-    }
-  }
+  const cacheKey = `aviation:yt-live:${videoId || channel}:v1`;
 
-  if (videoId && /^[A-Za-z0-9_-]{11}$/.test(videoId)) {
-    try {
-      const oembedResponse = await fetch(
-        `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoId}&format=json`,
-        {
-          headers: {
-            'User-Agent': CHROME_UA,
-          },
-          signal: AbortSignal.timeout(5_000),
-        },
-      );
-      if (oembedResponse.ok) {
-        const payload = (await oembedResponse.json()) as YoutubeOEmbedPayload;
-        return {
-          videoId,
-          // OEmbed confirms video/channel existence, not live status.
-          isLive: false,
-          channelExists: true,
-          channelName: payload.author_name || '',
-          hlsUrl: '',
-          title: payload.title || '',
-          error: '',
-        };
-      }
-    } catch {
-      // Fall through to channel scrape fallback.
-    }
-  }
-
-  if (channel) {
-    try {
-      const channelHandle = channel.startsWith('@') ? channel : `@${channel}`;
-      const response = await fetch(`https://www.youtube.com/${channelHandle}/live`, {
-        headers: {
-          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
-        },
-        redirect: 'follow',
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (response.ok) {
-        const html = await response.text();
-        const channelExists = html.includes('"channelId"') || html.includes('og:url');
-
-        let channelName = '';
-        const ownerMatch = html.match(/"ownerChannelName"\s*:\s*"([^"]+)"/);
-        if (ownerMatch?.[1]) {
-          channelName = ownerMatch[1];
-        } else {
-          const authorMatch = html.match(/"author"\s*:\s*"([^"]+)"/);
-          if (authorMatch?.[1]) channelName = authorMatch[1];
-        }
-
-        let detectedVideoId = '';
-        const detailsIndex = html.indexOf('"videoDetails"');
-        if (detailsIndex !== -1) {
-          const detailsBlock = html.substring(detailsIndex, detailsIndex + 5_000);
-          const videoIdMatch = detailsBlock.match(/"videoId":"([a-zA-Z0-9_-]{11})"/);
-          const isLiveMatch = detailsBlock.match(/"isLive"\s*:\s*true/);
-          if (videoIdMatch?.[1] && isLiveMatch) {
-            detectedVideoId = videoIdMatch[1];
-          }
-        }
-
-        let hlsUrl = '';
-        const hlsMatch = html.match(/"hlsManifestUrl"\s*:\s*"([^"]+)"/);
-        if (hlsMatch?.[1] && detectedVideoId) {
-          hlsUrl = hlsMatch[1].replace(/\\u0026/g, '&');
-        }
-
-        return {
-          videoId: detectedVideoId,
-          isLive: Boolean(detectedVideoId),
-          channelExists,
-          channelName,
-          hlsUrl,
-          title: '',
-          error: '',
-        };
-      }
-    } catch {
-      // Fall through.
-    }
+  try {
+    const cached = await cachedFetchJson<GetYoutubeLiveStreamInfoResponse>(
+      cacheKey,
+      POSITIVE_TTL,
+      () => fetchLiveStreamInfo(channel, videoId, params.toString()),
+      NEGATIVE_TTL,
+    );
+    if (cached) return cached;
+  } catch {
+    // Redis unavailable — fall through to live response.
   }
 
   return emptyResult('Failed to detect live status', Boolean(channel));

--- a/server/worldmonitor/aviation/v1/search-google-flights.ts
+++ b/server/worldmonitor/aviation/v1/search-google-flights.ts
@@ -26,6 +26,8 @@ export async function searchGoogleFlights(
     return { flights: [], degraded: true, error: 'relay unavailable' };
   }
 
+  // Clamp once so equivalent relay calls (e.g. passengers=99 → 9) share a cache entry.
+  const passengers = Math.max(1, Math.min(req.passengers ?? 1, 9));
   const airlines = parseStringArray(req.airlines);
   const params = new URLSearchParams({
     origin,
@@ -36,7 +38,7 @@ export async function searchGoogleFlights(
     ...(req.maxStops ? { max_stops: req.maxStops } : {}),
     ...(req.departureWindow ? { departure_window: req.departureWindow } : {}),
     ...(req.sortBy ? { sort_by: req.sortBy } : {}),
-    passengers: String(Math.max(1, Math.min(req.passengers ?? 1, 9))),
+    passengers: String(passengers),
   });
   for (const airline of airlines) {
     params.append('airlines', airline);
@@ -45,7 +47,7 @@ export async function searchGoogleFlights(
   // Cache key uses a sorted-airlines axis so input order doesn't fragment cache hits;
   // the relay still receives airlines in the caller's order via `params`.
   const sortedAirlinesKey = [...airlines].sort().join(',');
-  const cacheKey = `aviation:gf:${origin}:${destination}:${departureDate}:${req.returnDate ?? ''}:${req.cabinClass ?? ''}:${req.maxStops ?? ''}:${req.departureWindow ?? ''}:${req.sortBy ?? ''}:${req.passengers ?? 1}:${sortedAirlinesKey}:v1`;
+  const cacheKey = `aviation:gf:${origin}:${destination}:${departureDate}:${req.returnDate ?? ''}:${req.cabinClass ?? ''}:${req.maxStops ?? ''}:${req.departureWindow ?? ''}:${req.sortBy ?? ''}:${passengers}:${sortedAirlinesKey}:v1`;
 
   try {
     const data = await cachedFetchJson<{ flights: unknown[] }>(

--- a/server/worldmonitor/aviation/v1/search-google-flights.ts
+++ b/server/worldmonitor/aviation/v1/search-google-flights.ts
@@ -5,6 +5,9 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
 import { parseStringArray } from '../../../_shared/parse-string-array';
+import { cachedFetchJson } from '../../../_shared/redis';
+
+const CACHE_TTL = 600;
 
 export async function searchGoogleFlights(
   _ctx: ServerContext,
@@ -23,33 +26,45 @@ export async function searchGoogleFlights(
     return { flights: [], degraded: true, error: 'relay unavailable' };
   }
 
+  const airlines = parseStringArray(req.airlines);
+  const params = new URLSearchParams({
+    origin,
+    destination,
+    departure_date: departureDate,
+    ...(req.returnDate ? { return_date: req.returnDate } : {}),
+    ...(req.cabinClass ? { cabin_class: req.cabinClass } : {}),
+    ...(req.maxStops ? { max_stops: req.maxStops } : {}),
+    ...(req.departureWindow ? { departure_window: req.departureWindow } : {}),
+    ...(req.sortBy ? { sort_by: req.sortBy } : {}),
+    passengers: String(Math.max(1, Math.min(req.passengers ?? 1, 9))),
+  });
+  for (const airline of airlines) {
+    params.append('airlines', airline);
+  }
+
+  // Cache key uses a sorted-airlines axis so input order doesn't fragment cache hits;
+  // the relay still receives airlines in the caller's order via `params`.
+  const sortedAirlinesKey = [...airlines].sort().join(',');
+  const cacheKey = `aviation:gf:${origin}:${destination}:${departureDate}:${req.returnDate ?? ''}:${req.cabinClass ?? ''}:${req.maxStops ?? ''}:${req.departureWindow ?? ''}:${req.sortBy ?? ''}:${req.passengers ?? 1}:${sortedAirlinesKey}:v1`;
+
   try {
-    const params = new URLSearchParams({
-      origin,
-      destination,
-      departure_date: departureDate,
-      ...(req.returnDate ? { return_date: req.returnDate } : {}),
-      ...(req.cabinClass ? { cabin_class: req.cabinClass } : {}),
-      ...(req.maxStops ? { max_stops: req.maxStops } : {}),
-      ...(req.departureWindow ? { departure_window: req.departureWindow } : {}),
-      ...(req.sortBy ? { sort_by: req.sortBy } : {}),
-      passengers: String(Math.max(1, Math.min(req.passengers ?? 1, 9))),
-    });
-    for (const airline of parseStringArray(req.airlines)) {
-      params.append('airlines', airline);
-    }
+    const data = await cachedFetchJson<{ flights: unknown[] }>(
+      cacheKey,
+      CACHE_TTL,
+      async () => {
+        const resp = await fetch(`${relayBaseUrl}/google-flights/search?${params}`, {
+          headers: getRelayHeaders(),
+          signal: AbortSignal.timeout(20_000),
+        });
+        if (!resp.ok) throw new Error(`relay returned ${resp.status}`);
+        const json = (await resp.json()) as { flights?: unknown[]; error?: string };
+        if (!Array.isArray(json.flights)) throw new Error(json.error ?? 'no results');
+        return { flights: json.flights };
+      },
+    );
 
-    const resp = await fetch(`${relayBaseUrl}/google-flights/search?${params}`, {
-      headers: getRelayHeaders(),
-      signal: AbortSignal.timeout(20_000),
-    });
-    if (!resp.ok) {
-      return { flights: [], degraded: true, error: `relay returned ${resp.status}` };
-    }
-
-    const data = (await resp.json()) as { flights?: unknown[]; error?: string };
-    if (!Array.isArray(data.flights)) {
-      return { flights: [], degraded: true, error: data.error ?? 'no results' };
+    if (!data) {
+      return { flights: [], degraded: true, error: 'no results' };
     }
 
     return {


### PR DESCRIPTION
## Summary

- These were the two of eleven aviation RPCs missing a Redis cache layer. Axiom shows `/api/aviation` P95 sitting around 10 s — ~3× above sibling APIs that read from precomputed seed snapshots — and the uncached 20 s Google Flights scrape + 23 s worst-case 3-tier YouTube fallback were dominating the tail.
- `searchGoogleFlights` now wraps the relay fetch in `cachedFetchJson` with a 10-minute TTL, mirroring the sibling `searchGoogleDates` exactly (same backend, same staleness profile). Cache key uses a sorted-airlines axis so caller-side input order doesn't fragment hits; the relay still receives airlines in caller order (existing wire contract preserved, existing test unchanged).
- `getYoutubeLiveStreamInfo` now wraps the full 3-tier relay → oEmbed → channel-scrape fallback in `cachedFetchJson` with 60 s positive / 30 s negative TTL — mirrors the `trackAircraft` callsign pattern since live status is volatile but expensive to recompute. The fallback chain was extracted into named helpers (`tryRelay`, `tryOEmbed`, `tryChannelScrape`, `parseChannelHtml`) so the fetcher stays under biome's cyclomatic-complexity budget.
- Errors thrown inside the fetcher so transient relay failures aren't poison-cached as empty results; outer `try/catch` preserves the existing degraded-response shapes. Redis unavailable falls through to live behavior.

## Test plan

- [x] `npm run typecheck` (full) — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — pre-existing warnings only, no new diagnostics on changed files
- [x] `npm run test:data` — 7359/7359 pass; existing `tests/google-flights.test.mts` (4 cases) still green and validates the wire-format contract is unchanged
- [x] `node --test tests/edge-functions.test.mjs` — 178/178 pass
- [x] Edge bundle check on every `api/*.js` — clean
- [x] `npm run lint:md` + `version:check` — clean
- [ ] Post-deploy: confirm `/api/aviation` P95 drops in Axiom over the next 24 h once cache warms