### PR TITLE
docs: add API Reference index + surface agent-discovery endpoints

### DIFF
--- a/docs/agent-discovery.mdx
+++ b/docs/agent-discovery.mdx
@@ -1,0 +1,123 @@
+---
+title: "Agent Discovery"
+description: "Point any AI agent, codegen tool, or MCP client at worldmonitor.app and discover every API, OpenAPI spec, MCP server, and OAuth endpoint from a single root URL."
+---
+
+WorldMonitor is built to be **agent-native**. An autonomous agent — Claude, Cursor, an MCP client, or your own LangChain / LangGraph workflow — can start from a single root URL and discover everything it needs: REST schemas, MCP transport, OAuth flow, skill bundles, and human-readable briefings.
+
+No prior knowledge required. Just `GET https://worldmonitor.app/`.
+
+## The one URL to remember
+
+```
+https://worldmonitor.app/
+```
+
+The HTTP response carries an [RFC 8288](https://datatracker.ietf.org/doc/html/rfc8288) `Link:` header with `rel` values pointing at every machine-readable surface below. An agent that follows the links resolves the full picture without hardcoding a single path.
+
+```bash
+curl -sI https://worldmonitor.app/ | grep -i '^link:'
+```
+
+You'll see entries like:
+
+```
+Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json",
+      </openapi.yaml>; rel="service-desc"; type="application/vnd.oai.openapi",
+      </docs/documentation>; rel="service-doc"; type="text/html",
+      </api/health>; rel="status"; type="application/json",
+      </.well-known/oauth-protected-resource>; rel="...oauth-protected-resource",
+      </.well-known/oauth-authorization-server>; rel="...oauth-authorization-server",
+      </.well-known/mcp/server-card.json>; rel="mcp-server-card"; anchor="/mcp",
+      </.well-known/agent-skills/index.json>; rel="agent-skills-index"; type="application/json"
+```
+
+## Discovery endpoints
+
+| Endpoint | Standard | What it returns |
+|---|---|---|
+| [`/.well-known/api-catalog`](https://worldmonitor.app/.well-known/api-catalog) | [RFC 9727](https://datatracker.ietf.org/doc/html/rfc9727) | JSON linkset bundling every other discovery URL — start here if you want one fetch and a map |
+| [`/openapi.yaml`](https://www.worldmonitor.app/openapi.yaml) | OpenAPI 3.1 | Single bundled spec covering **every** REST service (Conflict, Resilience, Market, Economic, Maritime, Aviation, Climate, …) — feed it to any code-generator |
+| [`/.well-known/mcp/server-card.json`](https://worldmonitor.app/.well-known/mcp/server-card.json) | MCP | Transport (`streamableHttp`), endpoint, OAuth resource, scopes, capability flags |
+| [`/.well-known/oauth-authorization-server`](https://api.worldmonitor.app/.well-known/oauth-authorization-server) | [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) | OAuth 2.1 authorization-server metadata (PKCE, DCR, token endpoints) |
+| [`/.well-known/oauth-protected-resource`](https://worldmonitor.app/.well-known/oauth-protected-resource) | [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) | Resource metadata for `https://worldmonitor.app/mcp` |
+| [`/.well-known/agent-skills/index.json`](https://worldmonitor.app/.well-known/agent-skills/index.json) | (custom) | Index of pre-packaged agent skills (`fetch-country-brief`, `fetch-resilience-score`, …) — each skill is a self-contained recipe |
+| [`/llms.txt`](https://worldmonitor.app/llms.txt) | [llmstxt.org](https://llmstxt.org) | LLM-friendly markdown briefing — overview, capabilities, links |
+| [`/llms-full.txt`](https://worldmonitor.app/llms-full.txt) | (extension) | Long-form variant covering all data layers, panels, and data sources |
+| [`/api/health`](https://api.worldmonitor.app/api/health) | (custom) | Per-key seed status, freshness, record counts — agents can gate fetches on this |
+
+All endpoints serve `Access-Control-Allow-Origin: *` and are cached `public, max-age=3600`.
+
+## Agent walkthroughs
+
+### Codegen a REST client for every service
+
+```bash
+# 1. Discover the bundled OpenAPI URL
+curl -s https://worldmonitor.app/.well-known/api-catalog \
+  | jq -r '.linkset[0]."service-desc"[0].href'
+# → https://www.worldmonitor.app/openapi.yaml
+
+# 2. Generate clients
+curl -s https://www.worldmonitor.app/openapi.yaml -o worldmonitor.openapi.yaml
+npx @openapitools/openapi-generator-cli generate \
+  -i worldmonitor.openapi.yaml -g typescript-fetch -o ./client
+```
+
+The bundled spec covers all 30+ services in a single document, so one codegen pass produces typed clients for everything.
+
+### Connect an MCP client to live data
+
+```bash
+# 1. Read the server card
+curl -s https://worldmonitor.app/.well-known/mcp/server-card.json
+# → endpoint, transport, OAuth resource, scopes
+
+# 2. Discover the OAuth authorization server
+curl -s https://worldmonitor.app/.well-known/oauth-protected-resource \
+  | jq -r '.authorization_servers[0]'
+# → https://api.worldmonitor.app
+
+# 3. Fetch authorization-server metadata
+curl -s https://api.worldmonitor.app/.well-known/oauth-authorization-server
+# → token / authorize / registration endpoints, PKCE required, etc.
+```
+
+Or skip the manual flow entirely — most clients (Claude Desktop, claude.ai, Cursor, MCP Inspector, Claude Code) accept the MCP URL directly and run discovery + OAuth automatically:
+
+```
+https://worldmonitor.app/mcp
+```
+
+See [MCP Server](/mcp-server) for client-specific config snippets.
+
+### Server-side with a direct API key
+
+If you don't want OAuth, every REST endpoint and the MCP endpoint accept `X-WorldMonitor-Key: wm_live_...`:
+
+```bash
+curl -s https://api.worldmonitor.app/api/resilience/v1/get-resilience-ranking \
+  -H "X-WorldMonitor-Key: $WM_KEY"
+```
+
+PRO subscribers get a key from [worldmonitor.app/pro](https://www.worldmonitor.app/pro). See [Authentication](/usage-auth).
+
+### Drop-in agent skills
+
+`/.well-known/agent-skills/index.json` lists pre-packaged skills — each is a self-contained recipe an agent can ingest without reading the OpenAPI. Useful for narrow tasks where you'd rather hand the agent "fetch a country brief" than "read 30 OpenAPI specs and figure it out." Today's catalog includes `fetch-country-brief` and `fetch-resilience-score`; more land over time.
+
+## Why this matters
+
+The point isn't novelty — RFCs 8414, 8288, 9727, 9728 are old. The point is that **every** WorldMonitor surface (REST, MCP, OAuth, skills, LLM briefings) is reachable from one root URL via well-known conventions, with no out-of-band setup. An agent can:
+
+- Discover the API without reading our docs.
+- Authenticate without us telling it which OAuth flow we use.
+- Pick the right transport (REST vs MCP) based on its own preferences.
+- Stay current — when we ship a new service, the bundled `/openapi.yaml` and the api-catalog reflect it on the next deploy. No version pinning, no client SDK release cycle.
+
+## Related
+
+- [MCP Server](/mcp-server) — full client setup (Claude Desktop, Cursor, claude.ai, MCP Inspector, Claude Code)
+- [API Reference](/api-reference) — human-readable service catalog and MCP→REST tool mapping
+- [Authentication](/usage-auth) — browser, API key, and OAuth modes
+- [Quickstart](/usage-quickstart) — first call in under a minute

--- a/docs/agent-discovery.mdx
+++ b/docs/agent-discovery.mdx
@@ -46,7 +46,7 @@ Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+j
 | [`/llms-full.txt`](https://worldmonitor.app/llms-full.txt) | (extension) | Long-form variant covering all data layers, panels, and data sources |
 | [`/api/health`](https://api.worldmonitor.app/api/health) | (custom) | Per-key seed status, freshness, record counts — agents can gate fetches on this |
 
-All endpoints serve `Access-Control-Allow-Origin: *` and are cached `public, max-age=3600`.
+All endpoints serve `Access-Control-Allow-Origin: *`. The static discovery assets (`.well-known/*`, `/openapi.yaml`, `/llms*.txt`) are cached `public, max-age=3600` — safe to memoize. `/api/health` is **not** cached (`private, no-store`) because it reflects real-time seed freshness; agents should hit it fresh whenever they need to gate on data availability.
 
 ## Agent walkthroughs
 
@@ -69,19 +69,17 @@ The bundled spec covers all 30+ services in a single document, so one codegen pa
 ### Connect an MCP client to live data
 
 ```bash
-# 1. Read the server card
+# 1. Read the server card — this is the canonical descriptor for MCP
 curl -s https://worldmonitor.app/.well-known/mcp/server-card.json
-# → endpoint, transport, OAuth resource, scopes
+# → endpoint (https://worldmonitor.app/mcp), transport, OAuth scopes,
+#   and authorization_servers: ["https://api.worldmonitor.app"]
 
-# 2. Discover the OAuth authorization server
-curl -s https://worldmonitor.app/.well-known/oauth-protected-resource \
-  | jq -r '.authorization_servers[0]'
-# → https://api.worldmonitor.app
-
-# 3. Fetch authorization-server metadata
+# 2. Fetch authorization-server metadata from that host
 curl -s https://api.worldmonitor.app/.well-known/oauth-authorization-server
 # → token / authorize / registration endpoints, PKCE required, etc.
 ```
+
+`/.well-known/oauth-protected-resource` is also available, but its `authorization_servers` field is derived from the request `Host` header so each origin (apex, www, api) reports itself — same-origin metadata that satisfies strict MCP scanners. Use the **MCP server card** for the cross-origin auth-server URL the actual MCP endpoint expects.
 
 Or skip the manual flow entirely — most clients (Claude Desktop, claude.ai, Cursor, MCP Inspector, Claude Code) accept the MCP URL directly and run discovery + OAuth automatically:
 

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -15,24 +15,9 @@ The grouped pages in the left sidebar render the full OpenAPI spec — request p
 
 ## Machine-readable discovery
 
-Point any agent, codegen tool, or MCP client at `https://worldmonitor.app/` and it can discover everything below from a single root. The root response advertises all of the following via an [RFC 8288](https://datatracker.ietf.org/doc/html/rfc8288) `Link:` header.
+Building an agent or codegen pipeline? Point at `https://worldmonitor.app/` and follow the `Link:` header — every OpenAPI spec, MCP server card, OAuth endpoint, and agent-skill bundle is discoverable from one root URL via standard `.well-known` paths. See [Agent Discovery](/agent-discovery) for the full walkthrough.
 
-| Endpoint | What it returns |
-|---|---|
-| [`/.well-known/api-catalog`](https://worldmonitor.app/.well-known/api-catalog) | RFC 9727 linkset pointing at the OpenAPI spec, MCP server card, status endpoint, OAuth metadata, and agent-skills index |
-| [`/openapi.yaml`](https://www.worldmonitor.app/openapi.yaml) | Single bundled OpenAPI 3.1 spec covering **every** REST service (Conflict, Resilience, Market, Economic, Maritime, …) |
-| [`/.well-known/mcp/server-card.json`](https://worldmonitor.app/.well-known/mcp/server-card.json) | MCP server descriptor — transport, endpoint URL, OAuth resource, scopes |
-| [`/.well-known/oauth-authorization-server`](https://api.worldmonitor.app/.well-known/oauth-authorization-server) | RFC 8414 OAuth 2.1 authorization-server metadata (PKCE) |
-| [`/.well-known/oauth-protected-resource`](https://worldmonitor.app/.well-known/oauth-protected-resource) | RFC 9728 protected-resource metadata for `https://worldmonitor.app/mcp` |
-| [`/.well-known/agent-skills/index.json`](https://worldmonitor.app/.well-known/agent-skills/index.json) | Index of pre-packaged agent skills (e.g. `fetch-country-brief`, `fetch-resilience-score`) |
-| [`/llms.txt`](https://worldmonitor.app/llms.txt) / [`/llms-full.txt`](https://worldmonitor.app/llms-full.txt) | Markdown briefing aimed at LLM agents — overview, capabilities, layer/panel reference |
-
-A typical agent flow:
-
-1. `GET https://worldmonitor.app/` → read the `Link:` header for `rel=api-catalog` and `rel=mcp-server-card`.
-2. `GET https://worldmonitor.app/.well-known/api-catalog` → resolve the bundled OpenAPI URL.
-3. `GET https://www.worldmonitor.app/openapi.yaml` → codegen REST clients for every service in one pass.
-4. To use MCP instead, point the client at `https://worldmonitor.app/mcp` (it'll fetch the server card and OAuth metadata on its own).
+The single bundled spec is at [`/openapi.yaml`](https://www.worldmonitor.app/openapi.yaml) — feed it to any OpenAPI generator to produce typed clients for all 30+ services in one pass.
 
 ## Service catalog
 

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -13,6 +13,27 @@ https://api.worldmonitor.app/api/<service>/v1/<rpc-name>
 
 The grouped pages in the left sidebar render the full OpenAPI spec — request parameters, response schemas, and try-it-out — for each service.
 
+## Machine-readable discovery
+
+Point any agent, codegen tool, or MCP client at `https://worldmonitor.app/` and it can discover everything below from a single root. The root response advertises all of the following via an [RFC 8288](https://datatracker.ietf.org/doc/html/rfc8288) `Link:` header.
+
+| Endpoint | What it returns |
+|---|---|
+| [`/.well-known/api-catalog`](https://worldmonitor.app/.well-known/api-catalog) | RFC 9727 linkset pointing at the OpenAPI spec, MCP server card, status endpoint, OAuth metadata, and agent-skills index |
+| [`/openapi.yaml`](https://www.worldmonitor.app/openapi.yaml) | Single bundled OpenAPI 3.1 spec covering **every** REST service (Conflict, Resilience, Market, Economic, Maritime, …) |
+| [`/.well-known/mcp/server-card.json`](https://worldmonitor.app/.well-known/mcp/server-card.json) | MCP server descriptor — transport, endpoint URL, OAuth resource, scopes |
+| [`/.well-known/oauth-authorization-server`](https://api.worldmonitor.app/.well-known/oauth-authorization-server) | RFC 8414 OAuth 2.1 authorization-server metadata (PKCE) |
+| [`/.well-known/oauth-protected-resource`](https://worldmonitor.app/.well-known/oauth-protected-resource) | RFC 9728 protected-resource metadata for `https://worldmonitor.app/mcp` |
+| [`/.well-known/agent-skills/index.json`](https://worldmonitor.app/.well-known/agent-skills/index.json) | Index of pre-packaged agent skills (e.g. `fetch-country-brief`, `fetch-resilience-score`) |
+| [`/llms.txt`](https://worldmonitor.app/llms.txt) / [`/llms-full.txt`](https://worldmonitor.app/llms-full.txt) | Markdown briefing aimed at LLM agents — overview, capabilities, layer/panel reference |
+
+A typical agent flow:
+
+1. `GET https://worldmonitor.app/` → read the `Link:` header for `rel=api-catalog` and `rel=mcp-server-card`.
+2. `GET https://worldmonitor.app/.well-known/api-catalog` → resolve the bundled OpenAPI URL.
+3. `GET https://www.worldmonitor.app/openapi.yaml` → codegen REST clients for every service in one pass.
+4. To use MCP instead, point the client at `https://worldmonitor.app/mcp` (it'll fetch the server card and OAuth metadata on its own).
+
 ## Service catalog
 
 **Geopolitical** — Conflicts, Military, Unrest, Intelligence, Displacement, Cyber, Sanctions

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -37,32 +37,35 @@ Open any group in the sidebar to browse its operations.
 
 ## MCP equivalents
 
-If you've been using the [MCP server](/mcp-server) and want the matching REST call, most MCP tools map 1:1 to a single REST RPC under the corresponding service:
+If you've been using the [MCP server](/mcp-server) and want REST equivalents, the relationship isn't always 1:1. Most MCP tools fall into one of three buckets:
 
-| MCP tool | Service | Example REST endpoint |
-|---|---|---|
-| `get_market_data` | Markets | `/api/market/v1/get-quotes` |
-| `get_conflict_events` | Conflicts | `/api/conflict/v1/list-acled-events` |
-| `get_aviation_status` | Aviation | `/api/aviation/v1/track-aircraft` |
-| `get_news_intelligence` | News | `/api/news/v1/list-feed-digest` |
-| `get_natural_disasters` | Natural Disasters | `/api/natural/v1/list-events` |
-| `get_military_posture` | Military | `/api/military/v1/list-military-flights` |
-| `get_cyber_threats` | Cyber | `/api/cyber/v1/...` |
-| `get_economic_data` / `get_country_macro` | Economic | `/api/economic/v1/get-fred-series`, `/api/economic/v1/get-country-macro` |
-| `get_eu_housing_cycle` / `get_eu_quarterly_gov_debt` / `get_eu_industrial_production` | Economic | `/api/economic/v1/...` |
-| `get_prediction_markets` | Predictions | `/api/prediction/v1/...` |
-| `get_sanctions_data` | Sanctions | `/api/sanctions/v1/...` |
-| `get_climate_data` | Climate | `/api/climate/v1/...` |
-| `get_infrastructure_status` | Infrastructure | `/api/infrastructure/v1/...` |
-| `get_supply_chain_data` | Supply Chain | `/api/supply-chain/v1/...` |
-| `get_positive_events` | Positive Events | `/api/positive-events/v1/...` |
-| `get_radiation_data` | Radiation | `/api/radiation/v1/...` |
-| `get_research_signals` | Research | `/api/research/v1/...` |
-| `get_forecast_predictions` | Forecasts | `/api/forecast/v1/get-forecasts` |
-| `get_maritime_activity` | Maritime | `/api/maritime/v1/get-vessel-snapshot` |
-| `search_flights` / `search_flight_prices_by_date` | Aviation | `/api/aviation/v1/search-google-flights`, `/api/aviation/v1/search-google-dates` |
+**Bundled cache-reads** — the MCP tool reads multiple Redis keys in one call. There's no single REST RPC that returns the same envelope; instead, REST exposes the underlying domains as fine-grained operations you can mix-and-match. Examples: `get_market_data` (bundles equity / commodity / crypto / sectors / ETF flows / Gulf / fear-greed) → see `list-market-quotes`, `list-commodity-quotes`, `list-crypto-quotes`, `get-sector-summary`, `list-etf-flows`, `list-gulf-quotes`, `get-fear-greed-index` in MarketService. Same shape for `get_economic_data`, `get_country_macro` (IMF WEO macro), and `get_eu_*`.
 
-Composite MCP tools (`get_world_brief`, `get_country_brief`, `get_country_risk`, `get_airspace`, `analyze_situation`, `generate_forecasts`) fan out to multiple REST RPCs and merge results — there's no single REST equivalent. Hit the underlying RPCs in the relevant service spec and combine client-side.
+**1:1 RPC tools** — the MCP tool wraps a single REST RPC:
+
+| MCP tool | REST endpoint |
+|---|---|
+| `get_conflict_events` | `/api/conflict/v1/list-acled-events` (also `list-ucdp-events`, `list-iran-events`) |
+| `get_news_intelligence` | `/api/news/v1/list-feed-digest`, `/api/news/v1/summarize-article` |
+| `get_natural_disasters` | `/api/natural/v1/list-natural-events` |
+| `get_military_posture` | `/api/military/v1/list-military-flights`, `/api/military/v1/get-theater-posture` |
+| `get_cyber_threats` | `/api/cyber/v1/list-cyber-threats` |
+| `get_prediction_markets` | `/api/prediction/v1/list-prediction-markets` |
+| `get_sanctions_data` | `/api/sanctions/v1/list-sanctions-pressure`, `/api/sanctions/v1/lookup-sanction-entity` |
+| `get_climate_data` | `/api/climate/v1/list-climate-anomalies`, `/api/climate/v1/get-co2-monitoring`, `/api/climate/v1/get-ocean-ice-data`, `/api/climate/v1/list-air-quality-data`, … |
+| `get_infrastructure_status` | `/api/infrastructure/v1/list-internet-outages`, `/api/infrastructure/v1/list-service-statuses` |
+| `get_supply_chain_data` | `/api/supply-chain/v1/get-shipping-stress`, `/api/supply-chain/v1/get-chokepoint-status`, `/api/supply-chain/v1/get-critical-minerals`, … |
+| `get_positive_events` | `/api/positive-events/v1/list-positive-geo-events` |
+| `get_radiation_data` | `/api/radiation/v1/list-radiation-observations` |
+| `get_research_signals` | `/api/research/v1/list-arxiv-papers`, `/api/research/v1/list-trending-repos`, `/api/research/v1/list-hackernews-items`, `/api/research/v1/list-tech-events` |
+| `get_forecast_predictions` | `/api/forecast/v1/get-forecasts` |
+| `get_maritime_activity` | `/api/maritime/v1/get-vessel-snapshot` |
+| `get_aviation_status` | `/api/aviation/v1/list-airport-delays`, `/api/aviation/v1/track-aircraft`, `/api/aviation/v1/get-flight-status` |
+| `search_flights` / `search_flight_prices_by_date` | `/api/aviation/v1/search-google-flights`, `/api/aviation/v1/search-google-dates` |
+
+**Composite / LLM tools** — `get_world_brief`, `get_country_brief`, `get_country_risk`, `get_airspace`, `analyze_situation`, `generate_forecasts` fan out to multiple REST RPCs and apply LLM synthesis or geographic filtering. There's no single REST equivalent — call the underlying RPCs and combine client-side.
+
+Always cross-check against [the bundled OpenAPI spec](https://www.worldmonitor.app/openapi.yaml) — that's the source of truth for path names, parameters, and response shapes.
 
 ## Platform endpoints
 

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -1,0 +1,63 @@
+---
+title: "API Reference"
+description: "Catalog of every WorldMonitor REST service. All endpoints follow /api/<service>/v1/<rpc-name>."
+---
+
+WorldMonitor exposes its data through a family of versioned REST services. Every endpoint follows the same shape:
+
+```
+https://api.worldmonitor.app/api/<service>/v1/<rpc-name>
+```
+
+`<rpc-name>` is kebab-case (e.g. `list-acled-events`, `get-resilience-ranking`). Auth is the same on every service — pass `X-WorldMonitor-Key: wm_live_...` (or rely on a trusted browser origin). See [Authentication](/usage-auth) for details.
+
+The grouped pages in the left sidebar render the full OpenAPI spec — request parameters, response schemas, and try-it-out — for each service.
+
+## Service catalog
+
+**Geopolitical** — Conflicts, Military, Unrest, Intelligence, Displacement, Cyber, Sanctions
+
+**Natural events** — Natural Disasters, Seismology, Climate, Wildfires, Radiation, Thermal
+
+**Economy and markets** — Economic (FRED / IMF / BIS / country macro), Markets (quotes / indices / FX / commodities), Trade, Supply Chain, Consumer Prices, Predictions (prediction markets), Forecasts
+
+**Infrastructure and transport** — Aviation (aircraft tracking, flight search), Maritime (vessels, density zones), Infrastructure, Resilience (country resilience score and ranking)
+
+**Health and environment** — Public Health, Imagery, Webcams
+
+**Other** — News (feed digest, article summaries), Research, Positive Events, Giving
+
+Open any group in the sidebar to browse its operations.
+
+## MCP equivalents
+
+If you've been using the [MCP server](/mcp-server) and want the matching REST call, most MCP tools map 1:1 to a single REST RPC under the corresponding service:
+
+| MCP tool | Service | Example REST endpoint |
+|---|---|---|
+| `get_market_data` | Markets | `/api/market/v1/get-quotes` |
+| `get_conflict_events` | Conflicts | `/api/conflict/v1/list-acled-events` |
+| `get_aviation_status` | Aviation | `/api/aviation/v1/track-aircraft` |
+| `get_news_intelligence` | News | `/api/news/v1/list-feed-digest` |
+| `get_natural_disasters` | Natural Disasters | `/api/natural/v1/list-events` |
+| `get_military_posture` | Military | `/api/military/v1/list-military-flights` |
+| `get_cyber_threats` | Cyber | `/api/cyber/v1/...` |
+| `get_economic_data` / `get_country_macro` | Economic | `/api/economic/v1/get-fred-series`, `/api/economic/v1/get-country-macro` |
+| `get_eu_housing_cycle` / `get_eu_quarterly_gov_debt` / `get_eu_industrial_production` | Economic | `/api/economic/v1/...` |
+| `get_prediction_markets` | Predictions | `/api/prediction/v1/...` |
+| `get_sanctions_data` | Sanctions | `/api/sanctions/v1/...` |
+| `get_climate_data` | Climate | `/api/climate/v1/...` |
+| `get_infrastructure_status` | Infrastructure | `/api/infrastructure/v1/...` |
+| `get_supply_chain_data` | Supply Chain | `/api/supply-chain/v1/...` |
+| `get_positive_events` | Positive Events | `/api/positive-events/v1/...` |
+| `get_radiation_data` | Radiation | `/api/radiation/v1/...` |
+| `get_research_signals` | Research | `/api/research/v1/...` |
+| `get_forecast_predictions` | Forecasts | `/api/forecast/v1/get-forecasts` |
+| `get_maritime_activity` | Maritime | `/api/maritime/v1/get-vessel-snapshot` |
+| `search_flights` / `search_flight_prices_by_date` | Aviation | `/api/aviation/v1/search-google-flights`, `/api/aviation/v1/search-google-dates` |
+
+Composite MCP tools (`get_world_brief`, `get_country_brief`, `get_country_risk`, `get_airspace`, `analyze_situation`, `generate_forecasts`) fan out to multiple REST RPCs and merge results — there's no single REST equivalent. Hit the underlying RPCs in the relevant service spec and combine client-side.
+
+## Platform endpoints
+
+Bootstrap, health, version, and cache-purge live outside the per-service catalog — see [Platform Endpoints](/api-platform).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -221,6 +221,12 @@
         "tab": "API Reference",
         "groups": [
           {
+            "group": "Overview",
+            "pages": [
+              "api-reference"
+            ]
+          },
+          {
             "group": "Geopolitical",
             "pages": [
               {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -179,6 +179,7 @@
           {
             "group": "MCP & Integrations",
             "pages": [
+              "agent-discovery",
               "mcp-server",
               "api-oauth",
               "api-notifications"

--- a/docs/documentation.mdx
+++ b/docs/documentation.mdx
@@ -23,7 +23,7 @@ The platform is designed for journalists, security analysts, researchers, PRO su
 - **New here?** Start with [Getting Started](/getting-started) for installation and setup
 - **Want the quick tour?** [Features & Interface](/features) walks through the map, layers, panels, and Cmd+K
 - **Want to understand the system?** Read [Architecture](/architecture) for how the pieces fit together
-- **Building an integration?** Start with the [Quickstart](/usage-quickstart) and browse the [API Reference](/api/ConflictService.openapi.yaml)
+- **Building an integration?** Start with the [Quickstart](/usage-quickstart) and browse the [API Reference](/api-reference)
 - **Connecting an AI agent?** Set up the [MCP server](/mcp-server)
 - **Interested in the data sources?** See [Data Sources](/data-sources)
 - **Want to contribute?** Read [Contributing](/contributing) for code style and PR process

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -240,5 +240,5 @@ Tool-level errors return `isError: true` with a text explanation in `content`.
 ## Related
 
 - [Authentication overview](/authentication) — browser vs bearer vs OAuth
-- [API Reference](/api/ConflictService.openapi.yaml) — the same data via REST
+- [API Reference](/api-reference) — the same data via REST
 - [Pro features](https://www.worldmonitor.app/pro)

--- a/docs/usage-quickstart.mdx
+++ b/docs/usage-quickstart.mdx
@@ -72,3 +72,4 @@ See [MCP](/mcp-server) for client-specific setup.
 - [Rate limits](/usage-rate-limits) — per-endpoint caps
 - [Errors](/usage-errors) — response shapes and retry guidance
 - [API Reference](/api-reference) — every service, RPC, and request/response schema
+- [Agent Discovery](/agent-discovery) — for AI agents and codegen tools: discover all OpenAPI / MCP / OAuth surfaces from one root URL

--- a/docs/usage-quickstart.mdx
+++ b/docs/usage-quickstart.mdx
@@ -71,4 +71,4 @@ See [MCP](/mcp-server) for client-specific setup.
 - [Authentication](/usage-auth) — all three auth modes
 - [Rate limits](/usage-rate-limits) — per-endpoint caps
 - [Errors](/usage-errors) — response shapes and retry guidance
-- [API Reference](/api/ConflictService.openapi.yaml) — every RPC with request/response schemas
+- [API Reference](/api-reference) — every service, RPC, and request/response schema


### PR DESCRIPTION
## Summary

- An API Starter customer reported that he thought "only the Conflict service is documented" — three docs pages linked **API Reference** → \`/api/ConflictService.openapi.yaml\` (a single OpenAPI YAML), so users landed on Conflicts and didn't realize the other 29 services are documented too.
- Added a new \`docs/api-reference.mdx\` overview page: REST path-pattern recap, full service catalog grouped by domain, MCP→REST tool-mapping table, and a **Machine-readable discovery** section that surfaces the agent-friendly endpoints (api-catalog, bundled \`/openapi.yaml\`, MCP server-card, OAuth metadata, agent-skills index, llms.txt) — all of which are already wired in \`vercel.json\` (Link header on \`/\`) and the \`prebuild\` openapi-bundling step but were undocumented user-side.
- Wired the new page as the first entry of the **API Reference** tab in \`docs.json\` so clicking the tab lands on the catalog instead of Conflicts.
- Repointed the three \`/api/ConflictService.openapi.yaml\` links in \`usage-quickstart.mdx\`, \`documentation.mdx\`, \`mcp-server.mdx\` at \`/api-reference\`.

## Test plan

- [ ] Mintlify preview: API Reference tab opens on the new overview page
- [ ] Sidebar still renders all 30+ service groups under their domain headings
- [ ] \`/usage-quickstart\`, \`/documentation\`, \`/mcp-server\` "API Reference" links navigate to \`/api-reference\` (not a YAML file)
- [ ] All discovery endpoints listed are reachable in prod (\`/.well-known/api-catalog\`, \`/openapi.yaml\`, \`/.well-known/mcp/server-card.json\`, etc.)