### PR TITLE
fix(resilience): parity-check actual Redis persistence before lying meta write

### DIFF
--- a/server/worldmonitor/resilience/v1/_shared.ts
+++ b/server/worldmonitor/resilience/v1/_shared.ts
@@ -258,7 +258,7 @@ function normalizeCountryCode(countryCode: string): string {
   return /^[A-Z]{2}$/.test(normalized) ? normalized : '';
 }
 
-function scoreCacheKey(countryCode: string): string {
+export function scoreCacheKey(countryCode: string): string {
   return `${RESILIENCE_SCORE_CACHE_PREFIX}${countryCode}`;
 }
 

--- a/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
@@ -19,6 +19,7 @@ import {
   rankingCacheTagMatches,
   sortRankingItems,
   stampRankingCacheTag,
+  scoreCacheKey,
   warmMissingResilienceScores,
   type ScoreInterval,
 } from './_shared';
@@ -163,6 +164,35 @@ export const getResilienceRanking: ResilienceServiceHandler['getResilienceRankin
   // `greyedOut` with coverage 0, so the response is correct for partial states.
   const coverageRatio = cachedScores.size / countryCodes.length;
   if (coverageRatio >= RANKING_CACHE_MIN_COVERAGE) {
+    // Persistence parity check: confirm the score SETs actually landed in
+    // Redis before declaring success and writing seed-meta. Upstash REST
+    // /pipeline returns `result:'OK'` per command, but under saturated edge-
+    // runtime conditions that OK can be a transport-level acknowledgement
+    // that doesn't translate to durable persistence — observed 2026-04-27
+    // when seed-meta:resilience:ranking said scored=196 while a SCAN of
+    // resilience:score:v16:* returned just 2 keys. Without this check the
+    // meta would lie about success, downstream health flips between OK and
+    // EMPTY, and operators chase phantom TTL/cron issues.
+    //
+    // Sample 20 random keys (cheap: one extra round-trip ~50-200ms on Edge);
+    // refuse to write meta if fewer than half exist. The handler returns the
+    // computed response anyway, so callers still see correct data; only the
+    // cache + meta publish is skipped, letting the next cron retry naturally.
+    const sampleKeys = [...cachedScores.keys()].slice(0, 20).map(scoreCacheKey);
+    if (sampleKeys.length > 0) {
+      const verifyResults = await runRedisPipeline(sampleKeys.map((k) => ['EXISTS', k]));
+      const actualPersisted = verifyResults.filter((r) => r?.result === 1).length;
+      if (actualPersisted < sampleKeys.length * 0.5) {
+        console.warn(
+          `[resilience] persistence parity fail: ${actualPersisted}/${sampleKeys.length} ` +
+          `sampled score keys exist in Redis (cachedScores.size=${cachedScores.size}, ` +
+          `coverage=${(coverageRatio * 100).toFixed(0)}%) — refusing meta write to avoid ` +
+          `lying about ranking publish.`,
+        );
+        return response;
+      }
+    }
+
     // Upstash REST /pipeline is not transactional: each SET can succeed or
     // fail independently. A partial write (ranking OK, meta missed) would
     // leave health.js reading a stale meta over a fresh ranking — the seeder

--- a/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
@@ -135,6 +135,13 @@ export const getResilienceRanking: ResilienceServiceHandler['getResilienceRankin
 
   const cachedScores = await getCachedResilienceScores(countryCodes);
   const missing = countryCodes.filter((countryCode) => !cachedScores.has(countryCode));
+  // Track the country codes whose scores were JUST warmed by this invocation.
+  // The persistence parity check below samples from THIS set specifically —
+  // pre-warmed entries from `getCachedResilienceScores` already proved they
+  // exist (we just read them), so verifying them is uninformative; the keys
+  // whose durability is in question are the ones we just SET via the
+  // batched pipeline inside `warmMissingResilienceScores`.
+  const warmedCountryCodes: string[] = [];
   if (missing.length > 0) {
     try {
       // Merge warm results into cachedScores directly rather than re-reading
@@ -144,7 +151,10 @@ export const getResilienceRanking: ResilienceServiceHandler['getResilienceRankin
       // publish. The warmer already holds every score in memory — trust it.
       // See `feedback_upstash_write_reread_race_in_handler.md`.
       const warmed = await warmMissingResilienceScores(missing.slice(0, SYNC_WARM_LIMIT));
-      for (const [countryCode, score] of warmed) cachedScores.set(countryCode, score);
+      for (const [countryCode, score] of warmed) {
+        cachedScores.set(countryCode, score);
+        warmedCountryCodes.push(countryCode);
+      }
     } catch (err) {
       console.warn('[resilience] ranking warmup failed:', err);
     }
@@ -174,20 +184,33 @@ export const getResilienceRanking: ResilienceServiceHandler['getResilienceRankin
     // meta would lie about success, downstream health flips between OK and
     // EMPTY, and operators chase phantom TTL/cron issues.
     //
-    // Sample 20 random keys (cheap: one extra round-trip ~50-200ms on Edge);
-    // refuse to write meta if fewer than half exist. The handler returns the
-    // computed response anyway, so callers still see correct data; only the
-    // cache + meta publish is skipped, letting the next cron retry naturally.
-    const sampleKeys = [...cachedScores.keys()].slice(0, 20).map(scoreCacheKey);
-    if (sampleKeys.length > 0) {
+    // Critical: sample from `warmedCountryCodes` (entries SET by THIS
+    // invocation), NOT from all of cachedScores. Pre-warmed entries came
+    // from `getCachedResilienceScores` — we just READ them, so they are
+    // tautologically present. The keys whose durability is uncertain are
+    // the ones we just WROTE. A naïve `slice(0, 20)` over cachedScores
+    // creates a blind spot: if the first 20 are pre-warmed and the
+    // durability failure only affects the warmed tail, the check passes
+    // and meta still lies (reviewer catch on PR #3458).
+    //
+    // Within the warmed set, shuffle before slicing so the same N entries
+    // aren't checked every invocation — partial-failure modes that
+    // consistently affect the same subset (e.g. last batch of 30 fails
+    // due to queue saturation) are more likely to be sampled.
+    //
+    // Cost: one extra ~50-200ms round-trip on Edge. Skip entirely when
+    // there were no warmed writes (cache hit on every country).
+    if (warmedCountryCodes.length > 0) {
+      const shuffled = [...warmedCountryCodes].sort(() => Math.random() - 0.5);
+      const sampleKeys = shuffled.slice(0, 20).map(scoreCacheKey);
       const verifyResults = await runRedisPipeline(sampleKeys.map((k) => ['EXISTS', k]));
       const actualPersisted = verifyResults.filter((r) => r?.result === 1).length;
       if (actualPersisted < sampleKeys.length * 0.5) {
         console.warn(
           `[resilience] persistence parity fail: ${actualPersisted}/${sampleKeys.length} ` +
-          `sampled score keys exist in Redis (cachedScores.size=${cachedScores.size}, ` +
-          `coverage=${(coverageRatio * 100).toFixed(0)}%) — refusing meta write to avoid ` +
-          `lying about ranking publish.`,
+          `sampled WARMED score keys exist in Redis (warmed=${warmedCountryCodes.length}, ` +
+          `cachedScores.size=${cachedScores.size}, coverage=${(coverageRatio * 100).toFixed(0)}%) — ` +
+          `refusing meta write to avoid lying about ranking publish.`,
         );
         return response;
       }

--- a/tests/helpers/fake-upstash-redis.mts
+++ b/tests/helpers/fake-upstash-redis.mts
@@ -84,6 +84,13 @@ export function createRedisFetch(fixtures: Record<string, unknown>): FakeRedisSt
           return { result: 'OK' };
         }
 
+        if (verb === 'EXISTS') {
+          // Real Redis EXISTS returns 1/0 for single key, count for multi-key.
+          // The handler's parity check uses single-key form per pipeline entry,
+          // so we just mirror that shape here.
+          return { result: redis.has(redisKey) ? 1 : 0 };
+        }
+
         if (verb === 'ZADD') {
           let added = 0;
           for (let index = 0; index < args.length; index += 2) {

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -308,6 +308,57 @@ describe('resilience ranking contracts', () => {
     assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written despite pipeline-GET race');
   });
 
+  it('parity check: refuses meta write when Upstash returns SET=OK but EXISTS shows keys did not durably persist (2026-04-27 incident)', async () => {
+    // Production observation 2026-04-27 (resilienceIntervals): seed-meta said
+    // scored=196 while a SCAN of resilience:score:v16:* showed only 2 keys.
+    // Mechanism: under saturated edge-runtime conditions, Upstash REST can
+    // return result:'OK' for SETs that don't durably persist. The handler's
+    // existing persistence guard (`persistResults[i]?.result === 'OK'`)
+    // trusts the OK response, so cachedScores.size inflates to N while only
+    // a fraction actually landed — meta lies about success.
+    //
+    // The parity check samples up to 20 score keys via EXISTS BEFORE writing
+    // meta. If <50% of sampled keys exist, refuse the meta write so health
+    // doesn't lie. Simulate this by making SETs return OK in the warm path
+    // but NOT actually mutating the underlying redis map for those keys.
+    const { redis, fetchImpl } = installRedis(RESILIENCE_FIXTURES);
+    redis.set('resilience:static:index:v1', JSON.stringify({
+      countries: ['NO', 'US'],
+      recordCount: 2,
+      failedDatasets: [],
+      seedYear: 2026,
+    }));
+
+    // Hijack /pipeline so SETs to score:v16:* return OK but don't actually
+    // persist (simulating Upstash's optimistic-OK under load). Other commands
+    // (GET, EXISTS for the parity check, ranking + meta SETs) pass through.
+    const optimisticOk = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
+        const commands = JSON.parse(init.body) as Array<Array<string>>;
+        const allScoreSets = commands.length > 0 && commands.every(
+          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v16:'),
+        );
+        if (allScoreSets) {
+          // Return OK without mutating redis — the lying-Upstash scenario.
+          return new Response(
+            JSON.stringify(commands.map(() => ({ result: 'OK' }))),
+            { status: 200 },
+          );
+        }
+      }
+      return fetchImpl(input, init);
+    }) as typeof fetch;
+    globalThis.fetch = optimisticOk;
+
+    await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
+
+    assert.equal(redis.has('resilience:ranking:v16'), false,
+      'ranking must NOT be published when score SETs returned OK but did not durably persist');
+    assert.equal(redis.has('seed-meta:resilience:ranking'), false,
+      'seed-meta must NOT be written when parity check fails — that would be a lying meta');
+  });
+
   it('pipeline SETs apply env prefix so preview warms do not leak into production namespace', async () => {
     // Reviewer regression: passing `raw=true` to runRedisPipeline bypasses the
     // env-based key prefix (preview: / dev:) that isolates preview deploys

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -359,6 +359,81 @@ describe('resilience ranking contracts', () => {
       'seed-meta must NOT be written when parity check fails — that would be a lying meta');
   });
 
+  it('parity check: catches mixed persisted-tail failure (pre-warmed keys exist; new warmed-tail SETs return OK but do not persist)', async () => {
+    // Reviewer regression on PR #3458: a naïve `slice(0, 20)` over
+    // cachedScores would sample the FIRST 20 entries deterministically.
+    // If those first 20 are pre-warmed (already-persisted) score keys
+    // and the durability failure only affects the newly warmed tail,
+    // the parity check would pass and meta would still be written
+    // claiming scored=N — exactly the lying-meta state we're trying to
+    // prevent. The fix samples from `warmedCountryCodes` (entries SET
+    // by THIS invocation) rather than all of cachedScores; pre-warmed
+    // entries came from getCachedResilienceScores so they are
+    // tautologically present and verifying them is uninformative.
+    //
+    // Setup: 4 countries in the static index. Pre-cache 2 of them
+    // (NO + US) so they are tautologically present. The other 2
+    // (YE + ZZ) get warmed via the SET pipeline, but our mock returns
+    // OK without actually persisting them.
+    const { redis, fetchImpl } = installRedis(RESILIENCE_FIXTURES);
+    redis.set('resilience:static:index:v1', JSON.stringify({
+      countries: ['NO', 'US', 'YE', 'ZZ'],
+      recordCount: 4,
+      failedDatasets: [],
+      seedYear: 2026,
+    }));
+    const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
+    // Pre-cache NO + US WITH formula tag so getCachedResilienceScores admits them.
+    redis.set('resilience:score:v16:NO', JSON.stringify({
+      countryCode: 'NO', overallScore: 82, level: 'high',
+      domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
+      lowConfidence: false, imputationShare: 0.05, _formula: 'd6',
+    }));
+    redis.set('resilience:score:v16:US', JSON.stringify({
+      countryCode: 'US', overallScore: 61, level: 'medium',
+      domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
+      lowConfidence: false, imputationShare: 0.1, _formula: 'd6',
+    }));
+
+    // Hijack /pipeline so SETs to score:v16:* return OK but don't persist —
+    // simulating Upstash optimistic-OK on the warmed tail. Other commands
+    // (the bulk GET pre-cache check, EXISTS for parity, ranking + meta SETs)
+    // pass through to the real fake redis.
+    const optimisticOkOnWarmedTail = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
+        const commands = JSON.parse(init.body) as Array<Array<string>>;
+        const allScoreSets = commands.length > 0 && commands.every(
+          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v16:'),
+        );
+        if (allScoreSets) {
+          // Return OK without mutating redis — the warmed-tail keys
+          // (YE, ZZ) "say" they landed but actually don't.
+          return new Response(
+            JSON.stringify(commands.map(() => ({ result: 'OK' }))),
+            { status: 200 },
+          );
+        }
+      }
+      return fetchImpl(input, init);
+    }) as typeof fetch;
+    globalThis.fetch = optimisticOkOnWarmedTail;
+
+    await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
+
+    // Pre-fix (slice(0, 20) over cachedScores): NO + US would be sampled,
+    // both EXIST, parity check passes, meta gets written claiming
+    // scored=4 even though YE + ZZ are missing → lying meta.
+    //
+    // Post-fix (sample from warmedCountryCodes only): YE + ZZ are
+    // sampled, neither exists in Redis, parity check fails, meta
+    // refused.
+    assert.equal(redis.has('resilience:ranking:v16'), false,
+      'ranking must NOT be published when warmed-tail keys returned OK but did not persist (mixed-failure mode)');
+    assert.equal(redis.has('seed-meta:resilience:ranking'), false,
+      'seed-meta must NOT lie when only the warmed tail failed — sampling must focus on warmed entries, not cachedScores broadly');
+  });
+
   it('pipeline SETs apply env prefix so preview warms do not leak into production namespace', async () => {
     // Reviewer regression: passing `raw=true` to runRedisPipeline bypasses the
     // env-based key prefix (preview: / dev:) that isolates preview deploys


### PR DESCRIPTION
## Summary

Production `/api/health` 2026-04-27 reported `resilienceIntervals` status=EMPTY while `seed-meta:resilience:ranking` claimed scored=196. Direct Redis query exposed the meta as **lying**:

```
resilience:intervals:v2:*  →  0 keys      (health reads this; explains EMPTY)
resilience:score:v15:*     →  4 keys      (leftovers, pre-PR #3452)
resilience:score:v16:*     →  2 keys      (BR, CN — current code)
seed-meta:resilience:ranking → count=196, scored=196   ← LYING
seed-meta:resilience:intervals → recordCount=196        ← LYING
```

**Root cause:** under saturated edge-runtime conditions, Upstash REST `/pipeline` returns `result:'OK'` for SETs that don't durably persist. The handler's existing persistence guard (`persistResults[i]?.result === 'OK'` in `_shared.ts:903`) trusts that OK response, so `cachedScores.size` inflates to 196 even when only 6 keys actually land. The coverage gate (≥0.75) passes; meta gets written with scored=196; downstream health reads the lying meta and either reports OK or EMPTY without firing STALE_SEED.

## Fix

Sample-based parity check between the coverage gate and the meta write in `server/worldmonitor/resilience/v1/get-resilience-ranking.ts`:

```ts
const sampleKeys = [...cachedScores.keys()].slice(0, 20).map(scoreCacheKey);
if (sampleKeys.length > 0) {
  const verifyResults = await runRedisPipeline(sampleKeys.map((k) => ['EXISTS', k]));
  const actualPersisted = verifyResults.filter((r) => r?.result === 1).length;
  if (actualPersisted < sampleKeys.length * 0.5) {
    console.warn(`[resilience] persistence parity fail: ...`);
    return response;  // skip cache + meta publish; next cron retries
  }
}
```

Cost: one extra ~50-200ms round-trip on Edge. Benefit: prevents the lying-meta state.

## Test plan

- [x] **1 new regression test** in `tests/resilience-ranking.test.mts` — simulates Upstash returning OK for SETs that don't durably persist (the 2026-04-27 incident shape) and asserts ranking + meta are NOT written.
- [x] **All 16 existing ranking tests pass**, including the `pipeline-GET race` test that simulates write→re-read visibility lag — parity check uses `EXISTS` (not `GET`), so that test's mock correctly falls through to the real fake redis.
- [x] Added `EXISTS` support to `fake-upstash-redis.mts` test helper.
- [x] Exported `scoreCacheKey` from `_shared.ts` (was private; needed by handler for sample-key construction).
- [x] `npm run typecheck` + `typecheck:api` clean
- [x] `biome lint` clean (1 pre-existing complexity warning bumped from 60→61 in fake-redis helper; severity `warn` not `error`, doesn't fail CI)
- [x] `tests/edge-functions.test.mjs` 178/178
- [ ] Production canary: after merge, watch for `[resilience] persistence parity fail` warnings — if they fire intermittently, confirms the underlying Upstash saturation is real (and we're now correctly refusing to lie). If they never fire, the guard is just defensive.

## Related

- Skill: `upstash-rest-pipeline-ok-not-durable-persistence` (the mechanism)
- Skill: `seed-meta-lies-about-recordcount-coverage-gate-bug` (the symptom)
- Sister fix coming in PR #3452: tighten `resilienceIntervals.maxStaleMin` from 20160 (14d) to 1080 (3× 6h cron) — defense-in-depth for visibility on future occurrences.