### PR TITLE
chore(pre-push): typecheck convex/ to catch stale _generated/api.d.ts

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -43,3 +43,7 @@ jobs:
       - run: npm ci
       - run: npm run typecheck
       - run: npm run typecheck:api
+      # Mirror the pre-push convex typecheck so direct pushes to main
+      # and `--no-verify` bypasses can't land stale convex/_generated
+      # types. See .husky/pre-push for the rationale.
+      - run: npx tsc --noEmit -p convex/tsconfig.json

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -54,6 +54,13 @@ npm run typecheck || exit 1
 echo "Running API type check..."
 npm run typecheck:api || exit 1
 
+echo "Running Convex type check..."
+# Catches stale convex/_generated/api.d.ts (forgotten `npx convex codegen`
+# after adding a module) and any drift between convex/schema.ts and the
+# code that reads it. Pre-push is the right gate — these errors surface
+# only at convex deploy time otherwise, deep into a release window.
+npx tsc --noEmit -p convex/tsconfig.json || exit 1
+
 echo "Running CJS syntax check..."
 for f in scripts/*.cjs; do
   [ -f "$f" ] && node -c "$f" || exit 1


### PR DESCRIPTION
## Summary

PR #3453 review caught a missing-codegen slip: a new module under `convex/broadcast/` was committed without re-running `npx convex codegen`, so `convex/_generated/api.d.ts` was stale and the import of `internal.broadcast.backfillCanaryWaveStamps` referenced a non-existent type. The pre-push gate ran `typecheck` (root) and `typecheck:api` but not `tsc -p convex/tsconfig.json`, so the error only surfaced in PR review.

## Change

Adds one step to `.husky/pre-push`, between the existing API typecheck and the CJS syntax check:

```bash
echo "Running Convex type check..."
npx tsc --noEmit -p convex/tsconfig.json || exit 1
```

## What this catches

- Stale `convex/_generated/api.d.ts` (forgotten `npx convex codegen` after adding a module).
- Drift between `convex/schema.ts` and code that reads it.
- Any TS error inside `convex/` that the root tsconfig's project references would otherwise miss (the root `typecheck` includes `convex/` only via project refs, which can hide errors when the convex sub-project is misconfigured).

## Test plan

- [x] `npx tsc --noEmit -p convex/tsconfig.json` exits 0 on current main (no preexisting errors to clean up).
- [x] Pre-push hook ran the new step locally on this branch — exit 0.
- [ ] Mental test: a future PR that adds a convex module without running codegen would now fail pre-push with "Property 'X' does not exist on type 'internal.Y'", forcing the operator to run `npx convex codegen` and re-stage `_generated/api.d.ts` before pushing.

## Cost

One extra `tsc --noEmit` invocation per push — same cost shape as the existing `typecheck` and `typecheck:api` steps. Adds maybe 2-5s to pre-push wall time on a warm node_modules.