### PR TITLE
fix(ais-relay): RSS fetch maxHeaderSize 64KB — unblock news pipeline

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -9358,7 +9358,16 @@ const server = http.createServer(async (req, res) => {
             'Accept-Language': 'en-US,en;q=0.9',
             ...conditionalHeaders,
           },
-          timeout: 15000
+          timeout: 15000,
+          // Bumped from Node's 16KB default. Some publishers (Substack, big-CDN-
+          // fronted feeds) chain Set-Cookie + CSP + Permissions-Policy + tracking
+          // headers that exceed 16KB, which makes Node's HTTP parser throw
+          // `Parse Error: Header overflow` and fail every fetch from this relay.
+          // The relay's in-memory rssResponseCache used to mask this on long-
+          // running deploys; a redeploy clears the cache and the broken feeds
+          // surface immediately. 64KB is well above any legitimate header set,
+          // and is per-request (no process-level Node flag needed).
+          maxHeaderSize: 65536,
         }, (response) => {
           if ([301, 302, 303, 307, 308].includes(response.statusCode) && response.headers.location) {
             const redirectUrl = response.headers.location.startsWith('http')


### PR DESCRIPTION
## Summary

Every news regional panel (World News / United States / Europe / Middle East / Africa / Latin America / Asia-Pacific / Energy & Resources / Government / Think Tanks) renders **UNAVAILABLE** because the relay's RSS poller is starved.

## Root cause

Node's native HTTP parser defaults to a **16KB \`maxHeaderSize\`**. Some upstream RSS publishers now ship response header sets that exceed it (Substack-class \`Set-Cookie\` chains; big-CDN-fronted feeds with stacked \`CSP\` / \`Permissions-Policy\` / tracking headers). The relay's \`https.get(url, options)\` was inheriting that default, so the parser threw \`Parse Error: Header overflow\` on every fetch, no body was ever read, and no items reached Redis.

Production evidence (2026-05-03):

\`\`\`
[Relay] RSS error: Parse Error: Header overflow (backoff 60s, failures=1)
× 13 simultaneously, every poll cycle (104 events in ~30 min slice)
\`\`\`

The exact same 13 feeds fail every cycle — structural, not per-feed. The relay's in-memory \`rssResponseCache\` was masking it on long-running deploys; today's #3565 redeploy cleared the cache and surfaced the issue.

## Fix

One-line addition: \`maxHeaderSize: 65536\` in the per-request options bag for \`protocol.get(url, ...)\`. Scoped to RSS fetches only — no process-level Node flag, no Railway env-var change.

## Out of scope, flagged separately

Warm-pings (Chokepoints / CableHealth / CII / ServiceStatuses) still 401 — that's a different bug, fixed in #3572 (api-key precedence).

## Test plan

- [x] \`node -c scripts/ais-relay.cjs\` — syntax check passes
- [ ] After deploy: confirm \`Header overflow\` errors disappear from Railway logs
- [ ] After deploy: confirm news panels recover