### PR TITLE
chore(broadcast): backfill proLaunchWave stamps for canary-250 contacts

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as alertRules from "../alertRules.js";
 import type * as apiKeys from "../apiKeys.js";
 import type * as broadcast_audienceExport from "../broadcast/audienceExport.js";
+import type * as broadcast_backfillCanaryWaveStamps from "../broadcast/backfillCanaryWaveStamps.js";
 import type * as broadcast_metrics from "../broadcast/metrics.js";
 import type * as broadcast_proLaunchEmailContent from "../broadcast/proLaunchEmailContent.js";
 import type * as broadcast_sendBroadcast from "../broadcast/sendBroadcast.js";
@@ -51,6 +52,7 @@ declare const fullApi: ApiFromModules<{
   alertRules: typeof alertRules;
   apiKeys: typeof apiKeys;
   "broadcast/audienceExport": typeof broadcast_audienceExport;
+  "broadcast/backfillCanaryWaveStamps": typeof broadcast_backfillCanaryWaveStamps;
   "broadcast/metrics": typeof broadcast_metrics;
   "broadcast/proLaunchEmailContent": typeof broadcast_proLaunchEmailContent;
   "broadcast/sendBroadcast": typeof broadcast_sendBroadcast;

--- a/convex/broadcast/audienceExport.ts
+++ b/convex/broadcast/audienceExport.ts
@@ -142,6 +142,13 @@ type ExportStats = {
   // Dedup-only counters: shared between live and dry-run (don't depend on Resend).
   suppressedSkipped: number;
   paidSkipped: number;
+  // Registrations stamped with `proLaunchWave` from a prior broadcast
+  // (canary-250 backfill or any future wave-export). Skipping here is
+  // the load-bearing guarantee that the same contact is never emailed
+  // twice across the launch ramp. Without this skip, re-running this
+  // exporter against `pro-launch-main` would re-pick the canary 244 (or
+  // any later wave) and the next broadcast would dupe-email them.
+  alreadyInPriorWaveSkipped: number;
   emptyEmail: number;
   // Dry-run-only: count of registrations that passed dedup and WOULD be
   // upserted on a live run. Strictly disjoint from `upserted` so an
@@ -315,6 +322,7 @@ export const exportProLaunchAudience = internalAction({
       failed: 0,
       suppressedSkipped: 0,
       paidSkipped: 0,
+      alreadyInPriorWaveSkipped: 0,
       emptyEmail: 0,
       wouldUpsertAfterDedup: 0,
       isDone: page.isDone,
@@ -334,6 +342,14 @@ export const exportProLaunchAudience = internalAction({
       }
       if (paidSet.has(email)) {
         stats.paidSkipped++;
+        continue;
+      }
+      // Skip rows already stamped by a prior wave (canary-250 backfill
+      // or any later wave-export action). Load-bearing — without this
+      // the canary 244 land back in the next segment and get a
+      // duplicate email when the broadcast fires.
+      if (row.proLaunchWave) {
+        stats.alreadyInPriorWaveSkipped++;
         continue;
       }
 

--- a/convex/broadcast/backfillCanaryWaveStamps.ts
+++ b/convex/broadcast/backfillCanaryWaveStamps.ts
@@ -1,0 +1,229 @@
+/**
+ * One-shot backfill: stamp `proLaunchWave = "canary-250"` on the 244
+ * registrations who received the first PRO-launch broadcast on
+ * 2026-04-26. Without this stamp, the next wave-export action would
+ * re-pick those contacts and re-email them.
+ *
+ * Reads the canary segment's contact list directly from Resend (the
+ * authoritative record of who got that send), maps each email back to
+ * `registrations.normalizedEmail`, and patches the wave fields.
+ *
+ * Run once:
+ *   npx convex run broadcast/backfillCanaryWaveStamps:backfillCanary250
+ *
+ * Idempotent — re-runs are no-ops for already-stamped rows. Safe to
+ * re-invoke if it's interrupted (e.g., transient Resend 429).
+ */
+import { v } from "convex/values";
+import {
+  internalAction,
+  internalMutation,
+} from "../_generated/server";
+import { internal } from "../_generated/api";
+
+const RESEND_API_BASE = "https://api.resend.com";
+const USER_AGENT =
+  "WorldMonitor-CanaryWaveBackfill/1.0 (+https://worldmonitor.app)";
+
+// Hard-coded — this is a one-off backfill for a specific historical
+// send. Future wave-export actions will pass these as parameters.
+const CANARY_SEGMENT_ID = "4be8a9fd-8066-4322-ae27-4f9ed74cfab9";
+const CANARY_WAVE_LABEL = "canary-250";
+// Resend `sent_at` for the canary broadcast 2cc31355-15b1-459b-9142-489441c4d6cb.
+const CANARY_SENT_AT_MS = Date.parse("2026-04-26T22:50:49.673Z");
+
+// Resend caps `limit` at 100 per page. Pagination via `after=<contact_id>`.
+const RESEND_PAGE_SIZE = 100;
+
+/**
+ * Mask an email for log output. Convex dashboard logs are observable to
+ * anyone with project access; raw waitlist addresses must not land
+ * there. Mirrors the helper in `audienceExport.ts` for consistency.
+ */
+function maskEmail(email: string): string {
+  const at = email.indexOf("@");
+  if (at <= 0) return "***";
+  const local = email.slice(0, at);
+  const domain = email.slice(at);
+  const visible = local.slice(0, Math.min(2, local.length));
+  const masked = "*".repeat(Math.max(1, local.length - visible.length));
+  return `${visible}${masked}${domain}`;
+}
+
+/**
+ * Stamp the PRO-launch wave on a single `registrations` row by
+ * normalizedEmail. Idempotent: returns `alreadyStamped: true` if the
+ * row already carries the same wave label, `notFound` if no
+ * registration matches the email (e.g., manually-imported Resend
+ * contacts that never came through the waitlist), or `stamped: true`
+ * on a successful patch.
+ *
+ * Internal because callers are server-side actions only — this is not
+ * a user-facing mutation.
+ */
+export const _stampWaveByNormalizedEmail = internalMutation({
+  args: {
+    normalizedEmail: v.string(),
+    waveLabel: v.string(),
+    assignedAt: v.number(),
+  },
+  handler: async (ctx, { normalizedEmail, waveLabel, assignedAt }) => {
+    const row = await ctx.db
+      .query("registrations")
+      .withIndex("by_normalized_email", (q) =>
+        q.eq("normalizedEmail", normalizedEmail),
+      )
+      .first();
+    if (!row) {
+      return { result: "notFound" as const };
+    }
+    if (row.proLaunchWave === waveLabel) {
+      return { result: "alreadyStamped" as const };
+    }
+    await ctx.db.patch(row._id, {
+      proLaunchWave: waveLabel,
+      proLaunchWaveAssignedAt: assignedAt,
+    });
+    return { result: "stamped" as const };
+  },
+});
+
+type ResendListContactsResponse = {
+  object: "list";
+  has_more: boolean;
+  data: Array<{
+    id: string;
+    email: string;
+    // Resend may include other fields; we only use id + email.
+  }>;
+};
+
+type BackfillStats = {
+  fetched: number;
+  stamped: number;
+  alreadyStamped: number;
+  notFound: number;
+  failed: number;
+};
+
+/**
+ * Page Resend's `GET /contacts?segment_id=...` with cursor pagination
+ * (`after=<contact-id>`) until exhausted, calling
+ * `_stampWaveByNormalizedEmail` for each contact's email.
+ *
+ * Convex action time limit is 10 minutes; at ~244 contacts and one
+ * Resend GET per ~100 plus one Convex mutation per contact, this
+ * comfortably fits in well under a minute.
+ *
+ * All Resend addresses are normalized via the same `trim().toLowerCase()`
+ * convention used at every write site — must match
+ * `registrations.normalizedEmail` semantics or the join would silently
+ * miss rows.
+ */
+export const backfillCanary250 = internalAction({
+  args: {},
+  handler: async (ctx): Promise<BackfillStats> => {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        "[backfillCanary250] RESEND_API_KEY not set — run with the same env that hosts the canary segment.",
+      );
+    }
+
+    if (!Number.isFinite(CANARY_SENT_AT_MS)) {
+      throw new Error(
+        "[backfillCanary250] CANARY_SENT_AT_MS failed Date.parse — check the literal.",
+      );
+    }
+
+    const stats: BackfillStats = {
+      fetched: 0,
+      stamped: 0,
+      alreadyStamped: 0,
+      notFound: 0,
+      failed: 0,
+    };
+
+    let after: string | null = null;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const url = new URL(`${RESEND_API_BASE}/contacts`);
+      url.searchParams.set("segment_id", CANARY_SEGMENT_ID);
+      url.searchParams.set("limit", String(RESEND_PAGE_SIZE));
+      if (after) url.searchParams.set("after", after);
+
+      const res = await fetch(url.toString(), {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "User-Agent": USER_AGENT,
+        },
+      });
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => "<no body>");
+        throw new Error(
+          `[backfillCanary250] Resend list-contacts ${res.status}: ${body}`,
+        );
+      }
+
+      const json = (await res.json()) as ResendListContactsResponse;
+      if (!json || !Array.isArray(json.data)) {
+        throw new Error(
+          `[backfillCanary250] unexpected Resend response shape: ${JSON.stringify(json).slice(0, 200)}`,
+        );
+      }
+
+      for (const contact of json.data) {
+        stats.fetched++;
+        const normalizedEmail = (contact.email ?? "").trim().toLowerCase();
+        if (!normalizedEmail) {
+          stats.failed++;
+          continue;
+        }
+        try {
+          const out = await ctx.runMutation(
+            internal.broadcast.backfillCanaryWaveStamps
+              ._stampWaveByNormalizedEmail,
+            {
+              normalizedEmail,
+              waveLabel: CANARY_WAVE_LABEL,
+              assignedAt: CANARY_SENT_AT_MS,
+            },
+          );
+          if (out.result === "stamped") stats.stamped++;
+          else if (out.result === "alreadyStamped") stats.alreadyStamped++;
+          else if (out.result === "notFound") {
+            stats.notFound++;
+            // Some segment members may have been added directly via the
+            // Resend dashboard rather than coming through the waitlist
+            // (e.g. test addresses, manual additions). Logging masked
+            // so the operator can spot unexpected gaps without raw
+            // emails landing in the dashboard log.
+            console.log(
+              `[backfillCanary250] no registration for ${maskEmail(normalizedEmail)}`,
+            );
+          }
+        } catch (err) {
+          stats.failed++;
+          console.error(
+            `[backfillCanary250] stamp failed for ${maskEmail(normalizedEmail)}:`,
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      }
+
+      if (!json.has_more || json.data.length === 0) break;
+
+      const last = json.data[json.data.length - 1];
+      if (!last?.id) break;
+      after = last.id;
+    }
+
+    console.log(
+      `[backfillCanary250] complete: ${JSON.stringify(stats)}`,
+    );
+
+    return stats;
+  },
+});

--- a/convex/broadcast/backfillCanaryWaveStamps.ts
+++ b/convex/broadcast/backfillCanaryWaveStamps.ts
@@ -147,8 +147,14 @@ export const backfillCanary250 = internalAction({
     let after: string | null = null;
     // eslint-disable-next-line no-constant-condition
     while (true) {
-      const url = new URL(`${RESEND_API_BASE}/contacts`);
-      url.searchParams.set("segment_id", CANARY_SEGMENT_ID);
+      // Resend's per-segment contact-listing endpoint is
+      // `GET /segments/{id}/contacts` (NOT `/contacts?segment_id=...`).
+      // The `/contacts` endpoint exists but its `segment_id` param is
+      // documented inconsistently across Resend's docs pages — only
+      // the `/segments/{id}/contacts` route is canonical.
+      const url = new URL(
+        `${RESEND_API_BASE}/segments/${encodeURIComponent(CANARY_SEGMENT_ID)}/contacts`,
+      );
       url.searchParams.set("limit", String(RESEND_PAGE_SIZE));
       if (after) url.searchParams.set("after", after);
 
@@ -205,6 +211,13 @@ export const backfillCanary250 = internalAction({
             );
           }
         } catch (err) {
+          // sentry-coverage-ok: per-contact stamp failure is counted
+          // into `stats.failed` and surfaced in the action's return
+          // value — that's the operator's visible surface for partial
+          // failures. Re-throwing would abort the loop and leave most
+          // contacts unstamped, defeating the point. Convex auto-Sentry
+          // still captures the underlying mutation throw inside the
+          // mutation itself, before it bubbles up here as a rejection.
           stats.failed++;
           console.error(
             `[backfillCanary250] stamp failed for ${maskEmail(normalizedEmail)}:`,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -138,9 +138,22 @@ export default defineSchema({
     referralCode: v.optional(v.string()),
     referredBy: v.optional(v.string()),
     referralCount: v.optional(v.number()),
+    // Per-row stamp recording which PRO-launch broadcast wave a
+    // registrant landed in (e.g. "canary-250", "wave-2", "wave-3").
+    // Future wave-export actions filter on `proLaunchWave === undefined`
+    // to pick only un-emailed registrants. Optional so existing rows
+    // pass schema validation; the canary-250 backfill stamps the 244
+    // contacts already emailed yesterday, future waves stamp themselves
+    // at export time.
+    proLaunchWave: v.optional(v.string()),
+    proLaunchWaveAssignedAt: v.optional(v.number()),
   })
     .index("by_normalized_email", ["normalizedEmail"])
-    .index("by_referral_code", ["referralCode"]),
+    .index("by_referral_code", ["referralCode"])
+    // Index on the wave stamp so future picks can scan only-stamped
+    // / only-unstamped efficiently without a full table scan against
+    // tens of thousands of registrations.
+    .index("by_proLaunchWave", ["proLaunchWave"]),
 
   // Phase 9 / Todo #223 — Clerk-user referral codes.
   // The `registrations.referralCode` column uses a 6-char hash of


### PR DESCRIPTION
## Summary

The 244 registrations who received yesterday's PRO-launch canary broadcast need a wave stamp in Convex so future wave-export actions can exclude them. Without this stamp, the next wave-export would re-pick them and re-email — exactly the duplication the wave system exists to prevent.

This PR lays the schema + the one-shot backfill. The full wave-export action (pick N unstamped, stamp them, push to a fresh Resend segment per wave) comes in a follow-up PR.

## Why this design

Resend's API doesn't support broadcast subset/sample/exclude (verified via docs):

- `POST /broadcasts` accepts `segment_id` only — no inclusion/exclusion filters.
- `POST /segments` accepts `name` only — segments are membership lists, not query-defined.
- Contacts have `properties` (custom k/v) but no documented query API.

So progressive waves require tracking membership somewhere. Convex is the right source of truth for us — it's already where dedup math runs, and it lets us scan unstamped registrations efficiently.

## Changes

### `convex/schema.ts` — `registrations` table

Two new optional fields + one index:

- `proLaunchWave?: v.optional(v.string())` — wave label (e.g. `"canary-250"`, `"wave-2"`)
- `proLaunchWaveAssignedAt?: v.optional(v.number())` — ms timestamp, mostly for audit
- `.index("by_proLaunchWave", ["proLaunchWave"])` — so the next-wave pick can scan only-unstamped efficiently against tens of thousands of registrations

Both fields optional so existing rows pass schema validation.

### `convex/broadcast/backfillCanaryWaveStamps.ts` (new)

Two exports:

- `_stampWaveByNormalizedEmail` — internal mutation that looks up `registrations` by `normalizedEmail`, patches the wave fields if not already stamped. Idempotent on the wave label.
- `backfillCanary250` — internal action that pages Resend `GET /contacts?segment_id=<canary>` (cursor pagination via `after=<contact-id>`, 100/page max) and stamps each contact's matching registration.

Hard-coded to the canary-250 segment ID and the `sent_at` timestamp from the broadcast — this is a one-off historical backfill, not a generic wave-stamp tool.

PII safety: emails masked in logs (`jo******@example.com` shape) — Convex dashboard is observable to project viewers, raw waitlist addresses must not land in plaintext.

## Test plan

- [x] Pre-push hooks green (typecheck, biome, sentry-coverage, edge bundle, version sync)
- [ ] After merge + Convex deploy: `npx convex run broadcast/backfillCanaryWaveStamps:backfillCanary250`
  - Expect: `{ fetched: 244, stamped: ~244, alreadyStamped: 0, notFound: <small>, failed: 0 }`
  - `notFound` may be non-zero if test addresses or manual additions ended up in the canary segment without a matching `registrations` row — log inspection (masked) to confirm those are expected.
- [ ] Re-run the same command — expect `alreadyStamped` count = previous `stamped` count, `stamped: 0`. Idempotency verified.
- [ ] Spot-check via Data Explorer: filter `registrations` by `proLaunchWave = "canary-250"` — count should match `stamped + alreadyStamped`.

## What comes next (separate PR)

`convex/broadcast/audienceWaveExport.ts:assignAndExportWave({ waveLabel, count })` that:
1. Picks `count` registrations where `proLaunchWave IS NULL` AND not in suppressions/customers, random sample.
2. Stamps each with the new `waveLabel`.
3. Creates a fresh Resend segment via API.
4. Pushes the picked contacts to it.
5. Returns the new `segmentId` for the existing `createProLaunchBroadcast` flow.

That action is the sustainable per-wave primitive — one CLI command per send, no manual dashboard work, no re-emailing previous waves.