### PR TITLE
fix(widget-agent): accept Convex entitlement tier>=1 for paid users

### DIFF
--- a/api/widget-agent.ts
+++ b/api/widget-agent.ts
@@ -20,6 +20,7 @@ export const config = { runtime: 'edge' };
 // @ts-expect-error — JS module, no declaration file
 import { getCorsHeaders } from './_cors.js';
 import { validateBearerToken } from '../server/auth-session';
+import { getEntitlements } from '../server/_shared/entitlement-check';
 
 const RELAY_BASE = 'https://proxy.worldmonitor.app';
 const WIDGET_AGENT_KEY = process.env.WIDGET_AGENT_KEY ?? '';
@@ -68,12 +69,30 @@ export default async function handler(req: Request): Promise<Response> {
   } else {
     const authHeader = req.headers.get('Authorization');
     if (authHeader?.startsWith('Bearer ')) {
-      // Clerk JWT path (web users with active subscription)
+      // Clerk JWT path (web users with active subscription).
+      //
+      // Accept EITHER a Clerk 'pro' role OR a Convex Dodo entitlement with
+      // tier >= 1. The Dodo webhook pipeline writes Convex entitlements but
+      // does NOT sync Clerk publicMetadata.plan, so a paying subscriber's
+      // session.role stays 'free' indefinitely (panel-gating.ts:11-27 documents
+      // the same split at the frontend layer). A Clerk-role-only check here
+      // would 403 every paying user despite a valid Dodo subscription, with
+      // the modal then surfacing a misleading "PRO key rejected. Update
+      // wm-pro-key…" message — these users have no tester key.
+      //
+      // This mirrors server/gateway.ts:521-526 (legacy bearer path) and
+      // server/_shared/premium-check.ts::isCallerPremium so every Pro gate
+      // agrees on who is premium.
       const session = await validateBearerToken(authHeader.slice(7));
       if (!session.valid) {
         return json({ error: 'Invalid or expired session' }, 401, corsHeaders);
       }
-      if (session.role !== 'pro') {
+      let allowed = session.role === 'pro';
+      if (!allowed && session.userId) {
+        const ent = await getEntitlements(session.userId);
+        allowed = !!ent && ent.features.tier >= 1;
+      }
+      if (!allowed) {
         return json({ error: 'Pro subscription required' }, 403, corsHeaders);
       }
       isPro = true;

--- a/api/widget-agent.ts
+++ b/api/widget-agent.ts
@@ -88,11 +88,33 @@ export default async function handler(req: Request): Promise<Response> {
         return json({ error: 'Invalid or expired session' }, 401, corsHeaders);
       }
       let allowed = session.role === 'pro';
+      let entitlementChecked = false;
+      let entitlementTier: number | null = null;
       if (!allowed && session.userId) {
         const ent = await getEntitlements(session.userId);
+        entitlementChecked = true;
+        entitlementTier = ent ? ent.features.tier : null;
         allowed = !!ent && ent.features.tier >= 1;
       }
       if (!allowed) {
+        // Structured log so on-call can distinguish two distinct 403 causes
+        // sharing one user-facing message:
+        //   reason=not_entitled      — Convex returned a row, tier < 1 (real free user)
+        //   reason=service_unavailable — entitlement lookup returned null
+        //                                (Convex unreachable / Redis trouble / cache miss + Convex down).
+        //                                The latter blocks paying users during outages —
+        //                                grep these in Vercel logs to trigger an incident
+        //                                instead of waiting for refund tickets.
+        const reason = entitlementChecked && entitlementTier === null
+          ? 'service_unavailable'
+          : 'not_entitled';
+        console.warn('[widget-agent] 403 pro-required', JSON.stringify({
+          reason,
+          userId: session.userId ?? null,
+          clerkRole: session.role ?? null,
+          entitlementChecked,
+          entitlementTier,
+        }));
         return json({ error: 'Pro subscription required' }, 403, corsHeaders);
       }
       isPro = true;

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -147,8 +147,23 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
     const result = await response.json() as CachedEntitlements | null;
 
     if (result) {
-      // Populate Redis cache for subsequent requests (15-min TTL, raw key)
-      await setCachedJson(`entitlements:${ENV_PREFIX}:${userId}`, result, ENTITLEMENT_CACHE_TTL_SECONDS, true);
+      // Populate Redis cache for subsequent requests (15-min TTL, raw key).
+      //
+      // Cache-write failures must NOT collapse "entitlement confirmed by Convex"
+      // into the null-means-no-entitlement return. Today setCachedJson swallows
+      // its own Upstash errors via an internal try/catch (server/_shared/redis.ts),
+      // but that contract is fragile — the tauri-sidecar dynamic import path at
+      // redis.ts:142-146 is OUTSIDE the inner try/catch, and any future code
+      // motion could let other errors propagate. Wrap explicitly here so the
+      // property "Convex said yes ⇒ caller sees yes" is local and load-bearing.
+      // Without this, an Upstash hiccup would 403 every paying customer on the
+      // very call paths this file gates — the same shape PR #3505 fixed for the
+      // Clerk-only-no-Convex outlier in api/widget-agent.ts.
+      try {
+        await setCachedJson(`entitlements:${ENV_PREFIX}:${userId}`, result, ENTITLEMENT_CACHE_TTL_SECONDS, true);
+      } catch (cacheErr) {
+        console.warn('[entitlement-check] cache write failed (non-fatal):', cacheErr instanceof Error ? cacheErr.message : String(cacheErr));
+      }
       return result as CachedEntitlements;
     }
 

--- a/src/components/WidgetChatModal.ts
+++ b/src/components/WidgetChatModal.ts
@@ -44,7 +44,16 @@ let overlay: HTMLElement | null = null;
 let abortController: AbortController | null = null;
 let clientTimeout: ReturnType<typeof setTimeout> | null = null;
 
-async function buildWidgetAuthHeaders(isPro: boolean): Promise<Record<string, string>> {
+interface BuiltAuthHeaders {
+  headers: Record<string, string>;
+  /** True when the request is authenticated with a tester key (wm-widget-key /
+   *  wm-pro-key / wm-worldmonitor-key) rather than a Clerk JWT. Used to pick
+   *  the right 403 error message — the "Update wm-pro-key" hint is misleading
+   *  for normal paying users who have no tester key. */
+  usedTesterKey: boolean;
+}
+
+async function buildWidgetAuthHeaders(isPro: boolean): Promise<BuiltAuthHeaders> {
   const testerKey = getBrowserTesterKey();
   const widgetKey = getWidgetAgentKey();
   const proKey = getProWidgetKey();
@@ -53,11 +62,11 @@ async function buildWidgetAuthHeaders(isPro: boolean): Promise<Record<string, st
     if (testerKey) headers['X-WorldMonitor-Key'] = testerKey;
     if (widgetKey) headers['X-Widget-Key'] = widgetKey;
     if (isPro && proKey) headers['X-Pro-Key'] = proKey;
-    return headers;
+    return { headers, usedTesterKey: true };
   }
   const token = await getClerkToken();
-  if (token) return { 'Authorization': `Bearer ${token}` };
-  return {};
+  if (token) return { headers: { 'Authorization': `Bearer ${token}` }, usedTesterKey: false };
+  return { headers: {}, usedTesterKey: false };
 }
 
 export function openWidgetChatModal(options: WidgetChatOptions): void {
@@ -159,13 +168,13 @@ export function openWidgetChatModal(options: WidgetChatOptions): void {
   async function runPreflight(): Promise<void> {
     setReadinessState(readinessEl, 'checking', t('widgets.checkingConnection'));
     try {
-      const headers = await buildWidgetAuthHeaders(isPro);
-      const res = await fetch(widgetAgentHealthUrl(), { headers });
+      const auth = await buildWidgetAuthHeaders(isPro);
+      const res = await fetch(widgetAgentHealthUrl(), { headers: auth.headers });
       let payload: WidgetAgentHealth | null = null;
       try { payload = await res.json() as WidgetAgentHealth; } catch { /* ignore */ }
 
       if (!res.ok) {
-        const message = resolvePreflightMessage(res.status, payload, isPro);
+        const message = resolvePreflightMessage(res.status, payload, isPro, auth.usedTesterKey);
         preflightReady = false;
         setReadinessState(readinessEl, 'error', message);
         setFooterStatus(footerStatusEl, message, 'error');
@@ -240,9 +249,10 @@ export function openWidgetChatModal(options: WidgetChatOptions): void {
     }, timeoutMs);
 
     try {
+      const auth = await buildWidgetAuthHeaders(isPro);
       const reqHeaders: Record<string, string> = {
         'Content-Type': 'application/json',
-        ...(await buildWidgetAuthHeaders(isPro)),
+        ...auth.headers,
       };
 
       const res = await fetch(widgetAgentUrl(), {
@@ -386,8 +396,19 @@ function renderExampleChips(container: HTMLElement, inputEl: HTMLTextAreaElement
   }
 }
 
-function resolvePreflightMessage(status: number, payload: WidgetAgentHealth | null, isPro: boolean): string {
-  if (status === 403) return isPro ? t('widgets.preflightInvalidProKey') : t('widgets.preflightInvalidKey');
+function resolvePreflightMessage(
+  status: number,
+  payload: WidgetAgentHealth | null,
+  isPro: boolean,
+  usedTesterKey: boolean,
+): string {
+  if (status === 403) {
+    // Tester-key path: tell the operator to update the wm-*-key they actually have.
+    // Clerk-auth path (normal paying users): they have no tester key — recommending
+    // "Update wm-pro-key" sends them down a dead end. Surface a Pro-required message.
+    if (usedTesterKey) return isPro ? t('widgets.preflightInvalidProKey') : t('widgets.preflightInvalidKey');
+    return t('widgets.preflightProSubscriptionRequired');
+  }
   if (status === 503 && payload?.proKeyConfigured === false) return t('widgets.preflightProUnavailable');
   if (payload?.anthropicConfigured === false) return t('widgets.preflightAiUnavailable');
   return t('widgets.preflightUnavailable');

--- a/src/components/WidgetChatModal.ts
+++ b/src/components/WidgetChatModal.ts
@@ -404,10 +404,16 @@ function resolvePreflightMessage(
 ): string {
   if (status === 403) {
     // Tester-key path: tell the operator to update the wm-*-key they actually have.
-    // Clerk-auth path (normal paying users): they have no tester key — recommending
-    // "Update wm-pro-key" sends them down a dead end. Surface a Pro-required message.
     if (usedTesterKey) return isPro ? t('widgets.preflightInvalidProKey') : t('widgets.preflightInvalidKey');
-    return t('widgets.preflightProSubscriptionRequired');
+    // Clerk-auth path: split on isPro.
+    //   isPro=true  — the modal believes the user is Pro; a 403 means either
+    //                 (a) they just upgraded (entitlement still propagating)
+    //                 or (b) the entitlement service is degraded. Tell them to
+    //                 refresh / contact support.
+    //   isPro=false — a free user reached a Pro action; "contact support" is
+    //                 wrong, they need to upgrade. Surface a clean upgrade ask
+    //                 without the "just upgraded" language.
+    return isPro ? t('widgets.preflightProSubscriptionRequired') : t('widgets.preflightProRequired');
   }
   if (status === 503 && payload?.proKeyConfigured === false) return t('widgets.preflightProUnavailable');
   if (payload?.anthropicConfigured === false) return t('widgets.preflightAiUnavailable');

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -51,6 +51,7 @@
     "proBadge": "PRO",
     "preflightProUnavailable": "PRO widget agent unavailable. Check PRO_WIDGET_KEY on the server.",
     "preflightInvalidProKey": "PRO key rejected. Update wm-pro-key and reload.",
+    "preflightProSubscriptionRequired": "Pro subscription required. If you just upgraded, refresh the page; otherwise contact support.",
     "examples": {
       "oilGold": "Show me today's crude oil price versus gold",
       "cryptoMovers": "Create a widget for the top crypto movers in the last 24 hours",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -52,6 +52,7 @@
     "preflightProUnavailable": "PRO widget agent unavailable. Check PRO_WIDGET_KEY on the server.",
     "preflightInvalidProKey": "PRO key rejected. Update wm-pro-key and reload.",
     "preflightProSubscriptionRequired": "Pro subscription required. If you just upgraded, refresh the page; otherwise contact support.",
+    "preflightProRequired": "Pro subscription required to use the Widget Builder. Upgrade to unlock.",
     "examples": {
       "oilGold": "Show me today's crude oil price versus gold",
       "cryptoMovers": "Create a widget for the top crypto movers in the last 24 hours",

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1296,3 +1296,87 @@ describe('PRO widget — i18n keys and CSS', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// PRO widget — edge-proxy auth (Convex entitlement fallback for paid users)
+// ---------------------------------------------------------------------------
+//
+// Dodo webhook does NOT sync Clerk publicMetadata.plan, so a paying subscriber's
+// Clerk session.role stays 'free' indefinitely. The edge proxy at
+// api/widget-agent.ts must accept EITHER Clerk role==='pro' OR Convex
+// entitlement tier>=1, mirroring server/_shared/premium-check.ts::isCallerPremium
+// and server/gateway.ts:521-526. A regression here surfaces as a misleading
+// "PRO key rejected. Update wm-pro-key…" 403 in the modal — the user has no
+// tester key, so the suggested action is a dead end.
+describe('widget-agent edge proxy — Convex entitlement fallback', () => {
+  const edge = src('api/widget-agent.ts');
+
+  it('imports getEntitlements from server/_shared/entitlement-check', () => {
+    assert.ok(
+      /import\s*\{[^}]*\bgetEntitlements\b[^}]*\}\s*from\s*['"][^'"]*entitlement-check['"]/.test(edge),
+      'api/widget-agent.ts must import getEntitlements for Dodo entitlement fallback',
+    );
+  });
+
+  it('Clerk JWT path falls back to Convex entitlement when role !== "pro"', () => {
+    const bearerIdx = edge.indexOf("authHeader?.startsWith('Bearer ')");
+    assert.ok(bearerIdx !== -1, 'Bearer-token branch not found in api/widget-agent.ts');
+    // Constrain the search to the bearer-token branch only.
+    const region = edge.slice(bearerIdx, bearerIdx + 2000);
+    assert.ok(
+      region.includes('getEntitlements(session.userId)'),
+      'Bearer-token branch must call getEntitlements(session.userId) when Clerk role !== "pro"',
+    );
+    assert.ok(
+      /features\.tier\s*>=\s*1/.test(region),
+      'Bearer-token branch must accept Convex entitlement tier >= 1',
+    );
+  });
+
+  it('does NOT 403 immediately on session.role !== "pro"', () => {
+    // The legacy shape `if (session.role !== 'pro') return 403` is the bug —
+    // it would short-circuit before the Convex fallback. Lock it out.
+    assert.ok(
+      !/if\s*\(\s*session\.role\s*!==\s*['"]pro['"]\s*\)\s*\{\s*return\s+json\([^}]*403/.test(edge),
+      'api/widget-agent.ts must NOT 403 on session.role !== "pro" without checking Convex entitlement',
+    );
+  });
+});
+
+describe('WidgetChatModal — preflight 403 message branches on auth mode', () => {
+  const modal = src('src/components/WidgetChatModal.ts');
+  const en = JSON.parse(src('src/locales/en.json'));
+
+  it('buildWidgetAuthHeaders returns usedTesterKey flag', () => {
+    assert.ok(
+      modal.includes('usedTesterKey'),
+      'buildWidgetAuthHeaders must report whether a tester key was used so the 403 message can branch',
+    );
+  });
+
+  it('resolvePreflightMessage takes usedTesterKey and uses preflightProSubscriptionRequired for Clerk path', () => {
+    const fnIdx = modal.indexOf('function resolvePreflightMessage');
+    assert.ok(fnIdx !== -1, 'resolvePreflightMessage not found');
+    const region = modal.slice(fnIdx, fnIdx + 800);
+    assert.ok(
+      region.includes('usedTesterKey'),
+      'resolvePreflightMessage must take usedTesterKey to branch on auth mode',
+    );
+    assert.ok(
+      region.includes('preflightProSubscriptionRequired'),
+      'Clerk-auth 403 must surface preflightProSubscriptionRequired (not the wm-pro-key tester message)',
+    );
+  });
+
+  it('en.json defines widgets.preflightProSubscriptionRequired', () => {
+    assert.ok(
+      typeof en.widgets?.preflightProSubscriptionRequired === 'string'
+        && en.widgets.preflightProSubscriptionRequired.length > 0,
+      'en.json must define widgets.preflightProSubscriptionRequired',
+    );
+    assert.ok(
+      !/wm-pro-key/i.test(en.widgets.preflightProSubscriptionRequired),
+      'preflightProSubscriptionRequired must not mention wm-pro-key — Clerk users have no tester key',
+    );
+  });
+});

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1416,21 +1416,25 @@ describe('WidgetChatModal — preflight 403 message branches on auth mode', () =
     );
   });
 
-  it('resolvePreflightMessage takes usedTesterKey and uses preflightProSubscriptionRequired for Clerk path', () => {
+  it('resolvePreflightMessage takes usedTesterKey and branches Clerk path on isPro', () => {
     const fnIdx = modal.indexOf('function resolvePreflightMessage');
     assert.ok(fnIdx !== -1, 'resolvePreflightMessage not found');
-    const region = modal.slice(fnIdx, fnIdx + 800);
+    const region = modal.slice(fnIdx, fnIdx + 1200);
     assert.ok(
       region.includes('usedTesterKey'),
       'resolvePreflightMessage must take usedTesterKey to branch on auth mode',
     );
     assert.ok(
       region.includes('preflightProSubscriptionRequired'),
-      'Clerk-auth 403 must surface preflightProSubscriptionRequired (not the wm-pro-key tester message)',
+      'Clerk-auth 403 (isPro=true) must surface preflightProSubscriptionRequired',
+    );
+    assert.ok(
+      region.includes('preflightProRequired'),
+      'Clerk-auth 403 (isPro=false, free user) must surface preflightProRequired (clean upgrade ask, no "just upgraded" language)',
     );
   });
 
-  it('en.json defines widgets.preflightProSubscriptionRequired', () => {
+  it('en.json defines widgets.preflightProSubscriptionRequired (just-upgraded / outage)', () => {
     assert.ok(
       typeof en.widgets?.preflightProSubscriptionRequired === 'string'
         && en.widgets.preflightProSubscriptionRequired.length > 0,
@@ -1439,6 +1443,53 @@ describe('WidgetChatModal — preflight 403 message branches on auth mode', () =
     assert.ok(
       !/wm-pro-key/i.test(en.widgets.preflightProSubscriptionRequired),
       'preflightProSubscriptionRequired must not mention wm-pro-key — Clerk users have no tester key',
+    );
+  });
+
+  it('en.json defines widgets.preflightProRequired (free-user upgrade ask, no "just upgraded" language)', () => {
+    assert.ok(
+      typeof en.widgets?.preflightProRequired === 'string'
+        && en.widgets.preflightProRequired.length > 0,
+      'en.json must define widgets.preflightProRequired',
+    );
+    assert.ok(
+      !/wm-pro-key/i.test(en.widgets.preflightProRequired),
+      'preflightProRequired must not mention wm-pro-key',
+    );
+    assert.ok(
+      !/just upgraded|refresh the page|contact support/i.test(en.widgets.preflightProRequired),
+      'preflightProRequired is for genuinely-free users — must not include "just upgraded / refresh / contact support" language',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// widget-agent edge proxy — observability for fail-closed entitlement 403s
+// ---------------------------------------------------------------------------
+//
+// When getEntitlements returns null, callers can't tell "user genuinely not
+// entitled" from "entitlement service degraded" — both shapes 403 paying users
+// during a Convex/Upstash outage. Emit a structured log at the 403 site so
+// on-call can grep Vercel logs and disambiguate incident vs not-entitled
+// without waiting for refund tickets.
+describe('widget-agent edge proxy — fail-closed observability', () => {
+  const edge = src('api/widget-agent.ts');
+
+  it('403 site emits a structured log with reason + userId + entitlementTier', () => {
+    const idx = edge.indexOf("error: 'Pro subscription required'");
+    assert.ok(idx !== -1, 'Pro-required 403 site not found');
+    // Walk backward from the 403 to find the preceding console.warn — must
+    // sit in the same allowed-check block, not in some unrelated error path.
+    const before = edge.slice(Math.max(0, idx - 1500), idx);
+    assert.ok(
+      /console\.warn\([^)]*widget-agent[^)]*pro-required/i.test(before),
+      'A console.warn naming "widget-agent" + "pro-required" must precede the 403 return',
+    );
+    assert.ok(before.includes('reason'), 'Structured log must include "reason" field (not_entitled vs service_unavailable)');
+    assert.ok(before.includes('userId'), 'Structured log must include userId for grep/correlation');
+    assert.ok(
+      before.includes('service_unavailable') && before.includes('not_entitled'),
+      'Structured log must distinguish service_unavailable (Convex/Redis down) from not_entitled (real free user)',
     );
   });
 });

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1343,6 +1343,68 @@ describe('widget-agent edge proxy — Convex entitlement fallback', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// entitlement-check — cache-write failure must NOT collapse to "no entitlement"
+// ---------------------------------------------------------------------------
+//
+// getEntitlements() returns null on three different failure modes — Convex
+// said no, Convex unreachable, and (the trap this test guards) cache-write
+// failed AFTER Convex confirmed the entitlement. Once Convex returns a valid
+// entitlement, an Upstash hiccup or any error inside setCachedJson must NOT
+// turn that yes into a null-meaning-no — that would 403 paying customers on
+// every call path this file gates, including the widget-agent fallback PR
+// #3505 just added.
+describe('entitlement-check — cache-write failure does not collapse confirmed entitlement', () => {
+  const src_ = src('server/_shared/entitlement-check.ts');
+
+  it('setCachedJson call is wrapped in its own try/catch', () => {
+    // Find the success-path block: `if (result) { … setCachedJson(…) … return result }`
+    const successIdx = src_.indexOf('if (result) {');
+    assert.ok(successIdx !== -1, 'success-path "if (result)" branch not found');
+    const region = src_.slice(successIdx, successIdx + 1500);
+
+    const setIdx = region.indexOf('setCachedJson(');
+    assert.ok(setIdx !== -1, 'setCachedJson call missing from success path');
+
+    // Walk backward from setCachedJson to find the nearest enclosing `try {`
+    // BEFORE the outer catch. The outer try is at the top of the function,
+    // far away — we want a LOCAL try/catch around the cache write so the
+    // safety property is explicit at the call site.
+    const beforeSet = region.slice(0, setIdx);
+    const lastTry = beforeSet.lastIndexOf('try {');
+    const lastCatch = beforeSet.lastIndexOf('catch');
+    assert.ok(
+      lastTry !== -1 && lastTry > lastCatch,
+      'setCachedJson must be inside a LOCAL try/catch within the success branch — relying on setCachedJson to swallow its own errors is fragile',
+    );
+
+    // The success-path return must come AFTER the try/catch, not inside the catch.
+    const returnIdx = region.indexOf('return result', setIdx);
+    assert.ok(
+      returnIdx !== -1,
+      '`return result` must follow the cache-write try/catch so a swallowed cache error still returns the confirmed entitlement',
+    );
+  });
+
+  it('cache-write catch logs but does not return null or throw', () => {
+    const successIdx = src_.indexOf('if (result) {');
+    const region = src_.slice(successIdx, successIdx + 1500);
+    // The catch block for cache write must NOT contain `return null` — that
+    // would re-introduce the bug. It also must not rethrow.
+    const cacheCatchMatch = region.match(/catch\s*\(\s*cacheErr[^)]*\)\s*\{([^}]*)\}/);
+    assert.ok(cacheCatchMatch, 'cache-write catch block must be named distinctly (e.g. cacheErr) so future readers see the intent');
+    const cacheCatchBody = cacheCatchMatch[1];
+    assert.ok(
+      !/return\s+null/.test(cacheCatchBody),
+      'cache-write catch must NOT return null — a confirmed entitlement must survive cache-write failure',
+    );
+    assert.ok(
+      !/throw\b/.test(cacheCatchBody),
+      'cache-write catch must NOT rethrow — that would bubble to the outer catch and collapse to null',
+    );
+  });
+});
+
 describe('WidgetChatModal — preflight 403 message branches on auth mode', () => {
   const modal = src('src/components/WidgetChatModal.ts');
   const en = JSON.parse(src('src/locales/en.json'));


### PR DESCRIPTION
## Why

Paying Dodo subscribers reported being blocked from the Widget Builder with a misleading **"PRO key rejected. Update wm-pro-key and reload."** error — the panel was visible to them, but every preflight 403'd.

## Root cause

`api/widget-agent.ts:76` validated the Clerk JWT and rejected with 403 whenever `session.role !== 'pro'`. But our Dodo webhook pipeline never syncs Clerk `publicMetadata.plan`, so every paying subscriber's `session.role` stays `'free'` indefinitely.

This is the same shape as the 2026-04-17/18 duplicate-subscription incident documented at `src/services/panel-gating.ts:11-27` — that incident fixed the **frontend** dual-signal (`isProUser()` now folds in `isEntitled()`), but the same fix was never propagated to the **server-side** widget-agent edge auth.

## Sweep result

I audited every `validateBearerToken` caller. **Widget-agent was the lone outlier.** Every other Pro-gated endpoint already does the dual signal (Clerk role OR Convex tier ≥ 1):

| Endpoint | Status |
|---|---|
| `api/widget-agent.ts` | ❌ Clerk-only (this PR) |
| `api/latest-brief.ts:141` | ✅ uses `getEntitlements` |
| `api/notify.ts:48` | ✅ |
| `api/notification-channels.ts:217` | ✅ |
| `api/discord/oauth/start.ts:51` | ✅ |
| `api/slack/oauth/start.ts:51` | ✅ |
| `api/brief/share-url.ts:95` | ✅ |
| `api/me/entitlement.ts` | ✅ via `isCallerPremium` |
| `server/gateway.ts:521-526` | ✅ legacy bearer path (has the 13-line comment documenting the pattern) |
| `server/_shared/premium-check.ts` | ✅ canonical `isCallerPremium` |

## Fix

1. **`api/widget-agent.ts`** — accept EITHER `session.role === 'pro'` OR Convex entitlement `tier >= 1`. Mirrors `server/gateway.ts:521-526` and `premium-check.ts::isCallerPremium` exactly.

2. **`src/components/WidgetChatModal.ts`** — `WidgetChatModal.ts:390` surfaced "Update wm-pro-key" on any 403 regardless of auth mode. For Clerk-authenticated users (normal paying customers) the wm-pro-key tester key doesn't exist, so the suggested action was a dead end. `buildWidgetAuthHeaders` now reports `usedTesterKey`, and `resolvePreflightMessage` branches on it to surface a new locale string `widgets.preflightProSubscriptionRequired` for the Clerk path. The wm-pro-key message stays for the tester-key path where it is still actionable.

## Test plan

- [x] `node --test tests/widget-builder.test.mjs` — 187/187 pass (added 6 new regression tests)
- [x] `npx tsx --test tests/widget-agent-auth.test.mts` — 3/3 pass (no regression on existing edge-proxy auth tests)
- [x] `tsc --noEmit` — clean
- [x] `biome lint` on changed files — clean (one pre-existing complexity warning unchanged)
- [ ] Manual verification: a paying Dodo subscriber whose Clerk publicMetadata.plan is `undefined` should now reach the Widget Builder preflight green-state.
- [ ] Manual verification: a free user should still see a Pro-required message (not the misleading "Update wm-pro-key").
- [ ] Manual verification: tester-key flow (wm-pro-key, wm-widget-key, wm-worldmonitor-key) unchanged.