### PR TITLE
fix(sentry): suppress zero-frame signal-timed-out + NotSupportedError rejections

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -459,6 +459,17 @@ Sentry.init({
       !hasFirstParty
       && /(?:Failed to fetch|error loading) dynamically imported module|Importing a module script failed/i.test(msg)
     ) return null;
+    // Zero-frame async-rejection patterns: AbortSignal.timeout() rejections
+    // and DOMException(NotSupportedError) bubble up via
+    // onunhandledrejection without any first-party frames captured (the
+    // browser fires them from internal infra at the timer boundary). Both
+    // phrases are runtime-emitted only — our shipped code cannot synthesize
+    // the literal "signal timed out" or DOMException name. Same `!hasFirstParty`
+    // safety as the dynamic-import block (WORLDMONITOR-66 / WORLDMONITOR-62).
+    if (
+      !hasFirstParty
+      && (/signal timed out/.test(msg) || /NotSupportedError/.test(msg))
+    ) return null;
     if (hasAnyStack && !hasFirstParty && (
       /\.(?:toLowerCase|trim|indexOf|findIndex) is not a function/.test(msg)
       || /Maximum call stack size exceeded/.test(msg)
@@ -466,7 +477,6 @@ Sentry.init({
       || /^\w{1,2} is not a (?:function|constructor)/.test(msg)
       || /Cannot add property \w+, object is not extensible/.test(msg)
       || /^TypeError: Internal error$/.test(msg)
-      || /NotSupportedError/.test(msg)
       || /^Key not found$/.test(msg)
       || /^Element not found$/.test(msg)
       || /^(?:TypeError: )?Failed to fetch$/.test(msg)
@@ -476,7 +486,6 @@ Sentry.init({
       || /^SyntaxError: Unexpected (?:token|keyword)/.test(msg)
       || /Invalid or unexpected token/.test(msg)
       || /^Operation timed out/.test(msg)
-      || /signal timed out/.test(msg)
       || /Cannot inject key into script value/.test(msg)
       || /Connection lost while action was in flight/.test(msg)
       || /WEBGLRenderPipeline.*Link error/.test(msg)

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -142,7 +142,6 @@ describe('empty-stack network/timeout errors are NOT suppressed', () => {
     'TypeError: NetworkError when attempting to fetch resource.',
     'Could not connect to the server',
     'Operation timed out',
-    'signal timed out',
     'Invalid or unexpected token',
   ];
 
@@ -230,6 +229,38 @@ describe('dynamic-module-import failures (stale chunk after deploy)', () => {
 
     it(`lets through "${msg.slice(0, 60)}..." with first-party stack`, () => {
       const event = makeEvent(msg, 'TypeError', [firstPartyFrame()]);
+      assert.ok(beforeSend(event) !== null, `"${msg}" with first-party stack should NOT be suppressed`);
+    });
+  }
+});
+
+// ─── Zero-frame async-rejection patterns: AbortSignal timeouts + DOMException(NotSupportedError) ───
+//
+// AbortSignal.timeout() rejections and DOMException(NotSupportedError) bubble
+// up via onunhandledrejection without first-party frames captured (browser
+// fires them from internal infra at the timer boundary). Both phrases are
+// runtime-emitted only — our shipped code cannot synthesize them
+// (WORLDMONITOR-66 / WORLDMONITOR-62).
+
+describe('zero-frame async-rejection patterns (timeout / DOMException)', () => {
+  const zeroFrameErrors = [
+    ['signal timed out', 'TimeoutError'],
+    ['NotSupportedError: The operation is not supported.', 'Error'],
+  ];
+
+  for (const [msg, type] of zeroFrameErrors) {
+    it(`suppresses "${msg.slice(0, 60)}..." with empty stack`, () => {
+      const event = makeEvent(msg, type, []);
+      assert.equal(beforeSend(event), null, `"${msg}" with empty stack should be suppressed`);
+    });
+
+    it(`suppresses "${msg.slice(0, 60)}..." with confirmed third-party stack`, () => {
+      const event = makeEvent(msg, type, [extensionFrame()]);
+      assert.equal(beforeSend(event), null);
+    });
+
+    it(`lets through "${msg.slice(0, 60)}..." with first-party stack`, () => {
+      const event = makeEvent(msg, type, [firstPartyFrame()]);
       assert.ok(beforeSend(event) !== null, `"${msg}" with first-party stack should NOT be suppressed`);
     });
   }


### PR DESCRIPTION
## Summary

- Move `signal timed out` and `NotSupportedError` patterns out of the `hasAnyStack && !hasFirstParty` block in `src/main.ts:beforeSend` and into the no-frames-allowed `!hasFirstParty` block (alongside the existing dynamic-import suppressor).
- Both patterns were technically present already, but the `hasAnyStack` gate kept them dead-letter — these errors arrive via `auto.browser.global_handlers.onunhandledrejection` with **zero captured frames**, so `hasAnyStack` is `false` and the suppressor never fires.
- Triage source: WORLDMONITOR-66 (`TimeoutError: signal timed out`, 86 events / 76 users) and WORLDMONITOR-62 (`NotSupportedError`, 28 events / 23 users).

## Why these are safe with `!hasFirstParty` only

Both phrases are **runtime-emitted only** — our shipped bundle cannot synthesize the literal `signal timed out` (only `AbortSignal.timeout()` does, from browser internals at the timer boundary) or the `NotSupportedError` DOMException name (only browser-vendor APIs throw it: audio/video/IndexedDB/getUserMedia/push). Same safety property the existing dynamic-import suppressor relies on. If a first-party frame ever appears in the trace (genuine first-party regression that goes through our code), `!hasFirstParty` evaluates false and the event passes through.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 7654/7654 pass
- [x] `node --test tests/sentry-beforesend.test.mjs` — 127/127 pass (added `zero-frame async-rejection patterns` suite, 6 new cases; removed stale `signal timed out` "should NOT suppress" assertion which was the inverse of the desired behavior)
- [x] `node --test tests/edge-functions.test.mjs` — 178/178 pass
- [x] Edge bundle check — clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK

## Suppression estimate

~114 events/month (99 unique users) from these two issues will start dropping after deploy. Both Sentry issues marked resolved in next release; auto-reopen if the suppression regresses.