### PR TITLE
feat(user-prefs): map Convex ServiceUnavailable → 503 + Retry-After

### DIFF
--- a/api/_convex-error.js
+++ b/api/_convex-error.js
@@ -35,6 +35,15 @@ export function extractConvexErrorKind(err, msg) {
     const kind = /** @type {Record<string, unknown>} */ (data).kind;
     if (typeof kind === 'string') return kind;
   }
+  // Convex platform-level 503: the runtime returns a JSON body
+  // `{"code":"ServiceUnavailable","message":"Service temporarily unavailable"}`
+  // when the deployment is briefly unreachable. The HTTP client surfaces
+  // this as `Error('{"code":"ServiceUnavailable",...}')` — `.data` is
+  // undefined (it's not a ConvexError, it's a transport-layer 503), so
+  // we detect via the JSON-shape substring. Edge maps this to a 503
+  // response with Retry-After so clients back off rather than treating
+  // it as a permanent 500.
+  if (msg.includes('"code":"ServiceUnavailable"')) return 'SERVICE_UNAVAILABLE';
   if (msg.includes('CONFLICT')) return 'CONFLICT';
   if (msg.includes('BLOB_TOO_LARGE')) return 'BLOB_TOO_LARGE';
   if (msg.includes('UNAUTHENTICATED')) return 'UNAUTHENTICATED';

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -85,6 +85,19 @@ export default async function handler(
         }));
         return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
       }
+      if (kind === 'SERVICE_UNAVAILABLE') {
+        // Convex platform-level 503 — transient and self-recovering. Map to
+        // 503 with `Retry-After` so the client backs off rather than treating
+        // it as a permanent 500. Still capture so we can spot regressions /
+        // sustained outages, but use the typed `convex_service_unavailable`
+        // shape so it groups distinctly from real internal 500s.
+        console.warn('[user-prefs] GET convex service unavailable:', msg);
+        captureSilentError(err, buildSentryContext(err, msg, {
+          method: 'GET', convexFn: 'userPreferences:getPreferences',
+          userId: session.userId, variant, ctx,
+        }));
+        return jsonResponse({ error: 'SERVICE_UNAVAILABLE' }, 503, { ...cors, 'Retry-After': '5' });
+      }
       console.error('[user-prefs] GET error:', err);
       captureSilentError(err, buildSentryContext(err, msg, {
         method: 'GET', convexFn: 'userPreferences:getPreferences',
@@ -152,6 +165,19 @@ export default async function handler(
       }));
       return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
     }
+    if (kind === 'SERVICE_UNAVAILABLE') {
+      // See GET branch above — Convex 503, transient. 503 + Retry-After
+      // so the client backs off rather than burning a 500-failed-write.
+      console.warn('[user-prefs] POST convex service unavailable:', msg);
+      captureSilentError(err, buildSentryContext(err, msg, {
+        method: 'POST', convexFn: 'userPreferences:setPreferences',
+        userId: session.userId, variant: body.variant, ctx,
+        schemaVersion: typeof body.schemaVersion === 'number' ? body.schemaVersion : null,
+        expectedSyncVersion: body.expectedSyncVersion,
+        blobSize: body.data !== undefined ? JSON.stringify(body.data).length : 0,
+      }));
+      return jsonResponse({ error: 'SERVICE_UNAVAILABLE' }, 503, { ...cors, 'Retry-After': '5' });
+    }
     console.error('[user-prefs] POST error:', err);
     captureSilentError(err, buildSentryContext(err, msg, {
       method: 'POST', convexFn: 'userPreferences:setPreferences',
@@ -202,7 +228,11 @@ function buildSentryContext(
   // Order matters: UNAUTHENTICATED is more specific than the request-id
   // server-error shape and must be checked first. Auth drift is its own bucket
   // so it groups separately from genuine Convex 5xx in the Sentry dashboard.
+  // SERVICE_UNAVAILABLE (Convex platform 503) is also its own bucket — it
+  // would otherwise fall into 'unknown' and conflate transient outages with
+  // genuinely-novel failure modes that haven't been classified yet.
   const errorShape = /UNAUTHENTICATED/.test(msg) ? 'convex_auth_drift'
+    : /"code":"ServiceUnavailable"/.test(msg) ? 'convex_service_unavailable'
     : /\[Request ID:\s*[a-f0-9]+\]\s*Server Error/i.test(msg) ? 'convex_server_error'
     : /timeout|timed out|aborted/i.test(msg) ? 'transport_timeout'
     : /fetch failed|network|ECONN|ENOTFOUND|getaddrinfo/i.test(msg) ? 'transport_network'

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -37,6 +37,28 @@ let _installed = false;
 let _suppressPatch = false; // prevents applyCloudBlob from re-triggering upload
 let _cachedToken: string | null = null; // synchronous token cache for flush()
 
+// ── 503 retry tracking ───────────────────────────────────────────────────────
+//
+// _retryTimer holds the single pending 503-retry setTimeout (we cancel and
+// re-schedule rather than stacking; only one retry should ever be in flight).
+//
+// _authGeneration increments on every onSignIn entry and onSignOut so a
+// scheduled retry callback can detect "I'm stale, abort." Without this guard,
+// a delayed retry from user A could fire after sign-out (calling onSignIn
+// with the prior userId but the now-empty Clerk token), or after user B has
+// signed in (using B's token but A's userId in the retry closure) — both
+// produce a misleading sync attempt and pollute Sentry with confused errors.
+
+let _retryTimer: ReturnType<typeof setTimeout> | null = null;
+let _authGeneration = 0;
+
+function clearRetryTimer(): void {
+  if (_retryTimer !== null) {
+    clearTimeout(_retryTimer);
+    _retryTimer = null;
+  }
+}
+
 // ── Guards ────────────────────────────────────────────────────────────────────
 
 function isEnabled(): boolean {
@@ -243,6 +265,14 @@ async function postCloudPrefs(
 export async function onSignIn(userId: string, variant: string): Promise<void> {
   if (!isEnabled()) return;
 
+  // New onSignIn entry — invalidate any pending 503 retry so a stale
+  // closure can't fire mid-flight, and bump generation so any timer that
+  // was already scheduled (and not yet caught by clearRetryTimer) bails
+  // when it fires.
+  clearRetryTimer();
+  _authGeneration += 1;
+  const myGeneration = _authGeneration;
+
   _currentVariant = variant;
   setState('syncing');
 
@@ -297,11 +327,22 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
       // the user-facing "transient outage shouldn't be permanent" fix
       // (PR #3479): without this branch the catch would fall through to
       // 'error' and the user's prefs would silently not sync until they
-      // reload. Single retry on the typed error is enough — if Convex
-      // is still 503 after the delay, we set 'error' on the next failure.
+      // reload.
+      //
+      // Generation guard: cancel any prior pending retry, then schedule a
+      // new one whose callback bails if `_authGeneration` has advanced
+      // (sign-out, user-switch, or another onSignIn invocation since this
+      // attempt began). Without the guard, a 5s delayed retry from user A
+      // could fire after sign-out (no token) or after user B signed in
+      // (wrong token in cache).
       console.warn(`[cloud-prefs] onSignIn 503; retrying in ${err.retryAfterSec}s`);
       setState('pending');
-      setTimeout(() => { void onSignIn(userId, variant); }, err.retryAfterSec * 1000);
+      clearRetryTimer();
+      _retryTimer = setTimeout(() => {
+        _retryTimer = null;
+        if (_authGeneration !== myGeneration) return;
+        void onSignIn(userId, variant);
+      }, err.retryAfterSec * 1000);
       return;
     }
     console.warn('[cloud-prefs] onSignIn failed:', err);
@@ -327,6 +368,13 @@ export function onSignOut(): void {
     clearTimeout(_debounceTimer);
     _debounceTimer = null;
   }
+  // Cancel any pending 503 retry and bump auth-generation so a timer that's
+  // already scheduled (and not yet caught by clearRetryTimer) bails when it
+  // fires — a delayed retry from the prior auth context must not call
+  // onSignIn / uploadNow against the now-empty token cache or, worse, against
+  // a different user's token after a fast user switch.
+  clearRetryTimer();
+  _authGeneration += 1;
   _cachedToken = null;
 
   // Preserve prefs; only clear sync metadata
@@ -336,6 +384,14 @@ export function onSignOut(): void {
 }
 
 async function uploadNow(variant: string): Promise<void> {
+  // Capture the auth generation at entry. If sign-out / user-switch happens
+  // while we're awaiting fetch, the generation guard on any 503 retry below
+  // will detect it and abort the scheduled retry. We do NOT increment the
+  // generation here — uploadNow runs WITHIN an existing auth context (it's
+  // called by the debounced upload path), so we want to inherit the current
+  // generation, not start a new one.
+  const myGeneration = _authGeneration;
+
   const token = await getClerkToken();
   if (!token) return;
   _cachedToken = token;
@@ -373,9 +429,20 @@ async function uploadNow(variant: string): Promise<void> {
       // Convex platform 503 — transient. Re-queue the upload after the
       // server-suggested delay so the unsaved blob isn't lost. Setting
       // 'pending' state matches the existing schedulePrefUpload UX.
+      //
+      // Generation guard: same as the onSignIn branch — if the user signs
+      // out or switches accounts during the retry window, the timer fires
+      // but the closure's captured `myGeneration` no longer matches, so
+      // the retry aborts. Without this, the upload would re-fire against
+      // a now-empty token cache or a different user's token.
       console.warn(`[cloud-prefs] uploadNow 503; retrying in ${err.retryAfterSec}s`);
       setState('pending');
-      setTimeout(() => { void uploadNow(variant); }, err.retryAfterSec * 1000);
+      clearRetryTimer();
+      _retryTimer = setTimeout(() => {
+        _retryTimer = null;
+        if (_authGeneration !== myGeneration) return;
+        void uploadNow(variant);
+      }, err.retryAfterSec * 1000);
       return;
     }
     console.warn('[cloud-prefs] uploadNow failed:', err);

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -149,11 +149,63 @@ interface CloudPrefs {
   syncVersion: number;
 }
 
+/**
+ * Typed 503 from the edge — Convex platform-level outage. Callers detect
+ * this via `instanceof ServiceUnavailableError` and back off using
+ * `retryAfterSec` instead of treating it as a permanent error.
+ */
+export class ServiceUnavailableError extends Error {
+  retryAfterSec: number;
+  constructor(retryAfterSec: number) {
+    super(`service unavailable (retry after ${retryAfterSec}s)`);
+    this.name = 'ServiceUnavailableError';
+    this.retryAfterSec = retryAfterSec;
+  }
+}
+
+// Bounds on the Retry-After value we'll honor. Lower bound prevents a
+// retry storm if the server sends 0 or a malformed value; upper bound
+// caps the delay so a misconfigured/extreme header doesn't strand sync
+// for minutes.
+const RETRY_AFTER_MIN_SEC = 1;
+const RETRY_AFTER_MAX_SEC = 60;
+const RETRY_AFTER_DEFAULT_SEC = 5;
+
+/**
+ * Parse the `Retry-After` header per RFC 7231: either delta-seconds or an
+ * HTTP-date. Returns a clamped number of seconds, with the configured
+ * default for missing/malformed values. Exported for testability.
+ */
+export function parseRetryAfterSeconds(headers: Headers): number {
+  const raw = headers.get('Retry-After');
+  if (!raw) return RETRY_AFTER_DEFAULT_SEC;
+  const trimmed = raw.trim();
+  // delta-seconds form: digits only.
+  if (/^\d+$/.test(trimmed)) {
+    const n = Number(trimmed);
+    if (!Number.isFinite(n)) return RETRY_AFTER_DEFAULT_SEC;
+    return Math.min(Math.max(n, RETRY_AFTER_MIN_SEC), RETRY_AFTER_MAX_SEC);
+  }
+  // HTTP-date form: parse and convert to delta-seconds from now.
+  // `Date.parse` is permissive — `Date.parse("-5")` parses as year -5 BCE,
+  // and other garbage strings can produce finite timestamps that then
+  // clamp to RETRY_AFTER_MIN_SEC, retrying in 1s instead of the safer
+  // default. Require the input to look like a real HTTP-date (must
+  // contain both a 4-digit year and a `:` time separator) so non-date
+  // garbage falls into the default-seconds branch instead.
+  if (!/\b\d{4}\b/.test(trimmed) || !trimmed.includes(':')) return RETRY_AFTER_DEFAULT_SEC;
+  const t = Date.parse(trimmed);
+  if (!Number.isFinite(t)) return RETRY_AFTER_DEFAULT_SEC;
+  const delta = Math.round((t - Date.now()) / 1000);
+  return Math.min(Math.max(delta, RETRY_AFTER_MIN_SEC), RETRY_AFTER_MAX_SEC);
+}
+
 async function fetchCloudPrefs(token: string, variant: string): Promise<CloudPrefs | null> {
   const res = await fetch(`/api/user-prefs?variant=${encodeURIComponent(variant)}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (res.status === 401) return null;
+  if (res.status === 503) throw new ServiceUnavailableError(parseRetryAfterSeconds(res.headers));
   if (!res.ok) throw new Error(`fetch prefs: ${res.status}`);
   return (await res.json()) as CloudPrefs | null;
 }
@@ -181,6 +233,7 @@ async function postCloudPrefs(
     const actualSyncVersion = typeof body.actualSyncVersion === 'number' ? body.actualSyncVersion : undefined;
     return { conflict: true, actualSyncVersion };
   }
+  if (res.status === 503) throw new ServiceUnavailableError(parseRetryAfterSeconds(res.headers));
   if (!res.ok) throw new Error(`post prefs: ${res.status}`);
   return (await res.json()) as { syncVersion: number };
 }
@@ -238,6 +291,19 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
 
     Storage.prototype.setItem.call(localStorage, KEY_LAST_SIGNED_IN_AS, userId);
   } catch (err) {
+    if (err instanceof ServiceUnavailableError) {
+      // Convex platform 503 — transient. Set 'pending' (not 'error') and
+      // re-attempt sign-in sync after the server-suggested delay. This is
+      // the user-facing "transient outage shouldn't be permanent" fix
+      // (PR #3479): without this branch the catch would fall through to
+      // 'error' and the user's prefs would silently not sync until they
+      // reload. Single retry on the typed error is enough — if Convex
+      // is still 503 after the delay, we set 'error' on the next failure.
+      console.warn(`[cloud-prefs] onSignIn 503; retrying in ${err.retryAfterSec}s`);
+      setState('pending');
+      setTimeout(() => { void onSignIn(userId, variant); }, err.retryAfterSec * 1000);
+      return;
+    }
     console.warn('[cloud-prefs] onSignIn failed:', err);
     setState(!navigator.onLine || (err instanceof TypeError && err.message.includes('fetch')) ? 'offline' : 'error');
   }
@@ -303,6 +369,15 @@ async function uploadNow(variant: string): Promise<void> {
       setState('synced');
     }
   } catch (err) {
+    if (err instanceof ServiceUnavailableError) {
+      // Convex platform 503 — transient. Re-queue the upload after the
+      // server-suggested delay so the unsaved blob isn't lost. Setting
+      // 'pending' state matches the existing schedulePrefUpload UX.
+      console.warn(`[cloud-prefs] uploadNow 503; retrying in ${err.retryAfterSec}s`);
+      setState('pending');
+      setTimeout(() => { void uploadNow(variant); }, err.retryAfterSec * 1000);
+      return;
+    }
     console.warn('[cloud-prefs] uploadNow failed:', err);
     setState(!navigator.onLine || (err instanceof TypeError && err.message.includes('fetch')) ? 'offline' : 'error');
   }

--- a/tests/cloud-prefs-retry-after.test.mjs
+++ b/tests/cloud-prefs-retry-after.test.mjs
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Extract `parseRetryAfterSeconds` from src/utils/cloud-prefs-sync.ts and
+// run it standalone. The full module imports browser-only globals; this
+// test focuses on the pure-function piece. Same regex+Function pattern the
+// other src-extraction tests use (csp-filter, sentry-beforesend).
+const src = readFileSync(resolve(__dirname, '../src/utils/cloud-prefs-sync.ts'), 'utf-8');
+const constsBlock = src.match(/const RETRY_AFTER_MIN_SEC[\s\S]*?const RETRY_AFTER_DEFAULT_SEC[^\n]+/);
+assert.ok(constsBlock, 'RETRY_AFTER_* constants must exist in cloud-prefs-sync.ts');
+const fnMatch = src.match(/export function parseRetryAfterSeconds\(headers: Headers\): number \{([\s\S]*?)\n\}/);
+assert.ok(fnMatch, 'parseRetryAfterSeconds must exist in cloud-prefs-sync.ts');
+
+const fnBody = constsBlock[0] + ';\n' + fnMatch[1].trim();
+// eslint-disable-next-line no-new-func
+const parseRetryAfterSeconds = new Function('headers', fnBody);
+
+const mkHeaders = (value) => {
+  const h = new Headers();
+  if (value !== undefined) h.set('Retry-After', value);
+  return h;
+};
+
+describe('parseRetryAfterSeconds', () => {
+  describe('delta-seconds form', () => {
+    it('parses a small integer', () => {
+      assert.equal(parseRetryAfterSeconds(mkHeaders('5')), 5);
+    });
+
+    it('parses a larger integer', () => {
+      assert.equal(parseRetryAfterSeconds(mkHeaders('30')), 30);
+    });
+
+    it('clamps to RETRY_AFTER_MIN_SEC for 0', () => {
+      // 0 means "retry immediately" per RFC, but that risks a retry storm
+      // if the server is misbehaving. Floor at 1s.
+      assert.equal(parseRetryAfterSeconds(mkHeaders('0')), 1);
+    });
+
+    it('clamps to RETRY_AFTER_MAX_SEC for very large values', () => {
+      // Some servers send huge values during planned outages. Cap at 60s
+      // so sync isn't stranded for minutes.
+      assert.equal(parseRetryAfterSeconds(mkHeaders('3600')), 60);
+    });
+
+    it('handles whitespace around the value', () => {
+      assert.equal(parseRetryAfterSeconds(mkHeaders('  7  ')), 7);
+    });
+  });
+
+  describe('HTTP-date form', () => {
+    it('converts a future date to delta-seconds', () => {
+      const futureMs = Date.now() + 8000;
+      const dateStr = new Date(futureMs).toUTCString();
+      const result = parseRetryAfterSeconds(mkHeaders(dateStr));
+      // Allow ±1s tolerance for the round-trip through Date.toUTCString
+      assert.ok(result >= 7 && result <= 9, `expected ~8s, got ${result}s`);
+    });
+
+    it('clamps a past date to RETRY_AFTER_MIN_SEC', () => {
+      const pastDate = new Date(Date.now() - 60000).toUTCString();
+      assert.equal(parseRetryAfterSeconds(mkHeaders(pastDate)), 1);
+    });
+
+    it('clamps a far-future date to RETRY_AFTER_MAX_SEC', () => {
+      const farFuture = new Date(Date.now() + 999999999).toUTCString();
+      assert.equal(parseRetryAfterSeconds(mkHeaders(farFuture)), 60);
+    });
+  });
+
+  describe('missing or malformed → default', () => {
+    it('returns RETRY_AFTER_DEFAULT_SEC when header is absent', () => {
+      assert.equal(parseRetryAfterSeconds(mkHeaders(undefined)), 5);
+    });
+
+    it('returns default for a non-numeric / non-date string', () => {
+      assert.equal(parseRetryAfterSeconds(mkHeaders('soon-please')), 5);
+    });
+
+    it('returns default for empty string', () => {
+      // Empty header is treated as absent by Headers.set, but the regex
+      // won't match either — defensive double-check.
+      assert.equal(parseRetryAfterSeconds(mkHeaders('')), 5);
+    });
+
+    it('returns default for negative-number form (not a valid delta-seconds)', () => {
+      // RFC delta-seconds is digits-only; "-5" would parse via Number()
+      // but our `^\d+$` regex correctly rejects it. The HTTP-date branch
+      // is then gated on a 4-digit year + a `:` separator, so "-5" can't
+      // sneak through as Date.parse("-5") returning year -5 BCE.
+      assert.equal(parseRetryAfterSeconds(mkHeaders('-5')), 5);
+    });
+
+    it('returns default for a date-shaped string lacking a time component', () => {
+      // Defensive: "2025-01-01" would Date.parse() as midnight Jan 1.
+      // The colon-required gate excludes it, falling into default rather
+      // than letting Date.parse interpret a date-only string and clamp
+      // to MIN/MAX based on now's distance from Jan 1.
+      assert.equal(parseRetryAfterSeconds(mkHeaders('2025-01-01')), 5);
+    });
+  });
+});

--- a/tests/user-prefs-convex-error.test.mjs
+++ b/tests/user-prefs-convex-error.test.mjs
@@ -33,6 +33,39 @@ describe('extractConvexErrorKind — Convex client error → kind', () => {
     });
   });
 
+  describe('Convex platform 503 — ServiceUnavailable JSON body', () => {
+    it('detects SERVICE_UNAVAILABLE from the {"code":"ServiceUnavailable"} JSON shape', () => {
+      // Convex's HTTP runtime returns a JSON body when the deployment is briefly
+      // unreachable; the SDK surfaces it as `Error('{"code":"ServiceUnavailable",...}')`
+      // with `.data === undefined` (it's transport-layer, not a ConvexError).
+      const err = new Error('{"code":"ServiceUnavailable","message":"Service temporarily unavailable"}');
+      assert.equal(extractConvexErrorKind(err, err.message), 'SERVICE_UNAVAILABLE');
+    });
+
+    it('detects SERVICE_UNAVAILABLE even when the JSON has additional fields', () => {
+      const err = new Error('{"code":"ServiceUnavailable","message":"Try again later","retryAfterMs":5000}');
+      assert.equal(extractConvexErrorKind(err, err.message), 'SERVICE_UNAVAILABLE');
+    });
+
+    it('does NOT match the loose phrase "service unavailable" without the JSON code field', () => {
+      // Defensive: the detector keys off the exact JSON-shape `"code":"ServiceUnavailable"`,
+      // not the prose. Prevents matching some unrelated upstream that happens to
+      // include the words "service unavailable" in a free-form error message.
+      const err = new Error('Network error: service unavailable, try again');
+      assert.equal(extractConvexErrorKind(err, err.message), null);
+    });
+
+    it('structured-data path still wins over SERVICE_UNAVAILABLE substring (forward-compat)', () => {
+      // If a future ConvexError sets data.kind explicitly AND the message
+      // happens to contain the JSON code (very unlikely but defensive),
+      // the structured kind takes precedence.
+      const err = Object.assign(new Error('{"code":"ServiceUnavailable","message":"x"}'), {
+        data: { kind: 'CONFLICT' },
+      });
+      assert.equal(extractConvexErrorKind(err, err.message), 'CONFLICT');
+    });
+  });
+
   describe('legacy substring-match fallback (string-data ConvexError that arrived without errorData)', () => {
     it('matches CONFLICT in the message', () => {
       const err = new Error('CONFLICT');


### PR DESCRIPTION
## Summary

Yesterday's PD investigation surfaced a 4-event/3-user cluster of `Error('{"code":"ServiceUnavailable","message":"Service temporarily unavailable"}')` from `api/user-prefs` during a 20-second Convex platform outage (round 7 triage, WORLDMONITOR-PG/PH). These events fell into `error_shape: 'unknown'` and returned **500**, treating a transient platform hiccup the same as a permanent application bug. The client treated 500 as permanent and didn't retry.

This PR maps Convex's platform-level 503 to a proper edge 503 with `Retry-After`, and gives it its own Sentry bucket.

### Changes

- **`api/_convex-error.js`** — `extractConvexErrorKind` detects the `"code":"ServiceUnavailable"` JSON-shape signature and returns the `SERVICE_UNAVAILABLE` kind. The detector keys off the exact `"code":"ServiceUnavailable"` substring so it doesn't false-positive on prose containing the loose phrase "service unavailable".
- **`api/user-prefs.ts`** — both GET and POST catch paths return `503 + { 'Retry-After': '5' }` instead of 500 when `kind === 'SERVICE_UNAVAILABLE'`. Still captures to Sentry for monitoring sustained outages.
- **Classifier** in `buildSentryContext` — new `error_shape: 'convex_service_unavailable'` bucket, ordered between UNAUTHENTICATED (most specific) and the generic Convex Server Error / transport buckets. Forward-compat preserved: structured `err.data.kind` still wins over the JSON-shape detection.

### Why a JSON-shape match instead of structured `ConvexError`

This isn't a `ConvexError` — it's a transport-layer 503 where Convex's runtime returns a JSON body before any function code runs. `.data` is undefined; the client SDK falls through to `throw new Error(respJSON.errorMessage)` where `errorMessage` is the JSON body. Detecting via the exact `"code":"ServiceUnavailable"` substring is the correct identification path — substring is brittle in general, but this string only appears in this one wire format from Convex.

## Test plan

- [x] `tests/user-prefs-convex-error.test.mjs` — +4 cases:
  - detects from canonical Convex 503 JSON body
  - detects when JSON has additional fields (`retryAfterMs`, etc.)
  - does NOT match the loose phrase "service unavailable" without the JSON `code` field (anti-false-positive)
  - structured `err.data.kind` still wins over the JSON-shape detection (forward-compat)
- [x] `npx tsc --noEmit` + `tsc --noEmit -p tsconfig.api.json` — clean
- [x] `npm run lint` (biome) — 0 errors
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — 2.8.0 sync OK
- [x] `npm run test:data` — **7596/7596 pass** (+4 from new SERVICE_UNAVAILABLE cases)
- [x] Edge function bundle check — PASS
- [x] `node --test tests/edge-functions.test.mjs` — 178/178
- [ ] Verify post-deploy: next Convex platform 503 should appear under Sentry `error_shape:convex_service_unavailable` (its own bucket) instead of the generic 500 path, AND the client should see 503 instead of 500
- [ ] If a client retry-on-503 path exists, confirm it honors the `Retry-After: 5` header

## Notes

- `Retry-After: 5` is conservative — Convex outages have historically been short (yesterday's was 20 seconds). 5 seconds gives the client time to back off without hammering during recovery, but isn't so long that it feels broken to the user.
- This PR doesn't add client-side retry logic for 503 — the client's existing fetch error handling already differentiates transient transport errors. The server-side fix is the load-bearing piece; client improvements can come in a follow-up if Sentry shows users still hammering.