### PR TITLE
chore(proto): auto-commit generated artifacts for internal PRs

### DIFF
--- a/.github/workflows/proto-check.yml
+++ b/.github/workflows/proto-check.yml
@@ -10,25 +10,69 @@ on:
       - '.github/workflows/proto-check.yml'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  proto-freshness:
+  fork-proto-check:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout fork PR merge commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Check generated artifacts are included
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA"...HEAD -- proto src/generated docs/api Makefile .github/workflows/proto-check.yml || true)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No proto or generated artifact changes detected."
+            exit 0
+          fi
+
+          echo "Changed proto/codegen files:"
+          echo "$CHANGED_FILES"
+
+          PROTO_CHANGED=$(printf '%s\n' "$CHANGED_FILES" | grep -E '^proto/' || true)
+          GENERATED_CHANGED=$(printf '%s\n' "$CHANGED_FILES" | grep -E '^(src/generated/|docs/api/)' || true)
+
+          if [ -n "$PROTO_CHANGED" ] && [ -z "$GENERATED_CHANGED" ]; then
+            echo ""
+            echo "============================================================"
+            echo "ERROR: Proto files changed without committed generated artifacts."
+            echo "This PR comes from a fork, so CI does not execute the fork's Makefile,"
+            echo "buf.gen.yaml, or code generator configuration."
+            echo "Run 'make generate' locally and commit any changes under:"
+            echo "  - src/generated/"
+            echo "  - docs/api/"
+            echo "A maintainer can run the full freshness check from an internal branch."
+            echo "============================================================"
+            exit 1
+          fi
+
+          echo ""
+          echo "Fork PR proto safety check passed."
+          echo "CI did not execute generator code from the fork."
+
+  internal-auto-generate:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      pushed: ${{ steps.commit.outputs.pushed }}
     concurrency:
       group: proto-freshness-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
       - name: Checkout internal PR branch
-        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Checkout fork PR merge commit
-        if: github.event.pull_request.head.repo.full_name != github.repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
@@ -50,13 +94,14 @@ jobs:
       - name: Run proto generation
         run: make generate
 
-      - name: Commit generated artifacts for internal PRs
-        if: github.event.pull_request.head.repo.full_name == github.repository
+      - name: Commit generated artifacts
+        id: commit
         env:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if git diff --quiet -- src/generated/ docs/api/ && [ -z "$(git ls-files --others --exclude-standard src/generated/ docs/api/)" ]; then
-            echo "Proto-generated code is up to date."
+            echo "Proto-generated code is up to date on the PR branch."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -65,16 +110,44 @@ jobs:
           git add src/generated/ docs/api/
           git commit -m "chore(proto): update generated artifacts"
           git push origin HEAD:"$PR_HEAD_REF"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Verify generated code for fork PRs
-        if: github.event.pull_request.head.repo.full_name != github.repository
+  internal-merge-freshness:
+    needs: internal-auto-generate
+    if: github.event.pull_request.head.repo.full_name == github.repository && needs.internal-auto-generate.outputs.pushed != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout internal PR merge commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: '1.23'
+          cache: false
+
+      - name: Cache Go binaries (buf, protoc plugins)
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+        with:
+          path: ~/go/bin
+          key: go-bin-${{ runner.os }}-${{ hashFiles('Makefile') }}
+
+      - name: Install buf and protoc plugins
+        run: make install-buf install-plugins
+        env:
+          GOPROXY: direct
+          GOPRIVATE: github.com/SebastienMelki
+
+      - name: Run proto generation against merge commit
+        run: make generate
+
+      - name: Verify generated code is fresh against merge result
         run: |
-          if ! git diff --exit-code src/generated/ docs/api/; then
+          if ! git diff --exit-code -- src/generated/ docs/api/; then
             echo ""
             echo "============================================================"
-            echo "ERROR: Proto-generated code is out of date."
-            echo "This PR comes from a fork, so CI cannot safely push generated artifacts."
-            echo "Run 'make generate' locally and commit the updated files."
+            echo "ERROR: Proto-generated code is stale against the PR merge result."
+            echo "Re-run this workflow after the generated artifact commit lands,"
+            echo "or rebase the PR branch on the latest base branch and retry."
             echo "============================================================"
             exit 1
           fi
@@ -83,12 +156,10 @@ jobs:
           if [ -n "$UNTRACKED" ]; then
             echo ""
             echo "============================================================"
-            echo "ERROR: Untracked generated files found:"
+            echo "ERROR: Untracked generated files found against the PR merge result:"
             echo "$UNTRACKED"
-            echo "This PR comes from a fork, so CI cannot safely push generated artifacts."
-            echo "Run 'make generate' locally and commit the new files."
             echo "============================================================"
             exit 1
           fi
 
-          echo "Proto-generated code is up to date."
+          echo "Proto-generated code is fresh against the PR merge result."

--- a/.github/workflows/proto-check.yml
+++ b/.github/workflows/proto-check.yml
@@ -10,14 +10,22 @@ on:
       - '.github/workflows/proto-check.yml'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   proto-freshness:
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout internal PR branch
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout fork PR merge commit
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
@@ -39,12 +47,28 @@ jobs:
       - name: Run proto generation
         run: make generate
 
-      - name: Verify generated code is up to date
+      - name: Commit generated artifacts for internal PRs
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          if git diff --quiet -- src/generated/ docs/api/ && [ -z "$(git ls-files --others --exclude-standard src/generated/ docs/api/)" ]; then
+            echo "Proto-generated code is up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/generated/ docs/api/
+          git commit -m "chore(proto): update generated artifacts"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+
+      - name: Verify generated code for fork PRs
+        if: github.event.pull_request.head.repo.full_name != github.repository
         run: |
           if ! git diff --exit-code src/generated/ docs/api/; then
             echo ""
             echo "============================================================"
             echo "ERROR: Proto-generated code is out of date."
+            echo "This PR comes from a fork, so CI cannot safely push generated artifacts."
             echo "Run 'make generate' locally and commit the updated files."
             echo "============================================================"
             exit 1
@@ -56,6 +80,7 @@ jobs:
             echo "============================================================"
             echo "ERROR: Untracked generated files found:"
             echo "$UNTRACKED"
+            echo "This PR comes from a fork, so CI cannot safely push generated artifacts."
             echo "Run 'make generate' locally and commit the new files."
             echo "============================================================"
             exit 1

--- a/.github/workflows/proto-check.yml
+++ b/.github/workflows/proto-check.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Commit generated artifacts for internal PRs
         if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if git diff --quiet -- src/generated/ docs/api/ && [ -z "$(git ls-files --others --exclude-standard src/generated/ docs/api/)" ]; then
             echo "Proto-generated code is up to date."
@@ -59,7 +61,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add src/generated/ docs/api/
           git commit -m "chore(proto): update generated artifacts"
-          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          git push origin HEAD:"$PR_HEAD_REF"
 
       - name: Verify generated code for fork PRs
         if: github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/proto-check.yml
+++ b/.github/workflows/proto-check.yml
@@ -15,6 +15,9 @@ permissions:
 jobs:
   proto-freshness:
     runs-on: ubuntu-latest
+    concurrency:
+      group: proto-freshness-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - name: Checkout internal PR branch
         if: github.event.pull_request.head.repo.full_name == github.repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,6 +236,14 @@ make install-plugins   # Install sebuf protoc-gen plugins (requires Go)
 
 The pinned sebuf version is set by `SEBUF_VERSION` in the `Makefile` (currently **v0.11.1**). All three plugins — `protoc-gen-ts-client`, `protoc-gen-ts-server`, `protoc-gen-openapiv3` — must be installed from the same sebuf release. If you see codegen drift after pulling, rerun `make install-plugins` to resync.
 
+### Generated Artifacts in Pull Requests
+
+`make generate` writes generated files under `src/generated/` and `docs/api/`. These files remain committed to the repository, but they should never be edited by hand.
+
+For pull requests created from branches in this repository, CI runs `make generate` and automatically pushes a `chore(proto): update generated artifacts` commit when generated files drift.
+
+For pull requests created from forks, CI cannot safely push back to the contributor branch. In that case, run `make generate` locally and commit any changes under `src/generated/` and `docs/api/` yourself before requesting review.
+
 ### OpenAPI Output
 
 `make generate` (i.e. `cd proto && buf generate`) produces:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,9 +240,9 @@ The pinned sebuf version is set by `SEBUF_VERSION` in the `Makefile` (currently 
 
 `make generate` writes generated files under `src/generated/` and `docs/api/`. These files remain committed to the repository, but they should never be edited by hand.
 
-For pull requests created from branches in this repository, CI runs `make generate` and automatically pushes a `chore(proto): update generated artifacts` commit when generated files drift.
+For pull requests created from branches in this repository, CI runs `make generate` on the PR branch and automatically pushes a `chore(proto): update generated artifacts` commit when generated files drift. A follow-up CI job then checks the pull request merge result so generated files cannot be stale relative to the current base branch.
 
-For pull requests created from forks, CI cannot safely push back to the contributor branch. In that case, run `make generate` locally and commit any changes under `src/generated/` and `docs/api/` yourself before requesting review.
+For pull requests created from forks, CI does not execute the fork's `Makefile`, `buf.gen.yaml`, or code generator configuration. In that case, run `make generate` locally and commit any changes under `src/generated/` and `docs/api/` yourself before requesting review. Maintainers can run the full freshness check from an internal branch when needed.
 
 ### OpenAPI Output
 


### PR DESCRIPTION
## Summary

Moves generated proto/OpenAPI artifact churn out of normal internal PR review by teaching the proto freshness workflow to run `make generate` and push generated artifacts back to same-repository PR branches. Fork PRs keep a safe validation-only path with an explicit failure message because CI cannot safely push to contributor branches.

cc @koala73

Closes #3340

## Type of change

- [x] CI / Build / Infrastructure
- [x] Documentation

## Affected areas

- [x] Other: proto generation workflow and contributor docs

## Root cause

The existing proto freshness check could detect stale generated files, but contributors still had to include generated artifacts manually in every PR. That creates noisy reviews and makes code changes harder to evaluate.

## Changes

- Run `make generate` in `.github/workflows/proto-check.yml`.
- For internal PRs, auto-commit changes under `src/generated/` and `docs/api/` back to the PR branch.
- For fork PRs, keep validation-only behavior with clear instructions to run `make generate` locally.
- Quote the PR head ref through an environment variable before pushing.
- Add job-level concurrency to cancel stale proto freshness runs for the same PR.
- Document the generated artifact contract in `CONTRIBUTING.md`.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/proto-check.yml'); puts 'yaml ok'"`
- `git diff --check`
- Fork PR CI: lspassos1/worldmonitor#27

## Risk

Moderate. The workflow gets write permissions for internal PR branches only. Forks remain validation-only, and the push target is quoted to avoid shell evaluation of branch names.
