### PR TITLE
feat(freshness): surface seed health in risk panel

### DIFF
--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -84,9 +84,7 @@ export class StrategicRiskPanel extends Panel {
   private lastRiskFingerprint = '';
 
   public async refresh(): Promise<boolean> {
-    void this.refreshHealthFreshness().catch((error) => {
-      console.debug('[StrategicRiskPanel] Health freshness fetch failed (non-fatal)', error);
-    });
+    void this.refreshHealthFreshness();
     this.freshnessSummary = dataFreshness.getSummary();
     this.convergenceAlerts = detectConvergence();
 
@@ -169,9 +167,9 @@ export class StrategicRiskPanel extends Panel {
   private async refreshHealthFreshness(): Promise<void> {
     const now = Date.now();
     if (now - this.lastHealthFreshnessRefreshAt < 60_000) return;
-    this.lastHealthFreshnessRefreshAt = now;
     try {
       await refreshDataFreshnessFromHealth({ signal: this.signal });
+      this.lastHealthFreshnessRefreshAt = Date.now();
     } catch (error) {
       // Health is additive; local session freshness remains useful if it fails.
       console.debug('[StrategicRiskPanel] Health freshness fetch failed (non-fatal)', error);

--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -21,6 +21,7 @@ import {
 import { getLearningProgress } from '@/services/country-instability';
 import { fetchCachedRiskScores } from '@/services/cached-risk-scores';
 import { getCachedPosture } from '@/services/cached-theater-posture';
+import { refreshDataFreshnessFromHealth } from '@/services/health-freshness';
 
 export class StrategicRiskPanel extends Panel {
   private overview: StrategicRiskOverview | null = null;
@@ -33,6 +34,7 @@ export class StrategicRiskPanel extends Panel {
   private breakingAlerts: Map<string, { threatLevel: 'critical' | 'high'; timestamp: number }> = new Map();
   private boundOnBreaking: ((e: Event) => void) | null = null;
   private breakingExpiryTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastHealthFreshnessRefreshAt = 0;
 
   constructor() {
     super({
@@ -82,6 +84,7 @@ export class StrategicRiskPanel extends Panel {
   private lastRiskFingerprint = '';
 
   public async refresh(): Promise<boolean> {
+    await this.refreshHealthFreshness();
     this.freshnessSummary = dataFreshness.getSummary();
     this.convergenceAlerts = detectConvergence();
 
@@ -138,12 +141,15 @@ export class StrategicRiskPanel extends Panel {
       }
     }
 
+    const badgeDetail = this.freshnessSummary
+      ? `${this.freshnessSummary.activeSources}/${this.freshnessSummary.totalSources} sources`
+      : undefined;
     if (!this.freshnessSummary || this.freshnessSummary.activeSources === 0) {
       this.setDataBadge('unavailable');
     } else if (this.usedCachedScores) {
-      this.setDataBadge('cached');
+      this.setDataBadge('cached', badgeDetail);
     } else {
-      this.setDataBadge('live');
+      this.setDataBadge('live', badgeDetail);
     }
 
     this.render();
@@ -153,6 +159,17 @@ export class StrategicRiskPanel extends Panel {
     const changed = fp !== this.lastRiskFingerprint;
     this.lastRiskFingerprint = fp;
     return changed;
+  }
+
+  private async refreshHealthFreshness(): Promise<void> {
+    const now = Date.now();
+    if (now - this.lastHealthFreshnessRefreshAt < 60_000) return;
+    this.lastHealthFreshnessRefreshAt = now;
+    try {
+      await refreshDataFreshnessFromHealth({ signal: this.signal });
+    } catch {
+      // Health is additive; local session freshness remains useful if it fails.
+    }
   }
 
   private getScoreColor(score: number): string {
@@ -309,6 +326,7 @@ export class StrategicRiskPanel extends Panel {
         </div>
 
         ${this.renderMetrics()}
+        ${this.renderFreshnessSurface()}
         ${this.renderTopRisks()}
         ${this.renderRecentAlerts()}
 
@@ -334,6 +352,33 @@ export class StrategicRiskPanel extends Panel {
         ${panelId && (source.status === 'no_data' || source.status === 'disabled') ? `
           <button class="risk-source-enable" data-panel="${panelId}">${t('components.strategicRisk.enable')}</button>
         ` : ''}
+      </div>
+    `;
+  }
+
+  private renderFreshnessSurface(): string {
+    if (!this.freshnessSummary) return '';
+    const sources = dataFreshness.getAllSources()
+      .filter(source => source.status !== 'no_data' && source.status !== 'disabled')
+      .sort((a, b) => {
+        const order: Record<string, number> = { error: 0, very_stale: 1, stale: 2, fresh: 3 };
+        return (order[a.status] ?? 4) - (order[b.status] ?? 4);
+      })
+      .slice(0, 6);
+
+    if (sources.length === 0) return '';
+    return `
+      <div class="risk-section">
+        <div class="risk-section-title">${t('components.strategicRisk.dataFreshness')}</div>
+        <div class="risk-sources-compact">
+          ${sources.map(source => `
+            <span class="risk-source-chip" title="${escapeHtml(source.healthStatus || source.status)}" style="border-color: ${getStatusColor(source.status)}">
+              <span class="risk-source-dot" style="color: ${getStatusColor(source.status)}">${getStatusIcon(source.status)}</span>
+              <span class="risk-source-name">${escapeHtml(source.name)}</span>
+              <span class="risk-source-time">${escapeHtml(dataFreshness.getTimeSince(source.id))}</span>
+            </span>
+          `).join('')}
+        </div>
       </div>
     `;
   }

--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -167,8 +167,9 @@ export class StrategicRiskPanel extends Panel {
     this.lastHealthFreshnessRefreshAt = now;
     try {
       await refreshDataFreshnessFromHealth({ signal: this.signal });
-    } catch {
+    } catch (error) {
       // Health is additive; local session freshness remains useful if it fails.
+      console.debug('[StrategicRiskPanel] Health freshness fetch failed (non-fatal)', error);
     }
   }
 

--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -169,10 +169,11 @@ export class StrategicRiskPanel extends Panel {
     if (now - this.lastHealthFreshnessRefreshAt < 60_000) return;
     try {
       await refreshDataFreshnessFromHealth({ signal: this.signal });
-      this.lastHealthFreshnessRefreshAt = Date.now();
     } catch (error) {
       // Health is additive; local session freshness remains useful if it fails.
       console.debug('[StrategicRiskPanel] Health freshness fetch failed (non-fatal)', error);
+    } finally {
+      this.lastHealthFreshnessRefreshAt = Date.now();
     }
   }
 

--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -84,7 +84,9 @@ export class StrategicRiskPanel extends Panel {
   private lastRiskFingerprint = '';
 
   public async refresh(): Promise<boolean> {
-    await this.refreshHealthFreshness();
+    void this.refreshHealthFreshness().catch((error) => {
+      console.debug('[StrategicRiskPanel] Health freshness fetch failed (non-fatal)', error);
+    });
     this.freshnessSummary = dataFreshness.getSummary();
     this.convergenceAlerts = detectConvergence();
 
@@ -142,7 +144,10 @@ export class StrategicRiskPanel extends Panel {
     }
 
     const badgeDetail = this.freshnessSummary
-      ? `${this.freshnessSummary.activeSources}/${this.freshnessSummary.totalSources} sources`
+      ? t('components.strategicRisk.sourcesDetail', {
+        active: this.freshnessSummary.activeSources,
+        total: this.freshnessSummary.totalSources,
+      })
       : undefined;
     if (!this.freshnessSummary || this.freshnessSummary.activeSources === 0) {
       this.setDataBadge('unavailable');

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1566,6 +1566,7 @@
       "ciiDeviation": "CII Deviation",
       "infraEvents": "Infra Events",
       "highAlerts": "High Alerts",
+      "dataFreshness": "Data Freshness",
       "topRisks": "Top Risks",
       "recentAlerts": "Recent Alerts ({{count}})",
       "updated": "Updated: {{time}}",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1567,6 +1567,7 @@
       "infraEvents": "Infra Events",
       "highAlerts": "High Alerts",
       "dataFreshness": "Data Freshness",
+      "sourcesDetail": "{{active}}/{{total}} sources",
       "topRisks": "Top Risks",
       "recentAlerts": "Recent Alerts ({{count}})",
       "updated": "Updated: {{time}}",

--- a/src/services/data-freshness.ts
+++ b/src/services/data-freshness.ts
@@ -4,7 +4,7 @@
  * showing misleading "all clear" when we actually have no data.
  */
 
-import { getCSSColor } from '@/utils';
+import { getCSSColor } from '@/utils/theme-colors';
 import type { DataSourceId } from '@/types';
 
 export type { DataSourceId } from '@/types';
@@ -20,6 +20,8 @@ export interface DataSourceState {
   enabled: boolean;
   status: FreshnessStatus;
   requiredForRisk: boolean; // Is this source important for risk assessment?
+  maxStaleMin?: number;
+  healthStatus?: string;
 }
 
 export interface DataFreshnessSummary {
@@ -32,6 +34,15 @@ export interface DataFreshnessSummary {
   coveragePercent: number;
   oldestUpdate: Date | null;
   newestUpdate: Date | null;
+}
+
+export interface SeedHealthUpdate {
+  sourceId: DataSourceId;
+  status: string;
+  records?: number | null;
+  seedAgeMin?: number | null;
+  maxStaleMin?: number | null;
+  checkedAtMs?: number;
 }
 
 // Thresholds in milliseconds
@@ -125,6 +136,43 @@ class DataFreshnessTracker {
       source.status = 'error';
       this.notifyListeners();
     }
+  }
+
+  /**
+   * Merge cadence-aware seed freshness from /api/health.
+   */
+  recordSeedHealth(updates: SeedHealthUpdate[]): void {
+    let changed = false;
+    for (const update of updates) {
+      const source = this.sources.get(update.sourceId);
+      if (!source) continue;
+
+      const records = typeof update.records === 'number' && Number.isFinite(update.records)
+        ? Math.max(0, update.records)
+        : source.itemCount;
+      const maxStaleMin = typeof update.maxStaleMin === 'number' && update.maxStaleMin > 0
+        ? update.maxStaleMin
+        : undefined;
+      const checkedAtMs = Number.isFinite(update.checkedAtMs)
+        ? update.checkedAtMs!
+        : Date.now();
+      const seedAgeMin = typeof update.seedAgeMin === 'number' && update.seedAgeMin >= 0
+        ? update.seedAgeMin
+        : null;
+
+      source.itemCount = records;
+      source.maxStaleMin = maxStaleMin;
+      source.healthStatus = update.status;
+      source.lastError = this.healthStatusIsError(update.status) ? update.status : null;
+      source.lastUpdate = this.healthStatusHasNoData(update.status)
+        ? null
+        : seedAgeMin !== null
+        ? new Date(checkedAtMs - seedAgeMin * 60_000)
+        : source.lastUpdate;
+      source.status = source.enabled ? this.calculateStatus(source) : 'disabled';
+      changed = true;
+    }
+    if (changed) this.notifyListeners();
   }
 
   /**
@@ -248,10 +296,21 @@ class DataFreshnessTracker {
     if (!source.lastUpdate) return 'no_data';
 
     const age = Date.now() - source.lastUpdate.getTime();
-    if (age < FRESH_THRESHOLD) return 'fresh';
-    if (age < STALE_THRESHOLD) return 'stale';
-    if (age < VERY_STALE_THRESHOLD) return 'very_stale';
+    const freshThreshold = source.maxStaleMin ? source.maxStaleMin * 60_000 : FRESH_THRESHOLD;
+    const staleThreshold = source.maxStaleMin ? source.maxStaleMin * 2 * 60_000 : STALE_THRESHOLD;
+    const veryStaleThreshold = source.maxStaleMin ? source.maxStaleMin * 3 * 60_000 : VERY_STALE_THRESHOLD;
+    if (age <= freshThreshold) return 'fresh';
+    if (age <= staleThreshold) return 'stale';
+    if (age <= veryStaleThreshold) return 'very_stale';
     return 'no_data'; // Too old, treat as no data
+  }
+
+  private healthStatusIsError(status: string): boolean {
+    return status === 'SEED_ERROR' || status === 'REDIS_PARTIAL';
+  }
+
+  private healthStatusHasNoData(status: string): boolean {
+    return status === 'EMPTY' || status === 'EMPTY_DATA' || status === 'EMPTY_ON_DEMAND';
   }
 
   private notifyListeners(): void {

--- a/src/services/data-freshness.ts
+++ b/src/services/data-freshness.ts
@@ -306,7 +306,7 @@ class DataFreshnessTracker {
   }
 
   private healthStatusIsError(status: string): boolean {
-    return status === 'SEED_ERROR' || status === 'REDIS_PARTIAL';
+    return status === 'SEED_ERROR' || status === 'REDIS_DOWN' || status === 'REDIS_PARTIAL';
   }
 
   private healthStatusHasNoData(status: string): boolean {

--- a/src/services/data-freshness.ts
+++ b/src/services/data-freshness.ts
@@ -299,7 +299,7 @@ class DataFreshnessTracker {
     const freshThreshold = source.maxStaleMin ? source.maxStaleMin * 60_000 : FRESH_THRESHOLD;
     const staleThreshold = source.maxStaleMin ? source.maxStaleMin * 2 * 60_000 : STALE_THRESHOLD;
     const veryStaleThreshold = source.maxStaleMin ? source.maxStaleMin * 3 * 60_000 : VERY_STALE_THRESHOLD;
-    if (age <= freshThreshold) return 'fresh';
+    if (age <= freshThreshold) return source.healthStatus === 'COVERAGE_PARTIAL' ? 'stale' : 'fresh';
     if (age <= staleThreshold) return 'stale';
     if (age <= veryStaleThreshold) return 'very_stale';
     return 'no_data'; // Too old, treat as no data

--- a/src/services/data-freshness.ts
+++ b/src/services/data-freshness.ts
@@ -42,6 +42,8 @@ export interface SeedHealthUpdate {
   records?: number | null;
   seedAgeMin?: number | null;
   maxStaleMin?: number | null;
+  contentAgeMin?: number | null;
+  maxContentAgeMin?: number | null;
   checkedAtMs?: number;
 }
 
@@ -153,21 +155,32 @@ class DataFreshnessTracker {
       const maxStaleMin = typeof update.maxStaleMin === 'number' && update.maxStaleMin > 0
         ? update.maxStaleMin
         : undefined;
+      const maxContentAgeMin = typeof update.maxContentAgeMin === 'number' && update.maxContentAgeMin > 0
+        ? update.maxContentAgeMin
+        : undefined;
       const checkedAtMs = Number.isFinite(update.checkedAtMs)
         ? update.checkedAtMs!
         : Date.now();
       const seedAgeMin = typeof update.seedAgeMin === 'number' && update.seedAgeMin >= 0
         ? update.seedAgeMin
         : null;
+      const contentAgeMin = typeof update.contentAgeMin === 'number' && update.contentAgeMin >= 0
+        ? update.contentAgeMin
+        : null;
+      const ageMin = update.status === 'STALE_CONTENT' && contentAgeMin !== null
+        ? contentAgeMin
+        : seedAgeMin;
 
       source.itemCount = records;
-      source.maxStaleMin = maxStaleMin;
+      source.maxStaleMin = update.status === 'STALE_CONTENT'
+        ? (maxContentAgeMin ?? maxStaleMin)
+        : maxStaleMin;
       source.healthStatus = update.status;
       source.lastError = this.healthStatusIsError(update.status) ? update.status : null;
       source.lastUpdate = this.healthStatusHasNoData(update.status)
         ? null
-        : seedAgeMin !== null
-        ? new Date(checkedAtMs - seedAgeMin * 60_000)
+        : ageMin !== null
+        ? new Date(checkedAtMs - ageMin * 60_000)
         : source.lastUpdate;
       source.status = source.enabled ? this.calculateStatus(source) : 'disabled';
       changed = true;
@@ -299,7 +312,7 @@ class DataFreshnessTracker {
     const freshThreshold = source.maxStaleMin ? source.maxStaleMin * 60_000 : FRESH_THRESHOLD;
     const staleThreshold = source.maxStaleMin ? source.maxStaleMin * 2 * 60_000 : STALE_THRESHOLD;
     const veryStaleThreshold = source.maxStaleMin ? source.maxStaleMin * 3 * 60_000 : VERY_STALE_THRESHOLD;
-    if (age <= freshThreshold) return source.healthStatus === 'COVERAGE_PARTIAL' ? 'stale' : 'fresh';
+    if (age <= freshThreshold) return source.healthStatus === 'COVERAGE_PARTIAL' || source.healthStatus === 'STALE_CONTENT' ? 'stale' : 'fresh';
     if (age <= staleThreshold) return 'stale';
     if (age <= veryStaleThreshold) return 'very_stale';
     return 'no_data'; // Too old, treat as no data

--- a/src/services/data-freshness.ts
+++ b/src/services/data-freshness.ts
@@ -312,7 +312,11 @@ class DataFreshnessTracker {
     const freshThreshold = source.maxStaleMin ? source.maxStaleMin * 60_000 : FRESH_THRESHOLD;
     const staleThreshold = source.maxStaleMin ? source.maxStaleMin * 2 * 60_000 : STALE_THRESHOLD;
     const veryStaleThreshold = source.maxStaleMin ? source.maxStaleMin * 3 * 60_000 : VERY_STALE_THRESHOLD;
-    if (age <= freshThreshold) return source.healthStatus === 'COVERAGE_PARTIAL' || source.healthStatus === 'STALE_CONTENT' ? 'stale' : 'fresh';
+    if (age <= freshThreshold) return source.healthStatus === 'COVERAGE_PARTIAL'
+      || source.healthStatus === 'STALE_CONTENT'
+      || source.healthStatus === 'STALE_SEED'
+      ? 'stale'
+      : 'fresh';
     if (age <= staleThreshold) return 'stale';
     if (age <= veryStaleThreshold) return 'very_stale';
     return 'no_data'; // Too old, treat as no data

--- a/src/services/health-freshness.ts
+++ b/src/services/health-freshness.ts
@@ -6,6 +6,8 @@ interface HealthCheck {
   records?: number | null;
   seedAgeMin?: number | null;
   maxStaleMin?: number | null;
+  contentAgeMin?: number | null;
+  maxContentAgeMin?: number | null;
 }
 
 interface HealthResponse {
@@ -64,6 +66,7 @@ function statusRank(status: string): number {
     case 'EMPTY_DATA':
       return 4;
     case 'STALE_SEED':
+    case 'STALE_CONTENT':
     case 'COVERAGE_PARTIAL':
       return 3;
     case 'EMPTY_ON_DEMAND':
@@ -78,11 +81,17 @@ function statusRank(status: string): number {
 }
 
 function stalenessRatio(update: SeedHealthUpdate): number {
-  if (update.seedAgeMin == null || update.maxStaleMin == null) return 0;
-  if (update.maxStaleMin === 0) {
-    return update.seedAgeMin === 0 ? 0 : Number.POSITIVE_INFINITY;
+  const ageMin = update.status === 'STALE_CONTENT' && update.contentAgeMin != null
+    ? update.contentAgeMin
+    : update.seedAgeMin;
+  const maxAgeMin = update.status === 'STALE_CONTENT' && update.maxContentAgeMin != null
+    ? update.maxContentAgeMin
+    : update.maxStaleMin;
+  if (ageMin == null || maxAgeMin == null) return 0;
+  if (maxAgeMin === 0) {
+    return ageMin === 0 ? 0 : Number.POSITIVE_INFINITY;
   }
-  return update.seedAgeMin / update.maxStaleMin;
+  return ageMin / maxAgeMin;
 }
 
 function isRedisOutageStatus(status: string | undefined): status is 'REDIS_DOWN' | 'REDIS_PARTIAL' {
@@ -133,6 +142,8 @@ export async function refreshDataFreshnessFromHealth(options: RefreshHealthFresh
         records: check.records,
         seedAgeMin: check.seedAgeMin,
         maxStaleMin: check.maxStaleMin,
+        contentAgeMin: check.contentAgeMin,
+        maxContentAgeMin: check.maxContentAgeMin,
         checkedAtMs: checkedAt,
       };
       const existing = updatesBySource.get(sourceId);

--- a/src/services/health-freshness.ts
+++ b/src/services/health-freshness.ts
@@ -1,0 +1,123 @@
+import { dataFreshness, type SeedHealthUpdate } from '@/services/data-freshness';
+import type { DataSourceId } from '@/types';
+
+interface HealthCheck {
+  status?: string;
+  records?: number | null;
+  seedAgeMin?: number | null;
+  maxStaleMin?: number | null;
+}
+
+interface HealthResponse {
+  checkedAt?: string;
+  checks?: Record<string, HealthCheck>;
+}
+
+const HEALTH_CHECK_SOURCE_MAP: Record<string, DataSourceId[]> = {
+  unrestEvents: ['acled', 'gdelt_doc'],
+  gdeltIntel: ['gdelt'],
+  newsInsights: ['rss'],
+  outages: ['outages'],
+  cyberThreats: ['cyber_threats'],
+  naturalEvents: ['usgs'],
+  weatherAlerts: ['weather'],
+  spending: ['spending'],
+  wildfires: ['firms'],
+  ucdpEvents: ['ucdp_events'],
+  displacement: ['unhcr'],
+  climateAnomalies: ['climate'],
+  climateDisasters: ['climate'],
+  climateAirQuality: ['climate'],
+  predictionMarkets: ['polymarket'],
+  forecasts: ['predictions'],
+  pizzint: ['pizzint'],
+  gpsjam: ['gpsjam'],
+  securityAdvisories: ['security_advisories'],
+  sanctionsPressure: ['sanctions_pressure'],
+  radiationWatch: ['radiation'],
+  customsRevenue: ['treasury_revenue'],
+  bisPolicy: ['bis'],
+  bisDsr: ['bis'],
+  bisPropertyResidential: ['bis'],
+  bisPropertyCommercial: ['bis'],
+  blsSeries: ['bls'],
+  shippingRates: ['supply_chain'],
+  chokepoints: ['supply_chain'],
+  shippingStress: ['supply_chain'],
+};
+
+export interface RefreshHealthFreshnessOptions {
+  fetchFn?: typeof fetch;
+  endpoint?: string;
+  signal?: AbortSignal;
+  urlResolver?: (path: string) => string;
+}
+
+function statusRank(status: string): number {
+  switch (status) {
+    case 'SEED_ERROR':
+    case 'REDIS_PARTIAL':
+      return 5;
+    case 'EMPTY':
+    case 'EMPTY_DATA':
+      return 4;
+    case 'STALE_SEED':
+    case 'COVERAGE_PARTIAL':
+      return 3;
+    case 'EMPTY_ON_DEMAND':
+      return 2;
+    case 'OK_CASCADE':
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+function stalenessRatio(update: SeedHealthUpdate): number {
+  if (!update.seedAgeMin || !update.maxStaleMin) return 0;
+  return update.seedAgeMin / update.maxStaleMin;
+}
+
+export async function refreshDataFreshnessFromHealth(options: RefreshHealthFreshnessOptions = {}): Promise<number> {
+  const fetchFn = options.fetchFn ?? ((...args) => globalThis.fetch(...args));
+  const endpoint = options.endpoint ?? '/api/health';
+  const url = options.urlResolver
+    ? options.urlResolver(endpoint)
+    : (await import('@/services/runtime')).toApiUrl(endpoint);
+  const resp = await fetchFn(url, {
+    headers: { Accept: 'application/json' },
+    signal: options.signal,
+  });
+  if (!resp.ok) throw new Error(`health freshness fetch failed: ${resp.status}`);
+
+  const payload = await resp.json() as HealthResponse;
+  const checkedAtMs = payload.checkedAt ? Date.parse(payload.checkedAt) : Date.now();
+  const updatesBySource = new Map<DataSourceId, SeedHealthUpdate>();
+
+  for (const [checkName, check] of Object.entries(payload.checks ?? {})) {
+    const sourceIds = HEALTH_CHECK_SOURCE_MAP[checkName];
+    if (!sourceIds?.length || !check.status) continue;
+    for (const sourceId of sourceIds) {
+      const next = {
+        sourceId,
+        status: check.status,
+        records: check.records,
+        seedAgeMin: check.seedAgeMin,
+        maxStaleMin: check.maxStaleMin,
+        checkedAtMs: Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now(),
+      };
+      const existing = updatesBySource.get(sourceId);
+      if (
+        !existing ||
+        statusRank(next.status) > statusRank(existing.status) ||
+        (statusRank(next.status) === statusRank(existing.status) && stalenessRatio(next) > stalenessRatio(existing))
+      ) {
+        updatesBySource.set(sourceId, next);
+      }
+    }
+  }
+
+  const updates = [...updatesBySource.values()];
+  dataFreshness.recordSeedHealth(updates);
+  return updates.length;
+}

--- a/src/services/health-freshness.ts
+++ b/src/services/health-freshness.ts
@@ -56,6 +56,7 @@ export interface RefreshHealthFreshnessOptions {
 function statusRank(status: string): number {
   switch (status) {
     case 'SEED_ERROR':
+    case 'REDIS_DOWN':
     case 'REDIS_PARTIAL':
       return 5;
     case 'EMPTY':
@@ -68,13 +69,18 @@ function statusRank(status: string): number {
       return 2;
     case 'OK_CASCADE':
       return 1;
+    case 'OK':
+      return 0;
     default:
       return 0;
   }
 }
 
 function stalenessRatio(update: SeedHealthUpdate): number {
-  if (!update.seedAgeMin || !update.maxStaleMin) return 0;
+  if (update.seedAgeMin == null || update.maxStaleMin == null) return 0;
+  if (update.maxStaleMin === 0) {
+    return update.seedAgeMin === 0 ? 0 : Number.POSITIVE_INFINITY;
+  }
   return update.seedAgeMin / update.maxStaleMin;
 }
 

--- a/src/services/health-freshness.ts
+++ b/src/services/health-freshness.ts
@@ -9,6 +9,7 @@ interface HealthCheck {
 }
 
 interface HealthResponse {
+  status?: string;
   checkedAt?: string;
   checks?: Record<string, HealthCheck>;
 }
@@ -84,6 +85,14 @@ function stalenessRatio(update: SeedHealthUpdate): number {
   return update.seedAgeMin / update.maxStaleMin;
 }
 
+function isRedisOutageStatus(status: string | undefined): status is 'REDIS_DOWN' | 'REDIS_PARTIAL' {
+  return status === 'REDIS_DOWN' || status === 'REDIS_PARTIAL';
+}
+
+function getMappedSourceIds(): DataSourceId[] {
+  return [...new Set(Object.values(HEALTH_CHECK_SOURCE_MAP).flat())];
+}
+
 export async function refreshDataFreshnessFromHealth(options: RefreshHealthFreshnessOptions = {}): Promise<number> {
   const fetchFn = options.fetchFn ?? ((...args) => globalThis.fetch(...args));
   const endpoint = options.endpoint ?? '/api/health';
@@ -98,9 +107,23 @@ export async function refreshDataFreshnessFromHealth(options: RefreshHealthFresh
 
   const payload = await resp.json() as HealthResponse;
   const checkedAtMs = payload.checkedAt ? Date.parse(payload.checkedAt) : Date.now();
+  const checkedAt = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
   const updatesBySource = new Map<DataSourceId, SeedHealthUpdate>();
+  const checks = payload.checks ?? {};
 
-  for (const [checkName, check] of Object.entries(payload.checks ?? {})) {
+  if (Object.keys(checks).length === 0 && isRedisOutageStatus(payload.status)) {
+    const status = payload.status;
+    const updates = getMappedSourceIds().map((sourceId) => ({
+      sourceId,
+      status,
+      records: 0,
+      checkedAtMs: checkedAt,
+    }));
+    dataFreshness.recordSeedHealth(updates);
+    return updates.length;
+  }
+
+  for (const [checkName, check] of Object.entries(checks)) {
     const sourceIds = HEALTH_CHECK_SOURCE_MAP[checkName];
     if (!sourceIds?.length || !check.status) continue;
     for (const sourceId of sourceIds) {
@@ -110,7 +133,7 @@ export async function refreshDataFreshnessFromHealth(options: RefreshHealthFresh
         records: check.records,
         seedAgeMin: check.seedAgeMin,
         maxStaleMin: check.maxStaleMin,
-        checkedAtMs: Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now(),
+        checkedAtMs: checkedAt,
       };
       const existing = updatesBySource.get(sourceId);
       if (

--- a/src/services/health-freshness.ts
+++ b/src/services/health-freshness.ts
@@ -13,7 +13,7 @@ interface HealthResponse {
   checks?: Record<string, HealthCheck>;
 }
 
-const HEALTH_CHECK_SOURCE_MAP: Record<string, DataSourceId[]> = {
+export const HEALTH_CHECK_SOURCE_MAP: Record<string, DataSourceId[]> = {
   unrestEvents: ['acled', 'gdelt_doc'],
   gdeltIntel: ['gdelt'],
   newsInsights: ['rss'],

--- a/tests/data-freshness-health.test.mts
+++ b/tests/data-freshness-health.test.mts
@@ -148,4 +148,54 @@ describe('health freshness ingestion', () => {
     assert.equal(bis?.healthStatus, 'REDIS_DOWN');
     assert.equal(bis?.lastError, 'REDIS_DOWN');
   });
+
+  it('marks mapped sources unhealthy when /api/health reports top-level redis outage without checks', async () => {
+    const mappedSources = new Set(Object.values(HEALTH_CHECK_SOURCE_MAP).flat());
+    const checkedAtMs = Date.now();
+    const applied = await refreshDataFreshnessFromHealth({
+      endpoint: '/api/health',
+      urlResolver: (path) => path,
+      fetchFn: async () => jsonResponse({
+        status: 'REDIS_DOWN',
+        checkedAt: new Date(checkedAtMs).toISOString(),
+      }),
+    });
+
+    assert.equal(applied, mappedSources.size);
+    assert.ok(applied > 10);
+
+    for (const sourceId of ['gdelt', 'weather', 'bis'] as const) {
+      const source = dataFreshness.getSource(sourceId);
+      assert.equal(source?.status, 'error');
+      assert.equal(source?.healthStatus, 'REDIS_DOWN');
+      assert.equal(source?.lastError, 'REDIS_DOWN');
+      assert.equal(source?.itemCount, 0);
+    }
+  });
+
+  it('does not classify partial coverage as fresh even when recently seeded', async () => {
+    const checkedAtMs = Date.now();
+    const applied = await refreshDataFreshnessFromHealth({
+      endpoint: '/api/health',
+      urlResolver: (path) => path,
+      fetchFn: async () => jsonResponse({
+        checkedAt: new Date(checkedAtMs).toISOString(),
+        checks: {
+          gdeltIntel: {
+            status: 'COVERAGE_PARTIAL',
+            records: 12,
+            seedAgeMin: 1,
+            maxStaleMin: 420,
+          },
+        },
+      }),
+    });
+
+    assert.equal(applied, 1);
+
+    const gdelt = dataFreshness.getSource('gdelt');
+    assert.equal(gdelt?.status, 'stale');
+    assert.equal(gdelt?.healthStatus, 'COVERAGE_PARTIAL');
+    assert.equal(gdelt?.lastError, null);
+  });
 });

--- a/tests/data-freshness-health.test.mts
+++ b/tests/data-freshness-health.test.mts
@@ -116,4 +116,36 @@ describe('health freshness ingestion', () => {
     assert.equal(climate?.healthStatus, 'STALE_SEED');
     assert.equal(climate?.itemCount, 4);
   });
+
+  it('treats redis outages as higher severity than ok checks', async () => {
+    const checkedAtMs = Date.now();
+    const applied = await refreshDataFreshnessFromHealth({
+      endpoint: '/api/health',
+      urlResolver: (path) => path,
+      fetchFn: async () => jsonResponse({
+        checkedAt: new Date(checkedAtMs).toISOString(),
+        checks: {
+          bisPolicy: {
+            status: 'OK',
+            records: 12,
+            seedAgeMin: 0,
+            maxStaleMin: 360,
+          },
+          bisDsr: {
+            status: 'REDIS_DOWN',
+            records: 0,
+            seedAgeMin: 5,
+            maxStaleMin: 360,
+          },
+        },
+      }),
+    });
+
+    assert.equal(applied, 1);
+
+    const bis = dataFreshness.getSource('bis');
+    assert.equal(bis?.status, 'error');
+    assert.equal(bis?.healthStatus, 'REDIS_DOWN');
+    assert.equal(bis?.lastError, 'REDIS_DOWN');
+  });
 });

--- a/tests/data-freshness-health.test.mts
+++ b/tests/data-freshness-health.test.mts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { dataFreshness } from '../src/services/data-freshness.ts';
+import { refreshDataFreshnessFromHealth } from '../src/services/health-freshness.ts';
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response;
+}
+
+describe('health freshness ingestion', () => {
+  it('hydrates dataFreshness from /api/health cadence metadata', async () => {
+    const checkedAtMs = Date.now();
+    const applied = await refreshDataFreshnessFromHealth({
+      endpoint: '/api/health',
+      urlResolver: (path) => path,
+      fetchFn: async () => jsonResponse({
+        checkedAt: new Date(checkedAtMs).toISOString(),
+        checks: {
+          gdeltIntel: {
+            status: 'OK',
+            records: 14,
+            seedAgeMin: 30,
+            maxStaleMin: 420,
+          },
+          weatherAlerts: {
+            status: 'STALE_SEED',
+            records: 2,
+            seedAgeMin: 60,
+            maxStaleMin: 45,
+          },
+          cyberThreats: {
+            status: 'SEED_ERROR',
+            records: 0,
+            maxStaleMin: 240,
+          },
+        },
+      }),
+    });
+
+    assert.equal(applied, 3);
+
+    const gdelt = dataFreshness.getSource('gdelt');
+    assert.equal(gdelt?.status, 'fresh');
+    assert.equal(gdelt?.itemCount, 14);
+    assert.equal(gdelt?.maxStaleMin, 420);
+    assert.equal(gdelt?.lastUpdate?.toISOString(), new Date(checkedAtMs - 30 * 60_000).toISOString());
+
+    const weather = dataFreshness.getSource('weather');
+    assert.equal(weather?.status, 'stale');
+    assert.equal(weather?.healthStatus, 'STALE_SEED');
+
+    const cyber = dataFreshness.getSource('cyber_threats');
+    assert.equal(cyber?.status, 'error');
+    assert.equal(cyber?.lastError, 'SEED_ERROR');
+  });
+});

--- a/tests/data-freshness-health.test.mts
+++ b/tests/data-freshness-health.test.mts
@@ -199,6 +199,32 @@ describe('health freshness ingestion', () => {
     assert.equal(gdelt?.lastError, null);
   });
 
+  it('does not classify stale seeds as fresh even when recently seeded', async () => {
+    const checkedAtMs = Date.now();
+    const applied = await refreshDataFreshnessFromHealth({
+      endpoint: '/api/health',
+      urlResolver: (path) => path,
+      fetchFn: async () => jsonResponse({
+        checkedAt: new Date(checkedAtMs).toISOString(),
+        checks: {
+          gdeltIntel: {
+            status: 'STALE_SEED',
+            records: 12,
+            seedAgeMin: 1,
+            maxStaleMin: 420,
+          },
+        },
+      }),
+    });
+
+    assert.equal(applied, 1);
+
+    const gdelt = dataFreshness.getSource('gdelt');
+    assert.equal(gdelt?.status, 'stale');
+    assert.equal(gdelt?.healthStatus, 'STALE_SEED');
+    assert.equal(gdelt?.lastError, null);
+  });
+
   it('uses stale content age instead of seed age for STALE_CONTENT checks', async () => {
     const checkedAtMs = Date.now();
     const applied = await refreshDataFreshnessFromHealth({
@@ -228,5 +254,23 @@ describe('health freshness ingestion', () => {
     assert.equal(bls?.lastError, null);
     assert.equal(bls?.maxStaleMin, 60);
     assert.equal(bls?.lastUpdate?.toISOString(), new Date(checkedAtMs - 90 * 60_000).toISOString());
+  });
+
+  it('keeps health freshness failures debounced by updating the timestamp in finally', () => {
+    const panelSrc = readFileSync(resolve(repoRoot, 'src/components/StrategicRiskPanel.ts'), 'utf8');
+    const methodMatch = panelSrc.match(/private async refreshHealthFreshness\(\): Promise<void> \{[\s\S]*?\n  \}/);
+    assert.ok(methodMatch, 'StrategicRiskPanel.refreshHealthFreshness method should exist');
+
+    const methodSrc = methodMatch[0];
+    assert.doesNotMatch(
+      panelSrc,
+      /void this\.refreshHealthFreshness\(\)\.catch\(/,
+      'refreshHealthFreshness swallows internally, so refresh() should not add a dead outer catch',
+    );
+    assert.match(
+      methodSrc,
+      /finally\s*\{[\s\S]*this\.lastHealthFreshnessRefreshAt\s*=\s*Date\.now\(\);[\s\S]*\}/,
+      'lastHealthFreshnessRefreshAt should update in finally so failed health fetches are debounced',
+    );
   });
 });

--- a/tests/data-freshness-health.test.mts
+++ b/tests/data-freshness-health.test.mts
@@ -1,8 +1,16 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { dataFreshness } from '../src/services/data-freshness.ts';
-import { refreshDataFreshnessFromHealth } from '../src/services/health-freshness.ts';
+import {
+  HEALTH_CHECK_SOURCE_MAP,
+  refreshDataFreshnessFromHealth,
+} from '../src/services/health-freshness.ts';
+
+const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
 
 function jsonResponse(body: unknown): Response {
   return {
@@ -57,5 +65,55 @@ describe('health freshness ingestion', () => {
     const cyber = dataFreshness.getSource('cyber_threats');
     assert.equal(cyber?.status, 'error');
     assert.equal(cyber?.lastError, 'SEED_ERROR');
+  });
+
+  it('keeps the frontend mapping pinned to registered api/health checks', () => {
+    const healthSrc = readFileSync(resolve(repoRoot, 'api/health.js'), 'utf8');
+
+    for (const checkName of Object.keys(HEALTH_CHECK_SOURCE_MAP)) {
+      assert.match(
+        healthSrc,
+        new RegExp(`\\b${checkName}:\\s*(?:\\{|['"\`])`),
+        `HEALTH_CHECK_SOURCE_MAP references ${checkName}, but api/health.js does not register that check`,
+      );
+    }
+  });
+
+  it('uses the worst health status when several checks map to one frontend source', async () => {
+    const checkedAtMs = Date.now();
+    const applied = await refreshDataFreshnessFromHealth({
+      endpoint: '/api/health',
+      urlResolver: (path) => path,
+      fetchFn: async () => jsonResponse({
+        checkedAt: new Date(checkedAtMs).toISOString(),
+        checks: {
+          climateAnomalies: {
+            status: 'OK',
+            records: 25,
+            seedAgeMin: 10,
+            maxStaleMin: 540,
+          },
+          climateDisasters: {
+            status: 'STALE_SEED',
+            records: 4,
+            seedAgeMin: 900,
+            maxStaleMin: 720,
+          },
+          climateAirQuality: {
+            status: 'OK',
+            records: 8,
+            seedAgeMin: 20,
+            maxStaleMin: 180,
+          },
+        },
+      }),
+    });
+
+    assert.equal(applied, 1);
+
+    const climate = dataFreshness.getSource('climate');
+    assert.equal(climate?.status, 'stale');
+    assert.equal(climate?.healthStatus, 'STALE_SEED');
+    assert.equal(climate?.itemCount, 4);
   });
 });

--- a/tests/data-freshness-health.test.mts
+++ b/tests/data-freshness-health.test.mts
@@ -198,4 +198,35 @@ describe('health freshness ingestion', () => {
     assert.equal(gdelt?.healthStatus, 'COVERAGE_PARTIAL');
     assert.equal(gdelt?.lastError, null);
   });
+
+  it('uses stale content age instead of seed age for STALE_CONTENT checks', async () => {
+    const checkedAtMs = Date.now();
+    const applied = await refreshDataFreshnessFromHealth({
+      endpoint: '/api/health',
+      urlResolver: (path) => path,
+      fetchFn: async () => jsonResponse({
+        checkedAt: new Date(checkedAtMs).toISOString(),
+        checks: {
+          blsSeries: {
+            status: 'STALE_CONTENT',
+            records: 9,
+            seedAgeMin: 1,
+            maxStaleMin: 360,
+            contentAgeMin: 90,
+            maxContentAgeMin: 60,
+          },
+        },
+      }),
+    });
+
+    assert.equal(applied, 1);
+
+    const bls = dataFreshness.getSource('bls');
+    assert.equal(bls?.status, 'stale');
+    assert.notEqual(bls?.status, 'fresh');
+    assert.equal(bls?.healthStatus, 'STALE_CONTENT');
+    assert.equal(bls?.lastError, null);
+    assert.equal(bls?.maxStaleMin, 60);
+    assert.equal(bls?.lastUpdate?.toISOString(), new Date(checkedAtMs - 90 * 60_000).toISOString());
+  });
 });


### PR DESCRIPTION
## Summary

Surfaces seed-health freshness in the Strategic Risk panel by ingesting `/api/health` cadence metadata into the existing `dataFreshness` tracker. Analysts get a compact data freshness signal without blocking the main risk refresh path.

cc @koala73

Refs #3296

## Type of change

- [x] New feature
- [x] Refactor / code cleanup

## Affected areas

- [x] API endpoints (`/api/*`)
- [x] Other: Strategic Risk panel freshness UI and health ingestion

## Root cause

The frontend freshness tracker was mostly session-local. The backend already knows seed age, cadence, and health state, but that signal was not visible in the Strategic Risk panel, so stale or missing seeded data could be hard to distinguish from genuinely quiet conditions.

## Changes

- Add `refreshDataFreshnessFromHealth()` to fetch `/api/health`, map health checks to frontend data sources, and record cadence-aware seed health.
- Extend `dataFreshness` with seed-health metadata, per-source `maxStaleMin`, and error/no-data handling for health statuses.
- Surface a compact Data Freshness list in `StrategicRiskPanel` with source state and last-update timing.
- Run health freshness polling as a non-blocking background task so risk rendering is not serialized behind `/api/health`.
- Localize the active/total source badge detail.
- Add drift and severity tests for health-check mapping, shared-source worst-status selection, and Redis outage status handling.

## Validation

- `npx tsx --test tests/data-freshness-health.test.mts`
- `npm run typecheck`
- `npx biome lint src/components/StrategicRiskPanel.ts src/locales/en.json tests/data-freshness-health.test.mts`
- `git diff --check`
- Fork PR CI: lspassos1/worldmonitor#31

## Risk

Low to moderate. The health fetch is additive and non-blocking; if it fails, existing session-local freshness remains in use. The mapping guard test should catch future drift between frontend source IDs and `/api/health` check names.
