### PR TITLE
fix(panel-layout): Pro CTAs react to Convex entitlement updates

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -170,6 +170,7 @@ export class PanelLayoutManager implements AppModule {
   private readonly applyTimeRangeFilterDebounced: (() => void) & { cancel(): void };
   private unsubscribeAuth: (() => void) | null = null;
   private proBlockUnsubscribe: (() => void) | null = null;
+  private proBlockEntitlementUnsubscribe: (() => void) | null = null;
   private boundWidgetCreatorHandler: ((e: Event) => void) | null = null;
   private unsubscribeEntitlementChange: (() => void) | null = null;
   private unsubscribePaymentFailureBanner: (() => void) | null = null;
@@ -303,6 +304,8 @@ export class PanelLayoutManager implements AppModule {
     this.unsubscribeAuth = null;
     this.proBlockUnsubscribe?.();
     this.proBlockUnsubscribe = null;
+    this.proBlockEntitlementUnsubscribe?.();
+    this.proBlockEntitlementUnsubscribe = null;
     if (this.boundWidgetCreatorHandler) {
       this.ctx.container.removeEventListener('wm:open-widget-creator', this.boundWidgetCreatorHandler);
       this.boundWidgetCreatorHandler = null;
@@ -1505,17 +1508,32 @@ export class PanelLayoutManager implements AppModule {
     });
     panelsGrid.appendChild(mcpBlock);
 
-    // Reactively show/hide Pro-only UI blocks based on auth state
+    // Reactively show/hide Pro-only UI blocks ("Create Interactive Widget" +
+    // "Connect MCP" CTAs) based on premium access.
+    //
+    // hasPremiumAccess() folds in isEntitled() (Convex Dodo entitlement) per
+    // panel-gating.ts:11-27 — so a paying subscriber whose Clerk publicMetadata
+    // is never written by the webhook still resolves to true once the Convex
+    // snapshot lands. BUT: the snapshot lands AFTER auth state stabilises, and
+    // Convex updates do NOT necessarily fire a fresh subscribeAuthState event.
+    // Subscribing only to subscribeAuthState meant these CTAs stayed
+    // display:none for the whole page lifetime for paying users — exactly the
+    // shape PR #3505 chased on the server side, repeated here on the client.
+    //
+    // Subscribe to BOTH auth state and entitlement changes; whichever fires
+    // last (typically entitlements) is the one that flips the CTAs visible.
+    // Mirrors the same dual-subscription wiring used by updatePanelGating
+    // for existing panels (see lines ~259 and ~282).
     const proBlocks = [proBlock, mcpBlock];
     const applyProBlockGating = (isPro: boolean) => {
       for (const block of proBlocks) {
         block.style.display = isPro ? '' : 'none';
       }
     };
-    applyProBlockGating(hasPremiumAccess(getAuthState()));
-    this.proBlockUnsubscribe = subscribeAuthState((state) => {
-      applyProBlockGating(hasPremiumAccess(state));
-    });
+    const reapply = () => applyProBlockGating(hasPremiumAccess(getAuthState()));
+    reapply();
+    this.proBlockUnsubscribe = subscribeAuthState(reapply);
+    this.proBlockEntitlementUnsubscribe = onEntitlementChange(reapply);
 
     const bottomGrid = document.getElementById('mapBottomGrid');
     if (bottomGrid) {

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1354,6 +1354,58 @@ describe('widget-agent edge proxy — Convex entitlement fallback', () => {
 // turn that yes into a null-meaning-no — that would 403 paying customers on
 // every call path this file gates, including the widget-agent fallback PR
 // #3505 just added.
+// ---------------------------------------------------------------------------
+// panel-layout — Pro CTAs must re-evaluate on Convex entitlement updates
+// ---------------------------------------------------------------------------
+//
+// "Create Interactive Widget" (proBlock) and "Connect MCP" (mcpBlock) are
+// gated by applyProBlockGating(hasPremiumAccess(...)). For a paying Dodo
+// subscriber whose Clerk publicMetadata.plan is never written, hasPremiumAccess
+// only flips true once the Convex entitlement snapshot lands via
+// onEntitlementChange — NOT via subscribeAuthState. Subscribing only to
+// subscribeAuthState (the prior shape) meant the CTAs stayed display:none for
+// the entire page lifetime for paying users. Lock the dual-subscription.
+describe('panel-layout — Pro add-block gating reacts to entitlement updates', () => {
+  const layout = src('src/app/panel-layout.ts');
+
+  it('imports onEntitlementChange', () => {
+    assert.ok(
+      /import\s*\{[^}]*\bonEntitlementChange\b[^}]*\}\s*from\s*['"][^'"]*entitlements['"]/.test(layout),
+      'panel-layout must import onEntitlementChange to re-evaluate Pro CTA gating on Convex snapshots',
+    );
+  });
+
+  it('proBlock + mcpBlock gating subscribes to BOTH auth and entitlement changes', () => {
+    // Anchor on the gating function to scope the search to its surroundings.
+    const gateFnIdx = layout.indexOf('applyProBlockGating');
+    assert.ok(gateFnIdx !== -1, 'applyProBlockGating not found in panel-layout');
+    const region = layout.slice(gateFnIdx, gateFnIdx + 1500);
+    assert.ok(
+      region.includes('subscribeAuthState'),
+      'Pro CTA gating must subscribe to subscribeAuthState (legacy auth-driven path)',
+    );
+    assert.ok(
+      region.includes('onEntitlementChange'),
+      'Pro CTA gating MUST subscribe to onEntitlementChange so paying Dodo users flip from hidden->visible when the Convex entitlement snapshot lands',
+    );
+  });
+
+  it('teardown clears the entitlement subscription so a destroyed layout does not leak callbacks', () => {
+    assert.ok(
+      layout.includes('proBlockEntitlementUnsubscribe'),
+      'panel-layout must hold a proBlockEntitlementUnsubscribe handle and clear it in destroy()',
+    );
+    // Look for the destroy() block
+    const destroyIdx = layout.indexOf('destroy(): void {');
+    assert.ok(destroyIdx !== -1, 'destroy() not found');
+    const destroyRegion = layout.slice(destroyIdx, destroyIdx + 2000);
+    assert.ok(
+      destroyRegion.includes('proBlockEntitlementUnsubscribe'),
+      'destroy() must invoke proBlockEntitlementUnsubscribe to avoid leaking callbacks across layout init/destroy cycles',
+    );
+  });
+});
+
 describe('entitlement-check — cache-write failure does not collapse confirmed entitlement', () => {
   const src_ = src('server/_shared/entitlement-check.ts');
 


### PR DESCRIPTION
## User-visible bug

Paying Dodo subscribers did not see the **\"Create Interactive Widget\"** and **\"Connect MCP\"** CTAs on their dashboard, even though the underlying PRO panels rendered correctly.

Screenshots from the user reporting the issue (PRO badges visible — these tiles should be shown to paying users, not hidden):

- Create Interactive Widget tile
- Connect MCP tile

This is the **client-side mirror** of PR #3505. PR #3505 fixed the server side (widget-agent 403'd paying users because it only checked Clerk role, ignoring the Convex Dodo entitlement). The same shape was hiding here on the client.

## Root cause

`src/app/panel-layout.ts:1508-1518` gated `proBlock` + `mcpBlock` visibility through `applyProBlockGating(hasPremiumAccess(...))`, wired **only** to `subscribeAuthState`.

`hasPremiumAccess` folds in `isEntitled()` (Convex Dodo entitlement) per the [panel-gating.ts:11-27 contract](https://github.com/koala73/worldmonitor/blob/main/src/services/panel-gating.ts#L11-L27) — but the Convex snapshot lands **after** auth state stabilises, and Convex updates do **not** fire a fresh `subscribeAuthState` event.

Sequence for a paying Dodo user on first paint:

1. Page renders. `applyProBlockGating(hasPremiumAccess(getAuthState()))` runs once.
2. Convex hasn't bridged yet → `currentState === null` → `isEntitled() === false` → `hasPremiumAccess() === false`.
3. Both CTAs go `display: none`.
4. Convex auth bridges, snapshot lands → `onEntitlementChange` callbacks fire → `updatePanelGating()` re-runs and unlocks **existing panels** (correct ✅).
5. But `applyProBlockGating` is **not** registered against `onEntitlementChange` → CTAs stay hidden for the whole page lifetime ❌.

## Fix

Subscribe `applyProBlockGating` to **both** `subscribeAuthState` and `onEntitlementChange`. Mirrors the dual-subscription wiring already in place for `updatePanelGating` ([panel-layout.ts:259](https://github.com/koala73/worldmonitor/blob/main/src/app/panel-layout.ts#L259) + [:282](https://github.com/koala73/worldmonitor/blob/main/src/app/panel-layout.ts#L282)).

\`\`\`ts
const reapply = () => applyProBlockGating(hasPremiumAccess(getAuthState()));
reapply();
this.proBlockUnsubscribe            = subscribeAuthState(reapply);
this.proBlockEntitlementUnsubscribe = onEntitlementChange(reapply);
\`\`\`

`destroy()` clears both handles to avoid leaks across layout init/destroy cycles.

## Test plan

Three new source-grep regression tests in \`tests/widget-builder.test.mjs\`:

1. \`panel-layout.ts\` imports \`onEntitlementChange\` from \`@/services/entitlements\`
2. The Pro CTA gating block subscribes to **both** \`subscribeAuthState\` AND \`onEntitlementChange\`
3. \`destroy()\` clears \`proBlockEntitlementUnsubscribe\` so a destroyed layout does not leak callbacks

- [x] \`node --test tests/widget-builder.test.mjs\` → **194/194 pass** (was 191 on main, +3 new)
- [x] \`tsc --noEmit\` clean
- [ ] Manual verification: a paying Dodo subscriber loading the dashboard sees both CTAs after the Convex snapshot lands (typically <1s after auth bridges).
- [ ] Manual verification: a free user does not see either CTA.
- [ ] Manual verification: signing out clears the CTAs (\`subscribeAuthState\` path still works).

## Related

- PR #3505 (server-side mirror, merged) — the full sweep of \`validateBearerToken\` callers identified widget-agent as the lone server-side outlier; this patch closes the matching client-side outlier.
- Skill: [\`entitlement-signal-server-outlier-sweep\`](~/.claude/skills/entitlement-signal-server-outlier-sweep/SKILL.md) — the recipe that surfaced PR #3505. This bug is the same shape on the client gating layer; future audits should include it.