### PR TITLE
fix(ais-relay): warm-pings send X-WorldMonitor-Key — stop relying on Origin-trust alone

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -4100,6 +4100,14 @@ function startTheaterPostureSeedLoop() {
 //   WORLDMONITOR_RELAY_KEY=<value present in Vercel WORLDMONITOR_VALID_KEYS>
 // ─────────────────────────────────────────────────────────────
 const RELAY_API_KEY = process.env.WORLDMONITOR_RELAY_KEY || '';
+// Surface the auth-mode at boot so misconfig (env var on wrong service,
+// typo'd name, missing on a fresh Railway deploy) is visible in the first
+// log lines instead of waiting for the first 401. PR #3565 review P2.
+if (!RELAY_API_KEY) {
+  console.warn('[Relay] WORLDMONITOR_RELAY_KEY not set — warm-pings will rely on Origin-trust only (fragile against CDN/firewall changes)');
+} else {
+  console.log('[Relay] WORLDMONITOR_RELAY_KEY configured — warm-pings will send X-WorldMonitor-Key');
+}
 
 function warmPingHeaders(extra = {}) {
   const h = {
@@ -4166,7 +4174,7 @@ async function seedChokepointWarmPing() {
       signal: AbortSignal.timeout(60_000),
     });
     if (!resp.ok) {
-      console.warn(`[Chokepoints] Warm-ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (no WORLDMONITOR_RELAY_KEY set)'}`);
+      console.warn(`[Chokepoints] Warm-ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (no WORLDMONITOR_RELAY_KEY set; relying on Origin-trust)'}`);
       return;
     }
     const data = await resp.json();
@@ -4204,7 +4212,7 @@ async function seedCableHealthWarmPing() {
       signal: AbortSignal.timeout(60_000),
     });
     if (!resp.ok) {
-      console.warn(`[CableHealth] Warm-ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (no WORLDMONITOR_RELAY_KEY set)'}`);
+      console.warn(`[CableHealth] Warm-ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (no WORLDMONITOR_RELAY_KEY set; relying on Origin-trust)'}`);
       return;
     }
     const data = await resp.json();

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -4078,6 +4078,40 @@ function startTheaterPostureSeedLoop() {
 }
 
 // ─────────────────────────────────────────────────────────────
+// Warm-ping shared auth — relay → api.worldmonitor.app
+//
+// All warm-pings call api.worldmonitor.app/api/* edge functions. Pre-2026-05-02
+// these used Origin-trust alone (the relay sent `Origin: https://worldmonitor.app`
+// which `api/_api-key.js::validateApiKey` accepts via BROWSER_ORIGIN_PATTERNS).
+// On 2026-05-02 ALL three warm-pings (CII + Chokepoints + CableHealth) started
+// returning HTTP 401 simultaneously despite the relay sending the correct
+// Origin header. Root cause unclear (Vercel firewall change, CDN cache
+// poisoning, deploy mismatch) — but Origin-trust is fragile by nature: any
+// intermediary (CF, Vercel firewall, future CDN) can strip or rewrite Origin
+// without leaving a trace.
+//
+// Defense-in-depth: send an explicit X-WorldMonitor-Key in addition to the
+// Origin header. The gateway accepts EITHER, so when Origin trust breaks
+// the key carries the auth. When the key isn't configured, fall through to
+// Origin-only — preserves backward compatibility for local dev / before the
+// env var is provisioned on Railway.
+//
+// Required env var on Railway ais-relay service:
+//   WORLDMONITOR_RELAY_KEY=<value present in Vercel WORLDMONITOR_VALID_KEYS>
+// ─────────────────────────────────────────────────────────────
+const RELAY_API_KEY = process.env.WORLDMONITOR_RELAY_KEY || '';
+
+function warmPingHeaders(extra = {}) {
+  const h = {
+    'User-Agent': CHROME_UA,
+    Origin: 'https://worldmonitor.app',
+    ...extra,
+  };
+  if (RELAY_API_KEY) h['X-WorldMonitor-Key'] = RELAY_API_KEY;
+  return h;
+}
+
+// ─────────────────────────────────────────────────────────────
 // CII Risk Scores warm-ping — keeps RPC cache fresh so
 // bootstrap stale key never expires.
 // The RPC handler itself refreshes the stale key on every call.
@@ -4088,14 +4122,11 @@ const CII_RPC_URL = 'https://api.worldmonitor.app/api/intelligence/v1/get-risk-s
 async function seedCiiWarmPing() {
   try {
     const resp = await fetch(CII_RPC_URL, {
-      headers: {
-        'User-Agent': CHROME_UA,
-        Origin: 'https://worldmonitor.app',
-      },
+      headers: warmPingHeaders(),
       signal: AbortSignal.timeout(60_000),
     });
     if (!resp.ok) {
-      console.warn(`[CII] Warm-ping failed: HTTP ${resp.status}`);
+      console.warn(`[CII] Warm-ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (no WORLDMONITOR_RELAY_KEY set; relying on Origin-trust)'}`);
       return;
     }
     const data = await resp.json();
@@ -4130,12 +4161,12 @@ async function seedChokepointWarmPing() {
   try {
     const resp = await fetch(CHOKEPOINT_RPC_URL, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_UA, Origin: 'https://worldmonitor.app' },
+      headers: warmPingHeaders({ 'Content-Type': 'application/json' }),
       body: '{}',
       signal: AbortSignal.timeout(60_000),
     });
     if (!resp.ok) {
-      console.warn(`[Chokepoints] Warm-ping failed: HTTP ${resp.status}`);
+      console.warn(`[Chokepoints] Warm-ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (no WORLDMONITOR_RELAY_KEY set)'}`);
       return;
     }
     const data = await resp.json();
@@ -4168,12 +4199,12 @@ async function seedCableHealthWarmPing() {
   try {
     const resp = await fetch(CABLE_HEALTH_RPC_URL, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_UA, Origin: 'https://worldmonitor.app' },
+      headers: warmPingHeaders({ 'Content-Type': 'application/json' }),
       body: '{}',
       signal: AbortSignal.timeout(60_000),
     });
     if (!resp.ok) {
-      console.warn(`[CableHealth] Warm-ping failed: HTTP ${resp.status}`);
+      console.warn(`[CableHealth] Warm-ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (no WORLDMONITOR_RELAY_KEY set)'}`);
       return;
     }
     const data = await resp.json();


### PR DESCRIPTION
## Summary

Root-cause fix for the ais-relay → api.worldmonitor.app 401 issue diagnosed in PR #3562 (which fixed the riskScores STALE_SEED *symptom* by adding RPC-side seed-meta writes; this PR fixes the *cause* so warm-pings can resume their primary duty of keeping caches warm).

## Problem

Pre-fix, all three warm-pings (CII, Chokepoints, CableHealth) sent only `Origin: https://worldmonitor.app` to authenticate. The gateway's `api/_api-key.js::validateApiKey` accepts trusted origins via `BROWSER_ORIGIN_PATTERNS` — that worked for months, then broke globally on 2026-05-02.

Railway log evidence (in PR #3562 description):
```
[CII] Warm-ping failed: HTTP 401              × 5
[Chokepoints] Warm-ping failed: HTTP 401      × 1
[CableHealth] Warm-ping failed: HTTP 401      × 1
```

**Origin-trust is structurally fragile**:
- Cloudflare can strip the Origin header on cache hits, server-to-server requests, or under specific WAF rules
- Vercel firewall can rewrite/drop headers based on bot-protection signals
- Cloudflare cache key is URL-only by default — a single no-Origin request can poison the URL's CDN cache for the full s-maxage. Earlier probe observed `cache-control: public, max-age=1800` on a 401 from Dubai edge while Tokyo edge returned proper `private, no-store` for the same URL — consistent with cache poisoning at one POP.
- Any future intermediary (CDN, WAF, reverse proxy) that strips Origin silently breaks every warm-ping

## Fix

Defense-in-depth: send `X-WorldMonitor-Key` in addition to Origin. The gateway already accepts it via `validateApiKey`'s explicit-key branch — when the key is valid (matches `WORLDMONITOR_VALID_KEYS`), auth succeeds regardless of Origin. When the key is missing, the warm-ping falls back to the existing Origin-only path — preserves backward compat for local dev and for the Railway service before the env var is provisioned.

Implementation:
- Shared `warmPingHeaders(extra)` helper at the top of the warm-ping section. Reads `WORLDMONITOR_RELAY_KEY` env var once at module load; attaches `X-WorldMonitor-Key` to every header bag when set.
- All three warm-ping fetch calls migrated to use it (one-line change each).
- Failure-log lines now explicitly note when the key is missing — future incidents are debuggable in 30 seconds.

## REQUIRED OPS STEP after merge

1. Generate or pick an existing key from `WORLDMONITOR_VALID_KEYS` (Vercel project env var on the API project).
2. Set `WORLDMONITOR_RELAY_KEY=<that-key>` on the Railway `ais-relay` service env.
3. Redeploy the relay (Railway rebuilds on next push, or trigger manually).
4. Verify in Railway logs: `[CII] Warm-ping OK: NN scores` instead of `[CII] Warm-ping failed: HTTP 401`.

The PR ships the code change. Without the env var the relay continues the current Origin-only behaviour — **no regression**. With the env var, auth is bulletproof against future Origin-stripping intermediaries.

## Test plan

- [x] `npm run typecheck` + `typecheck:api` clean.
- [x] `npm run lint` clean.
- [x] `npm run test:data` 7834/7834 pass.
- [x] All other gates clean.
- [x] `node -c scripts/ais-relay.cjs` syntax clean.
- [ ] After merge + Railway env var set + redeploy: `riskScores`, `cableHealth`, `chokepoints` warm-pings all resume `OK` status. `/api/health.riskScores.seedAgeMin` drops to <8 min on next warm-ping tick.

## Stack of related PRs

| PR | Fixes |
|---|---|
| #3562 (open) | RPC-side seed-meta write for riskScores + daily cron docs for energy-v2 |
| **(this)** | Underlying auth root cause — relay sends explicit API key |