### PR TITLE
chore(sentry): triage 9 issues — first-party CSP infra suppression + user-prefs 500 provenance

### DIFF
--- a/api/_sentry-common.js
+++ b/api/_sentry-common.js
@@ -78,6 +78,12 @@ function buildEnvelope(err, ctx, runtimeCfg) {
     },
     tags: { surface: 'api', runtime: runtimeCfg.runtime, ...(ctx?.tags ?? {}) },
     extra: ctx?.extra,
+    // Caller-supplied fingerprint overrides Sentry's default grouping.
+    // Use when the error message contains a high-cardinality token (request id,
+    // ephemeral hash) that would otherwise split one logical issue into many.
+    ...(Array.isArray(ctx?.fingerprint) && ctx.fingerprint.length > 0
+      ? { fingerprint: ctx.fingerprint }
+      : {}),
   };
 
   // Envelope format: header line, item header line, item payload line.

--- a/api/_sentry-common.js
+++ b/api/_sentry-common.js
@@ -50,7 +50,14 @@ function parseStack(stack) {
 
 /**
  * @param {unknown} err
- * @param {{ tags?: Record<string, string|number|boolean>, extra?: Record<string, unknown> }} [ctx]
+ * @param {{
+ *   tags?: Record<string, string|number|boolean>,
+ *   extra?: Record<string, unknown>,
+ *   fingerprint?: string[],
+ * }} [ctx] When `fingerprint` is a non-empty array it overrides Sentry's
+ *   default message-based grouping. Use to consolidate one logical issue
+ *   whose error message contains a high-cardinality token (request id,
+ *   trace id) that would otherwise fragment grouping into N issues.
  * @param {{ runtime: 'edge' | 'node', platform: 'javascript' | 'node' }} runtimeCfg
  */
 function buildEnvelope(err, ctx, runtimeCfg) {

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -177,7 +177,9 @@ function buildSentryContext(
       ...(convexRequestId ? { convex_request_id: convexRequestId } : {}),
       // Skip the minified `errName` (e.g. 'I') — it's noise, not signal — but
       // keep meaningful names like ConvexError / TypeError / SyntaxError.
-      ...(errName !== 'unknown' && errName !== 'Error' && errName.length > 2
+      // `> 1` is the minimal guard for single-character noise; all real built-in
+      // error class names are well above that.
+      ...(errName !== 'unknown' && errName !== 'Error' && errName.length > 1
         ? { error_name: errName }
         : {}),
     },

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -66,10 +66,20 @@ export default async function handler(
       return jsonResponse(prefs ?? null, 200, cors);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      // UNAUTHENTICATED leaks here when the Clerk token is valid for our API
-      // but Convex rejects it (audience drift, JWT issuer mismatch). Surface as
-      // 401 so the client clears credentials instead of treating it as 500.
+      // UNAUTHENTICATED on this path means the Clerk token PASSED our edge's
+      // `validateBearerToken` but Convex still rejected it — i.e. genuine
+      // auth/audience/issuer drift between our Clerk JWKS validation and
+      // Convex's auth config (a Clerk JWKS rotation lag, an audience mismatch,
+      // a stale CLERK_JWT_ISSUER_DOMAIN env var). User-bad-token cases are
+      // caught earlier (the `validateBearerToken` 401 above) and never reach
+      // this catch. Capture before returning 401 so the drift surfaces under
+      // a stable Sentry bucket instead of silently 401'ing every request.
       if (msg.includes('UNAUTHENTICATED')) {
+        console.error('[user-prefs] GET convex auth drift:', err);
+        captureSilentError(err, buildSentryContext(err, msg, {
+          method: 'GET', convexFn: 'userPreferences:getPreferences',
+          userId: session.userId, variant, ctx,
+        }));
         return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
       }
       console.error('[user-prefs] GET error:', err);
@@ -115,6 +125,17 @@ export default async function handler(
       return jsonResponse({ error: 'BLOB_TOO_LARGE' }, 400, cors);
     }
     if (msg.includes('UNAUTHENTICATED')) {
+      // See GET branch above — UNAUTHENTICATED here means Clerk-vs-Convex
+      // auth drift (token already passed validateBearerToken). Capture
+      // before returning 401 so the drift is visible.
+      console.error('[user-prefs] POST convex auth drift:', err);
+      captureSilentError(err, buildSentryContext(err, msg, {
+        method: 'POST', convexFn: 'userPreferences:setPreferences',
+        userId: session.userId, variant: body.variant, ctx,
+        schemaVersion: typeof body.schemaVersion === 'number' ? body.schemaVersion : null,
+        expectedSyncVersion: body.expectedSyncVersion,
+        blobSize: body.data !== undefined ? JSON.stringify(body.data).length : 0,
+      }));
       return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
     }
     console.error('[user-prefs] POST error:', err);
@@ -163,7 +184,11 @@ function buildSentryContext(
   const errName = err instanceof Error ? err.name : 'unknown';
   const requestIdMatch = msg.match(/\[Request ID:\s*([a-f0-9]+)\]/i);
   const convexRequestId = requestIdMatch?.[1];
-  const errorShape = /\[Request ID:\s*[a-f0-9]+\]\s*Server Error/i.test(msg) ? 'convex_server_error'
+  // Order matters: UNAUTHENTICATED is more specific than the request-id
+  // server-error shape and must be checked first. Auth drift is its own bucket
+  // so it groups separately from genuine Convex 5xx in the Sentry dashboard.
+  const errorShape = /UNAUTHENTICATED/.test(msg) ? 'convex_auth_drift'
+    : /\[Request ID:\s*[a-f0-9]+\]\s*Server Error/i.test(msg) ? 'convex_server_error'
     : /timeout|timed out|aborted/i.test(msg) ? 'transport_timeout'
     : /fetch failed|network|ECONN|ENOTFOUND|getaddrinfo/i.test(msg) ? 'transport_network'
     : 'unknown';

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -65,8 +65,18 @@ export default async function handler(
       const prefs = await client.query('userPreferences:getPreferences' as any, { variant });
       return jsonResponse(prefs ?? null, 200, cors);
     } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // UNAUTHENTICATED leaks here when the Clerk token is valid for our API
+      // but Convex rejects it (audience drift, JWT issuer mismatch). Surface as
+      // 401 so the client clears credentials instead of treating it as 500.
+      if (msg.includes('UNAUTHENTICATED')) {
+        return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
+      }
       console.error('[user-prefs] GET error:', err);
-      captureSilentError(err, { tags: { route: 'api/user-prefs', method: 'GET' }, ctx });
+      captureSilentError(err, buildSentryContext(err, msg, {
+        method: 'GET', convexFn: 'userPreferences:getPreferences',
+        userId: session.userId, variant, ctx,
+      }));
       return jsonResponse({ error: 'Failed to fetch preferences' }, 500, cors);
     }
   }
@@ -104,8 +114,82 @@ export default async function handler(
     if (msg.includes('BLOB_TOO_LARGE')) {
       return jsonResponse({ error: 'BLOB_TOO_LARGE' }, 400, cors);
     }
+    if (msg.includes('UNAUTHENTICATED')) {
+      return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
+    }
     console.error('[user-prefs] POST error:', err);
-    captureSilentError(err, { tags: { route: 'api/user-prefs', method: 'POST' }, ctx });
+    captureSilentError(err, buildSentryContext(err, msg, {
+      method: 'POST', convexFn: 'userPreferences:setPreferences',
+      userId: session.userId, variant: body.variant, ctx,
+      schemaVersion: typeof body.schemaVersion === 'number' ? body.schemaVersion : null,
+      expectedSyncVersion: body.expectedSyncVersion,
+      blobSize: body.data !== undefined ? JSON.stringify(body.data).length : 0,
+    }));
     return jsonResponse({ error: 'Failed to save preferences' }, 500, cors);
   }
+}
+
+/**
+ * Build a captureSilentError context that carries enough provenance to triage
+ * a 500 from this endpoint without re-running the request:
+ *   - `convex_request_id` tag: the `[Request ID: X]` from Convex's error message,
+ *     queryable in Sentry and grep-able against Convex's dashboard logs.
+ *   - `error_shape` tag: classifies what KIND of failure this is so a single
+ *     Sentry filter splits "Convex internal 500" from "transport timeout" from
+ *     "everything else", instead of every flavor sharing the same opaque bucket.
+ *   - Stable `fingerprint`: forces Sentry to group by (route, method, error_shape)
+ *     rather than by the ever-varying request-id-bearing message — without this,
+ *     each request_id would create a new "issue" and drown the dashboard.
+ */
+function buildSentryContext(
+  err: unknown,
+  msg: string,
+  opts: {
+    method: 'GET' | 'POST';
+    convexFn: string;
+    userId: string;
+    variant?: unknown;
+    ctx?: { waitUntil: (p: Promise<unknown>) => void };
+    schemaVersion?: number | null;
+    expectedSyncVersion?: unknown;
+    blobSize?: number;
+  },
+): {
+  tags: Record<string, string | number>;
+  extra: Record<string, unknown>;
+  fingerprint: string[];
+  ctx?: { waitUntil: (p: Promise<unknown>) => void };
+} {
+  const errName = err instanceof Error ? err.name : 'unknown';
+  const requestIdMatch = msg.match(/\[Request ID:\s*([a-f0-9]+)\]/i);
+  const convexRequestId = requestIdMatch?.[1];
+  const errorShape = /\[Request ID:\s*[a-f0-9]+\]\s*Server Error/i.test(msg) ? 'convex_server_error'
+    : /timeout|timed out|aborted/i.test(msg) ? 'transport_timeout'
+    : /fetch failed|network|ECONN|ENOTFOUND|getaddrinfo/i.test(msg) ? 'transport_network'
+    : 'unknown';
+
+  return {
+    tags: {
+      route: 'api/user-prefs',
+      method: opts.method,
+      convex_fn: opts.convexFn,
+      error_shape: errorShape,
+      ...(convexRequestId ? { convex_request_id: convexRequestId } : {}),
+      // Skip the minified `errName` (e.g. 'I') — it's noise, not signal — but
+      // keep meaningful names like ConvexError / TypeError / SyntaxError.
+      ...(errName !== 'unknown' && errName !== 'Error' && errName.length > 2
+        ? { error_name: errName }
+        : {}),
+    },
+    extra: {
+      userId: opts.userId,
+      variant: typeof opts.variant === 'string' ? opts.variant : 'unknown',
+      messageHead: msg.slice(0, 300),
+      ...(opts.schemaVersion !== undefined ? { schemaVersion: opts.schemaVersion } : {}),
+      ...(opts.expectedSyncVersion !== undefined ? { expectedSyncVersion: opts.expectedSyncVersion } : {}),
+      ...(opts.blobSize !== undefined ? { blobSize: opts.blobSize } : {}),
+    },
+    fingerprint: ['api/user-prefs', opts.method, errorShape],
+    ctx: opts.ctx,
+  };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -446,6 +446,19 @@ Sentry.init({
     // (WORLDMONITOR-NJ).
     if (/Cannot read properties of undefined \(reading 'fetchToken'\)/.test(msg)
         && frames.some(f => /tryToReauthenticate/.test(f.function ?? ''))) return null;
+    // Stale-chunk-after-deploy: modulepreload / dynamic import failures arrive with no
+    // stack trace because the browser fires them as synthetic TypeErrors at fetch time,
+    // not at any first-party call site. The chunk-reload guard auto-reloads the page,
+    // so the user is unaffected — but the Sentry event is still captured. Drop these
+    // even when frames.length === 0 (WORLDMONITOR-Q / WORLDMONITOR-15). The phrases
+    // are runtime-emitted only — our shipped code cannot synthesize them. Browser
+    // variants: Chrome/Edge `Failed to fetch dynamically imported module: <url>`,
+    // Safari `Importing a module script failed.`, Firefox `error loading dynamically
+    // imported module`.
+    if (
+      !hasFirstParty
+      && /(?:Failed to fetch|error loading) dynamically imported module|Importing a module script failed/i.test(msg)
+    ) return null;
     if (hasAnyStack && !hasFirstParty && (
       /\.(?:toLowerCase|trim|indexOf|findIndex) is not a function/.test(msg)
       || /Maximum call stack size exceeded/.test(msg)
@@ -459,7 +472,6 @@ Sentry.init({
       || /^(?:TypeError: )?Failed to fetch$/.test(msg)
       || /^TypeError: NetworkError/.test(msg)
       || /Could not connect to the server/.test(msg)
-      || /(?:Failed to fetch|Importing a module script failed|error loading) dynamically imported module/i.test(msg)
       || (excType === 'SyntaxError' && /^Unexpected (?:token|keyword)/.test(msg))
       || /^SyntaxError: Unexpected (?:token|keyword)/.test(msg)
       || /Invalid or unexpected token/.test(msg)
@@ -497,6 +509,37 @@ function shouldSuppressCspViolation(
     try {
       if (new URL(blockedURI).protocol === 'https:') return true;
     } catch { /* scheme-only values like "blob" fall through */ }
+  }
+  // First-party Convex backend: corporate proxies / privacy extensions that mutate the
+  // page CSP (stripping bare `https:` from connect-src) cause Convex sync calls to be
+  // CSP-blocked even though our policy allows them. Suppress unconditionally for the
+  // *.convex.cloud host so we don't drown Sentry in 1M+ events/month from those users
+  // (WORLDMONITOR-HN). Real first-party CSP regressions on this host are caught by the
+  // staging deploy + uptime check, not by user CSP-violation reports.
+  if (directive === 'connect-src') {
+    try {
+      const host = new URL(blockedURI).hostname;
+      if (/\.convex\.cloud$/.test(host)) return true;
+    } catch { /* scheme-only values fall through */ }
+  }
+  // YouTube IFrame API loader: explicitly allowed by our script-src
+  // (`https://www.youtube.com`), so a block here means a third party (extension,
+  // corporate proxy, in-app webview) mutated the policy. Not actionable — embedded
+  // video remains broken in that user's environment regardless of our code
+  // (WORLDMONITOR-HP).
+  if (
+    (directive === 'script-src-elem' || directive === 'script-src')
+    && /^https:\/\/www\.youtube\.com\/iframe_api(?:\?|$)/.test(blockedURI)
+  ) return true;
+  // Zscaler enterprise content-filter proxy: `gateway.zscloud.net` is injected into
+  // corporate users' frames by Zscaler's web filter agent. We never load it ourselves;
+  // it's inserted into the host page outside our control (WORLDMONITOR-HT). Match by
+  // parsed hostname so a `gateway.zscloud.net.evil.com` lookalike doesn't bypass the
+  // surrounding signal filters.
+  if (directive === 'frame-src') {
+    try {
+      if (new URL(blockedURI).hostname === 'gateway.zscloud.net') return true;
+    } catch { /* scheme-only values fall through */ }
   }
   // Browser extensions or injected scripts.
   if (/^(?:chrome|moz|safari(?:-web)?)-extension/.test(sourceFile) || /^(?:chrome|moz|safari(?:-web)?)-extension/.test(blockedURI)) return true;

--- a/src/main.ts
+++ b/src/main.ts
@@ -500,6 +500,7 @@ function shouldSuppressCspViolation(
   blockedURI: string,
   sourceFile: string,
   cspConnectSrcAllowsHttps: boolean,
+  firstPartyConvexHost: string | null,
 ): boolean {
   // Skip non-enforced violations (report-only from dual-CSP interaction).
   if (disposition && disposition !== 'enforce') return true;
@@ -511,15 +512,16 @@ function shouldSuppressCspViolation(
     } catch { /* scheme-only values like "blob" fall through */ }
   }
   // First-party Convex backend: corporate proxies / privacy extensions that mutate the
-  // page CSP (stripping bare `https:` from connect-src) cause Convex sync calls to be
-  // CSP-blocked even though our policy allows them. Suppress unconditionally for the
-  // *.convex.cloud host so we don't drown Sentry in 1M+ events/month from those users
-  // (WORLDMONITOR-HN). Real first-party CSP regressions on this host are caught by the
-  // staging deploy + uptime check, not by user CSP-violation reports.
-  if (directive === 'connect-src') {
+  // page CSP (stripping bare `https:` from connect-src) cause our Convex sync calls to
+  // be CSP-blocked even though our policy allows them. Suppress unconditionally for OUR
+  // configured Convex deployment hostname (`VITE_CONVEX_URL`) so we don't drown Sentry
+  // in 1M+ events/month from those users (WORLDMONITOR-HN). Convex is multi-tenant —
+  // do NOT suppress all `*.convex.cloud`, that would silently swallow blocks to foreign/
+  // attacker-controlled Convex projects. Match by exact hostname only. Real first-party
+  // CSP regressions on this host are caught by the staging deploy + uptime check.
+  if (directive === 'connect-src' && firstPartyConvexHost) {
     try {
-      const host = new URL(blockedURI).hostname;
-      if (/\.convex\.cloud$/.test(host)) return true;
+      if (new URL(blockedURI).hostname === firstPartyConvexHost) return true;
     } catch { /* scheme-only values fall through */ }
   }
   // YouTube IFrame API loader: explicitly allowed by our script-src
@@ -582,6 +584,16 @@ const _cspAllowsHttps = (() => {
   if (!metaEl) return false;
   return metaAllows;
 })();
+// Resolve our configured Convex deployment hostname once. Convex is multi-tenant —
+// the CSP filter must scope its first-party suppression to OUR specific hostname,
+// not all *.convex.cloud, otherwise blocks to foreign/attacker tenants get silently
+// dropped too. Returns null when the env var is missing (dev/test); the filter
+// then leaves connect-src violations to fall through to the next rule.
+const _firstPartyConvexHost = ((): string | null => {
+  const url = import.meta.env.VITE_CONVEX_URL;
+  if (typeof url !== 'string' || url.length === 0) return null;
+  try { return new URL(url).hostname; } catch { return null; }
+})();
 // @ts-ignore — expose for tests
 window.__shouldSuppressCspViolation = shouldSuppressCspViolation;
 
@@ -595,6 +607,7 @@ window.addEventListener('securitypolicyviolation', (e) => {
     blocked,
     e.sourceFile ?? '',
     _cspAllowsHttps,
+    _firstPartyConvexHost,
   )) return;
   Sentry.captureMessage(`CSP: ${e.effectiveDirective} blocked ${blocked || '(inline)'}`, {
     level: 'warning',

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -157,43 +157,61 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
   describe('first-party infrastructure (mutated user CSP)', () => {
     // Corporate proxies / privacy extensions strip bare `https:` from connect-src in
     // the user's effective policy, blocking our first-party Convex backend even though
-    // our policy allows it. Suppress unconditionally for known infra hosts so we don't
-    // drown Sentry in events from those users (WORLDMONITOR-HN).
-    it('suppresses connect-src to *.convex.cloud regardless of cspAllowsHttps', () => {
-      assert.ok(suppress('enforce', 'connect-src', 'https://tacit-curlew-777.convex.cloud/api/1.34.0/sync', '', false));
+    // our policy allows it. Suppress unconditionally for our exact configured Convex
+    // host so we don't drown Sentry in events from those users (WORLDMONITOR-HN).
+    // Convex is multi-tenant — must NOT broaden to all *.convex.cloud (would silently
+    // suppress blocks to foreign / attacker-controlled tenants).
+    const FIRST_PARTY_CONVEX = 'tacit-curlew-777.convex.cloud';
+
+    it('suppresses connect-src to OUR configured convex host', () => {
+      assert.ok(suppress('enforce', 'connect-src', 'https://tacit-curlew-777.convex.cloud/api/1.34.0/sync', '', false, FIRST_PARTY_CONVEX));
     });
 
-    it('suppresses connect-src to *.convex.cloud subdomains', () => {
-      assert.ok(suppress('enforce', 'connect-src', 'https://abc-def-123.convex.cloud/api/x', '', false));
+    it('does NOT suppress connect-src to a DIFFERENT *.convex.cloud tenant (multi-tenant safety)', () => {
+      // Multi-tenant Convex: any other adjective-noun-N.convex.cloud is a foreign
+      // project. A real user-side block to one of these is signal, not noise.
+      assert.ok(!suppress('enforce', 'connect-src', 'https://abc-def-123.convex.cloud/api/x', '', false, FIRST_PARTY_CONVEX));
     });
 
-    it('does NOT suppress connect-src to non-convex domains masquerading as convex.cloud-suffix', () => {
-      assert.ok(!suppress('enforce', 'connect-src', 'https://convex.cloud.evil.com/api', '', false));
+    it('does NOT suppress connect-src to a similarly-named *.convex.cloud tenant', () => {
+      // e.g. attacker-controlled `tacit-curlew-778.convex.cloud` — exact-hostname
+      // match prevents a typo/lookalike from being whitelisted.
+      assert.ok(!suppress('enforce', 'connect-src', 'https://tacit-curlew-778.convex.cloud/api/1.34.0/sync', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress connect-src to suffix-spoof lookalike `convex.cloud.evil.com`', () => {
+      assert.ok(!suppress('enforce', 'connect-src', 'https://convex.cloud.evil.com/api', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress connect-src to OUR convex host when firstPartyConvexHost is null (env unconfigured)', () => {
+      // Dev/test environments without VITE_CONVEX_URL set should leave the filter
+      // open — falls through to other rules (extension, blob, etc.) instead of
+      // accidentally whitelisting on a stale closure.
+      assert.ok(!suppress('enforce', 'connect-src', 'https://tacit-curlew-777.convex.cloud/api/1.34.0/sync', '', false, null));
     });
 
     it('suppresses script-src-elem for YouTube IFrame API loader', () => {
-      assert.ok(suppress('enforce', 'script-src-elem', 'https://www.youtube.com/iframe_api', '', false));
+      assert.ok(suppress('enforce', 'script-src-elem', 'https://www.youtube.com/iframe_api', '', false, FIRST_PARTY_CONVEX));
     });
 
     it('suppresses script-src-elem for YouTube IFrame API with cache-buster', () => {
-      assert.ok(suppress('enforce', 'script-src-elem', 'https://www.youtube.com/iframe_api?ver=1', '', false));
+      assert.ok(suppress('enforce', 'script-src-elem', 'https://www.youtube.com/iframe_api?ver=1', '', false, FIRST_PARTY_CONVEX));
     });
 
     it('suppresses script-src for YouTube IFrame API loader (browser-variant directive)', () => {
-      assert.ok(suppress('enforce', 'script-src', 'https://www.youtube.com/iframe_api', '', false));
+      assert.ok(suppress('enforce', 'script-src', 'https://www.youtube.com/iframe_api', '', false, FIRST_PARTY_CONVEX));
     });
 
     it('does NOT suppress other youtube.com paths under script-src-elem', () => {
-      assert.ok(!suppress('enforce', 'script-src-elem', 'https://www.youtube.com/embed/abc', '', false));
+      assert.ok(!suppress('enforce', 'script-src-elem', 'https://www.youtube.com/embed/abc', '', false, FIRST_PARTY_CONVEX));
     });
 
     it('suppresses frame-src for Zscaler corporate proxy injection', () => {
-      assert.ok(suppress('enforce', 'frame-src', 'https://gateway.zscloud.net/auth/sso', '', false));
+      assert.ok(suppress('enforce', 'frame-src', 'https://gateway.zscloud.net/auth/sso', '', false, FIRST_PARTY_CONVEX));
     });
 
     it('does NOT suppress connect-src to Zscaler (only frame-src is the injection)', () => {
-      // Cleared by the bare `https:` connect-src case if cspConnectSrcAllowsHttps; otherwise should pass through
-      assert.ok(!suppress('enforce', 'connect-src', 'https://gateway.zscloud.net/api', '', false));
+      assert.ok(!suppress('enforce', 'connect-src', 'https://gateway.zscloud.net/api', '', false, FIRST_PARTY_CONVEX));
     });
   });
 

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -154,6 +154,49 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
     });
   });
 
+  describe('first-party infrastructure (mutated user CSP)', () => {
+    // Corporate proxies / privacy extensions strip bare `https:` from connect-src in
+    // the user's effective policy, blocking our first-party Convex backend even though
+    // our policy allows it. Suppress unconditionally for known infra hosts so we don't
+    // drown Sentry in events from those users (WORLDMONITOR-HN).
+    it('suppresses connect-src to *.convex.cloud regardless of cspAllowsHttps', () => {
+      assert.ok(suppress('enforce', 'connect-src', 'https://tacit-curlew-777.convex.cloud/api/1.34.0/sync', '', false));
+    });
+
+    it('suppresses connect-src to *.convex.cloud subdomains', () => {
+      assert.ok(suppress('enforce', 'connect-src', 'https://abc-def-123.convex.cloud/api/x', '', false));
+    });
+
+    it('does NOT suppress connect-src to non-convex domains masquerading as convex.cloud-suffix', () => {
+      assert.ok(!suppress('enforce', 'connect-src', 'https://convex.cloud.evil.com/api', '', false));
+    });
+
+    it('suppresses script-src-elem for YouTube IFrame API loader', () => {
+      assert.ok(suppress('enforce', 'script-src-elem', 'https://www.youtube.com/iframe_api', '', false));
+    });
+
+    it('suppresses script-src-elem for YouTube IFrame API with cache-buster', () => {
+      assert.ok(suppress('enforce', 'script-src-elem', 'https://www.youtube.com/iframe_api?ver=1', '', false));
+    });
+
+    it('suppresses script-src for YouTube IFrame API loader (browser-variant directive)', () => {
+      assert.ok(suppress('enforce', 'script-src', 'https://www.youtube.com/iframe_api', '', false));
+    });
+
+    it('does NOT suppress other youtube.com paths under script-src-elem', () => {
+      assert.ok(!suppress('enforce', 'script-src-elem', 'https://www.youtube.com/embed/abc', '', false));
+    });
+
+    it('suppresses frame-src for Zscaler corporate proxy injection', () => {
+      assert.ok(suppress('enforce', 'frame-src', 'https://gateway.zscloud.net/auth/sso', '', false));
+    });
+
+    it('does NOT suppress connect-src to Zscaler (only frame-src is the injection)', () => {
+      // Cleared by the bare `https:` connect-src case if cspConnectSrcAllowsHttps; otherwise should pass through
+      assert.ok(!suppress('enforce', 'connect-src', 'https://gateway.zscloud.net/api', '', false));
+    });
+  });
+
   describe('real violations pass through', () => {
     it('reports third-party script-src violation', () => {
       assert.ok(!suppress('enforce', 'script-src', 'https://evil.com/crypto-miner.js', '', true));

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -219,7 +219,7 @@ describe('dynamic-module-import failures (stale chunk after deploy)', () => {
 
   for (const msg of dynamicImportErrors) {
     it(`suppresses "${msg.slice(0, 60)}..." with empty stack`, () => {
-      const event = makeEvent(msg, msg.startsWith('TypeError:') ? 'TypeError' : 'TypeError', []);
+      const event = makeEvent(msg, 'TypeError', []);
       assert.equal(beforeSend(event), null, `"${msg}" with empty stack should be suppressed (chunk-reload guard handles it)`);
     });
 

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -133,12 +133,14 @@ describe('first-party file detection', () => {
 // ─── P1: empty-stack behavior for network/timeout errors ─────────────────
 
 describe('empty-stack network/timeout errors are NOT suppressed', () => {
+  // Note: dynamic-module-import failures are intentionally suppressed even with empty
+  // stacks — that exact phrase is emitted only by the runtime on stale-chunk-after-
+  // deploy, which the chunk-reload guard already auto-recovers. See the dedicated
+  // suite below for that case (WORLDMONITOR-Q / WORLDMONITOR-15).
   const networkErrors = [
     'TypeError: Failed to fetch',
     'TypeError: NetworkError when attempting to fetch resource.',
     'Could not connect to the server',
-    'Failed to fetch dynamically imported module: https://worldmonitor.app/assets/panels-abc.js',
-    'Importing a module script failed.',
     'Operation timed out',
     'signal timed out',
     'Invalid or unexpected token',
@@ -193,6 +195,42 @@ describe('empty-stack network/timeout errors are NOT suppressed', () => {
     it(`lets through SyntaxError (split: value="${value}") with first-party stack`, () => {
       const event = makeEvent(value, type, [firstPartyFrame()]);
       assert.ok(beforeSend(event) !== null);
+    });
+  }
+});
+
+// ─── Stale-chunk-after-deploy: dynamic-module-import failures ────────────
+//
+// Modulepreload / dynamic-import failures arrive with no stack trace because the
+// browser fires them as synthetic TypeErrors at fetch time, not at any first-party
+// call site. The chunk-reload guard auto-reloads the page, so the user is unaffected
+// — but the Sentry event is still captured. We suppress these even with empty stacks
+// because the exact phrase is only emitted by the runtime, never by our shipped code
+// (WORLDMONITOR-Q / WORLDMONITOR-15).
+
+describe('dynamic-module-import failures (stale chunk after deploy)', () => {
+  const dynamicImportErrors = [
+    'Failed to fetch dynamically imported module: https://worldmonitor.app/assets/panels-abc.js',
+    'Failed to fetch dynamically imported module: https://www.worldmonitor.app/assets/index-DSkSc57y.js',
+    'Importing a module script failed.',
+    'TypeError: Importing a module script failed.',
+    'error loading dynamically imported module',
+  ];
+
+  for (const msg of dynamicImportErrors) {
+    it(`suppresses "${msg.slice(0, 60)}..." with empty stack`, () => {
+      const event = makeEvent(msg, msg.startsWith('TypeError:') ? 'TypeError' : 'TypeError', []);
+      assert.equal(beforeSend(event), null, `"${msg}" with empty stack should be suppressed (chunk-reload guard handles it)`);
+    });
+
+    it(`suppresses "${msg.slice(0, 60)}..." with confirmed third-party stack`, () => {
+      const event = makeEvent(msg, 'TypeError', [extensionFrame()]);
+      assert.equal(beforeSend(event), null);
+    });
+
+    it(`lets through "${msg.slice(0, 60)}..." with first-party stack`, () => {
+      const event = makeEvent(msg, 'TypeError', [firstPartyFrame()]);
+      assert.ok(beforeSend(event) !== null, `"${msg}" with first-party stack should NOT be suppressed`);
     });
   }
 });


### PR DESCRIPTION
## Summary
- Suppress 3 high-volume CSP issues caused by corporate-proxy / privacy-extension users mutating their effective CSP policy: `*.convex.cloud` connect-src (HN, 1.1M events / 9886 users), `www.youtube.com/iframe_api` script-src (HP, 29K / 12K), `gateway.zscloud.net` frame-src — Zscaler enterprise injection (HT, 3.4K / 1.3K). All three suppressions are scoped to specific hosts/paths and added under `shouldSuppressCspViolation`; first-party CSP regressions still surface via the staging deploy + uptime check, not user-side violation reports.
- Drop the `frames>0` requirement on the `beforeSend` dynamic-import-failure filter so empty-stack stale-chunk-after-deploy events from Chrome/Edge/Safari/Firefox are suppressed (Q + 15, ~4K events combined). The `chunk-reload` guard already auto-recovers; the exact phrase is runtime-emitted only and cannot originate from our own shipped code.
- Add provenance to `api/user-prefs.ts` 500 events (PC, 117 events / 27 users today). The catch path was returning the same opaque "I: [Request ID: X] Server Error" for every distinct failure mode and the per-event `request_id` was breaking Sentry grouping. Now: returns 401 on UNAUTHENTICATED (was 500), tags every error with `convex_request_id` / `error_shape` / `convex_fn` / `error_name`, attaches `userId` / `variant` / `schemaVersion` / `expectedSyncVersion` / `blobSize` / `messageHead` to extras, and pins a stable `fingerprint = ['api/user-prefs', method, error_shape]` so future occurrences group cleanly and the request id becomes a queryable tag.
- Supporting plumbing: `api/_sentry-common.js` envelope builder gains optional `ctx.fingerprint` passthrough (purely additive — only emitted when caller passes a non-empty array; existing callers in `notification-channels.ts` etc. unaffected).
- Code-review nits applied: Zscaler check uses parsed `URL.hostname` (not regex prefix — defends against `gateway.zscloud.net.evil.com` lookalikes); `error_shape` `transport_timeout` regex narrowed (dropped bare `signal` token; `aborted` already covers AbortSignal-aborted errors).
- Sentry side: 8 of 9 issues marked resolved (`inNextRelease: true`) — HN, HP, HT, Q, 15, PB (one-off object-src), P9 (transient 502 amid OK calls), P8 (operator-side Resend "restricted_api_key" — error message is self-explanatory). PA (Convex OCC on `broadcastEventCounts`) was already fixed by PR #3449 (table dropped, aggregate-at-read) — resolved by reference. PC left open intentionally; will re-triage on next occurrence using the new tags.

## Test plan
- [x] `npm run typecheck` (4.4s)
- [x] `npm run typecheck:api` (1.5s)
- [x] CJS syntax check on all `scripts/*.cjs`
- [x] `npm run lint` (biome — 0 errors, 217 pre-existing warnings unchanged)
- [x] `npm run test:data` (7515/7515 — 1st run flaked on jsdelivr font fetch in `tests/brief-carousel.test.mjs`, unrelated network-dep test, retry passed)
- [x] Edge function bundle check across all `api/*.js`
- [x] `node --test tests/edge-functions.test.mjs` (178/178)
- [x] `npm run lint:md` (0 errors)
- [x] `npm run version:check` (2.8.0 sync OK)
- [x] `tests/csp-filter.test.mjs` 43/43 — +9 new cases for convex.cloud / YouTube IFrame API / Zscaler / non-suffix-spoof negatives
- [x] `tests/sentry-beforesend.test.mjs` 167/167 — split dynamic-import into its own dedicated suite (15 new assertions covering Chrome/Edge/Safari/Firefox variants × empty/third-party/first-party stack)
- [ ] Verify in production after deploy: HN/HP/HT events stop accumulating; PC re-emerges with new tags (then triage from `convex_request_id` against Convex dashboard logs)