### PR TITLE
fix(seed-infra): stop paging on warm-ping failures + accept API key

### DIFF
--- a/scripts/seed-infra.mjs
+++ b/scripts/seed-infra.mjs
@@ -23,12 +23,19 @@ loadEnvFile(import.meta.url);
 
 const API_BASE = 'https://api.worldmonitor.app';
 const TIMEOUT = 30_000;
+const API_KEY = process.env.WORLDMONITOR_API_KEY ?? '';
 
 async function warmPing(name, path) {
   try {
+    const headers = {
+      'Content-Type': 'application/json',
+      'User-Agent': CHROME_UA,
+      Origin: 'https://worldmonitor.app',
+    };
+    if (API_KEY) headers['X-WorldMonitor-Key'] = API_KEY;
     const resp = await fetch(`${API_BASE}${path}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'User-Agent': CHROME_UA, Origin: 'https://worldmonitor.app' },
+      headers,
       body: JSON.stringify({}),
       signal: AbortSignal.timeout(TIMEOUT),
     });
@@ -62,7 +69,11 @@ async function main() {
   const duration = Date.now() - start;
 
   console.log(`\n=== Done: ${ok}/${total} warm-pings OK (${duration}ms) ===`);
-  process.exit(ok > 0 ? 0 : 1);
+  // Best-effort cache warmer: a missed warm-ping is not a failure worth paging on.
+  // Upstream timeouts and transient 5xx happen routinely on the 30-status-page
+  // fan-out; exiting non-zero turned every blip into a Railway "Deploy crashed"
+  // email. Logs above still surface partial failures for investigation.
+  process.exit(0);
 }
 
 main();

--- a/scripts/seed-infra.mjs
+++ b/scripts/seed-infra.mjs
@@ -69,6 +69,11 @@ async function main() {
   const duration = Date.now() - start;
 
   console.log(`\n=== Done: ${ok}/${total} warm-pings OK (${duration}ms) ===`);
+  if (ok === 0) {
+    // Distinct, grep-able marker so persistent auth/gateway breakage is still
+    // visible in Railway logs even though we exit 0.
+    console.warn('WARN: all warm-pings failed — cache is cold (check WORLDMONITOR_API_KEY and gateway auth)');
+  }
   // Best-effort cache warmer: a missed warm-ping is not a failure worth paging on.
   // Upstream timeouts and transient 5xx happen routinely on the 30-status-page
   // fan-out; exiting non-zero turned every blip into a Railway "Deploy crashed"


### PR DESCRIPTION
## Summary

- Send `X-WorldMonitor-Key` from `scripts/seed-infra.mjs` when `WORLDMONITOR_API_KEY` is set on the Railway service, so the warm-ping actually populates the cache once a key is provisioned.
- Exit `0` unconditionally. This is a best-effort cache warmer, not a critical seed — upstream timeouts and transient 5xx happen routinely on the 30-status-page fan-out and don't warrant a Railway "Deploy crashed" email.

## Why

Inbox has been getting hourly `Deploy crashed for seed-infra in world-monitor!` emails. Logs from deployment `8c8b1378` and every other run sampled:

```
=== Infrastructure Warm-Ping Seed ===
  Service Statuses: HTTP 401
  Cable Health: HTTP 401
=== Done: 0/2 warm-pings OK (369ms) ===
```

Both endpoints return `{\"error\":\"API key required\"}` from `api.worldmonitor.app` even with `Origin: https://worldmonitor.app` + Chrome UA, despite neither path being in `PREMIUM_RPC_PATHS` or `ENDPOINT_ENTITLEMENTS` in main. That gateway-vs-main divergence is tracked separately in #3568 and needs @koala's read; this PR is the immediate noise + correctness fix.

This PR does not by itself fix the cache being cold — that requires `WORLDMONITOR_API_KEY` to be set on the Railway `seed-infra` service (value pulled from one of `WORLDMONITOR_VALID_KEYS` on Vercel). Without the env var, the script behaves exactly as before but no longer pages on the failure.

Refs #3568

## Test plan

- [ ] Set `WORLDMONITOR_API_KEY` on Railway `seed-infra` service
- [ ] Trigger a manual cron run from Railway
- [ ] Confirm logs show `Service Statuses: OK (...)` and `Cable Health: OK (...)`
- [ ] Confirm no \"Deploy crashed\" email
- [ ] If the warm-ping still 401s with a key, the issue is in #3568 — at least the email noise stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)