### PR TITLE
feat(convex/broadcast): audience-export pipeline for PRO launch

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as alertRules from "../alertRules.js";
 import type * as apiKeys from "../apiKeys.js";
+import type * as broadcast_audienceExport from "../broadcast/audienceExport.js";
 import type * as config_productCatalog from "../config/productCatalog.js";
 import type * as constants from "../constants.js";
 import type * as contactMessages from "../contactMessages.js";
@@ -23,6 +24,7 @@ import type * as lib_entitlements from "../lib/entitlements.js";
 import type * as lib_env from "../lib/env.js";
 import type * as lib_identitySigning from "../lib/identitySigning.js";
 import type * as notificationChannels from "../notificationChannels.js";
+import type * as payments_backfillCustomerNormalizedEmail from "../payments/backfillCustomerNormalizedEmail.js";
 import type * as payments_billing from "../payments/billing.js";
 import type * as payments_cacheActions from "../payments/cacheActions.js";
 import type * as payments_checkout from "../payments/checkout.js";
@@ -45,6 +47,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   alertRules: typeof alertRules;
   apiKeys: typeof apiKeys;
+  "broadcast/audienceExport": typeof broadcast_audienceExport;
   "config/productCatalog": typeof config_productCatalog;
   constants: typeof constants;
   contactMessages: typeof contactMessages;
@@ -58,6 +61,7 @@ declare const fullApi: ApiFromModules<{
   "lib/env": typeof lib_env;
   "lib/identitySigning": typeof lib_identitySigning;
   notificationChannels: typeof notificationChannels;
+  "payments/backfillCustomerNormalizedEmail": typeof payments_backfillCustomerNormalizedEmail;
   "payments/billing": typeof payments_billing;
   "payments/cacheActions": typeof payments_cacheActions;
   "payments/checkout": typeof payments_checkout;

--- a/convex/broadcast/audienceExport.ts
+++ b/convex/broadcast/audienceExport.ts
@@ -2,7 +2,8 @@
  * PRO-launch broadcast — audience export pipeline.
  *
  * Builds the deduped waitlist audience and pushes contacts to a Resend
- * Audience for one-shot launch broadcasting via Resend Broadcasts.
+ * Segment (formerly Audience) for one-shot launch broadcasting via Resend
+ * Broadcasts.
  *
  * Dedup formula:
  *   registrations
@@ -10,31 +11,33 @@
  *     − customers (anyone who has been through Dodo checkout — never pitch
  *       PRO to people who already paid)
  *
- * Join key: `normalizedEmail` (lowercased + trimmed). Requires the
- * customers.normalizedEmail backfill (`payments/backfillCustomerNormalizedEmail:backfill`)
- * to have run; otherwise paid users with un-backfilled rows leak into the send.
+ * Join key: `normalizedEmail` (lowercased + trimmed). Defense in depth:
+ * `getPaidEmails` falls back to deriving the key from `customers.email`
+ * if `normalizedEmail` is missing, so a missed/incomplete backfill no
+ * longer leaks paid users into the audience.
  *
  * Usage (run from CLI; not callable by clients):
  *   npx convex run broadcast/audienceExport:exportProLaunchAudience \
- *     '{"audienceId":"aud_xxx"}'
+ *     '{"segmentId":"seg_xxx"}'
  *
  *   # Subsequent pages — pass the continueCursor from the previous response
  *   npx convex run broadcast/audienceExport:exportProLaunchAudience \
- *     '{"audienceId":"aud_xxx","cursor":"<continueCursor>"}'
+ *     '{"segmentId":"seg_xxx","cursor":"<continueCursor>"}'
  *
  *   # Dry run — counts only, no Resend calls
  *   npx convex run broadcast/audienceExport:exportProLaunchAudience \
- *     '{"audienceId":"aud_xxx","dryRun":true}'
+ *     '{"segmentId":"seg_xxx","dryRun":true}'
  *
- * Re-running a page is safe: Resend's contacts API returns 422
- * `already_exists` for emails already in the audience, which we count
- * separately (not as a failure).
+ * Re-running a page is safe: Resend returns 422 with a duplicate-shaped
+ * error body when the email is already in the segment; that path increments
+ * `alreadyExists`. Other 422s (missing segment, invalid email, etc.) are
+ * logged and counted as `failed` so they don't masquerade as duplicates.
  *
  * Operational sequence for a full export:
- *   1. Backfill customers.normalizedEmail (PR #3424 must be merged + deployed)
- *   2. Run countPending diagnostic to confirm 0 pending
- *   3. Loop this action until isDone:true, passing continueCursor each time
- *   4. Verify contact count in Resend dashboard matches `upserted + alreadyExists`
+ *   1. Backfill customers.normalizedEmail (`payments/backfillCustomerNormalizedEmail:backfill`)
+ *   2. Run `payments/backfillCustomerNormalizedEmail:countPending` to confirm 0 pending
+ *   3. Loop this action until `isDone:true`, passing `continueCursor` each call
+ *   4. Verify segment contact count in Resend dashboard matches `upserted + alreadyExists`
  */
 import { v } from "convex/values";
 import {
@@ -50,6 +53,9 @@ const RESEND_API_BASE = "https://api.resend.com";
  * Uses `.collect()` — bounded by the size of `emailSuppressions` (Convex's
  * 16,384-doc read limit). At current scale (low thousands of bounces) safe;
  * if the table grows past 16k, switch to a streamed/paginated count.
+ *
+ * `emailSuppressions.normalizedEmail` is a required field (non-optional in
+ * the schema), so no fallback derivation is needed here.
  */
 export const getSuppressedEmails = internalQuery({
   args: {},
@@ -67,6 +73,13 @@ export const getSuppressedEmails = internalQuery({
  * been through Dodo checkout is excluded from the launch pitch (active,
  * cancelled, expired all skip).
  *
+ * Defense-in-depth fallback: `customers.normalizedEmail` is OPTIONAL in
+ * the schema (added by PR #3424; backfill populates existing rows), so a
+ * missed or incomplete backfill could otherwise silently let paid users
+ * through the dedup. We derive the join key from `row.email` on the fly
+ * when `normalizedEmail` isn't set, matching the convention used at every
+ * write site (`email.trim().toLowerCase()`).
+ *
  * Same `.collect()` caveat as above. Customers table is small relative to
  * registrations; this is acceptable.
  */
@@ -75,7 +88,11 @@ export const getPaidEmails = internalQuery({
   handler: async (ctx) => {
     const all = await ctx.db.query("customers").collect();
     return all
-      .map((row) => row.normalizedEmail)
+      .map((row) => {
+        const stored = row.normalizedEmail;
+        if (stored && stored.length > 0) return stored;
+        return (row.email ?? "").trim().toLowerCase();
+      })
       .filter((e): e is string => typeof e === "string" && e.length > 0);
   },
 });
@@ -108,14 +125,35 @@ type ExportStats = {
   pageProcessed: number;
 };
 
+/**
+ * Heuristic for distinguishing "this email is already in the segment"
+ * (a 422 we want to count as success-equivalent) from every other
+ * 422-flavored validation error (missing segment, invalid email,
+ * unauthorized field, etc., which we want to count as `failed` and log).
+ *
+ * Resend's error shape on 422 is `{ name, message, statusCode }`.
+ * Duplicate responses use names like `email_already_exists` /
+ * `contact_already_exists` and messages mentioning "already". We match
+ * generously on the message in case the `name` evolves.
+ */
+function isDuplicateContactError(body: unknown): boolean {
+  if (!body || typeof body !== "object") return false;
+  const obj = body as Record<string, unknown>;
+  const name = typeof obj.name === "string" ? obj.name.toLowerCase() : "";
+  const message = typeof obj.message === "string" ? obj.message.toLowerCase() : "";
+  if (name.includes("already_exists") || name.includes("duplicate")) return true;
+  if (/already (exists|in (the )?(audience|segment))|duplicate/.test(message)) return true;
+  return false;
+}
+
 export const exportProLaunchAudience = internalAction({
   args: {
-    audienceId: v.string(),
+    segmentId: v.string(),
     cursor: v.optional(v.union(v.string(), v.null())),
     numItems: v.optional(v.number()),
     dryRun: v.optional(v.boolean()),
   },
-  handler: async (ctx, { audienceId, cursor, numItems, dryRun }): Promise<ExportStats> => {
+  handler: async (ctx, { segmentId, cursor, numItems, dryRun }): Promise<ExportStats> => {
     const apiKey = process.env.RESEND_API_KEY;
     if (!apiKey && !dryRun) {
       throw new Error(
@@ -173,25 +211,40 @@ export const exportProLaunchAudience = internalAction({
         continue;
       }
 
-      const res = await fetch(
-        `${RESEND_API_BASE}/audiences/${encodeURIComponent(audienceId)}/contacts`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${apiKey}`,
-          },
-          body: JSON.stringify({ email, unsubscribed: false }),
+      // Resend Contacts API (current 2026): POST /contacts with segments in
+      // the body. Audiences was renamed to Segments — the legacy
+      // /audiences/{id}/contacts endpoint may still resolve but is no
+      // longer the canonical path documented at
+      // https://resend.com/docs/api-reference/contacts/create-contact.
+      const res = await fetch(`${RESEND_API_BASE}/contacts`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
         },
-      );
+        body: JSON.stringify({
+          email,
+          segments: [{ id: segmentId }],
+          unsubscribed: false,
+        }),
+      });
 
       if (res.ok) {
         stats.upserted++;
-      } else if (res.status === 409 || res.status === 422) {
-        // Resend returns 422 with `name: "validation_error"` and message
-        // mentioning duplicate when the email is already in the audience.
-        // Treat as already-imported, not a failure.
-        stats.alreadyExists++;
+      } else if (res.status === 422) {
+        // 422 covers BOTH duplicate-already-in-segment AND validation
+        // errors (missing segment, invalid email, etc.). Parse the body
+        // to distinguish — silently counting non-duplicate 422s as
+        // alreadyExists would mask configuration bugs.
+        const body = await res.json().catch(() => null);
+        if (isDuplicateContactError(body)) {
+          stats.alreadyExists++;
+        } else {
+          stats.failed++;
+          console.error(
+            `[exportProLaunchAudience] Resend 422 (non-duplicate) for ${email}: ${JSON.stringify(body)}`,
+          );
+        }
       } else {
         stats.failed++;
         const body = await res.text().catch(() => "<no body>");

--- a/convex/broadcast/audienceExport.ts
+++ b/convex/broadcast/audienceExport.ts
@@ -48,6 +48,25 @@ import { internal } from "../_generated/api";
 
 const RESEND_API_BASE = "https://api.resend.com";
 
+// AGENTS.md requires User-Agent on every server-side fetch.
+const USER_AGENT = "WorldMonitor-PROLaunchExporter/1.0 (+https://worldmonitor.app)";
+
+/**
+ * Redact an email for log output: keep the first 2 chars of the local
+ * part and the full domain, mask the rest. `john.doe@example.com` →
+ * `jo******@example.com`. Convex dashboard logs are observable to anyone
+ * with project access; raw waitlist emails should never be written there.
+ */
+function maskEmail(email: string): string {
+  const at = email.indexOf("@");
+  if (at <= 0) return "***";
+  const local = email.slice(0, at);
+  const domain = email.slice(at);
+  const visible = local.slice(0, Math.min(2, local.length));
+  const masked = "*".repeat(Math.max(1, local.length - visible.length));
+  return `${visible}${masked}${domain}`;
+}
+
 /**
  * Snapshot of suppressed normalizedEmails at call time.
  * Uses `.collect()` — bounded by the size of `emailSuppressions` (Convex's
@@ -114,13 +133,22 @@ export const getRegistrationsPage = internalQuery({
 });
 
 type ExportStats = {
-  upserted: number;
-  linkedExisting: number;
+  // Live-mode counters: result of actual Resend interactions on this page.
+  // All zero in dry-run mode (no Resend calls happen).
+  upserted: number;          // (created + linkedExisting) — landed in segment via this call
+  linkedExisting: number;    // pre-existing global contact, attached to our segment by this call
+  alreadyExists: number;     // verified already in this segment before this call
+  failed: number;
+  // Dedup-only counters: shared between live and dry-run (don't depend on Resend).
   suppressedSkipped: number;
   paidSkipped: number;
-  alreadyExists: number;
-  failed: number;
   emptyEmail: number;
+  // Dry-run-only: count of registrations that passed dedup and WOULD be
+  // upserted on a live run. Strictly disjoint from `upserted` so an
+  // operator comparing dry-run to live totals never confuses
+  // "would-attempt" with "successfully landed in segment."
+  wouldUpsertAfterDedup: number;
+  // Pagination
   isDone: boolean;
   continueCursor: string;
   pageProcessed: number;
@@ -189,6 +217,7 @@ async function upsertContactToSegment(
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
+      "User-Agent": USER_AGENT,
     },
     body: JSON.stringify({
       email,
@@ -216,6 +245,7 @@ async function upsertContactToSegment(
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${apiKey}`,
+          "User-Agent": USER_AGENT,
         },
       },
     );
@@ -281,11 +311,12 @@ export const exportProLaunchAudience = internalAction({
     const stats: ExportStats = {
       upserted: 0,
       linkedExisting: 0,
-      suppressedSkipped: 0,
-      paidSkipped: 0,
       alreadyExists: 0,
       failed: 0,
+      suppressedSkipped: 0,
+      paidSkipped: 0,
       emptyEmail: 0,
+      wouldUpsertAfterDedup: 0,
       isDone: page.isDone,
       continueCursor: page.continueCursor,
       pageProcessed: page.page.length,
@@ -307,7 +338,11 @@ export const exportProLaunchAudience = internalAction({
       }
 
       if (dry) {
-        stats.upserted++;
+        // Dry-run measures dedup math only. We can't know if an email
+        // would land in `created` / `linkedExisting` / `alreadyInSegment`
+        // without actually calling Resend, so we count them all as
+        // "would-attempt" and leave the live-mode counters at zero.
+        stats.wouldUpsertAfterDedup++;
         continue;
       }
 
@@ -328,8 +363,11 @@ export const exportProLaunchAudience = internalAction({
           break;
         case "failed":
           stats.failed++;
+          // Mask the email — Convex dashboard logs are observable to
+          // anyone with project access; raw waitlist addresses must not
+          // land there.
           console.error(
-            `[exportProLaunchAudience] Resend failure for ${email}: ${outcome.reason}`,
+            `[exportProLaunchAudience] Resend failure for ${maskEmail(email)}: ${outcome.reason}`,
           );
           break;
       }

--- a/convex/broadcast/audienceExport.ts
+++ b/convex/broadcast/audienceExport.ts
@@ -115,6 +115,7 @@ export const getRegistrationsPage = internalQuery({
 
 type ExportStats = {
   upserted: number;
+  linkedExisting: number;
   suppressedSkipped: number;
   paidSkipped: number;
   alreadyExists: number;
@@ -126,15 +127,18 @@ type ExportStats = {
 };
 
 /**
- * Heuristic for distinguishing "this email is already in the segment"
- * (a 422 we want to count as success-equivalent) from every other
- * 422-flavored validation error (missing segment, invalid email,
+ * Heuristic for distinguishing duplicate-shaped 422 responses from other
+ * 422-flavored validation errors (missing segment, invalid email,
  * unauthorized field, etc., which we want to count as `failed` and log).
  *
  * Resend's error shape on 422 is `{ name, message, statusCode }`.
  * Duplicate responses use names like `email_already_exists` /
  * `contact_already_exists` and messages mentioning "already". We match
  * generously on the message in case the `name` evolves.
+ *
+ * Used for BOTH `POST /contacts` duplicates (contact exists globally) AND
+ * `POST /contacts/{email}/segments/{segmentId}` duplicates (contact is
+ * already in this specific segment) — same shape, same heuristic.
  */
 function isDuplicateContactError(body: unknown): boolean {
   if (!body || typeof body !== "object") return false;
@@ -144,6 +148,101 @@ function isDuplicateContactError(body: unknown): boolean {
   if (name.includes("already_exists") || name.includes("duplicate")) return true;
   if (/already (exists|in (the )?(audience|segment))|duplicate/.test(message)) return true;
   return false;
+}
+
+type UpsertOutcome =
+  | { kind: "created" }
+  | { kind: "linkedExisting" }
+  | { kind: "alreadyInSegment" }
+  | { kind: "failed"; reason: string };
+
+/**
+ * Two-step contact-to-segment upsert that guarantees the contact ends up
+ * in `segmentId` regardless of pre-existing global state:
+ *
+ *   1. `POST /contacts` with `segments: [{ id }]`. If the contact is brand
+ *      new globally, this creates it AND attaches to the segment in one
+ *      call → "created".
+ *   2. If step 1 returns a duplicate-shaped 422, the contact already
+ *      exists globally — but Resend's documented behaviour is that the
+ *      `segments` field on the duplicate path is NOT applied. We don't
+ *      know whether the contact is already in our segment or in some
+ *      OTHER segment / no segment at all. Resolve the ambiguity with an
+ *      explicit `POST /contacts/{email}/segments/{segmentId}`:
+ *        - 2xx → it was global-only or in another segment, now linked
+ *          → "linkedExisting"
+ *        - 422 duplicate-shaped → was already in this segment
+ *          → "alreadyInSegment"
+ *        - anything else → "failed"
+ *
+ * Without step 2, paid-customers-or-anyone-else who happen to already
+ * exist as global contacts can be silently OMITTED from the launch
+ * segment while the export reports success. (Caught in PR #3431 review.)
+ */
+async function upsertContactToSegment(
+  apiKey: string,
+  email: string,
+  segmentId: string,
+): Promise<UpsertOutcome> {
+  const createRes = await fetch(`${RESEND_API_BASE}/contacts`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      email,
+      segments: [{ id: segmentId }],
+      unsubscribed: false,
+    }),
+  });
+
+  if (createRes.ok) return { kind: "created" };
+
+  if (createRes.status === 422) {
+    const createBody = await createRes.json().catch(() => null);
+    if (!isDuplicateContactError(createBody)) {
+      return {
+        kind: "failed",
+        reason: `POST /contacts 422 (non-duplicate): ${JSON.stringify(createBody)}`,
+      };
+    }
+
+    // Contact exists globally — attach to our segment explicitly.
+    const addRes = await fetch(
+      `${RESEND_API_BASE}/contacts/${encodeURIComponent(email)}/segments/${encodeURIComponent(segmentId)}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+      },
+    );
+
+    if (addRes.ok) return { kind: "linkedExisting" };
+
+    if (addRes.status === 422) {
+      const addBody = await addRes.json().catch(() => null);
+      if (isDuplicateContactError(addBody)) return { kind: "alreadyInSegment" };
+      return {
+        kind: "failed",
+        reason: `POST /contacts/{email}/segments/{id} 422 (non-duplicate): ${JSON.stringify(addBody)}`,
+      };
+    }
+
+    const addText = await addRes.text().catch(() => "<no body>");
+    return {
+      kind: "failed",
+      reason: `POST /contacts/{email}/segments/{id} ${addRes.status}: ${addText}`,
+    };
+  }
+
+  const createText = await createRes.text().catch(() => "<no body>");
+  return {
+    kind: "failed",
+    reason: `POST /contacts ${createRes.status}: ${createText}`,
+  };
 }
 
 export const exportProLaunchAudience = internalAction({
@@ -181,6 +280,7 @@ export const exportProLaunchAudience = internalAction({
 
     const stats: ExportStats = {
       upserted: 0,
+      linkedExisting: 0,
       suppressedSkipped: 0,
       paidSkipped: 0,
       alreadyExists: 0,
@@ -211,46 +311,27 @@ export const exportProLaunchAudience = internalAction({
         continue;
       }
 
-      // Resend Contacts API (current 2026): POST /contacts with segments in
-      // the body. Audiences was renamed to Segments — the legacy
-      // /audiences/{id}/contacts endpoint may still resolve but is no
-      // longer the canonical path documented at
-      // https://resend.com/docs/api-reference/contacts/create-contact.
-      const res = await fetch(`${RESEND_API_BASE}/contacts`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify({
-          email,
-          segments: [{ id: segmentId }],
-          unsubscribed: false,
-        }),
-      });
-
-      if (res.ok) {
-        stats.upserted++;
-      } else if (res.status === 422) {
-        // 422 covers BOTH duplicate-already-in-segment AND validation
-        // errors (missing segment, invalid email, etc.). Parse the body
-        // to distinguish — silently counting non-duplicate 422s as
-        // alreadyExists would mask configuration bugs.
-        const body = await res.json().catch(() => null);
-        if (isDuplicateContactError(body)) {
+      const outcome = await upsertContactToSegment(apiKey!, email, segmentId);
+      switch (outcome.kind) {
+        case "created":
+          stats.upserted++;
+          break;
+        case "linkedExisting":
+          // Pre-existing global contact, now linked to our segment.
+          // Counted as `upserted` (it ended up in the segment via this
+          // call) and tracked separately for diagnostics.
+          stats.upserted++;
+          stats.linkedExisting++;
+          break;
+        case "alreadyInSegment":
           stats.alreadyExists++;
-        } else {
+          break;
+        case "failed":
           stats.failed++;
           console.error(
-            `[exportProLaunchAudience] Resend 422 (non-duplicate) for ${email}: ${JSON.stringify(body)}`,
+            `[exportProLaunchAudience] Resend failure for ${email}: ${outcome.reason}`,
           );
-        }
-      } else {
-        stats.failed++;
-        const body = await res.text().catch(() => "<no body>");
-        console.error(
-          `[exportProLaunchAudience] Resend ${res.status} for ${email}: ${body}`,
-        );
+          break;
       }
     }
 

--- a/convex/broadcast/audienceExport.ts
+++ b/convex/broadcast/audienceExport.ts
@@ -1,0 +1,210 @@
+/**
+ * PRO-launch broadcast — audience export pipeline.
+ *
+ * Builds the deduped waitlist audience and pushes contacts to a Resend
+ * Audience for one-shot launch broadcasting via Resend Broadcasts.
+ *
+ * Dedup formula:
+ *   registrations
+ *     − emailSuppressions (hard bounces, complaints, manual)
+ *     − customers (anyone who has been through Dodo checkout — never pitch
+ *       PRO to people who already paid)
+ *
+ * Join key: `normalizedEmail` (lowercased + trimmed). Requires the
+ * customers.normalizedEmail backfill (`payments/backfillCustomerNormalizedEmail:backfill`)
+ * to have run; otherwise paid users with un-backfilled rows leak into the send.
+ *
+ * Usage (run from CLI; not callable by clients):
+ *   npx convex run broadcast/audienceExport:exportProLaunchAudience \
+ *     '{"audienceId":"aud_xxx"}'
+ *
+ *   # Subsequent pages — pass the continueCursor from the previous response
+ *   npx convex run broadcast/audienceExport:exportProLaunchAudience \
+ *     '{"audienceId":"aud_xxx","cursor":"<continueCursor>"}'
+ *
+ *   # Dry run — counts only, no Resend calls
+ *   npx convex run broadcast/audienceExport:exportProLaunchAudience \
+ *     '{"audienceId":"aud_xxx","dryRun":true}'
+ *
+ * Re-running a page is safe: Resend's contacts API returns 422
+ * `already_exists` for emails already in the audience, which we count
+ * separately (not as a failure).
+ *
+ * Operational sequence for a full export:
+ *   1. Backfill customers.normalizedEmail (PR #3424 must be merged + deployed)
+ *   2. Run countPending diagnostic to confirm 0 pending
+ *   3. Loop this action until isDone:true, passing continueCursor each time
+ *   4. Verify contact count in Resend dashboard matches `upserted + alreadyExists`
+ */
+import { v } from "convex/values";
+import {
+  internalAction,
+  internalQuery,
+} from "../_generated/server";
+import { internal } from "../_generated/api";
+
+const RESEND_API_BASE = "https://api.resend.com";
+
+/**
+ * Snapshot of suppressed normalizedEmails at call time.
+ * Uses `.collect()` — bounded by the size of `emailSuppressions` (Convex's
+ * 16,384-doc read limit). At current scale (low thousands of bounces) safe;
+ * if the table grows past 16k, switch to a streamed/paginated count.
+ */
+export const getSuppressedEmails = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const all = await ctx.db.query("emailSuppressions").collect();
+    return all
+      .map((row) => row.normalizedEmail)
+      .filter((e): e is string => typeof e === "string" && e.length > 0);
+  },
+});
+
+/**
+ * Snapshot of paid (customer) normalizedEmails at call time.
+ * Includes ALL customers regardless of subscription status — anyone who's
+ * been through Dodo checkout is excluded from the launch pitch (active,
+ * cancelled, expired all skip).
+ *
+ * Same `.collect()` caveat as above. Customers table is small relative to
+ * registrations; this is acceptable.
+ */
+export const getPaidEmails = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const all = await ctx.db.query("customers").collect();
+    return all
+      .map((row) => row.normalizedEmail)
+      .filter((e): e is string => typeof e === "string" && e.length > 0);
+  },
+});
+
+/**
+ * Paginated page of registrations. Cursor-driven; pass `null` cursor for
+ * the first page, then `continueCursor` from each response for the next.
+ */
+export const getRegistrationsPage = internalQuery({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    numItems: v.number(),
+  },
+  handler: async (ctx, { cursor, numItems }) => {
+    return await ctx.db
+      .query("registrations")
+      .paginate({ cursor, numItems });
+  },
+});
+
+type ExportStats = {
+  upserted: number;
+  suppressedSkipped: number;
+  paidSkipped: number;
+  alreadyExists: number;
+  failed: number;
+  emptyEmail: number;
+  isDone: boolean;
+  continueCursor: string;
+  pageProcessed: number;
+};
+
+export const exportProLaunchAudience = internalAction({
+  args: {
+    audienceId: v.string(),
+    cursor: v.optional(v.union(v.string(), v.null())),
+    numItems: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, { audienceId, cursor, numItems, dryRun }): Promise<ExportStats> => {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey && !dryRun) {
+      throw new Error(
+        "[exportProLaunchAudience] RESEND_API_KEY not set (omit or set dryRun:true to test without sending)",
+      );
+    }
+
+    // Default 200/page: at Resend's ~10 req/s rate limit that's ~20s of
+    // wall time per page, comfortably under the 10-minute Convex action cap
+    // even with retries and slow API responses.
+    const pageSize = numItems ?? 200;
+    const dry = dryRun ?? false;
+
+    const [suppressed, paid] = await Promise.all([
+      ctx.runQuery(internal.broadcast.audienceExport.getSuppressedEmails, {}),
+      ctx.runQuery(internal.broadcast.audienceExport.getPaidEmails, {}),
+    ]);
+    const suppressedSet = new Set(suppressed);
+    const paidSet = new Set(paid);
+
+    const page = await ctx.runQuery(
+      internal.broadcast.audienceExport.getRegistrationsPage,
+      { cursor: cursor ?? null, numItems: pageSize },
+    );
+
+    const stats: ExportStats = {
+      upserted: 0,
+      suppressedSkipped: 0,
+      paidSkipped: 0,
+      alreadyExists: 0,
+      failed: 0,
+      emptyEmail: 0,
+      isDone: page.isDone,
+      continueCursor: page.continueCursor,
+      pageProcessed: page.page.length,
+    };
+
+    for (const row of page.page) {
+      const email = row.normalizedEmail;
+      if (!email || email.length === 0) {
+        stats.emptyEmail++;
+        continue;
+      }
+      if (suppressedSet.has(email)) {
+        stats.suppressedSkipped++;
+        continue;
+      }
+      if (paidSet.has(email)) {
+        stats.paidSkipped++;
+        continue;
+      }
+
+      if (dry) {
+        stats.upserted++;
+        continue;
+      }
+
+      const res = await fetch(
+        `${RESEND_API_BASE}/audiences/${encodeURIComponent(audienceId)}/contacts`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({ email, unsubscribed: false }),
+        },
+      );
+
+      if (res.ok) {
+        stats.upserted++;
+      } else if (res.status === 409 || res.status === 422) {
+        // Resend returns 422 with `name: "validation_error"` and message
+        // mentioning duplicate when the email is already in the audience.
+        // Treat as already-imported, not a failure.
+        stats.alreadyExists++;
+      } else {
+        stats.failed++;
+        const body = await res.text().catch(() => "<no body>");
+        console.error(
+          `[exportProLaunchAudience] Resend ${res.status} for ${email}: ${body}`,
+        );
+      }
+    }
+
+    console.log(
+      `[exportProLaunchAudience] page complete: ${JSON.stringify(stats)}`,
+    );
+
+    return stats;
+  },
+});


### PR DESCRIPTION
## Why

Second PR in the WorldMonitor PRO launch broadcast chain. Builds on the `customers.normalizedEmail` index landed in #3424 (now on main).

Goal: build the deduped waitlist audience and push contacts to a Resend Audience for one-shot launch broadcasting.

## Dedup formula

```
registrations − emailSuppressions − customers
```

Any user who's been through Dodo checkout (active, cancelled, expired — **all** statuses) is excluded. Pitching paid users a "buy PRO!" email is the worst-case failure mode of the entire launch and the reason this PR exists.

## What this adds

**`convex/broadcast/audienceExport.ts`** — three internal queries + one internal action:

- **`getSuppressedEmails`** — snapshot of `emailSuppressions.normalizedEmail` (all bounces, complaints, manual)
- **`getPaidEmails`** — snapshot of `customers.normalizedEmail` (anyone who paid at any point)
- **`getRegistrationsPage`** — cursor-paginated page of `registrations` rows
- **`exportProLaunchAudience`** — orchestrates: materializes the two exclusion sets, paginates registrations, posts each non-excluded email to Resend's `POST /audiences/{id}/contacts`

### Action behavior

- **Idempotent on re-run**: Resend's 422 `already_exists` is counted as `alreadyExists`, not `failed`. Re-running the same page is safe.
- **Cursor-paginated**: returns `continueCursor` for the next call. Loop until `isDone: true`.
- **Dry-run mode**: `dryRun: true` returns counts without calling Resend — verify exclusion math before the first real send.
- **Required env**: `RESEND_API_KEY` (already set; same key used by `subscriptionEmails.ts`)
- **Default page size: 200** — at Resend's ~10 req/s limit that's ~20s of wall time, comfortably under the Convex 10-min action cap.

### Output shape

```typescript
{
  upserted: number;           // newly added to the Resend audience
  suppressedSkipped: number;  // hit emailSuppressions
  paidSkipped: number;        // hit customers (paid)
  alreadyExists: number;      // already in the Resend audience (re-run)
  failed: number;             // non-422 Resend errors
  emptyEmail: number;         // registrations with empty normalizedEmail
  isDone: boolean;
  continueCursor: string;
  pageProcessed: number;
}
```

## Codegen catch-up

`_generated/api.d.ts` now declares both:
- `broadcast/audienceExport` (this PR — required because the action cross-references its own sibling queries via `internal.*`)
- `payments/backfillCustomerNormalizedEmail` (#3424's file — that file didn't cross-reference so its CI passed without the codegen update; adding now so future callers can resolve it).

Convex regenerates `api.d.ts` identically on `convex dev` / `convex deploy`. No drift risk.

## Verification

- `npx tsc --noEmit -p convex/tsconfig.json` → clean
- All queries and the action are `internal` only — never exposed to clients
- Dry-run path tested: skips the `RESEND_API_KEY` requirement so the exclusion math can be verified independently of the Resend infra

## Operational sequence

After this PR merges and Convex deploys:

```bash
# Confirm backfill is complete (from #3424)
npx convex run payments/backfillCustomerNormalizedEmail:countPending
# Expect: { pending: 0 }

# Dry-run to verify the dedup math
npx convex run broadcast/audienceExport:exportProLaunchAudience \
  '{"audienceId":"aud_xxx","dryRun":true}'

# Real run — loop until isDone:true
npx convex run broadcast/audienceExport:exportProLaunchAudience \
  '{"audienceId":"aud_xxx"}'
npx convex run broadcast/audienceExport:exportProLaunchAudience \
  '{"audienceId":"aud_xxx","cursor":"<continueCursor from previous>"}'
# ... repeat until isDone:true
```

Then verify in Resend dashboard that the audience contact count matches `upserted + alreadyExists` (across all calls).

## Out of scope (future PRs)

- **PR #3**: canary segment helpers + Resend Broadcasts trigger + extend `resendWebhookHandler.ts` for `email.bounced` / `email.complained` → new `broadcastMetrics` table
- **PR #4**: copy variants, test send, header inspection (RFC 8058 `List-Unsubscribe-Post`)

## Known caveats

- **`getSuppressedEmails` and `getPaidEmails` use `.collect()`** — bounded by Convex's 16,384-doc read limit per query. Both tables are well under that today (low thousands). Comment in code flags the limit; if either grows, switch to streamed/paginated counts.
- **No rate-limit handling for Resend** — relies on Resend's documented 10 req/s and the 200/page default to stay under it. If Resend returns 429 we count as `failed`. Acceptable for the launch send cadence (250→500/wk in the canary plan); revisit if blast volume exceeds 10k/hour.