### PR TITLE
fix(seeders): warm-pings send X-WorldMonitor-Key — stop Origin-trust 401 crashes

### DIFF
--- a/scripts/seed-infra.mjs
+++ b/scripts/seed-infra.mjs
@@ -24,16 +24,35 @@ loadEnvFile(import.meta.url);
 const API_BASE = 'https://api.worldmonitor.app';
 const TIMEOUT = 30_000;
 
+// Defense-in-depth auth — Origin-trust alone broke globally on 2026-05-02
+// (CF/Vercel intermediaries can strip Origin and CF can cache the resulting
+// 401 for s-maxage, poisoning a POP). Send X-WorldMonitor-Key when configured;
+// fall through to Origin-only when unset to preserve local dev behaviour.
+// Set WORLDMONITOR_RELAY_KEY on the Railway service to a value already
+// present in Vercel's WORLDMONITOR_VALID_KEYS. Same pattern as ais-relay.cjs.
+const RELAY_API_KEY = process.env.WORLDMONITOR_RELAY_KEY || '';
+
+function warmPingHeaders() {
+  const h = {
+    'Content-Type': 'application/json',
+    'User-Agent': CHROME_UA,
+    Origin: 'https://worldmonitor.app',
+  };
+  if (RELAY_API_KEY) h['X-WorldMonitor-Key'] = RELAY_API_KEY;
+  return h;
+}
+
 async function warmPing(name, path) {
   try {
     const resp = await fetch(`${API_BASE}${path}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_UA, Origin: 'https://worldmonitor.app' },
+      headers: warmPingHeaders(),
       body: JSON.stringify({}),
       signal: AbortSignal.timeout(TIMEOUT),
     });
     if (!resp.ok) {
-      console.warn(`  ${name}: HTTP ${resp.status}`);
+      const keyNote = RELAY_API_KEY ? '' : ' (WORLDMONITOR_RELAY_KEY not set — Origin-only auth)';
+      console.warn(`  ${name}: HTTP ${resp.status}${keyNote}`);
       return false;
     }
     const data = await resp.json();

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -11,6 +11,12 @@ loadEnvFile(import.meta.url);
 const CANONICAL_KEY = 'news:insights:v1';
 const DIGEST_KEY = 'news:digest:v1:full:en';
 
+// Defense-in-depth auth — see seed-infra.mjs for the same pattern + rationale.
+// Set WORLDMONITOR_RELAY_KEY on the Railway service (must match a value in
+// Vercel's WORLDMONITOR_VALID_KEYS). Origin alone is no longer reliable
+// because CF/Vercel intermediaries may strip it and CF can cache the 401.
+const RELAY_API_KEY = process.env.WORLDMONITOR_RELAY_KEY || '';
+
 // Digest items store proto enum strings (THREAT_LEVEL_HIGH etc.) from toProtoItem().
 // Normalize to client-side lowercase values before propagating into insights output.
 const PROTO_TO_LEVEL = {
@@ -196,16 +202,11 @@ function categorizeStory(title) {
 
 async function warmDigestCache() {
   const apiBase = process.env.API_BASE_URL || 'https://api.worldmonitor.app';
-  // Defense-in-depth auth — see seed-infra.mjs for the same pattern + rationale.
-  // Set WORLDMONITOR_RELAY_KEY on the Railway service (must match a value in
-  // Vercel's WORLDMONITOR_VALID_KEYS). Origin alone is no longer reliable
-  // because CF/Vercel intermediaries may strip it and CF can cache the 401.
-  const relayApiKey = process.env.WORLDMONITOR_RELAY_KEY || '';
   const headers = {
     'User-Agent': CHROME_UA,
     Origin: 'https://worldmonitor.app',
   };
-  if (relayApiKey) headers['X-WorldMonitor-Key'] = relayApiKey;
+  if (RELAY_API_KEY) headers['X-WorldMonitor-Key'] = RELAY_API_KEY;
   try {
     const resp = await fetch(`${apiBase}/api/news/v1/list-feed-digest?variant=full&lang=en`, {
       headers,
@@ -213,7 +214,7 @@ async function warmDigestCache() {
     });
     if (resp.ok) console.log('  Digest cache warmed via RPC');
     else {
-      const keyNote = relayApiKey ? '' : ' (WORLDMONITOR_RELAY_KEY not set — Origin-only auth)';
+      const keyNote = RELAY_API_KEY ? '' : ' (WORLDMONITOR_RELAY_KEY not set — Origin-only auth)';
       console.warn(`  Digest warm failed: HTTP ${resp.status}${keyNote}`);
     }
   } catch (err) {

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -196,13 +196,26 @@ function categorizeStory(title) {
 
 async function warmDigestCache() {
   const apiBase = process.env.API_BASE_URL || 'https://api.worldmonitor.app';
+  // Defense-in-depth auth — see seed-infra.mjs for the same pattern + rationale.
+  // Set WORLDMONITOR_RELAY_KEY on the Railway service (must match a value in
+  // Vercel's WORLDMONITOR_VALID_KEYS). Origin alone is no longer reliable
+  // because CF/Vercel intermediaries may strip it and CF can cache the 401.
+  const relayApiKey = process.env.WORLDMONITOR_RELAY_KEY || '';
+  const headers = {
+    'User-Agent': CHROME_UA,
+    Origin: 'https://worldmonitor.app',
+  };
+  if (relayApiKey) headers['X-WorldMonitor-Key'] = relayApiKey;
   try {
     const resp = await fetch(`${apiBase}/api/news/v1/list-feed-digest?variant=full&lang=en`, {
-      headers: { 'User-Agent': CHROME_UA },
+      headers,
       signal: AbortSignal.timeout(30_000),
     });
     if (resp.ok) console.log('  Digest cache warmed via RPC');
-    else console.warn(`  Digest warm failed: HTTP ${resp.status}`);
+    else {
+      const keyNote = relayApiKey ? '' : ' (WORLDMONITOR_RELAY_KEY not set — Origin-only auth)';
+      console.warn(`  Digest warm failed: HTTP ${resp.status}${keyNote}`);
+    }
   } catch (err) {
     console.warn(`  Digest warm failed: ${err.message}`);
   }

--- a/scripts/seed-military-maritime-news.mjs
+++ b/scripts/seed-military-maritime-news.mjs
@@ -27,16 +27,32 @@ loadEnvFile(import.meta.url);
 const API_BASE = 'https://api.worldmonitor.app';
 const TIMEOUT = 30_000;
 
+// Defense-in-depth auth — see seed-infra.mjs for the same pattern + rationale.
+// Set WORLDMONITOR_RELAY_KEY on the Railway service to a value already
+// present in Vercel's WORLDMONITOR_VALID_KEYS.
+const RELAY_API_KEY = process.env.WORLDMONITOR_RELAY_KEY || '';
+
+function warmPingHeaders() {
+  const h = {
+    'Content-Type': 'application/json',
+    'User-Agent': CHROME_UA,
+    Origin: 'https://worldmonitor.app',
+  };
+  if (RELAY_API_KEY) h['X-WorldMonitor-Key'] = RELAY_API_KEY;
+  return h;
+}
+
 async function warmPing(name, path, body = {}) {
   try {
     const resp = await fetch(`${API_BASE}${path}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_UA, Origin: 'https://worldmonitor.app' },
+      headers: warmPingHeaders(),
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(TIMEOUT),
     });
     if (!resp.ok) {
-      console.warn(`  ${name}: HTTP ${resp.status}`);
+      const keyNote = RELAY_API_KEY ? '' : ' (WORLDMONITOR_RELAY_KEY not set — Origin-only auth)';
+      console.warn(`  ${name}: HTTP ${resp.status}${keyNote}`);
       return false;
     }
     const data = await resp.json();

--- a/scripts/seed-service-statuses.mjs
+++ b/scripts/seed-service-statuses.mjs
@@ -15,6 +15,21 @@ loadEnvFile(import.meta.url);
 const RPC_URL = 'https://api.worldmonitor.app/api/infrastructure/v1/list-service-statuses';
 const CANONICAL_KEY = 'infra:service-statuses:v1';
 
+// Defense-in-depth auth — see seed-infra.mjs for the same pattern + rationale.
+// Set WORLDMONITOR_RELAY_KEY on the Railway service to a value already
+// present in Vercel's WORLDMONITOR_VALID_KEYS.
+const RELAY_API_KEY = process.env.WORLDMONITOR_RELAY_KEY || '';
+
+function warmPingHeaders() {
+  const h = {
+    'Content-Type': 'application/json',
+    'User-Agent': CHROME_UA,
+    Origin: 'https://worldmonitor.app',
+  };
+  if (RELAY_API_KEY) h['X-WorldMonitor-Key'] = RELAY_API_KEY;
+  return h;
+}
+
 async function warmPing() {
   const startMs = Date.now();
   console.log('=== infra:service-statuses Warm Ping ===');
@@ -25,16 +40,15 @@ async function warmPing() {
   try {
     const resp = await fetch(RPC_URL, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': CHROME_UA,
-        Origin: 'https://worldmonitor.app',
-      },
+      headers: warmPingHeaders(),
       body: '{}',
       signal: AbortSignal.timeout(60_000),
     });
 
-    if (!resp.ok) throw new Error(`RPC failed: HTTP ${resp.status}`);
+    if (!resp.ok) {
+      const keyNote = RELAY_API_KEY ? '' : ' (WORLDMONITOR_RELAY_KEY not set — Origin-only auth)';
+      throw new Error(`RPC failed: HTTP ${resp.status}${keyNote}`);
+    }
     data = await resp.json();
   } catch (err) {
     console.error(`  FETCH FAILED: ${err.message || err}`);


### PR DESCRIPTION
## Summary

Sweep companion to PR #3563 (`c9cb13c49` — `ais-relay`) for the four remaining seed scripts that hit `api.worldmonitor.app` with `Origin: https://worldmonitor.app` as their **only** auth credential. On 2026-05-02 `seed-infra` started crashing with all warm-pings returning HTTP 401 simultaneously; `process.exit(ok > 0 ? 0 : 1)` made it look like a Railway container crash.

**Root cause** (identical to ais-relay's): `api/_api-key.js::validateApiKey` accepts trusted Origins via `BROWSER_ORIGIN_PATTERNS`, but CF/Vercel intermediaries can strip the `Origin` header (S2S calls, WAF rules, cache hits) and CF can cache the resulting 401 for the full `s-maxage`, poisoning a POP for ~30 min. Local curl with identical headers reproduced `HTTP/2 401` + `cache-control: public, max-age=1800` — smoking gun for per-POP cache poisoning.

**Fix:** send `X-WorldMonitor-Key` from `process.env.WORLDMONITOR_RELAY_KEY` in addition to Origin. The gateway already accepts it via `validateApiKey`'s explicit-key branch (`api/_api-key.js:62-66`). When the env var is unset the script falls through to the existing Origin-only path — preserves backward compatibility for local dev and for Railway services before provisioning.

**Affected scripts (4):**
| Script | Pre-fix behaviour |
|---|---|
| `scripts/seed-infra.mjs` | exits 1 → Railway "crash" |
| `scripts/seed-military-maritime-news.mjs` | same shape — would crash on next CDN-poisoning event |
| `scripts/seed-service-statuses.mjs` | degrades to TTL-extension; caches drift silently |
| `scripts/seed-insights.mjs::warmDigestCache` | sent NO Origin at all → 401 every run, silent LKG fallback |

## Required ops step after merge (per Railway service)

> **Code change is regression-safe before env var is set** (scripts fall back to Origin-only). The crash will only stop after both code + env var are deployed.

1. Pick a value from Vercel project env `WORLDMONITOR_VALID_KEYS`.
2. Set `WORLDMONITOR_RELAY_KEY=<that-value>` on each affected Railway service.
3. Redeploy.

## Sweep recipe (catch future instances)

```bash
grep -ln "api.worldmonitor.app" scripts/*.{mjs,cjs} \
  | xargs grep -L "X-WorldMonitor-Key"
```

## Test plan

- [ ] `node --check scripts/seed-{infra,insights,military-maritime-news,service-statuses}.mjs` (verified locally)
- [ ] After deploy + env var on `seed-infra` Railway service, watch next cron tick — expect `=== Done: 2/2 warm-pings OK ===` with zero `HTTP 401` lines
- [ ] Same verification on `seed-military-maritime`, `seed-service-statuses`, `seed-insights` services
- [ ] Confirm the "WORLDMONITOR_RELAY_KEY not set" log hint appears if env var missing (regression-safety check)