### PR TITLE
fix(entitlements): lower stock-analysis tier gate 2→1 (close Pro 403 gap)

### DIFF
--- a/server/__tests__/entitlement-check.test.ts
+++ b/server/__tests__/entitlement-check.test.ts
@@ -62,7 +62,7 @@ function makeEntitlements(tier: number, planKey = "free") {
 
 describe("gateway entitlement check", () => {
   test("getRequiredTier returns tier for gated endpoint", () => {
-    expect(getRequiredTier("/api/market/v1/analyze-stock")).toBe(2);
+    expect(getRequiredTier("/api/market/v1/analyze-stock")).toBe(1);
   });
 
   test("getRequiredTier returns null for ungated endpoint", () => {
@@ -83,7 +83,7 @@ describe("gateway entitlement check", () => {
 
     const body = await result!.json();
     expect(body.error).toBe("Authentication required");
-    expect(body.requiredTier).toBe(2);
+    expect(body.requiredTier).toBe(1);
   });
 
   test("checkEntitlement returns 403 when getEntitlements returns null (fail-closed)", async () => {
@@ -95,7 +95,7 @@ describe("gateway entitlement check", () => {
 
     const body = await result!.json();
     expect(body.error).toBe("Unable to verify entitlements");
-    expect(body.requiredTier).toBe(2);
+    expect(body.requiredTier).toBe(1);
   });
 
   test("checkEntitlement returns 403 for insufficient tier", async () => {
@@ -109,8 +109,19 @@ describe("gateway entitlement check", () => {
 
     const body = await result!.json();
     expect(body.error).toBe("Upgrade required");
-    expect(body.requiredTier).toBe(2);
+    expect(body.requiredTier).toBe(1);
     expect(body.currentTier).toBe(0);
+  });
+
+  test("checkEntitlement returns null for Pro tier (tier=1) on stock analysis", async () => {
+    // Regression: previous tier=2 requirement 403'd real Pro subscribers
+    // calling via Clerk session (no tester key in localStorage). Stock
+    // analysis is marketed as a Pro feature and must accept tier >= 1.
+    vi.mocked(getCachedJson).mockResolvedValueOnce(makeEntitlements(1, "pro_monthly"));
+
+    const req = makeRequest("/api/market/v1/analyze-stock", { "x-user-id": "test-user" });
+    const result = await checkEntitlement(req, "/api/market/v1/analyze-stock", {});
+    expect(result).toBeNull();
   });
 
   test("checkEntitlement returns null for sufficient tier", async () => {

--- a/server/__tests__/entitlement-check.test.ts
+++ b/server/__tests__/entitlement-check.test.ts
@@ -61,8 +61,13 @@ function makeEntitlements(tier: number, planKey = "free") {
 // ---------------------------------------------------------------------------
 
 describe("gateway entitlement check", () => {
-  test("getRequiredTier returns tier for gated endpoint", () => {
-    expect(getRequiredTier("/api/market/v1/analyze-stock")).toBe(1);
+  test.each([
+    "/api/market/v1/analyze-stock",
+    "/api/market/v1/get-stock-analysis-history",
+    "/api/market/v1/backtest-stock",
+    "/api/market/v1/list-stored-stock-backtests",
+  ])("getRequiredTier returns 1 for %s (regression-lock against tier-2 revert)", (path) => {
+    expect(getRequiredTier(path)).toBe(1);
   });
 
   test("getRequiredTier returns null for ungated endpoint", () => {

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -40,12 +40,18 @@ interface CachedEntitlements {
  *
  * Adding a new gated endpoint = adding one line to this map.
  * Endpoints NOT in this map are unrestricted.
+ *
+ * Stock-analysis endpoints sit at tier 1 (Pro) — the productCatalog markets
+ * "AI stock analysis & backtesting" as a Pro feature, and these paths are
+ * also in PREMIUM_RPC_PATHS where the legacy bearer gate accepts tier >= 1.
+ * Tier-2 here would have made the new gate stricter than the legacy one and
+ * 403'd real Pro subscribers calling via Clerk session (no tester key).
  */
 const ENDPOINT_ENTITLEMENTS: Record<string, number> = {
-  '/api/market/v1/analyze-stock': 2,
-  '/api/market/v1/get-stock-analysis-history': 2,
-  '/api/market/v1/backtest-stock': 2,
-  '/api/market/v1/list-stored-stock-backtests': 2,
+  '/api/market/v1/analyze-stock': 1,
+  '/api/market/v1/get-stock-analysis-history': 1,
+  '/api/market/v1/backtest-stock': 1,
+  '/api/market/v1/list-stored-stock-backtests': 1,
 };
 
 const CONVEX_INTERNAL_ENTITLEMENTS_PATH = '/api/internal-entitlements';


### PR DESCRIPTION
## Summary

- Pro subscribers (tier=1) calling `/api/market/v1/{analyze,backtest,...}-stock` via Clerk session (no tester key) were silently 403'd because the new strict `ENDPOINT_ENTITLEMENTS` gate (`tier >= 2`) shadowed the legacy `PREMIUM_RPC_PATHS` bearer gate (`tier >= 1`) on the same paths.
- The gap is structural: `gateway.ts:404` writes `needsLegacyProBearerGate = LEGACY.has(p) && !isTierGated`, so any path in both sets uses ONLY the strict gate. With strict > legacy, the legacy band silently fails.
- Marketing copy at `productCatalog.ts:124` already promises "AI stock analysis & backtesting" as a Pro feature, so tier=1 is the intended threshold. One-line fix in `server/_shared/entitlement-check.ts`: lower the 4 stock paths from tier 2 → 1.
- Adds a regression test asserting tier=1 succeeds on `/analyze-stock`. Previous tests only covered tier=0 (fail) and tier=2 (pass), leaving tier=1 (the gap band) unverified.

## Why it stayed silent

- Client-side `hasPremiumAccess()` hides panels before the RPC fires, so most paying users never trigger the request.
- Testers/admins with `wm-pro-key` or `WORLDMONITOR_VALID_KEYS` bypass the entitlement check entirely via the admin-key shortcut at `gateway.ts:554`. Operators don't see the failure; only fresh-device users with no localStorage tester key hit it.
- API Starter (tier=2) and above were unaffected.

## Test plan

- [x] Existing entitlement-check tests updated for new tier (4 assertions: 2 → 1)
- [x] New regression test: `checkEntitlement returns null for Pro tier (tier=1) on stock analysis`
- [x] All 9 tests in `server/__tests__/entitlement-check.test.ts` pass
- [x] Full PR gate: typecheck, typecheck:api, biome lint, 7479 data tests, edge bundle, 178 edge tests, markdown lint, version:check — all PASS
- [ ] Post-deploy: verify Pro subscriber (tier=1) on a fresh device can hit `/analyze-stock` without 403

## Out of scope (filed separately if needed)

- The structural mismatch between `PREMIUM_RPC_PATHS` and `ENDPOINT_ENTITLEMENTS` having the same paths but different intended semantics. This PR keeps both gates aligned at tier=1 for stock paths; longer-term a single source of truth would prevent recurrence. Documented as a learning at `~/.claude/projects/.../memory/skill_layered_auth_strict_gate_shadows_legacy.md`.