### PR TITLE
fix(resilience): mrv=5 + null-skip recipe sweep for 4 remaining seeders

### DIFF
--- a/scripts/seed-bis-lbs.mjs
+++ b/scripts/seed-bis-lbs.mjs
@@ -201,7 +201,15 @@ async function fetchGdpByCountry() {
       const rawCode = record?.countryiso3code ?? record?.country?.id ?? '';
       const iso2 = rawCode.length === 3 ? (iso3ToIso2[rawCode] ?? null) : (rawCode.length === 2 ? rawCode : null);
       if (!iso2) continue;
-      const value = Number(record?.value);
+      // Defense-in-depth: explicit null-skip BEFORE Number() coercion.
+      // Today the `value <= 0` filter below catches Number(null)=0 by side
+      // effect (GDP must be > 0), but per memory
+      // `feedback_wb_bulk_mrv1_null_coverage_trap` the protection is fragile.
+      // PR #3427's seeder defeated itself for exactly this reason; the
+      // explicit null-skip makes the picker null-safe regardless of any
+      // future filter relaxation.
+      if (record?.value == null) continue;
+      const value = Number(record.value);
       if (!Number.isFinite(value) || value <= 0) continue;
       const year = Number(record?.date);
       if (!Number.isFinite(year)) continue;

--- a/scripts/seed-fossil-electricity-share.mjs
+++ b/scripts/seed-fossil-electricity-share.mjs
@@ -25,7 +25,11 @@ async function fetchFossilElectricityShare() {
   let page = 1;
   let totalPages = 1;
   while (page <= totalPages) {
-    const url = `${WB_BASE}/country/all/indicator/${INDICATOR}?format=json&per_page=500&page=${page}&mrv=1`;
+    // mrv=5 (NOT mrv=1) per memory `feedback_wb_bulk_mrv1_null_coverage_trap`:
+    // mrv=1 returns a SINGLE year across all countries with `value: null` for
+    // late-reporters (KW/QA/AE publish 1-2y behind G7), silently dropping
+    // them. mrv=5 + per-country pickLatest gives a true latest-non-null.
+    const url = `${WB_BASE}/country/all/indicator/${INDICATOR}?format=json&per_page=2000&page=${page}&mrv=5`;
     const resp = await fetch(url, {
       headers: { 'User-Agent': CHROME_UA },
       signal: AbortSignal.timeout(30_000),
@@ -42,10 +46,24 @@ async function fetchFossilElectricityShare() {
     const rawCode = record?.countryiso3code ?? record?.country?.id ?? '';
     const iso2 = rawCode.length === 3 ? (iso3ToIso2[rawCode] ?? null) : (rawCode.length === 2 ? rawCode : null);
     if (!iso2) continue;
-    const value = Number(record?.value);
+    // CRITICAL: skip null records BEFORE Number() coercion.
+    // Number(null) === 0 (not NaN), passes Number.isFinite(), and would
+    // let a `value: null` record overwrite an older non-null record in
+    // the year-comparison below. EG.ELC.FOSL.ZS is a "% of" indicator
+    // where 0 IS a legitimate value (country has 0% fossil generation),
+    // so we CAN'T use the `value <= 0` defense from the recipe — must
+    // skip null explicitly. Same recipe as PR #3427 fixed for the
+    // recovery seeders.
+    if (record?.value == null) continue;
+    const value = Number(record.value);
     if (!Number.isFinite(value)) continue;
     const year = Number(record?.date);
-    countries[iso2] = { value, year: Number.isFinite(year) ? year : null };
+    if (!Number.isFinite(year)) continue;
+    // Per-country latest-non-null (mrv=5 returns up to 5 records per country).
+    const existing = countries[iso2];
+    if (!existing || year > existing.year) {
+      countries[iso2] = { value, year };
+    }
   }
 
   return { countries, seededAt: new Date().toISOString() };

--- a/scripts/seed-low-carbon-generation.mjs
+++ b/scripts/seed-low-carbon-generation.mjs
@@ -19,7 +19,10 @@
 // the power-system security intent.
 //
 // All three series are annual; WDI reports latest observed year per
-// country. We fetch the most-recent value (mrv=1) and sum by ISO2.
+// country. We fetch up to 5 most-recent years (mrv=5) and pick the
+// latest non-null per country, then sum by ISO2. The mrv=5 + null-skip
+// recipe is documented in skill `wb-bulk-mrv1-null-coverage-trap`;
+// applied to this file in PR #3432 (review fixup).
 // Missing any of the three (e.g. a country with no nuclear filing)
 // is treated as 0 for that slice — the scorer's 0..80 saturating
 // goalpost tolerates partial coverage without dropping the indicator

--- a/scripts/seed-low-carbon-generation.mjs
+++ b/scripts/seed-low-carbon-generation.mjs
@@ -40,7 +40,11 @@ async function fetchIndicator(indicatorId) {
   let page = 1;
   let totalPages = 1;
   while (page <= totalPages) {
-    const url = `${WB_BASE}/country/all/indicator/${indicatorId}?format=json&per_page=500&page=${page}&mrv=1`;
+    // mrv=5 (NOT mrv=1) per memory `feedback_wb_bulk_mrv1_null_coverage_trap`:
+    // mrv=1 returns a SINGLE year across all countries with `value: null` for
+    // late-reporters (KW/QA/AE publish 1-2y behind G7), silently dropping
+    // them. mrv=5 + per-country pickLatest gives a true latest-non-null.
+    const url = `${WB_BASE}/country/all/indicator/${indicatorId}?format=json&per_page=2000&page=${page}&mrv=5`;
     const resp = await fetch(url, {
       headers: { 'User-Agent': CHROME_UA },
       signal: AbortSignal.timeout(30_000),
@@ -60,10 +64,23 @@ function collectByIso2(records) {
     const rawCode = record?.countryiso3code ?? record?.country?.id ?? '';
     const iso2 = rawCode.length === 3 ? (iso3ToIso2[rawCode] ?? null) : (rawCode.length === 2 ? rawCode : null);
     if (!iso2) continue;
-    const value = Number(record?.value);
+    // CRITICAL: skip null records BEFORE Number() coercion.
+    // Number(null) === 0 (not NaN), passes Number.isFinite(), and the
+    // `out.set(iso2, ...)` overwrite below would replace an older
+    // non-null record. EG.ELC.{NUCL,RNEW,HYRO}.ZS are "% of" indicators
+    // where 0 IS a legitimate value (country has 0% nuclear / renewable /
+    // hydro), so we CAN'T use the `value <= 0` defense — must skip
+    // null explicitly. Same recipe as PR #3427.
+    if (record?.value == null) continue;
+    const value = Number(record.value);
     if (!Number.isFinite(value)) continue;
     const year = Number(record?.date);
-    out.set(iso2, { value, year: Number.isFinite(year) ? year : null });
+    if (!Number.isFinite(year)) continue;
+    // Per-country latest-non-null (mrv=5 returns up to 5 records per country).
+    const existing = out.get(iso2);
+    if (!existing || year > existing.year) {
+      out.set(iso2, { value, year });
+    }
   }
   return out;
 }

--- a/scripts/seed-power-reliability.mjs
+++ b/scripts/seed-power-reliability.mjs
@@ -26,7 +26,11 @@ async function fetchPowerLosses() {
   let page = 1;
   let totalPages = 1;
   while (page <= totalPages) {
-    const url = `${WB_BASE}/country/all/indicator/${INDICATOR}?format=json&per_page=500&page=${page}&mrv=1`;
+    // mrv=5 (NOT mrv=1) per memory `feedback_wb_bulk_mrv1_null_coverage_trap`:
+    // mrv=1 returns a SINGLE year across all countries with `value: null` for
+    // late-reporters (KW/QA/AE publish 1-2y behind G7), silently dropping
+    // them. mrv=5 + per-country pickLatest gives a true latest-non-null.
+    const url = `${WB_BASE}/country/all/indicator/${INDICATOR}?format=json&per_page=2000&page=${page}&mrv=5`;
     const resp = await fetch(url, {
       headers: { 'User-Agent': CHROME_UA },
       signal: AbortSignal.timeout(30_000),
@@ -43,10 +47,22 @@ async function fetchPowerLosses() {
     const rawCode = record?.countryiso3code ?? record?.country?.id ?? '';
     const iso2 = rawCode.length === 3 ? (iso3ToIso2[rawCode] ?? null) : (rawCode.length === 2 ? rawCode : null);
     if (!iso2) continue;
-    const value = Number(record?.value);
+    // CRITICAL: skip null records BEFORE Number() coercion.
+    // Number(null) === 0 (not NaN), passes Number.isFinite(), and would
+    // let a `value: null` record overwrite an older non-null record below.
+    // EG.ELC.LOSS.ZS is a "% of" indicator where 0 IS legitimate (perfect
+    // grid reliability), so we CAN'T use the `value <= 0` defense — must
+    // skip null explicitly. Same recipe as PR #3427.
+    if (record?.value == null) continue;
+    const value = Number(record.value);
     if (!Number.isFinite(value)) continue;
     const year = Number(record?.date);
-    countries[iso2] = { value, year: Number.isFinite(year) ? year : null };
+    if (!Number.isFinite(year)) continue;
+    // Per-country latest-non-null (mrv=5 returns up to 5 records per country).
+    const existing = countries[iso2];
+    if (!existing || year > existing.year) {
+      countries[iso2] = { value, year };
+    }
   }
 
   return { countries, seededAt: new Date().toISOString() };

--- a/scripts/seed-sovereign-wealth.mjs
+++ b/scripts/seed-sovereign-wealth.mjs
@@ -231,7 +231,15 @@ export function pickLatestPerCountry(records) {
     const rawCode = record?.countryiso3code ?? record?.country?.id ?? '';
     const iso2 = rawCode.length === 3 ? (iso3ToIso2[rawCode] ?? null) : (rawCode.length === 2 ? rawCode : null);
     if (!iso2) continue;
-    const value = Number(record?.value);
+    // Defense-in-depth: explicit null-skip BEFORE Number() coercion.
+    // Number(null) === 0 (not NaN). Today the `value <= 0` filter below
+    // accidentally catches that (annual imports must be > 0), but the
+    // protection is fragile — any future copy-paste of this picker for
+    // an indicator where 0 is legitimate (e.g. % of GDP, % share) would
+    // silently break. Per memory `feedback_wb_bulk_mrv1_null_coverage_trap`
+    // and the compound-bug case study in PR #3427.
+    if (record?.value == null) continue;
+    const value = Number(record.value);
     if (!Number.isFinite(value) || value <= 0) continue;
     const year = Number(record?.date);
     if (!Number.isFinite(year)) continue;

--- a/scripts/seed-wb-external-debt.mjs
+++ b/scripts/seed-wb-external-debt.mjs
@@ -66,13 +66,24 @@ async function fetchWbIndicator(indicator) {
       const rawCode = record?.countryiso3code ?? record?.country?.id ?? '';
       const iso2 = rawCode.length === 3 ? (iso3ToIso2[rawCode] ?? null) : (rawCode.length === 2 ? rawCode : null);
       if (!iso2) continue;
-      const value = Number(record?.value);
+      // CRITICAL: skip null records BEFORE Number() coercion.
+      // Number(null) === 0 (not NaN), passes Number.isFinite(), and would
+      // let a `value: null` record overwrite an older non-null record in
+      // the year-comparison below. The downstream country-level filter
+      // at `combineExternalDebt` only rejects `debt.value < 0`, not
+      // `< 0`, so a coerced 0 propagates through and publishes a false
+      // 0% short-term-debt-to-GNI for late-reporting LMICs. Same compound
+      // trap as PR #3427 / PR #3432 — original miss caught by reviewer
+      // post-PR-#3432 sweep.
+      if (record?.value == null) continue;
+      const value = Number(record.value);
       if (!Number.isFinite(value)) continue;
       const year = Number(record?.date);
       if (!Number.isFinite(year)) continue;
       // Per-key memory `feedback_wb_bulk_mrv1_null_coverage_trap`: mrv=1
       // returns SINGLE year across all countries with `value: null` for
       // late-reporters; mrv=5 + pickLatestPerCountry handles that.
+      // The explicit null-skip above is the second half of the trap fix.
       const existing = out[iso2];
       if (!existing || year > existing.year) {
         out[iso2] = { value, year };


### PR DESCRIPTION
## Summary

Companion to PR #3427. Sweep found 4 OTHER WB seeders still using `mrv=1` + `Number(record?.value)` (the compound trap PR #3427 fixed in the recovery seeders):

- `seed-fossil-electricity-share.mjs` — EG.ELC.FOSL.ZS
- `seed-low-carbon-generation.mjs` — EG.ELC.{NUCL,RNEW,HYRO}.ZS
- `seed-power-reliability.mjs` — EG.ELC.LOSS.ZS
- `seed-sovereign-wealth.mjs` — NE.IMP.GNFS.CD via `pickLatestPerCountry` helper (already mrv=5; added defense-in-depth null-skip)

## Critical: explicit null-skip required for "% of" indicators

The 3 energy seeders use `% of` indicators where **0 is a legitimate value** (country has 0% nuclear, perfect grid reliability, etc.). The `value <= 0` defense from the SWF picker would wrongly drop legitimate zeros for these — explicit `if (record?.value == null) continue;` BEFORE `Number()` coercion is the only safe pattern.

## Lineage

Plan 2026-04-26-001 cohort dry-run → PR #3427 (recovery seeders) → user audit Priority Check #4 → this PR. Memory `wb-bulk-mrv1-null-coverage-trap` updated post-PR-#3427 with the compound-bug case study.

## Test plan

- [ ] After merge: run each of the 4 seeders manually to verify the corrected count of countries returned (energy seeders should keep similar counts; SWF imports unchanged)
- [ ] Re-run `npm run dryrun:resilience` — energy domain scores should shift for late-reporters (KW/QA/AE) that mrv=1 was dropping