### PR TITLE
fix(health): RPC-side seed-meta for riskScores + document daily cron for energy-v2 bundle

### DIFF
--- a/scripts/seed-bundle-resilience-energy-v2.mjs
+++ b/scripts/seed-bundle-resilience-energy-v2.mjs
@@ -7,9 +7,25 @@
 //   - seed-fossil-electricity-share.mjs → resilience:fossil-electricity-share:v1
 //   - seed-power-reliability.mjs       → resilience:power-losses:v1
 //
-// Cadence: weekly (7 days); data is annual at source so polling more
-// frequently just hammers the World Bank API without gaining fresh
-// data. maxStaleMin in api/health.js is set to 8 days (2× interval).
+// Cadence: per-slot interval is 7 days; data is annual at source so polling
+// more frequently just hammers the World Bank API without gaining fresh
+// data. The per-slot intervalMs gate inside _bundle-runner.mjs enforces the
+// 7-day minimum between actual seeds — the Railway cron only needs to fire
+// often enough to catch the next-eligible day after the interval expires.
+//
+// Cron schedule: DAILY 06:00 UTC ("0 6 * * *"), not weekly Monday-only.
+// Why daily instead of weekly: the 7-day per-slot interval is anchored to
+// the previous successful seed's wall-clock time, NOT to a calendar day.
+// If a previous seed happened on a non-Monday (e.g. Friday from a manual
+// run, an initial provisioning fire, or any backfill), then with a
+// Monday-only cron the next eligible Monday is "previous seed + 3 days,
+// still inside 7-day interval, skip" → the seed waits another full 7 days
+// (10 days total). The maxStaleMin alarm fires at day 8 — 2 days before
+// the next cron-eligible Monday. Daily cron eliminates this dead window:
+// the 7-day interval auto-resyncs to whichever wall-clock day the seed
+// last fired, regardless of weekday. Verified against the 2026-04-24
+// Friday-seed → 2026-04-27 Monday-skip → 2026-05-04 Monday-fire
+// production incident that triggered this fix.
 //
 // Railway service config (set up manually via Railway dashboard or
 // `railway service`):
@@ -20,8 +36,12 @@
 //     scripts/seed-fossil-electricity-share.mjs,
 //     scripts/seed-power-reliability.mjs, scripts/_seed-utils.mjs,
 //     scripts/_bundle-runner.mjs, scripts/seed-bundle-resilience-energy-v2.mjs
-//   - Cron schedule: "0 6 * * 1" (Monday 06:00 UTC, weekly)
+//   - Cron schedule: "0 6 * * *" (daily 06:00 UTC; per-slot interval gates real seeds)
 //   - Required env: UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN
+//
+// IMPORTANT: After merging this PR, update the Railway service's cron
+// schedule to "0 6 * * *". Code-side change alone is not sufficient —
+// the Railway cron is configured in the dashboard, not in this file.
 
 import { runBundle, DAY } from './_bundle-runner.mjs';
 

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -597,7 +597,7 @@ export async function getRiskScores(
   _req: GetRiskScoresRequest,
 ): Promise<GetRiskScoresResponse> {
   try {
-    const { data: result } = await cachedFetchJsonWithMeta<GetRiskScoresResponse>(
+    const { data: result, source } = await cachedFetchJsonWithMeta<GetRiskScoresResponse>(
       RISK_CACHE_KEY,
       RISK_CACHE_TTL,
       async () => {
@@ -612,8 +612,8 @@ export async function getRiskScores(
     );
     if (result) {
       await setCachedJson(RISK_STALE_CACHE_KEY, result, RISK_STALE_TTL).catch(() => {});
-      // Write seed-meta on every fresh fetch so /api/health.riskScores stays
-      // green from real user traffic, independent of the ais-relay
+      // Write seed-meta on every FRESH upstream fetch so /api/health.riskScores
+      // stays green from real user traffic, independent of the ais-relay
       // CII warm-ping. Pre-2026-05-02 the warm-ping was the SOLE writer of
       // this seed-meta — when the relay → api.worldmonitor.app auth path
       // broke (all warm-ping types started returning HTTP 401 simultaneously),
@@ -621,15 +621,27 @@ export async function getRiskScores(
       // and chokepoints had RPC-side seed-meta writes keeping them fresh
       // via real user traffic. This brings riskScores into the same pattern
       // as those two: defense-in-depth, no single point of freshness failure.
+      //
+      // Gated on source === 'fresh' (PR #3562 review P2): cachedFetchJsonWithMeta
+      // returns immediately on cache hits with `source: 'cache'`. Stamping
+      // `fetchedAt: Date.now()` on cache hits would conflate "data was
+      // recently re-fetched" with "data was recently served," letting
+      // health.riskScores stay fresh even when upstream stopped responding
+      // (cache would be served until its TTL=600s expired, after which the
+      // first request triggers a fresh fetch and surfaces the failure
+      // properly — but only if seed-meta wasn't already advanced by a cache
+      // hit). Only stamp on actual upstream re-fetches.
       // 7-day TTL matches the warm-ping write so health.maxStaleMin (30min)
       // logic is unchanged.
-      const count = result.ciiScores?.length || 0;
-      if (count > 0) {
-        await setCachedJson(
-          'seed-meta:intelligence:risk-scores',
-          { fetchedAt: Date.now(), recordCount: count },
-          604800,
-        ).catch(() => {});
+      if (source === 'fresh') {
+        const count = result.ciiScores?.length || 0;
+        if (count > 0) {
+          await setCachedJson(
+            'seed-meta:intelligence:risk-scores',
+            { fetchedAt: Date.now(), recordCount: count },
+            604800,
+          ).catch(() => {});
+        }
       }
       return result;
     }

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -612,6 +612,25 @@ export async function getRiskScores(
     );
     if (result) {
       await setCachedJson(RISK_STALE_CACHE_KEY, result, RISK_STALE_TTL).catch(() => {});
+      // Write seed-meta on every fresh fetch so /api/health.riskScores stays
+      // green from real user traffic, independent of the ais-relay
+      // CII warm-ping. Pre-2026-05-02 the warm-ping was the SOLE writer of
+      // this seed-meta — when the relay → api.worldmonitor.app auth path
+      // broke (all warm-ping types started returning HTTP 401 simultaneously),
+      // riskScores was the only key that flipped STALE because cable-health
+      // and chokepoints had RPC-side seed-meta writes keeping them fresh
+      // via real user traffic. This brings riskScores into the same pattern
+      // as those two: defense-in-depth, no single point of freshness failure.
+      // 7-day TTL matches the warm-ping write so health.maxStaleMin (30min)
+      // logic is unchanged.
+      const count = result.ciiScores?.length || 0;
+      if (count > 0) {
+        await setCachedJson(
+          'seed-meta:intelligence:risk-scores',
+          { fetchedAt: Date.now(), recordCount: count },
+          604800,
+        ).catch(() => {});
+      }
       return result;
     }
   } catch { /* upstream failed, fall through to stale */ }


### PR DESCRIPTION
## Summary

Two distinct STALE_SEED alarms with definitive Railway log evidence.

### Issue 1: riskScores STALE_SEED — relay→gateway auth broken globally

```
riskScores: STALE_SEED  records=31  seedAgeMin=153  maxStaleMin=30
```

Railway `ais-relay` service log of the last 30 min:

```
[CII] Warm-ping failed: HTTP 401              × 5
[Chokepoints] Warm-ping failed: HTTP 401      × 1
[CableHealth] Warm-ping failed: HTTP 401      × 1
```

**ALL THREE** warm-pings to `api.worldmonitor.app` are 401-ing. The relay sends `Origin: https://worldmonitor.app` which should match `BROWSER_ORIGIN_PATTERNS` and `validateApiKey` should return `valid:true` — but the gateway is rejecting. Suspected causes (separate investigation): Vercel firewall rule, deploy mismatch with the local `_api-key.js` source, or Cloudflare cache poisoning the 401 across the CDN.

**Why only `riskScores` flipped STALE** while `cableHealth` and `chokepoints` stayed green: those two have **RPC-side seed-meta writes** in their handlers, so real user traffic keeps them fresh independently of the broken warm-ping. `getRiskScores` doesn't — the warm-ping is its sole writer.

**Fix**: bring `getRiskScores` into the same defense-in-depth pattern. Write `seed-meta:intelligence:risk-scores` inside the RPC handler on every fresh fetch (count > 0). Now real user traffic keeps it green; warm-ping becomes the secondary path.

This does NOT fix the underlying ais-relay 401 issue — that's a separate investigation. But it closes the single-point-of-freshness-failure for `riskScores` so the alarm stops firing immediately on first user request, while the auth root cause is debugged.

### Issue 2: lowCarbon/fossil/powerLosses STALE_SEED — Monday-only cron config bug

```
lowCarbonGeneration:    STALE_SEED  records=216  seedAgeMin=11907  maxStaleMin=11520
fossilElectricityShare: STALE_SEED  records=216  seedAgeMin=11907  maxStaleMin=11520
powerLosses:            STALE_SEED  records=216  seedAgeMin=11907  maxStaleMin=11520
```

Railway `seed-bundle-resilience-energy-v2` log shows the cron fired Mon 2026-04-27 06:01 UTC and SKIPPED all 3 slots:
```
[Low-Carbon-Generation] Skipped, last seeded 4337min ago (interval: 10080min)
[Fossil-Electricity-Share] Skipped, last seeded 4337min ago (interval: 10080min)
[Power-Losses] Skipped, last seeded 4337min ago (interval: 10080min)
```

Last successful seed was Friday 2026-04-24 (3 days before Monday 04-27 → inside 7-day interval → skipped). Next eligible Monday cron: 2026-05-04, **10 days after the last seed**. `maxStaleMin=11520` (8 days) fires the alarm Saturday 2026-05-02 — 2 days BEFORE the next eligible Monday.

This is a config bug: when the previous seed lands on a non-Monday, a Monday-only cron + 7-day per-slot interval guarantees a 10-13 day gap to the next actual seed, but the alarm window is 8 days.

**Fix**: change the bundle's cron schedule from `"0 6 * * 1"` (Monday weekly) to `"0 6 * * *"` (daily 06:00 UTC). The per-slot `intervalMs` gate inside `_bundle-runner.mjs` already enforces the 7-day minimum between actual seeds — daily cron just lets the next-eligible day after interval expiry pick up the seed regardless of weekday. Hammer-on-upstream is unchanged because the per-slot interval gates the actual fetch.

⚠️ **The Railway cron schedule is configured in the Railway dashboard, not in this file.** This PR updates the comment block to document the new schedule, but **you'll need to update the cron string in the Railway service config post-merge**. Documented inline at the top of `scripts/seed-bundle-resilience-energy-v2.mjs`.

## Test plan

- [x] `npm run typecheck` + `typecheck:api` clean.
- [x] `npm run lint` clean.
- [x] `npm run test:data` 7834/7834 pass.
- [x] All other gates clean.
- [ ] After merge: `riskScores` should flip to OK on next user-traffic RPC hit (typically within 60s of any dashboard load). The ais-relay 401 root cause remains; track separately.
- [ ] After merge + Railway dashboard cron update to `"0 6 * * *"`: lowCarbon/fossil/powerLosses will flip to OK on Monday 2026-05-04 06:00 UTC (the natural next-eligible-day fire). The fix structure prevents the alarm from re-firing on future non-Monday seeds.