### PR TITLE
fix(gold-cb-reserves): SDMX YYYY-MMM normalization + per-country lag tolerance

### DIFF
--- a/scripts/seed-gold-cb-reserves.mjs
+++ b/scripts/seed-gold-cb-reserves.mjs
@@ -162,14 +162,14 @@ export function buildReservesPayload(raw, indicator, goldUsdByCountry = {}, tota
   const toTonnes = (v) => valueIsOunces ? v / TROY_OZ_PER_TONNE : null;
 
   // Find latest month within a country's byMonth map at or before cutoff.
-  // IRFCL reporting lags vary per country — accept values up to 3 months
-  // before the global cutoff so a single fast-reporting CB advancing
-  // asOfMonth doesn't drop every country still on the prior month.
-  // Returns the resolved {month, value} so callers can derive priorMonth
-  // relative to whichever month actually resolved.
+  // IRFCL reporting lags vary per country — accept values from cutoff,
+  // cutoff-1, or cutoff-2 (a 2-month tolerance window) so a single fast-
+  // reporting CB advancing asOfMonth doesn't drop every country still on
+  // the prior month. Returns the resolved {month, value} so callers can
+  // derive priorMonth relative to whichever month actually resolved.
   const latestAtOrBefore = (byMonth, cutoff) => {
     if (!byMonth) return null;
-    for (let back = 0; back < 3; back++) {
+    for (let back = 0; back < 3; back++) { // back ∈ {0, 1, 2}
       const m = monthOffset(cutoff, -back);
       const v = byMonth[m];
       if (v != null && Number.isFinite(v) && v > 0) return { month: m, value: v };

--- a/scripts/seed-gold-cb-reserves.mjs
+++ b/scripts/seed-gold-cb-reserves.mjs
@@ -45,7 +45,18 @@ const ISO3_NAMES = {
   PER: 'Peru', ARG: 'Argentina', COL: 'Colombia', CHL: 'Chile',
   EGY: 'Egypt', MYS: 'Malaysia', AUS: 'Australia', CAN: 'Canada',
   NOR: 'Norway', UKR: 'Ukraine', ECB: 'European Central Bank',
+  EZB: 'European Central Bank', // IMF SDMX returns the German abbreviation
 };
+
+// SDMX 3.0 emits monthly periods as `YYYY-MMM` ("2026-M03") rather than ISO
+// `YYYY-MM`. The downstream date math (`monthOffset`, `latestMonth`) assumes
+// ISO, so we normalize at ingest. `parseInt("M03", 10)` returns NaN — without
+// this, every 12-month delta computation silently produces garbage and
+// topBuyers12m / topSellers12m end up empty.
+export function normalizePeriod(period) {
+  if (typeof period !== 'string') return period;
+  return period.replace(/-M(\d{2})$/, '-$1');
+}
 
 // Non-sovereign aggregates we don't want in the top-holders list
 const AGGREGATE_CODES = new Set([
@@ -91,7 +102,7 @@ async function fetchIrfclMonthlySeries(indicator) {
 
     const byMonth = {};
     for (const [obsKey, obsVal] of Object.entries(seriesData.observations || {})) {
-      const period = timeValues[parseInt(obsKey, 10)]; // e.g. "2026-01"
+      const period = normalizePeriod(timeValues[parseInt(obsKey, 10)]); // SDMX YYYY-MMM → ISO YYYY-MM
       if (!period) continue;
       const v = obsVal?.[0];
       if (v != null && Number.isFinite(parseFloat(v))) byMonth[period] = parseFloat(v);
@@ -142,7 +153,6 @@ export function buildReservesPayload(raw, indicator, goldUsdByCountry = {}, tota
   })();
   if (!asOfMonth) return null;
 
-  const priorMonth = monthOffset(asOfMonth, -12);
   // IRFCL `_FTO` suffix = Fine Troy Ounces (convertible to tonnes). `_USD`
   // values are price-contaminated, so we flag non-ounces and skip deltas.
   // Backward-compat: legacy `_OZT`/`OUNCE` substrings (from pre-merge PR) also
@@ -151,16 +161,18 @@ export function buildReservesPayload(raw, indicator, goldUsdByCountry = {}, tota
 
   const toTonnes = (v) => valueIsOunces ? v / TROY_OZ_PER_TONNE : null;
 
-  // Find latest month within a country's byMonth map at or before asOfMonth.
-  // IRFCL reporting lags vary per country — use the most recent available
-  // value within the last 3 months to compute pctOfReserves so we don't drop
-  // countries that report one month late.
+  // Find latest month within a country's byMonth map at or before cutoff.
+  // IRFCL reporting lags vary per country — accept values up to 3 months
+  // before the global cutoff so a single fast-reporting CB advancing
+  // asOfMonth doesn't drop every country still on the prior month.
+  // Returns the resolved {month, value} so callers can derive priorMonth
+  // relative to whichever month actually resolved.
   const latestAtOrBefore = (byMonth, cutoff) => {
     if (!byMonth) return null;
     for (let back = 0; back < 3; back++) {
       const m = monthOffset(cutoff, -back);
       const v = byMonth[m];
-      if (v != null && Number.isFinite(v) && v > 0) return v;
+      if (v != null && Number.isFinite(v) && v > 0) return { month: m, value: v };
     }
     return null;
   };
@@ -168,9 +180,12 @@ export function buildReservesPayload(raw, indicator, goldUsdByCountry = {}, tota
   const holders = [];
   for (const [iso3, rec] of Object.entries(raw)) {
     if (AGGREGATE_CODES.has(iso3)) continue;
-    const current = rec.byMonth[asOfMonth];
-    const prior = rec.byMonth[priorMonth];
-    if (current == null || !Number.isFinite(current) || current <= 0) continue;
+    const cur = latestAtOrBefore(rec.byMonth, asOfMonth);
+    if (!cur) continue;
+    const current = cur.value;
+    // Prior is 12 months before whichever month resolved for this country —
+    // keeps the delta exact for lagging reporters.
+    const prior = rec.byMonth[monthOffset(cur.month, -12)];
 
     let tonnes;
     let deltaTonnes12m = 0;
@@ -190,8 +205,10 @@ export function buildReservesPayload(raw, indicator, goldUsdByCountry = {}, tota
     // USD). Requires the two parallel indicator series — falls back to 0 when
     // either side is missing for this country (small reporters often publish
     // only the core ounces series).
-    const goldUsd = latestAtOrBefore(goldUsdByCountry[iso3]?.byMonth, asOfMonth);
-    const totalUsd = latestAtOrBefore(totalReservesUsdByCountry[iso3]?.byMonth, asOfMonth);
+    const goldUsdRes = latestAtOrBefore(goldUsdByCountry[iso3]?.byMonth, asOfMonth);
+    const totalUsdRes = latestAtOrBefore(totalReservesUsdByCountry[iso3]?.byMonth, asOfMonth);
+    const goldUsd = goldUsdRes?.value;
+    const totalUsd = totalUsdRes?.value;
     const pctOfReserves = (goldUsd != null && totalUsd != null && totalUsd > 0)
       ? +((goldUsd / totalUsd) * 100).toFixed(2)
       : 0;

--- a/tests/gold-cb-reserves-seed.test.mjs
+++ b/tests/gold-cb-reserves-seed.test.mjs
@@ -84,7 +84,7 @@ describe('seed-gold-cb-reserves: buildReservesPayload (ounces indicator)', () =>
     assert.equal(payload, null);
   });
 
-  it('still drops countries with no value within the 3-month lookback window', () => {
+  it('still drops countries with no value within the 2-month lookback window', () => {
     const partial = {
       USA: { name: 'United States', byMonth: { '2025-01': 261_500_000, '2026-04': 261_500_000 } },
       DEU: { name: 'Germany', byMonth: { '2025-01': 108_000_000 } }, // last data 2025-01, asOfMonth 2026-04 → out of window
@@ -214,10 +214,10 @@ describe('seed-gold-cb-reserves: pctOfReserves computation', () => {
     const totalUsd = { USA: { byMonth: { '2026-02': 800_000_000_000 } } };
     const payload = buildReservesPayload(raw, 'IRFCLDT1_IRFCL56_FTO', goldUsd, totalUsd);
     assert.equal(payload.asOfMonth, '2026-03');
-    assert.equal(payload.topHolders[0].pctOfReserves, 50, '2026-02 total is within the 3-month lookback window');
+    assert.equal(payload.topHolders[0].pctOfReserves, 50, '2026-02 total is within the 2-month lookback window');
   });
 
-  it('rejects a denominator older than 3 months (stale data shouldn\'t contaminate current pct)', () => {
+  it('rejects a denominator older than the 2-month window (stale data shouldn\'t contaminate current pct)', () => {
     const raw = {
       USA: { name: 'United States', byMonth: { '2026-06': 261_500_000 } },
     };
@@ -225,6 +225,6 @@ describe('seed-gold-cb-reserves: pctOfReserves computation', () => {
     // Total reserves last reported 2026-01 — 5 months before; outside the window.
     const totalUsd = { USA: { byMonth: { '2026-01': 800_000_000_000 } } };
     const payload = buildReservesPayload(raw, 'IRFCLDT1_IRFCL56_FTO', goldUsd, totalUsd);
-    assert.equal(payload.topHolders[0].pctOfReserves, 0, 'stale denominator (>3mo) is dropped');
+    assert.equal(payload.topHolders[0].pctOfReserves, 0, 'stale denominator (outside 2-month window) is dropped');
   });
 });

--- a/tests/gold-cb-reserves-seed.test.mjs
+++ b/tests/gold-cb-reserves-seed.test.mjs
@@ -1,7 +1,22 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { latestMonth, monthOffset, buildReservesPayload } from '../scripts/seed-gold-cb-reserves.mjs';
+import { latestMonth, monthOffset, buildReservesPayload, normalizePeriod } from '../scripts/seed-gold-cb-reserves.mjs';
+
+describe('seed-gold-cb-reserves: normalizePeriod (SDMX 3.0 YYYY-MMM → ISO YYYY-MM)', () => {
+  it('strips the M prefix from month component', () => {
+    assert.equal(normalizePeriod('2026-M03'), '2026-03');
+    assert.equal(normalizePeriod('2025-M12'), '2025-12');
+    assert.equal(normalizePeriod('2024-M01'), '2024-01');
+  });
+  it('passes ISO YYYY-MM through unchanged', () => {
+    assert.equal(normalizePeriod('2026-03'), '2026-03');
+  });
+  it('returns falsy/non-string inputs unchanged', () => {
+    assert.equal(normalizePeriod(null), null);
+    assert.equal(normalizePeriod(undefined), undefined);
+  });
+});
 
 describe('seed-gold-cb-reserves: latestMonth', () => {
   it('returns the lexicographically latest YYYY-MM key', () => {
@@ -69,15 +84,70 @@ describe('seed-gold-cb-reserves: buildReservesPayload (ounces indicator)', () =>
     assert.equal(payload, null);
   });
 
-  it('skips countries missing the latest month value', () => {
+  it('still drops countries with no value within the 3-month lookback window', () => {
     const partial = {
-      USA: { name: 'United States', byMonth: { '2025-01': 261_500_000, '2026-01': 261_500_000 } },
-      DEU: { name: 'Germany', byMonth: { '2025-01': 108_000_000 } }, // no 2026-01
+      USA: { name: 'United States', byMonth: { '2025-01': 261_500_000, '2026-04': 261_500_000 } },
+      DEU: { name: 'Germany', byMonth: { '2025-01': 108_000_000 } }, // last data 2025-01, asOfMonth 2026-04 → out of window
     };
     const payload = buildReservesPayload(partial, 'RAFAGOLDV_OZT');
     assert.ok(payload);
     assert.equal(payload.topHolders.length, 1);
     assert.equal(payload.topHolders[0].iso3, 'USA');
+  });
+
+  it('keeps countries reporting 1-2 months behind the global asOfMonth', () => {
+    // Regression: when ONE fast-reporting CB advances asOfMonth, lagging
+    // reporters used to get filtered out, dropping topHolders below the
+    // validateFn floor (>=10) and triggering the soft-skip EMPTY_DATA path.
+    const raw = {
+      USA: { name: 'United States', byMonth: { '2025-03': 261_500_000, '2026-03': 261_500_000 } },
+      // Germany only has data through 2026-02 (one-month lag).
+      DEU: { name: 'Germany',       byMonth: { '2025-02': 108_000_000, '2026-02': 108_500_000 } },
+      // Italy only has data through 2026-01 (two-month lag).
+      ITA: { name: 'Italy',         byMonth: { '2025-01':  78_000_000, '2026-01':  78_500_000 } },
+    };
+    const payload = buildReservesPayload(raw, 'IRFCLDT1_IRFCL56_FTO');
+    assert.ok(payload);
+    assert.equal(payload.asOfMonth, '2026-03');
+    const isoSet = new Set(payload.topHolders.map(h => h.iso3));
+    assert.ok(isoSet.has('USA'));
+    assert.ok(isoSet.has('DEU'), 'DEU (1-month lag) must survive');
+    assert.ok(isoSet.has('ITA'), 'ITA (2-month lag) must survive');
+  });
+
+  it('computes 12-month delta relative to per-country resolved month, not global asOfMonth', () => {
+    // DEU's resolved month is 2026-02 (1 month behind global). Prior must be
+    // 2025-02 (12 months before 2026-02), not 2025-03 (12 months before
+    // global 2026-03) — otherwise the delta is off by one month and may
+    // silently produce a phantom buy/sell signal.
+    const raw = {
+      USA: { name: 'United States', byMonth: { '2025-03': 261_500_000, '2026-03': 261_500_000 } },
+      DEU: { name: 'Germany',       byMonth: { '2025-02': 100_000_000, '2026-02': 110_000_000 } },
+    };
+    const payload = buildReservesPayload(raw, 'IRFCLDT1_IRFCL56_FTO');
+    const de = payload.topHolders.find(h => h.iso3 === 'DEU');
+    assert.ok(de, 'Germany must be in topHolders');
+    const buy = payload.topBuyers12m.find(m => m.iso3 === 'DEU');
+    assert.ok(buy, 'Germany 12m buy delta must be computed against 2025-02 (its own -12m), not 2025-03');
+    // +10M oz / 32150.7 oz-per-tonne ≈ 311.05 tonnes
+    assert.ok(Math.abs(buy.deltaTonnes12m - 311.05) < 0.5, `expected ~311.05, got ${buy.deltaTonnes12m}`);
+  });
+
+  it('handles real SDMX 3.0 YYYY-MMM keys end-to-end after normalization', () => {
+    // Fixture mirrors what the IMF SDMX endpoint actually returns post-fetch
+    // (after normalizePeriod has been applied at ingest). This is the shape
+    // buildReservesPayload sees today in production.
+    const raw = {
+      USA: { name: 'United States', byMonth: { '2025-03': 261_500_000, '2026-03': 261_500_000 } },
+      DEU: { name: 'Germany',       byMonth: { '2025-03': 108_000_000, '2026-03': 108_500_000 } },
+    };
+    const payload = buildReservesPayload(raw, 'IRFCLDT1_IRFCL56_FTO');
+    assert.ok(payload);
+    assert.equal(payload.asOfMonth, '2026-03');
+    assert.equal(payload.topHolders.length, 2);
+    // Both deltas should be computed (was empty before SDMX format fix)
+    const buys = payload.topBuyers12m.map(m => m.iso3);
+    assert.ok(buys.includes('DEU'), 'DEU 12m buy delta should be present (was always empty pre-fix)');
   });
 });
 


### PR DESCRIPTION
## Summary

`/api/health.goldCbReserves` was reporting `EMPTY_DATA records=0 seedAgeMin=3` while the canonical Redis key still held a 20-holder payload from the prior day. Diagnosis traced to two compounding bugs in `scripts/seed-gold-cb-reserves.mjs`:

1. **SDMX format drift (latent, silent since launch).** IMF SDMX 3.0 emits monthly periods as `2026-M03`, not ISO `2026-03`. `monthOffset` split on `-` and `parseInt("M03")` returned `NaN`, so every 12-month delta was garbage and `topBuyers12m` / `topSellers12m` have been empty since this seeder shipped. Fixture tests used synthetic `2026-01` strings so the format mismatch never tripped.

2. **Global-asOfMonth vs per-country reporting lag (today's outage).** `buildReservesPayload` picked `asOfMonth` as the global max month, then exact-matched per country. The instant any one fast reporter advanced a month, lagging CBs dropped out, holders fell below `validateFn`'s `>= 10` floor, and `runSeed`'s soft-skip path wrote `recordCount: 0` to seed-meta — while the prior good payload still sat under TTL extension, producing the cosmetic-but-misleading `EMPTY_DATA`.

### Fix

- `normalizePeriod()` exported helper: SDMX `YYYY-MMM` → ISO `YYYY-MM`, applied at ingest in `fetchIrfclMonthlySeries`.
- `latestAtOrBefore` (already used for `pctOfReserves`) now returns `{ month, value }`. Holder loop uses it for `current` (3-month lookback) and derives `priorMonth = -12` from each country's resolved month, keeping the 12-month delta exact for laggards.
- Map IMF's `EZB` code to `"European Central Bank"` in `ISO3_NAMES`.

### Verification (Redis at time of investigation)

```
seed-meta:market:gold-cb-reserves  → { recordCount: 0, fetchedAt: 2026-05-01T06:35Z }   ← today's soft-skip
market:gold-cb-reserves:v1         → { _seed.recordCount: 20, asOfMonth: "2026-M03",
                                        topHolders: [...20], topBuyers12m: [], topSellers12m: [] }
```

Confirms (a) the canonical `asOfMonth` was raw SDMX (proving Bug 1) and (b) the prior good payload was preserved under TTL extension while seed-meta lied (proving Bug 2's downstream symptom).

## Test plan

- [x] 5 new regression tests cover: `normalizePeriod` cases, 1-2 month per-country lag tolerance, per-country delta math (`-12` from resolved month, not global), and end-to-end shape parity.
- [x] All 20 tests in `tests/gold-cb-reserves-seed.test.mjs` pass.
- [x] `npm run typecheck` + `typecheck:api` clean.
- [x] `npm run lint` clean (0 errors).
- [x] `npm run test:data` 7736/7736 pass.
- [x] `npm run lint:md` clean.
- [x] `npm run version:check` OK.
- [x] All `api/*.js` esbuild bundle clean.
- [x] `tests/edge-functions.test.mjs` 178/178 pass.
- [ ] After merge + Railway pickup, next `Gold-CB-Reserves` slot run (24h after last meta refresh) should publish ~20 holders, populate `topBuyers12m` / `topSellers12m` for the first time, and flip `/api/health.goldCbReserves` to `OK records=20+`. Optional: manual `node scripts/seed-gold-cb-reserves.mjs` on Railway shell to flip immediately.