### PR TITLE
chore: bump version to 2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "world-monitor",
-  "version": "2.6.7",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "world-monitor",
-      "version": "2.6.7",
+      "version": "2.8.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "world-monitor",
   "private": true,
-  "version": "2.6.7",
+  "version": "2.8.0",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "world-monitor"
-version = "2.6.7"
+version = "2.8.0"
 dependencies = [
  "getrandom 0.2.17",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-monitor"
-version = "2.6.7"
+version = "2.8.0"
 description = "World Monitor desktop application"
 authors = ["World Monitor"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "World Monitor",
   "mainBinaryName": "world-monitor",
-  "version": "2.6.7",
+  "version": "2.8.0",
   "identifier": "app.worldmonitor.desktop",
   "build": {
     "beforeDevCommand": "npm run build:sidecar-sebuf && node scripts/build-sidecar-handlers.mjs && npm run dev",


### PR DESCRIPTION
## Summary
- Bumps app version from `2.6.7` → `2.8.0` across the four canonical sites:
  - `package.json` (source of truth)
  - `src-tauri/tauri.conf.json`
  - `src-tauri/Cargo.toml`
  - `src-tauri/Cargo.lock`
- Skips the 2.7.x line intentionally.

## Test plan
- [x] `node scripts/sync-desktop-version.mjs --check` reports all four files at 2.8.0.
- [x] Pre-push hooks pass (typecheck, typecheck:api, CJS syntax, Unicode safety, lint:boundaries, edge bundle, version sync).
- [ ] Vercel preview builds cleanly (auto).