### PR TITLE
fix(health): co-pin BIS-Extended triplet maxStaleMin to 3× bundle interval

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -253,22 +253,25 @@ const SEED_META = {
   macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 150 }, // seed-economy cron; primary key energy-prices has same 150min threshold
   bisPolicy:        { key: 'seed-meta:economic:bis',              maxStaleMin: 10080 }, // runSeed('economic','bis',...) writes seed-meta:economic:bis
   // seed-bis-extended.mjs is a child-process section spawned by
-  // scripts/seed-bundle-macro.mjs (Railway service `seed-bundle-macro`,
-  // cron `0 8 * * *` — daily 08:00 UTC). The per-section `intervalMs: 12*HOUR`
-  // inside the bundle config is a no-op gate here: the Railway cron only
-  // fires once per 24h, so the 12h staleness gate is always satisfied. The
-  // EFFECTIVE write cadence for these keys is therefore 24h (1440min), NOT
-  // 12h. Per-dataset seed-meta is only written when THAT dataset published
-  // fresh entries — so a single-dataset BIS outage (e.g. WS_DSR 500s) goes
-  // STALE in health without dragging down the healthy ones.
+  // scripts/seed-bundle-macro.mjs. The bundle's Railway cron fires more
+  // often than the per-section `intervalMs: 12 * HOUR` gate (production
+  // logs 2026-04-26T08:00:45 show "BIS-Extended Skipped, last seeded
+  // 175min ago, interval: 720min" — gate actively load-bearing on every
+  // bundle tick). So the EFFECTIVE write cadence is governed by the 12h
+  // gate, not the bundle cron. Per-dataset seed-meta is only written when
+  // THAT dataset published fresh entries — so a single-dataset BIS outage
+  // (e.g. WS_DSR 500s) goes STALE in health without dragging down the
+  // healthy ones.
   //
-  // The previous 1440 (= 1× cron cadence) had ZERO grace for cron drift.
-  // All three keys flipped to STALE_SEED synchronously at minute 1442 on
-  // 2026-04-27 (one missed/late cron). 2880 = 2× the 24h cadence covers
-  // single-cron drift while still firing within 48h on a real outage.
-  bisDsr:                { key: 'seed-meta:economic:bis-dsr',                  maxStaleMin: 2880 },
-  bisPropertyResidential:{ key: 'seed-meta:economic:bis-property-residential', maxStaleMin: 2880 },
-  bisPropertyCommercial: { key: 'seed-meta:economic:bis-property-commercial',  maxStaleMin: 2880 },
+  // The previous 1440 (= 2× the 12h gate, but only 1× the actual rolled-up
+  // cadence after typical cron drift) had ZERO grace. All three keys
+  // flipped to STALE_SEED synchronously at minute 1442 on 2026-04-27
+  // (gate-eligible run delayed by ~24h after one failed intermediate cron).
+  // 2160min = 3× the 12h gate covers cron drift + one degraded-to-24h
+  // cycle, fires within 36h on a real outage.
+  bisDsr:                { key: 'seed-meta:economic:bis-dsr',                  maxStaleMin: 2160 },
+  bisPropertyResidential:{ key: 'seed-meta:economic:bis-property-residential', maxStaleMin: 2160 },
+  bisPropertyCommercial: { key: 'seed-meta:economic:bis-property-commercial',  maxStaleMin: 2160 },
   imfMacro:         { key: 'seed-meta:economic:imf-macro',        maxStaleMin: 100800 }, // monthly seed; 100800min = 70 days = 2× interval (absorbs one missed run)
   imfGrowth:        { key: 'seed-meta:economic:imf-growth',       maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro (same WEO release cadence)
   imfLabor:         { key: 'seed-meta:economic:imf-labor',        maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro

--- a/api/health.js
+++ b/api/health.js
@@ -256,9 +256,15 @@ const SEED_META = {
   // specific dataset published fresh entries — so a single-dataset BIS outage
   // (e.g. WS_DSR 500s) goes stale in health without falsely dragging down the
   // healthy ones. 24h = 2× 12h cron.
-  bisDsr:                { key: 'seed-meta:economic:bis-dsr',                  maxStaleMin: 1440 },
-  bisPropertyResidential:{ key: 'seed-meta:economic:bis-property-residential', maxStaleMin: 1440 },
-  bisPropertyCommercial: { key: 'seed-meta:economic:bis-property-commercial',  maxStaleMin: 1440 },
+  // BIS-Extended bundle interval is 12h (720min) per scripts/seed-bundle-macro.mjs.
+  // 1440min was exactly 2× the cron interval = ZERO grace for cron jitter, Railway
+  // boot delay, or single missed run with retry. All three keys were flipping to
+  // STALE_SEED synchronously at minute 1442 (one missed cron) — observed 2026-04-27.
+  // 2160 = 3× interval matches the project convention for cron-driven keys
+  // (portwatchPortActivity, chokepointTransits, transitSummaries all follow 3×).
+  bisDsr:                { key: 'seed-meta:economic:bis-dsr',                  maxStaleMin: 2160 },
+  bisPropertyResidential:{ key: 'seed-meta:economic:bis-property-residential', maxStaleMin: 2160 },
+  bisPropertyCommercial: { key: 'seed-meta:economic:bis-property-commercial',  maxStaleMin: 2160 },
   imfMacro:         { key: 'seed-meta:economic:imf-macro',        maxStaleMin: 100800 }, // monthly seed; 100800min = 70 days = 2× interval (absorbs one missed run)
   imfGrowth:        { key: 'seed-meta:economic:imf-growth',       maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro (same WEO release cadence)
   imfLabor:         { key: 'seed-meta:economic:imf-labor',        maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro

--- a/api/health.js
+++ b/api/health.js
@@ -252,19 +252,23 @@ const SEED_META = {
   cableHealth:      { key: 'seed-meta:cable-health',              maxStaleMin: 90 }, // ais-relay warm-ping runs every 30min; 90min = 3× interval catches missed pings without false positives
   macroSignals:     { key: 'seed-meta:economic:macro-signals',    maxStaleMin: 150 }, // seed-economy cron; primary key energy-prices has same 150min threshold
   bisPolicy:        { key: 'seed-meta:economic:bis',              maxStaleMin: 10080 }, // runSeed('economic','bis',...) writes seed-meta:economic:bis
-  // seed-bis-extended.mjs writes per-dataset seed-meta keys ONLY when that
-  // specific dataset published fresh entries — so a single-dataset BIS outage
-  // (e.g. WS_DSR 500s) goes stale in health without falsely dragging down
-  // the healthy ones. BIS-Extended bundle interval is 12h (720min) per
-  // scripts/seed-bundle-macro.mjs. The previous 1440 (2× cron interval) had
-  // ZERO grace for cron jitter / Railway boot / one missed run with retry —
-  // all three keys flipped to STALE_SEED synchronously at minute 1442 on
-  // 2026-04-27. 2160 = 3× interval matches the project convention for
-  // cron-driven keys (portwatchPortActivity, chokepointTransits,
-  // transitSummaries all follow 3×).
-  bisDsr:                { key: 'seed-meta:economic:bis-dsr',                  maxStaleMin: 2160 },
-  bisPropertyResidential:{ key: 'seed-meta:economic:bis-property-residential', maxStaleMin: 2160 },
-  bisPropertyCommercial: { key: 'seed-meta:economic:bis-property-commercial',  maxStaleMin: 2160 },
+  // seed-bis-extended.mjs is a child-process section spawned by
+  // scripts/seed-bundle-macro.mjs (Railway service `seed-bundle-macro`,
+  // cron `0 8 * * *` — daily 08:00 UTC). The per-section `intervalMs: 12*HOUR`
+  // inside the bundle config is a no-op gate here: the Railway cron only
+  // fires once per 24h, so the 12h staleness gate is always satisfied. The
+  // EFFECTIVE write cadence for these keys is therefore 24h (1440min), NOT
+  // 12h. Per-dataset seed-meta is only written when THAT dataset published
+  // fresh entries — so a single-dataset BIS outage (e.g. WS_DSR 500s) goes
+  // STALE in health without dragging down the healthy ones.
+  //
+  // The previous 1440 (= 1× cron cadence) had ZERO grace for cron drift.
+  // All three keys flipped to STALE_SEED synchronously at minute 1442 on
+  // 2026-04-27 (one missed/late cron). 2880 = 2× the 24h cadence covers
+  // single-cron drift while still firing within 48h on a real outage.
+  bisDsr:                { key: 'seed-meta:economic:bis-dsr',                  maxStaleMin: 2880 },
+  bisPropertyResidential:{ key: 'seed-meta:economic:bis-property-residential', maxStaleMin: 2880 },
+  bisPropertyCommercial: { key: 'seed-meta:economic:bis-property-commercial',  maxStaleMin: 2880 },
   imfMacro:         { key: 'seed-meta:economic:imf-macro',        maxStaleMin: 100800 }, // monthly seed; 100800min = 70 days = 2× interval (absorbs one missed run)
   imfGrowth:        { key: 'seed-meta:economic:imf-growth',       maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro (same WEO release cadence)
   imfLabor:         { key: 'seed-meta:economic:imf-labor',        maxStaleMin: 100800 }, // monthly seed; 70d threshold matches imfMacro

--- a/api/health.js
+++ b/api/health.js
@@ -254,14 +254,14 @@ const SEED_META = {
   bisPolicy:        { key: 'seed-meta:economic:bis',              maxStaleMin: 10080 }, // runSeed('economic','bis',...) writes seed-meta:economic:bis
   // seed-bis-extended.mjs writes per-dataset seed-meta keys ONLY when that
   // specific dataset published fresh entries — so a single-dataset BIS outage
-  // (e.g. WS_DSR 500s) goes stale in health without falsely dragging down the
-  // healthy ones. 24h = 2× 12h cron.
-  // BIS-Extended bundle interval is 12h (720min) per scripts/seed-bundle-macro.mjs.
-  // 1440min was exactly 2× the cron interval = ZERO grace for cron jitter, Railway
-  // boot delay, or single missed run with retry. All three keys were flipping to
-  // STALE_SEED synchronously at minute 1442 (one missed cron) — observed 2026-04-27.
-  // 2160 = 3× interval matches the project convention for cron-driven keys
-  // (portwatchPortActivity, chokepointTransits, transitSummaries all follow 3×).
+  // (e.g. WS_DSR 500s) goes stale in health without falsely dragging down
+  // the healthy ones. BIS-Extended bundle interval is 12h (720min) per
+  // scripts/seed-bundle-macro.mjs. The previous 1440 (2× cron interval) had
+  // ZERO grace for cron jitter / Railway boot / one missed run with retry —
+  // all three keys flipped to STALE_SEED synchronously at minute 1442 on
+  // 2026-04-27. 2160 = 3× interval matches the project convention for
+  // cron-driven keys (portwatchPortActivity, chokepointTransits,
+  // transitSummaries all follow 3×).
   bisDsr:                { key: 'seed-meta:economic:bis-dsr',                  maxStaleMin: 2160 },
   bisPropertyResidential:{ key: 'seed-meta:economic:bis-property-residential', maxStaleMin: 2160 },
   bisPropertyCommercial: { key: 'seed-meta:economic:bis-property-commercial',  maxStaleMin: 2160 },

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -1,5 +1,8 @@
 import { describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   parseBisCSV,
@@ -257,4 +260,66 @@ describe('seed-bis-extended parser', () => {
     const out = selectBestSeriesByCountry(rows, { countryColumns: ['REF_AREA'], prefs: { PP_VALUATION: 'R' } });
     assert.equal(out.size, 0);
   });
+});
+
+describe('BIS-Extended health-check maxStaleMin co-pinned to 3× bundle interval', () => {
+  // Regression-locks the fix for the 2026-04-27 false-STALE event where all
+  // three BIS-Extended health entries (bisDsr, bisPropertyResidential,
+  // bisPropertyCommercial) flipped to STALE_SEED simultaneously at
+  // seedAgeMin=1442, just 2 minutes past maxStaleMin=1440. Root cause: the
+  // BIS-Extended bundle interval is 12h (720min); maxStaleMin was set to
+  // exactly 2× interval = ZERO grace for cron jitter / Railway boot delay /
+  // single missed run with retry. Following the project's 3× cron-driven
+  // convention (see portwatchPortActivity, chokepointTransits, etc.), the
+  // correct value is 3 × 720 = 2160min (36h).
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const root = resolve(__dirname, '..');
+  const healthSrc = readFileSync(resolve(root, 'api/health.js'), 'utf-8');
+  const bundleSrc = readFileSync(resolve(root, 'scripts/seed-bundle-macro.mjs'), 'utf-8');
+
+  function extractBundleIntervalHours(label) {
+    // Match `{ label: 'BIS-Extended', ..., intervalMs: 12 * HOUR, ... }`
+    const re = new RegExp(`label:\\s*'${label}'[\\s\\S]*?intervalMs:\\s*(\\d+)\\s*\\*\\s*HOUR`, 'm');
+    const m = bundleSrc.match(re);
+    if (!m) throw new Error(`could not find bundle entry for ${label}`);
+    return parseInt(m[1], 10);
+  }
+
+  function extractMaxStaleMin(name) {
+    const re = new RegExp(`${name}:\\s*\\{[^}]*?maxStaleMin:\\s*(\\d+)`, 'ms');
+    const m = healthSrc.match(re);
+    if (!m) throw new Error(`could not find ${name}.maxStaleMin in health src`);
+    return parseInt(m[1], 10);
+  }
+
+  it('BIS-Extended bundle interval is 12h — pinned so the relationship below stays meaningful', () => {
+    assert.equal(extractBundleIntervalHours('BIS-Extended'), 12);
+  });
+
+  for (const name of ['bisDsr', 'bisPropertyResidential', 'bisPropertyCommercial']) {
+    it(`${name}.maxStaleMin is 2160min (3× the 12h bundle interval)`, () => {
+      assert.equal(extractMaxStaleMin(name), 2160);
+    });
+
+    it(`${name}.maxStaleMin >= 2.5× bundle interval (no false-STALE on a single missed cron + retry)`, () => {
+      const intervalMin = extractBundleIntervalHours('BIS-Extended') * 60;
+      const maxStale = extractMaxStaleMin(name);
+      assert.ok(
+        maxStale >= intervalMin * 2.5,
+        `${name}.maxStaleMin (${maxStale}) must be >= ${intervalMin * 2.5} (2.5× bundle interval); ` +
+        `tighter values flip to STALE_SEED on routine cron jitter — see 2026-04-27 incident.`,
+      );
+    });
+
+    it(`${name}.maxStaleMin <= 4× bundle interval (still catches a real outage within 2 days)`, () => {
+      const intervalMin = extractBundleIntervalHours('BIS-Extended') * 60;
+      const maxStale = extractMaxStaleMin(name);
+      assert.ok(
+        maxStale <= intervalMin * 4,
+        `${name}.maxStaleMin (${maxStale}) must be <= ${intervalMin * 4} (4× bundle interval); ` +
+        `looser values mask real upstream outages from the alerting threshold.`,
+      );
+    });
+  }
 });

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -262,24 +262,44 @@ describe('seed-bis-extended parser', () => {
   });
 });
 
-describe('BIS-Extended health-check maxStaleMin co-pinned to 3× bundle interval', () => {
+describe('BIS-Extended health-check maxStaleMin co-pinned to actual cron cadence', () => {
   // Regression-locks the fix for the 2026-04-27 false-STALE event where all
   // three BIS-Extended health entries (bisDsr, bisPropertyResidential,
   // bisPropertyCommercial) flipped to STALE_SEED simultaneously at
-  // seedAgeMin=1442, just 2 minutes past maxStaleMin=1440. Root cause: the
-  // BIS-Extended bundle interval is 12h (720min); maxStaleMin was set to
-  // exactly 2× interval = ZERO grace for cron jitter / Railway boot delay /
-  // single missed run with retry. Following the project's 3× cron-driven
-  // convention (see portwatchPortActivity, chokepointTransits, etc.), the
-  // correct value is 3 × 720 = 2160min (36h).
+  // seedAgeMin=1442 vs maxStaleMin=1440 (2 minutes over).
+  //
+  // CRITICAL distinction: the bundle config in scripts/seed-bundle-macro.mjs
+  // declares `intervalMs: 12 * HOUR` for the BIS-Extended section, but
+  // `seed-bis-extended.mjs` is NOT a standalone Railway service — it's a
+  // child-process spawned by `seed-bundle-macro` whose cron schedule is
+  // `0 8 * * *` (daily, 08:00 UTC, per docs/railway-seed-consolidation-runbook.md).
+  // The 12h gate is therefore a no-op: the cron fires once per 24h so the
+  // 12h staleness check is always satisfied. EFFECTIVE write cadence = 24h.
+  //
+  // The previous maxStaleMin=1440 = 1× actual cadence = ZERO grace.
+  // Correct value per the 2× rule: 2 × 1440 = 2880min (48h).
 
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const root = resolve(__dirname, '..');
   const healthSrc = readFileSync(resolve(root, 'api/health.js'), 'utf-8');
   const bundleSrc = readFileSync(resolve(root, 'scripts/seed-bundle-macro.mjs'), 'utf-8');
+  const runbookSrc = readFileSync(resolve(root, 'docs/railway-seed-consolidation-runbook.md'), 'utf-8');
 
-  function extractBundleIntervalHours(label) {
-    // Match `{ label: 'BIS-Extended', ..., intervalMs: 12 * HOUR, ... }`
+  function extractCronCadenceMin() {
+    // Authoritative source = Railway cron schedule from the runbook.
+    // Match: `| **Cron schedule** | `0 8 * * *` (daily 08:00 UTC) |` under
+    // the `### Bundle 8: seed-bundle-macro` heading.
+    const m = runbookSrc.match(/Bundle\s+\d+:\s+seed-bundle-macro[\s\S]*?Cron schedule\*\*\s*\|\s*`([^`]+)`/);
+    if (!m) throw new Error('could not find seed-bundle-macro cron schedule in runbook');
+    const expr = m[1].trim();
+    if (expr === '0 8 * * *') return 24 * 60; // daily
+    throw new Error(`unexpected cron schedule "${expr}" — update test if cron cadence changed`);
+  }
+
+  function extractBundleSectionGateHours(label) {
+    // The per-section `intervalMs:` in seed-bundle-macro.mjs — only meaningful
+    // when smaller than the cron cadence. Pinned here so a future test can
+    // detect if the cron schedule changes and the gate becomes load-bearing.
     const re = new RegExp(`label:\\s*'${label}'[\\s\\S]*?intervalMs:\\s*(\\d+)\\s*\\*\\s*HOUR`, 'm');
     const m = bundleSrc.match(re);
     if (!m) throw new Error(`could not find bundle entry for ${label}`);
@@ -293,31 +313,39 @@ describe('BIS-Extended health-check maxStaleMin co-pinned to 3× bundle interval
     return parseInt(m[1], 10);
   }
 
-  it('BIS-Extended bundle interval is 12h — pinned so the relationship below stays meaningful', () => {
-    assert.equal(extractBundleIntervalHours('BIS-Extended'), 12);
+  it('seed-bundle-macro Railway cron is daily (24h cadence) — the actual write rate', () => {
+    assert.equal(extractCronCadenceMin(), 24 * 60);
+  });
+
+  it('BIS-Extended section gate (12h) is smaller than cron cadence (24h) — gate is a no-op, cron drives the cadence', () => {
+    const gateMin = extractBundleSectionGateHours('BIS-Extended') * 60;
+    const cronMin = extractCronCadenceMin();
+    assert.ok(gateMin <= cronMin,
+      `If the bundle's per-section gate (${gateMin}min) ever exceeds the cron cadence (${cronMin}min), ` +
+      `the gate becomes load-bearing and this test family must be re-derived from the gate, not the cron.`);
   });
 
   for (const name of ['bisDsr', 'bisPropertyResidential', 'bisPropertyCommercial']) {
-    it(`${name}.maxStaleMin is 2160min (3× the 12h bundle interval)`, () => {
-      assert.equal(extractMaxStaleMin(name), 2160);
+    it(`${name}.maxStaleMin is 2880min (2× the 24h cron cadence)`, () => {
+      assert.equal(extractMaxStaleMin(name), 2880);
     });
 
-    it(`${name}.maxStaleMin >= 2.5× bundle interval (no false-STALE on a single missed cron + retry)`, () => {
-      const intervalMin = extractBundleIntervalHours('BIS-Extended') * 60;
+    it(`${name}.maxStaleMin >= 1.5× cron cadence (no false-STALE on a single delayed cron tick)`, () => {
+      const cronMin = extractCronCadenceMin();
       const maxStale = extractMaxStaleMin(name);
       assert.ok(
-        maxStale >= intervalMin * 2.5,
-        `${name}.maxStaleMin (${maxStale}) must be >= ${intervalMin * 2.5} (2.5× bundle interval); ` +
-        `tighter values flip to STALE_SEED on routine cron jitter — see 2026-04-27 incident.`,
+        maxStale >= cronMin * 1.5,
+        `${name}.maxStaleMin (${maxStale}) must be >= ${cronMin * 1.5} (1.5× cron cadence); ` +
+        `tighter values flip to STALE_SEED on routine cron drift — see 2026-04-27 incident.`,
       );
     });
 
-    it(`${name}.maxStaleMin <= 4× bundle interval (still catches a real outage within 2 days)`, () => {
-      const intervalMin = extractBundleIntervalHours('BIS-Extended') * 60;
+    it(`${name}.maxStaleMin <= 3× cron cadence (still catches a real outage within 3 days)`, () => {
+      const cronMin = extractCronCadenceMin();
       const maxStale = extractMaxStaleMin(name);
       assert.ok(
-        maxStale <= intervalMin * 4,
-        `${name}.maxStaleMin (${maxStale}) must be <= ${intervalMin * 4} (4× bundle interval); ` +
+        maxStale <= cronMin * 3,
+        `${name}.maxStaleMin (${maxStale}) must be <= ${cronMin * 3} (3× cron cadence); ` +
         `looser values mask real upstream outages from the alerting threshold.`,
       );
     });

--- a/tests/bis-extended-seed.test.mjs
+++ b/tests/bis-extended-seed.test.mjs
@@ -262,48 +262,43 @@ describe('seed-bis-extended parser', () => {
   });
 });
 
-describe('BIS-Extended health-check maxStaleMin co-pinned to actual cron cadence', () => {
+describe('BIS-Extended health-check maxStaleMin co-pinned to section gate (load-bearing)', () => {
   // Regression-locks the fix for the 2026-04-27 false-STALE event where all
   // three BIS-Extended health entries (bisDsr, bisPropertyResidential,
   // bisPropertyCommercial) flipped to STALE_SEED simultaneously at
   // seedAgeMin=1442 vs maxStaleMin=1440 (2 minutes over).
   //
-  // CRITICAL distinction: the bundle config in scripts/seed-bundle-macro.mjs
-  // declares `intervalMs: 12 * HOUR` for the BIS-Extended section, but
-  // `seed-bis-extended.mjs` is NOT a standalone Railway service — it's a
-  // child-process spawned by `seed-bundle-macro` whose cron schedule is
-  // `0 8 * * *` (daily, 08:00 UTC, per docs/railway-seed-consolidation-runbook.md).
-  // The 12h gate is therefore a no-op: the cron fires once per 24h so the
-  // 12h staleness check is always satisfied. EFFECTIVE write cadence = 24h.
+  // The bundle's per-section `intervalMs: 12 * HOUR` IS load-bearing —
+  // production logs 2026-04-26T08:00:45 show "BIS-Extended Skipped, last
+  // seeded 175min ago, interval: 720min", confirming the bundle cron fires
+  // more often than the 12h gate. So the EFFECTIVE write cadence for BIS
+  // sections is governed by the 12h gate, not the bundle's Railway cron
+  // schedule. (The runbook's `0 8 * * *` daily schedule appears to be
+  // incomplete or stale — production runs more frequently, possibly via
+  // multiple cron entries or watch-paths-driven re-runs.)
   //
-  // The previous maxStaleMin=1440 = 1× actual cadence = ZERO grace.
-  // Correct value per the 2× rule: 2 × 1440 = 2880min (48h).
+  // Effective cadence = 12h ideal, degrading to 24h if a single intermediate
+  // bundle invocation fails. The 2026-04-27 incident saw 24h drift between
+  // gate-eligible runs.
+  //
+  // The previous maxStaleMin=1440 = 2× the 12h gate but only 1× the
+  // observed degraded cadence = ZERO grace. Correct value: 2160 = 3× the
+  // 12h gate, which equals 1.5× the degraded 24h cadence — covers cron
+  // drift while still firing within 36h on a real multi-cron outage.
 
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const root = resolve(__dirname, '..');
   const healthSrc = readFileSync(resolve(root, 'api/health.js'), 'utf-8');
   const bundleSrc = readFileSync(resolve(root, 'scripts/seed-bundle-macro.mjs'), 'utf-8');
-  const runbookSrc = readFileSync(resolve(root, 'docs/railway-seed-consolidation-runbook.md'), 'utf-8');
 
-  function extractCronCadenceMin() {
-    // Authoritative source = Railway cron schedule from the runbook.
-    // Match: `| **Cron schedule** | `0 8 * * *` (daily 08:00 UTC) |` under
-    // the `### Bundle 8: seed-bundle-macro` heading.
-    const m = runbookSrc.match(/Bundle\s+\d+:\s+seed-bundle-macro[\s\S]*?Cron schedule\*\*\s*\|\s*`([^`]+)`/);
-    if (!m) throw new Error('could not find seed-bundle-macro cron schedule in runbook');
-    const expr = m[1].trim();
-    if (expr === '0 8 * * *') return 24 * 60; // daily
-    throw new Error(`unexpected cron schedule "${expr}" — update test if cron cadence changed`);
-  }
-
-  function extractBundleSectionGateHours(label) {
-    // The per-section `intervalMs:` in seed-bundle-macro.mjs — only meaningful
-    // when smaller than the cron cadence. Pinned here so a future test can
-    // detect if the cron schedule changes and the gate becomes load-bearing.
+  function extractBundleSectionGateMin(label) {
+    // The per-section `intervalMs:` in seed-bundle-macro.mjs IS the
+    // authoritative cadence source when the bundle cron fires more often
+    // than this gate (verified in production logs 2026-04-26T08:00:45).
     const re = new RegExp(`label:\\s*'${label}'[\\s\\S]*?intervalMs:\\s*(\\d+)\\s*\\*\\s*HOUR`, 'm');
     const m = bundleSrc.match(re);
     if (!m) throw new Error(`could not find bundle entry for ${label}`);
-    return parseInt(m[1], 10);
+    return parseInt(m[1], 10) * 60;
   }
 
   function extractMaxStaleMin(name) {
@@ -313,39 +308,31 @@ describe('BIS-Extended health-check maxStaleMin co-pinned to actual cron cadence
     return parseInt(m[1], 10);
   }
 
-  it('seed-bundle-macro Railway cron is daily (24h cadence) — the actual write rate', () => {
-    assert.equal(extractCronCadenceMin(), 24 * 60);
-  });
-
-  it('BIS-Extended section gate (12h) is smaller than cron cadence (24h) — gate is a no-op, cron drives the cadence', () => {
-    const gateMin = extractBundleSectionGateHours('BIS-Extended') * 60;
-    const cronMin = extractCronCadenceMin();
-    assert.ok(gateMin <= cronMin,
-      `If the bundle's per-section gate (${gateMin}min) ever exceeds the cron cadence (${cronMin}min), ` +
-      `the gate becomes load-bearing and this test family must be re-derived from the gate, not the cron.`);
+  it('BIS-Extended section gate is 12h (720min) — pinned so the relationship below stays meaningful', () => {
+    assert.equal(extractBundleSectionGateMin('BIS-Extended'), 720);
   });
 
   for (const name of ['bisDsr', 'bisPropertyResidential', 'bisPropertyCommercial']) {
-    it(`${name}.maxStaleMin is 2880min (2× the 24h cron cadence)`, () => {
-      assert.equal(extractMaxStaleMin(name), 2880);
+    it(`${name}.maxStaleMin is 2160min (3× the 12h section gate)`, () => {
+      assert.equal(extractMaxStaleMin(name), 2160);
     });
 
-    it(`${name}.maxStaleMin >= 1.5× cron cadence (no false-STALE on a single delayed cron tick)`, () => {
-      const cronMin = extractCronCadenceMin();
+    it(`${name}.maxStaleMin >= 2.5× section gate (no false-STALE on routine cron drift)`, () => {
+      const gateMin = extractBundleSectionGateMin('BIS-Extended');
       const maxStale = extractMaxStaleMin(name);
       assert.ok(
-        maxStale >= cronMin * 1.5,
-        `${name}.maxStaleMin (${maxStale}) must be >= ${cronMin * 1.5} (1.5× cron cadence); ` +
+        maxStale >= gateMin * 2.5,
+        `${name}.maxStaleMin (${maxStale}) must be >= ${gateMin * 2.5} (2.5× section gate); ` +
         `tighter values flip to STALE_SEED on routine cron drift — see 2026-04-27 incident.`,
       );
     });
 
-    it(`${name}.maxStaleMin <= 3× cron cadence (still catches a real outage within 3 days)`, () => {
-      const cronMin = extractCronCadenceMin();
+    it(`${name}.maxStaleMin <= 4× section gate (still catches a real outage within 2 days)`, () => {
+      const gateMin = extractBundleSectionGateMin('BIS-Extended');
       const maxStale = extractMaxStaleMin(name);
       assert.ok(
-        maxStale <= cronMin * 3,
-        `${name}.maxStaleMin (${maxStale}) must be <= ${cronMin * 3} (3× cron cadence); ` +
+        maxStale <= gateMin * 4,
+        `${name}.maxStaleMin (${maxStale}) must be <= ${gateMin * 4} (4× section gate); ` +
         `looser values mask real upstream outages from the alerting threshold.`,
       );
     });


### PR DESCRIPTION
## Summary

Production \`/api/health\` 2026-04-27 reported all three BIS-Extended entries flipping to STALE_SEED at the same tick:

\`\`\`json
"bisDsr":                  { status: "STALE_SEED", records: 32, seedAgeMin: 1442, maxStaleMin: 1440 }
"bisPropertyResidential":  { status: "STALE_SEED", records: 42, seedAgeMin: 1442, maxStaleMin: 1440 }
"bisPropertyCommercial":   { status: "STALE_SEED", records: 14, seedAgeMin: 1442, maxStaleMin: 1440 }
\`\`\`

Synchronous flip across all three at seedAgeMin=1442 (2 minutes past 1440) confirms a **single missed cron event**, not three independent failures.

**Root cause:** BIS-Extended bundle interval is 12h (720min) per \`scripts/seed-bundle-macro.mjs:6\`. \`maxStaleMin: 1440\` was exactly 2× the interval = ZERO grace for cron jitter, Railway container cold-start, or one missed run + retry. Per the project convention for cron-driven keys (\`portwatchPortActivity\`, \`chokepointTransits\`, \`transitSummaries\` all follow 3× interval), the correct value is \`3 × 720 = 2160\`min (36h).

After this fix:
- 1 missed cron + recovery → still \`OK\` (no spurious page)
- 2 missed crons → \`STALE_SEED\` (real outage signal, alarm fires)

## Test plan

- [x] 10 new regression tests in \`tests/bis-extended-seed.test.mjs\`:
  - Pin BIS-Extended bundle interval = 12h
  - For each of bisDsr/bisPropertyResidential/bisPropertyCommercial:
    - Pin \`maxStaleMin = 2160\`
    - Assert \`maxStaleMin >= 2.5× interval\` (no false-STALE floor)
    - Assert \`maxStaleMin <= 4× interval\` (real-outage detection ceiling)
- [x] \`npm run typecheck\` + \`typecheck:api\` clean
- [x] \`biome lint\` clean on touched files
- [x] \`tests/edge-functions.test.mjs\` 178/178 (api/health.js bundles cleanly)
- [ ] Production canary: next /api/health probe after merge shows the BIS triplet returning to OK if the missed cron has caught up; if upstream still down, fires STALE_SEED only after 36h instead of false-positive at 24h

## Reference

Per skill \`health-maxstalemin-write-cadence\` (\`maxStaleMin = N × write_interval, never = data TTL, N=3 for cron-driven keys with cron-jitter variance\`).

Sister PR: #3444 (tariffTrendsUs silent EMPTY window — different inversion, same family of health-config bug).