### PR TITLE
feat(resilience): cohort anti-inversion fixture (Plan 2026-04-26-002 PR 0 / U1)

### DIFF
--- a/server/worldmonitor/resilience/v1/cohorts/g7.json
+++ b/server/worldmonitor/resilience/v1/cohorts/g7.json
@@ -1,0 +1,5 @@
+{
+  "name": "g7",
+  "description": "Group of Seven advanced economies. Used in resilience cohort anti-inversion test (plan 2026-04-26-002 §U1) as the structural anchor for 'large advanced economies should outperform sparse-data microstates / SARs'. Membership is the canonical G7 list; do NOT add or remove without methodology justification.",
+  "iso2": ["US", "GB", "DE", "FR", "JP", "IT", "CA"]
+}

--- a/server/worldmonitor/resilience/v1/cohorts/gcc.json
+++ b/server/worldmonitor/resilience/v1/cohorts/gcc.json
@@ -1,0 +1,5 @@
+{
+  "name": "gcc",
+  "description": "Gulf Cooperation Council oil-exporting monarchies. Used in resilience cohort anti-inversion test (plan 2026-04-26-002 §U1) as the comparison cohort for the Nordics-vs-GCC inversion check. Membership: the 6 GCC member states.",
+  "iso2": ["SA", "AE", "KW", "QA", "BH", "OM"]
+}

--- a/server/worldmonitor/resilience/v1/cohorts/microstate-territories.json
+++ b/server/worldmonitor/resilience/v1/cohorts/microstate-territories.json
@@ -1,0 +1,5 @@
+{
+  "name": "microstate-territories",
+  "description": "Microstates and SARs/territories — sparse data, often inflated by current scoring. Used in resilience cohort anti-inversion test (plan 2026-04-26-002 §U1) as the structural anchor for 'at most 1 microstate-territory in the headline top 20 after the universe filter + per-capita normalization land'. Membership: small population (<1M typical) sovereign microstates AND non-sovereign SARs/territories; the test treats them as one cohort because the structural problem (sparse coverage / per-capita inflation / non-sovereign membership) is shared.",
+  "iso2": ["AD", "LI", "MC", "SM", "TV", "PW", "NR", "MO", "HK", "GL", "GI", "IM", "FK"]
+}

--- a/server/worldmonitor/resilience/v1/cohorts/nordics.json
+++ b/server/worldmonitor/resilience/v1/cohorts/nordics.json
@@ -1,0 +1,5 @@
+{
+  "name": "nordics",
+  "description": "Nordic countries — established democracies with low debt and strong governance. Used in resilience cohort anti-inversion test (plan 2026-04-26-002 §U1) as the anchor for 'high-trust low-debt democracies should not catastrophically underperform GCC oil-state monarchies'. Membership: 5 sovereign Nordics; excludes Greenland (territory of DK) and Faroe Islands.",
+  "iso2": ["NO", "SE", "FI", "DK", "IS"]
+}

--- a/server/worldmonitor/resilience/v1/cohorts/sub-saharan-lic.json
+++ b/server/worldmonitor/resilience/v1/cohorts/sub-saharan-lic.json
@@ -1,0 +1,5 @@
+{
+  "name": "sub-saharan-lic",
+  "description": "Sub-Saharan low-income countries (LICs) — used in resilience cohort anti-inversion test (plan 2026-04-26-002 §U1) as the floor anchor for 'no G7 country should drop to within 10pt of the worst Sub-Saharan LIC'. Catches catastrophic recovery-domain regressions. Membership: 10 LICs picked across regions and conflict states; expand only with methodology justification.",
+  "iso2": ["TD", "CF", "NE", "ML", "BF", "SS", "GN", "SL", "BI", "MZ"]
+}

--- a/tests/resilience-cohort-anti-inversion.test.mts
+++ b/tests/resilience-cohort-anti-inversion.test.mts
@@ -1,0 +1,301 @@
+// Plan 2026-04-26-002 §U1 — Resilience cohort anti-inversion fixture (PR 0).
+//
+// PURPOSE — STRUCTURAL CI GATE FOR THE UNIVERSE + COVERAGE REBUILD
+//
+// PR #3425's post-merge cohort dry-run captured the empirical signature
+// of the structural problem this rebuild exists to solve: tiny states
+// (TV/PW/NR/MC) keep climbing in the v15 ranking even after targeted
+// scorer fixes correctly de-rated HICs. The targeted fixes can't reach
+// the universe + coverage handling defects. This test pins the cohort
+// invariants so future rebuild PRs can tighten thresholds in lockstep
+// with the corresponding fix:
+//
+//   PR 0 (this file): PERMISSIVE thresholds, passes against current v15.
+//   PR 3 (coverage penalty): TIGHTENS median(G7) > median(microstate) + 10pt
+//                            and min(G7) >= max(Sub-Saharan-LIC) - 10pt.
+//   PR 4 (stable-absence recal): contributes to the same invariants.
+//   PR 5 (per-capita normalization): TIGHTENS count(microstate) in top 20 <= 1.
+//
+// SOURCE OF TRUTH — COHORT MEMBERSHIP
+//
+// Membership is committed JSON at server/worldmonitor/resilience/v1/cohorts/
+// so it can be reviewed independently from test code. DO NOT inline cohort
+// lists here.
+//
+// READ PATTERN — READ-ONLY UPSTASH GET, SKIP-ON-MISSING-CREDS
+//
+// Reads live `resilience:ranking:vN` from production Upstash via the
+// pattern from scripts/dry-run-resilience-rebalance.mjs. The test SKIPS
+// (does not fail) when UPSTASH_REDIS_REST_URL is unset — required so
+// CI-without-prod-creds and dev-without-.env environments still pass.
+// When credentials ARE present, the test runs the invariants live.
+//
+// SAFETY — READ-ONLY
+//
+// Only HTTP GET against the ranking key. No mass DEL, no SET, no
+// pipeline mutations. Defense-in-depth: the redisGet helper is the
+// only Upstash interaction in this file.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const COHORTS_DIR = resolve(here, '../server/worldmonitor/resilience/v1/cohorts');
+
+interface CohortFile {
+  name: string;
+  description: string;
+  iso2: string[];
+}
+
+function loadCohort(filename: string): CohortFile {
+  const path = resolve(COHORTS_DIR, filename);
+  const raw = readFileSync(path, 'utf8');
+  const parsed = JSON.parse(raw) as CohortFile;
+  if (!parsed.name || !Array.isArray(parsed.iso2)) {
+    throw new Error(`Cohort file ${filename} missing required fields {name, iso2}`);
+  }
+  return parsed;
+}
+
+const ISO2_RE = /^[A-Z]{2}$/;
+
+const cohorts = {
+  g7: loadCohort('g7.json'),
+  nordics: loadCohort('nordics.json'),
+  gcc: loadCohort('gcc.json'),
+  subSaharanLic: loadCohort('sub-saharan-lic.json'),
+  microstateTerritories: loadCohort('microstate-territories.json'),
+};
+
+// --- Phase 1: cohort fixture self-tests (always run, no creds needed) ----------
+
+describe('cohort JSON fixtures (Plan 2026-04-26-002 §U1)', () => {
+  for (const [key, cohort] of Object.entries(cohorts)) {
+    describe(`${key}`, () => {
+      it('parses to a non-empty array of valid ISO2 codes', () => {
+        assert.ok(cohort.iso2.length > 0, `${key} cohort must be non-empty`);
+        for (const iso of cohort.iso2) {
+          assert.ok(ISO2_RE.test(iso),
+            `${key} contains invalid ISO2 code "${iso}" (must match /^[A-Z]{2}$/)`);
+        }
+      });
+
+      it('has no duplicate entries', () => {
+        const set = new Set(cohort.iso2);
+        assert.equal(set.size, cohort.iso2.length,
+          `${key} contains duplicates: ${cohort.iso2.length - set.size} extra entries`);
+      });
+
+      it('carries a non-empty description (anti-mystery-cohort gate)', () => {
+        assert.ok(typeof cohort.description === 'string' && cohort.description.length > 50,
+          `${key} description must explain the cohort's purpose (got ${cohort.description?.length ?? 0} chars)`);
+      });
+    });
+  }
+
+  it('cohorts are mutually disjoint where intent requires it', () => {
+    // G7 ∩ Nordics: empty (no Nordic country is in G7)
+    const g7Set = new Set(cohorts.g7.iso2);
+    const overlap = cohorts.nordics.iso2.filter((iso) => g7Set.has(iso));
+    assert.deepEqual(overlap, [],
+      `G7 and Nordics must be disjoint; overlap: ${overlap.join(', ')}`);
+
+    // G7 ∩ GCC: empty
+    const gccOverlap = cohorts.gcc.iso2.filter((iso) => g7Set.has(iso));
+    assert.deepEqual(gccOverlap, [],
+      `G7 and GCC must be disjoint; overlap: ${gccOverlap.join(', ')}`);
+
+    // microstate-territories ∩ G7: empty
+    const microG7 = cohorts.microstateTerritories.iso2.filter((iso) => g7Set.has(iso));
+    assert.deepEqual(microG7, [],
+      `microstate-territories and G7 must be disjoint; overlap: ${microG7.join(', ')}`);
+  });
+});
+
+// --- Phase 2: live-ranking anti-inversion (skipped when creds missing) ---------
+
+interface RankingItem {
+  iso2?: string;
+  countryCode?: string;
+  overallScore?: number;
+  score?: number;
+}
+
+interface RankingPayload {
+  rankings?: RankingItem[];
+  items?: RankingItem[];
+}
+
+interface EnvelopeWrapper {
+  data?: RankingPayload | null;
+}
+
+async function loadSeedUtils() {
+  // Dynamic import: scripts/_seed-utils.mjs is .mjs and imports loadEnvFile etc.
+  // The test only calls these helpers when UPSTASH creds are present, so any
+  // import-time failure on the .mjs path is swallowed gracefully below.
+  return import('../scripts/_seed-utils.mjs');
+}
+
+async function loadRankingKey(): Promise<string> {
+  const sharedModule = await import('../server/worldmonitor/resilience/v1/_shared.ts');
+  return (sharedModule as { RESILIENCE_RANKING_CACHE_KEY: string }).RESILIENCE_RANKING_CACHE_KEY;
+}
+
+async function fetchLiveRanking(rankingKey: string, url: string, token: string): Promise<RankingPayload | null> {
+  const resp = await fetch(`${url}/get/${encodeURIComponent(rankingKey)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) {
+    throw new Error(`Upstash GET ${rankingKey}: HTTP ${resp.status}`);
+  }
+  const body = await resp.json();
+  if (!body || body.result == null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body.result);
+  } catch {
+    return null;
+  }
+  // Envelope unwrap pattern from scripts/dry-run-resilience-rebalance.mjs:
+  // payload may be raw or wrapped { data, source, fetchedAt }.
+  if (parsed && typeof parsed === 'object' && 'data' in parsed) {
+    return (parsed as EnvelopeWrapper).data ?? null;
+  }
+  return parsed as RankingPayload;
+}
+
+function indexByIso2(payload: RankingPayload | null): Map<string, { score: number; rank: number }> {
+  const out = new Map<string, { score: number; rank: number }>();
+  const items = Array.isArray(payload?.rankings)
+    ? payload!.rankings!
+    : (Array.isArray(payload?.items) ? payload!.items! : []);
+  let rank = 1;
+  for (const entry of items) {
+    const iso2 = (entry.iso2 ?? entry.countryCode ?? '').toUpperCase();
+    if (!iso2) continue;
+    const score = Number(entry.overallScore ?? entry.score ?? NaN);
+    if (!Number.isFinite(score)) continue;
+    out.set(iso2, { score, rank });
+    rank++;
+  }
+  return out;
+}
+
+function median(nums: number[]): number {
+  if (nums.length === 0) return NaN;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function scoresFor(cohort: CohortFile, ranking: Map<string, { score: number; rank: number }>): number[] {
+  return cohort.iso2
+    .map((iso) => ranking.get(iso)?.score)
+    .filter((s): s is number => typeof s === 'number');
+}
+
+describe('cohort anti-inversion against live ranking (Plan 2026-04-26-002 §U1)', () => {
+  // SKIP guard: if Upstash creds are missing, all tests in this describe block
+  // log + pass without running the live invariants. Required for CI-without-prod-creds.
+  const upstashUrl = process.env.UPSTASH_REDIS_REST_URL;
+  const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+  const credsPresent = Boolean(upstashUrl && upstashToken);
+
+  if (!credsPresent) {
+    it('[skip] live invariants — UPSTASH_REDIS_REST_URL/TOKEN not set in env', () => {
+      console.log('[cohort-anti-inversion] Skipping live invariants — no Upstash credentials in env. Set UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN to run.');
+      assert.ok(true);
+    });
+    return;
+  }
+
+  // Fetch ranking once for all live invariants.
+  let ranking: Map<string, { score: number; rank: number }> | null = null;
+  let rankingKey = '';
+
+  it('[setup] fetches the live ranking from production Upstash', async () => {
+    // Lazy-load env helper only when creds present (avoids loading .env in CI).
+    const seedUtils = await loadSeedUtils() as { loadEnvFile: (u: string) => void };
+    try {
+      seedUtils.loadEnvFile(import.meta.url);
+    } catch {
+      // Non-fatal — env may already be loaded by the harness.
+    }
+    rankingKey = await loadRankingKey();
+    const payload = await fetchLiveRanking(rankingKey, upstashUrl!, upstashToken!);
+    assert.ok(payload, `Live ranking ${rankingKey} returned null/empty — production payload missing or malformed`);
+    ranking = indexByIso2(payload);
+    assert.ok(ranking.size >= 100,
+      `Live ranking has ${ranking.size} indexed countries — too few for cohort invariants (expect >= 100). Payload shape may have changed.`);
+    console.log(`[cohort-anti-inversion] Loaded ${ranking.size} countries from ${rankingKey}`);
+  });
+
+  // Each invariant runs as a separate `it` so failures isolate.
+
+  it('PERMISSIVE: median(G7) > median(microstate-territories) - 10pt [tracks current v15 inversion; PR 3 tightens to +10pt]', () => {
+    if (!ranking) return;
+    const g7Median = median(scoresFor(cohorts.g7, ranking));
+    const microMedian = median(scoresFor(cohorts.microstateTerritories, ranking));
+    console.log(`[cohort-anti-inversion] median(G7) = ${g7Median.toFixed(2)}, median(microstate) = ${microMedian.toFixed(2)}, gap = ${(g7Median - microMedian).toFixed(2)}`);
+    // Current v15 has median(G7) ~69.5 < median(microstate) ~75 — that's
+    // the STRUCTURAL inversion this rebuild exists to fix. PR 0 baseline
+    // tolerates the inversion up to 10pt so the test passes on the
+    // current state. PR 3 (coverage penalty) is expected to flip the
+    // sign and tighten this assertion to `g7Median > microMedian + 10`.
+    // If this assertion fails, the rebuild has REGRESSED past current
+    // v15 — investigate before merge.
+    assert.ok(g7Median > microMedian - 10,
+      `REGRESSION PAST v15 BASELINE: median(G7)=${g7Median} fell more than 10pt below median(microstate-territories)=${microMedian}. v15 baseline gap was ~-5.5pt; current is ${(g7Median - microMedian).toFixed(2)}. The rebuild has regressed past the current state.`);
+  });
+
+  it('PERMISSIVE: median(Nordics) >= median(GCC) - 30pt [PR 5 tightens to -5pt]', () => {
+    if (!ranking) return;
+    const nordicMedian = median(scoresFor(cohorts.nordics, ranking));
+    const gccMedian = median(scoresFor(cohorts.gcc, ranking));
+    console.log(`[cohort-anti-inversion] median(Nordics) = ${nordicMedian.toFixed(2)}, median(GCC) = ${gccMedian.toFixed(2)}, gap = ${(nordicMedian - gccMedian).toFixed(2)}`);
+    assert.ok(nordicMedian >= gccMedian - 30,
+      `Nordics median ${nordicMedian} dropped >30pt below GCC median ${gccMedian}. Catastrophic Nordic regression — investigate before merge.`);
+  });
+
+  it('PERMISSIVE: min(G7) >= max(Sub-Saharan-LIC) - 20pt [PR 3 tightens to -10pt]', () => {
+    if (!ranking) return;
+    const g7Scores = scoresFor(cohorts.g7, ranking);
+    const licScores = scoresFor(cohorts.subSaharanLic, ranking);
+    if (g7Scores.length === 0 || licScores.length === 0) {
+      console.warn(`[cohort-anti-inversion] G7 scores=${g7Scores.length}, LIC scores=${licScores.length} — skipping`);
+      return;
+    }
+    const g7Min = Math.min(...g7Scores);
+    const licMax = Math.max(...licScores);
+    console.log(`[cohort-anti-inversion] min(G7) = ${g7Min.toFixed(2)}, max(Sub-Saharan-LIC) = ${licMax.toFixed(2)}, gap = ${(g7Min - licMax).toFixed(2)}`);
+    assert.ok(g7Min >= licMax - 20,
+      `Catastrophic floor regression: min(G7)=${g7Min} fell within 20pt of max(Sub-Saharan-LIC)=${licMax}. Recovery domain or coverage handling has regressed.`);
+  });
+
+  it('REPORT-ONLY: count(microstate-territories) in top 20 [PR 5 will assert <= 1]', () => {
+    if (!ranking) return;
+    const microSet = new Set(cohorts.microstateTerritories.iso2);
+    const sorted = [...ranking.entries()]
+      .sort((a, b) => b[1].score - a[1].score)
+      .slice(0, 20);
+    const microInTop20 = sorted.filter(([iso]) => microSet.has(iso));
+    console.log(`[cohort-anti-inversion] microstate-territories in top 20: ${microInTop20.length} (${microInTop20.map(([i]) => i).join(', ')}) [no assertion in PR 0; PR 5 will assert <= 1]`);
+    // No assertion yet — PR 5 lands the <= 1 threshold after per-capita normalization.
+    assert.ok(true);
+  });
+
+  it('REPORT-ONLY: per-cohort coverage in the live ranking [diagnostic]', () => {
+    if (!ranking) return;
+    for (const [key, cohort] of Object.entries(cohorts)) {
+      const present = cohort.iso2.filter((iso) => ranking!.has(iso)).length;
+      console.log(`[cohort-anti-inversion] ${key}: ${present}/${cohort.iso2.length} present in ranking`);
+    }
+    assert.ok(true);
+  });
+});

--- a/tests/resilience-retired-dimensions-parity.test.mts
+++ b/tests/resilience-retired-dimensions-parity.test.mts
@@ -79,3 +79,53 @@ describe('retired-dimensions client/server parity', () => {
       `Client-only not-applicable dims: ${clientOnly.join(', ')}. Update RESILIENCE_NOT_APPLICABLE_WHEN_ZERO_COVERAGE in server/worldmonitor/resilience/v1/_dimension-scorers.ts.`);
   });
 });
+
+// Plan 2026-04-26-002 §U1: shape validation for cohort JSON fixtures.
+// Standalone describe block (different concern from retired/not-applicable
+// parity above) but kept in the same file so all "shape-of-data must
+// match the schema" gates live together.
+import { readdirSync } from 'node:fs';
+const COHORTS_DIR = resolve(here, '../server/worldmonitor/resilience/v1/cohorts');
+const ISO2_RE = /^[A-Z]{2}$/;
+
+interface CohortShape {
+  name: string;
+  description: string;
+  iso2: string[];
+}
+
+describe('cohort JSON fixture shapes (Plan 2026-04-26-002 §U1)', () => {
+  const files = readdirSync(COHORTS_DIR).filter((f) => f.endsWith('.json'));
+
+  it('cohorts directory contains at least the 5 expected files', () => {
+    const required = ['g7.json', 'nordics.json', 'gcc.json', 'sub-saharan-lic.json', 'microstate-territories.json'];
+    for (const req of required) {
+      assert.ok(files.includes(req), `Missing required cohort fixture: ${req}`);
+    }
+  });
+
+  for (const file of files) {
+    it(`${file}: parses to {name, description, iso2[]} with valid ISO2 codes`, () => {
+      const raw = readFileSync(resolve(COHORTS_DIR, file), 'utf8');
+      let parsed: CohortShape;
+      try {
+        parsed = JSON.parse(raw) as CohortShape;
+      } catch (err) {
+        throw new Error(`${file} is not valid JSON: ${(err as Error).message}`);
+      }
+      assert.ok(typeof parsed.name === 'string' && parsed.name.length > 0,
+        `${file} missing required "name" field`);
+      assert.ok(typeof parsed.description === 'string' && parsed.description.length > 50,
+        `${file} description must explain the cohort's purpose (got ${parsed.description?.length ?? 0} chars)`);
+      assert.ok(Array.isArray(parsed.iso2) && parsed.iso2.length > 0,
+        `${file} must have non-empty iso2[]`);
+      for (const iso of parsed.iso2) {
+        assert.ok(ISO2_RE.test(iso),
+          `${file} contains invalid ISO2 code "${iso}" (must match /^[A-Z]{2}$/)`);
+      }
+      const set = new Set(parsed.iso2);
+      assert.equal(set.size, parsed.iso2.length,
+        `${file} contains duplicate ISO2 entries`);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

PR 0 of plan [2026-04-26-002](docs/plans/2026-04-26-002-feat-resilience-universe-coverage-rebuild-plan.md) — lands the structural CI gate the universe + coverage rebuild needs. Passes against current v15 with PERMISSIVE thresholds; subsequent rebuild PRs (3, 5) tighten in lockstep.

PR #3425's cohort dry-run captured the empirical signature this gate now anchors: median(G7)=69.5 sits **5.5pt below** median(microstate-territories)=75.0 in current v15. The structural inversion the universe + coverage rebuild exists to fix.

## What this PR asserts (passing on current v15)

| Invariant | v15 measurement | PR 0 threshold | Future tightening |
|---|---|---|---|
| median(G7) − median(microstate) | **−5.52pt** (inverted) | > −10pt ✅ | PR 3 → > +10pt |
| median(Nordics) − median(GCC) | **+8.20pt** | ≥ −30pt ✅ | PR 5 → ≥ −5pt |
| min(G7) − max(Sub-Saharan-LIC) | **+10.40pt** | ≥ −20pt ✅ | PR 3 → ≥ −10pt |
| microstate-territories in top 20 | **6** (AD, LI, TV, PW, GL, MO) | report-only | PR 5 → ≤ 1 |

## What ships

- 5 cohort JSON fixtures at `server/worldmonitor/resilience/v1/cohorts/` — data, not test code
- `tests/resilience-cohort-anti-inversion.test.mts` — fixture self-tests (always run) + live-ranking invariants (skip-on-missing-creds)
- `tests/resilience-retired-dimensions-parity.test.mts` extended with JSON shape validation (anti-mystery-cohort gate)
- Read-only Upstash GET pattern; never SET/DEL/pipeline mutations
- 617/617 resilience tests pass

## Test plan

- [x] Local: `npx tsx --test tests/resilience-*` — 617/617 passes
- [x] Skip-on-missing-creds: passes without `.env` Upstash creds
- [x] With prod creds: live invariants pass against current v15

## Lineage

Plan 2026-04-26-002 §U1 (PR 0). Predecessors: PRs #3425, #3426, #3427, #3432.