### PR TITLE
chore(sentry): suppress ms-browser-extension + about: CSP noise (round 2 triage)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -543,12 +543,17 @@ function shouldSuppressCspViolation(
       if (new URL(blockedURI).hostname === 'gateway.zscloud.net') return true;
     } catch { /* scheme-only values fall through */ }
   }
-  // Browser extensions or injected scripts.
-  if (/^(?:chrome|moz|safari(?:-web)?)-extension/.test(sourceFile) || /^(?:chrome|moz|safari(?:-web)?)-extension/.test(blockedURI)) return true;
+  // Browser extensions or injected scripts. `ms-browser-extension://` is Edge's
+  // scheme for legacy/internal extensions (WORLDMONITOR-JM).
+  if (/^(?:chrome|moz|safari(?:-web)?|ms-browser)-extension/.test(sourceFile) || /^(?:chrome|moz|safari(?:-web)?|ms-browser)-extension/.test(blockedURI)) return true;
   // blob: — browsers report "blob" (scheme-only) or "blob:https://...".
   if (blockedURI === 'blob' || /^blob:/.test(sourceFile) || /^blob:/.test(blockedURI)) return true;
   // eval/inline/data.
   if (blockedURI === 'eval' || blockedURI === 'inline' || blockedURI === 'data' || /^data:/.test(blockedURI)) return true;
+  // about: — browsers report "about" (scheme-only) or "about:blank" / "about:srcdoc"
+  // for iframes created by extensions, ad-injectors, or Smart TV browsers (Samsung
+  // Internet on Tizen). We never set frame src to about:* ourselves (WORLDMONITOR-JQ).
+  if (blockedURI === 'about' || /^about:/.test(blockedURI)) return true;
   // Android WebView video poster injection.
   if (blockedURI === 'android-webview-video-poster') return true;
   // Own manifest.webmanifest — stale CSP cache hit.

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -82,6 +82,14 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
     it('suppresses safari-web-extension', () => {
       assert.ok(suppress('enforce', 'script-src', 'safari-web-extension://abc', '', false));
     });
+
+    it('suppresses ms-browser-extension blocked URI (Edge)', () => {
+      assert.ok(suppress('enforce', 'font-src', 'ms-browser-extension://abc/font.woff2', '', false));
+    });
+
+    it('suppresses ms-browser-extension source file (Edge)', () => {
+      assert.ok(suppress('enforce', 'script-src', 'https://x.com/a.js', 'ms-browser-extension://abc/inject.js', false));
+    });
   });
 
   describe('scheme-only and special values', () => {
@@ -115,6 +123,18 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
 
     it('suppresses android-webview-video-poster', () => {
       assert.ok(suppress('enforce', 'img-src', 'android-webview-video-poster', '', false));
+    });
+
+    it('suppresses about (scheme-only) for frame-src — Smart TV browsers / extensions', () => {
+      assert.ok(suppress('enforce', 'frame-src', 'about', '', false));
+    });
+
+    it('suppresses about:blank frame-src', () => {
+      assert.ok(suppress('enforce', 'frame-src', 'about:blank', '', false));
+    });
+
+    it('suppresses about:srcdoc frame-src', () => {
+      assert.ok(suppress('enforce', 'frame-src', 'about:srcdoc', '', false));
     });
   });
 


### PR DESCRIPTION
## Summary
Round-2 Sentry triage on top of #3460 (now merged). Two more CSP-violation issues that fall through the existing `shouldSuppressCspViolation` filter, both clearly third-party noise:

- **WORLDMONITOR-JM** (39 events / 21 users on Edge): `font-src` blocked `ms-browser-extension://...` — Microsoft Edge's extension scheme, the variant of `chrome|moz|safari(?:-web)?`-extension our regex already handled. Extended the regex to `(?:chrome|moz|safari(?:-web)?|ms-browser)-extension` so `blockedURI` and `sourceFile` matches stay symmetric.
- **WORLDMONITOR-JQ** (23 events / 18 users on Samsung Internet / Tizen): `frame-src` blocked `about` (scheme-only) — Smart TV browsers, ad-injectors, and some extensions create `about:blank` / `about:srcdoc` iframes. We never set frame `src` to `about:*` ourselves. New branch suppresses bare `about` plus any `about:*` URI.

Both issues marked `resolved/inNextRelease` in Sentry — they auto-reopen if the suppression somehow misses them after deploy.

Two issues from the same triage pass were intentionally **left open** rather than filtered:
- WORLDMONITOR-66 (`TimeoutError: signal timed out`, 82/72): the existing `signal timed out` rule in `beforeSend` is stack-gated by design, since AbortSignal-based timeouts CAN come from our own fetch calls. Old, low-volume, no actionable lead.
- WORLDMONITOR-P1 (`Dodo checkout declined`, 3/2): deliberate operational signal at `src/components/checkout-failure-banner.ts:32` (`Sentry.captureMessage(..., { level: 'warning' })`). Low volume, intentional.

## Test plan
- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS
- [x] CJS syntax check on all `scripts/*.cjs` — PASS
- [x] `npm run lint` (biome) — 0 errors
- [x] `npm run test:data` — 7522/7522
- [x] Edge function bundle check — PASS
- [x] `node --test tests/edge-functions.test.mjs` — 178/178
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — 2.8.0 sync OK
- [x] `tests/csp-filter.test.mjs` — 49/49 (+5: ms-browser-extension URI, ms-browser-extension source, about scheme-only, about:blank, about:srcdoc)
- [ ] Verify in production after deploy: JM/JQ events stop accumulating