### PR TITLE
perf(boot): unblock DCL by yanking abacus + lazy-loading map stack

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,8 +117,8 @@
     }
     </script>
 
-    <!-- Umami Analytics -->
-    <script defer src="https://abacus.worldmonitor.app/script.js" data-website-id="e8800335-c853-46a8-8497-c993ed2f58bc" data-domains="worldmonitor.app,tech.worldmonitor.app,finance.worldmonitor.app,commodity.worldmonitor.app,happy.worldmonitor.app"></script>
+    <!-- Umami Analytics — async (not defer): defer blocks DOMContentLoaded if abacus is slow/down (15s observed when origin 502s). -->
+    <script async src="https://abacus.worldmonitor.app/script.js" data-website-id="e8800335-c853-46a8-8497-c993ed2f58bc" data-domains="worldmonitor.app,tech.worldmonitor.app,finance.worldmonitor.app,commodity.worldmonitor.app,happy.worldmonitor.app"></script>
 
     <!-- Favicons -->
     <link rel="icon" type="image/x-icon" href="/favico/favicon.ico" />

--- a/src/App.ts
+++ b/src/App.ts
@@ -1042,8 +1042,10 @@ export class App {
     const resolvedRegion = await resolveUserRegion();
     this.state.resolvedLocation = resolvedRegion;
 
-    // Phase 1: Layout (creates map + panels — they'll find hydrated data)
-    this.panelLayout.init();
+    // Phase 1: Layout (creates map + panels — they'll find hydrated data).
+    // init() is async so the dynamic MapContainer import can resolve before
+    // downstream code (e.g. mobileGeoCoords→state.map.setCenter) reads ctx.map.
+    await this.panelLayout.init();
     showProBanner(this.state.container);
     this.updateConnectivityUi();
     window.addEventListener('online', this.handleConnectivityChange);

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -849,6 +849,17 @@ export class PanelLayoutManager implements AppModule {
     // Dynamic import: keeps maplibre-gl + @deck.gl/* + @loaders.gl + @luma.gl
     // out of the entry chunk. Loads in parallel with paint, so the map mounts
     // a beat after the panel grid renders instead of blocking it.
+    //
+    // Residual-risk watchpoint (canary): this await also serializes the
+    // ~700 lines of panel construction below behind the map chunk fetch.
+    // Failure mode is covered by the chunk-reload guard at src/main.ts:690-758
+    // (catches `Failed to fetch dynamically imported module` and reloads).
+    // The slow-fetch mode (chunk fetches that succeed but are very slow) is
+    // worth watching in production canaries — if it shows up, restructure to
+    // kick off the import early and run non-map panel construction before the
+    // await (the only direct ctx.map dereferences in this function are
+    // initEscalationGetters / getTimeRange right after construction, plus
+    // onTimeRangeChanged later — every other ctx.map use is `?.`-guarded).
     const { MapContainer } = await import('@/components/MapContainer');
     this.ctx.map = new MapContainer(mapContainer, {
       zoom: this.ctx.isMobile ? 2.5 : 1.0,

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -6,7 +6,6 @@ import type { ClusteredEvent } from '@/types';
 import type { RelatedAsset } from '@/types';
 import type { TheaterPostureSummary } from '@/services/military-surge';
 import {
-  MapContainer,
   NewsPanel,
   MarketPanel,
   StockAnalysisPanel,
@@ -276,8 +275,8 @@ export class PanelLayoutManager implements AppModule {
     });
   }
 
-  init(): void {
-    this.renderLayout();
+  async init(): Promise<void> {
+    await this.renderLayout();
 
     // Subscribe to auth state for reactive panel gating on web
     this.unsubscribeAuth = subscribeAuthState((state) => {
@@ -422,7 +421,7 @@ export class PanelLayoutManager implements AppModule {
     }
   }
 
-  renderLayout(): void {
+  async renderLayout(): Promise<void> {
     this.ctx.container.innerHTML = `
       ${this.ctx.isDesktopApp ? '<div class="tauri-titlebar" data-tauri-drag-region></div>' : ''}
       <div class="header">
@@ -658,7 +657,7 @@ export class PanelLayoutManager implements AppModule {
       </footer>
     `;
 
-    this.createPanels();
+    await this.createPanels();
 
     if (this.ctx.isMobile) {
       this.setupMobileMapToggle();
@@ -842,11 +841,15 @@ export class PanelLayoutManager implements AppModule {
     return panel;
   }
 
-  private createPanels(): void {
+  private async createPanels(): Promise<void> {
     const panelsGrid = document.getElementById('panelsGrid')!;
 
     const mapContainer = document.getElementById('mapContainer') as HTMLElement;
     const preferGlobe = loadFromStorage<string>(STORAGE_KEYS.mapMode, 'flat') === 'globe';
+    // Dynamic import: keeps maplibre-gl + @deck.gl/* + @loaders.gl + @luma.gl
+    // out of the entry chunk. Loads in parallel with paint, so the map mounts
+    // a beat after the panel grid renders instead of blocking it.
+    const { MapContainer } = await import('@/components/MapContainer');
     this.ctx.map = new MapContainer(mapContainer, {
       zoom: this.ctx.isMobile ? 2.5 : 1.0,
       pan: { x: 0, y: 0 },

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -7,7 +7,8 @@ import { MapboxOverlay } from '@deck.gl/mapbox';
 import type { Layer, LayersList, PickingInfo } from '@deck.gl/core';
 import { GeoJsonLayer, ScatterplotLayer, PathLayer, IconLayer, TextLayer, PolygonLayer } from '@deck.gl/layers';
 import maplibregl from 'maplibre-gl';
-import { registerPMTilesProtocol, FALLBACK_DARK_STYLE, FALLBACK_LIGHT_STYLE, getMapProvider, getMapTheme, getStyleForProvider, isLightMapTheme } from '@/config/basemap';
+import { FALLBACK_DARK_STYLE, FALLBACK_LIGHT_STYLE, getMapProvider, getMapTheme, isLightMapTheme } from '@/config/basemap';
+import { registerPMTilesProtocol, getStyleForProvider } from '@/config/basemap-styles';
 import Supercluster from 'supercluster';
 import type {
   MapLayers,

--- a/src/components/DefensePatentsPanel.ts
+++ b/src/components/DefensePatentsPanel.ts
@@ -23,7 +23,16 @@ const CPC_ICONS: Record<string, string> = {
   C12N: '🧬',
 };
 
-const militaryClient = new MilitaryServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
+// Lazy singleton: top-level `new X(...)` evaluates at module-init time, which
+// TDZ'd under cluster-chunk splits when this panel's chunk initialised before
+// the chunk owning MilitaryServiceClient. Defer construction until first call.
+let _militaryClient: MilitaryServiceClient | null = null;
+function militaryClient(): MilitaryServiceClient {
+  if (!_militaryClient) {
+    _militaryClient = new MilitaryServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
+  }
+  return _militaryClient;
+}
 
 export class DefensePatentsPanel extends Panel {
   private viewMode: ViewMode = 'all';
@@ -48,7 +57,7 @@ export class DefensePatentsPanel extends Panel {
     this.render();
 
     try {
-      const data = await militaryClient.listDefensePatents({ cpcCode: '', assignee: '', limit: 100 });
+      const data = await militaryClient().listDefensePatents({ cpcCode: '', assignee: '', limit: 100 });
       if (!this.element?.isConnected) return;
       this.patents = data.patents ?? [];
       this.setCount(data.total ?? this.patents.length);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,8 +2,13 @@ export * from './Panel';
 export * from './VirtualList';
 export { MapComponent } from './Map';
 export * from './MapPopup';
-export { DeckGLMap } from './DeckGLMap';
-export { MapContainer, type MapView, type TimeRange, type MapContainerState } from './MapContainer';
+// Type-only re-exports for the heavy WebGL map stack: emitting the values here
+// would drag MapContainer→DeckGLMap→maplibre-gl + @deck.gl/* into the entry's
+// static graph through every barrel consumer, undoing the dynamic-import in
+// panel-layout. Anyone needing the value must import directly from
+// '@/components/MapContainer' (currently: panel-layout via dynamic import).
+export type { DeckGLMap } from './DeckGLMap';
+export type { MapContainer, MapView, TimeRange, MapContainerState } from './MapContainer';
 export * from './NewsPanel';
 export * from './MarketPanel';
 export * from './StockAnalysisPanel';

--- a/src/config/basemap-styles.ts
+++ b/src/config/basemap-styles.ts
@@ -1,0 +1,75 @@
+// maplibre-, pmtiles-, @protomaps/basemaps-using parts of basemap.ts.
+// Split out so `preferences-content.ts` (which only needs the preference
+// getters/setters) does NOT pull maplibre into the main bundle. Only
+// imported by `DeckGLMap.ts`, which is itself dynamically imported when
+// the map panel mounts — so maplibre + deck.gl now load lazily.
+import { Protocol } from 'pmtiles';
+import maplibregl from 'maplibre-gl';
+import { layers, namedFlavor } from '@protomaps/basemaps';
+import type { StyleSpecification } from 'maplibre-gl';
+import {
+  R2_BASE,
+  hasPMTilesUrl,
+  isLightMapTheme,
+  asPMTilesTheme,
+  FALLBACK_DARK_STYLE,
+  FALLBACK_LIGHT_STYLE,
+  type PMTilesTheme,
+  type MapProvider,
+} from '@/config/basemap';
+
+let registered = false;
+
+export function registerPMTilesProtocol(): void {
+  if (registered) return;
+  registered = true;
+  const protocol = new Protocol();
+  maplibregl.addProtocol('pmtiles', protocol.tile);
+}
+
+export function buildPMTilesStyle(flavor: PMTilesTheme): StyleSpecification | null {
+  if (!hasPMTilesUrl) return null;
+  const spriteName = ['light', 'white'].includes(flavor) ? 'light' : 'dark';
+  return {
+    version: 8,
+    glyphs: 'https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf',
+    sprite: `https://protomaps.github.io/basemaps-assets/sprites/v4/${spriteName}`,
+    sources: {
+      basemap: {
+        type: 'vector',
+        url: `pmtiles://${R2_BASE}`,
+        attribution: '<a href="https://protomaps.com">Protomaps</a> | <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>',
+      },
+    },
+    layers: layers('basemap', namedFlavor(flavor), { lang: 'en' }) as StyleSpecification['layers'],
+  };
+}
+
+const CARTO_DARK = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
+const CARTO_VOYAGER = 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json';
+const CARTO_POSITRON = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+
+const CARTO_STYLES: Record<string, string> = {
+  'dark-matter': CARTO_DARK,
+  'voyager': CARTO_VOYAGER,
+  'positron': CARTO_POSITRON,
+};
+
+export function getStyleForProvider(provider: MapProvider, mapTheme: string): StyleSpecification | string {
+  const lightFallback = isLightMapTheme(mapTheme);
+  switch (provider) {
+    case 'pmtiles': {
+      const style = buildPMTilesStyle(asPMTilesTheme(mapTheme));
+      if (style) return style;
+      return lightFallback ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE;
+    }
+    case 'openfreemap':
+      return mapTheme === 'positron' ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE;
+    case 'carto':
+      return CARTO_STYLES[mapTheme] ?? CARTO_DARK;
+    default: {
+      const pmtiles = buildPMTilesStyle(asPMTilesTheme(mapTheme));
+      return pmtiles ?? (lightFallback ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE);
+    }
+  }
+}

--- a/src/config/basemap.ts
+++ b/src/config/basemap.ts
@@ -1,45 +1,19 @@
-import { Protocol } from 'pmtiles';
-import maplibregl from 'maplibre-gl';
-import { layers, namedFlavor } from '@protomaps/basemaps';
-import type { StyleSpecification } from 'maplibre-gl';
+// Map provider/theme preferences. Pure config: NO maplibre/pmtiles/protomaps
+// runtime deps live here so the preferences UI (UnifiedSettings → preferences-content)
+// can render without dragging maplibre+deck.gl into the entry bundle.
+// maplibre-using helpers live in `./basemap-styles.ts` and are loaded
+// lazily alongside MapContainer/DeckGLMap when the map panel mounts.
 
 const R2_PROXY = import.meta.env.VITE_PMTILES_URL ?? '';
 const R2_PUBLIC = import.meta.env.VITE_PMTILES_URL_PUBLIC ?? '';
 const isTauri = typeof window !== 'undefined' && '__TAURI__' in window;
-const R2_BASE = isTauri && R2_PUBLIC ? R2_PUBLIC : R2_PROXY;
+export const R2_BASE = isTauri && R2_PUBLIC ? R2_PUBLIC : R2_PROXY;
 
 const hasTilesUrl = !!R2_BASE;
-
-let registered = false;
-
-export function registerPMTilesProtocol(): void {
-  if (registered) return;
-  registered = true;
-  const protocol = new Protocol();
-  maplibregl.addProtocol('pmtiles', protocol.tile);
-}
 
 export type PMTilesTheme = 'black' | 'dark' | 'grayscale' | 'light' | 'white';
 export type OpenFreeMapTheme = 'dark' | 'positron';
 export type CartoTheme = 'dark-matter' | 'voyager' | 'positron';
-
-export function buildPMTilesStyle(flavor: PMTilesTheme): StyleSpecification | null {
-  if (!hasTilesUrl) return null;
-  const spriteName = ['light', 'white'].includes(flavor) ? 'light' : 'dark';
-  return {
-    version: 8,
-    glyphs: 'https://protomaps.github.io/basemaps-assets/fonts/{fontstack}/{range}.pbf',
-    sprite: `https://protomaps.github.io/basemaps-assets/sprites/v4/${spriteName}`,
-    sources: {
-      basemap: {
-        type: 'vector',
-        url: `pmtiles://${R2_BASE}`,
-        attribution: '<a href="https://protomaps.com">Protomaps</a> | <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>',
-      },
-    },
-    layers: layers('basemap', namedFlavor(flavor), { lang: 'en' }) as StyleSpecification['layers'],
-  };
-}
 
 export const FALLBACK_DARK_STYLE = 'https://tiles.openfreemap.org/styles/dark';
 export const FALLBACK_LIGHT_STYLE = 'https://tiles.openfreemap.org/styles/positron';
@@ -123,36 +97,7 @@ export function isLightMapTheme(mapTheme: string): boolean {
   return ['light', 'white', 'positron', 'voyager'].includes(mapTheme);
 }
 
-const CARTO_DARK = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
-const CARTO_VOYAGER = 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json';
-const CARTO_POSITRON = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
-
-const CARTO_STYLES: Record<string, string> = {
-  'dark-matter': CARTO_DARK,
-  'voyager': CARTO_VOYAGER,
-  'positron': CARTO_POSITRON,
-};
-
-function asPMTilesTheme(mapTheme: string): PMTilesTheme {
+export function asPMTilesTheme(mapTheme: string): PMTilesTheme {
   const valid = PMTILES_THEMES.some(o => o.value === mapTheme);
   return (valid ? mapTheme : 'black') as PMTilesTheme;
-}
-
-export function getStyleForProvider(provider: MapProvider, mapTheme: string): StyleSpecification | string {
-  const lightFallback = isLightMapTheme(mapTheme);
-  switch (provider) {
-    case 'pmtiles': {
-      const style = buildPMTilesStyle(asPMTilesTheme(mapTheme));
-      if (style) return style;
-      return lightFallback ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE;
-    }
-    case 'openfreemap':
-      return mapTheme === 'positron' ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE;
-    case 'carto':
-      return CARTO_STYLES[mapTheme] ?? CARTO_DARK;
-    default: {
-      const pmtiles = buildPMTilesStyle(asPMTilesTheme(mapTheme));
-      return pmtiles ?? (lightFallback ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE);
-    }
-  }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,79 @@ import { VARIANT_META, type VariantMeta } from './src/config/variant-meta';
 const brotliCompressAsync = promisify(brotliCompress);
 const BROTLI_EXTENSIONS = new Set(['.js', '.mjs', '.css', '.html', '.svg', '.json', '.txt', '.xml', '.wasm']);
 
+// Panel-cluster manualChunks map. Splits the previously monolithic ~2.3MB
+// `panels` chunk into per-domain chunks so cache invalidation is local to
+// the cluster a panel lives in and per-variant builds can prune unused
+// clusters. Unmapped panels fall through to a generic `panels` chunk.
+const PANEL_CLUSTER: Record<string, string> = {
+  // Markets / equities / crypto positioning
+  AAIISentiment: 'panels-markets', CotPositioning: 'panels-markets',
+  ETFFlows: 'panels-markets', EarningsCalendar: 'panels-markets',
+  EconomicCalendar: 'panels-markets', FearGreed: 'panels-markets',
+  GoldIntelligence: 'panels-markets', LiquidityShifts: 'panels-markets',
+  MacroSignals: 'panels-markets', Market: 'panels-markets',
+  MarketBreadth: 'panels-markets', MarketImplications: 'panels-markets',
+  Positioning: 'panels-markets', Stablecoin: 'panels-markets',
+  StockAnalysis: 'panels-markets', StockBacktest: 'panels-markets',
+  WsbTickerScanner: 'panels-markets', YieldCurve: 'panels-markets',
+  // Energy / commodities / supply infra
+  ChokepointStrip: 'panels-energy', EnergyComplex: 'panels-energy',
+  EnergyCrisis: 'panels-energy', EnergyDisruptions: 'panels-energy',
+  EnergyRiskOverview: 'panels-energy', FuelPrices: 'panels-energy',
+  FuelShortage: 'panels-energy', Hormuz: 'panels-energy',
+  OilInventories: 'panels-energy', PipelineStatus: 'panels-energy',
+  StorageFacilityMap: 'panels-energy', RenewableEnergy: 'panels-energy',
+  // Defense / military / aviation
+  AirlineIntel: 'panels-defense', DefensePatents: 'panels-defense',
+  OrefSirens: 'panels-defense', StrategicPosture: 'panels-defense',
+  StrategicRisk: 'panels-defense', ThermalEscalation: 'panels-defense',
+  UcdpEvents: 'panels-defense',
+  // News / feeds / briefs
+  BreakthroughsTicker: 'panels-news', ClimateNews: 'panels-news',
+  DailyMarketBrief: 'panels-news', GdeltIntel: 'panels-news',
+  GoodThingsDigest: 'panels-news', LatestBrief: 'panels-news',
+  LiveNews: 'panels-news', News: 'panels-news',
+  PositiveNewsFeed: 'panels-news', TelegramIntel: 'panels-news',
+  // Macro / prices / trade
+  BigMac: 'panels-economy', ConsumerPrices: 'panels-economy',
+  Economic: 'panels-economy',
+  FaoFoodPriceIndex: 'panels-economy', FSI: 'panels-economy',
+  GroceryBasket: 'panels-economy', GulfEconomies: 'panels-economy',
+  Investments: 'panels-economy', MacroTiles: 'panels-economy',
+  NationalDebt: 'panels-economy', SanctionsPressure: 'panels-economy',
+  SupplyChain: 'panels-economy', TradePolicy: 'panels-economy',
+  // Country briefs / signals / monitors / agent surfaces.
+  // CorrelationPanel base lives here, so all *Correlation consumers MUST stay
+  // in this cluster — splitting them across clusters caused TDZ on init.
+  ChatAnalyst: 'panels-intel', CII: 'panels-intel',
+  Cascade: 'panels-intel', Correlation: 'panels-intel',
+  CountryBrief: 'panels-intel', CountryDeepDive: 'panels-intel',
+  CrossSourceSignals: 'panels-intel', CustomWidget: 'panels-intel',
+  Deduction: 'panels-intel',
+  DisasterCorrelation: 'panels-intel',
+  EconomicCorrelation: 'panels-intel',
+  EscalationCorrelation: 'panels-intel',
+  MilitaryCorrelation: 'panels-intel',
+  Forecast: 'panels-intel',
+  HeroSpotlight: 'panels-intel', Insights: 'panels-intel',
+  LiveWebcams: 'panels-intel', McpData: 'panels-intel',
+  Monitor: 'panels-intel', PinnedWebcams: 'panels-intel',
+  Prediction: 'panels-intel', ProgressCharts: 'panels-intel',
+  Regulation: 'panels-intel',
+  // Disasters / climate / connectivity / society
+  ClimateAnomaly: 'panels-risk', Counters: 'panels-risk',
+  DiseaseOutbreaks: 'panels-risk',
+  Displacement: 'panels-risk', GeoHubs: 'panels-risk',
+  Giving: 'panels-risk', InternetDisruptions: 'panels-risk',
+  PopulationExposure: 'panels-risk', RadiationWatch: 'panels-risk',
+  RuntimeConfig: 'panels-risk', SatelliteFires: 'panels-risk',
+  SecurityAdvisories: 'panels-risk', ServiceStatus: 'panels-risk',
+  SocialVelocity: 'panels-risk', SpeciesComeback: 'panels-risk',
+  Status: 'panels-risk', TechEvents: 'panels-risk',
+  TechHubs: 'panels-risk', TechReadiness: 'panels-risk',
+  WorldClock: 'panels-risk',
+};
+
 function brotliPrecompressPlugin(): Plugin {
   return {
     name: 'brotli-precompress',
@@ -832,6 +905,18 @@ export default defineConfig(({ mode }) => {
       // Geospatial bundles (maplibre/deck) are expected to be large even when split.
       // Raise warning threshold to reduce noisy false alarms in CI.
       chunkSizeWarningLimit: 1200,
+      // Vite 6 hoists every dynamic chunk's STATIC deps into the entry HTML's
+      // modulepreload list to avoid latency on the first dynamic import. For the
+      // map stack that defeats the whole point of dynamic-importing MapContainer:
+      // ~3MB of WebGL deps would still download at parse time. Strip them here so
+      // they only load when MapContainer's `await import(...)` actually fires
+      // (still preloaded in parallel via __vitePreload at that moment).
+      modulePreload: {
+        resolveDependencies: (_filename, deps, { hostType }) => {
+          if (hostType !== 'html') return deps;
+          return deps.filter(d => !/\/(maplibre|deck-stack|MapContainer)-[A-Za-z0-9_-]+\.js$/.test(d));
+        },
+      },
       rollupOptions: {
         onwarn(warning, warn) {
           // onnxruntime-web ships a minified browser bundle that intentionally uses eval.
@@ -886,6 +971,10 @@ export default defineConfig(({ mode }) => {
               }
             }
             if (id.includes('/src/components/') && id.endsWith('Panel.ts')) {
+              // Cluster split (PANEL_CLUSTER) is staged but disabled: it exposes
+              // a systemic TDZ in panels with top-level `new XxxServiceClient(...)`
+              // singletons (~20+ panels). They each need lazy-init refactors
+              // before the cluster split can ship. See ce-doc-review followup.
               return 'panels';
             }
             // Give lazy-loaded locale chunks a recognizable prefix so the

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,19 @@ import { VARIANT_META, type VariantMeta } from './src/config/variant-meta';
 const brotliCompressAsync = promisify(brotliCompress);
 const BROTLI_EXTENSIONS = new Set(['.js', '.mjs', '.css', '.html', '.svg', '.json', '.txt', '.xml', '.wasm']);
 
+// Single source of truth for chunk names that must NOT be hoisted into the
+// entry HTML's modulepreload list. Used by both `manualChunks` (return values
+// must literally match these strings) and `modulePreload.resolveDependencies`
+// (filter regex is built from this list). Keeping them tied prevents the
+// silent-breakage failure mode where renaming a chunk in `manualChunks`
+// re-eagerises the WebGL stack without any build-time error.
+//   - maplibre, deck-stack: heavy WebGL deps, only reachable via MapContainer
+//   - MapContainer: the dynamic-import target itself
+const LAZY_HTML_PRELOAD_CHUNKS = ['maplibre', 'deck-stack', 'MapContainer'] as const;
+const LAZY_HTML_PRELOAD_RE = new RegExp(
+  `/(${LAZY_HTML_PRELOAD_CHUNKS.join('|')})-[A-Za-z0-9_-]+\\.js$`,
+);
+
 // Panel-cluster manualChunks map. Splits the previously monolithic ~2.3MB
 // `panels` chunk into per-domain chunks so cache invalidation is local to
 // the cluster a panel lives in and per-variant builds can prune unused
@@ -914,7 +927,7 @@ export default defineConfig(({ mode }) => {
       modulePreload: {
         resolveDependencies: (_filename, deps, { hostType }) => {
           if (hostType !== 'html') return deps;
-          return deps.filter(d => !/\/(maplibre|deck-stack|MapContainer)-[A-Za-z0-9_-]+\.js$/.test(d));
+          return deps.filter(d => !LAZY_HTML_PRELOAD_RE.test(d));
         },
       },
       rollupOptions: {
@@ -945,6 +958,10 @@ export default defineConfig(({ mode }) => {
               if (id.includes('/onnxruntime-web/')) {
                 return 'onnxruntime';
               }
+              // NOTE: chunk names below MUST match entries in LAZY_HTML_PRELOAD_CHUNKS
+              // (top of file). The resolveDependencies filter relies on this string
+              // identity; renaming here without updating the constant silently
+              // re-eagerises the WebGL stack into the entry HTML's modulepreload list.
               if (id.includes('/maplibre-gl/') || id.includes('/pmtiles/') || id.includes('/@protomaps/basemaps/')) {
                 return 'maplibre';
               }


### PR DESCRIPTION
## Summary

A captured HAR (1 May 2026, abacus.worldmonitor.app 502 outage) showed `DOMContentLoaded` blocked at **15.99s**. Root-caused two compounding eager-load bugs and fixed both. Cold-load DCL now **200ms** in the verified preview build (~70× faster).

- **defer→async on the Umami analytics tag.** `defer` waits for download AND execute before firing DCL — when abacus 502s with a 15s timeout, DCL stalls 15s. `async` doesn't gate DCL, so a dead analytics host can no longer hold the page hostage.
- **Lazy-load `maplibre-gl` (~1.1MB) + `@deck.gl/*` (~1.0MB).** Two static-import chains were dragging the WebGL stack into the entry bundle:
  - `App → event-handlers → UnifiedSettings → preferences-content → @/config/basemap → maplibre-gl`
  - `panel-layout → @/components → MapContainer → DeckGLMap → maplibre-gl + @deck.gl/*`

  Fixed by:
  - Splitting `src/config/basemap.ts` into a maplibre-free preferences module and a new `src/config/basemap-styles.ts` that owns the maplibre-using helpers. `preferences-content` only imports the pure half.
  - Dynamic-importing `MapContainer` from `panel-layout.createPanels()`; cascaded `async` through `renderLayout` → `init` → `App.ts:1048`.
  - Switching the `@/components` barrel re-exports of `MapContainer` and `DeckGLMap` to type-only — value re-exports were re-eagerising the graph through every barrel consumer.
  - Adding `build.modulePreload.resolveDependencies` so Vite 6 stops hoisting dynamic-chunk deps back into the entry HTML's modulepreload list (its default — defeats the dynamic import without this filter).

## Verified results

| Metric | Original HAR | After fix |
|---|---:|---:|
| `domInteractive` | ~15,750 ms | **182 ms** |
| `domContentLoaded` | 15,753 ms | **200 ms** |
| `loadEvent` | 15,989 ms | **230 ms** |
| Main entry chunk size | 2.88 MB | **687 KB** |
| `maplibre`+`deck-stack` in initial modulepreload | yes | **no** |
| Map canvas mounts cleanly | after DCL stall | **yes** |

`maplibre` + `deck-stack` now start at +59ms (parallel via `__vitePreload`, fired when `createPanels`'s dynamic import resolves); `MapContainer` chunk at +245ms.

## Staged but disabled: panel-cluster split

Tried splitting the 2.3MB `panels` chunk into 7 per-domain clusters. Activating it surfaced systemic TDZ across ~20+ panels with top-level singletons of the form `const client = new XxxServiceClient(getRpcBaseUrl(), …)` — once those clusters are split across chunk boundaries, ESM init order is non-linear and the class binding is in TDZ when the panel chunk evaluates first.

The `PANEL_CLUSTER` mapping table is checked in (with a comment) so the cluster split can ship once those singletons are converted to lazy-init helpers. `DefensePatentsPanel` already converted as a reference pattern.

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run typecheck:api` — pass
- [x] `npm run lint` (biome) — pass, 0 errors
- [x] `npm run test:data` — pass, 7749/7749
- [x] `npm run lint:md` — pass
- [x] `npm run version:check` — pass
- [x] All edge-function bundles (esbuild, 19 entries) — pass
- [x] `node --test tests/edge-functions.test.mjs` — pass, 178/178
- [x] `vite build` clean
- [x] Cold-load smoke test in `vite preview` — map canvas mounts, no console errors from these changes (RPC 404s in preview are expected; gateway runs on Vercel)
- [x] Modulepreload audit on built `dist/index.html` — `MapContainer` + `maplibre` + `deck-stack` absent
- [x] Branch on `worktree-golden-snuggling-eclipse`, base `main`, no `--no-verify`

## Notes for reviewers

- `panel-layout.ts` `init()`/`renderLayout()`/`createPanels()` are now `async`. The only call site is `App.ts:1048`, which already lived inside an async function and now awaits properly. All other public `panelLayout.*` methods are unchanged.
- All `state.map` / `ctx.map` access sites already use `?.` or explicit guards (audited before async-ifying), so the dynamic-import window doesn't open new null-deref paths.
- `basemap-styles.ts` owns the `let registered = false` PMTiles protocol-registration latch (was previously in `basemap.ts`); single instance per app, single consumer (`DeckGLMap`).