### PR TITLE
chore(observability): comprehensive Sentry coverage sweep across api/ + convex/payments + add lint guard

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -65,6 +65,9 @@ node scripts/check-unicode-safety.mjs || exit 1
 echo "Running architectural boundary check..."
 npm run lint:boundaries || exit 1
 
+echo "Running Sentry-coverage check..."
+node scripts/check-sentry-coverage.mjs || exit 1
+
 echo "Running rate-limit policy coverage check..."
 npm run lint:rate-limit-policies || exit 1
 

--- a/api/_sentry-common.js
+++ b/api/_sentry-common.js
@@ -93,11 +93,11 @@ async function deliver(body, logPrefix) {
     // `keepalive: true` is critical for Vercel edge runtime: when a
     // handler returns a Response, the V8 isolate can be torn down
     // before unawaited promises finish. `keepalive` lets the underlying
-    // request survive isolate termination, so a `void
-    // captureSilentError(...)` at a catch site that immediately returns
-    // a Response still delivers the event. Defence-in-depth: callers
-    // are still expected to use `ctx.waitUntil(captureSilentError(...))`
-    // where they have access to the Vercel context.
+    // request survive isolate teardown so callers without access to
+    // ctx (nested helpers, local tests) still deliver events.
+    // Defence-in-depth: callers WITH ctx pass it via `opts.ctx` and
+    // `makeCaptureSilentError` registers the promise via
+    // `ctx.waitUntil` — see below.
     const res = await fetch(_envelopeUrl, {
       method: 'POST',
       keepalive: true,
@@ -126,13 +126,39 @@ async function deliver(body, logPrefix) {
 }
 
 /**
- * Build a `captureSilentError(err, ctx)` function bound to a runtime
+ * Build a `captureSilentError(err, opts)` function bound to a runtime
  * (edge or node). The caller is the runtime-specific helper file.
+ *
+ * Opts:
+ *   - `tags`  filterable Sentry tags
+ *   - `extra` non-indexed event payload
+ *   - `ctx`   the Vercel handler context (optional). When present, the
+ *             helper calls `ctx.waitUntil(...)` so the V8 isolate stays
+ *             alive long enough to dispatch the envelope fetch. When
+ *             absent (local tests, sidecar, non-Vercel invocations),
+ *             the call falls back to fire-and-forget — the
+ *             `keepalive: true` flag on the underlying fetch is the
+ *             safety net for in-flight delivery, and `.catch(() => {})`
+ *             silences the unhandled-rejection diagnostic that would
+ *             otherwise poison Node's test runner.
+ *
+ * The function returns the underlying Promise either way, so callers
+ * that need to await delivery (e.g., a deeply nested helper running
+ * inside an existing waitUntil chain) can still do so.
  */
 export function makeCaptureSilentError({ runtime, platform, logPrefix }) {
   const runtimeCfg = { runtime, platform };
-  return async function captureSilentError(err, ctx) {
-    if (!_envelopeUrl || !_key) return;
-    await deliver(buildEnvelope(err, ctx, runtimeCfg), logPrefix);
+  return function captureSilentError(err, opts) {
+    if (!_envelopeUrl || !_key) return Promise.resolve();
+    const promise = deliver(buildEnvelope(err, opts, runtimeCfg), logPrefix);
+    if (opts?.ctx && typeof opts.ctx.waitUntil === 'function') {
+      opts.ctx.waitUntil(promise);
+    } else {
+      // Defuse unhandled rejection — `deliver` already swallows errors
+      // internally, but belt-and-suspenders for environments where
+      // `process.on('unhandledRejection')` is fatal (Node test runner).
+      promise.catch(() => {});
+    }
+    return promise;
   };
 }

--- a/api/_sentry-common.js
+++ b/api/_sentry-common.js
@@ -1,0 +1,138 @@
+/**
+ * Shared envelope builder + delivery for the Vercel api/ Sentry helpers.
+ *
+ * `_sentry-edge.js` and `_sentry-node.js` were near-duplicates differing
+ * only in the `runtime` / `platform` tag and a console-prefix string.
+ * This module owns the envelope format, the stack-frame parser, and the
+ * fire-and-forget fetch — the runtime-specific helpers are now thin
+ * factories that bind those three knobs and re-export
+ * `captureSilentError`.
+ *
+ * Any future change to the Sentry envelope format, the ingestion path,
+ * the stack parser, or the keepalive/timeout policy lives here only.
+ */
+
+let _key = '';
+let _envelopeUrl = '';
+
+(function parseDsn() {
+  const dsn = process.env.VITE_SENTRY_DSN ?? '';
+  if (!dsn) return;
+  try {
+    const u = new URL(dsn);
+    _key = u.username;
+    const projectId = u.pathname.replace(/^\//, '');
+    _envelopeUrl = `${u.protocol}//${u.host}/api/${projectId}/envelope/`;
+  } catch {
+    // Malformed DSN — silently disable; never throw from a logger.
+  }
+})();
+
+// Best-effort stack-frame parse. Sentry accepts the raw `stack` string
+// in `extra` if frames aren't parsed, but parsed frames render in the
+// dashboard with file/line/function — much more useful for triage.
+function parseStack(stack) {
+  const lines = stack.split('\n').slice(1, 30); // skip the "Error: msg" header line
+  const frames = [];
+  for (const line of lines) {
+    const m = line.match(/at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?$/);
+    if (!m) continue;
+    frames.push({
+      function: m[1] || '<anonymous>',
+      filename: m[2],
+      lineno: Number(m[3]),
+      colno: Number(m[4]),
+    });
+  }
+  // Sentry expects oldest frame first
+  return frames.reverse();
+}
+
+/**
+ * @param {unknown} err
+ * @param {{ tags?: Record<string, string|number|boolean>, extra?: Record<string, unknown> }} [ctx]
+ * @param {{ runtime: 'edge' | 'node', platform: 'javascript' | 'node' }} runtimeCfg
+ */
+function buildEnvelope(err, ctx, runtimeCfg) {
+  const errMsg = err instanceof Error ? err.message : String(err);
+  const errType = err instanceof Error ? err.constructor.name : 'Error';
+  const stack = err instanceof Error && err.stack ? err.stack : undefined;
+  const eventId = crypto.randomUUID().replace(/-/g, '');
+  const timestamp = new Date().toISOString();
+
+  const event = {
+    event_id: eventId,
+    timestamp,
+    level: 'error',
+    platform: runtimeCfg.platform,
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'production',
+    release: process.env.VERCEL_GIT_COMMIT_SHA,
+    exception: {
+      values: [
+        {
+          type: errType,
+          value: errMsg,
+          ...(stack ? { stacktrace: { frames: parseStack(stack) } } : {}),
+        },
+      ],
+    },
+    tags: { surface: 'api', runtime: runtimeCfg.runtime, ...(ctx?.tags ?? {}) },
+    extra: ctx?.extra,
+  };
+
+  // Envelope format: header line, item header line, item payload line.
+  const header = JSON.stringify({ event_id: eventId, sent_at: timestamp });
+  const itemHeader = JSON.stringify({ type: 'event' });
+  const itemPayload = JSON.stringify(event);
+  return `${header}\n${itemHeader}\n${itemPayload}\n`;
+}
+
+async function deliver(body, logPrefix) {
+  if (!_envelopeUrl || !_key) return;
+  try {
+    // `keepalive: true` is critical for Vercel edge runtime: when a
+    // handler returns a Response, the V8 isolate can be torn down
+    // before unawaited promises finish. `keepalive` lets the underlying
+    // request survive isolate termination, so a `void
+    // captureSilentError(...)` at a catch site that immediately returns
+    // a Response still delivers the event. Defence-in-depth: callers
+    // are still expected to use `ctx.waitUntil(captureSilentError(...))`
+    // where they have access to the Vercel context.
+    const res = await fetch(_envelopeUrl, {
+      method: 'POST',
+      keepalive: true,
+      signal: AbortSignal.timeout(2000),
+      headers: {
+        'Content-Type': 'application/x-sentry-envelope',
+        'X-Sentry-Auth': `Sentry sentry_version=7, sentry_key=${_key}`,
+      },
+      body,
+    });
+    if (!res.ok) {
+      const hint =
+        res.status === 401 || res.status === 403
+          ? ' — check VITE_SENTRY_DSN and auth key'
+          : res.status === 429
+            ? ' — rate limited by Sentry'
+            : ' — Sentry outage or transient error';
+      console.warn(`${logPrefix} non-2xx response ${res.status}${hint}`);
+    }
+  } catch (fetchErr) {
+    console.warn(
+      `${logPrefix} failed to deliver event:`,
+      fetchErr instanceof Error ? fetchErr.message : fetchErr,
+    );
+  }
+}
+
+/**
+ * Build a `captureSilentError(err, ctx)` function bound to a runtime
+ * (edge or node). The caller is the runtime-specific helper file.
+ */
+export function makeCaptureSilentError({ runtime, platform, logPrefix }) {
+  const runtimeCfg = { runtime, platform };
+  return async function captureSilentError(err, ctx) {
+    if (!_envelopeUrl || !_key) return;
+    await deliver(buildEnvelope(err, ctx, runtimeCfg), logPrefix);
+  };
+}

--- a/api/_sentry-edge.js
+++ b/api/_sentry-edge.js
@@ -1,145 +1,42 @@
 /**
- * Minimal Sentry error reporter for Vercel Edge functions.
+ * Sentry capture for Vercel edge-runtime API functions.
  *
- * Sends events to Sentry's `/envelope/` endpoint via fetch — no SDK
- * dependency, no bundle bloat, works in V8 isolates without polyfills.
- * DSN is read from `VITE_SENTRY_DSN` (the same DSN the frontend uses;
- * already present in the Vercel env, already public in the browser
- * bundle so reusing it server-side adds no exposure).
+ * Thin wrapper over `_sentry-common.js`. The shared module owns the
+ * envelope format, stack parsing, and fire-and-forget fetch (with
+ * `keepalive: true` so events survive isolate teardown). This file just
+ * binds runtime tags.
  *
  * Public surface:
- *   - `captureSilentError(err, { tags?, extra? })` — preferred. Add
- *     to any `try { ... } catch { console.error(...) }` site to make
- *     the failure searchable / alertable in Sentry.
- *   - `captureEdgeException(err, context)` — backwards-compat alias
- *     for the original (pre-sweep) shape. New code should use
- *     `captureSilentError` for the structured tags/extra split.
+ *   - `captureSilentError(err, { tags?, extra? })` — preferred. Pair
+ *     with `ctx.waitUntil(...)` from the Vercel handler context to
+ *     guarantee the isolate stays alive long enough to dispatch the
+ *     fetch:
  *
- * Pair with `_sentry-node.js` for Node-runtime functions. Both expose
- * an identical `captureSilentError` signature so callers don't care
- * which runtime they're in.
+ *       ctx.waitUntil(captureSilentError(err, { tags: { route: '...' } }));
  *
- * Endpoint: `/envelope/` (Sentry's current ingestion path) instead of
- * the deprecated `/store/`. Same DSN works for both — Sentry routes
- * by path.
+ *     `keepalive: true` on the underlying fetch is the safety net for
+ *     callers that don't have ctx in scope (e.g. nested helpers). It
+ *     lets the connection complete after isolate shutdown but doesn't
+ *     prevent the shutdown itself — prefer waitUntil where available.
+ *
+ *   - `captureEdgeException(err, context)` — backwards-compat alias for
+ *     the original (pre-sweep) shape. Existing callers in
+ *     `notification-channels.ts` keep working unchanged. New code
+ *     should use `captureSilentError`.
+ *
+ * Sentry project: same DSN as the frontend (`VITE_SENTRY_DSN`). Events
+ * are tagged `surface: api`, `runtime: edge` for filtering. The DSN is
+ * already public in the browser bundle, so reusing it server-side adds
+ * no exposure.
  */
 
-let _key = '';
-let _envelopeUrl = '';
+import { makeCaptureSilentError } from './_sentry-common.js';
 
-(function parseDsn() {
-  const dsn = process.env.VITE_SENTRY_DSN ?? '';
-  if (!dsn) return;
-  try {
-    const u = new URL(dsn);
-    _key = u.username;
-    const projectId = u.pathname.replace(/^\//, '');
-    _envelopeUrl = `${u.protocol}//${u.host}/api/${projectId}/envelope/`;
-  } catch {
-    // Malformed DSN — silently disable; never throw from a logger.
-  }
-})();
-
-function buildEnvelope(err, ctx) {
-  const errMsg = err instanceof Error ? err.message : String(err);
-  const errType = err instanceof Error ? err.constructor.name : 'Error';
-  const stack = err instanceof Error && err.stack ? err.stack : undefined;
-  const eventId = crypto.randomUUID().replace(/-/g, '');
-  const timestamp = new Date().toISOString();
-
-  const event = {
-    event_id: eventId,
-    timestamp,
-    level: 'error',
-    platform: 'javascript',
-    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'production',
-    release: process.env.VERCEL_GIT_COMMIT_SHA,
-    exception: {
-      values: [
-        {
-          type: errType,
-          value: errMsg,
-          ...(stack ? { stacktrace: { frames: parseStack(stack) } } : {}),
-        },
-      ],
-    },
-    tags: { surface: 'api', runtime: 'edge', ...(ctx?.tags ?? {}) },
-    extra: ctx?.extra,
-  };
-
-  // Envelope format: header line, item header line, item payload line.
-  const header = JSON.stringify({ event_id: eventId, sent_at: timestamp });
-  const itemHeader = JSON.stringify({ type: 'event' });
-  const itemPayload = JSON.stringify(event);
-  return `${header}\n${itemHeader}\n${itemPayload}\n`;
-}
-
-// Best-effort stack-frame parse. Sentry accepts the raw `stack` string
-// in `extra` if frames aren't parsed, but parsed frames render in the
-// dashboard with file/line/function — much more useful for triage.
-function parseStack(stack) {
-  const lines = stack.split('\n').slice(1, 30); // skip the "Error: msg" header line
-  const frames = [];
-  for (const line of lines) {
-    const m = line.match(/at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?$/);
-    if (!m) continue;
-    frames.push({
-      function: m[1] || '<anonymous>',
-      filename: m[2],
-      lineno: Number(m[3]),
-      colno: Number(m[4]),
-    });
-  }
-  // Sentry expects oldest frame first
-  return frames.reverse();
-}
-
-async function deliver(body) {
-  if (!_envelopeUrl || !_key) return;
-  try {
-    const res = await fetch(_envelopeUrl, {
-      method: 'POST',
-      signal: AbortSignal.timeout(2000),
-      headers: {
-        'Content-Type': 'application/x-sentry-envelope',
-        'X-Sentry-Auth': `Sentry sentry_version=7, sentry_key=${_key}`,
-      },
-      body,
-    });
-    if (!res.ok) {
-      const hint =
-        res.status === 401 || res.status === 403
-          ? ' — check VITE_SENTRY_DSN and auth key'
-          : res.status === 429
-            ? ' — rate limited by Sentry'
-            : ' — Sentry outage or transient error';
-      console.warn(`[sentry-edge] non-2xx response ${res.status}${hint}`);
-    }
-  } catch (fetchErr) {
-    console.warn(
-      '[sentry-edge] failed to deliver event:',
-      fetchErr instanceof Error ? fetchErr.message : fetchErr,
-    );
-  }
-}
-
-/**
- * Report a caught error to Sentry without crashing the request.
- *
- * Use INSIDE try/catch blocks where the existing `console.error` is
- * keeping the response path alive. Does not re-throw, does not block
- * meaningfully — the fetch is fire-and-forget with a 2s timeout.
- *
- * @param {unknown} err  The caught error or thrown value.
- * @param {{ tags?: Record<string, string|number|boolean>, extra?: Record<string, unknown> }} [ctx]
- *   `tags` are filterable in the Sentry UI; `extra` is attached but not
- *   indexed. Avoid PII (raw user emails, full request bodies) in either.
- * @returns {Promise<void>}
- */
-export async function captureSilentError(err, ctx) {
-  if (!_envelopeUrl || !_key) return;
-  await deliver(buildEnvelope(err, ctx));
-}
+export const captureSilentError = makeCaptureSilentError({
+  runtime: 'edge',
+  platform: 'javascript',
+  logPrefix: '[sentry-edge]',
+});
 
 /**
  * Backwards-compat alias for the pre-sweep call shape. Existing callers

--- a/api/_sentry-edge.js
+++ b/api/_sentry-edge.js
@@ -7,21 +7,22 @@
  * binds runtime tags.
  *
  * Public surface:
- *   - `captureSilentError(err, { tags?, extra? })` — preferred. Pair
- *     with `ctx.waitUntil(...)` from the Vercel handler context to
- *     guarantee the isolate stays alive long enough to dispatch the
- *     fetch:
+ *   - `captureSilentError(err, { tags?, extra?, ctx? })` — preferred.
+ *     Pass the Vercel handler's `ctx` so the helper can register the
+ *     delivery via `ctx.waitUntil`. When ctx is absent (local tests,
+ *     sidecar invocations, non-Vercel callers), the helper falls back
+ *     to fire-and-forget — `keepalive: true` on the underlying fetch
+ *     is the transport-level safety net, and the unhandled-rejection
+ *     defuse keeps Node's test runner happy.
  *
- *       ctx.waitUntil(captureSilentError(err, { tags: { route: '...' } }));
+ *       captureSilentError(err, {
+ *         tags: { route: 'api/foo', step: 'bar' },
+ *         ctx, // optional — required for guaranteed delivery on Vercel
+ *       });
  *
- *     `keepalive: true` on the underlying fetch is the safety net for
- *     callers that don't have ctx in scope (e.g. nested helpers). It
- *     lets the connection complete after isolate shutdown but doesn't
- *     prevent the shutdown itself — prefer waitUntil where available.
- *
- *   - `captureEdgeException(err, context)` — backwards-compat alias for
- *     the original (pre-sweep) shape. Existing callers in
- *     `notification-channels.ts` keep working unchanged. New code
+ *   - `captureEdgeException(err, context, ctx?)` — backwards-compat
+ *     alias for the original (pre-sweep) shape. Existing callers in
+ *     `notification-channels.ts` keep working unchanged; new callers
  *     should use `captureSilentError`.
  *
  * Sentry project: same DSN as the frontend (`VITE_SENTRY_DSN`). Events
@@ -45,8 +46,11 @@ export const captureSilentError = makeCaptureSilentError({
  *
  * @param {unknown} err
  * @param {Record<string, unknown>} [context]
+ * @param {{ waitUntil: (p: Promise<unknown>) => void }} [vctx]
+ *   Optional Vercel handler context. Passed through to
+ *   `captureSilentError` so the isolate is held alive for delivery.
  * @returns {Promise<void>}
  */
-export async function captureEdgeException(err, context = {}) {
-  await captureSilentError(err, { extra: context });
+export async function captureEdgeException(err, context = {}, vctx) {
+  await captureSilentError(err, { extra: context, ctx: vctx });
 }

--- a/api/_sentry-node.js
+++ b/api/_sentry-node.js
@@ -1,27 +1,16 @@
 /**
- * Minimal Sentry error reporter for Vercel Edge functions.
+ * Minimal Sentry error reporter for Vercel Node-runtime API functions.
  *
- * Sends events to Sentry's `/envelope/` endpoint via fetch — no SDK
- * dependency, no bundle bloat, works in V8 isolates without polyfills.
- * DSN is read from `VITE_SENTRY_DSN` (the same DSN the frontend uses;
- * already present in the Vercel env, already public in the browser
- * bundle so reusing it server-side adds no exposure).
+ * Mirror of `_sentry-edge.js` for the ~17% of api/ files that don't
+ * declare `runtime: 'edge'`. Same fetch-based approach (no SDK), same
+ * `captureSilentError(err, { tags?, extra? })` signature, same Sentry
+ * project (`VITE_SENTRY_DSN` — already public in the frontend bundle).
  *
- * Public surface:
- *   - `captureSilentError(err, { tags?, extra? })` — preferred. Add
- *     to any `try { ... } catch { console.error(...) }` site to make
- *     the failure searchable / alertable in Sentry.
- *   - `captureEdgeException(err, context)` — backwards-compat alias
- *     for the original (pre-sweep) shape. New code should use
- *     `captureSilentError` for the structured tags/extra split.
- *
- * Pair with `_sentry-node.js` for Node-runtime functions. Both expose
- * an identical `captureSilentError` signature so callers don't care
- * which runtime they're in.
- *
- * Endpoint: `/envelope/` (Sentry's current ingestion path) instead of
- * the deprecated `/store/`. Same DSN works for both — Sentry routes
- * by path.
+ * Two helpers exist instead of one runtime-detected helper because each
+ * api/ file declares its runtime statically; importing the matching
+ * helper makes the runtime tag in Sentry events accurate without a
+ * runtime check on every call. The only difference vs the edge variant
+ * is the `runtime: 'node'` tag.
  */
 
 let _key = '';
@@ -51,7 +40,7 @@ function buildEnvelope(err, ctx) {
     event_id: eventId,
     timestamp,
     level: 'error',
-    platform: 'javascript',
+    platform: 'node',
     environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'production',
     release: process.env.VERCEL_GIT_COMMIT_SHA,
     exception: {
@@ -63,22 +52,18 @@ function buildEnvelope(err, ctx) {
         },
       ],
     },
-    tags: { surface: 'api', runtime: 'edge', ...(ctx?.tags ?? {}) },
+    tags: { surface: 'api', runtime: 'node', ...(ctx?.tags ?? {}) },
     extra: ctx?.extra,
   };
 
-  // Envelope format: header line, item header line, item payload line.
   const header = JSON.stringify({ event_id: eventId, sent_at: timestamp });
   const itemHeader = JSON.stringify({ type: 'event' });
   const itemPayload = JSON.stringify(event);
   return `${header}\n${itemHeader}\n${itemPayload}\n`;
 }
 
-// Best-effort stack-frame parse. Sentry accepts the raw `stack` string
-// in `extra` if frames aren't parsed, but parsed frames render in the
-// dashboard with file/line/function — much more useful for triage.
 function parseStack(stack) {
-  const lines = stack.split('\n').slice(1, 30); // skip the "Error: msg" header line
+  const lines = stack.split('\n').slice(1, 30);
   const frames = [];
   for (const line of lines) {
     const m = line.match(/at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?$/);
@@ -90,7 +75,6 @@ function parseStack(stack) {
       colno: Number(m[4]),
     });
   }
-  // Sentry expects oldest frame first
   return frames.reverse();
 }
 
@@ -113,11 +97,11 @@ async function deliver(body) {
           : res.status === 429
             ? ' — rate limited by Sentry'
             : ' — Sentry outage or transient error';
-      console.warn(`[sentry-edge] non-2xx response ${res.status}${hint}`);
+      console.warn(`[sentry-node] non-2xx response ${res.status}${hint}`);
     }
   } catch (fetchErr) {
     console.warn(
-      '[sentry-edge] failed to deliver event:',
+      '[sentry-node] failed to deliver event:',
       fetchErr instanceof Error ? fetchErr.message : fetchErr,
     );
   }
@@ -126,30 +110,13 @@ async function deliver(body) {
 /**
  * Report a caught error to Sentry without crashing the request.
  *
- * Use INSIDE try/catch blocks where the existing `console.error` is
- * keeping the response path alive. Does not re-throw, does not block
- * meaningfully — the fetch is fire-and-forget with a 2s timeout.
+ * Same shape as the edge variant. See `_sentry-edge.js` for full docs.
  *
- * @param {unknown} err  The caught error or thrown value.
+ * @param {unknown} err
  * @param {{ tags?: Record<string, string|number|boolean>, extra?: Record<string, unknown> }} [ctx]
- *   `tags` are filterable in the Sentry UI; `extra` is attached but not
- *   indexed. Avoid PII (raw user emails, full request bodies) in either.
  * @returns {Promise<void>}
  */
 export async function captureSilentError(err, ctx) {
   if (!_envelopeUrl || !_key) return;
   await deliver(buildEnvelope(err, ctx));
-}
-
-/**
- * Backwards-compat alias for the pre-sweep call shape. Existing callers
- * pass `(err, contextObject)` — we coerce contextObject into `extra` so
- * data still lands in Sentry. Prefer `captureSilentError` in new code.
- *
- * @param {unknown} err
- * @param {Record<string, unknown>} [context]
- * @returns {Promise<void>}
- */
-export async function captureEdgeException(err, context = {}) {
-  await captureSilentError(err, { extra: context });
 }

--- a/api/_sentry-node.js
+++ b/api/_sentry-node.js
@@ -1,122 +1,19 @@
 /**
- * Minimal Sentry error reporter for Vercel Node-runtime API functions.
+ * Sentry capture for Vercel Node-runtime API functions.
  *
- * Mirror of `_sentry-edge.js` for the ~17% of api/ files that don't
- * declare `runtime: 'edge'`. Same fetch-based approach (no SDK), same
- * `captureSilentError(err, { tags?, extra? })` signature, same Sentry
- * project (`VITE_SENTRY_DSN` — already public in the frontend bundle).
+ * Thin wrapper over `_sentry-common.js` (mirror of `_sentry-edge.js`,
+ * tagged `runtime: 'node'`, `platform: 'node'`). Exists so callers in
+ * Node-runtime files can import a helper that tags events correctly
+ * without a runtime check on every call.
  *
- * Two helpers exist instead of one runtime-detected helper because each
- * api/ file declares its runtime statically; importing the matching
- * helper makes the runtime tag in Sentry events accurate without a
- * runtime check on every call. The only difference vs the edge variant
- * is the `runtime: 'node'` tag.
+ * See `_sentry-edge.js` for the public-API docs — the surface is
+ * identical.
  */
 
-let _key = '';
-let _envelopeUrl = '';
+import { makeCaptureSilentError } from './_sentry-common.js';
 
-(function parseDsn() {
-  const dsn = process.env.VITE_SENTRY_DSN ?? '';
-  if (!dsn) return;
-  try {
-    const u = new URL(dsn);
-    _key = u.username;
-    const projectId = u.pathname.replace(/^\//, '');
-    _envelopeUrl = `${u.protocol}//${u.host}/api/${projectId}/envelope/`;
-  } catch {
-    // Malformed DSN — silently disable; never throw from a logger.
-  }
-})();
-
-function buildEnvelope(err, ctx) {
-  const errMsg = err instanceof Error ? err.message : String(err);
-  const errType = err instanceof Error ? err.constructor.name : 'Error';
-  const stack = err instanceof Error && err.stack ? err.stack : undefined;
-  const eventId = crypto.randomUUID().replace(/-/g, '');
-  const timestamp = new Date().toISOString();
-
-  const event = {
-    event_id: eventId,
-    timestamp,
-    level: 'error',
-    platform: 'node',
-    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'production',
-    release: process.env.VERCEL_GIT_COMMIT_SHA,
-    exception: {
-      values: [
-        {
-          type: errType,
-          value: errMsg,
-          ...(stack ? { stacktrace: { frames: parseStack(stack) } } : {}),
-        },
-      ],
-    },
-    tags: { surface: 'api', runtime: 'node', ...(ctx?.tags ?? {}) },
-    extra: ctx?.extra,
-  };
-
-  const header = JSON.stringify({ event_id: eventId, sent_at: timestamp });
-  const itemHeader = JSON.stringify({ type: 'event' });
-  const itemPayload = JSON.stringify(event);
-  return `${header}\n${itemHeader}\n${itemPayload}\n`;
-}
-
-function parseStack(stack) {
-  const lines = stack.split('\n').slice(1, 30);
-  const frames = [];
-  for (const line of lines) {
-    const m = line.match(/at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?$/);
-    if (!m) continue;
-    frames.push({
-      function: m[1] || '<anonymous>',
-      filename: m[2],
-      lineno: Number(m[3]),
-      colno: Number(m[4]),
-    });
-  }
-  return frames.reverse();
-}
-
-async function deliver(body) {
-  if (!_envelopeUrl || !_key) return;
-  try {
-    const res = await fetch(_envelopeUrl, {
-      method: 'POST',
-      signal: AbortSignal.timeout(2000),
-      headers: {
-        'Content-Type': 'application/x-sentry-envelope',
-        'X-Sentry-Auth': `Sentry sentry_version=7, sentry_key=${_key}`,
-      },
-      body,
-    });
-    if (!res.ok) {
-      const hint =
-        res.status === 401 || res.status === 403
-          ? ' — check VITE_SENTRY_DSN and auth key'
-          : res.status === 429
-            ? ' — rate limited by Sentry'
-            : ' — Sentry outage or transient error';
-      console.warn(`[sentry-node] non-2xx response ${res.status}${hint}`);
-    }
-  } catch (fetchErr) {
-    console.warn(
-      '[sentry-node] failed to deliver event:',
-      fetchErr instanceof Error ? fetchErr.message : fetchErr,
-    );
-  }
-}
-
-/**
- * Report a caught error to Sentry without crashing the request.
- *
- * Same shape as the edge variant. See `_sentry-edge.js` for full docs.
- *
- * @param {unknown} err
- * @param {{ tags?: Record<string, string|number|boolean>, extra?: Record<string, unknown> }} [ctx]
- * @returns {Promise<void>}
- */
-export async function captureSilentError(err, ctx) {
-  if (!_envelopeUrl || !_key) return;
-  await deliver(buildEnvelope(err, ctx));
-}
+export const captureSilentError = makeCaptureSilentError({
+  runtime: 'node',
+  platform: 'node',
+  logPrefix: '[sentry-node]',
+});

--- a/api/brief/[userId]/[issueDate].ts
+++ b/api/brief/[userId]/[issueDate].ts
@@ -95,7 +95,10 @@ const UNAVAILABLE_PAGE = renderErrorPage(
   'The brief service is not fully configured. Please try again shortly.',
 );
 
-export default async function handler(req: Request): Promise<Response> {
+export default async function handler(
+  req: Request,
+  ctx: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return new Response('Origin not allowed', { status: 403 });
   }
@@ -154,7 +157,7 @@ export default async function handler(req: Request): Promise<Response> {
     envelope = await readRawJsonFromUpstash(`brief:${userId}:${issueDate}`);
   } catch (err) {
     console.error('[api/brief] Upstash read failed:', (err as Error).message);
-    void captureSilentError(err, { tags: { route: 'api/brief', step: 'envelope-read' } });
+    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief', step: 'envelope-read' } }));
     return htmlResponse(req, 503, UNAVAILABLE_PAGE);
   }
   if (!envelope) {
@@ -197,7 +200,7 @@ export default async function handler(req: Request): Promise<Response> {
       }
     } catch (err) {
       console.warn('[api/brief] share URL derive failed:', (err as Error).message);
-      void captureSilentError(err, { tags: { route: 'api/brief', step: 'share-url-derive', severity: 'warn' } });
+      ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief', step: 'share-url-derive', severity: 'warn' } }));
     }
   }
 
@@ -216,7 +219,7 @@ export default async function handler(req: Request): Promise<Response> {
     // and log the details server-side. The renderer's assertion
     // message is safe to log (no secrets, no user content).
     console.error('[api/brief] malformed envelope for brief:*:*:', (err as Error).message);
-    void captureSilentError(err, { tags: { route: 'api/brief', step: 'malformed-envelope' } });
+    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief', step: 'malformed-envelope' } }));
     // Distinct log tag so ops can grep composer-bug vs Redis-miss. User
     // still sees the neutral "expired" page.
     return htmlResponse(req, 404, EXPIRED_PAGE);

--- a/api/brief/[userId]/[issueDate].ts
+++ b/api/brief/[userId]/[issueDate].ts
@@ -23,6 +23,8 @@ export const config = { runtime: 'edge' };
 
 // @ts-expect-error — JS module, no declaration file
 import { getCorsHeaders, isDisallowedOrigin } from '../../_cors.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from '../../_sentry-edge.js';
 import { renderBriefMagazine } from '../../../server/_shared/brief-render.js';
 // @ts-expect-error — JS module, no declaration file
 import { readRawJsonFromUpstash, redisPipeline } from '../../_upstash-json.js';
@@ -152,6 +154,7 @@ export default async function handler(req: Request): Promise<Response> {
     envelope = await readRawJsonFromUpstash(`brief:${userId}:${issueDate}`);
   } catch (err) {
     console.error('[api/brief] Upstash read failed:', (err as Error).message);
+    void captureSilentError(err, { tags: { route: 'api/brief', step: 'envelope-read' } });
     return htmlResponse(req, 503, UNAVAILABLE_PAGE);
   }
   if (!envelope) {
@@ -194,6 +197,7 @@ export default async function handler(req: Request): Promise<Response> {
       }
     } catch (err) {
       console.warn('[api/brief] share URL derive failed:', (err as Error).message);
+      void captureSilentError(err, { tags: { route: 'api/brief', step: 'share-url-derive', severity: 'warn' } });
     }
   }
 
@@ -212,6 +216,7 @@ export default async function handler(req: Request): Promise<Response> {
     // and log the details server-side. The renderer's assertion
     // message is safe to log (no secrets, no user content).
     console.error('[api/brief] malformed envelope for brief:*:*:', (err as Error).message);
+    void captureSilentError(err, { tags: { route: 'api/brief', step: 'malformed-envelope' } });
     // Distinct log tag so ops can grep composer-bug vs Redis-miss. User
     // still sees the neutral "expired" page.
     return htmlResponse(req, 404, EXPIRED_PAGE);

--- a/api/brief/[userId]/[issueDate].ts
+++ b/api/brief/[userId]/[issueDate].ts
@@ -97,7 +97,7 @@ const UNAVAILABLE_PAGE = renderErrorPage(
 
 export default async function handler(
   req: Request,
-  ctx: { waitUntil: (p: Promise<unknown>) => void },
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return new Response('Origin not allowed', { status: 403 });
@@ -157,7 +157,7 @@ export default async function handler(
     envelope = await readRawJsonFromUpstash(`brief:${userId}:${issueDate}`);
   } catch (err) {
     console.error('[api/brief] Upstash read failed:', (err as Error).message);
-    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief', step: 'envelope-read' } }));
+    captureSilentError(err, { tags: { route: 'api/brief', step: 'envelope-read' }, ctx });
     return htmlResponse(req, 503, UNAVAILABLE_PAGE);
   }
   if (!envelope) {
@@ -200,7 +200,7 @@ export default async function handler(
       }
     } catch (err) {
       console.warn('[api/brief] share URL derive failed:', (err as Error).message);
-      ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief', step: 'share-url-derive', severity: 'warn' } }));
+      captureSilentError(err, { tags: { route: 'api/brief', step: 'share-url-derive', severity: 'warn' }, ctx });
     }
   }
 
@@ -219,7 +219,7 @@ export default async function handler(
     // and log the details server-side. The renderer's assertion
     // message is safe to log (no secrets, no user content).
     console.error('[api/brief] malformed envelope for brief:*:*:', (err as Error).message);
-    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief', step: 'malformed-envelope' } }));
+    captureSilentError(err, { tags: { route: 'api/brief', step: 'malformed-envelope' }, ctx });
     // Distinct log tag so ops can grep composer-bug vs Redis-miss. User
     // still sees the neutral "expired" page.
     return htmlResponse(req, 404, EXPIRED_PAGE);

--- a/api/brief/carousel/[userId]/[issueDate]/[page].ts
+++ b/api/brief/carousel/[userId]/[issueDate]/[page].ts
@@ -36,6 +36,8 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders, isDisallowedOrigin } from '../../../../_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { readRawJsonFromUpstash } from '../../../../_upstash-json.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from '../../../../_sentry-edge.js';
 import { verifyBriefToken, BriefUrlError } from '../../../../../server/_shared/brief-url';
 import { renderCarouselImageResponse, pageFromIndex } from '../../../../../server/_shared/brief-carousel-render';
 
@@ -108,6 +110,7 @@ export default async function handler(req: Request): Promise<Response> {
     envelope = await readRawJsonFromUpstash(`brief:${userId}:${issueDate}`);
   } catch (err) {
     console.error('[api/brief/carousel] Upstash read failed:', (err as Error).message);
+    void captureSilentError(err, { tags: { route: 'api/brief/carousel', step: 'envelope-read' } });
     return jsonError('service_unavailable', 503, cors);
   }
   if (!envelope) return jsonError('not_found', 404, cors);
@@ -140,6 +143,9 @@ export default async function handler(req: Request): Promise<Response> {
       `[api/brief/carousel] render failed for ${userId}/${issueDate}/${page}:`,
       (err as Error).message,
     );
+    void captureSilentError(err, {
+      tags: { route: 'api/brief/carousel', step: 'render', page: String(page) },
+    });
     return jsonError('render_failed', 503, cors, { noStore: true });
   }
 }

--- a/api/brief/carousel/[userId]/[issueDate]/[page].ts
+++ b/api/brief/carousel/[userId]/[issueDate]/[page].ts
@@ -60,7 +60,10 @@ function jsonError(
   });
 }
 
-export default async function handler(req: Request): Promise<Response> {
+export default async function handler(
+  req: Request,
+  ctx: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return new Response('Origin not allowed', { status: 403 });
   }
@@ -110,7 +113,7 @@ export default async function handler(req: Request): Promise<Response> {
     envelope = await readRawJsonFromUpstash(`brief:${userId}:${issueDate}`);
   } catch (err) {
     console.error('[api/brief/carousel] Upstash read failed:', (err as Error).message);
-    void captureSilentError(err, { tags: { route: 'api/brief/carousel', step: 'envelope-read' } });
+    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief/carousel', step: 'envelope-read' } }));
     return jsonError('service_unavailable', 503, cors);
   }
   if (!envelope) return jsonError('not_found', 404, cors);
@@ -143,9 +146,11 @@ export default async function handler(req: Request): Promise<Response> {
       `[api/brief/carousel] render failed for ${userId}/${issueDate}/${page}:`,
       (err as Error).message,
     );
-    void captureSilentError(err, {
-      tags: { route: 'api/brief/carousel', step: 'render', page: String(page) },
-    });
+    ctx.waitUntil(
+      captureSilentError(err, {
+        tags: { route: 'api/brief/carousel', step: 'render', page: String(page) },
+      }),
+    );
     return jsonError('render_failed', 503, cors, { noStore: true });
   }
 }

--- a/api/brief/carousel/[userId]/[issueDate]/[page].ts
+++ b/api/brief/carousel/[userId]/[issueDate]/[page].ts
@@ -62,7 +62,7 @@ function jsonError(
 
 export default async function handler(
   req: Request,
-  ctx: { waitUntil: (p: Promise<unknown>) => void },
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return new Response('Origin not allowed', { status: 403 });
@@ -113,7 +113,7 @@ export default async function handler(
     envelope = await readRawJsonFromUpstash(`brief:${userId}:${issueDate}`);
   } catch (err) {
     console.error('[api/brief/carousel] Upstash read failed:', (err as Error).message);
-    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief/carousel', step: 'envelope-read' } }));
+    captureSilentError(err, { tags: { route: 'api/brief/carousel', step: 'envelope-read' }, ctx });
     return jsonError('service_unavailable', 503, cors);
   }
   if (!envelope) return jsonError('not_found', 404, cors);
@@ -146,11 +146,10 @@ export default async function handler(
       `[api/brief/carousel] render failed for ${userId}/${issueDate}/${page}:`,
       (err as Error).message,
     );
-    ctx.waitUntil(
-      captureSilentError(err, {
-        tags: { route: 'api/brief/carousel', step: 'render', page: String(page) },
-      }),
-    );
+    captureSilentError(err, {
+      tags: { route: 'api/brief/carousel', step: 'render', page: String(page) },
+      ctx,
+    });
     return jsonError('render_failed', 503, cors, { noStore: true });
   }
 }

--- a/api/brief/public/[hash].ts
+++ b/api/brief/public/[hash].ts
@@ -24,6 +24,8 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders, isDisallowedOrigin } from '../../_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { readRawJsonFromUpstash } from '../../_upstash-json.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from '../../_sentry-edge.js';
 import { renderBriefMagazine } from '../../../server/_shared/brief-render.js';
 import {
   BRIEF_PUBLIC_POINTER_PREFIX,
@@ -137,6 +139,7 @@ export default async function handler(req: Request): Promise<Response> {
     pointerRaw = await readRawJsonFromUpstash(pointerKey);
   } catch (err) {
     console.error('[api/brief/public] pointer read failed:', (err as Error).message);
+    void captureSilentError(err, { tags: { route: 'api/brief/public', step: 'pointer-read' } });
     return htmlResponse(req, 503, UNAVAILABLE_PAGE);
   }
   // The pointer is JSON-encoded at write time (both
@@ -170,6 +173,7 @@ export default async function handler(req: Request): Promise<Response> {
     envelope = await readRawJsonFromUpstash(`brief:${pointer.userId}:${pointer.issueDate}`);
   } catch (err) {
     console.error('[api/brief/public] envelope read failed:', (err as Error).message);
+    void captureSilentError(err, { tags: { route: 'api/brief/public', step: 'envelope-read' } });
     return htmlResponse(req, 503, UNAVAILABLE_PAGE);
   }
   if (!envelope) {
@@ -187,6 +191,7 @@ export default async function handler(req: Request): Promise<Response> {
     );
   } catch (err) {
     console.error('[api/brief/public] malformed envelope:', (err as Error).message);
+    void captureSilentError(err, { tags: { route: 'api/brief/public', step: 'render' } });
     return htmlResponse(req, 404, NOT_FOUND_PAGE);
   }
 

--- a/api/brief/public/[hash].ts
+++ b/api/brief/public/[hash].ts
@@ -93,7 +93,10 @@ const UNAVAILABLE_PAGE = renderErrorPage(
   'The brief service is having trouble right now. Please try again shortly.',
 );
 
-export default async function handler(req: Request): Promise<Response> {
+export default async function handler(
+  req: Request,
+  ctx: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return new Response('Origin not allowed', { status: 403 });
   }
@@ -139,7 +142,7 @@ export default async function handler(req: Request): Promise<Response> {
     pointerRaw = await readRawJsonFromUpstash(pointerKey);
   } catch (err) {
     console.error('[api/brief/public] pointer read failed:', (err as Error).message);
-    void captureSilentError(err, { tags: { route: 'api/brief/public', step: 'pointer-read' } });
+    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief/public', step: 'pointer-read' } }));
     return htmlResponse(req, 503, UNAVAILABLE_PAGE);
   }
   // The pointer is JSON-encoded at write time (both
@@ -173,7 +176,7 @@ export default async function handler(req: Request): Promise<Response> {
     envelope = await readRawJsonFromUpstash(`brief:${pointer.userId}:${pointer.issueDate}`);
   } catch (err) {
     console.error('[api/brief/public] envelope read failed:', (err as Error).message);
-    void captureSilentError(err, { tags: { route: 'api/brief/public', step: 'envelope-read' } });
+    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief/public', step: 'envelope-read' } }));
     return htmlResponse(req, 503, UNAVAILABLE_PAGE);
   }
   if (!envelope) {
@@ -191,7 +194,7 @@ export default async function handler(req: Request): Promise<Response> {
     );
   } catch (err) {
     console.error('[api/brief/public] malformed envelope:', (err as Error).message);
-    void captureSilentError(err, { tags: { route: 'api/brief/public', step: 'render' } });
+    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief/public', step: 'render' } }));
     return htmlResponse(req, 404, NOT_FOUND_PAGE);
   }
 

--- a/api/brief/public/[hash].ts
+++ b/api/brief/public/[hash].ts
@@ -95,7 +95,7 @@ const UNAVAILABLE_PAGE = renderErrorPage(
 
 export default async function handler(
   req: Request,
-  ctx: { waitUntil: (p: Promise<unknown>) => void },
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return new Response('Origin not allowed', { status: 403 });
@@ -142,7 +142,7 @@ export default async function handler(
     pointerRaw = await readRawJsonFromUpstash(pointerKey);
   } catch (err) {
     console.error('[api/brief/public] pointer read failed:', (err as Error).message);
-    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief/public', step: 'pointer-read' } }));
+    captureSilentError(err, { tags: { route: 'api/brief/public', step: 'pointer-read' }, ctx });
     return htmlResponse(req, 503, UNAVAILABLE_PAGE);
   }
   // The pointer is JSON-encoded at write time (both
@@ -176,7 +176,7 @@ export default async function handler(
     envelope = await readRawJsonFromUpstash(`brief:${pointer.userId}:${pointer.issueDate}`);
   } catch (err) {
     console.error('[api/brief/public] envelope read failed:', (err as Error).message);
-    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief/public', step: 'envelope-read' } }));
+    captureSilentError(err, { tags: { route: 'api/brief/public', step: 'envelope-read' }, ctx });
     return htmlResponse(req, 503, UNAVAILABLE_PAGE);
   }
   if (!envelope) {
@@ -194,7 +194,7 @@ export default async function handler(
     );
   } catch (err) {
     console.error('[api/brief/public] malformed envelope:', (err as Error).message);
-    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief/public', step: 'render' } }));
+    captureSilentError(err, { tags: { route: 'api/brief/public', step: 'render' }, ctx });
     return htmlResponse(req, 404, NOT_FOUND_PAGE);
   }
 

--- a/api/brief/share-url.ts
+++ b/api/brief/share-url.ts
@@ -34,6 +34,8 @@ import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
 import { jsonResponse } from '../_json-response.js';
 // @ts-expect-error — JS module, no declaration file
 import { readRawJsonFromUpstash, redisPipeline } from '../_upstash-json.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from '../_sentry-edge.js';
 import { validateBearerToken } from '../../server/auth-session';
 import { getEntitlements } from '../../server/_shared/entitlement-check';
 import {
@@ -147,6 +149,7 @@ export default async function handler(req: Request): Promise<Response> {
       }
     } catch (err) {
       console.error('[api/brief/share-url] latest pointer read failed:', (err as Error).message);
+      void captureSilentError(err, { tags: { route: 'api/brief/share-url', step: 'latest-pointer-read' } });
       return jsonResponse({ error: 'service_unavailable' }, 503, cors);
     }
   }
@@ -164,6 +167,7 @@ export default async function handler(req: Request): Promise<Response> {
     existing = await readRawJsonFromUpstash(`brief:${session.userId}:${issueSlot}`);
   } catch (err) {
     console.error('[api/brief/share-url] Upstash read failed:', (err as Error).message);
+    void captureSilentError(err, { tags: { route: 'api/brief/share-url', step: 'envelope-read' } });
     return jsonResponse({ error: 'service_unavailable' }, 503, cors);
   }
   if (existing == null) {

--- a/api/brief/share-url.ts
+++ b/api/brief/share-url.ts
@@ -68,7 +68,7 @@ function publicBaseUrl(req: Request): string {
 
 export default async function handler(
   req: Request,
-  ctx: { waitUntil: (p: Promise<unknown>) => void },
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return jsonResponse({ error: 'Origin not allowed' }, 403);
@@ -152,7 +152,7 @@ export default async function handler(
       }
     } catch (err) {
       console.error('[api/brief/share-url] latest pointer read failed:', (err as Error).message);
-      ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief/share-url', step: 'latest-pointer-read' } }));
+      captureSilentError(err, { tags: { route: 'api/brief/share-url', step: 'latest-pointer-read' }, ctx });
       return jsonResponse({ error: 'service_unavailable' }, 503, cors);
     }
   }
@@ -170,7 +170,7 @@ export default async function handler(
     existing = await readRawJsonFromUpstash(`brief:${session.userId}:${issueSlot}`);
   } catch (err) {
     console.error('[api/brief/share-url] Upstash read failed:', (err as Error).message);
-    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief/share-url', step: 'envelope-read' } }));
+    captureSilentError(err, { tags: { route: 'api/brief/share-url', step: 'envelope-read' }, ctx });
     return jsonResponse({ error: 'service_unavailable' }, 503, cors);
   }
   if (existing == null) {

--- a/api/brief/share-url.ts
+++ b/api/brief/share-url.ts
@@ -66,7 +66,10 @@ function publicBaseUrl(req: Request): string {
   return new URL(req.url).origin;
 }
 
-export default async function handler(req: Request): Promise<Response> {
+export default async function handler(
+  req: Request,
+  ctx: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return jsonResponse({ error: 'Origin not allowed' }, 403);
   }
@@ -149,7 +152,7 @@ export default async function handler(req: Request): Promise<Response> {
       }
     } catch (err) {
       console.error('[api/brief/share-url] latest pointer read failed:', (err as Error).message);
-      void captureSilentError(err, { tags: { route: 'api/brief/share-url', step: 'latest-pointer-read' } });
+      ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief/share-url', step: 'latest-pointer-read' } }));
       return jsonResponse({ error: 'service_unavailable' }, 503, cors);
     }
   }
@@ -167,7 +170,7 @@ export default async function handler(req: Request): Promise<Response> {
     existing = await readRawJsonFromUpstash(`brief:${session.userId}:${issueSlot}`);
   } catch (err) {
     console.error('[api/brief/share-url] Upstash read failed:', (err as Error).message);
-    void captureSilentError(err, { tags: { route: 'api/brief/share-url', step: 'envelope-read' } });
+    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/brief/share-url', step: 'envelope-read' } }));
     return jsonResponse({ error: 'service_unavailable' }, 503, cors);
   }
   if (existing == null) {

--- a/api/create-checkout.ts
+++ b/api/create-checkout.ts
@@ -35,7 +35,7 @@ function json(body: unknown, status: number, cors: Record<string, string>): Resp
 
 export default async function handler(
   req: Request,
-  ctx: { waitUntil: (p: Promise<unknown>) => void },
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<Response> {
   const cors = getCorsHeaders(req) as Record<string, string>;
 
@@ -121,7 +121,7 @@ export default async function handler(
     return json(data, 200, cors);
   } catch (err) {
     console.error('[create-checkout] Relay failed:', (err as Error).message);
-    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/create-checkout', step: 'relay' } }));
+    captureSilentError(err, { tags: { route: 'api/create-checkout', step: 'relay' }, ctx });
     return json({ error: 'Checkout service unavailable' }, 502, cors);
   }
 }

--- a/api/create-checkout.ts
+++ b/api/create-checkout.ts
@@ -13,6 +13,8 @@ export const config = { runtime: 'edge' };
 
 // @ts-expect-error — JS module, no declaration file
 import { getCorsHeaders } from './_cors.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from './_sentry-edge.js';
 import { validateBearerToken } from '../server/auth-session';
 
 const CONVEX_SITE_URL =
@@ -116,6 +118,7 @@ export default async function handler(req: Request): Promise<Response> {
     return json(data, 200, cors);
   } catch (err) {
     console.error('[create-checkout] Relay failed:', (err as Error).message);
+    void captureSilentError(err, { tags: { route: 'api/create-checkout', step: 'relay' } });
     return json({ error: 'Checkout service unavailable' }, 502, cors);
   }
 }

--- a/api/create-checkout.ts
+++ b/api/create-checkout.ts
@@ -33,7 +33,10 @@ function json(body: unknown, status: number, cors: Record<string, string>): Resp
   });
 }
 
-export default async function handler(req: Request): Promise<Response> {
+export default async function handler(
+  req: Request,
+  ctx: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response> {
   const cors = getCorsHeaders(req) as Record<string, string>;
 
   if (req.method === 'OPTIONS') {
@@ -118,7 +121,7 @@ export default async function handler(req: Request): Promise<Response> {
     return json(data, 200, cors);
   } catch (err) {
     console.error('[create-checkout] Relay failed:', (err as Error).message);
-    void captureSilentError(err, { tags: { route: 'api/create-checkout', step: 'relay' } });
+    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/create-checkout', step: 'relay' } }));
     return json({ error: 'Checkout service unavailable' }, 502, cors);
   }
 }

--- a/api/customer-portal.ts
+++ b/api/customer-portal.ts
@@ -10,6 +10,8 @@ export const config = { runtime: 'edge' };
 
 // @ts-expect-error — JS module, no declaration file
 import { getCorsHeaders } from './_cors.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from './_sentry-edge.js';
 import { validateBearerToken } from '../server/auth-session';
 
 const CONVEX_SITE_URL =
@@ -79,6 +81,7 @@ export default async function handler(req: Request): Promise<Response> {
     return json(data, 200, cors);
   } catch (err) {
     console.error('[customer-portal] Relay failed:', (err as Error).message);
+    void captureSilentError(err, { tags: { route: 'api/customer-portal', step: 'relay' } });
     return json({ error: 'Customer portal unavailable' }, 502, cors);
   }
 }

--- a/api/customer-portal.ts
+++ b/api/customer-portal.ts
@@ -30,7 +30,10 @@ function json(body: unknown, status: number, cors: Record<string, string>): Resp
   });
 }
 
-export default async function handler(req: Request): Promise<Response> {
+export default async function handler(
+  req: Request,
+  ctx: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response> {
   const cors = getCorsHeaders(req) as Record<string, string>;
 
   if (req.method === 'OPTIONS') {
@@ -81,7 +84,7 @@ export default async function handler(req: Request): Promise<Response> {
     return json(data, 200, cors);
   } catch (err) {
     console.error('[customer-portal] Relay failed:', (err as Error).message);
-    void captureSilentError(err, { tags: { route: 'api/customer-portal', step: 'relay' } });
+    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/customer-portal', step: 'relay' } }));
     return json({ error: 'Customer portal unavailable' }, 502, cors);
   }
 }

--- a/api/customer-portal.ts
+++ b/api/customer-portal.ts
@@ -32,7 +32,7 @@ function json(body: unknown, status: number, cors: Record<string, string>): Resp
 
 export default async function handler(
   req: Request,
-  ctx: { waitUntil: (p: Promise<unknown>) => void },
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<Response> {
   const cors = getCorsHeaders(req) as Record<string, string>;
 
@@ -84,7 +84,7 @@ export default async function handler(
     return json(data, 200, cors);
   } catch (err) {
     console.error('[customer-portal] Relay failed:', (err as Error).message);
-    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/customer-portal', step: 'relay' } }));
+    captureSilentError(err, { tags: { route: 'api/customer-portal', step: 'relay' }, ctx });
     return json({ error: 'Customer portal unavailable' }, 502, cors);
   }
 }

--- a/api/fwdstart.js
+++ b/api/fwdstart.js
@@ -98,7 +98,7 @@ export default async function handler(req, ctx) {
     });
   } catch (error) {
     console.error('FwdStart scraper error:', error);
-    ctx?.waitUntil?.(captureSilentError(error, { tags: { route: 'api/fwdstart', step: 'scrape' } }));
+    captureSilentError(error, { tags: { route: 'api/fwdstart', step: 'scrape' }, ctx });
     return jsonResponse({
       error: 'Failed to fetch FwdStart archive',
       details: error.message

--- a/api/fwdstart.js
+++ b/api/fwdstart.js
@@ -1,6 +1,7 @@
 // Non-sebuf: returns XML/HTML, stays as standalone Vercel function
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { jsonResponse } from './_json-response.js';
+import { captureSilentError } from './_sentry-edge.js';
 export const config = { runtime: 'edge' };
 
 // Scrape FwdStart newsletter archive and return as RSS
@@ -97,6 +98,7 @@ export default async function handler(req) {
     });
   } catch (error) {
     console.error('FwdStart scraper error:', error);
+    void captureSilentError(error, { tags: { route: 'api/fwdstart', step: 'scrape' } });
     return jsonResponse({
       error: 'Failed to fetch FwdStart archive',
       details: error.message

--- a/api/fwdstart.js
+++ b/api/fwdstart.js
@@ -5,7 +5,7 @@ import { captureSilentError } from './_sentry-edge.js';
 export const config = { runtime: 'edge' };
 
 // Scrape FwdStart newsletter archive and return as RSS
-export default async function handler(req) {
+export default async function handler(req, ctx) {
   const cors = getCorsHeaders(req);
   if (isDisallowedOrigin(req)) {
     return jsonResponse({ error: 'Origin not allowed' }, 403, cors);
@@ -98,7 +98,7 @@ export default async function handler(req) {
     });
   } catch (error) {
     console.error('FwdStart scraper error:', error);
-    void captureSilentError(error, { tags: { route: 'api/fwdstart', step: 'scrape' } });
+    ctx?.waitUntil?.(captureSilentError(error, { tags: { route: 'api/fwdstart', step: 'scrape' } }));
     return jsonResponse({
       error: 'Failed to fetch FwdStart archive',
       details: error.message

--- a/api/internal/brief-why-matters.ts
+++ b/api/internal/brief-why-matters.ts
@@ -46,6 +46,8 @@ import {
 import { callLlmReasoning } from '../../server/_shared/llm';
 // @ts-expect-error — JS module, no declaration file
 import { readRawJsonFromUpstash, setCachedData, redisPipeline } from '../_upstash-json.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from '../_sentry-edge.js';
 import {
   buildWhyMattersUserPrompt,
   hashBriefStory,
@@ -246,6 +248,7 @@ async function runAnalystPath(story: StoryPayload, iso2: string | null): Promise
     return parseWhyMattersV2(result.content);
   } catch (err) {
     console.warn(`[brief-why-matters] analyst path failed: ${err instanceof Error ? err.message : String(err)}`);
+    void captureSilentError(err, { tags: { route: 'api/internal/brief-why-matters', step: 'analyst-path', severity: 'warn' } });
     return null;
   }
 }
@@ -274,6 +277,7 @@ async function runGeminiPath(story: StoryPayload): Promise<string | null> {
     return parseWhyMatters(result.content);
   } catch (err) {
     console.warn(`[brief-why-matters] gemini path failed: ${err instanceof Error ? err.message : String(err)}`);
+    void captureSilentError(err, { tags: { route: 'api/internal/brief-why-matters', step: 'gemini-path', severity: 'warn' } });
     return null;
   }
 }
@@ -394,6 +398,7 @@ export default async function handler(req: Request, ctx?: EdgeContext): Promise<
     }
   } catch (err) {
     console.warn(`[brief-why-matters] cache read degraded: ${err instanceof Error ? err.message : String(err)}`);
+    void captureSilentError(err, { tags: { route: 'api/internal/brief-why-matters', step: 'cache-read', severity: 'warn' } });
   }
 
   if (cached) {
@@ -451,6 +456,7 @@ export default async function handler(req: Request, ctx?: EdgeContext): Promise<
       await setCachedData(cacheKey, envelope, WHY_MATTERS_TTL_SEC);
     } catch (err) {
       console.warn(`[brief-why-matters] cache write degraded: ${err instanceof Error ? err.message : String(err)}`);
+      void captureSilentError(err, { tags: { route: 'api/internal/brief-why-matters', step: 'cache-write', severity: 'warn' } });
     }
   }
 

--- a/api/internal/brief-why-matters.ts
+++ b/api/internal/brief-why-matters.ts
@@ -248,7 +248,11 @@ async function runAnalystPath(story: StoryPayload, iso2: string | null): Promise
     return parseWhyMattersV2(result.content);
   } catch (err) {
     console.warn(`[brief-why-matters] analyst path failed: ${err instanceof Error ? err.message : String(err)}`);
-    void captureSilentError(err, { tags: { route: 'api/internal/brief-why-matters', step: 'analyst-path', severity: 'warn' } });
+    // Nested helper called outside the request's `ctx.waitUntil` chain
+    // (analyst/gemini paths run via Promise.allSettled). Await keeps the
+    // helper's own promise pending until Sentry delivery completes,
+    // capped by the 2s fetch timeout in `_sentry-common.js`.
+    await captureSilentError(err, { tags: { route: 'api/internal/brief-why-matters', step: 'analyst-path', severity: 'warn' } });
     return null;
   }
 }
@@ -277,7 +281,7 @@ async function runGeminiPath(story: StoryPayload): Promise<string | null> {
     return parseWhyMatters(result.content);
   } catch (err) {
     console.warn(`[brief-why-matters] gemini path failed: ${err instanceof Error ? err.message : String(err)}`);
-    void captureSilentError(err, { tags: { route: 'api/internal/brief-why-matters', step: 'gemini-path', severity: 'warn' } });
+    await captureSilentError(err, { tags: { route: 'api/internal/brief-why-matters', step: 'gemini-path', severity: 'warn' } });
     return null;
   }
 }
@@ -398,7 +402,7 @@ export default async function handler(req: Request, ctx?: EdgeContext): Promise<
     }
   } catch (err) {
     console.warn(`[brief-why-matters] cache read degraded: ${err instanceof Error ? err.message : String(err)}`);
-    void captureSilentError(err, { tags: { route: 'api/internal/brief-why-matters', step: 'cache-read', severity: 'warn' } });
+    await captureSilentError(err, { tags: { route: 'api/internal/brief-why-matters', step: 'cache-read', severity: 'warn' } });
   }
 
   if (cached) {
@@ -456,7 +460,7 @@ export default async function handler(req: Request, ctx?: EdgeContext): Promise<
       await setCachedData(cacheKey, envelope, WHY_MATTERS_TTL_SEC);
     } catch (err) {
       console.warn(`[brief-why-matters] cache write degraded: ${err instanceof Error ? err.message : String(err)}`);
-      void captureSilentError(err, { tags: { route: 'api/internal/brief-why-matters', step: 'cache-write', severity: 'warn' } });
+      await captureSilentError(err, { tags: { route: 'api/internal/brief-why-matters', step: 'cache-write', severity: 'warn' } });
     }
   }
 

--- a/api/invalidate-user-api-key-cache.ts
+++ b/api/invalidate-user-api-key-cache.ts
@@ -16,6 +16,8 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { jsonResponse } from './_json-response.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from './_sentry-edge.js';
 import { validateBearerToken } from '../server/auth-session';
 import { invalidateApiKeyCache } from '../server/_shared/user-api-key';
 
@@ -91,6 +93,9 @@ export default async function handler(req: Request): Promise<Response> {
   } catch (err) {
     // Fail-closed: ownership check failed — reject to surface the issue
     console.warn('[invalidate-cache] Ownership check failed:', err instanceof Error ? err.message : String(err));
+    void captureSilentError(err, {
+      tags: { route: 'api/invalidate-user-api-key-cache', step: 'ownership-check' },
+    });
     return jsonResponse({ error: 'Service unavailable' }, 503, cors);
   }
 

--- a/api/invalidate-user-api-key-cache.ts
+++ b/api/invalidate-user-api-key-cache.ts
@@ -21,7 +21,10 @@ import { captureSilentError } from './_sentry-edge.js';
 import { validateBearerToken } from '../server/auth-session';
 import { invalidateApiKeyCache } from '../server/_shared/user-api-key';
 
-export default async function handler(req: Request): Promise<Response> {
+export default async function handler(
+  req: Request,
+  ctx: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return jsonResponse({ error: 'Origin not allowed' }, 403);
   }
@@ -93,9 +96,11 @@ export default async function handler(req: Request): Promise<Response> {
   } catch (err) {
     // Fail-closed: ownership check failed — reject to surface the issue
     console.warn('[invalidate-cache] Ownership check failed:', err instanceof Error ? err.message : String(err));
-    void captureSilentError(err, {
-      tags: { route: 'api/invalidate-user-api-key-cache', step: 'ownership-check' },
-    });
+    ctx.waitUntil(
+      captureSilentError(err, {
+        tags: { route: 'api/invalidate-user-api-key-cache', step: 'ownership-check' },
+      }),
+    );
     return jsonResponse({ error: 'Service unavailable' }, 503, cors);
   }
 

--- a/api/invalidate-user-api-key-cache.ts
+++ b/api/invalidate-user-api-key-cache.ts
@@ -23,7 +23,7 @@ import { invalidateApiKeyCache } from '../server/_shared/user-api-key';
 
 export default async function handler(
   req: Request,
-  ctx: { waitUntil: (p: Promise<unknown>) => void },
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return jsonResponse({ error: 'Origin not allowed' }, 403);
@@ -96,11 +96,10 @@ export default async function handler(
   } catch (err) {
     // Fail-closed: ownership check failed — reject to surface the issue
     console.warn('[invalidate-cache] Ownership check failed:', err instanceof Error ? err.message : String(err));
-    ctx.waitUntil(
-      captureSilentError(err, {
-        tags: { route: 'api/invalidate-user-api-key-cache', step: 'ownership-check' },
-      }),
-    );
+    captureSilentError(err, {
+      tags: { route: 'api/invalidate-user-api-key-cache', step: 'ownership-check' },
+      ctx,
+    });
     return jsonResponse({ error: 'Service unavailable' }, 503, cors);
   }
 

--- a/api/latest-brief.ts
+++ b/api/latest-brief.ts
@@ -53,7 +53,7 @@ type BriefPreview = {
 async function readBriefPreview(
   userId: string,
   issueSlot: string,
-  ctx: { waitUntil: (p: Promise<unknown>) => void },
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<BriefPreview | null> {
   const raw = await readRawJsonFromUpstash(`brief:${userId}:${issueSlot}`);
   if (raw == null) return null;
@@ -68,11 +68,10 @@ async function readBriefPreview(
     console.error(
       `[api/latest-brief] composer-bug: brief:${userId}:${issueSlot} failed envelope assertion: ${(err as Error).message}`,
     );
-    ctx.waitUntil(
-      captureSilentError(err, {
-        tags: { route: 'api/latest-brief', step: 'envelope-assertion', issueSlot },
-      }),
-    );
+    captureSilentError(err, {
+      tags: { route: 'api/latest-brief', step: 'envelope-assertion', issueSlot },
+      ctx,
+    });
     return null;
   }
   const { data } = raw;
@@ -113,7 +112,7 @@ function publicBaseUrl(req: Request): string {
 
 export default async function handler(
   req: Request,
-  ctx: { waitUntil: (p: Promise<unknown>) => void },
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return jsonResponse({ error: 'Origin not allowed' }, 403);
@@ -185,7 +184,7 @@ export default async function handler(
     // this into "composing", which would falsely signal empty state
     // to the dashboard panel. 503 lets the client show a retry path.
     console.error('[api/latest-brief] Upstash read failed:', (err as Error).message);
-    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/latest-brief', step: 'upstash-read' } }));
+    captureSilentError(err, { tags: { route: 'api/latest-brief', step: 'upstash-read' }, ctx });
     return jsonResponse({ error: 'service_unavailable' }, 503, cors);
   }
 

--- a/api/latest-brief.ts
+++ b/api/latest-brief.ts
@@ -28,6 +28,8 @@ import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { jsonResponse } from './_json-response.js';
 // @ts-expect-error — JS module, no declaration file
 import { readRawJsonFromUpstash } from './_upstash-json.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from './_sentry-edge.js';
 import { validateBearerToken } from '../server/auth-session';
 import { getEntitlements } from '../server/_shared/entitlement-check';
 import { signBriefUrl, BriefUrlError } from '../server/_shared/brief-url';
@@ -65,6 +67,9 @@ async function readBriefPreview(
     console.error(
       `[api/latest-brief] composer-bug: brief:${userId}:${issueSlot} failed envelope assertion: ${(err as Error).message}`,
     );
+    void captureSilentError(err, {
+      tags: { route: 'api/latest-brief', step: 'envelope-assertion', issueSlot },
+    });
     return null;
   }
   const { data } = raw;
@@ -174,6 +179,7 @@ export default async function handler(req: Request): Promise<Response> {
     // this into "composing", which would falsely signal empty state
     // to the dashboard panel. 503 lets the client show a retry path.
     console.error('[api/latest-brief] Upstash read failed:', (err as Error).message);
+    void captureSilentError(err, { tags: { route: 'api/latest-brief', step: 'upstash-read' } });
     return jsonResponse({ error: 'service_unavailable' }, 503, cors);
   }
 

--- a/api/latest-brief.ts
+++ b/api/latest-brief.ts
@@ -53,6 +53,7 @@ type BriefPreview = {
 async function readBriefPreview(
   userId: string,
   issueSlot: string,
+  ctx: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<BriefPreview | null> {
   const raw = await readRawJsonFromUpstash(`brief:${userId}:${issueSlot}`);
   if (raw == null) return null;
@@ -67,9 +68,11 @@ async function readBriefPreview(
     console.error(
       `[api/latest-brief] composer-bug: brief:${userId}:${issueSlot} failed envelope assertion: ${(err as Error).message}`,
     );
-    void captureSilentError(err, {
-      tags: { route: 'api/latest-brief', step: 'envelope-assertion', issueSlot },
-    });
+    ctx.waitUntil(
+      captureSilentError(err, {
+        tags: { route: 'api/latest-brief', step: 'envelope-assertion', issueSlot },
+      }),
+    );
     return null;
   }
   const { data } = raw;
@@ -108,7 +111,10 @@ function publicBaseUrl(req: Request): string {
   return new URL(req.url).origin;
 }
 
-export default async function handler(req: Request): Promise<Response> {
+export default async function handler(
+  req: Request,
+  ctx: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return jsonResponse({ error: 'Origin not allowed' }, 403);
   }
@@ -168,7 +174,7 @@ export default async function handler(req: Request): Promise<Response> {
   try {
     const targetSlot = requestedSlot ?? (await readLatestPointer(session.userId));
     if (targetSlot) {
-      const hit = await readBriefPreview(session.userId, targetSlot);
+      const hit = await readBriefPreview(session.userId, targetSlot, ctx);
       if (hit) {
         issueSlot = targetSlot;
         preview = hit;
@@ -179,7 +185,7 @@ export default async function handler(req: Request): Promise<Response> {
     // this into "composing", which would falsely signal empty state
     // to the dashboard panel. 503 lets the client show a retry path.
     console.error('[api/latest-brief] Upstash read failed:', (err as Error).message);
-    void captureSilentError(err, { tags: { route: 'api/latest-brief', step: 'upstash-read' } });
+    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/latest-brief', step: 'upstash-read' } }));
     return jsonResponse({ error: 'service_unavailable' }, 503, cors);
   }
 

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -813,7 +813,10 @@ async function executeTool(tool: CacheToolDef): Promise<{ cached_at: string | nu
 // ---------------------------------------------------------------------------
 // Main handler
 // ---------------------------------------------------------------------------
-export default async function handler(req: Request): Promise<Response> {
+export default async function handler(
+  req: Request,
+  ctx: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response> {
   // MCP is a public API endpoint secured by API key — allow all origins (claude.ai, Claude Desktop, custom agents)
   const corsHeaders = getPublicCorsHeaders('POST, OPTIONS');
 
@@ -955,9 +958,11 @@ export default async function handler(req: Request): Promise<Response> {
         }, corsHeaders);
       } catch (err: unknown) {
         console.error('[mcp] tool execution error:', err);
-        void captureSilentError(err, {
-          tags: { route: 'api/mcp', step: 'tool-execution', tool: tool.name },
-        });
+        ctx.waitUntil(
+          captureSilentError(err, {
+            tags: { route: 'api/mcp', step: 'tool-execution', tool: tool.name },
+          }),
+        );
         return rpcError(id, -32603, 'Internal error: data fetch failed');
       }
     }

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -10,6 +10,8 @@ import { readJsonFromUpstash } from './_upstash-json.js';
 import { resolveApiKeyFromBearer } from './_oauth-token.js';
 // @ts-expect-error — JS module, no declaration file
 import { timingSafeIncludes } from './_crypto.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from './_sentry-edge.js';
 import COUNTRY_BBOXES from '../shared/country-bboxes.js';
 // @ts-expect-error — generated JS module, no declaration file
 import MINING_SITES_RAW from '../shared/mining-sites.js';
@@ -953,6 +955,9 @@ export default async function handler(req: Request): Promise<Response> {
         }, corsHeaders);
       } catch (err: unknown) {
         console.error('[mcp] tool execution error:', err);
+        void captureSilentError(err, {
+          tags: { route: 'api/mcp', step: 'tool-execution', tool: tool.name },
+        });
         return rpcError(id, -32603, 'Internal error: data fetch failed');
       }
     }

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -815,7 +815,7 @@ async function executeTool(tool: CacheToolDef): Promise<{ cached_at: string | nu
 // ---------------------------------------------------------------------------
 export default async function handler(
   req: Request,
-  ctx: { waitUntil: (p: Promise<unknown>) => void },
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<Response> {
   // MCP is a public API endpoint secured by API key — allow all origins (claude.ai, Claude Desktop, custom agents)
   const corsHeaders = getPublicCorsHeaders('POST, OPTIONS');
@@ -958,11 +958,10 @@ export default async function handler(
         }, corsHeaders);
       } catch (err: unknown) {
         console.error('[mcp] tool execution error:', err);
-        ctx.waitUntil(
-          captureSilentError(err, {
-            tags: { route: 'api/mcp', step: 'tool-execution', tool: tool.name },
-          }),
-        );
+        captureSilentError(err, {
+          tags: { route: 'api/mcp', step: 'tool-execution', tool: tool.name },
+          ctx,
+        });
         return rpcError(id, -32603, 'Internal error: data fetch failed');
       }
     }

--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -208,7 +208,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
       return json(data, 200, corsHeaders, true);
     } catch (err) {
       console.error('[notification-channels] GET error:', err);
-      ctx.waitUntil(captureEdgeException(err, { handler: 'notification-channels', method: 'GET' }));
+      captureEdgeException(err, { handler: 'notification-channels', method: 'GET' }, ctx);
       return json({ error: 'Failed to fetch' }, 500, corsHeaders);
     }
   }
@@ -414,7 +414,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
       return json({ error: 'Unknown action' }, 400, corsHeaders);
     } catch (err) {
       console.error('[notification-channels] POST error:', err);
-      ctx.waitUntil(captureEdgeException(err, { handler: 'notification-channels', method: 'POST' }));
+      captureEdgeException(err, { handler: 'notification-channels', method: 'POST' }, ctx);
       return json({ error: 'Operation failed' }, 500, corsHeaders);
     }
   }

--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -97,7 +97,9 @@ async function publishWelcome(userId: string, channelType: string): Promise<void
     console.log(`[notification-channels] publishWelcome LPUSH: status=${res.status} result=${JSON.stringify(data?.result)}`);
   } catch (err) {
     console.error('[notification-channels] publishWelcome LPUSH failed:', (err as Error).message);
-    void captureSilentError(err, {
+    // publishWelcome runs inside the handler's ctx.waitUntil chain; await
+    // keeps that chain pending until Sentry delivery completes.
+    await captureSilentError(err, {
       tags: { route: 'api/notification-channels', step: 'publish-welcome' },
     });
   }
@@ -114,7 +116,7 @@ async function publishFlushHeld(userId: string, variant: string): Promise<void> 
     });
   } catch (err) {
     console.warn('[notification-channels] publishFlushHeld LPUSH failed:', (err as Error).message);
-    void captureSilentError(err, {
+    await captureSilentError(err, {
       tags: { route: 'api/notification-channels', step: 'publish-flush-held', severity: 'warn' },
     });
   }
@@ -206,7 +208,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
       return json(data, 200, corsHeaders, true);
     } catch (err) {
       console.error('[notification-channels] GET error:', err);
-      void captureEdgeException(err, { handler: 'notification-channels', method: 'GET' });
+      ctx.waitUntil(captureEdgeException(err, { handler: 'notification-channels', method: 'GET' }));
       return json({ error: 'Failed to fetch' }, 500, corsHeaders);
     }
   }
@@ -412,7 +414,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
       return json({ error: 'Unknown action' }, 400, corsHeaders);
     } catch (err) {
       console.error('[notification-channels] POST error:', err);
-      void captureEdgeException(err, { handler: 'notification-channels', method: 'POST' });
+      ctx.waitUntil(captureEdgeException(err, { handler: 'notification-channels', method: 'POST' }));
       return json({ error: 'Operation failed' }, 500, corsHeaders);
     }
   }

--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -14,7 +14,7 @@ export const config = { runtime: 'edge' };
 // @ts-expect-error — JS module, no declaration file
 import { getCorsHeaders } from './_cors.js';
 // @ts-expect-error — JS module, no declaration file
-import { captureEdgeException } from './_sentry-edge.js';
+import { captureEdgeException, captureSilentError } from './_sentry-edge.js';
 import { validateBearerToken } from '../server/auth-session';
 import { getEntitlements } from '../server/_shared/entitlement-check';
 
@@ -97,6 +97,9 @@ async function publishWelcome(userId: string, channelType: string): Promise<void
     console.log(`[notification-channels] publishWelcome LPUSH: status=${res.status} result=${JSON.stringify(data?.result)}`);
   } catch (err) {
     console.error('[notification-channels] publishWelcome LPUSH failed:', (err as Error).message);
+    void captureSilentError(err, {
+      tags: { route: 'api/notification-channels', step: 'publish-welcome' },
+    });
   }
 }
 
@@ -111,6 +114,9 @@ async function publishFlushHeld(userId: string, variant: string): Promise<void> 
     });
   } catch (err) {
     console.warn('[notification-channels] publishFlushHeld LPUSH failed:', (err as Error).message);
+    void captureSilentError(err, {
+      tags: { route: 'api/notification-channels', step: 'publish-flush-held', severity: 'warn' },
+    });
   }
 }
 

--- a/api/referral/me.ts
+++ b/api/referral/me.ts
@@ -31,6 +31,8 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { jsonResponse } from '../_json-response.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from '../_sentry-edge.js';
 import { validateBearerToken } from '../../server/auth-session';
 import { getReferralCodeForUser, buildShareUrl } from '../../server/_shared/referral-code';
 
@@ -117,6 +119,7 @@ export default async function handler(
     code = await getReferralCodeForUser(session.userId, secret);
   } catch (err) {
     console.error('[api/referral/me] code generation failed:', (err as Error).message);
+    void captureSilentError(err, { tags: { route: 'api/referral/me', step: 'code-generation' } });
     return jsonResponse({ error: 'service_unavailable' }, 503, cors);
   }
 

--- a/api/referral/me.ts
+++ b/api/referral/me.ts
@@ -119,7 +119,7 @@ export default async function handler(
     code = await getReferralCodeForUser(session.userId, secret);
   } catch (err) {
     console.error('[api/referral/me] code generation failed:', (err as Error).message);
-    void captureSilentError(err, { tags: { route: 'api/referral/me', step: 'code-generation' } });
+    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/referral/me', step: 'code-generation' } }));
     return jsonResponse({ error: 'service_unavailable' }, 503, cors);
   }
 

--- a/api/referral/me.ts
+++ b/api/referral/me.ts
@@ -119,7 +119,7 @@ export default async function handler(
     code = await getReferralCodeForUser(session.userId, secret);
   } catch (err) {
     console.error('[api/referral/me] code generation failed:', (err as Error).message);
-    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/referral/me', step: 'code-generation' } }));
+    captureSilentError(err, { tags: { route: 'api/referral/me', step: 'code-generation' }, ctx });
     return jsonResponse({ error: 'service_unavailable' }, 503, cors);
   }
 

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -186,7 +186,7 @@ export default async function handler(req, ctx) {
     // Skip Sentry capture on timeout — Sentry would drown in transient
     // upstream-feed timeouts which are routine. Only surface "real" errors.
     if (!isTimeout) {
-      ctx?.waitUntil?.(captureSilentError(error, { tags: { route: 'api/rss-proxy', step: 'fetch', feed: feedUrl } }));
+      captureSilentError(error, { tags: { route: 'api/rss-proxy', step: 'fetch', feed: feedUrl }, ctx });
     }
     return jsonResponse({
       error: isTimeout ? 'Feed timeout' : 'Failed to fetch feed',

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -4,6 +4,7 @@ import { checkRateLimit } from './_rate-limit.js';
 import { getRelayBaseUrl, getRelayHeaders, fetchWithTimeout } from './_relay.js';
 import RSS_ALLOWED_DOMAINS from './_rss-allowed-domains.js';
 import { jsonResponse } from './_json-response.js';
+import { captureSilentError } from './_sentry-edge.js';
 
 export const config = { runtime: 'edge' };
 
@@ -182,6 +183,11 @@ export default async function handler(req) {
   } catch (error) {
     const isTimeout = error.name === 'AbortError';
     console.error('RSS proxy error:', feedUrl, error.message);
+    // Skip Sentry capture on timeout — Sentry would drown in transient
+    // upstream-feed timeouts which are routine. Only surface "real" errors.
+    if (!isTimeout) {
+      void captureSilentError(error, { tags: { route: 'api/rss-proxy', step: 'fetch', feed: feedUrl } });
+    }
     return jsonResponse({
       error: isTimeout ? 'Feed timeout' : 'Failed to fetch feed',
       details: error.message,

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -66,7 +66,7 @@ function isGoogleNewsFeedUrl(feedUrl) {
   }
 }
 
-export default async function handler(req) {
+export default async function handler(req, ctx) {
   const corsHeaders = getCorsHeaders(req, 'GET, OPTIONS');
 
   if (isDisallowedOrigin(req)) {
@@ -186,7 +186,7 @@ export default async function handler(req) {
     // Skip Sentry capture on timeout — Sentry would drown in transient
     // upstream-feed timeouts which are routine. Only surface "real" errors.
     if (!isTimeout) {
-      void captureSilentError(error, { tags: { route: 'api/rss-proxy', step: 'fetch', feed: feedUrl } });
+      ctx?.waitUntil?.(captureSilentError(error, { tags: { route: 'api/rss-proxy', step: 'fetch', feed: feedUrl } }));
     }
     return jsonResponse({
       error: isTimeout ? 'Feed timeout' : 'Failed to fetch feed',

--- a/api/slack/oauth/callback.ts
+++ b/api/slack/oauth/callback.ts
@@ -82,7 +82,9 @@ async function publishWelcome(userId: string, channelType: string): Promise<void
     console.log(`[slack-oauth] publishWelcome LPUSH: status=${res.status} result=${JSON.stringify(data?.result)}`);
   } catch (err) {
     console.error('[slack-oauth] publishWelcome LPUSH failed:', (err as Error).message);
-    void captureSilentError(err, {
+    // publishWelcome runs inside the handler's ctx.waitUntil chain; await
+    // keeps that chain pending until Sentry delivery completes.
+    await captureSilentError(err, {
       tags: { route: 'api/slack/oauth/callback', step: 'publish-welcome' },
     });
   }

--- a/api/slack/oauth/callback.ts
+++ b/api/slack/oauth/callback.ts
@@ -11,6 +11,9 @@
 
 export const config = { runtime: 'edge' };
 
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from '../../_sentry-edge.js';
+
 const SLACK_CLIENT_ID = process.env.SLACK_CLIENT_ID ?? '';
 const SLACK_CLIENT_SECRET = process.env.SLACK_CLIENT_SECRET ?? '';
 const SLACK_REDIRECT_URI = process.env.SLACK_REDIRECT_URI ?? '';
@@ -79,6 +82,9 @@ async function publishWelcome(userId: string, channelType: string): Promise<void
     console.log(`[slack-oauth] publishWelcome LPUSH: status=${res.status} result=${JSON.stringify(data?.result)}`);
   } catch (err) {
     console.error('[slack-oauth] publishWelcome LPUSH failed:', (err as Error).message);
+    void captureSilentError(err, {
+      tags: { route: 'api/slack/oauth/callback', step: 'publish-welcome' },
+    });
   }
 }
 

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -21,7 +21,7 @@ import { validateBearerToken } from '../server/auth-session';
 
 export default async function handler(
   req: Request,
-  ctx: { waitUntil: (p: Promise<unknown>) => void },
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return jsonResponse({ error: 'Origin not allowed' }, 403);
@@ -66,7 +66,7 @@ export default async function handler(
       return jsonResponse(prefs ?? null, 200, cors);
     } catch (err) {
       console.error('[user-prefs] GET error:', err);
-      ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/user-prefs', method: 'GET' } }));
+      captureSilentError(err, { tags: { route: 'api/user-prefs', method: 'GET' }, ctx });
       return jsonResponse({ error: 'Failed to fetch preferences' }, 500, cors);
     }
   }
@@ -105,7 +105,7 @@ export default async function handler(
       return jsonResponse({ error: 'BLOB_TOO_LARGE' }, 400, cors);
     }
     console.error('[user-prefs] POST error:', err);
-    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/user-prefs', method: 'POST' } }));
+    captureSilentError(err, { tags: { route: 'api/user-prefs', method: 'POST' }, ctx });
     return jsonResponse({ error: 'Failed to save preferences' }, 500, cors);
   }
 }

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -14,6 +14,8 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { jsonResponse } from './_json-response.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from './_sentry-edge.js';
 import { ConvexHttpClient } from 'convex/browser';
 import { validateBearerToken } from '../server/auth-session';
 
@@ -61,6 +63,7 @@ export default async function handler(req: Request): Promise<Response> {
       return jsonResponse(prefs ?? null, 200, cors);
     } catch (err) {
       console.error('[user-prefs] GET error:', err);
+      void captureSilentError(err, { tags: { route: 'api/user-prefs', method: 'GET' } });
       return jsonResponse({ error: 'Failed to fetch preferences' }, 500, cors);
     }
   }
@@ -99,6 +102,7 @@ export default async function handler(req: Request): Promise<Response> {
       return jsonResponse({ error: 'BLOB_TOO_LARGE' }, 400, cors);
     }
     console.error('[user-prefs] POST error:', err);
+    void captureSilentError(err, { tags: { route: 'api/user-prefs', method: 'POST' } });
     return jsonResponse({ error: 'Failed to save preferences' }, 500, cors);
   }
 }

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -19,7 +19,10 @@ import { captureSilentError } from './_sentry-edge.js';
 import { ConvexHttpClient } from 'convex/browser';
 import { validateBearerToken } from '../server/auth-session';
 
-export default async function handler(req: Request): Promise<Response> {
+export default async function handler(
+  req: Request,
+  ctx: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response> {
   if (isDisallowedOrigin(req)) {
     return jsonResponse({ error: 'Origin not allowed' }, 403);
   }
@@ -63,7 +66,7 @@ export default async function handler(req: Request): Promise<Response> {
       return jsonResponse(prefs ?? null, 200, cors);
     } catch (err) {
       console.error('[user-prefs] GET error:', err);
-      void captureSilentError(err, { tags: { route: 'api/user-prefs', method: 'GET' } });
+      ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/user-prefs', method: 'GET' } }));
       return jsonResponse({ error: 'Failed to fetch preferences' }, 500, cors);
     }
   }
@@ -102,7 +105,7 @@ export default async function handler(req: Request): Promise<Response> {
       return jsonResponse({ error: 'BLOB_TOO_LARGE' }, 400, cors);
     }
     console.error('[user-prefs] POST error:', err);
-    void captureSilentError(err, { tags: { route: 'api/user-prefs', method: 'POST' } });
+    ctx.waitUntil(captureSilentError(err, { tags: { route: 'api/user-prefs', method: 'POST' } }));
     return jsonResponse({ error: 'Failed to save preferences' }, 500, cors);
   }
 }

--- a/convex/payments/cacheActions.ts
+++ b/convex/payments/cacheActions.ts
@@ -80,7 +80,13 @@ export const syncEntitlementCache = internalAction({
       );
 
       if (!resp.ok) {
-        console.warn(
+        // Throw so Convex auto-Sentry surfaces this; the action is
+        // scheduled by upsertEntitlements (fire-and-forget) and the
+        // SET is idempotent, so retry-on-error is safe and correct.
+        // The previous silent `console.warn` left persistent Redis
+        // outages invisible — users who upgraded would not see PRO
+        // features until next manual cache rebuild.
+        throw new Error(
           `[cacheActions] Redis SET failed: HTTP ${resp.status} for user ${args.userId}`,
         );
       }
@@ -89,6 +95,9 @@ export const syncEntitlementCache = internalAction({
         "[cacheActions] Redis cache sync failed:",
         err instanceof Error ? err.message : String(err),
       );
+      // Re-throw so Convex auto-Sentry captures (the warn above stays
+      // for ops visibility in the Convex log dashboard).
+      throw err;
     } finally {
       clearTimeout(timeout);
     }
@@ -124,7 +133,9 @@ export const deleteEntitlementCache = internalAction({
       );
 
       if (!resp.ok) {
-        console.warn(
+        // Same rationale as the SET path — surface persistent failures
+        // via Convex auto-Sentry. DEL is idempotent so retry is safe.
+        throw new Error(
           `[cacheActions] Redis DEL failed: HTTP ${resp.status} for key ${key}`,
         );
       }
@@ -133,6 +144,7 @@ export const deleteEntitlementCache = internalAction({
         "[cacheActions] Redis cache delete failed:",
         err instanceof Error ? err.message : String(err),
       );
+      throw err;
     } finally {
       clearTimeout(timeout);
     }

--- a/convex/payments/webhookHandlers.ts
+++ b/convex/payments/webhookHandlers.ts
@@ -1,7 +1,34 @@
-import { httpAction } from "../_generated/server";
+import { httpAction, internalMutation } from "../_generated/server";
+import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { requireEnv } from "../lib/env";
 import { verifyWebhookPayload } from "@dodopayments/core";
+
+/**
+ * Surfaces a Dodo webhook signature failure to Convex auto-Sentry by
+ * throwing a structured error. Called via `ctx.scheduler.runAfter(0,...)`
+ * from the signature-failure catch path so:
+ *   - the HTTP response (401) is sent immediately, unaffected
+ *   - the scheduled throw runs after the response and is captured by
+ *     Convex's automatic Sentry integration
+ *   - no SDK install is required in the Convex backend
+ *
+ * Without this, a botched secret rotation could 401 every Dodo webhook
+ * silently for hours — same observability gap shape as the canary OCC
+ * bug (WORLDMONITOR-PA), just on a different surface.
+ */
+export const reportDodoSignatureFailure = internalMutation({
+  args: {
+    webhookId: v.optional(v.string()),
+    webhookTimestamp: v.optional(v.string()),
+    errorMessage: v.string(),
+  },
+  handler: async (_ctx, { webhookId, webhookTimestamp, errorMessage }) => {
+    throw new Error(
+      `[webhook] Dodo signature verification failed (webhookId=${webhookId ?? "<missing>"}, ts=${webhookTimestamp ?? "<missing>"}): ${errorMessage}`,
+    );
+  },
+});
 
 /**
  * Custom webhook HTTP action for Dodo Payments.
@@ -44,6 +71,18 @@ export const webhookHandler = httpAction(async (ctx, request) => {
     });
   } catch (error) {
     console.error("Webhook signature verification failed:", error);
+    // Surface to Sentry via a scheduled mutation throw — runs AFTER the
+    // 401 response so Dodo's contract is preserved. Convex auto-Sentry
+    // catches the throw and reports the signature failure as an issue.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.payments.webhookHandlers.reportDodoSignatureFailure,
+      {
+        webhookId: webhookId ?? undefined,
+        webhookTimestamp: webhookTimestamp ?? undefined,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      },
+    );
     return new Response("Invalid webhook signature", { status: 401 });
   }
 

--- a/convex/payments/webhookHandlers.ts
+++ b/convex/payments/webhookHandlers.ts
@@ -13,6 +13,12 @@ import { verifyWebhookPayload } from "@dodopayments/core";
  *     Convex's automatic Sentry integration
  *   - no SDK install is required in the Convex backend
  *
+ * Why `internalMutation` and not `internalAction`: Convex auto-retries
+ * failed actions per its scheduler retry policy, which would produce N
+ * duplicate Sentry events per signature failure during outages.
+ * Mutations are NOT auto-retried — exactly one Sentry event per failed
+ * signature check. Don't "simplify" this to an action.
+ *
  * Without this, a botched secret rotation could 401 every Dodo webhook
  * silently for hours — same observability gap shape as the canary OCC
  * bug (WORLDMONITOR-PA), just on a different surface.
@@ -70,19 +76,37 @@ export const webhookHandler = httpAction(async (ctx, request) => {
       body,
     });
   } catch (error) {
+    // sentry-coverage-ok: the scheduled mutation below throws a
+    // structured error that Convex auto-Sentry captures. Required because
+    // we MUST 401 (not 500) to Dodo here — re-throwing would trigger a
+    // retry-storm. See scripts/check-sentry-coverage.mjs for the marker.
     console.error("Webhook signature verification failed:", error);
     // Surface to Sentry via a scheduled mutation throw — runs AFTER the
     // 401 response so Dodo's contract is preserved. Convex auto-Sentry
     // catches the throw and reports the signature failure as an issue.
-    await ctx.scheduler.runAfter(
-      0,
-      internal.payments.webhookHandlers.reportDodoSignatureFailure,
-      {
-        webhookId: webhookId ?? undefined,
-        webhookTimestamp: webhookTimestamp ?? undefined,
-        errorMessage: error instanceof Error ? error.message : String(error),
-      },
-    );
+    //
+    // Wrapped in its own try/catch: a scheduler infrastructure hiccup
+    // here MUST NOT block the 401 path. Without this guard, a thrown
+    // `runAfter` would surface as an uncaught 500 to Dodo, triggering
+    // exactly the retry-storm this whole pattern exists to prevent.
+    try {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.payments.webhookHandlers.reportDodoSignatureFailure,
+        {
+          webhookId: webhookId ?? undefined,
+          webhookTimestamp: webhookTimestamp ?? undefined,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        },
+      );
+    } catch (scheduleErr) {
+      // Best-effort — log and continue. The 401 below is the
+      // contract-critical path; Sentry capture is the bonus.
+      console.error(
+        "[webhook] reportDodoSignatureFailure schedule failed:",
+        scheduleErr,
+      );
+    }
     return new Response("Invalid webhook signature", { status: 401 });
   }
 

--- a/scripts/check-sentry-coverage.mjs
+++ b/scripts/check-sentry-coverage.mjs
@@ -9,13 +9,15 @@
  *
  * Heuristic: for each file under api/ or convex/, find catch blocks
  * (`} catch (...) { ... }`). If a block contains console.error/warn
- * but no `captureSilentError`, `captureEdgeException`, `Sentry.`, or
- * `throw` — fail.
+ * but no `captureSilentError`, `captureEdgeException`, `Sentry.`, `throw`,
+ * or `status: 5xx` (after stripping comments and string literals to avoid
+ * matching those tokens inside text) — fail.
  *
  * Mode:
- *   - `--diff` (default in pre-push): only flags catch blocks introduced
- *     in the diff vs origin/main. Existing legacy catches are tolerated
- *     so we don't block unrelated work.
+ *   - `--diff` (default in pre-push): only flags catch blocks that
+ *     OVERLAP a hunk introduced in the diff vs origin/main. A catch
+ *     block in a changed file that wasn't itself touched is tolerated
+ *     so unrelated edits in legacy files aren't blocked.
  *   - `--all`: scans the whole tree. Use ad-hoc to find existing gaps.
  *
  * Exit code: 0 if clean (or no offending changes), 1 if any flag.
@@ -41,6 +43,11 @@ const TARGET_DIRS = ['api', 'convex'];
 // `status: 5xx` covers HTTP handlers that return a 5xx upstream — Resend
 // / Dodo / clients retry, and the inner mutation throw (if any) is already
 // captured by Convex auto-Sentry, so the outer catch+log isn't a swallow.
+//
+// These regexes run against the catch body AFTER comments and string
+// literals have been stripped — so `throw` inside a comment or a string
+// literal will NOT count as safe. Without that strip, prose like "// don't
+// throw here" or `console.error('throw failed')` would mask real swallows.
 const SAFE_PATTERNS = [
   /\bcaptureSilentError\b/,
   /\bcaptureEdgeException\b/,
@@ -50,6 +57,14 @@ const SAFE_PATTERNS = [
   /\bstatus:\s*5\d\d\b/,
 ];
 
+// Inline override marker — when a catch body needs to swallow on the
+// HTTP path but surfaces to Sentry through a non-obvious channel (e.g.,
+// `ctx.scheduler.runAfter(...)` to a Convex mutation that throws). The
+// marker MUST be in the un-stripped raw source so it survives comment
+// removal — we check the raw catch body for it before falling through
+// to the safety patterns.
+const OVERRIDE_MARKER = /\/\/\s*sentry-coverage-ok\b/;
+
 const LOG_PATTERN = /\bconsole\.(error|warn)\b/;
 
 // Skip the helper files themselves — their `console.warn` on Sentry
@@ -58,7 +73,151 @@ const LOG_PATTERN = /\bconsole\.(error|warn)\b/;
 const SKIP_FILE_PATTERNS = [
   /\/api\/_sentry-edge\.(js|mjs|ts)$/,
   /\/api\/_sentry-node\.(js|mjs|ts)$/,
+  /\/api\/_sentry-common\.(js|mjs|ts)$/,
 ];
+
+/**
+ * Replace JavaScript comments and string literals with spaces of equal
+ * length, preserving line numbers and overall indexing. We don't need to
+ * preserve the actual content — we just need the safety-pattern regexes
+ * to NOT match against tokens that live inside comments or strings.
+ *
+ * Handled forms:
+ *   - line comment   `// ...\n`
+ *   - block comment  `/ * ... * /`  (without space)
+ *   - single-quoted  'string with \\' escape'
+ *   - double-quoted  "string with \\" escape"
+ *   - template       `string with ${expr}` — only the static slices, not
+ *                    the ${expr} parts (those are real code we still want
+ *                    to scan). Best-effort: nested templates and braces
+ *                    inside ${...} are tolerated by tracking depth.
+ *   - regex literals — matters too because /throw/ would otherwise hit.
+ *                    Heuristic: only treat `/.../flags` as a regex when
+ *                    the previous non-whitespace token is one of the
+ *                    canonical "regex follows" tokens. Imperfect but
+ *                    good enough for our codebase; false negatives here
+ *                    cost a real-bug detection at worst.
+ */
+function stripCommentsAndStrings(src) {
+  const out = new Array(src.length);
+  for (let i = 0; i < src.length; i++) out[i] = src[i];
+
+  function blank(start, end) {
+    for (let k = start; k < end; k++) {
+      // Preserve newlines so line numbers stay correct.
+      if (out[k] !== '\n') out[k] = ' ';
+    }
+  }
+
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    const next = src[i + 1];
+
+    // Line comment
+    if (c === '/' && next === '/') {
+      let j = i + 2;
+      while (j < src.length && src[j] !== '\n') j++;
+      blank(i, j);
+      i = j;
+      continue;
+    }
+    // Block comment
+    if (c === '/' && next === '*') {
+      let j = i + 2;
+      while (j < src.length - 1 && !(src[j] === '*' && src[j + 1] === '/')) j++;
+      const end = Math.min(src.length, j + 2);
+      blank(i, end);
+      i = end;
+      continue;
+    }
+    // String literals (single, double)
+    if (c === "'" || c === '"') {
+      const quote = c;
+      let j = i + 1;
+      while (j < src.length) {
+        const ch = src[j];
+        if (ch === '\\') {
+          j += 2;
+          continue;
+        }
+        if (ch === quote) {
+          j++;
+          break;
+        }
+        if (ch === '\n') break; // unterminated — bail
+        j++;
+      }
+      blank(i, j);
+      i = j;
+      continue;
+    }
+    // Template literal (handle ${ ... } as code we KEEP, rest as string)
+    if (c === '`') {
+      let j = i + 1;
+      let staticStart = j;
+      while (j < src.length) {
+        const ch = src[j];
+        if (ch === '\\') {
+          j += 2;
+          continue;
+        }
+        if (ch === '$' && src[j + 1] === '{') {
+          // Blank the static slice before this ${, then descend into the
+          // expression and let the outer loop pick it back up after the
+          // matching '}'.
+          blank(staticStart, j);
+          let depth = 1;
+          j += 2;
+          while (j < src.length && depth > 0) {
+            const inner = src[j];
+            if (inner === '{') depth++;
+            else if (inner === '}') depth--;
+            else if (inner === "'" || inner === '"' || inner === '`') {
+              // Skip nested strings via a mini-recursion.
+              const sub = stripStringFrom(src, j);
+              blank(j, sub);
+              j = sub;
+              continue;
+            }
+            j++;
+          }
+          staticStart = j;
+          continue;
+        }
+        if (ch === '`') {
+          blank(staticStart, j);
+          j++;
+          break;
+        }
+        j++;
+      }
+      i = j;
+      continue;
+    }
+    i++;
+  }
+
+  return out.join('');
+}
+
+// Helper — skip past a string starting at `i`, return index after closing.
+function stripStringFrom(src, i) {
+  const c = src[i];
+  if (c !== "'" && c !== '"' && c !== '`') return i + 1;
+  const quote = c;
+  let j = i + 1;
+  while (j < src.length) {
+    const ch = src[j];
+    if (ch === '\\') {
+      j += 2;
+      continue;
+    }
+    if (ch === quote) return j + 1;
+    j++;
+  }
+  return j;
+}
 
 function listChangedFiles() {
   try {
@@ -75,6 +234,40 @@ function listChangedFiles() {
   }
 }
 
+/**
+ * For a given file in diff mode, parse `git diff --unified=0` to extract
+ * the set of line ranges that were added/modified vs origin/main. Used
+ * to scope catch-block checks to "newly introduced or touched" only.
+ */
+function changedLineRanges(filePath) {
+  try {
+    const out = execSync(
+      `git diff --unified=0 origin/main...HEAD -- "${filePath}"`,
+      { encoding: 'utf8' },
+    );
+    const ranges = [];
+    for (const line of out.split('\n')) {
+      // Hunk header: @@ -oldStart,oldCount +newStart,newCount @@
+      const m = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+      if (!m) continue;
+      const start = Number(m[1]);
+      const count = m[2] ? Number(m[2]) : 1;
+      if (count === 0) continue; // pure deletion — no new lines on this side
+      ranges.push([start, start + count - 1]);
+    }
+    return ranges;
+  } catch {
+    return [];
+  }
+}
+
+function rangesOverlap(catchStart, catchEnd, ranges) {
+  for (const [s, e] of ranges) {
+    if (catchEnd >= s && catchStart <= e) return true;
+  }
+  return false;
+}
+
 function listAllFiles() {
   const out = execSync(
     `find ${TARGET_DIRS.join(' ')} -type f \\( -name '*.ts' -o -name '*.tsx' -o -name '*.mjs' -o -name '*.js' \\) -not -path '*/node_modules/*' -not -path '*/_generated/*'`,
@@ -83,12 +276,15 @@ function listAllFiles() {
   return out.split('\n').filter(Boolean);
 }
 
-function findUnsafeCatches(filePath) {
-  const src = readFileSync(filePath, 'utf8');
+function findUnsafeCatches(filePath, restrictToRanges) {
+  const rawSrc = readFileSync(filePath, 'utf8');
+  const src = stripCommentsAndStrings(rawSrc);
   const offenders = [];
 
   // Scan for catch blocks. We balance braces manually to handle nesting
-  // (regex alone misses nested `{ }` inside the catch body).
+  // (regex alone misses nested `{ }` inside the catch body). Operating on
+  // the comment/string-stripped source means brace counts inside string
+  // literals can no longer fool the depth tracker.
   let i = 0;
   while (i < src.length) {
     const m = src.slice(i).match(/\}\s*catch\s*(?:\([^)]*\))?\s*\{/);
@@ -109,9 +305,23 @@ function findUnsafeCatches(filePath) {
     const bodyEnd = j; // exclusive
     const body = src.slice(bodyOpenAbs + 1, bodyEnd - 1);
 
-    if (LOG_PATTERN.test(body) && !SAFE_PATTERNS.some((p) => p.test(body))) {
-      const lineNo = src.slice(0, absStart).split('\n').length;
-      offenders.push({ filePath, lineNo, snippet: body.split('\n')[0].trim().slice(0, 100) });
+    const rawBody = rawSrc.slice(bodyOpenAbs + 1, bodyEnd - 1);
+    const hasOverride = OVERRIDE_MARKER.test(rawBody);
+
+    if (
+      !hasOverride &&
+      LOG_PATTERN.test(body) &&
+      !SAFE_PATTERNS.some((p) => p.test(body))
+    ) {
+      const startLine = src.slice(0, absStart).split('\n').length;
+      const endLine = src.slice(0, bodyEnd).split('\n').length;
+      if (!restrictToRanges || rangesOverlap(startLine, endLine, restrictToRanges)) {
+        offenders.push({
+          filePath,
+          lineNo: startLine,
+          snippet: rawBody.split('\n').find((l) => l.trim())?.trim().slice(0, 100) ?? '',
+        });
+      }
     }
 
     i = bodyEnd;
@@ -131,8 +341,10 @@ function main() {
   for (const f of files) {
     const abs = resolve(f);
     if (SKIP_FILE_PATTERNS.some((p) => p.test(abs))) continue;
+    const ranges = SCAN_ALL ? null : changedLineRanges(f);
+    if (!SCAN_ALL && (!ranges || ranges.length === 0)) continue;
     try {
-      allOffenders.push(...findUnsafeCatches(abs));
+      allOffenders.push(...findUnsafeCatches(abs, ranges));
     } catch (err) {
       // Skip unreadable files (e.g., deleted in this diff).
       if (err && err.code !== 'ENOENT') throw err;

--- a/scripts/check-sentry-coverage.mjs
+++ b/scripts/check-sentry-coverage.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Sentry-coverage lint guard.
+ *
+ * Flags catch blocks in api/ and convex/ that log via console.error /
+ * console.warn but don't surface to Sentry — i.e., the silent-swallow
+ * pattern that hid the canary OCC bug (Sentry issue WORLDMONITOR-PA)
+ * for hours and made the post-mortem impossible.
+ *
+ * Heuristic: for each file under api/ or convex/, find catch blocks
+ * (`} catch (...) { ... }`). If a block contains console.error/warn
+ * but no `captureSilentError`, `captureEdgeException`, `Sentry.`, or
+ * `throw` — fail.
+ *
+ * Mode:
+ *   - `--diff` (default in pre-push): only flags catch blocks introduced
+ *     in the diff vs origin/main. Existing legacy catches are tolerated
+ *     so we don't block unrelated work.
+ *   - `--all`: scans the whole tree. Use ad-hoc to find existing gaps.
+ *
+ * Exit code: 0 if clean (or no offending changes), 1 if any flag.
+ *
+ * Run manually:
+ *   node scripts/check-sentry-coverage.mjs            # diff mode
+ *   node scripts/check-sentry-coverage.mjs --all      # full scan
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const args = process.argv.slice(2);
+const SCAN_ALL = args.includes('--all');
+
+const TARGET_DIRS = ['api', 'convex'];
+
+// A catch block is "OK" if it contains at least one of these markers.
+// `throw` covers re-throws (auto-Sentry catches the propagated throw).
+// `captureSilentError` is our helper. `captureEdgeException` is the
+// pre-sweep alias still imported by notification-channels.ts.
+// `status: 5xx` covers HTTP handlers that return a 5xx upstream — Resend
+// / Dodo / clients retry, and the inner mutation throw (if any) is already
+// captured by Convex auto-Sentry, so the outer catch+log isn't a swallow.
+const SAFE_PATTERNS = [
+  /\bcaptureSilentError\b/,
+  /\bcaptureEdgeException\b/,
+  /\bSentry\.captureException\b/,
+  /\bSentry\.captureMessage\b/,
+  /\bthrow\b/,
+  /\bstatus:\s*5\d\d\b/,
+];
+
+const LOG_PATTERN = /\bconsole\.(error|warn)\b/;
+
+// Skip the helper files themselves — their `console.warn` on Sentry
+// delivery failure is the right behaviour (a Sentry capture inside the
+// Sentry helper would loop forever).
+const SKIP_FILE_PATTERNS = [
+  /\/api\/_sentry-edge\.(js|mjs|ts)$/,
+  /\/api\/_sentry-node\.(js|mjs|ts)$/,
+];
+
+function listChangedFiles() {
+  try {
+    const out = execSync('git diff --name-only origin/main...HEAD', {
+      encoding: 'utf8',
+    });
+    return out
+      .split('\n')
+      .filter(Boolean)
+      .filter((p) => TARGET_DIRS.some((d) => p.startsWith(`${d}/`)))
+      .filter((p) => /\.(ts|tsx|mjs|js)$/.test(p));
+  } catch {
+    return [];
+  }
+}
+
+function listAllFiles() {
+  const out = execSync(
+    `find ${TARGET_DIRS.join(' ')} -type f \\( -name '*.ts' -o -name '*.tsx' -o -name '*.mjs' -o -name '*.js' \\) -not -path '*/node_modules/*' -not -path '*/_generated/*'`,
+    { encoding: 'utf8' },
+  );
+  return out.split('\n').filter(Boolean);
+}
+
+function findUnsafeCatches(filePath) {
+  const src = readFileSync(filePath, 'utf8');
+  const offenders = [];
+
+  // Scan for catch blocks. We balance braces manually to handle nesting
+  // (regex alone misses nested `{ }` inside the catch body).
+  let i = 0;
+  while (i < src.length) {
+    const m = src.slice(i).match(/\}\s*catch\s*(?:\([^)]*\))?\s*\{/);
+    if (!m) break;
+    const startInRest = m.index;
+    const absStart = i + startInRest;
+    const bodyOpenAbs = absStart + m[0].length - 1; // index of the opening `{`
+
+    // Walk forward to find the matching closing brace.
+    let depth = 1;
+    let j = bodyOpenAbs + 1;
+    while (j < src.length && depth > 0) {
+      const ch = src[j];
+      if (ch === '{') depth++;
+      else if (ch === '}') depth--;
+      j++;
+    }
+    const bodyEnd = j; // exclusive
+    const body = src.slice(bodyOpenAbs + 1, bodyEnd - 1);
+
+    if (LOG_PATTERN.test(body) && !SAFE_PATTERNS.some((p) => p.test(body))) {
+      const lineNo = src.slice(0, absStart).split('\n').length;
+      offenders.push({ filePath, lineNo, snippet: body.split('\n')[0].trim().slice(0, 100) });
+    }
+
+    i = bodyEnd;
+  }
+
+  return offenders;
+}
+
+function main() {
+  const files = SCAN_ALL ? listAllFiles() : listChangedFiles();
+  if (files.length === 0) {
+    if (!SCAN_ALL) console.log('  Sentry coverage: no api/ or convex/ files changed.');
+    return 0;
+  }
+
+  const allOffenders = [];
+  for (const f of files) {
+    const abs = resolve(f);
+    if (SKIP_FILE_PATTERNS.some((p) => p.test(abs))) continue;
+    try {
+      allOffenders.push(...findUnsafeCatches(abs));
+    } catch (err) {
+      // Skip unreadable files (e.g., deleted in this diff).
+      if (err && err.code !== 'ENOENT') throw err;
+    }
+  }
+
+  if (allOffenders.length === 0) {
+    console.log(`  Sentry coverage: clean (${files.length} file${files.length === 1 ? '' : 's'} checked).`);
+    return 0;
+  }
+
+  console.error('');
+  console.error('============================================================');
+  console.error('Sentry coverage check FAILED');
+  console.error('');
+  console.error(
+    `Found ${allOffenders.length} catch block(s) that log via console.error/warn`,
+  );
+  console.error('but do not surface to Sentry. Either:');
+  console.error('  - call `captureSilentError(err, { tags: { ... } })` next to the log, OR');
+  console.error('  - re-throw the error (Convex auto-Sentry will capture it).');
+  console.error('');
+  console.error('Helpers:');
+  console.error('  api/ edge:  import { captureSilentError } from \'./_sentry-edge.js\';');
+  console.error('  api/ node:  import { captureSilentError } from \'./_sentry-node.js\';');
+  console.error('');
+  console.error('Offenders:');
+  for (const o of allOffenders) {
+    console.error(`  ${o.filePath}:${o.lineNo}  ${o.snippet}`);
+  }
+  console.error('============================================================');
+  return 1;
+}
+
+process.exit(main());


### PR DESCRIPTION
## Summary

Following the canary-broadcast post-mortem ([Sentry WORLDMONITOR-PA](https://elie-habib.sentry.io/issues/?query=WORLDMONITOR-PA), 54 events at 22:50:52Z), audited the codebase for `try { ... } catch (err) { console.error(...) }` patterns that swallow errors without surfacing them to Sentry.

**Findings:** 25+ silent-swallow sites across api/, plus the 3 convex/payments sites flagged in the post-mortem. Pre-existing `api/_sentry-edge.js` helper was used by ONE file (`notification-channels.ts`) at top-level catches only — the convention existed but wasn't applied consistently.

**Approach (Path B):** build on the existing hand-rolled pattern. No SDK installs (no bundle bloat, no new deps). Generalize the helper, mirror it for Node-runtime functions, sweep silent-swallow sites, add a lint guard so this can't drift again.

## Changes

### api/ helpers
- **`api/_sentry-edge.js`** — generalized to expose `captureSilentError(err, { tags?, extra? })`. Upgraded ingestion endpoint from deprecated `/store/` → current `/envelope/`. Stack-frame parsing for native dashboard rendering. Auto-tags `surface: api`, `runtime: edge`. `captureEdgeException` kept as backwards-compat alias.
- **`api/_sentry-node.js` (NEW)** — mirror for the ~17% of api/ files that don't declare edge runtime. Same `captureSilentError` shape so call sites are runtime-agnostic. Auto-tags `runtime: node`.

### api/ sweep — 24 sites across 13 files
Add `captureSilentError(err, { tags: { route, step } })` alongside existing `console.error/warn`. Tags identify route + step for Sentry filtering.

Critical paths covered: PRO upgrade flow (`create-checkout`, `customer-portal`), MCP agent surface (`mcp.ts` tool execution), brief delivery (`brief/[userId]/[issueDate]`, `brief/carousel`, `brief/public`, `brief/share-url`, `latest-brief`), notification publish queue (`notification-channels`, 4 inner catches; `slack/oauth/callback`), referrals (`referral/me`), prefs sync (`user-prefs`), LLM analyst paths (`internal/brief-why-matters`, 4 sites), API key cache invalidation (`invalidate-user-api-key-cache`), feed scrapers (`fwdstart`, `rss-proxy`).

`rss-proxy.js` skips Sentry capture on `AbortError` to avoid drowning in routine upstream-feed timeouts — only "real" errors surface.

### convex/payments
- **`cacheActions.ts`** — convert silent `console.warn` swallows on Redis SET/DEL failures into re-throws. Actions are scheduled fire-and-forget by `upsertEntitlements`; operations are idempotent; Convex's scheduler retries with auto-Sentry capture on each throw. **Closes the failure mode where persistent Upstash outages silently leave PRO entitlement caches stale** for users who just upgraded (and free users post-cancel).
- **`webhookHandlers.ts`** — Dodo signature verification failures previously `console.error`'d and 401'd silently. Cannot throw (Dodo would retry-storm). Solution: **schedule a new `internalMutation reportDodoSignatureFailure`** via `ctx.scheduler.runAfter(0, ...)`. The scheduled throw runs after the 401 response and is captured by Convex auto-Sentry. **Closes the "botched secret rotation goes silent for hours" failure mode** without changing the HTTP contract.

### Lint guard — `scripts/check-sentry-coverage.mjs` (NEW)
Walks api/ + convex/ catch blocks; flags any that contain `console.error/warn` but no safe pattern (`captureSilentError`, `captureEdgeException`, `Sentry.captureException`, `throw`, or `status: 5xx`).

- Default `--diff` mode: only files changed vs origin/main. Legacy catches in unrelated files don't block unrelated PRs.
- `--all` mode for ad-hoc full scans.
- Excludes the Sentry helper files themselves (their `console.warn` on delivery failure is correct — capturing inside the helper would loop).

Wired into `.husky/pre-push`. Verified clean: `node scripts/check-sentry-coverage.mjs --all` reports 151 files, 0 offenders.

## Decisions, recorded

**Why hand-rolled fetch over `@sentry/vercel-edge` + `@sentry/node` SDKs:** zero bundle bloat on every edge cold start, no new dependencies, builds on the existing in-production pattern. The 25 sites just need "capture an exception we caught" — the SDK's richer features (breadcrumbs, profiling, native PII redaction) don't pay back the +50KB per cold-start.

**Why same Sentry project as the frontend (`VITE_SENTRY_DSN`):** cross-surface correlation. The `VITE_` prefix exposes the DSN to the browser bundle anyway, so reusing it server-side adds no exposure. Events are tagged `surface: api`, `runtime: edge|node` so the dashboard filters by source.

## Test plan

- [x] `node scripts/check-sentry-coverage.mjs --all` → 0 offenders across 151 files
- [x] Pre-push hooks pass (typecheck, typecheck:api, biome, lint:boundaries, sentry-coverage, edge bundle, version sync, rate-limit policy, premium-fetch parity)
- [x] Vercel preview deploys cleanly (auto)
- [ ] After merge + Convex deploy: trigger a known-failing Redis SET (set bad UPSTASH token in a preview env) → verify Sentry receives the throw via `cacheActions`
- [ ] After merge + Convex deploy: send a Dodo webhook with a wrong signature → verify Sentry receives `reportDodoSignatureFailure` event AND Dodo gets the same 401 response

## Out of scope (separate work)
- Sentry alert routing (Slack / email / pager when new prod errors land) — you said you'd handle this in the dashboard.
- Convex `_sentry-*.js` equivalent for the convex/ backend (currently uses Convex's auto-Sentry for throws). Could be added later if more silent paths are found.