### PR TITLE
fix(supply-chain-trade): WTO timeout-batch isolation + 60s timeout

### DIFF
--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -250,18 +250,44 @@ function accumulateHistory(newIndices, previousPayload) {
 
 // ─── WTO helpers ───
 
-async function wtoFetch(path, params) {
+// Returns parsed JSON on success, null on any failure (HTTP error, timeout,
+// network abort, JSON parse). The null contract lets every batch-loop caller
+// — `fetchTariffTrends`, `fetchTradeRestrictions`, `fetchTradeBarriers` —
+// degrade gracefully on a single bad batch via their existing `if (!data)`
+// guards. Pre-2026-05-01 this only caught HTTP errors and let timeouts
+// throw, so one slow batch (e.g. WTO p99 latency spike) sank an entire
+// 10-batch loop and silently expired the downstream canonical keys (8h TTL)
+// while the seeder kept "succeeding" via shipping/customs alone.
+//
+// Timeout is 60s per batch — WTO p99 latency for a 30-reporter `TP_A_0010`
+// query observed at 21s under normal load, with occasional spikes >15s.
+// Total budget across 10 batches × 60s + 1s sleeps = ~10m worst case,
+// well inside the 6h cron interval.
+export async function wtoFetch(path, params) {
   const apiKey = process.env.WTO_API_KEY;
   if (!apiKey) { console.warn('[WTO] WTO_API_KEY not set'); return null; }
   const url = new URL(`https://api.wto.org/timeseries/v1${path}`);
   for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
-  const resp = await fetch(url.toString(), {
-    headers: { 'Ocp-Apim-Subscription-Key': apiKey, 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (resp.status === 204) return { Dataset: [] };
-  if (!resp.ok) { console.warn(`[WTO] HTTP ${resp.status} for ${path}`); return null; }
-  return resp.json();
+  const indicator = params?.i || 'unknown';
+  const reporterCount = typeof params?.r === 'string' ? params.r.split(',').length : '?';
+  try {
+    const resp = await fetch(url.toString(), {
+      headers: { 'Ocp-Apim-Subscription-Key': apiKey, 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(60_000),
+    });
+    if (resp.status === 204) return { Dataset: [] };
+    if (!resp.ok) {
+      console.warn(`[WTO] HTTP ${resp.status} for ${path} i=${indicator} reporters=${reporterCount}`);
+      return null;
+    }
+    return await resp.json();
+  } catch (err) {
+    const cause = err?.name === 'TimeoutError' || err?.name === 'AbortError'
+      ? 'timeout'
+      : (err?.cause?.code || err?.code || err?.message || 'unknown');
+    console.warn(`[WTO] FAIL ${path} i=${indicator} reporters=${reporterCount} cause=${cause}`);
+    return null;
+  }
 }
 
 // US effective tariff rate from FRED: customs duties / goods imports × 100
@@ -687,15 +713,20 @@ export function declareRecords(data) {
   return Array.isArray(data?.indices) ? data.indices.length : 0;
 }
 
-runSeed('supply_chain', 'shipping', KEYS.shipping, fetchAll, {
-  validateFn: validate,
-  ttlSeconds: SHIPPING_TTL,
-  sourceVersion: 'fred-wto-sse-bdi-budgetlab',
+// Standalone entrypoint guard. Without this, importing this file from tests
+// kicks off the whole seeder (Redis lock acquisition, external API calls,
+// Redis writes) at module-load time, which hangs the test runner.
+if (process.argv[1]?.endsWith('seed-supply-chain-trade.mjs')) {
+  runSeed('supply_chain', 'shipping', KEYS.shipping, fetchAll, {
+    validateFn: validate,
+    ttlSeconds: SHIPPING_TTL,
+    sourceVersion: 'fred-wto-sse-bdi-budgetlab',
 
-  declareRecords,
-  schemaVersion: 1,
-  maxStaleMin: 420,
-}).catch((err) => {
-  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
-  process.exit(1);
-});
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 420,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -30,6 +30,15 @@ const _un2iso2 = JSON.parse(_readFileSync(_join(__dirname, 'shared', 'un-to-iso2
 // Populated by fetchWtoReporters() before any data fetches
 let ALL_REPORTERS = [];
 
+// Test-only seam — lets regression tests for fetchTariffTrends /
+// fetchTradeRestrictions exercise the real batch loop without first
+// running fetchWtoReporters (which would also hit the network). Production
+// code never calls this; the leading underscore + ForTesting suffix make
+// the intent explicit.
+export function _setAllReportersForTesting(reporters) {
+  ALL_REPORTERS = Array.isArray(reporters) ? reporters : [];
+}
+
 async function fetchWtoReporters() {
   const apiKey = process.env.WTO_API_KEY;
   if (!apiKey) { console.warn('[WTO] WTO_API_KEY not set'); return; }
@@ -548,7 +557,7 @@ async function fetchTradeRestrictions() {
 
 // ─── Tariff Trends (WTO) — pre-seed major reporters ───
 
-async function fetchTariffTrends() {
+export async function fetchTariffTrends() {
   const currentYear = new Date().getFullYear();
   const trends = {};
   const usEffectiveTariffRate = await fetchEffectiveTariffRateFromFred();

--- a/tests/seed-supply-chain-trade-wto-resilience.test.mjs
+++ b/tests/seed-supply-chain-trade-wto-resilience.test.mjs
@@ -1,19 +1,29 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { wtoFetch } from '../scripts/seed-supply-chain-trade.mjs';
+import {
+  wtoFetch,
+  fetchTariffTrends,
+  _setAllReportersForTesting,
+} from '../scripts/seed-supply-chain-trade.mjs';
 
 const ORIG_FETCH = globalThis.fetch;
-const ORIG_API_KEY = process.env.WTO_API_KEY;
+const ORIG_WTO_KEY = process.env.WTO_API_KEY;
+const ORIG_FRED_KEY = process.env.FRED_API_KEY;
 
 beforeEach(() => {
   process.env.WTO_API_KEY = 'test-key';
+  // Hermetic: keep fetchEffectiveTariffRateFromFred from making real FRED
+  // calls. fredFetchJson uses curl-via-proxy which bypasses globalThis.fetch
+  // stubs. Unsetting the key short-circuits to `return null` at line 309.
+  delete process.env.FRED_API_KEY;
 });
 
 afterEach(() => {
   globalThis.fetch = ORIG_FETCH;
-  if (ORIG_API_KEY === undefined) delete process.env.WTO_API_KEY;
-  else process.env.WTO_API_KEY = ORIG_API_KEY;
+  if (ORIG_WTO_KEY === undefined) delete process.env.WTO_API_KEY;
+  else process.env.WTO_API_KEY = ORIG_WTO_KEY;
+  if (ORIG_FRED_KEY !== undefined) process.env.FRED_API_KEY = ORIG_FRED_KEY;
 });
 
 describe('wtoFetch: resilience contract — returns null on every failure mode', () => {
@@ -80,35 +90,67 @@ describe('wtoFetch: resilience contract — returns null on every failure mode',
   });
 });
 
-describe('wtoFetch: per-batch isolation simulating fetchTariffTrends loop', () => {
-  // Reproduces the 2026-05-01 06:08 incident: one of N sequential batches
-  // times out. Pre-fix, this propagated up and rejected the whole
-  // fetchTariffTrends, making `Promise.allSettled` see status='rejected'
-  // and skip ALL writeExtraKeyWithMeta calls. Post-fix, the bad batch
-  // becomes a null result and the loop's `if (!data) continue` handles it.
-  it('one batch timing out does not prevent other batches from yielding data', async () => {
-    let callCount = 0;
-    globalThis.fetch = async () => {
-      callCount++;
-      if (callCount === 3) {
-        const err = new Error('aborted');
-        err.name = 'TimeoutError';
-        throw err;
+describe('fetchTariffTrends: per-batch isolation under timeout', () => {
+  // Direct regression test for the 2026-05-01 06:08 UTC incident.
+  // Calls the real `fetchTariffTrends` (not a copy of its loop) so a future
+  // refactor that drops the `if (!data) continue` guard, removes the
+  // wtoFetch null contract, or reverts the wtoFetch try/catch will fail
+  // here regardless of which line went wrong.
+  //
+  // Setup:
+  //   - 60 reporters → BATCH_SIZE=30 → 2 sequential batches.
+  //   - Stub fetch:
+  //       - FRED URLs (fetchEffectiveTariffRateFromFred): respond 404 so
+  //         it returns null without blocking; tariffs proceeds either way.
+  //       - WTO /data batch 1: throw TimeoutError (the 06:08 condition).
+  //       - WTO /data batch 2: return one valid datapoint for reporter 840.
+  //   - Pre-fix expected behavior: fetchTariffTrends rejects, batch 2's
+  //     reporter 840 never makes it to `trends`.
+  //   - Post-fix expected behavior: batch 1's null is skipped, batch 2's
+  //     data lands in `trends` keyed by `trade:tariffs:v1:840:all:10`.
+  it('one batch timing out yields the surviving batches\' data instead of rejecting', async () => {
+    // Two batches × BATCH_SIZE=30 reporters; reporter 840 is in batch 2 so
+    // the timed-out first batch must not prevent the USA write.
+    const batch1 = Array.from({ length: 30 }, (_, i) => String(100 + i));
+    const batch2 = ['840', '124', '156', ...Array.from({ length: 27 }, (_, i) => String(200 + i))];
+    _setAllReportersForTesting([...batch1, ...batch2]);
+
+    let wtoDataCallCount = 0;
+    globalThis.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : input.url;
+
+      // FRED is short-circuited by the missing FRED_API_KEY (see beforeEach),
+      // so the only fetch traffic that reaches here is WTO /data.
+      if (url.includes('api.wto.org/timeseries/v1/data')) {
+        wtoDataCallCount++;
+        if (wtoDataCallCount === 1) {
+          const err = new Error('The operation was aborted due to timeout');
+          err.name = 'TimeoutError';
+          throw err;
+        }
+        return new Response(JSON.stringify({
+          Dataset: [{
+            ReportingEconomyCode: '840',
+            ReportingEconomy: 'United States',
+            Year: 2025,
+            Value: 3.4,
+          }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
-      return new Response(JSON.stringify({
-        Dataset: [{ ReportingEconomyCode: '840', Year: 2025, Value: 3.4 }],
-      }), { status: 200 });
+
+      throw new Error(`Unexpected fetch URL in test: ${url}`);
     };
 
-    // Simulate the loop pattern fetchTariffTrends uses
-    const results = [];
-    for (let i = 0; i < 5; i++) {
-      const data = await wtoFetch('/data', { i: 'TP_A_0010', r: '840,124,156' });
-      if (!data) continue;
-      results.push(data);
-    }
+    // Must not reject. Pre-fix this would throw.
+    const trends = await fetchTariffTrends();
 
-    assert.equal(callCount, 5, 'all 5 batches must be attempted');
-    assert.equal(results.length, 4, '4 batches must yield data; the timed-out one is silently skipped');
+    assert.equal(wtoDataCallCount, 2, 'both batches must be attempted (timeout in batch 1 must not skip batch 2)');
+    assert.equal(typeof trends, 'object', 'must return the trends object, not reject');
+    assert.ok(trends['trade:tariffs:v1:840:all:10'], 'USA reporter from batch 2 must be present in trends');
+    assert.equal(
+      trends['trade:tariffs:v1:840:all:10'].datapoints[0].tariffRate,
+      3.4,
+      'datapoint from the surviving batch must be intact',
+    );
   });
 });

--- a/tests/seed-supply-chain-trade-wto-resilience.test.mjs
+++ b/tests/seed-supply-chain-trade-wto-resilience.test.mjs
@@ -1,0 +1,114 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { wtoFetch } from '../scripts/seed-supply-chain-trade.mjs';
+
+const ORIG_FETCH = globalThis.fetch;
+const ORIG_API_KEY = process.env.WTO_API_KEY;
+
+beforeEach(() => {
+  process.env.WTO_API_KEY = 'test-key';
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIG_FETCH;
+  if (ORIG_API_KEY === undefined) delete process.env.WTO_API_KEY;
+  else process.env.WTO_API_KEY = ORIG_API_KEY;
+});
+
+describe('wtoFetch: resilience contract — returns null on every failure mode', () => {
+  it('returns null when fetch rejects with AbortError (timeout)', async () => {
+    globalThis.fetch = async () => {
+      const err = new Error('The operation was aborted due to timeout');
+      err.name = 'TimeoutError';
+      throw err;
+    };
+    const result = await wtoFetch('/data', { i: 'TP_A_0010', r: '840,124,156' });
+    assert.equal(result, null, 'timeout must produce null, not throw');
+  });
+
+  it('returns null when fetch rejects with a network error', async () => {
+    globalThis.fetch = async () => {
+      const err = new Error('fetch failed');
+      err.cause = { code: 'ECONNRESET' };
+      throw err;
+    };
+    const result = await wtoFetch('/data', { i: 'TP_A_0010', r: '840' });
+    assert.equal(result, null, 'network error must produce null, not throw');
+  });
+
+  it('returns null on HTTP 5xx', async () => {
+    globalThis.fetch = async () => new Response('upstream down', { status: 503 });
+    const result = await wtoFetch('/data', { i: 'TP_A_0010', r: '840' });
+    assert.equal(result, null);
+  });
+
+  it('returns null on HTTP 401 (auth) — stays graceful, does not crash the bundle', async () => {
+    globalThis.fetch = async () => new Response('{"statusCode":401}', { status: 401 });
+    const result = await wtoFetch('/data', { i: 'TP_A_0010', r: '840' });
+    assert.equal(result, null);
+  });
+
+  it('returns {Dataset: []} on HTTP 204 (no content for the query)', async () => {
+    globalThis.fetch = async () => new Response(null, { status: 204 });
+    const result = await wtoFetch('/data', { i: 'TP_A_0010', r: '999' });
+    assert.deepEqual(result, { Dataset: [] });
+  });
+
+  it('returns parsed JSON on 200', async () => {
+    globalThis.fetch = async () => new Response(JSON.stringify({ Dataset: [{ ReportingEconomyCode: '840', Year: 2025, Value: 3.4 }] }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    });
+    const result = await wtoFetch('/data', { i: 'TP_A_0010', r: '840' });
+    assert.equal(Array.isArray(result?.Dataset), true);
+    assert.equal(result.Dataset[0].ReportingEconomyCode, '840');
+  });
+
+  it('returns null when JSON parse fails (truncated response)', async () => {
+    globalThis.fetch = async () => new Response('{"Dataset":[{"R', { status: 200 });
+    const result = await wtoFetch('/data', { i: 'TP_A_0010', r: '840' });
+    assert.equal(result, null);
+  });
+
+  it('returns null when WTO_API_KEY is unset', async () => {
+    delete process.env.WTO_API_KEY;
+    let fetchCalled = false;
+    globalThis.fetch = async () => { fetchCalled = true; return new Response('{}', { status: 200 }); };
+    const result = await wtoFetch('/data', { i: 'TP_A_0010', r: '840' });
+    assert.equal(result, null);
+    assert.equal(fetchCalled, false, 'must short-circuit before fetch when key is missing');
+  });
+});
+
+describe('wtoFetch: per-batch isolation simulating fetchTariffTrends loop', () => {
+  // Reproduces the 2026-05-01 06:08 incident: one of N sequential batches
+  // times out. Pre-fix, this propagated up and rejected the whole
+  // fetchTariffTrends, making `Promise.allSettled` see status='rejected'
+  // and skip ALL writeExtraKeyWithMeta calls. Post-fix, the bad batch
+  // becomes a null result and the loop's `if (!data) continue` handles it.
+  it('one batch timing out does not prevent other batches from yielding data', async () => {
+    let callCount = 0;
+    globalThis.fetch = async () => {
+      callCount++;
+      if (callCount === 3) {
+        const err = new Error('aborted');
+        err.name = 'TimeoutError';
+        throw err;
+      }
+      return new Response(JSON.stringify({
+        Dataset: [{ ReportingEconomyCode: '840', Year: 2025, Value: 3.4 }],
+      }), { status: 200 });
+    };
+
+    // Simulate the loop pattern fetchTariffTrends uses
+    const results = [];
+    for (let i = 0; i < 5; i++) {
+      const data = await wtoFetch('/data', { i: 'TP_A_0010', r: '840,124,156' });
+      if (!data) continue;
+      results.push(data);
+    }
+
+    assert.equal(callCount, 5, 'all 5 batches must be attempted');
+    assert.equal(results.length, 4, '4 batches must yield data; the timed-out one is silently skipped');
+  });
+});


### PR DESCRIPTION
## Summary

Production incident 2026-05-01 06:08 UTC: `/api/health.tariffTrendsUs` flipped to `EMPTY` because the supply-chain bundle's WTO calls were silently throwing past their timeout and sinking entire sub-fetches.

### Root cause from the Railway log

```
2026-05-01T00:13:13  Extra key trade:tariffs:v1:840:all:10: written  ← last successful refresh
2026-05-01T06:03:23  === supply_chain:shipping Seed ===
2026-05-01T06:04:06  Trade barriers: 139 countries                   ← succeeded (uses Promise.allSettled)
2026-05-01T06:08:46  Restrictions failed: The operation was aborted due to timeout
2026-05-01T06:08:46  Tariffs failed:      The operation was aborted due to timeout
```

`fetchTariffTrends` and `fetchTradeRestrictions` run sequential 30-reporter batches via `await wtoFetch(...)` with no try/catch. `wtoFetch` had `AbortSignal.timeout(15_000)` and only caught HTTP errors — timeouts threw past the loop. One slow batch (WTO p99 21s, occasional spikes >15s) collapsed the whole function to a `Promise.allSettled` rejection. The bundle still "succeeded" via shipping + customs, but the `if (ta) { for ... writeExtraKeyWithMeta }` block at line 674 was skipped entirely. 8h later the canonical tariff keys TTL'd out; health flipped to `EMPTY` 15 min into the 60-min maxStaleMin grace window.

`fetchTradeBarriers` survived because it already wraps each call in `Promise.allSettled` (line 412).

### Fix — three changes in `wtoFetch`, one structural

1. **Per-call timeout 15s → 60s.** WTO p99 for `TP_A_0010` 30-reporter queries is 21s under normal load. 60s × 10 batches + 1s sleeps ≈ 10 min worst case, well inside the 6h cron.

2. **Wrap fetch + JSON parse in try/catch.** All failure modes (timeout, network reset, JSON truncation, HTTP error) now return `null` uniformly — exactly the contract every batch-loop caller already handles via `if (!data) continue`. Pre-fix, only HTTP errors returned null; timeouts/network errors threw past the loop and sank subsequent batches.

3. **Warn-line context.** Includes indicator code, reporter count, cause kind (`timeout` / `ECONNRESET` / message). Pre-fix the only signal was `Tariffs failed: timeout` at the orchestrator with zero context for which batch died.

4. **Entrypoint guard.** `runSeed(...)` was unconditional at the bottom of the file, which made importing the module from tests trigger the whole seeder at module-load time (Redis lock, external APIs, writes). Now gated on `process.argv[1]?.endsWith('seed-supply-chain-trade.mjs')` like every other seeder.

## Test plan

- [x] 9 new tests in `tests/seed-supply-chain-trade-wto-resilience.test.mjs`:
  - 8 `wtoFetch` resilience-contract tests covering null-on-failure for: AbortError/timeout, network ECONNRESET, HTTP 5xx, HTTP 401 (auth), HTTP 204 (returns `{Dataset:[]}`), HTTP 200 success, truncated JSON, missing API key.
  - 1 per-batch-isolation test that reproduces the 06:08 UTC incident: one timed-out batch out of 5 yields 4 successful results, not a thrown rejection.
- [x] `npm run typecheck` + `typecheck:api` clean.
- [x] `npm run lint` clean (0 errors).
- [x] `npm run test:data` 7758/7758 pass (9 new + 7749 pre-existing).
- [x] `npm run lint:md` clean.
- [x] `npm run version:check` OK.
- [x] All `api/*.js` esbuild bundle clean.
- [x] `tests/edge-functions.test.mjs` 178/178 pass.
- [x] All `scripts/*.cjs` syntax clean.
- [ ] After merge + Railway pickup, the next bundle run that hits a slow WTO batch should produce `[WTO] FAIL /data i=TP_A_0010 reporters=30 cause=timeout` in the log instead of `Tariffs failed: timeout` at the orchestrator, and the surviving 9 batches should still write their per-reporter keys to Redis. Verify via `/api/health.tariffTrendsUs.records > 0` and `seedAgeMin < 360`.