### PR TITLE
feat(convex/broadcast): PRO-launch broadcast trigger + metrics + locked content

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -11,6 +11,9 @@
 import type * as alertRules from "../alertRules.js";
 import type * as apiKeys from "../apiKeys.js";
 import type * as broadcast_audienceExport from "../broadcast/audienceExport.js";
+import type * as broadcast_metrics from "../broadcast/metrics.js";
+import type * as broadcast_proLaunchEmailContent from "../broadcast/proLaunchEmailContent.js";
+import type * as broadcast_sendBroadcast from "../broadcast/sendBroadcast.js";
 import type * as config_productCatalog from "../config/productCatalog.js";
 import type * as constants from "../constants.js";
 import type * as contactMessages from "../contactMessages.js";
@@ -48,6 +51,9 @@ declare const fullApi: ApiFromModules<{
   alertRules: typeof alertRules;
   apiKeys: typeof apiKeys;
   "broadcast/audienceExport": typeof broadcast_audienceExport;
+  "broadcast/metrics": typeof broadcast_metrics;
+  "broadcast/proLaunchEmailContent": typeof broadcast_proLaunchEmailContent;
+  "broadcast/sendBroadcast": typeof broadcast_sendBroadcast;
   "config/productCatalog": typeof config_productCatalog;
   constants: typeof constants;
   contactMessages: typeof contactMessages;

--- a/convex/broadcast/metrics.ts
+++ b/convex/broadcast/metrics.ts
@@ -32,6 +32,18 @@ const TRACKED_SET: ReadonlySet<string> = new Set(BROADCAST_TRACKED_EVENT_TYPES);
  * delivered multiple times. We trust the svix-id header (passed in as
  * `webhookEventId`) for de-duplication.
  *
+ * On a successful first-write, also bumps the matching aggregate row in
+ * `broadcastEventCounts` so `getBroadcastStats` can read in O(N tracked
+ * event types) instead of scanning the full event log. Counter increment
+ * is gated on insert success, so duplicate webhook deliveries cannot
+ * inflate the count.
+ *
+ * No `rawPayload` accepted — Resend's `data` object includes recipient
+ * emails (`to: string[]`), `from`, `subject`, etc. that are PII or
+ * PII-adjacent. Convex dashboard rows are observable; we keep only the
+ * identifying metadata. Deeper inspection lives in the Resend dashboard
+ * via `emailMessageId`.
+ *
  * Returns `{ inserted }` so the caller can distinguish first-write from
  * a retry.
  */
@@ -42,7 +54,6 @@ export const recordBroadcastEvent = internalMutation({
     emailMessageId: v.optional(v.string()),
     eventType: v.string(),
     occurredAt: v.number(),
-    rawPayload: v.any(),
   },
   handler: async (ctx, args) => {
     if (!TRACKED_SET.has(args.eventType)) {
@@ -64,6 +75,32 @@ export const recordBroadcastEvent = internalMutation({
     }
 
     await ctx.db.insert("broadcastEvents", args);
+
+    // Bump (or create) the aggregate counter. Read-then-write is safe
+    // here because Convex mutations run serializably — no two
+    // concurrent recordBroadcastEvent calls for the same
+    // (broadcastId, eventType) can interleave.
+    const counterRow = await ctx.db
+      .query("broadcastEventCounts")
+      .withIndex("by_broadcast_event", (q) =>
+        q.eq("broadcastId", args.broadcastId).eq("eventType", args.eventType),
+      )
+      .unique();
+    const now = Date.now();
+    if (counterRow) {
+      await ctx.db.patch(counterRow._id, {
+        count: counterRow.count + 1,
+        updatedAt: now,
+      });
+    } else {
+      await ctx.db.insert("broadcastEventCounts", {
+        broadcastId: args.broadcastId,
+        eventType: args.eventType,
+        count: 1,
+        updatedAt: now,
+      });
+    }
+
     return { inserted: true, reason: "ok" as const };
   },
 });
@@ -91,22 +128,25 @@ const COMPLAINT_KILL_THRESHOLD = 0.0008; // 0.08%
  * a canary send — call from a watch script every few seconds and stop
  * the rollout the moment a kill-gate trips.
  *
- * Counts each event type via the `by_broadcast_event` compound index;
- * read cost is proportional to the per-type result size, not the full
- * `broadcastEvents` table.
+ * Reads from `broadcastEventCounts` (one row per `(broadcastId, eventType)`)
+ * — N index lookups per call (N = tracked event types = 8), constant
+ * time regardless of broadcast size. The previous implementation
+ * `.collect()`-ed `broadcastEvents` per type and would have thrown
+ * Convex's 16,384-doc read limit on a 30k-recipient main send the
+ * moment `email.delivered` overflowed.
  */
 export const getBroadcastStats = internalQuery({
   args: { broadcastId: v.string() },
   handler: async (ctx, { broadcastId }): Promise<BroadcastStats> => {
     const counts: Record<string, number> = {};
     for (const eventType of BROADCAST_TRACKED_EVENT_TYPES) {
-      const rows = await ctx.db
-        .query("broadcastEvents")
+      const row = await ctx.db
+        .query("broadcastEventCounts")
         .withIndex("by_broadcast_event", (q) =>
           q.eq("broadcastId", broadcastId).eq("eventType", eventType),
         )
-        .collect();
-      counts[eventType] = rows.length;
+        .unique();
+      counts[eventType] = row?.count ?? 0;
     }
 
     const delivered = counts["email.delivered"] ?? 0;

--- a/convex/broadcast/metrics.ts
+++ b/convex/broadcast/metrics.ts
@@ -1,0 +1,131 @@
+/**
+ * Broadcast metrics — record per-event Resend webhook deliveries against
+ * a broadcast and expose live aggregates for canary kill-gate decisions.
+ *
+ * Kill-gate thresholds (per project memory `pro_launch_broadcast`):
+ *   - hard bounce > 4% of `delivered` → halt rollout
+ *   - spam complaint > 0.08% of `delivered` → halt rollout
+ *
+ * Resend webhook events that count:
+ *   email.delivered, email.bounced, email.complained, email.opened,
+ *   email.clicked, email.delivery_delayed, email.suppressed, email.failed
+ */
+import { v } from "convex/values";
+import { internalMutation, internalQuery } from "../_generated/server";
+
+export const BROADCAST_TRACKED_EVENT_TYPES = [
+  "email.delivered",
+  "email.bounced",
+  "email.complained",
+  "email.opened",
+  "email.clicked",
+  "email.delivery_delayed",
+  "email.suppressed",
+  "email.failed",
+] as const;
+
+const TRACKED_SET: ReadonlySet<string> = new Set(BROADCAST_TRACKED_EVENT_TYPES);
+
+/**
+ * Record one Resend webhook event against a broadcast. Idempotent on
+ * `webhookEventId` — Resend retries on 5xx and the same event may be
+ * delivered multiple times. We trust the svix-id header (passed in as
+ * `webhookEventId`) for de-duplication.
+ *
+ * Returns `{ inserted }` so the caller can distinguish first-write from
+ * a retry.
+ */
+export const recordBroadcastEvent = internalMutation({
+  args: {
+    webhookEventId: v.string(),
+    broadcastId: v.string(),
+    emailMessageId: v.optional(v.string()),
+    eventType: v.string(),
+    occurredAt: v.number(),
+    rawPayload: v.any(),
+  },
+  handler: async (ctx, args) => {
+    if (!TRACKED_SET.has(args.eventType)) {
+      // Drop — caller should pre-filter, but guard anyway so a future
+      // event type added upstream doesn't silently accumulate rows we
+      // can't aggregate against.
+      return { inserted: false, reason: "untracked_event_type" as const };
+    }
+
+    const existing = await ctx.db
+      .query("broadcastEvents")
+      .withIndex("by_webhookEventId", (q) =>
+        q.eq("webhookEventId", args.webhookEventId),
+      )
+      .first();
+
+    if (existing) {
+      return { inserted: false, reason: "duplicate" as const };
+    }
+
+    await ctx.db.insert("broadcastEvents", args);
+    return { inserted: true, reason: "ok" as const };
+  },
+});
+
+type BroadcastStats = {
+  broadcastId: string;
+  counts: Record<string, number>;
+  // Computed against `delivered` as the denominator. `null` when
+  // `delivered === 0` (rate is undefined, not zero).
+  bounceRate: number | null;
+  complaintRate: number | null;
+  openRate: number | null;
+  clickRate: number | null;
+  // Kill-gate booleans — `true` if the threshold has been crossed.
+  // Use these to halt subsequent canary expansion.
+  bouncesOverThreshold: boolean;
+  complaintsOverThreshold: boolean;
+};
+
+const BOUNCE_KILL_THRESHOLD = 0.04; // 4%
+const COMPLAINT_KILL_THRESHOLD = 0.0008; // 0.08%
+
+/**
+ * Live aggregate for one broadcast. Designed for operator polling during
+ * a canary send — call from a watch script every few seconds and stop
+ * the rollout the moment a kill-gate trips.
+ *
+ * Counts each event type via the `by_broadcast_event` compound index;
+ * read cost is proportional to the per-type result size, not the full
+ * `broadcastEvents` table.
+ */
+export const getBroadcastStats = internalQuery({
+  args: { broadcastId: v.string() },
+  handler: async (ctx, { broadcastId }): Promise<BroadcastStats> => {
+    const counts: Record<string, number> = {};
+    for (const eventType of BROADCAST_TRACKED_EVENT_TYPES) {
+      const rows = await ctx.db
+        .query("broadcastEvents")
+        .withIndex("by_broadcast_event", (q) =>
+          q.eq("broadcastId", broadcastId).eq("eventType", eventType),
+        )
+        .collect();
+      counts[eventType] = rows.length;
+    }
+
+    const delivered = counts["email.delivered"] ?? 0;
+    const rate = (n: number) => (delivered > 0 ? n / delivered : null);
+
+    const bounceRate = rate(counts["email.bounced"] ?? 0);
+    const complaintRate = rate(counts["email.complained"] ?? 0);
+
+    return {
+      broadcastId,
+      counts,
+      bounceRate,
+      complaintRate,
+      openRate: rate(counts["email.opened"] ?? 0),
+      clickRate: rate(counts["email.clicked"] ?? 0),
+      bouncesOverThreshold:
+        bounceRate !== null && bounceRate > BOUNCE_KILL_THRESHOLD,
+      complaintsOverThreshold:
+        complaintRate !== null && complaintRate > COMPLAINT_KILL_THRESHOLD,
+    };
+  },
+});

--- a/convex/broadcast/proLaunchEmailContent.ts
+++ b/convex/broadcast/proLaunchEmailContent.ts
@@ -40,7 +40,7 @@ It grew a new way to interact with it. Describe any visualization in plain langu
 
 And it became something your AI can use. WorldMonitor is accessible via REST API and MCP server. Connect it to Claude, ChatGPT, or Cursor in three minutes, and 28 live data tools become available inside your AI chat. Ask Claude "what's happening in the Taiwan Strait right now" and it pulls real-time data instead of training-set memories.
 
-More than half of this didn't exist 45 days ago. That's the build pace.
+More than half of this didn't exist 45 days ago. The open-source repo (https://github.com/koala73/worldmonitor) crossed 50,000 GitHub stars in the same window. That's the build pace.
 
 Most of it is in the free dashboard. PRO is where the two things you just read about earn their keep:
 
@@ -81,7 +81,7 @@ export const PRO_LAUNCH_HTML = `<!DOCTYPE html><html><body style="margin:0;paddi
 <p><strong>It grew a dedicated energy variant.</strong> <a href="https://energy.worldmonitor.app" style="color:#0066cc;">energy.worldmonitor.app</a>: live traffic and exposure on the four major shipping chokepoints, tanker positions in real time, 631 oil and gas pipelines mapped, EU gas storage, refinery utilization, retail fuel.</p>
 <p><strong>It grew a new way to interact with it.</strong> Describe any visualization in plain language: <em>"crude oil versus gold today," "worst international flight delays right now."</em> The AI builds it as a live widget on your dashboard. Save as many as you want.</p>
 <p><strong>And it became something your AI can use.</strong> WorldMonitor is accessible via REST API and MCP server. Connect it to Claude, ChatGPT, or Cursor in three minutes, and 28 live data tools become available inside your AI chat. Ask Claude <em>"what's happening in the Taiwan Strait right now"</em> and it pulls real-time data instead of training-set memories.</p>
-<p>More than half of this didn't exist 45 days ago. That's the build pace.</p>
+<p>More than half of this didn't exist 45 days ago. The <a href="https://github.com/koala73/worldmonitor" style="color:#0066cc;">open-source repo</a> crossed 50,000 GitHub stars in the same window. That's the build pace.</p>
 <p>Most of it is in the free dashboard. PRO is where the two things you just read about earn their keep:</p>
 <p><strong>AI Widget Builder.</strong> Plain language, live widget on your dashboard. Save as many as you want.</p>
 <p><strong>Native AI context.</strong> MCP server plus a 27-endpoint REST API. Plug it into Claude, ChatGPT, Cursor, or anything you're building.</p>

--- a/convex/broadcast/proLaunchEmailContent.ts
+++ b/convex/broadcast/proLaunchEmailContent.ts
@@ -1,0 +1,105 @@
+/**
+ * Locked PRO-launch email content.
+ *
+ * The body was finalised on 2026-04-26 with Elie. Source-of-truth copy
+ * lives in this file (not in code review comments or chat history) so
+ * future re-sends can reproduce the exact wording.
+ *
+ * If the copy needs to change for re-broadcasting, EDIT THIS FILE in a
+ * separate PR — don't change it inline as part of operational work.
+ */
+
+export const PRO_LAUNCH_FROM = "Elie from WorldMonitor <news@worldmonitor.app>";
+export const PRO_LAUNCH_REPLY_TO = "elie@worldmonitor.app";
+export const PRO_LAUNCH_SUBJECT = "You waitlisted WorldMonitor PRO. It's live.";
+
+// CAN-SPAM physical address. Required in every commercial email footer.
+// Update if the company physical address changes.
+export const PRO_LAUNCH_PHYSICAL_ADDRESS = "WorldMonitor — physical address TBD before send";
+
+// Token Resend auto-fills with the per-recipient unsubscribe URL.
+const UNSUBSCRIBE_TOKEN = "{{{RESEND_UNSUBSCRIBE_URL}}}";
+
+/**
+ * Plain-text fallback. Renders cleanly when the recipient's client
+ * blocks HTML, when forwarded into Slack/Teams threads, and as the
+ * deliverability spam-filter input. Should communicate the same value
+ * as the HTML version, not be a stripped-down preview of it.
+ */
+export const PRO_LAUNCH_TEXT = `I'm Elie, founder of WorldMonitor. PRO launched today. I'm writing because some of you signed up months ago, when the product was smaller and different.
+
+Here's what it is now.
+
+WorldMonitor stopped being only a real-time monitoring dashboard, though it still excels at that. It's also a research tool now. It tracks what's happening, and it forecasts what happens next: scenario probabilities on conflicts, market reactions to a headline you paste in, supply-chain shock paths, country stability trajectories. You read the present and stress-test the future in the same place.
+
+The dashboard grew sideways. Conflicts stream live alongside sanctions, regime shifts, GPS jamming, displacement, climate anomalies. Bilateral trade flows, tariff trends, chokepoint indices, route disruption, cost-shock simulations, stability scoring across 31 countries on 40+ indicators. AI stock analysis with price targets, backtesting, a scanner for tickers trending on Reddit. Live aircraft tracking, civilian and military: fighter scrambles over the Taiwan Strait, carrier strike groups in the Persian Gulf, special-ops by callsign, 100+ airports for delays and cascades. Useful when something breaks at 3 a.m. and a price chart won't tell you why.
+
+It grew a dedicated energy variant. energy.worldmonitor.app: live traffic and exposure on the four major shipping chokepoints, tanker positions in real time, 631 oil and gas pipelines mapped, EU gas storage, refinery utilization, retail fuel.
+
+It grew a new way to interact with it. Describe any visualization in plain language: "crude oil versus gold today," "worst international flight delays right now." The AI builds it as a live widget on your dashboard. Save as many as you want.
+
+And it became something your AI can use. WorldMonitor is accessible via REST API and MCP server. Connect it to Claude, ChatGPT, or Cursor in three minutes, and 28 live data tools become available inside your AI chat. Ask Claude "what's happening in the Taiwan Strait right now" and it pulls real-time data instead of training-set memories.
+
+More than half of this didn't exist 45 days ago. That's the build pace.
+
+Most of it is in the free dashboard. PRO is where the two things you just read about earn their keep:
+
+AI Widget Builder. Plain language, live widget on your dashboard. Save as many as you want.
+
+Native AI context. MCP server plus a 27-endpoint REST API. Plug it into Claude, ChatGPT, Cursor, or anything you're building.
+
+Also included:
+- WM Analyst. AI analyst with the full signal stack: ticker, country, sector, sanctions package. Ask it what you'd Google for an hour.
+- Critical Event Alerts. Pings to Telegram, Discord, Slack, email, browser push, or any webhook when your watch list breaks. Configurable sensitivity, quiet hours, AI digests daily or weekly.
+- AI Market Implications. Paste a headline, get a read on which assets, sectors, and currencies move.
+- Latest Brief. Magazine-style daily read on the last 24h of geopolitics and markets.
+- AI Stock Analysis, backtesting, and the Reddit ticker scanner.
+
+Code EARLYWM30: 30% off any PRO plan, 30 days. If anything above made you think "I'd check this every morning," that's your nudge.
+
+If not, reply and tell me what was missing. That's the one I'll act on.
+
+Elie
+
+—
+
+Unsubscribe: ${UNSUBSCRIBE_TOKEN}
+${PRO_LAUNCH_PHYSICAL_ADDRESS}
+`;
+
+/**
+ * HTML version. Inline styles only — most email clients strip <style>
+ * blocks, so layout must work without them. Tested narrative-first:
+ * single column, system-font stack, generous line-height for legibility.
+ */
+export const PRO_LAUNCH_HTML = `<!DOCTYPE html><html><body style="margin:0;padding:0;background:#ffffff;color:#111;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;line-height:1.6;">
+<div style="max-width:620px;margin:0 auto;padding:32px 24px;">
+<p>I'm Elie, founder of WorldMonitor. PRO launched today. I'm writing because some of you signed up months ago, when the product was smaller and different.</p>
+<p>Here's what it is now.</p>
+<p>WorldMonitor stopped being only a real-time monitoring dashboard, though it still excels at that. It's also a research tool now. It tracks what's happening, and it forecasts what happens next: scenario probabilities on conflicts, market reactions to a headline you paste in, supply-chain shock paths, country stability trajectories. You read the present and stress-test the future in the same place.</p>
+<p><strong>The dashboard grew sideways.</strong> Conflicts stream live alongside sanctions, regime shifts, GPS jamming, displacement, climate anomalies. Bilateral trade flows, tariff trends, chokepoint indices, route disruption, cost-shock simulations, stability scoring across 31 countries on 40+ indicators. AI stock analysis with price targets, backtesting, a scanner for tickers trending on Reddit. Live aircraft tracking, civilian and military: fighter scrambles over the Taiwan Strait, carrier strike groups in the Persian Gulf, special-ops by callsign, 100+ airports for delays and cascades. Useful when something breaks at 3 a.m. and a price chart won't tell you why.</p>
+<p><strong>It grew a dedicated energy variant.</strong> <a href="https://energy.worldmonitor.app" style="color:#0066cc;">energy.worldmonitor.app</a>: live traffic and exposure on the four major shipping chokepoints, tanker positions in real time, 631 oil and gas pipelines mapped, EU gas storage, refinery utilization, retail fuel.</p>
+<p><strong>It grew a new way to interact with it.</strong> Describe any visualization in plain language: <em>"crude oil versus gold today," "worst international flight delays right now."</em> The AI builds it as a live widget on your dashboard. Save as many as you want.</p>
+<p><strong>And it became something your AI can use.</strong> WorldMonitor is accessible via REST API and MCP server. Connect it to Claude, ChatGPT, or Cursor in three minutes, and 28 live data tools become available inside your AI chat. Ask Claude <em>"what's happening in the Taiwan Strait right now"</em> and it pulls real-time data instead of training-set memories.</p>
+<p>More than half of this didn't exist 45 days ago. That's the build pace.</p>
+<p>Most of it is in the free dashboard. PRO is where the two things you just read about earn their keep:</p>
+<p><strong>AI Widget Builder.</strong> Plain language, live widget on your dashboard. Save as many as you want.</p>
+<p><strong>Native AI context.</strong> MCP server plus a 27-endpoint REST API. Plug it into Claude, ChatGPT, Cursor, or anything you're building.</p>
+<p>Also included:</p>
+<ul style="padding-left:20px;">
+<li><strong>WM Analyst.</strong> AI analyst with the full signal stack: ticker, country, sector, sanctions package. Ask it what you'd Google for an hour.</li>
+<li><strong>Critical Event Alerts.</strong> Pings to Telegram, Discord, Slack, email, browser push, or any webhook when your watch list breaks. Configurable sensitivity, quiet hours, AI digests daily or weekly.</li>
+<li><strong>AI Market Implications.</strong> Paste a headline, get a read on which assets, sectors, and currencies move.</li>
+<li><strong>Latest Brief.</strong> Magazine-style daily read on the last 24h of geopolitics and markets.</li>
+<li><strong>AI Stock Analysis</strong>, backtesting, and the Reddit ticker scanner.</li>
+</ul>
+<p>Code <strong>EARLYWM30</strong>: 30% off any PRO plan, 30 days. If anything above made you think <em>"I'd check this every morning,"</em> that's your nudge.</p>
+<p>If not, reply and tell me what was missing. That's the one I'll act on.</p>
+<p>Elie</p>
+<hr style="border:none;border-top:1px solid #ddd;margin:32px 0 16px;">
+<p style="font-size:12px;color:#777;line-height:1.5;">
+<a href="${UNSUBSCRIBE_TOKEN}" style="color:#777;">Unsubscribe</a><br>
+${PRO_LAUNCH_PHYSICAL_ADDRESS}
+</p>
+</div>
+</body></html>`;

--- a/convex/broadcast/sendBroadcast.ts
+++ b/convex/broadcast/sendBroadcast.ts
@@ -1,0 +1,168 @@
+/**
+ * Trigger the PRO-launch Resend Broadcast against a Resend Segment.
+ *
+ * Splits create + send so the operator can:
+ *   1. Create the broadcast (any segment, any time) — returns the
+ *      Resend `broadcastId` for tracking.
+ *   2. Inspect raw headers / preview the rendered HTML in the Resend
+ *      dashboard before firing.
+ *   3. Trigger the send — either immediately (`scheduledAt` omitted)
+ *      or at a specific ISO timestamp ("in 2 hours" / scheduled times
+ *      are supported by Resend's API).
+ *
+ * Operational sequence for the canary plan (250 → 500 → ramp):
+ *   - Pre-build a `pro-launch-canary` segment in Resend with the first
+ *     250 deduped contacts (manually in dashboard, OR via a follow-up
+ *     PR that splits the audience programmatically).
+ *   - Pre-build a `pro-launch-main` segment with the rest, mutually
+ *     exclusive from canary.
+ *   - createProLaunchBroadcast({ segmentId: canarySegmentId }) → store id
+ *   - sendProLaunchBroadcast({ broadcastId }) → fire
+ *   - Poll `broadcast/metrics:getBroadcastStats` every few seconds.
+ *     Halt before main-send if `bouncesOverThreshold` or
+ *     `complaintsOverThreshold` flips true.
+ *   - createProLaunchBroadcast({ segmentId: mainSegmentId }) → store id
+ *   - sendProLaunchBroadcast({ broadcastId }) → fire
+ *
+ * Usage (run from CLI; not callable by clients):
+ *   npx convex run broadcast/sendBroadcast:createProLaunchBroadcast \
+ *     '{"segmentId":"seg_xxx"}'
+ *   npx convex run broadcast/sendBroadcast:sendProLaunchBroadcast \
+ *     '{"broadcastId":"bro_xxx"}'
+ *   # Or schedule:
+ *   npx convex run broadcast/sendBroadcast:sendProLaunchBroadcast \
+ *     '{"broadcastId":"bro_xxx","scheduledAt":"2026-04-27T13:00:00Z"}'
+ */
+import { v } from "convex/values";
+import { internalAction } from "../_generated/server";
+import {
+  PRO_LAUNCH_FROM,
+  PRO_LAUNCH_HTML,
+  PRO_LAUNCH_REPLY_TO,
+  PRO_LAUNCH_SUBJECT,
+  PRO_LAUNCH_TEXT,
+} from "./proLaunchEmailContent";
+
+const RESEND_API_BASE = "https://api.resend.com";
+const USER_AGENT = "WorldMonitor-PROLaunchSender/1.0 (+https://worldmonitor.app)";
+
+/**
+ * Create a Resend Broadcast from the locked launch content. Does NOT
+ * send — separate `sendProLaunchBroadcast` step. Returns the new
+ * broadcast id so the operator can preview in the Resend dashboard
+ * before firing.
+ *
+ * Idempotency: NOT idempotent on segmentId. Calling twice with the same
+ * segment creates two separate broadcasts. The operator owns "have I
+ * already created this?" tracking.
+ */
+export const createProLaunchBroadcast = internalAction({
+  args: {
+    segmentId: v.string(),
+    nameSuffix: v.optional(v.string()),
+  },
+  handler: async (_ctx, { segmentId, nameSuffix }) => {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) {
+      throw new Error("[createProLaunchBroadcast] RESEND_API_KEY not set");
+    }
+
+    const name =
+      nameSuffix && nameSuffix.length > 0
+        ? `PRO Launch — ${nameSuffix}`
+        : `PRO Launch — ${new Date().toISOString().slice(0, 10)}`;
+
+    const res = await fetch(`${RESEND_API_BASE}/broadcasts`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+        "User-Agent": USER_AGENT,
+      },
+      body: JSON.stringify({
+        name,
+        segment_id: segmentId,
+        from: PRO_LAUNCH_FROM,
+        reply_to: PRO_LAUNCH_REPLY_TO,
+        subject: PRO_LAUNCH_SUBJECT,
+        html: PRO_LAUNCH_HTML,
+        text: PRO_LAUNCH_TEXT,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "<no body>");
+      throw new Error(
+        `[createProLaunchBroadcast] Resend ${res.status}: ${body}`,
+      );
+    }
+
+    const json = (await res.json().catch(() => null)) as {
+      id?: string;
+    } | null;
+    if (!json?.id) {
+      throw new Error(
+        `[createProLaunchBroadcast] Resend response missing id: ${JSON.stringify(json)}`,
+      );
+    }
+
+    return {
+      broadcastId: json.id,
+      name,
+      segmentId,
+      subject: PRO_LAUNCH_SUBJECT,
+    };
+  },
+});
+
+/**
+ * Send (or schedule) a previously-created Resend Broadcast.
+ *
+ * `scheduledAt`: ISO 8601 timestamp string OR a natural-language phrase
+ * Resend accepts ("in 2 hours"). Omit for immediate send.
+ *
+ * Resend's send endpoint is fire-and-forget — it returns immediately
+ * after queueing. Track delivery via the `broadcastEvents` table
+ * (populated by webhook events) or the `getBroadcastStats` query.
+ */
+export const sendProLaunchBroadcast = internalAction({
+  args: {
+    broadcastId: v.string(),
+    scheduledAt: v.optional(v.string()),
+  },
+  handler: async (_ctx, { broadcastId, scheduledAt }) => {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) {
+      throw new Error("[sendProLaunchBroadcast] RESEND_API_KEY not set");
+    }
+
+    const body: Record<string, unknown> = {};
+    if (scheduledAt) body.scheduled_at = scheduledAt;
+
+    const res = await fetch(
+      `${RESEND_API_BASE}/broadcasts/${encodeURIComponent(broadcastId)}/send`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+          "User-Agent": USER_AGENT,
+        },
+        body: JSON.stringify(body),
+      },
+    );
+
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => "<no body>");
+      throw new Error(
+        `[sendProLaunchBroadcast] Resend ${res.status}: ${errBody}`,
+      );
+    }
+
+    return {
+      broadcastId,
+      status: scheduledAt ? "scheduled" : "queued",
+      scheduledAt: scheduledAt ?? null,
+    };
+  },
+});

--- a/convex/broadcast/sendBroadcast.ts
+++ b/convex/broadcast/sendBroadcast.ts
@@ -38,6 +38,7 @@ import { internalAction } from "../_generated/server";
 import {
   PRO_LAUNCH_FROM,
   PRO_LAUNCH_HTML,
+  PRO_LAUNCH_PHYSICAL_ADDRESS,
   PRO_LAUNCH_REPLY_TO,
   PRO_LAUNCH_SUBJECT,
   PRO_LAUNCH_TEXT,
@@ -65,6 +66,22 @@ export const createProLaunchBroadcast = internalAction({
     const apiKey = process.env.RESEND_API_KEY;
     if (!apiKey) {
       throw new Error("[createProLaunchBroadcast] RESEND_API_KEY not set");
+    }
+
+    // Hard-gate: refuse to ship the placeholder physical address.
+    // CAN-SPAM requires a valid postal address in every commercial
+    // email footer; sending the literal "physical address TBD" string
+    // is non-compliant and embarrassing. Edit
+    // `PRO_LAUNCH_PHYSICAL_ADDRESS` in proLaunchEmailContent.ts to the
+    // real postal address before invoking this action.
+    if (
+      PRO_LAUNCH_PHYSICAL_ADDRESS.includes("TBD") ||
+      PRO_LAUNCH_PHYSICAL_ADDRESS.includes("placeholder")
+    ) {
+      throw new Error(
+        `[createProLaunchBroadcast] PRO_LAUNCH_PHYSICAL_ADDRESS is still a placeholder ("${PRO_LAUNCH_PHYSICAL_ADDRESS}"). ` +
+          "Set the real CAN-SPAM postal address in convex/broadcast/proLaunchEmailContent.ts before sending.",
+      );
     }
 
     const name =

--- a/convex/resendWebhookHandler.ts
+++ b/convex/resendWebhookHandler.ts
@@ -1,8 +1,12 @@
 import { httpAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { requireEnv } from "./lib/env";
+import { BROADCAST_TRACKED_EVENT_TYPES } from "./broadcast/metrics";
 
 const HANDLED_EVENTS = new Set(["email.bounced", "email.complained"]);
+const BROADCAST_TRACKED_SET: ReadonlySet<string> = new Set(
+  BROADCAST_TRACKED_EVENT_TYPES,
+);
 
 async function verifySignature(
   payload: string,
@@ -56,11 +60,54 @@ export const resendWebhookHandler = httpAction(async (ctx, request) => {
     return new Response("Invalid signature", { status: 401 });
   }
 
-  let event: { type: string; data?: { to?: string[]; email_id?: string } };
+  let event: {
+    type: string;
+    created_at?: string;
+    data?: {
+      to?: string[];
+      email_id?: string;
+      broadcast_id?: string;
+    };
+  };
   try {
     event = JSON.parse(rawBody);
   } catch {
     return new Response("Invalid JSON", { status: 400 });
+  }
+
+  // Broadcast metrics — record any tracked event tagged with a
+  // `broadcast_id` into `broadcastEvents` for canary kill-gate decisions.
+  // Idempotent on svix-id (Resend retries on 5xx and we MUST treat each
+  // delivery as at-most-once).
+  const broadcastId = event.data?.broadcast_id;
+  if (broadcastId && BROADCAST_TRACKED_SET.has(event.type)) {
+    const svixId = request.headers.get("svix-id");
+    if (svixId) {
+      const occurredAt = event.created_at
+        ? Date.parse(event.created_at) || Date.now()
+        : Date.now();
+      try {
+        await ctx.runMutation(
+          internal.broadcast.metrics.recordBroadcastEvent,
+          {
+            webhookEventId: svixId,
+            broadcastId,
+            emailMessageId: event.data?.email_id,
+            eventType: event.type,
+            occurredAt,
+            rawPayload: event.data,
+          },
+        );
+      } catch (err) {
+        console.error(
+          `[resend-webhook] Failed to record broadcast event ${event.type} for ${broadcastId}:`,
+          err,
+        );
+        // Don't 500 the webhook on metrics-record failure — Resend would
+        // retry and we'd risk amplifying the issue. Suppression below is
+        // the more important path; metrics is best-effort.
+      }
+    }
   }
 
   if (!HANDLED_EVENTS.has(event.type)) {

--- a/convex/resendWebhookHandler.ts
+++ b/convex/resendWebhookHandler.ts
@@ -81,35 +81,36 @@ export const resendWebhookHandler = httpAction(async (ctx, request) => {
   // delivery as at-most-once).
   const broadcastId = event.data?.broadcast_id;
   if (broadcastId && BROADCAST_TRACKED_SET.has(event.type)) {
-    const svixId = request.headers.get("svix-id");
-    if (svixId) {
-      const occurredAt = event.created_at
-        ? Date.parse(event.created_at) || Date.now()
-        : Date.now();
-      try {
-        await ctx.runMutation(
-          internal.broadcast.metrics.recordBroadcastEvent,
-          {
-            webhookEventId: svixId,
-            broadcastId,
-            emailMessageId: event.data?.email_id,
-            eventType: event.type,
-            occurredAt,
-            // Intentionally NOT forwarding event.data — it includes
-            // recipient emails (`to: string[]`), `from`, `subject`,
-            // etc. Identifier metadata above is enough; deeper
-            // inspection via emailMessageId in the Resend dashboard.
-          },
-        );
-      } catch (err) {
-        console.error(
-          `[resend-webhook] Failed to record broadcast event ${event.type} for ${broadcastId}:`,
-          err,
-        );
-        // Don't 500 the webhook on metrics-record failure — Resend would
-        // retry and we'd risk amplifying the issue. Suppression below is
-        // the more important path; metrics is best-effort.
-      }
+    // svix-id is guaranteed non-null here: verifySignature returns false
+    // (and we 401'd above) if any of svix-id / svix-timestamp /
+    // svix-signature were absent. Non-null assert rather than re-guard.
+    const svixId = request.headers.get("svix-id") as string;
+    const occurredAt = event.created_at
+      ? Date.parse(event.created_at) || Date.now()
+      : Date.now();
+    try {
+      await ctx.runMutation(
+        internal.broadcast.metrics.recordBroadcastEvent,
+        {
+          webhookEventId: svixId,
+          broadcastId,
+          emailMessageId: event.data?.email_id,
+          eventType: event.type,
+          occurredAt,
+          // Intentionally NOT forwarding event.data — it includes
+          // recipient emails (`to: string[]`), `from`, `subject`,
+          // etc. Identifier metadata above is enough; deeper
+          // inspection via emailMessageId in the Resend dashboard.
+        },
+      );
+    } catch (err) {
+      console.error(
+        `[resend-webhook] Failed to record broadcast event ${event.type} for ${broadcastId}:`,
+        err,
+      );
+      // Don't 500 the webhook on metrics-record failure — Resend would
+      // retry and we'd risk amplifying the issue. Suppression below is
+      // the more important path; metrics is best-effort.
     }
   }
 

--- a/convex/resendWebhookHandler.ts
+++ b/convex/resendWebhookHandler.ts
@@ -95,7 +95,10 @@ export const resendWebhookHandler = httpAction(async (ctx, request) => {
             emailMessageId: event.data?.email_id,
             eventType: event.type,
             occurredAt,
-            rawPayload: event.data,
+            // Intentionally NOT forwarding event.data — it includes
+            // recipient emails (`to: string[]`), `from`, `subject`,
+            // etc. Identifier metadata above is enough; deeper
+            // inspection via emailMessageId in the Resend dashboard.
           },
         );
       } catch (err) {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -288,4 +288,21 @@ export default defineSchema({
     suppressedAt: v.number(),
     source: v.optional(v.string()),
   }).index("by_normalized_email", ["normalizedEmail"]),
+
+  // Per-event log of Resend webhook deliveries tagged with a broadcast_id.
+  // Used to drive canary kill-gates (bounce > 4%, complaint > 0.08%) and
+  // post-send engagement reporting. Idempotent on `webhookEventId` — Resend
+  // retries on 5xx and we MUST treat every delivery as at-most-once.
+  // No recipient email stored — Convex dashboard logs are observable; we
+  // rely on Resend's `email_id` for traceability via their dashboard.
+  broadcastEvents: defineTable({
+    webhookEventId: v.string(),
+    broadcastId: v.string(),
+    emailMessageId: v.optional(v.string()),
+    eventType: v.string(),
+    occurredAt: v.number(),
+    rawPayload: v.any(),
+  })
+    .index("by_webhookEventId", ["webhookEventId"])
+    .index("by_broadcast_event", ["broadcastId", "eventType"]),
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -290,19 +290,36 @@ export default defineSchema({
   }).index("by_normalized_email", ["normalizedEmail"]),
 
   // Per-event log of Resend webhook deliveries tagged with a broadcast_id.
-  // Used to drive canary kill-gates (bounce > 4%, complaint > 0.08%) and
-  // post-send engagement reporting. Idempotent on `webhookEventId` — Resend
-  // retries on 5xx and we MUST treat every delivery as at-most-once.
-  // No recipient email stored — Convex dashboard logs are observable; we
-  // rely on Resend's `email_id` for traceability via their dashboard.
+  // Used as forensic detail to drive engineer-level inspection alongside
+  // Resend's dashboard. Idempotent on `webhookEventId` — Resend retries
+  // on 5xx and we MUST treat every delivery as at-most-once.
+  //
+  // No recipient email stored, AND no rawPayload stored — Resend's
+  // `data` object includes `to: string[]` (recipient addresses), `from`,
+  // `subject`, etc. that are PII or PII-adjacent. Convex dashboard rows
+  // are observable to anyone with project access. We keep only the
+  // identifying metadata; if a specific event needs deeper inspection,
+  // look it up by `emailMessageId` in the Resend dashboard.
   broadcastEvents: defineTable({
     webhookEventId: v.string(),
     broadcastId: v.string(),
     emailMessageId: v.optional(v.string()),
     eventType: v.string(),
     occurredAt: v.number(),
-    rawPayload: v.any(),
   })
     .index("by_webhookEventId", ["webhookEventId"])
     .index("by_broadcast_event", ["broadcastId", "eventType"]),
+
+  // Pre-aggregated counter per (broadcastId, eventType). Updated by
+  // `recordBroadcastEvent` after a successful idempotent insert into
+  // `broadcastEvents`. Enables `getBroadcastStats` to run in O(N tracked
+  // event types) instead of O(events), so canary monitoring and
+  // post-send reporting work past Convex's 16,384-doc per-query read
+  // limit (a 30k-recipient send overruns it on `email.delivered` alone).
+  broadcastEventCounts: defineTable({
+    broadcastId: v.string(),
+    eventType: v.string(),
+    count: v.number(),
+    updatedAt: v.number(),
+  }).index("by_broadcast_event", ["broadcastId", "eventType"]),
 });


### PR DESCRIPTION
## Why

Third PR in the WorldMonitor PRO-launch broadcast chain. Builds on the audience-export pipeline (#3431, merged) to deliver the actual send + canary kill-gate observability.

## What this adds

### Schema
**`broadcastEvents` table** — per-event log of Resend webhook deliveries tagged with a `broadcast_id`. Indexes:
- `by_webhookEventId` — idempotency on Resend retries (svix-id)
- `by_broadcast_event` — aggregation per broadcast + event type

No recipient email stored — Convex dashboard logs are observable; we rely on Resend's `email_id` for traceability via their dashboard.

### Locked email content
**`convex/broadcast/proLaunchEmailContent.ts`** — source-of-truth for the launch copy: subject, from, reply-to, plain-text fallback, HTML, CAN-SPAM physical-address footer placeholder. Body finalised with Elie 2026-04-26. Future re-sends edit this file in a separate PR.

Subject locked: `You waitlisted WorldMonitor PRO. It's live.`
Discount: `EARLYWM30` (30% off, 30-day expiry — must be configured in Dodo before send).

### Metrics
**`convex/broadcast/metrics.ts`** —
- **`recordBroadcastEvent`** (`internalMutation`): idempotent on `webhookEventId`, drops untracked event types defensively.
- **`getBroadcastStats`** (`internalQuery`): live aggregate per broadcast — counts per tracked event type, plus `bounceRate` / `complaintRate` / `openRate` / `clickRate` (against `delivered`), plus boolean kill-gate flags `bouncesOverThreshold` (>4%) and `complaintsOverThreshold` (>0.08%) driven by the project plan.

### Send actions
**`convex/broadcast/sendBroadcast.ts`** —
- **`createProLaunchBroadcast`** (`internalAction`): `POST /broadcasts` to Resend with the locked content + given `segment_id`. Returns Resend broadcast id for previewing in their dashboard before firing.
- **`sendProLaunchBroadcast`** (`internalAction`): `POST /broadcasts/{id}/send`, optional `scheduled_at` ISO timestamp for time-of-day scheduling.

Splitting create + send is intentional — the operator can verify rendered HTML in Resend's preview before committing to the send.

### Webhook extension
**`convex/resendWebhookHandler.ts`** — extended to forward any tracked event with a `broadcast_id` to `recordBroadcastEvent` BEFORE the existing suppression handling. Metrics-record failure does NOT 500 the webhook — suppression is the more important path and Resend retries would amplify the problem.

### Codegen
`_generated/api.d.ts` declares `broadcast/metrics`, `broadcast/sendBroadcast`, `broadcast/proLaunchEmailContent`. Convex regenerates identically on next deploy — no drift risk.

## Verification

- `npx tsc --noEmit -p convex/tsconfig.json` → clean
- All actions / queries / mutations are `internal` only — never exposed to clients
- Webhook extension preserves the existing 200-on-non-handled-event short-circuit, so non-broadcast Resend traffic is unaffected
- Webhook idempotency anchored on the svix-id header (Resend's signed event id)
- `User-Agent` set on every Resend fetch per AGENTS.md

## Operational sequence (after merge + deploy)

```bash
# Pre-flight (one-time)
# - Configure Dodo coupon EARLYWM30 (30% off, 30-day expiry, usage cap)
# - Set up `news@worldmonitor.app` sender on Resend domain
# - Manually create canary + main Resend Segments in Resend dashboard
# - Run customer normalizedEmail backfill
npx convex run payments/backfillCustomerNormalizedEmail:backfill

# Populate audiences (uses #3431's action — already merged)
npx convex run broadcast/audienceExport:exportProLaunchAudience \
  '{"segmentId":"<canary>","dryRun":true}'   # verify dedup math
npx convex run broadcast/audienceExport:exportProLaunchAudience \
  '{"segmentId":"<canary>"}'                  # populate canary
npx convex run broadcast/audienceExport:exportProLaunchAudience \
  '{"segmentId":"<main>"}'                    # populate main

# Fire the canary
npx convex run broadcast/sendBroadcast:createProLaunchBroadcast \
  '{"segmentId":"<canary>","nameSuffix":"Canary 250"}'   # → broadcastId
npx convex run broadcast/sendBroadcast:sendProLaunchBroadcast \
  '{"broadcastId":"<id>"}'

# Watch the kill-gates (poll every few seconds)
npx convex run broadcast/metrics:getBroadcastStats \
  '{"broadcastId":"<id>"}'

# If bouncesOverThreshold or complaintsOverThreshold flips true → STOP.
# Otherwise repeat the create + send + monitor loop with the main segment.
```

## Out of scope (deferred)

- **Programmatic segment splitting** — for first send, segments are split manually in Resend dashboard. A follow-up could add a `splitAudienceForCanary` action.
- **Live monitoring loop / dashboard** — `getBroadcastStats` is the primitive; an automated kill-gate trigger (page-on-threshold, halt-main-send-on-canary-failure) is a separate concern.
- **RFC 8058 `List-Unsubscribe-Post` header verification** — must be checked by inspecting raw headers on a test send before canary. Resend may auto-inject; not confirmed in their docs.
- **Physical address in footer** — currently a placeholder. UPDATE `PRO_LAUNCH_PHYSICAL_ADDRESS` in `proLaunchEmailContent.ts` with the real address before send.