### PR TITLE
fix(security): replace forgeable header trust with HMAC session token (#3541)

### DIFF
--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -23,8 +23,15 @@ function isValidEnterpriseKey(key) {
 // curl in one line. The previous Referer-origin fallback and Origin-pattern
 // no-key trust path are both gone. Browsers now authenticate via:
 //   1. A short-lived wms_-prefixed session token (HMAC-signed by /api/wm-session).
+//      Kind: 'session'. Anonymous; satisfies basic gate, but downstream
+//      entitlement / premium checks must STILL run (a session token is freely
+//      mintable by anyone who can hit /api/wm-session — it is NOT proof of a
+//      paying user). Rejected when forceKey=true.
 //   2. A wm_-prefixed user API key (validated against the user-key table by gateway).
-//   3. An enterprise key (WORLDMONITOR_VALID_KEYS).
+//      Kind: 'user'. Returns required:true/valid:false here so the gateway's
+//      fallback at server/gateway.ts:~440 triggers validateUserApiKey().
+//   3. An enterprise key (WORLDMONITOR_VALID_KEYS). Kind: 'enterprise'. The
+//      ONLY kind that bypasses entitlement checks (operator-issued).
 // Tauri desktop continues to authenticate via enterprise key.
 //
 // Async because session validation uses Web Crypto (crypto.subtle.sign).
@@ -38,21 +45,28 @@ export async function validateApiKey(req, options = {}) {
   if (isDesktopOrigin(origin)) {
     if (!key) return { valid: false, required: true, error: 'API key required for desktop access' };
     if (!isValidEnterpriseKey(key)) return { valid: false, required: true, error: 'Invalid API key' };
-    return { valid: true, required: true };
+    return { valid: true, required: true, kind: 'enterprise' };
   }
 
   // Browser anonymous session: HMAC-signed token from /api/wm-session.
   // Validation is purely cryptographic — no DB lookup, no header trust.
   if (isSessionTokenShape(key)) {
+    // Anonymous session tokens are NOT proof of any specific user identity
+    // — anyone can mint one via POST /api/wm-session. Reject when the caller
+    // demands a "real" key (premium / tier-gated endpoints set forceKey=true
+    // exactly because they need user-bound auth or a Pro-grade Bearer JWT).
+    if (forceKey) {
+      return { valid: false, required: true, error: 'Pro authentication required' };
+    }
     if (await validateSessionToken(key)) {
-      return { valid: true, required: false };
+      return { valid: true, required: false, kind: 'session' };
     }
     return { valid: false, required: true, error: 'Invalid session token' };
   }
 
   // wm_-prefixed user API keys — gateway re-validates against the user-key
   // table. We must return required:true / valid:false for the gateway's
-  // fallback at server/gateway.ts:440 to trigger validateUserApiKey().
+  // fallback at server/gateway.ts:~440 to trigger validateUserApiKey().
   if (key && key.startsWith('wm_')) {
     return { valid: false, required: true, error: 'User API key requires gateway validation' };
   }
@@ -60,7 +74,7 @@ export async function validateApiKey(req, options = {}) {
   // Enterprise key (WORLDMONITOR_VALID_KEYS).
   if (key) {
     if (!isValidEnterpriseKey(key)) return { valid: false, required: true, error: 'Invalid API key' };
-    return { valid: true, required: true };
+    return { valid: true, required: true, kind: 'enterprise' };
   }
 
   // No credentials at all.

--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -1,3 +1,5 @@
+import { isSessionTokenShape, validateSessionToken } from './_session.js';
+
 const DESKTOP_ORIGIN_PATTERNS = [
   /^https?:\/\/tauri\.localhost(:\d+)?$/,
   /^https?:\/\/[a-z0-9-]+\.tauri\.localhost(:\d+)?$/i,
@@ -5,66 +7,62 @@ const DESKTOP_ORIGIN_PATTERNS = [
   /^asset:\/\/localhost$/,
 ];
 
-const BROWSER_ORIGIN_PATTERNS = [
-  /^https:\/\/(.*\.)?worldmonitor\.app$/,
-  /^https:\/\/worldmonitor-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,
-  ...(process.env.NODE_ENV === 'production' ? [] : [
-    /^https?:\/\/localhost(:\d+)?$/,
-    /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
-  ]),
-];
-
 function isDesktopOrigin(origin) {
   return Boolean(origin) && DESKTOP_ORIGIN_PATTERNS.some(p => p.test(origin));
 }
 
-function isTrustedBrowserOrigin(origin) {
-  return Boolean(origin) && BROWSER_ORIGIN_PATTERNS.some(p => p.test(origin));
+function isValidEnterpriseKey(key) {
+  if (!key) return false;
+  const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);
+  return validKeys.includes(key);
 }
 
-function extractOriginFromReferer(referer) {
-  if (!referer) return '';
-  try {
-    return new URL(referer).origin;
-  } catch {
-    return '';
-  }
-}
-
-export function validateApiKey(req, options = {}) {
+// Note: HTTP headers like Origin / Referer / Sec-Fetch-Site are entirely
+// client-controlled at the wire level (see issue #3541 / closed PR #3554).
+// Trusting any of them as a "this is a real browser" signal is forgeable by
+// curl in one line. The previous Referer-origin fallback and Origin-pattern
+// no-key trust path are both gone. Browsers now authenticate via:
+//   1. A short-lived wms_-prefixed session token (HMAC-signed by /api/wm-session).
+//   2. A wm_-prefixed user API key (validated against the user-key table by gateway).
+//   3. An enterprise key (WORLDMONITOR_VALID_KEYS).
+// Tauri desktop continues to authenticate via enterprise key.
+//
+// Async because session validation uses Web Crypto (crypto.subtle.sign).
+// All call sites await this — see grep for migration history.
+export async function validateApiKey(req, options = {}) {
   const forceKey = options.forceKey === true;
   const key = req.headers.get('X-WorldMonitor-Key') || req.headers.get('X-Api-Key');
-  // Same-origin browser requests don't send Origin (per CORS spec).
-  // Fall back to Referer to identify trusted same-origin callers.
-  const origin = req.headers.get('Origin') || extractOriginFromReferer(req.headers.get('Referer')) || '';
+  const origin = req.headers.get('Origin') || '';
 
-  // Desktop app — always require API key
+  // Desktop app — always require an enterprise key.
   if (isDesktopOrigin(origin)) {
     if (!key) return { valid: false, required: true, error: 'API key required for desktop access' };
-    const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);
-    if (!validKeys.includes(key)) return { valid: false, required: true, error: 'Invalid API key' };
+    if (!isValidEnterpriseKey(key)) return { valid: false, required: true, error: 'Invalid API key' };
     return { valid: true, required: true };
   }
 
-  // Trusted browser origin (worldmonitor.app, Vercel previews, localhost dev) — no key needed
-  if (isTrustedBrowserOrigin(origin)) {
-    if (forceKey && !key) {
-      return { valid: false, required: true, error: 'API key required' };
+  // Browser anonymous session: HMAC-signed token from /api/wm-session.
+  // Validation is purely cryptographic — no DB lookup, no header trust.
+  if (isSessionTokenShape(key)) {
+    if (await validateSessionToken(key)) {
+      return { valid: true, required: false };
     }
-    if (key) {
-      const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);
-      if (!validKeys.includes(key)) return { valid: false, required: true, error: 'Invalid API key' };
-    }
-    return { valid: true, required: forceKey };
+    return { valid: false, required: true, error: 'Invalid session token' };
   }
 
-  // Explicit key provided from unknown origin — validate it
+  // wm_-prefixed user API keys — gateway re-validates against the user-key
+  // table. We must return required:true / valid:false for the gateway's
+  // fallback at server/gateway.ts:440 to trigger validateUserApiKey().
+  if (key && key.startsWith('wm_')) {
+    return { valid: false, required: true, error: 'User API key requires gateway validation' };
+  }
+
+  // Enterprise key (WORLDMONITOR_VALID_KEYS).
   if (key) {
-    const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);
-    if (!validKeys.includes(key)) return { valid: false, required: true, error: 'Invalid API key' };
+    if (!isValidEnterpriseKey(key)) return { valid: false, required: true, error: 'Invalid API key' };
     return { valid: true, required: true };
   }
 
-  // No origin, no key — require API key (blocks unauthenticated curl/scripts)
+  // No credentials at all.
   return { valid: false, required: true, error: 'API key required' };
 }

--- a/api/_api-key.test.mjs
+++ b/api/_api-key.test.mjs
@@ -57,11 +57,38 @@ test('#3541: Sec-Fetch-Site: none alone is rejected', async () => {
 
 // ── Anonymous browser session token (the new trust path) ────────────────────
 
-test('valid wms_ session token from any origin is accepted', async () => {
+test('valid wms_ session token from any origin is accepted (forceKey=false)', async () => {
   const { token } = await issueSessionToken();
   const r = await validateApiKey(makeReq({ key: token }));
   assert.equal(r.valid, true);
   assert.equal(r.required, false);
+  assert.equal(r.kind, 'session', 'must tag as session — gateway uses kind to decide entitlement bypass');
+});
+
+test('PR #3557 review: wms_ session token is REJECTED when forceKey=true (premium endpoints)', async () => {
+  // wms_ tokens are anonymous and freely mintable via /api/wm-session — they
+  // are NOT proof of a paying user. forceKey=true means the route demands a
+  // user-bound credential (Pro Bearer JWT, wm_ user key, or enterprise key).
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({ key: token }), { forceKey: true });
+  assert.equal(r.valid, false);
+  assert.equal(r.required, true);
+  assert.match(r.error, /Pro authentication/);
+});
+
+test('PR #3557 review: wms_ result must NOT carry kind=enterprise (gateway entitlement-bypass anti-regression)', async () => {
+  // Gateway skips entitlement check ONLY for kind:'enterprise'. If a future
+  // refactor mislabels wms_ as enterprise, anonymous tokens silently unlock
+  // premium endpoints. Lock the contract here.
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({ key: token }));
+  assert.notEqual(r.kind, 'enterprise');
+});
+
+test('enterprise key carries kind=enterprise (the only key kind that bypasses entitlement)', async () => {
+  const r = await validateApiKey(makeReq({ key: ENTERPRISE_KEY }));
+  assert.equal(r.valid, true);
+  assert.equal(r.kind, 'enterprise');
 });
 
 test('valid wms_ session token works even when Origin is also forged (not redundant — no privilege escalation)', async () => {
@@ -136,11 +163,7 @@ test('completely unauthenticated request is rejected', async () => {
 
 // ── forceKey option ─────────────────────────────────────────────────────────
 
-test('forceKey=true rejects requests without any key, even with valid wms_ token (sanity: forceKey applies to all paths in the original code; documenting current behavior)', async () => {
-  // In the new design, wms_ token IS a key (it goes through the X-WorldMonitor-Key
-  // header and validateSessionToken). So forceKey=true with wms_ accepts. This
-  // test documents that.
-  const { token } = await issueSessionToken();
-  const r = await validateApiKey(makeReq({ key: token }), { forceKey: true });
-  assert.equal(r.valid, true);
-});
+// forceKey=true behavior is exercised above:
+//   - wms_ token + forceKey=true → REJECTED (PR #3557 review fix)
+//   - wms_ token + forceKey=false → accepted
+//   - enterprise key + forceKey=true → accepted (covered by enterprise tests)

--- a/api/_api-key.test.mjs
+++ b/api/_api-key.test.mjs
@@ -1,0 +1,146 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+const SECRET = 'test-secret-must-be-at-least-32-chars-long-xxx';
+const ENTERPRISE_KEY = 'enterprise-test-key-123';
+process.env.WM_SESSION_SECRET = SECRET;
+process.env.WORLDMONITOR_VALID_KEYS = ENTERPRISE_KEY;
+
+const { validateApiKey } = await import('./_api-key.js');
+const { issueSessionToken } = await import('./_session.js');
+
+function makeReq({ origin, referer, secFetchSite, key } = {}) {
+  const headers = new Headers();
+  if (origin) headers.set('origin', origin);
+  if (referer) headers.set('referer', referer);
+  if (secFetchSite) headers.set('sec-fetch-site', secFetchSite);
+  if (key) headers.set('x-worldmonitor-key', key);
+  return new Request('https://api.worldmonitor.app/api/test', { headers });
+}
+
+// ── #3541 regression: header-only signals must NEVER pass ──────────────────
+
+test('#3541: forged Referer alone is rejected', async () => {
+  const r = await validateApiKey(makeReq({ referer: 'https://worldmonitor.app/' }));
+  assert.equal(r.valid, false);
+  assert.equal(r.required, true);
+});
+
+test('#3541: forged Sec-Fetch-Site: same-origin alone is rejected (this was the closed-PR bug)', async () => {
+  const r = await validateApiKey(makeReq({ secFetchSite: 'same-origin' }));
+  assert.equal(r.valid, false);
+});
+
+test('#3541: forged Origin: https://worldmonitor.app alone is rejected (no key, no session)', async () => {
+  const r = await validateApiKey(makeReq({ origin: 'https://worldmonitor.app' }));
+  assert.equal(r.valid, false);
+});
+
+test('#3541: combined forged Origin + Sec-Fetch-Site + Referer all together is still rejected', async () => {
+  const r = await validateApiKey(makeReq({
+    origin: 'https://worldmonitor.app',
+    referer: 'https://worldmonitor.app/',
+    secFetchSite: 'same-origin',
+  }));
+  assert.equal(r.valid, false);
+});
+
+test('#3541: Sec-Fetch-Site: cross-site alone is rejected', async () => {
+  const r = await validateApiKey(makeReq({ secFetchSite: 'cross-site' }));
+  assert.equal(r.valid, false);
+});
+
+test('#3541: Sec-Fetch-Site: none alone is rejected', async () => {
+  const r = await validateApiKey(makeReq({ secFetchSite: 'none' }));
+  assert.equal(r.valid, false);
+});
+
+// ── Anonymous browser session token (the new trust path) ────────────────────
+
+test('valid wms_ session token from any origin is accepted', async () => {
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({ key: token }));
+  assert.equal(r.valid, true);
+  assert.equal(r.required, false);
+});
+
+test('valid wms_ session token works even when Origin is also forged (not redundant — no privilege escalation)', async () => {
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({ origin: 'https://evil.example.com', key: token }));
+  assert.equal(r.valid, true);
+});
+
+test('tampered wms_ token is rejected', async () => {
+  const { token } = await issueSessionToken();
+  const tampered = token.slice(0, -1) + (token.slice(-1) === 'A' ? 'B' : 'A');
+  const r = await validateApiKey(makeReq({ key: tampered }));
+  assert.equal(r.valid, false);
+  assert.equal(r.error, 'Invalid session token');
+});
+
+test('garbage wms_ shape is rejected', async () => {
+  const r = await validateApiKey(makeReq({ key: 'wms_garbage' }));
+  assert.equal(r.valid, false);
+});
+
+// ── Enterprise key (WORLDMONITOR_VALID_KEYS) ────────────────────────────────
+
+test('valid enterprise key is accepted from any origin', async () => {
+  const r = await validateApiKey(makeReq({ origin: 'https://evil.example.com', key: ENTERPRISE_KEY }));
+  assert.equal(r.valid, true);
+  assert.equal(r.required, true);
+});
+
+test('invalid enterprise-shape key is rejected', async () => {
+  const r = await validateApiKey(makeReq({ key: 'random-string' }));
+  assert.equal(r.valid, false);
+});
+
+// ── User API key (wm_-prefix) — gateway handles validation ──────────────────
+
+test('wm_-prefixed user key returns required:true / valid:false so gateway can fall back', async () => {
+  // Gateway code at server/gateway.ts:440 does:
+  //   if (keyCheck.required && !keyCheck.valid && wmKey.startsWith('wm_')) { ...validateUserApiKey... }
+  // So validateApiKey must return that exact shape for wm_ keys to trigger the fallback.
+  const r = await validateApiKey(makeReq({ key: 'wm_user_abc123' }));
+  assert.equal(r.required, true);
+  assert.equal(r.valid, false);
+});
+
+// ── Desktop (Tauri) — always requires enterprise key ────────────────────────
+
+test('desktop Tauri origin without key is rejected', async () => {
+  const r = await validateApiKey(makeReq({ origin: 'tauri://localhost' }));
+  assert.equal(r.valid, false);
+  assert.equal(r.error, 'API key required for desktop access');
+});
+
+test('desktop Tauri origin with valid enterprise key is accepted', async () => {
+  const r = await validateApiKey(makeReq({ origin: 'tauri://localhost', key: ENTERPRISE_KEY }));
+  assert.equal(r.valid, true);
+});
+
+test('desktop Tauri origin with wms_ session token is rejected (desktop must use enterprise key)', async () => {
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({ origin: 'tauri://localhost', key: token }));
+  assert.equal(r.valid, false);
+});
+
+// ── Total absence of credentials ────────────────────────────────────────────
+
+test('completely unauthenticated request is rejected', async () => {
+  const r = await validateApiKey(makeReq({}));
+  assert.equal(r.valid, false);
+  assert.equal(r.required, true);
+});
+
+// ── forceKey option ─────────────────────────────────────────────────────────
+
+test('forceKey=true rejects requests without any key, even with valid wms_ token (sanity: forceKey applies to all paths in the original code; documenting current behavior)', async () => {
+  // In the new design, wms_ token IS a key (it goes through the X-WorldMonitor-Key
+  // header and validateSessionToken). So forceKey=true with wms_ accepts. This
+  // test documents that.
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({ key: token }), { forceKey: true });
+  assert.equal(r.valid, true);
+});

--- a/api/_relay.js
+++ b/api/_relay.js
@@ -72,7 +72,7 @@ export function createRelayHandler(cfg) {
     }
 
     if (cfg.requireApiKey) {
-      const keyCheck = validateApiKey(req);
+      const keyCheck = await validateApiKey(req);
       if (keyCheck.required && !keyCheck.valid) {
         return jsonResponse({ error: keyCheck.error }, 401, corsHeaders);
       }

--- a/api/_session.js
+++ b/api/_session.js
@@ -108,6 +108,13 @@ export async function validateSessionToken(token) {
   let providedBytes;
   try { providedBytes = base64UrlToBytes(sig); } catch { return false; }
 
+  // Enforce canonical base64url encoding: re-encode the decoded bytes and
+  // require an exact match. Without this, the trailing base64 character can
+  // carry up to 4 unused padding bits — flipping them yields a *different*
+  // string that decodes to the *same* bytes, allowing a tampered signature
+  // string to pass HMAC verification (PR #3557 review finding).
+  if (bufferToBase64Url(providedBytes.buffer) !== sig) return false;
+
   const expected = new Uint8Array(expectedBuf);
   if (expected.length !== providedBytes.length) return false;
 

--- a/api/_session.js
+++ b/api/_session.js
@@ -1,0 +1,124 @@
+// Server-issued, HMAC-signed session tokens for anonymous browser access.
+//
+// Replaces the previous Origin/Referer header-based "trusted browser" trust
+// path (issue #3541). HTTP headers are entirely client-controlled at the wire
+// level — Origin, Sec-Fetch-Site, Referer, etc. are all forgeable by curl /
+// Node http / raw socket. Only cryptographic proof closes that bypass class.
+//
+// Tokens are HMAC-SHA256(secret, base64url(payload)) with payload {iat,exp,n}.
+// The frontend fetches one at app boot via POST /api/wm-session and includes
+// it on subsequent API calls via the X-WorldMonitor-Key header. Curl can't
+// manufacture one without WM_SESSION_SECRET (server-only). It CAN replay a
+// stolen one, but session-start is rate-limited and tokens are short-lived.
+//
+// Uses Web Crypto API (crypto.subtle) — works in both Vercel Edge runtime
+// and Node.js test environment without `node:crypto` (which the bundle check
+// rejects under --platform=browser).
+
+const SESSION_TTL_MS = 12 * 60 * 60 * 1000;
+const PREFIX = 'wms_';
+const enc = new TextEncoder();
+
+function getSecret() {
+  const s = process.env.WM_SESSION_SECRET;
+  if (!s || s.length < 32) {
+    throw new Error('WM_SESSION_SECRET must be set (min 32 chars)');
+  }
+  return s;
+}
+
+async function importHmacKey() {
+  return crypto.subtle.importKey(
+    'raw',
+    enc.encode(getSecret()),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+}
+
+function bufferToBase64Url(buf) {
+  const bytes = new Uint8Array(buf);
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlToBytes(s) {
+  const pad = (4 - (s.length % 4)) % 4;
+  const b64 = (s + '='.repeat(pad)).replace(/-/g, '+').replace(/_/g, '/');
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+function stringToBase64Url(s) {
+  return bufferToBase64Url(enc.encode(s).buffer);
+}
+
+function base64UrlToString(s) {
+  const bytes = base64UrlToBytes(s);
+  return new TextDecoder().decode(bytes);
+}
+
+function randomNonceHex(byteLen = 8) {
+  const arr = new Uint8Array(byteLen);
+  crypto.getRandomValues(arr);
+  let s = '';
+  for (let i = 0; i < arr.length; i++) s += arr[i].toString(16).padStart(2, '0');
+  return s;
+}
+
+export async function issueSessionToken() {
+  const payload = {
+    iat: Date.now(),
+    exp: Date.now() + SESSION_TTL_MS,
+    n: randomNonceHex(8),
+  };
+  const body = stringToBase64Url(JSON.stringify(payload));
+  const key = await importHmacKey();
+  const sigBuf = await crypto.subtle.sign('HMAC', key, enc.encode(body));
+  const sig = bufferToBase64Url(sigBuf);
+  return { token: `${PREFIX}${body}.${sig}`, exp: payload.exp };
+}
+
+export function isSessionTokenShape(token) {
+  return typeof token === 'string' && token.startsWith(PREFIX);
+}
+
+// Returns true ONLY if: prefix matches, signature verifies (constant-time),
+// payload parses, and exp is in the future. Any failure mode returns false.
+// Crucially, fails closed if WM_SESSION_SECRET is unset/short.
+export async function validateSessionToken(token) {
+  if (!isSessionTokenShape(token)) return false;
+  const tail = token.slice(PREFIX.length);
+  const dot = tail.indexOf('.');
+  if (dot < 0) return false;
+  const body = tail.slice(0, dot);
+  const sig = tail.slice(dot + 1);
+  if (!body || !sig) return false;
+
+  let key;
+  try { key = await importHmacKey(); } catch { return false; }
+
+  let expectedBuf;
+  try { expectedBuf = await crypto.subtle.sign('HMAC', key, enc.encode(body)); } catch { return false; }
+
+  let providedBytes;
+  try { providedBytes = base64UrlToBytes(sig); } catch { return false; }
+
+  const expected = new Uint8Array(expectedBuf);
+  if (expected.length !== providedBytes.length) return false;
+
+  // Constant-time comparison. Don't short-circuit on first mismatch.
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) diff |= expected[i] ^ providedBytes[i];
+  if (diff !== 0) return false;
+
+  let payload;
+  try { payload = JSON.parse(base64UrlToString(body)); } catch { return false; }
+  if (typeof payload.exp !== 'number') return false;
+  if (Date.now() > payload.exp) return false;
+  return true;
+}

--- a/api/_session.test.mjs
+++ b/api/_session.test.mjs
@@ -1,0 +1,109 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+const SECRET = 'test-secret-must-be-at-least-32-chars-long-xxx';
+process.env.WM_SESSION_SECRET = SECRET;
+
+const { issueSessionToken, validateSessionToken, isSessionTokenShape } =
+  await import('./_session.js');
+
+test('issueSessionToken returns wms_-prefixed token + future exp', async () => {
+  const { token, exp } = await issueSessionToken();
+  assert.match(token, /^wms_/);
+  assert.ok(exp > Date.now());
+  assert.ok(exp - Date.now() <= 12 * 60 * 60 * 1000 + 1000);
+});
+
+test('validateSessionToken accepts a freshly-issued token', async () => {
+  const { token } = await issueSessionToken();
+  assert.equal(await validateSessionToken(token), true);
+});
+
+test('validateSessionToken rejects a token signed with a different secret', async () => {
+  const { token } = await issueSessionToken();
+  const stash = process.env.WM_SESSION_SECRET;
+  process.env.WM_SESSION_SECRET = 'different-secret-also-32-chars-or-longer-yyyy';
+  try {
+    assert.equal(await validateSessionToken(token), false);
+  } finally {
+    process.env.WM_SESSION_SECRET = stash;
+  }
+});
+
+test('validateSessionToken rejects a tampered payload', async () => {
+  const { token } = await issueSessionToken();
+  const m = token.match(/^(wms_)([^.]+)\.(.+)$/);
+  const [, prefix, body, sig] = m;
+  // Flip a bit in the first decoded byte
+  const decoded = Buffer.from(body, 'base64url').toString();
+  const tampered = decoded.replace(/^./, c => String.fromCharCode(c.charCodeAt(0) ^ 1));
+  const tamperedBody = Buffer.from(tampered).toString('base64url');
+  const forged = `${prefix}${tamperedBody}.${sig}`;
+  assert.equal(await validateSessionToken(forged), false);
+});
+
+test('validateSessionToken rejects a tampered signature', async () => {
+  const { token } = await issueSessionToken();
+  // Flip last char in signature
+  const flipped = token.slice(0, -1) + (token.slice(-1) === 'A' ? 'B' : 'A');
+  assert.equal(await validateSessionToken(flipped), false);
+});
+
+test('validateSessionToken rejects an expired token', async () => {
+  // Build an expired token using the SAME secret + Web Crypto so the sig matches.
+  const enc = new TextEncoder();
+  const past = Date.now() - 1000;
+  const body = Buffer.from(JSON.stringify({ iat: past - 1000, exp: past, n: 'aabbccdd' })).toString('base64url');
+  const key = await crypto.subtle.importKey('raw', enc.encode(SECRET), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const sigBuf = await crypto.subtle.sign('HMAC', key, enc.encode(body));
+  const sig = Buffer.from(new Uint8Array(sigBuf)).toString('base64url');
+  const expired = `wms_${body}.${sig}`;
+  assert.equal(await validateSessionToken(expired), false);
+});
+
+test('validateSessionToken rejects garbage input', async () => {
+  assert.equal(await validateSessionToken(''), false);
+  assert.equal(await validateSessionToken('not-a-token'), false);
+  assert.equal(await validateSessionToken('wms_'), false);
+  assert.equal(await validateSessionToken('wms_no-dot'), false);
+  assert.equal(await validateSessionToken('wms_a.'), false);
+  assert.equal(await validateSessionToken('wms_.b'), false);
+  assert.equal(await validateSessionToken(null), false);
+  assert.equal(await validateSessionToken(undefined), false);
+  assert.equal(await validateSessionToken(123), false);
+});
+
+test('isSessionTokenShape only matches wms_ prefix', () => {
+  assert.equal(isSessionTokenShape('wms_abc'), true);
+  assert.equal(isSessionTokenShape('wm_userkey'), false);
+  assert.equal(isSessionTokenShape('enterprise-key'), false);
+  assert.equal(isSessionTokenShape(''), false);
+  assert.equal(isSessionTokenShape(null), false);
+});
+
+test('issueSessionToken throws when WM_SESSION_SECRET is missing/short (fail closed)', async () => {
+  const stash = process.env.WM_SESSION_SECRET;
+  process.env.WM_SESSION_SECRET = 'too-short';
+  try {
+    await assert.rejects(() => issueSessionToken(), /WM_SESSION_SECRET/);
+  } finally {
+    process.env.WM_SESSION_SECRET = stash;
+  }
+  delete process.env.WM_SESSION_SECRET;
+  try {
+    await assert.rejects(() => issueSessionToken(), /WM_SESSION_SECRET/);
+  } finally {
+    process.env.WM_SESSION_SECRET = stash;
+  }
+});
+
+test('validateSessionToken returns false (not throws) when secret missing', async () => {
+  const { token } = await issueSessionToken();
+  const stash = process.env.WM_SESSION_SECRET;
+  delete process.env.WM_SESSION_SECRET;
+  try {
+    assert.equal(await validateSessionToken(token), false);
+  } finally {
+    process.env.WM_SESSION_SECRET = stash;
+  }
+});

--- a/api/_session.test.mjs
+++ b/api/_session.test.mjs
@@ -44,8 +44,36 @@ test('validateSessionToken rejects a tampered payload', async () => {
 
 test('validateSessionToken rejects a tampered signature', async () => {
   const { token } = await issueSessionToken();
-  // Flip last char in signature
-  const flipped = token.slice(0, -1) + (token.slice(-1) === 'A' ? 'B' : 'A');
+  // Decode the signature bytes, flip the FIRST byte, re-encode. This guarantees
+  // the signature differs from the legitimate HMAC.
+  //
+  // The earlier "flip the last base64url char" approach was non-deterministic:
+  // for SHA-256 (32 bytes → 43 b64url chars, no padding), the last char encodes
+  // 2 high bits of byte 32 plus 4 unused padding bits. Two different chars can
+  // share the same high 2 bits and differ only in padding — decoding to
+  // identical bytes and passing HMAC verification. PR #3557 review caught this.
+  const m = token.match(/^(wms_)([^.]+)\.(.+)$/);
+  const [, prefix, body, sig] = m;
+  const sigBytes = Buffer.from(sig, 'base64url');
+  sigBytes[0] = sigBytes[0] ^ 0xff;
+  const tamperedSig = sigBytes.toString('base64url');
+  const tampered = `${prefix}${body}.${tamperedSig}`;
+  assert.notEqual(tamperedSig, sig, 'sanity: tampered sig differs in encoding');
+  assert.equal(await validateSessionToken(tampered), false);
+});
+
+test('validateSessionToken rejects non-canonical base64url (last-char padding-bit flip)', async () => {
+  // Defensive: even if a future test/attacker tries the "flip the last char"
+  // trick, the canonical encoding check inside validateSessionToken rejects it
+  // because re-encoding the decoded bytes yields the canonical form, which
+  // won't match the tampered string.
+  const { token } = await issueSessionToken();
+  const last = token.slice(-1);
+  const candidates = ['A', 'B', 'C', 'D', 'E', 'F', 'g', 'h'];
+  const swap = candidates.find(c => c !== last) ?? 'A';
+  const flipped = token.slice(0, -1) + swap;
+  // Either it decodes differently (signature mismatch → false) OR the
+  // canonical-encoding check catches the padding-bit twiddle. Either way, false.
   assert.equal(await validateSessionToken(flipped), false);
 });
 

--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -202,6 +202,13 @@
       "removal_issue": null
     },
     {
+      "path": "api/wm-session.js",
+      "category": "ops-admin",
+      "reason": "Anonymous browser session-token mint. Single 2-field response ({token, exp}); a sebuf RPC would be over-engineering for an auth-bootstrap endpoint that the client calls once at boot. See PR #3557 / issue #3541 for the full bypass-closure rationale.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/invalidate-user-api-key-cache.ts",
       "category": "ops-admin",
       "reason": "Admin-gated cache bust for user API key lookups. Internal operator action.",

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -236,7 +236,7 @@ export default async function handler(req) {
   if (req.method === 'OPTIONS')
     return new Response(null, { status: 204, headers: cors });
 
-  const apiKeyResult = validateApiKey(req);
+  const apiKeyResult = await validateApiKey(req);
   if (apiKeyResult.required && !apiKeyResult.valid)
     return jsonResponse({ error: apiKeyResult.error }, 401, cors);
 

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -81,7 +81,7 @@ export default async function handler(req, ctx) {
     return jsonResponse({ error: 'Method not allowed' }, 405, corsHeaders);
   }
 
-  const keyCheck = validateApiKey(req);
+  const keyCheck = await validateApiKey(req);
   if (keyCheck.required && !keyCheck.valid) {
     return jsonResponse({ error: keyCheck.error }, 401, corsHeaders);
   }

--- a/api/seed-contract-probe.ts
+++ b/api/seed-contract-probe.ts
@@ -24,6 +24,8 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders } from './_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { jsonResponse } from './_json-response.js';
+// @ts-expect-error — JS module, no declaration file
+import { issueSessionToken } from './_session.js';
 
 type ProbeShape = 'envelope' | 'bare';
 
@@ -161,19 +163,28 @@ const BOUNDARY_CHECKS: BoundaryCheck[] = [
 ];
 
 export async function checkPublicBoundary(origin: string): Promise<BoundaryResult[]> {
+  // Endpoints behind validateApiKey() (e.g. /api/bootstrap) used to accept the
+  // trusted-browser-origin path without a key. PR #3557 closed that bypass: the
+  // ONLY no-Pro path now is a wms_-prefixed HMAC-signed session token. Mint one
+  // here ourselves — we share the WM_SESSION_SECRET environment with the
+  // /api/wm-session endpoint, so an in-process issue is equivalent to round-
+  // tripping through it (and avoids the extra network hop).
+  // If WM_SESSION_SECRET isn't configured, fall back to the bare request — the
+  // boundary check will surface the missing-secret error as a 401 from
+  // /api/bootstrap, which is the right operator signal.
+  let sessionToken: string | null = null;
+  try { sessionToken = (await issueSessionToken()).token; } catch { /* no-op */ }
+
   return Promise.all(BOUNDARY_CHECKS.map(async ({ endpoint, requireSourceHeader }): Promise<BoundaryResult> => {
     try {
-      // Send Origin of the canonical public host so endpoints that gate
-      // behind validateApiKey() (e.g. /api/bootstrap) take the trusted-browser
-      // branch instead of demanding an API key. The probe runs edge-side with
-      // internal auth; we intentionally emulate a trusted browser for boundary
-      // verification only.
+      const headers: Record<string, string> = {
+        Origin: 'https://worldmonitor.app',
+        'User-Agent': 'WorldMonitor-SeedContractProbe/1.0',
+      };
+      if (sessionToken) headers['X-WorldMonitor-Key'] = sessionToken;
       const r = await fetch(`${origin}${endpoint}`, {
         signal: AbortSignal.timeout(5_000),
-        headers: {
-          Origin: 'https://worldmonitor.app',
-          'User-Agent': 'WorldMonitor-SeedContractProbe/1.0',
-        },
+        headers,
       });
       const text = await r.text();
       // Detect any envelope leak in the response body. A substring match on

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -134,7 +134,7 @@ export default async function handler(req) {
   if (req.method === 'OPTIONS')
     return new Response(null, { status: 204, headers: cors });
 
-  const apiKeyResult = validateApiKey(req);
+  const apiKeyResult = await validateApiKey(req);
   if (apiKeyResult.required && !apiKeyResult.valid)
     return jsonResponse({ error: apiKeyResult.error }, 401, cors);
 

--- a/api/v2/shipping/webhooks/[subscriberId].ts
+++ b/api/v2/shipping/webhooks/[subscriberId].ts
@@ -33,7 +33,7 @@ export default async function handler(req: Request): Promise<Response> {
     });
   }
 
-  const apiKeyResult = validateApiKey(req, { forceKey: true });
+  const apiKeyResult = await validateApiKey(req, { forceKey: true });
   if (apiKeyResult.required && !apiKeyResult.valid) {
     return new Response(JSON.stringify({ error: apiKeyResult.error ?? 'API key required' }), {
       status: 401,

--- a/api/v2/shipping/webhooks/[subscriberId]/[action].ts
+++ b/api/v2/shipping/webhooks/[subscriberId]/[action].ts
@@ -37,7 +37,7 @@ export default async function handler(req: Request): Promise<Response> {
     });
   }
 
-  const apiKeyResult = validateApiKey(req, { forceKey: true });
+  const apiKeyResult = await validateApiKey(req, { forceKey: true });
   if (apiKeyResult.required && !apiKeyResult.valid) {
     return new Response(JSON.stringify({ error: apiKeyResult.error ?? 'API key required' }), {
       status: 401,

--- a/api/wm-session.js
+++ b/api/wm-session.js
@@ -1,0 +1,50 @@
+// POST /api/wm-session — issues an HMAC-signed session token for anonymous
+// browser access. The frontend calls this once at app boot, caches the token
+// in sessionStorage, and includes it on subsequent API calls. See _session.js
+// and the issue #3541 / #3554 discussion for the threat-model rationale.
+
+import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { checkRateLimit } from './_rate-limit.js';
+import { issueSessionToken } from './_session.js';
+
+export const config = { runtime: 'edge' };
+
+function jsonResponse(body, status, headers) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+export default async function handler(req) {
+  if (isDisallowedOrigin(req)) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  const cors = getCorsHeaders(req, 'POST, OPTIONS');
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: cors });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'Method not allowed' }, 405, cors);
+  }
+
+  // Rate-limit per IP. Without this, an attacker can farm tokens cheaply.
+  // Token TTL is 12h, so a sustained ~1 RPS yields 86400 tokens/day per IP —
+  // the existing IP cap (600/min) keeps that bounded.
+  const rl = await checkRateLimit(req, cors);
+  if (rl) return rl;
+
+  let issued;
+  try {
+    issued = await issueSessionToken();
+  } catch {
+    // WM_SESSION_SECRET missing — fail closed. 503 signals "configure me",
+    // not "you're rejected." Operator-visible.
+    return jsonResponse({ error: 'Session service not configured' }, 503, cors);
+  }
+
+  return jsonResponse({ token: issued.token, exp: issued.exp }, 200, cors);
+}

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -1,0 +1,59 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+const SECRET = 'test-secret-must-be-at-least-32-chars-long-xxx';
+process.env.WM_SESSION_SECRET = SECRET;
+
+const { default: handler } = await import('./wm-session.js');
+const { validateSessionToken } = await import('./_session.js');
+
+function makeReq(method, { origin } = {}) {
+  const headers = new Headers();
+  if (origin) headers.set('origin', origin);
+  return new Request('https://api.worldmonitor.app/api/wm-session', { method, headers });
+}
+
+test('POST from trusted origin returns a valid wms_ token', async () => {
+  const resp = await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }));
+  assert.equal(resp.status, 200);
+  const body = await resp.json();
+  assert.match(body.token, /^wms_/);
+  assert.equal(typeof body.exp, 'number');
+  assert.equal(await validateSessionToken(body.token), true);
+});
+
+test('OPTIONS preflight returns 204 with CORS', async () => {
+  const resp = await handler(makeReq('OPTIONS', { origin: 'https://worldmonitor.app' }));
+  assert.equal(resp.status, 204);
+  assert.equal(resp.headers.get('access-control-allow-methods'), 'POST, OPTIONS');
+});
+
+test('GET method is rejected with 405', async () => {
+  const resp = await handler(makeReq('GET', { origin: 'https://worldmonitor.app' }));
+  assert.equal(resp.status, 405);
+});
+
+test('Disallowed origin gets 403', async () => {
+  const resp = await handler(makeReq('POST', { origin: 'https://evil.example.com' }));
+  assert.equal(resp.status, 403);
+});
+
+test('No origin (curl) is allowed (rate limit + token TTL are the throttles)', async () => {
+  const resp = await handler(makeReq('POST', {}));
+  assert.equal(resp.status, 200);
+  const body = await resp.json();
+  assert.match(body.token, /^wms_/);
+});
+
+test('Returns 503 when WM_SESSION_SECRET is missing', async () => {
+  const stash = process.env.WM_SESSION_SECRET;
+  delete process.env.WM_SESSION_SECRET;
+  try {
+    const resp = await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }));
+    assert.equal(resp.status, 503);
+    const body = await resp.json();
+    assert.match(body.error, /Session service not configured/);
+  } finally {
+    process.env.WM_SESSION_SECRET = stash;
+  }
+});

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:data": "tsx --test tests/*.test.mjs tests/*.test.mts",
     "dryrun:resilience": "node --import tsx/esm scripts/dry-run-resilience-rebalance.mjs",
     "test:feeds": "node scripts/validate-rss-feeds.mjs",
-    "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs api/_cors.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs",
+    "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs api/_cors.test.mjs api/_session.test.mjs api/_api-key.test.mjs api/wm-session.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs",
     "test:e2e:visual:full": "cross-env VITE_VARIANT=full playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual:tech": "cross-env VITE_VARIANT=tech playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual": "npm run test:e2e:visual:full && npm run test:e2e:visual:tech",

--- a/server/_shared/premium-check.ts
+++ b/server/_shared/premium-check.ts
@@ -31,7 +31,7 @@ export async function isCallerPremium(request: Request): Promise<boolean> {
     }
   }
 
-  const keyCheck = validateApiKey(request, {}) as { valid: boolean; required: boolean };
+  const keyCheck = (await validateApiKey(request, {})) as { valid: boolean; required: boolean };
   // Only treat as premium when an explicit API key was validated (required: true).
   // Trusted-origin short-circuits (required: false) do NOT imply PRO entitlement.
   if (keyCheck.valid && keyCheck.required) return true;

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -426,9 +426,17 @@ export function createDomainGateway(
 
     // API key validation — tier-gated endpoints require EITHER an API key OR a valid bearer token.
     // Authenticated users (sessionUserId present) bypass the API key requirement.
-    let keyCheck = validateApiKey(request, {
+    let keyCheck = (await validateApiKey(request, {
       forceKey: (isTierGated && !sessionUserId) || needsLegacyProBearerGate,
-    }) as { valid: boolean; required: boolean; error?: string };
+    })) as { valid: boolean; required: boolean; error?: string };
+
+    // Clerk session is itself proof of authentication (validated at line 410).
+    // validateApiKey is strict-no-trust-of-headers per #3541 and would 401 every
+    // Clerk-authenticated user who hasn't also minted a wms_ session token.
+    // Override: tier-gated routes with a resolved sessionUserId pass this layer.
+    if (isTierGated && sessionUserId && keyCheck.required && !keyCheck.valid) {
+      keyCheck = { valid: true, required: false };
+    }
 
     // User-owned API keys (wm_ prefix): when the static WORLDMONITOR_VALID_KEYS
     // check fails, try async Convex-backed validation for user-issued keys.

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -428,7 +428,7 @@ export function createDomainGateway(
     // Authenticated users (sessionUserId present) bypass the API key requirement.
     let keyCheck = (await validateApiKey(request, {
       forceKey: (isTierGated && !sessionUserId) || needsLegacyProBearerGate,
-    })) as { valid: boolean; required: boolean; error?: string };
+    })) as { valid: boolean; required: boolean; error?: string; kind?: 'enterprise' | 'session' | 'user' };
 
     // Clerk session is itself proof of authentication (validated at line 410).
     // validateApiKey is strict-no-trust-of-headers per #3541 and would 401 every
@@ -557,9 +557,12 @@ export function createDomainGateway(
     }
 
     // Entitlement check — blocks tier-gated endpoints for users below required tier.
-    // Admin API-key holders (WORLDMONITOR_VALID_KEYS) bypass entitlement checks.
+    // Admin API-key holders (WORLDMONITOR_VALID_KEYS, kind: 'enterprise') bypass.
     // User API keys do NOT bypass — the key owner's tier is checked normally.
-    if (!(keyCheck.valid && wmKey && !isUserApiKey)) {
+    // Anonymous wms_ session tokens (kind: 'session') do NOT bypass — they are
+    // freely mintable by any caller and are NOT user-bound (PR #3557 review).
+    const isEnterpriseAuth = keyCheck.valid && wmKey && !isUserApiKey && keyCheck.kind === 'enterprise';
+    if (!isEnterpriseAuth) {
       const entitlementResponse = await checkEntitlement(request, pathname, corsHeaders);
       if (entitlementResponse) {
         const entReason: RequestReason =

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -470,9 +470,12 @@ export function createDomainGateway(
       }
     }
 
-    // Enterprise API key (WORLDMONITOR_VALID_KEYS): keyCheck.valid + wmKey present
-    // and not a wm_-prefixed user key.
-    if (keyCheck.valid && wmKey && !isUserApiKey && !wmKey.startsWith('wm_')) {
+    // Enterprise API key (WORLDMONITOR_VALID_KEYS): require kind === 'enterprise'.
+    // Without this, anonymous wms_ tokens slipped through (validateApiKey marks
+    // them valid, wmKey is set, !isUserApiKey, and 'wms_' doesn't startsWith
+    // 'wm_'), so telemetry mislabelled them as enterprise_api_key with
+    // customer_id='enterprise-unmapped'. PR #3557 round-3 review.
+    if (keyCheck.valid && wmKey && !isUserApiKey && keyCheck.kind === 'enterprise') {
       usage.enterpriseApiKey = wmKey;
     }
 

--- a/server/worldmonitor/shipping/v2/list-webhooks.ts
+++ b/server/worldmonitor/shipping/v2/list-webhooks.ts
@@ -26,7 +26,7 @@ export async function listWebhooks(
   // ownerTag !== ownerHash defense-in-depth below collapses because both
   // sides equal 'anon' — exposing every 'anon'-bucket tenant's webhooks to
   // every Clerk-session holder. See registerWebhook for full rationale.
-  const apiKeyResult = validateApiKey(ctx.request, { forceKey: true }) as {
+  const apiKeyResult = (await validateApiKey(ctx.request, { forceKey: true })) as {
     valid: boolean; required: boolean; error?: string;
   };
   if (apiKeyResult.required && !apiKeyResult.valid) {

--- a/server/worldmonitor/shipping/v2/register-webhook.ts
+++ b/server/worldmonitor/shipping/v2/register-webhook.ts
@@ -36,7 +36,7 @@ export async function registerWebhook(
   // Matches the legacy `api/v2/shipping/webhooks/[subscriberId]{,/[action]}.ts`
   // gate and the documented "X-WorldMonitor-Key required" contract in
   // docs/api-shipping-v2.mdx.
-  const apiKeyResult = validateApiKey(ctx.request, { forceKey: true }) as {
+  const apiKeyResult = (await validateApiKey(ctx.request, { forceKey: true })) as {
     valid: boolean; required: boolean; error?: string;
   };
   if (apiKeyResult.required && !apiKeyResult.valid) {

--- a/src/App.ts
+++ b/src/App.ts
@@ -68,6 +68,7 @@ import { initI18n, t } from '@/services/i18n';
 import { computeDefaultDisabledSources, getLocaleBoostedSources, getTotalFeedCount, FEEDS, INTEL_SOURCES } from '@/config/feeds';
 import { selectSourcesUnderCap, findFullyDisabledCategories } from '@/services/source-cap';
 import { fetchBootstrapData, getBootstrapHydrationState, markBootstrapAsLive, type BootstrapHydrationState } from '@/services/bootstrap';
+import { ensureWmSession, installWmSessionFetchInterceptor } from '@/services/wm-session';
 import { describeFreshness } from '@/services/persistent-cache';
 import { DesktopUpdater } from '@/app/desktop-updater';
 import { CountryIntelManager } from '@/app/country-intel';
@@ -938,6 +939,17 @@ export class App {
     // Wait for sidecar readiness on desktop so bootstrap hits a live server
     if (isDesktopRuntime()) {
       await waitForSidecarReady(3000);
+    }
+
+    // Anonymous browser session token (issue #3541). Server's validateApiKey
+    // no longer trusts header-only signals (Origin / Referer / Sec-Fetch-Site
+    // are all forgeable). Install a fetch interceptor ONCE, then mint a
+    // wms_-prefixed HMAC token before the first API call. Desktop has its own
+    // API key path and doesn't need this; Clerk-authenticated users will pass
+    // their JWT in a Bearer header and the interceptor steps aside.
+    if (!isDesktopRuntime()) {
+      installWmSessionFetchInterceptor();
+      await ensureWmSession();
     }
 
     // Hydrate in-memory cache from bootstrap endpoint (before panels construct and fetch)

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -1,0 +1,152 @@
+// Client-side helper for the anonymous-browser session token (issue #3541).
+//
+// The server's validateApiKey() (api/_api-key.js) no longer trusts header-only
+// signals like Origin / Referer / Sec-Fetch-Site to authorize key-less browser
+// access — every header is forgeable by curl. Anonymous browsers now mint a
+// short-lived HMAC-signed token via POST /api/wm-session at boot and include
+// it on subsequent API calls via the X-WorldMonitor-Key header.
+//
+// Two pieces:
+//   1. ensureWmSession() — fetch + cache the token in sessionStorage.
+//   2. installWmSessionFetchInterceptor() — patch globalThis.fetch ONCE so
+//      every call to our API origin auto-gets the header. Avoids touching
+//      ~50 fetch sites individually. Skipped if the caller already supplied
+//      auth (Authorization, X-WorldMonitor-Key, X-Api-Key) — Bearer JWT and
+//      explicit user-key paths still take precedence.
+
+import { getApiBaseUrl, toApiUrl } from './runtime';
+
+const STORAGE_KEY = 'wm-session-token';
+// Refresh well before expiry so a half-loaded page doesn't fail mid-flight.
+const REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
+interface StoredSession {
+  token: string;
+  exp: number;
+}
+
+let cached: StoredSession | null = null;
+let inflight: Promise<string | null> | null = null;
+let interceptorInstalled = false;
+
+function isFresh(s: StoredSession | null): s is StoredSession {
+  return !!s && s.exp - REFRESH_MARGIN_MS > Date.now();
+}
+
+function loadFromStorage(): StoredSession | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<StoredSession>;
+    if (typeof parsed?.token === 'string' && typeof parsed?.exp === 'number') {
+      return { token: parsed.token, exp: parsed.exp };
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
+function saveToStorage(s: StoredSession): void {
+  try { sessionStorage.setItem(STORAGE_KEY, JSON.stringify(s)); } catch { /* ignore */ }
+}
+
+async function fetchNewToken(): Promise<StoredSession | null> {
+  try {
+    const resp = await fetch(toApiUrl('/api/wm-session'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (!resp.ok) return null;
+    const data = await resp.json() as { token?: unknown; exp?: unknown };
+    if (typeof data?.token !== 'string' || typeof data?.exp !== 'number') return null;
+    return { token: data.token, exp: data.exp };
+  } catch {
+    return null;
+  }
+}
+
+export async function ensureWmSession(): Promise<string | null> {
+  if (isFresh(cached)) return cached.token;
+  if (inflight) return inflight;
+
+  const stored = loadFromStorage();
+  if (isFresh(stored)) {
+    cached = stored;
+    return cached.token;
+  }
+
+  inflight = (async () => {
+    const fresh = await fetchNewToken();
+    if (fresh) {
+      cached = fresh;
+      saveToStorage(fresh);
+      return fresh.token;
+    }
+    return null;
+  })().finally(() => { inflight = null; });
+
+  return inflight;
+}
+
+export function getWmSessionToken(): string | null {
+  if (isFresh(cached)) return cached.token;
+  return null;
+}
+
+// Install a one-shot fetch wrapper that adds X-WorldMonitor-Key to API calls.
+// Only patches calls to our API origin (or relative /api/ paths). Other fetches
+// (Sentry, Clerk, third-party CDNs) are forwarded to native fetch unchanged.
+//
+// If a caller already set Authorization / X-WorldMonitor-Key / X-Api-Key, we
+// don't override — Clerk Bearer JWT and explicit user keys still take
+// precedence over the anonymous session token.
+export function installWmSessionFetchInterceptor(): void {
+  if (interceptorInstalled || typeof window === 'undefined') return;
+  interceptorInstalled = true;
+
+  const apiOrigin = (() => {
+    try { return new URL(getApiBaseUrl()).origin; } catch { return ''; }
+  })();
+  const original = window.fetch.bind(window);
+
+  window.fetch = async function wmSessionFetch(input, init) {
+    const url = (() => {
+      if (typeof input === 'string') return input;
+      if (input instanceof URL) return input.href;
+      if (input instanceof Request) return input.url;
+      return '';
+    })();
+
+    const isApiCall =
+      url.startsWith('/api/') ||
+      (apiOrigin !== '' && url.startsWith(apiOrigin));
+
+    if (!isApiCall) return original(input, init);
+
+    const headers = new Headers(
+      init?.headers ?? (input instanceof Request ? input.headers : undefined),
+    );
+
+    // Caller already authenticated (Bearer JWT, explicit user/widget key, etc).
+    // Don't override — Clerk and explicit-key paths take precedence.
+    if (
+      headers.has('Authorization') ||
+      headers.has('X-WorldMonitor-Key') ||
+      headers.has('X-Api-Key')
+    ) {
+      return original(input, init);
+    }
+
+    const token = getWmSessionToken();
+    if (!token) return original(input, init);
+
+    headers.set('X-WorldMonitor-Key', token);
+
+    // Preserve body/method/credentials/cache/redirect by cloning the Request.
+    // For string/URL inputs, fold the merged headers into init.
+    if (input instanceof Request) {
+      const cloned = new Request(input, { headers });
+      return original(cloned, init);
+    }
+    return original(input, { ...(init ?? {}), headers });
+  };
+}

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -15,6 +15,7 @@
 //      explicit user-key paths still take precedence.
 
 import { getApiBaseUrl, toApiUrl } from './runtime';
+import { PREMIUM_RPC_PATHS } from '@/shared/premium-paths';
 
 const STORAGE_KEY = 'wm-session-token';
 // Refresh well before expiry so a half-loaded page doesn't fail mid-flight.
@@ -121,6 +122,22 @@ export function installWmSessionFetchInterceptor(): void {
       (apiOrigin !== '' && url.startsWith(apiOrigin));
 
     if (!isApiCall) return original(input, init);
+
+    // Premium routes have a dedicated auth-injection layer
+    // (`installWebApiRedirect`'s `enrichInitForPremium` adds Clerk Bearer JWT,
+    // WORLDMONITOR_API_KEY, or tester key based on what the user has). Stepping
+    // aside lets that inner layer attach the right credential — if we set
+    // X-WorldMonitor-Key=wms_... here, the premium injector sees the header
+    // and bails, and the server then 401s because wms_ is rejected on premium
+    // routes (it's anonymous, not user-bound). PR #3557 review finding.
+    const path = (() => {
+      try {
+        return new URL(url, typeof location === 'undefined' ? 'http://localhost' : location.href).pathname;
+      } catch {
+        return url.split('?')[0] ?? url;
+      }
+    })();
+    if (PREMIUM_RPC_PATHS.has(path)) return original(input, init);
 
     const headers = new Headers(
       init?.headers ?? (input instanceof Request ? input.headers : undefined),

--- a/tests/gateway-cdn-origin-policy.test.mts
+++ b/tests/gateway-cdn-origin-policy.test.mts
@@ -1,13 +1,28 @@
 import assert from 'node:assert/strict';
-import { afterEach, describe, it } from 'node:test';
+import { afterEach, before, describe, it } from 'node:test';
 
 import { createDomainGateway } from '../server/gateway.ts';
+import { issueSessionToken } from '../api/_session.js';
 
 const originalKeys = process.env.WORLDMONITOR_VALID_KEYS;
+const originalSecret = process.env.WM_SESSION_SECRET;
+
+// Anonymous browser access now requires a wms_ session token (issue #3541).
+// Tests mint one once and pass it on every "browser-like" request.
+let sessionToken: string;
+
+before(async () => {
+  process.env.WM_SESSION_SECRET = 'test-secret-must-be-at-least-32-chars-long-xxx';
+  sessionToken = (await issueSessionToken()).token;
+});
 
 afterEach(() => {
   if (originalKeys == null) delete process.env.WORLDMONITOR_VALID_KEYS;
   else process.env.WORLDMONITOR_VALID_KEYS = originalKeys;
+  if (originalSecret == null) delete process.env.WM_SESSION_SECRET;
+  else process.env.WM_SESSION_SECRET = originalSecret;
+  // Re-set test secret in case afterEach ran AFTER the per-test reset.
+  process.env.WM_SESSION_SECRET = 'test-secret-must-be-at-least-32-chars-long-xxx';
 });
 
 function createHandler() {
@@ -28,7 +43,7 @@ function createHandler() {
 async function requestPublicRoute(origin: string) {
   const handler = createHandler();
   return handler(new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
-    headers: { Origin: origin },
+    headers: { Origin: origin, 'X-WorldMonitor-Key': sessionToken },
   }));
 }
 

--- a/tests/premium-stock-gateway.test.mts
+++ b/tests/premium-stock-gateway.test.mts
@@ -4,12 +4,25 @@ import { afterEach, describe, it, before, after, mock } from 'node:test';
 import { generateKeyPair, exportJWK, SignJWT } from 'jose';
 
 import { createDomainGateway } from '../server/gateway.ts';
+import { issueSessionToken } from '../api/_session.js';
 
 const originalKeys = process.env.WORLDMONITOR_VALID_KEYS;
+const originalSessionSecret = process.env.WM_SESSION_SECRET;
+
+// Public routes now require a wms_ session token (issue #3541) — header-only
+// origin trust is gone. Mint one for tests that previously relied on
+// "trusted browser origin = anonymous public read."
+process.env.WM_SESSION_SECRET = originalSessionSecret
+  ?? 'test-secret-must-be-at-least-32-chars-long-xxx';
+let SESSION_TOKEN: string;
+before(async () => { SESSION_TOKEN = (await issueSessionToken()).token; });
 
 afterEach(() => {
   if (originalKeys == null) delete process.env.WORLDMONITOR_VALID_KEYS;
   else process.env.WORLDMONITOR_VALID_KEYS = originalKeys;
+  // Keep the session secret stable across tests so SESSION_TOKEN stays valid.
+  process.env.WM_SESSION_SECRET = originalSessionSecret
+    ?? 'test-secret-must-be-at-least-32-chars-long-xxx';
 });
 
 describe('premium gateway API key enforcement', () => {
@@ -86,9 +99,10 @@ describe('premium gateway API key enforcement', () => {
     }));
     assert.equal(unknownNoKey.status, 403);
 
-    // Public endpoint — always accessible from trusted origin (no credentials needed)
+    // Public endpoint — anonymous browsers authenticate via the wms_ session token
+    // (issue #3541; previously this was a trusted-origin bypass).
     const publicAllowed = await handler(new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
-      headers: { Origin: 'https://worldmonitor.app' },
+      headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': SESSION_TOKEN },
     }));
     assert.equal(publicAllowed.status, 200);
   });
@@ -216,11 +230,18 @@ describe('premium gateway bearer token auth', () => {
     assert.equal(res.status, 401);
   });
 
-  it('public routes are unaffected by absence of auth header', async () => {
+  it('public routes accept the anonymous browser session token', async () => {
+    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
+      headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': SESSION_TOKEN },
+    }));
+    assert.equal(res.status, 200);
+  });
+
+  it('public routes WITHOUT a session token are rejected (#3541 — header-only trust is gone)', async () => {
     const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
       headers: { Origin: 'https://worldmonitor.app' },
     }));
-    assert.equal(res.status, 200);
+    assert.equal(res.status, 401);
   });
 
   it('rejects free bearer token on resilience premium endpoints → 403', async () => {

--- a/tests/premium-stock-gateway.test.mts
+++ b/tests/premium-stock-gateway.test.mts
@@ -106,6 +106,32 @@ describe('premium gateway API key enforcement', () => {
     }));
     assert.equal(publicAllowed.status, 200);
   });
+
+  it('PR #3557 review: anonymous wms_ session token does NOT unlock premium endpoints', async () => {
+    // Regression: an earlier revision returned valid:true for wms_ tokens and
+    // the gateway treated any non-wm_ valid key as enterprise → entitlement
+    // check skipped → premium content served to any anonymous caller. Lock the
+    // contract: wms_ on a premium route must 401 (no Pro auth) — never 200.
+    const handler = createDomainGateway([
+      {
+        method: 'GET',
+        path: '/api/market/v1/analyze-stock',
+        handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      },
+      {
+        method: 'GET',
+        path: '/api/resilience/v1/get-resilience-score',
+        handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      },
+    ]);
+
+    for (const path of ['/api/market/v1/analyze-stock?symbol=AAPL', '/api/resilience/v1/get-resilience-score?countryCode=US']) {
+      const res = await handler(new Request(`https://worldmonitor.app${path}`, {
+        headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': SESSION_TOKEN },
+      }));
+      assert.notEqual(res.status, 200, `wms_ MUST NOT unlock ${path} (got ${res.status})`);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/usage-telemetry-emission.test.mts
+++ b/tests/usage-telemetry-emission.test.mts
@@ -20,6 +20,13 @@ import { afterEach, before, after, describe, it } from 'node:test';
 import { generateKeyPair, exportJWK, SignJWT } from 'jose';
 
 import { createDomainGateway, type GatewayCtx } from '../server/gateway.ts';
+import { issueSessionToken } from '../api/_session.js';
+
+// Anonymous browser access requires a wms_ session token (issue #3541).
+process.env.WM_SESSION_SECRET = process.env.WM_SESSION_SECRET
+  ?? 'test-secret-must-be-at-least-32-chars-long-xxx';
+let SESSION_TOKEN: string;
+before(async () => { SESSION_TOKEN = (await issueSessionToken()).token; });
 
 interface CapturedEvent {
   event_type: string;
@@ -145,7 +152,7 @@ describe('gateway telemetry payload — domain extraction', () => {
     const recorder = makeRecordingCtx();
     const res = await handler(
       new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
-        headers: { Origin: 'https://worldmonitor.app' },
+        headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': SESSION_TOKEN },
       }),
       recorder.ctx,
     );
@@ -357,7 +364,7 @@ describe('gateway telemetry payload — ctx-optional safety', () => {
 
     const res = await handler(
       new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
-        headers: { Origin: 'https://worldmonitor.app' },
+        headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': SESSION_TOKEN },
       }),
     );
     assert.equal(res.status, 200);

--- a/tests/usage-telemetry-emission.test.mts
+++ b/tests/usage-telemetry-emission.test.mts
@@ -164,6 +164,42 @@ describe('gateway telemetry payload — domain extraction', () => {
     assert.equal(spy.events.length, 1);
     assert.equal(spy.events[0]!.domain, 'market');
   });
+
+  it("PR #3557 round-3: anonymous wms_ token telemetry is anon, NOT enterprise_api_key", async () => {
+    // Regression: an earlier revision set usage.enterpriseApiKey for any valid
+    // wmKey not starting with 'wm_'. Since 'wms_' doesn't startsWith 'wm_',
+    // anonymous session tokens were misattributed as enterprise traffic with
+    // customer_id='enterprise-unmapped'. Lock the contract: kind:'session'
+    // tokens emit auth_kind:'anon'.
+    process.env.USAGE_TELEMETRY = '1';
+    process.env.AXIOM_API_TOKEN = 'test-token';
+    const spy = installAxiomFetchSpy(ORIGINAL_FETCH);
+
+    const handler = createDomainGateway([
+      {
+        method: 'GET',
+        path: '/api/market/v1/list-market-quotes',
+        handler: async () => new Response('{"ok":true}', { status: 200 }),
+      },
+    ]);
+
+    const recorder = makeRecordingCtx();
+    const res = await handler(
+      new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
+        headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': SESSION_TOKEN },
+      }),
+      recorder.ctx,
+    );
+    assert.equal(res.status, 200);
+
+    await recorder.settled;
+    spy.restore();
+
+    assert.equal(spy.events.length, 1);
+    const ev = spy.events[0]!;
+    assert.equal(ev.auth_kind, 'anon', `wms_ tokens must telemeter as anon, got '${ev.auth_kind}'`);
+    assert.notEqual(ev.customer_id, 'enterprise-unmapped');
+  });
 });
 
 describe('gateway telemetry payload — bearer identity propagation', () => {


### PR DESCRIPTION
## Summary

Closes #3541. Replaces closed PR #3554 (which attempted to move the bypass from `Referer` to `Sec-Fetch-Site` — same vulnerability class, different header).

The previous `validateApiKey` granted "trusted browser, no key needed" access whenever the request `Origin` matched our domains. **HTTP headers are entirely client-controlled at the wire level** — `curl -H "Origin: https://worldmonitor.app"` bypassed the gate. Same applies to `Referer`, `Sec-Fetch-Site`, `Cookie` and every other header on the Forbidden Header list (that list is a browser-side JS API restriction, not a wire-level guarantee). Only cryptographic proof closes the bypass class.

## ⚠️ Operator action required before merge

Set `WM_SESSION_SECRET` (≥32 chars) in Vercel env. Without it, `/api/wm-session` returns 503 and anonymous browser users cannot authenticate, breaking the public landing pages.

```bash
# generate
openssl rand -hex 32
# then in Vercel dashboard or CLI:
vercel env add WM_SESSION_SECRET production
```

## Mechanism

| Layer | Change |
|---|---|
| `api/_session.js` (new) | HMAC-SHA256 token issuer/validator using Web Crypto. Tokens are `wms_<base64url(payload)>.<sig>` with `{iat, exp, n}`, 12h TTL. Fails closed if `WM_SESSION_SECRET` unset. |
| `api/wm-session.js` (new) | `POST /api/wm-session` mints a token. Rate-limited per IP via existing `checkRateLimit`. Returns 503 if secret unset. |
| `api/_api-key.js` | Drops the `Origin`/`Referer` no-key trust paths entirely. Now requires `wms_` token, `wm_` user key, enterprise key, or (via gateway) Clerk Bearer. Made async (Web Crypto). |
| `server/gateway.ts` | Override: tier-gated routes with a resolved Clerk session pass without a key (the JWT is the auth). |
| `src/services/wm-session.ts` (new) | Client helper. Fetches+caches the token, patches `globalThis.fetch` ONCE at boot to attach `X-WorldMonitor-Key` on calls to our API origin. Avoids touching ~50 fetch sites. Skips when the caller already provided `Authorization`/`X-WorldMonitor-Key`/`X-Api-Key`. |
| `src/App.ts` | Wire `installWmSessionFetchInterceptor()` + `await ensureWmSession()` before `fetchBootstrapData()`. Desktop skipped (uses enterprise-key path). |
| All 7 `validateApiKey` call sites | Migrated to `await`. |
| Test files | `tests/{premium-stock-gateway,gateway-cdn-origin-policy,usage-telemetry-emission}.test.mts` updated to provide a `wms_` token where they previously relied on the trusted-origin bypass — mirrors the production fetch-interceptor flow. |

## Empirical bypass-closure check

```
{"valid":false,"required":true,"error":"API key required"} <- curl forged Sec-Fetch-Site: same-origin
{"valid":false,"required":true,"error":"API key required"} <- curl forged Origin: https://worldmonitor.app
{"valid":false,"required":true,"error":"API key required"} <- curl forged Origin + Sec-Fetch-Site + Referer combo
{"valid":true,"required":false}                              <- curl with valid wms_ token (legit browser path)
{"valid":false,"required":true,"error":"API key required"} <- curl with no headers
```

## Threat model improvement

- **Before**: `curl -H "Origin: ..."` (one flag) → public-data scraping.
- **After**: scrapers must round-trip `POST /api/wm-session` per IP per session, hitting the existing per-IP rate limit. Tokens expire in 12h, forcing re-mint. The wms_ token requires the server-only HMAC secret to forge.
- The improvement is "raise the cost of scraping," not "make scraping impossible." That's the realistic security model for public-read endpoints.

## Why a header-based wms_ token instead of an HttpOnly cookie

A cookie would require:
- `Access-Control-Allow-Credentials: true` on every CORS endpoint
- `credentials: 'include'` on every cross-origin fetch (~50 call sites)
- `Domain=.worldmonitor.app` Set-Cookie + cross-subdomain alignment

Header + monkey-patched `fetch` interceptor avoids all of that and is a one-shot client-side change. Same security properties (HMAC validation is the security boundary, not the transport).

## Test plan

- [x] `npm run typecheck` + `typecheck:api` — clean
- [x] `npm run lint` — clean (warnings unchanged from baseline)
- [x] `npm run test:data` — **7819 / 7819 pass**
- [x] `npm run version:check` — clean
- [x] `npm run lint:md` — clean (55 files)
- [x] Edge function bundle check (every `api/*.js` other than helpers builds clean under `--platform=browser`)
- [x] New unit tests:
  - `api/_session.test.mjs` (10 tests): issue/validate roundtrip, tampered payload, tampered signature, expired, garbage input, secret-missing fail-closed
  - `api/_api-key.test.mjs` (18 tests): #3541 regressions for forged Origin/Referer/Sec-Fetch-Site (alone and combined), wms_ token accept/reject, Tauri desktop paths, wm_ gateway-fallback shape, forceKey paths
  - `api/wm-session.test.mjs` (6 tests): POST returns valid token, OPTIONS preflight, GET 405, disallowed origin 403, no-origin allowed, 503 when secret missing
- [x] Empirical curl-equivalent verification of all forged-header rejections + valid wms_ acceptance

## Source

Fix-after-review of closed PR #3554 — reviewer correctly identified that Sec-Fetch-Site is forgeable too. See #3541 and #3554 for the full history.