### PR TITLE
fix(sentry): suppress 3 more zero-frame patterns (OOM, DOM-walker, wrapper-injected timeout)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -466,14 +466,37 @@ Sentry.init({
     // phrases are runtime-emitted only — our shipped code cannot synthesize
     // the literal "signal timed out" or DOMException name. Same `!hasFirstParty`
     // safety as the dynamic-import block (WORLDMONITOR-66 / WORLDMONITOR-62).
+    //
+    // Extensions to the same gate:
+    //   • `out of memory` — Firefox via setInterval mechanism, zero frames
+    //     (WORLDMONITOR-KE). Browser-engine signal, not synthesizable by
+    //     our code.
+    //   • `\.(toLowerCase|trim|indexOf|findIndex) is not a function` —
+    //     Apple Mail privacy proxy walks DOM with forEach and assumes
+    //     `el.className` is a string, but on SVG elements it's a
+    //     `SVGAnimatedString` (WORLDMONITOR-P2). Frame stack is
+    //     [sentry-chunk, [native code]] which gets fully filtered out of
+    //     `nonInfraFrames` → hasAnyStack=false. The literal " is not a
+    //     function" suffix anchored to those four mutator names is
+    //     unambiguously a third-party prototype-mismatch (our code never
+    //     calls those methods on objects of unknown shape).
+    //   • `Request timeout: /...` — third-party Electron wrappers
+    //     (WORLDMONITOR-PW: Electron 39.2.7 polling /api/setIsSelect, an
+    //     endpoint we don't serve). Our own `Request timeout` strings
+    //     don't include a colon-and-path suffix; the format is unique to
+    //     wrapper-injected code.
     if (
       !hasFirstParty
-      && (/signal timed out/.test(msg) || /NotSupportedError/.test(msg))
+      && (
+        /signal timed out/.test(msg)
+        || /NotSupportedError/.test(msg)
+        || /out of memory/i.test(msg)
+        || /\.(?:toLowerCase|trim|indexOf|findIndex) is not a function/.test(msg)
+        || /^(?:Error: )?Request timeout: \//.test(msg)
+      )
     ) return null;
     if (hasAnyStack && !hasFirstParty && (
-      /\.(?:toLowerCase|trim|indexOf|findIndex) is not a function/.test(msg)
-      || /Maximum call stack size exceeded/.test(msg)
-      || /out of memory/i.test(msg)
+      /Maximum call stack size exceeded/.test(msg)
       || /^\w{1,2} is not a (?:function|constructor)/.test(msg)
       || /Cannot add property \w+, object is not extensible/.test(msg)
       || /^TypeError: Internal error$/.test(msg)

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -242,10 +242,23 @@ describe('dynamic-module-import failures (stale chunk after deploy)', () => {
 // runtime-emitted only — our shipped code cannot synthesize them
 // (WORLDMONITOR-66 / WORLDMONITOR-62).
 
-describe('zero-frame async-rejection patterns (timeout / DOMException)', () => {
+describe('zero-frame async-rejection patterns (timeout / DOMException / OOM / DOM-walker / wrapper-injected timeout)', () => {
   const zeroFrameErrors = [
     ['signal timed out', 'TimeoutError'],
     ['NotSupportedError: The operation is not supported.', 'Error'],
+    // Firefox setInterval mechanism, no captured frames (WORLDMONITOR-KE)
+    ['out of memory', 'Error'],
+    // Apple Mail privacy proxy DOM walker (WORLDMONITOR-P2). Frames in
+    // production are [sentry-chunk, [native code]] which fully filter out
+    // of `nonInfraFrames` so empty-stack semantics apply.
+    [".toLowerCase is not a function. (In 'el.className.toLowerCase()', 'el.className.toLowerCase' is undefined)", 'TypeError'],
+    ['.trim is not a function', 'TypeError'],
+    ['.indexOf is not a function', 'TypeError'],
+    ['.findIndex is not a function', 'TypeError'],
+    // Third-party Electron wrapper polling endpoints we don't serve
+    // (WORLDMONITOR-PW: /api/setIsSelect from Electron 39.2.7).
+    ['Request timeout: /api/setIsSelect', 'Error'],
+    ['Error: Request timeout: /api/whatever', 'Error'],
   ];
 
   for (const [msg, type] of zeroFrameErrors) {
@@ -270,11 +283,7 @@ describe('zero-frame async-rejection patterns (timeout / DOMException)', () => {
 
 describe('ambiguous runtime errors', () => {
   const ambiguousErrors = [
-    '.trim is not a function',
-    'e.toLowerCase is not a function',
-    '.indexOf is not a function',
     'Maximum call stack size exceeded',
-    'out of memory',
     'Cannot add property x, object is not extensible',
     'TypeError: Internal error',
     'Key not found',


### PR DESCRIPTION
## Summary

Follow-on to PR #3497 (which moved `signal timed out` + `NotSupportedError` out of the `hasAnyStack && !hasFirstParty` gate into a `!hasFirstParty`-only block). Triage of WORLDMONITOR-KE / WORLDMONITOR-P2 / WORLDMONITOR-PW found 3 more patterns that hit the same dead-letter problem and need the same fix:

- **`out of memory`** — Firefox 140 / Linux via `setInterval` mechanism, zero captured frames (WORLDMONITOR-KE, 8ev / 7u). Browser-engine signal; our shipped code cannot synthesize this exact phrase.
- **`\.(toLowerCase|trim|indexOf|findIndex) is not a function`** — Apple Mail privacy-proxy walks the DOM with `forEach` and assumes `el.className` is a string, but on SVG elements it's a `SVGAnimatedString` (WORLDMONITOR-P2, 2ev). Stack is `[sentry-chunk, [native code]]` which gets fully filtered out of `nonInfraFrames` → `hasAnyStack=false`, bypassing the old gate.
- **`^(Error: )?Request timeout: \/`** — third-party Electron 39.2.7 wrapper polling endpoints we don't serve (WORLDMONITOR-PW: `/api/setIsSelect`). Our own `Request timeout` strings in `scripts/ais-relay.cjs` don't include a colon-and-path suffix; the format is unique to wrapper-injected code.

## Why these are safe with `!hasFirstParty` only

Same safety contract as PR #3497:
- `out of memory` literal is browser-engine-emitted only.
- The four mutator-suffix patterns (`.toLowerCase` / `.trim` / `.indexOf` / `.findIndex`) anchored to `is not a function` is structurally a third-party prototype-mismatch — our code never invokes those methods on objects of unknown shape.
- `Request timeout: /…` colon-and-path format isn't synthesized anywhere in our codebase.
- If a first-party frame ever appears in the stack (genuine first-party regression), `!hasFirstParty` evaluates false and the event passes through.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 7670/7670 pass
- [x] `node --test tests/sentry-beforesend.test.mjs` — 136/136 pass (zero-frame suite extended with 7 new cases; removed stale "should NOT suppress with empty stack" assertions for `out of memory`, `.trim`, `.indexOf`, `e.toLowerCase` which were the inverse of the desired behavior)
- [x] `node --test tests/edge-functions.test.mjs` — 178/178 pass
- [x] Edge bundle check — clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK

## Sentry status

WORLDMONITOR-KE / -P2 / -PW marked resolved in next release; auto-reopen if the suppression regresses.