### PR TITLE
fix(security): replace Referer-origin fallback with Sec-Fetch-Site (#3541)

### DIFF
--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -22,49 +22,58 @@ function isTrustedBrowserOrigin(origin) {
   return Boolean(origin) && BROWSER_ORIGIN_PATTERNS.some(p => p.test(origin));
 }
 
-function extractOriginFromReferer(referer) {
-  if (!referer) return '';
-  try {
-    return new URL(referer).origin;
-  } catch {
-    return '';
-  }
+// Sec-Fetch-Site is on the Forbidden Header list — set ONLY by the browser at
+// request time, never by client JS or non-browser HTTP clients (curl, Node fetch,
+// Python requests). 'same-origin' = strict same-origin browser fetch.
+//
+// Replaced an earlier Referer-origin fallback (issue #3541) which trusted a
+// client-controlled header: `curl -H "Referer: https://worldmonitor.app/"`
+// with no Origin was classified as a trusted browser, bypassing the API-key
+// gate entirely. Sec-Fetch-Site is unforgeable; Referer is not.
+function isSameOriginBrowserRequest(req) {
+  return req.headers.get('Sec-Fetch-Site') === 'same-origin';
+}
+
+function isValidKey(key) {
+  if (!key) return false;
+  const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);
+  return validKeys.includes(key);
 }
 
 export function validateApiKey(req, options = {}) {
   const forceKey = options.forceKey === true;
   const key = req.headers.get('X-WorldMonitor-Key') || req.headers.get('X-Api-Key');
-  // Same-origin browser requests don't send Origin (per CORS spec).
-  // Fall back to Referer to identify trusted same-origin callers.
-  const origin = req.headers.get('Origin') || extractOriginFromReferer(req.headers.get('Referer')) || '';
+  const origin = req.headers.get('Origin') || '';
 
   // Desktop app — always require API key
   if (isDesktopOrigin(origin)) {
     if (!key) return { valid: false, required: true, error: 'API key required for desktop access' };
-    const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);
-    if (!validKeys.includes(key)) return { valid: false, required: true, error: 'Invalid API key' };
+    if (!isValidKey(key)) return { valid: false, required: true, error: 'Invalid API key' };
     return { valid: true, required: true };
   }
 
-  // Trusted browser origin (worldmonitor.app, Vercel previews, localhost dev) — no key needed
-  if (isTrustedBrowserOrigin(origin)) {
+  // Browser request from a trusted origin — either explicit Origin matches our
+  // hosts, or Origin is absent (CORS spec omits it on same-origin same-document
+  // requests) AND the unforgeable Sec-Fetch-Site header confirms same-origin.
+  const isTrustedBrowser = isTrustedBrowserOrigin(origin)
+    || (!origin && isSameOriginBrowserRequest(req));
+
+  if (isTrustedBrowser) {
     if (forceKey && !key) {
       return { valid: false, required: true, error: 'API key required' };
     }
-    if (key) {
-      const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);
-      if (!validKeys.includes(key)) return { valid: false, required: true, error: 'Invalid API key' };
+    if (key && !isValidKey(key)) {
+      return { valid: false, required: true, error: 'Invalid API key' };
     }
     return { valid: true, required: forceKey };
   }
 
   // Explicit key provided from unknown origin — validate it
   if (key) {
-    const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);
-    if (!validKeys.includes(key)) return { valid: false, required: true, error: 'Invalid API key' };
+    if (!isValidKey(key)) return { valid: false, required: true, error: 'Invalid API key' };
     return { valid: true, required: true };
   }
 
-  // No origin, no key — require API key (blocks unauthenticated curl/scripts)
+  // No trusted origin signal, no key — require API key (blocks curl/scripts)
   return { valid: false, required: true, error: 'API key required' };
 }

--- a/api/_api-key.test.mjs
+++ b/api/_api-key.test.mjs
@@ -1,0 +1,145 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import { validateApiKey } from './_api-key.js';
+
+const VALID_KEY = 'test-valid-key-123';
+
+function makeReq({ origin, referer, secFetchSite, key } = {}) {
+  const headers = new Headers();
+  if (origin) headers.set('origin', origin);
+  if (referer) headers.set('referer', referer);
+  if (secFetchSite) headers.set('sec-fetch-site', secFetchSite);
+  if (key) headers.set('x-worldmonitor-key', key);
+  return new Request('https://api.worldmonitor.app/api/test', { headers });
+}
+
+test.before(() => {
+  process.env.WORLDMONITOR_VALID_KEYS = VALID_KEY;
+});
+
+test('issue #3541 — curl with fake Referer cannot bypass key (no Origin, no Sec-Fetch-Site)', () => {
+  // Pre-fix behavior: validateApiKey({ Referer: https://worldmonitor.app/ }) returned valid=true.
+  // Post-fix: Referer is ignored; this request must be rejected.
+  const req = makeReq({ referer: 'https://worldmonitor.app/' });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, false, 'fake Referer must NOT trust the request');
+  assert.equal(result.required, true);
+});
+
+test('issue #3541 — curl with fake Referer AND fake Sec-Fetch-Site cannot bypass', () => {
+  // Sec-Fetch-Site is on the Forbidden Header list, so the browser overwrites
+  // it. But we verify defense-in-depth: even if a client tries to set BOTH,
+  // we never accept Referer signals.
+  const req = makeReq({
+    referer: 'https://worldmonitor.app/',
+    secFetchSite: 'cross-site',
+  });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, false);
+});
+
+test('browser same-origin request (no Origin, Sec-Fetch-Site: same-origin) is trusted', () => {
+  const req = makeReq({ secFetchSite: 'same-origin' });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, true);
+  assert.equal(result.required, false);
+});
+
+test('browser cross-origin request with explicit Origin worldmonitor.app is trusted', () => {
+  const req = makeReq({ origin: 'https://worldmonitor.app', secFetchSite: 'same-site' });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, true);
+});
+
+test('browser cross-origin request with subdomain Origin (tech.worldmonitor.app) is trusted', () => {
+  const req = makeReq({ origin: 'https://tech.worldmonitor.app', secFetchSite: 'same-site' });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, true);
+});
+
+test('browser request with attacker Origin is rejected', () => {
+  const req = makeReq({ origin: 'https://evil.example.com' });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, false);
+});
+
+test('Sec-Fetch-Site: cross-site (no Origin) is NOT trusted', () => {
+  // A cross-site nav from attacker.com that strips Origin somehow — should not pass.
+  const req = makeReq({ secFetchSite: 'cross-site' });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, false);
+});
+
+test('Sec-Fetch-Site: none (top-level navigation) is NOT trusted for API endpoints', () => {
+  // Direct URL-bar navigation to /api/foo — should not be classified as a
+  // browser app request. Only same-origin counts.
+  const req = makeReq({ secFetchSite: 'none' });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, false);
+});
+
+test('Sec-Fetch-Site: same-site (no Origin) is NOT trusted (defensive)', () => {
+  // Browsers send Origin on same-site cross-host requests, so this combo
+  // shouldn't occur in practice. Reject defensively.
+  const req = makeReq({ secFetchSite: 'same-site' });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, false);
+});
+
+test('valid API key from any origin is accepted', () => {
+  const req = makeReq({ origin: 'https://anywhere.example.com', key: VALID_KEY });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, true);
+  assert.equal(result.required, true);
+});
+
+test('invalid API key from any origin is rejected', () => {
+  const req = makeReq({ origin: 'https://anywhere.example.com', key: 'wrong' });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, false);
+});
+
+test('desktop Tauri origin without key is rejected', () => {
+  const req = makeReq({ origin: 'tauri://localhost' });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, false);
+  assert.equal(result.error, 'API key required for desktop access');
+});
+
+test('desktop Tauri origin with valid key is accepted', () => {
+  const req = makeReq({ origin: 'tauri://localhost', key: VALID_KEY });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, true);
+});
+
+test('desktop Tauri origin with invalid key is rejected', () => {
+  const req = makeReq({ origin: 'tauri://localhost', key: 'wrong' });
+  const result = validateApiKey(req);
+  assert.equal(result.valid, false);
+  assert.equal(result.error, 'Invalid API key');
+});
+
+test('forceKey=true requires key even from trusted browser origin', () => {
+  const req = makeReq({ origin: 'https://worldmonitor.app' });
+  const result = validateApiKey(req, { forceKey: true });
+  assert.equal(result.valid, false);
+});
+
+test('forceKey=true requires key even on same-origin Sec-Fetch-Site', () => {
+  const req = makeReq({ secFetchSite: 'same-origin' });
+  const result = validateApiKey(req, { forceKey: true });
+  assert.equal(result.valid, false);
+});
+
+test('forceKey=true with valid key from same-origin browser is accepted', () => {
+  const req = makeReq({ secFetchSite: 'same-origin', key: VALID_KEY });
+  const result = validateApiKey(req, { forceKey: true });
+  assert.equal(result.valid, true);
+});
+
+test('completely unauthenticated request (no Origin, no Sec-Fetch-Site, no key) is rejected', () => {
+  const req = makeReq({});
+  const result = validateApiKey(req);
+  assert.equal(result.valid, false);
+  assert.equal(result.required, true);
+});

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:data": "tsx --test tests/*.test.mjs tests/*.test.mts",
     "dryrun:resilience": "node --import tsx/esm scripts/dry-run-resilience-rebalance.mjs",
     "test:feeds": "node scripts/validate-rss-feeds.mjs",
-    "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs api/_cors.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs",
+    "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs api/_cors.test.mjs api/_api-key.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs",
     "test:e2e:visual:full": "cross-env VITE_VARIANT=full playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual:tech": "cross-env VITE_VARIANT=tech playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual": "npm run test:e2e:visual:full && npm run test:e2e:visual:tech",


### PR DESCRIPTION
## Summary

Fixes #3541 — API-key bypass via Referer header.

`api/_api-key.js` previously fell back to `extractOriginFromReferer(req.headers.get('Referer'))` when `Origin` was absent, then matched the result against `BROWSER_ORIGIN_PATTERNS` to grant trusted-browser access without an API key. **Referer is fully client-controlled** — `curl -H "Referer: https://worldmonitor.app/"` (no Origin) was classified as a trusted browser request, bypassing the key gate on every non-tier-gated endpoint and erasing rate-limit attribution because the request looked like a legitimate browser session.

## Mechanism

- **Removed**: `extractOriginFromReferer()` and the Referer fallback path.
- **Added**: `isSameOriginBrowserRequest(req)` checking `Sec-Fetch-Site === 'same-origin'`. Browsers set this on every request; it's on the [Forbidden Header list](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name), so curl / Node fetch / Python requests cannot forge it.

## Behavior changes

| Request shape | Before | After |
|---|---|---|
| `curl -H "Referer: https://worldmonitor.app/"` (no Origin, no key) | ✅ accepted (bug) | ❌ 401 |
| Browser GET same-origin (no Origin, `Sec-Fetch-Site: same-origin`) | ✅ accepted | ✅ accepted |
| Browser cross-origin XHR (`Origin: https://worldmonitor.app`) | ✅ accepted | ✅ accepted |
| Tauri desktop (`Origin: tauri://localhost`) — requires key | ✅ unchanged | ✅ unchanged |
| Pre-2019 browsers without `Sec-Fetch-Site` | ✅ accepted via Referer | ❌ must use API key (fail-closed) |

The pre-2019 browser break is intentional — Chrome 76 (2019), Firefox 90 (2021), Safari 16.4 (2023) all support the header. Users on truly ancient browsers fall through to the "API key required" path rather than being passively trusted.

## Test plan

- [x] `node --test api/_api-key.test.mjs` → 18 / 18 pass
- [x] `node --test api/_cors.test.mjs` → no regression
- [x] `npm run typecheck` + `typecheck:api` → clean
- [x] `npm run lint` → clean
- [x] `npm run test:data` → 7800 / 7800 pass
- [x] Edge function bundle check (every `api/*.js` other than helpers builds clean)
- [x] `npm run lint:md`, `npm run version:check` → clean

New regression tests cover:

- Curl with fake Referer is rejected (the bug).
- Defense-in-depth: combined Referer + spoofed Sec-Fetch-Site is rejected.
- Browser same-origin (`Sec-Fetch-Site: same-origin`) is trusted.
- `Sec-Fetch-Site: none` (URL-bar nav) is NOT trusted for API endpoints.
- `Sec-Fetch-Site: cross-site` / `same-site` without Origin is rejected (defensive).
- forceKey + trusted browser still requires a key.
- Tauri desktop key paths unchanged.

## Source

Manual security audit (deepseek), validated 2026-05-01. See #3541 for the full discovery write-up.