### PR TITLE
fix(energy): wire energy variant atlas panels and renewable coverage

### DIFF
--- a/e2e/map-harness.spec.ts
+++ b/e2e/map-harness.spec.ts
@@ -11,13 +11,13 @@ type OverlaySnapshot = {
 
 type VisualScenarioSummary = {
   id: string;
-  variant: 'both' | 'full' | 'tech' | 'finance';
+  variant: 'both' | 'full' | 'tech' | 'finance' | 'energy';
 };
 
 type HarnessWindow = Window & {
   __mapHarness?: {
     ready: boolean;
-    variant: 'full' | 'tech' | 'finance';
+    variant: 'full' | 'tech' | 'finance' | 'energy';
     seedAllDynamicData: () => void;
     setProtestsScenario: (scenario: 'alpha' | 'beta') => void;
     setPulseProtestsScenario: (
@@ -126,6 +126,27 @@ const EXPECTED_FINANCE_DECK_LAYERS = [
   'gulf-investments-layer',
 ];
 
+const EXPECTED_ENERGY_DECK_LAYERS = [
+  'pipelines-layer',
+  'storage-facilities-layer',
+  'fuel-shortages-layer',
+  'live-tankers-layer',
+  'ais-density-layer',
+  'ais-disruptions-layer',
+  'commodity-hubs-layer',
+  'commodity-ports-layer',
+  'trade-routes-layer',
+  'trade-chokepoints-layer',
+  'waterways-layer',
+  'weather-layer',
+  'outages-layer',
+  'earthquakes-layer',
+  'natural-events-layer',
+  'minerals-layer',
+  'fires-layer',
+  'climate-heatmap-layer',
+];
+
 const waitForHarnessReady = async (
   page: import('@playwright/test').Page
 ): Promise<void> => {
@@ -177,6 +198,8 @@ test.describe('DeckGL map harness', () => {
 
     const expectedVariant = process.env.VITE_VARIANT === 'tech'
       ? 'tech'
+      : process.env.VITE_VARIANT === 'energy'
+      ? 'energy'
       : process.env.VITE_VARIANT === 'finance'
       ? 'finance'
       : 'full';
@@ -232,6 +255,8 @@ test.describe('DeckGL map harness', () => {
 
     const expectedDeckLayers = variant === 'tech'
       ? EXPECTED_TECH_DECK_LAYERS
+      : variant === 'energy'
+      ? EXPECTED_ENERGY_DECK_LAYERS
       : variant === 'finance'
       ? EXPECTED_FINANCE_DECK_LAYERS
       : EXPECTED_FULL_DECK_LAYERS;
@@ -434,6 +459,10 @@ test.describe('DeckGL map harness', () => {
       const w = window as HarnessWindow;
       return w.__mapHarness?.variant ?? 'full';
     });
+    // Energy currently reuses the shared "both" visual scenarios; until we
+    // record Atlas-only golden scenes, compare those shared scenarios against
+    // the existing full baselines rather than silently coercing the runtime.
+    const screenshotVariant = variant === 'energy' ? 'full' : variant;
 
     const scenarios = await page.evaluate(() => {
       const w = window as HarnessWindow;
@@ -449,7 +478,7 @@ test.describe('DeckGL map harness', () => {
       await test.step(`visual baseline: ${scenario.id}`, async () => {
         await prepareVisualScenario(page, scenario.id);
         await expect(mapWrapper).toHaveScreenshot(
-          `layer-${variant}-${scenario.id}.png`,
+          `layer-${screenshotVariant}-${scenario.id}.png`,
           {
             animations: 'disabled',
             caret: 'hide',

--- a/src/App.ts
+++ b/src/App.ts
@@ -1570,6 +1570,48 @@ export class App {
     );
 
     this.refreshScheduler.scheduleRefresh(
+      'pipeline-status',
+      () => (this.state.panels['pipeline-status'] as PipelineStatusPanel).fetchData(),
+      REFRESH_INTERVALS.pipelineStatus,
+      () => this.isPanelNearViewport('pipeline-status')
+    );
+
+    this.refreshScheduler.scheduleRefresh(
+      'storage-facility-map',
+      () => (this.state.panels['storage-facility-map'] as StorageFacilityMapPanel).fetchData(),
+      REFRESH_INTERVALS.storageFacilityMap,
+      () => this.isPanelNearViewport('storage-facility-map')
+    );
+
+    this.refreshScheduler.scheduleRefresh(
+      'fuel-shortages',
+      () => (this.state.panels['fuel-shortages'] as FuelShortagePanel).fetchData(),
+      REFRESH_INTERVALS.fuelShortages,
+      () => this.isPanelNearViewport('fuel-shortages')
+    );
+
+    this.refreshScheduler.scheduleRefresh(
+      'energy-disruptions',
+      () => (this.state.panels['energy-disruptions'] as EnergyDisruptionsPanel).fetchData(),
+      REFRESH_INTERVALS.energyDisruptions,
+      () => this.isPanelNearViewport('energy-disruptions')
+    );
+
+    this.refreshScheduler.scheduleRefresh(
+      'energy-risk-overview',
+      () => (this.state.panels['energy-risk-overview'] as EnergyRiskOverviewPanel).fetchData(),
+      REFRESH_INTERVALS.energyRiskOverview,
+      () => this.isPanelNearViewport('energy-risk-overview')
+    );
+
+    this.refreshScheduler.scheduleRefresh(
+      'chokepoint-strip',
+      () => (this.state.panels['chokepoint-strip'] as ChokepointStripPanel).fetchData(),
+      REFRESH_INTERVALS.chokepointStrip,
+      () => this.isPanelNearViewport('chokepoint-strip')
+    );
+
+    this.refreshScheduler.scheduleRefresh(
       'climate-news',
       () => (this.state.panels['climate-news'] as ClimateNewsPanel).fetchData(),
       REFRESH_INTERVALS.climateNews,

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -501,12 +501,6 @@ export class DataLoaderManager implements AppModule {
           task: runGuarded('species', () => this.loadSpeciesData()),
         });
       }
-      if (shouldLoad('renewable')) {
-        tasks.push({
-          name: 'renewable',
-          task: runGuarded('renewable', () => this.loadRenewableData()),
-        });
-      }
       tasks.push({
         name: 'happinessMap',
         task: runGuarded('happinessMap', async () => {
@@ -520,6 +514,14 @@ export class DataLoaderManager implements AppModule {
           const installations = await fetchRenewableInstallations();
           this.ctx.map?.setRenewableInstallations(installations);
         }),
+      });
+    }
+
+    // Renewable panel is shared by happy and energy variants.
+    if (shouldLoad('renewable')) {
+      tasks.push({
+        name: 'renewable',
+        task: runGuarded('renewable', () => this.loadRenewableData()),
       });
     }
 

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1330,6 +1330,10 @@ export class PanelLayoutManager implements AppModule {
         }),
       );
 
+    }
+
+    // Renewable Energy is shared by happy and energy variants.
+    if (this.shouldCreatePanel('renewable') && !this.ctx.panels['renewable']) {
       this.lazyPanel('renewable', () =>
         import('@/components/RenewableEnergyPanel').then(m => {
           const p = new m.RenewableEnergyPanel();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1333,7 +1333,7 @@ export class PanelLayoutManager implements AppModule {
     }
 
     // Renewable Energy is shared by happy and energy variants.
-    if (this.shouldCreatePanel('renewable') && !this.ctx.panels['renewable']) {
+    if (this.shouldCreatePanel('renewable')) {
       this.lazyPanel('renewable', () =>
         import('@/components/RenewableEnergyPanel').then(m => {
           const p = new m.RenewableEnergyPanel();

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -598,6 +598,10 @@ export class UnifiedSettings {
     });
   }
 
+  private categoryMatchesVariant(catDef: { variants?: string[] }): boolean {
+    return !catDef.variants || catDef.variants.includes(SITE_VARIANT);
+  }
+
   private getAvailablePanelCategories(): Array<{ key: string; label: string }> {
     const settings = this.config.getPanelSettings();
     const categories: Array<{ key: string; label: string }> = [
@@ -605,6 +609,7 @@ export class UnifiedSettings {
     ];
 
     for (const [catKey, catDef] of Object.entries(PANEL_CATEGORY_MAP)) {
+      if (!this.categoryMatchesVariant(catDef)) continue;
       const hasEnabledPanel = catDef.panelKeys.some(pk => settings[pk]?.enabled);
       if (hasEnabledPanel) {
         categories.push({ key: catKey, label: t(catDef.labelKey) });
@@ -623,6 +628,9 @@ export class UnifiedSettings {
     if (this.activePanelCategory !== 'all') {
       const catDef = PANEL_CATEGORY_MAP[this.activePanelCategory];
       if (catDef) {
+        if (!this.categoryMatchesVariant(catDef)) {
+          return [];
+        }
         const allowed = new Set(catDef.panelKeys);
         entries = entries.filter(([key]) => allowed.has(key));
       }

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -1325,10 +1325,12 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   happyNews: {
     labelKey: 'header.panelCatHappyNews',
     panelKeys: ['positive-feed', 'progress', 'counters', 'spotlight', 'breakthroughs', 'digest'],
+    variants: ['happy'],
   },
   happyPlanet: {
     labelKey: 'header.panelCatHappyPlanet',
     panelKeys: ['species', 'renewable', 'giving'],
+    variants: ['happy'],
   },
 };
 

--- a/src/config/variants/base.ts
+++ b/src/config/variants/base.ts
@@ -58,6 +58,12 @@ export const REFRESH_INTERVALS = {
   hormuzTracker: 60 * 60 * 1000, // 1h — data updates daily
   hyperliquidFlow: 5 * 60 * 1000, // 5min — matches Railway seed cadence
   energyCrisis: 6 * 60 * 60 * 1000, // 6h — policy data updates infrequently
+  pipelineStatus: 24 * 60 * 60 * 1000, // curated registry reseeds weekly; daily poll keeps long-lived sessions fresh
+  storageFacilityMap: 24 * 60 * 60 * 1000, // curated registry reseeds weekly; daily poll keeps long-lived sessions fresh
+  fuelShortages: 60 * 60 * 1000, // active shortage alerts can change intra-day
+  energyDisruptions: 60 * 60 * 1000, // disruption log is low-volume but needs intra-day freshness
+  energyRiskOverview: 15 * 60 * 1000, // mixed market + supply-chain overview; refresh more often than the underlying weekly registries
+  chokepointStrip: 90 * 60 * 1000, // matches chokepoint client cache TTL / freshness budget
   macroTiles: 30 * 60 * 1000,
   fsi: 30 * 60 * 1000,
   yieldCurve: 30 * 60 * 1000,

--- a/src/e2e/map-harness.ts
+++ b/src/e2e/map-harness.ts
@@ -34,6 +34,7 @@ import type {
   CyberThreat,
   InternetOutage,
   MapLayers,
+  MilitaryBaseEnriched,
   MilitaryFlight,
   MilitaryFlightCluster,
   MilitaryVessel,
@@ -44,11 +45,15 @@ import type {
   SocialUnrestEvent,
 } from '../types';
 import type { AirportDelayAlert } from '../services/aviation';
+import type { ClimateAnomaly } from '../services/climate';
 import type { Earthquake } from '../services/earthquakes';
+import { setCachedFuelShortageRegistry } from '../shared/fuel-shortage-registry-store';
+import { setCachedPipelineRegistries } from '../shared/pipeline-registry-store';
+import { setCachedStorageFacilityRegistry } from '../shared/storage-facility-registry-store';
 import type { WeatherAlert } from '../services/weather';
 
 type Scenario = 'alpha' | 'beta';
-type HarnessVariant = 'full' | 'tech' | 'finance';
+type HarnessVariant = 'full' | 'tech' | 'finance' | 'energy';
 type HarnessLayerKey = keyof MapLayers;
 type PulseProtestScenario =
   | 'none'
@@ -74,6 +79,15 @@ type CameraState = {
   lon: number;
   lat: number;
   zoom: number;
+};
+
+type LiveTankerFixture = {
+  mmsi: string;
+  lat: number;
+  lon: number;
+  speed: number;
+  shipType: number;
+  name: string;
 };
 
 type VisualScenario = {
@@ -118,6 +132,8 @@ type MapHarness = {
   getCyberTooltipHtml: (indicator: string) => string;
   destroy: () => void;
 };
+
+const isEnergyHarnessVariant = SITE_VARIANT === 'energy';
 
 declare global {
   interface Window {
@@ -190,6 +206,9 @@ const allLayersEnabled: MapLayers = {
   commodityPorts: false,
   webcams: false,
   diseaseOutbreaks: true,
+  storageFacilities: false,
+  fuelShortages: false,
+  liveTankers: false,
 };
 
 const allLayersDisabled: MapLayers = {
@@ -247,6 +266,9 @@ const allLayersDisabled: MapLayers = {
   commodityPorts: false,
   webcams: false,
   diseaseOutbreaks: true,
+  storageFacilities: false,
+  fuelShortages: false,
+  liveTankers: false,
 };
 
 const SEEDED_NEWS_LOCATIONS: Array<{
@@ -263,11 +285,50 @@ const SEEDED_NEWS_LOCATIONS: Array<{
   },
 ];
 
+const SEEDED_LIVE_TANKERS: LiveTankerFixture[] = [
+  {
+    mmsi: '111000111',
+    lat: 26.45,
+    lon: 56.22,
+    speed: 0.2,
+    shipType: 80,
+    name: 'Harness VLCC Alpha',
+  },
+  {
+    mmsi: '222000222',
+    lat: 12.72,
+    lon: 43.5,
+    speed: 12.4,
+    shipType: 82,
+    name: 'Harness Aframax Beta',
+  },
+];
+
+const SEEDED_MILITARY_BASES: MilitaryBaseEnriched[] = (MILITARY_BASES as MilitaryBaseEnriched[])
+  .map((base) => ({ ...base }));
+
+const energyAllLayersEnabled: MapLayers = {
+  ...allLayersEnabled,
+  commodityPorts: true,
+  storageFacilities: true,
+  fuelShortages: true,
+  liveTankers: true,
+};
+
+const seededAllLayers: MapLayers = isEnergyHarnessVariant
+  ? energyAllLayersEnabled
+  : allLayersEnabled;
+
+const initialLayers: MapLayers = {
+  ...seededAllLayers,
+  liveTankers: false,
+};
+
 const map = new DeckGLMap(app, {
   zoom: 5,
   pan: { x: 0, y: 0 },
   view: 'global',
-  layers: allLayersEnabled,
+  layers: initialLayers,
   // Keep harness deterministic regardless of wall-clock date.
   timeRange: 'all',
 });
@@ -282,7 +343,32 @@ const internals = map as unknown as {
   newsPulseIntervalId?: ReturnType<typeof setInterval> | null;
   startupTime?: number;
   stopPulseAnimation?: () => void;
+  liveTankers?: LiveTankerFixture[];
+  loadLiveTankers?: () => Promise<void>;
+  serverBases?: MilitaryBaseEnriched[];
+  serverBaseClusters?: unknown[];
+  serverBasesLoaded?: boolean;
+  fetchServerBases?: () => void;
 };
+
+internals.loadLiveTankers = async (): Promise<void> => {
+  internals.liveTankers = SEEDED_LIVE_TANKERS.map((tanker) => ({ ...tanker }));
+};
+
+const seedHarnessBases = (): void => {
+  internals.serverBases = SEEDED_MILITARY_BASES.map((base) => ({ ...base }));
+  internals.serverBaseClusters = [];
+  internals.serverBasesLoaded = true;
+};
+
+// Keep the harness deterministic: the live RPC path can legitimately return an
+// empty viewport payload in local/dev runs, which would wipe the shared
+// `bases-layer` snapshot even though the harness is meant to exercise the
+// renderer with seeded fixture data.
+internals.fetchServerBases = (): void => {
+  seedHarnessBases();
+};
+seedHarnessBases();
 
 const buildLayerState = (enabledLayers: HarnessLayerKey[]): MapLayers => {
   const next: MapLayers = { ...allLayersDisabled };
@@ -329,12 +415,25 @@ const getDataCount = (data: unknown): number => {
   return data ? 1 : 0;
 };
 
+const normalizeLayerSnapshotId = (layerId: string): string =>
+  layerId === 'conflict-zones-layer-country-geometry'
+    ? 'conflict-zones-layer'
+    : layerId;
+
 const getDeckLayerSnapshot = (): LayerSnapshot[] => {
   const layers = internals.buildLayers?.() ?? [];
-  return layers.map((layer) => ({
-    id: layer.id,
-    dataCount: getDataCount(layer.props?.data),
-  }));
+  const counts = new Map<string, number>();
+
+  for (const layer of layers) {
+    const layerId = normalizeLayerSnapshotId(layer.id);
+    const dataCount = getDataCount(layer.props?.data);
+    const previous = counts.get(layerId) ?? 0;
+    if (dataCount > previous) {
+      counts.set(layerId, dataCount);
+    }
+  }
+
+  return [...counts.entries()].map(([id, dataCount]) => ({ id, dataCount }));
 };
 
 const getLayerDataCount = (layerId: string): number => {
@@ -346,7 +445,7 @@ const getLayerFirstScreenTransform = (layerId: string): string | null => {
   if (!maplibreMap) return null;
 
   const layers = internals.buildLayers?.() ?? [];
-  const target = layers.find((layer) => layer.id === layerId);
+  const target = layers.find((layer) => normalizeLayerSnapshotId(layer.id) === layerId);
   const data = target?.props?.data;
   if (!Array.isArray(data) || data.length === 0) return null;
 
@@ -748,6 +847,8 @@ const filterScenariosForVariant = (variant: HarnessVariant): VisualScenario[] =>
 
 const currentHarnessVariant: HarnessVariant = SITE_VARIANT === 'tech'
   ? 'tech'
+  : SITE_VARIANT === 'energy'
+  ? 'energy'
   : SITE_VARIANT === 'finance'
   ? 'finance'
   : 'full';
@@ -832,6 +933,68 @@ const buildHotspotActivityNews = (
 };
 
 const seedAllDynamicData = (): void => {
+  setCachedPipelineRegistries({
+    gas: {
+      pipelines: {
+        'e2e-gas-pipeline': {
+          id: 'e2e-gas-pipeline',
+          name: 'Harness Gas Trunkline',
+          operator: 'Harness Gas Co.',
+          commodityType: 'gas',
+          startPoint: { lat: 25.28, lon: 55.3 },
+          endPoint: { lat: 26.12, lon: 50.57 },
+        },
+      },
+      classifierVersion: 'e2e-harness-v1',
+      updatedAt: '2026-02-01T12:00:00.000Z',
+    },
+    oil: {
+      pipelines: {
+        'e2e-oil-pipeline': {
+          id: 'e2e-oil-pipeline',
+          name: 'Harness Crude Link',
+          operator: 'Harness Oil Co.',
+          commodityType: 'oil',
+          startPoint: { lat: 29.37, lon: 47.98 },
+          endPoint: { lat: 25.27, lon: 51.53 },
+        },
+      },
+      classifierVersion: 'e2e-harness-v1',
+      updatedAt: '2026-02-01T12:00:00.000Z',
+    },
+  });
+
+  setCachedStorageFacilityRegistry({
+    facilities: {
+      'e2e-storage-facility': {
+        id: 'e2e-storage-facility',
+        name: 'Harness LNG Export Terminal',
+        operator: 'Harness LNG',
+        facilityType: 'lng_export',
+        country: 'QA',
+        location: { lat: 25.98, lon: 51.61 },
+        capacityMtpa: 32.5,
+      },
+    },
+    classifierVersion: 'e2e-harness-v1',
+    updatedAt: '2026-02-01T12:00:00.000Z',
+  });
+
+  setCachedFuelShortageRegistry({
+    shortages: {
+      'e2e-fuel-shortage': {
+        id: 'e2e-fuel-shortage',
+        country: 'EG',
+        product: 'diesel',
+        severity: 'confirmed',
+        shortDescription: 'Harness shortage alert',
+        resolvedAt: null,
+      },
+    },
+    classifierVersion: 'e2e-harness-v1',
+    updatedAt: '2026-02-01T12:00:00.000Z',
+  });
+
   const earthquakes: Earthquake[] = [
     {
       id: 'e2e-eq-1',
@@ -1044,8 +1207,21 @@ const seedAllDynamicData = (): void => {
     },
   ];
 
+  const climateAnomalies: ClimateAnomaly[] = [
+    {
+      zone: 'Harness Heat Belt',
+      lat: 24.8,
+      lon: 54.9,
+      tempDelta: 3.2,
+      precipDelta: -12,
+      severity: 'extreme',
+      type: 'warm',
+      period: '2026-02',
+    },
+  ];
+
   map.setRenderPaused(true);
-  map.setLayers(allLayersEnabled);
+  map.setLayers(seededAllLayers);
   map.setZoom(5);
   map.setEarthquakes(earthquakes);
   map.setWeatherAlerts(weather);
@@ -1058,6 +1234,7 @@ const seedAllDynamicData = (): void => {
   map.setMilitaryFlights(militaryFlights, militaryFlightClusters);
   map.setMilitaryVessels(militaryVessels, militaryVesselClusters);
   map.setNaturalEvents(naturalEvents);
+  map.setClimateAnomalies(climateAnomalies);
   map.setFires([
     {
       lat: -5.4,

--- a/tests/energy-variant-atlas-guard.test.mts
+++ b/tests/energy-variant-atlas-guard.test.mts
@@ -1,0 +1,120 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+function src(relPath: string): string {
+  return readFileSync(resolve(root, relPath), 'utf-8');
+}
+
+describe('energy atlas guardrails', () => {
+  it('registers recurring refresh coverage for atlas panels', () => {
+    const base = src('src/config/variants/base.ts');
+    const app = src('src/App.ts');
+
+    const expectedIntervals = [
+      'pipelineStatus',
+      'storageFacilityMap',
+      'fuelShortages',
+      'energyDisruptions',
+      'energyRiskOverview',
+      'chokepointStrip',
+    ];
+
+    for (const key of expectedIntervals) {
+      assert.match(
+        base,
+        new RegExp(`\\b${key}:`),
+        `base refresh intervals must define ${key}`,
+      );
+    }
+
+    const schedulerCases: Array<[string, string]> = [
+      ['pipeline-status', 'pipelineStatus'],
+      ['storage-facility-map', 'storageFacilityMap'],
+      ['fuel-shortages', 'fuelShortages'],
+      ['energy-disruptions', 'energyDisruptions'],
+      ['energy-risk-overview', 'energyRiskOverview'],
+      ['chokepoint-strip', 'chokepointStrip'],
+    ];
+
+    for (const [panelId, intervalKey] of schedulerCases) {
+      assert.match(
+        app,
+        new RegExp(
+          `scheduleRefresh\\(\\s*'${panelId}'[\\s\\S]*?REFRESH_INTERVALS\\.${intervalKey}[\\s\\S]*?isPanelNearViewport\\('${panelId}'\\)`,
+        ),
+        `App.ts must schedule recurring refreshes for ${panelId}`,
+      );
+    }
+  });
+
+  it('filters variant-scoped panel categories in unified settings', () => {
+    const settings = src('src/components/UnifiedSettings.ts');
+
+    assert.match(
+      settings,
+      /private categoryMatchesVariant\(catDef: \{ variants\?: string\[\] \}\): boolean \{[\s\S]*?catDef\.variants\.includes\(SITE_VARIANT\)/,
+      'UnifiedSettings must compare category variants against SITE_VARIANT',
+    );
+    assert.match(
+      settings,
+      /getAvailablePanelCategories\(\):[\s\S]*?categoryMatchesVariant\(catDef\)/,
+      'category pills must skip categories outside the active variant',
+    );
+    assert.match(
+      settings,
+      /getVisiblePanelEntries\(\):[\s\S]*?categoryMatchesVariant\(catDef\)/,
+      'panel entry filtering must honor category variant scoping too',
+    );
+  });
+
+  it('treats energy as a first-class map harness variant', () => {
+    const harness = src('src/e2e/map-harness.ts');
+
+    assert.match(
+      harness,
+      /type HarnessVariant = 'full' \| 'tech' \| 'finance' \| 'energy';/,
+      'map harness must include energy in its runtime variant union',
+    );
+    assert.match(
+      harness,
+      /SITE_VARIANT === 'energy'\s*\?\s*'energy'/,
+      'map harness must resolve SITE_VARIANT=energy to the energy harness branch',
+    );
+    assert.match(
+      harness,
+      /const energyAllLayersEnabled: MapLayers = \{[\s\S]*?commodityPorts:\s*true,[\s\S]*?storageFacilities:\s*true,[\s\S]*?fuelShortages:\s*true,[\s\S]*?liveTankers:\s*true,/,
+      'energy harness must enable Atlas-specific map layers only in the energy-specific seeded layer set',
+    );
+    assert.match(
+      harness,
+      /setCachedPipelineRegistries\([\s\S]*?setCachedStorageFacilityRegistry\([\s\S]*?setCachedFuelShortageRegistry\(/,
+      'energy harness must seed Atlas registry stores instead of relying on network fetches',
+    );
+  });
+
+  it('uses energy-specific deck expectations in playwright coverage', () => {
+    const spec = src('e2e/map-harness.spec.ts');
+
+    assert.match(
+      spec,
+      /const EXPECTED_ENERGY_DECK_LAYERS = \[/,
+      'Playwright harness spec must define energy-specific expected deck layers',
+    );
+    assert.match(
+      spec,
+      /process\.env\.VITE_VARIANT === 'energy'\s*\?\s*'energy'/,
+      'Playwright harness spec must expect the energy runtime variant when requested',
+    );
+    assert.match(
+      spec,
+      /variant === 'energy'\s*\?\s*EXPECTED_ENERGY_DECK_LAYERS/,
+      'Playwright harness spec must assert Atlas-specific layer coverage',
+    );
+  });
+});

--- a/tests/energy-variant-renewable-guard.test.mts
+++ b/tests/energy-variant-renewable-guard.test.mts
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+function src(relPath: string): string {
+  return readFileSync(resolve(root, relPath), 'utf-8');
+}
+
+describe('energy variant renewable wiring', () => {
+  it('energy variant enables the renewable panel', () => {
+    const panels = src('src/config/panels.ts');
+    const energyPanelsBlock = panels.match(/const ENERGY_PANELS:[\s\S]*?^};/m);
+    assert.ok(energyPanelsBlock, 'ENERGY_PANELS block not found');
+    assert.match(
+      energyPanelsBlock[0],
+      /\brenewable:\s*\{\s*name:\s*'Renewable Energy'/,
+      'energy variant must keep renewable enabled in ENERGY_PANELS',
+    );
+  });
+
+  it('panel-layout mounts renewable for any variant that enables it', () => {
+    const layout = src('src/app/panel-layout.ts');
+    assert.match(
+      layout,
+      /Renewable Energy is shared by happy and energy variants\.[\s\S]*?shouldCreatePanel\('renewable'\)[\s\S]*?this\.lazyPanel\('renewable'/,
+      'panel-layout.ts must mount RenewableEnergyPanel via shouldCreatePanel() so energy can instantiate it',
+    );
+  });
+
+  it('data-loader hydrates renewable outside the happy-only branch', () => {
+    const loader = src('src/app/data-loader.ts');
+    assert.match(
+      loader,
+      /Renewable panel is shared by happy and energy variants\.[\s\S]*?if \(shouldLoad\('renewable'\)\) \{[\s\S]*?this\.loadRenewableData\(\)/,
+      'data-loader.ts must schedule renewable loading for energy as well as happy',
+    );
+  });
+});

--- a/tests/panel-config-guardrails.test.mjs
+++ b/tests/panel-config-guardrails.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const panelLayoutSrc = readFileSync(resolve(__dirname, '../src/app/panel-layout.ts'), 'utf-8');
 
-const VARIANT_FILES = ['full', 'tech', 'finance', 'commodity', 'happy'];
+const VARIANT_FILES = ['full', 'tech', 'finance', 'commodity', 'energy', 'happy'];
 
 function parsePanelKeys(variant) {
   const src = readFileSync(resolve(__dirname, '../src/config/panels.ts'), 'utf-8');


### PR DESCRIPTION
## Summary

Fixes energy-variant wiring gaps across panel creation, data loading, refresh scheduling, and map harness coverage. This restores Atlas-related energy panels and renewable coverage for the `energy` variant, scopes panel categories correctly in settings, and adds guardrail tests for the affected paths.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Map / Globe
- [x] Config / Settings
- [x] Other: panel wiring, refresh scheduling, and test guardrails for the `energy` variant

## Checklist


- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

