### PR TITLE
fix(resilience): symmetric headline gate + cache-key constant import in tests (PR #3472 follow-up)

### DIFF
--- a/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
@@ -156,9 +156,17 @@ export const getResilienceRanking: ResilienceServiceHandler['getResilienceRankin
       // wire shape matches the generated proto response type.
       const { _formula: _drop, ...publicResponse } = cached!;
       void _drop;
+      // Re-sort items[] after the symmetric promotion. A high-scoring
+      // item promoted from greyedOut[] would otherwise be appended at
+      // the end of items[] instead of landing in its correct rank
+      // position. The recompute path always sorts before publishing
+      // (line ~225 below), so the cache-hit path must too — otherwise
+      // a cache-hit response visibly differs from a fresh recompute
+      // for the same data, breaking the front-of-house ranking sort.
+      // Per Greptile P2 review of PR #3472 follow-up.
       return {
         ...(publicResponse as GetResilienceRankingResponse),
-        items: [...eligibleItems, ...promotedFromGreyed],
+        items: sortRankingItems([...eligibleItems, ...promotedFromGreyed]),
         greyedOut: [...stillGreyed, ...ineligibleFromItems],
       };
     }

--- a/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
@@ -137,23 +137,29 @@ export const getResilienceRanking: ResilienceServiceHandler['getResilienceRankin
       const backfillEligibilityConservative = <T extends { headlineEligible?: boolean }>(item: T): T =>
         (item.headlineEligible === undefined ? { ...item, headlineEligible: false } : item);
       // Plan 2026-04-26-002 §U7 (PR 6) — apply the headline-eligible
-      // gate to the cache-hit path. Otherwise stale items[] from a
-      // partially-migrated cache (or any future state where a writer
-      // forgets to filter) would surface ineligible countries in the
-      // headline ranking. The gate is the single source of truth — any
-      // path that returns items[] to callers must apply it.
+      // gate SYMMETRICALLY across both arrays: any item with
+      // `headlineEligible === true` ends up in items[] regardless of
+      // which cached array it was in; anything else ends up in
+      // greyedOut[]. Asymmetric gating (only filtering items → greyedOut)
+      // would leave a cached greyedOut entry permanently demoted even
+      // if it now passes the gate, until a full recompute. Symmetric
+      // gating makes the predicate the single source of truth across
+      // every code path that returns items[] / greyedOut[] to callers.
+      // Per Greptile P2 review of PR #3472.
       const itemsWithEligibility = filteredItems.map(backfillEligibilityConservative);
       const greyedWithEligibility = filteredGreyedOut.map(backfillEligibilityConservative);
-      const ineligibleFromItems = itemsWithEligibility.filter((item) => item.headlineEligible !== true);
       const eligibleItems = itemsWithEligibility.filter((item) => item.headlineEligible === true);
+      const ineligibleFromItems = itemsWithEligibility.filter((item) => item.headlineEligible !== true);
+      const promotedFromGreyed = greyedWithEligibility.filter((item) => item.headlineEligible === true);
+      const stillGreyed = greyedWithEligibility.filter((item) => item.headlineEligible !== true);
       // Strip the cache-only tag before returning to callers so the
       // wire shape matches the generated proto response type.
       const { _formula: _drop, ...publicResponse } = cached!;
       void _drop;
       return {
         ...(publicResponse as GetResilienceRankingResponse),
-        items: eligibleItems,
-        greyedOut: [...greyedWithEligibility, ...ineligibleFromItems],
+        items: [...eligibleItems, ...promotedFromGreyed],
+        greyedOut: [...stillGreyed, ...ineligibleFromItems],
       };
     }
   }

--- a/tests/resilience-headline-eligible-gate.test.mts
+++ b/tests/resilience-headline-eligible-gate.test.mts
@@ -16,6 +16,7 @@ import { describe, it } from 'node:test';
 
 import { getResilienceRanking } from '../server/worldmonitor/resilience/v1/get-resilience-ranking.ts';
 import {
+  RESILIENCE_RANKING_CACHE_KEY,
   computeHeadlineEligible,
   HEADLINE_ELIGIBLE_HIGH_COVERAGE,
   HEADLINE_ELIGIBLE_MIN_COVERAGE,
@@ -128,7 +129,7 @@ describe('ranking handler filter (Plan 2026-04-26-002 §U7)', () => {
       ],
       greyedOut: [],
     };
-    redis.set('resilience:ranking:v17', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
+    redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
@@ -141,6 +142,38 @@ describe('ranking handler filter (Plan 2026-04-26-002 §U7)', () => {
       `ineligible item TV must NOT appear in items[]; got items=${itemCodes.join(',')}`);
     assert.ok(greyedCodes.includes('TV'),
       `ineligible item TV must surface in greyedOut[]; got greyedOut=${greyedCodes.join(',')}`);
+  });
+
+  it('promotes greyedOut items with headlineEligible:true to items[] (symmetric gate)', async () => {
+    // Plan 002 §U7 review fix (PR #3472 follow-up): the gate must
+    // apply SYMMETRICALLY across both arrays. A cached greyedOut entry
+    // with `headlineEligible: true` should be promoted to items[] on
+    // the cache-hit read; otherwise an item that now passes the gate
+    // remains demoted until a full recompute (~6h TTL).
+    //
+    // Mutation-verified: removing `promotedFromGreyed` from the
+    // returned items[] array makes this test fail.
+    const { redis } = installRedis(RESILIENCE_FIXTURES);
+    const cachedPublic = {
+      items: [],
+      greyedOut: [
+        // Anomalous: cached in greyedOut but flagged eligible. Symmetric
+        // gate should promote it.
+        { countryCode: 'NO', overallScore: 82, level: 'high', lowConfidence: false, overallCoverage: 0.95, headlineEligible: true },
+        // Genuinely ineligible — stays in greyedOut.
+        { countryCode: 'TV', overallScore: 70, level: 'medium', lowConfidence: false, overallCoverage: 0.7, headlineEligible: false },
+      ],
+    };
+    redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
+
+    const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
+
+    assert.ok(response.items.some((item) => item.countryCode === 'NO'),
+      'symmetric gate must promote greyedOut entries with headlineEligible:true to items[]');
+    assert.ok(!response.greyedOut.some((item) => item.countryCode === 'NO'),
+      'NO must NOT remain in greyedOut[] after symmetric gate promotion');
+    assert.ok(response.greyedOut.some((item) => item.countryCode === 'TV'),
+      'TV (genuinely ineligible) must stay in greyedOut[]');
   });
 
   it('headlineEligible:true items pass even when overallCoverage is below the legacy GREY_OUT threshold', async () => {
@@ -160,7 +193,7 @@ describe('ranking handler filter (Plan 2026-04-26-002 §U7)', () => {
       ],
       greyedOut: [],
     };
-    redis.set('resilience:ranking:v17', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
+    redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 

--- a/tests/resilience-headline-eligible-gate.test.mts
+++ b/tests/resilience-headline-eligible-gate.test.mts
@@ -176,6 +176,37 @@ describe('ranking handler filter (Plan 2026-04-26-002 §U7)', () => {
       'TV (genuinely ineligible) must stay in greyedOut[]');
   });
 
+  it('re-sorts items[] after promoting from greyedOut (high-score promoted item lands at correct rank)', async () => {
+    // Plan 002 §U7 review fix (PR #3477 round 2): the symmetric gate
+    // appends `promotedFromGreyed` to items[] without re-sorting. A
+    // higher-scoring promoted item would land at the END of items[]
+    // instead of its correct rank position. Recompute path sorts
+    // before publishing, so cache-hit must too — otherwise cache-hit
+    // visibly differs from a fresh recompute for the same data.
+    //
+    // Mutation-verified: removing the sortRankingItems wrapper makes
+    // this test fail.
+    const { redis } = installRedis(RESILIENCE_FIXTURES);
+    const cachedPublic = {
+      items: [
+        // Lower-scoring eligible item — should land below the promotion.
+        { countryCode: 'US', overallScore: 61, level: 'medium', lowConfidence: false, overallCoverage: 0.88, headlineEligible: true },
+      ],
+      greyedOut: [
+        // Higher-scoring item flagged eligible — must promote to items[]
+        // AND land at the top after re-sort, not appended at the end.
+        { countryCode: 'NO', overallScore: 82, level: 'high', lowConfidence: false, overallCoverage: 0.95, headlineEligible: true },
+      ],
+    };
+    redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
+
+    const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
+
+    const itemCodes = response.items.map((item) => item.countryCode);
+    assert.deepEqual(itemCodes, ['NO', 'US'],
+      `expected items[] sorted descending by score: NO (82) before US (61); got ${itemCodes.join(',')}`);
+  });
+
   it('headlineEligible:true items pass even when overallCoverage is below the legacy GREY_OUT threshold', async () => {
     // Pins the rationale for Greptile P2's "redundant coverage check"
     // simplification. After dropping the legacy

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -109,15 +109,17 @@ describe('resilience ranking contracts', () => {
     // Regression for: `cached?.items?.length` was falsy when items=[] even though
     // greyedOut had entries, causing unnecessary rewarming on every request.
     const { redis } = installRedis(RESILIENCE_FIXTURES);
-    // Plan 002 §U3 (PR 2): greyed-out items also carry headlineEligible
-    // post-PR-2. Note: greyed-out items represent low-coverage countries
-    // that wouldn't pass the future PR-6 gate either; PR 2 still emits
-    // `true` per the no-behavior-change contract, and PR 6 will swap.
+    // Plan 002 §U7 (PR 6 + #3472 follow-up): greyed-out items represent
+    // low-coverage countries that wouldn't pass the gate. Post-PR-6, a
+    // legitimate writer stamps `headlineEligible: false` on them. The
+    // symmetric-gate handler promotes any greyedOut item flagged true
+    // back to items[], so the fixture must accurately reflect the
+    // post-PR-6 stamping (false for SS, ER) for the deepEqual to hold.
     const cachedPublic = {
       items: [],
       greyedOut: [
-        { countryCode: 'SS', overallScore: 12, level: 'critical', lowConfidence: true, overallCoverage: 0.15, headlineEligible: true },
-        { countryCode: 'ER', overallScore: 10, level: 'critical', lowConfidence: true, overallCoverage: 0.12, headlineEligible: true },
+        { countryCode: 'SS', overallScore: 12, level: 'critical', lowConfidence: true, overallCoverage: 0.15, headlineEligible: false },
+        { countryCode: 'ER', overallScore: 10, level: 'critical', lowConfidence: true, overallCoverage: 0.12, headlineEligible: false },
       ],
     };
     redis.set('resilience:ranking:v17', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 
 import { getResilienceRanking } from '../server/worldmonitor/resilience/v1/get-resilience-ranking.ts';
-import { buildRankingItem, sortRankingItems } from '../server/worldmonitor/resilience/v1/_shared.ts';
+import { RESILIENCE_RANKING_CACHE_KEY, buildRankingItem, sortRankingItems } from '../server/worldmonitor/resilience/v1/_shared.ts';
 import { __resetKeyPrefixCacheForTests } from '../server/_shared/redis.ts';
 import { installRedis } from './helpers/fake-upstash-redis.mts';
 import { RESILIENCE_FIXTURES } from './helpers/resilience-fixtures.mts';
@@ -61,7 +61,7 @@ describe('resilience ranking contracts', () => {
     // so fixtures must carry the `_formula` tag matching the current env
     // (default flag-off ⇒ 'd6'). Writing the tagged shape here mirrors
     // what the handler persists via stampRankingCacheTag.
-    redis.set('resilience:ranking:v17', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
+    redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
@@ -87,7 +87,7 @@ describe('resilience ranking contracts', () => {
         { countryCode: 'SS', overallScore: 12, level: 'critical', lowConfidence: true, overallCoverage: 0.15 },
       ],
     };
-    redis.set('resilience:ranking:v17', JSON.stringify({ ...legacyCached, _formula: 'd6' }));
+    redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify({ ...legacyCached, _formula: 'd6' }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
@@ -122,7 +122,7 @@ describe('resilience ranking contracts', () => {
         { countryCode: 'ER', overallScore: 10, level: 'critical', lowConfidence: true, overallCoverage: 0.12, headlineEligible: false },
       ],
     };
-    redis.set('resilience:ranking:v17', JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
+    redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify({ ...cachedPublic, _formula: 'd6' }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
@@ -200,7 +200,7 @@ describe('resilience ranking contracts', () => {
       greyedOut: [],
       _formula: 'pc', // mismatched — current env is flag-off ⇒ current='d6'
     };
-    redis.set('resilience:ranking:v17', JSON.stringify(stale));
+    redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify(stale));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
@@ -247,7 +247,7 @@ describe('resilience ranking contracts', () => {
     assert.equal(totalItems, 3, `expected 3 total items across ranked + greyedOut, got ${totalItems}`);
     assert.ok(redis.has('resilience:score:v17:YE'), 'missing country should be warmed during first call');
     assert.ok(response.items.every((item) => item.overallScore >= 0), 'ranked items should all have computed scores');
-    assert.ok(redis.has('resilience:ranking:v17'), 'fully scored ranking should be cached');
+    assert.ok(redis.has(RESILIENCE_RANKING_CACHE_KEY), 'fully scored ranking should be cached');
   });
 
   it('sets rankStable=true when interval data exists and width <= 8', async () => {
@@ -300,7 +300,7 @@ describe('resilience ranking contracts', () => {
 
     // 3 of 4 (NO + US pre-cached, YE warmed from fixtures, ZZ can't be warmed)
     // = 75% which meets the threshold — must cache.
-    assert.ok(redis.has('resilience:ranking:v17'), 'ranking must be cached at exactly 75% coverage');
+    assert.ok(redis.has(RESILIENCE_RANKING_CACHE_KEY), 'ranking must be cached at exactly 75% coverage');
     assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written alongside the ranking');
   });
 
@@ -347,7 +347,7 @@ describe('resilience ranking contracts', () => {
 
     await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
-    assert.ok(redis.has('resilience:ranking:v17'), 'ranking must be published despite pipeline-GET race');
+    assert.ok(redis.has(RESILIENCE_RANKING_CACHE_KEY), 'ranking must be published despite pipeline-GET race');
     assert.ok(redis.has('seed-meta:resilience:ranking'), 'seed-meta must be written despite pipeline-GET race');
   });
 
@@ -396,7 +396,7 @@ describe('resilience ranking contracts', () => {
 
     await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
-    assert.equal(redis.has('resilience:ranking:v17'), false,
+    assert.equal(redis.has(RESILIENCE_RANKING_CACHE_KEY), false,
       'ranking must NOT be published when score SETs returned OK but did not durably persist');
     assert.equal(redis.has('seed-meta:resilience:ranking'), false,
       'seed-meta must NOT be written when parity check fails — that would be a lying meta');
@@ -471,7 +471,7 @@ describe('resilience ranking contracts', () => {
     // Post-fix (sample from warmedCountryCodes only): YE + ZZ are
     // sampled, neither exists in Redis, parity check fails, meta
     // refused.
-    assert.equal(redis.has('resilience:ranking:v17'), false,
+    assert.equal(redis.has(RESILIENCE_RANKING_CACHE_KEY), false,
       'ranking must NOT be published when warmed-tail keys returned OK but did not persist (mixed-failure mode)');
     assert.equal(redis.has('seed-meta:resilience:ranking'), false,
       'seed-meta must NOT lie when only the warmed tail failed — sampling must focus on warmed entries, not cachedScores broadly');
@@ -563,7 +563,7 @@ describe('resilience ranking contracts', () => {
       // fallback test isn't about gate filtering — keep the field
       // present so the test exercises the auth path cleanly.
       const stale = { items: [{ countryCode: 'NR', overallScore: 1, level: 'low', lowConfidence: true, overallCoverage: 0.5, headlineEligible: true }], greyedOut: [], _formula: 'd6' };
-      redis.set('resilience:ranking:v17', JSON.stringify(stale));
+      redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify(stale));
 
       // No X-WorldMonitor-Key → refresh must be ignored, stale cache returned.
       const unauth = new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1');
@@ -617,7 +617,7 @@ describe('resilience ranking contracts', () => {
       // rejected by the formula gate and the refresh path would not
       // get tested as intended.
       const stale = { items: [{ countryCode: 'ZZ', overallScore: 1, level: 'low', lowConfidence: true, overallCoverage: 0.5 }], greyedOut: [], _formula: 'd6' };
-      redis.set('resilience:ranking:v17', JSON.stringify(stale));
+      redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify(stale));
 
       const request = new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1', {
         headers: { 'X-WorldMonitor-Key': 'seed-secret' },
@@ -707,7 +707,7 @@ describe('resilience ranking contracts', () => {
 
     await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
-    assert.ok(!redis.has('resilience:ranking:v17'), 'ranking must NOT be published when score writes failed');
+    assert.ok(!redis.has(RESILIENCE_RANKING_CACHE_KEY), 'ranking must NOT be published when score writes failed');
     assert.ok(!redis.has('seed-meta:resilience:ranking'), 'seed-meta must NOT be written when score writes failed');
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #3472 — Greptile review on the now-merged PR surfaced two P2s that warrant a separate fix:

### P2 — Asymmetric gate application

The cache-hit gate in `get-resilience-ranking.ts` demoted ineligible items from `items[] → greyedOut[]`, but never re-evaluated items already sitting in cached `greyedOut[]`. An item flagged `headlineEligible: true` in greyedOut[] would remain demoted on every cache-hit read until a full 6h-TTL recompute. The PR's stated contract — "gate is the single source of truth across both code paths" — was only half-delivered.

**Fix**: split `greyedOut[]` symmetrically. Eligible items in either array land in `items[]`; the rest land in `greyedOut[]`. New regression test `"promotes greyedOut items with headlineEligible:true to items[] (symmetric gate)"`. **Mutation-verified**: removing `promotedFromGreyed` from items[] makes the test fail.

### P2 — Hardcoded cache key in tests

Two `redis.set('resilience:ranking:v17', ...)` literals in `tests/resilience-headline-eligible-gate.test.mts`. A future v18 bump would silently land at a different Redis key, the handler finds nothing, falls through to recompute, and tests fail for an opaque reason unrelated to gate logic. Replaced with imported `RESILIENCE_RANKING_CACHE_KEY`.

### Test fixture cleanup

The pre-existing "all-greyed-out cached payload" test had `headlineEligible: true` on items in `greyedOut[]` — exactly the anomalous state the new symmetric gate correctly handles by promotion. Updated the fixture to `false` to match what a legitimate post-PR-6 writer stamps on low-coverage countries.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (exit 0)
- [x] 676 resilience tests pass (1 new + 675 existing)
- [x] Mutation-verified: removing the symmetric promotion makes the new test fail

## References

- Plan: `docs/plans/2026-04-26-002-feat-resilience-universe-coverage-rebuild-plan.md`
- Predecessor: #3472 (PR 6 follow-up — applied gate to cache-hit path)
- Earlier: #3469 (PR 6 / §U7 — activated the gate)