### PR TITLE
fix(sentry): ignoreErrors WKWebView postMessage host-app timeout

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -79,6 +79,13 @@ Sentry.init({
     /DataCloneError.*could not be cloned/,
     /cannot decode message/,
     /WKWebView was deallocated/,
+    // WKWebView host-app JS bridge timeout — Apple WebKit emits this exact phrase
+    // when a JS-to-native `postMessage` (e.g. WKScriptMessageHandler) gets no
+    // reply within the host's expected window. Common in in-app browsers like
+    // DuckDuckGo / Yelp / Reddit-mobile / Instagram. We never postMessage to a
+    // WKScriptMessageHandler ourselves; this is browser-native and unactionable
+    // (WORLDMONITOR-KJ — 15 events / 14 users in DuckDuckGo 26.3 on macOS).
+    /WKWebView API client did not respond to this postMessage/,
     /Unexpected end of(?: JSON)? input/,
     /window\.android\.\w+ is not a function/,
     /Attempted to assign to readonly property/,


### PR DESCRIPTION
## Summary

WORLDMONITOR-KJ — `Error: WKWebView API client did not respond to this postMessage`, **15 events / 14 users**, mostly DuckDuckGo 26.3 in-app browser on macOS. Zero captured frames, mechanism `auto.browser.global_handlers.onunhandledrejection`.

This is Apple WebKit's literal phrase emitted when a JS-to-native `postMessage` to a `WKScriptMessageHandler` gets no reply within the host app's window. Common in in-app browsers (DuckDuckGo, Yelp, Reddit-mobile, Instagram, Slack-mobile) when the host app's JS bridge is paused or unmounted while a page-level call is in flight.

## Why `ignoreErrors`-safe (vs. `beforeSend` stack-gating)

Per the project's strict policy, `ignoreErrors` is reserved for patterns that unambiguously **cannot** come from our own shipped code:
- It's a literal Apple WebKit phrase (not a generic runtime error like `Failed to fetch`).
- We never `postMessage` to a `WKScriptMessageHandler` — that's an iOS-native bridge concept, and we don't ship a native iOS host.
- Sister of the existing `/WKWebView was deallocated/` pattern in the same array (added in earlier triage).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 7758/7758 pass
- [x] `node --test tests/edge-functions.test.mjs` — 178/178 pass
- [x] Edge bundle check — clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK

## Sentry status

WORLDMONITOR-KJ marked resolved in next release; auto-reopen if the regex misses this variant.