### PR TITLE
fix(sentry): suppress zero-frame Failed to fetch (no host suffix)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -493,6 +493,15 @@ Sentry.init({
         || /out of memory/i.test(msg)
         || /\.(?:toLowerCase|trim|indexOf|findIndex) is not a function/.test(msg)
         || /^(?:Error: )?Request timeout: \//.test(msg)
+        // `^Failed to fetch$` (no host suffix) with zero captured frames =
+        // background fetch from a service worker / browser extension /
+        // in-app webview / stale pre-deploy bundle. A first-party fetch
+        // failing in our shipped code surfaces with at least one
+        // source-mapped .ts frame on the rejection (the awaiting site).
+        // The hostname-suffixed variant `Failed to fetch (<host>)` is
+        // handled above by `isMaplibreAjaxFailure` which does its own
+        // first-party-host allowlist (WORLDMONITOR-KM).
+        || /^(?:TypeError: )?Failed to fetch$/.test(msg)
       )
     ) return null;
     if (hasAnyStack && !hasFirstParty && (
@@ -502,7 +511,6 @@ Sentry.init({
       || /^TypeError: Internal error$/.test(msg)
       || /^Key not found$/.test(msg)
       || /^Element not found$/.test(msg)
-      || /^(?:TypeError: )?Failed to fetch$/.test(msg)
       || /^TypeError: NetworkError/.test(msg)
       || /Could not connect to the server/.test(msg)
       || (excType === 'SyntaxError' && /^Unexpected (?:token|keyword)/.test(msg))

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -138,7 +138,6 @@ describe('empty-stack network/timeout errors are NOT suppressed', () => {
   // deploy, which the chunk-reload guard already auto-recovers. See the dedicated
   // suite below for that case (WORLDMONITOR-Q / WORLDMONITOR-15).
   const networkErrors = [
-    'TypeError: Failed to fetch',
     'TypeError: NetworkError when attempting to fetch resource.',
     'Could not connect to the server',
     'Operation timed out',
@@ -259,6 +258,15 @@ describe('zero-frame async-rejection patterns (timeout / DOMException / OOM / DO
     // (WORLDMONITOR-PW: /api/setIsSelect from Electron 39.2.7).
     ['Request timeout: /api/setIsSelect', 'Error'],
     ['Error: Request timeout: /api/whatever', 'Error'],
+    // Bare `Failed to fetch` with zero frames = service worker /
+    // extension / in-app webview / stale pre-deploy bundle. First-party
+    // fetch failures surface with a source-mapped frame on the awaiting
+    // site (WORLDMONITOR-KM 10ev/8u). The host-suffixed variant
+    // `Failed to fetch (<host>)` has its own first-party allowlist
+    // earlier in beforeSend (isMaplibreAjaxFailure), so doesn't go
+    // through this gate.
+    ['Failed to fetch', 'TypeError'],
+    ['TypeError: Failed to fetch', 'TypeError'],
   ];
 
   for (const [msg, type] of zeroFrameErrors) {


### PR DESCRIPTION
## Summary

WORLDMONITOR-KM — `TypeError: Failed to fetch` arriving via `auto.browser.global_handlers.onunhandledrejection` with **zero captured frames**, 10 events / 8 users.

The pattern `^(TypeError: )?Failed to fetch$` already existed in `src/main.ts#beforeSend` but was gated on `hasAnyStack && !hasFirstParty`. With zero frames, `hasAnyStack=false` → suppressor never fires → events leak. Same dead-letter shape PR #3497, #3500 (zero-frame async-rejection patterns) and PR #3505 (the `out of memory` / DOM-walker / `Request timeout: /…` follow-on) already addressed for sibling patterns. This PR completes the set.

## Why `!hasFirstParty` only is safe here

- A first-party fetch failure surfaces with at least one source-mapped `.ts` frame on the unhandled rejection (the awaiting site lives in our code).
- Zero-frame `Failed to fetch` is structurally a service-worker / browser-extension / in-app-webview / stale-pre-deploy-bundle background fetch — none of which we own.
- The host-suffixed variant `Failed to fetch (<host>)` is **NOT** routed through this gate — it has its own first-party-host allowlist earlier in `beforeSend` via `isMaplibreAjaxFailure`. Real first-party CDN/tile regressions that surface as e.g. `Failed to fetch (api.worldmonitor.app)` still go through the existing host allowlist, untouched.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 7736/7736 pass
- [x] `node --test tests/sentry-beforesend.test.mjs` — 139/139 pass (removed the stale `'TypeError: Failed to fetch'` "should NOT suppress with empty stack" assertion which was the inverse of the desired behavior; added 2 cases to the zero-frame suite covering bare + `TypeError:` prefix variants)
- [x] `node --test tests/edge-functions.test.mjs` — 178/178 pass
- [x] Edge bundle check — clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK

## Sentry status

WORLDMONITOR-KM marked resolved in next release; auto-reopen if the regex misses this variant.