### PR TITLE
copy(proLaunch): drop www. from docs URL for link consistency

### DIFF
--- a/convex/broadcast/proLaunchEmailContent.ts
+++ b/convex/broadcast/proLaunchEmailContent.ts
@@ -51,7 +51,7 @@ Most of it is in the free dashboard. PRO is where the two things you just read a
 
 AI Widget Builder. Plain language, live widget on your dashboard. Save as many as you want.
 
-Native AI context. MCP server plus a 27-endpoint REST API — full docs at https://www.worldmonitor.app/docs/documentation. Plug it into Claude, ChatGPT, Cursor, or anything you're building.
+Native AI context. MCP server plus a 27-endpoint REST API — full docs at https://worldmonitor.app/docs/documentation. Plug it into Claude, ChatGPT, Cursor, or anything you're building.
 
 Also included:
 - WM Analyst. AI analyst with the full signal stack: ticker, country, sector, sanctions package. Ask it what you'd Google for an hour.
@@ -91,7 +91,7 @@ export const PRO_LAUNCH_HTML = `<!DOCTYPE html><html><body style="margin:0;paddi
 <p>More than half of this didn't exist 45 days ago. The <a href="https://github.com/koala73/worldmonitor" style="color:#0066cc;">open-source repo</a> crossed 50,000 GitHub stars in the same window. That's the build pace.</p>
 <p>Most of it is in the free dashboard. PRO is where the two things you just read about earn their keep:</p>
 <p><strong>AI Widget Builder.</strong> Plain language, live widget on your dashboard. Save as many as you want.</p>
-<p><strong>Native AI context.</strong> MCP server plus a 27-endpoint REST API — <a href="https://www.worldmonitor.app/docs/documentation" style="color:#0066cc;">full docs</a>. Plug it into Claude, ChatGPT, Cursor, or anything you're building.</p>
+<p><strong>Native AI context.</strong> MCP server plus a 27-endpoint REST API — <a href="https://worldmonitor.app/docs/documentation" style="color:#0066cc;">full docs</a>. Plug it into Claude, ChatGPT, Cursor, or anything you're building.</p>
 <p>Also included:</p>
 <ul style="padding-left:20px;">
 <li><strong>WM Analyst.</strong> AI analyst with the full signal stack: ticker, country, sector, sanctions package. Ask it what you'd Google for an hour.</li>


### PR DESCRIPTION
## Summary
- Strips `www.` from the docs URL added in #3440 (`https://www.worldmonitor.app/docs/documentation` → `https://worldmonitor.app/docs/documentation`).
- Both sites: plain-text version (line 54) and HTML version (line 94).
- Resolves the [Greptile P2](https://github.com/koala73/worldmonitor/pull/3440#discussion_r2456260000) flagged on #3440 — every other `worldmonitor.app` link in this file (upgrade URL, plain-text PRO link, HTML opener CTA, energy variant link, GitHub repo link) uses the bare apex domain. The new docs URL was the only one using `www.`.

## Why
- One extra redirect hop on most modern setups (apex → www, or www → apex depending on host config).
- Visual inconsistency in plain-text clients where the URL renders literally — the `www.` jumps out as the odd one.
- Net: −2 chars per render, one less redirect, consistent.

## Test plan
- [x] Pre-push hooks: typecheck, typecheck:api, CJS syntax, Unicode safety, lint:boundaries, edge bundle, version sync — all green.
- [x] Manually verified the bare apex resolves to the docs page (same target).
- [ ] Vercel preview deploys cleanly (auto).