### PR TITLE
fix(vpd-tracker): rewrite scraper for new eval("var res = [...]") bundle shape

### DIFF
--- a/scripts/seed-vpd-tracker.mjs
+++ b/scripts/seed-vpd-tracker.mjs
@@ -49,29 +49,91 @@ const CACHE_TTL = 259200; // 72h (3 days) — 3× daily cron interval per gold s
  */
 /**
  * Walk the JS-escaped form of one `eval("var res = [...]")` array starting
- * at `arrayOpen` (the `[` byte). Returns the index of the matching closing
- * `]`, or -1 on truncation. Treats `\"...\"` JSON-string segments as opaque
- * so brackets inside data values don't shift depth. Handles `\"`, `\\`,
- * `\n/\t/\b/\f/\r/\/`, and `\uXXXX` escapes.
+ * at `arrayOpen` (the `[` byte) and find the matching closing `]`. Returns
+ * the index of that `]` in the bundle, or -1 on truncation.
+ *
+ * The scanner operates at TWO levels of escaping simultaneously:
+ *
+ *   Level 1 (bundle text → eval'd source):
+ *     The bundle wraps the eval'd JSON in a JS string literal. Each `\X`
+ *     in the bundle (where X is `"`, `\`, `n`, `t`, `r`, `b`, `f`, `/`,
+ *     `'`, or `uXXXX`) decodes to ONE character in the eval'd source.
+ *
+ *   Level 2 (eval'd source → JSON):
+ *     The eval'd source is JSON. Inside a JSON string, an eval'd `\"` is
+ *     the JSON escape for a literal `"` and must NOT toggle the string
+ *     boundary. Outside a JSON string, an eval'd `[`/`]` shifts depth.
+ *
+ * Earlier versions conflated the two levels: a bundle sequence like
+ * `\\\"` (representing eval'd `\"` — JSON-escaped quote inside a string
+ * value) was incorrectly read as `\\` + `\"`, where the trailing `\"`
+ * toggled inJsonString mid-value. Free-text fields like `summary` can
+ * contain `"quoted phrases"` with brackets, e.g. `Officials confirm
+ * "[regional] outbreak" contained` — that would produce `\\\"...]\\\"...`
+ * sequences that misaligned bracket counting.
+ *
+ * The corrected algorithm: decode each bundle byte to its eval'd
+ * character first, then run a JSON-aware state machine over the
+ * decoded stream.
  */
 function findArrayCloseInEscapedForm(bundle, arrayOpen) {
+  // Map of single-char JS-string escape sequences. `\u` is handled
+  // separately because it consumes 4 additional hex digits.
+  const SINGLE_ESCAPE = { '"': '"', '\\': '\\', '/': '/', 'n': '\n', 't': '\t', 'r': '\r', 'b': '\b', 'f': '\f', "'": "'" };
+
   let depth = 0;
   let inJsonString = false;
-  for (let i = arrayOpen; i < bundle.length; i++) {
-    const ch = bundle[i];
-    if (ch === '\\') {
+  let inJsonEscape = false; // inside JSON string AND just saw a `\` in eval'd source
+  let i = arrayOpen;
+
+  while (i < bundle.length) {
+    // ---- Level 1: decode one eval'd char from bundle ----
+    let evaledCh;
+    let advance;
+    if (bundle[i] === '\\') {
       const next = bundle[i + 1];
-      if (next === '"') { inJsonString = !inJsonString; i++; continue; }
-      if (next === 'u') { i += 5; continue; }
-      i++;
-      continue;
+      if (next === undefined) return -1; // truncated trailing backslash
+      if (next === 'u') {
+        const hex = bundle.slice(i + 2, i + 6);
+        if (hex.length < 4) return -1;
+        evaledCh = String.fromCharCode(parseInt(hex, 16));
+        advance = 6;
+      } else {
+        evaledCh = SINGLE_ESCAPE[next] ?? next;
+        advance = 2;
+      }
+    } else {
+      evaledCh = bundle[i];
+      advance = 1;
     }
-    if (inJsonString) continue;
-    if (ch === '[') depth++;
-    else if (ch === ']') {
-      depth--;
-      if (depth === 0) return i;
+
+    // ---- Level 2: JSON state machine over eval'd char ----
+    if (inJsonString) {
+      if (inJsonEscape) {
+        // Previous eval'd char was `\` (JSON escape). This char is the
+        // escape target; consume without changing string/bracket state.
+        // (JSON's \uXXXX has 4 hex digits — those are not brackets and
+        // not quotes, so we don't need to special-case them here for
+        // correctness; depth/inJsonString are correctly preserved.)
+        inJsonEscape = false;
+      } else if (evaledCh === '\\') {
+        inJsonEscape = true;
+      } else if (evaledCh === '"') {
+        inJsonString = false;
+      }
+      // else: ordinary char inside JSON string — skip
+    } else {
+      if (evaledCh === '"') {
+        inJsonString = true;
+      } else if (evaledCh === '[') {
+        depth++;
+      } else if (evaledCh === ']') {
+        depth--;
+        if (depth === 0) return i + advance - 1; // last byte of the closing `]`
+      }
     }
+
+    i += advance;
   }
   return -1;
 }

--- a/scripts/seed-vpd-tracker.mjs
+++ b/scripts/seed-vpd-tracker.mjs
@@ -47,43 +47,22 @@ const CACHE_TTL = 259200; // 72h (3 days) — 3× daily cron interval per gold s
  * @param {string} marker  first field name of the target dataset (e.g. 'Alert_ID', 'country')
  * @returns {Array<object>} parsed JSON array
  */
-function extractEvalResArray(bundle, marker) {
-  const evalNeedle = `eval("var res = [{\\"${marker}\\"`;
-  const start = bundle.indexOf(evalNeedle);
-  if (start === -1) {
-    throw new Error(`[VPD] eval-block anchor for marker '${marker}' not found in bundle (upstream format drift?)`);
-  }
-
-  // The opening `[` of the array sits right after `eval("var res = `.
-  // The eval block itself wraps the ENTIRE compiled module (millions of
-  // bytes — d3 helpers, DOM code, etc.) so we cannot anchor on its closing
-  // `]")`. Instead bracket-match within the JS-escaped form to find the
-  // closing `]` of the array specifically. Treat `\"...\"` JSON-string
-  // segments as opaque so brackets inside data values don't shift depth.
-  const arrayOpen = start + 'eval("var res = '.length;
-  if (bundle[arrayOpen] !== '[') {
-    throw new Error(`[VPD] expected '[' at start of '${marker}' array, got '${bundle[arrayOpen]}'`);
-  }
-
+/**
+ * Walk the JS-escaped form of one `eval("var res = [...]")` array starting
+ * at `arrayOpen` (the `[` byte). Returns the index of the matching closing
+ * `]`, or -1 on truncation. Treats `\"...\"` JSON-string segments as opaque
+ * so brackets inside data values don't shift depth. Handles `\"`, `\\`,
+ * `\n/\t/\b/\f/\r/\/`, and `\uXXXX` escapes.
+ */
+function findArrayCloseInEscapedForm(bundle, arrayOpen) {
   let depth = 0;
   let inJsonString = false;
-  let arrayClose = -1;
   for (let i = arrayOpen; i < bundle.length; i++) {
     const ch = bundle[i];
     if (ch === '\\') {
-      // JS-string-literal escape sequence. Inspect next char.
       const next = bundle[i + 1];
-      if (next === '"') {
-        // \"  ── toggles JSON-string boundary in the eval'd source
-        inJsonString = !inJsonString;
-        i++; // skip the "
-        continue;
-      }
-      if (next === 'u') {
-        i += 5; // \uXXXX → skip the 5 hex/digit chars after \
-        continue;
-      }
-      // \\, \n, \t, \/, \b, \f, \r — skip the next char wholesale
+      if (next === '"') { inJsonString = !inJsonString; i++; continue; }
+      if (next === 'u') { i += 5; continue; }
       i++;
       continue;
     }
@@ -91,24 +70,84 @@ function extractEvalResArray(bundle, marker) {
     if (ch === '[') depth++;
     else if (ch === ']') {
       depth--;
-      if (depth === 0) { arrayClose = i; break; }
+      if (depth === 0) return i;
     }
   }
+  return -1;
+}
 
-  if (arrayClose === -1) {
-    throw new Error(`[VPD] array did not close for '${marker}' (bracket-match exhausted bundle)`);
+/**
+ * Enumerate every `eval("var res = [...JSON-array...]")` block in the bundle.
+ * Yields `{ array }` for each one that parses cleanly; silently skips
+ * truncated or malformed candidates.
+ *
+ * Used by parseRealtimeAlerts / parseHistoricalData to identify their
+ * target dataset by SCHEMA (field-presence in any record), not by the
+ * first-key position in the first record. A harmless upstream reordering
+ * like `{"country":"X","iso":"Y"}` → `{"iso":"Y","country":"X"}` would
+ * have broken a position-anchored parser; this approach treats either
+ * order as the same dataset.
+ */
+function* iterateEvalResArrays(bundle) {
+  let pos = 0;
+  const blockNeedle = 'eval("var res = [';
+  while (true) {
+    const start = bundle.indexOf(blockNeedle, pos);
+    if (start === -1) return;
+    const arrayOpen = start + 'eval("var res = '.length; // points at `[`
+    const arrayClose = findArrayCloseInEscapedForm(bundle, arrayOpen);
+    if (arrayClose === -1) return; // truncated; nothing further is parseable
+    const escaped = bundle.slice(arrayOpen, arrayClose + 1);
+    try {
+      const arrayJson = JSON.parse(`"${escaped}"`);
+      const array = JSON.parse(arrayJson);
+      if (Array.isArray(array)) yield { array };
+    } catch {
+      // Malformed candidate (rare — would mean we mis-counted brackets).
+      // Skip and keep searching for the next eval block.
+    }
+    pos = arrayClose + 1;
   }
+}
 
-  // bundle[arrayOpen..arrayClose] is the JS-escaped JSON array literal.
-  // JSON.parse('"' + escaped + '"') unescapes the JS-string-literal
-  // wrapping; JSON.parse on the result yields the data.
-  const escapedArray = bundle.slice(arrayOpen, arrayClose + 1);
-  const arrayJson = JSON.parse(`"${escapedArray}"`);
-  return JSON.parse(arrayJson);
+/**
+ * Find the first eval-block array whose records contain ALL of the named
+ * fields. Schema-based identification — independent of key order within
+ * objects, eval-block order in the bundle, and minor bundler shuffles.
+ *
+ * We sample multiple records (not just the first) because some upstream
+ * systems emit sparse records where a field may be omitted on a single
+ * row but present on others; a single-record check would false-negative.
+ */
+function findArrayBySchema(bundle, requiredFields) {
+  const needed = new Set(requiredFields);
+  for (const { array } of iterateEvalResArrays(bundle)) {
+    if (array.length === 0) continue;
+    // Sample up to 5 records to tolerate sparse fields on any single row.
+    const sampleSize = Math.min(5, array.length);
+    const seen = new Set();
+    for (let i = 0; i < sampleSize; i++) {
+      const r = array[i];
+      if (!r || typeof r !== 'object') continue;
+      for (const k of Object.keys(r)) seen.add(k);
+    }
+    let allPresent = true;
+    for (const f of needed) {
+      if (!seen.has(f)) { allPresent = false; break; }
+    }
+    if (allPresent) return array;
+  }
+  return null;
 }
 
 export function parseRealtimeAlerts(bundle) {
-  const rows = extractEvalResArray(bundle, 'Alert_ID');
+  // Realtime alerts are identified by the (Alert_ID, lat, lng, diseases)
+  // schema. Any reordering of these fields within a record (or across
+  // records) is fine; only a real schema change (renamed field) breaks us.
+  const rows = findArrayBySchema(bundle, ['Alert_ID', 'lat', 'lng', 'diseases']);
+  if (!rows) {
+    throw new Error('[VPD] no eval block matches realtime schema (Alert_ID, lat, lng, diseases) — upstream format drift?');
+  }
   return rows
     .filter((r) => r.lat && r.lng)
     .map((r) => ({
@@ -126,7 +165,13 @@ export function parseRealtimeAlerts(bundle) {
 }
 
 export function parseHistoricalData(bundle) {
-  const rows = extractEvalResArray(bundle, 'country');
+  // Historical WHO counts identified by (country, iso, disease, year, cases).
+  // 'cases' alone would also match realtime alerts so we use the full
+  // schema fingerprint — the iso/disease/year combo is unique to historical.
+  const rows = findArrayBySchema(bundle, ['country', 'iso', 'disease', 'year', 'cases']);
+  if (!rows) {
+    throw new Error('[VPD] no eval block matches historical schema (country, iso, disease, year, cases) — upstream format drift?');
+  }
   return rows.map((r) => ({
     country: r.country,
     iso: r.iso,

--- a/scripts/seed-vpd-tracker.mjs
+++ b/scripts/seed-vpd-tracker.mjs
@@ -22,31 +22,96 @@ const BUNDLE_URL = 'https://thinkglobalhealth.github.io/disease_tracker/index_bu
 const CACHE_TTL = 259200; // 72h (3 days) — 3× daily cron interval per gold standard; survives 2 consecutive missed runs
 
 /**
- * Parse realtime outbreak alerts from the embedded object array.
+ * Extract a JSON array from an `eval("var res = [...]")` block in the bundle.
  *
- * Bundle format (webpack CommonJS):
- *   var a=[{Alert_ID:"8731706",lat:"56.85",lng:"24.92",diseases:"Measles",...},
- *          ...
- *          {Alert_ID:"8707570",...}];
- *   a.columns=["Alert_ID","lat","lng","diseases","place_name","country","date","cases","link","Type","summary"]
+ * Bundle format (post-2026-04 webpack rebuild — verified against the live
+ * 7.5MB index_bundle.js on 2026-05-01):
  *
- * The .columns metadata property marks the end of the array.
+ *   eval("var res = [{\"Alert_ID\":\"8731706\",\"lat\":\"56.85\",...}, ...]")
+ *   eval("var res = [{\"country\":\"Afghanistan\",\"iso\":\"AF\",...}, ...]")
+ *
+ * The bundle has exactly TWO such blocks: one whose first object key is
+ * `Alert_ID` (realtime alerts), one whose first key is `country` (historical
+ * WHO annual counts). The wrapping is a JS string literal — properties are
+ * JSON-quoted with backslash-escaped quotes.
+ *
+ * Pre-2026-04 the bundle used `var a=[{Alert_ID:"...",...}]` (unquoted keys,
+ * named array, separate `.columns` metadata) and the parser anchored on
+ * `.columns=["Alert_ID"`, `var a=[`, and `[{country:"`. All three anchors
+ * are dead in the current bundle. This rewrite anchors on the FIELD NAMES
+ * (`Alert_ID`, `country`) which are domain-stable — they only change if
+ * Think Global Health renames the data schema itself, not when their
+ * bundler is upgraded.
+ *
+ * @param {string} bundle  raw JS bundle text
+ * @param {string} marker  first field name of the target dataset (e.g. 'Alert_ID', 'country')
+ * @returns {Array<object>} parsed JSON array
  */
-function parseRealtimeAlerts(bundle) {
-  const colIdx = bundle.indexOf('.columns=["Alert_ID"');
-  if (colIdx === -1) throw new Error('[VPD] Realtime data columns marker not found in bundle');
+function extractEvalResArray(bundle, marker) {
+  const evalNeedle = `eval("var res = [{\\"${marker}\\"`;
+  const start = bundle.indexOf(evalNeedle);
+  if (start === -1) {
+    throw new Error(`[VPD] eval-block anchor for marker '${marker}' not found in bundle (upstream format drift?)`);
+  }
 
-  const arrayEnd = bundle.lastIndexOf('}]', colIdx);
-  const arrayStart = bundle.lastIndexOf('var a=[', arrayEnd);
-  if (arrayStart === -1) throw new Error('[VPD] Realtime data array start not found');
+  // The opening `[` of the array sits right after `eval("var res = `.
+  // The eval block itself wraps the ENTIRE compiled module (millions of
+  // bytes — d3 helpers, DOM code, etc.) so we cannot anchor on its closing
+  // `]")`. Instead bracket-match within the JS-escaped form to find the
+  // closing `]` of the array specifically. Treat `\"...\"` JSON-string
+  // segments as opaque so brackets inside data values don't shift depth.
+  const arrayOpen = start + 'eval("var res = '.length;
+  if (bundle[arrayOpen] !== '[') {
+    throw new Error(`[VPD] expected '[' at start of '${marker}' array, got '${bundle[arrayOpen]}'`);
+  }
 
-  const rawArray = bundle.slice(arrayStart + 6, arrayEnd + 2); // skip 'var a='
-  // eslint-disable-next-line no-new-func
-  const rows = Function('"use strict"; return ' + rawArray)();
+  let depth = 0;
+  let inJsonString = false;
+  let arrayClose = -1;
+  for (let i = arrayOpen; i < bundle.length; i++) {
+    const ch = bundle[i];
+    if (ch === '\\') {
+      // JS-string-literal escape sequence. Inspect next char.
+      const next = bundle[i + 1];
+      if (next === '"') {
+        // \"  ── toggles JSON-string boundary in the eval'd source
+        inJsonString = !inJsonString;
+        i++; // skip the "
+        continue;
+      }
+      if (next === 'u') {
+        i += 5; // \uXXXX → skip the 5 hex/digit chars after \
+        continue;
+      }
+      // \\, \n, \t, \/, \b, \f, \r — skip the next char wholesale
+      i++;
+      continue;
+    }
+    if (inJsonString) continue;
+    if (ch === '[') depth++;
+    else if (ch === ']') {
+      depth--;
+      if (depth === 0) { arrayClose = i; break; }
+    }
+  }
 
+  if (arrayClose === -1) {
+    throw new Error(`[VPD] array did not close for '${marker}' (bracket-match exhausted bundle)`);
+  }
+
+  // bundle[arrayOpen..arrayClose] is the JS-escaped JSON array literal.
+  // JSON.parse('"' + escaped + '"') unescapes the JS-string-literal
+  // wrapping; JSON.parse on the result yields the data.
+  const escapedArray = bundle.slice(arrayOpen, arrayClose + 1);
+  const arrayJson = JSON.parse(`"${escapedArray}"`);
+  return JSON.parse(arrayJson);
+}
+
+export function parseRealtimeAlerts(bundle) {
+  const rows = extractEvalResArray(bundle, 'Alert_ID');
   return rows
-    .filter(r => r.lat && r.lng)
-    .map(r => ({
+    .filter((r) => r.lat && r.lng)
+    .map((r) => ({
       alertId: r.Alert_ID,
       lat: parseFloat(r.lat),
       lng: parseFloat(r.lng),
@@ -60,26 +125,9 @@ function parseRealtimeAlerts(bundle) {
     }));
 }
 
-/**
- * Parse historical WHO annual case counts from the embedded JS object array.
- *
- * Bundle format (second dataset, follows immediately after realtime module):
- *   [{"country":"Afghanistan","iso":"AF","disease":"Diphtheria","year":"2024","cases":"207"}, ...]
- */
-function parseHistoricalData(bundle) {
-  const colIdx = bundle.indexOf('.columns=["Alert_ID"');
-  if (colIdx === -1) throw new Error('[VPD] Bundle anchor not found for historical data search');
-
-  const arrayStart = bundle.indexOf('[{country:"', colIdx);
-  if (arrayStart === -1) throw new Error('[VPD] Historical data array not found');
-  const arrayEnd = bundle.indexOf('];', arrayStart);
-  if (arrayEnd === -1) throw new Error('[VPD] Historical data end marker not found');
-
-  const rawArray = bundle.slice(arrayStart, arrayEnd + 1);
-  // eslint-disable-next-line no-new-func
-  const rows = Function('"use strict"; return ' + rawArray)();
-
-  return rows.map(r => ({
+export function parseHistoricalData(bundle) {
+  const rows = extractEvalResArray(bundle, 'country');
+  return rows.map((r) => ({
     country: r.country,
     iso: r.iso,
     disease: r.disease,
@@ -113,23 +161,29 @@ export function declareRecords(data) {
   return Array.isArray(data?.alerts) ? data.alerts.length : 0;
 }
 
-runSeed('health', 'vpd-tracker', CANONICAL_KEY, fetchVpdTracker, {
-  validateFn: validate,
-  ttlSeconds: CACHE_TTL,
-  sourceVersion: 'tgh-bundle-v1',
-  extraKeys: [
-    {
-      key: HISTORICAL_KEY,
-      ttl: CACHE_TTL,
-      transform: data => ({ records: data.historical, fetchedAt: data.fetchedAt }),
-    },
-  ],
+// Standalone-only entrypoint guard. Without this, importing the file from
+// tests (e.g. to test parseRealtimeAlerts / parseHistoricalData) kicks off
+// the full runSeed pipeline at module-load time — Redis lock acquisition,
+// external bundle fetch, Redis writes — which hangs the test runner.
+if (process.argv[1]?.endsWith('seed-vpd-tracker.mjs')) {
+  runSeed('health', 'vpd-tracker', CANONICAL_KEY, fetchVpdTracker, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: 'tgh-bundle-v2',
+    extraKeys: [
+      {
+        key: HISTORICAL_KEY,
+        ttl: CACHE_TTL,
+        transform: data => ({ records: data.historical, fetchedAt: data.fetchedAt }),
+      },
+    ],
 
-  declareRecords,
-  schemaVersion: 1,
-  maxStaleMin: 2880,
-}).catch((err) => {
-  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
-  console.error('FATAL:', (err.message || err) + _cause);
-  process.exit(1);
-});
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 2880,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
+    console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/tests/vpd-tracker-parser.test.mjs
+++ b/tests/vpd-tracker-parser.test.mjs
@@ -6,33 +6,36 @@ import { parseRealtimeAlerts, parseHistoricalData } from '../scripts/seed-vpd-tr
 // Fixture mirroring the post-2026-04 bundle shape verified against the live
 // 7.5MB index_bundle.js on 2026-05-01: two `eval("var res = [...]")` blocks
 // with JSON-quoted properties inside JS-escaped string literals.
-function buildNewBundleFixture() {
-  const realtime = [
+function buildBundleFixture({ realtime, historical, blockOrder = ['historical', 'realtime'] } = {}) {
+  realtime ??= [
     { Alert_ID: '8731706', lat: '56.85', lng: '24.92', diseases: 'Measles', place_name: 'Riga', country: 'Latvia', date: '2026-04-15', cases: '12', link: 'https://example.com/a', Type: 'outbreak', summary: 'Cluster' },
     { Alert_ID: '8731707', lat: '40.4', lng: '-3.7', diseases: 'Pertussis', place_name: 'Madrid', country: 'Spain', date: '2026-04-12', cases: '1,234', link: 'https://example.com/b', Type: 'outbreak', summary: 'Surge' },
     { Alert_ID: '8731708', lat: '', lng: '', diseases: 'Diphtheria', place_name: 'Unknown', country: 'Nowhere', date: '2026-04-10', cases: '', link: '', Type: 'note', summary: 'Drop me' },
   ];
-  const historical = [
+  historical ??= [
     { country: 'Afghanistan', iso: 'AF', disease: 'Diphtheria', year: '2024', cases: '207' },
     { country: 'Albania', iso: 'AL', disease: 'Diphtheria', year: '2024', cases: '0' },
     { country: 'Australia', iso: 'AU', disease: 'Measles', year: '2024', cases: '9' },
   ];
-  // Build the bundle text the same way the upstream bundler does:
-  // `eval("<JS-string-literal-of-source>")` where the inner source is
-  // `var res = <JSON.stringify(array)>`.
   const realtimeInner = `var res = ${JSON.stringify(realtime)}`;
   const historicalInner = `var res = ${JSON.stringify(historical)}`;
-  // JS-escape the inner source for embedding in a string literal
-  const realtimeEscaped = JSON.stringify(realtimeInner).slice(1, -1); // strip outer quotes
+  const realtimeEscaped = JSON.stringify(realtimeInner).slice(1, -1);
   const historicalEscaped = JSON.stringify(historicalInner).slice(1, -1);
+  const blocks = {
+    realtime: `eval("${realtimeEscaped}")`,
+    historical: `eval("${historicalEscaped}")`,
+  };
   return [
     '/* unrelated leading bundler boilerplate */',
-    `eval("${historicalEscaped}")`, // historical comes first in the live bundle (offset 5720 vs 2712352)
+    blocks[blockOrder[0]],
     '/* lots of intermediate webpack chunks */',
-    `eval("${realtimeEscaped}")`,
+    blocks[blockOrder[1]],
     '/* trailing webpack runtime */',
   ].join('\n');
 }
+
+// Backwards-compat name so the existing test sites still call it
+const buildNewBundleFixture = () => buildBundleFixture();
 
 describe('seed-vpd-tracker: parseRealtimeAlerts (post-2026-04 bundle format)', () => {
   it('extracts alerts from the new eval("var res = [...]") shape', () => {
@@ -55,19 +58,23 @@ describe('seed-vpd-tracker: parseRealtimeAlerts (post-2026-04 bundle format)', (
     assert.equal(madrid.cases, 1234, 'comma-separated "1,234" must parse to 1234');
   });
 
-  it('throws a clear error when the realtime marker is missing (upstream format drift)', () => {
-    const bundle = '/* bundle with no Alert_ID anchor */';
+  it('throws a clear error when no eval block matches realtime schema (upstream format drift)', () => {
+    const bundle = '/* bundle with no eval var-res blocks */';
     assert.throws(
       () => parseRealtimeAlerts(bundle),
-      /eval-block anchor for marker 'Alert_ID' not found/,
+      /no eval block matches realtime schema \(Alert_ID, lat, lng, diseases\)/,
     );
   });
 
-  it('throws a clear error when the array is unterminated (truncated bundle)', () => {
-    const truncated = 'eval("var res = [{\\"Alert_ID\\":\\"8731706\\"';
+  it('throws clear error when realtime schema fields cannot be found in any block', () => {
+    // Bundle has an eval block but its records don't match the schema.
+    const phantom = [{ key: 'foo' }, { key: 'bar' }];
+    const inner = `var res = ${JSON.stringify(phantom)}`;
+    const escaped = JSON.stringify(inner).slice(1, -1);
+    const bundle = `eval("${escaped}")`;
     assert.throws(
-      () => parseRealtimeAlerts(truncated),
-      /array did not close for 'Alert_ID'/,
+      () => parseRealtimeAlerts(bundle),
+      /no eval block matches realtime schema/,
     );
   });
 });
@@ -95,13 +102,82 @@ describe('seed-vpd-tracker: parseHistoricalData (post-2026-04 bundle format)', (
     assert.equal(aus.cases, 9);
   });
 
-  it('throws a clear error when the historical marker is missing', () => {
-    // Bundle has the Alert_ID block but no country block.
-    const bundle = `eval("var res = ${JSON.stringify(`var res = ${JSON.stringify([{ Alert_ID: '1', lat: '0', lng: '0', diseases: '', place_name: '', country: '', date: '', cases: '', link: '', Type: '', summary: '' }])}`).slice(1, -1)}")`;
+  it('throws a clear error when no eval block matches historical schema', () => {
+    // Bundle has an Alert_ID block, but no historical-shaped block.
+    const realtime = [{ Alert_ID: '1', lat: '0', lng: '0', diseases: 'Measles', place_name: '', country: '', date: '', cases: '', link: '', Type: '', summary: '' }];
+    const inner = `var res = ${JSON.stringify(realtime)}`;
+    const escaped = JSON.stringify(inner).slice(1, -1);
+    const bundle = `eval("${escaped}")`;
     assert.throws(
       () => parseHistoricalData(bundle),
-      /eval-block anchor for marker 'country' not found/,
+      /no eval block matches historical schema/,
     );
+  });
+});
+
+describe('seed-vpd-tracker: REGRESSION — schema-based identification (key reordering, block reordering)', () => {
+  // Reorder field keys WITHIN every record. A position-anchored parser
+  // would fail because Alert_ID is no longer the first key; the
+  // schema-based finder must succeed because the field set is unchanged.
+  it('parses realtime alerts when Alert_ID is NOT the first key in records', () => {
+    const reorderedRealtime = [
+      { lat: '56.85', lng: '24.92', diseases: 'Measles', Alert_ID: '8731706', place_name: 'Riga', country: 'Latvia', date: '2026-04-15', cases: '12', link: 'https://example.com/a', Type: 'outbreak', summary: 'Cluster' },
+      { country: 'Spain', diseases: 'Pertussis', lat: '40.4', lng: '-3.7', Alert_ID: '8731707', place_name: 'Madrid', date: '2026-04-12', cases: '50', link: 'https://example.com/b', Type: 'outbreak', summary: 'Surge' },
+    ];
+    const bundle = buildBundleFixture({ realtime: reorderedRealtime });
+    const alerts = parseRealtimeAlerts(bundle);
+    assert.equal(alerts.length, 2);
+    assert.equal(alerts[0].alertId, '8731706');
+    assert.equal(alerts[1].country, 'Spain');
+  });
+
+  it('parses historical when country is NOT the first key in records', () => {
+    const reorderedHistorical = [
+      { iso: 'AF', country: 'Afghanistan', disease: 'Diphtheria', year: '2024', cases: '207' },
+      { year: '2024', cases: '9', iso: 'AU', country: 'Australia', disease: 'Measles' },
+    ];
+    const bundle = buildBundleFixture({ historical: reorderedHistorical });
+    const records = parseHistoricalData(bundle);
+    assert.equal(records.length, 2);
+    assert.equal(records[0].country, 'Afghanistan');
+    assert.equal(records[1].country, 'Australia');
+  });
+
+  it('parses regardless of which eval block appears first in the bundle', () => {
+    // Live bundle has historical-first; this test forces realtime-first.
+    const bundle = buildBundleFixture({ blockOrder: ['realtime', 'historical'] });
+    const alerts = parseRealtimeAlerts(bundle);
+    const historical = parseHistoricalData(bundle);
+    assert.equal(alerts.length, 2);
+    assert.equal(historical.length, 3);
+  });
+
+  it('discriminates between realtime and historical even when both blocks coexist', () => {
+    // Both parsers run on the same bundle; each must find the right block,
+    // not return the other's data. Schema fingerprint guarantees this:
+    // realtime requires (Alert_ID, lat, lng, diseases); historical
+    // requires (country, iso, disease, year, cases).
+    const bundle = buildBundleFixture();
+    const alerts = parseRealtimeAlerts(bundle);
+    const historical = parseHistoricalData(bundle);
+    assert.ok(alerts[0].alertId, 'realtime parsed Alert_ID');
+    assert.ok(historical[0].iso, 'historical parsed iso');
+    // Cross-contamination check: a historical record has no `alertId`
+    assert.ok(historical[0].alertId === undefined);
+  });
+
+  it('skips a phantom eval("var res = [...]") block that does NOT match either schema', () => {
+    // Some bundlers emit OTHER eval blocks (e.g. for color palettes or
+    // layout config). The finder must walk past them.
+    const phantom = [{ key: 'foo', value: 'bar' }, { key: 'baz', value: 'qux' }];
+    const phantomInner = `var res = ${JSON.stringify(phantom)}`;
+    const phantomEscaped = JSON.stringify(phantomInner).slice(1, -1);
+    const base = buildBundleFixture();
+    const bundleWithPhantom = `eval("${phantomEscaped}")\n${base}`;
+    const alerts = parseRealtimeAlerts(bundleWithPhantom);
+    const historical = parseHistoricalData(bundleWithPhantom);
+    assert.equal(alerts.length, 2);
+    assert.equal(historical.length, 3);
   });
 });
 
@@ -118,11 +194,11 @@ describe('seed-vpd-tracker: REGRESSION — pre-2026-04 bundle shape now throws c
     ].join('\n');
     assert.throws(
       () => parseRealtimeAlerts(oldShape),
-      /eval-block anchor for marker 'Alert_ID' not found/,
+      /no eval block matches realtime schema/,
     );
     assert.throws(
       () => parseHistoricalData(oldShape),
-      /eval-block anchor for marker 'country' not found/,
+      /no eval block matches historical schema/,
     );
   });
 });

--- a/tests/vpd-tracker-parser.test.mjs
+++ b/tests/vpd-tracker-parser.test.mjs
@@ -181,6 +181,98 @@ describe('seed-vpd-tracker: REGRESSION — schema-based identification (key reor
   });
 });
 
+describe('seed-vpd-tracker: REGRESSION — JSON-escaped quotes inside string values', () => {
+  // P1 review finding: when a JSON value contains a literal `"`, it's
+  // JSON-encoded as `\"`. Wrapped in a JS string literal that becomes
+  // `\\\"` (4 bundle bytes). Earlier scanner versions interpreted the
+  // sequence as `\\` (backslash escape) + `\"` (string-boundary toggle),
+  // incorrectly toggling inJsonString mid-value. If brackets appear inside
+  // the embedded-quoted span, depth counting goes wrong and arrayClose
+  // lands at the wrong position.
+  //
+  // The live bundle has 22 alerts whose `summary` field contains embedded
+  // quotes (e.g. `"alternative wellness" seminar`), so this is not
+  // theoretical — it was a latent production bug that worked by accident
+  // (compensating bugs cancelled when the quoted span contained no
+  // brackets).
+
+  it('parses an alert whose summary contains embedded quotes', () => {
+    const realtime = [
+      {
+        Alert_ID: '1', lat: '56.85', lng: '24.92', diseases: 'Measles',
+        place_name: 'Riga', country: 'Latvia', date: '2026-04-15',
+        cases: '12', link: 'https://example.com/a', Type: 'outbreak',
+        summary: 'Officials confirm "alternative wellness" seminar exposure',
+      },
+    ];
+    const bundle = buildBundleFixture({ realtime });
+    const alerts = parseRealtimeAlerts(bundle);
+    assert.equal(alerts.length, 1);
+    assert.equal(alerts[0].summary, 'Officials confirm "alternative wellness" seminar exposure');
+  });
+
+  it('parses correctly when an embedded-quote span ALSO contains brackets', () => {
+    // Most adversarial case: a value contains `"[regional] outbreak"`.
+    // Pre-fix scanner would have flipped inJsonString and then counted
+    // the `[` and `]` as bracket-depth changes, mis-locating arrayClose.
+    const realtime = [
+      {
+        Alert_ID: '1', lat: '56.85', lng: '24.92', diseases: 'Measles',
+        place_name: 'Riga', country: 'Latvia', date: '2026-04-15',
+        cases: '12', link: 'https://example.com/a', Type: 'outbreak',
+        summary: 'Officials confirm "[regional] outbreak" contained',
+      },
+      {
+        Alert_ID: '2', lat: '40.4', lng: '-3.7', diseases: 'Pertussis',
+        place_name: 'Madrid', country: 'Spain', date: '2026-04-12',
+        cases: '50', link: 'https://example.com/b', Type: 'outbreak',
+        summary: 'Followup record',
+      },
+    ];
+    const bundle = buildBundleFixture({ realtime });
+    const alerts = parseRealtimeAlerts(bundle);
+    assert.equal(alerts.length, 2, 'second record must be parsed (would be lost if depth counting misaligned)');
+    assert.equal(alerts[0].summary, 'Officials confirm "[regional] outbreak" contained');
+    assert.equal(alerts[1].alertId, '2');
+  });
+
+  it('parses correctly when a value contains backslash-bracket-bracket sequences', () => {
+    // Defensive: a value with literal backslashes adjacent to brackets.
+    // JSON encodes the backslash as `\\` and the value gets JS-string-
+    // wrapped, so subtle escape-sequence-misalignment edges show up here.
+    const realtime = [
+      {
+        Alert_ID: '1', lat: '1', lng: '1', diseases: 'Measles',
+        place_name: '', country: '', date: '',
+        cases: '0', link: '', Type: '',
+        summary: 'Path: C:\\\\foo\\\\bar [warn]',
+      },
+      {
+        Alert_ID: '2', lat: '2', lng: '2', diseases: 'Pertussis',
+        place_name: '', country: '', date: '',
+        cases: '0', link: '', Type: '',
+        summary: 'Second record',
+      },
+    ];
+    const bundle = buildBundleFixture({ realtime });
+    const alerts = parseRealtimeAlerts(bundle);
+    assert.equal(alerts.length, 2);
+    assert.ok(alerts[1].alertId === '2');
+  });
+
+  it('parses historical when a value contains embedded quotes', () => {
+    const historical = [
+      { country: 'United States of "America"', iso: 'US', disease: 'Measles', year: '2024', cases: '10' },
+      { country: 'Canada', iso: 'CA', disease: 'Measles', year: '2024', cases: '5' },
+    ];
+    const bundle = buildBundleFixture({ historical });
+    const records = parseHistoricalData(bundle);
+    assert.equal(records.length, 2);
+    assert.equal(records[0].country, 'United States of "America"');
+    assert.equal(records[1].cases, 5);
+  });
+});
+
 describe('seed-vpd-tracker: REGRESSION — pre-2026-04 bundle shape now throws clearly', () => {
   // The OLD format: `var a=[{Alert_ID:"...",...}]; a.columns=["Alert_ID",...]`
   // and `[{country:"Afghanistan",...}]`. The pre-fix parser anchored on these.

--- a/tests/vpd-tracker-parser.test.mjs
+++ b/tests/vpd-tracker-parser.test.mjs
@@ -1,0 +1,128 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseRealtimeAlerts, parseHistoricalData } from '../scripts/seed-vpd-tracker.mjs';
+
+// Fixture mirroring the post-2026-04 bundle shape verified against the live
+// 7.5MB index_bundle.js on 2026-05-01: two `eval("var res = [...]")` blocks
+// with JSON-quoted properties inside JS-escaped string literals.
+function buildNewBundleFixture() {
+  const realtime = [
+    { Alert_ID: '8731706', lat: '56.85', lng: '24.92', diseases: 'Measles', place_name: 'Riga', country: 'Latvia', date: '2026-04-15', cases: '12', link: 'https://example.com/a', Type: 'outbreak', summary: 'Cluster' },
+    { Alert_ID: '8731707', lat: '40.4', lng: '-3.7', diseases: 'Pertussis', place_name: 'Madrid', country: 'Spain', date: '2026-04-12', cases: '1,234', link: 'https://example.com/b', Type: 'outbreak', summary: 'Surge' },
+    { Alert_ID: '8731708', lat: '', lng: '', diseases: 'Diphtheria', place_name: 'Unknown', country: 'Nowhere', date: '2026-04-10', cases: '', link: '', Type: 'note', summary: 'Drop me' },
+  ];
+  const historical = [
+    { country: 'Afghanistan', iso: 'AF', disease: 'Diphtheria', year: '2024', cases: '207' },
+    { country: 'Albania', iso: 'AL', disease: 'Diphtheria', year: '2024', cases: '0' },
+    { country: 'Australia', iso: 'AU', disease: 'Measles', year: '2024', cases: '9' },
+  ];
+  // Build the bundle text the same way the upstream bundler does:
+  // `eval("<JS-string-literal-of-source>")` where the inner source is
+  // `var res = <JSON.stringify(array)>`.
+  const realtimeInner = `var res = ${JSON.stringify(realtime)}`;
+  const historicalInner = `var res = ${JSON.stringify(historical)}`;
+  // JS-escape the inner source for embedding in a string literal
+  const realtimeEscaped = JSON.stringify(realtimeInner).slice(1, -1); // strip outer quotes
+  const historicalEscaped = JSON.stringify(historicalInner).slice(1, -1);
+  return [
+    '/* unrelated leading bundler boilerplate */',
+    `eval("${historicalEscaped}")`, // historical comes first in the live bundle (offset 5720 vs 2712352)
+    '/* lots of intermediate webpack chunks */',
+    `eval("${realtimeEscaped}")`,
+    '/* trailing webpack runtime */',
+  ].join('\n');
+}
+
+describe('seed-vpd-tracker: parseRealtimeAlerts (post-2026-04 bundle format)', () => {
+  it('extracts alerts from the new eval("var res = [...]") shape', () => {
+    const bundle = buildNewBundleFixture();
+    const alerts = parseRealtimeAlerts(bundle);
+    assert.equal(alerts.length, 2, 'must drop the alert with empty lat/lng');
+    assert.equal(alerts[0].alertId, '8731706');
+    assert.equal(alerts[0].lat, 56.85);
+    assert.equal(alerts[0].lng, 24.92);
+    assert.equal(alerts[0].disease, 'Measles');
+    assert.equal(alerts[0].country, 'Latvia');
+    assert.equal(alerts[0].cases, 12);
+  });
+
+  it('parses comma-separated case counts as integers', () => {
+    const bundle = buildNewBundleFixture();
+    const alerts = parseRealtimeAlerts(bundle);
+    const madrid = alerts.find((a) => a.country === 'Spain');
+    assert.ok(madrid);
+    assert.equal(madrid.cases, 1234, 'comma-separated "1,234" must parse to 1234');
+  });
+
+  it('throws a clear error when the realtime marker is missing (upstream format drift)', () => {
+    const bundle = '/* bundle with no Alert_ID anchor */';
+    assert.throws(
+      () => parseRealtimeAlerts(bundle),
+      /eval-block anchor for marker 'Alert_ID' not found/,
+    );
+  });
+
+  it('throws a clear error when the array is unterminated (truncated bundle)', () => {
+    const truncated = 'eval("var res = [{\\"Alert_ID\\":\\"8731706\\"';
+    assert.throws(
+      () => parseRealtimeAlerts(truncated),
+      /array did not close for 'Alert_ID'/,
+    );
+  });
+});
+
+describe('seed-vpd-tracker: parseHistoricalData (post-2026-04 bundle format)', () => {
+  it('extracts WHO annual counts from the new eval("var res = [...]") shape', () => {
+    const bundle = buildNewBundleFixture();
+    const records = parseHistoricalData(bundle);
+    assert.equal(records.length, 3);
+    assert.equal(records[0].country, 'Afghanistan');
+    assert.equal(records[0].iso, 'AF');
+    assert.equal(records[0].disease, 'Diphtheria');
+    assert.equal(records[0].year, 2024);
+    assert.equal(records[0].cases, 207);
+  });
+
+  it('parses string year/cases fields into numbers', () => {
+    const bundle = buildNewBundleFixture();
+    const records = parseHistoricalData(bundle);
+    const aus = records.find((r) => r.iso === 'AU');
+    assert.ok(aus);
+    assert.equal(typeof aus.year, 'number');
+    assert.equal(typeof aus.cases, 'number');
+    assert.equal(aus.year, 2024);
+    assert.equal(aus.cases, 9);
+  });
+
+  it('throws a clear error when the historical marker is missing', () => {
+    // Bundle has the Alert_ID block but no country block.
+    const bundle = `eval("var res = ${JSON.stringify(`var res = ${JSON.stringify([{ Alert_ID: '1', lat: '0', lng: '0', diseases: '', place_name: '', country: '', date: '', cases: '', link: '', Type: '', summary: '' }])}`).slice(1, -1)}")`;
+    assert.throws(
+      () => parseHistoricalData(bundle),
+      /eval-block anchor for marker 'country' not found/,
+    );
+  });
+});
+
+describe('seed-vpd-tracker: REGRESSION — pre-2026-04 bundle shape now throws clearly', () => {
+  // The OLD format: `var a=[{Alert_ID:"...",...}]; a.columns=["Alert_ID",...]`
+  // and `[{country:"Afghanistan",...}]`. The pre-fix parser anchored on these.
+  // Post-fix, the same input throws a clear "anchor not found" message instead
+  // of attempting to parse and producing a confusing downstream error.
+  it('rejects the pre-2026-04 var-a format with a clear message', () => {
+    const oldShape = [
+      'var a=[{Alert_ID:"8731706",lat:"56.85",lng:"24.92",diseases:"Measles"}];',
+      'a.columns=["Alert_ID","lat","lng","diseases"];',
+      '[{country:"Afghanistan",iso:"AF",disease:"Diphtheria",year:"2024",cases:"207"}]',
+    ].join('\n');
+    assert.throws(
+      () => parseRealtimeAlerts(oldShape),
+      /eval-block anchor for marker 'Alert_ID' not found/,
+    );
+    assert.throws(
+      () => parseHistoricalData(oldShape),
+      /eval-block anchor for marker 'country' not found/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Production incident:

```
vpdTrackerRealtime    STALE_SEED  records=1920  seedAgeMin=2886  maxStaleMin=2880
vpdTrackerHistorical  STALE_SEED  records=1920  seedAgeMin=2886  maxStaleMin=2880
```

Same `seedAgeMin=2886` on both confirms one seeder run powers both keys, and two consecutive daily cron runs failed before maxStaleMin (48h) caught the staleness.

## Root cause: upstream webpack bundle rebuild

`thinkglobalhealth.github.io` rebuilt `/disease_tracker/index_bundle.js`. All four anchors the parser depended on are dead in the live 7.5MB bundle (probed directly, all return `0` matches via `grep -c`):

| Old anchor | Status in current bundle |
|---|---|
| `.columns=["Alert_ID"` | gone |
| `var a=[` | gone (now `var res =`) |
| `[{country:"` (unquoted keys) | gone (now JSON-quoted) |
| `}];` array close | gone (no `.columns` metadata anymore) |

The new bundle wraps both datasets in `eval("var res = [...JSON...]")` blocks with JSON-quoted property names inside JS-string-literal escaping. The eval block also wraps the **entire compiled module** (~1MB+ of d3 helpers, DOM code, etc.) so we can't anchor on its closing `]")`.

## Fix

1. **Anchor on field names instead of bundler internals.** `'Alert_ID'` and `'country'` are domain-stable — they only change if Think Global Health renames the data schema itself. Pre-fix anchors all depended on bundler-internal artifacts (variable name `a`, key-quoting style, `.columns` metadata) which any webpack/rollup/vite reconfiguration can break silently.

2. **Bracket-match in the JS-escaped form** to find the array's close `]` rather than the eval block's close `]")`. Walks `[/]` depth while treating `\"...\"` JSON-string segments as opaque so brackets inside data values don't shift depth. Handles `\"`, `\\`, `\n/\t/\b/\f/\r/\/`, and `\uXXXX` escape sequences.

3. **Unescape via `JSON.parse('"' + escaped + '"')`** then `JSON.parse` the resulting clean JSON. The double-decode mirrors the bundle's two encoding layers (JS string literal → JSON).

4. **Entrypoint guard**: `runSeed(...)` was unconditional. Importing the module from tests would trigger the full seeder pipeline (Redis lock, external bundle fetch, Redis writes) at module-load time. Now gated on `process.argv[1]?.endsWith('seed-vpd-tracker.mjs')` like every other seeder.

5. **Bumped `sourceVersion`** `'tgh-bundle-v1' → 'tgh-bundle-v2'` to mark the parser-format break.

## End-to-end verification against the real bundle

```
alerts: 1949 records       (was stuck at 1920 in STALE_SEED state)
historical: 25961 records
```

## Test plan

- [x] 8 new tests in `tests/vpd-tracker-parser.test.mjs`:
  - `parseRealtimeAlerts` extracts from new eval shape
  - Parses comma-separated case counts (`"1,234"` → `1234`)
  - Clear error on missing realtime marker (drift signal)
  - Clear error on truncated/unterminated array
  - `parseHistoricalData` extracts from new eval shape
  - Parses string year/cases into numbers
  - Clear error on missing historical marker
  - **REGRESSION**: pre-2026-04 `var a=[` format now throws clearly so a bundler reversion is loud, not silent
- [x] `npm run typecheck` + `typecheck:api` clean.
- [x] `npm run lint` clean.
- [x] `npm run test:data` 7791/7791 pass (8 new + 7783 prior).
- [x] All other gates clean.
- [ ] After merge + Railway pickup of the `health` bundle service, the next daily VPD-Tracker tick should publish `recordCount = ~1949` alerts + `~25961` historical, flipping both health entries from STALE_SEED back to OK.