### PR TITLE
fix(dashboard): align AI Insights freshness gate + un-mask marketImplications outage

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -434,6 +434,22 @@ const SEED_META = {
 
 // Standalone keys that are populated on-demand by RPC handlers (not seeds).
 // Empty = WARN not CRIT since they only exist after first request.
+//
+// POLICY (2026-05-01): If the seed-meta key feeds a panel that renders on the
+// DEFAULT homepage layout (`enabled: true, priority: 1` in src/config/panels.ts
+// or per-variant equivalents), it MUST NOT be in this set. ON_DEMAND softens
+// EMPTY to WARN, which is correct ONLY when data is genuinely populated lazily
+// after a user action (premium RPC caches that warm on click, intermediate
+// seed-to-seed pipeline keys, relay heartbeats, click-warmed lookups). For a
+// homepage panel, chronic absence is a real outage and deserves CRIT — softening
+// it masks production breakage behind an OK summary.
+//
+// Specific incident that motivated this policy: marketImplications (homepage
+// panel, default-enabled in panels.ts:114) sat at age=988 max=120 (8.2× the
+// staleness budget) for 16+ hours while the LLM provider returned HTTP 402 on
+// every cron run. /api/health stayed onDemandWarn=1 instead of crit, so the
+// chronic outage went undetected until a user noticed the panel was stuck on
+// "Loading...". Removed marketImplications below.
 const ON_DEMAND_KEYS = new Set([
   'riskScoresLive',
   'usniFleetStale', 'positiveEventsLive',
@@ -445,7 +461,8 @@ const ON_DEMAND_KEYS = new Set([
   'corridorrisk', // intermediate key; data flows through transit-summaries:v1
   'serviceStatuses', // RPC-populated; seed-meta written on fresh fetch only, goes stale between visits
   'militaryForecastInputs', // intermediate seed-to-seed pipeline key; only populated after seed-military-flights runs
-  'marketImplications', // LLM-generated inside forecast cron; can fail silently on LLM errors — degrade to WARN not CRIT
+  // marketImplications removed 2026-05-01 — see policy block above. Homepage panel,
+  // chronic LLM-provider failures must surface as CRIT.
   'simulationPackageLatest', // written by writeSimulationPackage after deep forecast runs; only present after first successful deep run
   'simulationOutcomeLatest', // written by writeSimulationOutcome after simulation runs; only present after first successful simulation
   'newsThreatSummary', // relay classify loop — only written when mergedByCountry has entries; absent on quiet news periods

--- a/src/services/insights-loader.ts
+++ b/src/services/insights-loader.ts
@@ -26,7 +26,15 @@ export interface ServerInsights {
 }
 
 let cached: ServerInsights | null = null;
-const MAX_AGE_MS = 15 * 60 * 1000;
+// Server cron interval: scripts/seed-insights.mjs runs every 30 min
+// (CACHE_TTL=10800s/3h, maxStaleMin: 30). The previous 15-min freshness gate
+// was strictly less than the cron interval, so the panel spent ~50% of every
+// 30-min cycle showing UNAVAILABLE + "Waiting for data..." even when the
+// system was working perfectly. 60 min = 2× cron interval, gives one full
+// missed-tick of headroom before falling through to the client-side path.
+// Exported so the regression test asserts against the real value rather than
+// inlining a copy that drifts silently when this constant changes.
+export const MAX_AGE_MS = 60 * 60 * 1000;
 
 function isFresh(data: ServerInsights): boolean {
   const age = Date.now() - new Date(data.generatedAt).getTime();

--- a/tests/insights-loader.test.mjs
+++ b/tests/insights-loader.test.mjs
@@ -1,21 +1,35 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 
-describe('insights-loader', () => {
-  describe('getServerInsights (logic validation)', () => {
-    const MAX_AGE_MS = 15 * 60 * 1000;
+import { MAX_AGE_MS } from '../src/services/insights-loader';
 
+describe('insights-loader', () => {
+  describe('MAX_AGE_MS — server-cadence-aligned freshness window', () => {
+    // The seeder cron interval is 30 min (scripts/seed-insights.mjs:363).
+    // MAX_AGE_MS must be >= the cron interval, otherwise the panel will
+    // appear UNAVAILABLE for part of every healthy cycle. 60 min gives
+    // one missed-tick of headroom on top of that.
+    it('is at least 30 minutes (cron interval)', () => {
+      assert.ok(MAX_AGE_MS >= 30 * 60 * 1000, `expected >=30min, got ${MAX_AGE_MS / 60000}min`);
+    });
+
+    it('is at least 60 minutes (cron interval × 2 for missed-tick headroom)', () => {
+      assert.ok(MAX_AGE_MS >= 60 * 60 * 1000, `expected >=60min, got ${MAX_AGE_MS / 60000}min`);
+    });
+  });
+
+  describe('getServerInsights (logic validation)', () => {
     function isFresh(generatedAt) {
       const age = Date.now() - new Date(generatedAt).getTime();
       return age < MAX_AGE_MS;
     }
 
-    it('rejects data older than 15 minutes', () => {
-      const old = new Date(Date.now() - 16 * 60 * 1000).toISOString();
+    it('rejects data older than the freshness window', () => {
+      const old = new Date(Date.now() - MAX_AGE_MS - 60_000).toISOString();
       assert.equal(isFresh(old), false);
     });
 
-    it('accepts data younger than 15 minutes', () => {
+    it('accepts data younger than the freshness window', () => {
       const fresh = new Date(Date.now() - 5 * 60 * 1000).toISOString();
       assert.equal(isFresh(fresh), true);
     });
@@ -24,7 +38,7 @@ describe('insights-loader', () => {
       assert.equal(isFresh(new Date().toISOString()), true);
     });
 
-    it('rejects exactly 15 minutes old data', () => {
+    it('rejects exactly window-aged data', () => {
       const exact = new Date(Date.now() - MAX_AGE_MS).toISOString();
       assert.equal(isFresh(exact), false);
     });


### PR DESCRIPTION
## Summary

Two dashboard health-perception bugs surfaced from today's investigation into broken homepage panels. Both produced false-or-misleading dashboard states; neither is a panel/seeder bug.

### Issue 1 — AI INSIGHTS shows UNAVAILABLE for ~50% of every healthy cycle

`src/services/insights-loader.ts` had `MAX_AGE_MS = 15 * 60 * 1000` while `scripts/seed-insights.mjs` runs every 30 min. The client-side freshness gate was *strictly less than the cron interval*, so for ~15 min of every 30-min cycle the panel treated fresh data as stale and fell through to "Waiting for data…" — even when `news:insights:v1` was healthy in Redis.

Verified against live Redis at investigation time:
```
news:insights:v1.generatedAt = 53 min old   ← past 15-min gate
seed-meta:news:insights age = current        ← seeder cron firing fine
```

**Fix:** bump `MAX_AGE_MS` to 60 min (2× cron interval = one full missed-tick of headroom). Export the constant so the regression test asserts the real value instead of inlining a copy that drifts silently.

### Issue 2 — `marketImplications` masked a 16+h LLM-provider outage as WARN

`api/health.js` `ON_DEMAND_KEYS` softens `EMPTY → EMPTY_ON_DEMAND` (WARN, not CRIT). That softening is correct for keys populated lazily by user action (premium RPC caches, click-warmed lookups, relay heartbeats, intermediate pipeline keys).

It is **wrong** for any key feeding a panel that loads on the default homepage on every visit. `src/config/panels.ts:114` has `'market-implications': { enabled: true, priority: 1, premium: 'locked' }` — default-enabled homepage panel.

On 2026-05-01 the panel was stuck at `age=988 max=120` (8.2× the staleness budget) for 16+ hours while OpenRouter returned `HTTP 402 Payment Required` on every cron run for `google/gemini-2.5-flash`. `/api/health.summary` reported `onDemandWarn=1` instead of `crit=1`, so the chronic outage went undetected until a user noticed the panel stuck on "Loading…".

**Fix:** remove `marketImplications` from `ON_DEMAND_KEYS`. Add a policy block above the set encoding the rule so future contributors don't repeat the mistake.

## Test plan

- [x] `tests/insights-loader.test.mjs` now imports `MAX_AGE_MS` and asserts `>= 30 min` (cron interval) and `>= 60 min` (2× headroom). Removes the inlined-copy anti-pattern that let the constant drift silently before.
- [x] `npm run typecheck` + `typecheck:api` clean.
- [x] `npm run lint` clean (0 errors).
- [x] `npm run test:data` 7760/7760 pass.
- [x] `npm run lint:md` clean.
- [x] `npm run version:check` OK.
- [x] All `api/*.js` esbuild bundle clean.
- [x] `tests/edge-functions.test.mjs` 178/178 pass.
- [x] All `scripts/*.cjs` syntax clean.
- [ ] After deploy: AI INSIGHTS panel should stop flickering UNAVAILABLE every other cycle. `/api/health.summary` will move from `onDemandWarn=1, crit=1` to `crit=2` while OpenRouter is paid up — once paid, both flip to OK.

## Out of scope (separate investigation)

- ESCALATION / ECONOMIC WARFARE / DISASTER CASCADE panels showing 0 cards — `correlation:cards-bootstrap:v1` has 0 cards for these 3 domains. Likely cause: `news:insights:v1.topStories` has 0 stories with `lat/lon`, breaking the `news_severity` weight in escalation and disaster's geographic clustering. Needs deeper trace; will file separately.
- "UNAVAILABLE" badge on RSS panels (CLOUD & INFRASTRUCTURE / FINANCIAL REGULATION / ENERGY & RESOURCES) — these panels use `NewsPanel.renderNews` which sets `unavailable` on `items.length === 0`. The badge can't currently distinguish "RSS query genuinely empty" from "RSS fetcher failed" — same display either way. Worth a separate UX/state-modeling discussion.