### PR TITLE
fix(convex): use scheduler.runAfter for touchKeyLastUsed in api-key validate

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -838,6 +838,8 @@ http.route({
       try {
         await ctx.scheduler.runAfter(0, (internal as any).apiKeys.touchKeyLastUsed, { keyId: result.id });
       } catch (err) {
+        // sentry-coverage-ok: re-throwing here would 500 the gateway, which coerces to null
+        // and stamps a 60s negative-cache sentinel for a valid key. lastUsedAt is best-effort telemetry.
         console.warn("[validate-api-key] touchKeyLastUsed schedule failed:", err instanceof Error ? err.message : String(err));
       }
     }

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -835,7 +835,11 @@ http.route({
     );
 
     if (result) {
-      await ctx.scheduler.runAfter(0, (internal as any).apiKeys.touchKeyLastUsed, { keyId: result.id });
+      try {
+        await ctx.scheduler.runAfter(0, (internal as any).apiKeys.touchKeyLastUsed, { keyId: result.id });
+      } catch (err) {
+        console.warn("[validate-api-key] touchKeyLastUsed schedule failed:", err instanceof Error ? err.message : String(err));
+      }
     }
 
     return new Response(JSON.stringify(result), {

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -835,8 +835,7 @@ http.route({
     );
 
     if (result) {
-      // Fire-and-forget: update lastUsedAt (don't await, don't block response)
-      void ctx.runMutation((internal as any).apiKeys.touchKeyLastUsed, { keyId: result.id });
+      await ctx.scheduler.runAfter(0, (internal as any).apiKeys.touchKeyLastUsed, { keyId: result.id });
     }
 
     return new Response(JSON.stringify(result), {


### PR DESCRIPTION
## Summary

- `convex/http.ts` `/api/internal-validate-api-key` was firing-and-forgetting the `touchKeyLastUsed` mutation with `void ctx.runMutation(...)`. The `void` only silenced the TS warning — Convex still flagged the unawaited operation, and per the [docs on dangling promises](https://docs.convex.dev/functions/actions#dangling-promises) the mutation may not actually run because the httpAction can return before the mutation gets dispatched.
- Replaced with `await ctx.scheduler.runAfter(0, internal.apiKeys.touchKeyLastUsed, { keyId })` — the schedule call is a single cheap system-table insert (awaited so no dangling promise), and the mutation runs durably in the background.
- **Wrapped in try/catch** so a transient scheduler-enqueue failure cannot fail the validate endpoint. The gateway path (`server/_shared/user-api-key.ts:72`) coerces non-OK responses to `null`, and `cachedFetchJson` would stamp that `null` as a 60s negative-cache sentinel — which would have made a valid Pro key look invalid for 60s every time telemetry hiccupped. `lastUsedAt` is best-effort telemetry and must not gate auth availability.
- The existing `TOUCH_DEBOUNCE_MS = 5min` early-return inside `touchKeyLastUsed` still gates the actual `db.patch`, so per-key write load is unchanged.
- Net effect: the per-request `1 unawaited operation: [mutation]` log spam from `apiKeys:validateKeyByHash` goes away without introducing a new auth-availability failure mode.

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` (biome) + `lint:md`
- [x] `npm run test:data`
- [x] `npm run test:convex` (217 tests)
- [x] Edge function bundle check + `tests/edge-functions.test.mjs`
- [x] CJS syntax check + `version:check`
- [x] `scripts/check-sentry-coverage.mjs` clean (catch carries `// sentry-coverage-ok` with rationale)
- [ ] After deploy, confirm the `1 unawaited operation: [mutation]` line disappears from `apiKeys:validateKeyByHash` request logs