### PR TITLE
fix(user-prefs): structured ConvexError kinds — kill 50-events/hour CONFLICT retry loop

### DIFF
--- a/api/_convex-error.js
+++ b/api/_convex-error.js
@@ -1,0 +1,59 @@
+/**
+ * Convex client error introspection for edge-runtime catch paths.
+ *
+ * Convex's HTTP runtime propagates `ConvexError.data` to the client ONLY when
+ * the server-side throw passes object-typed data. String-data ConvexErrors
+ * (e.g. `throw new ConvexError("CONFLICT")`) arrive at the client as a plain
+ * `Error("[Request ID: X] Server Error")` with `.data === undefined` — a
+ * `msg.includes('CONFLICT')` check NEVER matches and the throw gets
+ * misclassified as 500. See `node_modules/convex/dist/esm/browser/
+ * http_client.js:244` — when `respJSON.errorData === void 0` the client
+ * falls through to `throw new Error(respJSON.errorMessage)`.
+ *
+ * Always throw `ConvexError({ kind, ... })` with object data on the server,
+ * and read the kind via {@link extractConvexErrorKind} on the edge.
+ *
+ * Pure JS so test files (`.mjs`) and edge handlers (`.ts`) can both import
+ * directly without going through a build step. JSDoc carries the types.
+ */
+
+/**
+ * Extract the named-error `kind` from a Convex client throw. Prefers the
+ * structured `err.data.kind` (server-side `ConvexError({ kind, ... })`),
+ * falls back to substring-matching the legacy string-data error message
+ * (`ConvexError("CONFLICT")`) for the deploy-ordering window where the
+ * Vercel build may run against an older Convex deployment.
+ *
+ * @param {unknown} err
+ * @param {string} msg `err.message` (passed in to avoid re-coercing in
+ *   callers that already computed it).
+ * @returns {string | null} the kind, or null when neither path matches.
+ */
+export function extractConvexErrorKind(err, msg) {
+  const data = /** @type {{ data?: unknown } | null | undefined} */ (err)?.data;
+  if (data && typeof data === 'object' && 'kind' in data) {
+    const kind = /** @type {Record<string, unknown>} */ (data).kind;
+    if (typeof kind === 'string') return kind;
+  }
+  if (msg.includes('CONFLICT')) return 'CONFLICT';
+  if (msg.includes('BLOB_TOO_LARGE')) return 'BLOB_TOO_LARGE';
+  if (msg.includes('UNAUTHENTICATED')) return 'UNAUTHENTICATED';
+  return null;
+}
+
+/**
+ * Read a numeric field from `err.data` (e.g. `actualSyncVersion`,
+ * `BLOB_TOO_LARGE.size`). Returns undefined when the field is missing or
+ * not a number, so callers can build a strict response contract via
+ * `field !== undefined ? { ..., field } : { ... }`.
+ *
+ * @param {unknown} err
+ * @param {string} field
+ * @returns {number | undefined}
+ */
+export function readConvexErrorNumber(err, field) {
+  const data = /** @type {{ data?: unknown } | null | undefined} */ (err)?.data;
+  if (!data || typeof data !== 'object' || !(field in data)) return undefined;
+  const raw = /** @type {Record<string, unknown>} */ (data)[field];
+  return typeof raw === 'number' ? raw : undefined;
+}

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -16,6 +16,8 @@ import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { jsonResponse } from './_json-response.js';
 // @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from './_sentry-edge.js';
+// @ts-expect-error — JS module, no declaration file
+import { extractConvexErrorKind, readConvexErrorNumber } from './_convex-error.js';
 import { ConvexHttpClient } from 'convex/browser';
 import { validateBearerToken } from '../server/auth-session';
 
@@ -120,14 +122,13 @@ export default async function handler(
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     const kind = extractConvexErrorKind(err, msg);
-    const errData = (err as { data?: unknown })?.data;
     if (kind === 'CONFLICT') {
-      // Echo `actualSyncVersion` from the structured ConvexError so the
-      // client can refresh its local sync state in one round-trip instead
-      // of re-fetching getPreferences.
-      const actualSyncVersion = (errData && typeof errData === 'object' && 'actualSyncVersion' in errData)
-        ? (errData as Record<string, unknown>).actualSyncVersion
-        : undefined;
+      // Echo `actualSyncVersion` from the structured ConvexError when present
+      // and numeric so the client can refresh its local sync state without a
+      // follow-up GET. Type-guarded at the boundary — the response contract
+      // is `actualSyncVersion?: number`, so we drop non-numeric values rather
+      // than forwarding them as `unknown`.
+      const actualSyncVersion = readConvexErrorNumber(err, 'actualSyncVersion');
       return jsonResponse(
         actualSyncVersion !== undefined ? { error: 'CONFLICT', actualSyncVersion } : { error: 'CONFLICT' },
         409,
@@ -163,32 +164,6 @@ export default async function handler(
   }
 }
 
-/**
- * Extract the named-error `kind` from a Convex client throw, preferring the
- * structured `err.data.kind` (set when the server throws
- * `ConvexError({ kind, ... })`) and falling back to substring-matching the
- * legacy string-data error message (`ConvexError("CONFLICT")`).
- *
- * Rationale: Convex's HTTP client wire format only forwards `errorData` to
- * the client when the server-side `ConvexError` carries object-typed data.
- * String-data ConvexErrors arrive as `Error("[Request ID: X] Server Error")`
- * with `errorData` undefined — so a `msg.includes('CONFLICT')` check NEVER
- * matches and the throw gets misclassified as a 500. The structured-data
- * path is the load-bearing one; the legacy string-match is a safety net for
- * the deploy-ordering window where Vercel may run a build that pre-dates
- * the Convex server-side update.
- */
-function extractConvexErrorKind(err: unknown, msg: string): string | null {
-  const data = (err as { data?: unknown })?.data;
-  if (data && typeof data === 'object' && 'kind' in data) {
-    const kind = (data as Record<string, unknown>).kind;
-    if (typeof kind === 'string') return kind;
-  }
-  if (msg.includes('CONFLICT')) return 'CONFLICT';
-  if (msg.includes('BLOB_TOO_LARGE')) return 'BLOB_TOO_LARGE';
-  if (msg.includes('UNAUTHENTICATED')) return 'UNAUTHENTICATED';
-  return null;
-}
 
 /**
  * Build a captureSilentError context that carries enough provenance to triage

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -66,6 +66,7 @@ export default async function handler(
       return jsonResponse(prefs ?? null, 200, cors);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      const kind = extractConvexErrorKind(err, msg);
       // UNAUTHENTICATED on this path means the Clerk token PASSED our edge's
       // `validateBearerToken` but Convex still rejected it — i.e. genuine
       // auth/audience/issuer drift between our Clerk JWKS validation and
@@ -74,7 +75,7 @@ export default async function handler(
       // caught earlier (the `validateBearerToken` 401 above) and never reach
       // this catch. Capture before returning 401 so the drift surfaces under
       // a stable Sentry bucket instead of silently 401'ing every request.
-      if (msg.includes('UNAUTHENTICATED')) {
+      if (kind === 'UNAUTHENTICATED') {
         console.error('[user-prefs] GET convex auth drift:', err);
         captureSilentError(err, buildSentryContext(err, msg, {
           method: 'GET', convexFn: 'userPreferences:getPreferences',
@@ -118,13 +119,25 @@ export default async function handler(
     return jsonResponse(result, 200, cors);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes('CONFLICT')) {
-      return jsonResponse({ error: 'CONFLICT' }, 409, cors);
+    const kind = extractConvexErrorKind(err, msg);
+    const errData = (err as { data?: unknown })?.data;
+    if (kind === 'CONFLICT') {
+      // Echo `actualSyncVersion` from the structured ConvexError so the
+      // client can refresh its local sync state in one round-trip instead
+      // of re-fetching getPreferences.
+      const actualSyncVersion = (errData && typeof errData === 'object' && 'actualSyncVersion' in errData)
+        ? (errData as Record<string, unknown>).actualSyncVersion
+        : undefined;
+      return jsonResponse(
+        actualSyncVersion !== undefined ? { error: 'CONFLICT', actualSyncVersion } : { error: 'CONFLICT' },
+        409,
+        cors,
+      );
     }
-    if (msg.includes('BLOB_TOO_LARGE')) {
+    if (kind === 'BLOB_TOO_LARGE') {
       return jsonResponse({ error: 'BLOB_TOO_LARGE' }, 400, cors);
     }
-    if (msg.includes('UNAUTHENTICATED')) {
+    if (kind === 'UNAUTHENTICATED') {
       // See GET branch above — UNAUTHENTICATED here means Clerk-vs-Convex
       // auth drift (token already passed validateBearerToken). Capture
       // before returning 401 so the drift is visible.
@@ -148,6 +161,33 @@ export default async function handler(
     }));
     return jsonResponse({ error: 'Failed to save preferences' }, 500, cors);
   }
+}
+
+/**
+ * Extract the named-error `kind` from a Convex client throw, preferring the
+ * structured `err.data.kind` (set when the server throws
+ * `ConvexError({ kind, ... })`) and falling back to substring-matching the
+ * legacy string-data error message (`ConvexError("CONFLICT")`).
+ *
+ * Rationale: Convex's HTTP client wire format only forwards `errorData` to
+ * the client when the server-side `ConvexError` carries object-typed data.
+ * String-data ConvexErrors arrive as `Error("[Request ID: X] Server Error")`
+ * with `errorData` undefined — so a `msg.includes('CONFLICT')` check NEVER
+ * matches and the throw gets misclassified as a 500. The structured-data
+ * path is the load-bearing one; the legacy string-match is a safety net for
+ * the deploy-ordering window where Vercel may run a build that pre-dates
+ * the Convex server-side update.
+ */
+function extractConvexErrorKind(err: unknown, msg: string): string | null {
+  const data = (err as { data?: unknown })?.data;
+  if (data && typeof data === 'object' && 'kind' in data) {
+    const kind = (data as Record<string, unknown>).kind;
+    if (typeof kind === 'string') return kind;
+  }
+  if (msg.includes('CONFLICT')) return 'CONFLICT';
+  if (msg.includes('BLOB_TOO_LARGE')) return 'BLOB_TOO_LARGE';
+  if (msg.includes('UNAUTHENTICATED')) return 'UNAUTHENTICATED';
+  return null;
 }
 
 /**

--- a/convex/userPreferences.ts
+++ b/convex/userPreferences.ts
@@ -38,12 +38,23 @@ export const setPreferences = mutation({
   },
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new ConvexError("UNAUTHENTICATED");
+    // Throw structured `ConvexError({ kind, ... })` instead of string-data —
+    // Convex's wire format reliably propagates `errorData` for object payloads,
+    // so the edge handler can route via `err.data.kind` to the correct HTTP
+    // status. String-data ConvexErrors arrive at the edge as a generic
+    // `Error("[Request ID: X] Server Error")` with `errorData` undefined,
+    // which previously caused CONFLICT throws to be misclassified as 500
+    // and trigger an unbounded retry loop on the client (PD investigation).
+    if (!identity) throw new ConvexError({ kind: "UNAUTHENTICATED" });
     const userId = identity.subject;
 
     const blobSize = JSON.stringify(args.data).length;
     if (blobSize > MAX_PREFS_BLOB_SIZE) {
-      throw new ConvexError(`BLOB_TOO_LARGE: ${blobSize} > ${MAX_PREFS_BLOB_SIZE}`);
+      throw new ConvexError({
+        kind: "BLOB_TOO_LARGE",
+        size: blobSize,
+        max: MAX_PREFS_BLOB_SIZE,
+      });
     }
 
     const existing = await ctx.db
@@ -54,7 +65,13 @@ export const setPreferences = mutation({
       .unique();
 
     if (existing && existing.syncVersion !== args.expectedSyncVersion) {
-      throw new ConvexError("CONFLICT");
+      // Include `actualSyncVersion` so the edge can echo it in the 409 body
+      // and the client can refresh its local view in one round-trip instead
+      // of re-fetching getPreferences.
+      throw new ConvexError({
+        kind: "CONFLICT",
+        actualSyncVersion: existing.syncVersion,
+      });
     }
 
     const nextSyncVersion = (existing?.syncVersion ?? 0) + 1;

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -163,7 +163,7 @@ async function postCloudPrefs(
   variant: string,
   data: Record<string, string>,
   expectedSyncVersion: number,
-): Promise<{ syncVersion: number } | { conflict: true }> {
+): Promise<{ syncVersion: number } | { conflict: true; actualSyncVersion?: number }> {
   const res = await fetch('/api/user-prefs', {
     method: 'POST',
     headers: {
@@ -172,7 +172,15 @@ async function postCloudPrefs(
     },
     body: JSON.stringify({ variant, data, expectedSyncVersion, schemaVersion: CURRENT_PREFS_SCHEMA_VERSION }),
   });
-  if (res.status === 409) return { conflict: true };
+  if (res.status === 409) {
+    // Server now echoes the row's current syncVersion in the 409 body
+    // (when available) so we can advance local state without a follow-up
+    // GET. Fall back to undefined for older edge deploys that don't yet
+    // include the field — the existing re-fetch path still handles those.
+    const body = await res.json().catch(() => ({} as Record<string, unknown>));
+    const actualSyncVersion = typeof body.actualSyncVersion === 'number' ? body.actualSyncVersion : undefined;
+    return { conflict: true, actualSyncVersion };
+  }
   if (!res.ok) throw new Error(`post prefs: ${res.status}`);
   return (await res.json()) as { syncVersion: number };
 }

--- a/tests/user-prefs-convex-error.test.mjs
+++ b/tests/user-prefs-convex-error.test.mjs
@@ -1,0 +1,108 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Extract `extractConvexErrorKind` from api/user-prefs.ts and run it as a
+// standalone function. Avoids importing the whole edge handler (Vercel-runtime
+// bindings, Clerk validator, ConvexHttpClient).
+const src = readFileSync(resolve(__dirname, '../api/user-prefs.ts'), 'utf-8');
+const fnMatch = src.match(/function extractConvexErrorKind\(([\s\S]*?)\): string \| null \{([\s\S]*?)\n\}/);
+assert.ok(fnMatch, 'extractConvexErrorKind must exist in api/user-prefs.ts');
+
+const fnBody = fnMatch[2]
+  // Strip TS type cast / generic syntax that breaks Function constructor parsing.
+  .replace(/as \{ data\?: unknown \}/g, '')
+  .replace(/as Record<string, unknown>/g, '');
+const fnParams = fnMatch[1].split(',').map(p => p.replace(/:.*/s, '').trim()).filter(Boolean);
+// eslint-disable-next-line no-new-func
+const extractKind = new Function(...fnParams, fnBody);
+
+describe('extractConvexErrorKind — Convex client error → kind', () => {
+  describe('structured-data path (preferred — server throws ConvexError({ kind, ... }))', () => {
+    it('reads CONFLICT from err.data.kind', () => {
+      const err = Object.assign(new Error('[Request ID: abc] Server Error'), {
+        data: { kind: 'CONFLICT', actualSyncVersion: 13 },
+      });
+      assert.equal(extractKind(err, err.message), 'CONFLICT');
+    });
+
+    it('reads BLOB_TOO_LARGE from err.data.kind even when message is generic', () => {
+      const err = Object.assign(new Error('[Request ID: xyz] Server Error'), {
+        data: { kind: 'BLOB_TOO_LARGE', size: 9999, max: 8192 },
+      });
+      assert.equal(extractKind(err, err.message), 'BLOB_TOO_LARGE');
+    });
+
+    it('reads UNAUTHENTICATED from err.data.kind', () => {
+      const err = Object.assign(new Error('[Request ID: q] Server Error'), {
+        data: { kind: 'UNAUTHENTICATED' },
+      });
+      assert.equal(extractKind(err, err.message), 'UNAUTHENTICATED');
+    });
+
+    it('returns the kind verbatim for forward-compat new kinds (BAD_REQUEST etc.)', () => {
+      const err = Object.assign(new Error('Server Error'), {
+        data: { kind: 'NEW_KIND_NOT_YET_HANDLED' },
+      });
+      assert.equal(extractKind(err, err.message), 'NEW_KIND_NOT_YET_HANDLED');
+    });
+  });
+
+  describe('legacy substring-match fallback (string-data ConvexError that arrived without errorData)', () => {
+    it('matches CONFLICT in the message', () => {
+      const err = new Error('CONFLICT');
+      assert.equal(extractKind(err, err.message), 'CONFLICT');
+    });
+
+    it('matches BLOB_TOO_LARGE substring in the message', () => {
+      const err = new Error('BLOB_TOO_LARGE: 9999 > 8192');
+      assert.equal(extractKind(err, err.message), 'BLOB_TOO_LARGE');
+    });
+
+    it('matches UNAUTHENTICATED in the message', () => {
+      const err = new Error('UNAUTHENTICATED');
+      assert.equal(extractKind(err, err.message), 'UNAUTHENTICATED');
+    });
+
+    it('does NOT match a generic "Server Error" message (the bug pre-fix)', () => {
+      // This is the exact symptom the structured-data fix exists to address:
+      // Convex's `[Request ID: X] Server Error` wrapper used to bypass every
+      // catch branch in the edge handler. Confirm the fallback still returns
+      // null for it (so the caller treats it as a real 500).
+      const err = new Error('[Request ID: 9fee2a2bfa791253] Server Error');
+      assert.equal(extractKind(err, err.message), null);
+    });
+  });
+
+  describe('precedence — structured-data wins over message-substring', () => {
+    it('reads .data.kind even if the message contains a different token', () => {
+      // Defensive: if a future ConvexError both sets data.kind AND the
+      // message string accidentally contains "CONFLICT", structured wins.
+      const err = Object.assign(new Error('[Request ID: x] Server Error mentioning CONFLICT'), {
+        data: { kind: 'BLOB_TOO_LARGE', size: 9999, max: 8192 },
+      });
+      assert.equal(extractKind(err, err.message), 'BLOB_TOO_LARGE');
+    });
+  });
+
+  describe('null returns', () => {
+    it('returns null for an unrelated error', () => {
+      const err = new Error('TypeError: Failed to fetch');
+      assert.equal(extractKind(err, err.message), null);
+    });
+
+    it('returns null for err.data without a kind field', () => {
+      const err = Object.assign(new Error('msg'), { data: { other: 'x' } });
+      assert.equal(extractKind(err, err.message), null);
+    });
+
+    it('returns null for non-string kind (e.g. number)', () => {
+      const err = Object.assign(new Error('msg'), { data: { kind: 42 } });
+      assert.equal(extractKind(err, err.message), null);
+    });
+  });
+});

--- a/tests/user-prefs-convex-error.test.mjs
+++ b/tests/user-prefs-convex-error.test.mjs
@@ -1,25 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-// Extract `extractConvexErrorKind` from api/user-prefs.ts and run it as a
-// standalone function. Avoids importing the whole edge handler (Vercel-runtime
-// bindings, Clerk validator, ConvexHttpClient).
-const src = readFileSync(resolve(__dirname, '../api/user-prefs.ts'), 'utf-8');
-const fnMatch = src.match(/function extractConvexErrorKind\(([\s\S]*?)\): string \| null \{([\s\S]*?)\n\}/);
-assert.ok(fnMatch, 'extractConvexErrorKind must exist in api/user-prefs.ts');
-
-const fnBody = fnMatch[2]
-  // Strip TS type cast / generic syntax that breaks Function constructor parsing.
-  .replace(/as \{ data\?: unknown \}/g, '')
-  .replace(/as Record<string, unknown>/g, '');
-const fnParams = fnMatch[1].split(',').map(p => p.replace(/:.*/s, '').trim()).filter(Boolean);
-// eslint-disable-next-line no-new-func
-const extractKind = new Function(...fnParams, fnBody);
+import { extractConvexErrorKind, readConvexErrorNumber } from '../api/_convex-error.js';
 
 describe('extractConvexErrorKind — Convex client error → kind', () => {
   describe('structured-data path (preferred — server throws ConvexError({ kind, ... }))', () => {
@@ -27,45 +8,45 @@ describe('extractConvexErrorKind — Convex client error → kind', () => {
       const err = Object.assign(new Error('[Request ID: abc] Server Error'), {
         data: { kind: 'CONFLICT', actualSyncVersion: 13 },
       });
-      assert.equal(extractKind(err, err.message), 'CONFLICT');
+      assert.equal(extractConvexErrorKind(err, err.message), 'CONFLICT');
     });
 
     it('reads BLOB_TOO_LARGE from err.data.kind even when message is generic', () => {
       const err = Object.assign(new Error('[Request ID: xyz] Server Error'), {
         data: { kind: 'BLOB_TOO_LARGE', size: 9999, max: 8192 },
       });
-      assert.equal(extractKind(err, err.message), 'BLOB_TOO_LARGE');
+      assert.equal(extractConvexErrorKind(err, err.message), 'BLOB_TOO_LARGE');
     });
 
     it('reads UNAUTHENTICATED from err.data.kind', () => {
       const err = Object.assign(new Error('[Request ID: q] Server Error'), {
         data: { kind: 'UNAUTHENTICATED' },
       });
-      assert.equal(extractKind(err, err.message), 'UNAUTHENTICATED');
+      assert.equal(extractConvexErrorKind(err, err.message), 'UNAUTHENTICATED');
     });
 
     it('returns the kind verbatim for forward-compat new kinds (BAD_REQUEST etc.)', () => {
       const err = Object.assign(new Error('Server Error'), {
         data: { kind: 'NEW_KIND_NOT_YET_HANDLED' },
       });
-      assert.equal(extractKind(err, err.message), 'NEW_KIND_NOT_YET_HANDLED');
+      assert.equal(extractConvexErrorKind(err, err.message), 'NEW_KIND_NOT_YET_HANDLED');
     });
   });
 
   describe('legacy substring-match fallback (string-data ConvexError that arrived without errorData)', () => {
     it('matches CONFLICT in the message', () => {
       const err = new Error('CONFLICT');
-      assert.equal(extractKind(err, err.message), 'CONFLICT');
+      assert.equal(extractConvexErrorKind(err, err.message), 'CONFLICT');
     });
 
     it('matches BLOB_TOO_LARGE substring in the message', () => {
       const err = new Error('BLOB_TOO_LARGE: 9999 > 8192');
-      assert.equal(extractKind(err, err.message), 'BLOB_TOO_LARGE');
+      assert.equal(extractConvexErrorKind(err, err.message), 'BLOB_TOO_LARGE');
     });
 
     it('matches UNAUTHENTICATED in the message', () => {
       const err = new Error('UNAUTHENTICATED');
-      assert.equal(extractKind(err, err.message), 'UNAUTHENTICATED');
+      assert.equal(extractConvexErrorKind(err, err.message), 'UNAUTHENTICATED');
     });
 
     it('does NOT match a generic "Server Error" message (the bug pre-fix)', () => {
@@ -74,7 +55,7 @@ describe('extractConvexErrorKind — Convex client error → kind', () => {
       // catch branch in the edge handler. Confirm the fallback still returns
       // null for it (so the caller treats it as a real 500).
       const err = new Error('[Request ID: 9fee2a2bfa791253] Server Error');
-      assert.equal(extractKind(err, err.message), null);
+      assert.equal(extractConvexErrorKind(err, err.message), null);
     });
   });
 
@@ -85,24 +66,53 @@ describe('extractConvexErrorKind — Convex client error → kind', () => {
       const err = Object.assign(new Error('[Request ID: x] Server Error mentioning CONFLICT'), {
         data: { kind: 'BLOB_TOO_LARGE', size: 9999, max: 8192 },
       });
-      assert.equal(extractKind(err, err.message), 'BLOB_TOO_LARGE');
+      assert.equal(extractConvexErrorKind(err, err.message), 'BLOB_TOO_LARGE');
     });
   });
 
   describe('null returns', () => {
     it('returns null for an unrelated error', () => {
       const err = new Error('TypeError: Failed to fetch');
-      assert.equal(extractKind(err, err.message), null);
+      assert.equal(extractConvexErrorKind(err, err.message), null);
     });
 
     it('returns null for err.data without a kind field', () => {
       const err = Object.assign(new Error('msg'), { data: { other: 'x' } });
-      assert.equal(extractKind(err, err.message), null);
+      assert.equal(extractConvexErrorKind(err, err.message), null);
     });
 
     it('returns null for non-string kind (e.g. number)', () => {
       const err = Object.assign(new Error('msg'), { data: { kind: 42 } });
-      assert.equal(extractKind(err, err.message), null);
+      assert.equal(extractConvexErrorKind(err, err.message), null);
     });
+  });
+});
+
+describe('readConvexErrorNumber — type-guarded numeric field reader', () => {
+  it('reads a numeric actualSyncVersion', () => {
+    const err = Object.assign(new Error(), { data: { kind: 'CONFLICT', actualSyncVersion: 13 } });
+    assert.equal(readConvexErrorNumber(err, 'actualSyncVersion'), 13);
+  });
+
+  it('returns undefined for missing fields', () => {
+    const err = Object.assign(new Error(), { data: { kind: 'CONFLICT' } });
+    assert.equal(readConvexErrorNumber(err, 'actualSyncVersion'), undefined);
+  });
+
+  it('returns undefined for non-numeric values (string)', () => {
+    // Defensive: prevents a malformed ConvexError(`{ actualSyncVersion: "13" }`)
+    // from leaking a string into our 409 response body.
+    const err = Object.assign(new Error(), { data: { actualSyncVersion: '13' } });
+    assert.equal(readConvexErrorNumber(err, 'actualSyncVersion'), undefined);
+  });
+
+  it('returns undefined for null/undefined data', () => {
+    assert.equal(readConvexErrorNumber(new Error('no data'), 'actualSyncVersion'), undefined);
+    assert.equal(readConvexErrorNumber(undefined, 'actualSyncVersion'), undefined);
+  });
+
+  it('preserves zero (a valid number)', () => {
+    const err = Object.assign(new Error(), { data: { actualSyncVersion: 0 } });
+    assert.equal(readConvexErrorNumber(err, 'actualSyncVersion'), 0);
   });
 });


### PR DESCRIPTION
## Summary

Closes the root cause behind WORLDMONITOR-PD (148 events / 18 users at last sample, dominated by one user generating 50% of volume).

**Traced via Convex prod logs:**

```
"error": "Uncaught ConvexError: CONFLICT
    at handler (../convex/userPreferences.ts:59:29)"
```

The mutation throws `ConvexError("CONFLICT")` correctly server-side, but the wire format from Convex's HTTP runtime to our edge presents it as `Error("[Request ID: X] Server Error")` with `errorData` undefined. Looking at `node_modules/convex/dist/esm/browser/http_client.js:244` confirms: when `respJSON.errorData === void 0`, the client falls through to a plain `throw new Error(respJSON.errorMessage)`. **String-data `ConvexError`s do not get their `.data` forwarded over the wire; object-data `ConvexError`s do.**

**Pre-fix flow:**

1. Convex row at `syncVersion: 13`, client sends `expectedSyncVersion: 12` (stale state in one of two tabs)
2. Server: `throw new ConvexError("CONFLICT")` (correct)
3. Wire: `{ errorMessage: "[Request ID: X] Server Error", errorData: undefined }`
4. Edge `api/user-prefs.ts` catch: `msg.includes('CONFLICT')` doesn't match → returns 500
5. Client treats 500 as transient transport failure → retries forever with the same `expectedSyncVersion` → 50 events/hour from one user

**Fix — three layers, all small:**

- **Server (`convex/userPreferences.ts`):** throw `ConvexError({ kind: "CONFLICT", actualSyncVersion: existing.syncVersion })` and the equivalent for `BLOB_TOO_LARGE` / `UNAUTHENTICATED`. Object-data ConvexErrors propagate reliably.
- **Edge (`api/user-prefs.ts`):** new `extractConvexErrorKind` helper inspects `err.data.kind` first (the load-bearing path) with a `msg.includes(...)` legacy fallback for the deploy-ordering window where Vercel might build before Convex updates. 409 body now echoes `actualSyncVersion`.
- **Client (`src/utils/cloud-prefs-sync.ts`):** type signature accepts the optional `actualSyncVersion` field. Existing 409-handling at lines 221/282 already does the right thing (re-fetch + reapply), so no behavior change to the retry loop itself.

## Verification

- `npx tsc --noEmit` + `tsc --noEmit -p tsconfig.api.json` — PASS
- `npm run lint` (biome) — PASS, 0 errors
- `npm run lint:md` — 0 errors
- `npm run version:check` — PASS
- `npm run test:data` — **7558 / 7558 pass** (+12 from new test file)
- `npm run test:convex` — **116 / 116 pass**
- Edge function bundle check (`api/*.js`) — PASS
- `node --test tests/edge-functions.test.mjs` — 178 / 178 pass

## Test plan

- [x] `tests/user-prefs-convex-error.test.mjs` — 12 cases covering:
  - structured-data path (CONFLICT / BLOB_TOO_LARGE / UNAUTHENTICATED via `err.data.kind`)
  - forward-compat: a future kind (`NEW_KIND_NOT_YET_HANDLED`) returns through verbatim
  - legacy substring fallback (CONFLICT / BLOB_TOO_LARGE / UNAUTHENTICATED in message)
  - **explicit regression test:** `[Request ID: 9fee2a2bfa791253] Server Error` (the exact pre-fix bug message) returns `null`
  - precedence: structured-data wins over message-substring
  - null returns: unrelated errors, `data` without `kind`, non-string `kind`
- [ ] Verify post-deploy: WORLDMONITOR-PD volume drops to ~zero as the dominant retry loop closes
- [ ] Verify post-deploy: any future CONFLICT shows up as a 409 in `api/user-prefs` access logs (not 500)

## Notes

- The `actualSyncVersion` echo in the 409 body is informational for now; the existing client conflict-handler still does a follow-up `fetchCloudPrefs` to get the data blob (which the 409 doesn't return). A future small PR could optimize this away by including the data blob in the 409 itself, but that's out of scope.
- `WORLDMONITOR-66` (`TimeoutError: signal timed out`) and `WORLDMONITOR-P1` (`Dodo checkout declined`) intentionally left open — not relevant to this fix; documented in the round-3 triage report.