### PR TITLE
feat(broadcast): wave-loading state machine — replace monolithic action with multi-step pipeline (plan PR2)

### DIFF
--- a/convex/__tests__/rampRunner.test.ts
+++ b/convex/__tests__/rampRunner.test.ts
@@ -506,76 +506,16 @@ describe("_recordWaveSent — clears all pending* progress markers (P1#4)", () =
 // clearPartialFailure — fail-closed unless operator confirms no export (P1#3)
 // ----------------------------------------------------------------------------
 
-describe("runDailyRamp — underfilled branch routes through recoverable partial-failure (PR #3476 review round 4)", () => {
-  test("underfilled branch records lastRunStatus=partial-failure (NOT pool-drained), deactivates ramp", () => {
-    // Round 4 fix: contacts ARE stamped + in Resend segment by the time
-    // assignAndExportWave returns underfilled. The previous code recorded
-    // status="pool-drained" + deactivate + cleared lease — stranding the
-    // exported audience (no broadcast created/sent, contacts excluded from
-    // future picks). recoverFromPartialFailure couldn't run because status
-    // was "pool-drained" not "partial-failure". Route through
-    // partial-failure with persisted pending* markers so manual recovery
-    // is reachable.
-    //
-    // Source-grep contract: the underfilled branch must call _recordRunOutcome
-    // with status: "partial-failure" (not "pool-drained"), AND the error
-    // message must mention recoverFromPartialFailure for operator guidance.
-    const underfilledIdx = runnerSrc.indexOf("exportResult.underfilled");
-    expect(underfilledIdx).toBeGreaterThan(-1);
-    // Slice the source from the underfilled check forward through the next
-    // branch boundary (next `if (` or end-of-function); contract assertions
-    // below match against this slice.
-    const sliceEnd = runnerSrc.indexOf("// ──── Step 4", underfilledIdx);
-    expect(sliceEnd).toBeGreaterThan(underfilledIdx);
-    const underfilledBlock = runnerSrc.slice(underfilledIdx, sliceEnd);
-
-    // Status must be partial-failure (so recovery is reachable).
-    expect(underfilledBlock).toMatch(/status:\s*"partial-failure"/);
-    // Must NOT route through pool-drained status (that strands the audience).
-    expect(underfilledBlock).not.toMatch(/status:\s*"pool-drained"/);
-    // Must deactivate (curve is done).
-    expect(underfilledBlock).toMatch(/deactivate:\s*true/);
-    // Operator guidance must reference recoverFromPartialFailure.
-    expect(underfilledBlock).toMatch(/recoverFromPartialFailure/);
-  });
-});
-
-describe("runDailyRamp — call order: _recordPendingExport BEFORE failure branches (PR #3476 review round 3)", () => {
-  test("_recordPendingExport is called immediately after assignAndExportWave returns, BEFORE checking failed/stampFailed/underfilled", () => {
-    // Source-grep regression test. Catches the foot-gun caught in PR #3476
-    // review round 3: if `_recordPendingExport` ran AFTER the
-    // (failed > 0 || stampFailed > 0) branch or the underfilled branch,
-    // those partial-failure paths would leave the row WITHOUT
-    // pendingWaveLabel/SegmentId/Assigned set — and clearPartialFailure
-    // ({confirmNoExport: true}) would then not throw, masking stamped
-    // contacts and the already-created Resend segment.
-    //
-    // Invariant: in runDailyRamp, the _recordPendingExport call must appear
-    // BEFORE any source line containing `exportResult.failed`, `exportResult.stampFailed`,
-    // or `exportResult.underfilled`.
-    const recordPendingIdx = runnerSrc.indexOf("_recordPendingExport,");
-    const failedCheckIdx = runnerSrc.indexOf("exportResult.failed > 0");
-    const stampFailedCheckIdx = runnerSrc.indexOf("exportResult.stampFailed > 0");
-    const underfilledCheckIdx = runnerSrc.indexOf("exportResult.underfilled");
-
-    expect(recordPendingIdx).toBeGreaterThan(-1);
-    expect(failedCheckIdx).toBeGreaterThan(-1);
-    expect(stampFailedCheckIdx).toBeGreaterThan(-1);
-    expect(underfilledCheckIdx).toBeGreaterThan(-1);
-
-    // The first occurrence of `_recordPendingExport,` (the runner call site,
-    // not the export declaration) inside runDailyRamp must precede every
-    // failure-counter check.
-    const runnerCallSiteIdx = runnerSrc.indexOf(
-      "_recordPendingExport,",
-      runnerSrc.indexOf("runDailyRamp"),
-    );
-    expect(runnerCallSiteIdx).toBeGreaterThan(-1);
-    expect(runnerCallSiteIdx).toBeLessThan(failedCheckIdx);
-    expect(runnerCallSiteIdx).toBeLessThan(stampFailedCheckIdx);
-    expect(runnerCallSiteIdx).toBeLessThan(underfilledCheckIdx);
-  });
-});
+// PR 2 (post-launch-stabilization, 2026-04-30) replaced the monolithic
+// `runDailyRamp` body with a state-machine-based scheduler call. The two
+// source-grep tests that lived here previously (PR #3476 review rounds 3
+// and 4) protected against regressions in the now-removed
+// `_recordPendingExport` call ordering and `pool-drained vs partial-failure`
+// routing. Both branches are gone — `pickWaveAction` (in waveRuns.ts) now
+// owns underfill / persist-failure handling, and the legacy
+// `_recordPendingExport` mutation remains in this module only for
+// `recoverFromPartialFailure` to use against any legacy partial-failure
+// rows. New behaviour is tested in `convex/__tests__/waveRuns.test.ts`.
 
 describe("clearPartialFailure — confirmNoExport guard (P1#3)", () => {
   test("REFUSES when any pending* progress marker is set — even with confirmNoExport=true", async () => {

--- a/convex/__tests__/rampRunner.test.ts
+++ b/convex/__tests__/rampRunner.test.ts
@@ -830,3 +830,64 @@ describe("end-to-end: lease prevents duplicate-send race", () => {
     expect(row?.pendingRunId).toBeUndefined();
   });
 });
+
+// ───────────────────────────────────────────────────────────────────────────
+// PR2 review-fix 7: runDailyRamp checks pendingRunId before scheduling
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("runDailyRamp — pendingRunId guard (PR2 review-fix 7)", () => {
+  test("refuses to schedule pickWaveAction when broadcastRampConfig.pendingRunId is held by a failed run", async () => {
+    // Scenario: a wave hit `persist-failed` (or `segment-create-failed` /
+    // `batch-failure-rate-exceeded`) — status='failed' but lease HELD.
+    // _listInFlightWaveRuns excludes failed runs, so without this guard
+    // runDailyRamp would schedule a new pickWaveAction whose
+    // _claimWaveRunLease would refuse with `lease-held` — operator sees
+    // wave-scheduled but ramp is actually blocked.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t, {
+      pendingRunId: "stuck-run-1",
+      pendingRunStartedAt: Date.now() - 5 * 60_000,
+      pendingWaveLabel: "pro-launch-wave-4",
+    });
+    // Insert a corresponding waveRuns row in failed/persist-failed.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("waveRuns", {
+        runId: "stuck-run-1",
+        waveLabel: "pro-launch-wave-4",
+        status: "failed",
+        failureSubstatus: "persist-failed",
+        requestedCount: 100, totalCount: 0, underfilled: false,
+        pushedCount: 0, failedCount: 0, batchSize: 50,
+        createdAt: Date.now() - 5 * 60_000,
+        updatedAt: Date.now() - 5 * 60_000,
+      });
+    });
+
+    const result = await t.action(
+      internal.broadcast.rampRunner.runDailyRamp,
+      {},
+    );
+    // Must surface the lease-held condition, NOT report wave-scheduled.
+    expect(result).toMatchObject({
+      status: "lease-held-by-failed-run",
+    });
+    expect(result.detail).toContain("stuck-run-1");
+    expect(result.detail).toContain("persist-failed");
+
+    // Drain any incidentally scheduled functions to silence convex-test's
+    // scheduler-dispatch artifact.
+    await t.finishInProgressScheduledFunctions().catch(() => {});
+  });
+
+  test("schedules pickWaveAction normally when no lease is held", async () => {
+    // Sanity: the pendingRunId guard should be a no-op on a clean ramp.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    const result = await t.action(
+      internal.broadcast.rampRunner.runDailyRamp,
+      {},
+    );
+    expect(result.status).toBe("wave-scheduled");
+    await t.finishInProgressScheduledFunctions().catch(() => {});
+  });
+});

--- a/convex/__tests__/waveRuns.test.ts
+++ b/convex/__tests__/waveRuns.test.ts
@@ -104,6 +104,20 @@ async function readContacts(t: ReturnType<typeof convexTest>, runId: string) {
   );
 }
 
+/** Helper: find a contact's _id by (runId, normalizedEmail). Tests call
+ *  the mark-mutations by `contactId` after PR2 review-fix 9 (avoid the
+ *  Convex 8192-doc-read scan limit). */
+async function findContactId(
+  t: ReturnType<typeof convexTest>,
+  runId: string,
+  normalizedEmail: string,
+): Promise<string> {
+  const all = await readContacts(t, runId);
+  const match = all.find((c) => c.normalizedEmail === normalizedEmail);
+  if (!match) throw new Error(`findContactId: no contact (${runId}, ${normalizedEmail})`);
+  return match._id;
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // _claimWaveRunLease
 // ───────────────────────────────────────────────────────────────────────────
@@ -269,6 +283,7 @@ describe("push-phase CAS mutations", () => {
     const t = convexTest(schema, modules);
     const [first] = await setupPushing(t);
     const r = await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      contactId: await findContactId(t, "run-1", first!),
       runId: "run-1", normalizedEmail: first!, waveLabel: "pro-launch-wave-4",
     });
     expect(r).toMatchObject({ ok: true, stampResult: "stamped" });
@@ -281,10 +296,13 @@ describe("push-phase CAS mutations", () => {
   test("_markContactPushed CAS: second call returns not-pending; pushedCount stays 1", async () => {
     const t = convexTest(schema, modules);
     const [first] = await setupPushing(t);
+    const contactId = await findContactId(t, "run-1", first!);
     await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      contactId,
       runId: "run-1", normalizedEmail: first!, waveLabel: "pro-launch-wave-4",
     });
     const second = await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      contactId,
       runId: "run-1", normalizedEmail: first!, waveLabel: "pro-launch-wave-4",
     });
     expect(second).toMatchObject({ ok: false, reason: "not-pending" });
@@ -298,6 +316,7 @@ describe("push-phase CAS mutations", () => {
     const emails = await setupPushing(t, 100);
     const first = emails[0]!;
     const r = await t.mutation(internal.broadcast.waveRuns._markContactFailed, {
+      contactId: await findContactId(t, "run-1", first),
       runId: "run-1", normalizedEmail: first, failedReason: "Resend 422",
     });
     expect(r).toMatchObject({ ok: true, runFailed: false });
@@ -315,6 +334,7 @@ describe("push-phase CAS mutations", () => {
     const t = convexTest(schema, modules);
     const [first] = await setupPushing(t, 4);
     const r = await t.mutation(internal.broadcast.waveRuns._markContactFailed, {
+      contactId: await findContactId(t, "run-1", first!),
       runId: "run-1", normalizedEmail: first!, failedReason: "Resend 500",
     });
     expect(r).toMatchObject({ ok: true, runFailed: true });
@@ -340,10 +360,13 @@ describe("push-phase CAS mutations", () => {
     });
     await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
 
+    const c0Id = await findContactId(t, "run-1", emails[0]!);
     await t.mutation(internal.broadcast.waveRuns._markContactFailed, {
+      contactId: c0Id,
       runId: "run-1", normalizedEmail: emails[0]!, failedReason: "Resend 500",
     });
     const second = await t.mutation(internal.broadcast.waveRuns._markContactFailed, {
+      contactId: c0Id,
       runId: "run-1", normalizedEmail: emails[0]!, failedReason: "Resend 500 again",
     });
     expect(second).toMatchObject({ ok: false, reason: "not-pending" });
@@ -755,9 +778,11 @@ describe("review-fix 2: unstamp on discard", () => {
     // Push two of three (third stays pending). All three were seeded with
     // matching registrations by seedRegistrations.
     await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      contactId: await findContactId(t, "run-1", "a@t"),
       runId: "run-1", normalizedEmail: "a@t", waveLabel: "pro-launch-wave-4",
     });
     await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      contactId: await findContactId(t, "run-1", "b@t"),
       runId: "run-1", normalizedEmail: "b@t", waveLabel: "pro-launch-wave-4",
     });
     // Verify a + b are stamped before cleanup.
@@ -799,6 +824,7 @@ describe("review-fix 2: unstamp on discard", () => {
     });
     await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
     await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      contactId: await findContactId(t, "run-1", "a@t"),
       runId: "run-1", normalizedEmail: "a@t", waveLabel: "pro-launch-wave-4",
     });
     // Manually re-stamp the registration as if it were re-picked into wave-5.
@@ -839,6 +865,7 @@ describe("review-fix 2: unstamp on discard", () => {
     });
     await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
     await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      contactId: await findContactId(t, "run-1", "a@t"),
       runId: "run-1", normalizedEmail: "a@t", waveLabel: "pro-launch-wave-4",
     });
     // Operator discard — flips the run to failed/discarded-by-operator and
@@ -1119,6 +1146,10 @@ describe("review-fix 6: terminal-CAS on finalize failure / recovery", () => {
     await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
       runId: "run-1", broadcastId: "bro_xyz",
     });
+    // PR2 review-fix 10: substatus required for the recovery to be reachable.
+    await t.mutation(internal.broadcast.waveRuns._markFinalizeFailed, {
+      runId: "run-1", substatus: "send-broadcast-failed", error: "timeout",
+    });
     // Force-clear the lease (operator did forceReleaseLease).
     await t.run(async (ctx) => {
       const config = await ctx.db
@@ -1134,7 +1165,7 @@ describe("review-fix 6: terminal-CAS on finalize failure / recovery", () => {
     ).rejects.toThrow(/lost lease/);
   });
 
-  test("markFinalizeRecovered: succeeds on broadcast-created with held lease", async () => {
+  test("markFinalizeRecovered: succeeds on broadcast-created + send-broadcast-failed substatus + held lease", async () => {
     const t = convexTest(schema, modules);
     await seedRampConfig(t);
     await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
@@ -1147,6 +1178,12 @@ describe("review-fix 6: terminal-CAS on finalize failure / recovery", () => {
     await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
       runId: "run-1", broadcastId: "bro_xyz",
     });
+    // PR2 review-fix 10: markFinalizeRecovered now requires the substatus
+    // signal. Without it, status='broadcast-created' alone is also the
+    // mid-flight pre-send state and would race-advance the tier.
+    await t.mutation(internal.broadcast.waveRuns._markFinalizeFailed, {
+      runId: "run-1", substatus: "send-broadcast-failed", error: "network timeout",
+    });
     const sentAt = Date.now();
     const r = await t.mutation(internal.broadcast.waveRuns.markFinalizeRecovered, {
       runId: "run-1", sentAt, reason: "Resend dashboard confirmed sent",
@@ -1155,5 +1192,30 @@ describe("review-fix 6: terminal-CAS on finalize failure / recovery", () => {
     const config = await readConfig(t);
     expect(config!.currentTier).toBe(1);
     expect(config!.lastWaveSentAt).toBe(sentAt);
+  });
+
+  test("markFinalizeRecovered: REFUSES on broadcast-created without send-broadcast-failed substatus (mid-flight protection)", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    // status='broadcast-created' but no failureSubstatus — this is the
+    // active mid-flight state between create and send. Operator MUST
+    // NOT be able to short-circuit here.
+    await expect(
+      t.mutation(internal.broadcast.waveRuns.markFinalizeRecovered, {
+        runId: "run-1", sentAt: Date.now(), reason: "operator confused",
+      }),
+    ).rejects.toThrow(/failureSubstatus.*<none>|only applies to send-broadcast-failed/);
+    const config = await readConfig(t);
+    expect(config!.currentTier).toBe(0); // NOT advanced
   });
 });

--- a/convex/__tests__/waveRuns.test.ts
+++ b/convex/__tests__/waveRuns.test.ts
@@ -219,7 +219,11 @@ describe("pick-phase mutations", () => {
     expect(run!.failureSubstatus).toBe("empty-pool");
     const config = await readConfig(t);
     expect(config!.pendingRunId).toBeUndefined();
-    expect(config!.lastRunStatus).toBe("no-op-empty-pool");
+    // PR2 review-fix 3: empty-pool now also DEACTIVATES the ramp (not just
+    // clears the lease) and uses a `ramp-complete-*` status to signal
+    // terminal completion to the operator.
+    expect(config!.active).toBe(false);
+    expect(config!.lastRunStatus).toBe("ramp-complete-empty-pool");
   });
 
   test("_markPickFailed segment-create-failed KEEPS the lease (operator must discard)", async () => {
@@ -598,5 +602,325 @@ describe("_listInFlightWaveRuns + cleanup", () => {
     expect(r.hasMore).toBe(false);
     const remaining = await readContacts(t, "run-1");
     expect(remaining).toHaveLength(0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// PR2 review-fix 1: _markBroadcastCreated + _finalizeWaveRun lease+status CAS
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("review-fix 1: lease+status CAS", () => {
+  async function setupPushing(t: ReturnType<typeof convexTest>) {
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+  }
+
+  test("_markBroadcastCreated: idempotent on re-call with same broadcastId", async () => {
+    const t = convexTest(schema, modules);
+    await setupPushing(t);
+    const r1 = await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    expect(r1).toMatchObject({ ok: true, alreadyMarked: false });
+    const r2 = await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    expect(r2).toMatchObject({ ok: true, alreadyMarked: true });
+  });
+
+  test("_markBroadcastCreated: refuses different broadcastId on already-marked run (duplicate detection)", async () => {
+    const t = convexTest(schema, modules);
+    await setupPushing(t);
+    await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    const r = await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_OTHER",
+    });
+    expect(r).toMatchObject({
+      ok: false,
+      reason: "duplicate-broadcast-detected",
+      existing: "bro_xyz",
+    });
+  });
+
+  test("_markBroadcastCreated: refuses on lost lease", async () => {
+    const t = convexTest(schema, modules);
+    await setupPushing(t);
+    // Force-clear the lease (simulates operator forceReleaseLease).
+    await t.run(async (ctx) => {
+      const config = await ctx.db
+        .query("broadcastRampConfig")
+        .withIndex("by_key", (q) => q.eq("key", "current"))
+        .unique();
+      await ctx.db.patch(config!._id, { pendingRunId: undefined });
+    });
+    const r = await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    expect(r).toMatchObject({ ok: false, reason: "lost-lease" });
+  });
+
+  test("_markBroadcastCreated: refuses on wrong status (e.g. picking)", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    // Status is still 'picking' — not allowed.
+    const r = await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    expect(r).toMatchObject({ ok: false, reason: "wrong-status-picking" });
+  });
+
+  test("_finalizeWaveRun: idempotent on already-sent run (no-op, no double-advance)", async () => {
+    const t = convexTest(schema, modules);
+    await setupPushing(t);
+    await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    const sentAt = Date.now();
+    const r1 = await t.mutation(internal.broadcast.waveRuns._finalizeWaveRun, {
+      runId: "run-1", sentAt,
+    });
+    expect(r1).toMatchObject({ ok: true, advancedToTier: 1 });
+    // Second call should NOT advance the tier again.
+    const r2 = await t.mutation(internal.broadcast.waveRuns._finalizeWaveRun, {
+      runId: "run-1", sentAt: sentAt + 1000,
+    });
+    expect(r2).toMatchObject({ ok: true, alreadySent: true });
+    const config = await readConfig(t);
+    expect(config!.currentTier).toBe(1); // NOT 2
+  });
+
+  test("_finalizeWaveRun: throws on lost lease (refuses to advance after operator force-release)", async () => {
+    const t = convexTest(schema, modules);
+    await setupPushing(t);
+    await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    await t.run(async (ctx) => {
+      const config = await ctx.db
+        .query("broadcastRampConfig")
+        .withIndex("by_key", (q) => q.eq("key", "current"))
+        .unique();
+      await ctx.db.patch(config!._id, { pendingRunId: undefined });
+    });
+    await expect(
+      t.mutation(internal.broadcast.waveRuns._finalizeWaveRun, {
+        runId: "run-1", sentAt: Date.now(),
+      }),
+    ).rejects.toThrow(/lost lease/);
+  });
+
+  test("_finalizeWaveRun: throws on wrong status (e.g. pushing instead of broadcast-created)", async () => {
+    const t = convexTest(schema, modules);
+    await setupPushing(t);
+    // Skip _markBroadcastCreated — try to finalize from 'pushing' directly.
+    await expect(
+      t.mutation(internal.broadcast.waveRuns._finalizeWaveRun, {
+        runId: "run-1", sentAt: Date.now(),
+      }),
+    ).rejects.toThrow(/expected broadcast-created/);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// PR2 review-fix 2: discardWaveRun unstamps registrations
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("review-fix 2: unstamp on discard", () => {
+  test("_cleanupDiscardedWavePickedContacts unstamps registrations matching the run's waveLabel", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 3, batchSize: 50,
+    });
+    const emails = ["a@t", "b@t", "c@t"];
+    await seedRegistrations(t, emails);
+    await t.mutation(internal.broadcast.waveRuns._persistPickedBatch, {
+      runId: "run-1", contacts: emails,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 3, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    // Push two of three (third stays pending). All three were seeded with
+    // matching registrations by seedRegistrations.
+    await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      runId: "run-1", normalizedEmail: "a@t", waveLabel: "pro-launch-wave-4",
+    });
+    await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      runId: "run-1", normalizedEmail: "b@t", waveLabel: "pro-launch-wave-4",
+    });
+    // Verify a + b are stamped before cleanup.
+    const stampedBefore = await t.run(async (ctx) =>
+      ctx.db.query("registrations").collect(),
+    );
+    expect(stampedBefore.filter((r) => r.proLaunchWave === "pro-launch-wave-4")).toHaveLength(2);
+
+    // Cleanup should unstamp the 2 pushed contacts and delete all 3 wavePickedContacts rows.
+    const r = await t.mutation(
+      internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts,
+      { runId: "run-1" },
+    );
+    expect(r).toMatchObject({ deleted: 3, unstamped: 2, hasMore: false });
+
+    const stampedAfter = await t.run(async (ctx) =>
+      ctx.db.query("registrations").collect(),
+    );
+    expect(stampedAfter.filter((r) => r.proLaunchWave === "pro-launch-wave-4")).toHaveLength(0);
+    const remainingContacts = await readContacts(t, "run-1");
+    expect(remainingContacts).toHaveLength(0);
+  });
+
+  test("_cleanupDiscardedWavePickedContacts does NOT unstamp a contact re-picked into a later wave", async () => {
+    // Defensive: if the operator discards run-1, then a later run-2 picks
+    // and stamps the same email with a different waveLabel, the cleanup of
+    // run-1 must NOT clear run-2's stamp.
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await seedRegistrations(t, ["a@t"]);
+    await t.mutation(internal.broadcast.waveRuns._persistPickedBatch, {
+      runId: "run-1", contacts: ["a@t"],
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      runId: "run-1", normalizedEmail: "a@t", waveLabel: "pro-launch-wave-4",
+    });
+    // Manually re-stamp the registration as if it were re-picked into wave-5.
+    await t.run(async (ctx) => {
+      const reg = await ctx.db
+        .query("registrations")
+        .withIndex("by_normalized_email", (q) => q.eq("normalizedEmail", "a@t"))
+        .first();
+      await ctx.db.patch(reg!._id, { proLaunchWave: "pro-launch-wave-5" });
+    });
+    // Cleanup run-1 — must leave the wave-5 stamp alone.
+    const r = await t.mutation(
+      internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts,
+      { runId: "run-1" },
+    );
+    expect(r.unstamped).toBe(0);
+    const reg = await t.run(async (ctx) =>
+      ctx.db
+        .query("registrations")
+        .withIndex("by_normalized_email", (q) => q.eq("normalizedEmail", "a@t"))
+        .first(),
+    );
+    expect(reg!.proLaunchWave).toBe("pro-launch-wave-5");
+  });
+
+  test("discardWaveRun + cleanup unstamps the registration (action runs after discard)", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await seedRegistrations(t, ["a@t"]);
+    await t.mutation(internal.broadcast.waveRuns._persistPickedBatch, {
+      runId: "run-1", contacts: ["a@t"],
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      runId: "run-1", normalizedEmail: "a@t", waveLabel: "pro-launch-wave-4",
+    });
+    // Operator discard — flips the run to failed/discarded-by-operator and
+    // schedules cleanup (we exercise the cleanup mutation directly here
+    // since convex-test's action-dispatch path emits a benign "Write outside
+    // of transaction" rejection on schedule.runAfter; the BEHAVIOR we want
+    // to verify is that cleanup unstamps).
+    await t.mutation(internal.broadcast.waveRuns.discardWaveRun, {
+      runId: "run-1", reason: "operator decision",
+    });
+    // Run the cleanup mutation directly (same one the eager scheduler call
+    // would invoke). Verifies the unstamp behavior on a discarded run.
+    const r = await t.mutation(
+      internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts,
+      { runId: "run-1" },
+    );
+    expect(r.unstamped).toBe(1);
+    const reg = await t.run(async (ctx) =>
+      ctx.db
+        .query("registrations")
+        .withIndex("by_normalized_email", (q) => q.eq("normalizedEmail", "a@t"))
+        .first(),
+    );
+    expect(reg!.proLaunchWave).toBeUndefined();
+    // Drain the action that discardWaveRun also scheduled (it's a no-op
+    // by this point since cleanup is already done; just suppress the
+    // convex-test scheduler artifact).
+    await t.finishInProgressScheduledFunctions().catch(() => {});
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// PR2 review-fix 3: pool-too-small terminates ramp
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("review-fix 3: pool-too-small terminates ramp", () => {
+  test("_markPickFailed pool-too-small clears lease + DEACTIVATES the ramp", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1500, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickFailed, {
+      runId: "run-1",
+      substatus: "pool-too-small",
+      error: "picked 50 contacts < threshold",
+    });
+    const config = await readConfig(t);
+    expect(config!.active).toBe(false);
+    expect(config!.pendingRunId).toBeUndefined();
+    expect(config!.lastRunStatus).toBe("ramp-complete-pool-too-small");
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.status).toBe("failed");
+    expect(run!.failureSubstatus).toBe("pool-too-small");
+  });
+
+  test("_markPickFailed empty-pool also DEACTIVATES the ramp (terminal completion)", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1500, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickFailed, {
+      runId: "run-1", substatus: "empty-pool", error: "no contacts",
+    });
+    const config = await readConfig(t);
+    expect(config!.active).toBe(false);
+    expect(config!.lastRunStatus).toBe("ramp-complete-empty-pool");
+  });
+
+  test("_markPickFailed segment-create-failed does NOT deactivate (operator must triage)", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1500, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickFailed, {
+      runId: "run-1", substatus: "segment-create-failed", error: "Resend 500",
+    });
+    const config = await readConfig(t);
+    // Ramp stays active — operator inspects + discards. Lease stays held.
+    expect(config!.active).toBe(true);
+    expect(config!.pendingRunId).toBe("run-1");
   });
 });

--- a/convex/__tests__/waveRuns.test.ts
+++ b/convex/__tests__/waveRuns.test.ts
@@ -924,3 +924,236 @@ describe("review-fix 3: pool-too-small terminates ramp", () => {
     expect(config!.pendingRunId).toBe("run-1");
   });
 });
+
+// ───────────────────────────────────────────────────────────────────────────
+// PR2 review-fix 5: cleanup excludes recoverable finalize failures
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("review-fix 5: cleanup excludes recoverable failures", () => {
+  async function setupOldFailedRun(
+    t: ReturnType<typeof convexTest>,
+    substatus: string,
+  ) {
+    // Seed a failed run with updatedAt 25h ago so it passes the age cutoff.
+    const oldTime = Date.now() - 25 * 60 * 60 * 1000;
+    await seedRampConfig(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("waveRuns", {
+        runId: `run-${substatus}`,
+        waveLabel: `pro-launch-wave-${substatus}`,
+        status: "failed",
+        failureSubstatus: substatus,
+        requestedCount: 100,
+        totalCount: 100,
+        underfilled: false,
+        pushedCount: 50,
+        failedCount: 0,
+        batchSize: 50,
+        createdAt: oldTime,
+        updatedAt: oldTime,
+      });
+    });
+  }
+
+  test("auto-cleanup INCLUDES discarded-by-operator runs", async () => {
+    const t = convexTest(schema, modules);
+    await setupOldFailedRun(t, "discarded-by-operator");
+    const candidates = await t.query(
+      internal.broadcast.waveRuns._listFailedWaveRunsForCleanup,
+      {},
+    );
+    expect(candidates).toContain("run-discarded-by-operator");
+  });
+
+  test("auto-cleanup INCLUDES batch-failure-rate-exceeded (24h safety net)", async () => {
+    const t = convexTest(schema, modules);
+    await setupOldFailedRun(t, "batch-failure-rate-exceeded");
+    const candidates = await t.query(
+      internal.broadcast.waveRuns._listFailedWaveRunsForCleanup,
+      {},
+    );
+    expect(candidates).toContain("run-batch-failure-rate-exceeded");
+  });
+
+  test("auto-cleanup EXCLUDES recoverable create-broadcast-failed", async () => {
+    const t = convexTest(schema, modules);
+    await setupOldFailedRun(t, "create-broadcast-failed");
+    const candidates = await t.query(
+      internal.broadcast.waveRuns._listFailedWaveRunsForCleanup,
+      {},
+    );
+    // Operator may yet run resumeFinalizeWaveRun; cleanup would unstamp
+    // pushed contacts and a subsequent successful send would re-stamp them
+    // — risking duplicate outreach. Skip these in auto-cleanup.
+    expect(candidates).not.toContain("run-create-broadcast-failed");
+  });
+
+  test("auto-cleanup EXCLUDES recoverable send-broadcast-failed", async () => {
+    const t = convexTest(schema, modules);
+    await setupOldFailedRun(t, "send-broadcast-failed");
+    const candidates = await t.query(
+      internal.broadcast.waveRuns._listFailedWaveRunsForCleanup,
+      {},
+    );
+    expect(candidates).not.toContain("run-send-broadcast-failed");
+  });
+
+  test("auto-cleanup EXCLUDES failed runs with no substatus (defensive)", async () => {
+    const t = convexTest(schema, modules);
+    const oldTime = Date.now() - 25 * 60 * 60 * 1000;
+    await seedRampConfig(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("waveRuns", {
+        runId: "run-no-substatus",
+        waveLabel: "pro-launch-wave-x",
+        status: "failed", // status='failed' but no failureSubstatus set
+        requestedCount: 100, totalCount: 100, underfilled: false,
+        pushedCount: 0, failedCount: 0, batchSize: 50,
+        createdAt: oldTime, updatedAt: oldTime,
+      });
+    });
+    const candidates = await t.query(
+      internal.broadcast.waveRuns._listFailedWaveRunsForCleanup,
+      {},
+    );
+    expect(candidates).not.toContain("run-no-substatus");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// PR2 review-fix 6: _markFinalizeFailed terminal CAS + markFinalizeRecovered strict
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("review-fix 6: terminal-CAS on finalize failure / recovery", () => {
+  async function setupSent(t: ReturnType<typeof convexTest>) {
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    await t.mutation(internal.broadcast.waveRuns._finalizeWaveRun, {
+      runId: "run-1", sentAt: Date.now(),
+    });
+  }
+
+  test("_markFinalizeFailed: refuses to overwrite status='sent' (duplicate-finalize loser)", async () => {
+    const t = convexTest(schema, modules);
+    await setupSent(t);
+    // Loser of a finalize race calls _markFinalizeFailed after Resend
+    // returns 422 already-sent.
+    const r = await t.mutation(internal.broadcast.waveRuns._markFinalizeFailed, {
+      runId: "run-1",
+      substatus: "send-broadcast-failed",
+      error: "Resend 422 already sent",
+    });
+    expect(r).toMatchObject({ ok: false, reason: "already-sent" });
+    // Run state unchanged — sent stays sent.
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.status).toBe("sent");
+    expect(run!.failureSubstatus).toBeUndefined();
+  });
+
+  test("_markFinalizeFailed: refuses to overwrite a different existing substatus", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    // First failure — create-broadcast-failed.
+    await t.mutation(internal.broadcast.waveRuns._markFinalizeFailed, {
+      runId: "run-1", substatus: "create-broadcast-failed", error: "Resend 500",
+    });
+    // Second mutation tries to relabel — refuses.
+    const r = await t.mutation(internal.broadcast.waveRuns._markFinalizeFailed, {
+      runId: "run-1", substatus: "send-broadcast-failed", error: "different reason",
+    });
+    expect(r).toMatchObject({
+      ok: false,
+      reason: "already-failed-different-substatus",
+      existing: "create-broadcast-failed",
+    });
+  });
+
+  test("markFinalizeRecovered: throws on status='sent' (no double-advance)", async () => {
+    const t = convexTest(schema, modules);
+    await setupSent(t);
+    // Even if a stale failureSubstatus was somehow set, status='sent' must block recovery.
+    await t.run(async (ctx) => {
+      const run = await ctx.db
+        .query("waveRuns")
+        .withIndex("by_runId", (q) => q.eq("runId", "run-1"))
+        .unique();
+      // Force a malformed state (won't happen in practice now that
+      // _markFinalizeFailed CAS-rejects, but tests defense in depth).
+      await ctx.db.patch(run!._id, { failureSubstatus: "send-broadcast-failed" });
+    });
+    await expect(
+      t.mutation(internal.broadcast.waveRuns.markFinalizeRecovered, {
+        runId: "run-1", sentAt: Date.now(), reason: "stale state recovery",
+      }),
+    ).rejects.toThrow(/already finalized|requires status/);
+    const config = await readConfig(t);
+    expect(config!.currentTier).toBe(1); // NOT advanced again
+  });
+
+  test("markFinalizeRecovered: throws on lost lease (refuses to advance from stale runId)", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    // Force-clear the lease (operator did forceReleaseLease).
+    await t.run(async (ctx) => {
+      const config = await ctx.db
+        .query("broadcastRampConfig")
+        .withIndex("by_key", (q) => q.eq("key", "current"))
+        .unique();
+      await ctx.db.patch(config!._id, { pendingRunId: undefined });
+    });
+    await expect(
+      t.mutation(internal.broadcast.waveRuns.markFinalizeRecovered, {
+        runId: "run-1", sentAt: Date.now(), reason: "operator verified",
+      }),
+    ).rejects.toThrow(/lost lease/);
+  });
+
+  test("markFinalizeRecovered: succeeds on broadcast-created with held lease", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    const sentAt = Date.now();
+    const r = await t.mutation(internal.broadcast.waveRuns.markFinalizeRecovered, {
+      runId: "run-1", sentAt, reason: "Resend dashboard confirmed sent",
+    });
+    expect(r).toMatchObject({ ok: true, advancedToTier: 1 });
+    const config = await readConfig(t);
+    expect(config!.currentTier).toBe(1);
+    expect(config!.lastWaveSentAt).toBe(sentAt);
+  });
+});

--- a/convex/__tests__/waveRuns.test.ts
+++ b/convex/__tests__/waveRuns.test.ts
@@ -1,0 +1,602 @@
+/**
+ * Wave-loading state machine integration tests (PR 2).
+ *
+ * Covers the mutations + queries directly. Actions (pickWaveAction,
+ * pushBatchAction, finalizeWaveAction) integrate Resend HTTP calls and
+ * the Convex scheduler — those are exercised end-to-end on a test fork
+ * with mocked Resend, not in this unit suite.
+ *
+ * Acceptance criteria mapped to tests in this file:
+ *   - lease conflict (second claim refused)
+ *   - underfill flag preserved through pick → finalize
+ *   - empty pool → terminal no-op + lease cleared
+ *   - CAS idempotency (_markContactPushed twice = +1 pushedCount once)
+ *   - failure-rate threshold flips whole run
+ *   - operator recovery routing (resumeStalled / resumeFinalize / discard)
+ *   - confirmedNotSent gate on send-failure recovery
+ *   - cleanup chunked deletion
+ */
+
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.ts");
+
+// convex-test 0.0.43 emits an unhandled rejection of shape
+// `Error: Write outside of transaction <id>;_scheduled_functions` when a
+// mutation under test calls `ctx.scheduler.runAfter(...)` and the framework
+// later attempts to dispatch the scheduled action. This is a framework
+// artifact (the scheduled action would touch `_scheduled_functions` outside
+// the test's transactional fake) — not a bug in our code. Filter only this
+// specific rejection so genuine errors still surface.
+process.on("unhandledRejection", (err) => {
+  if (err instanceof Error && /Write outside of transaction.*_scheduled_functions/.test(err.message)) {
+    return; // swallow the convex-test scheduler-dispatch artifact
+  }
+  throw err;
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+const RAMP_KEY = "current";
+
+async function seedRampConfig(t: ReturnType<typeof convexTest>): Promise<void> {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("broadcastRampConfig", {
+      key: RAMP_KEY,
+      active: true,
+      rampCurve: [1500, 5000, 15000, 25000],
+      currentTier: 0,
+      waveLabelPrefix: "pro-launch-wave",
+      waveLabelOffset: 3,
+      bounceKillThreshold: 0.04,
+      complaintKillThreshold: 0.0008,
+      killGateTripped: false,
+    });
+  });
+}
+
+async function seedRegistrations(
+  t: ReturnType<typeof convexTest>,
+  emails: string[],
+): Promise<void> {
+  await t.run(async (ctx) => {
+    const now = Date.now();
+    for (const email of emails) {
+      await ctx.db.insert("registrations", {
+        email,
+        normalizedEmail: email.toLowerCase().trim(),
+        registeredAt: now,
+        appVersion: "test",
+      });
+    }
+  });
+}
+
+async function readConfig(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) =>
+    ctx.db
+      .query("broadcastRampConfig")
+      .withIndex("by_key", (q) => q.eq("key", RAMP_KEY))
+      .unique(),
+  );
+}
+
+async function readWaveRun(t: ReturnType<typeof convexTest>, runId: string) {
+  return t.run(async (ctx) =>
+    ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique(),
+  );
+}
+
+async function readContacts(t: ReturnType<typeof convexTest>, runId: string) {
+  return t.run(async (ctx) =>
+    ctx.db
+      .query("wavePickedContacts")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .collect(),
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// _claimWaveRunLease
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("_claimWaveRunLease", () => {
+  test("claims lease when no holder + no active waveRun + no label collision", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    const result = await t.mutation(
+      internal.broadcast.waveRuns._claimWaveRunLease,
+      { waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 100, batchSize: 50 },
+    );
+    expect(result).toEqual({ ok: true, runId: "run-1" });
+    const config = await readConfig(t);
+    expect(config!.pendingRunId).toBe("run-1");
+    expect(config!.pendingWaveLabel).toBe("pro-launch-wave-4");
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.status).toBe("picking");
+    expect(run!.requestedCount).toBe(100);
+    expect(run!.batchSize).toBe(50);
+  });
+
+  test("refuses second claim while first lease is held", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 100, batchSize: 50,
+    });
+    const second = await t.mutation(
+      internal.broadcast.waveRuns._claimWaveRunLease,
+      { waveLabel: "pro-launch-wave-5", runId: "run-2", requestedCount: 100, batchSize: 50 },
+    );
+    expect(second).toMatchObject({ ok: false, reason: "lease-held", current: "run-1" });
+  });
+
+  test("refuses claim when waveLabel already has a stamped registration", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("registrations", {
+        email: "stamped@example.com",
+        normalizedEmail: "stamped@example.com",
+        registeredAt: Date.now(),
+        appVersion: "test",
+        proLaunchWave: "pro-launch-wave-4",
+      });
+    });
+    const result = await t.mutation(
+      internal.broadcast.waveRuns._claimWaveRunLease,
+      { waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 100, batchSize: 50 },
+    );
+    expect(result).toMatchObject({ ok: false, reason: "label-collides" });
+  });
+
+  test("refuses claim when no broadcastRampConfig row exists", async () => {
+    const t = convexTest(schema, modules);
+    const result = await t.mutation(
+      internal.broadcast.waveRuns._claimWaveRunLease,
+      { waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 100, batchSize: 50 },
+    );
+    expect(result).toMatchObject({ ok: false, reason: "no-config" });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// _persistPickedBatch + _markPickComplete + _markPickFailed
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("pick-phase mutations", () => {
+  test("_persistPickedBatch inserts contacts as pending + bumps updatedAt", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 3, batchSize: 50,
+    });
+    const r = await t.mutation(
+      internal.broadcast.waveRuns._persistPickedBatch,
+      { runId: "run-1", contacts: ["a@test", "b@test", "c@test"] },
+    );
+    expect(r.inserted).toBe(3);
+    const contacts = await readContacts(t, "run-1");
+    expect(contacts).toHaveLength(3);
+    expect(contacts.every((c) => c.status === "pending")).toBe(true);
+  });
+
+  test("_markPickComplete transitions picking → segment-created with totalCount/underfilled", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 100, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 80, underfilled: true,
+    });
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.status).toBe("segment-created");
+    expect(run!.segmentId).toBe("seg_abc");
+    expect(run!.totalCount).toBe(80);
+    expect(run!.underfilled).toBe(true);
+  });
+
+  test("_markPickFailed empty-pool clears the lease (terminal no-op)", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 100, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickFailed, {
+      runId: "run-1", substatus: "empty-pool", error: "no unstamped registrations",
+    });
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.status).toBe("failed");
+    expect(run!.failureSubstatus).toBe("empty-pool");
+    const config = await readConfig(t);
+    expect(config!.pendingRunId).toBeUndefined();
+    expect(config!.lastRunStatus).toBe("no-op-empty-pool");
+  });
+
+  test("_markPickFailed segment-create-failed KEEPS the lease (operator must discard)", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 100, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickFailed, {
+      runId: "run-1", substatus: "segment-create-failed", error: "Resend 500",
+    });
+    const config = await readConfig(t);
+    expect(config!.pendingRunId).toBe("run-1");
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.status).toBe("failed");
+    expect(run!.failureSubstatus).toBe("segment-create-failed");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// _markContactPushed / _markContactFailed (CAS guards)
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("push-phase CAS mutations", () => {
+  async function setupPushing(t: ReturnType<typeof convexTest>, totalCount = 4) {
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: totalCount, batchSize: 50,
+    });
+    const emails = Array.from({ length: totalCount }, (_, i) => `c${i}@test`);
+    await seedRegistrations(t, emails);
+    await t.mutation(internal.broadcast.waveRuns._persistPickedBatch, {
+      runId: "run-1", contacts: emails,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    return emails;
+  }
+
+  test("_markContactPushed: pushed=true + pushedCount++ + registration stamped", async () => {
+    const t = convexTest(schema, modules);
+    const [first] = await setupPushing(t);
+    const r = await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      runId: "run-1", normalizedEmail: first!, waveLabel: "pro-launch-wave-4",
+    });
+    expect(r).toMatchObject({ ok: true, stampResult: "stamped" });
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.pushedCount).toBe(1);
+    const contacts = await readContacts(t, "run-1");
+    expect(contacts.find((c) => c.normalizedEmail === first)?.status).toBe("pushed");
+  });
+
+  test("_markContactPushed CAS: second call returns not-pending; pushedCount stays 1", async () => {
+    const t = convexTest(schema, modules);
+    const [first] = await setupPushing(t);
+    await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      runId: "run-1", normalizedEmail: first!, waveLabel: "pro-launch-wave-4",
+    });
+    const second = await t.mutation(internal.broadcast.waveRuns._markContactPushed, {
+      runId: "run-1", normalizedEmail: first!, waveLabel: "pro-launch-wave-4",
+    });
+    expect(second).toMatchObject({ ok: false, reason: "not-pending" });
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.pushedCount).toBe(1);
+  });
+
+  test("_markContactFailed: contact failed + failedCount++ (under threshold)", async () => {
+    // 100 contacts: 1 failure = 1%, under the 5% threshold → run does NOT flip.
+    const t = convexTest(schema, modules);
+    const emails = await setupPushing(t, 100);
+    const first = emails[0]!;
+    const r = await t.mutation(internal.broadcast.waveRuns._markContactFailed, {
+      runId: "run-1", normalizedEmail: first, failedReason: "Resend 422",
+    });
+    expect(r).toMatchObject({ ok: true, runFailed: false });
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.failedCount).toBe(1);
+    expect(run!.status).toBe("pushing"); // still pushing — under threshold
+    const contacts = await readContacts(t, "run-1");
+    const failed = contacts.find((c) => c.normalizedEmail === first);
+    expect(failed?.status).toBe("failed");
+    expect(failed?.failedReason).toBe("Resend 422");
+  });
+
+  test("_markContactFailed flips whole run when failure rate exceeds 5%", async () => {
+    // 4 contacts; 1 fail = 25% which is >5% → should flip.
+    const t = convexTest(schema, modules);
+    const [first] = await setupPushing(t, 4);
+    const r = await t.mutation(internal.broadcast.waveRuns._markContactFailed, {
+      runId: "run-1", normalizedEmail: first!, failedReason: "Resend 500",
+    });
+    expect(r).toMatchObject({ ok: true, runFailed: true });
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.status).toBe("failed");
+    expect(run!.failureSubstatus).toBe("batch-failure-rate-exceeded");
+  });
+
+  test("_markContactFailed CAS: second call on already-failed contact is no-op", async () => {
+    const t = convexTest(schema, modules);
+    // Use 100 contacts so a single failure is 1% — under threshold (won't flip the run)
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 100, batchSize: 50,
+    });
+    const emails = Array.from({ length: 100 }, (_, i) => `c${i}@test`);
+    await seedRegistrations(t, emails);
+    await t.mutation(internal.broadcast.waveRuns._persistPickedBatch, {
+      runId: "run-1", contacts: emails,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 100, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+
+    await t.mutation(internal.broadcast.waveRuns._markContactFailed, {
+      runId: "run-1", normalizedEmail: emails[0]!, failedReason: "Resend 500",
+    });
+    const second = await t.mutation(internal.broadcast.waveRuns._markContactFailed, {
+      runId: "run-1", normalizedEmail: emails[0]!, failedReason: "Resend 500 again",
+    });
+    expect(second).toMatchObject({ ok: false, reason: "not-pending" });
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.failedCount).toBe(1);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// _finalizeWaveRun + _markBroadcastCreated
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("finalize-phase mutations", () => {
+  async function setupBroadcastCreated(t: ReturnType<typeof convexTest>) {
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+  }
+
+  test("_markBroadcastCreated transitions pushing → broadcast-created with broadcastId", async () => {
+    const t = convexTest(schema, modules);
+    await setupBroadcastCreated(t);
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.status).toBe("broadcast-created");
+    expect(run!.broadcastId).toBe("bro_xyz");
+  });
+
+  test("_finalizeWaveRun atomically advances tier, sets lastWave*, clears lease, marks sent", async () => {
+    const t = convexTest(schema, modules);
+    await setupBroadcastCreated(t);
+    const sentAt = Date.now();
+    const r = await t.mutation(internal.broadcast.waveRuns._finalizeWaveRun, {
+      runId: "run-1", sentAt,
+    });
+    expect(r).toMatchObject({ ok: true, advancedToTier: 1 });
+    const config = await readConfig(t);
+    expect(config!.currentTier).toBe(1);
+    expect(config!.lastWaveLabel).toBe("pro-launch-wave-4");
+    expect(config!.lastWaveBroadcastId).toBe("bro_xyz");
+    expect(config!.lastWaveSegmentId).toBe("seg_abc");
+    expect(config!.lastWaveSentAt).toBe(sentAt);
+    expect(config!.lastRunStatus).toBe("succeeded");
+    expect(config!.pendingRunId).toBeUndefined();
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.status).toBe("sent");
+  });
+
+  test("_markFinalizeFailed create-broadcast-failed flips status='failed' (no broadcast yet)", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    await t.mutation(internal.broadcast.waveRuns._markFinalizeFailed, {
+      runId: "run-1", substatus: "create-broadcast-failed", error: "Resend 500",
+    });
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.status).toBe("failed");
+    expect(run!.failureSubstatus).toBe("create-broadcast-failed");
+  });
+
+  test("_markFinalizeFailed send-broadcast-failed KEEPS status='broadcast-created' (broadcast exists)", async () => {
+    const t = convexTest(schema, modules);
+    await setupBroadcastCreated(t);
+    await t.mutation(internal.broadcast.waveRuns._markFinalizeFailed, {
+      runId: "run-1", substatus: "send-broadcast-failed", error: "network timeout",
+    });
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.status).toBe("broadcast-created"); // unchanged
+    expect(run!.failureSubstatus).toBe("send-broadcast-failed");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Operator recovery — refuse-vs-route guards
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("operator recovery", () => {
+  test("resumeStalledWaveRun refuses broadcast-created (routes to resumeFinalizeWaveRun)", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    await expect(
+      t.mutation(internal.broadcast.waveRuns.resumeStalledWaveRun, { runId: "run-1" }),
+    ).rejects.toThrow(/broadcast-created.*resumeFinalizeWaveRun/);
+  });
+
+  test("resumeFinalizeWaveRun refuses send-failure case without confirmedNotSent", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    await t.mutation(internal.broadcast.waveRuns._markFinalizeFailed, {
+      runId: "run-1", substatus: "send-broadcast-failed", error: "network",
+    });
+    await expect(
+      t.mutation(internal.broadcast.waveRuns.resumeFinalizeWaveRun, { runId: "run-1" }),
+    ).rejects.toThrow(/verify in the Resend dashboard/);
+  });
+
+  test("resumeFinalizeWaveRun for create-broadcast-failed needs no confirmedNotSent (no broadcast exists)", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    await t.mutation(internal.broadcast.waveRuns._markFinalizeFailed, {
+      runId: "run-1", substatus: "create-broadcast-failed", error: "Resend 500",
+    });
+    const r = await t.mutation(
+      internal.broadcast.waveRuns.resumeFinalizeWaveRun,
+      { runId: "run-1" },
+    );
+    expect(r).toMatchObject({ ok: true, scheduled: "finalizeWaveAction-create-and-send" });
+    const run = await readWaveRun(t, "run-1");
+    // Patched back to pushing so finalize action re-enters via create path.
+    expect(run!.status).toBe("pushing");
+    expect(run!.failureSubstatus).toBeUndefined();
+    // Drain the scheduled finalizeWaveAction so it doesn't escape into an
+    // unhandled rejection (the action would try Resend HTTP which fails in
+    // the test env, but the scheduler-fail itself is fine).
+    await t.finishInProgressScheduledFunctions().catch(() => {});
+  });
+
+  test("discardWaveRun marks failed + bumps waveLabelOffset + clears lease", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 100, batchSize: 50,
+    });
+    const r = await t.mutation(internal.broadcast.waveRuns.discardWaveRun, {
+      runId: "run-1", reason: "operator decision",
+    });
+    expect(r).toMatchObject({ ok: true, newWaveLabelOffset: 4 });
+    const config = await readConfig(t);
+    expect(config!.waveLabelOffset).toBe(4);
+    expect(config!.pendingRunId).toBeUndefined();
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.status).toBe("failed");
+    expect(run!.failureSubstatus).toBe("discarded-by-operator");
+  });
+
+  test("markFinalizeRecovered finalizes the run when operator confirms send happened", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 1, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickComplete, {
+      runId: "run-1", segmentId: "seg_abc", totalCount: 1, underfilled: false,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPushingStarted, { runId: "run-1" });
+    await t.mutation(internal.broadcast.waveRuns._markBroadcastCreated, {
+      runId: "run-1", broadcastId: "bro_xyz",
+    });
+    await t.mutation(internal.broadcast.waveRuns._markFinalizeFailed, {
+      runId: "run-1", substatus: "send-broadcast-failed", error: "timeout",
+    });
+    const sentAt = Date.now();
+    const r = await t.mutation(internal.broadcast.waveRuns.markFinalizeRecovered, {
+      runId: "run-1", sentAt, reason: "Resend dashboard confirmed sent at 10:19 UTC",
+    });
+    expect(r).toMatchObject({ ok: true, advancedToTier: 1 });
+    const config = await readConfig(t);
+    expect(config!.currentTier).toBe(1);
+    expect(config!.lastWaveSentAt).toBe(sentAt);
+    expect(config!.pendingRunId).toBeUndefined();
+    const run = await readWaveRun(t, "run-1");
+    expect(run!.status).toBe("sent");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// In-flight guard query + cleanup
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("_listInFlightWaveRuns + cleanup", () => {
+  test("_listInFlightWaveRuns returns active runs with lastActivityAt fallback", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 100, batchSize: 50,
+    });
+    const inFlight = await t.query(
+      internal.broadcast.waveRuns._listInFlightWaveRuns,
+      {},
+    );
+    expect(inFlight).toHaveLength(1);
+    expect(inFlight[0]).toMatchObject({ runId: "run-1", status: "picking" });
+    expect(inFlight[0]!.lastActivityAt).toBeGreaterThan(0);
+  });
+
+  test("_listInFlightWaveRuns excludes terminal-state runs (sent, failed)", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 100, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._markPickFailed, {
+      runId: "run-1", substatus: "empty-pool", error: "no contacts",
+    });
+    const inFlight = await t.query(
+      internal.broadcast.waveRuns._listInFlightWaveRuns,
+      {},
+    );
+    expect(inFlight).toHaveLength(0);
+  });
+
+  test("_cleanupDiscardedWavePickedContacts deletes a chunk + reports hasMore", async () => {
+    const t = convexTest(schema, modules);
+    await seedRampConfig(t);
+    await t.mutation(internal.broadcast.waveRuns._claimWaveRunLease, {
+      waveLabel: "pro-launch-wave-4", runId: "run-1", requestedCount: 3, batchSize: 50,
+    });
+    await t.mutation(internal.broadcast.waveRuns._persistPickedBatch, {
+      runId: "run-1", contacts: ["a@t", "b@t", "c@t"],
+    });
+    const r = await t.mutation(
+      internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts,
+      { runId: "run-1" },
+    );
+    expect(r.deleted).toBe(3);
+    expect(r.hasMore).toBe(false);
+    const remaining = await readContacts(t, "run-1");
+    expect(remaining).toHaveLength(0);
+  });
+});

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as broadcast_metrics from "../broadcast/metrics.js";
 import type * as broadcast_proLaunchEmailContent from "../broadcast/proLaunchEmailContent.js";
 import type * as broadcast_rampRunner from "../broadcast/rampRunner.js";
 import type * as broadcast_sendBroadcast from "../broadcast/sendBroadcast.js";
+import type * as broadcast_waveRuns from "../broadcast/waveRuns.js";
 import type * as config_productCatalog from "../config/productCatalog.js";
 import type * as constants from "../constants.js";
 import type * as contactMessages from "../contactMessages.js";
@@ -62,6 +63,7 @@ declare const fullApi: ApiFromModules<{
   "broadcast/proLaunchEmailContent": typeof broadcast_proLaunchEmailContent;
   "broadcast/rampRunner": typeof broadcast_rampRunner;
   "broadcast/sendBroadcast": typeof broadcast_sendBroadcast;
+  "broadcast/waveRuns": typeof broadcast_waveRuns;
   "config/productCatalog": typeof config_productCatalog;
   constants: typeof constants;
   contactMessages: typeof contactMessages;

--- a/convex/broadcast/rampRunner.ts
+++ b/convex/broadcast/rampRunner.ts
@@ -1045,6 +1045,34 @@ export const runDailyRamp = internalAction({
       return { status: "wave-in-flight", detail: top.runId };
     }
 
+    // Belt-and-suspenders lease check. `_listInFlightWaveRuns` only returns
+    // runs in active states (picking/segment-created/pushing/broadcast-created)
+    // — it does NOT include `failed` runs. But `failed` runs may STILL hold
+    // the lease (e.g. `persist-failed`, `segment-create-failed`,
+    // `batch-failure-rate-exceeded` all preserve the lease until the
+    // operator explicitly discards). Without this check, we'd schedule a
+    // new pickWaveAction whose `_claimWaveRunLease` then refuses with
+    // `lease-held` — operator sees `wave-scheduled` but the ramp is
+    // actually blocked waiting for them. Surface the failed-with-lease
+    // case explicitly so the operator knows to act.
+    if (row.pendingRunId) {
+      // Look up the run to surface its substatus for operator triage.
+      const heldRun = await ctx.runQuery(
+        internal.broadcast.waveRuns.getWaveRunStatus,
+        { runId: row.pendingRunId },
+      );
+      const detail =
+        heldRun !== null
+          ? `${row.pendingRunId} status=${heldRun.status}` +
+            (heldRun.failureSubstatus ? ` substatus=${heldRun.failureSubstatus}` : "")
+          : row.pendingRunId;
+      console.error(
+        `[runDailyRamp] LEASE HELD by ${detail} — likely a failed run pending operator action ` +
+        `(resumeFinalizeWaveRun / discardWaveRun depending on substatus). Skipping today's tick.`,
+      );
+      return { status: "lease-held-by-failed-run", detail };
+    }
+
     // ──── Step 4: schedule pickWaveAction (fire-and-forget via scheduler) ────
     // Use ctx.scheduler.runAfter(0, ...) — NOT ctx.runAction(...) — so the
     // entire pick→push→finalize pipeline runs in fresh execution contexts,

--- a/convex/broadcast/rampRunner.ts
+++ b/convex/broadcast/rampRunner.ts
@@ -76,7 +76,6 @@ import {
 } from "../_generated/server";
 import { internal } from "../_generated/api";
 import type { Doc } from "../_generated/dataModel";
-import type { WaveExportStats } from "./audienceWaveExport";
 
 const DEFAULT_BOUNCE_KILL_THRESHOLD = 0.04;
 const DEFAULT_COMPLAINT_KILL_THRESHOLD = 0.0008;
@@ -93,10 +92,11 @@ const MIN_DELIVERED_FOR_KILLGATE = 100;
 // the cron runs more than once a day.
 const MIN_HOURS_BETWEEN_WAVES = 18;
 
-// If `assignAndExportWave` returns `assigned < count * UNDERFILL_RATIO`,
-// treat the pool as drained and stop the ramp. 0.5 catches the case
-// where the curve outpaces the actual remaining audience.
-const UNDERFILL_RATIO = 0.5;
+// PR 2 (post-launch-stabilization, 2026-04-30) moved underfill handling
+// into pickWaveAction (waveRuns.ts) — the pool-drained branch in
+// runDailyRamp is gone, and `WaveExportStats` / `UNDERFILL_RATIO` are no
+// longer referenced from this file. Kept the constants and types in
+// `audienceWaveExport.ts` for the legacy direct-CLI invocation path.
 
 const RAMP_KEY = "current";
 
@@ -505,6 +505,53 @@ export const getRampStatus = internalQuery({
       pendingExportAt: row.pendingExportAt,
       pendingBroadcastId: row.pendingBroadcastId,
       pendingBroadcastAt: row.pendingBroadcastAt,
+      // PR 2 (post-launch-stabilization): in-flight wave-loading state
+      // machine surface. Empty array when no run is active.
+      activeWaveRuns: await (async () => {
+        const runs: Array<{
+          runId: string;
+          waveLabel: string;
+          status: string;
+          totalCount: number;
+          pushedCount: number;
+          failedCount: number;
+          batchSize: number;
+          underfilled: boolean;
+          segmentId?: string;
+          broadcastId?: string;
+          failureSubstatus?: string;
+          lastActivityAt: number;
+          ageMin: number;
+        }> = [];
+        const activeStatuses: Array<
+          "picking" | "segment-created" | "pushing" | "broadcast-created"
+        > = ["picking", "segment-created", "pushing", "broadcast-created"];
+        for (const status of activeStatuses) {
+          const found = await ctx.db
+            .query("waveRuns")
+            .withIndex("by_status", (q) => q.eq("status", status))
+            .collect();
+          for (const r of found) {
+            const lastActivityAt = r.lastBatchAt ?? r.updatedAt ?? r.createdAt;
+            runs.push({
+              runId: r.runId,
+              waveLabel: r.waveLabel,
+              status: r.status,
+              totalCount: r.totalCount,
+              pushedCount: r.pushedCount,
+              failedCount: r.failedCount,
+              batchSize: r.batchSize,
+              underfilled: r.underfilled,
+              segmentId: r.segmentId,
+              broadcastId: r.broadcastId,
+              failureSubstatus: r.failureSubstatus,
+              lastActivityAt,
+              ageMin: (Date.now() - lastActivityAt) / 60_000,
+            });
+          }
+        }
+        return runs;
+      })(),
     };
   },
 });
@@ -957,188 +1004,66 @@ export const runDailyRamp = internalAction({
     }
     const waveLabel = `${row.waveLabelPrefix}-${nextTier + row.waveLabelOffset}`;
 
-    // ──── Step 3a: ATOMICALLY CLAIM THE LEASE before any external side effect ────
-    // Two concurrent runs (cron + manual trigger, Convex retry, misconfigured
-    // schedule) both pass kill-gate / tier-bounds checks above before anything
-    // mutates state. Without this claim, both would proceed through
-    // assignAndExportWave + createProLaunchBroadcast + sendProLaunchBroadcast,
-    // duplicate-emailing every recipient, and only collide at _recordWaveSent.
-    // Claim the lease BEFORE any external side effect so the loser exits clean.
+    // ──── Step 3: in-flight guard via the new wave-loading state machine ────
+    // PR 2 (post-launch-stabilization plan, 2026-04-29) replaces the
+    // monolithic assignAndExportWave + createProLaunchBroadcast + sendProLaunchBroadcast
+    // chain with a self-driving multi-step pipeline that fits within the
+    // Convex 10-min action runtime budget at any wave size. The state lives
+    // on `waveRuns` + `wavePickedContacts`. See `convex/broadcast/waveRuns.ts`.
+    //
+    // The legacy `_claimTierForRun` + `_recordPendingExport` + `_recordPendingBroadcast`
+    // + `_recordWaveSent` + `_recordRunOutcome` mutations remain in this
+    // module so the operator-recovery commands (`recoverFromPartialFailure`,
+    // `clearPartialFailure`, `forceReleaseLease`) keep working on any
+    // legacy partial-failure rows. New runs go through the state machine.
+    //
+    // In-flight guard: refuse to start a new wave while any waveRuns row is
+    // active. The new state machine maintains its own `pendingRunId` lease
+    // on `broadcastRampConfig` via `_claimWaveRunLease` — this guard is
+    // belt-and-suspenders against a force-cleared lease leaving an orphaned
+    // active waveRuns row.
+    const inFlight = await ctx.runQuery(
+      internal.broadcast.waveRuns._listInFlightWaveRuns,
+      {},
+    );
+    if (inFlight.length > 0) {
+      const top = inFlight[0];
+      // top is guaranteed non-null by the length check (silences
+      // noUncheckedIndexedAccess and protects future code changes that
+      // might break the bounds check).
+      if (!top) throw new Error("[runDailyRamp] inFlight bounds-check invariant violated");
+      const ageMin = (Date.now() - top.lastActivityAt) / 60_000;
+      if (ageMin >= 15) {
+        console.error(
+          `[runDailyRamp] STALLED waveRun runId=${top.runId} status=${top.status} (last activity ${ageMin.toFixed(1)}min ago) — operator must resume (resumeStalledWaveRun / resumeFinalizeWaveRun) or discard (discardWaveRun) before next tick.`,
+        );
+        return { status: "stalled-wave-run", detail: top.runId };
+      }
+      console.log(
+        `[runDailyRamp] wave already in flight (runId=${top.runId} status=${top.status}, last activity ${ageMin.toFixed(1)}min ago) — skip`,
+      );
+      return { status: "wave-in-flight", detail: top.runId };
+    }
+
+    // ──── Step 4: schedule pickWaveAction (fire-and-forget via scheduler) ────
+    // Use ctx.scheduler.runAfter(0, ...) — NOT ctx.runAction(...) — so the
+    // entire pick→push→finalize pipeline runs in fresh execution contexts,
+    // each with its own 10-min budget. ctx.runAction would await the whole
+    // chain inside this single runDailyRamp invocation and re-introduce
+    // the budget problem the rebuild exists to solve.
     const runId =
       typeof crypto !== "undefined" && crypto.randomUUID
         ? crypto.randomUUID()
         : `run-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-    const claim: { ok: boolean; reason?: string; actualTier?: number; heldBy?: string; ageMs?: number } =
-      await ctx.runMutation(internal.broadcast.rampRunner._claimTierForRun, {
-        runId,
-        expectedCurrentTier: row.currentTier,
-      });
-    if (!claim.ok) {
-      console.log(
-        `[runDailyRamp] claim rejected (${claim.reason}${
-          claim.heldBy ? `, heldBy=${claim.heldBy}, ageMs=${claim.ageMs}` : ""
-        }${claim.actualTier !== undefined ? `, actualTier=${claim.actualTier}` : ""}) — skip`,
-      );
-      // Don't record an outcome here — the other holder will record theirs;
-      // recording ours would stomp their lease/status. Just exit.
-      return { status: `claim-rejected-${claim.reason}` };
-    }
-
-    // ──── Step 3b: pick + stamp + create segment + push ────
-    let exportResult: WaveExportStats;
-    try {
-      exportResult = await ctx.runAction(
-        internal.broadcast.audienceWaveExport.assignAndExportWave,
-        { waveLabel, count },
-      );
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await ctx.runMutation(
-        internal.broadcast.rampRunner._recordRunOutcome,
-        { runId, status: "partial-failure", error: msg },
-      );
-      throw err; // bubble so Convex auto-Sentry captures
-    }
-
-    // P1#4 (round 2): persist post-export progress IMMEDIATELY after
-    // assignAndExportWave returns, BEFORE inspecting failure counters /
-    // underfill. The export ran — there's a real `segmentId`, contacts may
-    // be stamped, contacts may be in the Resend segment — independent of
-    // whether `failed > 0`, `stampFailed > 0`, or `assigned < threshold`.
-    // If we deferred persistence past those branches, an operator running
-    // `clearPartialFailure({confirmNoExport: true})` would see no
-    // `pendingWaveLabel/SegmentId/BroadcastId` and the fail-closed guard
-    // would let the clear through — masking stamped contacts and the
-    // segment that's already in Resend. Persisting first means every
-    // partial-failure path post-export carries the markers, and
-    // clearPartialFailure refuses loudly. Lease-validating: throws if the
-    // lease was force-released mid-flight, bubbling to Convex auto-Sentry.
-    await ctx.runMutation(
-      internal.broadcast.rampRunner._recordPendingExport,
-      {
-        runId,
-        waveLabel,
-        segmentId: exportResult.segmentId,
-        assigned: exportResult.assigned,
-      },
+    await ctx.scheduler.runAfter(
+      0,
+      internal.broadcast.waveRuns.pickWaveAction,
+      { waveLabel, runId, requestedCount: count },
     );
-
-    // Treat any non-zero export failure counter as a partial-failure
-    // and refuse to send. Without this, a wave that requested 500 and
-    // got 250 push failures + 250 successes would still proceed to
-    // create + send the broadcast — the cron would record the wave as
-    // a clean tier advance even though half the audience was dropped
-    // and `stampFailed > 0` would silently leak duplicate-email risk
-    // into the next pick (pushed but unstamped → re-eligible).
-    // Operator clears via the same `lastRunStatus === partial-failure`
-    // gate that handles other partial-failure paths.
-    if (exportResult.failed > 0 || exportResult.stampFailed > 0) {
-      const reason = `assignAndExportWave partial: failed=${exportResult.failed}, stampFailed=${exportResult.stampFailed} (segment=${exportResult.segmentId}, assigned=${exportResult.assigned}, requested=${count}, waveLabel=${waveLabel}). Investigate Resend logs + Convex stamp errors before resuming; stampFailed contacts are in the segment but unstamped (duplicate-email risk).`;
-      console.error(`[runDailyRamp] ${reason}`);
-      await ctx.runMutation(
-        internal.broadcast.rampRunner._recordRunOutcome,
-        { runId, status: "partial-failure", error: reason },
-      );
-      return { status: "partial-failure", detail: reason };
-    }
-
-    if (
-      exportResult.underfilled &&
-      exportResult.assigned < count * UNDERFILL_RATIO
-    ) {
-      // P1 round 4: contacts ARE stamped (excluded from future picks) AND in
-      // the Resend segment, but no broadcast was created/sent. Routing
-      // through "pool-drained" + deactivate-and-clear-lease would strand
-      // them — they'd never receive the email AND `recoverFromPartialFailure`
-      // couldn't run because status would be "pool-drained" instead of
-      // "partial-failure". Route through the recoverable partial-failure
-      // path: persisted pending* markers + lastRunStatus="partial-failure"
-      // make recoverFromPartialFailure({recovery:"manual-finished"}) able to
-      // pick up exactly where the runner stopped, OR
-      // recoverFromPartialFailure({recovery:"discard-and-rotate"}) to
-      // explicitly abandon (operator's call, not the runner's). Ramp is
-      // still deactivated — pool drained means the curve is done.
-      const reason = `pool drained — requested ${count}, got ${exportResult.assigned} stamped + in segment ${exportResult.segmentId} (waveLabel=${waveLabel}). Contacts ARE stamped and excluded from future picks; they will be lost unless this wave is sent. Recovery: pending* state persisted; recoverFromPartialFailure({recovery:"manual-finished", sentAt:<epoch>}) after manually completing the broadcast in Resend, OR recoverFromPartialFailure({recovery:"discard-and-rotate"}) to abandon. Ramp deactivated; resumeRamp if appropriate after recovery.`;
-      console.log(`[runDailyRamp] ${reason}`);
-      await ctx.runMutation(
-        internal.broadcast.rampRunner._recordRunOutcome,
-        {
-          runId,
-          status: "partial-failure",
-          deactivate: true,
-          error: reason,
-        },
-      );
-      return { status: "pool-drained-partial-failure", detail: reason };
-    }
-
-    // ──── Step 4: create + send the broadcast ────
-    let broadcastId: string;
-    try {
-      const created: { broadcastId: string } = await ctx.runAction(
-        internal.broadcast.sendBroadcast.createProLaunchBroadcast,
-        { segmentId: exportResult.segmentId, nameSuffix: waveLabel },
-      );
-      broadcastId = created.broadcastId;
-    } catch (err) {
-      // sentry-coverage-ok: status recorded into config; Convex
-      // auto-Sentry catches the throw via the re-raise below.
-      const msg = err instanceof Error ? err.message : String(err);
-      await ctx.runMutation(
-        internal.broadcast.rampRunner._recordRunOutcome,
-        {
-          runId,
-          status: "partial-failure",
-          error: `createProLaunchBroadcast: ${msg} (waveLabel=${waveLabel}, segmentId=${exportResult.segmentId}, ${exportResult.assigned} contacts stamped + in segment). Recovery: pending* state persisted; call recoverFromPartialFailure({recovery:"manual-finished", sentAt:<epoch>}) after manually completing send, or recoverFromPartialFailure({recovery:"discard-and-rotate"}) to bump waveLabelOffset.`,
-        },
-      );
-      throw err;
-    }
-
-    // P1#4: persist post-broadcast-create progress before the send. Lease-
-    // validating: throws if the lease was force-released mid-flight.
-    await ctx.runMutation(
-      internal.broadcast.rampRunner._recordPendingBroadcast,
-      { runId, broadcastId },
-    );
-
-    try {
-      await ctx.runAction(
-        internal.broadcast.sendBroadcast.sendProLaunchBroadcast,
-        { broadcastId },
-      );
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      await ctx.runMutation(
-        internal.broadcast.rampRunner._recordRunOutcome,
-        {
-          runId,
-          status: "partial-failure",
-          error: `sendProLaunchBroadcast: ${msg} (waveLabel=${waveLabel}, segmentId=${exportResult.segmentId}, broadcastId=${broadcastId}, assigned=${exportResult.assigned}). Recovery: pending* state persisted; preview in Resend dashboard, then recoverFromPartialFailure({recovery:"manual-finished", sentAt:<epoch>}) (broadcastId/segmentId/assigned/waveLabel auto-fill from persisted state). If unrecoverable, recoverFromPartialFailure({recovery:"discard-and-rotate"}) bumps waveLabelOffset.`,
-        },
-      );
-      throw err;
-    }
-
-    // ──── Step 5: record success ────
-    await ctx.runMutation(internal.broadcast.rampRunner._recordWaveSent, {
-      runId,
-      expectedCurrentTier: row.currentTier,
-      newTier: nextTier,
-      waveLabel,
-      broadcastId,
-      segmentId: exportResult.segmentId,
-      assigned: exportResult.assigned,
-      sentAt: Date.now(),
-    });
-
     console.log(
-      `[runDailyRamp] sent ${waveLabel} (tier ${nextTier}, count ${exportResult.assigned}, broadcast ${broadcastId})`,
+      `[runDailyRamp] scheduled pickWaveAction runId=${runId} waveLabel=${waveLabel} requestedCount=${count}`,
     );
-    return {
-      status: "sent",
-      detail: `${waveLabel} → ${exportResult.assigned} contacts`,
-    };
+    return { status: "wave-scheduled", detail: runId };
   },
 });
 

--- a/convex/broadcast/waveRuns.ts
+++ b/convex/broadcast/waveRuns.ts
@@ -83,8 +83,10 @@ const CLEANUP_CHUNK_SIZE = 500;
  *  `failed/batch-failure-rate-exceeded` — operator must `discardWaveRun`. */
 const FAILURE_RATE_THRESHOLD = 0.05;
 
-/** Resend backoff schedule (ms) for 429/5xx. Last entry is jitter base. */
-const RESEND_BACKOFF_MS = [250, 500, 1000];
+/** Resend backoff schedule (ms) for 429/5xx. The loop runs for
+ *  attempts 0..MAX-1; the final attempt's outcome is returned without
+ *  sleeping further. So we need MAX-1 sleep slots, not MAX. */
+const RESEND_BACKOFF_MS = [250, 500];
 const RESEND_BACKOFF_MAX_RETRIES = 3;
 
 /** Pagination size for `_getRegistrationsPage`. Same value as the legacy
@@ -155,10 +157,12 @@ async function pushWithBackoff(
     if (!transient || attempt === RESEND_BACKOFF_MAX_RETRIES - 1) {
       return result;
     }
-    // The fallback chain ends at the last entry of RESEND_BACKOFF_MS, which
-    // is statically non-empty — but `noUncheckedIndexedAccess` doesn't know
-    // that. Coerce to number (last entry guaranteed defined; default 1000ms
-    // if the array were ever emptied — fail-safe).
+    // The loop returns before reaching this line on attempt === MAX-1 (see
+    // condition above), so attempt is in [0, MAX-1) here. RESEND_BACKOFF_MS
+    // is sized to MAX-1 slots — the index is always in-range — but
+    // noUncheckedIndexedAccess can't prove that. Defensive fallback to
+    // the last entry, then a hard 1000ms safety net if the array were
+    // ever shorter.
     const base =
       RESEND_BACKOFF_MS[attempt] ??
       RESEND_BACKOFF_MS[RESEND_BACKOFF_MS.length - 1] ??
@@ -704,23 +708,31 @@ export const _markPushingStarted = internalMutation({
  * AND inline-stamp the matching `registrations` row (mutations cannot
  * call other mutations via runMutation, so the stamp logic from
  * `_stampWaveByNormalizedEmail` is duplicated here).
+ *
+ * Takes `contactId` directly (not a query lookup) — at large wave sizes
+ * the previous `.filter().unique()` scan over by_runId_status would
+ * traverse all pending rows and trip Convex's 8192-document-read-per-
+ * mutation limit (~8k pending contacts breaks the mutation). The id is
+ * already in hand at the action's call site (`_getPendingBatch` returns
+ * full Docs), so a direct `ctx.db.get(contactId)` is O(1) / 1 read AND
+ * provides the same CAS guard via the post-load status check.
  */
 export const _markContactPushed = internalMutation({
   args: {
+    contactId: v.id("wavePickedContacts"),
     runId: v.string(),
     normalizedEmail: v.string(),
     waveLabel: v.string(),
   },
-  handler: async (ctx, { runId, normalizedEmail, waveLabel }) => {
-    const contact = await ctx.db
-      .query("wavePickedContacts")
-      .withIndex("by_runId_status", (q) =>
-        q.eq("runId", runId).eq("status", "pending"),
-      )
-      .filter((q) => q.eq(q.field("normalizedEmail"), normalizedEmail))
-      .unique();
-    if (!contact) {
-      // Either already-pushed or already-failed (CAS no-op) OR nonexistent.
+  handler: async (ctx, { contactId, runId, normalizedEmail, waveLabel }) => {
+    const contact = await ctx.db.get(contactId);
+    if (
+      !contact ||
+      contact.runId !== runId ||
+      contact.status !== "pending" ||
+      contact.normalizedEmail !== normalizedEmail
+    ) {
+      // CAS: no-op if already-pushed/failed, runId mismatch, or row deleted.
       return { ok: false as const, reason: "not-pending" as const };
     }
     const now = Date.now();
@@ -768,22 +780,25 @@ export const _markContactPushed = internalMutation({
  * status is 'pending'. Increments failedCount. If the new failure rate
  * exceeds FAILURE_RATE_THRESHOLD, ALSO atomically flips the whole run
  * to status='failed' with failureSubstatus='batch-failure-rate-exceeded'.
+ *
+ * Takes `contactId` directly to avoid the 8192-doc-read limit on large
+ * waves — see `_markContactPushed` for rationale.
  */
 export const _markContactFailed = internalMutation({
   args: {
+    contactId: v.id("wavePickedContacts"),
     runId: v.string(),
     normalizedEmail: v.string(),
     failedReason: v.string(),
   },
-  handler: async (ctx, { runId, normalizedEmail, failedReason }) => {
-    const contact = await ctx.db
-      .query("wavePickedContacts")
-      .withIndex("by_runId_status", (q) =>
-        q.eq("runId", runId).eq("status", "pending"),
-      )
-      .filter((q) => q.eq(q.field("normalizedEmail"), normalizedEmail))
-      .unique();
-    if (!contact) {
+  handler: async (ctx, { contactId, runId, normalizedEmail, failedReason }) => {
+    const contact = await ctx.db.get(contactId);
+    if (
+      !contact ||
+      contact.runId !== runId ||
+      contact.status !== "pending" ||
+      contact.normalizedEmail !== normalizedEmail
+    ) {
       return { ok: false as const, reason: "not-pending" as const };
     }
     const now = Date.now();
@@ -886,6 +901,7 @@ export const pushBatchAction = internalAction({
         const failResult = await ctx.runMutation(
           internal.broadcast.waveRuns._markContactFailed,
           {
+            contactId: contact._id,
             runId,
             normalizedEmail: contact.normalizedEmail,
             failedReason: result.reason,
@@ -907,6 +923,7 @@ export const pushBatchAction = internalAction({
       await ctx.runMutation(
         internal.broadcast.waveRuns._markContactPushed,
         {
+          contactId: contact._id,
           runId,
           normalizedEmail: contact.normalizedEmail,
           waveLabel: info.run.waveLabel,
@@ -1307,16 +1324,44 @@ export const markFinalizeRecovered = internalMutation({
       .unique();
     if (!run) throw new Error(`[markFinalizeRecovered] no run ${runId}`);
 
-    // Strict status guard. Substatus alone is insufficient: a duplicate
-    // finalize loser could have stamped `failureSubstatus='send-broadcast-failed'`
-    // onto a run that's actually `status='sent'` — without this check,
-    // markFinalizeRecovered would re-advance the tier a second time.
+    // Strict status + substatus guard. We need BOTH:
+    //   - status === 'broadcast-created' (the only state where the broadcast
+    //     object exists in Resend AND the tier hasn't been advanced)
+    //   - failureSubstatus === 'send-broadcast-failed' (confirms a genuine
+    //     send failure that the operator has verified-as-actually-sent in
+    //     the Resend dashboard)
+    //
+    // Status alone is insufficient: status='broadcast-created' is ALSO the
+    // mid-flight state between _markBroadcastCreated and sendProLaunchBroadcast
+    // (no substatus yet). An operator calling markFinalizeRecovered in that
+    // window would advance the tier while finalizeWaveAction still runs;
+    // the action's _finalizeWaveRun is now idempotent (won't double-advance),
+    // but Resend ALSO sees the send as legitimate — so we'd have advanced
+    // the tier on a still-in-flight wave. Better: require explicit failure
+    // signal from operator-confirmed send-broadcast-failed.
+    //
+    // resumeFinalizeWaveRun's success path PATCHES failureSubstatus back to
+    // undefined and reschedules the action, so a post-resume run also won't
+    // pass this guard — operator must wait for the next attempt to either
+    // succeed (status='sent') or fail back to send-broadcast-failed before
+    // markFinalizeRecovered is invocable again. That's the right behavior:
+    // markFinalizeRecovered is for the specific case "Resend confirmed sent
+    // but our action saw an error".
     if (run.status !== "broadcast-created") {
       throw new Error(
         `[markFinalizeRecovered] run ${runId} status=${run.status} — recovery requires status='broadcast-created'. ` +
         (run.status === "sent"
           ? `The run was already finalized; nothing to recover. Inspect lastWaveSentAt on broadcastRampConfig.`
           : `If in 'failed', use resumeFinalizeWaveRun (which patches back to broadcast-created) or discardWaveRun.`),
+      );
+    }
+    if (run.failureSubstatus !== "send-broadcast-failed") {
+      throw new Error(
+        `[markFinalizeRecovered] run ${runId} status='broadcast-created' but failureSubstatus=` +
+        `${run.failureSubstatus ?? "<none>"}. markFinalizeRecovered only applies to send-broadcast-failed. ` +
+        `If the run is mid-flight (no substatus), wait for finalizeWaveAction to finish — _finalizeWaveRun is ` +
+        `idempotent on already-sent. If you ran resumeFinalizeWaveRun and want to abort the retry instead, ` +
+        `wait for the scheduled finalizeWaveAction to either succeed or re-fail; only then is markFinalizeRecovered safe.`,
       );
     }
     if (!run.broadcastId || !run.segmentId) {
@@ -1715,6 +1760,12 @@ const TERMINAL_FAILURE_SUBSTATUSES = [
   "batch-failure-rate-exceeded",
 ] as const;
 
+/** Max failed runs to consider per cleanup cron tick. Bounded so a
+ *  long-lived deployment with many discarded waves doesn't load the
+ *  whole table into memory at once. The cron runs daily — at 100/day,
+ *  cleanup would catch up on any reasonable backlog within a week. */
+const CLEANUP_CANDIDATES_PER_TICK = 100;
+
 export const _listFailedWaveRunsForCleanup = internalQuery({
   args: {},
   handler: async (ctx) => {
@@ -1722,7 +1773,7 @@ export const _listFailedWaveRunsForCleanup = internalQuery({
     const failed = await ctx.db
       .query("waveRuns")
       .withIndex("by_status", (q) => q.eq("status", "failed"))
-      .collect();
+      .take(CLEANUP_CANDIDATES_PER_TICK);
     return failed
       .filter(
         (r) =>

--- a/convex/broadcast/waveRuns.ts
+++ b/convex/broadcast/waveRuns.ts
@@ -1008,6 +1008,14 @@ export const _markBroadcastCreated = internalMutation({
   },
 });
 
+/**
+ * CAS-guarded failure recorder. Refuses to overwrite a terminal-success row
+ * (`status='sent'`) — without this guard, a duplicate finalize action whose
+ * Resend send returns "already sent" 422 would overwrite the WINNING
+ * finalize's clean state with `failureSubstatus='send-broadcast-failed'`,
+ * and a subsequent operator `markFinalizeRecovered` would re-advance the
+ * tier a second time.
+ */
 export const _markFinalizeFailed = internalMutation({
   args: {
     runId: v.string(),
@@ -1023,6 +1031,29 @@ export const _markFinalizeFailed = internalMutation({
       .withIndex("by_runId", (q) => q.eq("runId", runId))
       .unique();
     if (!run) throw new Error(`[_markFinalizeFailed] no run ${runId}`);
+
+    // Terminal-status CAS. If a concurrent finalize already committed
+    // status='sent', this is a duplicate-finalize loser whose Resend
+    // 422-already-sent error landed it here. Treat as no-op success — the
+    // winner's state is correct; we should not overwrite it.
+    if (run.status === "sent") {
+      return { ok: false as const, reason: "already-sent" as const };
+    }
+    // Defensive: if already in a failed-with-different-substatus state,
+    // refuse to overwrite. Operator's existing recovery routing depends
+    // on the original substatus.
+    if (
+      run.status === "failed" &&
+      run.failureSubstatus !== undefined &&
+      run.failureSubstatus !== substatus
+    ) {
+      return {
+        ok: false as const,
+        reason: "already-failed-different-substatus" as const,
+        existing: run.failureSubstatus,
+      };
+    }
+
     const now = Date.now();
     // For send-broadcast-failed we keep status='broadcast-created' so the
     // discriminator is the substatus, not the status — clearer for operator
@@ -1222,7 +1253,7 @@ export const finalizeWaveAction = internalAction({
         { broadcastId: after.run.broadcastId },
       );
     } catch (err) {
-      await ctx.runMutation(
+      const failResult = await ctx.runMutation(
         internal.broadcast.waveRuns._markFinalizeFailed,
         {
           runId,
@@ -1230,6 +1261,16 @@ export const finalizeWaveAction = internalAction({
           error: err instanceof Error ? err.message : String(err),
         },
       );
+      // CAS detected the run is already 'sent' — this is a duplicate finalize
+      // whose Resend call returned 422 already-sent (the winner finalized
+      // ahead of us). Don't propagate the throw; the run state is correct.
+      if (!failResult.ok && failResult.reason === "already-sent") {
+        console.log(
+          `[finalizeWaveAction] runId=${runId} send returned error but run already sent ` +
+          `by another invocation — treating as duplicate-finalize loser (clean exit)`,
+        );
+        return { ok: true, reason: "already-sent-duplicate-loser" };
+      }
       throw err;
     }
 
@@ -1265,9 +1306,17 @@ export const markFinalizeRecovered = internalMutation({
       .withIndex("by_runId", (q) => q.eq("runId", runId))
       .unique();
     if (!run) throw new Error(`[markFinalizeRecovered] no run ${runId}`);
-    if (run.failureSubstatus !== "send-broadcast-failed" && run.status !== "broadcast-created") {
+
+    // Strict status guard. Substatus alone is insufficient: a duplicate
+    // finalize loser could have stamped `failureSubstatus='send-broadcast-failed'`
+    // onto a run that's actually `status='sent'` — without this check,
+    // markFinalizeRecovered would re-advance the tier a second time.
+    if (run.status !== "broadcast-created") {
       throw new Error(
-        `[markFinalizeRecovered] run ${runId} not in send-failure state (status=${run.status}, substatus=${run.failureSubstatus ?? "<none>"})`,
+        `[markFinalizeRecovered] run ${runId} status=${run.status} — recovery requires status='broadcast-created'. ` +
+        (run.status === "sent"
+          ? `The run was already finalized; nothing to recover. Inspect lastWaveSentAt on broadcastRampConfig.`
+          : `If in 'failed', use resumeFinalizeWaveRun (which patches back to broadcast-created) or discardWaveRun.`),
       );
     }
     if (!run.broadcastId || !run.segmentId) {
@@ -1278,6 +1327,16 @@ export const markFinalizeRecovered = internalMutation({
       .withIndex("by_key", (q) => q.eq("key", "current"))
       .unique();
     if (!config) throw new Error("[markFinalizeRecovered] no broadcastRampConfig");
+    // Lease must still be held by THIS runId — otherwise another run has
+    // taken over OR an operator force-released and we'd be advancing the
+    // tier from a stale runId.
+    if (config.pendingRunId !== runId) {
+      throw new Error(
+        `[markFinalizeRecovered] runId=${runId} lost lease (held by ${config.pendingRunId ?? "<cleared>"}). ` +
+        `Investigate: another run may have advanced the tier OR forceReleaseLease was used. ` +
+        `Refusing to advance the tier from a stale runId.`,
+      );
+    }
 
     const now = Date.now();
     const nextTier = config.currentTier + 1;
@@ -1621,6 +1680,41 @@ export const cleanupDiscardedWavePickedContactsAction = internalAction({
   },
 });
 
+/**
+ * Auto-cleanup candidates: failed runs >24h old whose substatus indicates
+ * **terminal abandonment** — meaning the operator either explicitly discarded
+ * them or no recovery path is meaningful. RECOVERABLE finalize failures
+ * (`create-broadcast-failed`, `send-broadcast-failed`) are excluded because
+ * the segment may still be valid in Resend AND the operator may yet run
+ * `resumeFinalizeWaveRun` / `markFinalizeRecovered`. If we cleaned those up,
+ * the unstamping step would re-eligibilize already-pushed recipients and a
+ * subsequent successful send would create duplicate outreach.
+ *
+ * Terminal substatuses (auto-cleanable):
+ *   - `discarded-by-operator`           — operator chose abandonment
+ *   - `empty-pool` / `pool-too-small`   — no contacts pushed; nothing to recover
+ *   - `segment-create-failed`           — no contacts pushed; segment doesn't exist
+ *   - `persist-failed`                  — partial pushes possible; operator should
+ *                                          discard explicitly. Auto-cleanup AFTER
+ *                                          24h is a safety net for forgotten cases
+ *   - `batch-failure-rate-exceeded`     — push-rate threshold tripped; operator
+ *                                          should discard. Same 24h safety net rationale
+ *
+ * Recoverable (NEVER auto-cleaned):
+ *   - `create-broadcast-failed`         — `resumeFinalizeWaveRun` retries create
+ *   - `send-broadcast-failed`           — `resumeFinalizeWaveRun({confirmedNotSent})`
+ *                                          retries send, OR `markFinalizeRecovered`
+ *                                          finalizes if Resend shows already-sent
+ */
+const TERMINAL_FAILURE_SUBSTATUSES = [
+  "discarded-by-operator",
+  "empty-pool",
+  "pool-too-small",
+  "segment-create-failed",
+  "persist-failed",
+  "batch-failure-rate-exceeded",
+] as const;
+
 export const _listFailedWaveRunsForCleanup = internalQuery({
   args: {},
   handler: async (ctx) => {
@@ -1629,7 +1723,16 @@ export const _listFailedWaveRunsForCleanup = internalQuery({
       .query("waveRuns")
       .withIndex("by_status", (q) => q.eq("status", "failed"))
       .collect();
-    return failed.filter((r) => r.updatedAt < cutoff).map((r) => r.runId);
+    return failed
+      .filter(
+        (r) =>
+          r.updatedAt < cutoff &&
+          r.failureSubstatus !== undefined &&
+          (TERMINAL_FAILURE_SUBSTATUSES as readonly string[]).includes(
+            r.failureSubstatus,
+          ),
+      )
+      .map((r) => r.runId);
   },
 });
 

--- a/convex/broadcast/waveRuns.ts
+++ b/convex/broadcast/waveRuns.ts
@@ -91,6 +91,18 @@ const RESEND_BACKOFF_MAX_RETRIES = 3;
  *  `assignAndExportWave` for consistency. */
 const REGISTRATIONS_PAGE_SIZE = 1000;
 
+/** Minimum picked count for a wave to be useful. Tied to
+ *  `MIN_DELIVERED_FOR_KILLGATE = 100` (rampRunner.ts) — if fewer than this
+ *  many contacts are picked, the wave's delivered count will never reach
+ *  the threshold needed for the kill-gate stats to be trusted, and the
+ *  next runDailyRamp tick gets stuck on `awaiting-prior-stats` forever.
+ *
+ *  Below this threshold, pickWaveAction treats the run as terminal —
+ *  marks `failed/pool-too-small`, deactivates the ramp, and clears the
+ *  lease. The waitlist is effectively drained; operator must extend the
+ *  curve OR restart the ramp manually if more contacts are wanted. */
+const MIN_USABLE_POOL_SIZE = 100;
+
 // ───────────────────────────────────────────────────────────────────────────
 // Helpers (pure)
 // ───────────────────────────────────────────────────────────────────────────
@@ -389,6 +401,7 @@ export const _markPickFailed = internalMutation({
     runId: v.string(),
     substatus: v.union(
       v.literal("empty-pool"),
+      v.literal("pool-too-small"),
       v.literal("segment-create-failed"),
       v.literal("persist-failed"),
     ),
@@ -408,7 +421,15 @@ export const _markPickFailed = internalMutation({
       updatedAt: now,
     });
 
-    if (substatus === "empty-pool") {
+    // Terminal-completion substatuses: clear the lease AND deactivate the
+    // ramp. Both 'empty-pool' (zero picked) and 'pool-too-small' (picked
+    // below MIN_USABLE_POOL_SIZE) mean the waitlist is drained — without
+    // deactivating, the next cron tick would re-fire pickWaveAction and
+    // hit the same condition repeatedly. For 'pool-too-small' specifically,
+    // the alternative — let the wave proceed with say 50 contacts — would
+    // strand the next cron tick on `awaiting-prior-stats` forever because
+    // delivered count never reaches MIN_DELIVERED_FOR_KILLGATE=100.
+    if (substatus === "empty-pool" || substatus === "pool-too-small") {
       const config = await ctx.db
         .query("broadcastRampConfig")
         .withIndex("by_key", (q) => q.eq("key", "current"))
@@ -418,7 +439,11 @@ export const _markPickFailed = internalMutation({
           pendingRunId: undefined,
           pendingRunStartedAt: undefined,
           pendingWaveLabel: undefined,
-          lastRunStatus: "no-op-empty-pool",
+          active: false,
+          lastRunStatus:
+            substatus === "empty-pool"
+              ? "ramp-complete-empty-pool"
+              : "ramp-complete-pool-too-small",
           lastRunAt: now,
         });
       }
@@ -500,7 +525,7 @@ export const pickWaveAction = internalAction({
 
       const picked = reservoir.values();
 
-      // Empty-pool guard. Clears the lease via _markPickFailed.
+      // Empty-pool guard. Clears the lease + deactivates the ramp.
       if (picked.length === 0) {
         await ctx.runMutation(internal.broadcast.waveRuns._markPickFailed, {
           runId: args.runId,
@@ -508,6 +533,26 @@ export const pickWaveAction = internalAction({
           error: "no unstamped registrations",
         });
         return { ok: false, reason: "empty-pool" };
+      }
+
+      // Pool-too-small guard. picked.length < MIN_USABLE_POOL_SIZE means
+      // the wave's delivered count will never reach the kill-gate threshold,
+      // so the next cron tick would get stuck on `awaiting-prior-stats`
+      // forever. Treat as terminal completion: deactivate the ramp + clear
+      // the lease, surface for operator triage. Operator can re-activate
+      // and extend `rampCurve` if more sends are wanted, OR run a final
+      // wave manually via direct `pickWaveAction` call (which bypasses this
+      // guard since the operator is taking deliberate action).
+      if (picked.length < MIN_USABLE_POOL_SIZE) {
+        await ctx.runMutation(internal.broadcast.waveRuns._markPickFailed, {
+          runId: args.runId,
+          substatus: "pool-too-small",
+          error:
+            `picked ${picked.length} contacts (< MIN_USABLE_POOL_SIZE=${MIN_USABLE_POOL_SIZE}); ` +
+            `ramp deactivated to avoid stranding the next cron tick on awaiting-prior-stats. ` +
+            `Operator: extend rampCurve + resumeRamp if more sends desired, or run a final wave manually.`,
+        });
+        return { ok: false, reason: "pool-too-small" };
       }
 
       // Step 3: create the Resend segment.
@@ -900,6 +945,20 @@ export const pushBatchAction = internalAction({
 // Finalize phase
 // ───────────────────────────────────────────────────────────────────────────
 
+/**
+ * Lease + status CAS guard. Refuses unless:
+ *   - waveRuns.status === 'pushing' (or already 'broadcast-created' for
+ *     idempotency on retry — a duplicate finalizeWaveAction sees the same
+ *     broadcastId and is a no-op)
+ *   - broadcastRampConfig.pendingRunId === runId (still hold the lease)
+ *
+ * Without these guards, two concurrent finalizeWaveAction invocations
+ * (e.g. operator-triggered resumeFinalizeWaveRun while the original is
+ * mid-flight on a slow Resend response) could both call
+ * createProLaunchBroadcast, both call _markBroadcastCreated, and overwrite
+ * each other's broadcastId — leading to one of the two created Resend
+ * broadcasts being orphaned + duplicate sends downstream.
+ */
 export const _markBroadcastCreated = internalMutation({
   args: {
     runId: v.string(),
@@ -911,6 +970,33 @@ export const _markBroadcastCreated = internalMutation({
       .withIndex("by_runId", (q) => q.eq("runId", runId))
       .unique();
     if (!run) throw new Error(`[_markBroadcastCreated] no run ${runId}`);
+
+    // Idempotent: if already broadcast-created with the SAME broadcastId,
+    // treat as no-op success. Different broadcastId = a duplicate Resend
+    // broadcast was created — surface as failure so the caller can decide
+    // (typically: log, don't proceed to send the new duplicate).
+    if (run.status === "broadcast-created") {
+      if (run.broadcastId === broadcastId) {
+        return { ok: true as const, alreadyMarked: true as const };
+      }
+      return {
+        ok: false as const,
+        reason: "duplicate-broadcast-detected" as const,
+        existing: run.broadcastId,
+      };
+    }
+    if (run.status !== "pushing") {
+      return { ok: false as const, reason: `wrong-status-${run.status}` as const };
+    }
+
+    const config = await ctx.db
+      .query("broadcastRampConfig")
+      .withIndex("by_key", (q) => q.eq("key", "current"))
+      .unique();
+    if (!config || config.pendingRunId !== runId) {
+      return { ok: false as const, reason: "lost-lease" as const };
+    }
+
     const now = Date.now();
     await ctx.db.patch(run._id, {
       status: "broadcast-created",
@@ -918,7 +1004,7 @@ export const _markBroadcastCreated = internalMutation({
       lastBatchAt: now, // re-arm in-flight guard for the send phase
       updatedAt: now,
     });
-    return { ok: true as const };
+    return { ok: true as const, alreadyMarked: false as const };
   },
 });
 
@@ -962,6 +1048,15 @@ export const _markFinalizeFailed = internalMutation({
  * `lastWave*` fields, clears the lease, AND marks `waveRuns.status='sent'`
  * — all in one transaction. The only path that reconciles the run with
  * the long-term ramp state.
+ *
+ * Lease + status CAS:
+ *   - waveRuns.status MUST be 'broadcast-created' (or 'sent' for idempotency
+ *     on a duplicate finalize — returns no-op success without re-advancing
+ *     the tier)
+ *   - broadcastRampConfig.pendingRunId MUST === runId
+ *
+ * Without these, two concurrent finalizes could both advance currentTier
+ * (skipping a wave's worth of progress) AND both clear the lease.
  */
 export const _finalizeWaveRun = internalMutation({
   args: {
@@ -974,6 +1069,20 @@ export const _finalizeWaveRun = internalMutation({
       .withIndex("by_runId", (q) => q.eq("runId", runId))
       .unique();
     if (!run) throw new Error(`[_finalizeWaveRun] no run ${runId}`);
+
+    // Status check FIRST — broadcastId presence is downstream of being in
+    // broadcast-created status. Checking presence before status would mask
+    // a wrong-status caller behind a misleading "missing broadcastId" error.
+    if (run.status === "sent") {
+      // Idempotent: a duplicate finalize on an already-sent run is a no-op,
+      // not an error. Don't re-advance the tier.
+      return { ok: true as const, alreadySent: true as const, advancedToTier: undefined };
+    }
+    if (run.status !== "broadcast-created") {
+      throw new Error(
+        `[_finalizeWaveRun] run ${runId} is ${run.status}, expected broadcast-created`,
+      );
+    }
     if (!run.broadcastId || !run.segmentId) {
       throw new Error(
         `[_finalizeWaveRun] run ${runId} missing broadcastId/segmentId`,
@@ -985,6 +1094,12 @@ export const _finalizeWaveRun = internalMutation({
       .withIndex("by_key", (q) => q.eq("key", "current"))
       .unique();
     if (!config) throw new Error("[_finalizeWaveRun] no broadcastRampConfig");
+    if (config.pendingRunId !== runId) {
+      throw new Error(
+        `[_finalizeWaveRun] lost lease: expected ${runId}, found ${config.pendingRunId ?? "<cleared>"}. ` +
+        `Refusing to advance tier — operator force-released the lease, or another run took over.`,
+      );
+    }
 
     const now = Date.now();
     const nextTier = config.currentTier + 1;
@@ -1056,10 +1171,23 @@ export const finalizeWaveAction = internalAction({
         );
         throw err;
       }
-      await ctx.runMutation(
+      // CAS-check the broadcast-created transition. A concurrent finalize
+      // (e.g. operator-triggered resume mid-flight) could have already
+      // created its own broadcast and patched the run. If we lost the race,
+      // we just created an orphan broadcast in Resend — log loudly so the
+      // operator knows to clean it up, then exit without sending.
+      const markResult = await ctx.runMutation(
         internal.broadcast.waveRuns._markBroadcastCreated,
         { runId, broadcastId: createResult.broadcastId },
       );
+      if (!markResult.ok) {
+        console.error(
+          `[finalizeWaveAction] CAS lost on _markBroadcastCreated runId=${runId} reason=${markResult.reason} ` +
+          `our-broadcastId=${createResult.broadcastId}. The Resend broadcast we created is orphaned — ` +
+          `operator should delete it via Resend dashboard if not the same as the winning runner's broadcastId.`,
+        );
+        return { ok: false, reason: `markBroadcastCreated-${markResult.reason}` };
+      }
     } else if (info.run.status !== "broadcast-created") {
       return { ok: false, reason: `wrong-status-${info.run.status}` };
     }
@@ -1071,6 +1199,22 @@ export const finalizeWaveAction = internalAction({
     );
     if (!after?.run.broadcastId) {
       throw new Error(`[finalizeWaveAction] runId=${runId} missing broadcastId post-create`);
+    }
+    // Final lease+status revalidation before send — narrows the duplicate-
+    // send window. (Doesn't eliminate it: send IS external I/O; two actions
+    // racing past this point still both call sendProLaunchBroadcast. Resend's
+    // /broadcasts/:id/send rejects already-sent broadcasts with 422, which
+    // is our last line of defence — if both actions raced past here, the
+    // loser sees a Resend 422 and goes to send-broadcast-failed; the
+    // _finalizeWaveRun's idempotency on already-sent then handles cleanup.)
+    if (after.run.status === "sent") {
+      // Another finalize already won. Idempotent no-op.
+      console.log(`[finalizeWaveAction] runId=${runId} already sent by another invocation — exiting clean`);
+      return { ok: true, reason: "already-sent" };
+    }
+    if (!after.configHoldsLease) {
+      console.warn(`[finalizeWaveAction] runId=${runId} lost lease before send — exiting`);
+      return { ok: false, reason: "lost-lease-pre-send" };
     }
     try {
       await ctx.runAction(
@@ -1089,11 +1233,16 @@ export const finalizeWaveAction = internalAction({
       throw err;
     }
 
-    // Success — atomic finalize.
-    await ctx.runMutation(internal.broadcast.waveRuns._finalizeWaveRun, {
+    // Success — atomic finalize. _finalizeWaveRun's CAS returns
+    // {alreadySent: true} as a no-op if a concurrent finalize already
+    // committed; that's fine.
+    const fin = await ctx.runMutation(internal.broadcast.waveRuns._finalizeWaveRun, {
       runId,
       sentAt: Date.now(),
     });
+    if ("alreadySent" in fin && fin.alreadySent) {
+      return { ok: true, reason: "already-sent" };
+    }
     return { ok: true };
   },
 });
@@ -1210,6 +1359,15 @@ export const discardWaveRun = internalMutation({
       pendingBroadcastId: undefined,
       pendingBroadcastAt: undefined,
     });
+    // Schedule cleanup IMMEDIATELY (not via the daily cron) so any contacts
+    // that were `status='pushed'` during the discarded run are unstamped
+    // before the next runDailyRamp tick — otherwise they'd be excluded
+    // from future picks despite never having received the email.
+    await ctx.scheduler.runAfter(
+      0,
+      internal.broadcast.waveRuns.cleanupDiscardedWavePickedContactsAction,
+      { runId },
+    );
     return {
       ok: true as const,
       newWaveLabelOffset: config.waveLabelOffset + 1,
@@ -1338,30 +1496,85 @@ export const resumeFinalizeWaveRun = internalMutation({
 // Cleanup
 // ───────────────────────────────────────────────────────────────────────────
 
+/**
+ * Cleanup mutation. Two responsibilities, in order:
+ *
+ *   1. UNSTAMP — for each `wavePickedContacts` row with `status='pushed'`,
+ *      look up the matching `registrations` row and clear `proLaunchWave`
+ *      iff it still equals THIS run's `waveLabel` (defensive — don't
+ *      clobber a contact's stamp from a later wave). Without this, a
+ *      contact pushed during a discarded run is permanently excluded from
+ *      future picks despite never having received the email.
+ *   2. DELETE — remove the `wavePickedContacts` row.
+ *
+ * Chunked at 500 rows. Caller (the cleanup action) loops until `hasMore`
+ * is false. Idempotent: if called twice, the second call sees no rows
+ * and returns `{deleted: 0, hasMore: false}`.
+ */
 export const _cleanupDiscardedWavePickedContacts = internalMutation({
   args: { runId: v.string() },
   handler: async (ctx, { runId }) => {
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    const waveLabel = run?.waveLabel;
+
     const rows = await ctx.db
       .query("wavePickedContacts")
       .withIndex("by_runId", (q) => q.eq("runId", runId))
       .take(CLEANUP_CHUNK_SIZE);
+    let unstamped = 0;
     for (const row of rows) {
+      if (row.status === "pushed" && waveLabel) {
+        const reg = await ctx.db
+          .query("registrations")
+          .withIndex("by_normalized_email", (q) =>
+            q.eq("normalizedEmail", row.normalizedEmail),
+          )
+          .first();
+        // Only clear if the stamp still matches THIS run's wave — a contact
+        // re-picked into a later wave would have proLaunchWave set to that
+        // newer wave's label; leave it alone.
+        if (reg && reg.proLaunchWave === waveLabel) {
+          await ctx.db.patch(reg._id, {
+            proLaunchWave: undefined,
+            proLaunchWaveAssignedAt: undefined,
+          });
+          unstamped++;
+        }
+      }
       await ctx.db.delete(row._id);
     }
-    return { deleted: rows.length, hasMore: rows.length === CLEANUP_CHUNK_SIZE };
+    return {
+      deleted: rows.length,
+      unstamped,
+      hasMore: rows.length === CLEANUP_CHUNK_SIZE,
+    };
   },
 });
 
 /**
- * Cron-scheduled action that finds discarded/failed `waveRuns` rows older
- * than 24h and chunked-deletes their `wavePickedContacts`. Self-schedules
- * the next chunk if any rows remain.
+ * Cleanup orchestrator. Two invocation modes:
+ *   - With `runId` arg: targeted cleanup, scheduled IMMEDIATELY by
+ *     `discardWaveRun` so unstamping happens before the next runDailyRamp
+ *     tick (otherwise `status='pushed'` contacts stay stamped until the
+ *     daily cron runs).
+ *   - Without `runId`: daily-cron scan of all `failed` waveRuns rows >24h
+ *     old (cleans up runs the operator didn't explicitly discard).
+ *
+ * Both modes self-schedule the next 500-row chunk until each run is fully
+ * drained, then move to the next candidate.
  */
 export const cleanupDiscardedWavePickedContactsAction = internalAction({
   args: {
     runId: v.optional(v.string()),
   },
-  handler: async (ctx, args): Promise<{ deleted: number; hasMore: boolean }> => {
+  handler: async (ctx, args): Promise<{
+    deleted: number;
+    unstamped: number;
+    hasMore: boolean;
+  }> => {
     if (args.runId) {
       const result = await ctx.runMutation(
         internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts,
@@ -1373,6 +1586,11 @@ export const cleanupDiscardedWavePickedContactsAction = internalAction({
           internal.broadcast.waveRuns.cleanupDiscardedWavePickedContactsAction,
           { runId: args.runId },
         );
+      } else if (result.unstamped > 0) {
+        console.log(
+          `[cleanupDiscardedWavePickedContactsAction] runId=${args.runId} ` +
+          `unstamped ${result.unstamped} registrations (re-eligible for future picks)`,
+        );
       }
       return result;
     }
@@ -1383,12 +1601,14 @@ export const cleanupDiscardedWavePickedContactsAction = internalAction({
       {},
     );
     let totalDeleted = 0;
+    let totalUnstamped = 0;
     for (const runId of candidates) {
       const result = await ctx.runMutation(
         internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts,
         { runId },
       );
       totalDeleted += result.deleted;
+      totalUnstamped += result.unstamped;
       if (result.hasMore) {
         await ctx.scheduler.runAfter(
           0,
@@ -1397,7 +1617,7 @@ export const cleanupDiscardedWavePickedContactsAction = internalAction({
         );
       }
     }
-    return { deleted: totalDeleted, hasMore: false };
+    return { deleted: totalDeleted, unstamped: totalUnstamped, hasMore: false };
   },
 });
 

--- a/convex/broadcast/waveRuns.ts
+++ b/convex/broadcast/waveRuns.ts
@@ -1,0 +1,1485 @@
+/**
+ * Wave-loading state machine — replaces the monolithic `assignAndExportWave`
+ * action (which hits the Convex 10-min runtime budget at ~1500 contacts) with
+ * a multi-step pipeline that fits within budget at any wave size.
+ *
+ * Pipeline:
+ *   pickWaveAction → _claimWaveRunLease → reservoir-sample → createSegment
+ *                  → _persistPickedBatch (×N, 500 rows each)
+ *                  → _markPickComplete → schedule pushBatchAction
+ *
+ *   pushBatchAction → _resumeBatchInfo (lease guard) → _getPendingBatch
+ *                   → upsertContactToSegment (Resend, with 429/5xx backoff)
+ *                   → _markContactPushed | _markContactFailed (per-row CAS)
+ *                   → schedule next pushBatchAction OR finalizeWaveAction
+ *
+ *   finalizeWaveAction → createProLaunchBroadcast → _markBroadcastCreated
+ *                      → sendProLaunchBroadcast → _finalizeWaveRun
+ *                      (atomically advances broadcastRampConfig.lastWave*,
+ *                       clears lease, marks waveRuns.status='sent')
+ *
+ * Function-shape rules (Convex-correct, enforced by review):
+ *   - internalAction = external I/O (Resend, fetch); calls runQuery/runMutation
+ *   - internalMutation = DB writes only; CANNOT call runMutation (Convex
+ *     forbids mutation-to-mutation chaining); registration stamping is
+ *     INLINED into `_markContactPushed`
+ *   - internalQuery = read-only DB
+ *
+ * Lease semantics:
+ *   - `_claimWaveRunLease` sets `broadcastRampConfig.pendingRunId = runId`
+ *     AND inserts the `waveRuns` row in the same mutation. Refuses if a
+ *     lease is held OR if any active `waveRuns` row exists.
+ *   - Every scheduled action re-validates lease at entry. If
+ *     `pendingRunId !== row.runId` it exits without side effects (operator
+ *     force-released, or run was discarded).
+ *   - Lease is cleared on `_finalizeWaveRun` success or `discardWaveRun`.
+ *
+ * Recovery routing (operator):
+ *   - status='pushing' / 'segment-created' (stale): `resumeStalledWaveRun`
+ *   - status='broadcast-created' OR failureSubstatus='send-broadcast-failed':
+ *       `resumeFinalizeWaveRun({confirmedNotSent: true})` after Resend-
+ *       dashboard verification, OR `markFinalizeRecovered` if Resend shows
+ *       already sent
+ *   - failureSubstatus='create-broadcast-failed': `resumeFinalizeWaveRun`
+ *       (no confirmedNotSent — no broadcast exists yet)
+ *   - failureSubstatus='batch-failure-rate-exceeded' / 'segment-create-failed' /
+ *       'persist-failed': `discardWaveRun` (transient retry won't help)
+ *   - failureSubstatus='empty-pool': terminal no-op; lease auto-cleared
+ *
+ * See `plans/2026-04-29-post-launch-stabilization.md` for the full
+ * architecture decisions, codex-approved through round 6.
+ */
+
+import { v } from "convex/values";
+import {
+  internalAction,
+  internalMutation,
+  internalQuery,
+} from "../_generated/server";
+import { internal } from "../_generated/api";
+import {
+  createSegment,
+  upsertContactToSegment,
+} from "./_resendContacts";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Constants
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Default per-batch push size. Sized so 250 Resend round-trips at ~400ms each
+ *  fit well below the 10-min Convex action runtime budget. */
+const DEFAULT_BATCH_SIZE = 250;
+
+/** Max rows persisted per `_persistPickedBatch` call. Convex per-mutation write
+ *  limits sit around 8k docs; 500 leaves comfortable headroom for the row
+ *  insert + the lease-coordination patches. */
+const PERSIST_CHUNK_SIZE = 500;
+
+/** Max rows deleted per `_cleanupDiscardedWavePickedContacts` call. */
+const CLEANUP_CHUNK_SIZE = 500;
+
+/** Rolling failure-rate ceiling. If a `pushBatchAction` brings
+ *  `failedCount/totalCount` above this fraction, the whole run flips to
+ *  `failed/batch-failure-rate-exceeded` — operator must `discardWaveRun`. */
+const FAILURE_RATE_THRESHOLD = 0.05;
+
+/** Resend backoff schedule (ms) for 429/5xx. Last entry is jitter base. */
+const RESEND_BACKOFF_MS = [250, 500, 1000];
+const RESEND_BACKOFF_MAX_RETRIES = 3;
+
+/** Pagination size for `_getRegistrationsPage`. Same value as the legacy
+ *  `assignAndExportWave` for consistency. */
+const REGISTRATIONS_PAGE_SIZE = 1000;
+
+// ───────────────────────────────────────────────────────────────────────────
+// Helpers (pure)
+// ───────────────────────────────────────────────────────────────────────────
+
+function maskEmail(email: string): string {
+  const at = email.indexOf("@");
+  if (at <= 0) return "***";
+  const local = email.slice(0, at);
+  const domain = email.slice(at);
+  const visible = local.slice(0, Math.min(2, local.length));
+  return `${visible}${"*".repeat(Math.max(1, local.length - visible.length))}${domain}`;
+}
+
+class Reservoir<T> {
+  private readonly size: number;
+  private readonly buf: T[] = [];
+  private seen = 0;
+  constructor(size: number) { this.size = size; }
+  offer(item: T): void {
+    this.seen++;
+    if (this.buf.length < this.size) {
+      this.buf.push(item);
+    } else {
+      const j = Math.floor(Math.random() * this.seen);
+      if (j < this.size) this.buf[j] = item;
+    }
+  }
+  values(): T[] { return this.buf; }
+  totalSeen(): number { return this.seen; }
+}
+
+/**
+ * Wraps an upstream Resend call with exponential backoff on 429/5xx-like
+ * outcomes. The push helper returns `{kind:'failed', reason}` rather than
+ * throwing, so we re-classify the reason string.
+ */
+async function pushWithBackoff(
+  apiKey: string,
+  email: string,
+  segmentId: string,
+): Promise<Awaited<ReturnType<typeof upsertContactToSegment>>> {
+  let lastResult: Awaited<ReturnType<typeof upsertContactToSegment>> | undefined;
+  for (let attempt = 0; attempt < RESEND_BACKOFF_MAX_RETRIES; attempt++) {
+    const result = await upsertContactToSegment(apiKey, email, segmentId);
+    if (result.kind !== "failed") return result;
+    lastResult = result;
+    // Re-classify: only retry transient (429, 5xx). 4xx other than 429
+    // (e.g. 400/403/404) is permanent — abort early.
+    const transient = /\b(429|5\d\d)\b/.test(result.reason);
+    if (!transient || attempt === RESEND_BACKOFF_MAX_RETRIES - 1) {
+      return result;
+    }
+    // The fallback chain ends at the last entry of RESEND_BACKOFF_MS, which
+    // is statically non-empty — but `noUncheckedIndexedAccess` doesn't know
+    // that. Coerce to number (last entry guaranteed defined; default 1000ms
+    // if the array were ever emptied — fail-safe).
+    const base =
+      RESEND_BACKOFF_MS[attempt] ??
+      RESEND_BACKOFF_MS[RESEND_BACKOFF_MS.length - 1] ??
+      1000;
+    // ±20% jitter
+    const jitter = base * 0.2 * (Math.random() * 2 - 1);
+    const sleepMs = Math.max(0, base + jitter);
+    await new Promise((resolve) => setTimeout(resolve, sleepMs));
+  }
+  return lastResult ?? { kind: "failed", reason: "[pushWithBackoff] exhausted with no result" };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Types
+// ───────────────────────────────────────────────────────────────────────────
+
+export type WaveRunStatus =
+  | "picking"
+  | "segment-created"
+  | "pushing"
+  | "broadcast-created"
+  | "sent"
+  | "failed";
+
+export type WaveFailureSubstatus =
+  | "empty-pool"
+  | "segment-create-failed"
+  | "persist-failed"
+  | "batch-failure-rate-exceeded"
+  | "create-broadcast-failed"
+  | "send-broadcast-failed"
+  | "discarded-by-operator";
+
+export type ClaimLeaseResult =
+  | { ok: true; runId: string }
+  | { ok: false; reason: "lease-held" | "no-config" | "label-collides"; current?: string };
+
+// ───────────────────────────────────────────────────────────────────────────
+// Pre-flight queries (re-used from audienceWaveExport via direct query —
+// kept here as proxies so this module's runQuery calls don't reach across
+// sibling modules unnecessarily)
+// ───────────────────────────────────────────────────────────────────────────
+
+export const _hasWaveLabel = internalQuery({
+  args: { waveLabel: v.string() },
+  handler: async (ctx, { waveLabel }) => {
+    const existing = await ctx.db
+      .query("registrations")
+      .withIndex("by_proLaunchWave", (q) => q.eq("proLaunchWave", waveLabel))
+      .first();
+    return existing !== null;
+  },
+});
+
+export const _getSuppressedEmails = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const all = await ctx.db.query("emailSuppressions").collect();
+    return all
+      .map((row) => row.normalizedEmail)
+      .filter((e): e is string => typeof e === "string" && e.length > 0);
+  },
+});
+
+export const _getPaidEmails = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const all = await ctx.db.query("customers").collect();
+    return all
+      .map((row) => {
+        const stored = row.normalizedEmail;
+        if (stored && stored.length > 0) return stored;
+        return (row.email ?? "").trim().toLowerCase();
+      })
+      .filter((e): e is string => typeof e === "string" && e.length > 0);
+  },
+});
+
+export const _getRegistrationsPage = internalQuery({
+  args: {
+    cursor: v.union(v.string(), v.null()),
+    numItems: v.number(),
+  },
+  handler: async (ctx, { cursor, numItems }) => {
+    return await ctx.db
+      .query("registrations")
+      .paginate({ cursor, numItems });
+  },
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Pick phase
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Acquire the wave-run lease atomically. Refuses if:
+ *   - no `broadcastRampConfig` row (config was aborted)
+ *   - `pendingRunId` is already set on the config (another run holds the lease)
+ *   - any active `waveRuns` row exists with status in
+ *     {picking, segment-created, pushing, broadcast-created} — defensive belt
+ *     in case the ramp lease was force-cleared but a `waveRuns` row survives
+ *
+ * On success: sets `pendingRunId` on the config + inserts the `waveRuns` row
+ * in `picking` status. Both writes are in this single mutation so there's
+ * no window where one is set without the other.
+ */
+export const _claimWaveRunLease = internalMutation({
+  args: {
+    waveLabel: v.string(),
+    runId: v.string(),
+    requestedCount: v.number(),
+    batchSize: v.number(),
+  },
+  handler: async (ctx, args): Promise<ClaimLeaseResult> => {
+    const config = await ctx.db
+      .query("broadcastRampConfig")
+      .withIndex("by_key", (q) => q.eq("key", "current"))
+      .unique();
+    if (!config) return { ok: false, reason: "no-config" };
+    if (config.pendingRunId) {
+      return { ok: false, reason: "lease-held", current: config.pendingRunId };
+    }
+    // Defensive: even if the ramp lease was force-cleared, refuse if any
+    // active waveRuns row exists (would otherwise allow a parallel run that
+    // collides on the segment + registration stamps). Iterate over each
+    // active status so we use the by_status index instead of a full scan.
+    for (const status of ACTIVE_STATUSES) {
+      const existing = await ctx.db
+        .query("waveRuns")
+        .withIndex("by_status", (q) => q.eq("status", status))
+        .first();
+      if (existing) {
+        return { ok: false, reason: "lease-held", current: existing.runId };
+      }
+    }
+    const collides = await ctx.db
+      .query("registrations")
+      .withIndex("by_proLaunchWave", (q) => q.eq("proLaunchWave", args.waveLabel))
+      .first();
+    if (collides) return { ok: false, reason: "label-collides" };
+
+    const now = Date.now();
+    await ctx.db.patch(config._id, {
+      pendingRunId: args.runId,
+      pendingRunStartedAt: now,
+      pendingWaveLabel: args.waveLabel,
+    });
+    await ctx.db.insert("waveRuns", {
+      runId: args.runId,
+      waveLabel: args.waveLabel,
+      status: "picking",
+      requestedCount: args.requestedCount,
+      totalCount: 0,
+      underfilled: false,
+      pushedCount: 0,
+      failedCount: 0,
+      batchSize: args.batchSize,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return { ok: true, runId: args.runId };
+  },
+});
+
+/**
+ * Insert a chunk of picked-contact rows. Called repeatedly from
+ * `pickWaveAction` to stay under Convex per-mutation write limits.
+ */
+export const _persistPickedBatch = internalMutation({
+  args: {
+    runId: v.string(),
+    contacts: v.array(v.string()), // normalizedEmails
+  },
+  handler: async (ctx, { runId, contacts }) => {
+    if (contacts.length > PERSIST_CHUNK_SIZE) {
+      throw new Error(
+        `[_persistPickedBatch] chunk too large: ${contacts.length} > ${PERSIST_CHUNK_SIZE}`,
+      );
+    }
+    const now = Date.now();
+    for (const email of contacts) {
+      await ctx.db.insert("wavePickedContacts", {
+        runId,
+        normalizedEmail: email,
+        status: "pending",
+      });
+    }
+    // Bump updatedAt so the in-flight guard's lastActivityAt fallback sees fresh activity.
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (run) await ctx.db.patch(run._id, { updatedAt: now });
+    return { inserted: contacts.length };
+  },
+});
+
+/**
+ * Transition a `picking`-status run to `segment-created` after pickWaveAction
+ * has finished sampling, persisting, and creating the Resend segment.
+ */
+export const _markPickComplete = internalMutation({
+  args: {
+    runId: v.string(),
+    segmentId: v.string(),
+    totalCount: v.number(),
+    underfilled: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", args.runId))
+      .unique();
+    if (!run) throw new Error(`[_markPickComplete] no run ${args.runId}`);
+    if (run.status !== "picking") {
+      throw new Error(
+        `[_markPickComplete] run ${args.runId} is ${run.status}, expected picking`,
+      );
+    }
+    const now = Date.now();
+    await ctx.db.patch(run._id, {
+      status: "segment-created",
+      segmentId: args.segmentId,
+      totalCount: args.totalCount,
+      underfilled: args.underfilled,
+      updatedAt: now,
+    });
+    return { ok: true };
+  },
+});
+
+/**
+ * Record a pick-phase failure. Lease policy depends on substatus:
+ *   - 'empty-pool' clears the lease (terminal no-op; operator may retry next cycle)
+ *   - 'segment-create-failed' / 'persist-failed' KEEP the lease (operator must
+ *     `discardWaveRun` to clear, after inspecting Resend dashboard)
+ */
+export const _markPickFailed = internalMutation({
+  args: {
+    runId: v.string(),
+    substatus: v.union(
+      v.literal("empty-pool"),
+      v.literal("segment-create-failed"),
+      v.literal("persist-failed"),
+    ),
+    error: v.string(),
+  },
+  handler: async (ctx, { runId, substatus, error }) => {
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (!run) return { ok: false as const, reason: "no-run" as const };
+    const now = Date.now();
+    await ctx.db.patch(run._id, {
+      status: "failed",
+      failureSubstatus: substatus,
+      error: error.slice(0, 500),
+      updatedAt: now,
+    });
+
+    if (substatus === "empty-pool") {
+      const config = await ctx.db
+        .query("broadcastRampConfig")
+        .withIndex("by_key", (q) => q.eq("key", "current"))
+        .unique();
+      if (config && config.pendingRunId === runId) {
+        await ctx.db.patch(config._id, {
+          pendingRunId: undefined,
+          pendingRunStartedAt: undefined,
+          pendingWaveLabel: undefined,
+          lastRunStatus: "no-op-empty-pool",
+          lastRunAt: now,
+        });
+      }
+    }
+    return { ok: true as const };
+  },
+});
+
+export const pickWaveAction = internalAction({
+  args: {
+    waveLabel: v.string(),
+    runId: v.string(),
+    requestedCount: v.number(),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<{ ok: boolean; reason?: string }> => {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) {
+      throw new Error("[pickWaveAction] RESEND_API_KEY not set");
+    }
+    if (!Number.isFinite(args.requestedCount) || args.requestedCount <= 0) {
+      throw new Error(
+        `[pickWaveAction] requestedCount must be a positive integer; got ${args.requestedCount}`,
+      );
+    }
+    if (args.waveLabel.length === 0 || args.waveLabel.length > 64) {
+      throw new Error("[pickWaveAction] waveLabel must be 1-64 chars");
+    }
+    const batchSize = args.batchSize ?? DEFAULT_BATCH_SIZE;
+
+    // Step 1: claim lease + insert waveRuns row.
+    const claim: ClaimLeaseResult = await ctx.runMutation(
+      internal.broadcast.waveRuns._claimWaveRunLease,
+      {
+        waveLabel: args.waveLabel,
+        runId: args.runId,
+        requestedCount: args.requestedCount,
+        batchSize,
+      },
+    );
+    if (!claim.ok) {
+      throw new Error(
+        `[pickWaveAction] could not claim lease: ${claim.reason}` +
+        (claim.current ? ` (current: ${claim.current})` : ""),
+      );
+    }
+
+    try {
+      // Step 2: stream registrations + reservoir-sample.
+      const [suppressed, paid] = await Promise.all([
+        ctx.runQuery(internal.broadcast.waveRuns._getSuppressedEmails, {}),
+        ctx.runQuery(internal.broadcast.waveRuns._getPaidEmails, {}),
+      ]);
+      const suppressedSet = new Set(suppressed);
+      const paidSet = new Set(paid);
+
+      const reservoir = new Reservoir<string>(args.requestedCount);
+      let cursor: string | null = null;
+      while (true) {
+        const page: {
+          page: Array<{ normalizedEmail: string; proLaunchWave?: string }>;
+          isDone: boolean;
+          continueCursor: string;
+        } = await ctx.runQuery(
+          internal.broadcast.waveRuns._getRegistrationsPage,
+          { cursor, numItems: REGISTRATIONS_PAGE_SIZE },
+        );
+        for (const row of page.page) {
+          const email = row.normalizedEmail;
+          if (!email || email.length === 0) continue;
+          if (suppressedSet.has(email)) continue;
+          if (paidSet.has(email)) continue;
+          if (row.proLaunchWave) continue;
+          reservoir.offer(email);
+        }
+        if (page.isDone) break;
+        cursor = page.continueCursor;
+      }
+
+      const picked = reservoir.values();
+
+      // Empty-pool guard. Clears the lease via _markPickFailed.
+      if (picked.length === 0) {
+        await ctx.runMutation(internal.broadcast.waveRuns._markPickFailed, {
+          runId: args.runId,
+          substatus: "empty-pool",
+          error: "no unstamped registrations",
+        });
+        return { ok: false, reason: "empty-pool" };
+      }
+
+      // Step 3: create the Resend segment.
+      const segmentName = `pro-launch-${args.waveLabel}`;
+      let segmentId: string;
+      try {
+        segmentId = await createSegment(apiKey, segmentName);
+      } catch (err) {
+        await ctx.runMutation(internal.broadcast.waveRuns._markPickFailed, {
+          runId: args.runId,
+          substatus: "segment-create-failed",
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      }
+
+      // Step 4: chunk-persist picked rows. Each chunk is its own mutation so
+      // we stay under Convex per-mutation write limits at any wave size.
+      try {
+        for (let i = 0; i < picked.length; i += PERSIST_CHUNK_SIZE) {
+          const chunk = picked.slice(i, i + PERSIST_CHUNK_SIZE);
+          await ctx.runMutation(internal.broadcast.waveRuns._persistPickedBatch, {
+            runId: args.runId,
+            contacts: chunk,
+          });
+        }
+      } catch (err) {
+        await ctx.runMutation(internal.broadcast.waveRuns._markPickFailed, {
+          runId: args.runId,
+          substatus: "persist-failed",
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      }
+
+      // Step 5: mark pick complete + schedule first push batch.
+      await ctx.runMutation(internal.broadcast.waveRuns._markPickComplete, {
+        runId: args.runId,
+        segmentId,
+        totalCount: picked.length,
+        underfilled: picked.length < args.requestedCount,
+      });
+      await ctx.scheduler.runAfter(
+        0,
+        internal.broadcast.waveRuns.pushBatchAction,
+        { runId: args.runId, batchN: 0 },
+      );
+
+      console.log(
+        `[pickWaveAction] complete: runId=${args.runId} waveLabel=${args.waveLabel} ` +
+        `picked=${picked.length} requested=${args.requestedCount} underfilled=${picked.length < args.requestedCount}`,
+      );
+      return { ok: true };
+    } catch (err) {
+      // If we got here without _markPickFailed having run, surface the error
+      // — but DON'T clear the lease (keeps the run in failed state for
+      // operator inspection).
+      console.error(
+        `[pickWaveAction] runId=${args.runId} unexpected error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      throw err;
+    }
+  },
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Push phase
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Lightweight read for a `pushBatchAction` to validate state on entry +
+ * decide whether to schedule the next batch or finalize.
+ */
+export const _resumeBatchInfo = internalQuery({
+  args: { runId: v.string() },
+  handler: async (ctx, { runId }) => {
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (!run) return null;
+    const config = await ctx.db
+      .query("broadcastRampConfig")
+      .withIndex("by_key", (q) => q.eq("key", "current"))
+      .unique();
+    const pending = await ctx.db
+      .query("wavePickedContacts")
+      .withIndex("by_runId_status", (q) => q.eq("runId", runId).eq("status", "pending"))
+      .take(1);
+    return {
+      run: {
+        runId: run.runId,
+        waveLabel: run.waveLabel,
+        status: run.status,
+        segmentId: run.segmentId,
+        totalCount: run.totalCount,
+        pushedCount: run.pushedCount,
+        failedCount: run.failedCount,
+        batchSize: run.batchSize,
+        broadcastId: run.broadcastId,
+      },
+      configHoldsLease: config?.pendingRunId === runId,
+      hasPending: pending.length > 0,
+    };
+  },
+});
+
+/**
+ * Return up to `limit` `pending`-status contacts for a run. Sorted by
+ * `_creationTime` (default Convex order) so the same prefix is returned to
+ * a resume call as to the original action — gives idempotent batching.
+ */
+export const _getPendingBatch = internalQuery({
+  args: {
+    runId: v.string(),
+    limit: v.number(),
+  },
+  handler: async (ctx, { runId, limit }) => {
+    return await ctx.db
+      .query("wavePickedContacts")
+      .withIndex("by_runId_status", (q) =>
+        q.eq("runId", runId).eq("status", "pending"),
+      )
+      .take(limit);
+  },
+});
+
+export const _markPushingStarted = internalMutation({
+  args: { runId: v.string() },
+  handler: async (ctx, { runId }) => {
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (!run) return { ok: false as const, reason: "no-run" as const };
+    if (run.status === "pushing") return { ok: true as const, alreadyPushing: true as const };
+    if (run.status !== "segment-created") {
+      return { ok: false as const, reason: `wrong-status-${run.status}` as const };
+    }
+    const now = Date.now();
+    await ctx.db.patch(run._id, { status: "pushing", lastBatchAt: now, updatedAt: now });
+    return { ok: true as const, alreadyPushing: false as const };
+  },
+});
+
+/**
+ * Mark a per-contact row as pushed. CAS guard: no-op unless current
+ * status is 'pending'. Atomic with: pushedCount++, lastBatchAt update,
+ * AND inline-stamp the matching `registrations` row (mutations cannot
+ * call other mutations via runMutation, so the stamp logic from
+ * `_stampWaveByNormalizedEmail` is duplicated here).
+ */
+export const _markContactPushed = internalMutation({
+  args: {
+    runId: v.string(),
+    normalizedEmail: v.string(),
+    waveLabel: v.string(),
+  },
+  handler: async (ctx, { runId, normalizedEmail, waveLabel }) => {
+    const contact = await ctx.db
+      .query("wavePickedContacts")
+      .withIndex("by_runId_status", (q) =>
+        q.eq("runId", runId).eq("status", "pending"),
+      )
+      .filter((q) => q.eq(q.field("normalizedEmail"), normalizedEmail))
+      .unique();
+    if (!contact) {
+      // Either already-pushed or already-failed (CAS no-op) OR nonexistent.
+      return { ok: false as const, reason: "not-pending" as const };
+    }
+    const now = Date.now();
+    await ctx.db.patch(contact._id, { status: "pushed", pushedAt: now });
+
+    // Inline registration stamp (cannot delegate to _stampWaveByNormalizedEmail
+    // because Convex mutations cannot call other mutations).
+    const reg = await ctx.db
+      .query("registrations")
+      .withIndex("by_normalized_email", (q) =>
+        q.eq("normalizedEmail", normalizedEmail),
+      )
+      .first();
+    let stampResult: "stamped" | "alreadyStamped" | "notFound";
+    if (!reg) {
+      stampResult = "notFound";
+    } else if (reg.proLaunchWave === waveLabel) {
+      stampResult = "alreadyStamped";
+    } else {
+      await ctx.db.patch(reg._id, {
+        proLaunchWave: waveLabel,
+        proLaunchWaveAssignedAt: now,
+      });
+      stampResult = "stamped";
+    }
+
+    // Bump waveRuns.pushedCount + lastBatchAt atomically with the row patch.
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (run) {
+      await ctx.db.patch(run._id, {
+        pushedCount: run.pushedCount + 1,
+        lastBatchAt: now,
+        updatedAt: now,
+      });
+    }
+    return { ok: true as const, stampResult };
+  },
+});
+
+/**
+ * Mark a per-contact row as failed. CAS guard: no-op unless current
+ * status is 'pending'. Increments failedCount. If the new failure rate
+ * exceeds FAILURE_RATE_THRESHOLD, ALSO atomically flips the whole run
+ * to status='failed' with failureSubstatus='batch-failure-rate-exceeded'.
+ */
+export const _markContactFailed = internalMutation({
+  args: {
+    runId: v.string(),
+    normalizedEmail: v.string(),
+    failedReason: v.string(),
+  },
+  handler: async (ctx, { runId, normalizedEmail, failedReason }) => {
+    const contact = await ctx.db
+      .query("wavePickedContacts")
+      .withIndex("by_runId_status", (q) =>
+        q.eq("runId", runId).eq("status", "pending"),
+      )
+      .filter((q) => q.eq(q.field("normalizedEmail"), normalizedEmail))
+      .unique();
+    if (!contact) {
+      return { ok: false as const, reason: "not-pending" as const };
+    }
+    const now = Date.now();
+    await ctx.db.patch(contact._id, {
+      status: "failed",
+      failedAt: now,
+      failedReason: failedReason.slice(0, 500),
+    });
+
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (!run) return { ok: true as const, runFailed: false as const };
+
+    const newFailedCount = run.failedCount + 1;
+    const failureRate = run.totalCount > 0 ? newFailedCount / run.totalCount : 0;
+    const exceeded = failureRate > FAILURE_RATE_THRESHOLD;
+    await ctx.db.patch(run._id, {
+      failedCount: newFailedCount,
+      lastBatchAt: now,
+      updatedAt: now,
+      ...(exceeded
+        ? {
+            status: "failed" as const,
+            failureSubstatus: "batch-failure-rate-exceeded",
+            error: `failure rate ${(failureRate * 100).toFixed(2)}% exceeds ${(FAILURE_RATE_THRESHOLD * 100).toFixed(0)}% threshold`,
+          }
+        : {}),
+    });
+    return { ok: true as const, runFailed: exceeded };
+  },
+});
+
+export const pushBatchAction = internalAction({
+  args: {
+    runId: v.string(),
+    batchN: v.number(),
+  },
+  handler: async (
+    ctx,
+    { runId, batchN },
+  ): Promise<{ ok: boolean; reason?: string }> => {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) throw new Error("[pushBatchAction] RESEND_API_KEY not set");
+
+    // Lease + state revalidation.
+    const info = await ctx.runQuery(
+      internal.broadcast.waveRuns._resumeBatchInfo,
+      { runId },
+    );
+    if (!info) {
+      console.warn(`[pushBatchAction] runId=${runId} not found; exiting`);
+      return { ok: false, reason: "no-run" };
+    }
+    if (!info.configHoldsLease) {
+      console.warn(`[pushBatchAction] runId=${runId} lost lease; exiting`);
+      return { ok: false, reason: "lost-lease" };
+    }
+    const allowedStatuses: WaveRunStatus[] = ["segment-created", "pushing"];
+    if (!allowedStatuses.includes(info.run.status)) {
+      console.warn(
+        `[pushBatchAction] runId=${runId} status=${info.run.status} not pushable; exiting`,
+      );
+      return { ok: false, reason: `wrong-status-${info.run.status}` };
+    }
+    if (!info.run.segmentId) {
+      throw new Error(`[pushBatchAction] runId=${runId} has no segmentId`);
+    }
+
+    // First-batch transition picking → pushing (idempotent).
+    if (info.run.status === "segment-created") {
+      await ctx.runMutation(
+        internal.broadcast.waveRuns._markPushingStarted,
+        { runId },
+      );
+    }
+
+    // Pull this batch's pending contacts.
+    const batch = await ctx.runQuery(
+      internal.broadcast.waveRuns._getPendingBatch,
+      { runId, limit: info.run.batchSize },
+    );
+    if (batch.length === 0) {
+      // Nothing pending — schedule finalize.
+      await ctx.scheduler.runAfter(
+        0,
+        internal.broadcast.waveRuns.finalizeWaveAction,
+        { runId },
+      );
+      return { ok: true, reason: "no-pending-finalize-scheduled" };
+    }
+
+    // Push each row with backoff. CAS-guarded mark mutations make the loop
+    // safe under overlapping pushBatchAction invocations.
+    let runFailed = false;
+    for (const contact of batch) {
+      const result = await pushWithBackoff(apiKey, contact.normalizedEmail, info.run.segmentId);
+      if (result.kind === "failed") {
+        const failResult = await ctx.runMutation(
+          internal.broadcast.waveRuns._markContactFailed,
+          {
+            runId,
+            normalizedEmail: contact.normalizedEmail,
+            failedReason: result.reason,
+          },
+        );
+        if (failResult.ok && failResult.runFailed) {
+          runFailed = true;
+          console.error(
+            `[pushBatchAction] runId=${runId} batch=${batchN} failure-rate threshold tripped`,
+          );
+          break;
+        }
+        console.error(
+          `[pushBatchAction] push failed for ${maskEmail(contact.normalizedEmail)}: ${result.reason}`,
+        );
+        continue;
+      }
+      // Outcomes: created | linkedExisting | alreadyInSegment — all valid.
+      await ctx.runMutation(
+        internal.broadcast.waveRuns._markContactPushed,
+        {
+          runId,
+          normalizedEmail: contact.normalizedEmail,
+          waveLabel: info.run.waveLabel,
+        },
+      );
+    }
+
+    if (runFailed) return { ok: false, reason: "batch-failure-rate-exceeded" };
+
+    // Decide next step from fresh state.
+    const after = await ctx.runQuery(
+      internal.broadcast.waveRuns._resumeBatchInfo,
+      { runId },
+    );
+    if (!after || after.run.status === "failed") {
+      return { ok: false, reason: `terminal-status-${after?.run.status ?? "<missing>"}` };
+    }
+    if (after.hasPending) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.broadcast.waveRuns.pushBatchAction,
+        { runId, batchN: batchN + 1 },
+      );
+      return { ok: true, reason: "next-batch-scheduled" };
+    }
+    await ctx.scheduler.runAfter(
+      0,
+      internal.broadcast.waveRuns.finalizeWaveAction,
+      { runId },
+    );
+    return { ok: true, reason: "finalize-scheduled" };
+  },
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Finalize phase
+// ───────────────────────────────────────────────────────────────────────────
+
+export const _markBroadcastCreated = internalMutation({
+  args: {
+    runId: v.string(),
+    broadcastId: v.string(),
+  },
+  handler: async (ctx, { runId, broadcastId }) => {
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (!run) throw new Error(`[_markBroadcastCreated] no run ${runId}`);
+    const now = Date.now();
+    await ctx.db.patch(run._id, {
+      status: "broadcast-created",
+      broadcastId,
+      lastBatchAt: now, // re-arm in-flight guard for the send phase
+      updatedAt: now,
+    });
+    return { ok: true as const };
+  },
+});
+
+export const _markFinalizeFailed = internalMutation({
+  args: {
+    runId: v.string(),
+    substatus: v.union(
+      v.literal("create-broadcast-failed"),
+      v.literal("send-broadcast-failed"),
+    ),
+    error: v.string(),
+  },
+  handler: async (ctx, { runId, substatus, error }) => {
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (!run) throw new Error(`[_markFinalizeFailed] no run ${runId}`);
+    const now = Date.now();
+    // For send-broadcast-failed we keep status='broadcast-created' so the
+    // discriminator is the substatus, not the status — clearer for operator
+    // tooling, and matches the "broadcast object exists in Resend; only the
+    // send call failed" invariant. For create-broadcast-failed we flip to
+    // status='failed' since no broadcast object was created.
+    const statusPatch =
+      substatus === "create-broadcast-failed"
+        ? { status: "failed" as const }
+        : {};
+    await ctx.db.patch(run._id, {
+      ...statusPatch,
+      failureSubstatus: substatus,
+      error: error.slice(0, 500),
+      updatedAt: now,
+    });
+    return { ok: true as const };
+  },
+});
+
+/**
+ * Atomic success commit. Advances `broadcastRampConfig.currentTier`, sets
+ * `lastWave*` fields, clears the lease, AND marks `waveRuns.status='sent'`
+ * — all in one transaction. The only path that reconciles the run with
+ * the long-term ramp state.
+ */
+export const _finalizeWaveRun = internalMutation({
+  args: {
+    runId: v.string(),
+    sentAt: v.number(),
+  },
+  handler: async (ctx, { runId, sentAt }) => {
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (!run) throw new Error(`[_finalizeWaveRun] no run ${runId}`);
+    if (!run.broadcastId || !run.segmentId) {
+      throw new Error(
+        `[_finalizeWaveRun] run ${runId} missing broadcastId/segmentId`,
+      );
+    }
+
+    const config = await ctx.db
+      .query("broadcastRampConfig")
+      .withIndex("by_key", (q) => q.eq("key", "current"))
+      .unique();
+    if (!config) throw new Error("[_finalizeWaveRun] no broadcastRampConfig");
+
+    const now = Date.now();
+    const nextTier = config.currentTier + 1;
+
+    await ctx.db.patch(config._id, {
+      currentTier: nextTier,
+      lastWaveLabel: run.waveLabel,
+      lastWaveBroadcastId: run.broadcastId,
+      lastWaveSegmentId: run.segmentId,
+      lastWaveAssigned: run.pushedCount,
+      lastWaveSentAt: sentAt,
+      lastRunStatus: "succeeded",
+      lastRunAt: now,
+      lastRunError: undefined,
+      pendingRunId: undefined,
+      pendingRunStartedAt: undefined,
+      pendingWaveLabel: undefined,
+      pendingSegmentId: undefined,
+      pendingAssigned: undefined,
+      pendingExportAt: undefined,
+      pendingBroadcastId: undefined,
+      pendingBroadcastAt: undefined,
+    });
+    await ctx.db.patch(run._id, {
+      status: "sent",
+      updatedAt: now,
+    });
+    return { ok: true as const, advancedToTier: nextTier };
+  },
+});
+
+export const finalizeWaveAction = internalAction({
+  args: { runId: v.string() },
+  handler: async (
+    ctx,
+    { runId },
+  ): Promise<{ ok: boolean; reason?: string }> => {
+    const info = await ctx.runQuery(
+      internal.broadcast.waveRuns._resumeBatchInfo,
+      { runId },
+    );
+    if (!info) return { ok: false, reason: "no-run" };
+    if (!info.configHoldsLease) return { ok: false, reason: "lost-lease" };
+    if (!info.run.segmentId) {
+      throw new Error(`[finalizeWaveAction] runId=${runId} missing segmentId`);
+    }
+
+    // Path 1: run is in 'pushing' (or 'segment-created' as a defensive case)
+    // → create the broadcast first via ctx.runAction (Convex pattern for
+    // action→action invocation, mirrors rampRunner.ts:886).
+    if (info.run.status === "pushing" || info.run.status === "segment-created") {
+      let createResult: { broadcastId: string; segmentId: string; subject: string; name: string };
+      try {
+        createResult = await ctx.runAction(
+          internal.broadcast.sendBroadcast.createProLaunchBroadcast,
+          {
+            segmentId: info.run.segmentId,
+            nameSuffix: info.run.waveLabel,
+          },
+        );
+      } catch (err) {
+        await ctx.runMutation(
+          internal.broadcast.waveRuns._markFinalizeFailed,
+          {
+            runId,
+            substatus: "create-broadcast-failed",
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
+        throw err;
+      }
+      await ctx.runMutation(
+        internal.broadcast.waveRuns._markBroadcastCreated,
+        { runId, broadcastId: createResult.broadcastId },
+      );
+    } else if (info.run.status !== "broadcast-created") {
+      return { ok: false, reason: `wrong-status-${info.run.status}` };
+    }
+
+    // Path 2 (and continuation of Path 1): broadcast exists in Resend; send it.
+    const after = await ctx.runQuery(
+      internal.broadcast.waveRuns._resumeBatchInfo,
+      { runId },
+    );
+    if (!after?.run.broadcastId) {
+      throw new Error(`[finalizeWaveAction] runId=${runId} missing broadcastId post-create`);
+    }
+    try {
+      await ctx.runAction(
+        internal.broadcast.sendBroadcast.sendProLaunchBroadcast,
+        { broadcastId: after.run.broadcastId },
+      );
+    } catch (err) {
+      await ctx.runMutation(
+        internal.broadcast.waveRuns._markFinalizeFailed,
+        {
+          runId,
+          substatus: "send-broadcast-failed",
+          error: err instanceof Error ? err.message : String(err),
+        },
+      );
+      throw err;
+    }
+
+    // Success — atomic finalize.
+    await ctx.runMutation(internal.broadcast.waveRuns._finalizeWaveRun, {
+      runId,
+      sentAt: Date.now(),
+    });
+    return { ok: true };
+  },
+});
+
+/**
+ * Operator one-shot: when `failureSubstatus='send-broadcast-failed'` BUT
+ * Resend dashboard shows the broadcast was actually queued/sent, finalize
+ * directly without retrying the send. Required arg `sentAt` from the
+ * operator's observation (Resend dashboard shows the timestamp).
+ */
+export const markFinalizeRecovered = internalMutation({
+  args: {
+    runId: v.string(),
+    sentAt: v.number(),
+    reason: v.string(),
+  },
+  handler: async (ctx, { runId, sentAt, reason }) => {
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (!run) throw new Error(`[markFinalizeRecovered] no run ${runId}`);
+    if (run.failureSubstatus !== "send-broadcast-failed" && run.status !== "broadcast-created") {
+      throw new Error(
+        `[markFinalizeRecovered] run ${runId} not in send-failure state (status=${run.status}, substatus=${run.failureSubstatus ?? "<none>"})`,
+      );
+    }
+    if (!run.broadcastId || !run.segmentId) {
+      throw new Error(`[markFinalizeRecovered] run ${runId} missing broadcastId/segmentId`);
+    }
+    const config = await ctx.db
+      .query("broadcastRampConfig")
+      .withIndex("by_key", (q) => q.eq("key", "current"))
+      .unique();
+    if (!config) throw new Error("[markFinalizeRecovered] no broadcastRampConfig");
+
+    const now = Date.now();
+    const nextTier = config.currentTier + 1;
+    await ctx.db.patch(config._id, {
+      currentTier: nextTier,
+      lastWaveLabel: run.waveLabel,
+      lastWaveBroadcastId: run.broadcastId,
+      lastWaveSegmentId: run.segmentId,
+      lastWaveAssigned: run.pushedCount,
+      lastWaveSentAt: sentAt,
+      lastRunStatus: `succeeded-via-finalize-recovered: ${reason.slice(0, 200)}`,
+      lastRunAt: now,
+      lastRunError: undefined,
+      pendingRunId: undefined,
+      pendingRunStartedAt: undefined,
+      pendingWaveLabel: undefined,
+      pendingSegmentId: undefined,
+      pendingAssigned: undefined,
+      pendingExportAt: undefined,
+      pendingBroadcastId: undefined,
+      pendingBroadcastAt: undefined,
+    });
+    await ctx.db.patch(run._id, {
+      status: "sent",
+      updatedAt: now,
+      error: undefined,
+      failureSubstatus: undefined,
+    });
+    return { ok: true as const, advancedToTier: nextTier };
+  },
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Operator recovery
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Soft-discard. Marks the run failed and rotates `waveLabelOffset` so the
+ * NEXT wave doesn't reuse the discarded label. Does NOT physically delete
+ * `wavePickedContacts` rows — the daily cleanup cron does that in chunks.
+ *
+ * Operator must inspect Resend dashboard separately for the segment +
+ * any partially-created broadcast.
+ */
+export const discardWaveRun = internalMutation({
+  args: {
+    runId: v.string(),
+    reason: v.string(),
+  },
+  handler: async (ctx, { runId, reason }) => {
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (!run) throw new Error(`[discardWaveRun] no run ${runId}`);
+    const config = await ctx.db
+      .query("broadcastRampConfig")
+      .withIndex("by_key", (q) => q.eq("key", "current"))
+      .unique();
+    if (!config) throw new Error("[discardWaveRun] no broadcastRampConfig");
+
+    const now = Date.now();
+    await ctx.db.patch(run._id, {
+      status: "failed",
+      failureSubstatus: "discarded-by-operator",
+      error: reason.slice(0, 500),
+      updatedAt: now,
+    });
+    await ctx.db.patch(config._id, {
+      waveLabelOffset: config.waveLabelOffset + 1,
+      lastRunStatus: `discarded-by-operator: ${reason.slice(0, 200)}`,
+      lastRunAt: now,
+      pendingRunId: undefined,
+      pendingRunStartedAt: undefined,
+      pendingWaveLabel: undefined,
+      pendingSegmentId: undefined,
+      pendingAssigned: undefined,
+      pendingExportAt: undefined,
+      pendingBroadcastId: undefined,
+      pendingBroadcastAt: undefined,
+    });
+    return {
+      ok: true as const,
+      newWaveLabelOffset: config.waveLabelOffset + 1,
+    };
+  },
+});
+
+/**
+ * Push-phase recovery only. Refuses for finalize-phase failures (route to
+ * `resumeFinalizeWaveRun`) and for terminal-success.
+ */
+export const resumeStalledWaveRun = internalMutation({
+  args: { runId: v.string() },
+  handler: async (ctx, { runId }) => {
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (!run) throw new Error(`[resumeStalledWaveRun] no run ${runId}`);
+    if (run.status === "broadcast-created") {
+      throw new Error(
+        `[resumeStalledWaveRun] runId=${runId} is in broadcast-created — use resumeFinalizeWaveRun({confirmedNotSent: true}) after Resend-dashboard verification, OR markFinalizeRecovered if the broadcast was actually sent.`,
+      );
+    }
+    if (run.status === "failed") {
+      throw new Error(
+        `[resumeStalledWaveRun] runId=${runId} is in failed (substatus=${run.failureSubstatus ?? "<none>"}) — use resumeFinalizeWaveRun (for create/send substatuses) or discardWaveRun (for batch-failure-rate-exceeded / pick-phase substatuses).`,
+      );
+    }
+    if (run.status === "sent") {
+      throw new Error(`[resumeStalledWaveRun] runId=${runId} is already sent`);
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(run._id, { lastBatchAt: now, updatedAt: now });
+    await ctx.scheduler.runAfter(
+      0,
+      internal.broadcast.waveRuns.pushBatchAction,
+      { runId, batchN: 0 },
+    );
+    return { ok: true as const, scheduled: "pushBatchAction" as const };
+  },
+});
+
+/**
+ * Finalize-phase recovery. Requires `confirmedNotSent: true` for the
+ * send-failure case (operator MUST verify in Resend dashboard before
+ * invoking — Resend may have queued the send despite the action seeing
+ * an error response).
+ */
+export const resumeFinalizeWaveRun = internalMutation({
+  args: {
+    runId: v.string(),
+    confirmedNotSent: v.optional(v.boolean()),
+  },
+  handler: async (ctx, { runId, confirmedNotSent }) => {
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (!run) throw new Error(`[resumeFinalizeWaveRun] no run ${runId}`);
+
+    const isSendFailureCase =
+      run.status === "broadcast-created" ||
+      run.failureSubstatus === "send-broadcast-failed";
+    const isCreateFailureCase =
+      run.status === "failed" &&
+      run.failureSubstatus === "create-broadcast-failed";
+
+    if (isSendFailureCase) {
+      if (confirmedNotSent !== true) {
+        throw new Error(
+          `[resumeFinalizeWaveRun] runId=${runId} is in send-failure state. ` +
+          `BEFORE retrying, verify in the Resend dashboard whether the broadcast for ` +
+          `broadcastId=${run.broadcastId ?? "<unknown>"} was actually queued or sent ` +
+          `(Resend may accept a send despite the action seeing a network/timeout error). ` +
+          `If confirmed NOT sent, re-run with {confirmedNotSent: true}. ` +
+          `If Resend shows the broadcast as already sent, use markFinalizeRecovered({runId, sentAt}) instead.`,
+        );
+      }
+      // Reset to broadcast-created so finalizeWaveAction skips create + retries send.
+      const now = Date.now();
+      await ctx.db.patch(run._id, {
+        status: "broadcast-created",
+        failureSubstatus: undefined,
+        error: undefined,
+        lastBatchAt: now,
+        updatedAt: now,
+      });
+      await ctx.scheduler.runAfter(
+        0,
+        internal.broadcast.waveRuns.finalizeWaveAction,
+        { runId },
+      );
+      return { ok: true as const, scheduled: "finalizeWaveAction-send-only" as const };
+    }
+
+    if (isCreateFailureCase) {
+      // No broadcast exists yet — patch back to pushing so finalizeWaveAction
+      // re-enters via the create-broadcast path. Operator should verify in
+      // Resend dashboard that the SEGMENT still exists before resuming.
+      const now = Date.now();
+      await ctx.db.patch(run._id, {
+        status: "pushing",
+        failureSubstatus: undefined,
+        error: undefined,
+        lastBatchAt: now,
+        updatedAt: now,
+      });
+      await ctx.scheduler.runAfter(
+        0,
+        internal.broadcast.waveRuns.finalizeWaveAction,
+        { runId },
+      );
+      return { ok: true as const, scheduled: "finalizeWaveAction-create-and-send" as const };
+    }
+
+    throw new Error(
+      `[resumeFinalizeWaveRun] runId=${runId} is in status=${run.status} substatus=${run.failureSubstatus ?? "<none>"} — ` +
+      `not a finalize-phase failure. Use resumeStalledWaveRun (for pushing/segment-created) or discardWaveRun (for batch-failure / pick-phase failures).`,
+    );
+  },
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Cleanup
+// ───────────────────────────────────────────────────────────────────────────
+
+export const _cleanupDiscardedWavePickedContacts = internalMutation({
+  args: { runId: v.string() },
+  handler: async (ctx, { runId }) => {
+    const rows = await ctx.db
+      .query("wavePickedContacts")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .take(CLEANUP_CHUNK_SIZE);
+    for (const row of rows) {
+      await ctx.db.delete(row._id);
+    }
+    return { deleted: rows.length, hasMore: rows.length === CLEANUP_CHUNK_SIZE };
+  },
+});
+
+/**
+ * Cron-scheduled action that finds discarded/failed `waveRuns` rows older
+ * than 24h and chunked-deletes their `wavePickedContacts`. Self-schedules
+ * the next chunk if any rows remain.
+ */
+export const cleanupDiscardedWavePickedContactsAction = internalAction({
+  args: {
+    runId: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<{ deleted: number; hasMore: boolean }> => {
+    if (args.runId) {
+      const result = await ctx.runMutation(
+        internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts,
+        { runId: args.runId },
+      );
+      if (result.hasMore) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.broadcast.waveRuns.cleanupDiscardedWavePickedContactsAction,
+          { runId: args.runId },
+        );
+      }
+      return result;
+    }
+
+    // No specific runId — scan failed runs >24h old.
+    const candidates = await ctx.runQuery(
+      internal.broadcast.waveRuns._listFailedWaveRunsForCleanup,
+      {},
+    );
+    let totalDeleted = 0;
+    for (const runId of candidates) {
+      const result = await ctx.runMutation(
+        internal.broadcast.waveRuns._cleanupDiscardedWavePickedContacts,
+        { runId },
+      );
+      totalDeleted += result.deleted;
+      if (result.hasMore) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.broadcast.waveRuns.cleanupDiscardedWavePickedContactsAction,
+          { runId },
+        );
+      }
+    }
+    return { deleted: totalDeleted, hasMore: false };
+  },
+});
+
+export const _listFailedWaveRunsForCleanup = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000;
+    const failed = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_status", (q) => q.eq("status", "failed"))
+      .collect();
+    return failed.filter((r) => r.updatedAt < cutoff).map((r) => r.runId);
+  },
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Status surface (for runDailyRamp guard + getRampStatus)
+// ───────────────────────────────────────────────────────────────────────────
+
+const ACTIVE_STATUSES: WaveRunStatus[] = [
+  "picking",
+  "segment-created",
+  "pushing",
+  "broadcast-created",
+];
+
+export const _listInFlightWaveRuns = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const rows: Array<{
+      runId: string;
+      status: WaveRunStatus;
+      lastActivityAt: number;
+    }> = [];
+    for (const status of ACTIVE_STATUSES) {
+      const found = await ctx.db
+        .query("waveRuns")
+        .withIndex("by_status", (q) => q.eq("status", status))
+        .collect();
+      for (const r of found) {
+        rows.push({
+          runId: r.runId,
+          status: r.status,
+          lastActivityAt: r.lastBatchAt ?? r.updatedAt ?? r.createdAt,
+        });
+      }
+    }
+    return rows;
+  },
+});
+
+export const getWaveRunStatus = internalQuery({
+  args: { runId: v.string() },
+  handler: async (ctx, { runId }) => {
+    const run = await ctx.db
+      .query("waveRuns")
+      .withIndex("by_runId", (q) => q.eq("runId", runId))
+      .unique();
+    if (!run) return null;
+    const pending = await ctx.db
+      .query("wavePickedContacts")
+      .withIndex("by_runId_status", (q) =>
+        q.eq("runId", runId).eq("status", "pending"),
+      )
+      .take(1);
+    return {
+      runId: run.runId,
+      waveLabel: run.waveLabel,
+      status: run.status,
+      failureSubstatus: run.failureSubstatus,
+      error: run.error,
+      segmentId: run.segmentId,
+      broadcastId: run.broadcastId,
+      requestedCount: run.requestedCount,
+      totalCount: run.totalCount,
+      pushedCount: run.pushedCount,
+      failedCount: run.failedCount,
+      underfilled: run.underfilled,
+      hasPendingContacts: pending.length > 0,
+      lastActivityAt: run.lastBatchAt ?? run.updatedAt,
+      createdAt: run.createdAt,
+      updatedAt: run.updatedAt,
+    };
+  },
+});

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -22,4 +22,17 @@ crons.daily(
   internal.broadcast.rampRunner.runDailyRamp,
 );
 
+// Daily prune of `wavePickedContacts` rows belonging to discarded/failed
+// wave runs older than 24h. Each invocation deletes one chunk (500 rows)
+// and self-schedules until a run's rows are drained, then moves on. Avoids
+// hitting Convex's per-mutation write limit on bulk deletion of up to 25k
+// rows in one shot. See `convex/broadcast/waveRuns.ts`
+// (`cleanupDiscardedWavePickedContactsAction`).
+crons.daily(
+  "wave-runs-cleanup",
+  { hourUTC: 4, minuteUTC: 0 },
+  internal.broadcast.waveRuns.cleanupDiscardedWavePickedContactsAction,
+  {},
+);
+
 export default crons;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -240,6 +240,106 @@ export default defineSchema({
     pendingBroadcastAt: v.optional(v.number()),
   }).index("by_key", ["key"]),
 
+  // ────────────────────────────────────────────────────────────────────────
+  // Plan 2026-04-29 (post-launch-stabilization PR 2): wave-loading state
+  // machine. Replaces the monolithic `assignAndExportWave` action — which
+  // hits the Convex 10-min runtime budget at ~1500 contacts — with a
+  // multi-step pipeline (pick → push-batch×N → finalize) that fits within
+  // budget at any wave size.
+  //
+  // `waveRuns` is the per-run state row. `wavePickedContacts` is the
+  // per-contact tri-state row that the push pipeline drains in batches.
+  // Together they are the durable source of truth for an in-flight wave;
+  // `broadcastRampConfig.lastWave*` is updated atomically by
+  // `_finalizeWaveRun` only when the whole pipeline succeeds.
+  //
+  // See `convex/broadcast/waveRuns.ts` for the function-shape rules
+  // (internalAction = external I/O, internalMutation = DB writes only)
+  // and the lease/recovery semantics.
+  // ────────────────────────────────────────────────────────────────────────
+  waveRuns: defineTable({
+    // Unique per pickWave call. Same string is set as
+    // `broadcastRampConfig.pendingRunId` for lease coordination — the
+    // existing rampRunner lease pattern. Cleared on `_finalizeWaveRun`
+    // success or operator recovery (`discardWaveRun`).
+    runId: v.string(),
+    waveLabel: v.string(),
+    segmentId: v.optional(v.string()),
+    // Lifecycle:
+    //   picking            → reservoir-sampling + creating segment + persisting picked rows
+    //   segment-created    → ready for first pushBatchAction
+    //   pushing            → at least one batch in flight; remaining `pending` rows
+    //   broadcast-created  → all contacts pushed; broadcast object exists in Resend; send may have failed
+    //   sent               → terminal success — broadcastRampConfig advanced atomically by _finalizeWaveRun
+    //   failed             → terminal-by-failure; substatus carries reason and dictates which operator
+    //                        recovery mutation applies (resumeStalledWaveRun, resumeFinalizeWaveRun,
+    //                        markFinalizeRecovered, or discardWaveRun)
+    status: v.union(
+      v.literal("picking"),
+      v.literal("segment-created"),
+      v.literal("pushing"),
+      v.literal("broadcast-created"),
+      v.literal("sent"),
+      v.literal("failed"),
+    ),
+    // Operator-supplied count from `pickWaveAction` args. May exceed pool —
+    // the actual picked count is in `totalCount`, with `underfilled=true`.
+    requestedCount: v.number(),
+    // = picked.length after reservoir sampling. Finalization gates on
+    // "zero `pending` rows for this runId", NOT on pushedCount === totalCount —
+    // failed contacts are tolerated up to the 5% threshold.
+    totalCount: v.number(),
+    underfilled: v.boolean(),
+    pushedCount: v.number(),
+    failedCount: v.number(),
+    batchSize: v.number(),
+    // Updated by every successful batch + by lease-revalidating recovery
+    // mutations. Used (with createdAt/updatedAt fallback) by `runDailyRamp`'s
+    // 15-min in-flight guard to distinguish "actively running" from "stalled
+    // — needs operator intervention".
+    lastBatchAt: v.optional(v.number()),
+    broadcastId: v.optional(v.string()),
+    // Discriminator for `failed` status. Drives operator recovery routing:
+    //   'create-broadcast-failed'      → segment ready, no broadcast yet → resumeFinalizeWaveRun retries create
+    //   'send-broadcast-failed'        → segment + broadcast ready, send failed → resumeFinalizeWaveRun({confirmedNotSent:true}) OR markFinalizeRecovered
+    //   'discarded-by-operator'        → discardWaveRun ran; cleanup cron prunes the rows
+    //   'batch-failure-rate-exceeded'  → push-side >5% failures → discardWaveRun (transient retry won't help)
+    //   'empty-pool'                   → pickWave found zero unstamped registrations → terminal no-op
+    //   'segment-create-failed'        → Resend createSegment failed → operator inspects + discards
+    //   'persist-failed'               → mid-loop _persistPickedBatch failed → operator inspects + discards
+    failureSubstatus: v.optional(v.string()),
+    error: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_runId", ["runId"])
+    .index("by_status", ["status"]),
+
+  // Per-contact tri-state row written by `_persistPickedBatch` during pick
+  // and patched atomically by `_markContactPushed` / `_markContactFailed`
+  // during push. The CAS guard on those mutations (no-op unless
+  // status==='pending') makes them idempotent under overlapping
+  // pushBatchAction invocations or operator-resume-while-original-still-running.
+  //
+  // Rows are NOT deleted synchronously on `discardWaveRun` — the daily
+  // `cleanupDiscardedWavePickedContactsAction` cron prunes them in 500-row
+  // batches to avoid hitting Convex's per-mutation write limits on bulk
+  // deletion of up to 25k rows.
+  wavePickedContacts: defineTable({
+    runId: v.string(),
+    normalizedEmail: v.string(),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("pushed"),
+      v.literal("failed"),
+    ),
+    pushedAt: v.optional(v.number()),
+    failedAt: v.optional(v.number()),
+    failedReason: v.optional(v.string()),
+  })
+    .index("by_runId", ["runId"])
+    .index("by_runId_status", ["runId", "status"]),
+
   // Phase 9 / Todo #223 — Clerk-user referral codes.
   // The `registrations.referralCode` column uses a 6-char hash of
   // the registering email; share-button codes are an 8-char HMAC


### PR DESCRIPTION
## Summary

PR 2 of post-launch-stabilization plan (codex-approved round 6, see `plans/2026-04-29-post-launch-stabilization.md`). Replaces the `assignAndExportWave + createProLaunchBroadcast + sendProLaunchBroadcast` monolith — which hits the Convex 10-min action runtime budget at ~1500 contacts and caused two manual-recovery incidents on 2026-04-28 / 2026-04-29 — with a self-driving state machine that fits within budget at any wave size.

## Pipeline

```
pickWaveAction (action)
  → _claimWaveRunLease + reservoir-sample + Resend createSegment
  → chunked _persistPickedBatch (≤500 rows/mutation)
  → schedule pushBatchAction

pushBatchAction (action)
  → _getPendingBatch → upsertContactToSegment with 429/5xx exponential backoff
  → _markContactPushed | _markContactFailed (per-row CAS, no-op unless status='pending')
  → schedule next pushBatchAction OR finalizeWaveAction

finalizeWaveAction (action)
  → createProLaunchBroadcast → _markBroadcastCreated
  → sendProLaunchBroadcast → _finalizeWaveRun
    (atomically advances broadcastRampConfig.lastWave* + clears lease)
```

## Function-shape rules (Convex-correct)

| Type | Allowed | Forbidden |
|---|---|---|
| `internalAction` | external I/O (Resend HTTP); calls `runQuery`/`runMutation` | direct DB read/write |
| `internalMutation` | DB writes only | external I/O; calling other mutations via `runMutation` |
| `internalQuery` | DB reads only | writes; external I/O |

> Convex forbids mutation→mutation chaining. The registration-stamp logic from `_stampWaveByNormalizedEmail` is **inlined** into `_markContactPushed` (with the same `alreadyStamped` early-return guard) — the existing public mutation remains untouched for callers in other modules.

## Schema additions

- `waveRuns` — per-run state row with status enum (`picking | segment-created | pushing | broadcast-created | sent | failed`), `requestedCount` / `totalCount` / `pushedCount` / `failedCount`, `batchSize`, `lastBatchAt`, `broadcastId`, `failureSubstatus`, `error`. Indexes: `by_runId`, `by_status`.
- `wavePickedContacts` — tri-state per-contact rows (`pending | pushed | failed`) with `failedReason`, `pushedAt`, `failedAt`. Indexes: `by_runId`, `by_runId_status`. Drained by `pushBatchAction`; pruned in 500-row chunks by daily cleanup cron.

## Operator recovery routing (refuse-vs-route guards)

| Stuck state | Recovery mutation | Notes |
|---|---|---|
| `pushing` / `segment-created` (stalled >15min) | `resumeStalledWaveRun` | Refuses for everything else |
| `broadcast-created` (send may have queued) | `resumeFinalizeWaveRun({confirmedNotSent: true})` | REQUIRES Resend-dashboard verification first; throws on default-false |
| Resend confirms already sent | `markFinalizeRecovered({sentAt})` | Records success without retrying send |
| `failed/create-broadcast-failed` | `resumeFinalizeWaveRun` | No `confirmedNotSent` needed (no broadcast yet) |
| `failed/batch-failure-rate-exceeded` / `segment-create-failed` / `persist-failed` | `discardWaveRun` | Rotates `waveLabelOffset`, soft-discard |
| `failed/empty-pool` | (terminal no-op) | Lease auto-cleared at failure record |

## `runDailyRamp` change

Replaced the monolithic Steps 3a-5 with:

1. In-flight guard — query active waveRuns; if any with `lastActivityAt = lastBatchAt ?? updatedAt ?? createdAt` <15min ago, skip; if ≥15min, log STALLED and return without claiming.
2. Otherwise: `ctx.scheduler.runAfter(0, internal.broadcast.waveRuns.pickWaveAction, ...)` — explicit comment in the code explains why **not** `ctx.runAction` (which awaits and re-introduces the budget problem).
3. Return immediately.

Legacy lease mutations (`_claimTierForRun`, `_recordPendingExport`, `_recordPendingBroadcast`, `_recordWaveSent`, `_recordRunOutcome`) remain in `rampRunner.ts` so the legacy operator-recovery commands (`recoverFromPartialFailure`, `clearPartialFailure`, `forceReleaseLease`) keep working on any pre-PR2 partial-failure rows. `runDailyRamp` no longer calls them.

`getRampStatus` extended with `activeWaveRuns[]` showing batch-level progress.

## Cron

Added `wave-runs-cleanup` daily at 04:00 UTC → `cleanupDiscardedWavePickedContactsAction` which prunes `wavePickedContacts` rows for `failed/discarded` runs older than 24h in 500-row chunks (avoids Convex per-mutation write limits on bulk deletion of up to 25k rows).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — green (no new warnings introduced)
- [x] `npm run test:data` — 7690 data tests pass (+31 over baseline)
- [x] `npm run test:convex` — **25 new wave-runs integration tests pass**, 183 total convex tests pass
- [x] Edge function bundle check — all clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — ok

### New tests breakdown (25)

- `_claimWaveRunLease` (4): claims, refuses second claim, refuses label collision, refuses no-config
- pick-phase mutations (4): persist + markPickComplete + markPickFailed empty-pool clears lease + segment-create-failed keeps lease
- push-phase CAS (5): markContactPushed atomic stamp + CAS idempotency, markContactFailed under-threshold + over-threshold flips run + CAS idempotency
- finalize-phase (4): markBroadcastCreated, finalizeWaveRun atomic commit, markFinalizeFailed branches by substatus
- operator recovery (5): resumeStalledWaveRun refuses broadcast-created, resumeFinalizeWaveRun requires confirmedNotSent for send-failure, create-broadcast-failed needs no confirm, discardWaveRun bumps offset, markFinalizeRecovered finalizes verified send
- in-flight guard + cleanup (3): listInFlightWaveRuns active + excludes terminal, cleanup chunked

### Removed tests

Two source-grep tests in `rampRunner.test.ts` that checked the now-removed monolithic body's internal call ordering and `underfilled-routes-to-partial-failure` regressions. Behavior moved into `pickWaveAction` and is tested in `waveRuns.test.ts`.

## Verification before resuming the cron

The plan's Phase D acceptance criteria — to be done after merge, on a test fork or in production with the ramp paused:

- [ ] Test-fork run of 5000 fake registrations → confirm `getRampStatus` shows live batch progress; final state `sent`.
- [ ] Force a kill mid-batch → run `resumeStalledWaveRun` → assert no duplicate stamps, no duplicate Resend calls.
- [ ] Lease conflict: invoke `pickWaveAction` twice in parallel → second is refused.
- [ ] Empty-pool: run with 0 unstamped registrations → `failed/empty-pool`, lease cleared.

## Out of scope

- **PR 3** still gated on ≥24h soak of PR 1 (#3499). Will follow once Sentry shows the `error_shape:setPreferences_conflict` distribution narrowed.