### PR TITLE
fix(widget-builder): keep Send button visible when sidebar overflows

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -20713,6 +20713,7 @@ body.map-width-resizing {
 }
 
 .widget-chat-readiness {
+  flex-shrink: 0;
   margin: 12px 12px 0;
   padding: 10px 12px;
   border-radius: 10px;
@@ -20790,6 +20791,7 @@ body.map-width-resizing {
 }
 
 .widget-chat-examples {
+  flex-shrink: 0;
   padding: 0 12px 12px;
   display: grid;
   gap: 8px;
@@ -20957,6 +20959,7 @@ body.map-width-resizing {
 }
 
 .widget-chat-input-row {
+  flex-shrink: 0;
   display: flex;
   gap: 8px;
   padding: 12px;


### PR DESCRIPTION
## Summary
- Pin `.widget-chat-readiness`, `.widget-chat-examples`, and `.widget-chat-input-row` to `flex-shrink: 0` so they cannot collapse under pressure.
- The chat sidebar's only `flex: 1` child is `.widget-chat-messages` (with `min-height: 0; overflow-y: auto`), so it now absorbs all shrinkage via its existing internal scroll instead of squeezing the row that holds the Send button.
- Without this pin, when the modal's available column wasn't tall enough for the natural stack (banner + messages + 4 example chips + 3-row textarea), every child shrank proportionally and the input row drifted below the layout's clip boundary while the sticky footer (`z-index: 2`) drew on top of it — producing the screenshot where only a sliver of the white Send button is visible behind "Add to Dashboard".

## Test plan
- [ ] Open Widget Builder → "Connected to the widget agent" → confirm Send button visible above footer.
- [ ] Generate a widget so two messages render → Send button still visible.
- [ ] Resize window vertically until messages would overflow → messages list scrolls internally, Send button stays anchored.
- [ ] Tab through composer → focus order unchanged.