### PR TITLE
Add Spain with its grocery sites to JSON

### DIFF
--- a/shared/grocery-basket.json
+++ b/shared/grocery-basket.json
@@ -99,6 +99,24 @@
       ]
     },
     {
+      "code": "ES",
+      "name": "Spain",
+      "currency": "EUR",
+      "flag": "🇪🇸",
+      "sites": [
+        "mercadona.es",
+        "carrefour.es",
+        "elcorteingles.es",
+        "hipercor.es",
+        "dia.es",
+        "alcampo.es",
+        "lidl.es",
+        "aldi.es",
+        "eroski.es",
+        "familycash.es"
+      ]
+    },
+    {
       "code": "FR",
       "name": "France",
       "currency": "EUR",


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [x] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [x] Config / Settings
- [ ] Other: <!-- specify -->

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [ ] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots

<!-- If applicable, add screenshots or screen recordings -->
