### PR TITLE
fix(cloud-prefs): schema-2 migration to recover v1 cap-bug victims at the cloud layer

### DIFF
--- a/src/utils/cloud-prefs-migrations.ts
+++ b/src/utils/cloud-prefs-migrations.ts
@@ -11,6 +11,37 @@
 import { findFullyDisabledCategories, type FeedsByCategory } from '@/services/source-cap';
 
 /**
+ * Apply all migrations from `fromVersion + 1` up through `toVersion`
+ * inclusive. Pure function — no I/O. Caller controls migrations map and
+ * feeds context. Extracted for direct testing without pulling in the
+ * cloud-prefs-sync runtime (which has a Vite-env transitive import).
+ */
+export function applyMigrationChain(
+  data: Record<string, unknown>,
+  fromVersion: number,
+  toVersion: number,
+  migrations: Record<number, (data: Record<string, unknown>) => Record<string, unknown>>,
+): Record<string, unknown> {
+  let result = data;
+  for (let v = fromVersion + 1; v <= toVersion; v++) {
+    result = migrations[v]?.(result) ?? result;
+  }
+  return result;
+}
+
+/**
+ * Schema-2 migrations map. Used both inline by cloud-prefs-sync.ts (against
+ * the variant-aware FEEDS) and by tests (against fixture FEEDS).
+ */
+export function buildMigrations(
+  feedsByCategory: FeedsByCategory,
+): Record<number, (data: Record<string, unknown>) => Record<string, unknown>> {
+  return {
+    2: (data) => migrateDisabledFeedsV2(data, feedsByCategory),
+  };
+}
+
+/**
  * Schema-2 migration body, kept separate for direct unit testing.
  *
  * Schema 2 (2026-05-01): one-shot recovery for the v1 free-tier source-cap

--- a/src/utils/cloud-prefs-migrations.ts
+++ b/src/utils/cloud-prefs-migrations.ts
@@ -1,0 +1,59 @@
+/**
+ * Cloud-prefs schema migrations, isolated from cloud-prefs-sync.ts so they
+ * stay testable without importing the full sync runtime (which transitively
+ * pulls in `import.meta.env.DEV` via `@/services/clerk` → proxy.ts and
+ * fails outside a Vite build).
+ *
+ * Each migration is a pure function from blob → blob. The map is keyed by
+ * the TARGET schema version (so MIGRATIONS[N] runs when going from N-1 → N).
+ */
+
+import { findFullyDisabledCategories, type FeedsByCategory } from '@/services/source-cap';
+
+/**
+ * Schema-2 migration body, kept separate for direct unit testing.
+ *
+ * Schema 2 (2026-05-01): one-shot recovery for the v1 free-tier source-cap
+ * bug. The pre-PR-3521 alphabetical-slice cap auto-disabled every source
+ * past position 80 alphabetically, leaving entire late-alphabet categories
+ * (Layoffs, Semiconductors, IPO, Funding, Product Hunt, …) with 100% of
+ * their feeds in `disabledFeeds`. PR #3521 added a per-origin localStorage
+ * migration to recover this, but cloud-prefs sync re-poisoned origins
+ * every load by overwriting localStorage with the still-bad cloud blob —
+ * the recovery had to live at the cloud-data layer to be permanent.
+ *
+ * This migration runs ONCE per cloud row (gated by schemaVersion < 2),
+ * detects categories where 100% of sources are in `disabledFeeds`, and
+ * re-enables them. After the migration completes, schemaVersion bumps to
+ * 2 and subsequent sync pulls skip recovery — so a user who explicitly
+ * disables every source in a category POST-migration keeps that
+ * preference forever. The 100%-disabled-category heuristic is targeted
+ * enough that explicit single-source disabling is preserved.
+ *
+ * The recovery uses the variant-aware FEEDS passed in by the caller; the
+ * cloud blob is variant-scoped (per /api/user-prefs?variant=...) so the
+ * caller-supplied FEEDS already matches the row's variant.
+ */
+export function migrateDisabledFeedsV2(
+  data: Record<string, unknown>,
+  feedsByCategory: FeedsByCategory,
+): Record<string, unknown> {
+  const raw = data['worldmonitor-disabled-feeds'];
+  if (typeof raw !== 'string') return data;
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch { return data; }
+  if (!Array.isArray(parsed) || parsed.length === 0) return data;
+
+  const disabledStrings = parsed.filter((n): n is string => typeof n === 'string');
+  const recoverable = findFullyDisabledCategories(feedsByCategory, new Set(disabledStrings));
+  if (recoverable.length === 0) return data;
+
+  const recoveredSet = new Set(recoverable);
+  const cleaned = parsed.filter(
+    (n) => typeof n !== 'string' || !recoveredSet.has(n),
+  );
+  console.log(
+    `[cloud-prefs] schema-2 migration: re-enabled ${recoverable.length} source(s) from fully-disabled categories`,
+  );
+  return { ...data, 'worldmonitor-disabled-feeds': JSON.stringify(cleaned) };
+}

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -15,6 +15,8 @@
 import { CLOUD_SYNC_KEYS, type CloudSyncKey } from './sync-keys';
 import { isDesktopRuntime } from '@/services/runtime';
 import { getClerkToken } from '@/services/clerk';
+import { FEEDS } from '@/config/feeds';
+import { migrateDisabledFeedsV2 } from './cloud-prefs-migrations';
 
 const ENABLED = import.meta.env.VITE_CLOUD_PREFS_ENABLED === 'true';
 
@@ -24,9 +26,29 @@ const KEY_LAST_SYNC_AT = 'wm-last-sync-at';
 const KEY_SYNC_STATE = 'wm-cloud-sync-state';
 const KEY_LAST_SIGNED_IN_AS = 'wm-last-signed-in-as';
 
-const CURRENT_PREFS_SCHEMA_VERSION = 1;
+const CURRENT_PREFS_SCHEMA_VERSION = 2;
 const MIGRATIONS: Record<number, (data: Record<string, unknown>) => Record<string, unknown>> = {
-  // Future: MIGRATIONS[2] = (data) => { ...transform... }
+  // Schema 2 (2026-05-01): one-shot recovery for the v1 free-tier source-cap
+  // bug. The pre-PR-3521 alphabetical-slice cap auto-disabled every source
+  // past position 80 alphabetically, leaving entire late-alphabet categories
+  // (Layoffs, Semiconductors, IPO, Funding, Product Hunt, …) with 100% of
+  // their feeds in `disabledFeeds`. PR #3521 added a per-origin localStorage
+  // migration to recover this, but cloud-prefs sync re-poisoned origins
+  // every load by overwriting localStorage with the still-bad cloud blob —
+  // the recovery had to live at the cloud-data layer to be permanent.
+  //
+  // This migration runs ONCE per cloud row (gated by schemaVersion < 2),
+  // detects categories where 100% of sources are in `disabledFeeds`, and
+  // re-enables them. After the migration completes, schemaVersion bumps to
+  // 2 and subsequent sync pulls skip recovery — so a user who explicitly
+  // disables every source in a category POST-migration keeps that
+  // preference forever. The 100%-disabled-category heuristic is targeted
+  // enough that explicit single-source disabling is preserved.
+  //
+  // The recovery uses the variant-aware FEEDS in scope at migration time;
+  // the cloud blob is variant-scoped (per /api/user-prefs?variant=...) so
+  // there's no cross-variant pollution risk.
+  2: (data) => migrateDisabledFeedsV2(data, FEEDS),
 };
 
 type SyncState = 'synced' | 'pending' | 'syncing' | 'conflict' | 'offline' | 'signed-out' | 'error';
@@ -288,8 +310,15 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
       const prevBlobJson = isFirstEverSync ? JSON.stringify(buildCloudBlob()) : null;
 
       const migrated = applyMigrations(cloud.data, cloud.schemaVersion ?? 1);
+      const migrationChanged = (cloud.schemaVersion ?? 1) < CURRENT_PREFS_SCHEMA_VERSION;
       applyCloudBlob(migrated);
       setSyncVersion(cloud.syncVersion);
+      // If applyMigrations advanced the schema, force an upload so the cloud
+      // row's schemaVersion catches up. Without this, the cloud blob stays at
+      // the old schemaVersion and the migration re-runs on every load until
+      // any user pref change happens to fire schedulePrefUpload organically.
+      // Idempotent migrations make that harmless but wasteful and noisy.
+      if (migrationChanged) schedulePrefUpload(variant);
       Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
 
       if (isFirstEverSync && prevBlobJson && Object.keys(cloud.data).length > 0) {

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -16,7 +16,7 @@ import { CLOUD_SYNC_KEYS, type CloudSyncKey } from './sync-keys';
 import { isDesktopRuntime } from '@/services/runtime';
 import { getClerkToken } from '@/services/clerk';
 import { FEEDS } from '@/config/feeds';
-import { migrateDisabledFeedsV2 } from './cloud-prefs-migrations';
+import { applyMigrationChain, buildMigrations } from './cloud-prefs-migrations';
 
 const ENABLED = import.meta.env.VITE_CLOUD_PREFS_ENABLED === 'true';
 
@@ -25,31 +25,38 @@ const KEY_SYNC_VERSION = 'wm-cloud-sync-version';
 const KEY_LAST_SYNC_AT = 'wm-last-sync-at';
 const KEY_SYNC_STATE = 'wm-cloud-sync-state';
 const KEY_LAST_SIGNED_IN_AS = 'wm-last-signed-in-as';
+// Tracks the schema version of the LOCAL blob (i.e. what's in localStorage
+// right now). Distinct from the cloud row's schemaVersion. Required because
+// uploads can post local data without first fetching cloud (uploadNow,
+// post-conflict retry, onSignIn else-branch when local is at-or-ahead of
+// cloud). Without local tracking, those post sites would stamp the new
+// schemaVersion onto unmigrated local data — cementing the poisoning at
+// the new schema version. Defaults to 1 when missing (assumes oldest).
+const KEY_LOCAL_SCHEMA_VERSION = 'wm-cloud-prefs-local-schema-version';
 
 const CURRENT_PREFS_SCHEMA_VERSION = 2;
-const MIGRATIONS: Record<number, (data: Record<string, unknown>) => Record<string, unknown>> = {
-  // Schema 2 (2026-05-01): one-shot recovery for the v1 free-tier source-cap
-  // bug. The pre-PR-3521 alphabetical-slice cap auto-disabled every source
-  // past position 80 alphabetically, leaving entire late-alphabet categories
-  // (Layoffs, Semiconductors, IPO, Funding, Product Hunt, …) with 100% of
-  // their feeds in `disabledFeeds`. PR #3521 added a per-origin localStorage
-  // migration to recover this, but cloud-prefs sync re-poisoned origins
-  // every load by overwriting localStorage with the still-bad cloud blob —
-  // the recovery had to live at the cloud-data layer to be permanent.
-  //
-  // This migration runs ONCE per cloud row (gated by schemaVersion < 2),
-  // detects categories where 100% of sources are in `disabledFeeds`, and
-  // re-enables them. After the migration completes, schemaVersion bumps to
-  // 2 and subsequent sync pulls skip recovery — so a user who explicitly
-  // disables every source in a category POST-migration keeps that
-  // preference forever. The 100%-disabled-category heuristic is targeted
-  // enough that explicit single-source disabling is preserved.
-  //
-  // The recovery uses the variant-aware FEEDS in scope at migration time;
-  // the cloud blob is variant-scoped (per /api/user-prefs?variant=...) so
-  // there's no cross-variant pollution risk.
-  2: (data) => migrateDisabledFeedsV2(data, FEEDS),
-};
+
+// Migrations live in cloud-prefs-migrations.ts to keep them testable —
+// cloud-prefs-sync.ts has a transitive `import.meta.env.DEV` dep via
+// `@/services/clerk` → `proxy.ts` that breaks outside a Vite build. The
+// migrations module is dependency-light and importable from node:test.
+//
+// Schema 2 (2026-05-01): one-shot recovery for the v1 free-tier source-cap
+// bug. The pre-PR-3521 alphabetical-slice cap auto-disabled every source
+// past position 80 alphabetically, leaving entire late-alphabet categories
+// (Layoffs, Semiconductors, IPO, Funding, Product Hunt, …) with 100% of
+// their feeds in `disabledFeeds`. PR #3521 added a per-origin localStorage
+// migration to recover this, but cloud-prefs sync re-poisoned origins
+// every load by overwriting localStorage with the still-bad cloud blob —
+// the recovery had to live at the cloud-data layer to be permanent.
+//
+// This migration runs ONCE per cloud row (gated by schemaVersion < 2),
+// detects categories where 100% of sources are in `disabledFeeds`, and
+// re-enables them. After the migration completes, schemaVersion bumps to
+// 2 and subsequent sync pulls skip recovery — so a user who explicitly
+// disables every source in a category POST-migration keeps that
+// preference forever.
+const MIGRATIONS = buildMigrations(FEEDS);
 
 type SyncState = 'synced' | 'pending' | 'syncing' | 'conflict' | 'offline' | 'signed-out' | 'error';
 
@@ -137,11 +144,40 @@ function applyMigrations(
   data: Record<string, unknown>,
   fromVersion: number,
 ): Record<string, unknown> {
-  let result = data;
-  for (let v = fromVersion + 1; v <= CURRENT_PREFS_SCHEMA_VERSION; v++) {
-    result = MIGRATIONS[v]?.(result) ?? result;
-  }
-  return result;
+  return applyMigrationChain(data, fromVersion, CURRENT_PREFS_SCHEMA_VERSION, MIGRATIONS);
+}
+
+function getLocalSchemaVersion(): number {
+  const raw = localStorage.getItem(KEY_LOCAL_SCHEMA_VERSION);
+  if (raw === null) return 1; // No marker yet → assume oldest, run migrations
+  const v = parseInt(raw, 10);
+  return Number.isFinite(v) && v > 0 ? v : 1;
+}
+
+function setLocalSchemaVersion(v: number): void {
+  Storage.prototype.setItem.call(localStorage, KEY_LOCAL_SCHEMA_VERSION, String(v));
+}
+
+/**
+ * Ensure the local blob is migrated to CURRENT_PREFS_SCHEMA_VERSION before
+ * upload. Idempotent — when local schema is already current, returns the
+ * existing blob unchanged. Otherwise runs pending migrations, writes the
+ * cleaned data back to localStorage, and bumps the local schema marker.
+ *
+ * Must be called before EVERY post path: onSignIn else-branch (when local
+ * is at-or-ahead of cloud), uploadNow normal path, uploadNow conflict
+ * retry. Otherwise the post would stamp CURRENT_PREFS_SCHEMA_VERSION onto
+ * unmigrated local data, "upgrading" the cloud row to the new schema with
+ * stale poisoning — the failure mode flagged in PR #3524 review.
+ */
+function migrateLocalBlobIfNeeded(): Record<string, string> {
+  const localSchema = getLocalSchemaVersion();
+  const blob = buildCloudBlob();
+  if (localSchema >= CURRENT_PREFS_SCHEMA_VERSION) return blob;
+  const migrated = applyMigrations(blob, localSchema) as Record<string, string>;
+  if (migrated !== blob) applyCloudBlob(migrated);
+  setLocalSchemaVersion(CURRENT_PREFS_SCHEMA_VERSION);
+  return migrated;
 }
 
 // ── Toast ─────────────────────────────────────────────────────────────────────
@@ -313,6 +349,10 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
       const migrationChanged = (cloud.schemaVersion ?? 1) < CURRENT_PREFS_SCHEMA_VERSION;
       applyCloudBlob(migrated);
       setSyncVersion(cloud.syncVersion);
+      // After applyCloudBlob, local data IS at CURRENT schema (applyMigrations
+      // ran every step from cloud.schemaVersion to CURRENT). Mark it so the
+      // post paths don't redundantly re-run migrations on already-clean data.
+      setLocalSchemaVersion(CURRENT_PREFS_SCHEMA_VERSION);
       // If applyMigrations advanced the schema, force an upload so the cloud
       // row's schemaVersion catches up. Without this, the cloud blob stays at
       // the old schemaVersion and the migration re-runs on every load until
@@ -327,7 +367,13 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
 
       setState('synced');
     } else {
-      const blob = buildCloudBlob();
+      // Local is at-or-ahead of cloud → post local. Migrate first so we
+      // never stamp CURRENT_PREFS_SCHEMA_VERSION onto unmigrated local data
+      // (the failure mode flagged in PR #3524 review: a user already synced
+      // to a poisoned cloud row would skip Branch A's inbound migration on
+      // subsequent sign-ins and post the bad blob back at schema 2,
+      // cementing the poisoning at the new schema).
+      const blob = migrateLocalBlobIfNeeded();
       const result = await postCloudPrefs(token, variant, blob, getSyncVersion());
 
       if ('conflict' in result) {
@@ -337,6 +383,7 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
           const migrated = applyMigrations(fresh.data, fresh.schemaVersion ?? 1);
           applyCloudBlob(migrated);
           setSyncVersion(fresh.syncVersion);
+          setLocalSchemaVersion(CURRENT_PREFS_SCHEMA_VERSION);
           setState('synced');
         } else {
           setState('error');
@@ -428,7 +475,7 @@ async function uploadNow(variant: string): Promise<void> {
   setState('syncing');
 
   try {
-    const result = await postCloudPrefs(token, variant, buildCloudBlob(), getSyncVersion());
+    const result = await postCloudPrefs(token, variant, migrateLocalBlobIfNeeded(), getSyncVersion());
 
     if ('conflict' in result) {
       setState('conflict');
@@ -437,6 +484,8 @@ async function uploadNow(variant: string): Promise<void> {
         const migrated = applyMigrations(fresh.data, fresh.schemaVersion ?? 1);
         applyCloudBlob(migrated);
         setSyncVersion(fresh.syncVersion);
+        // applyCloudBlob just put migrated data into local at CURRENT schema.
+        setLocalSchemaVersion(CURRENT_PREFS_SCHEMA_VERSION);
         const retryResult = await postCloudPrefs(token, variant, buildCloudBlob(), fresh.syncVersion);
         if (!('conflict' in retryResult)) {
           setSyncVersion(retryResult.syncVersion);
@@ -558,7 +607,10 @@ export function install(variant: string): void {
     clearTimeout(_debounceTimer);
     _debounceTimer = null;
 
-    const blob = buildCloudBlob();
+    // Same defensive migration as the synchronous post paths — never stamp
+    // CURRENT_PREFS_SCHEMA_VERSION onto unmigrated local data, even on
+    // best-effort unload flush.
+    const blob = migrateLocalBlobIfNeeded();
     const payload = JSON.stringify({ variant: _currentVariant, data: blob, expectedSyncVersion: getSyncVersion(), schemaVersion: CURRENT_PREFS_SCHEMA_VERSION });
     fetch('/api/user-prefs', {
       method: 'POST',

--- a/tests/cloud-prefs-disabled-feeds-migration.test.mts
+++ b/tests/cloud-prefs-disabled-feeds-migration.test.mts
@@ -1,0 +1,127 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { migrateDisabledFeedsV2 } from '../src/utils/cloud-prefs-migrations';
+
+const F = (...names: string[]) => names.map((name) => ({ name }));
+
+describe('cloud-prefs schema-2 migration: re-enable fully-disabled categories', () => {
+  // The poisoned-state shape that triggered this migration: free-tier v1
+  // alphabetical-slice cap auto-disabled every source past position 80
+  // alphabetically, leaving entire late-alphabet categories with 100% of
+  // their feeds in `disabledFeeds`.
+  const FEEDS = {
+    layoffs: F('Layoffs.fyi', 'TechCrunch Layoffs', 'Layoffs News'),
+    ipo: F('IPO News', 'Renaissance IPO', 'Tech IPO News'),
+    funding: F('SEC Filings', 'VC News', 'Seed & Pre-Seed', 'Startup Funding'),
+    producthunt: F('Product Hunt'),
+    politics: F('BBC World', 'Reuters World', 'AP News'), // healthy, must not be touched
+  };
+
+  it('returns blob unchanged when disabledFeeds key is missing', () => {
+    const blob = { 'worldmonitor-panels': '{"foo":1}' };
+    const result = migrateDisabledFeedsV2(blob, FEEDS);
+    assert.equal(result, blob, 'unchanged blob must be returned by reference (no copy)');
+  });
+
+  it('returns blob unchanged when disabledFeeds is not a string', () => {
+    const blob = { 'worldmonitor-disabled-feeds': 42 as unknown as string };
+    const result = migrateDisabledFeedsV2(blob, FEEDS);
+    assert.equal(result, blob);
+  });
+
+  it('returns blob unchanged when disabledFeeds is malformed JSON', () => {
+    const blob = { 'worldmonitor-disabled-feeds': 'not json {' };
+    const result = migrateDisabledFeedsV2(blob, FEEDS);
+    assert.equal(result, blob);
+  });
+
+  it('returns blob unchanged when disabledFeeds is an empty array', () => {
+    const blob = { 'worldmonitor-disabled-feeds': '[]' };
+    const result = migrateDisabledFeedsV2(blob, FEEDS);
+    assert.equal(result, blob);
+  });
+
+  it('returns blob unchanged when no category is 100% disabled', () => {
+    // Partial disable in two categories — explicit user prefs, must be preserved.
+    const blob = {
+      'worldmonitor-disabled-feeds': JSON.stringify(['Layoffs.fyi', 'IPO News']),
+    };
+    const result = migrateDisabledFeedsV2(blob, FEEDS);
+    assert.equal(result, blob, 'partial disabling is a real user pref — must not be touched');
+  });
+
+  it('REGRESSION: re-enables sources from a 100%-disabled late-alphabet category', () => {
+    // The exact production shape: `producthunt` has 1 feed, `Product Hunt`,
+    // which alphabetically lands after position 80 → got disabled by v1
+    // cap → now the entire panel reads "All sources disabled".
+    const blob = {
+      'worldmonitor-disabled-feeds': JSON.stringify(['Product Hunt']),
+      'worldmonitor-panels': '{"keep":"this"}',
+    };
+    const result = migrateDisabledFeedsV2(blob, FEEDS);
+    const newDisabled = JSON.parse(result['worldmonitor-disabled-feeds'] as string);
+    assert.deepEqual(newDisabled, [], 'Product Hunt must be removed from disabled');
+    assert.equal(result['worldmonitor-panels'], '{"keep":"this"}', 'other blob keys must be preserved');
+  });
+
+  it('REGRESSION: production-shape — multiple late-alphabet categories all recovered at once', () => {
+    // Mirror the user-reported state: layoffs (3), ipo (3), funding (4),
+    // producthunt (1) — 11 source names total, all in the disabled set.
+    const allDisabled = [
+      'Layoffs.fyi', 'TechCrunch Layoffs', 'Layoffs News',
+      'IPO News', 'Renaissance IPO', 'Tech IPO News',
+      'SEC Filings', 'VC News', 'Seed & Pre-Seed', 'Startup Funding',
+      'Product Hunt',
+    ];
+    const blob = { 'worldmonitor-disabled-feeds': JSON.stringify(allDisabled) };
+    const result = migrateDisabledFeedsV2(blob, FEEDS);
+    const newDisabled = JSON.parse(result['worldmonitor-disabled-feeds'] as string);
+    assert.deepEqual(newDisabled, [], 'all 11 entries must be recovered');
+  });
+
+  it('REGRESSION: preserves explicit single-source disabling (the heuristic\'s safety property)', () => {
+    // User explicitly disabled CNN. Migration must NOT undo this — a real
+    // pref (single source, not a 100%-disabled category).
+    const blob = {
+      'worldmonitor-disabled-feeds': JSON.stringify([
+        'BBC World',  // 1 of 3 in `politics` → not 100%
+        'Layoffs.fyi', 'TechCrunch Layoffs', 'Layoffs News',  // 100% of layoffs → recover
+      ]),
+    };
+    const result = migrateDisabledFeedsV2(blob, FEEDS);
+    const newDisabled = new Set(JSON.parse(result['worldmonitor-disabled-feeds'] as string));
+    assert.ok(newDisabled.has('BBC World'), 'explicit single disable must be preserved');
+    assert.equal(newDisabled.has('Layoffs.fyi'), false);
+    assert.equal(newDisabled.has('TechCrunch Layoffs'), false);
+    assert.equal(newDisabled.has('Layoffs News'), false);
+  });
+
+  it('returns a NEW object on mutation (does not mutate input)', () => {
+    const blob = {
+      'worldmonitor-disabled-feeds': JSON.stringify(['Product Hunt']),
+    };
+    const inputJson = blob['worldmonitor-disabled-feeds'];
+    const result = migrateDisabledFeedsV2(blob, FEEDS);
+    assert.notEqual(result, blob, 'result must be a new object on mutation');
+    assert.equal(blob['worldmonitor-disabled-feeds'], inputJson, 'input blob must not be mutated');
+  });
+
+  it('handles non-string entries in the disabledFeeds array defensively', () => {
+    // Malformed cloud data — an entry that's not a string. Skip it instead
+    // of throwing; recover whatever else is recoverable.
+    const blob = {
+      'worldmonitor-disabled-feeds': JSON.stringify([
+        null,
+        42,
+        'Product Hunt',
+        { weird: 'object' },
+      ]),
+    };
+    const result = migrateDisabledFeedsV2(blob, FEEDS);
+    const newDisabled = JSON.parse(result['worldmonitor-disabled-feeds'] as string);
+    // Product Hunt is recovered; the malformed entries pass through untouched.
+    // (We don't try to clean them — that's not this migration's job.)
+    assert.equal(newDisabled.includes('Product Hunt'), false);
+  });
+});

--- a/tests/cloud-prefs-disabled-feeds-migration.test.mts
+++ b/tests/cloud-prefs-disabled-feeds-migration.test.mts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { migrateDisabledFeedsV2 } from '../src/utils/cloud-prefs-migrations';
+import { migrateDisabledFeedsV2, applyMigrationChain, buildMigrations } from '../src/utils/cloud-prefs-migrations';
 
 const F = (...names: string[]) => names.map((name) => ({ name }));
 
@@ -107,6 +107,27 @@ describe('cloud-prefs schema-2 migration: re-enable fully-disabled categories', 
     assert.equal(blob['worldmonitor-disabled-feeds'], inputJson, 'input blob must not be mutated');
   });
 
+  it('REGRESSION (PR #3524 review): the same migration applied to LOCAL blob produces clean data', () => {
+    // The reviewer-flagged scenario: a user with poisoned local data and
+    // local syncVersion == cloud syncVersion would skip Branch A's inbound
+    // migration and post the local blob back at schemaVersion=2, cementing
+    // the poisoning. The fix runs the same migration on the local blob
+    // before any post. This test pins the SAME function (used at both
+    // sites) clears the same poisoning regardless of which side (cloud
+    // or local) it originated from.
+    const poisonedLocalBlob = {
+      'worldmonitor-disabled-feeds': JSON.stringify([
+        'Layoffs.fyi', 'TechCrunch Layoffs', 'Layoffs News', // 100% of layoffs
+        'BBC World',                                          // explicit single-source pref
+      ]),
+      'worldmonitor-panels': '{"some":"panel-state"}',
+    };
+    const result = migrateDisabledFeedsV2(poisonedLocalBlob, FEEDS);
+    const cleaned = JSON.parse(result['worldmonitor-disabled-feeds'] as string);
+    assert.deepEqual(cleaned, ['BBC World'], 'layoffs sources recovered, BBC World preserved as explicit pref');
+    assert.equal(result['worldmonitor-panels'], '{"some":"panel-state"}', 'unrelated blob keys preserved');
+  });
+
   it('handles non-string entries in the disabledFeeds array defensively', () => {
     // Malformed cloud data — an entry that's not a string. Skip it instead
     // of throwing; recover whatever else is recoverable.
@@ -123,5 +144,62 @@ describe('cloud-prefs schema-2 migration: re-enable fully-disabled categories', 
     // Product Hunt is recovered; the malformed entries pass through untouched.
     // (We don't try to clean them — that's not this migration's job.)
     assert.equal(newDisabled.includes('Product Hunt'), false);
+  });
+});
+
+describe('applyMigrationChain', () => {
+  // The chain runs migrations[v] for v = fromVersion+1 .. toVersion inclusive.
+  // It's the mechanism that drives the inbound (Branch A) AND outbound
+  // (Branch B + uploadNow) post-fix paths.
+
+  it('runs no migrations when fromVersion >= toVersion', () => {
+    let calls = 0;
+    const migrations = { 2: (data: Record<string, unknown>) => { calls++; return data; } };
+    const data = { foo: 'bar' };
+    const result = applyMigrationChain(data, 2, 2, migrations);
+    assert.equal(calls, 0, 'no migrations should run when already at target');
+    assert.equal(result, data);
+  });
+
+  it('runs migrations in order from fromVersion+1 to toVersion inclusive', () => {
+    const calledFor: number[] = [];
+    const migrations = {
+      2: (data: Record<string, unknown>) => { calledFor.push(2); return { ...data, m2: true }; },
+      3: (data: Record<string, unknown>) => { calledFor.push(3); return { ...data, m3: true }; },
+    };
+    const result = applyMigrationChain({}, 1, 3, migrations);
+    assert.deepEqual(calledFor, [2, 3]);
+    assert.equal((result as { m2?: boolean }).m2, true);
+    assert.equal((result as { m3?: boolean }).m3, true);
+  });
+
+  it('skips missing migrations in the chain (sparse map)', () => {
+    // No migrations[2] defined — chain should pass through to migrations[3].
+    const migrations = {
+      3: (data: Record<string, unknown>) => ({ ...data, m3: true }),
+    };
+    const result = applyMigrationChain({ initial: true }, 1, 3, migrations);
+    assert.equal((result as { initial?: boolean }).initial, true);
+    assert.equal((result as { m3?: boolean }).m3, true);
+  });
+
+  it('integrates with buildMigrations for the schema-2 production case', () => {
+    // End-to-end: simulate a user at schema=1 going to schema=2 via the
+    // production migrations map.
+    const productionLikeFeeds = {
+      layoffs: F('Layoffs.fyi', 'TechCrunch Layoffs', 'Layoffs News'),
+      politics: F('BBC World', 'Reuters World'),
+    };
+    const migrations = buildMigrations(productionLikeFeeds);
+    const blob = {
+      'worldmonitor-disabled-feeds': JSON.stringify([
+        'Layoffs.fyi', 'TechCrunch Layoffs', 'Layoffs News', // 100% layoffs
+        'BBC World',                                           // 50% politics
+      ]),
+    };
+    const result = applyMigrationChain(blob, 1, 2, migrations);
+    const cleaned = JSON.parse(result['worldmonitor-disabled-feeds'] as string);
+    // Layoffs sources recovered; BBC World preserved (partial-disable safety)
+    assert.deepEqual(cleaned, ['BBC World']);
   });
 });


### PR DESCRIPTION
## Summary

Pro user reported `tech.worldmonitor.app` showing "All sources disabled" red panels for LAYOFFS, FUNDING & VC, PRODUCT HUNT, SEMICONDUCTORS & HARDWARE, IPO & SPAC — despite **never being free** in the past 30 days, so the previous local-only migration (PR #3521) didn't reach them.

Diagnostic chain that nailed it:

```
localStorage.disabledFeedsSchema  → "1"   (PR #3521 migration ran)
localStorage.disabledFeeds[0..30] → ["Inc42 (India)", "India Startups",
                                      "Indonesia Tech", "InfoQ", "Janes",
                                      "Japan Startups", ..., "MIT Tech Review"]
                                      ↑ alphabetical I–M range = v1 cap-bug fingerprint
```

Confirmed via incognito sign-in on the same Pro account: the panels populate correctly for ~30s then go empty. That window is the gap between the local migration running at init time and `installCloudPrefsSync` → `onSignIn` → `fetchCloudPrefs` → `applyCloudBlob` overwriting localStorage with the still-poisoned cloud blob.

PR #3521's per-origin localStorage migration cannot fix this — its work is undone every sync pull. The recovery has to live at the **cloud-data layer** to be permanent.

## Fix

1. **Bump `CURRENT_PREFS_SCHEMA_VERSION` 1 → 2** in `src/utils/cloud-prefs-sync.ts`.
2. **Add `MIGRATIONS[2]`** that runs `findFullyDisabledCategories` on the inbound blob's `worldmonitor-disabled-feeds` and re-enables fully-disabled categories. Gated by `cloud.schemaVersion < 2` so it runs **once per cloud row**.
3. **Force `schedulePrefUpload` after the migration advanced the schema**, so the cloud row's `schemaVersion` catches up immediately. Without this the migration would re-run idempotently every load until any local pref change happens to fire `schedulePrefUpload` organically.

Same safety property as PR #3521's localStorage migration: 100%-disabled-category heuristic preserves explicit single-source disabling. After `schemaVersion` reaches 2, a user who explicitly disables every source in a category POST-migration keeps that preference forever.

### Architectural note

Extracted `migrateDisabledFeedsV2` into `src/utils/cloud-prefs-migrations.ts` because `cloud-prefs-sync.ts` has a transitive `import.meta.env.DEV` dependency (via `@/services/clerk` → `proxy.ts`) that fails to load outside Vite. The extracted module imports only from `@/services/source-cap`, which is testable in isolation.

## Test plan

- [x] 10 new tests in `tests/cloud-prefs-disabled-feeds-migration.test.mts`:
  - Missing/non-string/malformed/empty `disabledFeeds` → blob unchanged (defensive)
  - Partial-disable preservation (the safety property — explicit user disabling of a single source must NEVER be undone)
  - **REGRESSION**: 100%-disabled late-alphabet category (1 feed) recovered
  - **REGRESSION**: production-shape — 11 sources across 4 categories all recovered at once
  - Explicit-disable preservation in combination with category recovery (BBC World stays disabled, all 3 layoffs sources re-enabled in same pass)
  - Input blob not mutated (returns new object on change)
  - Non-string entries in `disabledFeeds` handled defensively
- [x] `npm run typecheck` + `typecheck:api` clean.
- [x] `npm run lint` clean.
- [x] `npm run test:data` 7810/7810 pass.
- [x] All other gates clean.
- [ ] After merge + deploy, Pro users on variant subdomains will see their broken panels populate on next sign-in: `onSignIn` pulls cloud blob → `applyMigrations(data, schemaVersion=1)` runs `MIGRATIONS[2]` → `findFullyDisabledCategories(VARIANT_FEEDS, disabled)` re-enables fully-disabled categories → cleaned data lands in localStorage → forced `schedulePrefUpload` posts back with `schemaVersion: 2` → next reload skips migration.

## Out of scope (separate issues from screenshots)

- **CLOUD & INFRASTRUCTURE / IPO & SPAC "UNAVAILABLE / No news available" in incognito** — these had FRESH localStorage and still showed empty. Different bug: the variant's RSS query for those categories is genuinely returning 0 items right now (Google News query like `(IPO OR "initial public offering" OR SPAC) tech when:7d`). The badge ambiguity (`NewsPanel.renderNews` can't distinguish empty-results from fetcher-failure) is the previously-flagged separate fix.