### PR TITLE
feat(notifications): tighten realtime to critical-only — forbid (realtime, high) too

### DIFF
--- a/convex/__tests__/alertRules.test.ts
+++ b/convex/__tests__/alertRules.test.ts
@@ -9,20 +9,22 @@ const USER = { subject: "user-tests-alertrules", tokenIdentifier: "clerk|user-te
 const VARIANT = "full";
 
 // ---------------------------------------------------------------------------
-// Cross-field invariant: (digestMode='realtime', sensitivity='all') is forbidden.
+// Cross-field invariant: realtime is for `critical`-tier events only.
+// Both `(realtime, all)` and `(realtime, high)` are forbidden.
 // See plans/forbid-realtime-all-events.md.
 // ---------------------------------------------------------------------------
 
-describe("alertRules — (realtime, all) cross-field invariant", () => {
+describe("alertRules — realtime+non-critical cross-field invariant", () => {
   test("setAlertRules({sensitivity:'all'}) against existing realtime row → throws", async () => {
     const t = convexTest(schema, modules);
     const asUser = t.withIdentity(USER);
-    // Seed an existing row in realtime mode with high sensitivity (compatible).
+    // Seed an existing row in realtime mode with critical sensitivity (compatible
+    // under the tightened rule — only 'critical' is allowed alongside realtime).
     await asUser.mutation(api.alertRules.setAlertRules, {
       variant: VARIANT,
       enabled: true,
       eventTypes: [],
-      sensitivity: "high",
+      sensitivity: "critical",
       channels: [],
     });
     // Attempting to widen to 'all' must throw INCOMPATIBLE_DELIVERY.
@@ -34,7 +36,31 @@ describe("alertRules — (realtime, all) cross-field invariant", () => {
         sensitivity: "all",
         channels: [],
       }),
-    ).rejects.toThrow(/INCOMPATIBLE_DELIVERY|Real-time delivery requires/i);
+    ).rejects.toThrow(/INCOMPATIBLE_DELIVERY|Real-time delivery is for Critical/i);
+  });
+
+  test("setAlertRules({sensitivity:'high'}) against existing realtime row → throws (tightened rule)", async () => {
+    const t = convexTest(schema, modules);
+    const asUser = t.withIdentity(USER);
+    // Seed compatible realtime+critical state.
+    await asUser.mutation(api.alertRules.setAlertRules, {
+      variant: VARIANT,
+      enabled: true,
+      eventTypes: [],
+      sensitivity: "critical",
+      channels: [],
+    });
+    // Attempting to widen to 'high' is now ALSO forbidden — was allowed under
+    // the previous rule, tightened 2026-04-27.
+    await expect(
+      asUser.mutation(api.alertRules.setAlertRules, {
+        variant: VARIANT,
+        enabled: true,
+        eventTypes: [],
+        sensitivity: "high",
+        channels: [],
+      }),
+    ).rejects.toThrow(/INCOMPATIBLE_DELIVERY|Real-time delivery is for Critical/i);
   });
 
   test("setAlertRules({sensitivity:'all'}) against existing daily-digest row → succeeds", async () => {
@@ -78,7 +104,7 @@ describe("alertRules — (realtime, all) cross-field invariant", () => {
         variant: VARIANT,
         digestMode: "realtime",
       }),
-    ).rejects.toThrow(/INCOMPATIBLE_DELIVERY|Real-time delivery requires/i);
+    ).rejects.toThrow(/INCOMPATIBLE_DELIVERY|Real-time delivery is for Critical/i);
   });
 
   test("setDigestSettings({digestMode:'daily'}) against existing sensitivity:'all' realtime → succeeds, sensitivity preserved", async () => {
@@ -111,13 +137,14 @@ describe("alertRules — (realtime, all) cross-field invariant", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Insert-only default flip: sensitivity:'all' → sensitivity:'high' on fresh
-// insert ONLY. Patch path must NEVER silently rewrite an existing row's
+// Insert-only default: sensitivity:'critical' on fresh insert ONLY (under the
+// tightened rule, was 'high' before 2026-04-27). Patch path must NEVER silently
+// rewrite an existing row's
 // sensitivity when the caller omits the field.
 // ---------------------------------------------------------------------------
 
 describe("alertRules — insert-only default for sensitivity", () => {
-  test("setAlertRulesForUser with no existing row, sensitivity omitted → defaults to 'high'", async () => {
+  test("setAlertRulesForUser with no existing row, sensitivity omitted → defaults to 'critical'", async () => {
     const t = convexTest(schema, modules);
     await t.mutation(internal.alertRules.setAlertRulesForUser, {
       userId: USER.subject,
@@ -133,7 +160,9 @@ describe("alertRules — insert-only default for sensitivity", () => {
         .withIndex("by_user_variant", (q) => q.eq("userId", USER.subject).eq("variant", VARIANT))
         .collect(),
     );
-    expect(rows[0]?.sensitivity).toBe("high");
+    // Under the tightened rule (2026-04-27), realtime insert default is 'critical'
+    // not 'high' — only 'critical' is compatible with the implicit realtime mode.
+    expect(rows[0]?.sensitivity).toBe("critical");
   });
 
   test("setAlertRulesForUser with existing daily+all row, sensitivity omitted → preserves 'all'", async () => {
@@ -173,7 +202,7 @@ describe("alertRules — insert-only default for sensitivity", () => {
     expect(rows[0]?.eventTypes).toEqual(["something"]);
   });
 
-  test("setQuietHoursForUser with no existing row → inserts with sensitivity:'high', not 'all'", async () => {
+  test("setQuietHoursForUser with no existing row → inserts with sensitivity:'critical', not 'all'/'high'", async () => {
     const t = convexTest(schema, modules);
     await t.mutation(internal.alertRules.setQuietHoursForUser, {
       userId: USER.subject,
@@ -189,7 +218,7 @@ describe("alertRules — insert-only default for sensitivity", () => {
         .withIndex("by_user_variant", (q) => q.eq("userId", USER.subject).eq("variant", VARIANT))
         .collect(),
     );
-    expect(rows[0]?.sensitivity).toBe("high");
+    expect(rows[0]?.sensitivity).toBe("critical");
   });
 
   test("setQuietHoursForUser does NOT throw on pre-migration forbidden row (Greptile P1)", async () => {
@@ -246,10 +275,10 @@ describe("alertRules — setNotificationConfigForUser atomic pair update", () =>
         digestMode: "realtime",
         sensitivity: "all",
       }),
-    ).rejects.toThrow(/INCOMPATIBLE_DELIVERY|Real-time delivery requires/i);
+    ).rejects.toThrow(/INCOMPATIBLE_DELIVERY|Real-time delivery is for Critical/i);
   });
 
-  test("daily+all → realtime+high lands atomically (no race)", async () => {
+  test("daily+all → realtime+critical lands atomically (no race) — tightened rule requires critical", async () => {
     const t = convexTest(schema, modules);
     // Seed daily+all (the legitimate prior state).
     await t.run(async (ctx) => {
@@ -270,7 +299,7 @@ describe("alertRules — setNotificationConfigForUser atomic pair update", () =>
       userId: USER.subject,
       variant: VARIANT,
       digestMode: "realtime",
-      sensitivity: "high",
+      sensitivity: "critical",
     });
     const rows = await t.run(async (ctx) =>
       ctx.db
@@ -279,7 +308,20 @@ describe("alertRules — setNotificationConfigForUser atomic pair update", () =>
         .collect(),
     );
     expect(rows[0]?.digestMode).toBe("realtime");
-    expect(rows[0]?.sensitivity).toBe("high");
+    expect(rows[0]?.sensitivity).toBe("critical");
+  });
+
+  test("setNotificationConfigForUser({digestMode:'realtime', sensitivity:'high'}) → throws (tightened rule)", async () => {
+    // The tightened rule (2026-04-27) forbids realtime+high alongside realtime+all.
+    const t = convexTest(schema, modules);
+    await expect(
+      t.mutation(internal.alertRules.setNotificationConfigForUser, {
+        userId: USER.subject,
+        variant: VARIANT,
+        digestMode: "realtime",
+        sensitivity: "high",
+      }),
+    ).rejects.toThrow(/INCOMPATIBLE_DELIVERY|Real-time delivery is for Critical/i);
   });
 
   test("partial update {enabled:true} against existing forbidden row → throws (re-validation)", async () => {
@@ -306,7 +348,7 @@ describe("alertRules — setNotificationConfigForUser atomic pair update", () =>
         enabled: true,
         // no digestMode/sensitivity in args — but existing pair is forbidden
       }),
-    ).rejects.toThrow(/INCOMPATIBLE_DELIVERY|Real-time delivery requires/i);
+    ).rejects.toThrow(/INCOMPATIBLE_DELIVERY|Real-time delivery is for Critical/i);
   });
 
   test("omitted sensitivity on patch preserves existing value", async () => {

--- a/convex/alertRules.ts
+++ b/convex/alertRules.ts
@@ -6,10 +6,21 @@ type DigestMode = "realtime" | "daily" | "twice_daily" | "weekly";
 type Sensitivity = "all" | "high" | "critical";
 
 // Cross-field invariant enforcement for (digestMode, sensitivity).
-// Real-time delivery + 'all' sensitivity produces unsustainable notification volume
-// (see plans/forbid-realtime-all-events.md). Forbidden combination must be rejected
-// at every mutation site; new-row defaults pick 'high' on insert; patches preserve
-// existing.sensitivity when caller omits the field (no silent narrowing of digest users).
+//
+// Tightened rule (2026-04-27): real-time delivery is now reserved for
+// `critical`-tier events only. `(realtime, all)` and `(realtime, high)` are
+// both forbidden. Anything below `critical` lives in a digest cadence
+// (daily / twice_daily / weekly).
+//
+// Why tighter: even on `(realtime, high)`, `high`-severity events fire
+// frequently enough on busy days to overload an inbox (severe weather,
+// market moves, geopolitics). Real-time is for "interrupt me NOW" content
+// only — i.e. genuinely critical. High events still reach the user, just
+// batched in a digest.
+//
+// New-row defaults pick `'critical'` on realtime insert; patches preserve
+// existing.sensitivity when caller omits the field (no silent narrowing of
+// digest users).
 function resolveEffectivePair(args: {
   incomingDigestMode?: DigestMode;
   incomingSensitivity?: Sensitivity;
@@ -20,17 +31,17 @@ function resolveEffectivePair(args: {
     ?? "realtime");
   const sensitivity = (args.incomingSensitivity
     ?? (args.existing?.sensitivity as Sensitivity | undefined)
-    ?? "high"); // insert-only default — patch path never includes sensitivity unless caller passed it
+    ?? "critical"); // insert-only default — patch path never includes sensitivity unless caller passed it
   return { digestMode, sensitivity };
 }
 
 function assertCompatibleDeliveryMode(pair: { digestMode: DigestMode; sensitivity: Sensitivity }) {
-  if (pair.digestMode === "realtime" && pair.sensitivity === "all") {
+  if (pair.digestMode === "realtime" && (pair.sensitivity === "all" || pair.sensitivity === "high")) {
     throw new ConvexError({
       code: "INCOMPATIBLE_DELIVERY",
       message:
-        "Real-time delivery requires High or Critical sensitivity. " +
-        "To receive all events, choose Daily, Twice daily, or Weekly digest.",
+        "Real-time delivery is for Critical events only. " +
+        "To receive High or All events, choose a digest cadence (Daily, Twice daily, or Weekly).",
     });
   }
 }
@@ -281,8 +292,8 @@ export const setQuietHours = mutation({
       }
     }
 
-    // resolveEffectivePair supplies sensitivity:'high' on fresh insert (compatible
-    // by construction). We DO NOT call assertCompatibleDeliveryMode here — quiet-hours
+    // resolveEffectivePair supplies sensitivity:'critical' on fresh insert (compatible
+    // by construction under the tightened rule). We DO NOT call assertCompatibleDeliveryMode here — quiet-hours
     // mutations don't touch the (digestMode, sensitivity) pair, so blocking unrelated
     // quiet-hours updates on pre-migration forbidden rows would surface as confusing
     // generic 500s ('set-quiet-hours' HTTP action has no INCOMPATIBLE_DELIVERY
@@ -387,8 +398,8 @@ export const setQuietHoursForUser = internalMutation({
 
     // No assertCompatibleDeliveryMode here — quiet-hours mutations don't touch
     // the (digestMode, sensitivity) pair. See setQuietHours above for the full
-    // rationale. resolveEffectivePair still supplies sensitivity:'high' on fresh
-    // insert (compatible by construction).
+    // rationale. resolveEffectivePair still supplies sensitivity:'critical' on fresh
+    // insert (compatible by construction under the tightened rule).
     const pair = resolveEffectivePair({ existing: existing ?? undefined });
 
     const now = Date.now();

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -627,16 +627,24 @@ function matchesSensitivity(ruleSensitivity, eventSeverity) {
  * shadow:score-log (currently v3) for tuning.
  */
 function shouldNotify(rule, event) {
-  // Coerce (effective realtime + 'all') → 'high' before consulting sensitivity in
-  // either branch. The mutation validators + migration make this state unreachable
-  // for new traffic; this catches in-flight rows during migration and any tooling
-  // that bypasses the validators. Both reads (legacy match below AND the importance
-  // threshold lookup) must use the SAME effective value, otherwise the threshold
-  // path silently falls through to the looser IMPORTANCE_SCORE_MIN floor.
+  // Coerce (effective realtime + non-critical) → 'critical' before consulting
+  // sensitivity in either branch. The mutation validators + migration make this
+  // state unreachable for new traffic; this catches in-flight rows during
+  // migration and any tooling that bypasses the validators.
+  //
+  // Tightened rule (2026-04-27): realtime is reserved for `critical`-tier events
+  // only. Both `(realtime, all)` and `(realtime, high)` are forbidden, so the
+  // relay collapses both to `'critical'` for in-flight forbidden rows.
+  //
+  // Both reads (legacy match below AND the importance threshold lookup) must
+  // use the SAME effective value, otherwise the threshold path silently falls
+  // through to the looser IMPORTANCE_SCORE_MIN floor.
   // See plans/forbid-realtime-all-events.md §3.
   const effectiveDigestMode = rule.digestMode ?? 'realtime';
   const effectiveSensitivity =
-    effectiveDigestMode === 'realtime' && rule.sensitivity === 'all' ? 'high' : rule.sensitivity;
+    effectiveDigestMode === 'realtime' && (rule.sensitivity === 'all' || rule.sensitivity === 'high')
+      ? 'critical'
+      : rule.sensitivity;
 
   const passesLegacy = matchesSensitivity(effectiveSensitivity, event.severity ?? 'high');
   if (!passesLegacy) return false;

--- a/src/services/notifications-settings.ts
+++ b/src/services/notifications-settings.ts
@@ -307,10 +307,10 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
           <div class="ai-flow-section-label" style="margin-top:8px">Sensitivity</div>
           <select class="unified-settings-select" id="usNotifSensitivity">
             <option value="all"${isRealtime ? ' disabled' : ''}${sensitivity === 'all' && !isRealtime ? ' selected' : ''}>All events${isRealtime ? ' (digest only)' : ''}</option>
-            <option value="high"${sensitivity === 'high' || (sensitivity === 'all' && isRealtime) ? ' selected' : ''}>High &amp; critical</option>
-            <option value="critical"${sensitivity === 'critical' ? ' selected' : ''}>Critical only</option>
+            <option value="high"${isRealtime ? ' disabled' : ''}${sensitivity === 'high' && !isRealtime ? ' selected' : ''}>High &amp; critical${isRealtime ? ' (digest only)' : ''}</option>
+            <option value="critical"${sensitivity === 'critical' || ((sensitivity === 'all' || sensitivity === 'high') && isRealtime) ? ' selected' : ''}>Critical only</option>
           </select>
-          <div class="ai-flow-toggle-desc" id="usSensitivityHint" style="margin-top:4px;${isRealtime ? '' : 'display:none'}">Real-time delivery requires High or Critical. To receive all events, switch to a digest cadence.</div>
+          <div class="ai-flow-toggle-desc" id="usSensitivityHint" style="margin-top:4px;${isRealtime ? '' : 'display:none'}">Real-time delivery is for Critical events only. To receive High or All events, switch to a digest cadence.</div>
           <div id="usRealtimeSection" style="${isRealtime ? '' : 'display:none'}">
             <div class="ai-flow-section-label" style="margin-top:8px">Alert Rules</div>
             <div class="ai-flow-toggle-row">
@@ -497,23 +497,32 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
           // See plans/forbid-realtime-all-events.md §2c, §2d.
           const sensitivityEl = container.querySelector<HTMLSelectElement>('#usNotifSensitivity');
           const allOption = sensitivityEl?.querySelector<HTMLOptionElement>('option[value="all"]');
+          const highOption = sensitivityEl?.querySelector<HTMLOptionElement>('option[value="high"]');
+          // Tightened rule: realtime is for Critical only — disable BOTH `all`
+          // and `high` options when realtime, only `critical` is allowed.
           if (allOption) {
             allOption.disabled = isRt;
             allOption.textContent = isRt ? 'All events (digest only)' : 'All events';
           }
-          // The sensitivity hint only applies in realtime mode (where 'all' is
-          // disabled); hide it in digest mode. Greptile P2 on PR #3461.
+          if (highOption) {
+            highOption.disabled = isRt;
+            highOption.textContent = isRt ? 'High & critical (digest only)' : 'High & critical';
+          }
+          // The sensitivity hint only applies in realtime mode (where non-critical
+          // options are disabled); hide it in digest mode.
           const hintEl = container.querySelector<HTMLElement>('#usSensitivityHint');
           if (hintEl) hintEl.style.display = isRt ? '' : 'none';
           let snappedSensitivity: 'all' | 'high' | 'critical' | undefined;
-          if (isRt && sensitivityEl?.value === 'all') {
-            sensitivityEl.value = 'high';
-            snappedSensitivity = 'high';
+          if (isRt && (sensitivityEl?.value === 'all' || sensitivityEl?.value === 'high')) {
+            const previousValue = sensitivityEl.value;
+            sensitivityEl.value = 'critical';
+            snappedSensitivity = 'critical';
             // Tiny inline notice — the user just lost a setting; tell them why.
             const hint = container.querySelector<HTMLElement>('#usSensitivityHint');
             if (hint) {
               const original = hint.textContent;
-              hint.textContent = "Switched to High & critical — real-time delivery doesn't support All events.";
+              const fromLabel = previousValue === 'all' ? 'All events' : 'High & critical';
+              hint.textContent = `Switched to Critical only — real-time delivery doesn't support ${fromLabel}.`;
               setTimeout(() => { if (hint && original) hint.textContent = original; }, 4000);
             }
           }

--- a/tests/notification-relay-effective-sensitivity.test.mjs
+++ b/tests/notification-relay-effective-sensitivity.test.mjs
@@ -1,8 +1,12 @@
 /**
  * Regression test: scripts/notification-relay.cjs's shouldNotify must coerce
- * (effective realtime + sensitivity:'all') → 'high' BEFORE consulting sensitivity
+ * (effective realtime + non-critical) → 'critical' BEFORE consulting sensitivity
  * in either branch. Both reads (the legacy matchesSensitivity call AND the
  * importance-score threshold lookup) must use the SAME effective value.
+ *
+ * Tightened rule (2026-04-27): under the new policy, realtime is reserved for
+ * `critical`-tier events only. Both `(realtime, all)` and `(realtime, high)`
+ * are forbidden, so the relay collapses both to `'critical'`.
  *
  * Why source-grep: notification-relay.cjs is a runtime script with no exports;
  * shouldNotify is only callable in-process via the queue loop. This test
@@ -36,8 +40,8 @@ describe('notification-relay shouldNotify effective-sensitivity coercion', () =>
     );
     assert.match(
       relaySrc,
-      /effectiveSensitivity\s*=\s*[\s\S]*?effectiveDigestMode\s*===\s*['"]realtime['"][\s\S]*?rule\.sensitivity\s*===\s*['"]all['"][\s\S]*?\?\s*['"]high['"]\s*:\s*rule\.sensitivity/,
-      'effectiveSensitivity must coerce (realtime+all) → high; otherwise pass rule.sensitivity through',
+      /effectiveSensitivity\s*=\s*[\s\S]*?effectiveDigestMode\s*===\s*['"]realtime['"][\s\S]*?\(rule\.sensitivity\s*===\s*['"]all['"][\s\S]*?rule\.sensitivity\s*===\s*['"]high['"]\)[\s\S]*?\?\s*['"]critical['"]\s*:\s*rule\.sensitivity/,
+      'effectiveSensitivity must coerce (realtime+non-critical) → critical (both \'all\' and \'high\' collapse); otherwise pass rule.sensitivity through',
     );
   });
 

--- a/tests/notifications-settings-ui-invariants.test.mjs
+++ b/tests/notifications-settings-ui-invariants.test.mjs
@@ -41,14 +41,20 @@ describe('notifications-settings.ts — sensitivity dropdown placement', () => {
     );
   });
 
-  it("'all' option carries an isRealtime-conditional disabled attribute", () => {
-    // The all option must be disabled when isRealtime is true. This catches the
-    // foot-gun the whole plan exists to prevent — without disable, the user can
-    // re-pick (realtime, all) through the UI.
+  it("'all' AND 'high' options both carry an isRealtime-conditional disabled attribute (tightened rule)", () => {
+    // The all+high options must both be disabled when isRealtime is true. Under
+    // the tightened rule (2026-04-27), only `critical` is allowed alongside
+    // realtime. This catches the foot-gun without disable: user re-picking
+    // (realtime, all) OR (realtime, high) through the UI.
     assert.match(
       src,
       /<option value="all"\$\{isRealtime \? ' disabled' : ''\}/,
       "the 'all' <option> must include `${isRealtime ? ' disabled' : ''}`",
+    );
+    assert.match(
+      src,
+      /<option value="high"\$\{isRealtime \? ' disabled' : ''\}/,
+      "the 'high' <option> must include `${isRealtime ? ' disabled' : ''}`",
     );
   });
 
@@ -57,7 +63,7 @@ describe('notifications-settings.ts — sensitivity dropdown placement', () => {
     // confuses users who hit the constraint from different surfaces.
     assert.match(
       src,
-      /Real-time delivery requires High or Critical/,
+      /Real-time delivery is for Critical events only/,
       'sensitivity helper text must match the server error wording',
     );
   });
@@ -79,31 +85,37 @@ describe('notifications-settings.ts — sensitivity dropdown placement', () => {
 });
 
 describe('notifications-settings.ts — mode-change behavior', () => {
-  it('snaps sensitivity to high when switching TO realtime with sensitivity=all', () => {
-    // The mode-change handler must snap the value AND ALSO record the snapped
-    // sensitivity so the atomic save sends it to the server.
+  it("snaps sensitivity to 'critical' when switching TO realtime with sensitivity in {all, high} (tightened rule)", () => {
+    // Under the tightened rule, both 'all' AND 'high' must trigger the snap.
+    // The handler must snap the value AND ALSO record the snapped sensitivity
+    // so the atomic save sends it to the server.
     assert.match(
       src,
-      /isRt\s*&&\s*sensitivityEl\?\.value\s*===\s*'all'/,
-      'mode-change must detect (switching to realtime) AND (current value is all)',
+      /isRt\s*&&\s*\(sensitivityEl\?\.value\s*===\s*'all'\s*\|\|\s*sensitivityEl\?\.value\s*===\s*'high'\)/,
+      'mode-change must detect (switching to realtime) AND (current value is "all" OR "high")',
     );
     assert.match(
       src,
-      /sensitivityEl\.value\s*=\s*'high'/,
-      'mode-change must set the dropdown value to high',
+      /sensitivityEl\.value\s*=\s*'critical'/,
+      "mode-change must set the dropdown value to 'critical' (was 'high' before the tightened rule)",
     );
     assert.match(
       src,
-      /snappedSensitivity\s*=\s*'high'/,
-      'mode-change must record snappedSensitivity so the atomic save includes it',
+      /snappedSensitivity\s*=\s*'critical'/,
+      "mode-change must record snappedSensitivity = 'critical' so the atomic save includes it",
     );
   });
 
-  it("toggles the 'all' option's disabled attribute on mode change", () => {
+  it("toggles BOTH 'all' AND 'high' option disabled attributes on mode change", () => {
     assert.match(
       src,
       /allOption\.disabled\s*=\s*isRt/,
       "mode-change handler must toggle allOption.disabled with isRt",
+    );
+    assert.match(
+      src,
+      /highOption\.disabled\s*=\s*isRt/,
+      "mode-change handler must toggle highOption.disabled with isRt (tightened rule disables high too)",
     );
   });
 


### PR DESCRIPTION
## Summary

Follow-on to #3461. The previous rule allowed \`(realtime, high)\` and only forbade \`(realtime, all)\`. Production observation today: even on \`(realtime, high)\`, high-severity events fire frequently enough on busy days to overload an inbox (severe weather, market moves, geopolitics). \`fatimalbeshri3@gmail.com\` — the user who triggered the original investigation — is on \`(realtime, high)\` and still getting hit.

**Tightened rule: realtime is reserved for \`critical\`-tier events only.** Both \`(realtime, all)\` AND \`(realtime, high)\` are now forbidden. High events still reach the user, just batched in a digest cadence.

## What changes — 5 surfaces in lockstep (same shape as #3461)

1. **Server validator** (\`convex/alertRules.ts\`):
   - \`assertCompatibleDeliveryMode\` rejects \`(realtime, all)\` AND \`(realtime, high)\`
   - Insert default for realtime sensitivity flips from \`'high'\` → \`'critical'\`
   - Error message: *\"Real-time delivery is for Critical events only. To receive High or All events, choose a digest cadence.\"*
2. **Relay coerce** (\`scripts/notification-relay.cjs\`): \`effectiveSensitivity\` coerces \`(realtime, all|high)\` → \`'critical'\` (was \`'high'\`)
3. **UI** (\`src/services/notifications-settings.ts\`): \`'high'\` option now ALSO disabled when realtime; snap-on-mode-change targets \`'critical'\`; updated helper text + snap notice
4. **Tests**: existing tests using \`(realtime, high)\` as negative-control updated to \`(realtime, critical)\`. New test asserts \`(realtime, high)\` is now rejected. Insert-only-default test now expects \`'critical'\`. Source-grep contracts for both relay and UI updated.

## Affected production rows: 10 total, 5 enabled

\`fatimalbeshri3@gmail.com\` (\`user_3CchfZw4...\`) is in the list. Variant split: 9 \`full\` + 1 \`finance\`.

## Migration plan (no temp helpers needed)

After this PR merges + deploys, run direct internal-mutation calls via Convex CLI deploy-key auth:

\`\`\`bash
npx convex run alertRules:setDigestSettingsForUser \\
  '{\"userId\":\"<id>\",\"variant\":\"<v>\",\"digestMode\":\"daily\",\"digestHour\":8,\"digestTimezone\":\"UTC\"}'
\`\`\`

…iterating over the 10 affected \`(userId, variant)\` pairs. The existing \`setDigestSettingsForUser\` handles the \`(realtime, high)\` → \`(daily, high)\` transition cleanly under the new validator (validated by the new test \`daily+all → realtime+critical lands atomically\`).

Migration target: \`(realtime, high)\` → \`(daily, high)\` (preserve event-set intent, batched). Same logic as the #3461 \`(realtime, all)\` → \`(daily, all)\` migration.

After migration, courtesy email to the 5 enabled users with verified email channels.

## Test plan

- [x] \`npx vitest run convex/__tests__/alertRules.test.ts\` — 14/14 passing
- [x] \`node --test\` source-grep tests — 24/24 passing
- [x] \`npm run typecheck\` + \`npm run typecheck:api\` — both clean
- [x] \`npx biome lint\` on changed files — clean (warnings pre-existing)
- [x] \`node -c\` syntax check on relay script — OK
- [ ] **Post-merge:** run migration loop above against prod (10 rows)
- [ ] **Post-migration:** send courtesy email + watch fatimalbeshri3's inbox over the next 24h to confirm volume drop