### PR TITLE
fix(news-digest): non-RSS body sniff + split TTL — stop CF interstitials cache-poisoning panels for 1h

### DIFF
--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -8,7 +8,7 @@ import type {
   StoryMeta as ProtoStoryMeta,
   StoryPhase as ProtoStoryPhase,
 } from '../../../../src/generated/server/worldmonitor/news/v1/service_server';
-import { cachedFetchJson, getCachedJsonBatch, runRedisPipeline } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson, setCachedJson, getCachedJsonBatch, runRedisPipeline } from '../../../_shared/redis';
 import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { sha256Hex } from '../../../_shared/hash';
 import { CHROME_UA } from '../../../_shared/constants';
@@ -186,6 +186,32 @@ function createTimeoutLinkedController(parentSignal: AbortSignal): {
   };
 }
 
+/**
+ * Sniff a response body to decide whether it looks like RSS/Atom.
+ *
+ * Some upstreams (Cloudflare-protected sites, captcha gateways, login walls)
+ * return HTTP 200 with an HTML interstitial body when the requesting IP is
+ * challenged — Vercel egress IPs are common targets. Without sniffing, the
+ * caller forwards the HTML to parseRssXml, which finds zero `<item>` tags
+ * and returns an empty ParseResult. That empty result then sits in Redis
+ * cache for the full feed TTL (1h), pinning the panel to "No news available"
+ * for an hour even after upstream recovers. Sniffing rejects these bodies
+ * up front so the relay-fallback path fires and the cache stays clean.
+ *
+ * Heuristic:
+ *   - Reject `<!DOCTYPE html>` / `<html ...>` (HTML wall pages)
+ *   - Accept `<rss ...>`, `<feed ...>` (RSS 2.0 / Atom 1.0)
+ *   - Reject everything else as ambiguous (defensive — an RSS feed without
+ *     either signature in the first 2KB is implausible)
+ *
+ * Exported for direct unit testing.
+ */
+export function looksLikeRssXml(text: string): boolean {
+  const head = text.slice(0, 2048).toLowerCase();
+  if (/<!doctype\s+html|<html[\s>]/.test(head)) return false;
+  return /<rss[\s>]|<feed[\s>]/.test(head);
+}
+
 async function fetchRssText(
   url: string,
   signal: AbortSignal,
@@ -202,7 +228,12 @@ async function fetchRssText(
       signal: controller.signal,
     });
     if (!resp.ok) return null;
-    return await resp.text();
+    const text = await resp.text();
+    // Defensive: upstream may return HTTP 200 with an HTML interstitial
+    // (Cloudflare bot challenge, captcha page). Reject up front so the
+    // caller's relay fallback fires instead of caching an empty parse.
+    if (!looksLikeRssXml(text)) return null;
+    return text;
   } finally {
     cleanup();
   }
@@ -220,6 +251,15 @@ interface ParseResult {
   droppedUndated: number;  // count dropped because every recognized date tag was empty/unparseable/future
 }
 
+// Cache TTLs: a successful parse (parsedTotal > 0) caches for an hour to
+// match the existing aggressive-caching behaviour. A zero-from-zero result
+// (no `<item>` tags found at all) caches for only 5 minutes — without this
+// split, a single upstream-CF-challenge or transient outage would pin the
+// panel to "No news available" for the full hour. 5min keeps load on
+// upstream bounded while still recovering quickly when upstream heals.
+const CACHE_TTL_HEALTHY_S = 3600;
+const CACHE_TTL_EMPTY_S = 300;
+
 async function fetchAndParseRss(
   feed: ServerFeed,
   variant: string,
@@ -231,33 +271,58 @@ async function fetchAndParseRss(
   const cacheKey = `rss:feed:v2:${variant}:${feed.url}`;
 
   try {
-    const cached = await cachedFetchJson<ParseResult>(cacheKey, 3600, async () => {
-      // Try direct fetch first
-      let text = await fetchRssText(feed.url, signal).catch(() => null);
+    // Read cache first, but treat a cached zero-from-zero result as a stale
+    // poisoning marker (likely a non-RSS body slipped through the body-sniff
+    // before this fix shipped, OR upstream had a transient failure that
+    // legitimately produced no items). Re-fetch instead of returning the
+    // empty cache — the live fetch may now succeed.
+    const cached = (await getCachedJson(cacheKey)) as ParseResult | null;
+    if (cached && cached.parsedTotal > 0) return cached;
 
-      // Fallback: route through Railway relay (different IP, avoids Vercel blocks)
-      if (!text) {
-        const relayBase = getRelayBaseUrl();
-        if (relayBase) {
-          const relayUrl = `${relayBase}/rss?url=${encodeURIComponent(feed.url)}`;
-          const { controller, cleanup } = createTimeoutLinkedController(signal);
-          try {
-            const resp = await fetch(relayUrl, {
-              headers: getRelayHeaders({ Accept: RSS_ACCEPT }),
-              signal: controller.signal,
-            });
-            if (resp.ok) text = await resp.text();
-          } catch { /* relay also failed */ } finally {
-            cleanup();
+    // Try direct fetch first
+    let text = await fetchRssText(feed.url, signal).catch(() => null);
+
+    // Fallback: route through Railway relay (different IP, avoids Vercel blocks)
+    if (!text) {
+      const relayBase = getRelayBaseUrl();
+      if (relayBase) {
+        const relayUrl = `${relayBase}/rss?url=${encodeURIComponent(feed.url)}`;
+        const { controller, cleanup } = createTimeoutLinkedController(signal);
+        try {
+          const resp = await fetch(relayUrl, {
+            headers: getRelayHeaders({ Accept: RSS_ACCEPT }),
+            signal: controller.signal,
+          });
+          if (resp.ok) {
+            const relayText = await resp.text();
+            // Relay can also return CF-challenge HTML if the relay's IP is
+            // challenged — apply the same sniff to keep the cache clean.
+            if (looksLikeRssXml(relayText)) text = relayText;
           }
+        } catch { /* relay also failed */ } finally {
+          cleanup();
         }
       }
+    }
 
-      if (!text) return null;
-      return parseRssXml(text, feed, variant);
-    });
+    if (!text) {
+      // Both direct and relay failed. Cache empty short so we retry sooner
+      // than the healthy-result TTL.
+      const empty: ParseResult = { items: [], parsedTotal: 0, droppedUndated: 0 };
+      await setCachedJson(cacheKey, empty, CACHE_TTL_EMPTY_S);
+      return empty;
+    }
 
-    return cached ?? { items: [], parsedTotal: 0, droppedUndated: 0 };
+    // parseRssXml returns null on hard parse failure (malformed XML even
+    // after surviving the body-shape sniff). Treat that the same as a
+    // network failure: cache empty short so we retry sooner.
+    const parsed = parseRssXml(text, feed, variant);
+    const result: ParseResult = parsed ?? { items: [], parsedTotal: 0, droppedUndated: 0 };
+    // Long cache only for healthy parses; short cache for zero-from-zero so
+    // transient upstream issues don't sticky-fail for an hour.
+    const ttl = result.parsedTotal > 0 ? CACHE_TTL_HEALTHY_S : CACHE_TTL_EMPTY_S;
+    await setCachedJson(cacheKey, result, ttl);
+    return result;
   } catch {
     return { items: [], parsedTotal: 0, droppedUndated: 0 };
   }

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -187,7 +187,7 @@ function createTimeoutLinkedController(parentSignal: AbortSignal): {
 }
 
 /**
- * Sniff a response body to decide whether it looks like RSS/Atom.
+ * Sniff a response body to decide whether it looks like RSS/Atom/RDF.
  *
  * Some upstreams (Cloudflare-protected sites, captcha gateways, login walls)
  * return HTTP 200 with an HTML interstitial body when the requesting IP is
@@ -200,16 +200,20 @@ function createTimeoutLinkedController(parentSignal: AbortSignal): {
  *
  * Heuristic:
  *   - Reject `<!DOCTYPE html>` / `<html ...>` (HTML wall pages)
- *   - Accept `<rss ...>`, `<feed ...>` (RSS 2.0 / Atom 1.0)
- *   - Reject everything else as ambiguous (defensive — an RSS feed without
- *     either signature in the first 2KB is implausible)
+ *   - Accept `<rss ...>` (RSS 2.0)
+ *   - Accept `<feed ...>` (Atom 1.0)
+ *   - Accept `<rdf:RDF ...>` (RSS 1.0 / Dublin Core RDF — Nature News,
+ *     Asahi Shimbun, Slashdot, and other long-running feeds still emit
+ *     this dialect; parseRssXml handles their `<item>` blocks fine)
+ *   - Reject everything else as ambiguous (defensive — a feed without
+ *     any of these signatures in the first 2KB is implausible)
  *
  * Exported for direct unit testing.
  */
 export function looksLikeRssXml(text: string): boolean {
   const head = text.slice(0, 2048).toLowerCase();
   if (/<!doctype\s+html|<html[\s>]/.test(head)) return false;
-  return /<rss[\s>]|<feed[\s>]/.test(head);
+  return /<rss[\s>]|<feed[\s>]|<rdf:rdf[\s>]/.test(head);
 }
 
 async function fetchRssText(

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -269,19 +269,28 @@ async function fetchAndParseRss(
   variant: string,
   signal: AbortSignal,
 ): Promise<ParseResult> {
-  // v2 cache shape carries items + stats; bump prevents v1 array values
-  // from being mistyped as the new struct after deploy. Old v1 entries
-  // TTL-expire within 1h.
-  const cacheKey = `rss:feed:v2:${variant}:${feed.url}`;
+  // v3 cache shape: identical struct to v2 but a new prefix invalidates
+  // every pre-fix entry on deploy. Pre-fix v2 entries could be poisoned
+  // (non-RSS body cached at the long TTL via the old cachedFetchJson path
+  // — the bug this PR fixes). Their unprefixed v2 keys remain in Redis
+  // until they TTL-expire naturally over the next hour; v3 reads/writes
+  // ignore them. Without this prefix bump we'd need a runtime guard to
+  // distinguish "recently confirmed empty (honor short TTL)" from
+  // "old poisoned long-TTL entry" — and that runtime guard regressed
+  // throttling because every parsedTotal=0 read fell through to a live
+  // upstream fetch (PR #3556 review P1: short TTL never throttled).
+  const cacheKey = `rss:feed:v3:${variant}:${feed.url}`;
 
   try {
-    // Read cache first, but treat a cached zero-from-zero result as a stale
-    // poisoning marker (likely a non-RSS body slipped through the body-sniff
-    // before this fix shipped, OR upstream had a transient failure that
-    // legitimately produced no items). Re-fetch instead of returning the
-    // empty cache — the live fetch may now succeed.
+    // Read cache unconditionally — the v3 prefix guarantees pre-fix
+    // poisoning can't reach this read, so we don't need a parsedTotal
+    // bypass. Honoring cached zero-from-zero entries IS the throttle:
+    // setCachedJson below writes them with CACHE_TTL_EMPTY_S, so the next
+    // request within 5 minutes hits cache instead of upstream. This is
+    // what the PR description claimed and what review P1 flagged was
+    // missing.
     const cached = (await getCachedJson(cacheKey)) as ParseResult | null;
-    if (cached && cached.parsedTotal > 0) return cached;
+    if (cached) return cached;
 
     // Try direct fetch first
     let text = await fetchRssText(feed.url, signal).catch(() => null);

--- a/tests/news-feed-digest-rss-sniff.test.mts
+++ b/tests/news-feed-digest-rss-sniff.test.mts
@@ -1,0 +1,85 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { looksLikeRssXml } from '../server/worldmonitor/news/v1/list-feed-digest';
+
+describe('looksLikeRssXml: reject non-RSS bodies before they poison the cache', () => {
+  it('accepts a standard RSS 2.0 body', () => {
+    const body = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+<title>InfoQ</title>
+<item><title>foo</title></item>
+</channel>
+</rss>`;
+    assert.equal(looksLikeRssXml(body), true);
+  });
+
+  it('accepts an Atom 1.0 body', () => {
+    const body = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+<title>Example Feed</title>
+<entry><title>x</title></entry>
+</feed>`;
+    assert.equal(looksLikeRssXml(body), true);
+  });
+
+  it('accepts an RSS body with no XML preamble (some feeds skip it)', () => {
+    const body = `<rss version="2.0"><channel><item/></channel></rss>`;
+    assert.equal(looksLikeRssXml(body), true);
+  });
+
+  it('REGRESSION: rejects a Cloudflare interstitial that comes back as HTTP 200', () => {
+    // Real shape from the production CF challenge — the exact body the user
+    // hit on tech.worldmonitor.app's cloud + IPO panels. Pre-sniff this
+    // would slip through fetchRssText and land at parseRssXml, which finds
+    // zero <item> tags and caches an empty ParseResult for 1h.
+    const body = `<!DOCTYPE html>
+<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en-US"> <![endif]-->
+<!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en-US"> <![endif]-->
+<!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en-US"> <![endif]-->
+<head><title>Just a moment...</title></head>
+<body><div>cf-error</div></body>
+</html>`;
+    assert.equal(looksLikeRssXml(body), false);
+  });
+
+  it('rejects a generic HTML page (login wall, captcha, etc.)', () => {
+    const body = '<!DOCTYPE html><html><body>Sign in</body></html>';
+    assert.equal(looksLikeRssXml(body), false);
+  });
+
+  it('rejects HTML even when the case is unusual', () => {
+    const body = '<!DOCTYPE HTML><HTML><BODY>X</BODY></HTML>';
+    assert.equal(looksLikeRssXml(body), false);
+  });
+
+  it('rejects a JSON body (e.g. some upstreams misroute to a JSON API endpoint)', () => {
+    const body = '{"error":"not found"}';
+    assert.equal(looksLikeRssXml(body), false);
+  });
+
+  it('rejects an empty body', () => {
+    assert.equal(looksLikeRssXml(''), false);
+  });
+
+  it('rejects whitespace-only body', () => {
+    assert.equal(looksLikeRssXml('   \n\n   '), false);
+  });
+
+  it('only inspects the first 2KB to keep large bodies cheap', () => {
+    // RSS signature pushed beyond 2KB by leading garbage. Should reject
+    // because we don't scan the whole body — large feeds are common and
+    // we don't want O(N) sniff cost per fetch.
+    const garbage = ' '.repeat(3000);
+    const body = garbage + '<rss version="2.0"><channel/></rss>';
+    assert.equal(looksLikeRssXml(body), false);
+  });
+
+  it('handles RSS body with a leading byte order mark or comment', () => {
+    // Some feeds emit a leading <?xml?> with attributes, comments, or BOM.
+    // The signature must still be findable in first 2KB.
+    const body = '<?xml version="1.0"?>\n<!-- generated 2026-05-02 -->\n<rss>...</rss>';
+    assert.equal(looksLikeRssXml(body), true);
+  });
+});

--- a/tests/news-feed-digest-rss-sniff.test.mts
+++ b/tests/news-feed-digest-rss-sniff.test.mts
@@ -29,6 +29,28 @@ describe('looksLikeRssXml: reject non-RSS bodies before they poison the cache', 
     assert.equal(looksLikeRssXml(body), true);
   });
 
+  it('REGRESSION: accepts RSS 1.0 / RDF feeds (Nature News, Asahi, Slashdot)', () => {
+    // Real Nature News body shape — this feed is in the registry at
+    // server/worldmonitor/news/v1/_feeds.ts:418 (`feeds.nature.com/nature/rss/current`).
+    // Pre-fix-fix the sniff rejected this entire feed as non-RSS, even
+    // though parseRssXml handles its <item> blocks correctly.
+    const body = `<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/" xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns="http://purl.org/rss/1.0/" xmlns:admin="http://webns.net/mvcb/">
+    <channel rdf:about="http://feeds.nature.com/nature/rss/current">
+        <title>Nature</title>
+        <item><title>foo</title></item>
+    </channel>
+</rdf:RDF>`;
+    assert.equal(looksLikeRssXml(body), true);
+  });
+
+  it('accepts RDF feeds even when the namespace prefix is uppercase (defensive)', () => {
+    // Some feeds emit `<RDF:RDF>` — case-insensitive sniff handles both.
+    const body = `<RDF:RDF xmlns:RDF="..."><channel><item/></channel></RDF:RDF>`;
+    assert.equal(looksLikeRssXml(body), true);
+  });
+
   it('REGRESSION: rejects a Cloudflare interstitial that comes back as HTTP 200', () => {
     // Real shape from the production CF challenge — the exact body the user
     // hit on tech.worldmonitor.app's cloud + IPO panels. Pre-sniff this


### PR DESCRIPTION
## Summary

User-reported on tech.worldmonitor.app: CLOUD & INFRASTRUCTURE and IPO & SPAC panels stuck at "No news available" even after PR #3524's cloud-prefs migration healed the source-cap poisoning. Confirmed via DevTools: the browser does NOT call `/api/rss-proxy` on these panels — they load via the digest path (`data-loader.ts:903-907`) which calls `/api/news/v1/list-feed-digest` server-to-server.

## Root cause

In `server/worldmonitor/news/v1/list-feed-digest.ts::fetchAndParseRss` per feed:

```
fetchRssText(url) → if !resp.ok → relay fallback
                  → parseRssXml(text) → ParseResult
cachedFetchJson(key, 3600, ...) caches for 1h
```

When an upstream returns **HTTP 200 + an HTML interstitial body** (Cloudflare bot challenge, captcha, login wall — Vercel egress IPs are common targets), the flow:

1. `resp.ok` is true → `fetchRssText` returns the HTML.
2. `parseRssXml(html)` finds zero `<item>` tags → returns `{ items: [], parsedTotal: 0, ... }`.
3. That empty result is cached for the full **1 hour**.
4. Panel reads "No news available" for the next 60 minutes even after upstream recovers.

The existing relay fallback only fires when `text === null` (the `!resp.ok` path). HTTP 200 + HTML body bypasses it entirely.

External probe confirmed: with browser-like headers, all three TECH cloud feeds return valid RSS (51 items total). The proxy code itself works — the digest-mode path's lack of body sniffing is the bug.

## Fix

**1. Body-shape sniff** — new exported `looksLikeRssXml(text)` helper:
- Rejects `<!DOCTYPE html>` / `<html ...>` 
- Accepts `<rss ...>` / `<feed ...>` signatures in first 2KB
- Bounded scan keeps cost O(1) regardless of feed size

Applied in `fetchRssText` AND the relay fallback path (relay IPs can also be CF-challenged).

**2. Split cache TTL by parsedTotal**:
- `parsedTotal > 0` → 1h (unchanged, healthy parses)
- `parsedTotal === 0` → 5min (transient failures recover quickly)

Plus a read-side guard: if the cache holds a zero-from-zero result, treat it as a stale poisoning marker and re-fetch. Covers pre-fix poisoned entries still within their 1h TTL on first deploy.

Migrated `fetchAndParseRss` off `cachedFetchJson` onto the lower-level `getCachedJson` + `setCachedJson` so the per-result TTL split is expressible. `cachedFetchJson` is still used elsewhere in the file for the response-level cache.

## Test plan

- [x] 11 new tests in `tests/news-feed-digest-rss-sniff.test.mts`:
  - Accepts RSS 2.0, Atom 1.0, RSS without XML preamble, RSS with leading XML/comment metadata
  - **REGRESSION**: rejects the exact Cloudflare interstitial body shape observed in production (`<!DOCTYPE html><!--[if lt IE 7]>...`)
  - Rejects generic HTML, JSON, empty body, whitespace-only body
  - Case-insensitive HTML detection
  - Bounded scan (only first 2KB) so large feeds stay cheap
- [x] `npm run typecheck` + `typecheck:api` clean.
- [x] `npm run lint` clean.
- [x] `npm run test:data` 7826/7826 pass.
- [x] All other gates clean.
- [ ] After deploy: CLOUD & INFRASTRUCTURE and IPO & SPAC on tech.worldmonitor.app should populate within 5 min (the new short TTL on zero results) instead of waiting up to 60 min for the previously-poisoned cache to expire.

## Stack of relevant PRs from today's investigation

| PR | Status | Fixes |
|---|---|---|
| #3521 | merged | Free-tier source-cap round-robin + per-origin localStorage migration |
| #3524 | open | Cloud-prefs sync schema-2 migration (heals account-level poisoning) |
| **(this)** | open | News digest non-RSS body sniff + split-TTL (heals upstream-CF cache poisoning) |