### PR TITLE
fix(relay): isUserPro fail-closed on entitlement-endpoint error (layer 3)

### DIFF
--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -91,6 +91,27 @@ async function deactivateChannel(userId, channelType) {
 
 const ENTITLEMENT_CACHE_TTL = 900; // 15 min
 
+/**
+ * Layer-3 PRO gate. Returns true iff the user has tier>=1 entitlement.
+ *
+ * Fail-CLOSED policy (changed from fail-open in PR #348X following the
+ * 2026-04-28 audit that found 7 of 28 enabled alertRules belonged to free-
+ * tier users — the relay's PRO filter has been silently masking a write-side
+ * gap, but the previous fail-open policy meant any entitlement-endpoint
+ * outage would briefly let those free users receive notifications).
+ *
+ * Three-layer model context:
+ *   - Layer 1 (UI paywall): visual, necessary, insufficient.
+ *   - Layer 2 (server-side mutation gate): primary defense (PR #3483).
+ *   - Layer 3 (THIS function): defense-in-depth at delivery time.
+ *
+ * Cache survives short outages (15-min Upstash TTL). The fail-CLOSED branch
+ * fires only when BOTH cache miss AND remote fetch error — a narrow window.
+ *
+ * Tradeoff: an entitlement-endpoint outage that exceeds cache TTL drops
+ * notifications for legitimate PRO users until recovered. Pair with
+ * monitoring on `[relay][entitlement-fail-closed]` log lines below.
+ */
 async function isUserPro(userId) {
   const cacheKey = `relay:entitlement:${userId}`;
   try {
@@ -104,12 +125,20 @@ async function isUserPro(userId) {
       body: JSON.stringify({ userId }),
       signal: AbortSignal.timeout(5000),
     });
-    if (!res.ok) return true; // fail-open: don't block delivery on entitlement service failure
+    if (!res.ok) {
+      // fail-CLOSED: drop delivery rather than risk exposing a paywalled
+      // feature to a free-tier user during an entitlement-endpoint outage.
+      // Logged with a stable prefix so an alert can fire on volume.
+      console.error(`[relay][entitlement-fail-closed] HTTP ${res.status} for ${userId}; dropping delivery`);
+      return false;
+    }
     const { tier } = await res.json();
     await upstashRest('SET', cacheKey, String(tier ?? 0), 'EX', String(ENTITLEMENT_CACHE_TTL));
     return (tier ?? 0) >= 1;
-  } catch {
-    return true; // fail-open
+  } catch (err) {
+    // Same fail-CLOSED policy on transport error / timeout.
+    console.error(`[relay][entitlement-fail-closed] error for ${userId}: ${err && err.message ? err.message : err}; dropping delivery`);
+    return false;
   }
 }
 

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -89,12 +89,20 @@ async function deactivateChannel(userId, channelType) {
 
 // ── Entitlement check (PRO gate for delivery) ───────────────────────────────
 
-const ENTITLEMENT_CACHE_TTL = 900; // 15 min
+const ENTITLEMENT_CACHE_TTL = 900; // 15 min — success-path cache
+// Short-TTL cache for fail-closed results during entitlement-endpoint
+// outages. Without this, every event during a sustained outage would
+// re-attempt the 5-second fetch per unique user — turning a high-frequency
+// event stream into a continuous 5-sec stall per poll iteration. 60s
+// absorbs a poll burst, recovers quickly when the endpoint comes back.
+// Cache value "0" (free); the success path naturally refreshes with the
+// real tier on the next attempt past TTL.
+const ENTITLEMENT_FAILCLOSED_CACHE_TTL = 60;
 
 /**
  * Layer-3 PRO gate. Returns true iff the user has tier>=1 entitlement.
  *
- * Fail-CLOSED policy (changed from fail-open in PR #348X following the
+ * Fail-CLOSED policy (changed from fail-open in PR #3485 following the
  * 2026-04-28 audit that found 7 of 28 enabled alertRules belonged to free-
  * tier users — the relay's PRO filter has been silently masking a write-side
  * gap, but the previous fail-open policy meant any entitlement-endpoint
@@ -105,12 +113,14 @@ const ENTITLEMENT_CACHE_TTL = 900; // 15 min
  *   - Layer 2 (server-side mutation gate): primary defense (PR #3483).
  *   - Layer 3 (THIS function): defense-in-depth at delivery time.
  *
- * Cache survives short outages (15-min Upstash TTL). The fail-CLOSED branch
- * fires only when BOTH cache miss AND remote fetch error — a narrow window.
+ * Caching:
+ *   - Success path: 15-min Upstash TTL.
+ *   - Fail-closed paths (HTTP non-OK, transport error, timeout): cache "0"
+ *     with 60s TTL — see ENTITLEMENT_FAILCLOSED_CACHE_TTL note above.
  *
- * Tradeoff: an entitlement-endpoint outage that exceeds cache TTL drops
- * notifications for legitimate PRO users until recovered. Pair with
- * monitoring on `[relay][entitlement-fail-closed]` log lines below.
+ * Tradeoff: an entitlement-endpoint outage drops notifications for
+ * legitimate PRO users for up to 60s after each cache miss. Pair with
+ * monitoring on `[relay][entitlement-fail-closed]` log lines.
  */
 async function isUserPro(userId) {
   const cacheKey = `relay:entitlement:${userId}`;
@@ -128,16 +138,21 @@ async function isUserPro(userId) {
     if (!res.ok) {
       // fail-CLOSED: drop delivery rather than risk exposing a paywalled
       // feature to a free-tier user during an entitlement-endpoint outage.
-      // Logged with a stable prefix so an alert can fire on volume.
+      // Cache "0" with short TTL so subsequent events for this user during
+      // the same outage skip the 5-sec fetch. Logged with stable prefix
+      // for alerting on volume.
       console.error(`[relay][entitlement-fail-closed] HTTP ${res.status} for ${userId}; dropping delivery`);
+      try { await upstashRest('SET', cacheKey, '0', 'EX', String(ENTITLEMENT_FAILCLOSED_CACHE_TTL)); } catch { /* cache write best-effort */ }
       return false;
     }
     const { tier } = await res.json();
     await upstashRest('SET', cacheKey, String(tier ?? 0), 'EX', String(ENTITLEMENT_CACHE_TTL));
     return (tier ?? 0) >= 1;
   } catch (err) {
-    // Same fail-CLOSED policy on transport error / timeout.
+    // Same fail-CLOSED policy on transport error / timeout. Same short-TTL
+    // cache write so we don't re-attempt the 5-sec fetch for every event.
     console.error(`[relay][entitlement-fail-closed] error for ${userId}: ${err && err.message ? err.message : err}; dropping delivery`);
+    try { await upstashRest('SET', cacheKey, '0', 'EX', String(ENTITLEMENT_FAILCLOSED_CACHE_TTL)); } catch { /* cache write best-effort */ }
     return false;
   }
 }


### PR DESCRIPTION
## Summary

Companion to **#3483** (server-side mutation gate, layer 2). The 2026-04-28 audit found 7 of 28 enabled `alertRules` rows belonged to free-tier users — the relay's PRO filter has been silently masking a write-side gap.

With #3483 closing the write path (layer 2), this PR tightens the delivery path (layer 3) so an entitlement-endpoint outage no longer exposes paywalled notifications to the legacy free-user rows that still exist (until the upcoming cleanup script disables them).

## Change

`scripts/notification-relay.cjs:isUserPro()` — both error branches flip from `return true` (fail-open) to `return false` (fail-closed):

```diff
-    if (!res.ok) return true; // fail-open: don't block delivery on entitlement service failure
+    if (!res.ok) {
+      console.error(`[relay][entitlement-fail-closed] HTTP ${res.status} for ${userId}; dropping delivery`);
+      return false;
+    }
     ...
-  } catch {
-    return true; // fail-open
+  } catch (err) {
+    console.error(`[relay][entitlement-fail-closed] error for ${userId}: ...; dropping delivery`);
+    return false;
   }
```

Logged with stable `[relay][entitlement-fail-closed]` prefix so an uptime/alerting rule can fire on volume.

## Tradeoff

A real entitlement-endpoint outage that exceeds the 15-min Upstash cache TTL drops notifications for legitimate PRO users until recovered. The cache covers all warm users, so the blast radius is limited to:
- (a) cold-start users in the first 15 min of the next event arriving for them, AND
- (b) any user whose cache entry expired during the outage.

Acceptable bias: better to drop legit-user delivery than expose the feature to free users.

## Test plan

- [x] `node -c scripts/notification-relay.cjs` — syntax clean
- [x] `npm run typecheck` — clean
- [x] No code or test changes outside the single function. Cache-hit path unchanged. Success path unchanged. Only the two error branches change behavior.

## Follow-up monitoring

Once merged + deployed, set an alert on the Railway logs for the `[relay][entitlement-fail-closed]` prefix. A spike indicates entitlement-endpoint health degradation; a sustained presence indicates ongoing outage and needs paging.

## Sequence (3-layer entitlement gate)

| PR | Layer | Status |
|---|---|---|
| #3483 | Layer 2 — server-side mutation gate | open |
| **this PR** | Layer 3 — relay fail-closed | **open** |
| (next) | Cleanup script for the 7 grandfathered free-user rows | queued |
| (next) | UI gate audit | manual / out of agent scope |