### PR TITLE
fix(sentry): suppress third-party stylesheet injection from cdn.jsdelivr.net

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -598,6 +598,14 @@ function shouldSuppressCspViolation(
   if (/securly\.com|goguardian\.com|contentkeeper\.com/.test(blockedURI)) return true;
   // Vercel Analytics script.
   if (/_vercel\/insights\/script\.js/.test(blockedURI)) return true;
+  // Third-party stylesheet injection from public CDNs (browser extensions,
+  // bookmarklets, "inspect element" UI tools loading antd/bootstrap/etc.).
+  // We legitimately load JSON + JS from `cdn.jsdelivr.net` (world-atlas /
+  // us-atlas TopoJSON, chart.js in widget-sanitizer iframe), but never
+  // CSS — so a `style-src*` block on jsDelivr is by definition third-party
+  // injection (WORLDMONITOR-J0 — antd@4 CSS injection, 270 events / 26
+  // users on finance.worldmonitor.app).
+  if (/^style-src(-elem)?$/.test(directive) && /^https:\/\/cdn\.jsdelivr\.net\//.test(blockedURI)) return true;
   // Inline script blocks from extensions/in-app browsers.
   if (blockedURI === 'inline' && directive === 'script-src-elem') return true;
   // Null blocked URI from in-app browsers.

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -158,6 +158,27 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
     it('suppresses manifest.webmanifest', () => {
       assert.ok(suppress('enforce', 'default-src', 'https://www.worldmonitor.app/manifest.webmanifest', '', false));
     });
+
+    it('suppresses third-party stylesheet injection from cdn.jsdelivr.net (style-src-elem)', () => {
+      // WORLDMONITOR-J0: extension/bookmarklet injecting antd@4 CSS on
+      // finance.worldmonitor.app — 270 events / 26 users. We never load
+      // CSS from jsDelivr (only JSON atlases + chart.js JS).
+      assert.ok(suppress('enforce', 'style-src-elem', 'https://cdn.jsdelivr.net/npm/antd@4/dist/antd.min.css', '', false));
+    });
+
+    it('suppresses cdn.jsdelivr.net for plain style-src directive too', () => {
+      // Older browsers / legacy CSP fall back to `style-src` rather than
+      // `style-src-elem`; same suppression should apply.
+      assert.ok(suppress('enforce', 'style-src', 'https://cdn.jsdelivr.net/npm/bootstrap@5/dist/css/bootstrap.min.css', '', false));
+    });
+
+    it('does NOT suppress jsDelivr for legitimate directive (script-src world-atlas / chart.js)', () => {
+      // We DO load JSON + JS from jsdelivr legitimately. Only style-src*
+      // is blanket-filtered. A real script-src block here would be a
+      // vendor-CDN CSP regression we want to see.
+      assert.ok(!suppress('enforce', 'script-src', 'https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js', '', false));
+      assert.ok(!suppress('enforce', 'connect-src', 'https://cdn.jsdelivr.net/npm/world-atlas@2/countries-50m.json', '', false));
+    });
   });
 
   describe('localhost/loopback', () => {


### PR DESCRIPTION
## Summary

WORLDMONITOR-J0 — 270 events / 26 users on `finance.worldmonitor.app` reporting `style-src-elem` CSP violations for `https://cdn.jsdelivr.net/npm/antd@4/dist/antd.min.css`. We never load Ant Design from jsDelivr; the injection is from a browser extension / bookmarklet / dev-tool walking our DOM and dropping in a popular UI library stylesheet.

We **do** use jsDelivr legitimately for:
- `world-atlas` / `us-atlas` TopoJSON (`src/config/geo.ts`) — `connect-src`
- `chart.js` inside the widget-sanitizer iframe — `script-src`

…but never for stylesheets. The filter is precisely scoped: only `style-src` and `style-src-elem` directives, only when the blocked URI host is `cdn.jsdelivr.net`. A real `script-src` or `connect-src` CSP regression on the same host still surfaces as a Sentry event (negative-control test enforces this).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 7733/7733 pass
- [x] `node --test tests/csp-filter.test.mjs` — 53/53 pass (3 new cases: antd@4 style-src-elem suppress, bootstrap@5 style-src fallback suppress, chart.js script-src + world-atlas connect-src **negative-control must-not-suppress**)
- [x] `node --test tests/edge-functions.test.mjs` — 178/178 pass
- [x] Edge bundle check — clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK

## Sentry status

WORLDMONITOR-J0 marked resolved in next release; auto-reopen if the regex doesn't catch this variant.