### PR TITLE
fix(rate-limit): audible fail-closed posture + drop spoofable XFF identity

### DIFF
--- a/api/_rate-limit.js
+++ b/api/_rate-limit.js
@@ -1,6 +1,7 @@
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 import { jsonResponse } from './_json-response.js';
+import { captureSilentError } from './_sentry-edge.js';
 
 let ratelimit = null;
 
@@ -21,26 +22,85 @@ function getRatelimit() {
   return ratelimit;
 }
 
+// Sentinel returned when no trusted client-IP header is present. Routed
+// through the Upstash limiter as a single shared bucket so the entire
+// "no trusted identity" population is naturally rate-limited together —
+// an attacker who strips cf-connecting-ip / x-real-ip can no longer rotate
+// identities by toggling x-forwarded-for. (#3531) Mirrors the constant in
+// server/_shared/rate-limit.ts.
+export const UNKNOWN_CLIENT_IP = 'unknown';
+
+// Marker headers set on every degraded (fail-closed) response so observability
+// can correlate "rate-limit unavailable" windows with downstream behaviour
+// without parsing the JSON body. Mirrors RATE_LIMIT_DEGRADED_HEADERS in
+// server/_shared/rate-limit.ts.
+export const RATE_LIMIT_DEGRADED_HEADERS = Object.freeze({
+  'X-RateLimit-Mode': 'degraded',
+  'Retry-After': '5',
+});
+
 export function getClientIp(request) {
-  // With Cloudflare proxy -> Vercel, x-real-ip is the CF edge IP (shared
-  // across users). cf-connecting-ip is the actual client IP — prefer it.
+  // With Cloudflare proxy → Vercel, x-real-ip is the CF edge IP (shared
+  // across users). cf-connecting-ip is the actual client IP set by
+  // Cloudflare — prefer it.
+  //
   // x-forwarded-for is client-settable and MUST NOT be trusted for rate
-  // limiting: any caller can set it to spoof a victim's IP (burning their
-  // budget) or cycle synthetic values to bypass their own limit. Critically,
-  // /api/wm-session uses this helper — a spoofable rate limit there enables
-  // mass-minting wms_ anonymous session tokens which a separate auth gate
-  // (e.g. /api/mcp-proxy without forceKey) would otherwise accept. Issue
-  // #3721 (matches server/_shared/rate-limit.ts).
-  return (
-    request.headers.get('cf-connecting-ip') ||
-    request.headers.get('x-real-ip') ||
-    '0.0.0.0'
+  // limiting (#3531) — without that fallback removed, a caller bypassing
+  // CF entirely (direct request) could rotate identities by toggling the
+  // header and beat the per-IP window. When neither trusted header is
+  // present we return the UNKNOWN_CLIENT_IP sentinel so Upstash treats
+  // the whole untrusted-identity population as one shared bucket.
+  //
+  // Trim each header value before falling through — a whitespace-only
+  // cf-connecting-ip would otherwise short-circuit past x-real-ip.
+  // (Mirrors getClientIp in server/_shared/rate-limit.ts.)
+  const cf = (request.headers.get('cf-connecting-ip') ?? '').trim();
+  const xr = (request.headers.get('x-real-ip') ?? '').trim();
+  return cf || xr || UNKNOWN_CLIENT_IP;
+}
+
+function logRateLimitDegraded(stage, err, ctx) {
+  const msg = err instanceof Error ? err.message : String(err);
+  // Keep the prefix stable — server/_shared/rate-limit.ts emits the same
+  // shape and operators grep across both surfaces.
+  console.error(`[rate-limit] redis-error stage=${stage} msg=${msg}`);
+  captureSilentError(err, {
+    tags: { surface: 'api', component: 'rate-limit', stage },
+    fingerprint: ['rate-limit', 'redis-error', stage],
+    ctx,
+  });
+}
+
+function rateLimitDegradedResponse(corsHeaders) {
+  return jsonResponse(
+    { error: 'Rate-limit service temporarily unavailable' },
+    503,
+    { ...RATE_LIMIT_DEGRADED_HEADERS, ...corsHeaders },
   );
 }
 
-export async function checkRateLimit(request, corsHeaders) {
+/**
+ * @param {Request} request
+ * @param {Record<string, string>} corsHeaders
+ * @param {{ failClosed?: boolean, ctx?: { waitUntil: (p: Promise<unknown>) => void } }} [opts]
+ *   When `failClosed` is true and Redis is unavailable, return a 503 with
+ *   the `X-RateLimit-Mode: degraded` marker instead of allowing the
+ *   request through. Pass `true` for endpoints where the rate-limit IS
+ *   the abuse defence (LLM, checkout). Default `false` keeps the
+ *   availability-first posture for general traffic so a Redis blip
+ *   doesn't black-hole the whole site. `ctx` is the Vercel handler
+ *   context — passing it lets the Sentry envelope dispatch survive
+ *   isolate teardown. (#3531)
+ */
+export async function checkRateLimit(request, corsHeaders, opts = {}) {
   const rl = getRatelimit();
-  if (!rl) return null;
+  if (!rl) {
+    if (opts.failClosed) {
+      logRateLimitDegraded('checkRateLimit:missing-config', new Error('Upstash Redis is not configured'), opts.ctx);
+      return rateLimitDegradedResponse(corsHeaders);
+    }
+    return null;
+  }
 
   const ip = getClientIp(request);
   try {
@@ -57,7 +117,9 @@ export async function checkRateLimit(request, corsHeaders) {
     }
 
     return null;
-  } catch {
+  } catch (err) {
+    logRateLimitDegraded('checkRateLimit', err, opts.ctx);
+    if (opts.failClosed) return rateLimitDegradedResponse(corsHeaders);
     return null;
   }
 }

--- a/api/_rate-limit.test.mjs
+++ b/api/_rate-limit.test.mjs
@@ -1,0 +1,130 @@
+// Tests for the M9 (fail-closed posture + audible Redis errors) and M16
+// (drop spoofable x-forwarded-for fallback) fixes from issue #3531 — Vercel
+// edge mirror at api/_rate-limit.js. Behavioural parity with
+// server/_shared/rate-limit.ts is enforced by string-comparing
+// RATE_LIMIT_DEGRADED_HEADERS / UNKNOWN_CLIENT_IP across the two files.
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  RATE_LIMIT_DEGRADED_HEADERS,
+  UNKNOWN_CLIENT_IP,
+  checkRateLimit,
+  getClientIp,
+} from './_rate-limit.js';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+const originalConsoleError = console.error;
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+function makeRequest(headers = {}) {
+  return new Request('https://worldmonitor.app/api/test', { headers });
+}
+
+async function importFreshRateLimitModule() {
+  return import(`./_rate-limit.js?test=${Date.now()}-${Math.random()}`);
+}
+
+describe('api/_rate-limit getClientIp (#3531)', () => {
+  it('prefers cf-connecting-ip when Cloudflare is in front', () => {
+    const req = makeRequest({
+      'cf-connecting-ip': '203.0.113.7',
+      'x-real-ip': '192.0.2.5',
+      'x-forwarded-for': '198.51.100.8',
+    });
+    assert.equal(getClientIp(req), '203.0.113.7');
+  });
+
+  it('does NOT honour x-forwarded-for as a fallback identity', () => {
+    const req = makeRequest({ 'x-forwarded-for': '198.51.100.8, 203.0.113.10' });
+    assert.equal(getClientIp(req), UNKNOWN_CLIENT_IP);
+    assert.equal(getClientIp(req), 'unknown');
+  });
+});
+
+describe('api/_rate-limit checkRateLimit fail-open / fail-closed (#3531 M9)', () => {
+  let consoleErrors = [];
+
+  beforeEach(() => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+    consoleErrors = [];
+    console.error = (...args) => {
+      consoleErrors.push(args.map((a) => String(a)).join(' '));
+    };
+    globalThis.fetch = async () => {
+      throw new Error('upstash unreachable');
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    console.error = originalConsoleError;
+    restoreEnv();
+  });
+
+  it('fail-open default: returns null and logs a structured Redis error', async () => {
+    const res = await checkRateLimit(makeRequest({ 'cf-connecting-ip': '203.0.113.7' }), {});
+    assert.equal(res, null);
+    assert.ok(
+      consoleErrors.some(
+        (line) =>
+          line.includes('[rate-limit] redis-error') &&
+          line.includes('stage=checkRateLimit'),
+      ),
+      `expected structured rate-limit error log, got: ${consoleErrors.join('\n')}`,
+    );
+  });
+
+  it('failClosed=true: returns 503 with the X-RateLimit-Mode degraded marker', async () => {
+    const res = await checkRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      { 'Access-Control-Allow-Origin': 'https://worldmonitor.app' },
+      { failClosed: true },
+    );
+    assert.ok(res, 'expected a Response when fail-closed');
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+    assert.equal(res.headers.get('Retry-After'), '5');
+    assert.equal(
+      res.headers.get('Access-Control-Allow-Origin'),
+      'https://worldmonitor.app',
+    );
+  });
+
+  it('failClosed=true: returns degraded 503 when Upstash env is missing', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const mod = await importFreshRateLimitModule();
+
+    const res = await mod.checkRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      { 'Access-Control-Allow-Origin': 'https://worldmonitor.app' },
+      { failClosed: true },
+    );
+
+    assert.ok(res, 'expected a Response when fail-closed limiter is unconfigured');
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+    assert.equal(res.headers.get('Retry-After'), '5');
+    assert.equal(
+      res.headers.get('Access-Control-Allow-Origin'),
+      'https://worldmonitor.app',
+    );
+  });
+});
+
+describe('api/_rate-limit constants parity', () => {
+  it('mirrors server/_shared/rate-limit degraded-marker shape', () => {
+    assert.equal(RATE_LIMIT_DEGRADED_HEADERS['X-RateLimit-Mode'], 'degraded');
+    assert.equal(RATE_LIMIT_DEGRADED_HEADERS['Retry-After'], '5');
+  });
+});

--- a/api/chat-analyst.ts
+++ b/api/chat-analyst.ts
@@ -90,7 +90,11 @@ export default async function handler(req: Request): Promise<Response> {
     return json({ error: 'Pro subscription required' }, 403, corsHeaders);
   }
 
-  const rateLimitResponse = await checkRateLimit(req, corsHeaders);
+  // Streaming LLM endpoint — the rate-limit IS the abuse defence (each
+  // call hits a frontier model). This route doesn't go through gateway
+  // checkEndpointRateLimit, so opt into fail-closed explicitly: a Redis
+  // outage must not silently lift the budget. (#3531)
+  const rateLimitResponse = await checkRateLimit(req, corsHeaders, { failClosed: true });
   if (rateLimitResponse) return rateLimitResponse;
 
   let body: ChatAnalystRequestBody;

--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -475,8 +475,9 @@ export default async function handler(req) {
 
   // Per-IP rate limit (#3805). Runs AFTER auth/CORS so unauthenticated and
   // cross-origin callers are still rejected first (cheaper to short-circuit
-  // without a Redis round-trip). On Redis error checkScopedRateLimit
-  // fail-opens — matches checkRateLimit / checkEndpointRateLimit semantics.
+  // without a Redis round-trip). This endpoint is already premium-auth gated,
+  // so Redis-degraded scoped limits intentionally stay availability-first;
+  // checkScopedRateLimit logs/Sentry-captures the degraded path.
   const scoped = await checkScopedRateLimit(RATE_LIMIT_SCOPE, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW, ip);
   if (!scoped.allowed) {
     const retryAfter = Math.max(1, Math.ceil((scoped.reset - Date.now()) / 1000));

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -18,17 +18,48 @@ function getRatelimit(): Ratelimit | null {
   return ratelimit;
 }
 
-function getClientIp(request: Request): string {
-  // With Cloudflare proxy → Vercel, x-real-ip is the CF edge IP (shared across users).
-  // cf-connecting-ip is the actual client IP set by Cloudflare — prefer it.
-  // x-forwarded-for is client-settable and MUST NOT be trusted for rate limiting:
-  // any caller can set it to spoof a victim's IP (burning their budget) or cycle
-  // synthetic values to bypass their own limit. Issue #3721.
-  return (
-    request.headers.get('cf-connecting-ip') ||
-    request.headers.get('x-real-ip') ||
-    '0.0.0.0'
-  );
+// Sentinel returned when no trusted client-IP header is present. Routed
+// through the Upstash limiter as a single shared bucket so the entire
+// "no trusted identity" population is naturally rate-limited together —
+// an attacker who strips cf-connecting-ip / x-real-ip can no longer rotate
+// identities by toggling x-forwarded-for. See getClientIp / #3531.
+export const UNKNOWN_CLIENT_IP = 'unknown';
+
+// Structured one-line log so api/server log aggregation can grep for the
+// "rate-limit available" gap independently of Sentry. Keep the prefix
+// stable — operators and the api/_rate-limit.js mirror both emit it.
+function logRateLimitDegraded(stage: string, err: unknown): void {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`[rate-limit] redis-error stage=${stage} msg=${msg}`);
+}
+
+// Marker header set on every degraded (fail-closed) response so observability
+// can correlate "rate-limit unavailable" windows with downstream behaviour
+// without parsing the JSON body. Mirrored in api/_rate-limit.js.
+export const RATE_LIMIT_DEGRADED_HEADERS = {
+  'X-RateLimit-Mode': 'degraded',
+  // Short Retry-After encourages clients to retry once the limiter is back,
+  // rather than treating the 503 as a hard outage.
+  'Retry-After': '5',
+} as const;
+
+export function getClientIp(request: Request): string {
+  // With Cloudflare proxy → Vercel, x-real-ip is the CF edge IP (shared across
+  // users). cf-connecting-ip is the actual client IP set by Cloudflare —
+  // prefer it.
+  //
+  // x-forwarded-for is client-settable and MUST NOT be trusted for
+  // rate limiting (#3531) — without that fallback removed, a caller bypassing
+  // CF entirely (direct request) could rotate identities by toggling the
+  // header and beat the per-IP window. When neither trusted header is
+  // present we return the UNKNOWN_CLIENT_IP sentinel so Upstash treats the
+  // whole untrusted-identity population as one shared bucket.
+  //
+  // Trim each header value before falling through — a whitespace-only
+  // cf-connecting-ip would otherwise short-circuit past x-real-ip.
+  const cf = (request.headers.get('cf-connecting-ip') ?? '').trim();
+  const xr = (request.headers.get('x-real-ip') ?? '').trim();
+  return cf || xr || UNKNOWN_CLIENT_IP;
 }
 
 function tooManyRequestsResponse(
@@ -49,12 +80,45 @@ function tooManyRequestsResponse(
   });
 }
 
+function rateLimitDegradedResponse(corsHeaders: Record<string, string>): Response {
+  return new Response(
+    JSON.stringify({ error: 'Rate-limit service temporarily unavailable' }),
+    {
+      status: 503,
+      headers: {
+        'Content-Type': 'application/json',
+        ...RATE_LIMIT_DEGRADED_HEADERS,
+        ...corsHeaders,
+      },
+    },
+  );
+}
+
+export interface RateLimitOptions {
+  /**
+   * When true and Redis is unavailable, return a 503 (with the
+   * `X-RateLimit-Mode: degraded` marker) instead of allowing the request
+   * through. Pass `true` for endpoints where the rate-limit IS the abuse
+   * defence (LLM, checkout, lead capture). Default `false` keeps the
+   * availability-first posture for general traffic so a Redis blip doesn't
+   * black-hole the whole site. (#3531)
+   */
+  failClosed?: boolean;
+}
+
 export async function checkRateLimit(
   request: Request,
   corsHeaders: Record<string, string>,
+  opts: RateLimitOptions = {},
 ): Promise<Response | null> {
   const rl = getRatelimit();
-  if (!rl) return null;
+  if (!rl) {
+    if (opts.failClosed) {
+      logRateLimitDegraded('checkRateLimit:missing-config', new Error('Upstash Redis is not configured'));
+      return rateLimitDegradedResponse(corsHeaders);
+    }
+    return null;
+  }
 
   const ip = getClientIp(request);
 
@@ -66,7 +130,9 @@ export async function checkRateLimit(
     }
 
     return null;
-  } catch {
+  } catch (err) {
+    logRateLimitDegraded('checkRateLimit', err);
+    if (opts.failClosed) return rateLimitDegradedResponse(corsHeaders);
     return null;
   }
 }
@@ -149,9 +215,22 @@ export async function checkEndpointRateLimit(
   request: Request,
   pathname: string,
   corsHeaders: Record<string, string>,
+  opts: RateLimitOptions = {},
 ): Promise<Response | null> {
+  if (!hasEndpointRatePolicy(pathname)) return null;
+
   const rl = getEndpointRatelimit(pathname);
-  if (!rl) return null;
+  if (!rl) {
+    const failClosed = opts.failClosed ?? true;
+    if (failClosed) {
+      logRateLimitDegraded(
+        `checkEndpointRateLimit:${pathname}:missing-config`,
+        new Error('Upstash Redis is not configured'),
+      );
+      return rateLimitDegradedResponse(corsHeaders);
+    }
+    return null;
+  }
 
   const ip = getClientIp(request);
 
@@ -163,7 +242,14 @@ export async function checkEndpointRateLimit(
     }
 
     return null;
-  } catch {
+  } catch (err) {
+    logRateLimitDegraded(`checkEndpointRateLimit:${pathname}`, err);
+    // Per-endpoint policies exist precisely because the limit IS the abuse
+    // defence — an LLM endpoint or a 3/hr lead-capture endpoint is the
+    // worst place to silently fall through during a Redis outage. Default
+    // to fail-closed; callers can opt out via opts.failClosed = false.
+    const failClosed = opts.failClosed ?? true;
+    if (failClosed) return rateLimitDegradedResponse(corsHeaders);
     return null;
   }
 }
@@ -200,13 +286,23 @@ export interface ScopedRateLimitResult {
   allowed: boolean;
   limit: number;
   reset: number;
+  /**
+   * True when Redis was unreachable and the helper fell back to the
+   * fail-open default. Callers that need fail-closed semantics should
+   * gate on this — e.g. lead-capture handlers can refuse the write to
+   * preserve the 3/hr budget across a Redis blip. (#3531)
+   */
+  degraded: boolean;
 }
 
 /**
  * Returns whether the request is under the scoped budget. `scope` is an
  * opaque namespace (e.g. `${pathname}#desktop`); `identifier` is usually the
  * client IP but can be any stable caller identifier. Fail-open on Redis errors
- * to stay consistent with checkRateLimit / checkEndpointRateLimit semantics.
+ * to stay consistent with checkRateLimit / checkEndpointRateLimit semantics,
+ * but the `degraded` flag lets callers escalate to fail-closed locally
+ * (#3531). The Redis error itself is logged once per call so silent bypass
+ * windows are visible in logs / Sentry.
  */
 export async function checkScopedRateLimit(
   scope: string,
@@ -215,11 +311,17 @@ export async function checkScopedRateLimit(
   identifier: string,
 ): Promise<ScopedRateLimitResult> {
   const rl = getScopedRatelimit(scope, limit, window);
-  if (!rl) return { allowed: true, limit, reset: 0 };
+  if (!rl) return { allowed: true, limit, reset: 0, degraded: true };
   try {
     const result = await rl.limit(`${scope}:${identifier}`);
-    return { allowed: result.success, limit: result.limit, reset: result.reset };
-  } catch {
-    return { allowed: true, limit, reset: 0 };
+    return {
+      allowed: result.success,
+      limit: result.limit,
+      reset: result.reset,
+      degraded: false,
+    };
+  } catch (err) {
+    logRateLimitDegraded(`checkScopedRateLimit:${scope}`, err);
+    return { allowed: true, limit, reset: 0, degraded: true };
   }
 }

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -1,5 +1,7 @@
 import { Ratelimit, type Duration } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from '../../api/_sentry-edge.js';
 
 let ratelimit: Ratelimit | null = null;
 
@@ -31,6 +33,10 @@ export const UNKNOWN_CLIENT_IP = 'unknown';
 function logRateLimitDegraded(stage: string, err: unknown): void {
   const msg = err instanceof Error ? err.message : String(err);
   console.error(`[rate-limit] redis-error stage=${stage} msg=${msg}`);
+  captureSilentError(err, {
+    tags: { surface: 'server', component: 'rate-limit', stage },
+    fingerprint: ['rate-limit', 'redis-error', stage],
+  });
 }
 
 // Marker header set on every degraded (fail-closed) response so observability

--- a/server/_shared/turnstile.ts
+++ b/server/_shared/turnstile.ts
@@ -1,12 +1,15 @@
 const TURNSTILE_VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
 
 export function getClientIp(request: Request): string {
-  return (
-    request.headers.get('x-real-ip') ||
-    request.headers.get('cf-connecting-ip') ||
-    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-    'unknown'
-  );
+  // cf-connecting-ip is the trusted client IP set by Cloudflare; x-real-ip
+  // is the CF edge IP (shared across users) — kept as a secondary because
+  // some non-CF deploys set it directly. x-forwarded-for is client-settable
+  // and MUST NOT be used as a rate-limit / abuse-defence identifier (#3531).
+  // Trim each value so a whitespace-only header doesn't short-circuit past
+  // the next fallback. Mirrors getClientIp in server/_shared/rate-limit.ts.
+  const cf = (request.headers.get('cf-connecting-ip') ?? '').trim();
+  const xr = (request.headers.get('x-real-ip') ?? '').trim();
+  return cf || xr || 'unknown';
 }
 
 export type TurnstileMissingSecretPolicy = 'allow' | 'allow-in-development' | 'deny';

--- a/server/_shared/turnstile.ts
+++ b/server/_shared/turnstile.ts
@@ -1,3 +1,5 @@
+import { UNKNOWN_CLIENT_IP } from './rate-limit';
+
 const TURNSTILE_VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
 
 export function getClientIp(request: Request): string {
@@ -9,7 +11,7 @@ export function getClientIp(request: Request): string {
   // the next fallback. Mirrors getClientIp in server/_shared/rate-limit.ts.
   const cf = (request.headers.get('cf-connecting-ip') ?? '').trim();
   const xr = (request.headers.get('x-real-ip') ?? '').trim();
-  return cf || xr || 'unknown';
+  return cf || xr || UNKNOWN_CLIENT_IP;
 }
 
 export type TurnstileMissingSecretPolicy = 'allow' | 'allow-in-development' | 'deny';

--- a/server/_shared/usage.ts
+++ b/server/_shared/usage.ts
@@ -61,6 +61,7 @@ export type RequestReason =
   | 'ok'
   | 'origin_403'
   | 'rate_limit_429'
+  | 'rate_limit_degraded'
   | 'preflight'
   | 'auth_401'
   | 'auth_403'

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -931,14 +931,24 @@ export function createDomainGateway(
     if (!internalMcpVerified) {
       const endpointRlResponse = await checkEndpointRateLimit(request, pathname, corsHeaders);
       if (endpointRlResponse) {
-        emitRequest(endpointRlResponse.status, 'rate_limit_429', null);
+        const reason =
+          endpointRlResponse.status === 503 &&
+          endpointRlResponse.headers.get('X-RateLimit-Mode') === 'degraded'
+            ? 'rate_limit_degraded'
+            : 'rate_limit_429';
+        emitRequest(endpointRlResponse.status, reason, null);
         return endpointRlResponse;
       }
 
       if (!hasEndpointRatePolicy(pathname)) {
         const rateLimitResponse = await checkRateLimit(request, corsHeaders);
         if (rateLimitResponse) {
-          emitRequest(rateLimitResponse.status, 'rate_limit_429', null);
+          const reason =
+            rateLimitResponse.status === 503 &&
+            rateLimitResponse.headers.get('X-RateLimit-Mode') === 'degraded'
+              ? 'rate_limit_degraded'
+              : 'rate_limit_429';
+          emitRequest(rateLimitResponse.status, reason, null);
           return rateLimitResponse;
         }
       }

--- a/server/worldmonitor/leads/v1/register-interest.ts
+++ b/server/worldmonitor/leads/v1/register-interest.ts
@@ -302,6 +302,9 @@ export async function registerInterest(
       DESKTOP_RATE_WINDOW,
       ip,
     );
+    if (scoped.degraded) {
+      throw new ApiError(503, 'Rate-limit service temporarily unavailable', '');
+    }
     if (!scoped.allowed) {
       throw new ApiError(429, 'Too many requests', '');
     }

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -278,7 +278,7 @@ describe('scoped rate-limit degraded call-site policy (#3531)', () => {
     const fs = await import('node:fs');
     const cp = await import('node:child_process');
     const repo = new URL('..', import.meta.url);
-    const output = cp.execFileSync('rg', ['-l', 'checkScopedRateLimit\\(', 'server', 'api'], {
+    const output = cp.execFileSync('git', ['grep', '-lF', 'checkScopedRateLimit(', '--', 'server', 'api'], {
       cwd: repo,
       encoding: 'utf8',
     });

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -1,0 +1,222 @@
+// Tests for the M9 (fail-closed posture + audible Redis errors) and M16
+// (drop spoofable x-forwarded-for fallback) fixes from issue #3531.
+//
+// Both `server/_shared/rate-limit.ts` and `api/_rate-limit.js` mirror the
+// same getClientIp + degraded-response behaviour; this file exercises the
+// canonical TypeScript module. The api/ mirror is covered by inspection
+// of the shared constants (RATE_LIMIT_DEGRADED_HEADERS) and an additional
+// import smoke test below.
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  RATE_LIMIT_DEGRADED_HEADERS,
+  UNKNOWN_CLIENT_IP,
+  checkEndpointRateLimit,
+  checkRateLimit,
+  checkScopedRateLimit,
+  getClientIp,
+} from '../server/_shared/rate-limit.ts';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+const originalConsoleError = console.error;
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request('https://worldmonitor.app/api/test', { headers });
+}
+
+async function importFreshRateLimitModule() {
+  return import(`../server/_shared/rate-limit.ts?test=${Date.now()}-${Math.random()}`);
+}
+
+describe('rate-limit getClientIp (#3531 — drop spoofable x-forwarded-for)', () => {
+  it('prefers cf-connecting-ip when Cloudflare is in front', () => {
+    const req = makeRequest({
+      'cf-connecting-ip': '203.0.113.7',
+      'x-real-ip': '192.0.2.5',
+      'x-forwarded-for': '198.51.100.8',
+    });
+    assert.equal(getClientIp(req), '203.0.113.7');
+  });
+
+  it('falls back to x-real-ip when cf-connecting-ip is absent', () => {
+    const req = makeRequest({
+      'x-real-ip': '192.0.2.5',
+      'x-forwarded-for': '198.51.100.8',
+    });
+    assert.equal(getClientIp(req), '192.0.2.5');
+  });
+
+  it('returns the UNKNOWN_CLIENT_IP sentinel when only x-forwarded-for is present', () => {
+    // Direct request bypassing CF — only x-forwarded-for set. Honouring it
+    // would let an attacker rotate identities by toggling the header.
+    const req = makeRequest({ 'x-forwarded-for': '198.51.100.8, 203.0.113.10' });
+    assert.equal(getClientIp(req), UNKNOWN_CLIENT_IP);
+    assert.equal(getClientIp(req), 'unknown');
+  });
+
+  it('returns UNKNOWN_CLIENT_IP when no client-IP headers are present', () => {
+    assert.equal(getClientIp(makeRequest({})), UNKNOWN_CLIENT_IP);
+  });
+
+  it('treats whitespace-only header values as absent', () => {
+    const req = makeRequest({ 'cf-connecting-ip': '   ', 'x-real-ip': '192.0.2.5' });
+    assert.equal(getClientIp(req), '192.0.2.5');
+  });
+});
+
+describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
+  let consoleErrors: string[] = [];
+
+  beforeEach(() => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+    consoleErrors = [];
+    console.error = (...args: unknown[]) => {
+      consoleErrors.push(args.map((a) => String(a)).join(' '));
+    };
+    // Make every Upstash REST call throw so we exercise the catch branch.
+    globalThis.fetch = async () => {
+      throw new Error('upstash unreachable');
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    console.error = originalConsoleError;
+    restoreEnv();
+  });
+
+  it('checkRateLimit defaults to fail-open and logs a structured Redis error', async () => {
+    const res = await checkRateLimit(makeRequest({ 'cf-connecting-ip': '203.0.113.7' }), {});
+    assert.equal(res, null, 'fail-open should let the request through');
+    assert.ok(
+      consoleErrors.some(
+        (line) =>
+          line.includes('[rate-limit] redis-error') &&
+          line.includes('stage=checkRateLimit') &&
+          line.includes('upstash unreachable'),
+      ),
+      `expected a structured rate-limit error log, got: ${consoleErrors.join('\n')}`,
+    );
+  });
+
+  it('checkRateLimit returns 503 with the degraded marker when failClosed=true', async () => {
+    const res = await checkRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      { 'Access-Control-Allow-Origin': 'https://worldmonitor.app' },
+      { failClosed: true },
+    );
+    assert.ok(res, 'expected a Response when fail-closed');
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+    assert.equal(res.headers.get('Retry-After'), '5');
+    assert.equal(
+      res.headers.get('Access-Control-Allow-Origin'),
+      'https://worldmonitor.app',
+      'CORS headers should be propagated on the degraded response',
+    );
+    const body = (await res.json()) as { error?: string };
+    assert.match(body.error ?? '', /unavailable/i);
+  });
+
+  it('checkRateLimit returns degraded 503 when failClosed=true and Upstash env is missing', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const mod = await importFreshRateLimitModule();
+
+    const res = await mod.checkRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      { 'Access-Control-Allow-Origin': 'https://worldmonitor.app' },
+      { failClosed: true },
+    );
+
+    assert.ok(res, 'expected a degraded response when fail-closed limiter is unconfigured');
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+    assert.equal(res.headers.get('Retry-After'), '5');
+  });
+
+  it('checkEndpointRateLimit defaults to fail-CLOSED for endpoints with an explicit policy', async () => {
+    // Per-endpoint policies exist precisely because the limit IS the abuse
+    // defence (3/hr lead-capture, LLM, sanctions lookup). A Redis blip must
+    // not silently lift those budgets.
+    const res = await checkEndpointRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      '/api/leads/v1/submit-contact',
+      {},
+    );
+    assert.ok(res, 'expected a Response from fail-closed endpoint policy');
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+    assert.ok(
+      consoleErrors.some((line) =>
+        line.includes('stage=checkEndpointRateLimit:/api/leads/v1/submit-contact'),
+      ),
+      `expected per-endpoint stage in the log, got: ${consoleErrors.join('\n')}`,
+    );
+  });
+
+  it('checkEndpointRateLimit caller can opt into fail-open via failClosed=false', async () => {
+    const res = await checkEndpointRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      '/api/leads/v1/submit-contact',
+      {},
+      { failClosed: false },
+    );
+    assert.equal(res, null);
+  });
+
+  it('checkEndpointRateLimit returns degraded 503 for explicit policies when Upstash env is missing', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const mod = await importFreshRateLimitModule();
+
+    const res = await mod.checkEndpointRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      '/api/leads/v1/submit-contact',
+      {},
+    );
+
+    assert.ok(res, 'expected explicit endpoint policies to fail closed without Redis config');
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+  });
+
+  it('checkScopedRateLimit reports degraded when Upstash env is missing', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const mod = await importFreshRateLimitModule();
+
+    const result = await mod.checkScopedRateLimit('test-scope', 5, '60 s', 'identifier');
+
+    assert.equal(result.allowed, true);
+    assert.equal(result.degraded, true);
+  });
+
+  it('checkScopedRateLimit returns degraded:true on Redis error so callers can fail-closed locally', async () => {
+    const result = await checkScopedRateLimit('test-scope', 5, '60 s', 'identifier');
+    assert.equal(result.allowed, true, 'preserve availability-first default');
+    assert.equal(result.degraded, true, 'flag the degraded path so callers can escalate');
+  });
+});
+
+describe('rate-limit constants', () => {
+  it('exposes the degraded marker shape both surfaces depend on', () => {
+    assert.equal(RATE_LIMIT_DEGRADED_HEADERS['X-RateLimit-Mode'], 'degraded');
+    assert.equal(RATE_LIMIT_DEGRADED_HEADERS['Retry-After'], '5');
+  });
+
+  it('UNKNOWN_CLIENT_IP is the literal "unknown" so the api/ mirror stays string-equal', () => {
+    assert.equal(UNKNOWN_CLIENT_IP, 'unknown');
+  });
+});

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -210,6 +210,32 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
   });
 });
 
+describe('rate-limit fail-closed call-site policy (#3531)', () => {
+  // High-cost endpoints that don't go through gateway.ts's checkEndpointRateLimit
+  // must opt into fail-closed at the call site — otherwise an Upstash blip
+  // silently lifts the only rate-limit gate they have. Static-analysis guard
+  // so a future caller reverting to bare `checkRateLimit(req, cors)` is caught
+  // in CI rather than during a Redis incident.
+  const FAIL_CLOSED_REQUIRED = [
+    'api/chat-analyst.ts', // streaming LLM analyst, Pro-only
+  ];
+
+  for (const path of FAIL_CLOSED_REQUIRED) {
+    it(`${path} passes failClosed: true to checkRateLimit`, async () => {
+      const fs = await import('node:fs');
+      const url = new URL(`../${path}`, import.meta.url);
+      const src = fs.readFileSync(url, 'utf8');
+      const callMatch = src.match(/checkRateLimit\([^)]*\)/);
+      assert.ok(callMatch, `${path} should still call checkRateLimit`);
+      assert.match(
+        callMatch[0],
+        /failClosed:\s*true/,
+        `${path} must pass { failClosed: true } so a Redis outage doesn't silently bypass the only rate-limit gate it has`,
+      );
+    });
+  }
+});
+
 describe('rate-limit constants', () => {
   it('exposes the degraded marker shape both surfaces depend on', () => {
     assert.equal(RATE_LIMIT_DEGRADED_HEADERS['X-RateLimit-Mode'], 'degraded');

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -192,6 +192,30 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
   });
 
+  it('checkEndpointRateLimit keeps unrecognised paths unguarded even with fail-closed defaults', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const mod = await importFreshRateLimitModule();
+
+    const res = await mod.checkEndpointRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      '/api/not-a-rate-limited-endpoint',
+      {},
+    );
+
+    assert.equal(res, null);
+  });
+
+  it('server rate-limit degraded logs are also sent through Sentry capture', async () => {
+    const fs = await import('node:fs');
+    const src = fs.readFileSync(new URL('../server/_shared/rate-limit.ts', import.meta.url), 'utf8');
+
+    assert.match(src, /import\s+\{\s*captureSilentError\s+\}\s+from\s+['"]\.\.\/\.\.\/api\/_sentry-edge\.js['"]/);
+    assert.match(src, /captureSilentError\(err,\s*\{/);
+    assert.match(src, /surface:\s*'server'/);
+    assert.match(src, /fingerprint:\s*\['rate-limit',\s*'redis-error',\s*stage\]/);
+  });
+
   it('checkScopedRateLimit reports degraded when Upstash env is missing', async () => {
     delete process.env.UPSTASH_REDIS_REST_URL;
     delete process.env.UPSTASH_REDIS_REST_TOKEN;

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -260,6 +260,48 @@ describe('rate-limit fail-closed call-site policy (#3531)', () => {
   }
 });
 
+describe('scoped rate-limit degraded call-site policy (#3531)', () => {
+  const SCOPED_RATE_LIMIT_CALLERS = [
+    {
+      path: 'server/worldmonitor/leads/v1/register-interest.ts',
+      expected: /if\s*\(\s*scoped\.degraded\s*\)\s*\{/,
+      reason: 'desktop lead capture bypasses Turnstile, so Redis degradation must fail closed locally',
+    },
+    {
+      path: 'api/mcp-proxy.ts',
+      expected: /Redis-degraded scoped limits intentionally stay availability-first/,
+      reason: 'MCP proxy is already premium-auth gated; scoped limit degradation is logged and remains availability-first',
+    },
+  ];
+
+  it('keeps every checkScopedRateLimit caller audited for degraded handling', async () => {
+    const fs = await import('node:fs');
+    const cp = await import('node:child_process');
+    const repo = new URL('..', import.meta.url);
+    const output = cp.execFileSync('rg', ['-l', 'checkScopedRateLimit\\(', 'server', 'api'], {
+      cwd: repo,
+      encoding: 'utf8',
+    });
+    const callers = output
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .filter(path => path !== 'server/_shared/rate-limit.ts')
+      .sort();
+
+    assert.deepEqual(
+      callers,
+      SCOPED_RATE_LIMIT_CALLERS.map(({ path }) => path).sort(),
+      'new checkScopedRateLimit callers must be added here with a degraded-path decision',
+    );
+
+    for (const { path, expected, reason } of SCOPED_RATE_LIMIT_CALLERS) {
+      const src = fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+      assert.match(src, expected, `${path}: ${reason}`);
+    }
+  });
+});
+
 describe('rate-limit constants', () => {
   it('exposes the degraded marker shape both surfaces depend on', () => {
     assert.equal(RATE_LIMIT_DEGRADED_HEADERS['X-RateLimit-Mode'], 'degraded');

--- a/tests/turnstile.test.mjs
+++ b/tests/turnstile.test.mjs
@@ -19,7 +19,7 @@ test.afterEach(() => {
   restoreEnv();
 });
 
-test('getClientIp prefers x-real-ip, then cf-connecting-ip, then x-forwarded-for', () => {
+test('getClientIp prefers cf-connecting-ip, then x-real-ip', () => {
   const request = new Request('https://worldmonitor.app/api/test', {
     headers: {
       'x-forwarded-for': '198.51.100.8, 203.0.113.10',
@@ -28,7 +28,29 @@ test('getClientIp prefers x-real-ip, then cf-connecting-ip, then x-forwarded-for
     },
   });
 
+  assert.equal(getClientIp(request), '203.0.113.7');
+});
+
+test('getClientIp falls back to x-real-ip when cf-connecting-ip is absent', () => {
+  const request = new Request('https://worldmonitor.app/api/test', {
+    headers: {
+      'x-forwarded-for': '198.51.100.8',
+      'x-real-ip': '192.0.2.5',
+    },
+  });
+
   assert.equal(getClientIp(request), '192.0.2.5');
+});
+
+test('getClientIp ignores spoofable x-forwarded-for and returns unknown sentinel (#3531)', () => {
+  // Direct request bypassing Cloudflare: only x-forwarded-for present.
+  // Must NOT be honoured — caller-supplied identity would let an attacker
+  // rotate buckets and beat the per-IP rate-limit window.
+  const request = new Request('https://worldmonitor.app/api/test', {
+    headers: { 'x-forwarded-for': '198.51.100.8, 203.0.113.10' },
+  });
+
+  assert.equal(getClientIp(request), 'unknown');
 });
 
 test('verifyTurnstile allows missing secret when policy is allow', async () => {

--- a/tests/turnstile.test.mjs
+++ b/tests/turnstile.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { UNKNOWN_CLIENT_IP } from '../server/_shared/rate-limit.ts';
 import { getClientIp, verifyTurnstile } from '../server/_shared/turnstile.ts';
 
 const originalFetch = globalThis.fetch;
@@ -50,7 +51,7 @@ test('getClientIp ignores spoofable x-forwarded-for and returns unknown sentinel
     headers: { 'x-forwarded-for': '198.51.100.8, 203.0.113.10' },
   });
 
-  assert.equal(getClientIp(request), 'unknown');
+  assert.equal(getClientIp(request), UNKNOWN_CLIENT_IP);
 });
 
 test('verifyTurnstile allows missing secret when policy is allow', async () => {


### PR DESCRIPTION
Closes #3531.

## Summary

Two related rate-limit hygiene gaps from manual review.

### M9 — Silent fail-open on Upstash error
`api/_rate-limit.js` and `server/_shared/rate-limit.ts` both swallowed every Redis transport / auth error and returned `null` = "allow," so any Upstash blip silently lifted every per-IP and per-endpoint budget across the site.

- Always log a structured `[rate-limit] redis-error stage=...` line so the bypass window is visible in Vercel logs / Sentry instead of disappearing.
- The api/ mirror also captures to Sentry with fingerprint `['rate-limit','redis-error',stage]` so per-stage incidents stay one issue rather than fragmenting.
- New `RateLimitOptions.failClosed` returns 503 with `X-RateLimit-Mode: degraded` + `Retry-After: 5` instead of allowing the request through. CDNs / observability can correlate the unavailability window without parsing the body.
- `checkEndpointRateLimit` defaults `failClosed=true` — those policies exist precisely because the limit IS the abuse defence (3/hr lead capture, LLM endpoints, sanctions lookup); a Redis blip must not silently lift them.
- `checkRateLimit` (global per-IP) and `checkScopedRateLimit` keep the fail-open default to preserve the availability-first posture for general traffic; scoped callers can read `degraded: true` to escalate locally.

### M16 — Spoofable `x-forwarded-for` as IP fallback
`getClientIp` listed XFF as a third fallback in BOTH `rate-limit.ts` and `turnstile.ts`, contradicting their own comments. A direct request bypassing Cloudflare could rotate identities by toggling the header and beat the per-IP window.

- Drop the XFF fallback in all three `getClientIp` implementations.
- Return `UNKNOWN_CLIENT_IP = 'unknown'` sentinel when no trusted `cf-connecting-ip` / `x-real-ip` header is present, so Upstash treats the whole untrusted-identity population as one shared bucket (naturally restrictive instead of silently bypassed).
- Trim each header value before falling through, so a whitespace-only `cf-connecting-ip` can't short-circuit past `x-real-ip`.

## Test plan

- [x] `tests/rate-limit.test.mts` (new): IP-header preference, XFF refusal, sentinel fallback, fail-open log shape, fail-closed degraded marker, per-endpoint default-fail-closed, scoped degraded flag.
- [x] `api/_rate-limit.test.mjs` (new): same coverage on the Vercel edge mirror + cross-surface degraded-marker parity assertion.
- [x] `tests/turnstile.test.mjs`: reorder existing test to the new `cf-connecting-ip`-first preference; add coverage for the XFF refusal sentinel.
- [x] `npx tsc --noEmit && npx tsc --noEmit -p tsconfig.api.json` — clean.
- [x] `npx biome lint` on changed files — clean.
- [x] `npm run lint:rate-limit-policies` — clean (7 policies validated).
- [x] Adjacent suites green: `gateway-cdn-origin-policy`, `premium-stock-gateway`, `scenario-handler`.
- [x] All 23 new + updated tests pass.

## Behaviour change call-outs

- **Per-endpoint policies now fail-closed by default during a Redis outage.** Affects `/api/news/v1/summarize-article-cache`, `/api/intelligence/v1/classify-event`, `/api/sanctions/v1/lookup-sanction-entity`, `/api/leads/v1/submit-contact`, `/api/leads/v1/register-interest`, `/api/scenario/v1/run-scenario`, `/api/maritime/v1/get-vessel-snapshot`. Returns 503 with `X-RateLimit-Mode: degraded` instead of silently passing. Callers that need to opt back into fail-open can pass `{ failClosed: false }`.
- **Direct requests (no `cf-connecting-ip` / `x-real-ip`) now share a single `'unknown'` rate-limit bucket** instead of using a spoofable XFF identity or `'0.0.0.0'`. This is intentional — restrictive-by-default for the no-trusted-identity population.