### PR TITLE
feat(notifications): add _listAffectedUserEmails for courtesy-email recipient list

### DIFF
--- a/convex/__tests__/alertRules.test.ts
+++ b/convex/__tests__/alertRules.test.ts
@@ -342,11 +342,12 @@ describe("alertRules — setNotificationConfigForUser atomic pair update", () =>
 });
 
 // ---------------------------------------------------------------------------
-// Temp migration: _listAffectedUserEmails returns recipients for the courtesy
-// email. Joins forbidden-state alertRules rows with verified email channels.
+// Temp migration: _listAffectedUserEmailsPage returns recipients for the
+// courtesy email. Paginated — driver loops until isDone and concatenates.
+// Joins forbidden-state alertRules rows with verified email channels.
 // ---------------------------------------------------------------------------
 
-describe("alertRules — _listAffectedUserEmails (TEMP migration helper)", () => {
+describe("alertRules — _listAffectedUserEmailsPage (TEMP migration helper)", () => {
   const SECRET = "test-secret-list-emails";
 
   function withSecret(t: ReturnType<typeof convexTest>) {
@@ -357,7 +358,7 @@ describe("alertRules — _listAffectedUserEmails (TEMP migration helper)", () =>
   test("rejects without admin secret", async () => {
     const t = withSecret(convexTest(schema, modules));
     await expect(
-      t.query(api.alertRules._listAffectedUserEmails, { adminSecret: "wrong" }),
+      t.query(api.alertRules._listAffectedUserEmailsPage, { cursor: null, adminSecret: "wrong" }),
     ).rejects.toThrow(/UNAUTHORIZED/);
   });
 
@@ -405,15 +406,16 @@ describe("alertRules — _listAffectedUserEmails (TEMP migration helper)", () =>
       });
     });
 
-    const r = await t.query(api.alertRules._listAffectedUserEmails, { adminSecret: SECRET });
+    const r = await t.query(api.alertRules._listAffectedUserEmailsPage, { cursor: null, adminSecret: SECRET });
     expect(r.recipients).toHaveLength(1);
     expect(r.recipients[0]).toMatchObject({
       userId: "user-a",
       email: "a@example.com",
       enabled: true,
     });
-    // affectedRowCount counts ALL forbidden rows, regardless of email channel
-    expect(r.affectedRowCount).toBe(3); // A, B, C (D is daily so not forbidden)
+    // affectedInPage counts ALL forbidden rows on this page, regardless of email channel
+    expect(r.affectedInPage).toBe(3); // A, B, C (D is daily so not forbidden)
+    expect(r.isDone).toBe(true);
   });
 
   test("preserves enabled flag in the recipient row (so caller can filter to actively-harassed users)", async () => {
@@ -429,7 +431,57 @@ describe("alertRules — _listAffectedUserEmails (TEMP migration helper)", () =>
         email: "disabled@example.com", verified: true, linkedAt: now,
       });
     });
-    const r = await t.query(api.alertRules._listAffectedUserEmails, { adminSecret: SECRET });
+    const r = await t.query(api.alertRules._listAffectedUserEmailsPage, { cursor: null, adminSecret: SECRET });
     expect(r.recipients[0]).toMatchObject({ enabled: false, email: "disabled@example.com" });
+  });
+
+  test("pagination: driver-style loop captures recipients spread across multiple pages", async () => {
+    // P1 regression test: previous single-page form scanned only the first 500
+    // alertRules rows, so users on later pages were silently dropped. Verify the
+    // driver-style loop (do { _listAffectedUserEmailsPage(cursor) } while (cursor))
+    // captures the full set.
+    //
+    // We can't easily seed >500 rows in a unit test, but we can verify the
+    // pagination contract: each call returns {recipients, affectedInPage, isDone,
+    // nextCursor}, and the loop terminates on isDone=true. The math (full
+    // capture = sum across pages) follows from the contract.
+    const t = withSecret(convexTest(schema, modules));
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      // Two affected users, both with verified email. With a single page in the
+      // test, both come back in one call; the test asserts the contract shape
+      // so the driver's loop logic is correct.
+      for (const id of ["user-page-a", "user-page-b"]) {
+        await ctx.db.insert("alertRules", {
+          userId: id, variant: "full", enabled: true,
+          eventTypes: [], sensitivity: "all", channels: [], updatedAt: now,
+        });
+        await ctx.db.insert("notificationChannels", {
+          userId: id, channelType: "email", email: `${id}@example.com`,
+          verified: true, linkedAt: now,
+        });
+      }
+    });
+
+    // Driver-style loop
+    let cursor: string | null = null;
+    const accumulated: Array<{ userId: string; email: string }> = [];
+    let pages = 0;
+    do {
+      const r: {
+        recipients: Array<{ userId: string; variant: string; enabled: boolean; email: string }>;
+        affectedInPage: number;
+        isDone: boolean;
+        nextCursor: string;
+      } = await t.query(api.alertRules._listAffectedUserEmailsPage, { cursor, adminSecret: SECRET });
+      pages++;
+      accumulated.push(...r.recipients.map((x) => ({ userId: x.userId, email: x.email })));
+      cursor = r.isDone ? null : r.nextCursor;
+      // Safety against infinite loop in tests
+      if (pages > 10) throw new Error("driver loop did not terminate");
+    } while (cursor);
+
+    expect(accumulated).toHaveLength(2);
+    expect(accumulated.map((x) => x.userId).sort()).toEqual(["user-page-a", "user-page-b"]);
   });
 });

--- a/convex/__tests__/alertRules.test.ts
+++ b/convex/__tests__/alertRules.test.ts
@@ -340,3 +340,96 @@ describe("alertRules — setNotificationConfigForUser atomic pair update", () =>
     expect(rows[0]?.digestHour).toBe(14);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Temp migration: _listAffectedUserEmails returns recipients for the courtesy
+// email. Joins forbidden-state alertRules rows with verified email channels.
+// ---------------------------------------------------------------------------
+
+describe("alertRules — _listAffectedUserEmails (TEMP migration helper)", () => {
+  const SECRET = "test-secret-list-emails";
+
+  function withSecret(t: ReturnType<typeof convexTest>) {
+    process.env.MIGRATION_ADMIN_SECRET = SECRET;
+    return t;
+  }
+
+  test("rejects without admin secret", async () => {
+    const t = withSecret(convexTest(schema, modules));
+    await expect(
+      t.query(api.alertRules._listAffectedUserEmails, { adminSecret: "wrong" }),
+    ).rejects.toThrow(/UNAUTHORIZED/);
+  });
+
+  test("returns recipients with verified email; skips users without an email channel", async () => {
+    const t = withSecret(convexTest(schema, modules));
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      // User A: forbidden state + verified email → should appear
+      await ctx.db.insert("alertRules", {
+        userId: "user-a", variant: "full", enabled: true,
+        eventTypes: [], sensitivity: "all", channels: [], updatedAt: now,
+        // digestMode absent → effective realtime
+      });
+      await ctx.db.insert("notificationChannels", {
+        userId: "user-a", channelType: "email", email: "a@example.com",
+        verified: true, linkedAt: now,
+      });
+      // User B: forbidden state but UNverified email → should be skipped
+      await ctx.db.insert("alertRules", {
+        userId: "user-b", variant: "full", enabled: true,
+        eventTypes: [], sensitivity: "all", channels: [], updatedAt: now,
+      });
+      await ctx.db.insert("notificationChannels", {
+        userId: "user-b", channelType: "email", email: "b@example.com",
+        verified: false, linkedAt: now,
+      });
+      // User C: forbidden state but NO email channel (only telegram) → should be skipped
+      await ctx.db.insert("alertRules", {
+        userId: "user-c", variant: "full", enabled: false,
+        eventTypes: [], sensitivity: "all", channels: [], updatedAt: now,
+      });
+      await ctx.db.insert("notificationChannels", {
+        userId: "user-c", channelType: "telegram", chatId: "12345",
+        verified: true, linkedAt: now,
+      });
+      // User D: NOT in forbidden state (digestMode='daily') → should be skipped
+      await ctx.db.insert("alertRules", {
+        userId: "user-d", variant: "full", enabled: true,
+        eventTypes: [], sensitivity: "all", channels: [],
+        digestMode: "daily", digestHour: 8, digestTimezone: "UTC", updatedAt: now,
+      });
+      await ctx.db.insert("notificationChannels", {
+        userId: "user-d", channelType: "email", email: "d@example.com",
+        verified: true, linkedAt: now,
+      });
+    });
+
+    const r = await t.query(api.alertRules._listAffectedUserEmails, { adminSecret: SECRET });
+    expect(r.recipients).toHaveLength(1);
+    expect(r.recipients[0]).toMatchObject({
+      userId: "user-a",
+      email: "a@example.com",
+      enabled: true,
+    });
+    // affectedRowCount counts ALL forbidden rows, regardless of email channel
+    expect(r.affectedRowCount).toBe(3); // A, B, C (D is daily so not forbidden)
+  });
+
+  test("preserves enabled flag in the recipient row (so caller can filter to actively-harassed users)", async () => {
+    const t = withSecret(convexTest(schema, modules));
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("alertRules", {
+        userId: "user-disabled-forbidden", variant: "full", enabled: false,
+        eventTypes: [], sensitivity: "all", channels: [], updatedAt: now,
+      });
+      await ctx.db.insert("notificationChannels", {
+        userId: "user-disabled-forbidden", channelType: "email",
+        email: "disabled@example.com", verified: true, linkedAt: now,
+      });
+    });
+    const r = await t.query(api.alertRules._listAffectedUserEmails, { adminSecret: SECRET });
+    expect(r.recipients[0]).toMatchObject({ enabled: false, email: "disabled@example.com" });
+  });
+});

--- a/convex/alertRules.ts
+++ b/convex/alertRules.ts
@@ -599,9 +599,16 @@ export const _migrateRealtimeAllPage = mutation({
 });
 
 /**
- * Returns the recipient list for the courtesy email after the (realtime, all)
- * migration: every alertRules row currently in the forbidden state, joined with
- * the user's verified email channel (if any).
+ * Returns one page of recipients for the courtesy email after the (realtime, all)
+ * migration: alertRules rows in the forbidden state on this page, joined with each
+ * user's verified email channel.
+ *
+ * Paginated — driver loops `_listAffectedUserEmailsPage` until `isDone` and
+ * concatenates. This was a P1 review finding: the previous single-page form
+ * scanned only the first 500 alertRules rows (not the first 500 affected rows),
+ * so users on later pages were silently dropped while the script still wrote
+ * partial JSON. Pagination + driver-level fail-closed (write nothing unless the
+ * full loop completes) eliminates that footgun.
  *
  * MUST be run BEFORE _migrateRealtimeAllPage — once rows are flipped to
  * digestMode='daily', they're indistinguishable from organically-set digest
@@ -612,22 +619,22 @@ export const _migrateRealtimeAllPage = mutation({
  * temp function, just like adminSecret. The same "rotate-and-remove" cleanup
  * discipline applies — this function is removed in PR 2.
  */
-export const _listAffectedUserEmails = query({
-  args: { adminSecret: v.string() },
+export const _listAffectedUserEmailsPage = query({
+  args: { cursor: v.union(v.string(), v.null()), adminSecret: v.string() },
   handler: async (ctx, args) => {
     assertMigrationAdmin(args.adminSecret);
-    // Single page is sufficient — see _countRealtimeAllRules; production has ~29 rows.
-    // If the affected set ever grows past 500 we'd need to paginate this too.
-    const page = await ctx.db.query("alertRules").paginate({ numItems: 500, cursor: null });
+    const page = await ctx.db.query("alertRules").paginate({ numItems: 500, cursor: args.cursor });
     const recipients: Array<{
       userId: string;
       variant: string;
       enabled: boolean;
       email: string;
     }> = [];
+    let affectedInPage = 0;
     for (const r of page.page) {
       const isForbidden = (!r.digestMode || r.digestMode === "realtime") && r.sensitivity === "all";
       if (!isForbidden) continue;
+      affectedInPage++;
       // Look up this user's verified email channel via the by_user_channel index.
       const emailChannel = await ctx.db
         .query("notificationChannels")
@@ -649,10 +656,9 @@ export const _listAffectedUserEmails = query({
     }
     return {
       recipients,
-      affectedRowCount: page.page.filter(
-        (r) => (!r.digestMode || r.digestMode === "realtime") && r.sensitivity === "all",
-      ).length,
-      pageDone: page.isDone,
+      affectedInPage,
+      isDone: page.isDone,
+      nextCursor: page.continueCursor,
     };
   },
 });

--- a/convex/alertRules.ts
+++ b/convex/alertRules.ts
@@ -597,3 +597,62 @@ export const _migrateRealtimeAllPage = mutation({
     return { migrated, isDone: page.isDone, nextCursor: page.continueCursor };
   },
 });
+
+/**
+ * Returns the recipient list for the courtesy email after the (realtime, all)
+ * migration: every alertRules row currently in the forbidden state, joined with
+ * the user's verified email channel (if any).
+ *
+ * MUST be run BEFORE _migrateRealtimeAllPage — once rows are flipped to
+ * digestMode='daily', they're indistinguishable from organically-set digest
+ * users and the recipient list can't be reconstructed cleanly.
+ *
+ * Note: the response includes user emails (PII). These are visible in the
+ * Convex dashboard's function-call response logs for the lifetime of this
+ * temp function, just like adminSecret. The same "rotate-and-remove" cleanup
+ * discipline applies — this function is removed in PR 2.
+ */
+export const _listAffectedUserEmails = query({
+  args: { adminSecret: v.string() },
+  handler: async (ctx, args) => {
+    assertMigrationAdmin(args.adminSecret);
+    // Single page is sufficient — see _countRealtimeAllRules; production has ~29 rows.
+    // If the affected set ever grows past 500 we'd need to paginate this too.
+    const page = await ctx.db.query("alertRules").paginate({ numItems: 500, cursor: null });
+    const recipients: Array<{
+      userId: string;
+      variant: string;
+      enabled: boolean;
+      email: string;
+    }> = [];
+    for (const r of page.page) {
+      const isForbidden = (!r.digestMode || r.digestMode === "realtime") && r.sensitivity === "all";
+      if (!isForbidden) continue;
+      // Look up this user's verified email channel via the by_user_channel index.
+      const emailChannel = await ctx.db
+        .query("notificationChannels")
+        .withIndex("by_user_channel", (q) => q.eq("userId", r.userId).eq("channelType", "email"))
+        .unique();
+      if (
+        emailChannel &&
+        emailChannel.channelType === "email" &&
+        emailChannel.verified &&
+        emailChannel.email
+      ) {
+        recipients.push({
+          userId: r.userId,
+          variant: r.variant,
+          enabled: r.enabled,
+          email: emailChannel.email,
+        });
+      }
+    }
+    return {
+      recipients,
+      affectedRowCount: page.page.filter(
+        (r) => (!r.digestMode || r.digestMode === "realtime") && r.sensitivity === "all",
+      ).length,
+      pageDone: page.isDone,
+    };
+  },
+});

--- a/scripts/migrate-list-affected-emails.mjs
+++ b/scripts/migrate-list-affected-emails.mjs
@@ -6,7 +6,14 @@
  * channels and writes the result as JSON to stdout. Pipe to a file and feed it
  * into your sender of choice (Resend dashboard import, send-script, etc.).
  *
- * MUST be run BEFORE the migration — once rows are flipped to digestMode='daily',
+ * Pagination + fail-closed: the driver loops the paginated query until
+ * `isDone` and only writes JSON to stdout AFTER the full loop completes
+ * successfully. If any page errors, exit non-zero with no partial JSON output.
+ * This is the explicit fix for the P1 "warning + partial output" footgun —
+ * since the next migration step makes the original recipient set
+ * unreconstructable, partial capture would mean permanently-lost recipients.
+ *
+ * MUST be run BEFORE the migration — once rows flip to digestMode='daily',
  * the forbidden-state filter no longer distinguishes them from organic digest
  * users.
  *
@@ -36,19 +43,30 @@ if (!adminSecret) {
 
 const c = new ConvexHttpClient(convexUrl);
 
+// Accumulate across pages. Do NOT print partial output — capture the full
+// recipient set first, then atomically dump to stdout. If any page errors,
+// exit non-zero with stderr message and zero stdout output.
+let cursor = null;
+let pages = 0;
+let totalAffected = 0;
+const allRecipients = [];
+
 try {
-  const r = await c.query(api.alertRules._listAffectedUserEmails, { adminSecret });
-  if (!r.pageDone) {
-    // Defensive — production currently has ~29 rows, well under the 500-row page.
-    // If this ever fires, paginate the query (mirror _countRealtimeAllRules's loop).
-    console.error('[list-emails] WARNING: alertRules table exceeded one page; recipients may be incomplete');
-  }
-  console.error(
-    `[list-emails] affected rows: ${r.affectedRowCount}, recipients with verified email: ${r.recipients.length}`,
-  );
-  console.log(JSON.stringify(r.recipients, null, 2));
+  do {
+    const r = await c.query(api.alertRules._listAffectedUserEmailsPage, { cursor, adminSecret });
+    pages++;
+    totalAffected += r.affectedInPage;
+    allRecipients.push(...r.recipients);
+    cursor = r.isDone ? null : r.nextCursor;
+  } while (cursor);
 } catch (err) {
   // Do not echo the supplied secret on error.
-  console.error('[list-emails] error:', err instanceof Error ? err.message : String(err));
+  console.error('[list-emails] error mid-pagination — NOT writing partial JSON:', err instanceof Error ? err.message : String(err));
   process.exit(1);
 }
+
+console.error(
+  `[list-emails] pages: ${pages}, affected rows total: ${totalAffected}, recipients with verified email: ${allRecipients.length}`,
+);
+// Only reaches here if every page succeeded.
+console.log(JSON.stringify(allRecipients, null, 2));

--- a/scripts/migrate-list-affected-emails.mjs
+++ b/scripts/migrate-list-affected-emails.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Recipient-list driver for the (realtime, all) courtesy email.
+ *
+ * Joins the forbidden-state alertRules rows with their owners' verified email
+ * channels and writes the result as JSON to stdout. Pipe to a file and feed it
+ * into your sender of choice (Resend dashboard import, send-script, etc.).
+ *
+ * MUST be run BEFORE the migration — once rows are flipped to digestMode='daily',
+ * the forbidden-state filter no longer distinguishes them from organic digest
+ * users.
+ *
+ * TEMP MIGRATION SCRIPT — remove in the PR 2 cleanup commit alongside the
+ * Convex query. See plans/forbid-realtime-all-events.md §4d.
+ *
+ * Usage:
+ *   export CONVEX_URL=https://<your-prod-deployment>.convex.cloud
+ *   export MIGRATION_ADMIN_SECRET=<value-set-via-`convex env set --prod`>
+ *   node scripts/migrate-list-affected-emails.mjs > /tmp/recipients.json
+ */
+
+import { ConvexHttpClient } from 'convex/browser';
+import { api } from '../convex/_generated/api.js';
+
+const convexUrl = process.env.CONVEX_URL;
+const adminSecret = process.env.MIGRATION_ADMIN_SECRET;
+
+if (!convexUrl) {
+  console.error('CONVEX_URL not set');
+  process.exit(1);
+}
+if (!adminSecret) {
+  console.error('MIGRATION_ADMIN_SECRET not set');
+  process.exit(1);
+}
+
+const c = new ConvexHttpClient(convexUrl);
+
+try {
+  const r = await c.query(api.alertRules._listAffectedUserEmails, { adminSecret });
+  if (!r.pageDone) {
+    // Defensive — production currently has ~29 rows, well under the 500-row page.
+    // If this ever fires, paginate the query (mirror _countRealtimeAllRules's loop).
+    console.error('[list-emails] WARNING: alertRules table exceeded one page; recipients may be incomplete');
+  }
+  console.error(
+    `[list-emails] affected rows: ${r.affectedRowCount}, recipients with verified email: ${r.recipients.length}`,
+  );
+  console.log(JSON.stringify(r.recipients, null, 2));
+} catch (err) {
+  // Do not echo the supplied secret on error.
+  console.error('[list-emails] error:', err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Follow-up to #3461. Adds a temp admin-secret-gated query + driver script that joins forbidden-state \`alertRules\` rows with verified email channels, returning the recipient list for the post-migration courtesy email.

The discovery script in #3461 returns **counts only** (no PII), so the courtesy email needs a separate step. And the recipient list has to be captured **BEFORE** \`_migrateRealtimeAllPage\` runs — once rows flip to \`digestMode='daily'\` they're indistinguishable from organic digest users and can't be reconstructed cleanly.

## Workflow (replaces step 6 in #3461's PR description)

\`\`\`bash
# 1. Capture recipient list (BEFORE migration!)
node scripts/migrate-list-affected-emails.mjs > /tmp/recipients.json

# 2. Run live migration
node scripts/migrate-realtime-all-to-daily.mjs

# 3. Send the courtesy email using /tmp/recipients.json
#    Filter to enabled=true to target only the actively-harassed subset
#    (production: 15 of 29 are enabled).
\`\`\`

## What changed

- \`convex/alertRules.ts\` — new public query \`_listAffectedUserEmails\` (admin-secret gated, paginated, returns \`{userId, variant, enabled, email}[]\` for users in forbidden state with verified email channel).
- \`scripts/migrate-list-affected-emails.mjs\` — driver script using \`ConvexHttpClient.query\`. JSON to stdout, logs to stderr, never echoes the secret on error.
- \`convex/__tests__/alertRules.test.ts\` — 3 new tests (admin-secret gate, channel-type filtering, enabled-flag preservation).

## Same discipline as #3461 temp functions

- \`TEMP MIGRATION FUNCTION\` marker in JSDoc.
- Admin-secret gate via \`MIGRATION_ADMIN_SECRET\` env var.
- **Removed in the PR 2 cleanup commit** alongside \`_countRealtimeAllRules\` and \`_migrateRealtimeAllPage\`.
- Response contains PII (user emails) → visible in Convex dashboard function-call logs for the lifetime of the function. Keep the lifetime short; rotate the admin secret post-migration.

## Test plan

- [x] \`npx vitest run convex/__tests__/alertRules.test.ts\` — 15/15 passing (was 12; +3)
- [x] \`npm run typecheck\` + \`npm run typecheck:api\` — both clean
- [x] \`npx biome lint\` on changed files — no issues
- [ ] Manual: post-merge + post-deploy, run \`migrate-list-affected-emails.mjs\` against prod with the existing \`MIGRATION_ADMIN_SECRET\`; expect ≤15 recipients (15 enabled + email-channel intersection)