### PR TITLE
copy(proLaunch): tighten opener + add proper CTAs

### DIFF
--- a/convex/broadcast/proLaunchEmailContent.ts
+++ b/convex/broadcast/proLaunchEmailContent.ts
@@ -13,6 +13,11 @@ export const PRO_LAUNCH_FROM = "Elie from WorldMonitor <news@worldmonitor.app>";
 export const PRO_LAUNCH_REPLY_TO = "elie@worldmonitor.app";
 export const PRO_LAUNCH_SUBJECT = "You waitlisted WorldMonitor PRO. It's live.";
 
+// Primary CTA destination. UTMs scoped to this campaign so we can attribute
+// conversions in analytics. Update if the upgrade page moves.
+export const PRO_LAUNCH_UPGRADE_URL =
+  "https://worldmonitor.app/pro?utm_source=resend&utm_medium=email&utm_campaign=pro-launch&utm_content=launch-email";
+
 // CAN-SPAM physical address. Required in every commercial email footer.
 // Update if the company physical address changes.
 export const PRO_LAUNCH_PHYSICAL_ADDRESS = "WorldMonitor FZ LLC, Dubai - United Arab Emirates";
@@ -26,7 +31,7 @@ const UNSUBSCRIBE_TOKEN = "{{{RESEND_UNSUBSCRIBE_URL}}}";
  * deliverability spam-filter input. Should communicate the same value
  * as the HTML version, not be a stripped-down preview of it.
  */
-export const PRO_LAUNCH_TEXT = `I'm Elie, founder of WorldMonitor. PRO launched today. I'm writing because some of you signed up months ago, when the product was smaller and different.
+export const PRO_LAUNCH_TEXT = `I'm Elie, founder of WorldMonitor. PRO launched today (https://worldmonitor.app/pro). I'm writing because you signed up a month ago, when the product was smaller and different.
 
 Here's what it is now.
 
@@ -57,6 +62,8 @@ Also included:
 
 Code EARLYWM30: 30% off any PRO plan, 30 days. If anything above made you think "I'd check this every morning," that's your nudge.
 
+→ Upgrade to PRO: https://worldmonitor.app/pro?utm_source=resend&utm_medium=email&utm_campaign=pro-launch&utm_content=launch-email
+
 If not, reply and tell me what was missing. That's the one I'll act on.
 
 Elie
@@ -74,7 +81,7 @@ ${PRO_LAUNCH_PHYSICAL_ADDRESS}
  */
 export const PRO_LAUNCH_HTML = `<!DOCTYPE html><html><body style="margin:0;padding:0;background:#ffffff;color:#111;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;line-height:1.6;">
 <div style="max-width:620px;margin:0 auto;padding:32px 24px;">
-<p>I'm Elie, founder of WorldMonitor. PRO launched today. I'm writing because some of you signed up months ago, when the product was smaller and different.</p>
+<p>I'm Elie, founder of WorldMonitor. <a href="https://worldmonitor.app/pro?utm_source=resend&utm_medium=email&utm_campaign=pro-launch&utm_content=opener" style="color:#0066cc;">PRO launched today</a>. I'm writing because you signed up a month ago, when the product was smaller and different.</p>
 <p>Here's what it is now.</p>
 <p>WorldMonitor stopped being only a real-time monitoring dashboard, though it still excels at that. It's also a research tool now. It tracks what's happening, and it forecasts what happens next: scenario probabilities on conflicts, market reactions to a headline you paste in, supply-chain shock paths, country stability trajectories. You read the present and stress-test the future in the same place.</p>
 <p><strong>The dashboard grew sideways.</strong> Conflicts stream live alongside sanctions, regime shifts, GPS jamming, displacement, climate anomalies. Bilateral trade flows, tariff trends, chokepoint indices, route disruption, cost-shock simulations, stability scoring across 31 countries on 40+ indicators. AI stock analysis with price targets, backtesting, a scanner for tickers trending on Reddit. Live aircraft tracking, civilian and military: fighter scrambles over the Taiwan Strait, carrier strike groups in the Persian Gulf, special-ops by callsign, 100+ airports for delays and cascades. Useful when something breaks at 3 a.m. and a price chart won't tell you why.</p>
@@ -94,6 +101,9 @@ export const PRO_LAUNCH_HTML = `<!DOCTYPE html><html><body style="margin:0;paddi
 <li><strong>AI Stock Analysis</strong>, backtesting, and the Reddit ticker scanner.</li>
 </ul>
 <p>Code <strong>EARLYWM30</strong>: 30% off any PRO plan, 30 days. If anything above made you think <em>"I'd check this every morning,"</em> that's your nudge.</p>
+<p style="margin:24px 0;text-align:center;">
+<a href="https://worldmonitor.app/pro?utm_source=resend&utm_medium=email&utm_campaign=pro-launch&utm_content=cta-button" style="display:inline-block;background:#111;color:#ffffff;text-decoration:none;padding:14px 28px;border-radius:6px;font-weight:600;">Upgrade to PRO with EARLYWM30 →</a>
+</p>
 <p>If not, reply and tell me what was missing. That's the one I'll act on.</p>
 <p>Elie</p>
 <hr style="border:none;border-top:1px solid #ddd;margin:32px 0 16px;">


### PR DESCRIPTION
## Why

Updates in test send to `elie.habib@gmail.com`:

1. **Opener softened the appeal.** "Some of you signed up months ago" assumed the list was older than it actually is and addressed the reader as a member of a vague group rather than directly. List is ≤1.5 months old.

2. **"PRO launched today" wasn't a link.** First sentence promised the news but gave no clickable destination. A reader curious enough to open the email but skeptical of reading 600 words had no way to act early.

3. **No actual CTA.** The "Code EARLYWM30: 30% off any PRO plan, 30 days. If anything above made you think 'I'd check this every morning,' that's your nudge." line told readers there was a nudge but gave them nowhere to go. The only links in the email were `energy.worldmonitor.app` and the GitHub repo — neither converts to PRO.

## What

- **Opener tweak:** "some of you signed up months ago" → "you signed up a month ago". Singular addressee, accurate timing.
- **Hyperlink "PRO launched today"** → `/pro?utm_content=opener`. Soft-sell click for the early-clickers.
- **Add a button-style CTA** after the discount line: "Upgrade to PRO with EARLYWM30 →" → `/pro?utm_content=cta-button`. Hard-sell click for the bottom-of-funnel readers.
- **New `PRO_LAUNCH_UPGRADE_URL` constant** at the top of the file so the upgrade page can move without hunting through HTML/text bodies.
- **Plain-text version** carries the URLs inline next to "PRO launched today" and after "30 days." for plain-text fallback readers.

## Two-UTM split

`utm_content=opener` and `utm_content=cta-button` lets us see how the two CTA placements convert differently. If the opener clickthrough rate dwarfs the CTA-button rate, we know readers don't make it to the bottom; if the reverse, the body is doing its job. Both still resolve to the same `/pro` page so no funnel branching needed.

## Verification

- `npx tsc --noEmit -p convex/tsconfig.json` → clean
- Resend's `email.clicked` webhook event will tag with the link clicked, so `broadcastEvents` will let us inspect per-link clickthrough after the canary

## Operational

After merge + Convex deploy: the existing test broadcast (`broadcastId 4e512658...`) is locked to the OLD copy because Resend snapshots content at broadcast creation. Need to:
1. Merge + deploy
2. Create a fresh test broadcast against the same `test` segment
3. Verify the new opener wording + clickable links + CTA button