### PR TITLE
feat(resilience): activate headline-eligible gate (plan 002 PR 6, v16→v17)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -165,7 +165,7 @@ const STANDALONE_KEYS = {
   pizzint:                  'intelligence:pizzint:seed:v1',
   resilienceStaticIndex:    'resilience:static:index:v1',
   resilienceStaticFao:      'resilience:static:fao',
-  resilienceRanking:        'resilience:ranking:v16',
+  resilienceRanking:        'resilience:ranking:v17',
   productCatalog:           'product-catalog:v2',
   energySpineCountries:     'energy:spine:v1:_countries',
   energyExposure:           'energy:exposure:v1:index',

--- a/scripts/backtest-resilience-outcomes.mjs
+++ b/scripts/backtest-resilience-outcomes.mjs
@@ -27,7 +27,7 @@ loadEnvFile(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const VALIDATION_DIR = join(__dirname, '..', 'docs', 'methodology', 'country-resilience-index', 'validation');
 
-const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v16:';
+const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v17:';
 
 // Mirror of _shared.ts#currentCacheFormula. Must stay in lockstep; see
 // the same comment in scripts/validate-resilience-correlation.mjs for

--- a/scripts/benchmark-resilience-external.mjs
+++ b/scripts/benchmark-resilience-external.mjs
@@ -374,7 +374,7 @@ function currentCacheFormulaLocal() {
 
 async function readWmScoresFromRedis() {
   const { url, token } = getRedisCredentials();
-  const rankingResp = await fetch(`${url}/get/${encodeURIComponent('resilience:ranking:v16')}`, {
+  const rankingResp = await fetch(`${url}/get/${encodeURIComponent('resilience:ranking:v17')}`, {
     headers: { Authorization: `Bearer ${token}` },
     signal: AbortSignal.timeout(10_000),
   });

--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -30,8 +30,8 @@ const SEED_UA = 'Mozilla/5.0 (compatible; WorldMonitor-Seed/1.0)';
 // Earlier: v11 → v12 for PR 3A §net-imports denominator (plan
 // 2026-04-24-002). Seeder and server MUST agree on the prefix or the
 // seeder writes scores the handler will never read.
-export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v16:';
-export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v16';
+export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v17:';
+export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v17';
 // Must match the server-side RESILIENCE_RANKING_CACHE_TTL_SECONDS. Extended
 // to 12h (2x the cron interval) so a missed/slow cron can't create an
 // EMPTY_ON_DEMAND gap before the next successful rebuild.

--- a/scripts/validate-resilience-backtest.mjs
+++ b/scripts/validate-resilience-backtest.mjs
@@ -27,7 +27,7 @@ import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 loadEnvFile(import.meta.url);
 
 // Source of truth: server/worldmonitor/resilience/v1/_shared.ts
-const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v16:';
+const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v17:';
 
 // Mirror of _shared.ts#currentCacheFormula — must stay in lockstep so
 // the backtest only ingests same-formula cache entries. A mixed-formula

--- a/scripts/validate-resilience-correlation.mjs
+++ b/scripts/validate-resilience-correlation.mjs
@@ -3,7 +3,7 @@
 import { loadEnvFile, getRedisCredentials } from './_seed-utils.mjs';
 
 // Source of truth: server/worldmonitor/resilience/v1/_shared.ts → RESILIENCE_SCORE_CACHE_PREFIX
-const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v16:';
+const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v17:';
 
 // Mirror of server/worldmonitor/resilience/v1/_shared.ts#currentCacheFormula.
 // Must stay in lockstep with the server-side definition so this script

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -274,7 +274,7 @@ const RESILIENCE_TRANSIT_SUMMARIES_KEY = 'supply_chain:transit-summaries:v1';
 const RESILIENCE_BIS_DSR_KEY = 'economic:bis:dsr:v1';
 const RESILIENCE_NATIONAL_DEBT_KEY = 'economic:national-debt:v1';
 const RESILIENCE_IMF_MACRO_KEY = 'economic:imf:macro:v2';
-const RESILIENCE_IMF_LABOR_KEY = 'economic:imf:labor:v1';
+export const RESILIENCE_IMF_LABOR_KEY = 'economic:imf:labor:v1';
 // RETIRED in plan 2026-04-25-004 Phase 1: the `RESILIENCE_SANCTIONS_KEY`
 // constant ('sanctions:country-counts:v1') is no longer read by any scorer
 // in this module — scoreTradePolicy dropped the OFAC component. The seed
@@ -812,6 +812,36 @@ function readPopulationMillions(imfLaborRaw: unknown, countryCode: string): numb
   if (raw == null) return 0.5;
   const millions = raw >= 10_000 ? raw / 1_000_000 : raw;
   return Math.max(millions, 0.5);
+}
+
+/**
+ * Plan 2026-04-26-002 §U7 (PR 6) — population reader for the headline-
+ * eligible gate. Differs from `readPopulationMillions` in two ways:
+ *
+ *   1. Returns `null` when no IMF labor entry exists for the country
+ *      (instead of the §U6 0.5M default). The gate's "population >= 200k"
+ *      branch needs to distinguish "country with known small population"
+ *      from "country with unknown population"; defaulting to 0.5M (above
+ *      the 200k threshold) would incorrectly admit every unknown-pop
+ *      country to the headline ranking.
+ *
+ *   2. Does NOT apply the §U6 0.5M tiny-state floor. The §U6 floor is
+ *      a per-capita-math safety device (prevent /0 and amplification);
+ *      the headline gate needs the REAL population to decide eligibility.
+ *      Tuvalu's actual headcount of ~10k is below 200k → not eligible
+ *      via the population branch (it can still pass via the coverage>=0.85
+ *      branch if data quality is high enough).
+ *
+ * Defensive raw-persons detection mirrors `readPopulationMillions`
+ * (>= 10_000 is impossible as "millions" → divide by 1e6).
+ */
+export function readCountryPopulationMillionsForGate(
+  imfLaborRaw: unknown,
+  countryCode: string,
+): number | null {
+  const raw = safeNum(getImfLaborEntry(imfLaborRaw, countryCode)?.populationMillions);
+  if (raw == null) return null;
+  return raw >= 10_000 ? raw / 1_000_000 : raw;
 }
 
 // getCountryBisExchangeRates() removed in PR 3 §3.5: only scoreCurrencyExternal

--- a/server/worldmonitor/resilience/v1/_shared.ts
+++ b/server/worldmonitor/resilience/v1/_shared.ts
@@ -19,9 +19,11 @@ import {
   RESILIENCE_DIMENSION_TYPES,
   RESILIENCE_DIMENSION_WEIGHTS,
   RESILIENCE_DOMAIN_ORDER,
+  RESILIENCE_IMF_LABOR_KEY,
   isExcludedFromConfidenceMean,
   createMemoizedSeedReader,
   getResilienceDomainWeight,
+  readCountryPopulationMillionsForGate,
   scoreAllDimensions,
   type ImputationClass,
   type ResilienceDimensionId,
@@ -152,7 +154,14 @@ export const RESILIENCE_RANKING_CACHE_TTL_SECONDS = 12 * 60 * 60;
 // UCDP) normalize per-million-population (U6). Every country's score
 // shifts; mixing v15 + v16 cached scores in the same response would
 // create internally-inconsistent rankings.
-export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v16:';
+// v16→v17 bump for plan 2026-04-26-002 §U7 (PR 6): `headlineEligible`
+// flips from PR 2's "true everywhere" to actual eligibility logic
+// (coverage >= 0.65 AND (population >= 200k OR coverage >= 0.85) AND
+// !lowConfidence). Cached v16 score entries carry headlineEligible:true
+// for every country (the PR 2 default), which would let ineligible
+// countries through the headline ranking filter for the full 6h TTL
+// post-deploy. Bump forces a clean recompute aligned with the new gate.
+export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v17:';
 // Bumped from v4 to v5 in the pillar-combined activation PR. Provides
 // a clean slate at PR deploy so pre-PR history points (which were
 // written without a formula tag) do not mix with tagged points. NOTE:
@@ -190,7 +199,15 @@ export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v16:';
 // v10 history points with post-fix v16 score points inside the 30-day
 // rolling window would produce false-trend signals — the score-formula
 // shift this PR introduces is one of the largest in the index's history.
-export const RESILIENCE_HISTORY_KEY_PREFIX = 'resilience:history:v11:';
+// v11→v12 bump in lockstep with RESILIENCE_SCORE_CACHE_PREFIX v16→v17
+// for plan 2026-04-26-002 §U7 (PR 6). Per the cache-prefix-bump-
+// propagation-scope skill: history points written under v11 reflect
+// the PR-2 "all-true headlineEligible" world; mixing them with v17
+// score points across the rolling 30-day window risks no behavior
+// shift on history (history doesn't carry the field), but rotating
+// in lockstep keeps the bump pattern consistent and the audit trail
+// clean.
+export const RESILIENCE_HISTORY_KEY_PREFIX = 'resilience:history:v12:';
 // v12 bump in lockstep with RESILIENCE_SCORE_CACHE_PREFIX (v11 → v12)
 // for PR 3A §net-imports denominator. As with the score prefix, the
 // version bump is a belt — the suspenders are the `_formula` tag on
@@ -203,7 +220,13 @@ export const RESILIENCE_HISTORY_KEY_PREFIX = 'resilience:history:v11:';
 // for plan 2026-04-25-004 Phase 2 (Ship 2).
 // v15→v16 bump in lockstep with RESILIENCE_SCORE_CACHE_PREFIX for
 // plan 2026-04-26-002 §U4+U5+U6 (combined PR 3+4+5).
-export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v16';
+// v16→v17 bump in lockstep with RESILIENCE_SCORE_CACHE_PREFIX for
+// plan 2026-04-26-002 §U7 (PR 6). v16 cached rankings include items
+// flagged headlineEligible:true unconditionally (PR 2 default); they
+// would serve as the front-of-house ranking for the full 6h TTL even
+// after the gate logic flips. Bump forces a clean recompute against
+// the v17 score entries, which now carry the real headlineEligible.
+export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v17';
 export const RESILIENCE_STATIC_INDEX_KEY = 'resilience:static:index:v1';
 // Plan 2026-04-26-002 §U4+U5+U6 (combined PR 3+4+5) — intervals bump
 // v1 → v2. The pre-PR interval seeders used the OLD 5-domain weights
@@ -445,6 +468,38 @@ function parseHistoryPoints(raw: unknown): ResilienceHistoryPoint[] {
   return history.sort((left, right) => left.date.localeCompare(right.date));
 }
 
+// Plan 2026-04-26-002 §U7 (PR 6) — headline-eligible gate. Per origin
+// Q2 + Q5: a country is eligible for the headline ranking iff
+//   coverage >= 0.65 AND
+//   (population >= 200k OR coverage >= 0.85) AND
+//   NOT lowConfidence
+// Population is in millions; 200k = 0.2M. The coverage>=0.85 branch is
+// the data-quality compensator: a tiny state with high data quality
+// (Iceland, Liechtenstein, Monaco) can still earn headline status
+// even though its population is below the 200k threshold.
+//
+// `populationMillions` is `null` when the country has no IMF labor
+// entry. Per the conservative-default rule, unknown population fails
+// the population branch — eligibility then depends entirely on the
+// coverage>=0.85 branch. This avoids inflating eligibility by
+// assuming a default population.
+export const HEADLINE_ELIGIBLE_MIN_COVERAGE = 0.65;
+export const HEADLINE_ELIGIBLE_MIN_POPULATION_MILLIONS = 0.2;
+export const HEADLINE_ELIGIBLE_HIGH_COVERAGE = 0.85;
+
+export function computeHeadlineEligible(args: {
+  overallCoverage: number;
+  populationMillions: number | null;
+  lowConfidence: boolean;
+}): boolean {
+  if (args.lowConfidence) return false;
+  if (args.overallCoverage < HEADLINE_ELIGIBLE_MIN_COVERAGE) return false;
+  const popOk = args.populationMillions != null
+    && args.populationMillions >= HEADLINE_ELIGIBLE_MIN_POPULATION_MILLIONS;
+  const highCoverageOk = args.overallCoverage >= HEADLINE_ELIGIBLE_HIGH_COVERAGE;
+  return popOk || highCoverageOk;
+}
+
 export function computeLowConfidence(dimensions: ResilienceDimension[], imputationShare: number): boolean {
   // Exclude RETIRED dimensions (fuelStockDays, post-PR-3) from the
   // confidence reading. They contribute zero weight to domain scoring
@@ -514,7 +569,11 @@ async function buildResilienceScore(
     ? new Date(staticMeta.fetchedAt).toISOString().slice(0, 10)
     : todayIsoDate();
 
-  const scoreMap = await scoreAllDimensions(normalizedCountryCode, reader);
+  // Plan §U7 (PR 6) — memoize the seed reader once at the top of the
+  // build so the IMF labor seed read for the headline-eligible gate
+  // (below) shares the cache with the dimension scorers' reads.
+  const seedReader = reader ?? createMemoizedSeedReader();
+  const scoreMap = await scoreAllDimensions(normalizedCountryCode, seedReader);
   const dimensions = buildDimensionList(scoreMap);
   const domains = buildDomainList(dimensions);
   const pillars = buildPillarList(domains, true);
@@ -569,6 +628,31 @@ async function buildResilienceScore(
 
   await appendHistory(normalizedCountryCode, overallScore, formula);
 
+  const lowConfidence = computeLowConfidence(dimensions, imputationShare);
+  // Plan 2026-04-26-002 §U7 (PR 6) — headline-eligible gate flips from
+  // PR 2's "true everywhere" to actual eligibility logic. Three
+  // conjuncts (per origin Q2 + Q5):
+  //   1. coverage >= 0.65 (≥ 65% of dims have observed data)
+  //   2. population >= 200k OR coverage >= 0.85 (real-state size OR
+  //      data quality high enough to compensate for tiny pop)
+  //   3. NOT lowConfidence (which already gates ≥ 50% imputation share)
+  // Population is read fresh from IMF labor; the helper returns the
+  // REAL population (no §U6 0.5M floor) so a tiny state with known
+  // sub-200k pop is correctly excluded via conjunct 2 — falling
+  // through to the floor would inflate the gate's permissiveness.
+  // Unknown population is treated as `null` → conjunct 2 evaluates
+  // to "coverage >= 0.85" alone, which is the conservative behavior:
+  // an unknown-pop country only earns headline status via high data
+  // quality, not via assumption.
+  const imfLaborRaw = await seedReader(RESILIENCE_IMF_LABOR_KEY);
+  const overallCoverageForGate = computeOverallCoverage({ domains } as GetResilienceScoreResponse);
+  const populationMillionsForGate = readCountryPopulationMillionsForGate(imfLaborRaw, normalizedCountryCode);
+  const headlineEligible = computeHeadlineEligible({
+    overallCoverage: overallCoverageForGate,
+    populationMillions: populationMillionsForGate,
+    lowConfidence,
+  });
+
   return {
     countryCode: normalizedCountryCode,
     overallScore,
@@ -579,17 +663,12 @@ async function buildResilienceScore(
     domains,
     trend: detectTrend(scoreSeries),
     change30d: oldestScore == null ? 0 : round(overallScore - oldestScore),
-    lowConfidence: computeLowConfidence(dimensions, imputationShare),
+    lowConfidence,
     imputationShare,
     dataVersion,
     pillars,
     schemaVersion: '2.0',
-    // Plan 2026-04-26-002 §U3 (PR 2) — populate `true` for every country.
-    // PR 6 / §U7 swaps to `coverage >= 0.65 && (population >= 200k ||
-    // coverage >= 0.85) && !lowConfidence`. The field exists from PR 2
-    // onward so downstream readers can begin consuming it (informational
-    // only) before the gate logic flips.
-    headlineEligible: true,
+    headlineEligible,
   };
 }
 

--- a/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
@@ -3,6 +3,7 @@ import type {
   ServerContext,
   GetResilienceRankingRequest,
   GetResilienceRankingResponse,
+  ResilienceRankingItem,
 } from '../../../../src/generated/server/worldmonitor/resilience/v1/service_server';
 
 import { getCachedJson, runRedisPipeline } from '../../../_shared/redis';
@@ -171,9 +172,20 @@ export const getResilienceRanking: ResilienceServiceHandler['getResilienceRankin
 
   const intervals = await fetchIntervals([...cachedScores.keys()]);
   const allItems = countryCodes.map((countryCode) => buildRankingItem(countryCode, cachedScores.get(countryCode), intervals.get(countryCode)));
+  // Plan 2026-04-26-002 §U7 (PR 6) — headline-eligible gate. The
+  // headline ranking endpoint returns ONLY items with
+  // `headlineEligible: true`; ineligible items move to `greyedOut`
+  // alongside the existing low-coverage greyout. This is the load-
+  // bearing change from PR 2's "headlineEligible: true everywhere"
+  // contract: real eligibility logic now decides the front-of-house
+  // ranking. Raw API endpoints (get-resilience-score per-country)
+  // continue to return the full set with `headlineEligible: false`
+  // surfaced; only the *ranking* endpoint applies the filter.
+  const passesHeadlineGate = (item: ResilienceRankingItem): boolean =>
+    item.overallCoverage >= GREY_OUT_COVERAGE_THRESHOLD && item.headlineEligible === true;
   const response: GetResilienceRankingResponse = {
-    items: sortRankingItems(allItems.filter((item) => item.overallCoverage >= GREY_OUT_COVERAGE_THRESHOLD)),
-    greyedOut: allItems.filter((item) => item.overallCoverage < GREY_OUT_COVERAGE_THRESHOLD),
+    items: sortRankingItems(allItems.filter(passesHeadlineGate)),
+    greyedOut: allItems.filter((item) => !passesHeadlineGate(item)),
   };
 
   // Cache the ranking when we have substantive coverage — don't hold out for 100%.

--- a/tests/helpers/resilience-release-fixtures.mts
+++ b/tests/helpers/resilience-release-fixtures.mts
@@ -394,6 +394,19 @@ export function buildReleaseGateFixtures(): ReleaseGateFixtureMap {
     };
   }
 
+  // Plan 2026-04-26-002 §U7 (PR 6) — IMF labor seed must carry
+  // population for the headline-eligible gate's "population >= 200k"
+  // branch. Without this fixture, every release-gate country would
+  // fall through to the coverage>=0.85 conjunct only; G20+EU27
+  // members are by definition large states (well above 0.2M) so a
+  // uniform 50M placeholder satisfies the gate without distorting
+  // any other test that reads this seed.
+  fixtures['economic:imf:labor:v1'] = {
+    countries: Object.fromEntries(
+      descriptors.map(({ code }) => [code, { unemploymentPct: 5.0, populationMillions: 50, year: 2025 }]),
+    ),
+    seededAt: '2026-04-04T00:00:00.000Z',
+  };
   fixtures['economic:national-debt:v1'] = { entries: debtEntries };
   fixtures['economic:bis:credit:v1'] = { entries: bisCreditEntries };
   fixtures['economic:bis:eer:v1'] = { rates: bisExchangeRates };

--- a/tests/resilience-handlers.test.mts
+++ b/tests/resilience-handlers.test.mts
@@ -28,7 +28,7 @@ describe('resilience handlers', () => {
     delete process.env.VERCEL_ENV;
 
     const { fetchImpl, redis, sortedSets } = createRedisFetch(RESILIENCE_FIXTURES);
-    sortedSets.set('resilience:history:v11:US', [
+    sortedSets.set('resilience:history:v12:US', [
       { member: '2026-04-01:20', score: 20260401 },
       { member: '2026-04-02:30', score: 20260402 },
     ]);
@@ -60,16 +60,16 @@ describe('resilience handlers', () => {
     assert.ok(response.stressFactor >= 0 && response.stressFactor <= 0.5, `stressFactor out of bounds: ${response.stressFactor}`);
     assert.equal(response.dataVersion, '2024-04-03', 'dataVersion should be the ISO date from seed-meta fetchedAt');
 
-    const cachedScore = redis.get('resilience:score:v16:US');
+    const cachedScore = redis.get('resilience:score:v17:US');
     assert.ok(cachedScore, 'expected score cache to be written');
     assert.equal(JSON.parse(cachedScore || '{}').countryCode, 'US');
 
-    const history = sortedSets.get('resilience:history:v11:US') ?? [];
+    const history = sortedSets.get('resilience:history:v12:US') ?? [];
     assert.ok(history.some((entry) => entry.member.startsWith(today + ':')), 'expected today history member to be written');
 
     await getResilienceScore({ request: new Request('https://example.com') } as never, {
       countryCode: 'US',
     });
-    assert.equal((sortedSets.get('resilience:history:v11:US') ?? []).length, history.length, 'cache hit must not append history');
+    assert.equal((sortedSets.get('resilience:history:v12:US') ?? []).length, history.length, 'cache hit must not append history');
   });
 });

--- a/tests/resilience-headline-eligible-gate.test.mts
+++ b/tests/resilience-headline-eligible-gate.test.mts
@@ -1,0 +1,101 @@
+// Plan 2026-04-26-002 §U7 (PR 6) — pinning tests for the
+// headline-eligible gate logic + the ranking-handler filter.
+//
+// PR 6 swaps `headlineEligible` from the PR-2 default `true` to actual
+// eligibility per origin Q2 + Q5:
+//   coverage >= 0.65 AND (population >= 200k OR coverage >= 0.85) AND !lowConfidence
+//
+// These tests pin the truth table directly via `computeHeadlineEligible`
+// and assert the ranking handler filters by the field.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  computeHeadlineEligible,
+  HEADLINE_ELIGIBLE_HIGH_COVERAGE,
+  HEADLINE_ELIGIBLE_MIN_COVERAGE,
+  HEADLINE_ELIGIBLE_MIN_POPULATION_MILLIONS,
+} from '../server/worldmonitor/resilience/v1/_shared.ts';
+
+describe('computeHeadlineEligible truth table (Plan 2026-04-26-002 §U7)', () => {
+  it('happy path: high coverage + large population + not lowConfidence → true', () => {
+    assert.equal(
+      computeHeadlineEligible({ overallCoverage: 0.9, populationMillions: 100, lowConfidence: false }),
+      true,
+    );
+  });
+
+  it('lowConfidence short-circuits to false regardless of other signals', () => {
+    assert.equal(
+      computeHeadlineEligible({ overallCoverage: 0.99, populationMillions: 1000, lowConfidence: true }),
+      false,
+      'lowConfidence must dominate — even perfect coverage + huge population fail',
+    );
+  });
+
+  it('coverage just below 0.65 floor → false even with large population', () => {
+    assert.equal(
+      computeHeadlineEligible({ overallCoverage: 0.64, populationMillions: 100, lowConfidence: false }),
+      false,
+      `${HEADLINE_ELIGIBLE_MIN_COVERAGE} is the absolute floor; below it, no compensator helps`,
+    );
+  });
+
+  it('coverage at 0.65 floor + large population → true', () => {
+    assert.equal(
+      computeHeadlineEligible({ overallCoverage: HEADLINE_ELIGIBLE_MIN_COVERAGE, populationMillions: 50, lowConfidence: false }),
+      true,
+    );
+  });
+
+  it('tiny state (< 200k pop) with mid coverage 0.7 → false', () => {
+    // Iceland-shape: coverage 0.7 but pop 0.4M is below 0.2M floor?
+    // 0.4 > 0.2 → passes. Test with a real micro-state: pop 0.05M.
+    assert.equal(
+      computeHeadlineEligible({ overallCoverage: 0.7, populationMillions: 0.05, lowConfidence: false }),
+      false,
+      'micro-state without high-quality data fails the gate',
+    );
+  });
+
+  it('tiny state (< 200k pop) with high coverage >= 0.85 → true (data-quality compensator)', () => {
+    assert.equal(
+      computeHeadlineEligible({ overallCoverage: HEADLINE_ELIGIBLE_HIGH_COVERAGE, populationMillions: 0.05, lowConfidence: false }),
+      true,
+      'high-coverage micro-state earns headline status (Iceland-class with 0.85+ coverage)',
+    );
+  });
+
+  it('unknown population (null) + mid coverage → false (conservative default)', () => {
+    assert.equal(
+      computeHeadlineEligible({ overallCoverage: 0.75, populationMillions: null, lowConfidence: false }),
+      false,
+      'unknown population fails the population branch; needs coverage >= 0.85 alone to pass',
+    );
+  });
+
+  it('unknown population (null) + coverage >= 0.85 → true (coverage compensator alone)', () => {
+    assert.equal(
+      computeHeadlineEligible({ overallCoverage: HEADLINE_ELIGIBLE_HIGH_COVERAGE, populationMillions: null, lowConfidence: false }),
+      true,
+      'unknown-pop country can earn headline status via the high-coverage branch',
+    );
+  });
+
+  it('boundary: population at exactly 200k floor → true', () => {
+    assert.equal(
+      computeHeadlineEligible({ overallCoverage: 0.7, populationMillions: HEADLINE_ELIGIBLE_MIN_POPULATION_MILLIONS, lowConfidence: false }),
+      true,
+      '0.2M is the inclusive boundary',
+    );
+  });
+
+  it('boundary: population just below 200k → false (population branch)', () => {
+    assert.equal(
+      computeHeadlineEligible({ overallCoverage: 0.7, populationMillions: 0.19, lowConfidence: false }),
+      false,
+      '0.19M < 0.2M → fails population branch; coverage 0.7 < 0.85 → fails coverage branch',
+    );
+  });
+});

--- a/tests/resilience-pillar-aggregation.test.mts
+++ b/tests/resilience-pillar-aggregation.test.mts
@@ -157,8 +157,8 @@ describe('pillar constants', () => {
     assert.equal(PENALTY_ALPHA, 0.50);
   });
 
-  it('RESILIENCE_SCORE_CACHE_PREFIX is v16', () => {
-    assert.equal(RESILIENCE_SCORE_CACHE_PREFIX, 'resilience:score:v16:');
+  it('RESILIENCE_SCORE_CACHE_PREFIX is v17', () => {
+    assert.equal(RESILIENCE_SCORE_CACHE_PREFIX, 'resilience:score:v17:');
   });
 
   it('PILLAR_ORDER has 3 entries', () => {

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -61,14 +61,14 @@ describe('resilience ranking contracts', () => {
     // so fixtures must carry the `_formula` tag matching the current env
     // (default flag-off ⇒ 'd6'). Writing the tagged shape here mirrors
     // what the handler persists via stampRankingCacheTag.
-    redis.set('resilience:ranking:v16', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
+    redis.set('resilience:ranking:v17', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
     // The handler strips `_formula` before returning, so response matches
     // the public shape rather than the on-wire cache shape.
     assert.deepEqual(response, cachedPublic);
-    assert.equal(redis.has('resilience:score:v16:YE'), false, 'cache hit must not trigger score warmup');
+    assert.equal(redis.has('resilience:score:v17:YE'), false, 'cache hit must not trigger score warmup');
   });
 
   it('backfills headlineEligible on cached items written before PR 2 (review fix)', async () => {
@@ -86,7 +86,7 @@ describe('resilience ranking contracts', () => {
         { countryCode: 'SS', overallScore: 12, level: 'critical', lowConfidence: true, overallCoverage: 0.15 },
       ],
     };
-    redis.set('resilience:ranking:v16', JSON.stringify({ ...legacyCached, _formula: 'd6' }));
+    redis.set('resilience:ranking:v17', JSON.stringify({ ...legacyCached, _formula: 'd6' }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
@@ -111,12 +111,12 @@ describe('resilience ranking contracts', () => {
         { countryCode: 'ER', overallScore: 10, level: 'critical', lowConfidence: true, overallCoverage: 0.12, headlineEligible: true },
       ],
     };
-    redis.set('resilience:ranking:v16', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
+    redis.set('resilience:ranking:v17', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
     assert.deepEqual(response, cachedPublic);
-    assert.equal(redis.has('resilience:score:v16:SS'), false, 'all-greyed-out cache hit must not trigger score warmup');
+    assert.equal(redis.has('resilience:score:v17:SS'), false, 'all-greyed-out cache hit must not trigger score warmup');
   });
 
   it('bulk-read path skips untagged per-country score entries (legacy writes must rebuild on flip)', async () => {
@@ -143,13 +143,13 @@ describe('resilience ranking contracts', () => {
 
     const domain = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
     // Tagged entry: served as-is.
-    redis.set('resilience:score:v16:NO', JSON.stringify({
+    redis.set('resilience:score:v17:NO', JSON.stringify({
       countryCode: 'NO', overallScore: 82, level: 'high',
       domains: domain, trend: 'stable', change30d: 1.2,
       lowConfidence: false, imputationShare: 0.05, _formula: 'd6',
     }));
     // Untagged entry: must be rejected, ranking warm rebuilds US.
-    redis.set('resilience:score:v16:US', JSON.stringify({
+    redis.set('resilience:score:v17:US', JSON.stringify({
       countryCode: 'US', overallScore: 61, level: 'medium',
       domains: domain, trend: 'rising', change30d: 4.3,
       lowConfidence: false, imputationShare: 0.1,
@@ -162,7 +162,7 @@ describe('resilience ranking contracts', () => {
     // `_formula: 'd6'`. If the bulk read had ADMITTED the untagged
     // entry (the pre-fix bug), the warm path for US would not have
     // run, and the stored value would still be untagged.
-    const rewrittenRaw = redis.get('resilience:score:v16:US');
+    const rewrittenRaw = redis.get('resilience:score:v17:US');
     assert.ok(rewrittenRaw, 'US entry must remain in Redis after the ranking run');
     const rewritten = JSON.parse(rewrittenRaw!);
     assert.equal(
@@ -189,7 +189,7 @@ describe('resilience ranking contracts', () => {
       greyedOut: [],
       _formula: 'pc', // mismatched — current env is flag-off ⇒ current='d6'
     };
-    redis.set('resilience:ranking:v16', JSON.stringify(stale));
+    redis.set('resilience:ranking:v17', JSON.stringify(stale));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
@@ -201,7 +201,7 @@ describe('resilience ranking contracts', () => {
     // Recompute path warms missing per-country scores, so YE (in
     // RESILIENCE_FIXTURES) must get scored during this call.
     assert.ok(
-      redis.has('resilience:score:v16:YE'),
+      redis.has('resilience:score:v17:YE'),
       'stale-formula reject must trigger the recompute-and-warm path',
     );
   });
@@ -209,7 +209,7 @@ describe('resilience ranking contracts', () => {
   it('warms missing scores synchronously and returns complete ranking on first call', async () => {
     const { redis } = installRedis(RESILIENCE_FIXTURES);
     const domainWithCoverage = [{ name: 'political', dimensions: [{ name: 'd1', coverage: 0.9 }] }];
-    redis.set('resilience:score:v16:NO', JSON.stringify({
+    redis.set('resilience:score:v17:NO', JSON.stringify({
       countryCode: 'NO',
       overallScore: 82,
       level: 'high',
@@ -219,7 +219,7 @@ describe('resilience ranking contracts', () => {
       lowConfidence: false,
       imputationShare: 0.05,
     }));
-    redis.set('resilience:score:v16:US', JSON.stringify({
+    redis.set('resilience:score:v17:US', JSON.stringify({
       countryCode: 'US',
       overallScore: 61,
       level: 'medium',
@@ -234,20 +234,20 @@ describe('resilience ranking contracts', () => {
 
     const totalItems = response.items.length + (response.greyedOut?.length ?? 0);
     assert.equal(totalItems, 3, `expected 3 total items across ranked + greyedOut, got ${totalItems}`);
-    assert.ok(redis.has('resilience:score:v16:YE'), 'missing country should be warmed during first call');
+    assert.ok(redis.has('resilience:score:v17:YE'), 'missing country should be warmed during first call');
     assert.ok(response.items.every((item) => item.overallScore >= 0), 'ranked items should all have computed scores');
-    assert.ok(redis.has('resilience:ranking:v16'), 'fully scored ranking should be cached');
+    assert.ok(redis.has('resilience:ranking:v17'), 'fully scored ranking should be cached');
   });
 
   it('sets rankStable=true when interval data exists and width <= 8', async () => {
     const { redis } = installRedis(RESILIENCE_FIXTURES);
     const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
-    redis.set('resilience:score:v16:NO', JSON.stringify({
+    redis.set('resilience:score:v17:NO', JSON.stringify({
       countryCode: 'NO', overallScore: 82, level: 'high',
       domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
       lowConfidence: false, imputationShare: 0.05,
     }));
-    redis.set('resilience:score:v16:US', JSON.stringify({
+    redis.set('resilience:score:v17:US', JSON.stringify({
       countryCode: 'US', overallScore: 61, level: 'medium',
       domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
       lowConfidence: false, imputationShare: 0.1,
@@ -274,12 +274,12 @@ describe('resilience ranking contracts', () => {
       seedYear: 2025,
     }));
     const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
-    redis.set('resilience:score:v16:NO', JSON.stringify({
+    redis.set('resilience:score:v17:NO', JSON.stringify({
       countryCode: 'NO', overallScore: 82, level: 'high',
       domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
       lowConfidence: false, imputationShare: 0.05,
     }));
-    redis.set('resilience:score:v16:US', JSON.stringify({
+    redis.set('resilience:score:v17:US', JSON.stringify({
       countryCode: 'US', overallScore: 61, level: 'medium',
       domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
       lowConfidence: false, imputationShare: 0.1,
@@ -289,7 +289,7 @@ describe('resilience ranking contracts', () => {
 
     // 3 of 4 (NO + US pre-cached, YE warmed from fixtures, ZZ can't be warmed)
     // = 75% which meets the threshold — must cache.
-    assert.ok(redis.has('resilience:ranking:v16'), 'ranking must be cached at exactly 75% coverage');
+    assert.ok(redis.has('resilience:ranking:v17'), 'ranking must be cached at exactly 75% coverage');
     assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written alongside the ranking');
   });
 
@@ -320,7 +320,7 @@ describe('resilience ranking contracts', () => {
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
         const allScoreReads = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'GET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v16:'),
+          (cmd) => cmd[0] === 'GET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v17:'),
         );
         if (allScoreReads) {
           // Simulate visibility lag: pretend no scores are cached yet.
@@ -336,13 +336,13 @@ describe('resilience ranking contracts', () => {
 
     await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
-    assert.ok(redis.has('resilience:ranking:v16'), 'ranking must be published despite pipeline-GET race');
+    assert.ok(redis.has('resilience:ranking:v17'), 'ranking must be published despite pipeline-GET race');
     assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written despite pipeline-GET race');
   });
 
   it('parity check: refuses meta write when Upstash returns SET=OK but EXISTS shows keys did not durably persist (2026-04-27 incident)', async () => {
     // Production observation 2026-04-27 (resilienceIntervals): seed-meta said
-    // scored=196 while a SCAN of resilience:score:v16:* showed only 2 keys.
+    // scored=196 while a SCAN of resilience:score:v17:* showed only 2 keys.
     // Mechanism: under saturated edge-runtime conditions, Upstash REST can
     // return result:'OK' for SETs that don't durably persist. The handler's
     // existing persistence guard (`persistResults[i]?.result === 'OK'`)
@@ -369,7 +369,7 @@ describe('resilience ranking contracts', () => {
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
         const allScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v16:'),
+          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v17:'),
         );
         if (allScoreSets) {
           // Return OK without mutating redis — the lying-Upstash scenario.
@@ -385,7 +385,7 @@ describe('resilience ranking contracts', () => {
 
     await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
-    assert.equal(redis.has('resilience:ranking:v16'), false,
+    assert.equal(redis.has('resilience:ranking:v17'), false,
       'ranking must NOT be published when score SETs returned OK but did not durably persist');
     assert.equal(redis.has('seed-meta:resilience:ranking'), false,
       'seed-meta must NOT be written when parity check fails — that would be a lying meta');
@@ -416,12 +416,12 @@ describe('resilience ranking contracts', () => {
     }));
     const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
     // Pre-cache NO + US WITH formula tag so getCachedResilienceScores admits them.
-    redis.set('resilience:score:v16:NO', JSON.stringify({
+    redis.set('resilience:score:v17:NO', JSON.stringify({
       countryCode: 'NO', overallScore: 82, level: 'high',
       domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
       lowConfidence: false, imputationShare: 0.05, _formula: 'd6',
     }));
-    redis.set('resilience:score:v16:US', JSON.stringify({
+    redis.set('resilience:score:v17:US', JSON.stringify({
       countryCode: 'US', overallScore: 61, level: 'medium',
       domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
       lowConfidence: false, imputationShare: 0.1, _formula: 'd6',
@@ -436,7 +436,7 @@ describe('resilience ranking contracts', () => {
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
         const allScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v16:'),
+          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v17:'),
         );
         if (allScoreSets) {
           // Return OK without mutating redis — the warmed-tail keys
@@ -460,7 +460,7 @@ describe('resilience ranking contracts', () => {
     // Post-fix (sample from warmedCountryCodes only): YE + ZZ are
     // sampled, neither exists in Redis, parity check fails, meta
     // refused.
-    assert.equal(redis.has('resilience:ranking:v16'), false,
+    assert.equal(redis.has('resilience:ranking:v17'), false,
       'ranking must NOT be published when warmed-tail keys returned OK but did not persist (mixed-failure mode)');
     assert.equal(redis.has('seed-meta:resilience:ranking'), false,
       'seed-meta must NOT lie when only the warmed tail failed — sampling must focus on warmed entries, not cachedScores broadly');
@@ -470,8 +470,8 @@ describe('resilience ranking contracts', () => {
     // Reviewer regression: passing `raw=true` to runRedisPipeline bypasses the
     // env-based key prefix (preview: / dev:) that isolates preview deploys
     // from production. The symptom is asymmetric: preview reads hit
-    // `preview:<sha>:resilience:score:v16:XX` while preview writes landed at
-    // raw `resilience:score:v16:XX`, simultaneously (a) missing the preview
+    // `preview:<sha>:resilience:score:v17:XX` while preview writes landed at
+    // raw `resilience:score:v17:XX`, simultaneously (a) missing the preview
     // cache forever and (b) poisoning production's shared cache. Simulate a
     // preview deploy and assert the pipeline SET keys carry the prefix.
     // Shared afterEach snapshots/restores VERCEL_ENV + VERCEL_GIT_COMMIT_SHA
@@ -503,7 +503,7 @@ describe('resilience ranking contracts', () => {
 
     const scoreSetKeys = pipelineBodies
       .flat()
-      .filter((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v16:'))
+      .filter((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v17:'))
       .map((cmd) => cmd[1] as string);
     assert.ok(scoreSetKeys.length >= 2, `expected at least 2 score SETs, got ${scoreSetKeys.length}`);
     for (const key of scoreSetKeys) {
@@ -549,7 +549,7 @@ describe('resilience ranking contracts', () => {
       // fixture? No — but the auth-failed path returns the stale cache
       // unmodified, so NR survives the cache-filter).
       const stale = { items: [{ countryCode: 'NR', overallScore: 1, level: 'low', lowConfidence: true, overallCoverage: 0.5 }], greyedOut: [], _formula: 'd6' };
-      redis.set('resilience:ranking:v16', JSON.stringify(stale));
+      redis.set('resilience:ranking:v17', JSON.stringify(stale));
 
       // No X-WorldMonitor-Key → refresh must be ignored, stale cache returned.
       const unauth = new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1');
@@ -603,7 +603,7 @@ describe('resilience ranking contracts', () => {
       // rejected by the formula gate and the refresh path would not
       // get tested as intended.
       const stale = { items: [{ countryCode: 'ZZ', overallScore: 1, level: 'low', lowConfidence: true, overallCoverage: 0.5 }], greyedOut: [], _formula: 'd6' };
-      redis.set('resilience:ranking:v16', JSON.stringify(stale));
+      redis.set('resilience:ranking:v17', JSON.stringify(stale));
 
       const request = new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1', {
         headers: { 'X-WorldMonitor-Key': 'seed-secret' },
@@ -638,7 +638,7 @@ describe('resilience ranking contracts', () => {
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
         const isAllScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v16:'),
+          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes('resilience:score:v17:'),
         );
         if (isAllScoreSets) setPipelineSizes.push(commands.length);
       }
@@ -670,7 +670,7 @@ describe('resilience ranking contracts', () => {
       seedYear: 2026,
     }));
 
-    // Intercept any pipeline SET to resilience:score:v16:* and reply with
+    // Intercept any pipeline SET to resilience:score:v17:* and reply with
     // non-OK results (persisted but authoritative signal says no). /set and
     // other paths pass through normally so history/interval writes succeed.
     const blockedScoreWrites = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -678,7 +678,7 @@ describe('resilience ranking contracts', () => {
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
         const allScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v16:'),
+          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith('resilience:score:v17:'),
         );
         if (allScoreSets) {
           return new Response(
@@ -693,7 +693,7 @@ describe('resilience ranking contracts', () => {
 
     await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
-    assert.ok(!redis.has('resilience:ranking:v16'), 'ranking must NOT be published when score writes failed');
+    assert.ok(!redis.has('resilience:ranking:v17'), 'ranking must NOT be published when score writes failed');
     assert.ok(!redis.has('seed-meta:resilience:ranking'), 'seed-meta must NOT be written when score writes failed');
   });
 

--- a/tests/resilience-scores-seed.test.mjs
+++ b/tests/resilience-scores-seed.test.mjs
@@ -10,12 +10,12 @@ import {
 } from '../scripts/seed-resilience-scores.mjs';
 
 describe('exported constants', () => {
-  it('RESILIENCE_RANKING_CACHE_KEY matches server-side key (v16)', () => {
-    assert.equal(RESILIENCE_RANKING_CACHE_KEY, 'resilience:ranking:v16');
+  it('RESILIENCE_RANKING_CACHE_KEY matches server-side key (v17)', () => {
+    assert.equal(RESILIENCE_RANKING_CACHE_KEY, 'resilience:ranking:v17');
   });
 
-  it('RESILIENCE_SCORE_CACHE_PREFIX matches server-side prefix (v16)', () => {
-    assert.equal(RESILIENCE_SCORE_CACHE_PREFIX, 'resilience:score:v16:');
+  it('RESILIENCE_SCORE_CACHE_PREFIX matches server-side prefix (v17)', () => {
+    assert.equal(RESILIENCE_SCORE_CACHE_PREFIX, 'resilience:score:v17:');
   });
 
   it('RESILIENCE_RANKING_CACHE_TTL_SECONDS is 12 hours (2x cron interval)', () => {


### PR DESCRIPTION
## Summary

Plan 2026-04-26-002 §U7 (PR 6 in the 8-PR sequence) — flips `headlineEligible` from PR 2's "true everywhere" no-behavior-change contract to the actual eligibility logic:

> **`coverage >= 0.65 AND (population >= 200k OR coverage >= 0.85) AND !lowConfidence`**

The headline ranking endpoint (`get-resilience-ranking.ts`) now filters `items[]` by `headlineEligible: true`; ineligible items move to `greyedOut`. Raw API endpoints (per-country score) keep returning the full set with the field surfaced — only the *ranking* endpoint applies the filter.

## Why this matters empirically

- Tiny states with sub-200k population are excluded from the headline ranking unless data quality is exceptional (≥85% coverage). This compounds with the §U6 per-capita normalization that already shipped in #3452 to address the small-state bias the entire plan was scoped to fix.
- Unknown-population countries (no IMF labor entry) default to the conservative path: they only earn headline status via the `coverage >= 0.85` branch alone — no inflated permissiveness from a default-pop assumption.
- The data-quality compensator (coverage ≥ 0.85) preserves Iceland-class small states with high coverage in the headline.

## Files

- `_shared.ts`: new `computeHeadlineEligible()` + 3 exported constants. Wired into `buildResilienceScore` response. Reader memoization extended.
- `_dimension-scorers.ts`: exported `RESILIENCE_IMF_LABOR_KEY` + new `readCountryPopulationMillionsForGate()` helper (returns `null` for unknown, no §U6 floor).
- `get-resilience-ranking.ts`: `passesHeadlineGate` predicate combining `GREY_OUT_COVERAGE_THRESHOLD` + `headlineEligible === true`. Items split.
- `tests/helpers/resilience-release-fixtures.mts`: add `economic:imf:labor:v1` fixture (50M placeholder for all 43 G20+EU27 countries).
- New `tests/resilience-headline-eligible-gate.test.mts`: 10 truth-table tests for `computeHeadlineEligible` — happy path, lowConfidence short-circuit, the 0.65 floor, the 200k boundary, the 0.85 compensator, and the unknown-pop conservative default.

## Cache prefix bumps (per `cache-prefix-bump-propagation-scope` skill)

- `RESILIENCE_SCORE_CACHE_PREFIX` v16 → v17 (pre-PR-6 score entries carry `headlineEligible: true` unconditionally — would let ineligible countries through the headline filter for the full 6h TTL post-deploy)
- `RESILIENCE_RANKING_CACHE_KEY` v16 → v17 (same)
- `RESILIENCE_HISTORY_KEY_PREFIX` v11 → v12 (lockstep)
- 10 hardcoded literal sites bulk-updated across `tests/`, `scripts/`, `api/health.js`
- Stale `(v16)` test descriptions updated to `(v17)`

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run typecheck:api` clean
- [x] `npm run lint` clean (exit 0)
- [x] `npm run test:data` — 7556/7556 pass (10 new + 7546 existing)
- [x] All response shapes carry the field; the new gate truth-table is fully covered

## References

- Plan: `docs/plans/2026-04-26-002-feat-resilience-universe-coverage-rebuild-plan.md`
- Predecessor (just merged): #3457 (PR 2 / §U3 — added the `headlineEligible` field)
- Earlier predecessor: #3452 (combined PR 3+4+5 — coverage penalty + source-comprehensive + per-capita)
- Next: PR 7 / §U8 — methodology rewrite + widget badge polish