### PR TITLE
feat(resilience): coverage penalty + source-comprehensive + per-capita (plan 002 PR 3+4+5, v15→v16)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -165,7 +165,7 @@ const STANDALONE_KEYS = {
   pizzint:                  'intelligence:pizzint:seed:v1',
   resilienceStaticIndex:    'resilience:static:index:v1',
   resilienceStaticFao:      'resilience:static:fao',
-  resilienceRanking:        'resilience:ranking:v15',
+  resilienceRanking:        'resilience:ranking:v16',
   productCatalog:           'product-catalog:v2',
   energySpineCountries:     'energy:spine:v1:_countries',
   energyExposure:           'energy:exposure:v1:index',

--- a/api/health.js
+++ b/api/health.js
@@ -182,7 +182,7 @@ const STANDALONE_KEYS = {
   portwatchChokepointsRef:  'portwatch:chokepoints:ref:v1',
   chokepointFlows:          'energy:chokepoint-flows:v1',
   emberElectricity:         'energy:ember:v1:_all',
-  resilienceIntervals:      'resilience:intervals:v1:US',
+  resilienceIntervals:      'resilience:intervals:v2:US',
   sprPolicies:              'energy:spr-policies:v1',
   pipelinesGas:             'energy:pipelines:gas:v1',
   pipelinesOil:             'energy:pipelines:oil:v1',

--- a/docs/internal/country-resilience-upgrade-plan.md
+++ b/docs/internal/country-resilience-upgrade-plan.md
@@ -235,7 +235,7 @@ intervals, change attribution, external expert review).
 - **Cache keys** (all in `_shared.ts`): `resilience:score:v7:<cc>` (6h),
   `resilience:ranking:v8` (6h, written only when all countries scored),
   `resilience:history:v4:<cc>` (daily sorted set, 30-day retention),
-  `resilience:intervals:v1:<cc>` (95% CI from backtest).
+  `resilience:intervals:v2:<cc>` (95% CI from backtest).
 - **Warmup:** handler-owned, up to 200 missing countries per ranking request
   via `warmMissingResilienceScores()` in `get-resilience-ranking.ts`.
 - **Static seeding**, 11 slots in `scripts/seed-resilience-static.mjs` (WGI,

--- a/docs/methodology/country-resilience-index.mdx
+++ b/docs/methodology/country-resilience-index.mdx
@@ -584,7 +584,7 @@ The CRI is designed to be auditable end-to-end: given the Redis snapshot at any 
 | `resilience:score:v11:{countryCode}` | JSON | 6 hours | `buildResilienceScore` in `server/worldmonitor/resilience/v1/_shared.ts` | `getResilienceScore` handler |
 | `resilience:ranking:v11` | JSON | 6 hours | `buildResilienceRanking`, only when all countries are scored | `getResilienceRanking` handler |
 | `resilience:history:v6:{countryCode}` | sorted set | indefinite, trimmed to 30 days | `appendHistory` during scoring | trend and `change30d` computation |
-| `resilience:intervals:v1:{countryCode}` | JSON | 6 hours | `scripts/seed-resilience-intervals.mjs` | `getResilienceScore` (optional `scoreInterval` field) |
+| `resilience:intervals:v2:{countryCode}` | JSON | 6 hours | `scripts/seed-resilience-intervals.mjs` | `getResilienceScore` (optional `scoreInterval` field) |
 | `seed-meta:resilience:static` | JSON | 2 hours | `scripts/seed-resilience-static.mjs` at the end of each successful seed run | scorer for `dataVersion` population, health checks |
 | `resilience:static:{countryCode}` | JSON | 400 days | `scripts/seed-resilience-static.mjs` | scorer for all baseline signals (WGI, WHO, FAO, GPI, RSF, and so on) |
 | `resilience:static:index:v1` | JSON | 400 days | `scripts/seed-resilience-static.mjs` | warmup path to enumerate countries |

--- a/scripts/backtest-resilience-outcomes.mjs
+++ b/scripts/backtest-resilience-outcomes.mjs
@@ -27,7 +27,7 @@ loadEnvFile(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const VALIDATION_DIR = join(__dirname, '..', 'docs', 'methodology', 'country-resilience-index', 'validation');
 
-const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v15:';
+const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v16:';
 
 // Mirror of _shared.ts#currentCacheFormula. Must stay in lockstep; see
 // the same comment in scripts/validate-resilience-correlation.mjs for

--- a/scripts/benchmark-resilience-external.mjs
+++ b/scripts/benchmark-resilience-external.mjs
@@ -374,7 +374,7 @@ function currentCacheFormulaLocal() {
 
 async function readWmScoresFromRedis() {
   const { url, token } = getRedisCredentials();
-  const rankingResp = await fetch(`${url}/get/${encodeURIComponent('resilience:ranking:v15')}`, {
+  const rankingResp = await fetch(`${url}/get/${encodeURIComponent('resilience:ranking:v16')}`, {
     headers: { Authorization: `Bearer ${token}` },
     signal: AbortSignal.timeout(10_000),
   });

--- a/scripts/seed-imf-labor.mjs
+++ b/scripts/seed-imf-labor.mjs
@@ -56,9 +56,19 @@ export function buildLaborCountries({ unemployment = {}, population = {} }) {
 
     if (!lur && !lp) continue;
 
+    // IMF SDMX `LP` indicator returns Population in PERSONS (raw count,
+    // e.g. US ≈ 342_594_000), not millions. The downstream field is named
+    // `populationMillions` and consumed as such by every reader (resilience
+    // per-capita normalization in _dimension-scorers.ts; cohort builder in
+    // dry-run-resilience-rebalance.mjs; src/services/imf-country-data.ts).
+    // Divide by 1e6 here so the field name matches its semantic. Pre-fix
+    // the field stored raw persons, silently breaking the §U6 per-capita
+    // normalization (denominator was 1e6× too large → unrest score
+    // saturated at 100 for every country).
+    const popMillions = lp?.value != null ? lp.value / 1_000_000 : null;
     countries[iso2] = {
       unemploymentPct: lur?.value ?? null,
-      populationMillions: lp?.value ?? null,
+      populationMillions: popMillions,
       year: lur?.year ?? lp?.year ?? null,
     };
   }

--- a/scripts/seed-resilience-intervals.mjs
+++ b/scripts/seed-resilience-intervals.mjs
@@ -18,16 +18,24 @@ const WM_KEY = process.env.WORLDMONITOR_API_KEY
   || '';
 const SEED_UA = 'Mozilla/5.0 (compatible; WorldMonitor-Seed/1.0)';
 
-const INTERVAL_KEY_PREFIX = 'resilience:intervals:v1:';
+const INTERVAL_KEY_PREFIX = 'resilience:intervals:v2:';
 const INTERVAL_TTL_SECONDS = 7 * 24 * 60 * 60;
 const DRAWS = 100;
 
+// Plan 2026-04-26-002 review fix: 6-domain weights (recovery added) in
+// lockstep with server/worldmonitor/resilience/v1/_dimension-scorers.ts
+// `RESILIENCE_DOMAIN_WEIGHTS`. The pre-PR 5-domain weights here mixed
+// recovery into nothing, then computed a 5-domain score-band band that
+// the server's 6-domain coverage-weighted overall score never matched.
+// Bumped INTERVAL_KEY_PREFIX v1 → v2 in lockstep so post-bump readers
+// see only post-fix bands.
 const DOMAIN_WEIGHTS = {
-  economic: 0.22,
-  infrastructure: 0.20,
-  energy: 0.15,
-  'social-governance': 0.25,
-  'health-food': 0.18,
+  economic: 0.17,
+  infrastructure: 0.15,
+  energy: 0.11,
+  'social-governance': 0.19,
+  'health-food': 0.13,
+  recovery: 0.25,
 };
 
 const DOMAIN_ORDER = [
@@ -36,6 +44,7 @@ const DOMAIN_ORDER = [
   'energy',
   'social-governance',
   'health-food',
+  'recovery',
 ];
 
 export function computeIntervals(domainScores, domainWeights, draws = DRAWS) {

--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -30,8 +30,8 @@ const SEED_UA = 'Mozilla/5.0 (compatible; WorldMonitor-Seed/1.0)';
 // Earlier: v11 → v12 for PR 3A §net-imports denominator (plan
 // 2026-04-24-002). Seeder and server MUST agree on the prefix or the
 // seeder writes scores the handler will never read.
-export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v15:';
-export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v15';
+export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v16:';
+export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v16';
 // Must match the server-side RESILIENCE_RANKING_CACHE_TTL_SECONDS. Extended
 // to 12h (2x the cron interval) so a missed/slow cron can't create an
 // EMPTY_ON_DEMAND gap before the next successful rebuild.

--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -38,16 +38,22 @@ export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v16';
 export const RESILIENCE_RANKING_CACHE_TTL_SECONDS = 12 * 60 * 60;
 export const RESILIENCE_STATIC_INDEX_KEY = 'resilience:static:index:v1';
 
-const INTERVAL_KEY_PREFIX = 'resilience:intervals:v1:';
+const INTERVAL_KEY_PREFIX = 'resilience:intervals:v2:';
 const INTERVAL_TTL_SECONDS = 7 * 24 * 60 * 60;
 const DRAWS = 100;
 
+// Plan 2026-04-26-002 review fix: 6-domain weights (recovery added) in
+// lockstep with server/worldmonitor/resilience/v1/_dimension-scorers.ts
+// `RESILIENCE_DOMAIN_WEIGHTS`. Bumped INTERVAL_KEY_PREFIX v1 → v2 in
+// lockstep so old 5-domain bands don't feed scoreInterval/rankStable
+// after the v15→v16 score-prefix bump.
 const DOMAIN_WEIGHTS = {
-  economic: 0.22,
-  infrastructure: 0.20,
-  energy: 0.15,
-  'social-governance': 0.25,
-  'health-food': 0.18,
+  economic: 0.17,
+  infrastructure: 0.15,
+  energy: 0.11,
+  'social-governance': 0.19,
+  'health-food': 0.13,
+  recovery: 0.25,
 };
 
 const DOMAIN_ORDER = [
@@ -56,6 +62,7 @@ const DOMAIN_ORDER = [
   'energy',
   'social-governance',
   'health-food',
+  'recovery',
 ];
 
 export function computeIntervals(domainScores, domainWeights, draws = DRAWS) {

--- a/scripts/validate-resilience-backtest.mjs
+++ b/scripts/validate-resilience-backtest.mjs
@@ -27,7 +27,7 @@ import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 loadEnvFile(import.meta.url);
 
 // Source of truth: server/worldmonitor/resilience/v1/_shared.ts
-const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v15:';
+const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v16:';
 
 // Mirror of _shared.ts#currentCacheFormula — must stay in lockstep so
 // the backtest only ingests same-formula cache entries. A mixed-formula

--- a/scripts/validate-resilience-correlation.mjs
+++ b/scripts/validate-resilience-correlation.mjs
@@ -3,7 +3,7 @@
 import { loadEnvFile, getRedisCredentials } from './_seed-utils.mjs';
 
 // Source of truth: server/worldmonitor/resilience/v1/_shared.ts → RESILIENCE_SCORE_CACHE_PREFIX
-const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v15:';
+const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v16:';
 
 // Mirror of server/worldmonitor/resilience/v1/_shared.ts#currentCacheFormula.
 // Must stay in lockstep with the server-side definition so this script

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -3,6 +3,7 @@ import iso2ToIso3Json from '../../../../shared/iso2-to-iso3.json';
 import { normalizeCountryToken } from '../../../_shared/country-token';
 import { getCachedJson } from '../../../_shared/redis';
 import { classifyDimensionFreshness, readFreshnessMap, resolveSeedMetaKey } from './_dimension-freshness';
+import { isIndicatorComprehensive } from './_indicator-registry';
 import { getLanguageCoverageFactor } from './_language-coverage';
 import { failedDimensionsFromDatasets, readFailedDatasets } from './_source-failure';
 
@@ -1646,16 +1647,29 @@ export async function scoreSocialCohesion(
   countryCode: string,
   reader: ResilienceSeedReader = defaultSeedReader,
 ): Promise<ResilienceDimensionScore> {
-  const [staticRecord, displacementRaw, unrestRaw] = await Promise.all([
+  const [staticRecord, displacementRaw, unrestRaw, imfLaborRaw] = await Promise.all([
     readStaticCountry(countryCode, reader),
     reader(`${RESILIENCE_DISPLACEMENT_PREFIX}:${new Date().getFullYear()}`),
     reader(RESILIENCE_UNREST_KEY),
+    reader(RESILIENCE_IMF_LABOR_KEY),
   ]);
   const gpiScore = safeNum(staticRecord?.gpi?.score);
   const displacement = getCountryDisplacement(displacementRaw, countryCode);
   const unrest = summarizeUnrest(unrestRaw, countryCode);
   const displacementMetric = safeNum(displacement?.totalDisplaced);
-  const unrestMetric = unrest.unrestCount + Math.sqrt(unrest.fatalities);
+  // Plan 2026-04-26-002 §U6 — per-capita normalization. Event counts are
+  // divided by max(populationMillions, 0.5) so 0 events on TV (12k pop)
+  // does not score above 5 events on Yemen (33M pop). The 0.5-million
+  // floor protects against divide-by-zero/inflation for tiny states
+  // (Tuvalu/Nauru/Palau ≈ 0.01M-0.02M); the floor's effect is to anchor
+  // micro-state per-capita rates at "as-if 500k population" rather than
+  // amplifying single events into towering rates. Goalposts re-anchored
+  // 0..10 events/M; Iceland ≈ 0 events/M, Yemen ≈ 6 events/M, Lebanon
+  // outliers ≈ 10 events/M (calibrated empirically against the live
+  // unrest:events:v1 distribution).
+  const populationMillions = safeNum(getImfLaborEntry(imfLaborRaw, countryCode)?.populationMillions) ?? 0.5;
+  const popDenominator = Math.max(populationMillions, 0.5);
+  const unrestMetric = (unrest.unrestCount + Math.sqrt(unrest.fatalities)) / popDenominator;
 
   // GPI empirical range: 1.1 (Iceland) – 3.4 (Yemen 2024). Anchor worst=3.6 (slightly
   // above observed max) so the worst-peace countries score near 0, not 20.
@@ -1729,12 +1743,25 @@ export async function scoreSocialCohesion(
     // "we have no signal that displacement is unusual" — only case (b) is the
     // intentional cohort de-rate.
     if (displacementRaw != null && displacementMetric == null) {
+      // Plan 2026-04-26-002 §U5 — registry-driven source-comprehensiveness
+      // fallback. The unrest:events:v1 source is non-comprehensive (event-
+      // scraping feed, English-biased, ACLED-style coverage gaps), so per
+      // the plan, absence of unrest data should NOT impute at the stable-
+      // absence anchor. When the indicator is non-comprehensive, fall back
+      // to IMPUTATION.curated_list_absent (50/0.3, 'unmonitored') instead
+      // of the stable-absence anchor (70/0.5). This pulls the GPI-only
+      // blend down for tiny peaceful states (TV/PW/NR/MC) that previously
+      // rode the 70 anchor to a near-perfect dim score; comprehensive-
+      // source countries are unaffected.
+      const unrestImpute = isIndicatorComprehensive('unrestEvents')
+        ? IMPUTE.socialCohesionGpiOnlyUnrest
+        : IMPUTATION.curated_list_absent;
       unrestRow = {
-        score: IMPUTE.socialCohesionGpiOnlyUnrest.score,
+        score: unrestImpute.score,
         weight: 0.2,
-        certaintyCoverage: IMPUTE.socialCohesionGpiOnlyUnrest.certaintyCoverage,
+        certaintyCoverage: unrestImpute.certaintyCoverage,
         imputed: true,
-        imputationClass: IMPUTE.socialCohesionGpiOnlyUnrest.imputationClass,
+        imputationClass: unrestImpute.imputationClass,
       };
     } else {
       unrestRow = {
@@ -1746,9 +1773,11 @@ export async function scoreSocialCohesion(
       };
     }
   } else {
-    // Observed unrest events — score directly.
+    // Observed unrest events — score directly. Plan §U6 per-capita
+    // anchor: 10 events/M = "worst" (Lebanon-class), 0 events/M = "best"
+    // (Iceland). Was 0..20 in raw event-count units before §U6.
     unrestRow = {
-      score: normalizeLowerBetter(unrestMetric, 0, 20),
+      score: normalizeLowerBetter(unrestMetric, 0, 10),
       weight: 0.2,
     };
   }
@@ -1760,17 +1789,27 @@ export async function scoreBorderSecurity(
   countryCode: string,
   reader: ResilienceSeedReader = defaultSeedReader,
 ): Promise<ResilienceDimensionScore> {
-  const [ucdpRaw, displacementRaw] = await Promise.all([
+  const [ucdpRaw, displacementRaw, imfLaborRaw] = await Promise.all([
     reader(RESILIENCE_UCDP_KEY),
     reader(`${RESILIENCE_DISPLACEMENT_PREFIX}:${new Date().getFullYear()}`),
+    reader(RESILIENCE_IMF_LABOR_KEY),
   ]);
   const ucdp = summarizeUcdp(ucdpRaw, countryCode);
   const displacement = getCountryDisplacement(displacementRaw, countryCode);
-  const conflictMetric = ucdp.eventCount * 2 + ucdp.typeWeight + Math.sqrt(ucdp.deaths);
+  // Plan 2026-04-26-002 §U6 — UCDP per-capita event normalization, same
+  // pattern as scoreSocialCohesion above. eventCount and deaths are
+  // population-normalized so 0 events on TV doesn't ride above 5 events
+  // on Yemen. typeWeight is dimensionless (severity tag, not a count) so
+  // it stays as-is. Goalposts re-anchored 0..15 events/M (slightly higher
+  // ceiling than socialCohesion because UCDP eventCount * 2 multiplier
+  // already lifts the metric magnitude).
+  const populationMillions = safeNum(getImfLaborEntry(imfLaborRaw, countryCode)?.populationMillions) ?? 0.5;
+  const popDenominator = Math.max(populationMillions, 0.5);
+  const conflictMetric = (ucdp.eventCount * 2) / popDenominator + ucdp.typeWeight + Math.sqrt(ucdp.deaths) / popDenominator;
   const displacementMetric = safeNum(displacement?.hostTotal) ?? safeNum(displacement?.totalDisplaced);
 
   return weightedBlend([
-    { score: ucdpRaw != null ? normalizeLowerBetter(conflictMetric, 0, 30) : null, weight: 0.65 },
+    { score: ucdpRaw != null ? normalizeLowerBetter(conflictMetric, 0, 15) : null, weight: 0.65 },
     // Not in UNHCR displacement registry → crisis_monitoring_absent (country is not a
     // significant refugee source or host). Only impute if source was loaded; null source
     // means seed outage, not country absence.

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -796,14 +796,21 @@ function getImfLaborEntry(raw: unknown, countryCode: string): ImfLaborEntry | nu
  * `populationMillions` (e.g. US ≈ 342_594_000 instead of 342.6). The
  * seeder is fixed in the same PR, but cached payloads from prior cron
  * runs may still carry raw persons until the next refresh. Any value
- * > 10_000 is impossible as "millions" (no country has 10B+ people),
- * so treat it as raw persons and divide by 1e6. Once the cache cycles,
- * this branch becomes a no-op.
+ * >= 10_000 is impossible as "millions" (China = ~1430 millions = the
+ * realistic ceiling), so treat it as raw persons and divide by 1e6.
+ * The threshold is INCLUSIVE: live cache currently has TV's value at
+ * exactly 10_000 (Tuvalu's actual headcount), and a `> 10_000` check
+ * would let it through as "10000M" instead of converting to 0.01M.
+ * The IMF labor bundle is 30-day gated; without inclusive comparison
+ * a microstate is mis-handled until the next bundle refresh.
+ *
+ * Once the cache cycles to post-fix values (everything in the 0.01-1500
+ * range), this branch becomes a no-op.
  */
 function readPopulationMillions(imfLaborRaw: unknown, countryCode: string): number {
   const raw = safeNum(getImfLaborEntry(imfLaborRaw, countryCode)?.populationMillions);
   if (raw == null) return 0.5;
-  const millions = raw > 10_000 ? raw / 1_000_000 : raw;
+  const millions = raw >= 10_000 ? raw / 1_000_000 : raw;
   return Math.max(millions, 0.5);
 }
 

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -786,6 +786,28 @@ function getImfLaborEntry(raw: unknown, countryCode: string): ImfLaborEntry | nu
   return (countries[countryCode] as ImfLaborEntry | undefined) ?? null;
 }
 
+/**
+ * Plan 2026-04-26-002 §U6 — robust population-in-millions reader for the
+ * per-capita normalization in scoreSocialCohesion + scoreBorderSecurity.
+ *
+ * Always returns a number ≥ 0.5 (the plan's tiny-state floor).
+ *
+ * Defensive raw-persons detection: the historical IMF labor seed stored
+ * the LP indicator's raw-persons value in a field misleadingly named
+ * `populationMillions` (e.g. US ≈ 342_594_000 instead of 342.6). The
+ * seeder is fixed in the same PR, but cached payloads from prior cron
+ * runs may still carry raw persons until the next refresh. Any value
+ * > 10_000 is impossible as "millions" (no country has 10B+ people),
+ * so treat it as raw persons and divide by 1e6. Once the cache cycles,
+ * this branch becomes a no-op.
+ */
+function readPopulationMillions(imfLaborRaw: unknown, countryCode: string): number {
+  const raw = safeNum(getImfLaborEntry(imfLaborRaw, countryCode)?.populationMillions);
+  if (raw == null) return 0.5;
+  const millions = raw > 10_000 ? raw / 1_000_000 : raw;
+  return Math.max(millions, 0.5);
+}
+
 // getCountryBisExchangeRates() removed in PR 3 §3.5: only scoreCurrencyExternal
 // called it, and that scorer no longer reads BIS EER. Drill-down panels
 // that want BIS series read it via their own dedicated handler.
@@ -1667,8 +1689,7 @@ export async function scoreSocialCohesion(
   // 0..10 events/M; Iceland ≈ 0 events/M, Yemen ≈ 6 events/M, Lebanon
   // outliers ≈ 10 events/M (calibrated empirically against the live
   // unrest:events:v1 distribution).
-  const populationMillions = safeNum(getImfLaborEntry(imfLaborRaw, countryCode)?.populationMillions) ?? 0.5;
-  const popDenominator = Math.max(populationMillions, 0.5);
+  const popDenominator = readPopulationMillions(imfLaborRaw, countryCode);
   const unrestMetric = (unrest.unrestCount + Math.sqrt(unrest.fatalities)) / popDenominator;
 
   // GPI empirical range: 1.1 (Iceland) – 3.4 (Yemen 2024). Anchor worst=3.6 (slightly
@@ -1803,9 +1824,13 @@ export async function scoreBorderSecurity(
   // it stays as-is. Goalposts re-anchored 0..15 events/M (slightly higher
   // ceiling than socialCohesion because UCDP eventCount * 2 multiplier
   // already lifts the metric magnitude).
-  const populationMillions = safeNum(getImfLaborEntry(imfLaborRaw, countryCode)?.populationMillions) ?? 0.5;
-  const popDenominator = Math.max(populationMillions, 0.5);
-  const conflictMetric = (ucdp.eventCount * 2) / popDenominator + ucdp.typeWeight + Math.sqrt(ucdp.deaths) / popDenominator;
+  const popDenominator = readPopulationMillions(imfLaborRaw, countryCode);
+  // Plan §U6 review fix: typeWeight is event-count-scaled (incremented
+  // per-event in summarizeUcdp:907), not a per-event severity tag, so it
+  // must scale per-capita too. Pre-fix the unnormalized typeWeight could
+  // dominate the per-capita metric for high-event countries (US/IN type
+  // peaceful but high-volume), defeating §U6's intended scaling.
+  const conflictMetric = (ucdp.eventCount * 2 + ucdp.typeWeight + Math.sqrt(ucdp.deaths)) / popDenominator;
   const displacementMetric = safeNum(displacement?.hostTotal) ?? safeNum(displacement?.totalDisplaced);
 
   return weightedBlend([

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -3,7 +3,6 @@ import iso2ToIso3Json from '../../../../shared/iso2-to-iso3.json';
 import { normalizeCountryToken } from '../../../_shared/country-token';
 import { getCachedJson } from '../../../_shared/redis';
 import { classifyDimensionFreshness, readFreshnessMap, resolveSeedMetaKey } from './_dimension-freshness';
-import { isIndicatorComprehensive } from './_indicator-registry';
 import { getLanguageCoverageFactor } from './_language-coverage';
 import { failedDimensionsFromDatasets, readFailedDatasets } from './_source-failure';
 
@@ -1764,25 +1763,29 @@ export async function scoreSocialCohesion(
     // "we have no signal that displacement is unusual" — only case (b) is the
     // intentional cohort de-rate.
     if (displacementRaw != null && displacementMetric == null) {
-      // Plan 2026-04-26-002 §U5 — registry-driven source-comprehensiveness
-      // fallback. The unrest:events:v1 source is non-comprehensive (event-
-      // scraping feed, English-biased, ACLED-style coverage gaps), so per
-      // the plan, absence of unrest data should NOT impute at the stable-
-      // absence anchor. When the indicator is non-comprehensive, fall back
-      // to IMPUTATION.curated_list_absent (50/0.3, 'unmonitored') instead
-      // of the stable-absence anchor (70/0.5). This pulls the GPI-only
-      // blend down for tiny peaceful states (TV/PW/NR/MC) that previously
-      // rode the 70 anchor to a near-perfect dim score; comprehensive-
-      // source countries are unaffected.
-      const unrestImpute = isIndicatorComprehensive('unrestEvents')
-        ? IMPUTE.socialCohesionGpiOnlyUnrest
-        : IMPUTATION.curated_list_absent;
+      // Plan 2026-04-26-002 §U5 — non-comprehensive source fallback.
+      // The unrest:events:v1 source is non-comprehensive (event-scraping
+      // feed, English-biased, ACLED-style coverage gaps), so per the
+      // plan, absence of unrest data does NOT impute at the stable-
+      // absence anchor (70/0.5). It falls back to unmonitored (50/0.3),
+      // pulling the GPI-only blend down for tiny peaceful states (TV/PW/
+      // NR/MC) that previously rode the 70 anchor to a near-perfect dim
+      // score; comprehensive-source countries are unaffected.
+      //
+      // The §U5 contract is enforced by the registry assertion in
+      // tests/resilience-source-comprehensive-flag.test.mts (unrestEvents
+      // pinned `comprehensive: false`); IF a future PR ever flips that
+      // flag, the pinning test fires and the contributor must also
+      // restore the higher-anchor IMPUTE here. Inlining (rather than
+      // wrapping in `isIndicatorComprehensive('unrestEvents') ? ...`)
+      // keeps the code path active and tested instead of relying on a
+      // dead-by-construction conditional.
       unrestRow = {
-        score: unrestImpute.score,
+        score: IMPUTATION.curated_list_absent.score,
         weight: 0.2,
-        certaintyCoverage: unrestImpute.certaintyCoverage,
+        certaintyCoverage: IMPUTATION.curated_list_absent.certaintyCoverage,
         imputed: true,
-        imputationClass: unrestImpute.imputationClass,
+        imputationClass: IMPUTATION.curated_list_absent.imputationClass,
       };
     } else {
       unrestRow = {

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -32,6 +32,20 @@ export type IndicatorSpec = {
   tier: IndicatorTier; // Core = moves the public overall score, Enrichment = drill-down only, Experimental = internal
   coverage: number; // expected country count; the tier linter enforces Core >= 180
   license: IndicatorLicense; // source license category for the audit trail
+  // Plan 2026-04-26-002 §U5 (combined PR 3+4+5) — source-comprehensiveness flag.
+  // True when the upstream source enumerates ALL UN-member countries
+  // (or as close as the underlying universe allows): IPC, UNHCR, UCDP,
+  // FATF listings, WHO global indicators, IMF WEO, WB annual statistical
+  // series. False when the source is an event-scraping feed, English-
+  // biased, a curated subset (BIS LBS by-parent reporters list, WTO
+  // tariff-overview top-50 reporters, IEA OECD-only series), or a
+  // real-time signal whose absence does not encode "stable absence."
+  // Used by IMPUTE callers in _dimension-scorers.ts: when reaching for
+  // a stable-absence anchor (85/0.6 or 88/0.7), if the underlying source
+  // is non-comprehensive, fall back to `unmonitored` (50/0.3) instead.
+  // Conservative default: when in doubt, mark `false` (the lower-confidence
+  // impute is the safer error-mode per the plan §risk-mitigation row).
+  comprehensive: boolean;
 };
 
 export const INDICATOR_REGISTRY: IndicatorSpec[] = [
@@ -49,6 +63,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 212,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'debtGrowthRate',
@@ -63,6 +78,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 190,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'currentAccountPct',
@@ -77,6 +93,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 190,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'unemploymentPct',
@@ -91,6 +108,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'enrichment',
     coverage: 150,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'householdDebtService',
@@ -106,6 +124,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'enrichment',
     coverage: 40,
     license: 'non-commercial',
+    comprehensive: false,
   },
 
   // ── currencyExternal ─────────────────────────────────────────────────────
@@ -132,6 +151,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 185,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'fxReservesAdequacy',
@@ -146,6 +166,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 188,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'fxVolatility',
@@ -161,6 +182,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'experimental',
     coverage: 60,
     license: 'non-commercial',
+    comprehensive: false,
   },
   {
     id: 'fxDeviation',
@@ -176,6 +198,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'experimental',
     coverage: 60,
     license: 'non-commercial',
+    comprehensive: false,
   },
 
   // ── tradePolicy (3 sub-metrics) ───────────────────────────────────────────
@@ -201,6 +224,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'enrichment',
     coverage: 50,
     license: 'open-data',
+    comprehensive: false,
   },
   {
     id: 'tradeBarriers',
@@ -216,6 +240,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'enrichment',
     coverage: 50,
     license: 'open-data',
+    comprehensive: false,
   },
   {
     id: 'appliedTariffRate',
@@ -230,6 +255,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 188,
     license: 'open-data',
+    comprehensive: true,
   },
 
   // ── financialSystemExposure (4 sub-metrics) ───────────────────────────────
@@ -261,6 +287,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'enrichment',
     coverage: 125,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'bisLbsXborderPctGdp',
@@ -284,6 +311,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'enrichment',
     coverage: 200,
     license: 'non-commercial', // BIS terms of use; redistributed under attribution
+    comprehensive: false,
   },
   {
     id: 'fatfListingStatus',
@@ -298,6 +326,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 200,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'financialCenterRedundancy',
@@ -312,6 +341,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'enrichment',
     coverage: 200,
     license: 'non-commercial',
+    comprehensive: false,
   },
 
   // ── cyberDigital (3 sub-metrics) ──────────────────────────────────────────
@@ -328,6 +358,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-attribution',
+    comprehensive: false,
   },
   {
     id: 'internetOutages',
@@ -342,6 +373,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-attribution',
+    comprehensive: false,
   },
   {
     id: 'gpsJamming',
@@ -356,6 +388,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-attribution',
+    comprehensive: false,
   },
 
   // ── logisticsSupply (3 sub-metrics) ───────────────────────────────────────
@@ -372,6 +405,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 188,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'shippingStress',
@@ -386,6 +420,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-attribution',
+    comprehensive: false,
   },
   {
     id: 'transitDisruption',
@@ -400,6 +435,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-attribution',
+    comprehensive: false,
   },
 
   // ── infrastructure (3 sub-metrics) ────────────────────────────────────────
@@ -416,6 +452,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 217,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'roadsPavedInfra',
@@ -430,6 +467,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 188,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'infraOutages',
@@ -444,6 +482,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-attribution',
+    comprehensive: false,
   },
 
   // ── energy (7 sub-metrics) ────────────────────────────────────────────────
@@ -460,6 +499,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 188,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'gasShare',
@@ -474,6 +514,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-attribution',
+    comprehensive: true,
   },
   {
     id: 'coalShare',
@@ -488,6 +529,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-attribution',
+    comprehensive: true,
   },
   {
     id: 'renewShare',
@@ -502,6 +544,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-attribution',
+    comprehensive: true,
   },
   {
     id: 'gasStorageStress',
@@ -518,6 +561,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'enrichment',
     coverage: 38,
     license: 'open-attribution',
+    comprehensive: false,
   },
   {
     id: 'energyPriceStress',
@@ -532,6 +576,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'public-domain',
+    comprehensive: true,
   },
   {
     id: 'electricityConsumption',
@@ -546,6 +591,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 217,
     license: 'open-data',
+    comprehensive: true,
   },
 
   // ── PR 1 energy-construct v2 (tier='experimental' until RESILIENCE_ENERGY_V2_ENABLED ──
@@ -568,6 +614,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'experimental',
     coverage: 190,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'lowCarbonGenerationShare',
@@ -583,6 +630,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'experimental',
     coverage: 190,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'powerLossesPct',
@@ -598,6 +646,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'experimental',
     coverage: 188,
     license: 'open-data',
+    comprehensive: true,
   },
   // reserveMarginPct is DEFERRED per plan §3.1 open-question: IEA
   // electricity-balance data is sparse outside OECD+G20 and the
@@ -623,6 +672,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 214,
     license: 'public-domain',
+    comprehensive: true,
   },
   {
     id: 'wgiPoliticalStability',
@@ -637,6 +687,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 214,
     license: 'public-domain',
+    comprehensive: true,
   },
   {
     id: 'wgiGovernmentEffectiveness',
@@ -651,6 +702,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 214,
     license: 'public-domain',
+    comprehensive: true,
   },
   {
     id: 'wgiRegulatoryQuality',
@@ -665,6 +717,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 214,
     license: 'public-domain',
+    comprehensive: true,
   },
   {
     id: 'wgiRuleOfLaw',
@@ -679,6 +732,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 214,
     license: 'public-domain',
+    comprehensive: true,
   },
   {
     id: 'wgiControlOfCorruption',
@@ -693,6 +747,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 214,
     license: 'public-domain',
+    comprehensive: true,
   },
 
   // ── socialCohesion (3 sub-metrics) ────────────────────────────────────────
@@ -714,6 +769,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'enrichment',
     coverage: 163,
     license: 'non-commercial',
+    comprehensive: true,
   },
   {
     id: 'displacementTotal',
@@ -728,6 +784,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 200,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'unrestEvents',
@@ -742,6 +799,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-attribution',
+    comprehensive: false,
   },
 
   // ── borderSecurity (2 sub-metrics) ────────────────────────────────────────
@@ -762,6 +820,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 193,
     license: 'research-only',
+    comprehensive: true,
   },
   {
     id: 'displacementHosted',
@@ -777,6 +836,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 200,
     license: 'open-data',
+    comprehensive: true,
   },
 
   // ── informationCognitive (3 sub-metrics) ──────────────────────────────────
@@ -797,6 +857,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 180,
     license: 'open-attribution',
+    comprehensive: true,
   },
   {
     id: 'socialVelocity',
@@ -811,6 +872,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-attribution',
+    comprehensive: false,
   },
   {
     id: 'newsThreatScore',
@@ -825,6 +887,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-attribution',
+    comprehensive: false,
   },
 
   // ── healthPublicService (3 sub-metrics) ───────────────────────────────────
@@ -841,6 +904,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 194,
     license: 'public-domain',
+    comprehensive: true,
   },
   {
     id: 'measlesCoverage',
@@ -855,6 +919,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 194,
     license: 'public-domain',
+    comprehensive: true,
   },
   {
     id: 'hospitalBeds',
@@ -869,6 +934,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 194,
     license: 'public-domain',
+    comprehensive: true,
   },
 
   // ── foodWater (3 sub-metrics) ─────────────────────────────────────────────
@@ -889,6 +955,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'ipcPhase',
@@ -904,6 +971,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 195,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'aquastatWaterStress',
@@ -918,6 +986,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 188,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'aquastatWaterAvailability',
@@ -932,6 +1001,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 188,
     license: 'open-data',
+    comprehensive: true,
   },
 
   // ── fiscalSpace (3 sub-metrics) ──────────────────────────────────────────
@@ -948,6 +1018,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 190,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'recoveryFiscalBalance',
@@ -962,6 +1033,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 190,
     license: 'open-data',
+    comprehensive: true,
   },
   {
     id: 'recoveryDebtToGdp',
@@ -976,6 +1048,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 190,
     license: 'open-data',
+    comprehensive: true,
   },
 
   // ── reserveAdequacy (RETIRED in PR 2 §3.4) ───────────────────────────────
@@ -996,6 +1069,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'experimental',
     coverage: 188,
     license: 'open-data',
+    comprehensive: true,
   },
 
   // ── liquidReserveAdequacy (1 sub-metric) ─────────────────────────────────
@@ -1016,6 +1090,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 188,
     license: 'open-data',
+    comprehensive: true,
   },
 
   // ── sovereignFiscalBuffer (1 sub-metric) ─────────────────────────────────
@@ -1054,6 +1129,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'experimental',
     coverage: 8,
     license: 'open-data',
+    comprehensive: false,
   },
 
   // ── externalDebtCoverage (1 sub-metric) ──────────────────────────────────
@@ -1077,6 +1153,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 185,
     license: 'open-data',
+    comprehensive: true,
   },
 
   // ── importConcentration (1 sub-metric) ───────────────────────────────────
@@ -1093,6 +1170,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 190,
     license: 'public-domain',
+    comprehensive: true,
   },
 
   // ── stateContinuity (3 sub-metrics, derived from existing keys) ──────────
@@ -1109,6 +1187,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 214,
     license: 'public-domain',
+    comprehensive: true,
   },
   {
     id: 'recoveryConflictPressure',
@@ -1123,6 +1202,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 193,
     license: 'research-only',
+    comprehensive: true,
   },
   {
     id: 'recoveryDisplacementVelocity',
@@ -1137,6 +1217,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'core',
     coverage: 200,
     license: 'open-data',
+    comprehensive: true,
   },
 
   // ── fuelStockDays (1 sub-metric) ─────────────────────────────────────────
@@ -1167,5 +1248,32 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'experimental',
     coverage: 45,
     license: 'open-data',
+    comprehensive: false,
   },
 ];
+
+// Plan 2026-04-26-002 §U5 helpers — registry-driven check used by IMPUTE
+// callers in _dimension-scorers.ts. Keeping this lookup here (rather than
+// inlining .find() at every scorer) makes the comprehensiveness contract
+// auditable (one source of truth for the rule "absence on a non-
+// comprehensive source falls back to unmonitored").
+
+const INDICATOR_BY_ID: ReadonlyMap<string, IndicatorSpec> = new Map(
+  INDICATOR_REGISTRY.map((spec) => [spec.id, spec]),
+);
+
+/**
+ * Returns true when the upstream source for the given indicator id
+ * enumerates ALL UN-member countries (or as close as the underlying
+ * universe allows). Returns false for non-comprehensive sources (event
+ * feeds, curated subsets, regional registries).
+ *
+ * Conservative default for unknown ids: false — matches the plan's
+ * "when in doubt, mark `comprehensive: false`" risk-mitigation rule.
+ * Returning false for an unknown id means a stable-absence IMPUTE caller
+ * falls back to `unmonitored` (50/0.3), which is the safer error mode.
+ */
+export function isIndicatorComprehensive(indicatorId: string): boolean {
+  const spec = INDICATOR_BY_ID.get(indicatorId);
+  return spec?.comprehensive ?? false;
+}

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -287,7 +287,14 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     tier: 'enrichment',
     coverage: 125,
     license: 'open-data',
-    comprehensive: true,
+    // §U5 review fix: comprehensive=false. WB IDS coverage is the LMIC
+    // subset (~125 countries), NOT the universe. HIC absence from this
+    // source is NOT a stable-absence signal — those countries fall through
+    // to the BIS LBS structural-exposure component instead. Marking
+    // comprehensive=true would let any future IMPUTE caller treat HIC
+    // absence as the high stable-absence anchor (85+), which would
+    // misrepresent HIC financial-system exposure.
+    comprehensive: false,
   },
   {
     id: 'bisLbsXborderPctGdp',

--- a/server/worldmonitor/resilience/v1/_shared.ts
+++ b/server/worldmonitor/resilience/v1/_shared.ts
@@ -205,7 +205,15 @@ export const RESILIENCE_HISTORY_KEY_PREFIX = 'resilience:history:v11:';
 // plan 2026-04-26-002 §U4+U5+U6 (combined PR 3+4+5).
 export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v16';
 export const RESILIENCE_STATIC_INDEX_KEY = 'resilience:static:index:v1';
-export const RESILIENCE_INTERVAL_KEY_PREFIX = 'resilience:intervals:v1:';
+// Plan 2026-04-26-002 §U4+U5+U6 (combined PR 3+4+5) — intervals bump
+// v1 → v2. The pre-PR interval seeders used the OLD 5-domain weights
+// (no recovery, economic at 0.22 vs canonical 0.17, etc.) so any v1
+// interval cached pre-bump represents a different formula than the
+// score it was computed against. After the v15→v16 score bump the
+// scoreInterval/rankStable readout would mix new scores with old-
+// formula bands, producing internally-inconsistent stability gates.
+// Bump forces a clean recompute aligned with the 6-domain weights.
+export const RESILIENCE_INTERVAL_KEY_PREFIX = 'resilience:intervals:v2:';
 const RESILIENCE_STATIC_META_KEY = 'seed-meta:resilience:static';
 const RANK_STABLE_MAX_INTERVAL_WIDTH = 8;
 

--- a/server/worldmonitor/resilience/v1/_shared.ts
+++ b/server/worldmonitor/resilience/v1/_shared.ts
@@ -144,7 +144,15 @@ export const RESILIENCE_RANKING_CACHE_TTL_SECONDS = 12 * 60 * 60;
 // `financialSystemExposure` dim — adds a 20th dimension contributing to
 // the economic domain, so v13 entries (which lack the new dim's score)
 // would surface incomplete payloads on cache hit.
-export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v15:';
+// v15→v16 bump for plan 2026-04-26-002 §U4+U5+U6 (combined PR 3+4+5):
+// imputed dims now contribute 0.5× nominal weight to the
+// coverage-weighted mean (U4); IMPUTE entries fall back to "unknown"
+// (50/0.3) instead of "stable-absence" (85/0.6) for non-comprehensive
+// sources (U5); event-counted dims (socialCohesion unrest, borderSecurity
+// UCDP) normalize per-million-population (U6). Every country's score
+// shifts; mixing v15 + v16 cached scores in the same response would
+// create internally-inconsistent rankings.
+export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v16:';
 // Bumped from v4 to v5 in the pillar-combined activation PR. Provides
 // a clean slate at PR deploy so pre-PR history points (which were
 // written without a formula tag) do not mix with tagged points. NOTE:
@@ -177,7 +185,12 @@ export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v15:';
 // v9 history points with post-fix v15 score points inside the 30-day
 // rolling window would produce false-trend signals across the deploy
 // (memory: cache-prefix-bump-propagation-scope).
-export const RESILIENCE_HISTORY_KEY_PREFIX = 'resilience:history:v10:';
+// v10→v11 bump in lockstep with RESILIENCE_SCORE_CACHE_PREFIX v15→v16
+// for plan 2026-04-26-002 §U4+U5+U6 (combined PR 3+4+5). Mixing pre-fix
+// v10 history points with post-fix v16 score points inside the 30-day
+// rolling window would produce false-trend signals — the score-formula
+// shift this PR introduces is one of the largest in the index's history.
+export const RESILIENCE_HISTORY_KEY_PREFIX = 'resilience:history:v11:';
 // v12 bump in lockstep with RESILIENCE_SCORE_CACHE_PREFIX (v11 → v12)
 // for PR 3A §net-imports denominator. As with the score prefix, the
 // version bump is a belt — the suspenders are the `_formula` tag on
@@ -188,7 +201,9 @@ export const RESILIENCE_HISTORY_KEY_PREFIX = 'resilience:history:v10:';
 // in lockstep with RESILIENCE_SCORE_CACHE_PREFIX for plan 2026-04-25-004
 // Phase 1 (Ship 1). v13→v14 bump in lockstep with RESILIENCE_SCORE_CACHE_PREFIX
 // for plan 2026-04-25-004 Phase 2 (Ship 2).
-export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v15';
+// v15→v16 bump in lockstep with RESILIENCE_SCORE_CACHE_PREFIX for
+// plan 2026-04-26-002 §U4+U5+U6 (combined PR 3+4+5).
+export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v16';
 export const RESILIENCE_STATIC_INDEX_KEY = 'resilience:static:index:v1';
 export const RESILIENCE_INTERVAL_KEY_PREFIX = 'resilience:intervals:v1:';
 const RESILIENCE_STATIC_META_KEY = 'seed-meta:resilience:static';
@@ -316,20 +331,44 @@ function buildDimensionList(
   }));
 }
 
+// Plan 2026-04-26-002 §U4 (combined PR 3+4+5) — fully-imputed dims
+// (no observed data, scorer set imputationClass and observedWeight=0)
+// contribute at IMPUTED_DIM_WEIGHT_FACTOR (0.5) of their nominal weight.
+// Rationale: an imputed signal is a structural assumption, not measured
+// evidence; counting it at full weight equates "we don't know" with "we
+// measured." A coverage-weighted mean over mostly-imputed dims should
+// not reach the same overall score as a coverage-weighted mean over
+// mostly-observed dims at the same per-dim score. This is the empirical
+// lever that finally pulls median(microstate-territories) below
+// median(G7) — territories like Tuvalu/Palau hit ~95% of dims via IMPUTE
+// (no IPC, no IMF SDDS, no BIS, etc.) and previously rode imputed 85s
+// to false-high overall scores. Observed dims keep coverage × weight
+// unchanged so countries like Iceland (peaceful + fully-monitored) do
+// not regress.
+const IMPUTED_DIM_WEIGHT_FACTOR = 0.5;
+
 // Coverage-weighted mean with an optional per-dimension weight multiplier.
-// Each dim's effective weight is `coverage * dimWeight`, so when all
-// weights default to 1.0 this reduces to the original coverage-weighted
-// mean. PR 2 §3.4 uses the weight channel to dial the two new recovery
-// dims down to ~10% share (see RESILIENCE_DIMENSION_WEIGHTS in
-// _dimension-scorers.ts for the rationale). Retired dims have
-// coverage=0 so they're neutralized at the coverage end; the weight
-// channel stays 1.0 for them in the canonical map.
+// Each dim's effective weight is `coverage * dimWeight * imputationFactor`,
+// where imputationFactor = IMPUTED_DIM_WEIGHT_FACTOR (0.5) when the dim
+// is fully imputed (imputationClass set, indicating no observed data),
+// 1.0 otherwise. When all weights default to 1.0 and no dims are imputed
+// this reduces to the original coverage-weighted mean. PR 2 §3.4 uses
+// the weight channel to dial the two new recovery dims down to ~10%
+// share (see RESILIENCE_DIMENSION_WEIGHTS in _dimension-scorers.ts).
+// Retired dims have coverage=0 so they're neutralized at the coverage
+// end; the weight channel stays 1.0 for them in the canonical map.
 function coverageWeightedMean(dimensions: ResilienceDimension[]): number {
   let totalWeight = 0;
   let weightedSum = 0;
   for (const d of dimensions) {
     const w = RESILIENCE_DIMENSION_WEIGHTS[d.id as ResilienceDimensionId] ?? 1.0;
-    const effective = d.coverage * w;
+    // imputationClass is '' (empty string) when the dim has observed data
+    // and a class label ('stable-absence' | 'unmonitored' | 'source-failure'
+    // | 'not-applicable') when fully imputed. See buildDimensionList:323
+    // and the scorer-side comment in _dimension-scorers.ts confirming the
+    // class is only set when observedWeight === 0.
+    const imputationFactor = d.imputationClass ? IMPUTED_DIM_WEIGHT_FACTOR : 1.0;
+    const effective = d.coverage * w * imputationFactor;
     totalWeight += effective;
     weightedSum += d.score * effective;
   }

--- a/tests/resilience-cohort-anti-inversion.test.mts
+++ b/tests/resilience-cohort-anti-inversion.test.mts
@@ -238,32 +238,35 @@ describe('cohort anti-inversion against live ranking (Plan 2026-04-26-002 §U1)'
 
   // Each invariant runs as a separate `it` so failures isolate.
 
-  it('PERMISSIVE: median(G7) > median(microstate-territories) - 10pt [tracks current v15 inversion; PR 3 tightens to +10pt]', () => {
+  it('TIGHTENED (plan 002 PR 3+4+5): median(G7) > median(microstate-territories) + 15pt', () => {
     if (!ranking) return;
     const g7Median = median(scoresFor(cohorts.g7, ranking));
     const microMedian = median(scoresFor(cohorts.microstateTerritories, ranking));
     console.log(`[cohort-anti-inversion] median(G7) = ${g7Median.toFixed(2)}, median(microstate) = ${microMedian.toFixed(2)}, gap = ${(g7Median - microMedian).toFixed(2)}`);
-    // Current v15 has median(G7) ~69.5 < median(microstate) ~75 — that's
-    // the STRUCTURAL inversion this rebuild exists to fix. PR 0 baseline
-    // tolerates the inversion up to 10pt so the test passes on the
-    // current state. PR 3 (coverage penalty) is expected to flip the
-    // sign and tighten this assertion to `g7Median > microMedian + 10`.
-    // If this assertion fails, the rebuild has REGRESSED past current
-    // v15 — investigate before merge.
-    assert.ok(g7Median > microMedian - 10,
-      `REGRESSION PAST v15 BASELINE: median(G7)=${g7Median} fell more than 10pt below median(microstate-territories)=${microMedian}. v15 baseline gap was ~-5.5pt; current is ${(g7Median - microMedian).toFixed(2)}. The rebuild has regressed past the current state.`);
+    // Plan 2026-04-26-002 §U4+U5+U6 (combined PR 3+4+5) eliminates the
+    // structural inversion: median(G7) must now exceed median(microstate-
+    // territories) by 15pt+. The fix is empirically expected via three
+    // levers: (U4) coverage penalty halves imputed-dim weight so micro-
+    // states' stable-absence inflated stats lose grip; (U5) source-
+    // comprehensiveness flag drops unrest impute from 70 → 50 for
+    // tiny states; (U6) per-capita normalization stops 0-event micros
+    // from out-scoring low-rate large states.
+    assert.ok(g7Median > microMedian + 15,
+      `STRUCTURAL FAIL: median(G7)=${g7Median.toFixed(2)} did not exceed median(microstate-territories)=${microMedian.toFixed(2)} by ≥15pt. Gap=${(g7Median - microMedian).toFixed(2)}. Plan 002 PR 3+4+5 must produce this separation; if it doesn't, U4/U5/U6 levers are mis-calibrated.`);
   });
 
-  it('PERMISSIVE: median(Nordics) >= median(GCC) - 30pt [PR 5 tightens to -5pt]', () => {
+  it('TIGHTENED (plan 002 PR 3+4+5): median(Nordics) >= median(GCC) - 5pt', () => {
     if (!ranking) return;
     const nordicMedian = median(scoresFor(cohorts.nordics, ranking));
     const gccMedian = median(scoresFor(cohorts.gcc, ranking));
     console.log(`[cohort-anti-inversion] median(Nordics) = ${nordicMedian.toFixed(2)}, median(GCC) = ${gccMedian.toFixed(2)}, gap = ${(nordicMedian - gccMedian).toFixed(2)}`);
-    assert.ok(nordicMedian >= gccMedian - 30,
-      `Nordics median ${nordicMedian} dropped >30pt below GCC median ${gccMedian}. Catastrophic Nordic regression — investigate before merge.`);
+    // Plan 002: Nordic median should be at least within 5pt of GCC.
+    // GCC small-state inflation should be largely corrected via U4+U6.
+    assert.ok(nordicMedian >= gccMedian - 5,
+      `STRUCTURAL FAIL: Nordics median ${nordicMedian.toFixed(2)} dropped >5pt below GCC median ${gccMedian.toFixed(2)}. After plan 002 §U4+U6, GCC inflation should be largely corrected.`);
   });
 
-  it('PERMISSIVE: min(G7) >= max(Sub-Saharan-LIC) - 20pt [PR 3 tightens to -10pt]', () => {
+  it('TIGHTENED (plan 002 PR 3): min(G7) >= max(Sub-Saharan-LIC) - 10pt', () => {
     if (!ranking) return;
     const g7Scores = scoresFor(cohorts.g7, ranking);
     const licScores = scoresFor(cohorts.subSaharanLic, ranking);
@@ -274,20 +277,23 @@ describe('cohort anti-inversion against live ranking (Plan 2026-04-26-002 §U1)'
     const g7Min = Math.min(...g7Scores);
     const licMax = Math.max(...licScores);
     console.log(`[cohort-anti-inversion] min(G7) = ${g7Min.toFixed(2)}, max(Sub-Saharan-LIC) = ${licMax.toFixed(2)}, gap = ${(g7Min - licMax).toFixed(2)}`);
-    assert.ok(g7Min >= licMax - 20,
-      `Catastrophic floor regression: min(G7)=${g7Min} fell within 20pt of max(Sub-Saharan-LIC)=${licMax}. Recovery domain or coverage handling has regressed.`);
+    assert.ok(g7Min >= licMax - 10,
+      `Catastrophic floor regression: min(G7)=${g7Min.toFixed(2)} fell within 10pt of max(Sub-Saharan-LIC)=${licMax.toFixed(2)}. Recovery domain or coverage handling has regressed.`);
   });
 
-  it('REPORT-ONLY: count(microstate-territories) in top 20 [PR 5 will assert <= 1]', () => {
+  it('TIGHTENED (plan 002 PR 5): count(microstate-territories) in top 20 <= 1', () => {
     if (!ranking) return;
     const microSet = new Set(cohorts.microstateTerritories.iso2);
     const sorted = [...ranking.entries()]
       .sort((a, b) => b[1].score - a[1].score)
       .slice(0, 20);
     const microInTop20 = sorted.filter(([iso]) => microSet.has(iso));
-    console.log(`[cohort-anti-inversion] microstate-territories in top 20: ${microInTop20.length} (${microInTop20.map(([i]) => i).join(', ')}) [no assertion in PR 0; PR 5 will assert <= 1]`);
-    // No assertion yet — PR 5 lands the <= 1 threshold after per-capita normalization.
-    assert.ok(true);
+    console.log(`[cohort-anti-inversion] microstate-territories in top 20: ${microInTop20.length} (${microInTop20.map(([i]) => i).join(', ')})`);
+    // Per-capita normalization (U6) should ensure no more than 1 micro-
+    // state appears in the top 20. If multiple do, U6's pop-floor
+    // calibration or U4's imputation factor needs adjustment.
+    assert.ok(microInTop20.length <= 1,
+      `STRUCTURAL FAIL: ${microInTop20.length} microstate-territories appeared in top 20 (${microInTop20.map(([i]) => i).join(', ')}). Plan 002 §U6 per-capita normalization should keep this ≤ 1.`);
   });
 
   it('REPORT-ONLY: per-cohort coverage in the live ranking [diagnostic]', () => {

--- a/tests/resilience-cohort-bias-anchors.test.mts
+++ b/tests/resilience-cohort-bias-anchors.test.mts
@@ -124,15 +124,17 @@ describe('resilience cohort bias anchors (Plan 2026-04-26-001 §U5)', () => {
 
   describe('U2 (Fix C) — tiny peaceful states (GPI-only mode) must NOT inflate socialCohesion', () => {
     for (const fx of TINY_PEACEFUL) {
-      it(`${fx.iso2}: socialCohesion <= 83 (gated GPI-only impute pulls blend down)`, async () => {
+      it(`${fx.iso2}: socialCohesion <= 80 (gated GPI-only impute + §U5 unrest fallback pull blend down)`, async () => {
         const reader = buildReader(fx);
         const result = await scoreSocialCohesion(fx.iso2, reader);
-        // GPI 1.3 → norm(1.3, 1.0, 3.6) ≈ 88; with both displacement+unrest
-        // imputed at 70 (GPI-only mode) → blended ≈ 80.4.
-        assert.ok(result.score <= 83,
-          `${fx.iso2} socialCohesion must be <= 83 (got ${result.score}); v14 ~93 collapsed to GPI alone`);
-        assert.ok(result.score >= 75,
-          `${fx.iso2} socialCohesion must remain plausible (>=75) — over-correction would punish genuinely peaceful tiny states`);
+        // GPI 1.3 → norm(1.3, 1.0, 3.6) ≈ 88; displacement imputed at 70
+        // (UNHCR comprehensive=true, GPI-only mode), unrest imputed at 50
+        // (plan 002 §U5: unrest:events:v1 is non-comprehensive → fall back
+        // to unmonitored 50/0.3) → blended ≈ 76.
+        assert.ok(result.score <= 80,
+          `${fx.iso2} socialCohesion must be <= 80 (got ${result.score}); v14 ~93 collapsed to GPI alone, plan 002 §U5 lowered ceiling 83 → 80`);
+        assert.ok(result.score >= 70,
+          `${fx.iso2} socialCohesion must remain plausible (>=70) — over-correction would punish genuinely peaceful tiny states`);
         // Dim-level imputationClass MUST be null because GPI is observed.
         assert.equal(result.imputationClass, null,
           `${fx.iso2} dim-level imputationClass must be null when GPI is observed (per-row imputation does not bubble up)`);

--- a/tests/resilience-coverage-penalty.test.mts
+++ b/tests/resilience-coverage-penalty.test.mts
@@ -1,0 +1,121 @@
+// Plan 2026-04-26-002 §U4 (combined PR 3+4+5) — pinning tests for the
+// imputed-dim coverage penalty in `coverageWeightedMean`.
+//
+// The penalty halves the effective weight of any dim with a non-empty
+// `imputationClass` (i.e., the scorer set the class because the dim has
+// no observed data). These tests pin the math directly using synthetic
+// dim arrays so future contributors can't silently change the factor.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+// We can't import the private `coverageWeightedMean` directly, but we
+// can drive it end-to-end by constructing fixture dimensions and calling
+// `buildPillarList` / domain aggregation. Simpler approach: replicate
+// the contract here with the EXACT same formula — if the production
+// formula drifts, the §U4 doc-comment in _shared.ts will visibly
+// disagree with this mirror, surfacing the divergence in code review.
+
+const IMPUTED_DIM_WEIGHT_FACTOR = 0.5;
+
+function coverageWeightedMeanMirror(
+  dims: Array<{ score: number; coverage: number; weight?: number; imputationClass: string }>,
+): number {
+  let totalWeight = 0;
+  let weightedSum = 0;
+  for (const d of dims) {
+    const w = d.weight ?? 1.0;
+    const imputationFactor = d.imputationClass ? IMPUTED_DIM_WEIGHT_FACTOR : 1.0;
+    const effective = d.coverage * w * imputationFactor;
+    totalWeight += effective;
+    weightedSum += d.score * effective;
+  }
+  if (!totalWeight) return 0;
+  return weightedSum / totalWeight;
+}
+
+describe('coverage penalty for imputed dims (Plan 2026-04-26-002 §U4)', () => {
+  it('observed-only dims behave like the v15 coverage-weighted mean (no penalty)', () => {
+    const dims = [
+      { score: 80, coverage: 1.0, imputationClass: '' },
+      { score: 60, coverage: 1.0, imputationClass: '' },
+    ];
+    // (80 + 60) / 2 = 70 — no penalty applied.
+    assert.equal(coverageWeightedMeanMirror(dims), 70);
+  });
+
+  it('half-imputed dim contributes half-weight, lifting the mean toward observed dims', () => {
+    // High-scoring imputed dim (85, stable-absence) at half weight, paired
+    // with an observed dim at 60. Pre-§U4: mean = (85 + 60) / 2 = 72.5.
+    // Post-§U4: mean = (85*0.5 + 60*1.0) / (0.5 + 1.0) = (42.5 + 60) / 1.5 = 68.33.
+    const dims = [
+      { score: 85, coverage: 1.0, imputationClass: 'stable-absence' },
+      { score: 60, coverage: 1.0, imputationClass: '' },
+    ];
+    const result = coverageWeightedMeanMirror(dims);
+    assert.ok(Math.abs(result - 68.333) < 0.01,
+      `expected ~68.33 (imputed at 0.5 weight), got ${result}`);
+  });
+
+  it('low-scoring imputed dim at half weight lifts the mean (less drag)', () => {
+    // unmonitored impute (50/0.3) at half weight; observed dim at 80.
+    // Pre-§U4: weighted = (50*0.3 + 80*1.0) / (0.3 + 1.0) = (15 + 80) / 1.3 ≈ 73.08
+    // Post-§U4: weighted = (50*0.15 + 80*1.0) / (0.15 + 1.0) = (7.5 + 80) / 1.15 ≈ 76.09
+    const dims = [
+      { score: 50, coverage: 0.3, imputationClass: 'unmonitored' },
+      { score: 80, coverage: 1.0, imputationClass: '' },
+    ];
+    const result = coverageWeightedMeanMirror(dims);
+    assert.ok(result > 75 && result < 77,
+      `expected ~76.09 (imputed drag halved → mean lifted), got ${result}`);
+  });
+
+  it('all-imputed dim list: penalty cancels in the ratio (mean unchanged from v15)', () => {
+    // When every dim is imputed, halving every weight cancels in the ratio:
+    // (s1*c1*0.5 + s2*c2*0.5) / (c1*0.5 + c2*0.5) = (s1*c1 + s2*c2) / (c1 + c2).
+    // The penalty ONLY shifts the mean when there's a mix of observed +
+    // imputed dims — pure-imputed countries see no change.
+    const dimsAllImputed = [
+      { score: 85, coverage: 0.7, imputationClass: 'stable-absence' },
+      { score: 50, coverage: 0.3, imputationClass: 'unmonitored' },
+    ];
+    const dimsAllImputedV15 = [
+      { score: 85, coverage: 0.7, imputationClass: '' },  // simulated v15: no penalty
+      { score: 50, coverage: 0.3, imputationClass: '' },
+    ];
+    const v16 = coverageWeightedMeanMirror(dimsAllImputed);
+    const v15 = coverageWeightedMeanMirror(dimsAllImputedV15);
+    assert.ok(Math.abs(v16 - v15) < 0.001,
+      `pure-imputed dim list should be invariant under §U4 (v15=${v15}, v16=${v16})`);
+  });
+
+  it('zero-coverage dims contribute zero regardless of imputation factor', () => {
+    // Retired dims have coverage=0; they should be neutralized whether
+    // imputed or not. Verifies §U4 doesn't double-count them.
+    const dims = [
+      { score: 0, coverage: 0, imputationClass: '' },               // retired observed
+      { score: 0, coverage: 0, imputationClass: 'unmonitored' },    // retired imputed
+      { score: 70, coverage: 1.0, imputationClass: '' },
+    ];
+    assert.equal(coverageWeightedMeanMirror(dims), 70);
+  });
+
+  it('empty dim list returns 0 (no division-by-zero)', () => {
+    assert.equal(coverageWeightedMeanMirror([]), 0);
+  });
+
+  it('per-dim weight is multiplicative with the imputation factor', () => {
+    // Recovery dims dial down to weight=0.5; if also imputed, effective
+    // weight = coverage * 0.5 * 0.5 = 0.25 of nominal.
+    const dims = [
+      { score: 90, coverage: 1.0, weight: 1.0, imputationClass: '' },
+      { score: 50, coverage: 0.3, weight: 0.5, imputationClass: 'unmonitored' },  // recovery imputed
+    ];
+    // weighted = 90*1*1*1 + 50*0.3*0.5*0.5 = 90 + 3.75 = 93.75
+    // totalW = 1*1*1 + 0.3*0.5*0.5 = 1 + 0.075 = 1.075
+    // mean = 93.75 / 1.075 ≈ 87.21
+    const result = coverageWeightedMeanMirror(dims);
+    assert.ok(Math.abs(result - 87.21) < 0.01,
+      `expected ~87.21 (per-dim weight × imputation factor compose), got ${result}`);
+  });
+});

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -663,7 +663,7 @@ describe('resilience dimension scorers', () => {
       };
     }
 
-    it('TV (GPI 1.3, no displacement registry entry, no unrest events) → blended ~80, dim-level imputationClass null', async () => {
+    it('TV (GPI 1.3, no displacement registry entry, no unrest events) → blended ~76, dim-level imputationClass null', async () => {
       const reader = makeReader({
         gpi: 1.3,
         countryCode: 'TV',
@@ -672,9 +672,12 @@ describe('resilience dimension scorers', () => {
       });
       const result = await scoreSocialCohesion('TV', reader);
       // GPI 1.3 → norm(1.3, 1.0, 3.6) = (3.6-1.3)/(3.6-1.0) = 2.3/2.6 ≈ 88.46
-      // Blended: 88.46*0.55 + 70*0.25 + 70*0.20 = 48.65 + 17.5 + 14 = 80.15
-      assert.ok(result.score <= 83 && result.score >= 78,
-        `TV must blend to ~80 (got ${result.score}); plan §U2 cohort target is ≤83 with ≥8pt drop from v14 ~93`);
+      // Plan 2026-04-26-002 §U5 dropped GPI-only unrest impute from 70 → 50
+      // (unrest:events:v1 is non-comprehensive). Blended: 88.46*0.55 +
+      // 70*0.25 + 50*0.20 = 48.65 + 17.5 + 10 = 76.15. Plan target was
+      // "TV socialCohesion ≤ 80" (per AE4 in plan 002), satisfied.
+      assert.ok(result.score <= 80 && result.score >= 73,
+        `TV must blend to ~76 (got ${result.score}); plan 002 §U5 cohort target is ≤80 (was ≤83 in plan 001 §U2)`);
       // Dim-level imputationClass MUST be null because GPI is observed.
       // Per-row imputed:true is set on displacement+unrest rows but
       // weightedBlend correctly null-s the dim-level class when observedWeight > 0.

--- a/tests/resilience-handlers.test.mts
+++ b/tests/resilience-handlers.test.mts
@@ -28,7 +28,7 @@ describe('resilience handlers', () => {
     delete process.env.VERCEL_ENV;
 
     const { fetchImpl, redis, sortedSets } = createRedisFetch(RESILIENCE_FIXTURES);
-    sortedSets.set('resilience:history:v10:US', [
+    sortedSets.set('resilience:history:v11:US', [
       { member: '2026-04-01:20', score: 20260401 },
       { member: '2026-04-02:30', score: 20260402 },
     ]);
@@ -60,16 +60,16 @@ describe('resilience handlers', () => {
     assert.ok(response.stressFactor >= 0 && response.stressFactor <= 0.5, `stressFactor out of bounds: ${response.stressFactor}`);
     assert.equal(response.dataVersion, '2024-04-03', 'dataVersion should be the ISO date from seed-meta fetchedAt');
 
-    const cachedScore = redis.get('resilience:score:v15:US');
+    const cachedScore = redis.get('resilience:score:v16:US');
     assert.ok(cachedScore, 'expected score cache to be written');
     assert.equal(JSON.parse(cachedScore || '{}').countryCode, 'US');
 
-    const history = sortedSets.get('resilience:history:v10:US') ?? [];
+    const history = sortedSets.get('resilience:history:v11:US') ?? [];
     assert.ok(history.some((entry) => entry.member.startsWith(today + ':')), 'expected today history member to be written');
 
     await getResilienceScore({ request: new Request('https://example.com') } as never, {
       countryCode: 'US',
     });
-    assert.equal((sortedSets.get('resilience:history:v10:US') ?? []).length, history.length, 'cache hit must not append history');
+    assert.equal((sortedSets.get('resilience:history:v11:US') ?? []).length, history.length, 'cache hit must not append history');
   });
 });

--- a/tests/resilience-intervals-handler.test.mts
+++ b/tests/resilience-intervals-handler.test.mts
@@ -28,7 +28,7 @@ describe('resilience score interval integration', () => {
 
     const fixtures = {
       ...RESILIENCE_FIXTURES,
-      'resilience:intervals:v1:US': {
+      'resilience:intervals:v2:US': {
         p05: 65.2,
         p95: 72.8,
         draws: 100,

--- a/tests/resilience-per-capita-normalization.test.mts
+++ b/tests/resilience-per-capita-normalization.test.mts
@@ -1,0 +1,186 @@
+// Plan 2026-04-26-002 §U6 (combined PR 3+4+5) — pinning tests for the
+// per-capita event normalization in `scoreSocialCohesion` and
+// `scoreBorderSecurity`.
+//
+// The key invariant: 0 events on a tiny state (TV, 0.012M) does NOT
+// out-score 5 events on a large state (Yemen, 33M). Pre-§U6 the raw
+// event counts were goalpost-anchored 0..20 (socialCohesion) and 0..30
+// (borderSecurity), which let micro-states with literal-zero counts
+// crowd the top of the ranking against actually-low-rate large states.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  scoreSocialCohesion,
+  scoreBorderSecurity,
+} from '../server/worldmonitor/resilience/v1/_dimension-scorers';
+
+// Mirror of the production reader contract: returns a Map-keyed seed lookup.
+function makeReader(seed: Record<string, unknown>) {
+  return async (key: string) => seed[key] ?? null;
+}
+
+// Standard ISO2 codes used in the assertions below: country choice
+// reflects the plan's empirical anchors (TV/PW for tiny peaceful states;
+// US/YE for large-pop high/low-rate countries; IS/NO as Iceland-shape
+// regression guards for comprehensive-source peaceful states).
+
+describe('per-capita normalization invariants (Plan 2026-04-26-002 §U6)', () => {
+  it('tiny state with zero unrest does NOT out-score large state with low-rate unrest', async () => {
+    // TV: 0 events, GPI 1.3, no displacement registry entry, pop floor 0.5M.
+    const tvReader = makeReader({
+      'resilience:static:TV': {
+        gpi: { score: 1.3 },
+      },
+      'displacement:summary:v1:2026': { countries: {} },     // not in registry → GPI-only mode
+      'unrest:events:v1': { events: [] },                    // zero unrest events
+      'economic:imf:labor:v1': { countries: {} },            // TV not in IMF labor → 0.5M floor
+    });
+    const tvResult = await scoreSocialCohesion('TV', tvReader);
+
+    // US: low-rate unrest (5 events, 0 fatalities), GPI 1.7, observed
+    // displacement, pop 333M. Per-capita rate = 5/333 ≈ 0.015 events/M.
+    const usReader = makeReader({
+      'resilience:static:US': { gpi: { score: 1.7 } },
+      'displacement:summary:v1:2026': {
+        countries: { US: { totalDisplaced: 1000 } },         // observed displacement
+      },
+      'unrest:events:v1': {
+        events: Array.from({ length: 5 }, () => ({
+          country: 'US', type: 'protest', fatalities: 0,
+        })),
+      },
+      'economic:imf:labor:v1': {
+        countries: { US: { populationMillions: 333 } },
+      },
+    });
+    const usResult = await scoreSocialCohesion('US', usReader);
+
+    // The plan's load-bearing invariant: TV must NOT out-score US.
+    // Pre-§U5+§U6: TV ≈ 95 (GPI-only collapse + 0 raw events), US ≈ 87.
+    // Post-§U5+§U6: TV ≈ 76 (lower impute + per-capita), US ≈ 90+ (low-rate
+    // unrest at per-million scale → near-perfect unrest score).
+    assert.ok(usResult.score > tvResult.score,
+      `INVERSION: US (low-rate unrest, 333M pop) scored ${usResult.score}, TV (zero unrest, tiny) scored ${tvResult.score}. Plan §U6 must keep US > TV.`);
+  });
+
+  it('observed-unrest score scales inversely with population (per-capita anchoring)', async () => {
+    // Two countries with the SAME raw unrest count (10 events, 0
+    // fatalities), differing only in population. The smaller country
+    // should score LOWER (worse) on socialCohesion because its per-capita
+    // unrest rate is higher.
+    const baseSeed = {
+      'displacement:summary:v1:2026': {
+        countries: { XA: { totalDisplaced: 100 }, XB: { totalDisplaced: 100 } },
+      },
+      'unrest:events:v1': {
+        events: [
+          ...Array.from({ length: 10 }, () => ({ country: 'XA', type: 'protest', fatalities: 0 })),
+          ...Array.from({ length: 10 }, () => ({ country: 'XB', type: 'protest', fatalities: 0 })),
+        ],
+      },
+    };
+
+    const smallPopReader = makeReader({
+      ...baseSeed,
+      'resilience:static:XA': { gpi: { score: 1.5 } },
+      'economic:imf:labor:v1': { countries: { XA: { populationMillions: 1 } } },
+    });
+    const largePopReader = makeReader({
+      ...baseSeed,
+      'resilience:static:XB': { gpi: { score: 1.5 } },
+      'economic:imf:labor:v1': { countries: { XB: { populationMillions: 100 } } },
+    });
+
+    const smallResult = await scoreSocialCohesion('XA', smallPopReader);
+    const largeResult = await scoreSocialCohesion('XB', largePopReader);
+
+    assert.ok(largeResult.score > smallResult.score,
+      `per-capita scaling broken: XB (100M pop, same 10 events) scored ${largeResult.score}; XA (1M pop) scored ${smallResult.score}. Per-capita normalization should make XB outperform XA.`);
+  });
+
+  it('UCDP eventCount is per-capita normalized in scoreBorderSecurity', async () => {
+    // Same shape as above but for UCDP events in scoreBorderSecurity.
+    const smallPopReader = makeReader({
+      'conflict:ucdp-events:v1': {
+        events: [
+          { country: 'XA', type: 'state-based', deaths: 5 },
+          { country: 'XA', type: 'state-based', deaths: 5 },
+          { country: 'XA', type: 'state-based', deaths: 5 },
+        ],
+      },
+      'displacement:summary:v1:2026': {
+        countries: { XA: { hostTotal: 100 } },
+      },
+      'economic:imf:labor:v1': { countries: { XA: { populationMillions: 1 } } },
+    });
+    const largePopReader = makeReader({
+      'conflict:ucdp-events:v1': {
+        events: [
+          { country: 'XB', type: 'state-based', deaths: 5 },
+          { country: 'XB', type: 'state-based', deaths: 5 },
+          { country: 'XB', type: 'state-based', deaths: 5 },
+        ],
+      },
+      'displacement:summary:v1:2026': {
+        countries: { XB: { hostTotal: 100 } },
+      },
+      'economic:imf:labor:v1': { countries: { XB: { populationMillions: 100 } } },
+    });
+
+    const smallResult = await scoreBorderSecurity('XA', smallPopReader);
+    const largeResult = await scoreBorderSecurity('XB', largePopReader);
+
+    assert.ok(largeResult.score > smallResult.score,
+      `borderSecurity per-capita normalization broken: XB (100M pop) scored ${largeResult.score}, XA (1M) scored ${smallResult.score}. UCDP eventCount + deaths must scale per-capita.`);
+  });
+
+  it('0.5-million pop floor protects tiny states from per-capita inflation', async () => {
+    // A country with 0.01M pop reported (Tuvalu-class) and a country
+    // with 0.5M pop reported (Iceland-class) should produce the SAME
+    // per-capita unrest score for the same event count, because the
+    // 0.5M floor anchors both at the same denominator.
+    const microReader = makeReader({
+      'resilience:static:XA': { gpi: { score: 1.5 } },
+      'displacement:summary:v1:2026': { countries: { XA: { totalDisplaced: 100 } } },
+      'unrest:events:v1': { events: [{ country: 'XA', type: 'protest', fatalities: 0 }] },
+      'economic:imf:labor:v1': { countries: { XA: { populationMillions: 0.01 } } },
+    });
+    const halfMillionReader = makeReader({
+      'resilience:static:XB': { gpi: { score: 1.5 } },
+      'displacement:summary:v1:2026': { countries: { XB: { totalDisplaced: 100 } } },
+      'unrest:events:v1': { events: [{ country: 'XB', type: 'protest', fatalities: 0 }] },
+      'economic:imf:labor:v1': { countries: { XB: { populationMillions: 0.5 } } },
+    });
+
+    const microResult = await scoreSocialCohesion('XA', microReader);
+    const halfMillionResult = await scoreSocialCohesion('XB', halfMillionReader);
+
+    // Both should have the SAME socialCohesion score (within rounding):
+    // their per-capita rate is identical because both denominators clamp
+    // to 0.5M via the floor.
+    assert.equal(microResult.score, halfMillionResult.score,
+      `0.5M floor not applied: 0.01M-pop XA scored ${microResult.score}, 0.5M-pop XB scored ${halfMillionResult.score}. Both should clamp to the same per-capita denominator.`);
+  });
+
+  it('country missing from IMF labor seed defaults to 0.5M pop (tiny-state proxy)', async () => {
+    // Plan §U6 design choice: when IMF labor doesn't carry a country
+    // (typically tiny states or non-IMF members), fall back to the
+    // 0.5M floor. This is directionally correct because the missing-
+    // pop cohort overlaps with the tiny-state cohort.
+    const reader = makeReader({
+      'resilience:static:XA': { gpi: { score: 1.5 } },
+      'displacement:summary:v1:2026': { countries: { XA: { totalDisplaced: 100 } } },
+      'unrest:events:v1': { events: [] },                       // zero unrest
+      'economic:imf:labor:v1': { countries: {} },               // XA missing
+    });
+    const result = await scoreSocialCohesion('XA', reader);
+    // Zero unrest + missing IMF labor → impute branch fires (case (c) in
+    // scoreSocialCohesion: observed displacement + zero unrest →
+    // unhcrDisplacement.score 85). Per-capita doesn't apply when count=0.
+    // Just verify the scorer doesn't throw and returns a sane score.
+    assert.ok(result.score > 0 && result.score <= 100,
+      `scorer must produce a valid score for missing-pop country, got ${result.score}`);
+  });
+});

--- a/tests/resilience-per-capita-normalization.test.mts
+++ b/tests/resilience-per-capita-normalization.test.mts
@@ -164,6 +164,34 @@ describe('per-capita normalization invariants (Plan 2026-04-26-002 §U6)', () =>
       `0.5M floor not applied: 0.01M-pop XA scored ${microResult.score}, 0.5M-pop XB scored ${halfMillionResult.score}. Both should clamp to the same per-capita denominator.`);
   });
 
+  it('TV boundary: live raw-persons value of exactly 10_000 falls through the defensive normalizer', async () => {
+    // Plan §U6 review fix: live Redis currently has TV.populationMillions
+    // = 10_000 (raw persons for Tuvalu's 10k headcount). The defensive
+    // normalizer's threshold MUST be inclusive (`>= 10_000`, not `>`)
+    // or this exact value would be treated as 10_000M and bypass §U6
+    // for Tuvalu until the next IMF labor bundle (30-day gated).
+    const tvRaw = makeReader({
+      'resilience:static:TV': { gpi: { score: 1.3 } },
+      'displacement:summary:v1:2026': { countries: { TV: { totalDisplaced: 100 } } },
+      'unrest:events:v1': { events: [{ country: 'TV', type: 'protest', fatalities: 0 }] },
+      'economic:imf:labor:v1': { countries: { TV: { populationMillions: 10_000 } } }, // raw persons
+    });
+    const tvFixed = makeReader({
+      'resilience:static:TV': { gpi: { score: 1.3 } },
+      'displacement:summary:v1:2026': { countries: { TV: { totalDisplaced: 100 } } },
+      'unrest:events:v1': { events: [{ country: 'TV', type: 'protest', fatalities: 0 }] },
+      'economic:imf:labor:v1': { countries: { TV: { populationMillions: 0.01 } } }, // post-fix millions
+    });
+    const rawResult = await scoreSocialCohesion('TV', tvRaw);
+    const fixedResult = await scoreSocialCohesion('TV', tvFixed);
+    // Both must produce the SAME socialCohesion score: the defensive
+    // branch divides 10_000 by 1e6 → 0.01 → max(0.01, 0.5) = 0.5;
+    // the post-fix branch reads 0.01 directly → max(0.01, 0.5) = 0.5.
+    // Identical denominators → identical per-capita math → identical scores.
+    assert.equal(rawResult.score, fixedResult.score,
+      `TV-boundary regression: raw-persons defensive path scored ${rawResult.score}, post-fix scored ${fixedResult.score}. The defensive normalizer must use \`>= 10_000\` to handle the live cache value.`);
+  });
+
   it('country missing from IMF labor seed defaults to 0.5M pop (tiny-state proxy)', async () => {
     // Plan §U6 design choice: when IMF labor doesn't carry a country
     // (typically tiny states or non-IMF members), fall back to the

--- a/tests/resilience-pillar-aggregation.test.mts
+++ b/tests/resilience-pillar-aggregation.test.mts
@@ -157,8 +157,8 @@ describe('pillar constants', () => {
     assert.equal(PENALTY_ALPHA, 0.50);
   });
 
-  it('RESILIENCE_SCORE_CACHE_PREFIX is v14', () => {
-    assert.equal(RESILIENCE_SCORE_CACHE_PREFIX, 'resilience:score:v15:');
+  it('RESILIENCE_SCORE_CACHE_PREFIX is v16', () => {
+    assert.equal(RESILIENCE_SCORE_CACHE_PREFIX, 'resilience:score:v16:');
   });
 
   it('PILLAR_ORDER has 3 entries', () => {

--- a/tests/resilience-pillar-combine-activation.test.mts
+++ b/tests/resilience-pillar-combine-activation.test.mts
@@ -35,9 +35,19 @@ import {
 // stays ~65-72, fragile states drop to ~15-35. The re-anchored bands
 // preserve the "high" vs "low" separation without pinning numbers that
 // are only valid for the legacy formula.
-const HIGH_BAND_FLOOR = 60;
+//
+// Plan 2026-04-26-002 §U4 (combined PR 3+4+5) coverage-penalty drop:
+// halving the weight of fully-imputed dims (IPC stable-absence in
+// foodWater, BIS/WTO unmonitored in economic) shifts NO down ~2pt
+// because Norway's IPC stable-absence-imputed foodWater rows were
+// pulling its foodWater dim UP at the prior weight; with the penalty
+// the observed (lower-scoring) AQUASTAT components carry more weight.
+// HIGH_BAND_FLOOR re-anchored 60 → 55 to absorb the v16 score-formula
+// shift without losing the "elite stays comfortably above mid-tier"
+// invariant the floor encodes.
+const HIGH_BAND_FLOOR = 55;
 const LOW_BAND_CEILING = 40;
-const MIN_HIGH_LOW_SEPARATION = 20;
+const MIN_HIGH_LOW_SEPARATION = 15;
 
 const fixtures = buildReleaseGateFixtures();
 
@@ -224,7 +234,7 @@ describe('pillar-combined score activation', () => {
       { request: new Request('https://example.com?countryCode=NO') } as never,
       { countryCode: 'NO' },
     );
-    assert.ok(firstRead.overallScore >= 70, `flag-off NO should score ≥70, got ${firstRead.overallScore}`);
+    assert.ok(firstRead.overallScore >= 65, `flag-off NO should score ≥65, got ${firstRead.overallScore}`);
 
     // Flip the flag. The cached entry in Redis still carries
     // _formula='d6' from the first read. Without the stale-formula
@@ -240,8 +250,8 @@ describe('pillar-combined score activation', () => {
       `flag-on rebuild must drop NO's score below the 6-domain value (penalty factor ≤ 1); got first=${firstRead.overallScore} second=${secondRead.overallScore}. If these are equal, the stale-formula cache gate is not firing and a flag flip in production would serve legacy values for up to the 6h TTL.`,
     );
     assert.ok(
-      secondRead.overallScore >= 60,
-      `flag-on NO should still meet the re-anchored 60 floor, got ${secondRead.overallScore}`,
+      secondRead.overallScore >= HIGH_BAND_FLOOR,
+      `flag-on NO should still meet the re-anchored high-band floor (${HIGH_BAND_FLOOR}), got ${secondRead.overallScore}`,
     );
   });
 });

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -220,8 +220,8 @@ describe('resilience ranking contracts', () => {
       domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
       lowConfidence: false, imputationShare: 0.1,
     }));
-    redis.set('resilience:intervals:v1:NO', JSON.stringify({ p05: 78, p95: 84 }));
-    redis.set('resilience:intervals:v1:US', JSON.stringify({ p05: 50, p95: 72 }));
+    redis.set('resilience:intervals:v2:NO', JSON.stringify({ p05: 78, p95: 84 }));
+    redis.set('resilience:intervals:v2:US', JSON.stringify({ p05: 50, p95: 72 }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -58,14 +58,14 @@ describe('resilience ranking contracts', () => {
     // so fixtures must carry the `_formula` tag matching the current env
     // (default flag-off ⇒ 'd6'). Writing the tagged shape here mirrors
     // what the handler persists via stampRankingCacheTag.
-    redis.set('resilience:ranking:v15', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
+    redis.set('resilience:ranking:v16', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
     // The handler strips `_formula` before returning, so response matches
     // the public shape rather than the on-wire cache shape.
     assert.deepEqual(response, cachedPublic);
-    assert.equal(redis.has('resilience:score:v15:YE'), false, 'cache hit must not trigger score warmup');
+    assert.equal(redis.has('resilience:score:v16:YE'), false, 'cache hit must not trigger score warmup');
   });
 
   it('returns all-greyed-out cached payload without rewarming (items=[], greyedOut non-empty)', async () => {
@@ -79,12 +79,12 @@ describe('resilience ranking contracts', () => {
         { countryCode: 'ER', overallScore: 10, level: 'critical', lowConfidence: true, overallCoverage: 0.12 },
       ],
     };
-    redis.set('resilience:ranking:v15', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
+    redis.set('resilience:ranking:v16', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
     assert.deepEqual(response, cachedPublic);
-    assert.equal(redis.has('resilience:score:v15:SS'), false, 'all-greyed-out cache hit must not trigger score warmup');
+    assert.equal(redis.has('resilience:score:v16:SS'), false, 'all-greyed-out cache hit must not trigger score warmup');
   });
 
   it('bulk-read path skips untagged per-country score entries (legacy writes must rebuild on flip)', async () => {
@@ -111,13 +111,13 @@ describe('resilience ranking contracts', () => {
 
     const domain = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
     // Tagged entry: served as-is.
-    redis.set('resilience:score:v15:NO', JSON.stringify({
+    redis.set('resilience:score:v16:NO', JSON.stringify({
       countryCode: 'NO', overallScore: 82, level: 'high',
       domains: domain, trend: 'stable', change30d: 1.2,
       lowConfidence: false, imputationShare: 0.05, _formula: 'd6',
     }));
     // Untagged entry: must be rejected, ranking warm rebuilds US.
-    redis.set('resilience:score:v15:US', JSON.stringify({
+    redis.set('resilience:score:v16:US', JSON.stringify({
       countryCode: 'US', overallScore: 61, level: 'medium',
       domains: domain, trend: 'rising', change30d: 4.3,
       lowConfidence: false, imputationShare: 0.1,
@@ -130,7 +130,7 @@ describe('resilience ranking contracts', () => {
     // `_formula: 'd6'`. If the bulk read had ADMITTED the untagged
     // entry (the pre-fix bug), the warm path for US would not have
     // run, and the stored value would still be untagged.
-    const rewrittenRaw = redis.get('resilience:score:v15:US');
+    const rewrittenRaw = redis.get('resilience:score:v16:US');
     assert.ok(rewrittenRaw, 'US entry must remain in Redis after the ranking run');
     const rewritten = JSON.parse(rewrittenRaw!);
     assert.equal(
@@ -157,7 +157,7 @@ describe('resilience ranking contracts', () => {
       greyedOut: [],
       _formula: 'pc', // mismatched — current env is flag-off ⇒ current='d6'
     };
-    redis.set('resilience:ranking:v15', JSON.stringify(stale));
+    redis.set('resilience:ranking:v16', JSON.stringify(stale));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
@@ -169,7 +169,7 @@ describe('resilience ranking contracts', () => {
     // Recompute path warms missing per-country scores, so YE (in
     // RESILIENCE_FIXTURES) must get scored during this call.
     assert.ok(
-      redis.has('resilience:score:v15:YE'),
+      redis.has('resilience:score:v16:YE'),
       'stale-formula reject must trigger the recompute-and-warm path',
     );
   });
@@ -177,7 +177,7 @@ describe('resilience ranking contracts', () => {
   it('warms missing scores synchronously and returns complete ranking on first call', async () => {
     const { redis } = installRedis(RESILIENCE_FIXTURES);
     const domainWithCoverage = [{ name: 'political', dimensions: [{ name: 'd1', coverage: 0.9 }] }];
-    redis.set('resilience:score:v15:NO', JSON.stringify({
+    redis.set('resilience:score:v16:NO', JSON.stringify({
       countryCode: 'NO',
       overallScore: 82,
       level: 'high',
@@ -187,7 +187,7 @@ describe('resilience ranking contracts', () => {
       lowConfidence: false,
       imputationShare: 0.05,
     }));
-    redis.set('resilience:score:v15:US', JSON.stringify({
+    redis.set('resilience:score:v16:US', JSON.stringify({
       countryCode: 'US',
       overallScore: 61,
       level: 'medium',
@@ -202,20 +202,20 @@ describe('resilience ranking contracts', () => {
 
     const totalItems = response.items.length + (response.greyedOut?.length ?? 0);
     assert.equal(totalItems, 3, `expected 3 total items across ranked + greyedOut, got ${totalItems}`);
-    assert.ok(redis.has('resilience:score:v15:YE'), 'missing country should be warmed during first call');
+    assert.ok(redis.has('resilience:score:v16:YE'), 'missing country should be warmed during first call');
     assert.ok(response.items.every((item) => item.overallScore >= 0), 'ranked items should all have computed scores');
-    assert.ok(redis.has('resilience:ranking:v15'), 'fully scored ranking should be cached');
+    assert.ok(redis.has('resilience:ranking:v16'), 'fully scored ranking should be cached');
   });
 
   it('sets rankStable=true when interval data exists and width <= 8', async () => {
     const { redis } = installRedis(RESILIENCE_FIXTURES);
     const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
-    redis.set('resilience:score:v15:NO', JSON.stringify({
+    redis.set('resilience:score:v16:NO', JSON.stringify({
       countryCode: 'NO', overallScore: 82, level: 'high',
       domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
       lowConfidence: false, imputationShare: 0.05,
     }));
-    redis.set('resilience:score:v15:US', JSON.stringify({
+    redis.set('resilience:score:v16:US', JSON.stringify({
       countryCode: 'US', overallScore: 61, level: 'medium',
       domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
       lowConfidence: false, imputationShare: 0.1,
@@ -242,12 +242,12 @@ describe('resilience ranking contracts', () => {
       seedYear: 2025,
     }));
     const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
-    redis.set('resilience:score:v15:NO', JSON.stringify({
+    redis.set('resilience:score:v16:NO', JSON.stringify({
       countryCode: 'NO', overallScore: 82, level: 'high',
       domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
       lowConfidence: false, imputationShare: 0.05,
     }));
-    redis.set('resilience:score:v15:US', JSON.stringify({
+    redis.set('resilience:score:v16:US', JSON.stringify({
       countryCode: 'US', overallScore: 61, level: 'medium',
       domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
       lowConfidence: false, imputationShare: 0.1,
@@ -257,7 +257,7 @@ describe('resilience ranking contracts', () => {
 
     // 3 of 4 (NO + US pre-cached, YE warmed from fixtures, ZZ can't be warmed)
     // = 75% which meets the threshold — must cache.
-    assert.ok(redis.has('resilience:ranking:v15'), 'ranking must be cached at exactly 75% coverage');
+    assert.ok(redis.has('resilience:ranking:v16'), 'ranking must be cached at exactly 75% coverage');
     assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written alongside the ranking');
   });
 
@@ -288,7 +288,7 @@ describe('resilience ranking contracts', () => {
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
         const allScoreReads = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'GET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v15:'),
+          (cmd) => cmd[0] === 'GET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v16:'),
         );
         if (allScoreReads) {
           // Simulate visibility lag: pretend no scores are cached yet.
@@ -304,7 +304,7 @@ describe('resilience ranking contracts', () => {
 
     await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
-    assert.ok(redis.has('resilience:ranking:v15'), 'ranking must be published despite pipeline-GET race');
+    assert.ok(redis.has('resilience:ranking:v16'), 'ranking must be published despite pipeline-GET race');
     assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written despite pipeline-GET race');
   });
 
@@ -312,8 +312,8 @@ describe('resilience ranking contracts', () => {
     // Reviewer regression: passing `raw=true` to runRedisPipeline bypasses the
     // env-based key prefix (preview: / dev:) that isolates preview deploys
     // from production. The symptom is asymmetric: preview reads hit
-    // `preview:<sha>:resilience:score:v15:XX` while preview writes landed at
-    // raw `resilience:score:v15:XX`, simultaneously (a) missing the preview
+    // `preview:<sha>:resilience:score:v16:XX` while preview writes landed at
+    // raw `resilience:score:v16:XX`, simultaneously (a) missing the preview
     // cache forever and (b) poisoning production's shared cache. Simulate a
     // preview deploy and assert the pipeline SET keys carry the prefix.
     // Shared afterEach snapshots/restores VERCEL_ENV + VERCEL_GIT_COMMIT_SHA
@@ -345,7 +345,7 @@ describe('resilience ranking contracts', () => {
 
     const scoreSetKeys = pipelineBodies
       .flat()
-      .filter((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v15:'))
+      .filter((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v16:'))
       .map((cmd) => cmd[1] as string);
     assert.ok(scoreSetKeys.length >= 2, `expected at least 2 score SETs, got ${scoreSetKeys.length}`);
     for (const key of scoreSetKeys) {
@@ -391,7 +391,7 @@ describe('resilience ranking contracts', () => {
       // fixture? No — but the auth-failed path returns the stale cache
       // unmodified, so NR survives the cache-filter).
       const stale = { items: [{ countryCode: 'NR', overallScore: 1, level: 'low', lowConfidence: true, overallCoverage: 0.5 }], greyedOut: [], _formula: 'd6' };
-      redis.set('resilience:ranking:v15', JSON.stringify(stale));
+      redis.set('resilience:ranking:v16', JSON.stringify(stale));
 
       // No X-WorldMonitor-Key → refresh must be ignored, stale cache returned.
       const unauth = new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1');
@@ -445,7 +445,7 @@ describe('resilience ranking contracts', () => {
       // rejected by the formula gate and the refresh path would not
       // get tested as intended.
       const stale = { items: [{ countryCode: 'ZZ', overallScore: 1, level: 'low', lowConfidence: true, overallCoverage: 0.5 }], greyedOut: [], _formula: 'd6' };
-      redis.set('resilience:ranking:v15', JSON.stringify(stale));
+      redis.set('resilience:ranking:v16', JSON.stringify(stale));
 
       const request = new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1', {
         headers: { 'X-WorldMonitor-Key': 'seed-secret' },
@@ -480,7 +480,7 @@ describe('resilience ranking contracts', () => {
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
         const isAllScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v15:'),
+          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v16:'),
         );
         if (isAllScoreSets) setPipelineSizes.push(commands.length);
       }
@@ -512,7 +512,7 @@ describe('resilience ranking contracts', () => {
       seedYear: 2026,
     }));
 
-    // Intercept any pipeline SET to resilience:score:v15:* and reply with
+    // Intercept any pipeline SET to resilience:score:v16:* and reply with
     // non-OK results (persisted but authoritative signal says no). /set and
     // other paths pass through normally so history/interval writes succeed.
     const blockedScoreWrites = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -520,7 +520,7 @@ describe('resilience ranking contracts', () => {
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
         const allScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v15:'),
+          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v16:'),
         );
         if (allScoreSets) {
           return new Response(
@@ -535,7 +535,7 @@ describe('resilience ranking contracts', () => {
 
     await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
-    assert.ok(!redis.has('resilience:ranking:v15'), 'ranking must NOT be published when score writes failed');
+    assert.ok(!redis.has('resilience:ranking:v16'), 'ranking must NOT be published when score writes failed');
     assert.ok(!redis.has('seed-meta:resilience:ranking'), 'seed-meta must NOT be written when score writes failed');
   });
 

--- a/tests/resilience-scorers.test.mts
+++ b/tests/resilience-scorers.test.mts
@@ -140,11 +140,19 @@ describe('resilience scorer contracts', () => {
     // the coverage-weighted-mean path which CORRECTLY drops a coverage=0
     // dim from the blend; the headline overall is unaffected by the
     // flag-off baseline beyond the small tradePolicy-reweight shift.
+    // Plan 2026-04-26-002 §U6 (combined PR 3+4+5): social-governance
+    // 61.75 → 65.25. Per-capita normalization of unrest event counts +
+    // UCDP eventCount lifts the US (333M pop) socialCohesion and
+    // borderSecurity dim scores — fixture event counts of ~5-10 events
+    // become 0.015-0.03 events/M, well inside the 0..10 / 0..15 lowerBetter
+    // anchors → higher scores. The plan's per-capita design TARGETS this
+    // re-anchoring (intent: don't rank micro-states with raw zero counts
+    // above large states with low-rate counts).
     assert.deepEqual(domainAverages, {
       economic: 53.25,
       infrastructure: 79,
       energy: 80,
-      'social-governance': 61.75,
+      'social-governance': 65.25,
       'health-food': 60.5,
       recovery: 48.75,
     });
@@ -152,14 +160,14 @@ describe('resilience scorer contracts', () => {
     function round(v: number, d = 2) { return Number(v.toFixed(d)); }
     // Mirror of the production coverage-weighted mean (see
     // server/worldmonitor/resilience/v1/_shared.ts). Must apply the
-    // per-dim weight from RESILIENCE_DIMENSION_WEIGHTS so the expected
-    // values here track the production aggregation after the PR 2 §3.4
-    // recovery-domain weight rebalance.
-    function coverageWeightedMean(dims: { id: string; score: number; coverage: number }[]) {
+    // per-dim weight from RESILIENCE_DIMENSION_WEIGHTS and the §U4
+    // imputation half-weight factor so expected values track production.
+    function coverageWeightedMean(dims: { id: string; score: number; coverage: number; imputationClass: string | null }[]) {
       let totalW = 0, sum = 0;
       for (const d of dims) {
         const w = (RESILIENCE_DIMENSION_WEIGHTS as Record<string, number>)[d.id] ?? 1.0;
-        const effective = d.coverage * w;
+        const imputationFactor = d.imputationClass ? 0.5 : 1.0;
+        const effective = d.coverage * w * imputationFactor;
         totalW += effective;
         sum += d.score * effective;
       }
@@ -171,6 +179,7 @@ describe('resilience scorer contracts', () => {
       id,
       score: round(scoreMap[id].score),
       coverage: round(scoreMap[id].coverage),
+      imputationClass: scoreMap[id].imputationClass,
     }));
     const baselineDims = dimensions.filter((d) => {
       const t = RESILIENCE_DIMENSION_TYPES[d.id as keyof typeof RESILIENCE_DIMENSION_TYPES];
@@ -196,7 +205,12 @@ describe('resilience scorer contracts', () => {
     // the low-scoring liquidReserveAdequacy (18) and partial-coverage
     // sovereignFiscalBuffer (50 × 0.3) contribute ~half as much to
     // the US baseline aggregate as under the equal-weight default.
-    assert.equal(baselineScore, 62.17);
+    // Plan 2026-04-26-002 §U4 (combined PR 3+4+5): 62.17 → 62.72. The
+    // coverage penalty halves the weight of fully-imputed dims (US has
+    // sovereignFiscalBuffer at IMPUTE 50/0.3 since US has no SWF
+    // manifest entry — fixture defaults). Halving its already-low
+    // contribution lifts the baseline mean.
+    assert.equal(baselineScore, 62.72);
     // PR 3 §3.5: 65.84 → 67.85 (fuelStockDays retirement) → 67.21
     // (currencyExternal rebuilt on IMF inflation + WB reserves, coverage
     // shifts and US stress score moves).
@@ -209,20 +223,34 @@ describe('resilience scorer contracts', () => {
     // `financialSystemExposure` dim is also stress-class and ships
     // flag-gated off → score 0 → drags the stress-only mean down.
     //   1 - 67.98/100 = 0.3202, clamped to 0.5.
-    assert.equal(stressScore, 67.98);
-    assert.equal(stressFactor, 0.3202);
+    // Plan 2026-04-26-002 §U4+§U6 (combined PR 3+4+5): 67.98 → 69.08.
+    // U4 halves the weight of US's fully-imputed stress dims (BIS DSR
+    // imputed at 60, WTO trade imputed at 60, financialSystemExposure
+    // imputed at 50/0.3); U6 lifts borderSecurity for US (333M pop) via
+    // per-capita normalization. Net positive shift in the stress mean,
+    // raising the stress factor proportionally.
+    //   1 - 69.08/100 = 0.3092, clamped to 0.5.
+    assert.equal(stressScore, 69.08);
+    assert.equal(stressFactor, 0.3092);
 
     const overallScore = round(
       RESILIENCE_DOMAIN_ORDER.map((domainId) => {
         const dimScores = RESILIENCE_DIMENSION_ORDER
           .filter((id) => RESILIENCE_DIMENSION_DOMAINS[id] === domainId)
-          .map((id) => ({ id, score: round(scoreMap[id].score), coverage: round(scoreMap[id].coverage) }));
-        // Mirror production: apply per-dim weight to each dim's
-        // effective coverage before computing the mean.
+          .map((id) => ({
+            id,
+            score: round(scoreMap[id].score),
+            coverage: round(scoreMap[id].coverage),
+            imputationClass: scoreMap[id].imputationClass,
+          }));
+        // Mirror production: apply per-dim weight + §U4 imputation
+        // half-weight factor to each dim's effective coverage before
+        // computing the mean.
         let totalW = 0, sum = 0;
         for (const d of dimScores) {
           const w = (RESILIENCE_DIMENSION_WEIGHTS as Record<string, number>)[d.id] ?? 1.0;
-          const eff = d.coverage * w;
+          const imputationFactor = d.imputationClass ? 0.5 : 1.0;
+          const eff = d.coverage * w * imputationFactor;
           totalW += eff;
           sum += d.score * eff;
         }
@@ -253,7 +281,13 @@ describe('resilience scorer contracts', () => {
     // flag flips on in production with seeders populated, the dim will
     // contribute its own signal; the expected value here will move
     // accordingly in a future PR.
-    assert.equal(overallScore, 64.78);
+    // Plan 2026-04-26-002 §U4+§U6 (combined PR 3+4+5): 64.78 → 65.45.
+    // Same delta as the local-helper-based test above; both apply the
+    // imputation half-weight factor + per-capita normalization, which
+    // shift the US overall by ~+0.67 (imputed dims contribute less,
+    // population-normalized event-counts boost socialCohesion +
+    // borderSecurity for high-pop countries).
+    assert.equal(overallScore, 65.45);
   });
 
   it('baselineScore is computed from baseline + mixed dimensions only', async () => {
@@ -302,12 +336,15 @@ describe('resilience scorer contracts', () => {
     // server/worldmonitor/resilience/v1/_shared.ts). Must apply the
     // per-dim weight from RESILIENCE_DIMENSION_WEIGHTS so the expected
     // values here track the production aggregation after the PR 2 §3.4
-    // recovery-domain weight rebalance.
-    function coverageWeightedMean(dims: { id: string; score: number; coverage: number }[]) {
+    // recovery-domain weight rebalance. Plan 2026-04-26-002 §U4 added
+    // the imputation-class half-weight factor; mirror it here so the
+    // local helper stays in sync with the production formula.
+    function coverageWeightedMean(dims: { id: string; score: number; coverage: number; imputationClass: string | null }[]) {
       let totalW = 0, sum = 0;
       for (const d of dims) {
         const w = (RESILIENCE_DIMENSION_WEIGHTS as Record<string, number>)[d.id] ?? 1.0;
-        const effective = d.coverage * w;
+        const imputationFactor = d.imputationClass ? 0.5 : 1.0;
+        const effective = d.coverage * w * imputationFactor;
         totalW += effective;
         sum += d.score * effective;
       }
@@ -316,7 +353,10 @@ describe('resilience scorer contracts', () => {
     }
 
     const dimensions = RESILIENCE_DIMENSION_ORDER.map((id) => ({
-      id, score: round(scoreMap[id].score), coverage: round(scoreMap[id].coverage),
+      id,
+      score: round(scoreMap[id].score),
+      coverage: round(scoreMap[id].coverage),
+      imputationClass: scoreMap[id].imputationClass,
     }));
 
     const grouped = new Map<string, typeof dimensions>();
@@ -348,7 +388,13 @@ describe('resilience scorer contracts', () => {
     // off by default, so it contributes coverage=0 and drops from the
     // coverage-weighted mean. When the flag flips on with seeders
     // populated, the expected here will shift accordingly.
-    assert.equal(expected, 64.78, 'overallScore should match sum(domainScore * domainWeight); 65.24 → 64.78 after Ship 2 dim added (flag-off baseline)');
+    // Plan 2026-04-26-002 §U4+§U6 (combined PR 3+4+5): 64.78 → 65.45.
+    // U4 coverage penalty halves the weight of fully-imputed dims (US has
+    // a couple of WTO/BIS imputes); U6 per-capita normalization bumps
+    // social-cohesion + border-security for the US (333M pop) since
+    // event-counts/M are tiny. Net positive shift for a high-population
+    // comprehensive-source country, as designed.
+    assert.equal(expected, 65.45, 'overallScore should match sum(domainScore * domainWeight); plan 002 §U4+§U6 64.78 → 65.45');
   });
 
   it('stressFactor is still computed (informational) and clamped to [0, 0.5]', () => {

--- a/tests/resilience-scorers.test.mts
+++ b/tests/resilience-scorers.test.mts
@@ -141,18 +141,19 @@ describe('resilience scorer contracts', () => {
     // dim from the blend; the headline overall is unaffected by the
     // flag-off baseline beyond the small tradePolicy-reweight shift.
     // Plan 2026-04-26-002 §U6 (combined PR 3+4+5): social-governance
-    // 61.75 → 65.25. Per-capita normalization of unrest event counts +
-    // UCDP eventCount lifts the US (333M pop) socialCohesion and
-    // borderSecurity dim scores — fixture event counts of ~5-10 events
-    // become 0.015-0.03 events/M, well inside the 0..10 / 0..15 lowerBetter
-    // anchors → higher scores. The plan's per-capita design TARGETS this
-    // re-anchoring (intent: don't rank micro-states with raw zero counts
-    // above large states with low-rate counts).
+    // 61.75 → 66.25. Per-capita normalization of unrest event counts +
+    // UCDP eventCount + typeWeight + deaths lifts the US (333M pop)
+    // socialCohesion and borderSecurity dim scores — fixture event counts
+    // of ~5-10 events become 0.015-0.03 events/M, well inside the 0..10
+    // / 0..15 lowerBetter anchors → higher scores. typeWeight is now also
+    // per-capita normalized (review fix: it's an event-count-scaled term,
+    // not dimensionless), accounting for the additional +1.0pt vs the
+    // initial commit's 65.25 expectation.
     assert.deepEqual(domainAverages, {
       economic: 53.25,
       infrastructure: 79,
       energy: 80,
-      'social-governance': 65.25,
+      'social-governance': 66.25,
       'health-food': 60.5,
       recovery: 48.75,
     });
@@ -230,8 +231,11 @@ describe('resilience scorer contracts', () => {
     // per-capita normalization. Net positive shift in the stress mean,
     // raising the stress factor proportionally.
     //   1 - 69.08/100 = 0.3092, clamped to 0.5.
-    assert.equal(stressScore, 69.08);
-    assert.equal(stressFactor, 0.3092);
+    // typeWeight per-capita review fix: stress score lifts further on
+    // borderSecurity (typeWeight is now divided by population denominator).
+    //   1 - 69.63/100 = 0.3037, clamped to 0.5.
+    assert.equal(stressScore, 69.63);
+    assert.equal(stressFactor, 0.3037);
 
     const overallScore = round(
       RESILIENCE_DOMAIN_ORDER.map((domainId) => {
@@ -281,13 +285,14 @@ describe('resilience scorer contracts', () => {
     // flag flips on in production with seeders populated, the dim will
     // contribute its own signal; the expected value here will move
     // accordingly in a future PR.
-    // Plan 2026-04-26-002 §U4+§U6 (combined PR 3+4+5): 64.78 → 65.45.
+    // Plan 2026-04-26-002 §U4+§U6 (combined PR 3+4+5): 64.78 → 65.64.
     // Same delta as the local-helper-based test above; both apply the
-    // imputation half-weight factor + per-capita normalization, which
-    // shift the US overall by ~+0.67 (imputed dims contribute less,
-    // population-normalized event-counts boost socialCohesion +
-    // borderSecurity for high-pop countries).
-    assert.equal(overallScore, 65.45);
+    // imputation half-weight factor + per-capita normalization (with
+    // the typeWeight-per-capita review fix), which shift the US overall
+    // by ~+0.86 (imputed dims contribute less, population-normalized
+    // event-counts boost socialCohesion + borderSecurity for high-pop
+    // countries).
+    assert.equal(overallScore, 65.64);
   });
 
   it('baselineScore is computed from baseline + mixed dimensions only', async () => {
@@ -388,13 +393,12 @@ describe('resilience scorer contracts', () => {
     // off by default, so it contributes coverage=0 and drops from the
     // coverage-weighted mean. When the flag flips on with seeders
     // populated, the expected here will shift accordingly.
-    // Plan 2026-04-26-002 §U4+§U6 (combined PR 3+4+5): 64.78 → 65.45.
+    // Plan 2026-04-26-002 §U4+§U6 (combined PR 3+4+5): 64.78 → 65.64.
     // U4 coverage penalty halves the weight of fully-imputed dims (US has
-    // a couple of WTO/BIS imputes); U6 per-capita normalization bumps
-    // social-cohesion + border-security for the US (333M pop) since
-    // event-counts/M are tiny. Net positive shift for a high-population
-    // comprehensive-source country, as designed.
-    assert.equal(expected, 65.45, 'overallScore should match sum(domainScore * domainWeight); plan 002 §U4+§U6 64.78 → 65.45');
+    // a couple of WTO/BIS imputes); U6 per-capita normalization (incl.
+    // typeWeight per the review fix) bumps social-cohesion + border-
+    // security for the US (333M pop) since event-counts/M are tiny.
+    assert.equal(expected, 65.64, 'overallScore should match sum(domainScore * domainWeight); plan 002 §U4+§U6 64.78 → 65.64');
   });
 
   it('stressFactor is still computed (informational) and clamped to [0, 0.5]', () => {

--- a/tests/resilience-scores-seed.test.mjs
+++ b/tests/resilience-scores-seed.test.mjs
@@ -11,11 +11,11 @@ import {
 
 describe('exported constants', () => {
   it('RESILIENCE_RANKING_CACHE_KEY matches server-side key (v14)', () => {
-    assert.equal(RESILIENCE_RANKING_CACHE_KEY, 'resilience:ranking:v15');
+    assert.equal(RESILIENCE_RANKING_CACHE_KEY, 'resilience:ranking:v16');
   });
 
   it('RESILIENCE_SCORE_CACHE_PREFIX matches server-side prefix (v14)', () => {
-    assert.equal(RESILIENCE_SCORE_CACHE_PREFIX, 'resilience:score:v15:');
+    assert.equal(RESILIENCE_SCORE_CACHE_PREFIX, 'resilience:score:v16:');
   });
 
   it('RESILIENCE_RANKING_CACHE_TTL_SECONDS is 12 hours (2x cron interval)', () => {

--- a/tests/resilience-scores-seed.test.mjs
+++ b/tests/resilience-scores-seed.test.mjs
@@ -10,11 +10,11 @@ import {
 } from '../scripts/seed-resilience-scores.mjs';
 
 describe('exported constants', () => {
-  it('RESILIENCE_RANKING_CACHE_KEY matches server-side key (v14)', () => {
+  it('RESILIENCE_RANKING_CACHE_KEY matches server-side key (v16)', () => {
     assert.equal(RESILIENCE_RANKING_CACHE_KEY, 'resilience:ranking:v16');
   });
 
-  it('RESILIENCE_SCORE_CACHE_PREFIX matches server-side prefix (v14)', () => {
+  it('RESILIENCE_SCORE_CACHE_PREFIX matches server-side prefix (v16)', () => {
     assert.equal(RESILIENCE_SCORE_CACHE_PREFIX, 'resilience:score:v16:');
   });
 

--- a/tests/resilience-source-comprehensive-flag.test.mts
+++ b/tests/resilience-source-comprehensive-flag.test.mts
@@ -75,6 +75,7 @@ describe('source-comprehensiveness flag (Plan 2026-04-26-002 §U5)', () => {
       'gasStorageStress',           // GIE AGSI+ EU+ subset
       'recoverySovereignWealthEffectiveMonths', // Wikipedia 8-fund manifest
       'recoveryFuelStockDays',      // RETIRED + IEA OECD-only
+      'shortTermExternalDebtPctGni', // WB IDS LMIC-only (~125 countries); HIC absence is NOT a stable-absence signal
     ];
     for (const id of mustBeNonComprehensive) {
       assert.equal(isIndicatorComprehensive(id), false,

--- a/tests/resilience-source-comprehensive-flag.test.mts
+++ b/tests/resilience-source-comprehensive-flag.test.mts
@@ -1,0 +1,104 @@
+// Plan 2026-04-26-002 §U5 (combined PR 3+4+5) — pinning tests for the
+// source-comprehensiveness flag.
+//
+// The flag discriminates which IMPUTE callers should fall back from the
+// stable-absence anchor (85/0.6 or 88/0.7) to `unmonitored` (50/0.3) when
+// the country is absent from a non-comprehensive source. These tests pin
+// the registry's per-source classification AND the helper's lookup
+// behavior so a future contributor can't silently flip a comprehensive
+// flag without the test review surfacing the change.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  INDICATOR_REGISTRY,
+  isIndicatorComprehensive,
+} from '../server/worldmonitor/resilience/v1/_indicator-registry';
+
+describe('source-comprehensiveness flag (Plan 2026-04-26-002 §U5)', () => {
+  it('every indicator entry carries an explicit `comprehensive` boolean', () => {
+    for (const spec of INDICATOR_REGISTRY) {
+      assert.equal(typeof spec.comprehensive, 'boolean',
+        `indicator ${spec.id} must have comprehensive: boolean (got ${typeof spec.comprehensive})`);
+    }
+  });
+
+  it('comprehensive=true pins canonical global-coverage sources', () => {
+    // These ids MUST stay comprehensive=true. The plan's IMPUTE stable-
+    // absence anchors (85/0.6, 88/0.7) only make sense if the source
+    // really enumerates all UN-member countries.
+    const mustBeComprehensive = [
+      'ipcPeopleInCrisis',          // IPC food crisis
+      'ipcPhase',                   // IPC phase
+      'displacementTotal',          // UNHCR
+      'displacementHosted',         // UNHCR
+      'ucdpConflict',               // UCDP
+      'fatfListingStatus',          // FATF (global registry)
+      'recoveryConflictPressure',   // UCDP-derived
+      'recoveryDisplacementVelocity', // UNHCR-derived
+      'wgiVoiceAccountability',     // World Bank WGI
+      'wgiPoliticalStability',
+      'wgiGovernmentEffectiveness',
+      'wgiRegulatoryQuality',
+      'wgiRuleOfLaw',
+      'wgiControlOfCorruption',
+    ];
+    for (const id of mustBeComprehensive) {
+      assert.equal(isIndicatorComprehensive(id), true,
+        `${id} must be comprehensive=true (canonical global-coverage source)`);
+    }
+  });
+
+  it('comprehensive=false pins event-feed and curated-subset sources', () => {
+    // These ids MUST stay comprehensive=false. They are event feeds,
+    // English-biased social signals, or curated subsets where absence
+    // does NOT mean "stable absence" — it means "we didn't measure this
+    // country" (the unmonitored 50/0.3 anchor).
+    const mustBeNonComprehensive = [
+      'unrestEvents',               // GDELT-like event feed (load-bearing for §U5)
+      'newsThreatScore',            // English-bias news summary
+      'socialVelocity',             // Reddit (English-bias)
+      'cyberThreats',               // event feed
+      'internetOutages',            // event feed
+      'gpsJamming',                 // event feed
+      'shippingStress',             // real-time corridor monitor
+      'transitDisruption',          // real-time corridor monitor
+      'infraOutages',               // event feed
+      'tradeRestrictions',          // WTO top-50 reporters
+      'tradeBarriers',              // WTO top-50 reporters
+      'householdDebtService',       // BIS DSR ~40 economies
+      'fxVolatility',               // BIS EER ~64 economies
+      'fxDeviation',                // BIS EER ~64 economies
+      'bisLbsXborderPctGdp',        // BIS LBS by-parent reporters
+      'financialCenterRedundancy',  // BIS LBS by-parent reporters
+      'gasStorageStress',           // GIE AGSI+ EU+ subset
+      'recoverySovereignWealthEffectiveMonths', // Wikipedia 8-fund manifest
+      'recoveryFuelStockDays',      // RETIRED + IEA OECD-only
+    ];
+    for (const id of mustBeNonComprehensive) {
+      assert.equal(isIndicatorComprehensive(id), false,
+        `${id} must be comprehensive=false (event feed / curated subset / English-biased)`);
+    }
+  });
+
+  it('isIndicatorComprehensive() returns false for unknown ids (conservative default)', () => {
+    // Plan §risk-mitigation row: "when in doubt, mark `comprehensive: false`".
+    // The helper applies the same conservative default for ids not in the
+    // registry — falling back to `unmonitored` (50/0.3) is the safer error
+    // mode if a typo/refactor breaks the lookup.
+    assert.equal(isIndicatorComprehensive('thisIndicatorDoesNotExist'), false);
+    assert.equal(isIndicatorComprehensive(''), false);
+  });
+
+  it('every comprehensive=true entry has coverage >= 100 (sanity gate)', () => {
+    // A "comprehensive" source by definition enumerates most countries.
+    // If a flag is true but coverage < 100, the flag is mis-tagged.
+    for (const spec of INDICATOR_REGISTRY) {
+      if (spec.comprehensive) {
+        assert.ok(spec.coverage >= 100,
+          `${spec.id}: comprehensive=true but coverage=${spec.coverage}. A truly comprehensive source should cover ≥100 countries; this is mis-tagged.`);
+      }
+    }
+  });
+});

--- a/tests/seed-imf-extended.test.mjs
+++ b/tests/seed-imf-extended.test.mjs
@@ -106,10 +106,14 @@ describe('seed-imf-labor', () => {
     assert.equal(LABOR_TTL, 35 * 24 * 3600);
   });
 
-  it('buildLaborCountries surfaces unemployment and population per ISO2', () => {
+  it('buildLaborCountries surfaces unemployment and population per ISO2 (LP raw persons → millions)', () => {
+    // Plan 002 review fix: IMF SDMX `LP` returns Population in PERSONS
+    // (raw count), not millions. Mock here matches real upstream shape:
+    // US ≈ 333.3M people = 333_300_000 raw. The seeder now divides by 1e6
+    // so the field name (populationMillions) matches its semantic.
     const countries = buildLaborCountries({
       unemployment: { USA: { [YEAR]: 4.1 }, FRA: { [YEAR]: 7.5 } },
-      population:   { USA: { [YEAR]: 333.3 }, FRA: { [YEAR]: 67.9 }, ZAF: { [YEAR]: 60.2 } },
+      population:   { USA: { [YEAR]: 333_300_000 }, FRA: { [YEAR]: 67_900_000 }, ZAF: { [YEAR]: 60_200_000 } },
     });
     assert.deepEqual(countries.US, {
       unemploymentPct: 4.1, populationMillions: 333.3, year: Number(YEAR),


### PR DESCRIPTION
## Summary

Plan 2026-04-26-002 §U4+U5+U6 — combined PR 3+4+5. Three coordinated levers ride a single cache prefix bump (v15→v16, history v10→v11) to eliminate the structural small-state inflation.

- **§U4 coverage penalty** — fully-imputed dims contribute `coverage × weight × 0.5` instead of full weight in `coverageWeightedMean`. Tiny states like TV/PW/NR previously rode imputed 85s (no IPC, no UNHCR) to false-high overall scores; now the imputed signal carries half the influence.
- **§U5 source-comprehensiveness flag** — new required `comprehensive: boolean` on every IndicatorSpec (68 entries, 19 marked false). Wired into `scoreSocialCohesion`'s GPI-only unrest impute: drops 70/0.5 stable-absence → 50/0.3 unmonitored for `unrest:events:v1` (event-scraping feed, English-bias).
- **§U6 per-capita normalization** — unrest count + UCDP eventCount divide by `max(populationMillions, 0.5)`. Goalposts re-anchored 0..10 (socialCohesion) and 0..15 (borderSecurity) events/M. Population read from `economic:imf:labor:v1`.

## What changed empirically

Documented per-site with the §U-id justifying each shift (cache prefix bump scope per `cache-prefix-bump-propagation-scope` skill):

- TV `socialCohesion`: ~80 → ~76 (§U5 unrest impute drops 70 → 50 for tiny states in GPI-only mode)
- US `overall`: 64.78 → 65.45 (§U4 reduces drag from US's WTO/BIS imputed dims; §U6 lifts socialCohesion + borderSecurity for high-pop countries)
- NO `pillar-combined` high-band floor: 60 → 55 (Norway has IPC stable-absence-imputed foodWater rows that previously inflated foodWater; coverage penalty halves their pull)
- Iceland regression guard (peaceful + comprehensive-source) passes — no regression
- Cohort fixture tightened from PR 0 PERMISSIVE to plan-002-PR-5 thresholds: median(G7) > median(microstate) + 15pt, count(microstate in top 20) ≤ 1, median(Nordics) ≥ median(GCC) - 5pt, min(G7) ≥ max(Sub-Saharan-LIC) - 10pt.

## Cache propagation

Bumped `RESILIENCE_SCORE_CACHE_PREFIX` v15 → v16 + `RESILIENCE_HISTORY_KEY_PREFIX` v10 → v11 + `RESILIENCE_RANKING_CACHE_KEY` v15 → v16. 11 hardcoded literal sites bulk-updated across `tests/`, `scripts/`, `api/health.js`. Score-formula tag is the suspenders; cross-formula gate in `rankingCacheTagMatches` recompute-and-publishes a stale entry on any mismatch.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run typecheck:api` clean
- [x] `npm run lint` clean (exit 0)
- [x] `npm run test:data` — 7473/7473 pass
- [x] Iceland regression guard for comprehensive-source peaceful country passes
- [x] Cohort anti-inversion fixture passes (skip-on-missing-creds locally; live invariants will validate post-merge against refreshed v16 ranking)

## References

- Plan: `docs/plans/2026-04-26-002-feat-resilience-universe-coverage-rebuild-plan.md`
- Origin: `docs/brainstorms/2026-04-26-002-resilience-universe-coverage-rebuild-requirements.md`
- Predecessors (already merged): PR #3425, #3426, #3427, #3432, #3433 (PR 0 fixture), #3435 (PR 1 universe), #3441 (sovereign-status hotfix)