### PR TITLE
ci: auto-deploy convex/ changes to Convex prod on merge to main

### DIFF
--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -1,0 +1,89 @@
+name: Convex Deploy
+
+# Auto-deploy `convex/` changes to the Convex production deployment on every
+# merge to `main`. Required because Vercel's build step only deploys api/, src/,
+# and other Vercel-served code — the Convex backend has its own deployment
+# pipeline that must be triggered separately. Without this workflow,
+# `convex/<module>.ts` changes silently merged into main without ever running
+# in production. Surfaced concretely as PR #3460 / #3466: the structured-data
+# `ConvexError({ kind, ... })` fix sat in main for 30+ minutes while
+# `WORLDMONITOR-PD` kept growing because Convex prod was still running the old
+# string-data throws.
+#
+# Setup required (one-time): add `CONVEX_DEPLOY_KEY` to the repo's GitHub
+# Actions secrets. Generate via `npx convex deploy --once-create-deploy-key`
+# against the prod deployment, or via the Convex dashboard → Settings →
+# Deploy Keys → "Production: deploy" scope.
+
+on:
+  push:
+    branches: [main]
+  # Manual fallback so the operator can re-run a deploy without a code change
+  # (e.g. recover from a failed deploy or push a hotfix off-cycle).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize deploys so two back-to-back merges don't race against each other.
+  # `cancel-in-progress: false` is intentional — every merge that touches
+  # convex/ should reach prod, even if a later merge follows quickly.
+  group: convex-deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      convex: ${{ steps.diff.outputs.convex }}
+    steps:
+      - id: diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # workflow_dispatch always deploys; otherwise gate on convex/ touch.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "convex=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # On push to main, GitHub gives us before..after; diff that range
+          # for any convex/* path. Scoped to convex/ only — schema changes,
+          # function code, and codegen all live here. `convex/_generated/`
+          # is regenerated locally on `npx convex codegen`; including it in
+          # the trigger is a small cost (a no-op deploy when only generated
+          # files churn) but keeps the gate robust.
+          BEFORE="${{ github.event.before }}"
+          AFTER="${{ github.event.after }}"
+          # Brand-new branch (rare on main) — fall through to a deploy.
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "convex=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          FILES=$(gh api "repos/${{ github.repository }}/compare/${BEFORE}...${AFTER}" \
+            --jq '.files[].filename' 2>/dev/null || echo "")
+          if echo "$FILES" | grep -qE '^convex/'; then
+            echo "convex=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "convex=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy:
+    needs: changes
+    if: needs.changes.outputs.convex == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci --no-audit --no-fund
+      - name: Convex deploy (prod)
+        # `--yes` skips the interactive "Are you sure?" prompt. The deploy
+        # key in CONVEX_DEPLOY_KEY pins the target deployment, so there is
+        # no ambiguity about which environment we're pushing to.
+        run: npx convex deploy --yes
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}

--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -38,31 +38,47 @@ jobs:
     outputs:
       convex: ${{ steps.diff.outputs.convex }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need both BEFORE and AFTER commits locally so `git diff` can name
+          # the changed files authoritatively. `fetch-depth: 0` (full history)
+          # is the cheapest way; the alternative — `gh api compare` — paginates
+          # at 300 files and silently empties on API failure, which fails OPEN
+          # (would skip a real convex/ change → recreates the exact drift this
+          # workflow is meant to prevent). git diff fails CLOSED: if it can't
+          # answer, the job errors and the deploy doesn't silently skip.
+          fetch-depth: 0
       - id: diff
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          # workflow_dispatch always deploys; otherwise gate on convex/ touch.
+          set -euo pipefail
+          # workflow_dispatch always deploys; nothing to diff.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "convex=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # On push to main, GitHub gives us before..after; diff that range
-          # for any convex/* path. Scoped to convex/ only — schema changes,
-          # function code, and codegen all live here. `convex/_generated/`
-          # is regenerated locally on `npx convex codegen`; including it in
-          # the trigger is a small cost (a no-op deploy when only generated
-          # files churn) but keeps the gate robust.
           BEFORE="${{ github.event.before }}"
           AFTER="${{ github.event.after }}"
-          # Brand-new branch (rare on main) — fall through to a deploy.
+          # Brand-new branch / first push (BEFORE is the all-zero SHA): we
+          # can't diff against a non-existent prior state. Fall through to
+          # deploy — this is the safe default for first-push scenarios.
           if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
             echo "convex=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          FILES=$(gh api "repos/${{ github.repository }}/compare/${BEFORE}...${AFTER}" \
-            --jq '.files[].filename' 2>/dev/null || echo "")
-          if echo "$FILES" | grep -qE '^convex/'; then
+          # Force-push or rebase can leave BEFORE unreachable in our local
+          # clone even at fetch-depth: 0. Verify both SHAs are present;
+          # if not, deploy (fail-CLOSED — better a redundant deploy than a
+          # missed one).
+          if ! git cat-file -e "$BEFORE^{commit}" 2>/dev/null \
+              || ! git cat-file -e "$AFTER^{commit}" 2>/dev/null; then
+            echo "::warning::commit not in fetched history (force-push?), deploying defensively"
+            echo "convex=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Authoritative path-scoped diff. `--` separates revisions from
+          # pathspecs, so `convex/` is interpreted as a path filter even if
+          # something weird is going on with the SHAs.
+          if git diff --name-only "$BEFORE" "$AFTER" -- 'convex/' | grep -q .; then
             echo "convex=true" >> "$GITHUB_OUTPUT"
           else
             echo "convex=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Closes the "Convex code merged but never deployed" gap that we hit today on PR #3466. Vercel's build auto-deploys `api/` and `src/` but does NOT run `npx convex deploy --prod` — the Convex backend has its own pipeline that has been manual-only in this repo. Result: any change to `convex/<module>.ts` (schema, mutation/query bodies, action handlers) silently lands in main without reaching production until someone remembers to push it by hand.

Concrete recent example: PR #3466's structured-data `ConvexError({ kind, ... })` fix sat in main for 30+ minutes while `WORLDMONITOR-PD` kept growing — Convex prod was still running the old string-data throws. The drift was invisible because the api/ side (which depends on Convex throwing object data) had auto-deployed cleanly; the symptom only surfaced when I noticed the Sentry events post-merge still tagged `error_shape=convex_server_error` instead of the expected typed CONFLICT bucket.

## Workflow design

- **Trigger:** push to `main`, gated by a path diff so non-`convex/` merges don't pay CI minutes for a no-op deploy. The diff uses `gh api repos/.../compare/${before}...${after}` to detect any `convex/*` file in the merge range.
- **Manual fallback:** `workflow_dispatch` so hotfixes / re-runs are possible off the regular code-merge cycle.
- **Concurrency:** serialized via `convex-deploy-prod` group with `cancel-in-progress: false`. Two back-to-back merges queue cleanly — every deploy eventually lands, none get cancelled by a later one.
- **Auth:** `CONVEX_DEPLOY_KEY` from secrets pins the target deployment; `npx convex deploy --yes` skips the interactive prompt.

## Setup required (one-time, before merging this)

Add `CONVEX_DEPLOY_KEY` to the repo's GitHub Actions secrets. Generate it via:
- Convex dashboard → Settings → Deploy Keys → "Production: deploy" scope, OR
- `npx convex deploy --once-create-deploy-key` against the prod deployment

Without this secret, the workflow will run but fail at the deploy step (clear log message). If you'd prefer to merge the workflow first and add the secret later, that's safe — failed deploys don't break anything (the next push to convex/ will succeed once the secret is set).

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` — YAML parses cleanly
- [ ] After merge: confirm the workflow runs on the merge commit but skips the deploy step (since this PR doesn't touch `convex/`, the path-diff gate should set `convex=false`)
- [ ] Next time you touch `convex/<file>.ts`, the workflow should run end-to-end and `npx convex deploy --yes` should push to `tacit-curlew-777`

## Notes

- Deliberately scoped to push-on-main; PR runs would deploy preview branches' Convex code to prod, which is wrong. PR previews against a Convex preview deployment is a separate, larger feature (would need per-PR deploy keys + preview deployment config) and not in scope here.
- `convex/_generated/` is included in the path-diff trigger. That's a small cost (a no-op deploy when only generated files churn) but keeps the gate robust against schema changes that only update generated types.