### PR TITLE
copy(proLaunch): subject 'It's live' → 'It's now live'

### DIFF
--- a/convex/broadcast/proLaunchEmailContent.ts
+++ b/convex/broadcast/proLaunchEmailContent.ts
@@ -11,7 +11,7 @@
 
 export const PRO_LAUNCH_FROM = "Elie from WorldMonitor <news@worldmonitor.app>";
 export const PRO_LAUNCH_REPLY_TO = "elie@worldmonitor.app";
-export const PRO_LAUNCH_SUBJECT = "You waitlisted WorldMonitor PRO. It's live.";
+export const PRO_LAUNCH_SUBJECT = "You waitlisted WorldMonitor PRO. It's now live.";
 
 // Primary CTA destination. UTMs scoped to this campaign so we can attribute
 // conversions in analytics. Update if the upgrade page moves.


### PR DESCRIPTION
Tiny subject tweak before canary send. Adds 'now' for present-tense freshness — reads as a moment-in-time signal instead of a flat declaration.

Old: `You waitlisted WorldMonitor PRO. It's live.`
New: `You waitlisted WorldMonitor PRO. It's now live.`

Char count: 47 → 51, still mobile-safe. After merge + Convex deploy, next `createProLaunchBroadcast` call will pick up the new subject.