### PR TITLE
fix: fetch configured CoinPaprika tickers by id

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -38,6 +38,36 @@ export function describeErr(err) {
 }
 
 /**
+ * Fetch only configured CoinPaprika ticker IDs instead of the full /tickers
+ * catalog. The catalog endpoint currently returns 13k+ records; seeders only
+ * need a small mapped subset, so per-ID reads avoid Edge/cron memory and
+ * latency spikes while preserving the same ticker shape.
+ *
+ * @param {string[]} paprikaIds CoinPaprika ids, e.g. btc-bitcoin
+ * @param {{ fetchFn?: typeof fetch, headers?: Record<string, string>, timeoutMs?: number }} [options]
+ * @returns {Promise<object[]>}
+ */
+export async function fetchCoinPaprikaTickersById(paprikaIds, options = {}) {
+  const ids = [...new Set(paprikaIds.filter(Boolean))];
+  if (ids.length === 0) return [];
+
+  const fetchFn = options.fetchFn || fetch;
+  const headers = options.headers || { Accept: 'application/json', 'User-Agent': CHROME_UA };
+  const timeoutMs = options.timeoutMs || 15_000;
+
+  const tickers = await Promise.all(ids.map(async (id) => {
+    const resp = await fetchFn(`https://api.coinpaprika.com/v1/tickers/${encodeURIComponent(id)}?quotes=USD`, {
+      headers,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!resp.ok) throw new Error(`CoinPaprika ${id} HTTP ${resp.status}`);
+    return resp.json();
+  }));
+
+  return tickers;
+}
+
+/**
  * Return the bundle-run start timestamp injected by `_bundle-runner.mjs`
  * as the `BUNDLE_RUN_STARTED_AT_MS` env var, or `null` when the seeder
  * is running STANDALONE (manual invocation outside the bundle).

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -54,15 +54,16 @@ export async function fetchCoinPaprikaTickersById(paprikaIds, options = {}) {
   const fetchFn = options.fetchFn || fetch;
   const headers = { Accept: 'application/json', 'User-Agent': CHROME_UA, ...(options.headers || {}) };
   const timeoutMs = options.timeoutMs || 15_000;
+  const concurrency = Math.max(1, Math.min(Number(options.concurrency || 4), ids.length));
 
-  const results = await Promise.allSettled(ids.map(async (id) => {
+  const results = await allSettledWithConcurrency(ids, concurrency, async (id) => {
     const resp = await fetchFn(`https://api.coinpaprika.com/v1/tickers/${encodeURIComponent(id)}?quotes=USD`, {
       headers,
       signal: AbortSignal.timeout(timeoutMs),
     });
     if (!resp.ok) throw new Error(`CoinPaprika ${id} HTTP ${resp.status}`);
     return resp.json();
-  }));
+  });
 
   const tickers = [];
   const failures = [];
@@ -81,6 +82,26 @@ export async function fetchCoinPaprikaTickersById(paprikaIds, options = {}) {
   }
 
   return tickers;
+}
+
+async function allSettledWithConcurrency(items, concurrency, mapper) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+
+  await Promise.all(Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      try {
+        results[index] = { status: 'fulfilled', value: await mapper(items[index], index) };
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason };
+      }
+    }
+  }));
+
+  return results;
 }
 
 /**

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -52,10 +52,10 @@ export async function fetchCoinPaprikaTickersById(paprikaIds, options = {}) {
   if (ids.length === 0) return [];
 
   const fetchFn = options.fetchFn || fetch;
-  const headers = options.headers || { Accept: 'application/json', 'User-Agent': CHROME_UA };
+  const headers = { Accept: 'application/json', 'User-Agent': CHROME_UA, ...(options.headers || {}) };
   const timeoutMs = options.timeoutMs || 15_000;
 
-  const tickers = await Promise.all(ids.map(async (id) => {
+  const results = await Promise.allSettled(ids.map(async (id) => {
     const resp = await fetchFn(`https://api.coinpaprika.com/v1/tickers/${encodeURIComponent(id)}?quotes=USD`, {
       headers,
       signal: AbortSignal.timeout(timeoutMs),
@@ -63,6 +63,22 @@ export async function fetchCoinPaprikaTickersById(paprikaIds, options = {}) {
     if (!resp.ok) throw new Error(`CoinPaprika ${id} HTTP ${resp.status}`);
     return resp.json();
   }));
+
+  const tickers = [];
+  const failures = [];
+  for (let i = 0; i < results.length; i += 1) {
+    const result = results[i];
+    if (result.status === 'fulfilled') {
+      tickers.push(result.value);
+    } else {
+      failures.push(result.reason);
+      console.warn(`[CoinPaprika] Skipping ${ids[i]}: ${describeErr(result.reason)}`);
+    }
+  }
+
+  if (tickers.length === 0 && failures.length > 0) {
+    throw new Error(`All ${failures.length} CoinPaprika ticker request(s) failed`);
+  }
 
   return tickers;
 }

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2176,34 +2176,70 @@ const CRYPTO_PAPRIKA_MAP = _cryptoCfg.coinpaprika;
 const CRYPTO_SEED_TTL = 7200; // 2h — 1h buffer over 5min cron cadence (was 1h = 55min buffer)
 
 // Shared CoinPaprika tickers fetcher — direct first, PROXY_URL fallback.
-// Cached for 5 min so the 3 crypto seeders (crypto, stablecoins, token-panels)
-// that run in the same cycle don't triple-fetch the same 2000-item response.
-let _paprikaCached = null;
-let _paprikaCachedAt = 0;
+// Cached per ticker for 5 min so crypto, stablecoins, sectors, and token panels
+// that run in the same cycle can share overlap without fetching the full catalog.
+const _paprikaTickerCache = new Map();
 const _PAPRIKA_CACHE_MS = 5 * 60 * 1000;
-const _PAPRIKA_URL = 'https://api.coinpaprika.com/v1/tickers?quotes=USD';
 
-async function _fetchCoinPaprikaTickers() {
-  if (_paprikaCached && Date.now() - _paprikaCachedAt < _PAPRIKA_CACHE_MS) return _paprikaCached;
-  // Try direct
-  let data = await cyberHttpGetJson(_PAPRIKA_URL, { Accept: 'application/json' }, 15000);
-  if (Array.isArray(data) && data.length > 0) { _paprikaCached = data; _paprikaCachedAt = Date.now(); return data; }
-  // Fallback via proxy
-  if (!PROXY_URL) throw new Error('CoinPaprika direct failed and no PROXY_URL configured');
+async function _fetchCoinPaprikaTickerById(id) {
+  const url = `https://api.coinpaprika.com/v1/tickers/${encodeURIComponent(id)}?quotes=USD`;
+  const direct = await cyberHttpGetJson(url, { Accept: 'application/json' }, 15000);
+  if (direct && typeof direct === 'object' && direct.id) return direct;
+
+  if (!PROXY_URL) throw new Error(`CoinPaprika ${id} direct failed and no PROXY_URL configured`);
   const proxy = { ...parseProxyUrl(PROXY_URL), tls: true };
-  const resp = await ytFetchViaProxy(_PAPRIKA_URL, proxy);
-  if (!resp?.ok) throw new Error(`CoinPaprika proxy HTTP ${resp?.status || 'unavailable'}`);
-  data = JSON.parse(resp.body);
-  if (!Array.isArray(data)) throw new Error('CoinPaprika proxy returned non-array');
-  _paprikaCached = data; _paprikaCachedAt = Date.now();
+  const resp = await ytFetchViaProxy(url, proxy);
+  if (!resp?.ok) throw new Error(`CoinPaprika ${id} proxy HTTP ${resp?.status || 'unavailable'}`);
+  const data = JSON.parse(resp.body);
+  if (!data || typeof data !== 'object' || !data.id) throw new Error(`CoinPaprika ${id} proxy returned invalid ticker`);
   return data;
 }
 
+async function _fetchCoinPaprikaTickersById(paprikaIds) {
+  const ids = [...new Set(paprikaIds.filter(Boolean))];
+  if (ids.length === 0) return [];
+
+  const now = Date.now();
+  const tickers = [];
+  const misses = [];
+  for (const id of ids) {
+    const cached = _paprikaTickerCache.get(id);
+    if (cached && now - cached.cachedAt < _PAPRIKA_CACHE_MS) {
+      tickers.push(cached.ticker);
+    } else {
+      misses.push(id);
+    }
+  }
+
+  const results = await Promise.allSettled(misses.map(async (id) => {
+    const ticker = await _fetchCoinPaprikaTickerById(id);
+    _paprikaTickerCache.set(id, { ticker, cachedAt: Date.now() });
+    return ticker;
+  }));
+
+  const failures = [];
+  for (let i = 0; i < results.length; i += 1) {
+    const result = results[i];
+    if (result.status === 'fulfilled') {
+      tickers.push(result.value);
+    } else {
+      failures.push(result.reason);
+      console.warn(`[CoinPaprika] Skipping ${misses[i]}: ${result.reason?.message || result.reason}`);
+    }
+  }
+
+  if (tickers.length === 0 && failures.length > 0) {
+    throw new Error(`All ${failures.length} CoinPaprika ticker request(s) failed`);
+  }
+
+  return tickers;
+}
+
 async function fetchCryptoCoinPaprika() {
-  const data = await _fetchCoinPaprikaTickers();
-  const paprikaIds = new Set(CRYPTO_IDS.map((id) => CRYPTO_PAPRIKA_MAP[id]).filter(Boolean));
+  const paprikaIds = CRYPTO_IDS.map((id) => CRYPTO_PAPRIKA_MAP[id]).filter(Boolean);
+  const data = await _fetchCoinPaprikaTickersById(paprikaIds);
   const reverseMap = Object.fromEntries(Object.entries(CRYPTO_PAPRIKA_MAP).map(([g, p]) => [p, g]));
-  return data.filter((t) => paprikaIds.has(t.id)).map((t) => ({
+  return data.map((t) => ({
     id: reverseMap[t.id] || t.id, current_price: t.quotes.USD.price,
     price_change_percentage_24h: t.quotes.USD.percent_change_24h,
     sparkline_in_7d: undefined, symbol: t.symbol.toLowerCase(), name: t.name,
@@ -2257,11 +2293,11 @@ const STABLECOIN_PAPRIKA_MAP = { tether: 'usdt-tether', 'usd-coin': 'usdc-usd-co
 const STABLECOIN_SEED_TTL = 7200; // 2h — 1h buffer over 5min cron cadence (was 1h = 55min buffer)
 
 async function fetchStablecoinCoinPaprika() {
-  const data = await _fetchCoinPaprikaTickers();
   const ids = STABLECOIN_IDS.split(',');
-  const paprikaIds = new Set(ids.map((id) => STABLECOIN_PAPRIKA_MAP[id]).filter(Boolean));
+  const paprikaIds = ids.map((id) => STABLECOIN_PAPRIKA_MAP[id]).filter(Boolean);
+  const data = await _fetchCoinPaprikaTickersById(paprikaIds);
   const reverseMap = Object.fromEntries(Object.entries(STABLECOIN_PAPRIKA_MAP).map(([g, p]) => [p, g]));
-  return data.filter((t) => paprikaIds.has(t.id)).map((t) => ({
+  return data.map((t) => ({
     id: reverseMap[t.id] || t.id, current_price: t.quotes.USD.price,
     price_change_percentage_24h: t.quotes.USD.percent_change_24h,
     price_change_percentage_7d_in_currency: t.quotes.USD.percent_change_7d,
@@ -2319,11 +2355,9 @@ async function seedCryptoSectors() {
   } catch (err) {
     console.warn(`[CryptoSectors] CoinGecko failed: ${err.message} — trying CoinPaprika`);
     try {
-      const paprika = await _fetchCoinPaprikaTickers();
-      data = paprika.filter((t) => {
-        const geckoId = Object.entries(CRYPTO_PAPRIKA_MAP).find(([, p]) => p === t.id)?.[0];
-        return geckoId && allIds.includes(geckoId);
-      }).map((t) => {
+      const paprikaIds = allIds.map((id) => CRYPTO_PAPRIKA_MAP[id]).filter(Boolean);
+      const paprika = await _fetchCoinPaprikaTickersById(paprikaIds);
+      data = paprika.map((t) => {
         const geckoId = Object.entries(CRYPTO_PAPRIKA_MAP).find(([, p]) => p === t.id)?.[0] || t.id;
         return { id: geckoId, price_change_percentage_24h: t.quotes?.USD?.percent_change_24h ?? 0 };
       });
@@ -2367,10 +2401,10 @@ function _mapTokens(ids, meta, byId) {
 }
 
 async function fetchTokenPanelsCoinPaprika(allIds) {
-  const data = await _fetchCoinPaprikaTickers();
-  const paprikaIds = new Set(allIds.map((id) => TOKEN_PANELS_PAPRIKA_MAP[id]).filter(Boolean));
+  const paprikaIds = allIds.map((id) => TOKEN_PANELS_PAPRIKA_MAP[id]).filter(Boolean);
+  const data = await _fetchCoinPaprikaTickersById(paprikaIds);
   const reverseMap = Object.fromEntries(Object.entries(TOKEN_PANELS_PAPRIKA_MAP).map(([g, p]) => [p, g]));
-  return data.filter((t) => paprikaIds.has(t.id)).map((t) => ({
+  return data.map((t) => ({
     id: reverseMap[t.id] || t.id,
     current_price: t.quotes.USD.price,
     price_change_percentage_24h: t.quotes.USD.percent_change_24h,

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2180,6 +2180,7 @@ const CRYPTO_SEED_TTL = 7200; // 2h — 1h buffer over 5min cron cadence (was 1h
 // that run in the same cycle can share overlap without fetching the full catalog.
 const _paprikaTickerCache = new Map();
 const _PAPRIKA_CACHE_MS = 5 * 60 * 1000;
+const _PAPRIKA_FETCH_CONCURRENCY = 4;
 
 async function _fetchCoinPaprikaTickerById(id) {
   const url = `https://api.coinpaprika.com/v1/tickers/${encodeURIComponent(id)}?quotes=USD`;
@@ -2211,11 +2212,11 @@ async function _fetchCoinPaprikaTickersById(paprikaIds) {
     }
   }
 
-  const results = await Promise.allSettled(misses.map(async (id) => {
+  const results = await allSettledWithConcurrency(misses, _PAPRIKA_FETCH_CONCURRENCY, async (id) => {
     const ticker = await _fetchCoinPaprikaTickerById(id);
     _paprikaTickerCache.set(id, { ticker, cachedAt: Date.now() });
     return ticker;
-  }));
+  });
 
   const failures = [];
   for (let i = 0; i < results.length; i += 1) {
@@ -2233,6 +2234,24 @@ async function _fetchCoinPaprikaTickersById(paprikaIds) {
   }
 
   return tickers;
+}
+
+async function allSettledWithConcurrency(items, concurrency, mapper) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+  await Promise.all(Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      try {
+        results[index] = { status: 'fulfilled', value: await mapper(items[index], index) };
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason };
+      }
+    }
+  }));
+  return results;
 }
 
 async function fetchCryptoCoinPaprika() {

--- a/scripts/seed-crypto-quotes.mjs
+++ b/scripts/seed-crypto-quotes.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, loadSharedConfig, CHROME_UA, runSeed, sleep } from './_seed-utils.mjs';
+import { loadEnvFile, loadSharedConfig, CHROME_UA, runSeed, sleep, fetchCoinPaprikaTickersById } from './_seed-utils.mjs';
 
 const cryptoConfig = loadSharedConfig('crypto.json');
 
@@ -55,17 +55,11 @@ async function fetchFromCoinGecko() {
 }
 
 async function fetchFromCoinPaprika() {
-  console.log('  [CoinPaprika] Fetching tickers...');
-  const resp = await fetch('https://api.coinpaprika.com/v1/tickers?quotes=USD', {
-    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (!resp.ok) throw new Error(`CoinPaprika HTTP ${resp.status}`);
-  const allTickers = await resp.json();
-  const paprikaIds = new Set(CRYPTO_IDS.map((id) => COINPAPRIKA_ID_MAP[id]).filter(Boolean));
+  console.log('  [CoinPaprika] Fetching configured tickers...');
+  const paprikaIds = CRYPTO_IDS.map((id) => COINPAPRIKA_ID_MAP[id]).filter(Boolean);
+  const tickers = await fetchCoinPaprikaTickersById(paprikaIds);
   const reverseMap = new Map(Object.entries(COINPAPRIKA_ID_MAP).map(([g, p]) => [p, g]));
-  return allTickers
-    .filter((t) => paprikaIds.has(t.id))
+  return tickers
     .map((t) => ({
       id: reverseMap.get(t.id) || t.id,
       current_price: t.quotes.USD.price,

--- a/scripts/seed-stablecoin-markets.mjs
+++ b/scripts/seed-stablecoin-markets.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, loadSharedConfig, CHROME_UA, runSeed, sleep } from './_seed-utils.mjs';
+import { loadEnvFile, loadSharedConfig, CHROME_UA, runSeed, sleep, fetchCoinPaprikaTickersById } from './_seed-utils.mjs';
 
 const stablecoinConfig = loadSharedConfig('stablecoins.json');
 
@@ -51,18 +51,12 @@ async function fetchFromCoinGecko() {
 async function fetchFromCoinPaprika() {
   console.log('  [CoinPaprika] Falling back to CoinPaprika...');
   const ids = STABLECOIN_IDS.split(',');
-  const paprikaIds = new Set(ids.map((id) => COINPAPRIKA_ID_MAP[id]).filter(Boolean));
-  if (paprikaIds.size === 0) throw new Error('No CoinPaprika ID mapping for stablecoins');
+  const paprikaIds = ids.map((id) => COINPAPRIKA_ID_MAP[id]).filter(Boolean);
+  if (paprikaIds.length === 0) throw new Error('No CoinPaprika ID mapping for stablecoins');
 
-  const resp = await fetch('https://api.coinpaprika.com/v1/tickers?quotes=USD', {
-    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (!resp.ok) throw new Error(`CoinPaprika HTTP ${resp.status}`);
-  const allTickers = await resp.json();
+  const tickers = await fetchCoinPaprikaTickersById(paprikaIds);
   const reverseMap = new Map(Object.entries(COINPAPRIKA_ID_MAP).map(([g, p]) => [p, g]));
-  return allTickers
-    .filter((t) => paprikaIds.has(t.id))
+  return tickers
     .map((t) => ({
       id: reverseMap.get(t.id) || t.id,
       current_price: t.quotes.USD.price,

--- a/scripts/seed-token-panels.mjs
+++ b/scripts/seed-token-panels.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, loadSharedConfig, CHROME_UA, runSeed, sleep } from './_seed-utils.mjs';
+import { loadEnvFile, loadSharedConfig, CHROME_UA, runSeed, sleep, fetchCoinPaprikaTickersById } from './_seed-utils.mjs';
 
 const defiConfig = loadSharedConfig('defi-tokens.json');
 const aiConfig = loadSharedConfig('ai-tokens.json');
@@ -46,16 +46,10 @@ async function fetchFromCoinGecko() {
 
 async function fetchFromCoinPaprika() {
   console.log('  [CoinPaprika] Falling back to CoinPaprika...');
-  const resp = await fetch('https://api.coinpaprika.com/v1/tickers?quotes=USD', {
-    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (!resp.ok) throw new Error(`CoinPaprika HTTP ${resp.status}`);
-  const allTickers = await resp.json();
-  const paprikaIds = new Set(ALL_IDS.map((id) => COINPAPRIKA_ID_MAP[id]).filter(Boolean));
+  const paprikaIds = ALL_IDS.map((id) => COINPAPRIKA_ID_MAP[id]).filter(Boolean);
+  const tickers = await fetchCoinPaprikaTickersById(paprikaIds);
   const reverseMap = new Map(Object.entries(COINPAPRIKA_ID_MAP).map(([g, p]) => [p, g]));
-  return allTickers
-    .filter((t) => paprikaIds.has(t.id))
+  return tickers
     .map((t) => ({
       id: reverseMap.get(t.id) || t.id,
       current_price: t.quotes.USD.price,

--- a/server/worldmonitor/market/v1/_shared.ts
+++ b/server/worldmonitor/market/v1/_shared.ts
@@ -381,20 +381,22 @@ interface CoinPaprikaTicker {
   };
 }
 
+const COINPAPRIKA_FETCH_CONCURRENCY = 4;
+
 async function fetchCoinPaprikaTickersById(
   paprikaIds: string[],
 ): Promise<CoinPaprikaTicker[]> {
   const ids = [...new Set(paprikaIds.filter((id): id is string => Boolean(id)))];
   if (ids.length === 0) return [];
 
-  const results = await Promise.allSettled(ids.map(async id => {
+  const results = await allSettledWithConcurrency(ids, COINPAPRIKA_FETCH_CONCURRENCY, async id => {
     const resp = await fetch(`https://api.coinpaprika.com/v1/tickers/${encodeURIComponent(id)}?quotes=USD`, {
       headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
       signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
     if (!resp.ok) throw new Error(`CoinPaprika ${id} HTTP ${resp.status}`);
     return resp.json() as Promise<CoinPaprikaTicker>;
-  }));
+  });
 
   const tickers: CoinPaprikaTicker[] = [];
   const failures: unknown[] = [];
@@ -412,6 +414,30 @@ async function fetchCoinPaprikaTickersById(
   }
 
   return tickers;
+}
+
+async function allSettledWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+
+  await Promise.all(Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      try {
+        results[index] = { status: 'fulfilled', value: await mapper(items[index]!, index) };
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason };
+      }
+    }
+  }));
+
+  return results;
 }
 
 export async function fetchCoinPaprikaMarkets(

--- a/server/worldmonitor/market/v1/_shared.ts
+++ b/server/worldmonitor/market/v1/_shared.ts
@@ -381,22 +381,29 @@ interface CoinPaprikaTicker {
   };
 }
 
+async function fetchCoinPaprikaTickersById(
+  paprikaIds: string[],
+): Promise<CoinPaprikaTicker[]> {
+  const ids = [...new Set(paprikaIds.filter(Boolean))];
+  if (ids.length === 0) return [];
+
+  return Promise.all(ids.map(async id => {
+    const resp = await fetch(`https://api.coinpaprika.com/v1/tickers/${encodeURIComponent(id)}?quotes=USD`, {
+      headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+    if (!resp.ok) throw new Error(`CoinPaprika ${id} HTTP ${resp.status}`);
+    return resp.json() as Promise<CoinPaprikaTicker>;
+  }));
+}
+
 export async function fetchCoinPaprikaMarkets(
   geckoIds: string[],
 ): Promise<CoinGeckoMarketItem[]> {
   const paprikaIds = geckoIds.map(id => COINPAPRIKA_ID_MAP[id]).filter(Boolean);
   if (paprikaIds.length === 0) throw new Error('No CoinPaprika ID mapping for requested coins');
 
-  const resp = await fetch('https://api.coinpaprika.com/v1/tickers?quotes=USD', {
-    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
-  });
-  if (!resp.ok) throw new Error(`CoinPaprika HTTP ${resp.status}`);
-
-  const allTickers: CoinPaprikaTicker[] = await resp.json();
-  const paprikaSet = new Set(paprikaIds);
-  const matched = allTickers.filter(t => paprikaSet.has(t.id));
-
+  const matched = await fetchCoinPaprikaTickersById(paprikaIds);
   const reverseMap = new Map(Object.entries(COINPAPRIKA_ID_MAP).map(([g, p]) => [p, g]));
 
   return matched.map(t => {

--- a/server/worldmonitor/market/v1/_shared.ts
+++ b/server/worldmonitor/market/v1/_shared.ts
@@ -384,10 +384,10 @@ interface CoinPaprikaTicker {
 async function fetchCoinPaprikaTickersById(
   paprikaIds: string[],
 ): Promise<CoinPaprikaTicker[]> {
-  const ids = [...new Set(paprikaIds.filter(Boolean))];
+  const ids = [...new Set(paprikaIds.filter((id): id is string => Boolean(id)))];
   if (ids.length === 0) return [];
 
-  return Promise.all(ids.map(async id => {
+  const results = await Promise.allSettled(ids.map(async id => {
     const resp = await fetch(`https://api.coinpaprika.com/v1/tickers/${encodeURIComponent(id)}?quotes=USD`, {
       headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
       signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
@@ -395,12 +395,29 @@ async function fetchCoinPaprikaTickersById(
     if (!resp.ok) throw new Error(`CoinPaprika ${id} HTTP ${resp.status}`);
     return resp.json() as Promise<CoinPaprikaTicker>;
   }));
+
+  const tickers: CoinPaprikaTicker[] = [];
+  const failures: unknown[] = [];
+  for (const [index, result] of results.entries()) {
+    if (result.status === 'fulfilled') {
+      tickers.push(result.value);
+    } else {
+      failures.push(result.reason);
+      console.warn(`[CoinPaprika] Skipping ${ids[index] ?? 'unknown'}:`, (result.reason as Error).message || result.reason);
+    }
+  }
+
+  if (tickers.length === 0 && failures.length > 0) {
+    throw new Error(`All ${failures.length} CoinPaprika ticker request(s) failed`);
+  }
+
+  return tickers;
 }
 
 export async function fetchCoinPaprikaMarkets(
   geckoIds: string[],
 ): Promise<CoinGeckoMarketItem[]> {
-  const paprikaIds = geckoIds.map(id => COINPAPRIKA_ID_MAP[id]).filter(Boolean);
+  const paprikaIds = geckoIds.map(id => COINPAPRIKA_ID_MAP[id]).filter((id): id is string => Boolean(id));
   if (paprikaIds.length === 0) throw new Error('No CoinPaprika ID mapping for requested coins');
 
   const matched = await fetchCoinPaprikaTickersById(paprikaIds);

--- a/tests/coinpaprika-edge-helper.test.mts
+++ b/tests/coinpaprika-edge-helper.test.mts
@@ -1,0 +1,98 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchCryptoMarkets } from '../server/worldmonitor/market/v1/_shared.ts';
+
+const originalFetch = globalThis.fetch;
+const originalWarn = console.warn;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  console.warn = originalWarn;
+});
+
+describe('market Edge CoinPaprika fallback', () => {
+  it('fetches only configured CoinPaprika ticker IDs after CoinGecko fails', async () => {
+    const seen: string[] = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      seen.push(url);
+
+      if (url.includes('api.coingecko.com')) {
+        return new Response('unavailable', { status: 503 });
+      }
+
+      const id = url.match(/tickers\/([^?]+)/)?.[1];
+      assert.ok(id, `expected targeted CoinPaprika ticker URL, got ${url}`);
+      return Response.json({
+        id,
+        name: id === 'btc-bitcoin' ? 'Bitcoin' : 'Ethereum',
+        symbol: id === 'btc-bitcoin' ? 'BTC' : 'ETH',
+        quotes: {
+          USD: {
+            price: id === 'btc-bitcoin' ? 100 : 50,
+            volume_24h: 123,
+            market_cap: 456,
+            percent_change_24h: 1.5,
+            percent_change_7d: 2.5,
+          },
+        },
+      });
+    }) as typeof fetch;
+
+    console.warn = () => {};
+
+    const markets = await fetchCryptoMarkets(['bitcoin', 'ethereum']);
+
+    assert.deepEqual(
+      seen.filter(url => url.includes('api.coinpaprika.com')),
+      [
+        'https://api.coinpaprika.com/v1/tickers/btc-bitcoin?quotes=USD',
+        'https://api.coinpaprika.com/v1/tickers/eth-ethereum?quotes=USD',
+      ],
+    );
+    assert.equal(seen.some(url => url === 'https://api.coinpaprika.com/v1/tickers?quotes=USD'), false);
+    assert.deepEqual(markets.map(item => item.id), ['bitcoin', 'ethereum']);
+    assert.equal(markets[0]?.current_price, 100);
+    assert.equal(markets[1]?.market_cap, 456);
+  });
+
+  it('preserves successful CoinPaprika rows when one requested ticker fails', async () => {
+    const warnings: unknown[] = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('api.coingecko.com')) {
+        return new Response('unavailable', { status: 503 });
+      }
+      const id = url.match(/tickers\/([^?]+)/)?.[1];
+      if (id === 'eth-ethereum') {
+        return new Response('missing', { status: 404 });
+      }
+      return Response.json({
+        id,
+        name: 'Bitcoin',
+        symbol: 'BTC',
+        quotes: {
+          USD: {
+            price: 100,
+            volume_24h: 123,
+            market_cap: 456,
+            percent_change_24h: 1.5,
+            percent_change_7d: 2.5,
+          },
+        },
+      });
+    }) as typeof fetch;
+
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+
+    const markets = await fetchCryptoMarkets(['bitcoin', 'ethereum']);
+
+    assert.deepEqual(markets.map(item => item.id), ['bitcoin']);
+    assert.equal(warnings.some(args => String(args[0]).includes('Skipping eth-ethereum')), true);
+  });
+});

--- a/tests/coinpaprika-edge-helper.test.mts
+++ b/tests/coinpaprika-edge-helper.test.mts
@@ -95,4 +95,56 @@ describe('market Edge CoinPaprika fallback', () => {
     assert.deepEqual(markets.map(item => item.id), ['bitcoin']);
     assert.equal(warnings.some(args => String(args[0]).includes('Skipping eth-ethereum')), true);
   });
+
+  it('bounds CoinPaprika fallback fanout for larger configured sets', async () => {
+    const ids = [
+      'bitcoin',
+      'ethereum',
+      'binancecoin',
+      'solana',
+      'ripple',
+      'cardano',
+      'dogecoin',
+      'tron',
+      'avalanche-2',
+      'chainlink',
+    ];
+    let activePaprika = 0;
+    let maxActivePaprika = 0;
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('api.coingecko.com')) {
+        return new Response('unavailable', { status: 503 });
+      }
+
+      activePaprika += 1;
+      maxActivePaprika = Math.max(maxActivePaprika, activePaprika);
+      await new Promise(resolve => setTimeout(resolve, 5));
+      activePaprika -= 1;
+
+      const id = url.match(/tickers\/([^?]+)/)?.[1] ?? 'unknown';
+      return Response.json({
+        id,
+        name: id,
+        symbol: id.slice(0, 3).toUpperCase(),
+        quotes: {
+          USD: {
+            price: 100,
+            volume_24h: 123,
+            market_cap: 456,
+            percent_change_24h: 1.5,
+            percent_change_7d: 2.5,
+          },
+        },
+      });
+    }) as typeof fetch;
+
+    console.warn = () => {};
+
+    const markets = await fetchCryptoMarkets(ids);
+
+    assert.equal(markets.length, ids.length);
+    assert.equal(maxActivePaprika, 4);
+  });
 });

--- a/tests/coinpaprika-targeted-fetch.test.mjs
+++ b/tests/coinpaprika-targeted-fetch.test.mjs
@@ -27,12 +27,63 @@ describe('fetchCoinPaprikaTickersById', () => {
     assert.equal(rows.length, 2);
   });
 
-  it('includes the ticker id in HTTP errors', async () => {
-    await assert.rejects(
-      fetchCoinPaprikaTickersById(['bad-token'], {
-        fetchFn: async () => ({ ok: false, status: 404 }),
-      }),
-      /CoinPaprika bad-token HTTP 404/,
-    );
+  it('keeps successful tickers when one configured id fails', async () => {
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (message) => warnings.push(message);
+    try {
+      const rows = await fetchCoinPaprikaTickersById(['btc-bitcoin', 'bad-token', 'eth-ethereum'], {
+        fetchFn: async (url) => {
+          const id = url.match(/tickers\/([^?]+)/)[1];
+          if (id === 'bad-token') return { ok: false, status: 404 };
+          return {
+            ok: true,
+            async json() {
+              return { id, quotes: { USD: { price: 1 } } };
+            },
+          };
+        },
+      });
+
+      assert.deepEqual(rows.map((row) => row.id), ['btc-bitcoin', 'eth-ethereum']);
+      assert.match(warnings[0], /CoinPaprika bad-token HTTP 404/);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it('merges custom headers without dropping default CoinPaprika headers', async () => {
+    const seen = [];
+    await fetchCoinPaprikaTickersById(['btc-bitcoin'], {
+      headers: { 'X-Test': '1' },
+      fetchFn: async (_url, options) => {
+        seen.push(options.headers);
+        return {
+          ok: true,
+          async json() {
+            return { id: 'btc-bitcoin', quotes: { USD: { price: 1 } } };
+          },
+        };
+      },
+    });
+
+    assert.equal(seen[0].Accept, 'application/json');
+    assert.equal(seen[0]['User-Agent'].includes('Chrome/'), true);
+    assert.equal(seen[0]['X-Test'], '1');
+  });
+
+  it('still fails when every configured ticker request fails', async () => {
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await assert.rejects(
+        fetchCoinPaprikaTickersById(['bad-token'], {
+          fetchFn: async () => ({ ok: false, status: 404 }),
+        }),
+        /All 1 CoinPaprika ticker request\(s\) failed/,
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 });

--- a/tests/coinpaprika-targeted-fetch.test.mjs
+++ b/tests/coinpaprika-targeted-fetch.test.mjs
@@ -73,6 +73,28 @@ describe('fetchCoinPaprikaTickersById', () => {
     assert.equal(seen[0]['X-Test'], '1');
   });
 
+  it('bounds per-id request fanout', async () => {
+    let active = 0;
+    let maxActive = 0;
+    await fetchCoinPaprikaTickersById(['a-a', 'b-b', 'c-c', 'd-d', 'e-e', 'f-f'], {
+      concurrency: 2,
+      fetchFn: async (url) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise(resolve => setTimeout(resolve, 5));
+        active -= 1;
+        return {
+          ok: true,
+          async json() {
+            return { id: url.match(/tickers\/([^?]+)/)[1], quotes: { USD: { price: 1 } } };
+          },
+        };
+      },
+    });
+
+    assert.equal(maxActive, 2);
+  });
+
   it('still fails when every configured ticker request fails', async () => {
     const originalWarn = console.warn;
     console.warn = () => {};
@@ -96,6 +118,7 @@ describe('ais-relay CoinPaprika fallback', () => {
     assert.doesNotMatch(src, /api\.coinpaprika\.com\/v1\/tickers\?quotes=USD/);
     assert.match(src, /api\.coinpaprika\.com\/v1\/tickers\/\$\{encodeURIComponent\(id\)\}\?quotes=USD/);
     assert.match(src, /async function _fetchCoinPaprikaTickersById\(paprikaIds\)/);
-    assert.match(src, /Promise\.allSettled\(misses\.map/);
+    assert.match(src, /const _PAPRIKA_FETCH_CONCURRENCY = 4/);
+    assert.match(src, /allSettledWithConcurrency\(misses, _PAPRIKA_FETCH_CONCURRENCY/);
   });
 });

--- a/tests/coinpaprika-targeted-fetch.test.mjs
+++ b/tests/coinpaprika-targeted-fetch.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 import { fetchCoinPaprikaTickersById } from '../scripts/_seed-utils.mjs';
 
@@ -85,5 +86,16 @@ describe('fetchCoinPaprikaTickersById', () => {
     } finally {
       console.warn = originalWarn;
     }
+  });
+});
+
+describe('ais-relay CoinPaprika fallback', () => {
+  it('does not fetch the full CoinPaprika ticker catalog in the primary market seed path', () => {
+    const src = readFileSync(new URL('../scripts/ais-relay.cjs', import.meta.url), 'utf8');
+
+    assert.doesNotMatch(src, /api\.coinpaprika\.com\/v1\/tickers\?quotes=USD/);
+    assert.match(src, /api\.coinpaprika\.com\/v1\/tickers\/\$\{encodeURIComponent\(id\)\}\?quotes=USD/);
+    assert.match(src, /async function _fetchCoinPaprikaTickersById\(paprikaIds\)/);
+    assert.match(src, /Promise\.allSettled\(misses\.map/);
   });
 });

--- a/tests/coinpaprika-targeted-fetch.test.mjs
+++ b/tests/coinpaprika-targeted-fetch.test.mjs
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchCoinPaprikaTickersById } from '../scripts/_seed-utils.mjs';
+
+describe('fetchCoinPaprikaTickersById', () => {
+  it('fetches one configured URL per unique ticker instead of the full catalog', async () => {
+    const seen = [];
+    const rows = await fetchCoinPaprikaTickersById(['btc-bitcoin', 'eth-ethereum', 'btc-bitcoin'], {
+      timeoutMs: 1234,
+      fetchFn: async (url, options) => {
+        seen.push({ url, options });
+        return {
+          ok: true,
+          async json() {
+            return { id: url.match(/tickers\/([^?]+)/)[1], quotes: { USD: { price: 1 } } };
+          },
+        };
+      },
+    });
+
+    assert.deepEqual(seen.map((entry) => entry.url), [
+      'https://api.coinpaprika.com/v1/tickers/btc-bitcoin?quotes=USD',
+      'https://api.coinpaprika.com/v1/tickers/eth-ethereum?quotes=USD',
+    ]);
+    assert.equal(seen[0].options.headers['User-Agent'].includes('Chrome/'), true);
+    assert.equal(rows.length, 2);
+  });
+
+  it('includes the ticker id in HTTP errors', async () => {
+    await assert.rejects(
+      fetchCoinPaprikaTickersById(['bad-token'], {
+        fetchFn: async () => ({ ok: false, status: 404 }),
+      }),
+      /CoinPaprika bad-token HTTP 404/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Replace full CoinPaprika `/v1/tickers?quotes=USD` fallback reads with per-ID `/v1/tickers/{id}?quotes=USD` requests for configured IDs.
- Share the targeted fetch helper across crypto, stablecoin, and token-panel seeders.
- Add a node:test regression covering URL selection, duplicate ID de-dupe, and HTTP error context.

Fixes #3528

## Verification
- `node --test tests/coinpaprika-targeted-fetch.test.mjs` ✅
- `node --check scripts/_seed-utils.mjs` ✅
- `node --check scripts/seed-crypto-quotes.mjs` ✅
- `node --check scripts/seed-stablecoin-markets.mjs` ✅
- `node --check scripts/seed-token-panels.mjs` ✅
- `git diff --check` ✅
