### PR TITLE
obs(seed-correlation): per-domain diagnostic logs to root-cause empty cards

### DIFF
--- a/scripts/seed-correlation.mjs
+++ b/scripts/seed-correlation.mjs
@@ -533,7 +533,11 @@ function clusterByEntity(signals) {
 }
 
 // ── Scoring ─────────────────────────────────────────────────
-function scoreClusters(clusters, weights, threshold) {
+// Returns ALL scored clusters (un-thresholded). Callers apply the threshold
+// filter so observability logs can report `topScore` even when zero cards
+// pass — distinguishing "clusters formed, score below threshold" from
+// "no clusters formed at all" without re-running the scoring pass.
+function scoreClusters(clusters, weights, _threshold) {
   return clusters
     .map(cluster => {
       const perType = new Map();
@@ -565,8 +569,7 @@ function scoreClusters(clusters, weights, threshold) {
       const key = cluster.country ?? cluster.entityKey ?? `${centroidLat?.toFixed(1)},${centroidLon?.toFixed(1)}`;
 
       return { cluster, score, countries, centroidLat, centroidLon, key };
-    })
-    .filter(c => c.score >= threshold);
+    });
 }
 
 // ── Card Generation ─────────────────────────────────────────
@@ -665,31 +668,60 @@ async function computeCorrelation() {
     lon: s.lon,
   }));
 
+  // Observability — raw inputs at the seam between fetchInputData and the
+  // per-domain pipelines. Without this it was impossible to tell whether
+  // 0-card domains meant "no input signals" vs "scored too low against
+  // threshold" vs "no clusters formed". news-with-coords is broken out
+  // because escalation/disaster spatial paths depend on it.
+  const newsWithCoords = newsClusters.filter(c => c.lat != null && c.lon != null).length;
+  console.log(
+    `  [Correlation] inputs: flights=${rawFlights.length} protests=${protests.length} ` +
+    `outages=${outages.length} quakes=${earthquakes.length} markets=${allMarkets.length} ` +
+    `news=${newsClusters.length} (${newsWithCoords} with lat/lon)`,
+  );
+
   const result = { military: [], escalation: [], economic: [], disaster: [], computedAt: Date.now() };
+
+  // Helper — apply threshold + emit one diagnostic line per domain.
+  // Logs signals, clusters, topScore (max regardless of threshold), and
+  // cards (count clearing threshold). topScore=0 when no clusters formed,
+  // distinguishing "scoring rejected everything" from "nothing to score".
+  const buildDomain = (domain, signals, clusters, scored, threshold, titleFn) => {
+    const topScore = scored.length > 0
+      ? Math.round(Math.max(...scored.map(s => s.score)))
+      : 0;
+    const passing = scored.filter(s => s.score >= threshold);
+    const cards = passing.map(s => toCard(s, domain, titleFn)).sort((a, b) => b.score - a.score);
+    console.log(
+      `  [Correlation] ${domain.padEnd(10)} signals=${signals.length} ` +
+      `clusters=${scored.length} topScore=${topScore} threshold=${threshold} cards=${cards.length}`,
+    );
+    return cards;
+  };
 
   // Military
   const milSignals = collectMilitarySignals(rawFlights);
   const milClusters = clusterByProximity(milSignals, 500);
   const milScored = scoreClusters(milClusters, DOMAINS.military.weights, DOMAINS.military.threshold);
-  result.military = milScored.map(s => toCard(s, 'military', generateMilitaryTitle)).sort((a, b) => b.score - a.score);
+  result.military = buildDomain('military', milSignals, milClusters, milScored, DOMAINS.military.threshold, generateMilitaryTitle);
 
   // Escalation
   const escSignals = collectEscalationSignals(protests, outages, newsClusters);
   const escClusters = clusterByCountry(escSignals);
   const escScored = scoreClusters(escClusters, DOMAINS.escalation.weights, DOMAINS.escalation.threshold);
-  result.escalation = escScored.map(s => toCard(s, 'escalation', generateEscalationTitle)).sort((a, b) => b.score - a.score);
+  result.escalation = buildDomain('escalation', escSignals, escClusters, escScored, DOMAINS.escalation.threshold, generateEscalationTitle);
 
   // Economic
   const ecoSignals = collectEconomicSignals(allMarkets, newsClusters);
   const ecoClusters = clusterByEntity(ecoSignals);
   const ecoScored = scoreClusters(ecoClusters, DOMAINS.economic.weights, DOMAINS.economic.threshold);
-  result.economic = ecoScored.map(s => toCard(s, 'economic', generateEconomicTitle)).sort((a, b) => b.score - a.score);
+  result.economic = buildDomain('economic', ecoSignals, ecoClusters, ecoScored, DOMAINS.economic.threshold, generateEconomicTitle);
 
   // Disaster
   const disSignals = collectDisasterSignals(earthquakes, outages, protests);
   const disClusters = clusterByProximity(disSignals, 500);
   const disScored = scoreClusters(disClusters, DOMAINS.disaster.weights, DOMAINS.disaster.threshold);
-  result.disaster = disScored.map(s => toCard(s, 'disaster', generateDisasterTitle)).sort((a, b) => b.score - a.score);
+  result.disaster = buildDomain('disaster', disSignals, disClusters, disScored, DOMAINS.disaster.threshold, generateDisasterTitle);
 
   return result;
 }


### PR DESCRIPTION
## Summary

Investigation context: dashboard ESCALATION / ECONOMIC WARFARE / DISASTER CASCADE panels stuck at "Waiting for data…" because `correlation:cards-bootstrap:v1` has 0 cards for those 3 of 4 domains. Verified against live Redis:

```
correlation:cards-bootstrap:v1   mil=3 esc=0 eco=0 dis=0
correlation:military:v1          cards=3 (top score 22 — barely over threshold 20)
correlation:escalation:v1        cards=0
correlation:economic:v1          cards=0
correlation:disaster:v1          cards=0
```

The cron runs every 5 min via the `derived-signals` bundle and reports `seed_complete` success. But `scripts/seed-correlation.mjs` had **zero console.log statements** — the Railway log gave no signal about which of these is happening per domain:

1. No input signals reaching the collection layer
2. Signals collected but not forming clusters (`sigs.length < 2` country/proximity gate)
3. Clusters formed but `topScore < threshold (20)` — density too thin

Each of those has a different fix. Tuning blind (lowering threshold? widening spatial radius? adjusting weights?) is unsafe.

## Changes

Strictly additive observability — no change to public output contract.

### 1. Raw input boundary log

```
[Correlation] inputs: flights=N protests=N outages=N quakes=N markets=N news=N (M with lat/lon)
```

The news-with-coords break-out matters because escalation's `news_severity` weight depends on country extraction (uses coords as fallback) and disaster uses spatial clustering.

### 2. Per-domain summary line

```
[Correlation] military   signals=N clusters=M topScore=S threshold=T cards=K
[Correlation] escalation signals=N clusters=M topScore=S threshold=T cards=K
[Correlation] economic   signals=N clusters=M topScore=S threshold=T cards=K
[Correlation] disaster   signals=N clusters=M topScore=S threshold=T cards=K
```

`topScore` is the maximum scored cluster **regardless** of threshold. So an empty domain reveals which failure mode is firing:

| Diagnostic shape | Failure mode | Real fix |
|---|---|---|
| `signals=0` | No inputs reached collection | Schema regression / fetch failure upstream |
| `clusters=0` | Signals collected but no clusters | `sigs.length < 2` country gate, 500km spatial radius too narrow, token-match too strict |
| `cards=0` w/ `topScore<threshold` | Scored, density too thin | Threshold/weight tuning |

### Refactor

`scoreClusters()` no longer applies the threshold filter — caller does. This lets the diagnostic log emit `topScore` from the unfiltered scored list. Single call site (`computeCorrelation`, 4 domains) is updated via a `buildDomain()` helper that applies threshold + emits diagnostic + builds cards in one place.

**Public output unchanged** — same `result.{military,escalation,economic,disaster}` arrays of threshold-passing cards sorted by score.

## Test plan

- [x] No existing tests touch `scoreClusters` (grep clean), so refactor is safe.
- [x] `node -c scripts/seed-correlation.mjs` syntax clean.
- [x] `npm run typecheck` + `typecheck:api` clean.
- [x] `npm run lint` clean (0 errors).
- [x] `npm run test:data` 7758/7758 pass.
- [x] `npm run lint:md` clean.
- [x] `npm run version:check` OK.
- [x] All `api/*.js` esbuild bundle clean.
- [x] `tests/edge-functions.test.mjs` 178/178 pass.
- [x] All `scripts/*.cjs` syntax clean.
- [ ] After merge + Railway pickup: the `derived-signals` service log will emit one new diagnostic block per 5-min cycle. Two bundle ticks (~10 min) gives definitive root cause for each empty domain. Follow-up PR will ship the actual tuning fix from that data.