### PR TITLE
refactor(seed-utils): lift normalizeSdmxPeriod into shared util

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -513,6 +513,45 @@ export async function imfFetchJson(url, proxyAuth) {
 // ---------------------------------------------------------------------------
 const IMF_SDMX_BASE = 'https://api.imf.org/external/sdmx/3.0';
 
+/**
+ * Normalize an SDMX 3.0 monthly period from `YYYY-MMM` (the on-the-wire
+ * shape, e.g. `2026-M03`) to ISO `YYYY-MM` so downstream date math —
+ * `period.split('-')`, `parseInt(month, 10)`, key comparisons — works
+ * without special-casing. The M-prefix silently corrupts these
+ * computations: `parseInt("M03", 10)` returns NaN, so 12-month delta
+ * lookups against `byMonth[priorMonth]` always miss.
+ *
+ * Other SDMX 3.0 frequencies pass through unchanged:
+ *   - Annual:    `YYYY`               (e.g. `2024`) — used by WEO/FM
+ *   - Quarterly: `YYYY-Q1..Q4`        (e.g. `2024-Q3`) — sortable as-is
+ *   - Daily:     `YYYY-MM-DD`         (e.g. `2024-03-15`) — used by ECB
+ *   - Monthly:   `YYYY-MMM` → YYYY-MM (e.g. `2026-M03` → `2026-03`)
+ *
+ * Future monthly/quarterly SDMX consumers MUST call this at ingest
+ * (right after reading `timeValues[parseInt(obsKey, 10)]`) so callers
+ * downstream can keep using simple string comparisons and ISO splits.
+ *
+ * @param {string|null|undefined} period
+ * @returns {string|null|undefined} Normalized period (or input unchanged for falsy/non-string)
+ */
+export function normalizeSdmxPeriod(period) {
+  if (typeof period !== 'string') return period;
+  return period.replace(/-M(\d{2})$/, '-$1');
+}
+
+/**
+ * IMF WEO/FM annual indicator fetcher. Hardcoded to annual frequency by URL
+ * construction (`*.${indicator}.A`) — period values come back as bare year
+ * strings (`"2024"`), so no SDMX-period normalization is required here.
+ *
+ * NOTE for future extensions: if you need IMF monthly or quarterly data
+ * (e.g. IRFCL, IFS, BOP), do NOT bolt frequency onto this helper — the
+ * dimension layout differs (e.g. IRFCL is 4-dim COUNTRY.INDICATOR.SECTOR.FREQUENCY,
+ * not WEO's 2-dim COUNTRY.INDICATOR). Roll a custom fetch and call
+ * `normalizeSdmxPeriod()` on every period before storing it as a key.
+ * See `scripts/seed-gold-cb-reserves.mjs::fetchIrfclMonthlySeries` for the
+ * canonical monthly pattern.
+ */
 export async function imfSdmxFetchIndicator(indicator, { database = 'WEO', years } = {}) {
   const agencyMap = { WEO: 'IMF.RES', FM: 'IMF.FAD' };
   const agency = agencyMap[database] || 'IMF.RES';

--- a/scripts/seed-gold-cb-reserves.mjs
+++ b/scripts/seed-gold-cb-reserves.mjs
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, withRetry } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, withRetry, normalizeSdmxPeriod } from './_seed-utils.mjs';
 loadEnvFile(import.meta.url);
+
+// Re-exported for the test suite. The shared normalizer lives in _seed-utils
+// so any future SDMX monthly/quarterly consumer can reuse it.
+export { normalizeSdmxPeriod as normalizePeriod };
 
 const CB_KEY = 'market:gold-cb-reserves:v1';
 const CB_TTL = 2_592_000; // 30 days — data is monthly, TTL long to survive missed runs
@@ -48,16 +52,6 @@ const ISO3_NAMES = {
   EZB: 'European Central Bank', // IMF SDMX returns the German abbreviation
 };
 
-// SDMX 3.0 emits monthly periods as `YYYY-MMM` ("2026-M03") rather than ISO
-// `YYYY-MM`. The downstream date math (`monthOffset`, `latestMonth`) assumes
-// ISO, so we normalize at ingest. `parseInt("M03", 10)` returns NaN — without
-// this, every 12-month delta computation silently produces garbage and
-// topBuyers12m / topSellers12m end up empty.
-export function normalizePeriod(period) {
-  if (typeof period !== 'string') return period;
-  return period.replace(/-M(\d{2})$/, '-$1');
-}
-
 // Non-sovereign aggregates we don't want in the top-holders list
 const AGGREGATE_CODES = new Set([
   'EU', 'WLD', 'AFE', 'AFW', 'AFR', 'EUU', 'EMU', 'OED', 'LIC', 'LMC',
@@ -102,7 +96,7 @@ async function fetchIrfclMonthlySeries(indicator) {
 
     const byMonth = {};
     for (const [obsKey, obsVal] of Object.entries(seriesData.observations || {})) {
-      const period = normalizePeriod(timeValues[parseInt(obsKey, 10)]); // SDMX YYYY-MMM → ISO YYYY-MM
+      const period = normalizeSdmxPeriod(timeValues[parseInt(obsKey, 10)]); // SDMX YYYY-MMM → ISO YYYY-MM
       if (!period) continue;
       const v = obsVal?.[0];
       if (v != null && Number.isFinite(parseFloat(v))) byMonth[period] = parseFloat(v);

--- a/tests/seed-utils-sdmx-period.test.mjs
+++ b/tests/seed-utils-sdmx-period.test.mjs
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizeSdmxPeriod } from '../scripts/_seed-utils.mjs';
+
+describe('_seed-utils: normalizeSdmxPeriod', () => {
+  it('converts SDMX 3.0 monthly YYYY-MMM to ISO YYYY-MM', () => {
+    assert.equal(normalizeSdmxPeriod('2026-M03'), '2026-03');
+    assert.equal(normalizeSdmxPeriod('2025-M12'), '2025-12');
+    assert.equal(normalizeSdmxPeriod('2024-M01'), '2024-01');
+  });
+
+  it('passes annual YYYY through unchanged (WEO/FM)', () => {
+    assert.equal(normalizeSdmxPeriod('2024'), '2024');
+    assert.equal(normalizeSdmxPeriod('2026'), '2026');
+  });
+
+  it('passes daily YYYY-MM-DD through unchanged (ECB)', () => {
+    assert.equal(normalizeSdmxPeriod('2024-03-15'), '2024-03-15');
+  });
+
+  it('passes quarterly YYYY-Q1..Q4 through unchanged', () => {
+    assert.equal(normalizeSdmxPeriod('2024-Q1'), '2024-Q1');
+    assert.equal(normalizeSdmxPeriod('2025-Q4'), '2025-Q4');
+  });
+
+  it('passes already-normalized YYYY-MM through unchanged', () => {
+    assert.equal(normalizeSdmxPeriod('2026-03'), '2026-03');
+  });
+
+  it('returns falsy and non-string inputs unchanged', () => {
+    assert.equal(normalizeSdmxPeriod(null), null);
+    assert.equal(normalizeSdmxPeriod(undefined), undefined);
+    assert.equal(normalizeSdmxPeriod(''), '');
+  });
+
+  it('only strips the M-prefix on month component, not stray M elsewhere', () => {
+    // Defensive — the regex is anchored with `$`, so a malformed period
+    // like "M2026-03" or "2026-M03-extra" should not be mutated.
+    assert.equal(normalizeSdmxPeriod('M2026-03'), 'M2026-03');
+    assert.equal(normalizeSdmxPeriod('2026-M03-extra'), '2026-M03-extra');
+  });
+});


### PR DESCRIPTION
## Summary

Defensive followup to #3513 (gold-cb-reserves SDMX format fix). Two preventive changes so the next IMF monthly/quarterly consumer doesn't re-encounter the same `YYYY-MMM` parsing trap:

1. **`normalizeSdmxPeriod` exported from `scripts/_seed-utils.mjs`** with JSDoc covering all SDMX 3.0 period formats:
   - Annual: `YYYY` (used by WEO/FM via `imfSdmxFetchIndicator`) — passthrough
   - Monthly: `YYYY-MMM` → `YYYY-MM` — actual fix
   - Quarterly: `YYYY-Q1..Q4` — passthrough (already sortable)
   - Daily: `YYYY-MM-DD` (used by ECB) — passthrough

   `seed-gold-cb-reserves.mjs` now imports the shared helper and re-exports the local `normalizePeriod` name so #3513's tests keep working without modification.

2. **`imfSdmxFetchIndicator` documented as annual-only** by URL construction (`*.${indicator}.A`). Comment block points future monthly/quarterly extensions at the canonical IRFCL pattern in `seed-gold-cb-reserves.mjs::fetchIrfclMonthlySeries`. The dimension layout differs (4-dim COUNTRY.INDICATOR.SECTOR.FREQUENCY vs WEO's 2-dim COUNTRY.INDICATOR), so the right move is a custom fetcher + ingest normalization — not bolting `frequency` onto the existing helper.

Strictly defensive — no live bugs fixed. The actual fix is in #3513; this PR makes the fix reusable so we don't see the same pattern recur in a future IMF monthly/quarterly seeder.

## Test plan

- [x] `tests/seed-utils-sdmx-period.test.mjs` (7 new): all SDMX period formats, defensive anchors against malformed periods (`M2026-03`, `2026-M03-extra`), null/undefined/empty.
- [x] `tests/gold-cb-reserves-seed.test.mjs` (20 pre-existing) — passes unchanged via the local re-export.
- [x] `npm run typecheck` + `typecheck:api` clean.
- [x] `npm run lint` clean (0 errors).
- [x] `npm run test:data` 7749/7749 pass.
- [x] `npm run lint:md` clean.
- [x] `npm run version:check` OK.
- [x] All `api/*.js` esbuild bundle clean.
- [x] `tests/edge-functions.test.mjs` 178/178 pass.
- [x] All `scripts/*.cjs` syntax clean.