### PR TITLE
fix(free-tier): round-robin source-cap, stop killing late-alphabet categories

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -66,6 +66,7 @@ import { preloadCountryGeometry, getCountryNameByCode } from '@/services/country
 import { initI18n, t } from '@/services/i18n';
 
 import { computeDefaultDisabledSources, getLocaleBoostedSources, getTotalFeedCount, FEEDS, INTEL_SOURCES } from '@/config/feeds';
+import { selectSourcesUnderCap } from '@/services/source-cap';
 import { fetchBootstrapData, getBootstrapHydrationState, markBootstrapAsLive, type BootstrapHydrationState } from '@/services/bootstrap';
 import { describeFreshness } from '@/services/persistent-cache';
 import { DesktopUpdater } from '@/app/desktop-updater';
@@ -1239,22 +1240,26 @@ export class App {
     if (cwDisabled || needsTrim) saveToStorage(STORAGE_KEYS.panels, panelSettings);
 
     // --- Source limit ---
+    // Free-tier 80-source cap. Pre-2026-05-01 this used `Array.sort().slice()`
+    // which silently auto-disabled every source past alphabetical position 80,
+    // catastrophically erasing late-alphabet categories (Layoffs, Semiconductors,
+    // IPO & SPAC, Funding & VC, Product Hunt, …) and producing the "All sources
+    // disabled" red panel state on the homepage with no user explanation.
+    // Replaced with round-robin per-category distribution from `selectSourcesUnderCap`.
     const disabledSources = new Set(loadFromStorage<string[]>(STORAGE_KEYS.disabledFeeds, []));
-    const allSourceNames = (() => {
+    const totalEligible = (() => {
       const s = new Set<string>();
-      Object.values(FEEDS).forEach(feeds => feeds?.forEach(f => s.add(f.name)));
-      INTEL_SOURCES.forEach(f => s.add(f.name));
-      return Array.from(s).sort((a, b) => a.localeCompare(b));
+      Object.values(FEEDS).forEach((feeds) => feeds?.forEach((f) => s.add(f.name)));
+      INTEL_SOURCES.forEach((f) => s.add(f.name));
+      let count = 0;
+      for (const name of s) if (!disabledSources.has(name)) count++;
+      return count;
     })();
-    const currentlyEnabled = allSourceNames.filter(n => !disabledSources.has(n));
-    const enabledCount = currentlyEnabled.length;
-    if (enabledCount > FREE_MAX_SOURCES) {
-      const toDisable = enabledCount - FREE_MAX_SOURCES;
-      for (const name of currentlyEnabled.slice(FREE_MAX_SOURCES)) {
-        disabledSources.add(name);
-      }
+    if (totalEligible > FREE_MAX_SOURCES) {
+      const { autoDisabled } = selectSourcesUnderCap(FEEDS, INTEL_SOURCES, disabledSources, FREE_MAX_SOURCES);
+      for (const name of autoDisabled) disabledSources.add(name);
       saveToStorage(STORAGE_KEYS.disabledFeeds, Array.from(disabledSources));
-      console.log(`[App] Free tier: disabled ${toDisable} source(s) to enforce ${FREE_MAX_SOURCES}-source limit`);
+      console.log(`[App] Free tier: round-robin disabled ${autoDisabled.size} source(s) to enforce ${FREE_MAX_SOURCES}-source limit (per-category fairness)`);
     }
   }
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -66,7 +66,7 @@ import { preloadCountryGeometry, getCountryNameByCode } from '@/services/country
 import { initI18n, t } from '@/services/i18n';
 
 import { computeDefaultDisabledSources, getLocaleBoostedSources, getTotalFeedCount, FEEDS, INTEL_SOURCES } from '@/config/feeds';
-import { selectSourcesUnderCap } from '@/services/source-cap';
+import { selectSourcesUnderCap, findFullyDisabledCategories } from '@/services/source-cap';
 import { fetchBootstrapData, getBootstrapHydrationState, markBootstrapAsLive, type BootstrapHydrationState } from '@/services/bootstrap';
 import { describeFreshness } from '@/services/persistent-cache';
 import { DesktopUpdater } from '@/app/desktop-updater';
@@ -1215,7 +1215,23 @@ export class App {
    * Safe to call multiple times (idempotent) — e.g. on auth state changes.
    */
   private enforceFreeTierLimits(): void {
-    if (isProUser()) return;
+    if (isProUser()) {
+      // Pro users have no source cap — but their localStorage may still
+      // hold v1-bug entries from a prior free-tier session OR from the
+      // pre-fix alphabetical-slice enforcement. Detect categories where
+      // 100% of sources are disabled (the bug fingerprint — a real user
+      // would hide the whole panel, not toggle every source individually)
+      // and re-enable them. Targeted enough that explicit single-source
+      // disabling is preserved.
+      const disabledSources = new Set(loadFromStorage<string[]>(STORAGE_KEYS.disabledFeeds, []));
+      const recoverable = findFullyDisabledCategories(FEEDS, disabledSources);
+      if (recoverable.length > 0) {
+        for (const name of recoverable) disabledSources.delete(name);
+        saveToStorage(STORAGE_KEYS.disabledFeeds, Array.from(disabledSources));
+        console.log(`[App] Pro user: recovered ${recoverable.length} source(s) from fully-disabled categories (likely v1 cap-bug victims)`);
+      }
+      return;
+    }
 
     // --- Panel limit ---
     const panelSettings = loadFromStorage<Record<string, PanelConfig>>(STORAGE_KEYS.panels, {});
@@ -1247,6 +1263,15 @@ export class App {
     // disabled" red panel state on the homepage with no user explanation.
     // Replaced with round-robin per-category distribution from `selectSourcesUnderCap`.
     const disabledSources = new Set(loadFromStorage<string[]>(STORAGE_KEYS.disabledFeeds, []));
+    // Free-user recovery: same v1-bug fingerprint as the Pro path above.
+    // Re-enable any 100%-disabled category before applying the new round-robin
+    // distribution, otherwise the round-robin sees those categories as having
+    // no eligible sources and silently skips them.
+    const recoverable = findFullyDisabledCategories(FEEDS, disabledSources);
+    if (recoverable.length > 0) {
+      for (const name of recoverable) disabledSources.delete(name);
+      console.log(`[App] Free tier: recovered ${recoverable.length} source(s) from fully-disabled categories before round-robin (likely v1 cap-bug victims)`);
+    }
     const totalEligible = (() => {
       const s = new Set<string>();
       Object.values(FEEDS).forEach((feeds) => feeds?.forEach((f) => s.add(f.name)));

--- a/src/App.ts
+++ b/src/App.ts
@@ -1288,8 +1288,15 @@ export class App {
       return count;
     })();
     if (totalEligible > FREE_MAX_SOURCES) {
-      const { autoDisabled } = selectSourcesUnderCap(FEEDS, INTEL_SOURCES, disabledSources, FREE_MAX_SOURCES);
-      for (const name of autoDisabled) disabledSources.add(name);
+      const { keep, autoDisabled } = selectSourcesUnderCap(FEEDS, INTEL_SOURCES, disabledSources, FREE_MAX_SOURCES);
+      // Defense in depth: feeds.ts has 35+ source names that appear in
+      // multiple category buckets. The helper guarantees keep ∩ autoDisabled
+      // = ∅, but a regression there would silently re-disable a kept source
+      // here. The keep.has() guard makes the cross-set invariant explicit
+      // at the caller too — if it ever fires it's a helper-bug signal.
+      for (const name of autoDisabled) {
+        if (!keep.has(name)) disabledSources.add(name);
+      }
       saveToStorage(STORAGE_KEYS.disabledFeeds, Array.from(disabledSources));
       console.log(`[App] Free tier: round-robin disabled ${autoDisabled.size} source(s) to enforce ${FREE_MAX_SOURCES}-source limit (per-category fairness)`);
     }

--- a/src/App.ts
+++ b/src/App.ts
@@ -1215,23 +1215,37 @@ export class App {
    * Safe to call multiple times (idempotent) — e.g. on auth state changes.
    */
   private enforceFreeTierLimits(): void {
-    if (isProUser()) {
-      // Pro users have no source cap — but their localStorage may still
-      // hold v1-bug entries from a prior free-tier session OR from the
-      // pre-fix alphabetical-slice enforcement. Detect categories where
-      // 100% of sources are disabled (the bug fingerprint — a real user
-      // would hide the whole panel, not toggle every source individually)
-      // and re-enable them. Targeted enough that explicit single-source
-      // disabling is preserved.
-      const disabledSources = new Set(loadFromStorage<string[]>(STORAGE_KEYS.disabledFeeds, []));
-      const recoverable = findFullyDisabledCategories(FEEDS, disabledSources);
+    // ── One-time v1 cap-bug recovery ──────────────────────────────────
+    // Pre-2026-05-01 the source cap was enforced by Array.sort().slice(),
+    // which silently auto-disabled every source past alphabetical position
+    // FREE_MAX_SOURCES — catastrophically erasing late-alphabet categories
+    // (Layoffs, Semiconductors, IPO, Funding, Product Hunt, …). Storage
+    // didn't track auto-disabled vs user-disabled, so a heuristic that runs
+    // on every load would silently undo a user who legitimately disabled
+    // every source in a category — and re-undo it on every refresh forever.
+    //
+    // Migration approach: run findFullyDisabledCategories ONCE, gated by
+    // disabledFeedsSchema version. After the migration completes, bump
+    // schema → 1 so subsequent loads skip recovery entirely. Users who
+    // explicitly toggle off every source in a category post-migration
+    // keep that preference permanently. Trade-off: a user who BEFORE the
+    // migration legitimately disabled every source in a category will lose
+    // those preferences once. That's acceptable since v1 victims have been
+    // suffering silent breakage and the explicit-full-category-disable
+    // pattern is rare (users typically hide the whole panel instead).
+    const schemaVersion = loadFromStorage<number>(STORAGE_KEYS.disabledFeedsSchema, 0);
+    if (schemaVersion < 1) {
+      const disabled = new Set(loadFromStorage<string[]>(STORAGE_KEYS.disabledFeeds, []));
+      const recoverable = findFullyDisabledCategories(FEEDS, disabled);
       if (recoverable.length > 0) {
-        for (const name of recoverable) disabledSources.delete(name);
-        saveToStorage(STORAGE_KEYS.disabledFeeds, Array.from(disabledSources));
-        console.log(`[App] Pro user: recovered ${recoverable.length} source(s) from fully-disabled categories (likely v1 cap-bug victims)`);
+        for (const name of recoverable) disabled.delete(name);
+        saveToStorage(STORAGE_KEYS.disabledFeeds, Array.from(disabled));
+        console.log(`[App] One-time v1-cap-bug migration: re-enabled ${recoverable.length} source(s) from fully-disabled categories. This will not run again.`);
       }
-      return;
+      saveToStorage(STORAGE_KEYS.disabledFeedsSchema, 1);
     }
+
+    if (isProUser()) return;
 
     // --- Panel limit ---
     const panelSettings = loadFromStorage<Record<string, PanelConfig>>(STORAGE_KEYS.panels, {});
@@ -1262,16 +1276,9 @@ export class App {
     // IPO & SPAC, Funding & VC, Product Hunt, …) and producing the "All sources
     // disabled" red panel state on the homepage with no user explanation.
     // Replaced with round-robin per-category distribution from `selectSourcesUnderCap`.
+    // (v1-bug recovery for stuck localStorage state is handled once at the top
+    // of this function via the schema-version migration.)
     const disabledSources = new Set(loadFromStorage<string[]>(STORAGE_KEYS.disabledFeeds, []));
-    // Free-user recovery: same v1-bug fingerprint as the Pro path above.
-    // Re-enable any 100%-disabled category before applying the new round-robin
-    // distribution, otherwise the round-robin sees those categories as having
-    // no eligible sources and silently skips them.
-    const recoverable = findFullyDisabledCategories(FEEDS, disabledSources);
-    if (recoverable.length > 0) {
-      for (const name of recoverable) disabledSources.delete(name);
-      console.log(`[App] Free tier: recovered ${recoverable.length} source(s) from fully-disabled categories before round-robin (likely v1 cap-bug victims)`);
-    }
     const totalEligible = (() => {
       const s = new Set<string>();
       Object.values(FEEDS).forEach((feeds) => feeds?.forEach((f) => s.add(f.name)));

--- a/src/config/variants/base.ts
+++ b/src/config/variants/base.ts
@@ -95,6 +95,14 @@ export const STORAGE_KEYS = {
   monitors: 'worldmonitor-monitors',
   mapLayers: 'worldmonitor-layers',
   disabledFeeds: 'worldmonitor-disabled-feeds',
+  // Schema version for the disabledFeeds set. Bumped on each migration that
+  // mutates the set in a backwards-incompatible way. Currently:
+  //   missing/0 → pre-2026-05-01 alphabetical-cap state. Eligible for
+  //               one-time recovery of fully-disabled categories.
+  //   1 → recovery has run; the set is post-migration and must NOT be
+  //       re-recovered on subsequent loads (otherwise user-explicit
+  //       full-category disabling would be silently undone forever).
+  disabledFeedsSchema: 'worldmonitor-disabled-feeds-schema',
   liveChannels: 'worldmonitor-live-channels',
   mapMode: 'worldmonitor-map-mode',          // 'flat' | 'globe'
   activeChannel: 'worldmonitor-active-channel',

--- a/src/services/source-cap.ts
+++ b/src/services/source-cap.ts
@@ -1,0 +1,91 @@
+// Free-tier source-cap distribution.
+//
+// Replaces the prior alphabetical-slice enforcement that silently auto-disabled
+// every source past position N in a sorted list — which catastrophically broke
+// late-alphabet categories. With FREE_MAX_SOURCES=80 and ~30 categories, the
+// alphabetical strategy left entire categories ('Layoffs', 'Semiconductors &
+// Hardware', 'IPO & SPAC', 'Funding & VC', 'Product Hunt', etc.) with ALL
+// their sources auto-disabled, producing the "All sources disabled" red panel
+// state on the homepage with no user explanation.
+//
+// New strategy: round-robin across category buckets so the cap is spent
+// fairly. Every category with at least one enabled-eligible source keeps at
+// least one slot until the cap is exhausted. Within a category, sources are
+// taken in `feeds.ts` declaration order — editorial team controls "primary"
+// by listing the most important source first.
+
+export interface FeedItem {
+  name: string;
+}
+
+export interface FeedsByCategory {
+  [category: string]: ReadonlyArray<FeedItem> | undefined;
+}
+
+export interface SourceCapResult {
+  /** Sources that should remain enabled. */
+  keep: Set<string>;
+  /** Sources that the cap auto-disabled (excludes user's explicit disables). */
+  autoDisabled: Set<string>;
+}
+
+/**
+ * Distribute the source cap fairly across feed categories.
+ *
+ * @param feedsByCategory  category-keyed map of feed lists (typically `FEEDS`)
+ * @param intelSources     flat list of intel sources (treated as one bucket)
+ * @param userDisabled     sources the user has explicitly disabled — these
+ *                         are excluded from consideration entirely. Caller
+ *                         is responsible for distinguishing user-disabled
+ *                         from auto-disabled if needed.
+ * @param cap              maximum number of sources to keep enabled
+ *
+ * Deterministic given the same inputs. Reload-stable (Object.entries
+ * preserves insertion order in modern JS engines, and feeds.ts declaration
+ * order is fixed at compile time).
+ */
+export function selectSourcesUnderCap(
+  feedsByCategory: FeedsByCategory,
+  intelSources: ReadonlyArray<FeedItem>,
+  userDisabled: ReadonlySet<string>,
+  cap: number,
+): SourceCapResult {
+  if (cap < 0) {
+    return { keep: new Set(), autoDisabled: new Set() };
+  }
+
+  // Build per-category queues of eligible sources (excluding user-disabled).
+  // Each queue is a mutable array so we can shift() in round-robin order.
+  const buckets: Array<{ category: string; remaining: string[] }> = [];
+  for (const [category, feeds] of Object.entries(feedsByCategory)) {
+    if (!feeds) continue;
+    const names = feeds.map((f) => f.name).filter((n) => !userDisabled.has(n));
+    if (names.length > 0) buckets.push({ category, remaining: names });
+  }
+  const intelNames = intelSources.map((f) => f.name).filter((n) => !userDisabled.has(n));
+  if (intelNames.length > 0) buckets.push({ category: '__intel__', remaining: intelNames });
+
+  const keep = new Set<string>();
+
+  // Round-robin: take one source from each non-empty bucket per pass until
+  // the cap is reached or all buckets are exhausted.
+  let madeProgress = true;
+  while (keep.size < cap && madeProgress) {
+    madeProgress = false;
+    for (const bucket of buckets) {
+      if (keep.size >= cap) break;
+      if (bucket.remaining.length === 0) continue;
+      keep.add(bucket.remaining.shift()!);
+      madeProgress = true;
+    }
+  }
+
+  // Anything still in a bucket's `remaining` queue didn't make the cut.
+  // These are auto-disabled by the cap (NOT user-disabled).
+  const autoDisabled = new Set<string>();
+  for (const bucket of buckets) {
+    for (const name of bucket.remaining) autoDisabled.add(name);
+  }
+
+  return { keep, autoDisabled };
+}

--- a/src/services/source-cap.ts
+++ b/src/services/source-cap.ts
@@ -99,11 +99,29 @@ export function selectSourcesUnderCap(
 
   // Round-robin: take one source from each non-empty bucket per pass until
   // the cap is reached or all buckets are exhausted.
+  //
+  // Source-name dedup: feeds.ts has 35+ names that appear in multiple
+  // categories (Yahoo Finance × 4, CNBC × 3, MarketWatch × 3, Layoffs.fyi
+  // × 2, ...). Without dedup, a duplicate occupied two bucket turns to add
+  // ONE unique name to `keep` (Set rejects the second add silently). Worse,
+  // if the cap was hit between the two turns, the duplicate name remained
+  // in the second bucket's `remaining` queue and ended up in `autoDisabled`
+  // — the SAME name in both keep AND autoDisabled, with autoDisabled
+  // winning at the App.ts caller (which adds autoDisabled back into the
+  // global disabled set). Two-part fix: skip already-keep'd names BEFORE
+  // consuming a bucket turn (so duplicates don't waste round-robin slots),
+  // and filter `keep` out of `autoDisabled` at the end (defense in depth).
   let madeProgress = true;
   while (keep.size < cap && madeProgress) {
     madeProgress = false;
     for (const bucket of buckets) {
       if (keep.size >= cap) break;
+      // Drop already-keep'd names from the front of this bucket's queue.
+      // Multiple consecutive duplicates can be in the queue; drain them all
+      // before either consuming the slot or moving on.
+      while (bucket.remaining.length > 0 && keep.has(bucket.remaining[0]!)) {
+        bucket.remaining.shift();
+      }
       if (bucket.remaining.length === 0) continue;
       keep.add(bucket.remaining.shift()!);
       madeProgress = true;
@@ -111,10 +129,14 @@ export function selectSourcesUnderCap(
   }
 
   // Anything still in a bucket's `remaining` queue didn't make the cut.
-  // These are auto-disabled by the cap (NOT user-disabled).
+  // EXCLUDE anything already in `keep` — a duplicate name kept via one
+  // bucket can still appear unconsumed in another bucket's tail; it must
+  // not be reported as auto-disabled.
   const autoDisabled = new Set<string>();
   for (const bucket of buckets) {
-    for (const name of bucket.remaining) autoDisabled.add(name);
+    for (const name of bucket.remaining) {
+      if (!keep.has(name)) autoDisabled.add(name);
+    }
   }
 
   return { keep, autoDisabled };

--- a/src/services/source-cap.ts
+++ b/src/services/source-cap.ts
@@ -30,6 +30,36 @@ export interface SourceCapResult {
 }
 
 /**
+ * Detect categories where 100% of sources are in the disabled set — the
+ * fingerprint of the pre-2026-05-01 free-tier alphabetical-slice cap bug.
+ * Returns the source names that should be re-enabled.
+ *
+ * Used to recover Pro users (and free users on a fresh deploy) whose
+ * localStorage `disabledFeeds` state was poisoned by the v1 enforcement.
+ * The 100%-disabled-category heuristic is targeted enough that explicit
+ * user disabling of single sources is preserved — only fully-starved
+ * categories (which a real user would just hide as a panel, not toggle
+ * source-by-source) get recovered.
+ *
+ * @param feedsByCategory  category-keyed map of feed lists
+ * @param disabled         current disabled-source set (mixed user + auto)
+ * @returns                source names from any fully-disabled category
+ */
+export function findFullyDisabledCategories(
+  feedsByCategory: FeedsByCategory,
+  disabled: ReadonlySet<string>,
+): string[] {
+  const recoverable: string[] = [];
+  for (const feeds of Object.values(feedsByCategory)) {
+    if (!feeds || feeds.length === 0) continue;
+    if (feeds.every((f) => disabled.has(f.name))) {
+      for (const f of feeds) recoverable.push(f.name);
+    }
+  }
+  return recoverable;
+}
+
+/**
  * Distribute the source cap fairly across feed categories.
  *
  * @param feedsByCategory  category-keyed map of feed lists (typically `FEEDS`)

--- a/tests/source-cap.test.mts
+++ b/tests/source-cap.test.mts
@@ -140,6 +140,106 @@ describe('selectSourcesUnderCap: round-robin per-category fairness', () => {
   });
 });
 
+describe('selectSourcesUnderCap: duplicate source names across buckets (feeds.ts reality)', () => {
+  // feeds.ts contains 35+ names appearing in multiple categories
+  // (Yahoo Finance × 4, CNBC × 3, MarketWatch × 3, Layoffs.fyi × 2, ...).
+  // These tests pin down the must-not-regress invariant: kept names
+  // never end up in autoDisabled, regardless of how many buckets contain
+  // them.
+
+  it('REGRESSION: a duplicate name kept via one bucket is not auto-disabled by another', () => {
+    // Yahoo Finance lives in BOTH 'markets' and 'finance' buckets.
+    // Cap is generous → we expect Yahoo Finance in keep, NOT in autoDisabled.
+    const feeds = {
+      markets: F('Yahoo Finance', 'CNBC'),
+      finance: F('Yahoo Finance', 'Bloomberg'),
+    };
+    const r = selectSourcesUnderCap(feeds, [], new Set(), 10);
+    assert.ok(r.keep.has('Yahoo Finance'));
+    assert.ok(
+      !r.autoDisabled.has('Yahoo Finance'),
+      'kept name must NEVER appear in autoDisabled — caller would re-disable it',
+    );
+    // Sanity: keep ∩ autoDisabled must be empty for ALL names
+    for (const k of r.keep) {
+      assert.ok(!r.autoDisabled.has(k), `${k} appeared in both keep and autoDisabled`);
+    }
+  });
+
+  it('REGRESSION: duplicate names do not waste round-robin slots when cap is tight', () => {
+    // 3 buckets, each contains 2 names where the FIRST is a shared duplicate.
+    // Pre-fix: round-robin pulled the duplicate from each bucket, "consuming"
+    // 3 slots but only adding 1 unique to keep — leaving cap=3 with only 1
+    // unique kept name and 2 unique-secondary names auto-disabled.
+    // Post-fix: the helper drops already-keep'd names before consuming a
+    // turn, so each bucket cleanly contributes its unique secondary.
+    const feeds = {
+      a: F('SHARED', 'a-only'),
+      b: F('SHARED', 'b-only'),
+      c: F('SHARED', 'c-only'),
+    };
+    const r = selectSourcesUnderCap(feeds, [], new Set(), 4);
+    assert.equal(r.keep.size, 4, 'all 4 unique names must fit under cap=4');
+    assert.ok(r.keep.has('SHARED'));
+    assert.ok(r.keep.has('a-only'));
+    assert.ok(r.keep.has('b-only'));
+    assert.ok(r.keep.has('c-only'));
+    assert.equal(r.autoDisabled.size, 0);
+  });
+
+  it('REGRESSION: duplicate at cap boundary — kept name not auto-disabled when cap=1', () => {
+    // Cap is 1. Bucket a yields 'SHARED' first. Bucket b also has 'SHARED'
+    // followed by 'b-unique'. After 'SHARED' is keep'd via bucket a, bucket
+    // b's leading 'SHARED' must be dropped (not consume a slot at cap=1)
+    // and 'SHARED' must NOT show up in autoDisabled.
+    const feeds = {
+      a: F('SHARED'),
+      b: F('SHARED', 'b-unique'),
+    };
+    const r = selectSourcesUnderCap(feeds, [], new Set(), 1);
+    assert.equal(r.keep.size, 1);
+    assert.ok(r.keep.has('SHARED'));
+    assert.ok(!r.autoDisabled.has('SHARED'), 'kept name must not be in autoDisabled');
+    // b-unique didn't fit and is correctly auto-disabled
+    assert.ok(r.autoDisabled.has('b-unique'));
+  });
+
+  it('REGRESSION: many consecutive duplicates at bucket front are all skipped', () => {
+    // Bucket b has duplicate of 'a1' AND 'a2' from bucket a at its front.
+    // The drop-while loop must drain BOTH before considering b-unique.
+    const feeds = {
+      a: F('a1', 'a2'),
+      b: F('a1', 'a2', 'b-unique'),
+    };
+    const r = selectSourcesUnderCap(feeds, [], new Set(), 3);
+    assert.equal(r.keep.size, 3);
+    assert.ok(r.keep.has('a1'));
+    assert.ok(r.keep.has('a2'));
+    assert.ok(r.keep.has('b-unique'));
+    assert.equal(r.autoDisabled.size, 0);
+  });
+
+  it('keep ∩ autoDisabled invariant holds at production-scale duplicate density', () => {
+    // Mirror the real feeds.ts pattern: 5 categories, with Yahoo Finance,
+    // CNBC, MarketWatch each appearing in multiple categories. Cap=8 is
+    // tight — forces round-robin under load.
+    const feeds = {
+      markets: F('Yahoo Finance', 'CNBC', 'AAPL News'),
+      finance: F('Yahoo Finance', 'CNBC', 'MarketWatch', 'WSJ'),
+      crypto: F('CoinDesk', 'CoinTelegraph'),
+      etfflows: F('Yahoo Finance', 'BlackRock'),
+      energy: F('OilPrice.com', 'Reuters Energy'),
+    };
+    const r = selectSourcesUnderCap(feeds, [], new Set(), 8);
+    for (const k of r.keep) {
+      assert.ok(
+        !r.autoDisabled.has(k),
+        `name ${k} appears in BOTH keep and autoDisabled`,
+      );
+    }
+  });
+});
+
 describe('findFullyDisabledCategories: recover v1 cap-bug victims', () => {
   it('returns empty when no category is 100% disabled', () => {
     const feeds = { a: F('a1', 'a2'), b: F('b1', 'b2') };

--- a/tests/source-cap.test.mts
+++ b/tests/source-cap.test.mts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { selectSourcesUnderCap } from '../src/services/source-cap';
+import { selectSourcesUnderCap, findFullyDisabledCategories } from '../src/services/source-cap';
 
 const F = (...names: string[]) => names.map((name) => ({ name }));
 
@@ -137,5 +137,63 @@ describe('selectSourcesUnderCap: round-robin per-category fairness', () => {
     assert.ok(r.autoDisabled.has('a2'));
     assert.ok(!r.autoDisabled.has('a3'));
     assert.ok(!r.keep.has('a3'));
+  });
+});
+
+describe('findFullyDisabledCategories: recover v1 cap-bug victims', () => {
+  it('returns empty when no category is 100% disabled', () => {
+    const feeds = { a: F('a1', 'a2'), b: F('b1', 'b2') };
+    const disabled = new Set(['a1']); // partial — keep a2 and all of b
+    assert.deepEqual(findFullyDisabledCategories(feeds, disabled), []);
+  });
+
+  it('returns sources from a 100%-disabled category', () => {
+    const feeds = { a: F('a1', 'a2', 'a3'), b: F('b1') };
+    const disabled = new Set(['a1', 'a2', 'a3']); // category a is fully disabled
+    const r = findFullyDisabledCategories(feeds, disabled);
+    assert.deepEqual(r.sort(), ['a1', 'a2', 'a3']);
+  });
+
+  it('returns sources from MULTIPLE fully-disabled categories', () => {
+    const feeds = {
+      layoffs: F('Layoffs.fyi', 'TechCrunch Layoffs', 'Layoffs News'),
+      ipo: F('IPO News', 'Renaissance IPO', 'Tech IPO News'),
+      politics: F('Reuters', 'AP'), // healthy
+    };
+    const disabled = new Set([
+      'Layoffs.fyi', 'TechCrunch Layoffs', 'Layoffs News',
+      'IPO News', 'Renaissance IPO', 'Tech IPO News',
+    ]);
+    const r = findFullyDisabledCategories(feeds, disabled);
+    assert.equal(r.length, 6);
+    assert.ok(r.includes('Layoffs.fyi'));
+    assert.ok(r.includes('IPO News'));
+    assert.ok(!r.includes('Reuters'), 'healthy categories must not be touched');
+  });
+
+  it('preserves explicit single-source disabling (the heuristic\'s key safety property)', () => {
+    // User explicitly toggled OFF one source in a multi-source category.
+    // That's a real preference we must not undo.
+    const feeds = { politics: F('Reuters', 'AP', 'CNN') };
+    const disabled = new Set(['CNN']); // user toggled CNN off
+    const r = findFullyDisabledCategories(feeds, disabled);
+    assert.deepEqual(r, [], 'partial disable must NOT be flagged as bug victim');
+  });
+
+  it('handles empty / undefined / single-source categories without false positives', () => {
+    const feeds = {
+      empty: [],
+      undef: undefined,
+      single: F('only-one'),
+    };
+    // single category with its only source disabled IS a 100% disabled category
+    const disabled = new Set(['only-one']);
+    const r = findFullyDisabledCategories(feeds, disabled);
+    assert.deepEqual(r, ['only-one']);
+  });
+
+  it('returns empty when disabled set is empty', () => {
+    const feeds = { a: F('a1', 'a2'), b: F('b1') };
+    assert.deepEqual(findFullyDisabledCategories(feeds, new Set()), []);
   });
 });

--- a/tests/source-cap.test.mts
+++ b/tests/source-cap.test.mts
@@ -1,0 +1,141 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { selectSourcesUnderCap } from '../src/services/source-cap';
+
+const F = (...names: string[]) => names.map((name) => ({ name }));
+
+describe('selectSourcesUnderCap: round-robin per-category fairness', () => {
+  it('returns empty when cap is 0', () => {
+    const r = selectSourcesUnderCap({ a: F('a1', 'a2') }, [], new Set(), 0);
+    assert.equal(r.keep.size, 0);
+    assert.deepEqual([...r.autoDisabled].sort(), ['a1', 'a2']);
+  });
+
+  it('returns empty for negative cap (defensive)', () => {
+    const r = selectSourcesUnderCap({ a: F('a1') }, [], new Set(), -5);
+    assert.equal(r.keep.size, 0);
+    assert.equal(r.autoDisabled.size, 0);
+  });
+
+  it('keeps everything when total <= cap', () => {
+    const r = selectSourcesUnderCap(
+      { a: F('a1', 'a2'), b: F('b1') },
+      F('intel-1'),
+      new Set(),
+      10,
+    );
+    assert.equal(r.keep.size, 4);
+    assert.equal(r.autoDisabled.size, 0);
+    assert.ok(r.keep.has('a1') && r.keep.has('a2') && r.keep.has('b1') && r.keep.has('intel-1'));
+  });
+
+  it('REGRESSION: every category gets at least 1 source when cap is small but >= category count', () => {
+    // The pre-fix bug: alphabetical sort + slice(0, N) could leave entire
+    // categories with ZERO enabled sources. Round-robin must keep ≥1 from
+    // each category until budget exhausted.
+    const feeds = {
+      'aaa-cat': F('alpha-1', 'alpha-2', 'alpha-3'),
+      'bbb-cat': F('beta-1', 'beta-2'),
+      'zzz-cat': F('zeta-1', 'zeta-2'), // alphabetically last — was the bug victim
+    };
+    const r = selectSourcesUnderCap(feeds, [], new Set(), 3);
+    assert.equal(r.keep.size, 3);
+    // All three categories must have at least one source kept
+    assert.ok(r.keep.has('alpha-1'), 'aaa-cat must keep alpha-1');
+    assert.ok(r.keep.has('beta-1'), 'bbb-cat must keep beta-1');
+    assert.ok(r.keep.has('zeta-1'), 'zzz-cat must keep zeta-1 (was the bug victim)');
+  });
+
+  it('REGRESSION: late-alphabet categories are not starved at production-realistic scale', () => {
+    // Approximate the production shape: 30 categories, 3-4 feeds each, cap=80.
+    // Pre-fix: late-alphabet categories went empty. Post-fix: every category
+    // keeps at least its first feed.
+    const categories: { [k: string]: ReturnType<typeof F> } = {};
+    const letters = 'abcdefghijklmnopqrstuvwxyz1234'.split('');
+    for (const letter of letters) {
+      categories[`cat-${letter}`] = F(`${letter}-1`, `${letter}-2`, `${letter}-3`);
+    }
+    const r = selectSourcesUnderCap(categories, [], new Set(), 80);
+
+    for (const letter of letters) {
+      assert.ok(
+        r.keep.has(`${letter}-1`),
+        `category cat-${letter} must keep its first source ${letter}-1 (would have been auto-disabled by pre-fix alphabetical slice for late letters)`,
+      );
+    }
+  });
+
+  it('respects user-disabled sources — never adds them to keep', () => {
+    const feeds = { a: F('a1', 'a2'), b: F('b1', 'b2') };
+    const userDisabled = new Set(['a1', 'b2']);
+    const r = selectSourcesUnderCap(feeds, [], userDisabled, 10);
+    assert.ok(!r.keep.has('a1'), 'a1 was user-disabled — must not be re-enabled');
+    assert.ok(!r.keep.has('b2'), 'b2 was user-disabled — must not be re-enabled');
+    assert.ok(r.keep.has('a2') && r.keep.has('b1'));
+    // autoDisabled is the cap-rejected set — it should NOT include user-disabled
+    assert.ok(!r.autoDisabled.has('a1'));
+    assert.ok(!r.autoDisabled.has('b2'));
+  });
+
+  it('takes within-category sources in declaration order (editorial primary first)', () => {
+    // feeds.ts editorial team controls "primary source" by listing it first.
+    // Round-robin shifts from the front of each bucket — primary always wins.
+    const feeds = { a: F('primary', 'secondary', 'tertiary') };
+    const r = selectSourcesUnderCap(feeds, [], new Set(), 1);
+    assert.ok(r.keep.has('primary'));
+    assert.ok(!r.keep.has('secondary'));
+    assert.ok(!r.keep.has('tertiary'));
+  });
+
+  it('handles INTEL_SOURCES as its own bucket (does not dominate categories)', () => {
+    const feeds = { a: F('a1'), b: F('b1') };
+    const intel = F('intel-1', 'intel-2', 'intel-3');
+    const r = selectSourcesUnderCap(feeds, intel, new Set(), 3);
+    // Round-robin: a1, b1, intel-1
+    assert.ok(r.keep.has('a1'));
+    assert.ok(r.keep.has('b1'));
+    assert.ok(r.keep.has('intel-1'));
+    assert.equal(r.keep.size, 3);
+  });
+
+  it('is deterministic across repeated calls with same input', () => {
+    const feeds = {
+      a: F('a1', 'a2', 'a3'),
+      b: F('b1', 'b2'),
+      c: F('c1', 'c2', 'c3', 'c4'),
+    };
+    const r1 = selectSourcesUnderCap(feeds, [], new Set(), 5);
+    const r2 = selectSourcesUnderCap(feeds, [], new Set(), 5);
+    assert.deepEqual([...r1.keep].sort(), [...r2.keep].sort());
+    assert.deepEqual([...r1.autoDisabled].sort(), [...r2.autoDisabled].sort());
+  });
+
+  it('skips empty / undefined categories without crashing', () => {
+    const feeds = { a: F('a1'), b: undefined, c: [] };
+    const r = selectSourcesUnderCap(feeds, [], new Set(), 10);
+    assert.equal(r.keep.size, 1);
+    assert.ok(r.keep.has('a1'));
+  });
+
+  it('uses Object.entries iteration order (deterministic per category insertion)', () => {
+    // With only 1 slot and 3 categories, only the first category's first source
+    // makes it. This documents that category iteration follows insertion order.
+    const feeds = { gamma: F('g1'), alpha: F('a1'), beta: F('b1') };
+    const r = selectSourcesUnderCap(feeds, [], new Set(), 1);
+    assert.ok(r.keep.has('g1'), 'gamma was first-inserted — gets the slot');
+    assert.ok(!r.keep.has('a1'));
+    assert.ok(!r.keep.has('b1'));
+  });
+
+  it('autoDisabled excludes sources the user explicitly disabled', () => {
+    const feeds = { a: F('a1', 'a2', 'a3') };
+    const userDisabled = new Set(['a3']);
+    const r = selectSourcesUnderCap(feeds, [], userDisabled, 1);
+    assert.ok(r.keep.has('a1'));
+    // a2 didn't make the cap → autoDisabled. a3 is user-disabled → not in either.
+    assert.ok(r.autoDisabled.has('a2'));
+    assert.ok(!r.autoDisabled.has('a3'));
+    assert.ok(!r.keep.has('a3'));
+  });
+});


### PR DESCRIPTION
## Summary

Direct response to your **"if they were toggled off, they wouldn't fucking appear on the homepage"** correction. You were right — the panels (LAYOFFS TRACKER, SEMICONDUCTORS & HARDWARE, IPO & SPAC, FUNDING & VC, PRODUCT HUNT) appearing on the homepage with "All sources disabled" red borders was NOT a user preference issue. It was a free-tier enforcement bug.

## Root cause

`src/App.ts:1241-1258` enforced the 80-source free-tier cap by:

```ts
const allSourceNames = ...sort((a, b) => a.localeCompare(b));   // alphabetical
const currentlyEnabled = allSourceNames.filter(n => !disabledSources.has(n));
if (enabledCount > FREE_MAX_SOURCES) {
  for (const name of currentlyEnabled.slice(FREE_MAX_SOURCES)) {  // keep first N alphabetically
    disabledSources.add(name);
  }
}
```

With ~30 categories × 80 slots, **whole late-alphabet categories landed entirely outside the first 80** — Layoffs (`L`), Semiconductors (`S`), IPO (`I/R/T`), Funding (`S/V`), Product Hunt (`P`) all had 100% of their feeds auto-disabled. The panels still rendered (still `enabled: true` in `panels.ts`) but their bodies showed "All sources disabled" + count=0 — looking exactly like a user preference state, with zero explanation. No console warning, no UI notification, no migration path.

## Fix

Extract `selectSourcesUnderCap` into `src/services/source-cap.ts` as a pure round-robin distributor:

- Each category with at least one enabled-eligible source keeps at least one slot until the cap is exhausted
- Within a category, sources are taken in `feeds.ts` declaration order — editorial team controls "primary" by listing it first
- User-explicitly-disabled sources passed in as `userDisabled`, never re-enabled
- `INTEL_SOURCES` is its own bucket so it doesn't dominate categories

With 80 slots and ~30 categories, every category now keeps at least 2 sources. The starved categories from your screenshots will be populated again.

`App.ts` source-cap block is updated to call the new helper.

## Test plan

- [x] 12 new unit tests in `tests/source-cap.test.mts`:
  - Production-shape regression (30 categories × cap=80 — asserts every category keeps its primary source — would have failed under the pre-fix alphabetical slice)
  - Smaller-scale regression (3 categories × cap=3 — every category keeps ≥1)
  - User-disabled preservation
  - Within-category declaration order (editorial primary first)
  - INTEL_SOURCES as its own bucket
  - cap=0, negative cap, total ≤ cap edge cases
  - Determinism across repeated calls
  - Empty/undefined category handling
- [x] `npm run typecheck` + `typecheck:api` clean.
- [x] `npm run lint` clean.
- [x] `npm run test:data` 7772/7772 pass (12 new + 7760 existing).
- [x] All other gates clean (esbuild, edge tests, CJS, lint:md, version:check).
- [ ] After deploy, the affected categories should populate again on next free-tier user load. Existing users with the v1 buggy `disabledFeeds` localStorage state may still have it stuck — see migration note below.

## Migration note

Existing users who were already affected by the alphabetical slice still have those entries in `localStorage.disabledFeeds`. The storage didn't distinguish "user explicitly disabled" from "auto-disabled by free-tier cap", so a clean automatic migration would either:

- (a) Risk re-enabling sources users genuinely disabled
- (b) Leave bug victims stuck unless they manually reset

This PR ships only the going-forward fix. New users + users who clear their settings get the correct behavior immediately. A v1→v2 storage migration is worth a separate PR if user reports indicate widespread stickiness — likely heuristic: "if every source in a default-enabled panel's category is in `disabledFeeds`, treat as bug victim and re-enable that category's primary source."

## Reconciling against the dashboard issues you flagged

| Issue | PR |
|---|---|
| ESCALATION / ECONOMIC / DISASTER 0 cards | Observability shipped #3519 |
| AI INSIGHTS UNAVAILABLE flicker | #3518 (15→60 min freshness) |
| AI MARKET IMPLICATIONS Loading… (OpenRouter 402) | Diagnosed; you're handling ops |
| marketImplications ON_DEMAND mistag (homepage panel masking 16h outage) | #3518 |
| ON_DEMAND policy header for prevention | #3518 |
| TRADE POLICY "WTO unavailable" | #3516 (WTO timeout-batch isolation) + #3515 (SDMX shared util) + #3513 (merged) |
| **"All sources disabled" red panels** | **THIS PR (#NEW)** |
| RSS panel "UNAVAILABLE" badge ambiguity (CLOUD & INFRA / FIN REG / ENERGY) | Awaiting your UX call |