### PR TITLE
feat(payments+prefs): subscription.updated + setPreferences throw→return (plan 002 PR 3)

### DIFF
--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -125,26 +125,48 @@ export default async function handler(
 
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = await client.mutation('userPreferences:setPreferences' as any, {
+    const result = (await client.mutation('userPreferences:setPreferences' as any, {
       variant: body.variant,
       data: body.data,
       expectedSyncVersion: body.expectedSyncVersion,
       schemaVersion: typeof body.schemaVersion === 'number' ? body.schemaVersion : undefined,
-    });
-    return jsonResponse(result, 200, cors);
+    })) as
+      | { ok: true; syncVersion: number }
+      | { ok: false; reason: 'CONFLICT'; actualSyncVersion: number };
+    // PR 3 (post-launch-stabilization): setPreferences now returns a
+    // discriminated result for CONFLICT instead of throwing. Wire shape
+    // to the client (HTTP 409 with actualSyncVersion) is unchanged. The
+    // change silences the dozens-per-day "Uncaught ConvexError" log surface
+    // in Convex Insights, which was just the intentional CAS guard. We no
+    // longer captureSilentError on CONFLICT either — PR 1.B's Sentry
+    // attribution served its purpose during the soak window (we used
+    // it to verify the stuck-bundle storm decayed) and is no longer
+    // needed now that CONFLICT is a normal return shape.
+    if (result.ok === false) {
+      // Discriminated union narrows to the CONFLICT variant here.
+      return jsonResponse(
+        { error: 'CONFLICT', actualSyncVersion: result.actualSyncVersion },
+        409,
+        cors,
+      );
+    }
+    return jsonResponse({ syncVersion: result.syncVersion }, 200, cors);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     const kind = extractConvexErrorKind(err, msg);
+    // Defensive: during the deploy window where the edge function may run
+    // against an OLD convex deployment (CONFLICT still throws), keep the
+    // catch-side CONFLICT branch. Once both layers have soaked on the new
+    // code, this branch is unreachable and can be removed.
     if (kind === 'CONFLICT') {
-      return handleConflictResponse(err, msg, {
-        userId: session.userId,
-        variant: body.variant,
-        ctx,
-        schemaVersion: typeof body.schemaVersion === 'number' ? body.schemaVersion : null,
-        expectedSyncVersion: body.expectedSyncVersion,
-        blobSize: body.data !== undefined ? JSON.stringify(body.data).length : 0,
+      const actualSyncVersion = readConvexErrorNumber(err, 'actualSyncVersion');
+      return jsonResponse(
+        actualSyncVersion !== undefined
+          ? { error: 'CONFLICT', actualSyncVersion }
+          : { error: 'CONFLICT' },
+        409,
         cors,
-      });
+      );
     }
     if (kind === 'BLOB_TOO_LARGE') {
       return jsonResponse({ error: 'BLOB_TOO_LARGE' }, 400, cors);
@@ -188,55 +210,6 @@ export default async function handler(
   }
 }
 
-
-/**
- * 409-CONFLICT response builder for setPreferences. Captures every
- * CONFLICT to Sentry so we can detect stuck-bundle users (constant
- * `actual_sync_version` across timestamps with no success interleaved
- * → one client looping; broadly-distributed `user_id` → real concurrency).
- * The CAS guard itself is intentional behavior, but we lose all per-user
- * attribution if we don't record it — Convex Insights surfaces a count but
- * no userId. Also: PR 1 ships a stale-bundle force-reload (build-hash
- * mismatch) to drain stuck-bundle users; this capture is how we verify
- * the storm decays.
- *
- * Echoes `actualSyncVersion` from the structured ConvexError when present
- * and numeric so the client can refresh its local sync state without a
- * follow-up GET. Type-guarded — drops non-numeric values rather than
- * forwarding them as `unknown`.
- */
-function handleConflictResponse(
-  err: unknown,
-  msg: string,
-  opts: {
-    userId: string;
-    variant: unknown;
-    ctx?: { waitUntil: (p: Promise<unknown>) => void };
-    schemaVersion: number | null;
-    expectedSyncVersion: unknown;
-    blobSize: number;
-    cors: Record<string, string>;
-  },
-): Response {
-  const actualSyncVersion = readConvexErrorNumber(err, 'actualSyncVersion');
-  captureSilentError(err, buildSentryContext(err, msg, {
-    method: 'POST',
-    convexFn: 'userPreferences:setPreferences',
-    userId: opts.userId,
-    variant: opts.variant,
-    ctx: opts.ctx,
-    schemaVersion: opts.schemaVersion,
-    expectedSyncVersion: opts.expectedSyncVersion,
-    blobSize: opts.blobSize,
-    errorShapeOverride: 'setPreferences_conflict',
-    extraTags: actualSyncVersion !== undefined ? { actual_sync_version: actualSyncVersion } : undefined,
-  }));
-  return jsonResponse(
-    actualSyncVersion !== undefined ? { error: 'CONFLICT', actualSyncVersion } : { error: 'CONFLICT' },
-    409,
-    opts.cors,
-  );
-}
 
 /**
  * Build a captureSilentError context that carries enough provenance to triage

--- a/convex/__tests__/subscription-updated.test.ts
+++ b/convex/__tests__/subscription-updated.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for the `subscription.updated` webhook handler (PR 3).
+ *
+ * Dispatches by payload `status` to the existing lifecycle handlers, so
+ * the policy invariants those handlers enforce (paid-through cancellation,
+ * out-of-order rejection, comp-floor preservation) apply automatically.
+ * Unknown statuses fall through to a defensive recompute path.
+ */
+
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.ts");
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const USER_ID = "user_3CSubUpdated";
+const PRODUCT_ID = "pdt_0Nbtt71uObulf7fGXhQup";
+const SUB_ID = "sub_test_updated";
+
+const CUSTOMER_ID = "cus_test";
+
+// Per-test seed: an active sub + matching entitlement + customer (for userId resolution).
+async function seedActiveSub(
+  t: ReturnType<typeof convexTest>,
+  opts: { currentPeriodEnd: number; planKey?: string } = { currentPeriodEnd: Date.now() + 7 * DAY_MS },
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("productPlans", {
+      dodoProductId: PRODUCT_ID,
+      planKey: opts.planKey ?? "pro_monthly",
+      displayName: "Pro Monthly",
+      isActive: true,
+    });
+    // Customer mapping so resolveUserId() finds the userId via dodoCustomerId
+    // (unsigned wm_user_id metadata is ignored by the handler).
+    await ctx.db.insert("customers", {
+      userId: USER_ID,
+      dodoCustomerId: CUSTOMER_ID,
+      email: "test@example.com",
+      createdAt: Date.now() - 365 * DAY_MS,
+      updatedAt: Date.now() - 365 * DAY_MS,
+    });
+    await ctx.db.insert("subscriptions", {
+      userId: USER_ID,
+      dodoSubscriptionId: SUB_ID,
+      dodoProductId: PRODUCT_ID,
+      planKey: opts.planKey ?? "pro_monthly",
+      status: "active",
+      currentPeriodStart: Date.now() - 23 * DAY_MS,
+      currentPeriodEnd: opts.currentPeriodEnd,
+      rawPayload: {},
+      updatedAt: Date.now() - 1000,
+    });
+    await ctx.db.insert("entitlements", {
+      userId: USER_ID,
+      planKey: opts.planKey ?? "pro_monthly",
+      features: {
+        tier: 1,
+        maxDashboards: 10,
+        apiAccess: false,
+        apiRateLimit: 0,
+        prioritySupport: false,
+        exportFormats: ["csv", "pdf"],
+      },
+      validUntil: opts.currentPeriodEnd,
+      updatedAt: Date.now() - 1000,
+    });
+  });
+}
+
+async function fireSubscriptionUpdated(
+  t: ReturnType<typeof convexTest>,
+  status: string,
+  opts: { eventTimestamp?: number; planKey?: string; cancelledAt?: number } = {},
+) {
+  await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+    webhookId: `msg_test_${SUB_ID}_updated_${status}_${Math.random().toString(36).slice(2, 6)}`,
+    eventType: "subscription.updated",
+    rawPayload: {
+      type: "subscription.updated",
+      data: {
+        subscription_id: SUB_ID,
+        product_id: PRODUCT_ID,
+        status,
+        customer: { customer_id: CUSTOMER_ID },
+        metadata: { wm_user_id: USER_ID },
+        previous_billing_date: new Date(Date.now() - 23 * DAY_MS).toISOString(),
+        next_billing_date: new Date(Date.now() + 7 * DAY_MS).toISOString(),
+        ...(opts.cancelledAt
+          ? { cancelled_at: new Date(opts.cancelledAt).toISOString() }
+          : {}),
+      },
+    },
+    timestamp: opts.eventTimestamp ?? Date.now(),
+  });
+}
+
+async function readEntitlement(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) =>
+    ctx.db
+      .query("entitlements")
+      .withIndex("by_userId", (q) => q.eq("userId", USER_ID))
+      .first(),
+  );
+}
+
+async function readSub(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) =>
+    ctx.db
+      .query("subscriptions")
+      .withIndex("by_dodoSubscriptionId", (q) => q.eq("dodoSubscriptionId", SUB_ID))
+      .unique(),
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Paid-through cancellation: the most important invariant
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("subscription.updated → status='cancelled' (paid-through invariant)", () => {
+  test("preserves entitlement until currentPeriodEnd (mid-period cancellation)", async () => {
+    const t = convexTest(schema, modules);
+    const periodEnd = Date.now() + 7 * DAY_MS;
+    await seedActiveSub(t, { currentPeriodEnd: periodEnd });
+
+    await fireSubscriptionUpdated(t, "cancelled", { cancelledAt: Date.now() });
+
+    const sub = await readSub(t);
+    expect(sub?.status).toBe("cancelled");
+    const ent = await readEntitlement(t);
+    // Paid-through: validUntil should remain at the period end, NOT
+    // collapsed to "now".
+    expect(ent?.planKey).toBe("pro_monthly");
+    expect(ent?.validUntil).toBe(periodEnd);
+  });
+
+  test("does NOT touch entitlement on cancellation — only subscription.expired downgrades to free", async () => {
+    const t = convexTest(schema, modules);
+    const expiredPeriodEnd = Date.now() - 1 * DAY_MS;
+    await seedActiveSub(t, { currentPeriodEnd: expiredPeriodEnd });
+
+    // Cancellation alone NEVER downgrades, even when the period is already
+    // in the past. The entitlement's `validUntil` already reflects period
+    // end; `subscription.expired` is the only path that flips planKey→free.
+    await fireSubscriptionUpdated(t, "cancelled", { cancelledAt: Date.now() });
+
+    const ent = await readEntitlement(t);
+    expect(ent?.planKey).toBe("pro_monthly");
+    expect(ent?.validUntil).toBe(expiredPeriodEnd);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Other status dispatches reuse existing lifecycle handlers
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("subscription.updated → other statuses dispatch correctly", () => {
+  test("status='active' triggers handleSubscriptionActive (sub patched, entitlement re-derived)", async () => {
+    const t = convexTest(schema, modules);
+    await seedActiveSub(t);
+    // Mutate the rawPayload to confirm the patch happened.
+    await fireSubscriptionUpdated(t, "active");
+    const sub = await readSub(t);
+    expect(sub?.status).toBe("active");
+    expect((sub?.rawPayload as { status?: string })?.status).toBe("active");
+  });
+
+  test("status='on_hold' triggers handleSubscriptionOnHold", async () => {
+    const t = convexTest(schema, modules);
+    await seedActiveSub(t);
+    await fireSubscriptionUpdated(t, "on_hold");
+    const sub = await readSub(t);
+    expect(sub?.status).toBe("on_hold");
+  });
+
+  test("status='expired' triggers handleSubscriptionExpired (free downgrade)", async () => {
+    const t = convexTest(schema, modules);
+    await seedActiveSub(t);
+    await fireSubscriptionUpdated(t, "expired");
+    const sub = await readSub(t);
+    expect(sub?.status).toBe("expired");
+    const ent = await readEntitlement(t);
+    expect(ent?.planKey).toBe("free");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Defensive paths
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("subscription.updated → defensive paths", () => {
+  test("unknown status: logs error + recomputes entitlement defensively (no crash)", async () => {
+    const t = convexTest(schema, modules);
+    await seedActiveSub(t);
+    // Send a status the handler doesn't dispatch for. Should NOT throw —
+    // defensive recompute path runs and the row is patched with the new
+    // rawPayload + updatedAt.
+    await fireSubscriptionUpdated(t, "paused");
+    const sub = await readSub(t);
+    expect(sub).not.toBeNull();
+    // Status field is unchanged (not in our enum) — defensive path only
+    // patches rawPayload + updatedAt.
+    expect((sub?.rawPayload as { status?: string })?.status).toBe("paused");
+  });
+
+  test("missing status: defensive recompute (no crash)", async () => {
+    const t = convexTest(schema, modules);
+    await seedActiveSub(t);
+    // Empty status falls into the default branch.
+    await fireSubscriptionUpdated(t, "");
+    const sub = await readSub(t);
+    expect(sub).not.toBeNull();
+  });
+
+  test("stale eventTimestamp: rejected via isNewerEvent guard inherited from delegated handler", async () => {
+    const t = convexTest(schema, modules);
+    await seedActiveSub(t);
+    // First update at "now" — wins.
+    const now = Date.now();
+    await fireSubscriptionUpdated(t, "active", { eventTimestamp: now });
+    const subAfterFirst = await readSub(t);
+    const updatedAtAfterFirst = subAfterFirst?.updatedAt;
+    // Second update with an OLDER timestamp — should be no-op.
+    await fireSubscriptionUpdated(t, "active", { eventTimestamp: now - 60_000 });
+    const subAfterSecond = await readSub(t);
+    expect(subAfterSecond?.updatedAt).toBe(updatedAtAfterFirst);
+  });
+});

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -146,7 +146,7 @@ http.route({
     }
 
     try {
-      const result = await ctx.runMutation(
+      const result = (await ctx.runMutation(
         anyApi.userPreferences!.setPreferences as any,
         {
           variant: body.variant,
@@ -154,10 +154,33 @@ http.route({
           expectedSyncVersion: body.expectedSyncVersion,
           schemaVersion: body.schemaVersion,
         },
+      )) as
+        | { ok: true; syncVersion: number }
+        | { ok: false; reason: "CONFLICT"; actualSyncVersion: number };
+      // PR 3 (post-launch-stabilization): setPreferences now returns a
+      // discriminated result for CONFLICT instead of throwing. Mirror the
+      // wire shape from api/user-prefs.ts (Vercel) so clients see the same
+      // 409 + actualSyncVersion regardless of which `/api/user-prefs` host
+      // they hit.
+      if (result.ok === false) {
+        return new Response(
+          JSON.stringify({
+            error: "CONFLICT",
+            actualSyncVersion: result.actualSyncVersion,
+          }),
+          { status: 409, headers },
+        );
+      }
+      return new Response(
+        JSON.stringify({ syncVersion: result.syncVersion }),
+        { status: 200, headers },
       );
-      return new Response(JSON.stringify(result), { status: 200, headers });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
+      // Defensive: keep CONFLICT-throw fallback for the deploy-ordering
+      // window where this http action may run against an older Convex
+      // deployment that still throws. Once both layers have soaked, this
+      // branch is unreachable and can be removed.
       if (msg.includes("CONFLICT")) {
         return new Response(JSON.stringify({ error: "CONFLICT" }), {
           status: 409,

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -25,6 +25,7 @@ interface DodoCustomer {
 interface DodoSubscriptionData {
   subscription_id: string;
   product_id: string;
+  status?: string;
   customer?: DodoCustomer;
   previous_billing_date?: string | number | Date;
   next_billing_date?: string | number | Date;
@@ -720,6 +721,64 @@ export async function handleSubscriptionExpired(
   // sub still covers the user we keep them on its tier, else free-downgrade.
   // The recompute helper also honours the comp-floor for goodwill credits.
   await recomputeEntitlementFromAllSubs(ctx, existing.userId, eventTimestamp);
+}
+
+/**
+ * Handles `subscription.updated` -- Dodo's catch-all "any field changed"
+ * event (per their webhook docs, this fires for real-time sync without
+ * polling). We dispatch by the payload's `status` field to reuse the
+ * dedicated lifecycle handlers AND inherit their policy invariants:
+ *
+ *   - paid-through cancellation: `handleSubscriptionCancelled` preserves
+ *     entitlement until `currentPeriodEnd`, NOT immediate revocation. A
+ *     `subscription.updated` carrying `status='cancelled'` mid-period
+ *     therefore does NOT downgrade until the period ends — same behavior
+ *     as a dedicated `subscription.cancelled` event.
+ *   - out-of-order protection: each lifecycle handler enforces
+ *     `isNewerEvent(existing.updatedAt, eventTimestamp)`, so a delayed
+ *     `subscription.updated` for an old state is rejected.
+ *
+ * Unknown statuses fall to a defensive recompute path: patch the row's
+ * rawPayload + updatedAt so we don't lose the event, recompute the
+ * entitlement, and console.error so ops can decide if a new dedicated
+ * handler is needed.
+ */
+export async function handleSubscriptionUpdated(
+  ctx: MutationCtx,
+  data: DodoSubscriptionData,
+  eventTimestamp: number,
+): Promise<void> {
+  const status = (data.status ?? "").toString();
+  switch (status) {
+    case "active":
+      return handleSubscriptionActive(ctx, data, eventTimestamp);
+    case "on_hold":
+      return handleSubscriptionOnHold(ctx, data, eventTimestamp);
+    case "cancelled":
+      return handleSubscriptionCancelled(ctx, data, eventTimestamp);
+    case "expired":
+      return handleSubscriptionExpired(ctx, data, eventTimestamp);
+    default: {
+      console.error(
+        `[handleSubscriptionUpdated] unhandled status="${status}" sub=${data.subscription_id}; ` +
+        `recomputing entitlement defensively. Add a dedicated dispatch case if this status starts ` +
+        `appearing regularly.`,
+      );
+      const existing = await ctx.db
+        .query("subscriptions")
+        .withIndex("by_dodoSubscriptionId", (q) =>
+          q.eq("dodoSubscriptionId", data.subscription_id),
+        )
+        .unique();
+      if (existing && isNewerEvent(existing.updatedAt, eventTimestamp)) {
+        await ctx.db.patch(existing._id, {
+          rawPayload: data,
+          updatedAt: eventTimestamp,
+        });
+        await recomputeEntitlementFromAllSubs(ctx, existing.userId, eventTimestamp);
+      }
+    }
+  }
 }
 
 /**

--- a/convex/payments/webhookMutations.ts
+++ b/convex/payments/webhookMutations.ts
@@ -7,6 +7,7 @@ import {
   handleSubscriptionCancelled,
   handleSubscriptionPlanChanged,
   handleSubscriptionExpired,
+  handleSubscriptionUpdated,
   handlePaymentOrRefundEvent,
   handleDisputeEvent,
 } from "./subscriptionHelpers";
@@ -66,6 +67,11 @@ export const processWebhookEvent = internalMutation({
     const subscriptionEvents = [
       "subscription.active", "subscription.renewed", "subscription.on_hold",
       "subscription.cancelled", "subscription.plan_changed", "subscription.expired",
+      // PR 3 (post-launch-stabilization): Dodo's docs list `subscription.updated`
+      // as a real-time-sync event for any subscription field change. Handler
+      // dispatches by the payload's `status` field to reuse our existing
+      // lifecycle logic AND respect the paid-through-cancellation policy.
+      "subscription.updated",
     ] as const;
 
     if (subscriptionEvents.includes(args.eventType as typeof subscriptionEvents[number]) && !(data as Record<string, unknown>).subscription_id) {
@@ -93,6 +99,9 @@ export const processWebhookEvent = internalMutation({
       case "subscription.expired":
         await handleSubscriptionExpired(ctx, data, args.timestamp);
         break;
+      case "subscription.updated":
+        await handleSubscriptionUpdated(ctx, data, args.timestamp);
+        break;
       case "payment.succeeded":
       case "payment.failed":
       case "refund.succeeded":
@@ -106,7 +115,15 @@ export const processWebhookEvent = internalMutation({
         await handleDisputeEvent(ctx, data, args.eventType, args.timestamp);
         break;
       default:
-        console.warn(`[webhook] Unhandled event type: ${args.eventType}`);
+        // Loud signal for `subscription.*` additions (so a future Dodo event
+        // type doesn't silently no-op). Other unhandled events remain a warn.
+        if (typeof args.eventType === "string" && args.eventType.startsWith("subscription.")) {
+          console.error(
+            `[webhook] Unhandled subscription.* event type: ${args.eventType} — needs a dedicated handler in subscriptionHelpers.ts`,
+          );
+        } else {
+          console.warn(`[webhook] Unhandled event type: ${args.eventType}`);
+        }
     }
 
     // 3. Record the event AFTER successful processing.

--- a/convex/userPreferences.ts
+++ b/convex/userPreferences.ts
@@ -29,6 +29,22 @@ export const getPreferences = query({
   },
 });
 
+/**
+ * Discriminated return shape. `CONFLICT` is the CAS-guard "no-op" path —
+ * intentional behavior for two-device concurrency. Switching from `throw`
+ * to `return` here means Convex Insights stops labeling it
+ * `Uncaught ConvexError` (no throw → no log surface), but the wire shape
+ * exposed through `api/user-prefs.ts` (HTTP 409 with `actualSyncVersion`)
+ * is unchanged — clients see the same response.
+ *
+ * `BLOB_TOO_LARGE` and `UNAUTHENTICATED` remain THROWS because they are
+ * rare and we DO want them visible in Sentry as errors. CONFLICT is
+ * dozens-per-day expected behavior, not an error.
+ */
+export type SetPreferencesResult =
+  | { ok: true; syncVersion: number }
+  | { ok: false; reason: "CONFLICT"; actualSyncVersion: number };
+
 export const setPreferences = mutation({
   args: {
     variant: v.string(),
@@ -36,15 +52,13 @@ export const setPreferences = mutation({
     expectedSyncVersion: v.number(),
     schemaVersion: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<SetPreferencesResult> => {
     const identity = await ctx.auth.getUserIdentity();
-    // Throw structured `ConvexError({ kind, ... })` instead of string-data —
-    // Convex's wire format reliably propagates `errorData` for object payloads,
-    // so the edge handler can route via `err.data.kind` to the correct HTTP
-    // status. String-data ConvexErrors arrive at the edge as a generic
-    // `Error("[Request ID: X] Server Error")` with `errorData` undefined,
-    // which previously caused CONFLICT throws to be misclassified as 500
-    // and trigger an unbounded retry loop on the client (PD investigation).
+    // BLOB_TOO_LARGE and UNAUTHENTICATED throw as structured ConvexErrors —
+    // they are rare error conditions we want surfaced in Sentry. Convex's
+    // wire format propagates `errorData` for object payloads so the edge
+    // handler routes via `err.data.kind`. (PR #3466 fixed the original
+    // string-data wire-strip bug.)
     if (!identity) throw new ConvexError({ kind: "UNAUTHENTICATED" });
     const userId = identity.subject;
 
@@ -65,13 +79,14 @@ export const setPreferences = mutation({
       .unique();
 
     if (existing && existing.syncVersion !== args.expectedSyncVersion) {
-      // Include `actualSyncVersion` so the edge can echo it in the 409 body
-      // and the client can refresh its local view in one round-trip instead
-      // of re-fetching getPreferences.
-      throw new ConvexError({
-        kind: "CONFLICT",
+      // CAS-guard "no-op". Returns rather than throws — see SetPreferencesResult
+      // doc comment. Wire shape (HTTP 409 with actualSyncVersion in body) is
+      // unchanged at the edge handler.
+      return {
+        ok: false,
+        reason: "CONFLICT",
         actualSyncVersion: existing.syncVersion,
-      });
+      };
     }
 
     const nextSyncVersion = (existing?.syncVersion ?? 0) + 1;
@@ -95,6 +110,6 @@ export const setPreferences = mutation({
       });
     }
 
-    return { syncVersion: nextSyncVersion };
+    return { ok: true, syncVersion: nextSyncVersion };
   },
 });


### PR DESCRIPTION
## Summary

Final PR of [`plans/2026-04-29-post-launch-stabilization.md`](plans/2026-04-29-post-launch-stabilization.md). Two surface-level cleanups identified during the post-launch soak.

**E. `setPreferences` throw→return**

The CAS-guard CONFLICT path was throwing `ConvexError({ kind: "CONFLICT", actualSyncVersion })`, which Convex Insights labeled `Uncaught ConvexError` — visually indistinguishable from real bugs in the dashboard. CONFLICT is intentional two-device concurrency behavior (dozens per day, expected); only `BLOB_TOO_LARGE` and `UNAUTHENTICATED` need to be visible as errors.

This switches CONFLICT to a discriminated return:

```ts
type SetPreferencesResult =
  | { ok: true; syncVersion: number }
  | { ok: false; reason: "CONFLICT"; actualSyncVersion: number };
```

**Wire shape unchanged**: both edge handlers (Vercel `api/user-prefs.ts` AND the parallel Convex `/api/user-prefs` route in `convex/http.ts`) still emit HTTP 409 with `actualSyncVersion` in the body. Clients see the same response. Both keep a defensive `kind === 'CONFLICT'` / `msg.includes('CONFLICT')` catch branch for the deploy-ordering window where the function may run against an older Convex deployment that still throws.

The 50% setPreferences error-rate chart we saw on 2026-04-29 was already addressed by PR #3502's stale-bundle force-reload + #3466's wire-format fix. This PR is the cosmetic follow-up that stops surfacing the now-tiny residual CAS noise as "Uncaught" in Insights.

**F. `subscription.updated` webhook handler**

Per Dodo's docs, `subscription.updated` is a real-time-sync event fired for any subscription field change. We were ignoring it (default \`console.warn\` branch) and relying on `subscription.active`/`cancelled`/`expired`/`on_hold` only. The new handler dispatches by payload `status` to those existing lifecycle handlers, so policy invariants apply automatically:

- **Paid-through cancellation preserved**: `subscription.updated` with `status='cancelled'` mid-period routes to `handleSubscriptionCancelled`, which keeps entitlement until `currentPeriodEnd`. Same behavior as a dedicated `subscription.cancelled` event.
- **Out-of-order rejection preserved**: each lifecycle handler enforces `isNewerEvent(existing.updatedAt, eventTimestamp)`.
- **Unknown statuses don't crash**: fall through to defensive recompute (patch rawPayload, recompute entitlement, `console.error` so ops can decide whether a dedicated handler is needed).

The default branch for unhandled `subscription.*` types is now `console.error` (loud) instead of `console.warn` (quiet), so future Dodo event additions don't silently no-op.

## Test plan

- [x] `npm run test:convex` — 217 tests pass (incl. 8 new tests in `convex/__tests__/subscription-updated.test.ts` covering paid-through invariant, status dispatches, and defensive paths)
- [x] `npm run test:data` — 7704 tests pass
- [x] `node --test tests/edge-functions.test.mjs` — 178 tests pass
- [x] `npm run typecheck` + `npm run typecheck:api` — clean
- [x] `npm run lint` — only pre-existing complexity warning at `api/user-prefs.ts:24` (was 58, now 59 — accepted +1 delta)
- [x] `npm run lint:md` + `npm run version:check` — clean
- [x] Edge function bundle check — clean

## Files changed

- `convex/userPreferences.ts` — discriminated CONFLICT return
- `api/user-prefs.ts` — handle new return + defensive catch for deploy-ordering window
- `convex/http.ts` — same fix for the parallel `/api/user-prefs` route
- `convex/payments/subscriptionHelpers.ts` — new `handleSubscriptionUpdated` dispatcher
- `convex/payments/webhookMutations.ts` — wire the new handler + loud default for unhandled `subscription.*`
- `convex/__tests__/subscription-updated.test.ts` — 8 new tests