### PR TITLE
fix(health): close tariffTrendsUs silent EMPTY window (maxStaleMin > TTL inversion)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -316,7 +316,7 @@ const SEED_META = {
   faoFoodPriceIndex:   { key: 'seed-meta:economic:fao-ffpi',                  maxStaleMin: 86400 }, // monthly seed; 86400 = 60 days (2x interval)
   thermalEscalation:   { key: 'seed-meta:thermal:escalation',                 maxStaleMin: 360 }, // cron every 2h; 360 = 3x interval (was 240 = 2x)
   nationalDebt:        { key: 'seed-meta:economic:national-debt',              maxStaleMin: 86400 }, // monthly seed (seed-bundle-macro intervalMs: 30 * DAY); 60d = 2x interval absorbs one missed run. Prior 10080 (7d) was narrower than the cron interval so every cron past day 7 alarmed STALE_SEED.
-  tariffTrendsUs:      { key: 'seed-meta:trade:tariffs:v1:840:all:10',        maxStaleMin: 900 },
+  tariffTrendsUs:      { key: 'seed-meta:trade:tariffs:v1:840:all:10',        maxStaleMin: 540 }, // co-pinned to TARIFF_TTL (8h=480min) + 60min grace. Prior 900 (15h) created an 8h-15h silent window where data had expired but seed-meta was still considered fresh, masking real outages as status=EMPTY (not STALE_SEED). See scripts/seed-supply-chain-trade.mjs TARIFF_TTL.
   // publish.ts runs once daily (02:30 UTC); seed-meta TTL=52h — maxStaleMin must cover the full 24h cycle
   consumerPricesOverview:   { key: 'seed-meta:consumer-prices:overview:ae',     maxStaleMin: 1500 }, // 25h = 24h cadence + 1h grace
   consumerPricesCategories: { key: 'seed-meta:consumer-prices:categories:ae:30d',            maxStaleMin: 1500 },

--- a/tests/trade-policy-tariffs.test.mjs
+++ b/tests/trade-policy-tariffs.test.mjs
@@ -11,6 +11,7 @@ const root = resolve(__dirname, '..');
 const protoSrc = readFileSync(join(root, 'proto/worldmonitor/trade/v1/get_tariff_trends.proto'), 'utf-8');
 const tradeDataProtoSrc = readFileSync(join(root, 'proto/worldmonitor/trade/v1/trade_data.proto'), 'utf-8');
 const seedSrc = readFileSync(join(root, 'scripts/seed-supply-chain-trade.mjs'), 'utf-8');
+const healthSrc = readFileSync(join(root, 'api/health.js'), 'utf-8');
 const panelSrc = readFileSync(join(root, 'src/components/TradePolicyPanel.ts'), 'utf-8');
 const serviceSrc = readFileSync(join(root, 'src/services/trade/index.ts'), 'utf-8');
 const clientGeneratedSrc = readFileSync(join(root, 'src/generated/client/worldmonitor/trade/v1/service_client.ts'), 'utf-8');
@@ -55,6 +56,58 @@ describe('FRED effective tariff rate seed integration', () => {
   it('keeps restrictions snapshot labeled as WTO MFN baseline data', () => {
     assert.match(seedSrc, /measureType: 'WTO MFN Baseline'/);
     assert.match(seedSrc, /description: `WTO MFN baseline: \$\{value\.toFixed\(1\)\}%`/);
+  });
+});
+
+describe('tariffTrendsUs health-check maxStaleMin must not exceed TARIFF_TTL (silent-EMPTY-window guard)', () => {
+  // Regression-locks the fix for the 2026-04-27 silent EMPTY window where
+  // TARIFF_TTL was 480min (8h) but maxStaleMin was 900 (15h). Between
+  // minute 480 and minute 900, the data key was gone but seed-meta was
+  // still considered fresh, so health emitted status=EMPTY (records=0)
+  // with no STALE_SEED alarm. UptimeRobot keyword-checks for "HEALTHY"
+  // continued to pass while paying users saw "data unavailable" panels.
+  // Rule: maxStaleMin must be tightly co-pinned to TTL_DATA + small grace.
+
+  function extractSeconds(varName) {
+    const re = new RegExp(`const\\s+${varName}\\s*=\\s*(\\d+)`, 'm');
+    const m = seedSrc.match(re);
+    if (!m) throw new Error(`could not find ${varName} in seed src`);
+    return parseInt(m[1], 10);
+  }
+
+  function extractMaxStaleMin(name) {
+    const re = new RegExp(`${name}:\\s*\\{[^}]*maxStaleMin:\\s*(\\d+)`, 'm');
+    const m = healthSrc.match(re);
+    if (!m) throw new Error(`could not find ${name}.maxStaleMin in health src`);
+    return parseInt(m[1], 10);
+  }
+
+  it('TARIFF_TTL is 28800s (8h) — pinned so the relationship below stays meaningful', () => {
+    assert.equal(extractSeconds('TARIFF_TTL'), 28800);
+  });
+
+  it('tariffTrendsUs.maxStaleMin is 540min — TARIFF_TTL/60 + 60min grace', () => {
+    assert.equal(extractMaxStaleMin('tariffTrendsUs'), 540);
+  });
+
+  it('maxStaleMin <= TARIFF_TTL_min + 120 grace ceiling (no silent EMPTY window > 2h)', () => {
+    const ttlMin = extractSeconds('TARIFF_TTL') / 60;
+    const maxStale = extractMaxStaleMin('tariffTrendsUs');
+    assert.ok(
+      maxStale <= ttlMin + 120,
+      `maxStaleMin (${maxStale}) must be <= TARIFF_TTL_min (${ttlMin}) + 120 grace; ` +
+      `larger gap creates a silent EMPTY window where data has expired but no STALE_SEED fires.`,
+    );
+  });
+
+  it('maxStaleMin >= TARIFF_TTL_min (no false STALE before data even expires)', () => {
+    const ttlMin = extractSeconds('TARIFF_TTL') / 60;
+    const maxStale = extractMaxStaleMin('tariffTrendsUs');
+    assert.ok(
+      maxStale >= ttlMin,
+      `maxStaleMin (${maxStale}) must be >= TARIFF_TTL_min (${ttlMin}); ` +
+      `tighter would fire STALE_SEED before the data has even expired.`,
+    );
   });
 });
 

--- a/tests/trade-policy-tariffs.test.mjs
+++ b/tests/trade-policy-tariffs.test.mjs
@@ -76,7 +76,11 @@ describe('tariffTrendsUs health-check maxStaleMin must not exceed TARIFF_TTL (si
   }
 
   function extractMaxStaleMin(name) {
-    const re = new RegExp(`${name}:\\s*\\{[^}]*maxStaleMin:\\s*(\\d+)`, 'm');
+    // Lazy `[^}]*?` instead of greedy + `ms` flag so the pattern still works
+    // if the entry ever grows multi-line or contains nested inline objects.
+    // Failure mode is noisy regardless — test throws when no match — but the
+    // lazy form is more forgiving against future formatting changes.
+    const re = new RegExp(`${name}:\\s*\\{[^}]*?maxStaleMin:\\s*(\\d+)`, 'ms');
     const m = healthSrc.match(re);
     if (!m) throw new Error(`could not find ${name}.maxStaleMin in health src`);
     return parseInt(m[1], 10);


### PR DESCRIPTION
## Summary

Production `/api/health` 2026-04-27 reported `tariffTrendsUs: { status: EMPTY, records: 0, seedAgeMin: 619, maxStaleMin: 900 }` — paying users saw "data unavailable" on the Trade Policy panel but the health endpoint stayed green and UptimeRobot kept saying HEALTHY.

**Root cause:** \`maxStaleMin\` (900min, 15h) was set wider than the data-key TTL (\`TARIFF_TTL = 28800s = 480min\`, 8h). When the seeder fails to refresh \`trade:tariffs:v1:840:all:10\`:
- Data key expires at minute 480 (TTL).
- Seed-meta still alive with 7d default TTL.
- \`seedAgeMin (480..900) < maxStaleMin\` → \`seedStale=false\`.
- \`hasData=false + !seedStale\` → \`status=EMPTY\`.
- \`records: 0\` because api/health.js:589 forces \`records=0\` whenever \`hasData=false\` (display-only; **NOT** a "seeder wrote 0" signal).

The 480..900 minute window was a silent panel outage — no STALE_SEED alarm, no UptimeRobot page. Tightening \`maxStaleMin\` to \`TARIFF_TTL_min + 60min grace = 540\` makes STALE_SEED fire the moment the data has been gone past the cron's recovery window.

**Note:** does NOT solve the upstream issue (WTO API not returning TP_A_0010 rows for reporter 840). That remains for ops to investigate via Railway \`seed-supply-chain-trade\` logs. This PR makes the next occurrence visible within alerting.

**Sibling audit:** \`customsRevenue\` TTL=1440min, maxStaleMin=1440 → ✓ already co-pinned. Only \`tariffTrendsUs\` was inverted in this seeder's extra-key set.

## Test plan

- [x] 4 new regression tests in \`tests/trade-policy-tariffs.test.mjs\`:
  - Pin \`TARIFF_TTL = 28800\`
  - Pin \`tariffTrendsUs.maxStaleMin = 540\`
  - Assert \`maxStaleMin <= TARIFF_TTL_min + 120\` (silent-window ceiling)
  - Assert \`maxStaleMin >= TARIFF_TTL_min\` (no false-STALE floor)
- [x] \`npm run typecheck\` + \`typecheck:api\` clean
- [x] \`biome lint\` clean on touched files
- [x] \`tests/edge-functions.test.mjs\` 178/178 (api/health.js bundles cleanly)
- [ ] Production canary: next /api/health probe shows tariffTrendsUs with seedAgeMin>540 → status=STALE_SEED (if upstream WTO issue persists), not silent EMPTY