### PR TITLE
fix(classifier): match flashback/throwback after publisher brand prefix

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3159,17 +3159,21 @@ function matchCountryNamesInText(text) {
   return [];
 }
 
-// v4 (2026-04-26): bumped from v3 in lockstep with
+// v5 (2026-04-28): bumped from v4 in lockstep with
 // server/worldmonitor/intelligence/v1/_shared.ts and
 // server/worldmonitor/news/v1/list-feed-digest.ts to evict cache entries
-// that previously promoted static-page titles to high/critical via the
-// LLM classifier. The relay maintains its own inline helper because
-// .cjs cannot import from .ts; the prefix-audit static-analysis test
+// that landed under the pre-publisher-prefix-fix classifier (PR #3480).
+// Brand-prefixed retrospective titles ("CBS News Radio flashback: ...")
+// had been promoted to severity=critical via the `invasion` keyword;
+// the new brand-prefix branch in _classifier.ts re-rules those rows on
+// next touch.
+// The relay maintains its own inline helper because .cjs cannot import
+// from .ts; the prefix-audit static-analysis test
 // (tests/news-classify-cache-prefix-audit.test.mjs) cross-checks all
-// three sites. See U4 of the plan.
+// three sites.
 function classifyCacheKey(title) {
   const hash = crypto.createHash('sha256').update(title.toLowerCase()).digest('hex').slice(0, 16);
-  return `classify:sebuf:v4:${hash}`;
+  return `classify:sebuf:v5:${hash}`;
 }
 
 // LLM provider fallback chain — mirrors seed-insights.mjs LLM_PROVIDERS

--- a/server/worldmonitor/intelligence/v1/_shared.ts
+++ b/server/worldmonitor/intelligence/v1/_shared.ts
@@ -9,6 +9,14 @@ import { hashString, sha256Hex } from '../../../_shared/hash';
 // ========================================================================
 
 export const UPSTREAM_TIMEOUT_MS = 25_000;
+// v5 (2026-04-28): bumped from v4 to evict entries that landed under
+// the pre-publisher-prefix-fix classifier (PR #3480). Brand-prefixed
+// retrospective titles like "CBS News Radio flashback: D-Day, Invasion
+// of Normandy in 1944" had been promoted to severity=critical via the
+// `invasion` keyword and persisted in the classify cache. The new
+// brand-prefix branch in _classifier.ts re-rules those rows on next
+// touch; v5 forces an immediate eviction rather than waiting for
+// natural TTL.
 // v4 (2026-04-26): bumped from v3 to evict entries poisoned by static
 // institutional pages that previously promoted info-keyword titles to
 // high/critical via the LLM classifier. See PR for U4 of
@@ -16,8 +24,9 @@ export const UPSTREAM_TIMEOUT_MS = 25_000;
 // Three sites read/write this prefix: this canonical writer, the digest
 // reader at server/worldmonitor/news/v1/list-feed-digest.ts (now uses
 // buildClassifyCacheKey), and scripts/ais-relay.cjs (independent inline
-// helper — cannot import from .ts). All three were updated atomically.
-const CLASSIFY_CACHE_PREFIX = 'classify:sebuf:v4:';
+// helper — cannot import from .ts). All three are kept in lockstep by
+// the news-classify-cache-prefix-audit static-analysis test.
+const CLASSIFY_CACHE_PREFIX = 'classify:sebuf:v5:';
 
 // ========================================================================
 // Tier-1 country definitions (used by risk-scores + country-intel-brief)

--- a/server/worldmonitor/news/v1/_classifier.ts
+++ b/server/worldmonitor/news/v1/_classifier.ts
@@ -235,17 +235,47 @@ function matchKeywords(
 // legitimate current-event uses ("Today in Ukraine: Russian missile strikes
 // Kyiv") that would have falsely downgraded real critical alerts. Only
 // patterns whose retrospective intent is unambiguous remain:
-//   - "Science history:" — Live Science series tag, never current. Stays
-//     anchored at the start because that's its editorial slot prefix.
-//   - "Throwback" / "Flashback" — always retrospective by definition,
-//     EVEN when a publisher brand prefixes the token (CBS News Radio
-//     Flashback, BBC Throwback Thursday, NPR Flashback Friday). The
-//     original anchored `^flashback` missed brief 2026-04-28-0801's
-//     "CBS News Radio flashback: D-Day, Invasion of Normandy in 1944",
-//     which still ranked CRITICAL via the `invasion` keyword. Word-
-//     boundary match catches the brand-prefixed forms.
-const HISTORICAL_PREFIX_RE =
-  /(?:^science history\s*:?|\b(?:throwback|flashback)\b)/i;
+//   - "Science history:" — Live Science series tag, never current.
+//   - "Throwback" / "Flashback" — always retrospective when used as an
+//     editorial-slot title (anchored at start, OR after a brand prefix).
+//
+// Two branches handle this:
+//
+//   1. ANCHORED form — the marker is at title position 0:
+//        "Throwback Thursday: 9/11 reflections"
+//        "Flashback: 1986 Iran-Contra disclosure"
+//        "Science history: Chernobyl meltdown"
+//
+//   2. BRAND-PREFIX form — the marker follows 1-4 Title Case brand
+//      words and the slot ends with a colon. Brief 2026-04-28-0801
+//      surfaced "CBS News Radio flashback: D-Day, Invasion of Normandy
+//      in 1944" because the original anchored regex missed this shape.
+//        "CBS News Radio flashback: D-Day, Invasion of Normandy in 1944"
+//        "BBC Throwback Thursday: the fall of Saigon"
+//        "NPR Flashback Friday: Watergate hearings"
+//
+// The brand-prefix branch deliberately requires:
+//   (a) Title-Case prefix words (rejects sentence-form like
+//       "markets see flashback to 2008 crisis"), AND
+//   (b) an editorial-slot colon after the marker (rejects
+//       "Markets See Flashback To 2008 Crisis As Bonds Tumble" — no
+//       colon, this is a sentence headline using flashback as a
+//       comparison, not a retrospective slot title).
+//
+// This matters because hasHistoricalMarker is also reused at
+// list-feed-digest.ts in the L3b LLM-cache guard (PR #3429), where
+// it force-demotes ANY cached LLM hit to info. Without the colon /
+// Title-Case constraint, current-event headlines that happen to use
+// "flashback" / "throwback" as a comparison word would be wrongly
+// suppressed at full severity.
+const HISTORICAL_ANCHORED_PREFIX_RE =
+  /^(?:science history|throwback|flashback)\s*:?/i;
+// No `i` flag — Title-Case enforcement on the brand prefix is
+// load-bearing. Marker token itself is matched in either case via
+// the [Tt]/[Ff] character classes (publishers ship both "Flashback"
+// title-case and "flashback" all-lowercase forms).
+const HISTORICAL_BRAND_PREFIX_RE =
+  /^(?:[A-Z][\w'&-]*\s+){1,4}(?:[Tt]hrowback|[Ff]lashback)(?:\s+[A-Za-z]+)?\s*:/;
 
 // "On this day in YYYY" requires a YEAR after the prefix — narrows out
 // "On this day, Iran fires missile" (current event) while keeping
@@ -294,7 +324,8 @@ function isPastRetrospectiveYear(year: number, nowMs: number): boolean {
  * other than classifyByKeyword and enrichWithAiCache.
  */
 export function hasHistoricalMarker(title: string, nowMs: number = Date.now()): boolean {
-  if (HISTORICAL_PREFIX_RE.test(title)) return true;
+  if (HISTORICAL_ANCHORED_PREFIX_RE.test(title)) return true;
+  if (HISTORICAL_BRAND_PREFIX_RE.test(title)) return true;
   if (HISTORICAL_PREFIX_WITH_YEAR_RE.test(title)) return true;
   if (THIS_DAY_IN_HISTORY_RE.test(title)) return true;
   if (HISTORICAL_PHRASE_RE.test(title)) return true;

--- a/server/worldmonitor/news/v1/_classifier.ts
+++ b/server/worldmonitor/news/v1/_classifier.ts
@@ -230,14 +230,22 @@ function matchKeywords(
  *   - "On this day: Iraq invasion 5 years ago"
  * Both contain a CRITICAL keyword AND an unmistakable retrospective marker.
  */
-// Highly-specific retrospective prefixes — bare "Today in" / "This day in"
+// Highly-specific retrospective markers — bare "Today in" / "This day in"
 // were intentionally REMOVED after PR #3429 review (round 2). Both have
 // legitimate current-event uses ("Today in Ukraine: Russian missile strikes
 // Kyiv") that would have falsely downgraded real critical alerts. Only
 // patterns whose retrospective intent is unambiguous remain:
-//   - "Science history:" — Live Science series tag, never current.
-//   - "Throwback" / "Flashback" — always retrospective by definition.
-const HISTORICAL_PREFIX_RE = /^(?:science history|throwback|flashback)\s*:?/i;
+//   - "Science history:" — Live Science series tag, never current. Stays
+//     anchored at the start because that's its editorial slot prefix.
+//   - "Throwback" / "Flashback" — always retrospective by definition,
+//     EVEN when a publisher brand prefixes the token (CBS News Radio
+//     Flashback, BBC Throwback Thursday, NPR Flashback Friday). The
+//     original anchored `^flashback` missed brief 2026-04-28-0801's
+//     "CBS News Radio flashback: D-Day, Invasion of Normandy in 1944",
+//     which still ranked CRITICAL via the `invasion` keyword. Word-
+//     boundary match catches the brand-prefixed forms.
+const HISTORICAL_PREFIX_RE =
+  /(?:^science history\s*:?|\b(?:throwback|flashback)\b)/i;
 
 // "On this day in YYYY" requires a YEAR after the prefix — narrows out
 // "On this day, Iran fires missile" (current event) while keeping

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -508,7 +508,7 @@ async function enrichWithAiCache(items: ParsedItem[]): Promise<void> {
   if (candidates.length === 0) return;
 
   // Use the canonical buildClassifyCacheKey from intelligence/v1/_shared
-  // so the cache prefix (currently classify:sebuf:v4:) lives in exactly
+  // so the cache prefix (currently classify:sebuf:v5:) lives in exactly
   // one place — bumping it again only requires touching _shared.ts and
   // the relay's independent .cjs helper. See U4 of the plan.
   const keyMap = new Map<string, ParsedItem[]>();

--- a/tests/news-classifier-historical-downgrade.test.mts
+++ b/tests/news-classifier-historical-downgrade.test.mts
@@ -125,6 +125,62 @@ describe('hasHistoricalMarker — predicate matrix', () => {
         false,
       );
     });
+
+    // After widening flashback/throwback to allow brand-prefix forms, we
+    // explicitly reject sentence-form occurrences where the marker is
+    // used as a comparison word, not as an editorial-slot title.
+    // hasHistoricalMarker is reused at list-feed-digest.ts:547 (L3b LLM-
+    // cache guard), where it force-demotes ANY cached LLM hit to info —
+    // a false positive there silently suppresses real critical news.
+    // The brand-prefix branch requires Title-Case prefix words AND a
+    // colon after the marker, which gates these out.
+    it('"Markets see flashback to 2008 crisis as bonds tumble" — sentence-form, no editorial slot', () => {
+      assert.equal(
+        hasHistoricalMarker(
+          'Markets see flashback to 2008 crisis as bonds tumble',
+          NOW,
+        ),
+        false,
+      );
+    });
+
+    it('"Stocks suffer flashback to March 2020 crash" — sentence-form, no colon', () => {
+      assert.equal(
+        hasHistoricalMarker('Stocks suffer flashback to March 2020 crash', NOW),
+        false,
+      );
+    });
+
+    it('"Tesla stock throwback after split" — sentence-form, no Title-Case prefix structure', () => {
+      assert.equal(
+        hasHistoricalMarker('Tesla stock throwback after split', NOW),
+        false,
+      );
+    });
+
+    it('"AI flashback to 2023 boom: Nvidia earnings beat" — colon present but not after marker slot', () => {
+      // Colon is after "boom", not adjacent to the flashback slot, and
+      // the optional qualifier slot only allows ONE word — so "flashback
+      // to 2023 boom" overruns the qualifier slot and the brand-prefix
+      // branch fails.
+      assert.equal(
+        hasHistoricalMarker(
+          'AI flashback to 2023 boom: Nvidia earnings beat',
+          NOW,
+        ),
+        false,
+      );
+    });
+
+    it('lowercase-leading sentence with flashback + colon — Title-Case prefix gate fires', () => {
+      // "markets see flashback: bonds tumble" (lowercase first word) is
+      // sentence-form, not editorial slot. Brand-prefix branch requires
+      // [A-Z]-leading words, so this is rejected.
+      assert.equal(
+        hasHistoricalMarker('markets see flashback: bonds tumble', NOW),
+        false,
+      );
+    });
   });
 
   describe('historical phrases (true)', () => {

--- a/tests/news-classifier-historical-downgrade.test.mts
+++ b/tests/news-classifier-historical-downgrade.test.mts
@@ -61,6 +61,28 @@ describe('hasHistoricalMarker — predicate matrix', () => {
       assert.equal(hasHistoricalMarker('Flashback: 1986 Iran-Contra disclosure', NOW), true);
     });
 
+    // Brief 2026-04-28-0801 surfaced this as CRITICAL in slot #3 even after
+    // PR #3429 shipped — the original `^flashback` anchor required position 0,
+    // but publishers prefix with their brand ("CBS News Radio flashback").
+    // Word-boundary match closes the gap.
+    it('publisher brand prefix + "flashback" / "throwback" still matches', () => {
+      assert.equal(
+        hasHistoricalMarker(
+          'CBS News Radio flashback: D-Day, Invasion of Normandy in 1944',
+          NOW,
+        ),
+        true,
+      );
+      assert.equal(
+        hasHistoricalMarker('BBC Throwback Thursday: the fall of Saigon', NOW),
+        true,
+      );
+      assert.equal(
+        hasHistoricalMarker('NPR Flashback Friday: Watergate hearings', NOW),
+        true,
+      );
+    });
+
     it('case-insensitive', () => {
       assert.equal(
         hasHistoricalMarker('SCIENCE HISTORY: Chernobyl meltdown', NOW),
@@ -259,6 +281,20 @@ describe('classifyByKeyword — historical downgrade integration', () => {
 
     it('"genocide" + "anniversary"', () => {
       const r = classifyByKeyword('40th anniversary of the Rwandan genocide');
+      assert.equal(r.level, 'info');
+      assert.equal(r.source, 'keyword-historical-downgrade');
+    });
+
+    // The exact title that surfaced as CRITICAL slot #3 in brief
+    // 2026-04-28-0801, two days after PR #3429's downgrade shipped.
+    // Keyword path matches `invasion` (CRITICAL); the publisher brand
+    // prefix "CBS News Radio" before "flashback" used to defeat the
+    // anchored `^flashback`. Now the word-boundary form catches it and
+    // the title returns 'keyword-historical-downgrade'.
+    it('"invasion" + publisher-brand "flashback" prefix (CBS D-Day, brief 2026-04-28-0801)', () => {
+      const r = classifyByKeyword(
+        'CBS News Radio flashback: D-Day, Invasion of Normandy in 1944',
+      );
       assert.equal(r.level, 'info');
       assert.equal(r.source, 'keyword-historical-downgrade');
     });


### PR DESCRIPTION
## Summary

- Brief 2026-04-28-0801 shipped `"CBS News Radio flashback: D-Day, Invasion of Normandy in 1944"` as severity=critical in slot #3, two days after PR #3429 ([f37216d04](https://github.com/koala73/worldmonitor/commit/f37216d04)) shipped the historical-retrospective downgrade.
- Root cause: `HISTORICAL_PREFIX_RE` in `_classifier.ts` was anchored with `^` so `flashback` / `throwback` only matched at title position 0. Publishers prepend their brand ("CBS News Radio", "BBC", "NPR") before the marker token, defeating the anchor. The keyword path then matched `invasion` unimpeded → critical.
- Fix shipped in three commits on this branch:
  1. **5ec98929c** — initial relax of the prefix anchor to word-boundary.
  2. **f61fae5fe** — tightened to two-branch form after Greptile P2: anchored at start OR brand-prefix slot (Title-Case prefix words + marker + optional qualifier + colon). Adds 5 negative tests covering sentence-form occurrences ("Markets see flashback to 2008 crisis…"), so the L3b LLM-cache guard at `list-feed-digest.ts:547` doesn't widen its blast radius.
  3. **fc1fcbfb2** — bumps `CLASSIFY_CACHE_PREFIX` v4 → v5 in lockstep across all three sites (`_shared.ts`, `list-feed-digest.ts` doc-comment, `ais-relay.cjs`) so existing cache entries that promoted these titles to critical evict immediately rather than waiting for natural TTL.

```diff
- const HISTORICAL_PREFIX_RE = /^(?:science history|throwback|flashback)\s*:?/i;
+ const HISTORICAL_ANCHORED_PREFIX_RE =
+   /^(?:science history|throwback|flashback)\s*:?/i;
+ // No `i` flag — Title-Case enforcement on the brand prefix is load-bearing.
+ const HISTORICAL_BRAND_PREFIX_RE =
+   /^(?:[A-Z][\w'&-]*\s+){1,4}(?:[Tt]hrowback|[Ff]lashback)(?:\s+[A-Za-z]+)?\s*:/;
```

## Test plan

- [x] 8 new test cases under `news-classifier-historical-downgrade.test.mts`:
  - 3 positive — CBS News Radio, BBC, NPR brand-prefix forms (incl. the exact title from brief 2026-04-28-0801)
  - 5 negative — `Markets see flashback to 2008 crisis…`, `Stocks suffer flashback to March 2020 crash`, `Tesla stock throwback after split`, `AI flashback to 2023 boom: Nvidia earnings beat`, lowercase-leading sentence
- [x] All 61 / 61 in `news-classifier-historical-downgrade.test.mts` + `news-classifier-llm-historical-guard.test.mts` pass
- [x] `news-classify-cache-prefix-audit.test.mjs` passes — all 3 sites in lockstep on v5
- [x] `npm run typecheck` + `npm run typecheck:api` — pass
- [x] Touched-file lint clean (pre-existing repo warnings unaffected)
- [x] `npm run test:data` — 7601 / 7601 pass
- [x] `node --test tests/edge-functions.test.mjs` — 178 / 178 pass
- [x] esbuild bundle of all 19 edge entries — pass
- [x] `npm run lint:md` — pass
- [x] `npm run version:check` — pass
- [x] CI on PR: biome / typecheck / unit / changes×3 / mintlify-slugs / Vercel deploy / gate — all green