### PR TITLE
fix(entitlements): preserve higher-tier sub when another sub on same userId expires

### DIFF
--- a/convex/__tests__/comp-entitlement.test.ts
+++ b/convex/__tests__/comp-entitlement.test.ts
@@ -280,3 +280,155 @@ describe("handleSubscriptionExpired comp guard", () => {
     expect(row!.compUntil).toBeGreaterThan(Date.now() + 80 * DAY_MS);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Multi-active-sub guard
+//
+// The entitlements table is keyed by_userId (one row per user), but Dodo
+// allows multiple concurrent subscriptions per user. Without this guard,
+// expiring or replacing one sub would clobber the entitlement to "free"
+// (or to a lower tier) even when another paid sub still covers the user.
+// ---------------------------------------------------------------------------
+
+describe("multi-active-sub guard", () => {
+  async function seedTwoActiveSubs(
+    t: ReturnType<typeof convexTest>,
+    opts: {
+      lower: { subscriptionId: string; planKey: string; productId: string };
+      higher: { subscriptionId: string; planKey: string; productId: string; tier: number };
+    },
+  ) {
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: USER_ID,
+        dodoSubscriptionId: opts.lower.subscriptionId,
+        dodoProductId: opts.lower.productId,
+        planKey: opts.lower.planKey,
+        status: "active",
+        currentPeriodStart: Date.now() - 30 * DAY_MS,
+        currentPeriodEnd: Date.now() + DAY_MS,
+        rawPayload: {},
+        updatedAt: Date.now() - 1000,
+      });
+      await ctx.db.insert("subscriptions", {
+        userId: USER_ID,
+        dodoSubscriptionId: opts.higher.subscriptionId,
+        dodoProductId: opts.higher.productId,
+        planKey: opts.higher.planKey,
+        status: "active",
+        currentPeriodStart: Date.now() - 30 * DAY_MS,
+        currentPeriodEnd: Date.now() + 30 * DAY_MS,
+        rawPayload: {},
+        updatedAt: Date.now() - 1000,
+      });
+      // Entitlement reflects the higher-tier sub (last-write-wins from when
+      // the user upgraded).
+      await ctx.db.insert("entitlements", {
+        userId: USER_ID,
+        planKey: opts.higher.planKey,
+        features: {
+          tier: opts.higher.tier,
+          maxDashboards: 25,
+          apiAccess: true,
+          apiRateLimit: 60,
+          prioritySupport: false,
+          exportFormats: ["csv", "pdf", "json"],
+        },
+        validUntil: Date.now() + 30 * DAY_MS,
+        updatedAt: Date.now() - 1000,
+      });
+    });
+  }
+
+  test("subscription.expired on the lower-tier sub preserves higher-tier entitlement", async () => {
+    const t = convexTest(schema, modules);
+    await seedTwoActiveSubs(t, {
+      lower: {
+        subscriptionId: "sub_pro_monthly",
+        planKey: "pro_monthly",
+        productId: "pdt_0Nbtt71uObulf7fGXhQup",
+      },
+      higher: {
+        subscriptionId: "sub_api_starter",
+        planKey: "api_starter",
+        productId: "pdt_0NbttVmG1SERrxhygbbUq",
+        tier: 2,
+      },
+    });
+
+    await fireSubscriptionExpired(t, "sub_pro_monthly");
+
+    const row = await readEntitlement(t);
+    // CRITICAL: must NOT downgrade to free — the api_starter sub is still active.
+    expect(row!.planKey).toBe("api_starter");
+    expect(row!.features.tier).toBe(2);
+    // validUntil should track the surviving sub's currentPeriodEnd.
+    expect(row!.validUntil).toBeGreaterThan(Date.now() + 25 * DAY_MS);
+  });
+
+  test("subscription.expired on the only sub still downgrades to free", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubAndEntitlement(t, {
+      subscriptionId: "sub_solo",
+      entitlementValidUntil: Date.now() + DAY_MS,
+    });
+    await fireSubscriptionExpired(t, "sub_solo");
+
+    const row = await readEntitlement(t);
+    expect(row!.planKey).toBe("free");
+    expect(row!.features.tier).toBe(0);
+  });
+
+  test("subscription.expired on cancelled-but-still-covering other sub is treated as covering", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      // Sub A: active, lower tier — about to expire.
+      await ctx.db.insert("subscriptions", {
+        userId: USER_ID,
+        dodoSubscriptionId: "sub_a_active_lower",
+        dodoProductId: "pdt_0Nbtt71uObulf7fGXhQup",
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: Date.now() - 30 * DAY_MS,
+        currentPeriodEnd: Date.now() + DAY_MS,
+        rawPayload: {},
+        updatedAt: Date.now() - 1000,
+      });
+      // Sub B: cancelled but currentPeriodEnd is in the future — still covers.
+      await ctx.db.insert("subscriptions", {
+        userId: USER_ID,
+        dodoSubscriptionId: "sub_b_cancelled_higher",
+        dodoProductId: "pdt_0NbttVmG1SERrxhygbbUq",
+        planKey: "api_starter",
+        status: "cancelled",
+        currentPeriodStart: Date.now() - 30 * DAY_MS,
+        currentPeriodEnd: Date.now() + 60 * DAY_MS,
+        cancelledAt: Date.now() - 5 * DAY_MS,
+        rawPayload: {},
+        updatedAt: Date.now() - 1000,
+      });
+      await ctx.db.insert("entitlements", {
+        userId: USER_ID,
+        planKey: "api_starter",
+        features: {
+          tier: 2,
+          maxDashboards: 25,
+          apiAccess: true,
+          apiRateLimit: 60,
+          prioritySupport: false,
+          exportFormats: ["csv", "pdf", "json"],
+        },
+        validUntil: Date.now() + 60 * DAY_MS,
+        updatedAt: Date.now() - 1000,
+      });
+    });
+
+    await fireSubscriptionExpired(t, "sub_a_active_lower");
+
+    const row = await readEntitlement(t);
+    // Sub B is cancelled but its paid period extends 60 days — the user
+    // should keep tier 2 access for that period.
+    expect(row!.planKey).toBe("api_starter");
+    expect(row!.features.tier).toBe(2);
+  });
+});

--- a/convex/__tests__/comp-entitlement.test.ts
+++ b/convex/__tests__/comp-entitlement.test.ts
@@ -431,4 +431,251 @@ describe("multi-active-sub guard", () => {
     expect(row!.planKey).toBe("api_starter");
     expect(row!.features.tier).toBe(2);
   });
+
+  // ---------------------------------------------------------------------
+  // Reviewer P1 #1 — guard must cover subscription.active and
+  // subscription.renewed paths, not just expired/plan_changed.
+  // ---------------------------------------------------------------------
+
+  async function fireSubscriptionRenewed(
+    t: ReturnType<typeof convexTest>,
+    subscriptionId: string,
+    productId: string,
+  ) {
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: `msg_test_${subscriptionId}_renewed`,
+      eventType: "subscription.renewed",
+      rawPayload: {
+        type: "subscription.renewed",
+        data: {
+          subscription_id: subscriptionId,
+          product_id: productId,
+          customer: { customer_id: "cus_test" },
+          metadata: { wm_user_id: USER_ID },
+          previous_billing_date: new Date(Date.now() - 1 * DAY_MS).toISOString(),
+          next_billing_date: new Date(Date.now() + 30 * DAY_MS).toISOString(),
+        },
+      },
+      timestamp: Date.now(),
+    });
+  }
+
+  test("subscription.renewed on lower-tier sub does NOT clobber higher-tier active sub", async () => {
+    const t = convexTest(schema, modules);
+    await seedTwoActiveSubs(t, {
+      lower: {
+        subscriptionId: "sub_pro_renewed",
+        planKey: "pro_monthly",
+        productId: "pdt_0Nbtt71uObulf7fGXhQup",
+      },
+      higher: {
+        subscriptionId: "sub_api_starter",
+        planKey: "api_starter",
+        productId: "pdt_0NbttVmG1SERrxhygbbUq",
+        tier: 2,
+      },
+    });
+
+    // The lower-tier sub renews monthly. Without the multi-active-sub guard
+    // covering the renewal path, this would write planKey="pro_monthly" tier=1
+    // into the entitlement row, silently downgrading the user.
+    await fireSubscriptionRenewed(t, "sub_pro_renewed", "pdt_0Nbtt71uObulf7fGXhQup");
+
+    const row = await readEntitlement(t);
+    expect(row!.planKey).toBe("api_starter");
+    expect(row!.features.tier).toBe(2);
+  });
+
+  test("subscription.active for a NEW lower-tier sub does NOT clobber existing higher-tier sub", async () => {
+    const t = convexTest(schema, modules);
+    // subscription.active calls resolvePlanKey (productPlans) and resolveUserId
+    // (HMAC-verified metadata OR customers lookup). Seed both — the customer
+    // row simulates the existing api_starter customer joining a second sub.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("productPlans", {
+        dodoProductId: "pdt_0Nbtt71uObulf7fGXhQup",
+        planKey: "pro_monthly",
+        displayName: "Pro Monthly",
+        isActive: true,
+      });
+      await ctx.db.insert("customers", {
+        userId: USER_ID,
+        dodoCustomerId: "cus_test",
+        email: "test@example.com",
+        normalizedEmail: "test@example.com",
+        createdAt: Date.now() - 60 * DAY_MS,
+        updatedAt: Date.now() - 60 * DAY_MS,
+      });
+    });
+    // Seed an existing higher-tier (api_starter) sub + entitlement.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: USER_ID,
+        dodoSubscriptionId: "sub_api_starter_existing",
+        dodoProductId: "pdt_0NbttVmG1SERrxhygbbUq",
+        planKey: "api_starter",
+        status: "active",
+        currentPeriodStart: Date.now() - 30 * DAY_MS,
+        currentPeriodEnd: Date.now() + 30 * DAY_MS,
+        rawPayload: {},
+        updatedAt: Date.now() - 1000,
+      });
+      await ctx.db.insert("entitlements", {
+        userId: USER_ID,
+        planKey: "api_starter",
+        features: {
+          tier: 2,
+          maxDashboards: 25,
+          apiAccess: true,
+          apiRateLimit: 60,
+          prioritySupport: false,
+          exportFormats: ["csv", "pdf", "json"],
+        },
+        validUntil: Date.now() + 30 * DAY_MS,
+        updatedAt: Date.now() - 1000,
+      });
+    });
+
+    // User accidentally subscribes to pro_monthly on the same userId
+    // (e.g. via an old checkout link). Dodo fires subscription.active.
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "msg_test_pro_active",
+      eventType: "subscription.active",
+      rawPayload: {
+        type: "subscription.active",
+        data: {
+          subscription_id: "sub_pro_new",
+          product_id: "pdt_0Nbtt71uObulf7fGXhQup",
+          customer: { customer_id: "cus_test", email: "test@example.com" },
+          metadata: { wm_user_id: USER_ID },
+          previous_billing_date: new Date(Date.now() - 1 * DAY_MS).toISOString(),
+          next_billing_date: new Date(Date.now() + 30 * DAY_MS).toISOString(),
+        },
+      },
+      timestamp: Date.now(),
+    });
+
+    const row = await readEntitlement(t);
+    // Entitlement must NOT have been clobbered to pro_monthly tier 1.
+    expect(row!.planKey).toBe("api_starter");
+    expect(row!.features.tier).toBe(2);
+  });
+
+  // ---------------------------------------------------------------------
+  // Reviewer P1 #2 — same-tier plans need a deterministic precedence.
+  // tier alone is insufficient: api_business and api_starter are both
+  // tier 2; pro_annual and pro_monthly are both tier 1.
+  // ---------------------------------------------------------------------
+
+  test("same-tier precedence: api_business outranks api_starter when both cover", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      // Two tier-2 subs. PLAN_PRECEDENCE gives api_business=30 over
+      // api_starter=20, so api_business must win regardless of insertion
+      // order or currentPeriodEnd.
+      await ctx.db.insert("subscriptions", {
+        userId: USER_ID,
+        dodoSubscriptionId: "sub_api_starter",
+        dodoProductId: "pdt_0NbttVmG1SERrxhygbbUq",
+        planKey: "api_starter",
+        status: "active",
+        currentPeriodStart: Date.now() - 30 * DAY_MS,
+        // Longer-lived than api_business deliberately — verifies that the
+        // capability tie-break (PLAN_PRECEDENCE) wins over the duration
+        // tie-break (currentPeriodEnd).
+        currentPeriodEnd: Date.now() + 90 * DAY_MS,
+        rawPayload: {},
+        updatedAt: Date.now() - 1000,
+      });
+      await ctx.db.insert("subscriptions", {
+        userId: USER_ID,
+        dodoSubscriptionId: "sub_api_business",
+        dodoProductId: "pdt_0Nbttg7NuOJrhbyBGCius",
+        planKey: "api_business",
+        status: "active",
+        currentPeriodStart: Date.now() - 30 * DAY_MS,
+        currentPeriodEnd: Date.now() + 30 * DAY_MS,
+        rawPayload: {},
+        updatedAt: Date.now() - 1000,
+      });
+      // Seed entitlement to whatever — the test asserts what recompute writes.
+      await ctx.db.insert("entitlements", {
+        userId: USER_ID,
+        planKey: "free",
+        features: {
+          tier: 0,
+          maxDashboards: 3,
+          apiAccess: false,
+          apiRateLimit: 0,
+          prioritySupport: false,
+          exportFormats: ["csv"],
+        },
+        validUntil: 0,
+        updatedAt: Date.now() - 1000,
+      });
+    });
+
+    // Trigger a recompute by firing renewed on the lower-precedence sub.
+    await fireSubscriptionRenewed(t, "sub_api_starter", "pdt_0NbttVmG1SERrxhygbbUq");
+
+    const row = await readEntitlement(t);
+    expect(row!.planKey).toBe("api_business");
+    // api_business has tier 2, but distinct features from api_starter:
+    // higher rate limit + priority support.
+    expect(row!.features.apiRateLimit).toBe(300);
+    expect(row!.features.prioritySupport).toBe(true);
+  });
+
+  test("comparator tie-break by currentPeriodEnd: same plan, longer-lived sub wins", async () => {
+    // This validates the comparator's third tie-break level. Two subs on the
+    // same planKey (both pro_monthly) — the recompute should pick the one
+    // with the later currentPeriodEnd, so the user's entitlement reflects
+    // their longest paid coverage.
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: USER_ID,
+        dodoSubscriptionId: "sub_pro_short",
+        dodoProductId: "pdt_0Nbtt71uObulf7fGXhQup",
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: Date.now() - 30 * DAY_MS,
+        currentPeriodEnd: Date.now() + 5 * DAY_MS,
+        rawPayload: {},
+        updatedAt: Date.now() - 1000,
+      });
+      await ctx.db.insert("subscriptions", {
+        userId: USER_ID,
+        dodoSubscriptionId: "sub_pro_long",
+        dodoProductId: "pdt_0Nbtt71uObulf7fGXhQup",
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: Date.now() - 30 * DAY_MS,
+        currentPeriodEnd: Date.now() + 60 * DAY_MS,
+        rawPayload: {},
+        updatedAt: Date.now() - 1000,
+      });
+      await ctx.db.insert("entitlements", {
+        userId: USER_ID,
+        planKey: "free",
+        features: {
+          tier: 0,
+          maxDashboards: 3,
+          apiAccess: false,
+          apiRateLimit: 0,
+          prioritySupport: false,
+          exportFormats: ["csv"],
+        },
+        validUntil: 0,
+        updatedAt: Date.now() - 1000,
+      });
+    });
+
+    await fireSubscriptionRenewed(t, "sub_pro_short", "pdt_0Nbtt71uObulf7fGXhQup");
+
+    const row = await readEntitlement(t);
+    expect(row!.planKey).toBe("pro_monthly");
+    // Recompute should pick the longer-lived one.
+    expect(row!.validUntil).toBeGreaterThan(Date.now() + 50 * DAY_MS);
+  });
 });

--- a/convex/config/productCatalog.ts
+++ b/convex/config/productCatalog.ts
@@ -239,6 +239,33 @@ export const LEGACY_PRODUCT_ALIASES: Record<string, string> = {
 // Derived helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Plan-level precedence for entitlement recompute.
+ *
+ * Higher value = stronger plan. Used by the entitlement-recompute helper in
+ * `subscriptionHelpers.ts` as the deterministic tie-breaker when a user has
+ * multiple covering subscriptions of the same `tier` (e.g. `api_starter` and
+ * `api_business` are both tier 2; monthly and annual variants of the same
+ * tier-group share `tier`). The order is:
+ *
+ *   1. higher `features.tier` wins (always)
+ *   2. higher `PLAN_PRECEDENCE` wins (capability tie-breaker within a tier)
+ *   3. later `currentPeriodEnd` wins (duration tie-breaker within the same plan)
+ *
+ * KEEP IN SYNC with PRODUCT_CATALOG. Any new planKey added to the catalog
+ * must also appear here, or the recompute helper falls back to 0 and the
+ * tie-break degenerates to currentPeriodEnd.
+ */
+export const PLAN_PRECEDENCE: Record<string, number> = {
+  free: 0,
+  pro_monthly: 10,
+  pro_annual: 11, // longer commitment outranks monthly at same tier
+  api_starter: 20,
+  api_starter_annual: 21,
+  api_business: 30, // higher capability than api_starter at same tier 2
+  enterprise: 40,
+};
+
 export function getEntitlementFeatures(planKey: string): PlanFeatures {
   const entry = PRODUCT_CATALOG[planKey];
   if (!entry) {

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -16,6 +16,7 @@ import { DodoPayments } from "dodopayments";
 import { resolveUserId, requireUserId } from "../lib/auth";
 import { getFeaturesForPlan } from "../lib/entitlements";
 import { PRODUCT_CATALOG, resolveProductToPlan } from "../config/productCatalog";
+import { recomputeEntitlementFromAllSubs } from "./subscriptionHelpers";
 
 // UUID v4 regex matching values produced by crypto.randomUUID() in user-identity.ts.
 // Hoisted to module scope to avoid re-allocation on every claimSubscription call.
@@ -517,104 +518,29 @@ export const deleteSubscriptionByDodoId = internalMutation({
       `[billing] deleteSubscriptionByDodoId userId=${userId} dodoSubscriptionId=${args.dodoSubscriptionId} planKey=${sub.planKey} reason="${args.reason}"`,
     );
 
-    // Recompute entitlement from any remaining active sub. If none, downgrade
-    // to free — but only if no compUntil floor is in place.
+    // Re-derive the entitlement from the user's REMAINING subscriptions
+    // through the same shared helper that subscription event handlers use.
+    // This guarantees identical precedence (tier > PLAN_PRECEDENCE >
+    // currentPeriodEnd) and identical comp-floor handling, so admin cleanup
+    // can never produce an entitlement state that an organic webhook flow
+    // wouldn't have produced.
     const now = Date.now();
-    const remaining = await ctx.db
-      .query("subscriptions")
-      .withIndex("by_userId", (q) => q.eq("userId", userId))
-      .collect();
+    await recomputeEntitlementFromAllSubs(ctx, userId, now);
 
-    let best: (typeof remaining)[number] | null = null;
-    let bestTier = -Infinity;
-    for (const s of remaining) {
-      const isCovering =
-        s.status === "active" ||
-        s.status === "on_hold" ||
-        (s.status === "cancelled" && s.currentPeriodEnd > now);
-      if (!isCovering) continue;
-      const tier = getFeaturesForPlan(s.planKey).tier;
-      if (tier > bestTier) {
-        best = s;
-        bestTier = tier;
-      }
-    }
-
-    const entitlement = await ctx.db
+    const entitlementAfter = await ctx.db
       .query("entitlements")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
       .first();
 
-    if (best) {
-      const features = getFeaturesForPlan(best.planKey);
-      if (entitlement) {
-        await ctx.db.patch(entitlement._id, {
-          planKey: best.planKey,
-          features,
-          validUntil: best.currentPeriodEnd,
-          updatedAt: now,
-        });
-      } else {
-        await ctx.db.insert("entitlements", {
-          userId,
-          planKey: best.planKey,
-          features,
-          validUntil: best.currentPeriodEnd,
-          updatedAt: now,
-        });
-      }
-      if (process.env.UPSTASH_REDIS_REST_URL) {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.payments.cacheActions.syncEntitlementCache,
-          { userId, planKey: best.planKey, features, validUntil: best.currentPeriodEnd },
-        );
-      }
-      return {
-        deleted: { _id: sub._id, dodoSubscriptionId: args.dodoSubscriptionId, planKey: sub.planKey },
-        entitlementAfter: { planKey: best.planKey, validUntil: best.currentPeriodEnd },
-      };
-    }
-
-    // No remaining active sub. Honour comp floor if present.
-    if (entitlement?.compUntil && entitlement.compUntil > now) {
-      console.log(
-        `[billing] deleteSubscriptionByDodoId — no active subs remain, but compUntil=${new Date(entitlement.compUntil).toISOString()} preserves entitlement`,
-      );
-      return {
-        deleted: { _id: sub._id, dodoSubscriptionId: args.dodoSubscriptionId, planKey: sub.planKey },
-        entitlementAfter: { planKey: entitlement.planKey, validUntil: entitlement.validUntil, compUntil: entitlement.compUntil },
-      };
-    }
-
-    // Downgrade to free.
-    const freeFeatures = getFeaturesForPlan("free");
-    if (entitlement) {
-      await ctx.db.patch(entitlement._id, {
-        planKey: "free",
-        features: freeFeatures,
-        validUntil: now,
-        updatedAt: now,
-      });
-    } else {
-      await ctx.db.insert("entitlements", {
-        userId,
-        planKey: "free",
-        features: freeFeatures,
-        validUntil: now,
-        updatedAt: now,
-      });
-    }
-    if (process.env.UPSTASH_REDIS_REST_URL) {
-      await ctx.scheduler.runAfter(
-        0,
-        internal.payments.cacheActions.syncEntitlementCache,
-        { userId, planKey: "free", features: freeFeatures, validUntil: now },
-      );
-    }
     return {
       deleted: { _id: sub._id, dodoSubscriptionId: args.dodoSubscriptionId, planKey: sub.planKey },
-      entitlementAfter: { planKey: "free", validUntil: now },
+      entitlementAfter: entitlementAfter
+        ? {
+            planKey: entitlementAfter.planKey,
+            validUntil: entitlementAfter.validUntil,
+            ...(entitlementAfter.compUntil !== undefined ? { compUntil: entitlementAfter.compUntil } : {}),
+          }
+        : null,
     };
   },
 });

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -473,3 +473,148 @@ export const grantComplimentaryEntitlement = internalMutation({
     };
   },
 });
+
+/**
+ * Deletes a subscription row from Convex by Dodo subscription_id.
+ *
+ * Ops tool. Use when a Dodo subscription was cancelled/refunded admin-side
+ * but you don't want its eventual `subscription.expired` webhook to clobber
+ * the user's entitlement (e.g. user upgraded by buying a separate higher-tier
+ * sub on the same userId — see the multi-active-sub guard in
+ * subscriptionHelpers.ts; this mutation is the explicit-cleanup counterpart
+ * for cases where you want zero-risk by removing the row entirely).
+ *
+ * Recomputes the entitlement from the user's remaining active subs after
+ * deletion. If none remain, downgrades to free.
+ *
+ * The audit trail (paymentEvents, webhookEvents) is preserved.
+ *
+ * Typical usage (CLI):
+ *   npx convex run 'payments/billing:deleteSubscriptionByDodoId' \
+ *     '{"dodoSubscriptionId":"sub_XXX","reason":"refunded by admin, user has higher-tier active sub"}'
+ */
+export const deleteSubscriptionByDodoId = internalMutation({
+  args: {
+    dodoSubscriptionId: v.string(),
+    reason: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const sub = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_dodoSubscriptionId", (q) =>
+        q.eq("dodoSubscriptionId", args.dodoSubscriptionId),
+      )
+      .unique();
+    if (!sub) {
+      throw new Error(
+        `[billing] deleteSubscriptionByDodoId: no subscription found with dodoSubscriptionId="${args.dodoSubscriptionId}"`,
+      );
+    }
+
+    const userId = sub.userId;
+    await ctx.db.delete(sub._id);
+    console.log(
+      `[billing] deleteSubscriptionByDodoId userId=${userId} dodoSubscriptionId=${args.dodoSubscriptionId} planKey=${sub.planKey} reason="${args.reason}"`,
+    );
+
+    // Recompute entitlement from any remaining active sub. If none, downgrade
+    // to free — but only if no compUntil floor is in place.
+    const now = Date.now();
+    const remaining = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .collect();
+
+    let best: (typeof remaining)[number] | null = null;
+    let bestTier = -Infinity;
+    for (const s of remaining) {
+      const isCovering =
+        s.status === "active" ||
+        s.status === "on_hold" ||
+        (s.status === "cancelled" && s.currentPeriodEnd > now);
+      if (!isCovering) continue;
+      const tier = getFeaturesForPlan(s.planKey).tier;
+      if (tier > bestTier) {
+        best = s;
+        bestTier = tier;
+      }
+    }
+
+    const entitlement = await ctx.db
+      .query("entitlements")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .first();
+
+    if (best) {
+      const features = getFeaturesForPlan(best.planKey);
+      if (entitlement) {
+        await ctx.db.patch(entitlement._id, {
+          planKey: best.planKey,
+          features,
+          validUntil: best.currentPeriodEnd,
+          updatedAt: now,
+        });
+      } else {
+        await ctx.db.insert("entitlements", {
+          userId,
+          planKey: best.planKey,
+          features,
+          validUntil: best.currentPeriodEnd,
+          updatedAt: now,
+        });
+      }
+      if (process.env.UPSTASH_REDIS_REST_URL) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.payments.cacheActions.syncEntitlementCache,
+          { userId, planKey: best.planKey, features, validUntil: best.currentPeriodEnd },
+        );
+      }
+      return {
+        deleted: { _id: sub._id, dodoSubscriptionId: args.dodoSubscriptionId, planKey: sub.planKey },
+        entitlementAfter: { planKey: best.planKey, validUntil: best.currentPeriodEnd },
+      };
+    }
+
+    // No remaining active sub. Honour comp floor if present.
+    if (entitlement?.compUntil && entitlement.compUntil > now) {
+      console.log(
+        `[billing] deleteSubscriptionByDodoId — no active subs remain, but compUntil=${new Date(entitlement.compUntil).toISOString()} preserves entitlement`,
+      );
+      return {
+        deleted: { _id: sub._id, dodoSubscriptionId: args.dodoSubscriptionId, planKey: sub.planKey },
+        entitlementAfter: { planKey: entitlement.planKey, validUntil: entitlement.validUntil, compUntil: entitlement.compUntil },
+      };
+    }
+
+    // Downgrade to free.
+    const freeFeatures = getFeaturesForPlan("free");
+    if (entitlement) {
+      await ctx.db.patch(entitlement._id, {
+        planKey: "free",
+        features: freeFeatures,
+        validUntil: now,
+        updatedAt: now,
+      });
+    } else {
+      await ctx.db.insert("entitlements", {
+        userId,
+        planKey: "free",
+        features: freeFeatures,
+        validUntil: now,
+        updatedAt: now,
+      });
+    }
+    if (process.env.UPSTASH_REDIS_REST_URL) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.payments.cacheActions.syncEntitlementCache,
+        { userId, planKey: "free", features: freeFeatures, validUntil: now },
+      );
+    }
+    return {
+      deleted: { _id: sub._id, dodoSubscriptionId: args.dodoSubscriptionId, planKey: sub.planKey },
+      entitlementAfter: { planKey: "free", validUntil: now },
+    };
+  },
+});

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -9,6 +9,7 @@
 import { MutationCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { getFeaturesForPlan } from "../lib/entitlements";
+import { PLAN_PRECEDENCE } from "../config/productCatalog";
 import { verifyUserId } from "../lib/identitySigning";
 import { DEV_USER_ID, isDev } from "../lib/auth";
 
@@ -121,6 +122,135 @@ export async function upsertEntitlements(
       { userId, planKey, features, validUntil },
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Coverage helpers
+// ---------------------------------------------------------------------------
+
+type SubscriptionRow = {
+  _id: import("../_generated/dataModel").Id<"subscriptions">;
+  userId: string;
+  dodoSubscriptionId: string;
+  planKey: string;
+  status: "active" | "on_hold" | "cancelled" | "expired";
+  currentPeriodEnd: number;
+};
+
+/**
+ * A subscription is "still covering" the user when it is active, on-hold
+ * (payment retry window — entitlement preserved per business policy), or
+ * cancelled-but-paid-through (currentPeriodEnd in the future).
+ */
+function isCoveringAt<T extends Pick<SubscriptionRow, "status" | "currentPeriodEnd">>(
+  s: T,
+  at: number,
+): boolean {
+  return (
+    s.status === "active" ||
+    s.status === "on_hold" ||
+    (s.status === "cancelled" && s.currentPeriodEnd > at)
+  );
+}
+
+/**
+ * Deterministic comparator over covering subscriptions. Returns positive when
+ * `a` outranks `b`, negative when `b` outranks `a`, zero only when fully
+ * indistinguishable. Tie-break order:
+ *
+ *   1. higher `features.tier` wins (primary)
+ *   2. higher `PLAN_PRECEDENCE[planKey]` wins (capability tie-break — e.g.
+ *      api_business beats api_starter at tier 2; pro_annual beats pro_monthly
+ *      at tier 1)
+ *   3. later `currentPeriodEnd` wins (duration tie-break — keep the longest-
+ *      lived covering sub)
+ *
+ * Exported for testing; use `pickBestCoveringSub` for the picker.
+ */
+export function compareSubscriptionsByCoverage<
+  T extends Pick<SubscriptionRow, "planKey" | "currentPeriodEnd">,
+>(a: T, b: T): number {
+  const tierDelta = getFeaturesForPlan(a.planKey).tier - getFeaturesForPlan(b.planKey).tier;
+  if (tierDelta !== 0) return tierDelta;
+  const rankDelta = (PLAN_PRECEDENCE[a.planKey] ?? 0) - (PLAN_PRECEDENCE[b.planKey] ?? 0);
+  if (rankDelta !== 0) return rankDelta;
+  return a.currentPeriodEnd - b.currentPeriodEnd;
+}
+
+/**
+ * Picks the strongest covering subscription for a user, or null if none
+ * cover. Reads ALL of the user's subscriptions via `by_userId`; pass the
+ * post-write timestamp so a sub that was just patched (e.g. expired) is
+ * correctly excluded.
+ */
+async function pickBestCoveringSub(
+  ctx: MutationCtx,
+  userId: string,
+  at: number,
+): Promise<SubscriptionRow | null> {
+  const candidates = await ctx.db
+    .query("subscriptions")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .collect();
+
+  let best: SubscriptionRow | null = null;
+  for (const s of candidates) {
+    if (!isCoveringAt(s, at)) continue;
+    if (best === null || compareSubscriptionsByCoverage(s, best) > 0) {
+      best = s as SubscriptionRow;
+    }
+  }
+  return best;
+}
+
+/**
+ * Recomputes the user's entitlement from ALL of their subscriptions.
+ *
+ * This is the ONE entitlement-write path for subscription event handlers.
+ * It exists because the `entitlements` table is one-row-per-user but a single
+ * user can hold multiple concurrent Dodo subscriptions on the same userId
+ * (e.g. upgraded by buying a higher-tier plan instead of plan-change in the
+ * customer portal). A naive per-event `upsertEntitlements(userId, planKey, ...)`
+ * silently clobbers the entitlement row with the *event's* sub even when
+ * another paid sub still covers the user — see review feedback on PR #3470.
+ *
+ * Algorithm:
+ *   1. Honor a standing comp floor: if compUntil is in the future, leave
+ *      the entitlement untouched (goodwill credit outlives Dodo state).
+ *   2. Pick the strongest covering sub via the deterministic comparator
+ *      (tier > PLAN_PRECEDENCE > currentPeriodEnd).
+ *   3. If a covering sub exists, write its (planKey, currentPeriodEnd).
+ *   4. Otherwise downgrade to free.
+ *
+ * Note: callers MUST persist their own subscription row patch BEFORE calling
+ * this helper so the recompute sees the post-event state.
+ */
+export async function recomputeEntitlementFromAllSubs(
+  ctx: MutationCtx,
+  userId: string,
+  eventTimestamp: number,
+): Promise<void> {
+  const entitlement = await ctx.db
+    .query("entitlements")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .first();
+  if (entitlement?.compUntil && entitlement.compUntil > eventTimestamp) {
+    console.log(
+      `[subscriptionHelpers] recompute for ${userId} — comp floor active until ${new Date(entitlement.compUntil).toISOString()}, preserving entitlement`,
+    );
+    return;
+  }
+
+  const best = await pickBestCoveringSub(ctx, userId, eventTimestamp);
+  if (best) {
+    await upsertEntitlements(ctx, userId, best.planKey, best.currentPeriodEnd, eventTimestamp);
+    return;
+  }
+
+  // No covering sub — downgrade to free. validUntil = eventTimestamp marks the
+  // immediate-revoke point; entitlement queries fall back to free-tier defaults
+  // when validUntil is in the past.
+  await upsertEntitlements(ctx, userId, "free", eventTimestamp, eventTimestamp);
 }
 
 // ---------------------------------------------------------------------------
@@ -332,7 +462,9 @@ export async function handleSubscriptionActive(
     }
   }
 
-  await upsertEntitlements(ctx, userId, planKey, currentPeriodEnd, eventTimestamp);
+  // Recompute from ALL subs on this userId — the event's sub may be a
+  // duplicate or lower-tier than another active sub (multi-active-sub guard).
+  await recomputeEntitlementFromAllSubs(ctx, userId, eventTimestamp);
 
   // Upsert customer record so portal session creation can find dodoCustomerId
   const dodoCustomerId = data.customer?.customer_id;
@@ -426,14 +558,9 @@ export async function handleSubscriptionRenewed(
     updatedAt: eventTimestamp,
   });
 
-  // Resolve userId from subscription record
-  await upsertEntitlements(
-    ctx,
-    existing.userId,
-    existing.planKey,
-    currentPeriodEnd,
-    eventTimestamp,
-  );
+  // Recompute from ALL subs — a renewal on a lower-tier sub must NOT
+  // clobber a higher-tier active sub on the same userId.
+  await recomputeEntitlementFromAllSubs(ctx, existing.userId, eventTimestamp);
 }
 
 /**
@@ -549,27 +676,10 @@ export async function handleSubscriptionPlanChanged(
     updatedAt: eventTimestamp,
   });
 
-  // Multi-active-sub guard: this user may hold a higher-tier sub that the
-  // entitlement row currently reflects. Naively pushing this sub's new plan
-  // would overwrite that. Pick the best across (this sub at its new plan)
-  // plus any OTHER covering sub, and write the highest-tier one.
-  const otherBest = await pickBestActiveSubExcluding(ctx, existing.userId, existing._id, eventTimestamp);
-  const newTier = getFeaturesForPlan(newPlanKey).tier;
-  if (otherBest && getFeaturesForPlan(otherBest.planKey).tier > newTier) {
-    console.log(
-      `[subscriptionHelpers] subscription.plan_changed for ${existing.userId} (${data.subscription_id} -> ${newPlanKey}) — other active sub ${otherBest.dodoSubscriptionId} (${otherBest.planKey}) is higher tier, preserving entitlement`,
-    );
-    await upsertEntitlements(ctx, existing.userId, otherBest.planKey, otherBest.currentPeriodEnd, eventTimestamp);
-    return;
-  }
-
-  await upsertEntitlements(
-    ctx,
-    existing.userId,
-    newPlanKey,
-    existing.currentPeriodEnd,
-    eventTimestamp,
-  );
+  // Recompute from ALL subs — the new plan may be lower-tier than another
+  // active sub on the same userId, in which case we must NOT clobber the
+  // entitlement with the downgrade.
+  await recomputeEntitlementFromAllSubs(ctx, existing.userId, eventTimestamp);
 }
 
 /**
@@ -605,81 +715,11 @@ export async function handleSubscriptionExpired(
     updatedAt: eventTimestamp,
   });
 
-  // Honour a standing complimentary entitlement before revoking. Support
-  // tooling writes compUntil via grantComplimentaryEntitlement; a Dodo
-  // subscription expiring after a cancellation or refund must not wipe the
-  // goodwill credit before it runs out. If the comp is still valid we
-  // leave the entitlement as-is — compUntil already acts as a floor for
-  // validUntil (grant logic keeps them synced).
-  const entitlement = await ctx.db
-    .query("entitlements")
-    .withIndex("by_userId", (q) => q.eq("userId", existing.userId))
-    .first();
-  if (entitlement?.compUntil && entitlement.compUntil > eventTimestamp) {
-    console.log(
-      `[subscriptionHelpers] subscription.expired for ${existing.userId} — complimentary entitlement still valid until ${new Date(entitlement.compUntil).toISOString()}, preserving`,
-    );
-    return;
-  }
-
-  // The entitlements table is one-row-per-user, but a single user can hold
-  // multiple concurrent Dodo subscriptions (e.g. user upgraded by subscribing
-  // to a new plan instead of plan-change, or admin cancelled an old plan
-  // while a higher-tier sub stays active). Without this guard the expiry of
-  // ANY sub would clobber the entitlement to "free", silently downgrading
-  // users who are still actively paying for a different sub.
-  const best = await pickBestActiveSubExcluding(ctx, existing.userId, existing._id, eventTimestamp);
-  if (best) {
-    console.log(
-      `[subscriptionHelpers] subscription.expired for ${existing.userId} (${data.subscription_id}) — other active sub ${best.dodoSubscriptionId} (${best.planKey}) still covers user, recomputing entitlement instead of free-downgrade`,
-    );
-    await upsertEntitlements(ctx, existing.userId, best.planKey, best.currentPeriodEnd, eventTimestamp);
-    return;
-  }
-
-  // Revoke entitlements by downgrading to free tier
-  await upsertEntitlements(ctx, existing.userId, "free", eventTimestamp, eventTimestamp);
-}
-
-/**
- * Returns the highest-tier still-covering subscription for a userId, excluding
- * the given subscription `_id`. Used to prevent a one-row-per-user entitlement
- * table from being clobbered to "free" when one of several concurrent
- * subscriptions expires or is replaced. A sub is "still covering" if it is
- * `active`, `on_hold`, or `cancelled`-with-future-`currentPeriodEnd` (the
- * standard "valid until end of paid period" state).
- *
- * Returns null when the user has no other coverage, in which case the caller
- * should fall through to its default behaviour (free-downgrade for expired,
- * or apply the new plan_changed plan).
- */
-async function pickBestActiveSubExcluding(
-  ctx: MutationCtx,
-  userId: string,
-  excludeId: import("../_generated/dataModel").Id<"subscriptions">,
-  eventTimestamp: number,
-) {
-  const candidates = await ctx.db
-    .query("subscriptions")
-    .withIndex("by_userId", (q) => q.eq("userId", userId))
-    .collect();
-
-  let best: (typeof candidates)[number] | null = null;
-  let bestTier = -Infinity;
-  for (const s of candidates) {
-    if (s._id === excludeId) continue;
-    const isCovering =
-      s.status === "active" ||
-      s.status === "on_hold" ||
-      (s.status === "cancelled" && s.currentPeriodEnd > eventTimestamp);
-    if (!isCovering) continue;
-    const tier = getFeaturesForPlan(s.planKey).tier;
-    if (tier > bestTier) {
-      best = s;
-      bestTier = tier;
-    }
-  }
-  return best;
+  // Recompute from ALL subs (post-patch). The expired sub is now status:
+  // "expired" so it's automatically excluded by isCoveringAt; if any other
+  // sub still covers the user we keep them on its tier, else free-downgrade.
+  // The recompute helper also honours the comp-floor for goodwill credits.
+  await recomputeEntitlementFromAllSubs(ctx, existing.userId, eventTimestamp);
 }
 
 /**

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -549,6 +549,20 @@ export async function handleSubscriptionPlanChanged(
     updatedAt: eventTimestamp,
   });
 
+  // Multi-active-sub guard: this user may hold a higher-tier sub that the
+  // entitlement row currently reflects. Naively pushing this sub's new plan
+  // would overwrite that. Pick the best across (this sub at its new plan)
+  // plus any OTHER covering sub, and write the highest-tier one.
+  const otherBest = await pickBestActiveSubExcluding(ctx, existing.userId, existing._id, eventTimestamp);
+  const newTier = getFeaturesForPlan(newPlanKey).tier;
+  if (otherBest && getFeaturesForPlan(otherBest.planKey).tier > newTier) {
+    console.log(
+      `[subscriptionHelpers] subscription.plan_changed for ${existing.userId} (${data.subscription_id} -> ${newPlanKey}) — other active sub ${otherBest.dodoSubscriptionId} (${otherBest.planKey}) is higher tier, preserving entitlement`,
+    );
+    await upsertEntitlements(ctx, existing.userId, otherBest.planKey, otherBest.currentPeriodEnd, eventTimestamp);
+    return;
+  }
+
   await upsertEntitlements(
     ctx,
     existing.userId,
@@ -608,8 +622,64 @@ export async function handleSubscriptionExpired(
     return;
   }
 
+  // The entitlements table is one-row-per-user, but a single user can hold
+  // multiple concurrent Dodo subscriptions (e.g. user upgraded by subscribing
+  // to a new plan instead of plan-change, or admin cancelled an old plan
+  // while a higher-tier sub stays active). Without this guard the expiry of
+  // ANY sub would clobber the entitlement to "free", silently downgrading
+  // users who are still actively paying for a different sub.
+  const best = await pickBestActiveSubExcluding(ctx, existing.userId, existing._id, eventTimestamp);
+  if (best) {
+    console.log(
+      `[subscriptionHelpers] subscription.expired for ${existing.userId} (${data.subscription_id}) — other active sub ${best.dodoSubscriptionId} (${best.planKey}) still covers user, recomputing entitlement instead of free-downgrade`,
+    );
+    await upsertEntitlements(ctx, existing.userId, best.planKey, best.currentPeriodEnd, eventTimestamp);
+    return;
+  }
+
   // Revoke entitlements by downgrading to free tier
   await upsertEntitlements(ctx, existing.userId, "free", eventTimestamp, eventTimestamp);
+}
+
+/**
+ * Returns the highest-tier still-covering subscription for a userId, excluding
+ * the given subscription `_id`. Used to prevent a one-row-per-user entitlement
+ * table from being clobbered to "free" when one of several concurrent
+ * subscriptions expires or is replaced. A sub is "still covering" if it is
+ * `active`, `on_hold`, or `cancelled`-with-future-`currentPeriodEnd` (the
+ * standard "valid until end of paid period" state).
+ *
+ * Returns null when the user has no other coverage, in which case the caller
+ * should fall through to its default behaviour (free-downgrade for expired,
+ * or apply the new plan_changed plan).
+ */
+async function pickBestActiveSubExcluding(
+  ctx: MutationCtx,
+  userId: string,
+  excludeId: import("../_generated/dataModel").Id<"subscriptions">,
+  eventTimestamp: number,
+) {
+  const candidates = await ctx.db
+    .query("subscriptions")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .collect();
+
+  let best: (typeof candidates)[number] | null = null;
+  let bestTier = -Infinity;
+  for (const s of candidates) {
+    if (s._id === excludeId) continue;
+    const isCovering =
+      s.status === "active" ||
+      s.status === "on_hold" ||
+      (s.status === "cancelled" && s.currentPeriodEnd > eventTimestamp);
+    if (!isCovering) continue;
+    const tier = getFeaturesForPlan(s.planKey).tier;
+    if (tier > bestTier) {
+      best = s;
+      bestTier = tier;
+    }
+  }
+  return best;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Bug**: `entitlements` is keyed `by_userId` (1 row/user), but Dodo allows multiple concurrent subscriptions per user. `handleSubscriptionExpired` unconditionally called `upsertEntitlements(userId, "free", ...)`, silently downgrading users who had **another active paid sub** on the same `userId`. `handleSubscriptionPlanChanged` had the sibling form (overwriting the higher-tier entitlement).
- **Fix**: Before downgrade/replace, scan the user's other subs via `by_userId`; if any are *still covering* (`active`, `on_hold`, or `cancelled` with future `currentPeriodEnd`), recompute the entitlement from the highest-tier one instead of clobbering.
- **Ops tool**: New internal mutation `payments/billing:deleteSubscriptionByDodoId` to delete a subscription row from Convex and re-derive the entitlement (used to defuse a known doomed `subscription.expired` admin-side without waiting on the webhook).

## Discovered case

User `bernardteng85@gmail.com` had:

| sub | plan | status | currentPeriodEnd |
|---|---|---|---|
| `sub_0Ndc7ofBOtXiph60dCcwn` | pro_monthly ($39.99) | active (cancelled by admin in Dodo) | 2026-05-27 14:19Z |
| `sub_0NdcGtIkEllB9Uw3a2lMQ` | api_starter ($99.99) | active, user-purchased | 2026-05-27 15:07Z |

Entitlement reflects `api_starter` (correct now), but pro_monthly's eventual `subscription.expired` would have wiped it for the ~48-min window before api_starter renewal.

## Why now (vs. defer)

- Without this guard, **anyone** who upgrades by buying a new sub instead of using plan-change is exposed.
- Cheap, well-bounded change. 3 new tests, 119 total passing.

## Runbook (post-merge + Convex deploy)

To clean up the bernardteng85 case:

```sh
npx convex run 'payments/billing:deleteSubscriptionByDodoId' '{"dodoSubscriptionId":"sub_0Ndc7ofBOtXiph60dCcwn","reason":"refunded by admin; user separately purchased api_starter on same userId — defusing doomed subscription.expired"}'
```

Verify:

```sh
npx convex run 'entitlements:getEntitlementsByUserId' '{"userId":"user_3CwaDRDtisKO3zbXSRd9f364L73"}'
# Expect: planKey: "api_starter", validUntil ~ 2026-05-27 15:07Z
```

Optional sweep — find any other users with multiple covering subs on the same userId so we know the population:

```sh
npx convex data subscriptions --limit 1000 | awk -F'|' '{print $NF}' | sort | uniq -c | awk '$1 > 1'
```

## Test plan

- [x] `npx vitest run` — 119/119 pass (3 new in `comp-entitlement.test.ts > multi-active-sub guard`)
- [x] `tsc --noEmit` clean
- [x] biome clean (1 pre-existing warning unrelated to this diff)
- [x] Existing `compUntil` floor test still passes (the new guard runs *after* the comp guard, so goodwill credits are still honoured)
- [ ] After merge + deploy: run cleanup mutation per runbook; confirm api_starter entitlement intact