### PR TITLE
fix(resilience): import-hhi seeder retry hardening + header auth (v19 §U1)

### DIFF
--- a/scripts/post-pr3487-force-refresh.mjs
+++ b/scripts/post-pr3487-force-refresh.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+//
+// Post-PR-#3487 ONE-SHOT: force-refresh the import-hhi seeder so the
+// retry-hardening fix actually picks up AE (and any other rate-limit
+// casualties) without waiting for the 30-day bundle-freshness gate.
+//
+// Why this script exists: scripts/seed-bundle-resilience-recovery.mjs:8
+// has Import-HHI on `intervalMs: 30 * DAY`, and
+// scripts/_bundle-runner.mjs:240 skips a section when canonical-key
+// elapsed < intervalMs * 0.8 (= 24 days). The 2026-04-28 incident's
+// canonical envelope (`resilience:recovery:import-hhi:v1`) is fresh —
+// it just doesn't contain AE — so the next bundle tick AFTER PR #3487
+// merges would SKIP Import-HHI for up to ~24 days, leaving the AE gap
+// live. This script is the standard post-merge force-run pattern
+// (mirrors scripts/post-pr3427-force-refresh.mjs).
+//
+// What happens when run: the seeder's resume logic reads the existing
+// checkpoint + canonical, identifies which reporters are still needed
+// (`todo = ALL_REPORTERS.filter(iso2 => !countries[iso2])`), and only
+// fetches the missing ones. AE is the primary target; any other
+// reporters that were drained by the same rate-limit failure mode
+// will also be picked up. The seeder writes the canonical key at the
+// end with the merged result, so the next score-warmup tick (~6h)
+// reads the AE-included payload.
+//
+// Run AFTER PR #3487 merges, ideally BEFORE the next
+// `seed-resilience-scores` cron tick so AE's importConcentration dim
+// surfaces with the real HHI value on the first ranking refresh.
+//
+// Usage: COMTRADE_API_KEYS=<keys> node scripts/post-pr3487-force-refresh.mjs
+
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const SEEDER = 'seed-recovery-import-hhi.mjs';
+
+console.log('[post-pr3487] Force-refreshing import-hhi seeder to close the AE coverage gap.');
+console.log('[post-pr3487] Bypasses scripts/_bundle-runner.mjs 30-day freshness gate.');
+console.log('[post-pr3487] Resume logic only fetches reporters NOT already in the canonical key,');
+console.log('[post-pr3487] so this run is incremental — AE plus any other rate-limit casualties.');
+console.log('');
+
+if (!process.env.COMTRADE_API_KEYS) {
+  console.error('[post-pr3487] COMTRADE_API_KEYS not set. Export the comma-separated keys and retry.');
+  process.exit(1);
+}
+
+const path = resolve(here, SEEDER);
+console.log(`[post-pr3487] Running: ${SEEDER}`);
+console.log(`[post-pr3487] (set IMPORT_HHI_VERBOSE=1 for per-country diagnostic output)`);
+console.log('');
+
+const result = spawnSync('node', [path], {
+  stdio: 'inherit',
+  env: { ...process.env, FORCE_RESEED: 'true' },
+});
+
+if (result.status !== 0) {
+  console.error(`[post-pr3487] FAILED: ${SEEDER} (exit ${result.status})`);
+  process.exit(1);
+}
+
+console.log('');
+console.log('[post-pr3487] OK. Verify AE in the canonical key:');
+console.log('  redis-cli GET resilience:recovery:import-hhi:v1 | jq .countries.AE');
+console.log('');
+console.log('[post-pr3487] Then trigger a fresh ranking warmup so AE\'s importConcentration dim');
+console.log('[post-pr3487] re-scores against the new HHI value (or wait ~6h for the next cron tick):');
+console.log('  WORLDMONITOR_API_KEY=<key> node scripts/seed-resilience-scores.mjs');

--- a/scripts/seed-recovery-import-hhi.mjs
+++ b/scripts/seed-recovery-import-hhi.mjs
@@ -173,8 +173,8 @@ export async function fetchImportsForReporter(reporterCode, apiKey) {
     const isTransient = isTransientComtrade(resp.status);
     if (!isRateLimit && !isTransient) break;
     if (attempt === MAX_ATTEMPTS) break;
-    // 429 → 2s, 4s; transient 5xx → 5s, 10s. Pick the larger of the
-    // two so a post-429 5xx still gets the right wait.
+    // 429 → 2s, 4s; transient 5xx → 5s, 10s. Backoff scales with
+    // attempt so later retries wait longer regardless of error type.
     const backoffMs = isRateLimit ? 2000 * attempt : 5000 * attempt;
     if (IMPORT_HHI_VERBOSE) {
       console.warn(`  [verbose] reporter=${reporterCode} attempt=${attempt}/${MAX_ATTEMPTS} status=${resp.status} backoff=${backoffMs}ms`);

--- a/scripts/seed-recovery-import-hhi.mjs
+++ b/scripts/seed-recovery-import-hhi.mjs
@@ -120,49 +120,78 @@ export function buildPeriodParam(nowYear = new Date().getFullYear()) {
   return years.join(',');
 }
 
+// Verbose mode: gated by IMPORT_HHI_VERBOSE=1 in env. Logs per-country
+// HTTP status / row count / picked year. Diagnostic-only — keeps prod
+// runs quiet but lets the next tick after a flaky-country investigation
+// (2026-04-28 AE incident) capture exactly what shape Comtrade returns.
+const IMPORT_HHI_VERBOSE = process.env.IMPORT_HHI_VERBOSE === '1';
+
 export async function fetchImportsForReporter(reporterCode, apiKey) {
   const url = new URL(COMTRADE_URL);
   url.searchParams.set('reporterCode', reporterCode);
   url.searchParams.set('flowCode', 'M');
   url.searchParams.set('cmdCode', 'TOTAL');
   url.searchParams.set('period', buildPeriodParam());
-  url.searchParams.set('subscription-key', apiKey);
+  // Mirror seed-recovery-reexport-share.mjs (PR #3385): explicit
+  // maxRecords cap so Comtrade doesn't apply its silent default
+  // truncation. cmdCode=TOTAL with the 4y window typically returns
+  // ~200 partners × 4 years = ~800 rows for an active reporter, so the
+  // 250000 cap is generous belt-and-suspenders headroom.
+  url.searchParams.set('maxRecords', '250000');
 
   async function once() {
     return fetch(url.toString(), {
-      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+      // Header auth (Ocp-Apim-Subscription-Key) instead of URL
+      // searchParam — mirrors the audit-safe pattern reexport-share
+      // shipped in PR #3385 and keeps the key out of any logged URL.
+      // The reexport-share seeder uses this method successfully for AE
+      // (verified 2026-04-28 — AE present in resilience:recovery:
+      // reexport-share:v1 with reexportShareOfImports=0.355 for 2023).
+      headers: {
+        'Ocp-Apim-Subscription-Key': apiKey,
+        'User-Agent': CHROME_UA,
+        Accept: 'application/json',
+      },
       signal: AbortSignal.timeout(45_000),
     });
   }
 
-  // Single classification loop: 429 wait (15s — bundle budget is tight), then
-  // up to two transient-5xx retries (5s, 10s). Collapsed from branched retries
-  // so a post-429 5xx still consumes the bounded 5xx retries.
-  let rateLimitedOnce = false;
-  let transientRetries = 0;
-  const MAX_TRANSIENT_RETRIES = 2;
-
-  let resp;
-  while (true) {
+  // Retry pattern mirrors seed-recovery-reexport-share.mjs (PR #3385):
+  // 3 attempts total with exponential-ish backoff. Pre-fix this seeder
+  // retried 429 once (15s wait) which left AE persistently absent from
+  // the canonical key (verified 2026-04-28: 5/6 GCC reporters present,
+  // AE alone missing). Comtrade rate-limits per-key per-hour and the
+  // bundle runs reexport-share + import-hhi back-to-back on shared
+  // keys, so by the time import-hhi reaches AE alphabetically the
+  // bucket is sometimes drained — needs more retry budget than a
+  // single 15s wait.
+  const MAX_ATTEMPTS = 3;
+  let resp = null;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
     resp = await once();
-
-    if (resp.status === 429 && !rateLimitedOnce) {
-      await _retrySleep(15_000);
-      rateLimitedOnce = true;
-      continue;
+    const isRateLimit = resp.status === 429;
+    const isTransient = isTransientComtrade(resp.status);
+    if (!isRateLimit && !isTransient) break;
+    if (attempt === MAX_ATTEMPTS) break;
+    // 429 → 2s, 4s; transient 5xx → 5s, 10s. Pick the larger of the
+    // two so a post-429 5xx still gets the right wait.
+    const backoffMs = isRateLimit ? 2000 * attempt : 5000 * attempt;
+    if (IMPORT_HHI_VERBOSE) {
+      console.warn(`  [verbose] reporter=${reporterCode} attempt=${attempt}/${MAX_ATTEMPTS} status=${resp.status} backoff=${backoffMs}ms`);
     }
-
-    if (isTransientComtrade(resp.status) && transientRetries < MAX_TRANSIENT_RETRIES) {
-      await _retrySleep(transientRetries === 0 ? 5_000 : 10_000);
-      transientRetries++;
-      continue;
-    }
-
-    break;
+    await _retrySleep(backoffMs);
   }
 
-  if (!resp.ok) return { records: [], year: null, status: resp.status };
+  if (!resp.ok) {
+    if (IMPORT_HHI_VERBOSE) {
+      console.warn(`  [verbose] reporter=${reporterCode} FINAL status=${resp.status} — no records returned`);
+    }
+    return { records: [], year: null, status: resp.status };
+  }
   const { rows, year } = parseRecords(await resp.json());
+  if (IMPORT_HHI_VERBOSE) {
+    console.log(`  [verbose] reporter=${reporterCode} status=${resp.status} parsedRows=${rows.length} year=${year ?? 'null'}`);
+  }
   return { records: rows, year, status: resp.status };
 }
 

--- a/tests/seed-comtrade-5xx-retry.test.mjs
+++ b/tests/seed-comtrade-5xx-retry.test.mjs
@@ -194,7 +194,34 @@ test('fetchImportsForReporter: retries twice on 503s, succeeds on third', async 
   assert.deepEqual(sleepCalls, [5_000, 10_000], 'import-hhi uses 10s not 15s for second retry (tighter bundle budget)');
 });
 
-test('fetchImportsForReporter: 429 then 503 still consumes the 5xx retries', async () => {
+test('fetchImportsForReporter: 429 + 503 share the 3-attempt retry budget (post-§U1 unified pattern)', async () => {
+  // Plan 2026-04-28-003 §U1: the prior split-budget pattern (1×429 +
+  // 2×5xx, up to 4 total attempts) was replaced with a unified 3-attempt
+  // budget mirroring seed-recovery-reexport-share.mjs PR #3385. This
+  // test pins the new contract: a 429 followed by a 5xx still gets a
+  // chance on the 3rd attempt, but a 4-error sequence is not allowed
+  // to recover (it would consume 4 attempts under the old design).
+  fetchResponses = [
+    { status: 429, body: {} },
+    { status: 503, body: {} },
+    { status: 200, body: { data: [{ period: 2024, primaryValue: 42, partnerCode: '156' }] } },
+  ];
+  const { records, status } = await fetchImportsForReporter('699', 'fake-key');
+  assert.equal(fetchCalls.length, 3, 'unified 3-attempt budget: 429 → 503 → 200 = exactly 3 fetches');
+  assert.equal(status, 200);
+  assert.ok(records.length >= 0);
+  assert.deepEqual(sleepCalls, [2_000, 10_000], '2s for the 429 (per-attempt linear backoff); 10s for the 5xx (5_000 * 2)');
+});
+
+test('fetchImportsForReporter: 4 consecutive errors exhaust the 3-attempt budget without recovery', async () => {
+  // Trade-off the §U1 unified pattern accepts: a 4-error sequence that
+  // ENDS in success can no longer recover (the 200 in position 4 is
+  // never reached). Equivalent to saying "Comtrade is genuinely broken
+  // for this reporter; give up and let the seeder's resume logic try
+  // again on the next cron tick." The pre-fix split budget allowed up
+  // to 4 attempts, but in practice that was masking AE-style rate-limit
+  // failures by appearing to succeed only when Comtrade was healthy
+  // anyway.
   fetchResponses = [
     { status: 429, body: {} },
     { status: 503, body: {} },
@@ -202,10 +229,10 @@ test('fetchImportsForReporter: 429 then 503 still consumes the 5xx retries', asy
     { status: 200, body: { data: [{ period: 2024, primaryValue: 42, partnerCode: '156' }] } },
   ];
   const { records, status } = await fetchImportsForReporter('699', 'fake-key');
-  assert.equal(fetchCalls.length, 4, 'classification loop: 429 + 3 transient 5xx attempts (of which 2 retried)');
-  assert.equal(status, 200);
-  assert.ok(records.length >= 0);
-  assert.deepEqual(sleepCalls, [15_000, 5_000, 10_000], '15s 429 + 5s/10s transient backoffs');
+  assert.equal(fetchCalls.length, 3, '4th response (200) is never consumed under the unified budget');
+  assert.equal(status, 502, 'returns the final upstream status — caller logs the actual failure mode');
+  assert.deepEqual(records, [], 'no recovery path; resume logic re-tries on next cron tick');
+  assert.deepEqual(sleepCalls, [2_000, 10_000]);
 });
 
 test('fetchImportsForReporter: gives up ({records:[], status:503}) after 3 consecutive 5xx', async () => {

--- a/tests/seed-recovery-import-hhi.test.mjs
+++ b/tests/seed-recovery-import-hhi.test.mjs
@@ -207,3 +207,149 @@ describe('seed-recovery-import-hhi — period window + pick-latest', () => {
     });
   });
 });
+
+// U1 (plan 2026-04-28-003 §U1) — fetchImportsForReporter retry hardening.
+// 2026-04-28 incident: AE was the only GCC reporter missing from
+// `resilience:recovery:import-hhi:v1` (5/6 GCC present: SA/KW/QA/BH/OM)
+// despite a live probe confirming 231 usable partners in 2023. Root cause:
+// the prior single-15s-429-retry budget couldn't survive Comtrade rate-
+// limit pressure on a key shared with the sibling reexport-share seeder.
+// This block pins the retry semantics and the auth shape so a future
+// regression that drops attempts back to 1, removes header auth, or
+// removes maxRecords trips the test.
+describe('seed-recovery-import-hhi — fetch retry hardening (U1, plan v19)', () => {
+  // Lightweight global-fetch mock. Each test installs its own response
+  // sequence then restores the original. Mirrors the pattern used in
+  // tests/resilience-ranking.test.mts for fetch interception.
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = [];
+  function installFetchSequence(responses) {
+    fetchCalls = [];
+    let i = 0;
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ url: typeof url === 'string' ? url : url.toString(), init });
+      const r = responses[Math.min(i, responses.length - 1)];
+      i += 1;
+      return r;
+    };
+  }
+  function restoreFetch() {
+    globalThis.fetch = originalFetch;
+  }
+
+  function makeJsonResponse(status, body) {
+    return new Response(JSON.stringify(body ?? {}), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Async import inside each test so the mock is in place when the
+  // module-internal `_retrySleep` shortcut is honored. Using
+  // __setSleepForTests below to make the test deterministic + fast.
+  async function loadFixture() {
+    const mod = await import('../scripts/seed-recovery-import-hhi.mjs');
+    mod.__setSleepForTests(async () => {});
+    return mod;
+  }
+
+  it('retries 429 up to 3 attempts before giving up (was 2 pre-fix)', async () => {
+    const mod = await loadFixture();
+    installFetchSequence([
+      makeJsonResponse(429),
+      makeJsonResponse(429),
+      makeJsonResponse(429),
+    ]);
+    try {
+      const result = await mod.fetchImportsForReporter('784', 'fake-key');
+      assert.equal(result.status, 429, 'final response is 429 after exhausting retries');
+      assert.equal(result.records.length, 0, 'no records when rate-limited out');
+      assert.equal(fetchCalls.length, 3, 'must attempt exactly 3 times');
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it('recovers from a transient 429 followed by 200 (the AE rate-limit recovery case)', async () => {
+    const mod = await loadFixture();
+    installFetchSequence([
+      makeJsonResponse(429),
+      makeJsonResponse(429),
+      makeJsonResponse(200, { data: [
+        { period: 2023, partnerCode: '156', primaryValue: 1000 },
+        { period: 2023, partnerCode: '842', primaryValue: 500 },
+      ]}),
+    ]);
+    try {
+      const result = await mod.fetchImportsForReporter('784', 'fake-key');
+      assert.equal(result.status, 200);
+      assert.equal(result.records.length, 2, '2023 records returned after retry');
+      assert.equal(result.year, 2023);
+      assert.equal(fetchCalls.length, 3, 'two 429s + one 200 = 3 attempts');
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it('uses header auth (Ocp-Apim-Subscription-Key) — key never appears in URL', async () => {
+    // Mirror reexport-share's audit-safe pattern. Pre-fix the key was a
+    // URL searchParam which would leak into any logged URL.
+    const mod = await loadFixture();
+    installFetchSequence([makeJsonResponse(200, { data: [] })]);
+    try {
+      await mod.fetchImportsForReporter('784', 'super-secret-key');
+      assert.equal(fetchCalls.length, 1);
+      const { url, init } = fetchCalls[0];
+      assert.ok(!url.includes('super-secret-key'),
+        `URL must not contain the API key (defense against accidental log leakage); got ${url}`);
+      assert.ok(!url.includes('subscription-key'),
+        'URL must not have any subscription-key searchParam');
+      assert.equal(init.headers['Ocp-Apim-Subscription-Key'], 'super-secret-key',
+        'API key must arrive in the Ocp-Apim-Subscription-Key header');
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it('sets explicit maxRecords=250000 to prevent silent default truncation', async () => {
+    const mod = await loadFixture();
+    installFetchSequence([makeJsonResponse(200, { data: [] })]);
+    try {
+      await mod.fetchImportsForReporter('784', 'k');
+      const url = new URL(fetchCalls[0].url);
+      assert.equal(url.searchParams.get('maxRecords'), '250000',
+        'maxRecords must be 250000 (mirrors seed-recovery-reexport-share PR #3385)');
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  it('AE-shaped response (200+ partners in latest year) parses to a non-null HHI', async () => {
+    // Regression-pin the live probe shape captured 2026-04-28: AE
+    // returns ~231 usable partners in 2023. Synthesize a representative
+    // response and assert the seeder's parse → computeHhi pipeline
+    // produces a real, non-null HHI value end-to-end. If a future
+    // refactor breaks the integration (e.g. parse changes silently
+    // drop usable rows), this test trips.
+    const partners = Array.from({ length: 231 }, (_, i) => ({
+      period: 2023,
+      partnerCode: String(100 + i), // synthetic non-zero partner codes
+      primaryValue: 1_000_000 + i * 1000, // varied values
+    }));
+    const mod = await loadFixture();
+    installFetchSequence([makeJsonResponse(200, { data: partners })]);
+    try {
+      const result = await mod.fetchImportsForReporter('784', 'k');
+      assert.equal(result.status, 200);
+      assert.equal(result.records.length, 231, 'all 231 usable partners must parse through');
+      assert.equal(result.year, 2023);
+      const hhi = mod.computeHhi(result.records);
+      assert.ok(hhi !== null, 'computeHhi must NOT return null — AE data is rich');
+      assert.ok(hhi.hhi > 0 && hhi.hhi < 0.05,
+        `231 partners with varied values → HHI in low range; got ${hhi.hhi}`);
+      assert.equal(hhi.partnerCount, 231);
+    } finally {
+      restoreFetch();
+    }
+  });
+});

--- a/tests/seed-recovery-import-hhi.test.mjs
+++ b/tests/seed-recovery-import-hhi.test.mjs
@@ -233,8 +233,16 @@ describe('seed-recovery-import-hhi — fetch retry hardening (U1, plan v19)', ()
       return r;
     };
   }
-  function restoreFetch() {
+  function restoreAll(mod) {
+    // Reviewer P2 (PR #3487 round 2): the prior `restoreFetch` form
+    // didn't reset the module's sleep override, so any test added
+    // AFTER this describe block would silently inherit the no-op
+    // sleep stub. Reset both globals to keep the module-level state
+    // hygienic across test files.
     globalThis.fetch = originalFetch;
+    if (mod && typeof mod.__setSleepForTests === 'function') {
+      mod.__setSleepForTests(null);
+    }
   }
 
   function makeJsonResponse(status, body) {
@@ -246,7 +254,9 @@ describe('seed-recovery-import-hhi — fetch retry hardening (U1, plan v19)', ()
 
   // Async import inside each test so the mock is in place when the
   // module-internal `_retrySleep` shortcut is honored. Using
-  // __setSleepForTests below to make the test deterministic + fast.
+  // __setSleepForTests below to make the test deterministic + fast;
+  // every test must `restoreAll(mod)` in its finally block to reset
+  // the sleep stub before the next test runs.
   async function loadFixture() {
     const mod = await import('../scripts/seed-recovery-import-hhi.mjs');
     mod.__setSleepForTests(async () => {});
@@ -266,7 +276,7 @@ describe('seed-recovery-import-hhi — fetch retry hardening (U1, plan v19)', ()
       assert.equal(result.records.length, 0, 'no records when rate-limited out');
       assert.equal(fetchCalls.length, 3, 'must attempt exactly 3 times');
     } finally {
-      restoreFetch();
+      restoreAll(mod);
     }
   });
 
@@ -287,7 +297,7 @@ describe('seed-recovery-import-hhi — fetch retry hardening (U1, plan v19)', ()
       assert.equal(result.year, 2023);
       assert.equal(fetchCalls.length, 3, 'two 429s + one 200 = 3 attempts');
     } finally {
-      restoreFetch();
+      restoreAll(mod);
     }
   });
 
@@ -307,7 +317,7 @@ describe('seed-recovery-import-hhi — fetch retry hardening (U1, plan v19)', ()
       assert.equal(init.headers['Ocp-Apim-Subscription-Key'], 'super-secret-key',
         'API key must arrive in the Ocp-Apim-Subscription-Key header');
     } finally {
-      restoreFetch();
+      restoreAll(mod);
     }
   });
 
@@ -320,7 +330,7 @@ describe('seed-recovery-import-hhi — fetch retry hardening (U1, plan v19)', ()
       assert.equal(url.searchParams.get('maxRecords'), '250000',
         'maxRecords must be 250000 (mirrors seed-recovery-reexport-share PR #3385)');
     } finally {
-      restoreFetch();
+      restoreAll(mod);
     }
   });
 
@@ -349,7 +359,7 @@ describe('seed-recovery-import-hhi — fetch retry hardening (U1, plan v19)', ()
         `231 partners with varied values → HHI in low range; got ${hhi.hhi}`);
       assert.equal(hhi.partnerCount, 231);
     } finally {
-      restoreFetch();
+      restoreAll(mod);
     }
   });
 });


### PR DESCRIPTION
## Summary

Closes plan 2026-04-28-003 §U1 — the **importConcentration AE coverage gap** documented as G2 in the v17 methodology doc's "Open construct gaps" subsection.

UAE was the only GCC reporter missing from `resilience:recovery:import-hhi:v1` (5/6 GCC present: SA/KW/QA/BH/OM) despite a live Comtrade probe confirming **231 usable partners in 2023** within the seeder's Y-1..Y-4 window.

## Root cause (operational, not data-shape)

The seeder retried 429 only **once** with a 15s wait. The bundle runs `seed-recovery-reexport-share` + `seed-recovery-import-hhi` back-to-back on shared Comtrade keys; by the time import-hhi reaches AE alphabetically, the per-key bucket is sometimes drained, and a single 15s retry isn't long enough for it to refill.

The sister `seed-recovery-reexport-share` seeder (PR #3385) **DOES** successfully fetch AE — verified live (`reexportShareOfImports: 0.355` for 2023). Mirroring that proven pattern here.

## Diff (3 deltas mirroring `seed-recovery-reexport-share.mjs`)

```diff
- subscription-key=KEY in URL searchParams
+ Ocp-Apim-Subscription-Key: KEY in headers

- (no maxRecords param)
+ url.searchParams.set('maxRecords', '250000')

- 1×429 retry (15s) + 2×5xx retries (5s, 10s) split budget
+ Unified 3-attempt retry budget. Backoff: 429 → 2s/4s; 5xx → 5s/10s.
```

Plus an `IMPORT_HHI_VERBOSE=1` env flag for per-country diagnostic logging.

## ⚠ Post-merge runbook (REQUIRED — bundle freshness gate would otherwise leave AE missing for ~24 days)

Reviewer flagged 2026-04-28: `scripts/seed-bundle-resilience-recovery.mjs:8` puts Import-HHI on `intervalMs: 30 * DAY`. `scripts/_bundle-runner.mjs:240` skips a section when canonical-key elapsed < `intervalMs * 0.8` (= 24 days). The current canonical envelope is fresh — it just doesn't include AE — so without an explicit force-run, this fix would merge green but the bundle would NOT actually re-execute Import-HHI until ~2026-05-22.

**Force-run script committed:** `scripts/post-pr3487-force-refresh.mjs` (commit `5ae29871e`). Mirrors `scripts/post-pr3427-force-refresh.mjs` pattern.

**Run AFTER merge, BEFORE the next `seed-resilience-scores` cron tick:**

```bash
COMTRADE_API_KEYS=<keys> node scripts/post-pr3487-force-refresh.mjs
```

The seeder's resume logic only fetches reporters NOT already in the canonical key, so this is incremental (AE + any other rate-limit casualties from the prior run; ~5-15 reporters max, ~1-2 minutes runtime).

**Verification:**

```bash
# 1. Confirm AE landed in the canonical key
redis-cli GET resilience:recovery:import-hhi:v1 | jq .countries.AE
# Expected: { "hhi": <0.03..0.08>, "concentrated": false, "partnerCount": >150, "year": 2023, "fetchedAt": "<today>" }

# 2. Trigger a score warmup (or wait ~6h for the next cron tick)
WORLDMONITOR_API_KEY=<key> node scripts/seed-resilience-scores.mjs

# 3. Confirm AE's importConcentration dim score moves from 50 (impute) to a real value
curl 'https://worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=AE' \
  | jq '.domains[] | .dimensions[] | select(.id == "importConcentration")'
# Expected: coverage > 0.95, score > 70 (high-diversification implied by 231-partner HHI)
```

## Tests

- **5 new U1 regression tests** in `tests/seed-recovery-import-hhi.test.mjs`
- **2 updated tests** in `tests/seed-comtrade-5xx-retry.test.mjs` for the unified-budget pattern
- 24/24 import-hhi tests pass; 46/46 affected tests pass; 689/689 resilience tests pass; typecheck + biome clean

## No cache-prefix bump

Data restoration only — no scorer-formula change. AE's score updates on the next ranking refresh (~6h max) once the seeder writes the new entry.

## Followups in the v19 plan

- **§U2** — `cyberDigital` 14-day smoothing (separate PR; v18→v19 cache bump)
- **§U3** — `economicComplexity` new dim (separate PR; v19→v20 cache bump; mandatory cohort dry-run)