### PR TITLE
fix(sentry): ignoreErrors ClerkJS Response auth-flow branch limitations

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -263,7 +263,7 @@ Sentry.init({
     /\.at is not a function/, // Instagram/older Android in-app browsers missing Array.at()
     /Response cannot have a body with the given status/, // Safari: Response constructor with 204/304 + body
     /ClerkJS: Network error/, // Clerk SDK transient network failures on user devices
-    /^ClerkJS: Response:/, // Clerk SDK auth-flow branch not yet supported (e.g. needs_first_factor, needs_second_factor); SDK-internal limitation, not our code — WORLDMONITOR-Q1
+    /^ClerkJS: Response: needs_(?:first|second)_factor\b/, // Clerk SDK auth-flow branch not yet supported; SDK-internal limitation, not our code — WORLDMONITOR-Q1. Narrow to the observed `needs_*_factor` family so future actionable `ClerkJS: Response: <something>` errors (e.g. misconfigured redirect URI) still surface.
     /doesn't provide an export named/, // stale cached chunk after deploy references removed export
     /Possible side-effect in debug-evaluate/, // Chrome DevTools internal EvalError
     /ConvexError: CONFLICT/, // Expected OCC rejection on concurrent preference saves

--- a/src/main.ts
+++ b/src/main.ts
@@ -263,6 +263,7 @@ Sentry.init({
     /\.at is not a function/, // Instagram/older Android in-app browsers missing Array.at()
     /Response cannot have a body with the given status/, // Safari: Response constructor with 204/304 + body
     /ClerkJS: Network error/, // Clerk SDK transient network failures on user devices
+    /^ClerkJS: Response:/, // Clerk SDK auth-flow branch not yet supported (e.g. needs_first_factor, needs_second_factor); SDK-internal limitation, not our code — WORLDMONITOR-Q1
     /doesn't provide an export named/, // stale cached chunk after deploy references removed export
     /Possible side-effect in debug-evaluate/, // Chrome DevTools internal EvalError
     /ConvexError: CONFLICT/, // Expected OCC rejection on concurrent preference saves


### PR DESCRIPTION
## Summary

WORLDMONITOR-Q1 — `Error: ClerkJS: Response: needs_first_factor not supported yet.` from Clerk SDK's `onCodeEntryFinishedAction` handler. Firefox 150 / Ubuntu. 1 event / 1 user (low volume but trivially classifiable — this is Clerk's own internal SDK error prefix).

`ClerkJS: Response:` is emitted by Clerk's SDK runtime when it receives an auth-flow status it doesn't yet support (`needs_first_factor`, `needs_second_factor`, etc.). We don't synthesize this prefix anywhere in our code; it's pure third-party SDK output. Sister of the existing `/ClerkJS: Network error/` rule in the same `ignoreErrors` array.

The pattern is anchored (`^ClerkJS: Response:`) to avoid masking any future first-party error message that happens to contain the substring elsewhere.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 7828/7828 pass
- [x] `node --test tests/edge-functions.test.mjs` — 178/178 pass
- [x] Edge bundle check — clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK

## Sentry status

WORLDMONITOR-Q1 marked resolved in next release; auto-reopen if the regex misses.