### PR TITLE
docs: add Peru national data source proposals

### DIFF
--- a/docs/proposals/peru-national-data-sources.md
+++ b/docs/proposals/peru-national-data-sources.md
@@ -1,0 +1,270 @@
+# Peru National Data Sources Proposal
+
+## Summary
+
+This document proposes a set of Peru-focused national data sources that could expand World Monitor's regional situational awareness coverage for infrastructure, transport, emergency management, hydrometeorology, seismic activity, energy, macroeconomics, and environmental monitoring.
+
+The goal is to identify official or high-value public sources before implementing any new data layer. This proposal is documentation-only and does not introduce code changes, dependencies, or live data ingestion.
+
+## Rationale
+
+Peru is highly exposed to transport disruptions, heavy rains, landslides, floods, earthquakes, energy demand shifts, and regional emergency events. Adding Peru-focused official sources would improve World Monitor's usefulness for:
+
+- LATAM situational awareness.
+- Critical infrastructure monitoring.
+- Business continuity planning.
+- Logistics and transport risk analysis.
+- MSP / ISP field operations planning.
+- Emergency and disaster monitoring.
+- Energy and macroeconomic context.
+
+## Candidate Sources
+
+| Priority | Source | Domain | Potential World Monitor Use |
+|---:|---|---|---|
+| 1 | MTC / Provias Nacional road status viewer | Transport infrastructure | Road transitability layer |
+| 2 | SUTRAN interactive alert map | Road alerts / transport risk | Road disruption and warning layer |
+| 3 | INDECI / COEN | Emergency management | Emergency reports and disaster awareness feed |
+| 4 | SENAMHI | Weather and hydrometeorology | Rainfall, river, climate and hydrological alert layer |
+| 5 | IGP / CENSIS | Seismic monitoring | Peru earthquake layer |
+| 6 | COES | Energy grid / electricity | Demand, generation and frequency indicators |
+| 7 | BCRPData | Macroeconomics | Peru macro indicators for the finance variant |
+| 8 | OEFA / MINAM / SINIA | Environmental monitoring | Water, air, protected areas and environmental risk layers |
+| 9 | Peru National Open Data Platform | Public datasets catalog | Source discovery and dataset registry |
+
+## 1. Transport Infrastructure
+
+### 1.1 MTC Road Status Viewer
+
+- **Source:** Ministerio de Transportes y Comunicaciones (MTC)
+- **Public viewer:** https://saecoe.mtc.gob.pe/visor
+- **Domain:** National road transitability
+- **Coverage:** Peru national road network
+- **Reported status model:**
+  - Green: normal transit
+  - Yellow: restricted transit
+  - Red: interrupted / blocked transit
+
+### Potential Layer
+
+```text
+Layer: Peru Road Transitability
+Type: transport_infrastructure
+Country: PE
+Severity mapping:
+  normal -> low
+  restricted -> medium
+  interrupted -> high
+```
+
+### Use Cases
+
+- Route risk monitoring.
+- Logistics disruption analysis.
+- Road closure awareness.
+- Emergency planning during rainy season.
+- MSP / ISP field operations planning.
+
+## 2. SUTRAN Road Alerts
+
+- **Source:** Superintendencia de Transporte Terrestre de Personas, Carga y Mercancias (SUTRAN)
+- **Public viewer:** http://gis.sutran.gob.pe/alerta_sutran/
+- **Domain:** Road disruption alerts
+- **Potential events:**
+  - Heavy rain
+  - Landslides
+  - Mudslides / huaicos
+  - Road accidents
+  - Social blockades
+  - Infrastructure damage
+  - Snow / weather-related disruptions
+
+### Potential Layer
+
+```text
+Layer: Peru SUTRAN Road Alerts
+Type: road_alerts
+Country: PE
+```
+
+## 3. Emergency Management
+
+### INDECI / COEN
+
+- **Source:** Instituto Nacional de Defensa Civil (INDECI) / Centro de Operaciones de Emergencia Nacional (COEN)
+- **Website:** https://coen.indeci.gob.pe/
+- **Domain:** Emergency and disaster monitoring
+
+### Potential Feed
+
+```text
+Feed: Peru Emergency Reports
+Type: emergency_management
+Country: PE
+```
+
+### Candidate Event Types
+
+- Floods
+- Landslides
+- Heavy rains
+- Earthquakes
+- Fires
+- Infrastructure damage
+- Humanitarian response
+- Regional emergency coordination
+
+## 4. Hydrometeorology
+
+### SENAMHI
+
+- **Source:** Servicio Nacional de Meteorologia e Hidrologia del Peru (SENAMHI)
+- **Domain:** Weather, climate and hydrological monitoring
+
+### Potential Layer
+
+```text
+Layer: Peru Hydro-Meteorological Alerts
+Type: hydromet_alerts
+Country: PE
+```
+
+### Candidate Signals
+
+- Rainfall alerts
+- River levels
+- Hydrological warnings
+- Frost / cold events
+- Heat waves
+- Wind alerts
+- Flood risk conditions
+
+## 5. Seismic Activity
+
+### IGP / CENSIS
+
+- **Source:** Instituto Geofisico del Peru (IGP) / Centro Sismologico Nacional
+- **Domain:** Seismic monitoring
+
+### Potential Layer
+
+```text
+Layer: Peru Earthquakes
+Type: seismic_activity
+Country: PE
+```
+
+### Candidate Fields
+
+- Magnitude
+- Depth
+- Epicenter
+- Region
+- Event time
+- Coordinates
+- Perceived / non-perceived classification, if available
+
+## 6. Energy Infrastructure
+
+### COES
+
+- **Source:** Comite de Operacion Economica del Sistema Interconectado Nacional (COES)
+- **API documentation:** https://appserver.coes.org.pe/waMediciones/Help
+- **Domain:** Electricity demand, generation and system frequency
+
+### Potential Panel
+
+```text
+Panel: Peru Power Grid Indicators
+Variant: finance / infrastructure
+Country: PE
+```
+
+### Candidate Metrics
+
+- Demand
+- Generation
+- Area-level demand
+- Daily forecast
+- Frequency
+- Maximum demand ranking
+
+## 7. Macroeconomic Indicators
+
+### BCRPData
+
+- **Source:** Banco Central de Reserva del Peru (BCRP)
+- **API documentation:** https://estadisticas.bcrp.gob.pe/estadisticas/series/ayuda/api
+- **Domain:** Economic and financial indicators
+
+### Potential Panel
+
+```text
+Panel: Peru Macro Indicators
+Variant: finance
+Country: PE
+```
+
+### Candidate Metrics
+
+- Exchange rate
+- Inflation
+- Reference interest rate
+- International reserves
+- Monetary indicators
+- Commodity-linked indicators
+
+## 8. Environmental Monitoring
+
+### OEFA / MINAM / SINIA
+
+- **Source examples:** OEFA, MINAM, SINIA
+- **Domain:** Environmental supervision and open environmental data
+
+### Potential Layer
+
+```text
+Layer: Peru Environmental Monitoring
+Type: environmental_risk
+Country: PE
+```
+
+### Candidate Datasets
+
+- Water quality
+- Air quality
+- Protected areas
+- Environmental supervision points
+- Deforestation
+- Solid waste
+- Glaciers and hydrological indicators
+
+## Implementation Notes
+
+Before implementation, each source should be reviewed for:
+
+1. Machine-readable access method: API, RSS, GeoJSON, ArcGIS FeatureServer, WMS/WFS, CSV, JSON or DKAN datastore.
+2. License and attribution requirements.
+3. Update frequency.
+4. Stability of endpoint.
+5. Field-level data quality.
+6. Geographic coordinates or geocoding feasibility.
+7. Whether the data can be safely cached.
+8. Whether the source is official, journalistic, civic or third-party.
+
+## Suggested Next Steps
+
+1. Validate MTC and SUTRAN map network calls to identify whether they expose a stable public endpoint.
+2. Validate INDECI / COEN feeds or report endpoints.
+3. Validate SENAMHI alert and hydrological data access.
+4. Validate IGP seismic dataset endpoint.
+5. Add a separate RSS candidate document for Peru news sources.
+6. Start with a documentation-only PR before introducing live data ingestion.
+
+## Proposed PR Scope
+
+```text
+docs: add Peru national data sources proposal
+```
+
+Documentation-only contribution. No code changes.

--- a/docs/proposals/peru-national-data-sources.md
+++ b/docs/proposals/peru-national-data-sources.md
@@ -258,8 +258,8 @@ Before implementation, each source should be reviewed for:
 2. Validate INDECI / COEN feeds or report endpoints.
 3. Validate SENAMHI alert and hydrological data access.
 4. Validate IGP seismic dataset endpoint.
-5. Add a separate RSS candidate document for Peru news sources.
-6. Start with a documentation-only PR before introducing live data ingestion.
+5. See `peru-rss-feed-candidates.md` for Peru RSS feed candidates (added in this PR).
+6. Next step: validate endpoint discovery per `peru-road-transitability-layer.md` Phase 1 checklist before introducing live data ingestion.
 
 ## Proposed PR Scope
 

--- a/docs/proposals/peru-road-transitability-layer.md
+++ b/docs/proposals/peru-road-transitability-layer.md
@@ -1,0 +1,159 @@
+# Peru Road Transitability Layer Proposal
+
+## Summary
+
+This document proposes a Peru road transitability layer for World Monitor using official public information from Peru's Ministry of Transport and Communications (MTC), Provias Nacional, concessionaires, and SUTRAN alert sources.
+
+The first implementation step should be endpoint discovery and validation. This proposal is documentation-only and does not introduce scraping, dependencies, or live ingestion.
+
+## Problem Statement
+
+Peru's national road network is frequently affected by heavy rains, landslides, mudslides, accidents, social blockades, maintenance works and infrastructure damage. These events can affect logistics, field operations, emergency response, travel, and business continuity.
+
+A road transitability layer would improve World Monitor's infrastructure and operational-risk coverage for Peru and could become a template for other LATAM countries.
+
+## Candidate Sources
+
+### MTC / Provias Nacional Road Status Viewer
+
+- **Source:** Ministerio de Transportes y Comunicaciones (MTC) / Provias Nacional
+- **Public viewer:** https://saecoe.mtc.gob.pe/visor
+- **Domain:** national road status / transitability
+- **Expected status model:**
+  - green: normal transit
+  - yellow: restricted transit
+  - red: interrupted / blocked transit
+
+### SUTRAN Interactive Alert Map
+
+- **Source:** Superintendencia de Transporte Terrestre de Personas, Carga y Mercancias (SUTRAN)
+- **Public viewer:** http://gis.sutran.gob.pe/alerta_sutran/
+- **Domain:** road alerts and operational road warnings
+- **Potential event classes:**
+  - heavy rain
+  - landslide
+  - mudslide / huaico
+  - road accident
+  - social blockade
+  - infrastructure damage
+  - restricted circulation
+
+## Proposed World Monitor Layer
+
+```text
+Layer: Peru Road Transitability
+Type: transport_infrastructure
+Country: PE
+Primary source: MTC / Provias Nacional
+Secondary source: SUTRAN road alerts
+```
+
+## Severity Mapping
+
+| Source status | Suggested World Monitor severity | Suggested meaning |
+|---|---|---|
+| Normal transit | low | road segment is operational |
+| Restricted transit | medium | degraded road availability or partial restriction |
+| Interrupted / blocked transit | high | road segment is unavailable or blocked |
+| Unknown / unavailable | unknown | source unavailable or status not classified |
+
+## Suggested Data Model
+
+```ts
+interface PeruRoadStatusEvent {
+  id: string;
+  source: 'mtc' | 'sutran';
+  country: 'PE';
+  region?: string;
+  province?: string;
+  district?: string;
+  roadName?: string;
+  routeCode?: string;
+  kilometerStart?: number;
+  kilometerEnd?: number;
+  status: 'normal' | 'restricted' | 'interrupted' | 'unknown';
+  severity: 'low' | 'medium' | 'high' | 'unknown';
+  cause?: string;
+  description?: string;
+  latitude?: number;
+  longitude?: number;
+  geometry?: unknown;
+  updatedAt?: string;
+  sourceUrl: string;
+}
+```
+
+## User Value
+
+This layer would support:
+
+- logistics disruption monitoring;
+- route risk assessment;
+- field operations planning;
+- emergency response awareness;
+- MSP / ISP technician dispatch planning;
+- rainy season monitoring;
+- regional business continuity analysis;
+- infrastructure risk dashboards.
+
+## Implementation Discovery Checklist
+
+Before implementation, inspect the public viewers and identify whether either source exposes:
+
+- JSON API;
+- GeoJSON;
+- ArcGIS FeatureServer;
+- WMS / WFS;
+- CSV / XLS download;
+- public REST endpoint;
+- static dataset;
+- official RSS / alert feed.
+
+Avoid brittle HTML scraping unless no other official machine-readable option exists and the project maintainers approve the approach.
+
+## Implementation Approach
+
+### Phase 1 — Source Discovery
+
+1. Inspect browser network calls for the MTC viewer.
+2. Inspect browser network calls for the SUTRAN alert map.
+3. Identify response format and update cadence.
+4. Validate attribution and reuse constraints.
+5. Document endpoint stability and sample payloads.
+
+### Phase 2 — Data Adapter Proposal
+
+If a stable endpoint exists:
+
+1. Add a source adapter.
+2. Normalize status values.
+3. Map road events to World Monitor severity.
+4. Add caching policy.
+5. Add basic tests for parsing and severity mapping.
+6. Document source attribution.
+
+### Phase 3 — Map Layer
+
+1. Add toggleable Peru road layer.
+2. Render road disruptions as markers or line segments depending on available geometry.
+3. Add popup with status, cause, route and source link.
+4. Add filter by severity and region if feasible.
+
+## Risks and Constraints
+
+| Risk | Mitigation |
+|---|---|
+| No stable public endpoint | Keep as documented proposal until endpoint is confirmed |
+| Viewer-only data | Avoid fragile scraping unless approved |
+| Incomplete geolocation | Support event markers first, route geometry later |
+| Attribution requirements | Display source and link for each event |
+| Update frequency unknown | Start with conservative caching |
+| Duplicate MTC/SUTRAN reports | Add deduplication by route, location, time and description |
+
+## Proposed PR Scope
+
+```text
+docs: propose Peru road transitability layer
+```
+
+Documentation-only contribution. No code changes.

--- a/docs/proposals/peru-rss-feed-candidates.md
+++ b/docs/proposals/peru-rss-feed-candidates.md
@@ -1,0 +1,186 @@
+# Peru RSS Feed Candidates
+
+## Summary
+
+This document proposes Peru-focused RSS feed candidates that could expand World Monitor's LATAM coverage across politics, economy, regional events, technology, infrastructure, and public-interest news.
+
+This proposal is documentation-only. It does not add live feeds to the application and does not modify feed configuration files.
+
+## Selection Criteria
+
+Candidate feeds should be reviewed against the following criteria before implementation:
+
+1. Feed availability and technical stability.
+2. Editorial reliability and update frequency.
+3. Clear category mapping.
+4. Attribution requirements.
+5. Language and regional relevance.
+6. Risk of duplicate content.
+7. Source tier classification.
+8. State affiliation or propaganda-risk labeling, when applicable.
+
+## Recommended Categories
+
+| Category | Purpose |
+|---|---|
+| Politics | National political developments and government signals |
+| Economy | Macroeconomic, business and markets coverage |
+| Regional | Local incidents, infrastructure disruptions and regional alerts |
+| Technology | Technology, cybersecurity and digital transformation coverage |
+| World | International events relevant to Peru and LATAM |
+| Public Safety | Events with operational impact, transport, incidents and emergencies |
+
+## High-Priority Official / Institutional Feeds
+
+### Agencia Andina
+
+Agencia Andina is a high-priority candidate because it provides official public-interest coverage and has dedicated RSS channels.
+
+Candidate feeds:
+
+```text
+http://www.andina.com.pe/rss/AndinaPolitica.xml
+http://www.andina.com.pe/rss/AndinaEconomia.xml
+http://www.andina.com.pe/rss/AndinaRegionales.xml
+http://www.andina.com.pe/rss/AndinaLocales.xml
+```
+
+Suggested mapping:
+
+| Feed | Category | Suggested Source Tier |
+|---|---|---:|
+| Andina Politica | politics | 2 |
+| Andina Economia | economy | 2 |
+| Andina Regionales | regional | 2 |
+| Andina Locales | regional | 2 |
+
+Notes:
+
+- State-affiliated source.
+- Useful for official narratives, government signals and regional reporting.
+- Should be labeled clearly as official/state media.
+
+## High-Priority Business / Economy Feeds
+
+### Gestion
+
+Gestion is a strong candidate for Peru business, markets, economy and technology coverage.
+
+Candidate feeds to validate:
+
+```text
+https://gestion.pe/arc/outboundfeeds/rss/category/economia/?outputType=xml
+https://gestion.pe/arc/outboundfeeds/rss/category/tecnologia/?outputType=xml
+https://gestion.pe/arc/outboundfeeds/rss/category/mundo/?outputType=xml
+```
+
+Suggested mapping:
+
+| Feed | Category | Suggested Source Tier |
+|---|---|---:|
+| Gestion Economia | economy | 2 |
+| Gestion Tecnologia | technology | 2 |
+| Gestion Mundo | world | 2 |
+
+## High-Priority General News Feeds
+
+### El Comercio Peru
+
+El Comercio is a candidate for national coverage, economy, Peru, politics and world events.
+
+Candidate feeds to validate:
+
+```text
+https://elcomercio.pe/arcio/rss/
+https://elcomercio.pe/arcio/rss/category/politica/
+https://elcomercio.pe/arcio/rss/category/economia/
+https://elcomercio.pe/arcio/rss/category/peru/
+https://elcomercio.pe/arcio/rss/category/mundo/
+https://elcomercio.pe/arcio/rss/category/tecnologia/
+```
+
+Suggested mapping:
+
+| Feed | Category | Suggested Source Tier |
+|---|---|---:|
+| El Comercio Politica | politics | 2 |
+| El Comercio Economia | economy | 2 |
+| El Comercio Peru | regional | 2 |
+| El Comercio Mundo | world | 2 |
+| El Comercio Tecnologia | technology | 2 |
+
+## Additional Candidates Requiring Validation
+
+### RPP
+
+RPP is relevant for national news, regional coverage, technology, public safety and citizen-reported incidents.
+
+Candidate endpoints to validate:
+
+```text
+https://rpp.pe/rss
+https://rpp.pe/feed
+https://rpp.pe/arc/outboundfeeds/rss/
+```
+
+Potential categories:
+
+- politics
+- national news
+- regional events
+- technology
+- public safety
+- citizen reports
+
+### Regional / Local Candidates
+
+Regional feeds can improve early detection of transport disruptions, floods, protests, public safety events and local emergencies.
+
+Candidates to validate:
+
+```text
+https://elbuho.pe/feed
+https://lahora.pe/feed
+https://diariovoces.com.pe/feed
+https://cronicaviva.com.pe/feed
+https://caretas.pe/feed
+https://perureports.com/feed
+```
+
+Suggested mapping:
+
+| Source | Region / Focus | Potential Category |
+|---|---|---|
+| El Buho | Southern Peru / Arequipa | regional |
+| La Hora | Northern Peru / Piura | regional |
+| Diario Voces | Amazon / San Martin | regional |
+| Cronica Viva | National / politics | politics |
+| Caretas | Politics / analysis | politics |
+| Peru Reports | English-language Peru news | world / regional |
+
+## Proposed Validation Workflow
+
+Before adding any feed to a live configuration:
+
+1. Confirm the feed returns valid XML.
+2. Confirm article URLs resolve correctly.
+3. Confirm titles and descriptions are parsable.
+4. Measure update frequency.
+5. Check whether the feed duplicates existing sources.
+6. Assign source tier.
+7. Label state affiliation when applicable.
+8. Run the repository feed validation script if feed configuration is modified.
+
+Suggested command after implementation:
+
+```bash
+npm run test:feeds
+```
+
+## Proposed PR Scope
+
+```text
+docs: add Peru RSS feed candidates
+```
+
+Documentation-only contribution. No code changes.


### PR DESCRIPTION
Adds documentation-only proposals for Peru-focused national data sources, RSS feed candidates, and a road transitability layer using MTC/SUTRAN sources. No code changes.