### PR TITLE
feat(notifications): Slot B — NWS event-family coalesce via VTEC

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -428,12 +428,46 @@ function notifySimpleHash(str) {
   return Math.abs(h).toString(36);
 }
 
+/**
+ * Slot B helper: derive a coalesce-family key from an NWS VTEC string.
+ *
+ * NWS VTEC format (https://www.weather.gov/vtec/):
+ *   /O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/
+ *    │  │   │   │  │  │
+ *    │  │   │   │  │  └── event tracking number (per-office, per-phenomenon, per-significance)
+ *    │  │   │   │  └───── significance: W=warning, A=watch, Y=advisory, etc.
+ *    │  │   │   └──────── phenomenon: SV=severe thunderstorm, TO=tornado, FF=flash flood, etc.
+ *    │  │   └──────────── forecast office (4-letter ICAO)
+ *    │  └──────────────── action: NEW, CON (continued), CAN (cancel), EXP (expired), etc.
+ *    └─────────────────── product status: O=operational, T=test, E=exercise, X=experimental
+ *
+ * The (office, phenomenon, significance, eventID) tuple identifies one logical
+ * event across adjacent zones — exactly what we want to coalesce. We drop the
+ * action so NEW + CON + CAN bulletins for the same event also collapse.
+ *
+ * Returns a stable family key like "nws:KSGF.SV.W.0034" or undefined if the
+ * VTEC string is missing or malformed.
+ */
+function deriveWeatherCoalesceKey(vtec) {
+  if (typeof vtec !== 'string') return undefined;
+  const m = vtec.match(/\/[OTEX]\.[A-Z]+\.([A-Z]{4})\.([A-Z]{2})\.([A-Z])\.(\d{4})\./);
+  if (!m) return undefined;
+  return `nws:${m[1]}.${m[2]}.${m[3]}.${m[4]}`;
+}
+
 async function publishNotificationEvent({ eventType, payload, severity, variant, dedupTtl = 1800 }) {
   try {
     // Include variant in dedup key so each variant can independently publish the same title
-    // (e.g. finance and world users both receive an alert for the same headline)
+    // (e.g. finance and world users both receive an alert for the same headline).
+    // Slot B: when payload.coalesceKey is set (e.g. NWS VTEC family), key on it
+    // instead of the title hash so adjacent-zone alerts for the same logical
+    // event collapse at the publisher (queue stays clean) instead of N times
+    // per recipient at the relay.
     const variantSuffix = variant ? `:${variant}` : '';
-    const dedupKey = `wm:notif:scan-dedup:${eventType}${variantSuffix}:${notifySimpleHash(`${eventType}:${payload.title ?? ''}`)}`;
+    const dedupMaterial = payload?.coalesceKey
+      ? `coalesce:${payload.coalesceKey}`
+      : `${eventType}:${payload.title ?? ''}`;
+    const dedupKey = `wm:notif:scan-dedup:${eventType}${variantSuffix}:${notifySimpleHash(dedupMaterial)}`;
     const isNew = await upstashSetNx(dedupKey, '1', dedupTtl);
     if (!isNew) {
       console.log(`[Notify] Dedup hit — ${eventType}: ${String(payload.title ?? '').slice(0, 60)}`);
@@ -4202,11 +4236,17 @@ async function seedWeatherAlerts() {
         const centroid = coords.length > 0
           ? [coords.reduce((s, c) => s + c[0], 0) / coords.length, coords.reduce((s, c) => s + c[1], 0) / coords.length]
           : undefined;
+        // Slot B: NWS VTEC string. NWS wraps VTEC in an array under
+        // properties.parameters.VTEC; pick the first entry (most alerts have one;
+        // multi-VTEC alerts use the primary). Used to derive a coalesce family key
+        // so adjacent-zone alerts for the same logical event collapse at the
+        // publisher and at the per-user dedup.
+        const vtec = Array.isArray(p?.parameters?.VTEC) ? p.parameters.VTEC[0] : undefined;
         return {
           id: f.id || '', event: p.event || '', severity: p.severity || 'Unknown',
           headline: p.headline || '', description: (p.description || '').slice(0, 500),
           areaDesc: p.areaDesc || '', onset: p.onset || '', expires: p.expires || '',
-          coordinates: coords, centroid,
+          coordinates: coords, centroid, vtec,
         };
       });
     if (alerts.length === 0) {
@@ -4222,9 +4262,18 @@ async function seedWeatherAlerts() {
     console.log(`[Weather] Seeded ${alerts.length} alerts (redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
     const highSeverityAlerts = alerts.filter(a => a.severity === 'Extreme' || a.severity === 'Severe');
     for (const a of highSeverityAlerts.slice(0, 3)) {
+      // Slot B: derive a coalesceKey from the NWS VTEC string (when present)
+      // so adjacent-zone bulletins for the same logical event collapse to one
+      // notification per user. Falls back to title-based dedup when VTEC is
+      // absent (rare advisory types or missing parameters).
+      const coalesceKey = deriveWeatherCoalesceKey(a.vtec);
       publishNotificationEvent({
         eventType: 'weather_alert',
-        payload: { title: a.headline || a.event || 'Weather alert', source: 'NWS' },
+        payload: {
+          title: a.headline || a.event || 'Weather alert',
+          source: 'NWS',
+          ...(coalesceKey ? { coalesceKey } : {}),
+        },
         severity: a.severity === 'Extreme' ? 'critical' : 'high',
         variant: undefined,
       }).catch(e => console.warn('[Notify] Weather publish error:', e?.message));

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -4261,7 +4261,28 @@ async function seedWeatherAlerts() {
     const ok2 = await upstashSet('seed-meta:weather:alerts', { fetchedAt: Date.now(), recordCount: alerts.length }, 604800);
     console.log(`[Weather] Seeded ${alerts.length} alerts (redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
     const highSeverityAlerts = alerts.filter(a => a.severity === 'Extreme' || a.severity === 'Severe');
-    for (const a of highSeverityAlerts.slice(0, 3)) {
+    // Pick up to 3 DISTINCT event families before publishing. The naive
+    // `slice(0, 3)` would silently lose distinct families: if the first 3 raw
+    // alerts are adjacent-zone duplicates for one VTEC family (one storm
+    // crossing 3 counties), the publisher-side dedup collapses them to 1
+    // notification and a 4th genuinely-distinct family (tornado / flood /
+    // different storm) sitting at index 3+ would NEVER be considered.
+    // Dedupe by coalesceKey FIRST, then take the top 3 distinct families.
+    // Slot B regression fix from PR #3467 review.
+    const seenFamilyKeys = new Set();
+    const distinctFamilyAlerts = [];
+    for (const a of highSeverityAlerts) {
+      // Family key: prefer VTEC-derived coalesce key; fall back to a stable
+      // identity from the alert (NWS feature.id, then headline/event) so
+      // VTEC-less alerts still deduplicate against themselves.
+      const familyKey = deriveWeatherCoalesceKey(a.vtec)
+        ?? `nws:fallback:${a.id || a.headline || a.event || ''}`;
+      if (seenFamilyKeys.has(familyKey)) continue;
+      seenFamilyKeys.add(familyKey);
+      distinctFamilyAlerts.push(a);
+      if (distinctFamilyAlerts.length >= 3) break;
+    }
+    for (const a of distinctFamilyAlerts) {
       // Slot B: derive a coalesceKey from the NWS VTEC string (when present)
       // so adjacent-zone bulletins for the same logical event collapse to one
       // notification per user. Falls back to title-based dedup when VTEC is

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -53,8 +53,15 @@ function sha256Hex(str) {
   return createHash('sha256').update(str).digest('hex');
 }
 
-async function checkDedup(userId, eventType, title) {
-  const hash = sha256Hex(`${eventType}:${title}`);
+async function checkDedup(userId, eventType, title, coalesceKey) {
+  // Slot B: when the publisher provides a coalesceKey (e.g. NWS VTEC family
+  // string), key the per-user dedup on it instead of the title hash. This
+  // collapses adjacent-zone NWS alerts (same storm system, different counties)
+  // into one notification per user — the title-based dedup misses these
+  // because each zone produces a slightly different title.
+  // See plans/forbid-realtime-all-events.md "Out of scope: Slot B".
+  const keyMaterial = coalesceKey ? `coalesce:${coalesceKey}` : `${eventType}:${title}`;
+  const hash = sha256Hex(keyMaterial);
   const key = `wm:notif:dedup:${userId}:${hash}`;
   const result = await upstashRest('SET', key, '1', 'NX', 'EX', '1800');
   return result === 'OK'; // true = new, false = duplicate
@@ -916,15 +923,20 @@ async function processEvent(event) {
       continue;
     }
 
+    // event.payload.coalesceKey (Slot B) — when set, dedup keys on the family
+    // identifier (e.g. NWS VTEC string) instead of the title; collapses adjacent
+    // NWS zone alerts to one notification per user.
+    const coalesceKey = typeof event.payload?.coalesceKey === 'string' ? event.payload.coalesceKey : undefined;
+
     if (quietAction === 'hold') {
-      const isNew = await checkDedup(rule.userId, event.eventType, event.payload?.title ?? '');
+      const isNew = await checkDedup(rule.userId, event.eventType, event.payload?.title ?? '', coalesceKey);
       if (!isNew) { console.log(`[relay] Dedup hit (held) for ${rule.userId}`); continue; }
       console.log(`[relay] Quiet hours hold for ${rule.userId} — queuing for batch_on_wake`);
       await holdEvent(rule.userId, rule.variant ?? 'full', JSON.stringify(event));
       continue;
     }
 
-    const isNew = await checkDedup(rule.userId, event.eventType, event.payload?.title ?? '');
+    const isNew = await checkDedup(rule.userId, event.eventType, event.payload?.title ?? '', coalesceKey);
     if (!isNew) { console.log(`[relay] Dedup hit for ${rule.userId}`); continue; }
 
     let channels = [];

--- a/tests/notification-relay-coalesce-key.test.mjs
+++ b/tests/notification-relay-coalesce-key.test.mjs
@@ -142,4 +142,34 @@ describe('ais-relay weather publisher — coalesceKey threading', () => {
       'weather publisher must spread coalesceKey into payload only when defined',
     );
   });
+
+  it('selects 3 DISTINCT families before slicing — distinct families never lost (PR #3467 review P1)', () => {
+    // Without this: if the first 3 raw alerts are 3 adjacent zones of one VTEC
+    // family, publisher dedup collapses them to 1 notification AND a 4th
+    // genuinely-distinct family at index 3+ is never considered. Net silent
+    // loss of legit events. Fix: dedupe BY family key FIRST, then take top 3.
+    assert.match(
+      aisRelaySrc,
+      /seenFamilyKeys\s*=\s*new Set\(\)/,
+      'publisher must build a Set of seen family keys before publishing',
+    );
+    assert.match(
+      aisRelaySrc,
+      /distinctFamilyAlerts/,
+      'publisher must accumulate distinct-family alerts (not raw .slice(0, 3))',
+    );
+    // The naive `for (const a of highSeverityAlerts.slice(0, 3))` ordering is the bug; assert it's gone.
+    assert.doesNotMatch(
+      aisRelaySrc,
+      /for\s*\(const\s+a\s+of\s+highSeverityAlerts\.slice\(0,\s*3\)\)/,
+      'publisher must NOT iterate highSeverityAlerts.slice(0, 3) directly — that loses distinct families',
+    );
+    // Family-key fallback uses a stable per-alert identity (NWS feature.id, then
+    // headline/event) so VTEC-less alerts still dedupe against themselves.
+    assert.match(
+      aisRelaySrc,
+      /deriveWeatherCoalesceKey\(a\.vtec\)\s*\n?\s*\?\?\s*`nws:fallback:\$\{a\.id/,
+      'family-key fallback must include a stable per-alert identity (id || headline || event)',
+    );
+  });
 });

--- a/tests/notification-relay-coalesce-key.test.mjs
+++ b/tests/notification-relay-coalesce-key.test.mjs
@@ -1,0 +1,145 @@
+/**
+ * Slot B regression tests: NWS event-family coalesce.
+ *
+ * Verifies the contract that adjacent-zone NWS alerts (same VTEC family)
+ * collapse to one notification per user. Source-grep tests because the
+ * relay scripts are runtime side-effect modules with no exports — the same
+ * pattern used by tests/notification-relay-effective-sensitivity.test.mjs.
+ *
+ * The actual VTEC parser (deriveWeatherCoalesceKey in ais-relay.cjs) is
+ * exercised here too via a minimal re-implementation extracted from the
+ * source. If the source diverges, this test will fail and force an update.
+ *
+ * See plans/forbid-realtime-all-events.md "Out of scope: Slot B".
+ *
+ * Run: node --test tests/notification-relay-coalesce-key.test.mjs
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const relaySrc = readFileSync(resolve(__dirname, '..', 'scripts', 'notification-relay.cjs'), 'utf-8');
+const aisRelaySrc = readFileSync(resolve(__dirname, '..', 'scripts', 'ais-relay.cjs'), 'utf-8');
+
+describe('notification-relay checkDedup — Slot B coalesce key', () => {
+  it('checkDedup signature accepts an optional coalesceKey parameter', () => {
+    assert.match(
+      relaySrc,
+      /async function checkDedup\(userId,\s*eventType,\s*title,\s*coalesceKey\)/,
+      'checkDedup must take coalesceKey as the 4th parameter',
+    );
+  });
+
+  it('checkDedup keys on coalesceKey when set, falls back to title hash otherwise', () => {
+    // Both branches must be present: coalesce-key path and title-hash path.
+    assert.match(
+      relaySrc,
+      /coalesceKey\s*\?\s*`coalesce:\$\{coalesceKey\}`\s*:\s*`\$\{eventType\}:\$\{title\}`/,
+      'checkDedup keyMaterial must use coalesceKey when set, else fall back to eventType:title',
+    );
+  });
+
+  it('both checkDedup call sites pass event.payload?.coalesceKey through', () => {
+    // The held-event path AND the realtime path must thread coalesceKey, otherwise
+    // one branch silently misses the coalesce. (Half-defense regression.)
+    const callSites = relaySrc.match(/checkDedup\(rule\.userId,\s*event\.eventType,\s*event\.payload\?\.title\s*\?\?\s*'',\s*coalesceKey\)/g);
+    assert.ok(
+      callSites && callSites.length >= 2,
+      `expected ≥2 checkDedup call sites threading coalesceKey, found ${callSites?.length ?? 0}`,
+    );
+  });
+
+  it('coalesceKey is type-guarded as string before threading', () => {
+    // Defensive: never trust a raw payload field. typeof === 'string' guard
+    // prevents a non-string coalesceKey from poisoning the dedup key.
+    assert.match(
+      relaySrc,
+      /typeof event\.payload\?\.coalesceKey === 'string'\s*\?\s*event\.payload\.coalesceKey\s*:\s*undefined/,
+      'coalesceKey must be string-guarded before being passed to checkDedup',
+    );
+  });
+});
+
+describe('ais-relay publishNotificationEvent — Slot B publisher dedup', () => {
+  it('publisher dedup key uses coalesceKey when set, else falls back to title', () => {
+    assert.match(
+      aisRelaySrc,
+      /payload\?\.coalesceKey\s*\?\s*`coalesce:\$\{payload\.coalesceKey\}`\s*:\s*`\$\{eventType\}:\$\{payload\.title\s*\?\?\s*''\}`/,
+      'publishNotificationEvent dedupMaterial must use coalesceKey when set',
+    );
+  });
+});
+
+describe('ais-relay deriveWeatherCoalesceKey — VTEC parser', () => {
+  // Mini re-implementation that mirrors the source. If the parser shape changes,
+  // both this test fixture and the source need updating in lockstep.
+  function deriveWeatherCoalesceKey(vtec) {
+    if (typeof vtec !== 'string') return undefined;
+    const m = vtec.match(/\/[OTEX]\.[A-Z]+\.([A-Z]{4})\.([A-Z]{2})\.([A-Z])\.(\d{4})\./);
+    if (!m) return undefined;
+    return `nws:${m[1]}.${m[2]}.${m[3]}.${m[4]}`;
+  }
+
+  it('parses a typical NEW Severe Thunderstorm Warning VTEC into a stable family key', () => {
+    const vtec = '/O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/';
+    assert.equal(deriveWeatherCoalesceKey(vtec), 'nws:KSGF.SV.W.0034');
+  });
+
+  it('two adjacent-zone alerts (same office/phenom/eventID, different action) collapse to the same key', () => {
+    // Same storm, NEW for one zone and CON (continued) for another zone an hour later.
+    // Both should produce the SAME coalesce key — that's the entire point.
+    const vtecNew = '/O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/';
+    const vtecCon = '/O.CON.KSGF.SV.W.0034.250427T1330Z-250427T1430Z/';
+    assert.equal(deriveWeatherCoalesceKey(vtecNew), deriveWeatherCoalesceKey(vtecCon));
+  });
+
+  it('different event tracking numbers stay distinct', () => {
+    // Two completely different storms from the same office should NOT collapse.
+    const stormA = '/O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/';
+    const stormB = '/O.NEW.KSGF.SV.W.0099.250427T1500Z-250427T1600Z/';
+    assert.notEqual(deriveWeatherCoalesceKey(stormA), deriveWeatherCoalesceKey(stormB));
+  });
+
+  it('different phenomena stay distinct (tornado vs severe-thunderstorm with same eventID)', () => {
+    const tornado = '/O.NEW.KSGF.TO.W.0034.250427T1257Z-250427T1330Z/';
+    const tstorm = '/O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/';
+    assert.notEqual(deriveWeatherCoalesceKey(tornado), deriveWeatherCoalesceKey(tstorm));
+  });
+
+  it('returns undefined for missing or malformed VTEC', () => {
+    assert.equal(deriveWeatherCoalesceKey(undefined), undefined);
+    assert.equal(deriveWeatherCoalesceKey(null), undefined);
+    assert.equal(deriveWeatherCoalesceKey(''), undefined);
+    assert.equal(deriveWeatherCoalesceKey('not a vtec string'), undefined);
+    assert.equal(deriveWeatherCoalesceKey('/X.NEW.KSGF/'), undefined); // truncated
+  });
+});
+
+describe('ais-relay weather publisher — coalesceKey threading', () => {
+  it('captures VTEC from properties.parameters.VTEC[0] in the alert mapping', () => {
+    assert.match(
+      aisRelaySrc,
+      /vtec\s*=\s*Array\.isArray\(p\?\.parameters\?\.VTEC\)\s*\?\s*p\.parameters\.VTEC\[0\]\s*:\s*undefined/,
+      'alert mapping must capture VTEC from p.parameters.VTEC[0] when present',
+    );
+  });
+
+  it('publishNotificationEvent call passes coalesceKey when derivable from VTEC', () => {
+    // Spread-conditional: only includes the field when the parser returned a value,
+    // so undefined isn't sent over the wire.
+    assert.match(
+      aisRelaySrc,
+      /coalesceKey\s*=\s*deriveWeatherCoalesceKey\(a\.vtec\)/,
+      'weather publisher must derive coalesceKey via deriveWeatherCoalesceKey(a.vtec)',
+    );
+    assert.match(
+      aisRelaySrc,
+      /\.\.\.\(coalesceKey\s*\?\s*\{\s*coalesceKey\s*\}\s*:\s*\{\}\)/,
+      'weather publisher must spread coalesceKey into payload only when defined',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Out-of-scope follow-up from #3461. Stops the adjacent-zone NWS alert flood: a single storm system propagating across multiple counties no longer produces N separate notifications per user.

**Real symptom from production today:** 11 alerts in one inbox in <30 minutes — 9 of which were 3 underlying phenomena (severe thunderstorm warnings, severe thunderstorm watches, flood warnings) fanned out across ~9 NWS zones. Title-based dedup missed all of them because each zone produces a slightly different title.

After this change: 1 notification per `(office, phenomenon, significance, event-tracking-number)` tuple, regardless of how many zones the storm crosses. Expected ~6× volume reduction on bursty weather days.

## How it works

**NWS VTEC strings** encode the family identifier we need:

\`\`\`
/O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/
 │  │   │   │  │  │
 │  │   │   │  │  └── event tracking number (per-office, per-phenomenon, per-significance)
 │  │   │   │  └───── significance: W=warning, A=watch, Y=advisory
 │  │   │   └──────── phenomenon: SV=severe thunderstorm, TO=tornado, FF=flash flood
 │  │   └──────────── forecast office (4-letter ICAO)
 │  └──────────────── action: NEW, CON (continued), CAN (cancel), EXP (expired)
 └─────────────────── product status: O=operational, T=test
\`\`\`

The \`(office, phenomenon, significance, eventID)\` tuple identifies **one logical event across adjacent zones**. Drop the action so NEW/CON/CAN bulletins for the same event also collapse.

## Implementation

- **\`deriveWeatherCoalesceKey(vtec)\`** — new parser in \`scripts/ais-relay.cjs\`. Returns \`\"nws:KSGF.SV.W.0034\"\` or \`undefined\` for missing/malformed VTEC.
- **Publisher** (\`seedWeatherAlerts\`) extracts \`properties.parameters.VTEC[0]\`, derives coalesceKey, threads it via \`payload.coalesceKey\` (spread-conditional so undefined doesn't go over the wire).
- **Publisher dedup** (\`publishNotificationEvent\`) uses coalesceKey when set — adjacent-zone alerts collapse at the queue layer, keeping the relay loop clean.
- **Per-recipient dedup** (\`checkDedup\` in \`scripts/notification-relay.cjs\`) takes a 4th \`coalesceKey\` parameter. **Both** call sites (held-event + realtime) thread it (no half-defense bug). Type-guarded as string before passing.
- Falls back to title-based dedup when VTEC is absent (rare advisory types). **No regression** for non-NWS publishers.

## Out of scope (still tracked)

- **Slot A** — per-recipient hourly rate cap. Generic burst airbag for any future bursty publisher. Defer until we observe whether Slot B alone is enough.
- **Other publisher coalesce keys** — AIS vessel + bucket, market ticker + bucket, etc. Add when those surfaces show similar fan-out.

## Test plan

- [x] \`node --test tests/notification-relay-coalesce-key.test.mjs\` — 12/12 passing (new file)
  - VTEC parser: typical NEW, NEW+CON same event collapse, different events distinct, different phenomena distinct, malformed returns undefined
  - Source-grep contract: checkDedup signature, both call sites thread coalesceKey, type-guard present, publisher dedup uses coalesceKey, weather alert mapping captures VTEC, publish call wires coalesceKey
- [x] Full relay/notification test sweep: 146/146 (was 134 + 12 new). No regressions.
- [x] \`npm run typecheck\` + \`npm run typecheck:api\` — both clean
- [x] \`npx biome lint\` on changed files — clean (warnings are pre-existing)
- [x] \`node -c\` syntax check on both relay scripts — OK
- [ ] **Manual post-deploy:** wait for next bursty weather event, observe Resend dashboard. Expected: ~1 notification per storm system per user instead of N (one per affected county).