### PR TITLE
fix(api-key): enterprise allowlist precedence over wm_ user-key prefix

### DIFF
--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -64,6 +64,20 @@ export async function validateApiKey(req, options = {}) {
     return { valid: false, required: true, error: 'Invalid session token' };
   }
 
+  // Enterprise key (WORLDMONITOR_VALID_KEYS) — checked BEFORE the wm_ user-key
+  // fallthrough so an operator-issued key that happens to start with wm_ is
+  // still recognized. Pre-#3541 the static allowlist accepted any prefix; some
+  // legacy operator keys (e.g. the Railway relay's WORLDMONITOR_RELAY_KEY) use
+  // the wm_ prefix from before user-issued keys were namespaced. Without this
+  // ordering, those keys get punted to validateUserApiKey() and 401 because
+  // the Convex user-key table has no record of an operator-minted value.
+  // Collision risk is negligible (wm_ user keys carry ≥192 bits of entropy
+  // and would have to be added to the static env list to be honored at all,
+  // which itself requires server-env-write access).
+  if (key && isValidEnterpriseKey(key)) {
+    return { valid: true, required: true, kind: 'enterprise' };
+  }
+
   // wm_-prefixed user API keys — gateway re-validates against the user-key
   // table. We must return required:true / valid:false for the gateway's
   // fallback at server/gateway.ts:~440 to trigger validateUserApiKey().
@@ -71,10 +85,9 @@ export async function validateApiKey(req, options = {}) {
     return { valid: false, required: true, error: 'User API key requires gateway validation' };
   }
 
-  // Enterprise key (WORLDMONITOR_VALID_KEYS).
+  // Non-wm_ key that isn't in the enterprise allowlist.
   if (key) {
-    if (!isValidEnterpriseKey(key)) return { valid: false, required: true, error: 'Invalid API key' };
-    return { valid: true, required: true, kind: 'enterprise' };
+    return { valid: false, required: true, error: 'Invalid API key' };
   }
 
   // No credentials at all.

--- a/api/_api-key.test.mjs
+++ b/api/_api-key.test.mjs
@@ -134,6 +134,27 @@ test('wm_-prefixed user key returns required:true / valid:false so gateway can f
   assert.equal(r.valid, false);
 });
 
+test('REGRESSION: wm_-prefixed key in WORLDMONITOR_VALID_KEYS is honored as enterprise', async () => {
+  // Pre-#3541 the static enterprise allowlist accepted any key shape, so
+  // some operator-issued keys (e.g. Railway WORLDMONITOR_RELAY_KEY) carry the
+  // wm_ prefix from before user-issued keys were namespaced. Without the
+  // static-allowlist-first ordering, those keys 401 because they get punted
+  // to validateUserApiKey() which doesn't know about operator-minted values.
+  // Symptom: ais-relay warm-pings (Chokepoints / CableHealth / CII /
+  // ServiceStatuses) all 401 in production despite the key being literally
+  // present in WORLDMONITOR_VALID_KEYS.
+  const previous = process.env.WORLDMONITOR_VALID_KEYS;
+  process.env.WORLDMONITOR_VALID_KEYS = `${ENTERPRISE_KEY},wm_legacy_operator_key_in_static_list`;
+  try {
+    const r = await validateApiKey(makeReq({ key: 'wm_legacy_operator_key_in_static_list' }));
+    assert.equal(r.valid, true, 'wm_-prefixed key in static allowlist must validate as enterprise');
+    assert.equal(r.required, true);
+    assert.equal(r.kind, 'enterprise', 'must be kind=enterprise so gateway skips entitlement check');
+  } finally {
+    process.env.WORLDMONITOR_VALID_KEYS = previous;
+  }
+});
+
 // ── Desktop (Tauri) — always requires enterprise key ────────────────────────
 
 test('desktop Tauri origin without key is rejected', async () => {

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -9358,7 +9358,16 @@ const server = http.createServer(async (req, res) => {
             'Accept-Language': 'en-US,en;q=0.9',
             ...conditionalHeaders,
           },
-          timeout: 15000
+          timeout: 15000,
+          // Bumped from Node's 16KB default. Some publishers (Substack, big-CDN-
+          // fronted feeds) chain Set-Cookie + CSP + Permissions-Policy + tracking
+          // headers that exceed 16KB, which makes Node's HTTP parser throw
+          // `Parse Error: Header overflow` and fail every fetch from this relay.
+          // The relay's in-memory rssResponseCache used to mask this on long-
+          // running deploys; a redeploy clears the cache and the broken feeds
+          // surface immediately. 64KB is well above any legitimate header set,
+          // and is per-request (no process-level Node flag needed).
+          maxHeaderSize: 65536,
         }, (response) => {
           if ([301, 302, 303, 307, 308].includes(response.statusCode) && response.headers.location) {
             const redirectUrl = response.headers.location.startsWith('http')


### PR DESCRIPTION
## Summary

Production regression from #3541 / #3557 (merged 2026-05-02): \`validateApiKey\` checks the \`wm_\`-prefixed user-key fallthrough BEFORE the static \`WORLDMONITOR_VALID_KEYS\` allowlist. Any \`wm_\`-prefixed key gets mandatorily punted to \`validateUserApiKey()\`, even when it's literally a member of the operator-issued enterprise list.

## Symptom

Every Railway service sending \`X-WorldMonitor-Key\` with a \`wm_\`-prefixed operator key 401s on every request. Diagnosed in production today: the relay startup banner reads \`WORLDMONITOR_RELAY_KEY configured\`, the key IS in \`WORLDMONITOR_VALID_KEYS\` on Vercel, but warm-pings (\`Chokepoints\`, \`CableHealth\`, \`CII\`, \`ServiceStatuses\`, seed warmers from #3566) all return HTTP 401 simultaneously.

\`\`\`
[Relay] WORLDMONITOR_RELAY_KEY configured — warm-pings will send X-WorldMonitor-Key
[ServiceStatuses] Seed ping failed: HTTP 401
[CableHealth]    Warm-ping failed: HTTP 401
[CII]            Warm-ping failed: HTTP 401
[Chokepoints]    Warm-ping failed: HTTP 401
\`\`\`

Net effect: cache warmers stop running → the panels they back go STALE_SEED → \`/api/health\` flips to UNAVAILABLE.

## Fix

Reorder \`validateApiKey()\`: check static enterprise allowlist FIRST, fall through to user-key path only if the key isn't in the static list.

- Preserves #3541's intent: only \`kind='enterprise'\` bypasses entitlement.
- Zero new attack surface: ≥192 bits of entropy on user-issued \`wm_\` keys + adding to static list requires server-env-write access.
- Regression test pins the trap so a future "simplify" PR that swaps the ordering back fails loudly.

## Operator-side companion

This is paired with the Railway-side workaround (rotate \`WORLDMONITOR_RELAY_KEY\` to a non-\`wm_\` value, like one of the other entries in \`WORLDMONITOR_VALID_KEYS\`). Either path resolves the 401s; this PR makes the rotation unnecessary.

## Test plan

- [x] \`node --test api/_api-key.test.mjs\` — 21/21 pass, including new regression case
- [x] \`npm run typecheck:api\` clean
- [ ] After merge: confirm Railway warm-ping logs flip from \`HTTP 401\` to \`HTTP 200\`
- [ ] After merge: confirm \`/api/health\` panel statuses recover within next cron cycle