### PR TITLE
fix(redis): timeout cachedFetchJson inflight fetcher (#3539)

### DIFF
--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -283,6 +283,15 @@ export function __resetFetcherTimeoutForTests(): void {
  * guaranteed to settle even if the fetcher hangs forever. The timer is
  * cleared as soon as the fetcher wins so we don't leak handles or keep the
  * isolate awake unnecessarily.
+ *
+ * Known limitation: this only times out the cache-layer wrapper — the
+ * underlying fetcher promise is NOT cancelled. A truly hung upstream
+ * fetcher continues running in the background until the isolate recycles
+ * (~socket + small heap residue per orphan). Inflight-slot release means
+ * subsequent callers re-fetch successfully, so user-facing behavior is
+ * correct; only resource-cost is affected. True cancellation would require
+ * threading an AbortSignal through the fetcher contract, which is a wider
+ * refactor across every cached-fetch call site.
  */
 function withFetcherTimeout<T>(
   promise: Promise<T>,

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -251,29 +251,31 @@ export async function runRedisPipeline(
 const inflight = new Map<string, Promise<unknown>>();
 
 /**
- * Hard upper bound on how long a single fetcher may run before its inflight
- * entry is forced to settle (#3539).
+ * Default upper bound on how long a single fetcher may run before its
+ * inflight entry is forced to settle (#3539).
  *
  * Without this, a fetcher with no internal timeout (no AbortController, no
- * `fetch` `signal`) that truly never settles persists in the inflight Map for
- * the lifetime of the Vercel isolate — every subsequent caller for that key
- * gets handed the same unresolved promise, permanently poisoning the key.
+ * `fetch` `signal`) that truly never settles persists in the inflight Map
+ * for the lifetime of the Vercel isolate — every subsequent caller for that
+ * key gets handed the same unresolved promise, permanently poisoning it.
  *
- * 30s is well above any well-behaved upstream's UPSTREAM_TIMEOUT_MS budget
- * (typically 5–15s), so this only fires on a misbehaving fetcher. The cache
- * layer is the last line of defense; well-behaved callers never see it.
+ * 30s comfortably exceeds well-behaved HTTP fetchers (UPSTREAM_TIMEOUT_MS is
+ * typically 5–15s), so this only fires on misbehaving callers. Callers whose
+ * fetcher legitimately runs longer (LLM reasoning, multi-stage aggregations)
+ * MUST pass an explicit `opts.timeoutMs` set above their internal budget,
+ * otherwise the cache layer will pre-empt the caller's own timeout/fallback.
  */
 const FETCHER_TIMEOUT_MS_DEFAULT = 30_000;
-let fetcherTimeoutMs = FETCHER_TIMEOUT_MS_DEFAULT;
+let fetcherTimeoutDefaultMs = FETCHER_TIMEOUT_MS_DEFAULT;
 
-// Test-only: override the inflight timeout so unit tests can exercise the
-// timeout branch without sleeping for 30s. No production caller should ever
-// invoke this.
+// Test-only: override the DEFAULT inflight timeout so unit tests can exercise
+// the timeout branch without sleeping for 30s. Per-call `opts.timeoutMs` still
+// wins. No production caller should ever invoke this.
 export function __setFetcherTimeoutForTests(ms: number): void {
-  fetcherTimeoutMs = ms;
+  fetcherTimeoutDefaultMs = ms;
 }
 export function __resetFetcherTimeoutForTests(): void {
-  fetcherTimeoutMs = FETCHER_TIMEOUT_MS_DEFAULT;
+  fetcherTimeoutDefaultMs = FETCHER_TIMEOUT_MS_DEFAULT;
 }
 
 /**
@@ -282,12 +284,12 @@ export function __resetFetcherTimeoutForTests(): void {
  * cleared as soon as the fetcher wins so we don't leak handles or keep the
  * isolate awake unnecessarily.
  */
-function withFetcherTimeout<T>(promise: Promise<T>, key: string): Promise<T> {
+function withFetcherTimeout<T>(promise: Promise<T>, key: string, timeoutMs: number): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
-      reject(new Error(`cachedFetchJson timeout after ${fetcherTimeoutMs}ms for "${key}"`));
-    }, fetcherTimeoutMs);
+      reject(new Error(`cachedFetchJson timeout after ${timeoutMs}ms for "${key}"`));
+    }, timeoutMs);
   });
   return Promise.race([promise, timeout]).finally(() => {
     if (timer !== undefined) clearTimeout(timer);
@@ -295,18 +297,33 @@ function withFetcherTimeout<T>(promise: Promise<T>, key: string): Promise<T> {
 }
 
 /**
+ * Per-call cache-helper options.
+ *
+ * - `timeoutMs`: Hard upper bound on the fetcher. Defaults to 30s. Pass a
+ *   value above the caller's internal timeout (LLM `timeoutMs`, aggregated
+ *   `UPSTREAM_TIMEOUT_MS` sum) so the cache layer doesn't pre-empt the
+ *   caller's own bound. The cache safety net should be the LAST resort.
+ */
+export interface CachedFetchOpts {
+  timeoutMs?: number;
+}
+
+/**
  * Check cache, then fetch with coalescing on miss.
  * Concurrent callers for the same key share a single upstream fetch + Redis write.
  * When fetcher returns null, a sentinel is cached for negativeTtlSeconds to prevent request storms.
  *
- * The fetcher is force-rejected after FETCHER_TIMEOUT_MS_DEFAULT (#3539) so a
- * misbehaving fetcher cannot poison the inflight Map for the isolate lifetime.
+ * The fetcher is force-rejected after `opts.timeoutMs` (default 30s, #3539)
+ * so a misbehaving fetcher cannot poison the inflight Map for the isolate
+ * lifetime. Callers with legitimately long-running fetchers (LLM, multi-stage
+ * upstream aggregation) MUST pass `opts.timeoutMs` above their internal bound.
  */
 export async function cachedFetchJson<T extends object>(
   key: string,
   ttlSeconds: number,
   fetcher: () => Promise<T | null>,
   negativeTtlSeconds = 120,
+  opts?: CachedFetchOpts,
 ): Promise<T | null> {
   const cached = await getCachedJson(key);
   if (cached === NEG_SENTINEL) return null;
@@ -315,7 +332,8 @@ export async function cachedFetchJson<T extends object>(
   const existing = inflight.get(key);
   if (existing) return existing as Promise<T | null>;
 
-  const promise = withFetcherTimeout(fetcher(), key)
+  const timeoutMs = opts?.timeoutMs ?? fetcherTimeoutDefaultMs;
+  const promise = withFetcherTimeout(fetcher(), key, timeoutMs)
     .then(async (result) => {
       if (result != null) {
         await setCachedJson(key, result, ttlSeconds);
@@ -379,7 +397,7 @@ export async function cachedFetchJsonWithMeta<T extends object>(
   ttlSeconds: number,
   fetcher: () => Promise<T | null>,
   negativeTtlSeconds = 120,
-  opts?: { usage?: UsageHook },
+  opts?: { usage?: UsageHook; timeoutMs?: number },
 ): Promise<{ data: T | null; source: 'cache' | 'fresh' }> {
   const cached = await getCachedJson(key);
   if (cached === NEG_SENTINEL) return { data: null, source: 'cache' };
@@ -395,7 +413,8 @@ export async function cachedFetchJsonWithMeta<T extends object>(
   let upstreamStatus = 0;
   let cacheStatus: 'miss' | 'neg-sentinel' = 'miss';
 
-  const promise = withFetcherTimeout(fetcher(), key)
+  const timeoutMs = opts?.timeoutMs ?? fetcherTimeoutDefaultMs;
+  const promise = withFetcherTimeout(fetcher(), key, timeoutMs)
     .then(async (result) => {
       // Only count an upstream call as a 200 when it actually returned data.
       // A null result triggers the neg-sentinel branch below — these are

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -251,9 +251,56 @@ export async function runRedisPipeline(
 const inflight = new Map<string, Promise<unknown>>();
 
 /**
+ * Hard upper bound on how long a single fetcher may run before its inflight
+ * entry is forced to settle (#3539).
+ *
+ * Without this, a fetcher with no internal timeout (no AbortController, no
+ * `fetch` `signal`) that truly never settles persists in the inflight Map for
+ * the lifetime of the Vercel isolate — every subsequent caller for that key
+ * gets handed the same unresolved promise, permanently poisoning the key.
+ *
+ * 30s is well above any well-behaved upstream's UPSTREAM_TIMEOUT_MS budget
+ * (typically 5–15s), so this only fires on a misbehaving fetcher. The cache
+ * layer is the last line of defense; well-behaved callers never see it.
+ */
+const FETCHER_TIMEOUT_MS_DEFAULT = 30_000;
+let fetcherTimeoutMs = FETCHER_TIMEOUT_MS_DEFAULT;
+
+// Test-only: override the inflight timeout so unit tests can exercise the
+// timeout branch without sleeping for 30s. No production caller should ever
+// invoke this.
+export function __setFetcherTimeoutForTests(ms: number): void {
+  fetcherTimeoutMs = ms;
+}
+export function __resetFetcherTimeoutForTests(): void {
+  fetcherTimeoutMs = FETCHER_TIMEOUT_MS_DEFAULT;
+}
+
+/**
+ * Race the fetcher promise against a setTimeout so the inflight slot is
+ * guaranteed to settle even if the fetcher hangs forever. The timer is
+ * cleared as soon as the fetcher wins so we don't leak handles or keep the
+ * isolate awake unnecessarily.
+ */
+function withFetcherTimeout<T>(promise: Promise<T>, key: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`cachedFetchJson timeout after ${fetcherTimeoutMs}ms for "${key}"`));
+    }, fetcherTimeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}
+
+/**
  * Check cache, then fetch with coalescing on miss.
  * Concurrent callers for the same key share a single upstream fetch + Redis write.
  * When fetcher returns null, a sentinel is cached for negativeTtlSeconds to prevent request storms.
+ *
+ * The fetcher is force-rejected after FETCHER_TIMEOUT_MS_DEFAULT (#3539) so a
+ * misbehaving fetcher cannot poison the inflight Map for the isolate lifetime.
  */
 export async function cachedFetchJson<T extends object>(
   key: string,
@@ -268,7 +315,7 @@ export async function cachedFetchJson<T extends object>(
   const existing = inflight.get(key);
   if (existing) return existing as Promise<T | null>;
 
-  const promise = fetcher()
+  const promise = withFetcherTimeout(fetcher(), key)
     .then(async (result) => {
       if (result != null) {
         await setCachedJson(key, result, ttlSeconds);
@@ -348,7 +395,7 @@ export async function cachedFetchJsonWithMeta<T extends object>(
   let upstreamStatus = 0;
   let cacheStatus: 'miss' | 'neg-sentinel' = 'miss';
 
-  const promise = fetcher()
+  const promise = withFetcherTimeout(fetcher(), key)
     .then(async (result) => {
       // Only count an upstream call as a 200 when it actually returned data.
       // A null result triggers the neg-sentinel branch below — these are

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -284,11 +284,16 @@ export function __resetFetcherTimeoutForTests(): void {
  * cleared as soon as the fetcher wins so we don't leak handles or keep the
  * isolate awake unnecessarily.
  */
-function withFetcherTimeout<T>(promise: Promise<T>, key: string, timeoutMs: number): Promise<T> {
+function withFetcherTimeout<T>(
+  promise: Promise<T>,
+  key: string,
+  timeoutMs: number,
+  callerName: 'cachedFetchJson' | 'cachedFetchJsonWithMeta',
+): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
-      reject(new Error(`cachedFetchJson timeout after ${timeoutMs}ms for "${key}"`));
+      reject(new Error(`${callerName} timeout after ${timeoutMs}ms for "${key}"`));
     }, timeoutMs);
   });
   return Promise.race([promise, timeout]).finally(() => {
@@ -333,7 +338,7 @@ export async function cachedFetchJson<T extends object>(
   if (existing) return existing as Promise<T | null>;
 
   const timeoutMs = opts?.timeoutMs ?? fetcherTimeoutDefaultMs;
-  const promise = withFetcherTimeout(fetcher(), key, timeoutMs)
+  const promise = withFetcherTimeout(fetcher(), key, timeoutMs, 'cachedFetchJson')
     .then(async (result) => {
       if (result != null) {
         await setCachedJson(key, result, ttlSeconds);
@@ -414,7 +419,7 @@ export async function cachedFetchJsonWithMeta<T extends object>(
   let cacheStatus: 'miss' | 'neg-sentinel' = 'miss';
 
   const timeoutMs = opts?.timeoutMs ?? fetcherTimeoutDefaultMs;
-  const promise = withFetcherTimeout(fetcher(), key, timeoutMs)
+  const promise = withFetcherTimeout(fetcher(), key, timeoutMs, 'cachedFetchJsonWithMeta')
     .then(async (result) => {
       // Only count an upstream call as a 200 when it actually returned data.
       // A null result triggers the neg-sentinel branch below — these are

--- a/server/worldmonitor/intelligence/v1/deduct-situation.ts
+++ b/server/worldmonitor/intelligence/v1/deduct-situation.ts
@@ -125,7 +125,12 @@ export async function deductSituation(
             if (!result) return null;
             const analysis = postProcessDeductionOutput(result.content, mode);
             return { analysis, model: result.model, provider: result.provider };
-        }
+        },
+        undefined,
+        // Cache safety net must sit above the LLM's own timeout so the
+        // caller's bound wins; otherwise the inflight wrapper rejects at
+        // the 30s default before callLlmReasoning can complete (#3539).
+        { timeoutMs: DEDUCT_TIMEOUT_MS + 5_000 },
     );
 
     if (!cached?.analysis) {

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -1212,6 +1212,12 @@ export async function analyzeStock(
     });
     await storeStockAnalysisSnapshot(response, includeNews);
     return response;
+  }, undefined, {
+    // Worst-case fetcher budget: 2× UPSTREAM_TIMEOUT_MS sequenced (10s+10s for
+    // history/analyst then headlines/dividend) + 20s LLM overlay + small
+    // overhead. 60s safely sits above this so the cache safety net (#3539)
+    // doesn't pre-empt the caller's own per-stage timeouts.
+    timeoutMs: 60_000,
   });
 
   if (cached) return cached;

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -486,7 +486,7 @@ describe('cachedFetchJson inflight timeout (#3539)', { concurrency: 1 }, () => {
       assert.equal(r1.status, 'rejected');
       assert.equal(r2.status, 'rejected');
       assert.equal(r3.status, 'rejected');
-      assert.match(r1.reason.message, /timeout after 50ms for "hang:test:key"/);
+      assert.match(r1.reason.message, /^cachedFetchJson timeout after 50ms for "hang:test:key"$/);
 
       // Critical assertion: a follow-up call after the timeout must trigger a
       // fresh fetcher execution. Pre-fix the inflight Map kept the unresolved
@@ -618,7 +618,7 @@ describe('cachedFetchJson inflight timeout (#3539)', { concurrency: 1 }, () => {
 
       await assert.rejects(
         () => redis.cachedFetchJsonWithMeta('meta:hang:key', 60, () => new Promise(() => {})),
-        /timeout after 50ms for "meta:hang:key"/,
+        /^Error: cachedFetchJsonWithMeta timeout after 50ms for "meta:hang:key"$/,
       );
 
       // Subsequent call must succeed against a healthy fetcher — proves the

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -445,6 +445,140 @@ describe('negative-result caching', { concurrency: 1 }, () => {
   });
 });
 
+describe('cachedFetchJson inflight timeout (#3539)', { concurrency: 1 }, () => {
+  it('rejects a hung fetcher and releases the inflight slot so subsequent callers re-fetch', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = async (url) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) return jsonResponse({ result: undefined });
+      if (raw.includes('/set/')) return jsonResponse({ result: 'OK' });
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      redis.__setFetcherTimeoutForTests(50);
+
+      let hungCalls = 0;
+      // Fetcher that NEVER settles — simulates an upstream that hangs forever
+      // with no internal timeout and no AbortController.
+      const hungFetcher = () => {
+        hungCalls += 1;
+        return new Promise(() => {});
+      };
+
+      // Concurrent callers should all share the same hung promise (coalescing
+      // still works on the way in) and all reject with the timeout error.
+      const [r1, r2, r3] = await Promise.allSettled([
+        redis.cachedFetchJson('hang:test:key', 60, hungFetcher),
+        redis.cachedFetchJson('hang:test:key', 60, hungFetcher),
+        redis.cachedFetchJson('hang:test:key', 60, hungFetcher),
+      ]);
+
+      assert.equal(hungCalls, 1, 'fetcher should still be coalesced — one execution shared by all callers');
+      assert.equal(r1.status, 'rejected');
+      assert.equal(r2.status, 'rejected');
+      assert.equal(r3.status, 'rejected');
+      assert.match(r1.reason.message, /timeout after 50ms for "hang:test:key"/);
+
+      // Critical assertion: a follow-up call after the timeout must trigger a
+      // fresh fetcher execution. Pre-fix the inflight Map kept the unresolved
+      // promise forever, handing every subsequent caller the same dead handle.
+      let recovered = false;
+      const recoveredValue = await redis.cachedFetchJson('hang:test:key', 60, async () => {
+        recovered = true;
+        return { value: 'recovered' };
+      });
+      assert.equal(recovered, true, 'inflight slot must be released so a new fetcher can run');
+      assert.deepEqual(recoveredValue, { value: 'recovered' });
+    } finally {
+      redis.__resetFetcherTimeoutForTests();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('does NOT fire the timeout when the fetcher settles promptly', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = async (url) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) return jsonResponse({ result: undefined });
+      if (raw.includes('/set/')) return jsonResponse({ result: 'OK' });
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      redis.__setFetcherTimeoutForTests(50);
+
+      const result = await redis.cachedFetchJson('happy:test:key', 60, async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return { value: 'fast' };
+      });
+      assert.deepEqual(result, { value: 'fast' });
+
+      // Wait past the timeout window — if the timer wasn't cleared we'd see
+      // an unhandled rejection. Node's test runner surfaces those as failures.
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      redis.__resetFetcherTimeoutForTests();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('cachedFetchJsonWithMeta also enforces the inflight timeout', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = async (url) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) return jsonResponse({ result: undefined });
+      if (raw.includes('/set/')) return jsonResponse({ result: 'OK' });
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      redis.__setFetcherTimeoutForTests(50);
+
+      await assert.rejects(
+        () => redis.cachedFetchJsonWithMeta('meta:hang:key', 60, () => new Promise(() => {})),
+        /timeout after 50ms for "meta:hang:key"/,
+      );
+
+      // Subsequent call must succeed against a healthy fetcher — proves the
+      // inflight slot was released even on the timeout path.
+      const { data, source } = await redis.cachedFetchJsonWithMeta('meta:hang:key', 60, async () => ({ value: 'recovered' }));
+      assert.equal(source, 'fresh');
+      assert.deepEqual(data, { value: 'recovered' });
+    } finally {
+      redis.__resetFetcherTimeoutForTests();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+});
+
 describe('theater posture caching behavior', { concurrency: 1 }, () => {
   async function importTheaterPosture() {
     return importPatchedTsModule('server/worldmonitor/military/v1/get-theater-posture.ts', {

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -541,6 +541,61 @@ describe('cachedFetchJson inflight timeout (#3539)', { concurrency: 1 }, () => {
     }
   });
 
+  it('per-call opts.timeoutMs overrides the default ceiling', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = async (url) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) return jsonResponse({ result: undefined });
+      if (raw.includes('/set/')) return jsonResponse({ result: 'OK' });
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      // Default ceiling deliberately tiny; caller passes a much higher per-call
+      // budget, so a fetcher that runs 80ms should succeed. Without the
+      // override it would reject at 20ms.
+      redis.__setFetcherTimeoutForTests(20);
+
+      const result = await redis.cachedFetchJson(
+        'override:test:long',
+        60,
+        async () => {
+          await new Promise((r) => setTimeout(r, 80));
+          return { value: 'long-fetcher-allowed' };
+        },
+        undefined,
+        { timeoutMs: 500 },
+      );
+      assert.deepEqual(result, { value: 'long-fetcher-allowed' });
+
+      // Same shape for cachedFetchJsonWithMeta — opts.timeoutMs lives next to opts.usage.
+      const meta = await redis.cachedFetchJsonWithMeta(
+        'override:meta:long',
+        60,
+        async () => {
+          await new Promise((r) => setTimeout(r, 80));
+          return { value: 'meta-long-allowed' };
+        },
+        undefined,
+        { timeoutMs: 500 },
+      );
+      assert.equal(meta.source, 'fresh');
+      assert.deepEqual(meta.data, { value: 'meta-long-allowed' });
+    } finally {
+      redis.__resetFetcherTimeoutForTests();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
   it('cachedFetchJsonWithMeta also enforces the inflight timeout', async () => {
     const redis = await importRedisFresh();
     const restoreEnv = withEnv({


### PR DESCRIPTION
## Summary

- Wraps the fetcher in `cachedFetchJson` and `cachedFetchJsonWithMeta` with a 30 s `Promise.race` timeout so the inflight Map slot is **guaranteed to settle** even if the fetcher truly never resolves (no internal timeout, no `AbortController`).
- Pre-fix, the inflight entry only deleted in `.finally()`. A hung fetcher persisted in the Vercel isolate forever — every subsequent caller for that key was handed the same unresolved promise, permanently poisoning the key.
- Treats the cache layer as the last line of defense: well-behaved fetchers using their own `UPSTREAM_TIMEOUT_MS` (typically 5–15 s) never see the 30 s ceiling. The trap was a future caller forgetting to set their own timeout.
- Test-only `__setFetcherTimeoutForTests` / `__resetFetcherTimeoutForTests` exports follow the existing `__resetKeyPrefixCacheForTests` pattern so unit tests can exercise the timeout branch without sleeping for 30 s.
- Timer is `clearTimeout`'d via `.finally()` whenever the fetcher wins so we don't leak handles or keep the isolate awake unnecessarily.

Closes #3539.

## Test plan

- [x] `npx tsx --test tests/redis-caching.test.mjs` — 21/21 pass, including 3 new cases:
  - hung fetcher rejects with the timeout error and the inflight slot is released so a follow-up caller successfully re-fetches (the core regression),
  - prompt fetchers don't trip the timeout (no leaked timers / unhandled rejections after the timeout window passes),
  - `cachedFetchJsonWithMeta` enforces the same bound.
- [x] `npx tsc --noEmit -p tsconfig.api.json` clean.
- [x] `npx biome lint server/_shared/redis.ts tests/redis-caching.test.mjs` clean.