### PR TITLE
fix(health): widen gpsjam maxStaleMin 12h → 24h

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -286,7 +286,7 @@ const SEED_META = {
   // minerals + giving: on-demand cachedFetchJson only, no seed-meta writer — freshness checked via TTL
   // bisExchange + bisCredit: extras written by same BIS script via writeExtraKey, no dedicated seed-meta
   fxYoy:            { key: 'seed-meta:economic:fx-yoy',           maxStaleMin: 1500 }, // daily cron; 25h tolerance + 1h drift
-  gpsjam:           { key: 'seed-meta:intelligence:gpsjam',       maxStaleMin: 720 },
+  gpsjam:           { key: 'seed-meta:intelligence:gpsjam',       maxStaleMin: 480 }, // Wingbits API (scripts/fetch-gpsjam.mjs); 480min = 8h tightens visibility on upstream outages and quota exhaustion (HTTP 402 observed 2026-04-29). seeder catch-block extends TTL on fail, so STALE_SEED via fetchedAt is the only alarm path.
   positiveGeoEvents:{ key: 'seed-meta:positive-events:geo',       maxStaleMin: 60 },
   riskScores:       { key: 'seed-meta:intelligence:risk-scores',  maxStaleMin: 30 }, // CII warm-ping every 8min; 30min = ~3.5x interval,
   iranEvents:       { key: 'seed-meta:conflict:iran-events',      maxStaleMin: 20160 }, // manual seed from LiveUAMap; 20160 = 14d = 2× weekly cadence

--- a/api/health.js
+++ b/api/health.js
@@ -286,7 +286,7 @@ const SEED_META = {
   // minerals + giving: on-demand cachedFetchJson only, no seed-meta writer — freshness checked via TTL
   // bisExchange + bisCredit: extras written by same BIS script via writeExtraKey, no dedicated seed-meta
   fxYoy:            { key: 'seed-meta:economic:fx-yoy',           maxStaleMin: 1500 }, // daily cron; 25h tolerance + 1h drift
-  gpsjam:           { key: 'seed-meta:intelligence:gpsjam',       maxStaleMin: 480 }, // Wingbits API (scripts/fetch-gpsjam.mjs); 480min = 8h tightens visibility on upstream outages and quota exhaustion (HTTP 402 observed 2026-04-29). seeder catch-block extends TTL on fail, so STALE_SEED via fetchedAt is the only alarm path.
+  gpsjam:           { key: 'seed-meta:intelligence:gpsjam',       maxStaleMin: 1440 }, // Wingbits API (scripts/fetch-gpsjam.mjs); 1440min = 24h tolerance gives operator headroom to handle upstream outages and monthly quota exhaustion (HTTP 402 observed 2026-04-29) without dashboard noise. Seeder catch-block extends TTL on fail without refreshing fetchedAt, so STALE_SEED via age is the only alarm path.
   positiveGeoEvents:{ key: 'seed-meta:positive-events:geo',       maxStaleMin: 60 },
   riskScores:       { key: 'seed-meta:intelligence:risk-scores',  maxStaleMin: 30 }, // CII warm-ping every 8min; 30min = ~3.5x interval,
   iranEvents:       { key: 'seed-meta:conflict:iran-events',      maxStaleMin: 20160 }, // manual seed from LiveUAMap; 20160 = 14d = 2× weekly cadence


### PR DESCRIPTION
## Summary

- \`api/health.js:289\` — \`gpsjam.maxStaleMin: 720 → 1440\` (12h → 24h)
- Adds the inline comment that was missing on this entry

## Why

Wingbits API hit HTTP 402 (monthly quota exhausted) 2026-04-29:
\`\`\`
{"statusCode":402,"error":"Payment Required",
 "message":"Monthly API usage limit exceeded. Please upgrade your plan."}
\`\`\`

The gpsjam seeder (\`scripts/fetch-gpsjam.mjs:258-262\`) catches all
fetch failures, calls \`extendExistingTtl(...172800)\`, and exits 0 —
which silences Railway's "deployment crashed" alarm. The ONLY signal
that the upstream is down is the \`fetchedAt\` age inside seed-meta
crossing \`maxStaleMin\`.

Operator-side decision: rather than alarming faster, widen the
tolerance so the monthly quota / upstream-outage signal doesn't keep
flipping the dashboard while the plan-side issue is being handled
out-of-band.

## Test plan

- [ ] Health endpoint returns OK once Wingbits quota resets (or upstream is otherwise restored) within 24h
- [ ] STALE_SEED still trips at 24h on a real prolonged outage