### PR TITLE
feat(notifications): show amount paid + discount in new-sub admin email

### DIFF
--- a/convex/payments/subscriptionEmails.ts
+++ b/convex/payments/subscriptionEmails.ts
@@ -7,6 +7,7 @@
 
 import { v } from "convex/values";
 import { internalAction } from "../_generated/server";
+import { PRODUCT_CATALOG } from "../config/productCatalog";
 
 const RESEND_URL = "https://api.resend.com/emails";
 const FROM = "World Monitor <noreply@worldmonitor.app>";
@@ -211,6 +212,67 @@ function userWelcomeHtml(planName: string, planKey: string): string {
 }
 
 /**
+ * Format a minor-unit amount (cents) into "$X.XX USD" / "€X.XX EUR" etc.
+ * Falls back to "<amount> <currency>" if the currency lacks a known symbol.
+ */
+const CURRENCY_SYMBOL: Record<string, string> = {
+  USD: "$", EUR: "€", GBP: "£", CAD: "$", AUD: "$", JPY: "¥", INR: "₹",
+};
+function formatMoney(amountMinor: number, currency: string): string {
+  const cur = currency.toUpperCase();
+  const symbol = CURRENCY_SYMBOL[cur] ?? "";
+  // JPY (and a few others) have no minor unit — Dodo still passes integers
+  // in the smallest unit, but JPY's "smallest unit" is the yen itself.
+  const divisor = cur === "JPY" ? 1 : 100;
+  const major = (amountMinor / divisor).toFixed(divisor === 1 ? 0 : 2);
+  return symbol ? `${symbol}${major} ${cur}` : `${major} ${cur}`;
+}
+
+/**
+ * Build the Amount/Discount rows for the admin notification.
+ * Compares the actual recurring charge against the catalog list price to
+ * surface the discount delta — that's the signal "did this user pay full
+ * price or use a code", which the raw subscription_id never communicated.
+ */
+function buildPriceRowsHtml(args: {
+  planKey: string;
+  recurringPreTaxAmount?: number;
+  currency?: string;
+  taxInclusive?: boolean;
+  discountId?: string;
+}): string {
+  const rows: string[] = [];
+  const currency = args.currency ?? "USD";
+  const paid = args.recurringPreTaxAmount;
+  const listCents = PRODUCT_CATALOG[args.planKey]?.priceCents;
+
+  if (typeof paid === "number") {
+    const taxNote = args.taxInclusive ? " (tax incl.)" : " (pre-tax)";
+    rows.push(
+      `<tr><td style="color: #888; padding-right: 16px;">Amount Paid:</td><td style="color: #fff;">${formatMoney(paid, currency)}${taxNote}</td></tr>`,
+    );
+    if (typeof listCents === "number" && listCents > 0 && listCents !== paid) {
+      const savedCents = listCents - paid;
+      const pct = Math.round((savedCents / listCents) * 100);
+      rows.push(
+        `<tr><td style="color: #888; padding-right: 16px;">List Price:</td><td style="color: #fff;">${formatMoney(listCents, currency)}</td></tr>`,
+      );
+      if (savedCents > 0) {
+        rows.push(
+          `<tr><td style="color: #888; padding-right: 16px;">Saved:</td><td style="color: #4ade80;">${formatMoney(savedCents, currency)} (${pct}% off)</td></tr>`,
+        );
+      }
+    }
+  }
+  if (args.discountId) {
+    rows.push(
+      `<tr><td style="color: #888; padding-right: 16px;">Discount:</td><td style="color: #fff; font-size: 12px;">${args.discountId}</td></tr>`,
+    );
+  }
+  return rows.join("");
+}
+
+/**
  * Send welcome email to user + admin notification on new subscription.
  * Scheduled from handleSubscriptionActive via ctx.scheduler.
  */
@@ -220,6 +282,10 @@ export const sendSubscriptionEmails = internalAction({
     planKey: v.string(),
     userId: v.string(),
     subscriptionId: v.string(),
+    recurringPreTaxAmount: v.optional(v.number()),
+    currency: v.optional(v.string()),
+    taxInclusive: v.optional(v.boolean()),
+    discountId: v.optional(v.string()),
   },
   handler: async (_ctx, args) => {
     const apiKey = process.env.RESEND_API_KEY;
@@ -242,7 +308,16 @@ export const sendSubscriptionEmails = internalAction({
     );
     console.log(`[subscriptionEmails] Welcome email sent to ${args.userEmail}`);
 
-    // 2. Admin notification
+    // 2. Admin notification — leads with what the user actually paid (and how
+    // it compares to list price) instead of the opaque subscription_id, which
+    // is rarely the question being asked when this email lands.
+    const priceRows = buildPriceRowsHtml({
+      planKey: args.planKey,
+      recurringPreTaxAmount: args.recurringPreTaxAmount,
+      currency: args.currency,
+      taxInclusive: args.taxInclusive,
+      discountId: args.discountId,
+    });
     await sendEmail(
       apiKey,
       ADMIN_EMAIL,
@@ -252,8 +327,8 @@ export const sendSubscriptionEmails = internalAction({
         <table style="font-size: 14px; line-height: 1.8;">
           <tr><td style="color: #888; padding-right: 16px;">Plan:</td><td style="color: #fff;">${planName}</td></tr>
           <tr><td style="color: #888; padding-right: 16px;">Email:</td><td style="color: #fff;">${args.userEmail}</td></tr>
+          ${priceRows}
           <tr><td style="color: #888; padding-right: 16px;">User ID:</td><td style="color: #fff; font-size: 12px;">${args.userId}</td></tr>
-          <tr><td style="color: #888; padding-right: 16px;">Subscription:</td><td style="color: #fff; font-size: 12px;">${args.subscriptionId}</td></tr>
         </table>
       </div>`,
     );

--- a/convex/payments/subscriptionEmails.ts
+++ b/convex/payments/subscriptionEmails.ts
@@ -251,7 +251,18 @@ function buildPriceRowsHtml(args: {
     rows.push(
       `<tr><td style="color: #888; padding-right: 16px;">Amount Paid:</td><td style="color: #fff;">${formatMoney(paid, currency)}${taxNote}</td></tr>`,
     );
-    if (typeof listCents === "number" && listCents > 0 && listCents !== paid) {
+    // List Price / Saved comparison is USD-only. PRODUCT_CATALOG.priceCents is
+    // hard-coded in USD, so subtracting it from a non-USD `paid` (Dodo's
+    // adaptive-currency mode bills EUR/GBP/etc.) would produce a meaningless
+    // delta with the wrong currency label. Skip the comparison rows in that
+    // case rather than show misleading numbers — Amount Paid + Discount are
+    // still rendered.
+    if (
+      currency.toUpperCase() === "USD" &&
+      typeof listCents === "number" &&
+      listCents > 0 &&
+      listCents !== paid
+    ) {
       const savedCents = listCents - paid;
       const pct = Math.round((savedCents / listCents) * 100);
       rows.push(
@@ -281,7 +292,11 @@ export const sendSubscriptionEmails = internalAction({
     userEmail: v.string(),
     planKey: v.string(),
     userId: v.string(),
-    subscriptionId: v.string(),
+    // Optional: previously rendered as a "Subscription:" row in the admin
+    // email, now dropped (opaque sub_… IDs were never the question being
+    // answered when the email landed). Kept as v.optional so any in-flight
+    // scheduled action enqueued before this deploy still validates on retry.
+    subscriptionId: v.optional(v.string()),
     recurringPreTaxAmount: v.optional(v.number()),
     currency: v.optional(v.string()),
     taxInclusive: v.optional(v.boolean()),

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -29,6 +29,10 @@ interface DodoSubscriptionData {
   next_billing_date?: string | number | Date;
   cancelled_at?: string | number | Date;
   metadata?: Record<string, string>;
+  recurring_pre_tax_amount?: number;
+  currency?: string;
+  tax_inclusive?: boolean;
+  discount_id?: string | null;
 }
 
 interface DodoPaymentData {
@@ -378,6 +382,10 @@ export async function handleSubscriptionActive(
         planKey,
         userId,
         subscriptionId: data.subscription_id,
+        recurringPreTaxAmount: data.recurring_pre_tax_amount,
+        currency: data.currency,
+        taxInclusive: data.tax_inclusive,
+        discountId: data.discount_id ?? undefined,
       },
     );
   }

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -381,7 +381,6 @@ export async function handleSubscriptionActive(
         userEmail: email,
         planKey,
         userId,
-        subscriptionId: data.subscription_id,
         recurringPreTaxAmount: data.recurring_pre_tax_amount,
         currency: data.currency,
         taxInclusive: data.tax_inclusive,


### PR DESCRIPTION
## Summary
- The admin "[WM] New User Subscribed" email surfaced the Dodo `subscription_id` (`sub_…`), which is the wrong signal — when this email lands the actual question is *"did the user pay full price or use a discount, and how much?"*. The opaque ID never answers that.
- Replaced the `Subscription:` row with **Amount Paid** (formatted from `recurring_pre_tax_amount` + `currency`, with a tax-inclusive / pre-tax note), **List Price** (from `PRODUCT_CATALOG[planKey].priceCents` — single source of truth), **Saved** (`$X.XX (NN% off)`, only when there's a delta), and **Discount** (raw `discount_id`, only when present).
- Threaded `recurring_pre_tax_amount` / `currency` / `tax_inclusive` / `discount_id` through `DodoSubscriptionData` → `handleSubscriptionActive` → `sendSubscriptionEmails` scheduler args. These fields already arrive on Dodo's `subscription.active` payload via existing `data` passthrough — no webhook changes.
- JPY handled (no minor unit divisor); unknown currencies fall back to `<amount> <CUR>` without a symbol.

Example for a Pro Monthly user paying $31.99 (list $39.99) with a code:

```
Plan:        Pro (Monthly)
Email:       user@example.com
Amount Paid: $31.99 USD (pre-tax)
List Price:  $39.99 USD
Saved:       $8.00 USD (20% off)
Discount:    dsc_…
User ID:     user_…
```

## Test plan
- [x] `npm run typecheck` + `typecheck:api` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run test:data` — 7546 / 7546 pass
- [x] `node --test convex/__tests__/webhook.test.ts` — 14 / 14 pass (covers `subscription.active` scheduler call shape)
- [x] Manual: verified `recurring_pre_tax_amount` is on Dodo's Subscription type (`node_modules/dodopayments/resources/subscriptions.d.ts:254`); webhook handler already passes `rawPayload.data` through verbatim, so no schema change at the wire layer.
- [ ] Post-deploy: trigger one real test-mode subscription with `WM20`-style discount and visually confirm the new rows render in the admin inbox.