### PR TITLE
fix(portwatch): resolve ArcGIS date field name dynamically (survive flap)

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -173,12 +173,25 @@ async function fetchAllPortRefs({ signal } = {}) {
 //
 // Strategy: introspect the layer schema once per process, find the field
 // whose alias is "date" (alias is the stable signal), use its `name` for
-// the rest of the run. Module-level memoisation so repeated calls within
-// a run are cheap. Falls back to ARCGIS_DATE_FIELD_FALLBACK on error so
-// transient schema-endpoint failures don't kill the whole seed run.
-let _arcgisDateFieldCached = null;
-export async function resolveArcgisDateField({ signal } = {}) {
-  if (_arcgisDateFieldCached != null) return _arcgisDateFieldCached;
+// the rest of the run. Falls back to ARCGIS_DATE_FIELD_FALLBACK on error
+// so transient schema-endpoint failures don't kill the whole seed run.
+//
+// Memoisation: cache the in-flight PROMISE, not the resolved value, so
+// concurrent first-callers share one schema round-trip. The
+// fetchAll-driven flow awaits the resolver before any parallel work, so
+// in practice only one call ever races — but the defensive fall-throughs
+// in paginateWindowInto / fetchMaxDate / fetchCountryAccum can be invoked
+// from outside fetchAll (tests, future callers), so the once-inflight
+// pattern is the load-bearing safety. Greptile P2 on PR #3496.
+let _arcgisDateFieldPromise = null;
+export function resolveArcgisDateField({ signal } = {}) {
+  if (!_arcgisDateFieldPromise) {
+    _arcgisDateFieldPromise = _doResolveArcgisDateField({ signal });
+  }
+  return _arcgisDateFieldPromise;
+}
+
+async function _doResolveArcgisDateField({ signal } = {}) {
   try {
     const body = await fetchWithTimeout(EP3_SCHEMA, { signal });
     const fields = Array.isArray(body?.fields) ? body.fields : [];
@@ -195,11 +208,9 @@ export async function resolveArcgisDateField({ signal } = {}) {
     } else if (resolved !== ARCGIS_DATE_FIELD_FALLBACK) {
       console.log(`  [port-activity] resolved ArcGIS date field name: "${resolved}" (alias=date)`);
     }
-    _arcgisDateFieldCached = resolved;
     return resolved;
   } catch (err) {
     console.warn(`  [port-activity] schema introspection failed (${err?.message || err}) — using fallback "${ARCGIS_DATE_FIELD_FALLBACK}"`);
-    _arcgisDateFieldCached = ARCGIS_DATE_FIELD_FALLBACK;
     return ARCGIS_DATE_FIELD_FALLBACK;
   }
 }
@@ -207,7 +218,7 @@ export async function resolveArcgisDateField({ signal } = {}) {
 // Test-only helper: clears the module-level cache so unit tests can
 // re-exercise the resolver with different mocked schemas.
 export function _resetArcgisDateFieldCache() {
-  _arcgisDateFieldCached = null;
+  _arcgisDateFieldPromise = null;
 }
 
 // Paginate a single ArcGIS EP3 window into per-port accumulators. Called

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -27,6 +27,15 @@ const MIN_VALID_COUNTRIES = 50;
 
 const EP3_BASE =
   'https://services9.arcgis.com/weJ1QsnbMYJlCHdG/arcgis/rest/services/Daily_Ports_Data/FeatureServer/0/query';
+// Schema introspection URL — same FeatureServer, no /query suffix. Used by
+// resolveArcgisDateField to resolve the queryable date-column name at run
+// start so the seeder survives IMF flapping the rename (`date` → `date_`
+// → `date` observed within ~9h on 2026-04-29).
+const EP3_SCHEMA = EP3_BASE.replace('/query', '?f=json');
+// Fallback when schema introspection fails. `date` is the historical default
+// (and the state observed at 12:09 UTC 2026-04-29 after IMF reverted the
+// rename); the resolver also accepts `date_` as a discovered name.
+const ARCGIS_DATE_FIELD_FALLBACK = 'date';
 const EP4_BASE =
   'https://services9.arcgis.com/weJ1QsnbMYJlCHdG/arcgis/rest/services/PortWatch_ports_database/FeatureServer/0/query';
 
@@ -96,11 +105,13 @@ async function fetchWithTimeout(url, { signal } = {}) {
 // bounded. Does not retry any other error class.
 //
 // IMPORTANT: a 100%-batch-rejected version of this error is NOT a flake —
-// it's an upstream schema-rename (e.g. `date` → `date_` on 2026-04-29 via
-// IMF's reserved-keyword sweep, see fetchAll's first-batch circuit-breaker).
-// The single-retry assumption only holds for sporadic 3-of-N rejections;
-// the circuit-breaker handles the global-regression case to avoid burning
-// 30s of doomed work per cron tick.
+// it's an upstream schema-rename or policy change. The 2026-04-29 IMF
+// reserved-keyword sweep flapped `date` → `date_` → `date` within ~9h,
+// which would silently break any seeder using a hardcoded literal twice
+// in the same incident. resolveArcgisDateField introspects the schema at
+// run start to survive the flap; the circuit-breaker below still covers
+// other global-regression classes (renamed table, removed field, policy
+// change) so we don't burn 30s of doomed work per cron tick.
 async function fetchWithRetryOnInvalidParams(url, { signal } = {}) {
   try {
     return await fetchWithTimeout(url, { signal });
@@ -152,23 +163,73 @@ async function fetchAllPortRefs({ signal } = {}) {
   return byIso3;
 }
 
+// Resolve the queryable date-column name on Daily_Ports_Data. ArcGIS treats
+// alias and name as separate concepts — alias stays "date" forever (it's
+// metadata, displayed in catalogs), but `name` is what WHERE / outFields /
+// orderByFields / outStatistics actually accept, and IMF has flapped the
+// `name` between `date` and `date_` (reserved-keyword sweep on 2026-04-29
+// flipped to `date_` at ~02:54 UTC, then reverted to `date` by ~12:09 UTC,
+// so a hardcoded literal breaks twice in the same incident).
+//
+// Strategy: introspect the layer schema once per process, find the field
+// whose alias is "date" (alias is the stable signal), use its `name` for
+// the rest of the run. Module-level memoisation so repeated calls within
+// a run are cheap. Falls back to ARCGIS_DATE_FIELD_FALLBACK on error so
+// transient schema-endpoint failures don't kill the whole seed run.
+let _arcgisDateFieldCached = null;
+export async function resolveArcgisDateField({ signal } = {}) {
+  if (_arcgisDateFieldCached != null) return _arcgisDateFieldCached;
+  try {
+    const body = await fetchWithTimeout(EP3_SCHEMA, { signal });
+    const fields = Array.isArray(body?.fields) ? body.fields : [];
+    // Prefer alias-match (canonical: alias is what humans named it, name is
+    // what the SQL parser eats). Fall back to a name-equality match if no
+    // alias hit, in case IMF ever reverses the alias too.
+    const byAlias = fields.find((f) => f && f.alias === 'date' &&
+      (f.type === 'esriFieldTypeDateOnly' || f.type === 'esriFieldTypeDate'));
+    const byName = fields.find((f) => f && (f.name === 'date' || f.name === 'date_') &&
+      (f.type === 'esriFieldTypeDateOnly' || f.type === 'esriFieldTypeDate'));
+    const resolved = byAlias?.name || byName?.name || ARCGIS_DATE_FIELD_FALLBACK;
+    if (!byAlias && !byName) {
+      console.warn(`  [port-activity] schema introspection found no date field — using fallback "${ARCGIS_DATE_FIELD_FALLBACK}"`);
+    } else if (resolved !== ARCGIS_DATE_FIELD_FALLBACK) {
+      console.log(`  [port-activity] resolved ArcGIS date field name: "${resolved}" (alias=date)`);
+    }
+    _arcgisDateFieldCached = resolved;
+    return resolved;
+  } catch (err) {
+    console.warn(`  [port-activity] schema introspection failed (${err?.message || err}) — using fallback "${ARCGIS_DATE_FIELD_FALLBACK}"`);
+    _arcgisDateFieldCached = ARCGIS_DATE_FIELD_FALLBACK;
+    return ARCGIS_DATE_FIELD_FALLBACK;
+  }
+}
+
+// Test-only helper: clears the module-level cache so unit tests can
+// re-exercise the resolver with different mocked schemas.
+export function _resetArcgisDateFieldCache() {
+  _arcgisDateFieldCached = null;
+}
+
 // Paginate a single ArcGIS EP3 window into per-port accumulators. Called
 // twice per country — once for each aggregation window (last30, prev30) —
 // in parallel so heavy countries no longer have to serialise through both
 // windows inside a single 90s cap.
-async function paginateWindowInto(portAccumMap, iso3, where, windowKind, { signal } = {}) {
+async function paginateWindowInto(portAccumMap, iso3, where, windowKind, { signal, dateField } = {}) {
+  // Defensive: callers should always thread dateField through, but if a
+  // future caller forgets, fall back to the resolver (idempotent + cached).
+  const df = dateField || (await resolveArcgisDateField({ signal }));
   let offset = 0;
   let body;
   do {
     if (signal?.aborted) throw signal.reason ?? new Error('aborted');
     const params = new URLSearchParams({
       where,
-      // IMF PortWatch renamed `date` → `date_` on 2026-04-29 (reserved-keyword
-      // sweep, see ARCGIS_DATE_FIELD comment below). Field alias is still
-      // "date" but the queryable name is `date_` — alias ≠ name in ArcGIS.
-      outFields: 'portid,portname,ISO3,date_,portcalls_tanker,import_tanker,export_tanker',
+      // ArcGIS treats alias and name as separate — alias stays "date" but
+      // the queryable name has flapped between `date` and `date_`. Resolved
+      // dynamically via resolveArcgisDateField() at run start.
+      outFields: `portid,portname,ISO3,${df},portcalls_tanker,import_tanker,export_tanker`,
       returnGeometry: 'false',
-      orderByFields: 'portid ASC,date_ ASC',
+      orderByFields: `portid ASC,${df} ASC`,
       resultRecordCount: String(PAGE_SIZE),
       resultOffset: String(offset),
       outSR: '4326',
@@ -178,7 +239,7 @@ async function paginateWindowInto(portAccumMap, iso3, where, windowKind, { signa
     const features = body.features ?? [];
     for (const f of features) {
       const a = f.attributes;
-      if (!a || a.portid == null || a.date_ == null) continue;
+      if (!a || a.portid == null || a[df] == null) continue;
       const portId = String(a.portid);
       const calls = Number(a.portcalls_tanker ?? 0);
       const imports = Number(a.import_tanker ?? 0);
@@ -241,30 +302,32 @@ function parseMaxDateToAnchor(maxDateStr) {
 // anomalySignal always false. Not a feature regression — it was already dead.
 //
 // Returns Map<portId, PortAccum>. Memory per country is O(unique ports) ≈ <200.
-async function fetchCountryAccum(iso3, { signal, anchorEpochMs } = {}) {
+async function fetchCountryAccum(iso3, { signal, anchorEpochMs, dateField } = {}) {
   const anchor = anchorEpochMs ?? Date.now();
   const cutoff30 = anchor - 30 * 86400000;
   const cutoff60 = anchor - 60 * 86400000;
+  const df = dateField || (await resolveArcgisDateField({ signal }));
 
   const portAccumMap = new Map();
 
-  // ARCGIS_DATE_FIELD: queryable column is `date_`, not `date` — see comment
-  // on outFields above. The `timestamp 'YYYY-MM-DD HH:MM:SS'` literal still
-  // works on the new esriFieldTypeDateOnly column (verified 2026-04-29).
+  // ARCGIS_DATE_FIELD: queryable column name is resolved dynamically at run
+  // start via resolveArcgisDateField. The `timestamp 'YYYY-MM-DD HH:MM:SS'`
+  // literal works on both the esriFieldTypeDateOnly and esriFieldTypeDate
+  // shapes ArcGIS may serve.
   await Promise.all([
     paginateWindowInto(
       portAccumMap,
       iso3,
-      `ISO3='${iso3}' AND date_ > ${epochToTimestamp(cutoff30)}`,
+      `ISO3='${iso3}' AND ${df} > ${epochToTimestamp(cutoff30)}`,
       'last30',
-      { signal },
+      { signal, dateField: df },
     ),
     paginateWindowInto(
       portAccumMap,
       iso3,
-      `ISO3='${iso3}' AND date_ > ${epochToTimestamp(cutoff60)} AND date_ <= ${epochToTimestamp(cutoff30)}`,
+      `ISO3='${iso3}' AND ${df} > ${epochToTimestamp(cutoff60)} AND ${df} <= ${epochToTimestamp(cutoff30)}`,
       'prev30',
-      { signal },
+      { signal, dateField: df },
     ),
   ]);
 
@@ -276,13 +339,15 @@ async function fetchCountryAccum(iso3, { signal, anchorEpochMs } = {}) {
 // advanced since the last cached run. ~1-2s per call at ArcGIS's current
 // steady-state. Returns ISO date string "YYYY-MM-DD" or null on any error
 // (we then fall through to the expensive path, which has its own retry).
-async function fetchMaxDate(iso3, { signal } = {}) {
+async function fetchMaxDate(iso3, { signal, dateField } = {}) {
+  const df = dateField || (await resolveArcgisDateField({ signal }));
   const outStats = JSON.stringify([{
     statisticType: 'max',
-    // See ARCGIS_DATE_FIELD comment in fetchCountryAccum: queryable name is
-    // `date_`, not `date`. outStatisticFieldName is the response key —
-    // unchanged on purpose so callers keep reading `attrs.max_date`.
-    onStatisticField: 'date_',
+    // See ARCGIS_DATE_FIELD comment in fetchCountryAccum: the queryable
+    // column name is resolved dynamically (alias=date, name flaps).
+    // outStatisticFieldName is the response key — unchanged on purpose so
+    // callers keep reading `attrs.max_date`.
+    onStatisticField: df,
     outStatisticFieldName: 'max_date',
   }]);
   const params = new URLSearchParams({
@@ -397,8 +462,21 @@ async function redisMgetJson(keys) {
 //
 // `progress` (optional) is mutated in-place so a SIGTERM handler in main()
 // can report which batch / country we died on.
+//
+// fetchAll is the orchestrator (refs → schema → preflight → cache-partition
+// → batched fetch → finalise); splitting it would move complexity into a
+// hidden seam and obscure the linear pipeline. Each stage is short and
+// well-commented; suppress the cognitive-complexity warning on the line.
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestrator pipeline
 export async function fetchAll(progress, { signal } = {}) {
   const { iso3ToIso2 } = createCountryResolvers();
+
+  // Resolve the queryable date-column name once per run, before any
+  // country-level work. Threaded through to fetchMaxDate, fetchCountryAccum,
+  // and paginateWindowInto so a single name flap on the upstream side
+  // can't half-break the run.
+  if (progress) progress.stage = 'schema';
+  const dateField = await resolveArcgisDateField({ signal });
 
   if (progress) progress.stage = 'refs';
   console.log('  [port-activity] Fetching global port reference (EP4)...');
@@ -446,7 +524,7 @@ export async function fetchAll(progress, { signal } = {}) {
     if (signal?.aborted) throw signal.reason ?? new Error('aborted');
     const slice = eligibleIso3.slice(i, i + PREFLIGHT_CONCURRENCY);
     const settled = await Promise.allSettled(
-      slice.map((iso3) => fetchMaxDate(iso3, { signal })),
+      slice.map((iso3) => fetchMaxDate(iso3, { signal, dateField })),
     );
     for (let j = 0; j < slice.length; j++) {
       const r = settled[j];
@@ -502,7 +580,7 @@ export async function fetchAll(progress, { signal } = {}) {
       // Falls back to Date.now() when preflight returned null.
       const anchorEpochMs = parseMaxDateToAnchor(upstreamMaxDate);
       const p = withPerCountryTimeout(
-        (childSignal) => fetchCountryAccum(iso3, { signal: childSignal, anchorEpochMs }),
+        (childSignal) => fetchCountryAccum(iso3, { signal: childSignal, anchorEpochMs, dateField }),
         iso3,
       );
       // Eager error flush so a SIGTERM mid-batch captures rejections that

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -44,16 +44,22 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /PortWatch_ports_database/);
   });
 
-  it('EP3 per-country WHERE uses ISO3 index + date filter', () => {
+  it('EP3 per-country WHERE uses ISO3 index + dynamic date field', () => {
     // After the PR #3225 globalisation failed in prod, we restored the
     // per-country shape because ArcGIS has an ISO3 index but NO date
     // index — the per-country filter is what keeps queries fast.
     // H+F refactor: the WHERE clause is now built inline at the
     // paginateWindowInto call site (not as a `where:` param in a params
     // bag) because each window has a different date predicate.
-    // Field is `date_` post-2026-04-29 IMF reserved-keyword sweep (alias=date,
-    // queryable name=date_). See ARCGIS_DATE_FIELD comment in the seeder.
-    assert.match(src, /`ISO3='\$\{iso3\}'\s+AND\s+date_\s*>/);
+    // Post-2026-04-29 (IMF reserved-keyword flap): the date field name is
+    // resolved DYNAMICALLY at run start via resolveArcgisDateField — the
+    // WHERE template must interpolate the resolved name (`${df}`), NOT a
+    // hardcoded literal, so the seeder survives a `date` ↔ `date_` flap.
+    assert.match(src, /`ISO3='\$\{iso3\}'\s+AND\s+\$\{df\}\s*>/);
+    // Hardcoded `date` or `date_` literals in the WHERE template are
+    // exactly the bug class this dynamic-resolution change exists to
+    // prevent. Lock that out at test time.
+    assert.doesNotMatch(src, /`ISO3='\$\{iso3\}'\s+AND\s+date_?\s*>/);
     // Global where=date>X shape (PR #3225) must NOT be present.
     assert.doesNotMatch(src, /where:\s*`date_?\s*>\s*\$\{epochToTimestamp\(since\)\}`/);
   });
@@ -131,7 +137,11 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
   it('fetchMaxDate preflight uses outStatistics for cheap cache invalidation', () => {
     assert.match(src, /async function fetchMaxDate/);
     assert.match(src, /statisticType:\s*'max'/);
-    assert.match(src, /onStatisticField:\s*'date_'/);
+    // Same dynamic-resolution invariant as the WHERE clause: onStatisticField
+    // must use the resolved `df`, not a hardcoded literal — the IMF
+    // 2026-04-29 flap proved either name can appear within hours.
+    assert.match(src, /onStatisticField:\s*df\b/);
+    assert.doesNotMatch(src, /onStatisticField:\s*'date_?'/);
   });
 
   it('fetchAll cache path: MGET preflight + maxDate check + reuse payload', () => {
@@ -210,12 +220,33 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /const anchor = anchorEpochMs \?\? Date\.now\(\)/);
   });
 
-  it('fetchCountryAccum receives anchorEpochMs at the call site', () => {
+  it('fetchCountryAccum receives anchorEpochMs and dateField at the call site', () => {
     // The call site must thread the parsed maxDate anchor into
     // fetchCountryAccum — otherwise the windows default to Date.now()
     // and cache reuse serves stale data (defeats the H-path entirely).
+    // The call site must also thread the run-resolved dateField so each
+    // country fetch uses the same resolved name and one introspection
+    // round-trip serves the whole run.
     assert.match(src, /parseMaxDateToAnchor\(upstreamMaxDate\)/);
-    assert.match(src, /fetchCountryAccum\(iso3,\s*\{\s*signal:\s*childSignal,\s*anchorEpochMs\s*\}\)/);
+    assert.match(
+      src,
+      /fetchCountryAccum\(iso3,\s*\{\s*signal:\s*childSignal,\s*anchorEpochMs,\s*dateField\s*\}\)/,
+    );
+  });
+
+  it('fetchAll resolves the ArcGIS date field once at run start', () => {
+    // The dynamic-resolution invariant: resolveArcgisDateField must be
+    // called BEFORE any country-level fetch (preflight or batches) so
+    // every per-country call within the run sees the same resolved name.
+    // This is the single source of truth that survives an IMF schema flap.
+    assert.match(src, /export async function resolveArcgisDateField/);
+    // Called inside fetchAll before refs/preflight/activity stages.
+    assert.match(
+      src,
+      /export async function fetchAll[\s\S]{0,400}?resolveArcgisDateField\(/,
+    );
+    // Both per-country fetchers receive dateField from the resolved value.
+    assert.match(src, /fetchMaxDate\(iso3,\s*\{\s*signal,\s*dateField\s*\}\)/);
   });
 
   it('TTL is 259200 (3 days)', () => {
@@ -482,5 +513,104 @@ describe('validateFn', () => {
     const data = null;
     const valid = !!(data && Array.isArray(data.countries) && data.countries.length >= 50);
     assert.equal(valid, false);
+  });
+});
+
+describe('resolveArcgisDateField (runtime, schema-flap defence)', () => {
+  let resolveArcgisDateField, _resetArcgisDateFieldCache;
+  let originalFetch;
+
+  before(async () => {
+    ({ resolveArcgisDateField, _resetArcgisDateFieldCache } = await import(
+      '../scripts/seed-portwatch-port-activity.mjs'
+    ));
+    originalFetch = globalThis.fetch;
+  });
+
+  function mockFetchOnce(body) {
+    globalThis.fetch = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => body,
+    });
+  }
+
+  function restoreFetch() {
+    globalThis.fetch = originalFetch;
+  }
+
+  it('returns "date" when schema reports name=date alias=date (post-revert state)', async () => {
+    _resetArcgisDateFieldCache();
+    mockFetchOnce({
+      fields: [
+        { name: 'date', alias: 'date', type: 'esriFieldTypeDateOnly' },
+        { name: 'portid', alias: 'portid', type: 'esriFieldTypeString' },
+      ],
+    });
+    try {
+      const df = await resolveArcgisDateField();
+      assert.equal(df, 'date');
+    } finally { restoreFetch(); }
+  });
+
+  it('returns "date_" when schema reports name=date_ alias=date (post-rename state)', async () => {
+    _resetArcgisDateFieldCache();
+    mockFetchOnce({
+      fields: [
+        { name: 'date_', alias: 'date', type: 'esriFieldTypeDateOnly' },
+        { name: 'portid', alias: 'portid', type: 'esriFieldTypeString' },
+      ],
+    });
+    try {
+      const df = await resolveArcgisDateField();
+      assert.equal(df, 'date_');
+    } finally { restoreFetch(); }
+  });
+
+  it('memoises the resolved value across calls within a run', async () => {
+    _resetArcgisDateFieldCache();
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls++;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          fields: [{ name: 'date_', alias: 'date', type: 'esriFieldTypeDateOnly' }],
+        }),
+      };
+    };
+    try {
+      const a = await resolveArcgisDateField();
+      const b = await resolveArcgisDateField();
+      const c = await resolveArcgisDateField();
+      assert.equal(a, 'date_');
+      assert.equal(b, 'date_');
+      assert.equal(c, 'date_');
+      assert.equal(calls, 1, 'schema endpoint must be hit at most once per run');
+    } finally { restoreFetch(); }
+  });
+
+  it('falls back to "date" when schema introspection throws', async () => {
+    _resetArcgisDateFieldCache();
+    globalThis.fetch = async () => { throw new Error('schema endpoint timeout'); };
+    try {
+      const df = await resolveArcgisDateField();
+      assert.equal(df, 'date');
+    } finally { restoreFetch(); }
+  });
+
+  it('falls back to "date" when schema response has no date field', async () => {
+    _resetArcgisDateFieldCache();
+    mockFetchOnce({
+      fields: [
+        { name: 'portid', alias: 'portid', type: 'esriFieldTypeString' },
+        { name: 'ISO3', alias: 'ISO3', type: 'esriFieldTypeString' },
+      ],
+    });
+    try {
+      const df = await resolveArcgisDateField();
+      assert.equal(df, 'date');
+    } finally { restoreFetch(); }
   });
 });

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -239,7 +239,12 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     // called BEFORE any country-level fetch (preflight or batches) so
     // every per-country call within the run sees the same resolved name.
     // This is the single source of truth that survives an IMF schema flap.
-    assert.match(src, /export async function resolveArcgisDateField/);
+    // Resolver is exported as a sync function that returns the cached
+    // in-flight promise (Greptile P2 fix on PR #3496) — the actual
+    // schema-fetch lives in `_doResolveArcgisDateField`. Both must be
+    // present, but only the former is the public entry point.
+    assert.match(src, /export function resolveArcgisDateField/);
+    assert.match(src, /async function _doResolveArcgisDateField/);
     // Called inside fetchAll before refs/preflight/activity stages.
     assert.match(
       src,
@@ -527,7 +532,11 @@ describe('resolveArcgisDateField (runtime, schema-flap defence)', () => {
     originalFetch = globalThis.fetch;
   });
 
-  function mockFetchOnce(body) {
+  // Sets globalThis.fetch to a stub returning `body`. Stays installed
+  // until restoreFetch() — name reflects that (Greptile P2 on PR #3496:
+  // the original `mockFetchOnce` name implied auto-reset semantics it
+  // didn't enforce, masking accidental cache hits in future edits).
+  function mockFetch(body) {
     globalThis.fetch = async () => ({
       ok: true,
       status: 200,
@@ -541,7 +550,7 @@ describe('resolveArcgisDateField (runtime, schema-flap defence)', () => {
 
   it('returns "date" when schema reports name=date alias=date (post-revert state)', async () => {
     _resetArcgisDateFieldCache();
-    mockFetchOnce({
+    mockFetch({
       fields: [
         { name: 'date', alias: 'date', type: 'esriFieldTypeDateOnly' },
         { name: 'portid', alias: 'portid', type: 'esriFieldTypeString' },
@@ -555,7 +564,7 @@ describe('resolveArcgisDateField (runtime, schema-flap defence)', () => {
 
   it('returns "date_" when schema reports name=date_ alias=date (post-rename state)', async () => {
     _resetArcgisDateFieldCache();
-    mockFetchOnce({
+    mockFetch({
       fields: [
         { name: 'date_', alias: 'date', type: 'esriFieldTypeDateOnly' },
         { name: 'portid', alias: 'portid', type: 'esriFieldTypeString' },
@@ -602,7 +611,7 @@ describe('resolveArcgisDateField (runtime, schema-flap defence)', () => {
 
   it('falls back to "date" when schema response has no date field', async () => {
     _resetArcgisDateFieldCache();
-    mockFetchOnce({
+    mockFetch({
       fields: [
         { name: 'portid', alias: 'portid', type: 'esriFieldTypeString' },
         { name: 'ISO3', alias: 'ISO3', type: 'esriFieldTypeString' },
@@ -611,6 +620,46 @@ describe('resolveArcgisDateField (runtime, schema-flap defence)', () => {
     try {
       const df = await resolveArcgisDateField();
       assert.equal(df, 'date');
+    } finally { restoreFetch(); }
+  });
+
+  it('concurrent first-callers share one schema round-trip (promise-cache)', async () => {
+    // Greptile P2 on PR #3496: cache the in-flight promise, not the
+    // resolved value, so `Promise.all([resolve(), resolve(), resolve()])`
+    // dispatches a single fetch. Without this, three null-checks fire
+    // before any fetch settles → three round-trips.
+    _resetArcgisDateFieldCache();
+    let calls = 0;
+    let resolveFetch;
+    globalThis.fetch = () => {
+      calls++;
+      // Hold the fetch open so all three callers race against the same
+      // unresolved promise — the bug-class this guards against.
+      return new Promise((r) => {
+        resolveFetch = () => r({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            fields: [{ name: 'date', alias: 'date', type: 'esriFieldTypeDateOnly' }],
+          }),
+        });
+      });
+    };
+    try {
+      const racing = Promise.all([
+        resolveArcgisDateField(),
+        resolveArcgisDateField(),
+        resolveArcgisDateField(),
+      ]);
+      // Microtask flush so the three calls have all entered the resolver
+      // and registered their continuations on the cached promise.
+      await Promise.resolve();
+      resolveFetch();
+      const [a, b, c] = await racing;
+      assert.equal(a, 'date');
+      assert.equal(b, 'date');
+      assert.equal(c, 'date');
+      assert.equal(calls, 1, 'three concurrent first-callers must share ONE schema fetch');
     } finally { restoreFetch(); }
   });
 });


### PR DESCRIPTION
## Summary

- Resolves the queryable date-column name on Daily_Ports_Data at run start by introspecting the FeatureServer schema (alias is the stable signal), instead of hardcoding `date` or `date_`.
- Threads the resolved \`dateField\` through every per-country query (\`fetchMaxDate\`, \`fetchCountryAccum\`, \`paginateWindowInto\`).
- New runtime test suite (5 cases) covering both schema states + memoisation + two fallback paths.

## Why

IMF PortWatch flapped the date-field \`name\` twice on 2026-04-29:
- ~02:54 UTC: \`date\` → \`date_\` (broke pre-#3495 seeder)
- ~12:09 UTC: \`date_\` → \`date\` (broke post-#3495 seeder)

PR #3495 fixed the first flap by hardcoding \`date_\`; a hardcoded \`date\` would have broken at 02:54. Either literal is brittle to the next flap. The **alias** stays \"date\" across the rename — that's the canonical signal. This PR resolves \`name\` from \`alias\` once at run start and uses the resolved value everywhere.

## What changes

| File | Change |
|---|---|
| \`scripts/seed-portwatch-port-activity.mjs\` | Add \`resolveArcgisDateField()\` (memoised). Thread \`dateField\` through \`fetchAll\` → \`fetchMaxDate\` + \`fetchCountryAccum\` → \`paginateWindowInto\`. All WHERE / outFields / orderByFields / onStatisticField now interpolate the resolved name. Fallback to \`\"date\"\` on schema-introspection failure. |
| \`tests/portwatch-port-activity-seed.test.mjs\` | Static-source assertions updated to require the dynamic interpolation pattern (\`\${df}\`) AND assert hardcoded \`date\`/\`date_\` literals are NOT present in the WHERE template. New runtime suite covers both schema states, memoisation, fetch-throw fallback, no-date-field fallback. |

## Verified

- 67/67 tests pass (\`node --test tests/portwatch-port-activity-seed.test.mjs\`)
- biome lint clean (one pre-existing \`windowKind\` unused-param warning unrelated)
- Live ArcGIS smoke test from CLI: \`resolveArcgisDateField()\` returns \`\"date\"\` in 1.2s (current upstream state)

## Test plan

- [ ] Merge → next 12h cron tick should publish 174-country payload, port-activity STALE_SEED clears
- [ ] If IMF flaps the name again, the resolver picks up the new \`name\` automatically without a code change