### PR TITLE
fix(seed-health): mirror gpsjam 24h staleness (#3494 follow-up)

### DIFF
--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -45,7 +45,7 @@ const SEED_DOMAINS = {
   'conflict:ucdp-events':     { key: 'seed-meta:conflict:ucdp-events',     intervalMin: 210 },
   'weather:alerts':           { key: 'seed-meta:weather:alerts',           intervalMin: 15 },
   'economic:spending':        { key: 'seed-meta:economic:spending',        intervalMin: 60 },
-  'intelligence:gpsjam':      { key: 'seed-meta:intelligence:gpsjam',      intervalMin: 360 },
+  'intelligence:gpsjam':      { key: 'seed-meta:intelligence:gpsjam',      intervalMin: 720 }, // 720 × 2 = 1440min (24h) staleness; matches api/health.js gpsjam.maxStaleMin. Widened from 360 (12h) on 2026-04-29 alongside Wingbits API quota incident — see PR #3494 + the seeder graceful-failure path at scripts/fetch-gpsjam.mjs:258-262.
   'intelligence:satellites':  { key: 'seed-meta:intelligence:satellites',  intervalMin: 90 },
   'military:flights':         { key: 'seed-meta:military:flights',         intervalMin: 8 },
   'military-forecast-inputs': { key: 'seed-meta:military-forecast-inputs', intervalMin: 8 },


### PR DESCRIPTION
## Summary

Mirror the gpsjam staleness widening from #3494 into \`api/seed-health.js\` so both monitoring surfaces agree.

## Why (reviewer P1 on #3494)

> *This PR only widens gpsjam.maxStaleMin in /api/health, but it leaves the parallel seed-loop monitor in api/seed-health.js unchanged at intervalMin: 360 (api/seed-health.js:48, with staleness computed as intervalMin × 2 at api/seed-health.js:158). That means one monitoring surface will still flag gpsjam stale after 12h while the other now waits 24h.*

Setting \`intervalMin: 720\` makes the \`× 2\` formula land on \`1440min (24h)\`, matching \`api/health.js\` \`gpsjam.maxStaleMin: 1440\`. Both endpoints now flag stale at the same threshold.

## Background

The Wingbits API hit HTTP 402 (quota exhausted) on 2026-04-29. \`scripts/fetch-gpsjam.mjs:258-262\` catches all fetch failures, extends TTL on stale data, and exits 0 — so \`fetchedAt\` age is the only alarm path. Operator decision (per #3494): widen the alarm threshold to 24h so the dashboard doesn't keep flipping while the upstream plan is sorted out-of-band.

## Test plan

- [ ] Once #3494 is deployed, confirm \`/api/seed-health\` and \`/api/health\` agree on gpsjam status (both fresh until 24h, both stale after).