### PR TITLE
fix(broadcast): lease-based race guard + structured partial-failure recovery

### DIFF
--- a/convex/__tests__/rampRunner.test.ts
+++ b/convex/__tests__/rampRunner.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Tests for the broadcast ramp runner's lease-based concurrency guard +
+ * structured recovery action.
+ *
+ * Two production-incident-prevention scenarios:
+ *
+ *   1. Race condition (P1, PR #3473 review): two overlapping cron runs (or
+ *      cron + manual trigger, or Convex action retry) both proceed through
+ *      assignAndExportWave + createProLaunchBroadcast + sendProLaunchBroadcast
+ *      before colliding at _recordWaveSent. By then DUPLICATE EMAILS have
+ *      already gone out. The lease (claimed BEFORE side effects) makes the
+ *      loser exit cleanly.
+ *
+ *   2. Recovery after exported-but-not-sent (P1, PR #3473 review): a partial
+ *      failure where assignAndExportWave succeeded (contacts stamped, segment
+ *      created) but createProLaunchBroadcast / sendProLaunchBroadcast threw.
+ *      Bare clearPartialFailure makes the next cron retry the same waveLabel,
+ *      which fails because the contacts are already stamped. recoverFromPartialFailure
+ *      provides explicit recovery modes: manual-finished (advance tier with
+ *      manually-completed broadcastId) or discard-and-rotate (bump
+ *      waveLabelOffset so next cron uses a fresh label).
+ */
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.ts");
+
+async function seedRampConfig(
+  t: ReturnType<typeof convexTest>,
+  overrides: Partial<{
+    currentTier: number;
+    rampCurve: number[];
+    waveLabelPrefix: string;
+    waveLabelOffset: number;
+    lastRunStatus: string | undefined;
+    lastWaveBroadcastId: string | undefined;
+    lastWaveSentAt: number | undefined;
+    pendingRunId: string | undefined;
+    pendingRunStartedAt: number | undefined;
+    active: boolean;
+    killGateTripped: boolean;
+  }> = {},
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("broadcastRampConfig", {
+      key: "current",
+      active: overrides.active ?? true,
+      rampCurve: overrides.rampCurve ?? [500, 1500, 5000],
+      currentTier: overrides.currentTier ?? 0,
+      waveLabelPrefix: overrides.waveLabelPrefix ?? "wave",
+      waveLabelOffset: overrides.waveLabelOffset ?? 3,
+      bounceKillThreshold: 0.04,
+      complaintKillThreshold: 0.0008,
+      killGateTripped: overrides.killGateTripped ?? false,
+      lastRunStatus: overrides.lastRunStatus,
+      lastWaveBroadcastId: overrides.lastWaveBroadcastId,
+      lastWaveSentAt: overrides.lastWaveSentAt,
+      pendingRunId: overrides.pendingRunId,
+      pendingRunStartedAt: overrides.pendingRunStartedAt,
+    });
+  });
+}
+
+async function loadRow(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) =>
+    ctx.db
+      .query("broadcastRampConfig")
+      .withIndex("by_key", (q) => q.eq("key", "current"))
+      .first(),
+  );
+}
+
+// ----------------------------------------------------------------------------
+// _claimTierForRun: the pre-side-effect lock
+// ----------------------------------------------------------------------------
+
+describe("_claimTierForRun — lease lifecycle", () => {
+  test("claims successfully when no lease is held", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    const result = await t.mutation(internal.broadcast.rampRunner._claimTierForRun, {
+      runId: "run-1",
+      expectedCurrentTier: 0,
+    });
+    expect(result.ok).toBe(true);
+    const row = await loadRow(t);
+    expect(row?.pendingRunId).toBe("run-1");
+    expect(row?.pendingRunStartedAt).toBeTypeOf("number");
+  });
+
+  test("rejects when another lease is held and fresh — RACE GUARD", async () => {
+    // The whole point: two concurrent runs both pass kill-gate / tier-bounds
+    // checks, both attempt to claim, only ONE wins. The loser exits without
+    // running assignAndExportWave + createProLaunchBroadcast + sendProLaunchBroadcast.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+
+    const first = await t.mutation(internal.broadcast.rampRunner._claimTierForRun, {
+      runId: "run-A",
+      expectedCurrentTier: 0,
+    });
+    expect(first.ok).toBe(true);
+
+    const second = await t.mutation(internal.broadcast.rampRunner._claimTierForRun, {
+      runId: "run-B",
+      expectedCurrentTier: 0,
+    });
+    expect(second.ok).toBe(false);
+    expect(second.reason).toBe("lease-held");
+    expect(second.heldBy).toBe("run-A");
+  });
+
+  test("rejects when expectedCurrentTier doesn't match — protects against tier-already-advanced", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, { currentTier: 2 });
+    const result = await t.mutation(internal.broadcast.rampRunner._claimTierForRun, {
+      runId: "run-1",
+      expectedCurrentTier: 1, // stale
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("tier-moved");
+    expect(result.actualTier).toBe(2);
+  });
+
+  test("overrides a stale lease (older than STALE_LEASE_MS) — recovers from runner crash", async () => {
+    // STALE_LEASE_MS is 30 minutes. Seed a lease 31 minutes old; new claim wins.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      pendingRunId: "run-crashed",
+      pendingRunStartedAt: Date.now() - 31 * 60 * 1000,
+    });
+    const result = await t.mutation(internal.broadcast.rampRunner._claimTierForRun, {
+      runId: "run-fresh",
+      expectedCurrentTier: 0,
+    });
+    expect(result.ok).toBe(true);
+    const row = await loadRow(t);
+    expect(row?.pendingRunId).toBe("run-fresh");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// _recordWaveSent: validates lease and clears it
+// ----------------------------------------------------------------------------
+
+describe("_recordWaveSent — lease validation on success", () => {
+  test("clears the lease and advances tier when the lease is held by the same runId", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      currentTier: 1,
+      pendingRunId: "run-X",
+      pendingRunStartedAt: Date.now(),
+    });
+    const result = await t.mutation(internal.broadcast.rampRunner._recordWaveSent, {
+      runId: "run-X",
+      expectedCurrentTier: 1,
+      newTier: 2,
+      waveLabel: "wave-5",
+      broadcastId: "bc-test-123",
+      segmentId: "seg-test-456",
+      assigned: 1500,
+      sentAt: Date.now(),
+    });
+    expect(result.ok).toBe(true);
+    const row = await loadRow(t);
+    expect(row?.currentTier).toBe(2);
+    expect(row?.lastWaveBroadcastId).toBe("bc-test-123");
+    expect(row?.pendingRunId).toBeUndefined();
+    expect(row?.pendingRunStartedAt).toBeUndefined();
+  });
+
+  test("throws when the lease has been overridden (lease-lost guard)", async () => {
+    // Defends against the (rare) case where our lease was overridden as stale
+    // by another run while we were in flight. We must NOT advance the tier —
+    // the other run may also be in flight and would conflict.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      currentTier: 1,
+      pendingRunId: "run-OTHER",
+      pendingRunStartedAt: Date.now(),
+    });
+    await expect(
+      t.mutation(internal.broadcast.rampRunner._recordWaveSent, {
+        runId: "run-MINE",
+        expectedCurrentTier: 1,
+        newTier: 2,
+        waveLabel: "wave-5",
+        broadcastId: "bc-test",
+        segmentId: "seg-test",
+        assigned: 1500,
+        sentAt: Date.now(),
+      }),
+    ).rejects.toThrow(/lease lost/i);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// _recordRunOutcome: clears lease for the matching runId
+// ----------------------------------------------------------------------------
+
+describe("_recordRunOutcome — lease release on failure", () => {
+  test("clears the lease when runId matches the held lease", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      pendingRunId: "run-Y",
+      pendingRunStartedAt: Date.now(),
+    });
+    await t.mutation(internal.broadcast.rampRunner._recordRunOutcome, {
+      runId: "run-Y",
+      status: "partial-failure",
+      error: "test failure",
+    });
+    const row = await loadRow(t);
+    expect(row?.pendingRunId).toBeUndefined();
+    expect(row?.pendingRunStartedAt).toBeUndefined();
+    expect(row?.lastRunStatus).toBe("partial-failure");
+  });
+
+  test("does NOT clear the lease when runId differs (avoids stomping another run's lease)", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      pendingRunId: "run-OTHER",
+      pendingRunStartedAt: Date.now(),
+    });
+    await t.mutation(internal.broadcast.rampRunner._recordRunOutcome, {
+      runId: "run-MINE",
+      status: "partial-failure",
+    });
+    const row = await loadRow(t);
+    // Lease stays with run-OTHER, even though we recorded an outcome.
+    expect(row?.pendingRunId).toBe("run-OTHER");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// recoverFromPartialFailure — the structured recovery for P1 #2
+// ----------------------------------------------------------------------------
+
+describe("recoverFromPartialFailure — exported-but-not-sent recovery", () => {
+  test("manual-finished: advances tier + records broadcastId from operator-completed wave", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      currentTier: 1,
+      lastRunStatus: "partial-failure",
+      pendingRunId: "run-stuck",
+      pendingRunStartedAt: Date.now(),
+    });
+    const result = await t.mutation(
+      internal.broadcast.rampRunner.recoverFromPartialFailure,
+      {
+        recovery: "manual-finished",
+        reason: "Sent wave-5 manually via Resend dashboard after createProLaunchBroadcast threw",
+        broadcastId: "bc-manual-789",
+        segmentId: "seg-manual-456",
+        sentAt: 1700000000000,
+        assigned: 1500,
+      },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.recovery).toBe("manual-finished");
+    expect(result.advancedToTier).toBe(2);
+
+    const row = await loadRow(t);
+    expect(row?.currentTier).toBe(2);
+    expect(row?.lastWaveBroadcastId).toBe("bc-manual-789");
+    expect(row?.lastWaveSegmentId).toBe("seg-manual-456");
+    expect(row?.lastWaveAssigned).toBe(1500);
+    expect(row?.lastWaveSentAt).toBe(1700000000000);
+    expect(row?.lastRunStatus).toMatch(/succeeded-via-manual-recovery/);
+    expect(row?.pendingRunId).toBeUndefined();
+  });
+
+  test("manual-finished: rejects when required fields are missing", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, { lastRunStatus: "partial-failure" });
+    await expect(
+      t.mutation(internal.broadcast.rampRunner.recoverFromPartialFailure, {
+        recovery: "manual-finished",
+        reason: "test",
+        // missing broadcastId, segmentId, sentAt, assigned
+      }),
+    ).rejects.toThrow(/broadcastId, segmentId, sentAt, assigned are all required/i);
+  });
+
+  test("discard-and-rotate: bumps waveLabelOffset so next cron uses a FRESH label", async () => {
+    // P1 #2 fix: without this, next cron retries the SAME waveLabel and
+    // assignAndExportWave rejects because contacts are already stamped.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      currentTier: 1,
+      waveLabelOffset: 3, // current next would be wave-(2+3)=wave-5
+      lastRunStatus: "partial-failure",
+      pendingRunId: "run-stuck",
+      pendingRunStartedAt: Date.now(),
+    });
+    const result = await t.mutation(
+      internal.broadcast.rampRunner.recoverFromPartialFailure,
+      {
+        recovery: "discard-and-rotate",
+        reason: "wave-5 is unrecoverable; discarding the stamped batch",
+      },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.recovery).toBe("discard-and-rotate");
+    expect(result.newWaveLabelOffset).toBe(4);
+    expect(result.nextWaveLabel).toBe("wave-6");
+
+    const row = await loadRow(t);
+    expect(row?.waveLabelOffset).toBe(4);
+    // Tier NOT advanced — we never sent.
+    expect(row?.currentTier).toBe(1);
+    expect(row?.lastRunStatus).toMatch(/partial-failure-discarded-rotated/);
+    expect(row?.pendingRunId).toBeUndefined();
+  });
+
+  test("noop when status is not partial-failure", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, { lastRunStatus: "succeeded" });
+    const result = await t.mutation(
+      internal.broadcast.rampRunner.recoverFromPartialFailure,
+      {
+        recovery: "discard-and-rotate",
+        reason: "operator confused, no actual partial-failure",
+      },
+    );
+    expect(result.noop).toBe(true);
+    expect(result.currentStatus).toBe("succeeded");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// End-to-end: the race scenario the lease prevents
+// ----------------------------------------------------------------------------
+
+describe("end-to-end: lease prevents duplicate-send race", () => {
+  test("first claim wins; second is rejected without ANY side effect path being taken", async () => {
+    // This is the scenario reviewer flagged: two concurrent runs both pass the
+    // kill-gate / tier-bounds checks above, both attempt to claim. With the
+    // lease, only ONE wins. The other returns claim-rejected and the runner
+    // exits before assignAndExportWave / createProLaunchBroadcast / sendProLaunchBroadcast
+    // are ever called.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+
+    const claimA = await t.mutation(internal.broadcast.rampRunner._claimTierForRun, {
+      runId: "run-A",
+      expectedCurrentTier: 0,
+    });
+    const claimB = await t.mutation(internal.broadcast.rampRunner._claimTierForRun, {
+      runId: "run-B",
+      expectedCurrentTier: 0,
+    });
+
+    // Exactly one wins.
+    expect([claimA.ok, claimB.ok].filter(Boolean).length).toBe(1);
+
+    // The winner can record success and clear the lease.
+    const winner = claimA.ok ? "run-A" : "run-B";
+    await t.mutation(internal.broadcast.rampRunner._recordWaveSent, {
+      runId: winner,
+      expectedCurrentTier: 0,
+      newTier: 1,
+      waveLabel: "wave-3",
+      broadcastId: "bc-1",
+      segmentId: "seg-1",
+      assigned: 500,
+      sentAt: Date.now(),
+    });
+
+    // After success: lease cleared, tier advanced.
+    const row = await loadRow(t);
+    expect(row?.currentTier).toBe(1);
+    expect(row?.pendingRunId).toBeUndefined();
+  });
+});

--- a/convex/__tests__/rampRunner.test.ts
+++ b/convex/__tests__/rampRunner.test.ts
@@ -39,6 +39,12 @@ async function seedRampConfig(
     lastWaveSentAt: number | undefined;
     pendingRunId: string | undefined;
     pendingRunStartedAt: number | undefined;
+    pendingWaveLabel: string | undefined;
+    pendingSegmentId: string | undefined;
+    pendingAssigned: number | undefined;
+    pendingExportAt: number | undefined;
+    pendingBroadcastId: string | undefined;
+    pendingBroadcastAt: number | undefined;
     active: boolean;
     killGateTripped: boolean;
   }> = {},
@@ -59,6 +65,12 @@ async function seedRampConfig(
       lastWaveSentAt: overrides.lastWaveSentAt,
       pendingRunId: overrides.pendingRunId,
       pendingRunStartedAt: overrides.pendingRunStartedAt,
+      pendingWaveLabel: overrides.pendingWaveLabel,
+      pendingSegmentId: overrides.pendingSegmentId,
+      pendingAssigned: overrides.pendingAssigned,
+      pendingExportAt: overrides.pendingExportAt,
+      pendingBroadcastId: overrides.pendingBroadcastId,
+      pendingBroadcastAt: overrides.pendingBroadcastAt,
     });
   });
 }
@@ -124,20 +136,90 @@ describe("_claimTierForRun — lease lifecycle", () => {
     expect(result.actualTier).toBe(2);
   });
 
-  test("overrides a stale lease (older than STALE_LEASE_MS) — recovers from runner crash", async () => {
-    // STALE_LEASE_MS is 30 minutes. Seed a lease 31 minutes old; new claim wins.
+  test("rejects EVEN A STALE lease — no automatic time-based override (P1#1)", async () => {
+    // P1#1 fix: a wall-clock-based override has the same failure mode the
+    // lease exists to prevent. assignAndExportWave can legitimately exceed
+    // any cutoff for large rampCurve sizes / slow Resend, and overriding
+    // mid-flight lets a second run race and duplicate-send. Recovery from
+    // a genuinely-stuck lease is operator-only via forceReleaseLease.
     const t = convexTest(schema, modules);
     await seedRampConfig(t, {
-      pendingRunId: "run-crashed",
-      pendingRunStartedAt: Date.now() - 31 * 60 * 1000,
+      pendingRunId: "run-very-old",
+      pendingRunStartedAt: Date.now() - 6 * 60 * 60 * 1000, // 6 hours ago
     });
     const result = await t.mutation(internal.broadcast.rampRunner._claimTierForRun, {
       runId: "run-fresh",
       expectedCurrentTier: 0,
     });
-    expect(result.ok).toBe(true);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("lease-held");
+    expect(result.heldBy).toBe("run-very-old");
     const row = await loadRow(t);
-    expect(row?.pendingRunId).toBe("run-fresh");
+    // Lease is unchanged.
+    expect(row?.pendingRunId).toBe("run-very-old");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// forceReleaseLease — operator-only stale-lease recovery
+// ----------------------------------------------------------------------------
+
+describe("forceReleaseLease — operator-only stale-lease recovery (P1#1)", () => {
+  test("clears the lease and sets lastRunStatus=partial-failure so recoverFromPartialFailure can pick up", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      pendingRunId: "run-wedged",
+      pendingRunStartedAt: Date.now() - 6 * 60 * 60 * 1000,
+      // Mid-flight progress preserved so the operator can decide between
+      // manual-finished and discard-and-rotate from persisted state.
+      pendingWaveLabel: "wave-7",
+      pendingSegmentId: "seg-wedged",
+      pendingAssigned: 5000,
+      pendingBroadcastId: "bc-wedged",
+    });
+    const result = await t.mutation(
+      internal.broadcast.rampRunner.forceReleaseLease,
+      { reason: "cron action wedged 6h, no partial-failure recorded" },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.releasedRunId).toBe("run-wedged");
+
+    const row = await loadRow(t);
+    expect(row?.pendingRunId).toBeUndefined();
+    expect(row?.pendingRunStartedAt).toBeUndefined();
+    expect(row?.lastRunStatus).toBe("partial-failure");
+    expect(row?.lastRunError).toMatch(/forced-release/i);
+    // Pending progress markers preserved.
+    expect(row?.pendingWaveLabel).toBe("wave-7");
+    expect(row?.pendingSegmentId).toBe("seg-wedged");
+    expect(row?.pendingBroadcastId).toBe("bc-wedged");
+  });
+
+  test("noop when no lease is held", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    const result = await t.mutation(
+      internal.broadcast.rampRunner.forceReleaseLease,
+      { reason: "no-op test" },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.noop).toBe(true);
+  });
+
+  test("after force-release, a fresh claim can succeed", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      pendingRunId: "run-stuck",
+      pendingRunStartedAt: Date.now() - 60 * 60 * 1000,
+    });
+    await t.mutation(internal.broadcast.rampRunner.forceReleaseLease, {
+      reason: "stuck",
+    });
+    const claim = await t.mutation(
+      internal.broadcast.rampRunner._claimTierForRun,
+      { runId: "run-recovered", expectedCurrentTier: 0 },
+    );
+    expect(claim.ok).toBe(true);
   });
 });
 
@@ -218,19 +300,253 @@ describe("_recordRunOutcome — lease release on failure", () => {
     expect(row?.lastRunStatus).toBe("partial-failure");
   });
 
-  test("does NOT clear the lease when runId differs (avoids stomping another run's lease)", async () => {
+  test("HARD NO-OP when runId differs — does NOT write status/error/active either (P1#2)", async () => {
+    // P1#2 fix: a lost-lease run must NOT overwrite the winner's authoritative
+    // outcome state. Previously, lease-mismatch only suppressed the lease-clear
+    // but still wrote lastRunStatus / lastRunError / killGateTripped / active —
+    // which clobbered the operator's recovery decisions.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      pendingRunId: "run-OTHER",
+      pendingRunStartedAt: Date.now(),
+      lastRunStatus: "succeeded", // operator/winner-set
+      killGateTripped: false,
+      active: true,
+    });
+    const result = await t.mutation(
+      internal.broadcast.rampRunner._recordRunOutcome,
+      {
+        runId: "run-MINE",
+        status: "partial-failure",
+        error: "should not land",
+        killGate: true,
+        killGateReason: "should not land",
+        deactivate: true,
+      },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("lease-lost");
+
+    const row = await loadRow(t);
+    // Lease unchanged.
+    expect(row?.pendingRunId).toBe("run-OTHER");
+    // ALL outcome fields unchanged — no stomp.
+    expect(row?.lastRunStatus).toBe("succeeded");
+    expect(row?.lastRunError).toBeUndefined();
+    expect(row?.killGateTripped).toBe(false);
+    expect(row?.killGateReason).toBeUndefined();
+    expect(row?.active).toBe(true);
+  });
+
+  test("HARD NO-OP when lease is cleared (operator already took control)", async () => {
+    // The other lease-lost case: operator already called forceReleaseLease /
+    // recoverFromPartialFailure, clearing pendingRunId. The displaced run's
+    // catch block tries to write — must be no-op too.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      pendingRunId: undefined,
+      lastRunStatus: "partial-failure", // operator-set
+    });
+    const result = await t.mutation(
+      internal.broadcast.rampRunner._recordRunOutcome,
+      {
+        runId: "run-DISPLACED",
+        status: "succeeded",
+        error: "should not land",
+      },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("lease-lost");
+    const row = await loadRow(t);
+    expect(row?.lastRunStatus).toBe("partial-failure"); // operator's status preserved
+  });
+});
+
+// ----------------------------------------------------------------------------
+// _recordPendingExport / _recordPendingBroadcast — per-step persistence (P1#4)
+// ----------------------------------------------------------------------------
+
+describe("_recordPendingExport — persists progress + lease-validates", () => {
+  test("persists waveLabel/segmentId/assigned/exportAt when lease is owned", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      pendingRunId: "run-X",
+      pendingRunStartedAt: Date.now(),
+    });
+    const result = await t.mutation(
+      internal.broadcast.rampRunner._recordPendingExport,
+      {
+        runId: "run-X",
+        waveLabel: "wave-5",
+        segmentId: "seg-export",
+        assigned: 1500,
+      },
+    );
+    expect(result.ok).toBe(true);
+    const row = await loadRow(t);
+    expect(row?.pendingWaveLabel).toBe("wave-5");
+    expect(row?.pendingSegmentId).toBe("seg-export");
+    expect(row?.pendingAssigned).toBe(1500);
+    expect(row?.pendingExportAt).toBeTypeOf("number");
+  });
+
+  test("throws when lease has been force-released (P1#1+P1#4 interaction)", async () => {
+    // The runner's _recordPendingExport call protects against operator
+    // force-releasing the lease while assignAndExportWave was running.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, { pendingRunId: undefined }); // no lease
+    await expect(
+      t.mutation(internal.broadcast.rampRunner._recordPendingExport, {
+        runId: "run-DISPLACED",
+        waveLabel: "wave-5",
+        segmentId: "seg-export",
+        assigned: 1500,
+      }),
+    ).rejects.toThrow(/lease lost/i);
+  });
+
+  test("throws when lease is owned by a different run", async () => {
     const t = convexTest(schema, modules);
     await seedRampConfig(t, {
       pendingRunId: "run-OTHER",
       pendingRunStartedAt: Date.now(),
     });
-    await t.mutation(internal.broadcast.rampRunner._recordRunOutcome, {
-      runId: "run-MINE",
-      status: "partial-failure",
+    await expect(
+      t.mutation(internal.broadcast.rampRunner._recordPendingExport, {
+        runId: "run-MINE",
+        waveLabel: "wave-5",
+        segmentId: "seg-export",
+        assigned: 1500,
+      }),
+    ).rejects.toThrow(/lease lost/i);
+  });
+});
+
+describe("_recordPendingBroadcast — persists broadcastId + lease-validates", () => {
+  test("persists broadcastId/broadcastAt when lease is owned", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      pendingRunId: "run-Y",
+      pendingRunStartedAt: Date.now(),
+      pendingWaveLabel: "wave-5",
+      pendingSegmentId: "seg-export",
+      pendingAssigned: 1500,
+      pendingExportAt: Date.now() - 1000,
+    });
+    const result = await t.mutation(
+      internal.broadcast.rampRunner._recordPendingBroadcast,
+      { runId: "run-Y", broadcastId: "bc-created" },
+    );
+    expect(result.ok).toBe(true);
+    const row = await loadRow(t);
+    expect(row?.pendingBroadcastId).toBe("bc-created");
+    expect(row?.pendingBroadcastAt).toBeTypeOf("number");
+    // Earlier persisted state preserved.
+    expect(row?.pendingWaveLabel).toBe("wave-5");
+  });
+
+  test("throws when lease has been force-released", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, { pendingRunId: undefined });
+    await expect(
+      t.mutation(internal.broadcast.rampRunner._recordPendingBroadcast, {
+        runId: "run-DISPLACED",
+        broadcastId: "bc-created",
+      }),
+    ).rejects.toThrow(/lease lost/i);
+  });
+});
+
+describe("_recordWaveSent — clears all pending* progress markers (P1#4)", () => {
+  test("on success, every pending* field is cleared so the next run starts fresh", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      currentTier: 1,
+      pendingRunId: "run-Z",
+      pendingRunStartedAt: Date.now(),
+      pendingWaveLabel: "wave-5",
+      pendingSegmentId: "seg-test",
+      pendingAssigned: 1500,
+      pendingExportAt: Date.now() - 5000,
+      pendingBroadcastId: "bc-test",
+      pendingBroadcastAt: Date.now() - 1000,
+    });
+    await t.mutation(internal.broadcast.rampRunner._recordWaveSent, {
+      runId: "run-Z",
+      expectedCurrentTier: 1,
+      newTier: 2,
+      waveLabel: "wave-5",
+      broadcastId: "bc-test",
+      segmentId: "seg-test",
+      assigned: 1500,
+      sentAt: Date.now(),
     });
     const row = await loadRow(t);
-    // Lease stays with run-OTHER, even though we recorded an outcome.
-    expect(row?.pendingRunId).toBe("run-OTHER");
+    expect(row?.pendingWaveLabel).toBeUndefined();
+    expect(row?.pendingSegmentId).toBeUndefined();
+    expect(row?.pendingAssigned).toBeUndefined();
+    expect(row?.pendingExportAt).toBeUndefined();
+    expect(row?.pendingBroadcastId).toBeUndefined();
+    expect(row?.pendingBroadcastAt).toBeUndefined();
+    // And the lease is also cleared.
+    expect(row?.pendingRunId).toBeUndefined();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// clearPartialFailure — fail-closed unless operator confirms no export (P1#3)
+// ----------------------------------------------------------------------------
+
+describe("clearPartialFailure — confirmNoExport guard (P1#3)", () => {
+  test("REFUSES when any pending* progress marker is set — even with confirmNoExport=true", async () => {
+    // P1#3 fix: confirmNoExport is a literal-true gate, but the operator
+    // could still get it wrong. The persisted pending* markers are the
+    // authoritative signal that the export DID run. Refuse loudly.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      lastRunStatus: "partial-failure",
+      pendingSegmentId: "seg-stamped", // export ran
+    });
+    await expect(
+      t.mutation(internal.broadcast.rampRunner.clearPartialFailure, {
+        reason: "operator thinks no export happened",
+        confirmNoExport: true,
+      }),
+    ).rejects.toThrow(/refused: pending progress markers present/i);
+  });
+
+  test("clears when no pending* markers AND confirmNoExport=true (truly pre-export failure)", async () => {
+    // Genuine case: assignAndExportWave threw before any contact stamping or
+    // segment creation, so no pending* markers were persisted. Operator
+    // confirms zero stamps in audience tables, calls clearPartialFailure.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      lastRunStatus: "partial-failure",
+      pendingRunId: "run-Q",
+      pendingRunStartedAt: Date.now(),
+      // no pendingWaveLabel/SegmentId/BroadcastId
+    });
+    const result = await t.mutation(
+      internal.broadcast.rampRunner.clearPartialFailure,
+      {
+        reason: "assignAndExportWave threw on Resend timeout before stamping",
+        confirmNoExport: true,
+      },
+    );
+    expect(result.ok).toBe(true);
+    const row = await loadRow(t);
+    expect(row?.lastRunStatus).toMatch(/partial-failure-cleared/);
+    expect(row?.pendingRunId).toBeUndefined();
+  });
+
+  test("noop when status isn't partial-failure", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, { lastRunStatus: "succeeded" });
+    const result = await t.mutation(
+      internal.broadcast.rampRunner.clearPartialFailure,
+      { reason: "test", confirmNoExport: true },
+    );
+    expect(result.noop).toBe(true);
   });
 });
 
@@ -272,7 +588,7 @@ describe("recoverFromPartialFailure — exported-but-not-sent recovery", () => {
     expect(row?.pendingRunId).toBeUndefined();
   });
 
-  test("manual-finished: rejects when required fields are missing", async () => {
+  test("manual-finished: rejects when required fields are missing AND no persisted fallback", async () => {
     const t = convexTest(schema, modules);
     await seedRampConfig(t, { lastRunStatus: "partial-failure" });
     await expect(
@@ -281,12 +597,122 @@ describe("recoverFromPartialFailure — exported-but-not-sent recovery", () => {
         reason: "test",
         // missing broadcastId, segmentId, sentAt, assigned
       }),
-    ).rejects.toThrow(/broadcastId, segmentId, sentAt, assigned are all required/i);
+    ).rejects.toThrow(/missing required field/i);
   });
 
-  test("discard-and-rotate: bumps waveLabelOffset so next cron uses a FRESH label", async () => {
-    // P1 #2 fix: without this, next cron retries the SAME waveLabel and
+  test("manual-finished: AUTO-FILLS from persisted pending* state when operator omits args (P1#4)", async () => {
+    // P1#4 fix: when the action dies after _recordPendingExport /
+    // _recordPendingBroadcast but before _recordWaveSent (Convex action
+    // timeout), recovery doesn't require operator to dig broadcastId/segmentId
+    // out of the Resend dashboard. Persisted state is the source of truth.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      currentTier: 1,
+      lastRunStatus: "partial-failure",
+      pendingRunId: "run-died",
+      pendingRunStartedAt: Date.now(),
+      pendingWaveLabel: "wave-5",
+      pendingSegmentId: "seg-persisted",
+      pendingAssigned: 1500,
+      pendingExportAt: Date.now() - 60000,
+      pendingBroadcastId: "bc-persisted",
+      pendingBroadcastAt: Date.now() - 30000,
+    });
+    const result = await t.mutation(
+      internal.broadcast.rampRunner.recoverFromPartialFailure,
+      {
+        recovery: "manual-finished",
+        reason: "Action timed out; manual send completed via Resend dashboard",
+        sentAt: 1700000000000, // operator-only
+        // broadcastId/segmentId/assigned/waveLabel — all OMITTED, fall back to persisted
+      },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.advancedToTier).toBe(2);
+    expect(result.broadcastId).toBe("bc-persisted");
+    expect(result.segmentId).toBe("seg-persisted");
+    expect(result.assigned).toBe(1500);
+    expect(result.waveLabel).toBe("wave-5");
+    expect(result.usedPersistedFallback).toEqual({
+      broadcastId: true,
+      segmentId: true,
+      assigned: true,
+      waveLabel: true,
+    });
+
+    const row = await loadRow(t);
+    expect(row?.currentTier).toBe(2);
+    expect(row?.lastWaveBroadcastId).toBe("bc-persisted");
+    expect(row?.lastWaveSegmentId).toBe("seg-persisted");
+    expect(row?.lastWaveAssigned).toBe(1500);
+    expect(row?.lastWaveLabel).toBe("wave-5");
+    expect(row?.lastWaveSentAt).toBe(1700000000000);
+    // ALL pending* cleared.
+    expect(row?.pendingWaveLabel).toBeUndefined();
+    expect(row?.pendingSegmentId).toBeUndefined();
+    expect(row?.pendingAssigned).toBeUndefined();
+    expect(row?.pendingExportAt).toBeUndefined();
+    expect(row?.pendingBroadcastId).toBeUndefined();
+    expect(row?.pendingBroadcastAt).toBeUndefined();
+    expect(row?.pendingRunId).toBeUndefined();
+  });
+
+  test("manual-finished: operator override beats persisted fallback when both supplied", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      currentTier: 1,
+      lastRunStatus: "partial-failure",
+      pendingBroadcastId: "bc-persisted",
+      pendingSegmentId: "seg-persisted",
+      pendingAssigned: 1500,
+      pendingWaveLabel: "wave-5",
+    });
+    const result = await t.mutation(
+      internal.broadcast.rampRunner.recoverFromPartialFailure,
+      {
+        recovery: "manual-finished",
+        reason: "broadcast was re-created with a different id during manual recovery",
+        broadcastId: "bc-OVERRIDE",
+        segmentId: "seg-OVERRIDE",
+        assigned: 1234,
+        waveLabel: "wave-5-retry",
+        sentAt: 1700000000000,
+      },
+    );
+    expect(result.broadcastId).toBe("bc-OVERRIDE");
+    expect(result.segmentId).toBe("seg-OVERRIDE");
+    expect(result.assigned).toBe(1234);
+    expect(result.waveLabel).toBe("wave-5-retry");
+    expect(result.usedPersistedFallback?.broadcastId).toBe(false);
+    expect(result.usedPersistedFallback?.segmentId).toBe(false);
+    expect(result.usedPersistedFallback?.assigned).toBe(false);
+    expect(result.usedPersistedFallback?.waveLabel).toBe(false);
+  });
+
+  test("manual-finished: rejects when sentAt is omitted even with full persisted fallback", async () => {
+    // sentAt is operator-only — no progress marker captures send-completion time.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      lastRunStatus: "partial-failure",
+      pendingWaveLabel: "wave-5",
+      pendingSegmentId: "seg-persisted",
+      pendingAssigned: 1500,
+      pendingBroadcastId: "bc-persisted",
+    });
+    await expect(
+      t.mutation(internal.broadcast.rampRunner.recoverFromPartialFailure, {
+        recovery: "manual-finished",
+        reason: "test",
+        // sentAt omitted, all others fall back
+      }),
+    ).rejects.toThrow(/missing required field.*sentAt/i);
+  });
+
+  test("discard-and-rotate: bumps waveLabelOffset + clears ALL pending* state", async () => {
+    // Without offset bump, next cron retries the SAME waveLabel and
     // assignAndExportWave rejects because contacts are already stamped.
+    // P1#4: also verify pending* are cleared so they don't leak into a
+    // future recovery surface.
     const t = convexTest(schema, modules);
     await seedRampConfig(t, {
       currentTier: 1,
@@ -294,6 +720,10 @@ describe("recoverFromPartialFailure — exported-but-not-sent recovery", () => {
       lastRunStatus: "partial-failure",
       pendingRunId: "run-stuck",
       pendingRunStartedAt: Date.now(),
+      pendingWaveLabel: "wave-5",
+      pendingSegmentId: "seg-stamped",
+      pendingAssigned: 1500,
+      pendingBroadcastId: "bc-stamped",
     });
     const result = await t.mutation(
       internal.broadcast.rampRunner.recoverFromPartialFailure,
@@ -313,6 +743,11 @@ describe("recoverFromPartialFailure — exported-but-not-sent recovery", () => {
     expect(row?.currentTier).toBe(1);
     expect(row?.lastRunStatus).toMatch(/partial-failure-discarded-rotated/);
     expect(row?.pendingRunId).toBeUndefined();
+    // All pending* cleared.
+    expect(row?.pendingWaveLabel).toBeUndefined();
+    expect(row?.pendingSegmentId).toBeUndefined();
+    expect(row?.pendingAssigned).toBeUndefined();
+    expect(row?.pendingBroadcastId).toBeUndefined();
   });
 
   test("noop when status is not partial-failure", async () => {

--- a/convex/__tests__/rampRunner.test.ts
+++ b/convex/__tests__/rampRunner.test.ts
@@ -506,6 +506,40 @@ describe("_recordWaveSent — clears all pending* progress markers (P1#4)", () =
 // clearPartialFailure — fail-closed unless operator confirms no export (P1#3)
 // ----------------------------------------------------------------------------
 
+describe("runDailyRamp — underfilled branch routes through recoverable partial-failure (PR #3476 review round 4)", () => {
+  test("underfilled branch records lastRunStatus=partial-failure (NOT pool-drained), deactivates ramp", () => {
+    // Round 4 fix: contacts ARE stamped + in Resend segment by the time
+    // assignAndExportWave returns underfilled. The previous code recorded
+    // status="pool-drained" + deactivate + cleared lease — stranding the
+    // exported audience (no broadcast created/sent, contacts excluded from
+    // future picks). recoverFromPartialFailure couldn't run because status
+    // was "pool-drained" not "partial-failure". Route through
+    // partial-failure with persisted pending* markers so manual recovery
+    // is reachable.
+    //
+    // Source-grep contract: the underfilled branch must call _recordRunOutcome
+    // with status: "partial-failure" (not "pool-drained"), AND the error
+    // message must mention recoverFromPartialFailure for operator guidance.
+    const underfilledIdx = runnerSrc.indexOf("exportResult.underfilled");
+    expect(underfilledIdx).toBeGreaterThan(-1);
+    // Slice the source from the underfilled check forward through the next
+    // branch boundary (next `if (` or end-of-function); contract assertions
+    // below match against this slice.
+    const sliceEnd = runnerSrc.indexOf("// ──── Step 4", underfilledIdx);
+    expect(sliceEnd).toBeGreaterThan(underfilledIdx);
+    const underfilledBlock = runnerSrc.slice(underfilledIdx, sliceEnd);
+
+    // Status must be partial-failure (so recovery is reachable).
+    expect(underfilledBlock).toMatch(/status:\s*"partial-failure"/);
+    // Must NOT route through pool-drained status (that strands the audience).
+    expect(underfilledBlock).not.toMatch(/status:\s*"pool-drained"/);
+    // Must deactivate (curve is done).
+    expect(underfilledBlock).toMatch(/deactivate:\s*true/);
+    // Operator guidance must reference recoverFromPartialFailure.
+    expect(underfilledBlock).toMatch(/recoverFromPartialFailure/);
+  });
+});
+
 describe("runDailyRamp — call order: _recordPendingExport BEFORE failure branches (PR #3476 review round 3)", () => {
   test("_recordPendingExport is called immediately after assignAndExportWave returns, BEFORE checking failed/stampFailed/underfilled", () => {
     // Source-grep regression test. Catches the foot-gun caught in PR #3476

--- a/convex/__tests__/rampRunner.test.ts
+++ b/convex/__tests__/rampRunner.test.ts
@@ -20,12 +20,21 @@
  *      manually-completed broadcastId) or discard-and-rotate (bump
  *      waveLabelOffset so next cron uses a fresh label).
  */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { convexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
 import schema from "../schema";
 import { internal } from "../_generated/api";
 
 const modules = import.meta.glob("../**/*.ts");
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const runnerSrc = readFileSync(
+  resolve(__dirname, "..", "broadcast", "rampRunner.ts"),
+  "utf-8",
+);
 
 async function seedRampConfig(
   t: ReturnType<typeof convexTest>,
@@ -496,6 +505,43 @@ describe("_recordWaveSent — clears all pending* progress markers (P1#4)", () =
 // ----------------------------------------------------------------------------
 // clearPartialFailure — fail-closed unless operator confirms no export (P1#3)
 // ----------------------------------------------------------------------------
+
+describe("runDailyRamp — call order: _recordPendingExport BEFORE failure branches (PR #3476 review round 3)", () => {
+  test("_recordPendingExport is called immediately after assignAndExportWave returns, BEFORE checking failed/stampFailed/underfilled", () => {
+    // Source-grep regression test. Catches the foot-gun caught in PR #3476
+    // review round 3: if `_recordPendingExport` ran AFTER the
+    // (failed > 0 || stampFailed > 0) branch or the underfilled branch,
+    // those partial-failure paths would leave the row WITHOUT
+    // pendingWaveLabel/SegmentId/Assigned set — and clearPartialFailure
+    // ({confirmNoExport: true}) would then not throw, masking stamped
+    // contacts and the already-created Resend segment.
+    //
+    // Invariant: in runDailyRamp, the _recordPendingExport call must appear
+    // BEFORE any source line containing `exportResult.failed`, `exportResult.stampFailed`,
+    // or `exportResult.underfilled`.
+    const recordPendingIdx = runnerSrc.indexOf("_recordPendingExport,");
+    const failedCheckIdx = runnerSrc.indexOf("exportResult.failed > 0");
+    const stampFailedCheckIdx = runnerSrc.indexOf("exportResult.stampFailed > 0");
+    const underfilledCheckIdx = runnerSrc.indexOf("exportResult.underfilled");
+
+    expect(recordPendingIdx).toBeGreaterThan(-1);
+    expect(failedCheckIdx).toBeGreaterThan(-1);
+    expect(stampFailedCheckIdx).toBeGreaterThan(-1);
+    expect(underfilledCheckIdx).toBeGreaterThan(-1);
+
+    // The first occurrence of `_recordPendingExport,` (the runner call site,
+    // not the export declaration) inside runDailyRamp must precede every
+    // failure-counter check.
+    const runnerCallSiteIdx = runnerSrc.indexOf(
+      "_recordPendingExport,",
+      runnerSrc.indexOf("runDailyRamp"),
+    );
+    expect(runnerCallSiteIdx).toBeGreaterThan(-1);
+    expect(runnerCallSiteIdx).toBeLessThan(failedCheckIdx);
+    expect(runnerCallSiteIdx).toBeLessThan(stampFailedCheckIdx);
+    expect(runnerCallSiteIdx).toBeLessThan(underfilledCheckIdx);
+  });
+});
 
 describe("clearPartialFailure — confirmNoExport guard (P1#3)", () => {
   test("REFUSES when any pending* progress marker is set — even with confirmNoExport=true", async () => {

--- a/convex/broadcast/rampRunner.ts
+++ b/convex/broadcast/rampRunner.ts
@@ -75,6 +75,16 @@ const UNDERFILL_RATIO = 0.5;
 
 const RAMP_KEY = "current";
 
+// Stale lease cutoff: if `pendingRunStartedAt` is older than this, assume the
+// previous runner crashed mid-flight and allow override. The lease itself is
+// cleared by every terminal outcome path (`_recordWaveSent`,
+// `_recordRunOutcome`, `recoverFromPartialFailure`), so we only hit this on a
+// genuine crash (e.g. Convex action timeout that kills the process between
+// claim and outcome record). 30 minutes is generous — the longest legitimate
+// runs (large rampCurve count) finish in seconds; 30min covers any retry
+// pattern Convex's runtime would use.
+const STALE_LEASE_MS = 30 * 60 * 1000;
+
 /**
  * Doc type derived from the schema. Convex generates this from
  * `convex/schema.ts:broadcastRampConfig` so it stays in sync with
@@ -205,20 +215,23 @@ export const clearKillGate = internalMutation({
 });
 
 /**
- * Clear a `partial-failure` block recorded by `runDailyRamp`. The runner
- * refuses to advance while `lastRunStatus === "partial-failure"` (so a
- * half-pushed export can't slip into a tier advance), and `clearKillGate`
- * does NOT clear this state — the kill-gate latch and the partial-failure
- * block are independent recovery paths with different operator
- * investigation requirements (kill-gate = email-reputation issue,
- * partial-failure = mechanical export/send failure). Without this
- * mutation, a partial-failure would block the cron forever short of
- * `abortRamp` or hand-patching the DB.
+ * Clear a `partial-failure` block recorded by `runDailyRamp`.
  *
- * Operator should investigate per the recorded `lastRunError` (e.g.
- * Resend logs for `failed > 0`, Convex logs for `stampFailed > 0`,
- * dashboard for `createProLaunchBroadcast` / `sendProLaunchBroadcast`
- * throws) BEFORE clearing.
+ * Naive clear is RISKY when the export already succeeded. Concrete failure
+ * shape: `assignAndExportWave` stamped contacts with `waveLabel` AND created
+ * the Resend segment, then `createProLaunchBroadcast` or `sendProLaunchBroadcast`
+ * threw. A bare clear lets the next cron retry with the SAME `waveLabel` →
+ * `assignAndExportWave` rejects because contacts are already stamped. The cron
+ * then thrashes on the same partial-failure indefinitely.
+ *
+ * Use `recoverFromPartialFailure` (below) instead — it requires the operator
+ * to declare what actually happened (manual send completed vs. discard-and-rotate)
+ * so the next cron lands cleanly.
+ *
+ * Kept as a "soft clear" for failures that DON'T involve a successful export
+ * (e.g. `assignAndExportWave` itself threw before any contact was stamped).
+ * Operator investigates and confirms zero stamps via the audience tables before
+ * calling this; mismatch is the operator's responsibility.
  */
 export const clearPartialFailure = internalMutation({
   args: { reason: v.string() },
@@ -231,8 +244,114 @@ export const clearPartialFailure = internalMutation({
     await ctx.db.patch(row._id, {
       lastRunStatus: `partial-failure-cleared: ${reason.slice(0, 200)}`,
       lastRunError: undefined,
+      pendingRunId: undefined,
+      pendingRunStartedAt: undefined,
     });
     return { ok: true };
+  },
+});
+
+/**
+ * Structured recovery for `lastRunStatus === "partial-failure"` that ALSO
+ * occurred AFTER `assignAndExportWave` succeeded. Two recovery modes:
+ *
+ *   manual-finished:
+ *     The operator manually completed the wave (e.g. `createProLaunchBroadcast`
+ *     ran fine in the Resend dashboard, send was triggered there or via
+ *     `npx convex run broadcast/sendBroadcast:sendProLaunchBroadcast`). Pass
+ *     the resulting broadcastId/segmentId/sentAt/assigned. Tier advances as
+ *     if the cron had succeeded; next kill-gate check uses the new
+ *     `lastWaveBroadcastId`.
+ *
+ *   discard-and-rotate:
+ *     The wave is written off (e.g. send is genuinely lost, can't or won't
+ *     retry manually). Bumps `waveLabelOffset` by 1 so the next cron uses a
+ *     FRESH `waveLabel` — the prior label's stamps remain in the audience
+ *     table and exclude those contacts from future picks (lost to this
+ *     campaign; operator can manually email them later if desired). Tier is
+ *     NOT advanced (no successful send to record).
+ *
+ * Both modes clear the lease and the partial-failure status.
+ */
+export const recoverFromPartialFailure = internalMutation({
+  args: {
+    recovery: v.union(
+      v.literal("manual-finished"),
+      v.literal("discard-and-rotate"),
+    ),
+    reason: v.string(),
+    // Required for recovery==='manual-finished' — fields that mirror the
+    // arguments _recordWaveSent would have used. Validated below.
+    broadcastId: v.optional(v.string()),
+    segmentId: v.optional(v.string()),
+    sentAt: v.optional(v.number()),
+    assigned: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const row = await loadConfig(ctx);
+    if (!row) throw new Error("[recoverFromPartialFailure] no ramp configured");
+    if (row.lastRunStatus !== "partial-failure") {
+      return {
+        ok: true as const,
+        noop: true as const,
+        currentStatus: row.lastRunStatus,
+      };
+    }
+
+    if (args.recovery === "manual-finished") {
+      if (
+        !args.broadcastId ||
+        !args.segmentId ||
+        args.sentAt === undefined ||
+        args.assigned === undefined
+      ) {
+        throw new Error(
+          "[recoverFromPartialFailure:manual-finished] broadcastId, segmentId, sentAt, assigned are all required",
+        );
+      }
+      const nextTier = row.currentTier + 1;
+      if (nextTier >= row.rampCurve.length) {
+        throw new Error(
+          `[recoverFromPartialFailure:manual-finished] currentTier=${row.currentTier} would advance past rampCurve.length=${row.rampCurve.length}. Curve is complete; nothing to recover.`,
+        );
+      }
+      const waveLabel = `${row.waveLabelPrefix}-${nextTier + row.waveLabelOffset}`;
+      await ctx.db.patch(row._id, {
+        currentTier: nextTier,
+        lastWaveLabel: waveLabel,
+        lastWaveBroadcastId: args.broadcastId,
+        lastWaveSegmentId: args.segmentId,
+        lastWaveAssigned: args.assigned,
+        lastWaveSentAt: args.sentAt,
+        lastRunStatus: `succeeded-via-manual-recovery: ${args.reason.slice(0, 200)}`,
+        lastRunAt: Date.now(),
+        lastRunError: undefined,
+        pendingRunId: undefined,
+        pendingRunStartedAt: undefined,
+      });
+      return {
+        ok: true as const,
+        recovery: "manual-finished" as const,
+        advancedToTier: nextTier,
+        waveLabel,
+      };
+    }
+
+    // discard-and-rotate
+    await ctx.db.patch(row._id, {
+      waveLabelOffset: row.waveLabelOffset + 1,
+      lastRunStatus: `partial-failure-discarded-rotated: ${args.reason.slice(0, 200)}`,
+      lastRunAt: Date.now(),
+      lastRunError: undefined,
+      pendingRunId: undefined,
+      pendingRunStartedAt: undefined,
+    });
+    return {
+      ok: true as const,
+      recovery: "discard-and-rotate" as const,
+      newWaveLabelOffset: row.waveLabelOffset + 1,
+      nextWaveLabel: `${row.waveLabelPrefix}-${row.currentTier + 1 + row.waveLabelOffset + 1}`,
+    };
   },
 });
 
@@ -274,6 +393,13 @@ export const getRampStatus = internalQuery({
       lastRunStatus: row.lastRunStatus,
       lastRunAt: row.lastRunAt,
       lastRunError: row.lastRunError,
+      pendingRunId: row.pendingRunId,
+      pendingRunStartedAt: row.pendingRunStartedAt,
+      // Operator-facing flag: is the lease currently held + fresh?
+      leaseHeld:
+        row.pendingRunId !== undefined &&
+        row.pendingRunStartedAt !== undefined &&
+        Date.now() - row.pendingRunStartedAt < STALE_LEASE_MS,
     };
   },
 });
@@ -290,14 +416,78 @@ async function loadConfig(
 }
 
 /**
- * Internal mutation that the action calls to atomically advance the
- * tier + record a successful wave-send. We use a mutation here (not a
- * patch from the action) so the read-modify-write is transactional —
- * two concurrent cron runs (which shouldn't happen, but just in case)
- * can't both advance the same tier.
+ * Atomically claim the lease before external side effects.
+ *
+ * Two concurrent cron runs (or a cron + a manually-triggered run, or a Convex
+ * runtime retry firing the action again) would both read the same `currentTier`,
+ * both proceed through `assignAndExportWave` + `createProLaunchBroadcast` +
+ * `sendProLaunchBroadcast` (DUPLICATE EMAILS), and only collide at
+ * `_recordWaveSent`. The tier check there is post-hoc; the emails have already
+ * gone out. This claim is the pre-side-effect lock.
+ *
+ * Returns `{ ok: true }` on success or `{ ok: false, reason }` for the runner
+ * to log and exit cleanly without side effects.
+ *
+ * Idempotency / staleness: a lease older than `STALE_LEASE_MS` is treated as
+ * abandoned (previous runner crashed) and overridable; a fresh lease blocks
+ * further claims. The new lease records `pendingRunId` and
+ * `pendingRunStartedAt` so the matching `_recordWaveSent` /
+ * `_recordRunOutcome` calls can validate they hold the lease they think they do.
+ */
+export const _claimTierForRun = internalMutation({
+  args: {
+    runId: v.string(),
+    expectedCurrentTier: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const row = await loadConfig(ctx);
+    if (!row) {
+      return { ok: false as const, reason: "no-config" as const };
+    }
+    if (row.currentTier !== args.expectedCurrentTier) {
+      return {
+        ok: false as const,
+        reason: "tier-moved" as const,
+        actualTier: row.currentTier,
+      };
+    }
+    const now = Date.now();
+    if (
+      row.pendingRunId &&
+      row.pendingRunStartedAt &&
+      now - row.pendingRunStartedAt < STALE_LEASE_MS
+    ) {
+      return {
+        ok: false as const,
+        reason: "lease-held" as const,
+        heldBy: row.pendingRunId,
+        ageMs: now - row.pendingRunStartedAt,
+      };
+    }
+    if (row.pendingRunId && row.pendingRunStartedAt) {
+      console.warn(
+        `[_claimTierForRun] overriding stale lease ${row.pendingRunId} ` +
+          `(age ${Math.round((now - row.pendingRunStartedAt) / 1000)}s > ${STALE_LEASE_MS / 1000}s) ` +
+          `— previous runner likely crashed mid-flight without releasing.`,
+      );
+    }
+    await ctx.db.patch(row._id, {
+      pendingRunId: args.runId,
+      pendingRunStartedAt: now,
+    });
+    return { ok: true as const };
+  },
+});
+
+/**
+ * Internal mutation that the action calls to atomically advance the tier +
+ * record a successful wave-send. Validates that the lease still belongs to
+ * this runId — protects against the (extremely unlikely) case where the
+ * lease was overridden as stale by another run while we were still working.
  */
 export const _recordWaveSent = internalMutation({
   args: {
+    runId: v.string(),
     expectedCurrentTier: v.number(),
     newTier: v.number(),
     waveLabel: v.string(),
@@ -314,6 +504,18 @@ export const _recordWaveSent = internalMutation({
         `[_recordWaveSent] tier moved underneath us: expected ${args.expectedCurrentTier}, found ${row.currentTier}. Refusing to overwrite.`,
       );
     }
+    if (row.pendingRunId !== args.runId) {
+      // The lease changed under us. Either:
+      //   (a) our lease was overridden as stale by another run while we were
+      //       still in flight, OR
+      //   (b) the lease was cleared by an operator action (recoverFromPartialFailure).
+      // Either way, we must NOT advance the tier — another run may be in flight
+      // and would conflict, or the operator has taken control. Fall through to
+      // an error so Convex auto-Sentry captures and ops can investigate.
+      throw new Error(
+        `[_recordWaveSent] lease lost: expected runId=${args.runId}, found ${row.pendingRunId ?? "<cleared>"}. Refusing to advance tier — investigate what cleared the lease.`,
+      );
+    }
     await ctx.db.patch(row._id, {
       currentTier: args.newTier,
       lastWaveLabel: args.waveLabel,
@@ -324,18 +526,25 @@ export const _recordWaveSent = internalMutation({
       lastRunStatus: "succeeded",
       lastRunAt: Date.now(),
       lastRunError: undefined,
+      pendingRunId: undefined,
+      pendingRunStartedAt: undefined,
     });
     return { ok: true };
   },
 });
 
 /**
- * Mutation that records a non-success outcome of a cron run without
- * advancing the tier. Used for kill-gate trips, drained pool, partial
- * failures, and "wait for prior wave to settle" deferrals.
+ * Mutation that records a non-success outcome of a cron run without advancing
+ * the tier. Used for kill-gate trips, drained pool, partial failures, and
+ * "wait for prior wave to settle" deferrals.
+ *
+ * Always clears the lease (if held by this runId). The lease must not outlive
+ * the run, otherwise the next cron run sees `lease-held` and skips, and
+ * eventually expires via STALE_LEASE_MS — bigger lockout window than necessary.
  */
 export const _recordRunOutcome = internalMutation({
   args: {
+    runId: v.optional(v.string()), // optional for backwards-compat with pre-claim deferrals
     status: v.string(),
     error: v.optional(v.string()),
     killGate: v.optional(v.boolean()),
@@ -356,6 +565,12 @@ export const _recordRunOutcome = internalMutation({
     }
     if (args.deactivate) {
       patch.active = false;
+    }
+    // Clear the lease if it's ours. Avoids stomping a lease that some other
+    // run claimed after we lost ours (e.g. our lease was overridden as stale).
+    if (args.runId && row.pendingRunId === args.runId) {
+      patch.pendingRunId = undefined;
+      patch.pendingRunStartedAt = undefined;
     }
     await ctx.db.patch(row._id, patch);
   },
@@ -496,7 +711,34 @@ export const runDailyRamp = internalAction({
     }
     const waveLabel = `${row.waveLabelPrefix}-${nextTier + row.waveLabelOffset}`;
 
-    // ──── Step 3: pick + stamp + create segment + push ────
+    // ──── Step 3a: ATOMICALLY CLAIM THE LEASE before any external side effect ────
+    // Two concurrent runs (cron + manual trigger, Convex retry, misconfigured
+    // schedule) both pass kill-gate / tier-bounds checks above before anything
+    // mutates state. Without this claim, both would proceed through
+    // assignAndExportWave + createProLaunchBroadcast + sendProLaunchBroadcast,
+    // duplicate-emailing every recipient, and only collide at _recordWaveSent.
+    // Claim the lease BEFORE any external side effect so the loser exits clean.
+    const runId =
+      typeof crypto !== "undefined" && crypto.randomUUID
+        ? crypto.randomUUID()
+        : `run-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const claim: { ok: boolean; reason?: string; actualTier?: number; heldBy?: string; ageMs?: number } =
+      await ctx.runMutation(internal.broadcast.rampRunner._claimTierForRun, {
+        runId,
+        expectedCurrentTier: row.currentTier,
+      });
+    if (!claim.ok) {
+      console.log(
+        `[runDailyRamp] claim rejected (${claim.reason}${
+          claim.heldBy ? `, heldBy=${claim.heldBy}, ageMs=${claim.ageMs}` : ""
+        }${claim.actualTier !== undefined ? `, actualTier=${claim.actualTier}` : ""}) — skip`,
+      );
+      // Don't record an outcome here — the other holder will record theirs;
+      // recording ours would stomp their lease/status. Just exit.
+      return { status: `claim-rejected-${claim.reason}` };
+    }
+
+    // ──── Step 3b: pick + stamp + create segment + push ────
     let exportResult: WaveExportStats;
     try {
       exportResult = await ctx.runAction(
@@ -507,7 +749,7 @@ export const runDailyRamp = internalAction({
       const msg = err instanceof Error ? err.message : String(err);
       await ctx.runMutation(
         internal.broadcast.rampRunner._recordRunOutcome,
-        { status: "partial-failure", error: msg },
+        { runId, status: "partial-failure", error: msg },
       );
       throw err; // bubble so Convex auto-Sentry captures
     }
@@ -522,11 +764,11 @@ export const runDailyRamp = internalAction({
     // Operator clears via the same `lastRunStatus === partial-failure`
     // gate that handles other partial-failure paths.
     if (exportResult.failed > 0 || exportResult.stampFailed > 0) {
-      const reason = `assignAndExportWave partial: failed=${exportResult.failed}, stampFailed=${exportResult.stampFailed} (segment=${exportResult.segmentId}, assigned=${exportResult.assigned}, requested=${count}). Investigate Resend logs + Convex stamp errors before resuming; stampFailed contacts are in the segment but unstamped (duplicate-email risk).`;
+      const reason = `assignAndExportWave partial: failed=${exportResult.failed}, stampFailed=${exportResult.stampFailed} (segment=${exportResult.segmentId}, assigned=${exportResult.assigned}, requested=${count}, waveLabel=${waveLabel}). Investigate Resend logs + Convex stamp errors before resuming; stampFailed contacts are in the segment but unstamped (duplicate-email risk).`;
       console.error(`[runDailyRamp] ${reason}`);
       await ctx.runMutation(
         internal.broadcast.rampRunner._recordRunOutcome,
-        { status: "partial-failure", error: reason },
+        { runId, status: "partial-failure", error: reason },
       );
       return { status: "partial-failure", detail: reason };
     }
@@ -539,7 +781,7 @@ export const runDailyRamp = internalAction({
       console.log(`[runDailyRamp] ${reason} — deactivating`);
       await ctx.runMutation(
         internal.broadcast.rampRunner._recordRunOutcome,
-        { status: "pool-drained", deactivate: true, error: reason },
+        { runId, status: "pool-drained", deactivate: true, error: reason },
       );
       return { status: "pool-drained", detail: reason };
     }
@@ -559,8 +801,9 @@ export const runDailyRamp = internalAction({
       await ctx.runMutation(
         internal.broadcast.rampRunner._recordRunOutcome,
         {
+          runId,
           status: "partial-failure",
-          error: `createProLaunchBroadcast: ${msg} (segmentId=${exportResult.segmentId}, ${exportResult.assigned} contacts stamped + in segment)`,
+          error: `createProLaunchBroadcast: ${msg} (waveLabel=${waveLabel}, segmentId=${exportResult.segmentId}, ${exportResult.assigned} contacts stamped + in segment). Recovery: see recoverFromPartialFailure(${JSON.stringify({ recovery: "manual-finished" })}) or recoverFromPartialFailure(${JSON.stringify({ recovery: "discard-and-rotate" })}).`,
         },
       );
       throw err;
@@ -576,8 +819,9 @@ export const runDailyRamp = internalAction({
       await ctx.runMutation(
         internal.broadcast.rampRunner._recordRunOutcome,
         {
+          runId,
           status: "partial-failure",
-          error: `sendProLaunchBroadcast: ${msg} (broadcastId=${broadcastId} — preview in Resend dashboard and fire manually if appropriate)`,
+          error: `sendProLaunchBroadcast: ${msg} (waveLabel=${waveLabel}, segmentId=${exportResult.segmentId}, broadcastId=${broadcastId}, assigned=${exportResult.assigned}). Recovery: preview in Resend dashboard; if it sent fine, recoverFromPartialFailure({recovery:'manual-finished', broadcastId, ...}). If it didn't, send manually then call manual-finished, OR call recoverFromPartialFailure({recovery:'discard-and-rotate'}) to bump waveLabelOffset and let next cron retry with a fresh label.`,
         },
       );
       throw err;
@@ -585,6 +829,7 @@ export const runDailyRamp = internalAction({
 
     // ──── Step 5: record success ────
     await ctx.runMutation(internal.broadcast.rampRunner._recordWaveSent, {
+      runId,
       expectedCurrentTier: row.currentTier,
       newTier: nextTier,
       waveLabel,

--- a/convex/broadcast/rampRunner.ts
+++ b/convex/broadcast/rampRunner.ts
@@ -34,7 +34,32 @@
  *   npx convex run broadcast/rampRunner:pauseRamp '{}'
  *   npx convex run broadcast/rampRunner:resumeRamp '{}'
  *   npx convex run broadcast/rampRunner:clearKillGate '{"reason":"investigated, false alarm"}'
- *   npx convex run broadcast/rampRunner:clearPartialFailure '{"reason":"3 stamp failures retried manually"}'
+ *
+ *   # Recovery for `lastRunStatus === "partial-failure"`. PREFER THIS over
+ *   # clearPartialFailure when ANY external step ran. Reads persisted pending*
+ *   # fields when operator omits broadcastId/segmentId/assigned/waveLabel.
+ *   npx convex run broadcast/rampRunner:recoverFromPartialFailure '{
+ *     "recovery":"manual-finished",
+ *     "reason":"sent wave-N manually after createProLaunchBroadcast threw",
+ *     "sentAt": 1700000000000
+ *     // broadcastId/segmentId/assigned/waveLabel auto-fill from pending* if absent
+ *   }'
+ *   # OR for unrecoverable waves (audience stamped but send is genuinely lost):
+ *   npx convex run broadcast/rampRunner:recoverFromPartialFailure '{
+ *     "recovery":"discard-and-rotate",
+ *     "reason":"unrecoverable; rotating waveLabelOffset"
+ *   }'
+ *
+ *   # Last-resort soft-clear (NO export happened — assignAndExportWave threw
+ *   # before any contact stamping). Refuses without confirmNoExport=true.
+ *   npx convex run broadcast/rampRunner:clearPartialFailure '{"reason":"export threw before any stamping","confirmNoExport":true}'
+ *
+ *   # Last-resort lease release for a stuck cron run (action wedged for hours
+ *   # with no partial-failure recorded — process likely died silently). Sets
+ *   # lastRunStatus=partial-failure so the operator can then call
+ *   # recoverFromPartialFailure to either advance or rotate.
+ *   npx convex run broadcast/rampRunner:forceReleaseLease '{"reason":"cron action wedged 6h, no partial-failure recorded"}'
+ *
  *   npx convex run broadcast/rampRunner:getRampStatus '{}'
  *   npx convex run broadcast/rampRunner:abortRamp '{}'  # full stop, sets active=false
  *
@@ -75,15 +100,15 @@ const UNDERFILL_RATIO = 0.5;
 
 const RAMP_KEY = "current";
 
-// Stale lease cutoff: if `pendingRunStartedAt` is older than this, assume the
-// previous runner crashed mid-flight and allow override. The lease itself is
-// cleared by every terminal outcome path (`_recordWaveSent`,
-// `_recordRunOutcome`, `recoverFromPartialFailure`), so we only hit this on a
-// genuine crash (e.g. Convex action timeout that kills the process between
-// claim and outcome record). 30 minutes is generous — the longest legitimate
-// runs (large rampCurve count) finish in seconds; 30min covers any retry
-// pattern Convex's runtime would use.
-const STALE_LEASE_MS = 30 * 60 * 1000;
+// Lease "age warning" cutoff used only for telemetry on getRampStatus.
+// There is NO automatic override — a held lease blocks all further claims
+// until it is cleared by the owning runId (terminal outcome path) or by
+// the operator calling `forceReleaseLease`. Reasoning: side effects can
+// legitimately exceed any wall-clock cutoff (large rampCurve count,
+// upstream Resend slowness), and an automatic override has the same
+// failure mode the lease exists to prevent — duplicate sends. The
+// operator-only release path forces a human decision before unblocking.
+const LEASE_AGE_WARN_MS = 30 * 60 * 1000;
 
 /**
  * Doc type derived from the schema. Convex generates this from
@@ -215,31 +240,60 @@ export const clearKillGate = internalMutation({
 });
 
 /**
- * Clear a `partial-failure` block recorded by `runDailyRamp`.
+ * Last-resort soft-clear of a `partial-failure` status. STRONGLY DISPREFERRED;
+ * use `recoverFromPartialFailure` instead in nearly every case.
  *
  * Naive clear is RISKY when the export already succeeded. Concrete failure
  * shape: `assignAndExportWave` stamped contacts with `waveLabel` AND created
  * the Resend segment, then `createProLaunchBroadcast` or `sendProLaunchBroadcast`
  * threw. A bare clear lets the next cron retry with the SAME `waveLabel` →
  * `assignAndExportWave` rejects because contacts are already stamped. The cron
- * then thrashes on the same partial-failure indefinitely.
+ * then thrashes on the same partial-failure indefinitely. Worse: if the
+ * broadcast was actually sent (just our recording failed), a clear-then-retry
+ * silently double-sends.
  *
- * Use `recoverFromPartialFailure` (below) instead — it requires the operator
- * to declare what actually happened (manual send completed vs. discard-and-rotate)
- * so the next cron lands cleanly.
+ * This mutation now REQUIRES `confirmNoExport: true` AND refuses to run if any
+ * `pending*` progress markers are set (which the runner persists as soon as
+ * any external step succeeds). Use this ONLY when `assignAndExportWave` itself
+ * threw BEFORE stamping any contact, e.g. an upstream Resend timeout that
+ * prevented segment creation. The operator MUST verify zero stamps via the
+ * audience tables AND verify no broadcast in the Resend dashboard before
+ * calling.
  *
- * Kept as a "soft clear" for failures that DON'T involve a successful export
- * (e.g. `assignAndExportWave` itself threw before any contact was stamped).
- * Operator investigates and confirms zero stamps via the audience tables before
- * calling this; mismatch is the operator's responsibility.
+ * For ANY case where the export ran (segment created, contacts stamped,
+ * broadcast created, or send fired), use `recoverFromPartialFailure` —
+ * `manual-finished` if the wave actually went out, `discard-and-rotate` if
+ * not.
  */
 export const clearPartialFailure = internalMutation({
-  args: { reason: v.string() },
+  args: {
+    reason: v.string(),
+    // Literal-true forces the operator to actively assert "I have verified no
+    // export happened." A future caller can't accidentally pass `false` to
+    // bypass this.
+    confirmNoExport: v.literal(true),
+  },
   handler: async (ctx, { reason }) => {
     const row = await loadConfig(ctx);
     if (!row) throw new Error("[clearPartialFailure] no ramp configured");
     if (row.lastRunStatus !== "partial-failure") {
-      return { ok: true, noop: true, currentStatus: row.lastRunStatus };
+      return {
+        ok: true as const,
+        noop: true as const,
+        currentStatus: row.lastRunStatus,
+      };
+    }
+    // Fail-closed: if any pending-progress marker exists, the export DID make
+    // progress past `assignAndExportWave` — clearing here would mask a stamped
+    // / sent wave. Force the operator to use recoverFromPartialFailure.
+    if (
+      row.pendingWaveLabel ||
+      row.pendingSegmentId ||
+      row.pendingBroadcastId
+    ) {
+      throw new Error(
+        `[clearPartialFailure] refused: pending progress markers present (waveLabel=${row.pendingWaveLabel ?? "-"}, segmentId=${row.pendingSegmentId ?? "-"}, broadcastId=${row.pendingBroadcastId ?? "-"}). The export DID run; clearing here would mask stamped contacts. Use recoverFromPartialFailure instead.`,
+      );
     }
     await ctx.db.patch(row._id, {
       lastRunStatus: `partial-failure-cleared: ${reason.slice(0, 200)}`,
@@ -247,31 +301,35 @@ export const clearPartialFailure = internalMutation({
       pendingRunId: undefined,
       pendingRunStartedAt: undefined,
     });
-    return { ok: true };
+    return { ok: true as const };
   },
 });
 
 /**
  * Structured recovery for `lastRunStatus === "partial-failure"` that ALSO
- * occurred AFTER `assignAndExportWave` succeeded. Two recovery modes:
+ * occurred AFTER `assignAndExportWave` succeeded (or after a forced lease
+ * release on a wedged run). Two recovery modes:
  *
  *   manual-finished:
  *     The operator manually completed the wave (e.g. `createProLaunchBroadcast`
  *     ran fine in the Resend dashboard, send was triggered there or via
- *     `npx convex run broadcast/sendBroadcast:sendProLaunchBroadcast`). Pass
- *     the resulting broadcastId/segmentId/sentAt/assigned. Tier advances as
- *     if the cron had succeeded; next kill-gate check uses the new
- *     `lastWaveBroadcastId`.
+ *     `npx convex run broadcast/sendBroadcast:sendProLaunchBroadcast`).
+ *     `broadcastId` / `segmentId` / `assigned` / `waveLabel` auto-fill from
+ *     the persisted `pending*` markers when the operator omits them; pass
+ *     them explicitly only when overriding (e.g. broadcast ID changed during
+ *     manual completion). `sentAt` is always required from the operator —
+ *     when the manual send finished is information no in-flight progress
+ *     marker captures.
  *
  *   discard-and-rotate:
- *     The wave is written off (e.g. send is genuinely lost, can't or won't
- *     retry manually). Bumps `waveLabelOffset` by 1 so the next cron uses a
- *     FRESH `waveLabel` — the prior label's stamps remain in the audience
- *     table and exclude those contacts from future picks (lost to this
- *     campaign; operator can manually email them later if desired). Tier is
- *     NOT advanced (no successful send to record).
+ *     The wave is written off. Bumps `waveLabelOffset` by 1 so the next cron
+ *     uses a FRESH `waveLabel` — the prior label's stamps remain in the
+ *     audience table and exclude those contacts from future picks (lost to
+ *     this campaign; operator can manually email them later if desired).
+ *     Tier is NOT advanced (no successful send to record).
  *
- * Both modes clear the lease and the partial-failure status.
+ * Both modes clear the lease, the partial-failure status, AND all pending*
+ * progress markers.
  */
 export const recoverFromPartialFailure = internalMutation({
   args: {
@@ -280,12 +338,14 @@ export const recoverFromPartialFailure = internalMutation({
       v.literal("discard-and-rotate"),
     ),
     reason: v.string(),
-    // Required for recovery==='manual-finished' — fields that mirror the
-    // arguments _recordWaveSent would have used. Validated below.
+    // For recovery==='manual-finished'. Fall back to persisted pending*
+    // markers when omitted; sentAt is ALWAYS operator-supplied (no progress
+    // marker captures send-completion time).
     broadcastId: v.optional(v.string()),
     segmentId: v.optional(v.string()),
     sentAt: v.optional(v.number()),
     assigned: v.optional(v.number()),
+    waveLabel: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const row = await loadConfig(ctx);
@@ -298,42 +358,75 @@ export const recoverFromPartialFailure = internalMutation({
       };
     }
 
+    const clearPending = {
+      pendingRunId: undefined,
+      pendingRunStartedAt: undefined,
+      pendingWaveLabel: undefined,
+      pendingSegmentId: undefined,
+      pendingAssigned: undefined,
+      pendingExportAt: undefined,
+      pendingBroadcastId: undefined,
+      pendingBroadcastAt: undefined,
+    } as const;
+
     if (args.recovery === "manual-finished") {
-      if (
-        !args.broadcastId ||
-        !args.segmentId ||
-        args.sentAt === undefined ||
-        args.assigned === undefined
-      ) {
-        throw new Error(
-          "[recoverFromPartialFailure:manual-finished] broadcastId, segmentId, sentAt, assigned are all required",
-        );
-      }
+      // Resolve each field: operator-supplied wins, persisted pending* is the
+      // fallback. sentAt is operator-only (no fallback).
+      const broadcastId = args.broadcastId ?? row.pendingBroadcastId;
+      const segmentId = args.segmentId ?? row.pendingSegmentId;
+      const assigned = args.assigned ?? row.pendingAssigned;
       const nextTier = row.currentTier + 1;
       if (nextTier >= row.rampCurve.length) {
         throw new Error(
           `[recoverFromPartialFailure:manual-finished] currentTier=${row.currentTier} would advance past rampCurve.length=${row.rampCurve.length}. Curve is complete; nothing to recover.`,
         );
       }
-      const waveLabel = `${row.waveLabelPrefix}-${nextTier + row.waveLabelOffset}`;
+      const waveLabel =
+        args.waveLabel ??
+        row.pendingWaveLabel ??
+        `${row.waveLabelPrefix}-${nextTier + row.waveLabelOffset}`;
+
+      const missing: string[] = [];
+      if (!broadcastId) missing.push("broadcastId");
+      if (!segmentId) missing.push("segmentId");
+      if (assigned === undefined) missing.push("assigned");
+      if (args.sentAt === undefined) missing.push("sentAt");
+      if (missing.length > 0) {
+        throw new Error(
+          `[recoverFromPartialFailure:manual-finished] missing required field(s): ${missing.join(", ")}. ` +
+            `Operator must supply (or rely on persisted pending* state from a prior runner). Persisted state: ` +
+            `pendingBroadcastId=${row.pendingBroadcastId ?? "-"}, pendingSegmentId=${row.pendingSegmentId ?? "-"}, ` +
+            `pendingAssigned=${row.pendingAssigned ?? "-"}, pendingWaveLabel=${row.pendingWaveLabel ?? "-"}.`,
+        );
+      }
+
       await ctx.db.patch(row._id, {
         currentTier: nextTier,
         lastWaveLabel: waveLabel,
-        lastWaveBroadcastId: args.broadcastId,
-        lastWaveSegmentId: args.segmentId,
-        lastWaveAssigned: args.assigned,
+        lastWaveBroadcastId: broadcastId,
+        lastWaveSegmentId: segmentId,
+        lastWaveAssigned: assigned,
         lastWaveSentAt: args.sentAt,
         lastRunStatus: `succeeded-via-manual-recovery: ${args.reason.slice(0, 200)}`,
         lastRunAt: Date.now(),
         lastRunError: undefined,
-        pendingRunId: undefined,
-        pendingRunStartedAt: undefined,
+        ...clearPending,
       });
       return {
         ok: true as const,
         recovery: "manual-finished" as const,
         advancedToTier: nextTier,
         waveLabel,
+        broadcastId,
+        segmentId,
+        assigned,
+        usedPersistedFallback: {
+          broadcastId: !args.broadcastId && !!row.pendingBroadcastId,
+          segmentId: !args.segmentId && !!row.pendingSegmentId,
+          assigned:
+            args.assigned === undefined && row.pendingAssigned !== undefined,
+          waveLabel: !args.waveLabel && !!row.pendingWaveLabel,
+        },
       };
     }
 
@@ -343,8 +436,7 @@ export const recoverFromPartialFailure = internalMutation({
       lastRunStatus: `partial-failure-discarded-rotated: ${args.reason.slice(0, 200)}`,
       lastRunAt: Date.now(),
       lastRunError: undefined,
-      pendingRunId: undefined,
-      pendingRunStartedAt: undefined,
+      ...clearPending,
     });
     return {
       ok: true as const,
@@ -395,11 +487,24 @@ export const getRampStatus = internalQuery({
       lastRunError: row.lastRunError,
       pendingRunId: row.pendingRunId,
       pendingRunStartedAt: row.pendingRunStartedAt,
-      // Operator-facing flag: is the lease currently held + fresh?
-      leaseHeld:
+      // Operator-facing flag: is the lease currently held?
+      // (No automatic staleness override — held = held until cleared.)
+      leaseHeld: row.pendingRunId !== undefined,
+      // Telemetry-only: lets ops see at-a-glance whether a held lease is
+      // older than the warn cutoff (potential candidate for forceReleaseLease
+      // after a manual investigation). It does NOT affect any code path.
+      leaseAgeWarn:
         row.pendingRunId !== undefined &&
         row.pendingRunStartedAt !== undefined &&
-        Date.now() - row.pendingRunStartedAt < STALE_LEASE_MS,
+        Date.now() - row.pendingRunStartedAt > LEASE_AGE_WARN_MS,
+      // Persisted per-step progress so operators can decide between
+      // recoverFromPartialFailure(manual-finished) vs (discard-and-rotate).
+      pendingWaveLabel: row.pendingWaveLabel,
+      pendingSegmentId: row.pendingSegmentId,
+      pendingAssigned: row.pendingAssigned,
+      pendingExportAt: row.pendingExportAt,
+      pendingBroadcastId: row.pendingBroadcastId,
+      pendingBroadcastAt: row.pendingBroadcastAt,
     };
   },
 });
@@ -428,11 +533,13 @@ async function loadConfig(
  * Returns `{ ok: true }` on success or `{ ok: false, reason }` for the runner
  * to log and exit cleanly without side effects.
  *
- * Idempotency / staleness: a lease older than `STALE_LEASE_MS` is treated as
- * abandoned (previous runner crashed) and overridable; a fresh lease blocks
- * further claims. The new lease records `pendingRunId` and
- * `pendingRunStartedAt` so the matching `_recordWaveSent` /
- * `_recordRunOutcome` calls can validate they hold the lease they think they do.
+ * NO automatic staleness override. A held lease blocks until the owning runId
+ * clears it (terminal outcome path) or an operator clears it via
+ * `forceReleaseLease`. Reasoning: a wall-clock-based override has the same
+ * failure mode the lease exists to prevent — the original runner can still be
+ * alive (long-running `assignAndExportWave` over a large segment, slow
+ * Resend), and overriding while it's mid-flight lets a second run race and
+ * duplicate-send. The operator-only release path forces a human decision.
  */
 export const _claimTierForRun = internalMutation({
   args: {
@@ -452,24 +559,16 @@ export const _claimTierForRun = internalMutation({
       };
     }
     const now = Date.now();
-    if (
-      row.pendingRunId &&
-      row.pendingRunStartedAt &&
-      now - row.pendingRunStartedAt < STALE_LEASE_MS
-    ) {
+    if (row.pendingRunId) {
       return {
         ok: false as const,
         reason: "lease-held" as const,
         heldBy: row.pendingRunId,
-        ageMs: now - row.pendingRunStartedAt,
+        ageMs:
+          row.pendingRunStartedAt !== undefined
+            ? now - row.pendingRunStartedAt
+            : undefined,
       };
-    }
-    if (row.pendingRunId && row.pendingRunStartedAt) {
-      console.warn(
-        `[_claimTierForRun] overriding stale lease ${row.pendingRunId} ` +
-          `(age ${Math.round((now - row.pendingRunStartedAt) / 1000)}s > ${STALE_LEASE_MS / 1000}s) ` +
-          `— previous runner likely crashed mid-flight without releasing.`,
-      );
     }
     await ctx.db.patch(row._id, {
       pendingRunId: args.runId,
@@ -480,10 +579,121 @@ export const _claimTierForRun = internalMutation({
 });
 
 /**
+ * Operator-only last-resort lease release.
+ *
+ * Use ONLY when a cron action is genuinely wedged (process died silently
+ * between claim and any catch block, leaving a held lease with no
+ * partial-failure status). Investigate Convex action logs + Resend dashboard
+ * BEFORE calling this — the side effects might have actually completed
+ * (segment created, broadcast sent) and the right recovery is then
+ * `recoverFromPartialFailure({recovery:"manual-finished"})`, not a fresh send.
+ *
+ * Sets `lastRunStatus = "partial-failure"` so `recoverFromPartialFailure`
+ * picks up; preserves any `pending*` progress markers so the operator can
+ * decide between manual-finished and discard-and-rotate from persisted state.
+ */
+export const forceReleaseLease = internalMutation({
+  args: { reason: v.string() },
+  handler: async (ctx, { reason }) => {
+    const row = await loadConfig(ctx);
+    if (!row) throw new Error("[forceReleaseLease] no ramp configured");
+    if (!row.pendingRunId) {
+      return {
+        ok: true as const,
+        noop: true as const,
+        currentStatus: row.lastRunStatus,
+      };
+    }
+    const releasedRunId = row.pendingRunId;
+    const heldForMs =
+      row.pendingRunStartedAt !== undefined
+        ? Date.now() - row.pendingRunStartedAt
+        : undefined;
+    await ctx.db.patch(row._id, {
+      pendingRunId: undefined,
+      pendingRunStartedAt: undefined,
+      lastRunStatus: "partial-failure",
+      lastRunAt: Date.now(),
+      lastRunError: `forced-release: ${reason.slice(0, 200)} (was held by ${releasedRunId}${heldForMs !== undefined ? `, age ${Math.round(heldForMs / 1000)}s` : ""})`,
+    });
+    return {
+      ok: true as const,
+      releasedRunId,
+      heldForMs,
+    };
+  },
+});
+
+/**
+ * Persist post-`assignAndExportWave` progress. Called by the runner AFTER
+ * `assignAndExportWave` returns successfully. Lets `recoverFromPartialFailure`
+ * recover the (segmentId, assigned, waveLabel) without operator-supplied
+ * metadata if the action dies between this point and a successful
+ * `_recordWaveSent`.
+ *
+ * Lease-validating: throws if the lease has changed (operator
+ * `forceReleaseLease` mid-flight, or a different run claimed). The throw
+ * bubbles to Convex auto-Sentry; the runner stops without advancing.
+ */
+export const _recordPendingExport = internalMutation({
+  args: {
+    runId: v.string(),
+    waveLabel: v.string(),
+    segmentId: v.string(),
+    assigned: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const row = await loadConfig(ctx);
+    if (!row) throw new Error("[_recordPendingExport] no ramp configured");
+    if (row.pendingRunId !== args.runId) {
+      throw new Error(
+        `[_recordPendingExport] lease lost: expected runId=${args.runId}, found ${row.pendingRunId ?? "<cleared>"}. Refusing to persist export progress — operator/another run owns the state.`,
+      );
+    }
+    await ctx.db.patch(row._id, {
+      pendingWaveLabel: args.waveLabel,
+      pendingSegmentId: args.segmentId,
+      pendingAssigned: args.assigned,
+      pendingExportAt: Date.now(),
+    });
+    return { ok: true as const };
+  },
+});
+
+/**
+ * Persist post-`createProLaunchBroadcast` progress. Called by the runner
+ * AFTER `createProLaunchBroadcast` returns successfully. Lets
+ * `recoverFromPartialFailure` recover the broadcastId without
+ * operator-supplied metadata if the action dies between this point and a
+ * successful `_recordWaveSent`.
+ *
+ * Lease-validating: same semantics as `_recordPendingExport`.
+ */
+export const _recordPendingBroadcast = internalMutation({
+  args: {
+    runId: v.string(),
+    broadcastId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const row = await loadConfig(ctx);
+    if (!row) throw new Error("[_recordPendingBroadcast] no ramp configured");
+    if (row.pendingRunId !== args.runId) {
+      throw new Error(
+        `[_recordPendingBroadcast] lease lost: expected runId=${args.runId}, found ${row.pendingRunId ?? "<cleared>"}. Refusing to persist broadcast progress — operator/another run owns the state.`,
+      );
+    }
+    await ctx.db.patch(row._id, {
+      pendingBroadcastId: args.broadcastId,
+      pendingBroadcastAt: Date.now(),
+    });
+    return { ok: true as const };
+  },
+});
+
+/**
  * Internal mutation that the action calls to atomically advance the tier +
  * record a successful wave-send. Validates that the lease still belongs to
- * this runId — protects against the (extremely unlikely) case where the
- * lease was overridden as stale by another run while we were still working.
+ * this runId AND clears all pending-progress markers.
  */
 export const _recordWaveSent = internalMutation({
   args: {
@@ -505,13 +715,9 @@ export const _recordWaveSent = internalMutation({
       );
     }
     if (row.pendingRunId !== args.runId) {
-      // The lease changed under us. Either:
-      //   (a) our lease was overridden as stale by another run while we were
-      //       still in flight, OR
-      //   (b) the lease was cleared by an operator action (recoverFromPartialFailure).
-      // Either way, we must NOT advance the tier — another run may be in flight
-      // and would conflict, or the operator has taken control. Fall through to
-      // an error so Convex auto-Sentry captures and ops can investigate.
+      // The lease changed under us — operator force-released it, or
+      // recoverFromPartialFailure cleared it. We must NOT advance the tier;
+      // bubble to Convex auto-Sentry so ops can investigate.
       throw new Error(
         `[_recordWaveSent] lease lost: expected runId=${args.runId}, found ${row.pendingRunId ?? "<cleared>"}. Refusing to advance tier — investigate what cleared the lease.`,
       );
@@ -528,6 +734,15 @@ export const _recordWaveSent = internalMutation({
       lastRunError: undefined,
       pendingRunId: undefined,
       pendingRunStartedAt: undefined,
+      // Clear all per-step progress markers — this run's state is now in
+      // the lastWave* fields and the markers would otherwise leak into the
+      // next run's recovery surface.
+      pendingWaveLabel: undefined,
+      pendingSegmentId: undefined,
+      pendingAssigned: undefined,
+      pendingExportAt: undefined,
+      pendingBroadcastId: undefined,
+      pendingBroadcastAt: undefined,
     });
     return { ok: true };
   },
@@ -538,13 +753,23 @@ export const _recordWaveSent = internalMutation({
  * the tier. Used for kill-gate trips, drained pool, partial failures, and
  * "wait for prior wave to settle" deferrals.
  *
- * Always clears the lease (if held by this runId). The lease must not outlive
- * the run, otherwise the next cron run sees `lease-held` and skips, and
- * eventually expires via STALE_LEASE_MS — bigger lockout window than necessary.
+ * Lease-mismatch policy: when `runId` is provided AND it does not match the
+ * currently-held lease (`row.pendingRunId`), this mutation is a HARD NO-OP —
+ * no fields are written. This protects the winning run's authoritative
+ * outcome from being stomped by a stale or operator-displaced run that lost
+ * its lease but still tried to record an outcome (e.g. operator called
+ * `forceReleaseLease` mid-flight, then the displaced run's
+ * createProLaunchBroadcast catch block ran and tried to write
+ * "partial-failure"). Without this guard, the displaced run would overwrite
+ * the kill-gate / status / error / active flags that the operator's recovery
+ * path just set.
+ *
+ * Pre-claim deferrals (kill-gate trips before claim, ramp-complete) pass no
+ * `runId` — those bypass the ownership check by design.
  */
 export const _recordRunOutcome = internalMutation({
   args: {
-    runId: v.optional(v.string()), // optional for backwards-compat with pre-claim deferrals
+    runId: v.optional(v.string()), // optional for pre-claim deferrals (kill-gate, ramp-complete)
     status: v.string(),
     error: v.optional(v.string()),
     killGate: v.optional(v.boolean()),
@@ -553,7 +778,27 @@ export const _recordRunOutcome = internalMutation({
   },
   handler: async (ctx, args) => {
     const row = await loadConfig(ctx);
-    if (!row) return;
+    if (!row) return { ok: false as const, reason: "no-config" as const };
+
+    // P1#2 fix: lease-lost is a hard no-op. Both cases below count as lost:
+    //   - row.pendingRunId is some OTHER runId (a new run claimed after our
+    //     lease was force-released)
+    //   - row.pendingRunId is undefined (operator cleared it via
+    //     forceReleaseLease / recoverFromPartialFailure / clearPartialFailure)
+    // Either way, the operator/winner owns the outcome state now; writing
+    // anything would clobber their decision.
+    if (args.runId && row.pendingRunId !== args.runId) {
+      console.warn(
+        `[_recordRunOutcome] lease lost (expected ${args.runId}, found ${row.pendingRunId ?? "<cleared>"}); refusing to write outcome status=${args.status}.`,
+      );
+      return {
+        ok: false as const,
+        reason: "lease-lost" as const,
+        expectedRunId: args.runId,
+        actualRunId: row.pendingRunId ?? null,
+      };
+    }
+
     const patch: Record<string, unknown> = {
       lastRunStatus: args.status,
       lastRunAt: Date.now(),
@@ -566,13 +811,14 @@ export const _recordRunOutcome = internalMutation({
     if (args.deactivate) {
       patch.active = false;
     }
-    // Clear the lease if it's ours. Avoids stomping a lease that some other
-    // run claimed after we lost ours (e.g. our lease was overridden as stale).
+    // Clear the lease if it's ours. We only get here when ownership is
+    // verified (or no runId was provided — pre-claim deferral path).
     if (args.runId && row.pendingRunId === args.runId) {
       patch.pendingRunId = undefined;
       patch.pendingRunStartedAt = undefined;
     }
     await ctx.db.patch(row._id, patch);
+    return { ok: true as const };
   },
 });
 
@@ -786,6 +1032,23 @@ export const runDailyRamp = internalAction({
       return { status: "pool-drained", detail: reason };
     }
 
+    // P1#4: persist post-export progress BEFORE the next external step. If
+    // the action dies after this point but before _recordWaveSent (Convex
+    // action timeout, OOM, network), recoverFromPartialFailure can read the
+    // (segmentId, assigned, waveLabel) from persisted state — operator
+    // doesn't have to reconstruct from Resend dashboard correlation.
+    // Lease-validating: throws if the lease was force-released mid-flight,
+    // bubbling to Convex auto-Sentry.
+    await ctx.runMutation(
+      internal.broadcast.rampRunner._recordPendingExport,
+      {
+        runId,
+        waveLabel,
+        segmentId: exportResult.segmentId,
+        assigned: exportResult.assigned,
+      },
+    );
+
     // ──── Step 4: create + send the broadcast ────
     let broadcastId: string;
     try {
@@ -803,11 +1066,18 @@ export const runDailyRamp = internalAction({
         {
           runId,
           status: "partial-failure",
-          error: `createProLaunchBroadcast: ${msg} (waveLabel=${waveLabel}, segmentId=${exportResult.segmentId}, ${exportResult.assigned} contacts stamped + in segment). Recovery: see recoverFromPartialFailure(${JSON.stringify({ recovery: "manual-finished" })}) or recoverFromPartialFailure(${JSON.stringify({ recovery: "discard-and-rotate" })}).`,
+          error: `createProLaunchBroadcast: ${msg} (waveLabel=${waveLabel}, segmentId=${exportResult.segmentId}, ${exportResult.assigned} contacts stamped + in segment). Recovery: pending* state persisted; call recoverFromPartialFailure({recovery:"manual-finished", sentAt:<epoch>}) after manually completing send, or recoverFromPartialFailure({recovery:"discard-and-rotate"}) to bump waveLabelOffset.`,
         },
       );
       throw err;
     }
+
+    // P1#4: persist post-broadcast-create progress before the send. Lease-
+    // validating: throws if the lease was force-released mid-flight.
+    await ctx.runMutation(
+      internal.broadcast.rampRunner._recordPendingBroadcast,
+      { runId, broadcastId },
+    );
 
     try {
       await ctx.runAction(
@@ -821,7 +1091,7 @@ export const runDailyRamp = internalAction({
         {
           runId,
           status: "partial-failure",
-          error: `sendProLaunchBroadcast: ${msg} (waveLabel=${waveLabel}, segmentId=${exportResult.segmentId}, broadcastId=${broadcastId}, assigned=${exportResult.assigned}). Recovery: preview in Resend dashboard; if it sent fine, recoverFromPartialFailure({recovery:'manual-finished', broadcastId, ...}). If it didn't, send manually then call manual-finished, OR call recoverFromPartialFailure({recovery:'discard-and-rotate'}) to bump waveLabelOffset and let next cron retry with a fresh label.`,
+          error: `sendProLaunchBroadcast: ${msg} (waveLabel=${waveLabel}, segmentId=${exportResult.segmentId}, broadcastId=${broadcastId}, assigned=${exportResult.assigned}). Recovery: pending* state persisted; preview in Resend dashboard, then recoverFromPartialFailure({recovery:"manual-finished", sentAt:<epoch>}) (broadcastId/segmentId/assigned/waveLabel auto-fill from persisted state). If unrecoverable, recoverFromPartialFailure({recovery:"discard-and-rotate"}) bumps waveLabelOffset.`,
         },
       );
       throw err;

--- a/convex/broadcast/rampRunner.ts
+++ b/convex/broadcast/rampRunner.ts
@@ -1046,13 +1046,30 @@ export const runDailyRamp = internalAction({
       exportResult.underfilled &&
       exportResult.assigned < count * UNDERFILL_RATIO
     ) {
-      const reason = `pool drained — requested ${count}, got ${exportResult.assigned}`;
-      console.log(`[runDailyRamp] ${reason} — deactivating`);
+      // P1 round 4: contacts ARE stamped (excluded from future picks) AND in
+      // the Resend segment, but no broadcast was created/sent. Routing
+      // through "pool-drained" + deactivate-and-clear-lease would strand
+      // them — they'd never receive the email AND `recoverFromPartialFailure`
+      // couldn't run because status would be "pool-drained" instead of
+      // "partial-failure". Route through the recoverable partial-failure
+      // path: persisted pending* markers + lastRunStatus="partial-failure"
+      // make recoverFromPartialFailure({recovery:"manual-finished"}) able to
+      // pick up exactly where the runner stopped, OR
+      // recoverFromPartialFailure({recovery:"discard-and-rotate"}) to
+      // explicitly abandon (operator's call, not the runner's). Ramp is
+      // still deactivated — pool drained means the curve is done.
+      const reason = `pool drained — requested ${count}, got ${exportResult.assigned} stamped + in segment ${exportResult.segmentId} (waveLabel=${waveLabel}). Contacts ARE stamped and excluded from future picks; they will be lost unless this wave is sent. Recovery: pending* state persisted; recoverFromPartialFailure({recovery:"manual-finished", sentAt:<epoch>}) after manually completing the broadcast in Resend, OR recoverFromPartialFailure({recovery:"discard-and-rotate"}) to abandon. Ramp deactivated; resumeRamp if appropriate after recovery.`;
+      console.log(`[runDailyRamp] ${reason}`);
       await ctx.runMutation(
         internal.broadcast.rampRunner._recordRunOutcome,
-        { runId, status: "pool-drained", deactivate: true, error: reason },
+        {
+          runId,
+          status: "partial-failure",
+          deactivate: true,
+          error: reason,
+        },
       );
-      return { status: "pool-drained", detail: reason };
+      return { status: "pool-drained-partial-failure", detail: reason };
     }
 
     // ──── Step 4: create + send the broadcast ────

--- a/convex/broadcast/rampRunner.ts
+++ b/convex/broadcast/rampRunner.ts
@@ -1000,6 +1000,29 @@ export const runDailyRamp = internalAction({
       throw err; // bubble so Convex auto-Sentry captures
     }
 
+    // P1#4 (round 2): persist post-export progress IMMEDIATELY after
+    // assignAndExportWave returns, BEFORE inspecting failure counters /
+    // underfill. The export ran — there's a real `segmentId`, contacts may
+    // be stamped, contacts may be in the Resend segment — independent of
+    // whether `failed > 0`, `stampFailed > 0`, or `assigned < threshold`.
+    // If we deferred persistence past those branches, an operator running
+    // `clearPartialFailure({confirmNoExport: true})` would see no
+    // `pendingWaveLabel/SegmentId/BroadcastId` and the fail-closed guard
+    // would let the clear through — masking stamped contacts and the
+    // segment that's already in Resend. Persisting first means every
+    // partial-failure path post-export carries the markers, and
+    // clearPartialFailure refuses loudly. Lease-validating: throws if the
+    // lease was force-released mid-flight, bubbling to Convex auto-Sentry.
+    await ctx.runMutation(
+      internal.broadcast.rampRunner._recordPendingExport,
+      {
+        runId,
+        waveLabel,
+        segmentId: exportResult.segmentId,
+        assigned: exportResult.assigned,
+      },
+    );
+
     // Treat any non-zero export failure counter as a partial-failure
     // and refuse to send. Without this, a wave that requested 500 and
     // got 250 push failures + 250 successes would still proceed to
@@ -1031,23 +1054,6 @@ export const runDailyRamp = internalAction({
       );
       return { status: "pool-drained", detail: reason };
     }
-
-    // P1#4: persist post-export progress BEFORE the next external step. If
-    // the action dies after this point but before _recordWaveSent (Convex
-    // action timeout, OOM, network), recoverFromPartialFailure can read the
-    // (segmentId, assigned, waveLabel) from persisted state — operator
-    // doesn't have to reconstruct from Resend dashboard correlation.
-    // Lease-validating: throws if the lease was force-released mid-flight,
-    // bubbling to Convex auto-Sentry.
-    await ctx.runMutation(
-      internal.broadcast.rampRunner._recordPendingExport,
-      {
-        runId,
-        waveLabel,
-        segmentId: exportResult.segmentId,
-        assigned: exportResult.assigned,
-      },
-    );
 
     // ──── Step 4: create + send the broadcast ────
     let broadcastId: string;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -213,6 +213,16 @@ export default defineSchema({
     lastRunStatus: v.optional(v.string()),
     lastRunAt: v.optional(v.number()),
     lastRunError: v.optional(v.string()),
+    // Lease for the in-flight cron run. Set atomically by `_claimTierForRun`
+    // BEFORE the runner makes any external side effects (assignAndExportWave,
+    // createProLaunchBroadcast, sendProLaunchBroadcast). Cleared by
+    // `_recordWaveSent` (success), `_recordRunOutcome` (failure), or
+    // `recoverFromPartialFailure` (operator). Two overlapping cron runs both
+    // attempting `_claimTierForRun` will see a lease already held and exit
+    // before any duplicate emails go out. Stale leases (older than
+    // STALE_LEASE_MS) can be overridden — the runner crashed mid-flight.
+    pendingRunId: v.optional(v.string()),
+    pendingRunStartedAt: v.optional(v.number()),
   }).index("by_key", ["key"]),
 
   // Phase 9 / Todo #223 — Clerk-user referral codes.

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -216,13 +216,28 @@ export default defineSchema({
     // Lease for the in-flight cron run. Set atomically by `_claimTierForRun`
     // BEFORE the runner makes any external side effects (assignAndExportWave,
     // createProLaunchBroadcast, sendProLaunchBroadcast). Cleared by
-    // `_recordWaveSent` (success), `_recordRunOutcome` (failure), or
-    // `recoverFromPartialFailure` (operator). Two overlapping cron runs both
-    // attempting `_claimTierForRun` will see a lease already held and exit
-    // before any duplicate emails go out. Stale leases (older than
-    // STALE_LEASE_MS) can be overridden — the runner crashed mid-flight.
+    // `_recordWaveSent` (success), `_recordRunOutcome` (failure for the
+    // owning runId), `recoverFromPartialFailure` (operator), or
+    // `forceReleaseLease` (operator, last-resort). Two overlapping cron runs
+    // both attempting `_claimTierForRun` will see a lease already held and
+    // exit before any duplicate emails go out. There is NO automatic
+    // staleness override — long-running side effects (large waves) must not
+    // be racable just because they exceed an arbitrary clock; recovery from
+    // a genuinely-stuck lease is operator-only via `forceReleaseLease`.
     pendingRunId: v.optional(v.string()),
     pendingRunStartedAt: v.optional(v.number()),
+    // Per-step progress markers persisted by the in-flight run AFTER each
+    // external action succeeds. Lets `recoverFromPartialFailure` recover
+    // without operator-supplied metadata when the action dies between steps
+    // (e.g. Convex action timeout, OOM) before the catch can record
+    // partial-failure. Cleared on successful `_recordWaveSent` and on
+    // `recoverFromPartialFailure` completion.
+    pendingWaveLabel: v.optional(v.string()),
+    pendingSegmentId: v.optional(v.string()),
+    pendingAssigned: v.optional(v.number()),
+    pendingExportAt: v.optional(v.number()),
+    pendingBroadcastId: v.optional(v.string()),
+    pendingBroadcastAt: v.optional(v.number()),
   }).index("by_key", ["key"]),
 
   // Phase 9 / Todo #223 — Clerk-user referral codes.


### PR DESCRIPTION
## Summary

Addresses two P1 review findings on PR #3473 (\`rampRunner.ts\`, already merged).

### P1 #1 — Race condition that allowed DUPLICATE EMAIL SENDS

The runner reads \`currentTier\` and runs \`assignAndExportWave\` + \`createProLaunchBroadcast\` + \`sendProLaunchBroadcast\` BEFORE recording the tier in \`_recordWaveSent\`. Two overlapping cron runs (or cron + manual trigger, or Convex action retry) both pass kill-gate / tier checks, both proceed through all 3 external side effects, and only collide at \`_recordWaveSent\` — by then **duplicate emails have already gone out** to every recipient in the wave. The tier check there is post-hoc, not a pre-claim. Sender reputation impact: catastrophic on the canary-warmup audience.

**Fix:** atomic lease, claimed BEFORE any external side effect.

\`\`\`ts
// new mutation: writes pendingRunId + pendingRunStartedAt iff:
//  - currentTier matches expected
//  - no fresh lease (or held lease > STALE_LEASE_MS = 30min, override)
_claimTierForRun({ runId, expectedCurrentTier })
\`\`\`

The runner exits cleanly on claim rejection — no external state touched. \`_recordWaveSent\` now validates the lease still belongs to its runId and clears it on success. \`_recordRunOutcome\` / \`clearPartialFailure\` also clear the lease (**only when runId matches**, to avoid stomping another run's claim).

### P1 #2 — Recovery path broken after exported-but-not-sent

When \`assignAndExportWave\` succeeded (contacts stamped, segment created) but \`createProLaunchBroadcast\` or \`sendProLaunchBroadcast\` threw, bare \`clearPartialFailure\` made the next cron retry the SAME \`waveLabel\` — \`assignAndExportWave\` rejected because contacts were already stamped. The cron thrashed on the same partial-failure forever short of \`abortRamp\` or hand-patching the DB.

**Fix:** new \`recoverFromPartialFailure(recovery, ...)\` action with two operator-declared modes:

| Mode | Use when | Effect |
|---|---|---|
| \`manual-finished\` | Operator manually completed the wave (e.g. via Resend dashboard or direct \`sendProLaunchBroadcast\` call). Pass \`broadcastId\`, \`segmentId\`, \`sentAt\`, \`assigned\`. | Tier advances; next kill-gate check uses the recorded broadcastId. Equivalent to a successful cron run. |
| \`discard-and-rotate\` | Wave is genuinely lost; can't or won't retry. | Bumps \`waveLabelOffset\` by 1 so next cron uses a **fresh** waveLabel. Prior label's stamps remain (those contacts excluded from future picks). Tier NOT advanced. |

Both modes clear the lease + partial-failure status. Runner error messages now include the \`recoverFromPartialFailure\` invocation hint right next to each \`throw\` site, so on-call ops sees the recovery path inline.

## What changed

- **\`convex/schema.ts\`** — \`pendingRunId\` + \`pendingRunStartedAt\` optional fields on \`broadcastRampConfig\`
- **\`convex/broadcast/rampRunner.ts\`**:
  - new \`_claimTierForRun\` mutation
  - \`_recordWaveSent\`: lease validation, clears on success
  - \`_recordRunOutcome\`: takes optional \`runId\`, clears matching lease only
  - \`runDailyRamp\`: claims lease after tier-bounds check, BEFORE any external side effect; threads \`runId\` through every outcome record
  - new \`recoverFromPartialFailure\` mutation
  - \`getRampStatus\`: surfaces \`pendingRunId\`, \`pendingRunStartedAt\`, derived \`leaseHeld\` boolean
- **\`convex/__tests__/rampRunner.test.ts\`** — 13 new tests

## Test plan

- [x] 13 new ramp tests pass; 107/107 total Convex tests pass (was 94)
- [x] TS dual typecheck clean
- [x] Biome clean
- [ ] **Post-merge / pre-next-wave:** verify in prod via \`getRampStatus\` that no stale lease is held; if one is, \`abortRamp\` + \`initRamp\` to reset
- [ ] **Optional dry-run:** trigger \`runDailyRamp\` twice in quick succession (manual + cron); confirm only one wave goes out

## Operator quick reference (post-merge)

\`\`\`bash
# If a wave is stuck in partial-failure with stamped+created+not-sent state:

# Option A — operator finished it manually
npx convex run broadcast/rampRunner:recoverFromPartialFailure '{
  "recovery": "manual-finished",
  "reason": "sent wave-N via Resend dashboard after API timeout",
  "broadcastId": "<bc-id>",
  "segmentId": "<seg-id>",
  "sentAt": <epoch-ms>,
  "assigned": <count>
}'

# Option B — write off the failed wave
npx convex run broadcast/rampRunner:recoverFromPartialFailure '{
  "recovery": "discard-and-rotate",
  "reason": "wave-N unrecoverable, rotating label"
}'
\`\`\`