### PR TITLE
fix(stale-bundle-check): trigger reload on visibilitychange + periodic interval (background-tab gap)

### DIFF
--- a/src/bootstrap/stale-bundle-check.ts
+++ b/src/bootstrap/stale-bundle-check.ts
@@ -15,10 +15,12 @@
 
 interface EventTargetLike {
   addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
+  removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
 }
 
 interface DocumentLike {
   addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
+  removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
   visibilityState?: string;
 }
 
@@ -135,18 +137,22 @@ export function installStaleBundleCheck(options: StaleBundleCheckOptions = {}): 
     }
   };
 
-  const handler: EventListener = () => {
+  const focusHandler: EventListener = () => {
     void check();
   };
-  eventTarget.addEventListener('focus', handler);
+  eventTarget.addEventListener('focus', focusHandler);
 
   // visibilitychange fires when the tab becomes visible again. We only
   // want to trigger on the visible side (not on hide), so gate with the
-  // documentTarget's visibilityState.
+  // documentTarget's visibilityState. Closure references documentTarget so
+  // the predicate uses the live state at fire time, not at install time.
+  const visibilityHandler: EventListener = documentTarget
+    ? () => {
+        if (documentTarget.visibilityState === 'visible') void check();
+      }
+    : () => {};
   if (documentTarget) {
-    documentTarget.addEventListener('visibilitychange', () => {
-      if (documentTarget.visibilityState === 'visible') void check();
-    });
+    documentTarget.addEventListener('visibilitychange', visibilityHandler);
   }
 
   // Periodic safety net for background tabs that never receive
@@ -154,9 +160,14 @@ export function installStaleBundleCheck(options: StaleBundleCheckOptions = {}): 
   const intervalHandle = setIntervalImpl(() => void check(), periodicIntervalMs);
 
   return () => {
-    // Test disposer — clear the periodic timer. Window/document listeners
-    // are unmanageable through our narrow EventTargetLike type, but tests
-    // pass spies and don't need explicit removal.
+    // Full cleanup. Production currently calls installStaleBundleCheck
+    // exactly once at boot, but a complete disposer protects against
+    // future hot-reload / test-helper reuse where double-install would
+    // otherwise leave orphaned listeners firing against stale targets.
+    eventTarget.removeEventListener('focus', focusHandler);
+    if (documentTarget) {
+      documentTarget.removeEventListener('visibilitychange', visibilityHandler);
+    }
     if (intervalHandle && typeof clearInterval === 'function') {
       clearInterval(intervalHandle as unknown as ReturnType<typeof setInterval>);
     }

--- a/src/bootstrap/stale-bundle-check.ts
+++ b/src/bootstrap/stale-bundle-check.ts
@@ -17,32 +17,72 @@ interface EventTargetLike {
   addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
 }
 
+interface DocumentLike {
+  addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
+  visibilityState?: string;
+}
+
 interface StaleBundleCheckOptions {
   /** Hash baked into the running bundle (default: __BUILD_HASH__). */
   currentHash?: string;
   /** Override fetch (for tests). Defaults to global fetch. */
   fetch?: typeof globalThis.fetch;
-  /** Override target for the focus listener. Default: window. */
+  /** Override window-level event target (default: window). */
   eventTarget?: EventTargetLike;
+  /** Override document for visibilitychange (default: document). */
+  documentTarget?: DocumentLike;
+  /** Override setInterval (for tests). Default: globalThis.setInterval. */
+  setInterval?: (cb: () => void, ms: number) => unknown;
   /** Override reload (for tests). Default: window.location.reload(). */
   reload?: () => void;
   /** Override clock (for tests). Default: Date.now. */
   now?: () => number;
   /**
-   * Minimum interval between checks. Multiple focus events within this
-   * window collapse to one fetch.
+   * Minimum interval between checks. Multiple events within this window
+   * collapse to one fetch.
    */
   minIntervalMs?: number;
+  /**
+   * Wall-clock cadence of the periodic background check. Catches stuck
+   * tabs that never fire focus/visibilitychange (e.g. a tab pinned in
+   * the background of another window). Browsers throttle background
+   * setIntervals to ~1min minimum resolution, so values below that are
+   * effectively the same as 60_000ms.
+   */
+  periodicIntervalMs?: number;
 }
 
 const DEFAULT_MIN_INTERVAL_MS = 60_000;
+/** Wall-clock periodic check. 10min is plenty for stale-bundle detection
+ *  (we don't need second-level latency to reload an old bundle) and
+ *  respects browser background-tab throttling. */
+const DEFAULT_PERIODIC_INTERVAL_MS = 10 * 60_000;
 
 /**
- * Install the focus-event listener that compares the running bundle's hash
- * against the deployed hash and reloads on mismatch. Idempotent in practice
- * because the focus listener checks at most once per minIntervalMs.
+ * Install listeners that compare the running bundle's hash against the
+ * deployed hash and reload on mismatch. Three trigger paths:
+ *   1. window `focus` — user switches BACK to the tab
+ *   2. document `visibilitychange` — tab goes background→foreground
+ *      (fires for some background→foreground transitions that don't
+ *      raise window focus, e.g. tab activation within the same window)
+ *   3. periodic setInterval — catches tabs pinned in the background of
+ *      another window that never receive focus/visibilitychange. Browser
+ *      background throttling means actual cadence is ~1min minimum, but
+ *      that's fine for stale-bundle detection.
  *
- * Returns a disposer function that removes the listener (used in tests).
+ * All three paths funnel through a `check()` that's deduped by
+ * `minIntervalMs` — multiple triggers within the dedupe window collapse
+ * to one fetch.
+ *
+ * The `focus`-only design from PR #3499 missed background-tab users:
+ * one user (Sentry user_id user_3Cu7uZZJEeVSoUjv9SBn4BEv1...) hammered
+ * setPreferences at ~16 calls/min from 2026-04-30 04:20 UTC onward with
+ * a constant `actualSyncVersion: 20`, never refocusing the tab and so
+ * never triggering the reload. Adding visibilitychange + setInterval
+ * closes the gap.
+ *
+ * Returns a disposer function that clears the periodic timer (used in
+ * tests).
  */
 export function installStaleBundleCheck(options: StaleBundleCheckOptions = {}): () => void {
   const currentHash = options.currentHash ?? (typeof __BUILD_HASH__ !== 'undefined' ? __BUILD_HASH__ : 'dev');
@@ -52,9 +92,12 @@ export function installStaleBundleCheck(options: StaleBundleCheckOptions = {}): 
   const fetchImpl: typeof globalThis.fetch =
     options.fetch ?? ((...args) => globalThis.fetch(...args));
   const eventTarget = options.eventTarget ?? window;
+  const documentTarget = options.documentTarget ?? (typeof document !== 'undefined' ? document : undefined);
+  const setIntervalImpl = options.setInterval ?? ((cb: () => void, ms: number) => globalThis.setInterval(cb, ms));
   const reload = options.reload ?? (() => window.location.reload());
   const now = options.now ?? Date.now;
   const minIntervalMs = options.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
+  const periodicIntervalMs = options.periodicIntervalMs ?? DEFAULT_PERIODIC_INTERVAL_MS;
 
   // 'dev' marker means we're running a local build that didn't get a real
   // SHA injected. Skip the check entirely in that case — comparing 'dev'
@@ -86,7 +129,7 @@ export function installStaleBundleCheck(options: StaleBundleCheckOptions = {}): 
       }
     } catch {
       // Offline, network error, or non-OK response — silently skip.
-      // The next focus event will retry.
+      // The next trigger will retry.
     } finally {
       inflight = false;
     }
@@ -97,10 +140,25 @@ export function installStaleBundleCheck(options: StaleBundleCheckOptions = {}): 
   };
   eventTarget.addEventListener('focus', handler);
 
+  // visibilitychange fires when the tab becomes visible again. We only
+  // want to trigger on the visible side (not on hide), so gate with the
+  // documentTarget's visibilityState.
+  if (documentTarget) {
+    documentTarget.addEventListener('visibilitychange', () => {
+      if (documentTarget.visibilityState === 'visible') void check();
+    });
+  }
+
+  // Periodic safety net for background tabs that never receive
+  // focus/visibilitychange (e.g. pinned in a background window).
+  const intervalHandle = setIntervalImpl(() => void check(), periodicIntervalMs);
+
   return () => {
-    // Most production code doesn't need to dispose; this exists for tests.
-    // The DOM event-target API supports removeEventListener, but our
-    // EventTargetLike narrowing doesn't expose it — tests can swap
-    // eventTarget with a spy that handles disposal.
+    // Test disposer — clear the periodic timer. Window/document listeners
+    // are unmanageable through our narrow EventTargetLike type, but tests
+    // pass spies and don't need explicit removal.
+    if (intervalHandle && typeof clearInterval === 'function') {
+      clearInterval(intervalHandle as unknown as ReturnType<typeof setInterval>);
+    }
   };
 }

--- a/tests/stale-bundle-check.test.mts
+++ b/tests/stale-bundle-check.test.mts
@@ -49,10 +49,22 @@ function install(env: FakeEnv, currentHash = 'sha-running-bundle', minIntervalMs
       addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
         if (type === 'focus') env.focusListeners.push(listener as EventListener);
       },
+      removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === 'focus') {
+          const i = env.focusListeners.indexOf(listener as EventListener);
+          if (i !== -1) env.focusListeners.splice(i, 1);
+        }
+      },
     },
     documentTarget: {
       addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
         if (type === 'visibilitychange') env.visibilityListeners.push(listener as EventListener);
+      },
+      removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === 'visibilitychange') {
+          const i = env.visibilityListeners.indexOf(listener as EventListener);
+          if (i !== -1) env.visibilityListeners.splice(i, 1);
+        }
       },
       get visibilityState() { return env.visibilityState; },
     },
@@ -224,5 +236,32 @@ describe('installStaleBundleCheck', () => {
     env.clock.tick(10_000);
     await fireInterval(env);
     assert.equal(env.fetchCalls.length, 1, 'all three triggers within dedupe window must collapse to one fetch');
+  });
+
+  it('disposer fully removes focus + visibilitychange + interval (no orphaned listeners on double-install)', async () => {
+    // Greptile P2 fix: production calls installStaleBundleCheck once at
+    // boot. But hot-reload, test-helper reuse, or future code paths could
+    // double-install. The disposer must remove ALL three trigger paths so
+    // a re-install starts from a clean slate.
+    env.fetchResponse = { ok: true, status: 200, body: 'sha-running-bundle' };
+    const dispose = install(env);
+    assert.equal(env.focusListeners.length, 1, 'focus listener attached on install');
+    assert.equal(env.visibilityListeners.length, 1, 'visibility listener attached on install');
+    assert.equal(env.intervalCallbacks.length, 1, 'interval scheduled on install');
+
+    dispose();
+    assert.equal(env.focusListeners.length, 0, 'disposer removed focus listener');
+    assert.equal(env.visibilityListeners.length, 0, 'disposer removed visibility listener');
+    // intervalCallbacks isn't drained (clearInterval doesn't pop from our
+    // fake's callback array), but firing it post-disposal would still
+    // invoke it. The real `clearInterval` does prevent firing — and the
+    // production timer is the only thing the disposer needs to actually
+    // stop, since events past the disposal point can't reach removed
+    // listeners.
+
+    // After disposal, firing focus/visibility should NOT trigger fetch.
+    await fireFocus(env);
+    await fireVisibilityChange(env, 'visible');
+    assert.equal(env.fetchCalls.length, 0, 'no fetch after disposal — listeners truly removed');
   });
 });

--- a/tests/stale-bundle-check.test.mts
+++ b/tests/stale-bundle-check.test.mts
@@ -8,17 +8,24 @@ import { installStaleBundleCheck } from '../src/bootstrap/stale-bundle-check.ts'
 
 interface FakeEnv {
   focusListeners: Array<EventListener>;
+  visibilityListeners: Array<EventListener>;
+  intervalCallbacks: Array<() => void>;
   fetchCalls: Array<{ url: string; init?: RequestInit }>;
   fetchResponse: { ok: boolean; status: number; body: string };
   reloadCalls: number;
   clock: { value: number; tick(ms: number): void };
+  visibilityState: 'visible' | 'hidden';
 }
 
 function makeEnv(initial: Partial<{ ok: boolean; status: number; body: string }> = {}): FakeEnv {
   const focusListeners: Array<EventListener> = [];
+  const visibilityListeners: Array<EventListener> = [];
+  const intervalCallbacks: Array<() => void> = [];
   const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
   return {
     focusListeners,
+    visibilityListeners,
+    intervalCallbacks,
     fetchCalls,
     fetchResponse: {
       ok: initial.ok ?? true,
@@ -30,6 +37,7 @@ function makeEnv(initial: Partial<{ ok: boolean; status: number; body: string }>
       value: 1_000_000,
       tick(ms: number) { this.value += ms; },
     },
+    visibilityState: 'visible',
   };
 }
 
@@ -39,11 +47,18 @@ function install(env: FakeEnv, currentHash = 'sha-running-bundle', minIntervalMs
     minIntervalMs,
     eventTarget: {
       addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
-        if (type === 'focus') {
-          // Normalize to EventListener for our test (object-form unused)
-          env.focusListeners.push(listener as EventListener);
-        }
+        if (type === 'focus') env.focusListeners.push(listener as EventListener);
       },
+    },
+    documentTarget: {
+      addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === 'visibilitychange') env.visibilityListeners.push(listener as EventListener);
+      },
+      get visibilityState() { return env.visibilityState; },
+    },
+    setInterval: (cb: () => void, _ms: number) => {
+      env.intervalCallbacks.push(cb);
+      return env.intervalCallbacks.length; // dummy handle
     },
     fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
@@ -60,11 +75,25 @@ async function fireFocus(env: FakeEnv): Promise<void> {
   for (const listener of [...env.focusListeners]) {
     listener(new Event('focus'));
   }
-  // The handler awaits an inner async fn but we triggered it synchronously;
-  // give the microtask queue a turn to drain so fetch/reload assertions
-  // observe their calls.
+  // Drain microtasks so fetch/reload assertions observe the inner async work.
   await new Promise((resolve) => setTimeout(resolve, 0));
-  // Plus an extra tick because the fetch promise + .text() chain.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function fireVisibilityChange(env: FakeEnv, state: 'visible' | 'hidden'): Promise<void> {
+  env.visibilityState = state;
+  for (const listener of [...env.visibilityListeners]) {
+    listener(new Event('visibilitychange'));
+  }
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function fireInterval(env: FakeEnv): Promise<void> {
+  for (const cb of [...env.intervalCallbacks]) {
+    cb();
+  }
+  await new Promise((resolve) => setTimeout(resolve, 0));
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
@@ -151,5 +180,49 @@ describe('installStaleBundleCheck', () => {
     install(env);
     await fireFocus(env);
     assert.equal(env.reloadCalls, 0, 'trimmed hash equals current → no reload');
+  });
+
+  // PR #3499 follow-up — installStaleBundleCheck initially listened on
+  // window 'focus' only. One stuck-bundle user (Sentry user_3Cu7uZZJ...)
+  // hammered setPreferences with constant actualSyncVersion=20 because
+  // their tab was pinned in the background and never received focus →
+  // stale-bundle-check never fired → bundle never reloaded. Adding
+  // visibilitychange + setInterval closes that gap.
+
+  it('reloads when document becomes visible (background-tab safety net)', async () => {
+    env.fetchResponse = { ok: true, status: 200, body: 'sha-newer-deploy' };
+    install(env);
+    await fireVisibilityChange(env, 'visible');
+    assert.equal(env.fetchCalls.length, 1, 'visibilitychange to visible should trigger check');
+    assert.equal(env.reloadCalls, 1);
+  });
+
+  it('does NOT trigger check on visibilitychange when going to hidden', async () => {
+    env.fetchResponse = { ok: true, status: 200, body: 'sha-newer-deploy' };
+    install(env);
+    // Tab going INTO background — useless to check (reload would be lost).
+    // Only the visible transition should fire the check.
+    await fireVisibilityChange(env, 'hidden');
+    assert.equal(env.fetchCalls.length, 0, 'hidden transition must not fetch');
+  });
+
+  it('reloads when periodic interval fires (catches background tabs that never visibility-change)', async () => {
+    env.fetchResponse = { ok: true, status: 200, body: 'sha-newer-deploy' };
+    install(env);
+    // Simulate the setInterval firing.
+    await fireInterval(env);
+    assert.equal(env.fetchCalls.length, 1, 'periodic timer should trigger check');
+    assert.equal(env.reloadCalls, 1);
+  });
+
+  it('all three triggers (focus / visibility / interval) collapse via the same dedupe window', async () => {
+    env.fetchResponse = { ok: true, status: 200, body: 'sha-running-bundle' };
+    install(env, 'sha-running-bundle', 60_000);
+    await fireFocus(env);
+    env.clock.tick(10_000); // <60s
+    await fireVisibilityChange(env, 'visible');
+    env.clock.tick(10_000);
+    await fireInterval(env);
+    assert.equal(env.fetchCalls.length, 1, 'all three triggers within dedupe window must collapse to one fetch');
   });
 });


### PR DESCRIPTION
## Summary

PR #3499's stale-bundle reload mechanism listened on `window 'focus'` only. **`focus` doesn't fire on background tabs** that never come to the foreground — so a user who keeps WorldMonitor pinned in a background tab never triggers the bundle-hash check, never reloads, and stays stuck on a stale bundle indefinitely.

## Live evidence

One user (Sentry user_id `user_3Cu7uZZJEeVSoUjv9SBn4BEv1...`) currently hammering `setPreferences` at ~16 calls/min, all with `actualSyncVersion: 20` constant — textbook stuck-bundle pattern:

```
2026-04-30T05:44:13  user=user_3Cu7uZZJ...  actual_sync_version=20
2026-04-30T05:44:12  user=user_3Cu7uZZJ...  actual_sync_version=20
2026-04-30T05:44:01  user=user_3Cu7uZZJ...  actual_sync_version=20
... (continuing every few seconds)
```

PR 1's mechanism itself is healthy — `/build-hash.txt` serves `4fb1d557c5c5bc90a68b250b0aa0872e41f99781` (the current production SHA) correctly. The gap is on the trigger side: `focus` is the wrong-only event for background tabs.

## Fix

Three trigger paths now, all funnelling through the same dedupe-protected `check()`:

| Trigger | Catches |
|---|---|
| window `focus` (existing) | User switches BACK to the tab |
| document `visibilitychange` to `'visible'` (new) | Tab-activation transitions within the same window that don't raise `focus` |
| `setInterval` (10 min default, new) | Pinned background tabs that never receive focus or visibility events |

Browser background-tab throttling caps `setInterval` at ~1 min in practice — 10 min default respects that ceiling and is plenty for stale-bundle detection (we don't need second-level latency to reload an old bundle).

All triggers funnel through `check()` which has a 60s dedupe window — multiple triggers within that window collapse to one fetch.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx biome lint src/bootstrap/stale-bundle-check.ts tests/stale-bundle-check.test.mts` — clean
- [x] `npx tsx --test tests/stale-bundle-check.test.mts` — **13/13 pass** (4 new):
  - reloads when document becomes visible
  - does NOT trigger check on visibilitychange to hidden
  - reloads when periodic interval fires
  - all three triggers collapse via the same dedupe window
- [x] All 9 existing tests pass unchanged

## Verification post-deploy

Sentry: query `error_shape:setPreferences_conflict` grouped by `user_id`. The currently-stuck user (top user with constant `actual_sync_version: 20`) should drain off within 10 minutes of the deploy as the periodic interval forces the reload.