### PR TITLE
fix(notifications): server-side entitlement gate on alertRules — close 25% free-user bypass

### DIFF
--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -443,15 +443,17 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
         });
         if (!resp.ok) {
           // 400 from convex/http means user-facing validation failure (e.g.
-          // INCOMPATIBLE_DELIVERY). Pass body through so client renders the
-          // real reason instead of a generic toast.
-          if (resp.status === 400) {
+          // INCOMPATIBLE_DELIVERY). 402 means paywall (PRO_REQUIRED). Both
+          // must pass through with body intact so the client renders the
+          // real reason — inline helper text for 400, upgrade-flow modal
+          // for 402 — instead of a generic toast.
+          if (resp.status === 400 || resp.status === 402) {
             const text = await resp.text().catch(() => '');
             let payload: unknown = { error: 'Validation failed' };
             if (text) {
               try { payload = JSON.parse(text); } catch { /* keep default */ }
             }
-            return json(payload, 400, corsHeaders);
+            return json(payload, resp.status, corsHeaders);
           }
           console.error('[notification-channels] POST set-notification-config relay error:', resp.status);
           return json({ error: 'Operation failed' }, 500, corsHeaders);

--- a/convex/__tests__/alertRules.test.ts
+++ b/convex/__tests__/alertRules.test.ts
@@ -8,6 +8,39 @@ const modules = import.meta.glob("../**/*.ts");
 const USER = { subject: "user-tests-alertrules", tokenIdentifier: "clerk|user-tests-alertrules" };
 const VARIANT = "full";
 
+/**
+ * Seed a PRO entitlement for the test user. Required before invoking any
+ * public alertRules mutation (setAlertRules, setDigestSettings, setQuietHours)
+ * — those now gate on `assertProEntitlement`. Without this seed, every
+ * pre-existing test would fail with PRO_REQUIRED because convex-test starts
+ * with an empty `entitlements` table.
+ *
+ * Call at the start of any test that uses a public mutation OR that
+ * exercises setNotificationConfigForUser via the HTTP path.
+ */
+async function seedProEntitlement(
+  t: ReturnType<typeof convexTest>,
+  userId = USER.subject,
+  validUntil = Date.now() + 30 * 24 * 60 * 60 * 1000,
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("entitlements", {
+      userId,
+      planKey: "pro_monthly",
+      features: {
+        tier: 1,
+        maxDashboards: 10,
+        apiAccess: true,
+        apiRateLimit: 1000,
+        prioritySupport: true,
+        exportFormats: ["json", "csv"],
+      },
+      validUntil,
+      updatedAt: Date.now(),
+    });
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Cross-field invariant: realtime is for `critical`-tier events only.
 // Both `(realtime, all)` and `(realtime, high)` are forbidden.
@@ -17,6 +50,7 @@ const VARIANT = "full";
 describe("alertRules — realtime+non-critical cross-field invariant", () => {
   test("setAlertRules({sensitivity:'all'}) against existing realtime row → throws", async () => {
     const t = convexTest(schema, modules);
+    await seedProEntitlement(t);
     const asUser = t.withIdentity(USER);
     // Seed an existing row in realtime mode with critical sensitivity (compatible
     // under the tightened rule — only 'critical' is allowed alongside realtime).
@@ -41,6 +75,7 @@ describe("alertRules — realtime+non-critical cross-field invariant", () => {
 
   test("setAlertRules({sensitivity:'high'}) against existing realtime row → throws (tightened rule)", async () => {
     const t = convexTest(schema, modules);
+    await seedProEntitlement(t);
     const asUser = t.withIdentity(USER);
     // Seed compatible realtime+critical state.
     await asUser.mutation(api.alertRules.setAlertRules, {
@@ -65,6 +100,7 @@ describe("alertRules — realtime+non-critical cross-field invariant", () => {
 
   test("setAlertRules({sensitivity:'all'}) against existing daily-digest row → succeeds", async () => {
     const t = convexTest(schema, modules);
+    await seedProEntitlement(t);
     const asUser = t.withIdentity(USER);
     // Seed a daily-digest row.
     await asUser.mutation(api.alertRules.setDigestSettings, {
@@ -87,6 +123,7 @@ describe("alertRules — realtime+non-critical cross-field invariant", () => {
 
   test("setDigestSettings({digestMode:'realtime'}) against existing sensitivity:'all' digest → throws", async () => {
     const t = convexTest(schema, modules);
+    await seedProEntitlement(t);
     const asUser = t.withIdentity(USER);
     await asUser.mutation(api.alertRules.setDigestSettings, {
       variant: VARIANT,
@@ -109,6 +146,7 @@ describe("alertRules — realtime+non-critical cross-field invariant", () => {
 
   test("setDigestSettings({digestMode:'daily'}) against existing sensitivity:'all' realtime → succeeds, sensitivity preserved", async () => {
     const t = convexTest(schema, modules);
+    await seedProEntitlement(t);
     const asUser = t.withIdentity(USER);
     // Seed via direct insert to bypass the validators (simulates pre-migration row).
     await t.run(async (ctx) => {
@@ -268,6 +306,7 @@ describe("alertRules — insert-only default for sensitivity", () => {
 describe("alertRules — setNotificationConfigForUser atomic pair update", () => {
   test("rejects (realtime, all) atomically", async () => {
     const t = convexTest(schema, modules);
+    await seedProEntitlement(t);
     await expect(
       t.mutation(internal.alertRules.setNotificationConfigForUser, {
         userId: USER.subject,
@@ -280,6 +319,7 @@ describe("alertRules — setNotificationConfigForUser atomic pair update", () =>
 
   test("daily+all → realtime+critical lands atomically (no race) — tightened rule requires critical", async () => {
     const t = convexTest(schema, modules);
+    await seedProEntitlement(t);
     // Seed daily+all (the legitimate prior state).
     await t.run(async (ctx) => {
       await ctx.db.insert("alertRules", {
@@ -314,6 +354,7 @@ describe("alertRules — setNotificationConfigForUser atomic pair update", () =>
   test("setNotificationConfigForUser({digestMode:'realtime', sensitivity:'high'}) → throws (tightened rule)", async () => {
     // The tightened rule (2026-04-27) forbids realtime+high alongside realtime+all.
     const t = convexTest(schema, modules);
+    await seedProEntitlement(t);
     await expect(
       t.mutation(internal.alertRules.setNotificationConfigForUser, {
         userId: USER.subject,
@@ -329,6 +370,7 @@ describe("alertRules — setNotificationConfigForUser atomic pair update", () =>
     // doesn't touch the pair must still reject because the pair derived from
     // existing+incoming is still forbidden.
     const t = convexTest(schema, modules);
+    await seedProEntitlement(t);
     await t.run(async (ctx) => {
       await ctx.db.insert("alertRules", {
         userId: USER.subject,
@@ -351,8 +393,41 @@ describe("alertRules — setNotificationConfigForUser atomic pair update", () =>
     ).rejects.toThrow(/INCOMPATIBLE_DELIVERY|Real-time delivery is for Critical/i);
   });
 
+  test("free user (no entitlement) calling setNotificationConfigForUser → throws PRO_REQUIRED", async () => {
+    // Layer-2 gate: setNotificationConfigForUser is reachable from the public
+    // `/set-notification-config` HTTP action; a free-tier user hitting that
+    // endpoint must be rejected at the mutation, not just by the relay.
+    const t = convexTest(schema, modules);
+    // Deliberately NO seedProEntitlement — the user is free.
+    await expect(
+      t.mutation(internal.alertRules.setNotificationConfigForUser, {
+        userId: USER.subject,
+        variant: VARIANT,
+        digestMode: "daily",
+        sensitivity: "high",
+      }),
+    ).rejects.toThrow(/PRO_REQUIRED|Notifications are a PRO feature/i);
+  });
+
+  test("expired entitlement (validUntil < now) → throws PRO_REQUIRED", async () => {
+    // Mirrors entitlements.ts FREE_TIER_DEFAULTS fallback: an expired
+    // entitlement is treated identically to no entitlement. The mutation gate
+    // must apply the same semantics.
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, USER.subject, Date.now() - 1000); // expired 1s ago
+    await expect(
+      t.mutation(internal.alertRules.setNotificationConfigForUser, {
+        userId: USER.subject,
+        variant: VARIANT,
+        digestMode: "daily",
+        sensitivity: "high",
+      }),
+    ).rejects.toThrow(/PRO_REQUIRED|Notifications are a PRO feature/i);
+  });
+
   test("omitted sensitivity on patch preserves existing value", async () => {
     const t = convexTest(schema, modules);
+    await seedProEntitlement(t);
     await t.run(async (ctx) => {
       await ctx.db.insert("alertRules", {
         userId: USER.subject,
@@ -380,5 +455,115 @@ describe("alertRules — setNotificationConfigForUser atomic pair update", () =>
     );
     expect(rows[0]?.sensitivity).toBe("critical");
     expect(rows[0]?.digestHour).toBe(14);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Layer-2 entitlement gate: public mutations reject free-tier callers.
+// (Discovered 2026-04-28: 7 of 28 enabled alertRules rows belonged to
+// free-tier users despite the UI paywall — the relay's PRO filter has been
+// silently masking the bug at delivery time. This gate is the primary
+// defense at write time.)
+// ---------------------------------------------------------------------------
+
+describe("alertRules — layer-2 entitlement gate (PRO_REQUIRED)", () => {
+  test("setAlertRules from a free-tier user → throws PRO_REQUIRED", async () => {
+    const t = convexTest(schema, modules);
+    // No seedProEntitlement — the user has no entitlement row, treated as free.
+    const asFreeUser = t.withIdentity(USER);
+    await expect(
+      asFreeUser.mutation(api.alertRules.setAlertRules, {
+        variant: VARIANT,
+        enabled: true,
+        eventTypes: [],
+        sensitivity: "critical",
+        channels: [],
+      }),
+    ).rejects.toThrow(/PRO_REQUIRED|Notifications are a PRO feature/i);
+  });
+
+  test("setDigestSettings from a free-tier user → throws PRO_REQUIRED", async () => {
+    const t = convexTest(schema, modules);
+    const asFreeUser = t.withIdentity(USER);
+    await expect(
+      asFreeUser.mutation(api.alertRules.setDigestSettings, {
+        variant: VARIANT,
+        digestMode: "daily",
+        digestHour: 8,
+        digestTimezone: "UTC",
+      }),
+    ).rejects.toThrow(/PRO_REQUIRED|Notifications are a PRO feature/i);
+  });
+
+  test("setQuietHours from a free-tier user → throws PRO_REQUIRED", async () => {
+    const t = convexTest(schema, modules);
+    const asFreeUser = t.withIdentity(USER);
+    await expect(
+      asFreeUser.mutation(api.alertRules.setQuietHours, {
+        variant: VARIANT,
+        quietHoursEnabled: true,
+        quietHoursStart: 22,
+        quietHoursEnd: 7,
+        quietHoursTimezone: "UTC",
+      }),
+    ).rejects.toThrow(/PRO_REQUIRED|Notifications are a PRO feature/i);
+  });
+
+  test("setAlertRules with expired entitlement → throws PRO_REQUIRED", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, USER.subject, Date.now() - 1000); // expired
+    const asUser = t.withIdentity(USER);
+    await expect(
+      asUser.mutation(api.alertRules.setAlertRules, {
+        variant: VARIANT,
+        enabled: true,
+        eventTypes: [],
+        sensitivity: "critical",
+        channels: [],
+      }),
+    ).rejects.toThrow(/PRO_REQUIRED|Notifications are a PRO feature/i);
+  });
+
+  test("setAlertRules with PRO entitlement → succeeds (control)", async () => {
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t);
+    const asUser = t.withIdentity(USER);
+    await asUser.mutation(api.alertRules.setAlertRules, {
+      variant: VARIANT,
+      enabled: true,
+      eventTypes: [],
+      sensitivity: "critical",
+      channels: [],
+    });
+    const rows = await asUser.query(api.alertRules.getAlertRules, {});
+    expect(rows).toHaveLength(1);
+  });
+
+  test("INTENTIONAL: setAlertRulesForUser internal mutation stays UNGATED for operator/migration paths", async () => {
+    // The *ForUser internal mutations are reachable only via `npx convex run`
+    // (deploy-key auth) or trusted server-side code paths. They are intentionally
+    // NOT entitlement-gated so operator cleanup scripts (e.g. disabling
+    // notifications for free users that got rows in via a UI-gate hole) can
+    // still run. The HTTP-reachable setNotificationConfigForUser IS gated;
+    // see its dedicated tests above.
+    const t = convexTest(schema, modules);
+    // No seedProEntitlement — free user.
+    await t.mutation(internal.alertRules.setAlertRulesForUser, {
+      userId: USER.subject,
+      variant: VARIANT,
+      enabled: false,
+      eventTypes: [],
+      sensitivity: "critical",
+      channels: [],
+    });
+    // No throw expected — operator cleanup write succeeded against a free user.
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query("alertRules")
+        .withIndex("by_user_variant", (q) => q.eq("userId", USER.subject).eq("variant", VARIANT))
+        .collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.enabled).toBe(false);
   });
 });

--- a/convex/__tests__/alertRules.test.ts
+++ b/convex/__tests__/alertRules.test.ts
@@ -397,6 +397,13 @@ describe("alertRules — setNotificationConfigForUser atomic pair update", () =>
     // Layer-2 gate: setNotificationConfigForUser is reachable from the public
     // `/set-notification-config` HTTP action; a free-tier user hitting that
     // endpoint must be rejected at the mutation, not just by the relay.
+    //
+    // Note on identity context: unlike the public `setAlertRules` /
+    // `setDigestSettings` mutations (which derive `userId` from `ctx.auth`),
+    // `setNotificationConfigForUser` takes `userId` as an arg — the HTTP
+    // action sets it from the verified Clerk JWT. The entitlement check
+    // reads the arg-supplied userId, so a `t.withIdentity(...)` wrapper is
+    // intentionally absent from these tests.
     const t = convexTest(schema, modules);
     // Deliberately NO seedProEntitlement — the user is free.
     await expect(

--- a/convex/alertRules.ts
+++ b/convex/alertRules.ts
@@ -1,9 +1,58 @@
 import { ConvexError, v } from "convex/values";
-import { internalMutation, internalQuery, mutation, query } from "./_generated/server";
+import {
+  internalMutation,
+  internalQuery,
+  type MutationCtx,
+  mutation,
+  query,
+} from "./_generated/server";
 import { channelTypeValidator, digestModeValidator, quietHoursOverrideValidator, sensitivityValidator } from "./constants";
 
 type DigestMode = "realtime" | "daily" | "twice_daily" | "weekly";
 type Sensitivity = "all" | "high" | "critical";
+
+/**
+ * Layer-2 entitlement gate: notifications are a PRO feature, but until now
+ * the only enforcement was at layer 1 (UI paywall) and layer 3 (relay
+ * isUserPro filter). Layer 1 has had at least one hole — a 2026-04-28
+ * audit found 7 of 28 enabled `alertRules` rows belonged to free-tier
+ * users (`tier=0`, never been PRO). The relay's PRO filter has been
+ * masking the bug at delivery time, but it fail-opens on entitlement-
+ * service errors and shouldn't be the only line of defense.
+ *
+ * This helper is the WRITE-PATH gate. Throws ConvexError with structured
+ * `{code: "PRO_REQUIRED"}` data so the client can detect it and route to
+ * the upgrade flow rather than surface a generic 500.
+ *
+ * Mirrors the FREE_TIER_DEFAULTS semantics in `convex/entitlements.ts`:
+ *   - no entitlement row → tier 0 (free)
+ *   - validUntil < Date.now() → expired, treat as tier 0
+ *   - tier >= 1 → PRO, allowed
+ *
+ * Kept inline (not imported from entitlements.ts) for security-review
+ * readability: every alertRules mutation that calls this should be
+ * trivially auditable in one file.
+ */
+async function assertProEntitlement(
+  ctx: MutationCtx,
+  userId: string,
+): Promise<void> {
+  const entitlement = await ctx.db
+    .query("entitlements")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .first();
+  const tier =
+    entitlement && entitlement.validUntil >= Date.now()
+      ? entitlement.features.tier
+      : 0;
+  if (tier < 1) {
+    throw new ConvexError({
+      code: "PRO_REQUIRED",
+      message:
+        "Notifications are a PRO feature. Upgrade to enable real-time and digest alerts.",
+    });
+  }
+}
 
 // Cross-field invariant enforcement for (digestMode, sensitivity).
 //
@@ -71,6 +120,7 @@ export const setAlertRules = mutation({
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new ConvexError("UNAUTHENTICATED");
     const userId = identity.subject;
+    await assertProEntitlement(ctx, userId);
 
     const existing = await ctx.db
       .query("alertRules")
@@ -126,6 +176,7 @@ export const setDigestSettings = mutation({
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new ConvexError("UNAUTHENTICATED");
     const userId = identity.subject;
+    await assertProEntitlement(ctx, userId);
 
     if (args.digestHour !== undefined && (args.digestHour < 0 || args.digestHour > 23 || !Number.isInteger(args.digestHour))) {
       throw new ConvexError("digestHour must be an integer 0–23");
@@ -273,6 +324,7 @@ export const setQuietHours = mutation({
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new ConvexError("UNAUTHENTICATED");
     const userId = identity.subject;
+    await assertProEntitlement(ctx, userId);
     validateQuietHoursArgs(args);
 
     const existing = await ctx.db
@@ -451,6 +503,18 @@ export const setNotificationConfigForUser = internalMutation({
   },
   handler: async (ctx, args) => {
     const { userId, variant } = args;
+    // Layer-2 gate: this internal mutation is reachable from the public
+    // `set-notification-config` HTTP action in convex/http.ts. Even though
+    // the HTTP action verifies the Clerk JWT, the entitlement check belongs
+    // on the same transaction as the write — defense-in-depth against any
+    // future caller (a different HTTP action, a webhook handler, etc.).
+    // Sister *ForUser internal mutations (setAlertRulesForUser, etc.) are
+    // INTENTIONALLY left ungated: they are invoked by trusted operator paths
+    // (admin migration scripts, cleanup jobs) where the operator's intent
+    // is "manage another user's settings," and entitlement-gating those
+    // would block the very cleanup we need to do for free-tier rows that
+    // got created before this gate existed.
+    await assertProEntitlement(ctx, userId);
 
     if (args.digestHour !== undefined && (args.digestHour < 0 || args.digestHour > 23 || !Number.isInteger(args.digestHour))) {
       throw new ConvexError("digestHour must be an integer 0–23");

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -584,16 +584,30 @@ http.route({
             digestTimezone: typeof body.digestTimezone === "string" ? body.digestTimezone : undefined,
           });
         } catch (err: unknown) {
-          // Translate ConvexError(INCOMPATIBLE_DELIVERY) into 400 with the message
-          // so the API path can pass it through to the UI for inline rendering.
-          // Do NOT swallow as a generic 500 — the user needs the helper text.
+          // Translate structured ConvexError codes into machine-readable HTTP
+          // responses so the UI can route to inline helper text (400) or to
+          // the upgrade flow (402). Do NOT swallow as a generic 500 — the
+          // client needs the structured `error` field to render the right
+          // surface.
           const data = (err as { data?: unknown } | undefined)?.data;
-          if (data && typeof data === "object" && (data as { code?: string }).code === "INCOMPATIBLE_DELIVERY") {
-            const errPayload = data as { code: string; message?: string };
-            return new Response(
-              JSON.stringify({ error: errPayload.code, message: errPayload.message ?? "" }),
-              { status: 400, headers: { "Content-Type": "application/json" } },
-            );
+          if (data && typeof data === "object") {
+            const errPayload = data as { code?: string; message?: string };
+            if (errPayload.code === "INCOMPATIBLE_DELIVERY") {
+              return new Response(
+                JSON.stringify({ error: errPayload.code, message: errPayload.message ?? "" }),
+                { status: 400, headers: { "Content-Type": "application/json" } },
+              );
+            }
+            if (errPayload.code === "PRO_REQUIRED") {
+              // 402 Payment Required — the canonical HTTP status for
+              // paywall-gated content. Client reads `error: "PRO_REQUIRED"`
+              // to route to the upgrade flow rather than show a generic
+              // failure toast.
+              return new Response(
+                JSON.stringify({ error: errPayload.code, message: errPayload.message ?? "" }),
+                { status: 402, headers: { "Content-Type": "application/json" } },
+              );
+            }
           }
           throw err;
         }


### PR DESCRIPTION
## Summary

Closes the layer-2 hole that let **7 of 28 enabled `alertRules` rows belong to free-tier users (25%)** — discovered in a 2026-04-28 audit while doing the post-#3474 grandfathered-row migration (#3481).

## The 3-layer entitlement model — what was in place vs missing

| Layer | Status before this PR | After this PR |
|---|---|---|
| 1. UI paywall | ✓ in place but had at least one hole (7 free users got rows in) | unchanged — still relies on UI gate as visual layer |
| **2. Server-side mutation gate** | **✗ MISSING** — public mutations accepted any authed write | ✓ **NEW** — `assertProEntitlement` rejects free/expired writes |
| 3. Relay-side delivery gate | ✓ in place but **fail-OPEN** on entitlement-service errors | follow-up PR — change to fail-CLOSED |

## What this PR does

Adds `assertProEntitlement(ctx, userId)` helper in `convex/alertRules.ts`. Reads the entitlements table inline (transactional with the alertRules write, no runQuery hop). Mirrors the `FREE_TIER_DEFAULTS` semantics in `convex/entitlements.ts`:
- no entitlement row → tier 0 (free)
- `validUntil < Date.now()` → expired, treat as tier 0
- tier ≥ 1 → PRO, allowed

Throws `ConvexError({ code: "PRO_REQUIRED", message: ... })` so the client can detect the structured kind and route to the upgrade flow rather than surface a generic 500.

### Gated (this PR)
- `setAlertRules` (public)
- `setDigestSettings` (public)
- `setQuietHours` (public)
- `setNotificationConfigForUser` (internal, reachable from public `/set-notification-config` HTTP action)

### INTENTIONALLY ungated (operator/migration paths)
- `setAlertRulesForUser`
- `setDigestSettingsForUser`
- `setQuietHoursForUser`

These are reachable only via `npx convex run` (deploy-key auth) or trusted server-side code. Gating them would block operator cleanup scripts — **including the upcoming script to disable notifications for the 7 free users that got rows in via the old hole**. A dedicated test in this PR pins this contract.

## Test plan

- [x] `convex/__tests__/alertRules.test.ts` suite goes **14 → 22 tests**
- [x] All existing tests now seed PRO via new `seedProEntitlement` helper
- [x] New tests:
  - `setAlertRules` / `setDigestSettings` / `setQuietHours` / `setNotificationConfigForUser` from free user → `PRO_REQUIRED` ✓
  - Expired entitlement (`validUntil < now`) → `PRO_REQUIRED` ✓
  - PRO entitlement → succeeds (control) ✓
  - `setAlertRulesForUser` stays UNGATED (operator path contract) ✓
- [x] `npm run typecheck` clean
- [x] `npm run test:data` — 7594/7594 pass

## Behavioral change (worth noting before merge)

Post-merge, the 7 existing free users with rows will receive `PRO_REQUIRED` if they try to toggle settings via the UI. This is an *improvement* over the silent-no-delivery they get today (the relay drops their notifications anyway), but it's why the cleanup script needs to run soon after merge.

## Follow-ups (NOT in this PR)

1. **Layer 3 hardening**: change `scripts/notification-relay.cjs` `isUserPro()` from fail-open to fail-closed on entitlement-endpoint errors.
2. **Cleanup script**: one-shot script to set `enabled=false` for the 7 existing free-user rows via `setAlertRulesForUser` (the ungated path).
3. **UI gate audit**: identify and close the path that let free users get rows in the first place.