### PR TITLE
fix(health): close climateAnomalies silent-EMPTY window (TTL = cron cadence)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -224,7 +224,7 @@ const SEED_META = {
   earthquakes:      { key: 'seed-meta:seismology:earthquakes',  maxStaleMin: 30 },
   wildfires:        { key: 'seed-meta:wildfire:fires',          maxStaleMin: 360 }, // FIRMS NRT resets at midnight UTC; new-day data takes 3-6h to accumulate
   outages:          { key: 'seed-meta:infra:outages',           maxStaleMin: 30 },
-  climateAnomalies: { key: 'seed-meta:climate:anomalies',       maxStaleMin: 240 }, // runs as independent Railway cron (0 */2 * * *); 240 = 2x interval
+  climateAnomalies: { key: 'seed-meta:climate:anomalies',       maxStaleMin: 540 }, // bundled into seed-bundle-climate (cron `0 */3 * * *`, every 3h); 540 = 3× cron cadence per project convention. Prior 240 (1.33× cron) flipped to silent-EMPTY between minute 180 (TTL_DATA expiry) and 240 (alarm trigger) on every routine cron-jitter cycle — see scripts/seed-climate-anomalies.mjs CACHE_TTL comment.
   climateDisasters: { key: 'seed-meta:climate:disasters',       maxStaleMin: 720 }, // runs every 6h; 720min = 2x interval
   climateAirQuality:{ key: 'seed-meta:health:air-quality',      maxStaleMin: 180 }, // hourly cron; 180 = 3x interval — shares meta key with healthAirQuality (same seeder run)
   climateZoneNormals: { key: 'seed-meta:climate:zone-normals',  maxStaleMin: 89280 }, // monthly cron on the 1st; 62d = 2x 31-day cadence

--- a/scripts/seed-climate-anomalies.mjs
+++ b/scripts/seed-climate-anomalies.mjs
@@ -8,7 +8,17 @@ import { CLIMATE_ZONE_NORMALS_KEY } from './seed-climate-zone-normals.mjs';
 loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'climate:anomalies:v2';
-const CACHE_TTL = 10800; // 3h
+// 9h = 3× the 3h bundle cron cadence (seed-bundle-climate fires every 3h).
+// Co-pinned to api/health.js's `climateAnomalies.maxStaleMin: 540` so the
+// data key survives at least until the alarm fires — no silent-EMPTY window
+// between TTL_DATA expiry and STALE_SEED trigger. The previous 10800 (3h)
+// equalled cron cadence exactly, so any cron jitter (1-3min normal Railway
+// variance) meant the data key expired in Redis before the next cron could
+// refresh it — health emitted status=EMPTY (records=0, display-forced)
+// during routine drift, and UptimeRobot's HEALTHY-substring check stayed
+// green. Production logs 2026-04-27T00:00:59 + 03:03:35 show the 3h+3min
+// drift pattern that produced the 2026-04-27 silent-EMPTY incident.
+const CACHE_TTL = 32400; // 9h
 const ANOMALY_BATCH_SIZE = 8;
 const ANOMALY_BATCH_DELAY_MS = 750;
 // Daily precipitation deltas are in mm/day (Open-Meteo daily precipitation_sum).

--- a/tests/climate-seeds.test.mjs
+++ b/tests/climate-seeds.test.mjs
@@ -1,5 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { computeMonthlyNormals, buildZoneNormalsFromBatch } from '../scripts/seed-climate-zone-normals.mjs';
 import { hasRequiredClimateZones } from '../scripts/_climate-zones.mjs';
@@ -625,5 +628,88 @@ describe('open-meteo archive helper', () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+});
+
+describe('climate-anomalies CACHE_TTL + maxStaleMin co-pinned to 3h cron cadence', () => {
+  // Regression-locks the fix for the 2026-04-27 silent-EMPTY-window incident.
+  // climate-anomalies is bundled into seed-bundle-climate (cron `0 */3 * * *`,
+  // every 3h, runbook Bundle 6). The previous CACHE_TTL=10800s (3h) equalled
+  // the cron cadence exactly — any cron jitter (1-3min normal Railway
+  // variance) caused the data key to expire BEFORE the next cron could
+  // refresh it, with health emitting status=EMPTY records=0 because
+  // seedAgeMin (~3h+drift) was still < maxStaleMin (4h). Production logs
+  // 2026-04-27T00:00:59 + 03:03:35 show the 3h+3min drift pattern.
+  //
+  // Fix: TTL = 6h (2× cron cadence) so data survives single missed cron;
+  // maxStaleMin = 9h (3× cron cadence per project convention) so alarm
+  // fires on a real outage but tolerates routine drift.
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const root = resolve(__dirname, '..');
+  const seedSrc = readFileSync(resolve(root, 'scripts/seed-climate-anomalies.mjs'), 'utf-8');
+  const healthSrc = readFileSync(resolve(root, 'api/health.js'), 'utf-8');
+  const bundleSrc = readFileSync(resolve(root, 'scripts/seed-bundle-climate.mjs'), 'utf-8');
+
+  function extractCacheTtlSec() {
+    const m = seedSrc.match(/const\s+CACHE_TTL\s*=\s*(\d+)/m);
+    if (!m) throw new Error('could not find CACHE_TTL in seed-climate-anomalies.mjs');
+    return parseInt(m[1], 10);
+  }
+
+  function extractBundleSectionGateSec(label) {
+    const re = new RegExp(`label:\\s*'${label}'[\\s\\S]*?intervalMs:\\s*(\\d+)\\s*\\*\\s*HOUR`, 'm');
+    const m = bundleSrc.match(re);
+    if (!m) throw new Error(`could not find bundle entry for ${label}`);
+    return parseInt(m[1], 10) * 3600;
+  }
+
+  function extractMaxStaleMin(name) {
+    const re = new RegExp(`${name}:\\s*\\{[^}]*?maxStaleMin:\\s*(\\d+)`, 'ms');
+    const m = healthSrc.match(re);
+    if (!m) throw new Error(`could not find ${name}.maxStaleMin in health src`);
+    return parseInt(m[1], 10);
+  }
+
+  it('Anomalies bundle section gate is 3h (matches cron cadence)', () => {
+    assert.equal(extractBundleSectionGateSec('Anomalies'), 3 * 3600);
+  });
+
+  it('CACHE_TTL is 32400s (9h, 3× the 3h cron cadence; co-pinned to maxStaleMin)', () => {
+    assert.equal(extractCacheTtlSec(), 32400);
+  });
+
+  it('CACHE_TTL > cron cadence (data survives one missed cron + drift)', () => {
+    const ttl = extractCacheTtlSec();
+    const cron = extractBundleSectionGateSec('Anomalies');
+    assert.ok(
+      ttl >= cron * 2,
+      `CACHE_TTL (${ttl}s) must be >= 2× cron cadence (${cron * 2}s); ` +
+      `tighter values create silent-EMPTY windows on every cron-jitter cycle — see 2026-04-27 incident.`,
+    );
+  });
+
+  it('climateAnomalies.maxStaleMin is 540 (3× cron cadence per project convention)', () => {
+    assert.equal(extractMaxStaleMin('climateAnomalies'), 540);
+  });
+
+  it('CACHE_TTL_min >= maxStaleMin (no silent-EMPTY window: data survives at least until alarm fires)', () => {
+    const ttlMin = extractCacheTtlSec() / 60;
+    const maxStale = extractMaxStaleMin('climateAnomalies');
+    assert.ok(
+      ttlMin >= maxStale,
+      `CACHE_TTL_min (${ttlMin}) must be >= maxStaleMin (${maxStale}); ` +
+      `larger maxStaleMin creates a (TTL, maxStaleMin) silent window where data is gone but no alarm fires.`,
+    );
+  });
+
+  it('maxStaleMin >= 2.5× cron cadence (no false-STALE on routine cron drift)', () => {
+    const cronMin = extractBundleSectionGateSec('Anomalies') / 60;
+    const maxStale = extractMaxStaleMin('climateAnomalies');
+    assert.ok(
+      maxStale >= cronMin * 2.5,
+      `climateAnomalies.maxStaleMin (${maxStale}) must be >= ${cronMin * 2.5} (2.5× cron cadence); ` +
+      `tighter values flip to STALE_SEED on routine cron drift.`,
+    );
   });
 });

--- a/tests/climate-seeds.test.mjs
+++ b/tests/climate-seeds.test.mjs
@@ -641,9 +641,13 @@ describe('climate-anomalies CACHE_TTL + maxStaleMin co-pinned to 3h cron cadence
   // seedAgeMin (~3h+drift) was still < maxStaleMin (4h). Production logs
   // 2026-04-27T00:00:59 + 03:03:35 show the 3h+3min drift pattern.
   //
-  // Fix: TTL = 6h (2× cron cadence) so data survives single missed cron;
-  // maxStaleMin = 9h (3× cron cadence per project convention) so alarm
-  // fires on a real outage but tolerates routine drift.
+  // Fix: TTL = 9h (3× cron cadence) so data survives one missed cron + drift,
+  // co-pinned to maxStaleMin (also 9h / 540min) so the data key is always
+  // alive when the alarm would fire — no silent-EMPTY window. maxStaleMin =
+  // 9h (3× cron cadence per project convention) fires on a real outage but
+  // tolerates routine drift. (An earlier draft used TTL=6h but the
+  // `TTL_min >= maxStaleMin` test below caught the residual 6h-9h gap and
+  // forced TTL up to match.)
 
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const root = resolve(__dirname, '..');


### PR DESCRIPTION
## Summary

Production `/api/health` 2026-04-27 reported:

```json
"climateAnomalies": { "status": "EMPTY", "records": 0, "seedAgeMin": 202, "maxStaleMin": 240 }
```

Railway logs prove the **seeder is healthy** — wrote 22 records at 00:00:59 UTC and again at 03:03:35 UTC (normal 3h+3min cron drift between runs).

**Root cause:** `CACHE_TTL = 10800s (3h)` exactly equalled the cron cadence of `seed-bundle-climate` (`0 */3 * * *`). Any cron jitter (the 1-3min Railway variance is routine, not a fault) meant the data key expired in Redis before the next cron wrote a fresh one. `seedAgeMin (~3h+drift)` was still `< maxStaleMin (4h)`, so health emitted `status: EMPTY records: 0` (display-forced because `hasData=false` per `api/health.js:589`) — and UptimeRobot's HEALTHY substring check kept saying HEALTHY while the panel showed "data unavailable."

Compounding: `maxStaleMin: 240` was only 1.33× cron cadence; project convention for cron-driven keys is 3× (`portwatchPortActivity`, `chokepointTransits`, `transitSummaries`). The inline comment was stale too — said "runs as independent Railway cron `0 */2 * * *`" but climate-anomalies was migrated into seed-bundle-climate Bundle 6 with cron `0 */3 * * *`.

## Fix

- `CACHE_TTL`: 10800 (3h, = cron cadence) → **32400 (9h, 3× cron)**
- `climateAnomalies.maxStaleMin`: 240 → **540 (3× cron)**
- Inline comment in `api/health.js` corrected
- Both values **co-pinned at 540min** so there's no `TTL_DATA < maxStaleMin` inversion (no silent-EMPTY window)

## Test plan

- [x] 6 new regression tests in `tests/climate-seeds.test.mjs`:
  - Pin Anomalies bundle gate = 3h
  - Pin `CACHE_TTL = 32400`
  - Pin `maxStaleMin = 540`
  - Assert `TTL >= cron × 2` (data survives one missed cron)
  - Assert `TTL_min >= maxStaleMin` (no silent-EMPTY window — caught a bug in my own first attempt!)
  - Assert `maxStaleMin >= cron × 2.5` (no false-STALE on cron drift)
- [x] `npm run typecheck` + `typecheck:api` clean
- [x] `biome lint` clean on touched files
- [x] `tests/edge-functions.test.mjs` 178/178 (api/health.js bundles cleanly)
- [ ] Production canary: next /api/health probe shows climateAnomalies returning to OK if seeder ran recently; if upstream Open-Meteo is down, fires STALE_SEED at 9h instead of silent EMPTY at 3h

## Related

- PR #3444 — same silent-EMPTY-window pattern on tariffTrendsUs
- PR #3448 — sister fix for BIS-Extended triplet (cron-cadence inversion, different shape)
- Skill: `health-empty-status-data-ttl-vs-maxstalemin-gap`
- Skill: `health-maxstalemin-write-cadence`