### PR TITLE
fix(sentry): ignoreErrors NS_ERROR_FILE_NO_DEVICE_SPACE (Firefox disk-full)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -76,6 +76,7 @@ Sentry.init({
     /NS_ERROR_ABORT/,
     /NS_ERROR_OUT_OF_MEMORY/,
     /NS_ERROR_UNEXPECTED/, // Firefox XPCOM: Worker init failure on privacy-hardened Firefox/Ubuntu — WORLDMONITOR-N6/N7/N8/N9
+    /NS_ERROR_FILE_NO_DEVICE_SPACE/, // Firefox XPCOM: disk-full on IndexedDB/cache/SW write — WORLDMONITOR-Q0
     /DataCloneError.*could not be cloned/,
     /cannot decode message/,
     /WKWebView was deallocated/,


### PR DESCRIPTION
## Summary

WORLDMONITOR-Q0 — Firefox 115 / Windows 7, `Error: NS_ERROR_FILE_NO_DEVICE_SPACE: No error message`. 1 event / 1 user (low volume but trivially noise — this is a textbook XPCOM platform code).

`NS_ERROR_FILE_NO_DEVICE_SPACE` is emitted by Mozilla's XPCOM layer when a disk write fails because the user's disk is full (IndexedDB / localStorage / cache / service-worker fetch). Our shipped JS doesn't synthesize this exact phrase — only the Firefox platform does.

Sister rule to the existing `/NS_ERROR_ABORT/`, `/NS_ERROR_OUT_OF_MEMORY/`, `/NS_ERROR_UNEXPECTED/` patterns in the same `ignoreErrors` array.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 7783/7783 pass
- [x] `node --test tests/edge-functions.test.mjs` — 178/178 pass
- [x] Edge bundle check — clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK

## Sentry status

WORLDMONITOR-Q0 marked resolved in next release; auto-reopen if the regex misses.