### PR TITLE
fix(sentry): downgrade setPreferences CONFLICT capture to level=warning

### DIFF
--- a/api/_sentry-common.js
+++ b/api/_sentry-common.js
@@ -67,10 +67,17 @@ function buildEnvelope(err, ctx, runtimeCfg) {
   const eventId = crypto.randomUUID().replace(/-/g, '');
   const timestamp = new Date().toISOString();
 
+  // Caller may downgrade level for expected-but-still-trackable conditions
+  // (e.g. optimistic-concurrency CONFLICT from multi-tab sync — the capture
+  // exists to surface stuck-bundle users by user_id distribution, but at
+  // 'error' level it drowns real bugs in dashboards/alerting).
+  const level = ctx?.level === 'warning' || ctx?.level === 'info' || ctx?.level === 'fatal'
+    ? ctx.level
+    : 'error';
   const event = {
     event_id: eventId,
     timestamp,
-    level: 'error',
+    level,
     platform: runtimeCfg.platform,
     environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'production',
     release: process.env.VERCEL_GIT_COMMIT_SHA,

--- a/api/_sentry-common.js
+++ b/api/_sentry-common.js
@@ -54,10 +54,16 @@ function parseStack(stack) {
  *   tags?: Record<string, string|number|boolean>,
  *   extra?: Record<string, unknown>,
  *   fingerprint?: string[],
+ *   level?: 'warning' | 'info' | 'error' | 'fatal',
  * }} [ctx] When `fingerprint` is a non-empty array it overrides Sentry's
  *   default message-based grouping. Use to consolidate one logical issue
  *   whose error message contains a high-cardinality token (request id,
  *   trace id) that would otherwise fragment grouping into N issues.
+ *   `level` defaults to `'error'`; pass `'warning'` for expected-but-
+ *   trackable conditions (e.g. optimistic-concurrency CONFLICT) so the
+ *   capture stays queryable in the dashboard but doesn't count toward
+ *   error totals or page on-call. Values other than the four listed
+ *   above are ignored and the default `'error'` is used.
  * @param {{ runtime: 'edge' | 'node', platform: 'javascript' | 'node' }} runtimeCfg
  */
 function buildEnvelope(err, ctx, runtimeCfg) {

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -219,6 +219,13 @@ function handleConflictResponse(
   },
 ): Response {
   const actualSyncVersion = readConvexErrorNumber(err, 'actualSyncVersion');
+  // CONFLICT is an EXPECTED outcome of optimistic concurrency (multi-tab
+  // / multi-device sync, or a stuck-bundle user retrying with an old
+  // expectedSyncVersion). The capture exists to surface stuck-bundle
+  // users via user_id distribution (see WORLDMONITOR-PX 2026-04-30:
+  // 316 events / 59 users at 18 distinct actualSyncVersions). At
+  // level=error it drowned real bugs; level=warning keeps it queryable
+  // in Sentry but drops it out of error totals and alerting.
   captureSilentError(err, buildSentryContext(err, msg, {
     method: 'POST',
     convexFn: 'userPreferences:setPreferences',
@@ -230,6 +237,7 @@ function handleConflictResponse(
     blobSize: opts.blobSize,
     errorShapeOverride: 'setPreferences_conflict',
     extraTags: actualSyncVersion !== undefined ? { actual_sync_version: actualSyncVersion } : undefined,
+    level: 'warning',
   }));
   return jsonResponse(
     actualSyncVersion !== undefined ? { error: 'CONFLICT', actualSyncVersion } : { error: 'CONFLICT' },
@@ -274,12 +282,18 @@ export function buildSentryContext(
     // Additional tags (queryable in Sentry, unlike `extra`). Used e.g. to
     // pass `actual_sync_version` so on-call can group/filter by it.
     extraTags?: Record<string, string | number>;
+    // Sentry severity. Default 'error'. Pass 'warning' for expected-but-
+    // trackable conditions (CONFLICT from optimistic-concurrency) so the
+    // capture stays queryable in the dashboard but doesn't count toward
+    // error totals or page on-call.
+    level?: 'warning' | 'info' | 'error' | 'fatal';
   },
 ): {
   tags: Record<string, string | number>;
   extra: Record<string, unknown>;
   fingerprint: string[];
   ctx?: { waitUntil: (p: Promise<unknown>) => void };
+  level?: 'warning' | 'info' | 'error' | 'fatal';
 } {
   const errName = err instanceof Error ? err.name : 'unknown';
   const requestIdMatch = msg.match(/\[Request ID:\s*([a-f0-9]+)\]/i);
@@ -327,5 +341,6 @@ export function buildSentryContext(
     },
     fingerprint: ['api/user-prefs', opts.method, errorShape],
     ctx: opts.ctx,
+    ...(opts.level ? { level: opts.level } : {}),
   };
 }

--- a/tests/user-prefs-sentry-context.test.mts
+++ b/tests/user-prefs-sentry-context.test.mts
@@ -90,6 +90,33 @@ describe('buildSentryContext — extraTags', () => {
   });
 });
 
+describe('buildSentryContext — level downgrade for expected-but-trackable conditions', () => {
+  it('omits level field by default (envelope falls back to error)', () => {
+    const err = new Error('[Request ID: abc] Server Error');
+    const ctx = buildSentryContext(err, err.message, baseOpts);
+    assert.equal('level' in ctx, false);
+  });
+
+  it('passes through level: warning when caller specifies it', () => {
+    // CONFLICT capture (handleConflictResponse) uses this so the high-volume
+    // optimistic-concurrency events stay queryable without polluting error
+    // totals or alerting (WORLDMONITOR-PX 2026-04-30: 316 events / 59 users).
+    const err = new Error('[Request ID: abc] Server Error');
+    const ctx = buildSentryContext(err, err.message, {
+      ...baseOpts,
+      errorShapeOverride: 'setPreferences_conflict',
+      level: 'warning',
+    });
+    assert.equal(ctx.level, 'warning');
+  });
+
+  it('passes through level: info', () => {
+    const err = new Error('msg');
+    const ctx = buildSentryContext(err, err.message, { ...baseOpts, level: 'info' });
+    assert.equal(ctx.level, 'info');
+  });
+});
+
 describe('buildSentryContext — backwards-compat for non-CONFLICT callers', () => {
   it('UNAUTHENTICATED still classifies via message-pattern when override omitted', () => {
     const err = new Error('UNAUTHENTICATED auth drift');


### PR DESCRIPTION
## Summary

PR #3499 added intentional Sentry capture of CONFLICT (409) responses on `/api/user-prefs` POST so stuck-bundle users could be discovered via `user_id` distribution analysis (one user_id at constant `actual_sync_version` across timestamps = stuck client looping). The capture is doing its job — WORLDMONITOR-PX (2026-04-30) shows 26 events from one user_id at `actual_sync_version=110`, exactly the diagnostic signal the PR was built to surface.

But the firehose also captured 316 events / **59 distinct users** at **18 distinct `actual_sync_version` values** (1, 4, 5, 7, 11, 14, 17, 18, 20, 26, 28, 32, 33, 43, 58, 110) — i.e. mostly normal multi-tab optimistic-concurrency CONFLICTs. At `level=error` this drowned real bugs in the dashboard and would page on-call.

This PR wires `level: 'warning'` through:
- **`api/_sentry-common.js#buildEnvelope`** — reads `ctx?.level` (defaults to `'error'`; accepts `'warning' \| 'info' \| 'fatal'`)
- **`api/user-prefs.ts#buildSentryContext`** — accepts a `level` opt and returns it on the context shape; envelope picks it up
- **`handleConflictResponse`** — passes `level: 'warning'` with a comment explaining why this single capture path needs the downgrade

Diagnostic queryability is **fully preserved** (`error_shape: setPreferences_conflict`, `user_id`, `actual_sync_version`, `convex_request_id` all stay queryable in Sentry). Only the level field changes — moving from "error" lane (alerts/totals) to "warning" lane (still queryable, doesn't page).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 7707/7707 pass
- [x] 3 new test cases in `tests/user-prefs-sentry-context.test.mts` (default omits `level`, `level: 'warning'` passthrough, `level: 'info'` passthrough) — 12/12 pass
- [x] `node --test tests/edge-functions.test.mjs` — 178/178 pass
- [x] Edge bundle check — clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK

## Sentry status

WORLDMONITOR-PX resolved with `inNextRelease: true`. Will auto-reopen if it recurs at error level after this deploy ships — that would mean the level-downgrade didn't take effect, or a NEW CONFLICT path bypassed the helper.