### PR TITLE
fix(panel-layout, sentry): insertByOrder DOM-race guard + Convex SDK protocol-error filter

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1846,7 +1846,15 @@ export class PanelLayoutManager implements AppModule {
     for (let i = idx + 1; i < this.resolvedPanelOrder.length; i++) {
       const nextKey = this.resolvedPanelOrder[i]!;
       const nextEl = grid.querySelector(`[data-panel="${CSS.escape(nextKey)}"]`);
-      if (nextEl) { grid.insertBefore(el, nextEl); return; }
+      // `parentNode === grid` guard: querySelector returns nodes that match
+      // ANY descendant, but a concurrent DOM mutation (browser extension,
+      // overlapping resize event mid-iteration) can move/remove nextEl
+      // between this read and the insertBefore call below — at which point
+      // insertBefore throws `NotFoundError: The node before which the new
+      // node is to be inserted is not a child of this node.`
+      // (WORLDMONITOR-Q6). If the reference moved, fall through to the
+      // appendChild path so the panel still lands in the grid.
+      if (nextEl && nextEl.parentNode === grid) { grid.insertBefore(el, nextEl); return; }
     }
     grid.appendChild(el);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -269,6 +269,7 @@ Sentry.init({
     /ConvexError: CONFLICT/, // Expected OCC rejection on concurrent preference saves
     /ConvexError: API_ACCESS_REQUIRED/, // Expected business error: free user opens API Keys tab; client handles gracefully (UnifiedSettings.ts:731-738) — WORLDMONITOR-NA
     /\[CONVEX [AQM]\(.+?\)\] Connection lost while action was in flight/, // Convex SDK transient WS disconnect
+    /^Invalid start version: \d+:\d+:\d+, transitioning from \d+:\d+:\d+$/, // Convex SDK internal sync protocol error from `remote_query_set.js` (server republished query mid-transition or WS reconnect race) — WORLDMONITOR-Q5
     /Response did not contain `success` or `data`/, // DuckDuckGo browser internal tracker/content-block response — never emitted by our code
     /Cannot set properties of undefined \(setting 'bodyTouched'\)/, // Quark browser (Alibaba mobile) touch-tracking script injection (WORLDMONITOR-N1)
     /Cannot read properties of \w+ \(reading '[^']*[^\x00-\x7F][^']*'\)/, // Non-ASCII property name in message = mojibake/corrupted identifier from injected extension; our bundle emits ASCII-only identifiers (WORLDMONITOR-NS)


### PR DESCRIPTION
## Summary

Two unrelated Sentry findings, bundled because both are one-line fixes from the same triage session:

### 1. WORLDMONITOR-Q6 — `panel-layout.ts:insertByOrder` DOM-race fix

`NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.` Frames trace to `Ot.insertByOrder` → `Ot.ensureCorrectZones` (resize handler).

**Race:** `grid.querySelector(...)` finds `nextEl`, then a concurrent DOM mutation (browser extension, overlapping resize event mid-iteration) removes/moves `nextEl` before the `grid.insertBefore(el, nextEl)` call.

**Fix:** add a `nextEl.parentNode === grid` guard inside the existing `if (nextEl)` branch in `insertByOrder`. Falls through to the existing `grid.appendChild(el)` fallback if the reference moved, so the panel still lands in the grid instead of crashing the resize handler.

### 2. WORLDMONITOR-Q5 — Convex SDK sync-protocol error filter

`Invalid start version: <id>:N:N, transitioning from <id>:N:N`. Verified the literal phrase lives in `node_modules/convex/dist/esm/browser/sync/remote_query_set.js` — Convex SDK internal sync-protocol error fired on server-side query republish mid-transition or WS reconnect race. We don't synthesize this string anywhere.

**Fix:** anchored regex `/^Invalid start version: \d+:\d+:\d+, transitioning from \d+:\d+:\d+$/` added to `ignoreErrors` next to the existing Convex SDK `Connection lost while action was in flight` pattern.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 7834/7834 pass
- [x] `node --test tests/edge-functions.test.mjs` — 181/181 pass
- [x] Edge bundle check — clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK

## Sentry status

Both issues marked resolved with `inNextRelease: true`. WORLDMONITOR-Q4 (Dodo Payments transient `service_unavailable`) was also resolved this round but doesn't need code changes — it's a single-event external-system 503.