### PR TITLE
fix(seed-infra): stop paging on warm-ping blips

### DIFF
--- a/scripts/seed-infra.mjs
+++ b/scripts/seed-infra.mjs
@@ -81,7 +81,17 @@ async function main() {
   const duration = Date.now() - start;
 
   console.log(`\n=== Done: ${ok}/${total} warm-pings OK (${duration}ms) ===`);
-  process.exit(ok > 0 ? 0 : 1);
+  if (ok === 0) {
+    // Distinct, grep-able marker so persistent auth/gateway breakage stays
+    // visible in Railway logs even though we exit 0. Set up a Railway log
+    // alert on this string instead of relying on container exit codes.
+    console.warn('WARN: all warm-pings failed — cache is cold (check WORLDMONITOR_RELAY_KEY and gateway auth)');
+  }
+  // Best-effort cache warmer: a missed warm-ping is not a failure worth paging on.
+  // Upstream timeouts and transient 5xx happen routinely; exiting non-zero turned
+  // every blip into a Railway "Deploy crashed" email. Logs above still surface
+  // partial failures for investigation.
+  process.exit(0);
 }
 
 main();

--- a/scripts/seed-infra.mjs
+++ b/scripts/seed-infra.mjs
@@ -85,7 +85,7 @@ async function main() {
     // Distinct, grep-able marker so persistent auth/gateway breakage stays
     // visible in Railway logs even though we exit 0. Set up a Railway log
     // alert on this string instead of relying on container exit codes.
-    console.warn('WARN: all warm-pings failed — cache is cold (check WORLDMONITOR_RELAY_KEY and gateway auth)');
+    console.log('WARN: all warm-pings failed — cache is cold (check WORLDMONITOR_RELAY_KEY and gateway auth)');
   }
   // Best-effort cache warmer: a missed warm-ping is not a failure worth paging on.
   // Upstream timeouts and transient 5xx happen routinely; exiting non-zero turned


### PR DESCRIPTION
## Summary
- `scripts/seed-infra.mjs` now exits 0 even when zero warm-pings succeed.
- A distinct `WARN: all warm-pings failed — cache is cold (check WORLDMONITOR_RELAY_KEY and gateway auth)` line is emitted when `ok === 0` so persistent auth/gateway breakage stays grep-able in Railway logs.
- Set up a Railway log-alert on the `WARN: all warm-pings failed` string instead of relying on container exit codes.

## Why
Upstream timeouts and transient 5xx happen routinely on the warm-ping fan-out. The previous \`process.exit(ok > 0 ? 0 : 1)\` turned every blip into a Railway "Deploy crashed" email. Real persistent failure is now signalled via a stable log marker, not an exit code that pages on every transient.

## Context
Carved out from #3569 (now closed). The API-key plumbing half of that PR landed in #3566; this is just the no-page + WARN change.

## Test plan
- [x] \`node -c scripts/seed-infra.mjs\` — syntax check passes
- [ ] Verify next Railway run logs the line on intentional failure (set bogus relay-key, observe \`WARN: all warm-pings failed\` and exit 0)
- [ ] Add Railway log alert on the new WARN string